### PR TITLE
fix: resolve flaky video recording auto-stop test on macOS CI

### DIFF
--- a/test/server/videoRecordingManager.test.ts
+++ b/test/server/videoRecordingManager.test.ts
@@ -68,13 +68,14 @@ describe("videoRecordingManager", () => {
   });
 
   const waitForRecordingCount = async (expected: number): Promise<void> => {
-    for (let attempt = 0; attempt < 20; attempt++) {
+    for (let attempt = 0; attempt < 50; attempt++) {
       const recordings = await listVideoRecordings();
       if (recordings.length === expected) {
         return;
       }
-      // Yield to event loop to let async operations complete
-      await new Promise(resolve => setImmediate(resolve));
+      // Use setTimeout instead of setImmediate for more reliable cross-platform timing
+      // The auto-stop callback fires async work that needs multiple event loop cycles
+      await new Promise(resolve => setTimeout(resolve, 1));
     }
     throw new Error(`Timed out waiting for ${expected} recordings`);
   };


### PR DESCRIPTION
## Summary

- Fixed flaky `auto-stops recordings using FakeTimer` test that was consistently failing on macOS CI
- Changed `waitForRecordingCount` polling from `setImmediate` to `setTimeout(1ms)` for reliable cross-platform timing
- Increased polling attempts from 20 to 50 to handle slower async chain completion

## Root Cause

The auto-stop callback calls `void stopVideoRecording()` (fire-and-forget). The test awaits `stopCall` which resolves when `fakeBackend.stop()` is called, but `stopVideoRecording` still needs to complete `await recordingRepository.updateRecording(status: "completed")` before the recording appears in `listVideoRecordings()`.

On macOS CI, 20 `setImmediate` cycles weren't enough for the async chain to complete.

## Test Plan

- [x] Tests pass locally (15 consecutive runs, all pass)
- [x] Full test suite passes (1594 tests)
- [x] Lint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)