### PR TITLE
docs: organize design-docs tooling references

### DIFF
--- a/docs/design-docs/index.md
+++ b/docs/design-docs/index.md
@@ -39,7 +39,7 @@ stateDiagram-v2
 | [MCP Server](mcp/index.md) | Protocol server enabling AI agent interaction |
 | [Interaction Loop](mcp/interaction-loop.md) | Observe-act-observe cycle with idle detection |
 | [Observation](mcp/observe/index.md) | Real-time UI hierarchy and screen capture |
-| [Actions](mcp/tools.md) | Touch, swipe, input, and app management |
+| [Actions](mcp/tools/index.md) | Touch, swipe, input, and app management |
 | [Navigation Graph](mcp/nav/index.md) | Automatic screen flow mapping |
 | [Daemon](mcp/daemon/index.md) | Device pooling and test execution |
 
@@ -62,4 +62,3 @@ stateDiagram-v2
 | [Accessibility Bridge](plat/ios/accessibility-service.md) | WebSocket automation server |
 | [XCTest Runner](plat/ios/xctestrunner.md) | Test execution framework |
 | [Xcode Integration](plat/ios/ide-plugin/overview.md) | Editor extension |
-

--- a/docs/design-docs/mcp/a11y/index.md
+++ b/docs/design-docs/mcp/a11y/index.md
@@ -11,7 +11,7 @@ flowchart LR
 
     subgraph Adaptation
         Tap["👆 tapOn<br/>ACTION_CLICK"]
-        Scroll["📜 swipeOn<br/>Two-finger / Scroll Action"]
+        Scroll["👉 swipeOn<br/>Two-finger / Scroll Action"]
         Input["⌨️ inputText<br/>ACTION_SET_TEXT"]
     end
 

--- a/docs/design-docs/mcp/daemon/critical-section.md
+++ b/docs/design-docs/mcp/daemon/critical-section.md
@@ -2,11 +2,11 @@
 
 ## Overview
 
-The `criticalSection` tool provides multi-device synchronization for serialized execution of steps. It implements a barrier synchronization pattern where all devices must arrive at the critical section before any can proceed, and then executes steps one device at a time.
+The 🔒 [`criticalSection`](../tools/index.md) tool provides multi-device synchronization for serialized execution of steps. It implements a barrier synchronization pattern where all devices must arrive at the critical section before any can proceed, and then executes steps one device at a time.
 
 ## Availability
 
-The `criticalSection` tool is available only when the AutoMobile as an [MCP Daemon](index.md). It is not registered in standalone MCP mode.
+The 🔒 `criticalSection` tool is available only when AutoMobile runs as an [MCP Daemon](index.md). It is not registered in standalone MCP mode.
 
 ## Use Cases
 
@@ -100,14 +100,14 @@ steps:
   - tool: criticalSection
     steps:
       - tool: tapOn
-          device: A
-          text: Edit Profile
+        device: A
+        text: Edit Profile
       - tool: tapOn
-          device: A
-          text: Status
+        device: A
+        text: Status
       - tool: inputText
-          device: A
-          text: Pretty awesome
+        device: A
+        text: Pretty awesome
       - tool: tapOn
         device: A
         text: Clear Status
@@ -116,14 +116,12 @@ steps:
         await:
           - text: No Status
       - tool: tapOn
-        params:
-          device: A
-          text: Save profile
+        device: A
+        text: Save profile
       - tool: observe
-        params:
-          device: B
-          await:
-            - text: Pretty awesome
+        device: B
+        await:
+          - text: Pretty awesome
 ```
 
 ## Error Handling

--- a/docs/design-docs/mcp/daemon/index.md
+++ b/docs/design-docs/mcp/daemon/index.md
@@ -1,8 +1,6 @@
 # Overview
 
 Background daemon service for device pooling and parallel test execution.
-
-
 The AutoMobile daemon:
 
 1. Maintains a pool of available devices specifically for running tests
@@ -12,7 +10,7 @@ The AutoMobile daemon:
 
 ## Architecture
 
-With Android in mind, JUnitRunner is able to use the MCP Daemon to orchestrate and control N-number devices under test. Since the Daemon is simply a long lived node process with all the same capabilies as the MCP server it is able to handle and reproduce the same interactions it took when an AI Agent was driving it. This architecture also enables multi-device features like [critical section](critical-section.md).
+With Android in mind, JUnitRunner uses the MCP Daemon to orchestrate and control N devices under test. The daemon is a long-lived Node process with the same MCP capabilities, so it can replay the same interactions an AI agent would run. This architecture also enables multi-device features like [critical section](critical-section.md).
 
 ```mermaid
 stateDiagram-v2

