### PR TITLE
Add Android design docs and IDE plugin pages

### DIFF
--- a/docs/design-docs/plat/android/accessibility-testing.md
+++ b/docs/design-docs/plat/android/accessibility-testing.md
@@ -1,0 +1,55 @@
+# Extended accessibility testing
+
+## Goal
+
+Expose an MCP tool that runs fast a11y checks using the existing
+AccessibilityService, with optional deeper checks via ATF.
+
+## Proposed MCP tool
+
+```
+runA11yChecks({
+  scope: "visible" | "screen",
+  includeContrast: boolean,
+  includeFocusOrder: boolean,
+  minTapTargetDp: 48
+})
+```
+
+Return structure should include:
+
+- `violations`: array of rule IDs, node references, and summaries
+- `supported`: per-rule capability flags
+
+## Android implementation
+
+Baseline checks (fast, AccessibilityService):
+
+- Content description on image-only controls
+- Minimum tap target size (dp -> px from density)
+- Clickable without label
+- Duplicate or ambiguous labels
+- Focusability issues for editable text
+
+Contrast checks:
+
+- Use a recent screenshot and view bounds from AccessibilityNodeInfo.
+- Sample foreground and background colors and compute WCAG contrast ratio.
+- Flag nodes under a threshold (e.g., 4.5:1).
+
+Optional ATF integration:
+
+- Dependency: `com.google.android.apps.common.testing.accessibility:accessibility-test-framework`
+- Use `AccessibilityCheckRunner.runChecks()` on the current node tree.
+- Map ATF results into the MCP violation schema.
+
+## Plan
+
+1. Implement baseline heuristic rules using accessibility nodes.
+2. Add contrast checks with screenshot sampling.
+3. Add optional ATF integration behind a feature flag.
+
+## Risks
+
+- Contrast sampling can be noisy on transparent backgrounds.
+- ATF may increase build size and dependency surface.

--- a/docs/design-docs/plat/android/biometrics.md
+++ b/docs/design-docs/plat/android/biometrics.md
@@ -1,0 +1,72 @@
+# Biometrics stubbing (Android)
+
+## Goal
+
+Allow tests and agents to trigger biometric success/failure/cancel on
+emulators (API 29/35) and provide a path for app-under-test integration
+when emulator support is not sufficient.
+
+## Proposed MCP tool
+
+```
+biometricAuth({
+  action: "match" | "fail" | "cancel",
+  modality: "any" | "fingerprint" | "face",
+  fingerprintId?: number
+})
+```
+
+Behavior:
+
+- `modality: any` prefers fingerprint on emulator (highest support).
+- `action: match` should succeed if enrollment exists.
+- `action: fail` should simulate a non-matching biometric.
+
+## Emulator implementation (API 29/35)
+
+Primary mechanism (fingerprint):
+
+- Enroll a fingerprint in Settings (one-time per emulator snapshot).
+- Trigger match: `adb -s <device> emu finger touch <id>`
+- Release sensor: `adb -s <device> emu finger remove <id>`
+
+Failure simulation:
+
+- Use a non-enrolled `<id>` to generate a mismatch when the prompt is active.
+- If emulator does not differentiate ids, treat `fail` as `cancel` and return
+  `supported: partial` with a reason.
+
+Capability probing:
+
+- `adb -s <device> shell getprop ro.kernel.qemu` (1 indicates emulator)
+- `adb -s <device> emu help` to confirm `finger` commands are available
+
+## App-under-test integration (AutoMobile SDK)
+
+When emulator-only support is not enough, add a debug-only SDK hook to
+bypass or simulate biometric callbacks within the app-under-test.
+
+Suggested SDK entrypoint:
+
+```
+AutoMobileBiometrics.overrideResult(
+  result = SUCCESS | FAILURE | CANCEL,
+  ttlMs = 5000
+)
+```
+
+Notes:
+
+- This is a build-time opt-in for apps we can modify.
+- It can bypass the system prompt to make tests deterministic.
+
+## Plan
+
+1. Implement emulator fingerprint support via `adb emu finger`.
+2. Add capability detection and clear error messages for unsupported devices.
+3. Add optional SDK hook for deterministic app-under-test flows.
+
+## Risks
+
+- Emulator support is primarily fingerprint; face/iris is not consistent.
+- Physical devices may not allow simulation without device-owner privileges.

