### PR TITLE
Abstract xcodebuild through host control

### DIFF
--- a/src/utils/ios-cmdline-tools/XcodebuildClient.ts
+++ b/src/utils/ios-cmdline-tools/XcodebuildClient.ts
@@ -129,7 +129,13 @@ export class XcodebuildClient implements Xcodebuild {
     if (!this.hostControlAvailability) {
       this.hostControlAvailability = this.hostControl.isAvailable();
     }
-    return this.hostControlAvailability;
+
+    const available = await this.hostControlAvailability;
+    if (!available) {
+      this.hostControlAvailability = null;
+    }
+
+    return available;
   }
 
   private async isLocalXcodebuildAvailable(): Promise<boolean> {


### PR DESCRIPTION
## Summary
- add xcodebuild client abstraction with host-control routing
- use host-control exec parsing for xcodebuild results
- retry host-control availability after transient failures
- update XcodeSigning to use the new xcodebuild client

## Testing
- bun run lint
- bun test
- bun run build

Closes #931
