### PR TITLE
Add touch latency testing implementation

### DIFF
--- a/docs/features/ui-performance-audit.md
+++ b/docs/features/ui-performance-audit.md
@@ -29,9 +29,11 @@ The UI Performance Audit mode monitors Android app performance during `observe` 
    - Pending Application Not Responding states
    - Via `dumpsys activity processes`
 
-5. **Touch Latency** (Planned)
-   - Inject touch events on non-clickable areas
-   - Measure response time
+5. **Touch Latency** (--ui-perf-mode only)
+   - Inject synthetic touch events on non-clickable areas (status bar)
+   - Measure time until frame activity detected via gfxinfo
+   - Uses median of 3 samples for accuracy
+   - Detects UI responsiveness issues
 
 ### Automatic Threshold Detection
 
@@ -88,7 +90,7 @@ When enabled, `observe` tool calls will include a `performanceAudit` field:
       "slowUiThreadCount": 4,
       "frameDeadlineMissedCount": 0,
       "cpuUsagePercent": 65.2,
-      "touchLatencyMs": null,
+      "touchLatencyMs": 28.5,
       "anrDetected": false
     },
     "violations": [
@@ -164,6 +166,12 @@ When enabled, `observe` tool calls will include a `performanceAudit` field:
 - Calculates weighted averages
 - Updates weights based on outcomes
 
+**TouchLatencyTracker** (src/features/performance/TouchLatencyTracker.ts)
+- Injects synthetic touches on safe screen areas
+- Monitors gfxinfo for frame activity changes
+- Calculates median latency from multiple samples
+- Only runs when --ui-perf-mode is enabled
+
 ### Integration Point
 
 Performance audits run during `ObserveScreen.execute()`:
@@ -171,7 +179,7 @@ Performance audits run during `ObserveScreen.execute()`:
 2. If audit enabled and Android device:
    - Detect device capabilities
    - Get/create thresholds
-   - Run audit
+   - Run audit (includes touch latency if --ui-perf-mode enabled)
    - Attach results to observation
    - Update threshold weights
 
@@ -181,12 +189,6 @@ Performance audits run during `ObserveScreen.execute()`:
 - Global configuration management
 - UI/API for threshold customization
 - Enable/disable per device via config
-
-### Touch Latency Testing
-- Identify non-clickable screen areas
-- Inject periodic touch events
-- Measure time to UI response
-- Report latency violations
 
 ### Enhanced Diagnostics
 - Memory pressure detection
@@ -198,7 +200,7 @@ Performance audits run during `ObserveScreen.execute()`:
 
 - Audit adds ~200-500ms to observe calls
 - CPU/ANR checks run in parallel with gfxinfo
-- Touch latency testing (when implemented) adds interaction time
+- Touch latency testing adds ~500-800ms (3 samples × ~200ms each, only when --ui-perf-mode enabled)
 - Database queries cached per session
 - Threshold calculation only on first session access
 
@@ -208,9 +210,24 @@ Performance audits run during `ObserveScreen.execute()`:
 - Requires `dumpsys` access
 - System/launcher apps use simplified checks
 - No audit if no active app window
-- Touch latency not yet implemented
+- Touch latency requires --ui-perf-mode flag and adds overhead
+
+## How Touch Latency Works
+
+When --ui-perf-mode is enabled, touch latency is measured by:
+
+1. **Safe Touch Location Selection**: Selects top-right corner of status bar (95% width, 2% height) to avoid triggering UI interactions
+2. **Baseline Capture**: Resets gfxinfo and captures baseline frame stats
+3. **Touch Injection**: Injects synthetic touch event via `adb shell input tap`
+4. **Response Detection**: Polls gfxinfo every 10ms, watching for frame activity:
+   - Increased missed vsync count
+   - Increased slow UI thread count
+   - Increased frame deadline missed count
+5. **Multiple Samples**: Takes 3 samples and calculates median for accuracy
+6. **Result**: Reports median latency in milliseconds
 
 ## Related Issues
 
 - #36: Initial implementation
 - #67: Global configuration system
+- #85: Touch latency testing implementation

--- a/src/features/observe/ObserveScreen.ts
+++ b/src/features/observe/ObserveScreen.ts
@@ -634,6 +634,7 @@ export class ObserveScreen {
         const auditResult = await performanceAudit.runAudit(
           result.activeWindow!.appId,
           thresholds,
+          result.screenSize,
           perf
         );
 

--- a/src/features/performance/PerformanceAudit.ts
+++ b/src/features/performance/PerformanceAudit.ts
@@ -1,9 +1,11 @@
 import { AdbClient } from "../../utils/android-cmdline-tools/AdbClient";
 import { logger } from "../../utils/logger";
-import { BootedDevice } from "../../models";
+import { BootedDevice, ScreenSize } from "../../models";
 import { PerformanceTracker, NoOpPerformanceTracker } from "../../utils/PerformanceTracker";
 import { Idle } from "../observe/Idle";
 import { DeviceCapabilitiesDetector, DeviceCapabilities } from "../../utils/DeviceCapabilities";
+import { TouchLatencyTracker } from "./TouchLatencyTracker";
+import { serverConfig } from "../../utils/ServerConfig";
 
 /**
  * Performance metrics collected during audit
@@ -67,12 +69,14 @@ export class PerformanceAudit {
   private device: BootedDevice;
   private idle: Idle;
   private capabilitiesDetector: DeviceCapabilitiesDetector;
+  private touchLatencyTracker: TouchLatencyTracker;
 
   constructor(device: BootedDevice, adb: AdbClient | null = null) {
     this.device = device;
     this.adb = adb || new AdbClient(device);
     this.idle = new Idle(device, this.adb);
     this.capabilitiesDetector = new DeviceCapabilitiesDetector(device, this.adb);
+    this.touchLatencyTracker = new TouchLatencyTracker(device, this.adb);
   }
 
   /**
@@ -80,6 +84,7 @@ export class PerformanceAudit {
    */
   async collectMetrics(
     packageName: string,
+    screenSize?: ScreenSize,
     perf: PerformanceTracker = new NoOpPerformanceTracker()
   ): Promise<PerformanceMetrics> {
     logger.info(`[PerformanceAudit] Collecting metrics for ${packageName}`);
@@ -92,7 +97,7 @@ export class PerformanceAudit {
     ]);
 
     // Touch latency requires sequential execution after other metrics
-    const touchLatency = await this.measureTouchLatency(packageName, perf);
+    const touchLatency = await this.measureTouchLatency(packageName, screenSize, perf);
 
     const result: PerformanceMetrics = {
       p50Ms: gfxMetrics.p50Ms ?? null,
@@ -262,16 +267,41 @@ export class PerformanceAudit {
   /**
    * Measure touch response latency
    * Injects touch on non-clickable area and measures response time
+   * Only runs when --ui-perf-mode flag is enabled
    */
   private async measureTouchLatency(
     packageName: string,
+    screenSize: ScreenSize | undefined,
     perf: PerformanceTracker
   ): Promise<number | null> {
-    try {
-      // For now, return null - this will be implemented in a follow-up task
-      // TODO: Implement touch latency measurement
-      logger.debug("[PerformanceAudit] Touch latency measurement not yet implemented");
+    // Only measure touch latency when UI performance mode is enabled
+    if (!serverConfig.isUiPerfModeEnabled()) {
+      logger.debug("[PerformanceAudit] Touch latency measurement skipped (--ui-perf-mode not enabled)");
       return null;
+    }
+
+    // Screen size is required for touch latency measurement
+    if (!screenSize) {
+      logger.warn("[PerformanceAudit] Touch latency measurement skipped (screen size not provided)");
+      return null;
+    }
+
+    try {
+      logger.info("[PerformanceAudit] Measuring touch latency with synthetic touches");
+      const result = await perf.track("touchLatencyMeasurement", () =>
+        this.touchLatencyTracker.measureLatency(packageName, screenSize, {
+          sampleCount: 3,
+          maxWaitMs: 200
+        }, perf)
+      );
+
+      if (result.success) {
+        logger.info(`[PerformanceAudit] Touch latency measured: ${result.latencyMs}ms`);
+        return result.latencyMs;
+      } else {
+        logger.warn(`[PerformanceAudit] Touch latency measurement failed: ${result.error}`);
+        return null;
+      }
     } catch (error) {
       logger.warn(`[PerformanceAudit] Failed to measure touch latency: ${error}`);
       return null;
@@ -460,6 +490,7 @@ export class PerformanceAudit {
       cpuUsageThresholdPercent: number;
       touchLatencyThresholdMs: number;
     },
+    screenSize?: ScreenSize,
     perf: PerformanceTracker = new NoOpPerformanceTracker()
   ): Promise<PerformanceAuditResult> {
     logger.info(`[PerformanceAudit] Running audit for ${packageName}`);
@@ -468,7 +499,7 @@ export class PerformanceAudit {
     const deviceCapabilities = await this.capabilitiesDetector.getCapabilities();
 
     // Collect metrics
-    const metrics = await this.collectMetrics(packageName, perf);
+    const metrics = await this.collectMetrics(packageName, screenSize, perf);
 
     // Validate against thresholds
     const violations = this.validateMetrics(metrics, thresholds);

--- a/src/features/performance/TouchLatencyTracker.ts
+++ b/src/features/performance/TouchLatencyTracker.ts
@@ -1,0 +1,225 @@
+import { AdbClient } from "../../utils/android-cmdline-tools/AdbClient";
+import { logger } from "../../utils/logger";
+import { BootedDevice, ScreenSize } from "../../models";
+import { PerformanceTracker, NoOpPerformanceTracker } from "../../utils/PerformanceTracker";
+import { Idle } from "../observe/Idle";
+
+/**
+ * Result of a touch latency measurement
+ */
+export interface TouchLatencyResult {
+  /** Measured latency in milliseconds */
+  latencyMs: number;
+  /** Touch coordinates used for measurement */
+  touchCoordinates: { x: number; y: number };
+  /** Whether the measurement was successful */
+  success: boolean;
+  /** Error message if measurement failed */
+  error?: string;
+  /** Number of samples taken */
+  sampleCount: number;
+}
+
+/**
+ * Measures touch input latency by injecting synthetic touches
+ * and measuring the time until UI response is detected via gfxinfo
+ */
+export class TouchLatencyTracker {
+  private adb: AdbClient;
+  private device: BootedDevice;
+  private idle: Idle;
+
+  constructor(device: BootedDevice, adb: AdbClient | null = null) {
+    this.device = device;
+    this.adb = adb || new AdbClient(device);
+    this.idle = new Idle(device, this.adb);
+  }
+
+  /**
+   * Select a safe touch location that's unlikely to trigger UI interactions
+   * Uses screen edges or status bar area
+   * @param screenSize - Device screen dimensions
+   * @returns Touch coordinates (x, y)
+   */
+  private selectSafeTouchLocation(screenSize: ScreenSize): { x: number; y: number } {
+    // Use top-right corner of status bar area (typically safe and non-interactive)
+    // Status bar is usually ~50-75px tall
+    const x = Math.floor(screenSize.width * 0.95); // 95% to right
+    const y = Math.floor(screenSize.height * 0.02); // 2% from top (status bar)
+
+    logger.debug(`[TouchLatency] Selected safe touch location: (${x}, ${y})`);
+    return { x, y };
+  }
+
+  /**
+   * Inject a synthetic touch event at specified coordinates
+   * @param x - X coordinate
+   * @param y - Y coordinate
+   * @param perf - Performance tracker
+   */
+  private async injectTouch(
+    x: number,
+    y: number,
+    perf: PerformanceTracker
+  ): Promise<void> {
+    await perf.track("adbInputTap", () =>
+      this.adb.executeCommand(`shell input tap ${x} ${y}`)
+    );
+  }
+
+  /**
+   * Measure time until frame statistics show activity after touch
+   * Uses gfxinfo frame count changes as indicator of UI processing
+   * @param packageName - Package to monitor
+   * @param beforeStats - Baseline frame stats before touch
+   * @param maxWaitMs - Maximum time to wait for response
+   * @param perf - Performance tracker
+   * @returns Time until frame activity detected, or null if timeout
+   */
+  private async measureFrameResponse(
+    packageName: string,
+    beforeStats: { missedVsync: number | null; slowUiThread: number | null; frameDeadlineMissed: number | null },
+    maxWaitMs: number,
+    perf: PerformanceTracker
+  ): Promise<number | null> {
+    const startTime = Date.now();
+    const pollIntervalMs = 10; // Poll every 10ms for quick response
+
+    while (Date.now() - startTime < maxWaitMs) {
+      await new Promise(resolve => setTimeout(resolve, pollIntervalMs));
+
+      try {
+        const { stdout } = await perf.track("adbGfxinfoCheck", () =>
+          this.adb.executeCommand(`shell dumpsys gfxinfo ${packageName}`)
+        );
+
+        const currentStats = this.idle.parseMetrics(stdout);
+
+        // Check if any jank indicator has changed (indicates frame processing)
+        const hasFrameActivity =
+          (beforeStats.missedVsync !== null && currentStats.missedVsync !== null &&
+           currentStats.missedVsync > beforeStats.missedVsync) ||
+          (beforeStats.slowUiThread !== null && currentStats.slowUiThread !== null &&
+           currentStats.slowUiThread > beforeStats.slowUiThread) ||
+          (beforeStats.frameDeadlineMissed !== null && currentStats.frameDeadlineMissed !== null &&
+           currentStats.frameDeadlineMissed > beforeStats.frameDeadlineMissed);
+
+        if (hasFrameActivity) {
+          const latency = Date.now() - startTime;
+          logger.debug(`[TouchLatency] Frame activity detected after ${latency}ms`);
+          return latency;
+        }
+      } catch (error) {
+        logger.warn(`[TouchLatency] Error checking frame stats: ${error}`);
+        // Continue polling despite errors
+      }
+    }
+
+    logger.warn(`[TouchLatency] No frame activity detected within ${maxWaitMs}ms`);
+    return null;
+  }
+
+  /**
+   * Measure touch latency for a given package
+   * @param packageName - Package name to monitor
+   * @param screenSize - Device screen dimensions
+   * @param options - Measurement options
+   * @param perf - Performance tracker
+   * @returns Touch latency result
+   */
+  async measureLatency(
+    packageName: string,
+    screenSize: ScreenSize,
+    options: {
+      sampleCount?: number;
+      maxWaitMs?: number;
+    } = {},
+    perf: PerformanceTracker = new NoOpPerformanceTracker()
+  ): Promise<TouchLatencyResult> {
+    const sampleCount = options.sampleCount || 3;
+    const maxWaitMs = options.maxWaitMs || 200; // 200ms max wait per sample
+
+    logger.info(`[TouchLatency] Measuring touch latency for ${packageName} (${sampleCount} samples)`);
+
+    const touchLocation = this.selectSafeTouchLocation(screenSize);
+    const measurements: number[] = [];
+
+    try {
+      for (let i = 0; i < sampleCount; i++) {
+        logger.debug(`[TouchLatency] Taking sample ${i + 1}/${sampleCount}`);
+
+        // Reset gfxinfo to get clean baseline
+        await perf.track("adbGfxinfoReset", () =>
+          this.adb.executeCommand(`shell dumpsys gfxinfo ${packageName} reset`)
+        );
+
+        // Small delay to ensure reset is processed
+        await new Promise(resolve => setTimeout(resolve, 50));
+
+        // Get baseline frame stats
+        const { stdout: baselineStdout } = await perf.track("adbGfxinfoBaseline", () =>
+          this.adb.executeCommand(`shell dumpsys gfxinfo ${packageName}`)
+        );
+        const baselineStats = this.idle.parseMetrics(baselineStdout);
+
+        // Inject touch and immediately start measuring
+        await this.injectTouch(touchLocation.x, touchLocation.y, perf);
+
+        // Measure time until frame response
+        const latency = await this.measureFrameResponse(
+          packageName,
+          baselineStats,
+          maxWaitMs,
+          perf
+        );
+
+        if (latency !== null) {
+          measurements.push(latency);
+          logger.debug(`[TouchLatency] Sample ${i + 1}: ${latency}ms`);
+        } else {
+          logger.warn(`[TouchLatency] Sample ${i + 1} timeout - no response within ${maxWaitMs}ms`);
+        }
+
+        // Wait between samples to avoid interference
+        if (i < sampleCount - 1) {
+          await new Promise(resolve => setTimeout(resolve, 100));
+        }
+      }
+
+      if (measurements.length === 0) {
+        return {
+          latencyMs: 0,
+          touchCoordinates: touchLocation,
+          success: false,
+          error: "No successful measurements - UI may be frozen or gfxinfo unavailable",
+          sampleCount: 0
+        };
+      }
+
+      // Calculate median latency (more robust than average)
+      measurements.sort((a, b) => a - b);
+      const medianLatency = measurements.length % 2 === 0
+        ? (measurements[measurements.length / 2 - 1] + measurements[measurements.length / 2]) / 2
+        : measurements[Math.floor(measurements.length / 2)];
+
+      logger.info(`[TouchLatency] Measured latency: ${medianLatency}ms (from ${measurements.length} samples)`);
+
+      return {
+        latencyMs: medianLatency,
+        touchCoordinates: touchLocation,
+        success: true,
+        sampleCount: measurements.length
+      };
+
+    } catch (error) {
+      logger.error(`[TouchLatency] Failed to measure touch latency: ${error}`);
+      return {
+        latencyMs: 0,
+        touchCoordinates: touchLocation,
+        success: false,
+        error: error instanceof Error ? error.message : String(error),
+        sampleCount: measurements.length
+      };
+    }
+  }
+}

--- a/test/features/performance/TouchLatencyTracker.test.ts
+++ b/test/features/performance/TouchLatencyTracker.test.ts
@@ -1,0 +1,325 @@
+import { expect } from "chai";
+import { describe, it, beforeEach } from "mocha";
+import { TouchLatencyTracker } from "../../../src/features/performance/TouchLatencyTracker";
+import { BootedDevice, ScreenSize } from "../../../src/models";
+import { AdbClient } from "../../../src/utils/android-cmdline-tools/AdbClient";
+import { NoOpPerformanceTracker } from "../../../src/utils/PerformanceTracker";
+
+describe("TouchLatencyTracker - Unit Tests", function() {
+  let tracker: TouchLatencyTracker;
+  let adb: AdbClient;
+  let device: BootedDevice;
+  let screenSize: ScreenSize;
+  let perf: NoOpPerformanceTracker;
+
+  beforeEach(function() {
+    device = {
+      deviceId: "test-device",
+      platform: "android",
+      state: "device"
+    };
+
+    screenSize = {
+      width: 1080,
+      height: 1920
+    };
+
+    perf = new NoOpPerformanceTracker();
+  });
+
+  describe("selectSafeTouchLocation", function() {
+    it("should select a location in the top-right corner", function() {
+      adb = new AdbClient(device, async () => ({ stdout: "", stderr: "" }));
+      tracker = new TouchLatencyTracker(device, adb);
+
+      // Access private method via type assertion for testing
+      const location = (tracker as any).selectSafeTouchLocation(screenSize);
+
+      // Should be at 95% width and 2% height (status bar area)
+      expect(location.x).to.equal(Math.floor(1080 * 0.95)); // 1026
+      expect(location.y).to.equal(Math.floor(1920 * 0.02)); // 38
+    });
+
+    it("should handle different screen sizes", function() {
+      adb = new AdbClient(device, async () => ({ stdout: "", stderr: "" }));
+      tracker = new TouchLatencyTracker(device, adb);
+
+      const smallScreen: ScreenSize = { width: 720, height: 1280 };
+      const location = (tracker as any).selectSafeTouchLocation(smallScreen);
+
+      expect(location.x).to.equal(Math.floor(720 * 0.95)); // 684
+      expect(location.y).to.equal(Math.floor(1280 * 0.02)); // 25
+    });
+  });
+
+  describe("measureLatency", function() {
+    it("should return successful result when frame activity is detected", async function() {
+      // Set up fake ADB responses
+      let callCount = 0;
+
+      adb = new AdbClient(device, async (command: string) => {
+        if (command.includes("dumpsys gfxinfo")) {
+          if (command.includes("reset")) {
+            return { stdout: "", stderr: "" };
+          }
+
+          // Return baseline stats first, then show increased jank on subsequent calls
+          callCount++;
+          if (callCount === 1) {
+            // Baseline
+            return {
+              stdout: `
+                50th percentile: 8.5ms
+                90th percentile: 12.3ms
+                95th percentile: 15.7ms
+                99th percentile: 22.1ms
+                Number Missed Vsync: 0
+                Number Slow UI thread: 0
+                Number Frame deadline missed: 0
+              `,
+              stderr: ""
+            };
+          } else {
+            // After touch - show frame activity
+            return {
+              stdout: `
+                50th percentile: 10.2ms
+                90th percentile: 15.8ms
+                95th percentile: 18.3ms
+                99th percentile: 25.7ms
+                Number Missed Vsync: 1
+                Number Slow UI thread: 0
+                Number Frame deadline missed: 0
+              `,
+              stderr: ""
+            };
+          }
+        } else if (command.includes("input tap")) {
+          return { stdout: "", stderr: "" };
+        }
+
+        return { stdout: "", stderr: "" };
+      });
+
+      tracker = new TouchLatencyTracker(device, adb);
+
+      const result = await tracker.measureLatency(
+        "com.example.app",
+        screenSize,
+        { sampleCount: 1, maxWaitMs: 200 },
+        perf
+      );
+
+      expect(result.success).to.be.true;
+      expect(result.latencyMs).to.be.greaterThan(0);
+      expect(result.sampleCount).to.equal(1);
+      expect(result.touchCoordinates.x).to.be.greaterThan(0);
+      expect(result.touchCoordinates.y).to.be.greaterThan(0);
+    });
+
+    it("should calculate median from multiple samples", async function() {
+      let callCount = 0;
+
+      adb = new AdbClient(device, async (command: string) => {
+        if (command.includes("dumpsys gfxinfo")) {
+          if (command.includes("reset")) {
+            callCount = 0;
+            return { stdout: "", stderr: "" };
+          }
+
+          callCount++;
+          // Return baseline first, then activity on second call for each sample
+          if (callCount % 2 === 1) {
+            return {
+              stdout: `
+                Number Missed Vsync: 0
+                Number Slow UI thread: 0
+                Number Frame deadline missed: 0
+              `,
+              stderr: ""
+            };
+          } else {
+            return {
+              stdout: `
+                Number Missed Vsync: 1
+                Number Slow UI thread: 0
+                Number Frame deadline missed: 0
+              `,
+              stderr: ""
+            };
+          }
+        } else if (command.includes("input tap")) {
+          return { stdout: "", stderr: "" };
+        }
+
+        return { stdout: "", stderr: "" };
+      });
+
+      tracker = new TouchLatencyTracker(device, adb);
+
+      const result = await tracker.measureLatency(
+        "com.example.app",
+        screenSize,
+        { sampleCount: 3, maxWaitMs: 200 },
+        perf
+      );
+
+      expect(result.success).to.be.true;
+      expect(result.sampleCount).to.equal(3);
+      expect(result.latencyMs).to.be.greaterThan(0);
+    });
+
+    it("should handle timeout when no frame activity detected", async function() {
+      adb = new AdbClient(device, async (command: string) => {
+        if (command.includes("dumpsys gfxinfo")) {
+          if (command.includes("reset")) {
+            return { stdout: "", stderr: "" };
+          }
+
+          // Always return same stats - no frame activity
+          return {
+            stdout: `
+              Number Missed Vsync: 0
+              Number Slow UI thread: 0
+              Number Frame deadline missed: 0
+            `,
+            stderr: ""
+          };
+        } else if (command.includes("input tap")) {
+          return { stdout: "", stderr: "" };
+        }
+
+        return { stdout: "", stderr: "" };
+      });
+
+      tracker = new TouchLatencyTracker(device, adb);
+
+      const result = await tracker.measureLatency(
+        "com.example.app",
+        screenSize,
+        { sampleCount: 1, maxWaitMs: 50 }, // Short timeout for fast test
+        perf
+      );
+
+      expect(result.success).to.be.false;
+      expect(result.sampleCount).to.equal(0);
+      expect(result.error).to.include("No successful measurements");
+    });
+
+    it("should detect frame activity via slowUiThread increase", async function() {
+      let callCount = 0;
+
+      adb = new AdbClient(device, async (command: string) => {
+        if (command.includes("dumpsys gfxinfo")) {
+          if (command.includes("reset")) {
+            return { stdout: "", stderr: "" };
+          }
+
+          callCount++;
+          if (callCount === 1) {
+            return {
+              stdout: `
+                Number Missed Vsync: 0
+                Number Slow UI thread: 0
+                Number Frame deadline missed: 0
+              `,
+              stderr: ""
+            };
+          } else {
+            return {
+              stdout: `
+                Number Missed Vsync: 0
+                Number Slow UI thread: 1
+                Number Frame deadline missed: 0
+              `,
+              stderr: ""
+            };
+          }
+        } else if (command.includes("input tap")) {
+          return { stdout: "", stderr: "" };
+        }
+
+        return { stdout: "", stderr: "" };
+      });
+
+      tracker = new TouchLatencyTracker(device, adb);
+
+      const result = await tracker.measureLatency(
+        "com.example.app",
+        screenSize,
+        { sampleCount: 1, maxWaitMs: 200 },
+        perf
+      );
+
+      expect(result.success).to.be.true;
+      expect(result.latencyMs).to.be.greaterThan(0);
+    });
+
+    it("should detect frame activity via frameDeadlineMissed increase", async function() {
+      let callCount = 0;
+
+      adb = new AdbClient(device, async (command: string) => {
+        if (command.includes("dumpsys gfxinfo")) {
+          if (command.includes("reset")) {
+            return { stdout: "", stderr: "" };
+          }
+
+          callCount++;
+          if (callCount === 1) {
+            return {
+              stdout: `
+                Number Missed Vsync: 0
+                Number Slow UI thread: 0
+                Number Frame deadline missed: 0
+              `,
+              stderr: ""
+            };
+          } else {
+            return {
+              stdout: `
+                Number Missed Vsync: 0
+                Number Slow UI thread: 0
+                Number Frame deadline missed: 2
+              `,
+              stderr: ""
+            };
+          }
+        } else if (command.includes("input tap")) {
+          return { stdout: "", stderr: "" };
+        }
+
+        return { stdout: "", stderr: "" };
+      });
+
+      tracker = new TouchLatencyTracker(device, adb);
+
+      const result = await tracker.measureLatency(
+        "com.example.app",
+        screenSize,
+        { sampleCount: 1, maxWaitMs: 200 },
+        perf
+      );
+
+      expect(result.success).to.be.true;
+      expect(result.latencyMs).to.be.greaterThan(0);
+    });
+
+    it("should handle errors gracefully and return error result", async function() {
+      adb = new AdbClient(device, async (command: string) => {
+        throw new Error("ADB connection failed");
+      });
+
+      tracker = new TouchLatencyTracker(device, adb);
+
+      const result = await tracker.measureLatency(
+        "com.example.app",
+        screenSize,
+        { sampleCount: 1, maxWaitMs: 200 },
+        perf
+      );
+
+      expect(result.success).to.be.false;
+      expect(result.error).to.include("ADB connection failed");
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Implements touch latency testing to measure the time between tool call execution and actual UI response on the device (resolves #85).

## Implementation

### TouchLatencyTracker Class
- **Synthetic Touch Injection**: Injects touches on safe screen areas (status bar, top-right corner at 95% width × 2% height)
- **Frame Activity Detection**: Monitors gfxinfo for frame activity changes (missedVsync, slowUiThread, frameDeadlineMissed)
- **Median Calculation**: Takes 3 samples and calculates median for accuracy and outlier resistance
- **Polling Strategy**: Polls gfxinfo every 10ms for quick response detection (max 200ms per sample)

### Integration
- **PerformanceAudit**: Integrated `measureTouchLatency()` method that only runs when `--ui-perf-mode` flag is enabled
- **ObserveScreen**: Updated to pass screen size to performance audit for safe touch location selection
- **ServerConfig**: Uses existing `--ui-perf-mode` flag to control when latency testing is enabled

### Metrics
- **Command Latency**: Captured via PerformanceTracker
- **Device Latency**: Time from touch injection to frame activity detection
- **Total Latency**: Reported in performance audit results as `touchLatencyMs`

## Test Coverage

Added comprehensive unit tests:
- ✅ Safe touch location selection for different screen sizes
- ✅ Successful latency measurement with frame activity detection
- ✅ Median calculation from multiple samples
- ✅ Timeout handling when no frame activity detected
- ✅ Detection via all three jank indicators (missedVsync, slowUiThread, frameDeadlineMissed)
- ✅ Error handling and graceful degradation

**All 8 tests passing** ✅

## Documentation

Updated `docs/features/ui-performance-audit.md`:
- Added "How Touch Latency Works" section
- Updated metrics list with touch latency details
- Documented performance overhead (~500-800ms when enabled)
- Added example showing `touchLatencyMs` in results

## Performance Considerations

- **Overhead**: ~500-800ms (3 samples × ~200ms each) when `--ui-perf-mode` is enabled
- **No Impact When Disabled**: Returns `null` immediately if flag not set
- **Safe Touch Location**: Carefully chosen to avoid triggering UI interactions
- **Minimal Device Impact**: Uses existing gfxinfo infrastructure

## Usage

Enable touch latency testing:
```bash
npx @kaeawc/auto-mobile --ui-perf-mode
```

Results included in `observe` response:
```json
{
  "performanceAudit": {
    "metrics": {
      "touchLatencyMs": 28.5,
      ...
    }
  }
}
```

## Benefits

- **Performance Validation**: Measure actual impact of navigation optimizations
- **Regression Detection**: Identify performance regressions in CI
- **Debugging**: Help diagnose slow device responses
- **Benchmarking**: Compare different navigation strategies
- **User Experience**: Validate that optimizations improve real-world latency

## Related Work

- Built on existing PerformanceAudit infrastructure (#36)
- Uses existing `--ui-perf-mode` flag
- Complements back stack awareness (#78, #82)

🤖 Generated with [Claude Code](https://claude.com/claude-code)