### PR TITLE
fix: upgrade tar to 7.5.4 for CVE-2026-23950

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -66,6 +66,7 @@
   },
   "overrides": {
     "lodash": "^4.17.23",
+    "tar": "7.5.4",
   },
   "packages": {
     "@anthropic-ai/sdk": ["@anthropic-ai/sdk@0.71.2", "", { "dependencies": { "json-schema-to-ts": "^3.1.1" }, "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" }, "optionalPeers": ["zod"], "bin": { "anthropic-ai-sdk": "bin/cli" } }, "sha512-TGNDEUuEstk/DKu0/TflXAEt+p+p/WhTlFzEnoosvbaDU2LTjm42igSdlL0VijrKpWejtOKxX0b8A7uc+XiSAQ=="],
@@ -1148,7 +1149,7 @@
 
     "supports-preserve-symlinks-flag": ["supports-preserve-symlinks-flag@1.0.0", "", {}, "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w=="],
 
-    "tar": ["tar@7.5.2", "", { "dependencies": { "@isaacs/fs-minipass": "^4.0.0", "chownr": "^3.0.0", "minipass": "^7.1.2", "minizlib": "^3.1.0", "yallist": "^5.0.0" } }, "sha512-7NyxrTE4Anh8km8iEy7o0QYPs+0JKBTj5ZaqHg6B39erLg0qYXN3BijtShwbsNSvQ+LN75+KV+C4QR/f6Gwnpg=="],
+    "tar": ["tar@7.5.4", "", { "dependencies": { "@isaacs/fs-minipass": "^4.0.0", "chownr": "^3.0.0", "minipass": "^7.1.2", "minizlib": "^3.1.0", "yallist": "^5.0.0" } }, "sha512-AN04xbWGrSTDmVwlI4/GTlIIwMFk/XEv7uL8aa57zuvRy6s4hdBed+lVq2fAZ89XDa7Us3ANXcE3Tvqvja1kTA=="],
 
     "tinycolor2": ["tinycolor2@1.6.0", "", {}, "sha512-XPaBkWQJdsf3pLKJV9p4qN/S+fm2Oj8AIPo1BTUhg5oxkvm9+SVEGFdhyOz7tTdUTfvxMiAs4sp6/eZO2Ew+pw=="],
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -7811,9 +7811,9 @@
       }
     },
     "node_modules/tar": {
-      "version": "7.5.3",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.3.tgz",
-      "integrity": "sha512-ENg5JUHUm2rDD7IvKNFGzyElLXNjachNLp6RaGf4+JOgxXHkqA+gq81ZAMCUmtMtqBsoU62lcp6S27g1LCYGGQ==",
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.4.tgz",
+      "integrity": "sha512-AN04xbWGrSTDmVwlI4/GTlIIwMFk/XEv7uL8aa57zuvRy6s4hdBed+lVq2fAZ89XDa7Us3ANXcE3Tvqvja1kTA==",
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "@isaacs/fs-minipass": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -102,11 +102,13 @@
     "xml2js": "^0.6.2",
     "zod": "^4.3.5"
   },
-  "overrides": {
-    "lodash": "^4.17.23"
-  },
   "//overrides": {
-    "lodash": "CVE-2025-13465: prototype pollution in _.unset and _.omit"
+    "lodash": "CVE-2025-13465: prototype pollution in _.unset and _.omit",
+    "tar": "CVE-2026-23950: Race condition in path reservations via Unicode collisions on macOS APFS"
+  },
+  "overrides": {
+    "lodash": "^4.17.23",
+    "tar": "7.5.4"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3.3.3",


### PR DESCRIPTION
## Summary
- Fixes high severity security vulnerability CVE-2026-23950 (GHSA-r6q2-hw4h-h46w)
- Adds override to force `tar@7.5.4` which patches a race condition in path reservations
- Vulnerability allowed symlink poisoning via Unicode collisions (ß/ss) on macOS APFS

## Test Plan
- [x] `bun run build` passes
- [x] `bun test` passes (1594 tests)
- [x] Verified `npm ls tar` shows `tar@7.5.4 overridden`

Closes https://github.com/kaeawc/auto-mobile/security/dependabot/11

🤖 Generated with [Claude Code](https://claude.com/claude-code)