### PR TITLE
Add tapOn selectedElement metadata

### DIFF
--- a/docs/design-docs/mcp/actions.md
+++ b/docs/design-docs/mcp/actions.md
@@ -13,6 +13,32 @@ In cases where the agent needs to determine what to do next, the [observe](obser
 - 🔍 `pinchOn` for zoom in/out gestures.
 - 📳 `shake` for accelerometer simulation.
 
+#### tapOn Response Metadata
+
+Successful `tapOn` calls include `selectedElement` metadata describing which match was chosen.
+
+```json
+{
+  "success": true,
+  "action": "tap",
+  "selectedElement": {
+    "text": "Sarah's Channel",
+    "resourceId": "com.example:id/channel_item",
+    "bounds": {
+      "left": 50,
+      "top": 200,
+      "right": 350,
+      "bottom": 280,
+      "centerX": 200,
+      "centerY": 240
+    },
+    "indexInMatches": 3,
+    "totalMatches": 10,
+    "selectionStrategy": "random"
+  }
+}
+```
+
 #### App Management
 
 - 📱 `listApps` enumerates installed apps (deprecated; use the `automobile:apps` resource with query filters).

--- a/schemas/tool-definitions.json
+++ b/schemas/tool-definitions.json
@@ -1805,7 +1805,7 @@
   },
   {
     "name": "tapOn",
-    "description": "Tap UI elements by text or ID",
+    "description": "Tap UI elements by text or ID (returns selectedElement metadata)",
     "inputSchema": {
       "type": "object",
       "properties": {

--- a/src/features/action/TapOnElement.ts
+++ b/src/features/action/TapOnElement.ts
@@ -3,8 +3,10 @@ import {
   ActionableError,
   BootedDevice,
   Element,
+  ElementSelectionResult,
   ObserveResult,
   TapOnElementResult,
+  TapOnSelectedElement,
   ViewHierarchyResult
 } from "../../models";
 import { AdbClient } from "../../utils/android-cmdline-tools/AdbClient";
@@ -124,11 +126,11 @@ export class TapOnElement extends BaseVisualChange {
   private findElementInHierarchy(
     options: TapOnElementOptions,
     viewHierarchy: ViewHierarchyResult
-  ): { element: Element | null; containerFound: boolean } {
+  ): { selection: ElementSelectionResult; containerFound: boolean } {
     const containerFound = this.isContainerAvailable(viewHierarchy, options.container);
     if (options.text) {
       return {
-        element: this.elementSelector.selectByText(viewHierarchy, options.text, {
+        selection: this.elementSelector.selectByText(viewHierarchy, options.text, {
           container: options.container,
           fuzzyMatch: true,
           caseSensitive: false,
@@ -139,7 +141,7 @@ export class TapOnElement extends BaseVisualChange {
     }
     if (options.elementId) {
       return {
-        element: this.elementSelector.selectByResourceId(viewHierarchy, options.elementId, {
+        selection: this.elementSelector.selectByResourceId(viewHierarchy, options.elementId, {
           container: options.container,
           partialMatch: false,
           strategy: options.selectionStrategy
@@ -179,7 +181,7 @@ export class TapOnElement extends BaseVisualChange {
     observeResult: ObserveResult,
     signal?: AbortSignal
   ): Promise<{
-    element: Element | null;
+    selection: ElementSelectionResult;
     viewHierarchy: ViewHierarchyResult;
     containerFound: boolean;
     stats: SearchUntilStats;
@@ -197,7 +199,8 @@ export class TapOnElement extends BaseVisualChange {
 
     let latestViewHierarchy = viewHierarchy;
     const initialSearch = this.findElementInHierarchy(options, latestViewHierarchy);
-    let element = initialSearch.element;
+    let selection = initialSearch.selection;
+    let element = selection.element;
     let containerFoundEver = initialSearch.containerFound;
 
     if (!element) {
@@ -223,7 +226,8 @@ export class TapOnElement extends BaseVisualChange {
         }
 
         const searchResult = this.findElementInHierarchy(options, refreshedHierarchy);
-        element = searchResult.element;
+        selection = searchResult.selection;
+        element = selection.element;
         containerFoundEver = containerFoundEver || searchResult.containerFound;
         if (element) {
           break;
@@ -238,10 +242,45 @@ export class TapOnElement extends BaseVisualChange {
     };
 
     return {
-      element,
+      selection,
       viewHierarchy: latestViewHierarchy,
       containerFound: containerFoundEver,
       stats
+    };
+  }
+
+  private buildSelectedElementMetadata(selection: ElementSelectionResult): TapOnSelectedElement | undefined {
+    if (!selection.element) {
+      return undefined;
+    }
+
+    const bounds = selection.element.bounds;
+    const center = this.elementUtils.getElementCenter(selection.element);
+    const text = typeof selection.element.text === "string" && selection.element.text.length > 0
+      ? selection.element.text
+      : (typeof selection.element["content-desc"] === "string"
+        ? selection.element["content-desc"]
+        : (typeof selection.element["ios-accessibility-label"] === "string"
+          ? selection.element["ios-accessibility-label"]
+          : ""));
+    const resourceId = typeof selection.element["resource-id"] === "string"
+      ? selection.element["resource-id"]
+      : "";
+
+    return {
+      text,
+      resourceId,
+      bounds: {
+        left: bounds.left,
+        top: bounds.top,
+        right: bounds.right,
+        bottom: bounds.bottom,
+        centerX: center.x,
+        centerY: center.y
+      },
+      indexInMatches: selection.indexInMatches,
+      totalMatches: selection.totalMatches,
+      selectionStrategy: selection.strategy
     };
   }
 
@@ -564,10 +603,12 @@ export class TapOnElement extends BaseVisualChange {
           searchUntilStats = searchOutcome.stats;
           observeResult.viewHierarchy = searchOutcome.viewHierarchy;
           viewHierarchy = searchOutcome.viewHierarchy;
-          if (!searchOutcome.element) {
+          if (!searchOutcome.selection.element) {
             await this.handleElementNotFound(options, observeResult, searchOutcome.containerFound, signal);
           }
-          const element = searchOutcome.element as Element;
+          const selection = searchOutcome.selection;
+          const element = selection.element as Element;
+          const selectedElementMetadata = this.buildSelectedElementMetadata(selection);
           const initialTapPoint = this.elementUtils.getElementCenter(element);
           let action = options.action;
           const longPressDuration = this.getLongPressDuration(options, this.device.platform);
@@ -582,6 +623,7 @@ export class TapOnElement extends BaseVisualChange {
               return {
                 success: true,
                 element: element,
+                selectedElement: selectedElementMetadata,
                 searchUntil: searchOutcome.stats,
                 wasAlreadyFocused: true,
                 focusChanged: false,
@@ -644,6 +686,7 @@ export class TapOnElement extends BaseVisualChange {
             success: true,
             action,
             element: tapElement,
+            selectedElement: selectedElementMetadata,
             searchUntil: searchOutcome.stats,
           };
         },

--- a/src/features/utility/DefaultElementSelector.ts
+++ b/src/features/utility/DefaultElementSelector.ts
@@ -1,4 +1,5 @@
 import type { Element } from "../../models/Element";
+import type { ElementSelectionResult } from "../../models/ElementSelectionResult";
 import type { ViewHierarchyResult } from "../../models/ViewHierarchyResult";
 import type { ElementSelectionStrategy } from "../../models/ElementSelectionStrategy";
 import type { ElementSelector } from "../../utils/interfaces/ElementSelector";
@@ -25,7 +26,8 @@ export class DefaultElementSelector implements ElementSelector {
       caseSensitive?: boolean;
       strategy?: ElementSelectionStrategy;
     }
-  ): Element | null {
+  ): ElementSelectionResult {
+    const strategy = options?.strategy ?? "first";
     const matches = this.finder.findElementsByText(
       viewHierarchy,
       text,
@@ -33,7 +35,7 @@ export class DefaultElementSelector implements ElementSelector {
       options?.fuzzyMatch ?? true,
       options?.caseSensitive ?? false
     );
-    return this.pickMatch(matches, options?.strategy ?? "first");
+    return this.pickMatch(matches, strategy);
   }
 
   selectByResourceId(
@@ -44,29 +46,31 @@ export class DefaultElementSelector implements ElementSelector {
       partialMatch?: boolean;
       strategy?: ElementSelectionStrategy;
     }
-  ): Element | null {
+  ): ElementSelectionResult {
+    const strategy = options?.strategy ?? "first";
     const matches = this.finder.findElementsByResourceId(
       viewHierarchy,
       resourceId,
       options?.container ?? null,
       options?.partialMatch ?? false
     );
-    return this.pickMatch(matches, options?.strategy ?? "first");
+    return this.pickMatch(matches, strategy);
   }
 
-  private pickMatch(matches: Element[], strategy: ElementSelectionStrategy): Element | null {
-    if (matches.length === 0) {
-      return null;
+  private pickMatch(matches: Element[], strategy: ElementSelectionStrategy): ElementSelectionResult {
+    const totalMatches = matches.length;
+    if (totalMatches === 0) {
+      return { element: null, indexInMatches: -1, totalMatches: 0, strategy };
     }
 
+    let indexInMatches = 0;
     if (strategy === "random") {
-      const rawIndex = Math.floor(this.random() * matches.length);
-      const safeIndex = Number.isFinite(rawIndex)
-        ? Math.min(matches.length - 1, Math.max(0, rawIndex))
+      const rawIndex = Math.floor(this.random() * totalMatches);
+      indexInMatches = Number.isFinite(rawIndex)
+        ? Math.min(totalMatches - 1, Math.max(0, rawIndex))
         : 0;
-      return matches[safeIndex];
     }
 
-    return matches[0];
+    return { element: matches[indexInMatches], indexInMatches, totalMatches, strategy };
   }
 }

--- a/src/models/ElementSelectionResult.ts
+++ b/src/models/ElementSelectionResult.ts
@@ -1,0 +1,12 @@
+import type { Element } from "./Element";
+import type { ElementSelectionStrategy } from "./ElementSelectionStrategy";
+
+/**
+ * Result of selecting an element from a list of matches.
+ */
+export interface ElementSelectionResult {
+  element: Element | null;
+  indexInMatches: number;
+  totalMatches: number;
+  strategy: ElementSelectionStrategy;
+}

--- a/src/models/TapOnElementResult.ts
+++ b/src/models/TapOnElementResult.ts
@@ -1,6 +1,22 @@
 import { Element } from "./Element";
+import { ElementBounds } from "./ElementBounds";
+import { ElementSelectionStrategy } from "./ElementSelectionStrategy";
 import { ObserveResult } from "./ObserveResult";
 import { ToolDebugInfo } from "../utils/DebugContextBuilder";
+
+export interface TapOnSelectedElementBounds extends ElementBounds {
+  centerX: number;
+  centerY: number;
+}
+
+export interface TapOnSelectedElement {
+  text: string;
+  resourceId: string;
+  bounds: TapOnSelectedElementBounds;
+  indexInMatches: number;
+  totalMatches: number;
+  selectionStrategy: ElementSelectionStrategy;
+}
 
 /**
  * Result of a tap on text operation
@@ -9,6 +25,7 @@ export interface TapOnElementResult {
   success: boolean;
   action: string;
   element: Element;
+  selectedElement?: TapOnSelectedElement;
   observation?: ObserveResult;
   error?: string;
   debug?: ToolDebugInfo;

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -17,6 +17,7 @@ export * from "./DragAndDropOptions";
 export * from "./DragAndDropResult";
 export * from "./Element";
 export * from "./ElementSelectionStrategy";
+export * from "./ElementSelectionResult";
 export * from "./ElementBounds";
 export * from "./DeviceInfo";
 export * from "./ExecResult";

--- a/src/server/interactionTools.ts
+++ b/src/server/interactionTools.ts
@@ -1686,7 +1686,7 @@ export function registerInteractionTools() {
 
   ToolRegistry.registerDeviceAware(
     "tapOn",
-    "Tap UI elements by text or ID",
+    "Tap UI elements by text or ID (returns selectedElement metadata)",
     tapOnSchema,
     tapOnHandler,
     true // Supports progress notifications

--- a/src/utils/interfaces/ElementSelector.ts
+++ b/src/utils/interfaces/ElementSelector.ts
@@ -1,4 +1,4 @@
-import type { Element } from "../../models/Element";
+import type { ElementSelectionResult } from "../../models/ElementSelectionResult";
 import type { ViewHierarchyResult } from "../../models/ViewHierarchyResult";
 import type { ElementSelectionStrategy } from "../../models/ElementSelectionStrategy";
 
@@ -12,7 +12,7 @@ export interface ElementSelector {
       caseSensitive?: boolean;
       strategy?: ElementSelectionStrategy;
     }
-  ): Element | null;
+  ): ElementSelectionResult;
 
   selectByResourceId(
     viewHierarchy: ViewHierarchyResult,
@@ -22,5 +22,5 @@ export interface ElementSelector {
       partialMatch?: boolean;
       strategy?: ElementSelectionStrategy;
     }
-  ): Element | null;
+  ): ElementSelectionResult;
 }

--- a/test/fakes/FakeElementSelector.ts
+++ b/test/fakes/FakeElementSelector.ts
@@ -1,4 +1,5 @@
 import type { Element } from "../../src/models/Element";
+import type { ElementSelectionResult } from "../../src/models/ElementSelectionResult";
 import type { ViewHierarchyResult } from "../../src/models/ViewHierarchyResult";
 import type { ElementSelectionStrategy } from "../../src/models/ElementSelectionStrategy";
 import type { ElementSelector } from "../../src/utils/interfaces/ElementSelector";
@@ -8,6 +9,8 @@ export class FakeElementSelector implements ElementSelector {
   lastText?: string;
   lastResourceId?: string;
   nextElement: Element | null;
+  nextIndexInMatches?: number;
+  nextTotalMatches?: number;
 
   constructor(nextElement: Element | null = null) {
     this.nextElement = nextElement;
@@ -15,6 +18,28 @@ export class FakeElementSelector implements ElementSelector {
 
   setNextElement(element: Element | null): void {
     this.nextElement = element;
+  }
+
+  setNextSelection(selection: { element: Element | null; indexInMatches?: number; totalMatches?: number }): void {
+    this.nextElement = selection.element;
+    this.nextIndexInMatches = selection.indexInMatches;
+    this.nextTotalMatches = selection.totalMatches;
+  }
+
+  private buildSelectionResult(strategy: ElementSelectionStrategy | undefined): ElementSelectionResult {
+    const element = this.nextElement;
+    const totalMatches = typeof this.nextTotalMatches === "number"
+      ? this.nextTotalMatches
+      : (element ? 1 : 0);
+    const indexInMatches = typeof this.nextIndexInMatches === "number"
+      ? this.nextIndexInMatches
+      : (element ? 0 : -1);
+    return {
+      element,
+      indexInMatches,
+      totalMatches,
+      strategy: strategy ?? "first"
+    };
   }
 
   selectByText(
@@ -26,11 +51,11 @@ export class FakeElementSelector implements ElementSelector {
       caseSensitive?: boolean;
       strategy?: ElementSelectionStrategy;
     }
-  ): Element | null {
+  ): ElementSelectionResult {
     void viewHierarchy;
     this.lastStrategy = options?.strategy;
     this.lastText = text;
-    return this.nextElement;
+    return this.buildSelectionResult(options?.strategy);
   }
 
   selectByResourceId(
@@ -41,10 +66,10 @@ export class FakeElementSelector implements ElementSelector {
       partialMatch?: boolean;
       strategy?: ElementSelectionStrategy;
     }
-  ): Element | null {
+  ): ElementSelectionResult {
     void viewHierarchy;
     this.lastStrategy = options?.strategy;
     this.lastResourceId = resourceId;
-    return this.nextElement;
+    return this.buildSelectionResult(options?.strategy);
   }
 }

--- a/test/fakes/ResultFaker.ts
+++ b/test/fakes/ResultFaker.ts
@@ -9,6 +9,7 @@ import {
   ActiveWindowInfo,
   TapResult,
   TapOnElementResult,
+  TapOnSelectedElement,
   ExitDialogResult,
   LaunchAppResult,
   TerminateAppResult,
@@ -67,6 +68,43 @@ export class ResultFaker {
       "scrollable": overrides.scrollable ?? faker.datatype.boolean(0.3),
       "selected": overrides.selected ?? faker.datatype.boolean(0.3),
       ...overrides
+    };
+  }
+
+  /**
+   * Generate fake TapOnSelectedElement metadata
+   */
+  static tapOnSelectedElement(
+    element: Element,
+    overrides: Partial<TapOnSelectedElement> = {}
+  ): TapOnSelectedElement {
+    const bounds = element.bounds;
+    const centerX = Math.floor((bounds.left + bounds.right) / 2);
+    const centerY = Math.floor((bounds.top + bounds.bottom) / 2);
+    const text = typeof element.text === "string" && element.text.length > 0
+      ? element.text
+      : (typeof element["content-desc"] === "string"
+        ? element["content-desc"]
+        : (typeof element["ios-accessibility-label"] === "string"
+          ? element["ios-accessibility-label"]
+          : ""));
+
+    return {
+      text: overrides.text ?? text,
+      resourceId: overrides.resourceId ?? (typeof element["resource-id"] === "string"
+        ? element["resource-id"]
+        : ""),
+      bounds: overrides.bounds ?? {
+        left: bounds.left,
+        top: bounds.top,
+        right: bounds.right,
+        bottom: bounds.bottom,
+        centerX,
+        centerY
+      },
+      indexInMatches: overrides.indexInMatches ?? 0,
+      totalMatches: overrides.totalMatches ?? 1,
+      selectionStrategy: overrides.selectionStrategy ?? "first"
     };
   }
 
@@ -169,16 +207,14 @@ export class ResultFaker {
    * Generate fake TapOnTextResult
    */
   static tapOnTextResult(overrides: Partial<TapOnElementResult> = {}): TapOnElementResult {
-    const text = overrides.text ?? faker.lorem.words({ min: 1, max: 5 });
-    const x = overrides.x ?? faker.number.int({ min: 0, max: 1080 });
-    const y = overrides.y ?? faker.number.int({ min: 0, max: 1920 });
+    const element = overrides.element ?? this.element();
+    const selectedElement = overrides.selectedElement ?? this.tapOnSelectedElement(element);
 
     return {
       success: overrides.success ?? true,
-      text,
-      element: overrides.element ?? this.element({ text }),
-      x,
-      y,
+      action: overrides.action ?? "tap",
+      element,
+      selectedElement,
       observation: overrides.observation ?? this.observeResult(),
       error: overrides.error
     };

--- a/test/features/action/TapOnElement.selectedElement.test.ts
+++ b/test/features/action/TapOnElement.selectedElement.test.ts
@@ -1,0 +1,143 @@
+import { describe, expect, test } from "bun:test";
+import type {
+  Element,
+  ElementSelectionResult,
+  TapOnElementResult
+} from "../../../src/models";
+import { TapOnElement } from "../../../src/features/action/TapOnElement";
+import { FakeAdbClient } from "../../fakes/FakeAdbClient";
+import { FakeTimer } from "../../fakes/FakeTimer";
+import { ResultFaker } from "../../fakes/ResultFaker";
+
+const createTapOnElement = (): TapOnElement => {
+  return new TapOnElement(
+    {
+      name: "test-device",
+      platform: "android",
+      id: "emulator-5554",
+    } as any,
+    new FakeAdbClient() as any,
+    null,
+    null,
+    undefined,
+    undefined,
+    undefined,
+    new FakeTimer()
+  );
+};
+
+describe("TapOnElement selectedElement metadata", () => {
+  test("populates selection metadata and computes bounds centers", () => {
+    const tapOnElement = createTapOnElement();
+    const element: Element = {
+      "text": "Sarah's Channel",
+      "resource-id": "com.example:id/channel_item",
+      "class": "android.widget.TextView",
+      "bounds": { left: 50, top: 200, right: 350, bottom: 280 }
+    };
+    const selection: ElementSelectionResult = {
+      element,
+      indexInMatches: 3,
+      totalMatches: 10,
+      strategy: "random"
+    };
+
+    const selectedElement = (tapOnElement as any).buildSelectedElementMetadata(selection);
+
+    expect(selectedElement).toEqual({
+      text: "Sarah's Channel",
+      resourceId: "com.example:id/channel_item",
+      bounds: {
+        left: 50,
+        top: 200,
+        right: 350,
+        bottom: 280,
+        centerX: 200,
+        centerY: 240
+      },
+      indexInMatches: 3,
+      totalMatches: 10,
+      selectionStrategy: "random"
+    });
+  });
+
+  test("handles text, button, and list item element types", () => {
+    const tapOnElement = createTapOnElement();
+    const cases: Array<{ label: string; element: Element }> = [
+      {
+        label: "text",
+        element: {
+          "text": "Channel",
+          "resource-id": "com.example:id/channel_text",
+          "class": "android.widget.TextView",
+          "bounds": { left: 0, top: 0, right: 100, bottom: 40 }
+        }
+      },
+      {
+        label: "button",
+        element: {
+          "text": "Submit",
+          "resource-id": "com.example:id/submit_button",
+          "class": "android.widget.Button",
+          "bounds": { left: 10, top: 50, right: 210, bottom: 130 }
+        }
+      },
+      {
+        label: "list item",
+        element: {
+          "text": "Item 7",
+          "resource-id": "com.example:id/list_item",
+          "class": "android.widget.LinearLayout",
+          "bounds": { left: 12, top: 140, right: 312, bottom: 220 }
+        }
+      }
+    ];
+
+    for (const entry of cases) {
+      const selection: ElementSelectionResult = {
+        element: entry.element,
+        indexInMatches: 0,
+        totalMatches: 1,
+        strategy: "first"
+      };
+
+      const selectedElement = (tapOnElement as any).buildSelectedElementMetadata(selection);
+
+      expect(selectedElement.text).toBe(entry.element.text);
+      expect(selectedElement.resourceId).toBe(entry.element["resource-id"]);
+      expect(selectedElement.selectionStrategy).toBe("first");
+      expect(selectedElement.totalMatches).toBe(1);
+      expect(selectedElement.indexInMatches).toBe(0);
+      expect(selectedElement.bounds.centerX).toBe(
+        Math.floor((entry.element.bounds.left + entry.element.bounds.right) / 2)
+      );
+      expect(selectedElement.bounds.centerY).toBe(
+        Math.floor((entry.element.bounds.top + entry.element.bounds.bottom) / 2)
+      );
+    }
+  });
+
+  test("tapOn response matches TapOnElementResult interface", () => {
+    const element = ResultFaker.element({
+      "text": "Profile",
+      "resource-id": "com.example:id/profile_tab",
+      "bounds": { left: 0, top: 0, right: 80, bottom: 40 }
+    });
+    const selectedElement = ResultFaker.tapOnSelectedElement(element, {
+      indexInMatches: 1,
+      totalMatches: 4,
+      selectionStrategy: "random"
+    });
+
+    const response: TapOnElementResult = {
+      success: true,
+      action: "tap",
+      element,
+      selectedElement
+    };
+
+    expect(response.selectedElement?.selectionStrategy).toBe("random");
+    expect(response.selectedElement?.bounds.centerX).toBe(40);
+    expect(response.selectedElement?.bounds.centerY).toBe(20);
+  });
+});

--- a/test/features/action/TapOnElement.selectionStrategy.test.ts
+++ b/test/features/action/TapOnElement.selectionStrategy.test.ts
@@ -34,7 +34,7 @@ describe("TapOnElement selectionStrategy", () => {
       { hierarchy: { node: {} } }
     );
 
-    expect(result.element).not.toBeNull();
+    expect(result.selection.element).not.toBeNull();
     expect(fakeSelector.lastText).toBe("Match");
     expect(fakeSelector.lastStrategy).toBe("random");
   });

--- a/test/features/utility/DefaultElementSelector.test.ts
+++ b/test/features/utility/DefaultElementSelector.test.ts
@@ -40,7 +40,10 @@ describe("DefaultElementSelector", () => {
 
     const match = selector.selectByText(viewHierarchy, "Match", { strategy: "first" });
 
-    expect(match?.bounds).toEqual({ left: 0, top: 0, right: 10, bottom: 10 });
+    expect(match.element?.bounds).toEqual({ left: 0, top: 0, right: 10, bottom: 10 });
+    expect(match.indexInMatches).toBe(0);
+    expect(match.totalMatches).toBe(2);
+    expect(match.strategy).toBe("first");
   });
 
   test("random strategy returns different matches across calls", () => {
@@ -55,7 +58,11 @@ describe("DefaultElementSelector", () => {
     const first = selector.selectByText(viewHierarchy, "Match", { strategy: "random" });
     const second = selector.selectByText(viewHierarchy, "Match", { strategy: "random" });
 
-    expect(first?.bounds).not.toEqual(second?.bounds);
+    expect(first.element?.bounds).not.toEqual(second.element?.bounds);
+    expect(first.indexInMatches).toBe(0);
+    expect(second.indexInMatches).toBe(1);
+    expect(first.totalMatches).toBe(2);
+    expect(second.totalMatches).toBe(2);
   });
 
   test("random strategy prefers exact matches over fuzzy", () => {
@@ -67,7 +74,8 @@ describe("DefaultElementSelector", () => {
 
     const match = selector.selectByText(viewHierarchy, "Match", { strategy: "random" });
 
-    expect(match?.text).toBe("Match");
+    expect(match.element?.text).toBe("Match");
+    expect(match.totalMatches).toBe(1);
   });
 
   test("returns null when no matches are found", () => {
@@ -78,7 +86,9 @@ describe("DefaultElementSelector", () => {
 
     const match = selector.selectByText(viewHierarchy, "Match", { strategy: "first" });
 
-    expect(match).toBeNull();
+    expect(match.element).toBeNull();
+    expect(match.indexInMatches).toBe(-1);
+    expect(match.totalMatches).toBe(0);
   });
 
   test("random strategy returns single match for resource ID", () => {
@@ -89,6 +99,7 @@ describe("DefaultElementSelector", () => {
 
     const match = selector.selectByResourceId(viewHierarchy, "test:id/button", { strategy: "random" });
 
-    expect(match?.["resource-id"]).toBe("test:id/button");
+    expect(match.element?.["resource-id"]).toBe("test:id/button");
+    expect(match.totalMatches).toBe(1);
   });
 });


### PR DESCRIPTION
## Summary
- add selectedElement metadata to tapOn responses with bounds centers and selection details
- return selection metadata from element selector and update fakes/tests
- refresh tool definitions and document tapOn metadata

## Testing
- bun run test
- bun run build
- bun run lint
- bun run benchmark-context
- bun run benchmark-tools
- bash scripts/benchmark-startup.sh --output scratch/benchmark-startup.json
- bun run validate:yaml

## Issue
- Closes #694
