### PR TITLE
Add tapOn await option with strict CLI flag

### DIFF
--- a/src/daemon/manager.ts
+++ b/src/daemon/manager.ts
@@ -79,6 +79,9 @@ export class DaemonManager {
     if (options.debugPerf) {
       args.push("--debug-perf");
     }
+    if (options.strictAwait) {
+      args.push("--strict-await");
+    }
 
     // Create secure temp directory with random suffix to prevent symlink attacks
     const tempDir = mkdtempSync(join(tmpdir(), "auto-mobile-daemon-"));
@@ -311,6 +314,8 @@ export async function runDaemonCommand(
             options.debug = true;
           } else if (args[i] === "--debug-perf") {
             options.debugPerf = true;
+          } else if (args[i] === "--strict-await") {
+            options.strictAwait = true;
           }
         }
 
@@ -351,6 +356,8 @@ export async function runDaemonCommand(
             options.debug = true;
           } else if (args[i] === "--debug-perf") {
             options.debugPerf = true;
+          } else if (args[i] === "--strict-await") {
+            options.strictAwait = true;
           }
         }
 

--- a/src/daemon/types.ts
+++ b/src/daemon/types.ts
@@ -74,6 +74,8 @@ export interface DaemonOptions {
   debug?: boolean;
   /** Enable debug performance tracking */
   debugPerf?: boolean;
+  /** Enable strict await mode for tapOn await timeouts */
+  strictAwait?: boolean;
 }
 
 /**

--- a/src/features/action/TapOnElement.ts
+++ b/src/features/action/TapOnElement.ts
@@ -14,7 +14,7 @@ import { logger } from "../../utils/logger";
 import { AccessibilityServiceClient } from "../observe/AccessibilityServiceClient";
 import { AxeClient } from "../../utils/ios-cmdline-tools/AxeClient";
 import { WebDriverAgent } from "../../utils/ios-cmdline-tools/WebDriverAgent";
-import { createGlobalPerformanceTracker } from "../../utils/PerformanceTracker";
+import { createGlobalPerformanceTracker, NoOpPerformanceTracker } from "../../utils/PerformanceTracker";
 import { VisionFallback, DEFAULT_VISION_CONFIG, type VisionFallbackConfig } from "../../vision/index";
 import { TakeScreenshot } from "../observe/TakeScreenshot";
 import { buildElementSearchDebugContext } from "../../utils/DebugContextBuilder";
@@ -28,6 +28,7 @@ export class TapOnElement extends BaseVisualChange {
   private accessibilityService: AccessibilityServiceClient;
   private visionConfig: VisionFallbackConfig;
   private static readonly MAX_ATTEMPTS = 5;
+  private static readonly AWAIT_POLL_INTERVAL_MS = 100;
 
   constructor(
     device: BootedDevice,
@@ -303,7 +304,42 @@ export class TapOnElement extends BaseVisualChange {
           ...metadata
         };
       }
-      return result;
+      if (!result.success || !options.await?.element) {
+        return result;
+      }
+
+      if (!options.await.element.id && !options.await.element.text) {
+        return {
+          ...result,
+          success: false,
+          error: "await.element requires either id or text",
+          awaitTimeout: true,
+          awaitDuration: 0
+        };
+      }
+
+      const awaitOutcome = await this.waitForAwaitElement(
+        options.await,
+        result.observation
+      );
+
+      const awaitResult: TapOnElementResult = {
+        ...result,
+        awaitedElement: awaitOutcome.awaitedElement,
+        awaitDuration: awaitOutcome.awaitDuration,
+        awaitTimeout: awaitOutcome.awaitTimeout,
+        observation: awaitOutcome.observation || result.observation
+      };
+
+      if (awaitOutcome.awaitTimeout && options.strictAwait) {
+        return {
+          ...awaitResult,
+          success: false,
+          error: "Tap succeeded but awaited element not found within timeout"
+        };
+      }
+
+      return awaitResult;
     } catch (error) {
       perf.end();
 
@@ -582,5 +618,91 @@ export class TapOnElement extends BaseVisualChange {
     }
 
     return selectionFound;
+  }
+
+  private async waitForAwaitElement(
+    awaitOptions: NonNullable<TapOnElementOptions["await"]>,
+    initialObservation?: ObserveResult
+  ): Promise<{
+    awaitedElement?: Element;
+    awaitDuration: number;
+    awaitTimeout: boolean;
+    observation?: ObserveResult;
+  }> {
+    const startTime = Date.now();
+    const timeoutMs = awaitOptions.timeout ?? 5000;
+    const queryOptions = {
+      text: awaitOptions.element.text,
+      elementId: awaitOptions.element.id
+    };
+
+    if (initialObservation?.viewHierarchy) {
+      const existing = this.findAwaitElement(awaitOptions, initialObservation.viewHierarchy);
+      if (existing) {
+        return {
+          awaitedElement: existing,
+          awaitDuration: Date.now() - startTime,
+          awaitTimeout: false,
+          observation: initialObservation
+        };
+      }
+    }
+
+    let lastObservation: ObserveResult | undefined;
+
+    while (Date.now() - startTime < timeoutMs) {
+      const observation = await this.observeScreen.execute(
+        queryOptions,
+        new NoOpPerformanceTracker(),
+        false,
+        startTime
+      );
+      lastObservation = observation;
+
+      if (observation.viewHierarchy) {
+        const found = this.findAwaitElement(awaitOptions, observation.viewHierarchy);
+        if (found) {
+          return {
+            awaitedElement: found,
+            awaitDuration: Date.now() - startTime,
+            awaitTimeout: false,
+            observation
+          };
+        }
+      }
+
+      await new Promise(resolve => setTimeout(resolve, TapOnElement.AWAIT_POLL_INTERVAL_MS));
+    }
+
+    return {
+      awaitDuration: Date.now() - startTime,
+      awaitTimeout: true,
+      observation: lastObservation
+    };
+  }
+
+  private findAwaitElement(
+    awaitOptions: NonNullable<TapOnElementOptions["await"]>,
+    viewHierarchy: ViewHierarchyResult
+  ): Element | null {
+    if (awaitOptions.element.id) {
+      return this.elementUtils.findElementByResourceId(
+        viewHierarchy,
+        awaitOptions.element.id,
+        undefined
+      );
+    }
+
+    if (awaitOptions.element.text) {
+      return this.elementUtils.findElementByText(
+        viewHierarchy,
+        awaitOptions.element.text,
+        undefined,
+        true,
+        false
+      );
+    }
+
+    return null;
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -67,6 +67,7 @@ function parseArgs(): {
   debug: boolean;
   uiPerfMode: boolean;
   memPerfAuditMode: boolean;
+  strictAwait: boolean;
   a11yAuditMode: boolean;
   a11yLevel?: string;
   a11yFailureMode?: string;
@@ -110,6 +111,9 @@ function parseArgs(): {
 
   // Detect memory performance audit mode
   const memPerfAuditMode = args.includes("--mem-perf-audit");
+
+  // Detect strict await mode for tapOn await timeouts
+  const strictAwait = args.includes("--strict-await");
 
   // Detect accessibility audit mode
   const a11yAuditMode = args.includes("--accessibility-audit");
@@ -181,6 +185,7 @@ function parseArgs(): {
     debug,
     uiPerfMode,
     memPerfAuditMode,
+    strictAwait,
     a11yAuditMode,
     a11yLevel,
     a11yFailureMode,
@@ -564,6 +569,7 @@ async function main() {
       debug,
       uiPerfMode,
       memPerfAuditMode,
+      strictAwait,
       a11yAuditMode,
       a11yLevel,
       a11yFailureMode,
@@ -598,6 +604,11 @@ async function main() {
       logger.info("Memory performance audit mode enabled (--mem-perf-audit)");
     }
 
+    if (strictAwait) {
+      serverConfig.setStrictAwaitEnabled(true);
+      logger.info("Strict await mode enabled (--strict-await)");
+    }
+
     // Enable accessibility audit mode if --accessibility-audit flag is set
     if (a11yAuditMode) {
       const level = (a11yLevel as "A" | "AA" | "AAA" | undefined) || "AA";
@@ -622,6 +633,7 @@ async function main() {
         host: transport.host,
         debug,
         debugPerf,
+        strictAwait,
       });
       return;
     }

--- a/src/models/TapOnElementOptions.ts
+++ b/src/models/TapOnElementOptions.ts
@@ -22,4 +22,16 @@ export interface TapOnElementOptions {
     text?: string;
     elementId?: string;
   };
+
+  // Optional await for an element to appear after tap
+  await?: {
+    element: {
+      id?: string;
+      text?: string;
+    };
+    timeout?: number;
+  };
+
+  // Fail the tap if the awaited element is not found within the timeout
+  strictAwait?: boolean;
 }

--- a/src/models/TapOnElementResult.ts
+++ b/src/models/TapOnElementResult.ts
@@ -15,4 +15,7 @@ export interface TapOnElementResult {
   pressRecognized?: boolean;
   contextMenuOpened?: boolean;
   selectionStarted?: boolean;
+  awaitedElement?: Element;
+  awaitDuration?: number;
+  awaitTimeout?: boolean;
 }

--- a/src/server/interactionTools.ts
+++ b/src/server/interactionTools.ts
@@ -13,6 +13,7 @@ import { HomeScreen } from "../features/action/HomeScreen";
 import { Rotate } from "../features/action/Rotate";
 import { OpenURL } from "../features/action/OpenURL";
 import { ActionableError, BootedDevice, ViewHierarchyResult } from "../models";
+import { serverConfig } from "../utils/ServerConfig";
 import { ObserveScreen } from "../features/observe/ObserveScreen";
 import { createJSONToolResponse } from "../utils/toolUtils";
 import { Platform } from "../models";
@@ -62,6 +63,13 @@ export interface TapOnArgs {
     y?: number;
     text?: string;
     elementId?: string;
+  };
+  await?: {
+    element: {
+      id?: string;
+      text?: string;
+    };
+    timeout?: number;
   };
   platform: Platform;
 }
@@ -122,6 +130,13 @@ export const tapOnSchema = z.object({
     text: z.string().optional().describe("Text of the drag target element"),
     elementId: z.string().optional().describe("Element ID of the drag target element"),
   }).optional().describe("Drag target for long press drag action"),
+  await: z.object({
+    element: z.object({
+      id: z.string().optional().describe("Wait for element with this resource ID"),
+      text: z.string().optional().describe("Wait for element with this text"),
+    }).describe("Element to wait for after tap"),
+    timeout: z.number().optional().describe("Max wait time in ms (default: 5000)"),
+  }).optional().describe("Wait for an element to appear after tap"),
   platform: z.enum(["android", "ios"]).describe("Platform of the device"),
   // Framework parameters for device management (optional)
   sessionUuid: z.string().optional(),
@@ -394,6 +409,8 @@ export function registerInteractionTools() {
       action: args.action,
       duration: args.duration,
       dragTo: args.dragTo,
+      await: args.await,
+      strictAwait: serverConfig.isStrictAwaitEnabled(),
     }, progress);
 
     return createJSONToolResponse({

--- a/src/utils/ServerConfig.ts
+++ b/src/utils/ServerConfig.ts
@@ -11,6 +11,7 @@ class ServerConfig {
   private _uiPerfModeEnabled: boolean = false;
   private _accessibilityAuditConfig: AccessibilityAuditConfig | null = null;
   private _memPerfAuditEnabled: boolean = false;
+  private _strictAwaitEnabled: boolean = false;
 
   private constructor() {}
 
@@ -47,6 +48,14 @@ class ServerConfig {
 
   isMemPerfAuditEnabled(): boolean {
     return this._memPerfAuditEnabled;
+  }
+
+  setStrictAwaitEnabled(enabled: boolean): void {
+    this._strictAwaitEnabled = enabled;
+  }
+
+  isStrictAwaitEnabled(): boolean {
+    return this._strictAwaitEnabled;
   }
 }
 


### PR DESCRIPTION
## Summary
- add await support to tapOn to wait for next UI state
- report await duration/timeout in tapOn results
- enable strict await behavior via `--strict-await` CLI/daemon flag (kept internal; not exposed in tool schema)

## Testing
- not run
