### PR TITLE
docs: add collapsible demo wrappers

### DIFF
--- a/docs/contributing/overview.md
+++ b/docs/contributing/overview.md
@@ -26,6 +26,11 @@ Thank you for your interest in contributing to AutoMobile!
 - **Keep PRs focused** - One feature or fix per PR
 - **Add tests** - Cover new functionality with tests
 
+## Documentation Style
+
+- **Demos are collapsible** - Wrap GIF demos in MkDocs collapsible admonitions (e.g. `??? example "See demo: <label>"`).
+- **Vary labels by page** - Use "See demo: <context>" or similar, rather than repeating a single label everywhere.
+
 ## Pull Request Process
 
 1. Create a branch from `main`

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,11 +4,13 @@ AutoMobile lets AI agents control your Android & iOS devices using natural langu
 
 It can do this by being an MCP server that uses standard platform tools like `adb` & `simctl` paired with additional Kotlin & Swift libraries and apps. All components are open source. The point is to provide mobile engineers with AI workflow tools to perform UX deep dives, reproduce bugs, and run automated tests.
 
-![Setting an alarm in the Clock app](img/clock-app.gif)
-*An AI agent navigating to the Clock app, creating a new alarm*
+??? example "See demo: Clock app alarm"
+    ![Setting an alarm in the Clock app](img/clock-app.gif)
+    *An AI agent navigating to the Clock app, creating a new alarm*
 
-![Searching YouTube for a video](img/youtube-search.gif)
-*An AI agent searching YouTube and browsing results*
+??? example "See demo: YouTube search"
+    ![Searching YouTube for a video](img/youtube-search.gif)
+    *An AI agent searching YouTube and browsing results*
 
 ### Explore and Test
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -6,7 +6,8 @@ You can use our interactive installer to step through all host platform requirem
 curl -fsSL https://raw.githubusercontent.com/kaeawc/auto-mobile/main/scripts/install.sh | bash
 ```
 
-![Install Demo](img/install.gif)
+??? example "See demo: Install"
+    ![Install Demo](img/install.gif)
 
 Once you've finished that, learn [how to use AutoMobile](using/ux-exploration.md)
 
@@ -18,7 +19,8 @@ To remove AutoMobile and its configurations, use the uninstall script:
 curl -fsSL https://raw.githubusercontent.com/kaeawc/auto-mobile/main/scripts/uninstall.sh | bash
 ```
 
-![Uninstall Demo](img/uninstall.gif)
+??? example "See demo: Uninstall"
+    ![Uninstall Demo](img/uninstall.gif)
 
 This will interactively guide you through removing:
 

--- a/docs/using/perf-analysis/scroll-framerate.md
+++ b/docs/using/perf-analysis/scroll-framerate.md
@@ -2,7 +2,8 @@
 
 Scroll performance is critical to user experience. Janky scrolling is one of the most noticeable performance issues - users immediately feel stuttering and frame drops when swiping through lists, feeds, or grids. AutoMobile measures scroll framerate using Android's `gfxinfo` to catch performance regressions before they reach production.
 
-![Scroll performance demo](../../img/scroll-transition-perf.gif)
+??? example "See demo: Scroll performance"
+    ![Scroll performance demo](../../img/scroll-transition-perf.gif)
 
 ## What is Measured
 

--- a/docs/using/perf-analysis/startup.md
+++ b/docs/using/perf-analysis/startup.md
@@ -2,7 +2,8 @@
 
 Measure and optimize how quickly your app launches and becomes interactive.
 
-![App startup via deep link demo](../../img/deeplink-startup.gif)
+??? example "See demo: Deep link startup"
+    ![App startup via deep link demo](../../img/deeplink-startup.gif)
 
 App startup performance affects user experience and app store ratings. AutoMobile helps measure startup through UI observation and idle detection.
 

--- a/docs/using/reproducting-bugs.md
+++ b/docs/using/reproducting-bugs.md
@@ -22,5 +22,6 @@ The agent will:
 2. Take a snapshot of device state using the [deviceSnapshot](../design-docs/mcp/storage/snapshots.md).
 3. Reproduce any steps or context provided to approximate the state.
 
-![Bug reproduction workflow](../img/bug-repro.gif)
-*Demo: An AI agent reproducing a sample counter bug and [highlighting](../design-docs/mcp/observe/visual-highlighting.md) the main issue.*
+??? example "See demo: Bug reproduction"
+    ![Bug reproduction workflow](../img/bug-repro.gif)
+    *Demo: An AI agent reproducing a sample counter bug and [highlighting](../design-docs/mcp/observe/visual-highlighting.md) the main issue.*

--- a/docs/using/ux-exploration.md
+++ b/docs/using/ux-exploration.md
@@ -20,11 +20,14 @@ Use AI agents to interactively explore your app and discover UI flows.
 | Define boundaries | "Don't submit forms" prevents unwanted actions |
 | Request specific outputs | "Build a navigation summary" gives concrete results |
 
-![Exploring Google Maps](../img/google-maps.gif)
-*Demo: An AI agent exploring Google Maps, searching for locations, and interacting with map controls.*
+??? example "See demo: Google Maps exploration"
+    ![Exploring Google Maps](../img/google-maps.gif)
+    *Demo: An AI agent exploring Google Maps, searching for locations, and interacting with map controls.*
 
-![Setting an alarm in the Clock app](../img/clock-app.gif)
-*Demo: An AI agent navigating to the Clock app, opening the alarm tab, and creating a new alarm.*
+??? example "See demo: Clock app alarm"
+    ![Setting an alarm in the Clock app](../img/clock-app.gif)
+    *Demo: An AI agent navigating to the Clock app, opening the alarm tab, and creating a new alarm.*
 
-![Taking a photo and viewing the gallery](../img/camera-gallery.gif)
-*Demo: An AI agent opening the Camera app, taking a photo, and viewing it in the Gallery.*
+??? example "See demo: Camera gallery"
+    ![Taking a photo and viewing the gallery](../img/camera-gallery.gif)
+    *Demo: An AI agent opening the Camera app, taking a photo, and viewing it in the Gallery.*


### PR DESCRIPTION
## Summary
- wrap user-facing GIF demos in collapsible MkDocs admonitions with per-page labels
- add a brief documentation style note for demo wrapping

## Testing
- `bun run lint`
- `bun test`
- `bun run build`
- `bun run validate:yaml`
- `scripts/validate_mkdocs_nav.sh`
- `scripts/lychee/validate_lychee.sh`
- `scripts/validate_dependabot.sh`
- `scripts/act/validate_act.sh`
- `scripts/claude/validate_plugin.sh`
- `scripts/docker/validate_dockerfile.sh`
- `scripts/hadolint/validate_hadolint.sh`
- `scripts/shellcheck/validate_shell_scripts.sh`
- `scripts/swiftlint/validate_swiftlint.sh`
- `scripts/xml/validate_xml.sh`
- `scripts/ktfmt/validate_ktfmt.sh` (fails: existing formatting issues across Kotlin files)
- `scripts/swiftformat/validate_swiftformat.sh` (fails: existing formatting issues across Swift files)

Closes #987
