### PR TITLE
Preserve selected state in view hierarchy filtering

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ node_modules
 npm-debug.log*
 /.gitlab-ci-local
 *.tgz
+*.hprof
 
 # Places to locally write while thinking or planning
 /scratch

--- a/src/features/observe/ViewHierarchy.ts
+++ b/src/features/observe/ViewHierarchy.ts
@@ -867,7 +867,7 @@ export class ViewHierarchy {
   /**
    * Filter the view hierarchy to only include elements that meet specific criteria:
    * - Have resourceId, text, or contentDesc
-   * - OR have clickable, scrollable, or focused set to true
+   * - OR have clickable, scrollable, focused, or selected set to true
    * - Include descendants that meet criteria even if parents don't
    * - Omit boolean fields not set to true and class="android.view.View"
    * @param viewHierarchy - The view hierarchy to filter
@@ -1107,7 +1107,9 @@ export class ViewHierarchy {
     return Boolean(
       (props.clickable === "true") ||
       (props.scrollable === "true") ||
-      (props.focused === "true")
+      (props.focused === "true") ||
+      (props.selected === "true") ||
+      (props.selected === true)
     );
   }
 
@@ -1386,6 +1388,7 @@ export class ViewHierarchy {
       "clickable",
       "scrollable",
       "enabled",
+      "selected",
       "bounds",
       "accessible",
       "test-tag",

--- a/test/features/observe/ViewHierarchySample.test.ts
+++ b/test/features/observe/ViewHierarchySample.test.ts
@@ -183,7 +183,7 @@ describe("ViewHierarchy - Sample Data", function() {
     const filteredHierarchy = viewHierarchy.filterViewHierarchy(mapHierarchy);
 
     let hasUnwantedProperties = false;
-    const unwantedProps = ["checkable", "checked", "password", "long-clickable", "selected", "index"];
+    const unwantedProps = ["checkable", "checked", "password", "long-clickable", "index"];
 
     viewHierarchy.traverseViewHierarchy(filteredHierarchy.hierarchy, node => {
       if (node.$) {
@@ -204,5 +204,21 @@ describe("ViewHierarchy - Sample Data", function() {
     });
 
     expect(hasUnwantedProperties).toBe(false), "Filtered hierarchy should not contain unwanted properties";
+  });
+
+  test("should preserve selected attribute when filtering", async function() {
+    const selectedPath = path.join(__dirname, "../../sampleData/viewHierarchy/selectedElement.xml");
+    const selectedHierarchy = await readAndParseXmlFile(selectedPath);
+
+    const filteredHierarchy = viewHierarchy.filterViewHierarchy(selectedHierarchy);
+
+    let foundSelected = false;
+    viewHierarchy.traverseViewHierarchy(filteredHierarchy.hierarchy, node => {
+      if (node.$?.selected === "true" || node.selected === "true") {
+        foundSelected = true;
+      }
+    });
+
+    expect(foundSelected).toBe(true, "Selected nodes should be retained after filtering");
   });
 });

--- a/test/sampleData/viewHierarchy/selectedElement.xml
+++ b/test/sampleData/viewHierarchy/selectedElement.xml
@@ -1,0 +1,4 @@
+<?xml version='1.0' encoding='UTF-8' standalone='yes' ?>
+<hierarchy rotation="0">
+  <node index="0" text="" resource-id="" class="android.view.View" package="com.example" content-desc="" checkable="false" checked="false" clickable="false" enabled="true" focusable="false" focused="false" scrollable="false" long-clickable="false" password="false" selected="true" bounds="[0,0][100,100]" />
+</hierarchy>


### PR DESCRIPTION
## Summary
- preserve `selected` when filtering view hierarchy nodes
- include selected nodes in filter criteria so they are retained
- add a selected-state fixture and coverage in the view hierarchy sample tests
- ignore heap dumps via `.gitignore`

## Testing
- `bun run build`
- `bun run lint`
- `bun run test`
- `bash scripts/shellcheck/validate_shell_scripts.sh`
- `bash scripts/hadolint/validate_hadolint.sh`
- `bash scripts/ktfmt/validate_ktfmt.sh` (fails: formatting issues across Android Kotlin files)
- `bash scripts/xml/validate_xml.sh`
- `bash scripts/lychee/validate_lychee.sh`
- `bash scripts/act/validate_act.sh`
- `bash scripts/docker/validate_dockerfile.sh`
- `(cd android && ./gradlew compileKotlin)`
- `(cd android && ./gradlew compileTestKotlin)`

## Notes
- `(cd android && ./gradlew build)` was aborted mid-run per request.
