### PR TITLE
Fix swipeOn to avoid all overlays simultaneously

### DIFF
--- a/src/features/action/SwipeOn.ts
+++ b/src/features/action/SwipeOn.ts
@@ -85,7 +85,6 @@ export class SwipeOn extends BaseVisualChange {
   private static readonly MAX_ATTEMPTS = 5;
   private static readonly OVERLAY_PADDING = 8;
   private static readonly CANDIDATE_FRACTIONS = [0.5, 0.25, 0.75, 0.15, 0.85];
-  private static readonly OVERLAY_COVERAGE_THRESHOLD = 0.8;
   private static readonly DEFAULT_APEX_PAUSE_MS = 100;
   private static readonly DEFAULT_RETURN_SPEED = 1;
 
@@ -866,15 +865,16 @@ export class SwipeOn extends BaseVisualChange {
     );
 
     const overlayCandidates = this.collectOverlayCandidates(viewHierarchy, options.container, containerElement);
-    const primaryOverlay = this.selectOverlayCandidate(overlayCandidates);
-    if (!primaryOverlay) {
+    if (overlayCandidates.length === 0) {
       return defaultSwipe;
     }
 
+    // Pass all overlay bounds to find the best safe swipe path avoiding all overlays
+    const allOverlayBounds = overlayCandidates.map(overlay => overlay.overlapBounds);
     const safeSwipe = this.computeSafeSwipeCoordinates(
       options.direction,
       containerElement.bounds,
-      [primaryOverlay.overlapBounds]
+      allOverlayBounds
     );
 
     if (!safeSwipe) {
@@ -960,50 +960,6 @@ export class SwipeOn extends BaseVisualChange {
     return overlays;
   }
 
-  private selectOverlayCandidate(candidates: OverlayCandidate[]): OverlayCandidate | null {
-    if (candidates.length === 0) {
-      return null;
-    }
-
-    const sorted = [...candidates].sort((a, b) => b.coverage - a.coverage);
-    for (let i = 0; i < sorted.length; i++) {
-      const candidate = sorted[i];
-      const isCoveredByLower = sorted.slice(i + 1).some(lower =>
-        this.isSignificantlyCovered(candidate, lower)
-      );
-
-      if (!isCoveredByLower) {
-        return candidate;
-      }
-    }
-
-    return sorted[0];
-  }
-
-  private isAbove(a: OverlayCandidate, b: OverlayCandidate): boolean {
-    if (a.zOrder.windowRank !== b.zOrder.windowRank) {
-      return a.zOrder.windowRank > b.zOrder.windowRank;
-    }
-    return a.zOrder.nodeOrder > b.zOrder.nodeOrder;
-  }
-
-  private isSignificantlyCovered(candidate: OverlayCandidate, higher: OverlayCandidate): boolean {
-    if (!this.isAbove(higher, candidate)) {
-      return false;
-    }
-
-    const overlap = this.intersectBounds(candidate.overlapBounds, higher.overlapBounds);
-    if (!overlap) {
-      return false;
-    }
-
-    if (candidate.coverage <= 0) {
-      return false;
-    }
-
-    const overlapRatio = this.boundsArea(overlap) / candidate.coverage;
-    return overlapRatio >= SwipeOn.OVERLAY_COVERAGE_THRESHOLD;
-  }
 
   private intersectBounds(a: Element["bounds"], b: Element["bounds"]): Element["bounds"] | null {
     const left = Math.max(a.left, b.left);
@@ -1202,7 +1158,7 @@ export class SwipeOn extends BaseVisualChange {
   }
 
   private isClickableNode(nodeProperties: Record<string, unknown>): boolean {
-    return this.isTruthyFlag(nodeProperties.clickable);
+    return this.isTruthyFlag(nodeProperties.clickable) || this.isTruthyFlag(nodeProperties.focusable);
   }
 
   private isContainerNode(

--- a/test/fakes/FakeGestureExecutor.ts
+++ b/test/fakes/FakeGestureExecutor.ts
@@ -1,8 +1,9 @@
 import { GestureOptions } from "../../src/models";
 import { SwipeResult } from "../../src/models/SwipeResult";
 import { PerformanceTracker } from "../../src/utils/PerformanceTracker";
+import { GestureExecutor } from "../../src/features/action/SwipeOn";
 
-export class FakeGestureExecutor {
+export class FakeGestureExecutor implements GestureExecutor {
   private swipeCalls: Array<{
     x1: number;
     y1: number;

--- a/test/fakes/FakeObserveScreen.ts
+++ b/test/fakes/FakeObserveScreen.ts
@@ -1,10 +1,11 @@
 import { ObserveResult } from "../../src/models";
+import { ObserveScreenLike } from "../../src/features/action/SwipeOn";
 
 /**
  * Fake implementation of ObserveScreen for testing
  * Allows configuring observation responses and asserting method calls
  */
-export class FakeObserveScreen {
+export class FakeObserveScreen implements ObserveScreenLike {
   private executedOperations: string[] = [];
   private configuredObserveResult: ObserveResult | null = null;
   private observeResultFactory: (() => ObserveResult) | null = null;

--- a/test/features/action/SwipeOn.test.ts
+++ b/test/features/action/SwipeOn.test.ts
@@ -267,7 +267,7 @@ describe("SwipeOn container overlays", () => {
     expect(call.y1).toBeGreaterThan(400);
   });
 
-  test("prefers the topmost overlay when it covers most of a larger one", async () => {
+  test("avoids all overlapping clickable elements when multiple exist", async () => {
     const containerNode = createContainerNode("[0,0][1000,2000]", "map-container");
     const overlayLarge = createNode("[0,0][1000,1000]", {
       "resource-id": "large-overlay",
@@ -290,7 +290,253 @@ describe("SwipeOn container overlays", () => {
     expect(result.success).toBe(true);
     const [call] = fakeGesture.getSwipeCalls();
     expect(call).toBeDefined();
-    expect(call.y1).toBeLessThan(1100);
+    // Should start after the largest overlay (1000px) plus padding
+    expect(call.y1).toBeGreaterThan(1000);
+  });
+
+  test("handles complex scenarios like Google Maps with multiple overlays", async () => {
+    // Simulate Google Maps layout with multiple overlays
+    const containerNode = createContainerNode("[0,0][1080,2400]", "com.google.android.apps.maps:id/fullscreens_group");
+
+    // Search bar at top
+    const searchBar = createNode("[0,0][1080,226]", {
+      "resource-id": "com.google.android.apps.maps:id/search_omnibox_container",
+      "clickable": "true"
+    });
+
+    // Category chips below search bar
+    const categoryChips = createNode("[31,226][1080,352]", {
+      "resource-id": "com.google.android.apps.maps:id/recycler_view",
+      "clickable": "true"
+    });
+
+    // Bottom controls
+    const locationButton = createNode("[881,1886][1080,2072]", {
+      "resource-id": "com.google.android.apps.maps:id/mylocation_button",
+      "clickable": "true"
+    });
+
+    const streetViewThumb = createNode("[36,1907][272,2049]", {
+      "resource-id": "com.google.android.apps.maps:id/street_view_thumbnail",
+      "clickable": "true"
+    });
+
+    const layersButton = createNode("[928,378][1080,520]", {
+      "resource-id": "com.google.android.apps.maps:id/layers_fab",
+      "clickable": "true"
+    });
+
+    const hierarchy = createHierarchy([
+      containerNode,
+      searchBar,
+      categoryChips,
+      locationButton,
+      streetViewThumb,
+      layersButton
+    ]);
+    fakeObserveScreen.setObserveResult(createObserveResult(hierarchy));
+
+    const swipeOn = createSwipeOn();
+    const result = await swipeOn.execute({
+      direction: "down",
+      container: { elementId: "com.google.android.apps.maps:id/fullscreens_group" }
+    });
+
+    expect(result.success).toBe(true);
+    const [call] = fakeGesture.getSwipeCalls();
+    expect(call).toBeDefined();
+
+    // Should start below the category chips (352px) plus padding
+    expect(call.y1).toBeGreaterThan(352);
+
+    // The swipe should be vertical (same x coordinate)
+    expect(call.x1).toBe(call.x2);
+
+    // X coordinate should avoid overlays:
+    // - Not in streetViewThumb range [36-272]
+    // - Not in locationButton range [881-1080]
+    // - Not in layersButton range [928-1080]
+    // So it should be in the safe middle zone [272-881]
+    expect(call.x1).toBeGreaterThan(272);
+    expect(call.x1).toBeLessThan(881);
+
+    // Swipe should have reasonable distance (at least 500px for "down" direction)
+    const swipeDistance = Math.abs(call.y2 - call.y1);
+    expect(swipeDistance).toBeGreaterThan(500);
+  });
+
+  test("uses default bounds when no overlays are present", async () => {
+    const containerNode = createContainerNode("[0,0][1000,2000]", "container-no-overlays");
+
+    const hierarchy = createHierarchy([containerNode]);
+    fakeObserveScreen.setObserveResult(createObserveResult(hierarchy));
+
+    const swipeOn = createSwipeOn();
+    const result = await swipeOn.execute({
+      direction: "down",
+      container: { elementId: "container-no-overlays" }
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.warning).toBeUndefined();
+    const [call] = fakeGesture.getSwipeCalls();
+    expect(call).toBeDefined();
+    // Should use center x coordinate (500) since no overlays
+    expect(call.x1).toBe(500);
+  });
+
+  test("handles horizontal swipes with overlays on top and bottom", async () => {
+    const containerNode = createContainerNode("[0,0][1000,2000]", "horizontal-container");
+    const topOverlay = createNode("[0,0][1000,300]", {
+      "resource-id": "top-bar",
+      "clickable": "true"
+    });
+    const bottomOverlay = createNode("[0,1700][1000,2000]", {
+      "resource-id": "bottom-bar",
+      "clickable": "true"
+    });
+
+    const hierarchy = createHierarchy([containerNode, topOverlay, bottomOverlay]);
+    fakeObserveScreen.setObserveResult(createObserveResult(hierarchy));
+
+    const swipeOn = createSwipeOn();
+    const result = await swipeOn.execute({
+      direction: "left",
+      container: { elementId: "horizontal-container" }
+    });
+
+    expect(result.success).toBe(true);
+    const [call] = fakeGesture.getSwipeCalls();
+    expect(call).toBeDefined();
+    // Y should be in safe zone between overlays
+    expect(call.y1).toBeGreaterThan(300);
+    expect(call.y1).toBeLessThan(1700);
+    expect(call.y1).toBe(call.y2); // Same Y for horizontal swipe
+  });
+
+  test("ignores non-clickable elements", async () => {
+    const containerNode = createContainerNode("[0,0][1000,2000]", "container-with-non-clickable");
+    const nonClickableOverlay = createNode("[0,0][1000,500]", {
+      "resource-id": "non-clickable-element",
+      "clickable": "false"
+    });
+
+    const hierarchy = createHierarchy([containerNode, nonClickableOverlay]);
+    fakeObserveScreen.setObserveResult(createObserveResult(hierarchy));
+
+    const swipeOn = createSwipeOn();
+    const result = await swipeOn.execute({
+      direction: "down",
+      container: { elementId: "container-with-non-clickable" }
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.warning).toBeUndefined();
+    const [call] = fakeGesture.getSwipeCalls();
+    expect(call).toBeDefined();
+    // Should not avoid non-clickable overlay, so y1 can be anywhere
+    // Including the area covered by the non-clickable element
+    expect(call.y1).toBeLessThan(500);
+  });
+
+  test("avoids focusable elements even if not clickable", async () => {
+    const containerNode = createContainerNode("[0,0][1000,2000]", "container-with-focusable");
+    const focusableOverlay = createNode("[0,0][1000,300]", {
+      "resource-id": "focusable-element",
+      "focusable": "true"
+    });
+
+    const hierarchy = createHierarchy([containerNode, focusableOverlay]);
+    fakeObserveScreen.setObserveResult(createObserveResult(hierarchy));
+
+    const swipeOn = createSwipeOn();
+    const result = await swipeOn.execute({
+      direction: "down",
+      container: { elementId: "container-with-focusable" }
+    });
+
+    expect(result.success).toBe(true);
+    const [call] = fakeGesture.getSwipeCalls();
+    expect(call).toBeDefined();
+    // Should avoid focusable overlay
+    expect(call.y1).toBeGreaterThan(300);
+  });
+
+  test("ignores overlays completely outside container bounds", async () => {
+    const containerNode = createContainerNode("[100,100][900,1900]", "inner-container");
+    // Overlay outside container bounds
+    const outsideOverlay = createNode("[0,0][50,2000]", {
+      "resource-id": "outside-overlay",
+      "clickable": "true"
+    });
+
+    const hierarchy = createHierarchy([containerNode, outsideOverlay]);
+    fakeObserveScreen.setObserveResult(createObserveResult(hierarchy));
+
+    const swipeOn = createSwipeOn();
+    const result = await swipeOn.execute({
+      direction: "down",
+      container: { elementId: "inner-container" }
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.warning).toBeUndefined();
+    const [call] = fakeGesture.getSwipeCalls();
+    expect(call).toBeDefined();
+    // Should use container center (500) since overlay doesn't overlap
+    expect(call.x1).toBe(500);
+  });
+
+  test("warns when overlays leave minimal safe space", async () => {
+    const containerNode = createContainerNode("[0,0][1000,2000]", "mostly-blocked-container");
+    // Create overlays that cover most of the vertical space
+    const overlay1 = createNode("[0,0][1000,1950]", {
+      "resource-id": "massive-overlay",
+      "clickable": "true"
+    });
+
+    const hierarchy = createHierarchy([containerNode, overlay1]);
+    fakeObserveScreen.setObserveResult(createObserveResult(hierarchy));
+
+    const swipeOn = createSwipeOn();
+    const result = await swipeOn.execute({
+      direction: "down",
+      container: { elementId: "mostly-blocked-container" }
+    });
+
+    expect(result.success).toBe(true);
+    // Should have warning about reduced swipe area
+    expect(result.warning).toBeDefined();
+    expect(result.warning).toContain("Swipe area reduced");
+    const [call] = fakeGesture.getSwipeCalls();
+    expect(call).toBeDefined();
+    // Y should be in the small remaining gap
+    expect(call.y1).toBeGreaterThan(1950);
+  });
+
+  test("handles overlays with partial intersection", async () => {
+    const containerNode = createContainerNode("[0,0][1000,2000]", "container");
+    // Overlay that only partially overlaps container
+    const partialOverlay = createNode("[500,0][1500,400]", {
+      "resource-id": "partial-overlay",
+      "clickable": "true"
+    });
+
+    const hierarchy = createHierarchy([containerNode, partialOverlay]);
+    fakeObserveScreen.setObserveResult(createObserveResult(hierarchy));
+
+    const swipeOn = createSwipeOn();
+    const result = await swipeOn.execute({
+      direction: "down",
+      container: { elementId: "container" }
+    });
+
+    expect(result.success).toBe(true);
+    const [call] = fakeGesture.getSwipeCalls();
+    expect(call).toBeDefined();
+    // Should avoid the overlapping part [500-1000, 0-400]
+    // X should be < 500 or Y should start > 400
+    expect(call.x1 < 500 || call.y1 > 400).toBe(true);
   });
 });
 


### PR DESCRIPTION
## Summary

- Fixed overlay avoidance to consider ALL overlays simultaneously instead of just one
- Added support for avoiding focusable elements (not just clickable)
- Enhanced test coverage with 8 new edge case tests
- Made test fakes explicitly implement interfaces for type safety

## Problem

The previous implementation (PR #659) collected all clickable overlays but then used `selectOverlayCandidate` to pick only ONE "primary" overlay to avoid. For complex UIs like Google Maps with multiple overlays (search bar, category chips, location button, street view thumbnail, layers button), this meant only one would be avoided, causing swipes to hit the others.

Additionally, the code only checked for `clickable` elements but missed `focusable` elements like the Google Maps search bar.

## Solution

Changed `resolveContainerSwipeCoordinates` to pass **all** overlay bounds to `computeSafeSwipeCoordinates`, which was already designed to handle multiple overlays. The algorithm tries multiple candidate X coordinates and finds the one with the longest unobstructed vertical path that avoids ALL overlays.

Also updated `isClickableNode` to detect both clickable AND focusable elements.

## Changes

**Core fix:**
- `src/features/action/SwipeOn.ts:858-889` - Pass all overlays to coordinate calculation
- `src/features/action/SwipeOn.ts:1160-1162` - Detect focusable elements
- Removed unused methods: `selectOverlayCandidate`, `isAbove`, `isSignificantlyCovered`
- Removed unused constant: `OVERLAY_COVERAGE_THRESHOLD`

**Test improvements:**
- `test/fakes/FakeGestureExecutor.ts:6` - Explicitly implement `GestureExecutor` interface
- `test/fakes/FakeObserveScreen.ts:8` - Explicitly implement `ObserveScreenLike` interface
- `test/features/action/SwipeOn.test.ts` - Added 8 new edge case tests:
  - No overlays present
  - Horizontal swipes with overlays
  - Non-clickable elements (should ignore)
  - Focusable elements (should avoid)
  - Overlays outside container bounds
  - Minimal safe space warning
  - Partial intersection handling
  - Google Maps complex scenario

## Test Results

- Before: 9 tests, 36 expect() calls
- After: 17 tests, 71 expect() calls
- All 1,295 project tests passing

## Testing

```bash
bun run build
bun run lint
bun test test/features/action/SwipeOn.test.ts
bun test
```

Closes #645

🤖 Generated with [Claude Code](https://claude.com/claude-code)