### PR TITLE
Fix Android app listing for system-like packages

### DIFF
--- a/schemas/tool-definitions.json
+++ b/schemas/tool-definitions.json
@@ -921,48 +921,164 @@
           "description": "Highlight ID (required for add/remove)"
         },
         "shape": {
-          "type": "object",
-          "properties": {
-            "type": {
-              "type": "string",
-              "enum": [
-                "box",
-                "circle"
-              ]
-            },
-            "bounds": {
+          "anyOf": [
+            {
               "type": "object",
               "properties": {
-                "x": {
-                  "type": "integer"
+                "type": {
+                  "type": "string",
+                  "const": "box"
                 },
-                "y": {
-                  "type": "integer"
-                },
-                "width": {
-                  "type": "integer",
-                  "exclusiveMinimum": 0
-                },
-                "height": {
-                  "type": "integer",
-                  "exclusiveMinimum": 0
-                },
-                "sourceWidth": {
-                  "anyOf": [
-                    {
+                "bounds": {
+                  "type": "object",
+                  "properties": {
+                    "x": {
+                      "type": "integer"
+                    },
+                    "y": {
+                      "type": "integer"
+                    },
+                    "width": {
                       "type": "integer",
                       "exclusiveMinimum": 0
                     },
-                    {
-                      "type": "null"
-                    }
-                  ]
-                },
-                "sourceHeight": {
-                  "anyOf": [
-                    {
+                    "height": {
                       "type": "integer",
                       "exclusiveMinimum": 0
+                    },
+                    "sourceWidth": {
+                      "anyOf": [
+                        {
+                          "type": "integer",
+                          "exclusiveMinimum": 0
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "sourceHeight": {
+                      "anyOf": [
+                        {
+                          "type": "integer",
+                          "exclusiveMinimum": 0
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    }
+                  },
+                  "required": [
+                    "x",
+                    "y",
+                    "width",
+                    "height"
+                  ],
+                  "additionalProperties": false
+                },
+                "style": {
+                  "anyOf": [
+                    {
+                      "type": "object",
+                      "properties": {
+                        "strokeColor": {
+                          "anyOf": [
+                            {
+                              "type": "string",
+                              "minLength": 1
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ]
+                        },
+                        "strokeWidth": {
+                          "anyOf": [
+                            {
+                              "type": "number",
+                              "exclusiveMinimum": 0
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ]
+                        },
+                        "dashPattern": {
+                          "anyOf": [
+                            {
+                              "type": "array",
+                              "items": {
+                                "type": "number",
+                                "exclusiveMinimum": 0
+                              },
+                              "minItems": 1
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ]
+                        },
+                        "smoothing": {
+                          "anyOf": [
+                            {
+                              "type": "string",
+                              "enum": [
+                                "none",
+                                "catmull-rom",
+                                "bezier",
+                                "douglas-peucker"
+                              ]
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ]
+                        },
+                        "tension": {
+                          "anyOf": [
+                            {
+                              "type": "number",
+                              "minimum": 0,
+                              "maximum": 1
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ]
+                        },
+                        "capStyle": {
+                          "anyOf": [
+                            {
+                              "type": "string",
+                              "enum": [
+                                "butt",
+                                "round",
+                                "square"
+                              ]
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ]
+                        },
+                        "joinStyle": {
+                          "anyOf": [
+                            {
+                              "type": "string",
+                              "enum": [
+                                "miter",
+                                "round",
+                                "bevel"
+                              ]
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ]
+                        }
+                      },
+                      "additionalProperties": false
                     },
                     {
                       "type": "null"
@@ -971,80 +1087,93 @@
                 }
               },
               "required": [
-                "x",
-                "y",
-                "width",
-                "height"
+                "type",
+                "bounds"
               ],
               "additionalProperties": false
             },
-            "style": {
-              "anyOf": [
-                {
-                  "type": "object",
-                  "properties": {
-                    "strokeColor": {
-                      "anyOf": [
-                        {
-                          "type": "string",
-                          "minLength": 1
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ]
-                    },
-                    "strokeWidth": {
-                      "anyOf": [
-                        {
-                          "type": "number",
-                          "exclusiveMinimum": 0
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ]
-                    },
-                    "fillColor": {
-                      "anyOf": [
-                        {
-                          "type": "string",
-                          "minLength": 1
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ]
-                    },
-                    "dashPattern": {
-                      "anyOf": [
-                        {
-                          "type": "array",
-                          "items": {
-                            "type": "number",
-                            "exclusiveMinimum": 0
-                          },
-                          "minItems": 1
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ]
-                    }
-                  },
-                  "additionalProperties": false
+            {
+              "type": "object",
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "const": "circle"
                 },
-                {
-                  "type": "null"
+                "bounds": {
+                  "$ref": "#/properties/shape/anyOf/0/properties/bounds"
+                },
+                "style": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/properties/shape/anyOf/0/properties/style/anyOf/0"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
                 }
-              ]
+              },
+              "required": [
+                "type",
+                "bounds"
+              ],
+              "additionalProperties": false
+            },
+            {
+              "type": "object",
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "const": "path"
+                },
+                "points": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "x": {
+                        "type": "number"
+                      },
+                      "y": {
+                        "type": "number"
+                      }
+                    },
+                    "required": [
+                      "x",
+                      "y"
+                    ],
+                    "additionalProperties": false
+                  },
+                  "minItems": 2
+                },
+                "bounds": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/properties/shape/anyOf/0/properties/bounds"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
+                "style": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/properties/shape/anyOf/0/properties/style/anyOf/0"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                }
+              },
+              "required": [
+                "type",
+                "points"
+              ],
+              "additionalProperties": false
             }
-          },
-          "required": [
-            "type",
-            "bounds"
           ],
-          "additionalProperties": false,
           "description": "Highlight shape definition (required for add)"
         }
       },

--- a/src/features/observe/ListInstalledApps.ts
+++ b/src/features/observe/ListInstalledApps.ts
@@ -70,8 +70,10 @@ export class ListInstalledApps {
         try {
           logger.info(`[ListInstalledApps] Listing packages for user ${user.userId}...`);
 
+          const allPackages = await this.listPackagesForUser(user.userId);
           const systemPackages = await this.listPackagesForUser(user.userId, "-s");
-          const userPackages = await this.listPackagesForUser(user.userId, "-3");
+          const systemPackageSet = new Set(systemPackages);
+          const userPackages = allPackages.filter(packageName => !systemPackageSet.has(packageName));
 
           logger.info(`[ListInstalledApps] Found ${userPackages.length} user package(s) and ${systemPackages.length} system package(s) for user ${user.userId}`);
 
@@ -127,9 +129,10 @@ export class ListInstalledApps {
     }
   }
 
-  private async listPackagesForUser(userId: number, filterFlag: "-s" | "-3"): Promise<string[]> {
+  private async listPackagesForUser(userId: number, filterFlag?: "-s" | "-3"): Promise<string[]> {
+    const flag = filterFlag ? ` ${filterFlag}` : "";
     const { stdout } = await this.adb.executeCommand(
-      `shell pm list packages ${filterFlag} --user ${userId}`
+      `shell pm list packages${flag} --user ${userId}`
     );
     return this.parsePackages(stdout);
   }

--- a/src/server/appResources.ts
+++ b/src/server/appResources.ts
@@ -62,6 +62,7 @@ export interface AppsResourceContent {
   totalCount: number;
   foregroundApp: string | null;
   lastUpdated: string; // ISO 8601
+  message?: string;
 }
 
 export interface InstalledAppInfo {
@@ -246,7 +247,8 @@ function createAppsResourceContent(
   device: BootedDevice,
   apps: InstalledAppInfo[],
   foregroundApp: string | null,
-  lastUpdated: string
+  lastUpdated: string,
+  message?: string
 ): AppsResourceContent {
   return {
     deviceId: device.deviceId,
@@ -254,8 +256,13 @@ function createAppsResourceContent(
     apps,
     totalCount: apps.length,
     foregroundApp,
-    lastUpdated
+    lastUpdated,
+    ...(message ? { message } : {})
   };
+}
+
+function getAndroidAppsMessage(deviceId: string): string {
+  return `User apps only. Use automobile:apps?deviceId=${deviceId}&type=system to list system apps.`;
 }
 
 async function findBootedDevice(deviceId: string): Promise<BootedDevice | null> {
@@ -276,10 +283,11 @@ async function fetchAppsForDevice(device: BootedDevice): Promise<AppsCacheEntry>
     const installedApps = await listInstalledApps.executeDetailed();
     const { userApps, queryApps } = normalizeAndroidApps(installedApps);
     const foregroundApp = queryApps.find(app => app.foreground)?.packageName ?? null;
+    const message = getAndroidAppsMessage(device.deviceId);
 
     return {
       expiresAt: Date.now() + APPS_CACHE_TTL_MS,
-      content: createAppsResourceContent(device, userApps, foregroundApp, lastUpdated),
+      content: createAppsResourceContent(device, userApps, foregroundApp, lastUpdated, message),
       appsByPackage: buildAppsByPackage(userApps),
       queryApps
     };
@@ -572,7 +580,8 @@ function registerDeviceAppResource(device: BootedDevice): void {
   ResourceRegistry.register(
     uri,
     `Installed Apps (${device.deviceId})`,
-    `List of installed apps for device ${device.deviceId} (${device.platform}).`,
+    `List of installed user apps for device ${device.deviceId} (${device.platform}). ` +
+      `System apps: use automobile:apps?deviceId=${device.deviceId}&type=system.`,
     "application/json",
     () => getAppsResource(device.deviceId)
   );
@@ -690,7 +699,8 @@ export function registerAppResources(): void {
   ResourceRegistry.registerTemplate(
     APP_RESOURCE_TEMPLATES.DEVICE_APPS,
     "Installed Apps",
-    "List of installed apps for a specific device.",
+    "List of installed user apps for a specific device. " +
+      "System apps: use automobile:apps?deviceId=DEVICE_ID&type=system.",
     "application/json",
     async params => getAppsResource(params.deviceId)
   );
@@ -698,7 +708,8 @@ export function registerAppResources(): void {
   ResourceRegistry.registerTemplate(
     APP_RESOURCE_TEMPLATES.DEVICE_APP,
     "Installed App Details",
-    "Details for a specific app installed on a specific device.",
+    "Details for a specific user app installed on a specific device. " +
+      "System apps: use automobile:apps?deviceId=DEVICE_ID&type=system&search=PACKAGE_NAME.",
     "application/json",
     async params => getAppResource(params.deviceId, params.packageName)
   );

--- a/test/features/action/LaunchApp.test.ts
+++ b/test/features/action/LaunchApp.test.ts
@@ -26,11 +26,11 @@ describe("LaunchApp", () => {
   });
 
   const configureInstalledApp = () => {
-    fakeAdb.setCommandResponse("shell pm list packages -s --user 0", { stdout: "", stderr: "" });
-    fakeAdb.setCommandResponse("shell pm list packages -3 --user 0", {
+    fakeAdb.setCommandResponse("shell pm list packages --user 0", {
       stdout: `package:${packageName}\n`,
       stderr: ""
     });
+    fakeAdb.setCommandResponse("shell pm list packages -s --user 0", { stdout: "", stderr: "" });
   };
 
   beforeEach(() => {

--- a/test/features/observe/ListInstalledApps.test.ts
+++ b/test/features/observe/ListInstalledApps.test.ts
@@ -24,12 +24,12 @@ describe("ListInstalledApps", function() {
     test("should list all installed packages", async function() {
       // Set up single user with packages
       fakeAdb.setUsers([{ userId: 0, name: "Owner", flags: 13, running: true }]);
-      fakeAdb.setCommandResponse("shell pm list packages -s --user 0", {
-        stdout: "package:com.android.chrome\npackage:com.google.android.gms\n",
+      fakeAdb.setCommandResponse("shell pm list packages --user 0", {
+        stdout: "package:com.android.chrome\npackage:com.google.android.gms\npackage:com.example.myapp\n",
         stderr: ""
       });
-      fakeAdb.setCommandResponse("shell pm list packages -3 --user 0", {
-        stdout: "package:com.example.myapp\n",
+      fakeAdb.setCommandResponse("shell pm list packages -s --user 0", {
+        stdout: "package:com.android.chrome\npackage:com.google.android.gms\n",
         stderr: ""
       });
 
@@ -44,8 +44,12 @@ describe("ListInstalledApps", function() {
 
     test("should filter out empty lines and non-package lines", async function() {
       fakeAdb.setUsers([{ userId: 0, name: "Owner", flags: 13, running: true }]);
-      fakeAdb.setCommandResponse("shell pm list packages -3 --user 0", {
+      fakeAdb.setCommandResponse("shell pm list packages --user 0", {
         stdout: "package:com.example.app\n\nsome other line\npackage:com.test.app\n",
+        stderr: ""
+      });
+      fakeAdb.setCommandResponse("shell pm list packages -s --user 0", {
+        stdout: "",
         stderr: ""
       });
 
@@ -58,7 +62,7 @@ describe("ListInstalledApps", function() {
 
     test("should handle adb command failure gracefully", async function() {
       fakeAdb.setUsers([{ userId: 0, name: "Owner", flags: 13, running: true }]);
-      fakeAdb.setCommandResponse("shell pm list packages -3 --user 0", {
+      fakeAdb.setCommandResponse("shell pm list packages --user 0", {
         stdout: "",
         stderr: "error"
       });
@@ -75,7 +79,7 @@ describe("ListInstalledApps", function() {
 
     test("should trim package names correctly", async function() {
       fakeAdb.setUsers([{ userId: 0, name: "Owner", flags: 13, running: true }]);
-      fakeAdb.setCommandResponse("shell pm list packages -3 --user 0", {
+      fakeAdb.setCommandResponse("shell pm list packages --user 0", {
         stdout: "package: com.example.app \npackage:com.test.app\t\n",
         stderr: ""
       });
@@ -102,20 +106,20 @@ describe("ListInstalledApps", function() {
       fakeAdb.setUsers(users);
 
       // Configure packages for each user
+      fakeAdb.setCommandResponse("shell pm list packages --user 0", {
+        stdout: "package:com.android.chrome\npackage:com.example.personalapp\n",
+        stderr: ""
+      });
       fakeAdb.setCommandResponse("shell pm list packages -s --user 0", {
         stdout: "package:com.android.chrome\n",
         stderr: ""
       });
-      fakeAdb.setCommandResponse("shell pm list packages -3 --user 0", {
-        stdout: "package:com.example.personalapp\n",
+      fakeAdb.setCommandResponse("shell pm list packages --user 10", {
+        stdout: "package:com.android.chrome\npackage:com.example.workapp\n",
         stderr: ""
       });
       fakeAdb.setCommandResponse("shell pm list packages -s --user 10", {
         stdout: "package:com.android.chrome\n",
-        stderr: ""
-      });
-      fakeAdb.setCommandResponse("shell pm list packages -3 --user 10", {
-        stdout: "package:com.example.workapp\n",
         stderr: ""
       });
 
@@ -152,20 +156,20 @@ describe("ListInstalledApps", function() {
       fakeAdb.setUsers(users);
       fakeAdb.setForegroundApp({ packageName: "com.android.settings", userId: 10 });
 
+      fakeAdb.setCommandResponse("shell pm list packages --user 0", {
+        stdout: "package:com.android.settings\n",
+        stderr: ""
+      });
       fakeAdb.setCommandResponse("shell pm list packages -s --user 0", {
         stdout: "package:com.android.settings\n",
         stderr: ""
       });
-      fakeAdb.setCommandResponse("shell pm list packages -3 --user 0", {
-        stdout: "",
+      fakeAdb.setCommandResponse("shell pm list packages --user 10", {
+        stdout: "package:com.android.settings\n",
         stderr: ""
       });
       fakeAdb.setCommandResponse("shell pm list packages -s --user 10", {
         stdout: "package:com.android.settings\n",
-        stderr: ""
-      });
-      fakeAdb.setCommandResponse("shell pm list packages -3 --user 10", {
-        stdout: "",
         stderr: ""
       });
 
@@ -175,6 +179,28 @@ describe("ListInstalledApps", function() {
       expect(result.system[0].packageName).toBe("com.android.settings");
       expect(result.system[0].userIds.sort()).toEqual([0, 10]);
       expect(result.system[0].foreground).toBe(true);
+    });
+
+    test("should treat non-system packages as user apps even if not listed in -s", async function() {
+      const users: AndroidUser[] = [
+        { userId: 0, name: "Owner", flags: 13, running: true }
+      ];
+      fakeAdb.setUsers(users);
+
+      fakeAdb.setCommandResponse("shell pm list packages --user 0", {
+        stdout: "package:com.android.chrome\npackage:com.google.android.apps.weather\n",
+        stderr: ""
+      });
+      fakeAdb.setCommandResponse("shell pm list packages -s --user 0", {
+        stdout: "package:com.android.chrome\n",
+        stderr: ""
+      });
+
+      const result = await listInstalledApps.executeDetailed();
+
+      const userPackages = result.profiles[0].map(app => app.packageName);
+      expect(userPackages).toContain("com.google.android.apps.weather");
+      expect(result.system.some(app => app.packageName === "com.google.android.apps.weather")).toBe(false);
     });
 
     test("should mark foreground app correctly", async function() {
@@ -187,7 +213,7 @@ describe("ListInstalledApps", function() {
       // Set foreground app in work profile
       fakeAdb.setForegroundApp({ packageName: "com.example.workapp", userId: 10 });
 
-      fakeAdb.setCommandResponse("shell pm list packages -3 --user 0", {
+      fakeAdb.setCommandResponse("shell pm list packages --user 0", {
         stdout: "package:com.example.personalapp\n",
         stderr: ""
       });
@@ -195,7 +221,7 @@ describe("ListInstalledApps", function() {
         stdout: "",
         stderr: ""
       });
-      fakeAdb.setCommandResponse("shell pm list packages -3 --user 10", {
+      fakeAdb.setCommandResponse("shell pm list packages --user 10", {
         stdout: "package:com.example.workapp\n",
         stderr: ""
       });
@@ -219,12 +245,12 @@ describe("ListInstalledApps", function() {
       ];
       fakeAdb.setUsers(users);
 
-      fakeAdb.setCommandResponse("shell pm list packages -s --user 0", {
-        stdout: "package:com.android.chrome\n",
+      fakeAdb.setCommandResponse("shell pm list packages --user 0", {
+        stdout: "package:com.android.chrome\npackage:com.example.app\n",
         stderr: ""
       });
-      fakeAdb.setCommandResponse("shell pm list packages -3 --user 0", {
-        stdout: "package:com.example.app\n",
+      fakeAdb.setCommandResponse("shell pm list packages -s --user 0", {
+        stdout: "package:com.android.chrome\n",
         stderr: ""
       });
 


### PR DESCRIPTION
## Summary
- list Android apps using full per-user package list and classify user apps by excluding system packages
- add messaging to device app resources pointing to `automobile:apps?deviceId=...&type=system`
- update listApps-related tests for the new package listing behavior

## Testing
- bun run test -- test/features/observe/ListInstalledApps.test.ts

Closes #715
