### PR TITLE
fix: handle CTE queries as read operations in database inspection

### DIFF
--- a/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/database/SQLiteDatabaseDriver.kt
+++ b/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/database/SQLiteDatabaseDriver.kt
@@ -146,19 +146,76 @@ class SQLiteDatabaseDriver(private val context: Context) : DatabaseDriver {
 
   override fun executeSQL(databasePath: String, query: String): SQLExecutionResult {
     val trimmedQuery = query.trim()
-    val upperQuery = trimmedQuery.uppercase()
 
     // Determine if this is a query or mutation
-    val isQuery =
-        upperQuery.startsWith("SELECT") ||
-            upperQuery.startsWith("PRAGMA") ||
-            upperQuery.startsWith("EXPLAIN")
+    val isQuery = isReadQuery(trimmedQuery)
 
     return if (isQuery) {
       executeQuery(databasePath, trimmedQuery)
     } else {
       executeMutation(databasePath, trimmedQuery)
     }
+  }
+
+  /**
+   * Determine if a SQL statement is a read query (returns rows) vs a mutation.
+   *
+   * Handles CTE queries (WITH ... SELECT) by looking past the CTE prefix to find the actual
+   * statement type.
+   */
+  private fun isReadQuery(query: String): Boolean {
+    val upperQuery = query.uppercase()
+
+    // Direct read queries
+    if (upperQuery.startsWith("SELECT") ||
+        upperQuery.startsWith("PRAGMA") ||
+        upperQuery.startsWith("EXPLAIN")) {
+      return true
+    }
+
+    // CTE queries: WITH ... followed by SELECT/INSERT/UPDATE/DELETE
+    // We need to find the actual statement after the CTE definitions
+    if (upperQuery.startsWith("WITH")) {
+      // Find the final statement after all CTE definitions
+      // CTEs are: WITH name AS (...), name2 AS (...) SELECT/INSERT/UPDATE/DELETE
+      // We look for the last occurrence of a statement keyword not inside parentheses
+      val statementType = findStatementAfterCTE(upperQuery)
+      return statementType == "SELECT"
+    }
+
+    return false
+  }
+
+  /**
+   * Find the actual statement type after CTE definitions.
+   *
+   * Parses past WITH ... AS (...) clauses to find SELECT/INSERT/UPDATE/DELETE.
+   */
+  private fun findStatementAfterCTE(upperQuery: String): String? {
+    var depth = 0
+    var i = 4 // Skip "WITH"
+
+    while (i < upperQuery.length) {
+      val char = upperQuery[i]
+
+      when {
+        char == '(' -> depth++
+        char == ')' -> depth--
+        depth == 0 -> {
+          // Check for statement keywords at this position
+          val remaining = upperQuery.substring(i).trimStart()
+          when {
+            remaining.startsWith("SELECT") -> return "SELECT"
+            remaining.startsWith("INSERT") -> return "INSERT"
+            remaining.startsWith("UPDATE") -> return "UPDATE"
+            remaining.startsWith("DELETE") -> return "DELETE"
+          }
+        }
+      }
+      i++
+    }
+
+    return null
   }
 
   private fun executeQuery(databasePath: String, query: String): SQLExecutionResult.Query {

--- a/src/server/databaseTools.ts
+++ b/src/server/databaseTools.ts
@@ -54,10 +54,15 @@ function extractAffectedTables(query: string): string[] {
 
 /**
  * Determine if query is a mutation (modifies data)
+ *
+ * Handles CTE queries (WITH ... SELECT/INSERT/UPDATE/DELETE) by looking past
+ * the CTE prefix to find the actual statement type.
  */
 function isMutationQuery(query: string): boolean {
   const upperQuery = query.trim().toUpperCase();
-  return (
+
+  // Direct mutations
+  if (
     upperQuery.startsWith("INSERT") ||
     upperQuery.startsWith("UPDATE") ||
     upperQuery.startsWith("DELETE") ||
@@ -65,7 +70,48 @@ function isMutationQuery(query: string): boolean {
     upperQuery.startsWith("DROP") ||
     upperQuery.startsWith("CREATE") ||
     upperQuery.startsWith("TRUNCATE")
-  );
+  ) {
+    return true;
+  }
+
+  // CTE queries: WITH ... followed by SELECT/INSERT/UPDATE/DELETE
+  if (upperQuery.startsWith("WITH")) {
+    const statementType = findStatementAfterCTE(upperQuery);
+    // Only INSERT/UPDATE/DELETE are mutations; SELECT is not
+    return statementType === "INSERT" || statementType === "UPDATE" || statementType === "DELETE";
+  }
+
+  return false;
+}
+
+/**
+ * Find the actual statement type after CTE definitions.
+ *
+ * Parses past WITH ... AS (...) clauses to find SELECT/INSERT/UPDATE/DELETE.
+ */
+function findStatementAfterCTE(upperQuery: string): string | null {
+  let depth = 0;
+  let i = 4; // Skip "WITH"
+
+  while (i < upperQuery.length) {
+    const char = upperQuery[i];
+
+    if (char === "(") {
+      depth++;
+    } else if (char === ")") {
+      depth--;
+    } else if (depth === 0) {
+      // Check for statement keywords at this position
+      const remaining = upperQuery.slice(i).trimStart();
+      if (remaining.startsWith("SELECT")) {return "SELECT";}
+      if (remaining.startsWith("INSERT")) {return "INSERT";}
+      if (remaining.startsWith("UPDATE")) {return "UPDATE";}
+      if (remaining.startsWith("DELETE")) {return "DELETE";}
+    }
+    i++;
+  }
+
+  return null;
 }
 
 /**


### PR DESCRIPTION
## Summary
Fixes CTE (Common Table Expression) queries being misclassified as mutations.

`WITH ... SELECT` queries were being sent to `execSQL` which fails for queries that return rows. Added `findStatementAfterCTE` function to both Kotlin and TypeScript implementations that parses past CTE definitions (WITH ... AS (...)) to find the actual statement type (SELECT/INSERT/UPDATE/DELETE).

## Changes
- **SQLiteDatabaseDriver.kt**: Added `isReadQuery` and `findStatementAfterCTE` methods
- **databaseTools.ts**: Updated `isMutationQuery` and added `findStatementAfterCTE`

## Test plan
- [x] All 1620 tests pass
- [x] Android SDK compiles

Closes #1019

🤖 Generated with [Claude Code](https://claude.com/claude-code)