### PR TITLE
Publish JUnitRunner snapshots on merge

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -363,6 +363,70 @@ jobs:
           name: playground-app-apk
           path: android/playground/app/build/outputs/apk/debug/playground-app-debug.apk
 
+  publish-junit-runner-snapshot:
+    name: "Publish JUnitRunner Snapshot"
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/main' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
+    needs:
+      - build-ide-plugin
+      - ide-plugin-unit-tests
+      - validate-xml
+      - ktfmt
+      - validate-shell-scripts
+      - validate-mkdocs-nav
+      - validate-documentation-links
+      - mcp-build-and-test
+      - junit-runner-unit-tests
+      - junit-runner-emulator-tests
+      - playground-automobile-emulator-tests
+      - android-accessibility-service-unit-tests
+      - build-junit-runner-library
+      - build-android-accessibility-service
+      - build-playground-app
+      - benchmark-context-thresholds
+    env:
+      MAVEN_USERNAME: ${{ secrets.MAVEN_USERNAME || vars.MAVEN_USERNAME }}
+      MAVEN_PASSWORD: ${{ secrets.MAVEN_PASSWORD || vars.MAVEN_PASSWORD }}
+    steps:
+      - name: "Git Checkout"
+        uses: actions/checkout@v4
+
+      - name: "Read JUnitRunner version"
+        id: junit-runner-version
+        shell: bash
+        run: |
+          version_line=$(grep -E '^version = "' android/junit-runner/build.gradle.kts || true)
+          if [ -z "$version_line" ]; then
+            echo "Could not find JUnitRunner version in android/junit-runner/build.gradle.kts" >&2
+            exit 1
+          fi
+          version=$(echo "$version_line" | sed -E 's/version = "([^"]+)"/\1/')
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "JUnitRunner version: $version"
+
+      - name: "Verify Maven Central credentials"
+        if: ${{ endsWith(steps.junit-runner-version.outputs.version, '-SNAPSHOT') }}
+        shell: bash
+        run: |
+          if [ -z "$MAVEN_USERNAME" ] || [ -z "$MAVEN_PASSWORD" ]; then
+            echo "Missing MAVEN_USERNAME or MAVEN_PASSWORD for snapshot publish." >&2
+            exit 1
+          fi
+
+      - uses: ./.github/actions/gradle-task-run
+        if: ${{ endsWith(steps.junit-runner-version.outputs.version, '-SNAPSHOT') }}
+        with:
+          gradle-tasks: ":junit-runner:publishToMavenCentral"
+          gradle-project-directory: "android"
+          gradle-home-directory: "~/.gradle/${{ github.job }}"
+          reuse-configuration-cache: true
+          gradle-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
+
+      - name: "Skip snapshot publish (non-snapshot version)"
+        if: ${{ !endsWith(steps.junit-runner-version.outputs.version, '-SNAPSHOT') }}
+        run: |
+          echo "Skipping publish. Version is ${{ steps.junit-runner-version.outputs.version }}."
+
 #  playground-app-unit-tests:
 #    name: "Build Playground App"
 #    runs-on: ubuntu-latest

--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -1,6 +1,7 @@
 # npm Publishing
 
 This guide covers publishing `@kaeawc/auto-mobile` to npm.
+For Android JUnitRunner (Maven Central), see `docs/design-docs/plat/android/junitrunner.md`.
 
 ## Prerequisites
 

--- a/android/junit-runner/src/main/kotlin/dev/jasonpearson/automobile/junit/README.md
+++ b/android/junit-runner/src/main/kotlin/dev/jasonpearson/automobile/junit/README.md
@@ -267,9 +267,11 @@ Add to your `build.gradle`:
 
 ```gradle
 dependencies {
-    testImplementation 'dev.jasonpearson.auto-mobile:auto-mobile-junit-runner:1.0.0'
+    testImplementation 'dev.jasonpearson.auto-mobile:auto-mobile-junit-runner:x.y.z'
 }
 ```
+
+This artifact is intended for Maven Central distribution. Use the latest release version once published.
 
 Ensure AutoMobile daemon dependencies are available:
 
