### PR TITLE
Move intent chooser detection into accessibility service

### DIFF
--- a/android/accessibility-service/src/main/java/dev/jasonpearson/automobile/accessibilityservice/ViewHierarchyExtractor.kt
+++ b/android/accessibility-service/src/main/java/dev/jasonpearson/automobile/accessibilityservice/ViewHierarchyExtractor.kt
@@ -61,8 +61,13 @@ class ViewHierarchyExtractor {
     return try {
       val rootElement = extractNodeInfo(rootNode, 0, textFilter, screenDimensions, dedupeTextContentDesc)
       val optimizedElement = rootElement?.let { optimizeHierarchy(it) }
+      val intentChooserDetected = optimizedElement?.let { detectIntentChooserIndicators(it) } ?: false
 
-      ViewHierarchy(packageName = rootNode.packageName?.toString(), hierarchy = optimizedElement)
+      ViewHierarchy(
+        packageName = rootNode.packageName?.toString(),
+        hierarchy = optimizedElement,
+        intentChooserDetected = intentChooserDetected
+      )
     } catch (e: Exception) {
       Log.e(TAG, "Error extracting view hierarchy", e)
       ViewHierarchy(error = "Failed to extract view hierarchy: ${e.message}")
@@ -95,6 +100,7 @@ class ViewHierarchyExtractor {
     val windowHierarchies = mutableListOf<WindowHierarchy>()
     var mainHierarchy: UIElementInfo? = null
     var mainPackageName: String? = null
+    var intentChooserDetected = false
 
     // Extract from each window
     for (window in windows) {
@@ -114,6 +120,9 @@ class ViewHierarchyExtractor {
         val element = extractNodeInfo(rootNode, 0, textFilter, screenDimensions, dedupeTextContentDesc)
         val optimizedElement = element?.let { optimizeHierarchy(it) }
         val packageName = rootNode.packageName?.toString()
+        if (!intentChooserDetected && optimizedElement != null) {
+          intentChooserDetected = detectIntentChooserIndicators(optimizedElement)
+        }
 
         // The active window becomes the main hierarchy (backward compatibility)
         if (window.isActive) {
@@ -157,6 +166,9 @@ class ViewHierarchyExtractor {
       val element = extractNodeInfo(activeWindowRoot, 0, textFilter, screenDimensions, dedupeTextContentDesc)
       mainHierarchy = element?.let { optimizeHierarchy(it) }
       mainPackageName = activeWindowRoot.packageName?.toString()
+      if (!intentChooserDetected && mainHierarchy != null) {
+        intentChooserDetected = detectIntentChooserIndicators(mainHierarchy!!)
+      }
     }
 
     Log.d(TAG, "Extracted ${windowHierarchies.size} additional window hierarchies (after filtering)")
@@ -164,7 +176,8 @@ class ViewHierarchyExtractor {
     return ViewHierarchy(
       packageName = mainPackageName,
       hierarchy = mainHierarchy,
-      windows = if (windowHierarchies.isNotEmpty()) windowHierarchies else null
+      windows = if (windowHierarchies.isNotEmpty()) windowHierarchies else null,
+      intentChooserDetected = intentChooserDetected
     )
   }
 
@@ -211,6 +224,58 @@ class ViewHierarchyExtractor {
     }
 
     return false
+  }
+
+  /**
+   * Detect intent chooser indicators in an optimized hierarchy.
+   */
+  private fun detectIntentChooserIndicators(element: UIElementInfo): Boolean {
+    val textIndicators = setOf(
+      "Choose an app",
+      "Open with",
+      "Complete action using",
+      "Always",
+      "Just once"
+    )
+
+    val classIndicators = listOf(
+      "com.android.internal.app.ChooserActivity",
+      "com.android.internal.app.ResolverActivity"
+    )
+
+    val resourceIdIndicators = listOf(
+      "android:id/button_always",
+      "android:id/button_once",
+      "resolver_list",
+      "chooser_list"
+    )
+
+    val nodeText = element.text ?: element.contentDesc ?: ""
+    if (textIndicators.contains(nodeText)) {
+      return true
+    }
+
+    val nodeClass = element.className ?: ""
+    if (classIndicators.any { nodeClass.contains(it) }) {
+      return true
+    }
+
+    val resourceId = element.resourceId ?: ""
+    if (resourceIdIndicators.any { resourceId.contains(it) }) {
+      return true
+    }
+
+    for (child in extractChildrenFromNode(element.node)) {
+      if (detectIntentChooserIndicators(child)) {
+        return true
+      }
+    }
+
+    return false
+  }
+
+  internal fun detectIntentChooserIndicatorsForTest(element: UIElementInfo): Boolean {
+    return detectIntentChooserIndicators(element)
   }
 
   /**

--- a/android/accessibility-service/src/main/java/dev/jasonpearson/automobile/accessibilityservice/models/ViewHierarchy.kt
+++ b/android/accessibility-service/src/main/java/dev/jasonpearson/automobile/accessibilityservice/models/ViewHierarchy.kt
@@ -13,6 +13,7 @@ data class ViewHierarchy(
     val hierarchy: UIElementInfo? = null,
     val windowInfo: WindowInfo? = null,
     val windows: List<WindowHierarchy>? = null, // All visible windows (including popups, toolbars)
+    val intentChooserDetected: Boolean? = null,
     val error: String? = null // For error cases like locked screen
 )
 

--- a/android/accessibility-service/src/test/java/dev/jasonpearson/automobile/accessibilityservice/ViewHierarchyExtractorTest.kt
+++ b/android/accessibility-service/src/test/java/dev/jasonpearson/automobile/accessibilityservice/ViewHierarchyExtractorTest.kt
@@ -140,6 +140,33 @@ class ViewHierarchyExtractorTest {
   }
 
   @Test
+  fun `detectIntentChooserIndicators returns true for text indicator`() {
+    val child = UIElementInfo(text = "Choose an app")
+    val childJson = json.encodeToJsonElement(UIElementInfo.serializer(), child)
+    val root = UIElementInfo(className = "android.widget.LinearLayout", node = childJson)
+
+    assertTrue(extractor.detectIntentChooserIndicatorsForTest(root))
+  }
+
+  @Test
+  fun `detectIntentChooserIndicators returns true for resource id indicator`() {
+    val child = UIElementInfo(resourceId = "android:id/button_once", className = "android.widget.Button")
+    val childJson = json.encodeToJsonElement(UIElementInfo.serializer(), child)
+    val root = UIElementInfo(className = "android.widget.LinearLayout", node = childJson)
+
+    assertTrue(extractor.detectIntentChooserIndicatorsForTest(root))
+  }
+
+  @Test
+  fun `detectIntentChooserIndicators returns false when no indicators present`() {
+    val child = UIElementInfo(text = "Normal content", className = "android.widget.TextView")
+    val childJson = json.encodeToJsonElement(UIElementInfo.serializer(), child)
+    val root = UIElementInfo(className = "android.widget.LinearLayout", node = childJson)
+
+    assertFalse(extractor.detectIntentChooserIndicatorsForTest(root))
+  }
+
+  @Test
   fun `accessibility score is calculated for clickable elements`() = runTest {
     // This test would need a more complex setup to test accessibility scoring
     // For now, just verify that the structure supports it

--- a/src/features/observe/AccessibilityServiceClient.ts
+++ b/src/features/observe/AccessibilityServiceClient.ts
@@ -65,6 +65,7 @@ export interface AccessibilityHierarchy {
   packageName: string;
   hierarchy: AccessibilityNode;
   windows?: AccessibilityWindowHierarchy[];
+  intentChooserDetected?: boolean;
 }
 
 /**
@@ -1036,7 +1037,8 @@ export class AccessibilityServiceClient implements AccessibilityService {
 
       const result: ViewHierarchyResult = {
         hierarchy: convertedHierarchy,
-        packageName: accessibilityHierarchy.packageName
+        packageName: accessibilityHierarchy.packageName,
+        intentChooserDetected: accessibilityHierarchy.intentChooserDetected
       };
 
       // Convert windows if present (for multi-window support - popups, toolbars, etc.)

--- a/src/features/observe/DetectIntentChooser.ts
+++ b/src/features/observe/DetectIntentChooser.ts
@@ -27,7 +27,9 @@ export class DetectIntentChooser extends BaseVisualChange {
           }
 
           logger.info("[DetectIntentChooser] Starting intent chooser detection");
-          const detected = this.deepLinkManager.detectIntentChooser(viewHierarchy);
+          const detected =
+            viewHierarchy.intentChooserDetected ??
+            this.deepLinkManager.detectIntentChooser(viewHierarchy);
 
           logger.info(`[DetectIntentChooser] Intent chooser detection completed. Detected: ${detected}`);
 

--- a/src/features/observe/ObserveScreen.ts
+++ b/src/features/observe/ObserveScreen.ts
@@ -9,7 +9,6 @@ import { TakeScreenshot } from "./TakeScreenshot";
 import { GetDumpsysWindow } from "./GetDumpsysWindow";
 import { GetBackStack } from "./GetBackStack";
 import { AdbClient } from "../../utils/android-cmdline-tools/AdbClient";
-import { DeepLinkManager } from "../../utils/DeepLinkManager";
 import fs from "fs-extra";
 import path from "path";
 import { readdirAsync, readFileAsync, statAsync, writeFileAsync } from "../../utils/io";
@@ -47,7 +46,6 @@ export class ObserveScreen {
   private adb: AdbClient;
   private axe: AxeClient;
   private webdriver: WebDriverAgent;
-  private deepLinkManager: DeepLinkManager;
 
   // Static cache for observe results
   private static observeResultCache: Map<string, ObserveResultCache> = new Map();
@@ -97,7 +95,6 @@ export class ObserveScreen {
     this.screenshotUtil = new TakeScreenshot(device, this.adb);
     this.dumpsysWindow = new GetDumpsysWindow(device, this.adb);
     this.backStack = new GetBackStack(this.adb);
-    this.deepLinkManager = new DeepLinkManager(device);
 
     // Ensure observe result cache directory exists
     if (!fs.existsSync(ObserveScreen.observeResultCacheDir)) {
@@ -257,7 +254,7 @@ export class ObserveScreen {
     }
 
     try {
-      const intentChooserDetected = this.deepLinkManager.detectIntentChooser(result.viewHierarchy);
+      const intentChooserDetected = result.viewHierarchy.intentChooserDetected;
 
       // Add intent chooser detection to result
       result.intentChooserDetected = intentChooserDetected;

--- a/src/models/ViewHierarchyResult.ts
+++ b/src/models/ViewHierarchyResult.ts
@@ -9,6 +9,8 @@ export interface ViewHierarchyResult {
   updatedAt?: number;
   /** Package name of the foreground app (from accessibility service) */
   packageName?: string;
+  /** Whether an intent chooser dialog was detected (from accessibility service) */
+  intentChooserDetected?: boolean;
   /** All visible windows (including popups, toolbars, etc.) */
   windows?: WindowHierarchy[];
 }

--- a/src/server/deepLinkTools.ts
+++ b/src/server/deepLinkTools.ts
@@ -1,8 +1,6 @@
 import { z } from "zod";
 import { ToolRegistry } from "./toolRegistry";
 import { GetDeepLinks } from "../features/utility/GetDeepLinks";
-import { DetectIntentChooser } from "../features/observe/DetectIntentChooser";
-import { HandleIntentChooser } from "../features/action/HandleIntentChooser";
 import { ActionableError, BootedDevice } from "../models";
 import { createJSONToolResponse } from "../utils/toolUtils";
 import { logger } from "../utils/logger";
@@ -12,25 +10,9 @@ export const getDeepLinksSchema = z.object({
   appId: z.string().describe("Android app package ID to query for deep links"),
 });
 
-export const detectIntentChooserSchema = z.object({
-});
-
-export const handleIntentChooserSchema = z.object({
-  preference: z.enum(["always", "just_once", "custom"]).optional().describe("Preference for handling intent chooser (default: 'just_once')"),
-  customAppPackage: z.string().optional().describe("Specific app package to select when preference is 'custom'"),
-});
-
 // Type definitions for better TypeScript support
 export interface GetDeepLinksArgs {
     appId: string;
-}
-
-export interface DetectIntentChooserArgs {
-}
-
-export interface HandleIntentChooserArgs {
-    preference?: "always" | "just_once" | "custom";
-    customAppPackage?: string;
 }
 
 // Register tools
@@ -59,73 +41,12 @@ export function registerDeepLinkTools() {
     }
   };
 
-  // Detect intent chooser handler
-  const detectIntentChooserHandler = async (device: BootedDevice, args: DetectIntentChooserArgs) => {
-    try {
-      const detectIntentChooser = new DetectIntentChooser(device);
-      const result = await detectIntentChooser.execute();
-
-      return createJSONToolResponse({
-        message: `Intent chooser detection completed. Detected: ${result.detected}`,
-        success: result.success,
-        detected: result.detected,
-        error: result.error,
-        observation: result.observation
-      });
-    } catch (error) {
-      logger.error(`[detectIntentChooser] Failed to detect intent chooser: ${error}`);
-      throw new ActionableError(`Failed to detect intent chooser: ${error}`);
-    }
-  };
-
-  // Handle intent chooser handler
-  const handleIntentChooserHandler = async (device: BootedDevice, args: HandleIntentChooserArgs) => {
-    try {
-      const handleIntentChooser = new HandleIntentChooser(device);
-      const result = await handleIntentChooser.execute(
-        args.preference || "just_once",
-        args.customAppPackage,
-      );
-
-      return createJSONToolResponse({
-        message: result.detected
-          ? `Intent chooser handled with preference: ${args.preference || "just_once"}`
-          : "No intent chooser detected",
-        success: result.success,
-        detected: result.detected,
-        action: result.action,
-        appSelected: result.appSelected,
-        error: result.error,
-        observation: result.observation
-      });
-    } catch (error) {
-      logger.error(`[handleIntentChooser] Failed to handle intent chooser: ${error}`);
-      throw new ActionableError(`Failed to handle intent chooser: ${error}`);
-    }
-  };
-
   // Register with the tool registry
   ToolRegistry.registerDeviceAware(
     "getDeepLinks",
     "Query available deep links and intent filters for an Android application",
     getDeepLinksSchema,
     getDeepLinksHandler,
-    false // Does not support progress notifications
-  );
-
-  ToolRegistry.registerDeviceAware(
-    "detectIntentChooser",
-    "Detect system intent chooser dialog in the current view hierarchy",
-    detectIntentChooserSchema,
-    detectIntentChooserHandler,
-    false // Does not support progress notifications
-  );
-
-  ToolRegistry.registerDeviceAware(
-    "handleIntentChooser",
-    "Automatically handle system intent chooser dialog with specified preferences",
-    handleIntentChooserSchema,
-    handleIntentChooserHandler,
     false // Does not support progress notifications
   );
 }

--- a/test/fakes/FakeAccessibilityService.ts
+++ b/test/fakes/FakeAccessibilityService.ts
@@ -280,7 +280,8 @@ export class FakeAccessibilityService implements AccessibilityService {
         }
       },
       packageName: accessibilityHierarchy.packageName,
-      updatedAt: accessibilityHierarchy.updatedAt
+      updatedAt: accessibilityHierarchy.updatedAt,
+      intentChooserDetected: accessibilityHierarchy.intentChooserDetected
     };
   }
 

