### PR TITLE
Preserve double-tap behavior in TalkBack mode

### DIFF
--- a/src/features/action/TapOnElement.ts
+++ b/src/features/action/TapOnElement.ts
@@ -803,6 +803,24 @@ export class TapOnElement extends BaseVisualChange {
     // This is faster than ADB and precise (uses exact coordinates, not resource-id lookup).
     // Use short duration (50ms) for tap/doubleTap to avoid being interpreted as long press
     const tapDuration = action === "longPress" ? durationMs : 50;
+    if (action === "doubleTap") {
+      const firstTap = await this.accessibilityService.requestTapCoordinates(x, y, tapDuration);
+      if (!firstTap.success) {
+        logger.warn(`[TapOnElement] Accessibility coordinate double tap failed (first tap: ${firstTap.error}), falling back to ADB double tap at (${x}, ${y})`);
+        await this.executeAndroidTapWithCoordinates(action, x, y, durationMs, element, signal);
+        return;
+      }
+
+      await this.timer.sleep(200);
+
+      const secondTap = await this.accessibilityService.requestTapCoordinates(x, y, tapDuration);
+      if (!secondTap.success) {
+        logger.warn(`[TapOnElement] Accessibility coordinate double tap failed (second tap: ${secondTap.error}), falling back to ADB tap at (${x}, ${y})`);
+        await this.executeAndroidTapWithCoordinates("tap", x, y, durationMs, element, signal);
+      }
+      return;
+    }
+
     const result = await this.accessibilityService.requestTapCoordinates(x, y, tapDuration);
     if (!result.success) {
       logger.warn(`[TapOnElement] Accessibility coordinate tap failed (${result.error}), falling back to ADB tap at (${x}, ${y})`);

--- a/test/features/action/TapOnElement.talkback.test.ts
+++ b/test/features/action/TapOnElement.talkback.test.ts
@@ -233,6 +233,108 @@ describe("TapOnElement TalkBack mode detection", () => {
     });
   });
 
+  describe("executeAndroidTapWithAccessibility doubleTap behavior", () => {
+    let mockAccessibilityService: any;
+
+    beforeEach(() => {
+      executeAndroidTapWithAccessibility.mockRestore();
+
+      mockAccessibilityService = {
+        requestTapCoordinates: async () => ({ success: true, totalTimeMs: 1 })
+      };
+
+      (tapOnElement as any).accessibilityService = mockAccessibilityService;
+    });
+
+    test("issues two accessibility taps with a delay", async () => {
+      const requestTapCoordinates = spyOn(mockAccessibilityService, "requestTapCoordinates")
+        .mockResolvedValue({ success: true, totalTimeMs: 1 });
+
+      const element = {
+        "resource-id": "test:id/button"
+      } as any;
+
+      await (tapOnElement as any).executeAndroidTapWithAccessibility(
+        "doubleTap",
+        50,
+        50,
+        element,
+        500,
+        {},
+        undefined
+      );
+
+      expect(requestTapCoordinates).toHaveBeenCalledTimes(2);
+      expect(requestTapCoordinates.mock.calls).toEqual([
+        [50, 50, 50],
+        [50, 50, 50]
+      ]);
+      expect(fakeTimer.wasSleepCalled(200)).toBe(true);
+      expect(executeAndroidTapWithCoordinates).not.toHaveBeenCalled();
+    });
+
+    test("falls back to coordinate double tap if the first accessibility tap fails", async () => {
+      const requestTapCoordinates = spyOn(mockAccessibilityService, "requestTapCoordinates")
+        .mockResolvedValueOnce({ success: false, totalTimeMs: 1, error: "nope" });
+
+      const element = {
+        "resource-id": "test:id/button"
+      } as any;
+
+      await (tapOnElement as any).executeAndroidTapWithAccessibility(
+        "doubleTap",
+        50,
+        50,
+        element,
+        500,
+        {},
+        undefined
+      );
+
+      expect(requestTapCoordinates).toHaveBeenCalledTimes(1);
+      expect(executeAndroidTapWithCoordinates).toHaveBeenCalledTimes(1);
+      expect(executeAndroidTapWithCoordinates).toHaveBeenCalledWith(
+        "doubleTap",
+        50,
+        50,
+        500,
+        element,
+        undefined
+      );
+    });
+
+    test("falls back to a single coordinate tap if the second accessibility tap fails", async () => {
+      const requestTapCoordinates = spyOn(mockAccessibilityService, "requestTapCoordinates")
+        .mockResolvedValueOnce({ success: true, totalTimeMs: 1 })
+        .mockResolvedValueOnce({ success: false, totalTimeMs: 1, error: "nope" });
+
+      const element = {
+        "resource-id": "test:id/button"
+      } as any;
+
+      await (tapOnElement as any).executeAndroidTapWithAccessibility(
+        "doubleTap",
+        50,
+        50,
+        element,
+        500,
+        {},
+        undefined
+      );
+
+      expect(requestTapCoordinates).toHaveBeenCalledTimes(2);
+      expect(executeAndroidTapWithCoordinates).toHaveBeenCalledTimes(1);
+      expect(executeAndroidTapWithCoordinates).toHaveBeenCalledWith(
+        "tap",
+        50,
+        50,
+        500,
+        element,
+        undefined
+      );
+    });
+  });
+
   describe("clickable parent resolution", () => {
     test("uses clickable parent when child is not clickable", () => {
       const viewHierarchy = {


### PR DESCRIPTION
## Summary
- preserve TalkBack double-tap by issuing two accessibility taps with delay and fallback paths
- add TalkBack double-tap coverage for success and failure scenarios

## Testing
- bun run lint
- bun run test

Fixes #672
