### PR TITLE
MCP daemon: provide historical test timings

### DIFF
--- a/android/junit-runner/src/main/kotlin/dev/jasonpearson/automobile/junit/AutoMobileRunner.kt
+++ b/android/junit-runner/src/main/kotlin/dev/jasonpearson/automobile/junit/AutoMobileRunner.kt
@@ -38,16 +38,31 @@ class AutoMobileRunner(private val klass: Class<*>) : BlockJUnit4ClassRunner(kla
   private val agent: AutoMobileAgent
     get() = LazyInitializer.getAgent()
 
-  private val randomizedChildren: List<FrameworkMethod> by lazy {
+  private val orderedChildren: List<FrameworkMethod> by lazy {
     val children = super.getChildren()
+
+    TestTimingCache.prefetchIfEnabled()
+    val orderingStrategy = resolveTimingOrderingStrategy()
+    val timingOrderedChildren =
+        if (orderingStrategy == TimingOrderingStrategy.NONE || !TestTimingCache.hasTimings()) {
+          children
+        } else {
+          val ordered = orderChildrenByTiming(children, orderingStrategy)
+          println("AutoMobileRunner: Ordering tests by historical duration (${orderingStrategy.label})")
+          ordered
+        }
+
     val shuffleEnabled = SystemPropertyCache.getBoolean("automobile.junit.shuffle.enabled", true)
-    if (!shuffleEnabled || children.size <= 1) {
-      children
+    if (!shuffleEnabled || timingOrderedChildren.size <= 1 || orderingStrategy != TimingOrderingStrategy.NONE) {
+      if (shuffleEnabled && orderingStrategy != TimingOrderingStrategy.NONE) {
+        println("AutoMobileRunner: Shuffle enabled but timing ordering is active; preserving timing order.")
+      }
+      timingOrderedChildren
     } else {
       val seedProperty = SystemPropertyCache.get("automobile.junit.shuffle.seed", "").trim()
       val seed = seedProperty.toLongOrNull() ?: System.currentTimeMillis()
       println("AutoMobileRunner: Shuffling test order with seed=$seed")
-      children.shuffled(Random(seed))
+      timingOrderedChildren.shuffled(Random(seed))
     }
   }
 
@@ -74,7 +89,81 @@ class AutoMobileRunner(private val klass: Class<*>) : BlockJUnit4ClassRunner(kla
   }
 
   override fun getChildren(): List<FrameworkMethod> {
-    return randomizedChildren
+    return orderedChildren
+  }
+
+  private enum class TimingOrderingStrategy(val label: String) {
+    NONE("none"),
+    DURATION_ASC("shortest-first"),
+    DURATION_DESC("longest-first"),
+  }
+
+  private data class TimingCandidate(
+      val method: FrameworkMethod,
+      val index: Int,
+      val durationMs: Int?,
+  )
+
+  private fun resolveTimingOrderingStrategy(): TimingOrderingStrategy {
+    val rawValue =
+        SystemPropertyCache.get("automobile.junit.timing.ordering", "none").trim().lowercase()
+    return when (rawValue) {
+      "duration-asc",
+      "duration_asc",
+      "shortest-first",
+      "shortest_first",
+      "shortest" -> TimingOrderingStrategy.DURATION_ASC
+      "duration-desc",
+      "duration_desc",
+      "longest-first",
+      "longest_first",
+      "longest" -> TimingOrderingStrategy.DURATION_DESC
+      else -> TimingOrderingStrategy.NONE
+    }
+  }
+
+  private fun orderChildrenByTiming(
+      children: List<FrameworkMethod>,
+      strategy: TimingOrderingStrategy,
+  ): List<FrameworkMethod> {
+    if (strategy == TimingOrderingStrategy.NONE || children.isEmpty()) {
+      return children
+    }
+
+    val className = klass.simpleName
+    val candidates =
+        children.mapIndexed { index, method ->
+          TimingCandidate(
+              method = method,
+              index = index,
+              durationMs = TestTimingCache.getTiming(className, method.name)?.averageDurationMs,
+          )
+        }
+
+    val withTiming = candidates.filter { it.durationMs != null }
+    val withoutTiming = candidates.filter { it.durationMs == null }
+
+    if (withTiming.isEmpty()) {
+      return children
+    }
+
+    val sortedWithTiming =
+        when (strategy) {
+          TimingOrderingStrategy.DURATION_DESC ->
+              withTiming.sortedWith(
+                  compareByDescending<TimingCandidate> { it.durationMs }
+                      .thenBy { it.index }
+              )
+          TimingOrderingStrategy.DURATION_ASC ->
+              withTiming.sortedWith(
+                  compareBy<TimingCandidate> { it.durationMs }.thenBy { it.index }
+              )
+          TimingOrderingStrategy.NONE -> withTiming
+        }
+
+    val sortedWithoutTiming = withoutTiming.sortedBy { it.index }
+
+    return sortedWithTiming.map { it.method } + sortedWithoutTiming.map { it.method }
   }
 
   override fun childrenInvoker(notifier: RunNotifier): org.junit.runners.model.Statement {

--- a/android/junit-runner/src/main/kotlin/dev/jasonpearson/automobile/junit/README.md
+++ b/android/junit-runner/src/main/kotlin/dev/jasonpearson/automobile/junit/README.md
@@ -73,6 +73,38 @@ When using prompt-based testing:
 - `automobile.daemon.startup.timeout.ms`: Daemon startup timeout in milliseconds (default: 10000)
 - `automobile.junit.shuffle.enabled`: Randomize test execution order (default: true)
 - `automobile.junit.shuffle.seed`: Seed for randomized order (default: current time)
+- `automobile.junit.timing.enabled`: Fetch historical timing data from the daemon (default: true)
+- `automobile.junit.timing.lookback.days`: Days of history to include (default: 90)
+- `automobile.junit.timing.limit`: Max tests returned from timing query (default: 1000)
+- `automobile.junit.timing.min.samples`: Minimum sample size per test (default: 1)
+- `automobile.junit.timing.ordering`: Test order strategy based on historical duration (`none`, `duration-asc`, `duration-desc`; default: `none`)
+- `automobile.junit.timing.fetch.timeout.ms`: Timing query timeout in milliseconds (default: 5000)
+  - Timing fetch is automatically disabled when CI is detected (`automobile.ci.mode=true` or `CI=true`).
+
+### Historical Test Timing
+
+On startup, the runner requests historical execution timing data from the AutoMobile daemon using the
+`getTestTimings` MCP tool. This data is cached for the JVM and can optionally drive test ordering
+when `automobile.junit.timing.ordering` is set.
+
+Example response format:
+
+```json
+{
+  "testTimings": [
+    {
+      "testClass": "com.example.LoginTest",
+      "testMethod": "testSuccessfulLogin",
+      "averageDurationMs": 1250,
+      "sampleSize": 15,
+      "lastRun": "2026-01-05T12:00:00Z",
+      "successRate": 0.93
+    }
+  ],
+  "generatedAt": "2026-01-05T13:00:00Z",
+  "totalTests": 150
+}
+```
 
 ### Test Cleanup Behavior
 

--- a/android/junit-runner/src/main/kotlin/dev/jasonpearson/automobile/junit/TestTimingCache.kt
+++ b/android/junit-runner/src/main/kotlin/dev/jasonpearson/automobile/junit/TestTimingCache.kt
@@ -1,0 +1,196 @@
+package dev.jasonpearson.automobile.junit
+
+import java.util.concurrent.atomic.AtomicBoolean
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+
+@Serializable
+internal data class TestTimingStatusCounts(
+    val passed: Int = 0,
+    val failed: Int = 0,
+    val skipped: Int = 0,
+)
+
+@Serializable
+internal data class TestTimingEntry(
+    val testClass: String,
+    val testMethod: String,
+    val averageDurationMs: Int = 0,
+    val sampleSize: Int = 0,
+    val lastRun: String? = null,
+    val lastRunTimestampMs: Long? = null,
+    val successRate: Double? = null,
+    val failureRate: Double? = null,
+    val stdDevDurationMs: Int? = null,
+    val statusCounts: TestTimingStatusCounts? = null,
+)
+
+@Serializable
+internal data class TestTimingSummary(
+    val testTimings: List<TestTimingEntry> = emptyList(),
+    val generatedAt: String? = null,
+    val totalTests: Int = 0,
+    val totalSamples: Int = 0,
+)
+
+internal data class TestTimingKey(val testClass: String, val testMethod: String)
+
+internal object TestTimingCache {
+  private const val DEFAULT_LOOKBACK_DAYS = 90
+  private const val DEFAULT_LIMIT = 1000
+  private const val DEFAULT_MIN_SAMPLES = 1
+  private const val DEFAULT_TIMEOUT_MS = 5000L
+
+  private val json = Json { ignoreUnknownKeys = true }
+  private val loaded = AtomicBoolean(false)
+  private val loadLock = Any()
+
+  @Volatile private var timingMap: Map<TestTimingKey, TestTimingEntry> = emptyMap()
+  @Volatile private var summary: TestTimingSummary? = null
+
+  fun prefetchIfEnabled() {
+    if (!isEnabled()) {
+      return
+    }
+
+    if (loaded.get()) {
+      return
+    }
+
+    synchronized(loadLock) {
+      if (loaded.get()) {
+        return
+      }
+      loadFromDaemon()
+      loaded.set(true)
+    }
+  }
+
+  fun getTiming(testClass: String, testMethod: String): TestTimingEntry? {
+    prefetchIfEnabled()
+    return timingMap[TestTimingKey(testClass, testMethod)]
+  }
+
+  fun hasTimings(): Boolean {
+    prefetchIfEnabled()
+    return timingMap.isNotEmpty()
+  }
+
+  fun getSummary(): TestTimingSummary? {
+    prefetchIfEnabled()
+    return summary
+  }
+
+  fun clear() {
+    timingMap = emptyMap()
+    summary = null
+    loaded.set(false)
+  }
+
+  private fun isEnabled(): Boolean {
+    if (isCiMode()) {
+      return false
+    }
+    return SystemPropertyCache.getBoolean("automobile.junit.timing.enabled", true)
+  }
+
+  private fun isCiMode(): Boolean {
+    if (SystemPropertyCache.getBoolean("automobile.ci.mode", false)) {
+      return true
+    }
+    val envValue = System.getenv("CI") ?: return false
+    return envValue.equals("true", ignoreCase = true) || envValue == "1"
+  }
+
+  private fun loadFromDaemon() {
+    val debugMode = SystemPropertyCache.getBoolean("automobile.debug", false)
+    val args = buildRequestArgs()
+    try {
+      val response =
+          DaemonSocketClientManager.callTool("getTestTimings", args, resolveTimeoutMs())
+      val payload = extractToolPayload(response)
+      if (payload.isNullOrBlank()) {
+        if (debugMode) {
+          println("AutoMobileRunner: No timing data returned from daemon.")
+        }
+        return
+      }
+
+      val parsed = json.decodeFromString(TestTimingSummary.serializer(), payload)
+      summary = parsed
+      timingMap = parsed.testTimings.associateBy { TestTimingKey(it.testClass, it.testMethod) }
+
+      if (debugMode) {
+        println("AutoMobileRunner: Loaded ${parsed.testTimings.size} historical test timings.")
+      }
+    } catch (e: Exception) {
+      if (debugMode) {
+        println("AutoMobileRunner: Failed to load historical timings: ${e.message}")
+      }
+    }
+  }
+
+  private fun buildRequestArgs(): JsonObject {
+    val values = mutableMapOf<String, JsonElement>()
+    values["lookbackDays"] = JsonPrimitive(resolvePositiveIntProperty(
+        "automobile.junit.timing.lookback.days",
+        DEFAULT_LOOKBACK_DAYS
+    ))
+    values["limit"] = JsonPrimitive(resolvePositiveIntProperty(
+        "automobile.junit.timing.limit",
+        DEFAULT_LIMIT
+    ))
+    values["minSamples"] = JsonPrimitive(resolveMinSamples())
+    values["devicePlatform"] = JsonPrimitive("android")
+    return JsonObject(values)
+  }
+
+  private fun resolveMinSamples(): Int {
+    val value =
+        SystemPropertyCache.get("automobile.junit.timing.min.samples", DEFAULT_MIN_SAMPLES.toString())
+            .toIntOrNull()
+    return when {
+      value == null -> DEFAULT_MIN_SAMPLES
+      value < 0 -> 0
+      else -> value
+    }
+  }
+
+  private fun resolvePositiveIntProperty(name: String, fallback: Int): Int {
+    val value = SystemPropertyCache.get(name, fallback.toString()).toIntOrNull()
+    return if (value != null && value > 0) value else fallback
+  }
+
+  private fun resolveTimeoutMs(): Long {
+    val value =
+        SystemPropertyCache.get(
+            "automobile.junit.timing.fetch.timeout.ms",
+            DEFAULT_TIMEOUT_MS.toString(),
+        ).toLongOrNull()
+    return if (value != null && value > 0) value else DEFAULT_TIMEOUT_MS
+  }
+
+  private fun extractToolPayload(response: DaemonResponse): String? {
+    if (!response.success) {
+      return null
+    }
+
+    val resultElement = response.result ?: return null
+    val resultObject = resultElement.jsonObject
+    val contentElement = resultObject["content"]
+    if (contentElement !is JsonArray || contentElement.isEmpty()) {
+      return null
+    }
+    val first = contentElement.first().jsonObject
+    if (first["type"]?.jsonPrimitive?.content != "text") {
+      return null
+    }
+    return first["text"]?.jsonPrimitive?.content
+  }
+}

--- a/android/junit-runner/src/test/kotlin/dev/jasonpearson/automobile/junit/AutoMobileRunnerTest.kt
+++ b/android/junit-runner/src/test/kotlin/dev/jasonpearson/automobile/junit/AutoMobileRunnerTest.kt
@@ -23,6 +23,7 @@ class AutoMobileRunnerTest {
     SystemPropertyCache.clear()
     PlanCache.clear()
     RegexCache.clear() // Phase 6: Clear regex cache for test isolation
+    TestTimingCache.clear()
   }
 
   @Test

--- a/docs/features/test-execution/junitrunner.md
+++ b/docs/features/test-execution/junitrunner.md
@@ -4,19 +4,45 @@ Add this test Gradle dependency to all Android apps and libraries in your codeba
 modules that cover the UI you want to test.
 
 ```gradle
-testImplementation("dev.jasonpearson.automobile:junit-runner:x.y.z")
+testImplementation("dev.jasonpearson.automobile.junitrunner:x.y.z")
 ```
 
-The coordinates and current version are defined in `android/junit-runner/build.gradle.kts`.
+Note that this artifact hasn't been published to Maven Central just yet and is forthcoming.  
 
-To publish locally (for `~/.m2`) from the repo:
 
-```bash
-(cd android && ./gradlew :junit-runner:publishToMavenLocal)
+In the meantime, publish to your mavenLocal (`~/.m2`) via:
+
+```
+./gradlew publishToMavenLocal
 ```
 
-Then replace `x.y.z` with the version from `android/junit-runner/build.gradle.kts`.
+and use the above testImplementation dependency with `x.y.z` version from `android/junit-runner/build.gradle.kts`.
 
-## Implementation references
+## Historical Timing Data
 
-- [`android/junit-runner/build.gradle.kts#L18-L58`](https://github.com/kaeawc/auto-mobile/blob/main/android/junit-runner/build.gradle.kts#L18-L58) for version and Maven coordinates.
+The AutoMobile daemon exposes historical test timing summaries to the JUnitRunner via the
+`getTestTimings` MCP tool. The runner fetches this data on startup (per JVM) and can optionally
+use it to order tests based on historical duration. Set the system property
+`automobile.junit.timing.ordering` to `duration-desc` (longest-first) or `duration-asc` (shortest-first)
+to enable ordering.
+
+Timing fetch is automatically disabled when CI is detected (`automobile.ci.mode=true` or `CI=true`).
+
+Example response format:
+
+```json
+{
+  "testTimings": [
+    {
+      "testClass": "com.example.LoginTest",
+      "testMethod": "testSuccessfulLogin",
+      "averageDurationMs": 1250,
+      "sampleSize": 15,
+      "lastRun": "2026-01-05T12:00:00Z",
+      "successRate": 0.93
+    }
+  ],
+  "generatedAt": "2026-01-05T13:00:00Z",
+  "totalTests": 150
+}
+```

--- a/src/db/testExecutionRepository.ts
+++ b/src/db/testExecutionRepository.ts
@@ -1,9 +1,10 @@
+import { sql } from "kysely";
 import { getDatabase } from "./database";
 import type { NewTestExecution } from "./types";
 import { logger } from "../utils/logger";
 
-const RETENTION_MAX_ROWS = 10_000;
-const RETENTION_MAX_DAYS = 90;
+export const TEST_EXECUTION_RETENTION_MAX_ROWS = 10_000;
+export const TEST_EXECUTION_RETENTION_MAX_DAYS = 90;
 const MS_PER_DAY = 24 * 60 * 60 * 1000;
 
 let cleanupInProgress = false;
@@ -28,6 +29,40 @@ export interface TestExecutionRecord {
   gradleVersion?: string | null;
   isCi?: boolean | null;
   sessionUuid?: string | null;
+}
+
+export interface TestTimingQueryOptions {
+  lookbackDays?: number;
+  testClass?: string;
+  testMethod?: string;
+  deviceId?: string;
+  deviceName?: string;
+  devicePlatform?: "android" | "ios";
+  deviceType?: "emulator" | "simulator" | "device";
+  appVersion?: string;
+  gitCommit?: string;
+  targetSdk?: number;
+  jdkVersion?: string;
+  jvmTarget?: string;
+  gradleVersion?: string;
+  isCi?: boolean;
+  sessionUuid?: string;
+  minSamples?: number;
+  limit?: number;
+  orderBy?: "lastRun" | "averageDuration" | "sampleSize";
+  orderDirection?: "asc" | "desc";
+}
+
+export interface TestTimingStats {
+  testClass: string;
+  testMethod: string;
+  averageDurationMs: number;
+  sampleSize: number;
+  lastRunTimestampMs: number;
+  passedCount: number;
+  failedCount: number;
+  skippedCount: number;
+  stdDevDurationMs: number;
 }
 
 export class TestExecutionRepository {
@@ -67,7 +102,7 @@ export class TestExecutionRepository {
     cleanupInProgress = true;
     try {
       const db = getDatabase();
-      const cutoff = Date.now() - RETENTION_MAX_DAYS * MS_PER_DAY;
+      const cutoff = Date.now() - TEST_EXECUTION_RETENTION_MAX_DAYS * MS_PER_DAY;
 
       await db
         .deleteFrom("test_executions")
@@ -80,7 +115,7 @@ export class TestExecutionRepository {
         .orderBy("timestamp", "desc")
         .orderBy("id", "desc")
         .limit(1)
-        .offset(RETENTION_MAX_ROWS - 1)
+        .offset(TEST_EXECUTION_RETENTION_MAX_ROWS - 1)
         .executeTakeFirst();
 
       if (!threshold) {
@@ -102,5 +137,129 @@ export class TestExecutionRepository {
     } finally {
       cleanupInProgress = false;
     }
+  }
+
+  async getTimingStats(options: TestTimingQueryOptions): Promise<TestTimingStats[]> {
+    const db = getDatabase();
+
+    let query = db
+      .selectFrom("test_executions")
+      .select([
+        "test_class as testClass",
+        "test_method as testMethod",
+        db.fn.avg<number>("duration_ms").as("avgDurationMs"),
+        db.fn.avg<number>(sql`duration_ms * duration_ms`).as("avgDurationMsSquared"),
+        db.fn.countAll<number>().as("sampleSize"),
+        db.fn.max<number>("timestamp").as("lastRunTimestampMs"),
+        db.fn.sum<number>(sql`case when status = 'passed' then 1 else 0 end`).as("passedCount"),
+        db.fn.sum<number>(sql`case when status = 'failed' then 1 else 0 end`).as("failedCount"),
+        db.fn.sum<number>(sql`case when status = 'skipped' then 1 else 0 end`).as("skippedCount"),
+      ])
+      .groupBy(["test_class", "test_method"]);
+
+    if (options.lookbackDays && options.lookbackDays > 0) {
+      const cutoff = Date.now() - options.lookbackDays * MS_PER_DAY;
+      query = query.where("timestamp", ">=", cutoff);
+    }
+
+    if (options.testClass) {
+      query = query.where("test_class", "=", options.testClass);
+    }
+
+    if (options.testMethod) {
+      query = query.where("test_method", "=", options.testMethod);
+    }
+
+    if (options.deviceId) {
+      query = query.where("device_id", "=", options.deviceId);
+    }
+
+    if (options.deviceName) {
+      query = query.where("device_name", "=", options.deviceName);
+    }
+
+    if (options.devicePlatform) {
+      query = query.where("device_platform", "=", options.devicePlatform);
+    }
+
+    if (options.deviceType) {
+      query = query.where("device_type", "=", options.deviceType);
+    }
+
+    if (options.appVersion) {
+      query = query.where("app_version", "=", options.appVersion);
+    }
+
+    if (options.gitCommit) {
+      query = query.where("git_commit", "=", options.gitCommit);
+    }
+
+    if (options.targetSdk !== undefined) {
+      query = query.where("target_sdk", "=", options.targetSdk);
+    }
+
+    if (options.jdkVersion) {
+      query = query.where("jdk_version", "=", options.jdkVersion);
+    }
+
+    if (options.jvmTarget) {
+      query = query.where("jvm_target", "=", options.jvmTarget);
+    }
+
+    if (options.gradleVersion) {
+      query = query.where("gradle_version", "=", options.gradleVersion);
+    }
+
+    if (options.sessionUuid) {
+      query = query.where("session_uuid", "=", options.sessionUuid);
+    }
+
+    if (typeof options.isCi === "boolean") {
+      query = query.where("is_ci", "=", options.isCi ? 1 : 0);
+    }
+
+    if (options.minSamples && options.minSamples > 1) {
+      query = query.having(db.fn.countAll(), ">=", options.minSamples);
+    }
+
+    const orderBy = options.orderBy ?? "lastRun";
+    const orderDirection = options.orderDirection ?? "desc";
+
+    switch (orderBy) {
+      case "averageDuration":
+        query = query.orderBy("avgDurationMs", orderDirection);
+        break;
+      case "sampleSize":
+        query = query.orderBy("sampleSize", orderDirection);
+        break;
+      default:
+        query = query.orderBy("lastRunTimestampMs", orderDirection);
+        break;
+    }
+
+    if (options.limit && options.limit > 0) {
+      query = query.limit(options.limit);
+    }
+
+    const rows = await query.execute();
+
+    return rows.map(row => {
+      const avgDuration = Number(row.avgDurationMs ?? 0);
+      const avgSquare = Number(row.avgDurationMsSquared ?? 0);
+      const variance = Math.max(0, avgSquare - avgDuration * avgDuration);
+      const stdDev = Math.sqrt(variance);
+
+      return {
+        testClass: row.testClass,
+        testMethod: row.testMethod,
+        averageDurationMs: Math.round(avgDuration),
+        sampleSize: Number(row.sampleSize ?? 0),
+        lastRunTimestampMs: Number(row.lastRunTimestampMs ?? 0),
+        passedCount: Number(row.passedCount ?? 0),
+        failedCount: Number(row.failedCount ?? 0),
+        skippedCount: Number(row.skippedCount ?? 0),
+        stdDevDurationMs: Math.round(stdDev),
+      };
+    });
   }
 }

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -28,6 +28,7 @@ import { registerDaemonTools } from "./daemonTools";
 import { registerPlanTools } from "./planTools";
 import { registerDoctorTools } from "./doctorTools";
 import { registerFeatureFlagTools } from "./featureFlagTools";
+import { registerTestTimingTools } from "./testTimingTools";
 
 // Import resource registration functions
 import { registerObservationResources } from "./observationResources";
@@ -86,6 +87,7 @@ export const createMcpServer = (options: McpServerOptions = {}): McpServer => {
   registerNavigationTools();
   registerDaemonTools();
   registerPlanTools();
+  registerTestTimingTools();
   registerDoctorTools();
   registerFeatureFlagTools();
 

--- a/src/server/testTimingTools.ts
+++ b/src/server/testTimingTools.ts
@@ -1,0 +1,134 @@
+import { z } from "zod";
+import { ToolRegistry } from "./toolRegistry";
+import { ActionableError } from "../models";
+import { createJSONToolResponse } from "../utils/toolUtils";
+import {
+  TestExecutionRepository,
+  TestTimingQueryOptions,
+  TEST_EXECUTION_RETENTION_MAX_DAYS,
+} from "../db/testExecutionRepository";
+
+const DEFAULT_LOOKBACK_DAYS = TEST_EXECUTION_RETENTION_MAX_DAYS;
+const DEFAULT_LIMIT = 1000;
+const DEFAULT_MIN_SAMPLES = 1;
+
+const testTimingQuerySchema = z.object({
+  lookbackDays: z.number().int().positive().optional().describe("Number of days of history to include."),
+  limit: z.number().int().positive().max(5000).optional().describe("Maximum number of tests to return."),
+  minSamples: z.number().int().nonnegative().optional().describe("Minimum sample size to include a test."),
+  orderBy: z.enum(["lastRun", "averageDuration", "sampleSize"]).optional().describe("Sort key for results."),
+  orderDirection: z.enum(["asc", "desc"]).optional().describe("Sort direction for results."),
+  testClass: z.string().optional().describe("Filter by test class name."),
+  testMethod: z.string().optional().describe("Filter by test method name."),
+  deviceId: z.string().optional().describe("Filter by device ID."),
+  deviceName: z.string().optional().describe("Filter by device name."),
+  devicePlatform: z.enum(["android", "ios"]).optional().describe("Filter by device platform."),
+  deviceType: z.enum(["emulator", "simulator", "device"]).optional().describe("Filter by device type."),
+  appVersion: z.string().optional().describe("Filter by app version."),
+  gitCommit: z.string().optional().describe("Filter by git commit SHA."),
+  targetSdk: z.number().int().positive().optional().describe("Filter by target SDK."),
+  jdkVersion: z.string().optional().describe("Filter by JDK version."),
+  jvmTarget: z.string().optional().describe("Filter by JVM target."),
+  gradleVersion: z.string().optional().describe("Filter by Gradle version."),
+  isCi: z.boolean().optional().describe("Filter by CI mode."),
+  sessionUuid: z.string().optional().describe("Filter by session UUID."),
+}).strict();
+
+const testExecutionRepository = new TestExecutionRepository();
+
+export function registerTestTimingTools(): void {
+  ToolRegistry.register(
+    "getTestTimings",
+    "Retrieve aggregated historical test execution timing statistics for optimization.",
+    testTimingQuerySchema,
+    async args => {
+      try {
+        const lookbackDays = args.lookbackDays ?? DEFAULT_LOOKBACK_DAYS;
+        const limit = args.limit ?? DEFAULT_LIMIT;
+        const minSamples = args.minSamples ?? DEFAULT_MIN_SAMPLES;
+
+        const options: TestTimingQueryOptions = {
+          lookbackDays,
+          limit,
+          minSamples,
+          orderBy: args.orderBy,
+          orderDirection: args.orderDirection,
+          testClass: args.testClass,
+          testMethod: args.testMethod,
+          deviceId: args.deviceId,
+          deviceName: args.deviceName,
+          devicePlatform: args.devicePlatform,
+          deviceType: args.deviceType,
+          appVersion: args.appVersion,
+          gitCommit: args.gitCommit,
+          targetSdk: args.targetSdk,
+          jdkVersion: args.jdkVersion,
+          jvmTarget: args.jvmTarget,
+          gradleVersion: args.gradleVersion,
+          isCi: args.isCi,
+          sessionUuid: args.sessionUuid,
+        };
+
+        const timings = await testExecutionRepository.getTimingStats(options);
+        const totalSamples = timings.reduce((total, entry) => total + entry.sampleSize, 0);
+
+        const filters: Record<string, unknown> = {};
+        if (args.testClass) {filters.testClass = args.testClass;}
+        if (args.testMethod) {filters.testMethod = args.testMethod;}
+        if (args.deviceId) {filters.deviceId = args.deviceId;}
+        if (args.deviceName) {filters.deviceName = args.deviceName;}
+        if (args.devicePlatform) {filters.devicePlatform = args.devicePlatform;}
+        if (args.deviceType) {filters.deviceType = args.deviceType;}
+        if (args.appVersion) {filters.appVersion = args.appVersion;}
+        if (args.gitCommit) {filters.gitCommit = args.gitCommit;}
+        if (args.targetSdk !== undefined) {filters.targetSdk = args.targetSdk;}
+        if (args.jdkVersion) {filters.jdkVersion = args.jdkVersion;}
+        if (args.jvmTarget) {filters.jvmTarget = args.jvmTarget;}
+        if (args.gradleVersion) {filters.gradleVersion = args.gradleVersion;}
+        if (typeof args.isCi === "boolean") {filters.isCi = args.isCi;}
+        if (args.sessionUuid) {filters.sessionUuid = args.sessionUuid;}
+
+        const response = {
+          testTimings: timings.map(entry => ({
+            testClass: entry.testClass,
+            testMethod: entry.testMethod,
+            averageDurationMs: entry.averageDurationMs,
+            sampleSize: entry.sampleSize,
+            lastRunTimestampMs: entry.lastRunTimestampMs || null,
+            lastRun: entry.lastRunTimestampMs
+              ? new Date(entry.lastRunTimestampMs).toISOString()
+              : null,
+            successRate: entry.sampleSize > 0
+              ? Number((entry.passedCount / entry.sampleSize).toFixed(4))
+              : 0,
+            failureRate: entry.sampleSize > 0
+              ? Number((entry.failedCount / entry.sampleSize).toFixed(4))
+              : 0,
+            stdDevDurationMs: entry.stdDevDurationMs,
+            statusCounts: {
+              passed: entry.passedCount,
+              failed: entry.failedCount,
+              skipped: entry.skippedCount,
+            },
+          })),
+          generatedAt: new Date().toISOString(),
+          totalTests: timings.length,
+          totalSamples,
+          aggregation: {
+            strategy: "mean",
+            lookbackDays,
+            minSamples,
+            limit,
+            orderBy: options.orderBy ?? "lastRun",
+            orderDirection: options.orderDirection ?? "desc",
+          },
+          filters,
+        };
+
+        return createJSONToolResponse(response);
+      } catch (error) {
+        throw new ActionableError(`Failed to retrieve test timing data: ${error}`);
+      }
+    }
+  );
+}


### PR DESCRIPTION
## Summary
- add getTestTimings tool to aggregate SQLite test execution timing stats
- prefetch and cache timings in JUnitRunner with optional duration-based ordering (disabled in CI)
- document timing configuration and response format

## Testing
- bun run build
- bun run lint
- bun run test
- (cd android && ./gradlew compileKotlin)
- (cd android && ./gradlew compileTestKotlin)
- (cd android && ./gradlew build)
- (cd android && ./gradlew test)
- (cd android && ./gradlew :junit-runner:test --tests "dev.jasonpearson.automobile.junit.AutoMobileRunnerTest")
