### PR TITLE
Optimize Docker publish cache export

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -554,8 +554,9 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: |
+            type=registry,ref=kaeawc/auto-mobile:latest
+            type=gha
           platforms: linux/amd64
 
       - name: "Update Docker Hub description"


### PR DESCRIPTION
## Summary
- avoid exporting GHA cache on Docker Hub publish; rely on registry + GHA as cache sources

## Testing
- `bash scripts/act/validate_act.sh`

## Issues
- Closes #640
