### PR TITLE
fix: allow iOS observe after setActiveDevice without sessionUuid

### DIFF
--- a/src/server/toolRegistry.ts
+++ b/src/server/toolRegistry.ts
@@ -377,10 +377,12 @@ class ToolRegistryClass {
       return;
     }
 
-    // Check if an iOS device was set via setActiveDevice
+    // Check if an iOS device was set via setActiveDevice and platform is explicitly ios
+    // Only skip the guard when platform === "ios" because ensureDeviceReady only honors
+    // the current device when the requested platform matches currentPlatform
     const currentDevice = this.deviceSessionManager.getCurrentDevice();
     const currentPlatform = this.deviceSessionManager.getCurrentPlatform();
-    if (currentDevice && currentPlatform === "ios") {
+    if (currentDevice && currentPlatform === "ios" && platform === "ios") {
       return;
     }
 

--- a/test/server/toolRegistry.iosSessionContext.test.ts
+++ b/test/server/toolRegistry.iosSessionContext.test.ts
@@ -96,7 +96,7 @@ describe("ToolRegistry iOS session context", () => {
     expect(fakeDeviceSessionManager.getEnsureDeviceReadyCallCount()).toBe(1);
   });
 
-  test("allows operation when setActiveDevice was called with an iOS device", async () => {
+  test("allows operation when setActiveDevice was called with an iOS device and platform is ios", async () => {
     fakeDeviceSessionManager.setConnectedDevices([iosDeviceA, iosDeviceB]);
     // Simulate setActiveDevice having been called
     fakeDeviceSessionManager.setCurrentDevice(iosDeviceA, "ios");
@@ -114,9 +114,35 @@ describe("ToolRegistry iOS session context", () => {
     const tool = ToolRegistry.getTool("iosActiveDeviceTool");
     expect(tool).toBeDefined();
 
-    // Should succeed without sessionUuid because setActiveDevice was called
+    // Should succeed without sessionUuid because setActiveDevice was called with platform: ios
     const response = await tool!.handler({ platform: "ios" });
     expect(response).toEqual({ success: true });
     expect(fakeDeviceSessionManager.getEnsureDeviceReadyCallCount()).toBe(1);
+  });
+
+  test("still requires sessionUuid when setActiveDevice was called but platform is not ios", async () => {
+    fakeDeviceSessionManager.setConnectedDevices([iosDeviceA, iosDeviceB]);
+    // Simulate setActiveDevice having been called
+    fakeDeviceSessionManager.setCurrentDevice(iosDeviceA, "ios");
+
+    ToolRegistry.registerDeviceAware(
+      "iosActiveDeviceEitherPlatformTool",
+      "Tool requires sessionUuid when platform is either even with setActiveDevice",
+      z.object({
+        platform: z.enum(["ios", "android"]).optional(),
+        sessionUuid: z.string().optional(),
+      }),
+      async () => ({ success: true })
+    );
+
+    const tool = ToolRegistry.getTool("iosActiveDeviceEitherPlatformTool");
+    expect(tool).toBeDefined();
+
+    // Should still require sessionUuid because platform is not explicitly "ios"
+    // ensureDeviceReady won't honor currentDevice when platform doesn't match
+    await expect(tool!.handler({})).rejects.toThrow(
+      "Multiple iOS simulators detected. Provide sessionUuid to target a specific simulator."
+    );
+    expect(fakeDeviceSessionManager.getEnsureDeviceReadyCallCount()).toBe(0);
   });
 });


### PR DESCRIPTION
## Summary
- When multiple iOS simulators are running, `setActiveDevice` with a specific `deviceId` now properly allows subsequent `observe` calls without requiring `sessionUuid`
- Modified `enforceSessionUuidForMultipleIos` in `toolRegistry.ts` to check if a current iOS device was set via `setActiveDevice`
- Added test case verifying the fix

## Test Plan
- [x] Unit tests pass locally (`bun test`)
- [x] Validation passes (`bun run lint`, `bun run build`)
- [x] Swift builds pass
- [x] New test case covers the specific scenario

Closes #1001

🤖 Generated with [Claude Code](https://claude.com/claude-code)