### PR TITLE
Ensure fresh observations after actions

### DIFF
--- a/src/features/action/BaseVisualChange.ts
+++ b/src/features/action/BaseVisualChange.ts
@@ -8,6 +8,7 @@ import { ActionableError, BootedDevice, GfxMetrics, ObserveResult } from "../../
 import { AxeClient } from "../../utils/ios-cmdline-tools/AxeClient";
 import { ViewHierarchyQueryOptions } from "../../models/ViewHierarchyQueryOptions";
 import { PerformanceTracker, NoOpPerformanceTracker } from "../../utils/PerformanceTracker";
+import { NodeCryptoService } from "../../utils/crypto";
 
 export interface ProgressCallback {
   (progress: number, total?: number, message?: string): Promise<void>;
@@ -97,8 +98,16 @@ export class BaseVisualChange {
       }
     }
 
-    // Record the action start time - used to ensure final observe returns fresh data
-    const actionStartTime = Date.now();
+    // Record the action start time (device time if available) to ensure fresh data
+    const actionStartTime = await perf.track("getActionStartTime", async () => {
+      if (this.device.platform !== "android") {
+        return Date.now();
+      }
+      if (typeof this.adb.getDeviceTimestampMs === "function") {
+        return this.adb.getDeviceTimestampMs();
+      }
+      return Date.now();
+    });
 
     const blockResult = await perf.track("executeBlock", async () => {
       return block(previousObserveResult!);
@@ -180,12 +189,46 @@ export class BaseVisualChange {
     // Use actionStartTime as minTimestamp to ensure we get data captured after the action
     // This prevents returning stale cached data from before the action was executed
     const minTimestamp = options.actionStartTime ?? 0;
+    const retryDelaysMs = [50, 100, 200, 400];
+    const previousHash = this.hashViewHierarchy(previousObserveResult?.viewHierarchy);
 
     perf.serial("finalObserve");
     // Wait for fresh data from accessibility service (skipWaitForFresh=false)
     // This ensures we get observation data that reflects the action that just completed
-    const latestObservation = await this.observeScreen.execute(options.queryOptions, perf, false, minTimestamp);
+    let latestObservation = await this.observeScreen.execute(options.queryOptions, perf, false, minTimestamp);
     perf.end();
+
+    const shouldRetry = (observation: ObserveResult): boolean => {
+      const isFresh = observation.freshness?.isFresh ?? true;
+      if (minTimestamp > 0 && !isFresh) {
+        return true;
+      }
+      if (!options.changeExpected) {
+        return false;
+      }
+      const currentHash = this.hashViewHierarchy(observation.viewHierarchy);
+      return !!previousHash && !!currentHash && previousHash === currentHash;
+    };
+
+    for (let attempt = 0; attempt < retryDelaysMs.length && shouldRetry(latestObservation); attempt++) {
+      const delayMs = retryDelaysMs[attempt];
+      logger.info(`[BaseVisualChange] Observation appears stale/unchanged, retrying in ${delayMs}ms (attempt ${attempt + 1}/${retryDelaysMs.length})`);
+      await new Promise(resolve => setTimeout(resolve, delayMs));
+      perf.serial(`finalObserve_retry_${attempt + 1}`);
+      latestObservation = await this.observeScreen.execute(options.queryOptions, perf, false, minTimestamp);
+      perf.end();
+    }
+
+    if (shouldRetry(latestObservation)) {
+      const warning = minTimestamp > 0
+        ? "Observation may be stale after interaction"
+        : "Observation may not reflect expected visual change";
+      latestObservation.freshness = {
+        ...latestObservation.freshness,
+        warning
+      };
+      logger.warn(`[BaseVisualChange] ${warning}`);
+    }
 
     if (options.changeExpected && latestObservation.viewHierarchy && previousObserveResult && previousObserveResult?.viewHierarchy) {
       blockResult.success = latestObservation.viewHierarchy !== previousObserveResult.viewHierarchy;
@@ -218,5 +261,17 @@ export class BaseVisualChange {
     blockResult.observation = latestObservation;
 
     return blockResult;
+  }
+
+  private hashViewHierarchy(viewHierarchy?: ObserveResult["viewHierarchy"]): string | null {
+    if (!viewHierarchy) {
+      return null;
+    }
+    try {
+      return NodeCryptoService.generateCacheKey(JSON.stringify(viewHierarchy));
+    } catch (error) {
+      logger.debug(`[BaseVisualChange] Failed to hash view hierarchy: ${error}`);
+      return null;
+    }
   }
 }

--- a/src/features/observe/AccessibilityServiceClient.ts
+++ b/src/features/observe/AccessibilityServiceClient.ts
@@ -807,6 +807,35 @@ export class AccessibilityServiceClient implements AccessibilityService {
   }
 
   /**
+   * Determine whether cached data satisfies a minTimestamp requirement.
+   * Prefers device timestamp (updatedAt) when available; falls back to receivedAt otherwise.
+   */
+  private evaluateMinTimestamp(
+    cachedHierarchy: CachedHierarchy,
+    minTimestamp: number,
+    useDeviceTimestamp: boolean
+  ): {
+    isFresh: boolean;
+    updatedAt?: number;
+    updatedAfter: boolean;
+    receivedAfter: boolean;
+    usesUpdatedAt: boolean;
+  } {
+    const updatedAt = cachedHierarchy.hierarchy.updatedAt;
+    const hasUpdatedAt = typeof updatedAt === "number" && !Number.isNaN(updatedAt);
+    const shouldUseUpdatedAt = useDeviceTimestamp && hasUpdatedAt;
+    const updatedAfter = shouldUseUpdatedAt ? updatedAt >= minTimestamp : false;
+    const receivedAfter = !shouldUseUpdatedAt ? cachedHierarchy.receivedAt >= minTimestamp : false;
+    return {
+      isFresh: shouldUseUpdatedAt ? updatedAfter : receivedAfter,
+      updatedAt,
+      updatedAfter,
+      receivedAfter,
+      usesUpdatedAt: shouldUseUpdatedAt
+    };
+  }
+
+  /**
    * Get the latest hierarchy from cache or wait for fresh data
    * @param waitForFresh - If true, wait up to timeout for fresh data
    * @param timeout - Maximum time to wait for fresh data in milliseconds
@@ -849,18 +878,20 @@ export class AccessibilityServiceClient implements AccessibilityService {
         // Use BOTH timestamps to handle clock skew between JavaScript and Android
         // This matches the logic in waitForFreshData()
         if (minTimestamp > 0) {
-          const receivedAfterAction = this.cachedHierarchy.receivedAt >= minTimestamp;
-          const updatedAfterAction = updatedAt >= minTimestamp;
+          const freshness = this.evaluateMinTimestamp(this.cachedHierarchy, minTimestamp, true);
 
-          // Reject cache only if BOTH timestamps indicate stale data
-          // Accept if EITHER timestamp shows data is fresh (handles clock skew)
-          if (!receivedAfterAction && !updatedAfterAction) {
-            logger.debug(`[ACCESSIBILITY_SERVICE] Cache rejected: receivedAt ${this.cachedHierarchy.receivedAt} < ${minTimestamp} AND updatedAt ${updatedAt} < ${minTimestamp} (stale by ${minTimestamp - Math.max(this.cachedHierarchy.receivedAt, updatedAt)}ms)`);
+          if (!freshness.isFresh) {
+            const staleReference = freshness.usesUpdatedAt ? freshness.updatedAt : this.cachedHierarchy.receivedAt;
+            logger.debug(`[ACCESSIBILITY_SERVICE] Cache rejected: ${freshness.usesUpdatedAt ? "updatedAt" : "receivedAt"} ${staleReference} < ${minTimestamp}`);
             // Fall through to wait for fresh data or sync
           } else {
             const isFresh = cacheAge < 1000; // Consider fresh if less than 1 second old
             const duration = Date.now() - startTime;
-            logger.debug(`[ACCESSIBILITY_SERVICE] Cache accepted in ${duration}ms: receivedAt=${this.cachedHierarchy.receivedAt} (>=${minTimestamp}? ${receivedAfterAction}), updatedAt=${updatedAt} (>=${minTimestamp}? ${updatedAfterAction}), age=${cacheAge}ms, fresh=${isFresh}`);
+            logger.debug(
+              `[ACCESSIBILITY_SERVICE] Cache accepted in ${duration}ms: ` +
+              `receivedAt=${this.cachedHierarchy.receivedAt}, ` +
+              `updatedAt=${updatedAt}, age=${cacheAge}ms, fresh=${isFresh}`
+            );
 
             return {
               hierarchy: this.cachedHierarchy.hierarchy,
@@ -890,15 +921,17 @@ export class AccessibilityServiceClient implements AccessibilityService {
       // because the caller requires data newer than minTimestamp (e.g., after an action like inputText)
       // Cache is rejected only if BOTH timestamps indicate stale data (to handle clock skew)
       const cacheRejected = minTimestamp > 0 && this.cachedHierarchy &&
-        this.cachedHierarchy.receivedAt < minTimestamp &&
-        this.cachedHierarchy.hierarchy.updatedAt < minTimestamp;
+        !this.evaluateMinTimestamp(this.cachedHierarchy, minTimestamp, true).isFresh;
       const shouldWait = (waitForFresh || cacheRejected) && (!skipWaitForFresh || cacheRejected) && !this.shouldSkipWebSocketWait();
       if (shouldWait) {
         // Use minTimestamp if provided, otherwise use startTime
         const waitMinTimestamp = minTimestamp > 0 ? minTimestamp : startTime;
+        const useDeviceTimestamp = minTimestamp > 0;
         logger.debug(`[ACCESSIBILITY_SERVICE] Waiting up to ${timeout}ms for fresh hierarchy data (must be newer than ${waitMinTimestamp})`);
 
-        const freshData = await perf.track("waitForFresh", () => this.waitForFreshData(timeout, waitMinTimestamp));
+        const freshData = await perf.track("waitForFresh", () =>
+          this.waitForFreshData(timeout, waitMinTimestamp, useDeviceTimestamp)
+        );
         const duration = Date.now() - startTime;
 
         if (freshData) {
@@ -955,7 +988,11 @@ export class AccessibilityServiceClient implements AccessibilityService {
    * @param minTimestamp - Minimum timestamp the data must have (request start time)
    * @returns CachedHierarchy if fresh data received, null on timeout or screen off
    */
-  private async waitForFreshData(timeout: number, minTimestamp: number): Promise<CachedHierarchy | null> {
+  private async waitForFreshData(
+    timeout: number,
+    minTimestamp: number,
+    useDeviceTimestamp: boolean
+  ): Promise<CachedHierarchy | null> {
     const startTime = this.timer.now();
     const checkInterval = 50; // Check every 50ms
     const screenCheckInterval = 1000; // Check screen state every 1 second
@@ -971,12 +1008,11 @@ export class AccessibilityServiceClient implements AccessibilityService {
         // Check if we received data that was updated AFTER our request started
         // This ensures we get fresh pushed data, not stale cached data
         if (this.cachedHierarchy) {
-          const receivedAfterRequest = this.cachedHierarchy.receivedAt > minTimestamp;
-          const updatedAfterRequest = this.cachedHierarchy.hierarchy.updatedAt > minTimestamp;
+          const freshness = this.evaluateMinTimestamp(this.cachedHierarchy, minTimestamp, useDeviceTimestamp);
 
-          if (receivedAfterRequest || updatedAfterRequest) {
+          if (freshness.isFresh) {
             this.timer.clearInterval(intervalId);
-            logger.debug(`[ACCESSIBILITY_SERVICE] Fresh data received: receivedAt=${this.cachedHierarchy.receivedAt} (>${minTimestamp}? ${receivedAfterRequest}), updatedAt=${this.cachedHierarchy.hierarchy.updatedAt} (>${minTimestamp}? ${updatedAfterRequest})`);
+            logger.debug(`[ACCESSIBILITY_SERVICE] Fresh data received: receivedAt=${this.cachedHierarchy.receivedAt}, updatedAt=${this.cachedHierarchy.hierarchy.updatedAt}`);
             resolve(this.cachedHierarchy);
             return;
           }

--- a/src/features/observe/ObserveScreen.ts
+++ b/src/features/observe/ObserveScreen.ts
@@ -397,6 +397,23 @@ export class ObserveScreen {
   }
 
   /**
+   * Resolve observation timestamp in milliseconds (device time if available).
+   */
+  private resolveObservationTimestampMs(result: ObserveResult): number | undefined {
+    const candidate = result.viewHierarchy?.updatedAt ?? result.updatedAt;
+    if (typeof candidate === "number" && !Number.isNaN(candidate)) {
+      return candidate;
+    }
+    if (typeof candidate === "string") {
+      const parsed = Date.parse(candidate);
+      if (!Number.isNaN(parsed)) {
+        return parsed;
+      }
+    }
+    return undefined;
+  }
+
+  /**
    * Get the most recent cached observe result from memory or disk cache
    * @returns Promise<ObserveResult> - The most recent cached observe result
    */
@@ -832,6 +849,21 @@ export class ObserveScreen {
       await perf.track("cacheResult", () => this.cacheObserveResult(result));
 
       perf.end();
+
+      const requestedAfter = minTimestamp > 0 ? minTimestamp : undefined;
+      const actualTimestamp = this.resolveObservationTimestampMs(result);
+      const isFresh = requestedAfter === undefined
+        ? true
+        : actualTimestamp !== undefined && actualTimestamp >= requestedAfter;
+      const staleDurationMs = requestedAfter !== undefined && actualTimestamp !== undefined && actualTimestamp < requestedAfter
+        ? requestedAfter - actualTimestamp
+        : undefined;
+      result.freshness = {
+        requestedAfter,
+        actualTimestamp,
+        isFresh,
+        staleDurationMs
+      };
 
       // Attach performance timing if enabled (with filtering and truncation)
       const timings = perf.getTimings();

--- a/src/models/ObserveResult.ts
+++ b/src/models/ObserveResult.ts
@@ -98,4 +98,21 @@ export interface ObserveResult {
    * Contains WCAG 2.1 violation detection and compliance checking
    */
   accessibilityAudit?: AccessibilityAuditResult;
+
+  /**
+   * Freshness metadata for the observation
+   * Helps agents understand if the data reflects a recent interaction
+   */
+  freshness?: {
+    /** Minimum timestamp requested for freshness (milliseconds since epoch, device time if available) */
+    requestedAfter?: number;
+    /** Actual timestamp of the observation (milliseconds since epoch) */
+    actualTimestamp?: number;
+    /** Whether actualTimestamp satisfied requestedAfter (or true when no request was made) */
+    isFresh: boolean;
+    /** How stale the observation was in milliseconds, if stale */
+    staleDurationMs?: number;
+    /** Optional warning when freshness could not be guaranteed */
+    warning?: string;
+  };
 }

--- a/src/utils/android-cmdline-tools/AdbClient.ts
+++ b/src/utils/android-cmdline-tools/AdbClient.ts
@@ -195,6 +195,37 @@ export class AdbClient implements AdbExecutor {
   }
 
   /**
+   * Get device time in milliseconds since epoch.
+   * Falls back to host time if the device timestamp cannot be retrieved.
+   */
+  async getDeviceTimestampMs(): Promise<number> {
+    try {
+      const result = await this.executeCommand("shell date +%s%3N");
+      const trimmed = result.stdout.trim();
+      const parsed = parseInt(trimmed, 10);
+      if (!Number.isNaN(parsed) && parsed > 0) {
+        return parsed;
+      }
+    } catch (error) {
+      logger.debug(`[ADB] Failed to read device time with ms precision: ${error}`);
+    }
+
+    try {
+      const result = await this.executeCommand("shell date +%s");
+      const trimmed = result.stdout.trim();
+      const parsed = parseInt(trimmed, 10);
+      if (!Number.isNaN(parsed) && parsed > 0) {
+        return parsed * 1000;
+      }
+    } catch (error) {
+      logger.debug(`[ADB] Failed to read device time in seconds: ${error}`);
+    }
+
+    logger.debug("[ADB] Falling back to host time for device timestamp");
+    return Date.now();
+  }
+
+  /**
    * Internal implementation of command execution
    * @param command - The ADB command to execute
    * @param timeoutMs - Optional timeout in milliseconds


### PR DESCRIPTION
## Summary
This PR fixes stale view hierarchies after interactions by improving observation freshness guarantees and surfacing explicit freshness metadata to agents.

## What changed
- **Device-time action timestamps**: `BaseVisualChange` now uses device time (with safe fallback) to establish the minimum freshness window for post‑action observations.
- **Observation freshness metadata**: `ObserveResult` now includes a `freshness` block with `requestedAfter`, `actualTimestamp`, `isFresh`, `staleDurationMs`, and optional `warning` to make staleness explicit to agents.
- **Retry when stale or unchanged**: `BaseVisualChange` retries observations with backoff when data appears stale or unchanged after an action, and logs warnings when freshness can’t be guaranteed.
- **Freshness checks prefer device timestamps**: `AccessibilityServiceClient` now validates minTimestamp using device `updatedAt` when provided, falling back to host receive time only when device time isn’t available. Direct observe calls without a minTimestamp retain their existing semantics.
- **Device time helper**: `AdbClient` adds `getDeviceTimestampMs()` with robust fallbacks.

## Why
Agents were frequently getting stale hierarchy data after interactions due to clock skew, async UI updates, and caching races. These changes bias freshness checks toward device timestamps, add retry logic, and provide explicit staleness indicators so agents can make informed decisions.

## Files touched
- `src/features/action/BaseVisualChange.ts`
- `src/features/observe/ObserveScreen.ts`
- `src/features/observe/AccessibilityServiceClient.ts`
- `src/models/ObserveResult.ts`
- `src/utils/android-cmdline-tools/AdbClient.ts`

## Tests
- `bun test`

## Notes
- Direct observe calls (no minTimestamp) still use host receive time to determine “freshness,” preserving existing behavior.
- Post‑action observes now prefer device `updatedAt` to avoid host/device clock skew.
