### PR TITLE
Restrict executePlan and criticalSection tools to daemon mode

### DIFF
--- a/docs/critical-section.md
+++ b/docs/critical-section.md
@@ -4,6 +4,10 @@
 
 The `criticalSection` tool provides multi-device synchronization for serialized execution of steps. It implements a barrier synchronization pattern where all devices must arrive at the critical section before any can proceed, and then executes steps one device at a time.
 
+## Availability
+
+The `criticalSection` tool is available only when the AutoMobile daemon is running (daemon-backed MCP server). It is not registered in standalone MCP mode.
+
 ## Use Cases
 
 Critical sections are useful when you need to:

--- a/docs/design-docs/mcp/actions.md
+++ b/docs/design-docs/mcp/actions.md
@@ -54,7 +54,8 @@ In cases where the agent needs to determine what to do next, the [observe](obser
 
 #### Testing & Debugging
 
-- 🧪 `executePlan` executes a series of tool calls from a YAML plan content, stopping if any step fails.
+- 🧪 `executePlan` (daemon mode only) executes a series of tool calls from a YAML plan content, stopping if any step fails.
+- 🔒 `criticalSection` (daemon mode only) coordinates multiple devices at a synchronization barrier for serialized steps.
 - 🩺 `doctor` runs diagnostic checks to verify AutoMobile setup and environment configuration.
 - 🐛 `bugReport` generates a comprehensive bug report including screen state, view hierarchy, logcat, and screenshot.
 - 🔍 `debugSearch` debugs element search operations to understand why elements aren't found or wrong elements are selected.

--- a/docs/validation/yaml-test-plans.md
+++ b/docs/validation/yaml-test-plans.md
@@ -39,7 +39,7 @@ The schema validates:
 
 Validation happens automatically in two places:
 
-**MCP Server (`executePlan` tool):**
+**Daemon-backed MCP Server (`executePlan` tool, daemon mode only):**
 - Validates YAML before parsing
 - Runs in TypeScript using AJV (Another JSON Schema Validator)
 - Reports errors with line/column numbers when possible

--- a/src/daemon/daemon.ts
+++ b/src/daemon/daemon.ts
@@ -325,7 +325,11 @@ export class Daemon {
           // Create and connect MCP server
           let mcpServer;
           try {
-            mcpServer = createMcpServer({ debug: this.debug, sessionContext });
+            mcpServer = createMcpServer({
+              debug: this.debug,
+              sessionContext,
+              daemonMode: true
+            });
           } catch (error) {
             logger.error("Failed to create MCP server:", error);
             sendJsonRpcError("Server error", error);

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -53,6 +53,7 @@ export interface McpServerOptions {
   debug?: boolean;
   sessionContext?: { sessionId?: string };
   planExecutionLock?: PlanExecutionLock;
+  daemonMode?: boolean;
 }
 
 function formatToolParamError(toolName: string, error: unknown): string {
@@ -85,6 +86,7 @@ export const createMcpServer = (options: McpServerOptions = {}): McpServer => {
   // Plan execution lock with per-session scope to prevent interference during executePlan
   // Each test thread gets its own sessionUuid, enabling parallel execution on different devices
   const planExecutionLock = options.planExecutionLock ?? createDefaultPlanExecutionLock();
+  const daemonMode = options.daemonMode ?? false;
   void FeatureFlagService.getInstance()
     .initialize()
     .catch(error => {
@@ -103,10 +105,12 @@ export const createMcpServer = (options: McpServerOptions = {}): McpServer => {
   registerNavigationTools();
   registerNotificationTools();
   registerDaemonTools();
-  registerPlanTools();
+  if (daemonMode) {
+    registerPlanTools();
+    registerCriticalSectionTools();
+  }
   registerDoctorTools();
   registerFeatureFlagTools();
-  registerCriticalSectionTools();
   registerVideoRecordingTools();
   registerSnapshotTools();
   registerBiometricTools();

--- a/src/server/planTools.ts
+++ b/src/server/planTools.ts
@@ -253,7 +253,7 @@ const executePlanTool = async (device: BootedDevice, params: {
   }
 };
 
-// Register plan tools. Note that only AutoMobile CLI includes this since we do not execute plans in MCP mode.
+// Register plan tools for daemon-backed MCP servers and CLI usage.
 export const registerPlanTools = () => {
   ToolRegistry.registerDeviceAware(
     "executePlan",

--- a/test/server/tools/daemonModeTools.test.ts
+++ b/test/server/tools/daemonModeTools.test.ts
@@ -1,0 +1,29 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { createMcpServer } from "../../../src/server/index";
+import { ToolRegistry } from "../../../src/server/toolRegistry";
+
+describe("Daemon-only MCP tools", () => {
+  beforeEach(() => {
+    (ToolRegistry as any).tools.clear();
+  });
+
+  afterEach(() => {
+    (ToolRegistry as any).tools.clear();
+  });
+
+  test("does not register executePlan or criticalSection outside daemon mode", () => {
+    createMcpServer();
+
+    const toolNames = ToolRegistry.getToolDefinitions().map(tool => tool.name);
+    expect(toolNames).not.toContain("executePlan");
+    expect(toolNames).not.toContain("criticalSection");
+  });
+
+  test("registers executePlan and criticalSection in daemon mode", () => {
+    createMcpServer({ daemonMode: true });
+
+    const toolNames = ToolRegistry.getToolDefinitions().map(tool => tool.name);
+    expect(toolNames).toContain("executePlan");
+    expect(toolNames).toContain("criticalSection");
+  });
+});


### PR DESCRIPTION
## Summary
- register executePlan and criticalSection only when daemon mode is enabled
- add a daemon-only tool registration test
- document daemon-only availability

## Testing
- bun run test test/server/tools/daemonModeTools.test.ts

## Issue
- Fixes #603
