### PR TITLE
Install accessibility service APK in CI emulator runs

### DIFF
--- a/.github/actions/android-emulator/action.yml
+++ b/.github/actions/android-emulator/action.yml
@@ -27,6 +27,10 @@ inputs:
     description: "Working directory"
     default: "./"
     required: "true"
+  accessibility-apk-path:
+    description: "Optional path to accessibility service APK to install before running the script"
+    default: ""
+    required: "false"
 
 runs:
   using: "composite"
@@ -65,7 +69,16 @@ runs:
         api-level: ${{ inputs.api_level }}
         arch: ${{ inputs.arch }}
         target: ${{ inputs.target }}
-        script: ${{ inputs.script }}
+        script: |
+          if [ -n "${{ inputs.accessibility-apk-path }}" ]; then
+            if [ ! -f "${{ inputs.accessibility-apk-path }}" ]; then
+              echo "Accessibility APK not found at ${{ inputs.accessibility-apk-path }}"
+              exit 1
+            fi
+            echo "Installing accessibility service APK from ${{ inputs.accessibility-apk-path }}"
+            adb install -r "${{ inputs.accessibility-apk-path }}"
+          fi
+          ${{ inputs.script }}
         working-directory: ${{ inputs.working-directory }}
         force-avd-creation: false
         emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -92,17 +92,25 @@ jobs:
     name: "Run JUnit Runner Emulator Tests"
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    needs: build-android-accessibility-service
     steps:
       - name: "Git Checkout"
         uses: actions/checkout@v4
 
       - uses: ./.github/actions/setup-auto-mobile-npm-package
 
+      - name: "Download Accessibility Service APK"
+        uses: actions/download-artifact@v4
+        with:
+          name: accessibility-service-apk
+          path: ./apk
+
       # Run AutoMobile tests that require emulator
       - uses: ./.github/actions/android-emulator
         with:
           script: "./gradlew :junit-runner:test"
           working-directory: './android/'
+          accessibility-apk-path: ./apk/accessibility-service-debug.apk
 
       - name: "Upload Test Results"
         if: always()
@@ -176,6 +184,12 @@ jobs:
           gradle-project-directory: "android"
           reuse-configuration-cache: true
           gradle-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
+
+      - name: "Store Accessibility Service APK"
+        uses: actions/upload-artifact@v4.4.0
+        with:
+          name: accessibility-service-apk
+          path: android/accessibility-service/build/outputs/apk/debug/accessibility-service-debug.apk
 
   build-playground-app:
     name: "Build Playground App"

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -146,17 +146,25 @@ jobs:
     name: "Run JUnit Runner Emulator Tests"
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    needs: build-android-accessibility-service
     steps:
       - name: "Git Checkout"
         uses: actions/checkout@v4
 
       - uses: ./.github/actions/setup-auto-mobile-npm-package
 
+      - name: "Download Accessibility Service APK"
+        uses: actions/download-artifact@v4
+        with:
+          name: accessibility-service-apk
+          path: ./apk
+
       # Run AutoMobile tests that require emulator
       - uses: ./.github/actions/android-emulator
         with:
           script: "./gradlew :junit-runner:test"
           working-directory: './android/'
+          accessibility-apk-path: ./apk/accessibility-service-debug.apk
 
       - name: "Upload Test Results"
         if: always()
@@ -230,6 +238,12 @@ jobs:
           gradle-project-directory: "android"
           reuse-configuration-cache: true
           gradle-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
+
+      - name: "Store Accessibility Service APK"
+        uses: actions/upload-artifact@v4.4.0
+        with:
+          name: accessibility-service-apk
+          path: android/accessibility-service/build/outputs/apk/debug/accessibility-service-debug.apk
 
   build-playground-app:
     name: "Build Playground App"
@@ -440,4 +454,3 @@ jobs:
         run: |
           docker compose config --services | grep -q auto-mobile
           docker compose config --services | grep -q auto-mobile-dev
-

--- a/docs/github-issue-avd-snapshot-accessibility-service.md
+++ b/docs/github-issue-avd-snapshot-accessibility-service.md
@@ -1,0 +1,27 @@
+# Speed Up CI by Capturing Accessibility Service Install in AVD Snapshot
+
+## Overview
+We currently install the accessibility service APK on every emulator run. This ensures correctness but adds time to each CI job. Investigate using an AVD snapshot that already has the accessibility service installed, so subsequent runs can restore the snapshot and skip installation.
+
+## Goals
+- Reduce emulator startup/setup time in CI.
+- Keep the accessibility service reliably installed and enabled.
+- Avoid flakiness when restoring snapshots.
+
+## Proposed Approach
+- During the AVD cache creation step, boot emulator, install and enable the accessibility service, then save a named snapshot.
+- On future runs, restore that snapshot before running tests.
+- Provide a fallback path that installs the APK if the snapshot restore fails or is unavailable.
+
+## Considerations
+- Snapshot compatibility across emulator versions and runner images.
+- Ensure the service stays enabled after snapshot restore.
+- Decide where to store snapshot metadata and how to invalidate when APK changes.
+
+## Acceptance Criteria
+- CI jobs restore a snapshot with the service installed (no explicit install step when snapshot is available).
+- Emulator tests still pass in PR and merge workflows.
+- Clear logging indicating whether snapshot restoration or fallback install was used.
+
+## Notes
+This is intentionally separate from the current "install on every run" approach. The snapshot path should be additive and safe to disable if it introduces instability.


### PR DESCRIPTION
## Summary
- install accessibility service APK during emulator runs via composite action input
- download/upload accessibility service APK artifact in PR and merge workflows
- add issue draft for future AVD snapshot optimization

## Testing
- scripts/shellcheck/validate_shell_scripts.sh
- scripts/hadolint/validate_hadolint.sh
- scripts/ktfmt/validate_ktfmt.sh
- scripts/xml/validate_xml.sh
- scripts/lychee/validate_lychee.sh
- scripts/docker/validate_dockerfile.sh
- scripts/act/validate_act.sh (dry run failed: Docker/port bind permissions)