--- a/test/features/observe/AccessibilityServiceClient.test.ts
+++ b/test/features/observe/AccessibilityServiceClient.test.ts
@@ -228,6 +228,7 @@ describe("AccessibilityServiceClient", function() {
       const accessibilityHierarchy = {
         updatedAt: 1750934583218,
         packageName: "com.google.android.deskclock",
+        intentChooserDetected: true,
         hierarchy: {
           "text": "6:43 AM",
           "content-desc": "6:43 AM",
@@ -264,6 +265,7 @@ describe("AccessibilityServiceClient", function() {
       expect(result.hierarchy.bounds).toBe("[175,687][692,973]");
       expect(result.hierarchy.clickable).toBeUndefined();
       expect(result.hierarchy.enabled).toBe("true");
+      expect(result.intentChooserDetected).toBe(true);
 
       // Check child node conversion
       expect(typeof result.hierarchy.node).toBe("object");

--- a/test/server/deepLinkTools.test.ts
+++ b/test/server/deepLinkTools.test.ts
@@ -2,7 +2,6 @@ import { expect, describe, test, beforeEach, afterEach, beforeAll } from "bun:te
 import { registerDeepLinkTools } from "../../src/server/deepLinkTools";
 import { ToolRegistry } from "../../src/server/toolRegistry";
 import { MultiPlatformDeviceManager } from "../../src/utils/deviceUtils";
-import { FakeDeepLinkManager } from "../fakes/FakeDeepLinkManager";
 
 // Helper function to check if AVDs are available
 async function checkAvdAvailability(): Promise<boolean> {
@@ -27,7 +26,6 @@ async function checkAvdAvailability(): Promise<boolean> {
 
 describe("Deep Link Tools Registration", function() {
   let avdsAvailable: boolean;
-  let fakeDeepLinkManager: FakeDeepLinkManager;
 
   beforeAll(async function() {
     // Check if AVDs are available once before all tests
@@ -40,15 +38,11 @@ describe("Deep Link Tools Registration", function() {
   beforeEach(() => {
     // Clear the tool registry before each test
     (ToolRegistry as any).tools.clear();
-
-    // Create fake deep link manager for testing
-    fakeDeepLinkManager = new FakeDeepLinkManager();
   });
 
   afterEach(() => {
     // Clean up after each test
     (ToolRegistry as any).tools.clear();
-    fakeDeepLinkManager.clearHistory();
   });
 
   describe("registerDeepLinkTools", () => {
@@ -59,8 +53,6 @@ describe("Deep Link Tools Registration", function() {
       const toolNames = registeredTools.map(tool => tool.name);
 
       expect(toolNames).toContain("getDeepLinks");
-      expect(toolNames).toContain("detectIntentChooser");
-      expect(toolNames).toContain("handleIntentChooser");
     });
 
     test("should register getDeepLinks tool with correct schema", () => {
@@ -79,44 +71,6 @@ describe("Deep Link Tools Registration", function() {
       expect(() => tool!.schema.parse(invalidArgs)).toThrow();
     });
 
-    test("should register detectIntentChooser tool with correct schema", () => {
-      registerDeepLinkTools();
-
-      const tool = ToolRegistry.getTool("detectIntentChooser");
-      expect(tool).toBeDefined();
-      expect(tool!.description).toContain("Detect system intent chooser");
-      expect(tool!.supportsProgress).toBe(false);
-
-      // Test schema validation
-      const validArgs = { platform: "android" };
-      expect(() => tool!.schema.parse(validArgs)).not.toThrow();
-
-      const validArgsIos = { platform: "ios" };
-      expect(() => tool!.schema.parse(validArgsIos)).not.toThrow();
-    });
-
-    test("should register handleIntentChooser tool with correct schema", () => {
-      registerDeepLinkTools();
-
-      const tool = ToolRegistry.getTool("handleIntentChooser");
-      expect(tool).toBeDefined();
-      expect(tool!.description).toContain("Automatically handle system intent chooser");
-      expect(tool!.supportsProgress).toBe(false);
-
-      // Test schema validation
-      const validArgs = {
-        preference: "always",
-        customAppPackage: "com.example.app",
-        platform: "android"
-      };
-      expect(() => tool!.schema.parse(validArgs)).not.toThrow();
-
-      const validArgsMinimal = { platform: "android" };
-      expect(() => tool!.schema.parse(validArgsMinimal)).not.toThrow();
-
-      const invalidArgs = { preference: "invalid", platform: "android" };
-      expect(() => tool!.schema.parse(invalidArgs)).toThrow();
-    });
   });
 
   describe("Tool Handlers", function() {
@@ -145,64 +99,6 @@ describe("Deep Link Tools Registration", function() {
       });
     });
 
-    describe("detectIntentChooser handler", () => {
-      test("should validate schema and register tool", async function() {
-        const tool = ToolRegistry.getTool("detectIntentChooser");
-        expect(tool).toBeDefined();
-
-        // Test that the schema allows empty input (all params optional)
-        const parsed = tool!.schema.parse({});
-        expect(parsed).toBeDefined();
-      });
-
-      test("should have no required parameters", async function() {
-        const tool = ToolRegistry.getTool("detectIntentChooser");
-        expect(tool).toBeDefined();
-
-        // The schema should accept empty input (no required parameters)
-        const parsed = tool!.schema.parse({});
-        expect(parsed).toEqual({});
-      });
-    });
-
-    describe("handleIntentChooser handler", () => {
-      test("should validate all preference options in schema", async function() {
-        const tool = ToolRegistry.getTool("handleIntentChooser");
-        expect(tool).toBeDefined();
-
-        const preferences = ["always", "just_once", "custom"];
-
-        for (const preference of preferences) {
-          const parsed = tool!.schema.parse({ preference });
-          expect(parsed.preference).toBe(preference);
-        }
-      });
-
-      test("should validate custom app package in schema", async function() {
-        const tool = ToolRegistry.getTool("handleIntentChooser");
-        expect(tool).toBeDefined();
-
-        const parsed = tool!.schema.parse({
-          preference: "custom",
-          customAppPackage: "com.example.app"
-        });
-        expect(parsed.preference).toBe("custom");
-        expect(parsed.customAppPackage).toBe("com.example.app");
-      });
-
-      test("should validate preference enum", () => {
-        const tool = ToolRegistry.getTool("handleIntentChooser");
-        expect(tool).toBeDefined();
-
-        // Valid preferences should pass
-        expect(() => tool!.schema.parse({ preference: "always", platform: "android" })).not.toThrow();
-        expect(() => tool!.schema.parse({ preference: "just_once", platform: "android" })).not.toThrow();
-        expect(() => tool!.schema.parse({ preference: "custom", platform: "android" })).not.toThrow();
-
-        // Invalid preference should fail
-        expect(() => tool!.schema.parse({ preference: "invalid", platform: "android" })).toThrow();
-      });
-    });
   });
 
   describe("Error Handling", function() {
@@ -224,8 +120,6 @@ describe("Deep Link Tools Registration", function() {
       const schemas = require("../../src/server/deepLinkTools");
 
       expect(schemas.getDeepLinksSchema).toBeDefined();
-      expect(schemas.detectIntentChooserSchema).toBeDefined();
-      expect(schemas.handleIntentChooserSchema).toBeDefined();
     });
 
     test("should have correct TypeScript interfaces", () => {
@@ -233,8 +127,6 @@ describe("Deep Link Tools Registration", function() {
 
       // These should exist as type definitions (compile-time check)
       expect(interfaces.GetDeepLinksArgs).toBeUndefined(); // Interfaces don't exist at runtime
-      expect(interfaces.DetectIntentChooserArgs).toBeUndefined();
-      expect(interfaces.HandleIntentChooserArgs).toBeUndefined();
     });
   });
 });


### PR DESCRIPTION
## Summary
- move intent chooser detection into the accessibility-service view hierarchy payload
- plumb `intentChooserDetected` through the observe pipeline
- drop MCP tools for detect/handle intent chooser and update tests

## Testing
- `bun test`
- `./gradlew :junit-runner:test --rerun-tasks` (after daemon restart)
