### PR TITLE
Add variable-width path highlights

### DIFF
--- a/android/accessibility-service/src/main/kotlin/dev/jasonpearson/automobile/accessibilityservice/OverlayDrawer.kt
+++ b/android/accessibility-service/src/main/kotlin/dev/jasonpearson/automobile/accessibilityservice/OverlayDrawer.kt
@@ -4,13 +4,24 @@ import android.graphics.Canvas
 import android.graphics.Color
 import android.graphics.DashPathEffect
 import android.graphics.Paint
+import android.graphics.Path
+import android.graphics.PathMeasure
+import android.graphics.PointF
 import android.graphics.RectF
 import android.util.Log
 import android.view.View
 import dev.jasonpearson.automobile.accessibilityservice.models.HighlightBounds
 import dev.jasonpearson.automobile.accessibilityservice.models.HighlightEntry
+import dev.jasonpearson.automobile.accessibilityservice.models.HighlightLineCap
+import dev.jasonpearson.automobile.accessibilityservice.models.HighlightLineJoin
+import dev.jasonpearson.automobile.accessibilityservice.models.HighlightPoint
 import dev.jasonpearson.automobile.accessibilityservice.models.HighlightShape
+import dev.jasonpearson.automobile.accessibilityservice.models.HighlightStyle
 import dev.jasonpearson.automobile.accessibilityservice.models.ScreenDimensions
