### PR TITLE
IDE plugin: add MCP discovery interfaces and tests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,6 +4,7 @@
 - Multi-language monorepo: TypeScript for core tooling, Kotlin for `android/` projects.
 - Do not add JavaScript (prefer TypeScript or Kotlin as appropriate).
 - `android/` is an Android Kotlin Gradle project containing apps and libraries.
+- IntelliJ IDE plugin lives in `android/ide-plugin` (Gradle project).
 - After implementation changes, run relevant validation commands.
 - Write terminal output to `scratch/` when command output is not visible in the session.
 - Validation guidance: `docs/ai/validation.md`.

--- a/android/ide-plugin/README.md
+++ b/android/ide-plugin/README.md
@@ -9,9 +9,13 @@ IntelliJ/Android Studio plugin scaffold for AutoMobile.
 
 ## MCP transport selection
 The plugin selects the MCP transport in this order:
-1. `AUTO_MOBILE_MCP_HTTP_URL` (or `-Dautomobile.mcp.httpUrl`) for Streamable HTTP.
-2. `AUTO_MOBILE_MCP_STDIO_COMMAND` (or `-Dautomobile.mcp.stdioCommand`) for stdio.
-3. Unix socket fallback at `/tmp/auto-mobile-daemon-<uid>.sock`.
+1. Discovered MCP dev server over HTTP (health-checked on localhost).
+2. `AUTO_MOBILE_MCP_HTTP_URL` (or `-Dautomobile.mcp.httpUrl`) for Streamable HTTP.
+3. `AUTO_MOBILE_MCP_STDIO_COMMAND` (or `-Dautomobile.mcp.stdioCommand`) for stdio.
+4. Unix socket fallback at `/tmp/auto-mobile-daemon-<uid>.sock`.
+
+The tool window lists git worktrees and any matching MCP dev servers. Use the dropdown to pick which worktree/server
+to attach before connecting.
 
 ## Local development
 Use the Android Gradle wrapper from the repository root:

