### PR TITLE
Fix listApps system app dedupe

### DIFF
--- a/src/features/observe/ListInstalledApps.ts
+++ b/src/features/observe/ListInstalledApps.ts
@@ -1,6 +1,6 @@
 import { AdbClient } from "../../utils/android-cmdline-tools/AdbClient";
 import { logger } from "../../utils/logger";
-import { ActionableError, BootedDevice, InstalledApp } from "../../models";
+import { ActionableError, BootedDevice, InstalledAppsByProfile, SystemInstalledApp } from "../../models";
 import { SimCtlClient } from "../../utils/ios-cmdline-tools/SimCtlClient";
 
 export class ListInstalledApps {
@@ -33,7 +33,7 @@ export class ListInstalledApps {
         case "android":
           // For backward compatibility, just return package names
           const detailedApps = await this.executeDetailed();
-          return detailedApps.map(app => app.packageName);
+          return this.flattenPackageNames(detailedApps);
         default:
           throw new ActionableError(`Unsupported platform: ${this.device.platform}`);
       }
@@ -44,18 +44,18 @@ export class ListInstalledApps {
   }
 
   /**
-   * List all installed packages on Android with detailed user profile information
-   * Returns apps from all user profiles (personal, work, etc.) with foreground/recent status
-   * @returns Promise with list of installed app details
+   * List installed packages on Android grouped by user profile, with system apps deduped.
+   * @returns Promise with grouped installed app details
    */
-  async executeDetailed(): Promise<InstalledApp[]> {
+  async executeDetailed(): Promise<InstalledAppsByProfile> {
     if (this.device.platform !== "android") {
       logger.warn("executeDetailed() is only supported on Android");
-      return [];
+      return { profiles: {}, system: [] };
     }
 
     try {
-      const installedApps: InstalledApp[] = [];
+      const installedApps: InstalledAppsByProfile = { profiles: {}, system: [] };
+      const systemAppsMap = new Map<string, SystemInstalledApp>();
 
       // Get all users on the device
       logger.info("[ListInstalledApps] Getting list of users...");
@@ -69,30 +69,46 @@ export class ListInstalledApps {
       for (const user of users) {
         try {
           logger.info(`[ListInstalledApps] Listing packages for user ${user.userId}...`);
-          const { stdout } = await this.adb.executeCommand(
-            `shell pm list packages --user ${user.userId}`
-          );
-          logger.info(`[ListInstalledApps] Got ${stdout.length} chars of output for user ${user.userId}`);
 
-          const packages = stdout
-            .split("\n")
-            .filter(line => line.startsWith("package:"))
-            .map(line => line.replace("package:", "").trim())
-            .filter(pkg => pkg.length > 0);
+          const systemPackages = await this.listPackagesForUser(user.userId, "-s");
+          const userPackages = await this.listPackagesForUser(user.userId, "-3");
 
-          logger.info(`[ListInstalledApps] Found ${packages.length} package(s) for user ${user.userId}`);
+          logger.info(`[ListInstalledApps] Found ${userPackages.length} user package(s) and ${systemPackages.length} system package(s) for user ${user.userId}`);
 
-          for (const packageName of packages) {
+          installedApps.profiles[user.userId] = installedApps.profiles[user.userId] || [];
+
+          for (const packageName of userPackages) {
             const isForeground = foregroundApp !== null &&
                                  foregroundApp.packageName === packageName &&
                                  foregroundApp.userId === user.userId;
 
-            installedApps.push({
+            installedApps.profiles[user.userId].push({
               packageName,
               userId: user.userId,
               foreground: isForeground,
               recent: false // TODO: Implement recent app detection
             });
+          }
+
+          for (const packageName of systemPackages) {
+            const isForeground = foregroundApp !== null &&
+                                 foregroundApp.packageName === packageName &&
+                                 foregroundApp.userId === user.userId;
+
+            const existing = systemAppsMap.get(packageName);
+            if (existing) {
+              if (!existing.userIds.includes(user.userId)) {
+                existing.userIds.push(user.userId);
+              }
+              existing.foreground = existing.foreground || isForeground;
+            } else {
+              systemAppsMap.set(packageName, {
+                packageName,
+                userIds: [user.userId],
+                foreground: isForeground,
+                recent: false // TODO: Implement recent app detection
+              });
+            }
           }
         } catch (error) {
           logger.warn(`Failed to list packages for user ${user.userId}:`, error);
@@ -100,11 +116,42 @@ export class ListInstalledApps {
         }
       }
 
-      logger.info(`Found ${installedApps.length} installed app(s) across ${users.length} user(s)`);
+      installedApps.system = Array.from(systemAppsMap.values());
+      const profileAppCount = Object.values(installedApps.profiles).reduce((count, apps) => count + apps.length, 0);
+
+      logger.info(`Found ${profileAppCount} user app(s) across ${users.length} user(s); ${installedApps.system.length} system app(s) deduped`);
       return installedApps;
     } catch (error) {
       logger.warn("Failed to list installed apps with details:", error);
-      return [];
+      return { profiles: {}, system: [] };
     }
+  }
+
+  private async listPackagesForUser(userId: number, filterFlag: "-s" | "-3"): Promise<string[]> {
+    const { stdout } = await this.adb.executeCommand(
+      `shell pm list packages ${filterFlag} --user ${userId}`
+    );
+    return this.parsePackages(stdout);
+  }
+
+  private parsePackages(stdout: string): string[] {
+    return stdout
+      .split("\n")
+      .filter(line => line.startsWith("package:"))
+      .map(line => line.replace("package:", "").trim())
+      .filter(pkg => pkg.length > 0);
+  }
+
+  private flattenPackageNames(detailedApps: InstalledAppsByProfile): string[] {
+    const packageNames = new Set<string>();
+    for (const apps of Object.values(detailedApps.profiles)) {
+      for (const app of apps) {
+        packageNames.add(app.packageName);
+      }
+    }
+    for (const app of detailedApps.system) {
+      packageNames.add(app.packageName);
+    }
+    return Array.from(packageNames);
   }
 }

--- a/src/models/InstalledApp.ts
+++ b/src/models/InstalledApp.ts
@@ -25,3 +25,37 @@ export interface InstalledApp {
    */
   recent: boolean;
 }
+
+/**
+ * Represents a system app installed across one or more Android user profiles.
+ */
+export interface SystemInstalledApp {
+  /**
+   * Package name (e.g., "com.android.settings")
+   */
+  packageName: string;
+
+  /**
+   * Android user IDs where this system app is installed
+   */
+  userIds: number[];
+
+  /**
+   * Whether this app instance is currently in the foreground
+   */
+  foreground: boolean;
+
+  /**
+   * Whether this app instance was recently used
+   * (Placeholder for future implementation - currently always false)
+   */
+  recent: boolean;
+}
+
+/**
+ * Grouped installed apps by profile with system apps deduped.
+ */
+export interface InstalledAppsByProfile {
+  profiles: Record<number, InstalledApp[]>;
+  system: SystemInstalledApp[];
+}

--- a/src/server/observeTools.ts
+++ b/src/server/observeTools.ts
@@ -59,9 +59,12 @@ export function registerObserveTools() {
       // For iOS, return simple package names
       if (device.platform === "android") {
         const apps = await listInstalledApps.executeDetailed();
+        const profileAppCount = Object.values(apps.profiles).reduce((count, profileApps) => count + profileApps.length, 0);
+        const profileCount = Object.keys(apps.profiles).length;
         return createJSONToolResponse({
-          message: `Listed ${apps.length} app installation(s) across all user profiles`,
-          apps
+          message: `Listed ${profileAppCount} user app(s) across ${profileCount} profile(s); ${apps.system.length} system app(s) deduped`,
+          profiles: apps.profiles,
+          system: apps.system
         });
       } else {
         const apps = await listInstalledApps.execute();
@@ -85,7 +88,7 @@ export function registerObserveTools() {
 
   ToolRegistry.registerDeviceAware(
     "listApps",
-    "List all apps installed on the device. For Android, returns detailed info including userId (0=personal, 10+=work profile), foreground status, and recent status. For iOS, returns package names only.",
+    "List all apps installed on the device. For Android, returns user apps grouped by profile and system apps under a separate key with profile coverage. For iOS, returns package names only.",
     listAppsSchema,
     listAppsHandler
   );

--- a/test/features/observe/ListInstalledApps.test.ts
+++ b/test/features/observe/ListInstalledApps.test.ts
@@ -24,8 +24,12 @@ describe("ListInstalledApps", function() {
     test("should list all installed packages", async function() {
       // Set up single user with packages
       fakeAdb.setUsers([{ userId: 0, name: "Owner", flags: 13, running: true }]);
-      fakeAdb.setCommandResponse("shell pm list packages --user 0", {
-        stdout: "package:com.android.chrome\npackage:com.google.android.gms\npackage:com.example.myapp\n",
+      fakeAdb.setCommandResponse("shell pm list packages -s --user 0", {
+        stdout: "package:com.android.chrome\npackage:com.google.android.gms\n",
+        stderr: ""
+      });
+      fakeAdb.setCommandResponse("shell pm list packages -3 --user 0", {
+        stdout: "package:com.example.myapp\n",
         stderr: ""
       });
 
@@ -40,7 +44,7 @@ describe("ListInstalledApps", function() {
 
     test("should filter out empty lines and non-package lines", async function() {
       fakeAdb.setUsers([{ userId: 0, name: "Owner", flags: 13, running: true }]);
-      fakeAdb.setCommandResponse("shell pm list packages --user 0", {
+      fakeAdb.setCommandResponse("shell pm list packages -3 --user 0", {
         stdout: "package:com.example.app\n\nsome other line\npackage:com.test.app\n",
         stderr: ""
       });
@@ -54,9 +58,13 @@ describe("ListInstalledApps", function() {
 
     test("should handle adb command failure gracefully", async function() {
       fakeAdb.setUsers([{ userId: 0, name: "Owner", flags: 13, running: true }]);
-      fakeAdb.setCommandResponse("shell pm list packages --user 0", {
+      fakeAdb.setCommandResponse("shell pm list packages -3 --user 0", {
         stdout: "",
         stderr: "error"
+      });
+      fakeAdb.setCommandResponse("shell pm list packages -s --user 0", {
+        stdout: "",
+        stderr: ""
       });
 
       const result = await listInstalledApps.execute();
@@ -67,8 +75,12 @@ describe("ListInstalledApps", function() {
 
     test("should trim package names correctly", async function() {
       fakeAdb.setUsers([{ userId: 0, name: "Owner", flags: 13, running: true }]);
-      fakeAdb.setCommandResponse("shell pm list packages --user 0", {
+      fakeAdb.setCommandResponse("shell pm list packages -3 --user 0", {
         stdout: "package: com.example.app \npackage:com.test.app\t\n",
+        stderr: ""
+      });
+      fakeAdb.setCommandResponse("shell pm list packages -s --user 0", {
+        stdout: "",
         stderr: ""
       });
 
@@ -90,34 +102,79 @@ describe("ListInstalledApps", function() {
       fakeAdb.setUsers(users);
 
       // Configure packages for each user
-      fakeAdb.setCommandResponse("shell pm list packages --user 0", {
-        stdout: "package:com.android.chrome\npackage:com.example.personalapp\n",
+      fakeAdb.setCommandResponse("shell pm list packages -s --user 0", {
+        stdout: "package:com.android.chrome\n",
         stderr: ""
       });
-      fakeAdb.setCommandResponse("shell pm list packages --user 10", {
-        stdout: "package:com.example.workapp\npackage:com.android.chrome\n",
+      fakeAdb.setCommandResponse("shell pm list packages -3 --user 0", {
+        stdout: "package:com.example.personalapp\n",
+        stderr: ""
+      });
+      fakeAdb.setCommandResponse("shell pm list packages -s --user 10", {
+        stdout: "package:com.android.chrome\n",
+        stderr: ""
+      });
+      fakeAdb.setCommandResponse("shell pm list packages -3 --user 10", {
+        stdout: "package:com.example.workapp\n",
         stderr: ""
       });
 
       const result = await listInstalledApps.executeDetailed();
 
-      expect(Array.isArray(result)).toBe(true);
-      expect(result).toHaveLength(4);
+      expect(typeof result).toBe("object");
+      expect(result).toHaveProperty("profiles");
+      expect(result).toHaveProperty("system");
 
       // Check personal apps
-      const personalChrome = result.find(app => app.packageName === "com.android.chrome" && app.userId === 0);
-      expect(personalChrome).toBeDefined();
-      expect(personalChrome?.foreground).toBe(false);
-
-      const personalApp = result.find(app => app.packageName === "com.example.personalapp" && app.userId === 0);
+      const personalApps = result.profiles[0];
+      expect(Array.isArray(personalApps)).toBe(true);
+      const personalApp = personalApps.find(app => app.packageName === "com.example.personalapp");
       expect(personalApp).toBeDefined();
+      expect(personalApp?.foreground).toBe(false);
 
       // Check work profile apps
-      const workChrome = result.find(app => app.packageName === "com.android.chrome" && app.userId === 10);
-      expect(workChrome).toBeDefined();
-
-      const workApp = result.find(app => app.packageName === "com.example.workapp" && app.userId === 10);
+      const workApps = result.profiles[10];
+      expect(Array.isArray(workApps)).toBe(true);
+      const workApp = workApps.find(app => app.packageName === "com.example.workapp");
       expect(workApp).toBeDefined();
+
+      // Check system apps are deduped
+      expect(result.system).toHaveLength(1);
+      expect(result.system[0].packageName).toBe("com.android.chrome");
+      expect(result.system[0].userIds.sort()).toEqual([0, 10]);
+    });
+
+    test("should dedupe system apps across profiles", async function() {
+      const users: AndroidUser[] = [
+        { userId: 0, name: "Owner", flags: 13, running: true },
+        { userId: 10, name: "Work profile", flags: 30, running: true }
+      ];
+      fakeAdb.setUsers(users);
+      fakeAdb.setForegroundApp({ packageName: "com.android.settings", userId: 10 });
+
+      fakeAdb.setCommandResponse("shell pm list packages -s --user 0", {
+        stdout: "package:com.android.settings\n",
+        stderr: ""
+      });
+      fakeAdb.setCommandResponse("shell pm list packages -3 --user 0", {
+        stdout: "",
+        stderr: ""
+      });
+      fakeAdb.setCommandResponse("shell pm list packages -s --user 10", {
+        stdout: "package:com.android.settings\n",
+        stderr: ""
+      });
+      fakeAdb.setCommandResponse("shell pm list packages -3 --user 10", {
+        stdout: "",
+        stderr: ""
+      });
+
+      const result = await listInstalledApps.executeDetailed();
+
+      expect(result.system).toHaveLength(1);
+      expect(result.system[0].packageName).toBe("com.android.settings");
+      expect(result.system[0].userIds.sort()).toEqual([0, 10]);
+      expect(result.system[0].foreground).toBe(true);
     });
 
     test("should mark foreground app correctly", async function() {
@@ -130,21 +187,29 @@ describe("ListInstalledApps", function() {
       // Set foreground app in work profile
       fakeAdb.setForegroundApp({ packageName: "com.example.workapp", userId: 10 });
 
-      fakeAdb.setCommandResponse("shell pm list packages --user 0", {
+      fakeAdb.setCommandResponse("shell pm list packages -3 --user 0", {
         stdout: "package:com.example.personalapp\n",
         stderr: ""
       });
-      fakeAdb.setCommandResponse("shell pm list packages --user 10", {
+      fakeAdb.setCommandResponse("shell pm list packages -s --user 0", {
+        stdout: "",
+        stderr: ""
+      });
+      fakeAdb.setCommandResponse("shell pm list packages -3 --user 10", {
         stdout: "package:com.example.workapp\n",
+        stderr: ""
+      });
+      fakeAdb.setCommandResponse("shell pm list packages -s --user 10", {
+        stdout: "",
         stderr: ""
       });
 
       const result = await listInstalledApps.executeDetailed();
 
-      const personalApp = result.find(app => app.packageName === "com.example.personalapp");
+      const personalApp = result.profiles[0].find(app => app.packageName === "com.example.personalapp");
       expect(personalApp?.foreground).toBe(false);
 
-      const workApp = result.find(app => app.packageName === "com.example.workapp");
+      const workApp = result.profiles[10].find(app => app.packageName === "com.example.workapp");
       expect(workApp?.foreground).toBe(true);
     });
 
@@ -154,18 +219,23 @@ describe("ListInstalledApps", function() {
       ];
       fakeAdb.setUsers(users);
 
-      fakeAdb.setCommandResponse("shell pm list packages --user 0", {
-        stdout: "package:com.android.chrome\npackage:com.example.app\n",
+      fakeAdb.setCommandResponse("shell pm list packages -s --user 0", {
+        stdout: "package:com.android.chrome\n",
+        stderr: ""
+      });
+      fakeAdb.setCommandResponse("shell pm list packages -3 --user 0", {
+        stdout: "package:com.example.app\n",
         stderr: ""
       });
 
       const result = await listInstalledApps.executeDetailed();
 
-      expect(result).toHaveLength(2);
-      expect(result.every(app => app.userId === 0)).toBe(true);
+      expect(result.profiles[0]).toHaveLength(1);
+      expect(result.profiles[0][0].userId).toBe(0);
+      expect(result.system).toHaveLength(1);
     });
 
-    test("should return empty array for non-Android platforms", async function() {
+    test("should return empty result for non-Android platforms", async function() {
       const iosDevice: BootedDevice = {
         deviceId: "test-device",
         platform: "ios"
@@ -174,8 +244,7 @@ describe("ListInstalledApps", function() {
       const iosListApps = new ListInstalledApps(iosDevice, fakeAdb);
       const result = await iosListApps.executeDetailed();
 
-      expect(Array.isArray(result)).toBe(true);
-      expect(result).toHaveLength(0);
+      expect(result).toEqual({ profiles: {}, system: [] });
     });
   });
 });


### PR DESCRIPTION
## Summary
- group Android listApps results by profile and dedupe system apps under a system key
- update listApps tool response messaging
- add coverage for new grouping/dedupe behavior

## Testing
- bun test test/features/observe/ListInstalledApps.test.ts
