### PR TITLE
Implement doctor diagnostic tool for onboarding and troubleshooting

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -11,6 +11,7 @@ import { registerAppTools } from "../server/appTools";
 import { registerUtilityTools } from "../server/utilityTools";
 import { registerDeviceTools } from "../server/deviceTools";
 import { registerPlanTools } from "../server/planTools";
+import { registerDoctorTools } from "../server/doctorTools";
 
 // Initialize tool registry for CLI mode
 export function initializeCliTools(): void {
@@ -22,6 +23,7 @@ export function initializeCliTools(): void {
   registerUtilityTools();
   registerDeviceTools();
   registerPlanTools();
+  registerDoctorTools();
 }
 
 // Parse CLI arguments into tool name, session UUID, and parameters
@@ -45,29 +47,35 @@ function parseCliArgs(args: string[]): { toolName: string; sessionUuid?: string;
   const toolName = args[toolNameIndex];
   const params: Record<string, any> = {};
 
-  // Parse remaining arguments as key-value pairs
-  for (let i = toolNameIndex + 1; i < args.length; i += 2) {
+  // Parse remaining arguments as key-value pairs or boolean flags
+  for (let i = toolNameIndex + 1; i < args.length; i++) {
     const key = args[i];
-    const value = args[i + 1];
 
     if (!key.startsWith("--")) {
       throw new ActionableError(`Invalid parameter format: ${key}. Parameters must start with --`);
-    }
-
-    if (value === undefined) {
-      throw new ActionableError(`Missing value for parameter: ${key}`);
     }
 
     // Remove '--' prefix and convert kebab-case to camelCase
     // e.g., --session-uuid -> sessionUuid
     const paramName = key.slice(2).replace(/-([a-z])/g, (_, letter) => letter.toUpperCase());
 
-    // Try to parse as JSON, fallback to string
-    try {
-      params[paramName] = JSON.parse(value);
-    } catch {
-      // If not valid JSON, treat as string
-      params[paramName] = value;
+    const nextArg = args[i + 1];
+
+    // Check if this is a boolean flag (no value or next arg is also a flag)
+    if (nextArg === undefined || nextArg.startsWith("--")) {
+      // Boolean flag without value - treat as true
+      params[paramName] = true;
+    } else {
+      // Key-value pair
+      i++; // Skip the value in the next iteration
+
+      // Try to parse as JSON, fallback to string
+      try {
+        params[paramName] = JSON.parse(nextArg);
+      } catch {
+        // If not valid JSON, treat as string
+        params[paramName] = nextArg;
+      }
     }
   }
 
@@ -141,6 +149,72 @@ async function runToolViaDaemon(
   }
 }
 
+/**
+ * Run the doctor command with daemon fallback to direct execution
+ */
+async function runDoctorCommand(params: Record<string, any>): Promise<void> {
+  const jsonOutput = params.json === true;
+
+  // Try daemon first
+  try {
+    logger.debug("Attempting to run doctor via daemon");
+    const daemonResult = await runToolViaDaemon("doctor", params);
+    handleDoctorResult(daemonResult, jsonOutput);
+    return;
+  } catch (error) {
+    logger.debug(`Daemon not available for doctor, falling back to direct execution: ${error}`);
+  }
+
+  // Fallback to direct execution
+  const { runDoctor, formatConsoleOutput, formatJsonOutput } = await import("../doctor");
+  const report = await runDoctor({
+    android: params.android,
+    ios: params.ios,
+  });
+
+  if (jsonOutput) {
+    console.log(formatJsonOutput(report));
+  } else {
+    console.log(formatConsoleOutput(report, process.stdout.isTTY ?? true));
+  }
+
+  // Exit with error code if any failures
+  if (report.summary.failed > 0) {
+    process.exit(1);
+  }
+}
+
+/**
+ * Handle doctor command result from daemon
+ */
+function handleDoctorResult(result: any, jsonOutput: boolean): void {
+  // Extract the report from MCP response format
+  let report = result;
+  if (result && typeof result === "object" && "content" in result && Array.isArray(result.content)) {
+    if (result.content.length > 0 && result.content[0].type === "text") {
+      try {
+        report = JSON.parse(result.content[0].text);
+      } catch {
+        // Keep original result
+      }
+    }
+  }
+
+  if (jsonOutput) {
+    console.log(JSON.stringify(report, null, 2));
+  } else {
+    // Use the formatter for console output
+    import("../doctor").then(({ formatConsoleOutput }) => {
+      console.log(formatConsoleOutput(report, process.stdout.isTTY ?? true));
+    });
+  }
+
+  // Exit with error code if any failures
+  if (report && report.summary && report.summary.failed > 0) {
+    process.exit(1);
+  }
+}
+
 function handleToolResult(result: any, toolName: string): void {
   console.log(JSON.stringify(result, null, 2));
 
@@ -206,6 +280,12 @@ export async function runCliCommand(args: string[]): Promise<void> {
     if (sessionUuid) {
       params.sessionUuid = sessionUuid;
       logger.debug(`Using session UUID: ${sessionUuid}`);
+    }
+
+    // Special handling for doctor command - try daemon first, fallback to direct
+    if (toolName === "doctor") {
+      await runDoctorCommand(params);
+      return;
     }
 
     // All tool execution goes through daemon (mandatory)

--- a/src/doctor/checks/android.ts
+++ b/src/doctor/checks/android.ts
@@ -1,0 +1,248 @@
+/**
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { existsSync } from "node:fs";
+import { CheckResult } from "../types";
+import { getAndroidSdkFromEnvironment } from "../../utils/android-cmdline-tools/detection";
+import { AdbClient } from "../../utils/android-cmdline-tools/AdbClient";
+import { AndroidEmulatorClient } from "../../utils/android-cmdline-tools/AndroidEmulatorClient";
+import { logger } from "../../utils/logger";
+
+/**
+ * Check ANDROID_HOME environment variable
+ */
+export async function checkAndroidHome(): Promise<CheckResult> {
+  const androidHome = getAndroidSdkFromEnvironment();
+
+  if (androidHome) {
+    return {
+      name: "ANDROID_HOME",
+      status: "pass",
+      message: `Android SDK found`,
+      value: androidHome,
+    };
+  }
+
+  return {
+    name: "ANDROID_HOME",
+    status: "fail",
+    message: "ANDROID_HOME or ANDROID_SDK_ROOT not set or path does not exist",
+    recommendation: "Set ANDROID_HOME to your Android SDK installation path. " +
+      "Example: export ANDROID_HOME=$HOME/Library/Android/sdk",
+  };
+}
+
+/**
+ * Check JAVA_HOME environment variable
+ */
+export async function checkJavaHome(): Promise<CheckResult> {
+  const javaHome = process.env.JAVA_HOME;
+
+  if (!javaHome) {
+    return {
+      name: "JAVA_HOME",
+      status: "warn",
+      message: "JAVA_HOME environment variable not set",
+      recommendation: "Set JAVA_HOME to your Java installation. " +
+        "Example: export JAVA_HOME=$(/usr/libexec/java_home)",
+    };
+  }
+
+  if (!existsSync(javaHome)) {
+    return {
+      name: "JAVA_HOME",
+      status: "warn",
+      message: `JAVA_HOME is set but path does not exist: ${javaHome}`,
+      recommendation: "Update JAVA_HOME to a valid Java installation path",
+    };
+  }
+
+  return {
+    name: "JAVA_HOME",
+    status: "pass",
+    message: "Java home directory found",
+    value: javaHome,
+  };
+}
+
+/**
+ * Check ADB installation and get path
+ */
+export async function checkAdbInstallation(): Promise<CheckResult> {
+  try {
+    const adb = new AdbClient();
+    const baseCommand = await adb.getBaseCommand();
+
+    // Extract just the ADB path (remove any device flags)
+    const adbPath = baseCommand.split(" ")[0];
+
+    return {
+      name: "ADB Installation",
+      status: "pass",
+      message: "ADB is available",
+      value: adbPath,
+    };
+  } catch (error) {
+    return {
+      name: "ADB Installation",
+      status: "fail",
+      message: `ADB not found: ${error instanceof Error ? error.message : String(error)}`,
+      recommendation: "Install Android SDK Platform-Tools. " +
+        "Via Homebrew: brew install android-platform-tools",
+    };
+  }
+}
+
+/**
+ * Check ADB version
+ */
+export async function checkAdbVersion(): Promise<CheckResult> {
+  try {
+    const adb = new AdbClient();
+    const result = await adb.executeCommand("--version", undefined, undefined, true);
+
+    // Parse version from output like "Android Debug Bridge version 35.0.0"
+    const versionMatch = result.stdout.match(/Android Debug Bridge version (\d+\.\d+\.\d+)/);
+    const version = versionMatch ? versionMatch[1] : "unknown";
+
+    return {
+      name: "ADB Version",
+      status: "pass",
+      message: `Version ${version}`,
+      value: version,
+    };
+  } catch (error) {
+    return {
+      name: "ADB Version",
+      status: "warn",
+      message: `Could not determine ADB version: ${error instanceof Error ? error.message : String(error)}`,
+    };
+  }
+}
+
+/**
+ * Check Android emulator availability
+ */
+export async function checkEmulator(): Promise<CheckResult> {
+  try {
+    const emulator = new AndroidEmulatorClient();
+    // Try to list AVDs - this will fail if emulator is not available
+    await emulator.listAvds();
+
+    return {
+      name: "Android Emulator",
+      status: "pass",
+      message: "Emulator is available",
+    };
+  } catch (error) {
+    const errorMsg = error instanceof Error ? error.message : String(error);
+
+    // Check if it's a "not found" error
+    if (errorMsg.includes("not found") || errorMsg.includes("ENOENT")) {
+      return {
+        name: "Android Emulator",
+        status: "warn",
+        message: "Emulator not found",
+        recommendation: "Install Android Emulator via SDK Manager or Homebrew: " +
+          "brew install android-emulator",
+      };
+    }
+
+    return {
+      name: "Android Emulator",
+      status: "warn",
+      message: `Emulator check failed: ${errorMsg}`,
+    };
+  }
+}
+
+/**
+ * Check connected Android devices
+ */
+export async function checkConnectedDevices(): Promise<CheckResult> {
+  try {
+    const adb = new AdbClient();
+    const devices = await adb.getBootedAndroidDevices();
+
+    if (devices.length === 0) {
+      return {
+        name: "Connected Devices",
+        status: "warn",
+        message: "No Android devices connected",
+        value: 0,
+        recommendation: "Connect a device via USB or start an emulator",
+      };
+    }
+
+    const deviceNames = devices.map(d => d.deviceId).join(", ");
+    return {
+      name: "Connected Devices",
+      status: "pass",
+      message: `${devices.length} device(s) connected: ${deviceNames}`,
+      value: devices.length,
+    };
+  } catch (error) {
+    return {
+      name: "Connected Devices",
+      status: "warn",
+      message: `Could not list devices: ${error instanceof Error ? error.message : String(error)}`,
+      value: 0,
+    };
+  }
+}
+
+/**
+ * Check available AVDs
+ */
+export async function checkAvailableAvds(): Promise<CheckResult> {
+  try {
+    const emulator = new AndroidEmulatorClient();
+    const avds = await emulator.listAvds();
+
+    if (avds.length === 0) {
+      return {
+        name: "Available AVDs",
+        status: "warn",
+        message: "No AVDs found",
+        value: 0,
+        recommendation: "Create an AVD using Android Studio or avdmanager",
+      };
+    }
+
+    const avdNames = avds.map(a => a.name).join(", ");
+    return {
+      name: "Available AVDs",
+      status: "pass",
+      message: `${avds.length} AVD(s) available: ${avdNames}`,
+      value: avds.length,
+    };
+  } catch (error) {
+    logger.debug(`Failed to list AVDs: ${error}`);
+    return {
+      name: "Available AVDs",
+      status: "skip",
+      message: "Could not list AVDs (emulator may not be installed)",
+      value: 0,
+    };
+  }
+}
+
+/**
+ * Run all Android checks
+ */
+export async function runAndroidChecks(): Promise<CheckResult[]> {
+  const results: CheckResult[] = [];
+
+  // Run checks sequentially to avoid overwhelming the system
+  results.push(await checkAndroidHome());
+  results.push(await checkJavaHome());
+  results.push(await checkAdbInstallation());
+  results.push(await checkAdbVersion());
+  results.push(await checkEmulator());
+  results.push(await checkConnectedDevices());
+  results.push(await checkAvailableAvds());
+
+  return results;
+}

--- a/src/doctor/checks/automobile.ts
+++ b/src/doctor/checks/automobile.ts
@@ -1,0 +1,165 @@
+/**
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { CheckResult } from "../types";
+import { DaemonManager } from "../../daemon/manager";
+import { getDaemonHealthReport } from "../../daemon/debugTools";
+import { RELEASE_VERSION } from "../../constants/release";
+import { AdbClient } from "../../utils/android-cmdline-tools/AdbClient";
+import { AndroidAccessibilityServiceManager } from "../../utils/AccessibilityServiceManager";
+import { logger } from "../../utils/logger";
+
+/**
+ * Check AutoMobile version
+ */
+export function checkVersion(): CheckResult {
+  return {
+    name: "AutoMobile Version",
+    status: "pass",
+    message: `Version ${RELEASE_VERSION}`,
+    value: RELEASE_VERSION,
+  };
+}
+
+/**
+ * Check daemon status
+ */
+export async function checkDaemonStatus(): Promise<CheckResult> {
+  try {
+    const manager = new DaemonManager();
+    const status = await manager.status();
+
+    if (status.running) {
+      return {
+        name: "Daemon Status",
+        status: "pass",
+        message: `Running (PID ${status.pid})`,
+        value: status.pid,
+      };
+    }
+
+    return {
+      name: "Daemon Status",
+      status: "warn",
+      message: "Daemon is not running",
+      recommendation: "Start the daemon with: auto-mobile --daemon start",
+    };
+  } catch (error) {
+    return {
+      name: "Daemon Status",
+      status: "warn",
+      message: `Could not check daemon: ${error instanceof Error ? error.message : String(error)}`,
+      recommendation: "Try: auto-mobile --daemon start",
+    };
+  }
+}
+
+/**
+ * Check daemon connectivity
+ */
+export async function checkDaemonConnectivity(): Promise<CheckResult> {
+  try {
+    const report = await getDaemonHealthReport();
+
+    if (report.socketConnectable) {
+      return {
+        name: "Daemon Connectivity",
+        status: "pass",
+        message: "Daemon is responsive",
+      };
+    }
+
+    if (!report.daemonRunning) {
+      return {
+        name: "Daemon Connectivity",
+        status: "skip",
+        message: "Daemon is not running",
+      };
+    }
+
+    return {
+      name: "Daemon Connectivity",
+      status: "warn",
+      message: "Daemon running but not responding",
+      recommendation: report.recommendations.join("; ") || "Try: auto-mobile --daemon restart",
+    };
+  } catch (error) {
+    return {
+      name: "Daemon Connectivity",
+      status: "warn",
+      message: `Connectivity check failed: ${error instanceof Error ? error.message : String(error)}`,
+    };
+  }
+}
+
+/**
+ * Check accessibility service status on connected devices
+ */
+export async function checkAccessibilityService(): Promise<CheckResult> {
+  try {
+    const adb = new AdbClient();
+    const devices = await adb.getBootedAndroidDevices();
+
+    if (devices.length === 0) {
+      return {
+        name: "Accessibility Service",
+        status: "skip",
+        message: "No Android devices connected",
+      };
+    }
+
+    // Check first connected device
+    const device = devices[0];
+    const serviceManager = new AndroidAccessibilityServiceManager(device);
+
+    const isInstalled = await serviceManager.isInstalled();
+    const isEnabled = await serviceManager.isEnabled();
+
+    if (isInstalled && isEnabled) {
+      return {
+        name: "Accessibility Service",
+        status: "pass",
+        message: `Installed and enabled on ${device.deviceId}`,
+      };
+    }
+
+    if (isInstalled && !isEnabled) {
+      return {
+        name: "Accessibility Service",
+        status: "warn",
+        message: `Installed but not enabled on ${device.deviceId}`,
+        recommendation: "Enable the accessibility service in device settings",
+      };
+    }
+
+    return {
+      name: "Accessibility Service",
+      status: "warn",
+      message: `Not installed on ${device.deviceId}`,
+      recommendation: "The accessibility service will be installed automatically when needed",
+    };
+  } catch (error) {
+    logger.debug(`Accessibility service check failed: ${error}`);
+    return {
+      name: "Accessibility Service",
+      status: "skip",
+      message: `Could not check: ${error instanceof Error ? error.message : String(error)}`,
+    };
+  }
+}
+
+/**
+ * Run all AutoMobile checks
+ */
+export async function runAutoMobileChecks(): Promise<CheckResult[]> {
+  const results: CheckResult[] = [];
+
+  results.push(checkVersion());
+  results.push(await checkDaemonStatus());
+  results.push(await checkDaemonConnectivity());
+  results.push(await checkAccessibilityService());
+
+  return results;
+}

--- a/src/doctor/checks/ios.ts
+++ b/src/doctor/checks/ios.ts
@@ -1,0 +1,113 @@
+/**
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { CheckResult } from "../types";
+import { SimCtlClient } from "../../utils/ios-cmdline-tools/SimCtlClient";
+
+/**
+ * Check if simctl is available (requires Xcode)
+ */
+export async function checkSimctlAvailable(): Promise<CheckResult> {
+  // Only run on macOS
+  if (process.platform !== "darwin") {
+    return {
+      name: "simctl",
+      status: "skip",
+      message: "iOS development requires macOS",
+    };
+  }
+
+  try {
+    const simctl = new SimCtlClient();
+    const available = await simctl.isAvailable();
+
+    if (available) {
+      return {
+        name: "simctl",
+        status: "pass",
+        message: "Xcode command line tools available",
+      };
+    }
+
+    return {
+      name: "simctl",
+      status: "fail",
+      message: "simctl not available",
+      recommendation: "Install Xcode command line tools: xcode-select --install",
+    };
+  } catch (error) {
+    return {
+      name: "simctl",
+      status: "fail",
+      message: `simctl check failed: ${error instanceof Error ? error.message : String(error)}`,
+      recommendation: "Install Xcode command line tools: xcode-select --install",
+    };
+  }
+}
+
+/**
+ * Check booted iOS simulators
+ */
+export async function checkBootedSimulators(): Promise<CheckResult> {
+  // Only run on macOS
+  if (process.platform !== "darwin") {
+    return {
+      name: "Booted Simulators",
+      status: "skip",
+      message: "iOS simulators only available on macOS",
+    };
+  }
+
+  try {
+    const simctl = new SimCtlClient();
+
+    // First check if simctl is available
+    if (!(await simctl.isAvailable())) {
+      return {
+        name: "Booted Simulators",
+        status: "skip",
+        message: "simctl not available",
+      };
+    }
+
+    const simulators = await simctl.getBootedSimulators();
+
+    if (simulators.length === 0) {
+      return {
+        name: "Booted Simulators",
+        status: "pass",
+        message: "No simulators currently running",
+        value: 0,
+      };
+    }
+
+    const simNames = simulators.map(s => s.name).join(", ");
+    return {
+      name: "Booted Simulators",
+      status: "pass",
+      message: `${simulators.length} simulator(s) running: ${simNames}`,
+      value: simulators.length,
+    };
+  } catch (error) {
+    return {
+      name: "Booted Simulators",
+      status: "skip",
+      message: `Could not check simulators: ${error instanceof Error ? error.message : String(error)}`,
+      value: 0,
+    };
+  }
+}
+
+/**
+ * Run all iOS checks (minimal)
+ */
+export async function runIosChecks(): Promise<CheckResult[]> {
+  const results: CheckResult[] = [];
+
+  results.push(await checkSimctlAvailable());
+  results.push(await checkBootedSimulators());
+
+  return results;
+}

--- a/src/doctor/checks/system.ts
+++ b/src/doctor/checks/system.ts
@@ -1,0 +1,73 @@
+/**
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { release } from "node:os";
+import { CheckResult } from "../types";
+
+/**
+ * Check operating system information
+ */
+export function checkOperatingSystem(): CheckResult {
+  const platform = process.platform;
+  const osRelease = release();
+
+  return {
+    name: "Operating System",
+    status: "pass",
+    message: `${platform} (${osRelease})`,
+    value: platform,
+  };
+}
+
+/**
+ * Check system architecture
+ */
+export function checkArchitecture(): CheckResult {
+  const arch = process.arch;
+
+  return {
+    name: "Architecture",
+    status: "pass",
+    message: arch,
+    value: arch,
+  };
+}
+
+/**
+ * Check runtime environment (Node.js or Bun)
+ */
+export function checkRuntime(): CheckResult {
+  // Check if running in Bun
+  const bunVersion = (globalThis as any).Bun?.version;
+
+  if (bunVersion) {
+    return {
+      name: "Runtime",
+      status: "pass",
+      message: `Bun ${bunVersion}`,
+      value: `bun@${bunVersion}`,
+    };
+  }
+
+  // Fallback to Node.js
+  const nodeVersion = process.version;
+  return {
+    name: "Runtime",
+    status: "pass",
+    message: `Node.js ${nodeVersion}`,
+    value: `node@${nodeVersion}`,
+  };
+}
+
+/**
+ * Run all system checks
+ */
+export function runSystemChecks(): CheckResult[] {
+  return [
+    checkOperatingSystem(),
+    checkArchitecture(),
+    checkRuntime(),
+  ];
+}

--- a/src/doctor/formatter.ts
+++ b/src/doctor/formatter.ts
@@ -1,0 +1,144 @@
+/**
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { DoctorReport, CheckResult, CheckStatus } from "./types";
+
+const STATUS_ICONS: Record<CheckStatus, string> = {
+  pass: "[PASS]",
+  warn: "[WARN]",
+  fail: "[FAIL]",
+  skip: "[SKIP]",
+};
+
+const STATUS_COLORS: Record<CheckStatus, string> = {
+  pass: "\x1b[32m",  // green
+  warn: "\x1b[33m",  // yellow
+  fail: "\x1b[31m",  // red
+  skip: "\x1b[90m",  // gray
+};
+
+const RESET = "\x1b[0m";
+
+/**
+ * Format a single check result line
+ */
+function formatCheckLine(check: CheckResult, useColors: boolean): string {
+  const icon = STATUS_ICONS[check.status];
+  const color = useColors ? STATUS_COLORS[check.status] : "";
+  const reset = useColors ? RESET : "";
+
+  let line = `${color}${icon}${reset} ${check.name}`;
+
+  if (check.value !== undefined && check.value !== null) {
+    line += `: ${check.value}`;
+  } else if (check.message) {
+    line += `: ${check.message}`;
+  }
+
+  return line;
+}
+
+/**
+ * Format the doctor report for console output
+ */
+export function formatConsoleOutput(report: DoctorReport, useColors: boolean = true): string {
+  const lines: string[] = [];
+
+  // Header
+  lines.push("");
+  lines.push("AutoMobile Doctor");
+  lines.push("=================");
+  lines.push(`Version: ${report.version}`);
+  lines.push(`Platform: ${report.platform} (${report.arch})`);
+  lines.push(`Timestamp: ${report.timestamp}`);
+  lines.push("");
+
+  // System section
+  lines.push("--- System ---");
+  for (const check of report.system.checks) {
+    lines.push(formatCheckLine(check, useColors));
+  }
+  lines.push("");
+
+  // Android section (if present)
+  if (report.android) {
+    lines.push("--- Android Platform ---");
+    for (const check of report.android.checks) {
+      lines.push(formatCheckLine(check, useColors));
+      if (check.recommendation && (check.status === "warn" || check.status === "fail")) {
+        lines.push(`       Tip: ${check.recommendation}`);
+      }
+    }
+    lines.push("");
+  }
+
+  // iOS section (if present)
+  if (report.ios) {
+    lines.push("--- iOS Platform ---");
+    for (const check of report.ios.checks) {
+      lines.push(formatCheckLine(check, useColors));
+      if (check.recommendation && (check.status === "warn" || check.status === "fail")) {
+        lines.push(`       Tip: ${check.recommendation}`);
+      }
+    }
+    lines.push("");
+  }
+
+  // AutoMobile section
+  lines.push("--- AutoMobile ---");
+  for (const check of report.autoMobile.checks) {
+    lines.push(formatCheckLine(check, useColors));
+    if (check.recommendation && (check.status === "warn" || check.status === "fail")) {
+      lines.push(`       Tip: ${check.recommendation}`);
+    }
+  }
+  lines.push("");
+
+  // Summary
+  lines.push("--- Summary ---");
+  const passColor = useColors ? STATUS_COLORS.pass : "";
+  const warnColor = useColors ? STATUS_COLORS.warn : "";
+  const failColor = useColors ? STATUS_COLORS.fail : "";
+  const skipColor = useColors ? STATUS_COLORS.skip : "";
+  const reset = useColors ? RESET : "";
+
+  const summaryParts: string[] = [
+    `Total: ${report.summary.total}`,
+    `${passColor}Passed: ${report.summary.passed}${reset}`,
+    `${warnColor}Warnings: ${report.summary.warnings}${reset}`,
+    `${failColor}Failed: ${report.summary.failed}${reset}`,
+  ];
+
+  if (report.summary.skipped > 0) {
+    summaryParts.push(`${skipColor}Skipped: ${report.summary.skipped}${reset}`);
+  }
+
+  lines.push(summaryParts.join(" | "));
+  lines.push("");
+
+  // Overall status message
+  if (report.summary.failed > 0) {
+    lines.push(`${failColor}Some checks failed. Please address the issues above.${reset}`);
+  } else if (report.summary.warnings > 0) {
+    lines.push(`${warnColor}All critical checks passed, but there are warnings to review.${reset}`);
+  } else {
+    lines.push(`${passColor}All checks passed! AutoMobile is ready to use.${reset}`);
+  }
+  lines.push("");
+
+  // Issue link
+  lines.push("Include this output in GitHub issues:");
+  lines.push("  https://github.com/kaeawc/auto-mobile/issues");
+  lines.push("");
+
+  return lines.join("\n");
+}
+
+/**
+ * Format the doctor report as JSON
+ */
+export function formatJsonOutput(report: DoctorReport): string {
+  return JSON.stringify(report, null, 2);
+}

--- a/src/doctor/index.ts
+++ b/src/doctor/index.ts
@@ -1,0 +1,120 @@
+/**
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { DoctorReport, DoctorOptions, DoctorSummary, CheckResult } from "./types";
+import { runSystemChecks } from "./checks/system";
+import { runAndroidChecks } from "./checks/android";
+import { runIosChecks } from "./checks/ios";
+import { runAutoMobileChecks } from "./checks/automobile";
+import { RELEASE_VERSION } from "../constants/release";
+
+/**
+ * Calculate summary statistics from check results
+ */
+function calculateSummary(allChecks: CheckResult[]): DoctorSummary {
+  const summary: DoctorSummary = {
+    total: allChecks.length,
+    passed: 0,
+    warnings: 0,
+    failed: 0,
+    skipped: 0,
+  };
+
+  for (const check of allChecks) {
+    switch (check.status) {
+      case "pass":
+        summary.passed++;
+        break;
+      case "warn":
+        summary.warnings++;
+        break;
+      case "fail":
+        summary.failed++;
+        break;
+      case "skip":
+        summary.skipped++;
+        break;
+    }
+  }
+
+  return summary;
+}
+
+/**
+ * Collect all recommendations from failed/warning checks
+ */
+function collectRecommendations(allChecks: CheckResult[]): string[] {
+  const recommendations: string[] = [];
+
+  for (const check of allChecks) {
+    if ((check.status === "fail" || check.status === "warn") && check.recommendation) {
+      recommendations.push(`${check.name}: ${check.recommendation}`);
+    }
+  }
+
+  return recommendations;
+}
+
+/**
+ * Run the doctor diagnostic tool
+ */
+export async function runDoctor(options: DoctorOptions = {}): Promise<DoctorReport> {
+  const allChecks: CheckResult[] = [];
+
+  // Always run system checks
+  const systemChecks = runSystemChecks();
+  allChecks.push(...systemChecks);
+
+  // Determine which platform checks to run
+  const runAndroid = options.android === true || (options.android !== false && options.ios !== true);
+  const runIos = options.ios === true || (options.ios !== true && options.android !== true && process.platform === "darwin");
+
+  // Run Android checks if applicable
+  let androidChecks: CheckResult[] | undefined;
+  if (runAndroid) {
+    androidChecks = await runAndroidChecks();
+    allChecks.push(...androidChecks);
+  }
+
+  // Run iOS checks if applicable
+  let iosChecks: CheckResult[] | undefined;
+  if (runIos) {
+    iosChecks = await runIosChecks();
+    allChecks.push(...iosChecks);
+  }
+
+  // Always run AutoMobile checks
+  const autoMobileChecks = await runAutoMobileChecks();
+  allChecks.push(...autoMobileChecks);
+
+  // Calculate summary and recommendations
+  const summary = calculateSummary(allChecks);
+  const recommendations = collectRecommendations(allChecks);
+
+  const report: DoctorReport = {
+    timestamp: new Date().toISOString(),
+    version: RELEASE_VERSION,
+    platform: process.platform,
+    arch: process.arch,
+    system: { checks: systemChecks },
+    autoMobile: { checks: autoMobileChecks },
+    summary,
+    recommendations,
+  };
+
+  // Add platform-specific sections if they were run
+  if (androidChecks) {
+    report.android = { checks: androidChecks };
+  }
+  if (iosChecks) {
+    report.ios = { checks: iosChecks };
+  }
+
+  return report;
+}
+
+// Re-export types and formatter for convenience
+export { formatConsoleOutput, formatJsonOutput } from "./formatter";
+export * from "./types";

--- a/src/doctor/types.ts
+++ b/src/doctor/types.ts
@@ -1,0 +1,66 @@
+/**
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Status of an individual diagnostic check
+ */
+export type CheckStatus = "pass" | "warn" | "fail" | "skip";
+
+/**
+ * Result of a single diagnostic check
+ */
+export interface CheckResult {
+  name: string;
+  status: CheckStatus;
+  message: string;
+  value?: string | number | boolean | null;
+  recommendation?: string;
+}
+
+/**
+ * Section containing multiple checks
+ */
+export interface CheckSection {
+  checks: CheckResult[];
+}
+
+/**
+ * Summary statistics for the doctor report
+ */
+export interface DoctorSummary {
+  total: number;
+  passed: number;
+  warnings: number;
+  failed: number;
+  skipped: number;
+}
+
+/**
+ * Complete doctor diagnostic report
+ */
+export interface DoctorReport {
+  timestamp: string;
+  version: string;
+  platform: string;
+  arch: string;
+  system: CheckSection;
+  android?: CheckSection;
+  ios?: CheckSection;
+  autoMobile: CheckSection;
+  summary: DoctorSummary;
+  recommendations: string[];
+}
+
+/**
+ * Options for running the doctor diagnostic
+ */
+export interface DoctorOptions {
+  /** Run Android-specific checks only */
+  android?: boolean;
+  /** Run iOS-specific checks only */
+  ios?: boolean;
+  /** Output in JSON format */
+  json?: boolean;
+}

--- a/src/server/doctorTools.ts
+++ b/src/server/doctorTools.ts
@@ -1,0 +1,44 @@
+/**
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { z } from "zod";
+import { ToolRegistry } from "./toolRegistry";
+import { createJSONToolResponse } from "../utils/toolUtils";
+import { runDoctor } from "../doctor";
+
+/**
+ * Schema for the doctor tool
+ */
+export const doctorSchema = z.object({
+  android: z.boolean().optional().describe("Run Android-specific checks only"),
+  ios: z.boolean().optional().describe("Run iOS-specific checks only"),
+}).strict();
+
+/**
+ * Arguments for the doctor tool
+ */
+export interface DoctorArgs {
+  android?: boolean;
+  ios?: boolean;
+}
+
+/**
+ * Register the doctor diagnostic tool
+ */
+export function registerDoctorTools(): void {
+  ToolRegistry.register(
+    "doctor",
+    "Run diagnostic checks to verify AutoMobile setup and environment configuration",
+    doctorSchema,
+    async (args: DoctorArgs) => {
+      const report = await runDoctor({
+        android: args.android,
+        ios: args.ios,
+      });
+
+      return createJSONToolResponse(report);
+    }
+  );
+}

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -25,6 +25,7 @@ import { registerDebugTools } from "./debugTools";
 import { registerNavigationTools } from "./navigationTools";
 import { registerDaemonTools } from "./daemonTools";
 import { registerPlanTools } from "./planTools";
+import { registerDoctorTools } from "./doctorTools";
 
 // Import resource registration functions
 import { registerObservationResources } from "./observationResources";
@@ -48,6 +49,7 @@ export const createMcpServer = (options: McpServerOptions = {}): McpServer => {
   registerNavigationTools();
   registerDaemonTools();
   registerPlanTools();
+  registerDoctorTools();
 
   // Register all resources
   registerObservationResources();


### PR DESCRIPTION
## Summary

Implements a comprehensive doctor/diagnostic tool that validates system configuration, identifies issues, and generates reports for troubleshooting. Closes #160.

- Added CLI access via `auto-mobile --cli doctor [--android] [--ios] [--json]`
- Added MCP tool access via `doctor` tool for programmatic use
- Implemented 16 diagnostic checks across System, Android, iOS, and AutoMobile categories
- Default to daemon execution with fallback to direct execution when unavailable

## Checks Implemented

| Category | Checks |
|----------|--------|
| System | OS, architecture, runtime (Bun/Node) |
| Android | ANDROID_HOME, JAVA_HOME, ADB path/version, emulator, connected devices, available AVDs |
| iOS | simctl availability, booted simulators |
| AutoMobile | version, daemon status, daemon connectivity, accessibility service |

## Output Formats

**Console output** with colored [PASS]/[WARN]/[FAIL]/[SKIP] indicators:
```
AutoMobile Doctor
=================
Version: latest
Platform: darwin (arm64)

--- System ---
[PASS] Operating System: darwin
[PASS] Architecture: arm64
[PASS] Runtime: bun@1.3.5

--- Android Platform ---
[PASS] ANDROID_HOME: /Users/name/Library/Android/sdk
...

--- Summary ---
Total: 16 | Passed: 16 | Warnings: 0 | Failed: 0
```

**JSON output** for scripting via `--json` flag.

## Test plan

- [x] Run `bun run lint` - passes
- [x] Run `bun run build` - passes
- [x] Test `auto-mobile --cli doctor` - shows all checks with colored output
- [x] Test `auto-mobile --cli doctor --json` - shows hierarchical JSON
- [x] Test `auto-mobile --cli doctor --android` - skips iOS checks
- [x] Verify daemon fallback works when daemon is not running

🤖 Generated with [Claude Code](https://claude.com/claude-code)