### PR TITLE
Add swipeOn auto-targeting and tests

### DIFF
--- a/docs/MIGRATION_swipeOn.md
+++ b/docs/MIGRATION_swipeOn.md
@@ -37,7 +37,6 @@ This migration guide will help you transition from the old tools to the new unif
 {
   "tool": "swipeOn",
   "arguments": {
-    "screen": true,
     "direction": "up",
     "includeSystemInsets": false,
     "duration": 300,
@@ -47,7 +46,7 @@ This migration guide will help you transition from the old tools to the new unif
 ```
 
 **Changes:**
-- Add `"screen": true` to indicate full-screen swipe
+- Omit `container` to indicate a full-screen swipe
 - All other parameters remain the same
 
 ### 2. swipeOnElement → swipeOn
@@ -70,7 +69,9 @@ This migration guide will help you transition from the old tools to the new unif
 {
   "tool": "swipeOn",
   "arguments": {
-    "elementId": "com.example:id/carousel",
+    "container": {
+      "elementId": "com.example:id/carousel"
+    },
     "direction": "left",
     "duration": 300,
     "platform": "android"
@@ -79,8 +80,7 @@ This migration guide will help you transition from the old tools to the new unif
 ```
 
 **Changes:**
-- Remove `screen` field (or set to `false`)
-- Specify element via `elementId` or `text`
+- Specify the swipe target using `container.elementId` or `container.text`
 - Duration and direction remain the same
 
 ### 3. scroll (simple) → swipeOn
@@ -105,7 +105,9 @@ This migration guide will help you transition from the old tools to the new unif
 {
   "tool": "swipeOn",
   "arguments": {
-    "elementId": "com.example:id/list",
+    "container": {
+      "elementId": "com.example:id/list"
+    },
     "direction": "down",
     "speed": "normal",
     "platform": "android"
@@ -114,8 +116,7 @@ This migration guide will help you transition from the old tools to the new unif
 ```
 
 **Changes:**
-- Flatten `container.elementId` to just `elementId`
-- Can also use `containerText` instead of `containerElementId`
+- Keep `container.elementId` under `container`
 - Speed parameter remains the same
 
 ### 4. scroll (with lookFor) → swipeOn
@@ -145,7 +146,9 @@ This migration guide will help you transition from the old tools to the new unif
 {
   "tool": "swipeOn",
   "arguments": {
-    "containerElementId": "com.example:id/list",
+    "container": {
+      "elementId": "com.example:id/list"
+    },
     "direction": "down",
     "lookFor": {
       "text": "Submit",
@@ -159,7 +162,7 @@ This migration guide will help you transition from the old tools to the new unif
 ```
 
 **Changes:**
-- Change `container.elementId` to `containerElementId`
+- Keep `container.elementId` under `container`
 - `lookFor` structure remains the same
 - Speed and scrollMode parameters remain the same
 
@@ -184,7 +187,9 @@ This migration guide will help you transition from the old tools to the new unif
 {
   "tool": "swipeOn",
   "arguments": {
-    "containerText": "Products",
+    "container": {
+      "text": "Products"
+    },
     "direction": "up",
     "platform": "android"
   }
@@ -192,7 +197,7 @@ This migration guide will help you transition from the old tools to the new unif
 ```
 
 **Changes:**
-- Change `container.text` to `containerText`
+- Keep `container.text` under `container`
 
 ## Complete Parameter Reference
 
@@ -200,11 +205,10 @@ This migration guide will help you transition from the old tools to the new unif
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `screen` | boolean | No | Set to `true` for full-screen swipe |
-| `text` | string | No* | Text of element to swipe on |
-| `elementId` | string | No* | Resource ID of element to swipe on |
-| `containerElementId` | string | No | Container element ID to restrict search |
-| `containerText` | string | No | Container text to restrict search |
+| `container` | object | No | Container element to swipe within. REQUIRED for list scrolling; omit for full-screen swipes. |
+| `container.elementId` | string | No* | Resource ID of container element |
+| `container.text` | string | No* | Text within container element (finds nearest scrollable parent) |
+| `autoTarget` | boolean | No | Auto-target a scrollable container when `container` is omitted (default true). Set to false only if you intend to swipe the entire screen after autoTarget selected a list unexpectedly. |
 | `direction` | enum | **Yes** | Direction: "up", "down", "left", "right" |
 | `lookFor` | object | No | Search for element while scrolling |
 | `lookFor.text` | string | No* | Text to search for |
@@ -216,86 +220,111 @@ This migration guide will help you transition from the old tools to the new unif
 | `includeSystemInsets` | boolean | No | Include status/nav bars (screen swipes) |
 | `platform` | enum | **Yes** | Platform: "android", "ios" |
 
-\* At least one target type must be specified: `screen`, `text`, `elementId`, or use `lookFor` for scroll-until-visible
+\* When using `container`, specify exactly one of `container.elementId` or `container.text`
 
 ## Operation Modes
 
 The `swipeOn` tool automatically determines the operation mode based on parameters:
 
 ### 1. Screen Swipe Mode
-- **Trigger**: `screen: true`
+- **Trigger**: `container` omitted and no `lookFor`
 - **Behavior**: Swipes across the entire screen (respects system insets by default)
 - **Use case**: Page scrolling, app navigation
 
 ### 2. Element Swipe Mode
-- **Trigger**: `text` or `elementId` specified (without `lookFor`)
+- **Trigger**: `container` specified (without `lookFor`)
 - **Behavior**: Swipes within the specified element's bounds
 - **Use case**: Carousel swiping, horizontal scrolling
 
 ### 3. Scroll-Until-Visible Mode
-- **Trigger**: `lookFor` object specified
+- **Trigger**: `lookFor` object specified (optionally with `container`)
 - **Behavior**: Repeatedly scrolls until target element is found or timeout
 - **Use case**: Finding elements in long lists
 
 ## Best Practices
 
-1. **Use screen swipes for page navigation:**
+1. **Use screen swipes for page navigation (omit `container`; set `autoTarget: false` if a list is auto-selected):**
    ```json
-   { "screen": true, "direction": "up" }
+   { "direction": "up", "platform": "android", "autoTarget": false }
    ```
 
-2. **Use element swipes for carousels:**
+2. **Use container swipes for lists and feeds:**
    ```json
-   { "elementId": "carousel", "direction": "left" }
+   { "container": { "elementId": "list" }, "direction": "down", "platform": "android" }
    ```
 
-3. **Use lookFor for finding elements in lists:**
+3. **Use element swipes for carousels:**
+   ```json
+   { "container": { "elementId": "carousel" }, "direction": "left", "platform": "android" }
+   ```
+
+4. **Use lookFor for finding elements in lists:**
    ```json
    {
-     "containerElementId": "list",
+     "container": { "elementId": "list" },
      "direction": "down",
-     "lookFor": { "text": "Item 42" }
+     "lookFor": { "text": "Item 42" },
+     "platform": "android"
    }
    ```
 
-4. **Prefer `speed` over `duration` for readability:**
+5. **Prefer `speed` over `duration` for readability:**
    ```json
    { "speed": "fast" }  // Instead of { "duration": 100 }
    ```
 
-5. **Use `scrollMode: "a11y"` for faster scrolling on Android:**
+6. **Use `scrollMode: "a11y"` for faster scrolling on Android:**
    ```json
    { "scrollMode": "a11y" }  // ~50-150ms vs ~540ms with adb
    ```
 
 ## Common Migration Mistakes
 
-### ❌ Don't nest container in an object
+### ❌ Don't scroll lists without a container
 ```json
 {
-  "container": { "elementId": "list" }  // OLD WAY
+  "direction": "up",
+  "platform": "android"
 }
 ```
 
-### ✅ Use flat structure
+### ✅ Target the list container explicitly
 ```json
 {
-  "containerElementId": "list"  // NEW WAY
+  "container": { "elementId": "list" },
+  "direction": "up",
+  "platform": "android"
 }
 ```
 
-### ❌ Don't forget to specify target type
+### ❌ Don't disable autoTarget unless you want a full-screen swipe
 ```json
 {
-  "direction": "up"  // ERROR: No target specified
+  "direction": "up",
+  "autoTarget": false,
+  "platform": "android"
 }
 ```
 
-### ✅ Always specify at least one target
+### ✅ Keep autoTarget enabled for list scrolling when container is unknown
 ```json
 {
-  "screen": true,  // Target type
-  "direction": "up"
+  "direction": "up",
+  "platform": "android"
+}
+```
+
+### ❌ Don't set both container fields
+```json
+{
+  "container": { "elementId": "list", "text": "Items" }
+}
+```
+
+### ✅ Provide exactly one container locator
+```json
+{
+  "container": { "text": "Items" }
 }
 ```
 

--- a/src/features/action/SwipeOn.ts
+++ b/src/features/action/SwipeOn.ts
@@ -6,6 +6,7 @@ import {
   ObserveResult,
   SwipeOnOptions,
   SwipeOnResult,
+  ScrollableCandidate,
   ViewHierarchyResult,
   GestureOptions
 } from "../../models";
@@ -18,6 +19,36 @@ import { createGlobalPerformanceTracker, PerformanceTracker, NoOpPerformanceTrac
 import { AccessibilityServiceClient } from "../observe/AccessibilityServiceClient";
 import { WebDriverAgent } from "../../utils/ios-cmdline-tools/WebDriverAgent";
 import { buildElementSearchDebugContext } from "../../utils/DebugContextBuilder";
+import { SwipeResult } from "../../models/SwipeResult";
+import { ObserveScreen } from "../observe/ObserveScreen";
+
+export interface GestureExecutor {
+  swipe(
+    x1: number,
+    y1: number,
+    x2: number,
+    y2: number,
+    options?: GestureOptions,
+    perf?: PerformanceTracker
+  ): Promise<SwipeResult>;
+}
+
+export interface ObserveScreenLike {
+  execute(
+    queryOptions?: import("../../models").ViewHierarchyQueryOptions,
+    perf?: PerformanceTracker,
+    skipWaitForFresh?: boolean,
+    minTimestamp?: number,
+    signal?: AbortSignal
+  ): Promise<ObserveResult>;
+  getMostRecentCachedObserveResult(): Promise<ObserveResult>;
+}
+
+export interface SwipeOnDependencies {
+  executeGesture?: GestureExecutor;
+  observeScreen?: ObserveScreenLike;
+  elementUtils?: ElementUtils;
+}
 
 /**
  * Unified command to swipe on screen or elements, with optional scroll-until-visible functionality
@@ -28,7 +59,7 @@ import { buildElementSearchDebugContext } from "../../utils/DebugContextBuilder"
  * - scroll: Scrolling with optional element search
  */
 export class SwipeOn extends BaseVisualChange {
-  private executeGesture: ExecuteGesture;
+  private executeGesture: GestureExecutor;
   private elementUtils: ElementUtils;
   private accessibilityService: AccessibilityServiceClient;
   private webdriver: WebDriverAgent;
@@ -38,22 +69,31 @@ export class SwipeOn extends BaseVisualChange {
     device: BootedDevice,
     adb: AdbClient | null = null,
     axe: AxeClient | null = null,
-    webdriver: WebDriverAgent | null = null
+    webdriver: WebDriverAgent | null = null,
+    dependencies: SwipeOnDependencies = {}
   ) {
     super(device, adb, axe);
-    this.executeGesture = new ExecuteGesture(device, adb);
-    this.elementUtils = new ElementUtils();
+    this.executeGesture = dependencies.executeGesture ?? new ExecuteGesture(device, adb);
+    this.elementUtils = dependencies.elementUtils ?? new ElementUtils();
     this.accessibilityService = AccessibilityServiceClient.getInstance(device, this.adb);
     this.webdriver = webdriver || new WebDriverAgent(device);
+    if (dependencies.observeScreen) {
+      this.observeScreen = dependencies.observeScreen as unknown as ObserveScreen;
+    }
   }
 
   /**
    * Create an error result with consistent structure
    */
-  private createErrorResult(error: string): SwipeOnResult {
+  private createErrorResult(
+    error: string,
+    extras: { warning?: string; scrollableCandidates?: ScrollableCandidate[] } = {}
+  ): SwipeOnResult {
     return {
       success: false,
       error,
+      warning: extras.warning,
+      scrollableCandidates: extras.scrollableCandidates,
       targetType: "screen",
       x1: 0,
       y1: 0,
@@ -61,6 +101,52 @@ export class SwipeOn extends BaseVisualChange {
       y2: 0,
       duration: 0
     };
+  }
+
+  private async getScrollableContext(): Promise<{
+    scrollables: Element[];
+    candidates: ScrollableCandidate[];
+    observeResult?: ObserveResult;
+  }> {
+    let observeResult = await this.observeScreen.getMostRecentCachedObserveResult();
+    if (!observeResult.viewHierarchy || observeResult.viewHierarchy.hierarchy?.error) {
+      observeResult = await this.observeScreen.execute();
+    }
+
+    if (!observeResult.viewHierarchy) {
+      return { scrollables: [], candidates: [], observeResult };
+    }
+
+    const scrollables = this.elementUtils.findScrollableElements(observeResult.viewHierarchy);
+    const candidates = this.buildScrollableCandidates(scrollables);
+    return { scrollables, candidates, observeResult };
+  }
+
+  private buildScrollableCandidates(scrollables: Element[]): ScrollableCandidate[] {
+    const candidates: ScrollableCandidate[] = [];
+    const seen = new Set<string>();
+
+    for (const scrollable of scrollables) {
+      const candidate: ScrollableCandidate = {
+        elementId: scrollable["resource-id"],
+        text: scrollable.text,
+        contentDesc: scrollable["content-desc"],
+        className: scrollable.class
+      };
+
+      if (!candidate.elementId && !candidate.text && !candidate.contentDesc && !candidate.className) {
+        continue;
+      }
+
+      const key = `${candidate.elementId ?? ""}|${candidate.text ?? ""}|${candidate.contentDesc ?? ""}|${candidate.className ?? ""}`;
+      if (seen.has(key)) {
+        continue;
+      }
+      seen.add(key);
+      candidates.push(candidate);
+    }
+
+    return candidates;
   }
 
   /**
@@ -86,8 +172,55 @@ export class SwipeOn extends BaseVisualChange {
         // Scroll-until-visible mode
         return await this.executeScrollUntilVisible(options, progress, perf);
       } else if (!options.container) {
-        // No container = screen swipe
-        return await this.executeScreenSwipe(options, progress, perf);
+        const autoTargetEnabled = options.autoTarget !== false;
+        if (!autoTargetEnabled) {
+          return await this.executeScreenSwipe(options, progress, perf);
+        }
+
+        const scrollableContext = await this.getScrollableContext();
+        if (scrollableContext.scrollables.length === 0) {
+          return await this.executeScreenSwipe(options, progress, perf);
+        }
+
+        const screenBounds = scrollableContext.observeResult
+          ? this.getScreenBounds(scrollableContext.observeResult)
+          : null;
+        const autoTargetElement = this.selectAutoTargetScrollable(
+          scrollableContext.scrollables,
+          screenBounds,
+          options.direction
+        );
+
+        if (!autoTargetElement) {
+          const result = await this.executeScreenSwipe(options, progress, perf);
+          return {
+            ...result,
+            warning: "Scrollable containers found but none matched the swipe direction; swiping the screen. Set autoTarget: false to force screen swipes.",
+            scrollableCandidates: scrollableContext.candidates
+          };
+        }
+
+        const autoTargetContainer = this.buildContainerFromElement(autoTargetElement);
+        if (!autoTargetContainer) {
+          const result = await this.executeScreenSwipe(options, progress, perf);
+          return {
+            ...result,
+            warning: "Auto-targeted scrollable container lacks a usable identifier; swiping the screen. Provide container.elementId or container.text to target it explicitly.",
+            scrollableCandidates: scrollableContext.candidates
+          };
+        }
+
+        const autoTargetResult = await this.executeElementSwipe(
+          { ...options, container: autoTargetContainer },
+          progress,
+          perf
+        );
+
+        return {
+          ...autoTargetResult,
+          warning: `Auto-targeted scrollable container (${this.describeContainer(autoTargetContainer)}). Set autoTarget: false to force full-screen swipes.`,
+          scrollableCandidates: scrollableContext.candidates
+        };
       } else {
         // Container specified = swipe within container
         return await this.executeElementSwipe(options, progress, perf);
@@ -150,6 +283,101 @@ export class SwipeOn extends BaseVisualChange {
     }
 
     return null;
+  }
+
+  private getScreenBounds(observeResult: ObserveResult): Element["bounds"] | null {
+    if (!observeResult.screenSize) {
+      return null;
+    }
+
+    const insets = observeResult.systemInsets || { top: 0, right: 0, bottom: 0, left: 0 };
+    return {
+      left: insets.left,
+      top: insets.top,
+      right: observeResult.screenSize.width - insets.right,
+      bottom: observeResult.screenSize.height - insets.bottom
+    };
+  }
+
+  private selectAutoTargetScrollable(
+    scrollables: Element[],
+    screenBounds: Element["bounds"] | null,
+    direction: SwipeOnOptions["direction"]
+  ): Element | null {
+    if (scrollables.length === 0) {
+      return null;
+    }
+
+    if (scrollables.length === 1) {
+      return this.matchesDirection(scrollables[0], direction) ? scrollables[0] : null;
+    }
+
+    const nonScreenScrollables = screenBounds
+      ? scrollables.filter(scrollable => !this.boundsEqual(scrollable.bounds, screenBounds))
+      : scrollables.slice();
+
+    const candidates = nonScreenScrollables.length > 0 ? nonScreenScrollables : scrollables;
+    return this.pickLargestScrollable(candidates);
+  }
+
+  private pickLargestScrollable(scrollables: Element[]): Element | null {
+    if (scrollables.length === 0) {
+      return null;
+    }
+
+    return scrollables.reduce((largest, current) => {
+      const largestArea = this.boundsArea(largest.bounds);
+      const currentArea = this.boundsArea(current.bounds);
+      return currentArea > largestArea ? current : largest;
+    });
+  }
+
+  private boundsArea(bounds: Element["bounds"]): number {
+    return Math.max(0, bounds.right - bounds.left) * Math.max(0, bounds.bottom - bounds.top);
+  }
+
+  private boundsEqual(a: Element["bounds"], b: Element["bounds"]): boolean {
+    return a.left === b.left && a.top === b.top && a.right === b.right && a.bottom === b.bottom;
+  }
+
+  private matchesDirection(element: Element, direction: SwipeOnOptions["direction"]): boolean {
+    const width = Math.abs(element.bounds.right - element.bounds.left);
+    const height = Math.abs(element.bounds.bottom - element.bounds.top);
+
+    if (direction === "up" || direction === "down") {
+      return height >= width;
+    }
+
+    return width >= height;
+  }
+
+  private buildContainerFromElement(element: Element): SwipeOnOptions["container"] | null {
+    if (element["resource-id"]) {
+      return { elementId: element["resource-id"] };
+    }
+    if (element.text) {
+      return { text: element.text };
+    }
+    if (element["content-desc"]) {
+      return { text: element["content-desc"] };
+    }
+    if (element["ios-accessibility-label"]) {
+      return { text: element["ios-accessibility-label"] };
+    }
+    return null;
+  }
+
+  private describeContainer(container: SwipeOnOptions["container"]): string {
+    if (!container) {
+      return "unknown";
+    }
+    if (container.elementId) {
+      return `elementId="${container.elementId}"`;
+    }
+    if (container.text) {
+      return `text="${container.text}"`;
+    }
+    return "unknown";
   }
 
   /**

--- a/src/models/SwipeOnOptions.ts
+++ b/src/models/SwipeOnOptions.ts
@@ -11,6 +11,9 @@ export interface SwipeOnOptions {
     text?: string; // Text within container
   };
 
+  // Auto-target a scrollable container when no container is specified (default true)
+  autoTarget?: boolean;
+
   // Direction (required)
   direction: "up" | "down" | "left" | "right";
 

--- a/src/models/SwipeOnResult.ts
+++ b/src/models/SwipeOnResult.ts
@@ -8,6 +8,10 @@ import { ToolDebugInfo } from "../utils/DebugContextBuilder";
 export interface SwipeOnResult {
   success: boolean;
   error?: string;
+  warning?: string;
+
+  // Context to help callers target scrollable containers
+  scrollableCandidates?: ScrollableCandidate[];
 
   // Target information
   targetType: "screen" | "element";
@@ -40,4 +44,11 @@ export interface SwipeOnResult {
 
   // Debug information (when debug mode is enabled)
   debug?: ToolDebugInfo;
+}
+
+export interface ScrollableCandidate {
+  elementId?: string;
+  text?: string;
+  contentDesc?: string;
+  className?: string;
 }

--- a/src/server/interactionTools.ts
+++ b/src/server/interactionTools.ts
@@ -81,6 +81,7 @@ export interface SwipeOnArgs {
     elementId?: string;
     text?: string;
   };
+  autoTarget?: boolean;
   direction: "up" | "down" | "left" | "right";
   lookFor?: {
     elementId?: string;
@@ -162,7 +163,8 @@ export const swipeOnSchema = z.object({
   container: z.object({
     elementId: z.string().optional().describe("Resource ID of the container element (finds nearest scrollable parent if element is not scrollable)"),
     text: z.string().optional().describe("Text within the container (finds nearest scrollable parent of element containing this text)")
-  }).optional().describe("Container element to swipe within - specify elementId or text to locate it. If not specified swipe on window"),
+  }).optional().describe("Container element to swipe within. REQUIRED for scrolling lists (RecyclerView/ScrollView/ListView). Omit only for intentional full-screen swipes like page navigation or dismissing sheets."),
+  autoTarget: z.boolean().optional().describe("Auto-target a scrollable container when container is omitted (default true). Set to false only if you intend to swipe the entire screen after autoTarget selected a list unexpectedly."),
   direction: z.enum(["up", "down", "left", "right"]).describe("Direction to swipe finger: 'up' swipes finger up (content moves down, reveals content from above), 'down' swipes finger down (content moves up, reveals content from below)"),
   lookFor: z.object({
     elementId: z.string().optional().describe("ID of the element to look for"),
@@ -517,6 +519,7 @@ export function registerInteractionTools() {
     const options: import("../models").SwipeOnOptions = {
       includeSystemInsets: args.includeSystemInsets,
       container: args.container,
+      autoTarget: args.autoTarget,
       direction: args.direction,
       lookFor: args.lookFor,
       speed: args.speed
@@ -527,7 +530,9 @@ export function registerInteractionTools() {
 
     // Determine message based on operation type
     let message = "";
-    if (result.found !== undefined) {
+    if (!result.success && result.error) {
+      message = `Swipe failed: ${result.error}`;
+    } else if (result.found !== undefined) {
       // Scroll-until-visible operation
       if (result.found) {
         const target = args.lookFor?.text
@@ -546,6 +551,10 @@ export function registerInteractionTools() {
       message = `Swiped ${args.direction} in container with id "${args.container.elementId}"`;
     } else {
       message = `Swiped ${args.direction}`;
+    }
+
+    if (result.warning) {
+      message = `${message} Warning: ${result.warning}`;
     }
 
     return createJSONToolResponse({
@@ -742,7 +751,7 @@ export function registerInteractionTools() {
 
   ToolRegistry.registerDeviceAware(
     "swipeOn",
-    "Unified swipe/scroll tool - swipe on screen or elements, with optional scroll-until-visible",
+    "Unified swipe/scroll tool - swipe on screen or elements, with optional scroll-until-visible. IMPORTANT: use container when scrolling lists; omit only for full-screen swipes.",
     swipeOnSchema,
     swipeOnHandler,
     true // Supports progress notifications

--- a/test/fakes/FakeGestureExecutor.ts
+++ b/test/fakes/FakeGestureExecutor.ts
@@ -1,0 +1,42 @@
+import { GestureOptions } from "../../src/models";
+import { SwipeResult } from "../../src/models/SwipeResult";
+import { PerformanceTracker } from "../../src/utils/PerformanceTracker";
+
+export class FakeGestureExecutor {
+  private swipeCalls: Array<{
+    x1: number;
+    y1: number;
+    x2: number;
+    y2: number;
+    options?: GestureOptions;
+  }> = [];
+
+  async swipe(
+    x1: number,
+    y1: number,
+    x2: number,
+    y2: number,
+    options: GestureOptions = {},
+    _perf: PerformanceTracker | undefined = undefined
+  ): Promise<SwipeResult> {
+    this.swipeCalls.push({ x1, y1, x2, y2, options });
+    return {
+      success: true,
+      x1,
+      y1,
+      x2,
+      y2,
+      duration: options.duration ?? 0
+    };
+  }
+
+  getSwipeCalls(): Array<{
+    x1: number;
+    y1: number;
+    x2: number;
+    y2: number;
+    options?: GestureOptions;
+  }> {
+    return [...this.swipeCalls];
+  }
+}

--- a/test/fakes/FakeObserveScreen.ts
+++ b/test/fakes/FakeObserveScreen.ts
@@ -107,7 +107,13 @@ export class FakeObserveScreen {
 
   // Implementation of ObserveScreen interface
 
-  async execute(): Promise<ObserveResult> {
+  async execute(
+    _queryOptions?: any,
+    _perf?: any,
+    _skipWaitForFresh?: boolean,
+    _minTimestamp?: number,
+    _signal?: AbortSignal
+  ): Promise<ObserveResult> {
     this.executedOperations.push("execute");
     this.executeCallCount++;
 

--- a/test/features/action/SwipeOn.test.ts
+++ b/test/features/action/SwipeOn.test.ts
@@ -1,0 +1,116 @@
+import { beforeEach, describe, expect, test } from "bun:test";
+import { SwipeOn } from "../../../src/features/action/SwipeOn";
+import { ObserveResult } from "../../../src/models";
+import { FakeAwaitIdle } from "../../fakes/FakeAwaitIdle";
+import { FakeObserveScreen } from "../../fakes/FakeObserveScreen";
+import { FakeGestureExecutor } from "../../fakes/FakeGestureExecutor";
+import { FakeWindow } from "../../fakes/FakeWindow";
+
+describe("SwipeOn autoTarget", () => {
+  const device = { name: "test-device", platform: "android", deviceId: "device-1" } as const;
+  let fakeObserveScreen: FakeObserveScreen;
+  let fakeGesture: FakeGestureExecutor;
+  let fakeAwaitIdle: FakeAwaitIdle;
+  let fakeWindow: FakeWindow;
+
+  const createObserveResult = (viewHierarchy: any): ObserveResult => ({
+    timestamp: Date.now(),
+    screenSize: { width: 1000, height: 2000 },
+    systemInsets: { top: 0, right: 0, bottom: 0, left: 0 },
+    viewHierarchy
+  });
+
+  const createScrollableNode = (
+    bounds: string,
+    resourceId: string
+  ) => ({
+    $: {
+      bounds,
+      scrollable: "true",
+      "resource-id": resourceId,
+      class: "androidx.recyclerview.widget.RecyclerView"
+    }
+  });
+
+  const createHierarchy = (nodes: any[]) => ({
+    hierarchy: {
+      node: nodes
+    }
+  });
+
+  const createSwipeOn = () => {
+    const swipeOn = new SwipeOn(device, null, null, null, {
+      executeGesture: fakeGesture,
+      observeScreen: fakeObserveScreen
+    });
+    (swipeOn as any).awaitIdle = fakeAwaitIdle;
+    (swipeOn as any).window = fakeWindow;
+    return swipeOn;
+  };
+
+  beforeEach(() => {
+    fakeObserveScreen = new FakeObserveScreen();
+    fakeGesture = new FakeGestureExecutor();
+    fakeAwaitIdle = new FakeAwaitIdle();
+    fakeWindow = new FakeWindow();
+    fakeWindow.setCachedActiveWindow(null);
+  });
+
+  test("auto-targets the largest non-fullscreen scrollable when multiple exist", async () => {
+    const hierarchy = createHierarchy([
+      createScrollableNode("[0,0][1000,2000]", "root-scroll"),
+      createScrollableNode("[0,200][1000,1800]", "list-scroll")
+    ]);
+    fakeObserveScreen.setObserveResult(createObserveResult(hierarchy));
+
+    const swipeOn = createSwipeOn();
+    const result = await swipeOn.execute({ direction: "up" });
+
+    expect(result.success).toBe(true);
+    expect(result.targetType).toBe("element");
+    expect(result.element?.["resource-id"]).toBe("list-scroll");
+    expect(result.warning || "").toContain("Auto-targeted scrollable container");
+  });
+
+  test("auto-targets the single scrollable that matches the swipe direction", async () => {
+    const hierarchy = createHierarchy([
+      createScrollableNode("[0,200][1000,1800]", "list-scroll")
+    ]);
+    fakeObserveScreen.setObserveResult(createObserveResult(hierarchy));
+
+    const swipeOn = createSwipeOn();
+    const result = await swipeOn.execute({ direction: "up" });
+
+    expect(result.success).toBe(true);
+    expect(result.targetType).toBe("element");
+    expect(result.element?.["resource-id"]).toBe("list-scroll");
+  });
+
+  test("falls back to screen swipe when single scrollable does not match direction", async () => {
+    const hierarchy = createHierarchy([
+      createScrollableNode("[0,0][800,200]", "horizontal-scroll")
+    ]);
+    fakeObserveScreen.setObserveResult(createObserveResult(hierarchy));
+
+    const swipeOn = createSwipeOn();
+    const result = await swipeOn.execute({ direction: "up" });
+
+    expect(result.success).toBe(true);
+    expect(result.targetType).toBe("screen");
+    expect(result.warning || "").toContain("none matched the swipe direction");
+  });
+
+  test("respects autoTarget=false and performs a screen swipe", async () => {
+    const hierarchy = createHierarchy([
+      createScrollableNode("[0,200][1000,1800]", "list-scroll")
+    ]);
+    fakeObserveScreen.setObserveResult(createObserveResult(hierarchy));
+
+    const swipeOn = createSwipeOn();
+    const result = await swipeOn.execute({ direction: "up", autoTarget: false });
+
+    expect(result.success).toBe(true);
+    expect(result.targetType).toBe("screen");
+    expect(result.warning).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary
- add autoTarget option with smarter scrollable selection for swipeOn
- inject swipe dependencies for testing and add fakes
- add autoTarget unit tests and update swipeOn docs/schema messaging

## Testing
- bun test