@@ -278,3 +280,13 @@ Ensure AutoMobile daemon dependencies are available:
 # The runner will start the daemon automatically when needed.
 npm install -g auto-mobile
 ```
+
+## Publishing (Maintainers)
+
+```bash
+cd android
+./gradlew :junit-runner:publishToMavenCentral
+```
+
+Release the deployment in https://central.sonatype.com (or use
+`./gradlew :junit-runner:publishAndReleaseToMavenCentral` for auto-release).

--- a/android/settings.gradle.kts
+++ b/android/settings.gradle.kts
@@ -1,4 +1,15 @@
 dependencyResolutionManagement {
+  val mavenUsername = System.getenv("MAVEN_USERNAME")
+  if (!mavenUsername.isNullOrBlank() &&
+      System.getProperty("org.gradle.project.mavenCentralUsername").isNullOrBlank()) {
+    System.setProperty("org.gradle.project.mavenCentralUsername", mavenUsername)
+  }
+  val mavenPassword = System.getenv("MAVEN_PASSWORD")
+  if (!mavenPassword.isNullOrBlank() &&
+      System.getProperty("org.gradle.project.mavenCentralPassword").isNullOrBlank()) {
+    System.setProperty("org.gradle.project.mavenCentralPassword", mavenPassword)
+  }
+
   @Suppress("UnstableApiUsage") repositoriesMode.set(RepositoriesMode.PREFER_PROJECT)
   // Use Maven Central as the default repository (where Gradle will download dependencies) in all
   // subprojects.

--- a/docs/design-docs/plat/android/junitrunner.md
+++ b/docs/design-docs/plat/android/junitrunner.md
@@ -9,15 +9,16 @@ modules that cover the UI you want to test.
 testImplementation("dev.jasonpearson.auto-mobile:auto-mobile-junit-runner:x.y.z")
 ```
 
-Note that this artifact hasn't been published to Maven Central just yet and is forthcoming.
+This artifact is intended for Maven Central distribution. Use the latest release version once published.
 
-In the meantime, publish to your mavenLocal (`~/.m2`) via:
+For local development or testing unpublished changes, publish to your mavenLocal (`~/.m2`) via:
 
 ```
-./gradlew publishToMavenLocal
+cd android
+./gradlew :junit-runner:publishToMavenLocal
 ```
 
-and use the above testImplementation dependency with `x.y.z` version from `android/junit-runner/build.gradle.kts`.
+and use the above testImplementation dependency with the version from `android/junit-runner/build.gradle.kts`.
 
 ## Configuration
 
@@ -122,9 +123,26 @@ android {
 }
 ```
 
+## Publishing (Manual)
+
+1. Update `version` in `android/junit-runner/build.gradle.kts` to a release value (no `-SNAPSHOT`).
+2. Ensure Maven Central credentials are available as Gradle properties (`mavenCentralUsername`,
+   `mavenCentralPassword`). These can live in `~/.gradle/gradle.properties` or be provided via
+   `ORG_GRADLE_PROJECT_` environment variables.
+3. Ensure signing credentials are configured (for example `signingInMemoryKey` and
+   `signingInMemoryKeyPassword`, or the `signing.*` Gradle properties).
+4. From `android/`, run:
+
+```
+./gradlew :junit-runner:publishToMavenCentral
+```
+
+5. Release the deployment in https://central.sonatype.com (or run
+   `./gradlew :junit-runner:publishAndReleaseToMavenCentral` to auto-release).
+
 ## Best Practices
 
-1. **Use mavenLocal for development** - Until published to Maven Central
+1. **Use mavenLocal for local iteration** - Helpful for testing unpublished changes
 2. **Enable the [Accessibility Service](accessibility-service.md)** - Required for real-time view hierarchy access
 3. **Configure API keys securely** - Use environment variables in CI, avoid hardcoding
 4. **Enable timing optimization** - Use historical timing data to order tests efficiently


### PR DESCRIPTION
## Summary
- add a merge workflow job to publish JUnitRunner snapshots when version ends with -SNAPSHOT
- wire Maven Central creds from CI env vars and link JUnitRunner publishing docs
- expand JUnitRunner docs with local publish and manual release steps

## Testing
- ACT_DRY_RUN=true scripts/act/validate_act.sh
- cd android && ./gradlew :junit-runner:publishToMavenLocal

Refs #121