--- a/docs/design-docs/plat/android/clipboard.md
+++ b/docs/design-docs/plat/android/clipboard.md
@@ -1,0 +1,48 @@
+# Clipboard tool
+
+## Goal
+
+Provide clipboard copy/paste/clear/get for Android 29/35 emulators and
+best-effort support on devices.
+
+## Proposed MCP tool
+
+```
+clipboard({
+  action: "copy" | "paste" | "clear" | "get",
+  text?: string
+})
+```
+
+## Android implementation
+
+Primary path (API 29/35 if supported):
+
+- `adb -s <device> shell cmd clipboard set "<text>"`
+- `adb -s <device> shell cmd clipboard get`
+- `adb -s <device> shell cmd clipboard clear`
+
+Capability probe:
+
+- `adb -s <device> shell cmd clipboard help`
+
+Fallback path (helper APK):
+
+- Helper app exposes a broadcast receiver or bound service to set/read
+  the clipboard via `ClipboardManager`.
+- AutoMobile reads results via file or socket for `get`.
+
+Notes:
+
+- Newer Android versions restrict clipboard reads for background apps.
+  The helper should run in the foreground when possible.
+
+## Plan
+
+1. Implement adb `cmd clipboard` support with capability detection.
+2. Add helper APK fallback for consistent behavior.
+
+## Risks
+
+- Clipboard reads may be blocked on physical devices without foreground UI.
+- Service call clipboard APIs are unstable across OEMs.

--- a/docs/design-docs/plat/android/executeplan-assertions.md
+++ b/docs/design-docs/plat/android/executeplan-assertions.md
@@ -1,0 +1,51 @@
+# executePlan assertions and await
+
+## Goal
+
+Add native assertion and await steps to `executePlan`, with fail-fast
+behavior by default and idling support from accessibility events.
+
+## Proposed YAML extensions
+
+```
+- await:
+    lookFor:
+      text: "Logged in"
+    timeoutMs: 5000
+    idle: "a11y"
+
+- assert:
+    exists:
+      resourceId: "com.app:id/error"
+    shouldBe: false
+```
+
+Semantics:
+
+- `await` polls until the selector matches or timeout occurs.
+- `assert` fails immediately when the condition is not met.
+- Default failure mode is hard fail (stop plan). JUnitRunner can wrap
+  failures into test assertions if needed.
+
+## Android implementation
+
+Idle detection:
+
+- Prefer AccessibilityService events (e.g., `WINDOW_CONTENT_CHANGED`).
+- If no events arrive, fall back to polling `observe` at a low interval.
+
+Selector resolution:
+
+- Reuse existing element finding logic (text/resourceId/regex/class).
+- The tool should return `lastObservationId` for debugging.
+
+## Plan
+
+1. Extend executePlan schema to include `await` and `assert` steps.
+2. Implement a11y-event idling with polling fallback.
+3. Map failures to JUnitRunner assertions when invoked under JUnit.
+
+## Risks
+
+- Event-driven idling may miss transient states; use a min-hold duration.
+- Polling too aggressively can increase device load.

