### PR TITLE
feat(android): capture logcat Displayed startup metrics

### DIFF
--- a/docs/design-docs/mcp/observation.md
+++ b/docs/design-docs/mcp/observation.md
@@ -66,7 +66,7 @@ All collected data is assembled into an object containing (fields may be omitted
 - `focusedElement`: currently focused UI element (if any)
 - `intentChooserDetected`: whether a system intent chooser is visible
 - `wakefulness` and `backStack`: Android-specific state
-- `perfTiming`, `performanceAudit`, and `accessibilityAudit`: present when the relevant modes are enabled
+- `perfTiming`, `displayedTimeMetrics` (Android launchApp "Displayed" startup timings), `performanceAudit`, and `accessibilityAudit`: present when the relevant modes are enabled
 - `error`: error messages encountered during observation
 
 The observation gracefully handles various error conditions:

--- a/src/features/action/LaunchApp.ts
+++ b/src/features/action/LaunchApp.ts
@@ -9,6 +9,8 @@ import { AxeClient } from "../../utils/ios-cmdline-tools/AxeClient";
 import { ListInstalledApps } from "../observe/ListInstalledApps";
 import { SimCtlClient } from "../../utils/ios-cmdline-tools/SimCtlClient";
 import { createGlobalPerformanceTracker, PerformanceTracker } from "../../utils/PerformanceTracker";
+import { DisplayedTimeMetricsCollector } from "../performance/DisplayedTimeMetricsCollector";
+import { serverConfig } from "../../utils/ServerConfig";
 
 export type ForegroundCheckMode = "parallel" | "single";
 
@@ -381,8 +383,20 @@ export class LaunchApp extends BaseVisualChange {
 
     logger.info(`[LaunchApp] Proceeding with app launch`);
 
-    return this.observedInteraction(
+    const captureDisplayedMetrics = serverConfig.isUiPerfModeEnabled();
+    const displayedMetricsCollector = captureDisplayedMetrics
+      ? new DisplayedTimeMetricsCollector(this.device, this.adb)
+      : null;
+    let displayedMetricsStartMs: number | null = null;
+
+    const launchResult = await this.observedInteraction(
       async () => {
+        if (displayedMetricsCollector) {
+          displayedMetricsStartMs = await perf.track(
+            "displayedLogcatStartTime",
+            () => this.adb.getDeviceTimestampMs()
+          );
+        }
         return this.performLaunch(packageName, activityName, targetUserId, perf);
       },
       {
@@ -392,6 +406,24 @@ export class LaunchApp extends BaseVisualChange {
         skipUiStability: skipUiStability ?? false
       }
     );
+
+    if (displayedMetricsCollector && displayedMetricsStartMs !== null && launchResult?.observation) {
+      const displayedMetricsEndMs = await perf.track(
+        "displayedLogcatEndTime",
+        () => this.adb.getDeviceTimestampMs()
+      );
+      const displayedTimeMetrics = await displayedMetricsCollector.captureDisplayedMetrics(
+        {
+          packageName,
+          startTimestampMs: displayedMetricsStartMs,
+          endTimestampMs: displayedMetricsEndMs
+        },
+        perf
+      );
+      launchResult.observation.displayedTimeMetrics = displayedTimeMetrics;
+    }
+
+    return launchResult;
   }
 
   /**

--- a/src/features/performance/DisplayedTimeMetricsCollector.ts
+++ b/src/features/performance/DisplayedTimeMetricsCollector.ts
@@ -1,0 +1,183 @@
+import { AdbClient } from "../../utils/android-cmdline-tools/AdbClient";
+import { logger } from "../../utils/logger";
+import { BootedDevice, DisplayedLogcatTag, DisplayedTimeMetric } from "../../models";
+import { NoOpPerformanceTracker, PerformanceTracker } from "../../utils/PerformanceTracker";
+
+export interface DisplayedTimeCaptureOptions {
+  packageName: string;
+  startTimestampMs: number;
+  endTimestampMs: number;
+}
+
+export class DisplayedTimeMetricsCollector {
+  private adb: AdbClient;
+  private device: BootedDevice;
+  private logcatTagCache: DisplayedLogcatTag | undefined;
+
+  constructor(device: BootedDevice, adb: AdbClient | null = null) {
+    this.device = device;
+    this.adb = adb || new AdbClient(device);
+  }
+
+  async captureDisplayedMetrics(
+    options: DisplayedTimeCaptureOptions,
+    perf: PerformanceTracker = new NoOpPerformanceTracker()
+  ): Promise<DisplayedTimeMetric[]> {
+    if (this.device.platform !== "android") {
+      return [];
+    }
+
+    const logcatTag = await this.getPreferredLogcatTag();
+    try {
+      const { stdout } = await perf.track("adbLogcatDisplayed", () =>
+        this.adb.executeCommand(
+          this.buildLogcatCommand(logcatTag),
+          5000,
+          1024 * 1024
+        )
+      );
+      return this.parseDisplayedMetrics(stdout, options);
+    } catch (error) {
+      logger.warn(`[DisplayedTimeMetrics] Failed to read logcat: ${error}`);
+      return [];
+    }
+  }
+
+  private async getPreferredLogcatTag(): Promise<DisplayedLogcatTag> {
+    if (this.logcatTagCache) {
+      return this.logcatTagCache;
+    }
+
+    const apiLevel = await this.adb.getAndroidApiLevel();
+    this.logcatTagCache = apiLevel !== null && apiLevel >= 29
+      ? "ActivityTaskManager"
+      : "ActivityManager";
+    return this.logcatTagCache;
+  }
+
+  private buildLogcatCommand(tag: DisplayedLogcatTag): string {
+    return `shell logcat -d -v epoch -s ${tag}:I`;
+  }
+
+  private parseDisplayedMetrics(
+    output: string,
+    options: DisplayedTimeCaptureOptions
+  ): DisplayedTimeMetric[] {
+    const metrics: DisplayedTimeMetric[] = [];
+    const lines = output.split("\n");
+
+    for (const line of lines) {
+      const parsedLine = this.parseLogcatLine(line);
+      if (!parsedLine) {
+        continue;
+      }
+
+      const { timestampMs, logcatTag, message } = parsedLine;
+
+      if (timestampMs < options.startTimestampMs || timestampMs > options.endTimestampMs) {
+        continue;
+      }
+
+      const component = this.extractComponentName(message);
+      if (!component) {
+        continue;
+      }
+
+      const componentInfo = this.parseComponent(component);
+      if (componentInfo.packageName !== options.packageName) {
+        continue;
+      }
+
+      const displayedTimeMs = this.extractDisplayedDurationMs(message);
+      if (displayedTimeMs === null) {
+        continue;
+      }
+
+      metrics.push({
+        packageName: componentInfo.packageName,
+        activityName: componentInfo.activityName,
+        componentName: componentInfo.componentName,
+        displayedTimeMs,
+        timestampMs,
+        logcatTag
+      });
+    }
+
+    return metrics;
+  }
+
+  private parseLogcatLine(
+    line: string
+  ): { timestampMs: number; logcatTag: DisplayedLogcatTag; message: string } | null {
+    const match = line.match(/^(\d+\.\d+)\s+\d+\s+\d+\s+[VDIWEF]\s+(\w+):\s+(.*)$/);
+    if (!match) {
+      return null;
+    }
+
+    const timestampSeconds = Number.parseFloat(match[1]);
+    if (Number.isNaN(timestampSeconds)) {
+      return null;
+    }
+
+    const logcatTag = match[2] as DisplayedLogcatTag;
+    if (logcatTag !== "ActivityManager" && logcatTag !== "ActivityTaskManager") {
+      return null;
+    }
+
+    return {
+      timestampMs: Math.round(timestampSeconds * 1000),
+      logcatTag,
+      message: match[3]
+    };
+  }
+
+  private extractComponentName(message: string): string | null {
+    const match = message.match(/Displayed\s+([^:]+):/);
+    return match ? match[1].trim() : null;
+  }
+
+  private parseComponent(component: string): { packageName: string; activityName: string; componentName: string } {
+    const [packageName, activityPart] = component.split("/");
+    let activityName = activityPart ?? "";
+
+    if (activityName.startsWith(".")) {
+      activityName = `${packageName}${activityName}`;
+    }
+
+    return {
+      packageName,
+      activityName,
+      componentName: component
+    };
+  }
+
+  private extractDisplayedDurationMs(message: string): number | null {
+    const durationMatch = message.match(/\+\s*\d+(?:s\d+ms|ms|s)/);
+    if (!durationMatch) {
+      return null;
+    }
+
+    return this.parseDurationMs(durationMatch[0]);
+  }
+
+  private parseDurationMs(value: string): number | null {
+    const trimmed = value.replace("+", "").trim();
+    const secondsWithMsMatch = trimmed.match(/^(\d+)s(\d+)ms$/);
+    if (secondsWithMsMatch) {
+      return (Number.parseInt(secondsWithMsMatch[1], 10) * 1000)
+        + Number.parseInt(secondsWithMsMatch[2], 10);
+    }
+
+    const msMatch = trimmed.match(/^(\d+)ms$/);
+    if (msMatch) {
+      return Number.parseInt(msMatch[1], 10);
+    }
+
+    const secondsMatch = trimmed.match(/^(\d+)s$/);
+    if (secondsMatch) {
+      return Number.parseInt(secondsMatch[1], 10) * 1000;
+    }
+
+    return null;
+  }
+}

--- a/src/models/DisplayedTimeMetric.ts
+++ b/src/models/DisplayedTimeMetric.ts
@@ -1,0 +1,19 @@
+export type DisplayedLogcatTag = "ActivityManager" | "ActivityTaskManager";
+
+/**
+ * Android "Displayed" logcat metric for app startup timing.
+ */
+export interface DisplayedTimeMetric {
+  /** App package name extracted from the displayed component. */
+  packageName: string;
+  /** Fully qualified activity name (best effort). */
+  activityName: string;
+  /** Raw component name from logcat (e.g., com.example/.MainActivity). */
+  componentName: string;
+  /** Time to display the activity, in milliseconds. */
+  displayedTimeMs: number;
+  /** Logcat timestamp (milliseconds since epoch). */
+  timestampMs: number;
+  /** Logcat tag that emitted the entry. */
+  logcatTag: DisplayedLogcatTag;
+}

--- a/src/models/ObserveResult.ts
+++ b/src/models/ObserveResult.ts
@@ -9,6 +9,7 @@ import { BackStackInfo } from "./BackStack";
 import { PerformanceAuditResult } from "../features/performance/PerformanceAudit";
 import { AccessibilityAuditResult } from "./AccessibilityAudit";
 import { RecompositionSummary } from "./Recomposition";
+import { DisplayedTimeMetric } from "./DisplayedTimeMetric";
 
 export interface PredictionTarget {
   text?: string;
@@ -126,6 +127,9 @@ export interface ObserveResult {
 
   /** Graphics frame metrics from gfxinfo (only present when --debug-perf is enabled) */
   gfxMetrics?: GfxMetrics;
+
+  /** Android "Displayed" metrics captured during launch (when ui-perf-mode is enabled). */
+  displayedTimeMetrics?: DisplayedTimeMetric[];
 
   /**
    * Performance audit results (when UI performance audit mode is enabled)

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -7,6 +7,7 @@ export * from "./ClearAppDataResult";
 export * from "./ClearTextResult";
 export * from "./DeepLinkResult";
 export * from "./DemoModeResult";
+export * from "./DisplayedTimeMetric";
 export * from "./Device";
 export * from "./DeviceSession";
 export * from "./DragAndDropOptions";

--- a/src/utils/android-cmdline-tools/AdbClient.ts
+++ b/src/utils/android-cmdline-tools/AdbClient.ts
@@ -37,6 +37,7 @@ export class AdbClient implements AdbExecutor {
   private adbPath: string;
   private isTestMode: boolean;
   private activeProcesses: Set<ChildProcess> = new Set();
+  private apiLevelCache: number | null | undefined;
 
   // Static cache for device list
   private static deviceListCache: { devices: BootedDevice[], timestamp: number } | null = null;
@@ -203,6 +204,7 @@ export class AdbClient implements AdbExecutor {
    */
   setDevice(device: BootedDevice): void {
     this.device = device;
+    this.apiLevelCache = undefined;
   }
 
   /**
@@ -262,6 +264,31 @@ export class AdbClient implements AdbExecutor {
 
     logger.debug("[ADB] Falling back to host time for device timestamp");
     return Date.now();
+  }
+
+  /**
+   * Get the Android API level for the connected device.
+   */
+  async getAndroidApiLevel(): Promise<number | null> {
+    if (this.apiLevelCache !== undefined) {
+      return this.apiLevelCache;
+    }
+
+    try {
+      const result = await this.executeCommand(
+        "shell getprop ro.build.version.sdk",
+        undefined,
+        undefined,
+        true
+      );
+      const parsed = Number.parseInt(result.stdout.trim(), 10);
+      this.apiLevelCache = Number.isNaN(parsed) ? null : parsed;
+      return this.apiLevelCache;
+    } catch (error) {
+      logger.warn(`[ADB] Failed to read API level: ${error}`);
+      this.apiLevelCache = null;
+      return null;
+    }
   }
 
   /**

--- a/test/features/performance/DisplayedTimeMetricsCollector.test.ts
+++ b/test/features/performance/DisplayedTimeMetricsCollector.test.ts
@@ -1,0 +1,57 @@
+import { beforeEach, describe, expect, test } from "bun:test";
+import { DisplayedTimeMetricsCollector } from "../../../src/features/performance/DisplayedTimeMetricsCollector";
+
+describe("DisplayedTimeMetricsCollector - Unit Tests", function() {
+  let collector: DisplayedTimeMetricsCollector;
+
+  beforeEach(function() {
+    collector = new DisplayedTimeMetricsCollector({ deviceId: "test", name: "test", platform: "android" });
+  });
+
+  test("parses ActivityManager displayed metrics with millisecond duration", function() {
+    const output = "1694099696.789  1234  5678 I ActivityManager: Displayed com.example/.MainActivity: +824ms";
+    const result = (collector as any).parseDisplayedMetrics(output, {
+      packageName: "com.example",
+      startTimestampMs: 1694099696000,
+      endTimestampMs: 1694099697000
+    });
+
+    expect(result.length).toBe(1);
+    expect(result[0].packageName).toBe("com.example");
+    expect(result[0].activityName).toBe("com.example.MainActivity");
+    expect(result[0].displayedTimeMs).toBe(824);
+    expect(result[0].logcatTag).toBe("ActivityManager");
+  });
+
+  test("parses ActivityTaskManager displayed metrics with seconds duration", function() {
+    const output = "1694099697.123  1111  2222 I ActivityTaskManager: Displayed com.example/com.example.MainActivity: +1s234ms";
+    const result = (collector as any).parseDisplayedMetrics(output, {
+      packageName: "com.example",
+      startTimestampMs: 1694099697000,
+      endTimestampMs: 1694099698000
+    });
+
+    expect(result.length).toBe(1);
+    expect(result[0].activityName).toBe("com.example.MainActivity");
+    expect(result[0].displayedTimeMs).toBe(1234);
+    expect(result[0].logcatTag).toBe("ActivityTaskManager");
+  });
+
+  test("filters metrics by package and time window", function() {
+    const output = [
+      "1694099696.100  1234  5678 I ActivityManager: Displayed com.example/.SplashActivity: +200ms",
+      "1694099600.000  1234  5678 I ActivityManager: Displayed com.example/.OldActivity: +400ms",
+      "1694099696.200  1234  5678 I ActivityManager: Displayed com.other/.MainActivity: +300ms"
+    ].join("\n");
+
+    const result = (collector as any).parseDisplayedMetrics(output, {
+      packageName: "com.example",
+      startTimestampMs: 1694099696000,
+      endTimestampMs: 1694099697000
+    });
+
+    expect(result.length).toBe(1);
+    expect(result[0].activityName).toBe("com.example.SplashActivity");
+    expect(result[0].displayedTimeMs).toBe(200);
+  });
+});


### PR DESCRIPTION
## Summary
- capture Android logcat "Displayed" startup metrics during launchApp when `--ui-perf-mode` is enabled
- attach collected metrics to launchApp observations and document the field
- add collector unit tests and API-level selection for ActivityTaskManager/ActivityManager

## Testing
- bun run test

Fixes #311
