### PR TITLE
Add device labels for device-scoped tools

### DIFF
--- a/android/junit-runner/build.gradle.kts
+++ b/android/junit-runner/build.gradle.kts
@@ -93,6 +93,15 @@ tasks.configureEach {
 tasks.withType<Test> {
   // Enable parallel test execution across multiple devices
   maxParallelForks = Runtime.getRuntime().availableProcessors().coerceAtLeast(2)
+  dependsOn(":accessibility-service:assembleDebug")
+  val accessibilityApk =
+      project(":accessibility-service")
+          .layout
+          .buildDirectory
+          .file("outputs/apk/debug/accessibility-service-debug.apk")
+  environment("AUTOMOBILE_ACCESSIBILITY_APK_PATH", accessibilityApk.get().asFile.absolutePath)
+  systemProperty("automobile.accessibility.apk.path", accessibilityApk.get().asFile.absolutePath)
+  systemProperty("automobile.daemon.force.restart", "true")
 
   testLogging {
     // Show standard output and error for tests

--- a/android/junit-runner/src/main/kotlin/dev/jasonpearson/automobile/junit/AutoMobileSharedUtils.kt
+++ b/android/junit-runner/src/main/kotlin/dev/jasonpearson/automobile/junit/AutoMobileSharedUtils.kt
@@ -7,8 +7,21 @@ object AutoMobileSharedUtils {
   // Phase 5: Lazy device checker initialization
   val deviceChecker: DeviceAvailabilityChecker by lazy { DeviceAvailabilityChecker() }
 
-  fun executeCommand(command: List<String>, timeoutMs: Long): CommandResult {
-    val process = ProcessBuilder(command).start()
+  fun executeCommand(
+      command: List<String>,
+      timeoutMs: Long,
+      environmentOverrides: Map<String, String> = emptyMap(),
+  ): CommandResult {
+    val processBuilder = ProcessBuilder(command)
+    if (environmentOverrides.isNotEmpty()) {
+      val environment = processBuilder.environment()
+      environmentOverrides.forEach { (key, value) ->
+        if (value.isNotBlank()) {
+          environment[key] = value
+        }
+      }
+    }
+    val process = processBuilder.start()
 
     // CRITICAL FIX: Close stdin immediately to prevent the process from hanging
     // waiting for input. This is essential for non-interactive command execution.

--- a/android/junit-runner/src/main/kotlin/dev/jasonpearson/automobile/junit/DaemonSocketClient.kt
+++ b/android/junit-runner/src/main/kotlin/dev/jasonpearson/automobile/junit/DaemonSocketClient.kt
@@ -48,21 +48,33 @@ internal object DaemonSocketClientManager {
   }
 
   private fun ensureDaemonRunning() {
-    if (DaemonSocketClient.isAvailable(DaemonSocketPaths.socketPath())) {
+    val socketPath = DaemonSocketPaths.socketPath()
+    val forceRestart = SystemPropertyCache.getBoolean("automobile.daemon.force.restart", false)
+    if (!forceRestart && DaemonSocketClient.isAvailable(socketPath)) {
       return
     }
 
-    val startCommand = DaemonSocketPaths.buildDaemonStartCommand()
+    val startCommand =
+        if (forceRestart) {
+          DaemonSocketPaths.buildDaemonRestartCommand()
+        } else {
+          DaemonSocketPaths.buildDaemonStartCommand()
+        }
     val debugMode = SystemPropertyCache.getBoolean("automobile.debug", false)
     if (debugMode) {
       println("Starting AutoMobile daemon with: ${startCommand.joinToString(" ")}")
     }
 
-    AutoMobileSharedUtils.executeCommand(startCommand, DaemonSocketPaths.daemonStartTimeoutMs())
+    val environmentOverrides = resolveDaemonEnvironmentOverrides()
+    AutoMobileSharedUtils.executeCommand(
+        startCommand,
+        DaemonSocketPaths.daemonStartTimeoutMs(),
+        environmentOverrides,
+    )
 
     val started =
         DaemonSocketClient.waitForAvailability(
-            DaemonSocketPaths.socketPath(),
+            socketPath,
             DaemonSocketPaths.daemonStartTimeoutMs(),
         )
     if (!started) {
@@ -70,6 +82,33 @@ internal object DaemonSocketClientManager {
           "Daemon failed to start within ${DaemonSocketPaths.daemonStartTimeoutMs()}ms"
       )
     }
+  }
+
+  private fun resolveDaemonEnvironmentOverrides(): Map<String, String> {
+    val resolvedOverrides = mutableMapOf<String, String>()
+    val accessibilityApkProperty =
+        SystemPropertyCache.get("automobile.accessibility.apk.path", "").trim()
+    val accessibilityApkEnv = System.getenv("AUTOMOBILE_ACCESSIBILITY_APK_PATH")?.trim().orEmpty()
+    val accessibilityApkPath =
+        when {
+          accessibilityApkProperty.isNotEmpty() -> accessibilityApkProperty
+          accessibilityApkEnv.isNotEmpty() -> accessibilityApkEnv
+          else -> findLocalAccessibilityApkPath().orEmpty()
+        }
+    if (accessibilityApkPath.isNotEmpty()) {
+      resolvedOverrides["AUTOMOBILE_ACCESSIBILITY_APK_PATH"] = accessibilityApkPath
+    }
+    return resolvedOverrides
+  }
+
+  private fun findLocalAccessibilityApkPath(): String? {
+    val candidates =
+        listOf(
+            File("accessibility-service/build/outputs/apk/debug/accessibility-service-debug.apk"),
+            File("../accessibility-service/build/outputs/apk/debug/accessibility-service-debug.apk"),
+            File("../../accessibility-service/build/outputs/apk/debug/accessibility-service-debug.apk"),
+        )
+    return candidates.firstOrNull { it.exists() }?.absolutePath
   }
 }
 
@@ -94,6 +133,14 @@ internal object DaemonSocketPaths {
   }
 
   fun buildDaemonStartCommand(): List<String> {
+    return buildDaemonCommand("start")
+  }
+
+  fun buildDaemonRestartCommand(): List<String> {
+    return buildDaemonCommand("restart")
+  }
+
+  private fun buildDaemonCommand(subCommand: String): List<String> {
     val command = ArrayList<String>(4)
     if (localAutoMobileExists()) {
       command.add("bun")
@@ -103,7 +150,7 @@ internal object DaemonSocketPaths {
       command.add("auto-mobile")
     }
     command.add("--daemon")
-    command.add("start")
+    command.add(subCommand)
     return command
   }
 

--- a/src/server/appTools.ts
+++ b/src/server/appTools.ts
@@ -5,22 +5,22 @@ import { LaunchApp } from "../features/action/LaunchApp";
 import { TerminateApp } from "../features/action/TerminateApp";
 import { InstallApp } from "../features/action/InstallApp";
 import { createJSONToolResponse } from "../utils/toolUtils";
-import { addSessionUuidToSchema } from "./toolSchemaHelpers";
+import { addDeviceTargetingToSchema } from "./toolSchemaHelpers";
 import { invalidateInstalledAppsCache, notifyInstalledAppResourceUpdated } from "./appResources";
 import { logger } from "../utils/logger";
 
 // Schema definitions
-export const packageNameSchema = addSessionUuidToSchema(z.object({
+export const packageNameSchema = addDeviceTargetingToSchema(z.object({
   appId: z.string().describe("App package ID of the app"),
 }));
 
-export const launchAppSchema = addSessionUuidToSchema(z.object({
+export const launchAppSchema = addDeviceTargetingToSchema(z.object({
   appId: z.string().describe("App package ID of the app"),
   clearAppData: z.boolean().optional().describe("Whether to clear app data before launching, default false"),
   coldBoot: z.boolean().optional().describe("Whether to cold boot the app, default false"),
 }));
 
-export const installAppSchema = addSessionUuidToSchema(z.object({
+export const installAppSchema = addDeviceTargetingToSchema(z.object({
   apkPath: z.string().describe("Path to the APK file to install"),
 }));
 

--- a/src/server/debugTools.ts
+++ b/src/server/debugTools.ts
@@ -6,6 +6,7 @@ import { DebugSearch } from "../features/debug/DebugSearch";
 import { BugReport } from "../features/debug/BugReport";
 import { createJSONToolResponse } from "../utils/toolUtils";
 import { BootedDevice, Platform } from "../models";
+import { addDeviceTargetingToSchema } from "./toolSchemaHelpers";
 import { isDebugModeEnabled } from "../utils/debug";
 
 const ensureDebugEnabled = () => {
@@ -46,14 +47,14 @@ export interface BugReportArgs {
 }
 
 // Schema definitions
-export const rawViewHierarchySchema = z.object({
+export const rawViewHierarchySchema = addDeviceTargetingToSchema(z.object({
   platform: z.enum(["android", "ios"]).describe("Target platform"),
   source: z.enum(["uiautomator", "accessibility-service", "both"])
     .optional()
     .describe("Source for hierarchy extraction: 'uiautomator' for raw XML, 'accessibility-service' for JSON, or 'both' for comparison")
-});
+}));
 
-export const debugSearchSchema = z.object({
+export const debugSearchSchema = addDeviceTargetingToSchema(z.object({
   platform: z.enum(["android", "ios"]).describe("Target platform"),
   text: z.string().optional().describe("Text to search for in elements"),
   resourceId: z.string().optional().describe("Resource ID to search for"),
@@ -65,9 +66,9 @@ export const debugSearchSchema = z.object({
   caseSensitive: z.boolean().optional().describe("Whether to use case-sensitive matching (default: false)"),
   includeNearMisses: z.boolean().optional().describe("Include elements that almost matched (default: true)"),
   maxNearMisses: z.number().optional().describe("Maximum number of near-misses to include (default: 10)")
-});
+}));
 
-export const bugReportSchema = z.object({
+export const bugReportSchema = addDeviceTargetingToSchema(z.object({
   platform: z.enum(["android", "ios"]).describe("Target platform"),
   appId: z.string().optional().describe("App package ID to filter logcat for specific app"),
   includeScreenshot: z.boolean().optional().describe("Whether to include screenshot (default: true)"),
@@ -76,7 +77,7 @@ export const bugReportSchema = z.object({
   logcatLines: z.number().optional().describe("Number of recent logcat lines to include (default: 100)"),
   saveToFile: z.boolean().optional().describe("Whether to save full report to a file (default: false)"),
   saveDir: z.string().optional().describe("Directory to save report to")
-});
+}));
 
 // Register debug tools
 export function registerDebugTools() {

--- a/src/server/deepLinkTools.ts
+++ b/src/server/deepLinkTools.ts
@@ -4,11 +4,12 @@ import { GetDeepLinks } from "../features/utility/GetDeepLinks";
 import { ActionableError, BootedDevice } from "../models";
 import { createJSONToolResponse } from "../utils/toolUtils";
 import { logger } from "../utils/logger";
+import { addDeviceTargetingToSchema } from "./toolSchemaHelpers";
 
 // Schema definitions for tool arguments
-export const getDeepLinksSchema = z.object({
+export const getDeepLinksSchema = addDeviceTargetingToSchema(z.object({
   appId: z.string().describe("Android app package ID to query for deep links"),
-});
+}));
 
 // Type definitions for better TypeScript support
 export interface GetDeepLinksArgs {

--- a/src/server/deviceLabelMapping.ts
+++ b/src/server/deviceLabelMapping.ts
@@ -1,0 +1,146 @@
+import { DaemonState } from "../daemon/daemonState";
+import { ActionableError } from "../models";
+import { createToolExecutionContext, updateSessionCache } from "./ToolExecutionContext";
+import { logger } from "../utils/logger";
+
+export type DeviceLabelMap = Record<string, string>;
+
+const DEVICE_LABEL_CACHE_KEY = "deviceLabelMap";
+
+const buildDeviceLabelList = (labels: string[]): string[] => {
+  const seen = new Set<string>();
+  const unique: string[] = [];
+  for (const label of labels) {
+    if (typeof label !== "string") {
+      continue;
+    }
+    const trimmed = label.trim();
+    if (!trimmed || seen.has(trimmed)) {
+      continue;
+    }
+    seen.add(trimmed);
+    unique.push(trimmed);
+  }
+  return unique;
+};
+
+export const buildDeviceLabelMap = (
+  labels: string[],
+  baseSessionUuid: string,
+  primaryLabel?: string
+): DeviceLabelMap => {
+  const uniqueLabels = buildDeviceLabelList(labels);
+  if (uniqueLabels.length === 0) {
+    return {};
+  }
+
+  const resolvedPrimaryLabel =
+    (primaryLabel && uniqueLabels.includes(primaryLabel))
+      ? primaryLabel
+      : (uniqueLabels.includes("A") ? "A" : uniqueLabels[0]);
+
+  const map: DeviceLabelMap = {};
+  for (const label of uniqueLabels) {
+    map[label] = label === resolvedPrimaryLabel
+      ? baseSessionUuid
+      : `${baseSessionUuid}:${label}`;
+  }
+
+  return map;
+};
+
+export const getDeviceLabelMap = (baseSessionUuid: string): DeviceLabelMap | null => {
+  if (!DaemonState.getInstance().isInitialized()) {
+    return null;
+  }
+
+  const sessionManager = DaemonState.getInstance().getSessionManager();
+  const session = sessionManager.getSession(baseSessionUuid);
+  if (!session) {
+    return null;
+  }
+
+  const map = session.cacheData.customData?.[DEVICE_LABEL_CACHE_KEY];
+  if (!map || typeof map !== "object" || Array.isArray(map)) {
+    return null;
+  }
+
+  return map as DeviceLabelMap;
+};
+
+export const registerDeviceLabelMap = async (
+  baseSessionUuid: string,
+  labels: string[],
+  primaryLabel?: string
+): Promise<DeviceLabelMap> => {
+  if (!DaemonState.getInstance().isInitialized()) {
+    throw new ActionableError("Device labels require an active daemon session.");
+  }
+
+  const devicePool = DaemonState.getInstance().getDevicePool();
+  const sessionManager = DaemonState.getInstance().getSessionManager();
+  const deviceLabelMap = buildDeviceLabelMap(labels, baseSessionUuid, primaryLabel);
+
+  if (Object.keys(deviceLabelMap).length === 0) {
+    return deviceLabelMap;
+  }
+
+  const baseContext = await createToolExecutionContext(baseSessionUuid, sessionManager, devicePool);
+  await updateSessionCache(baseContext, DEVICE_LABEL_CACHE_KEY, deviceLabelMap);
+
+  const assignedSessions = new Set(Object.values(deviceLabelMap));
+  assignedSessions.delete(baseSessionUuid);
+
+  for (const sessionUuid of assignedSessions) {
+    await createToolExecutionContext(sessionUuid, sessionManager, devicePool);
+  }
+
+  logger.info(`[DeviceLabelMap] Registered labels for session ${baseSessionUuid}: ${Object.keys(deviceLabelMap).join(", ")}`);
+  return deviceLabelMap;
+};
+
+export const resolveDeviceLabel = (
+  baseSessionUuid: string,
+  label: string
+): string | null => {
+  const map = getDeviceLabelMap(baseSessionUuid);
+  if (!map) {
+    return null;
+  }
+  return map[label] ?? null;
+};
+
+export const releaseDeviceLabelSessions = async (baseSessionUuid: string): Promise<string[]> => {
+  if (!DaemonState.getInstance().isInitialized()) {
+    return [];
+  }
+
+  const map = getDeviceLabelMap(baseSessionUuid);
+  if (!map) {
+    return [];
+  }
+
+  const devicePool = DaemonState.getInstance().getDevicePool();
+  const sessionManager = DaemonState.getInstance().getSessionManager();
+  const sessions = new Set(Object.values(map));
+  const released: string[] = [];
+
+  sessions.delete(baseSessionUuid);
+
+  for (const sessionUuid of sessions) {
+    const session = sessionManager.getSession(sessionUuid);
+    if (!session) {
+      continue;
+    }
+    const deviceId = session.assignedDevice;
+    sessionManager.releaseSession(sessionUuid);
+    await devicePool.releaseDevice(deviceId);
+    released.push(sessionUuid);
+  }
+
+  if (released.length > 0) {
+    logger.info(`[DeviceLabelMap] Released label sessions for base ${baseSessionUuid}: ${released.join(", ")}`);
+  }
+
+  return released;
+};

--- a/src/server/interactionTools.ts
+++ b/src/server/interactionTools.ts
@@ -21,6 +21,7 @@ import { createJSONToolResponse } from "../utils/toolUtils";
 import { Platform } from "../models";
 import { resolveSwipeDirection } from "../utils/swipeOnUtils";
 import { RecompositionTracker } from "../features/performance/RecompositionTracker";
+import { DEVICE_LABEL_DESCRIPTION } from "./toolSchemaHelpers";
 
 // Type definitions for better TypeScript support
 export interface ClearTextArgs {
@@ -155,7 +156,8 @@ export const shakeSchema = z.object({
   intensity: z.number().optional().describe("Intensity of the shake acceleration (default: 100)"),
   platform: z.enum(["android", "ios"]).describe("Platform of the device"),
   sessionUuid: z.string().optional(),
-  deviceId: z.string().optional()
+  deviceId: z.string().optional(),
+  device: z.string().optional().describe(DEVICE_LABEL_DESCRIPTION)
 });
 
 const tapOnContainerSchema = z.object({
@@ -194,7 +196,8 @@ export const tapOnSchema = z.object({
   platform: z.enum(["android", "ios"]).describe("Platform of the device"),
   // Framework parameters for device management (optional)
   sessionUuid: z.string().optional(),
-  deviceId: z.string().optional()
+  deviceId: z.string().optional(),
+  device: z.string().optional().describe(DEVICE_LABEL_DESCRIPTION)
 });
 
 export const dragAndDropSchema = z.object({
@@ -211,7 +214,8 @@ export const dragAndDropSchema = z.object({
   dropDelay: z.number().optional().describe("Delay after dropping in milliseconds (default: 100)"),
   platform: z.enum(["android", "ios"]).describe("Platform of the device"),
   sessionUuid: z.string().optional(),
-  deviceId: z.string().optional()
+  deviceId: z.string().optional(),
+  device: z.string().optional().describe(DEVICE_LABEL_DESCRIPTION)
 });
 
 export const swipeOnSchema = z.object({
@@ -255,7 +259,8 @@ To see more content ABOVE: use direction "down".`
   platform: z.enum(["android", "ios"]).describe("Platform of the device"),
   // Framework parameters for device management (optional)
   sessionUuid: z.string().optional(),
-  deviceId: z.string().optional()
+  deviceId: z.string().optional(),
+  device: z.string().optional().describe(DEVICE_LABEL_DESCRIPTION)
 });
 
 export const pinchOnSchema = z.object({
@@ -273,19 +278,22 @@ export const pinchOnSchema = z.object({
   autoTarget: z.boolean().optional().describe("Auto-target a large, tappable surface when container is omitted (default true)"),
   platform: z.enum(["android", "ios"]).describe("Platform of the device"),
   sessionUuid: z.string().optional(),
-  deviceId: z.string().optional()
+  deviceId: z.string().optional(),
+  device: z.string().optional().describe(DEVICE_LABEL_DESCRIPTION)
 });
 
 export const clearTextSchema = z.object({
   platform: z.enum(["android", "ios"]).describe("Platform of the device"),
   sessionUuid: z.string().optional(),
-  deviceId: z.string().optional()
+  deviceId: z.string().optional(),
+  device: z.string().optional().describe(DEVICE_LABEL_DESCRIPTION)
 });
 
 export const selectAllTextSchema = z.object({
   platform: z.enum(["android", "ios"]).describe("Platform of the device"),
   sessionUuid: z.string().optional(),
-  deviceId: z.string().optional()
+  deviceId: z.string().optional(),
+  device: z.string().optional().describe(DEVICE_LABEL_DESCRIPTION)
 });
 
 export const pressButtonSchema = z.object({
@@ -293,13 +301,15 @@ export const pressButtonSchema = z.object({
     .describe("The button to press"),
   platform: z.enum(["android", "ios"]).describe("Platform of the device"),
   sessionUuid: z.string().optional(),
-  deviceId: z.string().optional()
+  deviceId: z.string().optional(),
+  device: z.string().optional().describe(DEVICE_LABEL_DESCRIPTION)
 });
 
 export const openSystemTraySchema = z.object({
   platform: z.enum(["android", "ios"]).describe("Platform of the device"),
   sessionUuid: z.string().optional(),
-  deviceId: z.string().optional()
+  deviceId: z.string().optional(),
+  device: z.string().optional().describe(DEVICE_LABEL_DESCRIPTION)
 });
 
 export const pressKeySchema = z.object({
@@ -307,14 +317,16 @@ export const pressKeySchema = z.object({
     .describe("The key to press"),
   platform: z.enum(["android", "ios"]).describe("Platform of the device"),
   sessionUuid: z.string().optional(),
-  deviceId: z.string().optional()
+  deviceId: z.string().optional(),
+  device: z.string().optional().describe(DEVICE_LABEL_DESCRIPTION)
 });
 
 export const stopAppSchema = z.object({
   appId: z.string().describe("App package ID to stop"),
   platform: z.enum(["android", "ios"]).describe("Platform of the device"),
   sessionUuid: z.string().optional(),
-  deviceId: z.string().optional()
+  deviceId: z.string().optional(),
+  device: z.string().optional().describe(DEVICE_LABEL_DESCRIPTION)
 });
 
 export const clearStateSchema = z.object({
@@ -322,7 +334,8 @@ export const clearStateSchema = z.object({
   clearKeychain: z.boolean().optional().describe("Also clear iOS keychain (iOS only)"),
   platform: z.enum(["android", "ios"]).describe("Platform of the device"),
   sessionUuid: z.string().optional(),
-  deviceId: z.string().optional()
+  deviceId: z.string().optional(),
+  device: z.string().optional().describe(DEVICE_LABEL_DESCRIPTION)
 });
 
 export const inputTextSchema = z.object({
@@ -331,40 +344,46 @@ export const inputTextSchema = z.object({
     .describe("Optional IME action to perform after text input"),
   platform: z.enum(["android", "ios"]).describe("Platform of the device"),
   sessionUuid: z.string().optional(),
-  deviceId: z.string().optional()
+  deviceId: z.string().optional(),
+  device: z.string().optional().describe(DEVICE_LABEL_DESCRIPTION)
 });
 
 export const openLinkSchema = z.object({
   url: z.string().describe("URL to open in the default browser"),
   platform: z.enum(["android", "ios"]).describe("Platform of the device"),
   sessionUuid: z.string().optional(),
-  deviceId: z.string().optional()
+  deviceId: z.string().optional(),
+  device: z.string().optional().describe(DEVICE_LABEL_DESCRIPTION)
 });
 
 export const imeActionSchema = z.object({
   action: z.enum(["done", "next", "search", "send", "go", "previous"]).describe("IME action to perform"),
   platform: z.enum(["android", "ios"]).describe("Platform of the device"),
   sessionUuid: z.string().optional(),
-  deviceId: z.string().optional()
+  deviceId: z.string().optional(),
+  device: z.string().optional().describe(DEVICE_LABEL_DESCRIPTION)
 });
 
 export const recentAppsSchema = z.object({
   platform: z.enum(["android", "ios"]).describe("Platform of the device"),
   sessionUuid: z.string().optional(),
-  deviceId: z.string().optional()
+  deviceId: z.string().optional(),
+  device: z.string().optional().describe(DEVICE_LABEL_DESCRIPTION)
 });
 
 export const homeScreenSchema = z.object({
   platform: z.enum(["android", "ios"]).describe("Platform of the device"),
   sessionUuid: z.string().optional(),
-  deviceId: z.string().optional()
+  deviceId: z.string().optional(),
+  device: z.string().optional().describe(DEVICE_LABEL_DESCRIPTION)
 });
 
 export const rotateSchema = z.object({
   orientation: z.enum(["portrait", "landscape"]).describe("The orientation to set"),
   platform: z.enum(["android", "ios"]).describe("Platform of the device"),
   sessionUuid: z.string().optional(),
-  deviceId: z.string().optional()
+  deviceId: z.string().optional(),
+  device: z.string().optional().describe(DEVICE_LABEL_DESCRIPTION)
 });
 
 const SYSTEM_TRAY_PACKAGE = "com.android.systemui";

--- a/src/server/navigationTools.ts
+++ b/src/server/navigationTools.ts
@@ -6,19 +6,19 @@ import { NavigationGraphManager } from "../features/navigation/NavigationGraphMa
 import { Explore, ExploreOptions } from "../features/navigation/Explore";
 import { createJSONToolResponse } from "../utils/toolUtils";
 import { Platform } from "../models";
-import { addSessionUuidToSchema } from "./toolSchemaHelpers";
+import { addDeviceTargetingToSchema } from "./toolSchemaHelpers";
 
 // Schema definitions
-export const navigateToSchema = addSessionUuidToSchema(z.object({
+export const navigateToSchema = addDeviceTargetingToSchema(z.object({
   targetScreen: z.string().describe("The destination screen name to navigate to"),
   platform: z.enum(["android", "ios"]).default("android")
 }));
 
-export const getNavigationGraphSchema = addSessionUuidToSchema(z.object({
+export const getNavigationGraphSchema = addDeviceTargetingToSchema(z.object({
   platform: z.enum(["android", "ios"]).default("android")
 }));
 
-export const exploreSchema = addSessionUuidToSchema(z.object({
+export const exploreSchema = addDeviceTargetingToSchema(z.object({
   maxInteractions: z.number().optional().describe("Maximum number of interactions to perform (default: 50)"),
   timeoutMs: z.number().optional().describe("Maximum time in milliseconds (default: 300000 - 5 minutes)"),
   strategy: z.enum(["breadth-first", "depth-first", "weighted"]).optional().describe("Exploration strategy (default: weighted)"),

--- a/src/server/observeTools.ts
+++ b/src/server/observeTools.ts
@@ -10,18 +10,18 @@ import { BootedDevice } from "../models";
 import { createGlobalPerformanceTracker } from "../utils/PerformanceTracker";
 import { NavigationGraphManager } from "../features/navigation/NavigationGraphManager";
 import { IdentifyInteractions, IdentifyInteractionsOptions } from "../features/observe/IdentifyInteractions";
-import { addSessionUuidToSchema } from "./toolSchemaHelpers";
+import { addDeviceTargetingToSchema } from "./toolSchemaHelpers";
 
 // Schema definitions
-export const observeSchema = addSessionUuidToSchema(z.object({
+export const observeSchema = addDeviceTargetingToSchema(z.object({
   platform: z.enum(["android", "ios"]).describe("Target platform")
 }));
 
-export const listAppsSchema = addSessionUuidToSchema(z.object({
+export const listAppsSchema = addDeviceTargetingToSchema(z.object({
   platform: z.enum(["android", "ios"]).describe("Target platform")
 }));
 
-export const identifyInteractionsSchema = addSessionUuidToSchema(z.object({
+export const identifyInteractionsSchema = addDeviceTargetingToSchema(z.object({
   platform: z.enum(["android", "ios"]).describe("Target platform"),
   filter: z.object({
     types: z.array(z.enum(["navigation", "input", "action", "scroll", "toggle"]))

--- a/src/server/planTools.ts
+++ b/src/server/planTools.ts
@@ -1,11 +1,13 @@
 import { z } from "zod";
 import { ToolRegistry } from "./toolRegistry";
-import { BootedDevice, ExecutePlanResult } from "../models";
+import { ActionableError, BootedDevice, ExecutePlanResult } from "../models";
 import { importPlanFromYaml, executePlan } from "../utils/planUtils";
 import { logger } from "../utils/logger";
 import { createJSONToolResponse } from "../utils/toolUtils";
 import { Platform } from "../models";
 import { TestExecutionRepository, TestExecutionStatus } from "../db/testExecutionRepository";
+import { DEVICE_LABEL_DESCRIPTION } from "./toolSchemaHelpers";
+import { registerDeviceLabelMap } from "./deviceLabelMapping";
 
 const testMetadataSchema = z.object({
   testClass: z.string(),
@@ -29,6 +31,8 @@ const executePlanSchema = z.object({
   // Framework parameters for device management (optional)
   sessionUuid: z.string().optional().describe("Session UUID for parallel test execution"),
   deviceId: z.string().optional().describe("Specific device ID to use"),
+  device: z.string().optional().describe(DEVICE_LABEL_DESCRIPTION),
+  devices: z.array(z.string()).optional().describe("Device labels to allocate for multi-device plans (e.g., [\"A\", \"B\"]). Use only when controlling multiple devices."),
   testMetadata: testMetadataSchema.optional().describe("Optional test metadata for execution timing history"),
   cleanupAppId: z.string().optional().describe("App package ID to terminate after plan execution"),
   cleanupClearAppData: z.boolean().optional().describe("Clear app data during cleanup (Android only)")
@@ -50,6 +54,8 @@ const executePlanTool = async (device: BootedDevice, params: {
   platform: Platform;
   sessionUuid?: string;
   deviceId?: string;
+  device?: string;
+  devices?: string[];
   testMetadata?: TestExecutionMetadata;
   cleanupAppId?: string;
   cleanupClearAppData?: boolean;
@@ -103,6 +109,20 @@ const executePlanTool = async (device: BootedDevice, params: {
     logger.info("=== Parsing plan from YAML ===");
     const plan = importPlanFromYaml(yamlContent);
     logger.info(`Plan parsed successfully: '${plan.name}' with ${plan.steps.length} steps`);
+
+    if (params.devices && params.devices.length > 0) {
+      if (!params.sessionUuid) {
+        throw new ActionableError("Device labels require a sessionUuid to be provided.");
+      }
+      if (params.device && !params.devices.includes(params.device)) {
+        throw new ActionableError(
+          `Device label '${params.device}' was not declared in devices list: ${params.devices.join(", ")}`
+        );
+      }
+      await registerDeviceLabelMap(params.sessionUuid, params.devices, params.device);
+    } else if (params.device) {
+      throw new ActionableError("Device label requires a devices list to be provided.");
+    }
 
     // Execute the plan with device context
     logger.info(`=== Starting plan execution on device ${device.deviceId} ===`);

--- a/src/server/toolRegistry.ts
+++ b/src/server/toolRegistry.ts
@@ -14,6 +14,7 @@ import { DaemonState } from "../daemon/daemonState";
 import { createToolExecutionContext, updateSessionCache } from "./ToolExecutionContext";
 import { AppCleanupService, DefaultAppCleanupService } from "./AppCleanupService";
 import { ToolCallRepository } from "../db/toolCallRepository";
+import { getDeviceLabelMap, releaseDeviceLabelSessions } from "./deviceLabelMapping";
 
 // Progress notification interface
 export interface ProgressCallback {
@@ -94,7 +95,41 @@ class ToolRegistryClass {
     const wrappedHandler: ToolHandler = async (args: any, progress?: ProgressCallback, signal?: AbortSignal) => {
       // Check for session UUID and create execution context
       let providedDeviceId = args.deviceId;
-      const sessionUuid = args.sessionUuid;
+      const baseSessionUuid = args.sessionUuid;
+      const deviceLabel = typeof args.device === "string" ? args.device : undefined;
+      const declaredDeviceLabels = Array.isArray(args.devices) ? args.devices : undefined;
+      let sessionUuid = baseSessionUuid;
+
+      if (deviceLabel) {
+        if (!DaemonState.getInstance().isInitialized()) {
+          throw new ActionableError("Device labels require an active daemon session.");
+        }
+        if (!baseSessionUuid) {
+          throw new ActionableError(`Device label '${deviceLabel}' requires sessionUuid to be provided.`);
+        }
+
+        const deviceLabelMap = getDeviceLabelMap(baseSessionUuid);
+        if (deviceLabelMap) {
+          const mappedSession = deviceLabelMap[deviceLabel];
+          if (!mappedSession) {
+            const available = Object.keys(deviceLabelMap);
+            const suffix = available.length > 0 ? ` Available labels: ${available.join(", ")}` : "";
+            throw new ActionableError(`Unknown device label '${deviceLabel}'.${suffix}`);
+          }
+          sessionUuid = mappedSession;
+        } else if (name === "executePlan" && declaredDeviceLabels?.includes(deviceLabel)) {
+          sessionUuid = baseSessionUuid;
+        } else {
+          throw new ActionableError(
+            `Device label '${deviceLabel}' is not allocated. Provide a devices list to executePlan before using device labels.`
+          );
+        }
+
+        if (providedDeviceId) {
+          logger.warn(`[ToolRegistry] Ignoring deviceId because device label '${deviceLabel}' was provided.`);
+          providedDeviceId = undefined;
+        }
+      }
 
       logger.info(`[ToolRegistry] Tool ${name} called, sessionUuid=${sessionUuid}, daemonInitialized=${DaemonState.getInstance().isInitialized()}`);
       void this.toolCallRepository.recordToolCall({
@@ -245,12 +280,17 @@ class ToolRegistryClass {
           try {
             const sessionManager = DaemonState.getInstance().getSessionManager();
             const devicePool = DaemonState.getInstance().getDevicePool();
-            const session = sessionManager.getSession(sessionUuid);
+            const releaseSessionUuid = baseSessionUuid ?? sessionUuid;
+            if (releaseSessionUuid) {
+              await releaseDeviceLabelSessions(releaseSessionUuid);
+            }
+
+            const session = releaseSessionUuid ? sessionManager.getSession(releaseSessionUuid) : null;
             if (session) {
               const deviceId = session.assignedDevice;
-              sessionManager.releaseSession(sessionUuid);
+              sessionManager.releaseSession(session.sessionId);
               await devicePool.releaseDevice(deviceId);
-              logger.info(`Auto-released session ${sessionUuid} and freed device ${deviceId} after executePlan`);
+              logger.info(`Auto-released session ${session.sessionId} and freed device ${deviceId} after executePlan`);
             }
           } catch (releaseError) {
             // Don't fail the tool if session release fails

--- a/src/server/toolSchemaHelpers.ts
+++ b/src/server/toolSchemaHelpers.ts
@@ -1,5 +1,8 @@
 import { z } from "zod";
 
+export const DEVICE_LABEL_DESCRIPTION =
+  "Optional device label for multi-device control only (use letters like \"A\", \"B\", \"C\").";
+
 /**
  * Helper to add sessionUuid field to tool schemas
  *
@@ -11,4 +14,20 @@ export function addSessionUuidToSchema<T extends z.ZodObject<any>>(schema: T): z
   return schema.extend({
     sessionUuid: z.string().optional().describe("Session UUID for session-based device targeting (optional)"),
   }) as z.ZodObject<any>;
+}
+
+/**
+ * Helper to add device label field to tool schemas.
+ */
+export function addDeviceLabelToSchema<T extends z.ZodObject<any>>(schema: T): z.ZodObject<any> {
+  return schema.extend({
+    device: z.string().optional().describe(DEVICE_LABEL_DESCRIPTION),
+  }) as z.ZodObject<any>;
+}
+
+/**
+ * Helper to add sessionUuid + device label fields to tool schemas.
+ */
+export function addDeviceTargetingToSchema<T extends z.ZodObject<any>>(schema: T): z.ZodObject<any> {
+  return addDeviceLabelToSchema(addSessionUuidToSchema(schema));
 }

--- a/src/server/utilityTools.ts
+++ b/src/server/utilityTools.ts
@@ -7,10 +7,10 @@ import { logger } from "../utils/logger";
 import { createJSONToolResponse } from "../utils/toolUtils";
 import { DeviceSessionManager } from "../utils/DeviceSessionManager";
 import { BootedDevice, Platform } from "../models";
-import { addSessionUuidToSchema } from "./toolSchemaHelpers";
+import { addDeviceTargetingToSchema, addSessionUuidToSchema } from "./toolSchemaHelpers";
 
 // Schema definitions
-export const enableDemoModeSchema = addSessionUuidToSchema(z.object({
+export const enableDemoModeSchema = addDeviceTargetingToSchema(z.object({
   time: z.string().optional().describe("Time to display in statusbar in HHMM format (e.g., 1000 for 10:00)"),
   batteryLevel: z.number().min(0).max(100).optional().describe("Battery level percentage (0-100)"),
   batteryPlugged: z.boolean().optional().describe("Whether the device appears to be charging"),
@@ -21,7 +21,7 @@ export const enableDemoModeSchema = addSessionUuidToSchema(z.object({
   platform: z.enum(["android", "ios"]).describe("Target platform")
 }));
 
-export const disableDemoModeSchema = addSessionUuidToSchema(z.object({
+export const disableDemoModeSchema = addDeviceTargetingToSchema(z.object({
   platform: z.enum(["android", "ios"]).describe("Target platform")
 }));
 
@@ -30,27 +30,27 @@ export const setActiveDeviceSchema = addSessionUuidToSchema(z.object({
   platform: z.enum(["android", "ios"]).describe("Target platform")
 }));
 
-export const setLocaleSchema = addSessionUuidToSchema(z.object({
+export const setLocaleSchema = addDeviceTargetingToSchema(z.object({
   languageTag: z.string().min(1).describe("Locale language tag (e.g., \"ar-SA\", \"ja-JP\")"),
   platform: z.enum(["android", "ios"]).describe("Target platform")
 }));
 
-export const setTimeZoneSchema = addSessionUuidToSchema(z.object({
+export const setTimeZoneSchema = addDeviceTargetingToSchema(z.object({
   zoneId: z.string().min(1).describe("Time zone ID (e.g., \"America/Los_Angeles\")"),
   platform: z.enum(["android", "ios"]).describe("Target platform")
 }));
 
-export const setTextDirectionSchema = addSessionUuidToSchema(z.object({
+export const setTextDirectionSchema = addDeviceTargetingToSchema(z.object({
   rtl: z.boolean().describe("Enable or disable RTL layout"),
   platform: z.enum(["android", "ios"]).describe("Target platform")
 }));
 
-export const set24HourFormatSchema = addSessionUuidToSchema(z.object({
+export const set24HourFormatSchema = addDeviceTargetingToSchema(z.object({
   enabled: z.boolean().describe("Enable or disable 24-hour time format"),
   platform: z.enum(["android", "ios"]).describe("Target platform")
 }));
 
-export const getCalendarSystemSchema = addSessionUuidToSchema(z.object({
+export const getCalendarSystemSchema = addDeviceTargetingToSchema(z.object({
   platform: z.enum(["android", "ios"]).describe("Target platform")
 }));
 

--- a/src/utils/plan/PlanExecutor.ts
+++ b/src/utils/plan/PlanExecutor.ts
@@ -129,7 +129,7 @@ export class DefaultPlanExecutor implements PlanExecutor {
             }
 
             // Inject deviceId if provided and not already set - this ensures the tool uses the correct device
-            if (deviceId && !enhancedParams.deviceId) {
+            if (deviceId && !enhancedParams.deviceId && !enhancedParams.device) {
               enhancedParams.deviceId = deviceId;
               logger.info(`[PlanExecutor] Injecting deviceId ${deviceId} into ${step.tool}`);
             }


### PR DESCRIPTION
## Summary
- add optional device labels plus executePlan devices list for multi-device routing
- resolve label-to-session mappings in the daemon and tool registry
- ensure JUnit runner tests use the local accessibility APK when starting the daemon

## Testing
- bun run test
- (cd android && ./gradlew test)

Closes #388
