### PR TITLE
feat: add automatic wakefulness check and unlock on emulator boot

### DIFF
--- a/src/utils/android-cmdline-tools/AndroidEmulatorClient.ts
+++ b/src/utils/android-cmdline-tools/AndroidEmulatorClient.ts
@@ -3,6 +3,7 @@ import { promisify } from "util";
 import { logger } from "../logger";
 import { BootedDevice, DeviceInfo, ExecResult, ActionableError } from "../../models";
 import { AdbClient } from "./AdbClient";
+import { AdbExecutor } from "./interfaces/AdbExecutor";
 import { arch } from "os";
 import { detectAndroidCommandLineTools, getBestAndroidToolsLocation } from "./detection";
 
@@ -870,19 +871,20 @@ export class AndroidEmulatorClient implements AndroidEmulator {
    * Wake up the emulator and dismiss the lock screen after boot.
    * This ensures the device is immediately usable for automation.
    * @param device - The booted device to wake and unlock
+   * @param adb - Optional AdbExecutor for testing (defaults to new AdbClient)
    */
-  private async wakeAndUnlock(device: BootedDevice): Promise<void> {
-    const adb = new AdbClient(device);
+  private async wakeAndUnlock(device: BootedDevice, adb?: AdbExecutor): Promise<void> {
+    const executor = adb ?? new AdbClient(device);
 
     try {
       // Check wakefulness state
-      const wakefulness = await adb.getWakefulness();
+      const wakefulness = await executor.getWakefulness();
       logger.info(`[WakeAndUnlock] Device wakefulness state: ${wakefulness}`);
 
       if (wakefulness !== "Awake") {
         // Send KEYCODE_WAKEUP to wake the device
         logger.info("[WakeAndUnlock] Device not awake, sending KEYCODE_WAKEUP");
-        await adb.executeCommand("shell input keyevent KEYCODE_WAKEUP");
+        await executor.executeCommand("shell input keyevent KEYCODE_WAKEUP");
 
         // Small delay to allow the screen to turn on
         await this.sleep(500);
@@ -890,10 +892,10 @@ export class AndroidEmulatorClient implements AndroidEmulator {
 
       // Dismiss the lock screen / keyguard
       logger.info("[WakeAndUnlock] Dismissing keyguard");
-      await adb.executeCommand("shell wm dismiss-keyguard");
+      await executor.executeCommand("shell wm dismiss-keyguard");
 
       // Verify the device is now awake
-      const finalWakefulness = await adb.getWakefulness();
+      const finalWakefulness = await executor.getWakefulness();
       logger.info(`[WakeAndUnlock] Final wakefulness state: ${finalWakefulness}`);
     } catch (error) {
       // Log but don't fail - the device is still ready, just might need manual interaction

--- a/test/utils/android-cmdline-tools/AndroidEmulatorClient-wakeAndUnlock.test.ts
+++ b/test/utils/android-cmdline-tools/AndroidEmulatorClient-wakeAndUnlock.test.ts
@@ -1,14 +1,11 @@
-import { afterEach, beforeEach, describe, expect, test, spyOn } from "bun:test";
+import { beforeEach, describe, expect, test } from "bun:test";
 import { AndroidEmulatorClient } from "../../../src/utils/android-cmdline-tools/AndroidEmulatorClient";
-import { AdbClient } from "../../../src/utils/android-cmdline-tools/AdbClient";
+import { FakeAdbExecutor } from "../../fakes/FakeAdbExecutor";
 import { ExecResult } from "../../../src/models";
 
 describe("AndroidEmulatorClient wakeAndUnlock", () => {
   let emulatorClient: AndroidEmulatorClient;
-  let executedCommands: string[] = [];
-  let mockWakefulness: "Awake" | "Asleep" | "Dozing" | null = "Asleep";
-  let adbGetWakefulnessSpy: ReturnType<typeof spyOn>;
-  let adbExecuteCommandSpy: ReturnType<typeof spyOn>;
+  let fakeAdb: FakeAdbExecutor;
 
   const createExecResult = (stdout: string, stderr: string = ""): ExecResult => ({
     stdout,
@@ -23,105 +20,91 @@ describe("AndroidEmulatorClient wakeAndUnlock", () => {
   };
 
   beforeEach(() => {
-    executedCommands = [];
-    mockWakefulness = "Asleep";
-
+    fakeAdb = new FakeAdbExecutor();
     emulatorClient = new AndroidEmulatorClient(mockExecAsync, null);
-
-    // Spy on AdbClient methods
-    adbGetWakefulnessSpy = spyOn(AdbClient.prototype, "getWakefulness").mockImplementation(async () => {
-      const result = mockWakefulness;
-      // After first call, simulate device becoming awake
-      if (mockWakefulness !== "Awake") {
-        mockWakefulness = "Awake";
-      }
-      return result;
-    });
-
-    adbExecuteCommandSpy = spyOn(AdbClient.prototype, "executeCommand").mockImplementation(async (command: string) => {
-      executedCommands.push(command);
-      return createExecResult("", "");
-    });
-  });
-
-  afterEach(() => {
-    // Restore spies to avoid leaking into other tests
-    adbGetWakefulnessSpy.mockRestore();
-    adbExecuteCommandSpy.mockRestore();
   });
 
   test("should wake device and dismiss keyguard when device is Asleep", async () => {
-    mockWakefulness = "Asleep";
+    fakeAdb.setScreenState(false, "Asleep");
     const device = { name: "test-avd", platform: "android" as const, deviceId: "emulator-5554" };
 
     // Access the private method using bracket notation for testing
     const wakeAndUnlock = (emulatorClient as any).wakeAndUnlock.bind(emulatorClient);
-    await wakeAndUnlock(device);
-
-    // Verify getWakefulness was called
-    expect(adbGetWakefulnessSpy).toHaveBeenCalled();
+    await wakeAndUnlock(device, fakeAdb);
 
     // Verify KEYCODE_WAKEUP was sent since device was Asleep
-    expect(executedCommands.some(cmd => cmd.includes("KEYCODE_WAKEUP"))).toBe(true);
+    expect(fakeAdb.wasCommandExecuted("KEYCODE_WAKEUP")).toBe(true);
 
     // Verify keyguard was dismissed
-    expect(executedCommands.some(cmd => cmd.includes("wm dismiss-keyguard"))).toBe(true);
+    expect(fakeAdb.wasCommandExecuted("wm dismiss-keyguard")).toBe(true);
   });
 
   test("should wake device and dismiss keyguard when device is Dozing", async () => {
-    mockWakefulness = "Dozing";
+    fakeAdb.setScreenState(false, "Dozing");
     const device = { name: "test-avd", platform: "android" as const, deviceId: "emulator-5554" };
 
     const wakeAndUnlock = (emulatorClient as any).wakeAndUnlock.bind(emulatorClient);
-    await wakeAndUnlock(device);
+    await wakeAndUnlock(device, fakeAdb);
 
     // Verify KEYCODE_WAKEUP was sent since device was Dozing
-    expect(executedCommands.some(cmd => cmd.includes("KEYCODE_WAKEUP"))).toBe(true);
+    expect(fakeAdb.wasCommandExecuted("KEYCODE_WAKEUP")).toBe(true);
 
     // Verify keyguard was dismissed
-    expect(executedCommands.some(cmd => cmd.includes("wm dismiss-keyguard"))).toBe(true);
+    expect(fakeAdb.wasCommandExecuted("wm dismiss-keyguard")).toBe(true);
   });
 
   test("should skip KEYCODE_WAKEUP when device is already Awake", async () => {
-    mockWakefulness = "Awake";
+    fakeAdb.setScreenState(true, "Awake");
     const device = { name: "test-avd", platform: "android" as const, deviceId: "emulator-5554" };
 
     const wakeAndUnlock = (emulatorClient as any).wakeAndUnlock.bind(emulatorClient);
-    await wakeAndUnlock(device);
+    await wakeAndUnlock(device, fakeAdb);
 
     // Verify KEYCODE_WAKEUP was NOT sent since device was already Awake
-    expect(executedCommands.some(cmd => cmd.includes("KEYCODE_WAKEUP"))).toBe(false);
+    expect(fakeAdb.wasCommandExecuted("KEYCODE_WAKEUP")).toBe(false);
 
     // Verify keyguard was still dismissed (always dismiss to be safe)
-    expect(executedCommands.some(cmd => cmd.includes("wm dismiss-keyguard"))).toBe(true);
+    expect(fakeAdb.wasCommandExecuted("wm dismiss-keyguard")).toBe(true);
   });
 
   test("should handle errors gracefully without throwing", async () => {
-    mockWakefulness = "Asleep";
-    const device = { name: "test-avd", platform: "android" as const, deviceId: "emulator-5554" };
-
+    fakeAdb.setScreenState(false, "Asleep");
     // Make executeCommand throw an error
-    adbExecuteCommandSpy.mockImplementation(async () => {
-      throw new Error("Simulated ADB error");
+    fakeAdb.setCommandResponse("KEYCODE_WAKEUP", {
+      stdout: "",
+      stderr: "Error",
+      toString: () => "",
+      trim: () => "",
+      includes: () => false,
     });
+    // Override to throw
+    const originalExecuteCommand = fakeAdb.executeCommand.bind(fakeAdb);
+    fakeAdb.executeCommand = async (command: string) => {
+      if (command.includes("KEYCODE_WAKEUP")) {
+        throw new Error("Simulated ADB error");
+      }
+      return originalExecuteCommand(command);
+    };
 
+    const device = { name: "test-avd", platform: "android" as const, deviceId: "emulator-5554" };
     const wakeAndUnlock = (emulatorClient as any).wakeAndUnlock.bind(emulatorClient);
 
     // Should not throw
-    await expect(wakeAndUnlock(device)).resolves.toBeUndefined();
+    await expect(wakeAndUnlock(device, fakeAdb)).resolves.toBeUndefined();
   });
 
-  test("should still dismiss keyguard when wakefulness check returns null", async () => {
-    mockWakefulness = null;
+  test("should still try to wake when wakefulness check returns null", async () => {
+    // Set wakefulness to null (unknown state)
+    (fakeAdb as any).wakefulness = null;
     const device = { name: "test-avd", platform: "android" as const, deviceId: "emulator-5554" };
 
     const wakeAndUnlock = (emulatorClient as any).wakeAndUnlock.bind(emulatorClient);
-    await wakeAndUnlock(device);
+    await wakeAndUnlock(device, fakeAdb);
 
     // When wakefulness is null (unknown), should still try to wake the device
-    expect(executedCommands.some(cmd => cmd.includes("KEYCODE_WAKEUP"))).toBe(true);
+    expect(fakeAdb.wasCommandExecuted("KEYCODE_WAKEUP")).toBe(true);
 
     // Verify keyguard was dismissed
-    expect(executedCommands.some(cmd => cmd.includes("wm dismiss-keyguard"))).toBe(true);
+    expect(fakeAdb.wasCommandExecuted("wm dismiss-keyguard")).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary
- Add `wakeAndUnlock()` method to `AndroidEmulatorClient` that automatically wakes the device and dismisses the lock screen after boot
- Check device wakefulness state using `AdbClient.getWakefulness()` and send `KEYCODE_WAKEUP` if needed
- Dismiss keyguard using `wm dismiss-keyguard` to ensure device is immediately usable
- Handle errors gracefully without failing the startup process

## Test Plan
- [x] Unit tests added for `wakeAndUnlock` functionality (5 tests covering Asleep, Dozing, Awake, error handling, and null wakefulness states)
- [x] Lint passes
- [x] Build passes

Closes #879

🤖 Generated with [Claude Code](https://claude.com/claude-code)