--- a/docs/design-docs/plat/android/feature-ideas.md
+++ b/docs/design-docs/plat/android/feature-ideas.md
@@ -1,0 +1,28 @@
+# Android Feature Ideas (Draft)
+
+This page summarizes Android-specific MCP feature ideas and links to the
+per-feature design notes.
+
+## Current scope decisions
+
+- Emulator images: API 29 and API 35.
+- Helper APKs are allowed and preferred when faster or more reliable.
+- Use the AccessibilityService whenever it is the lowest-latency option.
+- Biometrics: support any available modality (fingerprint first).
+- Notifications must appear as the app-under-test (use AutoMobile SDK hooks).
+- Network controls should include all toggles plus shaping profiles.
+- executePlan failures should halt immediately (JUnitRunner may override).
+- Multi-device tests should support true parallel steps plus critical sections.
+
+## Feature docs
+
+- [takeScreenshot fallback](take-screenshot.md)
+- [Biometrics stubbing](biometrics.md)
+- [Network state control](network-state.md)
+- [Extended accessibility testing](accessibility-testing.md)
+- [Notification triggering](notifications.md)
+- [System tray lookFor notifications](system-tray-lookfor.md)
+- [executePlan assertions and await](executeplan-assertions.md)
+- [TalkBack simulation/enablement](talkback.md)
+- [Multi-device and critical sections](multi-device.md)
+- [Clipboard tool](clipboard.md)

--- a/docs/design-docs/plat/android/ide-plugin/feature-flags.md
+++ b/docs/design-docs/plat/android/ide-plugin/feature-flags.md
@@ -1,0 +1,43 @@
+# Intellij IDE Plugin - Feature Flags
+
+## Goal
+
+Provide a dedicated UI in the Android Studio plugin to view and toggle
+AutoMobile feature flags without leaving the IDE.
+
+## UX
+
+- Tool window tab: "Feature Flags".
+- Table view with:
+  - Flag key
+  - Current value
+  - Description (if provided)
+  - Toggle control
+- Search/filter by flag key.
+- A refresh action to re-fetch from the daemon socket.
+
+## Data sources
+
+Use the AutoMobile daemon Unix socket (e.g., `/tmp/auto-mobile-daemon-<uid>.sock`)
+to fetch and update feature flags. Avoid MCP tool calls for this surface.
+
+## Behavior
+
+- Load flags on tab open and on explicit refresh.
+- Optimistically update the UI after a toggle, but roll back on error.
+- If a flag is read-only, disable the toggle and show the reason.
+
+## Error handling
+
+- If the daemon socket is unavailable, show a reconnect state.
+- If a toggle fails, show a toast with the error message and revert.
+
+## Performance notes
+
+- Cache the last fetched list and only diff updates when reloading.
+- Debounce search input to avoid UI thrash.
+
+## See also
+
+- [Feature Flags](../../mcp/feature-flags.md)
+- [IDE Plugin Overview](overview.md)

--- a/docs/design-docs/plat/android/ide-plugin/navigation-graph.md
+++ b/docs/design-docs/plat/android/ide-plugin/navigation-graph.md
@@ -1,0 +1,48 @@
+# Intellij IDE Plugin - Navigation Graph Render
+
+## Goal
+
+Render the current navigation graph inside the Android Studio plugin so
+engineers can inspect app flow and validate navigation coverage without
+leaving the IDE.
+
+## UX
+
+- Tool window tab: "Navigation Graph".
+- Graph view with zoom/pan and node selection.
+- Selected node shows:
+  - Screen name
+  - Last observed activity/package
+  - Recent transitions (incoming/outgoing)
+- Latest cached screenshot for the screen, if available.
+- A refresh action to fetch the latest graph snapshot.
+
+## Data sources
+
+The MCP server streams navigation graph updates to the plugin. Nodes may
+include an optional screenshot reference, exposed via navigation node
+resources.
+
+## Rendering pipeline
+
+1. Subscribe to the server's navigation graph stream.
+2. Normalize nodes/edges into a stable layout model.
+3. Render via a lightweight graph UI (no per-frame allocations).
+4. Keep a cached layout and only recompute on structural changes.
+
+## Error handling
+
+- If the graph is empty, show a "No navigation data yet" state.
+- If the MCP server is unreachable, show a reconnect action with diagnostics.
+- If parsing fails, log the raw payload and surface a brief error.
+
+## Performance notes
+
+- Defer layout work until the view is visible.
+- Limit re-renders to changes in graph topology.
+- Avoid blocking the UI thread on large graphs.
+
+## See also
+
+- [Navigation Graph](../../mcp/navigation-graph.md)
+- [IDE Plugin Overview](overview.md)

