### PR TITLE
feat: add automatic video recording during plan execution

### DIFF
--- a/src/daemon/types.ts
+++ b/src/daemon/types.ts
@@ -90,6 +90,8 @@ export interface DaemonOptions {
   videoFormat?: string;
   /** Default video archive size limit in MB */
   videoMaxArchiveSizeMb?: number;
+  /** Enable automatic video recording during plan execution */
+  testVideoRecording?: boolean;
 }
 
 /**

--- a/src/features/featureFlags/FeatureFlagDefinitions.ts
+++ b/src/features/featureFlags/FeatureFlagDefinitions.ts
@@ -8,7 +8,8 @@ export type FeatureFlagKey =
   | "predictive-ui"
   | "force-accessibility-mode"
   | "accessibility-auto-detect"
-  | "raw-element-search";
+  | "raw-element-search"
+  | "test-video-recording";
 
 export type FeatureFlagConfig = Record<string, unknown>;
 
@@ -93,5 +94,11 @@ export const FEATURE_FLAG_DEFINITIONS: FeatureFlagDefinition[] = [
     label: "Accessibility auto-detect",
     description: "Automatically detect and adapt to TalkBack/VoiceOver when enabled.",
     defaultValue: true,
+  },
+  {
+    key: "test-video-recording",
+    label: "Test video recording",
+    description: "Automatically record video during plan execution for test debugging.",
+    defaultValue: false,
   },
 ];

--- a/src/index.ts
+++ b/src/index.ts
@@ -99,6 +99,7 @@ function parseArgs(): {
   daemonArgs: string[];
   skipAccessibilityDownload: boolean;
   directMode: boolean;
+  testVideoRecording: boolean;
   } {
   const args = process.argv.slice(2);
 
@@ -151,6 +152,9 @@ function parseArgs(): {
   const predictiveUi = args.includes("--predictive") || args.includes("--predictive-ui");
   const rawElementSearch = args.includes("--raw-element-search");
   const skipAccessibilityDownload = args.includes("--skip-accessibility-download");
+  const testVideoRecording =
+    args.includes("--test-video-recording") ||
+    process.env.AUTO_MOBILE_TEST_VIDEO_RECORDING === "1";
   let planExecutionLockScope: PlanExecutionLockScope = "session";
   const videoRecordingDefaults: VideoRecordingConfigInput = {};
 
@@ -352,6 +356,7 @@ function parseArgs(): {
     daemonArgs,
     skipAccessibilityDownload,
     directMode,
+    testVideoRecording,
   };
 }
 
@@ -1105,11 +1110,13 @@ async function main() {
       daemonArgs,
       skipAccessibilityDownload,
       directMode,
+      testVideoRecording,
     } = parseArgs();
 
     serverConfig.setPlanExecutionLockScope(planExecutionLockScope);
     serverConfig.setVideoRecordingDefaults(videoRecordingDefaults);
     serverConfig.setSkipAccessibilityDownload(skipAccessibilityDownload);
+    serverConfig.setTestVideoRecordingEnabled(testVideoRecording);
     if (skipAccessibilityDownload) {
       logger.info("Accessibility APK download disabled (--skip-accessibility-download)");
     } else {
@@ -1146,6 +1153,7 @@ async function main() {
       ["accessibility-audit", a11yAuditMode, "--accessibility-audit", accessibilityConfig],
       ["predictive-ui", predictiveUi, "--predictive/--predictive-ui"],
       ["raw-element-search", rawElementSearch, "--raw-element-search"],
+      ["test-video-recording", testVideoRecording, "--test-video-recording"],
     ];
 
     for (const [key, enabled, flagLabel, config] of cliOverrides) {
@@ -1200,6 +1208,7 @@ async function main() {
         videoFps: videoRecordingDefaults.fps,
         videoFormat: videoRecordingDefaults.format,
         videoMaxArchiveSizeMb: videoRecordingDefaults.maxArchiveSizeMb,
+        testVideoRecording,
       };
 
       if (useProxyMode) {

--- a/src/server/planTools.ts
+++ b/src/server/planTools.ts
@@ -12,6 +12,8 @@ import { PlanSchemaValidator } from "../utils/plan/PlanSchemaValidator";
 import { DaemonState } from "../daemon/daemonState";
 import { normalizePlanDevices } from "../utils/plan/PlanDevices";
 import { ExecutePlanStepDebugInfo } from "../models/ExecutePlanResult";
+import { serverConfig } from "../utils/ServerConfig";
+import { startVideoRecording, stopVideoRecording } from "./videoRecordingManager";
 
 const testMetadataSchema = z.object({
   testClass: z.string(),
@@ -350,11 +352,45 @@ const executePlanTool = async (device: BootedDevice, params: {
       throw new ActionableError("Device label requires a devices list to be provided.");
     }
 
-    // Execute the plan with device context
-    logger.info(`[PERF +${Date.now() - perfStart}ms] Starting plan execution on device ${device.deviceId} (${device.platform})`);
-    const result = await executePlan(plan, startStep, params.platform, device.deviceId, params.sessionUuid, signal, params.abortStrategy);
-    const execDuration = Date.now() - perfStart;
-    logger.info(`[PERF +${execDuration}ms] Plan execution completed: ${result.success ? "SUCCESS" : "FAILED"} (${result.executedSteps}/${result.totalSteps} steps)`);
+    // Start video recording if enabled
+    const testVideoRecordingEnabled = serverConfig.isTestVideoRecordingEnabled();
+    let videoRecordingId: string | undefined;
+    if (testVideoRecordingEnabled) {
+      try {
+        logger.info(`[PERF +${Date.now() - perfStart}ms] Starting automatic video recording for test`);
+        const recording = await startVideoRecording({
+          device,
+          outputName: `test-${plan.name}-${Date.now()}`,
+          maxDurationSeconds: 300, // 5 minutes max
+        });
+        videoRecordingId = recording.recordingId;
+        logger.info(`[PERF +${Date.now() - perfStart}ms] Video recording started: ${videoRecordingId}`);
+      } catch (videoError) {
+        logger.warn(`[PERF +${Date.now() - perfStart}ms] Failed to start automatic video recording: ${videoError}`);
+        // Continue with plan execution even if video recording fails to start
+      }
+    }
+
+    // Execute the plan with device context, ensuring video recording is stopped in finally block
+    let result;
+    try {
+      logger.info(`[PERF +${Date.now() - perfStart}ms] Starting plan execution on device ${device.deviceId} (${device.platform})`);
+      result = await executePlan(plan, startStep, params.platform, device.deviceId, params.sessionUuid, signal, params.abortStrategy);
+      const execDuration = Date.now() - perfStart;
+      logger.info(`[PERF +${execDuration}ms] Plan execution completed: ${result.success ? "SUCCESS" : "FAILED"} (${result.executedSteps}/${result.totalSteps} steps)`);
+    } finally {
+      // Stop video recording regardless of plan execution outcome
+      if (videoRecordingId) {
+        try {
+          logger.info(`[PERF +${Date.now() - perfStart}ms] Stopping automatic video recording: ${videoRecordingId}`);
+          await stopVideoRecording(videoRecordingId);
+          logger.info(`[PERF +${Date.now() - perfStart}ms] Video recording stopped successfully`);
+        } catch (videoError) {
+          logger.warn(`[PERF +${Date.now() - perfStart}ms] Failed to stop automatic video recording: ${videoError}`);
+          // Don't throw - let the original result/error propagate
+        }
+      }
+    }
 
     // Capture step data and error message for recording
     const steps = convertDebugStepsToRecords(result.debug?.steps);

--- a/src/utils/ServerConfig.ts
+++ b/src/utils/ServerConfig.ts
@@ -26,6 +26,7 @@ class ServerConfig {
   private _deviceSnapshotDefaults: DeviceSnapshotConfigInput = {};
   private _appearanceDefaults: AppearanceConfigInput = {};
   private _skipAccessibilityDownload: boolean = false;
+  private _testVideoRecordingEnabled: boolean = false;
 
   private constructor() {}
 
@@ -126,6 +127,14 @@ class ServerConfig {
 
   isSkipAccessibilityDownloadEnabled(): boolean {
     return this._skipAccessibilityDownload;
+  }
+
+  setTestVideoRecordingEnabled(enabled: boolean): void {
+    this._testVideoRecordingEnabled = enabled;
+  }
+
+  isTestVideoRecordingEnabled(): boolean {
+    return this._testVideoRecordingEnabled;
   }
 }
 


### PR DESCRIPTION
## Summary
- Adds `--test-video-recording` CLI flag and `AUTO_MOBILE_TEST_VIDEO_RECORDING` environment variable
- Automatically starts video recording at the beginning of plan execution when enabled
- Stops video recording at the end regardless of success/failure using try/finally pattern
- Errors during plan execution are propagated exactly as before

## Changes
- Added `test-video-recording` feature flag to `FeatureFlagDefinitions.ts`
- Added `testVideoRecording` setting to `ServerConfig.ts`
- Added `testVideoRecording` option to `DaemonOptions` type
- Added CLI/env var parsing in `index.ts`
- Wrapped plan execution in `planTools.ts` with video recording start/stop

## Test Plan
- [x] Build passes
- [x] Lint passes
- [x] All 1667 tests pass

🤖 Generated with [Claude Code](https://claude.ai/code)