### PR TITLE
Validate accessibility version when skipping download

### DIFF
--- a/docs/design-docs/plat/android/accessibility-service.md
+++ b/docs/design-docs/plat/android/accessibility-service.md
@@ -74,6 +74,10 @@ AutoMobile manages accessibility service versions automatically:
 - Validates downloaded APKs via SHA256 checksum
 - Supports local APK overrides for development
 
+When device setup uses `skipAccessibilityDownload`, AutoMobile still validates the installed service checksum.
+If the version is incompatible, it surfaces a warning/error advising you to rerun without
+`skipAccessibilityDownload` to upgrade or install the matching APK manually.
+
 ## Environment Variables
 
 - `AUTOMOBILE_ACCESSIBILITY_APK_PATH`: Override APK source with local file path

--- a/src/utils/DeviceSessionManager.ts
+++ b/src/utils/DeviceSessionManager.ts
@@ -336,6 +336,16 @@ export class DeviceSessionManager implements DeviceSessionManager {
       }
 
       const manager = AndroidAccessibilityServiceManager.getInstance(device);
+      const verifyCompatibilityWhenSkipping = async (): Promise<void> => {
+        const isCompatible = await manager.isVersionCompatible();
+        if (isCompatible) {
+          logger.info(`[DeviceSessionManager] Accessibility service version compatible for ${deviceId}`);
+          return;
+        }
+        const errorMessage = "Accessibility service version mismatch detected. Run without skipAccessibilityDownload to install a compatible version.";
+        logger.warn(`[DeviceSessionManager] ${errorMessage} Device: ${deviceId}`);
+        throw new ActionableError(errorMessage);
+      };
       const [isInstalled, isEnabled] = await Promise.all([
         manager.isInstalled(),
         manager.isEnabled()
@@ -344,6 +354,7 @@ export class DeviceSessionManager implements DeviceSessionManager {
       if (isInstalled && isEnabled) {
         logger.info(`[DeviceSessionManager] Accessibility service already enabled for ${deviceId}`);
         if (skipAccessibilityDownload) {
+          await verifyCompatibilityWhenSkipping();
           return;
         }
         logger.info(`[DeviceSessionManager] Accessibility service enabled for ${deviceId}, verifying version compatibility`);
@@ -359,6 +370,7 @@ export class DeviceSessionManager implements DeviceSessionManager {
         try {
           await manager.enable();
           if (skipAccessibilityDownload) {
+            await verifyCompatibilityWhenSkipping();
             return;
           }
           logger.info(`[DeviceSessionManager] Accessibility service enabled for ${deviceId}, verifying version compatibility`);

--- a/test/utils/DeviceSessionManager.test.ts
+++ b/test/utils/DeviceSessionManager.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { DeviceSessionManager } from "../../src/utils/DeviceSessionManager";
 import { FakeAdbExecutor } from "../fakes/FakeAdbExecutor";
 import { FakeDeviceUtils } from "../fakes/FakeDeviceUtils";
+import { FakeAccessibilityServiceManager } from "../fakes/FakeAccessibilityServiceManager";
 import { AndroidAccessibilityServiceManager } from "../../src/utils/AccessibilityServiceManager";
 import { AccessibilityServiceClient } from "../../src/features/observe/AccessibilityServiceClient";
 import { Window } from "../../src/features/observe/Window";
@@ -45,20 +46,10 @@ describe("DeviceSessionManager", () => {
   });
 
   test("should skip accessibility download when requested and not installed", async () => {
-    let setupCalled = false;
-    let enableCalled = false;
-    AndroidAccessibilityServiceManager.getInstance = () =>
-      ({
-        isInstalled: async () => false,
-        isEnabled: async () => false,
-        enable: async () => {
-          enableCalled = true;
-        },
-        setup: async () => {
-          setupCalled = true;
-          return { success: true, message: "ok" };
-        }
-      } as any);
+    const accessibilityManager = new FakeAccessibilityServiceManager();
+    accessibilityManager.setInstalled(false);
+    accessibilityManager.setEnabled(false);
+    AndroidAccessibilityServiceManager.getInstance = () => accessibilityManager as any;
     AccessibilityServiceClient.getInstance = () =>
       ({
         isConnected: () => false
@@ -67,25 +58,16 @@ describe("DeviceSessionManager", () => {
     const manager = DeviceSessionManager.createInstance(fakeAdb, fakeDeviceUtils);
     await manager.ensureDeviceReady("android", "device-1", { skipAccessibilityDownload: true });
 
-    expect(setupCalled).toBe(false);
-    expect(enableCalled).toBe(false);
+    expect(accessibilityManager.wasMethodCalled("setup")).toBe(false);
+    expect(accessibilityManager.wasMethodCalled("enable")).toBe(false);
   });
 
   test("should enable accessibility when installed but disabled even when download is skipped", async () => {
-    let setupCalled = false;
-    let enableCalled = false;
-    AndroidAccessibilityServiceManager.getInstance = () =>
-      ({
-        isInstalled: async () => true,
-        isEnabled: async () => false,
-        enable: async () => {
-          enableCalled = true;
-        },
-        setup: async () => {
-          setupCalled = true;
-          return { success: true, message: "ok" };
-        }
-      } as any);
+    const accessibilityManager = new FakeAccessibilityServiceManager();
+    accessibilityManager.setInstalled(true);
+    accessibilityManager.setEnabled(false);
+    accessibilityManager.setVersionCompatible(true);
+    AndroidAccessibilityServiceManager.getInstance = () => accessibilityManager as any;
     AccessibilityServiceClient.getInstance = () =>
       ({
         isConnected: () => false
@@ -94,22 +76,51 @@ describe("DeviceSessionManager", () => {
     const manager = DeviceSessionManager.createInstance(fakeAdb, fakeDeviceUtils);
     await manager.ensureDeviceReady("android", "device-1", { skipAccessibilityDownload: true });
 
-    expect(enableCalled).toBe(true);
-    expect(setupCalled).toBe(false);
+    expect(accessibilityManager.wasMethodCalled("enable")).toBe(true);
+    expect(accessibilityManager.wasMethodCalled("isVersionCompatible")).toBe(true);
+    expect(accessibilityManager.wasMethodCalled("setup")).toBe(false);
+  });
+
+  test("should verify compatibility when download is skipped and service enabled", async () => {
+    const accessibilityManager = new FakeAccessibilityServiceManager();
+    accessibilityManager.setInstalled(true);
+    accessibilityManager.setEnabled(true);
+    accessibilityManager.setVersionCompatible(true);
+    AndroidAccessibilityServiceManager.getInstance = () => accessibilityManager as any;
+    AccessibilityServiceClient.getInstance = () =>
+      ({
+        isConnected: () => false
+      } as any);
+
+    const manager = DeviceSessionManager.createInstance(fakeAdb, fakeDeviceUtils);
+    await manager.ensureDeviceReady("android", "device-1", { skipAccessibilityDownload: true });
+
+    expect(accessibilityManager.wasMethodCalled("isVersionCompatible")).toBe(true);
+    expect(accessibilityManager.wasMethodCalled("setup")).toBe(false);
+  });
+
+  test("should error on incompatible accessibility version when download is skipped", async () => {
+    const accessibilityManager = new FakeAccessibilityServiceManager();
+    accessibilityManager.setInstalled(true);
+    accessibilityManager.setEnabled(true);
+    accessibilityManager.setVersionCompatible(false);
+    AndroidAccessibilityServiceManager.getInstance = () => accessibilityManager as any;
+    AccessibilityServiceClient.getInstance = () =>
+      ({
+        isConnected: () => false
+      } as any);
+
+    const manager = DeviceSessionManager.createInstance(fakeAdb, fakeDeviceUtils);
+    await expect(
+      manager.ensureDeviceReady("android", "device-1", { skipAccessibilityDownload: true })
+    ).rejects.toThrow("Accessibility service version mismatch");
   });
 
   test("should run accessibility setup by default", async () => {
-    let setupCalled = false;
-    AndroidAccessibilityServiceManager.getInstance = () =>
-      ({
-        isInstalled: async () => false,
-        isEnabled: async () => false,
-        enable: async () => {},
-        setup: async () => {
-          setupCalled = true;
-          return { success: true, message: "ok" };
-        }
-      } as any);
+    const accessibilityManager = new FakeAccessibilityServiceManager();
+    accessibilityManager.setInstalled(false);
+    accessibilityManager.setEnabled(false);
+    AndroidAccessibilityServiceManager.getInstance = () => accessibilityManager as any;
     AccessibilityServiceClient.getInstance = () =>
       ({
         isConnected: () => false
@@ -118,21 +129,14 @@ describe("DeviceSessionManager", () => {
     const manager = DeviceSessionManager.createInstance(fakeAdb, fakeDeviceUtils);
     await manager.ensureDeviceReady("android", "device-1");
 
-    expect(setupCalled).toBe(true);
+    expect(accessibilityManager.wasMethodCalled("setup")).toBe(true);
   });
 
   test("should verify compatibility when accessibility is already enabled", async () => {
-    let setupCalled = false;
-    AndroidAccessibilityServiceManager.getInstance = () =>
-      ({
-        isInstalled: async () => true,
-        isEnabled: async () => true,
-        enable: async () => {},
-        setup: async () => {
-          setupCalled = true;
-          return { success: true, message: "ok" };
-        }
-      } as any);
+    const accessibilityManager = new FakeAccessibilityServiceManager();
+    accessibilityManager.setInstalled(true);
+    accessibilityManager.setEnabled(true);
+    AndroidAccessibilityServiceManager.getInstance = () => accessibilityManager as any;
     AccessibilityServiceClient.getInstance = () =>
       ({
         isConnected: () => false
@@ -141,7 +145,7 @@ describe("DeviceSessionManager", () => {
     const manager = DeviceSessionManager.createInstance(fakeAdb, fakeDeviceUtils);
     await manager.ensureDeviceReady("android", "device-1");
 
-    expect(setupCalled).toBe(true);
+    expect(accessibilityManager.wasMethodCalled("setup")).toBe(true);
   });
 
   test("should skip accessibility checks when websocket is connected", async () => {


### PR DESCRIPTION
## Summary
- validate accessibility service version compatibility even when skipAccessibilityDownload is set
- use the accessibility service fake in DeviceSessionManager tests for faster, deterministic assertions
- document checksum validation behavior when downloads are skipped

## Testing
- `bun run test -- test/utils/DeviceSessionManager.test.ts`
- `bun run lint`
- `bun run test` *(fails: SQLiteError "attempt to write a readonly database" in navigation tests; see scratch/bun-test.log)*

Fixes #580
