### PR TITLE
ci: install ripgrep for bump versions

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -25,6 +25,13 @@ jobs:
         with:
           bun-version: 1.3.5
 
+      - name: Install ripgrep
+        run: |
+          if ! command -v rg >/dev/null 2>&1; then
+            sudo apt-get update
+            sudo apt-get install -y ripgrep
+          fi
+
       - name: Bump versions
         run: bash scripts/versioning/bump-versions.sh --new-version "${{ inputs.version }}"
 


### PR DESCRIPTION
## Summary
- install ripgrep in the Bump Versions workflow when missing
- unblock version bump runs on ubuntu-latest runners

## Testing
- not run (workflow-only change)

Fixes #296
