### PR TITLE
IDE plugin: Unix socket transport for MCP attachment

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,8 @@
 # AutoMobile Codex Instructions
 
 ## Project rules
-- TypeScript only; do not add JavaScript.
+- Multi-language monorepo: TypeScript for core tooling, Kotlin for `android/` projects.
+- Do not add JavaScript (prefer TypeScript or Kotlin as appropriate).
 - `android/` is an Android Kotlin Gradle project containing apps and libraries.
 - After implementation changes, run relevant validation commands.
 - Write terminal output to `scratch/` when command output is not visible in the session.

--- a/android/ide-plugin/README.md
+++ b/android/ide-plugin/README.md
@@ -3,9 +3,15 @@
 IntelliJ/Android Studio plugin scaffold for AutoMobile.
 
 ## Goals
-- Attach to a running AutoMobile MCP server (Unix socket first).
+- Attach to a running AutoMobile MCP server or MCP daemon.
 - Render and import/export navigation graphs.
 - Toggle feature flags without restarting the MCP server.
+
+## MCP transport selection
+The plugin selects the MCP transport in this order:
+1. `AUTO_MOBILE_MCP_HTTP_URL` (or `-Dautomobile.mcp.httpUrl`) for Streamable HTTP.
+2. `AUTO_MOBILE_MCP_STDIO_COMMAND` (or `-Dautomobile.mcp.stdioCommand`) for stdio.
+3. Unix socket fallback at `/tmp/auto-mobile-daemon-<uid>.sock`.
 
 ## Local development
 Use the Android Gradle wrapper from the repository root:

--- a/android/ide-plugin/src/main/kotlin/com/automobile/ide/AutoMobileToolWindowContent.kt
+++ b/android/ide-plugin/src/main/kotlin/com/automobile/ide/AutoMobileToolWindowContent.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -15,8 +16,8 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
-import com.automobile.ide.daemon.DaemonUnavailableException
-import com.automobile.ide.daemon.McpDaemonClient
+import com.automobile.ide.daemon.McpClientFactory
+import com.automobile.ide.daemon.McpConnectionException
 import com.automobile.ide.daemon.McpResource
 import com.automobile.ide.daemon.McpResourceTemplate
 import kotlinx.coroutines.Dispatchers
