### PR TITLE
Add iOS session enforcement for multi-simulator tools

### DIFF
--- a/src/server/toolRegistry.ts
+++ b/src/server/toolRegistry.ts
@@ -173,7 +173,7 @@ class ToolRegistryClass {
       let platform: SomePlatform = args.platform || "either";
 
       if (shouldResolveDevice) {
-        await this.enforceSessionUuidForMultipleIos(platform, sessionUuid);
+        await this.enforceSessionUuidForMultipleIos(platform, sessionUuid, providedDeviceId);
       }
 
       // If session UUID provided, resolve device from session
@@ -370,9 +370,10 @@ class ToolRegistryClass {
 
   private async enforceSessionUuidForMultipleIos(
     platform: SomePlatform,
-    sessionUuid: string | undefined
+    sessionUuid: string | undefined,
+    providedDeviceId: string | undefined
   ): Promise<void> {
-    if (sessionUuid) {
+    if (sessionUuid || providedDeviceId) {
       return;
     }
 

--- a/test/server/toolRegistry.iosSessionContext.test.ts
+++ b/test/server/toolRegistry.iosSessionContext.test.ts
@@ -73,4 +73,26 @@ describe("ToolRegistry iOS session context", () => {
     expect(response).toEqual({ success: true });
     expect(fakeDeviceSessionManager.getEnsureDeviceReadyCallCount()).toBe(1);
   });
+
+  test("allows explicit deviceId when multiple iOS simulators are booted", async () => {
+    fakeDeviceSessionManager.setConnectedDevices([iosDeviceA, iosDeviceB]);
+
+    ToolRegistry.registerDeviceAware(
+      "iosDeviceIdAllowedTool",
+      "Tool allows deviceId without sessionUuid when multiple iOS simulators are booted",
+      z.object({
+        platform: z.enum(["ios", "android"]).optional(),
+        deviceId: z.string().optional(),
+        sessionUuid: z.string().optional(),
+      }),
+      async () => ({ success: true })
+    );
+
+    const tool = ToolRegistry.getTool("iosDeviceIdAllowedTool");
+    expect(tool).toBeDefined();
+
+    const response = await tool!.handler({ platform: "ios", deviceId: "ios-device-b" });
+    expect(response).toEqual({ success: true });
+    expect(fakeDeviceSessionManager.getEnsureDeviceReadyCallCount()).toBe(1);
+  });
 });


### PR DESCRIPTION
## Summary
- require `sessionUuid` when multiple iOS simulators are booted to avoid ambiguous targeting
- add coverage for iOS session enforcement

## Testing
- `bun test test/server/toolRegistry.iosSessionContext.test.ts`

Closes #866
