### PR TITLE
Improve VM snapshot validation

### DIFF
--- a/docs/features/snapshots.md
+++ b/docs/features/snapshots.md
@@ -23,6 +23,7 @@ Capture the current device state as a snapshot.
 - `includeAppData` (optional, default: true): Include app data directories in snapshot
 - `includeSettings` (optional, default: true): Include system settings (global/secure/system)
 - `useVmSnapshot` (optional, default: true): Use emulator VM snapshot if available (faster for emulators)
+- `vmSnapshotTimeoutMs` (optional, default: 30000): Timeout in milliseconds for emulator VM snapshot commands
 - `strictBackupMode` (optional, default: false): If true, fail entire snapshot if app data backup fails or times out
 - `backupTimeout` (optional, default: 30000): Timeout in milliseconds for adb backup user confirmation
 - `userApps` (optional, default: "current"): Which apps to backup - "current" (foreground app only) or "all" (all user-installed apps)
@@ -66,6 +67,7 @@ Restore device to a previously captured snapshot state.
 **Parameters:**
 - `snapshotName` (required): Name of the snapshot to restore
 - `useVmSnapshot` (optional, default: true): Use emulator VM snapshot if available
+- `vmSnapshotTimeoutMs` (optional, default: 30000): Timeout in milliseconds for emulator VM snapshot commands
 - `sessionUuid` (optional): Session UUID for multi-device targeting
 - `device` (optional): Device label for multi-device control
 
