### PR TITLE
Add view hierarchy-based navigation detection

### DIFF
--- a/src/features/navigation/HierarchyNavigationDetector.ts
+++ b/src/features/navigation/HierarchyNavigationDetector.ts
@@ -1,0 +1,255 @@
+import { logger } from "../../utils/logger";
+import { Timer, defaultTimer } from "../../utils/SystemTimer";
+import { NavigationGraphManager } from "./NavigationGraphManager";
+import {
+  ScreenFingerprint,
+  AccessibilityHierarchy,
+  FingerprintResult,
+} from "./ScreenFingerprint";
+
+/**
+ * Options for the hierarchy navigation detector.
+ */
+export interface HierarchyNavigationDetectorOptions {
+  /** Debounce time in milliseconds (default: 100ms) */
+  debounceMs?: number;
+  /** Max time to wait for UI stability in milliseconds (default: 5000ms) */
+  stabilityTimeoutMs?: number;
+  /** Timer for setTimeout/clearTimeout (default: defaultTimer) */
+  timer?: Timer;
+}
+
+const DEFAULT_OPTIONS: Required<Omit<HierarchyNavigationDetectorOptions, "timer">> & { timer: Timer } = {
+  debounceMs: 100,
+  stabilityTimeoutMs: 5000,
+  timer: defaultTimer,
+};
+
+/**
+ * Detects navigation events from view hierarchy changes.
+ *
+ * This detector:
+ * 1. Listens for hierarchy updates
+ * 2. Computes screen fingerprints
+ * 3. Debounces updates to wait for UI stability
+ * 4. Records navigation when fingerprint changes
+ *
+ * The detector uses debouncing to avoid recording navigation during
+ * animations or rapid UI updates. A fingerprint is considered "stable"
+ * when it hasn't changed for the debounce period.
+ */
+export class HierarchyNavigationDetector {
+  private navigationManager: NavigationGraphManager;
+  private debounceMs: number;
+  private stabilityTimeoutMs: number;
+  private timer: Timer;
+
+  /** Current stable fingerprint (after debounce) */
+  private currentStableFingerprint: FingerprintResult | null = null;
+  /** Previous stable fingerprint (before current navigation) */
+  private previousStableFingerprint: FingerprintResult | null = null;
+  /** Pending fingerprint waiting for stability */
+  private pendingFingerprint: FingerprintResult | null = null;
+  /** Timestamp when pending fingerprint was first seen */
+  private pendingFingerprintStartTime: number = 0;
+  /** Debounce timer handle */
+  private debounceTimer: NodeJS.Timeout | null = null;
+  /** Stability timeout timer handle */
+  private stabilityTimeoutTimer: NodeJS.Timeout | null = null;
+
+  constructor(
+    navigationManager: NavigationGraphManager,
+    options?: HierarchyNavigationDetectorOptions
+  ) {
+    this.navigationManager = navigationManager;
+    this.debounceMs = options?.debounceMs ?? DEFAULT_OPTIONS.debounceMs;
+    this.stabilityTimeoutMs = options?.stabilityTimeoutMs ?? DEFAULT_OPTIONS.stabilityTimeoutMs;
+    this.timer = options?.timer ?? DEFAULT_OPTIONS.timer;
+  }
+
+  /**
+   * Handle a hierarchy update from the accessibility service.
+   * This is the main entry point called when new hierarchy data arrives.
+   */
+  public onHierarchyUpdate(hierarchy: AccessibilityHierarchy): void {
+    // Compute fingerprint for this hierarchy
+    const fingerprint = ScreenFingerprint.compute(hierarchy);
+
+    logger.debug(
+      `[HIERARCHY_NAV] Received hierarchy update: hash=${fingerprint.hash.substring(0, 12)}, ` +
+      `elements=${fingerprint.elementCount}, pkg=${fingerprint.packageName}`
+    );
+
+    // Check if fingerprint is different from pending
+    if (this.pendingFingerprint && this.pendingFingerprint.hash === fingerprint.hash) {
+      // Same as pending - fingerprint hasn't changed, let debounce timer continue
+      logger.debug(`[HIERARCHY_NAV] Same as pending fingerprint, waiting for stability`);
+      return;
+    }
+
+    // New fingerprint - reset debounce timer
+    this.clearDebounceTimer();
+
+    // Update pending fingerprint
+    this.pendingFingerprint = fingerprint;
+    this.pendingFingerprintStartTime = this.timer.now();
+
+    logger.debug(
+      `[HIERARCHY_NAV] New pending fingerprint: ${fingerprint.hash.substring(0, 12)}, ` +
+      `starting debounce (${this.debounceMs}ms)`
+    );
+
+    // Start new debounce timer
+    this.debounceTimer = this.timer.setTimeout(() => {
+      this.onFingerprintStable();
+    }, this.debounceMs);
+
+    // Start stability timeout if not already running
+    if (!this.stabilityTimeoutTimer) {
+      this.stabilityTimeoutTimer = this.timer.setTimeout(() => {
+        this.onStabilityTimeout();
+      }, this.stabilityTimeoutMs);
+    }
+  }
+
+  /**
+   * Called when fingerprint has been stable for debounce period.
+   */
+  private onFingerprintStable(): void {
+    this.clearTimers();
+
+    if (!this.pendingFingerprint) {
+      return;
+    }
+
+    const newFingerprint = this.pendingFingerprint;
+    this.pendingFingerprint = null;
+
+    logger.debug(
+      `[HIERARCHY_NAV] Fingerprint stable: ${newFingerprint.hash.substring(0, 12)}`
+    );
+
+    // Check if this is a navigation (different from current stable)
+    if (this.currentStableFingerprint?.hash !== newFingerprint.hash) {
+      this.recordNavigation(newFingerprint);
+    }
+  }
+
+  /**
+   * Called when stability timeout is reached.
+   * Forces navigation detection even if UI hasn't stabilized.
+   */
+  private onStabilityTimeout(): void {
+    this.clearTimers();
+
+    if (!this.pendingFingerprint) {
+      return;
+    }
+
+    const newFingerprint = this.pendingFingerprint;
+    this.pendingFingerprint = null;
+
+    logger.info(
+      `[HIERARCHY_NAV] Stability timeout reached, forcing navigation detection: ` +
+      `${newFingerprint.hash.substring(0, 12)}`
+    );
+
+    // Check if this is a navigation
+    if (this.currentStableFingerprint?.hash !== newFingerprint.hash) {
+      this.recordNavigation(newFingerprint);
+    }
+  }
+
+  /**
+   * Record a navigation event to the navigation graph.
+   */
+  private recordNavigation(newFingerprint: FingerprintResult): void {
+    const fromFingerprint = this.currentStableFingerprint?.hash || null;
+    const toFingerprint = newFingerprint.hash;
+
+    logger.info(
+      `[HIERARCHY_NAV] Navigation detected: ` +
+      `${fromFingerprint ? fromFingerprint.substring(0, 12) : "(initial)"} -> ` +
+      `${toFingerprint.substring(0, 12)}`
+    );
+
+    // Update fingerprint state
+    this.previousStableFingerprint = this.currentStableFingerprint;
+    this.currentStableFingerprint = newFingerprint;
+
+    // Record to navigation graph
+    this.navigationManager
+      .recordHierarchyNavigation({
+        fromFingerprint,
+        toFingerprint,
+        timestamp: newFingerprint.timestamp,
+        packageName: newFingerprint.packageName,
+      })
+      .catch(error => {
+        logger.error(`[HIERARCHY_NAV] Failed to record navigation: ${error}`);
+      });
+  }
+
+  /**
+   * Get the current stable fingerprint.
+   */
+  public getCurrentFingerprint(): FingerprintResult | null {
+    return this.currentStableFingerprint;
+  }
+
+  /**
+   * Get the previous stable fingerprint.
+   */
+  public getPreviousFingerprint(): FingerprintResult | null {
+    return this.previousStableFingerprint;
+  }
+
+  /**
+   * Check if there's a pending fingerprint waiting for stability.
+   */
+  public hasPendingFingerprint(): boolean {
+    return this.pendingFingerprint !== null;
+  }
+
+  /**
+   * Reset the detector state.
+   * Call this when the app changes or you want to start fresh.
+   */
+  public reset(): void {
+    this.clearTimers();
+    this.currentStableFingerprint = null;
+    this.previousStableFingerprint = null;
+    this.pendingFingerprint = null;
+    this.pendingFingerprintStartTime = 0;
+
+    logger.debug(`[HIERARCHY_NAV] Detector state reset`);
+  }
+
+  /**
+   * Clear the debounce timer.
+   */
+  private clearDebounceTimer(): void {
+    if (this.debounceTimer) {
+      this.timer.clearTimeout(this.debounceTimer);
+      this.debounceTimer = null;
+    }
+  }
+
+  /**
+   * Clear all timers.
+   */
+  private clearTimers(): void {
+    this.clearDebounceTimer();
+    if (this.stabilityTimeoutTimer) {
+      this.timer.clearTimeout(this.stabilityTimeoutTimer);
+      this.stabilityTimeoutTimer = null;
+    }
+  }
+
+  /**
+   * Cleanup resources. Call when the detector is no longer needed.
+   */
+  public dispose(): void {
+    this.clearTimers();
+  }
+}

