### PR TITLE
Recorded plan migrations + MCP versioning

### DIFF
--- a/src/models/Plan.ts
+++ b/src/models/Plan.ts
@@ -1,12 +1,14 @@
 export interface PlanStep {
   tool: string;
   params: Record<string, any>;
+  label?: string;
 }
 
 export interface Plan {
   name: string;
   description?: string;
   steps: PlanStep[];
+  mcpVersion?: string;
   metadata?: {
     createdAt: string;
     version: string;

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -30,6 +30,7 @@ import { registerDoctorTools } from "./doctorTools";
 import { registerFeatureFlagTools } from "./featureFlagTools";
 import { registerTestTimingTools } from "./testTimingTools";
 import { registerPerformanceTools } from "./performanceTools";
+import { getMcpServerVersion } from "../utils/mcpVersion";
 
 // Import resource registration functions
 import { registerObservationResources } from "./observationResources";
@@ -105,7 +106,7 @@ export const createMcpServer = (options: McpServerOptions = {}): McpServer => {
   // Create a new MCP server
   const server = new McpServer({
     name: "AutoMobile",
-    version: "0.0.1"
+    version: getMcpServerVersion()
   }, {
     capabilities: {
       resources: {},

--- a/src/utils/mcpVersion.ts
+++ b/src/utils/mcpVersion.ts
@@ -1,0 +1,51 @@
+import fs from "fs";
+import path from "path";
+import { fileURLToPath } from "url";
+
+let cachedVersion: string | null = null;
+
+const findPackageJson = (startDir: string): string | null => {
+  let currentDir = startDir;
+  for (let depth = 0; depth < 6; depth++) {
+    const candidate = path.join(currentDir, "package.json");
+    if (fs.existsSync(candidate)) {
+      return candidate;
+    }
+    const parentDir = path.dirname(currentDir);
+    if (parentDir === currentDir) {
+      break;
+    }
+    currentDir = parentDir;
+  }
+  return null;
+};
+
+export const getMcpServerVersion = (): string => {
+  if (cachedVersion) {
+    return cachedVersion;
+  }
+
+  const envVersion = process.env.MCP_SERVER_VERSION || process.env.npm_package_version;
+  if (envVersion) {
+    cachedVersion = envVersion;
+    return envVersion;
+  }
+
+  const moduleDir = path.dirname(fileURLToPath(import.meta.url));
+  const packagePath = findPackageJson(moduleDir) ?? findPackageJson(process.cwd());
+  if (packagePath) {
+    try {
+      const raw = fs.readFileSync(packagePath, "utf-8");
+      const parsed = JSON.parse(raw) as { version?: string };
+      if (parsed.version) {
+        cachedVersion = parsed.version;
+        return parsed.version;
+      }
+    } catch {
+      // Fall through to unknown
+    }
+  }
+
+  cachedVersion = "unknown";
+  return cachedVersion;
+};

--- a/src/utils/plan/PlanMigrator.ts
+++ b/src/utils/plan/PlanMigrator.ts
@@ -1,0 +1,359 @@
+import { getMcpServerVersion } from "../mcpVersion";
+
+type MigrationWarning = {
+  message: string;
+  stepIndex?: number;
+};
+
+export type PlanMigrationReport = {
+  appliedMigrations: string[];
+  warnings: MigrationWarning[];
+  originalVersion: string;
+  targetVersion: string;
+  migrated: boolean;
+  outdated: boolean;
+};
+
+const parseVersion = (version: string | undefined): number[] | null => {
+  if (!version || version === "unknown" || version === "latest") {
+    return null;
+  }
+  const numericParts = version.split(".").map(part => parseInt(part.replace(/\D/g, ""), 10));
+  if (numericParts.some(part => Number.isNaN(part))) {
+    return null;
+  }
+  return numericParts.slice(0, 3);
+};
+
+const isOlderVersion = (version: string | undefined, target: string): boolean => {
+  const parsedVersion = parseVersion(version);
+  const parsedTarget = parseVersion(target);
+  if (!parsedVersion || !parsedTarget) {
+    return true;
+  }
+  const length = Math.max(parsedVersion.length, parsedTarget.length);
+  for (let i = 0; i < length; i++) {
+    const current = parsedVersion[i] ?? 0;
+    const targetPart = parsedTarget[i] ?? 0;
+    if (current < targetPart) {
+      return true;
+    }
+    if (current > targetPart) {
+      return false;
+    }
+  }
+  return false;
+};
+
+const isRecord = (value: unknown): value is Record<string, any> => {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+};
+
+const recordWarning = (
+  warnings: MigrationWarning[],
+  message: string,
+  stepIndex?: number
+): void => {
+  warnings.push(stepIndex === undefined ? { message } : { message, stepIndex });
+};
+
+const ensureMetadata = (plan: Record<string, any>, warnings: MigrationWarning[]): Record<string, any> => {
+  if (!isRecord(plan.metadata)) {
+    if (plan.metadata !== undefined) {
+      recordWarning(warnings, "Plan metadata was not an object; resetting to defaults.");
+    }
+    plan.metadata = {};
+  }
+  return plan.metadata as Record<string, any>;
+};
+
+const migratePlanFields = (plan: Record<string, any>, warnings: MigrationWarning[]): boolean => {
+  let changed = false;
+  const metadata = ensureMetadata(plan, warnings);
+
+  if (!plan.name && typeof plan.planName === "string") {
+    plan.name = plan.planName;
+    delete plan.planName;
+    recordWarning(warnings, "Renamed planName to name.");
+    changed = true;
+  }
+
+  if (!plan.name && typeof metadata.name === "string") {
+    plan.name = metadata.name;
+    delete metadata.name;
+    recordWarning(warnings, "Moved metadata.name to plan name.");
+    changed = true;
+  }
+
+  if (!plan.description && typeof metadata.description === "string") {
+    plan.description = metadata.description;
+    delete metadata.description;
+    recordWarning(warnings, "Moved metadata.description to plan description.");
+    changed = true;
+  }
+
+  if (typeof plan.generated === "string" && !metadata.createdAt) {
+    metadata.createdAt = plan.generated;
+    recordWarning(warnings, "Mapped generated timestamp to metadata.createdAt.");
+    changed = true;
+  }
+  if (plan.generated !== undefined) {
+    delete plan.generated;
+    recordWarning(warnings, "Removed deprecated generated field.");
+    changed = true;
+  }
+
+  if (typeof plan.appId === "string" && !metadata.appId) {
+    metadata.appId = plan.appId;
+    recordWarning(warnings, "Moved top-level appId to metadata.appId.");
+    changed = true;
+  }
+  if (plan.appId !== undefined) {
+    delete plan.appId;
+    recordWarning(warnings, "Removed deprecated top-level appId field.");
+    changed = true;
+  }
+
+  if (typeof metadata.mcpVersion === "string" && !plan.mcpVersion) {
+    plan.mcpVersion = metadata.mcpVersion;
+    delete metadata.mcpVersion;
+    recordWarning(warnings, "Moved metadata.mcpVersion to top-level mcpVersion.");
+    changed = true;
+  }
+
+  if (typeof plan.mcpVersion !== "string" || !plan.mcpVersion) {
+    plan.mcpVersion = "unknown";
+    recordWarning(warnings, "Defaulted missing mcpVersion to \"unknown\".");
+    changed = true;
+  }
+
+  if (!metadata.createdAt) {
+    metadata.createdAt = new Date().toISOString();
+    recordWarning(warnings, "Defaulted missing metadata.createdAt.");
+    changed = true;
+  }
+
+  if (!metadata.version) {
+    metadata.version = "1.0.0";
+    recordWarning(warnings, "Defaulted missing metadata.version to 1.0.0.");
+    changed = true;
+  }
+
+  return changed;
+};
+
+const migrateStepFields = (
+  step: Record<string, any>,
+  stepIndex: number,
+  warnings: MigrationWarning[]
+): boolean => {
+  let changed = false;
+
+  if (!step.tool && typeof step.command === "string") {
+    step.tool = step.command;
+    delete step.command;
+    recordWarning(warnings, "Renamed command to tool.", stepIndex);
+    changed = true;
+  }
+  if (step.command !== undefined) {
+    delete step.command;
+    recordWarning(warnings, "Removed deprecated command field.", stepIndex);
+    changed = true;
+  }
+
+  if (typeof step.description === "string" && !step.label) {
+    step.label = step.description;
+    recordWarning(warnings, "Mapped step description to label.", stepIndex);
+    changed = true;
+  }
+  if (step.description !== undefined) {
+    delete step.description;
+    recordWarning(warnings, "Removed deprecated step description field.", stepIndex);
+    changed = true;
+  }
+
+  const toolName = step.tool;
+  if (typeof toolName !== "string") {
+    return changed;
+  }
+
+  const paramsFromStep = isRecord(step.params) ? { ...step.params } : {};
+  const inlineParams: Record<string, any> = {};
+  for (const [key, value] of Object.entries(step)) {
+    if (["tool", "command", "label", "params"].includes(key)) {
+      continue;
+    }
+    inlineParams[key] = value;
+    delete step[key];
+    changed = true;
+  }
+  const mergedParams = { ...inlineParams, ...paramsFromStep };
+
+  let normalizedTool = toolName;
+  if (toolName === "tapOnText") {
+    normalizedTool = "tapOn";
+    recordWarning(warnings, "Renamed tapOnText to tapOn.", stepIndex);
+    changed = true;
+  }
+  if (toolName === "swipeOnScreen") {
+    normalizedTool = "swipeOn";
+    recordWarning(warnings, "Renamed swipeOnScreen to swipeOn.", stepIndex);
+    if (mergedParams.autoTarget === undefined) {
+      mergedParams.autoTarget = false;
+      recordWarning(warnings, "Defaulted autoTarget=false for swipeOnScreen migration.", stepIndex);
+    }
+    changed = true;
+  }
+  if (toolName === "scroll") {
+    normalizedTool = "swipeOn";
+    recordWarning(warnings, "Renamed scroll to swipeOn.", stepIndex);
+    if (!mergedParams.gestureType) {
+      mergedParams.gestureType = "scrollTowardsDirection";
+      recordWarning(warnings, "Defaulted gestureType=scrollTowardsDirection for scroll migration.", stepIndex);
+    }
+    changed = true;
+  }
+
+  step.tool = normalizedTool;
+
+  if (["launchApp", "terminateApp", "stopApp"].includes(normalizedTool)) {
+    if (mergedParams.appId === undefined && typeof mergedParams.packageName === "string") {
+      mergedParams.appId = mergedParams.packageName;
+      delete mergedParams.packageName;
+      recordWarning(warnings, "Renamed packageName to appId.", stepIndex);
+      changed = true;
+    }
+    if (mergedParams.appId === undefined && typeof mergedParams.bundleId === "string") {
+      mergedParams.appId = mergedParams.bundleId;
+      delete mergedParams.bundleId;
+      recordWarning(warnings, "Renamed bundleId to appId.", stepIndex);
+      changed = true;
+    }
+  }
+
+  if (normalizedTool === "tapOn") {
+    if (!mergedParams.action) {
+      mergedParams.action = "tap";
+      recordWarning(warnings, "Defaulted tapOn.action to tap.", stepIndex);
+      changed = true;
+    }
+    if (mergedParams.id === undefined && typeof mergedParams.elementId === "string") {
+      mergedParams.id = mergedParams.elementId;
+      delete mergedParams.elementId;
+      recordWarning(warnings, "Renamed elementId to id for tapOn.", stepIndex);
+      changed = true;
+    }
+  }
+
+  if (normalizedTool === "inputText") {
+    if (mergedParams.text === undefined && typeof mergedParams.value === "string") {
+      mergedParams.text = mergedParams.value;
+      delete mergedParams.value;
+      recordWarning(warnings, "Renamed inputText.value to text.", stepIndex);
+      changed = true;
+    }
+  }
+
+  if (normalizedTool === "openLink") {
+    if (mergedParams.url === undefined && typeof mergedParams.link === "string") {
+      mergedParams.url = mergedParams.link;
+      delete mergedParams.link;
+      recordWarning(warnings, "Renamed openLink.link to url.", stepIndex);
+      changed = true;
+    }
+  }
+
+  if (normalizedTool === "swipeOn") {
+    const container = isRecord(mergedParams.container) ? { ...mergedParams.container } : {};
+    if (typeof mergedParams.containerElementId === "string" && !container.elementId) {
+      container.elementId = mergedParams.containerElementId;
+      delete mergedParams.containerElementId;
+      recordWarning(warnings, "Renamed containerElementId to container.elementId.", stepIndex);
+      changed = true;
+    }
+    if (typeof mergedParams.containerText === "string" && !container.text) {
+      container.text = mergedParams.containerText;
+      delete mergedParams.containerText;
+      recordWarning(warnings, "Renamed containerText to container.text.", stepIndex);
+      changed = true;
+    }
+    if (Object.keys(container).length > 0) {
+      mergedParams.container = container;
+    }
+    if (mergedParams.duration !== undefined) {
+      if (!mergedParams.speed && typeof mergedParams.duration === "number") {
+        mergedParams.speed = mergedParams.duration >= 800 ? "slow" : mergedParams.duration <= 250 ? "fast" : "normal";
+        recordWarning(warnings, "Mapped swipe duration to speed.", stepIndex);
+      }
+      delete mergedParams.duration;
+      recordWarning(warnings, "Removed deprecated swipe duration field.", stepIndex);
+      changed = true;
+    }
+    if (mergedParams.scrollMode !== undefined) {
+      delete mergedParams.scrollMode;
+      recordWarning(warnings, "Removed deprecated scrollMode field.", stepIndex);
+      changed = true;
+    }
+  }
+
+  if (normalizedTool === "observe") {
+    if (mergedParams.withViewHierarchy !== undefined) {
+      delete mergedParams.withViewHierarchy;
+      recordWarning(warnings, "Removed deprecated observe.withViewHierarchy field.", stepIndex);
+      changed = true;
+    }
+  }
+
+  step.params = mergedParams;
+
+  return changed;
+};
+
+export const migratePlan = (rawPlan: unknown): { plan: Record<string, any>; report: PlanMigrationReport } => {
+  if (!isRecord(rawPlan)) {
+    throw new Error("Plan is not a valid object");
+  }
+
+  const warnings: MigrationWarning[] = [];
+  const plan = rawPlan;
+  const targetVersion = getMcpServerVersion();
+  const originalVersion = typeof plan.mcpVersion === "string" ? plan.mcpVersion : typeof plan.metadata?.mcpVersion === "string" ? plan.metadata.mcpVersion : "unknown";
+  const outdated = isOlderVersion(originalVersion, targetVersion);
+
+  let migrated = false;
+  const appliedMigrations: string[] = [];
+
+  const planChanged = migratePlanFields(plan, warnings);
+  if (planChanged) {
+    appliedMigrations.push("plan-fields");
+    migrated = true;
+  }
+
+  if (Array.isArray(plan.steps)) {
+    let stepsChanged = false;
+    plan.steps = plan.steps.map((step, index) => {
+      if (!isRecord(step)) {
+        return step;
+      }
+      const stepChanged = migrateStepFields(step, index, warnings);
+      stepsChanged = stepsChanged || stepChanged;
+      return step;
+    });
+    if (stepsChanged) {
+      appliedMigrations.push("step-fields");
+      migrated = true;
+    }
+  }
+
+  return {
+    plan,
+    report: {
+      appliedMigrations,
+      warnings,
+      originalVersion,
+      targetVersion,
+      migrated,
+      outdated
+    }
+  };
+};

--- a/src/utils/plan/PlanNormalizer.ts
+++ b/src/utils/plan/PlanNormalizer.ts
@@ -6,6 +6,10 @@ import { logger } from "../logger";
  * Converts legacy formats to current PlanStep structure
  */
 export class PlanNormalizer {
+  private static isRecord(value: unknown): value is Record<string, any> {
+    return typeof value === "object" && value !== null && !Array.isArray(value);
+  }
+
   /**
    * Normalize a raw step object into a PlanStep
    * Handles conversion of 'command' to 'tool' and moves parameters into params object
@@ -22,18 +26,27 @@ export class PlanNormalizer {
       throw new Error(`Invalid step at index ${index}: missing or invalid tool/command name`);
     }
 
-    // Create normalized step - start with empty params object
-    const normalizedStep: PlanStep = {
-      tool: toolName,
-      params: {}
-    };
-
-    // Copy all properties except tool, command, and label into params
+    const inlineParams: Record<string, any> = {};
     Object.keys(step).forEach(key => {
-      if (key !== "tool" && key !== "command" && key !== "label") {
-        normalizedStep.params[key] = step[key];
+      if (key !== "tool" && key !== "command" && key !== "label" && key !== "params") {
+        inlineParams[key] = step[key];
       }
     });
+
+    const paramsFromStep = PlanNormalizer.isRecord(step.params) ? step.params : {};
+
+    // Create normalized step - prefer explicit params over inline fields
+    const normalizedStep: PlanStep = {
+      tool: toolName,
+      params: {
+        ...inlineParams,
+        ...paramsFromStep
+      }
+    };
+
+    if (typeof step.label === "string") {
+      normalizedStep.label = step.label;
+    }
 
     logger.info(`Normalized step ${index}:`, JSON.stringify(normalizedStep, null, 2));
     return normalizedStep;

--- a/src/utils/plan/PlanSerializer.ts
+++ b/src/utils/plan/PlanSerializer.ts
@@ -4,6 +4,8 @@ import yaml from "js-yaml";
 import { Plan, PlanStep } from "../../models/Plan";
 import { logger } from "../logger";
 import { PlanNormalizer } from "./PlanNormalizer";
+import { migratePlan } from "./PlanMigrator";
+import { getMcpServerVersion } from "../mcpVersion";
 
 /**
  * Interface for plan serialization/deserialization
@@ -160,10 +162,12 @@ export class YamlPlanSerializer implements PlanSerializer {
       }
 
       // Create the plan
+      const mcpVersion = getMcpServerVersion();
       const plan: Plan = {
         name: planName,
         description: `Exported plan with ${planSteps.length} steps`,
         steps: planSteps,
+        mcpVersion,
         metadata: {
           createdAt: new Date().toISOString(),
           version: "1.0.0"
@@ -215,13 +219,29 @@ export class YamlPlanSerializer implements PlanSerializer {
 
       logger.info("Raw plan loaded:", JSON.stringify(rawPlan, null, 2));
 
+      const { plan: migratedPlan, report } = migratePlan(rawPlan);
+
       // Handle both legacy and new field names
-      const planName = rawPlan.name || rawPlan.planName;
-      const steps = rawPlan.steps;
+      const planName = migratedPlan.name;
+      const steps = migratedPlan.steps;
 
       // Validate basic structure
       if (!planName || !steps || !Array.isArray(steps)) {
-        throw new Error("Invalid plan structure: missing name/planName or steps");
+        throw new Error("Invalid plan structure: missing name or steps");
+      }
+
+      if (report.migrated) {
+        const applied = report.appliedMigrations.length > 0 ? report.appliedMigrations.join(", ") : "none";
+        logger.info(
+          `[PLAN_MIGRATION] Plan '${planName}' migrated (${report.originalVersion} -> ${report.targetVersion}). Applied: ${applied}`
+        );
+      }
+
+      if (report.warnings.length > 0) {
+        report.warnings.forEach(warning => {
+          const location = warning.stepIndex !== undefined ? `step ${warning.stepIndex}` : "plan";
+          logger.warn(`[PLAN_MIGRATION] ${location}: ${warning.message}`);
+        });
       }
 
       logger.info(`Processing ${steps.length} steps`);
@@ -238,9 +258,10 @@ export class YamlPlanSerializer implements PlanSerializer {
 
       const plan: Plan = {
         name: planName,
-        description: rawPlan.description || `Plan with ${normalizedSteps.length} steps`,
+        description: migratedPlan.description || `Plan with ${normalizedSteps.length} steps`,
         steps: normalizedSteps,
-        metadata: rawPlan.metadata || {
+        mcpVersion: migratedPlan.mcpVersion,
+        metadata: migratedPlan.metadata || {
           createdAt: new Date().toISOString(),
           version: "1.0.0"
         }

--- a/test/planUtils.test.ts
+++ b/test/planUtils.test.ts
@@ -58,6 +58,7 @@ describe("Plan Utils", () => {
       expect(result.success).toBe(true);
       expect(result.stepCount).toBe(3); // launchApp, tapOnText, last observe
       expect(result.planContent).toContain("Test Plan");
+      expect(result.planContent).toContain("mcpVersion:");
       expect(result.planContent).toContain("launchApp");
       expect(result.planContent).toContain("tapOnText");
     });
@@ -186,8 +187,9 @@ metadata:
       expect(plan.steps).toHaveLength(2);
       expect(plan.steps[0].tool).toBe("launchApp");
       expect(plan.steps[0].params.appId).toBe("com.example.app");
-      expect(plan.steps[1].tool).toBe("tapOnText");
+      expect(plan.steps[1].tool).toBe("tapOn");
       expect(plan.steps[1].params.text).toBe("Login");
+      expect(plan.steps[1].params.action).toBe("tap");
     });
 
     test("should throw error for invalid YAML", () => {
@@ -213,6 +215,40 @@ steps:
 `;
 
       expect(() => importPlanFromYaml(yamlContent)).toThrow("Invalid step");
+    });
+
+    test("should migrate legacy plan fields and params", () => {
+      const yamlContent = `
+planName: Legacy Plan
+metadata:
+  description: Legacy description
+steps:
+  - command: launchApp
+    packageName: com.example.app
+  - tool: scroll
+    containerElementId: list-id
+    direction: down
+  - tool: swipeOnScreen
+    direction: up
+    duration: 900
+  - tool: tapOnText
+    text: Login
+`;
+
+      const plan = importPlanFromYaml(yamlContent);
+
+      expect(plan.name).toBe("Legacy Plan");
+      expect(plan.description).toBe("Legacy description");
+      expect(plan.steps[0].tool).toBe("launchApp");
+      expect(plan.steps[0].params.appId).toBe("com.example.app");
+      expect(plan.steps[1].tool).toBe("swipeOn");
+      expect(plan.steps[1].params.container.elementId).toBe("list-id");
+      expect(plan.steps[1].params.gestureType).toBe("scrollTowardsDirection");
+      expect(plan.steps[2].tool).toBe("swipeOn");
+      expect(plan.steps[2].params.autoTarget).toBe(false);
+      expect(plan.steps[2].params.speed).toBe("slow");
+      expect(plan.steps[3].tool).toBe("tapOn");
+      expect(plan.steps[3].params.action).toBe("tap");
     });
   });
 

--- a/test/server/initialization.test.ts
+++ b/test/server/initialization.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { McpTestFixture } from "../fixtures/mcpTestFixture";
+import { getMcpServerVersion } from "../../src/utils/mcpVersion";
 
 describe("MCP Server Initialization", () => {
   let fixture: McpTestFixture;
@@ -57,7 +58,7 @@ describe("MCP Server Initialization", () => {
 
     // Verify server info
     expect(result.serverInfo).toHaveProperty("name", "AutoMobile");
-    expect(result.serverInfo).toHaveProperty("version", "0.0.1");
+    expect(result.serverInfo).toHaveProperty("version", getMcpServerVersion());
   });
 
 });


### PR DESCRIPTION
## Summary
- add MCP version helper and migrate plan fields/steps on import
- record plan `mcpVersion` on export and normalize legacy step params
- align MCP server version metadata with package version

## Testing
- bun run lint
- bun run test

Closes #331
