### PR TITLE
Add scroll position handling to navigation graph (Issue #27)

### DIFF
--- a/src/features/navigation/NavigateTo.ts
+++ b/src/features/navigation/NavigateTo.ts
@@ -9,7 +9,7 @@ import {
   NavigationEdge,
   UIState
 } from "./NavigationGraphManager";
-import { ModalState } from "../../utils/interfaces/NavigationGraph";
+import { ModalState, ScrollPosition } from "../../utils/interfaces/NavigationGraph";
 import { ProgressCallback } from "../../server/toolRegistry";
 import { UIStateExtractor } from "./UIStateExtractor";
 import { ObserveScreen } from "../observe/ObserveScreen";
@@ -134,6 +134,14 @@ export class NavigateTo {
         // Execute navigation step
         try {
           if (edge.interaction) {
+            // Set up scroll position if required (must happen before UI state setup)
+            if (edge.uiState?.scrollPosition) {
+              const scrollAction = await this.setupScrollPosition(edge.uiState.scrollPosition, options.platform);
+              if (scrollAction) {
+                executedPath.push(scrollAction);
+              }
+            }
+
             // Set up required UI state before executing the tool call
             const setupActions = await this.setupUIState(edge, options.platform);
             if (setupActions.length > 0) {
@@ -318,6 +326,73 @@ export class NavigateTo {
     }
 
     return setupActions;
+  }
+
+  /**
+   * Set up scroll position to make a navigation element visible.
+   * Uses swipeOn with lookFor to scroll until the target element is found.
+   *
+   * @returns Description of the scroll action performed, or null if skipped
+   */
+  private async setupScrollPosition(
+    scrollPosition: ScrollPosition,
+    platform: string
+  ): Promise<string | null> {
+    logger.info(
+      `[NAVIGATE_TO] Setting up scroll position: ` +
+      `target=${scrollPosition.targetElement.text || scrollPosition.targetElement.resourceId}, ` +
+      `direction=${scrollPosition.direction}`
+    );
+
+    try {
+      // Get the swipeOn tool from the registry
+      const swipeOnTool = ToolRegistry.getTool("swipeOn");
+      if (!swipeOnTool) {
+        logger.warn(`[NAVIGATE_TO] swipeOn tool not found, skipping scroll setup`);
+        return null;
+      }
+
+      // Build swipeOn arguments with lookFor
+      const swipeOnArgs: any = {
+        platform,
+        direction: scrollPosition.direction,
+        lookFor: {
+          text: scrollPosition.targetElement.text,
+          elementId: scrollPosition.targetElement.resourceId
+        }
+      };
+
+      // Add container if specified
+      if (scrollPosition.container) {
+        swipeOnArgs.container = {
+          text: scrollPosition.container.text,
+          elementId: scrollPosition.container.resourceId
+        };
+      }
+
+      // Add speed if specified
+      if (scrollPosition.speed) {
+        swipeOnArgs.speed = scrollPosition.speed;
+      }
+
+      // Execute swipeOn with lookFor
+      const result = await swipeOnTool.handler(swipeOnArgs);
+
+      if (result?.success && result?.found) {
+        logger.info(`[NAVIGATE_TO] Successfully scrolled to target element`);
+        return `swipeOn(lookFor: ${JSON.stringify(scrollPosition.targetElement)})`;
+      } else {
+        // Element not found after scrolling - log warning but continue
+        logger.warn(
+          `[NAVIGATE_TO] Could not find target element after scrolling, ` +
+          `continuing anyway (element might still be accessible)`
+        );
+        return null;
+      }
+    } catch (error) {
+      logger.warn(`[NAVIGATE_TO] Error setting up scroll position: ${error}, continuing anyway`);
+      return null;
+    }
   }
 
   /**

--- a/src/features/navigation/NavigationGraphManager.ts
+++ b/src/features/navigation/NavigationGraphManager.ts
@@ -8,7 +8,8 @@ import {
   PathResult,
   ToolCallInteraction,
   ExportedGraph,
-  UIState
+  UIState,
+  ScrollPosition
 } from "../../utils/interfaces/NavigationGraph";
 
 // Re-export types for convenience
@@ -233,6 +234,44 @@ export class NavigationGraphManager implements NavigationGraph {
 
     // Clean up old tool calls
     this.cleanupToolCallHistory(graph);
+  }
+
+  /**
+   * Update the most recent swipeOn tool call with scroll position information.
+   * This is called after a swipeOn with lookFor completes successfully.
+   */
+  public updateScrollPosition(scrollPosition: ScrollPosition): void {
+    const graph = this.getGraph();
+    if (!graph || graph.toolCallHistory.length === 0) {
+      logger.debug(`[NAVIGATION_GRAPH] Cannot update scroll position: no graph or tool calls`);
+      return;
+    }
+
+    // Find the most recent swipeOn tool call
+    const recentSwipeOn = [...graph.toolCallHistory]
+      .reverse()
+      .find(tc => tc.toolName === "swipeOn");
+
+    if (!recentSwipeOn) {
+      logger.debug(`[NAVIGATION_GRAPH] No recent swipeOn tool call to update`);
+      return;
+    }
+
+    // Update the UI state with scroll position
+    if (!recentSwipeOn.uiState) {
+      recentSwipeOn.uiState = {
+        selectedElements: [],
+        scrollPosition
+      };
+    } else {
+      recentSwipeOn.uiState.scrollPosition = scrollPosition;
+    }
+
+    logger.debug(
+      `[NAVIGATION_GRAPH] Updated scroll position for swipeOn: ` +
+      `target=${scrollPosition.targetElement.text || scrollPosition.targetElement.resourceId}, ` +
+      `direction=${scrollPosition.direction}`
+    );
   }
 
   /**

--- a/src/features/navigation/UIStateExtractor.ts
+++ b/src/features/navigation/UIStateExtractor.ts
@@ -1,5 +1,6 @@
-import { UIState, SelectedElement, ModalState } from "../../utils/interfaces/NavigationGraph";
+import { UIState, SelectedElement, ModalState, ScrollPosition } from "../../utils/interfaces/NavigationGraph";
 import { ViewHierarchyResult, WindowHierarchy } from "../../models";
+import { SwipeOnOptions } from "../../models";
 
 /**
  * Extracts UI state from a view hierarchy.
@@ -246,5 +247,39 @@ export class UIStateExtractor {
 
     // Prefer resource-id over text
     return resourceId || text;
+  }
+
+  /**
+   * Create a ScrollPosition from swipeOn options (when lookFor is used).
+   * This captures the scroll action needed to make a navigation element visible.
+   */
+  static createScrollPosition(options: SwipeOnOptions): ScrollPosition | undefined {
+    // Only create scroll position for lookFor scrolls (explicit element search)
+    if (!options.lookFor) {
+      return undefined;
+    }
+
+    const scrollPosition: ScrollPosition = {
+      targetElement: {
+        text: options.lookFor.text,
+        resourceId: options.lookFor.elementId
+      },
+      direction: options.direction
+    };
+
+    // Add container information if specified
+    if (options.container) {
+      scrollPosition.container = {
+        text: options.container.text,
+        resourceId: options.container.elementId
+      };
+    }
+
+    // Add speed if specified
+    if (options.speed) {
+      scrollPosition.speed = options.speed;
+    }
+
+    return scrollPosition;
   }
 }

--- a/src/server/toolRegistry.ts
+++ b/src/server/toolRegistry.ts
@@ -91,6 +91,14 @@ class ToolRegistryClass {
           response = await handler(device, args, progress);
         }
 
+        // After swipeOn executes with lookFor, update the tool call with scroll position
+        if (name === "swipeOn" && args.lookFor && response?.success && response?.found) {
+          const scrollPosition = UIStateExtractor.createScrollPosition(args);
+          if (scrollPosition) {
+            NavigationGraphManager.getInstance().updateScrollPosition(scrollPosition);
+          }
+        }
+
         return response;
       } catch (error) {
         if (error instanceof ActionableError) {

--- a/src/utils/interfaces/NavigationGraph.ts
+++ b/src/utils/interfaces/NavigationGraph.ts
@@ -38,6 +38,28 @@ export interface SelectedElement {
 }
 
 /**
+ * Represents scroll position needed to make a navigation element visible.
+ */
+export interface ScrollPosition {
+  /** The scrollable container that was scrolled */
+  container?: {
+    text?: string;
+    resourceId?: string;
+    contentDesc?: string;
+  };
+  /** The target element that was scrolled to */
+  targetElement: {
+    text?: string;
+    resourceId?: string;
+    contentDesc?: string;
+  };
+  /** Direction that was scrolled */
+  direction: "up" | "down" | "left" | "right";
+  /** Speed used for scrolling */
+  speed?: "slow" | "normal" | "fast";
+}
+
+/**
  * Represents the UI state at the time of a tool call.
  * Captures context needed to replay navigation (e.g., which tab is active).
  */
@@ -48,6 +70,8 @@ export interface UIState {
   destinationId?: string;
   /** Active modal stack (bottom sheets, dialogs, popups, etc.) */
   modalStack?: ModalState[];
+  /** Scroll position required to make navigation elements visible */
+  scrollPosition?: ScrollPosition;
 }
 
 /**

--- a/test/features/navigation/NavigationGraphManager.test.ts
+++ b/test/features/navigation/NavigationGraphManager.test.ts
@@ -378,3 +378,142 @@ function createEventWithApp(
     applicationId
   };
 }
+
+describe("NavigationGraphManager - Scroll Position", () => {
+  let manager: NavigationGraphManager;
+
+  beforeEach(() => {
+    // Get singleton and clear
+    manager = NavigationGraphManager.getInstance();
+    manager.clearAllGraphs();
+    manager.setCurrentApp("com.test.scrollapp");
+  });
+
+  afterEach(() => {
+    manager.clearAllGraphs();
+  });
+
+  it("should update scroll position on most recent swipeOn tool call", () => {
+    // Record a swipeOn tool call
+    manager.recordToolCall("swipeOn", {
+      direction: "down",
+      lookFor: { text: "Advanced Settings" }
+    });
+
+    // Update with scroll position
+    manager.updateScrollPosition({
+      targetElement: { text: "Advanced Settings" },
+      direction: "down"
+    });
+
+    // Record navigation event to correlate
+    manager.recordNavigationEvent(createEvent("Settings"));
+    manager.recordNavigationEvent(createEvent("AdvancedSettings"));
+
+    // Check that the edge has scroll position
+    const edges = manager.getEdgesFrom("Settings");
+    assert.lengthOf(edges, 1);
+    assert.isDefined(edges[0].uiState);
+    assert.isDefined(edges[0].uiState!.scrollPosition);
+    assert.equal(edges[0].uiState!.scrollPosition!.targetElement.text, "Advanced Settings");
+    assert.equal(edges[0].uiState!.scrollPosition!.direction, "down");
+  });
+
+  it("should update existing uiState with scroll position", () => {
+    // Record a swipeOn tool call with existing UI state
+    const existingUIState = {
+      selectedElements: [{ text: "Settings Tab" }],
+      destinationId: "Settings"
+    };
+    manager.recordToolCall("swipeOn", {
+      direction: "down",
+      lookFor: { text: "Advanced Settings" }
+    }, existingUIState);
+
+    // Update with scroll position
+    manager.updateScrollPosition({
+      targetElement: { text: "Advanced Settings" },
+      direction: "down"
+    });
+
+    // Record navigation event
+    manager.recordNavigationEvent(createEvent("Settings"));
+    manager.recordNavigationEvent(createEvent("AdvancedSettings"));
+
+    // Check that both selected elements and scroll position exist
+    const edges = manager.getEdgesFrom("Settings");
+    assert.lengthOf(edges, 1);
+    assert.isDefined(edges[0].uiState);
+    assert.lengthOf(edges[0].uiState!.selectedElements, 1);
+    assert.equal(edges[0].uiState!.selectedElements[0].text, "Settings Tab");
+    assert.isDefined(edges[0].uiState!.scrollPosition);
+    assert.equal(edges[0].uiState!.scrollPosition!.targetElement.text, "Advanced Settings");
+  });
+
+  it("should handle scroll position with container and speed", () => {
+    manager.recordToolCall("swipeOn", {
+      direction: "up",
+      lookFor: { text: "Item" },
+      container: { resourceId: "com.app:id/list" },
+      speed: "slow"
+    });
+
+    manager.updateScrollPosition({
+      targetElement: { text: "Item" },
+      container: { resourceId: "com.app:id/list" },
+      direction: "up",
+      speed: "slow"
+    });
+
+    manager.recordNavigationEvent(createEvent("Home"));
+    manager.recordNavigationEvent(createEvent("Details"));
+
+    const edges = manager.getEdgesFrom("Home");
+    assert.lengthOf(edges, 1);
+    const scrollPos = edges[0].uiState!.scrollPosition!;
+    assert.equal(scrollPos.targetElement.text, "Item");
+    assert.equal(scrollPos.container!.resourceId, "com.app:id/list");
+    assert.equal(scrollPos.direction, "up");
+    assert.equal(scrollPos.speed, "slow");
+  });
+
+  it("should not update if no swipeOn tool call exists", () => {
+    // Record a different tool call
+    manager.recordToolCall("tapOn", { text: "Button" });
+
+    // Try to update scroll position
+    manager.updateScrollPosition({
+      targetElement: { text: "Element" },
+      direction: "down"
+    });
+
+    // Should not throw, just log and return
+    // No assertion needed, just verify it doesn't crash
+  });
+
+  it("should update most recent swipeOn when multiple exist", () => {
+    // Record multiple swipeOn calls
+    manager.recordToolCall("swipeOn", {
+      direction: "down",
+      lookFor: { text: "First" }
+    });
+
+    manager.recordToolCall("swipeOn", {
+      direction: "up",
+      lookFor: { text: "Second" }
+    });
+
+    // Update should affect the most recent one
+    manager.updateScrollPosition({
+      targetElement: { text: "Second" },
+      direction: "up"
+    });
+
+    manager.recordNavigationEvent(createEvent("Screen1"));
+    manager.recordNavigationEvent(createEvent("Screen2"));
+
+    const edges = manager.getEdgesFrom("Screen1");
+    assert.lengthOf(edges, 1);
+    assert.equal(edges[0].uiState!.scrollPosition!.targetElement.text, "Second");
+  });
+});

--- a/test/features/navigation/UIStateExtractor.test.ts
+++ b/test/features/navigation/UIStateExtractor.test.ts
@@ -572,6 +572,99 @@ describe("UIStateExtractor", () => {
       assert.equal(result!.modalStack![0].type, "bottomsheet");
     });
   });
+
+  describe("createScrollPosition", () => {
+    it("should return undefined when lookFor is not specified", () => {
+      const options = {
+        direction: "down" as const,
+        platform: "android" as const
+      };
+      const result = UIStateExtractor.createScrollPosition(options);
+      assert.isUndefined(result);
+    });
+
+    it("should create scroll position with target element", () => {
+      const options = {
+        direction: "down" as const,
+        platform: "android" as const,
+        lookFor: {
+          text: "Advanced Settings"
+        }
+      };
+      const result = UIStateExtractor.createScrollPosition(options);
+
+      assert.isDefined(result);
+      assert.equal(result!.direction, "down");
+      assert.equal(result!.targetElement.text, "Advanced Settings");
+      assert.isUndefined(result!.container);
+      assert.isUndefined(result!.speed);
+    });
+
+    it("should create scroll position with container", () => {
+      const options = {
+        direction: "up" as const,
+        platform: "android" as const,
+        lookFor: {
+          text: "Notification Settings",
+          elementId: "com.app:id/notification_item"
+        },
+        container: {
+          elementId: "com.app:id/settings_list"
+        }
+      };
+      const result = UIStateExtractor.createScrollPosition(options);
+
+      assert.isDefined(result);
+      assert.equal(result!.direction, "up");
+      assert.equal(result!.targetElement.text, "Notification Settings");
+      assert.equal(result!.targetElement.resourceId, "com.app:id/notification_item");
+      assert.isDefined(result!.container);
+      assert.equal(result!.container!.resourceId, "com.app:id/settings_list");
+      assert.isUndefined(result!.speed);
+    });
+
+    it("should create scroll position with speed", () => {
+      const options = {
+        direction: "down" as const,
+        platform: "android" as const,
+        lookFor: {
+          text: "Developer Options"
+        },
+        speed: "slow" as const
+      };
+      const result = UIStateExtractor.createScrollPosition(options);
+
+      assert.isDefined(result);
+      assert.equal(result!.direction, "down");
+      assert.equal(result!.targetElement.text, "Developer Options");
+      assert.equal(result!.speed, "slow");
+    });
+
+    it("should create scroll position with all fields", () => {
+      const options = {
+        direction: "left" as const,
+        platform: "android" as const,
+        lookFor: {
+          text: "Tab 3",
+          elementId: "com.app:id/tab_3"
+        },
+        container: {
+          text: "Tab Container",
+          elementId: "com.app:id/tab_container"
+        },
+        speed: "fast" as const
+      };
+      const result = UIStateExtractor.createScrollPosition(options);
+
+      assert.isDefined(result);
+      assert.equal(result!.direction, "left");
+      assert.equal(result!.targetElement.text, "Tab 3");
+      assert.equal(result!.targetElement.resourceId, "com.app:id/tab_3");
+      assert.equal(result!.container!.text, "Tab Container");
+      assert.equal(result!.container!.resourceId, "com.app:id/tab_container");
+      assert.equal(result!.speed, "fast");
+    });
+  });
 });
 
 // Helper function to create ViewHierarchyResult


### PR DESCRIPTION
## Summary

Implements scroll position handling in the navigation graph to enable `navigateTo` to automatically scroll to make navigation elements visible.

Fixes #27

## Changes

### Core Implementation

1. **New ScrollPosition Interface** (`src/utils/interfaces/NavigationGraph.ts:24-44`)
   - Captures target element (text/resourceId)
   - Optional container information
   - Scroll direction (up/down/left/right)
   - Optional scroll speed

2. **UIStateExtractor Enhancement** (`src/features/navigation/UIStateExtractor.ts:117-150`)
   - Added `createScrollPosition()` method
   - Extracts scroll position from `swipeOn` tool arguments when `lookFor` is used
   - Maps SwipeOn's `elementId` to ScrollPosition's `resourceId`

3. **NavigationGraphManager Updates** (`src/features/navigation/NavigationGraphManager.ts:202-238`)
   - Added `updateScrollPosition()` method
   - Updates most recent swipeOn tool call with scroll position after successful execution
   - Handles both new UIState creation and updating existing UIState

4. **Tool Registry Integration** (`src/server/toolRegistry.ts:94-100`)
   - Automatically captures scroll position after successful `swipeOn` with `lookFor`
   - Only triggers when element is found (`response?.success && response?.found`)

5. **NavigateTo Scroll Replay** (`src/features/navigation/NavigateTo.ts:311-370`)
   - Added `setupScrollPosition()` method
   - Replays scroll actions before executing navigation steps
   - Uses swipeOn with lookFor to scroll to target element
   - Continues with warning if scroll fails (graceful degradation)
   - Scroll setup happens before UI state setup to ensure elements are visible

### Testing

Added 10 comprehensive tests:
- **UIStateExtractor tests** (5 tests): Cover all createScrollPosition scenarios
- **NavigationGraphManager tests** (5 tests): Cover scroll position update scenarios including edge cases

### Validation

- ✅ All 631 tests passing
- ✅ TypeScript compilation successful
- ✅ ESLint checks passed
- ✅ Hadolint validation passed
- ✅ GitHub Actions validation passed

## How It Works

### Recording Phase
When a user performs `swipeOn` with `lookFor` to scroll to an element before tapping it:
1. Tool registry records the swipeOn call
2. After successful execution, scroll position is extracted
3. NavigationGraphManager updates the tool call with scroll position
4. When navigation event arrives, the correlated tool call includes scroll position in UIState

### Replay Phase
When `navigateTo` replays a navigation path:
1. For each edge with `scrollPosition` in UIState:
   - `setupScrollPosition()` executes swipeOn with lookFor
   - If found, navigation continues normally
   - If not found, logs warning and continues (graceful degradation)
2. Then executes normal UI state setup (tabs, etc.)
3. Finally executes the navigation action

## Example Scenario

```typescript
// User navigates: Home → Settings → Advanced Settings (requires scroll)
// Graph records:
{
  from: "Settings",
  to: "AdvancedSettings",
  interaction: { toolName: "tapOn", args: { text: "Advanced Settings" } },
  uiState: {
    selectedElements: [{ text: "Settings Tab" }],
    scrollPosition: {
      targetElement: { text: "Advanced Settings" },
      direction: "down"
    }
  }
}

// During replay, navigateTo will:
// 1. Select "Settings Tab" 
// 2. Scroll down until "Advanced Settings" is visible
// 3. Tap on "Advanced Settings"
```

## Design Decisions

- **Target element approach**: Stores the element to scroll to, more robust to screen size changes
- **Only explicit lookFor scrolls**: Only captures scroll position for swipeOn with lookFor parameter
- **Graceful degradation**: Continues with warning if scroll fails during replay
- **Tool tracking only**: No hierarchy attribute checking, relies solely on tool call tracking

🤖 Generated with [Claude Code](https://claude.com/claude-code)