--- a/src/features/navigation/NavigationGraphManager.ts
+++ b/src/features/navigation/NavigationGraphManager.ts
@@ -5,6 +5,7 @@ import type { NavigationEdge as DBNavigationEdge } from "../../db/types";
 import {
   NavigationGraph,
   NavigationEvent,
+  HierarchyNavigationEvent,
   NavigationNode,
   NavigationEdge,
   NavigationGraphStats,
@@ -20,6 +21,7 @@ import {
 export type {
   NavigationGraph,
   NavigationEvent,
+  HierarchyNavigationEvent,
   NavigationNode,
   NavigationEdge,
   NavigationGraphStats,
@@ -204,6 +206,103 @@ export class NavigationGraphManager implements NavigationGraph {
           timestamp
         );
       }
+    }
+
+    this.currentScreen = screenName;
+    await this.repository.touchApp(this.currentAppId);
+  }
+
+  /**
+   * Record a navigation event detected from view hierarchy changes.
+   * This is an alternative to SDK navigation events for apps without SDK integration.
+   * Uses the fingerprint hash as the screen name.
+   */
+  public async recordHierarchyNavigation(event: HierarchyNavigationEvent): Promise<void> {
+    // Auto-set current app from package name if provided
+    if (event.packageName && event.packageName !== this.currentAppId) {
+      await this.setCurrentApp(event.packageName);
+    }
+
+    if (!this.currentAppId) {
+      logger.warn(`[NAVIGATION_GRAPH] Cannot record hierarchy navigation - no current app set`);
+      return;
+    }
+
+    // Use a shortened fingerprint hash as the screen name for readability
+    const screenName = `screen_${event.toFingerprint.substring(0, 12)}`;
+    const timestamp = event.timestamp;
+
+    // Get or create node and update visit count
+    await this.repository.getOrCreateNode(
+      this.currentAppId,
+      screenName,
+      timestamp
+    );
+
+    // Get modal stack from the most recent tool call (if any)
+    const recentToolCall = this.findCorrelatedToolCall(timestamp);
+    const currentModalStack = recentToolCall?.uiState?.modalStack;
+
+    // Create edge from previous screen to current screen
+    const fromScreenName = event.fromFingerprint
+      ? `screen_${event.fromFingerprint.substring(0, 12)}`
+      : null;
+
+    if (fromScreenName && fromScreenName !== screenName) {
+      const interaction = this.findCorrelatedToolCall(timestamp);
+
+      const toolName = interaction?.toolName || null;
+      const toolArgs = interaction?.args || null;
+
+      const edge = await this.repository.createEdge(
+        this.currentAppId,
+        fromScreenName,
+        screenName,
+        toolName,
+        toolArgs,
+        timestamp
+      );
+
+      // Store UI elements if present in interaction
+      if (interaction?.uiState?.selectedElements) {
+        await this.storeUIElements(
+          edge.id,
+          interaction.uiState.selectedElements,
+          timestamp
+        );
+      }
+
+      // Store modal stacks for from/to
+      const fromNode = await this.repository.getNode(this.currentAppId, fromScreenName);
+      if (fromNode) {
+        const fromModals = await this.repository.getNodeModals(fromNode.id);
+        if (fromModals.length > 0) {
+          await this.repository.setEdgeModals(edge.id, "from", fromModals);
+        }
+      }
+
+      if (currentModalStack && currentModalStack.length > 0) {
+        const toModalIds = currentModalStack.map(
+          m => m.identifier || `${m.type}-${m.layer}`
+        );
+        await this.repository.setEdgeModals(edge.id, "to", toModalIds);
+      }
+
+      // Store scroll position if present
+      if (interaction?.uiState?.scrollPosition) {
+        await this.storeScrollPosition(
+          edge.id,
+          interaction.uiState.scrollPosition,
+          timestamp
+        );
+      }
+
+      logger.info(
+        `[NAVIGATION_GRAPH] Hierarchy navigation: ${fromScreenName} -> ${screenName}` +
+        (toolName ? ` (via ${toolName})` : " (no correlated tool call)")
+      );
+    } else if (!fromScreenName) {
+      logger.info(`[NAVIGATION_GRAPH] Initial hierarchy screen: ${screenName}`);
     }
 
     this.currentScreen = screenName;

--- a/src/features/navigation/ScreenFingerprint.ts
+++ b/src/features/navigation/ScreenFingerprint.ts
@@ -1,0 +1,346 @@
+import crypto from "crypto";
+
+/**
+ * Interface for accessibility service node format (subset of AccessibilityNode from AccessibilityServiceClient)
+ */
+interface AccessibilityNode {
+  text?: string;
+  "content-desc"?: string;
+  "resource-id"?: string;
+  "test-tag"?: string;
+  className?: string;
+  scrollable?: string;
+  node?: AccessibilityNode | AccessibilityNode[];
+}
+
+/**
+ * Interface for accessibility hierarchy format
+ */
+export interface AccessibilityHierarchy {
+  updatedAt: number;
+  packageName: string;
+  hierarchy: AccessibilityNode;
+  windows?: Array<{
+    windowId: number;
+    windowType: string;
+    windowLayer: number;
+    packageName?: string;
+    isActive: boolean;
+    isFocused: boolean;
+    hierarchy?: AccessibilityNode;
+  }>;
+}
+
+/**
+ * Result of computing a screen fingerprint
+ */
+export interface FingerprintResult {
+  /** SHA-256 hash of sorted fingerprint elements */
+  hash: string;
+  /** Timestamp when the hierarchy was captured */
+  timestamp: number;
+  /** Package name of the app */
+  packageName: string;
+  /** Number of elements included in the fingerprint */
+  elementCount: number;
+}
+
+/**
+ * Options for fingerprint computation
+ */
+export interface FingerprintOptions {
+  /** Filter duplicate elements from scrollable containers (default: true) */
+  filterDuplicates?: boolean;
+  /** Include resource-ids in fingerprint (default: true) */
+  includeResourceIds?: boolean;
+  /** Include text content in fingerprint (default: true) */
+  includeText?: boolean;
+  /** Include content descriptions in fingerprint (default: true) */
+  includeContentDesc?: boolean;
+  /** Include test tags in fingerprint (default: true) */
+  includeTestTags?: boolean;
+}
+
+const DEFAULT_OPTIONS: Required<FingerprintOptions> = {
+  filterDuplicates: true,
+  includeResourceIds: true,
+  includeText: true,
+  includeContentDesc: true,
+  includeTestTags: true,
+};
+
+/**
+ * Class names that indicate scrollable list containers
+ */
+const SCROLLABLE_CLASS_NAMES = [
+  "recyclerview",
+  "listview",
+  "scrollview",
+  "lazycolumn",
+  "lazyrow",
+  "lazyverticalgrid",
+  "lazyhorizontalgrid",
+  "nestedscrollview",
+  "horizontalscrollview",
+];
+
+/**
+ * Computes a fingerprint hash from a view hierarchy to identify screens.
+ *
+ * The fingerprint is computed by:
+ * 1. Traversing all nodes in the hierarchy
+ * 2. Collecting text, resource-id, content-desc, and test-tag from each node
+ * 3. Filtering duplicate elements from scrollable containers (list items)
+ * 4. Sorting elements lexicographically for stable ordering
+ * 5. Hashing with SHA-256
+ */
+export class ScreenFingerprint {
+  /**
+   * Compute a fingerprint from a view hierarchy.
+   */
+  static compute(
+    hierarchy: AccessibilityHierarchy,
+    options?: FingerprintOptions
+  ): FingerprintResult {
+    const opts = { ...DEFAULT_OPTIONS, ...options };
+    const elements: string[] = [];
+    const scrollableContainerChildren = new Map<string, Map<string, string[]>>();
+
+    // Traverse hierarchy and collect elements
+    this.traverseHierarchy(
+      hierarchy.hierarchy,
+      elements,
+      scrollableContainerChildren,
+      opts,
+      null,
+      false
+    );
+
+    // Also traverse windows if present
+    if (hierarchy.windows) {
+      for (const window of hierarchy.windows) {
+        if (window.hierarchy) {
+          this.traverseHierarchy(
+            window.hierarchy,
+            elements,
+            scrollableContainerChildren,
+            opts,
+            null,
+            false
+          );
+        }
+      }
+    }
+
+    // Filter duplicates from scrollable containers if enabled
+    let filteredElements = elements;
+    if (opts.filterDuplicates) {
+      filteredElements = this.filterScrollableContainerDuplicates(
+        elements,
+        scrollableContainerChildren
+      );
+    }
+
+    // Sort lexicographically for deterministic output
+    filteredElements.sort();
+
+    // Generate SHA-256 hash
+    const hash = this.generateHash(filteredElements);
+
+    return {
+      hash,
+      timestamp: hierarchy.updatedAt,
+      packageName: hierarchy.packageName,
+      elementCount: filteredElements.length,
+    };
+  }
+
+  /**
+   * Traverse the view hierarchy and collect fingerprint elements.
+   *
+   * @param node - Current node to process
+   * @param elements - Array to collect fingerprint elements into
+   * @param scrollableContainerChildren - Map tracking children of scrollable containers
+   * @param opts - Fingerprint options
+   * @param currentScrollableId - ID of the current scrollable container (if inside one)
+   * @param insideScrollable - Whether we're inside a scrollable container
+   */
+  private static traverseHierarchy(
+    node: AccessibilityNode,
+    elements: string[],
+    scrollableContainerChildren: Map<string, Map<string, string[]>>,
+    opts: Required<FingerprintOptions>,
+    currentScrollableId: string | null,
+    insideScrollable: boolean
+  ): void {
+    // Check if this node is a scrollable container
+    const isScrollable = this.isScrollableContainer(node);
+    let scrollableId = currentScrollableId;
+    let isInsideScrollable = insideScrollable;
+
+    if (isScrollable && !insideScrollable) {
+      // This is a new scrollable container - use resource-id or generate unique id
+      scrollableId = node["resource-id"] || `scrollable_${elements.length}`;
+      isInsideScrollable = true;
+
+      // Initialize the map for this container
+      if (!scrollableContainerChildren.has(scrollableId)) {
+        scrollableContainerChildren.set(scrollableId, new Map());
+      }
+    }
+
+    // Collect fingerprint elements from this node
+    const nodeElements = this.collectNodeElements(node, opts);
+
+    for (const element of nodeElements) {
+      if (isInsideScrollable && scrollableId) {
+        // Track this element as part of a scrollable container
+        const containerMap = scrollableContainerChildren.get(scrollableId)!;
+
+        // Group by element value (resource-id takes priority)
+        const groupKey = this.getGroupKey(node, element);
+        if (!containerMap.has(groupKey)) {
+          containerMap.set(groupKey, []);
+        }
+        containerMap.get(groupKey)!.push(element);
+      }
+
+      elements.push(element);
+    }
+
+    // Recurse into children
+    if (node.node) {
+      const children = Array.isArray(node.node) ? node.node : [node.node];
+      for (const child of children) {
+        this.traverseHierarchy(
+          child,
+          elements,
+          scrollableContainerChildren,
+          opts,
+          scrollableId,
+          isInsideScrollable
+        );
+      }
+    }
+  }
+
+  /**
+   * Collect fingerprint elements from a single node.
+   */
+  private static collectNodeElements(
+    node: AccessibilityNode,
+    opts: Required<FingerprintOptions>
+  ): string[] {
+    const elements: string[] = [];
+
+    if (opts.includeResourceIds && node["resource-id"]) {
+      elements.push(`id:${node["resource-id"]}`);
+    }
+
+    if (opts.includeText && node.text) {
+      elements.push(`text:${node.text}`);
+    }
+
+    if (opts.includeContentDesc && node["content-desc"]) {
+      elements.push(`desc:${node["content-desc"]}`);
+    }
+
+    if (opts.includeTestTags && node["test-tag"]) {
+      elements.push(`tag:${node["test-tag"]}`);
+    }
+
+    return elements;
+  }
+
+  /**
+   * Get a grouping key for an element based on its resource-id or value.
+   * Elements with the same resource-id are grouped together for duplicate filtering.
+   */
+  private static getGroupKey(node: AccessibilityNode, element: string): string {
+    // If the node has a resource-id, group by that
+    if (node["resource-id"]) {
+      return `id:${node["resource-id"]}`;
+    }
+    // Otherwise, group by the element value itself
+    return element;
+  }
+
+  /**
+   * Check if a node is a scrollable container.
+   */
+  private static isScrollableContainer(node: AccessibilityNode): boolean {
+    // Check scrollable attribute
+    if (node.scrollable === "true") {
+      return true;
+    }
+
+    // Check class name for known scrollable containers
+    if (node.className) {
+      const classNameLower = node.className.toLowerCase();
+      for (const scrollableClass of SCROLLABLE_CLASS_NAMES) {
+        if (classNameLower.includes(scrollableClass)) {
+          return true;
+        }
+      }
+    }
+
+    return false;
+  }
+
+  /**
+   * Filter duplicate elements from scrollable containers.
+   * For each scrollable container, group elements by resource-id and keep only the first occurrence.
+   */
+  private static filterScrollableContainerDuplicates(
+    elements: string[],
+    scrollableContainerChildren: Map<string, Map<string, string[]>>
+  ): string[] {
+    // Collect all elements that should be removed (duplicates beyond the first)
+    const duplicatesToRemove = new Set<string>();
+
+    for (const containerMap of scrollableContainerChildren.values()) {
+      for (const groupElements of containerMap.values()) {
+        // Keep the first element, mark rest as duplicates
+        for (let i = 1; i < groupElements.length; i++) {
+          duplicatesToRemove.add(groupElements[i]);
+        }
+      }
+    }
+
+    // Track which duplicates we've already removed (for elements appearing multiple times)
+    const removedCounts = new Map<string, number>();
+
+    return elements.filter(element => {
+      if (duplicatesToRemove.has(element)) {
+        const removedCount = removedCounts.get(element) || 0;
+
+        // Find how many times this element appears in duplicate lists
+        let totalDuplicates = 0;
+        for (const containerMap of scrollableContainerChildren.values()) {
+          for (const groupElements of containerMap.values()) {
+            // Count duplicates (skip first element in each group)
+            for (let i = 1; i < groupElements.length; i++) {
+              if (groupElements[i] === element) {
+                totalDuplicates++;
+              }
+            }
+          }
+        }
+
+        if (removedCount < totalDuplicates) {
+          removedCounts.set(element, removedCount + 1);
+          return false; // Remove this duplicate
+        }
+      }
+      return true;
+    });
+  }
+
+  /**
+   * Generate SHA-256 hash from sorted element list.
+   */
+  private static generateHash(elements: string[]): string {
+    const data = elements.join("\n");
+    return crypto.createHash("sha256").update(data).digest("hex");
+  }
+}

--- a/src/features/observe/AccessibilityServiceClient.ts
+++ b/src/features/observe/AccessibilityServiceClient.ts
@@ -8,6 +8,7 @@ import { AndroidAccessibilityServiceManager } from "../../utils/AccessibilitySer
 import { PerformanceTracker, NoOpPerformanceTracker } from "../../utils/PerformanceTracker";
 import { Timer, defaultTimer } from "../../utils/SystemTimer";
 import { NavigationGraphManager, NavigationEvent } from "../navigation/NavigationGraphManager";
+import { HierarchyNavigationDetector } from "../navigation/HierarchyNavigationDetector";
 import { throwIfAborted } from "../../utils/toolUtils";
 
 /**
@@ -499,6 +500,9 @@ export class AccessibilityServiceClient implements AccessibilityService {
   // Timer for testing
   private timer: Timer;
 
+  // Hierarchy navigation detector for view hierarchy-based navigation
+  private hierarchyNavigationDetector: HierarchyNavigationDetector | null = null;
+
   /**
    * Private constructor - use getInstance() instead
    * @param device - The booted device
@@ -559,6 +563,29 @@ export class AccessibilityServiceClient implements AccessibilityService {
     timer?: Timer
   ): AccessibilityServiceClient {
     return new AccessibilityServiceClient(device, adb, webSocketFactory, timer);
+  }
+
+  /**
+   * Get the hierarchy navigation detector, creating it lazily if needed.
+   * The detector monitors view hierarchy updates to detect screen changes.
+   */
+  public getHierarchyNavigationDetector(): HierarchyNavigationDetector {
+    if (!this.hierarchyNavigationDetector) {
+      this.hierarchyNavigationDetector = new HierarchyNavigationDetector(
+        NavigationGraphManager.getInstance()
+      );
+    }
+    return this.hierarchyNavigationDetector;
+  }
+
+  /**
+   * Reset the hierarchy navigation detector.
+   * Call this when switching apps or when you want to start fresh.
+   */
+  public resetHierarchyNavigationDetector(): void {
+    if (this.hierarchyNavigationDetector) {
+      this.hierarchyNavigationDetector.reset();
+    }
   }
 
   /**
@@ -761,6 +788,11 @@ export class AccessibilityServiceClient implements AccessibilityService {
         };
 
         logger.debug(`[ACCESSIBILITY_SERVICE] Cached fresh hierarchy (updatedAt: ${message.data.updatedAt})`);
+
+        // Notify hierarchy navigation detector for view hierarchy-based navigation detection
+        if (this.hierarchyNavigationDetector) {
+          this.hierarchyNavigationDetector.onHierarchyUpdate(message.data);
+        }
       }
 
       // Handle screenshot response
@@ -1620,6 +1652,12 @@ export class AccessibilityServiceClient implements AccessibilityService {
         logger.info("[ACCESSIBILITY_SERVICE] Closing WebSocket connection");
         this.ws.close();
         this.ws = null;
+      }
+
+      // Dispose hierarchy navigation detector
+      if (this.hierarchyNavigationDetector) {
+        this.hierarchyNavigationDetector.dispose();
+        this.hierarchyNavigationDetector = null;
       }
 
       // Optionally remove port forwarding

--- a/src/utils/interfaces/NavigationGraph.ts
+++ b/src/utils/interfaces/NavigationGraph.ts
@@ -159,6 +159,21 @@ export interface BackStackInfo {
 }
 
 /**
+ * Represents a navigation event detected from view hierarchy changes.
+ * This is an alternative to SDK navigation events for apps without SDK integration.
+ */
+export interface HierarchyNavigationEvent {
+  /** Screen fingerprint of the source screen (null if first screen) */
+  fromFingerprint: string | null;
+  /** Screen fingerprint of the destination screen */
+  toFingerprint: string;
+  /** Timestamp when the navigation was detected */
+  timestamp: number;
+  /** Package name of the app */
+  packageName?: string;
+}
+
+/**
  * Interface for navigation graph management.
  * Allows for easy mocking in tests.
  */
@@ -171,6 +186,9 @@ export interface NavigationGraph {
 
   /** Record a navigation event from WebSocket */
   recordNavigationEvent(event: NavigationEvent): Promise<void>;
+
+  /** Record a navigation event detected from view hierarchy changes */
+  recordHierarchyNavigation(event: HierarchyNavigationEvent): Promise<void>;
 
   /** Record back stack information for the current screen */
   recordBackStack(backStack: BackStackInfo): void;

--- a/test/features/navigation/HierarchyNavigationDetector.test.ts
+++ b/test/features/navigation/HierarchyNavigationDetector.test.ts
@@ -1,0 +1,297 @@
+import { expect, describe, test, beforeEach, afterEach, beforeAll } from "bun:test";
+import {
+  HierarchyNavigationDetector,
+} from "../../../src/features/navigation/HierarchyNavigationDetector";
+import { NavigationGraphManager } from "../../../src/features/navigation/NavigationGraphManager";
+import { AccessibilityHierarchy } from "../../../src/features/navigation/ScreenFingerprint";
+import { FakeTimer } from "../../fakes/FakeTimer";
+import { runMigrations } from "../../helpers/database";
+
+describe("HierarchyNavigationDetector", () => {
+  let manager: NavigationGraphManager;
+  let detector: HierarchyNavigationDetector;
+  let fakeTimer: FakeTimer;
+
+  beforeAll(async () => {
+    await runMigrations();
+  });
+
+  beforeEach(async () => {
+    NavigationGraphManager.resetInstance();
+    manager = NavigationGraphManager.getInstance();
+    await manager.setCurrentApp("com.test.app");
+    await manager.clearCurrentGraph();
+    await manager.setCurrentApp("com.test.app");
+
+    // Use FakeTimer in manual mode for deterministic timing
+    fakeTimer = new FakeTimer();
+    fakeTimer.setManualMode();
+
+    detector = new HierarchyNavigationDetector(manager, {
+      debounceMs: 50,
+      stabilityTimeoutMs: 200,
+      timer: fakeTimer,
+    });
+  });
+
+  afterEach(() => {
+    detector.dispose();
+    fakeTimer.reset();
+    NavigationGraphManager.resetInstance();
+  });
+
+  describe("initial state", () => {
+    test("should start with no fingerprints", () => {
+      expect(detector.getCurrentFingerprint()).toBeNull();
+      expect(detector.getPreviousFingerprint()).toBeNull();
+      expect(detector.hasPendingFingerprint()).toBe(false);
+    });
+  });
+
+  describe("onHierarchyUpdate", () => {
+    test("should set pending fingerprint on first update", () => {
+      const hierarchy = createHierarchy("Screen A");
+      detector.onHierarchyUpdate(hierarchy);
+
+      expect(detector.hasPendingFingerprint()).toBe(true);
+      expect(detector.getCurrentFingerprint()).toBeNull(); // Not stable yet
+    });
+
+    test("should stabilize fingerprint after debounce", () => {
+      const hierarchy = createHierarchy("Screen A");
+      detector.onHierarchyUpdate(hierarchy);
+
+      // Advance time past debounce
+      fakeTimer.advanceTime(60);
+
+      expect(detector.hasPendingFingerprint()).toBe(false);
+      expect(detector.getCurrentFingerprint()).not.toBeNull();
+      expect(detector.getCurrentFingerprint()?.packageName).toBe("com.test.app");
+    });
+
+    test("should reset debounce timer on new fingerprint", () => {
+      const hierarchy1 = createHierarchy("Screen A");
+      const hierarchy2 = createHierarchy("Screen B");
+
+      detector.onHierarchyUpdate(hierarchy1);
+      fakeTimer.advanceTime(30); // Less than debounce
+
+      detector.onHierarchyUpdate(hierarchy2);
+      fakeTimer.advanceTime(30); // Less than debounce from second update
+
+      // Should still be pending (timer was reset)
+      expect(detector.hasPendingFingerprint()).toBe(true);
+
+      // Advance past debounce
+      fakeTimer.advanceTime(30);
+
+      // Should now be stable with Screen B
+      expect(detector.hasPendingFingerprint()).toBe(false);
+      expect(detector.getCurrentFingerprint()).not.toBeNull();
+    });
+
+    test("should not reset timer for same fingerprint", () => {
+      const hierarchy = createHierarchy("Screen A");
+
+      detector.onHierarchyUpdate(hierarchy);
+      fakeTimer.advanceTime(30);
+
+      // Same hierarchy again - should not reset timer
+      detector.onHierarchyUpdate(hierarchy);
+      fakeTimer.advanceTime(30);
+
+      // Should be stable now (60ms > 50ms debounce)
+      expect(detector.hasPendingFingerprint()).toBe(false);
+      expect(detector.getCurrentFingerprint()).not.toBeNull();
+    });
+  });
+
+  describe("navigation detection", () => {
+    test("should detect navigation when fingerprint changes", () => {
+      const hierarchy1 = createHierarchy("Screen A");
+      const hierarchy2 = createHierarchy("Screen B");
+
+      // First screen
+      detector.onHierarchyUpdate(hierarchy1);
+      fakeTimer.advanceTime(60);
+
+      const firstFingerprint = detector.getCurrentFingerprint();
+      expect(firstFingerprint).not.toBeNull();
+
+      // Navigate to second screen
+      detector.onHierarchyUpdate(hierarchy2);
+      fakeTimer.advanceTime(60);
+
+      const secondFingerprint = detector.getCurrentFingerprint();
+      expect(secondFingerprint).not.toBeNull();
+      expect(secondFingerprint?.hash).not.toBe(firstFingerprint?.hash);
+
+      // Previous should be first screen
+      expect(detector.getPreviousFingerprint()?.hash).toBe(firstFingerprint?.hash);
+    });
+
+    test("should record navigation to graph manager", async () => {
+      const hierarchy1 = createHierarchy("Screen A");
+      const hierarchy2 = createHierarchy("Screen B");
+
+      detector.onHierarchyUpdate(hierarchy1);
+      fakeTimer.advanceTime(60);
+
+      detector.onHierarchyUpdate(hierarchy2);
+      fakeTimer.advanceTime(60);
+
+      // Wait for async navigation recording
+      await new Promise(resolve => setImmediate(resolve));
+
+      // Should have recorded navigation
+      const screens = await manager.getKnownScreens();
+      expect(screens.length).toBeGreaterThanOrEqual(2);
+    });
+
+    test("should not detect navigation for same fingerprint", () => {
+      const hierarchy = createHierarchy("Screen A");
+
+      detector.onHierarchyUpdate(hierarchy);
+      fakeTimer.advanceTime(60);
+
+      const firstFingerprint = detector.getCurrentFingerprint();
+
+      // Same hierarchy again
+      detector.onHierarchyUpdate(hierarchy);
+      fakeTimer.advanceTime(60);
+
+      // Should still be same fingerprint, no navigation
+      expect(detector.getCurrentFingerprint()?.hash).toBe(firstFingerprint?.hash);
+      expect(detector.getPreviousFingerprint()).toBeNull(); // No navigation occurred
+    });
+  });
+
+  describe("stability timeout", () => {
+    test("should force navigation detection after timeout", () => {
+      // Create detector with long debounce, short timeout
+      detector.dispose();
+      const longDebounceTimer = new FakeTimer();
+      longDebounceTimer.setManualMode();
+      detector = new HierarchyNavigationDetector(manager, {
+        debounceMs: 1000, // Long debounce
+        stabilityTimeoutMs: 100, // Short timeout
+        timer: longDebounceTimer,
+      });
+
+      const hierarchy1 = createHierarchy("Screen A");
+      detector.onHierarchyUpdate(hierarchy1);
+
+      // Advance past stability timeout (not debounce)
+      longDebounceTimer.advanceTime(150);
+
+      // Should have forced stable despite long debounce
+      expect(detector.hasPendingFingerprint()).toBe(false);
+      expect(detector.getCurrentFingerprint()).not.toBeNull();
+    });
+  });
+
+  describe("reset", () => {
+    test("should clear all state", () => {
+      const hierarchy = createHierarchy("Screen A");
+      detector.onHierarchyUpdate(hierarchy);
+      fakeTimer.advanceTime(60);
+
+      expect(detector.getCurrentFingerprint()).not.toBeNull();
+
+      detector.reset();
+
+      expect(detector.getCurrentFingerprint()).toBeNull();
+      expect(detector.getPreviousFingerprint()).toBeNull();
+      expect(detector.hasPendingFingerprint()).toBe(false);
+    });
+
+    test("should clear pending timers", () => {
+      const hierarchy = createHierarchy("Screen A");
+      detector.onHierarchyUpdate(hierarchy);
+
+      expect(detector.hasPendingFingerprint()).toBe(true);
+
+      detector.reset();
+
+      expect(detector.hasPendingFingerprint()).toBe(false);
+    });
+  });
+
+  describe("dispose", () => {
+    test("should clear timers", () => {
+      const hierarchy = createHierarchy("Screen A");
+      detector.onHierarchyUpdate(hierarchy);
+
+      detector.dispose();
+
+      // Advancing time after dispose should not crash
+      fakeTimer.advanceTime(100);
+    });
+  });
+
+  describe("tool call correlation", () => {
+    test("should correlate with recent tool call", async () => {
+      // First screen - stabilize
+      // Use real timestamps for correlation to work
+      const hierarchy1: AccessibilityHierarchy = {
+        updatedAt: Date.now(),
+        packageName: "com.test.app",
+        hierarchy: {
+          "text": "Screen A",
+          "resource-id": "com.test.app:id/screen_a",
+        },
+      };
+      detector.onHierarchyUpdate(hierarchy1);
+      fakeTimer.advanceTime(60);
+
+      // Wait for async recording
+      await new Promise(resolve => setImmediate(resolve));
+
+      // Record a tool call BEFORE the second screen appears
+      manager.recordToolCall("tapOn", { text: "Next" });
+
+      // Second screen appears (navigation triggered by tool call)
+      // Use real timestamp slightly after tool call for correlation to work
+      const hierarchy2: AccessibilityHierarchy = {
+        updatedAt: Date.now(),
+        packageName: "com.test.app",
+        hierarchy: {
+          "text": "Screen B",
+          "resource-id": "com.test.app:id/screen_b",
+        },
+      };
+      detector.onHierarchyUpdate(hierarchy2);
+      fakeTimer.advanceTime(60);
+
+      // Wait for async navigation recording
+      await new Promise(resolve => setImmediate(resolve));
+
+      // Check that edge was recorded
+      const firstFingerprint = detector.getPreviousFingerprint();
+      expect(firstFingerprint).not.toBeNull();
+
+      const fromScreen = `screen_${firstFingerprint!.hash.substring(0, 12)}`;
+      const edges = await manager.getEdgesFrom(fromScreen);
+
+      // Should have an edge
+      expect(edges.length).toBe(1);
+
+      // Edge should have the correlated tool call
+      expect(edges[0].edgeType).toBe("tool");
+      expect(edges[0].interaction).toBeDefined();
+      expect(edges[0].interaction?.toolName).toBe("tapOn");
+    });
+  });
+});
+
+// Helper to create hierarchy with unique content
+function createHierarchy(uniqueContent: string): AccessibilityHierarchy {
+  return {
+    updatedAt: Date.now(),
+    packageName: "com.test.app",
+    hierarchy: {
+      "text": uniqueContent,
+      "resource-id": `com.test.app:id/${uniqueContent.toLowerCase().replace(/\s/g, "_")}`,
+    },
+  };
+}

--- a/test/features/navigation/ScreenFingerprint.test.ts
+++ b/test/features/navigation/ScreenFingerprint.test.ts
@@ -1,0 +1,506 @@
+import { expect, describe, test } from "bun:test";
+import { ScreenFingerprint, AccessibilityHierarchy } from "../../../src/features/navigation/ScreenFingerprint";
+
+describe("ScreenFingerprint", () => {
+  describe("compute", () => {
+    test("should compute fingerprint from simple hierarchy", () => {
+      const hierarchy = createHierarchy({
+        "text": "Hello World",
+        "resource-id": "com.app:id/title",
+      });
+
+      const result = ScreenFingerprint.compute(hierarchy);
+
+      expect(result.hash).toBeDefined();
+      expect(result.hash.length).toBe(64); // SHA-256 produces 64 hex chars
+      expect(result.timestamp).toBe(1234567890);
+      expect(result.packageName).toBe("com.test.app");
+      expect(result.elementCount).toBeGreaterThan(0);
+    });
+
+    test("should produce same hash for same hierarchy (determinism)", () => {
+      const hierarchy = createHierarchy({
+        "text": "Screen Title",
+        "resource-id": "com.app:id/header",
+        "node": [
+          { "text": "Button 1", "resource-id": "com.app:id/btn1" },
+          { "text": "Button 2", "resource-id": "com.app:id/btn2" },
+        ],
+      });
+
+      const result1 = ScreenFingerprint.compute(hierarchy);
+      const result2 = ScreenFingerprint.compute(hierarchy);
+
+      expect(result1.hash).toBe(result2.hash);
+    });
+
+    test("should produce different hash for different hierarchy", () => {
+      const hierarchy1 = createHierarchy({
+        "text": "Screen A",
+        "resource-id": "com.app:id/screen_a",
+      });
+
+      const hierarchy2 = createHierarchy({
+        "text": "Screen B",
+        "resource-id": "com.app:id/screen_b",
+      });
+
+      const result1 = ScreenFingerprint.compute(hierarchy1);
+      const result2 = ScreenFingerprint.compute(hierarchy2);
+
+      expect(result1.hash).not.toBe(result2.hash);
+    });
+
+    test("should include text in fingerprint", () => {
+      const hierarchy1 = createHierarchy({
+        text: "Text A",
+      });
+
+      const hierarchy2 = createHierarchy({
+        text: "Text B",
+      });
+
+      const result1 = ScreenFingerprint.compute(hierarchy1);
+      const result2 = ScreenFingerprint.compute(hierarchy2);
+
+      expect(result1.hash).not.toBe(result2.hash);
+    });
+
+    test("should include resource-id in fingerprint", () => {
+      const hierarchy1 = createHierarchy({
+        "resource-id": "com.app:id/screen_a",
+      });
+
+      const hierarchy2 = createHierarchy({
+        "resource-id": "com.app:id/screen_b",
+      });
+
+      const result1 = ScreenFingerprint.compute(hierarchy1);
+      const result2 = ScreenFingerprint.compute(hierarchy2);
+
+      expect(result1.hash).not.toBe(result2.hash);
+    });
+
+    test("should include content-desc in fingerprint", () => {
+      const hierarchy1 = createHierarchy({
+        "content-desc": "Description A",
+      });
+
+      const hierarchy2 = createHierarchy({
+        "content-desc": "Description B",
+      });
+
+      const result1 = ScreenFingerprint.compute(hierarchy1);
+      const result2 = ScreenFingerprint.compute(hierarchy2);
+
+      expect(result1.hash).not.toBe(result2.hash);
+    });
+
+    test("should include test-tag in fingerprint", () => {
+      const hierarchy1 = createHierarchy({
+        "test-tag": "tag_a",
+      });
+
+      const hierarchy2 = createHierarchy({
+        "test-tag": "tag_b",
+      });
+
+      const result1 = ScreenFingerprint.compute(hierarchy1);
+      const result2 = ScreenFingerprint.compute(hierarchy2);
+
+      expect(result1.hash).not.toBe(result2.hash);
+    });
+
+    test("should handle nested hierarchy", () => {
+      const hierarchy = createHierarchy({
+        "resource-id": "com.app:id/root",
+        "node": {
+          "resource-id": "com.app:id/container",
+          "node": {
+            "text": "Nested Text",
+            "resource-id": "com.app:id/nested",
+          },
+        },
+      });
+
+      const result = ScreenFingerprint.compute(hierarchy);
+
+      expect(result.elementCount).toBeGreaterThanOrEqual(3); // At least 3 elements collected
+    });
+
+    test("should handle array of child nodes", () => {
+      const hierarchy = createHierarchy({
+        "resource-id": "com.app:id/root",
+        "node": [
+          { "text": "Item 1", "resource-id": "com.app:id/item1" },
+          { "text": "Item 2", "resource-id": "com.app:id/item2" },
+          { "text": "Item 3", "resource-id": "com.app:id/item3" },
+        ],
+      });
+
+      const result = ScreenFingerprint.compute(hierarchy);
+
+      expect(result.elementCount).toBeGreaterThanOrEqual(4); // root + 3 items, each with text + id
+    });
+
+    test("should handle empty hierarchy", () => {
+      const hierarchy = createHierarchy({});
+
+      const result = ScreenFingerprint.compute(hierarchy);
+
+      expect(result.hash).toBeDefined();
+      expect(result.elementCount).toBe(0);
+    });
+
+    test("should include windows in fingerprint", () => {
+      const hierarchyWithWindows: AccessibilityHierarchy = {
+        updatedAt: 1234567890,
+        packageName: "com.test.app",
+        hierarchy: {
+          "resource-id": "com.app:id/main",
+        },
+        windows: [
+          {
+            windowId: 1,
+            windowType: "TYPE_APPLICATION",
+            windowLayer: 0,
+            isActive: true,
+            isFocused: true,
+            hierarchy: {
+              "text": "Window Content",
+              "resource-id": "com.app:id/window_content",
+            },
+          },
+        ],
+      };
+
+      const hierarchyWithoutWindows = createHierarchy({
+        "resource-id": "com.app:id/main",
+      });
+
+      const result1 = ScreenFingerprint.compute(hierarchyWithWindows);
+      const result2 = ScreenFingerprint.compute(hierarchyWithoutWindows);
+
+      expect(result1.hash).not.toBe(result2.hash);
+    });
+  });
+
+  describe("scrollable container duplicate filtering", () => {
+    test("should filter duplicate list items by resource-id", () => {
+      const hierarchy = createHierarchy({
+        "resource-id": "com.app:id/screen",
+        "node": {
+          "className": "androidx.recyclerview.widget.RecyclerView",
+          "scrollable": "true",
+          "resource-id": "com.app:id/list",
+          "node": [
+            { "text": "Item 1", "resource-id": "com.app:id/list_item" },
+            { "text": "Item 2", "resource-id": "com.app:id/list_item" },
+            { "text": "Item 3", "resource-id": "com.app:id/list_item" },
+          ],
+        },
+      });
+
+      const resultWithFilter = ScreenFingerprint.compute(hierarchy, {
+        filterDuplicates: true,
+      });
+
+      const resultWithoutFilter = ScreenFingerprint.compute(hierarchy, {
+        filterDuplicates: false,
+      });
+
+      // With filtering, should have fewer elements
+      expect(resultWithFilter.elementCount).toBeLessThan(
+        resultWithoutFilter.elementCount
+      );
+    });
+
+    test("should detect scrollable by scrollable attribute", () => {
+      const hierarchy = createHierarchy({
+        "resource-id": "com.app:id/screen",
+        "node": {
+          "scrollable": "true",
+          "resource-id": "com.app:id/list",
+          "node": [
+            { "text": "A", "resource-id": "com.app:id/item" },
+            { "text": "B", "resource-id": "com.app:id/item" },
+          ],
+        },
+      });
+
+      const resultWithFilter = ScreenFingerprint.compute(hierarchy, {
+        filterDuplicates: true,
+      });
+
+      const resultWithoutFilter = ScreenFingerprint.compute(hierarchy, {
+        filterDuplicates: false,
+      });
+
+      expect(resultWithFilter.elementCount).toBeLessThan(
+        resultWithoutFilter.elementCount
+      );
+    });
+
+    test("should detect RecyclerView by class name", () => {
+      const hierarchy = createHierarchy({
+        node: {
+          "className": "androidx.recyclerview.widget.RecyclerView",
+          "resource-id": "com.app:id/list",
+          "node": [
+            { "text": "X", "resource-id": "com.app:id/row" },
+            { "text": "Y", "resource-id": "com.app:id/row" },
+          ],
+        },
+      });
+
+      const resultWithFilter = ScreenFingerprint.compute(hierarchy, {
+        filterDuplicates: true,
+      });
+
+      const resultWithoutFilter = ScreenFingerprint.compute(hierarchy, {
+        filterDuplicates: false,
+      });
+
+      expect(resultWithFilter.elementCount).toBeLessThan(
+        resultWithoutFilter.elementCount
+      );
+    });
+
+    test("should detect ListView by class name", () => {
+      const hierarchy = createHierarchy({
+        node: {
+          className: "android.widget.ListView",
+          node: [
+            { "text": "P", "resource-id": "com.app:id/list_item" },
+            { "text": "Q", "resource-id": "com.app:id/list_item" },
+          ],
+        },
+      });
+
+      const resultWithFilter = ScreenFingerprint.compute(hierarchy);
+      const resultWithoutFilter = ScreenFingerprint.compute(hierarchy, {
+        filterDuplicates: false,
+      });
+
+      expect(resultWithFilter.elementCount).toBeLessThan(
+        resultWithoutFilter.elementCount
+      );
+    });
+
+    test("should detect LazyColumn by class name", () => {
+      const hierarchy = createHierarchy({
+        node: {
+          className: "androidx.compose.foundation.lazy.LazyColumn",
+          node: [
+            { "text": "R", "resource-id": "item" },
+            { "text": "S", "resource-id": "item" },
+          ],
+        },
+      });
+
+      const resultWithFilter = ScreenFingerprint.compute(hierarchy);
+      const resultWithoutFilter = ScreenFingerprint.compute(hierarchy, {
+        filterDuplicates: false,
+      });
+
+      expect(resultWithFilter.elementCount).toBeLessThan(
+        resultWithoutFilter.elementCount
+      );
+    });
+
+    test("should detect ScrollView by class name", () => {
+      const hierarchy = createHierarchy({
+        node: {
+          className: "android.widget.ScrollView",
+          node: [
+            { "resource-id": "com.app:id/section" },
+            { "resource-id": "com.app:id/section" },
+          ],
+        },
+      });
+
+      const resultWithFilter = ScreenFingerprint.compute(hierarchy);
+      const resultWithoutFilter = ScreenFingerprint.compute(hierarchy, {
+        filterDuplicates: false,
+      });
+
+      expect(resultWithFilter.elementCount).toBeLessThan(
+        resultWithoutFilter.elementCount
+      );
+    });
+
+    test("should keep first occurrence of each resource-id group", () => {
+      const hierarchy = createHierarchy({
+        node: {
+          scrollable: "true",
+          node: [
+            { "text": "First", "resource-id": "com.app:id/item" },
+            { "text": "Second", "resource-id": "com.app:id/item" },
+            { "text": "Third", "resource-id": "com.app:id/item" },
+          ],
+        },
+      });
+
+      // Without filtering, we get all texts and ids
+      const resultWithoutFilter = ScreenFingerprint.compute(hierarchy, {
+        filterDuplicates: false,
+      });
+
+      // With filtering, duplicates are removed
+      const resultWithFilter = ScreenFingerprint.compute(hierarchy);
+
+      // Filtering should reduce element count
+      expect(resultWithFilter.elementCount).toBeLessThan(
+        resultWithoutFilter.elementCount
+      );
+      // Should remove duplicates, keeping only first item's elements
+      expect(resultWithFilter.elementCount).toBe(1); // Only the first id:com.app:id/item
+    });
+
+    test("should not filter items outside scrollable containers", () => {
+      const hierarchy = createHierarchy({
+        node: [
+          { "text": "Static 1", "resource-id": "com.app:id/static" },
+          { "text": "Static 2", "resource-id": "com.app:id/static" },
+        ],
+      });
+
+      const resultWithFilter = ScreenFingerprint.compute(hierarchy);
+      const resultWithoutFilter = ScreenFingerprint.compute(hierarchy, {
+        filterDuplicates: false,
+      });
+
+      // Should be the same since items aren't in scrollable container
+      expect(resultWithFilter.elementCount).toBe(
+        resultWithoutFilter.elementCount
+      );
+    });
+
+    test("should handle nested scrollable containers", () => {
+      const hierarchy = createHierarchy({
+        node: {
+          "scrollable": "true",
+          "resource-id": "com.app:id/outer_list",
+          "node": [
+            {
+              "scrollable": "true",
+              "resource-id": "com.app:id/inner_list",
+              "node": [
+                { "text": "Inner 1", "resource-id": "com.app:id/inner_item" },
+                { "text": "Inner 2", "resource-id": "com.app:id/inner_item" },
+              ],
+            },
+          ],
+        },
+      });
+
+      const result = ScreenFingerprint.compute(hierarchy);
+
+      // Should have filtered duplicates in the inner list
+      expect(result.elementCount).toBeGreaterThan(0);
+    });
+  });
+
+  describe("options", () => {
+    test("should exclude resource-ids when includeResourceIds is false", () => {
+      const hierarchy = createHierarchy({
+        "resource-id": "com.app:id/title",
+      });
+
+      const resultWith = ScreenFingerprint.compute(hierarchy, {
+        includeResourceIds: true,
+      });
+      const resultWithout = ScreenFingerprint.compute(hierarchy, {
+        includeResourceIds: false,
+      });
+
+      expect(resultWith.elementCount).toBe(1);
+      expect(resultWithout.elementCount).toBe(0);
+    });
+
+    test("should exclude text when includeText is false", () => {
+      const hierarchy = createHierarchy({
+        text: "Hello",
+      });
+
+      const resultWith = ScreenFingerprint.compute(hierarchy, {
+        includeText: true,
+      });
+      const resultWithout = ScreenFingerprint.compute(hierarchy, {
+        includeText: false,
+      });
+
+      expect(resultWith.elementCount).toBe(1);
+      expect(resultWithout.elementCount).toBe(0);
+    });
+
+    test("should exclude content-desc when includeContentDesc is false", () => {
+      const hierarchy = createHierarchy({
+        "content-desc": "Description",
+      });
+
+      const resultWith = ScreenFingerprint.compute(hierarchy, {
+        includeContentDesc: true,
+      });
+      const resultWithout = ScreenFingerprint.compute(hierarchy, {
+        includeContentDesc: false,
+      });
+
+      expect(resultWith.elementCount).toBe(1);
+      expect(resultWithout.elementCount).toBe(0);
+    });
+
+    test("should exclude test-tag when includeTestTags is false", () => {
+      const hierarchy = createHierarchy({
+        "test-tag": "my_tag",
+      });
+
+      const resultWith = ScreenFingerprint.compute(hierarchy, {
+        includeTestTags: true,
+      });
+      const resultWithout = ScreenFingerprint.compute(hierarchy, {
+        includeTestTags: false,
+      });
+
+      expect(resultWith.elementCount).toBe(1);
+      expect(resultWithout.elementCount).toBe(0);
+    });
+  });
+
+  describe("element ordering", () => {
+    test("should produce same hash regardless of child order", () => {
+      const hierarchy1 = createHierarchy({
+        node: [
+          { "resource-id": "com.app:id/a" },
+          { "resource-id": "com.app:id/b" },
+          { "resource-id": "com.app:id/c" },
+        ],
+      });
+
+      const hierarchy2 = createHierarchy({
+        node: [
+          { "resource-id": "com.app:id/c" },
+          { "resource-id": "com.app:id/a" },
+          { "resource-id": "com.app:id/b" },
+        ],
+      });
+
+      const result1 = ScreenFingerprint.compute(hierarchy1);
+      const result2 = ScreenFingerprint.compute(hierarchy2);
+
+      // Hashes should be the same because elements are sorted
+      expect(result1.hash).toBe(result2.hash);
+    });
+  });
+});
+
+// Helper function to create AccessibilityHierarchy
+function createHierarchy(
+  hierarchy: Record<string, any>
+): AccessibilityHierarchy {
+  return {
+    updatedAt: 1234567890,
+    packageName: "com.test.app",
+    hierarchy,
+  };
+}


### PR DESCRIPTION
## Summary
- Add `ScreenFingerprint` class to compute SHA-256 hash from view hierarchy elements
- Add `HierarchyNavigationDetector` with debouncing (100ms) and stability timeout (5s)
- Filter duplicate list items from scrollable containers (RecyclerView, ListView, LazyColumn)
- Correlate detected navigation with recent tool calls within 2000ms window
- Integrate detector into `AccessibilityServiceClient` hierarchy_update handler

## Test plan
- [x] Run `bun test` - all 38 new tests pass
- [x] Run `bun run lint` - passes
- [x] Run `bun run build` - passes
- [x] Run hadolint validation - passes
- [x] Run act validation - passes

Closes #277

🤖 Generated with [Claude Code](https://claude.com/claude-code)