### PR TITLE
fix: restore tapOn schema object root

### DIFF
--- a/schemas/tool-definitions.json
+++ b/schemas/tool-definitions.json
@@ -453,19 +453,6 @@
             {
               "type": "object",
               "properties": {
-                "text": {
-                  "type": "string",
-                  "description": "Source text"
-                }
-              },
-              "required": [
-                "text"
-              ],
-              "additionalProperties": false
-            },
-            {
-              "type": "object",
-              "properties": {
                 "elementId": {
                   "type": "string",
                   "description": "Source ID"
@@ -473,6 +460,19 @@
               },
               "required": [
                 "elementId"
+              ],
+              "additionalProperties": false
+            },
+            {
+              "type": "object",
+              "properties": {
+                "text": {
+                  "type": "string",
+                  "description": "Source text"
+                }
+              },
+              "required": [
+                "text"
               ],
               "additionalProperties": false
             }
@@ -484,19 +484,6 @@
             {
               "type": "object",
               "properties": {
-                "text": {
-                  "type": "string",
-                  "description": "Target text"
-                }
-              },
-              "required": [
-                "text"
-              ],
-              "additionalProperties": false
-            },
-            {
-              "type": "object",
-              "properties": {
                 "elementId": {
                   "type": "string",
                   "description": "Target ID"
@@ -504,6 +491,19 @@
               },
               "required": [
                 "elementId"
+              ],
+              "additionalProperties": false
+            },
+            {
+              "type": "object",
+              "properties": {
+                "text": {
+                  "type": "string",
+                  "description": "Target text"
+                }
+              },
+              "required": [
+                "text"
               ],
               "additionalProperties": false
             }
@@ -1429,7 +1429,7 @@
             }
           ]
         },
