### PR TITLE
chore: update accessibility service APK SHA256

### DIFF
--- a/src/constants/release.ts
+++ b/src/constants/release.ts
@@ -19,4 +19,4 @@ export const RELEASE_VERSION: string = "latest";
 export const APK_URL: string = RELEASE_VERSION === "latest"
   ? `https://github.com/kaeawc/auto-mobile/releases/latest/download/accessibility-service-debug.apk`
   : `https://github.com/kaeawc/auto-mobile/releases/download/v${RELEASE_VERSION}/accessibility-service-debug.apk`;
-export const APK_SHA256_CHECKSUM: string = "36bb186482d15fbeabe3e052dbbc2b4c4456dc4e3270487d9d0accbde93dbd43"; // Empty = skip verification (local dev only)
+export const APK_SHA256_CHECKSUM: string = "a02f7086eb4d1e5c5d1a011de3de296b1ca7af9ad72cd25dff276dc1d4d6ce98"; // Empty = skip verification (local dev only)


### PR DESCRIPTION
## Automated Checksum Update

The accessibility service APK was rebuilt on `main` with a different SHA256 checksum.

| | SHA256 |
|--|--------|
| **Previous** | `36bb186482d15fbeabe3e052dbbc2b4c4456dc4e3270487d9d0accbde93dbd43` |
| **New** | `a02f7086eb4d1e5c5d1a011de3de296b1ca7af9ad72cd25dff276dc1d4d6ce98` |

### Why did this happen?

The SHA256 changes when any of these change:
- Source code in `android/accessibility-service/src/`
- Build configuration (`build.gradle.kts`)
- Dependencies or SDK versions

### What to do

1. Review this PR to ensure the change is expected
2. Merge when ready
3. Future releases will use this checksum for APK verification

---
Auto-generated by `update-accessibility-service-sha256` workflow