### PR TITLE
chore: set up Dependabot for Android Gradle dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,3 +15,16 @@ updates:
     open-pull-requests-limit: 10
     # Set versioning strategy appropriate for a library/package
     versioning-strategy: "increase-if-necessary"
+  # Android Gradle dependencies
+  - package-ecosystem: "gradle"
+    directory: "/android"
+    schedule:
+      interval: "daily"
+      time: "07:00"
+      timezone: "UTC"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "android"
+    commit-message:
+      prefix: "chore(deps)"

--- a/schemas/tool-definitions.json
+++ b/schemas/tool-definitions.json
@@ -390,11 +390,11 @@
           "type": "number"
         },
         "appBundleIds": {
+          "description": "iOS-only: bundle IDs to include in app data snapshots (omit to skip app data capture)",
           "type": "array",
           "items": {
             "type": "string"
-          },
-          "description": "iOS-only: bundle IDs to include in app data snapshots (omit to skip app data capture)"
+          }
         },
         "sessionUuid": {
           "description": "Session UUID for device targeting",

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -145,6 +145,10 @@ See individual script directories for specialized validation:
 - `shellcheck/` - Shell script linting and formatting
 - `xml/` - XML validation and formatting
 
+Root-level validation scripts:
+- `validate_dependabot.sh` - Validate Dependabot config YAML
+- `validate_mkdocs_nav.sh` - Validate MkDocs nav configuration
+
 Run `scripts/<category>/validate_*.sh` for validation or `scripts/<category>/apply_*.sh` for auto-formatting.
 
 ## CI Integration

--- a/scripts/validate_dependabot.sh
+++ b/scripts/validate_dependabot.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+#
+# validate_dependabot.sh
+#
+# Validate that the Dependabot config parses as YAML.
+#
+# Usage:
+#   ./scripts/validate_dependabot.sh [path]
+#
+# Exit codes:
+#   0 - YAML parsed successfully
+#   1 - Missing file, missing dependency, or parse error
+#
+set -euo pipefail
+
+DEPENDABOT_PATH="${1:-.github/dependabot.yml}"
+
+if ! command -v ruby >/dev/null 2>&1; then
+  echo "[ERROR] ruby is required to validate YAML." >&2
+  exit 1
+fi
+
+if [[ ! -f "$DEPENDABOT_PATH" ]]; then
+  echo "[ERROR] Dependabot config not found at: $DEPENDABOT_PATH" >&2
+  exit 1
+fi
+
+ruby - "$DEPENDABOT_PATH" <<'RUBY'
+path = ARGV[0]
+require "yaml"
+
+begin
+  YAML.load_file(path)
+rescue StandardError => e
+  warn "[ERROR] Failed to parse #{path}: #{e.class}: #{e.message}"
+  exit 1
+end
+RUBY
+
+echo "[INFO] Dependabot config is valid YAML: $DEPENDABOT_PATH"


### PR DESCRIPTION
## Summary
- configure Dependabot for Android Gradle updates (daily schedule, labels, commit prefix)
- add a local Dependabot YAML validation script and document it
- include regenerated tool definitions from commit hook

## Testing
- scripts/validate_dependabot.sh

Closes #840
