### PR TITLE
Add AGENTS guide and Codex skills

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,21 @@
+# AutoMobile Codex Instructions
+
+## Project rules
+- TypeScript only; do not add JavaScript.
+- After implementation changes, run relevant validation commands.
+- Write terminal output to `scratch/` when command output is not visible in the session.
+- Validation guidance: `docs/ai/validation.md`.
+
+## Tooling and workflows
+- GitHub interactions use the GitHub CLI (`gh`).
+- Create or edit PRs with `gh pr create`/`gh pr edit` using `--body-file` to preserve newlines.
+- Android tasks run via the Gradle wrapper from `android/` (e.g., `(cd android && ./gradlew <task>)`).
+- Local validations live under `scripts/` (prefer existing scripts over ad-hoc checks).
+- Bun tasks are defined in `package.json` (run with `bun run <script>`).
+
+## Skills
+- github-cli: Use `gh` for PRs, issues, checks, and repo metadata. Path: `skills/github-cli/SKILL.md`.
+- gh-pr-workflow: Create/update PRs without mangling newlines. Path: `skills/gh-pr-workflow/SKILL.md`.
+- android-gradlew: Run Android tasks via `android/gradlew`. Path: `skills/android-gradlew/SKILL.md`.
+- local-validation-scripts: Use `scripts/` for local validations. Path: `skills/local-validation-scripts/SKILL.md`.
+- bun-tasks: Use `package.json` scripts with Bun. Path: `skills/bun-tasks/SKILL.md`.

--- a/skills/android-gradlew/SKILL.md
+++ b/skills/android-gradlew/SKILL.md
@@ -1,0 +1,12 @@
+---
+name: android-gradlew
+description: Use this skill for Android project tasks in the android/ subdirectory, including build, test, lint, and verification commands that must run via the Gradle wrapper.
+---
+
+# Android Gradle Wrapper
+
+Run Android tasks from the `android/` directory using the Gradle wrapper.
+
+- Use `(cd android && ./gradlew <task>)` for Android-only builds, tests, and lint.
+- Avoid running Gradle tasks from the repo root.
+- Prefer explicit tasks (e.g., `assemble`, `test`, `lint`, `connectedAndroidTest`) based on the requested verification.

--- a/skills/bun-tasks/SKILL.md
+++ b/skills/bun-tasks/SKILL.md
@@ -1,0 +1,12 @@
+---
+name: bun-tasks
+description: Use this skill when running or documenting repository tasks; package.json is the source of truth for Bun scripts and commands.
+---
+
+# Bun Tasks
+
+Use `package.json` scripts via Bun.
+
+- Check `package.json` for available scripts.
+- Run tasks with `bun run <script>`.
+- Prefer existing scripts over ad-hoc commands.

--- a/skills/gh-pr-workflow/SKILL.md
+++ b/skills/gh-pr-workflow/SKILL.md
@@ -1,0 +1,27 @@
+---
+name: gh-pr-workflow
+description: Use this skill when creating or updating GitHub pull requests so PR bodies preserve newlines and formatting, especially when using gh pr create or gh pr edit.
+---
+
+# PR Creation Without Newline Mangling
+
+Preserve PR body formatting by supplying a file to `gh`.
+
+- Write the PR body to a file (prefer `scratch/pr-body.md` when created in-session).
+- Create the PR with `gh pr create --title "..." --body-file scratch/pr-body.md`.
+- Update an existing PR with `gh pr edit --body-file scratch/pr-body.md`.
+- Avoid `--body "..."` with inline newlines; it often collapses or escapes formatting.
+
+Example:
+
+```bash
+cat <<'EOF_BODY' > scratch/pr-body.md
+## Summary
+- ...
+
+## Testing
+- ...
+EOF_BODY
+
+gh pr create --title "Your title" --body-file scratch/pr-body.md
+```

--- a/skills/github-cli/SKILL.md
+++ b/skills/github-cli/SKILL.md
@@ -1,0 +1,13 @@
+---
+name: github-cli
+description: Use this skill when interacting with GitHub for this repo (PRs, issues, checks, releases, or repository metadata). Prefer the GitHub CLI (gh) for all GitHub actions instead of web/API calls.
+---
+
+# GitHub CLI Usage
+
+Use `gh` for all GitHub interactions.
+
+- Prefer `gh pr view`, `gh pr list`, `gh pr create`, and `gh pr edit` for pull requests.
+- Prefer `gh issue list` and `gh issue view` for issues.
+- Prefer `gh pr checks` and `gh run view` for CI status and logs.
+- Avoid manual API calls unless `gh` cannot perform the task.

--- a/skills/local-validation-scripts/SKILL.md
+++ b/skills/local-validation-scripts/SKILL.md
@@ -1,0 +1,12 @@
+---
+name: local-validation-scripts
+description: Use this skill when running project validations; the scripts/ directory contains local validation helpers and should be used instead of reimplementing checks.
+---
+
+# Local Validation Scripts
+
+Use the scripts under `scripts/` for local validations.
+
+- Check `scripts/` for purpose-built validation commands before writing new ones.
+- Prefer `bash scripts/<path>.sh` when a validation exists there.
+- Keep validation output concise and report any manual fixes needed.


### PR DESCRIPTION
## Summary
- add AGENTS.md with project rules and tooling guidance
- add Codex skill files for gh usage, PR body workflow, Android gradlew, scripts validations, and bun tasks

## Testing
- not run (docs-only changes)
