### PR TITLE
Add Claude Code MCP client documentation

### DIFF
--- a/docs/mcp-clients/claude-code.md
+++ b/docs/mcp-clients/claude-code.md
@@ -1,0 +1,49 @@
+# Claude Code MCP Config
+
+This is a simple sample of how to get AutoMobile running with Claude Code, for other options see the
+[overview](index.md).
+
+## Option 1: Using the CLI (Recommended)
+
+Add AutoMobile via the terminal:
+
+```bash
+claude mcp add --type stdio auto-mobile \
+  --command npx \
+  --arg "-y" \
+  --arg "@kaeawc/auto-mobile@latest" \
+  --env ANDROID_HOME=/path/to/Android/sdk
+```
+
+Replace `/path/to/Android/sdk` with your actual Android SDK path:
+- **macOS**: Usually `~/Library/Android/sdk`
+- **Linux**: Usually `~/Android/Sdk`
+- **Windows**: Usually `C:\Users\YourName\AppData\Local\Android\Sdk`
+
+## Option 2: Manual Configuration
+
+Add the following to your Claude Code configuration file:
+
+**macOS/Linux**: `~/.config/claude-code/config.json`
+**Windows**: `%APPDATA%\claude-code\config.json`
+
+```json
+{
+  "mcpServers": {
+    "auto-mobile": {
+      "command": "npx",
+      "args": ["-y", "@kaeawc/auto-mobile@latest"],
+      "env": {
+        "ANDROID_HOME": "/path/to/Android/sdk"
+      }
+    }
+  }
+}
+```
+
+Replace `/path/to/Android/sdk` with your actual Android SDK path:
+- **macOS**: Usually `~/Library/Android/sdk`
+- **Linux**: Usually `~/Android/Sdk`
+- **Windows**: Usually `C:\Users\YourName\AppData\Local\Android\Sdk`
+
+After saving the config, restart Claude Code and the AutoMobile server will start automatically.

--- a/docs/mcp-clients/index.md
+++ b/docs/mcp-clients/index.md
@@ -5,6 +5,7 @@ AutoMobile MCP is designed to be run in STDIO mode in production settings like w
 
 We have specific documentation for clients we have used AutoMobile with:
 
-* [Firebender](firebender.md)
+* [Claude Code](claude-code.md)
 * [Cursor](cursor.md)
+* [Firebender](firebender.md)
 * [Goose](goose.md) 


### PR DESCRIPTION
## Summary

- Added simple Claude Code installation guide at `docs/mcp-clients/claude-code.md`
- Includes both CLI command (`claude mcp add`) and manual JSON configuration options
- Updated MCP clients index to include Claude Code in the list

This provides users with a quick reference for setting up AutoMobile with Claude Code, similar to the existing guides for Cursor, Firebender, and Goose.

Closes #31

🤖 Generated with [Claude Code](https://claude.com/claude-code)