--- a/docs/design-docs/plat/android/multi-device.md
+++ b/docs/design-docs/plat/android/multi-device.md
@@ -1,0 +1,115 @@
+# Multi-device and critical sections
+
+## Goal
+
+Enable true parallel steps in `executePlan`, while supporting critical
+sections where only one device can proceed at a time. Keep the plan format
+close to the existing single-device test plans by adding a `device` key per
+step and a simple `devices` list. Parallelism is implicit: top-level steps
+for different devices run concurrently unless synchronized via
+`criticalSection`.
+
+## Proposed YAML extensions
+
+Simple device labels, allocated by JUnitRunner/Daemon:
+
+```
+devices: ["A", "B"]
+
+steps:
+  - tool: launchApp
+    device: A
+    appId: com.chat.app
+    label: Launch chat app (sender)
+
+  - tool: launchApp
+    device: B
+    appId: com.chat.app
+    label: Launch chat app (receiver)
+```
+
+Top-level steps remain consistent; parallelism is implicit:
+
+```
+devices: ["A", "B"]
+
+steps:
+  - tool: launchApp
+    device: A
+    appId: com.chat.app
+    label: Launch sender
+
+  - tool: launchApp
+    device: B
+    appId: com.chat.app
+    label: Launch receiver
+
+  - tool: criticalSection
+    lock: "chat-room"
+    steps:
+      - tool: inputText
+        device: A
+        text: "Hello"
+        label: Type message
+      - tool: imeAction
+        device: A
+        action: send
+        label: Send message
+
+  - tool: openSystemTray
+    device: B
+    lookFor: { text: "Hello" }
+    timeoutMs: 5000
+    label: Verify notification
+```
+
+YAML anchors (merge keys) should be supported for reuse and validation:
+
+```
+devices: ["A", "B"]
+
+tap: &tap
+  tool: tapOn
+  action: tap
+
+steps:
+  - <<: *tap
+    device: A
+    id: "com.google.android.deskclock:id/tab_menu_alarm"
+    label: Tap Alarm tab
+  - <<: *tap
+    device: B
+    id: "com.google.android.deskclock:id/tab_menu_alarm"
+    label: Tap Alarm tab
+```
+
+Semantics:
+
+- `devices` is a list of labels to allocate sessions for; JUnitRunner requests
+  the required number of devices from the MCP Daemon and maps them to labels.
+- `device` on a step selects the label for routing.
+- Steps targeting different devices run concurrently by default.
+- `criticalSection` is a mutex; all devices must reach it, then steps execute
+  one device at a time within the section.
+- Optional `barrier` tool can synchronize devices without serializing actions.
+
+## Android implementation
+
+- Resolve label -> session routing in JUnitRunner/Daemon, not in the plan.
+- Use a per-plan scheduler to track device tasks and locks.
+- `criticalSection` waits until all devices reach the block before executing
+  steps in a single-device sequence.
+- Emit per-device timing metadata for debugging.
+- Support YAML merge keys (`<<`) so anchors validate correctly.
+
+## Plan
+
+1. Add `devices` list and `device` routing key on steps.
+2. Run top-level steps in parallel when device labels differ.
+3. Add `criticalSection` tool support with a per-plan lock registry.
+4. Support YAML anchors and merge keys in validation.
+
+## Risks
+
+- Parallel actions can cause ordering hazards without explicit locks.
+- Timeouts need to be per-device to avoid deadlocks.

