### PR TITLE
Android CI Performance Improvements

### DIFF
--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -36,7 +36,7 @@ plugins.withId(libs.plugins.mavenPublish.get().pluginId) {
 
 val gradleWorkerJvmArgs = providers.gradleProperty("org.gradle.testWorker.jvmargs").get()
 
-allprojects {
+subprojects {
   tasks.withType<Test>().configureEach { jvmArgs(gradleWorkerJvmArgs) }
 
   tasks.withType<KotlinCompile>().configureEach {

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -24,7 +24,7 @@
 # - CodeCache normally defaults to a very small size. Increasing it from platform defaults of 32-48m
 #   because of how many classes can be loaded into memory and then cached as native compiled code
 #   for a small speed boost.
-org.gradle.jvmargs=-Xmx4g -XX:MaxMetaspaceSize=2g -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
+org.gradle.jvmargs=-XX:+UseG1GC -XX:SoftRefLRUPolicyMSPerMB=1 -XX:ReservedCodeCacheSize=256m -XX:+HeapDumpOnOutOfMemoryError -Xmx1g -Xms512m -Dfile.encoding=UTF-8
 
 # For more information about how Kotlin Daemon JVM options were chosen:
 # - Kotlin JVM args only inherit Xmx, ReservedCodeCache, and MaxMetaspace. Since we are specifying
@@ -34,7 +34,7 @@ org.gradle.jvmargs=-Xmx4g -XX:MaxMetaspaceSize=2g -XX:+HeapDumpOnOutOfMemoryErro
 kotlin.daemon.jvmargs=-XX:+UseG1GC -XX:SoftRefLRUPolicyMSPerMB=1 -XX:ReservedCodeCacheSize=320m -XX:+HeapDumpOnOutOfMemoryError -Xmx1g -Xms512m
 
 # For more information about how Gradle Worker JVM options were chosen
-org.gradle.testWorker.jvmargs=-Dfile.encoding=UTF-8 -XX:+UseG1GC -XX:SoftRefLRUPolicyMSPerMB=1 -XX:ReservedCodeCacheSize=128m -XX:+HeapDumpOnOutOfMemoryError -Xmx512g -Xms256m
+org.gradle.testWorker.jvmargs=-Dfile.encoding=UTF-8 -XX:+UseG1GC -XX:SoftRefLRUPolicyMSPerMB=1 -XX:ReservedCodeCacheSize=128m -XX:+HeapDumpOnOutOfMemoryError -Xmx512m -Xms256m
 #########################################
 # Non-default Gradle performance settings
 
@@ -78,7 +78,7 @@ org.gradle.configuration-cache.parallel=true
 #   KGP: Unknown
 #   Compose Compiler: Unknown
 # See https://docs.gradle.org/current/userguide/isolated_projects.html
-org.gradle.unsafe.isolated-projects=false
+org.gradle.unsafe.isolated-projects=true
 
 #########################################
 # Android
@@ -122,13 +122,8 @@ android.defaults.buildfeatures.shaders=false
 # Kotlin code style for this project: "official" or "obsolete":
 kotlin.code.style=official
 
-# New Kotlin IC flags, should become defaults in Kotlin 2.0
-kotlin.compiler.suppressExperimentalICOptimizationsWarning=true
-kotlin.compiler.keepIncrementalCompilationCachesInMemory=true
-kotlin.compiler.preciseCompilationResultsBackup=true
-
+# Kotlin incremental compilation
 kotlin.incremental=true
-kotlin.incremental.useClasspathSnapshot=true
 
 # Anvil experimental incremental compilation and build caching
 com.squareup.anvil.trackSourceFiles=true

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Sat Jun 07 04:11:55 CDT 2025
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.2.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
## Summary

Applied battle-tested performance optimizations from [kaeawc/android-build](https://github.com/kaeawc/android-build) reference repository to significantly improve Android build times in CI.

### Key Changes

- **Fixed critical bug**: Test worker memory typo (512g → 512m) that would cause OOM errors
- **Enabled isolated projects**: Parallel configuration with independent caching (AGP 8.13.2+ supported)
- **Upgraded Gradle**: 8.14.2 → 9.2.1 for latest performance improvements
- **Optimized JVM args**: 
  - Added G1GC garbage collector for better memory management
  - Reduced Gradle daemon heap from 4g to 1g (more appropriate sizing)
  - Added ReservedCodeCacheSize=256m for JIT compilation optimization
  - Added SoftRefLRUPolicyMSPerMB=1 for faster soft reference collection
- **Cleaned up deprecated flags**: Removed Kotlin compiler flags incompatible with Kotlin 2.3.0
- **Fixed build compatibility**: Changed `allprojects` → `subprojects` for isolated projects support

### Expected Performance Improvements

✅ Faster configuration phase with parallel project configuration
✅ Better cache reuse with Gradle 9.2.1's improved configuration cache
✅ Reduced memory pressure and GC overhead during builds
✅ Proven fast CI setup aligned with reference repository

### Files Changed

- `android/gradle.properties` - JVM args optimization, isolated projects, deprecated flags removal
- `android/gradle/wrapper/gradle-wrapper.properties` - Gradle version upgrade
- `android/build.gradle.kts` - Isolated projects compatibility fix

### Test Plan

- [x] Build compiles successfully with new settings
- [x] Configuration cache working and reusing entries
- [x] Isolated projects enabled and functional
- [ ] Monitor CI build times after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)