### PR TITLE
Add Android first-run quickstart

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -8,6 +8,7 @@ Android is the primary supported platform today; iOS support is on the roadmap.
 **How do I get started?**
 
 - [Installation](install/overview.md) - Install AutoMobile in your environment or IDE
+- [Android first run](install/overview.md#android-first-run) - Verify a device, launch your app, and capture a concrete exploration result
 
 ### What can I use this to do?
 

--- a/docs/install/overview.md
+++ b/docs/install/overview.md
@@ -78,6 +78,24 @@ If you have a private npm registry for proxying public npm:
 - Android: [Android setup](plat/android.md)
 - iOS: unsupported at the moment, but the [design doc](../design-docs/plat/ios/index.md) outlines plans.
 
+## Android first run
+
+Use this short path once the MCP server is running, a device is connected, the Accessibility Service is enabled, and your
+app is installed on the device.
+
+1. **Verify device connectivity**
+   Claude Code prompt: "Use AutoMobile to list connected Android devices and confirm one is ready."
+2. **List installed apps**
+   Claude Code prompt: "List installed apps and show package names so I can pick the target package."
+3. **Launch the target app**
+   Claude Code prompt: "Launch package `com.example.app` and confirm it is in the foreground."
+4. **Run a short exploration**
+   Claude Code prompt: "Explore this app for about 10 interactions, avoid destructive actions, and stay in the main flow."
+5. **Capture a concrete result**
+   Claude Code prompt: "Summarize the screens discovered and the actions that navigate between them (a mini navigation graph)."
+
+You should end with a device ID, a package name, and a short navigation summary you can save or share.
+
 ## Decision guide (Android)
 
 If your goal is interactive AI-driven automation, the MCP server plus an agent is enough. The rest are optional based on

--- a/docs/using/ux-exploration.md
+++ b/docs/using/ux-exploration.md
@@ -2,6 +2,11 @@
 
 Use AutoMobile with AI agents to interactively explore and understand your app's user experience.
 
+## First run (Android)
+
+If this is your first time using AutoMobile, start with the [Android first run](../install/overview.md#android-first-run)
+quickstart. It verifies device connectivity, launches your app, runs a short exploration, and produces a concrete
+navigation summary.
 
 AutoMobile's exploration capabilities allow AI agents to:
 

--- a/schemas/tool-definitions.json
+++ b/schemas/tool-definitions.json
@@ -31,6 +31,10 @@
           "type": "string",
           "description": "Session UUID for device targeting"
         },
+        "keepScreenAwake": {
+          "type": "boolean",
+          "description": "Keep physical Android devices awake during the session (default: true)"
+        },
         "device": {
           "type": "string",
           "description": "Device label for multi-device plans (e.g., \"A\", \"B\")"
@@ -89,6 +93,10 @@
           "type": "string",
           "description": "Session UUID for device targeting"
         },
+        "keepScreenAwake": {
+          "type": "boolean",
+          "description": "Keep physical Android devices awake during the session (default: true)"
+        },
         "device": {
           "type": "string",
           "description": "Device label for multi-device plans (e.g., \"A\", \"B\")"
@@ -145,9 +153,18 @@
           "default": "current",
           "description": "Which apps to backup: 'current' (foreground app only) or 'all' (all user-installed apps)"
         },
+        "vmSnapshotTimeoutMs": {
+          "type": "number",
+          "default": 30000,
+          "description": "Timeout in milliseconds for emulator VM snapshot commands (default: 30000ms)"
+        },
         "sessionUuid": {
           "type": "string",
           "description": "Session UUID for device targeting"
+        },
+        "keepScreenAwake": {
+          "type": "boolean",
+          "description": "Keep physical Android devices awake during the session (default: true)"
         },
         "device": {
           "type": "string",
@@ -175,6 +192,10 @@
         "sessionUuid": {
           "type": "string",
           "description": "Session UUID for device targeting"
+        },
+        "keepScreenAwake": {
+          "type": "boolean",
+          "description": "Keep physical Android devices awake during the session (default: true)"
         },
         "device": {
           "type": "string",
@@ -219,6 +240,10 @@
         "sessionUuid": {
           "type": "string",
           "description": "Session UUID for device targeting"
+        },
+        "keepScreenAwake": {
+          "type": "boolean",
+          "description": "Keep physical Android devices awake during the session (default: true)"
         },
         "device": {
           "type": "string",
@@ -404,6 +429,10 @@
           "type": "string",
           "description": "Session UUID for device targeting"
         },
+        "keepScreenAwake": {
+          "type": "boolean",
+          "description": "Keep physical Android devices awake during the session (default: true)"
+        },
         "device": {
           "type": "string",
           "description": "Device label for multi-device plans (e.g., \"A\", \"B\")"
@@ -429,6 +458,10 @@
         "sessionUuid": {
           "type": "string",
           "description": "Session UUID for device targeting"
+        },
+        "keepScreenAwake": {
+          "type": "boolean",
+          "description": "Keep physical Android devices awake during the session (default: true)"
         },
         "device": {
           "type": "string",
@@ -477,6 +510,10 @@
         "sessionUuid": {
           "type": "string",
           "description": "Session UUID for device targeting"
+        },
+        "keepScreenAwake": {
+          "type": "boolean",
+          "description": "Keep physical Android devices awake during the session (default: true)"
         },
         "device": {
           "type": "string",
@@ -569,6 +606,10 @@
           "type": "string",
           "description": "Session UUID for device targeting"
         },
+        "keepScreenAwake": {
+          "type": "boolean",
+          "description": "Keep physical Android devices awake during the session (default: true)"
+        },
         "device": {
           "type": "string",
           "description": "Device label for multi-device plans (e.g., \"A\", \"B\")"
@@ -643,6 +684,10 @@
           "type": "string",
           "description": "Session UUID for device targeting"
         },
+        "keepScreenAwake": {
+          "type": "boolean",
+          "description": "Keep physical Android devices awake during the session (default: true)"
+        },
         "device": {
           "type": "string",
           "description": "Device label for multi-device plans (e.g., \"A\", \"B\")"
@@ -681,6 +726,10 @@
         "sessionUuid": {
           "type": "string",
           "description": "Session UUID for parallel execution"
+        },
+        "keepScreenAwake": {
+          "type": "boolean",
+          "description": "Keep physical Android devices awake during the session (default: true)"
         },
         "deviceId": {
           "type": "string",
@@ -827,6 +876,10 @@
           "type": "string",
           "description": "Session UUID for device targeting"
         },
+        "keepScreenAwake": {
+          "type": "boolean",
+          "description": "Keep physical Android devices awake during the session (default: true)"
+        },
         "device": {
           "type": "string",
           "description": "Device label for multi-device plans (e.g., \"A\", \"B\")"
@@ -854,6 +907,10 @@
           "type": "string",
           "description": "Session UUID for device targeting"
         },
+        "keepScreenAwake": {
+          "type": "boolean",
+          "description": "Keep physical Android devices awake during the session (default: true)"
+        },
         "device": {
           "type": "string",
           "description": "Device label for multi-device plans (e.g., \"A\", \"B\")"
@@ -879,6 +936,10 @@
         "sessionUuid": {
           "type": "string",
           "description": "Session UUID for device targeting"
+        },
+        "keepScreenAwake": {
+          "type": "boolean",
+          "description": "Keep physical Android devices awake during the session (default: true)"
         },
         "device": {
           "type": "string",
@@ -909,6 +970,10 @@
         "sessionUuid": {
           "type": "string",
           "description": "Session UUID for device targeting"
+        },
+        "keepScreenAwake": {
+          "type": "boolean",
+          "description": "Keep physical Android devices awake during the session (default: true)"
         },
         "device": {
           "type": "string",
@@ -1047,6 +1112,10 @@
           "type": "string",
           "description": "Session UUID for device targeting"
         },
+        "keepScreenAwake": {
+          "type": "boolean",
+          "description": "Keep physical Android devices awake during the session (default: true)"
+        },
         "device": {
           "type": "string",
           "description": "Device label for multi-device plans (e.g., \"A\", \"B\")"
@@ -1128,6 +1197,10 @@
           "type": "string",
           "description": "Session UUID for device targeting"
         },
+        "keepScreenAwake": {
+          "type": "boolean",
+          "description": "Keep physical Android devices awake during the session (default: true)"
+        },
         "device": {
           "type": "string",
           "description": "Device label for multi-device plans (e.g., \"A\", \"B\")"
@@ -1169,6 +1242,10 @@
         "sessionUuid": {
           "type": "string",
           "description": "Session UUID for device targeting"
+        },
+        "keepScreenAwake": {
+          "type": "boolean",
+          "description": "Keep physical Android devices awake during the session (default: true)"
         },
         "device": {
           "type": "string",
@@ -1217,6 +1294,10 @@
           "type": "string",
           "description": "Session UUID for device targeting"
         },
+        "keepScreenAwake": {
+          "type": "boolean",
+          "description": "Keep physical Android devices awake during the session (default: true)"
+        },
         "device": {
           "type": "string",
           "description": "Device label for multi-device plans (e.g., \"A\", \"B\")"
@@ -1243,6 +1324,10 @@
         "sessionUuid": {
           "type": "string",
           "description": "Session UUID for device targeting"
+        },
+        "keepScreenAwake": {
+          "type": "boolean",
+          "description": "Keep physical Android devices awake during the session (default: true)"
         },
         "device": {
           "type": "string",
@@ -1319,6 +1404,10 @@
           "type": "string",
           "description": "Session UUID for device targeting"
         },
+        "keepScreenAwake": {
+          "type": "boolean",
+          "description": "Keep physical Android devices awake during the session (default: true)"
+        },
         "device": {
           "type": "string",
           "description": "Device label for multi-device plans (e.g., \"A\", \"B\")"
@@ -1348,6 +1437,10 @@
         "sessionUuid": {
           "type": "string",
           "description": "Session UUID for device targeting"
+        },
+        "keepScreenAwake": {
+          "type": "boolean",
+          "description": "Keep physical Android devices awake during the session (default: true)"
         },
         "device": {
           "type": "string",
@@ -1459,6 +1552,10 @@
           "type": "string",
           "description": "Session UUID for device targeting"
         },
+        "keepScreenAwake": {
+          "type": "boolean",
+          "description": "Keep physical Android devices awake during the session (default: true)"
+        },
         "device": {
           "type": "string",
           "description": "Device label for multi-device plans (e.g., \"A\", \"B\")"
@@ -1500,6 +1597,10 @@
           "type": "string",
           "description": "Session UUID for device targeting"
         },
+        "keepScreenAwake": {
+          "type": "boolean",
+          "description": "Keep physical Android devices awake during the session (default: true)"
+        },
         "device": {
           "type": "string",
           "description": "Device label for multi-device plans (e.g., \"A\", \"B\")"
@@ -1529,6 +1630,10 @@
         "sessionUuid": {
           "type": "string",
           "description": "Session UUID for device targeting"
+        },
+        "keepScreenAwake": {
+          "type": "boolean",
+          "description": "Keep physical Android devices awake during the session (default: true)"
         },
         "device": {
           "type": "string",
@@ -1564,6 +1669,10 @@
           "type": "string",
           "description": "Session UUID for device targeting"
         },
+        "keepScreenAwake": {
+          "type": "boolean",
+          "description": "Keep physical Android devices awake during the session (default: true)"
+        },
         "device": {
           "type": "string",
           "description": "Device label for multi-device plans (e.g., \"A\", \"B\")"
@@ -1594,6 +1703,10 @@
         "sessionUuid": {
           "type": "string",
           "description": "Session UUID for device targeting"
+        },
+        "keepScreenAwake": {
+          "type": "boolean",
+          "description": "Keep physical Android devices awake during the session (default: true)"
         },
         "device": {
           "type": "string",
@@ -1676,6 +1789,10 @@
           "type": "string",
           "description": "Session UUID for device targeting"
         },
+        "keepScreenAwake": {
+          "type": "boolean",
+          "description": "Keep physical Android devices awake during the session (default: true)"
+        },
         "device": {
           "type": "string",
           "description": "Device label for multi-device plans (e.g., \"A\", \"B\")"
@@ -1719,6 +1836,10 @@
         "sessionUuid": {
           "type": "string",
           "description": "Session UUID for device targeting"
+        },
+        "keepScreenAwake": {
+          "type": "boolean",
+          "description": "Keep physical Android devices awake during the session (default: true)"
         },
         "device": {
           "type": "string",
@@ -1764,6 +1885,10 @@
           "type": "string",
           "description": "Session UUID for device targeting"
         },
+        "keepScreenAwake": {
+          "type": "boolean",
+          "description": "Keep physical Android devices awake during the session (default: true)"
+        },
         "device": {
           "type": "string",
           "description": "Device label for multi-device plans (e.g., \"A\", \"B\")"
@@ -1804,6 +1929,10 @@
           "type": "string",
           "description": "Session UUID for device targeting"
         },
+        "keepScreenAwake": {
+          "type": "boolean",
+          "description": "Keep physical Android devices awake during the session (default: true)"
+        },
         "device": {
           "type": "string",
           "description": "Device label for multi-device plans (e.g., \"A\", \"B\")"
@@ -1834,6 +1963,10 @@
           "type": "string",
           "description": "Session UUID for device targeting"
         },
+        "keepScreenAwake": {
+          "type": "boolean",
+          "description": "Keep physical Android devices awake during the session (default: true)"
+        },
         "device": {
           "type": "string",
           "description": "Device label for multi-device plans (e.g., \"A\", \"B\")"
@@ -1861,9 +1994,18 @@
           "default": true,
           "description": "Use emulator VM snapshot if available (faster, emulator only)"
         },
+        "vmSnapshotTimeoutMs": {
+          "type": "number",
+          "default": 30000,
+          "description": "Timeout in milliseconds for emulator VM snapshot commands (default: 30000ms)"
+        },
         "sessionUuid": {
           "type": "string",
           "description": "Session UUID for device targeting"
+        },
+        "keepScreenAwake": {
+          "type": "boolean",
+          "description": "Keep physical Android devices awake during the session (default: true)"
         },
         "device": {
           "type": "string",
@@ -1903,6 +2045,10 @@
           "type": "string",
           "description": "Session UUID for device targeting"
         },
+        "keepScreenAwake": {
+          "type": "boolean",
+          "description": "Keep physical Android devices awake during the session (default: true)"
+        },
         "device": {
           "type": "string",
           "description": "Device label for multi-device plans (e.g., \"A\", \"B\")"
@@ -1933,6 +2079,10 @@
         "sessionUuid": {
           "type": "string",
           "description": "Session UUID for device targeting"
+        },
+        "keepScreenAwake": {
+          "type": "boolean",
+          "description": "Keep physical Android devices awake during the session (default: true)"
         },
         "device": {
           "type": "string",
@@ -1968,6 +2118,10 @@
           "type": "string",
           "description": "Session UUID for device targeting"
         },
+        "keepScreenAwake": {
+          "type": "boolean",
+          "description": "Keep physical Android devices awake during the session (default: true)"
+        },
         "device": {
           "type": "string",
           "description": "Device label for multi-device plans (e.g., \"A\", \"B\")"
@@ -2002,6 +2156,10 @@
         "sessionUuid": {
           "type": "string",
           "description": "Session UUID for device targeting"
+        },
+        "keepScreenAwake": {
+          "type": "boolean",
+          "description": "Keep physical Android devices awake during the session (default: true)"
         }
       },
       "required": [
@@ -2034,6 +2192,10 @@
         "sessionUuid": {
           "type": "string",
           "description": "Session UUID for device targeting"
+        },
+        "keepScreenAwake": {
+          "type": "boolean",
+          "description": "Keep physical Android devices awake during the session (default: true)"
         },
         "device": {
           "type": "string",
@@ -2070,6 +2232,10 @@
           "type": "string",
           "description": "Session UUID for device targeting"
         },
+        "keepScreenAwake": {
+          "type": "boolean",
+          "description": "Keep physical Android devices awake during the session (default: true)"
+        },
         "device": {
           "type": "string",
           "description": "Device label for multi-device plans (e.g., \"A\", \"B\")"
@@ -2105,6 +2271,10 @@
         "sessionUuid": {
           "type": "string",
           "description": "Session UUID for device targeting"
+        },
+        "keepScreenAwake": {
+          "type": "boolean",
+          "description": "Keep physical Android devices awake during the session (default: true)"
         },
         "device": {
           "type": "string",
@@ -2144,6 +2314,10 @@
         "sessionUuid": {
           "type": "string",
           "description": "Session UUID for device targeting"
+        },
+        "keepScreenAwake": {
+          "type": "boolean",
+          "description": "Keep physical Android devices awake during the session (default: true)"
         },
         "device": {
           "type": "string",
@@ -2293,6 +2467,10 @@
           "type": "string",
           "description": "Session UUID for device targeting"
         },
+        "keepScreenAwake": {
+          "type": "boolean",
+          "description": "Keep physical Android devices awake during the session (default: true)"
+        },
         "device": {
           "type": "string",
           "description": "Device label for multi-device plans (e.g., \"A\", \"B\")"
@@ -2403,6 +2581,10 @@
           "type": "string",
           "description": "Session UUID for device targeting"
         },
+        "keepScreenAwake": {
+          "type": "boolean",
+          "description": "Keep physical Android devices awake during the session (default: true)"
+        },
         "device": {
           "type": "string",
           "description": "Device label for multi-device plans (e.g., \"A\", \"B\")"
@@ -2435,7 +2617,7 @@
             }
           },
           "additionalProperties": false,
-          "description": "Container to scope search (elementId or text)"
+          "description": "Container selector object to scope search. Provide { \"elementId\": \"<id>\" } or { \"text\": \"<text>\" }."
         },
         "action": {
           "type": "string",
@@ -2500,6 +2682,10 @@
           "type": "string",
           "description": "Session UUID for device targeting"
         },
+        "keepScreenAwake": {
+          "type": "boolean",
+          "description": "Keep physical Android devices awake during the session (default: true)"
+        },
         "device": {
           "type": "string",
           "description": "Device label for multi-device plans (e.g., \"A\", \"B\")"
@@ -2526,6 +2712,10 @@
         "sessionUuid": {
           "type": "string",
           "description": "Session UUID for device targeting"
+        },
+        "keepScreenAwake": {
+          "type": "boolean",
+          "description": "Keep physical Android devices awake during the session (default: true)"
         },
         "device": {
           "type": "string",


### PR DESCRIPTION
## Summary
- add an Android first-run quickstart path with Claude Code prompts
- link the quickstart from the docs index and UX exploration page
- capture the generated tool definitions update from commit time

## Testing
- Not run (docs-only change)

Closes #341
