### PR TITLE
Add tapOn searchUntil polling and remove await

### DIFF
--- a/docs/design-docs/mcp/feature-flags.md
+++ b/docs/design-docs/mcp/feature-flags.md
@@ -43,11 +43,6 @@ setFeatureFlag("mem-perf-audit", true)
 
 ### Behavior Flags
 
-**`strict-await`** - Strict element waiting behavior
-```typescript
-setFeatureFlag("strict-await", true)
-```
-
 **`accessibility-audit`** - Enable accessibility checks
 ```typescript
 setFeatureFlag("accessibility-audit", true)

--- a/docs/design-docs/mcp/vision-fallback.md
+++ b/docs/design-docs/mcp/vision-fallback.md
@@ -11,7 +11,7 @@ Vision fallback is an **internal feature** that is:
 - **Disabled by default** to avoid unexpected API costs
 - Only available when constructing `TapOnElement` with custom vision configuration
 - Not exposed via MCP server or CLI by default
-- Currently integrated into `tapOn` only (invoked after 5 retry attempts fail)
+- Currently integrated into `tapOn` only (invoked after polling times out)
 - Android screenshots only (iOS not yet implemented)
 
 ### How It Works

--- a/schemas/tool-definitions.json
+++ b/schemas/tool-definitions.json
@@ -1771,34 +1771,18 @@
           "type": "number",
           "description": "Long press duration (ms)"
         },
-        "await": {
+        "searchUntil": {
           "type": "object",
           "properties": {
-            "element": {
-              "type": "object",
-              "properties": {
-                "id": {
-                  "type": "string",
-                  "description": "Element ID to wait for"
-                },
-                "text": {
-                  "type": "string",
-                  "description": "Element text to wait for"
-                }
-              },
-              "additionalProperties": false,
-              "description": "Element to wait for"
-            },
-            "timeout": {
+            "duration": {
               "type": "number",
-              "description": "Wait timeout ms (default: 5000)"
+              "minimum": 100,
+              "maximum": 12000,
+              "description": "Polling duration (ms, default: 500)"
             }
           },
-          "required": [
-            "element"
-          ],
           "additionalProperties": false,
-          "description": "Wait for element after tap"
+          "description": "Poll for element before tapping"
         },
         "platform": {
           "type": "string",

--- a/src/daemon/manager.ts
+++ b/src/daemon/manager.ts
@@ -159,9 +159,6 @@ export class DaemonManager {
     if (options.debugPerf) {
       args.push("--debug-perf");
     }
-    if (options.strictAwait) {
-      args.push("--strict-await");
-    }
     if (options.planExecutionLockScope) {
       args.push("--plan-execution-lock-scope", options.planExecutionLockScope);
     }
@@ -421,8 +418,6 @@ export async function runDaemonCommand(
             options.debug = true;
           } else if (args[i] === "--debug-perf") {
             options.debugPerf = true;
-          } else if (args[i] === "--strict-await") {
-            options.strictAwait = true;
           } else if (args[i] === "--plan-execution-lock-scope") {
             const scope = args[i + 1];
             if (scope === "global" || scope === "session") {
@@ -501,8 +496,6 @@ export async function runDaemonCommand(
             options.debug = true;
           } else if (args[i] === "--debug-perf") {
             options.debugPerf = true;
-          } else if (args[i] === "--strict-await") {
-            options.strictAwait = true;
           } else if (args[i] === "--plan-execution-lock-scope") {
             const scope = args[i + 1];
             if (scope === "global" || scope === "session") {

--- a/src/daemon/types.ts
+++ b/src/daemon/types.ts
@@ -74,8 +74,6 @@ export interface DaemonOptions {
   debug?: boolean;
   /** Enable debug performance tracking */
   debugPerf?: boolean;
-  /** Enable strict await mode for tapOn await timeouts */
-  strictAwait?: boolean;
   /** Plan execution lock scope (session or global) */
   planExecutionLockScope?: "session" | "global";
   /** Default video quality preset */

--- a/src/features/action/TapOnElement.ts
+++ b/src/features/action/TapOnElement.ts
@@ -24,6 +24,9 @@ import { SelectionStateTracker, SelectionCaptureState, TakeScreenshotCapturer } 
 import { AccessibilityDetector } from "../../utils/interfaces/AccessibilityDetector";
 import { accessibilityDetector as defaultAccessibilityDetector } from "../../utils/AccessibilityDetector";
 import type { Timer } from "../../utils/SystemTimer";
+import { NodeCryptoService } from "../../utils/crypto";
+
+type SearchUntilStats = NonNullable<TapOnElementResult["searchUntil"]>;
 
 /**
  * Command to tap on UI element containing specified text
@@ -36,8 +39,9 @@ export class TapOnElement extends BaseVisualChange {
   private visionConfig: VisionFallbackConfig;
   private selectionStateTracker: SelectionStateTracker;
   private accessibilityDetector: AccessibilityDetector;
-  private static readonly MAX_ATTEMPTS = 5;
-  private static readonly AWAIT_POLL_INTERVAL_MS = 100;
+  private static readonly SEARCH_UNTIL_DEFAULT_MS = 500;
+  private static readonly SEARCH_UNTIL_MIN_MS = 100;
+  private static readonly SEARCH_UNTIL_MAX_MS = 12000;
 
   constructor(
     device: BootedDevice,
@@ -78,49 +82,172 @@ export class TapOnElement extends BaseVisualChange {
     };
   }
 
-  async handleElementResult(
-    element: Element | null,
+  private getSearchUntilDuration(options: TapOnElementOptions): number {
+    const duration = options.searchUntil?.duration ?? TapOnElement.SEARCH_UNTIL_DEFAULT_MS;
+
+    if (!Number.isFinite(duration)) {
+      throw new ActionableError("searchUntil.duration must be a number");
+    }
+
+    if (duration < TapOnElement.SEARCH_UNTIL_MIN_MS) {
+      throw new ActionableError(
+        `searchUntil.duration must be at least ${TapOnElement.SEARCH_UNTIL_MIN_MS}ms`
+      );
+    }
+
+    if (duration > TapOnElement.SEARCH_UNTIL_MAX_MS) {
+      throw new ActionableError(
+        `searchUntil.duration must be at most ${TapOnElement.SEARCH_UNTIL_MAX_MS}ms`
+      );
+    }
+
+    return Math.round(duration);
+  }
+
+  private hashViewHierarchy(viewHierarchy: ViewHierarchyResult | null): string | null {
+    if (!viewHierarchy) {
+      return null;
+    }
+    try {
+      return NodeCryptoService.generateCacheKey(JSON.stringify(viewHierarchy.hierarchy));
+    } catch (error) {
+      logger.debug(`[TapOnElement] Failed to hash view hierarchy: ${error}`);
+      return null;
+    }
+  }
+
+  private findElementInHierarchy(
     options: TapOnElementOptions,
-    attempt: number,
-    observeResult?: ObserveResult,
-    signal?: AbortSignal,
-    containerFound: boolean = true
-  ): Promise<Element> {
-    if (!element && attempt < TapOnElement.MAX_ATTEMPTS) {
-      const delayNextAttempt = Math.min(10 * Math.pow(2, attempt), 1000);
-      await this.timer.sleep(delayNextAttempt);
+    viewHierarchy: ViewHierarchyResult
+  ): { element: Element | null; containerFound: boolean } {
+    const containerFound = this.isContainerAvailable(viewHierarchy, options.container);
+    if (options.text) {
+      return {
+        element: this.elementUtils.findElementByText(
+          viewHierarchy,
+          options.text,
+          options.container,
+          true,
+          false,
+        ),
+        containerFound
+      };
+    }
+    if (options.elementId) {
+      return {
+        element: this.elementUtils.findElementByResourceId(
+          viewHierarchy,
+          options.elementId,
+          options.container,
+        ),
+        containerFound
+      };
+    }
+    throw new ActionableError("tapOn requires non-blank text or elementId to interact with");
+  }
 
-      let latestViewHierarchy: ViewHierarchyResult | null = null;
-
-      // Platform-specific view hierarchy retrieval
-      switch (this.device.platform) {
-        case "android":
-          const queryOptions = {
-            query: options.text || options.elementId || "",
-            containerElementId: options.container?.elementId
-          };
-          latestViewHierarchy = await this.accessibilityService.getAccessibilityHierarchy(queryOptions, undefined, false, 0, signal);
-          break;
-        case "ios":
-          latestViewHierarchy = await this.webdriver.getViewHierarchy(this.device);
-          break;
-        default:
-          throw new ActionableError(`Unsupported platform: ${this.device.platform}`);
-      }
-
-      if (latestViewHierarchy) {
-        logger.info(`Retrying to find element after ${delayNextAttempt}ms delay`);
-        return await this.findElementToTap(
-          options,
-          latestViewHierarchy,
-          attempt + 1,
-          observeResult,
-          signal
+  private async refreshViewHierarchy(
+    timeoutMs: number,
+    signal?: AbortSignal
+  ): Promise<ViewHierarchyResult | null> {
+    const effectiveTimeoutMs = Math.max(0, timeoutMs);
+    switch (this.device.platform) {
+      case "android": {
+        const syncResult = await this.accessibilityService.requestHierarchySync(
+          new NoOpPerformanceTracker(),
+          false,
+          signal,
+          effectiveTimeoutMs
         );
+        return syncResult
+          ? this.accessibilityService.convertToViewHierarchyResult(syncResult.hierarchy)
+          : null;
+      }
+      case "ios":
+        return this.webdriver.getViewHierarchy(this.device);
+      default:
+        throw new ActionableError(`Unsupported platform: ${this.device.platform}`);
+    }
+  }
+
+  private async searchForElement(
+    options: TapOnElementOptions,
+    observeResult: ObserveResult,
+    signal?: AbortSignal
+  ): Promise<{
+    element: Element | null;
+    viewHierarchy: ViewHierarchyResult;
+    containerFound: boolean;
+    stats: SearchUntilStats;
+  }> {
+    const viewHierarchy = observeResult.viewHierarchy;
+    if (!viewHierarchy) {
+      throw new ActionableError("Unable to get view hierarchy, cannot tap on element");
+    }
+
+    const searchDurationMs = this.getSearchUntilDuration(options);
+    const startTime = this.timer.now();
+    let requestCount = 0;
+    let changeCount = 0;
+    let lastHash = this.hashViewHierarchy(viewHierarchy);
+
+    let latestViewHierarchy = viewHierarchy;
+    const initialSearch = this.findElementInHierarchy(options, latestViewHierarchy);
+    let element = initialSearch.element;
+    let containerFoundEver = initialSearch.containerFound;
+
+    if (!element) {
+      const deadline = startTime + searchDurationMs;
+      while (this.timer.now() < deadline) {
+        throwIfAborted(signal);
+        const remainingTimeMs = Math.max(0, deadline - this.timer.now());
+        const refreshedHierarchy = await this.refreshViewHierarchy(remainingTimeMs, signal);
+        requestCount += 1;
+
+        if (!refreshedHierarchy) {
+          continue;
+        }
+
+        latestViewHierarchy = refreshedHierarchy;
+        const hash = this.hashViewHierarchy(refreshedHierarchy);
+        if (hash && hash !== lastHash) {
+          changeCount += 1;
+          lastHash = hash;
+        } else if (hash && !lastHash) {
+          changeCount += 1;
+          lastHash = hash;
+        }
+
+        const searchResult = this.findElementInHierarchy(options, refreshedHierarchy);
+        element = searchResult.element;
+        containerFoundEver = containerFoundEver || searchResult.containerFound;
+        if (element) {
+          break;
+        }
       }
     }
 
-    if (!element && options.container && !containerFound) {
+    const stats: SearchUntilStats = {
+      durationMs: Math.max(0, Math.round(this.timer.now() - startTime)),
+      requestCount,
+      changeCount
+    };
+
+    return {
+      element,
+      viewHierarchy: latestViewHierarchy,
+      containerFound: containerFoundEver,
+      stats
+    };
+  }
+
+  private async handleElementNotFound(
+    options: TapOnElementOptions,
+    observeResult?: ObserveResult,
+    containerFound: boolean = true,
+    signal?: AbortSignal
+  ): Promise<never> {
+    if (options.container && !containerFound) {
       const containerLabel = options.container.elementId
         ? `elementId '${options.container.elementId}'`
         : `text '${options.container.text}'`;
@@ -129,12 +256,10 @@ export class TapOnElement extends BaseVisualChange {
       );
     }
 
-    // Vision fallback: Try Claude vision API if all retries exhausted
-    if (!element && attempt >= TapOnElement.MAX_ATTEMPTS && this.visionConfig.enabled && observeResult) {
-      logger.info("🔍 Element not found after retries, trying vision fallback...");
+    if (this.visionConfig.enabled && observeResult) {
+      logger.info("🔍 Element not found after polling, trying vision fallback...");
 
       try {
-        // Take a screenshot for vision analysis
         const screenshot = new TakeScreenshot(this.device, this.adb);
         const screenshotResult = await screenshot.execute({}, signal);
 
@@ -154,7 +279,6 @@ export class TapOnElement extends BaseVisualChange {
           }
         );
 
-        // If high confidence navigation steps provided, throw error with steps
         if (visionResult.confidence === "high" && visionResult.navigationSteps && visionResult.navigationSteps.length > 0) {
           const stepsText = visionResult.navigationSteps
             .map((step, i) => `${i + 1}. ${step.description}`)
@@ -166,7 +290,6 @@ export class TapOnElement extends BaseVisualChange {
           );
         }
 
-        // If alternative selectors found, throw error with suggestions
         if (visionResult.alternativeSelectors && visionResult.alternativeSelectors.length > 0) {
           const suggestions = visionResult.alternativeSelectors
             .map(alt => `- ${alt.type}: "${alt.value}" (${alt.reasoning})`)
@@ -178,7 +301,6 @@ export class TapOnElement extends BaseVisualChange {
           );
         }
 
-        // Otherwise, throw detailed error with vision insights
         throw new ActionableError(
           `Element not found. ${visionResult.reason || "No clear path found."}\n\n` +
           `(Cost: $${visionResult.costUsd.toFixed(4)}, Confidence: ${visionResult.confidence})`
@@ -189,25 +311,20 @@ export class TapOnElement extends BaseVisualChange {
           throw error;
         }
         logger.error("Vision fallback failed:", error);
-        // Fall through to standard error
       }
     }
 
-    if (!element) {
-      if (options.text) {
-        const containerHint = options.container
-          ? ` within container ${options.container.elementId ? `elementId '${options.container.elementId}'` : `text '${options.container.text}'`}`
-          : "";
-        throw new ActionableError(`Element not found with provided text '${options.text}'${containerHint}`);
-      } else {
-        const containerHint = options.container
-          ? ` within container ${options.container.elementId ? `elementId '${options.container.elementId}'` : `text '${options.container.text}'`}`
-          : "";
-        throw new ActionableError(`Element not found with provided elementId '${options.elementId}'${containerHint}`);
-      }
+    if (options.text) {
+      const containerHint = options.container
+        ? ` within container ${options.container.elementId ? `elementId '${options.container.elementId}'` : `text '${options.container.text}'`}`
+        : "";
+      throw new ActionableError(`Element not found with provided text '${options.text}'${containerHint}`);
     }
 
-    return element;
+    const containerHint = options.container
+      ? ` within container ${options.container.elementId ? `elementId '${options.container.elementId}'` : `text '${options.container.text}'`}`
+      : "";
+    throw new ActionableError(`Element not found with provided elementId '${options.elementId}'${containerHint}`);
   }
 
   private isContainerAvailable(
@@ -219,39 +336,6 @@ export class TapOnElement extends BaseVisualChange {
     }
 
     return this.elementUtils.hasContainerElement(viewHierarchy, container);
-  }
-
-  async findElementToTap(
-    options: TapOnElementOptions,
-    viewHierarchy: ViewHierarchyResult,
-    attempt: number = 0,
-    observeResult?: ObserveResult,
-    signal?: AbortSignal
-  ): Promise<Element> {
-    const containerFound = this.isContainerAvailable(viewHierarchy, options.container);
-    if (options.text) {
-      // Find the UI element that contains the text
-      const element = this.elementUtils.findElementByText(
-        viewHierarchy,
-        options.text,
-        options.container,
-        true,
-        false,
-      );
-
-      return await this.handleElementResult(element, options, attempt, observeResult, signal, containerFound);
-    } else if (options.elementId) {
-      // Find the UI element that matches the id
-      const element = this.elementUtils.findElementByResourceId(
-        viewHierarchy,
-        options.elementId,
-        options.container,
-      );
-
-      return await this.handleElementResult(element, options, attempt, observeResult, signal, containerFound);
-    } else {
-      throw new ActionableError(`tapOn requires non-blank text or elementId to interact with`);
-    }
   }
 
   private isTruthyFlag(value: unknown): boolean {
@@ -454,6 +538,7 @@ export class TapOnElement extends BaseVisualChange {
     perf.serial("tapOnElement");
     let previousObserveResult: ObserveResult | null = null;
     let selectionCapture: SelectionCaptureState | null = null;
+    let searchUntilStats: SearchUntilStats | undefined;
 
     try {
       throwIfAborted(signal);
@@ -463,15 +548,22 @@ export class TapOnElement extends BaseVisualChange {
           previousObserveResult = observeResult;
           throwIfAborted(signal);
 
-          const viewHierarchy = observeResult.viewHierarchy;
+          let viewHierarchy = observeResult.viewHierarchy;
           if (!viewHierarchy) {
             perf.end();
             return { success: false, error: "Unable to get view hierarchy, cannot tap on element" };
           }
 
-          const element = await perf.track("findElement", () =>
-            this.findElementToTap(options, viewHierarchy, 0, observeResult, signal)
+          const searchOutcome = await perf.track("findElement", () =>
+            this.searchForElement(options, observeResult, signal)
           );
+          searchUntilStats = searchOutcome.stats;
+          observeResult.viewHierarchy = searchOutcome.viewHierarchy;
+          viewHierarchy = searchOutcome.viewHierarchy;
+          if (!searchOutcome.element) {
+            await this.handleElementNotFound(options, observeResult, searchOutcome.containerFound, signal);
+          }
+          const element = searchOutcome.element as Element;
           const initialTapPoint = this.elementUtils.getElementCenter(element);
           let action = options.action;
           const longPressDuration = this.getLongPressDuration(options, this.device.platform);
@@ -486,6 +578,7 @@ export class TapOnElement extends BaseVisualChange {
               return {
                 success: true,
                 element: element,
+                searchUntil: searchOutcome.stats,
                 wasAlreadyFocused: true,
                 focusChanged: false,
                 x: initialTapPoint.x,
@@ -547,6 +640,7 @@ export class TapOnElement extends BaseVisualChange {
             success: true,
             action,
             element: tapElement,
+            searchUntil: searchOutcome.stats,
           };
         },
         {
@@ -568,7 +662,7 @@ export class TapOnElement extends BaseVisualChange {
               action: options.action,
               duration: options.duration,
               container: options.container,
-              await: options.await,
+              searchUntil: options.searchUntil,
               platform: this.device.platform
             }
           }
@@ -596,42 +690,7 @@ export class TapOnElement extends BaseVisualChange {
           ...metadata
         };
       }
-      if (!result.success || !options.await?.element) {
-        return result;
-      }
-
-      if (!options.await.element.id && !options.await.element.text) {
-        return {
-          ...result,
-          success: false,
-          error: "await.element requires either id or text",
-          awaitTimeout: true,
-          awaitDuration: 0
-        };
-      }
-
-      const awaitOutcome = await this.waitForAwaitElement(
-        options.await,
-        result.observation
-      );
-
-      const awaitResult: TapOnElementResult = {
-        ...result,
-        awaitedElement: awaitOutcome.awaitedElement,
-        awaitDuration: awaitOutcome.awaitDuration,
-        awaitTimeout: awaitOutcome.awaitTimeout,
-        observation: awaitOutcome.observation || result.observation
-      };
-
-      if (awaitOutcome.awaitTimeout && options.strictAwait) {
-        return {
-          ...awaitResult,
-          success: false,
-          error: "Tap succeeded but awaited element not found within timeout"
-        };
-      }
-
-      return awaitResult;
+      return result;
     } catch (error) {
       perf.end();
 
@@ -654,6 +713,7 @@ export class TapOnElement extends BaseVisualChange {
         element: {
           bounds: { left: 0, top: 0, right: 0, bottom: 0 }
         } as Element,
+        ...(searchUntilStats ? { searchUntil: searchUntilStats } : {}),
         ...(debugContext ? { debug: { elementSearch: debugContext } } : {})
       };
     }
@@ -972,91 +1032,5 @@ export class TapOnElement extends BaseVisualChange {
       }
     });
     return found;
-  }
-
-  private async waitForAwaitElement(
-    awaitOptions: NonNullable<TapOnElementOptions["await"]>,
-    initialObservation?: ObserveResult
-  ): Promise<{
-    awaitedElement?: Element;
-    awaitDuration: number;
-    awaitTimeout: boolean;
-    observation?: ObserveResult;
-  }> {
-    const startTime = this.timer.now();
-    const timeoutMs = awaitOptions.timeout ?? 5000;
-    const queryOptions = {
-      text: awaitOptions.element.text,
-      elementId: awaitOptions.element.id
-    };
-
-    if (initialObservation?.viewHierarchy) {
-      const existing = this.findAwaitElement(awaitOptions, initialObservation.viewHierarchy);
-      if (existing) {
-        return {
-          awaitedElement: existing,
-          awaitDuration: this.timer.now() - startTime,
-          awaitTimeout: false,
-          observation: initialObservation
-        };
-      }
-    }
-
-    let lastObservation: ObserveResult | undefined;
-
-    while (this.timer.now() - startTime < timeoutMs) {
-      const observation = await this.observeScreen.execute(
-        queryOptions,
-        new NoOpPerformanceTracker(),
-        false,
-        startTime
-      );
-      lastObservation = observation;
-
-      if (observation.viewHierarchy) {
-        const found = this.findAwaitElement(awaitOptions, observation.viewHierarchy);
-        if (found) {
-          return {
-            awaitedElement: found,
-            awaitDuration: this.timer.now() - startTime,
-            awaitTimeout: false,
-            observation
-          };
-        }
-      }
-
-      await this.timer.sleep(TapOnElement.AWAIT_POLL_INTERVAL_MS);
-    }
-
-    return {
-      awaitDuration: this.timer.now() - startTime,
-      awaitTimeout: true,
-      observation: lastObservation
-    };
-  }
-
-  private findAwaitElement(
-    awaitOptions: NonNullable<TapOnElementOptions["await"]>,
-    viewHierarchy: ViewHierarchyResult
-  ): Element | null {
-    if (awaitOptions.element.id) {
-      return this.elementUtils.findElementByResourceId(
-        viewHierarchy,
-        awaitOptions.element.id,
-        undefined
-      );
-    }
-
-    if (awaitOptions.element.text) {
-      return this.elementUtils.findElementByText(
-        viewHierarchy,
-        awaitOptions.element.text,
-        undefined,
-        true,
-        false
-      );
-    }
-
-    return null;
   }
 }

--- a/src/features/featureFlags/FeatureFlagApplier.ts
+++ b/src/features/featureFlags/FeatureFlagApplier.ts
@@ -33,9 +33,6 @@ export class DefaultFeatureFlagApplier implements FeatureFlagApplier {
       case "mem-perf-audit":
         serverConfig.setMemPerfAuditMode(enabled);
         break;
-      case "strict-await":
-        serverConfig.setStrictAwaitEnabled(enabled);
-        break;
       case "accessibility-audit":
         serverConfig.setAccessibilityAuditConfig(
           enabled ? applyAccessibilityConfig(config) : null

--- a/src/features/featureFlags/FeatureFlagDefinitions.ts
+++ b/src/features/featureFlags/FeatureFlagDefinitions.ts
@@ -4,7 +4,6 @@ export type FeatureFlagKey =
   | "ui-perf-mode"
   | "ui-perf-debug"
   | "mem-perf-audit"
-  | "strict-await"
   | "accessibility-audit"
   | "predictive-ui"
   | "force-accessibility-mode"
@@ -49,12 +48,6 @@ export const FEATURE_FLAG_DEFINITIONS: FeatureFlagDefinition[] = [
     key: "mem-perf-audit",
     label: "Memory audit",
     description: "Run memory audits during tool execution.",
-    defaultValue: false,
-  },
-  {
-    key: "strict-await",
-    label: "Strict await",
-    description: "Treat await timeouts as failures instead of warnings.",
     defaultValue: false,
   },
   {

--- a/src/features/observe/AccessibilityServiceClient.ts
+++ b/src/features/observe/AccessibilityServiceClient.ts
@@ -309,7 +309,9 @@ export interface AccessibilityService {
    */
   requestHierarchySync(
     perf?: PerformanceTracker,
-    disableAllFiltering?: boolean
+    disableAllFiltering?: boolean,
+    signal?: AbortSignal,
+    timeoutMs?: number
   ): Promise<{ hierarchy: AccessibilityHierarchy; perfTiming?: AndroidPerfTiming[] } | null>;
 
   /**
@@ -1920,9 +1922,11 @@ export class AccessibilityServiceClient implements AccessibilityService {
   async requestHierarchySync(
     perf: PerformanceTracker = new NoOpPerformanceTracker(),
     disableAllFiltering: boolean = false,
-    signal?: AbortSignal
+    signal?: AbortSignal,
+    timeoutMs: number = 10000
   ): Promise<{ hierarchy: AccessibilityHierarchy; perfTiming?: AndroidPerfTiming[] } | null> {
     const startTime = Date.now();
+    const effectiveTimeoutMs = Math.max(0, timeoutMs);
 
     try {
       logger.info("[ACCESSIBILITY_SERVICE] Requesting hierarchy sync via WebSocket");
@@ -1949,9 +1953,9 @@ export class AccessibilityServiceClient implements AccessibilityService {
 
       // Wait for WebSocket push (triggered by either method)
       // The Android service calls broadcastHierarchyUpdate() after extraction
-      // Use 10 second timeout to handle long animations (switch toggles can trigger 10+ concurrent extractions)
+      // Use a configurable timeout to align with caller expectations.
       const freshData = await perf.track("waitForPush", () =>
-        this.waitForFreshData(10000, startTime, signal)
+        this.waitForFreshData(effectiveTimeoutMs, startTime, false, signal)
       );
 
       if (freshData) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -77,7 +77,6 @@ function parseArgs(): {
   uiPerfMode: boolean;
   uiPerfDebug: boolean;
   memPerfAuditMode: boolean;
-  strictAwait: boolean;
   a11yAuditMode: boolean;
   a11yLevel?: string;
   a11yFailureMode?: string;
@@ -125,9 +124,6 @@ function parseArgs(): {
 
   // Detect memory performance audit mode
   const memPerfAuditMode = args.includes("--mem-perf-audit");
-
-  // Detect strict await mode for tapOn await timeouts
-  const strictAwait = args.includes("--strict-await");
 
   // Detect accessibility audit mode
   const a11yAuditMode = args.includes("--accessibility-audit");
@@ -323,7 +319,6 @@ function parseArgs(): {
     uiPerfMode,
     uiPerfDebug,
     memPerfAuditMode,
-    strictAwait,
     a11yAuditMode,
     a11yLevel,
     a11yFailureMode,
@@ -745,7 +740,6 @@ async function main() {
       uiPerfMode,
       uiPerfDebug,
       memPerfAuditMode,
-      strictAwait,
       a11yAuditMode,
       a11yLevel,
       a11yFailureMode,
@@ -781,7 +775,6 @@ async function main() {
       ["ui-perf-mode", uiPerfMode, "--ui-perf-mode"],
       ["ui-perf-debug", uiPerfDebug, "--ui-perf-debug"],
       ["mem-perf-audit", memPerfAuditMode, "--mem-perf-audit"],
-      ["strict-await", strictAwait, "--strict-await"],
       ["accessibility-audit", a11yAuditMode, "--accessibility-audit", accessibilityConfig],
       ["predictive-ui", predictiveUi, "--predictive/--predictive-ui"],
     ];
@@ -802,7 +795,6 @@ async function main() {
         host: transport.host,
         debug,
         debugPerf,
-        strictAwait,
       });
       return;
     }

--- a/src/models/TapOnElementOptions.ts
+++ b/src/models/TapOnElementOptions.ts
@@ -15,22 +15,15 @@ export interface TapOnElementOptions {
   // Action to perform
   action: "tap" | "doubleTap" | "longPress" | "focus";
 
+  // Optional polling before tap to wait for element to appear
+  searchUntil?: {
+    duration?: number;
+  };
+
   // Optional duration for long press actions (milliseconds)
   duration?: number;
 
   // Optional flag to set accessibility focus before performing action (TalkBack mode)
   // If not specified, will be determined automatically based on TalkBack state
   focusFirst?: boolean;
-
-  // Optional await for an element to appear after tap
-  await?: {
-    element: {
-      id?: string;
-      text?: string;
-    };
-    timeout?: number;
-  };
-
-  // Fail the tap if the awaited element is not found within the timeout
-  strictAwait?: boolean;
 }

--- a/src/models/TapOnElementResult.ts
+++ b/src/models/TapOnElementResult.ts
@@ -15,7 +15,9 @@ export interface TapOnElementResult {
   pressRecognized?: boolean;
   contextMenuOpened?: boolean;
   selectionStarted?: boolean;
-  awaitedElement?: Element;
-  awaitDuration?: number;
-  awaitTimeout?: boolean;
+  searchUntil?: {
+    durationMs: number;
+    requestCount: number;
+    changeCount: number;
+  };
 }

--- a/src/server/interactionTools.ts
+++ b/src/server/interactionTools.ts
@@ -16,7 +16,6 @@ import { Rotate } from "../features/action/Rotate";
 import { OpenURL } from "../features/action/OpenURL";
 import { Clipboard } from "../features/action/Clipboard";
 import { ActionableError, BootedDevice, Element, ViewHierarchyResult } from "../models";
-import { serverConfig } from "../utils/ServerConfig";
 import { ObserveScreen } from "../features/observe/ObserveScreen";
 import { ListInstalledApps } from "../features/observe/ListInstalledApps";
 import { createJSONToolResponse } from "../utils/toolUtils";
@@ -80,12 +79,8 @@ export interface TapOnArgs {
   id?: string;
   action: "tap" | "doubleTap" | "longPress" | "focus";
   duration?: number;
-  await?: {
-    element: {
-      id?: string;
-      text?: string;
-    };
-    timeout?: number;
+  searchUntil?: {
+    duration?: number;
   };
   platform: Platform;
 }
@@ -191,13 +186,9 @@ export const tapOnSchema = addDeviceTargetingToSchema(z.object({
   text: z.string().optional().describe("Text to tap (overrides id)"),
   id: z.string().optional().describe("Element ID to tap"),
   duration: z.number().optional().describe("Long press duration (ms)"),
-  await: z.object({
-    element: z.object({
-      id: z.string().optional().describe("Element ID to wait for"),
-      text: z.string().optional().describe("Element text to wait for"),
-    }).describe("Element to wait for"),
-    timeout: z.number().optional().describe("Wait timeout ms (default: 5000)"),
-  }).optional().describe("Wait for element after tap"),
+  searchUntil: z.object({
+    duration: z.number().min(100).max(12000).optional().describe("Polling duration (ms, default: 500)"),
+  }).optional().describe("Poll for element before tapping"),
   platform: z.enum(["android", "ios"]).describe("Platform")
 }));
 
@@ -1058,12 +1049,15 @@ export function registerInteractionTools() {
       elementId: args.id,
       action: args.action,
       duration: args.duration,
-      await: args.await,
-      strictAwait: serverConfig.isStrictAwaitEnabled(),
+      searchUntil: args.searchUntil,
     }, progress);
 
+    const searchSummary = result.searchUntil
+      ? `${result.searchUntil.changeCount} view hierarchy changes over ${result.searchUntil.requestCount} requests within ${result.searchUntil.durationMs}ms`
+      : undefined;
+
     return createJSONToolResponse({
-      message: `Tapped on element`,
+      message: searchSummary ? `Tapped on element (${searchSummary})` : "Tapped on element",
       observation: result.observation,
       ...result
     });

--- a/src/utils/ServerConfig.ts
+++ b/src/utils/ServerConfig.ts
@@ -15,7 +15,6 @@ class ServerConfig {
   private _uiPerfDebugEnabled: boolean = false;
   private _accessibilityAuditConfig: AccessibilityAuditConfig | null = null;
   private _memPerfAuditEnabled: boolean = false;
-  private _strictAwaitEnabled: boolean = false;
   private _predictiveUiEnabled: boolean = false;
   private _planExecutionLockScope: PlanExecutionLockScope = "session";
   private _videoRecordingDefaults: VideoRecordingConfigInput = {};
@@ -64,14 +63,6 @@ class ServerConfig {
 
   isMemPerfAuditEnabled(): boolean {
     return this._memPerfAuditEnabled;
-  }
-
-  setStrictAwaitEnabled(enabled: boolean): void {
-    this._strictAwaitEnabled = enabled;
-  }
-
-  isStrictAwaitEnabled(): boolean {
-    return this._strictAwaitEnabled;
   }
 
   setPredictiveUiEnabled(enabled: boolean): void {


### PR DESCRIPTION
## Summary
- add `searchUntil` polling for `tapOn` with hierarchy refresh/change stats
- remove `tapOn.await` support and strict-await flag plumbing
- update schemas/docs to match the new behavior

## Testing
- bun run test
- bun run build

Fixes #662
