### PR TITLE
Improve tapOn container schema and docs

### DIFF
--- a/docs/features/mcp-server/actions.md
+++ b/docs/features/mcp-server/actions.md
@@ -7,7 +7,8 @@ expose the [observe](observation.md) ability as a tool call.
 
 #### Interactions
 
-- 👆 **Tap**: Intelligent text-based or resource-id tapping with fuzzy search and view hierarchy analysis.
+- 👆 **Tap**: Intelligent text-based or resource-id tapping with fuzzy search and view hierarchy analysis. See
+  [tapOn details](tap-on.md) for container scoping and precedence.
 - 👉 **Swipe**: Directional swiping within element bounds with configurable release timing.
 - ⏰ **Long Press**: Extended touch gestures for context menus and advanced interactions.
 - 📜 **Scroll**: Intelligent scrolling until target text becomes visible.

--- a/docs/features/mcp-server/tap-on.md
+++ b/docs/features/mcp-server/tap-on.md
@@ -1,0 +1,52 @@
+# TapOn Tool
+
+Use `tapOn` to tap UI elements by text or resource ID. It supports optional container scoping when you need to target a
+specific element inside a list, card, or panel that contains repeated labels.
+
+## When to use container
+
+Use `container` when:
+- Multiple elements share the same text and you want the one inside a specific list or section.
+- You want to limit the search to a specific panel or sub-tree for speed and predictability.
+
+Avoid `container` when the element is unique on screen; it adds an extra lookup step.
+
+## Schema highlights
+
+- `text` and `id` are optional, but one must be provided.
+- If both `text` and `id` are provided, `text` takes precedence.
+- `container` accepts either `elementId` or `text` to locate the container element.
+- If both `container.elementId` and `container.text` are provided, `elementId` is used to find the container.
+
+## Examples
+
+Tap within a specific container by ID:
+
+```ts
+tapOn({
+  platform: "android",
+  text: "Duluth",
+  container: { elementId: "com.google.android.apps.maps:id/suggestions_list" }
+});
+```
+
+Tap within a container found by text:
+
+```ts
+tapOn({
+  platform: "android",
+  text: "Duluth",
+  container: { text: "Suggested places" }
+});
+```
+
+Multiple containers match:
+
+If multiple containers match the selector, the first match in the view-hierarchy traversal order is used. If multiple
+target elements match inside that container, exact text matches are preferred and the smallest visible element is chosen.
+
+## Precedence and matching behavior
+
+- Container lookup happens first; if the container is not found, `tapOn` fails with a container-specific error.
+- The element search is scoped to the container's subtree when `container` is set.
+- Text matching is fuzzy by default, so partial matches can resolve to a smaller, more specific element.

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -3,6 +3,7 @@ import {
   ListToolsRequestSchema,
   CallToolRequestSchema
 } from "@modelcontextprotocol/sdk/types.js";
+import { ZodError } from "zod";
 import { ActionableError } from "../models";
 import { logger } from "../utils/logger";
 import { executionTracker } from "./executionTracker";
@@ -37,6 +38,29 @@ export interface McpServerOptions {
   debug?: boolean;
   sessionContext?: { sessionId?: string };
 }
+
+const formatZodValidationError = (toolName: string, error: ZodError): string => {
+  const issues = error.issues.map(issue => {
+    const path = issue.path.length > 0 ? issue.path.join(".") : "root";
+    let message = issue.message;
+
+    if (toolName === "tapOn" && issue.path[0] === "container") {
+      if (issue.code === "invalid_type" && issue.expected === "object") {
+        message = "container must be an object like { elementId: \"...\" } or { text: \"...\" }";
+      } else if (issue.code === "custom") {
+        message = "container must include elementId or text (example: { text: \"Results\" })";
+      }
+    }
+
+    return `${path}: ${message}`;
+  });
+
+  if (issues.length === 0) {
+    return `Invalid parameters for tool ${toolName}.`;
+  }
+
+  return `Invalid parameters for tool ${toolName}:\n- ${issues.join("\n- ")}`;
+};
 
 export const createMcpServer = (options: McpServerOptions = {}): McpServer => {
   // Get configuration and device session managers
@@ -128,6 +152,9 @@ export const createMcpServer = (options: McpServerOptions = {}): McpServer => {
     try {
       parsedParams = tool.schema.parse(toolParams);
     } catch (error) {
+      if (error instanceof ZodError) {
+        throw new ActionableError(formatZodValidationError(name, error));
+      }
       throw new ActionableError(`Invalid parameters for tool ${name}: ${error}`);
     }
 

--- a/src/server/interactionTools.ts
+++ b/src/server/interactionTools.ts
@@ -125,14 +125,25 @@ export const shakeSchema = z.object({
   deviceId: z.string().optional()
 });
 
+const tapOnContainerSchema = z.object({
+  elementId: z.string().optional().describe("Container element resource ID to restrict search within"),
+  text: z.string().optional().describe("Container element text to restrict search within")
+}).superRefine((value, ctx) => {
+  if (!value.elementId && !value.text) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: "container must include elementId or text"
+    });
+  }
+});
+
 export const tapOnSchema = z.object({
-  container: z.object({
-    elementId: z.string().optional().describe("Container element resource ID to restrict search within"),
-    text: z.string().optional().describe("Container element text to restrict search within")
-  }).optional().describe("Container element to scope the search - specify elementId or text to locate it"),
+  container: tapOnContainerSchema.optional().describe(
+    "Container element to scope the search. Provide elementId or text to locate it."
+  ),
   action: z.enum(["tap", "doubleTap", "longPress", "longPressDrag", "focus"]).describe("Action to perform on the element"),
-  text: z.string().optional().describe("Text to tap on"),
-  id: z.string().optional().describe("Element ID to tap on"),
+  text: z.string().optional().describe("Text to tap on. Takes precedence over id if both are provided."),
+  id: z.string().optional().describe("Element ID to tap on. Ignored when text is provided."),
   duration: z.number().optional().describe("Long press duration in milliseconds"),
   dragTo: z.object({
     x: z.number().optional().describe("Drag target X coordinate"),
@@ -788,7 +799,7 @@ export function registerInteractionTools() {
 
   ToolRegistry.registerDeviceAware(
     "tapOn",
-    "Tap supporting text or resourceId",
+    "Tap UI elements by text or resource ID, optionally scoped to a container",
     tapOnSchema,
     tapOnHandler,
     true // Supports progress notifications

--- a/test/server/tools/schema.test.ts
+++ b/test/server/tools/schema.test.ts
@@ -182,6 +182,28 @@ describe("MCP Tools Schema", () => {
     }
   });
 
+  test("tapOn should report helpful errors for malformed container", async () => {
+    const { client } = fixture.getContext();
+
+    try {
+      const { z } = await import("zod");
+      await client.request({
+        method: "tools/call",
+        params: {
+          name: "tapOn",
+          arguments: {
+            platform: "android",
+            text: "Duluth",
+            container: "MN"
+          }
+        }
+      }, z.any());
+      expect.fail("Should have thrown an error for invalid container");
+    } catch (error: any) {
+      expect(error.message).toContain("container must be an object");
+    }
+  });
+
   test("given a request contains fields that are defined by the schema but have incorrect values, should return an error response", async function() {
 
     const { client } = fixture.getContext();


### PR DESCRIPTION
## Summary
- clarify tapOn container schema and add validation to require elementId or text
- improve Zod error messaging for malformed tapOn container inputs
- document tapOn container usage, precedence, and multi-match behavior with examples
- add schema test coverage for malformed container errors

## Testing
- bun run test

Closes #262
