### PR TITLE
JUnitRunner: auto timing ordering with device-aware forks

### DIFF
--- a/android/junit-runner/src/main/kotlin/dev/jasonpearson/automobile/junit/AutoMobileRunner.kt
+++ b/android/junit-runner/src/main/kotlin/dev/jasonpearson/automobile/junit/AutoMobileRunner.kt
@@ -41,20 +41,32 @@ class AutoMobileRunner(private val klass: Class<*>) : BlockJUnit4ClassRunner(kla
   private val orderedChildren: List<FrameworkMethod> by lazy {
     val children = super.getChildren()
 
-    TestTimingCache.prefetchIfEnabled()
-    val orderingStrategy = resolveTimingOrderingStrategy()
+    val requestedStrategy =
+        parseTimingOrderingStrategy(
+            SystemPropertyCache.get("automobile.junit.timing.ordering", "auto").trim().lowercase()
+        )
+    val parallelForks =
+        if (requestedStrategy == TimingOrderingStrategy.AUTO) {
+          resolveEffectiveParallelForks()
+        } else {
+          1
+        }
+    val selection = resolveTimingOrderingSelection(requestedStrategy, parallelForks)
+    val timingAvailable = TestTimingCache.hasTimings()
+    logTimingOrdering(selection, timingAvailable)
+
+    val timingOrderingActive =
+        selection.resolved != TimingOrderingStrategy.NONE && timingAvailable
     val timingOrderedChildren =
-        if (orderingStrategy == TimingOrderingStrategy.NONE || !TestTimingCache.hasTimings()) {
+        if (!timingOrderingActive) {
           children
         } else {
-          val ordered = orderChildrenByTiming(children, orderingStrategy)
-          println("AutoMobileRunner: Ordering tests by historical duration (${orderingStrategy.label})")
-          ordered
+          orderChildrenByTiming(children, selection.resolved)
         }
 
     val shuffleEnabled = SystemPropertyCache.getBoolean("automobile.junit.shuffle.enabled", true)
-    if (!shuffleEnabled || timingOrderedChildren.size <= 1 || orderingStrategy != TimingOrderingStrategy.NONE) {
-      if (shuffleEnabled && orderingStrategy != TimingOrderingStrategy.NONE) {
+    if (!shuffleEnabled || timingOrderedChildren.size <= 1 || timingOrderingActive) {
+      if (shuffleEnabled && timingOrderingActive) {
         println("AutoMobileRunner: Shuffle enabled but timing ordering is active; preserving timing order.")
       }
       timingOrderedChildren
@@ -94,9 +106,15 @@ class AutoMobileRunner(private val klass: Class<*>) : BlockJUnit4ClassRunner(kla
 
   private enum class TimingOrderingStrategy(val label: String) {
     NONE("none"),
+    AUTO("auto"),
     DURATION_ASC("shortest-first"),
     DURATION_DESC("longest-first"),
   }
+
+  private data class TimingOrderingSelection(
+      val requested: TimingOrderingStrategy,
+      val resolved: TimingOrderingStrategy,
+  )
 
   private data class TimingCandidate(
       val method: FrameworkMethod,
@@ -104,10 +122,9 @@ class AutoMobileRunner(private val klass: Class<*>) : BlockJUnit4ClassRunner(kla
       val durationMs: Int?,
   )
 
-  private fun resolveTimingOrderingStrategy(): TimingOrderingStrategy {
-    val rawValue =
-        SystemPropertyCache.get("automobile.junit.timing.ordering", "none").trim().lowercase()
+  private fun parseTimingOrderingStrategy(rawValue: String): TimingOrderingStrategy {
     return when (rawValue) {
+      "auto" -> TimingOrderingStrategy.AUTO
       "duration-asc",
       "duration_asc",
       "shortest-first",
@@ -118,8 +135,55 @@ class AutoMobileRunner(private val klass: Class<*>) : BlockJUnit4ClassRunner(kla
       "longest-first",
       "longest_first",
       "longest" -> TimingOrderingStrategy.DURATION_DESC
+      "none",
+      "off",
+      "false",
+      "disabled" -> TimingOrderingStrategy.NONE
       else -> TimingOrderingStrategy.NONE
     }
+  }
+
+  private fun resolveTimingOrderingSelection(
+      requested: TimingOrderingStrategy,
+      parallelForks: Int,
+  ): TimingOrderingSelection {
+    val resolved =
+        when (requested) {
+          TimingOrderingStrategy.AUTO ->
+              if (parallelForks > 1) {
+                TimingOrderingStrategy.DURATION_DESC
+              } else {
+                TimingOrderingStrategy.DURATION_ASC
+              }
+          else -> requested
+        }
+    return TimingOrderingSelection(requested, resolved)
+  }
+
+  private fun resolveEffectiveParallelForks(): Int {
+    val configuredForks =
+        SystemPropertyCache.get(
+                "junit.parallel.forks",
+                Runtime.getRuntime().availableProcessors().toString(),
+            )
+            .toIntOrNull() ?: 2
+    val safeConfiguredForks = if (configuredForks > 0) configuredForks else 1
+    val deviceCount = AutoMobileSharedUtils.deviceChecker.getDeviceCount()
+    return if (deviceCount > 0) {
+      safeConfiguredForks.coerceAtMost(deviceCount)
+    } else {
+      safeConfiguredForks
+    }
+  }
+
+  private fun logTimingOrdering(selection: TimingOrderingSelection, timingAvailable: Boolean) {
+    val message =
+        if (selection.requested == TimingOrderingStrategy.AUTO) {
+          "AutoMobileRunner: Timing ordering=auto (resolved=${selection.resolved.label}), timing data available=$timingAvailable"
+        } else {
+          "AutoMobileRunner: Timing ordering=${selection.requested.label}, timing data available=$timingAvailable"
+        }
+    println(message)
   }
 
   private fun orderChildrenByTiming(
@@ -158,6 +222,7 @@ class AutoMobileRunner(private val klass: Class<*>) : BlockJUnit4ClassRunner(kla
               withTiming.sortedWith(
                   compareBy<TimingCandidate> { it.durationMs }.thenBy { it.index }
               )
+          TimingOrderingStrategy.AUTO,
           TimingOrderingStrategy.NONE -> withTiming
         }
 

--- a/android/junit-runner/src/main/kotlin/dev/jasonpearson/automobile/junit/README.md
+++ b/android/junit-runner/src/main/kotlin/dev/jasonpearson/automobile/junit/README.md
@@ -77,15 +77,17 @@ When using prompt-based testing:
 - `automobile.junit.timing.lookback.days`: Days of history to include (default: 90)
 - `automobile.junit.timing.limit`: Max tests returned from timing query (default: 1000)
 - `automobile.junit.timing.min.samples`: Minimum sample size per test (default: 1)
-- `automobile.junit.timing.ordering`: Test order strategy based on historical duration (`none`, `duration-asc`, `duration-desc`; default: `none`)
+- `automobile.junit.timing.ordering`: Test order strategy based on historical duration (`auto`, `none`, `duration-asc`, `duration-desc`; default: `auto`)
 - `automobile.junit.timing.fetch.timeout.ms`: Timing query timeout in milliseconds (default: 5000)
   - Timing fetch is automatically disabled when CI is detected (`automobile.ci.mode=true` or `CI=true`).
 
 ### Historical Test Timing
 
 On startup, the runner requests historical execution timing data from the AutoMobile daemon using the
-`getTestTimings` MCP tool. This data is cached for the JVM and can optionally drive test ordering
-when `automobile.junit.timing.ordering` is set.
+`getTestTimings` MCP tool. This data is cached for the JVM and can optionally drive test ordering.
+When `automobile.junit.timing.ordering=auto`, the runner chooses longest-first when effective parallel
+forks are greater than 1 after device availability is applied, otherwise shortest-first. Set
+`automobile.junit.timing.ordering=none` to disable ordering.
 
 Example response format:
 

--- a/android/junit-runner/src/main/kotlin/dev/jasonpearson/automobile/junit/TestTimingCache.kt
+++ b/android/junit-runner/src/main/kotlin/dev/jasonpearson/automobile/junit/TestTimingCache.kt
@@ -109,30 +109,19 @@ internal object TestTimingCache {
   }
 
   private fun loadFromDaemon() {
-    val debugMode = SystemPropertyCache.getBoolean("automobile.debug", false)
     val args = buildRequestArgs()
     try {
       val response =
           DaemonSocketClientManager.callTool("getTestTimings", args, resolveTimeoutMs())
       val payload = extractToolPayload(response)
       if (payload.isNullOrBlank()) {
-        if (debugMode) {
-          println("AutoMobileRunner: No timing data returned from daemon.")
-        }
         return
       }
 
       val parsed = json.decodeFromString(TestTimingSummary.serializer(), payload)
       summary = parsed
       timingMap = parsed.testTimings.associateBy { TestTimingKey(it.testClass, it.testMethod) }
-
-      if (debugMode) {
-        println("AutoMobileRunner: Loaded ${parsed.testTimings.size} historical test timings.")
-      }
     } catch (e: Exception) {
-      if (debugMode) {
-        println("AutoMobileRunner: Failed to load historical timings: ${e.message}")
-      }
     }
   }
 

--- a/docs/features/test-execution/junitrunner.md
+++ b/docs/features/test-execution/junitrunner.md
@@ -22,9 +22,10 @@ and use the above testImplementation dependency with `x.y.z` version from `andro
 
 The AutoMobile daemon exposes historical test timing summaries to the JUnitRunner via the
 `getTestTimings` MCP tool. The runner fetches this data on startup (per JVM) and can optionally
-use it to order tests based on historical duration. Set the system property
-`automobile.junit.timing.ordering` to `duration-desc` (longest-first) or `duration-asc` (shortest-first)
-to enable ordering.
+use it to order tests based on historical duration. The default is `automobile.junit.timing.ordering=auto`,
+which chooses longest-first when effective parallel forks are greater than 1 after device availability
+is applied, and shortest-first otherwise. Set `automobile.junit.timing.ordering=none` to disable ordering,
+or explicitly set `duration-desc` (longest-first) / `duration-asc` (shortest-first).
 
 Timing fetch is automatically disabled when CI is detected (`automobile.ci.mode=true` or `CI=true`).
 


### PR DESCRIPTION
## Summary
- default timing ordering to auto with device-aware fork resolution
- limit timing logs to ordering/availability signals
- document auto ordering behavior in JUnitRunner docs

## Testing
- (cd android && ./gradlew :junit-runner:test --tests "dev.jasonpearson.automobile.junit.AutoMobileRunnerTest")

Refs #280
