### PR TITLE
Add Android decision guide for component choices

### DIFF
--- a/docs/install/overview.md
+++ b/docs/install/overview.md
@@ -78,6 +78,22 @@ If you have a private npm registry for proxying public npm:
 - Android: [Android setup](plat/android.md)
 - iOS: unsupported at the moment, but the [design doc](../design-docs/plat/ios/index.md) outlines plans.
 
+## Decision guide (Android)
+
+If your goal is interactive AI-driven automation, the MCP server plus an agent is enough. The rest are optional based on
+what you want to do:
+
+- **IntelliJ IDE Plugin** - Toggle feature flags, record tests, visualize the navigation graph, and inspect app
+  performance while coding.
+- **JUnitRunner** - Test framework dependency (not the SDK library) to run AutoMobile tests from JUnit/Gradle or CI with
+  device pooling, timing ordering, and optional AI self-healing (requires model provider keys).
+- **Android SDK library** - Add app-side instrumentation like recomposition tracking.
+
+For Android UI automation, you must enable the [Accessibility Service](../design-docs/plat/android/accessibility-service.md)
+on test devices so AutoMobile can access the view hierarchy.
+
+For a comparison table and scenarios, see the [Android decision guide](plat/android.md#decision-guide).
+
 ### AI Agent & Model Providers
 
 Any MCP-compatible client can use AutoMobile. Configuration guides for specific clients:
@@ -96,4 +112,3 @@ For model provider supported features like JUnitRunner AI self-healing tests you
 - **AWS Bedrock** - [Setup Guide](https://docs.aws.amazon.com/bedrock/latest/userguide/setting-up.html)
 
 Set API keys via environment variables or system properties. See [JUnitRunner](../design-docs/plat/android/junitrunner.md#model-providers) for configuration details.
-

--- a/docs/install/plat/android.md
+++ b/docs/install/plat/android.md
@@ -49,11 +49,36 @@ Quick example:
 }
 ```
 
-## Optional Components
+## Decision guide
 
-1. Install the [IntelliJ IDE Plugin](../../design-docs/plat/android/ide-plugin/overview.md) to gain the ability to toggle feature flags, record tests, visualize the real-time navigation graph, and inspect app performance.
-2. Add the [JUnitRunner](../../design-docs/plat/android/junitrunner.md) test dependency to all Android application and library modules you want to run AutoMobile tests from.
-3. Add the [Android SDK](../../design-docs/plat/android/auto-mobile-sdk.md) Android library to add recomposition tracking.
+AutoMobile always needs the MCP server (configured in the overview). Everything below is optional and only needed for
+specific workflows.
+
+### Component summary
+
+- **Accessibility Service** - Required on test devices for AutoMobile to access the view hierarchy and UI signals.
+- **IntelliJ IDE Plugin** - Attach to a running MCP server to toggle feature flags, record tests, visualize the
+  real-time navigation graph, and inspect app performance.
+- **JUnitRunner** - Test framework dependency (not the SDK library) to run AutoMobile tests from JUnit/Gradle or CI.
+  Enables device pooling and timing-based ordering, and can use AI self-healing when model provider keys are configured.
+- **Android SDK library** - Add to app modules when you want app-side instrumentation like recomposition tracking.
+
+### Comparison table
+
+| Goal | Use these components |
+| --- | --- |
+| Drive the app from an AI agent (Claude, Cursor, etc.) | MCP server + agent |
+| Record tests or view the navigation graph inside Android Studio | MCP server + [IntelliJ IDE Plugin](../../design-docs/plat/android/ide-plugin/overview.md) |
+| Run AutoMobile tests in Gradle/CI | MCP server + [JUnitRunner](../../design-docs/plat/android/junitrunner.md) |
+| Collect recomposition tracking data | MCP server + [Android SDK library](../../design-docs/plat/android/auto-mobile-sdk.md) |
+| Access the real-time view hierarchy | Enable the [Accessibility Service](../../design-docs/plat/android/accessibility-service.md) |
+
+### Scenarios
+
+- **Exploratory automation** - MCP server + agent only, plus the Accessibility Service on devices. Add the IDE plugin if
+  you want the navigation graph while you explore.
+- **CI or local JUnit execution** - Add JUnitRunner (plus model provider keys if you want AI self-healing).
+- **App instrumentation focus** - Add the Android SDK library for recomposition tracking.
 
 ## Troubleshooting
 


### PR DESCRIPTION
## Summary
- add Android decision guide with component summaries, comparison table, and scenarios
- call out Accessibility Service requirement in install docs
- clarify JUnitRunner as a test framework dependency (not SDK library)

## Testing
- not run (docs-only)

Closes #342
