### PR TITLE
Clarify bug reproduction doc with snapshot and MCP action links

### DIFF
--- a/docs/using/reproducting-bugs.md
+++ b/docs/using/reproducting-bugs.md
@@ -15,10 +15,47 @@ When you receive a bug report, ask your AI agent:
 
 The agent will:
 1. Navigate to screen (if specified), otherwise it will attempt to find the behavior in the app
-2. Take a snapshot of device state using the [takeDeviceSnapshot]() MCP tool call.
-2. Reproduce any steps or context provided to approximate the state.
+2. Take a snapshot of device state using the [captureDeviceSnapshot](../features/snapshots.md#capturedevicesnapshot) MCP tool call.
+3. Reproduce any steps or context provided to approximate the state.
 
 Once a bug is reproduced, you can create an [automated test](ui-tests.md).
+
+## Next Steps
+
+After reproducing a bug, use these MCP tools to complete the workflow:
+
+### Generate Bug Report
+
+Use the [bugReport](../design-docs/mcp/actions.md#testing--debugging) tool to create a comprehensive bug report:
+
+```javascript
+await bugReport({
+  description: "Login button not responding after network error"
+});
+```
+
+This captures:
+- Current screen state and view hierarchy
+- Recent logcat entries
+- Screenshot
+- Device and app information
+
+### Automate Reproduction Steps
+
+Convert your bug reproduction steps into an automated test using [executePlan](../design-docs/mcp/actions.md#testing--debugging):
+
+```javascript
+await executePlan({
+  planContent: `
+- launchApp: { packageName: "com.example.app" }
+- tapOn: { contentDescription: "Login" }
+- inputText: { text: "user@example.com" }
+- tapOn: { text: "Submit" }
+  `
+});
+```
+
+This ensures the bug can be reliably reproduced and becomes a regression test once fixed.
 
 ## Debugging Workflow
 


### PR DESCRIPTION
## Summary

Fixes #345 by clarifying the bug reproduction documentation with proper tool names, links, and workflow completion steps.

## Changes

- **Fixed tool name**: Changed `takeDeviceSnapshot` to `captureDeviceSnapshot` (the correct MCP tool name)
- **Added link**: Linked to comprehensive snapshot documentation at `docs/features/snapshots.md#capturedevicesnapshot`
- **Fixed numbering**: Corrected duplicate step "2" to "3" in the workflow
- **Added "Next Steps" section**: Provides clear guidance on what to do after reproducing a bug:
  - **Generate Bug Report**: Shows how to use `bugReport` tool with examples
  - **Automate Reproduction Steps**: Shows how to use `executePlan` tool with YAML plan examples
- **Added code examples**: Practical JavaScript examples for both `bugReport` and `executePlan`

## Impact

The documentation now provides a complete workflow from bug report → reproduction → snapshot → bug report generation → test automation, resolving the "dead end" issue where users didn't know what to do after reproducing a bug.

## Test Plan

- [x] Build succeeds
- [x] All markdown links verified (snapshots.md, actions.md, ui-tests.md)
- [x] Documentation follows existing format and style

🤖 Generated with [Claude Code](https://claude.com/claude-code)