### PR TITLE
Add drag-and-drop MCP tool

### DIFF
--- a/android/accessibility-service/src/main/java/dev/jasonpearson/automobile/accessibilityservice/AutoMobileAccessibilityService.kt
+++ b/android/accessibility-service/src/main/java/dev/jasonpearson/automobile/accessibilityservice/AutoMobileAccessibilityService.kt
@@ -265,6 +265,9 @@ class AutoMobileAccessibilityService : AccessibilityService() {
               onRequestSwipe = { requestId, x1, y1, x2, y2, duration ->
                 performSwipe(requestId, x1, y1, x2, y2, duration)
               },
+              onRequestDrag = { requestId, x1, y1, x2, y2, duration, holdTime ->
+                performDrag(requestId, x1, y1, x2, y2, duration, holdTime)
+              },
               onRequestSetText = { requestId, text, resourceId ->
                 performSetText(requestId, text, resourceId)
               },
@@ -749,6 +752,104 @@ class AutoMobileAccessibilityService : AccessibilityService() {
       Log.e(TAG, "Error performing swipe", e)
       serviceScope.launch {
         broadcastSwipeResult(requestId, false, e.message, errorTime - startTime, null)
+      }
+    }
+  }
+
+  /**
+   * Perform a drag gesture using AccessibilityService's dispatchGesture API.
+   */
+  private fun performDrag(
+      requestId: String?,
+      x1: Int,
+      y1: Int,
+      x2: Int,
+      y2: Int,
+      duration: Long,
+      holdTime: Long,
+  ) {
+    val startTime = System.currentTimeMillis()
+    Log.d(TAG, "performDrag: ($x1, $y1) -> ($x2, $y2) hold=${holdTime}ms duration=${duration}ms")
+    perfProvider.serial("performDrag")
+
+    try {
+      perfProvider.startOperation("buildPath")
+      val holdPath =
+          Path().apply {
+            moveTo(x1.toFloat(), y1.toFloat())
+            lineTo(x1.toFloat(), y1.toFloat())
+          }
+      val dragPath =
+          Path().apply {
+            moveTo(x1.toFloat(), y1.toFloat())
+            lineTo(x2.toFloat(), y2.toFloat())
+          }
+
+      val holdStroke = GestureDescription.StrokeDescription(holdPath, 0, holdTime, true)
+      val dragStroke = holdStroke.continueStroke(dragPath, 0, duration, false)
+
+      val gesture =
+          GestureDescription.Builder()
+              .addStroke(holdStroke)
+              .addStroke(dragStroke)
+              .build()
+      perfProvider.endOperation("buildPath")
+
+      val gestureBuiltTime = System.currentTimeMillis()
+      Log.d(TAG, "Drag gesture built in ${gestureBuiltTime - startTime}ms")
+
+      perfProvider.startOperation("dispatchGesture")
+      val dispatched =
+          dispatchGesture(
+              gesture,
+              object : GestureResultCallback() {
+                override fun onCompleted(gestureDescription: GestureDescription?) {
+                  perfProvider.endOperation("dispatchGesture")
+                  perfProvider.end()
+                  val completedTime = System.currentTimeMillis()
+                  val totalTime = completedTime - startTime
+                  val gestureTime = completedTime - gestureBuiltTime
+                  Log.d(TAG, "Drag completed: gesture=${gestureTime}ms, total=${totalTime}ms")
+                  serviceScope.launch {
+                    broadcastDragResult(requestId, true, null, totalTime, gestureTime)
+                  }
+                }
+
+                override fun onCancelled(gestureDescription: GestureDescription?) {
+                  perfProvider.endOperation("dispatchGesture")
+                  perfProvider.end()
+                  val cancelledTime = System.currentTimeMillis()
+                  val totalTime = cancelledTime - startTime
+                  Log.w(TAG, "Drag cancelled after ${totalTime}ms")
+                  serviceScope.launch {
+                    broadcastDragResult(requestId, false, "Gesture was cancelled", totalTime, null)
+                  }
+                }
+              },
+              null,
+          )
+
+      if (!dispatched) {
+        perfProvider.endOperation("dispatchGesture")
+        perfProvider.end()
+        val failTime = System.currentTimeMillis()
+        Log.e(TAG, "Failed to dispatch drag gesture")
+        serviceScope.launch {
+          broadcastDragResult(
+              requestId,
+              false,
+              "Failed to dispatch gesture",
+              failTime - startTime,
+              null,
+          )
+        }
+      }
+    } catch (e: Exception) {
+      perfProvider.end()
+      val errorTime = System.currentTimeMillis()
+      Log.e(TAG, "Error performing drag", e)
+      serviceScope.launch {
+        broadcastDragResult(requestId, false, e.message, errorTime - startTime, null)
       }
     }
   }
