### PR TITLE
Add video recording MCP controls

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -12,6 +12,7 @@ import { registerUtilityTools } from "../server/utilityTools";
 import { registerDeviceTools } from "../server/deviceTools";
 import { registerPlanTools } from "../server/planTools";
 import { registerDoctorTools } from "../server/doctorTools";
+import { registerVideoRecordingTools } from "../server/videoRecordingTools";
 
 // Initialize tool registry for CLI mode
 export function initializeCliTools(): void {
@@ -24,6 +25,7 @@ export function initializeCliTools(): void {
   registerDeviceTools();
   registerPlanTools();
   registerDoctorTools();
+  registerVideoRecordingTools();
 }
 
 // Parse CLI arguments into tool name, session UUID, and parameters

--- a/src/daemon/manager.ts
+++ b/src/daemon/manager.ts
@@ -85,6 +85,24 @@ export class DaemonManager {
     if (options.planExecutionLockScope) {
       args.push("--plan-execution-lock-scope", options.planExecutionLockScope);
     }
+    if (options.videoQualityPreset) {
+      args.push("--video-quality", options.videoQualityPreset);
+    }
+    if (options.videoTargetBitrateKbps !== undefined) {
+      args.push("--video-target-bitrate-kbps", options.videoTargetBitrateKbps.toString());
+    }
+    if (options.videoMaxThroughputMbps !== undefined) {
+      args.push("--video-max-throughput-mbps", options.videoMaxThroughputMbps.toString());
+    }
+    if (options.videoFps !== undefined) {
+      args.push("--video-fps", options.videoFps.toString());
+    }
+    if (options.videoFormat) {
+      args.push("--video-format", options.videoFormat);
+    }
+    if (options.videoMaxArchiveSizeMb !== undefined) {
+      args.push("--video-archive-size-mb", options.videoMaxArchiveSizeMb.toString());
+    }
 
     // Create secure temp directory with random suffix to prevent symlink attacks
     const tempDir = mkdtempSync(join(tmpdir(), "auto-mobile-daemon-"));
@@ -325,6 +343,24 @@ export async function runDaemonCommand(
               options.planExecutionLockScope = scope;
             }
             i++;
+          } else if (args[i] === "--video-quality" || args[i] === "--video-quality-preset") {
+            options.videoQualityPreset = args[i + 1];
+            i++;
+          } else if (args[i] === "--video-target-bitrate-kbps") {
+            options.videoTargetBitrateKbps = parseInt(args[i + 1], 10);
+            i++;
+          } else if (args[i] === "--video-max-throughput-mbps") {
+            options.videoMaxThroughputMbps = Number(args[i + 1]);
+            i++;
+          } else if (args[i] === "--video-fps") {
+            options.videoFps = parseInt(args[i + 1], 10);
+            i++;
+          } else if (args[i] === "--video-format") {
+            options.videoFormat = args[i + 1];
+            i++;
+          } else if (args[i] === "--video-archive-size-mb") {
+            options.videoMaxArchiveSizeMb = Number(args[i + 1]);
+            i++;
           }
         }
 
@@ -372,6 +408,24 @@ export async function runDaemonCommand(
             if (scope === "global" || scope === "session") {
               options.planExecutionLockScope = scope;
             }
+            i++;
+          } else if (args[i] === "--video-quality" || args[i] === "--video-quality-preset") {
+            options.videoQualityPreset = args[i + 1];
+            i++;
+          } else if (args[i] === "--video-target-bitrate-kbps") {
+            options.videoTargetBitrateKbps = parseInt(args[i + 1], 10);
+            i++;
+          } else if (args[i] === "--video-max-throughput-mbps") {
+            options.videoMaxThroughputMbps = Number(args[i + 1]);
+            i++;
+          } else if (args[i] === "--video-fps") {
+            options.videoFps = parseInt(args[i + 1], 10);
+            i++;
+          } else if (args[i] === "--video-format") {
+            options.videoFormat = args[i + 1];
+            i++;
+          } else if (args[i] === "--video-archive-size-mb") {
+            options.videoMaxArchiveSizeMb = Number(args[i + 1]);
             i++;
           }
         }

