### PR TITLE
Fix JUnit runner tests on merge workflow

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -103,14 +103,14 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: accessibility-service-apk
-          path: ./apk
+          path: android/accessibility-service/build/outputs/apk/debug
 
       # Run AutoMobile tests that require emulator
       - uses: ./.github/actions/android-emulator
         with:
           script: "./gradlew :junit-runner:test"
           working-directory: './android/'
-          accessibility-apk-path: ./apk/accessibility-service-debug.apk
+          accessibility-apk-path: accessibility-service/build/outputs/apk/debug/accessibility-service-debug.apk
 
       - name: "Upload Test Results"
         if: always()
@@ -141,14 +141,14 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: accessibility-service-apk
-          path: ./apk
+          path: android/accessibility-service/build/outputs/apk/debug
 
       # Run AutoMobile tests that require emulator
       - uses: ./.github/actions/android-emulator
         with:
           script: "./gradlew :playground:app:test"
           working-directory: './android/'
-          accessibility-apk-path: ./apk/accessibility-service-debug.apk
+          accessibility-apk-path: accessibility-service/build/outputs/apk/debug/accessibility-service-debug.apk
 
       - name: "Upload Test Results"
         if: always()


### PR DESCRIPTION
## Summary
Fix the JUnit runner tests on merge workflow by aligning APK paths with the PR workflow. This resolves path inconsistencies that were causing the junit-runner-emulator-tests and playground-automobile-emulator-tests jobs to fail.

## Changes
- Updated `junit-runner-emulator-tests` job to use correct APK paths
- Updated `playground-automobile-emulator-tests` job to use correct APK paths
- APK download path: `./apk` → `android/accessibility-service/build/outputs/apk/debug`
- APK reference path: `./apk/accessibility-service-debug.apk` → `accessibility-service/build/outputs/apk/debug/accessibility-service-debug.apk`

## Test plan
- [ ] Verify merge workflow runs successfully with these path changes
- [ ] Confirm junit-runner-emulator-tests passes
- [ ] Confirm playground-automobile-emulator-tests passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)