### PR TITLE
Add iOS dependency checks to doctor

### DIFF
--- a/schemas/tool-definitions.json
+++ b/schemas/tool-definitions.json
@@ -433,6 +433,10 @@
         "installCmdlineTools": {
           "description": "Automatically download and install Android SDK Command-line Tools to ANDROID_HOME if missing",
           "type": "boolean"
+        },
+        "installXcodeCommandLineTools": {
+          "description": "Install Xcode Command Line Tools if missing",
+          "type": "boolean"
         }
       },
       "additionalProperties": false

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -158,14 +158,15 @@ async function runToolViaDaemon(
  */
 async function runDoctorCommand(params: Record<string, any>): Promise<void> {
   const jsonOutput = params.json === true;
-  const { installCmdlineTools, ...daemonParams } = params;
+  const { installCmdlineTools, installXcodeCommandLineTools, ...daemonParams } = params;
 
-  if (installCmdlineTools === true) {
+  if (installCmdlineTools === true || installXcodeCommandLineTools === true) {
     const { runDoctor, formatConsoleOutput, formatJsonOutput } = await import("../doctor");
     const report = await runDoctor({
       android: params.android,
       ios: params.ios,
       installCmdlineTools,
+      installXcodeCommandLineTools,
     });
 
     if (jsonOutput) {
@@ -197,6 +198,7 @@ async function runDoctorCommand(params: Record<string, any>): Promise<void> {
     android: params.android,
     ios: params.ios,
     installCmdlineTools,
+    installXcodeCommandLineTools,
   });
 
   if (jsonOutput) {

--- a/src/doctor/checks/ios.ts
+++ b/src/doctor/checks/ios.ts
@@ -3,15 +3,276 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { CheckResult } from "../types";
-import { SimCtlClient } from "../../utils/ios-cmdline-tools/SimCtlClient";
+import { execFile } from "node:child_process";
+import { existsSync, promises as fs } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { promisify } from "node:util";
+import type { ExecResult } from "../../models";
+import { CheckResult, DoctorOptions } from "../types";
+import { SimCtl, SimCtlClient } from "../../utils/ios-cmdline-tools/SimCtlClient";
+
+const MIN_XCODE_VERSION = "15.0";
+
+const execFileAsync = promisify(execFile);
+
+export interface IosDoctorDependencies {
+  platform: () => NodeJS.Platform;
+  execFile: (file: string, args: string[]) => Promise<ExecResult>;
+  fileExists: (path: string) => boolean;
+  readDir: (path: string) => Promise<string[]>;
+  homedir: () => string;
+  createSimctlClient: () => SimCtl;
+}
+
+const createExecResult = (stdout: string, stderr: string): ExecResult => ({
+  stdout,
+  stderr,
+  toString() {
+    return this.stdout;
+  },
+  trim() {
+    return this.stdout.trim();
+  },
+  includes(searchString: string) {
+    return this.stdout.includes(searchString);
+  }
+});
+
+const createIosDoctorDependencies = (): IosDoctorDependencies => ({
+  platform: () => process.platform,
+  execFile: async (file, args) => {
+    const result = await execFileAsync(file, args);
+    const stdout = typeof result.stdout === "string" ? result.stdout : result.stdout.toString();
+    const stderr = typeof result.stderr === "string" ? result.stderr : result.stderr.toString();
+    return createExecResult(stdout, stderr);
+  },
+  fileExists: existsSync,
+  readDir: async path => fs.readdir(path),
+  homedir,
+  createSimctlClient: () => new SimCtlClient()
+});
+
+function parseXcodeVersion(output: string): string | null {
+  const match = output.match(/Xcode\s+([0-9]+(?:\.[0-9]+)*)/);
+  return match ? match[1] : null;
+}
+
+function compareVersions(current: string, minimum: string): number {
+  const currentParts = current.split(".").map(part => Number(part));
+  const minimumParts = minimum.split(".").map(part => Number(part));
+  const length = Math.max(currentParts.length, minimumParts.length);
+
+  for (let i = 0; i < length; i++) {
+    const currentValue = currentParts[i] ?? 0;
+    const minimumValue = minimumParts[i] ?? 0;
+    if (currentValue > minimumValue) {
+      return 1;
+    }
+    if (currentValue < minimumValue) {
+      return -1;
+    }
+  }
+
+  return 0;
+}
+
+function normalizeErrorMessage(error: unknown): string {
+  if (error instanceof Error) {
+    return error.message;
+  }
+  return String(error);
+}
+
+function errorOutput(error: unknown): string {
+  const stdout = typeof (error as { stdout?: string })?.stdout === "string"
+    ? (error as { stdout?: string }).stdout
+    : "";
+  const stderr = typeof (error as { stderr?: string })?.stderr === "string"
+    ? (error as { stderr?: string }).stderr
+    : "";
+  return [stdout, stderr, normalizeErrorMessage(error)].join("\n");
+}
+
+/**
+ * Check Xcode installation and minimum version
+ */
+export async function checkXcodeInstallation(
+  minimumVersion: string = MIN_XCODE_VERSION,
+  dependencies = createIosDoctorDependencies()
+): Promise<CheckResult> {
+  if (dependencies.platform() !== "darwin") {
+    return {
+      name: "Xcode",
+      status: "skip",
+      message: "iOS development requires macOS",
+    };
+  }
+
+  try {
+    const result = await dependencies.execFile("xcodebuild", ["-version"]);
+    const version = parseXcodeVersion(result.stdout);
+
+    if (!version) {
+      return {
+        name: "Xcode",
+        status: "fail",
+        message: "Unable to determine Xcode version",
+        recommendation: `Install Xcode ${minimumVersion}+ from the App Store.`,
+      };
+    }
+
+    if (compareVersions(version, minimumVersion) < 0) {
+      return {
+        name: "Xcode",
+        status: "fail",
+        message: `Xcode ${version} installed (requires ${minimumVersion}+)`,
+        recommendation: `Update Xcode to ${minimumVersion}+ and re-run doctor.`,
+        value: version,
+      };
+    }
+
+    return {
+      name: "Xcode",
+      status: "pass",
+      message: `Xcode ${version} installed`,
+      value: version,
+    };
+  } catch (error) {
+    return {
+      name: "Xcode",
+      status: "fail",
+      message: `Xcode not detected: ${normalizeErrorMessage(error)}`,
+      recommendation: `Install Xcode ${minimumVersion}+ from the App Store.`,
+    };
+  }
+}
+
+/**
+ * Check Xcode Command Line Tools (with optional auto-install)
+ */
+export async function checkXcodeCommandLineTools(
+  options: DoctorOptions = {},
+  dependencies = createIosDoctorDependencies()
+): Promise<CheckResult> {
+  const name = "Command Line Tools";
+
+  if (dependencies.platform() !== "darwin") {
+    return {
+      name,
+      status: "skip",
+      message: "iOS development requires macOS",
+    };
+  }
+
+  if (options.installXcodeCommandLineTools) {
+    try {
+      await dependencies.execFile("xcode-select", ["--install"]);
+      return {
+        name,
+        status: "pass",
+        message: "Command Line Tools installation started",
+        recommendation: "Follow the installer prompt and re-run doctor.",
+      };
+    } catch (error) {
+      const output = errorOutput(error).toLowerCase();
+      if (output.includes("already installed")) {
+        return {
+          name,
+          status: "pass",
+          message: "Command Line Tools already installed",
+        };
+      }
+
+      return {
+        name,
+        status: "fail",
+        message: `Command Line Tools install failed: ${normalizeErrorMessage(error)}`,
+        recommendation: "Run: xcode-select --install",
+      };
+    }
+  }
+
+  try {
+    const result = await dependencies.execFile("xcode-select", ["-p"]);
+    const developerDir = result.stdout.trim();
+
+    if (!developerDir) {
+      return {
+        name,
+        status: "fail",
+        message: "Command Line Tools path not configured",
+        recommendation: "Run: xcode-select --install",
+      };
+    }
+
+    if (!dependencies.fileExists(developerDir)) {
+      return {
+        name,
+        status: "fail",
+        message: `Command Line Tools path missing: ${developerDir}`,
+        recommendation: "Run: xcode-select --install",
+      };
+    }
+
+    const message = developerDir.includes("CommandLineTools")
+      ? "Command Line Tools installed"
+      : "Xcode developer directory selected";
+
+    return {
+      name,
+      status: "pass",
+      message,
+      value: developerDir,
+    };
+  } catch (error) {
+    return {
+      name,
+      status: "fail",
+      message: `Command Line Tools not available: ${normalizeErrorMessage(error)}`,
+      recommendation: "Run: xcode-select --install",
+    };
+  }
+}
+
+/**
+ * Check xcrun availability
+ */
+export async function checkXcrunAvailable(
+  dependencies = createIosDoctorDependencies()
+): Promise<CheckResult> {
+  if (dependencies.platform() !== "darwin") {
+    return {
+      name: "xcrun",
+      status: "skip",
+      message: "iOS development requires macOS",
+    };
+  }
+
+  try {
+    await dependencies.execFile("xcrun", ["--version"]);
+    return {
+      name: "xcrun",
+      status: "pass",
+      message: "xcrun functional",
+    };
+  } catch (error) {
+    return {
+      name: "xcrun",
+      status: "fail",
+      message: `xcrun not functional: ${normalizeErrorMessage(error)}`,
+      recommendation: "Install Xcode Command Line Tools: xcode-select --install",
+    };
+  }
+}
 
 /**
  * Check if simctl is available (requires Xcode)
  */
-export async function checkSimctlAvailable(): Promise<CheckResult> {
-  // Only run on macOS
-  if (process.platform !== "darwin") {
+export async function checkSimctlAvailable(
+  dependencies = createIosDoctorDependencies()
+): Promise<CheckResult> {
+  if (dependencies.platform() !== "darwin") {
     return {
       name: "simctl",
       status: "skip",
@@ -20,14 +281,14 @@ export async function checkSimctlAvailable(): Promise<CheckResult> {
   }
 
   try {
-    const simctl = new SimCtlClient();
+    const simctl = dependencies.createSimctlClient();
     const available = await simctl.isAvailable();
 
     if (available) {
       return {
         name: "simctl",
         status: "pass",
-        message: "Xcode command line tools available",
+        message: "simctl functional",
       };
     }
 
@@ -35,14 +296,205 @@ export async function checkSimctlAvailable(): Promise<CheckResult> {
       name: "simctl",
       status: "fail",
       message: "simctl not available",
-      recommendation: "Install Xcode command line tools: xcode-select --install",
+      recommendation: "Install Xcode Command Line Tools: xcode-select --install",
     };
   } catch (error) {
     return {
       name: "simctl",
       status: "fail",
-      message: `simctl check failed: ${error instanceof Error ? error.message : String(error)}`,
-      recommendation: "Install Xcode command line tools: xcode-select --install",
+      message: `simctl check failed: ${normalizeErrorMessage(error)}`,
+      recommendation: "Install Xcode Command Line Tools: xcode-select --install",
+    };
+  }
+}
+
+/**
+ * Check available iOS simulator runtimes
+ */
+export async function checkSimulatorRuntimes(
+  dependencies = createIosDoctorDependencies()
+): Promise<CheckResult> {
+  const name = "iOS Simulator Runtimes";
+
+  if (dependencies.platform() !== "darwin") {
+    return {
+      name,
+      status: "skip",
+      message: "iOS simulators only available on macOS",
+    };
+  }
+
+  const simctl = dependencies.createSimctlClient();
+  if (!(await simctl.isAvailable())) {
+    return {
+      name,
+      status: "skip",
+      message: "simctl not available",
+    };
+  }
+
+  try {
+    const runtimes = await simctl.getRuntimes();
+    const iosRuntimes = runtimes.filter(runtime => runtime.name.startsWith("iOS"));
+
+    if (iosRuntimes.length === 0) {
+      return {
+        name,
+        status: "fail",
+        message: "No iOS simulator runtimes available",
+        recommendation: "Install an iOS Simulator runtime in Xcode Settings > Platforms.",
+      };
+    }
+
+    const runtimeNames = iosRuntimes.map(runtime => runtime.name).join(", ");
+    return {
+      name,
+      status: "pass",
+      message: `iOS runtimes available: ${runtimeNames}`,
+      value: iosRuntimes.length,
+    };
+  } catch (error) {
+    return {
+      name,
+      status: "fail",
+      message: `Failed to list runtimes: ${normalizeErrorMessage(error)}`,
+      recommendation: "Install an iOS Simulator runtime in Xcode Settings > Platforms.",
+    };
+  }
+}
+
+/**
+ * Check code signing identities (optional)
+ */
+export async function checkCodeSigning(
+  dependencies = createIosDoctorDependencies()
+): Promise<CheckResult> {
+  const name = "Code Signing Identity";
+
+  if (dependencies.platform() !== "darwin") {
+    return {
+      name,
+      status: "skip",
+      message: "Code signing only available on macOS",
+    };
+  }
+
+  try {
+    const result = await dependencies.execFile("security", ["find-identity", "-v", "-p", "codesigning"]);
+    const match = result.stdout.match(/(\d+)\s+valid identities found/);
+    const count = match ? Number(match[1]) : 0;
+
+    if (count > 0) {
+      return {
+        name,
+        status: "pass",
+        message: `${count} code signing identity(ies) available`,
+        value: count,
+      };
+    }
+
+    return {
+      name,
+      status: "warn",
+      message: "No code signing identities found",
+      recommendation: "Sign in to Xcode and install a development certificate for device testing.",
+    };
+  } catch (error) {
+    return {
+      name,
+      status: "warn",
+      message: `Code signing check failed: ${normalizeErrorMessage(error)}`,
+      recommendation: "Sign in to Xcode and install a development certificate for device testing.",
+    };
+  }
+}
+
+/**
+ * Check Apple Developer account presence (optional)
+ */
+export async function checkAppleDeveloperAccount(
+  dependencies = createIosDoctorDependencies()
+): Promise<CheckResult> {
+  const name = "Apple Developer Account";
+
+  if (dependencies.platform() !== "darwin") {
+    return {
+      name,
+      status: "skip",
+      message: "Apple Developer accounts only available on macOS",
+    };
+  }
+
+  const accountsPath = join(dependencies.homedir(), "Library", "Developer", "Xcode", "Accounts");
+  try {
+    const entries = await dependencies.readDir(accountsPath);
+    const visibleEntries = entries.filter(entry => entry.trim().length > 0);
+    if (visibleEntries.length > 0) {
+      return {
+        name,
+        status: "pass",
+        message: "Apple Developer account configured",
+      };
+    }
+
+    return {
+      name,
+      status: "warn",
+      message: "No Apple Developer account configured",
+      recommendation: "Sign in to Xcode to enable device testing.",
+    };
+  } catch (error) {
+    return {
+      name,
+      status: "warn",
+      message: "No Apple Developer account configured",
+      recommendation: "Sign in to Xcode to enable device testing.",
+    };
+  }
+}
+
+/**
+ * Check provisioning profiles (optional)
+ */
+export async function checkProvisioningProfiles(
+  dependencies = createIosDoctorDependencies()
+): Promise<CheckResult> {
+  const name = "Provisioning Profiles";
+
+  if (dependencies.platform() !== "darwin") {
+    return {
+      name,
+      status: "skip",
+      message: "Provisioning profiles only available on macOS",
+    };
+  }
+
+  const profilesPath = join(dependencies.homedir(), "Library", "MobileDevice", "Provisioning Profiles");
+  try {
+    const entries = await dependencies.readDir(profilesPath);
+    const profiles = entries.filter(entry => entry.endsWith(".mobileprovision"));
+
+    if (profiles.length > 0) {
+      return {
+        name,
+        status: "pass",
+        message: `${profiles.length} provisioning profile(s) available`,
+        value: profiles.length,
+      };
+    }
+
+    return {
+      name,
+      status: "warn",
+      message: "No provisioning profiles found",
+      recommendation: "Create a provisioning profile in Xcode to enable device testing.",
+    };
+  } catch (error) {
+    return {
+      name,
+      status: "warn",
+      message: "No provisioning profiles found",
+      recommendation: "Create a provisioning profile in Xcode to enable device testing.",
     };
   }
 }
@@ -50,9 +502,10 @@ export async function checkSimctlAvailable(): Promise<CheckResult> {
 /**
  * Check booted iOS simulators
  */
-export async function checkBootedSimulators(): Promise<CheckResult> {
-  // Only run on macOS
-  if (process.platform !== "darwin") {
+export async function checkBootedSimulators(
+  dependencies = createIosDoctorDependencies()
+): Promise<CheckResult> {
+  if (dependencies.platform() !== "darwin") {
     return {
       name: "Booted Simulators",
       status: "skip",
@@ -61,9 +514,8 @@ export async function checkBootedSimulators(): Promise<CheckResult> {
   }
 
   try {
-    const simctl = new SimCtlClient();
+    const simctl = dependencies.createSimctlClient();
 
-    // First check if simctl is available
     if (!(await simctl.isAvailable())) {
       return {
         name: "Booted Simulators",
@@ -94,19 +546,26 @@ export async function checkBootedSimulators(): Promise<CheckResult> {
     return {
       name: "Booted Simulators",
       status: "skip",
-      message: `Could not check simulators: ${error instanceof Error ? error.message : String(error)}`,
+      message: `Could not check simulators: ${normalizeErrorMessage(error)}`,
       value: 0,
     };
   }
 }
 
 /**
- * Run all iOS checks (minimal)
+ * Run all iOS checks
  */
-export async function runIosChecks(): Promise<CheckResult[]> {
+export async function runIosChecks(options: DoctorOptions = {}): Promise<CheckResult[]> {
   const results: CheckResult[] = [];
 
+  results.push(await checkXcodeInstallation());
+  results.push(await checkXcodeCommandLineTools(options));
+  results.push(await checkXcrunAvailable());
   results.push(await checkSimctlAvailable());
+  results.push(await checkSimulatorRuntimes());
+  results.push(await checkCodeSigning());
+  results.push(await checkAppleDeveloperAccount());
+  results.push(await checkProvisioningProfiles());
   results.push(await checkBootedSimulators());
 
   return results;

--- a/src/doctor/index.ts
+++ b/src/doctor/index.ts
@@ -83,7 +83,7 @@ export async function runDoctor(
   // Run iOS checks if applicable
   let iosChecks: CheckResult[] | undefined;
   if (runIos) {
-    iosChecks = await runIosChecks();
+    iosChecks = await runIosChecks(options);
     allChecks.push(...iosChecks);
   }
 

--- a/src/doctor/types.ts
+++ b/src/doctor/types.ts
@@ -63,6 +63,8 @@ export interface DoctorOptions {
   ios?: boolean;
   /** Install Android SDK command-line tools if missing */
   installCmdlineTools?: boolean;
+  /** Install Xcode Command Line Tools if missing */
+  installXcodeCommandLineTools?: boolean;
   /** Output in JSON format */
   json?: boolean;
 }

--- a/src/features/observe/Window.ts
+++ b/src/features/observe/Window.ts
@@ -256,7 +256,7 @@ export class Window {
       if (!packageName || !activityName) {
         const sample = stdout.trim().slice(0, 200);
         logger.warn(
-          `[WINDOW] Failed to parse active window from dumpsys output. Sample: ${sample || "<empty>"}` 
+          `[WINDOW] Failed to parse active window from dumpsys output. Sample: ${sample || "<empty>"}`
         );
       }
 

--- a/src/server/doctorTools.ts
+++ b/src/server/doctorTools.ts
@@ -17,6 +17,9 @@ export const doctorSchema = z.object({
   installCmdlineTools: z.boolean().optional().describe(
     "Automatically download and install Android SDK Command-line Tools to ANDROID_HOME if missing"
   ),
+  installXcodeCommandLineTools: z.boolean().optional().describe(
+    "Install Xcode Command Line Tools if missing"
+  ),
 }).strict();
 
 /**
@@ -26,6 +29,7 @@ export interface DoctorArgs {
   android?: boolean;
   ios?: boolean;
   installCmdlineTools?: boolean;
+  installXcodeCommandLineTools?: boolean;
 }
 
 /**
@@ -41,6 +45,7 @@ export function registerDoctorTools(): void {
         android: args.android,
         ios: args.ios,
         installCmdlineTools: args.installCmdlineTools,
+        installXcodeCommandLineTools: args.installXcodeCommandLineTools,
       });
 
       return createJSONToolResponse(report);

--- a/test/doctor/ios.test.ts
+++ b/test/doctor/ios.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, test } from "bun:test";
+import type { IosDoctorDependencies } from "../../src/doctor/checks/ios";
+import {
+  checkAppleDeveloperAccount,
+  checkCodeSigning,
+  checkSimulatorRuntimes,
+  checkXcodeCommandLineTools,
+  checkXcodeInstallation
+} from "../../src/doctor/checks/ios";
+import type { ExecResult } from "../../src/models";
+import { FakeTimer } from "../fakes/FakeTimer";
+
+const createExecResult = (stdout: string, stderr: string = ""): ExecResult => ({
+  stdout,
+  stderr,
+  toString() {
+    return this.stdout;
+  },
+  trim() {
+    return this.stdout.trim();
+  },
+  includes(searchString: string) {
+    return this.stdout.includes(searchString);
+  }
+});
+
+const baseDependencies: IosDoctorDependencies = {
+  platform: () => "darwin",
+  execFile: async () => createExecResult(""),
+  fileExists: () => true,
+  readDir: async () => [],
+  homedir: () => "/Users/test",
+  createSimctlClient: () => ({
+    setDevice: () => {},
+    executeCommand: async () => createExecResult(""),
+    isAvailable: async () => true,
+    isSimulatorRunning: async () => false,
+    startSimulator: async () => ({} as any),
+    killSimulator: async () => {},
+    waitForSimulatorReady: async () => ({ name: "sim", platform: "ios", deviceId: "123" }),
+    listSimulatorImages: async () => [],
+    getBootedSimulators: async () => [],
+    getDeviceInfo: async () => null,
+    bootSimulator: async () => ({ name: "sim", platform: "ios", deviceId: "123" }),
+    getDeviceTypes: async () => [],
+    getRuntimes: async () => [],
+    createSimulator: async () => "123",
+    deleteSimulator: async () => {},
+    listApps: async () => [],
+    launchApp: async () => ({ success: true }),
+    terminateApp: async () => {},
+    getScreenSize: async () => ({ width: 100, height: 100 }),
+    setAppearance: async () => {}
+  })
+};
+
+describe("iOS doctor checks", () => {
+  test("fails when Xcode version is below minimum", async () => {
+    const result = await checkXcodeInstallation("15.0", {
+      ...baseDependencies,
+      execFile: async () => createExecResult("Xcode 14.2\nBuild version 14C18")
+    });
+
+    expect(result.status).toBe("fail");
+    expect(result.message).toContain("requires 15.0");
+  });
+
+  test("passes when Command Line Tools are already installed via install flag", async () => {
+    const fakeTimer = new FakeTimer();
+    fakeTimer.setManualMode();
+    const execCalls: string[] = [];
+
+    const execFile = async () => {
+      execCalls.push("xcode-select --install");
+      await fakeTimer.sleep(0);
+      const error = new Error("Command line tools are already installed.");
+      (error as { stderr?: string }).stderr = "Command line tools are already installed.";
+      throw error;
+    };
+
+    const resultPromise = checkXcodeCommandLineTools(
+      { installXcodeCommandLineTools: true },
+      { ...baseDependencies, execFile }
+    );
+
+    fakeTimer.advanceTime(0);
+    const result = await resultPromise;
+
+    expect(execCalls).toHaveLength(1);
+    expect(result.status).toBe("pass");
+  });
+
+  test("fails when no simulator runtimes are available", async () => {
+    const result = await checkSimulatorRuntimes({
+      ...baseDependencies,
+      createSimctlClient: () => ({
+        ...baseDependencies.createSimctlClient(),
+        getRuntimes: async () => []
+      })
+    });
+
+    expect(result.status).toBe("fail");
+    expect(result.message).toContain("No iOS simulator runtimes");
+  });
+
+  test("warns when no code signing identities are present", async () => {
+    const result = await checkCodeSigning({
+      ...baseDependencies,
+      execFile: async () => createExecResult("  0 valid identities found")
+    });
+
+    expect(result.status).toBe("warn");
+    expect(result.message).toContain("No code signing identities");
+  });
+
+  test("warns when no Apple Developer account is configured", async () => {
+    const result = await checkAppleDeveloperAccount({
+      ...baseDependencies,
+      readDir: async () => []
+    });
+
+    expect(result.status).toBe("warn");
+    expect(result.message).toContain("No Apple Developer account");
+  });
+});


### PR DESCRIPTION
## Summary
- add iOS doctor dependency checks (Xcode, CLT, xcrun, simctl, runtimes, signing/account/profile)
- wire `installXcodeCommandLineTools` flag through doctor tool/CLI
- add iOS doctor unit tests

## Testing
- `bun test`
- `bun run lint`
- `bun run build`

Closes #869
