### PR TITLE
Add JUnit test isolation with cleanup and randomization

### DIFF
--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -24,14 +24,14 @@
 # - CodeCache normally defaults to a very small size. Increasing it from platform defaults of 32-48m
 #   because of how many classes can be loaded into memory and then cached as native compiled code
 #   for a small speed boost.
-org.gradle.jvmargs=-XX:+UseG1GC -XX:SoftRefLRUPolicyMSPerMB=1 -XX:ReservedCodeCacheSize=256m -XX:+HeapDumpOnOutOfMemoryError -Xmx1g -Xms512m -Dfile.encoding=UTF-8
+org.gradle.jvmargs=-XX:+UseG1GC -XX:SoftRefLRUPolicyMSPerMB=1 -XX:ReservedCodeCacheSize=256m -XX:+HeapDumpOnOutOfMemoryError -Xmx2g -Xms512m -Dfile.encoding=UTF-8
 
 # For more information about how Kotlin Daemon JVM options were chosen:
 # - Kotlin JVM args only inherit Xmx, ReservedCodeCache, and MaxMetaspace. Since we are specifying
 #   other args we need to specify all of them here.
 # - We're using the Kotlin Gradle Plugin's default value for ReservedCodeCacheSize, if we do not then
 #   the Gradle JVM arg value for ReservedCodeCacheSize will be used.
-kotlin.daemon.jvmargs=-XX:+UseG1GC -XX:SoftRefLRUPolicyMSPerMB=1 -XX:ReservedCodeCacheSize=320m -XX:+HeapDumpOnOutOfMemoryError -Xmx1g -Xms512m
+kotlin.daemon.jvmargs=-XX:+UseG1GC -XX:SoftRefLRUPolicyMSPerMB=1 -XX:ReservedCodeCacheSize=320m -XX:+HeapDumpOnOutOfMemoryError -Xmx2g -Xms512m
 
 # For more information about how Gradle Worker JVM options were chosen
 # Robolectric and Android tests need more memory than simple unit tests

--- a/android/junit-runner/src/main/kotlin/dev/jasonpearson/automobile/junit/AutoMobileRunner.kt
+++ b/android/junit-runner/src/main/kotlin/dev/jasonpearson/automobile/junit/AutoMobileRunner.kt
@@ -7,6 +7,7 @@ import java.util.UUID
 import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
 import kotlin.jvm.java
