### PR TITLE
Fix JUnit Runner test plan file reference to resolve skipped tests

### DIFF
--- a/android/junit-runner/src/test/kotlin/dev/jasonpearson/automobile/junit/SimpleIntegrationTest.kt
+++ b/android/junit-runner/src/test/kotlin/dev/jasonpearson/automobile/junit/SimpleIntegrationTest.kt
@@ -18,7 +18,7 @@ class SimpleIntegrationTest {
     val annotation = method.getAnnotation(AutoMobileTest::class.java)
 
     assertNotNull(annotation)
-    assertEquals("test-plans/launch-clock.yaml", annotation.plan)
+    assertEquals("test-plans/launch-clock-app.yaml", annotation.plan)
     assertEquals("", annotation.prompt)
     assertEquals(0, annotation.maxRetries)
     assertTrue(annotation.aiAssistance)
@@ -32,7 +32,7 @@ class SimpleIntegrationTest {
     val annotation = method.getAnnotation(AutoMobileTest::class.java)
 
     assertNotNull(annotation)
-    assertEquals("test-plans/launch-clock.yaml", annotation.plan)
+    assertEquals("test-plans/launch-clock-app.yaml", annotation.plan)
     assertFalse(annotation.aiAssistance)
   }
 
@@ -42,7 +42,7 @@ class SimpleIntegrationTest {
     val annotation = method.getAnnotation(AutoMobileTest::class.java)
 
     assertNotNull(annotation)
-    assertEquals("test-plans/launch-clock.yaml", annotation.plan)
+    assertEquals("test-plans/launch-clock-app.yaml", annotation.plan)
     assertEquals("emulator-5554", annotation.device)
   }
 
@@ -62,13 +62,13 @@ class SimpleIntegrationTest {
 /** Test target class for SimpleIntegrationTest */
 class SimpleTestTargetClass {
 
-  @Test @AutoMobileTest(plan = "test-plans/launch-clock.yaml") fun testWithAutoMobileAnnotation() {}
+  @Test @AutoMobileTest(plan = "test-plans/launch-clock-app.yaml") fun testWithAutoMobileAnnotation() {}
 
   @Test
-  @AutoMobileTest(plan = "test-plans/launch-clock.yaml", aiAssistance = false)
+  @AutoMobileTest(plan = "test-plans/launch-clock-app.yaml", aiAssistance = false)
   fun testWithPlanParameter() {}
 
   @Test
-  @AutoMobileTest(plan = "test-plans/launch-clock.yaml", device = "emulator-5554")
+  @AutoMobileTest(plan = "test-plans/launch-clock-app.yaml", device = "emulator-5554")
   fun testWithSpecificDevice() {}
 }


### PR DESCRIPTION
## Summary
Fixes #473 - Updates `SimpleIntegrationTest` to reference the correct test plan file `launch-clock-app.yaml` instead of the non-existent `launch-clock.yaml`. This resolves 3 tests that were being skipped in CI.

## Changes
- Updated `@AutoMobileTest` annotations in `SimpleTestTargetClass` to use `test-plans/launch-clock-app.yaml`
- Updated assertion expectations in `SimpleIntegrationTest` unit tests to match the corrected filename

## Impact
- ✅ All 3 previously skipped tests now run and pass
- ✅ CI will show 0 skipped tests instead of 3
- ✅ Integration tests provide actual value by running on emulators

## Test Results
```
SimpleTestTargetClass > testWithAutoMobileAnnotation PASSED
SimpleTestTargetClass > testWithSpecificDevice PASSED  
SimpleTestTargetClass > testWithPlanParameter PASSED
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)