### PR TITLE
Add ESLint rule to prevent .js extensions in TypeScript imports

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -147,6 +147,21 @@ export const baseRules = {
 	"@stylistic/function-call-spacing": 2,
 	"@stylistic/type-annotation-spacing": 2,
 
+	// import rules
+	// Prevent .js/.ts extensions in relative imports (which cause test failures with esbuild-register)
+	// This uses no-restricted-syntax since import/extensions doesn't cleanly support this use case
+	"no-restricted-syntax": [
+		2,
+		{
+			selector: "ImportDeclaration[source.value=/^\\..*\\.js$/]",
+			message: "Do not use .js extension in relative imports. Use extensionless imports instead (e.g., './foo' not './foo.js'). This causes MODULE_NOT_FOUND errors in tests.",
+		},
+		{
+			selector: "ImportDeclaration[source.value=/^\\..*\\.ts$/]",
+			message: "Do not use .ts extension in relative imports. Use extensionless imports instead (e.g., './foo' not './foo.ts').",
+		},
+	],
+
 	// file whitespace
 	"no-multiple-empty-lines": [2, {max: 2, maxEOF: 0}],
 	"no-mixed-spaces-and-tabs": 2,


### PR DESCRIPTION
## Summary

Adds an ESLint rule to prevent `.js` and `.ts` extensions in relative TypeScript imports, which cause `MODULE_NOT_FOUND` errors during test execution with `esbuild-register`.

## Changes

- Added `no-restricted-syntax` rule in `eslint.config.mjs` to catch problematic import patterns
- Rule prevents `.js` and `.ts` extensions in relative imports (e.g., `./foo.js`, `../bar.ts`)
- Allows package imports to use `.js` extensions (e.g., `@modelcontextprotocol/sdk/foo.js`)
- Does not require extensions for standard extensionless imports (TypeScript convention)

## Why `no-restricted-syntax`?

The `import/extensions` rule from `eslint-plugin-import` doesn't cleanly support the use case of "prevent extensions in relative imports while allowing them in package imports without requiring all imports to have extensions."

The `no-restricted-syntax` approach provides:
- Clear, actionable error messages explaining the issue
- Precise targeting of only relative imports with `.js` or `.ts` extensions  
- No interference with package imports that require `.js` extensions

## Example

```typescript
// ❌ ERROR - Caught by linter
import { VisionFallback } from "../../vision/index.js";

// ✅ CORRECT - Standard TypeScript convention
import { VisionFallback } from "../../vision/index";

// ✅ ALLOWED - Package imports can use .js
import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
```

## Test plan

- [x] `bun run lint` passes with no errors
- [x] `bun run build` completes successfully
- [x] `bun run test` passes (647 tests)
- [x] Verified rule catches `.js` extensions in relative imports
- [x] Verified rule allows `.js` extensions in package imports
- [x] Verified rule does not require extensions for extensionless imports

## Related

Fixes #90

🤖 Generated with [Claude Code](https://claude.com/claude-code)