### PR TITLE
feat: add automatic retry for flaky emulator tests in CI

### DIFF
--- a/.github/actions/android-emulator/action.yml
+++ b/.github/actions/android-emulator/action.yml
@@ -151,7 +151,11 @@ runs:
         echo "RELEASE_KEY_ALIAS=${{ inputs.release-key-alias }}" >> $GITHUB_ENV
         echo "RELEASE_KEY_PASSWORD=${{ inputs.release-key-password }}" >> $GITHUB_ENV
 
-    - name: Run Emulator
+    # Run emulator with automatic retry for infrastructure flakiness (#808)
+    # Handles: adb device offline, device not found, adb server killed, emulator boot failures
+    - name: Run Emulator (Attempt 1)
+      id: emulator-attempt-1
+      continue-on-error: true
       uses: reactivecircus/android-emulator-runner@v2.35.0
       with:
         api-level: ${{ inputs.api_level }}
@@ -162,3 +166,32 @@ runs:
         force-avd-creation: false
         emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
         disable-animations: false
+
+    - name: Run Emulator (Retry)
+      id: emulator-attempt-2
+      if: steps.emulator-attempt-1.outcome == 'failure'
+      uses: reactivecircus/android-emulator-runner@v2.35.0
+      with:
+        api-level: ${{ inputs.api_level }}
+        arch: ${{ inputs.arch }}
+        target: ${{ inputs.target }}
+        script: ../scripts/android/run-emulator-tests.sh "${{ inputs.accessibility-apk-path }}" "${{ inputs.script }}"
+        working-directory: ${{ inputs.working-directory }}
+        force-avd-creation: false
+        emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
+        disable-animations: false
+
+    - name: Verify Emulator Tests Passed
+      if: always()
+      shell: ${{ inputs.shell }}
+      run: |
+        if [[ "${{ steps.emulator-attempt-1.outcome }}" == "success" ]]; then
+          echo "✓ Emulator tests passed on first attempt"
+          exit 0
+        elif [[ "${{ steps.emulator-attempt-2.outcome }}" == "success" ]]; then
+          echo "✓ Emulator tests passed on retry (infrastructure flakiness detected)"
+          exit 0
+        else
+          echo "✗ Emulator tests failed after retry"
+          exit 1
+        fi

--- a/scripts/android/run-emulator-tests.sh
+++ b/scripts/android/run-emulator-tests.sh
@@ -69,13 +69,22 @@ print_warning() {
 }
 
 # Retry function with exponential backoff for transient failures
-# Detects known transient error patterns (403, timeout, connection issues)
+# Detects known transient error patterns:
+# - Network/HTTP errors: 403, timeout, connection issues
+# - Emulator/ADB errors: device offline, device not found, adb server killed (#808)
 retry_with_backoff() {
   local max_attempts="${RETRY_MAX_ATTEMPTS:-3}"
   local initial_delay="${RETRY_INITIAL_DELAY:-10}"
   local delay=$initial_delay
   local attempt=1
   local exit_code=0
+
+  # Transient error patterns that warrant retry
+  # Network/HTTP errors
+  local network_errors="status code 403|Forbidden|Could not resolve|timeout|Connection refused|Connection reset|ETIMEDOUT|ECONNRESET|503 Service Unavailable|502 Bad Gateway"
+  # Emulator/ADB infrastructure errors (#808)
+  local emulator_errors="device offline|device not found|adb server|AdbHostServer|emulator: ERROR|waiting for device|cannot connect to daemon"
+  local transient_pattern="($network_errors|$emulator_errors)"
 
   while [ "$attempt" -le "$max_attempts" ]; do
     echo ""
@@ -96,7 +105,7 @@ retry_with_backoff() {
     fi
 
     # Check if this is a transient/retryable error
-    if echo "$output" | grep -qE "(status code 403|Forbidden|Could not resolve|timeout|Connection refused|Connection reset|ETIMEDOUT|ECONNRESET|503 Service Unavailable|502 Bad Gateway)"; then
+    if echo "$output" | grep -qiE "$transient_pattern"; then
       if [ "$attempt" -lt "$max_attempts" ]; then
         print_warning "Transient error detected (attempt $attempt/$max_attempts)"
         echo "Retrying in ${delay}s with exponential backoff..."
@@ -313,10 +322,14 @@ echo ""
 echo "Retry configuration:"
 echo "  Max attempts: ${RETRY_MAX_ATTEMPTS:-3}"
 echo "  Initial delay: ${RETRY_INITIAL_DELAY:-10}s (doubles on each retry)"
-echo "  Retryable errors: 403, timeout, connection issues"
+echo "  Retryable errors:"
+echo "    - Network: 403, timeout, connection refused/reset"
+echo "    - Emulator: device offline, device not found, adb server issues"
 echo ""
 
-# Use retry_with_backoff to handle transient CI failures (Maven 403, network issues)
+# Use retry_with_backoff to handle transient CI failures:
+# - Network issues: Maven 403, DNS failures, connection timeouts
+# - Emulator issues: device offline, device not found, adb server problems (#808)
 # The function will retry up to 3 times with exponential backoff for known transient errors
 # but will fail immediately for actual test failures or code issues
 retry_with_backoff eval "$TEST_SCRIPT"


### PR DESCRIPTION
## Summary

- Add retry mechanism to `android-emulator` composite action with 1 automatic retry on failure
- Expand `retry_with_backoff()` in `run-emulator-tests.sh` to detect emulator-specific errors

## Error Patterns Handled

**Emulator/ADB infrastructure errors:**
- `adb: device offline`
- `error: device not found`
- `adb server killed/crashed`
- `emulator: ERROR` (AdbHostServer, etc.)
- `waiting for device` / `cannot connect to daemon`

**Network errors (existing):**
- 403, Forbidden
- Timeout, Connection refused/reset
- 503 Service Unavailable, 502 Bad Gateway

## Retry Strategy

Two-level approach:
1. **Script level**: Retries test execution while emulator is running (up to 3 attempts with exponential backoff)
2. **Action level**: Restarts entire emulator on infrastructure failure (1 immediate retry)

## Test plan

- [ ] Verify PR CI passes with new retry logic
- [ ] Real test failures still fail the build (not retried indefinitely)
- [ ] Transient emulator errors trigger retry and pass on subsequent attempt

Closes #808

🤖 Generated with [Claude Code](https://claude.ai/code)