### PR TITLE
Enable npm Trusted Publisher in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,7 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  id-token: write
 
 jobs:
   build-and-release:
@@ -23,6 +24,14 @@ jobs:
         uses: oven-sh/setup-bun@v2
         with:
           bun-version: 1.3.5
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Ensure npm CLI is 11.5.1+
+        run: npm install -g npm@11.5.1
 
       - name: Set up Java
         uses: actions/setup-java@v4
@@ -150,9 +159,7 @@ jobs:
           echo "EOF" >> $GITHUB_OUTPUT
 
       - name: Publish to npm
-        run: bun publish
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish --provenance --access public
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v1

--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -5,8 +5,9 @@ This guide covers publishing `@kaeawc/auto-mobile` to npm.
 ## Prerequisites
 
 - npm account with access to the `@kaeawc` scope.
-- Logged in locally: `npm login` and `npm whoami`.
+- Logged in locally: `npm login` and `npm whoami` (local publishing only).
 - Clean working tree and an up-to-date build.
+- Trusted Publisher configured for GitHub Actions (`.github/workflows/release.yml`) for automated releases.
 
 ## Build and verify
 
@@ -31,6 +32,12 @@ This updates `package.json` and creates a git tag.
 
 ## Publish
 
+### GitHub Actions (Trusted Publisher)
+
+Publishing on tags uses GitHub Actions OIDC credentials. No npm token is required.
+
+### Local publish
+
 ```sh
 npm publish --access public
 ```
@@ -42,6 +49,7 @@ npm publish --access public
 - `prepublishOnly` temporarily rewrites `README.md` via `scripts/npm/transform-readme.js`.
 - `postpublish` restores `README.md` from the backup.
 - Release workflow updates `src/constants/release.ts` using `scripts/generate-release-constants.sh` with `RELEASE_VERSION` set.
+- Release workflow uses `npm publish --provenance` with npm CLI 11.5.1+.
 
 ## Troubleshooting
 


### PR DESCRIPTION
## Summary
- switch release workflow to npm Trusted Publisher OIDC and remove token usage
- enforce npm CLI 11.5.1+ and publish with provenance
- document Trusted Publisher vs local publish steps

## Testing
- ./scripts/act/validate_act.sh

## Issue
- Closes #275
