### PR TITLE
Fix flaky planExecutionLock test by injecting FakeDeviceUtils

### DIFF
--- a/test/server/planExecutionLock.test.ts
+++ b/test/server/planExecutionLock.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { McpTestFixture } from "../fixtures/mcpTestFixture";
 import { FakePlanExecutionLock } from "../fakes/FakePlanExecutionLock";
 import {
@@ -7,6 +7,8 @@ import {
 } from "../../src/server/PlanExecutionLock";
 import { ExecutionTracker } from "../../src/server/executionTracker";
 import type { PlanExecutionLockScope } from "../../src/utils/ServerConfig";
+import { FakeDeviceUtils } from "../fakes/FakeDeviceUtils";
+import { resetDeviceToolsDependencies, setDeviceToolsDependencies } from "../../src/server/deviceTools";
 
 class FakePlanExecutionLockScopeProvider implements PlanExecutionLockScopeProvider {
   constructor(private scope: PlanExecutionLockScope) {}
@@ -21,6 +23,24 @@ class FakePlanExecutionLockScopeProvider implements PlanExecutionLockScopeProvid
 }
 
 describe("Plan execution lock", () => {
+  let fakeDeviceUtils: FakeDeviceUtils;
+
+  beforeEach(() => {
+    // Set up FakeDeviceUtils to avoid real ADB commands
+    fakeDeviceUtils = new FakeDeviceUtils();
+    // Configure with empty device list since we're testing plan lock, not device functionality
+    fakeDeviceUtils.setBootedDevices("android", []);
+
+    setDeviceToolsDependencies({
+      deviceManagerFactory: () => fakeDeviceUtils
+    });
+  });
+
+  afterEach(() => {
+    // Reset dependencies to avoid test pollution
+    resetDeviceToolsDependencies();
+  });
+
   test("rejects MCP tool calls when a plan is executing", async () => {
     const fixture = new McpTestFixture({
       planExecutionLock: new FakePlanExecutionLock({


### PR DESCRIPTION
## Summary

Fixes #482 - Resolves flaky test `"allows MCP tool calls when no plan is executing"` that was timing out in CI.

The test was executing real ADB commands through `MultiPlatformDeviceManager`, causing:
- Timeouts in CI (5000ms+) due to missing/slow Android SDK
- Non-deterministic behavior depending on environment
- Testing implementation details instead of plan lock behavior

**Solution**: Inject `FakeDeviceUtils` using the existing dependency injection pattern, making the test:
- ⚡ Fast: ~220ms (down from 5000ms+ timeout)
- 🎯 Focused: Tests plan execution lock, not device management
- 🔒 Reliable: No real I/O operations, fully deterministic

## Changes

- Add `beforeEach` hook to inject `FakeDeviceUtils` 
- Add `afterEach` hook to reset dependencies (avoid test pollution)
- Configure fake to return empty device list (sufficient for testing lock behavior)

## Test Plan

- [x] Test passes 10/10 consecutive runs locally (212-238ms each)
- [x] Full test suite passes: 1101 pass, 0 fail
- [x] Verified test still validates both blocked and non-blocked scenarios
- [x] Follows existing pattern from `test/server/tools/schema.test.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)