### PR TITLE
Reduce wakeAndUnlock test duration

### DIFF
--- a/src/utils/android-cmdline-tools/AndroidEmulatorClient.ts
+++ b/src/utils/android-cmdline-tools/AndroidEmulatorClient.ts
@@ -6,6 +6,7 @@ import { AdbClient } from "./AdbClient";
 import { AdbExecutor } from "./interfaces/AdbExecutor";
 import { arch } from "os";
 import { detectAndroidCommandLineTools, getBestAndroidToolsLocation } from "./detection";
+import { defaultTimer, Timer } from "../SystemTimer";
 
 /**
  * Interface for Android Emulator (AVD) management
@@ -95,6 +96,7 @@ export class AndroidEmulatorClient implements AndroidEmulator {
   private execAsync: (command: string) => Promise<ExecResult>;
   private spawnFn: typeof spawn;
   private emulatorPath: string;
+  private timer: Timer;
 
   /**
    * Create an AndroidEmulatorClient instance
@@ -103,10 +105,12 @@ export class AndroidEmulatorClient implements AndroidEmulator {
    */
   constructor(
     execAsyncFn: ((command: string) => Promise<ExecResult>) | null = null,
-    spawnFn: typeof spawn | null = null
+    spawnFn: typeof spawn | null = null,
+    timer: Timer = defaultTimer
   ) {
     this.execAsync = execAsyncFn || execAsync;
     this.spawnFn = spawnFn || spawn;
+    this.timer = timer;
     // Only set a fallback emulator path here; proper detection happens lazily
     this.emulatorPath = this.getFallbackEmulatorPath();
   }
@@ -908,6 +912,6 @@ export class AndroidEmulatorClient implements AndroidEmulator {
    * @param ms - Milliseconds to sleep
    */
   private sleep(ms: number): Promise<void> {
-    return new Promise(resolve => setTimeout(resolve, ms));
+    return this.timer.sleep(ms);
   }
 }

--- a/test/utils/android-cmdline-tools/AndroidEmulatorClient-wakeAndUnlock.test.ts
+++ b/test/utils/android-cmdline-tools/AndroidEmulatorClient-wakeAndUnlock.test.ts
@@ -2,10 +2,12 @@ import { beforeEach, describe, expect, test } from "bun:test";
 import { AndroidEmulatorClient } from "../../../src/utils/android-cmdline-tools/AndroidEmulatorClient";
 import { FakeAdbExecutor } from "../../fakes/FakeAdbExecutor";
 import { ExecResult } from "../../../src/models";
+import { FakeTimer } from "../../fakes/FakeTimer";
 
 describe("AndroidEmulatorClient wakeAndUnlock", () => {
   let emulatorClient: AndroidEmulatorClient;
   let fakeAdb: FakeAdbExecutor;
+  let fakeTimer: FakeTimer;
 
   const createExecResult = (stdout: string, stderr: string = ""): ExecResult => ({
     stdout,
@@ -21,7 +23,8 @@ describe("AndroidEmulatorClient wakeAndUnlock", () => {
 
   beforeEach(() => {
     fakeAdb = new FakeAdbExecutor();
-    emulatorClient = new AndroidEmulatorClient(mockExecAsync, null);
+    fakeTimer = new FakeTimer();
+    emulatorClient = new AndroidEmulatorClient(mockExecAsync, null, fakeTimer);
   });
 
   test("should wake device and dismiss keyguard when device is Asleep", async () => {


### PR DESCRIPTION
## Summary
- inject a Timer into AndroidEmulatorClient so wake/unlock delays can use FakeTimer in tests
- update wakeAndUnlock tests to use FakeTimer for sub-100ms execution

## Testing
- bun test test/utils/android-cmdline-tools/AndroidEmulatorClient-wakeAndUnlock.test.ts
- bun test

Closes #919
