### PR TITLE
Add visual fallback for selected-state detection

### DIFF
--- a/src/features/action/TapOnElement.ts
+++ b/src/features/action/TapOnElement.ts
@@ -19,6 +19,7 @@ import { VisionFallback, DEFAULT_VISION_CONFIG, type VisionFallbackConfig } from
 import { TakeScreenshot } from "../observe/TakeScreenshot";
 import { buildElementSearchDebugContext } from "../../utils/DebugContextBuilder";
 import { throwIfAborted } from "../../utils/toolUtils";
+import { SelectionStateTracker, SelectionCaptureState, TakeScreenshotCapturer } from "../navigation/SelectionStateTracker";
 
 /**
  * Command to tap on UI element containing specified text
@@ -28,6 +29,7 @@ export class TapOnElement extends BaseVisualChange {
   private elementUtils: ElementUtils;
   private accessibilityService: AccessibilityServiceClient;
   private visionConfig: VisionFallbackConfig;
+  private selectionStateTracker: SelectionStateTracker;
   private static readonly MAX_ATTEMPTS = 5;
   private static readonly AWAIT_POLL_INTERVAL_MS = 100;
 
@@ -36,13 +38,17 @@ export class TapOnElement extends BaseVisualChange {
     adb: AdbClient | null = null,
     axe: AxeClient | null = null,
     webdriver: WebDriverAgent | null = null,
-    visionConfig?: VisionFallbackConfig
+    visionConfig?: VisionFallbackConfig,
+    selectionStateTracker?: SelectionStateTracker
   ) {
     super(device, adb, axe);
     this.elementUtils = new ElementUtils();
     this.accessibilityService = AccessibilityServiceClient.getInstance(device, this.adb);
     this.webdriver = webdriver || new WebDriverAgent(device);
     this.visionConfig = visionConfig || DEFAULT_VISION_CONFIG;
+    this.selectionStateTracker = selectionStateTracker ?? new SelectionStateTracker({
+      screenshotCapturer: new TakeScreenshotCapturer(device, this.adb)
+    });
   }
 
   /**
@@ -256,6 +262,7 @@ export class TapOnElement extends BaseVisualChange {
     const perf = createGlobalPerformanceTracker();
     perf.serial("tapOnElement");
     let previousObserveResult: ObserveResult | null = null;
+    let selectionCapture: SelectionCaptureState | null = null;
 
     try {
       throwIfAborted(signal);
@@ -275,7 +282,7 @@ export class TapOnElement extends BaseVisualChange {
             this.findElementToTap(options, viewHierarchy, 0, observeResult, signal)
           );
           const tapPoint = this.elementUtils.getElementCenter(element);
-          const action = options.action;
+          let action = options.action;
           const longPressDuration = this.getLongPressDuration(options, this.device.platform);
           const dragTarget = action === "longPressDrag"
             ? this.resolveDragTarget(options, viewHierarchy)
@@ -299,15 +306,23 @@ export class TapOnElement extends BaseVisualChange {
             }
 
             // if not, change action to tap
+            action = "tap";
             options.action = "tap";
           }
+
+          selectionCapture = await this.selectionStateTracker.prepare({
+            action,
+            observation: observeResult,
+            element,
+            signal
+          });
 
           // Platform-specific tap execution
           await perf.track("executeTap", async () => {
             switch (this.device.platform) {
               case "android":
                 await this.executeAndroidTap(
-                  options.action,
+                  action,
                   tapPoint.x,
                   tapPoint.y,
                   longPressDuration,
@@ -317,7 +332,7 @@ export class TapOnElement extends BaseVisualChange {
                 );
                 break;
               case "ios":
-                await this.executeiOSTap(options.action, tapPoint.x, tapPoint.y, longPressDuration, dragTarget);
+                await this.executeiOSTap(action, tapPoint.x, tapPoint.y, longPressDuration, dragTarget);
                 break;
               default:
                 throw new ActionableError(`Unsupported platform: ${this.device.platform}`);
@@ -327,7 +342,7 @@ export class TapOnElement extends BaseVisualChange {
           perf.end();
           return {
             success: true,
-            action: options.action,
+            action,
             element,
           };
         },
@@ -357,6 +372,21 @@ export class TapOnElement extends BaseVisualChange {
           }
         }
       );
+
+      if (result.success && result.observation && result.element) {
+        const selectedElements = await this.selectionStateTracker.finalize({
+          action: options.action,
+          selectionState: selectionCapture,
+          currentObservation: result.observation,
+          previousObservation: previousObserveResult,
+          element: result.element,
+          signal
+        });
+        if (selectedElements.length > 0) {
+          result.observation.selectedElements = selectedElements;
+        }
+      }
+
       if (options.action === "longPress" || options.action === "longPressDrag") {
         const metadata = this.detectLongPressMetadata(previousObserveResult, result.observation);
         return {

--- a/src/features/navigation/DefaultUIStateSetup.ts
+++ b/src/features/navigation/DefaultUIStateSetup.ts
@@ -162,7 +162,7 @@ export class DefaultUIStateSetup implements UIStateSetup {
         return undefined;
       }
 
-      return UIStateExtractor.extract(result.viewHierarchy);
+      return UIStateExtractor.extractFromObservation(result);
     } catch (error) {
       logger.warn(`[UI_STATE_SETUP] Error getting current UI state: ${error}`);
       return undefined;

--- a/src/features/navigation/SelectionStateDetector.ts
+++ b/src/features/navigation/SelectionStateDetector.ts
@@ -1,0 +1,256 @@
+import { Element, ElementBounds, ObserveResult, ScreenSize } from "../../models";
+import { SelectedElement, SelectedElementDetection } from "../../utils/interfaces/NavigationGraph";
+import { ScreenshotUtils, screenshotUtilsAdapter } from "../../utils/ScreenshotUtilsAdapter";
+import { ImageUtils } from "../../utils/interfaces/ImageUtils";
+import { SharpImageUtils } from "../../utils/image-utils";
+import { logger } from "../../utils/logger";
+import { UIStateExtractor } from "./UIStateExtractor";
+
+export interface VisualSelectionConfig {
+  minDifferencePercent?: number;
+  minElementSizePx?: number;
+  pixelmatchThreshold?: number;
+  confidenceScale?: number;
+}
+
+export const DEFAULT_VISUAL_SELECTION_CONFIG: Required<VisualSelectionConfig> = {
+  minDifferencePercent: 1,
+  minElementSizePx: 4,
+  pixelmatchThreshold: 0.1,
+  confidenceScale: 5
+};
+
+export interface SelectionStateDetectorOptions {
+  screenshotUtils?: ScreenshotUtils;
+  imageUtils?: ImageUtils;
+  config?: VisualSelectionConfig;
+}
+
+export interface SelectionDetectionContext {
+  currentObservation?: ObserveResult;
+  previousObservation?: ObserveResult | null;
+  tappedElement?: Element;
+  beforeScreenshotPath?: string | null;
+  afterScreenshotPath?: string | null;
+}
+
+export interface SelectionStateDetectorLike {
+  detectSelectedElements(context: SelectionDetectionContext): Promise<SelectedElement[]>;
+}
+
+export class SelectionStateDetector implements SelectionStateDetectorLike {
+  private screenshotUtils: ScreenshotUtils;
+  private imageUtils: ImageUtils;
+  private config: Required<VisualSelectionConfig>;
+
+  constructor(options: SelectionStateDetectorOptions = {}) {
+    this.screenshotUtils = options.screenshotUtils ?? screenshotUtilsAdapter;
+    this.imageUtils = options.imageUtils ?? new SharpImageUtils();
+    this.config = {
+      ...DEFAULT_VISUAL_SELECTION_CONFIG,
+      ...options.config
+    };
+  }
+
+  async detectSelectedElements(context: SelectionDetectionContext): Promise<SelectedElement[]> {
+    const currentObservation = context.currentObservation;
+    if (!currentObservation?.viewHierarchy) {
+      return [];
+    }
+
+    const accessibilityState = UIStateExtractor.extract(currentObservation.viewHierarchy);
+    if (accessibilityState?.selectedElements?.length) {
+      const selectedElements = this.applySelectedState(accessibilityState.selectedElements, {
+        method: "accessibility",
+        confidence: 1,
+        reason: "selected attribute present in view hierarchy"
+      });
+      logger.info(`[SELECTION_STATE] Using accessibility selected state (${selectedElements.length} element(s))`);
+      return selectedElements;
+    }
+
+    if (!context.tappedElement) {
+      logger.debug("[SELECTION_STATE] Visual fallback skipped: no tapped element provided");
+      return [];
+    }
+
+    if (!context.beforeScreenshotPath || !context.afterScreenshotPath) {
+      logger.debug("[SELECTION_STATE] Visual fallback skipped: missing before/after screenshots");
+      return [];
+    }
+
+    const selectedElement = this.buildSelectedElement(context.tappedElement);
+    if (!selectedElement) {
+      logger.debug("[SELECTION_STATE] Visual fallback skipped: tapped element lacks identifiers");
+      return [];
+    }
+
+    const visualResult = await this.detectVisualSelection(
+      context.tappedElement.bounds,
+      context.beforeScreenshotPath,
+      context.afterScreenshotPath,
+      context.previousObservation?.screenSize,
+      currentObservation.screenSize
+    );
+
+    if (!visualResult) {
+      return [];
+    }
+
+    const detection: SelectedElementDetection = {
+      method: "visual",
+      confidence: visualResult.confidence,
+      reason: visualResult.reason
+    };
+
+    logger.info(
+      `[SELECTION_STATE] Using visual fallback for ${this.describeElement(selectedElement)} ` +
+      `(diff=${visualResult.differencePercent.toFixed(2)}%, confidence=${visualResult.confidence})`
+    );
+
+    return [{
+      ...selectedElement,
+      selectedState: detection
+    }];
+  }
+
+  private applySelectedState(
+    selectedElements: SelectedElement[],
+    selectedState: SelectedElementDetection
+  ): SelectedElement[] {
+    return selectedElements.map(element => ({
+      ...element,
+      selectedState: element.selectedState ?? selectedState
+    }));
+  }
+
+  private buildSelectedElement(element: Element): SelectedElement | null {
+    const selected: SelectedElement = {
+      text: element.text,
+      resourceId: element["resource-id"],
+      contentDesc: element["content-desc"]
+    };
+
+    if (!selected.text && !selected.resourceId && !selected.contentDesc) {
+      return null;
+    }
+
+    return selected;
+  }
+
+  private describeElement(element: SelectedElement): string {
+    return element.text || element.resourceId || element.contentDesc || "unknown element";
+  }
+
+  private async detectVisualSelection(
+    bounds: ElementBounds,
+    beforeScreenshotPath: string,
+    afterScreenshotPath: string,
+    beforeScreenSize?: ScreenSize,
+    afterScreenSize?: ScreenSize
+  ): Promise<{ differencePercent: number; confidence: number; reason: string } | null> {
+    try {
+      const beforeScreenshot = await this.screenshotUtils.getCachedScreenshot(beforeScreenshotPath);
+      const afterScreenshot = await this.screenshotUtils.getCachedScreenshot(afterScreenshotPath);
+
+      const beforeDimensions = await this.screenshotUtils.getImageDimensions(beforeScreenshot.buffer);
+      const afterDimensions = await this.screenshotUtils.getImageDimensions(afterScreenshot.buffer);
+
+      const beforeCrop = await this.cropElementRegion(
+        beforeScreenshot.buffer,
+        bounds,
+        beforeScreenSize,
+        beforeDimensions
+      );
+      const afterCrop = await this.cropElementRegion(
+        afterScreenshot.buffer,
+        bounds,
+        afterScreenSize,
+        afterDimensions
+      );
+
+      if (!beforeCrop || !afterCrop) {
+        logger.debug("[SELECTION_STATE] Visual fallback skipped: invalid element bounds for cropping");
+        return null;
+      }
+
+      const comparison = await this.screenshotUtils.compareImages(
+        beforeCrop,
+        afterCrop,
+        this.config.pixelmatchThreshold,
+        false
+      );
+
+      const differencePercent = Math.max(0, 100 - comparison.similarity);
+      if (differencePercent < this.config.minDifferencePercent) {
+        logger.debug(
+          `[SELECTION_STATE] Visual fallback skipped: diff ${differencePercent.toFixed(2)}% ` +
+          `< threshold ${this.config.minDifferencePercent}%`
+        );
+        return null;
+      }
+
+      const confidence = this.computeConfidence(differencePercent);
+      return {
+        differencePercent,
+        confidence,
+        reason: `visual diff ${differencePercent.toFixed(2)}% >= ${this.config.minDifferencePercent}%`
+      };
+    } catch (error) {
+      logger.warn(`[SELECTION_STATE] Visual fallback failed: ${error}`);
+      return null;
+    }
+  }
+
+  private async cropElementRegion(
+    buffer: Buffer,
+    bounds: ElementBounds,
+    screenSize: ScreenSize | undefined,
+    imageDimensions: { width: number; height: number }
+  ): Promise<Buffer | null> {
+    const normalized = this.normalizeBounds(bounds, screenSize, imageDimensions);
+    if (!normalized) {
+      return null;
+    }
+
+    return this.imageUtils.crop(
+      buffer,
+      normalized.width,
+      normalized.height,
+      normalized.left,
+      normalized.top
+    );
+  }
+
+  private normalizeBounds(
+    bounds: ElementBounds,
+    screenSize: ScreenSize | undefined,
+    imageDimensions: { width: number; height: number }
+  ): { left: number; top: number; width: number; height: number } | null {
+    if (imageDimensions.width <= 0 || imageDimensions.height <= 0) {
+      return null;
+    }
+
+    const scaleX = screenSize?.width ? imageDimensions.width / screenSize.width : 1;
+    const scaleY = screenSize?.height ? imageDimensions.height / screenSize.height : 1;
+
+    const left = Math.max(0, Math.floor(bounds.left * scaleX));
+    const top = Math.max(0, Math.floor(bounds.top * scaleY));
+    const right = Math.min(imageDimensions.width, Math.ceil(bounds.right * scaleX));
+    const bottom = Math.min(imageDimensions.height, Math.ceil(bounds.bottom * scaleY));
+
+    const width = right - left;
+    const height = bottom - top;
+
+    if (width < this.config.minElementSizePx || height < this.config.minElementSizePx) {
+      return null;
+    }
+
+    return { left, top, width, height };
+  }
+
+  private computeConfidence(differencePercent: number): number {
+    const normalized = Math.min(1, Math.max(0, differencePercent / this.config.confidenceScale));
+    return Number(normalized.toFixed(2));
+  }
+}

--- a/src/features/navigation/SelectionStateTracker.ts
+++ b/src/features/navigation/SelectionStateTracker.ts
@@ -1,0 +1,133 @@
+import { BootedDevice, Element, ObserveResult } from "../../models";
+import { AdbClient } from "../../utils/android-cmdline-tools/AdbClient";
+import { logger } from "../../utils/logger";
+import { SelectedElement } from "../../utils/interfaces/NavigationGraph";
+import { TakeScreenshot } from "../observe/TakeScreenshot";
+import { SelectionDetectionContext, SelectionStateDetector, SelectionStateDetectorLike } from "./SelectionStateDetector";
+import { UIStateExtractor } from "./UIStateExtractor";
+
+export interface ScreenshotCapturer {
+  capture(signal?: AbortSignal): Promise<string | null>;
+}
+
+export class TakeScreenshotCapturer implements ScreenshotCapturer {
+  private device: BootedDevice;
+  private adb: AdbClient;
+
+  constructor(device: BootedDevice, adb: AdbClient) {
+    this.device = device;
+    this.adb = adb;
+  }
+
+  async capture(signal?: AbortSignal): Promise<string | null> {
+    const screenshot = new TakeScreenshot(this.device, this.adb);
+    const result = await screenshot.execute({ format: "png" }, signal);
+    if (!result.success || !result.path) {
+      return null;
+    }
+    return result.path;
+  }
+}
+
+export interface SelectionCaptureState {
+  beforeScreenshotPath: string;
+  action: string;
+}
+
+export interface SelectionCaptureRequest {
+  action: string;
+  observation?: ObserveResult;
+  element?: Element;
+  signal?: AbortSignal;
+}
+
+export interface SelectionFinalizeRequest {
+  action: string;
+  selectionState?: SelectionCaptureState | null;
+  currentObservation?: ObserveResult;
+  previousObservation?: ObserveResult | null;
+  element?: Element;
+  signal?: AbortSignal;
+}
+
+export interface SelectionStateTrackerOptions {
+  detector?: SelectionStateDetectorLike;
+  screenshotCapturer: ScreenshotCapturer;
+}
+
+export class SelectionStateTracker {
+  private detector: SelectionStateDetectorLike;
+  private screenshotCapturer: ScreenshotCapturer;
+
+  constructor(options: SelectionStateTrackerOptions) {
+    this.detector = options.detector ?? new SelectionStateDetector();
+    this.screenshotCapturer = options.screenshotCapturer;
+  }
+
+  async prepare(request: SelectionCaptureRequest): Promise<SelectionCaptureState | null> {
+    const { observation, element, action, signal } = request;
+    if (!observation?.viewHierarchy || !element) {
+      return null;
+    }
+
+    if (!this.hasIdentifier(element)) {
+      logger.debug(`[SELECTION_STATE] Skip selection capture (${action}): element lacks identifier`);
+      return null;
+    }
+
+    if (!this.isSelectionCandidate(element)) {
+      logger.debug(`[SELECTION_STATE] Skip selection capture (${action}): element not selectable`);
+      return null;
+    }
+
+    const accessibilityState = UIStateExtractor.extract(observation.viewHierarchy);
+    if (accessibilityState?.selectedElements?.length) {
+      logger.info(`[SELECTION_STATE] Skip visual capture (${action}): accessibility selected state available`);
+      return null;
+    }
+
+    const beforeScreenshotPath = await this.screenshotCapturer.capture(signal);
+    if (!beforeScreenshotPath) {
+      logger.warn(`[SELECTION_STATE] Failed to capture pre-action screenshot (${action})`);
+      return null;
+    }
+
+    return {
+      beforeScreenshotPath,
+      action
+    };
+  }
+
+  async finalize(request: SelectionFinalizeRequest): Promise<SelectedElement[]> {
+    const { selectionState, currentObservation, previousObservation, element, action, signal } = request;
+    if (!selectionState || !currentObservation || !element) {
+      return [];
+    }
+
+    const afterScreenshotPath = await this.screenshotCapturer.capture(signal);
+    if (!afterScreenshotPath) {
+      logger.warn(`[SELECTION_STATE] Failed to capture post-action screenshot (${action})`);
+      return [];
+    }
+
+    const context: SelectionDetectionContext = {
+      currentObservation,
+      previousObservation,
+      tappedElement: element,
+      beforeScreenshotPath: selectionState.beforeScreenshotPath,
+      afterScreenshotPath
+    };
+
+    return this.detector.detectSelectedElements(context);
+  }
+
+  private hasIdentifier(element: Element): boolean {
+    return Boolean(element.text || element["resource-id"] || element["content-desc"]);
+  }
+
+  private isSelectionCandidate(element: Element): boolean {
+    const clickable = element.clickable === true || element.clickable === "true";
+    const checkable = element.checkable === true || element.checkable === "true";
+    return clickable || checkable;
+  }
+}

--- a/src/features/navigation/UIStateExtractor.ts
+++ b/src/features/navigation/UIStateExtractor.ts
@@ -1,5 +1,5 @@
-import { UIState, SelectedElement, ModalState, ScrollPosition } from "../../utils/interfaces/NavigationGraph";
-import { ViewHierarchyResult, WindowHierarchy } from "../../models";
+import { UIState, SelectedElement, SelectedElementDetection, ModalState, ScrollPosition } from "../../utils/interfaces/NavigationGraph";
+import { ObserveResult, ViewHierarchyResult, WindowHierarchy } from "../../models";
 import { SwipeOnOptions } from "../../models";
 import { resolveSwipeDirection } from "../../utils/swipeOnUtils";
 
@@ -73,6 +73,46 @@ export class UIStateExtractor {
   }
 
   /**
+   * Extract UI state from an observation, using visual fallback selections if accessibility data is missing.
+   */
+  static extractFromObservation(observation?: ObserveResult): UIState | undefined {
+    if (!observation?.viewHierarchy) {
+      return undefined;
+    }
+
+    const baseState = this.extract(observation.viewHierarchy);
+    const accessibilitySelected = baseState?.selectedElements ?? [];
+
+    if (accessibilitySelected.length > 0) {
+      const selectedElements = this.applySelectedState(accessibilitySelected, {
+        method: "accessibility",
+        confidence: 1,
+        reason: "selected attribute present in view hierarchy"
+      });
+      return {
+        ...baseState,
+        selectedElements
+      };
+    }
+
+    const fallbackSelected = observation.selectedElements ?? [];
+    if (fallbackSelected.length > 0) {
+      if (baseState) {
+        return {
+          ...baseState,
+          selectedElements: fallbackSelected
+        };
+      }
+
+      return {
+        selectedElements: fallbackSelected
+      };
+    }
+
+    return baseState;
+  }
+
+  /**
    * Traverse the view hierarchy and call visitor for each node.
    */
   private static traverseHierarchy(
@@ -90,6 +130,16 @@ export class UIStateExtractor {
       // Handle single child node
       this.traverseHierarchy(node.node, visitor);
     }
+  }
+
+  private static applySelectedState(
+    selectedElements: SelectedElement[],
+    selectedState: SelectedElementDetection
+  ): SelectedElement[] {
+    return selectedElements.map(element => ({
+      ...element,
+      selectedState: element.selectedState ?? selectedState
+    }));
   }
 
   /**

--- a/src/models/ObserveResult.ts
+++ b/src/models/ObserveResult.ts
@@ -10,6 +10,7 @@ import { PerformanceAuditResult } from "../features/performance/PerformanceAudit
 import { AccessibilityAuditResult } from "./AccessibilityAudit";
 import { RecompositionSummary } from "./Recomposition";
 import { DisplayedTimeMetric } from "./DisplayedTimeMetric";
+import { SelectedElement } from "../utils/interfaces/NavigationGraph";
 
 export interface PredictionTarget {
   text?: string;
@@ -84,6 +85,11 @@ export interface ObserveResult {
     scrollable: Element[];
     text: Element[];
   };
+
+  /**
+   * Selected elements detected for this observation (accessibility or visual fallback)
+   */
+  selectedElements?: SelectedElement[];
 
   /**
    * The single currently focused UI element from the view hierarchy

--- a/src/server/toolRegistry.ts
+++ b/src/server/toolRegistry.ts
@@ -141,7 +141,7 @@ class ToolRegistryClass {
         if (navigationRelevantTools.includes(name)) {
           // Extract UI state from the most recent cached observation
           const cachedResult = ObserveScreen.getRecentCachedResult();
-          const uiState = UIStateExtractor.extract(cachedResult?.viewHierarchy);
+          const uiState = UIStateExtractor.extractFromObservation(cachedResult);
           NavigationGraphManager.getInstance().recordToolCall(name, args, uiState);
         }
 

--- a/src/utils/interfaces/NavigationGraph.ts
+++ b/src/utils/interfaces/NavigationGraph.ts
@@ -31,10 +31,17 @@ export interface ModalState {
 /**
  * Represents a selected UI element (tab, menu item, etc.) captured at the time of a tool call.
  */