--- a/docs/design-docs/plat/android/network-state.md
+++ b/docs/design-docs/plat/android/network-state.md
@@ -1,0 +1,69 @@
+# Network state control
+
+## Goal
+
+Provide a single MCP tool to toggle Wi-Fi, cellular, and airplane mode,
+plus emulator-friendly latency/bandwidth shaping.
+
+## Proposed MCP tool
+
+```
+setNetworkState({
+  airplaneMode?: boolean,
+  wifi?: boolean,
+  cellular?: boolean,
+  profile?: "edge" | "umts" | "lte" | "full",
+  delayProfile?: "gprs" | "edge" | "umts" | "none"
+})
+```
+
+Semantics:
+
+- Toggles are applied first (airplane, wifi, cellular).
+- Profiles are best-effort on emulators only.
+- Response includes `supported` and `applied` fields per sub-action.
+
+## Android implementation
+
+Wi-Fi:
+
+- `adb -s <device> shell svc wifi enable`
+- `adb -s <device> shell svc wifi disable`
+
+Cellular:
+
+- `adb -s <device> shell svc data enable`
+- `adb -s <device> shell svc data disable`
+
+Airplane mode (preferred, API 29/35 emulators):
+
+- `adb -s <device> shell cmd connectivity airplane-mode enable`
+- `adb -s <device> shell cmd connectivity airplane-mode disable`
+
+Airplane mode fallback:
+
+- `adb -s <device> shell settings put global airplane_mode_on 1|0`
+- `adb -s <device> shell am broadcast -a android.intent.action.AIRPLANE_MODE --ez state true|false`
+
+Emulator shaping (API 29/35 emulator only):
+
+- `adb -s <device> emu network speed <profile>`
+- `adb -s <device> emu network delay <profile>`
+
+Notes:
+
+- Custom ms/throughput values are not supported by `emu network` and should
+  be rejected with a clear error.
+- Physical devices often restrict airplane mode toggles; report
+  `supported: false` with a reason when blocked.
+
+## Plan
+
+1. Implement toggles with capability reporting.
+2. Add emulator shaping support (speed/delay profiles).
+3. Expose `getNetworkState` for verification in assertions.
+
+## Risks
+
+- OEM images may block `cmd connectivity airplane-mode`.
+- Work profile behavior can differ from personal profile toggles.

--- a/docs/design-docs/plat/android/notifications.md
+++ b/docs/design-docs/plat/android/notifications.md
@@ -1,0 +1,65 @@
+# Notification triggering
+
+## Goal
+
+Trigger notifications that appear as the app-under-test. Provide
+rich content (title, body, big text, big image, actions).
+
+## Proposed MCP tool
+
+```
+postNotification({
+  title: string,
+  body: string,
+  style?: "default" | "bigText" | "bigPicture",
+  imagePath?: string,
+  actions?: Array<{ label: string, actionId: string }>,
+  channelId?: string
+})
+```
+
+## Preferred path: AutoMobile SDK hook (app-under-test)
+
+Add a debug-only SDK component that accepts a broadcast or bound-service
+request and posts a notification from the target app process.
+
+Suggested SDK entrypoint (app side):
+
+```
+AutoMobileNotifications.post(
+  title,
+  body,
+  style,
+  imagePath,
+  actions
+)
+```
+
+Implementation notes:
+
+- Use `NotificationManager` / `NotificationCompat` with a known channel ID.
+- When `style == bigPicture`, load from `imagePath` on device storage
+  (e.g., `/sdcard/Download/automobile/`) or decode base64 payload.
+- Actions should target a test-only activity or broadcast receiver.
+
+## Fallback path (emulator only)
+
+Use `cmd notification` for basic text notifications when SDK hooks are
+not available (does not look like app-under-test).
+
+- `adb -s <device> shell cmd notification post -S bigtext -t "Title" <tag> "Body"`
+- Validate command support with `adb -s <device> shell cmd notification help`
+
+This path should be flagged as `supported: partial` and discouraged
+in tool descriptions.
+
+## Plan
+
+1. Implement SDK notification hook (debug-only).
+2. Add MCP `postNotification` tool that targets SDK by default.
+3. Provide emulator-only fallback using `cmd notification`.
+
+## Risks
+
+- Requires app-under-test integration (not possible for third-party apps).
+- Big picture style has size constraints and may fail with large images.

