### PR TITLE
Allow normalized params in criticalSection steps

### DIFF
--- a/docs/design-docs/mcp/daemon/critical-section.md
+++ b/docs/design-docs/mcp/daemon/critical-section.md
@@ -83,45 +83,60 @@ sequenceDiagram
 ```yaml
 steps:
   - tool: navigateTo
-    device: A
-    text: Edit Profile
+    params:
+      device: A
+      text: Edit Profile
   - tool: tapOn
-    device: A
-    text: Clear Status
+    params:
+      device: A
+      text: Clear Status
   - tool: navigateTo
-    device: A
-    text: Search
+    params:
+      device: A
+      text: Search
   - tool: inputText
-    device: B
-    text: Test User A
+    params:
+      device: B
+      text: Test User A
   - tool: imeAction
-    device: B
-    text: done
+    params:
+      device: B
+      text: done
   - tool: criticalSection
-    steps:
-      - tool: tapOn
-        device: A
-        text: Edit Profile
-      - tool: tapOn
-        device: A
-        text: Status
-      - tool: inputText
-        device: A
-        text: Pretty awesome
-      - tool: tapOn
-        device: A
-        text: Clear Status
-      - tool: observe
-        device: B
-        await:
-          - text: No Status
-      - tool: tapOn
-        device: A
-        text: Save profile
-      - tool: observe
-        device: B
-        await:
-          - text: Pretty awesome
+    params:
+      lock: profile-sync
+      deviceCount: 2
+      steps:
+        - tool: tapOn
+          params:
+            device: A
+            text: Edit Profile
+        - tool: tapOn
+          params:
+            device: A
+            text: Status
+        - tool: inputText
+          params:
+            device: A
+            text: Pretty awesome
+        - tool: tapOn
+          params:
+            device: A
+            text: Clear Status
+        - tool: observe
+          params:
+            device: B
+            await:
+              - text: No Status
+        - tool: tapOn
+          params:
+            device: A
+            text: Save profile
+        - tool: observe
+          params:
+            device: B
+            await:
+              - text: Pretty awesome
 ```
 
 ## Error Handling

--- a/docs/design-docs/mcp/multi-device.md
+++ b/docs/design-docs/mcp/multi-device.md
@@ -39,32 +39,39 @@ devices: ["A", "B"]
 
 steps:
   - tool: launchApp
-    device: A
-    appId: com.chat.app
+    params:
+      device: A
+      appId: com.chat.app
     label: Launch sender
 
   - tool: launchApp
-    device: B
-    appId: com.chat.app
+    params:
+      device: B
+      appId: com.chat.app
     label: Launch receiver
 
   - tool: criticalSection
-    lock: "chat-room"
-    steps:
-      - tool: inputText
-        device: A
-        text: "Hello"
-        label: Type message
-      - tool: imeAction
-        device: A
-        action: send
-        label: Send message
+    params:
+      lock: "chat-room"
+      deviceCount: 2
+      steps:
+        - tool: inputText
+          params:
+            device: A
+            text: "Hello"
+          label: Type message
+        - tool: imeAction
+          params:
+            device: A
+            action: send
+          label: Send message
 
   - tool: systemTray
