### PR TITLE
Exclude tests from dead-code tsconfig

### DIFF
--- a/tsconfig.dead-code.json
+++ b/tsconfig.dead-code.json
@@ -2,7 +2,6 @@
   "extends": "./tsconfig.json",
   "include": [
     "src",
-    "test",
     "scripts",
     "build.ts"
   ],


### PR DESCRIPTION
## Summary
- exclude test files from the dead-code tsconfig to avoid bun:test type errors during ts-prune

## Testing
- `bash scripts/detect-dead-code-ts.sh --output-dir=scratch`

Refs #946