@@ -168,7 +170,9 @@ await deleteSnapshot({
 
 **Technical Details:**
 - Uses `adb emu avd snapshot save/load` commands
-- Snapshots stored in emulator's AVD directory
+- Emulator replies with `OK` or `KO: <reason>` (missing `OK` is treated as failure)
+- Commands time out after 30000ms by default (configurable via `vmSnapshotTimeoutMs`)
+- Snapshots stored in emulator's AVD directory (typically `~/.android/avd/<avd>.avd/snapshots/`)
 - Metadata stored in `~/.automobile/snapshots/` for management
 
 ### ADB Snapshots (All Devices)
@@ -218,6 +222,8 @@ Snapshots are stored in `~/.automobile/snapshots/` with the following structure:
 └── another-snapshot/
     └── ...
 ```
+
+VM snapshots themselves are stored in the emulator AVD directory and persist across emulator restarts. Deleting a snapshot via `deleteSnapshot` removes AutoMobile metadata but does not delete the emulator's VM snapshot.
 
 ## Use Cases
 
@@ -377,6 +383,8 @@ await captureDeviceSnapshot({
 
 - Verify device is connected and responsive
 - For VM snapshots, ensure emulator console is accessible
+- If VM snapshot commands time out, increase `vmSnapshotTimeoutMs` or restart the emulator
+- If the emulator reports an unknown command, update the emulator to a version that supports snapshots
 - Check available disk space in `~/.automobile/snapshots/`
 
 ### Snapshot Restore Fails
@@ -384,6 +392,7 @@ await captureDeviceSnapshot({
 - Verify snapshot exists using `listSnapshots`
 - Check platform compatibility (snapshot vs device)
 - For VM snapshots, ensure emulator is running
+- If the emulator reports device offline, reconnect or restart the emulator
 
 ### Snapshot Too Large
 

--- a/src/features/action/CaptureSnapshot.ts
+++ b/src/features/action/CaptureSnapshot.ts
@@ -1,6 +1,11 @@
 import { BootedDevice, ActionableError } from "../../models";
 import { AdbClient } from "../../utils/android-cmdline-tools/AdbClient";
 import { AndroidEmulatorClient } from "../../utils/android-cmdline-tools/AndroidEmulatorClient";
+import {
+  buildVmSnapshotCommand,
+  evaluateVmSnapshotResult,
+  formatVmSnapshotExecutionError
+} from "../../utils/android-cmdline-tools/vmSnapshot";
 import { SnapshotStorage, SnapshotManifest } from "../../utils/snapshotStorage";
 import { logger } from "../../utils/logger";
 import { promises as fs } from "fs";
@@ -15,6 +20,7 @@ export interface CaptureSnapshotArgs {
   strictBackupMode?: boolean; // If true, fail entire snapshot if app data backup fails
   backupTimeout?: number; // Timeout in milliseconds for adb backup (default: 30000ms)
   userApps?: "current" | "all"; // Which apps to backup: "current" (foreground app only) or "all" (all user apps)
+  vmSnapshotTimeoutMs?: number; // Timeout in milliseconds for emulator VM snapshot commands (default: 30000ms)
 }
 
 export interface CaptureSnapshotResult {
@@ -58,7 +64,8 @@ export class CaptureSnapshot {
       useVmSnapshot = true,
       strictBackupMode = false,
       backupTimeout = 30000,
-      userApps = "current"
+      userApps = "current",
+      vmSnapshotTimeoutMs = 30000
     } = args;
 
     // Generate snapshot name if not provided
@@ -78,7 +85,7 @@ export class CaptureSnapshot {
     let manifest: SnapshotManifest;
 
     if (shouldUseVmSnapshot) {
-      manifest = await this.captureVmSnapshot(snapshotName, includeSettings);
+      manifest = await this.captureVmSnapshot(snapshotName, includeSettings, vmSnapshotTimeoutMs);
     } else {
       manifest = await this.captureAdbSnapshot(snapshotName, includeAppData, includeSettings, strictBackupMode, backupTimeout, userApps);
     }
@@ -101,19 +108,26 @@ export class CaptureSnapshot {
    */
   private async captureVmSnapshot(
     snapshotName: string,
-    includeSettings: boolean
+    includeSettings: boolean,
+    vmSnapshotTimeoutMs: number
   ): Promise<SnapshotManifest> {
     logger.info(`Using VM snapshot for emulator ${this.device.deviceId}`);
 
     try {
       // Save VM snapshot using ADB emu command
-      const saveCommand = `emu avd snapshot save ${snapshotName}`;
+      const saveCommand = buildVmSnapshotCommand("save", snapshotName);
       logger.info(`Executing: adb -s ${this.device.deviceId} ${saveCommand}`);
 
-      const result = await this.adb.executeCommand(saveCommand);
+      let result;
+      try {
+        result = await this.adb.executeCommand(saveCommand, vmSnapshotTimeoutMs);
+      } catch (error) {
+        throw new Error(formatVmSnapshotExecutionError("save", snapshotName, error));
+      }
 
-      if (result.stderr && result.stderr.includes("KO")) {
-        throw new Error(`VM snapshot failed: ${result.stderr}`);
+      const evaluation = evaluateVmSnapshotResult("save", snapshotName, result);
+      if (!evaluation.ok) {
+        throw new Error(evaluation.errorMessage);
       }
 
       logger.info(`VM snapshot saved successfully`);
@@ -143,8 +157,9 @@ export class CaptureSnapshot {
 
       return manifest;
     } catch (error) {
-      logger.error(`Failed to capture VM snapshot: ${error}`);
-      throw new ActionableError(`Failed to capture VM snapshot: ${error}`);
+      const message = error instanceof Error ? error.message : String(error);
+      logger.error(`Failed to capture VM snapshot: ${message}`);
+      throw new ActionableError(`Failed to capture VM snapshot: ${message}`);
     }
   }
 

--- a/src/features/action/RestoreSnapshot.ts
+++ b/src/features/action/RestoreSnapshot.ts
@@ -1,6 +1,11 @@
 import { BootedDevice, ActionableError } from "../../models";
 import { AdbClient } from "../../utils/android-cmdline-tools/AdbClient";
 import { AndroidEmulatorClient } from "../../utils/android-cmdline-tools/AndroidEmulatorClient";
+import {
+  buildVmSnapshotCommand,
+  evaluateVmSnapshotResult,
+  formatVmSnapshotExecutionError
+} from "../../utils/android-cmdline-tools/vmSnapshot";
 import { SnapshotStorage, SnapshotManifest } from "../../utils/snapshotStorage";
 import { logger } from "../../utils/logger";
 import { promises as fs } from "fs";
@@ -10,6 +15,7 @@ import { Timer, defaultTimer } from "../../utils/SystemTimer";
 export interface RestoreSnapshotArgs {
   snapshotName: string;
   useVmSnapshot?: boolean;
+  vmSnapshotTimeoutMs?: number; // Timeout in milliseconds for emulator VM snapshot commands (default: 30000ms)
 }
 
 export interface RestoreSnapshotResult {
@@ -44,7 +50,7 @@ export class RestoreSnapshot {
    * Execute snapshot restoration
    */
   async execute(args: RestoreSnapshotArgs): Promise<RestoreSnapshotResult> {
-    const { snapshotName, useVmSnapshot = true } = args;
+    const { snapshotName, useVmSnapshot = true, vmSnapshotTimeoutMs = 30000 } = args;
 
     // Check if snapshot exists
     if (!(await this.storage.snapshotExists(snapshotName))) {
@@ -68,7 +74,7 @@ export class RestoreSnapshot {
     const shouldUseVmSnapshot = useVmSnapshot && manifest.snapshotType === "vm" && isEmulator;
 
     if (shouldUseVmSnapshot) {
-      await this.restoreVmSnapshot(snapshotName, manifest);
+      await this.restoreVmSnapshot(snapshotName, manifest, vmSnapshotTimeoutMs);
     } else {
       await this.restoreAdbSnapshot(snapshotName, manifest);
     }
@@ -86,19 +92,26 @@ export class RestoreSnapshot {
    */
   private async restoreVmSnapshot(
     snapshotName: string,
-    manifest: SnapshotManifest
+    manifest: SnapshotManifest,
+    vmSnapshotTimeoutMs: number
   ): Promise<void> {
     logger.info(`Restoring VM snapshot for emulator ${this.device.deviceId}`);
 
     try {
       // Load VM snapshot using ADB emu command
-      const loadCommand = `emu avd snapshot load ${snapshotName}`;
+      const loadCommand = buildVmSnapshotCommand("load", snapshotName);
       logger.info(`Executing: adb -s ${this.device.deviceId} ${loadCommand}`);
 
-      const result = await this.adb.executeCommand(loadCommand);
+      let result;
+      try {
+        result = await this.adb.executeCommand(loadCommand, vmSnapshotTimeoutMs);
+      } catch (error) {
+        throw new Error(formatVmSnapshotExecutionError("load", snapshotName, error));
+      }
 
-      if (result.stderr && result.stderr.includes("KO")) {
-        throw new Error(`VM snapshot restoration failed: ${result.stderr}`);
+      const evaluation = evaluateVmSnapshotResult("load", snapshotName, result);
+      if (!evaluation.ok) {
+        throw new Error(evaluation.errorMessage);
       }
 
       logger.info(`VM snapshot restored successfully`);
@@ -108,8 +121,9 @@ export class RestoreSnapshot {
 
       logger.info("VM snapshot restoration complete");
     } catch (error) {
-      logger.error(`Failed to restore VM snapshot: ${error}`);
-      throw new ActionableError(`Failed to restore VM snapshot: ${error}`);
+      const message = error instanceof Error ? error.message : String(error);
+      logger.error(`Failed to restore VM snapshot: ${message}`);
+      throw new ActionableError(`Failed to restore VM snapshot: ${message}`);
     }
   }
 

--- a/src/server/snapshotTools.ts
+++ b/src/server/snapshotTools.ts
@@ -15,12 +15,14 @@ export const captureDeviceSnapshotSchema = addDeviceTargetingToSchema(z.object({
   useVmSnapshot: z.boolean().optional().default(true).describe("Use emulator VM snapshot if available (faster, emulator only)"),
   strictBackupMode: z.boolean().optional().default(false).describe("If true, fail entire snapshot if app data backup fails or times out"),
   backupTimeout: z.number().optional().default(30000).describe("Timeout in milliseconds for adb backup user confirmation (default: 30000ms)"),
-  userApps: z.enum(["current", "all"]).optional().default("current").describe("Which apps to backup: 'current' (foreground app only) or 'all' (all user-installed apps)")
+  userApps: z.enum(["current", "all"]).optional().default("current").describe("Which apps to backup: 'current' (foreground app only) or 'all' (all user-installed apps)"),
+  vmSnapshotTimeoutMs: z.number().optional().default(30000).describe("Timeout in milliseconds for emulator VM snapshot commands (default: 30000ms)")
 }));
 
 export const restoreDeviceSnapshotSchema = addDeviceTargetingToSchema(z.object({
   snapshotName: z.string().describe("Name of the snapshot to restore"),
-  useVmSnapshot: z.boolean().optional().default(true).describe("Use emulator VM snapshot if available (faster, emulator only)")
+  useVmSnapshot: z.boolean().optional().default(true).describe("Use emulator VM snapshot if available (faster, emulator only)"),
+  vmSnapshotTimeoutMs: z.number().optional().default(30000).describe("Timeout in milliseconds for emulator VM snapshot commands (default: 30000ms)")
 }));
 
 export const listSnapshotsSchema = addDeviceTargetingToSchema(z.object({
@@ -40,11 +42,13 @@ export interface CaptureSnapshotArgs {
   strictBackupMode?: boolean;
   backupTimeout?: number;
   userApps?: "current" | "all";
+  vmSnapshotTimeoutMs?: number;
 }
 
 export interface RestoreSnapshotArgs {
   snapshotName: string;
   useVmSnapshot?: boolean;
+  vmSnapshotTimeoutMs?: number;
 }
 
 export interface ListSnapshotsArgs {

--- a/src/utils/android-cmdline-tools/vmSnapshot.ts
+++ b/src/utils/android-cmdline-tools/vmSnapshot.ts
@@ -1,0 +1,86 @@
+import { ExecResult } from "../../models";
+
+export type VmSnapshotAction = "save" | "load";
+
+const OK_TOKEN = /\bOK\b/;
+const KO_TOKEN = /\bKO\b/;
+
+export function buildVmSnapshotCommand(action: VmSnapshotAction, snapshotName: string): string {
+  return `emu avd snapshot ${action} ${snapshotName}`;
+}
+
+export function evaluateVmSnapshotResult(
+  action: VmSnapshotAction,
+  snapshotName: string,
+  result: ExecResult
+): { ok: boolean; errorMessage?: string } {
+  const output = combineVmSnapshotOutput(result.stdout, result.stderr);
+  const upper = output.toUpperCase();
+  const hasKo = KO_TOKEN.test(upper);
+  if (hasKo) {
+    return { ok: false, errorMessage: buildVmSnapshotErrorMessage(action, snapshotName, output) };
+  }
+  const hasOk = OK_TOKEN.test(upper);
+  if (hasOk) {
+    return { ok: true };
+  }
+  const detail = output ? `unexpected response: ${output}` : "no response from emulator";
+  return { ok: false, errorMessage: buildVmSnapshotErrorMessage(action, snapshotName, detail) };
+}
+
+export function formatVmSnapshotExecutionError(
+  action: VmSnapshotAction,
+  snapshotName: string,
+  error: unknown
+): string {
+  const detail = describeVmSnapshotError(error);
+  return buildVmSnapshotErrorMessage(action, snapshotName, detail);
+}
+
+export function buildVmSnapshotErrorMessage(
+  action: VmSnapshotAction,
+  snapshotName: string,
+  detail: string
+): string {
+  const trimmed = detail.trim();
+  const cleaned = trimmed.replace(/^KO[:\s]*/i, "").trim();
+  const lower = cleaned.toLowerCase();
+  const base = `VM snapshot ${action} failed for '${snapshotName}'`;
+
+  if (!cleaned) {
+    return `${base}: no response from emulator`;
+  }
+
+  if (lower.includes("timed out") || lower.includes("timeout")) {
+    return `${base}: command timed out (${cleaned})`;
+  }
+  if (lower.includes("device offline") || lower.includes("offline")) {
+    return `${base}: emulator is offline or not responding (${cleaned})`;
+  }
+  if (lower.includes("device not found") || lower.includes("no devices") || lower.includes("no emulators")) {
+    return `${base}: emulator not found (${cleaned})`;
+  }
+  if (lower.includes("unknown command") || lower.includes("not supported") || lower.includes("unknown avd")) {
+    return `${base}: emulator does not support snapshot commands (${cleaned})`;
+  }
+  if (lower.includes("snapshot") && (lower.includes("not found") || lower.includes("does not exist"))) {
+    return `${base}: snapshot not found (${cleaned})`;
+  }
+
+  return `${base}: ${cleaned}`;
+}
+
+function combineVmSnapshotOutput(stdout: string, stderr: string): string {
+  return [stdout, stderr]
+    .filter(part => part && part.trim().length > 0)
+    .join("\n")
+    .trim();
+}
+
+function describeVmSnapshotError(error: unknown): string {
+  if (error instanceof Error) {
+    const errorWithOutput = error as Error & { stdout?: string; stderr?: string };
+    return [error.message, errorWithOutput.stdout, errorWithOutput.stderr].filter(Boolean).join("\n");
+  }
+  return String(error);
+}

--- a/test/fakes/FakeAdbClient.ts
+++ b/test/fakes/FakeAdbClient.ts
@@ -3,20 +3,32 @@
  * Captures commands executed without actually running ADB
  */
 export class FakeAdbClient {
-  private commands: string[] = [];
+  private commandCalls: Array<{
+    command: string;
+    timeoutMs?: number;
+    maxBuffer?: number;
+    noRetry?: boolean;
+    signal?: AbortSignal;
+  }> = [];
   private commandResults: Map<string, { stdout: string; stderr: string }> = new Map();
+  private commandErrors: Map<string, Error> = new Map();
 
   /**
    * Record a command execution
    */
   async executeCommand(
     command: string,
-    _options?: any,
-    _timeout?: number,
-    _encoding?: string,
-    _signal?: AbortSignal
+    timeoutMs?: number,
+    maxBuffer?: number,
+    noRetry?: boolean,
+    signal?: AbortSignal
   ): Promise<{ stdout: string; stderr: string }> {
-    this.commands.push(command);
+    this.commandCalls.push({ command, timeoutMs, maxBuffer, noRetry, signal });
+
+    const error = this.commandErrors.get(command);
+    if (error) {
+      throw error;
+    }
 
     // Return configured result or default success
     const result = this.commandResults.get(command) || { stdout: "", stderr: "" };
@@ -31,32 +43,66 @@ export class FakeAdbClient {
   }
 
   /**
+   * Configure a command to throw an error
+   */
+  setCommandError(command: string, error: Error): void {
+    this.commandErrors.set(command, error);
+  }
+
+  /**
+   * Get all recorded command calls
+   */
+  getCommandCalls(): Array<{
+    command: string;
+    timeoutMs?: number;
+    maxBuffer?: number;
+    noRetry?: boolean;
+    signal?: AbortSignal;
+  }> {
+    return [...this.commandCalls];
+  }
+
+  /**
+   * Get the last command call details
+   */
+  getLastCommandCall(): {
+    command: string;
+    timeoutMs?: number;
+    maxBuffer?: number;
+    noRetry?: boolean;
+    signal?: AbortSignal;
+  } | undefined {
+    return this.commandCalls[this.commandCalls.length - 1];
+  }
+
+  /**
    * Get the last command executed
    */
   getLastCommand(): string {
-    return this.commands[this.commands.length - 1] || "";
+    return this.commandCalls[this.commandCalls.length - 1]?.command || "";
   }
 
   /**
    * Get all commands executed
    */
   getAllCommands(): string[] {
-    return [...this.commands];
+    return this.commandCalls.map(call => call.command);
   }
 
   /**
    * Clear recorded commands
    */
   clearCommands(): void {
-    this.commands = [];
+    this.commandCalls = [];
   }
 
   /**
    * Reset fake state
    */
   reset(): void {
-    this.commands = [];
+    this.commandCalls = [];
     this.commandResults.clear();
+    this.commandErrors.clear();
   }
 
   /**
@@ -64,9 +110,9 @@ export class FakeAdbClient {
    */
   wasCommandExecuted(commandPattern: string | RegExp): boolean {
     if (typeof commandPattern === "string") {
-      return this.commands.some(cmd => cmd.includes(commandPattern));
+      return this.commandCalls.some(call => call.command.includes(commandPattern));
     }
-    return this.commands.some(cmd => commandPattern.test(cmd));
+    return this.commandCalls.some(call => commandPattern.test(call.command));
   }
 
   /**
@@ -74,8 +120,8 @@ export class FakeAdbClient {
    */
   getCommandCount(commandPattern: string | RegExp): number {
     if (typeof commandPattern === "string") {
-      return this.commands.filter(cmd => cmd.includes(commandPattern)).length;
+      return this.commandCalls.filter(call => call.command.includes(commandPattern)).length;
     }
-    return this.commands.filter(cmd => commandPattern.test(cmd)).length;
+    return this.commandCalls.filter(call => commandPattern.test(call.command)).length;
   }
 }

--- a/test/features/action/CaptureSnapshot.test.ts
+++ b/test/features/action/CaptureSnapshot.test.ts
@@ -142,6 +142,84 @@ describe("CaptureSnapshot", () => {
       })).rejects.toThrow("Failed to capture VM snapshot");
     });
 
+    it("should throw error when VM snapshot fails with KO in stdout", async () => {
+      const snapshotName = "test-vm-fail-stdout";
+
+      // Setup getForegroundApp
+      (captureSnapshot as any).getForegroundApp = async () => "com.example.app";
+
+      // Setup VM snapshot command to fail (KO in stdout)
+      fakeAdb.setCommandResult(`emu avd snapshot save ${snapshotName}`, "KO: snapshot failed");
+
+      await expect(captureSnapshot.execute({
+        snapshotName,
+        includeAppData: true,
+        includeSettings: false,
+        useVmSnapshot: true
+      })).rejects.toThrow("Failed to capture VM snapshot");
+    });
+
+    it("should throw error when VM snapshot returns no OK response", async () => {
+      const snapshotName = "test-vm-empty-response";
+
+      // Setup getForegroundApp
+      (captureSnapshot as any).getForegroundApp = async () => "com.example.app";
+
+      // Setup VM snapshot command with empty output
+      fakeAdb.setCommandResult(`emu avd snapshot save ${snapshotName}`, "", "");
+
+      await expect(captureSnapshot.execute({
+        snapshotName,
+        includeAppData: true,
+        includeSettings: false,
+        useVmSnapshot: true
+      })).rejects.toThrow("no response from emulator");
+    });
+
+    it("should surface offline errors when VM snapshot command fails", async () => {
+      const snapshotName = "test-vm-offline";
+
+      // Setup getForegroundApp
+      (captureSnapshot as any).getForegroundApp = async () => "com.example.app";
+
+      // Setup VM snapshot command to throw offline error
+      fakeAdb.setCommandError(
+        `emu avd snapshot save ${snapshotName}`,
+        new Error("device offline")
+      );
+
+      await expect(captureSnapshot.execute({
+        snapshotName,
+        includeAppData: true,
+        includeSettings: false,
+        useVmSnapshot: true
+      })).rejects.toThrow("offline");
+    });
+
+    it("should pass VM snapshot timeout to adb command", async () => {
+      const snapshotName = "test-vm-timeout";
+      const vmSnapshotTimeoutMs = 12000;
+
+      // Setup getForegroundApp
+      (captureSnapshot as any).getForegroundApp = async () => "com.example.app";
+
+      // Setup VM snapshot command
+      fakeAdb.setCommandResult(`emu avd snapshot save ${snapshotName}`, "OK");
+
+      await captureSnapshot.execute({
+        snapshotName,
+        includeAppData: true,
+        includeSettings: false,
+        useVmSnapshot: true,
+        vmSnapshotTimeoutMs
+      });
+
+      const call = fakeAdb.getCommandCalls().find(
+        entry => entry.command === `emu avd snapshot save ${snapshotName}`
+      );
+      expect(call?.timeoutMs).toBe(vmSnapshotTimeoutMs);
+    });
+
     it("should use ADB snapshot for non-emulator device even with useVmSnapshot=true", async () => {
       const snapshotName = "test-physical-device";
 

--- a/test/features/action/RestoreSnapshot.test.ts
+++ b/test/features/action/RestoreSnapshot.test.ts
@@ -115,6 +115,124 @@ describe("RestoreSnapshot", () => {
       })).rejects.toThrow("Failed to restore VM snapshot");
     });
 
+    it("should throw error when VM snapshot load fails with KO in stdout", async () => {
+      const snapshotName = "test-vm-fail-stdout";
+
+      // Create VM snapshot manifest
+      const manifest: SnapshotManifest = {
+        snapshotName,
+        timestamp: new Date().toISOString(),
+        deviceId: device.deviceId,
+        deviceName: device.name,
+        platform: "android",
+        snapshotType: "vm",
+        includeAppData: true,
+        includeSettings: false
+      };
+
+      // Save manifest
+      await storage.saveManifest(manifest);
+
+      // Setup VM snapshot load command to fail (KO in stdout)
+      fakeAdb.setCommandResult(`emu avd snapshot load ${snapshotName}`, "KO: snapshot load failed");
+
+      await expect(restoreSnapshot.execute({
+        snapshotName,
+        useVmSnapshot: true
+      })).rejects.toThrow("Failed to restore VM snapshot");
+    });
+
+    it("should throw error when VM snapshot load returns no OK response", async () => {
+      const snapshotName = "test-vm-empty-response";
+
+      // Create VM snapshot manifest
+      const manifest: SnapshotManifest = {
+        snapshotName,
+        timestamp: new Date().toISOString(),
+        deviceId: device.deviceId,
+        deviceName: device.name,
+        platform: "android",
+        snapshotType: "vm",
+        includeAppData: true,
+        includeSettings: false
+      };
+
+      // Save manifest
+      await storage.saveManifest(manifest);
+
+      // Setup VM snapshot load command with empty output
+      fakeAdb.setCommandResult(`emu avd snapshot load ${snapshotName}`, "", "");
+
+      await expect(restoreSnapshot.execute({
+        snapshotName,
+        useVmSnapshot: true
+      })).rejects.toThrow("no response from emulator");
+    });
+
+    it("should surface offline errors when VM snapshot command fails", async () => {
+      const snapshotName = "test-vm-offline";
+
+      // Create VM snapshot manifest
+      const manifest: SnapshotManifest = {
+        snapshotName,
+        timestamp: new Date().toISOString(),
+        deviceId: device.deviceId,
+        deviceName: device.name,
+        platform: "android",
+        snapshotType: "vm",
+        includeAppData: true,
+        includeSettings: false
+      };
+
+      // Save manifest
+      await storage.saveManifest(manifest);
+
+      // Setup VM snapshot load command to throw offline error
+      fakeAdb.setCommandError(
+        `emu avd snapshot load ${snapshotName}`,
+        new Error("device offline")
+      );
+
+      await expect(restoreSnapshot.execute({
+        snapshotName,
+        useVmSnapshot: true
+      })).rejects.toThrow("offline");
+    });
+
+    it("should pass VM snapshot timeout to adb command", async () => {
+      const snapshotName = "test-vm-timeout";
+      const vmSnapshotTimeoutMs = 15000;
+
+      // Create VM snapshot manifest
+      const manifest: SnapshotManifest = {
+        snapshotName,
+        timestamp: new Date().toISOString(),
+        deviceId: device.deviceId,
+        deviceName: device.name,
+        platform: "android",
+        snapshotType: "vm",
+        includeAppData: true,
+        includeSettings: false
+      };
+
+      // Save manifest
+      await storage.saveManifest(manifest);
+
+      // Setup VM snapshot load command
+      fakeAdb.setCommandResult(`emu avd snapshot load ${snapshotName}`, "OK");
+
+      await restoreSnapshot.execute({
+        snapshotName,
+        useVmSnapshot: true,
+        vmSnapshotTimeoutMs
+      });
+
+      const call = fakeAdb.getCommandCalls().find(
+        entry => entry.command === `emu avd snapshot load ${snapshotName}`
+      );
+      expect(call?.timeoutMs).toBe(vmSnapshotTimeoutMs);
+    });
+
     it("should use ADB restore for VM snapshot when useVmSnapshot is false", async () => {
       const snapshotName = "test-vm-as-adb";
 


### PR DESCRIPTION
## Summary
- add VM snapshot response parsing with OK/KO validation and timeout plumbing
- extend VM snapshot tests for stdout KO, empty responses, offline errors, and timeouts
- document VM snapshot timeout behavior and storage notes

## Testing
- bun run test -- test/features/action/CaptureSnapshot.test.ts test/features/action/RestoreSnapshot.test.ts

## Issue
- Closes #507
