### PR TITLE
Publish as scoped npm package @kaeawc/auto-mobile

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -126,7 +126,7 @@ For AutoMobile's CLI you can always run the tool without commands to get helpful
 a dedicated documentation page beyond running tool output and updating [this page](features/cli.md).
 
 ```text
-npm install -g auto-mobile@latest
+npm install -g @kaeawc/auto-mobile@latest
 auto-mobile --cli
 ```
 

--- a/docs/features/batteries-included.md
+++ b/docs/features/batteries-included.md
@@ -44,23 +44,23 @@ You can opt out of any or all automated behaviors via CLI arguments:
 
 ```bash
 # Disable automatic SDK detection
-npx auto-mobile --no-auto-sdk
+npx @kaeawc/auto-mobile --no-auto-sdk
 
 # Use specific SDK path without validation
-npx auto-mobile --android-home /custom/path --no-validate-sdk
+npx @kaeawc/auto-mobile --android-home /custom/path --no-validate-sdk
 ```
 
 #### Device Management
 
 ```bash
 # Disable device auto-detection
-npx auto-mobile --no-auto-device
+npx @kaeawc/auto-mobile --no-auto-device
 
 # Skip USB debugging setup assistance
-npx auto-mobile --no-setup-assistance
+npx @kaeawc/auto-mobile --no-setup-assistance
 
 # Disable emulator auto-start
-npx auto-mobile --no-auto-emulator
+npx @kaeawc/auto-mobile --no-auto-emulator
 ```
 
 By leveraging these batteries-included features, AutoMobile provides a smooth onboarding experience while 

--- a/docs/features/mcp-server/index.md
+++ b/docs/features/mcp-server/index.md
@@ -26,13 +26,13 @@ stateDiagram-v2
 AutoMobile MCP is designed to be run in STDIO mode in production settings like workstations and CI automation.
 
 ```shell
-npx -y auto-mobile@latest
+npx -y @kaeawc/auto-mobile@latest
 ```
 
 If you have a private npm registry you can instead do the following
 
 ```shell
-npx --registry https://your.awesome.private.registry.net/path/to/npm/proxy -y auto-mobile@latest
+npx --registry https://your.awesome.private.registry.net/path/to/npm/proxy -y @kaeawc/auto-mobile@latest
 ```
 
 A lot of MCP clients configure MCP servers through JSON, this sample will work with most

--- a/docs/features/test-execution/ci.md
+++ b/docs/features/test-execution/ci.md
@@ -4,7 +4,7 @@ Since AutoMobile is a tool designed to automate mobile interactions one of the b
 
 ## Run plans on CI with no agent capabilities
 
-1. Install AutoMobile: `npm install -g auto-mobile@latest`
+1. Install AutoMobile: `npm install -g @kaeawc/auto-mobile@latest`
 2. Ensure one or more Android emulators are running and detectable by `adb devices`
 3. Run test plans: `auto-mobile --cli executePlan --planContent "$(cat my-plan.yaml)"`
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -22,7 +22,7 @@ If your favorite MCP client doesn't have that capability yet, copy the following
       "command": "npx",
       "args": [
         "-y",
-        "auto-mobile@latest"
+        "@kaeawc/auto-mobile@latest"
       ]
     }
   }
@@ -55,7 +55,7 @@ If you have a private npm registry for proxying public npm:
         "-y",
         "--registry",
         "https://your.awesome.private.registry.net/path/to/npm/proxy",
-        "auto-mobile@latest"
+        "@kaeawc/auto-mobile@latest"
       ]
     }
   }
@@ -65,7 +65,7 @@ If you have a private npm registry for proxying public npm:
 You can also install it directly as a CLI tool.
 
 ```shell
-npm install -g auto-mobile@latest
+npm install -g @kaeawc/auto-mobile@latest
 
 # Test CLI mode to check installation succeeded
 auto-mobile --cli

--- a/docs/mcp-clients/cursor.md
+++ b/docs/mcp-clients/cursor.md
@@ -11,7 +11,7 @@ or copy the following into your Cursor `mcp.json`:
   "mcpServers": {
     "AutoMobile": {
       "command": "npx",
-      "args": ["-y", "auto-mobile@latest"]
+      "args": ["-y", "@kaeawc/auto-mobile@latest"]
     }
   }
 }

--- a/docs/mcp-clients/firebender.md
+++ b/docs/mcp-clients/firebender.md
@@ -5,7 +5,7 @@
   "mcpServers": {
     "AutoMobile": {
       "command": "npx",
-      "args": ["-y", "auto-mobile@latest"]
+      "args": ["-y", "@kaeawc/auto-mobile@latest"]
     }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "auto-mobile",
+  "name": "@kaeawc/auto-mobile",
   "version": "0.0.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "auto-mobile",
+      "name": "@kaeawc/auto-mobile",
       "version": "0.0.6",
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "auto-mobile",
+  "name": "@kaeawc/auto-mobile",
   "version": "0.0.6",
   "description": "Mobile device interaction automation via MCP",
   "scripts": {
@@ -49,6 +49,10 @@
     }
   ],
   "homepage": "https://kaeawc.github.io/auto-mobile/",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/kaeawc/auto-mobile.git"
+  },
   "publishConfig": {
     "access": "public"
   },


### PR DESCRIPTION
## Summary
- Convert auto-mobile to use scoped npm package name @kaeawc/auto-mobile
- Update package.json with new scoped name and repository field
- Update all documentation examples to reference the new scoped package name

## Test plan
- ✅ Build passes (`npm run build`)
- ✅ All tests pass (`npm test` - 1000+ tests)
- ✅ Package configuration is valid
- ✅ Ready for public npm publication

🤖 Generated with [Claude Code](https://claude.com/claude-code)