--- a/docs/design-docs/plat/android/system-tray-lookfor.md
+++ b/docs/design-docs/plat/android/system-tray-lookfor.md
@@ -1,0 +1,57 @@
+# System tray lookFor (notifications)
+
+## Goal
+
+Enable agents to open the notification shade and wait for a matching
+notification by text or resource ID.
+
+## Proposed MCP tool
+
+Option A (extend existing):
+
+```
+openSystemTray({
+  lookFor?: { text?: string, resourceId?: string },
+  timeoutMs?: number,
+  pollIntervalMs?: number
+})
+```
+
+Option B (new):
+
+```
+lookForNotification({
+  text?: string,
+  resourceId?: string,
+  timeoutMs?: number
+})
+```
+
+## Android implementation
+
+Open/close the tray (preferred, emulator):
+
+- `adb -s <device> shell cmd statusbar expand-notifications`
+- `adb -s <device> shell cmd statusbar collapse`
+
+Fallback (gesture):
+
+- Swipe down from status bar if `cmd statusbar` is unavailable.
+
+Finding notifications:
+
+- Use AccessibilityService to read the System UI node tree.
+- Search for a node with matching text or resource ID in
+  `com.android.systemui`.
+- Return bounding box + hierarchy path for use in follow-up taps.
+
+## Plan
+
+1. Add `lookFor` and timeout handling to tray open.
+2. Use accessibility node search to match notifications.
+3. Return structured match details for action chaining.
+
+## Risks
+
+- OEM System UI layouts vary; emulator support may be the reliable baseline.
+- Requires AccessibilityService access to System UI nodes.

--- a/docs/design-docs/plat/android/take-screenshot.md
+++ b/docs/design-docs/plat/android/take-screenshot.md
@@ -1,0 +1,58 @@
+# takeScreenshot fallback
+
+## Goal
+
+Provide a screenshot tool that is explicitly a visual fallback when element
+lookup fails. The tool should be gated by server-side checks so agents
+cannot treat it as a primary discovery method.
+
+## Proposed MCP tool
+
+```
+takeScreenshot({
+  reason: "element-not-found",
+  context: {
+    action: "tapOn",
+    selector: { text: "Login" }
+  },
+  preferReuse: true
+})
+```
+
+Key semantics:
+
+- `reason` must be `element-not-found`.
+- Server issues a short-lived "fallback ticket" after a not-found failure;
+  `takeScreenshot` consumes it. Calls without a ticket fail.
+- `preferReuse` reuses the most recent `observe` screenshot if it is fresh
+  (e.g., under 250ms) to avoid another capture.
+
+## Android implementation
+
+Preferred capture path (fast, no temp file):
+
+- `adb -s <device> exec-out screencap -p`
+
+Fallback path (older devices/emulators):
+
+- `adb -s <device> shell screencap -p /sdcard/automobile/s.png`
+- `adb -s <device> pull /sdcard/automobile/s.png <out>`
+
+Notes:
+
+- API 29/35 emulators support `exec-out` reliably; keep the file-based path
+  as a compatibility fallback.
+- If AccessibilityService already delivered a screenshot in the last N ms,
+  reuse it and return `reused: true` to keep the tool cheap.
+
+## Plan
+
+1. Add MCP tool metadata and server-side gating (fallback ticket).
+2. Reuse recent `observe` screenshots when available.
+3. Add a `reused` flag to the response for agent transparency.
+
+## Risks
+
+- Agents can still call the tool after a legitimate not-found, but server
+  gating prevents general misuse.
+- If `observe` is not delivering screenshots, fallback costs increase.

