### PR TITLE
Abstract xcodebuild commands through host control daemon

### DIFF
--- a/src/utils/hostControlClient.ts
+++ b/src/utils/hostControlClient.ts
@@ -303,6 +303,20 @@ export async function runXcodebuild(
   return sendCommand("xcodebuild", { args });
 }
 
+export async function runXcodebuildExec(
+  args: string[]
+): Promise<HostControlResult<ReturnType<typeof createExecResult>>> {
+  const result = await runXcodebuild(args);
+  if (!result.success || !result.data) {
+    return { success: false, error: result.error || "xcodebuild failed" };
+  }
+
+  return {
+    success: true,
+    data: createExecResult(result.data.stdout, result.data.stderr)
+  };
+}
+
 export async function startXCTestService(params: {
   deviceId: string;
   port: number;

--- a/src/utils/ios-cmdline-tools/XcodeSigning.ts
+++ b/src/utils/ios-cmdline-tools/XcodeSigning.ts
@@ -5,6 +5,7 @@ import { createHash, X509Certificate } from "crypto";
 import { Parser } from "xml2js";
 import type { ExecResult } from "../../models";
 import { logger } from "../logger";
+import { Xcodebuild, XcodebuildClient } from "./XcodebuildClient";
 
 export type SigningStyle = "automatic" | "manual";
 
@@ -52,6 +53,7 @@ export interface SigningResolution {
 export interface XcodeSigningDependencies {
   platform: () => NodeJS.Platform;
   exec: (command: string) => Promise<ExecResult>;
+  xcodebuild: Xcodebuild;
   readDir: (path: string) => Promise<string[]>;
   readFile: (path: string) => Promise<string>;
   stat: (path: string) => Promise<{ isFile: () => boolean }>;
@@ -89,6 +91,7 @@ const createDefaultDependencies = (): XcodeSigningDependencies => ({
       includes(searchString: string) { return stdout.includes(searchString); }
     };
   },
+  xcodebuild: new XcodebuildClient(),
   readDir: async path => fs.readdir(path),
   readFile: async path => fs.readFile(path, "utf-8"),
   stat: async path => fs.stat(path),
@@ -327,13 +330,19 @@ export class XcodeSigningManager {
   }
 
   public async detectTeamIdsFromXcode(): Promise<string[]> {
-    if (this.dependencies.platform() !== "darwin") {
-      return [];
-    }
     const projectPath = join(process.cwd(), "ios", "XCTestService", "XCTestService.xcodeproj");
-    const command = `xcodebuild -showBuildSettings -project ${quoteShell(projectPath)} -scheme XCTestServiceApp`;
     try {
-      const result = await this.dependencies.exec(command);
+      if (this.dependencies.platform() !== "darwin") {
+        const available = await this.dependencies.xcodebuild.isAvailable();
+        if (!available) {
+          return [];
+        }
+      }
+
+      const result = await this.dependencies.xcodebuild.executeCommand(
+        ["-showBuildSettings", "-project", projectPath, "-scheme", "XCTestServiceApp"],
+        { timeoutMs: 30000, maxBuffer: 10 * 1024 * 1024 }
+      );
       const teams = new Set<string>();
       for (const line of result.stdout.split("\n")) {
         const match = line.match(/DEVELOPMENT_TEAM\s*=\s*([A-Z0-9]+)/);

--- a/src/utils/ios-cmdline-tools/XcodebuildClient.ts
+++ b/src/utils/ios-cmdline-tools/XcodebuildClient.ts
@@ -1,0 +1,143 @@
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import { ActionableError, ExecResult } from "../../models";
+import { logger } from "../logger";
+import { createExecResult } from "../execResult";
+import { isRunningInDocker } from "../dockerEnv";
+import { isHostControlAvailable, runXcodebuildExec, shouldUseHostControl } from "../hostControlClient";
+
+export interface XcodebuildCommandOptions {
+  timeoutMs?: number;
+  maxBuffer?: number;
+}
+
+export interface Xcodebuild {
+  executeCommand(args: string[], options?: XcodebuildCommandOptions): Promise<ExecResult>;
+  isAvailable(): Promise<boolean>;
+}
+
+interface XcodebuildHostControlRunner {
+  isAvailable(): Promise<boolean>;
+  isRunningInDocker(): boolean;
+  runXcodebuild(args: string[]): Promise<ExecResult>;
+  shouldUseHostControl(): boolean;
+}
+
+const execAsync = async (file: string, args: string[], maxBuffer?: number): Promise<ExecResult> => {
+  const options = maxBuffer ? { maxBuffer } : undefined;
+  const result = await promisify(execFile)(file, args, options);
+  const stdout = typeof result.stdout === "string" ? result.stdout : result.stdout.toString();
+  const stderr = typeof result.stderr === "string" ? result.stderr : result.stderr.toString();
+  return createExecResult(stdout, stderr);
+};
+
+export class XcodebuildClient implements Xcodebuild {
+  execAsync: (file: string, args: string[], maxBuffer?: number) => Promise<ExecResult>;
+  private hostControl: XcodebuildHostControlRunner;
+  private hostControlAvailability: Promise<boolean> | null = null;
+
+  constructor(
+    execAsyncFn: ((file: string, args: string[], maxBuffer?: number) => Promise<ExecResult>) | null = null,
+    hostControlRunner: XcodebuildHostControlRunner | null = null
+  ) {
+    this.execAsync = execAsyncFn || execAsync;
+    this.hostControl = hostControlRunner || {
+      isAvailable: () => isHostControlAvailable(),
+      isRunningInDocker,
+      runXcodebuild: async (args: string[]) => {
+        const result = await runXcodebuildExec(args);
+        if (!result.success || !result.data) {
+          throw new Error(result.error || "Host control xcodebuild failed");
+        }
+        return result.data;
+      },
+      shouldUseHostControl
+    };
+  }
+
+  async isAvailable(): Promise<boolean> {
+    const wantsHostControl = this.hostControl.shouldUseHostControl() && this.hostControl.isRunningInDocker();
+    if (wantsHostControl) {
+      return this.isHostControlAvailable();
+    }
+    return this.isLocalXcodebuildAvailable();
+  }
+
+  async executeCommand(args: string[], options: XcodebuildCommandOptions = {}): Promise<ExecResult> {
+    const { timeoutMs, maxBuffer } = options;
+    const wantsHostControl = this.hostControl.shouldUseHostControl() && this.hostControl.isRunningInDocker();
+    const hostControlAvailable = wantsHostControl ? await this.isHostControlAvailable() : false;
+    const useHostControl = wantsHostControl && hostControlAvailable;
+    const fullCommand = useHostControl ? `host-control xcodebuild ${args.join(" ")}` : `xcodebuild ${args.join(" ")}`;
+    const startTime = Date.now();
+
+    logger.debug(`[iOS] Executing command: ${fullCommand}`);
+
+    if (wantsHostControl && !hostControlAvailable) {
+      throw new ActionableError(
+        "xcodebuild is not available via host control. " +
+        "Ensure the host control daemon is running and reachable from the container."
+      );
+    }
+
+    if (!useHostControl && !(await this.isLocalXcodebuildAvailable())) {
+      throw new ActionableError("xcodebuild is not available. Please install Xcode to continue.");
+    }
+
+    const runCommand = () => (
+      useHostControl
+        ? this.hostControl.runXcodebuild(args)
+        : this.execAsync("xcodebuild", args, maxBuffer)
+    );
+
+    if (timeoutMs) {
+      let timeoutId: NodeJS.Timeout;
+      const timeoutPromise = new Promise<ExecResult>((_, reject) => {
+        timeoutId = setTimeout(
+          () => reject(new Error(`Command timed out after ${timeoutMs}ms: ${fullCommand}`)),
+          timeoutMs
+        );
+      });
+
+      try {
+        const result = await Promise.race([runCommand(), timeoutPromise]);
+        const duration = Date.now() - startTime;
+        logger.debug(`[iOS] Command completed in ${duration}ms: ${fullCommand}`);
+        return result;
+      } catch (error) {
+        const duration = Date.now() - startTime;
+        logger.warn(`[iOS] Command failed after ${duration}ms: ${fullCommand} - ${(error as Error).message}`);
+        throw error;
+      } finally {
+        clearTimeout(timeoutId!);
+      }
+    }
+
+    try {
+      const result = await runCommand();
+      const duration = Date.now() - startTime;
+      logger.debug(`[iOS] Command completed in ${duration}ms: ${fullCommand}`);
+      return result;
+    } catch (error) {
+      const duration = Date.now() - startTime;
+      logger.warn(`[iOS] Command failed after ${duration}ms: ${fullCommand} - ${(error as Error).message}`);
+      throw error;
+    }
+  }
+
+  private async isHostControlAvailable(): Promise<boolean> {
+    if (!this.hostControlAvailability) {
+      this.hostControlAvailability = this.hostControl.isAvailable();
+    }
+    return this.hostControlAvailability;
+  }
+
+  private async isLocalXcodebuildAvailable(): Promise<boolean> {
+    try {
+      await this.execAsync("xcodebuild", ["-version"]);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+}

--- a/test/utils/ios-cmdline-tools/XcodeSigning.test.ts
+++ b/test/utils/ios-cmdline-tools/XcodeSigning.test.ts
@@ -77,15 +77,6 @@ const createFakeDependencies = (options?: { identities?: string; profiles?: stri
         includes(searchString: string) { return this.stdout.includes(searchString); }
       };
     }
-    if (command.includes("xcodebuild -showBuildSettings")) {
-      return {
-        stdout: `DEVELOPMENT_TEAM = ${teamId}`,
-        stderr: "",
-        toString() { return this.stdout; },
-        trim() { return this.stdout.trim(); },
-        includes(searchString: string) { return this.stdout.includes(searchString); }
-      };
-    }
     return {
       stdout: "",
       stderr: "",
@@ -99,6 +90,27 @@ const createFakeDependencies = (options?: { identities?: string; profiles?: stri
     deps: {
       platform: () => "darwin" as const,
       exec,
+      xcodebuild: {
+        executeCommand: async (args: string[]) => {
+          if (args.includes("-showBuildSettings")) {
+            return {
+              stdout: `DEVELOPMENT_TEAM = ${teamId}`,
+              stderr: "",
+              toString() { return this.stdout; },
+              trim() { return this.stdout.trim(); },
+              includes(searchString: string) { return this.stdout.includes(searchString); }
+            };
+          }
+          return {
+            stdout: "",
+            stderr: "",
+            toString() { return this.stdout; },
+            trim() { return this.stdout.trim(); },
+            includes(searchString: string) { return this.stdout.includes(searchString); }
+          };
+        },
+        isAvailable: async () => true
+      },
       readDir: async () => options?.profiles ?? ["test.mobileprovision"],
       readFile: async () => "",
       stat: async () => ({ isFile: () => true }),


### PR DESCRIPTION
## Summary
- add xcodebuild client abstraction with host-control routing
- use host-control exec parsing for xcodebuild results
- update XcodeSigning to use the new xcodebuild client

## Testing
- bun run lint
- bun test
- bun run build

Closes #931
