### PR TITLE
Add boomerang option to swipeOn

### DIFF
--- a/schemas/tool-definitions.json
+++ b/schemas/tool-definitions.json
@@ -1645,6 +1645,20 @@
           "additionalProperties": false,
           "description": "Swipe until we find a match"
         },
+        "boomerang": {
+          "type": "boolean",
+          "description": "Return to the starting point after swiping (default false)"
+        },
+        "apexPause": {
+          "type": "number",
+          "minimum": 0,
+          "description": "Pause at the furthest point in ms (default 100)"
+        },
+        "returnSpeed": {
+          "type": "number",
+          "exclusiveMinimum": 0,
+          "description": "Return speed multiplier (default 1.0)"
+        },
         "speed": {
           "type": "string",
           "enum": [

--- a/src/features/action/SwipeOn.ts
+++ b/src/features/action/SwipeOn.ts
@@ -60,6 +60,7 @@ export interface SwipeOnDependencies {
 type SwipeOnResolvedOptions = SwipeOnOptions & { direction: SwipeDirection };
 
 type SwipeInterval = { start: number; end: number; length: number };
+type BoomerangConfig = { apexPauseMs: number; returnSpeed: number };
 type OverlayCandidate = {
   bounds: Element["bounds"];
   overlapBounds: Element["bounds"];
@@ -85,6 +86,8 @@ export class SwipeOn extends BaseVisualChange {
   private static readonly OVERLAY_PADDING = 8;
   private static readonly CANDIDATE_FRACTIONS = [0.5, 0.25, 0.75, 0.15, 0.85];
   private static readonly OVERLAY_COVERAGE_THRESHOLD = 0.8;
+  private static readonly DEFAULT_APEX_PAUSE_MS = 100;
+  private static readonly DEFAULT_RETURN_SPEED = 1;
 
   constructor(
     device: BootedDevice,
@@ -137,10 +140,16 @@ export class SwipeOn extends BaseVisualChange {
     direction: SwipeDirection,
     containerElement: Element | null,
     gestureOptions?: GestureOptions,
-    perf?: PerformanceTracker
+    perf?: PerformanceTracker,
+    boomerang?: BoomerangConfig
   ): Promise<SwipeResult> {
+    const boomerangEnabled = Boolean(boomerang);
+
     // Only check TalkBack for Android platform
     if (this.device.platform !== "android") {
+      if (boomerangEnabled) {
+        return this.executeBoomerangGesture(x1, y1, x2, y2, gestureOptions, boomerang!, perf);
+      }
       return this.executeGesture.swipe(x1, y1, x2, y2, gestureOptions, perf);
     }
 
@@ -151,6 +160,11 @@ export class SwipeOn extends BaseVisualChange {
     );
 
     if (isTalkBackEnabled) {
+      if (boomerangEnabled) {
+        logger.info("[SwipeOn] TalkBack enabled, boomerang requested; announcing swipeable element");
+        return this.announceSwipeable(x1, y1, x2, y2, containerElement, gestureOptions, perf);
+      }
+
       logger.info("[SwipeOn] TalkBack enabled, using accessibility-aware swipe");
       return this.executeAndroidSwipeWithAccessibility(
         x1, y1, x2, y2,
@@ -160,10 +174,122 @@ export class SwipeOn extends BaseVisualChange {
         perf
       );
     } else {
+      if (boomerangEnabled) {
+        logger.debug("[SwipeOn] TalkBack disabled, using boomerang swipe");
+        return this.executeBoomerangGesture(x1, y1, x2, y2, gestureOptions, boomerang!, perf);
+      }
+
       // Standard mode: Use coordinate-based swipes
       logger.debug("[SwipeOn] TalkBack disabled, using standard swipe");
       return this.executeGesture.swipe(x1, y1, x2, y2, gestureOptions, perf);
     }
+  }
+
+  private async executeBoomerangGesture(
+    x1: number,
+    y1: number,
+    x2: number,
+    y2: number,
+    gestureOptions: GestureOptions | undefined,
+    boomerang: BoomerangConfig,
+    perf: PerformanceTracker = new NoOpPerformanceTracker()
+  ): Promise<SwipeResult> {
+    const forwardDuration = gestureOptions?.duration ?? 300;
+    const returnDuration = this.getReturnDuration(forwardDuration, boomerang.returnSpeed);
+    const totalDuration = forwardDuration + boomerang.apexPauseMs + returnDuration;
+
+    const forwardOptions = this.buildGestureOptions(gestureOptions, forwardDuration);
+    const returnOptions = this.buildGestureOptions(gestureOptions, returnDuration);
+
+    const forwardResult = await this.executeGesture.swipe(x1, y1, x2, y2, forwardOptions, perf);
+    if (!forwardResult.success) {
+      return forwardResult;
+    }
+
+    if (boomerang.apexPauseMs > 0) {
+      await this.timer.sleep(boomerang.apexPauseMs);
+    }
+
+    const returnResult = await this.executeGesture.swipe(x2, y2, x1, y1, returnOptions, perf);
+    if (!returnResult.success) {
+      return {
+        ...returnResult,
+        x1,
+        y1,
+        x2,
+        y2,
+        duration: totalDuration
+      };
+    }
+
+    return {
+      ...forwardResult,
+      x1,
+      y1,
+      x2,
+      y2,
+      duration: totalDuration,
+      a11yTotalTimeMs: this.sumOptional(forwardResult.a11yTotalTimeMs, returnResult.a11yTotalTimeMs),
+      a11yGestureTimeMs: this.sumOptional(forwardResult.a11yGestureTimeMs, returnResult.a11yGestureTimeMs),
+      fallbackReason: forwardResult.fallbackReason ?? returnResult.fallbackReason
+    };
+  }
+
+  private async announceSwipeable(
+    x1: number,
+    y1: number,
+    x2: number,
+    y2: number,
+    containerElement: Element | null,
+    gestureOptions?: GestureOptions,
+    perf: PerformanceTracker = new NoOpPerformanceTracker()
+  ): Promise<SwipeResult> {
+    const duration = gestureOptions?.duration ?? 0;
+    const resourceId = containerElement?.["resource-id"];
+
+    if (!resourceId) {
+      const error = "Boomerang swipe in TalkBack mode requires a container element with a resource-id.";
+      logger.warn(`[SwipeOn] ${error}`);
+      return {
+        success: false,
+        error,
+        x1,
+        y1,
+        x2,
+        y2,
+        duration
+      };
+    }
+
+    const result = await this.accessibilityService.requestAction(
+      "focus",
+      resourceId,
+      5000,
+      perf
+    );
+
+    if (!result.success) {
+      const error = result.error ?? "Failed to set accessibility focus for boomerang swipe.";
+      logger.warn(`[SwipeOn] ${error}`);
+      return {
+        success: false,
+        error,
+        x1,
+        y1,
+        x2,
+        y2,
+        duration
+      };
+    }
+
+    return {
+      success: true,
+      x1,
+      y1,
+      x2,
+      y2,
+      duration
+    };
   }
 
   /**
@@ -442,6 +568,22 @@ export class SwipeOn extends BaseVisualChange {
       }
     }
 
+    if (options.boomerang && options.lookFor) {
+      return "boomerang cannot be used with lookFor";
+    }
+
+    if (!options.boomerang && (options.apexPause !== undefined || options.returnSpeed !== undefined)) {
+      return "apexPause/returnSpeed require boomerang=true";
+    }
+
+    if (options.apexPause !== undefined && options.apexPause < 0) {
+      return "apexPause must be >= 0";
+    }
+
+    if (options.returnSpeed !== undefined && options.returnSpeed <= 0) {
+      return "returnSpeed must be > 0";
+    }
+
     return null;
   }
 
@@ -556,6 +698,9 @@ export class SwipeOn extends BaseVisualChange {
       direction: options.direction,
       lookFor: options.lookFor,
       speed: options.speed,
+      boomerang: options.boomerang,
+      apexPause: options.apexPause,
+      returnSpeed: options.returnSpeed,
       platform: this.device.platform
     };
   }
@@ -596,6 +741,7 @@ export class SwipeOn extends BaseVisualChange {
         );
 
         const duration = this.getDuration(options);
+        const boomerang = this.resolveBoomerangConfig(options);
         const gestureOptions: GestureOptions = {
           duration,
           scrollMode: options.scrollMode
@@ -610,7 +756,8 @@ export class SwipeOn extends BaseVisualChange {
             options.direction,
             null, // No container for screen swipe
             gestureOptions,
-            perf
+            perf,
+            boomerang
           )
         );
 
@@ -662,6 +809,7 @@ export class SwipeOn extends BaseVisualChange {
         );
 
         const duration = this.getDuration(options);
+        const boomerang = this.resolveBoomerangConfig(options);
         const gestureOptions: GestureOptions = {
           duration,
           scrollMode: options.scrollMode
@@ -676,7 +824,8 @@ export class SwipeOn extends BaseVisualChange {
             options.direction,
             element, // Use the container element
             gestureOptions,
-            perf
+            perf,
+            boomerang
           )
         );
 
@@ -1264,6 +1413,7 @@ export class SwipeOn extends BaseVisualChange {
       // Use direction directly (finger swipe direction) for consistency with regular swipes
       const { startX, startY, endX, endY } = swipeCoordinates;
 
+      const boomerang = this.resolveBoomerangConfig(options);
       const gestureOptions: GestureOptions = {
         duration: swipeDuration,
         scrollMode: options.scrollMode
@@ -1280,7 +1430,8 @@ export class SwipeOn extends BaseVisualChange {
             options.direction,
             containerElement, // Use the container element
             gestureOptions,
-            perf
+            perf,
+            boomerang
           );
         },
         {
@@ -1572,5 +1723,34 @@ export class SwipeOn extends BaseVisualChange {
     }
 
     return this.elementUtils.getSwipeDurationFromSpeed(options.speed);
+  }
+
+  private resolveBoomerangConfig(options: SwipeOnResolvedOptions): BoomerangConfig | undefined {
+    if (!options.boomerang) {
+      return undefined;
+    }
+
+    return {
+      apexPauseMs: options.apexPause ?? SwipeOn.DEFAULT_APEX_PAUSE_MS,
+      returnSpeed: options.returnSpeed ?? SwipeOn.DEFAULT_RETURN_SPEED
+    };
+  }
+
+  private buildGestureOptions(base: GestureOptions | undefined, duration: number): GestureOptions {
+    return {
+      ...(base ?? {}),
+      duration
+    };
+  }
+
+  private getReturnDuration(forwardDuration: number, returnSpeed: number): number {
+    return Math.max(1, Math.round(forwardDuration / returnSpeed));
+  }
+
+  private sumOptional(a?: number, b?: number): number | undefined {
+    if (a === undefined && b === undefined) {
+      return undefined;
+    }
+    return (a ?? 0) + (b ?? 0);
   }
 }

--- a/src/models/SwipeOnOptions.ts
+++ b/src/models/SwipeOnOptions.ts
@@ -43,6 +43,13 @@ export interface SwipeOnOptions {
    */
   focusTarget?: boolean;
 
+  // Execute a swipe that returns to the start point for dry-run testing (default false)
+  boomerang?: boolean;
+
+  // Boomerang-only settings (internal only)
+  apexPause?: number; // Pause at the far end of the swipe in ms (default 100)
+  returnSpeed?: number; // Multiplier for return speed (default 1.0)
+
   // Gesture options
   speed?: "slow" | "normal" | "fast"; // Speed preset
   duration?: number; // Manual duration override (ms) - internal only

--- a/src/server/interactionTools.ts
+++ b/src/server/interactionTools.ts
@@ -113,6 +113,9 @@ export interface SwipeOnArgs {
     elementId?: string;
     text?: string;
   };
+  boomerang?: boolean;
+  apexPause?: number;
+  returnSpeed?: number;
   speed?: "slow" | "normal" | "fast";
   platform: Platform;
 }
@@ -232,6 +235,9 @@ export const swipeOnSchema = addDeviceTargetingToSchema(z.object({
     elementId: z.string().optional().describe("ID of the element to look for"),
     text: z.string().optional().describe("Text to look for"),
   }).optional().describe("Swipe until we find a match"),
+  boomerang: z.boolean().optional().describe("Return to the starting point after swiping (default false)"),
+  apexPause: z.number().min(0).optional().describe("Pause at the furthest point in ms (default 100)"),
+  returnSpeed: z.number().positive().optional().describe("Return speed multiplier (default 1.0)"),
   speed: z.enum(["slow", "normal", "fast"]).optional().describe("Scroll speed"),
   platform: z.enum(["android", "ios"]).describe("Platform")
 }));
@@ -1350,8 +1356,11 @@ export function registerInteractionTools() {
       direction: resolved.direction,
       gestureType: args.gestureType,
       lookFor: args.lookFor,
-      speed: args.speed
-      // duration and scrollMode are internal-only, not exposed in schema
+      speed: args.speed,
+      boomerang: args.boomerang,
+      apexPause: args.apexPause,
+      returnSpeed: args.returnSpeed
+      // duration and scrollMode are internal-only
     };
 
     const result = await swipeOn.execute(options, progress);

--- a/test/features/action/SwipeOn.talkback.test.ts
+++ b/test/features/action/SwipeOn.talkback.test.ts
@@ -183,6 +183,40 @@ describe("SwipeOn TalkBack mode detection", () => {
         expect(executeGestureSwipe).not.toHaveBeenCalled();
       }
     });
+
+    test("boomerang announces swipeable element instead of swiping", async () => {
+      const mockAccessibilityService = {
+        requestAction: async () => ({ success: true })
+      };
+      (swipeOn as any).accessibilityService = mockAccessibilityService;
+      const requestActionSpy = spyOn(mockAccessibilityService, "requestAction")
+        .mockResolvedValue({ success: true });
+
+      const containerElement = {
+        "resource-id": "test:id/scrollView"
+      } as any;
+
+      await (swipeOn as any).executeSwipeGesture(
+        100,
+        500,
+        100,
+        200,
+        "up" as SwipeDirection,
+        containerElement,
+        { duration: 300 },
+        new NoOpPerformanceTracker(),
+        { apexPauseMs: 100, returnSpeed: 1 }
+      );
+
+      expect(requestActionSpy).toHaveBeenCalledWith(
+        "focus",
+        "test:id/scrollView",
+        5000,
+        expect.any(NoOpPerformanceTracker)
+      );
+      expect(executeAndroidSwipeWithAccessibility).not.toHaveBeenCalled();
+      expect(executeGestureSwipe).not.toHaveBeenCalled();
+    });
   });
 
   describe("TalkBack state cache invalidation", () => {

--- a/test/features/action/SwipeOn.test.ts
+++ b/test/features/action/SwipeOn.test.ts
@@ -293,3 +293,72 @@ describe("SwipeOn container overlays", () => {
     expect(call.y1).toBeLessThan(1100);
   });
 });
+
+describe("SwipeOn boomerang", () => {
+  const device = { name: "test-device", platform: "android", deviceId: "device-1" } as const;
+  let fakeObserveScreen: FakeObserveScreen;
+  let fakeGesture: FakeGestureExecutor;
+  let fakeAwaitIdle: FakeAwaitIdle;
+  let fakeWindow: FakeWindow;
+  let fakeAccessibilityDetector: FakeAccessibilityDetector;
+  let getInstanceSpy: ReturnType<typeof spyOn> | null = null;
+
+  const createObserveResult = (): ObserveResult => ({
+    timestamp: Date.now(),
+    screenSize: { width: 1000, height: 2000 },
+    systemInsets: { top: 0, right: 0, bottom: 0, left: 0 },
+    viewHierarchy: null
+  });
+
+  const createSwipeOn = () => {
+    const swipeOn = new SwipeOn(device, null, null, null, {
+      executeGesture: fakeGesture,
+      observeScreen: fakeObserveScreen,
+      accessibilityDetector: fakeAccessibilityDetector
+    });
+    (swipeOn as any).awaitIdle = fakeAwaitIdle;
+    (swipeOn as any).window = fakeWindow;
+    return swipeOn;
+  };
+
+  beforeEach(() => {
+    fakeAccessibilityDetector = new FakeAccessibilityDetector();
+    fakeAccessibilityDetector.setTalkBackEnabled(false);
+    getInstanceSpy = spyOn(AccessibilityServiceClient, "getInstance").mockReturnValue({} as AccessibilityServiceClient);
+    fakeObserveScreen = new FakeObserveScreen();
+    fakeGesture = new FakeGestureExecutor();
+    fakeAwaitIdle = new FakeAwaitIdle();
+    fakeWindow = new FakeWindow();
+    fakeWindow.setCachedActiveWindow(null);
+  });
+
+  afterEach(() => {
+    getInstanceSpy?.mockRestore();
+  });
+
+  test("performs a round-trip swipe with return speed", async () => {
+    fakeObserveScreen.setObserveResult(createObserveResult());
+
+    const swipeOn = createSwipeOn();
+    const result = await swipeOn.execute({
+      direction: "up",
+      autoTarget: false,
+      duration: 400,
+      boomerang: true,
+      apexPause: 0,
+      returnSpeed: 2
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.duration).toBe(600);
+
+    const calls = fakeGesture.getSwipeCalls();
+    expect(calls).toHaveLength(2);
+    expect(calls[0].options?.duration).toBe(400);
+    expect(calls[1].options?.duration).toBe(200);
+    expect(calls[1].x1).toBe(calls[0].x2);
+    expect(calls[1].y1).toBe(calls[0].y2);
+    expect(calls[1].x2).toBe(calls[0].x1);
+    expect(calls[1].y2).toBe(calls[0].y1);
+  });
+});


### PR DESCRIPTION
## Summary
- add boomerang options to swipeOn across model, action, and server schema
- announce swipeable elements in TalkBack when boomerang is requested
- cover boomerang behavior with tests

## Testing
- bun run test
- bun run lint
- bun run build

Closes #675
