### PR TITLE
Fix swipeOn direction resolution for lookFor

### DIFF
--- a/src/models/SwipeOnOptions.ts
+++ b/src/models/SwipeOnOptions.ts
@@ -24,7 +24,7 @@ export interface SwipeOnOptions {
   autoTarget?: boolean;
 
   // Direction - interpretation depends on gestureType
-  direction?: SwipeDirection;
+  direction: SwipeDirection;
 
   // How to interpret the direction parameter
   gestureType?: GestureType;

--- a/src/server/interactionTools.ts
+++ b/src/server/interactionTools.ts
@@ -107,7 +107,7 @@ export interface SwipeOnArgs {
     text?: string;
   };
   autoTarget?: boolean;
-  direction?: "up" | "down" | "left" | "right";
+  direction: "up" | "down" | "left" | "right";
   gestureType?: "swipeFingerTowardsDirection" | "scrollTowardsDirection";
   lookFor?: {
     elementId?: string;
@@ -1342,12 +1342,12 @@ export function registerInteractionTools() {
       });
     }
 
-    // Convert SwipeOnArgs to SwipeOnOptions with resolved direction
+    // Convert SwipeOnArgs to SwipeOnOptions (direction resolution happens in SwipeOn)
     const options: import("../models").SwipeOnOptions = {
       includeSystemInsets: args.includeSystemInsets,
       container: args.container,
       autoTarget: args.autoTarget,
-      direction: resolved.direction,
+      direction: args.direction,
       gestureType: args.gestureType,
       lookFor: args.lookFor,
       speed: args.speed


### PR DESCRIPTION
## Summary
- route swipeOn through a single direction resolution path so lookFor scrolling stays consistent
- require direction in swipeOn args/options to avoid unset values at runtime

## Testing
- bun run build

## Issue
- Fixes #671
