### PR TITLE
Block MCP tool calls during executePlan

### DIFF
--- a/src/daemon/manager.ts
+++ b/src/daemon/manager.ts
@@ -82,6 +82,9 @@ export class DaemonManager {
     if (options.strictAwait) {
       args.push("--strict-await");
     }
+    if (options.planExecutionLockScope) {
+      args.push("--plan-execution-lock-scope", options.planExecutionLockScope);
+    }
 
     // Create secure temp directory with random suffix to prevent symlink attacks
     const tempDir = mkdtempSync(join(tmpdir(), "auto-mobile-daemon-"));
@@ -316,6 +319,12 @@ export async function runDaemonCommand(
             options.debugPerf = true;
           } else if (args[i] === "--strict-await") {
             options.strictAwait = true;
+          } else if (args[i] === "--plan-execution-lock-scope") {
+            const scope = args[i + 1];
+            if (scope === "global" || scope === "session") {
+              options.planExecutionLockScope = scope;
+            }
+            i++;
           }
         }
 
@@ -358,6 +367,12 @@ export async function runDaemonCommand(
             options.debugPerf = true;
           } else if (args[i] === "--strict-await") {
             options.strictAwait = true;
+          } else if (args[i] === "--plan-execution-lock-scope") {
+            const scope = args[i + 1];
+            if (scope === "global" || scope === "session") {
+              options.planExecutionLockScope = scope;
+            }
+            i++;
           }
         }
 

--- a/src/daemon/types.ts
+++ b/src/daemon/types.ts
@@ -76,6 +76,8 @@ export interface DaemonOptions {
   debugPerf?: boolean;
   /** Enable strict await mode for tapOn await timeouts */
   strictAwait?: boolean;
+  /** Plan execution lock scope (session or global) */
+  planExecutionLockScope?: "session" | "global";
 }
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,7 @@ import { execSync } from "node:child_process";
 import { executionTracker } from "./server/executionTracker";
 import { FeatureFlagService } from "./features/featureFlags/FeatureFlagService";
 import type { FeatureFlagKey } from "./features/featureFlags/FeatureFlagDefinitions";
+import { serverConfig, type PlanExecutionLockScope } from "./utils/ServerConfig";
 
 // Detect port from git branch name for worktree isolation
 // e.g., work/164-feature-name -> port 9164
