### PR TITLE
Gate debug-only MCP tools

### DIFF
--- a/schemas/tool-definitions.json
+++ b/schemas/tool-definitions.json
@@ -48,68 +48,6 @@
     }
   },
   {
-    "name": "bugReport",
-    "description": "Generate a comprehensive bug report for debugging AutoMobile interactions. Captures screen state, view hierarchy, logcat, window info, and optionally a screenshot. The report can be saved to a file for sharing with AutoMobile developers.",
-    "inputSchema": {
-      "type": "object",
-      "properties": {
-        "platform": {
-          "type": "string",
-          "enum": [
-            "android",
-            "ios"
-          ],
-          "description": "Target platform"
-        },
-        "appId": {
-          "type": "string",
-          "description": "App package ID to filter logcat for specific app"
-        },
-        "includeScreenshot": {
-          "type": "boolean",
-          "description": "Whether to include screenshot (default: true)"
-        },
-        "includeRawHierarchy": {
-          "type": "boolean",
-          "description": "Whether to include raw view hierarchy XML (default: true)"
-        },
-        "includeLogcat": {
-          "type": "boolean",
-          "description": "Whether to include logcat entries (default: true)"
-        },
-        "logcatLines": {
-          "type": "number",
-          "description": "Number of recent logcat lines to include (default: 100)"
-        },
-        "saveToFile": {
-          "type": "boolean",
-          "description": "Whether to save full report to a file (default: false)"
-        },
-        "saveDir": {
-          "type": "string",
-          "description": "Directory to save report to"
-        },
-        "sessionUuid": {
-          "type": "string",
-          "description": "Session UUID for device targeting"
-        },
-        "keepScreenAwake": {
-          "type": "boolean",
-          "description": "Keep physical Android devices awake during the session (default: true)"
-        },
-        "device": {
-          "type": "string",
-          "description": "Device label for multi-device plans (e.g., \"A\", \"B\")"
-        }
-      },
-      "required": [
-        "platform"
-      ],
-      "additionalProperties": false,
-      "$schema": "http://json-schema.org/draft-07/schema#"
-    }
-  },
-  {
     "name": "captureDeviceSnapshot",
     "description": "Capture current device state as a snapshot for later restoration. Supports both VM snapshots (emulators) and ADB-based capture (all devices).",
     "inputSchema": {
@@ -367,79 +305,6 @@
       },
       "required": [
         "sessionId"
-      ],
-      "additionalProperties": false,
-      "$schema": "http://json-schema.org/draft-07/schema#"
-    }
-  },
-  {
-    "name": "debugSearch",
-    "description": "Debug element search operations. Shows all matching elements, which one would be selected, and near-misses that almost matched. Use this to understand why an element isn't being found or why the wrong element is being selected.",
-    "inputSchema": {
-      "type": "object",
-      "properties": {
-        "platform": {
-          "type": "string",
-          "enum": [
-            "android",
-            "ios"
-          ],
-          "description": "Target platform"
-        },
-        "text": {
-          "type": "string",
-          "description": "Text to search for in elements"
-        },
-        "resourceId": {
-          "type": "string",
-          "description": "Resource ID to search for"
-        },
-        "container": {
-          "type": "object",
-          "properties": {
-            "elementId": {
-              "type": "string",
-              "description": "Container element resource ID to restrict search within"
-            },
-            "text": {
-              "type": "string",
-              "description": "Container element text to restrict search within"
-            }
-          },
-          "additionalProperties": false,
-          "description": "Container element to scope the search - specify elementId or text to locate it"
-        },
-        "fuzzyMatch": {
-          "type": "boolean",
-          "description": "Whether to use fuzzy matching (default: true)"
-        },
-        "caseSensitive": {
-          "type": "boolean",
-          "description": "Whether to use case-sensitive matching (default: false)"
-        },
-        "includeNearMisses": {
-          "type": "boolean",
-          "description": "Include elements that almost matched (default: true)"
-        },
-        "maxNearMisses": {
-          "type": "number",
-          "description": "Maximum number of near-misses to include (default: 10)"
-        },
-        "sessionUuid": {
-          "type": "string",
-          "description": "Session UUID for device targeting"
-        },
-        "keepScreenAwake": {
-          "type": "boolean",
-          "description": "Keep physical Android devices awake during the session (default: true)"
-        },
-        "device": {
-          "type": "string",
-          "description": "Device label for multi-device plans (e.g., \"A\", \"B\")"
-        }
-      },
-      "required": [
-        "platform"
       ],
       "additionalProperties": false,
       "$schema": "http://json-schema.org/draft-07/schema#"
@@ -954,37 +819,6 @@
     }
   },
   {
-    "name": "getNavigationGraph",
-    "description": "Get navigation graph for debugging",
-    "inputSchema": {
-      "type": "object",
-      "properties": {
-        "platform": {
-          "type": "string",
-          "enum": [
-            "android",
-            "ios"
-          ],
-          "default": "android"
-        },
-        "sessionUuid": {
-          "type": "string",
-          "description": "Session UUID for device targeting"
-        },
-        "keepScreenAwake": {
-          "type": "boolean",
-          "description": "Keep physical Android devices awake during the session (default: true)"
-        },
-        "device": {
-          "type": "string",
-          "description": "Device label for multi-device plans (e.g., \"A\", \"B\")"
-        }
-      },
-      "additionalProperties": false,
-      "$schema": "http://json-schema.org/draft-07/schema#"
-    }
-  },
-  {
     "name": "getTestTimings",
     "description": "Retrieve aggregated historical test execution timing statistics for optimization.",
     "inputSchema": {
@@ -1107,91 +941,6 @@
             "ios"
           ],
           "description": "Platform"
-        },
-        "sessionUuid": {
-          "type": "string",
-          "description": "Session UUID for device targeting"
-        },
-        "keepScreenAwake": {
-          "type": "boolean",
-          "description": "Keep physical Android devices awake during the session (default: true)"
-        },
-        "device": {
-          "type": "string",
-          "description": "Device label for multi-device plans (e.g., \"A\", \"B\")"
-        }
-      },
-      "required": [
-        "platform"
-      ],
-      "additionalProperties": false,
-      "$schema": "http://json-schema.org/draft-07/schema#"
-    }
-  },
-  {
-    "name": "identifyInteractions",
-    "description": "Suggest likely interactions",
-    "inputSchema": {
-      "type": "object",
-      "properties": {
-        "platform": {
-          "type": "string",
-          "enum": [
-            "android",
-            "ios"
-          ],
-          "description": "Platform"
-        },
-        "filter": {
-          "type": "object",
-          "properties": {
-            "types": {
-              "type": "array",
-              "items": {
-                "type": "string",
-                "enum": [
-                  "navigation",
-                  "input",
-                  "action",
-                  "scroll",
-                  "toggle"
-                ]
-              },
-              "description": "Interaction types"
-            },
-            "minConfidence": {
-              "type": "number",
-              "minimum": 0,
-              "maximum": 1,
-              "description": "Min confidence (0-1)"
-            },
-            "limit": {
-              "type": "integer",
-              "exclusiveMinimum": 0,
-              "description": "Max results"
-            }
-          },
-          "additionalProperties": false,
-          "description": "Filter options"
-        },
-        "includeContext": {
-          "type": "object",
-          "properties": {
-            "navigationGraph": {
-              "type": "boolean",
-              "description": "Include nav graph predictions"
-            },
-            "elementDetails": {
-              "type": "boolean",
-              "description": "Include element details"
-            },
-            "suggestedParams": {
-              "type": "boolean",
-              "description": "Include tool params"
-            }
-          },
-          "additionalProperties": false,
-          "description": "Context options"
         },
         "sessionUuid": {
           "type": "string",
@@ -1896,49 +1645,6 @@
       },
       "required": [
         "key",
-        "platform"
-      ],
-      "additionalProperties": false,
-      "$schema": "http://json-schema.org/draft-07/schema#"
-    }
-  },
-  {
-    "name": "rawViewHierarchy",
-    "description": "Get raw view hierarchy data without parsing. Returns XML from uiautomator and/or JSON from accessibility service. Useful for debugging when parsed hierarchy doesn't match what's on screen.",
-    "inputSchema": {
-      "type": "object",
-      "properties": {
-        "platform": {
-          "type": "string",
-          "enum": [
-            "android",
-            "ios"
-          ],
-          "description": "Target platform"
-        },
-        "source": {
-          "type": "string",
-          "enum": [
-            "uiautomator",
-            "accessibility-service",
-            "both"
-          ],
-          "description": "Source for hierarchy extraction: 'uiautomator' for raw XML, 'accessibility-service' for JSON, or 'both' for comparison"
-        },
-        "sessionUuid": {
-          "type": "string",
-          "description": "Session UUID for device targeting"
-        },
-        "keepScreenAwake": {
-          "type": "boolean",
-          "description": "Keep physical Android devices awake during the session (default: true)"
-        },
-        "device": {
-          "type": "string",
-          "description": "Device label for multi-device plans (e.g., \"A\", \"B\")"
-        }
-      },
-      "required": [
         "platform"
       ],
       "additionalProperties": false,

--- a/src/server/debugTools.ts
+++ b/src/server/debugTools.ts
@@ -147,20 +147,26 @@ export function registerDebugTools() {
     "rawViewHierarchy",
     "Get raw view hierarchy data without parsing. Returns XML from uiautomator and/or JSON from accessibility service. Useful for debugging when parsed hierarchy doesn't match what's on screen.",
     rawViewHierarchySchema,
-    rawViewHierarchyHandler
+    rawViewHierarchyHandler,
+    false,
+    true
   );
 
   ToolRegistry.registerDeviceAware(
     "debugSearch",
     "Debug element search operations. Shows all matching elements, which one would be selected, and near-misses that almost matched. Use this to understand why an element isn't being found or why the wrong element is being selected.",
     debugSearchSchema,
-    debugSearchHandler
+    debugSearchHandler,
+    false,
+    true
   );
 
   ToolRegistry.registerDeviceAware(
     "bugReport",
     "Generate a comprehensive bug report for debugging AutoMobile interactions. Captures screen state, view hierarchy, logcat, window info, and optionally a screenshot. The report can be saved to a file for sharing with AutoMobile developers.",
     bugReportSchema,
-    bugReportHandler
+    bugReportHandler,
+    false,
+    true
   );
 }

--- a/src/server/navigationTools.ts
+++ b/src/server/navigationTools.ts
@@ -126,7 +126,9 @@ export function registerNavigationTools() {
     "getNavigationGraph",
     "Get navigation graph for debugging",
     getNavigationGraphSchema,
-    getNavigationGraphHandler
+    getNavigationGraphHandler,
+    false,
+    true
   );
 
   // Explore handler

--- a/src/server/observeTools.ts
+++ b/src/server/observeTools.ts
@@ -136,6 +136,8 @@ export function registerObserveTools() {
     "identifyInteractions",
     "Suggest likely interactions",
     identifyInteractionsSchema,
-    identifyInteractionsHandler
+    identifyInteractionsHandler,
+    false,
+    true
   );
 }

--- a/src/server/toolRegistry.ts
+++ b/src/server/toolRegistry.ts
@@ -15,6 +15,7 @@ import { createToolExecutionContext, updateSessionCache } from "./ToolExecutionC
 import { AppCleanupService, DefaultAppCleanupService } from "./AppCleanupService";
 import { ToolCallRepository } from "../db/toolCallRepository";
 import { getDeviceLabelMap, releaseDeviceLabelSessions } from "./deviceLabelMapping";
+import { isDebugModeEnabled } from "../utils/debug";
 
 // Progress notification interface
 export interface ProgressCallback {
@@ -40,6 +41,7 @@ export interface RegisteredTool {
   supportsProgress?: boolean;
     requiresDevice?: boolean;
     deviceAwareHandler?: DeviceAwareToolHandler;
+  debugOnly?: boolean;
 }
 
 // The registry that holds all tools
@@ -55,15 +57,28 @@ class ToolRegistryClass {
     this.toolCallRepository = new ToolCallRepository();
   }
 
+  private isToolAvailable(tool: RegisteredTool): boolean {
+    return !tool.debugOnly || isDebugModeEnabled();
+  }
+
   // Register a new tool
   register(
     name: string,
     description: string,
     schema: any,
     handler: ToolHandler,
-    supportsProgress: boolean = false
+    supportsProgress: boolean = false,
+    debugOnly: boolean = false
   ): void {
-    this.tools.set(name, { name, description, schema, handler, supportsProgress, requiresDevice: false });
+    this.tools.set(name, {
+      name,
+      description,
+      schema,
+      handler,
+      supportsProgress,
+      requiresDevice: false,
+      debugOnly
+    });
   }
 
   // Helper: Get foreground app package name
@@ -89,7 +104,8 @@ class ToolRegistryClass {
     description: string,
     schema: any,
     handler: DeviceAwareToolHandler,
-    supportsProgress: boolean = false
+    supportsProgress: boolean = false,
+    debugOnly: boolean = false
   ): void {
     // Create a wrapper that handles device ID injection
     const wrappedHandler: ToolHandler = async (args: any, progress?: ProgressCallback, signal?: AbortSignal) => {
@@ -309,18 +325,23 @@ class ToolRegistryClass {
       handler: wrappedHandler,
       supportsProgress,
       requiresDevice: true,
-      deviceAwareHandler: handler
+      deviceAwareHandler: handler,
+      debugOnly
     });
   }
 
   // Get all registered tools
   getAllTools(): RegisteredTool[] {
-    return Array.from(this.tools.values());
+    return Array.from(this.tools.values()).filter(tool => this.isToolAvailable(tool));
   }
 
   // Get a specific tool by name
   getTool(name: string): RegisteredTool | undefined {
-    return this.tools.get(name);
+    const tool = this.tools.get(name);
+    if (!tool || !this.isToolAvailable(tool)) {
+      return undefined;
+    }
+    return tool;
   }
 
   // Register all tools with an MCP server
@@ -344,7 +365,7 @@ class ToolRegistryClass {
 
   // Get tools in MCP format
   getToolDefinitions() {
-    return Array.from(this.tools.values()).map(tool => ({
+    return this.getAllTools().map(tool => ({
       name: tool.name,
       description: tool.description,
       inputSchema: zodToJsonSchema(tool.schema)
@@ -354,7 +375,7 @@ class ToolRegistryClass {
   // Get a map of all schema
   getSchemaMap(): Record<string, any> {
     const schemaMap: Record<string, any> = {};
-    this.tools.forEach(tool => {
+    this.getAllTools().forEach(tool => {
       schemaMap[tool.name] = tool.schema;
     });
     return schemaMap;


### PR DESCRIPTION
## Summary
- gate identifyInteractions and getNavigationGraph behind debug-only registration
- mark debug tools as debug-only and filter tool lists based on debug mode
- regenerate tool definitions

## Testing
- bun run test

## Issue
- Closes #594
