### PR TITLE
fix: pressButton awaits fresh view hierarchy before returning observation

### DIFF
--- a/src/features/action/PressButton.ts
+++ b/src/features/action/PressButton.ts
@@ -45,7 +45,7 @@ export class PressButton extends BaseVisualChange {
         }
       },
       {
-        changeExpected: false,
+        changeExpected: true,
         timeoutMs: 2000, // Reduce timeout for faster execution
         progress,
         perf


### PR DESCRIPTION
## Summary
- Set `changeExpected` to `true` in `PressButton.execute()` so the retry mechanism properly waits for UI changes after button presses
- This prevents stale observation data from being returned (e.g., keyboard still visible after pressing back)

## Test Plan
- [x] All 245 action tests pass
- [x] Lint passes

Closes #1051

🤖 Generated with [Claude Code](https://claude.com/claude-code)