### PR TITLE
feat: fallback to uiautomator when accessibility service returns incomplete hierarchy

### DIFF
--- a/android/accessibility-service/src/main/kotlin/dev/jasonpearson/automobile/accessibilityservice/ViewHierarchyExtractor.kt
+++ b/android/accessibility-service/src/main/kotlin/dev/jasonpearson/automobile/accessibilityservice/ViewHierarchyExtractor.kt
@@ -184,10 +184,24 @@ class ViewHierarchyExtractor(private val recompositionStore: RecompositionStore?
     var activeWindowKey: Int? = null
     val windowInfos = mutableListOf<WindowInfo>()
 
+    // Track whether the accessibility service hierarchy is incomplete
+    // This happens when active windows have null roots or only system UI is accessible
+    var activeWindowHasNullRoot = false
+    var hasApplicationWindow = false
+
     // Extract from each window
     for (window in windows) {
       try {
-        val rootNode = window.root ?: continue
+        val rootNode = window.root
+        if (rootNode == null) {
+          if (window.isActive) {
+            Log.w(TAG, "[HIERARCHY-DEBUG] Active window ${window.id} has null root node - accessibility service incomplete")
+            activeWindowHasNullRoot = true
+          } else {
+            Log.d(TAG, "[HIERARCHY-DEBUG] Window ${window.id} has null root node, skipping")
+          }
+          continue
+        }
         val windowLayer = window.layer
         if (window.isActive) {
           activeWindowLayer = windowLayer
@@ -204,6 +218,12 @@ class ViewHierarchyExtractor(private val recompositionStore: RecompositionStore?
               AccessibilityWindowInfo.TYPE_MAGNIFICATION_OVERLAY -> "magnification_overlay"
               else -> "unknown_${window.type}"
             }
+
+        // Track if we successfully extract from any application window
+        // Only TYPE_APPLICATION counts - IME, overlays, and system windows don't represent app content
+        if (window.type == AccessibilityWindowInfo.TYPE_APPLICATION) {
+          hasApplicationWindow = true
+        }
 
         val windowBounds = Rect()
         window.getBoundsInScreen(windowBounds)
@@ -343,8 +363,11 @@ class ViewHierarchyExtractor(private val recompositionStore: RecompositionStore?
     }
 
     if (windowEntries.isEmpty()) {
-      Log.w(TAG, "No visible windows available after filtering")
-      return ViewHierarchy(error = "No visible windows available")
+      Log.w(TAG, "[HIERARCHY-DEBUG] No visible windows available after filtering - marking as incomplete for fallback")
+      return ViewHierarchy(
+          error = "No visible windows available",
+          accessibilityServiceIncomplete = true,
+      )
     }
 
     val sortedWindowRoots =
@@ -356,6 +379,15 @@ class ViewHierarchyExtractor(private val recompositionStore: RecompositionStore?
     val accessibilityFocusedElement =
         unifiedHierarchy?.let { findAccessibilityFocusedElement(it) }
 
+    // Determine if the accessibility service hierarchy is incomplete
+    // This happens when:
+    // 1. An active window has a null root (app restricts accessibility access)
+    // 2. Only system UI windows were successfully extracted (no app windows accessible)
+    val accessibilityServiceIncomplete = activeWindowHasNullRoot || !hasApplicationWindow
+    if (accessibilityServiceIncomplete) {
+      Log.w(TAG, "[HIERARCHY-DEBUG] Accessibility service incomplete: activeWindowHasNullRoot=$activeWindowHasNullRoot, hasApplicationWindow=$hasApplicationWindow")
+    }
+
     return ViewHierarchy(
         packageName = mainPackageName,
         hierarchy = unifiedHierarchy,
@@ -363,6 +395,7 @@ class ViewHierarchyExtractor(private val recompositionStore: RecompositionStore?
         intentChooserDetected = intentChooserDetected,
         notificationPermissionDetected = notificationPermissionDetected,
         accessibilityFocusedElement = accessibilityFocusedElement,
+        accessibilityServiceIncomplete = if (accessibilityServiceIncomplete) true else null,
     )
   }
 

--- a/android/accessibility-service/src/main/kotlin/dev/jasonpearson/automobile/accessibilityservice/models/ViewHierarchy.kt
+++ b/android/accessibility-service/src/main/kotlin/dev/jasonpearson/automobile/accessibilityservice/models/ViewHierarchy.kt
@@ -18,5 +18,6 @@ data class ViewHierarchy(
     val notificationPermissionDetected: Boolean? = null,
     @SerialName("accessibility-focused-element")
     val accessibilityFocusedElement: UIElementInfo? = null, // Element with TalkBack cursor
+    val accessibilityServiceIncomplete: Boolean? = null,
     val error: String? = null, // For error cases like locked screen
 )

--- a/src/features/action/DragAndDrop.ts
+++ b/src/features/action/DragAndDrop.ts
@@ -18,6 +18,7 @@ import { Timer, defaultTimer } from "../../utils/SystemTimer";
 import { ViewHierarchy } from "../observe/ViewHierarchy";
 import { serverConfig } from "../../utils/ServerConfig";
 import { attachRawViewHierarchy } from "../../utils/viewHierarchySearch";
+import { logger } from "../../utils/logger";
 
 const PRESS_DURATION_MIN_MS = 600;
 const PRESS_DURATION_MAX_MS = 3000;
@@ -242,12 +243,27 @@ export class DragAndDrop extends BaseVisualChange {
       HIERARCHY_REFRESH_TIMEOUT_MS
     );
 
-    const rawHierarchy = syncResult
+    let rawHierarchy = syncResult
       ? this.accessibilityService.convertToViewHierarchyResult(syncResult.hierarchy)
       : null;
     if (!rawHierarchy) {
       return null;
     }
+
+    // Check if accessibility service hierarchy is incomplete and merge with uiautomator
+    if (rawHierarchy.accessibilityServiceIncomplete) {
+      logger.debug("[DRAG_AND_DROP] Accessibility service returned incomplete hierarchy, fetching uiautomator fallback");
+      try {
+        const uiautomatorHierarchy = await this.viewHierarchy.getUiAutomatorHierarchy(
+          signal,
+          !serverConfig.isRawElementSearchEnabled()
+        );
+        rawHierarchy = this.viewHierarchy.mergeHierarchies(rawHierarchy, uiautomatorHierarchy);
+      } catch (fallbackErr) {
+        logger.warn(`[DRAG_AND_DROP] Failed to get uiautomator fallback: ${fallbackErr}`);
+      }
+    }
+
     if (!serverConfig.isRawElementSearchEnabled()) {
       return rawHierarchy;
     }

--- a/src/features/action/TapOnElement.ts
+++ b/src/features/action/TapOnElement.ts
@@ -223,9 +223,24 @@ export class TapOnElement extends BaseVisualChange {
           signal,
           effectiveTimeoutMs
         );
-        const rawHierarchy = syncResult
+        let rawHierarchy = syncResult
           ? this.accessibilityService.convertToViewHierarchyResult(syncResult.hierarchy)
           : null;
+
+        // Check if accessibility service hierarchy is incomplete and merge with uiautomator
+        if (rawHierarchy?.accessibilityServiceIncomplete) {
+          logger.debug("[TAP_ON_ELEMENT] Accessibility service returned incomplete hierarchy, fetching uiautomator fallback");
+          try {
+            const uiautomatorHierarchy = await this.viewHierarchy.getUiAutomatorHierarchy(
+              signal,
+              !serverConfig.isRawElementSearchEnabled()
+            );
+            rawHierarchy = this.viewHierarchy.mergeHierarchies(rawHierarchy, uiautomatorHierarchy);
+          } catch (fallbackErr) {
+            logger.warn(`[TAP_ON_ELEMENT] Failed to get uiautomator fallback: ${fallbackErr}`);
+          }
+        }
+
         return rawHierarchy
           ? this.prepareViewHierarchyForResponse(rawHierarchy, screenSize)
           : null;

--- a/src/features/observe/AccessibilityServiceClient.ts
+++ b/src/features/observe/AccessibilityServiceClient.ts
@@ -80,6 +80,14 @@ export interface AccessibilityHierarchy {
   windows?: ViewHierarchyWindowInfo[];
   intentChooserDetected?: boolean;
   notificationPermissionDetected?: boolean;
+  /** Element with TalkBack cursor */
+  "accessibility-focused-element"?: AccessibilityNode;
+  /**
+   * True when the accessibility service couldn't fully extract the hierarchy.
+   * This happens when the active window has a null root (app restricts accessibility)
+   * or only system UI windows were accessible.
+   */
+  accessibilityServiceIncomplete?: boolean;
   error?: string;
 }
 
@@ -1909,19 +1917,29 @@ export class AccessibilityServiceClient implements AccessibilityService {
           packageName: resolvedPackageName,
           windows: accessibilityHierarchy.windows,
           intentChooserDetected: accessibilityHierarchy.intentChooserDetected,
-          notificationPermissionDetected: accessibilityHierarchy.notificationPermissionDetected
+          notificationPermissionDetected: accessibilityHierarchy.notificationPermissionDetected,
+          accessibilityServiceIncomplete: accessibilityHierarchy.accessibilityServiceIncomplete,
+          sources: ["accessibility-service"]
         } as ViewHierarchyResult;
       }
 
       // Convert the accessibility node format to match the existing XML-based format
       const convertedHierarchy = this.convertAccessibilityNode(hierarchyToConvert);
 
+      // Convert accessibility-focused element if present
+      const accessibilityFocusedElement = accessibilityHierarchy["accessibility-focused-element"]
+        ? this.convertAccessibilityNode(accessibilityHierarchy["accessibility-focused-element"])
+        : undefined;
+
       const result: ViewHierarchyResult = {
-        hierarchy: convertedHierarchy,
-        packageName: resolvedPackageName,
-        windows: accessibilityHierarchy.windows,
-        intentChooserDetected: accessibilityHierarchy.intentChooserDetected,
-        notificationPermissionDetected: accessibilityHierarchy.notificationPermissionDetected
+        "hierarchy": convertedHierarchy,
+        "packageName": resolvedPackageName,
+        "windows": accessibilityHierarchy.windows,
+        "intentChooserDetected": accessibilityHierarchy.intentChooserDetected,
+        "notificationPermissionDetected": accessibilityHierarchy.notificationPermissionDetected,
+        "accessibility-focused-element": accessibilityFocusedElement,
+        "accessibilityServiceIncomplete": accessibilityHierarchy.accessibilityServiceIncomplete,
+        "sources": ["accessibility-service"]
       };
 
       const duration = Date.now() - startTime;

--- a/src/features/observe/ViewHierarchy.ts
+++ b/src/features/observe/ViewHierarchy.ts
@@ -12,7 +12,7 @@ import { ElementUtils } from "../utility/ElementUtils";
 import { readdirAsync, readFileAsync, statAsync, writeFileAsync } from "../../utils/io";
 import { ScreenshotUtils } from "../../utils/screenshot/ScreenshotUtils";
 import { DEFAULT_FUZZY_MATCH_TOLERANCE_PERCENT } from "../../utils/constants";
-import { ViewHierarchyQueryOptions } from "../../models";
+import { ViewHierarchyQueryOptions, HierarchySource } from "../../models";
 import { AccessibilityServiceClient } from "./AccessibilityServiceClient";
 import { WebDriverAgent } from "../../utils/ios-cmdline-tools/WebDriverAgent";
 import { PerformanceTracker, NoOpPerformanceTracker } from "../../utils/PerformanceTracker";
@@ -390,6 +390,97 @@ export class ViewHierarchy {
   }
 
   /**
+   * Merge accessibility service hierarchy with uiautomator hierarchy.
+   * When accessibility service returns incomplete data (e.g., active window has null root),
+   * we supplement it with uiautomator data.
+   *
+   * @param accessibilityHierarchy - Hierarchy from accessibility service
+   * @param uiautomatorHierarchy - Hierarchy from uiautomator
+   * @returns Merged hierarchy with combined root nodes
+   */
+  mergeHierarchies(
+    accessibilityHierarchy: ViewHierarchyResult,
+    uiautomatorHierarchy: ViewHierarchyResult
+  ): ViewHierarchyResult {
+    const a11yNode = accessibilityHierarchy.hierarchy?.node;
+    const uiautomatorNode = uiautomatorHierarchy.hierarchy?.node;
+
+    // If one is missing, use the other
+    if (!a11yNode && !uiautomatorNode) {
+      return {
+        ...accessibilityHierarchy,
+        hierarchy: { error: "No hierarchy data available from either source" },
+        sources: ["accessibility-service", "uiautomator"]
+      };
+    }
+
+    if (!a11yNode) {
+      return {
+        ...uiautomatorHierarchy,
+        // Preserve metadata from accessibility service
+        "packageName": accessibilityHierarchy.packageName || uiautomatorHierarchy.packageName,
+        "windows": accessibilityHierarchy.windows,
+        "intentChooserDetected": accessibilityHierarchy.intentChooserDetected,
+        "notificationPermissionDetected": accessibilityHierarchy.notificationPermissionDetected,
+        "accessibility-focused-element": accessibilityHierarchy["accessibility-focused-element"],
+        "accessibilityServiceIncomplete": true,
+        "sources": ["accessibility-service", "uiautomator"]
+      };
+    }
+
+    if (!uiautomatorNode) {
+      return {
+        ...accessibilityHierarchy,
+        sources: ["accessibility-service", "uiautomator"]
+      };
+    }
+
+    // Both have data - combine root nodes under a wrapper
+    // This creates a unified hierarchy that contains both data sources
+    const combinedNodes: any[] = [];
+
+    // Add accessibility service nodes
+    if (Array.isArray(a11yNode)) {
+      combinedNodes.push(...a11yNode);
+    } else {
+      combinedNodes.push(a11yNode);
+    }
+
+    // Add uiautomator nodes
+    if (Array.isArray(uiautomatorNode)) {
+      combinedNodes.push(...uiautomatorNode);
+    } else {
+      combinedNodes.push(uiautomatorNode);
+    }
+
+    logger.debug(`[VIEW_HIERARCHY] Merged hierarchies: ${combinedNodes.length} root nodes from both sources`);
+
+    return {
+      ...accessibilityHierarchy,
+      hierarchy: {
+        node: combinedNodes.length === 1 ? combinedNodes[0] : combinedNodes
+      },
+      accessibilityServiceIncomplete: true,
+      sources: ["accessibility-service", "uiautomator"]
+    };
+  }
+
+  /**
+   * Get uiautomator hierarchy for fallback/merge scenarios.
+   * This is a public method that can be used by other components.
+   */
+  async getUiAutomatorHierarchy(
+    signal?: AbortSignal,
+    filter: boolean = true
+  ): Promise<ViewHierarchyResult> {
+    const result = await this._getViewHierarchyWithoutCache(signal, filter);
+    return {
+      ...result,
+      sources: ["uiautomator"] as HierarchySource[]
+    };
+  }
+
+  /**
    * Retrieve the view hierarchy of the current screen
    * @param queryOptions - Optional query options for targeted element retrieval
    * @param perf - Performance tracker for timing data
@@ -421,6 +512,24 @@ export class ViewHierarchy {
         signal
       );
       if (accessibilityHierarchy) {
+        // Check if accessibility service hierarchy is incomplete
+        if (accessibilityHierarchy.accessibilityServiceIncomplete) {
+          logger.info("[VIEW_HIERARCHY] Accessibility service returned incomplete hierarchy, fetching uiautomator fallback");
+          try {
+            const uiautomatorHierarchy = await perf.track("uiautomatorFallback", () =>
+              this._getViewHierarchyWithoutCache(signal, !useRawElementSearch)
+            );
+            const mergedHierarchy = this.mergeHierarchies(accessibilityHierarchy, uiautomatorHierarchy);
+            perf.end();
+            const accessibilityDuration = Date.now() - startTime;
+            logger.info(`[VIEW_HIERARCHY] Retrieved merged hierarchy (a11y + uiautomator) in ${accessibilityDuration}ms`);
+            return this.prepareHierarchyForResponse(mergedHierarchy);
+          } catch (fallbackErr) {
+            logger.warn(`[VIEW_HIERARCHY] Failed to get uiautomator fallback: ${fallbackErr}`);
+            // Fall through to return incomplete accessibility hierarchy
+          }
+        }
+
         perf.end();
         const accessibilityDuration = Date.now() - startTime;
         logger.debug(`[VIEW_HIERARCHY] Successfully retrieved hierarchy from accessibility service in ${accessibilityDuration}ms`);

--- a/src/models/ViewHierarchyResult.ts
+++ b/src/models/ViewHierarchyResult.ts
@@ -2,6 +2,11 @@ import { ElementBounds } from "./ElementBounds";
 import { RecompositionMetrics, RecompositionNodeInfo } from "./Recomposition";
 
 /**
+ * Hierarchy data sources that contributed to the result
+ */
+export type HierarchySource = "accessibility-service" | "uiautomator";
+
+/**
  * Represents the ViewHierarchy dump result from a device.
  */
 export interface ViewHierarchyResult {
@@ -18,6 +23,16 @@ export interface ViewHierarchyResult {
   notificationPermissionDetected?: boolean;
   /** Element with TalkBack/accessibility cursor (Android only) */
   "accessibility-focused-element"?: ViewHierarchyNode;
+  /**
+   * True when the accessibility service couldn't fully extract the hierarchy.
+   * This indicates that uiautomator fallback may have been used.
+   */
+  accessibilityServiceIncomplete?: boolean;
+  /**
+   * Sources that contributed to this hierarchy result.
+   * When both sources are present, the hierarchy was merged from accessibility service + uiautomator.
+   */
+  sources?: HierarchySource[];
 }
 
 export interface Hierarchy {


### PR DESCRIPTION
## Summary

- Detects when accessibility service returns incomplete hierarchy (null root for active window)
- Automatically fetches uiautomator hierarchy as fallback and merges results
- Preserves accessibility service metadata (windows, packageName, etc.) in merged result
- Updates element selection operations (tapOn, dragAndDrop) to use fallback during refresh

## Detection Criteria

The `accessibilityServiceIncomplete` flag is set when:
1. The active window has a null root (app restricts accessibility access)
2. Only system UI windows were accessible (no app windows extracted)

## Test plan

- [ ] Navigate to Settings > Security & Privacy on Android
- [ ] Call `observe()` - should return full screen content (not just status bar)
- [ ] Call `tapOn({ text: "Device unlock" })` - should successfully find and tap element
- [ ] Verify logs show fallback being triggered when on restricted screens

Fixes #775

🤖 Generated with [Claude Code](https://claude.com/claude-code)