### PR TITLE
Update changelog workflow to use PAT

### DIFF
--- a/.github/workflows/update_changelog.yml
+++ b/.github/workflows/update_changelog.yml
@@ -24,6 +24,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          token: ${{ secrets.AUTO_MOBILE_PR_TOKEN }}
 
       - name: Resolve tag
         id: tag
@@ -37,7 +38,7 @@ jobs:
       - name: Update changelog
         env:
           CURRENT_TAG: ${{ steps.tag.outputs.current_tag }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.AUTO_MOBILE_PR_TOKEN }}
         run: scripts/changelog/update_changelog_from_issues.sh
 
       - name: Check for changes
@@ -52,13 +53,15 @@ jobs:
       - name: Create pull request
         if: steps.changes.outputs.has_changes == 'true'
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.AUTO_MOBILE_PR_TOKEN }}
         run: |
           BASE_BRANCH=$(gh repo view --json defaultBranchRef -q .defaultBranchRef.name)
           BRANCH="chore/update-changelog-${{ steps.tag.outputs.current_tag }}"
 
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          GH_LOGIN=$(gh api user -q '.login')
+          GH_ID=$(gh api user -q '.id')
+          git config user.name "$GH_LOGIN"
+          git config user.email "${GH_ID}+${GH_LOGIN}@users.noreply.github.com"
           git checkout -B "$BRANCH"
           git add CHANGELOG.md
           git commit -m "chore: update changelog for ${{ steps.tag.outputs.current_tag }}"


### PR DESCRIPTION
## Summary
- use AUTO_MOBILE_PR_TOKEN for checkout and gh auth in update_changelog
- set changelog commit author to the PAT owner
- allow changelog PRs to trigger CI workflows

## Testing
- not run (workflow change only)

Fixes #297
