### PR TITLE
Update dragAndDrop timing options

### DIFF
--- a/android/accessibility-service/src/main/kotlin/dev/jasonpearson/automobile/accessibilityservice/AutoMobileAccessibilityService.kt
+++ b/android/accessibility-service/src/main/kotlin/dev/jasonpearson/automobile/accessibilityservice/AutoMobileAccessibilityService.kt
@@ -307,8 +307,25 @@ class AutoMobileAccessibilityService : AccessibilityService() {
               onRequestTwoFingerSwipe = { requestId, x1, y1, x2, y2, duration, offset ->
                 performTwoFingerSwipe(requestId, x1, y1, x2, y2, duration, offset)
               },
-              onRequestDrag = { requestId, x1, y1, x2, y2, duration, holdTime ->
-                performDrag(requestId, x1, y1, x2, y2, duration, holdTime)
+              onRequestDrag = {
+                  requestId,
+                  x1,
+                  y1,
+                  x2,
+                  y2,
+                  pressDurationMs,
+                  dragDurationMs,
+                  holdDurationMs ->
+                performDrag(
+                    requestId,
+                    x1,
+                    y1,
+                    x2,
+                    y2,
+                    pressDurationMs,
+                    dragDurationMs,
+                    holdDurationMs,
+                )
               },
               onRequestPinch = {
                   requestId,
@@ -988,8 +1005,9 @@ class AutoMobileAccessibilityService : AccessibilityService() {
    * @param y1 Starting Y coordinate
    * @param x2 Ending X coordinate
    * @param y2 Ending Y coordinate
-   * @param duration Drag duration in milliseconds
-   * @param holdTime Hold time before dragging in milliseconds
+   * @param pressDurationMs Press duration before dragging in milliseconds
+   * @param dragDurationMs Drag duration in milliseconds
+   * @param holdDurationMs Hold duration after dragging in milliseconds
    */
   private fun performDrag(
       requestId: String?,
@@ -997,13 +1015,14 @@ class AutoMobileAccessibilityService : AccessibilityService() {
       y1: Int,
       x2: Int,
       y2: Int,
-      duration: Long,
-      holdTime: Long,
+      pressDurationMs: Long,
+      dragDurationMs: Long,
+      holdDurationMs: Long,
   ) {
     val startTime = System.currentTimeMillis()
     Log.d(
         TAG,
-        "performDrag: ($x1, $y1) -> ($x2, $y2) duration=${duration}ms hold=${holdTime}ms",
+        "performDrag: ($x1, $y1) -> ($x2, $y2) press=${pressDurationMs}ms drag=${dragDurationMs}ms hold=${holdDurationMs}ms",
     )
     perfProvider.serial("performDrag")
 
@@ -1015,26 +1034,51 @@ class AutoMobileAccessibilityService : AccessibilityService() {
       val endX = x2.toFloat()
       val endY = y2.toFloat()
 
-      if (holdTime > 0) {
-        val holdPath =
+      val dragPath =
+          Path().apply {
+            moveTo(startX, startY)
+            lineTo(endX, endY)
+          }
+      val holdEndPath =
+          Path().apply {
+            moveTo(endX, endY)
+          }
+
+      if (pressDurationMs > 0) {
+        val pressPath =
             Path().apply {
               moveTo(startX, startY)
             }
-        val dragPath =
-            Path().apply {
-              moveTo(startX, startY)
-              lineTo(endX, endY)
-            }
-        val holdStroke = GestureDescription.StrokeDescription(holdPath, 0, holdTime, true)
-        val dragStroke = holdStroke.continueStroke(dragPath, holdTime, duration, false)
-        gestureBuilder.addStroke(holdStroke).addStroke(dragStroke)
+        val pressStroke = GestureDescription.StrokeDescription(pressPath, 0, pressDurationMs, true)
+        val dragStroke =
+            pressStroke.continueStroke(
+                dragPath,
+                pressDurationMs,
+                dragDurationMs,
+                holdDurationMs > 0,
+            )
+        gestureBuilder.addStroke(pressStroke).addStroke(dragStroke)
+
+        if (holdDurationMs > 0) {
+          val holdStroke =
+              dragStroke.continueStroke(
+                  holdEndPath,
+                  pressDurationMs + dragDurationMs,
+                  holdDurationMs,
+                  false,
+              )
+          gestureBuilder.addStroke(holdStroke)
+        }
       } else {
-        val dragPath =
-            Path().apply {
-              moveTo(startX, startY)
-              lineTo(endX, endY)
-            }
-        gestureBuilder.addStroke(GestureDescription.StrokeDescription(dragPath, 0, duration))
+        val dragStroke =
+            GestureDescription.StrokeDescription(dragPath, 0, dragDurationMs, holdDurationMs > 0)
+        gestureBuilder.addStroke(dragStroke)
+
+        if (holdDurationMs > 0) {
+          val holdStroke =
+              dragStroke.continueStroke(holdEndPath, dragDurationMs, holdDurationMs, false)
+          gestureBuilder.addStroke(holdStroke)
+        }
       }
       val gesture = gestureBuilder.build()
       perfProvider.endOperation("buildPath")

--- a/android/accessibility-service/src/main/kotlin/dev/jasonpearson/automobile/accessibilityservice/WebSocketServer.kt
+++ b/android/accessibility-service/src/main/kotlin/dev/jasonpearson/automobile/accessibilityservice/WebSocketServer.kt
@@ -41,6 +41,9 @@ data class WebSocketRequest(
     val duration: Long? = null,
     val offset: Int? = null, // Two-finger swipe offset
     val holdTime: Long? = null,
+    val pressDurationMs: Long? = null,
+    val dragDurationMs: Long? = null,
+    val holdDurationMs: Long? = null,
     // Pinch parameters
     val centerX: Int? = null,
     val centerY: Int? = null,
@@ -95,8 +98,9 @@ class WebSocketServer(
             y1: Int,
             x2: Int,
             y2: Int,
-            duration: Long,
-            holdTime: Long,
+            pressDurationMs: Long,
+            dragDurationMs: Long,
+            holdDurationMs: Long,
         ) -> Unit)? =
         null,
     private val onRequestPinch:
@@ -408,10 +412,20 @@ class WebSocketServer(
           val y1 = request.y1
           val x2 = request.x2
           val y2 = request.y2
-          val duration = request.duration ?: 500L
-          val holdTime = request.holdTime ?: 200L
+          val pressDurationMs = request.pressDurationMs ?: request.holdTime ?: 600L
+          val dragDurationMs = request.dragDurationMs ?: request.duration ?: 300L
+          val holdDurationMs = request.holdDurationMs ?: 100L
           if (x1 != null && y1 != null && x2 != null && y2 != null) {
-            onRequestDrag?.invoke(request.requestId, x1, y1, x2, y2, duration, holdTime)
+            onRequestDrag?.invoke(
+                request.requestId,
+                x1,
+                y1,
+                x2,
+                y2,
+                pressDurationMs,
+                dragDurationMs,
+                holdDurationMs,
+            )
           } else {
             Log.w(TAG, "Drag request missing required coordinates")
           }

--- a/android/test-plan-validation/src/main/resources/schemas/test-plan.schema.json
+++ b/android/test-plan-validation/src/main/resources/schemas/test-plan.schema.json
@@ -171,18 +171,23 @@
               "target": {
                 "$ref": "#/$defs/dragAndDropSelector"
               },
-              "duration": {
+              "pressDurationMs": {
                 "type": "number",
-                "description": "Drag duration ms (default: 500)"
+                "description": "Press duration ms (min: 600, max: 3000, default: 600)",
+                "minimum": 600,
+                "maximum": 3000
               },
-              "holdTime": {
+              "dragDurationMs": {
                 "type": "number",
-                "description": "Hold time ms (default: 200)"
+                "description": "Drag duration ms (min: 300, max: 1000, default: 300)",
+                "minimum": 300,
+                "maximum": 1000
               },
-              "dropDelay": {
+              "holdDurationMs": {
                 "type": "number",
+                "description": "Hold duration ms (min: 100, max: 3000, default: 100)",
                 "minimum": 100,
-                "description": "Drop delay ms (min: 100, default: 100)"
+                "maximum": 3000
               },
               "platform": {
                 "type": "string",
@@ -289,18 +294,23 @@
           "$ref": "#/$defs/dragAndDropSelector",
           "description": "Target element"
         },
-        "duration": {
+        "pressDurationMs": {
           "type": "number",
-          "description": "Drag duration ms (default: 500)"
+          "description": "Press duration ms (min: 600, max: 3000, default: 600)",
+          "minimum": 600,
+          "maximum": 3000
         },
-        "holdTime": {
+        "dragDurationMs": {
           "type": "number",
-          "description": "Hold time ms (default: 200)"
+          "description": "Drag duration ms (min: 300, max: 1000, default: 300)",
+          "minimum": 300,
+          "maximum": 1000
         },
-        "dropDelay": {
+        "holdDurationMs": {
           "type": "number",
+          "description": "Hold duration ms (min: 100, max: 3000, default: 100)",
           "minimum": 100,
-          "description": "Drop delay ms (min: 100, default: 100)"
+          "maximum": 3000
         },
         "platform": {
           "type": "string",

--- a/android/test-plan-validation/src/test/kotlin/dev/jasonpearson/automobile/validation/TestPlanValidatorTest.kt
+++ b/android/test-plan-validation/src/test/kotlin/dev/jasonpearson/automobile/validation/TestPlanValidatorTest.kt
@@ -541,7 +541,7 @@ class TestPlanValidatorTest {
                 target:
                   text: Target
                 params:
-                  duration: 800
+                  dragDurationMs: 800
         """.trimIndent()
 
         val result = TestPlanValidator.validateYaml(yaml)

--- a/schemas/test-plan.schema.json
+++ b/schemas/test-plan.schema.json
@@ -171,18 +171,23 @@
               "target": {
                 "$ref": "#/$defs/dragAndDropSelector"
               },
-              "duration": {
+              "pressDurationMs": {
                 "type": "number",
-                "description": "Drag duration ms (default: 500)"
+                "description": "Press duration ms (min: 600, max: 3000, default: 600)",
+                "minimum": 600,
+                "maximum": 3000
               },
-              "holdTime": {
+              "dragDurationMs": {
                 "type": "number",
-                "description": "Hold time ms (default: 200)"
+                "description": "Drag duration ms (min: 300, max: 1000, default: 300)",
+                "minimum": 300,
+                "maximum": 1000
               },
-              "dropDelay": {
+              "holdDurationMs": {
                 "type": "number",
+                "description": "Hold duration ms (min: 100, max: 3000, default: 100)",
                 "minimum": 100,
-                "description": "Drop delay ms (min: 100, default: 100)"
+                "maximum": 3000
               },
               "platform": {
                 "type": "string",
@@ -289,18 +294,23 @@
           "$ref": "#/$defs/dragAndDropSelector",
           "description": "Target element"
         },
-        "duration": {
+        "pressDurationMs": {
           "type": "number",
-          "description": "Drag duration ms (default: 500)"
+          "description": "Press duration ms (min: 600, max: 3000, default: 600)",
+          "minimum": 600,
+          "maximum": 3000
         },
-        "holdTime": {
+        "dragDurationMs": {
           "type": "number",
-          "description": "Hold time ms (default: 200)"
+          "description": "Drag duration ms (min: 300, max: 1000, default: 300)",
+          "minimum": 300,
+          "maximum": 1000
         },
-        "dropDelay": {
+        "holdDurationMs": {
           "type": "number",
+          "description": "Hold duration ms (min: 100, max: 3000, default: 100)",
           "minimum": 100,
-          "description": "Drop delay ms (min: 100, default: 100)"
+          "maximum": 3000
         },
         "platform": {
           "type": "string",

--- a/schemas/tool-definitions.json
+++ b/schemas/tool-definitions.json
@@ -494,18 +494,23 @@
           ],
           "description": "Target element"
         },
-        "duration": {
+        "pressDurationMs": {
           "type": "number",
-          "description": "Drag duration ms (default: 500)"
+          "minimum": 600,
+          "maximum": 3000,
+          "description": "Press duration ms (min: 600, max: 3000, default: 600)"
         },
-        "holdTime": {
+        "dragDurationMs": {
           "type": "number",
-          "description": "Hold time ms (default: 200)"
+          "minimum": 300,
+          "maximum": 1000,
+          "description": "Drag duration ms (min: 300, max: 1000, default: 300)"
         },
-        "dropDelay": {
+        "holdDurationMs": {
           "type": "number",
           "minimum": 100,
-          "description": "Drop delay ms (min: 100, default: 100)"
+          "maximum": 3000,
+          "description": "Hold duration ms (min: 100, max: 3000, default: 100)"
         },
         "platform": {
           "type": "string",

--- a/src/features/action/DragAndDrop.ts
+++ b/src/features/action/DragAndDrop.ts
@@ -13,6 +13,15 @@ import { createGlobalPerformanceTracker } from "../../utils/PerformanceTracker";
 import { throwIfAborted } from "../../utils/toolUtils";
 import { AndroidAccessibilityServiceManager } from "../../utils/AccessibilityServiceManager";
 
+const PRESS_DURATION_MIN_MS = 600;
+const PRESS_DURATION_MAX_MS = 3000;
+const DRAG_DURATION_MIN_MS = 300;
+const DRAG_DURATION_MAX_MS = 1000;
+const HOLD_DURATION_MIN_MS = 100;
+const HOLD_DURATION_MAX_MS = 3000;
+const DROP_DURATION_MS = 100;
+const DRAG_TIMEOUT_BUFFER_MS = 500;
+
 export class DragAndDrop extends BaseVisualChange {
   private elementUtils: ElementUtils;
   private accessibilityService: AccessibilityServiceClient;
@@ -64,6 +73,10 @@ export class DragAndDrop extends BaseVisualChange {
     }
 
     try {
+      const pressDurationMs = this.getPressDurationMs(options);
+      const dragDurationMs = this.getDragDurationMs(options);
+      const holdDurationMs = this.getHoldDurationMs(options);
+
       const result = await this.observedInteraction(
         async (observeResult: ObserveResult) => {
           throwIfAborted(signal);
@@ -76,29 +89,25 @@ export class DragAndDrop extends BaseVisualChange {
           const target = this.resolveTarget(viewHierarchy, options.target, "target");
           const sourcePoint = this.elementUtils.getElementCenter(source);
           const targetPoint = this.elementUtils.getElementCenter(target);
-          const duration = this.getDuration(options);
-          const holdTime = this.getHoldTime(options);
-          const dropDelay = this.getDropDelay(options);
 
           const dragResult = await this.executeAndroidDrag(
             sourcePoint.x,
             sourcePoint.y,
             targetPoint.x,
             targetPoint.y,
-            duration,
-            holdTime,
+            pressDurationMs,
+            dragDurationMs,
+            holdDurationMs,
             signal
           );
 
-          if (dropDelay > 0) {
-            await new Promise(resolve => setTimeout(resolve, dropDelay));
-          }
+          await new Promise(resolve => setTimeout(resolve, DROP_DURATION_MS));
 
           const distance = Math.hypot(targetPoint.x - sourcePoint.x, targetPoint.y - sourcePoint.y);
 
           return {
             success: dragResult.success,
-            duration,
+            duration: dragDurationMs,
             distance,
             a11yTotalTimeMs: dragResult.a11yTotalTimeMs,
             a11yGestureTimeMs: dragResult.a11yGestureTimeMs,
@@ -107,7 +116,6 @@ export class DragAndDrop extends BaseVisualChange {
         },
         {
           changeExpected: false,
-          timeoutMs: 5000,
           progress,
           perf,
           signal,
@@ -116,9 +124,9 @@ export class DragAndDrop extends BaseVisualChange {
             toolArgs: {
               source: options.source,
               target: options.target,
-              duration: options.duration,
-              holdTime: options.holdTime,
-              dropDelay: this.getDropDelay(options),
+              pressDurationMs,
+              dragDurationMs,
+              holdDurationMs,
               platform: this.device.platform
             }
           }
@@ -129,7 +137,7 @@ export class DragAndDrop extends BaseVisualChange {
 
       return {
         ...result,
-        duration: result.duration ?? this.getDuration(options),
+        duration: result.duration ?? this.getDragDurationMs(options),
         distance: result.distance ?? 0
       } as DragAndDropResult;
     } catch (error) {
@@ -157,8 +165,14 @@ export class DragAndDrop extends BaseVisualChange {
     if (targetSelectorCount !== 1) {
       return "dragAndDrop target must specify exactly one of text or elementId";
     }
-    if (typeof options.dropDelay === "number" && options.dropDelay < 100) {
-      return "dragAndDrop dropDelay must be at least 100ms";
+    if (!this.isDurationInRange(options.pressDurationMs, PRESS_DURATION_MIN_MS, PRESS_DURATION_MAX_MS)) {
+      return `dragAndDrop pressDurationMs must be between ${PRESS_DURATION_MIN_MS}ms and ${PRESS_DURATION_MAX_MS}ms`;
+    }
+    if (!this.isDurationInRange(options.dragDurationMs, DRAG_DURATION_MIN_MS, DRAG_DURATION_MAX_MS)) {
+      return `dragAndDrop dragDurationMs must be between ${DRAG_DURATION_MIN_MS}ms and ${DRAG_DURATION_MAX_MS}ms`;
+    }
+    if (!this.isDurationInRange(options.holdDurationMs, HOLD_DURATION_MIN_MS, HOLD_DURATION_MAX_MS)) {
+      return `dragAndDrop holdDurationMs must be between ${HOLD_DURATION_MIN_MS}ms and ${HOLD_DURATION_MAX_MS}ms`;
     }
     return null;
   }
@@ -189,25 +203,36 @@ export class DragAndDrop extends BaseVisualChange {
     throw new ActionableError(`dragAndDrop ${label} requires text or elementId`);
   }
 
-  private getDuration(options: DragAndDropOptions): number {
-    if (typeof options.duration === "number" && options.duration > 0) {
-      return options.duration;
+  private getPressDurationMs(options: DragAndDropOptions): number {
+    if (typeof options.pressDurationMs === "number") {
+      return options.pressDurationMs;
     }
-    return 500;
+    return PRESS_DURATION_MIN_MS;
   }
 
-  private getHoldTime(options: DragAndDropOptions): number {
-    if (typeof options.holdTime === "number" && options.holdTime >= 0) {
-      return options.holdTime;
+  private getDragDurationMs(options: DragAndDropOptions): number {
+    if (typeof options.dragDurationMs === "number") {
+      return options.dragDurationMs;
     }
-    return 200;
+    return DRAG_DURATION_MIN_MS;
   }
 
-  private getDropDelay(options: DragAndDropOptions): number {
-    if (typeof options.dropDelay === "number") {
-      return options.dropDelay;
+  private getHoldDurationMs(options: DragAndDropOptions): number {
+    if (typeof options.holdDurationMs === "number") {
+      return options.holdDurationMs;
     }
-    return 100;
+    return HOLD_DURATION_MIN_MS;
+  }
+
+  private isDurationInRange(value: number | undefined, min: number, max: number): boolean {
+    if (typeof value !== "number") {
+      return true;
+    }
+    return value >= min && value <= max;
+  }
+
+  private getDragTimeoutMs(pressDurationMs: number, dragDurationMs: number, holdDurationMs: number): number {
+    return pressDurationMs + dragDurationMs + holdDurationMs + DROP_DURATION_MS + DRAG_TIMEOUT_BUFFER_MS;
   }
 
   private async executeAndroidDrag(
@@ -215,8 +240,9 @@ export class DragAndDrop extends BaseVisualChange {
     startY: number,
     endX: number,
     endY: number,
-    duration: number,
-    holdTime: number,
+    pressDurationMs: number,
+    dragDurationMs: number,
+    holdDurationMs: number,
     signal?: AbortSignal
   ): Promise<{
     success: boolean;
@@ -231,9 +257,10 @@ export class DragAndDrop extends BaseVisualChange {
       startY,
       endX,
       endY,
-      duration,
-      holdTime,
-      5000
+      pressDurationMs,
+      dragDurationMs,
+      holdDurationMs,
+      this.getDragTimeoutMs(pressDurationMs, dragDurationMs, holdDurationMs)
     );
 
     if (result.success) {

--- a/src/features/observe/AccessibilityServiceClient.ts
+++ b/src/features/observe/AccessibilityServiceClient.ts
@@ -2552,8 +2552,9 @@ export class AccessibilityServiceClient implements AccessibilityService {
    * @param y1 - Starting Y coordinate
    * @param x2 - Ending X coordinate
    * @param y2 - Ending Y coordinate
-   * @param duration - Drag duration in milliseconds
-   * @param holdTime - Hold time before dragging in milliseconds
+   * @param pressDurationMs - Press duration before dragging in milliseconds
+   * @param dragDurationMs - Drag duration in milliseconds
+   * @param holdDurationMs - Hold duration after dragging in milliseconds
    * @param timeoutMs - Maximum time to wait for drag completion in milliseconds
    * @returns Promise<A11yDragResult> - The drag result with timing information
    */
@@ -2562,9 +2563,10 @@ export class AccessibilityServiceClient implements AccessibilityService {
     y1: number,
     x2: number,
     y2: number,
-    duration: number = 500,
-    holdTime: number = 200,
-    timeoutMs: number = 5000
+    pressDurationMs: number,
+    dragDurationMs: number,
+    holdDurationMs: number,
+    timeoutMs: number
   ): Promise<A11yDragResult> {
     const startTime = Date.now();
 
@@ -2607,11 +2609,12 @@ export class AccessibilityServiceClient implements AccessibilityService {
         y1: Math.round(y1),
         x2: Math.round(x2),
         y2: Math.round(y2),
-        duration,
-        holdTime
+        pressDurationMs,
+        dragDurationMs,
+        holdDurationMs
       });
       this.ws.send(message);
-      logger.debug(`[ACCESSIBILITY_SERVICE] Sent drag request (requestId: ${requestId}, ${x1},${y1} -> ${x2},${y2}, duration: ${duration}ms, hold: ${holdTime}ms)`);
+      logger.debug(`[ACCESSIBILITY_SERVICE] Sent drag request (requestId: ${requestId}, ${x1},${y1} -> ${x2},${y2}, press: ${pressDurationMs}ms, drag: ${dragDurationMs}ms, hold: ${holdDurationMs}ms)`);
 
       const result = await dragPromise;
       const clientDuration = Date.now() - startTime;

--- a/src/models/DragAndDropOptions.ts
+++ b/src/models/DragAndDropOptions.ts
@@ -6,7 +6,7 @@ export interface DragAndDropTarget {
 export interface DragAndDropOptions {
   source: DragAndDropTarget;
   target: DragAndDropTarget;
-  duration?: number;
-  holdTime?: number;
-  dropDelay?: number;
+  pressDurationMs?: number;
+  dragDurationMs?: number;
+  holdDurationMs?: number;
 }

--- a/src/server/interactionTools.ts
+++ b/src/server/interactionTools.ts
@@ -101,9 +101,9 @@ export interface DragAndDropArgs {
     text?: string;
     elementId?: string;
   };
-  duration?: number;
-  holdTime?: number;
-  dropDelay?: number;
+  pressDurationMs?: number;
+  dragDurationMs?: number;
+  holdDurationMs?: number;
   platform: Platform;
 }
 
@@ -263,9 +263,15 @@ const dragAndDropSelectorSchema = (label: "Source" | "Target") =>
 export const dragAndDropSchema = addDeviceTargetingToSchema(z.object({
   source: dragAndDropSelectorSchema("Source"),
   target: dragAndDropSelectorSchema("Target"),
-  duration: z.number().optional().describe("Drag duration ms (default: 500)"),
-  holdTime: z.number().optional().describe("Hold time ms (default: 200)"),
-  dropDelay: z.number().min(100).optional().describe("Drop delay ms (min: 100, default: 100)"),
+  pressDurationMs: z.number().min(600).max(3000).optional().describe(
+    "Press duration ms (min: 600, max: 3000, default: 600)"
+  ),
+  dragDurationMs: z.number().min(300).max(1000).optional().describe(
+    "Drag duration ms (min: 300, max: 1000, default: 300)"
+  ),
+  holdDurationMs: z.number().min(100).max(3000).optional().describe(
+    "Hold duration ms (min: 100, max: 3000, default: 100)"
+  ),
   platform: z.enum(["android", "ios"]).describe("Platform")
 }));
 
@@ -1148,9 +1154,9 @@ export function registerInteractionTools() {
     const result = await dragAndDrop.execute({
       source: args.source,
       target: args.target,
-      duration: args.duration,
-      holdTime: args.holdTime,
-      dropDelay: args.dropDelay
+      pressDurationMs: args.pressDurationMs,
+      dragDurationMs: args.dragDurationMs,
+      holdDurationMs: args.holdDurationMs
     }, progress);
 
     return createJSONToolResponse({

--- a/test/plan/PlanSchemaValidator.test.ts
+++ b/test/plan/PlanSchemaValidator.test.ts
@@ -96,7 +96,7 @@ steps:
     target:
       text: Target
     params:
-      duration: 800
+      dragDurationMs: 800
 `;
       const result = validator.validateYaml(yaml);
       expect(result.valid).toBe(true);


### PR DESCRIPTION
## Summary
- replace dragAndDrop timing fields with `pressDurationMs`, `dragDurationMs`, and `holdDurationMs` (defaults now use minimum values)
- update accessibility drag handling to honor press/drag/hold phases plus fixed 100ms drop pause
- align test plan schemas and regenerate tool definitions

## Testing
- `bun run test`
- `(cd android && ./gradlew :junit-runner:test)` **failed**: daemon stopped responding (connection refused)

Closes #683
