### PR TITLE
Add test recording and YAML plan documentation

### DIFF
--- a/docs/using/ui-tests.md
+++ b/docs/using/ui-tests.md
@@ -24,6 +24,42 @@ The agent will generate test code that you can review and commit.
 
 See [JUnitRunner documentation](../design-docs/plat/android/junitrunner.md) for details on writing tests manually.
 
+## Test Recording & YAML Plans
+
+Record user interactions and generate executable YAML test plans using the IDE plugin:
+
+1. **Start Recording** - Click "Start Recording" in the IDE plugin tool window
+2. **Interact with App** - Tap, swipe, and input text normally
+3. **Stop Recording** - Generate a YAML plan from your interactions
+4. **Execute Plan** - Run the plan via IDE plugin, code (`executePlan` tool), or CLI
+
+### YAML Plan Format
+
+```yaml
+steps:
+  - tool: launchApp
+    params:
+      appId: com.example.app
+
+  - tool: tapOn
+    params:
+      text: "Login"
+
+  - tool: inputText
+    params:
+      text: "user@example.com"
+```
+
+Plans support assertions, conditional steps, and wait conditions for robust test automation.
+
+### Learn More
+
+See the [Test Recording guide](../design-docs/plat/android/ide-plugin/test-recording.md) for:
+- Complete recording workflow
+- YAML plan structure and advanced features
+- Execution methods (IDE, code, CI)
+- Best practices and troubleshooting
+
 ## Running Tests
 
 ### Local Execution


### PR DESCRIPTION
## Summary
- Documents the IDE plugin's test recording feature in UI tests guide
- Adds YAML plan format examples and structure
- Links to detailed test recording design documentation

Closes #344

## Test plan
- [x] Documentation added to docs/using/ui-tests.md
- [x] Links to design docs verified
- [x] YAML example syntax validated

🤖 Generated with [Claude Code](https://claude.com/claude-code)