### PR TITLE
Expose latest observation as MCP resources

### DIFF
--- a/docs/features/mcp-server/index.md
+++ b/docs/features/mcp-server/index.md
@@ -1,8 +1,9 @@
 # Features - MCP Server
 
-AutoMobile's MCP makes its various [actions](actions.md) available as tool calls and automatically performs
-[observations](observation.md) within an [interaction loop](interaction-loop.md). This is a simple overview diagram,
-for more detail see the [full MCP server system design](system-design.md).
+AutoMobile's MCP makes its various [actions](actions.md) available as tool calls, exposes device state through
+[resources](resources.md), and automatically performs [observations](observation.md) within an
+[interaction loop](interaction-loop.md). This is a simple overview diagram, for more detail see the
+[full MCP server system design](system-design.md).
 
 ```mermaid
 stateDiagram-v2

--- a/docs/features/mcp-server/resources.md
+++ b/docs/features/mcp-server/resources.md
@@ -1,0 +1,176 @@
+# Features - MCP Server - Resources
+
+AutoMobile exposes MCP resources that provide direct access to the current device state for test authoring and debugging workflows.
+
+## Available Resources
+
+### Latest Observation
+
+**URI:** `automobile://observation/latest`
+
+**Type:** JSON (text)
+
+**Description:** The most recent screen observation including view hierarchy, elements, and metadata. Updated automatically after each `observe()` tool call.
+
+**Contents:**
+- `updatedAt`: Timestamp of the observation
+- `screenSize`: Current screen dimensions (rotation-aware)
+- `systemInsets`: UI insets for all screen edges (status bar, navigation bar, etc.)
+- `rotation`: Current device rotation value (0-3)
+- `activeWindow`: Current app and activity information
+- `viewHierarchy`: Complete UI hierarchy
+- `elements`: Categorized UI elements (clickable, scrollable, text)
+- `focusedElement`: Currently focused UI element (if any)
+- `intentChooserDetected`: Whether a system intent chooser is visible
+- `wakefulness`: Device wake state ("Awake", "Asleep", "Dozing")
+- `userId`: Android user profile ID (0=personal, 10+=work profile)
+- `backStack`: Activity back stack information
+- `performanceAudit`: UI performance metrics (if enabled)
+- `accessibilityAudit`: WCAG accessibility audit results (if enabled)
+
+**Example Usage:**
+
+```typescript
+// Read latest observation
+const response = await client.request({
+  method: "resources/read",
+  params: {
+    uri: "automobile://observation/latest"
+  }
+});
+
+const observation = JSON.parse(response.contents[0].text);
+console.log("Current screen:", observation.activeWindow);
+console.log("Clickable elements:", observation.elements.clickable);
+```
+
+### Latest Screenshot
+
+**URI:** `automobile://observation/latest/screenshot`
+
+**Type:** Image (PNG or WebP as base64 blob)
+
+**Description:** The most recent screen capture. Updated automatically after each `observe()` tool call.
+
+**Example Usage:**
+
+```typescript
+// Read latest screenshot
+const response = await client.request({
+  method: "resources/read",
+  params: {
+    uri: "automobile://observation/latest/screenshot"
+  }
+});
+
+const screenshot = response.contents[0];
+console.log("Screenshot format:", screenshot.mimeType); // "image/png" or "image/webp"
+// screenshot.blob contains base64-encoded image data
+```
+
+## Resource Updates
+
+Resources are automatically updated whenever the `observe()` tool is called. After each observation:
+
+1. The observation data is cached in memory and on disk
+2. The screenshot is saved to the cache directory
+3. Resource update notifications are sent to all connected MCP clients
+
+MCP clients can subscribe to resource updates using the standard MCP notification mechanism:
+
+```json
+{
+  "method": "notifications/resources/updated",
+  "params": {
+    "uri": "automobile://observation/latest"
+  }
+}
+```
+
+## Use Cases
+
+### Test Assertions
+
+Access the current screen state directly in your tests:
+
+```typescript
+// Check current screen state
+const obs = await getObservation();
+assert(obs.activeWindow.appId === "com.example.app");
+assert(obs.elements.clickable.some(el => el.text === "Login"));
+```
+
+### Debugging
+
+Inspect what the device sees without calling observe again:
+
+```typescript
+// Get the latest observation without triggering a new capture
+const currentState = await readResource("automobile://observation/latest");
+console.log("Last observation was at:", currentState.updatedAt);
+console.log("Screen elements:", currentState.viewHierarchy);
+```
+
+### Reactive Testing
+
+Wait for screen state changes:
+
+```typescript
+// Subscribe to observation updates
+client.on("notification", (notification) => {
+  if (notification.method === "notifications/resources/updated") {
+    if (notification.params.uri === "automobile://observation/latest") {
+      // Screen state changed, re-read observation
+      checkForExpectedState();
+    }
+  }
+});
+```
+
+### Visual Regression Testing
+
+Compare screenshots across test runs:
+
+```typescript
+// Get current screenshot
+const screenshot = await readResource("automobile://observation/latest/screenshot");
+const currentImage = Buffer.from(screenshot.blob, "base64");
+
+// Compare with baseline
+const diff = await compareImages(baselineImage, currentImage);
+assert(diff.percentDifferent < 0.01);
+```
+
+## Error Handling
+
+If no observation is available (i.e., `observe()` has not been called yet), the resources return an error message:
+
+```json
+{
+  "error": "No observation available. Call the 'observe' tool first to capture screen state."
+}
+```
+
+For screenshots:
+
+```json
+{
+  "error": "No screenshot available. Call the 'observe' tool first to capture a screenshot."
+}
+```
+
+## Cache Behavior
+
+- **Observation Cache:** Stored in `/tmp/auto-mobile/observe_results/` with a 5-minute TTL
+- **Screenshot Cache:** Stored in `/tmp/auto-mobile/screenshots/` with a 128MB size limit (LRU cleanup)
+
+The caches are shared across all MCP connections to the same AutoMobile server instance.
+
+## Implementation Notes
+
+Resources use the standard MCP resource protocol:
+- `resources/list` - List all available resources
+- `resources/read` - Read resource content by URI
+- `notifications/resources/updated` - Notification when a resource changes
+
+For more details on the MCP resource protocol, see the [Model Context Protocol specification](https://modelcontextprotocol.io/docs/concepts/resources).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -78,6 +78,7 @@ nav:
       - 'MCP Server':
           - 'Overview': features/mcp-server/index.md
           - 'Actions': features/mcp-server/actions.md
+          - 'Resources': features/mcp-server/resources.md
           - 'Observation': features/mcp-server/observation.md
           - 'Interaction Loop': features/mcp-server/interaction-loop.md
       - 'Test Authoring':

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -1,14 +1,16 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import {
   ListToolsRequestSchema,
-  CallToolRequestSchema,
-  ListResourcesRequestSchema
+  CallToolRequestSchema
 } from "@modelcontextprotocol/sdk/types.js";
 import { ActionableError } from "../models";
 import { logger } from "../utils/logger";
 
 // Import the tool registry
 import { ToolRegistry } from "./toolRegistry";
+
+// Import the resource registry
+import { ResourceRegistry } from "./resourceRegistry";
 
 // Import all tool registration functions
 import { registerObserveTools } from "./observeTools";
@@ -21,6 +23,9 @@ import { registerDeepLinkTools } from "./deepLinkTools";
 import { registerEnvironmentTools } from "./environmentTools";
 import { registerDebugTools } from "./debugTools";
 import { registerNavigationTools } from "./navigationTools";
+
+// Import resource registration functions
+import { registerObservationResources } from "./observationResources";
 
 export interface McpServerOptions {
   debug?: boolean;
@@ -39,6 +44,9 @@ export const createMcpServer = (options: McpServerOptions = {}): McpServer => {
   registerDeepLinkTools();
   registerEnvironmentTools();
   registerNavigationTools();
+
+  // Register all resources
+  registerObservationResources();
 
   // Only register debug tools when --debug flag is passed
   if (options.debug) {
@@ -60,6 +68,9 @@ export const createMcpServer = (options: McpServerOptions = {}): McpServer => {
   // Register all tools with the server
   ToolRegistry.registerWithServer(server);
 
+  // Register all resources with the server
+  ResourceRegistry.registerWithServer(server);
+
   // Register tool definitions using the lower-level interface
   server.server.setRequestHandler(ListToolsRequestSchema, async () => {
     return {
@@ -72,22 +83,6 @@ export const createMcpServer = (options: McpServerOptions = {}): McpServer => {
   const PingRequestSchema = require("@modelcontextprotocol/sdk/types.js").PingRequestSchema;
   server.server.setRequestHandler(PingRequestSchema, async () => {
     return {};
-  });
-
-  // Register resources list handler (currently returns empty list since no resources are implemented)
-  server.server.setRequestHandler(ListResourcesRequestSchema, async () => {
-    return {
-      resources: []
-    };
-  });
-
-  // Register resource templates list handler (currently returns empty list since no templates are implemented)
-  // Note: Using runtime access since TypeScript import has issues
-  const ListResourceTemplatesRequestSchema = require("@modelcontextprotocol/sdk/types.js").ListResourceTemplatesRequestSchema;
-  server.server.setRequestHandler(ListResourceTemplatesRequestSchema, async () => {
-    return {
-      resourceTemplates: []
-    };
   });
 
   // Register prompts list handler (currently returns empty list since no prompts are implemented)

--- a/src/server/observationResources.ts
+++ b/src/server/observationResources.ts
@@ -1,0 +1,140 @@
+import { ResourceRegistry, ResourceContent } from "./resourceRegistry";
+import { ObserveScreen } from "../features/observe/ObserveScreen";
+import { logger } from "../utils/logger";
+import * as fs from "fs/promises";
+import * as path from "path";
+
+// Resource URIs
+export const RESOURCE_URIS = {
+  LATEST_OBSERVATION: "automobile://observation/latest",
+  LATEST_SCREENSHOT: "automobile://observation/latest/screenshot"
+} as const;
+
+// Helper to get the latest screenshot path from cache
+async function getLatestScreenshotPath(): Promise<string | undefined> {
+  try {
+    const cacheDir = path.join("/tmp/auto-mobile", "screenshots");
+    const stat = await fs.stat(cacheDir);
+    if (!stat.isDirectory()) {
+      return undefined;
+    }
+
+    const files = await fs.readdir(cacheDir);
+    const imageFiles = files.filter(f => f.endsWith(".png") || f.endsWith(".webp"));
+
+    if (imageFiles.length === 0) {
+      return undefined;
+    }
+
+    // Sort by modification time (most recent first)
+    const fileStats = await Promise.all(
+      imageFiles.map(async f => {
+        const fullPath = path.join(cacheDir, f);
+        const fileStat = await fs.stat(fullPath);
+        return { path: fullPath, mtime: fileStat.mtime };
+      })
+    );
+
+    fileStats.sort((a, b) => b.mtime.getTime() - a.mtime.getTime());
+
+    return fileStats[0]?.path;
+  } catch (error) {
+    logger.warn(`[ObservationResources] Failed to get latest screenshot: ${error}`);
+    return undefined;
+  }
+}
+
+// Handler for latest observation resource (text/json)
+async function getLatestObservation(): Promise<ResourceContent> {
+  try {
+    const cachedResult = ObserveScreen.getRecentCachedResult();
+
+    if (!cachedResult) {
+      return {
+        uri: RESOURCE_URIS.LATEST_OBSERVATION,
+        mimeType: "application/json",
+        text: JSON.stringify({
+          error: "No observation available. Call the 'observe' tool first to capture screen state."
+        }, null, 2)
+      };
+    }
+
+    // Return the observation as JSON
+    return {
+      uri: RESOURCE_URIS.LATEST_OBSERVATION,
+      mimeType: "application/json",
+      text: JSON.stringify(cachedResult, null, 2)
+    };
+  } catch (error) {
+    logger.error(`[ObservationResources] Failed to get latest observation: ${error}`);
+    return {
+      uri: RESOURCE_URIS.LATEST_OBSERVATION,
+      mimeType: "application/json",
+      text: JSON.stringify({
+        error: `Failed to retrieve observation: ${error}`
+      }, null, 2)
+    };
+  }
+}
+
+// Handler for latest screenshot resource (image/png as blob)
+async function getLatestScreenshot(): Promise<ResourceContent> {
+  try {
+    const screenshotPath = await getLatestScreenshotPath();
+
+    if (!screenshotPath) {
+      return {
+        uri: RESOURCE_URIS.LATEST_SCREENSHOT,
+        mimeType: "application/json",
+        text: JSON.stringify({
+          error: "No screenshot available. Call the 'observe' tool first to capture a screenshot."
+        }, null, 2)
+      };
+    }
+
+    // Read the screenshot file and convert to base64
+    const imageBuffer = await fs.readFile(screenshotPath);
+    const base64Image = imageBuffer.toString("base64");
+
+    // Determine mime type from file extension
+    const mimeType = screenshotPath.endsWith(".webp") ? "image/webp" : "image/png";
+
+    return {
+      uri: RESOURCE_URIS.LATEST_SCREENSHOT,
+      mimeType,
+      blob: base64Image
+    };
+  } catch (error) {
+    logger.error(`[ObservationResources] Failed to get latest screenshot: ${error}`);
+    return {
+      uri: RESOURCE_URIS.LATEST_SCREENSHOT,
+      mimeType: "application/json",
+      text: JSON.stringify({
+        error: `Failed to retrieve screenshot: ${error}`
+      }, null, 2)
+    };
+  }
+}
+
+// Register all observation resources
+export function registerObservationResources(): void {
+  // Register latest observation as text/json resource
+  ResourceRegistry.register(
+    RESOURCE_URIS.LATEST_OBSERVATION,
+    "Latest Observation",
+    "The most recent screen observation including view hierarchy, elements, and metadata. Updated automatically after each observe() call.",
+    "application/json",
+    getLatestObservation
+  );
+
+  // Register latest screenshot as image blob resource
+  ResourceRegistry.register(
+    RESOURCE_URIS.LATEST_SCREENSHOT,
+    "Latest Screenshot",
+    "The most recent screen capture as a PNG or WebP image. Updated automatically after each observe() call.",
+    "image/png",
+    getLatestScreenshot
+  );
+
+  logger.info("[ObservationResources] Registered observation resources");
+}

--- a/src/server/observeTools.ts
+++ b/src/server/observeTools.ts
@@ -1,5 +1,7 @@
 import { z } from "zod";
 import { ToolRegistry } from "./toolRegistry";
+import { ResourceRegistry } from "./resourceRegistry";
+import { RESOURCE_URIS } from "./observationResources";
 import { ActionableError } from "../models/ActionableError";
 import { ObserveScreen } from "../features/observe/ObserveScreen";
 import { ListInstalledApps } from "../features/observe/ListInstalledApps";
@@ -34,6 +36,12 @@ export function registerObserveTools() {
           navGraph.recordBackStack(result.backStack);
         }
       }
+
+      // Notify MCP clients that observation resources have been updated
+      await ResourceRegistry.notifyResourcesUpdated([
+        RESOURCE_URIS.LATEST_OBSERVATION,
+        RESOURCE_URIS.LATEST_SCREENSHOT
+      ]);
 
       return createJSONToolResponse(result);
     } catch (error) {

--- a/src/server/resourceRegistry.ts
+++ b/src/server/resourceRegistry.ts
@@ -1,0 +1,130 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { Resource, ReadResourceRequestSchema, ListResourcesRequestSchema, ListResourceTemplatesRequestSchema } from "@modelcontextprotocol/sdk/types.js";
+
+// Interface for resource content handlers
+export interface ResourceHandler {
+  (): Promise<ResourceContent>;
+}
+
+// Resource content can be text or blob
+export interface ResourceContent {
+  uri: string;
+  mimeType?: string;
+  text?: string;
+  blob?: string; // base64 encoded
+}
+
+// Interface for a registered resource
+export interface RegisteredResource {
+  uri: string;
+  name: string;
+  description?: string;
+  mimeType?: string;
+  handler: ResourceHandler;
+}
+
+// The registry that holds all resources
+class ResourceRegistryClass {
+  private resources: Map<string, RegisteredResource> = new Map();
+  private server: McpServer | null = null;
+
+  // Register a new resource
+  register(
+    uri: string,
+    name: string,
+    description: string,
+    mimeType: string,
+    handler: ResourceHandler
+  ): void {
+    this.resources.set(uri, { uri, name, description, mimeType, handler });
+  }
+
+  // Get all registered resources
+  getAllResources(): RegisteredResource[] {
+    return Array.from(this.resources.values());
+  }
+
+  // Get a specific resource by URI
+  getResource(uri: string): RegisteredResource | undefined {
+    return this.resources.get(uri);
+  }
+
+  // Get resources in MCP format for ListResources response
+  getResourceDefinitions(): Resource[] {
+    return Array.from(this.resources.values()).map(resource => ({
+      uri: resource.uri,
+      name: resource.name,
+      description: resource.description,
+      mimeType: resource.mimeType
+    }));
+  }
+
+  // Register all resources with an MCP server
+  registerWithServer(server: McpServer): void {
+    this.server = server;
+
+    // Set handler for listing resources
+    server.server.setRequestHandler(ListResourcesRequestSchema, async () => {
+      return {
+        resources: this.getResourceDefinitions()
+      };
+    });
+
+    // Set handler for reading resource content
+    server.server.setRequestHandler(ReadResourceRequestSchema, async request => {
+      const { uri } = request.params;
+      const resource = this.getResource(uri);
+
+      if (!resource) {
+        throw new Error(`Resource not found: ${uri}`);
+      }
+
+      const content = await resource.handler();
+      return {
+        contents: [content]
+      };
+    });
+
+    // Set handler for listing resource templates (empty for now)
+    server.server.setRequestHandler(ListResourceTemplatesRequestSchema, async () => {
+      return {
+        resourceTemplates: []
+      };
+    });
+  }
+
+  // Send resource update notification
+  async notifyResourceUpdated(uri: string): Promise<void> {
+    if (!this.server) {
+      return;
+    }
+
+    const resource = this.getResource(uri);
+    if (!resource) {
+      return;
+    }
+
+    // Send notification to clients that resource has changed
+    await this.server.server.notification({
+      method: "notifications/resources/updated",
+      params: {
+        uri: resource.uri
+      }
+    });
+  }
+
+  // Send notifications for multiple resources
+  async notifyResourcesUpdated(uris: string[]): Promise<void> {
+    for (const uri of uris) {
+      await this.notifyResourceUpdated(uri);
+    }
+  }
+
+  // Clear all registered resources (for testing)
+  clearResources(): void {
+    this.resources.clear();
+  }
+}
+
+// Export a singleton instance
+export const ResourceRegistry = new ResourceRegistryClass();

--- a/test/server/resources/list.test.ts
+++ b/test/server/resources/list.test.ts
@@ -18,7 +18,7 @@ describe("MCP Resources List", () => {
     }
   });
 
-  test("given no resources are registered, endpoint should return an empty list", async function() {
+  test("should return observation resources", async function() {
 
     const { client } = fixture.getContext();
 
@@ -38,11 +38,23 @@ describe("MCP Resources List", () => {
       params: {}
     }, listResourcesResponseSchema);
 
-    // Verify empty resources list
+    // Verify resources list contains observation resources
     expect(typeof result).toBe("object");
     expect(result).toHaveProperty("resources");
     expect(Array.isArray(result.resources)).toBe(true);
-    expect(result.resources).toHaveLength(0);
+    expect(result.resources.length).toBeGreaterThanOrEqual(2);
+
+    // Verify latest observation resource is present
+    const obsResource = result.resources.find((r: any) => r.uri === "automobile://observation/latest");
+    expect(obsResource).toBeDefined();
+    expect(obsResource?.name).toBe("Latest Observation");
+    expect(obsResource?.mimeType).toBe("application/json");
+
+    // Verify latest screenshot resource is present
+    const screenshotResource = result.resources.find((r: any) => r.uri === "automobile://observation/latest/screenshot");
+    expect(screenshotResource).toBeDefined();
+    expect(screenshotResource?.name).toBe("Latest Screenshot");
+    expect(screenshotResource?.mimeType).toBe("image/png");
   });
 
   test("given a resource is registered, endpoint should return a list with that resource", async function() {

--- a/test/server/resources/read.test.ts
+++ b/test/server/resources/read.test.ts
@@ -1,0 +1,127 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { McpTestFixture } from "../../fixtures/mcpTestFixture";
+
+describe("MCP Resources Read", () => {
+  let fixture: McpTestFixture;
+
+  beforeEach(async () => {
+    fixture = new McpTestFixture();
+    await fixture.setup();
+  });
+
+  afterEach(async () => {
+    if (fixture) {
+      await fixture.teardown();
+    }
+  });
+
+  test("reading latest observation without prior observe should return error message", async function() {
+    const { client } = fixture.getContext();
+
+    // Send resources/read request
+    const { z } = await import("zod");
+    const readResourceResponseSchema = z.object({
+      contents: z.array(z.object({
+        uri: z.string(),
+        mimeType: z.string().optional(),
+        text: z.string().optional(),
+        blob: z.string().optional()
+      }))
+    });
+
+    const result = await client.request({
+      method: "resources/read",
+      params: {
+        uri: "automobile://observation/latest"
+      }
+    }, readResourceResponseSchema);
+
+    // Verify response structure
+    expect(typeof result).toBe("object");
+    expect(result).toHaveProperty("contents");
+    expect(Array.isArray(result.contents)).toBe(true);
+    expect(result.contents).toHaveLength(1);
+
+    // Verify content
+    const content = result.contents[0];
+    expect(content.uri).toBe("automobile://observation/latest");
+    expect(content.mimeType).toBe("application/json");
+    expect(content.text).toBeDefined();
+
+    // Parse and verify error message
+    const data = JSON.parse(content.text!);
+    expect(data).toHaveProperty("error");
+    expect(data.error).toContain("No observation available");
+  });
+
+  test("reading latest screenshot resource", async function() {
+    const { client } = fixture.getContext();
+
+    // Send resources/read request
+    const { z } = await import("zod");
+    const readResourceResponseSchema = z.object({
+      contents: z.array(z.object({
+        uri: z.string(),
+        mimeType: z.string().optional(),
+        text: z.string().optional(),
+        blob: z.string().optional()
+      }))
+    });
+
+    const result = await client.request({
+      method: "resources/read",
+      params: {
+        uri: "automobile://observation/latest/screenshot"
+      }
+    }, readResourceResponseSchema);
+
+    // Verify response structure
+    expect(typeof result).toBe("object");
+    expect(result).toHaveProperty("contents");
+    expect(Array.isArray(result.contents)).toBe(true);
+    expect(result.contents).toHaveLength(1);
+
+    // Verify content
+    const content = result.contents[0];
+    expect(content.uri).toBe("automobile://observation/latest/screenshot");
+
+    // Content can be either an error message (if no screenshot) or actual image data
+    if (content.mimeType === "application/json") {
+      // No screenshot available
+      expect(content.text).toBeDefined();
+      const data = JSON.parse(content.text!);
+      expect(data).toHaveProperty("error");
+      expect(data.error).toContain("No screenshot available");
+    } else {
+      // Screenshot available
+      expect(content.mimeType).toMatch(/^image\/(png|webp)$/);
+      expect(content.blob).toBeDefined();
+      expect(content.blob!.length).toBeGreaterThan(0);
+    }
+  });
+
+  test("reading non-existent resource should throw error", async function() {
+    const { client } = fixture.getContext();
+
+    // Send resources/read request for non-existent resource
+    const { z } = await import("zod");
+    const readResourceResponseSchema = z.object({
+      contents: z.array(z.object({
+        uri: z.string(),
+        mimeType: z.string().optional(),
+        text: z.string().optional(),
+        blob: z.string().optional()
+      }))
+    });
+
+    // Expect this to throw an error
+    await expect(async () => {
+      await client.request({
+        method: "resources/read",
+        params: {
+          uri: "automobile://observation/invalid"
+        }
+      }, readResourceResponseSchema);
+    }).toThrow();
+  });
+});


### PR DESCRIPTION
## Summary\n- add MCP resource registry with latest observation/screenshot resources\n- notify resource updates after observe\n- document resources and add tests\n\n## Testing\n- bun test test/server/resources