### PR TITLE
chore: update accessibility service APK SHA256

### DIFF
--- a/src/constants/release.ts
+++ b/src/constants/release.ts
@@ -19,4 +19,4 @@ export const RELEASE_VERSION: string = "latest";
 export const APK_URL: string = RELEASE_VERSION === "latest"
   ? `https://github.com/kaeawc/auto-mobile/releases/latest/download/accessibility-service-debug.apk`
   : `https://github.com/kaeawc/auto-mobile/releases/download/v${RELEASE_VERSION}/accessibility-service-debug.apk`;
-export const APK_SHA256_CHECKSUM: string = "f262deede08ea2fc371c3af8444d0d0c928b783aef5f2efe1b36616cfc9de429"; // Empty = skip verification (local dev only)
+export const APK_SHA256_CHECKSUM: string = "a80b4e0101a66c47828b958aac882abe05824fe51393bb4cf2eacc82fa422169"; // Empty = skip verification (local dev only)


### PR DESCRIPTION
## Automated Checksum Update

The accessibility service APK was rebuilt on `main` with a different SHA256 checksum.

| | SHA256 |
|--|--------|
| **Previous** | `f262deede08ea2fc371c3af8444d0d0c928b783aef5f2efe1b36616cfc9de429` |
| **New** | `a80b4e0101a66c47828b958aac882abe05824fe51393bb4cf2eacc82fa422169` |

### Why did this happen?

The SHA256 changes when any of these change:
- Source code in `android/accessibility-service/src/`
- Build configuration (`build.gradle.kts`)
- Dependencies or SDK versions

### What to do

1. Review this PR to ensure the change is expected
2. Merge when ready
3. Future releases will use this checksum for APK verification

---
Auto-generated by `update-accessibility-service-sha256` workflow