### PR TITLE
chore: update accessibility service APK SHA256

### DIFF
--- a/src/constants/release.ts
+++ b/src/constants/release.ts
@@ -19,4 +19,4 @@ export const RELEASE_VERSION: string = "latest";
 export const APK_URL: string = RELEASE_VERSION === "latest"
   ? `https://github.com/kaeawc/auto-mobile/releases/latest/download/accessibility-service-debug.apk`
   : `https://github.com/kaeawc/auto-mobile/releases/download/v${RELEASE_VERSION}/accessibility-service-debug.apk`;
-export const APK_SHA256_CHECKSUM: string = "dae46f39aefc5e7d1225ed582dbcf2a767028e281a84ae07d0a6259590da8e7d"; // Empty = skip verification (local dev only)
+export const APK_SHA256_CHECKSUM: string = "38580ec000cbe2873801763de19e6c50826bb16ce03c233d1b09b5fa09cf8e11"; // Empty = skip verification (local dev only)


### PR DESCRIPTION
## Automated Checksum Update

The accessibility service APK was rebuilt on `main` with a different SHA256 checksum.

| | SHA256 |
|--|--------|
| **Previous** | `dae46f39aefc5e7d1225ed582dbcf2a767028e281a84ae07d0a6259590da8e7d` |
| **New** | `38580ec000cbe2873801763de19e6c50826bb16ce03c233d1b09b5fa09cf8e11` |

### Why did this happen?

The SHA256 changes when any of these change:
- Source code in `android/accessibility-service/src/`
- Build configuration (`build.gradle.kts`)
- Dependencies or SDK versions

### What to do

1. Review this PR to ensure the change is expected
2. Merge when ready
3. Future releases will use this checksum for APK verification

---
Auto-generated by `build-android-accessibility-service` job in merge workflow