### PR TITLE
CI: Add Playground Automobile emulator tests job (#132)

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -126,6 +126,44 @@ jobs:
           check_name: "JUnit Runner Emulator Test Report"
           report_paths: '**/build/test-results/**/*.xml'
 
+  playground-automobile-emulator-tests:
+    name: "Run Playground Automobile Emulator Tests"
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    needs: build-android-accessibility-service
+    steps:
+      - name: "Git Checkout"
+        uses: actions/checkout@v4
+
+      - uses: ./.github/actions/setup-auto-mobile-npm-package
+
+      - name: "Download Accessibility Service APK"
+        uses: actions/download-artifact@v4
+        with:
+          name: accessibility-service-apk
+          path: ./apk
+
+      # Run AutoMobile tests that require emulator
+      - uses: ./.github/actions/android-emulator
+        with:
+          script: "./gradlew :playground:app:test"
+          working-directory: './android/'
+          accessibility-apk-path: ./apk/accessibility-service-debug.apk
+
+      - name: "Upload Test Results"
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playground-automobile-emulator-test-results
+          path: android/playground/app/build/reports/tests/test/
+
+      - name: "Publish Test Report"
+        uses: mikepenz/action-junit-report@v4
+        if: always()
+        with:
+          check_name: "Playground Automobile Emulator Test Report"
+          report_paths: '**/build/test-results/**/*.xml'
+
   android-accessibility-service-unit-tests:
     name: "Run Accessibility Service Unit Tests"
     runs-on: ubuntu-latest

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -180,6 +180,44 @@ jobs:
           check_name: "JUnit Runner Emulator Test Report"
           report_paths: '**/build/test-results/**/*.xml'
 
+  playground-automobile-emulator-tests:
+    name: "Run Playground Automobile Emulator Tests"
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    needs: build-android-accessibility-service
+    steps:
+      - name: "Git Checkout"
+        uses: actions/checkout@v4
+
+      - uses: ./.github/actions/setup-auto-mobile-npm-package
+
+      - name: "Download Accessibility Service APK"
+        uses: actions/download-artifact@v4
+        with:
+          name: accessibility-service-apk
+          path: android/accessibility-service/build/outputs/apk/debug
+
+      # Run AutoMobile tests that require emulator
+      - uses: ./.github/actions/android-emulator
+        with:
+          script: "./gradlew :playground:app:test"
+          working-directory: './android/'
+          accessibility-apk-path: accessibility-service/build/outputs/apk/debug/accessibility-service-debug.apk
+
+      - name: "Upload Test Results"
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playground-automobile-emulator-test-results
+          path: android/playground/app/build/reports/tests/test/
+
+      - name: "Publish Test Report"
+        uses: mikepenz/action-junit-report@v4
+        if: always()
+        with:
+          check_name: "Playground Automobile Emulator Test Report"
+          report_paths: '**/build/test-results/**/*.xml'
+
   android-accessibility-service-unit-tests:
     name: "Run Accessibility Service Unit Tests"
     runs-on: ubuntu-latest

--- a/android/playground/app/src/test/resources/test-plans/test-plan.yaml
+++ b/android/playground/app/src/test/resources/test-plans/test-plan.yaml
@@ -1,0 +1,12 @@
+---
+name: test-plan
+description: Basic test plan for Playground Automobile tests
+steps:
+  - tool: launchApp
+    appId: dev.jasonpearson.automobile.playground
+    clearAppData: true
+    label: Launch Playground app with clean state
+
+  - tool: terminateApp
+    appId: dev.jasonpearson.automobile.playground
+    label: Terminate Playground app


### PR DESCRIPTION
## Summary
- Add new CI job to run Playground Automobile tests on emulator
- Replicates JUnitRunner CI setup for consistency
- Validates Automobile functionality and catches regressions
- Test results and reports integrated into CI pipeline

## Test plan
- [x] Gradle task `:playground:app:test` verified working
- [x] Test plan YAML files created in correct location
- [x] CI jobs added to both pull_request.yml and merge.yml
- [x] Jobs configured to run in parallel with JUnitRunner tests
- [x] Accessibility service dependency properly configured

🤖 Generated with [Claude Code](https://claude.com/claude-code)