### PR TITLE
Rename monkeyNavigate MCP tool to explore

### DIFF
--- a/src/features/navigation/Explore.ts
+++ b/src/features/navigation/Explore.ts
@@ -10,19 +10,19 @@ import { TapOnElement } from "../action/TapOnElement";
 import { ElementParser } from "../utility/ElementParser";
 
 /**
- * Exploration strategies for monkeyNavigate
+ * Exploration strategies for explore
  */
 export type ExplorationStrategy = "breadth-first" | "depth-first" | "weighted";
 
 /**
- * Exploration modes for monkeyNavigate
+ * Exploration modes for explore
  */
 export type ExplorationMode = "discover" | "validate" | "hybrid";
 
 /**
- * Options for MonkeyNavigate execution
+ * Options for Explore execution
  */
-export interface MonkeyNavigateOptions {
+export interface ExploreOptions {
   /** Maximum number of interactions to perform */
   maxInteractions?: number;
 
@@ -59,9 +59,9 @@ export interface ElementSelectionStats {
 }
 
 /**
- * Result of MonkeyNavigate execution
+ * Result of Explore execution
  */
-export interface MonkeyNavigateResult {
+export interface ExploreResult {
   success: boolean;
   error?: string;
   interactionsPerformed: number;
@@ -92,11 +92,12 @@ interface TrackedElement {
 }
 
 /**
- * MonkeyNavigate implements intelligent app navigation exploration.
- * It automatically discovers navigation paths by prioritizing likely navigation elements,
+ * Explore implements intelligent app navigation exploration.
+ * Perpetually explores until all navigation destinations have been reached by
+ * automatically discovering navigation paths, prioritizing likely navigation elements,
  * avoiding redundant interactions, and efficiently covering unexplored screens.
  */
-export class MonkeyNavigate extends BaseVisualChange {
+export class Explore extends BaseVisualChange {
   private navigationManager: NavigationGraphManager;
   private exploredElements: Map<string, TrackedElement>;
   private interactionCount: number = 0;
@@ -127,26 +128,26 @@ export class MonkeyNavigate extends BaseVisualChange {
   }
 
   /**
-   * Execute monkey navigation exploration
+   * Execute exploration
    */
   async execute(
-    options: MonkeyNavigateOptions = {},
+    options: ExploreOptions = {},
     progress?: ProgressCallback
-  ): Promise<MonkeyNavigateResult> {
+  ): Promise<ExploreResult> {
     const perf = createGlobalPerformanceTracker();
-    perf.serial("monkeyNavigate");
+    perf.serial("explore");
     const startTime = Date.now();
 
     try {
       // Set defaults
-      const maxInteractions = options.maxInteractions ?? MonkeyNavigate.DEFAULT_MAX_INTERACTIONS;
-      const timeoutMs = options.timeoutMs ?? MonkeyNavigate.DEFAULT_TIMEOUT_MS;
+      const maxInteractions = options.maxInteractions ?? Explore.DEFAULT_MAX_INTERACTIONS;
+      const timeoutMs = options.timeoutMs ?? Explore.DEFAULT_TIMEOUT_MS;
       const strategy = options.strategy ?? "weighted";
       const mode = options.mode ?? "hybrid";
-      const resetInterval = options.resetInterval ?? MonkeyNavigate.DEFAULT_RESET_INTERVAL;
+      const resetInterval = options.resetInterval ?? Explore.DEFAULT_RESET_INTERVAL;
 
       if (progress) {
-        await progress(0, maxInteractions, "Starting monkey navigation exploration...");
+        await progress(0, maxInteractions, "Starting exploration...");
       }
 
       // Capture initial graph state
@@ -167,7 +168,7 @@ export class MonkeyNavigate extends BaseVisualChange {
 
         // Check for safety conditions
         if (this.shouldBreakForSafety(observation)) {
-          logger.warn("[MonkeyNavigate] Safety condition triggered, stopping exploration");
+          logger.warn("[Explore] Safety condition triggered, stopping exploration");
           break;
         }
 
@@ -186,7 +187,7 @@ export class MonkeyNavigate extends BaseVisualChange {
         );
 
         if (!nextElement) {
-          logger.info("[MonkeyNavigate] No suitable element found, attempting back navigation");
+          logger.info("[Explore] No suitable element found, attempting back navigation");
           await this.handleDeadEnd(progress);
           continue;
         }
@@ -226,7 +227,7 @@ export class MonkeyNavigate extends BaseVisualChange {
       return this.generateReport(initialGraph, startTime);
     } catch (error) {
       perf.end();
-      throw new ActionableError(`Failed to execute monkey navigation: ${error}`);
+      throw new ActionableError(`Failed to execute exploration: ${error}`);
     }
   }
 
@@ -241,12 +242,12 @@ export class MonkeyNavigate extends BaseVisualChange {
     const elapsed = Date.now() - startTime;
 
     if (this.interactionCount >= maxInteractions) {
-      logger.info(`[MonkeyNavigate] Reached max interactions: ${maxInteractions}`);
+      logger.info(`[Explore] Reached max interactions: ${maxInteractions}`);
       return false;
     }
 
     if (elapsed >= timeoutMs) {
-      logger.info(`[MonkeyNavigate] Reached timeout: ${timeoutMs}ms`);
+      logger.info(`[Explore] Reached timeout: ${timeoutMs}ms`);
       return false;
     }
 
@@ -258,14 +259,14 @@ export class MonkeyNavigate extends BaseVisualChange {
    */
   private shouldBreakForSafety(observation: ObserveResult): boolean {
     // Check for consecutive backs
-    if (this.consecutiveBackCount >= MonkeyNavigate.MAX_CONSECUTIVE_BACKS) {
-      logger.warn("[MonkeyNavigate] Too many consecutive backs");
+    if (this.consecutiveBackCount >= Explore.MAX_CONSECUTIVE_BACKS) {
+      logger.warn("[Explore] Too many consecutive backs");
       return true;
     }
 
     // Check for screen stuck (no changes)
-    if (this.consecutiveNoChangeCount >= MonkeyNavigate.MAX_CONSECUTIVE_NO_CHANGE) {
-      logger.warn("[MonkeyNavigate] Screen appears stuck (no changes detected)");
+    if (this.consecutiveNoChangeCount >= Explore.MAX_CONSECUTIVE_NO_CHANGE) {
+      logger.warn("[Explore] Screen appears stuck (no changes detected)");
       return true;
     }
 
@@ -273,8 +274,8 @@ export class MonkeyNavigate extends BaseVisualChange {
     const currentScreen = this.navigationManager.getCurrentScreen();
     if (currentScreen) {
       const loopCount = this.loopDetection.get(currentScreen) ?? 0;
-      if (loopCount >= MonkeyNavigate.MAX_LOOP_ITERATIONS) {
-        logger.warn(`[MonkeyNavigate] Detected loop on screen: ${currentScreen}`);
+      if (loopCount >= Explore.MAX_LOOP_ITERATIONS) {
+        logger.warn(`[Explore] Detected loop on screen: ${currentScreen}`);
         return true;
       }
     }
@@ -639,7 +640,7 @@ export class MonkeyNavigate extends BaseVisualChange {
 
       return tapResult.success;
     } catch (error) {
-      logger.warn(`[MonkeyNavigate] Failed to interact with element: ${error}`);
+      logger.warn(`[Explore] Failed to interact with element: ${error}`);
       return false;
     }
   }
@@ -661,20 +662,20 @@ export class MonkeyNavigate extends BaseVisualChange {
 
     // Check for permission dialogs
     if (this.isPermissionDialog(elements)) {
-      logger.info("[MonkeyNavigate] Detected permission dialog, attempting to dismiss");
+      logger.info("[Explore] Detected permission dialog, attempting to dismiss");
       return await this.handlePermissionDialog(elements, progress);
     }
 
     // Check for login/signup screens
     if (this.isLoginScreen(elements)) {
-      logger.info("[MonkeyNavigate] Detected login screen, skipping by going back");
+      logger.info("[Explore] Detected login screen, skipping by going back");
       await this.handleDeadEnd(progress);
       return true;
     }
 
     // Check for app rating/review dialogs
     if (this.isRatingDialog(elements)) {
-      logger.info("[MonkeyNavigate] Detected rating dialog, attempting to dismiss");
+      logger.info("[Explore] Detected rating dialog, attempting to dismiss");
       return await this.dismissDialog(elements, progress);
     }
 
@@ -768,7 +769,7 @@ export class MonkeyNavigate extends BaseVisualChange {
           await new Promise(resolve => setTimeout(resolve, 1000));
           return true;
         } catch (error) {
-          logger.warn(`[MonkeyNavigate] Failed to handle permission dialog: ${error}`);
+          logger.warn(`[Explore] Failed to handle permission dialog: ${error}`);
         }
       }
     }
@@ -806,7 +807,7 @@ export class MonkeyNavigate extends BaseVisualChange {
           await new Promise(resolve => setTimeout(resolve, 1000));
           return true;
         } catch (error) {
-          logger.warn(`[MonkeyNavigate] Failed to dismiss dialog: ${error}`);
+          logger.warn(`[Explore] Failed to dismiss dialog: ${error}`);
         }
       }
     }
@@ -834,7 +835,7 @@ export class MonkeyNavigate extends BaseVisualChange {
       // Wait briefly for navigation
       await new Promise(resolve => setTimeout(resolve, 1000));
     } catch (error) {
-      logger.warn(`[MonkeyNavigate] Failed to navigate back: ${error}`);
+      logger.warn(`[Explore] Failed to navigate back: ${error}`);
     }
   }
 
@@ -860,7 +861,7 @@ export class MonkeyNavigate extends BaseVisualChange {
       // Reset consecutive back count
       this.consecutiveBackCount = 0;
     } catch (error) {
-      logger.warn(`[MonkeyNavigate] Failed to reset to home: ${error}`);
+      logger.warn(`[Explore] Failed to reset to home: ${error}`);
     }
   }
 
@@ -892,7 +893,7 @@ export class MonkeyNavigate extends BaseVisualChange {
   private generateReport(
     initialGraph: ExportedGraph,
     startTime: number
-  ): MonkeyNavigateResult {
+  ): ExploreResult {
     const finalGraph = this.navigationManager.exportGraph();
     const screensDiscovered = finalGraph.nodes.length - initialGraph.nodes.length;
     const edgesAdded = finalGraph.edges.length - initialGraph.edges.length;

--- a/src/server/navigationTools.ts
+++ b/src/server/navigationTools.ts
@@ -3,7 +3,7 @@ import { ToolRegistry, ProgressCallback } from "./toolRegistry";
 import { ActionableError, BootedDevice } from "../models";
 import { NavigateTo, NavigateToOptions } from "../features/navigation/NavigateTo";
 import { NavigationGraphManager } from "../features/navigation/NavigationGraphManager";
-import { MonkeyNavigate, MonkeyNavigateOptions } from "../features/navigation/MonkeyNavigate";
+import { Explore, ExploreOptions } from "../features/navigation/Explore";
 import { createJSONToolResponse } from "../utils/toolUtils";
 import { Platform } from "../models";
 
@@ -17,7 +17,7 @@ export const getNavigationGraphSchema = z.object({
   platform: z.enum(["android", "ios"]).default("android")
 });
 
-export const monkeyNavigateSchema = z.object({
+export const exploreSchema = z.object({
   maxInteractions: z.number().optional().describe("Maximum number of interactions to perform (default: 50)"),
   timeoutMs: z.number().optional().describe("Maximum time in milliseconds (default: 300000 - 5 minutes)"),
   strategy: z.enum(["breadth-first", "depth-first", "weighted"]).optional().describe("Exploration strategy (default: weighted)"),
@@ -39,7 +39,7 @@ export interface GetNavigationGraphArgs {
   platform: Platform;
 }
 
-export interface MonkeyNavigateArgs extends MonkeyNavigateOptions {
+export interface ExploreArgs extends ExploreOptions {
   platform: Platform;
 }
 
@@ -131,15 +131,15 @@ export function registerNavigationTools() {
     getNavigationGraphHandler
   );
 
-  // MonkeyNavigate handler
-  const monkeyNavigateHandler = async (
+  // Explore handler
+  const exploreHandler = async (
     device: BootedDevice,
-    args: MonkeyNavigateArgs,
+    args: ExploreArgs,
     progress?: ProgressCallback
   ) => {
     try {
-      const monkeyNavigate = new MonkeyNavigate(device);
-      const options: MonkeyNavigateOptions = {
+      const explore = new Explore(device);
+      const options: ExploreOptions = {
         maxInteractions: args.maxInteractions,
         timeoutMs: args.timeoutMs,
         strategy: args.strategy,
@@ -148,27 +148,28 @@ export function registerNavigationTools() {
         mode: args.mode,
         packageName: args.packageName
       };
-      const result = await monkeyNavigate.execute(options, progress);
+      const result = await explore.execute(options, progress);
 
       return createJSONToolResponse({
-        message: `Monkey navigation completed: ${result.interactionsPerformed} interactions, ${result.screensDiscovered} new screens discovered, ${result.coverage.percentage}% coverage`,
+        message: `Exploration completed: ${result.interactionsPerformed} interactions, ${result.screensDiscovered} new screens discovered, ${result.coverage.percentage}% coverage`,
         ...result
       });
     } catch (error) {
-      throw new ActionableError(`Failed to execute monkey navigation: ${error}`);
+      throw new ActionableError(`Failed to execute exploration: ${error}`);
     }
   };
 
   ToolRegistry.registerDeviceAware(
-    "monkeyNavigate",
-    "Automatically explore the app by intelligently selecting and interacting with navigation elements. " +
+    "explore",
+    "Perpetually explore until all navigation destinations have been reached by " +
+    "automatically exploring the app and intelligently selecting and interacting with navigation elements. " +
     "Builds a comprehensive navigation graph by prioritizing likely navigation elements (buttons, tabs, menus), " +
     "avoiding redundant interactions, and efficiently covering unexplored screens. " +
     "Supports breadth-first, depth-first, and weighted exploration strategies. " +
     "Automatically detects and handles common blockers like permission dialogs and login screens. " +
     "Default: 50 interactions, weighted strategy, 5-minute timeout.",
-    monkeyNavigateSchema,
-    monkeyNavigateHandler,
+    exploreSchema,
+    exploreHandler,
     true // supports progress
   );
 }

--- a/test/features/navigation/Explore.test.ts
+++ b/test/features/navigation/Explore.test.ts
@@ -1,11 +1,11 @@
 import { assert } from "chai";
-import { MonkeyNavigate } from "../../../src/features/navigation/MonkeyNavigate";
+import { Explore } from "../../../src/features/navigation/Explore";
 import { NavigationGraphManager } from "../../../src/features/navigation/NavigationGraphManager";
 import { BootedDevice, Element, ObserveResult } from "../../../src/models";
 import { AdbClient } from "../../../src/utils/android-cmdline-tools/AdbClient";
 
-describe("MonkeyNavigate", () => {
-  let monkeyNavigate: MonkeyNavigate;
+describe("Explore", () => {
+  let explore: Explore;
   let device: BootedDevice;
   let mockAdb: any;
   let mockObserveScreen: any;
@@ -129,10 +129,10 @@ describe("MonkeyNavigate", () => {
     it.skip("should complete with default options (requires full device setup)", async () => {
       // This test requires mocking TapOnElement which is complex
       // Core functionality is tested in unit tests below
-      monkeyNavigate = new MonkeyNavigate(device, mockAdb);
-      (monkeyNavigate as any).observeScreen = mockObserveScreen;
+      explore = new Explore(device, mockAdb);
+      (explore as any).observeScreen = mockObserveScreen;
 
-      const result = await monkeyNavigate.execute({
+      const result = await explore.execute({
         maxInteractions: 2,
         timeoutMs: 5000
       });
@@ -144,11 +144,11 @@ describe("MonkeyNavigate", () => {
     });
 
     it.skip("should respect maxInteractions limit (requires full device setup)", async () => {
-      monkeyNavigate = new MonkeyNavigate(device, mockAdb);
-      (monkeyNavigate as any).observeScreen = mockObserveScreen;
+      explore = new Explore(device, mockAdb);
+      (explore as any).observeScreen = mockObserveScreen;
 
       const maxInteractions = 3;
-      const result = await monkeyNavigate.execute({
+      const result = await explore.execute({
         maxInteractions,
         timeoutMs: 10000
       });
@@ -171,10 +171,10 @@ describe("MonkeyNavigate", () => {
         applicationId: "com.test.app"
       });
 
-      monkeyNavigate = new MonkeyNavigate(device, mockAdb);
-      (monkeyNavigate as any).observeScreen = mockObserveScreen;
+      explore = new Explore(device, mockAdb);
+      (explore as any).observeScreen = mockObserveScreen;
 
-      const result = await monkeyNavigate.execute({
+      const result = await explore.execute({
         maxInteractions: 5,
         timeoutMs: 10000
       });
@@ -197,10 +197,10 @@ describe("MonkeyNavigate", () => {
         applicationId: "com.test.app"
       });
 
-      monkeyNavigate = new MonkeyNavigate(device, mockAdb);
-      (monkeyNavigate as any).observeScreen = mockObserveScreen;
+      explore = new Explore(device, mockAdb);
+      (explore as any).observeScreen = mockObserveScreen;
 
-      const result = await monkeyNavigate.execute({
+      const result = await explore.execute({
         maxInteractions: 3,
         timeoutMs: 5000
       });
@@ -209,10 +209,10 @@ describe("MonkeyNavigate", () => {
     });
 
     it.skip("should calculate coverage correctly (requires full device setup)", async () => {
-      monkeyNavigate = new MonkeyNavigate(device, mockAdb);
-      (monkeyNavigate as any).observeScreen = mockObserveScreen;
+      explore = new Explore(device, mockAdb);
+      (explore as any).observeScreen = mockObserveScreen;
 
-      const result = await monkeyNavigate.execute({
+      const result = await explore.execute({
         maxInteractions: 5,
         timeoutMs: 5000
       });
@@ -248,8 +248,8 @@ describe("MonkeyNavigate", () => {
 
       const mockObservation = createMockObservation(nodes);
 
-      monkeyNavigate = new MonkeyNavigate(device, mockAdb);
-      const navElements = (monkeyNavigate as any).extractNavigationElements(mockObservation.viewHierarchy);
+      explore = new Explore(device, mockAdb);
+      const navElements = (explore as any).extractNavigationElements(mockObservation.viewHierarchy);
 
       // Should filter out EditText
       assert.isBelow(navElements.length, nodes.length);
@@ -260,7 +260,7 @@ describe("MonkeyNavigate", () => {
     });
 
     it("should calculate navigation scores correctly", async () => {
-      monkeyNavigate = new MonkeyNavigate(device, mockAdb);
+      explore = new Explore(device, mockAdb);
 
       const buttonElement = createMockElement({
         "text": "Settings",
@@ -274,8 +274,8 @@ describe("MonkeyNavigate", () => {
         "resource-id": "com.test:id/tab_profile"
       });
 
-      const buttonScore = (monkeyNavigate as any).calculateNavigationScore(buttonElement);
-      const tabScore = (monkeyNavigate as any).calculateNavigationScore(tabElement);
+      const buttonScore = (explore as any).calculateNavigationScore(buttonElement);
+      const tabScore = (explore as any).calculateNavigationScore(tabElement);
 
       // Tab should score higher than button
       assert.isAbove(tabScore, buttonScore);
@@ -291,8 +291,8 @@ describe("MonkeyNavigate", () => {
 
       const mockObservation = createMockObservation(nodes);
 
-      monkeyNavigate = new MonkeyNavigate(device, mockAdb);
-      const navElements = (monkeyNavigate as any).extractNavigationElements(mockObservation.viewHierarchy);
+      explore = new Explore(device, mockAdb);
+      const navElements = (explore as any).extractNavigationElements(mockObservation.viewHierarchy);
 
       // Should only include enabled clickable elements
       assert.equal(navElements.length, 1);
@@ -307,8 +307,8 @@ describe("MonkeyNavigate", () => {
         createMockElement({ text: "This app needs camera permission" })
       ];
 
-      monkeyNavigate = new MonkeyNavigate(device, mockAdb);
-      const isPermission = (monkeyNavigate as any).isPermissionDialog(elements);
+      explore = new Explore(device, mockAdb);
+      const isPermission = (explore as any).isPermissionDialog(elements);
 
       assert.isTrue(isPermission);
     });
@@ -320,8 +320,8 @@ describe("MonkeyNavigate", () => {
         createMockElement({ "text": "Password", "class": "android.widget.TextView" })
       ];
 
-      monkeyNavigate = new MonkeyNavigate(device, mockAdb);
-      const isLogin = (monkeyNavigate as any).isLoginScreen(elements);
+      explore = new Explore(device, mockAdb);
+      const isLogin = (explore as any).isLoginScreen(elements);
 
       assert.isTrue(isLogin);
     });
@@ -333,8 +333,8 @@ describe("MonkeyNavigate", () => {
         createMockElement({ text: "5 stars" })
       ];
 
-      monkeyNavigate = new MonkeyNavigate(device, mockAdb);
-      const isRating = (monkeyNavigate as any).isRatingDialog(elements);
+      explore = new Explore(device, mockAdb);
+      const isRating = (explore as any).isRatingDialog(elements);
 
       assert.isTrue(isRating);
     });
@@ -346,10 +346,10 @@ describe("MonkeyNavigate", () => {
         createMockElement({ text: "Profile" })
       ];
 
-      monkeyNavigate = new MonkeyNavigate(device, mockAdb);
-      const isPermission = (monkeyNavigate as any).isPermissionDialog(elements);
-      const isLogin = (monkeyNavigate as any).isLoginScreen(elements);
-      const isRating = (monkeyNavigate as any).isRatingDialog(elements);
+      explore = new Explore(device, mockAdb);
+      const isPermission = (explore as any).isPermissionDialog(elements);
+      const isLogin = (explore as any).isLoginScreen(elements);
+      const isRating = (explore as any).isRatingDialog(elements);
 
       assert.isFalse(isPermission);
       assert.isFalse(isLogin);
@@ -359,10 +359,10 @@ describe("MonkeyNavigate", () => {
 
   describe("exploration strategies", () => {
     it.skip("should support breadth-first strategy (requires full device setup)", async () => {
-      monkeyNavigate = new MonkeyNavigate(device, mockAdb);
-      (monkeyNavigate as any).observeScreen = mockObserveScreen;
+      explore = new Explore(device, mockAdb);
+      (explore as any).observeScreen = mockObserveScreen;
 
-      const result = await monkeyNavigate.execute({
+      const result = await explore.execute({
         maxInteractions: 3,
         strategy: "breadth-first",
         timeoutMs: 5000
@@ -372,10 +372,10 @@ describe("MonkeyNavigate", () => {
     });
 
     it.skip("should support depth-first strategy (requires full device setup)", async () => {
-      monkeyNavigate = new MonkeyNavigate(device, mockAdb);
-      (monkeyNavigate as any).observeScreen = mockObserveScreen;
+      explore = new Explore(device, mockAdb);
+      (explore as any).observeScreen = mockObserveScreen;
 
-      const result = await monkeyNavigate.execute({
+      const result = await explore.execute({
         maxInteractions: 3,
         strategy: "depth-first",
         timeoutMs: 5000
@@ -385,10 +385,10 @@ describe("MonkeyNavigate", () => {
     });
 
     it.skip("should support weighted strategy (requires full device setup)", async () => {
-      monkeyNavigate = new MonkeyNavigate(device, mockAdb);
-      (monkeyNavigate as any).observeScreen = mockObserveScreen;
+      explore = new Explore(device, mockAdb);
+      (explore as any).observeScreen = mockObserveScreen;
 
-      const result = await monkeyNavigate.execute({
+      const result = await explore.execute({
         maxInteractions: 3,
         strategy: "weighted",
         timeoutMs: 5000
@@ -400,10 +400,10 @@ describe("MonkeyNavigate", () => {
 
   describe("exploration modes", () => {
     it.skip("should support discover mode (requires full device setup)", async () => {
-      monkeyNavigate = new MonkeyNavigate(device, mockAdb);
-      (monkeyNavigate as any).observeScreen = mockObserveScreen;
+      explore = new Explore(device, mockAdb);
+      (explore as any).observeScreen = mockObserveScreen;
 
-      const result = await monkeyNavigate.execute({
+      const result = await explore.execute({
         maxInteractions: 3,
         mode: "discover",
         timeoutMs: 5000
@@ -413,10 +413,10 @@ describe("MonkeyNavigate", () => {
     });
 
     it.skip("should support validate mode (requires full device setup)", async () => {
-      monkeyNavigate = new MonkeyNavigate(device, mockAdb);
-      (monkeyNavigate as any).observeScreen = mockObserveScreen;
+      explore = new Explore(device, mockAdb);
+      (explore as any).observeScreen = mockObserveScreen;
 
-      const result = await monkeyNavigate.execute({
+      const result = await explore.execute({
         maxInteractions: 3,
         mode: "validate",
         timeoutMs: 5000
@@ -426,10 +426,10 @@ describe("MonkeyNavigate", () => {
     });
 
     it.skip("should support hybrid mode (requires full device setup)", async () => {
-      monkeyNavigate = new MonkeyNavigate(device, mockAdb);
-      (monkeyNavigate as any).observeScreen = mockObserveScreen;
+      explore = new Explore(device, mockAdb);
+      (explore as any).observeScreen = mockObserveScreen;
 
-      const result = await monkeyNavigate.execute({
+      const result = await explore.execute({
         maxInteractions: 3,
         mode: "hybrid",
         timeoutMs: 5000
@@ -441,14 +441,14 @@ describe("MonkeyNavigate", () => {
 
   describe("safety features", () => {
     it.skip("should track consecutive back presses (requires full device setup)", async () => {
-      monkeyNavigate = new MonkeyNavigate(device, mockAdb);
+      explore = new Explore(device, mockAdb);
 
       // Mock observe screen that returns no navigation elements
-      (monkeyNavigate as any).observeScreen = {
+      (explore as any).observeScreen = {
         execute: async () => createMockObservation([])
       };
 
-      const result = await monkeyNavigate.execute({
+      const result = await explore.execute({
         maxInteractions: 20,
         timeoutMs: 5000
       });
@@ -458,10 +458,10 @@ describe("MonkeyNavigate", () => {
     });
 
     it.skip("should include performance metrics (requires full device setup)", async () => {
-      monkeyNavigate = new MonkeyNavigate(device, mockAdb);
-      (monkeyNavigate as any).observeScreen = mockObserveScreen;
+      explore = new Explore(device, mockAdb);
+      (explore as any).observeScreen = mockObserveScreen;
 
-      const result = await monkeyNavigate.execute({
+      const result = await explore.execute({
         maxInteractions: 2,
         timeoutMs: 5000
       });
@@ -474,10 +474,10 @@ describe("MonkeyNavigate", () => {
 
   describe("element tracking", () => {
     it.skip("should track element interactions (requires full device setup)", async () => {
-      monkeyNavigate = new MonkeyNavigate(device, mockAdb);
-      (monkeyNavigate as any).observeScreen = mockObserveScreen;
+      explore = new Explore(device, mockAdb);
+      (explore as any).observeScreen = mockObserveScreen;
 
-      const result = await monkeyNavigate.execute({
+      const result = await explore.execute({
         maxInteractions: 5,
         timeoutMs: 5000
       });
@@ -489,7 +489,7 @@ describe("MonkeyNavigate", () => {
     });
 
     it("should generate unique element keys", async () => {
-      monkeyNavigate = new MonkeyNavigate(device, mockAdb);
+      explore = new Explore(device, mockAdb);
 
       const element1 = createMockElement({
         "text": "Button",
@@ -506,9 +506,9 @@ describe("MonkeyNavigate", () => {
         "resource-id": "com.test:id/other"
       });
 
-      const key1 = (monkeyNavigate as any).getElementKey(element1);
-      const key2 = (monkeyNavigate as any).getElementKey(element2);
-      const key3 = (monkeyNavigate as any).getElementKey(element3);
+      const key1 = (explore as any).getElementKey(element1);
+      const key2 = (explore as any).getElementKey(element2);
+      const key3 = (explore as any).getElementKey(element3);
 
       assert.equal(key1, key2);
       assert.notEqual(key1, key3);


### PR DESCRIPTION
## Summary
Comprehensively rename the `monkeyNavigate` feature to `explore` to better reflect its purpose of perpetually exploring until all navigation destinations have been reached.

## Changes

### Files Renamed
- `src/features/navigation/MonkeyNavigate.ts` → `src/features/navigation/Explore.ts`
- `test/features/navigation/MonkeyNavigate.test.ts` → `test/features/navigation/Explore.test.ts`

### Classes, Interfaces, and Types
- `MonkeyNavigate` class → `Explore` class
- `MonkeyNavigateOptions` interface → `ExploreOptions` interface
- `MonkeyNavigateResult` interface → `ExploreResult` interface
- `MonkeyNavigateArgs` interface → `ExploreArgs` interface

### MCP Tool Updates (navigationTools.ts)
- MCP tool name: `"monkeyNavigate"` → `"explore"`
- Schema: `monkeyNavigateSchema` → `exploreSchema`
- Handler: `monkeyNavigateHandler` → `exploreHandler`

### Description Update
Updated the tool description to combine the perpetual exploration goal with existing features:

> Perpetually explore until all navigation destinations have been reached by automatically exploring the app and intelligently selecting and interacting with navigation elements. Builds a comprehensive navigation graph by prioritizing likely navigation elements (buttons, tabs, menus), avoiding redundant interactions, and efficiently covering unexplored screens. Supports breadth-first, depth-first, and weighted exploration strategies. Automatically detects and handles common blockers like permission dialogs and login screens. Default: 50 interactions, weighted strategy, 5-minute timeout.

### Additional Updates
- All logger messages: `[MonkeyNavigate]` → `[Explore]`
- All code comments and docstrings updated
- All test variables and assertions updated
- Performance tracking calls updated
- Error messages updated

## Test plan
- [x] Lint passes
- [x] Build passes
- [x] All tests pass (566 tests)

## Related Issues
Fixes #80

🤖 Generated with [Claude Code](https://claude.com/claude-code)