+export interface SelectedElementDetection {
+  method: "accessibility" | "visual";
+  confidence: number;
+  reason?: string;
+}
+
 export interface SelectedElement {
   text?: string;
   resourceId?: string;
   contentDesc?: string;
+  selectedState?: SelectedElementDetection;
 }
 
 /**

--- a/test/fakes/FakeScreenshotCapturer.ts
+++ b/test/fakes/FakeScreenshotCapturer.ts
@@ -1,0 +1,21 @@
+import { ScreenshotCapturer } from "../../src/features/navigation/SelectionStateTracker";
+
+export class FakeScreenshotCapturer implements ScreenshotCapturer {
+  private paths: Array<string | null> = [];
+  private calls = 0;
+
+  setPaths(paths: Array<string | null>): void {
+    this.paths = paths;
+    this.calls = 0;
+  }
+
+  getCallCount(): number {
+    return this.calls;
+  }
+
+  async capture(): Promise<string | null> {
+    const path = this.paths[this.calls] ?? null;
+    this.calls += 1;
+    return path;
+  }
+}

--- a/test/fakes/FakeSelectionStateDetector.ts
+++ b/test/fakes/FakeSelectionStateDetector.ts
@@ -1,0 +1,20 @@
+import { SelectionDetectionContext, SelectionStateDetectorLike } from "../../src/features/navigation/SelectionStateDetector";
+import { SelectedElement } from "../../src/utils/interfaces/NavigationGraph";
+
+export class FakeSelectionStateDetector implements SelectionStateDetectorLike {
+  private result: SelectedElement[] = [];
+  private contexts: SelectionDetectionContext[] = [];
+
+  setResult(result: SelectedElement[]): void {
+    this.result = result;
+  }
+
+  getContexts(): SelectionDetectionContext[] {
+    return this.contexts;
+  }
+
+  async detectSelectedElements(context: SelectionDetectionContext): Promise<SelectedElement[]> {
+    this.contexts.push(context);
+    return this.result;
+  }
+}

--- a/test/features/navigation/SelectionStateDetector.test.ts
+++ b/test/features/navigation/SelectionStateDetector.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, test } from "bun:test";
+import { SelectionStateDetector } from "../../../src/features/navigation/SelectionStateDetector";
+import { FakeScreenshotUtils } from "../../fakes/FakeScreenshotUtils";
+import { FakeImageUtils } from "../../fakes/FakeImageUtils";
+import { Element, ObserveResult, ViewHierarchyResult } from "../../../src/models";
+
+const createHierarchy = (node: Record<string, any>): ViewHierarchyResult => ({
+  hierarchy: {
+    node
+  }
+} as ViewHierarchyResult);
+
+const createObservation = (viewHierarchy: ViewHierarchyResult): ObserveResult => ({
+  updatedAt: Date.now(),
+  screenSize: { width: 100, height: 100 },
+  systemInsets: { top: 0, right: 0, bottom: 0, left: 0 },
+  viewHierarchy
+});
+
+describe("SelectionStateDetector", () => {
+  test("prefers accessibility-selected elements when available", async () => {
+    const screenshotUtils = new FakeScreenshotUtils();
+    const imageUtils = new FakeImageUtils();
+    const detector = new SelectionStateDetector({ screenshotUtils, imageUtils });
+
+    const observation = createObservation(
+      createHierarchy({
+        text: "Home",
+        selected: "true",
+        bounds: "[0,0][50,50]"
+      })
+    );
+
+    const selected = await detector.detectSelectedElements({
+      currentObservation: observation
+    });
+
+    expect(selected).toHaveLength(1);
+    expect(selected[0].text).toBe("Home");
+    expect(selected[0].selectedState?.method).toBe("accessibility");
+    expect(screenshotUtils.wasMethodCalled("getCachedScreenshot")).toBe(false);
+  });
+
+  test("uses visual fallback when accessibility-selected elements are missing", async () => {
+    const screenshotUtils = new FakeScreenshotUtils();
+    const imageUtils = new FakeImageUtils();
+    const detector = new SelectionStateDetector({ screenshotUtils, imageUtils });
+
+    screenshotUtils.setCachedScreenshot("before.png", Buffer.from("before"), "hash-before");
+    screenshotUtils.setCachedScreenshot("after.png", Buffer.from("after"), "hash-after");
+    screenshotUtils.setImageDimensions(100, 100);
+    screenshotUtils.setCompareImagesResult({
+      similarity: 90,
+      pixelDifference: 10,
+      totalPixels: 100
+    });
+
+    const observation = createObservation(
+      createHierarchy({
+        text: "NotSelected",
+        selected: "false",
+        bounds: "[0,0][50,50]"
+      })
+    );
+
+    const element: Element = {
+      bounds: { left: 0, top: 0, right: 50, bottom: 50 },
+      text: "Tab1",
+      "resource-id": "tab1"
+    };
+
+    const selected = await detector.detectSelectedElements({
+      currentObservation: observation,
+      previousObservation: observation,
+      tappedElement: element,
+      beforeScreenshotPath: "before.png",
+      afterScreenshotPath: "after.png"
+    });
+
+    expect(selected).toHaveLength(1);
+    expect(selected[0].text).toBe("Tab1");
+    expect(selected[0].selectedState?.method).toBe("visual");
+    expect(selected[0].selectedState?.confidence).toBeGreaterThan(0);
+    expect(imageUtils.wasMethodCalled("crop")).toBe(true);
+  });
+});

--- a/test/features/navigation/SelectionStateTracker.test.ts
+++ b/test/features/navigation/SelectionStateTracker.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect, test } from "bun:test";
+import { SelectionStateTracker } from "../../../src/features/navigation/SelectionStateTracker";
+import { FakeSelectionStateDetector } from "../../fakes/FakeSelectionStateDetector";
+import { FakeScreenshotCapturer } from "../../fakes/FakeScreenshotCapturer";
+import { Element, ObserveResult, ViewHierarchyResult } from "../../../src/models";
+
+const createHierarchy = (node: Record<string, any>): ViewHierarchyResult => ({
+  hierarchy: {
+    node
+  }
+} as ViewHierarchyResult);
+
+const createObservation = (viewHierarchy: ViewHierarchyResult): ObserveResult => ({
+  updatedAt: Date.now(),
+  screenSize: { width: 100, height: 100 },
+  systemInsets: { top: 0, right: 0, bottom: 0, left: 0 },
+  viewHierarchy
+});
+
+describe("SelectionStateTracker", () => {
+  test("skips capture when accessibility selected state is present", async () => {
+    const detector = new FakeSelectionStateDetector();
+    const capturer = new FakeScreenshotCapturer();
+    const tracker = new SelectionStateTracker({
+      detector,
+      screenshotCapturer: capturer
+    });
+
+    const observation = createObservation(
+      createHierarchy({
+        text: "Home",
+        selected: "true",
+        bounds: "[0,0][10,10]"
+      })
+    );
+
+    const element: Element = {
+      bounds: { left: 0, top: 0, right: 10, bottom: 10 },
+      text: "Home",
+      clickable: true
+    };
+
+    const state = await tracker.prepare({
+      action: "tap",
+      observation,
+      element
+    });
+
+    expect(state).toBeNull();
+    expect(capturer.getCallCount()).toBe(0);
+    expect(detector.getContexts()).toHaveLength(0);
+  });
+
+  test("captures before/after and uses detector when accessibility is missing", async () => {
+    const detector = new FakeSelectionStateDetector();
+    const capturer = new FakeScreenshotCapturer();
+    const tracker = new SelectionStateTracker({
+      detector,
+      screenshotCapturer: capturer
+    });
+
+    capturer.setPaths(["before.png", "after.png"]);
+    detector.setResult([
+      {
+        text: "Tab1",
+        selectedState: { method: "visual", confidence: 0.6 }
+      }
+    ]);
+
+    const observation = createObservation(
+      createHierarchy({
+        text: "Tab1",
+        selected: "false",
+        bounds: "[0,0][10,10]"
+      })
+    );
+
+    const element: Element = {
+      bounds: { left: 0, top: 0, right: 10, bottom: 10 },
+      text: "Tab1",
+      clickable: true
+    };
+
+    const state = await tracker.prepare({
+      action: "tap",
+      observation,
+      element
+    });
+
+    expect(state?.beforeScreenshotPath).toBe("before.png");
+
+    const selected = await tracker.finalize({
+      action: "tap",
+      selectionState: state,
+      currentObservation: observation,
+      previousObservation: observation,
+      element
+    });
+
+    expect(selected).toHaveLength(1);
+    expect(selected[0].text).toBe("Tab1");
+
+    const contexts = detector.getContexts();
+    expect(contexts).toHaveLength(1);
+    expect(contexts[0].beforeScreenshotPath).toBe("before.png");
+    expect(contexts[0].afterScreenshotPath).toBe("after.png");
+  });
+
+  test("skips capture when element is not selectable", async () => {
+    const detector = new FakeSelectionStateDetector();
+    const capturer = new FakeScreenshotCapturer();
+    const tracker = new SelectionStateTracker({
+      detector,
+      screenshotCapturer: capturer
+    });
+
+    const observation = createObservation(
+      createHierarchy({
+        text: "Label",
+        bounds: "[0,0][10,10]"
+      })
+    );
+
+    const element: Element = {
+      bounds: { left: 0, top: 0, right: 10, bottom: 10 },
+      text: "Label"
+    };
+
+    const state = await tracker.prepare({
+      action: "tap",
+      observation,
+      element
+    });
+
+    expect(state).toBeNull();
+    expect(capturer.getCallCount()).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary
- add visual fallback selection detection using before/after element diffs when accessibility is missing
- attach selected-state metadata to observations and UI-state extraction
- add selection tracking + fakes and unit tests

## Testing
- bun run test

Fixes #242
