### PR TITLE
fix: improve SQL query parsing for database inspection

### DIFF
--- a/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/database/SQLiteDatabaseDriver.kt
+++ b/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/database/SQLiteDatabaseDriver.kt
@@ -187,9 +187,21 @@ class SQLiteDatabaseDriver(private val context: Context) : DatabaseDriver {
   }
 
   /**
+   * Check if text starts with a keyword followed by a word boundary.
+   * Prevents matching CTE names like "select_cte" as statement keywords.
+   */
+  private fun startsWithKeyword(text: String, keyword: String): Boolean {
+    if (!text.startsWith(keyword)) return false
+    val nextChar = text.getOrNull(keyword.length)
+    // Word boundary: next char is null (end of string) or not a word character
+    return nextChar == null || (!nextChar.isLetterOrDigit() && nextChar != '_')
+  }
+
+  /**
    * Find the actual statement type after CTE definitions.
    *
    * Parses past WITH ... AS (...) clauses to find SELECT/INSERT/UPDATE/DELETE.
+   * Uses word boundary checks to avoid matching CTE names like "update_cte".
    */
   private fun findStatementAfterCTE(upperQuery: String): String? {
     var depth = 0
@@ -202,13 +214,13 @@ class SQLiteDatabaseDriver(private val context: Context) : DatabaseDriver {
         char == '(' -> depth++
         char == ')' -> depth--
         depth == 0 -> {
-          // Check for statement keywords at this position
+          // Check for statement keywords at this position (with word boundary)
           val remaining = upperQuery.substring(i).trimStart()
           when {
-            remaining.startsWith("SELECT") -> return "SELECT"
-            remaining.startsWith("INSERT") -> return "INSERT"
-            remaining.startsWith("UPDATE") -> return "UPDATE"
-            remaining.startsWith("DELETE") -> return "DELETE"
+            startsWithKeyword(remaining, "SELECT") -> return "SELECT"
+            startsWithKeyword(remaining, "INSERT") -> return "INSERT"
+            startsWithKeyword(remaining, "UPDATE") -> return "UPDATE"
+            startsWithKeyword(remaining, "DELETE") -> return "DELETE"
           }
         }
       }

--- a/src/server/databaseTools.ts
+++ b/src/server/databaseTools.ts
@@ -90,9 +90,21 @@ function isMutationQuery(query: string): boolean {
 }
 
 /**
+ * Check if text starts with a keyword followed by a word boundary.
+ * Prevents matching CTE names like "select_cte" as statement keywords.
+ */
+function startsWithKeyword(text: string, keyword: string): boolean {
+  if (!text.startsWith(keyword)) {return false;}
+  const nextChar = text[keyword.length];
+  // Word boundary: next char is undefined (end of string) or not a word character
+  return nextChar === undefined || !/\w/.test(nextChar);
+}
+
+/**
  * Find the actual statement type after CTE definitions.
  *
  * Parses past WITH ... AS (...) clauses to find SELECT/INSERT/UPDATE/DELETE.
+ * Uses word boundary checks to avoid matching CTE names like "update_cte".
  */
 function findStatementAfterCTE(upperQuery: string): string | null {
   let depth = 0;
@@ -106,12 +118,12 @@ function findStatementAfterCTE(upperQuery: string): string | null {
     } else if (char === ")") {
       depth--;
     } else if (depth === 0) {
-      // Check for statement keywords at this position
+      // Check for statement keywords at this position (with word boundary)
       const remaining = upperQuery.slice(i).trimStart();
-      if (remaining.startsWith("SELECT")) {return "SELECT";}
-      if (remaining.startsWith("INSERT")) {return "INSERT";}
-      if (remaining.startsWith("UPDATE")) {return "UPDATE";}
-      if (remaining.startsWith("DELETE")) {return "DELETE";}
+      if (startsWithKeyword(remaining, "SELECT")) {return "SELECT";}
+      if (startsWithKeyword(remaining, "INSERT")) {return "INSERT";}
+      if (startsWithKeyword(remaining, "UPDATE")) {return "UPDATE";}
+      if (startsWithKeyword(remaining, "DELETE")) {return "DELETE";}
     }
     i++;
   }


### PR DESCRIPTION
## Summary
Three fixes for SQL query parsing in database inspection:

1. **CTE queries**: `WITH ... SELECT` queries were being misclassified as mutations. Added `findStatementAfterCTE` to parse past CTE definitions and find the actual statement type.

2. **Conflict clauses**: `INSERT OR REPLACE INTO` and `UPDATE OR IGNORE` were not extracting table names correctly for resource notifications. Updated regex patterns to handle optional conflict clauses (ABORT, FAIL, IGNORE, REPLACE, ROLLBACK).

3. **Word boundaries**: CTE names like `select_cte` or `update_cte` were being mistakenly matched as statement keywords. Added `startsWithKeyword` helper that verifies the character after the keyword is not a word character.

## Changes
- **SQLiteDatabaseDriver.kt**: Added `isReadQuery`, `findStatementAfterCTE`, and `startsWithKeyword` methods
- **databaseTools.ts**: Updated `isMutationQuery` with CTE handling, fixed `extractAffectedTables` for conflict clauses, added word boundary checks

## Test plan
- [x] All 1620 tests pass
- [x] Android SDK compiles

Closes #1019

🤖 Generated with [Claude Code](https://claude.com/claude-code)