### PR TITLE
Fix notification permission dialog detection

### DIFF
--- a/android/accessibility-service/src/main/java/dev/jasonpearson/automobile/accessibilityservice/ViewHierarchyExtractor.kt
+++ b/android/accessibility-service/src/main/java/dev/jasonpearson/automobile/accessibilityservice/ViewHierarchyExtractor.kt
@@ -77,11 +77,16 @@ class ViewHierarchyExtractor(private val recompositionStore: RecompositionStore?
           }
       val intentChooserDetected =
           filteredElement?.let { detectIntentChooserIndicators(it) } ?: false
+      val notificationPermissionDetected =
+          filteredElement?.let {
+            detectNotificationPermissionDialog(it, rootNode.packageName?.toString())
+          }
 
       ViewHierarchy(
           packageName = rootNode.packageName?.toString(),
           hierarchy = filteredElement,
           intentChooserDetected = intentChooserDetected,
+          notificationPermissionDetected = notificationPermissionDetected,
       )
     } catch (e: Exception) {
       Log.e(TAG, "Error extracting view hierarchy", e)
@@ -116,6 +121,7 @@ class ViewHierarchyExtractor(private val recompositionStore: RecompositionStore?
     var mainHierarchy: UIElementInfo? = null
     var mainPackageName: String? = null
     var intentChooserDetected = false
+    var notificationPermissionDetected: Boolean? = null
     var activeWindowLayer = 0
     var activeWindowKey: Int? = null
     val windowLayers = mutableMapOf<Int, Int>()
@@ -154,6 +160,10 @@ class ViewHierarchyExtractor(private val recompositionStore: RecompositionStore?
         if (window.isActive) {
           mainHierarchy = optimizedElement
           mainPackageName = packageName
+          if (notificationPermissionDetected == null && optimizedElement != null) {
+            notificationPermissionDetected =
+                detectNotificationPermissionDialog(optimizedElement, packageName)
+          }
           // Skip adding to windows list - it's already in main hierarchy
           continue
         }
@@ -196,6 +206,10 @@ class ViewHierarchyExtractor(private val recompositionStore: RecompositionStore?
       mainPackageName = activeWindowRoot.packageName?.toString()
       if (!intentChooserDetected && mainHierarchy != null) {
         intentChooserDetected = detectIntentChooserIndicators(mainHierarchy!!)
+      }
+      if (notificationPermissionDetected == null && mainHierarchy != null) {
+        notificationPermissionDetected =
+            detectNotificationPermissionDialog(mainHierarchy!!, mainPackageName)
       }
     }
 
@@ -244,6 +258,7 @@ class ViewHierarchyExtractor(private val recompositionStore: RecompositionStore?
         hierarchy = mainHierarchy,
         windows = if (windowHierarchies.isNotEmpty()) windowHierarchies else null,
         intentChooserDetected = intentChooserDetected,
+        notificationPermissionDetected = notificationPermissionDetected,
     )
   }
 
@@ -337,6 +352,55 @@ class ViewHierarchyExtractor(private val recompositionStore: RecompositionStore?
 
   internal fun detectIntentChooserIndicatorsForTest(element: UIElementInfo): Boolean {
     return detectIntentChooserIndicators(element)
+  }
+
+  /** Detect notification permission dialog indicators in an optimized hierarchy. */
+  private fun detectNotificationPermissionDialog(
+      element: UIElementInfo,
+      packageName: String?,
+  ): Boolean {
+    if (packageName.isNullOrBlank() || !packageName.contains("permissioncontroller", true)) {
+      return false
+    }
+
+    var hasNotificationText = false
+    var hasPermissionButtons = false
+
+    fun visit(node: UIElementInfo) {
+      val text = (node.text ?: node.contentDesc ?: "").lowercase()
+      if (text.contains("notification")) {
+        hasNotificationText = true
+      }
+
+      val resourceId = node.resourceId?.lowercase() ?: ""
+      if (
+          resourceId.contains("permission_allow_button") ||
+              resourceId.contains("permission_deny_button")
+      ) {
+        hasPermissionButtons = true
+      }
+
+      if (hasNotificationText && hasPermissionButtons) {
+        return
+      }
+
+      for (child in extractChildrenFromNode(node.node)) {
+        visit(child)
+        if (hasNotificationText && hasPermissionButtons) {
+          return
+        }
+      }
+    }
+
+    visit(element)
+    return hasNotificationText && hasPermissionButtons
+  }
+
+  internal fun detectNotificationPermissionDialogForTest(
+      element: UIElementInfo,
+      packageName: String?,
+  ): Boolean {
+    return detectNotificationPermissionDialog(element, packageName)
   }
 
   /**

--- a/android/accessibility-service/src/main/java/dev/jasonpearson/automobile/accessibilityservice/models/ViewHierarchy.kt
+++ b/android/accessibility-service/src/main/java/dev/jasonpearson/automobile/accessibilityservice/models/ViewHierarchy.kt
@@ -14,6 +14,7 @@ data class ViewHierarchy(
     val windowInfo: WindowInfo? = null,
     val windows: List<WindowHierarchy>? = null, // All visible windows (including popups, toolbars)
     val intentChooserDetected: Boolean? = null,
+    val notificationPermissionDetected: Boolean? = null,
     val error: String? = null, // For error cases like locked screen
 )
 

--- a/android/accessibility-service/src/test/java/dev/jasonpearson/automobile/accessibilityservice/ViewHierarchyExtractorTest.kt
+++ b/android/accessibility-service/src/test/java/dev/jasonpearson/automobile/accessibilityservice/ViewHierarchyExtractorTest.kt
@@ -171,6 +171,40 @@ class ViewHierarchyExtractorTest {
   }
 
   @Test
+  fun `detectNotificationPermissionDialog returns true when notification dialog markers present`() {
+    val title = UIElementInfo(text = "Allow Example to send notifications?")
+    val allowButton =
+        UIElementInfo(resourceId = "com.android.permissioncontroller:id/permission_allow_button")
+    val childrenJson =
+        json.encodeToJsonElement(ListSerializer(UIElementInfo.serializer()), listOf(title, allowButton))
+    val root = UIElementInfo(className = "android.widget.LinearLayout", node = childrenJson)
+
+    assertTrue(
+        extractor.detectNotificationPermissionDialogForTest(
+            root,
+            "com.android.permissioncontroller",
+        ),
+    )
+  }
+
+  @Test
+  fun `detectNotificationPermissionDialog returns false for non-permission controller package`() {
+    val title = UIElementInfo(text = "Allow Example to send notifications?")
+    val allowButton =
+        UIElementInfo(resourceId = "com.android.permissioncontroller:id/permission_allow_button")
+    val childrenJson =
+        json.encodeToJsonElement(ListSerializer(UIElementInfo.serializer()), listOf(title, allowButton))
+    val root = UIElementInfo(className = "android.widget.LinearLayout", node = childrenJson)
+
+    assertFalse(
+        extractor.detectNotificationPermissionDialogForTest(
+            root,
+            "com.example.app",
+        ),
+    )
+  }
+
+  @Test
   fun `meetsFilterCriteria excludes UIElementInfo with no values`() = runTest {
     val plainElement = UIElementInfo()
 

--- a/src/features/observe/AccessibilityServiceClient.ts
+++ b/src/features/observe/AccessibilityServiceClient.ts
@@ -72,6 +72,8 @@ export interface AccessibilityHierarchy {
   hierarchy: AccessibilityNode;
   windows?: AccessibilityWindowHierarchy[];
   intentChooserDetected?: boolean;
+  notificationPermissionDetected?: boolean;
+  error?: string;
 }
 
 /**
@@ -791,7 +793,13 @@ export class AccessibilityServiceClient implements AccessibilityService {
 
         // Notify hierarchy navigation detector for view hierarchy-based navigation detection
         if (this.hierarchyNavigationDetector) {
+          if (!message.data.hierarchy) {
+            logger.warn("[ACCESSIBILITY_SERVICE] Skipping navigation detection: hierarchy missing in update");
+          } else if (message.data.error) {
+            logger.warn(`[ACCESSIBILITY_SERVICE] Skipping navigation detection due to hierarchy error: ${message.data.error}`);
+          } else {
           this.hierarchyNavigationDetector.onHierarchyUpdate(message.data);
+          }
         }
       }
 
@@ -1259,13 +1267,47 @@ export class AccessibilityServiceClient implements AccessibilityService {
     try {
       logger.info("[ACCESSIBILITY_SERVICE] Converting accessibility service format to ViewHierarchyResult format");
 
+      let hierarchyToConvert: AccessibilityNode | undefined = accessibilityHierarchy.hierarchy;
+      let resolvedPackageName = accessibilityHierarchy.packageName;
+      let fallbackWindowId: number | undefined;
+
+      if (!hierarchyToConvert && accessibilityHierarchy.windows?.length) {
+        const windowsWithHierarchy = accessibilityHierarchy.windows.filter(window => window.hierarchy);
+        const fallbackWindow =
+          windowsWithHierarchy.find(window => window.isFocused) ?? windowsWithHierarchy[0];
+
+        if (fallbackWindow?.hierarchy) {
+          hierarchyToConvert = fallbackWindow.hierarchy;
+          fallbackWindowId = fallbackWindow.windowId;
+          if (!resolvedPackageName && fallbackWindow.packageName) {
+            resolvedPackageName = fallbackWindow.packageName;
+          }
+          logger.warn(
+            `[ACCESSIBILITY_SERVICE] Missing main hierarchy, using window ${fallbackWindow.windowId} for conversion`
+          );
+        }
+      }
+
+      if (!hierarchyToConvert) {
+        const errorMessage = accessibilityHierarchy.error || "Accessibility hierarchy missing from accessibility service";
+        return {
+          hierarchy: {
+            error: errorMessage
+          },
+          packageName: resolvedPackageName,
+          intentChooserDetected: accessibilityHierarchy.intentChooserDetected,
+          notificationPermissionDetected: accessibilityHierarchy.notificationPermissionDetected
+        } as ViewHierarchyResult;
+      }
+
       // Convert the accessibility node format to match the existing XML-based format
-      const convertedHierarchy = this.convertAccessibilityNode(accessibilityHierarchy.hierarchy);
+      const convertedHierarchy = this.convertAccessibilityNode(hierarchyToConvert);
 
       const result: ViewHierarchyResult = {
         hierarchy: convertedHierarchy,
-        packageName: accessibilityHierarchy.packageName,
-        intentChooserDetected: accessibilityHierarchy.intentChooserDetected
+        packageName: resolvedPackageName,
+        intentChooserDetected: accessibilityHierarchy.intentChooserDetected,
+        notificationPermissionDetected: accessibilityHierarchy.notificationPermissionDetected
       };
 
       // Convert windows if present (for multi-window support - popups, toolbars, etc.)
@@ -1283,7 +1325,10 @@ export class AccessibilityServiceClient implements AccessibilityService {
       }
 
       const duration = Date.now() - startTime;
-      logger.info(`[ACCESSIBILITY_SERVICE] Format conversion completed in ${duration}ms`);
+      logger.info(
+        `[ACCESSIBILITY_SERVICE] Format conversion completed in ${duration}ms` +
+        `${fallbackWindowId !== undefined ? ` (fallback window ${fallbackWindowId})` : ""}`
+      );
 
       return result;
     } catch (error) {

--- a/src/features/observe/ObserveScreen.ts
+++ b/src/features/observe/ObserveScreen.ts
@@ -234,6 +234,12 @@ export class ObserveScreen {
           logger.debug(`Found focused element: ${focusedElement.text || focusedElement["resource-id"] || "no text/id"}`);
         }
         await this.detectIntentChooser(result);
+        if (viewHierarchy.notificationPermissionDetected !== undefined) {
+          result.notificationPermissionDetected = viewHierarchy.notificationPermissionDetected;
+          if (viewHierarchy.notificationPermissionDetected) {
+            logger.info("[ObserveScreen] Notification permission dialog detected in view hierarchy");
+          }
+        }
       }
 
       logger.debug(`View hierarchy retrieval took ${Date.now() - viewHierarchyStart}ms`);
@@ -358,6 +364,10 @@ export class ObserveScreen {
         // Fallback: if activeWindow still not populated, use the Window class
         if (!result.activeWindow) {
           await this.collectActiveWindow(result);
+        }
+
+        if (result.notificationPermissionDetected && result.activeWindow) {
+          result.activeWindow.type = "notification_permission_dialog";
         }
 
         perf.end();

--- a/src/models/ActiveWindowInfo.ts
+++ b/src/models/ActiveWindowInfo.ts
@@ -5,4 +5,6 @@ export interface ActiveWindowInfo {
   appId: string;
   activityName: string;
   layoutSeqSum: number;
+  /** Optional classification for system dialogs or non-app surfaces */
+  type?: string;
 }

--- a/src/models/ObserveResult.ts
+++ b/src/models/ObserveResult.ts
@@ -99,6 +99,8 @@ export interface ObserveResult {
 
   /** Whether a system intent chooser dialog was detected */
   intentChooserDetected?: boolean;
+  /** Whether a notification permission dialog was detected */
+  notificationPermissionDetected?: boolean;
 
   /**
    * Device wakefulness state (Android only)

--- a/src/models/ViewHierarchyResult.ts
+++ b/src/models/ViewHierarchyResult.ts
@@ -12,6 +12,8 @@ export interface ViewHierarchyResult {
   packageName?: string;
   /** Whether an intent chooser dialog was detected (from accessibility service) */
   intentChooserDetected?: boolean;
+  /** Whether a notification permission dialog was detected (from accessibility service) */
+  notificationPermissionDetected?: boolean;
   /** All visible windows (including popups, toolbars, etc.) */
   windows?: WindowHierarchy[];
 }

--- a/test/fakes/FakeAccessibilityService.ts
+++ b/test/fakes/FakeAccessibilityService.ts
@@ -281,7 +281,8 @@ export class FakeAccessibilityService implements AccessibilityService {
       },
       packageName: accessibilityHierarchy.packageName,
       updatedAt: accessibilityHierarchy.updatedAt,
-      intentChooserDetected: accessibilityHierarchy.intentChooserDetected
+      intentChooserDetected: accessibilityHierarchy.intentChooserDetected,
+      notificationPermissionDetected: accessibilityHierarchy.notificationPermissionDetected
     };
   }
 

