### PR TITLE
simctl integration: simulator lifecycle management

### DIFF
--- a/src/daemon/devicePool.ts
+++ b/src/daemon/devicePool.ts
@@ -2,7 +2,7 @@ import { logger } from "../utils/logger";
 import { SessionManager } from "./sessionManager";
 import { ActionableError, BootedDevice, Platform } from "../models";
 import { Mutex } from "async-mutex";
-import { MultiPlatformDeviceManager } from "../utils/deviceUtils";
+import { MultiPlatformDeviceManager, PlatformDeviceManager } from "../utils/deviceUtils";
 import { Timer, defaultTimer } from "../utils/SystemTimer";
 import type { InstalledAppsStore } from "../db/installedAppsRepository";
 import { InstalledAppsRepository } from "../db/installedAppsRepository";
@@ -50,6 +50,7 @@ export class DevicePool {
   private lastReleasedDeviceId: string | null = null;
   private daemonSessionId: string;
   private installedAppsRepository: InstalledAppsStore;
+  private deviceManager: PlatformDeviceManager;
 
   // Max consecutive errors before marking device as failed
   private readonly MAX_DEVICE_ERRORS = 5;
@@ -62,7 +63,8 @@ export class DevicePool {
     sessionManager: SessionManager,
     daemonSessionId: string,
     timer: Timer = defaultTimer,
-    installedAppsRepository?: InstalledAppsStore
+    installedAppsRepository?: InstalledAppsStore,
+    deviceManager?: PlatformDeviceManager
   ) {
     this.instanceId = ++DevicePool.instanceCounter;
     logger.info(`[DEVICE-POOL-DEBUG] Creating DevicePool instance #${this.instanceId}`);
@@ -70,6 +72,7 @@ export class DevicePool {
     this.daemonSessionId = daemonSessionId;
     this.timer = timer;
     this.installedAppsRepository = installedAppsRepository ?? new InstalledAppsRepository();
+    this.deviceManager = deviceManager ?? new MultiPlatformDeviceManager();
   }
 
   /**
@@ -118,8 +121,7 @@ export class DevicePool {
       const androidSdkRoot = process.env.ANDROID_SDK_ROOT || "(not set)";
       logger.info(`Environment: ANDROID_HOME=${androidHome}, ANDROID_SDK_ROOT=${androidSdkRoot}`);
 
-      const deviceManager = new MultiPlatformDeviceManager();
-      const bootedDevices = await deviceManager.getBootedDevices("either");
+      const bootedDevices = await this.deviceManager.getBootedDevices("either");
       const discoveryTime = Date.now() - startTime;
       logger.info(`Device discovery completed in ${discoveryTime}ms, found ${bootedDevices.length} devices`);
 
@@ -502,6 +504,17 @@ export class DevicePool {
 
       logger.info(`[DEVICE-POOL-DEBUG] tryAssignDevice: totalDevices = ${totalDevices}`);
 
+      if (!device && platform === "ios") {
+        const bootedSimulator = await this.maybeBootDedicatedIosSimulator();
+        if (bootedSimulator) {
+          candidates = this.getDevicesByPlatform(platform);
+          totalDevices = candidates.length;
+          device = candidates.find(d => d.status === "idle" && d.id === bootedSimulator.deviceId)
+            ?? candidates.find(d => d.status === "idle");
+          logger.info(`[DevicePool] Added dedicated iOS simulator ${bootedSimulator.deviceId} to pool`);
+        }
+      }
+
       if (!device) {
         // No idle device - check if devices exist but are busy
         const busyDevices = candidates.filter(
@@ -534,6 +547,35 @@ export class DevicePool {
         totalDevices,
       };
     });
+  }
+
+  private async maybeBootDedicatedIosSimulator(): Promise<BootedDevice | null> {
+    try {
+      const available = await this.deviceManager.listDeviceImages("ios");
+      const candidates = available
+        .filter(device => device.deviceId)
+        .filter(device => !this.devices.has(device.deviceId!))
+        .filter(device => !device.isRunning);
+
+      if (candidates.length === 0) {
+        return null;
+      }
+
+      candidates.sort((a, b) => (a.deviceId || "").localeCompare(b.deviceId || ""));
+      const selected = candidates[0];
+
+      logger.info(
+        `[DevicePool] Booting dedicated iOS simulator ${selected.name} (${selected.deviceId})`
+      );
+
+      await this.deviceManager.startDevice(selected);
+      const booted = await this.deviceManager.waitForDeviceReady(selected);
+      await this.addDevice(booted);
+      return booted;
+    } catch (error) {
+      logger.warn(`[DevicePool] Failed to boot dedicated iOS simulator: ${error}`);
+      return null;
+    }
   }
 
   /**

--- a/src/server/deviceTools.ts
+++ b/src/server/deviceTools.ts
@@ -132,6 +132,10 @@ export function registerDeviceTools() {
   // Start emulator handler
   const startDeviceHandler = async (args: StartDeviceArgs, progress?: ProgressCallback) => {
     try {
+      if (args.device.platform === "ios" && !args.device.deviceId) {
+        throw new ActionableError("iOS simulator deviceId (UDID) is required to start a simulator.");
+      }
+
       const deviceUtils = getDeviceToolsDependencies().deviceManagerFactory();
       const childProcess = await deviceUtils.startDevice(args.device);
 
@@ -199,7 +203,7 @@ export function registerDeviceTools() {
 
       return createJSONToolResponse({
         message: `${args.device.platform} '${args.device.name}' shutdown successfully`,
-        udid: args.device.name,
+        udid: args.device.deviceId,
         name: args.device.name,
         platform: args.device.platform
       });

--- a/src/utils/DeviceSessionManager.ts
+++ b/src/utils/DeviceSessionManager.ts
@@ -672,6 +672,7 @@ export class DeviceSessionManager implements DeviceSessionManager {
       throw new ActionableError("iOS simulator tools not available");
     }
     const allDevices = await this.simctl.listSimulatorImages();
+    allDevices.sort((a, b) => (a.deviceId || "").localeCompare(b.deviceId || ""));
 
     if (allDevices.length === 0) {
       throw new ActionableError(
@@ -681,10 +682,12 @@ export class DeviceSessionManager implements DeviceSessionManager {
 
     // Check for already booted simulators first
     const bootedDevices = await this.simctl.getBootedSimulators();
+    bootedDevices.sort((a, b) => a.deviceId.localeCompare(b.deviceId));
 
     if (bootedDevices.length > 0) {
       // Use the first booted device
       const device = bootedDevices[0];
+      logger.info(`[DeviceSessionManager] Selected booted iOS simulator ${device.name} (${device.deviceId})`);
       await this.verifyIosDevice(device.deviceId!, options);
       return device;
     }
@@ -692,7 +695,7 @@ export class DeviceSessionManager implements DeviceSessionManager {
     // No booted devices - boot the first available simulator
     const device = allDevices[0];
     const deviceId = device.deviceId!;
-    logger.info(`Booting iOS simulator ${device}...`);
+    logger.info(`[DeviceSessionManager] Booting iOS simulator ${device.name} (${deviceId})...`);
 
     const bootedDevice = await this.simctl!.bootSimulator(deviceId);
     await this.verifyIosDevice(deviceId, options);

--- a/src/utils/deviceUtils.ts
+++ b/src/utils/deviceUtils.ts
@@ -101,7 +101,7 @@ export class MultiPlatformDeviceManager implements PlatformDeviceManager {
       case "android":
         return this.emulator.isAvdRunning(device.name);
       case "ios":
-        return this.simctl.isSimulatorRunning(device.name);
+        return this.simctl.isSimulatorRunning(device.deviceId ?? device.name);
     }
   }
 
@@ -130,6 +130,10 @@ export class MultiPlatformDeviceManager implements PlatformDeviceManager {
   async startDevice(
     device: DeviceInfo
   ): Promise<ChildProcess> {
+    if (device.platform === "ios" && !device.deviceId) {
+      throw new ActionableError("iOS simulator deviceId (UDID) is required to start a simulator.");
+    }
+
     const isRunning = await this.isDeviceImageRunning(device);
     if (isRunning) {
       throw new ActionableError(
@@ -141,7 +145,7 @@ export class MultiPlatformDeviceManager implements PlatformDeviceManager {
       case "android":
         return this.emulator.startEmulator(device.name);
       case "ios":
-        return this.simctl.startSimulator(device.name);
+        return this.simctl.startSimulator(device.deviceId!);
       default:
         throw new ActionableError("Unknown platform");
     }
@@ -177,7 +181,10 @@ export class MultiPlatformDeviceManager implements PlatformDeviceManager {
       case "android":
         return this.emulator.waitForEmulatorReady(device.name, timeoutMs);
       case "ios":
-        return this.simctl.waitForSimulatorReady(device.name);
+        if (!device.deviceId) {
+          throw new ActionableError("iOS simulator deviceId (UDID) is required to wait for readiness.");
+        }
+        return this.simctl.waitForSimulatorReady(device.deviceId);
       default:
         throw new ActionableError("Unknown platform");
     }

--- a/src/utils/ios-cmdline-tools/SimCtlClient.ts
+++ b/src/utils/ios-cmdline-tools/SimCtlClient.ts
@@ -62,7 +62,7 @@ export interface SimCtl {
 
   /**
    * Check if a simulator is running by name
-   * @param name - Simulator name
+   * @param name - Simulator name or UDID
    * @returns Promise with boolean indicating if running
    */
   isSimulatorRunning(name: string): Promise<boolean>;
@@ -429,8 +429,10 @@ export class SimCtlClient implements SimCtl {
     }
   }
 
-  async isSimulatorRunning(name: string): Promise<boolean> {
-    return (await this.getBootedSimulators()).find(simulator => simulator.name === name) !== undefined;
+  async isSimulatorRunning(identifier: string): Promise<boolean> {
+    return (await this.getBootedSimulators()).some(simulator =>
+      simulator.deviceId === identifier || simulator.name === identifier
+    );
   }
 
   async startSimulator(udid: string): Promise<ChildProcess> {
@@ -518,6 +520,7 @@ export class SimCtlClient implements SimCtl {
         timestamp: Date.now()
       };
 
+      devices.sort((a, b) => (a.deviceId || "").localeCompare(b.deviceId || ""));
       return devices;
     } catch (error) {
       logger.warn(`Failed to get iOS devices: ${error}`);
@@ -544,6 +547,7 @@ export class SimCtlClient implements SimCtl {
         }
       }
 
+      bootedDevices.sort((a, b) => a.deviceId.localeCompare(b.deviceId));
       return bootedDevices;
     } catch (error) {
       logger.warn(`Failed to get booted iOS devices: ${error}`);

--- a/test/daemon/devicePool.test.ts
+++ b/test/daemon/devicePool.test.ts
@@ -3,6 +3,7 @@ import { DevicePool } from "../../src/daemon/devicePool";
 import { SessionManager } from "../../src/daemon/sessionManager";
 import { FakeTimer } from "../fakes/FakeTimer";
 import { FakeInstalledAppsRepository } from "../fakes/FakeInstalledAppsRepository";
+import { FakeDeviceUtils } from "../fakes/FakeDeviceUtils";
 import { BootedDevice } from "../../src/models";
 
 describe("DevicePool", () => {
@@ -138,6 +139,30 @@ describe("DevicePool", () => {
       await devicePool.releaseDevice(device1);
       const device2 = await devicePool.assignDeviceToSession("session-2");
       expect(device1).toBe(device2);
+    });
+
+    test("should boot a dedicated iOS simulator when pool is empty", async () => {
+      const fakeDeviceUtils = new FakeDeviceUtils();
+      fakeDeviceUtils.setDeviceImages("ios", [
+        {
+          name: "iPhone 15",
+          platform: "ios",
+          deviceId: "ios-udid-1",
+          isRunning: false
+        }
+      ]);
+
+      devicePool = new DevicePool(
+        sessionManager,
+        "test-daemon-session-id",
+        fakeTimer,
+        fakeAppsRepo,
+        fakeDeviceUtils
+      );
+
+      const deviceId = await devicePool.assignDeviceToSession("session-1", "ios");
+      expect(deviceId).toBe("ios-udid-1");
+      expect(fakeDeviceUtils.wasMethodCalled("startDevice")).toBe(true);
     });
   });
 

--- a/test/fakes/FakeDeviceUtils.ts
+++ b/test/fakes/FakeDeviceUtils.ts
@@ -37,6 +37,7 @@ export class FakeDeviceUtils implements PlatformDeviceManager {
     // Track running device names
     devices.forEach(device => {
       this.runningDeviceNames.add(device.name);
+      this.runningDeviceNames.add(device.deviceId);
     });
   }
 
@@ -49,6 +50,7 @@ export class FakeDeviceUtils implements PlatformDeviceManager {
     const existing = this.bootedDevices.get(platform) || [];
     this.bootedDevices.set(platform, [...existing, device]);
     this.runningDeviceNames.add(device.name);
+    this.runningDeviceNames.add(device.deviceId);
   }
 
   /**
@@ -126,6 +128,9 @@ export class FakeDeviceUtils implements PlatformDeviceManager {
 
   async isDeviceImageRunning(device: DeviceInfo): Promise<boolean> {
     this.executedOperations.push(`isDeviceImageRunning:${device.name}`);
+    if (device.deviceId && this.runningDeviceNames.has(device.deviceId)) {
+      return true;
+    }
     return this.runningDeviceNames.has(device.name);
   }
 
@@ -144,6 +149,9 @@ export class FakeDeviceUtils implements PlatformDeviceManager {
   async startDevice(device: DeviceInfo): Promise<ChildProcess> {
     this.executedOperations.push(`startDevice:${device.name}`);
     this.runningDeviceNames.add(device.name);
+    if (device.deviceId) {
+      this.runningDeviceNames.add(device.deviceId);
+    }
 
     // Return mock process if configured, otherwise return a default mock
     if (this.mockChildProcesses.has(device.name)) {


### PR DESCRIPTION
## Summary
- require iOS simulator UDIDs for simctl lifecycle operations and keep selection deterministic
- boot dedicated iOS simulators from the device pool when needed for parallel sessions
- add coverage for dedicated iOS booting behavior

## Testing
- bun test test/daemon/devicePool.test.ts

Closes #350