--- a/android/ide-plugin/build.gradle.kts
+++ b/android/ide-plugin/build.gradle.kts
@@ -28,6 +28,8 @@ dependencies {
   implementation("org.jetbrains.jewel:jewel-int-ui-standalone:0.33.0-253.29795")
   implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.10.2")
   implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.7.3")
+  testImplementation("junit:junit:4.13.2")
+  testImplementation("org.jetbrains.kotlin:kotlin-test")
 
   intellijPlatform {
     intellijIdea("2025.3")

--- a/android/ide-plugin/src/main/kotlin/com/automobile/ide/AutoMobileToolWindowContent.kt
+++ b/android/ide-plugin/src/main/kotlin/com/automobile/ide/AutoMobileToolWindowContent.kt
@@ -17,31 +17,81 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import com.automobile.ide.daemon.McpClientFactory
+import com.automobile.ide.daemon.McpDiscoverySnapshot
+import com.automobile.ide.daemon.McpHttpDiscovery
+import com.automobile.ide.daemon.McpServerOption
 import com.automobile.ide.daemon.McpConnectionException
 import com.automobile.ide.daemon.McpResource
 import com.automobile.ide.daemon.McpResourceTemplate
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import org.jetbrains.jewel.ui.component.ListComboBox
 import org.jetbrains.jewel.intui.standalone.theme.IntUiTheme
 import org.jetbrains.jewel.ui.component.DefaultButton
 import org.jetbrains.jewel.ui.component.OutlinedButton
 import org.jetbrains.jewel.ui.component.Text
+import com.intellij.openapi.project.Project
 
 @Composable
-fun AutoMobileToolWindowContent() {
+fun AutoMobileToolWindowContent(project: Project) {
   val scope = rememberCoroutineScope()
-  val client = remember { McpClientFactory.create() }
+  val discovery = remember { McpHttpDiscovery() }
+  var discoverySnapshot by remember { mutableStateOf(McpDiscoverySnapshot.empty()) }
+  var selectedOptionId by remember { mutableStateOf<String?>(null) }
+  var client by remember { mutableStateOf(McpClientFactory.createPreferred(null)) }
   var statusText by remember { mutableStateOf("Not connected") }
   var lastError by remember { mutableStateOf<String?>(null) }
   var resources by remember { mutableStateOf<List<McpResource>>(emptyList()) }
   var templates by remember { mutableStateOf<List<McpResourceTemplate>>(emptyList()) }
   var navGraphSnippet by remember { mutableStateOf<String?>(null) }
 
-  DisposableEffect(Unit) {
+  DisposableEffect(client) {
     onDispose {
       client.close()
     }
+  }
+
+  fun resolveSelectionId(options: List<McpServerOption>): String? {
+    if (options.isEmpty()) {
+      return null
+    }
+
+    val currentId = selectedOptionId
+    if (currentId != null && options.any { it.id == currentId }) {
+      return currentId
+    }
+
+    val projectPath = project.basePath?.lowercase()
+    if (projectPath != null) {
+      val match = options.firstOrNull { option ->
+        val worktreePath = option.worktree?.path?.lowercase()
+        worktreePath != null && projectPath.startsWith(worktreePath)
+      }
+      if (match != null) {
+        return match.id
+      }
+    }
+
+    val withServer = options.firstOrNull { it.server != null }
+    return (withServer ?: options.first()).id
+  }
+
+  suspend fun refreshDiscovery(): McpDiscoverySnapshot {
+    lastError = null
+    val snapshot = withContext(Dispatchers.IO) { discovery.discover(project.basePath) }
+    discoverySnapshot = snapshot
+    selectedOptionId = resolveSelectionId(snapshot.options)
+    return snapshot
+  }
+
+  val options = discoverySnapshot.options
+  val selectedOption = options.firstOrNull { it.id == selectedOptionId }
+  val selectedIndex = options.indexOfFirst { it.id == selectedOptionId }.takeIf { it >= 0 } ?: 0
+  val optionLabels = if (options.isNotEmpty()) options.map { it.label } else listOf("No worktrees detected")
+
+  androidx.compose.runtime.LaunchedEffect(Unit) {
+    refreshDiscovery()
   }
 
   IntUiTheme {
@@ -57,6 +107,21 @@ fun AutoMobileToolWindowContent() {
         Text("Error: ${lastError ?: ""}")
       }
 
+      Column(verticalArrangement = Arrangement.spacedBy(6.dp)) {
+        Text("Worktrees / MCP servers")
+        ListComboBox(optionLabels, selectedIndex, { index ->
+          selectedOptionId = options.getOrNull(index)?.id
+        })
+        Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+          OutlinedButton(onClick = { scope.launch { refreshDiscovery() } }) {
+            Text("Rescan servers")
+          }
+          if (selectedOption != null && selectedOption.server == null) {
+            Text("Selected worktree has no running MCP server")
+          }
+        }
+      }
+
       Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
         DefaultButton(onClick = {
           scope.launch {
@@ -64,10 +129,16 @@ fun AutoMobileToolWindowContent() {
             lastError = null
             navGraphSnippet = null
             try {
+              val snapshot = refreshDiscovery()
+              val resolvedId = resolveSelectionId(snapshot.options)
+              val resolvedOption = snapshot.options.firstOrNull { it.id == resolvedId }
+              val nextClient = McpClientFactory.createPreferred(resolvedOption?.server)
+              client.close()
+              client = nextClient
               withContext(Dispatchers.IO) {
-                client.ping()
-                resources = client.listResources()
-                templates = client.listResourceTemplates()
+                nextClient.ping()
+                resources = nextClient.listResources()
+                templates = nextClient.listResourceTemplates()
               }
               statusText = "Connected"
             } catch (e: McpConnectionException) {

--- a/android/ide-plugin/src/main/kotlin/com/automobile/ide/AutoMobileToolWindowFactory.kt
+++ b/android/ide-plugin/src/main/kotlin/com/automobile/ide/AutoMobileToolWindowFactory.kt
@@ -13,7 +13,7 @@ class AutoMobileToolWindowFactory : ToolWindowFactory, DumbAware {
   override fun createToolWindowContent(project: Project, toolWindow: ToolWindow) {
     val panel = ComposePanel()
     panel.setContent {
-      AutoMobileToolWindowContent()
+      AutoMobileToolWindowContent(project)
     }
 
     val content = toolWindow.contentManager.factory.createContent(panel, "", false)

--- a/android/ide-plugin/src/main/kotlin/com/automobile/ide/daemon/McpClientFactory.kt
+++ b/android/ide-plugin/src/main/kotlin/com/automobile/ide/daemon/McpClientFactory.kt
@@ -1,18 +1,38 @@
 package com.automobile.ide.daemon
 
 object McpClientFactory {
-  fun create(): AutoMobileClient {
+  fun createPreferred(httpServer: McpHttpServer?): AutoMobileClient {
+    if (httpServer != null) {
+      return McpHttpClient(httpServer.endpoint)
+    }
+
+    val configuredHttp = createConfiguredHttp()
+    if (configuredHttp != null) {
+      return configuredHttp
+    }
+
+    val configuredStdio = createConfiguredStdio()
+    if (configuredStdio != null) {
+      return configuredStdio
+    }
+
+    return McpDaemonClient()
+  }
+
+  fun createConfiguredHttp(): McpHttpClient? {
     val httpUrl = readSetting("AUTO_MOBILE_MCP_HTTP_URL", "automobile.mcp.httpUrl")
     if (!httpUrl.isNullOrBlank()) {
       return McpHttpClient(normalizeHttpUrl(httpUrl))
     }
+    return null
+  }
 
+  fun createConfiguredStdio(): McpStdioClient? {
     val stdioCommand = readSetting("AUTO_MOBILE_MCP_STDIO_COMMAND", "automobile.mcp.stdioCommand")
     if (!stdioCommand.isNullOrBlank()) {
       return McpStdioClient(stdioCommand)
     }
-
-    return McpDaemonClient()
+    return null
   }
 
   private fun readSetting(envKey: String, propertyKey: String): String? {
@@ -24,7 +44,7 @@ object McpClientFactory {
     return propertyValue?.takeIf { it.isNotBlank() }
   }
 
-  private fun normalizeHttpUrl(raw: String): String {
+  fun normalizeHttpUrl(raw: String): String {
     val trimmed = raw.trim().removeSuffix("/")
     return when {
       trimmed.endsWith("/auto-mobile/streamable") || trimmed.endsWith("/auto-mobile/sse") -> trimmed

--- a/android/ide-plugin/src/main/kotlin/com/automobile/ide/daemon/McpDiscovery.kt
+++ b/android/ide-plugin/src/main/kotlin/com/automobile/ide/daemon/McpDiscovery.kt
@@ -1,0 +1,324 @@
+package com.automobile.ide.daemon
+
+import java.net.URI
+import java.net.http.HttpClient
+import java.net.http.HttpRequest
+import java.net.http.HttpResponse
+import java.nio.file.Path
+import java.time.Duration
+import java.util.concurrent.TimeUnit
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.withContext
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.decodeFromString
+import kotlinx.serialization.json.Json
+
+@Serializable
+data class McpHealthUptime(
+  val ms: Long? = null,
+  val human: String? = null,
+)
+
+@Serializable
+data class McpHealthResponse(
+  val status: String? = null,
+  val server: String? = null,
+  val version: String? = null,
+  val instanceId: String? = null,
+  val port: Int? = null,
+  val branch: String? = null,
+  val uptime: McpHealthUptime? = null,
+  val activeSessions: Int? = null,
+  val transport: String? = null,
+)
+
+data class GitWorktree(
+  val path: String,
+  val branch: String? = null,
+)
+
+data class McpHttpServer(
+  val endpoint: String,
+  val health: McpHealthResponse,
+)
+
+data class McpServerOption(
+  val id: String,
+  val label: String,
+  val server: McpHttpServer?,
+  val worktree: GitWorktree?,
+)
+
+data class McpDiscoverySnapshot(
+  val options: List<McpServerOption>,
+  val servers: List<McpHttpServer>,
+  val worktrees: List<GitWorktree>,
+) {
+  companion object {
+    fun empty(): McpDiscoverySnapshot = McpDiscoverySnapshot(emptyList(), emptyList(), emptyList())
+  }
+}
+
+interface WorktreeLister {
+  suspend fun listWorktrees(projectBasePath: String?): List<GitWorktree>
+}
+
+interface PortScanner {
+  suspend fun scanListeningPorts(): Set<Int>
+}
+
+interface HealthProbe {
+  suspend fun probeHealth(port: Int): McpHealthResponse?
+}
+
+class McpHttpDiscovery(
+  private val worktreeLister: WorktreeLister = GitWorktreeLister(),
+  private val portScanner: PortScanner = DefaultPortScanner(),
+  private val healthProbe: HealthProbe = HttpHealthProbe(),
+) {
+  suspend fun discover(projectBasePath: String?): McpDiscoverySnapshot = coroutineScope {
+    val worktrees = worktreeLister.listWorktrees(projectBasePath)
+    val ports = portScanner.scanListeningPorts()
+    val servers = ports.map { port ->
+      async(Dispatchers.IO) { probePort(port) }
+    }.awaitAll().filterNotNull()
+
+    val options = buildOptions(worktrees, servers)
+    McpDiscoverySnapshot(options, servers, worktrees)
+  }
+
+  private fun buildOptions(
+    worktrees: List<GitWorktree>,
+    servers: List<McpHttpServer>,
+  ): List<McpServerOption> {
+    val remainingServers = servers.toMutableList()
+    val options = mutableListOf<McpServerOption>()
+
+    for (worktree in worktrees) {
+      val server = worktree.branch?.let { branch ->
+        remainingServers.firstOrNull { it.health.branch == branch }
+      }
+      if (server != null) {
+        remainingServers.remove(server)
+      }
+      options.add(
+        McpServerOption(
+          id = "worktree:${worktree.path}",
+          label = buildWorktreeLabel(worktree, server),
+          server = server,
+          worktree = worktree,
+        )
+      )
+    }
+
+    for (server in remainingServers) {
+      options.add(
+        McpServerOption(
+          id = "server:${server.health.port ?: server.endpoint}",
+          label = buildServerLabel(server),
+          server = server,
+          worktree = null,
+        )
+      )
+    }
+
+    return options
+  }
+
+  private fun buildWorktreeLabel(worktree: GitWorktree, server: McpHttpServer?): String {
+    val branch = worktree.branch ?: "(detached)"
+    val pathHint = Path.of(worktree.path).fileName?.toString() ?: worktree.path
+    val serverHint = server?.let { formatServerHint(it) } ?: "no server"
+    return "$branch | $pathHint | $serverHint"
+  }
+
+  private fun buildServerLabel(server: McpHttpServer): String {
+    val branch = server.health.branch ?: "unknown branch"
+    return "server | $branch | ${formatServerHint(server)}"
+  }
+
+  private fun formatServerHint(server: McpHttpServer): String {
+    val port = server.health.port ?: extractPort(server.endpoint)
+    val transport = server.health.transport ?: "http"
+    val sessions = server.health.activeSessions?.toString() ?: "?"
+    return "${transport}:$port | sessions=$sessions"
+  }
+
+  private fun extractPort(endpoint: String): Int? {
+    return try {
+      val uri = URI.create(endpoint)
+      if (uri.port > 0) uri.port else null
+    } catch (_: Exception) {
+      null
+    }
+  }
+
+  private suspend fun probePort(port: Int): McpHttpServer? {
+    val health = healthProbe.probeHealth(port) ?: return null
+    if (health.server != "AutoMobile") {
+      return null
+    }
+    val resolvedPort = health.port ?: port
+    val endpoint = "http://localhost:$resolvedPort/auto-mobile/streamable"
+    return McpHttpServer(endpoint, health)
+  }
+}
+
+class GitWorktreeLister : WorktreeLister {
+  override suspend fun listWorktrees(projectBasePath: String?): List<GitWorktree> =
+    withContext(Dispatchers.IO) {
+      if (projectBasePath.isNullOrBlank()) {
+        return@withContext emptyList()
+      }
+
+      val output = runProcess(listOf("git", "worktree", "list", "--porcelain"), projectBasePath)
+        ?: return@withContext emptyList()
+
+      val worktrees = mutableListOf<GitWorktree>()
+      var currentPath: String? = null
+      var currentBranch: String? = null
+
+      for (line in output.lineSequence()) {
+        when {
+          line.startsWith("worktree ") -> {
+            if (currentPath != null) {
+              worktrees.add(GitWorktree(currentPath!!, currentBranch))
+            }
+            currentPath = line.removePrefix("worktree ").trim()
+            currentBranch = null
+          }
+          line.startsWith("branch ") -> {
+            val branchRef = line.removePrefix("branch ").trim()
+            currentBranch = branchRef.removePrefix("refs/heads/")
+          }
+          line.isBlank() -> {
+            if (currentPath != null) {
+              worktrees.add(GitWorktree(currentPath!!, currentBranch))
+              currentPath = null
+              currentBranch = null
+            }
+          }
+        }
+      }
+
+      if (currentPath != null) {
+        worktrees.add(GitWorktree(currentPath!!, currentBranch))
+      }
+
+      worktrees
+    }
+
+  private fun runProcess(command: List<String>, workingDir: String): String? {
+    return try {
+      val process = ProcessBuilder(command)
+        .directory(java.io.File(workingDir))
+        .redirectErrorStream(true)
+        .start()
+      val completed = process.waitFor(3, TimeUnit.SECONDS)
+      if (!completed) {
+        process.destroy()
+        return null
+      }
+      if (process.exitValue() != 0) {
+        return null
+      }
+      process.inputStream.bufferedReader().readText()
+    } catch (_: Exception) {
+      null
+    }
+  }
+}
+
+class DefaultPortScanner : PortScanner {
+  override suspend fun scanListeningPorts(): Set<Int> = withContext(Dispatchers.IO) {
+    val osName = System.getProperty("os.name", "").lowercase()
+    val outputs = mutableListOf<String>()
+
+    if (osName.contains("win")) {
+      runCommand(listOf("netstat", "-ano", "-p", "tcp"))?.let { outputs.add(it) }
+    } else {
+      runCommand(listOf("lsof", "-iTCP", "-sTCP:LISTEN", "-n", "-P"))?.let { outputs.add(it) }
+      runCommand(listOf("ss", "-ltn"))?.let { outputs.add(it) }
+      runCommand(listOf("netstat", "-an"))?.let { outputs.add(it) }
+    }
+
+    outputs.flatMap { parsePorts(it) }.toSet()
+  }
+
+  private fun runCommand(command: List<String>): String? {
+    return try {
+      val process = ProcessBuilder(command)
+        .redirectErrorStream(true)
+        .start()
+      val completed = process.waitFor(2, TimeUnit.SECONDS)
+      if (!completed) {
+        process.destroy()
+        return null
+      }
+      if (process.exitValue() != 0) {
+        return null
+      }
+      process.inputStream.bufferedReader().readText()
+    } catch (_: Exception) {
+      null
+    }
+  }
+
+  private fun parsePorts(output: String): List<Int> {
+    val ports = mutableListOf<Int>()
+    val listenRegex = Regex(":(\\d+)(?:\\s|\\)|$)")
+    for (line in output.lineSequence()) {
+      if (!line.contains("LISTEN", ignoreCase = true)) {
+        continue
+      }
+      val match = listenRegex.findAll(line).lastOrNull() ?: continue
+      val port = match.groupValues.getOrNull(1)?.toIntOrNull() ?: continue
+      if (port in 1..65535) {
+        ports.add(port)
+      }
+    }
+    return ports
+  }
+}
+
+class HttpHealthProbe(
+  private val json: Json = Json { ignoreUnknownKeys = true },
+  private val httpClient: HttpClient = HttpClient.newBuilder()
+    .connectTimeout(Duration.ofMillis(800))
+    .build(),
+) : HealthProbe {
+  override suspend fun probeHealth(port: Int): McpHealthResponse? {
+    val urls = listOf(
+      "http://localhost:$port/health",
+      "http://localhost:$port/auto-mobile/health",
+    )
+    for (url in urls) {
+      val health = requestHealth(url) ?: continue
+      return health
+    }
+    return null
+  }
+
+  private suspend fun requestHealth(url: String): McpHealthResponse? = withContext(Dispatchers.IO) {
+    try {
+      val request = HttpRequest.newBuilder(URI.create(url))
+        .timeout(Duration.ofMillis(800))
+        .GET()
+        .build()
+      val response = httpClient.send(request, HttpResponse.BodyHandlers.ofString())
+      if (response.statusCode() != 200) {
+        return@withContext null
+      }
+      val body = response.body().trim()
+      if (body.isEmpty()) {
+        return@withContext null
+      }
+      json.decodeFromString(McpHealthResponse.serializer(), body)
+    } catch (_: Exception) {
+      null
+    }
+  }
+}

--- a/android/ide-plugin/src/test/kotlin/com/automobile/ide/daemon/McpHttpDiscoveryTest.kt
+++ b/android/ide-plugin/src/test/kotlin/com/automobile/ide/daemon/McpHttpDiscoveryTest.kt
@@ -1,0 +1,117 @@
+package com.automobile.ide.daemon
+
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlinx.coroutines.runBlocking
+import org.junit.Test
+
+class McpHttpDiscoveryTest {
+  @Test
+  fun mapsServersToWorktreesByBranch() {
+    runBlocking {
+      val worktrees = listOf(
+        GitWorktree(path = "/worktrees/work-246", branch = "work/246"),
+        GitWorktree(path = "/worktrees/main", branch = "main"),
+      )
+      val ports = setOf(9164, 9000)
+      val probe = FakeHealthProbe(
+        mapOf(
+          9164 to McpHealthResponse(server = "AutoMobile", port = 9164, branch = "work/246"),
+          9000 to McpHealthResponse(server = "AutoMobile", port = 9000, branch = "main"),
+        )
+      )
+
+      val discovery = McpHttpDiscovery(
+        worktreeLister = FakeWorktreeLister(worktrees),
+        portScanner = FakePortScanner(ports),
+        healthProbe = probe,
+      )
+
+      val snapshot = discovery.discover("/worktrees")
+
+      assertEquals(2, snapshot.options.size)
+      val first = snapshot.options[0]
+      assertEquals("/worktrees/work-246", first.worktree?.path)
+      assertNotNull(first.server)
+      assertEquals("http://localhost:9164/auto-mobile/streamable", first.server?.endpoint)
+
+      val second = snapshot.options[1]
+      assertEquals("/worktrees/main", second.worktree?.path)
+      assertNotNull(second.server)
+      assertEquals("http://localhost:9000/auto-mobile/streamable", second.server?.endpoint)
+    }
+  }
+
+  @Test
+  fun addsUnmatchedServersAfterWorktrees() {
+    runBlocking {
+      val worktrees = listOf(
+        GitWorktree(path = "/worktrees/feature", branch = "feature"),
+      )
+      val ports = setOf(9100)
+      val probe = FakeHealthProbe(
+        mapOf(
+          9100 to McpHealthResponse(server = "AutoMobile", port = 9100, branch = "other"),
+        )
+      )
+
+      val discovery = McpHttpDiscovery(
+        worktreeLister = FakeWorktreeLister(worktrees),
+        portScanner = FakePortScanner(ports),
+        healthProbe = probe,
+      )
+
+      val snapshot = discovery.discover("/worktrees")
+
+      assertEquals(2, snapshot.options.size)
+      assertEquals("/worktrees/feature", snapshot.options[0].worktree?.path)
+      assertNull(snapshot.options[0].server)
+      assertNull(snapshot.options[1].worktree)
+      assertNotNull(snapshot.options[1].server)
+    }
+  }
+
+  @Test
+  fun usesHealthPortWhenProvided() {
+    runBlocking {
+      val worktrees = listOf(GitWorktree(path = "/worktrees/work-500", branch = "work/500"))
+      val ports = setOf(9100)
+      val probe = FakeHealthProbe(
+        mapOf(
+          9100 to McpHealthResponse(server = "AutoMobile", port = 9200, branch = "work/500"),
+        )
+      )
+
+      val discovery = McpHttpDiscovery(
+        worktreeLister = FakeWorktreeLister(worktrees),
+        portScanner = FakePortScanner(ports),
+        healthProbe = probe,
+      )
+
+      val snapshot = discovery.discover("/worktrees")
+
+      val option = snapshot.options.first()
+      assertNotNull(option.server)
+      assertEquals("http://localhost:9200/auto-mobile/streamable", option.server?.endpoint)
+    }
+  }
+}
+
+private class FakeWorktreeLister(
+  private val worktrees: List<GitWorktree>,
+) : WorktreeLister {
+  override suspend fun listWorktrees(projectBasePath: String?): List<GitWorktree> = worktrees
+}
+
+private class FakePortScanner(
+  private val ports: Set<Int>,
+) : PortScanner {
+  override suspend fun scanListeningPorts(): Set<Int> = ports
+}
+
+private class FakeHealthProbe(
+  private val responses: Map<Int, McpHealthResponse?>,
+) : HealthProbe {
+  override suspend fun probeHealth(port: Int): McpHealthResponse? = responses[port]
+}

--- a/docs/android-ide-plugin.md
+++ b/docs/android-ide-plugin.md
@@ -1,0 +1,37 @@
+# Android IDE Plugin
+
+## Overview
+The AutoMobile IntelliJ/Android Studio plugin attaches to a running MCP server to render navigation data and
+manage development workflows. It supports MCP over HTTP (streamable) and STDIO, and falls back to the
+local daemon socket when needed.
+
+## Transport selection
+The plugin resolves a transport when the user clicks "Attach to MCP":
+
+1. MCP dev server discovered via HTTP health checks on localhost.
+2. `AUTO_MOBILE_MCP_HTTP_URL` / `-Dautomobile.mcp.httpUrl` (streamable HTTP).
+3. `AUTO_MOBILE_MCP_STDIO_COMMAND` / `-Dautomobile.mcp.stdioCommand` (stdio).
+4. Unix socket fallback at `/tmp/auto-mobile-daemon-<uid>.sock`.
+
+## MCP dev server discovery
+Discovery focuses on hot-reload dev servers (bun `--watch`) and supports multiple worktrees.
+
+1. **Worktree enumeration**: the plugin runs `git worktree list --porcelain` using `ProcessBuilder` and coroutines.
+   - Each worktree record includes a filesystem path and optional branch name.
+2. **Port scan**: the plugin scans local listening ports (via `lsof`, `ss`, or `netstat` depending on OS).
+3. **Health probing**: each listening port is queried at `/health` (falling back to `/auto-mobile/health`).
+   - Responses with `server: "AutoMobile"` are treated as MCP servers.
+4. **Mapping**: discovered servers are matched to worktrees using the `branch` value from the health payload.
+
+The health response also includes `instanceId`, `port`, and `activeSessions` so the plugin can detect restarts
+and show server status.
+
+## Tool window UX
+- The dropdown lists every git worktree and its associated MCP server (if any).
+- Worktrees without a running server are shown as "no server".
+- Unmatched MCP servers are shown as standalone entries.
+- "Rescan servers" re-runs discovery to pick up cold restarts or newly launched dev servers.
+
+## Notes
+- Streamable HTTP endpoints are assumed to live at `http://localhost:<port>/auto-mobile/streamable`.
+- MCP stdio and daemon transports are still available for non-dev workflows.


### PR DESCRIPTION
## Summary
- add MCP discovery interfaces (worktree listing, port scan, health probe) with default implementations
- wire discovery into MCP HTTP selection and add unit tests with fakes
- document IDE plugin transport discovery and update README

Closes #246.

## Testing
- bun run build
- bun run lint
- bun run test
- (cd android && ./gradlew -p ide-plugin test)
- ./scripts/ide-plugin/validate.sh
