### PR TITLE
Standardize auto-mobile Maven coordinates

### DIFF
--- a/android/auto-mobile-sdk/README.md
+++ b/android/auto-mobile-sdk/README.md
@@ -17,7 +17,7 @@ Android library SDK for tracking navigation events across various navigation fra
 
 ```kotlin
 dependencies {
-    implementation("dev.jasonpearson.automobile:auto-mobile-sdk:0.0.1-SNAPSHOT")
+    implementation("dev.jasonpearson.auto-mobile:auto-mobile-sdk:0.0.1-SNAPSHOT")
 }
 ```
 
@@ -25,7 +25,7 @@ dependencies {
 
 ```groovy
 dependencies {
-    implementation 'dev.jasonpearson.automobile:auto-mobile-sdk:0.0.1-SNAPSHOT'
+    implementation 'dev.jasonpearson.auto-mobile:auto-mobile-sdk:0.0.1-SNAPSHOT'
 }
 ```
 

--- a/android/auto-mobile-sdk/build.gradle.kts
+++ b/android/auto-mobile-sdk/build.gradle.kts
@@ -82,7 +82,7 @@ mavenPublishing {
   publishToMavenCentral()
   signAllPublications()
 
-  coordinates("dev.jasonpearson.automobile", "auto-mobile-sdk", project.version.toString())
+  coordinates("dev.jasonpearson.auto-mobile", "auto-mobile-sdk", project.version.toString())
 
   pom {
     name.set("AutoMobile SDK")

--- a/android/junit-runner/build.gradle.kts
+++ b/android/junit-runner/build.gradle.kts
@@ -58,7 +58,7 @@ mavenPublishing {
   publishToMavenCentral()
   signAllPublications()
 
-  coordinates("dev.jasonpearson.automobile", "junit-runner", project.version.toString())
+  coordinates("dev.jasonpearson.auto-mobile", "auto-mobile-junit-runner", project.version.toString())
 
   pom {
     name.set("AutoMobile JUnit Runner")

--- a/android/junit-runner/src/main/kotlin/dev/jasonpearson/automobile/junit/README.md
+++ b/android/junit-runner/src/main/kotlin/dev/jasonpearson/automobile/junit/README.md
@@ -245,7 +245,7 @@ Add to your `build.gradle`:
 
 ```gradle
 dependencies {
-    testImplementation 'com.automobile:junit-runner:1.0.0'
+    testImplementation 'dev.jasonpearson.auto-mobile:auto-mobile-junit-runner:1.0.0'
 }
 ```
 

--- a/docs/design-docs/plat/android/junitrunner.md
+++ b/docs/design-docs/plat/android/junitrunner.md
@@ -6,7 +6,7 @@ Add this test Gradle dependency to all Android apps and libraries in your codeba
 modules that cover the UI you want to test.
 
 ```gradle
-testImplementation("dev.jasonpearson.automobile.junitrunner:x.y.z")
+testImplementation("dev.jasonpearson.auto-mobile:auto-mobile-junit-runner:x.y.z")
 ```
 
 Note that this artifact hasn't been published to Maven Central just yet and is forthcoming.


### PR DESCRIPTION
## Summary
- standardize Maven group IDs to `dev.jasonpearson.auto-mobile`
- rename JUnit runner artifact to `auto-mobile-junit-runner`
- update dependency docs to match the new coordinates

## Testing
- `cd android && ./gradlew :junit-runner:compileKotlin :auto-mobile-sdk:compileDebugKotlin`

## Issues
Closes #540
