### PR TITLE
Fix redundant observe calls after actions by correcting timestamp comparison logic

### DIFF
--- a/src/features/action/BaseVisualChange.ts
+++ b/src/features/action/BaseVisualChange.ts
@@ -182,7 +182,9 @@ export class BaseVisualChange {
     const minTimestamp = options.actionStartTime ?? 0;
 
     perf.serial("finalObserve");
-    const latestObservation = await this.observeScreen.execute(options.queryOptions, perf, true, minTimestamp);
+    // Wait for fresh data from accessibility service (skipWaitForFresh=false)
+    // This ensures we get observation data that reflects the action that just completed
+    const latestObservation = await this.observeScreen.execute(options.queryOptions, perf, false, minTimestamp);
     perf.end();
 
     if (options.changeExpected && latestObservation.viewHierarchy && previousObserveResult && previousObserveResult?.viewHierarchy) {

--- a/src/features/observe/AccessibilityServiceClient.ts
+++ b/src/features/observe/AccessibilityServiceClient.ts
@@ -845,10 +845,31 @@ export class AccessibilityServiceClient implements AccessibilityService {
         const updatedAt = this.cachedHierarchy.hierarchy.updatedAt;
 
         // If minTimestamp is set, check if cached data is too old
-        if (minTimestamp > 0 && updatedAt < minTimestamp) {
-          logger.debug(`[ACCESSIBILITY_SERVICE] Cache rejected: updatedAt ${updatedAt} < minTimestamp ${minTimestamp} (stale by ${minTimestamp - updatedAt}ms)`);
-          // Fall through to wait for fresh data or sync
+        // Use BOTH timestamps to handle clock skew between JavaScript and Android
+        // This matches the logic in waitForFreshData()
+        if (minTimestamp > 0) {
+          const receivedAfterAction = this.cachedHierarchy.receivedAt >= minTimestamp;
+          const updatedAfterAction = updatedAt >= minTimestamp;
+
+          // Reject cache only if BOTH timestamps indicate stale data
+          // Accept if EITHER timestamp shows data is fresh (handles clock skew)
+          if (!receivedAfterAction && !updatedAfterAction) {
+            logger.debug(`[ACCESSIBILITY_SERVICE] Cache rejected: receivedAt ${this.cachedHierarchy.receivedAt} < ${minTimestamp} AND updatedAt ${updatedAt} < ${minTimestamp} (stale by ${minTimestamp - Math.max(this.cachedHierarchy.receivedAt, updatedAt)}ms)`);
+            // Fall through to wait for fresh data or sync
+          } else {
+            const isFresh = cacheAge < 1000; // Consider fresh if less than 1 second old
+            const duration = Date.now() - startTime;
+            logger.debug(`[ACCESSIBILITY_SERVICE] Cache accepted in ${duration}ms: receivedAt=${this.cachedHierarchy.receivedAt} (>=${minTimestamp}? ${receivedAfterAction}), updatedAt=${updatedAt} (>=${minTimestamp}? ${updatedAfterAction}), age=${cacheAge}ms, fresh=${isFresh}`);
+
+            return {
+              hierarchy: this.cachedHierarchy.hierarchy,
+              fresh: isFresh,
+              updatedAt: updatedAt,
+              perfTiming: this.cachedHierarchy.perfTiming
+            };
+          }
         } else {
+          // No minTimestamp check, return cache
           const isFresh = cacheAge < 1000; // Consider fresh if less than 1 second old
           const duration = Date.now() - startTime;
           logger.debug(`[ACCESSIBILITY_SERVICE] Cache hit: ${duration}ms (age: ${cacheAge}ms, fresh: ${isFresh}, updatedAt: ${updatedAt})`);
@@ -866,7 +887,10 @@ export class AccessibilityServiceClient implements AccessibilityService {
       // Also wait if cache was rejected due to minTimestamp
       // IMPORTANT: When cacheRejected is true, we MUST wait for fresh data regardless of skipWaitForFresh
       // because the caller requires data newer than minTimestamp (e.g., after an action like inputText)
-      const cacheRejected = minTimestamp > 0 && this.cachedHierarchy && this.cachedHierarchy.hierarchy.updatedAt < minTimestamp;
+      // Cache is rejected only if BOTH timestamps indicate stale data (to handle clock skew)
+      const cacheRejected = minTimestamp > 0 && this.cachedHierarchy &&
+        this.cachedHierarchy.receivedAt < minTimestamp &&
+        this.cachedHierarchy.hierarchy.updatedAt < minTimestamp;
       const shouldWait = (waitForFresh || cacheRejected) && (!skipWaitForFresh || cacheRejected) && !this.shouldSkipWebSocketWait();
       if (shouldWait) {
         // Use minTimestamp if provided, otherwise use startTime


### PR DESCRIPTION
## Summary

Fixes #66 - Eliminates redundant `observe` calls that Claude was making immediately after actions like `tapOn` that already include observation data.

## Root Cause Analysis

Investigation revealed two related problems:

### 1. Clock Domain Mismatch
The cache freshness check in `AccessibilityServiceClient.ts` compared:
- `updatedAt` (Android system time from accessibility service)
- `minTimestamp` (JavaScript time from `Date.now()`)

Any clock skew between the Node.js process and Android device caused false cache rejections.

### 2. Ineffective skipWaitForFresh Parameter
The `skipWaitForFresh` parameter was always set to `true`, making it dead code. After actions:
1. Code tried to use cached data immediately
2. Timestamp check falsely rejected cache due to clock skew
3. Fell back to slow sync request (~1-2 seconds)
4. Returned incomplete/slow observation data
5. Claude made another `observe` call to verify state

## Changes

### Fix 1: Consistent Timestamp Comparison
**File**: `src/features/observe/AccessibilityServiceClient.ts`

Updated cache freshness logic to match `waitForFreshData()` behavior:
- Check **BOTH** `receivedAt` (JavaScript time) and `updatedAt` (Android time)
- Accept cache if **EITHER** timestamp indicates fresh data
- Only reject if **BOTH** timestamps indicate stale data
- Handles clock skew gracefully

### Fix 2: Use skipWaitForFresh Properly  
**File**: `src/features/action/BaseVisualChange.ts`

Changed `skipWaitForFresh` from `true` → `false` in `takeObservation()`:
- Actions now wait for WebSocket push (up to 100ms timeout)
- Ensures observation data reflects the completed action
- Eliminates race conditions

## Expected Impact

- ✅ Eliminates false cache rejections due to clock skew
- ✅ Reduces unnecessary sync requests (which take 1-2 seconds)  
- ✅ Ensures fresh observations after actions
- ✅ Should eliminate redundant observe calls from Claude

## Testing

- ✅ All tests pass (498 passing)
- ✅ Build successful
- ✅ Lint successful
- ✅ act validation successful

## Test Plan

- [ ] Test with the original YouTube exploration scenario from #66
- [ ] Verify no redundant observe calls after `tapOn`, `swipeOn`, `inputText`
- [ ] Confirm observation data is fresh after actions
- [ ] Monitor performance impact of 100ms WebSocket wait

🤖 Generated with [Claude Code](https://claude.com/claude-code)