--- a/test/features/observe/AccessibilityServiceClient.test.ts
+++ b/test/features/observe/AccessibilityServiceClient.test.ts
@@ -235,6 +235,7 @@ describe("AccessibilityServiceClient", function() {
         updatedAt: 1750934583218,
         packageName: "com.google.android.deskclock",
         intentChooserDetected: true,
+        notificationPermissionDetected: true,
         hierarchy: {
           "text": "6:43 AM",
           "content-desc": "6:43 AM",
@@ -272,6 +273,7 @@ describe("AccessibilityServiceClient", function() {
       expect(result.hierarchy.clickable).toBeUndefined();
       expect(result.hierarchy.enabled).toBe("true");
       expect(result.intentChooserDetected).toBe(true);
+      expect(result.notificationPermissionDetected).toBe(true);
 
       // Check child node conversion
       expect(typeof result.hierarchy.node).toBe("object");
@@ -314,7 +316,35 @@ describe("AccessibilityServiceClient", function() {
 
       expect(result).toBeDefined();
       expect(result.hierarchy).toBeDefined();
-      expect(result.hierarchy.error).toContain("Failed to convert accessibility service hierarchy format");
+      expect(result.hierarchy.error).toContain("Accessibility hierarchy missing from accessibility service");
+    });
+
+    test("should fall back to window hierarchy when main hierarchy is missing", function() {
+      const fallbackHierarchy = {
+        updatedAt: 1750934583218,
+        packageName: "",
+        hierarchy: null as any,
+        windows: [
+          {
+            windowId: 10,
+            windowType: "application",
+            windowLayer: 0,
+            packageName: "com.android.permissioncontroller",
+            isActive: false,
+            isFocused: true,
+            hierarchy: {
+              text: "Allow Example to send notifications?",
+              "resource-id": "com.android.permissioncontroller:id/permission_allow_button"
+            }
+          }
+        ]
+      };
+
+      const result = accessibilityServiceClient.convertToViewHierarchyResult(fallbackHierarchy);
+
+      expect(result.hierarchy).toBeDefined();
+      expect(result.hierarchy.text).toBe("Allow Example to send notifications?");
+      expect(result.packageName).toBe("com.android.permissioncontroller");
     });
   });
 


### PR DESCRIPTION
## Summary
- detect notification permission dialogs in the accessibility hierarchy and surface the flag through observe/activeWindow
- fall back to a window hierarchy when the main accessibility tree is missing
- add coverage for notification dialog detection and conversion fallback

## Testing
- bun run build
- bun run test -- --grep "AccessibilityServiceClient"
- (cd android && ./gradlew :accessibility-service:testDebugUnitTest)

Fixes #402