+import kotlin.random.Random
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonElement
@@ -37,6 +38,19 @@ class AutoMobileRunner(private val klass: Class<*>) : BlockJUnit4ClassRunner(kla
   private val agent: AutoMobileAgent
     get() = LazyInitializer.getAgent()
 
+  private val randomizedChildren: List<FrameworkMethod> by lazy {
+    val children = super.getChildren()
+    val shuffleEnabled = SystemPropertyCache.getBoolean("automobile.junit.shuffle.enabled", true)
+    if (!shuffleEnabled || children.size <= 1) {
+      children
+    } else {
+      val seedProperty = SystemPropertyCache.get("automobile.junit.shuffle.seed", "").trim()
+      val seed = seedProperty.toLongOrNull() ?: System.currentTimeMillis()
+      println("AutoMobileRunner: Shuffling test order with seed=$seed")
+      children.shuffled(Random(seed))
+    }
+  }
+
   override fun run(notifier: RunNotifier) {
     // Skip the entire class if no devices are available
     if (!AutoMobileSharedUtils.deviceChecker.areDevicesAvailable()) {
@@ -60,7 +74,7 @@ class AutoMobileRunner(private val klass: Class<*>) : BlockJUnit4ClassRunner(kla
   }
 
   override fun getChildren(): List<FrameworkMethod> {
-    return super.getChildren()
+    return randomizedChildren
   }
 
   override fun childrenInvoker(notifier: RunNotifier): org.junit.runners.model.Statement {
@@ -170,6 +184,11 @@ class AutoMobileRunner(private val klass: Class<*>) : BlockJUnit4ClassRunner(kla
     notifier.fireTestStarted(description)
 
     try {
+      if (annotation.cleanupAfter && annotation.appId.isBlank()) {
+        println(
+            "[WARNING] AutoMobile test ${method.name} requested cleanup but appId is blank; skipping cleanup."
+        )
+      }
       val planPath = getPlanPathOrGenerate(method, annotation)
       val resolvedPlanPath = resolvePlanPath(planPath)
 
@@ -375,6 +394,11 @@ class AutoMobileRunner(private val klass: Class<*>) : BlockJUnit4ClassRunner(kla
 
     if (annotation.device != "auto") {
       values["deviceId"] = JsonPrimitive(annotation.device)
+    }
+
+    if (annotation.cleanupAfter && annotation.appId.isNotBlank()) {
+      values["cleanupAppId"] = JsonPrimitive(annotation.appId)
+      values["cleanupClearAppData"] = JsonPrimitive(annotation.clearAppData)
     }
 
     return JsonObject(values)

--- a/android/junit-runner/src/main/kotlin/dev/jasonpearson/automobile/junit/AutoMobileTest.kt
+++ b/android/junit-runner/src/main/kotlin/dev/jasonpearson/automobile/junit/AutoMobileTest.kt
@@ -29,4 +29,16 @@ annotation class AutoMobileTest(
 
     /** Target device ID or "auto" for any available device. Default: "auto" */
     val device: String = "auto",
+
+    /**
+     * App package name to clean up after the test (terminate or clear app data).
+     * Required when cleanupAfter is enabled.
+     */
+    val appId: String = "",
+
+    /** Terminate app after the test completes. Default: true */
+    val cleanupAfter: Boolean = true,
+
+    /** Clear app data after the test completes. Default: false */
+    val clearAppData: Boolean = false,
 )

--- a/android/junit-runner/src/main/kotlin/dev/jasonpearson/automobile/junit/README.md
+++ b/android/junit-runner/src/main/kotlin/dev/jasonpearson/automobile/junit/README.md
@@ -47,6 +47,9 @@ fun `create timer from prompt`() {
 - `aiAssistance`: Enable/disable AI agent recovery on failure (default: true)
 - `timeoutMs`: Maximum execution time per test in milliseconds (default: 60000 - 1 minute)
 - `device`: Target device ID or "auto" for any available device (default: "auto")
+- `appId`: App package name to clean up after the test (terminate or clear app data)
+- `cleanupAfter`: Terminate the app after the test completes (default: true)
+- `clearAppData`: Clear app data after the test completes (default: false, Android only)
 
 ### Plan Generation Logic
 
@@ -68,6 +71,14 @@ When using prompt-based testing:
 - `automobile.ci.mode`: Disable AI assistance in CI environments (default: false)
 - `automobile.plan.max.age.ms`: Max age for generated plans in milliseconds (default: 3600000 - 1 hour)
 - `automobile.daemon.startup.timeout.ms`: Daemon startup timeout in milliseconds (default: 10000)
+- `automobile.junit.shuffle.enabled`: Randomize test execution order (default: true)
+- `automobile.junit.shuffle.seed`: Seed for randomized order (default: current time)
+
+### Test Cleanup Behavior
+
+By default, tests with `appId` set will terminate the app after execution to reduce state leakage.
+To fully reset app state between tests, set `clearAppData = true` (Android only). If `cleanupAfter`
+is enabled but `appId` is blank, cleanup is skipped and a warning is logged.
 
 #### Generated Plans Directory Structure
 

--- a/android/junit-runner/src/test/kotlin/dev/jasonpearson/automobile/junit/AutoMobileRunnerTest.kt
+++ b/android/junit-runner/src/test/kotlin/dev/jasonpearson/automobile/junit/AutoMobileRunnerTest.kt
@@ -62,6 +62,7 @@ class AutoMobileRunnerTest {
     assertEquals(0, args["startStep"]?.jsonPrimitive?.content?.toInt())
     assertEquals("session-123", args["sessionUuid"]?.jsonPrimitive?.content)
     assertNull("deviceId should be omitted when device=auto", args["deviceId"])
+    assertNull("cleanupAppId should be omitted when appId is blank", args["cleanupAppId"])
   }
 
   @Test
@@ -72,6 +73,17 @@ class AutoMobileRunnerTest {
     val args = runner.invokeBuildDaemonExecutePlanArgs("Zm9v", annotation, "session-456")
 
     assertEquals("emulator-5554", args["deviceId"]?.jsonPrimitive?.content)
+  }
+
+  @Test
+  fun testBuildDaemonExecutePlanArgsWithCleanup() {
+    val runner = AutoMobileRunner(TestTargetClass::class.java)
+    val method = TestTargetClass::class.java.getMethod("testWithCleanup")
+    val annotation = method.getAnnotation(AutoMobileTest::class.java)
+    val args = runner.invokeBuildDaemonExecutePlanArgs("Zm9v", annotation, "session-789")
+
+    assertEquals("com.example.app", args["cleanupAppId"]?.jsonPrimitive?.content)
+    assertEquals("true", args["cleanupClearAppData"]?.jsonPrimitive?.content)
   }
 }
 
@@ -87,6 +99,13 @@ class TestTargetClass {
 
   @AutoMobileTest(plan = "test-plans/launch-clock.yaml", device = "emulator-5554")
   fun testWithSpecificDevice() {}
+
+  @AutoMobileTest(
+      plan = "test-plans/launch-clock.yaml",
+      appId = "com.example.app",
+      clearAppData = true,
+  )
+  fun testWithCleanup() {}
 
   fun testMethodWithoutAnnotation() {}
 }

--- a/src/server/AppCleanupService.ts
+++ b/src/server/AppCleanupService.ts
@@ -1,0 +1,94 @@
+import { BootedDevice, ClearAppDataResult, TerminateAppResult } from "../models";
+import { ClearAppData } from "../features/action/ClearAppData";
+import { TerminateApp } from "../features/action/TerminateApp";
+import { Logger, logger } from "../utils/logger";
+
+export interface AppCleanupConfig {
+  appId: string;
+  clearAppData?: boolean;
+}
+
+export interface ClearAppDataAction {
+  execute(appId: string): Promise<ClearAppDataResult>;
+}
+
+export interface TerminateAppAction {
+  execute(
+    appId: string,
+    options?: {
+      skipObservation?: boolean;
+      skipUiStability?: boolean;
+    }
+  ): Promise<TerminateAppResult>;
+}
+
+export interface AppCleanupService {
+  cleanup(device: BootedDevice, config: AppCleanupConfig): Promise<void>;
+}
+
+export interface AppCleanupDependencies {
+  createClearAppData?: (device: BootedDevice) => ClearAppDataAction;
+  createTerminateApp?: (device: BootedDevice) => TerminateAppAction;
+  logger?: Pick<Logger, "info" | "warn">;
+}
+
+export class DefaultAppCleanupService implements AppCleanupService {
+  private createClearAppData: (device: BootedDevice) => ClearAppDataAction;
+  private createTerminateApp: (device: BootedDevice) => TerminateAppAction;
+  private log: Pick<Logger, "info" | "warn">;
+
+  constructor(dependencies: AppCleanupDependencies = {}) {
+    this.createClearAppData =
+      dependencies.createClearAppData ?? ((device: BootedDevice) => new ClearAppData(device));
+    this.createTerminateApp =
+      dependencies.createTerminateApp ?? ((device: BootedDevice) => new TerminateApp(device));
+    this.log = dependencies.logger ?? logger;
+  }
+
+  async cleanup(device: BootedDevice, config: AppCleanupConfig): Promise<void> {
+    if (!config.appId) {
+      return;
+    }
+
+    if (config.clearAppData) {
+      if (device.platform !== "android") {
+        this.log.warn(
+          `[AppCleanupService] cleanupClearAppData requested for non-Android device ${device.deviceId}; skipping clear app data`
+        );
+        return;
+      }
+
+      try {
+        const clearAppData = this.createClearAppData(device);
+        const result = await clearAppData.execute(config.appId);
+        if (!result.success) {
+          this.log.warn(
+            `[AppCleanupService] Failed to clear app data for ${config.appId} on ${device.deviceId}: ${result.error || "unknown error"}`
+          );
+        } else {
+          this.log.info(`[AppCleanupService] Cleared app data for ${config.appId} on ${device.deviceId}`);
+        }
+      } catch (error) {
+        this.log.warn(`[AppCleanupService] Cleanup failed for ${config.appId}: ${error}`);
+      }
+      return;
+    }
+
+    try {
+      const terminateApp = this.createTerminateApp(device);
+      const result = await terminateApp.execute(config.appId, {
+        skipObservation: true,
+        skipUiStability: true,
+      });
+      if (!result.success) {
+        this.log.warn(
+          `[AppCleanupService] Failed to terminate app ${config.appId} on ${device.deviceId}: ${result.error || "unknown error"}`
+        );
+      } else {
+        this.log.info(`[AppCleanupService] Terminated app ${config.appId} on ${device.deviceId}`);
+      }
+    } catch (error) {
+      this.log.warn(`[AppCleanupService] Cleanup failed for ${config.appId}: ${error}`);
+    }
+  }
+}

--- a/src/server/planTools.ts
+++ b/src/server/planTools.ts
@@ -13,7 +13,9 @@ const executePlanSchema = z.object({
   platform: z.enum(["android", "ios"]).describe("Target platform"),
   // Framework parameters for device management (optional)
   sessionUuid: z.string().optional().describe("Session UUID for parallel test execution"),
-  deviceId: z.string().optional().describe("Specific device ID to use")
+  deviceId: z.string().optional().describe("Specific device ID to use"),
+  cleanupAppId: z.string().optional().describe("App package ID to terminate after plan execution"),
+  cleanupClearAppData: z.boolean().optional().describe("Clear app data during cleanup (Android only)")
 });
 
 // Execute plan from YAML file or content
@@ -23,6 +25,8 @@ const executePlanTool = async (device: BootedDevice, params: {
   platform: Platform;
   sessionUuid?: string;
   deviceId?: string;
+  cleanupAppId?: string;
+  cleanupClearAppData?: boolean;
 }, _progress?: unknown, signal?: AbortSignal): Promise<any> => {
   try {
     logger.info("=== Starting executePlanTool ===");

--- a/src/server/toolRegistry.ts
+++ b/src/server/toolRegistry.ts
@@ -12,6 +12,7 @@ import { createGlobalPerformanceTracker } from "../utils/PerformanceTracker";
 import { logger } from "../utils/logger";
 import { DaemonState } from "../daemon/daemonState";
 import { createToolExecutionContext, updateSessionCache } from "./ToolExecutionContext";
+import { AppCleanupService, DefaultAppCleanupService } from "./AppCleanupService";
 
 // Progress notification interface
 export interface ProgressCallback {
@@ -43,9 +44,11 @@ export interface RegisteredTool {
 class ToolRegistryClass {
   private tools: Map<string, RegisteredTool> = new Map();
   private deviceSessionManager: DeviceSessionManager;
+  private cleanupService: AppCleanupService;
 
   constructor() {
     this.deviceSessionManager = DeviceSessionManager.getInstance();
+    this.cleanupService = new DefaultAppCleanupService();
   }
 
   // Register a new tool
@@ -221,6 +224,13 @@ class ToolRegistryClass {
         }
         throw new ActionableError(`Failed to execute tool ${name}: ${error}`);
       } finally {
+        if (name === "executePlan" && args?.cleanupAppId) {
+          await this.cleanupService.cleanup(device, {
+            appId: args.cleanupAppId,
+            clearAppData: args.cleanupClearAppData,
+          });
+        }
+
         // Auto-release session after executePlan completes
         // This frees the device immediately for parallel test execution
         if (sessionUuid && name === "executePlan" && DaemonState.getInstance().isInitialized()) {
@@ -304,6 +314,11 @@ class ToolRegistryClass {
   // Get the device session manager
   getDeviceSessionManager(): DeviceSessionManager {
     return this.deviceSessionManager;
+  }
+
+  // Allow tests to inject a cleanup implementation
+  setCleanupService(cleanupService: AppCleanupService): void {
+    this.cleanupService = cleanupService;
   }
 
   // Clear all registered tools (for testing)

--- a/test/server/AppCleanupService.test.ts
+++ b/test/server/AppCleanupService.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, test } from "bun:test";
+import { BootedDevice, ClearAppDataResult, TerminateAppResult } from "../../src/models";
+import { DefaultAppCleanupService } from "../../src/server/AppCleanupService";
+
+class FakeClearAppData {
+  public calls: string[] = [];
+  private result: ClearAppDataResult;
+
+  constructor(result: ClearAppDataResult) {
+    this.result = result;
+  }
+
+  async execute(appId: string): Promise<ClearAppDataResult> {
+    this.calls.push(appId);
+    return this.result;
+  }
+}
+
+class FakeTerminateApp {
+  public calls: { appId: string; options?: { skipObservation?: boolean; skipUiStability?: boolean } }[] = [];
+  private result: TerminateAppResult;
+
+  constructor(result: TerminateAppResult) {
+    this.result = result;
+  }
+
+  async execute(
+    appId: string,
+    options?: { skipObservation?: boolean; skipUiStability?: boolean }
+  ): Promise<TerminateAppResult> {
+    this.calls.push({ appId, options });
+    return this.result;
+  }
+}
+
+const androidDevice: BootedDevice = {
+  name: "Pixel 7",
+  platform: "android",
+  deviceId: "emulator-5554",
+};
+
+const iosDevice: BootedDevice = {
+  name: "iPhone 15",
+  platform: "ios",
+  deviceId: "ios-123",
+};
+
+describe("DefaultAppCleanupService", () => {
+  test("terminates app by default", async () => {
+    const terminate = new FakeTerminateApp({
+      success: true,
+      packageName: "com.example.app",
+      wasInstalled: true,
+      wasRunning: true,
+      wasForeground: false,
+    });
+    const clear = new FakeClearAppData({
+      success: true,
+      packageName: "com.example.app",
+    });
+    const cleanupService = new DefaultAppCleanupService({
+      createTerminateApp: () => terminate,
+      createClearAppData: () => clear,
+      logger: { info: () => {}, warn: () => {} },
+    });
+
+    await cleanupService.cleanup(androidDevice, { appId: "com.example.app" });
+
+    expect(terminate.calls).toHaveLength(1);
+    expect(terminate.calls[0]).toEqual({
+      appId: "com.example.app",
+      options: { skipObservation: true, skipUiStability: true },
+    });
+    expect(clear.calls).toHaveLength(0);
+  });
+
+  test("clears app data when requested on Android", async () => {
+    const terminate = new FakeTerminateApp({
+      success: true,
+      packageName: "com.example.app",
+      wasInstalled: true,
+      wasRunning: true,
+      wasForeground: false,
+    });
+    const clear = new FakeClearAppData({
+      success: true,
+      packageName: "com.example.app",
+    });
+    const cleanupService = new DefaultAppCleanupService({
+      createTerminateApp: () => terminate,
+      createClearAppData: () => clear,
+      logger: { info: () => {}, warn: () => {} },
+    });
+
+    await cleanupService.cleanup(androidDevice, {
+      appId: "com.example.app",
+      clearAppData: true,
+    });
+
+    expect(clear.calls).toEqual(["com.example.app"]);
+    expect(terminate.calls).toHaveLength(0);
+  });
+
+  test("skips clear app data on iOS", async () => {
+    const terminate = new FakeTerminateApp({
+      success: true,
+      packageName: "com.example.app",
+      wasInstalled: true,
+      wasRunning: true,
+      wasForeground: false,
+    });
+    const clear = new FakeClearAppData({
+      success: true,
+      packageName: "com.example.app",
+    });
+    const warnings: string[] = [];
+    const cleanupService = new DefaultAppCleanupService({
+      createTerminateApp: () => terminate,
+      createClearAppData: () => clear,
+      logger: {
+        info: () => {},
+        warn: message => warnings.push(message),
+      },
+    });
+
+    await cleanupService.cleanup(iosDevice, {
+      appId: "com.example.app",
+      clearAppData: true,
+    });
+
+    expect(warnings.length).toBe(1);
+    expect(clear.calls).toHaveLength(0);
+    expect(terminate.calls).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Summary
Implements test pollution prevention mechanisms for JUnitRunner to ensure tests can run independently in any order, addressing issue #134.

## Changes

### Test Cleanup
- Added `appId`, `cleanupAfter`, and `clearAppData` parameters to `@AutoMobileTest` annotation
- Automatically terminates or clears app data after test execution
- Validates cleanup configuration (warns if `cleanupAfter` enabled without `appId`)

### Test Randomization
- Shuffles test execution order by default using configurable seed
- System property: `automobile.junit.shuffle.enabled` (default: `true`)
- System property: `automobile.junit.shuffle.seed` (default: current time)
- Prints seed to console for reproducibility
- Ensures tests don't depend on execution order

### Server-Side Cleanup
- Added `AppCleanupService` for centralized cleanup logic
- Added `cleanupAppId` and `cleanupClearAppData` parameters to `executePlan` tool
- Supports both terminate and clear app data operations

### Build Fix
- Increased Gradle and Kotlin daemon heap from 1GB to 2GB in `gradle.properties`
- Resolves `OutOfMemoryError` during DEX merging with complex playground app
- Note: Playground app has minSdk 27, so multiDex is automatically enabled by AGP

## Testing
- All existing JUnit runner tests pass (23 passed, 3 skipped)
- Added unit tests for cleanup parameter validation
- Added tests for daemon executePlan args with cleanup
- Full Android build succeeds with increased heap

## Test Plan
- [ ] Run JUnit tests: `cd android && ./gradlew :junit-runner:test`
- [ ] Verify test order randomization in console output
- [ ] Verify cleanup warnings when appId is blank
- [ ] Run full Android build: `cd android && ./gradlew build`
- [ ] Test with actual device to verify cleanup behavior

Closes #134

🤖 Generated with [Claude Code](https://claude.com/claude-code)