### PR TITLE
Standardize environment variable naming to AUTOMOBILE_ prefix

### DIFF
--- a/android/ide-plugin/README.md
+++ b/android/ide-plugin/README.md
@@ -10,8 +10,8 @@ IntelliJ/Android Studio plugin scaffold for AutoMobile.
 ## MCP transport selection
 The plugin selects the MCP transport in this order:
 1. Discovered MCP dev server over HTTP (health-checked on localhost).
-2. `AUTO_MOBILE_MCP_HTTP_URL` (or `-Dautomobile.mcp.httpUrl`) for Streamable HTTP.
-3. `AUTO_MOBILE_MCP_STDIO_COMMAND` (or `-Dautomobile.mcp.stdioCommand`) for stdio.
+2. `AUTOMOBILE_MCP_HTTP_URL` (or `-Dautomobile.mcp.httpUrl`) for Streamable HTTP.
+3. `AUTOMOBILE_MCP_STDIO_COMMAND` (or `-Dautomobile.mcp.stdioCommand`) for stdio.
 4. Unix socket fallback at `/tmp/auto-mobile-daemon-<uid>.sock`.
 
 The tool window lists git worktrees and any matching MCP dev servers. Use the dropdown to pick which worktree/server

--- a/android/ide-plugin/src/main/kotlin/com/automobile/ide/daemon/McpClientFactory.kt
+++ b/android/ide-plugin/src/main/kotlin/com/automobile/ide/daemon/McpClientFactory.kt
@@ -19,26 +19,32 @@ object McpClientFactory {
     return McpDaemonClient()
   }
 
+  // @deprecated AUTO_MOBILE_MCP_HTTP_URL - use AUTOMOBILE_MCP_HTTP_URL instead
   fun createConfiguredHttp(): McpHttpClient? {
-    val httpUrl = readSetting("AUTO_MOBILE_MCP_HTTP_URL", "automobile.mcp.httpUrl")
+    val httpUrl = readSetting("AUTOMOBILE_MCP_HTTP_URL", "AUTO_MOBILE_MCP_HTTP_URL", "automobile.mcp.httpUrl")
     if (!httpUrl.isNullOrBlank()) {
       return McpHttpClient(normalizeHttpUrl(httpUrl))
     }
     return null
   }
 
+  // @deprecated AUTO_MOBILE_MCP_STDIO_COMMAND - use AUTOMOBILE_MCP_STDIO_COMMAND instead
   fun createConfiguredStdio(): McpStdioClient? {
-    val stdioCommand = readSetting("AUTO_MOBILE_MCP_STDIO_COMMAND", "automobile.mcp.stdioCommand")
+    val stdioCommand = readSetting("AUTOMOBILE_MCP_STDIO_COMMAND", "AUTO_MOBILE_MCP_STDIO_COMMAND", "automobile.mcp.stdioCommand")
     if (!stdioCommand.isNullOrBlank()) {
       return McpStdioClient(stdioCommand)
     }
     return null
   }
 