@@ -30,12 +31,18 @@ import org.jetbrains.jewel.ui.component.Text
 @Composable
 fun AutoMobileToolWindowContent() {
   val scope = rememberCoroutineScope()
-  val daemonClient = remember { McpDaemonClient() }
+  val client = remember { McpClientFactory.create() }
   var statusText by remember { mutableStateOf("Not connected") }
   var lastError by remember { mutableStateOf<String?>(null) }
   var resources by remember { mutableStateOf<List<McpResource>>(emptyList()) }
   var templates by remember { mutableStateOf<List<McpResourceTemplate>>(emptyList()) }
   var navGraphSnippet by remember { mutableStateOf<String?>(null) }
+
+  DisposableEffect(Unit) {
+    onDispose {
+      client.close()
+    }
+  }
 
   IntUiTheme {
     Column(
@@ -44,7 +51,8 @@ fun AutoMobileToolWindowContent() {
     ) {
       Text("AutoMobile")
       Text("Status: $statusText")
-      Text("Socket: ${daemonClient.socketPath}")
+      Text("Transport: ${client.transportName}")
+      Text("Endpoint: ${client.connectionDescription}")
       if (lastError != null) {
         Text("Error: ${lastError ?: ""}")
       }
@@ -57,12 +65,12 @@ fun AutoMobileToolWindowContent() {
             navGraphSnippet = null
             try {
               withContext(Dispatchers.IO) {
-                daemonClient.ping()
-                resources = daemonClient.listResources()
-                templates = daemonClient.listResourceTemplates()
+                client.ping()
+                resources = client.listResources()
+                templates = client.listResourceTemplates()
               }
               statusText = "Connected"
-            } catch (e: DaemonUnavailableException) {
+            } catch (e: McpConnectionException) {
               statusText = "Not connected"
               lastError = e.message
             }
@@ -75,10 +83,10 @@ fun AutoMobileToolWindowContent() {
             lastError = null
             try {
               withContext(Dispatchers.IO) {
-                resources = daemonClient.listResources()
-                templates = daemonClient.listResourceTemplates()
+                resources = client.listResources()
+                templates = client.listResourceTemplates()
               }
-            } catch (e: DaemonUnavailableException) {
+            } catch (e: McpConnectionException) {
               lastError = e.message
             }
           }
@@ -106,9 +114,9 @@ fun AutoMobileToolWindowContent() {
           scope.launch {
             lastError = null
             try {
-              val result = withContext(Dispatchers.IO) { daemonClient.getNavigationGraph() }
+              val result = withContext(Dispatchers.IO) { client.getNavigationGraph() }
               navGraphSnippet = result.toString().take(500)
-            } catch (e: DaemonUnavailableException) {
+            } catch (e: McpConnectionException) {
               lastError = e.message
             }
           }

--- a/android/ide-plugin/src/main/kotlin/com/automobile/ide/daemon/AutoMobileClient.kt
+++ b/android/ide-plugin/src/main/kotlin/com/automobile/ide/daemon/AutoMobileClient.kt
@@ -1,0 +1,76 @@
+package com.automobile.ide.daemon
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.JsonElement
+
+interface AutoMobileClient {
+  val transportName: String
+  val connectionDescription: String
+
+  fun ping()
+  fun listResources(): List<McpResource>
+  fun listResourceTemplates(): List<McpResourceTemplate>
+  fun readResource(uri: String): List<McpResourceContent>
+  fun getNavigationGraph(platform: String = "android"): JsonElement
+  fun close() {}
+}
+
+open class McpConnectionException(message: String, cause: Throwable? = null) : Exception(message, cause)
+
+@Serializable
+data class McpResource(
+    val uri: String,
+    val name: String,
+    val description: String? = null,
+    val mimeType: String? = null,
+)
+
+@Serializable
+data class McpResourceTemplate(
+    @SerialName("uriTemplate") val uriTemplate: String,
+    val name: String,
+    val description: String? = null,
+    val mimeType: String? = null,
+)
+
+@Serializable
+data class McpResourceContent(
+    val uri: String,
+    val mimeType: String? = null,
+    val text: String? = null,
+    val blob: String? = null,
+)
+
+@Serializable
+data class JsonRpcRequest(
+    val jsonrpc: String = "2.0",
+    val id: JsonElement? = null,
+    val method: String,
+    val params: JsonElement? = null,
+)
+
+@Serializable
+data class JsonRpcResponse(
+    val jsonrpc: String,
+    val id: JsonElement? = null,
+    val result: JsonElement? = null,
+    val error: JsonRpcError? = null,
+)
+
+@Serializable
+data class JsonRpcError(
+    val code: Int,
+    val message: String,
+)
+
+@Serializable
+internal data class ListResourcesResult(val resources: List<McpResource>)
+
+@Serializable
+internal data class ListResourceTemplatesResult(val resourceTemplates: List<McpResourceTemplate>)
+
+@Serializable
+internal data class ReadResourceResult(val contents: List<McpResourceContent>)
+
+internal const val LATEST_MCP_PROTOCOL_VERSION = "2025-11-25"

--- a/android/ide-plugin/src/main/kotlin/com/automobile/ide/daemon/McpClientFactory.kt
+++ b/android/ide-plugin/src/main/kotlin/com/automobile/ide/daemon/McpClientFactory.kt
@@ -1,0 +1,36 @@
+package com.automobile.ide.daemon
+
+object McpClientFactory {
+  fun create(): AutoMobileClient {
+    val httpUrl = readSetting("AUTO_MOBILE_MCP_HTTP_URL", "automobile.mcp.httpUrl")
+    if (!httpUrl.isNullOrBlank()) {
+      return McpHttpClient(normalizeHttpUrl(httpUrl))
+    }
+
+    val stdioCommand = readSetting("AUTO_MOBILE_MCP_STDIO_COMMAND", "automobile.mcp.stdioCommand")
+    if (!stdioCommand.isNullOrBlank()) {
+      return McpStdioClient(stdioCommand)
+    }
+
+    return McpDaemonClient()
+  }
+
+  private fun readSetting(envKey: String, propertyKey: String): String? {
+    val envValue = System.getenv(envKey)
+    if (!envValue.isNullOrBlank()) {
+      return envValue
+    }
+    val propertyValue = System.getProperty(propertyKey)
+    return propertyValue?.takeIf { it.isNotBlank() }
+  }
+
+  private fun normalizeHttpUrl(raw: String): String {
+    val trimmed = raw.trim().removeSuffix("/")
+    return when {
+      trimmed.endsWith("/auto-mobile/streamable") || trimmed.endsWith("/auto-mobile/sse") -> trimmed
+      trimmed.endsWith("/auto-mobile") -> "$trimmed/streamable"
+      trimmed.contains("/auto-mobile/") -> trimmed
+      else -> "$trimmed/auto-mobile/streamable"
+    }
+  }
+}

--- a/android/ide-plugin/src/main/kotlin/com/automobile/ide/daemon/McpDaemonClient.kt
+++ b/android/ide-plugin/src/main/kotlin/com/automobile/ide/daemon/McpDaemonClient.kt
@@ -11,7 +11,6 @@ import java.nio.channels.SocketChannel
 import java.nio.charset.StandardCharsets
 import java.nio.file.Files
 import java.util.UUID
-import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.encodeToString
@@ -25,29 +24,34 @@ import kotlinx.serialization.json.decodeFromJsonElement
 class McpDaemonClient(
     private val socketPathValue: String = DaemonSocketPaths.socketPath(),
     private val json: Json = Json { ignoreUnknownKeys = true },
-) {
+) : AutoMobileClient {
   val socketPath: String
     get() = socketPathValue
 
-  fun ping(): DaemonResponse {
-    return sendRequest("ide/ping")
+  override val transportName: String = "Unix Socket"
+  override val connectionDescription: String
+    get() = socketPathValue
+
+  override fun ping() {
+    val response = sendRequest("ide/ping")
+    ensureSuccess(response)
   }
 
-  fun listResources(): List<McpResource> {
+  override fun listResources(): List<McpResource> {
     val response = sendRequest("resources/list")
     ensureSuccess(response)
     val result = json.decodeFromJsonElement(ListResourcesResult.serializer(), response.result!!)
     return result.resources
   }
 
-  fun listResourceTemplates(): List<McpResourceTemplate> {
+  override fun listResourceTemplates(): List<McpResourceTemplate> {
     val response = sendRequest("resources/list-templates")
     ensureSuccess(response)
     val result = json.decodeFromJsonElement(ListResourceTemplatesResult.serializer(), response.result!!)
     return result.resourceTemplates
   }
 
-  fun readResource(uri: String): List<McpResourceContent> {
+  override fun readResource(uri: String): List<McpResourceContent> {
     val response = sendRequest(
         "resources/read",
         buildJsonObject { put("uri", JsonPrimitive(uri)) },
@@ -57,7 +61,7 @@ class McpDaemonClient(
     return result.contents
   }
 
-  fun getNavigationGraph(platform: String = "android"): JsonElement {
+  override fun getNavigationGraph(platform: String): JsonElement {
     val response = sendRequest(
         "ide/getNavigationGraph",
         buildJsonObject { put("platform", JsonPrimitive(platform)) },
@@ -153,37 +157,4 @@ data class DaemonResponse(
     val error: String? = null,
 )
 
-class DaemonUnavailableException(message: String) : Exception(message)
-
-@Serializable
-data class McpResource(
-    val uri: String,
-    val name: String,
-    val description: String? = null,
-    val mimeType: String? = null,
-)
-
-@Serializable
-data class McpResourceTemplate(
-    @SerialName("uriTemplate") val uriTemplate: String,
-    val name: String,
-    val description: String? = null,
-    val mimeType: String? = null,
-)
-
-@Serializable
-data class McpResourceContent(
-    val uri: String,
-    val mimeType: String? = null,
-    val text: String? = null,
-    val blob: String? = null,
-)
-
-@Serializable
-private data class ListResourcesResult(val resources: List<McpResource>)
-
-@Serializable
-private data class ListResourceTemplatesResult(val resourceTemplates: List<McpResourceTemplate>)
-
-@Serializable
-private data class ReadResourceResult(val contents: List<McpResourceContent>)
+class DaemonUnavailableException(message: String) : McpConnectionException(message)

--- a/android/ide-plugin/src/main/kotlin/com/automobile/ide/daemon/McpHttpClient.kt
+++ b/android/ide-plugin/src/main/kotlin/com/automobile/ide/daemon/McpHttpClient.kt
@@ -1,0 +1,166 @@
+package com.automobile.ide.daemon
+
+import java.net.URI
+import java.net.http.HttpClient
+import java.net.http.HttpRequest
+import java.net.http.HttpResponse
+import java.util.UUID
+import kotlinx.serialization.decodeFromString
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.decodeFromJsonElement
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.put
+
+class McpHttpClient(
+    private val endpoint: String,
+    private val json: Json = Json { ignoreUnknownKeys = true },
+) : AutoMobileClient {
+  override val transportName: String = "MCP HTTP"
+  override val connectionDescription: String = endpoint
+
+  private val httpClient = HttpClient.newBuilder().build()
+  private var sessionId: String? = null
+  private var protocolVersion: String? = null
+  private var initialized = false
+
+  override fun ping() {
+    ensureInitialized()
+  }
+
+  override fun listResources(): List<McpResource> {
+    ensureInitialized()
+    val response = sendRequest("resources/list")
+    val result = json.decodeFromJsonElement(ListResourcesResult.serializer(), response.result!!)
+    return result.resources
+  }
+
+  override fun listResourceTemplates(): List<McpResourceTemplate> {
+    ensureInitialized()
+    val response = sendRequest("resources/list-templates")
+    val result = json.decodeFromJsonElement(ListResourceTemplatesResult.serializer(), response.result!!)
+    return result.resourceTemplates
+  }
+
+  override fun readResource(uri: String): List<McpResourceContent> {
+    ensureInitialized()
+    val response = sendRequest(
+        "resources/read",
+        buildJsonObject { put("uri", JsonPrimitive(uri)) },
+    )
+    val result = json.decodeFromJsonElement(ReadResourceResult.serializer(), response.result!!)
+    return result.contents
+  }
+
+  override fun getNavigationGraph(platform: String): JsonElement {
+    ensureInitialized()
+    val response = sendRequest(
+        "tools/call",
+        buildJsonObject {
+          put("name", JsonPrimitive("getNavigationGraph"))
+          put("arguments", buildJsonObject { put("platform", JsonPrimitive(platform)) })
+        },
+    )
+    return response.result ?: JsonObject(emptyMap())
+  }
+
+  private fun ensureInitialized() {
+    if (initialized) {
+      return
+    }
+
+    val response = sendRequest(
+        "initialize",
+        buildJsonObject {
+          put("protocolVersion", JsonPrimitive(LATEST_MCP_PROTOCOL_VERSION))
+          put("capabilities", JsonObject(emptyMap()))
+          put(
+              "clientInfo",
+              buildJsonObject {
+                put("name", JsonPrimitive("auto-mobile-ide-plugin"))
+                put("version", JsonPrimitive("0.1.0"))
+              },
+          )
+        },
+        includeSession = false,
+    )
+
+    val result = response.result?.jsonObject
+        ?: throw McpConnectionException("Initialize response missing result")
+    protocolVersion = result["protocolVersion"]?.jsonPrimitive?.content
+        ?: LATEST_MCP_PROTOCOL_VERSION
+    initialized = true
+
+    sendNotification("notifications/initialized")
+  }
+
+  private fun sendNotification(method: String, params: JsonElement? = null) {
+    val request = JsonRpcRequest(
+        id = null,
+        method = method,
+        params = params,
+    )
+    sendRequest(request, includeSession = true, expectResponse = false)
+  }
+
+  private fun sendRequest(method: String, params: JsonElement? = null, includeSession: Boolean = true): JsonRpcResponse {
+    val requestId = JsonPrimitive(UUID.randomUUID().toString())
+    val request = JsonRpcRequest(
+        id = requestId,
+        method = method,
+        params = params,
+    )
+    return sendRequest(request, includeSession = includeSession, expectResponse = true)
+  }
+
+  private fun sendRequest(
+      request: JsonRpcRequest,
+      includeSession: Boolean,
+      expectResponse: Boolean,
+  ): JsonRpcResponse {
+    val requestBody = json.encodeToString(JsonRpcRequest.serializer(), request)
+    val builder = HttpRequest.newBuilder(URI.create(endpoint))
+        .header("Content-Type", "application/json")
+
+    if (includeSession && sessionId != null) {
+      builder.header("mcp-session-id", sessionId!!)
+    }
+    if (protocolVersion != null) {
+      builder.header("mcp-protocol-version", protocolVersion!!)
+    }
+
+    val response = httpClient.send(
+        builder.POST(HttpRequest.BodyPublishers.ofString(requestBody)).build(),
+        HttpResponse.BodyHandlers.ofString(),
+    )
+
+    response.headers().firstValue("mcp-session-id").ifPresent { header ->
+      if (header.isNotBlank()) {
+        sessionId = header
+      }
+    }
+
+    if (!expectResponse) {
+      return JsonRpcResponse(jsonrpc = "2.0")
+    }
+
+    val body = response.body().trim()
+    if (body.isEmpty()) {
+      throw McpConnectionException("MCP HTTP response was empty")
+    }
+
+    val rpcResponse = json.decodeFromString(JsonRpcResponse.serializer(), body)
+    if (rpcResponse.error != null) {
+      throw McpConnectionException("MCP HTTP error ${rpcResponse.error.code}: ${rpcResponse.error.message}")
+    }
+    if (rpcResponse.result == null) {
+      throw McpConnectionException("MCP HTTP response missing result")
+    }
+    return rpcResponse
+  }
+}

--- a/android/ide-plugin/src/main/kotlin/com/automobile/ide/daemon/McpStdioClient.kt
+++ b/android/ide-plugin/src/main/kotlin/com/automobile/ide/daemon/McpStdioClient.kt
@@ -1,0 +1,238 @@
+package com.automobile.ide.daemon
+
+import java.io.BufferedReader
+import java.io.BufferedWriter
+import java.io.InputStreamReader
+import java.io.OutputStreamWriter
+import java.util.UUID
+import kotlinx.serialization.decodeFromString
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.decodeFromJsonElement
+import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.put
+
+class McpStdioClient(
+    private val command: String,
+    private val json: Json = Json { ignoreUnknownKeys = true },
+) : AutoMobileClient {
+  override val transportName: String = "MCP STDIO"
+  override val connectionDescription: String = command
+
+  private var process: Process? = null
+  private var reader: BufferedReader? = null
+  private var writer: BufferedWriter? = null
+  private var initialized = false
+
+  override fun ping() {
+    ensureInitialized()
+  }
+
+  override fun listResources(): List<McpResource> {
+    ensureInitialized()
+    val response = sendRequest("resources/list")
+    val result = json.decodeFromJsonElement(ListResourcesResult.serializer(), response.result!!)
+    return result.resources
+  }
+
+  override fun listResourceTemplates(): List<McpResourceTemplate> {
+    ensureInitialized()
+    val response = sendRequest("resources/list-templates")
+    val result = json.decodeFromJsonElement(ListResourceTemplatesResult.serializer(), response.result!!)
+    return result.resourceTemplates
+  }
+
+  override fun readResource(uri: String): List<McpResourceContent> {
+    ensureInitialized()
+    val response = sendRequest(
+        "resources/read",
+        buildJsonObject { put("uri", JsonPrimitive(uri)) },
+    )
+    val result = json.decodeFromJsonElement(ReadResourceResult.serializer(), response.result!!)
+    return result.contents
+  }
+
+  override fun getNavigationGraph(platform: String): JsonElement {
+    ensureInitialized()
+    val response = sendRequest(
+        "tools/call",
+        buildJsonObject {
+          put("name", JsonPrimitive("getNavigationGraph"))
+          put("arguments", buildJsonObject { put("platform", JsonPrimitive(platform)) })
+        },
+    )
+    return response.result ?: JsonObject(emptyMap())
+  }
+
+  override fun close() {
+    try {
+      writer?.flush()
+    } catch (_: Exception) {
+    }
+    process?.destroy()
+    process = null
+    reader = null
+    writer = null
+  }
+
+  private fun ensureInitialized() {
+    if (initialized) {
+      return
+    }
+    ensureProcessStarted()
+
+    val response = sendRequest(
+        "initialize",
+        buildJsonObject {
+          put("protocolVersion", JsonPrimitive(LATEST_MCP_PROTOCOL_VERSION))
+          put("capabilities", JsonObject(emptyMap()))
+          put(
+              "clientInfo",
+              buildJsonObject {
+                put("name", JsonPrimitive("auto-mobile-ide-plugin"))
+                put("version", JsonPrimitive("0.1.0"))
+              },
+          )
+        },
+    )
+    if (response.result == null) {
+      throw McpConnectionException("Initialize response missing result")
+    }
+    initialized = true
+    sendNotification("notifications/initialized")
+  }
+
+  private fun sendNotification(method: String, params: JsonElement? = null) {
+    val request = JsonRpcRequest(
+        id = null,
+        method = method,
+        params = params,
+    )
+    sendRequest(request, expectResponse = false)
+  }
+
+  private fun sendRequest(method: String, params: JsonElement? = null): JsonRpcResponse {
+    val requestId = JsonPrimitive(UUID.randomUUID().toString())
+    val request = JsonRpcRequest(
+        id = requestId,
+        method = method,
+        params = params,
+    )
+    return sendRequest(request, expectResponse = true)
+  }
+
+  private fun sendRequest(request: JsonRpcRequest, expectResponse: Boolean): JsonRpcResponse {
+    ensureProcessStarted()
+    val currentWriter = writer ?: throw McpConnectionException("MCP stdio writer unavailable")
+    val currentReader = reader ?: throw McpConnectionException("MCP stdio reader unavailable")
+
+    val requestBody = json.encodeToString(JsonRpcRequest.serializer(), request)
+    currentWriter.write(requestBody)
+    currentWriter.newLine()
+    currentWriter.flush()
+
+    if (!expectResponse) {
+      return JsonRpcResponse(jsonrpc = "2.0")
+    }
+
+    val expectedId = request.id?.jsonPrimitive?.content
+    while (true) {
+      val line = currentReader.readLine() ?: throw McpConnectionException("MCP stdio closed")
+      if (line.isBlank()) {
+        continue
+      }
+      val response = json.decodeFromString(JsonRpcResponse.serializer(), line)
+      val responseId = response.id?.jsonPrimitive?.content
+      if (expectedId != null && responseId != expectedId) {
+        continue
+      }
+      if (response.error != null) {
+        throw McpConnectionException("MCP stdio error ${response.error.code}: ${response.error.message}")
+      }
+      if (response.result == null) {
+        throw McpConnectionException("MCP stdio response missing result")
+      }
+      return response
+    }
+  }
+
+  private fun ensureProcessStarted() {
+    if (process != null) {
+      return
+    }
+
+    val commandParts = parseCommand(command)
+    if (commandParts.isEmpty()) {
+      throw McpConnectionException("MCP stdio command is empty")
+    }
+
+    val newProcess = ProcessBuilder(commandParts)
+        .redirectError(ProcessBuilder.Redirect.INHERIT)
+        .start()
+    process = newProcess
+    reader = BufferedReader(InputStreamReader(newProcess.inputStream))
+    writer = BufferedWriter(OutputStreamWriter(newProcess.outputStream))
+  }
+
+  private fun parseCommand(command: String): List<String> {
+    val parts = mutableListOf<String>()
+    val current = StringBuilder()
+    var inSingle = false
+    var inDouble = false
+    var escapeNext = false
+
+    fun flushCurrent() {
+      if (current.isNotEmpty()) {
+        parts.add(current.toString())
+        current.clear()
+      }
+    }
+
+    for (char in command) {
+      if (escapeNext) {
+        current.append(char)
+        escapeNext = false
+        continue
+      }
+
+      when (char) {
+        '\\' -> {
+          if (inDouble) {
+            escapeNext = true
+          } else {
+            current.append(char)
+          }
+        }
+        '\'' -> {
+          if (!inDouble) {
+            inSingle = !inSingle
+          } else {
+            current.append(char)
+          }
+        }
+        '"' -> {
+          if (!inSingle) {
+            inDouble = !inDouble
+          } else {
+            current.append(char)
+          }
+        }
+        ' ', '\t', '\n' -> {
+          if (inSingle || inDouble) {
+            current.append(char)
+          } else {
+            flushCurrent()
+          }
+        }
+        else -> current.append(char)
+      }
+    }
+
+    flushCurrent()
+    return parts
+  }
+}

--- a/scripts/ide-plugin/validate.sh
+++ b/scripts/ide-plugin/validate.sh
@@ -6,4 +6,6 @@ ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 (
   cd "$ROOT_DIR/android"
   ./gradlew -p ide-plugin build
+  ./gradlew -p ide-plugin buildPlugin
+  ./gradlew -p ide-plugin verifyPlugin
 )


### PR DESCRIPTION
## Summary
- add transport selection for the IDE plugin: HTTP or stdio when configured, unix socket fallback
- implement JSON-RPC client support for Streamable HTTP and stdio (initialize + notifications)
- surface active transport/endpoint in the tool window and close stdio processes on dispose
- expand IDE plugin validation to include packaging and plugin verification
- clarify multi-language monorepo guidance in `AGENTS.md`

## Details
- HTTP transport: set `AUTO_MOBILE_MCP_HTTP_URL` or `-Dautomobile.mcp.httpUrl` (auto-normalizes to `/auto-mobile/streamable`)
- STDIO transport: set `AUTO_MOBILE_MCP_STDIO_COMMAND` or `-Dautomobile.mcp.stdioCommand`
- Unix socket fallback path remains `/tmp/auto-mobile-daemon-<uid>.sock`

## Testing
- `scripts/ide-plugin/validate.sh`

## Issue
- Fixes #252
