### PR TITLE
Upgrade Bun from 1.3.5 to 1.3.6 to fix CI segfault crashes

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: 1.3.5
+          bun-version: 1.3.6
 
       - name: Install ripgrep
         run: |

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -548,7 +548,7 @@ jobs:
       - name: "Setup Bun"
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: 1.3.5
+          bun-version: 1.3.6
 
       - name: "Extract version from package.json"
         id: package-version

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: 1.3.5
+          bun-version: 1.3.6
 
       - name: Set up Node.js
         uses: actions/setup-node@v4

--- a/Dockerfile
+++ b/Dockerfile
@@ -86,7 +86,7 @@ SHELL ["/bin/bash", "-exo", "pipefail", "-c"]
 
 # Install Bun - all-in-one JavaScript runtime and package manager
 # Check for updates: https://github.com/oven-sh/bun/releases
-ENV BUN_VERSION=1.3.5
+ENV BUN_VERSION=1.3.6
 RUN curl -fsSL "https://bun.sh/install" | bash -s "bun-v${BUN_VERSION}" \
     && mv /root/.bun/bin/bun /usr/local/bin/bun \
     && chmod +x /usr/local/bin/bun
@@ -191,7 +191,7 @@ RUN apk --no-cache add \
 SHELL ["/bin/bash", "-exo", "pipefail", "-c"]
 
 # Install Bun in runtime stage
-ENV BUN_VERSION=1.3.5
+ENV BUN_VERSION=1.3.6
 RUN curl -fsSL "https://bun.sh/install" | bash -s "bun-v${BUN_VERSION}" \
     && mv /root/.bun/bin/bun /usr/local/bin/bun \
     && chmod +x /usr/local/bin/bun

--- a/package.json
+++ b/package.json
@@ -31,9 +31,9 @@
     "prepublishOnly": "cp README.md README.md.backup && bun scripts/npm/transform-readme.js",
     "postpublish": "mv README.md.backup README.md || true"
   },
-  "packageManager": "bun@1.3.5",
+  "packageManager": "bun@1.3.6",
   "engines": {
-    "bun": ">=1.3.5"
+    "bun": ">=1.3.6"
   },
   "keywords": [
     "adb",


### PR DESCRIPTION
Bun v1.3.5 causes intermittent segmentation faults after tests complete successfully, failing CI jobs. This upgrades to v1.3.6 which includes bug fixes for runtime crashes.

Closes #815 