### PR TITLE
fix(dev): gitignore .mcp.json to prevent hot-reload noise in git status

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@ docs/changelog.md
 docs/contributing/index.md
 
 /.cache
+.mcp.json
 .mcp.local.json
 *.pid
 # IntelliJ Platform Gradle plugin artifacts

--- a/.mcp.json.example
+++ b/.mcp.json.example
@@ -2,7 +2,7 @@
   "mcpServers": {
     "auto-mobile": {
       "type": "http",
-      "url": "http://localhost:9831/auto-mobile/streamable"
+      "url": "http://localhost:9000/auto-mobile/streamable"
     }
   }
 }


### PR DESCRIPTION
## Summary
- Add `.mcp.json` and `.env.local` to `.gitignore` so hot-reload port changes don't show in git status
- Create `.mcp.json.example` as a template for developers to copy
- Update hot-reload scripts to write port to `.env.local` for environment-based configuration

## Test plan
- [ ] Run `scripts/local-dev/android-hot-reload.sh` and verify `.mcp.json` no longer appears in `git status`
- [ ] Verify `.env.local` is created with correct `AUTOMOBILE_PORT` value
- [ ] Verify MCP server starts correctly on the expected port

Closes #832

🤖 Generated with [Claude Code](https://claude.com/claude-code)