### PR TITLE
Fix insecure temporary file creation in daemon manager

### DIFF
--- a/src/daemon/manager.ts
+++ b/src/daemon/manager.ts
@@ -1,6 +1,6 @@
 import { spawn } from "node:child_process";
 import { readFile, unlink } from "node:fs/promises";
-import { existsSync, openSync, closeSync } from "node:fs";
+import { existsSync, openSync, closeSync, mkdtempSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { logger } from "../utils/logger";
@@ -80,9 +80,11 @@ export class DaemonManager {
       args.push("--debug-perf");
     }
 
-    // Create log file for daemon output
-    const logPath = join(tmpdir(), `auto-mobile-daemon-${process.getuid()}.log`);
-    const logFd = openSync(logPath, "w");
+    // Create secure temp directory with random suffix to prevent symlink attacks
+    const tempDir = mkdtempSync(join(tmpdir(), "auto-mobile-daemon-"));
+    const logPath = join(tempDir, "daemon.log");
+    // Open with restricted permissions (0o600 = owner read/write only)
+    const logFd = openSync(logPath, "w", 0o600);
 
     const daemonProcess = spawn(bunExe, [scriptPath, ...args], {
       detached: true,


### PR DESCRIPTION
## Summary

- Use `mkdtempSync()` to create a unique temp directory with random suffix, preventing symlink attacks and race conditions (CWE-377)
- Set file permissions to `0o600` (owner read/write only) to prevent information disclosure

## Security Issue Addressed

The daemon log file was being created insecurely in `/tmp` with:
- Predictable filename pattern (`auto-mobile-daemon-${uid}.log`)
- No explicit file permissions
- Vulnerable to symlink attacks and TOCTOU issues

## Test plan

- [x] Build passes
- [x] All 805 tests pass
- [x] Lint passes
- [x] Hadolint validation passes
- [x] Act (GitHub Actions) dry run passes

Fixes #157

🤖 Generated with [Claude Code](https://claude.com/claude-code)