+import dev.jasonpearson.automobile.accessibilityservice.models.SmoothingAlgorithm
+import kotlin.math.max
+import kotlin.math.min
+import kotlin.math.sqrt
 
 data class HighlightOperationResult(
     val success: Boolean,
@@ -28,11 +39,19 @@ class OverlayDrawer(
         private const val TAG = "OverlayDrawer"
         private const val DEFAULT_STROKE_COLOR = "#FF0000"
         private const val DEFAULT_STROKE_WIDTH = 4f
+        private const val DEFAULT_PATH_STROKE_WIDTH = 8f
+        private const val DEFAULT_PATH_TENSION = 0.5f
+        private const val PATH_MIN_SAMPLE_DISTANCE = 3f
+        private const val PATH_MAX_SEGMENTS = 240f
+        private const val PATH_TAPER_FRACTION = 0.12f
+        private const val PATH_MIN_WIDTH_FACTOR = 0.35f
+        private const val PATH_CURVE_TAPER_INTENSITY = 0.35f
     }
 
     private val lock = Any()
     private val highlights = LinkedHashMap<String, HighlightRenderState>()
     private var overlayView: View? = null
+    private val pathSmoother = PathSmoother()
 
     fun attachOverlayManager(manager: OverlayManager) {
         overlayManager = manager
@@ -118,18 +137,35 @@ class OverlayDrawer(
             when (renderState.shapeType) {
                 ShapeType.BOX -> drawBox(canvas, renderState)
                 ShapeType.CIRCLE -> drawCircle(canvas, renderState)
+                ShapeType.PATH -> drawPath(canvas, renderState)
             }
         }
     }
 
     private fun drawBox(canvas: Canvas, renderState: HighlightRenderState) {
-        renderState.fillPaint?.let { canvas.drawRect(renderState.rect, it) }
-        renderState.strokePaint?.let { canvas.drawRect(renderState.rect, it) }
+        val rect = renderState.rect ?: return
+        renderState.strokePaint?.let { canvas.drawRect(rect, it) }
     }
 
     private fun drawCircle(canvas: Canvas, renderState: HighlightRenderState) {
-        renderState.fillPaint?.let { canvas.drawOval(renderState.rect, it) }
-        renderState.strokePaint?.let { canvas.drawOval(renderState.rect, it) }
+        val rect = renderState.rect ?: return
+        renderState.strokePaint?.let { canvas.drawOval(rect, it) }
+    }
+
+    private fun drawPath(canvas: Canvas, renderState: HighlightRenderState) {
+        val strokePaint = renderState.strokePaint ?: return
+        val segments = renderState.pathSegments
+        if (segments.isNullOrEmpty()) {
+            renderState.path?.let { canvas.drawPath(it, strokePaint) }
+            return
+        }
+
+        val originalWidth = strokePaint.strokeWidth
+        segments.forEach { segment ->
+            strokePaint.strokeWidth = segment.strokeWidth
+            canvas.drawLine(segment.startX, segment.startY, segment.endX, segment.endY, strokePaint)
+        }
+        strokePaint.strokeWidth = originalWidth
     }
 
     private fun ensureOverlayVisible(): String? {
@@ -149,98 +185,279 @@ class OverlayDrawer(
             when (shape.type) {
                 "box" -> ShapeType.BOX
                 "circle" -> ShapeType.CIRCLE
+                "path" -> ShapeType.PATH
                 else ->
                     return HighlightRenderResult(
                         error = "Unsupported highlight shape: ${shape.type}"
                     )
             }
 
-        if (!shape.bounds.hasValidSize()) {
+        val paintResult = resolvePaints(shape.style, shapeType)
+        if (paintResult.error != null) {
+            return HighlightRenderResult(error = paintResult.error)
+        }
+
+        return when (shapeType) {
+            ShapeType.BOX,
+            ShapeType.CIRCLE -> buildRectRenderState(shape, shapeType, paintResult)
+            ShapeType.PATH -> buildPathRenderState(shape, paintResult)
+        }
+    }
+
+    private fun buildRectRenderState(
+        shape: HighlightShape,
+        shapeType: ShapeType,
+        paintResult: HighlightPaintResult,
+    ): HighlightRenderResult {
+        val bounds = shape.bounds ?: return HighlightRenderResult(error = "Missing highlight bounds")
+        if (!bounds.hasValidSize()) {
             return HighlightRenderResult(
                 error = "Highlight bounds must have positive width and height"
             )
         }
 
-        val rectResult = resolveRect(shape.bounds)
+        val rectResult = resolveRect(bounds)
         val rect = rectResult.rect
         if (rect == null) {
             return HighlightRenderResult(error = rectResult.error ?: "Invalid highlight bounds")
         }
-        // Treat empty style (all fields null) as equivalent to null style
-        val effectiveStyle =
-            shape.style?.takeIf {
-                it.strokeColor != null ||
-                    it.strokeWidth != null ||
-                    it.fillColor != null ||
-                    it.dashPattern != null
-            }
-        val hasStroke =
-            effectiveStyle == null ||
-                effectiveStyle.strokeColor != null ||
-                effectiveStyle.strokeWidth != null
-        val fillColor = effectiveStyle?.fillColor
-        val dashPattern = effectiveStyle?.dashPattern
-
-        if (!hasStroke && fillColor == null) {
-            return HighlightRenderResult(error = "Highlight style must include stroke or fill")
-        }
-
-        val strokePaint =
-            if (hasStroke) {
-                val strokeWidth = effectiveStyle?.strokeWidth ?: DEFAULT_STROKE_WIDTH
-                if (strokeWidth <= 0f) {
-                    return HighlightRenderResult(error = "strokeWidth must be greater than 0")
-                }
-
-                val strokeColor = effectiveStyle?.strokeColor ?: DEFAULT_STROKE_COLOR
-                val parsedStrokeColor =
-                    parseColor(strokeColor)
-                        ?: return HighlightRenderResult(error = "Invalid strokeColor: $strokeColor")
-
-                val paint =
-                    Paint(Paint.ANTI_ALIAS_FLAG).apply {
-                        color = parsedStrokeColor
-                        this.style = Paint.Style.STROKE
-                        this.strokeWidth = strokeWidth
-                    }
-
-                if (dashPattern != null) {
-                    if (dashPattern.isEmpty() || dashPattern.any { it <= 0f }) {
-                        return HighlightRenderResult(
-                            error = "dashPattern must contain positive values"
-                        )
-                    }
-                    paint.pathEffect = DashPathEffect(dashPattern.toFloatArray(), 0f)
-                }
-
-                paint
-            } else {
-                null
-            }
-
-        val fillPaint =
-            if (fillColor != null) {
-                val parsedFillColor =
-                    parseColor(fillColor)
-                        ?: return HighlightRenderResult(error = "Invalid fillColor: $fillColor")
-                Paint(Paint.ANTI_ALIAS_FLAG).apply {
-                    color = parsedFillColor
-                    this.style = Paint.Style.FILL
-                }
-            } else {
-                null
-            }
 
         return HighlightRenderResult(
             state =
                 HighlightRenderState(
                     shape = shape,
                     rect = rect,
+                    path = null,
+                    pathSegments = null,
                     shapeType = shapeType,
-                    strokePaint = strokePaint,
-                    fillPaint = fillPaint,
+                    strokePaint = paintResult.strokePaint,
                 )
         )
+    }
+
+    private fun buildPathRenderState(
+        shape: HighlightShape,
+        paintResult: HighlightPaintResult,
+    ): HighlightRenderResult {
+        val points = shape.points ?: return HighlightRenderResult(error = "Path highlight requires points")
+        if (points.size < 2) {
+            return HighlightRenderResult(error = "Path highlight requires at least 2 points")
+        }
+
+        val scaleResult = shape.bounds?.let { resolveScale(it) } ?: HighlightScaleResult()
+        if (scaleResult.error != null) {
+            return HighlightRenderResult(error = scaleResult.error)
+        }
+        val scaleX = scaleResult.scaleX ?: 1f
+        val scaleY = scaleResult.scaleY ?: 1f
+        val pathPoints = points.toPointFList(scaleX, scaleY)
+        if (pathPoints.any { !it.x.isFinite() || !it.y.isFinite() }) {
+            return HighlightRenderResult(error = "Path points must be finite numbers")
+        }
+
+        val tension = shape.style?.tension ?: DEFAULT_PATH_TENSION
+        if (tension < 0f || tension > 1f) {
+            return HighlightRenderResult(error = "tension must be between 0.0 and 1.0")
+        }
+
+        val algorithm = shape.style?.smoothing ?: SmoothingAlgorithm.CATMULL_ROM
+        val path = pathSmoother.smoothPath(pathPoints, algorithm, tension)
+        val baseStrokeWidth = paintResult.strokePaint?.strokeWidth ?: DEFAULT_PATH_STROKE_WIDTH
+        val pathSegments = buildPathSegments(path, baseStrokeWidth)
+
+        return HighlightRenderResult(
+            state =
+                HighlightRenderState(
+                    shape = shape,
+                    rect = null,
+                    path = path,
+                    pathSegments = pathSegments,
+                    shapeType = ShapeType.PATH,
+                    strokePaint = paintResult.strokePaint,
+                )
+        )
+    }
+
+    private fun resolvePaints(
+        style: HighlightStyle?,
+        shapeType: ShapeType,
+    ): HighlightPaintResult {
+        val effectiveStyle = style?.takeUnless { isStyleEmpty(it) }
+        val strokeWidth = effectiveStyle?.strokeWidth ?: defaultStrokeWidth(shapeType)
+        if (strokeWidth <= 0f) {
+            return HighlightPaintResult(error = "strokeWidth must be greater than 0")
+        }
+
+        val strokeColor = effectiveStyle?.strokeColor ?: DEFAULT_STROKE_COLOR
+        val parsedStrokeColor =
+            parseColor(strokeColor)
+                ?: return HighlightPaintResult(error = "Invalid strokeColor: $strokeColor")
+
+        val paint =
+            Paint(Paint.ANTI_ALIAS_FLAG).apply {
+                color = parsedStrokeColor
+                this.style = Paint.Style.STROKE
+                this.strokeWidth = strokeWidth
+                strokeCap = resolveStrokeCap(effectiveStyle, shapeType)
+                strokeJoin = resolveStrokeJoin(effectiveStyle, shapeType)
+            }
+
+        val dashPattern = effectiveStyle?.dashPattern
+        if (dashPattern != null) {
+            if (dashPattern.isEmpty() || dashPattern.any { it <= 0f }) {
+                return HighlightPaintResult(
+                    error = "dashPattern must contain positive values"
+                )
+            }
+            paint.pathEffect = DashPathEffect(dashPattern.toFloatArray(), 0f)
+        }
+
+        return HighlightPaintResult(strokePaint = paint)
+    }
+
+    private fun isStyleEmpty(style: HighlightStyle): Boolean {
+        return style.strokeColor == null &&
+            style.strokeWidth == null &&
+            style.dashPattern == null &&
+            style.smoothing == null &&
+            style.tension == null &&
+            style.capStyle == null &&
+            style.joinStyle == null
+    }
+
+    private fun defaultStrokeWidth(shapeType: ShapeType): Float {
+        return if (shapeType == ShapeType.PATH) {
+            DEFAULT_PATH_STROKE_WIDTH
+        } else {
+            DEFAULT_STROKE_WIDTH
+        }
+    }
+
+    private fun resolveStrokeCap(style: HighlightStyle?, shapeType: ShapeType): Paint.Cap {
+        val fallback = if (shapeType == ShapeType.PATH) Paint.Cap.ROUND else Paint.Cap.BUTT
+        return when (style?.capStyle) {
+            HighlightLineCap.BUTT -> Paint.Cap.BUTT
+            HighlightLineCap.ROUND -> Paint.Cap.ROUND
+            HighlightLineCap.SQUARE -> Paint.Cap.SQUARE
+            null -> fallback
+        }
+    }
+
+    private fun resolveStrokeJoin(style: HighlightStyle?, shapeType: ShapeType): Paint.Join {
+        val fallback = if (shapeType == ShapeType.PATH) Paint.Join.ROUND else Paint.Join.MITER
+        return when (style?.joinStyle) {
+            HighlightLineJoin.BEVEL -> Paint.Join.BEVEL
+            HighlightLineJoin.MITER -> Paint.Join.MITER
+            HighlightLineJoin.ROUND -> Paint.Join.ROUND
+            null -> fallback
+        }
+    }
+
+    private fun buildPathSegments(path: Path, baseStrokeWidth: Float): List<PathSegment> {
+        val measure = PathMeasure(path, false)
+        val length = measure.length
+        if (length <= 0f) {
+            return emptyList()
+        }
+
+        val step = max(PATH_MIN_SAMPLE_DISTANCE, length / PATH_MAX_SEGMENTS)
+        val segments = ArrayList<PathSegment>()
+
+        val prevPos = FloatArray(2)
+        val prevTan = FloatArray(2)
+        measure.getPosTan(0f, prevPos, prevTan)
+        var lastX = prevPos[0]
+        var lastY = prevPos[1]
+        var lastTanX = prevTan[0]
+        var lastTanY = prevTan[1]
+        var lastDistance = 0f
+        var distance = step
+
+        while (distance < length) {
+            val pos = FloatArray(2)
+            val tan = FloatArray(2)
+            measure.getPosTan(distance, pos, tan)
+            val midProgress = ((lastDistance + distance) / 2f / length).coerceIn(0f, 1f)
+            val widthFactor = resolveWidthFactor(midProgress, lastTanX, lastTanY, tan[0], tan[1])
+            segments.add(
+                PathSegment(
+                    startX = lastX,
+                    startY = lastY,
+                    endX = pos[0],
+                    endY = pos[1],
+                    strokeWidth = baseStrokeWidth * widthFactor,
+                )
+            )
+
+            lastX = pos[0]
+            lastY = pos[1]
+            lastTanX = tan[0]
+            lastTanY = tan[1]
+            lastDistance = distance
+            distance += step
+        }
+
+        val endPos = FloatArray(2)
+        val endTan = FloatArray(2)
+        measure.getPosTan(length, endPos, endTan)
+        val endProgress = ((lastDistance + length) / 2f / length).coerceIn(0f, 1f)
+        val endWidthFactor = resolveWidthFactor(endProgress, lastTanX, lastTanY, endTan[0], endTan[1])
+        segments.add(
+            PathSegment(
+                startX = lastX,
+                startY = lastY,
+                endX = endPos[0],
+                endY = endPos[1],
+                strokeWidth = baseStrokeWidth * endWidthFactor,
+            )
+        )
+
+        return segments
+    }
+
+    private fun resolveWidthFactor(
+        progress: Float,
+        previousTanX: Float,
+        previousTanY: Float,
+        tanX: Float,
+        tanY: Float,
+    ): Float {
+        val taperFactor = resolveTaperFactor(progress)
+        val curveFactor = resolveCurveFactor(previousTanX, previousTanY, tanX, tanY)
+        return max(PATH_MIN_WIDTH_FACTOR, taperFactor * curveFactor)
+    }
+
+    private fun resolveTaperFactor(progress: Float): Float {
+        if (PATH_TAPER_FRACTION <= 0f) {
+            return 1f
+        }
+        val start = min(1f, progress / PATH_TAPER_FRACTION)
+        val end = min(1f, (1f - progress) / PATH_TAPER_FRACTION)
+        val taper = min(start, end)
+        return taper * taper * (3f - 2f * taper)
+    }
+
+    private fun resolveCurveFactor(
+        previousTanX: Float,
+        previousTanY: Float,
+        tanX: Float,
+        tanY: Float,
+    ): Float {
+        val previousMagnitude = sqrt(previousTanX * previousTanX + previousTanY * previousTanY)
+        val currentMagnitude = sqrt(tanX * tanX + tanY * tanY)
+        if (previousMagnitude == 0f || currentMagnitude == 0f) {
+            return 1f
+        }
+
+        val normalizedPrevX = previousTanX / previousMagnitude
+        val normalizedPrevY = previousTanY / previousMagnitude
+        val normalizedX = tanX / currentMagnitude
+        val normalizedY = tanY / currentMagnitude
+        val dot = (normalizedPrevX * normalizedX + normalizedPrevY * normalizedY)
+            .coerceIn(-1f, 1f)
+        val curvature = (1f - dot) / 2f
+        val adjustment = min(1f, curvature) * PATH_CURVE_TAPER_INTENSITY
+        return 1f - adjustment
     }
 
     private fun parseColor(color: String): Int? {
@@ -262,10 +479,24 @@ class OverlayDrawer(
 
     private data class HighlightRenderState(
         val shape: HighlightShape,
-        val rect: RectF,
+        val rect: RectF?,
+        val path: Path?,
+        val pathSegments: List<PathSegment>?,
         val shapeType: ShapeType,
         val strokePaint: Paint?,
-        val fillPaint: Paint?,
+    )
+
+    private data class HighlightPaintResult(
+        val strokePaint: Paint? = null,
+        val error: String? = null,
+    )
+
+    private data class PathSegment(
+        val startX: Float,
+        val startY: Float,
+        val endX: Float,
+        val endY: Float,
+        val strokeWidth: Float,
     )
 
     private fun resolveRect(bounds: HighlightBounds): HighlightRectResult {
@@ -276,6 +507,10 @@ class OverlayDrawer(
         val scaleX = scale.scaleX ?: 1f
         val scaleY = scale.scaleY ?: 1f
         return HighlightRectResult(rect = bounds.toRectF(scaleX, scaleY))
+    }
+
+    private fun List<HighlightPoint>.toPointFList(scaleX: Float, scaleY: Float): List<PointF> {
+        return map { point -> PointF(point.x * scaleX, point.y * scaleY) }
     }
 
     private fun resolveScale(bounds: HighlightBounds): HighlightScaleResult {
@@ -333,5 +568,6 @@ class OverlayDrawer(
     private enum class ShapeType {
         BOX,
         CIRCLE,
+        PATH,
     }
 }

--- a/android/accessibility-service/src/main/kotlin/dev/jasonpearson/automobile/accessibilityservice/PathSmoother.kt
+++ b/android/accessibility-service/src/main/kotlin/dev/jasonpearson/automobile/accessibilityservice/PathSmoother.kt
@@ -1,0 +1,175 @@
+package dev.jasonpearson.automobile.accessibilityservice
+
+import android.graphics.Path
+import android.graphics.PointF
+import dev.jasonpearson.automobile.accessibilityservice.models.SmoothingAlgorithm
+import kotlin.math.abs
+import kotlin.math.hypot
+
+class PathSmoother {
+
+  fun smoothPath(
+      points: List<PointF>,
+      algorithm: SmoothingAlgorithm,
+      tension: Float = DEFAULT_TENSION,
+  ): Path {
+    val filteredPoints = filterClosePoints(points)
+    if (filteredPoints.size < 2) {
+      return Path()
+    }
+
+    return when (algorithm) {
+      SmoothingAlgorithm.NONE -> buildLinearPath(filteredPoints)
+      SmoothingAlgorithm.CATMULL_ROM -> buildCatmullRomPath(filteredPoints, tension)
+      SmoothingAlgorithm.BEZIER -> buildBezierPath(filteredPoints, tension)
+      SmoothingAlgorithm.DOUGLAS_PEUCKER -> buildDouglasPeuckerPath(filteredPoints, tension)
+    }
+  }
+
+  private fun buildLinearPath(points: List<PointF>): Path {
+    val path = Path()
+    path.moveTo(points.first().x, points.first().y)
+    for (i in 1 until points.size) {
+      val point = points[i]
+      path.lineTo(point.x, point.y)
+    }
+    return path
+  }
+
+  private fun buildCatmullRomPath(points: List<PointF>, tension: Float): Path {
+    val path = Path()
+    val t = tension.coerceIn(0f, 1f)
+    path.moveTo(points.first().x, points.first().y)
+
+    for (i in 0 until points.size - 1) {
+      val p0 = if (i > 0) points[i - 1] else points[i]
+      val p1 = points[i]
+      val p2 = points[i + 1]
+      val p3 = if (i + 2 < points.size) points[i + 2] else p2
+
+      val cp1x = p1.x + (p2.x - p0.x) * t / 6f
+      val cp1y = p1.y + (p2.y - p0.y) * t / 6f
+      val cp2x = p2.x - (p3.x - p1.x) * t / 6f
+      val cp2y = p2.y - (p3.y - p1.y) * t / 6f
+
+      path.cubicTo(cp1x, cp1y, cp2x, cp2y, p2.x, p2.y)
+    }
+
+    return path
+  }
+
+  private fun buildBezierPath(points: List<PointF>, tension: Float): Path {
+    val path = Path()
+    val t = tension.coerceIn(0f, 1f)
+    path.moveTo(points.first().x, points.first().y)
+
+    if (points.size == 2) {
+      path.lineTo(points.last().x, points.last().y)
+      return path
+    }
+
+    for (i in 1 until points.size - 1) {
+      val current = points[i]
+      val next = points[i + 1]
+      val midX = (current.x + next.x) / 2f
+      val midY = (current.y + next.y) / 2f
+      val endX = current.x + (midX - current.x) * t
+      val endY = current.y + (midY - current.y) * t
+      path.quadTo(current.x, current.y, endX, endY)
+    }
+
+    val last = points.last()
+    path.lineTo(last.x, last.y)
+    return path
+  }
+
+  private fun buildDouglasPeuckerPath(points: List<PointF>, tension: Float): Path {
+    val t = tension.coerceIn(0f, 1f)
+    if (t <= 0f) {
+      return buildLinearPath(points)
+    }
+
+    val epsilon = DEFAULT_SIMPLIFY_EPSILON * t
+    val simplifiedPoints = if (epsilon <= 0f) points else simplifyDouglasPeucker(points, epsilon)
+    return buildLinearPath(simplifiedPoints)
+  }
+
+  private fun filterClosePoints(points: List<PointF>): List<PointF> {
+    if (points.size <= 2) {
+      return points
+    }
+
+    val filtered = ArrayList<PointF>(points.size)
+    var lastKept = points.first()
+    filtered.add(lastKept)
+
+    for (i in 1 until points.size - 1) {
+      val point = points[i]
+      if (distanceSquared(point, lastKept) >= MIN_POINT_DISTANCE_SQ) {
+        filtered.add(point)
+        lastKept = point
+      }
+    }
+
+    val last = points.last()
+    if (distanceSquared(last, lastKept) >= MIN_POINT_DISTANCE_SQ || filtered.size == 1) {
+      filtered.add(last)
+    } else {
+      filtered[filtered.size - 1] = last
+    }
+
+    return filtered
+  }
+
+  private fun simplifyDouglasPeucker(points: List<PointF>, epsilon: Float): List<PointF> {
+    if (points.size < 3) {
+      return points
+    }
+
+    val start = points.first()
+    val end = points.last()
+    var maxDistance = 0f
+    var index = 0
+
+    for (i in 1 until points.size - 1) {
+      val distance = perpendicularDistance(points[i], start, end)
+      if (distance > maxDistance) {
+        maxDistance = distance
+        index = i
+      }
+    }
+
+    return if (maxDistance > epsilon) {
+      val left = simplifyDouglasPeucker(points.subList(0, index + 1), epsilon)
+      val right = simplifyDouglasPeucker(points.subList(index, points.size), epsilon)
+      left.dropLast(1) + right
+    } else {
+      listOf(start, end)
+    }
+  }
+
+  private fun perpendicularDistance(point: PointF, start: PointF, end: PointF): Float {
+    val dx = end.x - start.x
+    val dy = end.y - start.y
+    if (dx == 0f && dy == 0f) {
+      return hypot(point.x - start.x, point.y - start.y)
+    }
+
+    val numerator = abs(dy * point.x - dx * point.y + end.x * start.y - end.y * start.x)
+    val denominator = hypot(dx, dy)
+    return numerator / denominator
+  }
+
+  private fun distanceSquared(a: PointF, b: PointF): Float {
+    val dx = a.x - b.x
+    val dy = a.y - b.y
+    return dx * dx + dy * dy
+  }
+
+  companion object {
+    private const val DEFAULT_TENSION = 0.5f
+    private const val DEFAULT_SIMPLIFY_EPSILON = 6f
+    private const val MIN_POINT_DISTANCE = 0.5f
+    private const val MIN_POINT_DISTANCE_SQ = MIN_POINT_DISTANCE * MIN_POINT_DISTANCE
+  }
+}

--- a/android/accessibility-service/src/main/kotlin/dev/jasonpearson/automobile/accessibilityservice/models/HighlightModels.kt
+++ b/android/accessibility-service/src/main/kotlin/dev/jasonpearson/automobile/accessibilityservice/models/HighlightModels.kt
@@ -1,6 +1,7 @@
 package dev.jasonpearson.automobile.accessibilityservice.models
 
 import android.graphics.RectF
+import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
@@ -24,17 +25,59 @@ data class HighlightBounds(
 }
 
 @Serializable
+data class HighlightPoint(
+    val x: Float,
+    val y: Float,
+)
+
+@Serializable
+enum class SmoothingAlgorithm {
+  @SerialName("none")
+  NONE,
+  @SerialName("catmull-rom")
+  CATMULL_ROM,
+  @SerialName("bezier")
+  BEZIER,
+  @SerialName("douglas-peucker")
+  DOUGLAS_PEUCKER,
+}
+
+@Serializable
+enum class HighlightLineCap {
+  @SerialName("butt")
+  BUTT,
+  @SerialName("round")
+  ROUND,
+  @SerialName("square")
+  SQUARE,
+}
+
+@Serializable
+enum class HighlightLineJoin {
+  @SerialName("miter")
+  MITER,
+  @SerialName("round")
+  ROUND,
+  @SerialName("bevel")
+  BEVEL,
+}
+
+@Serializable
 data class HighlightStyle(
     val strokeColor: String? = null,
     val strokeWidth: Float? = null,
-    val fillColor: String? = null,
     val dashPattern: List<Float>? = null,
+    val smoothing: SmoothingAlgorithm? = null,
+    val tension: Float? = null,
+    val capStyle: HighlightLineCap? = null,
+    val joinStyle: HighlightLineJoin? = null,
 )
 
 @Serializable
 data class HighlightShape(
     val type: String,
-    val bounds: HighlightBounds,
+    val bounds: HighlightBounds? = null,
+    val points: List<HighlightPoint>? = null,
     val style: HighlightStyle? = null,
 )
 

--- a/android/accessibility-service/src/test/kotlin/dev/jasonpearson/automobile/accessibilityservice/PathSmootherTest.kt
+++ b/android/accessibility-service/src/test/kotlin/dev/jasonpearson/automobile/accessibilityservice/PathSmootherTest.kt
@@ -1,0 +1,77 @@
+package dev.jasonpearson.automobile.accessibilityservice
+
+import android.graphics.PointF
+import android.graphics.RectF
+import dev.jasonpearson.automobile.accessibilityservice.models.SmoothingAlgorithm
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class PathSmootherTest {
+
+  private val smoother = PathSmoother()
+
+  @Test
+  fun `smoothPath returns empty path for insufficient points`() {
+    val path = smoother.smoothPath(listOf(PointF(0f, 0f)), SmoothingAlgorithm.CATMULL_ROM)
+    val bounds = RectF()
+    path.computeBounds(bounds, true)
+    assertEquals(0f, bounds.width(), 0.001f)
+    assertEquals(0f, bounds.height(), 0.001f)
+  }
+
+  @Test
+  fun `smoothPath keeps endpoints for catmull rom`() {
+    val points = listOf(PointF(0f, 0f), PointF(50f, 100f), PointF(100f, 0f))
+    val path = smoother.smoothPath(points, SmoothingAlgorithm.CATMULL_ROM, 0.6f)
+    assertPathEndpoints(path, points.first(), points.last())
+  }
+
+  @Test
+  fun `smoothPath keeps endpoints for bezier`() {
+    val points = listOf(PointF(10f, 20f), PointF(60f, 80f), PointF(120f, 30f))
+    val path = smoother.smoothPath(points, SmoothingAlgorithm.BEZIER, 0.8f)
+    assertPathEndpoints(path, points.first(), points.last())
+  }
+
+  @Test
+  fun `smoothPath keeps endpoints for douglas peucker`() {
+    val points =
+        listOf(
+            PointF(0f, 0f),
+            PointF(25f, 5f),
+            PointF(50f, 10f),
+            PointF(75f, 6f),
+            PointF(100f, 0f),
+        )
+    val path = smoother.smoothPath(points, SmoothingAlgorithm.DOUGLAS_PEUCKER, 1f)
+    assertPathEndpoints(path, points.first(), points.last())
+  }
+
+  @Test
+  fun `smoothPath keeps endpoints for raw points`() {
+    val points = listOf(PointF(5f, 5f), PointF(15f, 25f))
+    val path = smoother.smoothPath(points, SmoothingAlgorithm.NONE)
+    assertPathEndpoints(path, points.first(), points.last())
+  }
+
+  private fun assertPathEndpoints(path: android.graphics.Path, start: PointF, end: PointF) {
+    val bounds = RectF()
+    path.computeBounds(bounds, true)
+    assertTrue("Expected non-empty bounds", bounds.width() > 0f || bounds.height() > 0f)
+
+    assertPointWithinBounds(bounds, start)
+    assertPointWithinBounds(bounds, end)
+  }
+
+  private fun assertPointWithinBounds(bounds: RectF, point: PointF) {
+    val tolerance = 0.5f
+    assertTrue(point.x >= bounds.left - tolerance)
+    assertTrue(point.x <= bounds.right + tolerance)
+    assertTrue(point.y >= bounds.top - tolerance)
+    assertTrue(point.y <= bounds.bottom + tolerance)
+  }
+}

--- a/android/accessibility-service/src/test/kotlin/dev/jasonpearson/automobile/accessibilityservice/WebSocketServerIntegrationTest.kt
+++ b/android/accessibility-service/src/test/kotlin/dev/jasonpearson/automobile/accessibilityservice/WebSocketServerIntegrationTest.kt
@@ -394,7 +394,7 @@ class WebSocketServerIntegrationTest {
 
         val requestId = "req-add"
         val message =
-            """{"type":"add_highlight","requestId":"$requestId","id":"highlight-1","shape":{"type":"box","bounds":{"x":10,"y":20,"width":100,"height":80},"style":{"strokeColor":"#FF0000","strokeWidth":4,"fillColor":null,"dashPattern":null}}}"""
+            """{"type":"add_highlight","requestId":"$requestId","id":"highlight-1","shape":{"type":"box","bounds":{"x":10,"y":20,"width":100,"height":80},"style":{"strokeColor":"#FF0000","strokeWidth":4,"dashPattern":null}}}"""
         send(Frame.Text(message))
 
         val responseFrame = withTimeout(1000) { incoming.receive() } as Frame.Text
@@ -407,6 +407,40 @@ class WebSocketServerIntegrationTest {
         val highlights = responseJson["highlights"]?.jsonArray
         assertNotNull("Should include highlights array", highlights)
         assertEquals(1, highlights?.size)
+      }
+    }
+  }
+
+  @Test
+  fun `add_path_highlight returns highlight response`() = runBlocking {
+    server.start()
+
+    val client = HttpClient(CIO) { install(WebSockets) }
+    client.use { client ->
+      client.webSocket(
+          method = HttpMethod.Get,
+          host = "localhost",
+          port = getServerPort(),
+          path = "/ws",
+      ) {
+        incoming.receive() // Connection message
+
+        val requestId = "req-add-path"
+        val message =
+            """{"type":"add_highlight","requestId":"$requestId","id":"path-1","shape":{"type":"path","points":[{"x":10,"y":20},{"x":40,"y":35},{"x":80,"y":25}],"style":{"strokeColor":"#FF8800","strokeWidth":5,"smoothing":"catmull-rom","tension":0.6}}}"""
+        send(Frame.Text(message))
+
+        val responseFrame = withTimeout(1000) { incoming.receive() } as Frame.Text
+        val responseJson = json.parseToJsonElement(responseFrame.readText()).jsonObject
+
+        assertEquals("highlight_response", responseJson["type"]?.jsonPrimitive?.content)
+        assertEquals(requestId, responseJson["requestId"]?.jsonPrimitive?.content)
+        assertEquals("true", responseJson["success"]?.jsonPrimitive?.content)
+        val highlights = responseJson["highlights"]?.jsonArray
+        assertNotNull("Should include highlights array", highlights)
+        assertEquals(1, highlights?.size)
+        val highlight = highlights?.firstOrNull()?.jsonObject
+        assertEquals("path", highlight?.get("shape")?.jsonObject?.get("type")?.jsonPrimitive?.content)
       }
     }
   }
@@ -427,7 +461,7 @@ class WebSocketServerIntegrationTest {
 
         val addRequestId = "req-add"
         val addMessage =
-            """{"type":"add_highlight","requestId":"$addRequestId","id":"highlight-1","shape":{"type":"box","bounds":{"x":15,"y":25,"width":120,"height":90},"style":{"strokeColor":"#00FF00","strokeWidth":6,"fillColor":null,"dashPattern":null}}}"""
+            """{"type":"add_highlight","requestId":"$addRequestId","id":"highlight-1","shape":{"type":"box","bounds":{"x":15,"y":25,"width":120,"height":90},"style":{"strokeColor":"#00FF00","strokeWidth":6,"dashPattern":null}}}"""
         send(Frame.Text(addMessage))
         withTimeout(1000) { incoming.receive() } // add response
 
@@ -465,7 +499,7 @@ class WebSocketServerIntegrationTest {
         incoming.receive() // Connection message
 
         val addMessage =
-            """{"type":"add_highlight","requestId":"req-add","id":"highlight-1","shape":{"type":"circle","bounds":{"x":40,"y":50,"width":60,"height":60},"style":{"strokeColor":"#0000FF","strokeWidth":5,"fillColor":null,"dashPattern":null}}}"""
+            """{"type":"add_highlight","requestId":"req-add","id":"highlight-1","shape":{"type":"circle","bounds":{"x":40,"y":50,"width":60,"height":60},"style":{"strokeColor":"#0000FF","strokeWidth":5,"dashPattern":null}}}"""
         send(Frame.Text(addMessage))
         withTimeout(1000) { incoming.receive() } // add response
 
@@ -536,9 +570,9 @@ class WebSocketServerIntegrationTest {
         incoming.receive() // Connection message
 
         val addMessageOne =
-            """{"type":"add_highlight","requestId":"req-add-1","id":"highlight-1","shape":{"type":"box","bounds":{"x":5,"y":10,"width":50,"height":40},"style":{"strokeColor":"#FF00FF","strokeWidth":3,"fillColor":null,"dashPattern":null}}}"""
+            """{"type":"add_highlight","requestId":"req-add-1","id":"highlight-1","shape":{"type":"box","bounds":{"x":5,"y":10,"width":50,"height":40},"style":{"strokeColor":"#FF00FF","strokeWidth":3,"dashPattern":null}}}"""
         val addMessageTwo =
-            """{"type":"add_highlight","requestId":"req-add-2","id":"highlight-2","shape":{"type":"box","bounds":{"x":60,"y":70,"width":80,"height":90},"style":{"strokeColor":"#00FFFF","strokeWidth":3,"fillColor":null,"dashPattern":null}}}"""
+            """{"type":"add_highlight","requestId":"req-add-2","id":"highlight-2","shape":{"type":"box","bounds":{"x":60,"y":70,"width":80,"height":90},"style":{"strokeColor":"#00FFFF","strokeWidth":3,"dashPattern":null}}}"""
         send(Frame.Text(addMessageOne))
         withTimeout(1000) { incoming.receive() } // add response
         send(Frame.Text(addMessageTwo))
@@ -579,7 +613,7 @@ class WebSocketServerIntegrationTest {
 
         val requestId = "req-invalid"
         val message =
-            """{"type":"add_highlight","requestId":"$requestId","shape":{"type":"box","bounds":{"x":10,"y":20,"width":100,"height":80},"style":{"strokeColor":"#FF0000","strokeWidth":4,"fillColor":null,"dashPattern":null}}}"""
+            """{"type":"add_highlight","requestId":"$requestId","shape":{"type":"box","bounds":{"x":10,"y":20,"width":100,"height":80},"style":{"strokeColor":"#FF0000","strokeWidth":4,"dashPattern":null}}}"""
         send(Frame.Text(message))
 
         val responseFrame = withTimeout(1000) { incoming.receive() } as Frame.Text

--- a/src/features/debug/VisualHighlight.ts
+++ b/src/features/debug/VisualHighlight.ts
@@ -6,6 +6,7 @@ import { AccessibilityServiceClient } from "../observe/AccessibilityServiceClien
 import {
   ActionableError,
   BootedDevice,
+  HighlightBounds,
   HighlightEntry,
   HighlightOperationResult,
   HighlightShape,
@@ -23,7 +24,7 @@ const normalizeNullableString = (value: string | null | undefined): string | und
   value === null ? undefined : value
 );
 
-export const highlightBoundsSchema: z.ZodType<HighlightShape["bounds"]> = z.object({
+export const highlightBoundsSchema: z.ZodType<HighlightBounds> = z.object({
   x: z.number().int(),
   y: z.number().int(),
   width: z.number().int().positive(),
@@ -47,50 +48,81 @@ export const highlightBoundsSchema: z.ZodType<HighlightShape["bounds"]> = z.obje
 const highlightStyleSchema: z.ZodType<HighlightStyle> = z.object({
   strokeColor: z.string().min(1).nullable().optional(),
   strokeWidth: z.number().positive().nullable().optional(),
-  fillColor: z.string().min(1).nullable().optional(),
-  dashPattern: z.array(z.number().positive()).nonempty().nullable().optional()
+  dashPattern: z.array(z.number().positive()).nonempty().nullable().optional(),
+  smoothing: z.enum(["none", "catmull-rom", "bezier", "douglas-peucker"]).nullable().optional(),
+  tension: z.number().min(0).max(1).nullable().optional(),
+  capStyle: z.enum(["butt", "round", "square"]).nullable().optional(),
+  joinStyle: z.enum(["miter", "round", "bevel"]).nullable().optional()
 }).superRefine((value, ctx) => {
   const strokeColor = normalizeNullableString(value.strokeColor);
   const strokeWidth = normalizeNullableNumber(value.strokeWidth);
-  const fillColor = normalizeNullableString(value.fillColor);
   const dashPattern = value.dashPattern ?? undefined;
+  const smoothing = value.smoothing ?? undefined;
+  const tension = normalizeNullableNumber(value.tension);
+  const capStyle = value.capStyle ?? undefined;
+  const joinStyle = value.joinStyle ?? undefined;
 
-  const hasStroke = strokeColor !== undefined || strokeWidth !== undefined;
-  const hasFill = fillColor !== undefined;
+  const hasStroke = strokeColor !== undefined
+    || strokeWidth !== undefined
+    || dashPattern !== undefined
+    || smoothing !== undefined
+    || tension !== undefined
+    || capStyle !== undefined
+    || joinStyle !== undefined;
 
-  if (!hasStroke && !hasFill) {
+  if (!hasStroke) {
     ctx.addIssue({
       code: z.ZodIssueCode.custom,
-      message: "Highlight style must include stroke or fill"
-    });
-  }
-
-  if (dashPattern !== undefined && !hasStroke) {
-    ctx.addIssue({
-      code: z.ZodIssueCode.custom,
-      message: "dashPattern requires strokeColor or strokeWidth"
+      message: "Highlight style must include stroke settings"
     });
   }
 });
 
-export const highlightShapeSchema: z.ZodType<HighlightShape> = z.object({
-  type: z.enum(["box", "circle"]),
+const highlightPointSchema = z.object({
+  x: z.number(),
+  y: z.number()
+});
+
+const highlightBoxShapeSchema = z.object({
+  type: z.literal("box"),
   bounds: highlightBoundsSchema,
   style: highlightStyleSchema.nullable().optional()
 });
 
+const highlightCircleShapeSchema = z.object({
+  type: z.literal("circle"),
+  bounds: highlightBoundsSchema,
+  style: highlightStyleSchema.nullable().optional()
+});
+
+const highlightPathShapeSchema = z.object({
+  type: z.literal("path"),
+  points: z.array(highlightPointSchema).min(2),
+  bounds: highlightBoundsSchema.nullable().optional(),
+  style: highlightStyleSchema.nullable().optional()
+});
+
+export const highlightShapeSchema: z.ZodType<HighlightShape> = z.discriminatedUnion("type", [
+  highlightBoxShapeSchema,
+  highlightCircleShapeSchema,
+  highlightPathShapeSchema
+]);
+
 const highlightStyleResponseSchema = z.object({
   strokeColor: z.string().nullable().optional(),
   strokeWidth: z.number().nullable().optional(),
-  fillColor: z.string().nullable().optional(),
-  dashPattern: z.array(z.number().positive()).nullable().optional()
+  dashPattern: z.array(z.number().positive()).nullable().optional(),
+  smoothing: z.enum(["none", "catmull-rom", "bezier", "douglas-peucker"]).nullable().optional(),
+  tension: z.number().nullable().optional(),
+  capStyle: z.enum(["butt", "round", "square"]).nullable().optional(),
+  joinStyle: z.enum(["miter", "round", "bevel"]).nullable().optional()
 }).nullable().optional();
 
-const highlightShapeResponseSchema: z.ZodType<HighlightShape> = z.object({
-  type: z.enum(["box", "circle"]),
-  bounds: highlightBoundsSchema,
-  style: highlightStyleResponseSchema
-});
+const highlightShapeResponseSchema: z.ZodType<HighlightShape> = z.discriminatedUnion("type", [
+  highlightBoxShapeSchema.extend({ style: highlightStyleResponseSchema }),
+  highlightCircleShapeSchema.extend({ style: highlightStyleResponseSchema }),
+  highlightPathShapeSchema.extend({ style: highlightStyleResponseSchema })
+]);
 
 const highlightEntryResponseSchema: z.ZodType<HighlightEntry> = z.object({
   id: z.string().min(1),

--- a/src/features/observe/AccessibilityServiceClient.ts
+++ b/src/features/observe/AccessibilityServiceClient.ts
@@ -4042,10 +4042,11 @@ export class AccessibilityServiceClient implements AccessibilityService {
   }
 
   private normalizeHighlightShape(shape: HighlightShape): HighlightShape {
-    const bounds = shape.bounds;
-    return {
-      ...shape,
-      bounds: {
+    const normalizeBounds = (bounds: HighlightShape["bounds"]): HighlightShape["bounds"] => {
+      if (!bounds) {
+        return bounds;
+      }
+      return {
         x: Math.round(bounds.x),
         y: Math.round(bounds.y),
         width: Math.round(bounds.width),
@@ -4056,7 +4057,19 @@ export class AccessibilityServiceClient implements AccessibilityService {
         sourceHeight: bounds.sourceHeight === null || bounds.sourceHeight === undefined
           ? bounds.sourceHeight
           : Math.round(bounds.sourceHeight)
-      }
+      };
+    };
+
+    if (shape.type === "path") {
+      return {
+        ...shape,
+        bounds: normalizeBounds(shape.bounds)
+      };
+    }
+
+    return {
+      ...shape,
+      bounds: normalizeBounds(shape.bounds)
     };
   }
 }

--- a/src/models/VisualHighlight.ts
+++ b/src/models/VisualHighlight.ts
@@ -1,4 +1,10 @@
-export type HighlightShapeType = "box" | "circle";
+export type HighlightShapeType = "box" | "circle" | "path";
+
+export type HighlightSmoothingAlgorithm = "none" | "catmull-rom" | "bezier" | "douglas-peucker";
+
+export type HighlightLineCap = "butt" | "round" | "square";
+
+export type HighlightLineJoin = "miter" | "round" | "bevel";
 
 export interface HighlightBounds {
   x: number;
@@ -12,15 +18,38 @@ export interface HighlightBounds {
 export interface HighlightStyle {
   strokeColor?: string | null;
   strokeWidth?: number | null;
-  fillColor?: string | null;
   dashPattern?: number[] | null;
+  smoothing?: HighlightSmoothingAlgorithm | null;
+  tension?: number | null;
+  capStyle?: HighlightLineCap | null;
+  joinStyle?: HighlightLineJoin | null;
 }
 
-export interface HighlightShape {
-  type: HighlightShapeType;
+export interface HighlightPoint {
+  x: number;
+  y: number;
+}
+
+export interface HighlightBoxShape {
+  type: "box";
   bounds: HighlightBounds;
   style?: HighlightStyle | null;
 }
+
+export interface HighlightCircleShape {
+  type: "circle";
+  bounds: HighlightBounds;
+  style?: HighlightStyle | null;
+}
+
+export interface HighlightPathShape {
+  type: "path";
+  points: HighlightPoint[];
+  bounds?: HighlightBounds | null;
+  style?: HighlightStyle | null;
+}
+
+export type HighlightShape = HighlightBoxShape | HighlightCircleShape | HighlightPathShape;
 
 export interface HighlightEntry {
   id: string;

--- a/test/features/debug/VisualHighlight.test.ts
+++ b/test/features/debug/VisualHighlight.test.ts
@@ -24,6 +24,21 @@ describe("VisualHighlight", () => {
     }
   };
 
+  const pathShape: HighlightShape = {
+    type: "path",
+    points: [
+      { x: 5, y: 10 },
+      { x: 25, y: 40 },
+      { x: 50, y: 20 }
+    ],
+    style: {
+      strokeColor: "#FF8800",
+      strokeWidth: 6,
+      smoothing: "catmull-rom",
+      tension: 0.6
+    }
+  };
+
   test("addHighlight returns parsed highlight response", async () => {
     const response: HighlightOperationResult = {
       success: true,
@@ -41,6 +56,28 @@ describe("VisualHighlight", () => {
 
     const highlight = new VisualHighlight(androidDevice, null, fakeClient as any);
     const result = await highlight.addHighlight("highlight-1", highlightShape);
+
+    expect(result.success).toBe(true);
+    expect(result.highlights.length).toBe(1);
+  });
+
+  test("addHighlight accepts path shapes", async () => {
+    const response: HighlightOperationResult = {
+      success: true,
+      highlights: [
+        {
+          id: "path-1",
+          shape: pathShape
+        }
+      ]
+    };
+
+    const fakeClient = {
+      requestAddHighlight: async () => response
+    };
+
+    const highlight = new VisualHighlight(androidDevice, null, fakeClient as any);
+    const result = await highlight.addHighlight("path-1", pathShape);
 
     expect(result.success).toBe(true);
     expect(result.highlights.length).toBe(1);


### PR DESCRIPTION
## Summary
- render path highlights with tapered variable-width strokes based on curvature
- remove fill support from highlight styles across Android + TypeScript models/validation
- add path smoothing and WebSocket highlight coverage

## Testing
- ./gradlew :accessibility-service:test
- bun run test -- --grep "VisualHighlight"
- bun run test -- --grep "AccessibilityServiceClient"

Closes #655
