### PR TITLE
Add MCP resources for test timings and performance

### DIFF
--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -39,6 +39,8 @@ import { registerBootedDeviceResources } from "./bootedDeviceResources";
 import { registerDeviceImageResources } from "./deviceImageResources";
 import { registerAppResources } from "./appResources";
 import { registerNavigationResources } from "./navigationResources";
+import { registerTestTimingResources } from "./testTimingResources";
+import { registerPerformanceResources } from "./performanceResources";
 import { FeatureFlagService } from "../features/featureFlags/FeatureFlagService";
 
 export interface McpServerOptions {
@@ -103,6 +105,8 @@ export const createMcpServer = (options: McpServerOptions = {}): McpServer => {
   registerDeviceImageResources();
   registerAppResources();
   registerNavigationResources();
+  registerTestTimingResources();
+  registerPerformanceResources();
 
   registerDebugTools();
 

--- a/src/server/performanceData.ts
+++ b/src/server/performanceData.ts
@@ -1,0 +1,88 @@
+import { PerformanceAuditRepository } from "../db/performanceAuditRepository";
+import { ToolCallRepository } from "../db/toolCallRepository";
+import type { PerformanceAuditHistoryEntry } from "../db/performanceAuditRepository";
+
+export const DEFAULT_PERFORMANCE_RESULTS_LIMIT = 50;
+export const DEFAULT_PERFORMANCE_RESULTS_OFFSET = 0;
+export const PERFORMANCE_RESULTS_LIMIT_MAX = 500;
+
+export interface PerformanceAuditQueryArgs {
+  startTime?: string | number;
+  endTime?: string | number;
+  limit?: number;
+  offset?: number;
+  deviceId?: string;
+}
+
+export interface PerformanceAuditResponse {
+  results: PerformanceAuditHistoryEntry[];
+  toolCalls: string[];
+  hasMore: boolean;
+  nextOffset: number | null;
+  range: { startTime: string; endTime: string } | null;
+}
+
+const auditRepository = new PerformanceAuditRepository();
+const toolCallRepository = new ToolCallRepository();
+
+function normalizeTimestamp(value?: string | number): string | undefined {
+  if (value === undefined || value === null) {
+    return undefined;
+  }
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    throw new Error(`Invalid timestamp: ${value}`);
+  }
+  return date.toISOString();
+}
+
+function getTimestampRange(timestamps: string[]): { start: string; end: string } | null {
+  if (timestamps.length === 0) {
+    return null;
+  }
+  let start = timestamps[0];
+  let end = timestamps[0];
+  for (const timestamp of timestamps) {
+    if (timestamp < start) {
+      start = timestamp;
+    }
+    if (timestamp > end) {
+      end = timestamp;
+    }
+  }
+  return { start, end };
+}
+
+export async function buildPerformanceAuditResponse(
+  args: PerformanceAuditQueryArgs
+): Promise<PerformanceAuditResponse> {
+  const startTime = normalizeTimestamp(args.startTime);
+  const endTime = normalizeTimestamp(args.endTime);
+  const limit = args.limit ?? DEFAULT_PERFORMANCE_RESULTS_LIMIT;
+  const offset = args.offset ?? DEFAULT_PERFORMANCE_RESULTS_OFFSET;
+
+  const page = await auditRepository.listResults({
+    startTime,
+    endTime,
+    limit,
+    offset,
+    deviceId: args.deviceId,
+  });
+
+  const range = getTimestampRange(page.results.map(result => result.timestamp));
+  const toolCalls = range
+    ? await toolCallRepository.listToolNamesBetween(
+      range.start,
+      range.end,
+      ["listPerformanceAuditResults"]
+    )
+    : [];
+
+  return {
+    results: page.results,
+    toolCalls,
+    hasMore: page.hasMore,
+    nextOffset: page.nextOffset,
+    range: range ? { startTime: range.start, endTime: range.end } : null,
+  };
+}

--- a/src/server/performanceResources.ts
+++ b/src/server/performanceResources.ts
@@ -1,0 +1,174 @@
+import { ResourceRegistry, ResourceContent } from "./resourceRegistry";
+import { logger } from "../utils/logger";
+import {
+  buildPerformanceAuditResponse,
+  PERFORMANCE_RESULTS_LIMIT_MAX,
+  type PerformanceAuditQueryArgs,
+} from "./performanceData";
+
+export const PERFORMANCE_RESOURCE_URIS = {
+  BASE: "automobile:performance-results",
+} as const;
+
+const PERFORMANCE_QUERY_KEYS = ["startTime", "endTime", "limit", "offset", "deviceId"] as const;
+type PerformanceQueryKey = typeof PERFORMANCE_QUERY_KEYS[number];
+
+function buildQueryTemplate(keys: readonly PerformanceQueryKey[]): string {
+  const query = keys.map(key => `${key}={${key}}`).join("&");
+  return `${PERFORMANCE_RESOURCE_URIS.BASE}?${query}`;
+}
+
+function parseInteger(
+  value: string | undefined,
+  label: string,
+  options: { min?: number; max?: number } = {}
+): number | undefined {
+  if (!value) {
+    return undefined;
+  }
+
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed) || !Number.isInteger(parsed)) {
+    throw new Error(`Invalid ${label}: ${value}`);
+  }
+
+  const min = options.min ?? 0;
+  if (parsed < min) {
+    throw new Error(`Invalid ${label}: ${value}`);
+  }
+
+  if (options.max !== undefined && parsed > options.max) {
+    throw new Error(`Invalid ${label}: ${value}`);
+  }
+
+  return parsed;
+}
+
+function parseTimestampParam(value: string | undefined, label: string): string | number | undefined {
+  if (!value) {
+    return undefined;
+  }
+
+  const decoded = decodeURIComponent(value).trim();
+  if (!decoded) {
+    return undefined;
+  }
+
+  if (/^-?\d+$/.test(decoded)) {
+    const parsed = Number(decoded);
+    if (!Number.isFinite(parsed)) {
+      throw new Error(`Invalid ${label}: ${value}`);
+    }
+    return parsed;
+  }
+
+  return decoded;
+}
+
+function parsePerformanceParams(
+  params: Record<string, string>
+): Pick<PerformanceAuditQueryArgs, "startTime" | "endTime" | "limit" | "offset" | "deviceId"> {
+  const startTime = parseTimestampParam(params.startTime, "startTime");
+  const endTime = parseTimestampParam(params.endTime, "endTime");
+  const limitRaw = params.limit ? decodeURIComponent(params.limit).trim() : undefined;
+  const offsetRaw = params.offset ? decodeURIComponent(params.offset).trim() : undefined;
+  const deviceIdRaw = params.deviceId ? decodeURIComponent(params.deviceId).trim() : undefined;
+
+  return {
+    startTime,
+    endTime,
+    limit: parseInteger(limitRaw, "limit", { min: 1, max: PERFORMANCE_RESULTS_LIMIT_MAX }),
+    offset: parseInteger(offsetRaw, "offset", { min: 0 }),
+    deviceId: deviceIdRaw || undefined,
+  };
+}
+
+function buildPerformanceUri(options: PerformanceAuditQueryArgs): string {
+  const query = new URLSearchParams();
+  if (options.startTime !== undefined) {
+    query.set("startTime", String(options.startTime));
+  }
+  if (options.endTime !== undefined) {
+    query.set("endTime", String(options.endTime));
+  }
+  if (options.limit !== undefined) {
+    query.set("limit", options.limit.toString());
+  }
+  if (options.offset !== undefined) {
+    query.set("offset", options.offset.toString());
+  }
+  if (options.deviceId !== undefined) {
+    query.set("deviceId", options.deviceId);
+  }
+
+  const queryString = query.toString();
+  return queryString ? `${PERFORMANCE_RESOURCE_URIS.BASE}?${queryString}` : PERFORMANCE_RESOURCE_URIS.BASE;
+}
+
+async function getPerformanceResource(
+  args: PerformanceAuditQueryArgs,
+  uri: string
+): Promise<ResourceContent> {
+  try {
+    const response = await buildPerformanceAuditResponse(args);
+    return {
+      uri,
+      mimeType: "application/json",
+      text: JSON.stringify(response, null, 2)
+    };
+  } catch (error) {
+    logger.error(`[PerformanceResources] Failed to get performance audit results: ${error}`);
+    return {
+      uri,
+      mimeType: "application/json",
+      text: JSON.stringify({
+        error: `Failed to retrieve performance audit results: ${error}`
+      }, null, 2)
+    };
+  }
+}
+
+function registerPerformanceTemplates(
+  handler: (params: Record<string, string>) => Promise<ResourceContent>
+): void {
+  const keyCount = PERFORMANCE_QUERY_KEYS.length;
+  for (let mask = 1; mask < (1 << keyCount); mask += 1) {
+    const keys = PERFORMANCE_QUERY_KEYS.filter((_, index) => (mask & (1 << index)) !== 0);
+    ResourceRegistry.registerTemplate(
+      buildQueryTemplate(keys),
+      "Performance Results",
+      "List UI performance audit results from the local database.",
+      "application/json",
+      handler
+    );
+  }
+}
+
+export function registerPerformanceResources(): void {
+  ResourceRegistry.register(
+    PERFORMANCE_RESOURCE_URIS.BASE,
+    "Performance Results",
+    "List UI performance audit results from the local database.",
+    "application/json",
+    () => getPerformanceResource({}, PERFORMANCE_RESOURCE_URIS.BASE)
+  );
+
+  registerPerformanceTemplates(async params => {
+    try {
+      const options = parsePerformanceParams(params);
+      const uri = buildPerformanceUri(options);
+      return getPerformanceResource(options, uri);
+    } catch (error) {
+      logger.error(`[PerformanceResources] Failed to parse query params: ${error}`);
+      return {
+        uri: PERFORMANCE_RESOURCE_URIS.BASE,
+        mimeType: "application/json",
+        text: JSON.stringify({
+          error: `Invalid performance query parameters: ${error}`
+        }, null, 2)
+      };
+    }
+  });
+
+  logger.info("[PerformanceResources] Registered performance resources");
+}

