### PR TITLE
Filter accessibility extras from MCP responses

### DIFF
--- a/src/server/observationResources.ts
+++ b/src/server/observationResources.ts
@@ -1,6 +1,7 @@
 import { ResourceRegistry, ResourceContent } from "./resourceRegistry";
 import { ObserveScreen } from "../features/observe/ObserveScreen";
 import { logger } from "../utils/logger";
+import { stringifyToolResponse } from "../utils/toolUtils";
 import * as fs from "fs/promises";
 import * as path from "path";
 
@@ -63,7 +64,7 @@ async function getLatestObservation(): Promise<ResourceContent> {
     return {
       uri: RESOURCE_URIS.LATEST_OBSERVATION,
       mimeType: "application/json",
-      text: JSON.stringify(cachedResult, null, 2)
+      text: stringifyToolResponse(cachedResult)
     };
   } catch (error) {
     logger.error(`[ObservationResources] Failed to get latest observation: ${error}`);

--- a/src/utils/toolUtils.ts
+++ b/src/utils/toolUtils.ts
@@ -3,6 +3,17 @@
  */
 import { OPERATION_CANCELLED_MESSAGE } from "./constants";
 
+const stripAccessibilityExtras = (key: string, value: unknown): unknown => {
+  if (key === "extras") {
+    return undefined;
+  }
+  return value;
+};
+
+export const stringifyToolResponse = (content: unknown): string => {
+  return JSON.stringify(content, stripAccessibilityExtras, 2);
+};
+
 /**
  * Interface for tool response formatter
  */
@@ -41,7 +52,7 @@ export class DefaultToolResponseFormatter implements ToolResponseFormatter {
       content: [
         {
           type: "text",
-          text: JSON.stringify(content, null, 2)
+          text: stringifyToolResponse(content)
         }
       ]
     };

--- a/test/fakes/FakeToolUtils.ts
+++ b/test/fakes/FakeToolUtils.ts
@@ -3,6 +3,7 @@
  * Allows configuration and verification of tool response creation
  */
 import { ToolUtils } from "../../src/utils/interfaces/ToolUtils";
+import { stringifyToolResponse } from "../../src/utils/toolUtils";
 
 export class FakeToolUtils implements ToolUtils {
   private jsonResponses: any[] = [];
@@ -24,7 +25,7 @@ export class FakeToolUtils implements ToolUtils {
       content: [
         {
           type: "text",
-          text: JSON.stringify(content, null, 2)
+          text: stringifyToolResponse(content)
         }
       ]
     };


### PR DESCRIPTION
## Summary
- filter accessibility `extras` out of MCP tool JSON responses while keeping full observation data internal
- reuse the same sanitized serialization for latest-observation resources and test helpers

## Testing
- `bun run build`
- `bun run lint`
- `bun run estimate-context`
- `bun run benchmark-context`
- `bash scripts/shellcheck/validate_shell_scripts.sh`
- `bash scripts/shellcheck/apply_shfmt.sh`
- `bash scripts/xml/format_xml.sh`
- `bun run test` (fails on retry: Parallel Execution Across Multiple Devices > Session Lifecycle with Device Reuse; expected "device-2" got "device-1"; log in `scratch/bun-test.log`)

Closes #539
