### PR TITLE
Fix Docker Hub publish job bun setup

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -291,6 +291,11 @@ jobs:
       - name: "Git Checkout"
         uses: actions/checkout@v4
 
+      - name: "Setup Bun"
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.5
+
       - name: "Extract version from package.json"
         id: package-version
         run: |


### PR DESCRIPTION
## Summary
- install Bun in the Docker Hub publish job before version extraction
- pin Bun to 1.3.5 to match repo packageManager/engines

## Testing
- not run (CI only)

## Issue
- fixes #188
