### PR TITLE
chore: update accessibility service APK SHA256

### DIFF
--- a/src/constants/release.ts
+++ b/src/constants/release.ts
@@ -19,4 +19,4 @@ export const RELEASE_VERSION: string = "latest";
 export const APK_URL: string = RELEASE_VERSION === "latest"
   ? `https://github.com/kaeawc/auto-mobile/releases/latest/download/accessibility-service-debug.apk`
   : `https://github.com/kaeawc/auto-mobile/releases/download/v${RELEASE_VERSION}/accessibility-service-debug.apk`;
-export const APK_SHA256_CHECKSUM: string = "2147cbc440c03503441643deebe501912601b2abba07579e86290ee41f27680b"; // Empty = skip verification (local dev only)
+export const APK_SHA256_CHECKSUM: string = "6c0c6ac56d6b4f927ea0ef20c6204b8e23976ed9587d598990a408864a2df391"; // Empty = skip verification (local dev only)


### PR DESCRIPTION
## Automated Checksum Update

The accessibility service APK was rebuilt on `main` with a different SHA256 checksum.

| | SHA256 |
|--|--------|
| **Previous** | `2147cbc440c03503441643deebe501912601b2abba07579e86290ee41f27680b` |
| **New** | `6c0c6ac56d6b4f927ea0ef20c6204b8e23976ed9587d598990a408864a2df391` |

### Why did this happen?

The SHA256 changes when any of these change:
- Source code in `android/accessibility-service/src/`
- Build configuration (`build.gradle.kts`)
- Dependencies or SDK versions

### What to do

1. Review this PR to ensure the change is expected
2. Merge when ready
3. Future releases will use this checksum for APK verification

---
Auto-generated by `build-android-accessibility-service` job in merge workflow