### PR TITLE
Docs: streamline Android onboarding docs

### DIFF
--- a/docs/design-docs/plat/android/auto-mobile-sdk.md
+++ b/docs/design-docs/plat/android/auto-mobile-sdk.md
@@ -2,145 +2,17 @@
 
 The AutoMobile SDK provides Android-specific components for integrating AutoMobile into your Android applications and test suites.
 
-
 The SDK consists of:
 
-- **JUnitRunner** - Test execution framework with AI self-healing capabilities
-- **Accessibility Service** - Real-time view hierarchy access and UI monitoring
+- [JUnitRunner](junitrunner.md) - Test execution framework with AI self-healing capabilities
+- [Accessibility Service](accessibility-service.md) - Real-time view hierarchy access and UI monitoring
 - **Gradle Integration** - Build configuration and dependency management
 
-## Installation
+## Setup
 
-### Gradle Dependency
-
-Add the AutoMobile JUnitRunner to your app or library module:
-
-```gradle
-testImplementation("dev.jasonpearson.automobile.junitrunner:x.y.z")
-```
-
-**Note**: This artifact is not yet published to Maven Central. For now, publish to mavenLocal:
-
-```bash
-./gradlew publishToMavenLocal
-```
-
-Then use the version from `android/junit-runner/build.gradle.kts`.
-
-### Accessibility Service
-
-The AutoMobile Accessibility Service is included in the SDK and provides:
-
-- Real-time view hierarchy access
-- UI change monitoring
-- WebSocket streaming to MCP Server
-- No root access required
-
-Enable it on your test device:
-1. Go to Settings > Accessibility
-2. Find "AutoMobile Accessibility Service"
-3. Enable the service
-
-## Components
-
-### JUnitRunner
-
-The JUnitRunner extends Android's standard test framework with:
-
-- **AI Self-Healing** - Automatic test recovery from common failures using AI analysis
-- **Device Pool Management** - Multi-device support with automatic device selection
-- **Historical Timing** - Fetch test duration history to optimize test ordering
-- **Model Provider Integration** - Built-in support for OpenAI, Anthropic, Google, AWS Bedrock
-
-#### Configuration
-
-Configure the runner via system properties or environment variables:
-
-```properties
-# gradle.properties
-automobile.ai.provider=anthropic
-automobile.junit.timing.ordering=duration-desc
-```
-
-Set API keys via environment variables:
-```bash
-export ANTHROPIC_API_KEY="your_api_key_here"
-```
-
-Or via system property:
-```bash
--Dautomobile.anthropic.api.key=your_api_key_here
-```
-
-Optional proxy endpoint:
-```bash
--Dautomobile:your-proxy.example.com
-```
-
-#### Historical Timing
-
-Enable test ordering based on historical execution time:
-
-```properties
-automobile.junit.timing.ordering=duration-desc  # Longest tests first
-automobile.junit.timing.ordering=duration-asc   # Shortest tests first
-```
-
-Timing fetch is automatically disabled in CI environments (`automobile.ci.mode=true` or `CI=true`).
-
-### Accessibility Service
-
-The Accessibility Service provides:
-
-- **Real-time Hierarchy** - Continuous UI monitoring without polling
-- **WebSocket Streaming** - Live updates to MCP Server
-- **File-based Fallback** - Writes hierarchy to app-private storage
-- **No Root Required** - Works with standard Android permissions
-
-The service writes view hierarchy data that the MCP Server consumes for observation and interaction.
-
-## Supported Model Providers
-
-The JUnitRunner supports OpenAI, Anthropic, Google Gemini, and AWS Bedrock.
-
-For API key setup and provider configuration, see [AI Agent Setup](../../../install/overview.md#model-provider-api-keys).
-
-## CI/CD Integration
-
-### Environment Variables
-
-For CI environments, use environment-injected secrets:
-
-```yaml
-# GitHub Actions example
-env:
-  ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-  AUTOMOBILE_CI_MODE: true
-```
-
-### Gradle Configuration
-
-```gradle
-android {
-    testOptions {
-        unitTests.all {
-            systemProperty "automobile.ai.provider", "anthropic"
-            systemProperty "automobile.ci.mode", "true"
-        }
-    }
-}
-```
-
-## Best Practices
-
-1. **Use mavenLocal for development** - Until published to Maven Central
-2. **Enable Accessibility Service** - Required for real-time view hierarchy access
-3. **Configure API keys securely** - Use environment variables in CI, avoid hardcoding
-4. **Enable timing optimization** - Use historical timing data to order tests efficiently
-5. **Monitor device pool** - Ensure enough devices are available for parallel execution
+- Follow [JUnitRunner](junitrunner.md) for dependency installation and runner configuration.
+- Enable the [Accessibility Service](accessibility-service.md) on test devices to access the view hierarchy.
 
 ## See Also
 
-- [JUnitRunner](junitrunner.md) - Detailed JUnitRunner documentation
-- [Accessibility Service](accessibility-service.md) - Accessibility Service technical details
 - [MCP Server](../../mcp/index.md) - MCP Server integration

--- a/docs/design-docs/plat/android/junitrunner.md
+++ b/docs/design-docs/plat/android/junitrunner.md
@@ -1,5 +1,7 @@
 # Test Execution - JUnitRunner
 
+## Installation
+
 Add this test Gradle dependency to all Android apps and libraries in your codebase. You can also add it only to the
 modules that cover the UI you want to test.
 
@@ -7,8 +9,7 @@ modules that cover the UI you want to test.
 testImplementation("dev.jasonpearson.automobile.junitrunner:x.y.z")
 ```
 
-Note that this artifact hasn't been published to Maven Central just yet and is forthcoming.  
-
+Note that this artifact hasn't been published to Maven Central just yet and is forthcoming.
 
 In the meantime, publish to your mavenLocal (`~/.m2`) via:
 
@@ -18,20 +19,41 @@ In the meantime, publish to your mavenLocal (`~/.m2`) via:
 
 and use the above testImplementation dependency with `x.y.z` version from `android/junit-runner/build.gradle.kts`.
 
+## Configuration
 
-#### AI Recovery
+Configure the runner via system properties or environment variables:
+
+```properties
+# gradle.properties
+automobile.ai.provider=anthropic
+automobile.junit.timing.ordering=duration-desc
+```
+
+Set API keys via environment variables:
+```bash
+export ANTHROPIC_API_KEY="your_api_key_here"
+```
+
+Or via system property:
+```bash
+-Dautomobile.anthropic.api.key=your_api_key_here
+```
+
+Optional proxy endpoint:
+```bash
+-Dautomobile:your-proxy.example.com
+```
+
+## AI Recovery
 
 The runner is designed to eventually support agentic self-healing capabilities, allowing tests to
 automatically adapt and recover from common failure scenarios by leveraging AI-driven analysis of test failures and UI changes.
 
-#### Pooled Device Management
+## Pooled Device Management
 
 Multi-device support with emulator control and app lifecycle management. As long as you have available adb connections,
 AutoMobile can automatically track which one its using for which execution plan or MCP session. CI still needs available
 device connections, but AutoMobile handles selection and readiness checks. During STDIO MCP sessions the tool call `setActiveDevice` will be done and kept for the duration of your session.
-
-
-
 
 ## Historical Timing Data
 
@@ -63,7 +85,7 @@ Example response format:
 }
 ```
 
-# Model Providers
+## Model Providers
 
 The JUnitRunner supports OpenAI, Anthropic, Google Gemini, and AWS Bedrock for AI self-healing capabilities.
 
@@ -72,4 +94,38 @@ Configure via system property:
 automobile.ai.provider=anthropic
 ```
 
-For API key setup, see [AI Agent Setup](../../../install/overview.md#model-provider-api-keys).
+For API key setup, see [Configuration](#configuration).
+
+## CI/CD Integration
+
+### Environment Variables
+
+For CI environments, use environment-injected secrets:
+
+```yaml
+# GitHub Actions example
+env:
+  ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+  AUTOMOBILE_CI_MODE: true
+```
+
+### Gradle Configuration
+
+```gradle
+android {
+    testOptions {
+        unitTests.all {
+            systemProperty "automobile.ai.provider", "anthropic"
+            systemProperty "automobile.ci.mode", "true"
+        }
+    }
+}
+```
+
+## Best Practices
+
+1. **Use mavenLocal for development** - Until published to Maven Central
+2. **Enable the [Accessibility Service](accessibility-service.md)** - Required for real-time view hierarchy access
+3. **Configure API keys securely** - Use environment variables in CI, avoid hardcoding
+4. **Enable timing optimization** - Use historical timing data to order tests efficiently
+5. **Monitor device pool** - Ensure enough devices are available for parallel execution

--- a/docs/index.md
+++ b/docs/index.md
@@ -11,10 +11,13 @@ Android is the primary supported platform today; iOS support is on the roadmap.
 
 ### What can I use this to do?
 
-- [Interactive Exploration](using/ux-exploration.md) Use AI agents to explore your app and discover issues
-- [Automated Testing](using/ui-tests.md) Write reproducible UI tests that run in CI/CD
-- Performance Monitoring of [startup](using/perf-analysis/startup.md), [scroll framerate](using/perf-analysis/scroll-framerate.md), and [transitions](using/perf-analysis/screen-transition.md).
-- [Accessibility Auditing](using/ux-exploration.md) Validate contrast ratios and touch target sizes
+- [Explore your app interactively](using/ux-exploration.md) - Discover UI flows and issues with an AI agent
+- [Create reproducible UI tests](using/ui-tests.md) - Automate UI flows in CI/CD
+- [Measure startup performance](using/perf-analysis/startup.md) - Track time to first frame and interactivity
+- [Measure scroll framerate](using/perf-analysis/scroll-framerate.md) - Detect jank and dropped frames
+- [Measure screen transitions](using/perf-analysis/screen-transition.md) - Evaluate navigation latency and smoothness
+- [Audit contrast ratios](using/a11y/contrast.md) - Validate WCAG contrast compliance
+- [Audit tap target sizes](using/a11y/tap-targets.md) - Verify touch target size and spacing
 
 ### How does AutoMobile work?
 

--- a/docs/install/overview.md
+++ b/docs/install/overview.md
@@ -1,6 +1,6 @@
 # AI Agent Setup
 
-AutoMobile runs as an MCP (Model Context Protocol) server in STDIO mode. Configure your AI agent to connect to AutoMobile using the examples below.
+AutoMobile runs as an MCP (Model Context Protocol) server in STDIO mode. Configure your AI agent to connect to AutoMobile using the example below.
 
 ### Prerequisites
 
@@ -19,7 +19,9 @@ AutoMobile runs as an MCP (Model Context Protocol) server in STDIO mode. Configu
 }
 ```
 
-If Android SDK is not on `PATH`:
+## Advanced Configuration
+
+If you need to point at a specific Android SDK path, set `ANDROID_HOME` (or `ANDROID_SDK_ROOT`) in the MCP server env:
 
 ```json
 {
@@ -40,7 +42,7 @@ If you have a private npm registry for proxying public npm:
 ```json
 {
   "mcpServers": {
-    "AutoMobile": {
+    "auto-mobile": {
       "command": "npx",
       "args": [
         "-y",
@@ -53,22 +55,10 @@ If you have a private npm registry for proxying public npm:
 }
 ```
 
-#### Android Setup
+## Platform Setup
 
-AutoMobile expects the Android SDK & command-line tools to be installed already; the automatic installation path has been
-removed. Configure the SDK path with `ANDROID_HOME`, `ANDROID_SDK_ROOT`, or `ANDROID_SDK_HOME` so AutoMobile can find
-`adb`, or make sure `adb` is on your `PATH`.
-
-Physical devices do need USB debugging enabled for AutoMobile to function with them.
-
-Additionally you can
-* Install the [IntelliJ IDE Plugin](../design-docs/plat/android/ide-plugin/overview.md) to gain the ability to toggle feature flags, record tests, visualize the real-time navigation graph, and inspect app performance.
-* Add the [JUnitRunner](../design-docs/plat/android/junitrunner.md) test dependency to all Android application and library modules.
-* Add the [Android SDK](../design-docs/plat/android/auto-mobile-sdk.md) Android library to add recomposition tracking.
-
-#### iOS Setup
-
-Unsupported at the moment but the [design doc](../design-docs/plat/ios/index.md) outlines plans.
+- Android: [Android setup](plat/android.md)
+- iOS: unsupported at the moment, but the [design doc](../design-docs/plat/ios/index.md) outlines plans.
 
 ### AI Agent & Model Providers
 
@@ -87,19 +77,6 @@ For model provider supported features like JUnitRunner AI self-healing tests you
 - **Google Gemini** - [Get API Key](https://aistudio.google.com/app/apikey) | [Docs](https://ai.google.dev/gemini-api/docs/api-key)
 - **AWS Bedrock** - [Setup Guide](https://docs.aws.amazon.com/bedrock/latest/userguide/setting-up.html)
 
-Set API keys via environment variables or system properties. See [AutoMobile SDK](../design-docs/plat/android/auto-mobile-sdk.md#model-providers) for configuration details.
-
-
-
-
-
-
-
-
-
-
-
-
-
+Set API keys via environment variables or system properties. See [JUnitRunner](../design-docs/plat/android/junitrunner.md#model-providers) for configuration details.
 
 

--- a/docs/using/a11y/contrast.md
+++ b/docs/using/a11y/contrast.md
@@ -25,11 +25,9 @@ Large text is defined as:
 
 ## Using AutoMobile
 
-Enable UI performance auditing in the IntelliJ IDE Plugin
+Prerequisites: [UI auditing prerequisites](../ui-auditing-prereqs.md).
 
-See [Feature Flags](../../design-docs/mcp/feature-flags.md) for more details.
-
-Ask your AI agent:
+Example prompt:
 
 ```
 Audit the login screen for contrast ratio accessibility issues

--- a/docs/using/a11y/tap-targets.md
+++ b/docs/using/a11y/tap-targets.md
@@ -21,11 +21,9 @@ AutoMobile can audit:
 
 ## Using AutoMobile
 
-Enable UI performance auditing in the IntelliJ IDE Plugin
+Prerequisites: [UI auditing prerequisites](../ui-auditing-prereqs.md).
 
-See [Feature Flags](../../design-docs/mcp/feature-flags.md) for more details.
-
-Ask your AI agent:
+Example prompt:
 
 ```
 Check if all buttons and links meet the minimum tap target size of 48x48dp

--- a/docs/using/perf-analysis/screen-transition.md
+++ b/docs/using/perf-analysis/screen-transition.md
@@ -10,9 +10,9 @@ Screen transitions should be smooth and responsive. Janky transitions hurt user 
 
 ## Example Usage
 
-Enable UI performance auditing in the IntelliJ IDE Plugin [feature flags](../../design-docs/mcp/feature-flags.md).
+Prerequisites: [UI auditing prerequisites](../ui-auditing-prereqs.md).
 
-Ask your AI agent:
+Example prompt:
 
 ```
 Tap the settings button and measure how long the transition takes

--- a/docs/using/perf-analysis/scroll-framerate.md
+++ b/docs/using/perf-analysis/scroll-framerate.md
@@ -17,9 +17,9 @@ AutoMobile collects frame rendering metrics during scroll interactions:
 
 ## Example Usage
 
-Enable UI performance auditing in the IntelliJ IDE Plugin [feature flags](../../design-docs/mcp/feature-flags.md).
+Prerequisites: [UI auditing prerequisites](../ui-auditing-prereqs.md).
 
-Ask your AI agent:
+Example prompt:
 
 ```
 Scroll through the product list and measure the framerate

--- a/docs/using/perf-analysis/startup.md
+++ b/docs/using/perf-analysis/startup.md
@@ -14,7 +14,9 @@ App startup performance affects user experience and app store ratings. AutoMobil
 
 ## Example Workflow
 
-Ask your AI agent:
+Prerequisites: [UI auditing prerequisites](../ui-auditing-prereqs.md).
+
+Example prompt:
 
 ```
 Launch the app and measure how long until the home screen is interactive

--- a/docs/using/ui-auditing-prereqs.md
+++ b/docs/using/ui-auditing-prereqs.md
@@ -1,0 +1,16 @@
+# UI Auditing Prerequisites
+
+Performance and accessibility audits require the IntelliJ IDE Plugin and UI performance auditing to be enabled.
+
+## Enable UI Performance Auditing
+
+1. Install the [IntelliJ IDE Plugin](../design-docs/plat/android/ide-plugin/overview.md).
+2. Enable UI performance auditing in the [feature flags](../design-docs/mcp/feature-flags.md).
+
+## Prompt Pattern
+
+Use a direct, task-focused prompt that names the screen or flow you want to inspect:
+
+```
+Measure scroll framerate on the product list
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -80,6 +80,7 @@ nav:
   - 'Using AutoMobile':
       - 'UX Exploration': using/ux-exploration.md
       - 'Reproducing Bugs': using/reproducting-bugs.md
+      - 'UI Auditing Prereqs': using/ui-auditing-prereqs.md
       - 'Performance Analysis':
           - 'Startup': using/perf-analysis/startup.md
           - 'Screen Transition': using/perf-analysis/screen-transition.md


### PR DESCRIPTION
## Summary
- tighten MCP config docs with advanced options and platform setup links
- add shared UI auditing prerequisites and refactor perf/a11y pages
- consolidate Android SDK/JUnitRunner docs and streamline the landing page task list

## Testing
- Not run (docs-only)
