### PR TITLE
Add overlay manager support to accessibility service

### DIFF
--- a/android/accessibility-service/src/main/AndroidManifest.xml
+++ b/android/accessibility-service/src/main/AndroidManifest.xml
@@ -5,6 +5,7 @@
   <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
   <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
   <uses-permission android:name="android.permission.MANAGE_CA_CERTIFICATES" />
+  <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW" />
 
   <application
         android:allowBackup="true"

--- a/android/accessibility-service/src/main/kotlin/dev/jasonpearson/automobile/accessibilityservice/AutoMobileAccessibilityService.kt
+++ b/android/accessibility-service/src/main/kotlin/dev/jasonpearson/automobile/accessibilityservice/AutoMobileAccessibilityService.kt
@@ -80,6 +80,7 @@ class AutoMobileAccessibilityService : AccessibilityService() {
   private lateinit var webSocketServer: WebSocketServer
   private lateinit var hierarchyDebouncer: HierarchyDebouncer
   private val navigationEventAccumulator = NavigationEventAccumulator()
+  private lateinit var overlayManager: OverlayManager
   private val clipboardManager by lazy {
     getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
   }
@@ -185,6 +186,8 @@ class AutoMobileAccessibilityService : AccessibilityService() {
     Log.d(TAG, "onServiceConnected")
 
     try {
+      overlayManager = OverlayManager(this)
+
       // Register broadcast receiver for commands
       val commandFilter = IntentFilter().apply { addAction(ACTION_EXTRACT_HIERARCHY) }
 
@@ -366,6 +369,10 @@ class AutoMobileAccessibilityService : AccessibilityService() {
       unregisterReceiver(recompositionReceiver)
     } catch (e: Exception) {
       Log.e(TAG, "Error unregistering recomposition receiver", e)
+    }
+
+    if (::overlayManager.isInitialized) {
+      overlayManager.destroy()
     }
 
     // Cancel hierarchy flow subscription

--- a/android/accessibility-service/src/main/kotlin/dev/jasonpearson/automobile/accessibilityservice/OverlayManager.kt
+++ b/android/accessibility-service/src/main/kotlin/dev/jasonpearson/automobile/accessibilityservice/OverlayManager.kt
@@ -1,0 +1,112 @@
+package dev.jasonpearson.automobile.accessibilityservice
+
+import android.content.Context
+import android.graphics.PixelFormat
+import android.provider.Settings
+import android.util.Log
+import android.view.Gravity
+import android.view.View
+import android.view.WindowManager
+import android.widget.FrameLayout
+
+class OverlayManager(
+    private val context: Context,
+    private val windowManager: WindowManager =
+        context.getSystemService(Context.WINDOW_SERVICE) as WindowManager,
+    private val canDrawOverlays: (Context) -> Boolean = { Settings.canDrawOverlays(it) },
+    private val viewFactory: (Context) -> View = { OverlayView(it) },
+) {
+
+  companion object {
+    private const val TAG = "OverlayManager"
+  }
+
+  private var overlayView: View? = null
+  private var overlayAdded = false
+  private var overlayVisible = false
+  private var overlayLayoutParams: WindowManager.LayoutParams? = null
+
+  fun show() {
+    val view = overlayView ?: viewFactory(context).also { overlayView = it }
+
+    if (!overlayAdded) {
+      val layoutParams = overlayLayoutParams ?: createLayoutParams().also { overlayLayoutParams = it }
+      try {
+        windowManager.addView(view, layoutParams)
+        overlayAdded = true
+      } catch (e: Exception) {
+        Log.e(TAG, "Failed to add overlay view", e)
+        return
+      }
+    }
+
+    view.visibility = View.VISIBLE
+    overlayVisible = true
+  }
+
+  fun hide() {
+    overlayView?.let { view ->
+      view.visibility = View.GONE
+      overlayVisible = false
+    }
+  }
+
+  fun destroy() {
+    val view = overlayView ?: return
+    if (overlayAdded) {
+      try {
+        windowManager.removeViewImmediate(view)
+      } catch (e: Exception) {
+        Log.e(TAG, "Failed to remove overlay view", e)
+      }
+    }
+
+    overlayView = null
+    overlayAdded = false
+    overlayVisible = false
+  }
+
+  internal fun getOverlayViewForTest(): View? = overlayView
+
+  internal fun isOverlayAddedForTest(): Boolean = overlayAdded
+
+  internal fun isOverlayVisibleForTest(): Boolean = overlayVisible
+
+  private fun createLayoutParams(): WindowManager.LayoutParams {
+    val overlayType = resolveOverlayType()
+    return WindowManager.LayoutParams(
+        WindowManager.LayoutParams.MATCH_PARENT,
+        WindowManager.LayoutParams.MATCH_PARENT,
+        overlayType,
+        WindowManager.LayoutParams.FLAG_NOT_FOCUSABLE or
+            WindowManager.LayoutParams.FLAG_NOT_TOUCHABLE or
+            WindowManager.LayoutParams.FLAG_LAYOUT_IN_SCREEN or
+            WindowManager.LayoutParams.FLAG_LAYOUT_NO_LIMITS,
+        PixelFormat.TRANSLUCENT,
+    )
+        .apply {
+          gravity = Gravity.TOP or Gravity.START
+          x = 0
+          y = 0
+          title = "AutoMobile Overlay"
+        }
+  }
+
+  private fun resolveOverlayType(): Int {
+    return if (canDrawOverlays(context)) {
+      WindowManager.LayoutParams.TYPE_APPLICATION_OVERLAY
+    } else {
+      Log.w(TAG, "SYSTEM_ALERT_WINDOW not granted; using accessibility overlay.")
+      WindowManager.LayoutParams.TYPE_ACCESSIBILITY_OVERLAY
+    }
+  }
+}
+
+internal class OverlayView(context: Context) : FrameLayout(context) {
+  init {
+    isClickable = false
+    isFocusable = false
+    importantForAccessibility = View.IMPORTANT_FOR_ACCESSIBILITY_NO
+    setWillNotDraw(false)
+  }
+}

--- a/android/accessibility-service/src/test/kotlin/dev/jasonpearson/automobile/accessibilityservice/OverlayManagerTest.kt
+++ b/android/accessibility-service/src/test/kotlin/dev/jasonpearson/automobile/accessibilityservice/OverlayManagerTest.kt
@@ -1,0 +1,107 @@
+package dev.jasonpearson.automobile.accessibilityservice
+
+import android.view.View
+import android.view.ViewGroup
+import android.view.WindowManager
+import io.mockk.CapturingSlot
+import io.mockk.Runs
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+
+@RunWith(RobolectricTestRunner::class)
+class OverlayManagerTest {
+
+  private lateinit var windowManager: WindowManager
+  private lateinit var viewSlot: CapturingSlot<View>
+  private lateinit var paramsSlot: CapturingSlot<ViewGroup.LayoutParams>
+
+  @Before
+  fun setUp() {
+    windowManager = mockk(relaxed = true)
+    viewSlot = slot()
+    paramsSlot = slot()
+    every { windowManager.addView(capture(viewSlot), capture(paramsSlot)) } just Runs
+    every { windowManager.removeViewImmediate(any()) } just Runs
+  }
+
+  private fun createOverlayManager(canDrawOverlays: Boolean): OverlayManager {
+    return OverlayManager(
+        RuntimeEnvironment.getApplication(),
+        windowManager = windowManager,
+        canDrawOverlays = { canDrawOverlays },
+    )
+  }
+
+  @Test
+  fun `show uses application overlay when permission granted`() {
+    val overlayManager = createOverlayManager(canDrawOverlays = true)
+    overlayManager.show()
+
+    verify(exactly = 1) { windowManager.addView(any(), any()) }
+    assertTrue(overlayManager.isOverlayAddedForTest())
+    assertTrue(overlayManager.isOverlayVisibleForTest())
+
+    val layoutParams = paramsSlot.captured as WindowManager.LayoutParams
+    assertEquals(WindowManager.LayoutParams.MATCH_PARENT, layoutParams.width)
+    assertEquals(WindowManager.LayoutParams.MATCH_PARENT, layoutParams.height)
+    assertEquals(WindowManager.LayoutParams.TYPE_APPLICATION_OVERLAY, layoutParams.type)
+    assertTrue(
+        layoutParams.flags and WindowManager.LayoutParams.FLAG_NOT_TOUCHABLE != 0,
+    )
+    assertTrue(
+        layoutParams.flags and WindowManager.LayoutParams.FLAG_NOT_FOCUSABLE != 0,
+    )
+  }
+
+  @Test
+  fun `show falls back to accessibility overlay when permission denied`() {
+    val overlayManager = createOverlayManager(canDrawOverlays = false)
+    overlayManager.show()
+
+    val layoutParams = paramsSlot.captured as WindowManager.LayoutParams
+    assertEquals(WindowManager.LayoutParams.TYPE_ACCESSIBILITY_OVERLAY, layoutParams.type)
+  }
+
+  @Test
+  fun `show is idempotent and hide keeps overlay attached`() {
+    val overlayManager = createOverlayManager(canDrawOverlays = true)
+    overlayManager.show()
+    val overlayView = viewSlot.captured
+
+    overlayManager.show()
+    verify(exactly = 1) { windowManager.addView(any(), any()) }
+    assertEquals(View.VISIBLE, overlayView.visibility)
+
+    overlayManager.hide()
+    verify(exactly = 0) { windowManager.removeViewImmediate(any()) }
+    assertEquals(View.GONE, overlayView.visibility)
+    assertTrue(overlayManager.isOverlayAddedForTest())
+    assertFalse(overlayManager.isOverlayVisibleForTest())
+  }
+
+  @Test
+  fun `destroy removes overlay and clears state`() {
+    val overlayManager = createOverlayManager(canDrawOverlays = true)
+    overlayManager.show()
+    val overlayView = viewSlot.captured
+
+    overlayManager.destroy()
+
+    verify(exactly = 1) { windowManager.removeViewImmediate(overlayView) }
+    assertFalse(overlayManager.isOverlayAddedForTest())
+    assertFalse(overlayManager.isOverlayVisibleForTest())
+    assertNull(overlayManager.getOverlayViewForTest())
+  }
+}


### PR DESCRIPTION
## Summary
- add OverlayManager to manage overlay windows with application/accessibility overlay types
- wire overlay lifecycle into AutoMobileAccessibilityService and add SYSTEM_ALERT_WINDOW permission
- add unit tests for overlay lifecycle and overlay type selection

## Testing
- ./gradlew :accessibility-service:test

## Issues
- Closes #647