--- a/docs/design-docs/mcp/feature-flags.md
+++ b/docs/design-docs/mcp/feature-flags.md
@@ -1,8 +1,6 @@
 # Feature Flags
 
 Runtime configuration system for experimental features and performance tuning.
-
-
 Feature flags allow:
 
 - **Experimental Features** - Enable/disable features in development
@@ -54,10 +52,10 @@ setFeatureFlag("predictive-ui", true)
 
 ## MCP Tools
 
-### `listFeatureFlags`
+### 🚩 [`listFeatureFlags`](tools/index.md)
 Lists all available feature flags and their current states.
 
-### `setFeatureFlag`
+### ⚙️ [`setFeatureFlag`](tools/index.md)
 Enable or disable a feature flag:
 
 ```json
@@ -92,4 +90,4 @@ setFeatureFlag("ui-perf-mode", true, {
 
 Feature flags are stored in memory and can be persisted to configuration files for permanent settings.
 
-See [MCP Actions](tools.md) for flag management tools.
+See [tool reference](tools/index.md) for the full MCP tool list.

--- a/docs/design-docs/mcp/index.md
+++ b/docs/design-docs/mcp/index.md
@@ -2,7 +2,7 @@
 
 The MCP server exposes AutoMobile's capabilities as tool calls, resources, and real-time observations.
 
-AutoMobile's MCP makes its various [actions](tools.md) available as tool calls and automatically performs
+AutoMobile's MCP makes its various [actions](tools/index.md) available as tool calls and automatically performs
 [observations](observe/index.md) within an [interaction loop](interaction-loop.md).
 
 ```mermaid
@@ -68,7 +68,7 @@ flowchart TB
 
 | Area | Documentation |
 |------|---------------|
-| **Actions** | [Tool calls](tools.md) for taps, swipes, input, app management |
+| **Actions** | [Tool calls](tools/index.md) for taps, swipes, input, app management |
 | **Observation** | [Real-time UI capture](observe/index.md) with view hierarchy |
 | **Interaction Loop** | [Observe-act-observe](interaction-loop.md) cycle with idle detection |
 | **Resources** | [Device state](resources.md) exposed via MCP resources |

--- a/docs/design-docs/mcp/interaction-loop.md
+++ b/docs/design-docs/mcp/interaction-loop.md
@@ -4,7 +4,7 @@
 
 This interaction loop is supported by comprehensive [observation](observe/index.md) of UI state and UI stability checks
 (Android uses `dumpsys gfxinfo`-based idle detection) before and after action execution. Together, that allows for
-accurate and precise exploration with the [action tool calls](tools.md).
+accurate and precise exploration with the [action tool calls](tools/index.md).
 
 ```mermaid
 sequenceDiagram

--- a/docs/design-docs/mcp/nav/index.md
+++ b/docs/design-docs/mcp/nav/index.md
@@ -3,7 +3,7 @@
 As AutoMobile explores an app it automatically maps what it observes into a [navigation graph](graph-structure.md).
 
 ```mermaid
-graph TD
+flowchart TD
     subgraph Navigation Graph
         Home["🏠 Home Screen"]
         Profile["👤 Profile Screen"]
@@ -13,16 +13,16 @@ graph TD
         Privacy["🔒 Privacy Settings"]
     end
 
-    Home -->|"tapOn 'Profile'"| Profile
-    Home -->|"tapOn 'Settings'"| Settings
-    Home -->|"tapOn 'Notifications'"| Notifications
-    Profile -->|"tapOn 'Edit'"| EditProfile
-    Profile -->|"pressButton 'back'"| Home
-    EditProfile -->|"pressButton 'back'"| Profile
-    Settings -->|"tapOn 'Privacy'"| Privacy
-    Settings -->|"pressButton 'back'"| Home
-    Privacy -->|"pressButton 'back'"| Settings
-    Notifications -->|"pressButton 'back'"| Home
+    Home -->|"👆 tapOn 'Profile'"| Profile
+    Home -->|"👆 tapOn 'Settings'"| Settings
+    Home -->|"👆 tapOn 'Notifications'"| Notifications
+    Profile -->|"👆 tapOn 'Edit'"| EditProfile
+    Profile -->|"🔘 pressButton 'back'"| Home
+    EditProfile -->|"🔘 pressButton 'back'"| Profile
+    Settings -->|"👆 tapOn 'Privacy'"| Privacy
+    Settings -->|"🔘 pressButton 'back'"| Home
+    Privacy -->|"🔘 pressButton 'back'"| Settings
+    Notifications -->|"🔘 pressButton 'back'"| Home
 
     classDef screen fill:#525FE1,stroke-width:0px,color:white;
     class Home,Profile,Settings,EditProfile,Notifications,Privacy screen;
