### PR TITLE
docs: improve documentation based on review feedback

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,10 +1,12 @@
 # Overview
 
-AutoMobile is a suite of mobile automation tools that can integrate into your AI agent of choice. It can be an assistant to enable individuals or empower teams to deliver better experiences. It does all of this with the [design principals](design-docs/#design-principles) that high quality, performant, and accessible workflows are necessary to creating good software.
+AutoMobile is a suite of mobile automation tools that can integrate into your AI agent of choice. It can be an assistant to enable individuals or empower teams to deliver better experiences. It does all of this with the [design principles](design-docs/#design-principles) that high quality, performant, and accessible workflows are necessary to creating good software.
 
 ![Setting an alarm in the Clock app](img/clock-app-demo.gif)
+*Demo: An AI agent navigating to the Clock app, opening the alarm tab, and creating a new alarm.*
 
 ![Searching YouTube for a video](img/youtube-search.gif)
+*Demo: An AI agent opening YouTube, entering a search query, and browsing the results.*
 
 ## Get Started
 

--- a/docs/using/perf-analysis/screen-transition.md
+++ b/docs/using/perf-analysis/screen-transition.md
@@ -59,13 +59,13 @@ Target metrics:
 For detailed transition analysis, use Android's native tools:
 
 - **Perfetto**: System-wide tracing with GPU/CPU timelines
-  - See [Perfetto UI](https://ui.perfetto.dev/)
+    - See [Perfetto UI](https://ui.perfetto.dev/)
 
 - **Jetpack Compose**: Built-in composition tracing
-  - See [Compose Performance](https://developer.android.com/jetpack/compose/performance)
+    - See [Compose Performance](https://developer.android.com/jetpack/compose/performance)
 
 - **Systrace**: View rendering pipeline details
-  - See [Systrace Guide](https://developer.android.com/topic/performance/tracing/command-line)
+    - See [Systrace Guide](https://developer.android.com/topic/performance/tracing/command-line)
 
 ## Best Practices
 

--- a/docs/using/perf-analysis/scroll-framerate.md
+++ b/docs/using/perf-analysis/scroll-framerate.md
@@ -9,7 +9,7 @@ Scroll performance is critical to user experience. Janky scrolling is one of the
 AutoMobile collects frame rendering metrics during scroll interactions:
 
 - **Frame Time Percentiles**: P50, P90, P95, P99 render times in milliseconds
-- **Jank Indicators**: Missed vsync count, slow UI thread count, frame deadline misses
+- **Jank Counts**: `missedVsyncCount`, `slowUiThreadCount`, `frameDeadlineMissedCount`
 - **FPS Calculation**: Average frames per second during scrolling
 - **UI Stability**: Time until rendering stabilizes after scroll completes
 - **Frame Drops**: Total count of dropped or janky frames during interaction
@@ -25,17 +25,17 @@ Scroll through the product list and measure the framerate
 The agent will:
 1. Navigate to the list
 2. Perform scroll gestures
-3. Measure FPS using dumpsys gfxinfo
+3. Measure FPS using `dumpsys gfxinfo`
 4. Report performance metrics
 
-## Performance Metrics
+## Performance Thresholds
 
-AutoMobile tracks:
+Target metrics for smooth scrolling:
 
-- **Average FPS**: Frames per second during scrolling
-- **Frame Drops**: Number of dropped/janky frames
-- **Render Times**: P50, P90, P99 frame render times
-- **UI Idle Detection**: When UI becomes stable
+- **Average FPS**: > 55 FPS (ideally 60 FPS)
+- **Frame Time P90**: < 16ms (maintains 60 FPS)
+- **Frame Time P99**: < 20ms
+- **Jank Counts**: 0 for smooth scrolling
 
 ## Best Practices
 

--- a/docs/using/perf-analysis/startup.md
+++ b/docs/using/perf-analysis/startup.md
@@ -10,8 +10,11 @@ App startup performance affects user experience and app store ratings. AutoMobil
 
 - **Time to First Frame**: How quickly the first screen renders
 - **Time to Interactive**: When the UI becomes responsive
-- **Cold Start**: Launch from terminated state
-- **Warm Start**: Launch from background state
+
+These metrics can be measured under different launch scenarios:
+
+- **Cold Start**: Launch from terminated state (no process running)
+- **Warm Start**: Launch when app is in background (process still alive)
 
 ## Example Workflow
 
@@ -30,7 +33,7 @@ The agent will:
 ## Best Practices
 
 - **Baseline First**: Measure current performance before optimizing
-- **Test Cold Starts**: Most representative of user experience
+- **Test Both Scenarios**: Cold starts matter for first-time users; warm starts may be more common for returning users
 - **Real Devices**: Emulators don't reflect real performance
 - **Consistent Conditions**: Same data state, same device, same network
 

--- a/docs/using/reproducting-bugs.md
+++ b/docs/using/reproducting-bugs.md
@@ -13,7 +13,9 @@ Use AutoMobile to systematically reproduce bugs and create reproducible test cas
 
 When you receive a bug report, ask your AI agent:
 
-> Here is a bug report I'm trying to reproduce and provide specific steps for. When you encounter a defect or notice something off, highlight it, especially if it will help reproduce the bug. If reproduced take a device snapshot to make further reproduction and debugging easier. /details
+> Here is a bug report I'm trying to reproduce and provide specific steps for. When you encounter a defect or notice something off, highlight it, especially if it will help reproduce the bug. If reproduced take a device snapshot to make further reproduction and debugging easier.
+>
+> <bug-report-details-here>
 
 The agent will:
 

--- a/docs/using/ui-tests.md
+++ b/docs/using/ui-tests.md
@@ -11,7 +11,7 @@ Write and run automated UI tests using AutoMobile.
 | Exploratory | "Explore <<feature>> so we can create tests for it" |
 | Regression | "Given <<regression steps to reproduce>>, lets run an exploration that would reproduce it and verify the bug is no longer possible." |
 | Built to spec | "Attempt to verify the <<product spec>>> given the current app version installed." |
-| Navigraph Graph | "Build a [navigation graph](../design-docs/mcp/nav/index.md) and then describe it as a mermaid diagram" |
+| Navigation Graph | "Build a [navigation graph](../design-docs/mcp/nav/index.md) and then describe it as a mermaid diagram" |
 | Break it | "Attempt to execute UX interactions that might expose bugs in <<feature>>" |
 
 ### Example Plan
@@ -44,6 +44,8 @@ Write a UI test that verifies the login flow works correctly
 
 ## Running Tests
 
+AutoMobile tests run using the **JUnit runner** (not `connectedAndroidTest`). This is similar to how screenshot tests work - they execute in the unit test configuration but communicate with a running emulator or device.
+
 ```bash
 # All UI tests
 ./gradlew testDebugUnitTest
@@ -51,6 +53,8 @@ Write a UI test that verifies the login flow works correctly
 # Specific tests
 ./gradlew testDebugUnitTest --tests '*AutoMobileTest'
 ```
+
+**Note:** Since these tests run via `testDebugUnitTest`, they will execute alongside your regular unit tests when running `gradle test`. Consider using test filtering or a separate test task if you want to run AutoMobile tests independently (e.g., they require an emulator to be running).
 
 ## Project Structure
 

--- a/docs/using/ux-exploration.md
+++ b/docs/using/ux-exploration.md
@@ -3,8 +3,13 @@
 Use AI agents to interactively explore your app and discover UI flows.
 
 ![Exploring Google Maps](../img/google-maps.gif)
+*Demo: An AI agent exploring Google Maps, searching for locations, and interacting with map controls.*
+
 ![Setting an alarm in the Clock app](../img/clock-app.gif)
+*Demo: An AI agent navigating to the Clock app, opening the alarm tab, and creating a new alarm.*
+
 ![Taking a photo and viewing the gallery](../img/camera-gallery.gif)
+*Demo: An AI agent opening the Camera app, taking a photo, and viewing it in the Gallery.*
 
 ## Example Prompts
 
@@ -13,7 +18,7 @@ Use AI agents to interactively explore your app and discover UI flows.
 | General exploration | "Explore the main features and identify key user flows" |
 | Specific screen | "Find all the ways to reach the settings screen" |
 | Flow analysis | "Explore the onboarding flow and report any confusing steps" |
-| Navigraph Graph | "Build a [navigation graph](../design-docs/mcp/nav/index.md) and then describe it as a mermaid diagram" |
+| Navigation Graph | "Build a [navigation graph](../design-docs/mcp/nav/index.md) and then describe it as a mermaid diagram" |
 | Element discovery | "Identify all screens that contain text input fields" |
 
 ## Best Practices


### PR DESCRIPTION
## Summary

- Fix typos: "design principals" → "design principles", "Navigraph Graph" → "Navigation Graph"
- Add descriptive captions below video demos so readers don't have to squint at agent window text
- Clarify bug report placeholder syntax with `<bug-report-details-here>` instead of `/details`
- Add JUnit runner explanation and test filtering guidance in UI tests doc
- Restructure startup metrics to clarify cold/warm are scenarios, not separate metrics
- Fix indentation and formatting consistency across perf-analysis docs
- Replace redundant Performance Metrics section with Performance Thresholds in scroll-framerate

## Test plan

- [ ] Review rendered markdown in docs site
- [ ] Verify video captions display correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)