### PR TITLE
Add Gradle test report patterns to root .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,10 @@ docs/contributing/index.md
 # IntelliJ Platform Gradle plugin artifacts
 android/ide-plugin/.intellijPlatform/
 .lycheecache
+
+# Gradle test reports (in case they're generated at root)
+/classes/
+/css/
+/index.html
+/js/
+/packages/


### PR DESCRIPTION
## Summary

Adds defensive `.gitignore` patterns to the root directory to prevent Gradle test report artifacts from being accidentally committed if they're generated at the wrong location.

Patterns added:
- `/classes/`
- `/css/`
- `/index.html`
- `/js/`
- `/packages/`

Closes #476

## Test plan

- [x] Verified patterns added to root `.gitignore` with appropriate comment
- [x] Confirmed no duplicate patterns exist
- [x] Validated patterns match Gradle test report structure

🤖 Generated with [Claude Code](https://claude.com/claude-code)