### PR TITLE
fix: improve MCP resource URI guidance and error messages

### DIFF
--- a/src/server/appTools.ts
+++ b/src/server/appTools.ts
@@ -78,12 +78,23 @@ export function registerAppTools(
   const listAppsHandler = async () => {
     const { toolResponseFormatter } = getListAppsToolDependencies();
     return toolResponseFormatter.createJSONToolResponse({
-      message: "To list apps, query the MCP resource 'automobile:apps' with appropriate filters. " +
-        "For device-specific apps, use 'automobile:devices/{deviceId}/apps'.",
+      message: "To list installed apps, follow this workflow:\n\n" +
+        "1. Get available devices:\n" +
+        "   Read resource: automobile:devices/booted\n\n" +
+        "2. List apps for a specific device (using deviceId from step 1):\n" +
+        "   Read resource: automobile:devices/{deviceId}/apps\n" +
+        "   Or query format: automobile:apps?deviceId={deviceId}\n\n" +
+        "Optional query filters:\n" +
+        "  - type=user|system (default: user)\n" +
+        "  - search=<term> (filter by package name)\n" +
+        "  - profile=<userId> (filter by user profile)\n\n" +
+        "Example: automobile:apps?deviceId=emulator-5554&type=system&search=google",
       resources: [
-        APPS_RESOURCE_URIS.BASE,
-        APP_RESOURCE_TEMPLATES.DEVICE_APPS
-      ]
+        "automobile:devices/booted",
+        APP_RESOURCE_TEMPLATES.DEVICE_APPS,
+        APPS_RESOURCE_URIS.BASE + "?deviceId={deviceId}"
+      ],
+      note: "All resource URIs use the 'automobile:' prefix. URIs like 'android://apps' are not supported."
     });
   };
 

--- a/src/server/deviceTools.ts
+++ b/src/server/deviceTools.ts
@@ -99,31 +99,31 @@ export function registerDeviceTools() {
   };
 
   const listDevicesHandler = async (args: ListDevicesArgs) => {
-    if (args.platform) {
-      const bootedResource = `${BOOTED_DEVICE_RESOURCE_URIS.ALL_BOOTED}/${args.platform}`;
-      const imagesResource = `${DEVICE_IMAGE_RESOURCE_URIS.ALL_IMAGES}/${args.platform}`;
-
-      return createJSONToolResponse({
-        message: `To list ${args.platform} devices, query the MCP resources '${bootedResource}' for running devices or '${imagesResource}' for available device images. For all devices, use '${BOOTED_DEVICE_RESOURCE_URIS.ALL_BOOTED}' or '${DEVICE_IMAGE_RESOURCE_URIS.ALL_IMAGES}'. Templates are also available: '${BOOTED_DEVICE_RESOURCE_URIS.PLATFORM_TEMPLATE}' and '${DEVICE_IMAGE_RESOURCE_URIS.PLATFORM_TEMPLATE}'.`,
-        resources: [
-          bootedResource,
-          imagesResource,
-          BOOTED_DEVICE_RESOURCE_URIS.ALL_BOOTED,
-          DEVICE_IMAGE_RESOURCE_URIS.ALL_IMAGES,
-          BOOTED_DEVICE_RESOURCE_URIS.PLATFORM_TEMPLATE,
-          DEVICE_IMAGE_RESOURCE_URIS.PLATFORM_TEMPLATE
-        ]
-      });
-    }
+    const platformFilter = args.platform ? ` (${args.platform} only)` : "";
 
     return createJSONToolResponse({
-      message: `To list devices, query the MCP resources '${BOOTED_DEVICE_RESOURCE_URIS.ALL_BOOTED}' for running devices or '${DEVICE_IMAGE_RESOURCE_URIS.ALL_IMAGES}' for available device images. For platform-specific queries, use '${BOOTED_DEVICE_RESOURCE_URIS.PLATFORM_TEMPLATE}' or '${DEVICE_IMAGE_RESOURCE_URIS.PLATFORM_TEMPLATE}'.`,
+      message: `To list devices${platformFilter}, use these MCP resources:\n\n` +
+        "RUNNING DEVICES (booted/active):\n" +
+        `  - automobile:devices/booted - All running devices\n` +
+        `  - automobile:devices/booted/android - Android devices only\n` +
+        `  - automobile:devices/booted/ios - iOS simulators only\n\n` +
+        "AVAILABLE DEVICE IMAGES (can be started):\n" +
+        `  - automobile:devices/images - All available images\n` +
+        `  - automobile:devices/images/android - Android AVDs\n` +
+        `  - automobile:devices/images/ios - iOS simulator runtimes\n\n` +
+        "WORKFLOW:\n" +
+        "  1. Read 'automobile:devices/booted' to see running devices and get deviceId\n" +
+        "  2. Use deviceId with other resources (e.g., automobile:devices/{deviceId}/apps)\n" +
+        "  3. To start a new device, read 'automobile:devices/images' then use startDevice tool",
       resources: [
         BOOTED_DEVICE_RESOURCE_URIS.ALL_BOOTED,
+        `${BOOTED_DEVICE_RESOURCE_URIS.ALL_BOOTED}/android`,
+        `${BOOTED_DEVICE_RESOURCE_URIS.ALL_BOOTED}/ios`,
         DEVICE_IMAGE_RESOURCE_URIS.ALL_IMAGES,
-        BOOTED_DEVICE_RESOURCE_URIS.PLATFORM_TEMPLATE,
-        DEVICE_IMAGE_RESOURCE_URIS.PLATFORM_TEMPLATE
-      ]
+        `${DEVICE_IMAGE_RESOURCE_URIS.ALL_IMAGES}/android`,
+        `${DEVICE_IMAGE_RESOURCE_URIS.ALL_IMAGES}/ios`
+      ],
+      note: "All resource URIs use the 'automobile:' prefix. URIs like 'android://devices' are not supported."
     });
   };
 

