### PR TITLE
Add iOS simulator metadata to device resources

### DIFF
--- a/src/models/DeviceInfo.ts
+++ b/src/models/DeviceInfo.ts
@@ -6,6 +6,10 @@ export interface DeviceInfo {
   isRunning: boolean;
   deviceId?: string;
   source?: "local";
+  // iOS-only metadata (optional)
+  state?: string;
+  iosVersion?: string;
+  deviceType?: string;
 }
 
 export interface BootedDevice {

--- a/src/server/appResources.ts
+++ b/src/server/appResources.ts
@@ -65,13 +65,22 @@ export interface AppsResourceContent {
   message?: string;
 }
 
-export interface InstalledAppInfo {
+export interface AndroidInstalledAppInfo {
   packageName: string;
   userId: number;
   userProfile: "personal" | "work";
   foreground: boolean;
   recent: boolean;
 }
+
+export interface IosInstalledAppInfo {
+  bundleId: string;
+  displayName?: string;
+  version?: string;
+  path?: string;
+}
+
+export type InstalledAppInfo = AndroidInstalledAppInfo | IosInstalledAppInfo;
 
 interface AppsCacheEntry {
   expiresAt: number;
@@ -101,7 +110,7 @@ function toInstalledAppInfo(app: InstalledApp): InstalledAppInfo {
   };
 }
 
-function toQueryUserApp(app: InstalledAppInfo): AppsQueryAppInfo {
+function toQueryAndroidApp(app: AndroidInstalledAppInfo): AppsQueryAppInfo {
   return {
     packageName: app.packageName,
     type: "user",
@@ -123,17 +132,17 @@ function toQuerySystemApp(app: SystemInstalledApp): AppsQueryAppInfo {
 }
 
 function normalizeAndroidApps(installedApps: InstalledAppsByProfile): {
-  userApps: InstalledAppInfo[];
+  userApps: AndroidInstalledAppInfo[];
   queryApps: AppsQueryAppInfo[];
 } {
-  const userApps: InstalledAppInfo[] = [];
+  const userApps: AndroidInstalledAppInfo[] = [];
   const queryApps: AppsQueryAppInfo[] = [];
 
   for (const profileApps of Object.values(installedApps.profiles)) {
     for (const app of profileApps) {
-      const info = toInstalledAppInfo(app);
+      const info = toInstalledAppInfo(app) as AndroidInstalledAppInfo;
       userApps.push(info);
-      queryApps.push(toQueryUserApp(info));
+      queryApps.push(toQueryAndroidApp(info));
     }
   }
 
@@ -183,6 +192,40 @@ function extractIosDisplayName(app: Record<string, unknown>): string | undefined
   ]);
 }
 
+function extractIosVersion(app: Record<string, unknown>): string | undefined {
+  return readIosAppField(app, [
+    "bundleShortVersionString",
+    "bundleVersion",
+    "CFBundleShortVersionString",
+    "CFBundleVersion",
+    "BundleShortVersionString",
+    "BundleVersion",
+    "version"
+  ]);
+}
+
+function extractIosPath(app: Record<string, unknown>): string | undefined {
+  return readIosAppField(app, [
+    "bundlePath",
+    "bundleContainer",
+    "path",
+    "Path",
+    "dataContainer"
+  ]);
+}
+
+function toQueryIosApp(app: IosInstalledAppInfo): AppsQueryAppInfo {
+  return {
+    packageName: app.bundleId,
+    type: "user",
+    userId: 0,
+    userProfile: "personal",
+    foreground: false,
+    recent: false,
+    displayName: app.displayName
+  };
+}
+
 function recordAppsQueryUri(deviceId: string, uri: string): void {
   const now = Date.now();
   let entries = appsQueryUrisByDeviceId.get(deviceId);
@@ -226,14 +269,19 @@ function getAppsQueryUrisForDevice(deviceId: string): string[] {
   return uris;
 }
 
+function getInstalledAppIdentifier(app: InstalledAppInfo): string {
+  return "bundleId" in app ? app.bundleId : app.packageName;
+}
+
 function buildAppsByPackage(apps: InstalledAppInfo[]): Map<string, InstalledAppInfo[]> {
   const appsByPackage = new Map<string, InstalledAppInfo[]>();
   for (const app of apps) {
-    const existing = appsByPackage.get(app.packageName);
+    const identifier = getInstalledAppIdentifier(app);
+    const existing = appsByPackage.get(identifier);
     if (existing) {
       existing.push(app);
     } else {
-      appsByPackage.set(app.packageName, [app]);
+      appsByPackage.set(identifier, [app]);
     }
   }
   return appsByPackage;
@@ -295,7 +343,7 @@ async function fetchAppsForDevice(device: BootedDevice): Promise<AppsCacheEntry>
 
   const simctl = new SimCtlClient(device);
   const installedApps = await simctl.listApps();
-  const apps: InstalledAppInfo[] = [];
+  const apps: IosInstalledAppInfo[] = [];
   const queryApps: AppsQueryAppInfo[] = [];
 
   for (const app of installedApps) {
@@ -304,17 +352,17 @@ async function fetchAppsForDevice(device: BootedDevice): Promise<AppsCacheEntry>
       continue;
     }
     const displayName = extractIosDisplayName(app as Record<string, unknown>);
-    const info: InstalledAppInfo = {
-      packageName: bundleId,
-      userId: 0,
-      userProfile: "personal",
-      foreground: false,
-      recent: false
+    const version = extractIosVersion(app as Record<string, unknown>);
+    const path = extractIosPath(app as Record<string, unknown>);
+    const info: IosInstalledAppInfo = {
+      bundleId,
+      displayName,
+      ...(version ? { version } : {}),
+      ...(path ? { path } : {})
     };
     apps.push(info);
     queryApps.push({
-      ...toQueryUserApp(info),
-      displayName
+      ...toQueryIosApp(info)
     });
   }
 

--- a/src/server/bootedDeviceResources.ts
+++ b/src/server/bootedDeviceResources.ts
@@ -3,6 +3,7 @@ import { MultiPlatformDeviceManager, PlatformDeviceManager } from "../utils/devi
 import { logger } from "../utils/logger";
 import { BootedDevice, Platform } from "../models";
 import { DaemonState } from "../daemon/daemonState";
+import type { Session } from "../daemon/sessionManager";
 import type { DevicePool } from "../daemon/devicePool";
 
 // Resource URIs
@@ -18,8 +19,10 @@ export interface BootedDeviceInfo {
   deviceId: string;
   source: "local" | "remote";
   isVirtual: boolean;
+  status: "booted";
   poolStatus?: PoolDeviceStatus;
   assignedSession?: string;
+  session?: DeviceSessionInfo;
 }
 
 // Resource content schema
@@ -42,6 +45,16 @@ export interface PoolStatusSummary {
   assigned: number;
   error: number;
   total: number;
+}
+
+export interface DeviceSessionInfo {
+  sessionId: string;
+  createdAt: string;
+  lastUsedAt: string;
+  lastHeartbeat: string;
+  expiresAt: string;
+  heartbeatTimeoutMs: number;
+  hasReceivedHeartbeat: boolean;
 }
 
 interface PoolDeviceInfo {
@@ -72,23 +85,31 @@ export function getDeviceManager(): PlatformDeviceManager {
 }
 
 // Convert BootedDevice to BootedDeviceInfo
-function toBootedDeviceInfo(device: BootedDevice, poolInfo?: PoolDeviceInfo): BootedDeviceInfo {
+function toBootedDeviceInfo(
+  device: BootedDevice,
+  poolInfo?: PoolDeviceInfo,
+  sessionInfo?: DeviceSessionInfo
+): BootedDeviceInfo {
   const info: BootedDeviceInfo = {
     name: device.name,
     platform: device.platform,
     deviceId: device.deviceId,
     source: device.source || "local",
-    isVirtual: isVirtualDevice(device)
+    isVirtual: isVirtualDevice(device),
+    status: "booted"
   };
 
-  if (!poolInfo) {
+  if (!poolInfo && !sessionInfo) {
     return info;
   }
 
   return {
     ...info,
-    poolStatus: poolInfo.poolStatus,
-    ...(poolInfo.assignedSession ? { assignedSession: poolInfo.assignedSession } : {})
+    ...(poolInfo ? {
+      poolStatus: poolInfo.poolStatus,
+      ...(poolInfo.assignedSession ? { assignedSession: poolInfo.assignedSession } : {})
+    } : {}),
+    ...(sessionInfo ? { session: sessionInfo } : {})
   };
 }
 
@@ -117,6 +138,18 @@ function getPoolDeviceInfo(devicePool: DevicePool | null, deviceId: string): Poo
   return {
     poolStatus,
     assignedSession: pooledDevice.sessionId || undefined
+  };
+}
+
+function toDeviceSessionInfo(session: Session): DeviceSessionInfo {
+  return {
+    sessionId: session.sessionId,
+    createdAt: new Date(session.createdAt).toISOString(),
+    lastUsedAt: new Date(session.lastUsedAt).toISOString(),
+    lastHeartbeat: new Date(session.lastHeartbeat).toISOString(),
+    expiresAt: new Date(session.expiresAt).toISOString(),
+    heartbeatTimeoutMs: session.heartbeatTimeoutMs,
+    hasReceivedHeartbeat: session.hasReceivedHeartbeat
   };
 }
 
@@ -160,6 +193,7 @@ async function getBootedDevicesForPlatforms(platforms: Platform[]): Promise<Boot
   let iosCount = 0;
   let devicePool: DevicePool | null = null;
   let poolStatus: PoolStatusSummary | undefined;
+  let sessionInfoByDeviceId: Map<string, DeviceSessionInfo> | null = null;
 
   const daemonState = DaemonState.getInstance();
   if (daemonState.isInitialized()) {
@@ -177,6 +211,17 @@ async function getBootedDevicesForPlatforms(platforms: Platform[]): Promise<Boot
       logger.warn(`[BootedDeviceResources] Failed to read device pool status: ${error}`);
       devicePool = null;
     }
+
+    try {
+      const sessionManager = daemonState.getSessionManager();
+      const sessions = sessionManager.getAllSessions();
+      sessionInfoByDeviceId = new Map(
+        sessions.map(session => [session.assignedDevice, toDeviceSessionInfo(session)])
+      );
+    } catch (error) {
+      logger.warn(`[BootedDeviceResources] Failed to read session manager state: ${error}`);
+      sessionInfoByDeviceId = null;
+    }
   }
 
   try {
@@ -185,7 +230,13 @@ async function getBootedDevicesForPlatforms(platforms: Platform[]): Promise<Boot
       try {
         const androidDevices = await deviceManager.getBootedDevices("android");
         for (const device of androidDevices) {
-          devices.push(toBootedDeviceInfo(device, getPoolDeviceInfo(devicePool, device.deviceId)));
+          devices.push(
+            toBootedDeviceInfo(
+              device,
+              getPoolDeviceInfo(devicePool, device.deviceId),
+              sessionInfoByDeviceId?.get(device.deviceId)
+            )
+          );
           androidCount++;
         }
       } catch (error) {
@@ -198,7 +249,13 @@ async function getBootedDevicesForPlatforms(platforms: Platform[]): Promise<Boot
       try {
         const iosDevices = await deviceManager.getBootedDevices("ios");
         for (const device of iosDevices) {
-          devices.push(toBootedDeviceInfo(device, getPoolDeviceInfo(devicePool, device.deviceId)));
+          devices.push(
+            toBootedDeviceInfo(
+              device,
+              getPoolDeviceInfo(devicePool, device.deviceId),
+              sessionInfoByDeviceId?.get(device.deviceId)
+            )
+          );
           iosCount++;
         }
       } catch (error) {

--- a/src/server/deviceImageResources.ts
+++ b/src/server/deviceImageResources.ts
@@ -23,6 +23,10 @@ export interface DeviceImageInfo {
   target?: string;
   basedOn?: string;
   error?: string;
+  // iOS simulator metadata (iOS only)
+  state?: string;
+  iosVersion?: string;
+  deviceType?: string;
 }
 
 // Resource content schema
@@ -202,7 +206,11 @@ function toDeviceImageInfo(device: DeviceInfo, avdInfo?: AvdInfo): DeviceImageIn
     path: avdInfo?.path,
     target: avdInfo?.target,
     basedOn: avdInfo?.basedOn,
-    error: avdInfo?.error
+    error: avdInfo?.error,
+    // iOS simulator metadata
+    state: device.state,
+    iosVersion: device.iosVersion,
+    deviceType: device.deviceType
   };
 }
 
@@ -324,4 +332,12 @@ export function registerDeviceImageResources(): void {
   );
 
   logger.info("[DeviceImageResources] Registered device image resources");
+}
+
+export async function notifyDeviceImageResourcesUpdated(): Promise<void> {
+  await ResourceRegistry.notifyResourcesUpdated([
+    DEVICE_IMAGE_RESOURCE_URIS.ALL_IMAGES,
+    `${DEVICE_IMAGE_RESOURCE_URIS.ALL_IMAGES}/android`,
+    `${DEVICE_IMAGE_RESOURCE_URIS.ALL_IMAGES}/ios`
+  ]);
 }

--- a/src/server/deviceTools.ts
+++ b/src/server/deviceTools.ts
@@ -4,7 +4,7 @@ import { MultiPlatformDeviceManager, PlatformDeviceManager } from "../utils/devi
 import { createJSONToolResponse } from "../utils/toolUtils";
 import { ActionableError, BootedDevice, DeviceInfo, SomePlatform } from "../models";
 import { BOOTED_DEVICE_RESOURCE_URIS, notifyBootedDeviceResourcesUpdated } from "./bootedDeviceResources";
-import { DEVICE_IMAGE_RESOURCE_URIS } from "./deviceImageResources";
+import { DEVICE_IMAGE_RESOURCE_URIS, notifyDeviceImageResourcesUpdated } from "./deviceImageResources";
 import { syncInstalledAppResources } from "./appResources";
 import { listActiveVideoRecordings, stopVideoRecording } from "./videoRecordingManager";
 import { logger } from "../utils/logger";
@@ -148,6 +148,7 @@ export function registerDeviceTools() {
 
       // Notify that booted device resources have changed
       await notifyBootedDeviceResourcesUpdated();
+      await notifyDeviceImageResourcesUpdated();
       await syncInstalledAppResources();
 
       return createJSONToolResponse({
@@ -193,6 +194,7 @@ export function registerDeviceTools() {
 
       // Notify that booted device resources have changed
       await notifyBootedDeviceResourcesUpdated();
+      await notifyDeviceImageResourcesUpdated();
       await syncInstalledAppResources();
 
       return createJSONToolResponse({

--- a/src/utils/ios-cmdline-tools/SimCtlClient.ts
+++ b/src/utils/ios-cmdline-tools/SimCtlClient.ts
@@ -263,6 +263,24 @@ function splitCommandArgs(command: string): string[] {
   return args;
 }
 
+function normalizeIosVersion(runtimeId: string | undefined, osVersion: string | undefined): string | undefined {
+  const trimmedOsVersion = osVersion?.trim();
+  if (trimmedOsVersion) {
+    return trimmedOsVersion;
+  }
+
+  if (!runtimeId) {
+    return undefined;
+  }
+
+  const match = runtimeId.match(/iOS[-_](\d+(?:[-_]\d+)*)/);
+  if (!match) {
+    return undefined;
+  }
+
+  return match[1].replace(/_/g, ".").replace(/-/g, ".");
+}
+
 /**
  * This file provides an interface to interact with iOS simulators using simctl.
  * It allows you to list, create, boot, and delete simulators.
@@ -463,7 +481,7 @@ export class SimCtlClient implements SimCtl {
       const devices: DeviceInfo[] = [];
 
       // Extract all devices from all runtime versions
-      for (const runtimeDevices of Object.values(simulatorList.devices)) {
+      for (const [runtimeId, runtimeDevices] of Object.entries(simulatorList.devices)) {
         for (const device of runtimeDevices) {
           if (device.isAvailable) {
             logger.debug(`Found iOS simulator: ${device.name} (${device.udid})`);
@@ -471,7 +489,10 @@ export class SimCtlClient implements SimCtl {
               name: device.name,
               platform: "ios",
               deviceId: device.udid,
-              isRunning: device.state === "Booted"
+              isRunning: device.state === "Booted",
+              state: device.state,
+              iosVersion: normalizeIosVersion(runtimeId, device.os_version),
+              deviceType: device.deviceTypeIdentifier
             } as DeviceInfo);
           }
         }

--- a/test/server/resources/deviceImages.test.ts
+++ b/test/server/resources/deviceImages.test.ts
@@ -144,6 +144,33 @@ describe("Device Image Resources with Fakes", () => {
       }
     });
 
+    test("should pass through iOS simulator metadata", async () => {
+      const iosDevices: DeviceInfo[] = [
+        {
+          name: "iPhone 15 Pro",
+          platform: "ios",
+          deviceId: "sim-15-pro",
+          source: "local",
+          state: "Booted",
+          iosVersion: "17.4",
+          deviceType: "com.apple.CoreSimulator.SimDeviceType.iPhone-15-Pro"
+        }
+      ];
+      fakeDeviceUtils.setDeviceImages("ios", iosDevices);
+      fakeAvdManager.setListDeviceImagesResponse([]);
+
+      const handler = createDeviceImageResourcesHandler({
+        deviceManager: fakeDeviceUtils,
+        avdManager: fakeAvdManager
+      });
+
+      const result = await handler.getDeviceImagesForPlatforms(["ios"]);
+      expect(result.totalCount).toBe(1);
+      expect(result.images[0].state).toBe("Booted");
+      expect(result.images[0].iosVersion).toBe("17.4");
+      expect(result.images[0].deviceType).toBe("com.apple.CoreSimulator.SimDeviceType.iPhone-15-Pro");
+    });
+
     test("should include extended AVD metadata for Android images", async () => {
       // Set up mock Android devices
       const androidDevices: DeviceInfo[] = [


### PR DESCRIPTION
## Summary
- enrich iOS simulator listings with state/version/type metadata
- embed session/status info into booted device resources
- return iOS-specific app fields in device app resources and notify image updates on start/kill

## Testing
- bun test test/server/resources/deviceImages.test.ts

Closes #868
