### PR TITLE
Enable auto-merge for automated accessibility service APK checksum PRs

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -374,6 +374,7 @@ jobs:
 
       - name: "Create PR for SHA256 update"
         if: steps.check.outputs.needed == 'true'
+        id: create-pr
         uses: peter-evans/create-pull-request@v6
         with:
           # Use a PAT with workflow scope so the PR triggers CI runs.
@@ -415,6 +416,13 @@ jobs:
             automated
             android
             release engineering
+
+      - name: "Enable auto-merge on PR"
+        if: steps.check.outputs.needed == 'true' && steps.create-pr.outputs.pull-request-number != ''
+        env:
+          GH_TOKEN: ${{ secrets.AUTO_MOBILE_PR_TOKEN }}
+        run: |
+          gh pr merge ${{ steps.create-pr.outputs.pull-request-number }} --auto --squash
 
   build-playground-app:
     name: "Build Playground App"


### PR DESCRIPTION
## Summary

- Add automatic auto-merge enablement to merge workflow for accessibility service APK SHA256 checksum update PRs
- When workflow detects checksum change and creates PR, it now enables auto-merge with squash method
- Eliminates manual intervention for routine checksum updates while maintaining safety through CI checks

## Changes

- Added `id: create-pr` to PR creation step to capture PR number
- Added new workflow step to enable auto-merge using `gh pr merge --auto --squash`
- Auto-merge triggers only when checksum update is needed and PR is created

## Test Plan

- [x] YAML syntax validated
- [x] Workflow logic reviewed
- [ ] Will be validated on next accessibility service build that triggers checksum change
- [ ] PR #517 serves as evidence of the issue (no auto-merge currently)

## Related

Fixes #436

🤖 Generated with [Claude Code](https://claude.com/claude-code)