### PR TITLE
Enable element search across window hierarchies

### DIFF
--- a/schemas/tool-definitions.json
+++ b/schemas/tool-definitions.json
@@ -31,6 +31,10 @@
           "type": "string",
           "description": "Session UUID for device targeting"
         },
+        "keepScreenAwake": {
+          "type": "boolean",
+          "description": "Keep physical Android devices awake during the session (default: true)"
+        },
         "device": {
           "type": "string",
           "description": "Device label for multi-device plans (e.g., \"A\", \"B\")"
@@ -89,6 +93,10 @@
           "type": "string",
           "description": "Session UUID for device targeting"
         },
+        "keepScreenAwake": {
+          "type": "boolean",
+          "description": "Keep physical Android devices awake during the session (default: true)"
+        },
         "device": {
           "type": "string",
           "description": "Device label for multi-device plans (e.g., \"A\", \"B\")"
@@ -145,9 +153,18 @@
           "default": "current",
           "description": "Which apps to backup: 'current' (foreground app only) or 'all' (all user-installed apps)"
         },
+        "vmSnapshotTimeoutMs": {
+          "type": "number",
+          "default": 30000,
+          "description": "Timeout in milliseconds for emulator VM snapshot commands (default: 30000ms)"
+        },
         "sessionUuid": {
           "type": "string",
           "description": "Session UUID for device targeting"
+        },
+        "keepScreenAwake": {
+          "type": "boolean",
+          "description": "Keep physical Android devices awake during the session (default: true)"
         },
         "device": {
           "type": "string",
@@ -175,6 +192,10 @@
         "sessionUuid": {
           "type": "string",
           "description": "Session UUID for device targeting"
+        },
+        "keepScreenAwake": {
+          "type": "boolean",
+          "description": "Keep physical Android devices awake during the session (default: true)"
         },
         "device": {
           "type": "string",
@@ -219,6 +240,10 @@
         "sessionUuid": {
           "type": "string",
           "description": "Session UUID for device targeting"
+        },
+        "keepScreenAwake": {
+          "type": "boolean",
+          "description": "Keep physical Android devices awake during the session (default: true)"
         },
         "device": {
           "type": "string",
@@ -404,6 +429,10 @@
           "type": "string",
           "description": "Session UUID for device targeting"
         },
+        "keepScreenAwake": {
+          "type": "boolean",
+          "description": "Keep physical Android devices awake during the session (default: true)"
+        },
         "device": {
           "type": "string",
           "description": "Device label for multi-device plans (e.g., \"A\", \"B\")"
@@ -429,6 +458,10 @@
         "sessionUuid": {
           "type": "string",
           "description": "Session UUID for device targeting"
+        },
+        "keepScreenAwake": {
+          "type": "boolean",
+          "description": "Keep physical Android devices awake during the session (default: true)"
         },
         "device": {
           "type": "string",
@@ -477,6 +510,10 @@
         "sessionUuid": {
           "type": "string",
           "description": "Session UUID for device targeting"
+        },
+        "keepScreenAwake": {
+          "type": "boolean",
+          "description": "Keep physical Android devices awake during the session (default: true)"
         },
         "device": {
           "type": "string",
@@ -569,6 +606,10 @@
           "type": "string",
           "description": "Session UUID for device targeting"
         },
+        "keepScreenAwake": {
+          "type": "boolean",
+          "description": "Keep physical Android devices awake during the session (default: true)"
+        },
         "device": {
           "type": "string",
           "description": "Device label for multi-device plans (e.g., \"A\", \"B\")"
@@ -643,6 +684,10 @@
           "type": "string",
           "description": "Session UUID for device targeting"
         },
+        "keepScreenAwake": {
+          "type": "boolean",
+          "description": "Keep physical Android devices awake during the session (default: true)"
+        },
         "device": {
           "type": "string",
           "description": "Device label for multi-device plans (e.g., \"A\", \"B\")"
@@ -681,6 +726,10 @@
         "sessionUuid": {
           "type": "string",
           "description": "Session UUID for parallel execution"
+        },
+        "keepScreenAwake": {
+          "type": "boolean",
+          "description": "Keep physical Android devices awake during the session (default: true)"
         },
         "deviceId": {
           "type": "string",
@@ -827,6 +876,10 @@
           "type": "string",
           "description": "Session UUID for device targeting"
         },
+        "keepScreenAwake": {
+          "type": "boolean",
+          "description": "Keep physical Android devices awake during the session (default: true)"
+        },
         "device": {
           "type": "string",
           "description": "Device label for multi-device plans (e.g., \"A\", \"B\")"
@@ -854,6 +907,10 @@
           "type": "string",
           "description": "Session UUID for device targeting"
         },
+        "keepScreenAwake": {
+          "type": "boolean",
+          "description": "Keep physical Android devices awake during the session (default: true)"
+        },
         "device": {
           "type": "string",
           "description": "Device label for multi-device plans (e.g., \"A\", \"B\")"
@@ -879,6 +936,10 @@
         "sessionUuid": {
           "type": "string",
           "description": "Session UUID for device targeting"
+        },
+        "keepScreenAwake": {
+          "type": "boolean",
+          "description": "Keep physical Android devices awake during the session (default: true)"
         },
         "device": {
           "type": "string",
@@ -909,6 +970,10 @@
         "sessionUuid": {
           "type": "string",
           "description": "Session UUID for device targeting"
+        },
+        "keepScreenAwake": {
+          "type": "boolean",
+          "description": "Keep physical Android devices awake during the session (default: true)"
         },
         "device": {
           "type": "string",
@@ -1047,6 +1112,10 @@
           "type": "string",
           "description": "Session UUID for device targeting"
         },
+        "keepScreenAwake": {
+          "type": "boolean",
+          "description": "Keep physical Android devices awake during the session (default: true)"
+        },
         "device": {
           "type": "string",
           "description": "Device label for multi-device plans (e.g., \"A\", \"B\")"
@@ -1128,6 +1197,10 @@
           "type": "string",
           "description": "Session UUID for device targeting"
         },
+        "keepScreenAwake": {
+          "type": "boolean",
+          "description": "Keep physical Android devices awake during the session (default: true)"
+        },
         "device": {
           "type": "string",
           "description": "Device label for multi-device plans (e.g., \"A\", \"B\")"
@@ -1169,6 +1242,10 @@
         "sessionUuid": {
           "type": "string",
           "description": "Session UUID for device targeting"
+        },
+        "keepScreenAwake": {
+          "type": "boolean",
+          "description": "Keep physical Android devices awake during the session (default: true)"
         },
         "device": {
           "type": "string",
@@ -1217,6 +1294,10 @@
           "type": "string",
           "description": "Session UUID for device targeting"
         },
+        "keepScreenAwake": {
+          "type": "boolean",
+          "description": "Keep physical Android devices awake during the session (default: true)"
+        },
         "device": {
           "type": "string",
           "description": "Device label for multi-device plans (e.g., \"A\", \"B\")"
@@ -1243,6 +1324,10 @@
         "sessionUuid": {
           "type": "string",
           "description": "Session UUID for device targeting"
+        },
+        "keepScreenAwake": {
+          "type": "boolean",
+          "description": "Keep physical Android devices awake during the session (default: true)"
         },
         "device": {
           "type": "string",
@@ -1319,6 +1404,10 @@
           "type": "string",
           "description": "Session UUID for device targeting"
         },
+        "keepScreenAwake": {
+          "type": "boolean",
+          "description": "Keep physical Android devices awake during the session (default: true)"
+        },
         "device": {
           "type": "string",
           "description": "Device label for multi-device plans (e.g., \"A\", \"B\")"
@@ -1348,6 +1437,10 @@
         "sessionUuid": {
           "type": "string",
           "description": "Session UUID for device targeting"
+        },
+        "keepScreenAwake": {
+          "type": "boolean",
+          "description": "Keep physical Android devices awake during the session (default: true)"
         },
         "device": {
           "type": "string",
@@ -1459,6 +1552,10 @@
           "type": "string",
           "description": "Session UUID for device targeting"
         },
+        "keepScreenAwake": {
+          "type": "boolean",
+          "description": "Keep physical Android devices awake during the session (default: true)"
+        },
         "device": {
           "type": "string",
           "description": "Device label for multi-device plans (e.g., \"A\", \"B\")"
@@ -1500,6 +1597,10 @@
           "type": "string",
           "description": "Session UUID for device targeting"
         },
+        "keepScreenAwake": {
+          "type": "boolean",
+          "description": "Keep physical Android devices awake during the session (default: true)"
+        },
         "device": {
           "type": "string",
           "description": "Device label for multi-device plans (e.g., \"A\", \"B\")"
@@ -1529,6 +1630,10 @@
         "sessionUuid": {
           "type": "string",
           "description": "Session UUID for device targeting"
+        },
+        "keepScreenAwake": {
+          "type": "boolean",
+          "description": "Keep physical Android devices awake during the session (default: true)"
         },
         "device": {
           "type": "string",
@@ -1564,6 +1669,10 @@
           "type": "string",
           "description": "Session UUID for device targeting"
         },
+        "keepScreenAwake": {
+          "type": "boolean",
+          "description": "Keep physical Android devices awake during the session (default: true)"
+        },
         "device": {
           "type": "string",
           "description": "Device label for multi-device plans (e.g., \"A\", \"B\")"
@@ -1594,6 +1703,10 @@
         "sessionUuid": {
           "type": "string",
           "description": "Session UUID for device targeting"
+        },
+        "keepScreenAwake": {
+          "type": "boolean",
+          "description": "Keep physical Android devices awake during the session (default: true)"
         },
         "device": {
           "type": "string",
@@ -1676,6 +1789,10 @@
           "type": "string",
           "description": "Session UUID for device targeting"
         },
+        "keepScreenAwake": {
+          "type": "boolean",
+          "description": "Keep physical Android devices awake during the session (default: true)"
+        },
         "device": {
           "type": "string",
           "description": "Device label for multi-device plans (e.g., \"A\", \"B\")"
@@ -1719,6 +1836,10 @@
         "sessionUuid": {
           "type": "string",
           "description": "Session UUID for device targeting"
+        },
+        "keepScreenAwake": {
+          "type": "boolean",
+          "description": "Keep physical Android devices awake during the session (default: true)"
         },
         "device": {
           "type": "string",
@@ -1764,6 +1885,10 @@
           "type": "string",
           "description": "Session UUID for device targeting"
         },
+        "keepScreenAwake": {
+          "type": "boolean",
+          "description": "Keep physical Android devices awake during the session (default: true)"
+        },
         "device": {
           "type": "string",
           "description": "Device label for multi-device plans (e.g., \"A\", \"B\")"
@@ -1804,6 +1929,10 @@
           "type": "string",
           "description": "Session UUID for device targeting"
         },
+        "keepScreenAwake": {
+          "type": "boolean",
+          "description": "Keep physical Android devices awake during the session (default: true)"
+        },
         "device": {
           "type": "string",
           "description": "Device label for multi-device plans (e.g., \"A\", \"B\")"
@@ -1834,6 +1963,10 @@
           "type": "string",
           "description": "Session UUID for device targeting"
         },
+        "keepScreenAwake": {
+          "type": "boolean",
+          "description": "Keep physical Android devices awake during the session (default: true)"
+        },
         "device": {
           "type": "string",
           "description": "Device label for multi-device plans (e.g., \"A\", \"B\")"
@@ -1861,9 +1994,18 @@
           "default": true,
           "description": "Use emulator VM snapshot if available (faster, emulator only)"
         },
+        "vmSnapshotTimeoutMs": {
+          "type": "number",
+          "default": 30000,
+          "description": "Timeout in milliseconds for emulator VM snapshot commands (default: 30000ms)"
+        },
         "sessionUuid": {
           "type": "string",
           "description": "Session UUID for device targeting"
+        },
+        "keepScreenAwake": {
+          "type": "boolean",
+          "description": "Keep physical Android devices awake during the session (default: true)"
         },
         "device": {
           "type": "string",
@@ -1903,6 +2045,10 @@
           "type": "string",
           "description": "Session UUID for device targeting"
         },
+        "keepScreenAwake": {
+          "type": "boolean",
+          "description": "Keep physical Android devices awake during the session (default: true)"
+        },
         "device": {
           "type": "string",
           "description": "Device label for multi-device plans (e.g., \"A\", \"B\")"
@@ -1933,6 +2079,10 @@
         "sessionUuid": {
           "type": "string",
           "description": "Session UUID for device targeting"
+        },
+        "keepScreenAwake": {
+          "type": "boolean",
+          "description": "Keep physical Android devices awake during the session (default: true)"
         },
         "device": {
           "type": "string",
@@ -1968,6 +2118,10 @@
           "type": "string",
           "description": "Session UUID for device targeting"
         },
+        "keepScreenAwake": {
+          "type": "boolean",
+          "description": "Keep physical Android devices awake during the session (default: true)"
+        },
         "device": {
           "type": "string",
           "description": "Device label for multi-device plans (e.g., \"A\", \"B\")"
@@ -2002,6 +2156,10 @@
         "sessionUuid": {
           "type": "string",
           "description": "Session UUID for device targeting"
+        },
+        "keepScreenAwake": {
+          "type": "boolean",
+          "description": "Keep physical Android devices awake during the session (default: true)"
         }
       },
       "required": [
@@ -2034,6 +2192,10 @@
         "sessionUuid": {
           "type": "string",
           "description": "Session UUID for device targeting"
+        },
+        "keepScreenAwake": {
+          "type": "boolean",
+          "description": "Keep physical Android devices awake during the session (default: true)"
         },
         "device": {
           "type": "string",
@@ -2070,6 +2232,10 @@
           "type": "string",
           "description": "Session UUID for device targeting"
         },
+        "keepScreenAwake": {
+          "type": "boolean",
+          "description": "Keep physical Android devices awake during the session (default: true)"
+        },
         "device": {
           "type": "string",
           "description": "Device label for multi-device plans (e.g., \"A\", \"B\")"
@@ -2105,6 +2271,10 @@
         "sessionUuid": {
           "type": "string",
           "description": "Session UUID for device targeting"
+        },
+        "keepScreenAwake": {
+          "type": "boolean",
+          "description": "Keep physical Android devices awake during the session (default: true)"
         },
         "device": {
           "type": "string",
@@ -2144,6 +2314,10 @@
         "sessionUuid": {
           "type": "string",
           "description": "Session UUID for device targeting"
+        },
+        "keepScreenAwake": {
+          "type": "boolean",
+          "description": "Keep physical Android devices awake during the session (default: true)"
         },
         "device": {
           "type": "string",
@@ -2293,6 +2467,10 @@
           "type": "string",
           "description": "Session UUID for device targeting"
         },
+        "keepScreenAwake": {
+          "type": "boolean",
+          "description": "Keep physical Android devices awake during the session (default: true)"
+        },
         "device": {
           "type": "string",
           "description": "Device label for multi-device plans (e.g., \"A\", \"B\")"
@@ -2403,6 +2581,10 @@
           "type": "string",
           "description": "Session UUID for device targeting"
         },
+        "keepScreenAwake": {
+          "type": "boolean",
+          "description": "Keep physical Android devices awake during the session (default: true)"
+        },
         "device": {
           "type": "string",
           "description": "Device label for multi-device plans (e.g., \"A\", \"B\")"
@@ -2435,7 +2617,7 @@
             }
           },
           "additionalProperties": false,
-          "description": "Container to scope search (elementId or text)"
+          "description": "Container selector object to scope search. Provide { \"elementId\": \"<id>\" } or { \"text\": \"<text>\" }."
         },
         "action": {
           "type": "string",
@@ -2500,6 +2682,10 @@
           "type": "string",
           "description": "Session UUID for device targeting"
         },
+        "keepScreenAwake": {
+          "type": "boolean",
+          "description": "Keep physical Android devices awake during the session (default: true)"
+        },
         "device": {
           "type": "string",
           "description": "Device label for multi-device plans (e.g., \"A\", \"B\")"
@@ -2526,6 +2712,10 @@
         "sessionUuid": {
           "type": "string",
           "description": "Session UUID for device targeting"
+        },
+        "keepScreenAwake": {
+          "type": "boolean",
+          "description": "Keep physical Android devices awake during the session (default: true)"
         },
         "device": {
           "type": "string",

--- a/src/features/utility/ElementFinder.ts
+++ b/src/features/utility/ElementFinder.ts
@@ -27,19 +27,11 @@ export class ElementFinder {
     return this.findContainerNode(viewHierarchy, container) !== null;
   }
 
-  private findContainerNode(
-    viewHierarchy: ViewHierarchyResult,
-    container: { elementId?: string; text?: string }
+  private findContainerNodeInRoots(
+    rootNodes: ViewHierarchyNode[],
+    container: { elementId?: string; text?: string },
+    matchesContainerText: ((input?: string) => boolean) | null
   ): ViewHierarchyNode | null {
-    if (!viewHierarchy || !container) {
-      return null;
-    }
-
-    const matchesContainerText = container.text
-      ? this.textMatcher.createTextMatcher(container.text, true, false)
-      : null;
-    const rootNodes = this.parser.extractRootNodes(viewHierarchy);
-
     for (const rootNode of rootNodes) {
       let containerNode: ViewHierarchyNode | null = null;
       this.parser.traverseNode(rootNode, (node: ViewHierarchyNode) => {
@@ -78,44 +70,59 @@ export class ElementFinder {
     return null;
   }
 
-  /**
-   * Find an element in the view hierarchy that matches the specified text
-   * @param viewHierarchy - The view hierarchy to search
-   * @param text - The text to search for
-   * @param container - Container element selector to restrict the search within its child nodes
-   * @param fuzzyMatch - Whether to use fuzzy matching (partial text match)
-   * @param caseSensitive - Whether to use case-sensitive matching
-   * @returns The found element or null
-   */
-  findElementByText(
+  private findContainerNode(
     viewHierarchy: ViewHierarchyResult,
-    text: string,
-    container: { elementId?: string; text?: string } | null = null,
-    fuzzyMatch: boolean = true,
-    caseSensitive: boolean = false
-  ): Element | null {
-    if (!viewHierarchy || !text) {
+    container: { elementId?: string; text?: string }
+  ): ViewHierarchyNode | null {
+    if (!viewHierarchy || !container) {
       return null;
     }
 
-    // Create matcher function once instead of repeatedly in the loop
-    const matchesText = this.textMatcher.createTextMatcher(text, fuzzyMatch, caseSensitive);
+    const matchesContainerText = container.text
+      ? this.textMatcher.createTextMatcher(container.text, true, false)
+      : null;
     const rootNodes = this.parser.extractRootNodes(viewHierarchy);
+    const containerInMain = this.findContainerNodeInRoots(
+      rootNodes,
+      container,
+      matchesContainerText
+    );
+    if (containerInMain) {
+      return containerInMain;
+    }
+
+    const windowRootGroups = this.parser.extractWindowRootGroups(viewHierarchy, "topmost-first");
+    for (const windowRoots of windowRootGroups) {
+      const containerInWindow = this.findContainerNodeInRoots(
+        windowRoots,
+        container,
+        matchesContainerText
+      );
+      if (containerInWindow) {
+        return containerInWindow;
+      }
+    }
+
+    return null;
+  }
+
+  private sortElementsByArea(elements: Element[]): void {
+    elements.sort((a, b) => {
+      const aArea = (a.bounds.right - a.bounds.left) * (a.bounds.bottom - a.bounds.top);
+      const bArea = (b.bounds.right - b.bounds.left) * (b.bounds.bottom - b.bounds.top);
+      return aArea - bArea;
+    });
+  }
+
+  private findElementByTextInRoots(
+    rootNodes: ViewHierarchyNode[],
+    text: string,
+    matchesText: (input?: string) => boolean
+  ): Element | null {
     const matches: Element[] = [];
     const exactMatches: Element[] = [];
 
-    const containerNode = container
-      ? this.findContainerNode(viewHierarchy, container)
-      : null;
-
-    if (container && !containerNode) {
-      // Container not found, return null
-      return null;
-    }
-
-    // Search only within the container node's subtree
-    const searchNodes = containerNode ? [containerNode] : rootNodes;
-    for (const searchNode of searchNodes) {
+    for (const searchNode of rootNodes) {
       this.parser.traverseNode(searchNode, (node: any) => {
         const nodeProperties = this.parser.extractNodeProperties(node);
         logger.info(`[Element] node: ${nodeProperties["text"]} ${nodeProperties["content-desc"]} ${nodeProperties["class"]}`);
@@ -185,21 +192,144 @@ export class ElementFinder {
     }
 
     if (exactMatches.length > 0) {
-      exactMatches.sort((a, b) => {
-        const aArea = (a.bounds.right - a.bounds.left) * (a.bounds.bottom - a.bounds.top);
-        const bArea = (b.bounds.right - b.bounds.left) * (b.bounds.bottom - b.bounds.top);
-        return aArea - bArea;
-      });
+      this.sortElementsByArea(exactMatches);
       return exactMatches[0];
     }
 
     if (matches.length > 0) {
-      matches.sort((a, b) => {
-        const aArea = (a.bounds.right - a.bounds.left) * (a.bounds.bottom - a.bounds.top);
-        const bArea = (b.bounds.right - b.bounds.left) * (b.bounds.bottom - b.bounds.top);
-        return aArea - bArea;
-      });
+      this.sortElementsByArea(matches);
       return matches[0];
+    }
+
+    return null;
+  }
+
+  private findElementByResourceIdInRoots(
+    rootNodes: ViewHierarchyNode[],
+    resourceId: string,
+    partialMatch: boolean
+  ): Element | null {
+    const matches: Element[] = [];
+
+    for (const searchNode of rootNodes) {
+      this.parser.traverseNode(searchNode, (node: any) => {
+        const nodeProperties = this.parser.extractNodeProperties(node);
+        if (nodeProperties["resource-id"] && typeof nodeProperties["resource-id"] === "string") {
+          const nodeResourceId = nodeProperties["resource-id"];
+          if (
+            nodeResourceId === resourceId ||
+            (partialMatch && nodeResourceId.toLowerCase().includes(resourceId.toLowerCase()))
+          ) {
+            const parsedNode = this.parser.parseNodeBounds(node);
+            if (parsedNode) {
+              matches.push(parsedNode);
+            }
+          }
+        }
+      });
+    }
+
+    if (matches.length > 0) {
+      this.sortElementsByArea(matches);
+      return matches[0];
+    }
+
+    return null;
+  }
+
+  private findScrollableContainerInRoots(rootNodes: ViewHierarchyNode[]): Element | null {
+    for (const rootNode of rootNodes) {
+      let foundScrollable: Element | null = null;
+      this.parser.traverseNode(rootNode, (node: any) => {
+        if (foundScrollable) {return;} // Already found one
+        const nodeProperties = this.parser.extractNodeProperties(node);
+        if (nodeProperties.scrollable === "true" || nodeProperties.scrollable === true) {
+          const parsedNode = this.parser.parseNodeBounds(node);
+          if (parsedNode) {
+            foundScrollable = parsedNode;
+          }
+        }
+      });
+      if (foundScrollable) {
+        return foundScrollable;
+      }
+    }
+
+    return null;
+  }
+
+  private findFocusedTextInputInRoots(rootNodes: ViewHierarchyNode[], inputClasses: string[]): Element | null {
+    for (const rootNode of rootNodes) {
+      let foundElement: Element | null = null;
+      this.parser.traverseNode(rootNode, (node: any) => {
+        if (foundElement) {return;} // Already found one
+
+        const nodeProperties = this.parser.extractNodeProperties(node);
+        // Check for both 'class' and 'className' property names
+        const nodeClass = nodeProperties.class || nodeProperties.className;
+        if ((nodeProperties.focused === "true" || nodeProperties.focused === true) &&
+          nodeClass &&
+          inputClasses.some(cls => nodeClass.includes(cls))) {
+          const parsedNode = this.parser.parseNodeBounds(node);
+          if (parsedNode) {
+            foundElement = parsedNode;
+          }
+        }
+      });
+
+      if (foundElement) {return foundElement;}
+    }
+
+    return null;
+  }
+
+  /**
+   * Find an element in the view hierarchy that matches the specified text
+   * @param viewHierarchy - The view hierarchy to search
+   * @param text - The text to search for
+   * @param container - Container element selector to restrict the search within its child nodes
+   * @param fuzzyMatch - Whether to use fuzzy matching (partial text match)
+   * @param caseSensitive - Whether to use case-sensitive matching
+   * @returns The found element or null
+   */
+  findElementByText(
+    viewHierarchy: ViewHierarchyResult,
+    text: string,
+    container: { elementId?: string; text?: string } | null = null,
+    fuzzyMatch: boolean = true,
+    caseSensitive: boolean = false
+  ): Element | null {
+    if (!viewHierarchy || !text) {
+      return null;
+    }
+
+    // Create matcher function once instead of repeatedly in the loop
+    const matchesText = this.textMatcher.createTextMatcher(text, fuzzyMatch, caseSensitive);
+    const containerNode = container
+      ? this.findContainerNode(viewHierarchy, container)
+      : null;
+
+    if (container && !containerNode) {
+      // Container not found, return null
+      return null;
+    }
+
+    if (containerNode) {
+      return this.findElementByTextInRoots([containerNode], text, matchesText);
+    }
+
+    const rootNodes = this.parser.extractRootNodes(viewHierarchy);
+    const mainMatch = this.findElementByTextInRoots(rootNodes, text, matchesText);
+    if (mainMatch) {
+      return mainMatch;
+    }
+
+    const windowRootGroups = this.parser.extractWindowRootGroups(viewHierarchy, "topmost-first");
+    for (const windowRoots of windowRootGroups) {
+      const windowMatch = this.findElementByTextInRoots(windowRoots, text, matchesText);
+      if (windowMatch) {
+        return windowMatch;
+      }
     }
 
     return null;
@@ -223,9 +353,6 @@ export class ElementFinder {
       return null;
     }
 
-    const rootNodes = this.parser.extractRootNodes(viewHierarchy);
-    const matches: Element[] = [];
-
     const containerNode = container
       ? this.findContainerNode(viewHierarchy, container)
       : null;
@@ -235,30 +362,22 @@ export class ElementFinder {
       return null;
     }
 
-    const searchNodes = containerNode ? [containerNode] : rootNodes;
-
-    for (const searchNode of searchNodes) {
-      this.parser.traverseNode(searchNode, (node: any) => {
-        const nodeProperties = this.parser.extractNodeProperties(node);
-        if (nodeProperties["resource-id"] && typeof nodeProperties["resource-id"] === "string") {
-          const nodeResourceId = nodeProperties["resource-id"];
-          if (nodeResourceId === resourceId || (partialMatch && nodeResourceId.toLowerCase().includes(resourceId.toLowerCase()))) {
-            const parsedNode = this.parser.parseNodeBounds(node);
-            if (parsedNode) {
-              matches.push(parsedNode);
-            }
-          }
-        }
-      });
+    if (containerNode) {
+      return this.findElementByResourceIdInRoots([containerNode], resourceId, partialMatch);
     }
 
-    if (matches.length > 0) {
-      matches.sort((a, b) => {
-        const aArea = (a.bounds.right - a.bounds.left) * (a.bounds.bottom - a.bounds.top);
-        const bArea = (b.bounds.right - b.bounds.left) * (b.bounds.bottom - b.bounds.top);
-        return aArea - bArea;
-      });
-      return matches[0];
+    const rootNodes = this.parser.extractRootNodes(viewHierarchy);
+    const mainMatch = this.findElementByResourceIdInRoots(rootNodes, resourceId, partialMatch);
+    if (mainMatch) {
+      return mainMatch;
+    }
+
+    const windowRootGroups = this.parser.extractWindowRootGroups(viewHierarchy, "topmost-first");
+    for (const windowRoots of windowRootGroups) {
+      const windowMatch = this.findElementByResourceIdInRoots(windowRoots, resourceId, partialMatch);
+      if (windowMatch) {
+        return windowMatch;
+      }
     }
 
     return null;
@@ -275,7 +394,10 @@ export class ElementFinder {
       return null;
     }
 
-    const flattenedElements = this.parser.flattenViewHierarchy(viewHierarchy);
+    const flattenedElements = this.parser.flattenViewHierarchy(viewHierarchy, {
+      includeWindows: true,
+      windowOrder: "topmost-first"
+    });
 
     if (index >= flattenedElements.length) {
       return null;
@@ -298,7 +420,10 @@ export class ElementFinder {
       return [];
     }
 
-    const rootNodes = this.parser.extractRootNodes(viewHierarchy);
+    const rootNodes = [
+      ...this.parser.extractRootNodes(viewHierarchy),
+      ...this.parser.extractWindowRootNodes(viewHierarchy, "topmost-first")
+    ];
     const scrollables: Element[] = [];
 
     // Process each root node
@@ -328,22 +453,16 @@ export class ElementFinder {
     }
 
     const rootNodes = this.parser.extractRootNodes(viewHierarchy);
+    const mainScrollable = this.findScrollableContainerInRoots(rootNodes);
+    if (mainScrollable) {
+      return mainScrollable;
+    }
 
-    // Process each root node
-    for (const rootNode of rootNodes) {
-      let foundScrollable: Element | null = null;
-      this.parser.traverseNode(rootNode, (node: any) => {
-        if (foundScrollable) {return;} // Already found one
-        const nodeProperties = this.parser.extractNodeProperties(node);
-        if (nodeProperties.scrollable === "true" || nodeProperties.scrollable === true) {
-          const parsedNode = this.parser.parseNodeBounds(node);
-          if (parsedNode) {
-            foundScrollable = parsedNode;
-          }
-        }
-      });
-      if (foundScrollable) {
-        return foundScrollable;
+    const windowRootGroups = this.parser.extractWindowRootGroups(viewHierarchy, "topmost-first");
+    for (const windowRoots of windowRootGroups) {
+      const windowScrollable = this.findScrollableContainerInRoots(windowRoots);
+      if (windowScrollable) {
+        return windowScrollable;
       }
     }
 
@@ -360,7 +479,10 @@ export class ElementFinder {
       return [];
     }
 
-    const rootNodes = this.parser.extractRootNodes(viewHierarchy);
+    const rootNodes = [
+      ...this.parser.extractRootNodes(viewHierarchy),
+      ...this.parser.extractWindowRootNodes(viewHierarchy, "topmost-first")
+    ];
     const clickables: Element[] = [];
 
     // Process each root node
@@ -390,7 +512,10 @@ export class ElementFinder {
       return [];
     }
 
-    const rootNodes = this.parser.extractRootNodes(viewHierarchy);
+    const rootNodes = [
+      ...this.parser.extractRootNodes(viewHierarchy),
+      ...this.parser.extractWindowRootNodes(viewHierarchy, "topmost-first")
+    ];
     const childElements: Element[] = [];
     const parentBounds = parentElement.bounds;
 
@@ -501,7 +626,6 @@ export class ElementFinder {
    * @returns The focused text input element or null if not found
    */
   findFocusedTextInput(viewHierarchy: any): any {
-    const rootNodes = this.parser.extractRootNodes(viewHierarchy);
     const inputClasses = [
       "android.widget.EditText",
       "android.widget.AutoCompleteTextView",
@@ -509,25 +633,18 @@ export class ElementFinder {
       "androidx.appcompat.widget.AppCompatEditText"
     ];
 
-    for (const rootNode of rootNodes) {
-      let foundElement: any = null;
-      this.parser.traverseNode(rootNode, (node: any) => {
-        if (foundElement) {return;} // Already found one
+    const rootNodes = this.parser.extractRootNodes(viewHierarchy);
+    const mainMatch = this.findFocusedTextInputInRoots(rootNodes, inputClasses);
+    if (mainMatch) {
+      return mainMatch;
+    }
 
-        const nodeProperties = this.parser.extractNodeProperties(node);
-        // Check for both 'class' and 'className' property names
-        const nodeClass = nodeProperties.class || nodeProperties.className;
-        if ((nodeProperties.focused === "true" || nodeProperties.focused === true) &&
-          nodeClass &&
-          inputClasses.some(cls => nodeClass.includes(cls))) {
-          const parsedNode = this.parser.parseNodeBounds(node);
-          if (parsedNode) {
-            foundElement = parsedNode;
-          }
-        }
-      });
-
-      if (foundElement) {return foundElement;}
+    const windowRootGroups = this.parser.extractWindowRootGroups(viewHierarchy, "topmost-first");
+    for (const windowRoots of windowRootGroups) {
+      const windowMatch = this.findFocusedTextInputInRoots(windowRoots, inputClasses);
+      if (windowMatch) {
+        return windowMatch;
+      }
     }
 
     return null;

--- a/src/features/utility/ElementParser.ts
+++ b/src/features/utility/ElementParser.ts
@@ -1,6 +1,8 @@
 import { Element } from "../../models/Element";
 import { ElementBounds, ViewHierarchyNode, ViewHierarchyResult } from "../../models";
 
+type WindowSearchOrder = "topmost-first" | "bottommost-first";
+
 /**
  * Handles parsing of view hierarchy structures
  */
@@ -75,20 +77,100 @@ export class ElementParser {
    * @returns Array of root nodes
    */
   extractRootNodes(viewHierarchy: ViewHierarchyResult): ViewHierarchyNode[] {
-    if (!viewHierarchy) {return [];}
-
-    let rootNodes: ViewHierarchyNode[] = [];
-
-    if (viewHierarchy.hierarchy && viewHierarchy.hierarchy.node) {
-      // Standard hierarchy from UI Automator
-      if (Array.isArray(viewHierarchy.hierarchy.node)) {
-        rootNodes = viewHierarchy.hierarchy.node;
-      } else {
-        rootNodes = [viewHierarchy.hierarchy.node];
-      }
+    if (!viewHierarchy?.hierarchy) {
+      return [];
     }
 
-    return rootNodes;
+    const hierarchy: any = viewHierarchy.hierarchy;
+    if (hierarchy && typeof hierarchy === "object" && "error" in hierarchy && hierarchy.error) {
+      return [];
+    }
+
+    return this.extractHierarchyRoots(hierarchy);
+  }
+
+  /**
+   * Extract root nodes from each window hierarchy, ordered by window layer.
+   * @param viewHierarchy - The view hierarchy to extract from
+   * @param order - Window search order (topmost-first by default)
+   * @returns Array of root node arrays for each window
+   */
+  extractWindowRootGroups(
+    viewHierarchy: ViewHierarchyResult,
+    order: WindowSearchOrder = "topmost-first"
+  ): ViewHierarchyNode[][] {
+    if (!viewHierarchy?.windows || viewHierarchy.windows.length === 0) {
+      return [];
+    }
+
+    const windowsWithHierarchy = viewHierarchy.windows.filter(window => window.hierarchy);
+    if (windowsWithHierarchy.length === 0) {
+      return [];
+    }
+
+    const sortedWindows = this.sortWindows(windowsWithHierarchy, order);
+    return sortedWindows.map(window => this.extractHierarchyRoots(window.hierarchy as ViewHierarchyNode));
+  }
+
+  /**
+   * Extract root nodes from all window hierarchies, ordered by window layer.
+   * @param viewHierarchy - The view hierarchy to extract from
+   * @param order - Window search order (topmost-first by default)
+   * @returns Array of root nodes across all windows
+   */
+  extractWindowRootNodes(
+    viewHierarchy: ViewHierarchyResult,
+    order: WindowSearchOrder = "topmost-first"
+  ): ViewHierarchyNode[] {
+    const groups = this.extractWindowRootGroups(viewHierarchy, order);
+    return groups.reduce(
+      (acc, group) => acc.concat(group),
+      [] as ViewHierarchyNode[]
+    );
+  }
+
+  private extractHierarchyRoots(hierarchy: any): ViewHierarchyNode[] {
+    if (!hierarchy) {
+      return [];
+    }
+
+    if (hierarchy.node) {
+      return Array.isArray(hierarchy.node) ? hierarchy.node : [hierarchy.node];
+    }
+
+    if (hierarchy.hierarchy) {
+      return [hierarchy.hierarchy];
+    }
+
+    return [hierarchy];
+  }
+
+  private sortWindows<T extends { windowLayer: number }>(windows: T[], order: WindowSearchOrder): T[] {
+    const direction = order === "topmost-first" ? -1 : 1;
+    return windows
+      .map((window, index) => ({ window, index }))
+      .sort((a, b) => {
+        const layerDelta = this.normalizeWindowLayer(a.window.windowLayer) -
+          this.normalizeWindowLayer(b.window.windowLayer);
+        if (layerDelta !== 0) {
+          return layerDelta * direction;
+        }
+        return a.index - b.index;
+      })
+      .map(entry => entry.window);
+  }
+
+  private normalizeWindowLayer(value: unknown): number {
+    if (typeof value === "number" && Number.isFinite(value)) {
+      return value;
+    }
+    if (typeof value === "string") {
+      const parsed = Number(value);
+      if (Number.isFinite(parsed)) {
+        return parsed;
+      }
+    }
+    return 0;
   }
 
   /**
@@ -121,13 +203,21 @@ export class ElementParser {
    * @param viewHierarchy - The view hierarchy to flatten
    * @returns Array of elements with their indices and depth in hierarchy
    */
-  flattenViewHierarchy(viewHierarchy: ViewHierarchyResult): Array<{ element: Element; index: number; depth: number; text?: string }> {
+  flattenViewHierarchy(
+    viewHierarchy: ViewHierarchyResult,
+    options: { includeWindows?: boolean; windowOrder?: WindowSearchOrder } = {}
+  ): Array<{ element: Element; index: number; depth: number; text?: string }> {
     if (!viewHierarchy) {
       return [];
     }
 
     const flattenedElements: Array<{ element: Element; index: number; depth: number; text?: string }> = [];
-    const rootNodes = this.extractRootNodes(viewHierarchy);
+    const rootNodes = options.includeWindows
+      ? [
+        ...this.extractRootNodes(viewHierarchy),
+        ...this.extractWindowRootNodes(viewHierarchy, options.windowOrder ?? "topmost-first")
+      ]
+      : this.extractRootNodes(viewHierarchy);
     let currentIndex = 0;
 
     // Process each root node

--- a/src/features/utility/ElementUtils.ts
+++ b/src/features/utility/ElementUtils.ts
@@ -91,7 +91,10 @@ export class ElementUtils {
   }
 
   flattenViewHierarchy(viewHierarchy: ViewHierarchyResult): Array<{ element: Element; index: number; text?: string }> {
-    return this.parser.flattenViewHierarchy(viewHierarchy);
+    return this.parser.flattenViewHierarchy(viewHierarchy, {
+      includeWindows: true,
+      windowOrder: "topmost-first"
+    });
   }
 
   // ===== ElementFinder methods =====

--- a/test/features/utility/ElementUtils.test.ts
+++ b/test/features/utility/ElementUtils.test.ts
@@ -601,5 +601,220 @@ describe("ElementUtils", () => {
       );
       expect(result).not.toBeNull();
     });
+
+    test("should fall back to the topmost window when main hierarchy has no match", () => {
+      const hierarchyWithWindows = {
+        hierarchy: {
+          node: {
+            $: {
+              bounds: "[0,0][100,100]",
+              class: "android.widget.FrameLayout"
+            },
+            node: [
+              {
+                $: {
+                  bounds: "[10,10][50,50]",
+                  class: "android.widget.TextView",
+                  text: "Main"
+                }
+              }
+            ]
+          }
+        },
+        windows: [
+          {
+            windowId: 1,
+            windowType: "popup",
+            windowLayer: 5,
+            isActive: true,
+            isFocused: true,
+            hierarchy: {
+              $: {
+                bounds: "[0,0][50,50]",
+                class: "android.widget.TextView",
+                text: "Cancel"
+              }
+            }
+          },
+          {
+            windowId: 2,
+            windowType: "input_method",
+            windowLayer: 10,
+            isActive: true,
+            isFocused: true,
+            hierarchy: {
+              $: {
+                bounds: "[0,0][80,80]",
+                class: "android.widget.TextView",
+                text: "Cancel"
+              }
+            }
+          }
+        ]
+      };
+
+      const mockObserveResult = createObserveResult(hierarchyWithWindows);
+      const result = elementUtils.findElementByText(
+        mockObserveResult.viewHierarchy,
+        "Cancel",
+        null,
+        true,
+        false
+      );
+
+      expect(result).not.toBeNull();
+      expect(result?.bounds).toEqual({ left: 0, top: 0, right: 80, bottom: 80 });
+    });
+
+    test("should prefer main hierarchy matches over window matches", () => {
+      const hierarchyWithMainAndWindowMatch = {
+        hierarchy: {
+          node: {
+            $: {
+              bounds: "[0,0][300,300]",
+              class: "android.widget.FrameLayout"
+            },
+            node: [
+              {
+                $: {
+                  bounds: "[20,20][200,200]",
+                  class: "android.widget.TextView",
+                  text: "Cancel"
+                }
+              }
+            ]
+          }
+        },
+        windows: [
+          {
+            windowId: 3,
+            windowType: "input_method",
+            windowLayer: 15,
+            isActive: true,
+            isFocused: true,
+            hierarchy: {
+              $: {
+                bounds: "[0,0][50,50]",
+                class: "android.widget.TextView",
+                text: "Cancel"
+              }
+            }
+          }
+        ]
+      };
+
+      const mockObserveResult = createObserveResult(hierarchyWithMainAndWindowMatch);
+      const result = elementUtils.findElementByText(
+        mockObserveResult.viewHierarchy,
+        "Cancel",
+        null,
+        true,
+        false
+      );
+
+      expect(result).not.toBeNull();
+      expect(result?.bounds).toEqual({ left: 20, top: 20, right: 200, bottom: 200 });
+    });
+  });
+
+  describe("findElementByResourceId", () => {
+    test("should fall back to the topmost window when main hierarchy has no match", () => {
+      const hierarchyWithWindows = {
+        hierarchy: {
+          node: {
+            $: {
+              bounds: "[0,0][100,100]",
+              class: "android.widget.FrameLayout"
+            }
+          }
+        },
+        windows: [
+          {
+            windowId: 10,
+            windowType: "popup",
+            windowLayer: 3,
+            isActive: true,
+            isFocused: true,
+            hierarchy: {
+              $: {
+                bounds: "[0,0][40,40]",
+                class: "android.widget.Button",
+                "resource-id": "com.example:id/cancel_button"
+              }
+            }
+          },
+          {
+            windowId: 11,
+            windowType: "input_method",
+            windowLayer: 8,
+            isActive: true,
+            isFocused: true,
+            hierarchy: {
+              $: {
+                bounds: "[0,0][90,90]",
+                class: "android.widget.Button",
+                "resource-id": "com.example:id/cancel_button"
+              }
+            }
+          }
+        ]
+      };
+
+      const mockObserveResult = createObserveResult(hierarchyWithWindows);
+      const result = elementUtils.findElementByResourceId(
+        mockObserveResult.viewHierarchy,
+        "com.example:id/cancel_button"
+      );
+
+      expect(result).not.toBeNull();
+      expect(result?.bounds).toEqual({ left: 0, top: 0, right: 90, bottom: 90 });
+    });
+
+    test("should prefer main hierarchy matches over window matches", () => {
+      const hierarchyWithMainAndWindowMatch = {
+        hierarchy: {
+          node: {
+            $: {
+              bounds: "[0,0][300,300]",
+              class: "android.widget.FrameLayout"
+            },
+            node: [
+              {
+                $: {
+                  bounds: "[30,30][220,220]",
+                  class: "android.widget.Button",
+                  "resource-id": "com.example:id/cancel_button"
+                }
+              }
+            ]
+          }
+        },
+        windows: [
+          {
+            windowId: 12,
+            windowType: "popup",
+            windowLayer: 12,
+            isActive: true,
+            isFocused: true,
+            hierarchy: {
+              $: {
+                bounds: "[0,0][60,60]",
+                class: "android.widget.Button",
+                "resource-id": "com.example:id/cancel_button"
+              }
+            }
+          }
+        ]
+      };
+
+      const mockObserveResult = createObserveResult(hierarchyWithMainAndWindowMatch);
+      const result = elementUtils.findElementByResourceId(
+        mockObserveResult.viewHierarchy,
+        "com.example:id/cancel_button"
+      );
+
+      expect(result).not.toBeNull();
+      expect(result?.bounds).toEqual({ left: 30, top: 30, right: 220, bottom: 220 });
+    });
   });
 });


### PR DESCRIPTION
## Summary
- search for elements in the main hierarchy first, then window hierarchies ordered by topmost layer
- include window hierarchies in flattening and other element lookup helpers
- add coverage for window fallback/precedence in element search tests

## Testing
- bun run build
- bun run test

Fixes #543