--- a/src/daemon/types.ts
+++ b/src/daemon/types.ts
@@ -78,6 +78,18 @@ export interface DaemonOptions {
   strictAwait?: boolean;
   /** Plan execution lock scope (session or global) */
   planExecutionLockScope?: "session" | "global";
+  /** Default video quality preset */
+  videoQualityPreset?: string;
+  /** Default video target bitrate in Kbps */
+  videoTargetBitrateKbps?: number;
+  /** Default video max throughput in Mbps */
+  videoMaxThroughputMbps?: number;
+  /** Default video FPS */
+  videoFps?: number;
+  /** Default video format */
+  videoFormat?: string;
+  /** Default video archive size limit in MB */
+  videoMaxArchiveSizeMb?: number;
 }
 
 /**

--- a/src/features/video/NoopVideoCaptureBackend.ts
+++ b/src/features/video/NoopVideoCaptureBackend.ts
@@ -1,0 +1,50 @@
+import fs from "fs-extra";
+import { logger } from "../../utils/logger";
+import type {
+  RecordingHandle,
+  RecordingResult,
+  VideoCaptureBackend,
+  VideoCaptureConfig,
+} from "./VideoRecorderService";
+
+let warnedNoopBackend = false;
+
+export class NoopVideoCaptureBackend implements VideoCaptureBackend {
+  async start(config: VideoCaptureConfig): Promise<RecordingHandle> {
+    await fs.ensureFile(config.outputPath);
+
+    if (!warnedNoopBackend) {
+      warnedNoopBackend = true;
+      logger.warn(
+        "[VideoCapture] Noop backend active; recordings will be empty placeholder files."
+      );
+    }
+
+    return {
+      recordingId: config.recordingId,
+      outputPath: config.outputPath,
+      startedAt: config.startedAt,
+    };
+  }
+
+  async stop(handle: RecordingHandle): Promise<RecordingResult> {
+    await fs.ensureFile(handle.outputPath);
+
+    let sizeBytes = 0;
+    try {
+      const stats = await fs.stat(handle.outputPath);
+      sizeBytes = stats.size;
+    } catch {
+      sizeBytes = 0;
+    }
+
+    return {
+      recordingId: handle.recordingId,
+      outputPath: handle.outputPath,
+      startedAt: handle.startedAt,
+      endedAt: new Date().toISOString(),
+      sizeBytes,
+      codec: "h264",
+    };
+  }
+}

--- a/src/features/video/PlatformVideoCaptureBackend.ts
+++ b/src/features/video/PlatformVideoCaptureBackend.ts
@@ -1,0 +1,306 @@
+import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
+import type { WriteStream } from "node:fs";
+import fs from "fs-extra";
+import { ActionableError, BootedDevice } from "../../models";
+import { AdbClient } from "../../utils/android-cmdline-tools/AdbClient";
+import { SimCtlClient } from "../../utils/ios-cmdline-tools/SimCtlClient";
+import { logger } from "../../utils/logger";
+import type {
+  RecordingHandle,
+  RecordingResult,
+  VideoCaptureBackend,
+  VideoCaptureConfig,
+} from "./VideoRecorderService";
+
+const ANDROID_SCREENRECORD_MAX_SECONDS = 180;
+const PROCESS_EXIT_TIMEOUT_MS = 5000;
+
+interface ProcessExitState {
+  exitCode?: number | null;
+  signal?: NodeJS.Signals | null;
+  endedAt?: string;
+}
+
+interface AndroidBackendHandle {
+  kind: "android";
+  process: ChildProcessWithoutNullStreams;
+  outputStream: WriteStream;
+  exitState: ProcessExitState;
+  exitPromise: Promise<void>;
+  stderr: string[];
+}
+
+interface IosBackendHandle {
+  kind: "ios";
+  process: ChildProcessWithoutNullStreams;
+  exitState: ProcessExitState;
+  exitPromise: Promise<void>;
+  stderr: string[];
+}
+
+type BackendHandle = AndroidBackendHandle | IosBackendHandle;
+
+function createExitTracker(
+  process: ChildProcessWithoutNullStreams,
+  stderr: string[]
+): { exitState: ProcessExitState; exitPromise: Promise<void> } {
+  const exitState: ProcessExitState = {};
+  let resolvePromise: (() => void) | null = null;
+  let rejectPromise: ((error: Error) => void) | null = null;
+
+  const exitPromise = new Promise<void>((resolve, reject) => {
+    resolvePromise = resolve;
+    rejectPromise = reject;
+  });
+
+  process.once("error", error => {
+    rejectPromise?.(error instanceof Error ? error : new Error(String(error)));
+  });
+
+  process.once("exit", (code, signal) => {
+    exitState.exitCode = code;
+    exitState.signal = signal;
+    exitState.endedAt = new Date().toISOString();
+    resolvePromise?.();
+  });
+
+  process.stderr.on("data", chunk => {
+    stderr.push(chunk.toString());
+  });
+
+  if (process.exitCode !== null) {
+    exitState.exitCode = process.exitCode;
+    exitState.signal = process.signalCode;
+    exitState.endedAt = new Date().toISOString();
+    resolvePromise?.();
+  }
+
+  return { exitState, exitPromise };
+}
+
+async function waitForExit(
+  process: ChildProcessWithoutNullStreams,
+  exitPromise: Promise<void>
+): Promise<void> {
+  if (process.exitCode !== null) {
+    await exitPromise;
+    return;
+  }
+
+  if (process.killed) {
+    await exitPromise;
+    return;
+  }
+
+  process.kill("SIGINT");
+
+  let timeoutId: NodeJS.Timeout | undefined;
+  const timeoutPromise = new Promise<void>(resolve => {
+    timeoutId = setTimeout(() => {
+      if (process.exitCode === null) {
+        process.kill("SIGKILL");
+      }
+      resolve();
+    }, PROCESS_EXIT_TIMEOUT_MS);
+  });
+
+  await Promise.race([exitPromise, timeoutPromise]);
+
+  if (timeoutId) {
+    clearTimeout(timeoutId);
+  }
+
+  await exitPromise;
+}
+
+function clampBitrateKbps(config: VideoCaptureConfig): number {
+  const maxBitrateKbps = Math.max(0, Math.floor(config.maxThroughputMbps * 1000));
+  if (!maxBitrateKbps) {
+    return config.targetBitrateKbps;
+  }
+
+  return Math.min(config.targetBitrateKbps, maxBitrateKbps);
+}
+
+export class PlatformVideoCaptureBackend implements VideoCaptureBackend {
+  async start(config: VideoCaptureConfig): Promise<RecordingHandle> {
+    const device = config.device;
+    if (!device) {
+      throw new ActionableError("Device is required to start video recording.");
+    }
+
+    if (device.platform === "android") {
+      return this.startAndroid(device, config);
+    }
+
+    if (device.platform === "ios") {
+      return this.startIos(device, config);
+    }
+
+    throw new ActionableError(`Unsupported platform for video recording: ${device.platform}`);
+  }
+
+  async stop(handle: RecordingHandle): Promise<RecordingResult> {
+    const backendHandle = handle.backendHandle as BackendHandle | undefined;
+    if (!backendHandle) {
+      throw new Error("Missing backend handle for video recording.");
+    }
+
+    await waitForExit(backendHandle.process, backendHandle.exitPromise);
+
+    if (backendHandle.kind === "android") {
+      await new Promise<void>((resolve, reject) => {
+        backendHandle.outputStream.once("close", resolve);
+        backendHandle.outputStream.once("error", reject);
+      });
+    }
+
+    const sizeBytes = await this.getFileSize(handle.outputPath);
+    const codec = "h264";
+
+    if (backendHandle.exitState.exitCode && backendHandle.exitState.exitCode !== 0) {
+      logger.warn(
+        `[VideoCapture] Recording exited with code ${backendHandle.exitState.exitCode}: ${backendHandle.stderr.join("")}`
+      );
+    }
+
+    return {
+      recordingId: handle.recordingId,
+      outputPath: handle.outputPath,
+      startedAt: handle.startedAt,
+      endedAt: backendHandle.exitState.endedAt ?? new Date().toISOString(),
+      sizeBytes,
+      codec,
+    };
+  }
+
+  private async startAndroid(
+    device: BootedDevice,
+    config: VideoCaptureConfig
+  ): Promise<RecordingHandle> {
+    const adb = new AdbClient(device);
+    const { adbPath, baseArgs } = await adb.getBaseCommandParts();
+    const bitrateKbps = clampBitrateKbps(config);
+    const bitrateBps = Math.max(1, Math.round(bitrateKbps * 1000));
+    const timeLimitSeconds = this.resolveAndroidTimeLimit(config.maxDurationSeconds);
+
+    if (config.maxDurationSeconds && config.maxDurationSeconds > ANDROID_SCREENRECORD_MAX_SECONDS) {
+      logger.warn(
+        `[VideoCapture] Android screenrecord caps at ${ANDROID_SCREENRECORD_MAX_SECONDS}s; requested ${config.maxDurationSeconds}s.`
+      );
+    }
+
+    const args = [
+      ...baseArgs,
+      "exec-out",
+      "screenrecord",
+      "--bit-rate",
+      String(bitrateBps),
+      "--time-limit",
+      String(timeLimitSeconds),
+    ];
+
+    if (config.resolution) {
+      args.push("--size", `${config.resolution.width}x${config.resolution.height}`);
+    }
+
+    const process = spawn(adbPath, args, { stdio: ["ignore", "pipe", "pipe"] });
+    const outputStream = fs.createWriteStream(config.outputPath);
+    process.stdout.pipe(outputStream);
+
+    try {
+      await this.waitForSpawn(process);
+    } catch (error) {
+      outputStream.destroy();
+      throw new ActionableError(`Failed to start Android recording: ${error}`);
+    }
+
+    const stderr: string[] = [];
+    const { exitState, exitPromise } = createExitTracker(process, stderr);
+
+    const backendHandle: AndroidBackendHandle = {
+      kind: "android",
+      process,
+      outputStream,
+      exitState,
+      exitPromise,
+      stderr,
+    };
+
+    return {
+      recordingId: config.recordingId,
+      outputPath: config.outputPath,
+      startedAt: config.startedAt,
+      backendHandle,
+    };
+  }
+
+  private async startIos(
+    device: BootedDevice,
+    config: VideoCaptureConfig
+  ): Promise<RecordingHandle> {
+    const simctl = new SimCtlClient(device);
+    const available = await simctl.isAvailable();
+    if (!available) {
+      throw new ActionableError("simctl is not available. Install Xcode command line tools.");
+    }
+
+    const args = [
+      "simctl",
+      "io",
+      device.deviceId,
+      "recordVideo",
+      config.outputPath,
+    ];
+
+    const process = spawn("xcrun", args, { stdio: ["ignore", "pipe", "pipe"] });
+
+    try {
+      await this.waitForSpawn(process);
+    } catch (error) {
+      throw new ActionableError(`Failed to start iOS recording: ${error}`);
+    }
+
+    const stderr: string[] = [];
+    const { exitState, exitPromise } = createExitTracker(process, stderr);
+
+    const backendHandle: IosBackendHandle = {
+      kind: "ios",
+      process,
+      exitState,
+      exitPromise,
+      stderr,
+    };
+
+    return {
+      recordingId: config.recordingId,
+      outputPath: config.outputPath,
+      startedAt: config.startedAt,
+      backendHandle,
+    };
+  }
+
+  private resolveAndroidTimeLimit(maxDurationSeconds?: number): number {
+    if (maxDurationSeconds && maxDurationSeconds > 0) {
+      return Math.min(maxDurationSeconds, ANDROID_SCREENRECORD_MAX_SECONDS);
+    }
+
+    return ANDROID_SCREENRECORD_MAX_SECONDS;
+  }
+
+  private async waitForSpawn(process: ChildProcessWithoutNullStreams): Promise<void> {
+    await new Promise<void>((resolve, reject) => {
+      process.once("spawn", () => resolve());
+      process.once("error", error => reject(error));
+    });
+  }
+
+  private async getFileSize(filePath: string): Promise<number | undefined> {
+    try {
+      const stats = await fs.stat(filePath);
+      return stats.size;
+    } catch {
+      return undefined;
+    }
+  }
+}

--- a/src/features/video/VideoRecorderService.ts
+++ b/src/features/video/VideoRecorderService.ts
@@ -8,6 +8,8 @@ import type {
   VideoRecordingConfigInput,
   VideoRecordingMetadata,
   VideoQualityPreset,
+  BootedDevice,
+  VideoResolution,
 } from "../../models";
 import { logger, type Logger } from "../../utils/logger";
 
@@ -17,6 +19,8 @@ export interface VideoCaptureConfig extends VideoRecordingConfig {
   outputPath: string;
   fileName: string;
   startedAt: string;
+  device?: BootedDevice;
+  maxDurationSeconds?: number;
 }
 
 export interface RecordingHandle {
@@ -44,6 +48,8 @@ export interface VideoCaptureBackend {
 export interface StartVideoRecordingOptions {
   outputName?: string;
   config?: VideoRecordingConfigInput | null;
+  device?: BootedDevice;
+  maxDurationSeconds?: number;
 }
 
 export interface ActiveVideoRecording {
@@ -92,16 +98,17 @@ export function parseVideoRecordingConfig(
     input && typeof input === "object" ? input : {};
 
   const qualityPreset = parseQualityPreset(safeInput.qualityPreset);
-  const targetBitrateKbps = parsePositiveNumber(
-    safeInput.targetBitrateKbps,
-    DEFAULT_VIDEO_RECORDING_CONFIG.targetBitrateKbps,
-    true
-  );
   const maxThroughputMbps = parsePositiveNumber(
     safeInput.maxThroughputMbps,
     DEFAULT_VIDEO_RECORDING_CONFIG.maxThroughputMbps,
     true
   );
+  const requestedBitrateKbps = parsePositiveNumber(
+    safeInput.targetBitrateKbps,
+    DEFAULT_VIDEO_RECORDING_CONFIG.targetBitrateKbps,
+    true
+  );
+  const targetBitrateKbps = capBitrateKbps(requestedBitrateKbps, maxThroughputMbps);
   const fps = parsePositiveNumber(
     safeInput.fps,
     DEFAULT_VIDEO_RECORDING_CONFIG.fps,
@@ -113,6 +120,7 @@ export function parseVideoRecordingConfig(
     true
   );
   const format = parseFormat(safeInput.format);
+  const resolution = parseResolution(safeInput.resolution);
 
   return {
     qualityPreset,
@@ -121,6 +129,7 @@ export function parseVideoRecordingConfig(
     fps,
     maxArchiveSizeMb,
     format,
+    resolution,
   };
 }
 
@@ -161,6 +170,8 @@ export class VideoRecorderService {
       outputPath,
       fileName,
       startedAt,
+      device: options.device,
+      maxDurationSeconds: options.maxDurationSeconds,
       ...config,
     });
 
@@ -455,6 +466,32 @@ function parseFormat(
   }
 
   return DEFAULT_VIDEO_RECORDING_CONFIG.format;
+}
+
+function parseResolution(
+  value: VideoRecordingConfigInput["resolution"]
+): VideoResolution | undefined {
+  if (!value || typeof value !== "object") {
+    return undefined;
+  }
+
+  const width = parsePositiveNumber(value.width, 0, false);
+  const height = parsePositiveNumber(value.height, 0, false);
+
+  if (width <= 0 || height <= 0) {
+    return undefined;
+  }
+
+  return { width, height };
+}
+
+function capBitrateKbps(targetBitrateKbps: number, maxThroughputMbps: number): number {
+  const maxBitrateKbps = Math.max(0, Math.floor(maxThroughputMbps * 1000));
+  if (!maxBitrateKbps) {
+    return targetBitrateKbps;
+  }
+
+  return Math.min(targetBitrateKbps, maxBitrateKbps);
 }
 
 function parsePositiveNumber(

--- a/src/features/video/index.ts
+++ b/src/features/video/index.ts
@@ -17,3 +17,5 @@ export {
   DEFAULT_VIDEO_RECORDING_CONFIG,
   parseVideoRecordingConfig,
 } from "./VideoRecorderService";
+export { NoopVideoCaptureBackend } from "./NoopVideoCaptureBackend";
+export { PlatformVideoCaptureBackend } from "./PlatformVideoCaptureBackend";

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,7 @@ import { executionTracker } from "./server/executionTracker";
 import { FeatureFlagService } from "./features/featureFlags/FeatureFlagService";
 import type { FeatureFlagKey } from "./features/featureFlags/FeatureFlagDefinitions";
 import { serverConfig, type PlanExecutionLockScope } from "./utils/ServerConfig";
+import type { VideoRecordingConfigInput } from "./models";
 
 // Detect port from git branch name for worktree isolation
 // e.g., work/164-feature-name -> port 9164
@@ -77,6 +78,7 @@ function parseArgs(): {
   a11yUseBaseline: boolean;
   predictiveUi: boolean;
   planExecutionLockScope: PlanExecutionLockScope;
+  videoRecordingDefaults: VideoRecordingConfigInput;
   daemonMode: boolean;
   daemonCommand?: string;
   daemonArgs: string[];
@@ -128,6 +130,86 @@ function parseArgs(): {
   let a11yUseBaseline = false;
   const predictiveUi = args.includes("--predictive") || args.includes("--predictive-ui");
   let planExecutionLockScope: PlanExecutionLockScope = "session";
+  const videoRecordingDefaults: VideoRecordingConfigInput = {};
+
+  const parsePositiveNumber = (
+    value: string | undefined,
+    label: string,
+    allowFloat: boolean
+  ): number | undefined => {
+    if (!value) {
+      return undefined;
+    }
+    const parsed = allowFloat ? Number(value) : parseInt(value, 10);
+    if (!Number.isFinite(parsed) || parsed <= 0) {
+      logger.warn(`Invalid ${label}: ${value}`);
+      return undefined;
+    }
+    return allowFloat ? parsed : Math.round(parsed);
+  };
+
+  const allowedQualityPresets = new Set(["low", "medium", "high"]);
+  const allowedFormats = new Set(["mp4"]);
+
+  const applyQualityPreset = (value: string | undefined, source: string) => {
+    if (!value) {
+      return;
+    }
+    if (!allowedQualityPresets.has(value)) {
+      logger.warn(`Invalid video quality preset (${source}): ${value}`);
+      return;
+    }
+    videoRecordingDefaults.qualityPreset = value;
+  };
+
+  const applyFormat = (value: string | undefined, source: string) => {
+    if (!value) {
+      return;
+    }
+    if (!allowedFormats.has(value)) {
+      logger.warn(`Invalid video format (${source}): ${value}`);
+      return;
+    }
+    videoRecordingDefaults.format = value;
+  };
+
+  applyQualityPreset(
+    process.env.AUTO_MOBILE_VIDEO_QUALITY_PRESET ??
+      process.env.AUTOMOBILE_VIDEO_QUALITY_PRESET,
+    "env"
+  );
+  const envTargetBitrate = process.env.AUTO_MOBILE_VIDEO_TARGET_BITRATE_KBPS ??
+    process.env.AUTOMOBILE_VIDEO_TARGET_BITRATE_KBPS;
+  const envMaxThroughput = process.env.AUTO_MOBILE_VIDEO_MAX_THROUGHPUT_MBPS ??
+    process.env.AUTOMOBILE_VIDEO_MAX_THROUGHPUT_MBPS;
+  const envFps = process.env.AUTO_MOBILE_VIDEO_FPS ??
+    process.env.AUTOMOBILE_VIDEO_FPS;
+  const envArchiveMb = process.env.AUTO_MOBILE_VIDEO_MAX_ARCHIVE_MB ??
+    process.env.AUTOMOBILE_VIDEO_MAX_ARCHIVE_MB;
+  const envFormat = process.env.AUTO_MOBILE_VIDEO_FORMAT ??
+    process.env.AUTOMOBILE_VIDEO_FORMAT;
+
+  const parsedTargetBitrate = parsePositiveNumber(envTargetBitrate, "video target bitrate", false);
+  if (parsedTargetBitrate !== undefined) {
+    videoRecordingDefaults.targetBitrateKbps = parsedTargetBitrate;
+  }
+
+  const parsedMaxThroughput = parsePositiveNumber(envMaxThroughput, "video max throughput", true);
+  if (parsedMaxThroughput !== undefined) {
+    videoRecordingDefaults.maxThroughputMbps = parsedMaxThroughput;
+  }
+
+  const parsedFps = parsePositiveNumber(envFps, "video fps", false);
+  if (parsedFps !== undefined) {
+    videoRecordingDefaults.fps = parsedFps;
+  }
+
+  const parsedArchive = parsePositiveNumber(envArchiveMb, "video max archive size", true);
+  if (parsedArchive !== undefined) {
+    videoRecordingDefaults.maxArchiveSizeMb = parsedArchive;
+  }
+
+  applyFormat(envFormat, "env");
 
   // Extract CLI-specific arguments (everything after --cli)
   const cliIndex = args.indexOf("--cli");
@@ -189,6 +271,38 @@ function parseArgs(): {
         logger.warn(`Invalid plan execution lock scope: ${scope}. Using default: ${planExecutionLockScope}`);
       }
       i++;
+    } else if (arg === "--video-quality" || arg === "--video-quality-preset") {
+      const qualityPreset = args[i + 1];
+      applyQualityPreset(qualityPreset, "cli");
+      i++;
+    } else if (arg === "--video-target-bitrate-kbps") {
+      const parsed = parsePositiveNumber(args[i + 1], "video target bitrate", false);
+      if (parsed !== undefined) {
+        videoRecordingDefaults.targetBitrateKbps = parsed;
+      }
+      i++;
+    } else if (arg === "--video-max-throughput-mbps") {
+      const parsed = parsePositiveNumber(args[i + 1], "video max throughput", true);
+      if (parsed !== undefined) {
+        videoRecordingDefaults.maxThroughputMbps = parsed;
+      }
+      i++;
+    } else if (arg === "--video-fps") {
+      const parsed = parsePositiveNumber(args[i + 1], "video fps", false);
+      if (parsed !== undefined) {
+        videoRecordingDefaults.fps = parsed;
+      }
+      i++;
+    } else if (arg === "--video-format") {
+      const format = args[i + 1];
+      applyFormat(format, "cli");
+      i++;
+    } else if (arg === "--video-archive-size-mb") {
+      const parsed = parsePositiveNumber(args[i + 1], "video max archive size", true);
+      if (parsed !== undefined) {
+        videoRecordingDefaults.maxArchiveSizeMb = parsed;
+      }
+      i++;
     }
   }
 
@@ -209,6 +323,7 @@ function parseArgs(): {
     a11yUseBaseline,
     predictiveUi,
     planExecutionLockScope,
+    videoRecordingDefaults,
     daemonMode,
     daemonCommand,
     daemonArgs,
@@ -602,12 +717,14 @@ async function main() {
       a11yUseBaseline,
       predictiveUi,
       planExecutionLockScope,
+      videoRecordingDefaults,
       daemonMode,
       daemonCommand,
       daemonArgs,
     } = parseArgs();
 
     serverConfig.setPlanExecutionLockScope(planExecutionLockScope);
+    serverConfig.setVideoRecordingDefaults(videoRecordingDefaults);
 
     const featureFlagService = FeatureFlagService.getInstance();
     await featureFlagService.initialize();

--- a/src/models/VideoRecording.ts
+++ b/src/models/VideoRecording.ts
@@ -2,6 +2,16 @@ export type VideoQualityPreset = "low" | "medium" | "high";
 
 export type VideoFormat = "mp4";
 
+export interface VideoResolution {
+  width: number;
+  height: number;
+}
+
+export interface VideoResolutionInput {
+  width?: number | string;
+  height?: number | string;
+}
+
 export interface VideoRecordingConfig {
   qualityPreset: VideoQualityPreset;
   targetBitrateKbps: number;
@@ -9,6 +19,7 @@ export interface VideoRecordingConfig {
   fps: number;
   maxArchiveSizeMb: number;
   format: VideoFormat;
+  resolution?: VideoResolution;
 }
 
 export interface VideoRecordingConfigInput {
@@ -18,6 +29,7 @@ export interface VideoRecordingConfigInput {
   fps?: number | string;
   maxArchiveSizeMb?: number | string;
   format?: VideoFormat | string;
+  resolution?: VideoResolutionInput;
 }
 
 export interface VideoRecordingMetadata {

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -31,6 +31,7 @@ import { registerDoctorTools } from "./doctorTools";
 import { registerFeatureFlagTools } from "./featureFlagTools";
 import { registerTestTimingTools } from "./testTimingTools";
 import { registerPerformanceTools } from "./performanceTools";
+import { registerVideoRecordingTools } from "./videoRecordingTools";
 import { getMcpServerVersion } from "../utils/mcpVersion";
 
 // Import resource registration functions
@@ -41,6 +42,7 @@ import { registerAppResources } from "./appResources";
 import { registerNavigationResources } from "./navigationResources";
 import { registerTestTimingResources } from "./testTimingResources";
 import { registerPerformanceResources } from "./performanceResources";
+import { registerVideoRecordingResources } from "./videoRecordingResources";
 import { FeatureFlagService } from "../features/featureFlags/FeatureFlagService";
 
 export interface McpServerOptions {
@@ -98,6 +100,7 @@ export const createMcpServer = (options: McpServerOptions = {}): McpServer => {
   registerDoctorTools();
   registerFeatureFlagTools();
   registerPerformanceTools();
+  registerVideoRecordingTools();
 
   // Register all resources
   registerObservationResources();
@@ -107,6 +110,7 @@ export const createMcpServer = (options: McpServerOptions = {}): McpServer => {
   registerNavigationResources();
   registerTestTimingResources();
   registerPerformanceResources();
+  registerVideoRecordingResources();
 
   registerDebugTools();
 

--- a/src/server/videoRecordingManager.ts
+++ b/src/server/videoRecordingManager.ts
@@ -1,0 +1,189 @@
+import { ActionableError, BootedDevice, VideoRecordingConfigInput, VideoRecordingMetadata } from "../models";
+import {
+  PlatformVideoCaptureBackend,
+  VideoRecorderService,
+  type ActiveVideoRecording,
+} from "../features/video";
+import { serverConfig } from "../utils/ServerConfig";
+import { logger } from "../utils/logger";
+import { defaultTimer, type Timer } from "../utils/SystemTimer";
+
+export interface StartVideoRecordingRequest {
+  device: BootedDevice;
+  configOverrides?: VideoRecordingConfigInput;
+  outputName?: string;
+  maxDurationSeconds?: number;
+}
+
+export interface VideoRecordingManagerDependencies {
+  videoRecorderService: VideoRecorderService;
+  timer: Timer;
+}
+
+let moduleDependencies: VideoRecordingManagerDependencies | null = null;
+
+const activeRecordingIds = new Set<string>();
+const autoStopTimers = new Map<string, { timer: Timer; handle: NodeJS.Timeout }>();
+let latestActiveRecordingId: string | null = null;
+
+function createDefaultRecorderService(): VideoRecorderService {
+  return new VideoRecorderService({
+    backend: new PlatformVideoCaptureBackend(),
+  });
+}
+
+function getVideoRecordingDependencies(): VideoRecordingManagerDependencies {
+  if (!moduleDependencies) {
+    moduleDependencies = {
+      videoRecorderService: createDefaultRecorderService(),
+      timer: defaultTimer,
+    };
+  }
+  return moduleDependencies;
+}
+
+export function setVideoRecordingManagerDependencies(
+  deps: Partial<VideoRecordingManagerDependencies>
+): void {
+  const current = getVideoRecordingDependencies();
+  moduleDependencies = {
+    videoRecorderService: deps.videoRecorderService ?? current.videoRecorderService,
+    timer: deps.timer ?? current.timer,
+  };
+  resetVideoRecordingManagerState();
+}
+
+export function resetVideoRecordingManagerState(): void {
+  for (const { timer, handle } of autoStopTimers.values()) {
+    timer.clearTimeout(handle);
+  }
+  autoStopTimers.clear();
+  activeRecordingIds.clear();
+  latestActiveRecordingId = null;
+}
+
+export function resetVideoRecordingManagerDependencies(): void {
+  resetVideoRecordingManagerState();
+  moduleDependencies = null;
+}
+
+function mergeConfigInput(
+  defaults: VideoRecordingConfigInput,
+  overrides: VideoRecordingConfigInput
+): VideoRecordingConfigInput {
+  const merged: VideoRecordingConfigInput = { ...defaults };
+  for (const [key, value] of Object.entries(overrides)) {
+    if (value !== undefined) {
+      (merged as Record<string, unknown>)[key] = value;
+    }
+  }
+  return merged;
+}
+
+function resolveActiveRecordingId(recordingId?: string): string {
+  if (recordingId) {
+    return recordingId;
+  }
+
+  if (latestActiveRecordingId && activeRecordingIds.has(latestActiveRecordingId)) {
+    return latestActiveRecordingId;
+  }
+
+  const [firstActive] = activeRecordingIds;
+  if (firstActive) {
+    return firstActive;
+  }
+
+  throw new ActionableError("No active video recording found. Provide recordingId.");
+}
+
+function scheduleAutoStop(recordingId: string, maxDurationSeconds: number): void {
+  if (!Number.isFinite(maxDurationSeconds) || maxDurationSeconds <= 0) {
+    return;
+  }
+
+  const { timer } = getVideoRecordingDependencies();
+  const timeoutMs = Math.max(1, Math.round(maxDurationSeconds * 1000));
+  const handle = timer.setTimeout(() => {
+    void stopVideoRecording(recordingId).catch(error => {
+      logger.warn(`[VideoRecording] Failed to auto-stop recording ${recordingId}: ${error}`);
+    });
+  }, timeoutMs);
+
+  autoStopTimers.set(recordingId, { timer, handle });
+}
+
+function clearAutoStop(recordingId: string): void {
+  const entry = autoStopTimers.get(recordingId);
+  if (entry) {
+    entry.timer.clearTimeout(entry.handle);
+    autoStopTimers.delete(recordingId);
+  }
+}
+
+export function getVideoRecorderService(): VideoRecorderService {
+  return getVideoRecordingDependencies().videoRecorderService;
+}
+
+export async function startVideoRecording(
+  request: StartVideoRecordingRequest
+): Promise<ActiveVideoRecording> {
+  const { videoRecorderService } = getVideoRecordingDependencies();
+  const defaults = serverConfig.getVideoRecordingDefaults();
+  const overrides = request.configOverrides ?? {};
+  const configInput = mergeConfigInput(defaults, overrides);
+
+  const active = await videoRecorderService.startRecording({
+    outputName: request.outputName,
+    config: configInput,
+    device: request.device,
+    maxDurationSeconds: request.maxDurationSeconds,
+  });
+
+  activeRecordingIds.add(active.recordingId);
+  latestActiveRecordingId = active.recordingId;
+
+  if (request.maxDurationSeconds) {
+    scheduleAutoStop(active.recordingId, request.maxDurationSeconds);
+  }
+
+  return active;
+}
+
+export async function stopVideoRecording(
+  recordingId?: string
+): Promise<VideoRecordingMetadata> {
+  const { videoRecorderService } = getVideoRecordingDependencies();
+  const resolvedId = resolveActiveRecordingId(recordingId);
+
+  clearAutoStop(resolvedId);
+
+  const metadata = await videoRecorderService.stopRecording(resolvedId);
+
+  activeRecordingIds.delete(resolvedId);
+  if (latestActiveRecordingId === resolvedId) {
+    latestActiveRecordingId = null;
+  }
+
+  return metadata;
+}
+
+export async function listVideoRecordings(): Promise<VideoRecordingMetadata[]> {
+  return getVideoRecordingDependencies().videoRecorderService.listRecordings();
+}
+
+export async function getVideoRecordingMetadata(
+  recordingId: string,
+  options?: { touch?: boolean }
+): Promise<VideoRecordingMetadata | null> {
+  return getVideoRecordingDependencies().videoRecorderService.getRecordingMetadata(recordingId, options);
+}
+
+export async function getLatestVideoRecordingMetadata(): Promise<VideoRecordingMetadata | null> {
+  const recordings = await listVideoRecordings();
+  return recordings[0] ?? null;
+}
+
+export async function deleteVideoRecording(recordingId: string): Promise<boolean> {
+  return getVideoRecordingDependencies().videoRecorderService.deleteRecording(recordingId);
+}

--- a/src/server/videoRecordingResources.ts
+++ b/src/server/videoRecordingResources.ts
@@ -1,0 +1,176 @@
+import { ResourceRegistry, ResourceContent } from "./resourceRegistry";
+import {
+  getLatestVideoRecordingMetadata,
+  getVideoRecordingMetadata,
+  listVideoRecordings,
+} from "./videoRecordingManager";
+import { logger } from "../utils/logger";
+import * as fs from "fs/promises";
+import type { VideoRecordingMetadata } from "../models";
+
+export const VIDEO_RESOURCE_URIS = {
+  LATEST: "automobile:video/latest",
+  ARCHIVE: "automobile:video/archive",
+  ARCHIVE_ITEM: "automobile:video/archive/{recordingId}",
+} as const;
+
+export function buildVideoArchiveItemUri(recordingId: string): string {
+  return `automobile:video/archive/${recordingId}`;
+}
+
+function getVideoMimeType(metadata: VideoRecordingMetadata): string {
+  if (metadata.format === "mp4") {
+    return "video/mp4";
+  }
+  return "application/octet-stream";
+}
+
+async function buildVideoResourceContent(
+  metadata: VideoRecordingMetadata,
+  uri: string
+): Promise<ResourceContent> {
+  if (!metadata.filePath) {
+    return {
+      uri,
+      mimeType: "application/json",
+      text: JSON.stringify({
+        error: `Missing file path for recording ${metadata.recordingId}`,
+        metadata,
+      }, null, 2),
+    };
+  }
+
+  try {
+    const fileBuffer = await fs.readFile(metadata.filePath);
+    const blob = fileBuffer.toString("base64");
+    return {
+      uri,
+      mimeType: getVideoMimeType(metadata),
+      text: JSON.stringify({ metadata }, null, 2),
+      blob,
+    };
+  } catch (error) {
+    logger.error(`[VideoRecordingResources] Failed to read video ${metadata.recordingId}: ${error}`);
+    return {
+      uri,
+      mimeType: "application/json",
+      text: JSON.stringify({
+        error: `Failed to read video data: ${error}`,
+        metadata,
+      }, null, 2),
+    };
+  }
+}
+
+async function getLatestVideoRecording(): Promise<ResourceContent> {
+  try {
+    const latest = await getLatestVideoRecordingMetadata();
+    if (!latest) {
+      return {
+        uri: VIDEO_RESOURCE_URIS.LATEST,
+        mimeType: "application/json",
+        text: JSON.stringify({
+          error: "No video recordings available. Call startVideoRecording first.",
+        }, null, 2),
+      };
+    }
+
+    const metadata = await getVideoRecordingMetadata(latest.recordingId, { touch: true }) ?? latest;
+    return buildVideoResourceContent(metadata, VIDEO_RESOURCE_URIS.LATEST);
+  } catch (error) {
+    logger.error(`[VideoRecordingResources] Failed to get latest recording: ${error}`);
+    return {
+      uri: VIDEO_RESOURCE_URIS.LATEST,
+      mimeType: "application/json",
+      text: JSON.stringify({
+        error: `Failed to retrieve latest recording: ${error}`,
+      }, null, 2),
+    };
+  }
+}
+
+async function getVideoArchiveList(): Promise<ResourceContent> {
+  try {
+    const recordings = await listVideoRecordings();
+    return {
+      uri: VIDEO_RESOURCE_URIS.ARCHIVE,
+      mimeType: "application/json",
+      text: JSON.stringify({
+        recordings,
+        count: recordings.length,
+      }, null, 2),
+    };
+  } catch (error) {
+    logger.error(`[VideoRecordingResources] Failed to list recordings: ${error}`);
+    return {
+      uri: VIDEO_RESOURCE_URIS.ARCHIVE,
+      mimeType: "application/json",
+      text: JSON.stringify({
+        error: `Failed to list recordings: ${error}`,
+      }, null, 2),
+    };
+  }
+}
+
+async function getVideoArchiveItem(params: Record<string, string>): Promise<ResourceContent> {
+  try {
+    const recordingId = params.recordingId;
+    if (!recordingId) {
+      return {
+        uri: VIDEO_RESOURCE_URIS.ARCHIVE_ITEM,
+        mimeType: "application/json",
+        text: JSON.stringify({ error: "Recording ID is required." }, null, 2),
+      };
+    }
+
+    const metadata = await getVideoRecordingMetadata(recordingId, { touch: true });
+    if (!metadata) {
+      return {
+        uri: buildVideoArchiveItemUri(recordingId),
+        mimeType: "application/json",
+        text: JSON.stringify({
+          error: `Recording not found: ${recordingId}`,
+        }, null, 2),
+      };
+    }
+
+    return buildVideoResourceContent(metadata, buildVideoArchiveItemUri(recordingId));
+  } catch (error) {
+    logger.error(`[VideoRecordingResources] Failed to read recording: ${error}`);
+    return {
+      uri: VIDEO_RESOURCE_URIS.ARCHIVE_ITEM,
+      mimeType: "application/json",
+      text: JSON.stringify({
+        error: `Failed to retrieve recording: ${error}`,
+      }, null, 2),
+    };
+  }
+}
+
+export function registerVideoRecordingResources(): void {
+  ResourceRegistry.register(
+    VIDEO_RESOURCE_URIS.LATEST,
+    "Latest Video Recording",
+    "The most recent video recording with metadata and base64-encoded video data.",
+    "video/mp4",
+    getLatestVideoRecording
+  );
+
+  ResourceRegistry.register(
+    VIDEO_RESOURCE_URIS.ARCHIVE,
+    "Video Recording Archive",
+    "Metadata list for archived video recordings.",
+    "application/json",
+    getVideoArchiveList
+  );
+
+  ResourceRegistry.registerTemplate(
+    VIDEO_RESOURCE_URIS.ARCHIVE_ITEM,
+    "Video Recording",
+    "Video recording content and metadata for the specified recording ID.",
+    "video/mp4",
+    getVideoArchiveItem
+  );
+
+  logger.info("[VideoRecordingResources] Registered video recording resources");
+}

--- a/src/server/videoRecordingTools.ts
+++ b/src/server/videoRecordingTools.ts
@@ -1,0 +1,221 @@
+import { z } from "zod";
+import { ToolRegistry } from "./toolRegistry";
+import { ActionableError, BootedDevice, VideoFormat, VideoQualityPreset } from "../models";
+import { createJSONToolResponse } from "../utils/toolUtils";
+import { addDeviceTargetingToSchema } from "./toolSchemaHelpers";
+import {
+  deleteVideoRecording,
+  listVideoRecordings,
+  startVideoRecording,
+  stopVideoRecording,
+} from "./videoRecordingManager";
+import { ResourceRegistry } from "./resourceRegistry";
+import { buildVideoArchiveItemUri, VIDEO_RESOURCE_URIS } from "./videoRecordingResources";
+import type { VideoRecordingConfigInput } from "../models";
+
+export interface StartVideoRecordingArgs {
+  platform: "android" | "ios";
+  deviceId?: string;
+  qualityPreset?: VideoQualityPreset;
+  targetBitrateKbps?: number;
+  maxThroughputMbps?: number;
+  fps?: number;
+  resolution?: {
+    width: number;
+    height: number;
+  };
+  format?: VideoFormat;
+  maxDurationSeconds?: number;
+  outputName?: string;
+  sessionUuid?: string;
+  device?: string;
+}
+
+export interface StopVideoRecordingArgs {
+  recordingId?: string;
+}
+
+export interface DeleteVideoRecordingArgs {
+  recordingId: string;
+}
+
+const resolutionSchema = z.object({
+  width: z.number().int().positive().describe("Override resolution width in pixels"),
+  height: z.number().int().positive().describe("Override resolution height in pixels"),
+});
+
+const startVideoRecordingSchema = addDeviceTargetingToSchema(z.object({
+  platform: z.enum(["android", "ios"]).describe("Target platform"),
+  deviceId: z.string().optional().describe("Optional device ID override"),
+  qualityPreset: z.enum(["low", "medium", "high"]).optional().describe("Recording quality preset"),
+  targetBitrateKbps: z.number().int().positive().optional().describe("Target bitrate in Kbps"),
+  maxThroughputMbps: z.number().positive().optional().describe("Max throughput in Mbps"),
+  fps: z.number().int().positive().optional().describe("Frames per second"),
+  resolution: resolutionSchema.optional().describe("Override capture resolution"),
+  format: z.enum(["mp4"]).optional().describe("Video format"),
+  maxDurationSeconds: z.number().int().positive().optional().describe("Maximum recording duration in seconds"),
+  outputName: z.string().optional().describe("Optional label to identify the recording"),
+}));
+
+const stopVideoRecordingSchema = z.object({
+  recordingId: z.string().optional().describe("Recording ID to stop (defaults to latest active recording)"),
+});
+
+const deleteVideoRecordingSchema = z.object({
+  recordingId: z.string().describe("Recording ID to delete"),
+});
+
+const listVideoRecordingsSchema = z.object({});
+
+function buildConfigOverrides(args: StartVideoRecordingArgs): VideoRecordingConfigInput {
+  const overrides: VideoRecordingConfigInput = {};
+  if (args.qualityPreset) {
+    overrides.qualityPreset = args.qualityPreset;
+  }
+  if (args.targetBitrateKbps !== undefined) {
+    overrides.targetBitrateKbps = args.targetBitrateKbps;
+  }
+  if (args.maxThroughputMbps !== undefined) {
+    overrides.maxThroughputMbps = args.maxThroughputMbps;
+  }
+  if (args.fps !== undefined) {
+    overrides.fps = args.fps;
+  }
+  if (args.format) {
+    overrides.format = args.format;
+  }
+  if (args.resolution) {
+    overrides.resolution = args.resolution;
+  }
+  return overrides;
+}
+
+export function registerVideoRecordingTools(): void {
+  const startVideoRecordingHandler = async (
+    device: BootedDevice,
+    args: StartVideoRecordingArgs
+  ) => {
+    try {
+      const active = await startVideoRecording({
+        device,
+        configOverrides: buildConfigOverrides(args),
+        outputName: args.outputName,
+        maxDurationSeconds: args.maxDurationSeconds,
+      });
+
+      return createJSONToolResponse({
+        message: `Started video recording ${active.recordingId}`,
+        recordingId: active.recordingId,
+        outputPath: active.outputPath,
+        startedAt: active.startedAt,
+        outputName: active.outputName,
+        deviceId: device.deviceId,
+        platform: device.platform,
+        settings: {
+          ...active.config,
+          resolution: active.config.resolution,
+          maxDurationSeconds: args.maxDurationSeconds,
+        },
+      });
+    } catch (error) {
+      throw new ActionableError(`Failed to start video recording: ${error}`);
+    }
+  };
+
+  const stopVideoRecordingHandler = async (args: StopVideoRecordingArgs) => {
+    try {
+      const metadata = await stopVideoRecording(args.recordingId);
+      const codec = metadata.codec ?? "unknown";
+      const durationMs = metadata.durationMs ?? 0;
+      const sizeBytes = metadata.sizeBytes ?? 0;
+
+      await ResourceRegistry.notifyResourcesUpdated([
+        VIDEO_RESOURCE_URIS.LATEST,
+        VIDEO_RESOURCE_URIS.ARCHIVE,
+        buildVideoArchiveItemUri(metadata.recordingId),
+      ]);
+
+      return createJSONToolResponse({
+        message: `Stopped video recording ${metadata.recordingId}`,
+        recordingId: metadata.recordingId,
+        filePath: metadata.filePath,
+        durationMs,
+        sizeBytes,
+        codec,
+        metadata: { ...metadata, durationMs, sizeBytes, codec },
+      });
+    } catch (error) {
+      throw new ActionableError(`Failed to stop video recording: ${error}`);
+    }
+  };
+
+  const listVideoRecordingsHandler = async () => {
+    try {
+      const recordings = await listVideoRecordings();
+      return createJSONToolResponse({
+        recordings,
+        count: recordings.length,
+      });
+    } catch (error) {
+      throw new ActionableError(`Failed to list video recordings: ${error}`);
+    }
+  };
+
+  const deleteVideoRecordingHandler = async (args: DeleteVideoRecordingArgs) => {
+    try {
+      const deleted = await deleteVideoRecording(args.recordingId);
+
+      if (!deleted) {
+        return createJSONToolResponse({
+          success: false,
+          deleted: false,
+          recordingId: args.recordingId,
+          error: `Recording not found: ${args.recordingId}`,
+        });
+      }
+
+      await ResourceRegistry.notifyResourcesUpdated([
+        VIDEO_RESOURCE_URIS.LATEST,
+        VIDEO_RESOURCE_URIS.ARCHIVE,
+        buildVideoArchiveItemUri(args.recordingId),
+      ]);
+
+      return createJSONToolResponse({
+        success: true,
+        deleted: true,
+        recordingId: args.recordingId,
+        message: `Deleted video recording ${args.recordingId}`,
+      });
+    } catch (error) {
+      throw new ActionableError(`Failed to delete video recording: ${error}`);
+    }
+  };
+
+  ToolRegistry.registerDeviceAware(
+    "startVideoRecording",
+    "Start a low-overhead video recording for the active device.",
+    startVideoRecordingSchema,
+    startVideoRecordingHandler
+  );
+
+  ToolRegistry.register(
+    "stopVideoRecording",
+    "Stop an active video recording and archive it.",
+    stopVideoRecordingSchema,
+    stopVideoRecordingHandler
+  );
+
+  ToolRegistry.register(
+    "listVideoRecordings",
+    "List archived video recordings and their metadata.",
+    listVideoRecordingsSchema,
+    listVideoRecordingsHandler
+  );
+
+  ToolRegistry.register(
+    "deleteVideoRecording",
+    "Delete an archived video recording by ID.",
+    deleteVideoRecordingSchema,
+    deleteVideoRecordingHandler
+  );
+}

--- a/src/utils/ServerConfig.ts
+++ b/src/utils/ServerConfig.ts
@@ -1,6 +1,7 @@
 import type {
   AccessibilityAuditConfig,
 } from "../models/AccessibilityAudit";
+import type { VideoRecordingConfigInput } from "../models/VideoRecording";
 
 export type PlanExecutionLockScope = "session" | "global";
 
@@ -17,6 +18,7 @@ class ServerConfig {
   private _strictAwaitEnabled: boolean = false;
   private _predictiveUiEnabled: boolean = false;
   private _planExecutionLockScope: PlanExecutionLockScope = "session";
+  private _videoRecordingDefaults: VideoRecordingConfigInput = {};
 
   private constructor() {}
 
@@ -85,6 +87,14 @@ class ServerConfig {
 
   getPlanExecutionLockScope(): PlanExecutionLockScope {
     return this._planExecutionLockScope;
+  }
+
+  setVideoRecordingDefaults(defaults: VideoRecordingConfigInput): void {
+    this._videoRecordingDefaults = { ...defaults };
+  }
+
+  getVideoRecordingDefaults(): VideoRecordingConfigInput {
+    return { ...this._videoRecordingDefaults };
   }
 }
 

--- a/test/fakes/FakeVideoCaptureBackend.ts
+++ b/test/fakes/FakeVideoCaptureBackend.ts
@@ -1,0 +1,66 @@
+import fs from "fs-extra";
+import type {
+  RecordingHandle,
+  RecordingResult,
+  VideoCaptureBackend,
+  VideoCaptureConfig,
+} from "../../src/features/video/VideoRecorderService";
+
+export class FakeVideoCaptureBackend implements VideoCaptureBackend {
+  readonly startCalls: VideoCaptureConfig[] = [];
+  readonly stopCalls: RecordingHandle[] = [];
+  private stopResolvers: Array<(handle: RecordingHandle) => void> = [];
+  private stopResultOverrides: Partial<RecordingResult> | null = null;
+  private outputPayload: Buffer = Buffer.from("fake-video");
+
+  setStopResultOverrides(overrides: Partial<RecordingResult>): void {
+    this.stopResultOverrides = overrides;
+  }
+
+  setOutputPayload(payload: Buffer): void {
+    this.outputPayload = payload;
+  }
+
+  async start(config: VideoCaptureConfig): Promise<RecordingHandle> {
+    this.startCalls.push(config);
+    await fs.ensureFile(config.outputPath);
+    return {
+      recordingId: config.recordingId,
+      outputPath: config.outputPath,
+      startedAt: config.startedAt,
+    };
+  }
+
+  async stop(handle: RecordingHandle): Promise<RecordingResult> {
+    this.stopCalls.push(handle);
+    if (this.stopResolvers.length > 0) {
+      const resolver = this.stopResolvers.shift();
+      resolver?.(handle);
+    }
+
+    await fs.writeFile(handle.outputPath, this.outputPayload);
+
+    const baseResult: RecordingResult = {
+      recordingId: handle.recordingId,
+      outputPath: handle.outputPath,
+      startedAt: handle.startedAt,
+      endedAt: new Date().toISOString(),
+      sizeBytes: this.outputPayload.length,
+      codec: "h264",
+    };
+
+    if (this.stopResultOverrides) {
+      const overrides = this.stopResultOverrides;
+      this.stopResultOverrides = null;
+      return { ...baseResult, ...overrides };
+    }
+
+    return baseResult;
+  }
+
+  waitForStopCall(): Promise<RecordingHandle> {
+    return new Promise(resolve => {
+      this.stopResolvers.push(resolve);
+    });
+  }
+}

--- a/test/server/videoRecordingManager.test.ts
+++ b/test/server/videoRecordingManager.test.ts
@@ -1,0 +1,99 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import os from "node:os";
+import path from "node:path";
+import fs from "fs-extra";
+import { FakeTimer } from "../fakes/FakeTimer";
+import { FakeVideoCaptureBackend } from "../fakes/FakeVideoCaptureBackend";
+import { VideoRecorderService } from "../../src/features/video";
+import type { BootedDevice } from "../../src/models";
+import {
+  listVideoRecordings,
+  resetVideoRecordingManagerDependencies,
+  setVideoRecordingManagerDependencies,
+  startVideoRecording,
+  stopVideoRecording,
+} from "../../src/server/videoRecordingManager";
+
+describe("videoRecordingManager", () => {
+  let fakeTimer: FakeTimer;
+  let fakeBackend: FakeVideoCaptureBackend;
+  let archiveRoot: string;
+  let testDevice: BootedDevice;
+
+  beforeEach(async () => {
+    fakeTimer = new FakeTimer();
+    fakeTimer.setManualMode();
+    fakeBackend = new FakeVideoCaptureBackend();
+    archiveRoot = await fs.mkdtemp(path.join(os.tmpdir(), "auto-mobile-video-"));
+
+    const service = new VideoRecorderService({
+      backend: fakeBackend,
+      archiveRoot,
+      now: () => new Date(fakeTimer.now()),
+    });
+
+    setVideoRecordingManagerDependencies({
+      videoRecorderService: service,
+      timer: fakeTimer,
+    });
+
+    testDevice = {
+      deviceId: "test-device",
+      platform: "android",
+      name: "Test Device",
+    };
+  });
+
+  afterEach(async () => {
+    resetVideoRecordingManagerDependencies();
+    await fs.remove(archiveRoot);
+  });
+
+  const waitForRecordingCount = async (expected: number): Promise<void> => {
+    for (let attempt = 0; attempt < 10; attempt++) {
+      const recordings = await listVideoRecordings();
+      if (recordings.length === expected) {
+        return;
+      }
+      await new Promise(resolve => setImmediate(resolve));
+    }
+    throw new Error(`Timed out waiting for ${expected} recordings`);
+  };
+
+  test("auto-stops recordings using FakeTimer", async () => {
+    const stopCall = fakeBackend.waitForStopCall();
+    const active = await startVideoRecording({
+      device: testDevice,
+      maxDurationSeconds: 2,
+    });
+
+    expect(fakeTimer.getPendingTimeoutCount()).toBe(1);
+    expect(fakeBackend.stopCalls.length).toBe(0);
+
+    fakeTimer.advanceTime(1999);
+    expect(fakeBackend.stopCalls.length).toBe(0);
+
+    fakeTimer.advanceTime(1);
+    await stopCall;
+    await waitForRecordingCount(1);
+
+    const recordings = await listVideoRecordings();
+    expect(recordings[0]?.recordingId).toBe(active.recordingId);
+  });
+
+  test("manual stop clears auto-stop timeout", async () => {
+    const active = await startVideoRecording({
+      device: testDevice,
+      maxDurationSeconds: 3,
+    });
+
+    expect(fakeTimer.getPendingTimeoutCount()).toBe(1);
+
+    await stopVideoRecording(active.recordingId);
+    expect(fakeTimer.getPendingTimeoutCount()).toBe(0);
+    expect(fakeBackend.stopCalls.length).toBe(1);
+
+    fakeTimer.advanceTime(3000);
+    expect(fakeBackend.stopCalls.length).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary
- add MCP video recording tools/resources with archive handling and quality defaults
- implement Android screenrecord + iOS simctl capture backend
- add test-friendly interfaces/fakes with FakeTimer-based auto-stop coverage

## Testing
- bun test
- bun run build

Closes #324
