### PR TITLE
Use FakeTimer in time-based utils tests

### DIFF
--- a/src/daemon/sessionManager.ts
+++ b/src/daemon/sessionManager.ts
@@ -1,3 +1,4 @@
+import { defaultTimer, Timer } from "../utils/SystemTimer";
 import { logger } from "../utils/logger";
 
 /**
@@ -48,6 +49,7 @@ export class SessionManager {
   private sessionDeviceMap: Map<string, string> = new Map(); // sessionId -> deviceId
   private deviceSessionMap: Map<string, string> = new Map(); // deviceId -> sessionId (reverse lookup)
   private cleanupTimer: NodeJS.Timeout | null = null;
+  private timer: Timer;
 
   // Session timeout: 30 minutes
   private readonly SESSION_TIMEOUT_MS = 30 * 60 * 1000;
@@ -57,7 +59,8 @@ export class SessionManager {
 
   static readonly DEFAULT_HEARTBEAT_TIMEOUT_MS = 10 * 1000;
 
-  constructor() {
+  constructor(timer: Timer = defaultTimer) {
+    this.timer = timer;
     // Start periodic cleanup of expired sessions
     this.startCleanupTimer();
   }
@@ -77,7 +80,7 @@ export class SessionManager {
       return this.sessions.get(sessionId)!;
     }
 
-    const now = Date.now();
+    const now = this.timer.now();
     const session: Session = {
       sessionId,
       assignedDevice,
@@ -128,8 +131,8 @@ export class SessionManager {
     if (existing) {
       logger.info(`[SessionManager] Found existing session ${sessionId} with device ${existing.assignedDevice}`);
       // Update last used time
-      existing.lastUsedAt = Date.now();
-      existing.expiresAt = Date.now() + this.SESSION_TIMEOUT_MS;
+      existing.lastUsedAt = this.timer.now();
+      existing.expiresAt = this.timer.now() + this.SESSION_TIMEOUT_MS;
       return existing;
     }
 
@@ -208,8 +211,8 @@ export class SessionManager {
       ...session.cacheData,
       ...updates,
     };
-    session.lastUsedAt = Date.now();
-    session.lastHeartbeat = Date.now();
+    session.lastUsedAt = this.timer.now();
+    session.lastHeartbeat = this.timer.now();
 
     logger.debug(`Updated cache for session ${sessionId}`);
   }
@@ -224,8 +227,8 @@ export class SessionManager {
     }
 
     // Update last used time when accessing cache
-    session.lastUsedAt = Date.now();
-    session.lastHeartbeat = Date.now();
+    session.lastUsedAt = this.timer.now();
+    session.lastHeartbeat = this.timer.now();
 
     return session.cacheData;
   }
@@ -239,7 +242,7 @@ export class SessionManager {
       logger.warn(`Cannot record heartbeat for session ${sessionId}: not found`);
       return;
     }
-    const now = Date.now();
+    const now = this.timer.now();
     session.lastHeartbeat = now;
     session.lastUsedAt = now;
     session.expiresAt = now + this.SESSION_TIMEOUT_MS;
@@ -297,7 +300,7 @@ export class SessionManager {
    * Check if session is expired
    */
   private isSessionExpired(session: Session): boolean {
-    return Date.now() > session.expiresAt;
+    return this.timer.now() > session.expiresAt;
   }
 
   /**
@@ -316,7 +319,7 @@ export class SessionManager {
    * Start periodic cleanup of expired sessions
    */
   private startCleanupTimer(): void {
-    this.cleanupTimer = setInterval(() => {
+    this.cleanupTimer = this.timer.setInterval(() => {
       const expiredSessions: string[] = [];
 
       for (const [sessionId, session] of this.sessions) {
@@ -338,7 +341,9 @@ export class SessionManager {
     }, this.CLEANUP_INTERVAL_MS);
 
     // Allow process to exit even if timer is running
-    this.cleanupTimer.unref();
+    if (this.cleanupTimer && typeof (this.cleanupTimer as { unref?: () => void }).unref === "function") {
+      this.cleanupTimer.unref();
+    }
   }
 
   /**
@@ -346,7 +351,7 @@ export class SessionManager {
    */
   stopCleanupTimer(): void {
     if (this.cleanupTimer) {
-      clearInterval(this.cleanupTimer);
+      this.timer.clearInterval(this.cleanupTimer);
       this.cleanupTimer = null;
     }
   }

--- a/src/utils/PerformanceTracker.ts
+++ b/src/utils/PerformanceTracker.ts
@@ -5,6 +5,7 @@
  * - Serial operations (executed sequentially) -> JSON arrays
  * - Parallel operations (executed concurrently) -> JSON objects
  */
+import { Timer, defaultTimer } from "./SystemTimer";
 
 /**
  * Represents a single timing entry in the performance data
@@ -111,13 +112,16 @@ export interface PerformanceTracker {
 export class DefaultPerformanceTracker implements PerformanceTracker {
   private root: TimingBlock;
   private current: TimingBlock;
+  private timer: Timer;
 
-  constructor() {
+  constructor(timer: Timer = defaultTimer) {
+    this.timer = timer;
+    const startMs = this.timer.now();
     // Initialize with a root serial block
     this.root = {
       name: "root",
       type: "serial",
-      startMs: Date.now(),
+      startMs,
       entries: [],
       parent: null
     };
@@ -128,7 +132,7 @@ export class DefaultPerformanceTracker implements PerformanceTracker {
     const block: TimingBlock = {
       name,
       type: "serial",
-      startMs: Date.now(),
+      startMs: this.timer.now(),
       entries: [],
       parent: this.current
     };
@@ -140,7 +144,7 @@ export class DefaultPerformanceTracker implements PerformanceTracker {
     const block: TimingBlock = {
       name,
       type: "parallel",
-      startMs: Date.now(),
+      startMs: this.timer.now(),
       entries: {},
       parent: this.current
     };
@@ -149,11 +153,11 @@ export class DefaultPerformanceTracker implements PerformanceTracker {
   }
 
   async track<T>(name: string, fn: () => Promise<T>): Promise<T> {
-    const startMs = Date.now();
+    const startMs = this.timer.now();
     try {
       return await fn();
     } finally {
-      const durationMs = Date.now() - startMs;
+      const durationMs = this.timer.now() - startMs;
       const entry: TimingEntry = { name, durationMs };
 
       if (Array.isArray(this.current.entries)) {
@@ -167,11 +171,11 @@ export class DefaultPerformanceTracker implements PerformanceTracker {
   }
 
   trackSync<T>(name: string, fn: () => T): T {
-    const startMs = Date.now();
+    const startMs = this.timer.now();
     try {
       return fn();
     } finally {
-      const durationMs = Date.now() - startMs;
+      const durationMs = this.timer.now() - startMs;
       const entry: TimingEntry = { name, durationMs };
 
       if (Array.isArray(this.current.entries)) {
@@ -186,7 +190,7 @@ export class DefaultPerformanceTracker implements PerformanceTracker {
 
   end(): PerformanceTracker {
     if (this.current.parent) {
-      const durationMs = Date.now() - this.current.startMs;
+      const durationMs = this.timer.now() - this.current.startMs;
       const entry: TimingEntry = {
         name: this.current.name,
         durationMs,
@@ -238,7 +242,7 @@ export class DefaultPerformanceTracker implements PerformanceTracker {
   private operationStarts: Map<string, number> = new Map();
 
   startOperation(name: string): void {
-    this.operationStarts.set(name, Date.now());
+    this.operationStarts.set(name, this.timer.now());
   }
 
   endOperation(name: string): void {
@@ -248,7 +252,7 @@ export class DefaultPerformanceTracker implements PerformanceTracker {
     }
     this.operationStarts.delete(name);
 
-    const durationMs = Date.now() - startMs;
+    const durationMs = this.timer.now() - startMs;
     const entry: TimingEntry = { name, durationMs };
 
     if (Array.isArray(this.current.entries)) {
@@ -318,8 +322,8 @@ export class NoOpPerformanceTracker implements PerformanceTracker {
 /**
  * Factory function to create appropriate tracker based on enabled flag
  */
-export function createPerformanceTracker(enabled: boolean): PerformanceTracker {
-  return enabled ? new DefaultPerformanceTracker() : new NoOpPerformanceTracker();
+export function createPerformanceTracker(enabled: boolean, timer: Timer = defaultTimer): PerformanceTracker {
+  return enabled ? new DefaultPerformanceTracker(timer) : new NoOpPerformanceTracker();
 }
 
 /**

--- a/src/utils/screenshot/ScreenshotCache.ts
+++ b/src/utils/screenshot/ScreenshotCache.ts
@@ -2,6 +2,7 @@ import fs from "fs-extra";
 import path from "path";
 import { logger } from "../logger";
 import { readFileAsync, readdirAsync } from "../io";
+import { Timer, defaultTimer } from "../SystemTimer";
 import { PerceptualHasher } from "./PerceptualHasher";
 
 export class ScreenshotCache {
@@ -13,11 +14,15 @@ export class ScreenshotCache {
   /**
    * Get screenshot from cache or load from disk
    * @param filePath Path to screenshot file
+   * @param timer Optional timer for testing
    * @returns Promise with screenshot buffer and perceptual hash
    */
-  static async getCachedScreenshot(filePath: string): Promise<{ buffer: Buffer; hash: string }> {
+  static async getCachedScreenshot(
+    filePath: string,
+    timer: Timer = defaultTimer
+  ): Promise<{ buffer: Buffer; hash: string }> {
     const normalizedPath = path.normalize(filePath);
-    const now = Date.now();
+    const now = timer.now();
 
     // Check memory cache first
     const cached = ScreenshotCache.screenshotCache.get(normalizedPath);
@@ -64,6 +69,13 @@ export class ScreenshotCache {
       hash,
       lastAccess: timestamp
     });
+  }
+
+  /**
+   * Clear the in-memory cache (useful for tests)
+   */
+  static clearCache(): void {
+    ScreenshotCache.screenshotCache.clear();
   }
 
   /**

--- a/test/daemon/sessionManager.test.ts
+++ b/test/daemon/sessionManager.test.ts
@@ -1,11 +1,15 @@
 import { describe, expect, test, beforeEach, afterEach } from "bun:test";
 import { SessionManager } from "../../src/daemon/sessionManager";
+import { FakeTimer } from "../fakes/FakeTimer";
 
 describe("SessionManager", () => {
   let sessionManager: SessionManager;
+  let fakeTimer: FakeTimer;
 
   beforeEach(() => {
-    sessionManager = new SessionManager();
+    fakeTimer = new FakeTimer();
+    fakeTimer.setManualMode();
+    sessionManager = new SessionManager(fakeTimer);
   });
 
   afterEach(() => {
@@ -32,13 +36,10 @@ describe("SessionManager", () => {
     });
 
     test("should set correct expiration time for session", async () => {
-      const beforeCreate = Date.now();
+      const beforeCreate = fakeTimer.now();
       const session = await sessionManager.createSession("session-1", "emulator-5554");
-      const afterCreate = Date.now();
-      const expectedMinExpiry = beforeCreate + 30 * 60 * 1000; // 30 minutes
-      const expectedMaxExpiry = afterCreate + 30 * 60 * 1000;
-      expect(session.expiresAt).toBeGreaterThanOrEqual(expectedMinExpiry);
-      expect(session.expiresAt).toBeLessThanOrEqual(expectedMaxExpiry);
+      const expectedExpiry = beforeCreate + 30 * 60 * 1000; // 30 minutes
+      expect(session.expiresAt).toBe(expectedExpiry);
     });
   });
 
@@ -54,10 +55,10 @@ describe("SessionManager", () => {
       const session1 = await sessionManager.createSession("session-1", "emulator-5554");
       const initialLastUsed = session1.lastUsedAt;
       const initialExpiry = session1.expiresAt;
-      await new Promise(resolve => setTimeout(resolve, 10)); // Small delay
+      fakeTimer.advanceTime(10);
       const session2 = await sessionManager.getOrCreateSession("session-1");
-      expect(session2.lastUsedAt).toBeGreaterThanOrEqual(initialLastUsed);
-      expect(session2.expiresAt).toBeGreaterThan(initialExpiry);
+      expect(session2.lastUsedAt).toBe(initialLastUsed + 10);
+      expect(session2.expiresAt).toBe(initialExpiry + 10);
     });
 
     test("should throw error for non-existent session without device pool", async () => {
@@ -73,7 +74,8 @@ describe("SessionManager", () => {
     test("should return null session when expired session requested", async () => {
       const session = await sessionManager.createSession("session-1", "emulator-5554");
       // Force expiration by setting expiresAt to past
-      const oneSecondAgo = Date.now() - 1000;
+      fakeTimer.advanceTime(2000);
+      const oneSecondAgo = fakeTimer.now() - 1000;
       (session as any).expiresAt = oneSecondAgo;
       const retrieved = sessionManager.getSession("session-1");
       expect(retrieved).toBeNull();
@@ -99,11 +101,11 @@ describe("SessionManager", () => {
       });
       const session1 = sessionManager.getSession("session-1");
       const initialLastUsed = session1?.lastUsedAt ?? 0;
-      await new Promise(resolve => setTimeout(resolve, 10));
+      fakeTimer.advanceTime(10);
       const cache = sessionManager.getSessionCache("session-1");
       const session2 = sessionManager.getSession("session-1");
       expect(cache?.customData).toEqual({ key: "value" });
-      expect((session2?.lastUsedAt ?? 0)).toBeGreaterThan(initialLastUsed);
+      expect((session2?.lastUsedAt ?? 0)).toBe(initialLastUsed + 10);
     });
 
     test("should clear specific cache key", async () => {

--- a/test/features/action/Shake.test.ts
+++ b/test/features/action/Shake.test.ts
@@ -17,7 +17,7 @@ describe("Shake", () => {
 
   // Helper function to create mock ObserveResult
   const createObserveResult = (): ObserveResult => ({
-    timestamp: Date.now(),
+    timestamp: 1700000000000,
     screenSize: { width: 1080, height: 1920 },
     systemInsets: { top: 0, bottom: 0, left: 0, right: 0 },
     viewHierarchy: { node: {} }
@@ -57,11 +57,6 @@ describe("Shake", () => {
 
       // Start the execution
       const resultPromise = shake.execute();
-
-      // Wait a bit for sleep to be called, then resolve all pending sleeps
-      await new Promise(resolve => setTimeout(resolve, 10));
-      fakeTimer.resolveAll();
-
       const result = await resultPromise;
 
       expect(result.success).toBe(true);
@@ -85,8 +80,6 @@ describe("Shake", () => {
       fakeObserveScreen.setObserveResult(mockObservation);
 
       const resultPromise = shake.execute({ duration: 100 }); // Reduced for faster test
-      await new Promise(resolve => setTimeout(resolve, 10));
-      fakeTimer.resolveAll();
       const result = await resultPromise;
 
       expect(result.success).toBe(true);
@@ -102,8 +95,6 @@ describe("Shake", () => {
       fakeObserveScreen.setObserveResult(mockObservation);
 
       const resultPromise = shake.execute({ intensity: 200, duration: 100 }); // Reduced duration
-      await new Promise(resolve => setTimeout(resolve, 10));
-      fakeTimer.resolveAll();
       const result = await resultPromise;
 
       expect(result.success).toBe(true);
@@ -118,8 +109,6 @@ describe("Shake", () => {
       fakeObserveScreen.setObserveResult(mockObservation);
 
       const resultPromise = shake.execute({ duration: 100, intensity: 150 }); // Reduced duration
-      await new Promise(resolve => setTimeout(resolve, 10));
-      fakeTimer.resolveAll();
       const result = await resultPromise;
 
       expect(result.success).toBe(true);
@@ -134,8 +123,6 @@ describe("Shake", () => {
       fakeObserveScreen.setObserveResult(mockObservation);
 
       const resultPromise = shake.execute({});
-      await new Promise(resolve => setTimeout(resolve, 10));
-      fakeTimer.resolveAll();
       const result = await resultPromise;
 
       expect(result.success).toBe(true);
@@ -153,8 +140,6 @@ describe("Shake", () => {
       fakeObserveScreen.setObserveResult(mockObservation);
 
       const resultPromise = shake.execute({ duration: 0 });
-      await new Promise(resolve => setTimeout(resolve, 10));
-      fakeTimer.resolveAll();
       const result = await resultPromise;
 
       expect(result.success).toBe(true);
@@ -168,8 +153,6 @@ describe("Shake", () => {
       fakeObserveScreen.setObserveResult(mockObservation);
 
       const resultPromise = shake.execute({ intensity: 0, duration: 100 });
-      await new Promise(resolve => setTimeout(resolve, 10));
-      fakeTimer.resolveAll();
       const result = await resultPromise;
 
       expect(result.success).toBe(true);
@@ -188,8 +171,6 @@ describe("Shake", () => {
         callbackCalled = true;
       };
       const resultPromise = shake.execute({ duration: 50 }, progressCallback);
-      await new Promise(resolve => setTimeout(resolve, 10));
-      fakeTimer.resolveAll();
       const result = await resultPromise;
 
       expect(result.success).toBe(true);
@@ -205,8 +186,6 @@ describe("Shake", () => {
 
       try {
         const resultPromise = shake.execute({ duration: 100 });
-        await new Promise(resolve => setTimeout(resolve, 10));
-        fakeTimer.resolveAll();
         const result = await resultPromise;
         // If we get here, command succeeded despite fake error
         expect(result.duration).toBe(100);
@@ -226,8 +205,6 @@ describe("Shake", () => {
 
       try {
         const resultPromise = shake.execute({ duration: 50 }); // Very short duration
-        await new Promise(resolve => setTimeout(resolve, 10));
-        fakeTimer.resolveAll();
         const result = await resultPromise;
         // If we get here, BaseVisualChange caught the error
         expect(result).toBeDefined();
@@ -266,8 +243,6 @@ describe("Shake", () => {
       const duration = 100;
 
       const resultPromise = shake.execute({ duration });
-      await new Promise(resolve => setTimeout(resolve, 10));
-      fakeTimer.resolveAll();
       const result = await resultPromise;
 
       expect(result.success).toBe(true);
@@ -287,8 +262,6 @@ describe("Shake", () => {
       fakeObserveScreen.setObserveResult(mockObservation);
 
       const resultPromise = shake.execute({ intensity: 9999, duration: 100 });
-      await new Promise(resolve => setTimeout(resolve, 10));
-      fakeTimer.resolveAll();
       const result = await resultPromise;
 
       expect(result.success).toBe(true);
@@ -306,8 +279,6 @@ describe("Shake", () => {
 
       // Use shorter duration to avoid test timeout
       const resultPromise = shake.execute({ duration: 200 });
-      await new Promise(resolve => setTimeout(resolve, 10));
-      fakeTimer.resolveAll();
       const result = await resultPromise;
 
       expect(result.success).toBe(true);
@@ -325,8 +296,6 @@ describe("Shake", () => {
       fakeObserveScreen.setObserveResult(mockObservation);
 
       const resultPromise = shake.execute({ duration: 100, intensity: -50 }); // Use positive duration
-      await new Promise(resolve => setTimeout(resolve, 10));
-      fakeTimer.resolveAll();
       const result = await resultPromise;
 
       expect(result.success).toBe(true);

--- a/test/features/observe/TakeScreenshot.test.ts
+++ b/test/features/observe/TakeScreenshot.test.ts
@@ -3,6 +3,7 @@ import { TakeScreenshot } from "../../../src/features/observe/TakeScreenshot";
 import { BootedDevice } from "../../../src/models/DeviceInfo";
 import { FakeAdbExecutor } from "../../fakes/FakeAdbExecutor";
 import { FakeFileSystem } from "../../fakes/FakeFileSystem";
+import { FakeTimer } from "../../fakes/FakeTimer";
 
 describe("TakeScreenshot", function() {
   describe("Unit Tests for Extracted Methods", function() {
@@ -44,13 +45,14 @@ describe("TakeScreenshot", function() {
     });
 
     test("should generate different timestamps for consecutive calls", async function() {
-      const timestamp1 = Date.now();
+      const fakeTimer = new FakeTimer();
+      fakeTimer.setManualMode();
+      const timestamp1 = fakeTimer.now();
       const options = { format: "png" as const };
 
       const result1 = takeScreenshot.generateScreenshotPath(timestamp1, options);
-      // Add a small delay to ensure different timestamps
-      await new Promise(resolve => setTimeout(resolve, 10));
-      const timestamp2 = Date.now();
+      fakeTimer.advanceTime(1);
+      const timestamp2 = fakeTimer.now();
       const result2 = takeScreenshot.generateScreenshotPath(timestamp2, options);
 
       expect(result1).not.toBe(result2);

--- a/test/server/deepLinkTools.test.ts
+++ b/test/server/deepLinkTools.test.ts
@@ -2,22 +2,29 @@ import { expect, describe, test, beforeEach, afterEach, beforeAll } from "bun:te
 import { registerDeepLinkTools } from "../../src/server/deepLinkTools";
 import { ToolRegistry } from "../../src/server/toolRegistry";
 import { MultiPlatformDeviceManager } from "../../src/utils/deviceUtils";
+import { FakeTimer } from "../fakes/FakeTimer";
 
 // Helper function to check if AVDs are available
 async function checkAvdAvailability(): Promise<boolean> {
   try {
     // Add timeout to prevent hanging in CI when Android SDK is not available
+    const fakeTimer = new FakeTimer();
+    fakeTimer.setManualMode();
+
     const timeoutPromise = new Promise<boolean>(resolve => {
-      setTimeout(() => resolve(false), 2000); // 2 second timeout
+      fakeTimer.setTimeout(() => resolve(false), 2000); // 2 second timeout
     });
 
     const checkPromise = (async () => {
       const deviceUtils = new MultiPlatformDeviceManager();
       const avds = await deviceUtils.listDeviceImages("android");
       return avds.length > 0;
-    })();
+    })().catch(() => false);
 
-    return await Promise.race([checkPromise, timeoutPromise]);
+    const racePromise = Promise.race([checkPromise, timeoutPromise]);
+    await Promise.resolve();
+    fakeTimer.advanceTime(2000);
+    return await racePromise;
   } catch (error) {
     // If we can't list AVDs (e.g., Android SDK not available), return false
     return false;

--- a/test/utils/PerformanceTracker.test.ts
+++ b/test/utils/PerformanceTracker.test.ts
@@ -13,13 +13,17 @@ import {
   setMaxPerfTimingSizeBytes,
   getMaxPerfTimingSizeBytes
 } from "../../src/utils/PerformanceTracker";
+import { FakeTimer } from "../fakes/FakeTimer";
 
 describe("PerformanceTracker", function() {
   describe("PerformanceTracker (enabled)", function() {
     let tracker: PerformanceTracker;
+    let fakeTimer: FakeTimer;
 
     beforeEach(function() {
-      tracker = new DefaultPerformanceTracker();
+      fakeTimer = new FakeTimer();
+      fakeTimer.setManualMode();
+      tracker = new DefaultPerformanceTracker(fakeTimer);
     });
 
     test("should be enabled", function() {
@@ -27,16 +31,18 @@ describe("PerformanceTracker", function() {
     });
 
     test("should track a simple operation", async function() {
-      await tracker.track("simpleOp", async () => {
-        await sleep(10);
+      const resultPromise = tracker.track("simpleOp", async () => {
+        await fakeTimer.sleep(10);
         return "result";
       });
+      fakeTimer.advanceTime(10);
+      await resultPromise;
 
       const timings = tracker.getTimings() as TimingEntry[];
       expect(Array.isArray(timings)).toBe(true);
       expect(timings).toHaveLength(1);
       expect(timings[0].name).toBe("simpleOp");
-      expect(timings[0].durationMs).toBeGreaterThanOrEqual(9);
+      expect(timings[0].durationMs).toBe(10);
     });
 
     test("should return function result from track", async function() {
@@ -50,9 +56,9 @@ describe("PerformanceTracker", function() {
     test("should track serial operations as array", async function() {
       tracker.serial("serialBlock");
 
-      await tracker.track("step1", async () => sleep(5));
-      await tracker.track("step2", async () => sleep(5));
-      await tracker.track("step3", async () => sleep(5));
+      await trackWithDelay(fakeTimer, tracker, "step1", 5);
+      await trackWithDelay(fakeTimer, tracker, "step2", 5);
+      await trackWithDelay(fakeTimer, tracker, "step3", 5);
 
       tracker.end();
 
@@ -74,11 +80,17 @@ describe("PerformanceTracker", function() {
     test("should track parallel operations as object", async function() {
       tracker.parallel("parallelBlock");
 
-      await Promise.all([
-        tracker.track("opA", async () => sleep(5)),
-        tracker.track("opB", async () => sleep(5)),
-        tracker.track("opC", async () => sleep(5)),
-      ]);
+      const opA = tracker.track("opA", async () => {
+        await fakeTimer.sleep(5);
+      });
+      const opB = tracker.track("opB", async () => {
+        await fakeTimer.sleep(5);
+      });
+      const opC = tracker.track("opC", async () => {
+        await fakeTimer.sleep(5);
+      });
+      fakeTimer.advanceTime(5);
+      await Promise.all([opA, opB, opC]);
 
       tracker.end();
 
@@ -100,16 +112,20 @@ describe("PerformanceTracker", function() {
     test("should handle nested serial and parallel blocks", async function() {
       tracker.serial("outer");
 
-      await tracker.track("first", async () => sleep(2));
+      await trackWithDelay(fakeTimer, tracker, "first", 2);
 
       tracker.parallel("parallel");
-      await Promise.all([
-        tracker.track("pA", async () => sleep(5)),
-        tracker.track("pB", async () => sleep(5)),
-      ]);
+      const parallelA = tracker.track("pA", async () => {
+        await fakeTimer.sleep(5);
+      });
+      const parallelB = tracker.track("pB", async () => {
+        await fakeTimer.sleep(5);
+      });
+      fakeTimer.advanceTime(5);
+      await Promise.all([parallelA, parallelB]);
       tracker.end();
 
-      await tracker.track("last", async () => sleep(2));
+      await trackWithDelay(fakeTimer, tracker, "last", 2);
 
       tracker.end();
 
@@ -135,7 +151,7 @@ describe("PerformanceTracker", function() {
 
     test("should auto-close unclosed blocks on getTimings", async function() {
       tracker.serial("unclosed");
-      await tracker.track("op", async () => sleep(1));
+      await trackWithDelay(fakeTimer, tracker, "op", 1);
       // Don't call end()
 
       const timings = tracker.getTimings() as TimingEntry[];
@@ -454,7 +470,15 @@ describe("PerformanceTracker", function() {
   });
 });
 
-// Helper function
-function sleep(ms: number): Promise<void> {
-  return new Promise(resolve => setTimeout(resolve, ms));
+async function trackWithDelay(
+  timer: FakeTimer,
+  tracker: PerformanceTracker,
+  name: string,
+  ms: number
+): Promise<void> {
+  const promise = tracker.track(name, async () => {
+    await timer.sleep(ms);
+  });
+  timer.advanceTime(ms);
+  await promise;
 }

--- a/test/utils/screenshot-cache.test.ts
+++ b/test/utils/screenshot-cache.test.ts
@@ -1,0 +1,71 @@
+import { expect, describe, test, beforeEach, afterEach } from "bun:test";
+import fs from "fs/promises";
+import os from "os";
+import path from "path";
+import sharp from "sharp";
+import { ScreenshotCache } from "../../src/utils/screenshot/ScreenshotCache";
+import { FakeTimer } from "../fakes/FakeTimer";
+
+const CACHE_TTL_MS = 10 * 60 * 1000;
+
+describe("ScreenshotCache", function() {
+  let tempDir: string;
+  let fakeTimer: FakeTimer;
+
+  beforeEach(async function() {
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "screenshot-cache-"));
+    fakeTimer = new FakeTimer();
+    fakeTimer.setManualMode();
+    ScreenshotCache.clearCache();
+  });
+
+  afterEach(async function() {
+    ScreenshotCache.clearCache();
+    await fs.rm(tempDir, { recursive: true, force: true });
+  });
+
+  test("returns cached buffer within TTL", async function() {
+    const filePath = path.join(tempDir, "screenshot.png");
+    const buffer1 = await createTestImage({ r: 255, g: 0, b: 0 });
+    await fs.writeFile(filePath, buffer1);
+
+    const first = await ScreenshotCache.getCachedScreenshot(filePath, fakeTimer);
+
+    const buffer2 = await createTestImage({ r: 0, g: 0, b: 255 });
+    await fs.writeFile(filePath, buffer2);
+
+    const second = await ScreenshotCache.getCachedScreenshot(filePath, fakeTimer);
+
+    expect(first.buffer.equals(buffer1)).toBe(true);
+    expect(second.buffer.equals(buffer1)).toBe(true);
+    expect(second.buffer.equals(buffer2)).toBe(false);
+  });
+
+  test("reloads cache after TTL expires", async function() {
+    const filePath = path.join(tempDir, "screenshot.png");
+    const buffer1 = await createTestImage({ r: 255, g: 255, b: 255 });
+    await fs.writeFile(filePath, buffer1);
+
+    await ScreenshotCache.getCachedScreenshot(filePath, fakeTimer);
+
+    const buffer2 = await createTestImage({ r: 0, g: 255, b: 0 });
+    await fs.writeFile(filePath, buffer2);
+
+    fakeTimer.advanceTime(CACHE_TTL_MS + 1);
+
+    const refreshed = await ScreenshotCache.getCachedScreenshot(filePath, fakeTimer);
+
+    expect(refreshed.buffer.equals(buffer2)).toBe(true);
+  });
+});
+
+async function createTestImage(color: { r: number; g: number; b: number }): Promise<Buffer> {
+  return sharp({
+    create: {
+      width: 10,
+      height: 10,
+      channels: 3,
+      background: color
+    }
+  }).png().toBuffer();
+}

--- a/test/utils/screenshot-utils.test.ts
+++ b/test/utils/screenshot-utils.test.ts
@@ -4,13 +4,17 @@ import { DEFAULT_FUZZY_MATCH_TOLERANCE_PERCENT } from "../../src/utils/constants
 import fs from "fs-extra";
 import path from "path";
 import sharp from "sharp";
+import { FakeTimer } from "../fakes/FakeTimer";
 
 describe("ScreenshotUtils", function() {
   const testDir = "/tmp/test-screenshots";
+  let fakeTimer: FakeTimer;
 
   beforeEach(async function() {
     // Create test directory
     await fs.ensureDir(testDir);
+    fakeTimer = new FakeTimer();
+    fakeTimer.setManualMode();
   });
 
   afterEach(async function() {
@@ -228,7 +232,7 @@ describe("ScreenshotUtils", function() {
         }
       }).png().toBuffer();
 
-      const timestamp = Date.now();
+      const timestamp = fakeTimer.now();
       const testFilename = `screenshot_${timestamp}.png`;
       await fs.writeFile(path.join(testDir, testFilename), baseImage);
 
@@ -264,7 +268,7 @@ describe("ScreenshotUtils", function() {
       }).png().toBuffer();
 
       // Save a very different image
-      const timestamp = Date.now();
+      const timestamp = fakeTimer.now();
       await fs.writeFile(path.join(testDir, `screenshot_${timestamp}.png`), differentImage);
 
       const result = await ScreenshotUtils.findSimilarScreenshots(
@@ -313,11 +317,10 @@ describe("ScreenshotUtils", function() {
 
       // Create 10 different screenshot files
       for (let i = 0; i < 10; i++) {
-        const timestamp = Date.now() + i;
+        fakeTimer.advanceTime(1);
+        const timestamp = fakeTimer.now();
         const filename = `screenshot_${timestamp}.png`;
         await fs.writeFile(path.join(testDir, filename), testImage);
-        // Add small delay to ensure different timestamps
-        await new Promise(resolve => setTimeout(resolve, 1));
       }
 
       const result = await ScreenshotUtils.findSimilarScreenshots(


### PR DESCRIPTION
## Summary
- inject Timer usage into SessionManager and ScreenshotCache; track time via injected timer in PerformanceTracker
- remove real sleeps/Date.now usage in time-based tests by using FakeTimer or fixed timestamps
- add ScreenshotCache coverage for TTL behavior

## Testing
- bun run test
