### PR TITLE
IDE plugin navigation graph rendering

### DIFF
--- a/android/ide-plugin/src/main/kotlin/com/automobile/ide/AutoMobileToolWindowContent.kt
+++ b/android/ide-plugin/src/main/kotlin/com/automobile/ide/AutoMobileToolWindowContent.kt
@@ -5,17 +5,25 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.weight
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
+import com.automobile.ide.graph.NavigationGraphLegend
+import com.automobile.ide.graph.NavigationGraphSummary
+import com.automobile.ide.graph.NavigationGraphView
+import com.automobile.ide.graph.RecentTransition
 import com.automobile.ide.daemon.McpClientFactory
 import com.automobile.ide.daemon.McpConnectionException
 import com.automobile.ide.daemon.McpDiscoverySnapshot
@@ -25,13 +33,23 @@ import com.automobile.ide.daemon.McpResourceTemplate
 import com.automobile.ide.daemon.McpServerOption
 import com.intellij.openapi.project.Project
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.decodeFromJsonElement
+import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.parseToJsonElement
 import org.jetbrains.jewel.intui.standalone.theme.IntUiTheme
 import org.jetbrains.jewel.ui.component.DefaultButton
 import org.jetbrains.jewel.ui.component.ListComboBox
 import org.jetbrains.jewel.ui.component.OutlinedButton
 import org.jetbrains.jewel.ui.component.Text
