### PR TITLE
Speed up schema and AVD manager tests

### DIFF
--- a/src/server/deviceTools.ts
+++ b/src/server/deviceTools.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import { ToolRegistry, ProgressCallback } from "./toolRegistry";
-import { MultiPlatformDeviceManager } from "../utils/deviceUtils";
+import { MultiPlatformDeviceManager, PlatformDeviceManager } from "../utils/deviceUtils";
 import { createJSONToolResponse } from "../utils/toolUtils";
 import { ActionableError, BootedDevice, DeviceInfo, SomePlatform } from "../models";
 import { notifyBootedDeviceResourcesUpdated } from "./bootedDeviceResources";
@@ -52,11 +52,37 @@ export interface ListDeviceImagesArgs {
   platform: SomePlatform;
 }
 
+export interface DeviceToolsDependencies {
+  deviceManagerFactory: () => PlatformDeviceManager;
+}
+
+let moduleDependencies: DeviceToolsDependencies | null = null;
+
+function getDeviceToolsDependencies(): DeviceToolsDependencies {
+  if (!moduleDependencies) {
+    moduleDependencies = {
+      deviceManagerFactory: () => new MultiPlatformDeviceManager()
+    };
+  }
+  return moduleDependencies;
+}
+
+export function setDeviceToolsDependencies(deps: Partial<DeviceToolsDependencies>): void {
+  const currentDeps = getDeviceToolsDependencies();
+  moduleDependencies = {
+    deviceManagerFactory: deps.deviceManagerFactory ?? currentDeps.deviceManagerFactory
+  };
+}
+
+export function resetDeviceToolsDependencies(): void {
+  moduleDependencies = null;
+}
+
 export function registerDeviceTools() {
   // List all connected devices (physical and emulators) handler
   const listBootedDevicesHandler = async (args: ListDevicesArgs) => {
     try {
-      const deviceUtils = new MultiPlatformDeviceManager();
+      const deviceUtils = getDeviceToolsDependencies().deviceManagerFactory();
       const bootedDevices = await deviceUtils.getBootedDevices(args.platform);
 
       // Categorize devices by type
@@ -93,7 +119,7 @@ export function registerDeviceTools() {
   const listDeviceImagesHandler = async (args: ListDeviceImagesArgs) => {
     try {
 
-      const deviceUtils = new MultiPlatformDeviceManager();
+      const deviceUtils = getDeviceToolsDependencies().deviceManagerFactory();
       const imageList = await deviceUtils.listDeviceImages(args.platform);
 
       return createJSONToolResponse({
@@ -110,7 +136,7 @@ export function registerDeviceTools() {
   // Start emulator handler
   const startDeviceHandler = async (args: StartDeviceArgs, progress?: ProgressCallback) => {
     try {
-      const deviceUtils = new MultiPlatformDeviceManager();
+      const deviceUtils = getDeviceToolsDependencies().deviceManagerFactory();
       const childProcess = await deviceUtils.startDevice(args.device);
 
       if (progress) {
@@ -147,7 +173,7 @@ export function registerDeviceTools() {
 
   const killDeviceHandler = async (args: KillDeviceArgs) => {
     try {
-      const deviceUtils = new MultiPlatformDeviceManager();
+      const deviceUtils = getDeviceToolsDependencies().deviceManagerFactory();
       await deviceUtils.killDevice(args.device);
 
       // Notify that booted device resources have changed

--- a/test/server/tools/schema.test.ts
+++ b/test/server/tools/schema.test.ts
@@ -1,12 +1,25 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { createMcpServer } from "../../../src/server/index";
+import { resetDeviceToolsDependencies, setDeviceToolsDependencies } from "../../../src/server/deviceTools";
 import { ToolRegistry } from "../../../src/server/toolRegistry";
+import { DeviceInfo } from "../../../src/models";
 import { McpTestFixture } from "../../fixtures/mcpTestFixture";
+import { FakeDeviceUtils } from "../../fakes/FakeDeviceUtils";
 
 describe("MCP Tools Schema", () => {
   let fixture: McpTestFixture;
+  let fakeDeviceUtils: FakeDeviceUtils;
 
   beforeEach(async () => {
+    fakeDeviceUtils = new FakeDeviceUtils();
+    const androidDevices: DeviceInfo[] = [
+      { name: "Pixel_6_API_34", platform: "android", isRunning: false, source: "local" }
+    ];
+    fakeDeviceUtils.setDeviceImages("android", androidDevices);
+    setDeviceToolsDependencies({
+      deviceManagerFactory: () => fakeDeviceUtils
+    });
+
     fixture = new McpTestFixture();
     await fixture.setup();
   });
@@ -15,18 +28,8 @@ describe("MCP Tools Schema", () => {
     if (fixture) {
       await fixture.teardown();
     }
+    resetDeviceToolsDependencies();
   });
-
-  // Helper function to check if emulator CLI is available
-  async function checkEmulatorAvailable(): Promise<boolean> {
-    try {
-      const { execSync } = await import("child_process");
-      execSync("emulator -version", { stdio: "ignore" });
-      return true;
-    } catch (error) {
-      return false;
-    }
-  }
 
   test("should validate tool schema definitions conform to MCP standards", () => {
     createMcpServer();
@@ -70,13 +73,6 @@ describe("MCP Tools Schema", () => {
       })).optional()
     }).passthrough();
 
-    // Test listDeviceImages tool which requires emulator CLI
-    const emulatorAvailable = await checkEmulatorAvailable();
-    if (!emulatorAvailable) {
-      // Note: Bun does not support dynamic test skipping // Skip test if emulator CLI is not available
-      return;
-    }
-
     const result = await client.request({
       method: "tools/call",
       params: {
@@ -102,13 +98,6 @@ describe("MCP Tools Schema", () => {
       })).optional()
     }).passthrough();
 
-    // Test listDeviceImages without optional parameters (listDeviceImages has no required params)
-    const emulatorAvailable = await checkEmulatorAvailable();
-    if (!emulatorAvailable) {
-      // Note: Bun does not support dynamic test skipping // Skip test if emulator CLI is not available
-      return;
-    }
-
     const result = await client.request({
       method: "tools/call",
       params: {
@@ -125,13 +114,6 @@ describe("MCP Tools Schema", () => {
   test("given a request contains fields that are not defined by the schema, should return an error response", async function() {
 
     const { client } = fixture.getContext();
-
-    // Test with listDeviceImages and unknown parameter to avoid device dependency
-    const emulatorAvailable = await checkEmulatorAvailable();
-    if (!emulatorAvailable) {
-      // Note: Bun does not support dynamic test skipping // Skip test if emulator CLI is not available
-      return;
-    }
 
     try {
       const { z } = await import("zod");

--- a/test/utils/android-cmdline-tools/avdmanager.test.ts
+++ b/test/utils/android-cmdline-tools/avdmanager.test.ts
@@ -1,5 +1,6 @@
 import { expect, describe, test, beforeEach } from "bun:test";
 import { AvdManagerDependencies } from "../../../src/utils/android-cmdline-tools/avdmanager";
+import { FakeTimer } from "../../fakes/FakeTimer";
 
 describe("AVDManager", function() {
   let mockLocation: any;
@@ -103,20 +104,35 @@ describe("AVDManager", function() {
     };
   }
 
+  function createFakeTimer(): FakeTimer {
+    return new FakeTimer();
+  }
+
+  async function resolveWithFakeTimer<T>(
+    timer: FakeTimer,
+    promise: Promise<T>,
+    advanceMs: number = 0
+  ): Promise<T> {
+    await Promise.resolve();
+    timer.advanceTime(advanceMs);
+    return await promise;
+  }
+
   describe("acceptLicenses", () => {
     test("should accept licenses successfully", async () => {
       const mockDeps = createDependencies();
       const originalSpawn = mockDeps.spawn;
+      const fakeTimer = createFakeTimer();
 
       mockDeps.spawn = (command: string, args: string[], options?: any) => {
         const child: any = originalSpawn(command, args, options);
-        setTimeout(() => {
+        fakeTimer.setTimeout(() => {
           child.triggerClose(0);
         }, 0);
         return child;
       };
 
-      const result = await avdmanager.acceptLicenses(mockDeps);
+      const result = await resolveWithFakeTimer(fakeTimer, avdmanager.acceptLicenses(mockDeps));
 
       expect(result.success).toBe(true);
       expect(result.message).toBe("Android SDK licenses accepted");
@@ -125,17 +141,18 @@ describe("AVDManager", function() {
     test("should handle license acceptance failure", async () => {
       const mockDeps = createDependencies();
       const originalSpawn = mockDeps.spawn;
+      const fakeTimer = createFakeTimer();
 
       mockDeps.spawn = (command: string, args: string[], options?: any) => {
         const child: any = originalSpawn(command, args, options);
-        setTimeout(() => {
+        fakeTimer.setTimeout(() => {
           child.triggerStderr(Buffer.from("License error"));
           child.triggerClose(1);
         }, 0);
         return child;
       };
 
-      const result = await avdmanager.acceptLicenses(mockDeps);
+      const result = await resolveWithFakeTimer(fakeTimer, avdmanager.acceptLicenses(mockDeps));
 
       expect(result.success).toBe(false);
       expect(result.message).toContain("License acceptance failed");
@@ -158,10 +175,11 @@ describe("AVDManager", function() {
     test("should list system images successfully", async () => {
       const mockDeps = createDependencies();
       const originalSpawn = mockDeps.spawn;
+      const fakeTimer = createFakeTimer();
 
       mockDeps.spawn = (command: string, args: string[], options?: any) => {
         const child: any = originalSpawn(command, args, options);
-        setTimeout(() => {
+        fakeTimer.setTimeout(() => {
           const mockOutput = `
 Available Packages:
   system-images;android-33;google_apis;arm64-v8a | 9
@@ -173,7 +191,7 @@ Available Packages:
         return child;
       };
 
-      const result = await avdmanager.listSystemImages(undefined, mockDeps);
+      const result = await resolveWithFakeTimer(fakeTimer, avdmanager.listSystemImages(undefined, mockDeps));
 
       expect(result).toHaveLength(2);
       expect(result[0].packageName).toBe("system-images;android-33;google_apis;arm64-v8a");
@@ -189,10 +207,11 @@ Available Packages:
     test("should filter system images by criteria", async () => {
       const mockDeps = createDependencies();
       const originalSpawn = mockDeps.spawn;
+      const fakeTimer = createFakeTimer();
 
       mockDeps.spawn = (command: string, args: string[], options?: any) => {
         const child: any = originalSpawn(command, args, options);
-        setTimeout(() => {
+        fakeTimer.setTimeout(() => {
           const mockOutput = `
 Available Packages:
   system-images;android-33;google_apis;arm64-v8a | 9
@@ -205,10 +224,13 @@ Available Packages:
         return child;
       };
 
-      const result = await avdmanager.listSystemImages({
-        apiLevel: 33,
-        tag: "google_apis"
-      }, mockDeps);
+      const result = await resolveWithFakeTimer(
+        fakeTimer,
+        avdmanager.listSystemImages({
+          apiLevel: 33,
+          tag: "google_apis"
+        }, mockDeps)
+      );
 
       expect(result).toHaveLength(1);
       expect(result[0].apiLevel).toBe(33);
@@ -220,10 +242,11 @@ Available Packages:
     test("should create AVD successfully", async () => {
       const mockDeps = createDependencies();
       const originalSpawn = mockDeps.spawn;
+      const fakeTimer = createFakeTimer();
 
       mockDeps.spawn = (command: string, args: string[], options?: any) => {
         const child: any = originalSpawn(command, args, options);
-        setTimeout(() => {
+        fakeTimer.setTimeout(() => {
           child.triggerClose(0);
         }, 0);
         return child;
@@ -236,7 +259,7 @@ Available Packages:
         force: true
       };
 
-      const result = await avdmanager.createAvd(params, mockDeps);
+      const result = await resolveWithFakeTimer(fakeTimer, avdmanager.createAvd(params, mockDeps));
 
       expect(result.success).toBe(true);
       expect(result.avdName).toBe("test_avd");
@@ -245,10 +268,11 @@ Available Packages:
     test("should include all optional parameters", async () => {
       const mockDeps = createDependencies();
       const originalSpawn = mockDeps.spawn;
+      const fakeTimer = createFakeTimer();
 
       mockDeps.spawn = (command: string, args: string[], options?: any) => {
         const child: any = originalSpawn(command, args, options);
-        setTimeout(() => {
+        fakeTimer.setTimeout(() => {
           child.triggerClose(0);
         }, 0);
         return child;
@@ -264,7 +288,7 @@ Available Packages:
         abi: "arm64-v8a"
       };
 
-      const result = await avdmanager.createAvd(params, mockDeps);
+      const result = await resolveWithFakeTimer(fakeTimer, avdmanager.createAvd(params, mockDeps));
 
       expect(result.success).toBe(true);
     });
@@ -272,10 +296,11 @@ Available Packages:
     test("should handle AVD creation failure", async () => {
       const mockDeps = createDependencies();
       const originalSpawn = mockDeps.spawn;
+      const fakeTimer = createFakeTimer();
 
       mockDeps.spawn = (command: string, args: string[], options?: any) => {
         const child: any = originalSpawn(command, args, options);
-        setTimeout(() => {
+        fakeTimer.setTimeout(() => {
           child.triggerStderr(Buffer.from("AVD creation failed"));
           child.triggerClose(1);
         }, 0);
@@ -287,7 +312,7 @@ Available Packages:
         package: "system-images;android-33;google_apis;arm64-v8a"
       };
 
-      const result = await avdmanager.createAvd(params, mockDeps);
+      const result = await resolveWithFakeTimer(fakeTimer, avdmanager.createAvd(params, mockDeps));
 
       expect(result.success).toBe(false);
       expect(result.message).toContain("AVD creation failed");
@@ -298,16 +323,17 @@ Available Packages:
     test("should delete AVD successfully", async () => {
       const mockDeps = createDependencies();
       const originalSpawn = mockDeps.spawn;
+      const fakeTimer = createFakeTimer();
 
       mockDeps.spawn = (command: string, args: string[], options?: any) => {
         const child: any = originalSpawn(command, args, options);
-        setTimeout(() => {
+        fakeTimer.setTimeout(() => {
           child.triggerClose(0);
         }, 0);
         return child;
       };
 
-      const result = await avdmanager.deleteAvd("test_avd", mockDeps);
+      const result = await resolveWithFakeTimer(fakeTimer, avdmanager.deleteAvd("test_avd", mockDeps));
 
       expect(result.success).toBe(true);
       expect(result.message).toContain("deleted successfully");
@@ -318,10 +344,11 @@ Available Packages:
     test("should parse AVD list correctly", async () => {
       const mockDeps = createDependencies();
       const originalSpawn = mockDeps.spawn;
+      const fakeTimer = createFakeTimer();
 
       mockDeps.spawn = (command: string, args: string[], options?: any) => {
         const child: any = originalSpawn(command, args, options);
-        setTimeout(() => {
+        fakeTimer.setTimeout(() => {
           const mockOutput = `
 Available Android Virtual Devices:
     Name: test_avd_1
@@ -347,7 +374,7 @@ Available Android Virtual Devices:
         return child;
       };
 
-      const result = await avdmanager.listDeviceImages(mockDeps);
+      const result = await resolveWithFakeTimer(fakeTimer, avdmanager.listDeviceImages(mockDeps));
 
       expect(result).toHaveLength(3);
 
@@ -371,10 +398,11 @@ Available Android Virtual Devices:
     test("should parse device list correctly", async () => {
       const mockDeps = createDependencies();
       const originalSpawn = mockDeps.spawn;
+      const fakeTimer = createFakeTimer();
 
       mockDeps.spawn = (command: string, args: string[], options?: any) => {
         const child: any = originalSpawn(command, args, options);
-        setTimeout(() => {
+        fakeTimer.setTimeout(() => {
           const mockOutput = `
 Available devices:
 id: 0
@@ -395,7 +423,7 @@ id: pixel_4
         return child;
       };
 
-      const result = await avdmanager.listDevices(mockDeps);
+      const result = await resolveWithFakeTimer(fakeTimer, avdmanager.listDevices(mockDeps));
 
       expect(result).toHaveLength(3);
 
@@ -417,17 +445,21 @@ id: pixel_4
     test("should install system image successfully", async () => {
       const mockDeps = createDependencies();
       const originalSpawn = mockDeps.spawn;
+      const fakeTimer = createFakeTimer();
 
       mockDeps.spawn = (command: string, args: string[], options?: any) => {
         const child: any = originalSpawn(command, args, options);
-        setTimeout(() => {
+        fakeTimer.setTimeout(() => {
           child.triggerClose(0);
         }, 0);
         return child;
       };
 
       const packageName = "system-images;android-33;google_apis;arm64-v8a";
-      const result = await avdmanager.installSystemImage(packageName, true, mockDeps);
+      const result = await resolveWithFakeTimer(
+        fakeTimer,
+        avdmanager.installSystemImage(packageName, true, mockDeps)
+      );
 
       expect(result.success).toBe(true);
       expect(result.message).toContain("installed successfully");
@@ -436,17 +468,21 @@ id: pixel_4
     test("should install without accepting license when specified", async () => {
       const mockDeps = createDependencies();
       const originalSpawn = mockDeps.spawn;
+      const fakeTimer = createFakeTimer();
 
       mockDeps.spawn = (command: string, args: string[], options?: any) => {
         const child: any = originalSpawn(command, args, options);
-        setTimeout(() => {
+        fakeTimer.setTimeout(() => {
           child.triggerClose(0);
         }, 0);
         return child;
       };
 
       const packageName = "system-images;android-33;google_apis;arm64-v8a";
-      const result = await avdmanager.installSystemImage(packageName, false, mockDeps);
+      const result = await resolveWithFakeTimer(
+        fakeTimer,
+        avdmanager.installSystemImage(packageName, false, mockDeps)
+      );
 
       expect(result.success).toBe(true);
     });
@@ -505,16 +541,17 @@ id: pixel_4
     test("should handle command spawn errors", async () => {
       const mockDeps = createDependencies();
       const originalSpawn = mockDeps.spawn;
+      const fakeTimer = createFakeTimer();
 
       mockDeps.spawn = (command: string, args: string[], options?: any) => {
         const child: any = originalSpawn(command, args, options);
-        setTimeout(() => {
+        fakeTimer.setTimeout(() => {
           child.triggerError(new Error("Spawn failed"));
         }, 0);
         return child;
       };
 
-      const result = await avdmanager.acceptLicenses(mockDeps);
+      const result = await resolveWithFakeTimer(fakeTimer, avdmanager.acceptLicenses(mockDeps));
 
       expect(result.success).toBe(false);
       expect(result.message).toContain("Failed to spawn command");


### PR DESCRIPTION
## Summary
- add device tool dependency injection for test fakes
- switch MCP tool schema tests to FakeDeviceUtils instead of emulator CLI
- replace real timer usage in avdmanager tests with FakeTimer scheduling

## Testing
- bun run test
