### PR TITLE
Remove test authoring references

### DIFF
--- a/android/README.md
+++ b/android/README.md
@@ -2,6 +2,5 @@
 
 ## Overview
 
-A set of Android Gradle libraries and applications that integrate AutoMobile into an Android app. JUnit test execution,
-automated test authoring generated via KotlinPoet, and a sample app that is also used to actively test and improve
-AutoMobile's capabilities on Android.
+A set of Android Gradle libraries and applications that integrate AutoMobile into an Android app. JUnit test execution
+and a sample app are used to actively test and improve AutoMobile's capabilities on Android.

--- a/android/gradle/libs.versions.toml
+++ b/android/gradle/libs.versions.toml
@@ -54,7 +54,6 @@ navigation3 = "1.0.0"              # Used in playground app
 
 # Kotlin ecosystem
 kotlinx-serialization-json = "1.9.0"
-kotlin-poet = "2.2.0"
 appcompat = "1.7.1"
 material = "1.13.0"
 lifecycleViewmodelNavigation3Android = "2.10.0"
@@ -90,8 +89,6 @@ kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-t
 kotlinx-coroutines = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "build-kotlin-coroutines" }
 kotlinx-datetime = { module = "org.jetbrains.kotlinx:kotlinx-datetime", version.ref = "build-kotlin-datetime" }
 kotlinx-serialization = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinx-serialization-json" }
-kotlin-poet = { module = "com.squareup:kotlinpoet", version.ref = "kotlin-poet" }
-
 mockk = { module = "io.mockk:mockk", version.ref = "mockk" }
 navigation3-runtime = { module = "androidx.navigation3:navigation3-runtime", version.ref = "navigation3" }
 navigation3-ui = { module = "androidx.navigation3:navigation3-ui", version.ref = "navigation3" }

--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -14,19 +14,6 @@ is tested with AutoMobile in order to keep improving.
 We combine project path config with deep view hierarchy analysis to determine the code is being rendered. This opens a
 lot of possibilities so we're looking for ways to improve indexing performance and accuracy.
 
-#### Automated Test Authoring
-
-When used in test authoring mode AutoMobile will write tests for you. It logs every tool call used during an exploration
-as well as the relevant source files observed. Once the target app is stopped it determines the correct path for the test
-and writes it to disk. This test will always be immediately runnable and correct because no AI is used in this process.
-AutoMobile authors [yaml plans](test-authoring/plan-syntax.md) of the tool calls logged along with platform specific
-unit tests via code writing tools. For Android this is a KotlinPoet wrapper Clikt app.
-
-The Clikt application is a Kotlin-based command-line interface that facilitates test authoring and device interaction.
-It leverages the Clikt library for creating intuitive command-line interfaces and serves as a bridge between the MCP
-server's capabilities and native Android testing frameworks. This component enables developers to author tests in Kotlin
-while benefiting from the comprehensive device automation capabilities provided by the broader AutoMobile ecosystem.
-
 #### Test Execution
 
 The Android JUnitRunner is responsible for executing authored tests on Android devices and emulators. It extends the

--- a/docs/features/mcp-server/index.md
+++ b/docs/features/mcp-server/index.md
@@ -11,15 +11,12 @@ stateDiagram-v2
   RequestHandler: Request Handler
   DeviceSessionManager: Device Session Manager
   InteractionLoop: Interaction Loop
-  AuthorTest: Author Test
 
   Agent --> RequestHandler
   RequestHandler --> Agent
   RequestHandler --> DeviceSessionManager
   InteractionLoop --> RequestHandler: 🖼️ Processed Results
   DeviceSessionManager --> InteractionLoop: 📱