--- a/src/server/resourceRegistry.ts
+++ b/src/server/resourceRegistry.ts
@@ -165,6 +165,19 @@ class ResourceRegistryClass {
     server.server.setRequestHandler(ReadResourceRequestSchema, async request => {
       const { uri } = request.params;
 
+      // Check for common incorrect URI schemes and provide helpful error messages
+      const schemeMatch = uri.match(/^([a-z][a-z0-9+.-]*):\/?\/?/i);
+      if (schemeMatch) {
+        const scheme = schemeMatch[1].toLowerCase();
+        if (scheme !== "automobile") {
+          const suggestedUri = uri.replace(/^[a-z][a-z0-9+.-]*:\/?\/?/i, "automobile:");
+          throw new Error(
+            `Unknown URI scheme '${scheme}://'. AutoMobile resources use the 'automobile:' prefix. ` +
+            `Try: ${suggestedUri}`
+          );
+        }
+      }
+
       // First, try to find an exact match resource
       const resource = this.getResource(uri);
       if (resource) {
@@ -183,7 +196,17 @@ class ResourceRegistryClass {
         };
       }
 
-      throw new Error(`Resource not found: ${uri}`);
+      // Provide helpful error message with available resource patterns
+      throw new Error(
+        `Resource not found: ${uri}\n\n` +
+        `Available resource patterns:\n` +
+        `  - automobile:devices/booted - List all booted devices\n` +
+        `  - automobile:devices/booted/{platform} - List devices by platform (android|ios)\n` +
+        `  - automobile:devices/{deviceId}/apps - List apps for a device\n` +
+        `  - automobile:apps?deviceId={deviceId} - Query apps with filters\n` +
+        `  - automobile:observation/latest - Latest screen observation\n\n` +
+        `Use the listApps tool for detailed guidance on listing apps.`
+      );
     });
 
     // Set handler for listing resource templates

--- a/test/server/appTools.listApps.test.ts
+++ b/test/server/appTools.listApps.test.ts
@@ -80,12 +80,23 @@ describe("listApps tool", () => {
     expect(fakeToolUtils.getJSONResponseCount()).toBe(1);
     const payload = fakeToolUtils.getLastJSONResponse();
     expect(payload).toEqual({
-      message: "To list apps, query the MCP resource 'automobile:apps' with appropriate filters. " +
-        "For device-specific apps, use 'automobile:devices/{deviceId}/apps'.",
+      message: "To list installed apps, follow this workflow:\n\n" +
+        "1. Get available devices:\n" +
+        "   Read resource: automobile:devices/booted\n\n" +
+        "2. List apps for a specific device (using deviceId from step 1):\n" +
+        "   Read resource: automobile:devices/{deviceId}/apps\n" +
+        "   Or query format: automobile:apps?deviceId={deviceId}\n\n" +
+        "Optional query filters:\n" +
+        "  - type=user|system (default: user)\n" +
+        "  - search=<term> (filter by package name)\n" +
+        "  - profile=<userId> (filter by user profile)\n\n" +
+        "Example: automobile:apps?deviceId=emulator-5554&type=system&search=google",
       resources: [
-        APPS_RESOURCE_URIS.BASE,
-        APP_RESOURCE_TEMPLATES.DEVICE_APPS
-      ]
+        "automobile:devices/booted",
+        APP_RESOURCE_TEMPLATES.DEVICE_APPS,
+        APPS_RESOURCE_URIS.BASE + "?deviceId={deviceId}"
+      ],
+      note: "All resource URIs use the 'automobile:' prefix. URIs like 'android://apps' are not supported."
     });
 
     const content = result.content?.[0];

--- a/test/server/deviceTools.listDevices.test.ts
+++ b/test/server/deviceTools.listDevices.test.ts
@@ -80,16 +80,26 @@ describe("listDevices tool", () => {
     expect(response.content?.[0]?.type).toBe("text");
     const payload = JSON.parse(response.content?.[0]?.text ?? "{}");
 
+    // Verify resources include all platform-specific URIs
     expect(payload.resources).toEqual([
       "automobile:devices/booted",
+      "automobile:devices/booted/android",
+      "automobile:devices/booted/ios",
       "automobile:devices/images",
-      "automobile:devices/booted/{platform}",
-      "automobile:devices/images/{platform}"
+      "automobile:devices/images/android",
+      "automobile:devices/images/ios"
     ]);
+
+    // Verify the message contains workflow guidance
+    expect(payload.message).toContain("RUNNING DEVICES");
+    expect(payload.message).toContain("AVAILABLE DEVICE IMAGES");
+    expect(payload.message).toContain("WORKFLOW");
     expect(payload.message).toContain("automobile:devices/booted");
     expect(payload.message).toContain("automobile:devices/images");
-    expect(payload.message).toContain("automobile:devices/booted/{platform}");
-    expect(payload.message).toContain("automobile:devices/images/{platform}");
+
+    // Verify note about URI prefix
+    expect(payload.note).toContain("automobile:");
+    expect(payload.note).toContain("android://devices");
 
     expect(fakeDeviceUtils.getExecutedOperations()).toHaveLength(0);
   });
@@ -106,18 +116,20 @@ describe("listDevices tool", () => {
     expect(response.content?.[0]?.type).toBe("text");
     const payload = JSON.parse(response.content?.[0]?.text ?? "{}");
 
+    // Same resources regardless of platform filter (guidance tool shows all options)
     expect(payload.resources).toEqual([
-      "automobile:devices/booted/android",
-      "automobile:devices/images/android",
       "automobile:devices/booted",
+      "automobile:devices/booted/android",
+      "automobile:devices/booted/ios",
       "automobile:devices/images",
-      "automobile:devices/booted/{platform}",
-      "automobile:devices/images/{platform}"
+      "automobile:devices/images/android",
+      "automobile:devices/images/ios"
     ]);
+
+    // Message should include platform filter indicator
+    expect(payload.message).toContain("android only");
     expect(payload.message).toContain("automobile:devices/booted/android");
     expect(payload.message).toContain("automobile:devices/images/android");
-    expect(payload.message).toContain("automobile:devices/booted/{platform}");
-    expect(payload.message).toContain("automobile:devices/images/{platform}");
 
     expect(fakeDeviceUtils.getExecutedOperations()).toHaveLength(0);
   });


### PR DESCRIPTION
## Summary

Fixes #804

- Improve `listApps` tool guidance with step-by-step workflow showing how to discover devices first, then query apps
- Improve `listDevices` tool guidance with clear categories (running devices vs available images) and workflow
- Add helpful error message when agents use incorrect URI prefixes (e.g., `android://apps`) with suggested correction
- Enhance "resource not found" error to list available resource patterns

## Changes

**listApps tool now returns:**
```
To list installed apps, follow this workflow:

1. Get available devices:
   Read resource: automobile:devices/booted

2. List apps for a specific device (using deviceId from step 1):
   Read resource: automobile:devices/{deviceId}/apps
   Or query format: automobile:apps?deviceId={deviceId}

Optional query filters:
  - type=user|system (default: user)
  - search=<term> (filter by package name)
  - profile=<userId> (filter by user profile)
```

**Invalid URI prefix error:**
```
Unknown URI scheme 'android://'. AutoMobile resources use the 'automobile:' prefix. Try: automobile:apps
```

**Resource not found error:**
```
Resource not found: automobile:foo

Available resource patterns:
  - automobile:devices/booted - List all booted devices
  - automobile:devices/booted/{platform} - List devices by platform
  - automobile:devices/{deviceId}/apps - List apps for a device
  - automobile:apps?deviceId={deviceId} - Query apps with filters
  - automobile:observation/latest - Latest screen observation

Use the listApps tool for detailed guidance on listing apps.
```

## Test plan

- [x] Build passes
- [x] Tests updated and passing
- [x] Lint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)