### PR TITLE
Remove deprecated listApps MCP tool

### DIFF
--- a/android/ide-plugin/src/main/kotlin/dev/jasonpearson/automobile/ide/yaml/TestPlanQuickFixes.kt
+++ b/android/ide-plugin/src/main/kotlin/dev/jasonpearson/automobile/ide/yaml/TestPlanQuickFixes.kt
@@ -146,7 +146,7 @@ object TestPlanQuickFixFactory {
 
     // Valid AutoMobile tool names (should match TestPlanValidator.VALID_TOOLS)
     private val VALID_TOOLS = setOf(
-        "launchApp", "terminateApp", "listApps", "installApp",
+        "launchApp", "terminateApp", "installApp",
         "tapOn", "swipeOn", "pinchOn", "dragAndDrop",
         "inputText", "clearText", "selectAllText", "imeAction",
         "pressButton", "pressKey", "homeScreen", "recentApps", "openLink", "navigateTo",

--- a/android/ide-plugin/src/main/kotlin/dev/jasonpearson/automobile/ide/yaml/TestPlanToolCategories.kt
+++ b/android/ide-plugin/src/main/kotlin/dev/jasonpearson/automobile/ide/yaml/TestPlanToolCategories.kt
@@ -5,7 +5,6 @@ object TestPlanToolCategories {
         "App management" to setOf(
             "launchApp",
             "terminateApp",
-            "listApps",
             "installApp"
         ),
         "UI interactions" to setOf(

--- a/android/ide-plugin/src/main/kotlin/dev/jasonpearson/automobile/ide/yaml/TestPlanValidator.kt
+++ b/android/ide-plugin/src/main/kotlin/dev/jasonpearson/automobile/ide/yaml/TestPlanValidator.kt
@@ -47,7 +47,7 @@ object TestPlanValidator {
     // Valid AutoMobile tool names (extracted from src/server/*Tools.ts)
     private val VALID_TOOLS = setOf(
         // App management
-        "launchApp", "terminateApp", "listApps", "installApp",
+        "launchApp", "terminateApp", "installApp",
         // UI interactions
         "tapOn", "swipeOn", "pinchOn", "dragAndDrop",
         // Input

--- a/android/test-plan-validation/src/main/kotlin/dev/jasonpearson/automobile/validation/ValidTools.kt
+++ b/android/test-plan-validation/src/main/kotlin/dev/jasonpearson/automobile/validation/ValidTools.kt
@@ -2,7 +2,7 @@ package dev.jasonpearson.automobile.validation
 
 object ValidTools {
     val TOOLS = setOf(
-        "launchApp", "terminateApp", "listApps", "installApp",
+        "launchApp", "terminateApp", "installApp",
         "tapOn", "swipeOn", "pinchOn", "dragAndDrop",
         "inputText", "clearText", "selectAllText", "imeAction",
         "pressButton", "pressKey", "homeScreen", "recentApps", "openLink", "navigateTo",

--- a/docs/design-docs/mcp/actions.md
+++ b/docs/design-docs/mcp/actions.md
@@ -41,7 +41,7 @@ Successful `tapOn` calls include `selectedElement` metadata describing which mat
 
 #### App Management
 
-- 📱 `listApps` enumerates installed apps (deprecated; use the `automobile:apps` resource with query filters).
+- 📱 Installed apps are exposed via the `automobile:apps` resource with query filters.
 - 🚀 `launchApp` starts apps by package name (with optional clear-app-data support).
 - ❌ `terminateApp` force-stops an app by package name.
 - 📦 `installApp` installs an APK.

--- a/docs/design-docs/plat/android/work-profiles.md
+++ b/docs/design-docs/plat/android/work-profiles.md
@@ -28,7 +28,7 @@ App management tools that support work profiles:
 - `installApp` - Install APKs to the auto-selected profile
 - `launchApp` - Launch apps in the auto-selected profile
 - `terminateApp` - Terminate apps in the auto-selected profile
-- `listApps` (deprecated; use `automobile:apps`) - List apps from all profiles with userId and foreground status (recent is a placeholder)
+- `automobile:apps` resource - List apps from all profiles with userId and foreground status (recent is a placeholder)
 
 ## Setting Up Work Profile on Android Emulator
 

--- a/schemas/tool-definitions.json
+++ b/schemas/tool-definitions.json
@@ -921,48 +921,164 @@
           "description": "Highlight ID (required for add/remove)"
         },
         "shape": {
-          "type": "object",
-          "properties": {
-            "type": {
-              "type": "string",
-              "enum": [
-                "box",
-                "circle"
-              ]
-            },
-            "bounds": {
+          "anyOf": [
+            {
               "type": "object",
               "properties": {
-                "x": {
-                  "type": "integer"
+                "type": {
+                  "type": "string",
+                  "const": "box"
                 },
-                "y": {
-                  "type": "integer"
-                },
-                "width": {
-                  "type": "integer",
-                  "exclusiveMinimum": 0
-                },
-                "height": {
-                  "type": "integer",
-                  "exclusiveMinimum": 0
-                },
-                "sourceWidth": {
-                  "anyOf": [
-                    {
+                "bounds": {
+                  "type": "object",
+                  "properties": {
+                    "x": {
+                      "type": "integer"
+                    },
+                    "y": {
+                      "type": "integer"
+                    },
+                    "width": {
                       "type": "integer",
                       "exclusiveMinimum": 0
                     },
-                    {
-                      "type": "null"
-                    }
-                  ]
-                },
-                "sourceHeight": {
-                  "anyOf": [
-                    {
+                    "height": {
                       "type": "integer",
                       "exclusiveMinimum": 0
+                    },
+                    "sourceWidth": {
+                      "anyOf": [
+                        {
+                          "type": "integer",
+                          "exclusiveMinimum": 0
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "sourceHeight": {
+                      "anyOf": [
+                        {
+                          "type": "integer",
+                          "exclusiveMinimum": 0
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    }
+                  },
+                  "required": [
+                    "x",
+                    "y",
+                    "width",
+                    "height"
+                  ],
+                  "additionalProperties": false
+                },
+                "style": {
+                  "anyOf": [
+                    {
+                      "type": "object",
+                      "properties": {
+                        "strokeColor": {
+                          "anyOf": [
+                            {
+                              "type": "string",
+                              "minLength": 1
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ]
+                        },
+                        "strokeWidth": {
+                          "anyOf": [
+                            {
+                              "type": "number",
+                              "exclusiveMinimum": 0
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ]
+                        },
+                        "dashPattern": {
+                          "anyOf": [
+                            {
+                              "type": "array",
+                              "items": {
+                                "type": "number",
+                                "exclusiveMinimum": 0
+                              },
+                              "minItems": 1
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ]
+                        },
+                        "smoothing": {
+                          "anyOf": [
+                            {
+                              "type": "string",
+                              "enum": [
+                                "none",
+                                "catmull-rom",
+                                "bezier",
+                                "douglas-peucker"
+                              ]
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ]
+                        },
+                        "tension": {
+                          "anyOf": [
+                            {
+                              "type": "number",
+                              "minimum": 0,
+                              "maximum": 1
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ]
+                        },
+                        "capStyle": {
+                          "anyOf": [
+                            {
+                              "type": "string",
+                              "enum": [
+                                "butt",
+                                "round",
+                                "square"
+                              ]
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ]
+                        },
+                        "joinStyle": {
+                          "anyOf": [
+                            {
+                              "type": "string",
+                              "enum": [
+                                "miter",
+                                "round",
+                                "bevel"
+                              ]
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ]
+                        }
+                      },
+                      "additionalProperties": false
                     },
                     {
                       "type": "null"
@@ -971,80 +1087,93 @@
                 }
               },
               "required": [
-                "x",
-                "y",
-                "width",
-                "height"
+                "type",
+                "bounds"
               ],
               "additionalProperties": false
             },
-            "style": {
-              "anyOf": [
-                {
-                  "type": "object",
-                  "properties": {
-                    "strokeColor": {
-                      "anyOf": [
-                        {
-                          "type": "string",
-                          "minLength": 1
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ]
-                    },
-                    "strokeWidth": {
-                      "anyOf": [
-                        {
-                          "type": "number",
-                          "exclusiveMinimum": 0
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ]
-                    },
-                    "fillColor": {
-                      "anyOf": [
-                        {
-                          "type": "string",
-                          "minLength": 1
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ]
-                    },
-                    "dashPattern": {
-                      "anyOf": [
-                        {
-                          "type": "array",
-                          "items": {
-                            "type": "number",
-                            "exclusiveMinimum": 0
-                          },
-                          "minItems": 1
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ]
-                    }
-                  },
-                  "additionalProperties": false
+            {
+              "type": "object",
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "const": "circle"
                 },
-                {
-                  "type": "null"
+                "bounds": {
+                  "$ref": "#/properties/shape/anyOf/0/properties/bounds"
+                },
+                "style": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/properties/shape/anyOf/0/properties/style/anyOf/0"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
                 }
-              ]
+              },
+              "required": [
+                "type",
+                "bounds"
+              ],
+              "additionalProperties": false
+            },
+            {
+              "type": "object",
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "const": "path"
+                },
+                "points": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "x": {
+                        "type": "number"
+                      },
+                      "y": {
+                        "type": "number"
+                      }
+                    },
+                    "required": [
+                      "x",
+                      "y"
+                    ],
+                    "additionalProperties": false
+                  },
+                  "minItems": 2
+                },
+                "bounds": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/properties/shape/anyOf/0/properties/bounds"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
+                "style": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/properties/shape/anyOf/0/properties/style/anyOf/0"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                }
+              },
+              "required": [
+                "type",
+                "points"
+              ],
+              "additionalProperties": false
             }
-          },
-          "required": [
-            "type",
-            "bounds"
           ],
-          "additionalProperties": false,
           "description": "Highlight shape definition (required for add)"
         }
       },
@@ -1292,40 +1421,6 @@
       },
       "required": [
         "appId"
-      ],
-      "additionalProperties": false,
-      "$schema": "http://json-schema.org/draft-07/schema#"
-    }
-  },
-  {
-    "name": "listApps",
-    "description": "List installed apps (DEPRECATED: use automobile:apps resource)",
-    "inputSchema": {
-      "type": "object",
-      "properties": {
-        "platform": {
-          "type": "string",
-          "enum": [
-            "android",
-            "ios"
-          ],
-          "description": "Platform"
-        },
-        "sessionUuid": {
-          "type": "string",
-          "description": "Session UUID for device targeting"
-        },
-        "keepScreenAwake": {
-          "type": "boolean",
-          "description": "Keep physical Android devices awake during the session (default: true)"
-        },
-        "device": {
-          "type": "string",
-          "description": "Device label for multi-device plans (e.g., \"A\", \"B\")"
-        }
-      },
-      "required": [
-        "platform"
       ],
       "additionalProperties": false,
       "$schema": "http://json-schema.org/draft-07/schema#"

--- a/src/server/observeTools.ts
+++ b/src/server/observeTools.ts
@@ -4,7 +4,6 @@ import { ResourceRegistry } from "./resourceRegistry";
 import { RESOURCE_URIS } from "./observationResources";
 import { ActionableError } from "../models/ActionableError";
 import { ObserveScreen } from "../features/observe/ObserveScreen";
-import { ListInstalledApps } from "../features/observe/ListInstalledApps";
 import { createJSONToolResponse, throwIfAborted } from "../utils/toolUtils";
 import { BootedDevice, Element, ObserveResult, ViewHierarchyResult } from "../models";
 import { createGlobalPerformanceTracker } from "../utils/PerformanceTracker";
@@ -85,10 +84,6 @@ const observeResultSchema = z.object({
   predictions: predictionsSchema.optional(),
   accessibilityState: accessibilityStateSchema.optional()
 }).passthrough();
-
-export const listAppsSchema = addDeviceTargetingToSchema(z.object({
-  platform: z.enum(["android", "ios"]).describe("Platform")
-}));
 
 export const identifyInteractionsSchema = addDeviceTargetingToSchema(z.object({
   platform: z.enum(["android", "ios"]).describe("Platform"),
@@ -282,37 +277,6 @@ export function registerObserveTools() {
     }
   };
 
-  // List Apps handler
-  const listAppsHandler = async (device: BootedDevice) => {
-    const deprecationNotice =
-      "Deprecated: use the `automobile:apps` MCP resource (e.g. automobile:apps?deviceId=DEVICE_ID&platform=android&search=slack&type=user).";
-    try {
-      const listInstalledApps = new ListInstalledApps(device);
-
-      // For Android, return detailed app info with userId, foreground status, etc.
-      // For iOS, return simple package names
-      if (device.platform === "android") {
-        const apps = await listInstalledApps.executeDetailed();
-        const profileAppCount = Object.values(apps.profiles).reduce((count, profileApps) => count + profileApps.length, 0);
-        const profileCount = Object.keys(apps.profiles).length;
-        return createJSONToolResponse({
-          message: `${deprecationNotice} Listed ${profileAppCount} user app(s) across ${profileCount} profile(s); ` +
-            `${apps.system.length} system app(s) deduped`,
-          profiles: apps.profiles,
-          system: apps.system
-        });
-      } else {
-        const apps = await listInstalledApps.execute();
-        return createJSONToolResponse({
-          message: `${deprecationNotice} Listed ${apps.length} apps`,
-          apps
-        });
-      }
-    } catch (error) {
-      throw new ActionableError(`Failed to list apps: ${error}`);
-    }
-  };
-
   // Register with the tool registry using the new device-aware method
   ToolRegistry.registerDeviceAware(
     "observe",
@@ -322,13 +286,6 @@ export function registerObserveTools() {
     false,
     false,
     { outputSchema: observeResultSchema }
-  );
-
-  ToolRegistry.registerDeviceAware(
-    "listApps",
-    "List installed apps (DEPRECATED: use automobile:apps resource)",
-    listAppsSchema,
-    listAppsHandler
   );
 
   ToolRegistry.registerDeviceAware(

--- a/src/test/resources/test-plans/auto-generated-calendar-2025-06-26T17-36.yaml
+++ b/src/test/resources/test-plans/auto-generated-calendar-2025-06-26T17-36.yaml
@@ -4,7 +4,7 @@ generated: "2025-06-26T17:36:10.504Z"
 appId: "com.google.android.calendar"
 metadata:
   sessionId: "758e9930-6afb-4b89-8575-2fff9403759b"
-  toolCallCount: 10
+  toolCallCount: 8
   duration: 930938
 steps:
   - tool: "homeScreen"
@@ -14,9 +14,6 @@ steps:
     params:
       button: "back"
     description: "pressButton executed at 2025-06-26T17:36:29.778Z"
-  - tool: "listApps"
-    params:
-    description: "listApps executed at 2025-06-26T17:36:36.214Z"
   - tool: "launchApp"
     params:
       appId: "com.google.android.calendar"

--- a/test/server/tools/registry.test.ts
+++ b/test/server/tools/registry.test.ts
@@ -23,8 +23,9 @@ describe("MCP Tools Registry", () => {
     expect(toolNames).toContain("tapOn");
 
     // Should include app management tools (MCP app lifecycle)
-    expect(toolNames).toContain("listApps");
     expect(toolNames).toContain("launchApp");
+    expect(toolNames).toContain("terminateApp");
+    expect(toolNames).not.toContain("listApps");
 
   });
 
@@ -70,7 +71,7 @@ describe("MCP Tools Registry", () => {
       interaction: ["tapOn", "sendText", "pressButton", "swipeOn"],
 
       // App management tools (lifecycle management)
-      app: ["listApps", "launchApp", "terminateApp", "installApp"],
+      app: ["launchApp", "terminateApp", "installApp"],
 
       // Utility tools (device state and configuration)
       utility: ["changeOrientation", "setActiveDevice", "openUrl", "exitDialog", "demoMode"],
@@ -89,7 +90,6 @@ describe("MCP Tools Registry", () => {
     // Verify specific core tools are present
     expect(toolNames).toContain("observe", "observe tool should be registered");
     expect(toolNames).toContain("tapOn", "tapOn tool should be registered");
-    expect(toolNames).toContain("listApps", "listApps tool should be registered");
 
     // Verify total tool count is reasonable (should have tools from all categories)
     expect(toolDefinitions.length).toBeGreaterThan(15, "Should have a substantial number of tools registered");


### PR DESCRIPTION
## Summary
- remove the deprecated listApps MCP tool from the registry and tool definitions
- align Android validation/IDE tool lists and docs with the automobile:apps resource
- update sample test plan + registry tests for listApps removal

## Testing
- bun run test
- bun run validate:yaml

Closes #713
