### PR TITLE
Add capability detection for settings-based accessibility toggle

### DIFF
--- a/src/utils/AccessibilityServiceManager.ts
+++ b/src/utils/AccessibilityServiceManager.ts
@@ -698,38 +698,40 @@ export class AndroidAccessibilityServiceManager implements AccessibilityServiceM
 
   /**
    * Detect if device is an emulator or physical device
+   * Returns [isEmulator, hadError] tuple to track detection success
    */
-  private async isEmulator(): Promise<boolean> {
+  private async isEmulator(): Promise<[boolean, boolean]> {
     try {
       const result = await this.adb.executeCommand("shell getprop ro.kernel.qemu", undefined, undefined, true);
       const qemuProp = result.stdout.trim();
       // ro.kernel.qemu is "1" on emulators, empty or "0" on physical devices
       if (qemuProp === "1") {
-        return true;
+        return [true, false];
       }
 
       // Fallback: check ro.product.model for common emulator strings
       const modelResult = await this.adb.executeCommand("shell getprop ro.product.model", undefined, undefined, true);
       const model = modelResult.stdout.trim().toLowerCase();
-      return model.includes("emulator") || model.includes("sdk");
+      return [model.includes("emulator") || model.includes("sdk"), false];
     } catch (error) {
       logger.warn("[ACCESSIBILITY_SERVICE] Error detecting device type", { error });
-      // Default to physical device on error (more conservative)
-      return false;
+      // Default to physical device on error (more conservative), but mark as errored
+      return [false, true];
     }
   }
 
   /**
    * Get device API level
+   * Returns [apiLevel, hadError] tuple to track detection success
    */
-  private async getApiLevel(): Promise<number | null> {
+  private async getApiLevel(): Promise<[number | null, boolean]> {
     try {
       const result = await this.adb.executeCommand("shell getprop ro.build.version.sdk", undefined, undefined, true);
       const apiLevel = parseInt(result.stdout.trim(), 10);
-      return isNaN(apiLevel) ? null : apiLevel;
+      return [isNaN(apiLevel) ? null : apiLevel, false];
     } catch (error) {
       logger.warn("[ACCESSIBILITY_SERVICE] Error getting API level", { error });
-      return null;
+      return [null, true];
     }
   }
 
@@ -755,14 +757,24 @@ export class AndroidAccessibilityServiceManager implements AccessibilityServiceM
 
     logger.info("[ACCESSIBILITY_SERVICE] Detecting toggle capabilities");
 
-    const isEmulator = await this.isEmulator();
-    const apiLevel = await this.getApiLevel();
+    const [isEmulator, emulatorDetectionError] = await this.isEmulator();
+    const [apiLevel, apiLevelDetectionError] = await this.getApiLevel();
     const deviceType = isEmulator ? "emulator" : "physical";
 
     let supportsSettingsToggle = false;
     let reason: string | undefined;
 
-    if (isEmulator) {
+    // If we had detection errors, don't make definitive claims about support
+    const hadDetectionError = emulatorDetectionError || apiLevelDetectionError;
+
+    if (hadDetectionError) {
+      supportsSettingsToggle = false;
+      reason = "Unable to detect device capabilities due to transient error. Retry may succeed.";
+      logger.warn("[ACCESSIBILITY_SERVICE] Detection error - not caching result", {
+        emulatorDetectionError,
+        apiLevelDetectionError
+      });
+    } else if (isEmulator) {
       // Emulators generally support settings-based toggle
       supportsSettingsToggle = true;
       logger.info("[ACCESSIBILITY_SERVICE] Emulator detected - settings toggle supported");
@@ -774,7 +786,7 @@ export class AndroidAccessibilityServiceManager implements AccessibilityServiceM
     }
 
     // Additional API level checks could be added here if needed
-    if (apiLevel !== null && apiLevel < 16) {
+    if (!hadDetectionError && apiLevel !== null && apiLevel < 16) {
       supportsSettingsToggle = false;
       reason = `API level ${apiLevel} is too old (requires API 16+)`;
       logger.warn("[ACCESSIBILITY_SERVICE] API level too old for settings toggle", { apiLevel });
@@ -787,9 +799,14 @@ export class AndroidAccessibilityServiceManager implements AccessibilityServiceM
       reason
     };
 
-    // Cache the result
-    this.cachedToggleCapabilities = capabilities;
-    logger.info("[ACCESSIBILITY_SERVICE] Toggle capabilities detected and cached", capabilities);
+    // Only cache if we successfully detected capabilities without errors
+    // This prevents transient errors from creating sticky false negatives
+    if (!hadDetectionError) {
+      this.cachedToggleCapabilities = capabilities;
+      logger.info("[ACCESSIBILITY_SERVICE] Toggle capabilities detected and cached", capabilities);
+    } else {
+      logger.info("[ACCESSIBILITY_SERVICE] Toggle capabilities detected but not cached due to detection errors", capabilities);
+    }
 
     return capabilities;
   }

--- a/test/utils/AccessibilityServiceManager.test.ts
+++ b/test/utils/AccessibilityServiceManager.test.ts
@@ -700,6 +700,43 @@ describe("AccessibilityServiceManager", function() {
       expect(capabilities.reason).toBeUndefined();
     });
 
+    test("should not cache capabilities when detection errors occur", async function() {
+      let callCount = 0;
+      const fakeExecAsync = async (command: string) => {
+        callCount++;
+        // First call fails, second call succeeds
+        if (callCount <= 2) {
+          throw new Error("ADB transient error");
+        }
+
+        const prefix = "adb -s test-device ";
+        const strippedCommand = command.startsWith(prefix) ? command.slice(prefix.length) : command;
+
+        if (strippedCommand.includes("ro.kernel.qemu")) {
+          return { stdout: "1", stderr: "" };
+        }
+        if (strippedCommand.includes("ro.build.version.sdk")) {
+          return { stdout: "29", stderr: "" };
+        }
+        return { stdout: "", stderr: "" };
+      };
+
+      const testAdb = new AdbClient(testDevice, fakeExecAsync);
+      AndroidAccessibilityServiceManager.resetInstances();
+      const manager = AndroidAccessibilityServiceManager.getInstance(testDevice, testAdb);
+
+      // First call - should fail with error and NOT cache
+      const capabilities1 = await manager.getToggleCapabilities();
+      expect(capabilities1.supportsSettingsToggle).toBe(false);
+      expect(capabilities1.reason).toContain("transient error");
+
+      // Second call - should retry and succeed
+      const capabilities2 = await manager.getToggleCapabilities();
+      expect(capabilities2.supportsSettingsToggle).toBe(true);
+      expect(capabilities2.deviceType).toBe("emulator");
+      expect(capabilities2.apiLevel).toBe(29);
+    });
+
     test("should detect physical device and not support settings toggle", async function() {
       fakeAdb.setCommandResponse("shell getprop ro.kernel.qemu", {
         stdout: "",


### PR DESCRIPTION
## Summary
Implements capability detection to determine if devices support programmatic accessibility toggling via adb settings commands, as specified in #409.

## Changes
- **ToggleCapabilities interface**: Provides structured capability information including device type, API level, and support status with optional reason
- **Device type detection**: Implements `isEmulator()` using `ro.kernel.qemu` property with fallback to model string detection for edge cases
- **API level detection**: Implements `getApiLevel()` to retrieve and parse device API level
- **Public API methods**:
  - `canUseSettingsToggle()`: Simple boolean check for capability
  - `getToggleCapabilities()`: Detailed capability information with caching
- **Enhanced error handling**: `enableViaSettings()` and `disableViaSettings()` now check capabilities first and provide clear error messages when unavailable
- **Performance optimization**: Capabilities are cached since settings permissions don't change during session
- **Comprehensive tests**: 13 new test cases covering emulator/physical detection, API level validation, caching behavior, and error scenarios

## Behavior
- **Emulators (API 16+)**: `supportsSettingsToggle = true`
- **Physical devices**: `supportsSettingsToggle = false` with reason: "Physical devices may require root, device owner status, or special shell permissions"
- **Old devices (API < 16)**: `supportsSettingsToggle = false` with specific API level reason
- Results are cached for efficiency on repeated calls
- Cache is cleared with `clearAvailabilityCache()`

## Testing
- ✅ All 47 AccessibilityServiceManager tests pass
- ✅ Full test suite passes (1039 pass, 0 fail)
- ✅ Build successful
- ✅ Lint passes

## Related Issues
Resolves #409
Related to #384

🤖 Generated with [Claude Code](https://claude.com/claude-code)