### PR TITLE
fix: make pressButton changeExpected conditional on button type

### DIFF
--- a/src/features/action/PressButton.ts
+++ b/src/features/action/PressButton.ts
@@ -10,12 +10,22 @@ export class PressButton extends BaseVisualChange {
     this.device = device;
   }
 
+  // Buttons that typically cause UI/navigation changes (dismiss keyboard, go home, lock screen, etc.)
+  // These should wait for hierarchy changes to ensure fresh observation data
+  private static readonly NAVIGATION_BUTTONS = new Set(["back", "home", "recent", "power"]);
+
   async execute(
     button: string,
     progress?: ProgressCallback
   ): Promise<PressButtonResult> {
     const perf = createGlobalPerformanceTracker();
     perf.serial("pressButton");
+
+    // Navigation buttons (back, home, recent, power) typically cause UI changes like
+    // dismissing keyboard, navigating screens, or showing lock screen. We set
+    // changeExpected=true so the observation waits for the hierarchy to actually change.
+    // Hardware buttons (volume, menu) don't change the hierarchy.
+    const isNavigationButton = PressButton.NAVIGATION_BUTTONS.has(button.toLowerCase());
 
     return this.observedInteraction(
       async () => {
@@ -45,8 +55,8 @@ export class PressButton extends BaseVisualChange {
         }
       },
       {
-        changeExpected: true,
-        timeoutMs: 2000, // Reduce timeout for faster execution
+        changeExpected: isNavigationButton,
+        timeoutMs: 2000,
         progress,
         perf
       }


### PR DESCRIPTION
## Summary
- Navigation buttons (`back`, `home`, `recent`, `power`) set `changeExpected=true` to wait for hierarchy changes
- Hardware buttons (`volume_up`, `volume_down`, `menu`) set `changeExpected=false` since they don't change the view hierarchy

## Context
This is a follow-up to #1067 which addressed #1051 by setting `changeExpected=true` for all buttons. PR feedback correctly pointed out this causes issues for hardware buttons like `volume_up`/`volume_down` that don't emit accessibility hierarchy changes, leading to incorrectly reported failures.

## Test Plan
- [x] All 245 action tests pass
- [x] Lint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)