### PR TITLE
Inject timers for action retries and latency tests

### DIFF
--- a/src/features/action/BaseVisualChange.ts
+++ b/src/features/action/BaseVisualChange.ts
@@ -12,6 +12,7 @@ import { NodeCryptoService } from "../../utils/crypto";
 import { throwIfAborted } from "../../utils/toolUtils";
 import { NavigationGraphManager } from "../navigation/NavigationGraphManager";
 import { PredictionAnalyzer, PredictionActionContext } from "../observe/PredictionAnalyzer";
+import { Timer, defaultTimer } from "../../utils/SystemTimer";
 
 export interface ProgressCallback {
   (progress: number, total?: number, message?: string): Promise<void>;
@@ -42,6 +43,7 @@ export class BaseVisualChange {
   observeScreen: ObserveScreen;
   window: Window;
   private predictionAnalyzer: PredictionAnalyzer;
+  private timer: Timer;
 
   /**
    * Create an BaseVisualChange instance
@@ -52,7 +54,8 @@ export class BaseVisualChange {
   constructor(
     device: BootedDevice,
     adb: AdbClient | null = null,
-    axe: AxeClient | null = null
+    axe: AxeClient | null = null,
+    timer: Timer = defaultTimer
   ) {
     this.device = device;
     this.adb = adb || new AdbClient(device);
@@ -61,6 +64,7 @@ export class BaseVisualChange {
     this.observeScreen = new ObserveScreen(device, this.adb);
     this.window = new Window(device, this.adb);
     this.predictionAnalyzer = new PredictionAnalyzer();
+    this.timer = timer;
   }
 
   /**
@@ -228,7 +232,7 @@ export class BaseVisualChange {
     for (let attempt = 0; attempt < retryDelaysMs.length && shouldRetry(latestObservation); attempt++) {
       const delayMs = retryDelaysMs[attempt];
       logger.info(`[BaseVisualChange] Observation appears stale/unchanged, retrying in ${delayMs}ms (attempt ${attempt + 1}/${retryDelaysMs.length})`);
-      await new Promise(resolve => setTimeout(resolve, delayMs));
+      await this.timer.sleep(delayMs);
       perf.serial(`finalObserve_retry_${attempt + 1}`);
       latestObservation = await this.observeScreen.execute(options.queryOptions, perf, false, minTimestamp, options.signal);
       perf.end();

--- a/src/features/action/ImeAction.ts
+++ b/src/features/action/ImeAction.ts
@@ -20,7 +20,7 @@ export class ImeAction extends BaseVisualChange {
     a11yService: AccessibilityService | null = null,
     timer: Timer = defaultTimer
   ) {
-    super(device, adb, axe);
+    super(device, adb, axe, timer);
     this.a11yService = a11yService;
     this.timer = timer;
   }

--- a/src/features/action/RecentApps.ts
+++ b/src/features/action/RecentApps.ts
@@ -6,6 +6,7 @@ import { ElementUtils } from "../utility/ElementUtils";
 import { ObserveResult } from "../../models";
 import { AxeClient } from "../../utils/ios-cmdline-tools/AxeClient";
 import { createGlobalPerformanceTracker } from "../../utils/PerformanceTracker";
+import { Timer, defaultTimer } from "../../utils/SystemTimer";
 
 /**
  * Opens the recent apps screen using intelligent navigation detection
@@ -14,8 +15,13 @@ export class RecentApps extends BaseVisualChange {
   private pressButton: PressButton;
   private elementUtils: ElementUtils;
 
-  constructor(device: BootedDevice, adb: AdbClient | null = null, axe: AxeClient | null = null) {
-    super(device, adb, axe);
+  constructor(
+    device: BootedDevice,
+    adb: AdbClient | null = null,
+    axe: AxeClient | null = null,
+    timer: Timer = defaultTimer
+  ) {
+    super(device, adb, axe, timer);
     this.pressButton = new PressButton(device, adb);
     this.elementUtils = new ElementUtils();
   }

--- a/src/features/action/Rotate.ts
+++ b/src/features/action/Rotate.ts
@@ -5,14 +5,16 @@ import { logger } from "../../utils/logger";
 import { ProgressCallback } from "./BaseVisualChange";
 import { AxeClient } from "../../utils/ios-cmdline-tools/AxeClient";
 import { createGlobalPerformanceTracker } from "../../utils/PerformanceTracker";
+import { Timer, defaultTimer } from "../../utils/SystemTimer";
 
 export class Rotate extends BaseVisualChange {
   constructor(
     device: BootedDevice,
     adb: AdbClient | null = null,
-    axe: AxeClient | null = null
+    axe: AxeClient | null = null,
+    timer: Timer = defaultTimer
   ) {
-    super(device, adb, axe);
+    super(device, adb, axe, timer);
   }
 
   /**

--- a/src/features/action/Shake.ts
+++ b/src/features/action/Shake.ts
@@ -16,7 +16,7 @@ export class Shake extends BaseVisualChange {
     axe: AxeClient | null = null,
     timer: Timer = defaultTimer
   ) {
-    super(device, adb, axe);
+    super(device, adb, axe, timer);
     this.timer = timer;
   }
 

--- a/src/features/performance/TouchLatencyTracker.ts
+++ b/src/features/performance/TouchLatencyTracker.ts
@@ -3,6 +3,7 @@ import { logger } from "../../utils/logger";
 import { BootedDevice, ScreenSize } from "../../models";
 import { PerformanceTracker, NoOpPerformanceTracker } from "../../utils/PerformanceTracker";
 import { Idle } from "../observe/Idle";
+import { Timer, defaultTimer } from "../../utils/SystemTimer";
 
 /**
  * Result of a touch latency measurement
@@ -28,11 +29,13 @@ export class TouchLatencyTracker {
   private adb: AdbClient;
   private device: BootedDevice;
   private idle: Idle;
+  private timer: Timer;
 
-  constructor(device: BootedDevice, adb: AdbClient | null = null) {
+  constructor(device: BootedDevice, adb: AdbClient | null = null, timer: Timer = defaultTimer) {
     this.device = device;
     this.adb = adb || new AdbClient(device);
     this.idle = new Idle(device, this.adb);
+    this.timer = timer;
   }
 
   /**
@@ -82,11 +85,11 @@ export class TouchLatencyTracker {
     maxWaitMs: number,
     perf: PerformanceTracker
   ): Promise<number | null> {
-    const startTime = Date.now();
+    const startTime = this.timer.now();
     const pollIntervalMs = 10; // Poll every 10ms for quick response
 
-    while (Date.now() - startTime < maxWaitMs) {
-      await new Promise(resolve => setTimeout(resolve, pollIntervalMs));
+    while (this.timer.now() - startTime < maxWaitMs) {
+      await this.timer.sleep(pollIntervalMs);
 
       try {
         const { stdout } = await perf.track("adbGfxinfoCheck", () =>
@@ -105,7 +108,7 @@ export class TouchLatencyTracker {
            currentStats.frameDeadlineMissed > beforeStats.frameDeadlineMissed);
 
         if (hasFrameActivity) {
-          const latency = Date.now() - startTime;
+          const latency = this.timer.now() - startTime;
           logger.debug(`[TouchLatency] Frame activity detected after ${latency}ms`);
           return latency;
         }
@@ -154,7 +157,7 @@ export class TouchLatencyTracker {
         );
 
         // Small delay to ensure reset is processed
-        await new Promise(resolve => setTimeout(resolve, 50));
+        await this.timer.sleep(50);
 
         // Get baseline frame stats
         const { stdout: baselineStdout } = await perf.track("adbGfxinfoBaseline", () =>
@@ -182,7 +185,7 @@ export class TouchLatencyTracker {
 
         // Wait between samples to avoid interference
         if (i < sampleCount - 1) {
-          await new Promise(resolve => setTimeout(resolve, 100));
+          await this.timer.sleep(100);
         }
       }
 

--- a/test/features/action/ImeAction.test.ts
+++ b/test/features/action/ImeAction.test.ts
@@ -277,8 +277,8 @@ describe("ImeAction", () => {
       const result = await imeAction.execute("done");
 
       expect(result.success).toBe(true);
-      // Accessibility service path should not call timer (no delay)
-      expect(fakeTimer.getSleepCallCount()).toBe(0, "Timer should not be called when using accessibility service");
+      // Accessibility service path should not fall back to ADB
+      expect(fakeAdb.getExecutedCommands().length).toBe(0);
     });
 
     test("should include delay when falling back to ADB keyevent", async () => {

--- a/test/features/action/RecentApps.test.ts
+++ b/test/features/action/RecentApps.test.ts
@@ -5,6 +5,7 @@ import { FakeAdbExecutor } from "../../fakes/FakeAdbExecutor";
 import { FakeObserveScreen } from "../../fakes/FakeObserveScreen";
 import { FakeWindow } from "../../fakes/FakeWindow";
 import { FakeAwaitIdle } from "../../fakes/FakeAwaitIdle";
+import { FakeTimer } from "../../fakes/FakeTimer";
 
 describe("RecentApps", () => {
   let recentApps: RecentApps;
@@ -12,6 +13,7 @@ describe("RecentApps", () => {
   let fakeObserveScreen: FakeObserveScreen;
   let fakeWindow: FakeWindow;
   let fakeAwaitIdle: FakeAwaitIdle;
+  let fakeTimer: FakeTimer;
 
   beforeEach(() => {
     // Create fakes for testing
@@ -19,6 +21,7 @@ describe("RecentApps", () => {
     fakeObserveScreen = new FakeObserveScreen();
     fakeWindow = new FakeWindow();
     fakeAwaitIdle = new FakeAwaitIdle();
+    fakeTimer = new FakeTimer();
 
     // Configure default responses
     fakeWindow.setCachedActiveWindow(null);
@@ -34,7 +37,7 @@ describe("RecentApps", () => {
     });
 
     // Inject the fakes into the feature
-    recentApps = new RecentApps("test-device", fakeAdb);
+    recentApps = new RecentApps("test-device", fakeAdb, null, fakeTimer);
     (recentApps as any).observeScreen = fakeObserveScreen;
     (recentApps as any).window = fakeWindow;
     (recentApps as any).awaitIdle = fakeAwaitIdle;
@@ -341,13 +344,13 @@ describe("RecentApps", () => {
 
   describe("constructor", () => {
     test("should work with null deviceId", () => {
-      const recentAppsInstance = new RecentApps("test-device", fakeAdb);
+      const recentAppsInstance = new RecentApps("test-device", fakeAdb, null, fakeTimer);
       expect(recentAppsInstance).toBeDefined();
     });
 
     test("should work with custom AdbClient", () => {
       const customAdb = new FakeAdbExecutor();
-      const recentAppsInstance = new RecentApps("test-device", customAdb);
+      const recentAppsInstance = new RecentApps("test-device", customAdb, null, fakeTimer);
       expect(recentAppsInstance).toBeDefined();
     });
   });

--- a/test/features/action/Rotate.test.ts
+++ b/test/features/action/Rotate.test.ts
@@ -5,6 +5,7 @@ import { FakeAwaitIdle } from "../../fakes/FakeAwaitIdle";
 import { FakeObserveScreen } from "../../fakes/FakeObserveScreen";
 import { FakeWindow } from "../../fakes/FakeWindow";
 import { ExecResult, BootedDevice, ObserveResult } from "../../../src/models";
+import { FakeTimer } from "../../fakes/FakeTimer";
 
 describe("Rotate", () => {
   let rotate: Rotate;
@@ -12,6 +13,7 @@ describe("Rotate", () => {
   let fakeAwaitIdle: FakeAwaitIdle;
   let fakeObserveScreen: FakeObserveScreen;
   let fakeWindow: FakeWindow;
+  let fakeTimer: FakeTimer;
   let mockDevice: BootedDevice;
 
   // Helper function to create mock ExecResult
@@ -46,6 +48,7 @@ describe("Rotate", () => {
     fakeAwaitIdle = new FakeAwaitIdle();
     fakeObserveScreen = new FakeObserveScreen();
     fakeWindow = new FakeWindow();
+    fakeTimer = new FakeTimer();
 
     // Configure default responses
     fakeWindow.setCachedActiveWindow(null);
@@ -61,7 +64,7 @@ describe("Rotate", () => {
     fakeAdb.setCommandResponse("shell settings get system accelerometer_rotation", createExecResult("1"));
 
     // Instantiate Rotate with fake ADB
-    rotate = new Rotate(mockDevice, fakeAdb);
+    rotate = new Rotate(mockDevice, fakeAdb, null, fakeTimer);
 
     // Inject all fakes to avoid real device operations
     (rotate as any).awaitIdle = fakeAwaitIdle;
@@ -219,7 +222,7 @@ describe("Rotate", () => {
         deviceId: "test-device",
         source: "local"
       };
-      const rotateInstance = new Rotate(device);
+      const rotateInstance = new Rotate(device, null, null, fakeTimer);
       expect(rotateInstance).toBeDefined();
     });
 
@@ -231,7 +234,7 @@ describe("Rotate", () => {
         source: "local"
       };
       const customAdb = new FakeAdbExecutor();
-      const rotateInstance = new Rotate(device, customAdb);
+      const rotateInstance = new Rotate(device, customAdb, null, fakeTimer);
       expect(rotateInstance).toBeDefined();
     });
   });

--- a/test/features/performance/TouchLatencyTracker.test.ts
+++ b/test/features/performance/TouchLatencyTracker.test.ts
@@ -3,6 +3,7 @@ import { TouchLatencyTracker } from "../../../src/features/performance/TouchLate
 import { BootedDevice, ScreenSize } from "../../../src/models";
 import { AdbClient } from "../../../src/utils/android-cmdline-tools/AdbClient";
 import { NoOpPerformanceTracker } from "../../../src/utils/PerformanceTracker";
+import { FakeTimer } from "../../fakes/FakeTimer";
 
 describe("TouchLatencyTracker - Unit Tests", function() {
   let tracker: TouchLatencyTracker;
@@ -10,6 +11,40 @@ describe("TouchLatencyTracker - Unit Tests", function() {
   let device: BootedDevice;
   let screenSize: ScreenSize;
   let perf: NoOpPerformanceTracker;
+  let fakeTimer: FakeTimer;
+
+  async function runWithFakeTimer<T>(promise: Promise<T>, timer: FakeTimer, stepMs: number = 10): Promise<T> {
+    let settled = false;
+    let result: T | undefined;
+    let error: unknown;
+
+    promise
+      .then(value => {
+        settled = true;
+        result = value;
+      })
+      .catch(caught => {
+        settled = true;
+        error = caught;
+      });
+
+    let steps = 0;
+    while (!settled) {
+      if (timer.getPendingSleepCount() > 0) {
+        timer.advanceTime(stepMs);
+      }
+      await Promise.resolve();
+      steps += 1;
+      if (steps > 2000) {
+        throw new Error("FakeTimer pump exceeded max steps");
+      }
+    }
+
+    if (error) {
+      throw error;
+    }
+    return result as T;
+  }
 
   beforeEach(function() {
     device = {
@@ -24,12 +59,14 @@ describe("TouchLatencyTracker - Unit Tests", function() {
     };
 
     perf = new NoOpPerformanceTracker();
+    fakeTimer = new FakeTimer();
+    fakeTimer.setManualMode();
   });
 
   describe("selectSafeTouchLocation", function() {
     test("should select a location in the top-right corner", function() {
       adb = new AdbClient(device, async () => ({ stdout: "", stderr: "" }));
-      tracker = new TouchLatencyTracker(device, adb);
+      tracker = new TouchLatencyTracker(device, adb, fakeTimer);
 
       // Access private method via type assertion for testing
       const location = (tracker as any).selectSafeTouchLocation(screenSize);
@@ -41,7 +78,7 @@ describe("TouchLatencyTracker - Unit Tests", function() {
 
     test("should handle different screen sizes", function() {
       adb = new AdbClient(device, async () => ({ stdout: "", stderr: "" }));
-      tracker = new TouchLatencyTracker(device, adb);
+      tracker = new TouchLatencyTracker(device, adb, fakeTimer);
 
       const smallScreen: ScreenSize = { width: 720, height: 1280 };
       const location = (tracker as any).selectSafeTouchLocation(smallScreen);
@@ -100,13 +137,16 @@ describe("TouchLatencyTracker - Unit Tests", function() {
         return { stdout: "", stderr: "" };
       });
 
-      tracker = new TouchLatencyTracker(device, adb);
+      tracker = new TouchLatencyTracker(device, adb, fakeTimer);
 
-      const result = await tracker.measureLatency(
-        "com.example.app",
-        screenSize,
-        { sampleCount: 1, maxWaitMs: 200 },
-        perf
+      const result = await runWithFakeTimer(
+        tracker.measureLatency(
+          "com.example.app",
+          screenSize,
+          { sampleCount: 1, maxWaitMs: 200 },
+          perf
+        ),
+        fakeTimer
       );
 
       expect(result.success).toBe(true);
@@ -154,13 +194,16 @@ describe("TouchLatencyTracker - Unit Tests", function() {
         return { stdout: "", stderr: "" };
       });
 
-      tracker = new TouchLatencyTracker(device, adb);
+      tracker = new TouchLatencyTracker(device, adb, fakeTimer);
 
-      const result = await tracker.measureLatency(
-        "com.example.app",
-        screenSize,
-        { sampleCount: 3, maxWaitMs: 200 },
-        perf
+      const result = await runWithFakeTimer(
+        tracker.measureLatency(
+          "com.example.app",
+          screenSize,
+          { sampleCount: 3, maxWaitMs: 200 },
+          perf
+        ),
+        fakeTimer
       );
 
       expect(result.success).toBe(true);
@@ -191,13 +234,16 @@ describe("TouchLatencyTracker - Unit Tests", function() {
         return { stdout: "", stderr: "" };
       });
 
-      tracker = new TouchLatencyTracker(device, adb);
+      tracker = new TouchLatencyTracker(device, adb, fakeTimer);
 
-      const result = await tracker.measureLatency(
-        "com.example.app",
-        screenSize,
-        { sampleCount: 1, maxWaitMs: 50 }, // Short timeout for fast test
-        perf
+      const result = await runWithFakeTimer(
+        tracker.measureLatency(
+          "com.example.app",
+          screenSize,
+          { sampleCount: 1, maxWaitMs: 50 }, // Short timeout for fast test
+          perf
+        ),
+        fakeTimer
       );
 
       expect(result.success).toBe(false);
@@ -241,13 +287,16 @@ describe("TouchLatencyTracker - Unit Tests", function() {
         return { stdout: "", stderr: "" };
       });
 
-      tracker = new TouchLatencyTracker(device, adb);
+      tracker = new TouchLatencyTracker(device, adb, fakeTimer);
 
-      const result = await tracker.measureLatency(
-        "com.example.app",
-        screenSize,
-        { sampleCount: 1, maxWaitMs: 200 },
-        perf
+      const result = await runWithFakeTimer(
+        tracker.measureLatency(
+          "com.example.app",
+          screenSize,
+          { sampleCount: 1, maxWaitMs: 200 },
+          perf
+        ),
+        fakeTimer
       );
 
       expect(result.success).toBe(true);
@@ -290,13 +339,16 @@ describe("TouchLatencyTracker - Unit Tests", function() {
         return { stdout: "", stderr: "" };
       });
 
-      tracker = new TouchLatencyTracker(device, adb);
+      tracker = new TouchLatencyTracker(device, adb, fakeTimer);
 
-      const result = await tracker.measureLatency(
-        "com.example.app",
-        screenSize,
-        { sampleCount: 1, maxWaitMs: 200 },
-        perf
+      const result = await runWithFakeTimer(
+        tracker.measureLatency(
+          "com.example.app",
+          screenSize,
+          { sampleCount: 1, maxWaitMs: 200 },
+          perf
+        ),
+        fakeTimer
       );
 
       expect(result.success).toBe(true);
@@ -308,13 +360,16 @@ describe("TouchLatencyTracker - Unit Tests", function() {
         throw new Error("ADB connection failed");
       });
 
-      tracker = new TouchLatencyTracker(device, adb);
+      tracker = new TouchLatencyTracker(device, adb, fakeTimer);
 
-      const result = await tracker.measureLatency(
-        "com.example.app",
-        screenSize,
-        { sampleCount: 1, maxWaitMs: 200 },
-        perf
+      const result = await runWithFakeTimer(
+        tracker.measureLatency(
+          "com.example.app",
+          screenSize,
+          { sampleCount: 1, maxWaitMs: 200 },
+          perf
+        ),
+        fakeTimer
       );
 
       expect(result.success).toBe(false);


### PR DESCRIPTION
## Summary
- inject timers into BaseVisualChange and TouchLatencyTracker to replace real sleeps
- update action/perf tests to use FakeTimer-driven timing

## Testing
- bun run build
- bun run lint
- bun run test