--- a/docs/design-docs/plat/android/talkback.md
+++ b/docs/design-docs/plat/android/talkback.md
@@ -1,0 +1,44 @@
+# TalkBack simulation / enablement
+
+## Goal
+
+Support TalkBack testing on emulator images (API 29/35) either by
+best-effort enabling real TalkBack or by simulating key behaviors via
+AutoMobile's AccessibilityService.
+
+## Proposed MCP tools
+
+```
+setTalkBackEnabled({ enabled: boolean })
+setA11yFocus({ resourceId?: string, text?: string })
+announce({ text: string })
+```
+
+## Android implementation
+
+Real TalkBack (best-effort, emulator):
+
+- Detect the service name via `adb -s <device> shell dumpsys accessibility`.
+- Enable:
+  - `adb -s <device> shell settings put secure enabled_accessibility_services <service>`
+  - `adb -s <device> shell settings put secure accessibility_enabled 1`
+- Disable:
+  - `adb -s <device> shell settings put secure enabled_accessibility_services ''`
+  - `adb -s <device> shell settings put secure accessibility_enabled 0`
+
+Simulated TalkBack (reliable, helper-based):
+
+- Use AccessibilityService to move focus and announce text via TTS.
+- `setA11yFocus` searches nodes and requests focus.
+- `announce` uses TextToSpeech to emit the same strings an agent would hear.
+
+## Plan
+
+1. Implement simulated focus + announce tools (works on all devices).
+2. Add best-effort TalkBack enablement for emulators with the service installed.
+3. Report `supported: false` on physical devices without privileges.
+
+## Risks
+
+- Some emulator images do not ship TalkBack; simulated mode remains primary.
+- Real TalkBack can interfere with automation timing; gating may be needed.

--- a/docs/install/plat/android.md
+++ b/docs/install/plat/android.md
@@ -48,11 +48,13 @@ Quick example:
 ## Troubleshooting
 
 **ADB not found:**
+
 1. Verify installation: `which adb` or `where adb` (Windows)
 2. Check environment variables are set
 3. Restart terminal after setting `PATH`
 
 **Devices not showing:**
+
 1. Run `adb devices` to verify connection
 2. Accept USB debugging prompt on device
 3. Try `adb kill-server && adb start-server`

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -110,9 +110,21 @@ nav:
             - 'IDE Plugin':
               - 'Overview': design-docs/plat/android/ide-plugin/overview.md
               - 'Test Recording': design-docs/plat/android/ide-plugin/test-recording.md
-              - 'Navigation Graph Render': design-docs/plat/android/ide-plugin/test-recording.md
-              - 'Control Feature Flags': design-docs/plat/android/ide-plugin/test-recording.md
+              - 'Navigation Graph Render': design-docs/plat/android/ide-plugin/navigation-graph.md
+              - 'Control Feature Flags': design-docs/plat/android/ide-plugin/feature-flags.md
             - 'Work Profiles': design-docs/plat/android/work-profiles.md
+            - 'Feature Ideas':
+              - 'Overview': design-docs/plat/android/feature-ideas.md
+              - 'takeScreenshot fallback': design-docs/plat/android/take-screenshot.md
+              - 'Biometrics stubbing': design-docs/plat/android/biometrics.md
+              - 'Network state control': design-docs/plat/android/network-state.md
+              - 'Accessibility testing': design-docs/plat/android/accessibility-testing.md
+              - 'Notification triggering': design-docs/plat/android/notifications.md
+              - 'System tray lookFor': design-docs/plat/android/system-tray-lookfor.md
+              - 'executePlan assertions': design-docs/plat/android/executeplan-assertions.md
+              - 'TalkBack simulation': design-docs/plat/android/talkback.md
+              - 'Multi-device': design-docs/plat/android/multi-device.md
+              - 'Clipboard tool': design-docs/plat/android/clipboard.md
           - 'iOS':
             - 'Overview': design-docs/plat/ios/index.md
             - 'Accessibility Bridge': design-docs/plat/ios/accessibility-service.md


### PR DESCRIPTION
## Summary
- add Android feature design docs under `docs/design-docs/plat/android/`
- add IDE plugin docs for navigation graph rendering and feature flag control
- update mkdocs navigation and fix Android install troubleshooting list formatting

## Testing
- not run (docs-only changes)