-  RequestHandler --> AuthorTest: on App Stopped
-
 ```
 
 ## Configuration

--- a/docs/features/mcp-server/resources.md
+++ b/docs/features/mcp-server/resources.md
@@ -1,6 +1,6 @@
 # Features - MCP Server - Resources
 
-AutoMobile exposes MCP resources that provide direct access to the current device state for test authoring and debugging workflows.
+AutoMobile exposes MCP resources that provide direct access to the current device state for automation and debugging workflows.
 
 ## Available Resources
 

--- a/docs/features/mcp-server/system-design.md
+++ b/docs/features/mcp-server/system-design.md
@@ -9,9 +9,6 @@ stateDiagram-v2
     RequestHandler: Request Handler
     DeviceSessionManager: Device Session Manager
     InteractionLoop: Interaction Loop
-    AuthorTest: Author Test
-  
-  
     InitialObserve: Observe
     FinalObserve: Observe
     MoreActions?: More Actions?
@@ -26,8 +23,6 @@ stateDiagram-v2
         RequestHandler --> DeviceSessionManager
         InteractionLoop --> RequestHandler: 🖼️ Processed Results 
         DeviceSessionManager --> InteractionLoop: 📱
-        RequestHandler --> AuthorTest: on App Stopped
-    
     state InteractionLoop {
         InitialObserve --> ExecuteActions
         ExecuteActions --> FinalObserve

--- a/docs/features/test-execution/junitrunner.md
+++ b/docs/features/test-execution/junitrunner.md
@@ -1,8 +1,7 @@
 # Test Execution - JUnitRunner
 
-Add this test Gradle dependency to all Android apps and libraries in your codebase. You could opt to only add it to some
-modules, but AutoMobile's automatic test authoring will still attempt to place tests in the module it thinks most closely
-matches the UI being tested.
+Add this test Gradle dependency to all Android apps and libraries in your codebase. You can also add it only to the
+modules that cover the UI you want to test.
 
 ```gradle
 testImplementation("dev.jasonpearson.automobile.junitrunner:x.y.z")

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,7 +8,6 @@ The first platform supported is Android with plans to extend to iOS.
 **How do I get started?**
 
 - [Installation](installation.md) - Install AutoMobile in your environment or IDE
-- [Test Authoring](features/test-authoring/index.md) - Automatically write tests
 - [Test Execution](features/test-execution/index.md) - Run tests locally or on CI
 
 ```mermaid
@@ -17,15 +16,12 @@ stateDiagram-v2
     RequestHandler: Request Handler
     DeviceSessionManager: Device Session Manager
     InteractionLoop: Interaction Loop
-    AuthorTest: Author Test
     
     Agent --> RequestHandler
     RequestHandler --> Agent
     RequestHandler --> DeviceSessionManager
     InteractionLoop --> RequestHandler: 🖼️ Processed Results 
     DeviceSessionManager --> InteractionLoop: 📱
-    RequestHandler --> AuthorTest: on App Stopped
-    
 ```
 
 **Additional Resources**

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -81,9 +81,6 @@ nav:
           - 'Resources': features/mcp-server/resources.md
           - 'Observation': features/mcp-server/observation.md
           - 'Interaction Loop': features/mcp-server/interaction-loop.md
-      - 'Test Authoring':
-          - 'Overview': features/test-authoring/index.md
-          - 'Plan Syntax': features/test-authoring/plan-syntax.md
       - 'Test Execution':
           - 'Overview': features/test-execution/index.md
           - 'JUnitRunner': features/test-execution/junitrunner.md

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -36,7 +36,7 @@ export interface McpServerOptions {
 }
 
 export const createMcpServer = (options: McpServerOptions = {}): McpServer => {
-  // Get configuration, device session, and test authoring managers
+  // Get configuration and device session managers
 
   // Register all tool categories
   registerObserveTools();


### PR DESCRIPTION
## Summary
- remove KotlinPoet from Android version catalog
- strip automated test authoring references from docs/nav/diagrams and MCP comment
- adjust JUnitRunner docs wording for module selection

## Testing
- scripts/shellcheck/validate_shell_scripts.sh
- scripts/hadolint/validate_hadolint.sh
- scripts/ktfmt/validate_ktfmt.sh (reported "mapfile: command not found" on macOS Bash 3.2; then "No Kotlin files to process")
- scripts/xml/validate_xml.sh
- scripts/lychee/validate_lychee.sh
- scripts/act/validate_act.sh (dry run)
- scripts/docker/validate_dockerfile.sh
- bun test