-        "id": {
+        "elementId": {
           "type": "string",
           "description": "Element resource ID / accessibility identifier"
         },
@@ -1855,18 +1855,34 @@
           "type": "object",
           "properties": {
             "element": {
-              "type": "object",
-              "properties": {
-                "id": {
-                  "description": "Element ID to wait for",
-                  "type": "string"
+              "anyOf": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "elementId": {
+                      "type": "string",
+                      "description": "Element resource ID / accessibility identifier"
+                    }
+                  },
+                  "required": [
+                    "elementId"
+                  ],
+                  "additionalProperties": false
                 },
-                "text": {
-                  "description": "Element text to wait for",
-                  "type": "string"
+                {
+                  "type": "object",
+                  "properties": {
+                    "text": {
+                      "type": "string",
+                      "description": "Element text"
+                    }
+                  },
+                  "required": [
+                    "text"
+                  ],
+                  "additionalProperties": false
                 }
-              },
-              "additionalProperties": false,
+              ],
               "description": "Element to wait for"
             },
             "timeout": {
@@ -2973,7 +2989,7 @@
               "properties": {
                 "elementId": {
                   "type": "string",
-                  "description": "Container ID"
+                  "description": "Container resource ID"
                 }
               },
               "required": [
@@ -3464,18 +3480,34 @@
         },
         "container": {
           "description": "Container to swipe within (elementId or text). REQUIRED for lists. Omit for full-screen swipes.",
-          "type": "object",
-          "properties": {
-            "elementId": {
-              "description": "Container resource ID",
-              "type": "string"
+          "anyOf": [
+            {
+              "type": "object",
+              "properties": {
+                "elementId": {
+                  "type": "string",
+                  "description": "Container resource ID"
+                }
+              },
+              "required": [
+                "elementId"
+              ],
+              "additionalProperties": false
             },
-            "text": {
-              "description": "Container text",
-              "type": "string"
+            {
+              "type": "object",
+              "properties": {
+                "text": {
+                  "type": "string",
+                  "description": "Container text"
+                }
+              },
+              "required": [
+                "text"
+              ],
+              "additionalProperties": false
             }
-          },
-          "additionalProperties": false
+          ]
         },
         "autoTarget": {
           "description": "Auto-target scrollable container (default true)",
@@ -4258,13 +4290,13 @@
           ],
           "description": "Platform"
         },
-        "id": {
-          "description": "Element resource ID / accessibility identifier",
-          "type": "string"
+        "elementId": {
+          "type": "string",
+          "description": "Element resource ID / accessibility identifier"
         },
         "text": {
-          "description": "Element text",
-          "type": "string"
+          "type": "string",
+          "description": "Element text"
         },
         "sessionUuid": {
           "description": "Session UUID for device targeting",
@@ -4287,7 +4319,7 @@
       "oneOf": [
         {
           "required": [
-            "id"
+            "elementId"
           ]
         },
         {

--- a/schemas/tool-definitions.json
+++ b/schemas/tool-definitions.json
@@ -4182,210 +4182,108 @@
     "description": "Tap UI elements by text or ID (returns selectedElement metadata)",
     "inputSchema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "anyOf": [
-        {
-          "type": "object",
-          "properties": {
-            "container": {
-              "description": "Container selector object to scope search. Provide { \"elementId\": \"<id>\" } or { \"text\": \"<text>\" }.",
-              "anyOf": [
-                {
-                  "type": "object",
-                  "properties": {
-                    "elementId": {
-                      "type": "string",
-                      "description": "Container resource ID"
-                    }
-                  },
-                  "required": [
-                    "elementId"
-                  ],
-                  "additionalProperties": false
-                },
-                {
-                  "type": "object",
-                  "properties": {
-                    "text": {
-                      "type": "string",
-                      "description": "Container text"
-                    }
-                  },
-                  "required": [
-                    "text"
-                  ],
-                  "additionalProperties": false
-                }
-              ]
-            },
-            "action": {
-              "type": "string",
-              "enum": [
-                "tap",
-                "doubleTap",
-                "longPress",
-                "focus"
-              ],
-              "description": "Action type"
-            },
-            "selectionStrategy": {
-              "description": "Element selection strategy when multiple matches are found (default: first)",
-              "type": "string",
-              "enum": [
-                "first",
-                "random"
-              ]
-            },
-            "duration": {
-              "description": "Long press duration (ms)",
-              "type": "number"
-            },
-            "searchUntil": {
-              "description": "Poll for element before tapping",
+      "type": "object",
+      "properties": {
+        "container": {
+          "description": "Container selector object to scope search. Provide { \"elementId\": \"<id>\" } or { \"text\": \"<text>\" }.",
+          "anyOf": [
+            {
               "type": "object",
               "properties": {
-                "duration": {
-                  "description": "Polling duration (ms, default: 500)",
-                  "type": "number",
-                  "minimum": 100,
-                  "maximum": 12000
+                "elementId": {
+                  "type": "string",
+                  "description": "Container resource ID"
                 }
               },
+              "required": [
+                "elementId"
+              ],
               "additionalProperties": false
             },
-            "platform": {
-              "type": "string",
-              "enum": [
-                "android",
-                "ios"
+            {
+              "type": "object",
+              "properties": {
+                "text": {
+                  "type": "string",
+                  "description": "Container text"
+                }
+              },
+              "required": [
+                "text"
               ],
-              "description": "Platform"
-            },
-            "id": {
-              "type": "string",
-              "description": "Element resource ID / accessibility identifier"
-            },
-            "sessionUuid": {
-              "description": "Session UUID for device targeting",
-              "type": "string"
-            },
-            "keepScreenAwake": {
-              "description": "Keep physical Android devices awake during the session (default: true)",
-              "type": "boolean"
-            },
-            "device": {
-              "description": "Device label for multi-device plans (e.g., \"A\", \"B\")",
-              "type": "string"
+              "additionalProperties": false
+            }
+          ]
+        },
+        "action": {
+          "type": "string",
+          "enum": [
+            "tap",
+            "doubleTap",
+            "longPress",
+            "focus"
+          ],
+          "description": "Action type"
+        },
+        "selectionStrategy": {
+          "description": "Element selection strategy when multiple matches are found (default: first)",
+          "type": "string",
+          "enum": [
+            "first",
+            "random"
+          ]
+        },
+        "duration": {
+          "description": "Long press duration (ms)",
+          "type": "number"
+        },
+        "searchUntil": {
+          "description": "Poll for element before tapping",
+          "type": "object",
+          "properties": {
+            "duration": {
+              "description": "Polling duration (ms, default: 500)",
+              "type": "number",
+              "minimum": 100,
+              "maximum": 12000
             }
           },
-          "required": [
-            "action",
-            "platform",
-            "id"
-          ],
           "additionalProperties": false
         },
-        {
-          "type": "object",
-          "properties": {
-            "container": {
-              "description": "Container selector object to scope search. Provide { \"elementId\": \"<id>\" } or { \"text\": \"<text>\" }.",
-              "anyOf": [
-                {
-                  "type": "object",
-                  "properties": {
-                    "elementId": {
-                      "type": "string",
-                      "description": "Container resource ID"
-                    }
-                  },
-                  "required": [
-                    "elementId"
-                  ],
-                  "additionalProperties": false
-                },
-                {
-                  "type": "object",
-                  "properties": {
-                    "text": {
-                      "type": "string",
-                      "description": "Container text"
-                    }
-                  },
-                  "required": [
-                    "text"
-                  ],
-                  "additionalProperties": false
-                }
-              ]
-            },
-            "action": {
-              "type": "string",
-              "enum": [
-                "tap",
-                "doubleTap",
-                "longPress",
-                "focus"
-              ],
-              "description": "Action type"
-            },
-            "selectionStrategy": {
-              "description": "Element selection strategy when multiple matches are found (default: first)",
-              "type": "string",
-              "enum": [
-                "first",
-                "random"
-              ]
-            },
-            "duration": {
-              "description": "Long press duration (ms)",
-              "type": "number"
-            },
-            "searchUntil": {
-              "description": "Poll for element before tapping",
-              "type": "object",
-              "properties": {
-                "duration": {
-                  "description": "Polling duration (ms, default: 500)",
-                  "type": "number",
-                  "minimum": 100,
-                  "maximum": 12000
-                }
-              },
-              "additionalProperties": false
-            },
-            "platform": {
-              "type": "string",
-              "enum": [
-                "android",
-                "ios"
-              ],
-              "description": "Platform"
-            },
-            "text": {
-              "type": "string",
-              "description": "Element text"
-            },
-            "sessionUuid": {
-              "description": "Session UUID for device targeting",
-              "type": "string"
-            },
-            "keepScreenAwake": {
-              "description": "Keep physical Android devices awake during the session (default: true)",
-              "type": "boolean"
-            },
-            "device": {
-              "description": "Device label for multi-device plans (e.g., \"A\", \"B\")",
-              "type": "string"
-            }
-          },
-          "required": [
-            "action",
-            "platform",
-            "text"
+        "platform": {
+          "type": "string",
+          "enum": [
+            "android",
+            "ios"
           ],
-          "additionalProperties": false
+          "description": "Platform"
+        },
+        "id": {
+          "description": "Element resource ID / accessibility identifier",
+          "type": "string"
+        },
+        "text": {
+          "description": "Element text",
+          "type": "string"
+        },
+        "sessionUuid": {
+          "description": "Session UUID for device targeting",
+          "type": "string"
+        },
+        "keepScreenAwake": {
+          "description": "Keep physical Android devices awake during the session (default: true)",
+          "type": "boolean"
+        },
+        "device": {
+          "description": "Device label for multi-device plans (e.g., \"A\", \"B\")",
+          "type": "string"
         }
-      ]
+      },
+      "required": [
+        "action",
+        "platform"
+      ],
+      "additionalProperties": false
     },
     "outputSchema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",

--- a/schemas/tool-definitions.json
+++ b/schemas/tool-definitions.json
@@ -4283,7 +4283,19 @@
         "action",
         "platform"
       ],
-      "additionalProperties": false
+      "additionalProperties": false,
+      "oneOf": [
+        {
+          "required": [
+            "id"
+          ]
+        },
+        {
+          "required": [
+            "text"
+          ]
+        }
+      ]
     },
     "outputSchema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",

--- a/src/features/navigation/DefaultUIStateSetup.ts
+++ b/src/features/navigation/DefaultUIStateSetup.ts
@@ -238,7 +238,7 @@ export class DefaultUIStateSetup implements UIStateSetup {
       if (element.text) {
         args.text = element.text;
       } else if (element.resourceId) {
-        args.id = element.resourceId;
+        args.elementId = element.resourceId;
       }
 
       await tapTool.handler(args);

--- a/src/features/observe/IdentifyInteractions.ts
+++ b/src/features/observe/IdentifyInteractions.ts
@@ -576,7 +576,11 @@ export class IdentifyInteractions {
   ): number {
     const args = edge.interaction?.args || {};
     const edgeText = typeof args.text === "string" ? args.text : undefined;
-    const edgeId = typeof args.id === "string" ? args.id : typeof args.elementId === "string" ? args.elementId : undefined;
+    const edgeId = typeof args.elementId === "string"
+      ? args.elementId
+      : typeof args.id === "string"
+        ? args.id
+        : undefined;
 
     let score = 0;
 

--- a/src/features/observe/PredictionAnalyzer.ts
+++ b/src/features/observe/PredictionAnalyzer.ts
@@ -121,7 +121,7 @@ export class PredictionAnalyzer {
   private matchesTapOn(prediction: PredictedAction, toolArgs: Record<string, any>): boolean {
     const target = prediction.target;
     const argText = normalizeIdentifier(toolArgs.text);
-    const argId = normalizeIdentifier(toolArgs.id ?? toolArgs.elementId);
+    const argId = normalizeIdentifier(toolArgs.elementId ?? toolArgs.id);
     const targetText = normalizeIdentifier(target.text);
     const targetId = normalizeIdentifier(target.elementId);
     const targetDesc = normalizeIdentifier(target.contentDesc);

--- a/src/features/observe/PredictiveUIState.ts
+++ b/src/features/observe/PredictiveUIState.ts
@@ -183,9 +183,10 @@ export class PredictiveUIState {
     }
 
     const hasTextMatch = this.matchesText(args.text, interactable);
-    const hasIdMatch = this.matchesResourceId(args.id, interactable);
+    const elementId = args.elementId ?? args.id;
+    const hasIdMatch = this.matchesResourceId(elementId, interactable);
 
-    return (args.text && hasTextMatch) || (args.id && hasIdMatch);
+    return (args.text && hasTextMatch) || (elementId && hasIdMatch);
   }
 
   private matchesSwipeOn(
@@ -245,7 +246,7 @@ export class PredictiveUIState {
 
     if (toolName === "tapOn") {
       const text = args?.text ?? interactable.text;
-      const elementId = args?.id ?? interactable.resourceId;
+      const elementId = args?.elementId ?? args?.id ?? interactable.resourceId;
       const contentDesc = interactable.contentDesc;
 
       if (!text && !elementId && !contentDesc) {

--- a/src/server/debugTools.ts
+++ b/src/server/debugTools.ts
@@ -9,6 +9,11 @@ import { createJSONToolResponse } from "../utils/toolUtils";
 import { BootedDevice, HighlightShape, Platform } from "../models";
 import { addDeviceTargetingToSchema } from "./toolSchemaHelpers";
 import { isDebugModeEnabled } from "../utils/debug";
+import {
+  elementContainerSchema,
+  elementIdTextFieldsSchema,
+  validateElementIdTextSelector
+} from "./elementSelectorSchemas";
 
 const ensureDebugEnabled = () => {
   if (!isDebugModeEnabled()) {
@@ -25,7 +30,7 @@ export interface RawViewHierarchyArgs {
 export interface DebugSearchArgs {
   platform: Platform;
   text?: string;
-  id?: string;
+  elementId?: string;
   container?: {
     elementId?: string;
     text?: string;
@@ -63,11 +68,12 @@ export const rawViewHierarchySchema = addDeviceTargetingToSchema(z.object({
 const debugSearchBaseSchema = z.object({
   platform: z.enum(["android", "ios"]).describe("Target platform"),
   text: z.string().optional().describe("Text to search for in elements"),
-  id: z.string().optional().describe("Element resource ID / accessibility identifier to search for"),
-  container: z.object({
-    elementId: z.string().optional().describe("Container element resource ID to restrict search within"),
-    text: z.string().optional().describe("Container element text to restrict search within")
-  }).optional().describe("Container element to scope the search - specify elementId or text to locate it"),
+  elementId: elementIdTextFieldsSchema.shape.elementId.describe(
+    "Element resource ID / accessibility identifier to search for"
+  ),
+  container: elementContainerSchema.optional().describe(
+    "Container element to scope the search - specify elementId or text to locate it"
+  ),
   fuzzyMatch: z.boolean().optional().describe("Whether to use fuzzy matching (default: true)"),
   caseSensitive: z.boolean().optional().describe("Whether to use case-sensitive matching (default: false)"),
   includeNearMisses: z.boolean().optional().describe("Include elements that almost matched (default: true)"),
@@ -75,14 +81,7 @@ const debugSearchBaseSchema = z.object({
 }).strict();
 
 export const debugSearchSchema = addDeviceTargetingToSchema(debugSearchBaseSchema).superRefine((value, ctx) => {
-  const hasId = value.id !== undefined;
-  const hasText = value.text !== undefined;
-  if (hasId === hasText) {
-    ctx.addIssue({
-      code: z.ZodIssueCode.custom,
-      message: "Provide exactly one of id or text"
-    });
-  }
+  validateElementIdTextSelector(value, ctx);
 });
 
 export const bugReportSchema = addDeviceTargetingToSchema(z.object({
@@ -121,14 +120,14 @@ export function registerDebugTools() {
   const debugSearchHandler = async (device: BootedDevice, args: DebugSearchArgs) => {
     try {
       ensureDebugEnabled();
-      if (!args.text && !args.id) {
-        throw new ActionableError("Either 'text' or 'id' must be provided");
+      if (!args.text && !args.elementId) {
+        throw new ActionableError("Either 'text' or 'elementId' must be provided");
       }
 
       const debugSearch = new DebugSearch(device);
       const result = await debugSearch.execute({
         text: args.text,
-        resourceId: args.id,
+        resourceId: args.elementId,
         container: args.container,
         fuzzyMatch: args.fuzzyMatch,
         caseSensitive: args.caseSensitive,

--- a/src/server/elementSelectorSchemas.ts
+++ b/src/server/elementSelectorSchemas.ts
@@ -1,17 +1,50 @@
 import { z } from "zod";
 
-export const elementContainerSchema = z.union([
+type ElementIdTextDescriptions = {
+  elementId: string;
+  text: string;
+};
+
+export const createElementIdTextSelectorSchema = (
+  descriptions: ElementIdTextDescriptions
+) => z.union([
   z.object({
-    elementId: z.string().describe("Container resource ID")
+    elementId: z.string().describe(descriptions.elementId)
   }).strict(),
   z.object({
-    text: z.string().describe("Container text")
+    text: z.string().describe(descriptions.text)
   }).strict()
 ]);
 
-export const elementIdTextSchema = z.object({
-  id: z.string().describe("Element resource ID / accessibility identifier").optional(),
+export const elementContainerSchema = createElementIdTextSelectorSchema({
+  elementId: "Container resource ID",
+  text: "Container text"
+});
+
+export const elementIdTextSelectorSchema = createElementIdTextSelectorSchema({
+  elementId: "Element resource ID / accessibility identifier",
+  text: "Element text"
+});
+
+export const elementIdTextFieldsSchema = z.object({
+  elementId: z.string().describe("Element resource ID / accessibility identifier").optional(),
   text: z.string().describe("Element text").optional()
 }).strict();
 
 export const elementSelectionStrategySchema = z.enum(["first", "random"]);
+
+export const validateElementIdTextSelector = (
+  value: { elementId?: string; text?: string },
+  ctx: z.RefinementCtx,
+  message: string = "Provide exactly one of elementId or text"
+): void => {
+  const hasElementId = value.elementId !== undefined;
+  const hasText = value.text !== undefined;
+
+  if (hasElementId === hasText) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message
+    });
+  }
+};

--- a/src/server/highlightTools.ts
+++ b/src/server/highlightTools.ts
@@ -22,8 +22,9 @@ import { ElementParser } from "../features/utility/ElementParser";
 import { NoOpPerformanceTracker } from "../utils/PerformanceTracker";
 import {
   elementContainerSchema,
-  elementIdTextSchema,
-  elementSelectionStrategySchema
+  elementIdTextFieldsSchema,
+  elementSelectionStrategySchema,
+  validateElementIdTextSelector
 } from "./elementSelectorSchemas";
 
 const UNSUPPORTED_MESSAGE = "Visual highlights are only supported on Android devices.";
@@ -40,8 +41,8 @@ const highlightBaseSchema = z.object({
   timeoutMs: z.number().int().positive().optional().describe("Highlight request timeout ms (default: 5000)"),
   description: z.string().optional().describe("Optional description of the highlight"),
   shape: highlightShapeSchema.optional().describe("Optional highlight shape definition"),
-  id: elementIdTextSchema.shape.id,
-  text: elementIdTextSchema.shape.text,
+  elementId: elementIdTextFieldsSchema.shape.elementId,
+  text: elementIdTextFieldsSchema.shape.text,
   container: elementContainerSchema.optional().describe(
     "Container selector object to scope search. Provide { \"elementId\": \"<id>\" } or { \"text\": \"<text>\" }."
   ),
@@ -55,14 +56,14 @@ const highlightBaseSchema = z.object({
 
 export const highlightSchema = addDeviceTargetingToSchema(highlightBaseSchema).superRefine((value, ctx) => {
   const hasShape = Boolean(value.shape);
-  const hasId = value.id !== undefined;
+  const hasElementId = value.elementId !== undefined;
   const hasText = value.text !== undefined;
-  const hasSelector = hasId || hasText;
+  const hasSelector = hasElementId || hasText;
 
   if (hasShape === hasSelector) {
     ctx.addIssue({
       code: z.ZodIssueCode.custom,
-      message: "Provide either shape or selector (id/text), but not both"
+      message: "Provide either shape or selector (elementId/text), but not both"
     });
   }
 
@@ -87,11 +88,8 @@ export const highlightSchema = addDeviceTargetingToSchema(highlightBaseSchema).s
     }
   }
 
-  if (hasId && hasText) {
-    ctx.addIssue({
-      code: z.ZodIssueCode.custom,
-      message: "Provide exactly one of id or text"
-    });
+  if (hasSelector) {
+    validateElementIdTextSelector(value, ctx);
   }
 });
 
@@ -209,8 +207,8 @@ const resolveHighlightShapeFromSelector = async (
   device: BootedDevice,
   args: HighlightArgs
 ): Promise<HighlightShape> => {
-  if (!args.id && !args.text) {
-    throw new ActionableError("highlight requires id or text when shape is not provided.");
+  if (!args.elementId && !args.text) {
+    throw new ActionableError("highlight requires elementId or text when shape is not provided.");
   }
 
   if (device.platform !== "android") {
@@ -246,7 +244,7 @@ const resolveHighlightShapeFromSelector = async (
       caseSensitive: false,
       strategy
     })
-    : elementSelector.selectByResourceId(viewHierarchy, args.id as string, {
+    : elementSelector.selectByResourceId(viewHierarchy, args.elementId as string, {
       container,
       partialMatch: false,
       strategy

--- a/src/server/interactionTools.ts
+++ b/src/server/interactionTools.ts
@@ -215,19 +215,24 @@ const tapOnBaseSchema = z.object({
   platform: z.enum(["android", "ios"]).describe("Platform")
 }).strict();
 
-const tapOnByIdSchema = addDeviceTargetingToSchema(
+const tapOnSelectorSchema = addDeviceTargetingToSchema(
   tapOnBaseSchema.extend({
-    id: z.string().describe("Element resource ID / accessibility identifier")
+    id: z.string().optional().describe("Element resource ID / accessibility identifier"),
+    text: z.string().optional().describe("Element text")
   }).strict()
 );
 
-const tapOnByTextSchema = addDeviceTargetingToSchema(
-  tapOnBaseSchema.extend({
-    text: z.string().describe("Element text")
-  }).strict()
-);
+export const tapOnSchema = tapOnSelectorSchema.superRefine((value, ctx) => {
+  const hasId = Boolean(value.id);
+  const hasText = Boolean(value.text);
 
-export const tapOnSchema = z.union([tapOnByIdSchema, tapOnByTextSchema]);
+  if (hasId === hasText) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: "Provide exactly one of id or text"
+    });
+  }
+});
 
 const tapOnResultSchema = z.object({
   success: z.boolean(),

--- a/src/server/interactionTools.ts
+++ b/src/server/interactionTools.ts
@@ -36,8 +36,11 @@ import { ElementUtils } from "../features/utility/ElementUtils";
 import { AdbClient } from "../utils/android-cmdline-tools/AdbClient";
 import { defaultTimer, type Timer } from "../utils/SystemTimer";
 import {
+  createElementIdTextSelectorSchema,
   elementContainerSchema,
-  elementSelectionStrategySchema
+  elementIdTextFieldsSchema,
+  elementSelectionStrategySchema,
+  validateElementIdTextSelector
 } from "./elementSelectorSchemas";
 import {
   elementSchema,
@@ -95,7 +98,7 @@ export interface TapOnArgs {
     elementId?: string;
     text?: string;
   };
-  id?: string;
+  elementId?: string;
   text?: string;
   selectionStrategy?: ElementSelectionStrategy;
   action: "tap" | "doubleTap" | "longPress" | "focus";
@@ -216,22 +219,11 @@ const tapOnBaseSchema = z.object({
 }).strict();
 
 const tapOnSelectorSchema = addDeviceTargetingToSchema(
-  tapOnBaseSchema.extend({
-    id: z.string().optional().describe("Element resource ID / accessibility identifier"),
-    text: z.string().optional().describe("Element text")
-  }).strict()
+  tapOnBaseSchema.extend(elementIdTextFieldsSchema.shape).strict()
 );
 
 export const tapOnSchema = tapOnSelectorSchema.superRefine((value, ctx) => {
-  const hasId = Boolean(value.id);
-  const hasText = Boolean(value.text);
-
-  if (hasId === hasText) {
-    ctx.addIssue({
-      code: z.ZodIssueCode.custom,
-      message: "Provide exactly one of id or text"
-    });
-  }
+  validateElementIdTextSelector(value, ctx);
 });
 
 const tapOnResultSchema = z.object({
@@ -280,23 +272,15 @@ const swipeOnResultSchema = z.object({
 }).passthrough();
 
 const dragAndDropSelectorSchema = (label: "Source" | "Target") =>
-  z.union([
-    z.object({
-      text: z.string().describe(`${label} text`)
-    }).strict(),
-    z.object({
-      elementId: z.string().describe(`${label} ID`)
-    }).strict()
-  ]).describe(`${label} element`);
+  createElementIdTextSelectorSchema({
+    elementId: `${label} ID`,
+    text: `${label} text`
+  }).describe(`${label} element`);
 
-const swipeOnLookForSchema = z.union([
-  z.object({
-    elementId: z.string().describe("ID of the element to look for")
-  }).strict(),
-  z.object({
-    text: z.string().describe("Text to look for")
-  }).strict()
-]);
+const swipeOnLookForSchema = createElementIdTextSelectorSchema({
+  elementId: "ID of the element to look for",
+  text: "Text to look for"
+});
 
 export const dragAndDropSchema = addDeviceTargetingToSchema(z.object({
   source: dragAndDropSelectorSchema("Source"),
@@ -315,14 +299,7 @@ export const dragAndDropSchema = addDeviceTargetingToSchema(z.object({
 
 export const swipeOnSchema = addDeviceTargetingToSchema(z.object({
   includeSystemInsets: z.boolean().optional().describe("Include system bars (default false)"),
-  container: z.object({
-    elementId: z.string().optional().describe("Container resource ID"),
-    text: z.string().optional().describe("Container text")
-  })
-    .refine(
-      value => [value.elementId, value.text].filter(Boolean).length === 1,
-      "container must specify exactly one of elementId or text"
-    )
+  container: elementContainerSchema
     .optional()
     .describe(
       "Container to swipe within (elementId or text). REQUIRED for lists. Omit for full-screen swipes."
@@ -342,14 +319,7 @@ export const swipeOnSchema = addDeviceTargetingToSchema(z.object({
   platform: z.enum(["android", "ios"]).describe("Platform")
 }));
 
-const pinchOnContainerSchema = z.union([
-  z.object({
-    elementId: z.string().describe("Container ID")
-  }).strict(),
-  z.object({
-    text: z.string().describe("Container text")
-  }).strict()
-]);
+const pinchOnContainerSchema = elementContainerSchema;
 
 export const pinchOnSchema = addDeviceTargetingToSchema(z.object({
   direction: z.enum(["in", "out"]).describe("Pinch direction (in=zoom out, out=zoom in)"),
@@ -1519,7 +1489,7 @@ export function registerInteractionTools() {
     const result = await tapOnTextCommand.execute({
       container: args.container,
       text: args.text,
-      elementId: args.id,
+      elementId: args.elementId,
       selectionStrategy: args.selectionStrategy,
       action: args.action,
       duration: args.duration,

--- a/src/server/observeTools.ts
+++ b/src/server/observeTools.ts
@@ -25,20 +25,10 @@ import {
   selectedElementSchema,
   systemInsetsSchema
 } from "./toolOutputSchemas";
+import { elementIdTextSelectorSchema } from "./elementSelectorSchemas";
 
 // Schema definitions
-const waitForElementSchema = z.object({
-  id: z.string().optional().describe("Element ID to wait for"),
-  text: z.string().optional().describe("Element text to wait for"),
-}).superRefine((value, ctx) => {
-  const provided = [value.id, value.text].filter(Boolean).length;
-  if (provided !== 1) {
-    ctx.addIssue({
-      code: z.ZodIssueCode.custom,
-      message: "waitFor.element must specify exactly one of id or text"
-    });
-  }
-});
+const waitForElementSchema = elementIdTextSelectorSchema.describe("Element to wait for");
 
 const waitForSchema = z.object({
   element: waitForElementSchema.describe("Element to wait for"),
@@ -114,15 +104,15 @@ const findWaitForElement = (
   waitFor: ObserveWaitForOptions,
   viewHierarchy: ViewHierarchyResult
 ): Element | null => {
-  if (waitFor.element.id) {
+  if ("elementId" in waitFor.element) {
     return elementUtils.findElementByResourceId(
       viewHierarchy,
-      waitFor.element.id,
+      waitFor.element.elementId,
       undefined
     );
   }
 
-  if (waitFor.element.text) {
+  if ("text" in waitFor.element) {
     return elementUtils.findElementByText(
       viewHierarchy,
       waitFor.element.text,
@@ -149,8 +139,8 @@ const waitForObservation = async (
   const timeoutMs = waitFor.timeout ?? 5000;
   const elementUtils = new ElementUtils();
   const queryOptions = {
-    text: waitFor.element.text,
-    elementId: waitFor.element.id
+    text: "text" in waitFor.element ? waitFor.element.text : undefined,
+    elementId: "elementId" in waitFor.element ? waitFor.element.elementId : undefined
   };
 
   throwIfAborted(signal);

--- a/src/server/testRecordingManager.ts
+++ b/src/server/testRecordingManager.ts
@@ -184,13 +184,13 @@ const buildRecordedMetadata = (event: InteractionEvent): Record<string, any> => 
 
 const buildSelector = (
   element?: Partial<Element>
-): { id?: string; text?: string } | null => {
+): { elementId?: string; text?: string } | null => {
   if (!element) {
     return null;
   }
   const resourceId = element["resource-id"];
   if (resourceId) {
-    return { id: resourceId };
+    return { elementId: resourceId };
   }
 
   const text = element.text ?? element["content-desc"];
@@ -253,8 +253,8 @@ const buildPlanSteps = (events: InteractionEvent[]): PlanStep[] => {
       };
 
       if (selector) {
-        params.container = selector.id
-          ? { elementId: selector.id }
+        params.container = selector.elementId
+          ? { elementId: selector.elementId }
           : { text: selector.text };
       }
 

--- a/src/server/toolRegistry.ts
+++ b/src/server/toolRegistry.ts
@@ -17,6 +17,30 @@ import { ToolCallRepository } from "../db/toolCallRepository";
 import { getDeviceLabelMap, releaseDeviceLabelSessions } from "./deviceLabelMapping";
 import { isDebugModeEnabled } from "../utils/debug";
 
+function applyInputSchemaOverrides(toolName: string, schema: any): any {
+  if (toolName !== "tapOn") {
+    return schema;
+  }
+
+  if (!schema || schema.type !== "object") {
+    return schema;
+  }
+
+  const hasId = Boolean(schema.properties?.id);
+  const hasText = Boolean(schema.properties?.text);
+  if (!hasId || !hasText || schema.oneOf) {
+    return schema;
+  }
+
+  return {
+    ...schema,
+    oneOf: [
+      { required: ["id"] },
+      { required: ["text"] }
+    ]
+  };
+}
+
 // Progress notification interface
 export interface ProgressCallback {
   (progress: number, total?: number, message?: string): Promise<void>;
@@ -441,7 +465,7 @@ class ToolRegistryClass {
     return this.getAllTools().map(tool => ({
       name: tool.name,
       description: tool.description,
-      inputSchema: toJSONSchema(tool.schema),
+      inputSchema: applyInputSchemaOverrides(tool.name, toJSONSchema(tool.schema)),
       ...(tool.outputSchema ? { outputSchema: toJSONSchema(tool.outputSchema) } : {})
     }));
   }

--- a/src/server/toolRegistry.ts
+++ b/src/server/toolRegistry.ts
@@ -17,8 +17,10 @@ import { ToolCallRepository } from "../db/toolCallRepository";
 import { getDeviceLabelMap, releaseDeviceLabelSessions } from "./deviceLabelMapping";
 import { isDebugModeEnabled } from "../utils/debug";
 
+const ROOT_SELECTOR_TOOLS = new Set(["tapOn", "debugSearch"]);
+
 function applyInputSchemaOverrides(toolName: string, schema: any): any {
-  if (toolName !== "tapOn") {
+  if (!ROOT_SELECTOR_TOOLS.has(toolName)) {
     return schema;
   }
 
@@ -26,16 +28,16 @@ function applyInputSchemaOverrides(toolName: string, schema: any): any {
     return schema;
   }
 
-  const hasId = Boolean(schema.properties?.id);
+  const hasElementId = Boolean(schema.properties?.elementId);
   const hasText = Boolean(schema.properties?.text);
-  if (!hasId || !hasText || schema.oneOf) {
+  if (!hasElementId || !hasText || schema.oneOf) {
     return schema;
   }
 
   return {
     ...schema,
     oneOf: [
-      { required: ["id"] },
+      { required: ["elementId"] },
       { required: ["text"] }
     ]
   };

--- a/src/utils/plan/PlanMigrator.ts
+++ b/src/utils/plan/PlanMigrator.ts
@@ -237,10 +237,10 @@ const migrateStepFields = (
       recordWarning(warnings, "Defaulted tapOn.action to tap.", stepIndex);
       changed = true;
     }
-    if (mergedParams.id === undefined && typeof mergedParams.elementId === "string") {
-      mergedParams.id = mergedParams.elementId;
-      delete mergedParams.elementId;
-      recordWarning(warnings, "Renamed elementId to id for tapOn.", stepIndex);
+    if (mergedParams.elementId === undefined && typeof mergedParams.id === "string") {
+      mergedParams.elementId = mergedParams.id;
+      delete mergedParams.id;
+      recordWarning(warnings, "Renamed id to elementId for tapOn.", stepIndex);
       changed = true;
     }
   }


### PR DESCRIPTION
## Summary
- restore tapOn input schema to object root with selector validation
- regenerate tool definitions for updated schema JSON

## Testing
- bun test

Fixes #973