+import java.time.LocalTime
+import java.time.format.DateTimeFormatter
 
 @Composable
 fun AutoMobileToolWindowContent(project: Project) {
@@ -41,10 +59,16 @@ fun AutoMobileToolWindowContent(project: Project) {
   var selectedOptionId by remember { mutableStateOf<String?>(null) }
   var client by remember { mutableStateOf(McpClientFactory.createPreferred(null)) }
   var statusText by remember { mutableStateOf("Not connected") }
+  var isConnected by remember { mutableStateOf(false) }
   var lastError by remember { mutableStateOf<String?>(null) }
   var resources by remember { mutableStateOf<List<McpResource>>(emptyList()) }
   var templates by remember { mutableStateOf<List<McpResourceTemplate>>(emptyList()) }
-  var navGraphSnippet by remember { mutableStateOf<String?>(null) }
+  var graphSummary by remember { mutableStateOf<NavigationGraphSummary?>(null) }
+  var graphError by remember { mutableStateOf<String?>(null) }
+  var graphUpdatedAt by remember { mutableStateOf<String?>(null) }
+  var lastCurrentScreen by remember { mutableStateOf<String?>(null) }
+  val recentTransitions = remember { mutableStateListOf<RecentTransition>() }
+  val graphJson = remember { Json { ignoreUnknownKeys = true } }
 
   DisposableEffect(client) { onDispose { client.close() } }
 
@@ -82,6 +106,44 @@ fun AutoMobileToolWindowContent(project: Project) {
     return snapshot
   }
 
+  suspend fun fetchNavigationGraph() {
+    val contents = withContext(Dispatchers.IO) { client.readResource(NAV_GRAPH_RESOURCE_URI) }
+    val payload = contents.firstOrNull()?.text?.trim().orEmpty()
+    if (payload.isBlank()) {
+      graphError = "Navigation graph resource returned no data."
+      return
+    }
+
+    val jsonElement = graphJson.parseToJsonElement(payload)
+    if (jsonElement is JsonObject) {
+      val errorMessage = jsonElement["error"]?.jsonPrimitive?.contentOrNull
+      if (!errorMessage.isNullOrBlank()) {
+        graphError = errorMessage
+        return
+      }
+    }
+
+    val summary =
+        graphJson.decodeFromJsonElement(NavigationGraphSummary.serializer(), jsonElement)
+    graphSummary = summary
+    graphError = null
+    graphUpdatedAt = LocalTime.now().format(GRAPH_TIME_FORMATTER)
+
+    val updatedTransitions =
+        updateTransitionHistory(
+            lastCurrentScreen,
+            summary,
+            recentTransitions.toList(),
+        )
+    if (updatedTransitions.isNotEmpty()) {
+      recentTransitions.clear()
+      recentTransitions.addAll(updatedTransitions)
+    } else if (recentTransitions.isNotEmpty()) {
+      recentTransitions.clear()
+    }
+    lastCurrentScreen = summary.currentScreen
+  }
+
   val options = discoverySnapshot.options
   val selectedOption = options.firstOrNull { it.id == selectedOptionId }
   val selectedIndex = options.indexOfFirst { it.id == selectedOptionId }.takeIf { it >= 0 } ?: 0
@@ -89,6 +151,22 @@ fun AutoMobileToolWindowContent(project: Project) {
       if (options.isNotEmpty()) options.map { it.label } else listOf("No worktrees detected")
 
   androidx.compose.runtime.LaunchedEffect(Unit) { refreshDiscovery() }
+  androidx.compose.runtime.LaunchedEffect(client, isConnected) {
+    if (!isConnected) {
+      return@LaunchedEffect
+    }
+
+    while (isActive) {
+      try {
+        fetchNavigationGraph()
+      } catch (e: McpConnectionException) {
+        graphError = e.message
+      } catch (e: Exception) {
+        graphError = e.message
+      }
+      delay(GRAPH_POLL_INTERVAL_MS)
+    }
+  }
 
   IntUiTheme {
     Column(
@@ -108,7 +186,16 @@ fun AutoMobileToolWindowContent(project: Project) {
         ListComboBox(
             optionLabels,
             selectedIndex,
-            { index -> selectedOptionId = options.getOrNull(index)?.id },
+            { index ->
+              selectedOptionId = options.getOrNull(index)?.id
+              statusText = "Not connected"
+              isConnected = false
+              graphSummary = null
+              graphError = null
+              graphUpdatedAt = null
+              lastCurrentScreen = null
+              recentTransitions.clear()
+            },
         )
         Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
           OutlinedButton(onClick = { scope.launch { refreshDiscovery() } }) {
@@ -126,7 +213,11 @@ fun AutoMobileToolWindowContent(project: Project) {
               scope.launch {
                 statusText = "Connecting..."
                 lastError = null
-                navGraphSnippet = null
+                graphSummary = null
+                graphError = null
+                graphUpdatedAt = null
+                lastCurrentScreen = null
+                recentTransitions.clear()
                 try {
                   val snapshot = refreshDiscovery()
                   val resolvedId = resolveSelectionId(snapshot.options)
@@ -140,9 +231,18 @@ fun AutoMobileToolWindowContent(project: Project) {
                     templates = nextClient.listResourceTemplates()
                   }
                   statusText = "Connected"
+                  isConnected = true
                 } catch (e: McpConnectionException) {
                   statusText = "Not connected"
+                  isConnected = false
                   lastError = e.message
+                }
+                if (isConnected) {
+                  try {
+                    fetchNavigationGraph()
+                  } catch (e: Exception) {
+                    graphError = e.message
+                  }
                 }
               }
             }
@@ -179,33 +279,75 @@ fun AutoMobileToolWindowContent(project: Project) {
         }
       }
 
-      Spacer(modifier = Modifier.height(12.dp))
+      Spacer(modifier = Modifier.height(8.dp))
       Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
         DefaultButton(
-            onClick = {
-              scope.launch {
-                lastError = null
-                try {
-                  val result = withContext(Dispatchers.IO) { client.getNavigationGraph() }
-                  navGraphSnippet = result.toString().take(500)
-                } catch (e: McpConnectionException) {
-                  lastError = e.message
-                }
-              }
-            }
+            onClick = { scope.launch { lastError = "Feature flags are not wired yet" } }
         ) {
-          Text("Import Graph")
+          Text("Toggle Perf Debug")
         }
-        OutlinedButton(onClick = { scope.launch { lastError = "Export not wired yet" } }) {
-          Text("Export Graph")
+        OutlinedButton(
+            onClick = { scope.launch { lastError = "Feature flags are not wired yet" } }
+        ) {
+          Text("Toggle Traces")
         }
       }
 
-      if (navGraphSnippet != null) {
-        Spacer(modifier = Modifier.height(8.dp))
-        Text("Navigation Graph (preview):")
-        Text(navGraphSnippet ?: "")
+      Spacer(modifier = Modifier.height(12.dp))
+      Column(verticalArrangement = Arrangement.spacedBy(6.dp)) {
+        Row(
+            horizontalArrangement = Arrangement.spacedBy(12.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+          Text("Navigation Graph")
+          if (graphUpdatedAt != null) {
+            Text("Updated $graphUpdatedAt")
+          }
+          Text("Auto-refresh 1s")
+        }
+        Text(
+            "Nodes: ${graphSummary?.nodes?.size ?: 0} | " +
+                "Edges: ${graphSummary?.edges?.size ?: 0} | " +
+                "Current: ${graphSummary?.currentScreen ?: "-"}"
+        )
+        NavigationGraphLegend(modifier = Modifier.fillMaxWidth())
       }
+      NavigationGraphView(
+          summary = graphSummary,
+          recentTransitions = recentTransitions.toList(),
+          errorMessage = graphError,
+          modifier = Modifier.fillMaxWidth().weight(1f),
+      )
     }
   }
+}
+
+private const val NAV_GRAPH_RESOURCE_URI = "automobile://navigation/graph"
+private const val GRAPH_POLL_INTERVAL_MS = 1000L
+private const val MAX_RECENT_TRANSITIONS = 10
+private val GRAPH_TIME_FORMATTER: DateTimeFormatter = DateTimeFormatter.ofPattern("HH:mm:ss")
+
+private fun updateTransitionHistory(
+    previousScreen: String?,
+    summary: NavigationGraphSummary,
+    existing: List<RecentTransition>,
+): List<RecentTransition> {
+  val currentScreen = summary.currentScreen
+  if (previousScreen.isNullOrBlank() || currentScreen.isNullOrBlank()) {
+    return existing
+  }
+  if (previousScreen == currentScreen) {
+    return existing
+  }
+
+  val matchingEdge =
+      summary.edges.firstOrNull { it.from == previousScreen && it.to == currentScreen }
+  val updated =
+      existing +
+          RecentTransition(
+              from = previousScreen,
+              to = currentScreen,
+              edgeId = matchingEdge?.id,
+          )
+  return updated.takeLast(MAX_RECENT_TRANSITIONS)
 }

--- a/android/ide-plugin/src/main/kotlin/com/automobile/ide/graph/NavigationGraphLayout.kt
+++ b/android/ide-plugin/src/main/kotlin/com/automobile/ide/graph/NavigationGraphLayout.kt
@@ -1,0 +1,143 @@
+package com.automobile.ide.graph
+
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.unit.IntSize
+import kotlin.math.PI
+import kotlin.math.cos
+import kotlin.math.max
+import kotlin.math.min
+import kotlin.math.sin
+
+data class NodeLayout(
+    val node: NavigationGraphSummaryNode,
+    val center: Offset,
+    val radius: Float,
+    val ring: Int,
+)
+
+data class GraphLayout(
+    val nodeLayouts: Map<String, NodeLayout>,
+    val size: IntSize,
+)
+
+fun computeGraphLayout(
+    summary: NavigationGraphSummary,
+    size: IntSize,
+    baseRadiusPx: Float,
+    paddingPx: Float,
+): GraphLayout {
+  if (summary.nodes.isEmpty() || size.width <= 0 || size.height <= 0) {
+    return GraphLayout(emptyMap(), size)
+  }
+
+  val adjacency = buildAdjacency(summary)
+  val root = summary.currentScreen?.takeIf { adjacency.containsKey(it) }
+      ?: summary.nodes.first().screenName
+  val distances = computeDistances(adjacency, root)
+
+  val maxDistance = distances.values.maxOrNull() ?: 0
+  val unreachableDistance = maxDistance + 1
+  summary.nodes.forEach { node ->
+    distances.putIfAbsent(node.screenName, unreachableDistance)
+  }
+
+  val maxRing = distances.values.maxOrNull() ?: 0
+  val center = Offset(size.width.toFloat() / 2f, size.height.toFloat() / 2f)
+  val maxRadius =
+      min(size.width, size.height).toFloat() / 2f - paddingPx - baseRadiusPx
+  val safeMaxRadius = max(0f, maxRadius)
+  val ringSpacing = if (maxRing <= 0) 0f else safeMaxRadius / (maxRing + 1)
+
+  val (minVisit, maxVisit) = visitCountRange(summary.nodes)
+  val extraRadius = baseRadiusPx * 0.6f
+
+  val nodesByRing = summary.nodes.groupBy { distances[it.screenName] ?: 0 }
+  val layouts = mutableMapOf<String, NodeLayout>()
+
+  for ((ring, nodes) in nodesByRing) {
+    val sorted = nodes.sortedBy { it.screenName }
+    if (ring == 0) {
+      val node = sorted.first()
+      layouts[node.screenName] =
+          NodeLayout(
+              node = node,
+              center = center,
+              radius = nodeRadius(node.visitCount, minVisit, maxVisit, baseRadiusPx, extraRadius),
+              ring = ring,
+          )
+      continue
+    }
+
+    val ringRadius = ringSpacing * ring
+    val count = sorted.size
+    val angleOffset = ring * 0.35
+
+    sorted.forEachIndexed { index, node ->
+      val angle = 2 * PI * index / count + angleOffset
+      val x = center.x + ringRadius * cos(angle).toFloat()
+      val y = center.y + ringRadius * sin(angle).toFloat()
+      layouts[node.screenName] =
+          NodeLayout(
+              node = node,
+              center = Offset(x, y),
+              radius = nodeRadius(node.visitCount, minVisit, maxVisit, baseRadiusPx, extraRadius),
+              ring = ring,
+          )
+    }
+  }
+
+  return GraphLayout(layouts, size)
+}
+
+private fun buildAdjacency(summary: NavigationGraphSummary): Map<String, MutableSet<String>> {
+  val adjacency = summary.nodes.associate { it.screenName to mutableSetOf<String>() }
+  summary.edges.forEach { edge ->
+    adjacency[edge.from]?.add(edge.to)
+    adjacency[edge.to]?.add(edge.from)
+  }
+  return adjacency
+}
+
+private fun computeDistances(
+    adjacency: Map<String, MutableSet<String>>,
+    root: String,
+): MutableMap<String, Int> {
+  val distances = mutableMapOf<String, Int>()
+  val queue = ArrayDeque<String>()
+  distances[root] = 0
+  queue.add(root)
+
+  while (queue.isNotEmpty()) {
+    val current = queue.removeFirst()
+    val currentDistance = distances[current] ?: 0
+    val neighbors = adjacency[current] ?: emptySet()
+    for (neighbor in neighbors) {
+      if (neighbor !in distances) {
+        distances[neighbor] = currentDistance + 1
+        queue.add(neighbor)
+      }
+    }
+  }
+
+  return distances
+}
+
+private fun visitCountRange(nodes: List<NavigationGraphSummaryNode>): Pair<Int, Int> {
+  val minVisit = nodes.minOfOrNull { it.visitCount } ?: 0
+  val maxVisit = nodes.maxOfOrNull { it.visitCount } ?: 0
+  return Pair(minVisit, maxVisit)
+}
+
+private fun nodeRadius(
+    visitCount: Int,
+    minVisit: Int,
+    maxVisit: Int,
+    baseRadius: Float,
+    extraRadius: Float,
+): Float {
+  if (maxVisit <= minVisit) {
+    return baseRadius
+  }
+  val normalized = (visitCount - minVisit).toFloat() / (maxVisit - minVisit).toFloat()
+  return baseRadius + extraRadius * normalized
+}

--- a/android/ide-plugin/src/main/kotlin/com/automobile/ide/graph/NavigationGraphModels.kt
+++ b/android/ide-plugin/src/main/kotlin/com/automobile/ide/graph/NavigationGraphModels.kt
@@ -1,0 +1,33 @@
+package com.automobile.ide.graph
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class NavigationGraphSummary(
+    val appId: String? = null,
+    val currentScreen: String? = null,
+    val nodes: List<NavigationGraphSummaryNode> = emptyList(),
+    val edges: List<NavigationGraphSummaryEdge> = emptyList(),
+)
+
+@Serializable
+data class NavigationGraphSummaryNode(
+    val id: Int,
+    val screenName: String,
+    val visitCount: Int,
+)
+
+@Serializable
+data class NavigationGraphSummaryEdge(
+    val id: Int,
+    val from: String,
+    val to: String,
+    val toolName: String? = null,
+)
+
+data class RecentTransition(
+    val from: String,
+    val to: String,
+    val edgeId: Int? = null,
+    val timestampMs: Long = System.currentTimeMillis(),
+)

--- a/android/ide-plugin/src/main/kotlin/com/automobile/ide/graph/NavigationGraphView.kt
+++ b/android/ide-plugin/src/main/kotlin/com/automobile/ide/graph/NavigationGraphView.kt
@@ -1,0 +1,381 @@
+package com.automobile.ide.graph
+
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.PathEffect
+import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.graphics.lerp
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.unit.IntSize
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import org.jetbrains.jewel.foundation.theme.JewelTheme
+import org.jetbrains.jewel.ui.component.Text
+import kotlin.math.atan2
+import kotlin.math.cos
+import kotlin.math.roundToInt
+import kotlin.math.sin
+import kotlin.math.sqrt
+
+@Composable
+fun NavigationGraphView(
+    summary: NavigationGraphSummary?,
+    recentTransitions: List<RecentTransition>,
+    modifier: Modifier = Modifier,
+    errorMessage: String? = null,
+) {
+  val palette = rememberGraphPalette()
+  val shape = RoundedCornerShape(12.dp)
+
+  Box(
+      modifier =
+          modifier
+              .background(palette.background, shape)
+              .border(1.dp, palette.border, shape)
+              .padding(8.dp)
+  ) {
+    if (summary == null || summary.nodes.isEmpty()) {
+      Text(
+          text = "No navigation graph data yet.",
+          color = palette.labelMuted,
+          fontSize = 12.sp,
+          modifier = Modifier.align(Alignment.CenterStart).padding(8.dp),
+      )
+    } else {
+      GraphCanvas(summary, recentTransitions, palette, Modifier.fillMaxSize())
+    }
+
+    if (!errorMessage.isNullOrBlank()) {
+      Text(
+          text = errorMessage,
+          color = palette.error,
+          fontSize = 11.sp,
+          maxLines = 2,
+          overflow = TextOverflow.Ellipsis,
+          modifier = Modifier.align(Alignment.BottomStart).padding(6.dp),
+      )
+    }
+  }
+}
+
+@Composable
+fun NavigationGraphLegend(modifier: Modifier = Modifier) {
+  val palette = rememberGraphPalette()
+  Row(modifier = modifier, verticalAlignment = Alignment.CenterVertically) {
+    LegendItem(palette, color = palette.nodeCurrentStroke, label = "Current screen")
+    LegendSpacer()
+    LegendItem(palette, color = palette.edgeHistory, label = "Recent transitions")
+    LegendSpacer()
+    LegendItem(palette, color = palette.edgeDefault, label = "Other edges")
+  }
+}
+
+@Composable
+private fun LegendItem(palette: GraphPalette, color: Color, label: String) {
+  Row(verticalAlignment = Alignment.CenterVertically) {
+    Box(
+        modifier =
+            Modifier
+                .size(10.dp)
+                .background(color, CircleShape)
+    )
+    Text(
+        text = label,
+        color = palette.labelMuted,
+        fontSize = 11.sp,
+        modifier = Modifier.padding(start = 6.dp, end = 8.dp),
+    )
+  }
+}
+
+@Composable
+private fun LegendSpacer() {
+  Box(modifier = Modifier.size(6.dp))
+}
+
+@Composable
+private fun GraphCanvas(
+    summary: NavigationGraphSummary,
+    recentTransitions: List<RecentTransition>,
+    palette: GraphPalette,
+    modifier: Modifier = Modifier,
+) {
+  BoxWithConstraints(modifier = modifier) {
+    val density = LocalDensity.current
+    val size =
+        with(density) {
+          IntSize(maxWidth.roundToPx(), maxHeight.roundToPx())
+        }
+    val baseRadiusPx = with(density) { 16.dp.toPx() }
+    val paddingPx = with(density) { 32.dp.toPx() }
+    val layout =
+        remember(summary, size) {
+          computeGraphLayout(
+              summary,
+              size,
+              baseRadiusPx = baseRadiusPx,
+              paddingPx = paddingPx,
+          )
+        }
+
+    val historyById =
+        remember(recentTransitions) {
+          val ranks = mutableMapOf<Int, Int>()
+          recentTransitions.forEachIndexed { index, transition ->
+            transition.edgeId?.let { edgeId -> ranks[edgeId] = index }
+          }
+          ranks
+        }
+    val historyByEdge =
+        remember(recentTransitions) {
+          val ranks = mutableMapOf<ScreenEdgeKey, Int>()
+          recentTransitions.forEachIndexed { index, transition ->
+            ranks[ScreenEdgeKey(transition.from, transition.to)] = index
+          }
+          ranks
+        }
+    val historyNodes =
+        remember(recentTransitions) {
+          recentTransitions.flatMap { listOf(it.from, it.to) }.toSet()
+        }
+
+    Canvas(modifier = Modifier.fillMaxSize()) {
+      drawEdges(summary, layout, palette, historyById, historyByEdge, recentTransitions.size)
+      drawNodes(summary, layout, palette, historyNodes)
+    }
+
+    if (layout.nodeLayouts.isNotEmpty()) {
+      val labelMaxWidthPx = with(density) { 140.dp.toPx() }
+      val labelHeightPx = with(density) { 16.dp.toPx() }
+      layout.nodeLayouts.values.forEach { nodeLayout ->
+        val label =
+            if (nodeLayout.node.visitCount > 1) {
+              "${nodeLayout.node.screenName} (${nodeLayout.node.visitCount})"
+            } else {
+              nodeLayout.node.screenName
+            }
+        val isCurrent = nodeLayout.node.screenName == summary.currentScreen
+        val isHistory = historyNodes.contains(nodeLayout.node.screenName)
+        val labelColor =
+            when {
+              isCurrent -> palette.nodeCurrentStroke
+              isHistory -> palette.edgeHistory
+              else -> palette.label
+            }
+
+        val widthPx = size.width.toFloat()
+        val heightPx = size.height.toFloat()
+        val placeLeft = nodeLayout.center.x > widthPx * 0.6f
+        val rawX =
+            if (placeLeft) {
+              nodeLayout.center.x - nodeLayout.radius - 8f - labelMaxWidthPx
+            } else {
+              nodeLayout.center.x + nodeLayout.radius + 8f
+            }
+        val maxX = (widthPx - labelMaxWidthPx - 4f).coerceAtLeast(4f)
+        val maxY = (heightPx - labelHeightPx - 4f).coerceAtLeast(4f)
+        val x = rawX.coerceIn(4f, maxX)
+        val y =
+            (nodeLayout.center.y - nodeLayout.radius - 6f)
+                .coerceIn(4f, maxY)
+
+        Text(
+            text = label,
+            color = labelColor,
+            fontSize = 11.sp,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+            modifier =
+                Modifier
+                    .offset { IntOffset(x.roundToInt(), y.roundToInt()) }
+                    .widthIn(max = 140.dp),
+        )
+      }
+    }
+  }
+}
+
+private fun androidx.compose.ui.graphics.drawscope.DrawScope.drawEdges(
+    summary: NavigationGraphSummary,
+    layout: GraphLayout,
+    palette: GraphPalette,
+    historyById: Map<Int, Int>,
+    historyByEdge: Map<ScreenEdgeKey, Int>,
+    historySize: Int,
+) {
+  if (layout.nodeLayouts.isEmpty()) {
+    return
+  }
+
+  summary.edges.forEach { edge ->
+    val from = layout.nodeLayouts[edge.from] ?: return@forEach
+    val to = layout.nodeLayouts[edge.to] ?: return@forEach
+    val recencyIndex =
+        historyById[edge.id] ?: historyByEdge[ScreenEdgeKey(edge.from, edge.to)]
+    val recencyRatio =
+        if (recencyIndex != null && historySize > 0) {
+          (recencyIndex + 1).toFloat() / historySize.toFloat()
+        } else {
+          null
+        }
+
+    val color =
+        if (recencyRatio != null) {
+          lerp(palette.edgeDefault, palette.edgeHistory, 0.35f + 0.65f * recencyRatio)
+        } else {
+          palette.edgeDefault
+        }
+    val strokeWidth = if (recencyRatio != null) 2.5f + 3f * recencyRatio else 1.2f
+    val dash =
+        if (recencyRatio == null && edge.toolName == null) {
+          PathEffect.dashPathEffect(floatArrayOf(8f, 6f), 0f)
+        } else {
+          null
+        }
+
+    val (start, end) = trimLine(from.center, to.center, from.radius, to.radius)
+    drawLine(color = color, start = start, end = end, strokeWidth = strokeWidth, pathEffect = dash)
+
+    if (recencyRatio != null) {
+      drawArrow(end, start, color, strokeWidth)
+    }
+  }
+}
+
+private fun androidx.compose.ui.graphics.drawscope.DrawScope.drawNodes(
+    summary: NavigationGraphSummary,
+    layout: GraphLayout,
+    palette: GraphPalette,
+    historyNodes: Set<String>,
+) {
+  layout.nodeLayouts.values.forEach { nodeLayout ->
+    val isCurrent = nodeLayout.node.screenName == summary.currentScreen
+    val isHistory = historyNodes.contains(nodeLayout.node.screenName)
+    val fill =
+        when {
+          isCurrent -> palette.nodeCurrentFill
+          isHistory -> palette.nodeHistoryFill
+          else -> palette.nodeFill
+        }
+    val stroke =
+        when {
+          isCurrent -> palette.nodeCurrentStroke
+          isHistory -> palette.edgeHistory
+          else -> palette.nodeStroke
+        }
+
+    drawCircle(color = fill, radius = nodeLayout.radius, center = nodeLayout.center)
+    drawCircle(
+        color = stroke,
+        radius = nodeLayout.radius,
+        center = nodeLayout.center,
+        style = Stroke(width = 1.4f),
+    )
+
+    if (isCurrent) {
+      drawCircle(
+          color = palette.nodeCurrentStroke.copy(alpha = 0.4f),
+          radius = nodeLayout.radius + 6f,
+          center = nodeLayout.center,
+          style = Stroke(width = 1.6f),
+      )
+    }
+  }
+}
+
+private fun trimLine(
+    from: Offset,
+    to: Offset,
+    fromRadius: Float,
+    toRadius: Float,
+): Pair<Offset, Offset> {
+  val dx = to.x - from.x
+  val dy = to.y - from.y
+  val distance = sqrt(dx * dx + dy * dy)
+  if (distance <= fromRadius + toRadius + 1f) {
+    return Pair(from, to)
+  }
+  val ux = dx / distance
+  val uy = dy / distance
+  val start = Offset(from.x + ux * fromRadius, from.y + uy * fromRadius)
+  val end = Offset(to.x - ux * toRadius, to.y - uy * toRadius)
+  return Pair(start, end)
+}
+
+private fun androidx.compose.ui.graphics.drawscope.DrawScope.drawArrow(
+    tip: Offset,
+    tail: Offset,
+    color: Color,
+    strokeWidth: Float,
+) {
+  val dx = tip.x - tail.x
+  val dy = tip.y - tail.y
+  val angle = atan2(dy, dx)
+  val arrowSize = 10f + strokeWidth
+  val angleOffset = 0.45f
+  val x1 = tip.x - arrowSize * cos(angle - angleOffset)
+  val y1 = tip.y - arrowSize * sin(angle - angleOffset)
+  val x2 = tip.x - arrowSize * cos(angle + angleOffset)
+  val y2 = tip.y - arrowSize * sin(angle + angleOffset)
+  drawLine(color = color, start = tip, end = Offset(x1, y1), strokeWidth = strokeWidth)
+  drawLine(color = color, start = tip, end = Offset(x2, y2), strokeWidth = strokeWidth)
+}
+
+private data class ScreenEdgeKey(val from: String, val to: String)
+
+private data class GraphPalette(
+    val background: Color,
+    val border: Color,
+    val edgeDefault: Color,
+    val edgeHistory: Color,
+    val nodeFill: Color,
+    val nodeStroke: Color,
+    val nodeCurrentFill: Color,
+    val nodeCurrentStroke: Color,
+    val nodeHistoryFill: Color,
+    val label: Color,
+    val labelMuted: Color,
+    val error: Color,
+)
+
+@Composable
+private fun rememberGraphPalette(): GraphPalette {
+  val globals = JewelTheme.globalColors
+  val baseText = globals.text.normal
+  val info = globals.text.info
+  val warning = globals.text.warning
+  val error = globals.text.error
+  return GraphPalette(
+      background = globals.panelBackground,
+      border = globals.outlines.focused.copy(alpha = 0.4f),
+      edgeDefault = baseText.copy(alpha = 0.25f),
+      edgeHistory = warning.copy(alpha = 0.9f),
+      nodeFill = baseText.copy(alpha = 0.08f),
+      nodeStroke = baseText.copy(alpha = 0.45f),
+      nodeCurrentFill = info.copy(alpha = 0.2f),
+      nodeCurrentStroke = info,
+      nodeHistoryFill = warning.copy(alpha = 0.2f),
+      label = baseText.copy(alpha = 0.9f),
+      labelMuted = baseText.copy(alpha = 0.65f),
+      error = error,
+  )
+}

--- a/docs/features/mcp-server/resources.md
+++ b/docs/features/mcp-server/resources.md
@@ -176,6 +176,48 @@ console.log("Graph nodes:", graph.nodes.length);
 console.log("Graph edges:", graph.edges.length);
 ```
 
+### Navigation History
+
+**URI:** `automobile://navigation/history`
+
+**URI Templates:**
+- `automobile://navigation/history?cursor={cursor}`
+- `automobile://navigation/history?limit={limit}`
+- `automobile://navigation/history?cursor={cursor}&limit={limit}`
+
+**Type:** JSON (text)
+
+**Description:** Ordered navigation history for the current app, suitable for playback. Use `nextCursor` to page through older transitions. The cursor is opaque and should be passed back exactly as returned.
+
+**Contents:**
+- `appId`: Current application package ID (or null if unset)
+- `currentScreen`: Most recently observed screen name
+- `cursor`: Cursor used for this page (or null for the first page)
+- `nextCursor`: Cursor for the next page (or null if no more history)
+- `nodes`: Ordered list of `{ id, screenName, timestamp, edgeId? }`
+- `edges`: Ordered list of `{ id, from, to, toolName, timestamp }`
+
+**Example Usage:**
+
+```typescript
+// Read navigation history with pagination
+let cursor: string | null = null;
+
+do {
+  const uri = cursor
+    ? `automobile://navigation/history?cursor=${encodeURIComponent(cursor)}&limit=50`
+    : "automobile://navigation/history?limit=50";
+  const response = await client.request({
+    method: "resources/read",
+    params: { uri }
+  });
+
+  const history = JSON.parse(response.contents[0].text);
+  console.log("Edges in page:", history.edges.length);
+  cursor = history.nextCursor;
+} while (cursor);
+```
+
 ### Navigation Graph Nodes
 
 **URI Templates:**

--- a/src/db/navigationRepository.ts
+++ b/src/db/navigationRepository.ts
@@ -190,6 +190,26 @@ export class NavigationRepository {
   }
 
   /**
+   * Get nodes by screen name.
+   */
+  async getNodesByScreenNames(
+    appId: string,
+    screenNames: string[]
+  ): Promise<NavigationNode[]> {
+    if (screenNames.length === 0) {
+      return [];
+    }
+
+    const db = getDatabase();
+    return db
+      .selectFrom("navigation_nodes")
+      .selectAll()
+      .where("app_id", "=", appId)
+      .where("screen_name", "in", screenNames)
+      .execute();
+  }
+
+  /**
    * Create a navigation edge.
    */
   async createEdge(
@@ -236,6 +256,46 @@ export class NavigationRepository {
       .where("app_id", "=", appId)
       .orderBy("timestamp", "asc")
       .execute();
+  }
+
+  /**
+   * Get edges for an app with pagination support.
+   */
+  async getEdgesPage(
+    appId: string,
+    options: {
+      cursor?: { timestamp: number; id: number } | null;
+      limit: number;
+    }
+  ): Promise<{ edges: NavigationEdge[]; hasMore: boolean }> {
+    const db = getDatabase();
+    let query = db
+      .selectFrom("navigation_edges")
+      .selectAll()
+      .where("app_id", "=", appId);
+
+    if (options.cursor) {
+      query = query.where(({ eb, or, and }) =>
+        or([
+          eb("timestamp", ">", options.cursor!.timestamp),
+          and([
+            eb("timestamp", "=", options.cursor!.timestamp),
+            eb("id", ">", options.cursor!.id),
+          ]),
+        ])
+      );
+    }
+
+    const rows = await query
+      .orderBy("timestamp", "asc")
+      .orderBy("id", "asc")
+      .limit(options.limit + 1)
+      .execute();
+
+    const hasMore = rows.length > options.limit;
+    const edges = hasMore ? rows.slice(0, options.limit) : rows;
+
+    return { edges, hasMore };
   }
 
   /**

--- a/src/features/navigation/NavigationGraphManager.ts
+++ b/src/features/navigation/NavigationGraphManager.ts
@@ -16,6 +16,10 @@ import {
   NavigationGraphSummaryEdge,
   NavigationGraphSummaryNode,
   NavigationGraphSummaryProvider,
+  NavigationGraphHistoryEdge,
+  NavigationGraphHistoryNode,
+  NavigationGraphHistoryPage,
+  NavigationGraphHistoryProvider,
   NavigationGraphNodeDetail,
   NavigationGraphNodeResource,
   NavigationGraphNodeResourceProvider,
@@ -39,17 +43,26 @@ export type {
   NavigationGraphSummaryEdge,
   NavigationGraphSummaryNode,
   NavigationGraphSummaryProvider,
+  NavigationGraphHistoryEdge,
+  NavigationGraphHistoryNode,
+  NavigationGraphHistoryPage,
+  NavigationGraphHistoryProvider,
   NavigationGraphNodeDetail,
   NavigationGraphNodeResource,
   NavigationGraphNodeResourceProvider,
   UIState,
 };
 
+type HistoryCursor = {
+  timestamp: number;
+  id: number;
+};
+
 /**
  * Manages the navigation graph with SQLite persistence.
  * Tracks screen visits and correlates navigation events with tool calls.
  */
-export class NavigationGraphManager implements NavigationGraph, NavigationGraphSummaryProvider, NavigationGraphNodeResourceProvider {
+export class NavigationGraphManager implements NavigationGraph, NavigationGraphSummaryProvider, NavigationGraphHistoryProvider, NavigationGraphNodeResourceProvider {
   private static instance: NavigationGraphManager | null = null;
 
   private repository: NavigationRepository;
@@ -59,6 +72,9 @@ export class NavigationGraphManager implements NavigationGraph, NavigationGraphS
 
   // Tool call history kept in memory for correlation (transient data)
   private toolCallHistory: ToolCallInteraction[] = [];
+
+  private readonly HISTORY_PAGE_DEFAULT = 50;
+  private readonly HISTORY_PAGE_MAX = 200;
 
   // Correlation window: tool call must occur 0-2000ms before navigation event
   private readonly TOOL_CALL_CORRELATION_WINDOW_MS = 2000;
@@ -942,6 +958,102 @@ export class NavigationGraphManager implements NavigationGraph, NavigationGraphS
   }
 
   /**
+   * Export a paginated navigation history for MCP resources.
+   */
+  public async exportGraphHistory(options: {
+    cursor?: string;
+    limit?: number;
+  } = {}): Promise<NavigationGraphHistoryPage> {
+    if (!this.currentAppId) {
+      return {
+        appId: null,
+        currentScreen: null,
+        cursor: options.cursor ?? null,
+        nextCursor: null,
+        nodes: [],
+        edges: [],
+      };
+    }
+
+    const limit = this.normalizeHistoryLimit(options.limit);
+    const cursor = options.cursor ? this.parseHistoryCursor(options.cursor) : null;
+
+    const { edges: dbEdges, hasMore } = await this.repository.getEdgesPage(
+      this.currentAppId,
+      {
+        cursor,
+        limit,
+      }
+    );
+
+    const historyEdges: NavigationGraphHistoryEdge[] = dbEdges.map(edge => ({
+      id: edge.id,
+      from: edge.from_screen,
+      to: edge.to_screen,
+      toolName: edge.tool_name,
+      timestamp: edge.timestamp,
+    }));
+
+    const nodeNames = new Set<string>();
+    if (dbEdges.length > 0) {
+      nodeNames.add(dbEdges[0].from_screen);
+      dbEdges.forEach(edge => nodeNames.add(edge.to_screen));
+    }
+
+    const nodeIdMap = new Map<string, number>();
+    if (nodeNames.size > 0) {
+      const dbNodes = await this.repository.getNodesByScreenNames(
+        this.currentAppId,
+        Array.from(nodeNames)
+      );
+      dbNodes.forEach(node => {
+        nodeIdMap.set(node.screen_name, node.id);
+      });
+    }
+
+    const historyNodes: NavigationGraphHistoryNode[] = [];
+    if (dbEdges.length > 0) {
+      const firstEdge = dbEdges[0];
+      historyNodes.push({
+        id: nodeIdMap.get(firstEdge.from_screen) ?? null,
+        screenName: firstEdge.from_screen,
+        timestamp: firstEdge.timestamp,
+        edgeId: null,
+      });
+      dbEdges.forEach(edge => {
+        historyNodes.push({
+          id: nodeIdMap.get(edge.to_screen) ?? null,
+          screenName: edge.to_screen,
+          timestamp: edge.timestamp,
+          edgeId: edge.id,
+        });
+      });
+    } else if (this.currentScreen) {
+      const node = await this.repository.getNode(this.currentAppId, this.currentScreen);
+      if (node) {
+        historyNodes.push({
+          id: node.id,
+          screenName: node.screen_name,
+          timestamp: node.last_seen_at,
+          edgeId: null,
+        });
+      }
+    }
+
+    const nextCursor =
+      hasMore && dbEdges.length > 0 ? this.encodeHistoryCursor(dbEdges[dbEdges.length - 1]) : null;
+
+    return {
+      appId: this.currentAppId,
+      currentScreen: this.currentScreen,
+      cursor: options.cursor ?? null,
+      nextCursor,
+      nodes: historyNodes,
+      edges: historyEdges,
+    };
+  }
+
+  /**
    * Register a listener for graph update notifications.
    */
   public setGraphUpdateListener(listener: (() => void) | null): void {
@@ -952,5 +1064,30 @@ export class NavigationGraphManager implements NavigationGraph, NavigationGraphS
     if (this.graphUpdateListener) {
       this.graphUpdateListener();
     }
+  }
+
+  private parseHistoryCursor(cursor: string): HistoryCursor {
+    const [timestampRaw, idRaw] = cursor.split(":");
+    const timestamp = Number(timestampRaw);
+    const id = Number(idRaw);
+    if (!Number.isFinite(timestamp) || !Number.isFinite(id)) {
+      throw new Error(`Invalid history cursor: ${cursor}`);
+    }
+    return { timestamp, id };
+  }
+
+  private encodeHistoryCursor(edge: DBNavigationEdge): string {
+    return `${edge.timestamp}:${edge.id}`;
+  }
+
+  private normalizeHistoryLimit(limit?: number): number {
+    if (!limit || !Number.isFinite(limit)) {
+      return this.HISTORY_PAGE_DEFAULT;
+    }
+    const normalized = Math.floor(limit);
+    if (normalized <= 0) {
+      return this.HISTORY_PAGE_DEFAULT;
+    }
+    return Math.min(normalized, this.HISTORY_PAGE_MAX);
   }
 }

--- a/src/server/navigationResources.ts
+++ b/src/server/navigationResources.ts
@@ -4,7 +4,8 @@ import {
   NavigationGraphSummary,
   NavigationGraphSummaryProvider,
   NavigationGraphNodeResource,
-  NavigationGraphNodeResourceProvider
+  NavigationGraphNodeResourceProvider,
+  NavigationGraphHistoryProvider
 } from "../utils/interfaces/NavigationGraph";
 import { logger } from "../utils/logger";
 
@@ -12,6 +13,10 @@ export const NAVIGATION_RESOURCE_URIS = {
   GRAPH: "automobile://navigation/graph",
   NODE_BY_ID: "automobile://navigation/nodes/{nodeId}",
   NODE_BY_SCREEN: "automobile://navigation/nodes?screen={screenName}",
+  HISTORY: "automobile://navigation/history",
+  HISTORY_WITH_CURSOR: "automobile://navigation/history?cursor={cursor}",
+  HISTORY_WITH_LIMIT: "automobile://navigation/history?limit={limit}",
+  HISTORY_WITH_CURSOR_AND_LIMIT: "automobile://navigation/history?cursor={cursor}&limit={limit}",
 } as const;
 
 export type NavigationGraphResourceContent = NavigationGraphSummary;
@@ -19,7 +24,10 @@ export type NavigationNodeResourceContent = NavigationGraphNodeResource;
 
 const GRAPH_RESOURCE_UPDATE_DEBOUNCE_MS = 1000;
 
-type NavigationGraphResourceProvider = NavigationGraphSummaryProvider & NavigationGraphNodeResourceProvider;
+type NavigationGraphResourceProvider =
+  NavigationGraphSummaryProvider &
+  NavigationGraphNodeResourceProvider &
+  NavigationGraphHistoryProvider;
 
 let navigationGraphProvider: NavigationGraphResourceProvider = NavigationGraphManager.getInstance();
 let updateListenerProvider: NavigationGraphSummaryProvider | null = null;
@@ -33,7 +41,10 @@ function scheduleNavigationGraphUpdate(): void {
 
   updateTimeout = setTimeout(() => {
     updateTimeout = null;
-    void ResourceRegistry.notifyResourceUpdated(NAVIGATION_RESOURCE_URIS.GRAPH);
+    void ResourceRegistry.notifyResourcesUpdated([
+      NAVIGATION_RESOURCE_URIS.GRAPH,
+      NAVIGATION_RESOURCE_URIS.HISTORY,
+    ]);
   }, GRAPH_RESOURCE_UPDATE_DEBOUNCE_MS);
 }
 
@@ -70,6 +81,32 @@ async function getNavigationGraphResource(): Promise<ResourceContent> {
       mimeType: "application/json",
       text: JSON.stringify({
         error: `Failed to retrieve navigation graph: ${error}`
+      }, null, 2)
+    };
+  }
+}
+
+async function getNavigationGraphHistoryResource(
+  uri: string,
+  options: {
+    cursor?: string;
+    limit?: number;
+  } = {}
+): Promise<ResourceContent> {
+  try {
+    const history = await navigationGraphProvider.exportGraphHistory(options);
+    return {
+      uri,
+      mimeType: "application/json",
+      text: JSON.stringify(history, null, 2)
+    };
+  } catch (error) {
+    logger.error(`[NavigationResources] Failed to get navigation history: ${error}`);
+    return {
+      uri,
+      mimeType: "application/json",
+      text: JSON.stringify({
+        error: `Failed to retrieve navigation history: ${error}`
       }, null, 2)
     };
   }
@@ -123,6 +160,29 @@ async function getNavigationNodeByScreenResource(screenName: string): Promise<Re
   }
 }
 
+function parseHistoryParams(params: Record<string, string>): {
+  cursor?: string;
+  limit?: number;
+} {
+  const cursorRaw = params.cursor ? decodeURIComponent(params.cursor).trim() : "";
+  const limitRaw = params.limit ? decodeURIComponent(params.limit).trim() : "";
+
+  const cursor = cursorRaw || undefined;
+  if (!limitRaw) {
+    return { cursor };
+  }
+
+  const parsedLimit = Number(limitRaw);
+  if (!Number.isFinite(parsedLimit) || parsedLimit <= 0) {
+    throw new Error(`Invalid history limit: ${params.limit}`);
+  }
+
+  return {
+    cursor,
+    limit: Math.floor(parsedLimit)
+  };
+}
+
 export function registerNavigationResources(options: {
   navigationGraph?: NavigationGraphResourceProvider;
 } = {}): void {
@@ -141,6 +201,54 @@ export function registerNavigationResources(options: {
     "High-level navigation graph for the current app (nodes and edges).",
     "application/json",
     getNavigationGraphResource
+  );
+
+  ResourceRegistry.register(
+    NAVIGATION_RESOURCE_URIS.HISTORY,
+    "Navigation History",
+    "Ordered navigation history for the current app (nodes and edges).",
+    "application/json",
+    () => getNavigationGraphHistoryResource(NAVIGATION_RESOURCE_URIS.HISTORY)
+  );
+
+  const historyHandler = async (params: Record<string, string>) => {
+    const { cursor, limit } = parseHistoryParams(params);
+    const query = new URLSearchParams();
+    if (cursor) {
+      query.set("cursor", cursor);
+    }
+    if (limit) {
+      query.set("limit", limit.toString());
+    }
+    const queryString = query.toString();
+    const uri = queryString
+      ? `${NAVIGATION_RESOURCE_URIS.HISTORY}?${queryString}`
+      : NAVIGATION_RESOURCE_URIS.HISTORY;
+    return getNavigationGraphHistoryResource(uri, { cursor, limit });
+  };
+
+  ResourceRegistry.registerTemplate(
+    NAVIGATION_RESOURCE_URIS.HISTORY_WITH_CURSOR_AND_LIMIT,
+    "Navigation History",
+    "Ordered navigation history with pagination support.",
+    "application/json",
+    historyHandler
+  );
+
+  ResourceRegistry.registerTemplate(
+    NAVIGATION_RESOURCE_URIS.HISTORY_WITH_CURSOR,
+    "Navigation History",
+    "Ordered navigation history with pagination support.",
+    "application/json",
+    historyHandler
+  );
+
+  ResourceRegistry.registerTemplate(
+    NAVIGATION_RESOURCE_URIS.HISTORY_WITH_LIMIT,
+    "Navigation History",
+    "Ordered navigation history with pagination support.",
+    "application/json",
+    historyHandler
   );
 
   ResourceRegistry.registerTemplate(

--- a/src/utils/interfaces/NavigationGraph.ts
+++ b/src/utils/interfaces/NavigationGraph.ts
@@ -198,6 +198,39 @@ export interface NavigationGraphNodeResource {
 }
 
 /**
+ * Ordered navigation edge for history playback.
+ */
+export interface NavigationGraphHistoryEdge {
+  id: number;
+  from: string;
+  to: string;
+  toolName: string | null;
+  timestamp: number;
+}
+
+/**
+ * Ordered navigation node for history playback.
+ */
+export interface NavigationGraphHistoryNode {
+  id: number | null;
+  screenName: string;
+  timestamp: number;
+  edgeId?: number | null;
+}
+
+/**
+ * Paginated navigation history resource.
+ */
+export interface NavigationGraphHistoryPage {
+  appId: string | null;
+  currentScreen: string | null;
+  cursor: string | null;
+  nextCursor: string | null;
+  nodes: NavigationGraphHistoryNode[];
+  edges: NavigationGraphHistoryEdge[];
+}
+
+/**
  * Provider interface for navigation graph summaries.
  */
 export interface NavigationGraphSummaryProvider {
@@ -211,6 +244,16 @@ export interface NavigationGraphSummaryProvider {
 export interface NavigationGraphNodeResourceProvider {
   getNodeResourceById(nodeId: number): Promise<NavigationGraphNodeResource | null>;
   getNodeResourceByScreen(screenName: string): Promise<NavigationGraphNodeResource | null>;
+}
+
+/**
+ * Provider interface for navigation graph history resources.
+ */
+export interface NavigationGraphHistoryProvider {
+  exportGraphHistory(options?: {
+    cursor?: string;
+    limit?: number;
+  }): Promise<NavigationGraphHistoryPage>;
 }
 
 /**


### PR DESCRIPTION
## Summary
- render the navigation graph in the IDE tool window using MCP resources and recent transition highlighting
- add a paginated navigation history MCP resource for ordered playback
- extend navigation graph interfaces/repository exports to support history pagination

## Testing
- bun run build
- bun run lint
- bun run test (fails: SQLiteError attempt to write a readonly database; see scratch/bun-test.log)

Refs #253
