### PR TITLE
fix: add disk cleanup to Docker publishing workflows (#435)

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -27,6 +27,20 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Free Disk Space
+        uses: endersonmenezes/free-disk-space@v3
+        with:
+          remove_android: true      # ~14 GB
+          remove_dotnet: true       # ~2.7 GB
+          remove_haskell: true      # Minimal
+          remove_tool_cache: false  # Keep Node.js since we need it
+          remove_swap: true         # ~4 GB
+          remove_codeql: true       # ~5.9 GB (we run CodeQL separately)
+          use_rmz: true            # 3x faster deletion
+
+      - name: Clean up Docker
+        run: docker system prune -af --volumes
+
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -162,6 +162,20 @@ jobs:
       - name: Publish to npm
         run: npm publish --provenance --access public
 
+      - name: Free Disk Space
+        uses: endersonmenezes/free-disk-space@v3
+        with:
+          remove_android: true      # ~14 GB
+          remove_dotnet: true       # ~2.7 GB
+          remove_haskell: true      # Minimal
+          remove_tool_cache: false  # Keep Node.js since we need it
+          remove_swap: true         # ~4 GB
+          remove_codeql: true       # ~5.9 GB (we run CodeQL separately)
+          use_rmz: true            # 3x faster deletion
+
+      - name: Clean up Docker
+        run: docker system prune -af --volumes
+
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
 


### PR DESCRIPTION
## Summary

Fixes #435 - Add disk space cleanup steps to Docker publishing workflows to prevent "No space left on device" errors.

## Changes

This PR adds proactive disk cleanup steps to the following workflows before Docker image building:

- ✅ `.github/workflows/docker-publish.yml` (the workflow that failed)
- ✅ `.github/workflows/release.yml` (also builds Docker images but lacked cleanup)

### Disk Cleanup Strategy

Using the `endersonmenezes/free-disk-space@v3` action (same as `pull_request.yml`):
- Removes Android SDK (~14 GB)
- Removes .NET SDK (~2.7 GB)  
- Removes Haskell stack (minimal)
- Removes swap storage (~4 GB)
- Removes CodeQL tools (~5.9 GB)
- Runs `docker system prune -af --volumes` for Docker cleanup

**Expected disk space freed:** ~30+ GB

## Root Cause

The GitHub Actions runner ran out of disk space during the Docker Hub publishing workflow because:
- Docker layers and base images consume significant space
- Build artifacts accumulate during the build process
- No cleanup was performed before the Docker build operations

## Test Plan

- [x] Ran `bun run lint` - passed
- [x] Ran `bun run build` - passed  
- [x] Ran `bun run test` - passed (1026 pass, 16 skip, 0 fail)

The next run of these workflows will verify the fix in the actual CI environment.

## Related

- Issue #435: GitHub Actions runner: No space left on device during Docker Hub publish
- PR #432: Add Docker Hub publishing workflows (original implementation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)