### PR TITLE
Add shell script auto-fix via shfmt

### DIFF
--- a/docs/ai/validation.md
+++ b/docs/ai/validation.md
@@ -19,4 +19,14 @@ bun run test -- --grep "Name of the test suite or test case"
 
 # Reinstall MCP server
 bun install
+
+# Auto-fix shell script formatting with shfmt (Google style: 2-space indent)
+# Only formats touched/staged files by default
+bash scripts/shellcheck/apply_shfmt.sh
+
+# Format all shell scripts in the project
+ONLY_TOUCHED_FILES=false bash scripts/shellcheck/apply_shfmt.sh
+
+# Auto-install shfmt if missing during apply
+INSTALL_SHFMT_WHEN_MISSING=true bash scripts/shellcheck/apply_shfmt.sh
 ```

--- a/scripts/shellcheck/apply_shfmt.sh
+++ b/scripts/shellcheck/apply_shfmt.sh
@@ -1,0 +1,194 @@
+#!/usr/bin/env bash
+
+INSTALL_SHFMT_WHEN_MISSING=${INSTALL_SHFMT_WHEN_MISSING:-false}
+ONLY_TOUCHED_FILES=${ONLY_TOUCHED_FILES:-true}
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+# Function to check if command exists
+command_exists() {
+  command -v "$1" > /dev/null 2>&1
+}
+
+PROJECT_ROOT="$(pwd)"
+
+echo "PROJECT_ROOT: $PROJECT_ROOT"
+
+# Check for required commands and install missing commands if allowed
+echo -e "${YELLOW}Checking for required commands...${NC}"
+
+# Check if shfmt is installed
+if ! command_exists shfmt; then
+  echo -e "${RED}shfmt is not installed${NC}"
+  if [[ "${INSTALL_SHFMT_WHEN_MISSING}" == "true" ]]; then
+    echo -e "${YELLOW}Installing shfmt...${NC}"
+    if [[ -f "$PROJECT_ROOT/scripts/shellcheck/install_shfmt.sh" ]]; then
+      if ! bash "$PROJECT_ROOT/scripts/shellcheck/install_shfmt.sh"; then
+        echo -e "${RED}Failed to install shfmt${NC}"
+        exit 1
+      fi
+    else
+      echo -e "${RED}shfmt installation script not found${NC}"
+      exit 1
+    fi
+  else
+    echo -e "${RED}shfmt is required. Set INSTALL_SHFMT_WHEN_MISSING=true to auto-install or install manually${NC}"
+    exit 1
+  fi
+fi
+
+# Verify shfmt is available
+if ! command_exists shfmt; then
+  echo -e "${RED}shfmt is still not available after installation attempt${NC}"
+  exit 1
+fi
+
+echo -e "${GREEN}shfmt is available${NC}"
+
+# Check for other required commands
+for cmd in find xargs git; do
+  if ! command_exists "$cmd"; then
+    echo -e "${RED}Required command '$cmd' is not available${NC}"
+    exit 1
+  fi
+done
+
+# Start the timer
+if [[ -f "$PROJECT_ROOT/scripts/utils/get_timestamp.sh" ]]; then
+  start_time=$(bash "$PROJECT_ROOT/scripts/utils/get_timestamp.sh")
+else
+  start_time=$(date +%s)000 # Fallback to seconds * 1000
+fi
+
+echo -e "${YELLOW}Starting shfmt formatting...${NC}"
+
+# Function to find all shell script files
+find_all_shell_files() {
+  git ls-files --cached --others --exclude-standard -z \
+    | grep -z '\.sh$' \
+    | xargs -0 -I {} echo "$PROJECT_ROOT/{}" \
+    | sort \
+    | uniq
+}
+
+# Function to get touched/staged files
+get_touched_files() {
+  {
+    # Get staged files
+    git diff --cached --name-only --diff-filter=ACMR | while read -r file; do
+      if [[ "$file" =~ ^.*\.sh$ ]] && [[ -f "$PROJECT_ROOT/$file" ]]; then
+        echo "$PROJECT_ROOT/$file"
+      fi
+    done
+
+    # Get modified but not staged files
+    git diff --name-only --diff-filter=ACMR | while read -r file; do
+      if [[ "$file" =~ ^.*\.sh$ ]] && [[ -f "$PROJECT_ROOT/$file" ]]; then
+        echo "$PROJECT_ROOT/$file"
+      fi
+    done
+  } | sort | uniq
+}
+
+# Determine which files to process
+declare -a files_to_process
+errors=""
+
+if [[ "${ONLY_TOUCHED_FILES}" == "true" ]]; then
+  echo -e "${YELLOW}Processing only touched/staged files${NC}"
+
+  # Get list of changed files
+  touched_files=$(get_touched_files)
+  while IFS= read -r file; do
+    [[ -n "$file" ]] && files_to_process+=("$file")
+  done <<< "$touched_files"
+
+else
+  echo -e "${YELLOW}Processing all shell script files in the project${NC}"
+
+  # Get all shell script files
+  all_files=$(find_all_shell_files)
+  while IFS= read -r file; do
+    [[ -n "$file" ]] && files_to_process+=("$file")
+  done <<< "$all_files"
+fi
+
+# Check if we have files to process
+if [[ ${#files_to_process[@]} -eq 0 ]]; then
+  echo -e "${GREEN}No shell script files to process${NC}"
+  if [[ -f "$PROJECT_ROOT/scripts/utils/get_timestamp.sh" ]]; then
+    end_time=$(bash "$PROJECT_ROOT/scripts/utils/get_timestamp.sh")
+    total_elapsed=$((end_time - start_time))
+  else
+    end_time=$(date +%s)000
+    total_elapsed=$((end_time - start_time))
+  fi
+  echo "Total time elapsed: $total_elapsed ms."
+  exit 0
+fi
+
+echo -e "${YELLOW}Found ${#files_to_process[@]} shell script file(s) to process${NC}"
+
+# Create temporary file for storing file list
+temp_file=$(mktemp)
+trap 'rm -f "$temp_file"' EXIT
+
+# Write files to temporary file for xargs processing
+printf '%s\n' "${files_to_process[@]}" > "$temp_file"
+
+# Apply shfmt formatting with Google style
+# -i 2: indent with 2 spaces
+# -bn: binary ops like && and | may start a line
+# -ci: switch cases will be indented
+# -sr: redirect operators will be followed by a space
+echo -e "${YELLOW}Applying shfmt formatting...${NC}"
+
+if [[ -s "$temp_file" ]]; then
+  # Apply shfmt formatting and capture output
+  shfmt_output=$(xargs shfmt -i 2 -bn -ci -sr -w 2>&1 < "$temp_file")
+
+  # Check if the output contains actual errors
+  if echo "$shfmt_output" | grep -E "(error|Error|ERROR|failed|Failed|FAILED)" > /dev/null 2>&1; then
+    errors="$shfmt_output"
+  fi
+fi
+
+# Count how many files were actually processed
+processed_count=0
+while IFS= read -r file; do
+  if [[ -f "$file" ]]; then
+    ((processed_count++))
+  fi
+done < "$temp_file"
+
+echo -e "${GREEN}Processed $processed_count file(s)${NC}"
+
+# Calculate total elapsed time
+if [[ -f "$PROJECT_ROOT/scripts/utils/get_timestamp.sh" ]]; then
+  end_time=$(bash "$PROJECT_ROOT/scripts/utils/get_timestamp.sh")
+else
+  end_time=$(date +%s)000
+fi
+total_elapsed=$((end_time - start_time))
+
+# Check and report errors
+if [[ -n "$errors" ]]; then
+  echo -e "${RED}Errors encountered during formatting:${NC}"
+  echo -e "$errors"
+  echo -e "${RED}Total time elapsed: $total_elapsed ms.${NC}"
+  exit 1
+fi
+
+# Stage the formatted files
+if [[ ${#files_to_process[@]} -gt 0 ]]; then
+  echo -e "${YELLOW}Staging formatted files...${NC}"
+  printf '%s\n' "${files_to_process[@]}" | xargs git add
+fi
+
+echo -e "${GREEN}Shell scripts have been formatted successfully.${NC}"
+echo "Total time elapsed: $total_elapsed ms."
+exit 0

--- a/scripts/shellcheck/install_shfmt.sh
+++ b/scripts/shellcheck/install_shfmt.sh
@@ -1,0 +1,211 @@
+#!/usr/bin/env bash
+
+SHFMT_VERSION="3.10.0" # Change this to the desired version
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+# Detect operating system
+detect_os() {
+  case "$(uname -s)" in
+    Darwin*)
+      echo "macos"
+      ;;
+    Linux*)
+      echo "linux"
+      ;;
+    CYGWIN* | MINGW* | MSYS*)
+      echo "windows"
+      ;;
+    *)
+      echo "unknown"
+      ;;
+  esac
+}
+
+# Detect architecture
+detect_arch() {
+  case "$(uname -m)" in
+    x86_64 | amd64)
+      echo "amd64"
+      ;;
+    arm64 | aarch64)
+      echo "arm64"
+      ;;
+    armv7l)
+      echo "arm"
+      ;;
+    i386 | i686)
+      echo "386"
+      ;;
+    *)
+      echo "unknown"
+      ;;
+  esac
+}
+
+# Check if command exists
+command_exists() {
+  command -v "$1" > /dev/null 2>&1
+}
+
+# Install shfmt on macOS
+install_macos() {
+  echo -e "${YELLOW}Installing shfmt on macOS...${NC}"
+
+  if command_exists brew; then
+    echo -e "${GREEN}Using Homebrew to install shfmt${NC}"
+    brew install shfmt
+    return $?
+  else
+    echo -e "${YELLOW}Homebrew not found. Falling back to binary installation...${NC}"
+    install_binary "darwin"
+    return $?
+  fi
+}
+
+# Install shfmt on Linux
+install_linux() {
+  echo -e "${YELLOW}Installing shfmt on Linux...${NC}"
+  install_binary "linux"
+  return $?
+}
+
+# Install shfmt on Windows
+install_windows() {
+  echo -e "${YELLOW}Installing shfmt on Windows...${NC}"
+
+  if command_exists scoop; then
+    echo -e "${GREEN}Using Scoop to install shfmt${NC}"
+    scoop install shfmt
+    return $?
+  elif command_exists choco; then
+    echo -e "${GREEN}Using Chocolatey to install shfmt${NC}"
+    choco install shfmt
+    return $?
+  else
+    echo -e "${YELLOW}No supported package manager found. Using binary installation...${NC}"
+    install_binary "windows"
+    return $?
+  fi
+}
+
+# Install shfmt by downloading binary
+install_binary() {
+  local os="$1"
+  local arch
+  arch=$(detect_arch)
+
+  echo -e "${YELLOW}Installing shfmt binary for $os ($arch)...${NC}"
+
+  if [[ "$arch" == "unknown" ]]; then
+    echo -e "${RED}Unsupported architecture: $(uname -m)${NC}"
+    return 1
+  fi
+
+  # Create installation directory
+  install_dir="$HOME/.local/bin"
+  mkdir -p "$install_dir"
+
+  # Construct download URL
+  # Format: https://github.com/mvdan/sh/releases/download/v3.10.0/shfmt_v3.10.0_darwin_amd64
+  local binary_name="shfmt_v${SHFMT_VERSION}_${os}_${arch}"
+  if [[ "$os" == "windows" ]]; then
+    binary_name="${binary_name}.exe"
+  fi
+
+  local download_url="https://github.com/mvdan/sh/releases/download/v${SHFMT_VERSION}/${binary_name}"
+
+  echo -e "${GREEN}Downloading shfmt from GitHub releases...${NC}"
+  echo -e "${YELLOW}URL: $download_url${NC}"
+
+  local target_file="$install_dir/shfmt"
+  if [[ "$os" == "windows" ]]; then
+    target_file="${target_file}.exe"
+  fi
+
+  if command_exists curl; then
+    curl -L -o "$target_file" "$download_url"
+  elif command_exists wget; then
+    wget -O "$target_file" "$download_url"
+  else
+    echo -e "${RED}Neither curl nor wget found. Please install one of them or download manually from:${NC}"
+    echo "$download_url"
+    return 1
+  fi
+
+  # Verify the binary was downloaded correctly
+  if [[ ! -f "$target_file" ]]; then
+    echo -e "${RED}Failed to download shfmt binary${NC}"
+    return 1
+  fi
+
+  # Make it executable
+  chmod +x "$target_file"
+
+  echo -e "${GREEN}shfmt binary installed successfully to $install_dir${NC}"
+
+  # Check if directory is in PATH
+  if [[ ":$PATH:" != *":$install_dir:"* ]]; then
+    echo -e "${YELLOW}Make sure $install_dir is in your PATH environment variable.${NC}"
+    echo -e "${YELLOW}To add $install_dir to your PATH, add this line to your shell configuration:${NC}"
+    echo "export PATH=\"\$PATH:$install_dir\""
+  fi
+
+  return 0
+}
+
+# Verify installation
+verify_installation() {
+  echo -e "${YELLOW}Verifying shfmt installation...${NC}"
+
+  if command_exists shfmt; then
+    echo -e "${GREEN}shfmt is installed and available in PATH${NC}"
+    shfmt --version 2> /dev/null || echo -e "${GREEN}shfmt is ready to use${NC}"
+    return 0
+  else
+    echo -e "${RED}shfmt is not available in PATH${NC}"
+    return 1
+  fi
+}
+
+# Main installation function
+main() {
+  echo -e "${GREEN}shfmt Installation Script${NC}"
+  echo -e "${GREEN}========================${NC}"
+
+  os=$(detect_os)
+  echo -e "${YELLOW}Detected OS: $os${NC}"
+
+  case $os in
+    macos)
+      install_macos
+      ;;
+    linux)
+      install_linux
+      ;;
+    windows)
+      install_windows
+      ;;
+    *)
+      echo -e "${RED}Unsupported operating system: $os${NC}"
+      exit 1
+      ;;
+  esac
+
+  install_result=$?
+
+  if [[ $install_result -eq 0 ]]; then
+    echo -e "${GREEN}Installation completed successfully!${NC}"
+    verify_installation
+  else
+    echo -e "${RED}Installation failed!${NC}"
+    exit 1
+  fi
+}
+
+# Run main function
+main "$@"


### PR DESCRIPTION
## Summary
Implements shell script auto-fix functionality using shfmt to complement the existing shellcheck validation.

## Changes
- **scripts/shellcheck/install_shfmt.sh**: Installation script with OS detection (macOS, Linux, Windows)
  - Uses native package managers (Homebrew, Scoop, Chocolatey) when available
  - Falls back to downloading binaries from GitHub releases
- **scripts/shellcheck/apply_shfmt.sh**: Auto-formatting script using Google style
  - 2-space indent, binary ops start line, switch cases indent, redirect follows
  - Only formats touched/staged files by default (configurable)
  - Auto-installs shfmt if missing (optional)
  - Auto-stages formatted files after formatting
- **docs/ai/validation.md**: Added usage examples and documentation

## Features
- `ONLY_TOUCHED_FILES=true` (default): Only formats changed/staged files for performance
- `ONLY_TOUCHED_FILES=false`: Formats all shell scripts in the project
- `INSTALL_SHFMT_WHEN_MISSING=true`: Auto-installs shfmt if not found
- Follows established pattern from `scripts/ktfmt/apply_ktfmt.sh`

## Test plan
- [x] Tested installation on macOS via Homebrew
- [x] Formatted new scripts (apply_shfmt.sh, install_shfmt.sh)
- [x] Verified shellcheck validation passes
- [x] Tested formatting all 37 shell scripts in project
- [x] Confirmed auto-staging works correctly

## Resolves
Closes #369

🤖 Generated with [Claude Code](https://claude.com/claude-code)