### PR TITLE
Add Codex MCP client installation docs

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,7 +1,7 @@
 # Installation
 
 Right now this guide assumes you are a software engineer who is roughly familiar with AI coding assistants like Cursor,
-Claude Code, or Firebender.
+Claude Code, Codex, or Firebender.
 
 ### MCP Server Configuration for your Agent
 

--- a/docs/mcp-clients/codex.md
+++ b/docs/mcp-clients/codex.md
@@ -1,0 +1,63 @@
+# Codex MCP Config
+
+This is a simple sample of how to get AutoMobile running with Codex, for other options see the
+[overview](index.md).
+
+## Option 1: Using the CLI (Recommended)
+
+Add AutoMobile via the terminal:
+
+```bash
+codex mcp add auto-mobile --env ANDROID_HOME=/Users/<username>/Library/Android/sdk -- npx -y @kaeawc/auto-mobile@latest
+```
+
+Replace `/Users/<username>/Library/Android/sdk` with your actual Android SDK path:
+- **macOS**: Usually `~/Library/Android/sdk`
+- **Linux**: Usually `~/Android/Sdk`
+- **Windows**: Usually `C:\Users\<username>\AppData\Local\Android\Sdk`
+
+You can verify the server was added:
+
+```bash
+codex mcp list
+```
+
+## Option 2: Manual Configuration
+
+Add the following to your Codex configuration file at `~/.codex/config.toml`:
+
+```toml
+[mcp_servers.auto-mobile]
+command = "npx"
+args = ["-y", "@kaeawc/auto-mobile@latest"]
+
+[mcp_servers.auto-mobile.env]
+ANDROID_HOME = "/Users/<username>/Library/Android/sdk"
+```
+
+Replace `/Users/<username>/Library/Android/sdk` with your actual Android SDK path:
+- **macOS**: Usually `~/Library/Android/sdk`
+- **Linux**: Usually `~/Android/Sdk`
+- **Windows**: Usually `C:\Users\<username>\AppData\Local\Android\Sdk`
+
+## Configuration Notes
+
+The Codex CLI and IDE extension share the same configuration file (`~/.codex/config.toml`), so you only need to configure AutoMobile once.
+
+### Optional Settings
+
+You can customize server behavior with additional options:
+
+```toml
+[mcp_servers.auto-mobile]
+command = "npx"
+args = ["-y", "@kaeawc/auto-mobile@latest"]
+startup_timeout_sec = 30  # Default: 10
+tool_timeout_sec = 120    # Default: 60
+enabled = true            # Set to false to disable without removing
+
+[mcp_servers.auto-mobile.env]
+ANDROID_HOME = "/Users/<username>/Library/Android/sdk"
+```
+
+After saving the config, restart Codex and the AutoMobile server will start automatically.

--- a/docs/mcp-clients/index.md
+++ b/docs/mcp-clients/index.md
@@ -6,6 +6,7 @@ AutoMobile MCP is designed to be run in STDIO mode in production settings like w
 We have specific documentation for clients we have used AutoMobile with:
 
 * [Claude Code](claude-code.md)
+* [Codex](codex.md)
 * [Cursor](cursor.md)
 * [Firebender](firebender.md)
 * [Goose](goose.md) 


### PR DESCRIPTION
## Summary

- Add `docs/mcp-clients/codex.md` with Codex-specific setup steps including CLI (`codex mcp add`) and manual TOML configuration
- Update `docs/mcp-clients/index.md` to include Codex link
- Update `docs/installation.md` to mention Codex alongside existing clients

## Test plan

- [ ] Verify codex.md renders correctly
- [ ] Verify links in index.md work
- [ ] Test CLI command syntax with Codex if available

Closes #184

🤖 Generated with [Claude Code](https://claude.com/claude-code)