### PR TITLE
fix: add disk cleanup to merge workflow Docker publish job

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -432,6 +432,20 @@ jobs:
       - name: "Git Checkout"
         uses: actions/checkout@v4
 
+      - name: Free Disk Space
+        uses: endersonmenezes/free-disk-space@v3
+        with:
+          remove_android: true      # ~14 GB
+          remove_dotnet: true       # ~2.7 GB
+          remove_haskell: true      # Minimal
+          remove_tool_cache: false  # Keep Node.js since we need it
+          remove_swap: true         # ~4 GB
+          remove_codeql: true       # ~5.9 GB (we run CodeQL separately)
+          use_rmz: true            # 3x faster deletion
+
+      - name: Clean up Docker
+        run: docker system prune -af --volumes
+
       - name: "Setup Bun"
         uses: oven-sh/setup-bun@v2
         with:


### PR DESCRIPTION
## Summary

- Add disk cleanup steps to `publish-docker-hub` job in merge workflow
- Fixes "No space left on device" failures during Docker Hub publishing

## Problem

The `publish-docker-hub` job in `.github/workflows/merge.yml` was failing with disk space exhaustion errors. While PR #451 added disk cleanup to the standalone `docker-publish.yml`, `release.yml`, and `pull_request.yml` workflows, the Docker publish job in the merge workflow was missed.

## Solution

Added the same disk cleanup steps used in other workflows:
- **Free Disk Space action** - Removes ~27GB (Android, .NET, swap, CodeQL, etc.)
- **Docker system prune** - Cleans up unused Docker artifacts

## Changes

- `.github/workflows/merge.yml` - Added disk cleanup before Docker build steps

## Test Plan

- [x] Verify cleanup steps match other workflows
- [ ] Monitor next merge to main to confirm Docker publish succeeds

Fixes #435

🤖 Generated with [Claude Code](https://claude.com/claude-code)