@@ -38,7 +38,7 @@ This process has been [benchmarked to take at most 1ms](performance.md) and it i
 
 ### Navigate to Screen
 
-The `navigateTo` tool uses the graph to find paths:
+The 🗺️ [`navigateTo`](../tools/index.md) tool uses the graph to find paths:
 
 1. Finds target screen in graph
 2. Calculates shortest path from current node to the target
@@ -47,13 +47,13 @@ The `navigateTo` tool uses the graph to find paths:
 
 ### Explore Efficiently
 
-The `explore` tool uses the graph to:
+The 🔍 [`explore`](../tools/index.md) tool uses the graph to:
 
 - Avoid revisiting known screens
 - Prioritize unexplored branches
 - Track coverage of app features
 
-Read more about [how to use the `explore` tool's various modes](explore.md)
+Read more about [how to use the 🔍 `explore` tool's modes](explore.md).
 
 ## Edge Cases & Limitations
 

--- a/docs/design-docs/mcp/observe/vision-fallback.md
+++ b/docs/design-docs/mcp/observe/vision-fallback.md
@@ -215,5 +215,5 @@ Planned improvements:
 
 ## See Also
 
-- [MCP Actions](../tools.md) - Tool implementation details
+- [MCP tool reference](../tools/index.md) - Tool implementation details
 - [Feature Flags](../feature-flags.md) - Runtime configuration

--- a/docs/design-docs/mcp/tools/index.md
+++ b/docs/design-docs/mcp/tools/index.md
@@ -2,7 +2,7 @@
 
 #### Observe
 
-Almost all other tool calls have built-in observation via the [interaction loop](interaction-loop.md), but we also have a standalone [observe](observe/index.md) tool that specifically performs just that action to get the AI agent up to speed.
+Almost all other tool calls have built-in observation via the [interaction loop](../interaction-loop.md), but we also have a standalone [observe](../observe/index.md) tool that specifically performs just that action to get the AI agent up to speed.
 
 #### Interactions
 
@@ -37,7 +37,7 @@ Almost all other tool calls have built-in observation via the [interaction loop]
 #### Navigation & Exploration
 
 - 🗺️ `navigateTo` navigates to a specific screen using learned paths from the navigation graph.
-- 🔍 [`explore`](nav/explore.md) automatically explores the app and builds the navigation graph by intelligently selecting and interacting with UI elements.
+- 🔍 [`explore`](../nav/explore.md) automatically explores the app and builds the navigation graph by intelligently selecting and interacting with UI elements.
 - 📊 `getNavigationGraph` retrieves the current navigation graph for debugging and analysis.
 
 #### Advanced Device Management

--- a/docs/design-docs/plat/android/ide-plugin/test-recording.md
+++ b/docs/design-docs/plat/android/ide-plugin/test-recording.md
@@ -227,6 +227,6 @@ Use descriptive names for test plans:
 
 ## See Also
 
-- [MCP Actions](../../../mcp/tools.md) - Available MCP tools for test plans
+- [MCP tool reference](../../../mcp/tools/index.md) - Available MCP tools for test plans
 - [IDE Plugin Overview](overview.md) - IDE plugin features and setup
 - [UI Tests](../../../../using/ui-tests.md) - Writing and running UI tests

--- a/docs/design-docs/plat/android/index.md
+++ b/docs/design-docs/plat/android/index.md
@@ -1,9 +1,9 @@
 # Overview
 
-AutoMobile has a lot of custom tooling, libraries, and various communication protocols
+AutoMobile's Android stack spans the MCP server, daemon, IDE plugin, JUnitRunner, and device-side services.
 
 ```mermaid
-graph TB
+flowchart TB
     subgraph "AI Agents"
         Agent[AI Agent<br/>Claude, GPT, etc.]
     end
@@ -29,7 +29,7 @@ graph TB
     MCP -->|Manages| Daemon
     MCP -->|ADB Commands| Device1
     MCP -->|ADB Commands| Device2
-    JUnit -->|MCP Tools| MCP
+    JUnit -->|MCP tools| MCP
     Daemon -->|Allocates| Device1
     Daemon -->|Allocates| Device2
     Device1 -->|WebSocket/File| AccessService
@@ -43,43 +43,31 @@ graph TB
     style Daemon fill:#7ED321,color:#000
 ```
 
-#### MCP Server
+## MCP Server
 
 The [MCP server](../../mcp/index.md) implements the [Model Context Protocol](https://modelcontextprotocol.io/introduction).
 It has [observation](../../mcp/observe/index.md) built into its [interaction loop](../../mcp/interaction-loop.md)
-that is fast. This is supported with UI stability checks (gfxinfo-based on Android) to determine idling. Together, that
-allows for accurate and precise exploration that gets better as more capabilities and heuristics are added.
+with UI stability checks (gfxinfo-based on Android). Together, that enables fast, precise exploration.
 
-#### Test Execution
+## Test Execution
 
-The Android JUnitRunner is responsible for executing AutoMobile tests on Android devices and emulators. It extends the
-standard Android testing framework to provide enhanced capabilities including intelligent test execution, detailed
-reporting, and integration with the MCP server's device management features. The runner is designed to eventually
-support agentic self-healing capabilities, allowing tests to automatically adapt and recover from common failure
-scenarios by leveraging AI-driven analysis of test failures and UI changes.
+The Android JUnitRunner executes AutoMobile tests on devices and emulators. It extends the standard
+Android testing framework with richer reporting and tighter MCP integration, with a long-term goal of
+self-healing test flows.
 
-#### Pooled Device Management
+## Pooled Device Management
 
-Multi-device support with emulator control and app lifecycle management. As long as you have available adb connections,
-AutoMobile can automatically track which one its using for which execution plan or MCP session. CI still needs available
-device connections, but AutoMobile handles selection and readiness checks. During STDIO MCP sessions the tool call `setActiveDevice` will be done and kept for the duration of your session.
+Multi-device support includes emulator control and app lifecycle management. As long as you have available ADB
+connections, AutoMobile tracks which device is used for each execution plan or MCP session. CI still needs available
+device connections, but AutoMobile handles selection and readiness checks. During STDIO MCP sessions,
+🔧 [`setActiveDevice`](../../mcp/tools/index.md) is set once and reused for the session.
 
-#### Android Accessibility Service
+## Android Accessibility Service
 
-The Android Accessibility Service provides real-time access to view hierarchy data and user interface elements without
-requiring device rooting or special permissions beyond accessibility service enablement. This service acts as a bridge
-between the Android system's accessibility framework and AutoMobile's automation capabilities. When enabled, the
-accessibility service continuously monitors UI changes and provides detailed information about view hierarchies. It
-writes the latest hierarchy to app-private storage and can stream updates over WebSocket for AutoMobile to consume.
+The Android Accessibility Service provides real-time access to view hierarchy data and UI elements without
+rooting or special permissions beyond accessibility enablement. When enabled, it monitors UI changes,
+stores the latest hierarchy in app-private storage, and streams updates over WebSocket.
 
-#### Batteries Included
+## Batteries Included
 
-AutoMobile comes with extensive functionality to minimize and streamline setup of required platform tools.
-
-## Components 
-
-#### MCP Server
-
-The Model Context Protocol ([MCP](https://modelcontextprotocol.io/introduction)) server is the core component of AutoMobile, built with Bun and TypeScript using the
-MCP TypeScript SDK. It serves as both a server for AI agents to interact with Android devices and a command-line
-interface for direct usage. You can read more about its setup and system design in our [MCP server docs](../../mcp/index.md)
+AutoMobile includes tooling to minimize setup for required platform dependencies.

--- a/docs/design-docs/plat/android/junitrunner.md
+++ b/docs/design-docs/plat/android/junitrunner.md
@@ -54,7 +54,8 @@ automatically adapt and recover from common failure scenarios by leveraging AI-d
 
 Multi-device support with emulator control and app lifecycle management. As long as you have available adb connections,
 AutoMobile can automatically track which one its using for which execution plan or MCP session. CI still needs available
-device connections, but AutoMobile handles selection and readiness checks. During STDIO MCP sessions the tool call `setActiveDevice` will be done and kept for the duration of your session.
+device connections, but AutoMobile handles selection and readiness checks. During STDIO MCP sessions,
+🔧 [`setActiveDevice`](../../mcp/tools/index.md) is set once and reused for the session.
 
 ## Historical Timing Data
 

--- a/docs/design-docs/plat/ios/accessibility-service.md
+++ b/docs/design-docs/plat/ios/accessibility-service.md
@@ -57,4 +57,4 @@ Server to client response:
 ## See also
 
 - [XCTestService](xctestrunner.md) - Touch injection via native XCUITest APIs.
-- [MCP actions](../../mcp/tools.md)
+- [MCP tool reference](../../mcp/tools/index.md)

--- a/docs/design-docs/plat/ios/ide-plugin/test-recording.md
+++ b/docs/design-docs/plat/ios/ide-plugin/test-recording.md
@@ -38,4 +38,4 @@ Extension or a standard file open action.
 ## See also
 
 - [Xcode integration](overview.md)
-- [MCP plan execution](../../../mcp/tools.md)
+- [MCP tool reference](../../../mcp/tools/index.md)

--- a/docs/design-docs/plat/ios/index.md
+++ b/docs/design-docs/plat/ios/index.md
@@ -5,7 +5,7 @@ The XCTestService provides a WebSocket server that exposes XCUITest capabilities
 simctl handles simulator lifecycle management.
 
 ```mermaid
-graph TB
+flowchart TB
     subgraph "MCP Client"
         Agent[AI Agent]
     end
@@ -36,7 +36,6 @@ graph TB
 - [simctl integration](simctl.md) - simulator lifecycle and app management.
 - [Managed App Configuration](managed-app-config.md) - MDM policies and app config payloads.
 - [Managed Apple IDs](managed-apple-ids.md) - account policies and device profiles.
-- [XCTest runner](xctestrunner.md) - plan execution and timing integration.
 - [Xcode integration](ide-plugin/overview.md) - companion app + source editor extension.
 
 ## Status
@@ -67,4 +66,4 @@ underlying system tooling differs.
 ## See also
 
 - [MCP server](../../mcp/index.md)
-- [MCP actions](../../mcp/tools.md)
+- [MCP tool reference](../../mcp/tools/index.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -26,7 +26,7 @@ It can do this by being an MCP server that uses standard platform tools like `ad
 
 - 🤖 **Fast UX Inspection** Kotlin Accessibility Service and Swift XCTestService to enable fast, accurate observations. 10x faster than the next fastest observation toolkit.
 - 🦾 **Full Touch Injection** Tap, Swipe, Pinch, Drag & Drop, Shake with automatic element targeting.
-- ♻️ **Tool Feedback** [Observations](design-docs/mcp/observe/index.md) drive the [interaction loop](design-docs/mcp/interaction-loop.md) for all [tool calls](design-docs/mcp/tools.md).
+- ♻️ **Tool Feedback** [Observations](design-docs/mcp/observe/index.md) drive the [interaction loop](design-docs/mcp/interaction-loop.md) for all [tool calls](design-docs/mcp/tools/index.md).
 - 🧪 **Test Execution** [Kotlin JUnitRunner](design-docs/plat/android/junitrunner.md) & [Swift XCTestRunner](design-docs/plat/ios/xctestrunner.md) execute tests natively handling device pooling, multi-device tests, and automatically optimizing test timing.
 
 ## License

--- a/docs/using/reproducting-bugs.md
+++ b/docs/using/reproducting-bugs.md
@@ -29,7 +29,7 @@ Once a bug is reproduced, you can create an [automated test](ui-tests.md).
 
 ### Automate Reproduction Steps
 
-Convert your bug reproduction steps into an automated test using [executePlan](../design-docs/mcp/tools.md#testing-debugging):
+Convert your bug reproduction steps into an automated test using [executePlan](../design-docs/mcp/tools/index.md#testing-debugging):
 
 ```javascript
 await executePlan({

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -94,7 +94,7 @@ nav:
       - 'Overview': design-docs/index.md
       - 'MCP':
           - 'Overview': design-docs/mcp/index.md
-          - 'Tools': design-docs/mcp/tools.md
+          - 'Tools': design-docs/mcp/tools/index.md
           - 'Observe':
              - 'Overview': design-docs/mcp/observe/index.md
              - 'Appearance Sync': design-docs/mcp/observe/appearance.md


### PR DESCRIPTION
## Summary
- move design-docs MCP tools doc to `tools/index.md` and update navigation
- align tool references and emoji usage for consistency across design docs
- tighten and clarify Android/iOS platform overview content

## Testing
- scripts/validate_mkdocs_nav.sh
- scripts/lychee/validate_lychee.sh

Closes #830