@@ -75,6 +76,7 @@ function parseArgs(): {
   a11yMinSeverity?: string;
   a11yUseBaseline: boolean;
   predictiveUi: boolean;
+  planExecutionLockScope: PlanExecutionLockScope;
   daemonMode: boolean;
   daemonCommand?: string;
   daemonArgs: string[];
@@ -125,6 +127,7 @@ function parseArgs(): {
   let a11yMinSeverity: string | undefined;
   let a11yUseBaseline = false;
   const predictiveUi = args.includes("--predictive") || args.includes("--predictive-ui");
+  let planExecutionLockScope: PlanExecutionLockScope = "session";
 
   // Extract CLI-specific arguments (everything after --cli)
   const cliIndex = args.indexOf("--cli");
@@ -178,6 +181,14 @@ function parseArgs(): {
       i++;
     } else if (arg === "--a11y-use-baseline") {
       a11yUseBaseline = true;
+    } else if (arg === "--plan-execution-lock-scope") {
+      const scope = args[i + 1];
+      if (scope === "global" || scope === "session") {
+        planExecutionLockScope = scope;
+      } else {
+        logger.warn(`Invalid plan execution lock scope: ${scope}. Using default: ${planExecutionLockScope}`);
+      }
+      i++;
     }
   }
 
@@ -197,6 +208,7 @@ function parseArgs(): {
     a11yMinSeverity,
     a11yUseBaseline,
     predictiveUi,
+    planExecutionLockScope,
     daemonMode,
     daemonCommand,
     daemonArgs,
@@ -589,10 +601,13 @@ async function main() {
       a11yMinSeverity,
       a11yUseBaseline,
       predictiveUi,
+      planExecutionLockScope,
       daemonMode,
       daemonCommand,
       daemonArgs,
     } = parseArgs();
+
+    serverConfig.setPlanExecutionLockScope(planExecutionLockScope);
 
     const featureFlagService = FeatureFlagService.getInstance();
     await featureFlagService.initialize();

--- a/src/server/PlanExecutionLock.ts
+++ b/src/server/PlanExecutionLock.ts
@@ -1,0 +1,63 @@
+import type { PlanExecutionLockScope } from "../utils/ServerConfig";
+import type { ExecutionTracker } from "./executionTracker";
+import { executionTracker } from "./executionTracker";
+import { serverConfig } from "../utils/ServerConfig";
+
+export interface PlanExecutionLockRequest {
+  toolName: string;
+  sessionId?: string;
+  sessionUuid?: string;
+}
+
+export interface PlanExecutionLockDecision {
+  blocked: boolean;
+  scope: PlanExecutionLockScope;
+  reason?: string;
+}
+
+export interface PlanExecutionLock {
+  evaluate(request: PlanExecutionLockRequest): PlanExecutionLockDecision;
+}
+
+export interface PlanExecutionLockScopeProvider {
+  getScope(): PlanExecutionLockScope;
+}
+
+export class ServerConfigPlanExecutionLockScopeProvider implements PlanExecutionLockScopeProvider {
+  getScope(): PlanExecutionLockScope {
+    return serverConfig.getPlanExecutionLockScope();
+  }
+}
+
+export class ExecutionTrackerPlanExecutionLock implements PlanExecutionLock {
+  constructor(
+    private readonly tracker: ExecutionTracker,
+    private readonly scopeProvider: PlanExecutionLockScopeProvider
+  ) {}
+
+  evaluate(request: PlanExecutionLockRequest): PlanExecutionLockDecision {
+    const scope = this.scopeProvider.getScope();
+    const hasActivePlan = this.tracker.hasActiveToolExecution("executePlan", {
+      scope,
+      sessionId: request.sessionId,
+      sessionUuid: request.sessionUuid,
+    });
+
+    if (!hasActivePlan) {
+      return { blocked: false, scope };
+    }
+
+    return {
+      blocked: true,
+      scope,
+      reason: "plan execution in progress",
+    };
+  }
+}
+
+export const createDefaultPlanExecutionLock = (): PlanExecutionLock => {
+  return new ExecutionTrackerPlanExecutionLock(
+    executionTracker,
+    new ServerConfigPlanExecutionLockScopeProvider()
+  );
+};

--- a/src/server/executionTracker.ts
+++ b/src/server/executionTracker.ts
@@ -10,7 +10,15 @@ export interface ActiveExecution {
   abortController: AbortController;
 }
 
-class ExecutionTracker {
+export type ExecutionScope = "session" | "global";
+
+export interface ExecutionScopeOptions {
+  scope: ExecutionScope;
+  sessionId?: string;
+  sessionUuid?: string;
+}
+
+export class ExecutionTracker {
   private executions = new Map<string, ActiveExecution>();
   private sessionExecutions = new Map<string, Set<string>>();
   private sessionUuidExecutions = new Map<string, Set<string>>();
@@ -83,6 +91,51 @@ class ExecutionTracker {
   hasActiveSessionUuidExecutions(sessionUuid: string): boolean {
     const executions = this.sessionUuidExecutions.get(sessionUuid);
     return executions !== undefined && executions.size > 0;
+  }
+
+  hasActiveToolExecution(toolName: string, options: ExecutionScopeOptions): boolean {
+    if (options.scope === "global") {
+      return this.hasActiveToolExecutionGlobal(toolName);
+    }
+
+    if (options.sessionUuid) {
+      return this.hasActiveToolExecutionForKey(toolName, this.sessionUuidExecutions, options.sessionUuid);
+    }
+
+    if (options.sessionId) {
+      return this.hasActiveToolExecutionForKey(toolName, this.sessionExecutions, options.sessionId);
+    }
+
+    return this.hasActiveToolExecutionGlobal(toolName);
+  }
+
+  private hasActiveToolExecutionGlobal(toolName: string): boolean {
+    for (const execution of this.executions.values()) {
+      if (execution.toolName === toolName) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private hasActiveToolExecutionForKey(
+    toolName: string,
+    executionMap: Map<string, Set<string>>,
+    key: string
+  ): boolean {
+    const executions = executionMap.get(key);
+    if (!executions || executions.size === 0) {
+      return false;
+    }
+
+    for (const executionId of executions) {
+      const execution = this.executions.get(executionId);
+      if (execution?.toolName === toolName) {
+        return true;
+      }
+    }
+
+    return false;
   }
 
   private async cancelExecutionsForKey(

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -8,6 +8,7 @@ import { ActionableError } from "../models";
 import { logger } from "../utils/logger";
 import { executionTracker } from "./executionTracker";
 import { runWithAbortSignal } from "../utils/AbortContext";
+import { createDefaultPlanExecutionLock, type PlanExecutionLock } from "./PlanExecutionLock";
 
 // Import the tool registry
 import { ToolRegistry } from "./toolRegistry";
@@ -42,6 +43,7 @@ import { FeatureFlagService } from "../features/featureFlags/FeatureFlagService"
 export interface McpServerOptions {
   debug?: boolean;
   sessionContext?: { sessionId?: string };
+  planExecutionLock?: PlanExecutionLock;
 }
 
 function formatToolParamError(toolName: string, error: unknown): string {
@@ -71,6 +73,7 @@ function formatToolParamError(toolName: string, error: unknown): string {
 }
 
 export const createMcpServer = (options: McpServerOptions = {}): McpServer => {
+  const planExecutionLock = options.planExecutionLock ?? createDefaultPlanExecutionLock();
   void FeatureFlagService.getInstance()
     .initialize()
     .catch(error => {
@@ -161,14 +164,6 @@ export const createMcpServer = (options: McpServerOptions = {}): McpServer => {
       throw new ActionableError(`Unknown tool: ${name}`);
     }
 
-    // Parse and validate the parameters
-    let parsedParams;
-    try {
-      parsedParams = tool.schema.parse(toolParams);
-    } catch (error) {
-      throw new ActionableError(`Invalid parameters for tool ${name}: ${formatToolParamError(name, error)}`);
-    }
-
     const sessionId = options.sessionContext?.sessionId;
     const rawSessionUuid =
       toolParams &&
@@ -177,6 +172,26 @@ export const createMcpServer = (options: McpServerOptions = {}): McpServer => {
         ? (toolParams as { sessionUuid?: string }).sessionUuid
         : undefined;
     const sessionUuid = typeof rawSessionUuid === "string" ? rawSessionUuid : undefined;
+
+    const decision = planExecutionLock.evaluate({
+      toolName: name,
+      sessionId,
+      sessionUuid,
+    });
+    if (decision.blocked) {
+      logger.warn(
+        `[MCP] Rejecting tool ${name} due to active executePlan (scope=${decision.scope}, sessionId=${sessionId ?? "none"}, sessionUuid=${sessionUuid ?? "none"})`
+      );
+      throw new ActionableError(decision.reason ?? "plan execution in progress");
+    }
+
+    // Parse and validate the parameters
+    let parsedParams;
+    try {
+      parsedParams = tool.schema.parse(toolParams);
+    } catch (error) {
+      throw new ActionableError(`Invalid parameters for tool ${name}: ${formatToolParamError(name, error)}`);
+    }
 
     const execution = executionTracker.startExecution(name, sessionId, sessionUuid);
 

--- a/src/utils/ServerConfig.ts
+++ b/src/utils/ServerConfig.ts
@@ -2,6 +2,8 @@ import type {
   AccessibilityAuditConfig,
 } from "../models/AccessibilityAudit";
 
+export type PlanExecutionLockScope = "session" | "global";
+
 /**
  * Global server configuration state
  * Set once during server initialization
@@ -14,6 +16,7 @@ class ServerConfig {
   private _memPerfAuditEnabled: boolean = false;
   private _strictAwaitEnabled: boolean = false;
   private _predictiveUiEnabled: boolean = false;
+  private _planExecutionLockScope: PlanExecutionLockScope = "session";
 
   private constructor() {}
 
@@ -74,6 +77,14 @@ class ServerConfig {
 
   isPredictiveUiEnabled(): boolean {
     return this._predictiveUiEnabled;
+  }
+
+  setPlanExecutionLockScope(scope: PlanExecutionLockScope): void {
+    this._planExecutionLockScope = scope;
+  }
+
+  getPlanExecutionLockScope(): PlanExecutionLockScope {
+    return this._planExecutionLockScope;
   }
 }
 

--- a/test/fakes/FakePlanExecutionLock.ts
+++ b/test/fakes/FakePlanExecutionLock.ts
@@ -1,0 +1,13 @@
+import type {
+  PlanExecutionLock,
+  PlanExecutionLockDecision,
+  PlanExecutionLockRequest,
+} from "../../src/server/PlanExecutionLock";
+
+export class FakePlanExecutionLock implements PlanExecutionLock {
+  constructor(private readonly decision: PlanExecutionLockDecision) {}
+
+  evaluate(_request: PlanExecutionLockRequest): PlanExecutionLockDecision {
+    return this.decision;
+  }
+}

--- a/test/fixtures/mcpTestFixture.ts
+++ b/test/fixtures/mcpTestFixture.ts
@@ -15,8 +15,12 @@ export class McpTestFixture {
   public serverTransport!: any;
   public clientTransport!: any;
 
+  constructor(
+    private readonly serverOptions: Parameters<typeof createMcpServer>[0] = {}
+  ) {}
+
   async setup(): Promise<void> {
-    this.server = createMcpServer();
+    this.server = createMcpServer(this.serverOptions);
     [this.serverTransport, this.clientTransport] = InMemoryTransport.createLinkedPair();
 
     await this.server.connect(this.serverTransport);

--- a/test/server/planExecutionLock.test.ts
+++ b/test/server/planExecutionLock.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, test } from "bun:test";
+import { McpTestFixture } from "../fixtures/mcpTestFixture";
+import { FakePlanExecutionLock } from "../fakes/FakePlanExecutionLock";
+import {
+  ExecutionTrackerPlanExecutionLock,
+  type PlanExecutionLockScopeProvider,
+} from "../../src/server/PlanExecutionLock";
+import { ExecutionTracker } from "../../src/server/executionTracker";
+import type { PlanExecutionLockScope } from "../../src/utils/ServerConfig";
+
+class FakePlanExecutionLockScopeProvider implements PlanExecutionLockScopeProvider {
+  constructor(private scope: PlanExecutionLockScope) {}
+
+  getScope(): PlanExecutionLockScope {
+    return this.scope;
+  }
+
+  setScope(scope: PlanExecutionLockScope): void {
+    this.scope = scope;
+  }
+}
+
+describe("Plan execution lock", () => {
+  test("rejects MCP tool calls when a plan is executing", async () => {
+    const fixture = new McpTestFixture({
+      planExecutionLock: new FakePlanExecutionLock({
+        blocked: true,
+        scope: "session",
+        reason: "plan execution in progress",
+      }),
+    });
+    await fixture.setup();
+
+    try {
+      const { client } = fixture.getContext();
+      const { z } = await import("zod");
+      await client.request({
+        method: "tools/call",
+        params: {
+          name: "listFeatureFlags",
+          arguments: {},
+        },
+      }, z.any());
+      expect.fail("Expected tool call to be rejected");
+    } catch (error: any) {
+      expect(error.message).toContain("plan execution in progress");
+    } finally {
+      await fixture.teardown();
+    }
+  });
+
+  test("allows MCP tool calls when no plan is executing", async () => {
+    const fixture = new McpTestFixture({
+      planExecutionLock: new FakePlanExecutionLock({
+        blocked: false,
+        scope: "session",
+      }),
+    });
+    await fixture.setup();
+
+    try {
+      const { client } = fixture.getContext();
+      const { z } = await import("zod");
+      const result = await client.request({
+        method: "tools/call",
+        params: {
+          name: "listFeatureFlags",
+          arguments: {},
+        },
+      }, z.any());
+
+      expect(result).toHaveProperty("content");
+    } finally {
+      await fixture.teardown();
+    }
+  });
+
+  test("scopes blocking to session or global", () => {
+    const tracker = new ExecutionTracker();
+    const scopeProvider = new FakePlanExecutionLockScopeProvider("session");
+    const lock = new ExecutionTrackerPlanExecutionLock(tracker, scopeProvider);
+
+    const execution = tracker.startExecution("executePlan", undefined, "session-a");
+    try {
+      const sessionDecision = lock.evaluate({
+        toolName: "tapOn",
+        sessionUuid: "session-a",
+      });
+      expect(sessionDecision.blocked).toBe(true);
+      expect(sessionDecision.scope).toBe("session");
+
+      const otherSessionDecision = lock.evaluate({
+        toolName: "tapOn",
+        sessionUuid: "session-b",
+      });
+      expect(otherSessionDecision.blocked).toBe(false);
+
+      scopeProvider.setScope("global");
+      const globalDecision = lock.evaluate({
+        toolName: "tapOn",
+        sessionUuid: "session-b",
+      });
+      expect(globalDecision.blocked).toBe(true);
+      expect(globalDecision.scope).toBe("global");
+    } finally {
+      tracker.endExecution(execution.id);
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- add plan execution lock abstraction backed by execution tracker with session/global scope
- enforce lock in MCP call handler and wire CLI/daemon scope flag
- add fakes and tests covering lock decisions and scope behavior

## Testing
- bun run build
- bun run lint
- bun run test


Closes #330
