### PR TITLE
Add random selection strategy for tapOn

### DIFF
--- a/schemas/tool-definitions.json
+++ b/schemas/tool-definitions.json
@@ -1842,6 +1842,14 @@
           "type": "string",
           "description": "Element ID to tap"
         },
+        "selectionStrategy": {
+          "type": "string",
+          "enum": [
+            "first",
+            "random"
+          ],
+          "description": "Element selection strategy when multiple matches are found (default: first)"
+        },
         "duration": {
           "type": "number",
           "description": "Long press duration (ms)"

--- a/src/features/action/TapOnElement.ts
+++ b/src/features/action/TapOnElement.ts
@@ -11,6 +11,7 @@ import { AdbClient } from "../../utils/android-cmdline-tools/AdbClient";
 import { TapOnElementOptions } from "../../models/TapOnElementOptions";
 import { ElementUtils } from "../utility/ElementUtils";
 import { ElementParser } from "../utility/ElementParser";
+import { DefaultElementSelector } from "../utility/DefaultElementSelector";
 import { logger } from "../../utils/logger";
 import { AccessibilityServiceClient } from "../observe/AccessibilityServiceClient";
 import { AxeClient } from "../../utils/ios-cmdline-tools/AxeClient";
@@ -23,6 +24,7 @@ import { throwIfAborted } from "../../utils/toolUtils";
 import { SelectionStateTracker, SelectionCaptureState, TakeScreenshotCapturer } from "../navigation/SelectionStateTracker";
 import { AccessibilityDetector } from "../../utils/interfaces/AccessibilityDetector";
 import { accessibilityDetector as defaultAccessibilityDetector } from "../../utils/AccessibilityDetector";
+import type { ElementSelector } from "../../utils/interfaces/ElementSelector";
 import type { Timer } from "../../utils/SystemTimer";
 import { NodeCryptoService } from "../../utils/crypto";
 
@@ -39,6 +41,7 @@ export class TapOnElement extends BaseVisualChange {
   private visionConfig: VisionFallbackConfig;
   private selectionStateTracker: SelectionStateTracker;
   private accessibilityDetector: AccessibilityDetector;
+  private elementSelector: ElementSelector;
   private static readonly SEARCH_UNTIL_DEFAULT_MS = 500;
   private static readonly SEARCH_UNTIL_MIN_MS = 100;
   private static readonly SEARCH_UNTIL_MAX_MS = 12000;
@@ -51,7 +54,8 @@ export class TapOnElement extends BaseVisualChange {
     visionConfig?: VisionFallbackConfig,
     selectionStateTracker?: SelectionStateTracker,
     accessibilityDetector?: AccessibilityDetector,
-    timer?: Timer
+    timer?: Timer,
+    elementSelector?: ElementSelector
   ) {
     super(device, adb, axe, timer);
     this.elementUtils = new ElementUtils();
@@ -63,6 +67,7 @@ export class TapOnElement extends BaseVisualChange {
       screenshotCapturer: new TakeScreenshotCapturer(device, this.adb)
     });
     this.accessibilityDetector = accessibilityDetector || defaultAccessibilityDetector;
+    this.elementSelector = elementSelector ?? new DefaultElementSelector();
   }
 
   /**
@@ -123,23 +128,22 @@ export class TapOnElement extends BaseVisualChange {
     const containerFound = this.isContainerAvailable(viewHierarchy, options.container);
     if (options.text) {
       return {
-        element: this.elementUtils.findElementByText(
-          viewHierarchy,
-          options.text,
-          options.container,
-          true,
-          false,
-        ),
+        element: this.elementSelector.selectByText(viewHierarchy, options.text, {
+          container: options.container,
+          fuzzyMatch: true,
+          caseSensitive: false,
+          strategy: options.selectionStrategy
+        }),
         containerFound
       };
     }
     if (options.elementId) {
       return {
-        element: this.elementUtils.findElementByResourceId(
-          viewHierarchy,
-          options.elementId,
-          options.container,
-        ),
+        element: this.elementSelector.selectByResourceId(viewHierarchy, options.elementId, {
+          container: options.container,
+          partialMatch: false,
+          strategy: options.selectionStrategy
+        }),
         containerFound
       };
     }
@@ -663,6 +667,7 @@ export class TapOnElement extends BaseVisualChange {
               duration: options.duration,
               container: options.container,
               searchUntil: options.searchUntil,
+              selectionStrategy: options.selectionStrategy,
               platform: this.device.platform
             }
           }

--- a/src/features/utility/DefaultElementSelector.ts
+++ b/src/features/utility/DefaultElementSelector.ts
@@ -1,0 +1,72 @@
+import type { Element } from "../../models/Element";
+import type { ViewHierarchyResult } from "../../models/ViewHierarchyResult";
+import type { ElementSelectionStrategy } from "../../models/ElementSelectionStrategy";
+import type { ElementSelector } from "../../utils/interfaces/ElementSelector";
+import { ElementFinder } from "./ElementFinder";
+
+export class DefaultElementSelector implements ElementSelector {
+  private finder: ElementFinder;
+  private random: () => number;
+
+  constructor(
+    finder: ElementFinder = new ElementFinder(),
+    random: () => number = Math.random
+  ) {
+    this.finder = finder;
+    this.random = random;
+  }
+
+  selectByText(
+    viewHierarchy: ViewHierarchyResult,
+    text: string,
+    options?: {
+      container?: { elementId?: string; text?: string } | null;
+      fuzzyMatch?: boolean;
+      caseSensitive?: boolean;
+      strategy?: ElementSelectionStrategy;
+    }
+  ): Element | null {
+    const matches = this.finder.findElementsByText(
+      viewHierarchy,
+      text,
+      options?.container ?? null,
+      options?.fuzzyMatch ?? true,
+      options?.caseSensitive ?? false
+    );
+    return this.pickMatch(matches, options?.strategy ?? "first");
+  }
+
+  selectByResourceId(
+    viewHierarchy: ViewHierarchyResult,
+    resourceId: string,
+    options?: {
+      container?: { elementId?: string; text?: string } | null;
+      partialMatch?: boolean;
+      strategy?: ElementSelectionStrategy;
+    }
+  ): Element | null {
+    const matches = this.finder.findElementsByResourceId(
+      viewHierarchy,
+      resourceId,
+      options?.container ?? null,
+      options?.partialMatch ?? false
+    );
+    return this.pickMatch(matches, options?.strategy ?? "first");
+  }
+
+  private pickMatch(matches: Element[], strategy: ElementSelectionStrategy): Element | null {
+    if (matches.length === 0) {
+      return null;
+    }
+
+    if (strategy === "random") {
+      const rawIndex = Math.floor(this.random() * matches.length);
+      const safeIndex = Number.isFinite(rawIndex)
+        ? Math.min(matches.length - 1, Math.max(0, rawIndex))
+        : 0;
+      return matches[safeIndex];
+    }
+
+    return matches[0];
+  }
+}

--- a/src/features/utility/ElementFinder.ts
+++ b/src/features/utility/ElementFinder.ts
@@ -114,12 +114,12 @@ export class ElementFinder {
     });
   }
 
-  private findElementByTextInRoots(
+  private collectTextMatchesInRoots(
     rootNodes: ViewHierarchyNode[],
     text: string,
     matchesText: (input?: string) => boolean
-  ): Element | null {
-    const matches: Element[] = [];
+  ): { exactMatches: Element[]; fuzzyMatches: Element[] } {
+    const fuzzyMatches: Element[] = [];
     const exactMatches: Element[] = [];
 
     for (const searchNode of rootNodes) {
@@ -139,7 +139,7 @@ export class ElementFinder {
             if (nodeProperties.text === text) {
               exactMatches.push(parsedNode);
             } else {
-              matches.push(parsedNode);
+              fuzzyMatches.push(parsedNode);
             }
           }
         } else if (
@@ -153,7 +153,7 @@ export class ElementFinder {
             if (nodeProperties["content-desc"] === text) {
               exactMatches.push(parsedNode);
             } else {
-              matches.push(parsedNode);
+              fuzzyMatches.push(parsedNode);
             }
           }
         } else if (
@@ -167,7 +167,7 @@ export class ElementFinder {
             if (nodeProperties["ios-accessibility-label"] === text) {
               exactMatches.push(parsedNode);
             } else {
-              matches.push(parsedNode);
+              fuzzyMatches.push(parsedNode);
             }
           }
         } else if (
@@ -183,7 +183,7 @@ export class ElementFinder {
           logger.info("[Element] Matches clickable element with text");
           const parsedNode = this.parser.parseNodeBounds(node);
           if (parsedNode) {
-            matches.push(parsedNode);
+            fuzzyMatches.push(parsedNode);
           }
         } else {
           logger.debug(`[Element] No match found in properties`);
@@ -193,22 +193,19 @@ export class ElementFinder {
 
     if (exactMatches.length > 0) {
       this.sortElementsByArea(exactMatches);
-      return exactMatches[0];
+    }
+    if (fuzzyMatches.length > 0) {
+      this.sortElementsByArea(fuzzyMatches);
     }
 
-    if (matches.length > 0) {
-      this.sortElementsByArea(matches);
-      return matches[0];
-    }
-
-    return null;
+    return { exactMatches, fuzzyMatches };
   }
 
-  private findElementByResourceIdInRoots(
+  private collectResourceIdMatchesInRoots(
     rootNodes: ViewHierarchyNode[],
     resourceId: string,
     partialMatch: boolean
-  ): Element | null {
+  ): Element[] {
     const matches: Element[] = [];
 
     for (const searchNode of rootNodes) {
@@ -231,10 +228,9 @@ export class ElementFinder {
 
     if (matches.length > 0) {
       this.sortElementsByArea(matches);
-      return matches[0];
     }
 
-    return null;
+    return matches;
   }
 
   private findScrollableContainerInRoots(rootNodes: ViewHierarchyNode[]): Element | null {
@@ -284,6 +280,60 @@ export class ElementFinder {
   }
 
   /**
+   * Find elements in the view hierarchy that match the specified text
+   * @param viewHierarchy - The view hierarchy to search
+   * @param text - The text to search for
+   * @param container - Container element selector to restrict the search within its child nodes
+   * @param fuzzyMatch - Whether to use fuzzy matching (partial text match)
+   * @param caseSensitive - Whether to use case-sensitive matching
+   * @returns Array of matching elements
+   */
+  findElementsByText(
+    viewHierarchy: ViewHierarchyResult,
+    text: string,
+    container: { elementId?: string; text?: string } | null = null,
+    fuzzyMatch: boolean = true,
+    caseSensitive: boolean = false
+  ): Element[] {
+    if (!viewHierarchy || !text) {
+      return [];
+    }
+
+    const matchesText = this.textMatcher.createTextMatcher(text, fuzzyMatch, caseSensitive);
+    const containerNode = container
+      ? this.findContainerNodeInternal(viewHierarchy, container)
+      : null;
+
+    if (container && !containerNode) {
+      return [];
+    }
+
+    const selectMatches = (matches: { exactMatches: Element[]; fuzzyMatches: Element[] }): Element[] => {
+      return matches.exactMatches.length > 0 ? matches.exactMatches : matches.fuzzyMatches;
+    };
+
+    if (containerNode) {
+      return selectMatches(this.collectTextMatchesInRoots([containerNode], text, matchesText));
+    }
+
+    const rootNodes = this.parser.extractRootNodes(viewHierarchy);
+    const mainMatches = selectMatches(this.collectTextMatchesInRoots(rootNodes, text, matchesText));
+    if (mainMatches.length > 0) {
+      return mainMatches;
+    }
+
+    const windowRootGroups = this.parser.extractWindowRootGroups(viewHierarchy, "topmost-first");
+    for (const windowRoots of windowRootGroups) {
+      const windowMatches = selectMatches(this.collectTextMatchesInRoots(windowRoots, text, matchesText));
+      if (windowMatches.length > 0) {
+        return windowMatches;
+      }
+    }
+
+    return [];
+  }
+
+  /**
    * Find an element in the view hierarchy that matches the specified text
    * @param viewHierarchy - The view hierarchy to search
    * @param text - The text to search for
@@ -299,40 +349,8 @@ export class ElementFinder {
     fuzzyMatch: boolean = true,
     caseSensitive: boolean = false
   ): Element | null {
-    if (!viewHierarchy || !text) {
-      return null;
-    }
-
-    // Create matcher function once instead of repeatedly in the loop
-    const matchesText = this.textMatcher.createTextMatcher(text, fuzzyMatch, caseSensitive);
-    const containerNode = container
-      ? this.findContainerNodeInternal(viewHierarchy, container)
-      : null;
-
-    if (container && !containerNode) {
-      // Container not found, return null
-      return null;
-    }
-
-    if (containerNode) {
-      return this.findElementByTextInRoots([containerNode], text, matchesText);
-    }
-
-    const rootNodes = this.parser.extractRootNodes(viewHierarchy);
-    const mainMatch = this.findElementByTextInRoots(rootNodes, text, matchesText);
-    if (mainMatch) {
-      return mainMatch;
-    }
-
-    const windowRootGroups = this.parser.extractWindowRootGroups(viewHierarchy, "topmost-first");
-    for (const windowRoots of windowRootGroups) {
-      const windowMatch = this.findElementByTextInRoots(windowRoots, text, matchesText);
-      if (windowMatch) {
-        return windowMatch;
-      }
-    }
-
-    return null;
+    const matches = this.findElementsByText(viewHierarchy, text, container, fuzzyMatch, caseSensitive);
+    return matches[0] ?? null;
   }
 
   /**
@@ -343,14 +361,14 @@ export class ElementFinder {
    * @param partialMatch - Whether to allow partial ID matching
    * @returns Array of matching elements
    */
-  findElementByResourceId(
+  findElementsByResourceId(
     viewHierarchy: ViewHierarchyResult,
     resourceId: string,
     container: { elementId?: string; text?: string } | null = null,
     partialMatch: boolean = false
-  ): Element | null {
+  ): Element[] {
     if (!viewHierarchy || !resourceId) {
-      return null;
+      return [];
     }
 
     const containerNode = container
@@ -358,29 +376,46 @@ export class ElementFinder {
       : null;
 
     if (container && !containerNode) {
-      // Container not found, return empty list
-      return null;
+      return [];
     }
 
     if (containerNode) {
-      return this.findElementByResourceIdInRoots([containerNode], resourceId, partialMatch);
+      return this.collectResourceIdMatchesInRoots([containerNode], resourceId, partialMatch);
     }
 
     const rootNodes = this.parser.extractRootNodes(viewHierarchy);
-    const mainMatch = this.findElementByResourceIdInRoots(rootNodes, resourceId, partialMatch);
-    if (mainMatch) {
-      return mainMatch;
+    const mainMatches = this.collectResourceIdMatchesInRoots(rootNodes, resourceId, partialMatch);
+    if (mainMatches.length > 0) {
+      return mainMatches;
     }
 
     const windowRootGroups = this.parser.extractWindowRootGroups(viewHierarchy, "topmost-first");
     for (const windowRoots of windowRootGroups) {
-      const windowMatch = this.findElementByResourceIdInRoots(windowRoots, resourceId, partialMatch);
-      if (windowMatch) {
-        return windowMatch;
+      const windowMatches = this.collectResourceIdMatchesInRoots(windowRoots, resourceId, partialMatch);
+      if (windowMatches.length > 0) {
+        return windowMatches;
       }
     }
 
-    return null;
+    return [];
+  }
+
+  /**
+   * Find element by resource ID
+   * @param viewHierarchy - The view hierarchy to search
+   * @param resourceId - Resource ID to search for
+   * @param container - Container element selector to restrict the search within its child nodes
+   * @param partialMatch - Whether to allow partial ID matching
+   * @returns The found element or null
+   */
+  findElementByResourceId(
+    viewHierarchy: ViewHierarchyResult,
+    resourceId: string,
+    container: { elementId?: string; text?: string } | null = null,
+    partialMatch: boolean = false
+  ): Element | null {
+    const matches = this.findElementsByResourceId(viewHierarchy, resourceId, container, partialMatch);
+    return matches[0] ?? null;
   }
 
   /**

--- a/src/models/ElementSelectionStrategy.ts
+++ b/src/models/ElementSelectionStrategy.ts
@@ -1,0 +1,1 @@
+export type ElementSelectionStrategy = "first" | "random";

--- a/src/models/TapOnElementOptions.ts
+++ b/src/models/TapOnElementOptions.ts
@@ -1,10 +1,14 @@
 /**
  * Options for tapping on an element
  */
+import type { ElementSelectionStrategy } from "./ElementSelectionStrategy";
+
 export interface TapOnElementOptions {
   // Element selection - one of these must be provided
   text?: string;
   elementId?: string;
+  // Selection strategy when multiple elements match (default: first)
+  selectionStrategy?: ElementSelectionStrategy;
 
   // Container to restrict search
   container?: {

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -16,6 +16,7 @@ export * from "./DeviceSession";
 export * from "./DragAndDropOptions";
 export * from "./DragAndDropResult";
 export * from "./Element";
+export * from "./ElementSelectionStrategy";
 export * from "./ElementBounds";
 export * from "./DeviceInfo";
 export * from "./ExecResult";

--- a/src/server/interactionTools.ts
+++ b/src/server/interactionTools.ts
@@ -15,7 +15,7 @@ import { HomeScreen } from "../features/action/HomeScreen";
 import { Rotate } from "../features/action/Rotate";
 import { OpenURL } from "../features/action/OpenURL";
 import { Clipboard } from "../features/action/Clipboard";
-import { ActionableError, BootedDevice, Element, ViewHierarchyResult } from "../models";
+import { ActionableError, BootedDevice, Element, ElementSelectionStrategy, ViewHierarchyResult } from "../models";
 import { ObserveScreen } from "../features/observe/ObserveScreen";
 import { ListInstalledApps } from "../features/observe/ListInstalledApps";
 import { createJSONToolResponse } from "../utils/toolUtils";
@@ -77,6 +77,7 @@ export interface TapOnArgs {
   };
   text?: string;
   id?: string;
+  selectionStrategy?: ElementSelectionStrategy;
   action: "tap" | "doubleTap" | "longPress" | "focus";
   duration?: number;
   searchUntil?: {
@@ -188,6 +189,9 @@ export const tapOnSchema = addDeviceTargetingToSchema(z.object({
   action: z.enum(["tap", "doubleTap", "longPress", "focus"]).describe("Action type"),
   text: z.string().optional().describe("Text to tap (overrides id)"),
   id: z.string().optional().describe("Element ID to tap"),
+  selectionStrategy: z.enum(["first", "random"]).optional().describe(
+    "Element selection strategy when multiple matches are found (default: first)"
+  ),
   duration: z.number().optional().describe("Long press duration (ms)"),
   searchUntil: z.object({
     duration: z.number().min(100).max(12000).optional().describe("Polling duration (ms, default: 500)"),
@@ -1057,6 +1061,7 @@ export function registerInteractionTools() {
       container: args.container,
       text: args.text,
       elementId: args.id,
+      selectionStrategy: args.selectionStrategy,
       action: args.action,
       duration: args.duration,
       searchUntil: args.searchUntil,

--- a/src/utils/interfaces/ElementSelector.ts
+++ b/src/utils/interfaces/ElementSelector.ts
@@ -1,0 +1,26 @@
+import type { Element } from "../../models/Element";
+import type { ViewHierarchyResult } from "../../models/ViewHierarchyResult";
+import type { ElementSelectionStrategy } from "../../models/ElementSelectionStrategy";
+
+export interface ElementSelector {
+  selectByText(
+    viewHierarchy: ViewHierarchyResult,
+    text: string,
+    options?: {
+      container?: { elementId?: string; text?: string } | null;
+      fuzzyMatch?: boolean;
+      caseSensitive?: boolean;
+      strategy?: ElementSelectionStrategy;
+    }
+  ): Element | null;
+
+  selectByResourceId(
+    viewHierarchy: ViewHierarchyResult,
+    resourceId: string,
+    options?: {
+      container?: { elementId?: string; text?: string } | null;
+      partialMatch?: boolean;
+      strategy?: ElementSelectionStrategy;
+    }
+  ): Element | null;
+}

--- a/src/utils/interfaces/index.ts
+++ b/src/utils/interfaces/index.ts
@@ -66,6 +66,7 @@ export { ElementGeometry } from "../../features/utility/ElementGeometry";
 export { ElementParser } from "../../features/utility/ElementParser";
 export { TextMatcher } from "../../features/utility/TextMatcher";
 export { ElementUtils } from "../../features/utility/ElementUtils";
+export { ElementSelector } from "./ElementSelector";
 export {
   NavigationGraph,
   NavigationEvent,

--- a/test/fakes/FakeElementSelector.ts
+++ b/test/fakes/FakeElementSelector.ts
@@ -1,0 +1,50 @@
+import type { Element } from "../../src/models/Element";
+import type { ViewHierarchyResult } from "../../src/models/ViewHierarchyResult";
+import type { ElementSelectionStrategy } from "../../src/models/ElementSelectionStrategy";
+import type { ElementSelector } from "../../src/utils/interfaces/ElementSelector";
+
+export class FakeElementSelector implements ElementSelector {
+  lastStrategy?: ElementSelectionStrategy;
+  lastText?: string;
+  lastResourceId?: string;
+  nextElement: Element | null;
+
+  constructor(nextElement: Element | null = null) {
+    this.nextElement = nextElement;
+  }
+
+  setNextElement(element: Element | null): void {
+    this.nextElement = element;
+  }
+
+  selectByText(
+    viewHierarchy: ViewHierarchyResult,
+    text: string,
+    options?: {
+      container?: { elementId?: string; text?: string } | null;
+      fuzzyMatch?: boolean;
+      caseSensitive?: boolean;
+      strategy?: ElementSelectionStrategy;
+    }
+  ): Element | null {
+    void viewHierarchy;
+    this.lastStrategy = options?.strategy;
+    this.lastText = text;
+    return this.nextElement;
+  }
+
+  selectByResourceId(
+    viewHierarchy: ViewHierarchyResult,
+    resourceId: string,
+    options?: {
+      container?: { elementId?: string; text?: string } | null;
+      partialMatch?: boolean;
+      strategy?: ElementSelectionStrategy;
+    }
+  ): Element | null {
+    void viewHierarchy;
+    this.lastStrategy = options?.strategy;
+    this.lastResourceId = resourceId;
+    return this.nextElement;
+  }
+}

--- a/test/features/action/TapOnElement.selectionStrategy.test.ts
+++ b/test/features/action/TapOnElement.selectionStrategy.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, test } from "bun:test";
+import { TapOnElement } from "../../../src/features/action/TapOnElement";
+import { FakeAdbClient } from "../../fakes/FakeAdbClient";
+import { FakeElementSelector } from "../../fakes/FakeElementSelector";
+import { FakeTimer } from "../../fakes/FakeTimer";
+
+describe("TapOnElement selectionStrategy", () => {
+  test("passes selectionStrategy to the element selector", () => {
+    const fakeSelector = new FakeElementSelector({
+      bounds: { left: 0, top: 0, right: 10, bottom: 10 }
+    } as any);
+    const tapOnElement = new TapOnElement(
+      {
+        name: "test-device",
+        platform: "android",
+        id: "emulator-5554",
+      } as any,
+      new FakeAdbClient() as any,
+      null,
+      null,
+      undefined,
+      undefined,
+      undefined,
+      new FakeTimer(),
+      fakeSelector
+    );
+
+    const result = (tapOnElement as any).findElementInHierarchy(
+      {
+        text: "Match",
+        action: "tap",
+        selectionStrategy: "random"
+      },
+      { hierarchy: { node: {} } }
+    );
+
+    expect(result.element).not.toBeNull();
+    expect(fakeSelector.lastText).toBe("Match");
+    expect(fakeSelector.lastStrategy).toBe("random");
+  });
+});

--- a/test/features/utility/DefaultElementSelector.test.ts
+++ b/test/features/utility/DefaultElementSelector.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, test } from "bun:test";
+import { DefaultElementSelector } from "../../../src/features/utility/DefaultElementSelector";
+import { ElementFinder } from "../../../src/features/utility/ElementFinder";
+import type { ViewHierarchyResult } from "../../../src/models/ViewHierarchyResult";
+
+type NodeSpec = {
+  bounds: string;
+  text?: string;
+  resourceId?: string;
+};
+
+const createViewHierarchy = (nodes: NodeSpec[]): ViewHierarchyResult => {
+  return {
+    hierarchy: {
+      node: {
+        $: {
+          bounds: "[0,0][100,100]",
+          class: "android.widget.FrameLayout"
+        },
+        node: nodes.map(node => ({
+          $: {
+            bounds: node.bounds,
+            class: "android.widget.TextView",
+            ...(node.text ? { text: node.text } : {}),
+            ...(node.resourceId ? { "resource-id": node.resourceId } : {})
+          }
+        }))
+      }
+    }
+  } as ViewHierarchyResult;
+};
+
+describe("DefaultElementSelector", () => {
+  test("first strategy returns smallest exact match", () => {
+    const selector = new DefaultElementSelector(new ElementFinder(), () => 0);
+    const viewHierarchy = createViewHierarchy([
+      { bounds: "[0,0][30,30]", text: "Match" },
+      { bounds: "[0,0][10,10]", text: "Match" }
+    ]);
+
+    const match = selector.selectByText(viewHierarchy, "Match", { strategy: "first" });
+
+    expect(match?.bounds).toEqual({ left: 0, top: 0, right: 10, bottom: 10 });
+  });
+
+  test("random strategy returns different matches across calls", () => {
+    const randomValues = [0, 0.99];
+    const random = () => randomValues.shift() ?? 0;
+    const selector = new DefaultElementSelector(new ElementFinder(), random);
+    const viewHierarchy = createViewHierarchy([
+      { bounds: "[0,0][10,10]", text: "Match" },
+      { bounds: "[0,0][20,20]", text: "Match" }
+    ]);
+
+    const first = selector.selectByText(viewHierarchy, "Match", { strategy: "random" });
+    const second = selector.selectByText(viewHierarchy, "Match", { strategy: "random" });
+
+    expect(first?.bounds).not.toEqual(second?.bounds);
+  });
+
+  test("random strategy prefers exact matches over fuzzy", () => {
+    const selector = new DefaultElementSelector(new ElementFinder(), () => 0.9);
+    const viewHierarchy = createViewHierarchy([
+      { bounds: "[0,0][10,10]", text: "Match" },
+      { bounds: "[0,0][20,20]", text: "Match 2" }
+    ]);
+
+    const match = selector.selectByText(viewHierarchy, "Match", { strategy: "random" });
+
+    expect(match?.text).toBe("Match");
+  });
+
+  test("returns null when no matches are found", () => {
+    const selector = new DefaultElementSelector(new ElementFinder(), () => 0);
+    const viewHierarchy = createViewHierarchy([
+      { bounds: "[0,0][10,10]", text: "Other" }
+    ]);
+
+    const match = selector.selectByText(viewHierarchy, "Match", { strategy: "first" });
+
+    expect(match).toBeNull();
+  });
+
+  test("random strategy returns single match for resource ID", () => {
+    const selector = new DefaultElementSelector(new ElementFinder(), () => 0.5);
+    const viewHierarchy = createViewHierarchy([
+      { bounds: "[0,0][10,10]", resourceId: "test:id/button" }
+    ]);
+
+    const match = selector.selectByResourceId(viewHierarchy, "test:id/button", { strategy: "random" });
+
+    expect(match?.["resource-id"]).toBe("test:id/button");
+  });
+});


### PR DESCRIPTION
## Summary
- add selectionStrategy support for tapOn with random selection
- introduce an element selector abstraction with a default implementation
- add unit tests for selection strategies and tapOn integration
- auto-generate tool definitions update

## Testing
- bun test test/features/utility/DefaultElementSelector.test.ts test/features/action/TapOnElement.selectionStrategy.test.ts

## Related
- Closes #693
