### PR TITLE
Revamp hot reload development workflow (#164)

### DIFF
--- a/docs/contributing/local-development.md
+++ b/docs/contributing/local-development.md
@@ -24,18 +24,53 @@ automatically restarts, allowing rapid iteration without manual restarts.
 # Start with hot reloading (bun --watch), streamable is the default
 bun run dev
 
-# Custom port
+# Custom port (overrides auto-detection)
 bun run dev:port 8080
 ```
 
-The server runs at `http://localhost:9000/auto-mobile/streamable` by default.
+### Automatic Port Detection (Worktree Isolation)
+
+The dev server automatically detects the port from your git branch name, enabling multiple worktrees to run
+simultaneously without port conflicts:
+
+| Branch | Port |
+|--------|------|
+| `work/164-feature-name` | 9164 |
+| `work/120-other-feature` | 9120 |
+| `main` (no issue number) | 9000 |
+
+**How it works:**
+- Extracts the first number (1-999) from the branch name
+- Adds it to base port 9000 (e.g., issue #164 → port 9164)
+- Falls back to 9000 if no number is found
+
+**Override options:**
+```shell
+# Environment variable (highest priority)
+AUTO_MOBILE_PORT=8080 bun run dev
+
+# Command line flag
+bun run dev:port 8080
+```
+
+This allows you to run multiple worktrees simultaneously:
+```shell
+# Terminal 1 (work/164-feature)
+cd ~/worktrees/auto-mobile/work-164-feature
+bun run dev  # → port 9164
+
+# Terminal 2 (work/120-other)
+cd ~/worktrees/auto-mobile/work-120-other
+bun run dev  # → port 9120
+```
 
 ### Health Check Endpoint
 
 Monitor server status and detect restarts using the health endpoint:
 
 ```shell
-curl http://localhost:9000/health
+# Use the port for your worktree (e.g., 9164 for issue #164)
+curl http://localhost:9164/health
 ```
 
 Response:
@@ -45,6 +80,8 @@ Response:
   "server": "AutoMobile",
   "version": "0.0.6",
   "instanceId": "unique-server-instance-id",
+  "port": 9164,
+  "branch": "work/164-feature-name",
   "uptime": {
     "ms": 12345,
     "human": "12s"
@@ -54,7 +91,9 @@ Response:
 }
 ```
 
-The `instanceId` changes each time the server restarts, which can be used to detect when reconnection is needed.
+- `instanceId` changes each time the server restarts (detect reconnection needs)
+- `port` shows the auto-detected or configured port
+- `branch` shows the current git branch
 
 ## MCP Client Configuration
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,44 @@ import { setDebugModeEnabled } from "./utils/debug";
 import { serverConfig } from "./utils/ServerConfig";
 import { runDaemonCommand } from "./daemon/manager";
 import { startDaemon } from "./daemon/daemon";
+import { execSync } from "node:child_process";
+
+// Detect port from git branch name for worktree isolation
+// e.g., work/164-feature-name -> port 9164
+function detectPortFromBranch(): number {
+  const basePort = 9000;
+
+  // Check environment variable first (explicit override)
+  const envPort = process.env.AUTO_MOBILE_PORT;
+  if (envPort) {
+    const port = parseInt(envPort, 10);
+    if (!isNaN(port) && port > 0 && port < 65536) {
+      return port;
+    }
+  }
+
+  try {
+    const branch = execSync("git rev-parse --abbrev-ref HEAD", {
+      encoding: "utf-8",
+      stdio: ["pipe", "pipe", "pipe"]
+    }).trim();
+
+    // Extract issue number from branch name patterns:
+    // work/164-feature-name, feature/164-name, fix/164, issue-164, etc.
+    const match = branch.match(/\b(\d{1,4})\b/);
+    if (match) {
+      const issueNumber = parseInt(match[1], 10);
+      // Keep port in valid range (9001-9999 for issue numbers 1-999)
+      if (issueNumber > 0 && issueNumber < 1000) {
+        return basePort + issueNumber;
+      }
+    }
+  } catch {
+    // Not in a git repo or git not available, use default
+  }
+
+  return basePort;
+}
 
 // Interface for transport configuration
 interface TransportConfig {
@@ -42,9 +80,10 @@ function parseArgs(): {
   const args = process.argv.slice(2);
 
   // Default transport configuration
+  // Port is auto-detected from git branch for worktree isolation
   const transport: TransportConfig = {
     type: "stdio",
-    port: 9000,
+    port: detectPortFromBranch(),
     host: "localhost"
   };
 
@@ -194,11 +233,22 @@ async function startStreamableServer(transport: TransportConfig, debug: boolean)
     // Health check endpoint for connection status and restart detection
     if (url.pathname === "/health" || url.pathname === "/auto-mobile/health") {
       const uptimeMs = Date.now() - serverStartTime;
+      let branch: string | undefined;
+      try {
+        branch = execSync("git rev-parse --abbrev-ref HEAD", {
+          encoding: "utf-8",
+          stdio: ["pipe", "pipe", "pipe"]
+        }).trim();
+      } catch {
+        // Not in git repo
+      }
       const health = {
         status: "ok",
         server: "AutoMobile",
         version: "0.0.6",
         instanceId: serverInstanceId,
+        port: transport.port,
+        branch,
         uptime: {
           ms: uptimeMs,
           human: formatUptime(uptimeMs)


### PR DESCRIPTION
## Summary

- Add `/health` endpoint for server status monitoring and restart detection
- Improve "Session not found" error with helpful guidance for reconnection
- Document native HTTP configuration for Claude Code (skip mcp-remote)
- Add comprehensive troubleshooting guide for common development issues

## Changes

### Health Check Endpoint
New endpoint at `/health` and `/auto-mobile/health` returns:
- Server status and version
- Unique `instanceId` (changes on restart for detection)
- Uptime in milliseconds and human-readable format
- Active session count
- Transport type

### Improved Error Messages
"Session not found" errors now include:
- Clear explanation that session may have expired or server restarted
- Hint to restart MCP client when using mcp-remote
- Server instance ID and active session count for debugging

### Documentation Updates
- Native HTTP configuration for Claude Code (preferred over mcp-remote)
- Troubleshooting sections for common issues:
  - Server restarts and session loss
  - Port already in use
  - Connection refused
  - mcp-remote issues
- Development tips for connection verification

## Investigation Notes

Tested `bun --hot` vs `bun --watch`:
- `bun --hot` does not preserve HTTP sessions because `main()` re-executes on module change
- Sessions are lost regardless of which mode is used
- Focus shifted to making reconnection seamless rather than preventing session loss

## Test plan

- [ ] Start dev server with `bun run dev`
- [ ] Verify health endpoint: `curl http://localhost:9000/health`
- [ ] Initialize MCP session and verify tools work
- [ ] Make a code change and observe server restart
- [ ] Verify helpful error message when using stale session
- [ ] Verify health endpoint shows new instanceId after restart

Fixes #164

🤖 Generated with [Claude Code](https://claude.com/claude-code)