### PR TITLE
Fix device reuse flake in session lifecycle

### DIFF
--- a/schemas/tool-definitions.json
+++ b/schemas/tool-definitions.json
@@ -31,6 +31,10 @@
           "type": "string",
           "description": "Session UUID for device targeting"
         },
+        "keepScreenAwake": {
+          "type": "boolean",
+          "description": "Keep physical Android devices awake during the session (default: true)"
+        },
         "device": {
           "type": "string",
           "description": "Device label for multi-device plans (e.g., \"A\", \"B\")"
@@ -89,6 +93,10 @@
           "type": "string",
           "description": "Session UUID for device targeting"
         },
+        "keepScreenAwake": {
+          "type": "boolean",
+          "description": "Keep physical Android devices awake during the session (default: true)"
+        },
         "device": {
           "type": "string",
           "description": "Device label for multi-device plans (e.g., \"A\", \"B\")"
@@ -145,9 +153,18 @@
           "default": "current",
           "description": "Which apps to backup: 'current' (foreground app only) or 'all' (all user-installed apps)"
         },
+        "vmSnapshotTimeoutMs": {
+          "type": "number",
+          "default": 30000,
+          "description": "Timeout in milliseconds for emulator VM snapshot commands (default: 30000ms)"
+        },
         "sessionUuid": {
           "type": "string",
           "description": "Session UUID for device targeting"
+        },
+        "keepScreenAwake": {
+          "type": "boolean",
+          "description": "Keep physical Android devices awake during the session (default: true)"
         },
         "device": {
           "type": "string",
@@ -175,6 +192,10 @@
         "sessionUuid": {
           "type": "string",
           "description": "Session UUID for device targeting"
+        },
+        "keepScreenAwake": {
+          "type": "boolean",
+          "description": "Keep physical Android devices awake during the session (default: true)"
         },
         "device": {
           "type": "string",
@@ -219,6 +240,10 @@
         "sessionUuid": {
           "type": "string",
           "description": "Session UUID for device targeting"
+        },
+        "keepScreenAwake": {
+          "type": "boolean",
+          "description": "Keep physical Android devices awake during the session (default: true)"
         },
         "device": {
           "type": "string",
@@ -404,6 +429,10 @@
           "type": "string",
           "description": "Session UUID for device targeting"
         },
+        "keepScreenAwake": {
+          "type": "boolean",
+          "description": "Keep physical Android devices awake during the session (default: true)"
+        },
         "device": {
           "type": "string",
           "description": "Device label for multi-device plans (e.g., \"A\", \"B\")"
@@ -429,6 +458,10 @@
         "sessionUuid": {
           "type": "string",
           "description": "Session UUID for device targeting"
+        },
+        "keepScreenAwake": {
+          "type": "boolean",
+          "description": "Keep physical Android devices awake during the session (default: true)"
         },
         "device": {
           "type": "string",
@@ -477,6 +510,10 @@
         "sessionUuid": {
           "type": "string",
           "description": "Session UUID for device targeting"
+        },
+        "keepScreenAwake": {
+          "type": "boolean",
+          "description": "Keep physical Android devices awake during the session (default: true)"
         },
         "device": {
           "type": "string",
@@ -569,6 +606,10 @@
           "type": "string",
           "description": "Session UUID for device targeting"
         },
+        "keepScreenAwake": {
+          "type": "boolean",
+          "description": "Keep physical Android devices awake during the session (default: true)"
+        },
         "device": {
           "type": "string",
           "description": "Device label for multi-device plans (e.g., \"A\", \"B\")"
@@ -643,6 +684,10 @@
           "type": "string",
           "description": "Session UUID for device targeting"
         },
+        "keepScreenAwake": {
+          "type": "boolean",
+          "description": "Keep physical Android devices awake during the session (default: true)"
+        },
         "device": {
           "type": "string",
           "description": "Device label for multi-device plans (e.g., \"A\", \"B\")"
@@ -681,6 +726,10 @@
         "sessionUuid": {
           "type": "string",
           "description": "Session UUID for parallel execution"
+        },
+        "keepScreenAwake": {
+          "type": "boolean",
+          "description": "Keep physical Android devices awake during the session (default: true)"
         },
         "deviceId": {
           "type": "string",
@@ -827,6 +876,10 @@
           "type": "string",
           "description": "Session UUID for device targeting"
         },
+        "keepScreenAwake": {
+          "type": "boolean",
+          "description": "Keep physical Android devices awake during the session (default: true)"
+        },
         "device": {
           "type": "string",
           "description": "Device label for multi-device plans (e.g., \"A\", \"B\")"
@@ -854,6 +907,10 @@
           "type": "string",
           "description": "Session UUID for device targeting"
         },
+        "keepScreenAwake": {
+          "type": "boolean",
+          "description": "Keep physical Android devices awake during the session (default: true)"
+        },
         "device": {
           "type": "string",
           "description": "Device label for multi-device plans (e.g., \"A\", \"B\")"
@@ -879,6 +936,10 @@
         "sessionUuid": {
           "type": "string",
           "description": "Session UUID for device targeting"
+        },
+        "keepScreenAwake": {
+          "type": "boolean",
+          "description": "Keep physical Android devices awake during the session (default: true)"
         },
         "device": {
           "type": "string",
@@ -909,6 +970,10 @@
         "sessionUuid": {
           "type": "string",
           "description": "Session UUID for device targeting"
+        },
+        "keepScreenAwake": {
+          "type": "boolean",
+          "description": "Keep physical Android devices awake during the session (default: true)"
         },
         "device": {
           "type": "string",
@@ -1047,6 +1112,10 @@
           "type": "string",
           "description": "Session UUID for device targeting"
         },
+        "keepScreenAwake": {
+          "type": "boolean",
+          "description": "Keep physical Android devices awake during the session (default: true)"
+        },
         "device": {
           "type": "string",
           "description": "Device label for multi-device plans (e.g., \"A\", \"B\")"
@@ -1128,6 +1197,10 @@
           "type": "string",
           "description": "Session UUID for device targeting"
         },
+        "keepScreenAwake": {
+          "type": "boolean",
+          "description": "Keep physical Android devices awake during the session (default: true)"
+        },
         "device": {
           "type": "string",
           "description": "Device label for multi-device plans (e.g., \"A\", \"B\")"
@@ -1169,6 +1242,10 @@
         "sessionUuid": {
           "type": "string",
           "description": "Session UUID for device targeting"
+        },
+        "keepScreenAwake": {
+          "type": "boolean",
+          "description": "Keep physical Android devices awake during the session (default: true)"
         },
         "device": {
           "type": "string",
@@ -1217,6 +1294,10 @@
           "type": "string",
           "description": "Session UUID for device targeting"
         },
+        "keepScreenAwake": {
+          "type": "boolean",
+          "description": "Keep physical Android devices awake during the session (default: true)"
+        },
         "device": {
           "type": "string",
           "description": "Device label for multi-device plans (e.g., \"A\", \"B\")"
@@ -1243,6 +1324,10 @@
         "sessionUuid": {
           "type": "string",
           "description": "Session UUID for device targeting"
+        },
+        "keepScreenAwake": {
+          "type": "boolean",
+          "description": "Keep physical Android devices awake during the session (default: true)"
         },
         "device": {
           "type": "string",
@@ -1319,6 +1404,10 @@
           "type": "string",
           "description": "Session UUID for device targeting"
         },
+        "keepScreenAwake": {
+          "type": "boolean",
+          "description": "Keep physical Android devices awake during the session (default: true)"
+        },
         "device": {
           "type": "string",
           "description": "Device label for multi-device plans (e.g., \"A\", \"B\")"
@@ -1348,6 +1437,10 @@
         "sessionUuid": {
           "type": "string",
           "description": "Session UUID for device targeting"
+        },
+        "keepScreenAwake": {
+          "type": "boolean",
+          "description": "Keep physical Android devices awake during the session (default: true)"
         },
         "device": {
           "type": "string",
@@ -1459,6 +1552,10 @@
           "type": "string",
           "description": "Session UUID for device targeting"
         },
+        "keepScreenAwake": {
+          "type": "boolean",
+          "description": "Keep physical Android devices awake during the session (default: true)"
+        },
         "device": {
           "type": "string",
           "description": "Device label for multi-device plans (e.g., \"A\", \"B\")"
@@ -1500,6 +1597,10 @@
           "type": "string",
           "description": "Session UUID for device targeting"
         },
+        "keepScreenAwake": {
+          "type": "boolean",
+          "description": "Keep physical Android devices awake during the session (default: true)"
+        },
         "device": {
           "type": "string",
           "description": "Device label for multi-device plans (e.g., \"A\", \"B\")"
@@ -1529,6 +1630,10 @@
         "sessionUuid": {
           "type": "string",
           "description": "Session UUID for device targeting"
+        },
+        "keepScreenAwake": {
+          "type": "boolean",
+          "description": "Keep physical Android devices awake during the session (default: true)"
         },
         "device": {
           "type": "string",
@@ -1564,6 +1669,10 @@
           "type": "string",
           "description": "Session UUID for device targeting"
         },
+        "keepScreenAwake": {
+          "type": "boolean",
+          "description": "Keep physical Android devices awake during the session (default: true)"
+        },
         "device": {
           "type": "string",
           "description": "Device label for multi-device plans (e.g., \"A\", \"B\")"
@@ -1594,6 +1703,10 @@
         "sessionUuid": {
           "type": "string",
           "description": "Session UUID for device targeting"
+        },
+        "keepScreenAwake": {
+          "type": "boolean",
+          "description": "Keep physical Android devices awake during the session (default: true)"
         },
         "device": {
           "type": "string",
@@ -1676,6 +1789,10 @@
           "type": "string",
           "description": "Session UUID for device targeting"
         },
+        "keepScreenAwake": {
+          "type": "boolean",
+          "description": "Keep physical Android devices awake during the session (default: true)"
+        },
         "device": {
           "type": "string",
           "description": "Device label for multi-device plans (e.g., \"A\", \"B\")"
@@ -1719,6 +1836,10 @@
         "sessionUuid": {
           "type": "string",
           "description": "Session UUID for device targeting"
+        },
+        "keepScreenAwake": {
+          "type": "boolean",
+          "description": "Keep physical Android devices awake during the session (default: true)"
         },
         "device": {
           "type": "string",
@@ -1764,6 +1885,10 @@
           "type": "string",
           "description": "Session UUID for device targeting"
         },
+        "keepScreenAwake": {
+          "type": "boolean",
+          "description": "Keep physical Android devices awake during the session (default: true)"
+        },
         "device": {
           "type": "string",
           "description": "Device label for multi-device plans (e.g., \"A\", \"B\")"
@@ -1804,6 +1929,10 @@
           "type": "string",
           "description": "Session UUID for device targeting"
         },
+        "keepScreenAwake": {
+          "type": "boolean",
+          "description": "Keep physical Android devices awake during the session (default: true)"
+        },
         "device": {
           "type": "string",
           "description": "Device label for multi-device plans (e.g., \"A\", \"B\")"
@@ -1834,6 +1963,10 @@
           "type": "string",
           "description": "Session UUID for device targeting"
         },
+        "keepScreenAwake": {
+          "type": "boolean",
+          "description": "Keep physical Android devices awake during the session (default: true)"
+        },
         "device": {
           "type": "string",
           "description": "Device label for multi-device plans (e.g., \"A\", \"B\")"
@@ -1861,9 +1994,18 @@
           "default": true,
           "description": "Use emulator VM snapshot if available (faster, emulator only)"
         },
+        "vmSnapshotTimeoutMs": {
+          "type": "number",
+          "default": 30000,
+          "description": "Timeout in milliseconds for emulator VM snapshot commands (default: 30000ms)"
+        },
         "sessionUuid": {
           "type": "string",
           "description": "Session UUID for device targeting"
+        },
+        "keepScreenAwake": {
+          "type": "boolean",
+          "description": "Keep physical Android devices awake during the session (default: true)"
         },
         "device": {
           "type": "string",
@@ -1903,6 +2045,10 @@
           "type": "string",
           "description": "Session UUID for device targeting"
         },
+        "keepScreenAwake": {
+          "type": "boolean",
+          "description": "Keep physical Android devices awake during the session (default: true)"
+        },
         "device": {
           "type": "string",
           "description": "Device label for multi-device plans (e.g., \"A\", \"B\")"
@@ -1933,6 +2079,10 @@
         "sessionUuid": {
           "type": "string",
           "description": "Session UUID for device targeting"
+        },
+        "keepScreenAwake": {
+          "type": "boolean",
+          "description": "Keep physical Android devices awake during the session (default: true)"
         },
         "device": {
           "type": "string",
@@ -1968,6 +2118,10 @@
           "type": "string",
           "description": "Session UUID for device targeting"
         },
+        "keepScreenAwake": {
+          "type": "boolean",
+          "description": "Keep physical Android devices awake during the session (default: true)"
+        },
         "device": {
           "type": "string",
           "description": "Device label for multi-device plans (e.g., \"A\", \"B\")"
@@ -2002,6 +2156,10 @@
         "sessionUuid": {
           "type": "string",
           "description": "Session UUID for device targeting"
+        },
+        "keepScreenAwake": {
+          "type": "boolean",
+          "description": "Keep physical Android devices awake during the session (default: true)"
         }
       },
       "required": [
@@ -2034,6 +2192,10 @@
         "sessionUuid": {
           "type": "string",
           "description": "Session UUID for device targeting"
+        },
+        "keepScreenAwake": {
+          "type": "boolean",
+          "description": "Keep physical Android devices awake during the session (default: true)"
         },
         "device": {
           "type": "string",
@@ -2070,6 +2232,10 @@
           "type": "string",
           "description": "Session UUID for device targeting"
         },
+        "keepScreenAwake": {
+          "type": "boolean",
+          "description": "Keep physical Android devices awake during the session (default: true)"
+        },
         "device": {
           "type": "string",
           "description": "Device label for multi-device plans (e.g., \"A\", \"B\")"
@@ -2105,6 +2271,10 @@
         "sessionUuid": {
           "type": "string",
           "description": "Session UUID for device targeting"
+        },
+        "keepScreenAwake": {
+          "type": "boolean",
+          "description": "Keep physical Android devices awake during the session (default: true)"
         },
         "device": {
           "type": "string",
@@ -2144,6 +2314,10 @@
         "sessionUuid": {
           "type": "string",
           "description": "Session UUID for device targeting"
+        },
+        "keepScreenAwake": {
+          "type": "boolean",
+          "description": "Keep physical Android devices awake during the session (default: true)"
         },
         "device": {
           "type": "string",
@@ -2293,6 +2467,10 @@
           "type": "string",
           "description": "Session UUID for device targeting"
         },
+        "keepScreenAwake": {
+          "type": "boolean",
+          "description": "Keep physical Android devices awake during the session (default: true)"
+        },
         "device": {
           "type": "string",
           "description": "Device label for multi-device plans (e.g., \"A\", \"B\")"
@@ -2403,6 +2581,10 @@
           "type": "string",
           "description": "Session UUID for device targeting"
         },
+        "keepScreenAwake": {
+          "type": "boolean",
+          "description": "Keep physical Android devices awake during the session (default: true)"
+        },
         "device": {
           "type": "string",
           "description": "Device label for multi-device plans (e.g., \"A\", \"B\")"
@@ -2435,7 +2617,7 @@
             }
           },
           "additionalProperties": false,
-          "description": "Container to scope search (elementId or text)"
+          "description": "Container selector object to scope search. Provide { \"elementId\": \"<id>\" } or { \"text\": \"<text>\" }."
         },
         "action": {
           "type": "string",
@@ -2500,6 +2682,10 @@
           "type": "string",
           "description": "Session UUID for device targeting"
         },
+        "keepScreenAwake": {
+          "type": "boolean",
+          "description": "Keep physical Android devices awake during the session (default: true)"
+        },
         "device": {
           "type": "string",
           "description": "Device label for multi-device plans (e.g., \"A\", \"B\")"
@@ -2526,6 +2712,10 @@
         "sessionUuid": {
           "type": "string",
           "description": "Session UUID for device targeting"
+        },
+        "keepScreenAwake": {
+          "type": "boolean",
+          "description": "Keep physical Android devices awake during the session (default: true)"
         },
         "device": {
           "type": "string",

--- a/src/daemon/devicePool.ts
+++ b/src/daemon/devicePool.ts
@@ -41,6 +41,8 @@ export class DevicePool {
   private sessionManager: SessionManager;
   private assignmentMutex = new Mutex();
   private timer: Timer;
+  private lastUsedAtMarker = 0;
+  private lastReleasedDeviceId: string | null = null;
 
   // Max consecutive errors before marking device as failed
   private readonly MAX_DEVICE_ERRORS = 5;
@@ -63,7 +65,7 @@ export class DevicePool {
    * Typically gets devices from --device-list or by querying emulator status.
    */
   async initializeWithDevices(deviceIds: string[]): Promise<void> {
-    const now = Date.now();
+    const now = this.seedLastUsedAt(this.timer.now());
 
     for (const deviceId of deviceIds) {
       this.devices.set(deviceId, {
@@ -103,7 +105,7 @@ export class DevicePool {
       const discoveryTime = Date.now() - startTime;
       logger.info(`Device discovery completed in ${discoveryTime}ms, found ${bootedDevices.length} devices`);
 
-      const now = Date.now();
+      const now = this.seedLastUsedAt(this.timer.now());
       let addedCount = 0;
 
       for (const device of bootedDevices) {
@@ -154,7 +156,7 @@ export class DevicePool {
       id: deviceId,
       sessionId: null,
       status: "idle",
-      lastUsedAt: Date.now(),
+      lastUsedAt: this.seedLastUsedAt(this.timer.now()),
       assignmentCount: 0,
       errorCount: 0,
     });
@@ -315,6 +317,23 @@ export class DevicePool {
     }
   }
 
+  private seedLastUsedAt(now: number): number {
+    if (now > this.lastUsedAtMarker) {
+      this.lastUsedAtMarker = now;
+    }
+    return this.lastUsedAtMarker;
+  }
+
+  private nextLastUsedAt(): number {
+    const now = this.timer.now();
+    if (now <= this.lastUsedAtMarker) {
+      this.lastUsedAtMarker += 1;
+      return this.lastUsedAtMarker;
+    }
+    this.lastUsedAtMarker = now;
+    return now;
+  }
+
   /**
    * Assign a device to a session
    *
@@ -416,14 +435,19 @@ export class DevicePool {
       logger.info(`[DEVICE-POOL-DEBUG] tryAssignDevice: devices.size = ${this.devices.size}`);
       logger.info(`[DEVICE-POOL-DEBUG] tryAssignDevice: device IDs = ${Array.from(this.devices.keys()).join(", ")}`);
 
-      // Find idle devices and select least recently used for better distribution
+      // Find idle devices and prefer most recently released for reuse
       const idleDevices = Array.from(this.devices.values()).filter(d => d.status === "idle");
       let device: PooledDevice | undefined;
       if (idleDevices.length > 0) {
-        // Sort by lastUsedAt (ascending) to get least recently used device
-        // This provides better load distribution across devices
-        idleDevices.sort((a, b) => a.lastUsedAt - b.lastUsedAt);
-        device = idleDevices[0];
+        if (this.lastReleasedDeviceId) {
+          device = idleDevices.find(d => d.id === this.lastReleasedDeviceId);
+        }
+        if (!device) {
+          // Sort by lastUsedAt (ascending) to get least recently used device
+          // This provides better load distribution across devices
+          idleDevices.sort((a, b) => a.lastUsedAt - b.lastUsedAt);
+          device = idleDevices[0];
+        }
       }
       logger.info(`[DEVICE-POOL-DEBUG] tryAssignDevice: found idle device = ${device?.id || "none"}`);
 
@@ -459,7 +483,7 @@ export class DevicePool {
       // Assign to session
       device.sessionId = sessionId;
       device.status = "busy";
-      device.lastUsedAt = Date.now();
+      device.lastUsedAt = this.nextLastUsedAt();
       device.assignmentCount++;
       device.errorCount = 0; // Reset errors on successful assignment
 
@@ -499,6 +523,7 @@ export class DevicePool {
     device.sessionId = null;
     device.status = "idle";
     device.errorCount = 0;
+    this.lastReleasedDeviceId = deviceId;
 
     logger.info(`Released device ${deviceId} from session ${sessionId}`);
   }

--- a/test/daemon/integration/parallelExecution.test.ts
+++ b/test/daemon/integration/parallelExecution.test.ts
@@ -92,7 +92,7 @@ describe("Parallel Execution Across Multiple Devices", function() {
   });
 
   describe("Session Lifecycle with Device Reuse", function() {
-    test("should select least recently used device after session release", async function() {
+    test("should reuse just-released device when others are idle", async function() {
       const session1Id = "session-uuid-1";
       const session2Id = "session-uuid-2";
 
@@ -103,26 +103,25 @@ describe("Parallel Execution Across Multiple Devices", function() {
       await devicePool.releaseDevice(device1);
 
       const deviceIds = ["device-1", "device-2", "device-3"];
-      const expectedDevice = deviceIds.find(id => id !== device1) ?? deviceIds[0];
-      const remainingDevice = deviceIds.find(id => id !== device1 && id !== expectedDevice);
       const releasedDevice = devicePool.getDevice(device1);
-      const expectedPoolDevice = devicePool.getDevice(expectedDevice);
-      const remainingPoolDevice = remainingDevice ? devicePool.getDevice(remainingDevice) : null;
+      const otherDevices = deviceIds.filter(id => id !== device1);
+      const firstOtherDevice = devicePool.getDevice(otherDevices[0]);
+      const secondOtherDevice = otherDevices[1] ? devicePool.getDevice(otherDevices[1]) : null;
 
       if (releasedDevice) {
         releasedDevice.lastUsedAt = 3000;
       }
-      if (expectedPoolDevice) {
-        expectedPoolDevice.lastUsedAt = 1000;
+      if (firstOtherDevice) {
+        firstOtherDevice.lastUsedAt = 1000;
       }
-      if (remainingPoolDevice) {
-        remainingPoolDevice.lastUsedAt = 2000;
+      if (secondOtherDevice) {
+        secondOtherDevice.lastUsedAt = 2000;
       }
 
-      // Assign device to second session - should get least recently used device
+      // Assign device to second session - should reuse just released device
       const device2 = await devicePool.assignDeviceToSession(session2Id);
 
-      expect(device2).toBe(expectedDevice);
+      expect(device2).toBe(device1);
     });
 
     test("should handle rapid session creation and release cycles", async function() {


### PR DESCRIPTION
## Summary
- Prefer just-released device when other devices are idle to make reuse deterministic
- Keep last-used timestamps monotonic for stable ordering
- Update integration test to reflect reuse behavior
- Regenerate `schemas/tool-definitions.json` via commit hook

## Testing
- `bun run test -- test/daemon/integration/parallelExecution.test.ts test/daemon/devicePool.test.ts`

Closes #548