-  private fun readSetting(envKey: String, propertyKey: String): String? {
-    val envValue = System.getenv(envKey)
-    if (!envValue.isNullOrBlank()) {
-      return envValue
+  private fun readSetting(primaryEnvKey: String, deprecatedEnvKey: String, propertyKey: String): String? {
+    val primaryEnvValue = System.getenv(primaryEnvKey)
+    if (!primaryEnvValue.isNullOrBlank()) {
+      return primaryEnvValue
+    }
+    val deprecatedEnvValue = System.getenv(deprecatedEnvKey)
+    if (!deprecatedEnvValue.isNullOrBlank()) {
+      return deprecatedEnvValue
     }
     val propertyValue = System.getProperty(propertyKey)
     return propertyValue?.takeIf { it.isNotBlank() }

--- a/android/junit-runner/src/main/kotlin/dev/jasonpearson/automobile/junit/AutoMobileRunner.kt
+++ b/android/junit-runner/src/main/kotlin/dev/jasonpearson/automobile/junit/AutoMobileRunner.kt
@@ -571,9 +571,11 @@ class AutoMobileRunner(private val klass: Class<*>) : BlockJUnit4ClassRunner(kla
             "isCi" to JsonPrimitive(resolveCiMode()),
         )
 
+    // @deprecated AUTO_MOBILE_APP_VERSION - use AUTOMOBILE_APP_VERSION instead
     val appVersion =
         firstNonBlank(
             SystemPropertyCache.get("automobile.app.version", ""),
+            System.getenv("AUTOMOBILE_APP_VERSION"),
             System.getenv("AUTO_MOBILE_APP_VERSION"),
             System.getenv("APP_VERSION"),
         )
@@ -581,9 +583,11 @@ class AutoMobileRunner(private val klass: Class<*>) : BlockJUnit4ClassRunner(kla
       metadata["appVersion"] = JsonPrimitive(appVersion)
     }
 
+    // @deprecated AUTO_MOBILE_GIT_COMMIT - use AUTOMOBILE_GIT_COMMIT instead
     val gitCommit =
         firstNonBlank(
             SystemPropertyCache.get("automobile.git.commit", ""),
+            System.getenv("AUTOMOBILE_GIT_COMMIT"),
             System.getenv("AUTO_MOBILE_GIT_COMMIT"),
             System.getenv("GITHUB_SHA"),
             System.getenv("GIT_COMMIT"),
@@ -619,11 +623,13 @@ class AutoMobileRunner(private val klass: Class<*>) : BlockJUnit4ClassRunner(kla
     return JsonObject(metadata)
   }
 
+  // @deprecated AUTO_MOBILE_TARGET_SDK - use AUTOMOBILE_TARGET_SDK instead
   private fun resolveTargetSdk(): Int? {
     val candidate =
         firstNonBlank(
             SystemPropertyCache.get("automobile.android.targetSdk", ""),
             SystemPropertyCache.get("automobile.targetSdk", ""),
+            System.getenv("AUTOMOBILE_TARGET_SDK"),
             System.getenv("AUTO_MOBILE_TARGET_SDK"),
             System.getenv("ANDROID_TARGET_SDK"),
         )

--- a/docs/contributing/local-development.md
+++ b/docs/contributing/local-development.md
@@ -73,7 +73,7 @@ simultaneously without port conflicts:
 **Override options:**
 ```shell
 # Environment variable (highest priority)
-AUTO_MOBILE_PORT=8080 bun run dev
+AUTOMOBILE_PORT=8080 bun run dev
 
 # Command line flag
 bun run dev:port 8080

--- a/docs/design-docs/mcp/migrations.md
+++ b/docs/design-docs/mcp/migrations.md
@@ -12,7 +12,7 @@ Migrations run on server startup and are managed with Kysely's `Migrator` + `Fil
 
 The migration directory is resolved in this order:
 
-1. `AUTO_MOBILE_MIGRATIONS_DIR` or `AUTOMOBILE_MIGRATIONS_DIR` (absolute or relative path).
+1. `AUTOMOBILE_MIGRATIONS_DIR` environment variable (absolute or relative path).
 2. Module-relative defaults (first match):
    - `dist/src/db/migrations` when running the bundled server.
    - `src/db/migrations` when running from source.

--- a/docs/design-docs/plat/android/ide-plugin/overview.md
+++ b/docs/design-docs/plat/android/ide-plugin/overview.md
@@ -8,8 +8,8 @@ local daemon socket when needed.
 The plugin resolves a transport when the user clicks "Attach to MCP":
 
 1. MCP dev server discovered via HTTP health checks on localhost.
-2. `AUTO_MOBILE_MCP_HTTP_URL` / `-Dautomobile.mcp.httpUrl` (streamable HTTP).
-3. `AUTO_MOBILE_MCP_STDIO_COMMAND` / `-Dautomobile.mcp.stdioCommand` (stdio).
+2. `AUTOMOBILE_MCP_HTTP_URL` / `-Dautomobile.mcp.httpUrl` (streamable HTTP).
+3. `AUTOMOBILE_MCP_STDIO_COMMAND` / `-Dautomobile.mcp.stdioCommand` (stdio).
 4. Unix socket fallback at `/tmp/auto-mobile-daemon-<uid>.sock`.
 
 ## MCP dev server discovery

--- a/docs/design-docs/plat/ios/ide-plugin/overview.md
+++ b/docs/design-docs/plat/ios/ide-plugin/overview.md
@@ -21,8 +21,8 @@ supported Apple tooling.
 The companion app selects an MCP transport in this order:
 
 1. Discovered MCP dev server over HTTP (health check on localhost).
-2. `AUTO_MOBILE_MCP_HTTP_URL` or `automobile.mcp.httpUrl`.
-3. `AUTO_MOBILE_MCP_STDIO_COMMAND` or `automobile.mcp.stdioCommand`.
+2. `AUTOMOBILE_MCP_HTTP_URL` or `automobile.mcp.httpUrl`.
+3. `AUTOMOBILE_MCP_STDIO_COMMAND` or `automobile.mcp.stdioCommand`.
 4. Unix socket fallback at `/tmp/auto-mobile-daemon-<uid>.sock`.
 
 ## MCP dev server discovery

--- a/src/db/database.ts
+++ b/src/db/database.ts
@@ -10,8 +10,10 @@ import { BunSqliteDialect } from "./bunSqliteDialect";
 
 // Database file location (defaults to ~/.auto-mobile/auto-mobile.db)
 const DEFAULT_DB_DIR = path.join(os.homedir(), ".auto-mobile");
-const ENV_DB_PATH = process.env.AUTO_MOBILE_DB_PATH ?? process.env.AUTOMOBILE_DB_PATH;
-const ENV_DB_DIR = process.env.AUTO_MOBILE_DB_DIR ?? process.env.AUTOMOBILE_DB_DIR;
+// @deprecated AUTO_MOBILE_DB_PATH - use AUTOMOBILE_DB_PATH instead
+// @deprecated AUTO_MOBILE_DB_DIR - use AUTOMOBILE_DB_DIR instead
+const ENV_DB_PATH = process.env.AUTOMOBILE_DB_PATH ?? process.env.AUTO_MOBILE_DB_PATH;
+const ENV_DB_DIR = process.env.AUTOMOBILE_DB_DIR ?? process.env.AUTO_MOBILE_DB_DIR;
 const DB_PATH = ENV_DB_PATH
   ? path.resolve(ENV_DB_PATH)
   : path.join(ENV_DB_DIR ? path.resolve(ENV_DB_DIR) : DEFAULT_DB_DIR, "auto-mobile.db");

--- a/src/db/migrator.ts
+++ b/src/db/migrator.ts
@@ -5,7 +5,8 @@ import { fileURLToPath } from "url";
 import { logger } from "../utils/logger";
 
 function resolveMigrationFolder(): string {
-  const envPath = process.env.AUTO_MOBILE_MIGRATIONS_DIR ?? process.env.AUTOMOBILE_MIGRATIONS_DIR;
+  // @deprecated AUTO_MOBILE_MIGRATIONS_DIR - use AUTOMOBILE_MIGRATIONS_DIR instead
+  const envPath = process.env.AUTOMOBILE_MIGRATIONS_DIR ?? process.env.AUTO_MOBILE_MIGRATIONS_DIR;
   if (envPath) {
     return path.resolve(envPath);
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,7 +22,8 @@ function detectPortFromBranch(): number {
   const basePort = 9000;
 
   // Check environment variable first (explicit override)
-  const envPort = process.env.AUTO_MOBILE_PORT;
+  // @deprecated AUTO_MOBILE_PORT - use AUTOMOBILE_PORT instead
+  const envPort = process.env.AUTOMOBILE_PORT ?? process.env.AUTO_MOBILE_PORT;
   if (envPort) {
     const port = parseInt(envPort, 10);
     if (!isNaN(port) && port > 0 && port < 65536) {
@@ -173,21 +174,22 @@ function parseArgs(): {
     videoRecordingDefaults.format = value;
   };
 
+  // @deprecated AUTO_MOBILE_VIDEO_* - use AUTOMOBILE_VIDEO_* instead
   applyQualityPreset(
-    process.env.AUTO_MOBILE_VIDEO_QUALITY_PRESET ??
-      process.env.AUTOMOBILE_VIDEO_QUALITY_PRESET,
+    process.env.AUTOMOBILE_VIDEO_QUALITY_PRESET ??
+      process.env.AUTO_MOBILE_VIDEO_QUALITY_PRESET,
     "env"
   );
-  const envTargetBitrate = process.env.AUTO_MOBILE_VIDEO_TARGET_BITRATE_KBPS ??
-    process.env.AUTOMOBILE_VIDEO_TARGET_BITRATE_KBPS;
-  const envMaxThroughput = process.env.AUTO_MOBILE_VIDEO_MAX_THROUGHPUT_MBPS ??
-    process.env.AUTOMOBILE_VIDEO_MAX_THROUGHPUT_MBPS;
-  const envFps = process.env.AUTO_MOBILE_VIDEO_FPS ??
-    process.env.AUTOMOBILE_VIDEO_FPS;
-  const envArchiveMb = process.env.AUTO_MOBILE_VIDEO_MAX_ARCHIVE_MB ??
-    process.env.AUTOMOBILE_VIDEO_MAX_ARCHIVE_MB;
-  const envFormat = process.env.AUTO_MOBILE_VIDEO_FORMAT ??
-    process.env.AUTOMOBILE_VIDEO_FORMAT;
+  const envTargetBitrate = process.env.AUTOMOBILE_VIDEO_TARGET_BITRATE_KBPS ??
+    process.env.AUTO_MOBILE_VIDEO_TARGET_BITRATE_KBPS;
+  const envMaxThroughput = process.env.AUTOMOBILE_VIDEO_MAX_THROUGHPUT_MBPS ??
+    process.env.AUTO_MOBILE_VIDEO_MAX_THROUGHPUT_MBPS;
+  const envFps = process.env.AUTOMOBILE_VIDEO_FPS ??
+    process.env.AUTO_MOBILE_VIDEO_FPS;
+  const envArchiveMb = process.env.AUTOMOBILE_VIDEO_MAX_ARCHIVE_MB ??
+    process.env.AUTO_MOBILE_VIDEO_MAX_ARCHIVE_MB;
+  const envFormat = process.env.AUTOMOBILE_VIDEO_FORMAT ??
+    process.env.AUTO_MOBILE_VIDEO_FORMAT;
 
   const parsedTargetBitrate = parsePositiveNumber(envTargetBitrate, "video target bitrate", false);
   if (parsedTargetBitrate !== undefined) {

--- a/src/utils/AccessibilityServiceManager.ts
+++ b/src/utils/AccessibilityServiceManager.ts
@@ -964,12 +964,10 @@ export class AndroidAccessibilityServiceManager implements AccessibilityServiceM
   }
 
   private shouldSkipChecksum(): boolean {
-    const explicitSkip = process.env.AUTO_MOBILE_ACCESSIBILITY_SERVICE_SHA_SKIP_CHECK;
-    if (explicitSkip && explicitSkip.toLowerCase() === "true") {
-      return true;
-    }
-    const skipEnv = process.env.AUTOMOBILE_SKIP_ACCESSIBILITY_CHECKSUM;
-    if (skipEnv && (skipEnv === "1" || skipEnv.toLowerCase() === "true")) {
+    // @deprecated AUTO_MOBILE_ACCESSIBILITY_SERVICE_SHA_SKIP_CHECK - use AUTOMOBILE_SKIP_ACCESSIBILITY_CHECKSUM instead
+    const explicitSkip = process.env.AUTOMOBILE_SKIP_ACCESSIBILITY_CHECKSUM ??
+      process.env.AUTO_MOBILE_ACCESSIBILITY_SERVICE_SHA_SKIP_CHECK;
+    if (explicitSkip && (explicitSkip === "1" || explicitSkip.toLowerCase() === "true")) {
       return true;
     }
     return this.getApkPathOverride() !== null;


### PR DESCRIPTION
## Summary
Standardizes all environment variables to use the `AUTOMOBILE_` prefix across the entire codebase, with `AUTO_MOBILE_` maintained as a deprecated fallback for backward compatibility.

## Changes
- ✅ **TypeScript files**: Updated `src/index.ts`, `src/db/database.ts`, `src/db/migrator.ts`, and `src/utils/AccessibilityServiceManager.ts` to prioritize `AUTOMOBILE_*` variables with `AUTO_MOBILE_*` as fallback
- ✅ **Kotlin files**: Updated `AutoMobileRunner.kt` and `McpClientFactory.kt` to use `AUTOMOBILE_*` as primary environment variables
- ✅ **Documentation**: Updated all docs to reference `AUTOMOBILE_*` as the standard prefix
- ✅ **Backward compatibility**: Existing `AUTO_MOBILE_*` variables continue to work via fallback logic
- ✅ **Deprecation**: Added code comments marking `AUTO_MOBILE_*` as deprecated (no runtime warnings)

## Environment Variables Standardized
**Server:** `AUTOMOBILE_PORT`  
**Video:** `AUTOMOBILE_VIDEO_*` (quality, bitrate, throughput, fps, archive, format)  
**Database:** `AUTOMOBILE_DB_PATH`, `AUTOMOBILE_DB_DIR`, `AUTOMOBILE_MIGRATIONS_DIR`  
**Accessibility:** `AUTOMOBILE_ACCESSIBILITY_APK_PATH`, `AUTOMOBILE_SKIP_ACCESSIBILITY_CHECKSUM`, `AUTOMOBILE_SKIP_ACCESSIBILITY_DOWNLOAD_IF_INSTALLED`  
**MCP:** `AUTOMOBILE_MCP_HTTP_URL`, `AUTOMOBILE_MCP_STDIO_COMMAND`  
**Android Metadata:** `AUTOMOBILE_APP_VERSION`, `AUTOMOBILE_GIT_COMMIT`, `AUTOMOBILE_TARGET_SDK`

## Test Plan
- [x] Lint passes
- [x] Build completes successfully
- [x] All changes maintain backward compatibility
- [x] Documentation updated

## Migration Guide
Users with existing `AUTO_MOBILE_*` variables don't need to change anything immediately - the old names continue to work. For new configurations, use `AUTOMOBILE_*` prefix going forward.

Closes #483

🤖 Generated with [Claude Code](https://claude.com/claude-code)