### PR TITLE
Fix dragAndDrop dropDelay default

### DIFF
--- a/android/test-plan-validation/src/main/resources/schemas/test-plan.schema.json
+++ b/android/test-plan-validation/src/main/resources/schemas/test-plan.schema.json
@@ -181,7 +181,8 @@
               },
               "dropDelay": {
                 "type": "number",
-                "description": "Drop delay ms (default: 100)"
+                "minimum": 100,
+                "description": "Drop delay ms (min: 100, default: 100)"
               },
               "platform": {
                 "type": "string",
@@ -298,7 +299,8 @@
         },
         "dropDelay": {
           "type": "number",
-          "description": "Drop delay ms (default: 100)"
+          "minimum": 100,
+          "description": "Drop delay ms (min: 100, default: 100)"
         },
         "platform": {
           "type": "string",

--- a/schemas/test-plan.schema.json
+++ b/schemas/test-plan.schema.json
@@ -181,7 +181,8 @@
               },
               "dropDelay": {
                 "type": "number",
-                "description": "Drop delay ms (default: 100)"
+                "minimum": 100,
+                "description": "Drop delay ms (min: 100, default: 100)"
               },
               "platform": {
                 "type": "string",
@@ -298,7 +299,8 @@
         },
         "dropDelay": {
           "type": "number",
-          "description": "Drop delay ms (default: 100)"
+          "minimum": 100,
+          "description": "Drop delay ms (min: 100, default: 100)"
         },
         "platform": {
           "type": "string",

--- a/schemas/tool-definitions.json
+++ b/schemas/tool-definitions.json
@@ -504,7 +504,8 @@
         },
         "dropDelay": {
           "type": "number",
-          "description": "Drop delay ms (default: 100)"
+          "minimum": 100,
+          "description": "Drop delay ms (min: 100, default: 100)"
         },
         "platform": {
           "type": "string",

--- a/src/features/action/DragAndDrop.ts
+++ b/src/features/action/DragAndDrop.ts
@@ -78,6 +78,7 @@ export class DragAndDrop extends BaseVisualChange {
           const targetPoint = this.elementUtils.getElementCenter(target);
           const duration = this.getDuration(options);
           const holdTime = this.getHoldTime(options);
+          const dropDelay = this.getDropDelay(options);
 
           const dragResult = await this.executeAndroidDrag(
             sourcePoint.x,
@@ -89,8 +90,8 @@ export class DragAndDrop extends BaseVisualChange {
             signal
           );
 
-          if (options.dropDelay && options.dropDelay > 0) {
-            await new Promise(resolve => setTimeout(resolve, options.dropDelay));
+          if (dropDelay > 0) {
+            await new Promise(resolve => setTimeout(resolve, dropDelay));
           }
 
           const distance = Math.hypot(targetPoint.x - sourcePoint.x, targetPoint.y - sourcePoint.y);
@@ -117,7 +118,7 @@ export class DragAndDrop extends BaseVisualChange {
               target: options.target,
               duration: options.duration,
               holdTime: options.holdTime,
-              dropDelay: options.dropDelay,
+              dropDelay: this.getDropDelay(options),
               platform: this.device.platform
             }
           }
@@ -155,6 +156,9 @@ export class DragAndDrop extends BaseVisualChange {
     const targetSelectorCount = [options.target.text, options.target.elementId].filter(Boolean).length;
     if (targetSelectorCount !== 1) {
       return "dragAndDrop target must specify exactly one of text or elementId";
+    }
+    if (typeof options.dropDelay === "number" && options.dropDelay < 100) {
+      return "dragAndDrop dropDelay must be at least 100ms";
     }
     return null;
   }
@@ -197,6 +201,13 @@ export class DragAndDrop extends BaseVisualChange {
       return options.holdTime;
     }
     return 200;
+  }
+
+  private getDropDelay(options: DragAndDropOptions): number {
+    if (typeof options.dropDelay === "number") {
+      return options.dropDelay;
+    }
+    return 100;
   }
 
   private async executeAndroidDrag(

--- a/src/server/interactionTools.ts
+++ b/src/server/interactionTools.ts
@@ -214,7 +214,7 @@ export const dragAndDropSchema = addDeviceTargetingToSchema(z.object({
   target: dragAndDropSelectorSchema("Target"),
   duration: z.number().optional().describe("Drag duration ms (default: 500)"),
   holdTime: z.number().optional().describe("Hold time ms (default: 200)"),
-  dropDelay: z.number().optional().describe("Drop delay ms (default: 100)"),
+  dropDelay: z.number().min(100).optional().describe("Drop delay ms (min: 100, default: 100)"),
   platform: z.enum(["android", "ios"]).describe("Platform")
 }));
 


### PR DESCRIPTION
## Summary
- default dragAndDrop dropDelay to 100ms and enforce a 100ms minimum in runtime validation
- add schema minimums + updated descriptions for dropDelay in test plan schemas
- regenerate tool definitions

## Testing
- bun run validate:yaml
- bun run lint
- bun run test
- bun run build

Fixes #682
