### PR TITLE
Remove daemon_available_devices tool

### DIFF
--- a/android/ide-plugin/src/main/kotlin/dev/jasonpearson/automobile/ide/yaml/TestPlanQuickFixes.kt
+++ b/android/ide-plugin/src/main/kotlin/dev/jasonpearson/automobile/ide/yaml/TestPlanQuickFixes.kt
@@ -163,7 +163,7 @@ object TestPlanQuickFixFactory {
         "listDeviceImages",
         "debugSearch", "bugReport",
         "doctor",
-        "daemon_available_devices", "daemon_session_info", "daemon_release_session"
+        "daemon_session_info", "daemon_release_session"
     )
 
     /**

--- a/android/ide-plugin/src/main/kotlin/dev/jasonpearson/automobile/ide/yaml/TestPlanToolCategories.kt
+++ b/android/ide-plugin/src/main/kotlin/dev/jasonpearson/automobile/ide/yaml/TestPlanToolCategories.kt
@@ -83,7 +83,6 @@ object TestPlanToolCategories {
             "doctor"
         ),
         "Daemon" to setOf(
-            "daemon_available_devices",
             "daemon_refresh_devices",
             "daemon_session_info",
             "daemon_release_session"

--- a/android/ide-plugin/src/main/kotlin/dev/jasonpearson/automobile/ide/yaml/TestPlanValidator.kt
+++ b/android/ide-plugin/src/main/kotlin/dev/jasonpearson/automobile/ide/yaml/TestPlanValidator.kt
@@ -80,7 +80,7 @@ object TestPlanValidator {
         // Doctor
         "doctor",
         // Daemon
-        "daemon_available_devices", "daemon_session_info", "daemon_release_session"
+        "daemon_session_info", "daemon_release_session"
     )
 
     /**

--- a/android/junit-runner/src/main/kotlin/dev/jasonpearson/automobile/junit/DaemonSocketClient.kt
+++ b/android/junit-runner/src/main/kotlin/dev/jasonpearson/automobile/junit/DaemonSocketClient.kt
@@ -24,6 +24,7 @@ import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.intOrNull
+import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
 
@@ -125,6 +126,7 @@ internal object DaemonSocketClientManager {
    */
   private fun waitForDevicePoolReady(timeoutMs: Long) {
     val debugMode = SystemPropertyCache.getBoolean("automobile.debug", false)
+    val json = Json { ignoreUnknownKeys = true }
     if (debugMode) {
       println("Waiting for daemon device pool to initialize...")
     }
@@ -162,16 +164,27 @@ internal object DaemonSocketClientManager {
           nextRefreshTime = now + 2000 // Schedule next refresh in 2 seconds
         }
 
-        val response = socketClient.callDaemonMethod(
-            "daemon/availableDevices",
+        val response = socketClient.callTool(
+            "listDevices",
+            JsonObject(mapOf("platform" to JsonPrimitive("android"))),
             5000
         )
         socketClient.close()
 
         if (response.success) {
-          val totalDevices = response.result
-              ?.jsonObject?.get("totalDevices")
-              ?.jsonPrimitive?.intOrNull ?: 0
+          val payloadText = response.result
+              ?.jsonObject?.get("content")
+              ?.jsonArray?.firstOrNull()
+              ?.jsonObject?.get("text")
+              ?.jsonPrimitive?.content
+          val parsedResult = payloadText?.let { json.parseToJsonElement(it).jsonObject }
+          val poolStatus = parsedResult?.get("poolStatus")?.jsonObject
+          val totalDevices = poolStatus
+              ?.get("total")
+              ?.jsonPrimitive
+              ?.intOrNull
+              ?: parsedResult?.get("totalCount")?.jsonPrimitive?.intOrNull
+              ?: 0
 
           if (totalDevices > 0) {
             if (debugMode) {

--- a/android/test-plan-validation/src/main/kotlin/dev/jasonpearson/automobile/validation/ValidTools.kt
+++ b/android/test-plan-validation/src/main/kotlin/dev/jasonpearson/automobile/validation/ValidTools.kt
@@ -19,7 +19,7 @@ object ValidTools {
         "listDeviceImages",
         "debugSearch", "bugReport",
         "doctor",
-        "daemon_available_devices", "daemon_session_info", "daemon_release_session",
+        "daemon_session_info", "daemon_release_session",
         "biometricAuth", "clipboard"
     )
 

--- a/docs/design-docs/mcp/actions.md
+++ b/docs/design-docs/mcp/actions.md
@@ -47,7 +47,7 @@ In cases where the agent needs to determine what to do next, the [observe](obser
 
 #### Advanced Device Management
 
-- 📱 `listDevices` lists all connected devices (physical and emulators).
+- 📱 `listDevices` lists all connected devices (physical and emulators); when the daemon is active it includes pool status in `poolStatus`.
 - 🚀 `startDevice` starts a device with the specified device image.
 - ❌ `killDevice` terminates a running device.
 - 🔧 `setActiveDevice` sets the active device for subsequent operations.
@@ -69,6 +69,5 @@ In cases where the agent needs to determine what to do next, the [observe](obser
 
 #### Daemon & Session Management
 
-- 🔢 `daemon_available_devices` queries number of available devices in daemon pool.
 - 📋 `daemon_session_info` gets information about an existing session.
 - 🔓 `daemon_release_session` releases a session and frees its device.

--- a/docs/design-docs/mcp/daemon.md
+++ b/docs/design-docs/mcp/daemon.md
@@ -67,8 +67,8 @@ The daemon listens on a Unix socket at:
 
 ## MCP Tools
 
-### `daemon_available_devices`
-Query available devices in the pool.
+### `listDevices`
+List connected devices; when the daemon is active, responses include `poolStatus` with pool counts.
 
 ### `daemon_session_info`
 Get information about an active session.

--- a/schemas/tool-definitions.json
+++ b/schemas/tool-definitions.json
@@ -255,16 +255,6 @@
     }
   },
   {
-    "name": "daemon_available_devices",
-    "description": "Query number of available devices in daemon pool",
-    "inputSchema": {
-      "type": "object",
-      "properties": {},
-      "additionalProperties": false,
-      "$schema": "http://json-schema.org/draft-07/schema#"
-    }
-  },
-  {
     "name": "daemon_refresh_devices",
     "description": "Refresh device pool by discovering connected devices",
     "inputSchema": {

--- a/scripts/benchmark-startup.sh
+++ b/scripts/benchmark-startup.sh
@@ -187,7 +187,7 @@ daemon_call() {
   local request
   request=$(jq -c -n \
     --arg id "$request_id" \
-    '{id:$id, type:"mcp_request", method:"tools/call", params:{name:"daemon_available_devices", arguments:{}}}')
+    '{id:$id, type:"mcp_request", method:"tools/call", params:{name:"listDevices", arguments:{platform:"android"}}}')
 
   local response
   if [[ "$daemon_socket_client" == "python" ]]; then
@@ -395,13 +395,13 @@ run_mcp_server() {
 
   mcp_send 3 '{"jsonrpc":"2.0","method":"notifications/initialized"}'
 
-  if ! mcp_call 3 4 "daemon_available_devices" '{}' 10 >/dev/null; then
+  if ! mcp_call 3 4 "listDevices" '{"platform":"android"}' 10 >/dev/null; then
     stop_process "$server_pid"
     exec 3>&-
     exec 4<&-
     exec 5<&-
     rm -rf "$fifo_dir"
-    echo "Failed to call daemon_available_devices" >&2
+    echo "Failed to call listDevices" >&2
     return 1
   fi
   local time_to_first_tool_call_ms

--- a/src/daemon/devicePool.ts
+++ b/src/daemon/devicePool.ts
@@ -283,7 +283,7 @@ export class DevicePool {
           `  Error: ${currentStats.error}\n\n` +
           `Suggestions:\n` +
           `  - Start an emulator or connect a physical device\n` +
-          `  - Check device pool status: auto-mobile --daemon available-devices\n` +
+          `  - Check device pool status: auto-mobile --cli listDevices --platform android\n` +
           `  - Verify ADB is working: adb devices`
         );
       } else {
@@ -413,7 +413,7 @@ export class DevicePool {
           `  Error: ${stats.error}\n\n` +
           `Suggestions:\n` +
           `  - Start an emulator or connect a physical device\n` +
-          `  - Check device pool status: auto-mobile --daemon available-devices\n` +
+          `  - Check device pool status: auto-mobile --cli listDevices --platform android\n` +
           `  - Verify ADB is working: adb devices`
         );
       }

--- a/src/daemon/manager.ts
+++ b/src/daemon/manager.ts
@@ -539,30 +539,6 @@ export async function runDaemonCommand(
         break;
       }
 
-      case "available-devices": {
-        // Check if running in daemon process
-        if (DaemonState.getInstance().isInitialized()) {
-          // Running inside daemon process
-          const pool = DaemonState.getInstance().getDevicePool();
-          const idleDevices = pool.getIdleDevices();
-          console.log(JSON.stringify({ availableDevices: idleDevices.length }));
-        } else {
-          // Running from CLI - query daemon via socket
-          const client = new DaemonClient();
-          try {
-            await client.connect();
-            const result = await client.callTool("daemon_available_devices", {});
-            console.log(JSON.stringify(result));
-            await client.close();
-          } catch (error) {
-            throw new ActionableError(
-              `Failed to query available devices: ${error instanceof Error ? error.message : String(error)}`
-            );
-          }
-        }
-        break;
-      }
-
       case "session-info": {
         if (args.length === 0) {
           throw new ActionableError("session-info requires a session ID argument");
@@ -648,7 +624,6 @@ export async function runDaemonCommand(
         console.log("  restart               Restart the daemon");
         console.log("  health                Check daemon health");
         console.log("  diagnose              Run full diagnostics");
-        console.log("  available-devices     Query number of available devices");
         console.log("  session-info <id>     Get information about a session");
         console.log("  release-session <id>  Release a session and free its device");
         process.exit(1);

--- a/src/daemon/socketServer.ts
+++ b/src/daemon/socketServer.ts
@@ -221,28 +221,6 @@ export class UnixSocketServer {
           stats: stats,
         };
       }
-      case "daemon/availableDevices": {
-        // Direct device pool query without going through MCP
-        const state = DaemonState.getInstance();
-        if (!state.isInitialized()) {
-          return {
-            success: false,
-            error: "Daemon not initialized",
-            availableDevices: 0,
-            totalDevices: 0,
-          };
-        }
-        const pool = state.getDevicePool();
-        const stats = pool.getStats();
-        return {
-          success: true,
-          availableDevices: stats.idle,
-          totalDevices: stats.total,
-          assignedDevices: stats.assigned,
-          errorDevices: stats.error,
-          stats: stats,
-        };
-      }
       default:
         throw new Error(`Unsupported daemon method: ${request.method}`);
     }

--- a/src/server/daemonTools.ts
+++ b/src/server/daemonTools.ts
@@ -3,57 +3,12 @@ import { ToolRegistry } from "./toolRegistry";
 import { DaemonState } from "../daemon/daemonState";
 import { ActionableError } from "../models";
 import { createJSONToolResponse } from "../utils/toolUtils";
-import { logger } from "../utils/logger";
 
 /**
  * Register internal daemon tools
  * These tools are used for daemon state queries and management
  */
 export function registerDaemonTools(): void {
-
-  // Available Devices Tool
-  ToolRegistry.register(
-    "daemon_available_devices",
-    "Query number of available devices in daemon pool",
-    z.object({}).strict(),
-    async () => {
-      try {
-        logger.info("[daemon_available_devices] TOOL CALLED!");
-        const state = DaemonState.getInstance();
-        logger.info("[daemon_available_devices] Got DaemonState instance");
-        const isInitialized = state.isInitialized();
-        logger.info(`[daemon_available_devices] DaemonState initialized: ${isInitialized}`);
-
-        if (!isInitialized) {
-          logger.error("[daemon_available_devices] DaemonState not initialized!");
-          return createJSONToolResponse({
-            message: "Daemon not running or device pool not initialized",
-            availableDevices: 0,
-            totalDevices: 0,
-          });
-        }
-
-        const devicePool = state.getDevicePool();
-        logger.info("[daemon_available_devices] Got device pool");
-        const stats = devicePool.getStats();
-        logger.info(`[daemon_available_devices] Device pool stats: ${JSON.stringify(stats)}`);
-
-        return createJSONToolResponse({
-          message: `Device pool status: ${stats.idle} idle, ${stats.assigned} assigned, ${stats.error} error (${stats.total} total)`,
-          availableDevices: stats.idle,
-          totalDevices: stats.total,
-          assignedDevices: stats.assigned,
-          errorDevices: stats.error,
-          stats: stats,
-        });
-      } catch (error) {
-        logger.error(`[daemon_available_devices] ERROR: ${error}`);
-        logger.error(`[daemon_available_devices] Stack: ${error instanceof Error ? error.stack : "no stack"}`);
-        throw error;
-      }
-    }
-  );
-
   // Session Info Tool
   ToolRegistry.register(
     "daemon_session_info",

--- a/src/server/deviceTools.ts
+++ b/src/server/deviceTools.ts
@@ -3,6 +3,7 @@ import { ToolRegistry, ProgressCallback } from "./toolRegistry";
 import { MultiPlatformDeviceManager, PlatformDeviceManager } from "../utils/deviceUtils";
 import { createJSONToolResponse } from "../utils/toolUtils";
 import { ActionableError, BootedDevice, DeviceInfo, SomePlatform } from "../models";
+import { DaemonState } from "../daemon/daemonState";
 import { notifyBootedDeviceResourcesUpdated } from "./bootedDeviceResources";
 import { syncInstalledAppResources } from "./appResources";
 
@@ -102,14 +103,48 @@ export function registerDeviceTools() {
       const virtualCount = devices.filter(d => d.isVirtual).length;
       const physicalCount = devices.filter(d => !d.isVirtual).length;
 
-      return createJSONToolResponse({
+      const response: {
+        message: string;
+        devices: Array<BootedDevice & { isVirtual: boolean }>;
+        totalCount: number;
+        virtualCount: number;
+        physicalCount: number;
+        platform: SomePlatform;
+        poolStatus?: {
+          idle: number;
+          assigned: number;
+          error: number;
+          total: number;
+        };
+      } = {
         message: `Found ${devices.length} connected ${args.platform} devices`,
         devices: devices,
         totalCount: devices.length,
         virtualCount: virtualCount,
         physicalCount: physicalCount,
         platform: args.platform
-      });
+      };
+
+      if (DaemonState.getInstance().isInitialized()) {
+        if (args.platform === "android") {
+          const stats = DaemonState.getInstance().getDevicePool().getStats();
+          response.poolStatus = {
+            idle: stats.idle,
+            assigned: stats.assigned,
+            error: stats.error,
+            total: stats.total
+          };
+        } else {
+          response.poolStatus = {
+            idle: 0,
+            assigned: 0,
+            error: 0,
+            total: 0
+          };
+        }
+      }
+
+      return createJSONToolResponse(response);
     } catch (error) {
       throw new ActionableError(`Failed to list ${args.platform} devices: ${error}`);
     }


### PR DESCRIPTION
## Summary
- remove the daemon_available_devices tool and the available-devices CLI path in favor of listDevices
- include optional poolStatus in listDevices responses (stubbed for iOS)
- update daemon socket usage, schemas, docs, benchmarks, and validators

## Testing
- bun run lint
- bun run build
- bash scripts/shellcheck/validate_shell_scripts.sh

Closes #607
