### PR TITLE
feat: add iOS support for rawViewHierarchy MCP tool

### DIFF
--- a/ios/XCTestService/Sources/XCTestService/CommandHandler.swift
+++ b/ios/XCTestService/Sources/XCTestService/CommandHandler.swift
@@ -127,10 +127,11 @@ public class CommandHandler: CommandHandling {
         perfProvider.serial("handleRequestHierarchy")
         defer { perfProvider.end() }
 
+        let disableAllFiltering = request.disableAllFiltering ?? false
         let hierarchy: ViewHierarchy
         do {
             hierarchy = try perfProvider.track("extraction") {
-                try elementLocator.getViewHierarchy()
+                try elementLocator.getViewHierarchy(disableAllFiltering: disableAllFiltering)
             }
         } catch {
             print("[CommandHandler] Hierarchy extraction failed: \(error)")

--- a/ios/XCTestService/Sources/XCTestService/ElementLocator.swift
+++ b/ios/XCTestService/Sources/XCTestService/ElementLocator.swift
@@ -303,7 +303,7 @@ public class ElementLocator: ElementLocating {
 
         // MARK: - View Hierarchy
 
-        public func getViewHierarchy() throws -> ViewHierarchy {
+        public func getViewHierarchy(disableAllFiltering: Bool = false) throws -> ViewHierarchy {
             perfProvider.serial("getViewHierarchy")
             defer { perfProvider.end() }
 
@@ -343,9 +343,15 @@ public class ElementLocator: ElementLocating {
             }
 
             // Apply optimization - flatten structural wrappers and filter empty nodes
-            let rootElement = perfProvider.track("optimize") {
-                let optimizedElements = optimizeHierarchy(rawElement, isRoot: true)
-                return optimizedElements.first ?? rawElement
+            // Skip optimization when disableAllFiltering is true (for raw hierarchy debugging)
+            let rootElement: UIElementInfo
+            if disableAllFiltering {
+                rootElement = rawElement
+            } else {
+                rootElement = perfProvider.track("optimize") {
+                    let optimizedElements = optimizeHierarchy(rawElement, isRoot: true)
+                    return optimizedElements.first ?? rawElement
+                }
             }
 
             // Get window info from snapshot
@@ -826,7 +832,7 @@ public class ElementLocator: ElementLocating {
         // Non-iOS stub implementation
         public init() {}
 
-        public func getViewHierarchy() throws -> ViewHierarchy {
+        public func getViewHierarchy(disableAllFiltering _: Bool = false) throws -> ViewHierarchy {
             return ViewHierarchy(
                 packageName: nil,
                 hierarchy: nil,

--- a/ios/XCTestService/Sources/XCTestService/Fakes.swift
+++ b/ios/XCTestService/Sources/XCTestService/Fakes.swift
@@ -16,6 +16,9 @@ public class FakeElementLocator: ElementLocating {
     private var findByIdHistory: [String] = []
     private var findByTextHistory: [String] = []
 
+    /// Tracks the last value of disableAllFiltering passed to getViewHierarchy
+    public private(set) var lastDisableAllFiltering: Bool?
+
     public init() {}
 
     // MARK: - Configuration
@@ -47,12 +50,14 @@ public class FakeElementLocator: ElementLocating {
         getHierarchyCallCount = 0
         findByIdHistory.removeAll()
         findByTextHistory.removeAll()
+        lastDisableAllFiltering = nil
     }
 
     // MARK: - ElementLocating
 
-    public func getViewHierarchy() throws -> ViewHierarchy {
+    public func getViewHierarchy(disableAllFiltering: Bool = false) throws -> ViewHierarchy {
         getHierarchyCallCount += 1
+        lastDisableAllFiltering = disableAllFiltering
 
         if let error = shouldThrow {
             throw error

--- a/ios/XCTestService/Sources/XCTestService/HierarchyDebouncer.swift
+++ b/ios/XCTestService/Sources/XCTestService/HierarchyDebouncer.swift
@@ -201,7 +201,7 @@ public class HierarchyDebouncer: HierarchyDebouncing {
 
     private func captureInitialState() {
         do {
-            let hierarchy = try elementLocator.getViewHierarchy()
+            let hierarchy = try elementLocator.getViewHierarchy(disableAllFiltering: false)
             let hash = StructuralHasher.computeHash(hierarchy)
 
             lock.lock()
@@ -250,7 +250,7 @@ public class HierarchyDebouncer: HierarchyDebouncing {
         let startTime = timer.now()
 
         do {
-            let hierarchy = try elementLocator.getViewHierarchy()
+            let hierarchy = try elementLocator.getViewHierarchy(disableAllFiltering: false)
             let extractionTime = timer.now() - startTime
             let newHash = StructuralHasher.computeHash(hierarchy)
 

--- a/ios/XCTestService/Sources/XCTestService/Protocols.swift
+++ b/ios/XCTestService/Sources/XCTestService/Protocols.swift
@@ -5,7 +5,8 @@ import Foundation
 /// Protocol for locating UI elements and building view hierarchies
 public protocol ElementLocating {
     /// Get the full view hierarchy
-    func getViewHierarchy() throws -> ViewHierarchy
+    /// - Parameter disableAllFiltering: If true, skip hierarchy optimization and return raw hierarchy
+    func getViewHierarchy(disableAllFiltering: Bool) throws -> ViewHierarchy
 
     /// Find element by resource ID / accessibility identifier
     func findElement(byResourceId resourceId: String) -> Any?

--- a/src/features/debug/RawViewHierarchy.ts
+++ b/src/features/debug/RawViewHierarchy.ts
@@ -3,6 +3,7 @@ import { logger } from "../../utils/logger";
 import { BootedDevice, RawViewHierarchyResult } from "../../models";
 import { ViewHierarchy } from "../observe/ViewHierarchy";
 import { AccessibilityServiceClient } from "../observe/AccessibilityServiceClient";
+import { XCTestServiceClient } from "../observe/XCTestServiceClient";
 import { NoOpPerformanceTracker } from "../../utils/PerformanceTracker";
 
 export interface RawViewHierarchyOptions {
@@ -41,11 +42,10 @@ export class RawViewHierarchy {
    * @returns Raw hierarchy data
    */
   async execute(options: RawViewHierarchyOptions = {}): Promise<RawViewHierarchyResult> {
-    const source = options.source || "both";
     const startTime = Date.now();
 
     const result: RawViewHierarchyResult = {
-      source,
+      source: this.device.platform === "ios" ? "xcuitest" : (options.source || "both"),
       timestamp: startTime,
       device: {
         deviceId: this.device.deviceId,
@@ -56,56 +56,81 @@ export class RawViewHierarchy {
     const errors: string[] = [];
 
     try {
-      if (source === "uiautomator" || source === "both") {
-        logger.info("[RawViewHierarchy] Extracting via uiautomator dump");
+      if (this.device.platform === "ios") {
+        // iOS: Get raw XCUITest hierarchy (ignore source parameter)
+        logger.info("[RawViewHierarchy] Extracting via XCTestService");
         try {
-          const xml = await this.viewHierarchy.executeUiAutomatorDump();
-          result.xml = xml;
-          logger.info(`[RawViewHierarchy] Got XML (${xml.length} bytes)`);
+          const xcTestClient = XCTestServiceClient.getInstance(this.device);
+          const hierarchyResult = await xcTestClient.requestHierarchySync(
+            new NoOpPerformanceTracker(),
+            true // disableAllFiltering = true
+          );
+          if (hierarchyResult?.hierarchy) {
+            result.xcuitest = JSON.stringify(hierarchyResult.hierarchy, null, 2);
+            logger.info(`[RawViewHierarchy] Got XCUITest JSON (${result.xcuitest.length} bytes)`);
+          } else {
+            errors.push("XCTestService returned no data");
+          }
         } catch (error) {
-          const errorMsg = `uiautomator dump failed: ${error}`;
+          const errorMsg = `XCTestService failed: ${error}`;
           errors.push(errorMsg);
           logger.warn(`[RawViewHierarchy] ${errorMsg}`);
         }
-      }
+      } else {
+        // Android: Use existing implementation
+        const source = options.source || "both";
 
-      if (source === "accessibility-service" || source === "both") {
-        logger.info("[RawViewHierarchy] Extracting via accessibility service");
-        try {
-          const perf = new NoOpPerformanceTracker();
-          const hierarchy = await this.accessibilityServiceClient.getAccessibilityHierarchy(
-            undefined,
-            perf,
-            false,
-            0,
-            true // disableAllFiltering - get unfiltered/unoptimized hierarchy
-          );
-
-          if (hierarchy) {
-            // Get the raw hierarchy data before conversion
-            result.json = JSON.stringify(hierarchy, null, 2);
-            logger.info(`[RawViewHierarchy] Got JSON (${result.json.length} bytes)`);
-          } else {
-            errors.push("accessibility-service returned no data");
+        if (source === "uiautomator" || source === "both") {
+          logger.info("[RawViewHierarchy] Extracting via uiautomator dump");
+          try {
+            const xml = await this.viewHierarchy.executeUiAutomatorDump();
+            result.xml = xml;
+            logger.info(`[RawViewHierarchy] Got XML (${xml.length} bytes)`);
+          } catch (error) {
+            const errorMsg = `uiautomator dump failed: ${error}`;
+            errors.push(errorMsg);
+            logger.warn(`[RawViewHierarchy] ${errorMsg}`);
           }
-        } catch (error) {
-          const errorMsg = `accessibility-service failed: ${error}`;
-          errors.push(errorMsg);
-          logger.warn(`[RawViewHierarchy] ${errorMsg}`);
+        }
+
+        if (source === "accessibility-service" || source === "both") {
+          logger.info("[RawViewHierarchy] Extracting via accessibility service");
+          try {
+            const perf = new NoOpPerformanceTracker();
+            const hierarchy = await this.accessibilityServiceClient.getAccessibilityHierarchy(
+              undefined,
+              perf,
+              false,
+              0,
+              true // disableAllFiltering - get unfiltered/unoptimized hierarchy
+            );
+
+            if (hierarchy) {
+              // Get the raw hierarchy data before conversion
+              result.json = JSON.stringify(hierarchy, null, 2);
+              logger.info(`[RawViewHierarchy] Got JSON (${result.json.length} bytes)`);
+            } else {
+              errors.push("accessibility-service returned no data");
+            }
+          } catch (error) {
+            const errorMsg = `accessibility-service failed: ${error}`;
+            errors.push(errorMsg);
+            logger.warn(`[RawViewHierarchy] ${errorMsg}`);
+          }
+        }
+
+        // Adjust source based on what we actually got
+        if (source === "both") {
+          if (result.xml && !result.json) {
+            result.source = "uiautomator";
+          } else if (!result.xml && result.json) {
+            result.source = "accessibility-service";
+          }
         }
       }
 
       if (errors.length > 0) {
         result.error = errors.join("; ");
-      }
-
-      // Adjust source based on what we actually got
-      if (source === "both") {
-        if (result.xml && !result.json) {
-          result.source = "uiautomator";
-        } else if (!result.xml && result.json) {
-          result.source = "accessibility-service";
-        }
       }
 
       const duration = Date.now() - startTime;

--- a/src/features/observe/XCTestServiceClient.ts
+++ b/src/features/observe/XCTestServiceClient.ts
@@ -980,7 +980,8 @@ export class XCTestServiceClient implements XCTestService {
 
     const message = {
       type: disableAllFiltering ? "request_hierarchy" : "request_hierarchy_if_stale",
-      requestId
+      requestId,
+      disableAllFiltering: disableAllFiltering ?? false
     };
 
     this.ws?.send(JSON.stringify(message));

--- a/src/models/RawViewHierarchyResult.ts
+++ b/src/models/RawViewHierarchyResult.ts
@@ -3,19 +3,24 @@
  */
 export interface RawViewHierarchyResult {
   /**
-   * Raw XML content from uiautomator dump
+   * Raw XML content from uiautomator dump (Android only)
    */
   xml?: string;
 
   /**
-   * Raw JSON content from accessibility service (if available)
+   * Raw JSON content from accessibility service (Android only)
    */
   json?: string;
 
   /**
+   * Raw JSON content from XCUITest (iOS only)
+   */
+  xcuitest?: string;
+
+  /**
    * Source of the hierarchy data
    */
-  source: "uiautomator" | "accessibility-service" | "both";
+  source: "uiautomator" | "accessibility-service" | "both" | "xcuitest";
 
   /**
    * Timestamp when the hierarchy was captured

--- a/src/server/debugTools.ts
+++ b/src/server/debugTools.ts
@@ -62,7 +62,7 @@ export const rawViewHierarchySchema = addDeviceTargetingToSchema(z.object({
   platform: z.enum(["android", "ios"]).describe("Target platform"),
   source: z.enum(["uiautomator", "accessibility-service", "both"])
     .optional()
-    .describe("Source for hierarchy extraction: 'uiautomator' for raw XML, 'accessibility-service' for JSON, or 'both' for comparison")
+    .describe("Source for hierarchy extraction (Android only, ignored on iOS): 'uiautomator' for raw XML, 'accessibility-service' for JSON, or 'both' for comparison. iOS always returns XCUITest JSON.")
 }));
 
 const debugSearchBaseSchema = z.object({


### PR DESCRIPTION
## Summary
- Add `disableAllFiltering` parameter to Swift's `ElementLocator.getViewHierarchy()` to skip hierarchy optimization
- Pass the flag through `CommandHandler` from WebSocket messages to iOS
- Include `disableAllFiltering` in TypeScript `XCTestServiceClient` WebSocket requests
- Add iOS branch in `RawViewHierarchy.execute()` returning `xcuitest` JSON field
- Update `RawViewHierarchyResult` model with `xcuitest` field and source type

## Test Plan
- [x] Swift builds successfully
- [x] Swift tests pass (49 tests)
- [x] TypeScript builds successfully  
- [x] TypeScript tests pass (1544 tests)
- [x] Lint passes
- [ ] Manual test on iOS simulator

Closes #1000

🤖 Generated with [Claude Code](https://claude.com/claude-code)