### PR TITLE
Implement iOS simulator snapshot restore

### DIFF
--- a/src/features/action/RestoreSnapshotIos.ts
+++ b/src/features/action/RestoreSnapshotIos.ts
@@ -44,6 +44,7 @@ export class RestoreSnapshotIos {
       );
     }
 
+    await this.validateSnapshotCompatibility(manifest);
     await this.restoreAppData(snapshotName, manifest);
 
     logger.info(`[iOS] Snapshot '${snapshotName}' restored successfully`);
@@ -100,8 +101,21 @@ export class RestoreSnapshotIos {
       return;
     }
 
+    const installedBundles = await this.getInstalledBundleIds();
+    if (installedBundles.size > 0) {
+      const missingBundles = bundleIds.filter(bundleId => !installedBundles.has(bundleId));
+      if (missingBundles.length > 0) {
+        throw new ActionableError(
+          `App(s) not installed on simulator: ${missingBundles.join(", ")}. Please reinstall and retry restore.`
+        );
+      }
+    } else {
+      logger.warn("[iOS] Unable to verify installed apps; proceeding with restore");
+    }
+
     for (const bundleId of bundleIds) {
       try {
+        await this.terminateAppIfRunning(bundleId);
         const containerPath = await this.getAppContainerPath(bundleId);
         if (!containerPath) {
           continue;
@@ -120,6 +134,93 @@ export class RestoreSnapshotIos {
       } catch (error) {
         logger.warn(`[iOS] Failed to restore app data for ${bundleId}: ${error}`);
       }
+    }
+  }
+
+  private async validateSnapshotCompatibility(manifest: DeviceSnapshotManifest): Promise<void> {
+    if (!manifest.osVersion) {
+      logger.warn("[iOS] Snapshot OS version missing; skipping compatibility check");
+      return;
+    }
+
+    const deviceOsVersion = await this.getDeviceOsVersion();
+    if (!deviceOsVersion) {
+      logger.warn("[iOS] Unable to read simulator OS version; skipping compatibility check");
+      return;
+    }
+
+    const snapshotVersion = this.parseOsVersion(manifest.osVersion);
+    const targetVersion = this.parseOsVersion(deviceOsVersion);
+
+    if (!snapshotVersion || !targetVersion) {
+      logger.warn("[iOS] Unable to parse OS versions for compatibility check; proceeding");
+      return;
+    }
+
+    if (snapshotVersion.major !== targetVersion.major) {
+      throw new ActionableError(
+        `Snapshot iOS version '${manifest.osVersion}' is incompatible with simulator iOS '${deviceOsVersion}'. ` +
+        `Please restore on an iOS ${snapshotVersion.major}.x simulator.`
+      );
+    }
+  }
+
+  private async getDeviceOsVersion(): Promise<string | undefined> {
+    try {
+      const deviceInfo = await this.simctl.getDeviceInfo(this.device.deviceId);
+      if (!deviceInfo) {
+        return undefined;
+      }
+
+      let osVersion: string | undefined = deviceInfo.os_version;
+      if (!osVersion && deviceInfo.runtime) {
+        const runtimes = await this.simctl.getRuntimes();
+        const runtime = runtimes.find(entry => entry.identifier === deviceInfo.runtime);
+        osVersion = runtime?.version || runtime?.name;
+      }
+
+      return osVersion;
+    } catch (error) {
+      logger.warn(`[iOS] Failed to read simulator OS version: ${error}`);
+      return undefined;
+    }
+  }
+
+  private parseOsVersion(version: string): { major: number; minor?: number } | null {
+    const runtimeMatch = version.match(/iOS[-\s_]?(\d+)(?:[.\-_](\d+))?/i);
+    const match = runtimeMatch ?? version.match(/(\d+)(?:\.(\d+))?/);
+    if (!match) {
+      return null;
+    }
+
+    const major = Number(match[1]);
+    if (!Number.isFinite(major)) {
+      return null;
+    }
+
+    const minorValue = match[2];
+    const minor = minorValue !== undefined ? Number(minorValue) : undefined;
+    return Number.isFinite(minor) || minor === undefined ? { major, minor } : { major };
+  }
+
+  private async getInstalledBundleIds(): Promise<Set<string>> {
+    try {
+      const apps = await this.simctl.listApps(this.device.deviceId);
+      const bundleIds = apps
+        .map((app: any) => app.bundleId || app.CFBundleIdentifier)
+        .filter((value: string | undefined) => typeof value === "string" && value.length > 0);
+      return new Set(bundleIds);
+    } catch (error) {
+      logger.warn(`[iOS] Failed to list installed apps: ${error}`);
+      return new Set();
+    }
+  }
+
+  private async terminateAppIfRunning(bundleId: string): Promise<void> {
+    try {
+      await this.simctl.terminateApp(bundleId, this.device.deviceId);
+    } catch (error) {
+      logger.warn(`[iOS] Failed to terminate ${bundleId} before restore: ${error}`);
     }
   }
 

--- a/src/utils/ios-cmdline-tools/SimCtlClient.ts
+++ b/src/utils/ios-cmdline-tools/SimCtlClient.ts
@@ -555,9 +555,19 @@ export class SimCtlClient implements SimCtl {
       const result = await this.executeCommand(`listapps ${targetDevice}`);
       const appsData = JSON.parse(result.stdout);
 
-      // Convert the apps object to an array
-      const apps = Object.values(appsData);
-      return apps;
+      if (Array.isArray(appsData)) {
+        return appsData;
+      }
+
+      if (!appsData || typeof appsData !== "object") {
+        return [];
+      }
+
+      // Convert the apps object to an array, preserving bundle IDs from keys.
+      return Object.entries(appsData).map(([bundleId, appInfo]) => {
+        const record = appInfo && typeof appInfo === "object" ? appInfo : {};
+        return { ...record, bundleId };
+      });
     } catch (error) {
       logger.warn(`Failed to list iOS apps: ${error}`);
       return [];


### PR DESCRIPTION
## Summary
- add iOS snapshot restore compatibility checks for simulator OS version and installed apps
- terminate apps before restoring app container data
- normalize simctl listapps results to include bundle IDs

## Testing
- bun run build
- bun run test

Closes #851
