### PR TITLE
Fix occlusion filtering for root-level siblings

### DIFF
--- a/android/accessibility-service/src/main/kotlin/dev/jasonpearson/automobile/accessibilityservice/ViewHierarchyExtractor.kt
+++ b/android/accessibility-service/src/main/kotlin/dev/jasonpearson/automobile/accessibilityservice/ViewHierarchyExtractor.kt
@@ -1113,8 +1113,8 @@ class ViewHierarchyExtractor(private val recompositionStore: RecompositionStore?
     val nodeParentPath = nodePath.substringBeforeLast('.', "")
     val occluderParentPath = occluderPath.substringBeforeLast('.', "")
 
-    // Check if they're direct siblings (same parent)
-    if (nodeParentPath.isNotEmpty() && nodeParentPath == occluderParentPath) {
+    // Check if they're direct siblings (same parent). Root-level siblings have empty parent paths.
+    if (nodeParentPath == occluderParentPath) {
       return NodeRelationship.SIBLING
     }
 

--- a/android/accessibility-service/src/test/kotlin/dev/jasonpearson/automobile/accessibilityservice/ViewHierarchyExtractorTest.kt
+++ b/android/accessibility-service/src/test/kotlin/dev/jasonpearson/automobile/accessibilityservice/ViewHierarchyExtractorTest.kt
@@ -463,7 +463,7 @@ class ViewHierarchyExtractorTest {
 
   @Test
   fun `determineNodeRelationship handles root node edge case`() {
-    // Root node (empty parent path)
+    // Root-level siblings (empty parent path)
     val nodePath = "0"
     val occluderPath = "1"
 
@@ -475,8 +475,7 @@ class ViewHierarchyExtractorTest {
         occluderOrder = 101,
     )
 
-    // Root nodes are not siblings (empty parent path check)
-    assertEquals(ViewHierarchyExtractor.NodeRelationship.UNRELATED, relationship)
+    assertEquals(ViewHierarchyExtractor.NodeRelationship.SIBLING, relationship)
   }
 
   @Test

--- a/schemas/tool-definitions.json
+++ b/schemas/tool-definitions.json
@@ -921,48 +921,164 @@
           "description": "Highlight ID (required for add/remove)"
         },
         "shape": {
-          "type": "object",
-          "properties": {
-            "type": {
-              "type": "string",
-              "enum": [
-                "box",
-                "circle"
-              ]
-            },
-            "bounds": {
+          "anyOf": [
+            {
               "type": "object",
               "properties": {
-                "x": {
-                  "type": "integer"
+                "type": {
+                  "type": "string",
+                  "const": "box"
                 },
-                "y": {
-                  "type": "integer"
-                },
-                "width": {
-                  "type": "integer",
-                  "exclusiveMinimum": 0
-                },
-                "height": {
-                  "type": "integer",
-                  "exclusiveMinimum": 0
-                },
-                "sourceWidth": {
-                  "anyOf": [
-                    {
+                "bounds": {
+                  "type": "object",
+                  "properties": {
+                    "x": {
+                      "type": "integer"
+                    },
+                    "y": {
+                      "type": "integer"
+                    },
+                    "width": {
                       "type": "integer",
                       "exclusiveMinimum": 0
                     },
-                    {
-                      "type": "null"
-                    }
-                  ]
-                },
-                "sourceHeight": {
-                  "anyOf": [
-                    {
+                    "height": {
                       "type": "integer",
                       "exclusiveMinimum": 0
+                    },
+                    "sourceWidth": {
+                      "anyOf": [
+                        {
+                          "type": "integer",
+                          "exclusiveMinimum": 0
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "sourceHeight": {
+                      "anyOf": [
+                        {
+                          "type": "integer",
+                          "exclusiveMinimum": 0
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    }
+                  },
+                  "required": [
+                    "x",
+                    "y",
+                    "width",
+                    "height"
+                  ],
+                  "additionalProperties": false
+                },
+                "style": {
+                  "anyOf": [
+                    {
+                      "type": "object",
+                      "properties": {
+                        "strokeColor": {
+                          "anyOf": [
+                            {
+                              "type": "string",
+                              "minLength": 1
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ]
+                        },
+                        "strokeWidth": {
+                          "anyOf": [
+                            {
+                              "type": "number",
+                              "exclusiveMinimum": 0
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ]
+                        },
+                        "dashPattern": {
+                          "anyOf": [
+                            {
+                              "type": "array",
+                              "items": {
+                                "type": "number",
+                                "exclusiveMinimum": 0
+                              },
+                              "minItems": 1
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ]
+                        },
+                        "smoothing": {
+                          "anyOf": [
+                            {
+                              "type": "string",
+                              "enum": [
+                                "none",
+                                "catmull-rom",
+                                "bezier",
+                                "douglas-peucker"
+                              ]
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ]
+                        },
+                        "tension": {
+                          "anyOf": [
+                            {
+                              "type": "number",
+                              "minimum": 0,
+                              "maximum": 1
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ]
+                        },
+                        "capStyle": {
+                          "anyOf": [
+                            {
+                              "type": "string",
+                              "enum": [
+                                "butt",
+                                "round",
+                                "square"
+                              ]
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ]
+                        },
+                        "joinStyle": {
+                          "anyOf": [
+                            {
+                              "type": "string",
+                              "enum": [
+                                "miter",
+                                "round",
+                                "bevel"
+                              ]
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ]
+                        }
+                      },
+                      "additionalProperties": false
                     },
                     {
                       "type": "null"
@@ -971,80 +1087,93 @@
                 }
               },
               "required": [
-                "x",
-                "y",
-                "width",
-                "height"
+                "type",
+                "bounds"
               ],
               "additionalProperties": false
             },
-            "style": {
-              "anyOf": [
-                {
-                  "type": "object",
-                  "properties": {
-                    "strokeColor": {
-                      "anyOf": [
-                        {
-                          "type": "string",
-                          "minLength": 1
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ]
-                    },
-                    "strokeWidth": {
-                      "anyOf": [
-                        {
-                          "type": "number",
-                          "exclusiveMinimum": 0
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ]
-                    },
-                    "fillColor": {
-                      "anyOf": [
-                        {
-                          "type": "string",
-                          "minLength": 1
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ]
-                    },
-                    "dashPattern": {
-                      "anyOf": [
-                        {
-                          "type": "array",
-                          "items": {
-                            "type": "number",
-                            "exclusiveMinimum": 0
-                          },
-                          "minItems": 1
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ]
-                    }
-                  },
-                  "additionalProperties": false
+            {
+              "type": "object",
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "const": "circle"
                 },
-                {
-                  "type": "null"
+                "bounds": {
+                  "$ref": "#/properties/shape/anyOf/0/properties/bounds"
+                },
+                "style": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/properties/shape/anyOf/0/properties/style/anyOf/0"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
                 }
-              ]
+              },
+              "required": [
+                "type",
+                "bounds"
+              ],
+              "additionalProperties": false
+            },
+            {
+              "type": "object",
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "const": "path"
+                },
+                "points": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "x": {
+                        "type": "number"
+                      },
+                      "y": {
+                        "type": "number"
+                      }
+                    },
+                    "required": [
+                      "x",
+                      "y"
+                    ],
+                    "additionalProperties": false
+                  },
+                  "minItems": 2
+                },
+                "bounds": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/properties/shape/anyOf/0/properties/bounds"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
+                "style": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/properties/shape/anyOf/0/properties/style/anyOf/0"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                }
+              },
+              "required": [
+                "type",
+                "points"
+              ],
+              "additionalProperties": false
             }
-          },
-          "required": [
-            "type",
-            "bounds"
           ],
-          "additionalProperties": false,
           "description": "Highlight shape definition (required for add)"
         }
       },


### PR DESCRIPTION
## Summary
- treat root-level siblings as siblings so occlusion filtering doesn't hide launcher widgets
- update the root-level relationship test
- include regenerated tool definitions (commit hook)

## Testing
- ./gradlew :accessibility-service:test

## Issues
- Closes #714
- Refs #719
