### PR TITLE
Skip Docker CI if Dockerfiles and package.json did not change

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -242,6 +242,28 @@ jobs:
   # Docker Build and Validation
   # =============================================================================
 
+  detect-docker-changes:
+    name: "Detect Docker File Changes"
+    runs-on: ubuntu-latest
+    outputs:
+      docker-changed: ${{ steps.filter.outputs.docker }}
+    steps:
+      - name: "Git Checkout"
+        uses: actions/checkout@v4
+
+      - name: "Check for Docker-related changes"
+        uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            docker:
+              - 'Dockerfile'
+              - 'docker-compose.yml'
+              - '.dockerignore'
+              - 'package.json'
+              - 'package-lock.json'
+              - '.hadolint.yaml'
+
   hadolint:
     name: "Lint Dockerfile"
     runs-on: ubuntu-latest
@@ -259,7 +281,8 @@ jobs:
   docker-build:
     name: "Build Docker Image"
     runs-on: ubuntu-latest
-    needs: hadolint
+    needs: [hadolint, detect-docker-changes]
+    if: needs.detect-docker-changes.outputs.docker-changed == 'true'
     steps:
       - name: "Git Checkout"
         uses: actions/checkout@v4
@@ -380,7 +403,8 @@ jobs:
   docker-compose-test:
     name: "Test Docker Compose"
     runs-on: ubuntu-latest
-    needs: hadolint
+    needs: [hadolint, detect-docker-changes]
+    if: needs.detect-docker-changes.outputs.docker-changed == 'true'
     steps:
       - name: "Git Checkout"
         uses: actions/checkout@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -105,13 +105,7 @@ jobs:
 
           # Add checksum to notes
           CHECKSUM="${{ steps.checksum.outputs.checksum }}"
-          NOTES="${NOTES}
-
-## Accessibility Service APK
-
-**SHA256 Checksum:** \`${CHECKSUM}\`
-
-Download the APK from the release assets below."
+          NOTES="${NOTES}"$'\n\n'"## Accessibility Service APK"$'\n\n'"**SHA256 Checksum:** \`${CHECKSUM}\`"$'\n\n'"Download the APK from the release assets below."
 
           # Save to file for GitHub release
           echo "$NOTES" > release_notes.txt


### PR DESCRIPTION
## Summary

- Add conditional execution for expensive Docker CI jobs (`docker-build` and `docker-compose-test`)
- Jobs now only run when Docker-related files change (Dockerfile, docker-compose.yml, .dockerignore, package.json, package-lock.json, or .hadolint.yaml)
- Docker lint (`hadolint`) continues to run on every PR
- Fix YAML syntax error in release workflow

## Benefits

- Significantly reduces CI time for PRs that don't modify Docker configuration
- The expensive Docker build and test jobs (which include disk space cleanup, image building, container structure tests, and MCP protocol tests) are skipped when unnecessary
- Maintains code quality by always running Docker lint

## Test plan

- [x] Run `npm run lint` - passed
- [x] Run `npm run build` - passed  
- [x] Run `bash scripts/hadolint/validate_hadolint.sh` - passed
- [x] Run `bash scripts/act/validate_act.sh` - passed
- [ ] Verify in GitHub Actions that Docker jobs are skipped when Docker files don't change
- [ ] Verify in GitHub Actions that Docker jobs run when Docker files do change

🤖 Generated with [Claude Code](https://claude.com/claude-code)