### PR TITLE
chore: set up Dependabot for iOS Swift packages

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -28,3 +28,52 @@ updates:
       - "android"
     commit-message:
       prefix: "chore(deps)"
+  # iOS Swift Package Manager dependencies
+  - package-ecosystem: "swift"
+    directory: "/ios/XCTestService"
+    schedule:
+      interval: "daily"
+      time: "07:00"
+      timezone: "UTC"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "ios"
+    commit-message:
+      prefix: "chore(deps)"
+  - package-ecosystem: "swift"
+    directory: "/ios/XCTestRunner"
+    schedule:
+      interval: "daily"
+      time: "07:00"
+      timezone: "UTC"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "ios"
+    commit-message:
+      prefix: "chore(deps)"
+  - package-ecosystem: "swift"
+    directory: "/ios/XcodeCompanion"
+    schedule:
+      interval: "daily"
+      time: "07:00"
+      timezone: "UTC"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "ios"
+    commit-message:
+      prefix: "chore(deps)"
+  - package-ecosystem: "swift"
+    directory: "/ios/XcodeExtension"
+    schedule:
+      interval: "daily"
+      time: "07:00"
+      timezone: "UTC"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "ios"
+    commit-message:
+      prefix: "chore(deps)"


### PR DESCRIPTION
## Summary
- add Dependabot entries for iOS Swift packages (SPM)
- match Android schedule and labels for Swift updates

## Testing
- `bun run build`
- `bun test` (fails: corrupted migrations: previously executed migration 2026_01_14_000_appearance_config is missing)

Closes #841