--- a/src/server/performanceTools.ts
+++ b/src/server/performanceTools.ts
@@ -2,88 +2,33 @@ import { z } from "zod";
 import { ToolRegistry } from "./toolRegistry";
 import { ActionableError } from "../models/ActionableError";
 import { createJSONToolResponse } from "../utils/toolUtils";
-import { PerformanceAuditRepository } from "../db/performanceAuditRepository";
-import { ToolCallRepository } from "../db/toolCallRepository";
+import {
+  buildPerformanceAuditResponse,
+  PERFORMANCE_RESULTS_LIMIT_MAX,
+  type PerformanceAuditQueryArgs,
+} from "./performanceData";
 
-const listPerformanceAuditResultsSchema = z.object({
+const listPerformanceAuditResultsSchema: z.ZodType<PerformanceAuditQueryArgs> = z.object({
   startTime: z.union([z.string(), z.number()])
     .optional()
     .describe("Start timestamp (ISO string or epoch ms)"),
   endTime: z.union([z.string(), z.number()])
     .optional()
     .describe("End timestamp (ISO string or epoch ms)"),
-  limit: z.number().int().positive().max(500).optional().describe("Max results to return"),
+  limit: z.number().int().positive().max(PERFORMANCE_RESULTS_LIMIT_MAX).optional().describe("Max results to return"),
   offset: z.number().int().nonnegative().optional().describe("Offset for pagination"),
   deviceId: z.string().optional().describe("Optional device ID filter"),
 });
 
-function normalizeTimestamp(value?: string | number): string | undefined {
-  if (value === undefined || value === null) {
-    return undefined;
-  }
-  const date = new Date(value);
-  if (Number.isNaN(date.getTime())) {
-    throw new Error(`Invalid timestamp: ${value}`);
-  }
-  return date.toISOString();
-}
-
-function getTimestampRange(timestamps: string[]): { start: string; end: string } | null {
-  if (timestamps.length === 0) {
-    return null;
-  }
-  let start = timestamps[0];
-  let end = timestamps[0];
-  for (const timestamp of timestamps) {
-    if (timestamp < start) {
-      start = timestamp;
-    }
-    if (timestamp > end) {
-      end = timestamp;
-    }
-  }
-  return { start, end };
-}
-
 export function registerPerformanceTools(): void {
-  const auditRepository = new PerformanceAuditRepository();
-  const toolCallRepository = new ToolCallRepository();
-
   ToolRegistry.register(
     "listPerformanceAuditResults",
     "List UI performance audit results from the local database.",
     listPerformanceAuditResultsSchema,
     async args => {
       try {
-        const startTime = normalizeTimestamp(args.startTime);
-        const endTime = normalizeTimestamp(args.endTime);
-        const limit = args.limit ?? 50;
-        const offset = args.offset ?? 0;
-
-        const page = await auditRepository.listResults({
-          startTime,
-          endTime,
-          limit,
-          offset,
-          deviceId: args.deviceId,
-        });
-
-        const range = getTimestampRange(page.results.map(result => result.timestamp));
-        const toolCalls = range
-          ? await toolCallRepository.listToolNamesBetween(
-            range.start,
-            range.end,
-            ["listPerformanceAuditResults"]
-          )
-          : [];
-
-        return createJSONToolResponse({
-          results: page.results,
-          toolCalls,
-          hasMore: page.hasMore,
-          nextOffset: page.nextOffset,
-          range: range ? { startTime: range.start, endTime: range.end } : null,
-        });
+        const response = await buildPerformanceAuditResponse(args);
+        return createJSONToolResponse(response);
       } catch (error) {
         throw new ActionableError(`Failed to list performance audit results: ${error}`);
       }

--- a/src/server/testTimingData.ts
+++ b/src/server/testTimingData.ts
@@ -1,0 +1,151 @@
+import {
+  TestExecutionRepository,
+  TestTimingQueryOptions,
+  TEST_EXECUTION_RETENTION_MAX_DAYS,
+} from "../db/testExecutionRepository";
+
+export const DEFAULT_TEST_TIMING_LOOKBACK_DAYS = TEST_EXECUTION_RETENTION_MAX_DAYS;
+export const DEFAULT_TEST_TIMING_LIMIT = 1000;
+export const DEFAULT_TEST_TIMING_MIN_SAMPLES = 1;
+export const TEST_TIMING_LIMIT_MAX = 5000;
+
+export interface TestTimingQueryArgs {
+  lookbackDays?: number;
+  limit?: number;
+  minSamples?: number;
+  orderBy?: "lastRun" | "averageDuration" | "sampleSize";
+  orderDirection?: "asc" | "desc";
+  testClass?: string;
+  testMethod?: string;
+  deviceId?: string;
+  deviceName?: string;
+  devicePlatform?: "android" | "ios";
+  deviceType?: "emulator" | "simulator" | "device";
+  appVersion?: string;
+  gitCommit?: string;
+  targetSdk?: number;
+  jdkVersion?: string;
+  jvmTarget?: string;
+  gradleVersion?: string;
+  isCi?: boolean;
+  sessionUuid?: string;
+}
+
+export interface TestTimingResponseEntry {
+  testClass: string;
+  testMethod: string;
+  averageDurationMs: number;
+  sampleSize: number;
+  lastRunTimestampMs: number | null;
+  lastRun: string | null;
+  successRate: number;
+  failureRate: number;
+  stdDevDurationMs: number;
+  statusCounts: {
+    passed: number;
+    failed: number;
+    skipped: number;
+  };
+}
+
+export interface TestTimingResponse {
+  testTimings: TestTimingResponseEntry[];
+  generatedAt: string;
+  totalTests: number;
+  totalSamples: number;
+  aggregation: {
+    strategy: "mean";
+    lookbackDays: number;
+    minSamples: number;
+    limit: number;
+    orderBy: "lastRun" | "averageDuration" | "sampleSize";
+    orderDirection: "asc" | "desc";
+  };
+  filters: Record<string, unknown>;
+}
+
+const testExecutionRepository = new TestExecutionRepository();
+
+export async function buildTestTimingResponse(args: TestTimingQueryArgs): Promise<TestTimingResponse> {
+  const lookbackDays = args.lookbackDays ?? DEFAULT_TEST_TIMING_LOOKBACK_DAYS;
+  const limit = args.limit ?? DEFAULT_TEST_TIMING_LIMIT;
+  const minSamples = args.minSamples ?? DEFAULT_TEST_TIMING_MIN_SAMPLES;
+
+  const options: TestTimingQueryOptions = {
+    lookbackDays,
+    limit,
+    minSamples,
+    orderBy: args.orderBy,
+    orderDirection: args.orderDirection,
+    testClass: args.testClass,
+    testMethod: args.testMethod,
+    deviceId: args.deviceId,
+    deviceName: args.deviceName,
+    devicePlatform: args.devicePlatform,
+    deviceType: args.deviceType,
+    appVersion: args.appVersion,
+    gitCommit: args.gitCommit,
+    targetSdk: args.targetSdk,
+    jdkVersion: args.jdkVersion,
+    jvmTarget: args.jvmTarget,
+    gradleVersion: args.gradleVersion,
+    isCi: args.isCi,
+    sessionUuid: args.sessionUuid,
+  };
+
+  const timings = await testExecutionRepository.getTimingStats(options);
+  const totalSamples = timings.reduce((total, entry) => total + entry.sampleSize, 0);
+
+  const filters: Record<string, unknown> = {};
+  if (args.testClass) {filters.testClass = args.testClass;}
+  if (args.testMethod) {filters.testMethod = args.testMethod;}
+  if (args.deviceId) {filters.deviceId = args.deviceId;}
+  if (args.deviceName) {filters.deviceName = args.deviceName;}
+  if (args.devicePlatform) {filters.devicePlatform = args.devicePlatform;}
+  if (args.deviceType) {filters.deviceType = args.deviceType;}
+  if (args.appVersion) {filters.appVersion = args.appVersion;}
+  if (args.gitCommit) {filters.gitCommit = args.gitCommit;}
+  if (args.targetSdk !== undefined) {filters.targetSdk = args.targetSdk;}
+  if (args.jdkVersion) {filters.jdkVersion = args.jdkVersion;}
+  if (args.jvmTarget) {filters.jvmTarget = args.jvmTarget;}
+  if (args.gradleVersion) {filters.gradleVersion = args.gradleVersion;}
+  if (typeof args.isCi === "boolean") {filters.isCi = args.isCi;}
+  if (args.sessionUuid) {filters.sessionUuid = args.sessionUuid;}
+
+  return {
+    testTimings: timings.map(entry => ({
+      testClass: entry.testClass,
+      testMethod: entry.testMethod,
+      averageDurationMs: entry.averageDurationMs,
+      sampleSize: entry.sampleSize,
+      lastRunTimestampMs: entry.lastRunTimestampMs || null,
+      lastRun: entry.lastRunTimestampMs
+        ? new Date(entry.lastRunTimestampMs).toISOString()
+        : null,
+      successRate: entry.sampleSize > 0
+        ? Number((entry.passedCount / entry.sampleSize).toFixed(4))
+        : 0,
+      failureRate: entry.sampleSize > 0
+        ? Number((entry.failedCount / entry.sampleSize).toFixed(4))
+        : 0,
+      stdDevDurationMs: entry.stdDevDurationMs,
+      statusCounts: {
+        passed: entry.passedCount,
+        failed: entry.failedCount,
+        skipped: entry.skippedCount,
+      },
+    })),
+    generatedAt: new Date().toISOString(),
+    totalTests: timings.length,
+    totalSamples,
+    aggregation: {
+      strategy: "mean",
+      lookbackDays,
+      minSamples,
+      limit,
+      orderBy: options.orderBy ?? "lastRun",
+      orderDirection: options.orderDirection ?? "desc",
+    },
+    filters,
+  };
+}

--- a/src/server/testTimingResources.ts
+++ b/src/server/testTimingResources.ts
@@ -1,0 +1,135 @@
+import { ResourceRegistry, ResourceContent } from "./resourceRegistry";
+import { logger } from "../utils/logger";
+import {
+  buildTestTimingResponse,
+  TEST_TIMING_LIMIT_MAX,
+  type TestTimingQueryArgs,
+} from "./testTimingData";
+
+export const TEST_TIMING_RESOURCE_URIS = {
+  BASE: "automobile:test-timings",
+} as const;
+
+const TEST_TIMING_QUERY_KEYS = ["lookbackDays", "limit"] as const;
+type TestTimingQueryKey = typeof TEST_TIMING_QUERY_KEYS[number];
+
+function buildQueryTemplate(keys: readonly TestTimingQueryKey[]): string {
+  const query = keys.map(key => `${key}={${key}}`).join("&");
+  return `${TEST_TIMING_RESOURCE_URIS.BASE}?${query}`;
+}
+
+function parsePositiveInt(
+  value: string | undefined,
+  label: string,
+  options: { min?: number; max?: number } = {}
+): number | undefined {
+  if (!value) {
+    return undefined;
+  }
+
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed) || !Number.isInteger(parsed)) {
+    throw new Error(`Invalid ${label}: ${value}`);
+  }
+
+  const min = options.min ?? 1;
+  if (parsed < min) {
+    throw new Error(`Invalid ${label}: ${value}`);
+  }
+
+  if (options.max !== undefined && parsed > options.max) {
+    throw new Error(`Invalid ${label}: ${value}`);
+  }
+
+  return parsed;
+}
+
+function parseTestTimingParams(params: Record<string, string>): Pick<TestTimingQueryArgs, "lookbackDays" | "limit"> {
+  const lookbackRaw = params.lookbackDays ? decodeURIComponent(params.lookbackDays).trim() : undefined;
+  const limitRaw = params.limit ? decodeURIComponent(params.limit).trim() : undefined;
+
+  return {
+    lookbackDays: parsePositiveInt(lookbackRaw, "lookbackDays"),
+    limit: parsePositiveInt(limitRaw, "limit", { max: TEST_TIMING_LIMIT_MAX }),
+  };
+}
+
+function buildTestTimingUri(options: Pick<TestTimingQueryArgs, "lookbackDays" | "limit">): string {
+  const query = new URLSearchParams();
+  if (options.lookbackDays !== undefined) {
+    query.set("lookbackDays", options.lookbackDays.toString());
+  }
+  if (options.limit !== undefined) {
+    query.set("limit", options.limit.toString());
+  }
+  const queryString = query.toString();
+  return queryString ? `${TEST_TIMING_RESOURCE_URIS.BASE}?${queryString}` : TEST_TIMING_RESOURCE_URIS.BASE;
+}
+
+async function getTestTimingResource(
+  args: TestTimingQueryArgs,
+  uri: string
+): Promise<ResourceContent> {
+  try {
+    const response = await buildTestTimingResponse(args);
+    return {
+      uri,
+      mimeType: "application/json",
+      text: JSON.stringify(response, null, 2)
+    };
+  } catch (error) {
+    logger.error(`[TestTimingResources] Failed to get test timing data: ${error}`);
+    return {
+      uri,
+      mimeType: "application/json",
+      text: JSON.stringify({
+        error: `Failed to retrieve test timing data: ${error}`
+      }, null, 2)
+    };
+  }
+}
+
+function registerTestTimingTemplates(
+  handler: (params: Record<string, string>) => Promise<ResourceContent>
+): void {
+  const keyCount = TEST_TIMING_QUERY_KEYS.length;
+  for (let mask = 1; mask < (1 << keyCount); mask += 1) {
+    const keys = TEST_TIMING_QUERY_KEYS.filter((_, index) => (mask & (1 << index)) !== 0);
+    ResourceRegistry.registerTemplate(
+      buildQueryTemplate(keys),
+      "Test Timing History",
+      "Historical aggregated test execution timing statistics.",
+      "application/json",
+      handler
+    );
+  }
+}
+
+export function registerTestTimingResources(): void {
+  ResourceRegistry.register(
+    TEST_TIMING_RESOURCE_URIS.BASE,
+    "Test Timing History",
+    "Historical aggregated test execution timing statistics.",
+    "application/json",
+    () => getTestTimingResource({}, TEST_TIMING_RESOURCE_URIS.BASE)
+  );
+
+  registerTestTimingTemplates(async params => {
+    try {
+      const options = parseTestTimingParams(params);
+      const uri = buildTestTimingUri(options);
+      return getTestTimingResource(options, uri);
+    } catch (error) {
+      logger.error(`[TestTimingResources] Failed to parse query params: ${error}`);
+      return {
+        uri: TEST_TIMING_RESOURCE_URIS.BASE,
+        mimeType: "application/json",
+        text: JSON.stringify({
+          error: `Invalid test timing query parameters: ${error}`
+        }, null, 2)
+      };
+    }
+  });
+
+  logger.info("[TestTimingResources] Registered test timing resources");
+}

--- a/src/server/testTimingTools.ts
+++ b/src/server/testTimingTools.ts
@@ -2,19 +2,12 @@ import { z } from "zod";
 import { ToolRegistry } from "./toolRegistry";
 import { ActionableError } from "../models";
 import { createJSONToolResponse } from "../utils/toolUtils";
-import {
-  TestExecutionRepository,
-  TestTimingQueryOptions,
-  TEST_EXECUTION_RETENTION_MAX_DAYS,
-} from "../db/testExecutionRepository";
+import { buildTestTimingResponse, TEST_TIMING_LIMIT_MAX } from "./testTimingData";
+import type { TestTimingQueryArgs } from "./testTimingData";
 
-const DEFAULT_LOOKBACK_DAYS = TEST_EXECUTION_RETENTION_MAX_DAYS;
-const DEFAULT_LIMIT = 1000;
-const DEFAULT_MIN_SAMPLES = 1;
-
-const testTimingQuerySchema = z.object({
+const testTimingQuerySchema: z.ZodType<TestTimingQueryArgs> = z.object({
   lookbackDays: z.number().int().positive().optional().describe("Number of days of history to include."),
-  limit: z.number().int().positive().max(5000).optional().describe("Maximum number of tests to return."),
+  limit: z.number().int().positive().max(TEST_TIMING_LIMIT_MAX).optional().describe("Maximum number of tests to return."),
   minSamples: z.number().int().nonnegative().optional().describe("Minimum sample size to include a test."),
   orderBy: z.enum(["lastRun", "averageDuration", "sampleSize"]).optional().describe("Sort key for results."),
   orderDirection: z.enum(["asc", "desc"]).optional().describe("Sort direction for results."),
@@ -34,8 +27,6 @@ const testTimingQuerySchema = z.object({
   sessionUuid: z.string().optional().describe("Filter by session UUID."),
 }).strict();
 
-const testExecutionRepository = new TestExecutionRepository();
-
 export function registerTestTimingTools(): void {
   ToolRegistry.register(
     "getTestTimings",
@@ -43,88 +34,7 @@ export function registerTestTimingTools(): void {
     testTimingQuerySchema,
     async args => {
       try {
-        const lookbackDays = args.lookbackDays ?? DEFAULT_LOOKBACK_DAYS;
-        const limit = args.limit ?? DEFAULT_LIMIT;
-        const minSamples = args.minSamples ?? DEFAULT_MIN_SAMPLES;
-
-        const options: TestTimingQueryOptions = {
-          lookbackDays,
-          limit,
-          minSamples,
-          orderBy: args.orderBy,
-          orderDirection: args.orderDirection,
-          testClass: args.testClass,
-          testMethod: args.testMethod,
-          deviceId: args.deviceId,
-          deviceName: args.deviceName,
-          devicePlatform: args.devicePlatform,
-          deviceType: args.deviceType,
-          appVersion: args.appVersion,
-          gitCommit: args.gitCommit,
-          targetSdk: args.targetSdk,
-          jdkVersion: args.jdkVersion,
-          jvmTarget: args.jvmTarget,
-          gradleVersion: args.gradleVersion,
-          isCi: args.isCi,
-          sessionUuid: args.sessionUuid,
-        };
-
-        const timings = await testExecutionRepository.getTimingStats(options);
-        const totalSamples = timings.reduce((total, entry) => total + entry.sampleSize, 0);
-
-        const filters: Record<string, unknown> = {};
-        if (args.testClass) {filters.testClass = args.testClass;}
-        if (args.testMethod) {filters.testMethod = args.testMethod;}
-        if (args.deviceId) {filters.deviceId = args.deviceId;}
-        if (args.deviceName) {filters.deviceName = args.deviceName;}
-        if (args.devicePlatform) {filters.devicePlatform = args.devicePlatform;}
-        if (args.deviceType) {filters.deviceType = args.deviceType;}
-        if (args.appVersion) {filters.appVersion = args.appVersion;}
-        if (args.gitCommit) {filters.gitCommit = args.gitCommit;}
-        if (args.targetSdk !== undefined) {filters.targetSdk = args.targetSdk;}
-        if (args.jdkVersion) {filters.jdkVersion = args.jdkVersion;}
-        if (args.jvmTarget) {filters.jvmTarget = args.jvmTarget;}
-        if (args.gradleVersion) {filters.gradleVersion = args.gradleVersion;}
-        if (typeof args.isCi === "boolean") {filters.isCi = args.isCi;}
-        if (args.sessionUuid) {filters.sessionUuid = args.sessionUuid;}
-
-        const response = {
-          testTimings: timings.map(entry => ({
-            testClass: entry.testClass,
-            testMethod: entry.testMethod,
-            averageDurationMs: entry.averageDurationMs,
-            sampleSize: entry.sampleSize,
-            lastRunTimestampMs: entry.lastRunTimestampMs || null,
-            lastRun: entry.lastRunTimestampMs
-              ? new Date(entry.lastRunTimestampMs).toISOString()
-              : null,
-            successRate: entry.sampleSize > 0
-              ? Number((entry.passedCount / entry.sampleSize).toFixed(4))
-              : 0,
-            failureRate: entry.sampleSize > 0
-              ? Number((entry.failedCount / entry.sampleSize).toFixed(4))
-              : 0,
-            stdDevDurationMs: entry.stdDevDurationMs,
-            statusCounts: {
-              passed: entry.passedCount,
-              failed: entry.failedCount,
-              skipped: entry.skippedCount,
-            },
-          })),
-          generatedAt: new Date().toISOString(),
-          totalTests: timings.length,
-          totalSamples,
-          aggregation: {
-            strategy: "mean",
-            lookbackDays,
-            minSamples,
-            limit,
-            orderBy: options.orderBy ?? "lastRun",
-            orderDirection: options.orderDirection ?? "desc",
-          },
-          filters,
-        };
-
+        const response = await buildTestTimingResponse(args);
         return createJSONToolResponse(response);
       } catch (error) {
         throw new ActionableError(`Failed to retrieve test timing data: ${error}`);


### PR DESCRIPTION
## Summary
- add MCP resources for test timing history and performance audit results
- share query/response builders between tools and resources for consistent output
- register new resources during MCP server setup

## Testing
- bun run lint
- bun run build
- bun run test
