### PR TITLE
Add iOS simulator snapshot tests

### DIFF
--- a/test/fakes/FakeSimCtlClient.ts
+++ b/test/fakes/FakeSimCtlClient.ts
@@ -1,0 +1,85 @@
+import type { ExecResult } from "../../src/models";
+import type { AppleDevice, AppleDeviceRuntime } from "../../src/utils/ios-cmdline-tools/SimCtlClient";
+
+const buildExecResult = (stdout: string): ExecResult => ({
+  stdout,
+  stderr: "",
+  toString: () => stdout,
+  trim: () => stdout.trim(),
+  includes: (value: string) => stdout.includes(value),
+});
+
+export class FakeSimCtlClient {
+  private deviceInfo = new Map<string, AppleDevice | null>();
+  private runtimes: AppleDeviceRuntime[] = [];
+  private installedApps: any[] = [];
+  private containerPaths = new Map<string, string>();
+  private containerErrors = new Map<string, Error>();
+  private methodCalls = new Map<string, Array<Record<string, unknown>>>();
+
+  setDeviceInfo(udid: string, info: AppleDevice | null): void {
+    this.deviceInfo.set(udid, info);
+  }
+
+  setRuntimes(runtimes: AppleDeviceRuntime[]): void {
+    this.runtimes = runtimes;
+  }
+
+  setInstalledApps(apps: any[]): void {
+    this.installedApps = apps;
+  }
+
+  setContainerPath(bundleId: string, containerPath: string): void {
+    this.containerPaths.set(bundleId, containerPath);
+  }
+
+  setContainerError(bundleId: string, error: Error): void {
+    this.containerErrors.set(bundleId, error);
+  }
+
+  getMethodCalls(methodName: string): Array<Record<string, unknown>> {
+    return this.methodCalls.get(methodName) ?? [];
+  }
+
+  private recordCall(methodName: string, params: Record<string, unknown>): void {
+    if (!this.methodCalls.has(methodName)) {
+      this.methodCalls.set(methodName, []);
+    }
+    this.methodCalls.get(methodName)!.push(params);
+  }
+
+  async executeCommand(command: string, timeoutMs?: number): Promise<ExecResult> {
+    this.recordCall("executeCommand", { command, timeoutMs });
+    const match = command.match(/get_app_container\s+\"([^\"]+)\"\s+\"([^\"]+)\"\s+data/);
+    const bundleId = match?.[2];
+    if (bundleId) {
+      const error = this.containerErrors.get(bundleId);
+      if (error) {
+        throw error;
+      }
+      const containerPath = this.containerPaths.get(bundleId) ?? "";
+      return buildExecResult(containerPath);
+    }
+
+    return buildExecResult("");
+  }
+
+  async getDeviceInfo(udid: string): Promise<AppleDevice | null> {
+    this.recordCall("getDeviceInfo", { udid });
+    return this.deviceInfo.get(udid) ?? null;
+  }
+
+  async getRuntimes(): Promise<AppleDeviceRuntime[]> {
+    this.recordCall("getRuntimes", {});
+    return this.runtimes;
+  }
+
+  async listApps(deviceId?: string): Promise<any[]> {
+    this.recordCall("listApps", { deviceId });
+    return this.installedApps;
+  }
+
+  async terminateApp(bundleId: string, deviceId?: string): Promise<void> {
+    this.recordCall("terminateApp", { bundleId, deviceId });
+  }
+}

--- a/test/features/action/CaptureSnapshotIos.test.ts
+++ b/test/features/action/CaptureSnapshotIos.test.ts
@@ -1,0 +1,120 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { promises as fs } from "fs";
+import * as os from "os";
+import * as path from "path";
+import { CaptureSnapshotIos } from "../../../src/features/action/CaptureSnapshotIos";
+import type { BootedDevice } from "../../../src/models";
+import { DeviceSnapshotStore } from "../../../src/utils/DeviceSnapshotStore";
+import { FakeSimCtlClient } from "../../fakes/FakeSimCtlClient";
+
+describe("CaptureSnapshotIos", () => {
+  let device: BootedDevice;
+  let simctl: FakeSimCtlClient;
+  let store: DeviceSnapshotStore;
+  let testBasePath: string;
+
+  beforeEach(async () => {
+    device = {
+      deviceId: "ios-device-1",
+      name: "iPhone 15",
+      platform: "ios",
+    };
+
+    simctl = new FakeSimCtlClient();
+    testBasePath = await fs.mkdtemp(path.join(os.tmpdir(), "snapshot-ios-capture-"));
+    store = new DeviceSnapshotStore(testBasePath);
+  });
+
+  afterEach(async () => {
+    try {
+      await fs.rm(testBasePath, { recursive: true, force: true });
+    } catch {
+      // Ignore cleanup errors
+    }
+  });
+
+  it("captures app data and writes metadata", async () => {
+    const snapshotName = "ios-snapshot";
+    const bundleId = "com.example.app";
+    const containerRoot = path.join(testBasePath, "containers", bundleId);
+    const documentsPath = path.join(containerRoot, "Documents");
+    await fs.mkdir(documentsPath, { recursive: true });
+    await fs.writeFile(path.join(documentsPath, "data.txt"), "hello");
+
+    simctl.setContainerPath(bundleId, containerRoot);
+    simctl.setDeviceInfo(device.deviceId, {
+      udid: device.deviceId,
+      name: "iPhone 15",
+      state: "Booted",
+      isAvailable: true,
+      deviceTypeIdentifier: "com.apple.CoreSimulator.SimDeviceType.iPhone-15",
+      os_version: "17.2",
+    });
+
+    const captureSnapshot = new CaptureSnapshotIos(
+      device,
+      simctl as any,
+      store
+    );
+
+    const result = await captureSnapshot.execute({
+      snapshotName,
+      includeAppData: true,
+      includeSettings: true,
+      appBundleIds: [bundleId, "com.apple.Preferences", ` ${bundleId} `],
+    });
+
+    const pathOptions = { platform: "ios", deviceId: device.deviceId } as const;
+    const metadataPath = store.getMetadataPath(snapshotName, pathOptions);
+    const metadataJson = await fs.readFile(metadataPath, "utf-8");
+    const parsed = JSON.parse(metadataJson) as typeof result.manifest;
+
+    expect(result.manifest.includeSettings).toBe(false);
+    expect(result.manifest.deviceType).toBe("com.apple.CoreSimulator.SimDeviceType.iPhone-15");
+    expect(result.manifest.osVersion).toBe("17.2");
+    expect(parsed.snapshotName).toBe(snapshotName);
+    expect(parsed.platform).toBe("ios");
+    expect(parsed.appDataBackup?.backedUpPackages).toEqual([bundleId]);
+    expect(parsed.appDataBackup?.skippedPackages).toEqual(["com.apple.Preferences"]);
+    expect(parsed.appDataBackup?.totalPackages).toBe(2);
+
+    const appDataPath = store.getAppDataPath(snapshotName, pathOptions);
+    const copiedFile = await fs.readFile(
+      path.join(appDataPath, bundleId, "Documents", "data.txt"),
+      "utf-8"
+    );
+    expect(copiedFile).toBe("hello");
+  });
+
+  it("fails when strictBackupMode is enabled and app data backup fails", async () => {
+    const captureSnapshot = new CaptureSnapshotIos(
+      device,
+      simctl as any,
+      store
+    );
+
+    await expect(captureSnapshot.execute({
+      snapshotName: "strict-backup",
+      includeAppData: true,
+      strictBackupMode: true,
+      appBundleIds: ["com.example.missing"],
+    })).rejects.toThrow("Failed to backup app data");
+  });
+
+  it("marks backup as none when no bundle IDs are provided", async () => {
+    const captureSnapshot = new CaptureSnapshotIos(
+      device,
+      simctl as any,
+      store
+    );
+
+    const result = await captureSnapshot.execute({
+      snapshotName: "no-bundles",
+      includeAppData: true,
+      appBundleIds: [],
+    });
+
+    expect(result.manifest.appDataBackup?.backupMethod).toBe("none");
+    expect(result.manifest.appDataBackup?.totalPackages).toBe(0);
+  });
+});

--- a/test/features/action/RestoreSnapshotIos.test.ts
+++ b/test/features/action/RestoreSnapshotIos.test.ts
@@ -1,0 +1,209 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { promises as fs } from "fs";
+import * as os from "os";
+import * as path from "path";
+import { RestoreSnapshotIos } from "../../../src/features/action/RestoreSnapshotIos";
+import type { BootedDevice, DeviceSnapshotManifest } from "../../../src/models";
+import { DeviceSnapshotStore } from "../../../src/utils/DeviceSnapshotStore";
+import { FakeSimCtlClient } from "../../fakes/FakeSimCtlClient";
+
+describe("RestoreSnapshotIos", () => {
+  let device: BootedDevice;
+  let simctl: FakeSimCtlClient;
+  let store: DeviceSnapshotStore;
+  let testBasePath: string;
+
+  beforeEach(async () => {
+    device = {
+      deviceId: "ios-device-1",
+      name: "iPhone 15",
+      platform: "ios",
+    };
+
+    simctl = new FakeSimCtlClient();
+    testBasePath = await fs.mkdtemp(path.join(os.tmpdir(), "snapshot-ios-restore-"));
+    store = new DeviceSnapshotStore(testBasePath);
+  });
+
+  afterEach(async () => {
+    try {
+      await fs.rm(testBasePath, { recursive: true, force: true });
+    } catch {
+      // Ignore cleanup errors
+    }
+  });
+
+  it("restores app data using fallback device path", async () => {
+    const snapshotName = "restore-snapshot";
+    const bundleId = "com.example.app";
+    const appDataPath = store.getAppDataPath(snapshotName, {
+      platform: "ios",
+      deviceId: device.deviceId,
+    });
+    await fs.mkdir(path.join(appDataPath, bundleId, "Documents"), { recursive: true });
+    await fs.writeFile(path.join(appDataPath, bundleId, "Documents", "data.txt"), "new-data");
+
+    const containerRoot = path.join(testBasePath, "containers", bundleId);
+    await fs.mkdir(path.join(containerRoot, "Documents"), { recursive: true });
+    await fs.writeFile(path.join(containerRoot, "Documents", "data.txt"), "old-data");
+
+    simctl.setContainerPath(bundleId, containerRoot);
+    simctl.setInstalledApps([{ bundleId }]);
+
+    const manifest: DeviceSnapshotManifest = {
+      snapshotName,
+      timestamp: new Date().toISOString(),
+      deviceId: "other-device",
+      deviceName: device.name,
+      platform: "ios",
+      snapshotType: "app_data",
+      includeAppData: true,
+      includeSettings: false,
+      appDataBackup: {
+        backupMethod: "simctl_copy",
+        backedUpPackages: [bundleId],
+      },
+    };
+
+    const restoreSnapshot = new RestoreSnapshotIos(
+      device,
+      simctl as any,
+      store
+    );
+
+    await restoreSnapshot.execute({
+      snapshotName,
+      manifest,
+      useVmSnapshot: false,
+    });
+
+    const restored = await fs.readFile(
+      path.join(containerRoot, "Documents", "data.txt"),
+      "utf-8"
+    );
+    expect(restored).toBe("new-data");
+    expect(simctl.getMethodCalls("terminateApp")).toHaveLength(1);
+  });
+
+  it("throws when required app is not installed", async () => {
+    const snapshotName = "missing-app";
+    const appDataPath = store.getAppDataPath(snapshotName, {
+      platform: "ios",
+      deviceId: device.deviceId,
+    });
+    await fs.mkdir(appDataPath, { recursive: true });
+    simctl.setInstalledApps([{ bundleId: "com.example.other" }]);
+
+    const restoreSnapshot = new RestoreSnapshotIos(
+      device,
+      simctl as any,
+      store
+    );
+
+    const manifest: DeviceSnapshotManifest = {
+      snapshotName,
+      timestamp: new Date().toISOString(),
+      deviceId: device.deviceId,
+      deviceName: device.name,
+      platform: "ios",
+      snapshotType: "app_data",
+      includeAppData: true,
+      includeSettings: false,
+      appDataBackup: {
+        backupMethod: "simctl_copy",
+        backedUpPackages: ["com.example.missing"],
+      },
+    };
+
+    await expect(restoreSnapshot.execute({
+      snapshotName,
+      manifest,
+      useVmSnapshot: false,
+    })).rejects.toThrow("App(s) not installed");
+  });
+
+  it("throws on major iOS version mismatch", async () => {
+    const restoreSnapshot = new RestoreSnapshotIos(
+      device,
+      simctl as any,
+      store
+    );
+
+    simctl.setDeviceInfo(device.deviceId, {
+      udid: device.deviceId,
+      name: device.name,
+      state: "Booted",
+      isAvailable: true,
+      runtime: "com.apple.CoreSimulator.SimRuntime.iOS-17-0",
+    });
+    simctl.setRuntimes([{
+      bundlePath: "/runtime",
+      buildversion: "A123",
+      runtimeRoot: "/runtime/root",
+      identifier: "com.apple.CoreSimulator.SimRuntime.iOS-17-0",
+      version: "17.0",
+      isAvailable: true,
+      name: "iOS 17.0",
+    }]);
+
+    const manifest: DeviceSnapshotManifest = {
+      snapshotName: "version-mismatch",
+      timestamp: new Date().toISOString(),
+      deviceId: device.deviceId,
+      deviceName: device.name,
+      platform: "ios",
+      snapshotType: "app_data",
+      includeAppData: true,
+      includeSettings: false,
+      osVersion: "iOS 16.4",
+      appDataBackup: {
+        backupMethod: "simctl_copy",
+        backedUpPackages: ["com.example.app"],
+      },
+    };
+
+    await expect(restoreSnapshot.execute({
+      snapshotName: "version-mismatch",
+      manifest,
+      useVmSnapshot: false,
+    })).rejects.toThrow("incompatible");
+  });
+
+  it("skips restore when backup method is none", async () => {
+    const snapshotName = "no-backup";
+    const appDataPath = store.getAppDataPath(snapshotName, {
+      platform: "ios",
+      deviceId: device.deviceId,
+    });
+    await fs.mkdir(appDataPath, { recursive: true });
+
+    const restoreSnapshot = new RestoreSnapshotIos(
+      device,
+      simctl as any,
+      store
+    );
+
+    const manifest: DeviceSnapshotManifest = {
+      snapshotName,
+      timestamp: new Date().toISOString(),
+      deviceId: device.deviceId,
+      deviceName: device.name,
+      platform: "ios",
+      snapshotType: "app_data",
+      includeAppData: true,
+      includeSettings: false,
+      appDataBackup: {
+        backupMethod: "none",
+      },
+    };
+
+    await restoreSnapshot.execute({
+      snapshotName,
+      manifest,
+      useVmSnapshot: false,
+    });
+
+    expect(simctl.getMethodCalls("executeCommand")).toHaveLength(0);
+    expect(simctl.getMethodCalls("terminateApp")).toHaveLength(0);
+  });
+});

--- a/test/server/snapshotTools.test.ts
+++ b/test/server/snapshotTools.test.ts
@@ -1,0 +1,158 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, test } from "bun:test";
+import type { BootedDevice, DeviceSnapshotManifest } from "../../src/models";
+import { registerSnapshotTools } from "../../src/server/snapshotTools";
+import { ToolRegistry } from "../../src/server/toolRegistry";
+import {
+  resetDeviceSnapshotManagerDependencies,
+  setDeviceSnapshotManagerDependencies,
+} from "../../src/server/deviceSnapshotManager";
+import { FakeDeviceSnapshotRepository } from "../fakes/FakeDeviceSnapshotRepository";
+import { FakeDeviceSnapshotConfigRepository } from "../fakes/FakeDeviceSnapshotConfigRepository";
+import { FakeDeviceSnapshotStore } from "../fakes/FakeDeviceSnapshotStore";
+import { FakeTimer } from "../fakes/FakeTimer";
+
+describe("snapshot tool", () => {
+  let repository: FakeDeviceSnapshotRepository;
+  let configRepository: FakeDeviceSnapshotConfigRepository;
+  let store: FakeDeviceSnapshotStore;
+  let fakeTimer: FakeTimer;
+  let captureCalls: Array<Record<string, unknown>>;
+  let restoreCalls: Array<Record<string, unknown>>;
+
+  const device: BootedDevice = {
+    deviceId: "ios-device-1",
+    name: "iPhone 15",
+    platform: "ios",
+  };
+
+  beforeAll(async () => {
+    repository = new FakeDeviceSnapshotRepository();
+    configRepository = new FakeDeviceSnapshotConfigRepository();
+    store = new FakeDeviceSnapshotStore();
+    fakeTimer = new FakeTimer();
+    fakeTimer.setManualMode();
+    captureCalls = [];
+    restoreCalls = [];
+
+    await setDeviceSnapshotManagerDependencies({
+      snapshotRepository: repository as any,
+      configRepository: configRepository as any,
+      snapshotStore: store as any,
+      timer: fakeTimer,
+      now: () => new Date(fakeTimer.now()),
+      createCaptureAction: () => ({
+        execute: async args => {
+          captureCalls.push({ ...args });
+          const timestamp = new Date(fakeTimer.now()).toISOString();
+          const manifest: DeviceSnapshotManifest = {
+            snapshotName: args.snapshotName,
+            timestamp,
+            deviceId: device.deviceId,
+            deviceName: device.name,
+            platform: device.platform,
+            snapshotType: "app_data",
+            includeAppData: args.includeAppData ?? true,
+            includeSettings: false,
+          };
+          return {
+            snapshotName: args.snapshotName,
+            timestamp,
+            snapshotType: "app_data",
+            manifest,
+          };
+        },
+      }),
+      createRestoreAction: () => ({
+        execute: async args => {
+          restoreCalls.push({ ...args });
+          return {
+            snapshotType: args.manifest.snapshotType,
+            restoredAt: new Date(fakeTimer.now()).toISOString(),
+          };
+        },
+      }),
+    });
+
+    if (!ToolRegistry.getTool("deviceSnapshot")) {
+      registerSnapshotTools();
+    }
+  });
+
+  beforeEach(() => {
+    captureCalls = [];
+    restoreCalls = [];
+  });
+
+  afterAll(() => {
+    resetDeviceSnapshotManagerDependencies();
+  });
+
+  test("captures snapshot and returns payload", async () => {
+    const tool = ToolRegistry.getTool("deviceSnapshot");
+    expect(tool?.deviceAwareHandler).toBeDefined();
+
+    const response = await tool!.deviceAwareHandler!(device, {
+      action: "capture",
+      snapshotName: "snapshot-1",
+      includeAppData: true,
+      appBundleIds: ["com.example.app"],
+    });
+
+    const payload = JSON.parse(response.content?.[0]?.text ?? "{}");
+    expect(payload.snapshotName).toBe("snapshot-1");
+    expect(payload.snapshotType).toBe("app_data");
+    expect(payload.message).toContain("captured successfully");
+    expect(captureCalls).toHaveLength(1);
+    expect(captureCalls[0]?.appBundleIds).toEqual(["com.example.app"]);
+  });
+
+  test("restores snapshot and returns payload", async () => {
+    const tool = ToolRegistry.getTool("deviceSnapshot");
+    expect(tool?.deviceAwareHandler).toBeDefined();
+
+    const manifest: DeviceSnapshotManifest = {
+      snapshotName: "snapshot-restore",
+      timestamp: new Date(fakeTimer.now()).toISOString(),
+      deviceId: device.deviceId,
+      deviceName: device.name,
+      platform: device.platform,
+      snapshotType: "app_data",
+      includeAppData: true,
+      includeSettings: false,
+    };
+
+    await repository.insertSnapshot({
+      snapshotName: "snapshot-restore",
+      deviceId: device.deviceId,
+      deviceName: device.name,
+      platform: device.platform,
+      snapshotType: "app_data",
+      includeAppData: true,
+      includeSettings: false,
+      createdAt: manifest.timestamp,
+      lastAccessedAt: manifest.timestamp,
+      sizeBytes: 0,
+      manifest,
+    });
+
+    const response = await tool!.deviceAwareHandler!(device, {
+      action: "restore",
+      snapshotName: "snapshot-restore",
+    });
+
+    const payload = JSON.parse(response.content?.[0]?.text ?? "{}");
+    expect(payload.snapshotName).toBe("snapshot-restore");
+    expect(payload.snapshotType).toBe("app_data");
+    expect(payload.message).toContain("restored successfully");
+    expect(restoreCalls).toHaveLength(1);
+  });
+
+  test("rejects restore without snapshotName", async () => {
+    const tool = ToolRegistry.getTool("deviceSnapshot");
+    expect(tool?.deviceAwareHandler).toBeDefined();
+
+    await expect(tool!.deviceAwareHandler!(device, {
+      action: "restore",
+    } as any)).rejects.toThrow("snapshotName is required");
+  });
+});


### PR DESCRIPTION
## Summary
- add a fake simctl client to drive iOS snapshot tests without real simulator calls
- add iOS snapshot capture/restore unit tests for metadata, app data handling, and compatibility checks
- cover deviceSnapshot tool capture/restore responses for iOS snapshots

## Testing
- bun test
- bun run build
- bun run lint

Closes #852