@@ -1392,6 +1493,46 @@ class AutoMobileAccessibilityService : AccessibilityService() {
       Log.d(TAG, "Broadcasted swipe result to ${webSocketServer.getConnectionCount()} clients")
     } catch (e: Exception) {
       Log.e(TAG, "Error broadcasting swipe result", e)
+    }
+  }
+
+  /** Broadcast drag result to WebSocket clients */
+  private suspend fun broadcastDragResult(
+      requestId: String?,
+      success: Boolean,
+      error: String?,
+      totalTimeMs: Long,
+      gestureTimeMs: Long?,
+  ) {
+    if (!::webSocketServer.isInitialized || !webSocketServer.isRunning()) {
+      Log.d(TAG, "WebSocket server not running, skipping drag result broadcast")
+      return
+    }
+
+    try {
+      webSocketServer.broadcastWithPerf { perfTiming ->
+        buildString {
+          append("""{"type":"drag_result","timestamp":${System.currentTimeMillis()}""")
+          if (requestId != null) {
+            append(""","requestId":"$requestId"""")
+          }
+          append(""","success":$success""")
+          append(""","totalTimeMs":$totalTimeMs""")
+          if (gestureTimeMs != null) {
+            append(""","gestureTimeMs":$gestureTimeMs""")
+          }
+          if (error != null) {
+            append(""","error":"$error"""")
+          }
+          if (perfTiming != null) {
+            append(""","perfTiming":$perfTiming""")
+          }
+          append("}")
+        }
+      }
+      Log.d(TAG, "Broadcasted drag result to ${webSocketServer.getConnectionCount()} clients")
+    } catch (e: Exception) {
+      Log.e(TAG, "Error broadcasting drag result", e)
     }
   }
 

--- a/android/accessibility-service/src/main/java/dev/jasonpearson/automobile/accessibilityservice/WebSocketServer.kt
+++ b/android/accessibility-service/src/main/java/dev/jasonpearson/automobile/accessibilityservice/WebSocketServer.kt
@@ -32,6 +32,7 @@ data class WebSocketRequest(
     val x2: Int? = null,
     val y2: Int? = null,
     val duration: Long? = null,
+    val holdTime: Long? = null,
     // Text input parameters
     val text: String? = null,
     val resourceId: String? = null, // Optional: target specific element by resource-id
@@ -57,6 +58,9 @@ class WebSocketServer(
     private val onRequestScreenshot: ((requestId: String?) -> Unit)? = null,
     private val onRequestSwipe:
         ((requestId: String?, x1: Int, y1: Int, x2: Int, y2: Int, duration: Long) -> Unit)? =
+        null,
+    private val onRequestDrag:
+        ((requestId: String?, x1: Int, y1: Int, x2: Int, y2: Int, duration: Long, holdTime: Long) -> Unit)? =
         null,
     private val onRequestSetText:
         ((requestId: String?, text: String, resourceId: String?) -> Unit)? =
@@ -299,6 +303,20 @@ class WebSocketServer(
             onRequestSwipe?.invoke(request.requestId, x1, y1, x2, y2, duration)
           } else {
             Log.w(TAG, "Swipe request missing required coordinates")
+          }
+        }
+        "request_drag" -> {
+          Log.d(TAG, "Received drag request (requestId: ${request.requestId})")
+          val x1 = request.x1
+          val y1 = request.y1
+          val x2 = request.x2
+          val y2 = request.y2
+          val duration = request.duration ?: 500L
+          val holdTime = request.holdTime ?: 200L
+          if (x1 != null && y1 != null && x2 != null && y2 != null) {
+            onRequestDrag?.invoke(request.requestId, x1, y1, x2, y2, duration, holdTime)
+          } else {
+            Log.w(TAG, "Drag request missing required coordinates")
           }
         }
         "request_set_text" -> {

--- a/src/features/action/DragAndDrop.ts
+++ b/src/features/action/DragAndDrop.ts
@@ -1,0 +1,233 @@
+import { BaseVisualChange, ProgressCallback } from "./BaseVisualChange";
+import {
+  ActionableError,
+  BootedDevice,
+  DragAndDropOptions,
+  DragAndDropResult,
+  ObserveResult,
+  ViewHierarchyResult
+} from "../../models";
+import { ElementUtils } from "../utility/ElementUtils";
+import { AccessibilityServiceClient } from "../observe/AccessibilityServiceClient";
+import { createGlobalPerformanceTracker } from "../../utils/PerformanceTracker";
+import { throwIfAborted } from "../../utils/toolUtils";
+import { AndroidAccessibilityServiceManager } from "../../utils/AccessibilityServiceManager";
+
+export class DragAndDrop extends BaseVisualChange {
+  private elementUtils: ElementUtils;
+  private accessibilityService: AccessibilityServiceClient;
+
+  constructor(device: BootedDevice) {
+    super(device);
+    this.elementUtils = new ElementUtils();
+    this.accessibilityService = AccessibilityServiceClient.getInstance(device, this.adb);
+  }
+
+  async execute(
+    options: DragAndDropOptions,
+    progress?: ProgressCallback,
+    signal?: AbortSignal
+  ): Promise<DragAndDropResult> {
+    if (this.device.platform === "ios") {
+      return {
+        success: false,
+        duration: 0,
+        distance: 0,
+        error: "dragAndDrop is not supported on iOS yet"
+      };
+    }
+
+    const a11yManager = AndroidAccessibilityServiceManager.getInstance(this.device, this.adb);
+    const isInstalled = await a11yManager.isInstalled();
+    if (!isInstalled) {
+      return {
+        success: false,
+        duration: 0,
+        distance: 0,
+        error: "dragAndDrop requires the Android accessibility service to be installed"
+      };
+    }
+
+    const validationError = this.validateOptions(options);
+    if (validationError) {
+      return {
+        success: false,
+        duration: 0,
+        distance: 0,
+        error: validationError
+      };
+    }
+
+    const perf = createGlobalPerformanceTracker();
+    perf.serial("dragAndDrop");
+
+    try {
+      const result = await this.observedInteraction(
+        async (observeResult: ObserveResult) => {
+          throwIfAborted(signal);
+          const viewHierarchy = observeResult.viewHierarchy;
+          if (!viewHierarchy) {
+            return { success: false, error: "Unable to get view hierarchy, cannot drag and drop" };
+          }
+
+          const source = this.resolveTarget(viewHierarchy, options.source, "source");
+          const target = this.resolveTarget(viewHierarchy, options.target, "target");
+          const sourcePoint = this.elementUtils.getElementCenter(source);
+          const targetPoint = this.elementUtils.getElementCenter(target);
+          const duration = this.getDuration(options);
+          const holdTime = this.getHoldTime(options);
+
+          const dragResult = await this.executeAndroidDrag(
+            sourcePoint.x,
+            sourcePoint.y,
+            targetPoint.x,
+            targetPoint.y,
+            duration,
+            holdTime,
+            signal
+          );
+
+          if (options.dropDelay && options.dropDelay > 0) {
+            await new Promise(resolve => setTimeout(resolve, options.dropDelay));
+          }
+
+          const distance = Math.hypot(targetPoint.x - sourcePoint.x, targetPoint.y - sourcePoint.y);
+
+          return {
+            success: dragResult.success,
+            duration,
+            distance,
+            a11yTotalTimeMs: dragResult.a11yTotalTimeMs,
+            a11yGestureTimeMs: dragResult.a11yGestureTimeMs,
+            error: dragResult.error
+          };
+        },
+        {
+          changeExpected: false,
+          timeoutMs: 5000,
+          progress,
+          perf,
+          signal,
+          predictionContext: {
+            toolName: "dragAndDrop",
+            toolArgs: {
+              source: options.source,
+              target: options.target,
+              duration: options.duration,
+              holdTime: options.holdTime,
+              dropDelay: options.dropDelay,
+              platform: this.device.platform
+            }
+          }
+        }
+      );
+
+      perf.end();
+
+      return {
+        ...result,
+        duration: result.duration ?? this.getDuration(options),
+        distance: result.distance ?? 0
+      } as DragAndDropResult;
+    } catch (error) {
+      perf.end();
+
+      const errorMessage = error instanceof Error ? error.message : String(error);
+      return {
+        success: false,
+        duration: 0,
+        distance: 0,
+        error: `Failed to perform drag and drop: ${errorMessage}`
+      };
+    }
+  }
+
+  private validateOptions(options: DragAndDropOptions): string | null {
+    if (!options?.source || !options?.target) {
+      return "dragAndDrop requires source and target";
+    }
+    if (!options.source.text && !options.source.elementId) {
+      return "dragAndDrop source requires text or elementId";
+    }
+    if (!options.target.text && !options.target.elementId) {
+      return "dragAndDrop target requires text or elementId";
+    }
+    return null;
+  }
+
+  private resolveTarget(
+    viewHierarchy: ViewHierarchyResult,
+    target: { text?: string; elementId?: string },
+    label: "source" | "target"
+  ) {
+    if (target.elementId) {
+      const element = this.elementUtils.findElementByResourceId(viewHierarchy, target.elementId);
+      if (!element) {
+        throw new ActionableError(`dragAndDrop ${label} not found with elementId '${target.elementId}'`);
+      }
+      return element;
+    }
+    if (target.text) {
+      const element = this.elementUtils.findElementByText(viewHierarchy, target.text);
+      if (!element) {
+        throw new ActionableError(`dragAndDrop ${label} not found with text '${target.text}'`);
+      }
+      return element;
+    }
+    throw new ActionableError(`dragAndDrop ${label} requires text or elementId`);
+  }
+
+  private getDuration(options: DragAndDropOptions): number {
+    if (typeof options.duration === "number" && options.duration > 0) {
+      return options.duration;
+    }
+    return 500;
+  }
+
+  private getHoldTime(options: DragAndDropOptions): number {
+    if (typeof options.holdTime === "number" && options.holdTime >= 0) {
+      return options.holdTime;
+    }
+    return 200;
+  }
+
+  private async executeAndroidDrag(
+    startX: number,
+    startY: number,
+    endX: number,
+    endY: number,
+    duration: number,
+    holdTime: number,
+    signal?: AbortSignal
+  ): Promise<{
+    success: boolean;
+    error?: string;
+    a11yTotalTimeMs?: number;
+    a11yGestureTimeMs?: number;
+  }> {
+    throwIfAborted(signal);
+
+    const result = await this.accessibilityService.requestDrag(
+      startX,
+      startY,
+      endX,
+      endY,
+      duration,
+      holdTime,
+      5000
+    );
+
+    if (result.success) {
+      return {
+        success: true,
+        a11yTotalTimeMs: result.totalTimeMs,
+        a11yGestureTimeMs: result.gestureTimeMs
+      };
+    }
+
+    return {
+      success: false,
+      error: result.error ?? "Drag failed via accessibility service"
+    };
+  }
+}

--- a/src/features/observe/AccessibilityServiceClient.ts
+++ b/src/features/observe/AccessibilityServiceClient.ts
@@ -117,6 +117,17 @@ export interface A11ySwipeResult {
 }
 
 /**
+ * Interface for drag result from accessibility service
+ */
+export interface A11yDragResult {
+  success: boolean;
+  totalTimeMs: number;
+  gestureTimeMs?: number;
+  error?: string;
+  perfTiming?: AndroidPerfTiming[];
+}
+
+/**
  * Interface for set text result from accessibility service
  */
 export interface A11ySetTextResult {
@@ -425,6 +436,8 @@ export class AccessibilityServiceClient implements AccessibilityService {
   // Swipe handling
   private pendingSwipeResolve: ((result: A11ySwipeResult) => void) | null = null;
   private pendingSwipeRequestId: string | null = null;
+  private pendingDragResolve: ((result: A11yDragResult) => void) | null = null;
+  private pendingDragRequestId: string | null = null;
 
   // Set text handling
   private pendingSetTextResolve: ((result: A11ySetTextResult) => void) | null = null;
@@ -758,6 +771,24 @@ export class AccessibilityServiceClient implements AccessibilityService {
           totalTimeMs: swipeMessage.totalTimeMs,
           gestureTimeMs: swipeMessage.gestureTimeMs,
           error: swipeMessage.error,
+          perfTiming
+        });
+      }
+
+      // Handle drag result
+      if (message.type === "drag_result" && this.pendingDragResolve) {
+        const dragMessage = message as any;
+        const perfTiming = dragMessage.perfTiming as AndroidPerfTiming[] | undefined;
+        logger.debug(`[ACCESSIBILITY_SERVICE] Drag result (requestId: ${dragMessage.requestId}, success: ${dragMessage.success}, totalTimeMs: ${dragMessage.totalTimeMs}, gestureTimeMs: ${dragMessage.gestureTimeMs}, perfTiming: ${perfTiming ? "present" : "absent"})`);
+
+        const resolve = this.pendingDragResolve;
+        this.pendingDragResolve = null;
+        this.pendingDragRequestId = null;
+        resolve({
+          success: dragMessage.success,
+          totalTimeMs: dragMessage.totalTimeMs,
+          gestureTimeMs: dragMessage.gestureTimeMs,
+          error: dragMessage.error,
           perfTiming
         });
       }
@@ -1717,6 +1748,93 @@ export class AccessibilityServiceClient implements AccessibilityService {
       return {
         success: false,
         totalTimeMs: duration,
+        error: `${error}`
+      };
+    }
+  }
+
+  /**
+   * Request a drag gesture from the accessibility service using dispatchGesture API.
+   * @param x1 - Starting X coordinate
+   * @param y1 - Starting Y coordinate
+   * @param x2 - Ending X coordinate
+   * @param y2 - Ending Y coordinate
+   * @param duration - Drag duration in milliseconds
+   * @param holdTime - Hold time before dragging in milliseconds
+   * @param timeoutMs - Maximum time to wait for drag completion in milliseconds
+   * @returns Promise<A11yDragResult> - The drag result with timing information
+   */
+  async requestDrag(
+    x1: number,
+    y1: number,
+    x2: number,
+    y2: number,
+    duration: number = 500,
+    holdTime: number = 200,
+    timeoutMs: number = 5000
+  ): Promise<A11yDragResult> {
+    const startTime = Date.now();
+
+    try {
+      const connected = await this.connectWebSocket();
+      if (!connected) {
+        logger.warn("[ACCESSIBILITY_SERVICE] Failed to establish WebSocket connection for drag");
+        return {
+          success: false,
+          totalTimeMs: Date.now() - startTime,
+          error: "Failed to connect to accessibility service"
+        };
+      }
+
+      const requestId = `drag_${Date.now()}_${generateSecureId()}`;
+      this.pendingDragRequestId = requestId;
+
+      const dragPromise = new Promise<A11yDragResult>(resolve => {
+        this.pendingDragResolve = resolve;
+        this.timer.setTimeout(() => {
+          if (this.pendingDragResolve === resolve) {
+            this.pendingDragResolve = null;
+            this.pendingDragRequestId = null;
+            resolve({
+              success: false,
+              totalTimeMs: Date.now() - startTime,
+              error: `Drag timeout after ${timeoutMs}ms`
+            });
+          }
+        }, timeoutMs);
+      });
+
+      if (!this.ws || this.ws.readyState !== WebSocket.OPEN) {
+        throw new Error("WebSocket not connected");
+      }
+      const message = JSON.stringify({
+        type: "request_drag",
+        requestId,
+        x1: Math.round(x1),
+        y1: Math.round(y1),
+        x2: Math.round(x2),
+        y2: Math.round(y2),
+        duration,
+        holdTime
+      });
+      this.ws.send(message);
+      logger.debug(`[ACCESSIBILITY_SERVICE] Sent drag request (requestId: ${requestId}, ${x1},${y1} -> ${x2},${y2}, duration: ${duration}ms, hold: ${holdTime}ms)`);
+
+      const result = await dragPromise;
+      const clientDuration = Date.now() - startTime;
+      if (result.success) {
+        logger.info(`[ACCESSIBILITY_SERVICE] Drag completed: clientTime=${clientDuration}ms, deviceTotalTime=${result.totalTimeMs}ms, gestureTime=${result.gestureTimeMs}ms`);
+      } else {
+        logger.warn(`[ACCESSIBILITY_SERVICE] Drag failed after ${clientDuration}ms: ${result.error}`);
+      }
+
+      return result;
+    } catch (error) {
+      const durationMs = Date.now() - startTime;
+      logger.warn(`[ACCESSIBILITY_SERVICE] Drag request failed after ${durationMs}ms: ${error}`);
+      return {
+        success: false,
+        totalTimeMs: durationMs,
         error: `${error}`
       };
     }

--- a/src/models/DragAndDropOptions.ts
+++ b/src/models/DragAndDropOptions.ts
@@ -1,0 +1,12 @@
+export interface DragAndDropTarget {
+  text?: string;
+  elementId?: string;
+}
+
+export interface DragAndDropOptions {
+  source: DragAndDropTarget;
+  target: DragAndDropTarget;
+  duration?: number;
+  holdTime?: number;
+  dropDelay?: number;
+}

--- a/src/models/DragAndDropResult.ts
+++ b/src/models/DragAndDropResult.ts
@@ -1,0 +1,11 @@
+import { ObserveResult } from "./ObserveResult";
+
+export interface DragAndDropResult {
+  success: boolean;
+  duration: number;
+  distance: number;
+  observation?: ObserveResult;
+  error?: string;
+  a11yTotalTimeMs?: number;
+  a11yGestureTimeMs?: number;
+}

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -9,6 +9,8 @@ export * from "./DeepLinkResult";
 export * from "./DemoModeResult";
 export * from "./Device";
 export * from "./DeviceSession";
+export * from "./DragAndDropOptions";
+export * from "./DragAndDropResult";
 export * from "./Element";
 export * from "./ElementBounds";
 export * from "./DeviceInfo";

--- a/src/server/interactionTools.ts
+++ b/src/server/interactionTools.ts
@@ -5,6 +5,7 @@ import { InputText } from "../features/action/InputText";
 import { ClearText } from "../features/action/ClearText";
 import { SelectAllText } from "../features/action/SelectAllText";
 import { PressButton } from "../features/action/PressButton";
+import { DragAndDrop } from "../features/action/DragAndDrop";
 import { SwipeOn } from "../features/action/SwipeOn";
 import { Shake } from "../features/action/Shake";
 import { ImeAction } from "../features/action/ImeAction";
@@ -76,6 +77,21 @@ export interface TapOnArgs {
     };
     timeout?: number;
   };
+  platform: Platform;
+}
+
+export interface DragAndDropArgs {
+  source: {
+    text?: string;
+    elementId?: string;
+  };
+  target: {
+    text?: string;
+    elementId?: string;
+  };
+  duration?: number;
+  holdTime?: number;
+  dropDelay?: number;
   platform: Platform;
 }
 
@@ -154,16 +170,20 @@ export const tapOnSchema = z.object({
 });
 
 export const dragAndDropSchema = z.object({
-  from: z.object({
-    index: z.number().describe("Index of the source element to drag"),
-    text: z.string().optional().describe("Optional text for validation and debugging")
+  source: z.object({
+    text: z.string().optional().describe("Text of the source element to drag"),
+    elementId: z.string().optional().describe("Element ID of the source element to drag")
   }).describe("Source element to drag from"),
-  to: z.object({
-    index: z.number().describe("Index of the destination element to drop to"),
-    text: z.string().optional().describe("Optional text for validation and debugging")
-  }).describe("Destination element to drop to"),
+  target: z.object({
+    text: z.string().optional().describe("Text of the target element to drop onto"),
+    elementId: z.string().optional().describe("Element ID of the target element to drop onto")
+  }).describe("Target element to drop onto"),
   duration: z.number().optional().describe("Duration of the drag in milliseconds (default: 500)"),
-  platform: z.enum(["android", "ios"]).describe("Platform of the device")
+  holdTime: z.number().optional().describe("Hold time before dragging in milliseconds (default: 200)"),
+  dropDelay: z.number().optional().describe("Delay after dropping in milliseconds (default: 100)"),
+  platform: z.enum(["android", "ios"]).describe("Platform of the device"),
+  sessionUuid: z.string().optional(),
+  deviceId: z.string().optional()
 });
 
 export const swipeOnSchema = z.object({
@@ -443,6 +463,25 @@ export function registerInteractionTools() {
 
     return createJSONToolResponse({
       message: `Tapped on element`,
+      observation: result.observation,
+      ...result
+    });
+  };
+
+  // Drag and drop handler
+  const dragAndDropHandler = async (device: BootedDevice, args: DragAndDropArgs, progress?: ProgressCallback) => {
+    RecompositionTracker.getInstance().recordInteraction();
+    const dragAndDrop = new DragAndDrop(device);
+    const result = await dragAndDrop.execute({
+      source: args.source,
+      target: args.target,
+      duration: args.duration,
+      holdTime: args.holdTime,
+      dropDelay: args.dropDelay
+    }, progress);
+
+    return createJSONToolResponse({
+      message: "Dragged element to target",
       observation: result.observation,
       ...result
     });
@@ -791,6 +830,14 @@ export function registerInteractionTools() {
     "Tap supporting text or resourceId",
     tapOnSchema,
     tapOnHandler,
+    true // Supports progress notifications
+  );
+
+  ToolRegistry.registerDeviceAware(
+    "dragAndDrop",
+    "Drag an element and drop it onto another element",
+    dragAndDropSchema,
+    dragAndDropHandler,
     true // Supports progress notifications
   );
 

--- a/src/server/toolRegistry.ts
+++ b/src/server/toolRegistry.ts
@@ -124,7 +124,7 @@ class ToolRegistryClass {
         // Excludes app lifecycle tools (launchApp, terminateApp, homeScreen, etc.)
         // as they don't represent replayable in-app navigation paths
         const navigationRelevantTools = [
-          "tapOn", "swipeOn",
+          "tapOn", "swipeOn", "dragAndDrop",
           "pressButton", "pressKey", "inputText", "clearText", "imeAction"
         ];
         if (navigationRelevantTools.includes(name)) {
@@ -209,7 +209,7 @@ class ToolRegistryClass {
           }
 
           // Update last action timestamp for interaction tools
-          if (["tapOn", "swipeOn", "scroll", "inputText", "clearText", "pressButton"].includes(name)) {
+          if (["tapOn", "swipeOn", "dragAndDrop", "scroll", "inputText", "clearText", "pressButton"].includes(name)) {
             await updateSessionCache(context, "lastActionTime", Date.now());
           }
         }


### PR DESCRIPTION
## Summary
- add Android-only dragAndDrop MCP tool backed by accessibility-service drag gestures
- wire drag request/response handling through the accessibility service WebSocket path
- enforce accessibility-service installation requirement (iOS returns not supported)

## Testing
- bun run build

## Issue
- Closes #265
