### PR TITLE
Validate dragAndDrop params in test plans

### DIFF
--- a/android/test-plan-validation/src/main/resources/schemas/test-plan.schema.json
+++ b/android/test-plan-validation/src/main/resources/schemas/test-plan.schema.json
@@ -200,16 +200,47 @@
                 "description": "Keep physical Android devices awake during the session (default: true)"
               }
             },
-            "anyOf": [
+            "allOf": [
               {
-                "required": [
-                  "params"
+                "anyOf": [
+                  {
+                    "required": [
+                      "source"
+                    ]
+                  },
+                  {
+                    "properties": {
+                      "params": {
+                        "required": [
+                          "source"
+                        ]
+                      }
+                    },
+                    "required": [
+                      "params"
+                    ]
+                  }
                 ]
               },
               {
-                "required": [
-                  "source",
-                  "target"
+                "anyOf": [
+                  {
+                    "required": [
+                      "target"
+                    ]
+                  },
+                  {
+                    "properties": {
+                      "params": {
+                        "required": [
+                          "target"
+                        ]
+                      }
+                    },
+                    "required": [
+                      "params"
+                    ]
+                  }
                 ]
               }
             ]
@@ -290,10 +321,6 @@
           "description": "Device label for multi-device plans (e.g., \"A\", \"B\")"
         }
       },
-      "required": [
-        "source",
-        "target"
-      ],
       "additionalProperties": true,
       "description": "Parameters for dragAndDrop"
     },

--- a/android/test-plan-validation/src/test/kotlin/dev/jasonpearson/automobile/validation/TestPlanValidatorTest.kt
+++ b/android/test-plan-validation/src/test/kotlin/dev/jasonpearson/automobile/validation/TestPlanValidatorTest.kt
@@ -531,7 +531,7 @@ class TestPlanValidatorTest {
     }
 
     @Test
-    fun `validates dragAndDrop with top-level selectors`() {
+    fun `validates dragAndDrop with top-level selectors and param overrides`() {
         val yaml = """
             name: drag-and-drop
             steps:
@@ -540,6 +540,8 @@ class TestPlanValidatorTest {
                   text: Source
                 target:
                   text: Target
+                params:
+                  duration: 800
         """.trimIndent()
 
         val result = TestPlanValidator.validateYaml(yaml)

--- a/schemas/test-plan.schema.json
+++ b/schemas/test-plan.schema.json
@@ -200,16 +200,47 @@
                 "description": "Keep physical Android devices awake during the session (default: true)"
               }
             },
-            "anyOf": [
+            "allOf": [
               {
-                "required": [
-                  "params"
+                "anyOf": [
+                  {
+                    "required": [
+                      "source"
+                    ]
+                  },
+                  {
+                    "properties": {
+                      "params": {
+                        "required": [
+                          "source"
+                        ]
+                      }
+                    },
+                    "required": [
+                      "params"
+                    ]
+                  }
                 ]
               },
               {
-                "required": [
-                  "source",
-                  "target"
+                "anyOf": [
+                  {
+                    "required": [
+                      "target"
+                    ]
+                  },
+                  {
+                    "properties": {
+                      "params": {
+                        "required": [
+                          "target"
+                        ]
+                      }
+                    },
+                    "required": [
+                      "params"
+                    ]
+                  }
                 ]
               }
             ]
@@ -290,10 +321,6 @@
           "description": "Device label for multi-device plans (e.g., \"A\", \"B\")"
         }
       },
-      "required": [
-        "source",
-        "target"
-      ],
       "additionalProperties": true,
       "description": "Parameters for dragAndDrop"
     },

--- a/test/plan/PlanSchemaValidator.test.ts
+++ b/test/plan/PlanSchemaValidator.test.ts
@@ -85,6 +85,22 @@ steps:
       const result = validator.validateYaml(yaml);
       expect(result.valid).toBe(true);
     });
+
+    it("should validate dragAndDrop with top-level selectors and param overrides", () => {
+      const yaml = `
+name: drag-and-drop
+steps:
+  - tool: dragAndDrop
+    source:
+      text: Source
+    target:
+      text: Target
+    params:
+      duration: 800
+`;
+      const result = validator.validateYaml(yaml);
+      expect(result.valid).toBe(true);
+    });
   });
 
   describe("Invalid YAML syntax", () => {


### PR DESCRIPTION
## Summary
- allow dragAndDrop selectors to be split between top-level fields and params
- keep dragAndDrop param overrides valid when selectors are top-level
- extend schema validation tests for dragAndDrop overrides

## Testing
- bun run test -- --grep "PlanSchemaValidator"
- (cd android && ./gradlew :test-plan-validation:test)

## Issue
Closes #687
