### PR TITLE
Avoid UnixSystem dependency in junit-runner

### DIFF
--- a/android/junit-runner/src/main/kotlin/dev/jasonpearson/automobile/junit/DaemonSocketClient.kt
+++ b/android/junit-runner/src/main/kotlin/dev/jasonpearson/automobile/junit/DaemonSocketClient.kt
@@ -111,8 +111,24 @@ internal object DaemonSocketPaths {
   }
 
   private fun getUserId(): String {
-    val userName = System.getProperty("user.name", "default")
-    return if (userName.isNotBlank()) userName else "default"
+    val userName = System.getProperty("user.name", "default").ifBlank { "default" }
+    val osName = System.getProperty("os.name").lowercase()
+    if (osName.contains("win")) {
+      return userName
+    }
+
+    return try {
+      val process = ProcessBuilder("id", "-u").start()
+      val exitCode = process.waitFor(2, java.util.concurrent.TimeUnit.SECONDS)
+      if (!exitCode) {
+        process.destroy()
+        return userName
+      }
+      val uid = process.inputStream.bufferedReader().readText().trim()
+      if (uid.isNotEmpty()) uid else userName
+    } catch (e: Exception) {
+      userName
+    }
   }
 }
 


### PR DESCRIPTION
## Summary
- remove reliance on JDK-internal UnixSystem for daemon socket path computation
- match the daemon’s socket naming by using `id -u` on Unix (username fallback on failure/Windows)

## Notes
- follow-up fix for a regression where the daemon socket path used username instead of UID

## Testing
- not run (commit only)
