### PR TITLE
Fix IDE plugin doc links to MCP design docs

### DIFF
--- a/docs/design-docs/plat/android/ide-plugin/feature-flags.md
+++ b/docs/design-docs/plat/android/ide-plugin/feature-flags.md
@@ -39,5 +39,5 @@ to fetch and update feature flags. Avoid MCP tool calls for this surface.
 
 ## See also
 
-- [Feature Flags](../../mcp/feature-flags.md)
+- [Feature Flags](../../../mcp/feature-flags.md)
 - [IDE Plugin Overview](overview.md)

--- a/docs/design-docs/plat/android/ide-plugin/navigation-graph.md
+++ b/docs/design-docs/plat/android/ide-plugin/navigation-graph.md
@@ -44,5 +44,5 @@ resources.
 
 ## See also
 
-- [Navigation Graph](../../mcp/navigation-graph.md)
+- [Navigation Graph](../../../mcp/navigation-graph.md)
 - [IDE Plugin Overview](overview.md)


### PR DESCRIPTION
## Summary
- fix MCP doc links in Android IDE plugin design docs

## Testing
- ./scripts/validate_mkdocs_nav.sh
- ./scripts/lychee/validate_lychee.sh
