### PR TITLE
Add XCTestService app launch support for iOS

### DIFF
--- a/ios/XCTestService/Sources/XCTestService/CommandHandler.swift
+++ b/ios/XCTestService/Sources/XCTestService/CommandHandler.swift
@@ -81,6 +81,9 @@ public class CommandHandler: CommandHandling {
             case RequestType.requestAction.rawValue:
                 return try handleAction(request, startTime: startTime)
 
+            case RequestType.requestLaunchApp.rawValue:
+                return try handleLaunchApp(request, startTime: startTime)
+
             // Clipboard commands
             case RequestType.requestClipboard.rawValue:
                 return try handleClipboard(request, startTime: startTime)
@@ -323,6 +326,20 @@ public class CommandHandler: CommandHandling {
         )
     }
 
+    private func handleLaunchApp(_ request: WebSocketRequest, startTime: Date) throws -> WebSocketResponse {
+        guard let bundleId = request.bundleId else {
+            throw CommandError.missingParameter("bundleId")
+        }
+
+        try gesturePerformer.launchApp(bundleId: bundleId)
+
+        return WebSocketResponse.success(
+            type: ResponseType.launchAppResult.rawValue,
+            requestId: request.requestId,
+            totalTimeMs: totalTimeMs(from: startTime)
+        )
+    }
+
     // MARK: - Clipboard
 
     private func handleClipboard(_ request: WebSocketRequest, startTime: Date) throws -> WebSocketResponse {
@@ -399,6 +416,8 @@ public class CommandHandler: CommandHandling {
             return ResponseType.pressHomeResult.rawValue
         case RequestType.requestAction.rawValue:
             return ResponseType.actionResult.rawValue
+        case RequestType.requestLaunchApp.rawValue:
+            return ResponseType.launchAppResult.rawValue
         case RequestType.requestClipboard.rawValue:
             return ResponseType.clipboardResult.rawValue
         default:

--- a/ios/XCTestService/Sources/XCTestService/Models.swift
+++ b/ios/XCTestService/Sources/XCTestService/Models.swift
@@ -39,6 +39,7 @@ public struct WebSocketRequest: Codable {
 
     // Action parameters
     public let action: String?
+    public let bundleId: String?
 
     // Filtering control
     public let sinceTimestamp: Int64?
@@ -76,6 +77,7 @@ public struct WebSocketRequest: Codable {
         text: String? = nil,
         resourceId: String? = nil,
         action: String? = nil,
+        bundleId: String? = nil,
         sinceTimestamp: Int64? = nil,
         disableAllFiltering: Bool? = nil,
         id: String? = nil,
@@ -106,6 +108,7 @@ public struct WebSocketRequest: Codable {
         self.text = text
         self.resourceId = resourceId
         self.action = action
+        self.bundleId = bundleId
         self.sinceTimestamp = sinceTimestamp
         self.disableAllFiltering = disableAllFiltering
         self.id = id
@@ -528,6 +531,7 @@ public enum RequestType: String {
 
     // Node actions
     case requestAction = "request_action"
+    case requestLaunchApp = "request_launch_app"
 
     // Clipboard
     case requestClipboard = "request_clipboard"
@@ -553,6 +557,7 @@ public enum ResponseType: String {
     case selectAllResult = "select_all_result"
     case pressHomeResult = "press_home_result"
     case actionResult = "action_result"
+    case launchAppResult = "launch_app_result"
     case clipboardResult = "clipboard_result"
     case currentFocusResult = "current_focus_result"
     case traversalOrderResult = "traversal_order_result"

--- a/ios/XCTestService/Tests/XCTestServiceTests/CommandHandlerTests.swift
+++ b/ios/XCTestService/Tests/XCTestServiceTests/CommandHandlerTests.swift
@@ -271,6 +271,25 @@ final class CommandHandlerTests: XCTestCase {
         XCTAssertEqual(fakeGesturePerformer.getPressHomeCallCount(), 1)
     }
 
+    func testLaunchAppSuccess() {
+        let request = WebSocketRequest(
+            type: "request_launch_app",
+            requestId: "launch-123",
+            bundleId: "com.apple.Preferences"
+        )
+
+        let response = commandHandler.handle(request)
+
+        guard let launchResponse = response as? WebSocketResponse else {
+            XCTFail("Expected WebSocketResponse")
+            return
+        }
+
+        XCTAssertEqual(launchResponse.success, true)
+        XCTAssertEqual(launchResponse.type, "launch_app_result")
+        XCTAssertEqual(fakeGesturePerformer.getAppLaunchHistory(), ["com.apple.Preferences"])
+    }
+
     // MARK: - Unknown Command Tests
 
     func testUnknownCommand() {

--- a/ios/XCTestService/Tests/XCTestServiceTests/ModelsTests.swift
+++ b/ios/XCTestService/Tests/XCTestServiceTests/ModelsTests.swift
@@ -292,6 +292,7 @@ final class ModelsTests: XCTestCase {
         XCTAssertEqual(RequestType.requestSwipe.rawValue, "request_swipe")
         XCTAssertEqual(RequestType.requestDrag.rawValue, "request_drag")
         XCTAssertEqual(RequestType.requestSetText.rawValue, "request_set_text")
+        XCTAssertEqual(RequestType.requestLaunchApp.rawValue, "request_launch_app")
     }
 
     // MARK: - ResponseType Tests
@@ -301,5 +302,6 @@ final class ModelsTests: XCTestCase {
         XCTAssertEqual(ResponseType.tapCoordinatesResult.rawValue, "tap_coordinates_result")
         XCTAssertEqual(ResponseType.swipeResult.rawValue, "swipe_result")
         XCTAssertEqual(ResponseType.screenshot.rawValue, "screenshot")
+        XCTAssertEqual(ResponseType.launchAppResult.rawValue, "launch_app_result")
     }
 }

--- a/src/features/action/LaunchApp.ts
+++ b/src/features/action/LaunchApp.ts
@@ -12,6 +12,7 @@ import { createGlobalPerformanceTracker, PerformanceTracker } from "../../utils/
 import { DisplayedTimeMetricsCollector } from "../performance/DisplayedTimeMetricsCollector";
 import { serverConfig } from "../../utils/ServerConfig";
 import { Timer, defaultTimer } from "../../utils/SystemTimer";
+import { XCTestServiceClient } from "../observe/XCTestServiceClient";
 
 export interface TargetUserDetector {
   detectTargetUserId(packageName: string, userId?: number): Promise<number>;
@@ -214,12 +215,14 @@ export class LaunchApp extends BaseVisualChange {
     logger.info(`executeiOS bundleId ${bundleId}`);
 
     let observationTimestampMs: number | undefined;
+    const isSystemBundleId = bundleId.startsWith("com.apple.");
 
     return this.observedInteraction(
       async () => {
         // Check if app is installed
-        const installedApps = await (new ListInstalledApps(this.device)).execute();
-        if (!installedApps.includes(bundleId)) {
+        const installedApps = await this.installedAppsProvider.listInstalledApps();
+        const shouldBlockOnMissing = !isSystemBundleId && installedApps.length > 0;
+        if (shouldBlockOnMissing && !installedApps.includes(bundleId)) {
           logger.info("App is not installed");
           return {
             success: false,
@@ -241,10 +244,19 @@ export class LaunchApp extends BaseVisualChange {
           }
         }
 
-        // Launch the app using axe
-        const launchResult = await this.simctl.launchApp(bundleId, {
-          foregroundIfRunning: !coldBoot
-        });
+        const xcTestClient = XCTestServiceClient.getInstance(this.device);
+        const xcTestLaunchResult = await xcTestClient.requestLaunchApp(bundleId);
+        let launchResult: { success: boolean; pid?: number; error?: string } = {
+          success: xcTestLaunchResult.success,
+          error: xcTestLaunchResult.error
+        };
+
+        if (!xcTestLaunchResult.success) {
+          logger.warn(`[LaunchApp] XCTestService launch failed: ${xcTestLaunchResult.error ?? "unknown error"}`);
+          launchResult = await this.simctl.launchApp(bundleId, {
+            foregroundIfRunning: !coldBoot
+          });
+        }
 
         if (launchResult.error) {
           return {

--- a/src/features/observe/XCTestServiceClient.ts
+++ b/src/features/observe/XCTestServiceClient.ts
@@ -185,6 +185,16 @@ export interface XCTestPressHomeResult {
 }
 
 /**
+ * Interface for launch app result from XCTestService
+ */
+export interface XCTestLaunchAppResult {
+  success: boolean;
+  totalTimeMs: number;
+  error?: string;
+  perfTiming?: XCTestPerfTiming;
+}
+
+/**
  * Interface for action result from XCTestService
  */
 export interface XCTestActionResult {
@@ -313,6 +323,12 @@ export interface XCTestService {
     timeoutMs?: number,
     perf?: PerformanceTracker
   ): Promise<XCTestPressHomeResult>;
+
+  requestLaunchApp(
+    bundleId: string,
+    timeoutMs?: number,
+    perf?: PerformanceTracker
+  ): Promise<XCTestLaunchAppResult>;
 
   requestScreenshot(
     timeoutMs?: number,
@@ -590,6 +606,7 @@ export class XCTestServiceClient implements XCTestService {
         case "set_text_result":
         case "select_all_result":
         case "press_home_result":
+        case "launch_app_result":
           result = {
             success: message.success ?? true,
             totalTimeMs: message.totalTimeMs ?? 0,
@@ -1491,6 +1508,37 @@ export class XCTestServiceClient implements XCTestService {
     const message = {
       type: "request_press_home",
       requestId
+    };
+
+    this.ws?.send(JSON.stringify(message));
+    return promise;
+  }
+
+  public async requestLaunchApp(
+    bundleId: string,
+    timeoutMs: number = 5000,
+    perf?: PerformanceTracker
+  ): Promise<XCTestLaunchAppResult> {
+    if (!await this.ensureConnected(perf)) {
+      return { success: false, totalTimeMs: 0, error: "Not connected" };
+    }
+
+    const requestId = this.requestManager.generateId("launchApp");
+    const promise = this.requestManager.register<XCTestLaunchAppResult>(
+      requestId,
+      "launch_app",
+      timeoutMs,
+      (id, type, timeout) => ({
+        success: false,
+        totalTimeMs: timeout,
+        error: `Launch app timed out after ${timeout}ms`
+      })
+    );
+
+    const message = {
+      type: "request_launch_app",
+      requestId,
+      bundleId
     };
 
     this.ws?.send(JSON.stringify(message));

--- a/src/utils/ios-cmdline-tools/SimCtlClient.ts
+++ b/src/utils/ios-cmdline-tools/SimCtlClient.ts
@@ -715,22 +715,33 @@ export class SimCtlClient implements SimCtl {
     logger.debug(`Listing installed apps on iOS simulator ${targetDevice}`);
 
     try {
+      const parseApps = (payload: string): any[] => {
+        const appsData = JSON.parse(payload);
+
+        if (Array.isArray(appsData)) {
+          return appsData;
+        }
+
+        if (!appsData || typeof appsData !== "object") {
+          return [];
+        }
+
+        // Convert the apps object to an array, preserving bundle IDs from keys.
+        return Object.entries(appsData).map(([bundleId, appInfo]) => {
+          const record = appInfo && typeof appInfo === "object" ? appInfo : {};
+          return { ...record, bundleId };
+        });
+      };
+
+      try {
+        const result = await this.executeCommand(`listapps ${targetDevice} --all`);
+        return parseApps(result.stdout);
+      } catch (error) {
+        logger.warn(`Failed to list iOS apps with --all: ${error}`);
+      }
+
       const result = await this.executeCommand(`listapps ${targetDevice}`);
-      const appsData = JSON.parse(result.stdout);
-
-      if (Array.isArray(appsData)) {
-        return appsData;
-      }
-
-      if (!appsData || typeof appsData !== "object") {
-        return [];
-      }
-
-      // Convert the apps object to an array, preserving bundle IDs from keys.
-      return Object.entries(appsData).map(([bundleId, appInfo]) => {
-        const record = appInfo && typeof appInfo === "object" ? appInfo : {};
-        return { ...record, bundleId };
-      });
+      return parseApps(result.stdout);
     } catch (error) {
       logger.warn(`Failed to list iOS apps: ${error}`);
       return [];

--- a/test/fakes/FakeXCTestService.ts
+++ b/test/fakes/FakeXCTestService.ts
@@ -9,6 +9,7 @@ import {
   XCTestImeActionResult,
   XCTestSelectAllResult,
   XCTestPressHomeResult,
+  XCTestLaunchAppResult,
   XCTestHierarchyResponse,
   IOSPerfTiming,
   XCTestHierarchy
@@ -85,6 +86,7 @@ export class FakeXCTestService implements XCTestService {
   private screenshotRequestCount: number = 0;
   private hierarchyRequestCount: number = 0;
   private pressHomeRequestCount: number = 0;
+  private launchAppHistory: string[] = [];
   private dragResult: XCTestDragResult | null = null;
   private pinchResult: XCTestPinchResult | null = null;
   private tapResult: XCTestTapResult | null = null;
@@ -204,6 +206,13 @@ export class FakeXCTestService implements XCTestService {
   }
 
   /**
+   * Get the history of launch app requests
+   */
+  getLaunchAppHistory(): string[] {
+    return [...this.launchAppHistory];
+  }
+
+  /**
    * Get the history of drag requests
    */
   getDragHistory(): Array<{
@@ -283,6 +292,7 @@ export class FakeXCTestService implements XCTestService {
     this.imeActionHistory = [];
     this.screenshotRequestCount = 0;
     this.hierarchyRequestCount = 0;
+    this.launchAppHistory = [];
   }
 
   // MARK: - Private Helpers
@@ -599,6 +609,22 @@ export class FakeXCTestService implements XCTestService {
     this.pressHomeRequestCount++;
     await this.applyDelay("pressHome");
     this.checkFailure("pressHome");
+
+    return {
+      success: true,
+      totalTimeMs: 100,
+      perfTiming: this.performanceTiming || undefined
+    };
+  }
+
+  async requestLaunchApp(
+    bundleId: string,
+    timeoutMs: number = 5000,
+    perf?: PerformanceTracker
+  ): Promise<XCTestLaunchAppResult> {
+    await this.applyDelay("launchApp");
+    this.checkFailure("launchApp");
+    this.launchAppHistory.push(bundleId);
 
     return {
       success: true,

--- a/test/features/action/LaunchApp.test.ts
+++ b/test/features/action/LaunchApp.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, test } from "bun:test";
+import { beforeEach, describe, expect, test, spyOn } from "bun:test";
 import { LaunchApp } from "../../../src/features/action/LaunchApp";
 import { BootedDevice, ObserveResult } from "../../../src/models";
 import { DefaultPerformanceTracker } from "../../../src/utils/PerformanceTracker";
@@ -9,6 +9,8 @@ import { FakeObserveScreen } from "../../fakes/FakeObserveScreen";
 import { FakeTargetUserDetector } from "../../fakes/FakeTargetUserDetector";
 import { FakeTimer } from "../../fakes/FakeTimer";
 import { FakeWindow } from "../../fakes/FakeWindow";
+import { FakeXCTestService } from "../../fakes/FakeXCTestService";
+import { XCTestServiceClient } from "../../../src/features/observe/XCTestServiceClient";
 
 describe("LaunchApp", () => {
   let device: BootedDevice;
@@ -201,5 +203,52 @@ describe("LaunchApp", () => {
     const childNames = (launchEntry.children as any[]).map(entry => entry.name);
     expect(childNames).toContain("detectTargetUser");
     expect(childNames).toContain("checkInstalled");
+  });
+
+  test("launches iOS system apps even when installed list is empty", async () => {
+    const iosDevice: BootedDevice = { name: "test-ios-device", platform: "ios", deviceId: "ios-123" };
+    const systemBundleId = "com.apple.Preferences";
+    const fakeXCTestService = new FakeXCTestService();
+    const getInstanceSpy = spyOn(XCTestServiceClient, "getInstance").mockReturnValue(
+      fakeXCTestService as unknown as XCTestServiceClient
+    );
+
+    const iosObserveResult: ObserveResult = {
+      updatedAt: Date.now(),
+      screenSize: { width: 1080, height: 1920 },
+      systemInsets: { top: 0, bottom: 0, left: 0, right: 0 },
+      viewHierarchy: { hierarchy: { node: {} }, packageName: systemBundleId } as any
+    };
+
+    const iosFakeObserveScreen = new FakeObserveScreen();
+    iosFakeObserveScreen.setObserveResult(iosObserveResult);
+    const iosFakeAwaitIdle = new FakeAwaitIdle();
+    const iosFakeWindow = new FakeWindow();
+    iosFakeWindow.setCachedActiveWindow({ appId: systemBundleId, activityName: "Main", layoutSeqSum: 1 });
+
+    const installedAppsProvider = new FakeInstalledAppsProvider(fakeTimer, {
+      installedApps: []
+    });
+
+    const iosLaunchApp = new LaunchApp(
+      iosDevice,
+      fakeAdb as unknown as any,
+      null,
+      fakeTimer,
+      { installedAppsProvider }
+    );
+    (iosLaunchApp as any).awaitIdle = iosFakeAwaitIdle;
+    (iosLaunchApp as any).observeScreen = iosFakeObserveScreen;
+    (iosLaunchApp as any).window = iosFakeWindow;
+    (iosLaunchApp as any).waitForIosHierarchyReady = async () => {};
+
+    try {
+      const result = await iosLaunchApp.execute(systemBundleId, false, false);
+      expect(result.success).toBe(true);
+      expect(fakeXCTestService.getLaunchAppHistory()).toEqual([systemBundleId]);
+      expect(installedAppsProvider.getCallCount()).toBe(1);
+    } finally {
+      getInstanceSpy.mockRestore();
+    }
   });
 });

--- a/test/features/observe/XCTestServiceClient.test.ts
+++ b/test/features/observe/XCTestServiceClient.test.ts
@@ -427,6 +427,46 @@ describe("XCTestServiceClient", function() {
     });
   });
 
+  describe("requestLaunchApp", function() {
+    test("should send launch app request and return result", async function() {
+      const testTimer = new FakeTimer();
+      testTimer.setSleepDuration(1);
+
+      const { factory, getSocket } = createCapturingWebSocketFactory(testTimer);
+      const testClient = XCTestServiceClient.createForTesting(
+        testDevice,
+        serverPort,
+        factory,
+        testTimer
+      );
+
+      try {
+        const resultPromise = testClient.requestLaunchApp("com.apple.Preferences", 5000);
+        const socket = await waitForSocket(getSocket);
+        expect(socket).not.toBeNull();
+        await waitForSocketOpen(socket);
+        await waitForSentMessages(socket, 1);
+
+        const sentMessage = JSON.parse(socket!.sentMessages[0]);
+        expect(sentMessage.type).toBe("request_launch_app");
+        expect(sentMessage.bundleId).toBe("com.apple.Preferences");
+
+        socket!.simulateMessage(JSON.stringify({
+          type: "launch_app_result",
+          requestId: sentMessage.requestId,
+          success: true,
+          totalTimeMs: 120
+        }));
+
+        const result = await resultPromise;
+        expect(result.success).toBe(true);
+        expect(result.totalTimeMs).toBe(120);
+      } finally {
+        await testClient.close();
+      }
+    });
+  });
+
   describe("connection management", function() {
     test("isConnected should return true when WebSocket is open", async function() {
       const testTimer = new FakeTimer();

--- a/test/utils/ios-cmdline-tools/simctl-client.listApps.test.ts
+++ b/test/utils/ios-cmdline-tools/simctl-client.listApps.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, test } from "bun:test";
+import { SimCtlClient } from "../../../src/utils/ios-cmdline-tools/SimCtlClient";
+import { BootedDevice } from "../../../src/models";
+import { createExecResult } from "../../../src/utils/execResult";
+
+const createHostControlRunner = () => ({
+  isAvailable: async () => false,
+  isRunningInDocker: () => false,
+  runSimctl: async () => {
+    throw new Error("Host control should not be used in tests");
+  },
+  shouldUseHostControl: () => false
+});
+
+describe("SimCtlClient listApps", () => {
+  test("uses --all to include system apps when supported", async () => {
+    const device: BootedDevice = {
+      deviceId: "ios-device-123",
+      name: "iOS Device",
+      platform: "ios",
+      source: "local"
+    };
+    const execCalls: string[] = [];
+    const execAsync = async (file: string, args: string[]) => {
+      execCalls.push(`${file} ${args.join(" ")}`);
+      if (args.join(" ") === "simctl --version") {
+        return createExecResult("simctl version 1.0.0", "");
+      }
+      if (args.join(" ") === "simctl listapps ios-device-123 --all") {
+        const payload = JSON.stringify({
+          "com.apple.Preferences": { bundleName: "Settings" }
+        });
+        return createExecResult(payload, "");
+      }
+      return createExecResult("{}", "");
+    };
+
+    const simctl = new SimCtlClient(device, execAsync, createHostControlRunner());
+    const apps = await simctl.listApps();
+
+    expect(execCalls).toContain("xcrun simctl listapps ios-device-123 --all");
+    expect(apps).toEqual([{ bundleId: "com.apple.Preferences", bundleName: "Settings" }]);
+  });
+
+  test("falls back to default listapps when --all is unsupported", async () => {
+    const device: BootedDevice = {
+      deviceId: "ios-device-456",
+      name: "iOS Device",
+      platform: "ios",
+      source: "local"
+    };
+    const execCalls: string[] = [];
+    const execAsync = async (file: string, args: string[]) => {
+      execCalls.push(`${file} ${args.join(" ")}`);
+      if (args.join(" ") === "simctl --version") {
+        return createExecResult("simctl version 1.0.0", "");
+      }
+      if (args.join(" ") === "simctl listapps ios-device-456 --all") {
+        throw new Error("unknown option: --all");
+      }
+      if (args.join(" ") === "simctl listapps ios-device-456") {
+        const payload = JSON.stringify({
+          "com.apple.Fitness": { bundleName: "Fitness" }
+        });
+        return createExecResult(payload, "");
+      }
+      return createExecResult("{}", "");
+    };
+
+    const simctl = new SimCtlClient(device, execAsync, createHostControlRunner());
+    const apps = await simctl.listApps();
+
+    expect(execCalls).toContain("xcrun simctl listapps ios-device-456 --all");
+    expect(execCalls).toContain("xcrun simctl listapps ios-device-456");
+    expect(apps).toEqual([{ bundleId: "com.apple.Fitness", bundleName: "Fitness" }]);
+  });
+});


### PR DESCRIPTION
## Summary
- add XCTestService command to launch apps via WebSocket
- wire iOS launchApp to use XCTestService with simctl fallback
- improve simctl listapps to include system apps and add tests

## Testing
- bun test test/features/action/LaunchApp.test.ts test/features/observe/XCTestServiceClient.test.ts
- swift test (ios/XCTestService)

Closes #984
