### PR TITLE
Fix large MCP response warning by filtering and truncating perf timing data

### DIFF
--- a/src/features/observe/ObserveScreen.ts
+++ b/src/features/observe/ObserveScreen.ts
@@ -16,7 +16,7 @@ import { readdirAsync, readFileAsync, statAsync, writeFileAsync } from "../../ut
 import { AndroidAccessibilityServiceManager } from "../../utils/AccessibilityServiceManager";
 import { AxeClient } from "../../utils/ios-cmdline-tools/AxeClient";
 import { WebDriverAgent } from "../../utils/ios-cmdline-tools/WebDriverAgent";
-import { PerformanceTracker, NoOpPerformanceTracker } from "../../utils/PerformanceTracker";
+import { PerformanceTracker, NoOpPerformanceTracker, processTimingData } from "../../utils/PerformanceTracker";
 import { PerformanceAudit } from "../performance/PerformanceAudit";
 import { ThresholdManager } from "../performance/ThresholdManager";
 import { DeviceCapabilitiesDetector } from "../../utils/DeviceCapabilities";
@@ -698,10 +698,14 @@ export class ObserveScreen {
 
       perf.end();
 
-      // Attach performance timing if enabled
+      // Attach performance timing if enabled (with filtering and truncation)
       const timings = perf.getTimings();
-      if (timings) {
-        result.perfTiming = timings;
+      const processedTimings = processTimingData(timings);
+      if (processedTimings) {
+        result.perfTiming = processedTimings.data;
+        if (processedTimings.truncated) {
+          result.perfTimingTruncated = true;
+        }
       }
 
       logger.debug("Observe command completed");

--- a/src/models/ObserveResult.ts
+++ b/src/models/ObserveResult.ts
@@ -80,6 +80,9 @@ export interface ObserveResult {
   /** Performance timing data (only present when --debug-perf is enabled) */
   perfTiming?: TimingData;
 
+  /** Indicates if performance timing data was truncated due to size limits */
+  perfTimingTruncated?: boolean;
+
   /** Graphics frame metrics from gfxinfo (only present when --debug-perf is enabled) */
   gfxMetrics?: GfxMetrics;
 

--- a/src/utils/PerformanceTracker.ts
+++ b/src/utils/PerformanceTracker.ts
@@ -348,3 +348,208 @@ export function isDebugPerfEnabled(): boolean {
 export function createGlobalPerformanceTracker(): PerformanceTracker {
   return createPerformanceTracker(debugPerfEnabled);
 }
+
+/**
+ * Maximum size for performance timing data in bytes (can be configured)
+ * Default: 50KB - reasonable limit that won't bloat MCP responses
+ */
+let maxPerfTimingSizeBytes = 50 * 1024; // 50KB
+
+/**
+ * Set the maximum size for performance timing data
+ */
+export function setMaxPerfTimingSizeBytes(sizeBytes: number): void {
+  maxPerfTimingSizeBytes = sizeBytes;
+}
+
+/**
+ * Get the current maximum size for performance timing data
+ */
+export function getMaxPerfTimingSizeBytes(): number {
+  return maxPerfTimingSizeBytes;
+}
+
+/**
+ * Result of processing timing data with filtering and truncation
+ */
+export interface ProcessedTimingData {
+  data: TimingData;
+  truncated?: boolean;
+}
+
+/**
+ * Recursively filter out timing entries with 0ms duration
+ */
+function filterZeroTimings(timings: TimingData): TimingData {
+  if (Array.isArray(timings)) {
+    // Filter array entries
+    return timings
+      .filter(entry => entry.durationMs > 0)
+      .map(entry => ({
+        ...entry,
+        children: entry.children ? filterZeroTimings(entry.children) : undefined
+      }))
+      .filter(entry => {
+        // Also remove entries that have no children after filtering
+        if (entry.children) {
+          const hasChildren = Array.isArray(entry.children)
+            ? entry.children.length > 0
+            : Object.keys(entry.children).length > 0;
+          return hasChildren;
+        }
+        return true;
+      });
+  } else {
+    // Filter object entries
+    const filtered: Record<string, TimingEntry> = {};
+    for (const [key, entry] of Object.entries(timings)) {
+      if (entry.durationMs > 0) {
+        const filteredEntry: TimingEntry = {
+          ...entry,
+          children: entry.children ? filterZeroTimings(entry.children) : undefined
+        };
+
+        // Only include if has children after filtering or has no children
+        if (filteredEntry.children) {
+          const hasChildren = Array.isArray(filteredEntry.children)
+            ? filteredEntry.children.length > 0
+            : Object.keys(filteredEntry.children).length > 0;
+          if (hasChildren) {
+            filtered[key] = filteredEntry;
+          }
+        } else {
+          filtered[key] = filteredEntry;
+        }
+      }
+    }
+    return filtered;
+  }
+}
+
+/**
+ * Estimate the JSON size of timing data in bytes
+ */
+function estimateTimingDataSize(timings: TimingData): number {
+  return JSON.stringify(timings).length;
+}
+
+/**
+ * Collect all timing entries with their paths for sorting and removal
+ */
+interface TimingPath {
+  path: string[];
+  entry: TimingEntry;
+  parent: TimingData;
+  key: string | number;
+}
+
+function collectTimingPaths(timings: TimingData, parentPath: string[] = []): TimingPath[] {
+  const paths: TimingPath[] = [];
+
+  if (Array.isArray(timings)) {
+    timings.forEach((entry, index) => {
+      paths.push({
+        path: [...parentPath, entry.name],
+        entry,
+        parent: timings,
+        key: index
+      });
+      if (entry.children) {
+        paths.push(...collectTimingPaths(entry.children, [...parentPath, entry.name]));
+      }
+    });
+  } else {
+    for (const [key, entry] of Object.entries(timings)) {
+      paths.push({
+        path: [...parentPath, key],
+        entry,
+        parent: timings,
+        key
+      });
+      if (entry.children) {
+        paths.push(...collectTimingPaths(entry.children, [...parentPath, key]));
+      }
+    }
+  }
+
+  return paths;
+}
+
+/**
+ * Remove a timing entry from its parent
+ */
+function removeTimingEntry(parent: TimingData, key: string | number): void {
+  if (Array.isArray(parent)) {
+    parent.splice(key as number, 1);
+  } else {
+    delete parent[key as string];
+  }
+}
+
+/**
+ * Truncate timing data by removing smallest duration entries until under size limit
+ */
+function truncateTimingData(timings: TimingData, maxSizeBytes: number): ProcessedTimingData {
+  // Make a deep copy to avoid mutating the original
+  const workingCopy = JSON.parse(JSON.stringify(timings)) as TimingData;
+
+  let currentSize = estimateTimingDataSize(workingCopy);
+  if (currentSize <= maxSizeBytes) {
+    return { data: workingCopy };
+  }
+
+  let truncated = false;
+
+  // Keep removing smallest timings until we're under the limit
+  while (currentSize > maxSizeBytes) {
+    // Collect all timing paths
+    const paths = collectTimingPaths(workingCopy);
+
+    if (paths.length === 0) {
+      // Nothing left to remove
+      break;
+    }
+
+    // Sort by duration (ascending) - smallest first
+    paths.sort((a, b) => a.entry.durationMs - b.entry.durationMs);
+
+    // Remove the smallest timing
+    const smallest = paths[0];
+    removeTimingEntry(smallest.parent, smallest.key);
+    truncated = true;
+
+    // Recalculate size
+    currentSize = estimateTimingDataSize(workingCopy);
+  }
+
+  return {
+    data: workingCopy,
+    truncated: truncated ? true : undefined
+  };
+}
+
+/**
+ * Process timing data by filtering zero-duration entries and truncating if needed
+ * @param timings - Raw timing data from performance tracker
+ * @returns Processed timing data with optional truncation flag
+ */
+export function processTimingData(timings: TimingData | null): ProcessedTimingData | null {
+  if (!timings) {
+    return null;
+  }
+
+  // First, filter out 0ms timings
+  const filtered = filterZeroTimings(timings);
+
+  // Check if empty after filtering
+  const isEmpty = Array.isArray(filtered)
+    ? filtered.length === 0
+    : Object.keys(filtered).length === 0;
+
+  if (isEmpty) {
+    return null;
+  }
+
+  // Then truncate if needed
+  return truncateTimingData(filtered, maxPerfTimingSizeBytes);
+}

--- a/test/utils/PerformanceTracker.test.ts
+++ b/test/utils/PerformanceTracker.test.ts
@@ -9,7 +9,10 @@ import {
   TimingData,
   setDebugPerfEnabled,
   isDebugPerfEnabled,
-  createGlobalPerformanceTracker
+  createGlobalPerformanceTracker,
+  processTimingData,
+  setMaxPerfTimingSizeBytes,
+  getMaxPerfTimingSizeBytes
 } from "../../src/utils/PerformanceTracker";
 
 describe("PerformanceTracker", function() {
@@ -258,6 +261,196 @@ describe("PerformanceTracker", function() {
         { method: "track", name: "op" },
         { method: "end", name: "" }
       ]);
+    });
+  });
+
+  describe("processTimingData", function() {
+    const originalLimit = getMaxPerfTimingSizeBytes();
+
+    beforeEach(function() {
+      // Reset to default for tests
+      setMaxPerfTimingSizeBytes(50 * 1024); // 50KB
+    });
+
+    afterEach(function() {
+      // Restore original limit
+      setMaxPerfTimingSizeBytes(originalLimit);
+    });
+
+    it("should return null for null input", function() {
+      const result = processTimingData(null);
+      expect(result).to.be.null;
+    });
+
+    it("should filter out 0ms timings from array", function() {
+      const timings: TimingEntry[] = [
+        { name: "op1", durationMs: 10 },
+        { name: "op2", durationMs: 0 },
+        { name: "op3", durationMs: 5 }
+      ];
+
+      const result = processTimingData(timings);
+      expect(result).to.not.be.null;
+      expect(result!.data).to.be.an("array");
+      expect((result!.data as TimingEntry[]).length).to.equal(2);
+      expect((result!.data as TimingEntry[])[0].name).to.equal("op1");
+      expect((result!.data as TimingEntry[])[1].name).to.equal("op3");
+      expect(result!.truncated).to.be.undefined;
+    });
+
+    it("should filter out 0ms timings from object", function() {
+      const timings: Record<string, TimingEntry> = {
+        op1: { name: "op1", durationMs: 10 },
+        op2: { name: "op2", durationMs: 0 },
+        op3: { name: "op3", durationMs: 5 }
+      };
+
+      const result = processTimingData(timings);
+      expect(result).to.not.be.null;
+      expect(result!.data).to.be.an("object");
+      expect(result!.data).to.not.be.an("array");
+      expect(Object.keys(result!.data)).to.deep.equal(["op1", "op3"]);
+      expect(result!.truncated).to.be.undefined;
+    });
+
+    it("should filter out 0ms timings recursively", function() {
+      const timings: TimingEntry[] = [
+        {
+          name: "parent",
+          durationMs: 20,
+          children: [
+            { name: "child1", durationMs: 10 },
+            { name: "child2", durationMs: 0 },
+            { name: "child3", durationMs: 5 }
+          ]
+        }
+      ];
+
+      const result = processTimingData(timings);
+      expect(result).to.not.be.null;
+      const data = result!.data as TimingEntry[];
+      expect(data[0].children).to.be.an("array");
+      const children = data[0].children as TimingEntry[];
+      expect(children.length).to.equal(2);
+      expect(children[0].name).to.equal("child1");
+      expect(children[1].name).to.equal("child3");
+    });
+
+    it("should return null when all timings are 0ms", function() {
+      const timings: TimingEntry[] = [
+        { name: "op1", durationMs: 0 },
+        { name: "op2", durationMs: 0 }
+      ];
+
+      const result = processTimingData(timings);
+      expect(result).to.be.null;
+    });
+
+    it("should not truncate when under size limit", function() {
+      const timings: TimingEntry[] = [
+        { name: "small", durationMs: 10 }
+      ];
+
+      const result = processTimingData(timings);
+      expect(result).to.not.be.null;
+      expect(result!.truncated).to.be.undefined;
+    });
+
+    it("should truncate by removing smallest timings when over size limit", function() {
+      // Set a very small limit to force truncation
+      setMaxPerfTimingSizeBytes(200);
+
+      // Create timing data that will exceed 200 bytes
+      const timings: TimingEntry[] = [
+        { name: "large1", durationMs: 100 },
+        { name: "large2", durationMs: 90 },
+        { name: "medium", durationMs: 50 },
+        { name: "small1", durationMs: 10 },
+        { name: "small2", durationMs: 5 },
+        { name: "small3", durationMs: 1 }
+      ];
+
+      const result = processTimingData(timings);
+      expect(result).to.not.be.null;
+      expect(result!.truncated).to.equal(true);
+
+      // Should have removed some entries
+      const data = result!.data as TimingEntry[];
+      expect(data.length).to.be.lessThan(timings.length);
+
+      // Check that remaining entries are the largest ones
+      const remainingDurations = data.map(e => e.durationMs);
+      expect(Math.max(...remainingDurations)).to.be.greaterThan(50);
+    });
+
+    it("should set truncated flag when truncation occurs", function() {
+      setMaxPerfTimingSizeBytes(100);
+
+      const timings: TimingEntry[] = Array.from({ length: 20 }, (_, i) => ({
+        name: `operation-${i}`,
+        durationMs: i + 1
+      }));
+
+      const result = processTimingData(timings);
+      expect(result).to.not.be.null;
+      expect(result!.truncated).to.equal(true);
+    });
+
+    it("should respect configured size limit", function() {
+      const customLimit = 500;
+      setMaxPerfTimingSizeBytes(customLimit);
+
+      expect(getMaxPerfTimingSizeBytes()).to.equal(customLimit);
+
+      // Create large timing data
+      const timings: TimingEntry[] = Array.from({ length: 50 }, (_, i) => ({
+        name: `operation-with-a-long-name-${i}`,
+        durationMs: i + 1
+      }));
+
+      const result = processTimingData(timings);
+      expect(result).to.not.be.null;
+
+      // Verify the result is under the limit
+      const resultSize = JSON.stringify(result!.data).length;
+      expect(resultSize).to.be.at.most(customLimit);
+    });
+
+    it("should remove parent entries that have no children after filtering", function() {
+      const timings: TimingEntry[] = [
+        {
+          name: "parent",
+          durationMs: 10,
+          children: [
+            { name: "child", durationMs: 0 }
+          ]
+        }
+      ];
+
+      const result = processTimingData(timings);
+      // Parent should be removed because all children were 0ms
+      expect(result).to.be.null;
+    });
+
+    it("should keep parent entries that still have children after filtering", function() {
+      const timings: TimingEntry[] = [
+        {
+          name: "parent",
+          durationMs: 15,
+          children: [
+            { name: "child1", durationMs: 0 },
+            { name: "child2", durationMs: 5 }
+          ]
+        }
+      ];
+
+      const result = processTimingData(timings);
+      expect(result).to.not.be.null;
+      const data = result!.data as TimingEntry[];
+      expect(data.length).to.equal(1);
+      expect(data[0].name).to.equal("parent");
+      expect(data[0].children).to.be.an("array");
+      expect((data[0].children as TimingEntry[]).length).to.equal(1);
     });
   });
 });


