### PR TITLE
Fix drag requests in Android accessibility service

### DIFF
--- a/android/accessibility-service/src/main/kotlin/dev/jasonpearson/automobile/accessibilityservice/AutoMobileAccessibilityService.kt
+++ b/android/accessibility-service/src/main/kotlin/dev/jasonpearson/automobile/accessibilityservice/AutoMobileAccessibilityService.kt
@@ -1007,9 +1007,9 @@ class AutoMobileAccessibilityService : AccessibilityService() {
               moveTo(startX, startY)
               lineTo(endX, endY)
             }
-        gestureBuilder
-            .addStroke(GestureDescription.StrokeDescription(holdPath, 0, holdTime, true))
-            .addStroke(GestureDescription.StrokeDescription(dragPath, holdTime, duration))
+        val holdStroke = GestureDescription.StrokeDescription(holdPath, 0, holdTime, true)
+        val dragStroke = holdStroke.continueStroke(dragPath, holdTime, duration, false)
+        gestureBuilder.addStroke(holdStroke).addStroke(dragStroke)
       } else {
         val dragPath =
             Path().apply {


### PR DESCRIPTION
## Summary
- wire drag requests to `performDrag` so they execute in the accessibility service
- broadcast drag results over WebSocket for success/failure timing

## Testing
- (cd android && ./gradlew :accessibility-service:assembleDebug)

Closes #680