-    device: B
-    action: find
-    notification: { body: "Hello" }
-    awaitTimeout: 5000
+    params:
+      device: B
+      action: find
+      notification: { body: "Hello" }
+      awaitTimeout: 5000
     label: Verify notification
 ```
 

--- a/schemas/tool-definitions.json
+++ b/schemas/tool-definitions.json
@@ -212,12 +212,12 @@
                 "description": "Tool name to execute"
               },
               "params": {
+                "description": "Tool-specific parameters",
                 "type": "object",
                 "propertyNames": {
                   "type": "string"
                 },
-                "additionalProperties": {},
-                "description": "Tool-specific parameters"
+                "additionalProperties": {}
               },
               "label": {
                 "description": "Optional human-readable label",
@@ -225,10 +225,9 @@
               }
             },
             "required": [
-              "tool",
-              "params"
+              "tool"
             ],
-            "additionalProperties": false
+            "additionalProperties": {}
           },
           "description": "Steps to execute serially within the critical section. Each step should target a specific device using the 'device' parameter."
         },

--- a/src/server/criticalSectionTools.ts
+++ b/src/server/criticalSectionTools.ts
@@ -1,16 +1,24 @@
 import { z } from "zod";
 import { ToolRegistry } from "./toolRegistry";
-import { ActionableError, BootedDevice, PlanStep } from "../models/index";
+import { ActionableError, BootedDevice } from "../models/index";
 import { logger } from "../utils/logger";
 import { createJSONToolResponse, throwIfAborted } from "../utils/toolUtils";
 import { CriticalSectionCoordinator } from "./CriticalSectionCoordinator";
+import { PlanNormalizer } from "../utils/plan/PlanNormalizer";
 
 // Schema for steps inside critical section
-const planStepSchema: z.ZodType<PlanStep> = z.object({
-  tool: z.string().describe("Tool name to execute"),
-  params: z.record(z.string(), z.any()).describe("Tool-specific parameters"),
-  label: z.string().optional().describe("Optional human-readable label"),
-});
+const criticalSectionStepSchema = z
+  .object({
+    tool: z.string().describe("Tool name to execute"),
+    params: z
+      .record(z.string(), z.any())
+      .optional()
+      .describe("Tool-specific parameters"),
+    label: z.string().optional().describe("Optional human-readable label"),
+  })
+  .passthrough();
+
+type CriticalSectionStepInput = z.infer<typeof criticalSectionStepSchema>;
 
 // Critical section tool schema
 const criticalSectionSchema = z.object({
@@ -20,7 +28,7 @@ const criticalSectionSchema = z.object({
       "Global lock identifier. All devices using the same lock name will wait for each other at this barrier."
     ),
   steps: z
-    .array(planStepSchema)
+    .array(criticalSectionStepSchema)
     .min(1)
     .describe(
       "Steps to execute serially within the critical section. Each step should target a specific device using the 'device' parameter."
@@ -55,6 +63,9 @@ const criticalSectionHandler = async (
   signal?: AbortSignal
 ): Promise<any> => {
   const { lock, steps, deviceCount, timeout } = params;
+  const normalizedSteps = PlanNormalizer.normalizeSteps(
+    steps as CriticalSectionStepInput[]
+  );
   const coordinator = CriticalSectionCoordinator.getInstance();
 
   logger.info(
@@ -65,7 +76,7 @@ const criticalSectionHandler = async (
   throwIfAborted(signal);
 
   // Validate steps to prevent nesting
-  for (const step of steps) {
+  for (const step of normalizedSteps) {
     if (step.tool === "criticalSection") {
       throw new ActionableError(
         `Nested critical sections are not supported. Found criticalSection step inside critical section "${lock}".`
@@ -93,18 +104,18 @@ const criticalSectionHandler = async (
     );
 
     logger.info(
-      `Device ${device.deviceId} executing ${steps.length} steps in critical section "${lock}"`
+      `Device ${device.deviceId} executing ${normalizedSteps.length} steps in critical section "${lock}"`
     );
 
     // Execute steps serially
     const executedSteps: Array<{ tool: string; success: boolean }> = [];
 
-    for (let i = 0; i < steps.length; i++) {
-      const step = steps[i];
+    for (let i = 0; i < normalizedSteps.length; i++) {
+      const step = normalizedSteps[i];
       throwIfAborted(signal);
 
       logger.debug(
-        `Device ${device.deviceId} executing step ${i + 1}/${steps.length}: ${step.tool}`
+        `Device ${device.deviceId} executing step ${i + 1}/${normalizedSteps.length}: ${step.tool}`
       );
 
       try {
@@ -165,7 +176,7 @@ const criticalSectionHandler = async (
       lock,
       deviceId: device.deviceId,
       executedSteps: executedSteps.length,
-      totalSteps: steps.length,
+      totalSteps: normalizedSteps.length,
     });
   } catch (error) {
     // Force cleanup on error to prevent other devices from waiting forever

--- a/test/server/criticalSectionTools.test.ts
+++ b/test/server/criticalSectionTools.test.ts
@@ -172,6 +172,7 @@ describe("criticalSection tool", () => {
     expect(executionLog).toEqual(["step1", "step2", "step3"]);
   });
 
+
   test("fails fast when a step fails", async () => {
     const tool = ToolRegistry.getTool("criticalSection");
     expect(tool).toBeDefined();

--- a/test/utils/plan/PlanNormalizer.test.ts
+++ b/test/utils/plan/PlanNormalizer.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, test } from "bun:test";
+import { PlanNormalizer } from "../../../src/utils/plan/PlanNormalizer";
+
+describe("PlanNormalizer", () => {
+  test("merges inline fields into params", () => {
+    const normalized = PlanNormalizer.normalizeStep(
+      { tool: "tapOn", text: "Hello", device: "A" },
+      0
+    );
+
+    expect(normalized.tool).toBe("tapOn");
+    expect(normalized.params).toEqual({ text: "Hello", device: "A" });
+  });
+
+  test("prefers explicit params over inline fields", () => {
+    const normalized = PlanNormalizer.normalizeStep(
+      {
+        tool: "tapOn",
+        text: "inline",
+        params: { text: "params", device: "B" },
+        label: "Tap button",
+      },
+      0
+    );
+
+    expect(normalized.params).toEqual({ text: "params", device: "B" });
+    expect(normalized.label).toBe("Tap button");
+  });
+});


### PR DESCRIPTION
## Summary
- normalize criticalSection nested steps so inline fields and params both work
- keep criticalSection examples using normalized params throughout docs
- add PlanNormalizer unit coverage for inline-to-params merging

## Testing
- bun run test
- bun run lint
- bun run build

Fixes #960