### PR DESCRIPTION
## Summary
Fixes #86 - Large MCP response warning on Accessibility Service websocket timeout

## Problem
When the Accessibility Service websocket times out or is unavailable while running with `--perf-debug`, the MCP server generates very large responses that bloat the context window. This is caused by:
- Many operations having 0ms duration timings (noise)
- Performance timing data growing unbounded with nested operations
- No size limits on the timing data included in responses

## Solution
Implemented `processTimingData()` function that:
1. **Filters out 0ms timings** - Recursively removes all zero-duration entries and parents with no children after filtering
2. **Enforces size limits** - Default 50KB limit (configurable via `setMaxPerfTimingSizeBytes()`)
3. **Truncates intelligently** - Removes smallest timings first when over the limit
4. **Adds truncation flag** - Sets `perfTimingTruncated: true` when data is truncated

## Changes
- `src/utils/PerformanceTracker.ts`: Added processing logic and configuration functions
- `src/models/ObserveResult.ts`: Added `perfTimingTruncated` field
- `src/features/observe/ObserveScreen.ts`: Integrated processing before returning results
- `test/utils/PerformanceTracker.test.ts`: Added 11 comprehensive tests

## Testing
✅ All 531 tests passing
✅ Lint passed
✅ Build passed  
✅ Hadolint passed
✅ Act validation passed

## Examples

### Before (0ms timings included, unbounded size)
```json
{
  "perfTiming": [
    { "name": "op1", "durationMs": 10 },
    { "name": "op2", "durationMs": 0 },   // Noise
    { "name": "op3", "durationMs": 0 },   // Noise
    { "name": "op4", "durationMs": 5 },
    // ... hundreds more entries ...
  ]
}
```

### After (filtered and truncated)
```json
{
  "perfTiming": [
    { "name": "op1", "durationMs": 10 },
    { "name": "op4", "durationMs": 5 }
  ],
  "perfTimingTruncated": true  // Only if truncation occurred
}
```

## Configuration
The size limit can be adjusted if needed:
```typescript
setMaxPerfTimingSizeBytes(100 * 1024);  // 100KB
```