### PR TITLE
fix: require all jobs to pass before Docker Hub publish

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -428,6 +428,22 @@ jobs:
     name: "Publish to Docker Hub"
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    needs:
+      - ide-plugin-validation
+      - validate-xml
+      - ktfmt
+      - validate-shell-scripts
+      - validate-mkdocs-nav
+      - validate-documentation-links
+      - mcp-build-and-test
+      - junit-runner-unit-tests
+      - junit-runner-emulator-tests
+      - playground-automobile-emulator-tests
+      - android-accessibility-service-unit-tests
+      - build-junit-runner-library
+      - build-android-accessibility-service
+      - build-playground-app
+      - benchmark-context-thresholds
     steps:
       - name: "Git Checkout"
         uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
This PR fixes the merge workflow to prevent broken Docker images from being published to Docker Hub by requiring all critical jobs to pass first.

## Changes
Added `needs` dependency to the `publish-docker-hub` job that requires 15 critical jobs to succeed:

**Validation (6):**
- IDE plugin validation
- XML validation
- ktfmt formatting
- Shell script validation
- MkDocs navigation validation
- Documentation link validation

**Tests (5):**
- MCP build and test
- JUnit runner unit tests
- JUnit runner emulator tests
- Playground automobile emulator tests
- Android accessibility service unit tests

**Builds (3):**
- JUnit runner library build
- Android accessibility service build
- Playground app build

**Performance (1):**
- Context benchmark thresholds

## Impact
✅ Docker images only published when all validation, tests, builds, and benchmarks pass
✅ Failed jobs prevent broken images from reaching Docker Hub users
✅ Workflow follows CI/CD best practices: validate → test → build → publish
✅ Documentation deployment remains independent (doesn't block Docker publishing)

## Test Plan
- [x] Workflow YAML syntax is valid
- [ ] Verify on merge: Docker publish waits for all jobs
- [ ] Verify on merge: Failed job blocks Docker publishing

Fixes #475

🤖 Generated with [Claude Code](https://claude.com/claude-code)