### PR TITLE
feat: add setUIState MCP tool for declarative form population

### DIFF
--- a/src/features/action/FieldTypeDetector.ts
+++ b/src/features/action/FieldTypeDetector.ts
@@ -1,0 +1,158 @@
+import { Element } from "../../models/Element";
+import { FieldType } from "../../models/SetUIStateResult";
+
+/**
+ * Platform-specific class patterns for field type detection
+ */
+const ANDROID_PATTERNS = {
+  text: [
+    "android.widget.EditText",
+    "android.widget.AutoCompleteTextView",
+    "android.widget.MultiAutoCompleteTextView",
+    "androidx.appcompat.widget.AppCompatEditText",
+    "com.google.android.material.textfield.TextInputEditText"
+  ],
+  toggle: [
+    "android.widget.Switch",
+    "android.widget.ToggleButton",
+    "androidx.appcompat.widget.SwitchCompat",
+    "com.google.android.material.switchmaterial.SwitchMaterial"
+  ],
+  checkbox: [
+    "android.widget.CheckBox",
+    "androidx.appcompat.widget.AppCompatCheckBox",
+    "android.widget.RadioButton",
+    "androidx.appcompat.widget.AppCompatRadioButton"
+  ],
+  dropdown: [
+    "android.widget.Spinner",
+    "androidx.appcompat.widget.AppCompatSpinner",
+    "android.widget.AutoCompleteTextView" // Can act as dropdown
+  ]
+};
+
+const IOS_PATTERNS = {
+  text: [
+    "UITextField",
+    "UITextView",
+    "UISearchBar"
+  ],
+  toggle: [
+    "UISwitch"
+  ],
+  checkbox: [
+    // iOS doesn't have native checkbox, often uses custom views
+  ],
+  dropdown: [
+    "UIPickerView",
+    "UIDatePicker"
+  ]
+};
+
+/**
+ * Detects the field type from element properties
+ */
+export class FieldTypeDetector {
+  /**
+   * Detect the field type for a given element
+   * @param element - The element to analyze
+   * @returns The detected field type
+   */
+  detect(element: Element): FieldType {
+    const className = this.getClassName(element);
+    const isCheckable = this.isCheckable(element);
+    const isFocusable = this.isFocusable(element);
+    const isClickable = this.isClickable(element);
+
+    // Check for toggle first (checkable + switch/toggle class)
+    if (isCheckable && this.matchesTogglePattern(className)) {
+      return "toggle";
+    }
+
+    // Check for checkbox (checkable but not toggle)
+    if (isCheckable) {
+      return "checkbox";
+    }
+
+    // Check for dropdown patterns
+    if (this.matchesDropdownPattern(className)) {
+      return "dropdown";
+    }
+
+    // Check for text input patterns
+    if (this.matchesTextPattern(className)) {
+      return "text";
+    }
+
+    // Fallback: focusable + clickable suggests text input
+    if (isFocusable && isClickable) {
+      return "text";
+    }
+
+    return "unknown";
+  }
+
+  private getClassName(element: Element): string {
+    return String(element["class"] ?? element.className ?? "").toLowerCase();
+  }
+
+  private isCheckable(element: Element): boolean {
+    const checkable = element.checkable;
+    return checkable === true || checkable === "true";
+  }
+
+  private isFocusable(element: Element): boolean {
+    const focusable = element.focusable;
+    return focusable === true || focusable === "true";
+  }
+
+  private isClickable(element: Element): boolean {
+    const clickable = element.clickable;
+    return clickable === true || clickable === "true";
+  }
+
+  private matchesTogglePattern(className: string): boolean {
+    const patterns = [...ANDROID_PATTERNS.toggle, ...IOS_PATTERNS.toggle];
+    return patterns.some(pattern => className.includes(pattern.toLowerCase()));
+  }
+
+  private matchesDropdownPattern(className: string): boolean {
+    const patterns = [...ANDROID_PATTERNS.dropdown, ...IOS_PATTERNS.dropdown];
+    // Exclude AutoCompleteTextView if it doesn't have dropdown indicators
+    return patterns.some(pattern => {
+      const lowerPattern = pattern.toLowerCase();
+      if (lowerPattern.includes("autocomplete")) {
+        // Only match AutoCompleteTextView if it looks like a spinner/dropdown
+        return className.includes("spinner") || className.includes("dropdown") || className.includes("picker");
+      }
+      return className.includes(lowerPattern);
+    });
+  }
+
+  private matchesTextPattern(className: string): boolean {
+    const patterns = [...ANDROID_PATTERNS.text, ...IOS_PATTERNS.text];
+    return patterns.some(pattern => className.includes(pattern.toLowerCase()));
+  }
+
+  /**
+   * Check if an element is currently checked/selected
+   * @param element - The element to check
+   * @returns true if the element is checked/selected
+   */
+  isChecked(element: Element): boolean {
+    const checked = element.checked;
+    return checked === true || checked === "true";
+  }
+
+  /**
+   * Get the current text value of an element
+   * @param element - The element to get text from
+   * @returns The text value or empty string
+   */
+  getTextValue(element: Element): string {
+    if (typeof element.text === "string") {
+      return element.text;
+    }
+    return "";
+  }
+}

--- a/src/features/action/SetUIState.ts
+++ b/src/features/action/SetUIState.ts
@@ -1,0 +1,596 @@
+import { AdbClient } from "../../utils/android-cmdline-tools/AdbClient";
+import { BaseVisualChange, ProgressCallback } from "./BaseVisualChange";
+import {
+  BootedDevice,
+  Element,
+  ObserveResult,
+  ViewHierarchyResult
+} from "../../models";
+import { SetUIStateOptions, FieldSpec, ElementSelector } from "../../models/SetUIStateOptions";
+import { SetUIStateResult, FieldResult, FieldType } from "../../models/SetUIStateResult";
+import { FieldTypeDetector } from "./FieldTypeDetector";
+import { ElementUtils } from "../utility/ElementUtils";
+import { logger } from "../../utils/logger";
+import { Timer, defaultTimer } from "../../utils/SystemTimer";
+
+/**
+ * Interface for TapOnElement dependency
+ */
+export interface TapOnElementLike {
+  execute(
+    options: { text?: string; elementId?: string; action: string; container?: { text?: string; elementId?: string } },
+    progress?: ProgressCallback,
+    signal?: AbortSignal
+  ): Promise<{ success: boolean; element?: Element; observation?: ObserveResult; error?: string }>;
+}
+
+/**
+ * Interface for InputText dependency
+ */
+export interface InputTextLike {
+  execute(text: string, imeAction?: string): Promise<{ success: boolean; text: string; observation?: ObserveResult; error?: string }>;
+}
+
+/**
+ * Interface for ClearText dependency
+ */
+export interface ClearTextLike {
+  execute(progress?: ProgressCallback): Promise<{ success: boolean; observation?: ObserveResult; error?: string }>;
+}
+
+/**
+ * Interface for SwipeOn dependency
+ */
+export interface SwipeOnLike {
+  execute(
+    options: { direction: string; lookFor?: { text?: string; elementId?: string }; scrollToFind?: boolean },
+    progress?: ProgressCallback
+  ): Promise<{ success: boolean; found?: boolean; element?: Element; observation?: ObserveResult; error?: string }>;
+}
+
+/**
+ * Interface for ObserveScreen dependency
+ */
+export interface ObserveScreenLike {
+  execute(
+    queryOptions?: any,
+    perf?: any,
+    skipWaitForFresh?: boolean,
+    minTimestamp?: number,
+    signal?: AbortSignal
+  ): Promise<ObserveResult>;
+}
+
+/**
+ * Dependencies that can be injected for testing
+ */
+export interface SetUIStateDependencies {
+  tapOnElement?: TapOnElementLike;
+  inputText?: InputTextLike;
+  clearText?: ClearTextLike;
+  swipeOn?: SwipeOnLike;
+  observeScreen?: ObserveScreenLike;
+  fieldTypeDetector?: FieldTypeDetector;
+  timer?: Timer;
+}
+
+const DEFAULT_MAX_RETRIES = 3;
+const DEFAULT_VERIFY_AFTER = true;
+const DEFAULT_SCROLL_TO_FIND = true;
+const DEFAULT_SCROLL_DIRECTION = "down";
+
+/**
+ * SetUIState - Declarative form field population tool
+ *
+ * Populates form fields by specifying desired end-state rather than procedural steps.
+ * Orchestrates existing tools (TapOnElement, InputText, ClearText, SwipeOn, ObserveScreen)
+ * with automatic retry and verification.
+ */
+export class SetUIState extends BaseVisualChange {
+  private fieldTypeDetector: FieldTypeDetector;
+  private elementUtils: ElementUtils;
+  private dependencies: SetUIStateDependencies;
+
+  constructor(
+    device: BootedDevice,
+    adb: AdbClient | null = null,
+    dependencies: SetUIStateDependencies = {}
+  ) {
+    super(device, adb, dependencies.timer ?? defaultTimer);
+    this.fieldTypeDetector = dependencies.fieldTypeDetector ?? new FieldTypeDetector();
+    this.elementUtils = new ElementUtils();
+    this.dependencies = dependencies;
+  }
+
+  /**
+   * Execute the setUIState operation
+   * @param options - Configuration options
+   * @param progress - Optional progress callback
+   * @param signal - Optional abort signal
+   * @returns Result of the operation
+   */
+  async execute(
+    options: SetUIStateOptions,
+    progress?: ProgressCallback,
+    signal?: AbortSignal
+  ): Promise<SetUIStateResult> {
+    const maxRetries = options.maxRetries ?? DEFAULT_MAX_RETRIES;
+    const verifyAfter = options.verifyAfter ?? DEFAULT_VERIFY_AFTER;
+    const scrollToFind = options.scrollToFind ?? DEFAULT_SCROLL_TO_FIND;
+    const scrollDirection = options.scrollDirection ?? DEFAULT_SCROLL_DIRECTION;
+
+    const fieldResults: FieldResult[] = [];
+    let totalAttempts = 0;
+    let lastObservation: ObserveResult | undefined;
+
+    // Get initial observation
+    lastObservation = await this.getObserveScreen().execute(undefined, undefined, false, 0, signal);
+
+    for (const fieldSpec of options.fields) {
+      const result = await this.processField(
+        fieldSpec,
+        {
+          maxRetries,
+          verifyAfter,
+          scrollToFind,
+          scrollDirection,
+          viewHierarchy: lastObservation?.viewHierarchy
+        },
+        progress,
+        signal
+      );
+
+      fieldResults.push(result);
+      totalAttempts += result.attempts;
+
+      // Update last observation if we got one
+      if (result.success) {
+        const freshObs = await this.getObserveScreen().execute(undefined, undefined, false, 0, signal);
+        if (freshObs) {
+          lastObservation = freshObs;
+        }
+      }
+
+      // Fail fast: stop on first field failure after retries
+      if (!result.success) {
+        logger.warn(`[SetUIState] Field failed, stopping: ${this.describeSelector(fieldSpec.selector)}`);
+        return {
+          success: false,
+          fields: fieldResults,
+          totalAttempts,
+          observation: lastObservation,
+          error: result.error ?? `Failed to set field: ${this.describeSelector(fieldSpec.selector)}`
+        };
+      }
+    }
+
+    return {
+      success: true,
+      fields: fieldResults,
+      totalAttempts,
+      observation: lastObservation
+    };
+  }
+
+  /**
+   * Process a single field
+   */
+  private async processField(
+    fieldSpec: FieldSpec,
+    context: {
+      maxRetries: number;
+      verifyAfter: boolean;
+      scrollToFind: boolean;
+      scrollDirection: "up" | "down";
+      viewHierarchy?: ViewHierarchyResult;
+    },
+    progress?: ProgressCallback,
+    signal?: AbortSignal
+  ): Promise<FieldResult> {
+    let attempts = 0;
+    let lastError: string | undefined;
+    let fieldType: FieldType | undefined;
+
+    while (attempts < context.maxRetries) {
+      attempts++;
+
+      try {
+        // Find the element
+        let element = this.findElement(fieldSpec.selector, context.viewHierarchy);
+
+        // If not found and scroll enabled, try scrolling
+        if (!element && context.scrollToFind) {
+          const scrollResult = await this.scrollToFindElement(
+            fieldSpec.selector,
+            context.scrollDirection,
+            progress
+          );
+          if (scrollResult.found && scrollResult.element) {
+            element = scrollResult.element;
+          } else if (!scrollResult.found) {
+            // Try reverse direction
+            const reverseDirection = context.scrollDirection === "down" ? "up" : "down";
+            const reverseResult = await this.scrollToFindElement(
+              fieldSpec.selector,
+              reverseDirection,
+              progress
+            );
+            if (reverseResult.found && reverseResult.element) {
+              element = reverseResult.element;
+            }
+          }
+        }
+
+        if (!element) {
+          lastError = `Element not found: ${this.describeSelector(fieldSpec.selector)}`;
+          continue;
+        }
+
+        // Detect field type
+        fieldType = this.fieldTypeDetector.detect(element);
+        logger.info(`[SetUIState] Field type detected: ${fieldType} for ${this.describeSelector(fieldSpec.selector)}`);
+
+        // Check if field already has correct value
+        const alreadyCorrect = this.isFieldAlreadyCorrect(element, fieldSpec, fieldType);
+        if (alreadyCorrect) {
+          logger.info(`[SetUIState] Field already has correct value, skipping`);
+          return {
+            selector: fieldSpec.selector,
+            success: true,
+            attempts,
+            verified: true,
+            fieldType,
+            skipped: true
+          };
+        }
+
+        // Apply the value based on field type
+        const applyResult = await this.applyFieldValue(
+          element,
+          fieldSpec,
+          fieldType,
+          progress,
+          signal
+        );
+
+        if (!applyResult.success) {
+          lastError = applyResult.error;
+          continue;
+        }
+
+        // Verify if requested (and not sensitive)
+        let verified: boolean | undefined;
+        if (context.verifyAfter && !fieldSpec.sensitive) {
+          verified = await this.verifyFieldValue(fieldSpec, fieldType, signal);
+          if (!verified) {
+            lastError = `Verification failed for ${this.describeSelector(fieldSpec.selector)}`;
+            continue;
+          }
+        }
+
+        return {
+          selector: fieldSpec.selector,
+          success: true,
+          attempts,
+          verified,
+          fieldType
+        };
+      } catch (error) {
+        lastError = error instanceof Error ? error.message : String(error);
+        logger.warn(`[SetUIState] Attempt ${attempts} failed: ${lastError}`);
+      }
+    }
+
+    return {
+      selector: fieldSpec.selector,
+      success: false,
+      attempts,
+      error: lastError,
+      fieldType
+    };
+  }
+
+  /**
+   * Find element in view hierarchy
+   */
+  private findElement(selector: ElementSelector, viewHierarchy?: ViewHierarchyResult): Element | null {
+    if (!viewHierarchy) {
+      return null;
+    }
+
+    if (selector.text) {
+      return this.elementUtils.findElementByText(viewHierarchy, selector.text, undefined, true, false);
+    }
+
+    if (selector.elementId) {
+      return this.elementUtils.findElementByResourceId(viewHierarchy, selector.elementId);
+    }
+
+    return null;
+  }
+
+  /**
+   * Scroll to find an element
+   */
+  private async scrollToFindElement(
+    selector: ElementSelector,
+    direction: "up" | "down",
+    progress?: ProgressCallback
+  ): Promise<{ found: boolean; element?: Element }> {
+    const swipeOn = this.getSwipeOn();
+    const lookFor = selector.text
+      ? { text: selector.text }
+      : { elementId: selector.elementId };
+
+    const result = await swipeOn.execute(
+      { direction, lookFor },
+      progress
+    );
+
+    return {
+      found: result.found ?? false,
+      element: result.element
+    };
+  }
+
+  /**
+   * Check if field already has the correct value
+   */
+  private isFieldAlreadyCorrect(element: Element, fieldSpec: FieldSpec, fieldType: FieldType): boolean {
+    switch (fieldType) {
+      case "text":
+        if (fieldSpec.value !== undefined) {
+          const currentValue = this.fieldTypeDetector.getTextValue(element);
+          return currentValue === fieldSpec.value;
+        }
+        return false;
+
+      case "checkbox":
+      case "toggle":
+        if (fieldSpec.selected !== undefined) {
+          const isChecked = this.fieldTypeDetector.isChecked(element);
+          return isChecked === fieldSpec.selected;
+        }
+        return false;
+
+      case "dropdown":
+        if (fieldSpec.value !== undefined) {
+          const currentValue = this.fieldTypeDetector.getTextValue(element);
+          return currentValue === fieldSpec.value;
+        }
+        return false;
+
+      default:
+        return false;
+    }
+  }
+
+  /**
+   * Apply value to field based on type
+   */
+  private async applyFieldValue(
+    element: Element,
+    fieldSpec: FieldSpec,
+    fieldType: FieldType,
+    progress?: ProgressCallback,
+    signal?: AbortSignal
+  ): Promise<{ success: boolean; error?: string }> {
+    const tapOnElement = this.getTapOnElement();
+    const inputText = this.getInputText();
+    const clearText = this.getClearText();
+
+    try {
+      switch (fieldType) {
+        case "text": {
+          if (fieldSpec.value === undefined) {
+            return { success: false, error: "value is required for text fields" };
+          }
+
+          // Tap to focus
+          const tapResult = await tapOnElement.execute(
+            this.buildTapOptions(fieldSpec.selector, "tap"),
+            progress,
+            signal
+          );
+          if (!tapResult.success) {
+            return { success: false, error: `Failed to tap on field: ${tapResult.error}` };
+          }
+
+          // Clear existing text
+          const clearResult = await clearText.execute(progress);
+          if (!clearResult.success) {
+            return { success: false, error: `Failed to clear text: ${clearResult.error}` };
+          }
+
+          // Input new text
+          const inputResult = await inputText.execute(fieldSpec.value);
+          if (!inputResult.success) {
+            return { success: false, error: `Failed to input text: ${inputResult.error}` };
+          }
+
+          return { success: true };
+        }
+
+        case "checkbox":
+        case "toggle": {
+          if (fieldSpec.selected === undefined) {
+            return { success: false, error: "selected is required for checkbox/toggle fields" };
+          }
+
+          // Check current state
+          const isChecked = this.fieldTypeDetector.isChecked(element);
+
+          // Only tap if state needs to change
+          if (isChecked !== fieldSpec.selected) {
+            const tapResult = await tapOnElement.execute(
+              this.buildTapOptions(fieldSpec.selector, "tap"),
+              progress,
+              signal
+            );
+            if (!tapResult.success) {
+              return { success: false, error: `Failed to tap checkbox/toggle: ${tapResult.error}` };
+            }
+          }
+
+          return { success: true };
+        }
+
+        case "dropdown": {
+          if (fieldSpec.value === undefined) {
+            return { success: false, error: "value is required for dropdown fields" };
+          }
+
+          // Tap to open dropdown
+          const openResult = await tapOnElement.execute(
+            this.buildTapOptions(fieldSpec.selector, "tap"),
+            progress,
+            signal
+          );
+          if (!openResult.success) {
+            return { success: false, error: `Failed to open dropdown: ${openResult.error}` };
+          }
+
+          // Wait a bit for dropdown to open
+          await this.timer.sleep(200);
+
+          // Tap on the desired value
+          const selectResult = await tapOnElement.execute(
+            { text: fieldSpec.value, action: "tap" },
+            progress,
+            signal
+          );
+          if (!selectResult.success) {
+            return { success: false, error: `Failed to select dropdown value: ${selectResult.error}` };
+          }
+
+          return { success: true };
+        }
+
+        default:
+          return { success: false, error: `Unknown field type: ${fieldType}` };
+      }
+    } catch (error) {
+      return {
+        success: false,
+        error: error instanceof Error ? error.message : String(error)
+      };
+    }
+  }
+
+  /**
+   * Verify field value after setting
+   */
+  private async verifyFieldValue(
+    fieldSpec: FieldSpec,
+    fieldType: FieldType,
+    signal?: AbortSignal
+  ): Promise<boolean> {
+    // Get fresh observation
+    const observation = await this.getObserveScreen().execute(undefined, undefined, false, 0, signal);
+    if (!observation?.viewHierarchy) {
+      return false;
+    }
+
+    // Find the element again
+    const element = this.findElement(fieldSpec.selector, observation.viewHierarchy);
+    if (!element) {
+      return false;
+    }
+
+    // Verify based on field type
+    switch (fieldType) {
+      case "text":
+        if (fieldSpec.value !== undefined) {
+          const currentValue = this.fieldTypeDetector.getTextValue(element);
+          return currentValue === fieldSpec.value;
+        }
+        return true;
+
+      case "checkbox":
+      case "toggle":
+        if (fieldSpec.selected !== undefined) {
+          const isChecked = this.fieldTypeDetector.isChecked(element);
+          return isChecked === fieldSpec.selected;
+        }
+        return true;
+
+      case "dropdown":
+        if (fieldSpec.value !== undefined) {
+          const currentValue = this.fieldTypeDetector.getTextValue(element);
+          return currentValue === fieldSpec.value;
+        }
+        return true;
+
+      default:
+        return true;
+    }
+  }
+
+  /**
+   * Build tap options from selector
+   */
+  private buildTapOptions(
+    selector: ElementSelector,
+    action: string
+  ): { text?: string; elementId?: string; action: string } {
+    if (selector.text) {
+      return { text: selector.text, action };
+    }
+    return { elementId: selector.elementId, action };
+  }
+
+  /**
+   * Describe a selector for error messages
+   */
+  private describeSelector(selector: ElementSelector): string {
+    if (selector.text) {
+      return `text="${selector.text}"`;
+    }
+    if (selector.elementId) {
+      return `elementId="${selector.elementId}"`;
+    }
+    return "unknown selector";
+  }
+
+  // Dependency getters with lazy initialization
+
+  private getTapOnElement(): TapOnElementLike {
+    if (this.dependencies.tapOnElement) {
+      return this.dependencies.tapOnElement;
+    }
+    // Lazy import to avoid circular dependencies
+    const { TapOnElement } = require("./TapOnElement");
+    return new TapOnElement(this.device, this.adb);
+  }
+
+  private getInputText(): InputTextLike {
+    if (this.dependencies.inputText) {
+      return this.dependencies.inputText;
+    }
+    const { InputText } = require("./InputText");
+    return new InputText(this.device, this.adb);
+  }
+
+  private getClearText(): ClearTextLike {
+    if (this.dependencies.clearText) {
+      return this.dependencies.clearText;
+    }
+    const { ClearText } = require("./ClearText");
+    return new ClearText(this.device, this.adb);
+  }
+
+  private getSwipeOn(): SwipeOnLike {
+    if (this.dependencies.swipeOn) {
+      return this.dependencies.swipeOn;
+    }
+    const { SwipeOn } = require("./SwipeOn");
+    return new SwipeOn(this.device, this.adb);
+  }
+
+  private getObserveScreen(): ObserveScreenLike {
+    if (this.dependencies.observeScreen) {
+      return this.dependencies.observeScreen;
+    }
+    return this.observeScreen;
+  }
+}

--- a/src/models/SetUIStateOptions.ts
+++ b/src/models/SetUIStateOptions.ts
@@ -1,0 +1,39 @@
+/**
+ * Selector for targeting a UI element
+ */
+export interface ElementSelector {
+  /** Element text or accessibility label */
+  text?: string;
+  /** Element resource ID / accessibility identifier */
+  elementId?: string;
+}
+
+/**
+ * Specification for a single field to set
+ */
+export interface FieldSpec {
+  /** Selector to find the field element */
+  selector: ElementSelector;
+  /** Value to set (for text inputs and dropdowns) */
+  value?: string;
+  /** Target selection state (for checkboxes and toggles) */
+  selected?: boolean;
+  /** Skip verification after setting (for sensitive fields like passwords) */
+  sensitive?: boolean;
+}
+
+/**
+ * Options for the setUIState operation
+ */
+export interface SetUIStateOptions {
+  /** List of fields to set */
+  fields: FieldSpec[];
+  /** Maximum retry attempts per field (default: 3) */
+  maxRetries?: number;
+  /** Verify field values after setting (default: true) */
+  verifyAfter?: boolean;
+  /** Scroll to find fields that aren't visible (default: true) */
+  scrollToFind?: boolean;
+  /** Initial scroll direction when searching (default: "down") */
+  scrollDirection?: "up" | "down";
+}

--- a/src/models/SetUIStateResult.ts
+++ b/src/models/SetUIStateResult.ts
@@ -1,0 +1,43 @@
+import { ObserveResult } from "./ObserveResult";
+import { ElementSelector } from "./SetUIStateOptions";
+
+/**
+ * Detected field type for a UI element
+ */
+export type FieldType = "text" | "checkbox" | "toggle" | "dropdown" | "unknown";
+
+/**
+ * Result for a single field operation
+ */
+export interface FieldResult {
+  /** Selector used to find the field */
+  selector: ElementSelector;
+  /** Whether the field was set successfully */
+  success: boolean;
+  /** Number of attempts made */
+  attempts: number;
+  /** Whether the value was verified after setting */
+  verified?: boolean;
+  /** Error message if the operation failed */
+  error?: string;
+  /** Detected field type */
+  fieldType?: FieldType;
+  /** Whether the field was skipped because it already had the correct value */
+  skipped?: boolean;
+}
+
+/**
+ * Result of the setUIState operation
+ */
+export interface SetUIStateResult {
+  /** Whether all fields were set successfully */
+  success: boolean;
+  /** Results for each field */
+  fields: FieldResult[];
+  /** Total attempts across all fields */
+  totalAttempts: number;
+  /** Final observation after all operations */
+  observation?: ObserveResult;
+  /** Error message if the operation failed */
+  error?: string;
+}

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -91,3 +91,5 @@ export * from "./VisualHighlight";
 export * from "./VideoRecording";
 export * from "./DeviceSnapshot";
 export * from "./Appearance";
+export * from "./SetUIStateOptions";
+export * from "./SetUIStateResult";

--- a/src/server/formTools.ts
+++ b/src/server/formTools.ts
@@ -1,0 +1,148 @@
+import { z } from "zod";
+import { ToolRegistry, ProgressCallback } from "./toolRegistry";
+import { SetUIState } from "../features/action/SetUIState";
+import { BootedDevice } from "../models";
+import { createStructuredToolResponse } from "../utils/toolUtils";
+import { AdbClient } from "../utils/android-cmdline-tools/AdbClient";
+import { addDeviceTargetingToSchema } from "./toolSchemaHelpers";
+import {
+  elementIdTextFieldsSchema,
+  validateElementIdTextSelector
+} from "./elementSelectorSchemas";
+
+/**
+ * Schema for a single field specification
+ */
+const fieldSpecSchema = z.object({
+  selector: elementIdTextFieldsSchema.superRefine((value, ctx) => {
+    validateElementIdTextSelector(value, ctx, "Provide exactly one of elementId or text in selector");
+  }).describe("Selector to find the field element"),
+  value: z.string().optional().describe("Value to set (for text inputs and dropdowns)"),
+  selected: z.boolean().optional().describe("Target selection state (for checkboxes and toggles)"),
+  sensitive: z.boolean().optional().describe("Skip verification for sensitive fields like passwords")
+}).refine(
+  data => data.value !== undefined || data.selected !== undefined,
+  { message: "Provide either value (for text/dropdown) or selected (for checkbox/toggle)" }
+);
+
+/**
+ * Schema for setUIState tool input
+ */
+const setUIStateSchema = z.object({
+  fields: z.array(fieldSpecSchema)
+    .min(1, "At least one field is required")
+    .describe("List of fields to set"),
+  maxRetries: z.number().int().positive().optional()
+    .describe("Maximum retry attempts per field (default: 3)"),
+  verifyAfter: z.boolean().optional()
+    .describe("Verify field values after setting (default: true)"),
+  scrollToFind: z.boolean().optional()
+    .describe("Scroll to find fields that aren't visible (default: true)"),
+  scrollDirection: z.enum(["up", "down"]).optional()
+    .describe("Initial scroll direction when searching (default: down)")
+});
+
+/**
+ * Output schema for field result
+ */
+const fieldResultSchema = z.object({
+  selector: z.object({
+    text: z.string().optional(),
+    elementId: z.string().optional()
+  }),
+  success: z.boolean(),
+  attempts: z.number(),
+  verified: z.boolean().optional(),
+  error: z.string().optional(),
+  fieldType: z.enum(["text", "checkbox", "toggle", "dropdown", "unknown"]).optional(),
+  skipped: z.boolean().optional()
+});
+
+/**
+ * Output schema for setUIState result
+ */
+const setUIStateResultSchema = z.object({
+  success: z.boolean().describe("Whether all fields were set successfully"),
+  fields: z.array(fieldResultSchema).describe("Results for each field"),
+  totalAttempts: z.number().describe("Total attempts across all fields"),
+  error: z.string().optional().describe("Error message if the operation failed")
+});
+
+/**
+ * Register form-related tools with the tool registry
+ */
+export function registerFormTools(): void {
+  // setUIState tool
+  ToolRegistry.registerDeviceAware(
+    "setUIState",
+    `Declaratively set UI form fields to desired values.
+
+Instead of procedural steps (tap, clear, type), specify the desired end-state for each field.
+Automatically handles:
+- Field type detection (text input, checkbox, toggle, dropdown)
+- Clearing existing text before typing
+- Toggling checkboxes only when needed
+- Scrolling to find hidden fields
+- Retry on failure
+- Value verification
+
+Example usage:
+\`\`\`json
+{
+  "fields": [
+    { "selector": { "elementId": "username" }, "value": "john@example.com" },
+    { "selector": { "text": "Password" }, "value": "secret123", "sensitive": true },
+    { "selector": { "elementId": "remember_me" }, "selected": true }
+  ]
+}
+\`\`\``,
+    addDeviceTargetingToSchema(setUIStateSchema),
+    async (
+      device: BootedDevice,
+      args: z.infer<typeof setUIStateSchema>,
+      progress?: ProgressCallback,
+      signal?: AbortSignal
+    ) => {
+      const adb = device.platform === "android" ? new AdbClient(device) : null;
+      const setUIState = new SetUIState(device, adb);
+
+      const result = await setUIState.execute(
+        {
+          fields: args.fields.map(f => ({
+            selector: {
+              text: f.selector.text,
+              elementId: f.selector.elementId
+            },
+            value: f.value,
+            selected: f.selected,
+            sensitive: f.sensitive
+          })),
+          maxRetries: args.maxRetries,
+          verifyAfter: args.verifyAfter,
+          scrollToFind: args.scrollToFind,
+          scrollDirection: args.scrollDirection
+        },
+        progress,
+        signal
+      );
+
+      return createStructuredToolResponse({
+        success: result.success,
+        fields: result.fields.map(f => ({
+          selector: f.selector,
+          success: f.success,
+          attempts: f.attempts,
+          verified: f.verified,
+          error: f.error,
+          fieldType: f.fieldType,
+          skipped: f.skipped
+        })),
+        totalAttempts: result.totalAttempts,
+        error: result.error
+      }, result.observation);
+    },
+    true, // supportsProgress
+    false, // debugOnly
+    { outputSchema: setUIStateResultSchema }
+  );
+}

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -35,6 +35,7 @@ import { registerSnapshotTools } from "./snapshotTools";
 import { registerBiometricTools } from "./biometricTools";
 import { registerHighlightTools } from "./highlightTools";
 import { registerDatabaseTools } from "./databaseTools";
+import { registerFormTools } from "./formTools";
 import { getMcpServerVersion } from "../utils/mcpVersion";
 
 // Import resource registration functions
@@ -143,6 +144,7 @@ export const createMcpServer = (options: McpServerOptions = {}): McpServer => {
   registerBiometricTools();
   registerHighlightTools();
   registerDatabaseTools();
+  registerFormTools();
   registerDebugTools();
   startupBenchmark.endPhase("toolRegistration");
 

--- a/test/fakes/FakeSetUIStateDependencies.ts
+++ b/test/fakes/FakeSetUIStateDependencies.ts
@@ -1,0 +1,357 @@
+import { Element, ObserveResult, ViewHierarchyResult } from "../../src/models";
+import { TapOnElementResult } from "../../src/models/TapOnElementResult";
+import { SendTextResult } from "../../src/models/SendTextResult";
+import { ClearTextResult } from "../../src/models/ClearTextResult";
+import { SwipeOnResult } from "../../src/models/SwipeOnResult";
+import { FieldType } from "../../src/models/SetUIStateResult";
+import { FieldTypeDetector } from "../../src/features/action/FieldTypeDetector";
+
+/**
+ * Interface for TapOnElement dependency
+ */
+export interface TapOnElementLike {
+  execute(
+    options: { text?: string; elementId?: string; action: string },
+    progress?: any,
+    signal?: AbortSignal
+  ): Promise<TapOnElementResult>;
+}
+
+/**
+ * Interface for InputText dependency
+ */
+export interface InputTextLike {
+  execute(text: string, imeAction?: string): Promise<SendTextResult>;
+}
+
+/**
+ * Interface for ClearText dependency
+ */
+export interface ClearTextLike {
+  execute(progress?: any): Promise<ClearTextResult>;
+}
+
+/**
+ * Interface for SwipeOn dependency
+ */
+export interface SwipeOnLike {
+  execute(
+    options: { direction: string; lookFor?: { text?: string; elementId?: string } },
+    progress?: any
+  ): Promise<SwipeOnResult>;
+}
+
+/**
+ * Interface for ObserveScreen dependency
+ */
+export interface ObserveScreenLike {
+  execute(
+    queryOptions?: any,
+    perf?: any,
+    skipWaitForFresh?: boolean,
+    minTimestamp?: number,
+    signal?: AbortSignal
+  ): Promise<ObserveResult>;
+}
+
+/**
+ * Recorded tap call for assertions
+ */
+export interface TapCall {
+  options: { text?: string; elementId?: string; action: string };
+}
+
+/**
+ * Recorded input text call for assertions
+ */
+export interface InputTextCall {
+  text: string;
+  imeAction?: string;
+}
+
+/**
+ * Recorded swipe call for assertions
+ */
+export interface SwipeCall {
+  options: { direction: string; lookFor?: { text?: string; elementId?: string } };
+}
+
+/**
+ * Fake TapOnElement for testing
+ */
+export class FakeTapOnElement implements TapOnElementLike {
+  private calls: TapCall[] = [];
+  private results: Map<string, TapOnElementResult> = new Map();
+  private defaultResult: TapOnElementResult = {
+    success: true,
+    action: "tap",
+    element: { bounds: { left: 0, top: 0, right: 100, bottom: 50 } }
+  };
+
+  async execute(
+    options: { text?: string; elementId?: string; action: string },
+    _progress?: any,
+    _signal?: AbortSignal
+  ): Promise<TapOnElementResult> {
+    this.calls.push({ options });
+    const key = options.text ?? options.elementId ?? "";
+    return this.results.get(key) ?? this.defaultResult;
+  }
+
+  setResult(selector: string, result: TapOnElementResult): void {
+    this.results.set(selector, result);
+  }
+
+  setDefaultResult(result: TapOnElementResult): void {
+    this.defaultResult = result;
+  }
+
+  getCalls(): TapCall[] {
+    return [...this.calls];
+  }
+
+  getCallCount(): number {
+    return this.calls.length;
+  }
+
+  reset(): void {
+    this.calls = [];
+    this.results.clear();
+  }
+}
+
+/**
+ * Fake InputText for testing
+ */
+export class FakeInputText implements InputTextLike {
+  private calls: InputTextCall[] = [];
+  private result: SendTextResult = { success: true, text: "" };
+
+  async execute(text: string, imeAction?: string): Promise<SendTextResult> {
+    this.calls.push({ text, imeAction });
+    return { ...this.result, text };
+  }
+
+  setResult(result: SendTextResult): void {
+    this.result = result;
+  }
+
+  getCalls(): InputTextCall[] {
+    return [...this.calls];
+  }
+
+  getCallCount(): number {
+    return this.calls.length;
+  }
+
+  reset(): void {
+    this.calls = [];
+  }
+}
+
+/**
+ * Fake ClearText for testing
+ */
+export class FakeClearText implements ClearTextLike {
+  private callCount: number = 0;
+  private result: ClearTextResult = { success: true };
+
+  async execute(_progress?: any): Promise<ClearTextResult> {
+    this.callCount++;
+    return this.result;
+  }
+
+  setResult(result: ClearTextResult): void {
+    this.result = result;
+  }
+
+  getCallCount(): number {
+    return this.callCount;
+  }
+
+  reset(): void {
+    this.callCount = 0;
+  }
+}
+
+/**
+ * Fake SwipeOn for testing
+ */
+export class FakeSwipeOn implements SwipeOnLike {
+  private calls: SwipeCall[] = [];
+  private results: Map<string, SwipeOnResult> = new Map();
+  private elementAppearsAfterSwipe: Map<string, Element> = new Map();
+  private swipeCount: number = 0;
+  private defaultResult: SwipeOnResult = {
+    success: true,
+    targetType: "screen",
+    x1: 0,
+    y1: 500,
+    x2: 0,
+    y2: 100,
+    duration: 300
+  };
+
+  async execute(
+    options: { direction: string; lookFor?: { text?: string; elementId?: string } },
+    _progress?: any
+  ): Promise<SwipeOnResult> {
+    this.calls.push({ options });
+    this.swipeCount++;
+
+    // Check if lookFor element should appear after this swipe
+    if (options.lookFor) {
+      const key = options.lookFor.text ?? options.lookFor.elementId ?? "";
+      const element = this.elementAppearsAfterSwipe.get(key);
+      if (element && this.swipeCount >= 1) {
+        return {
+          ...this.defaultResult,
+          found: true,
+          element,
+          scrollIterations: this.swipeCount
+        };
+      }
+    }
+
+    const key = options.lookFor?.text ?? options.lookFor?.elementId ?? "default";
+    return this.results.get(key) ?? this.defaultResult;
+  }
+
+  setResult(selector: string, result: SwipeOnResult): void {
+    this.results.set(selector, result);
+  }
+
+  setDefaultResult(result: SwipeOnResult): void {
+    this.defaultResult = result;
+  }
+
+  /**
+   * Configure an element to appear after scrolling
+   */
+  setElementAppearsAfterSwipe(selector: string, element: Element): void {
+    this.elementAppearsAfterSwipe.set(selector, element);
+  }
+
+  getCalls(): SwipeCall[] {
+    return [...this.calls];
+  }
+
+  getCallCount(): number {
+    return this.calls.length;
+  }
+
+  reset(): void {
+    this.calls = [];
+    this.results.clear();
+    this.elementAppearsAfterSwipe.clear();
+    this.swipeCount = 0;
+  }
+}
+
+/**
+ * Fake ObserveScreen for testing SetUIState
+ */
+export class FakeObserveScreenForSetUIState implements ObserveScreenLike {
+  private result: ObserveResult;
+  private callCount: number = 0;
+  private resultFactory: (() => ObserveResult) | null = null;
+
+  constructor() {
+    this.result = this.createDefaultResult();
+  }
+
+  private createDefaultResult(): ObserveResult {
+    return {
+      updatedAt: Date.now(),
+      screenSize: { width: 1080, height: 1920 },
+      systemInsets: { top: 0, right: 0, bottom: 0, left: 0 }
+    };
+  }
+
+  async execute(
+    _queryOptions?: any,
+    _perf?: any,
+    _skipWaitForFresh?: boolean,
+    _minTimestamp?: number,
+    _signal?: AbortSignal
+  ): Promise<ObserveResult> {
+    this.callCount++;
+    if (this.resultFactory) {
+      return this.resultFactory();
+    }
+    return this.result;
+  }
+
+  setResult(result: ObserveResult): void {
+    this.result = result;
+    this.resultFactory = null;
+  }
+
+  setResultFactory(factory: () => ObserveResult): void {
+    this.resultFactory = factory;
+  }
+
+  setViewHierarchy(hierarchy: ViewHierarchyResult): void {
+    this.result = {
+      ...this.result,
+      viewHierarchy: hierarchy
+    };
+  }
+
+  getCallCount(): number {
+    return this.callCount;
+  }
+
+  reset(): void {
+    this.callCount = 0;
+    this.result = this.createDefaultResult();
+    this.resultFactory = null;
+  }
+}
+
+/**
+ * Fake FieldTypeDetector for testing
+ */
+export class FakeFieldTypeDetector {
+  private typeOverrides: Map<string, FieldType> = new Map();
+  private checkedOverrides: Map<string, boolean> = new Map();
+  private textOverrides: Map<string, string> = new Map();
+  private realDetector: FieldTypeDetector = new FieldTypeDetector();
+
+  detect(element: Element): FieldType {
+    const key = element["resource-id"] ?? element.text ?? "";
+    return this.typeOverrides.get(key) ?? this.realDetector.detect(element);
+  }
+
+  isChecked(element: Element): boolean {
+    const key = element["resource-id"] ?? element.text ?? "";
+    const override = this.checkedOverrides.get(key);
+    if (override !== undefined) {
+      return override;
+    }
+    return this.realDetector.isChecked(element);
+  }
+
+  getTextValue(element: Element): string {
+    const key = element["resource-id"] ?? element.text ?? "";
+    return this.textOverrides.get(key) ?? this.realDetector.getTextValue(element);
+  }
+
+  setFieldType(selector: string, type: FieldType): void {
+    this.typeOverrides.set(selector, type);
+  }
+
+  setChecked(selector: string, checked: boolean): void {
+    this.checkedOverrides.set(selector, checked);
+  }
+
+  setTextValue(selector: string, text: string): void {
+    this.textOverrides.set(selector, text);
+  }
+
+  reset(): void {
+    this.typeOverrides.clear();
+    this.checkedOverrides.clear();
+    this.textOverrides.clear();
+  }
+}

--- a/test/features/action/FieldTypeDetector.test.ts
+++ b/test/features/action/FieldTypeDetector.test.ts
@@ -1,0 +1,231 @@
+import { describe, expect, test } from "bun:test";
+import { FieldTypeDetector } from "../../../src/features/action/FieldTypeDetector";
+import { Element } from "../../../src/models";
+
+describe("FieldTypeDetector", () => {
+  const detector = new FieldTypeDetector();
+
+  const createElement = (overrides: Partial<Element> = {}): Element => ({
+    bounds: { left: 0, top: 0, right: 100, bottom: 50 },
+    ...overrides
+  });
+
+  describe("detect", () => {
+    describe("text field detection", () => {
+      test("detects Android EditText as text", () => {
+        const element = createElement({
+          "class": "android.widget.EditText",
+          "focusable": true,
+          "clickable": true
+        });
+        expect(detector.detect(element)).toBe("text");
+      });
+
+      test("detects Android TextInputEditText as text", () => {
+        const element = createElement({
+          "class": "com.google.android.material.textfield.TextInputEditText",
+          "focusable": true,
+          "clickable": true
+        });
+        expect(detector.detect(element)).toBe("text");
+      });
+
+      test("detects iOS UITextField as text", () => {
+        const element = createElement({
+          "class": "UITextField",
+          "focusable": true,
+          "clickable": true
+        });
+        expect(detector.detect(element)).toBe("text");
+      });
+
+      test("detects iOS UITextView as text", () => {
+        const element = createElement({
+          "class": "UITextView",
+          "focusable": true,
+          "clickable": true
+        });
+        expect(detector.detect(element)).toBe("text");
+      });
+
+      test("detects focusable + clickable as text fallback", () => {
+        const element = createElement({
+          "class": "com.custom.TextInput",
+          "focusable": true,
+          "clickable": true
+        });
+        expect(detector.detect(element)).toBe("text");
+      });
+    });
+
+    describe("checkbox detection", () => {
+      test("detects Android CheckBox as checkbox", () => {
+        const element = createElement({
+          "class": "android.widget.CheckBox",
+          "checkable": true
+        });
+        expect(detector.detect(element)).toBe("checkbox");
+      });
+
+      test("detects AppCompat CheckBox as checkbox", () => {
+        const element = createElement({
+          "class": "androidx.appcompat.widget.AppCompatCheckBox",
+          "checkable": true
+        });
+        expect(detector.detect(element)).toBe("checkbox");
+      });
+
+      test("detects RadioButton as checkbox", () => {
+        const element = createElement({
+          "class": "android.widget.RadioButton",
+          "checkable": true
+        });
+        expect(detector.detect(element)).toBe("checkbox");
+      });
+
+      test("detects checkable without specific class as checkbox", () => {
+        const element = createElement({
+          "class": "com.custom.CheckableView",
+          "checkable": true
+        });
+        expect(detector.detect(element)).toBe("checkbox");
+      });
+
+      test("detects checkable=true as string", () => {
+        const element = createElement({
+          "class": "com.custom.View",
+          "checkable": "true" as any
+        });
+        expect(detector.detect(element)).toBe("checkbox");
+      });
+    });
+
+    describe("toggle detection", () => {
+      test("detects Android Switch as toggle", () => {
+        const element = createElement({
+          "class": "android.widget.Switch",
+          "checkable": true
+        });
+        expect(detector.detect(element)).toBe("toggle");
+      });
+
+      test("detects SwitchCompat as toggle", () => {
+        const element = createElement({
+          "class": "androidx.appcompat.widget.SwitchCompat",
+          "checkable": true
+        });
+        expect(detector.detect(element)).toBe("toggle");
+      });
+
+      test("detects SwitchMaterial as toggle", () => {
+        const element = createElement({
+          "class": "com.google.android.material.switchmaterial.SwitchMaterial",
+          "checkable": true
+        });
+        expect(detector.detect(element)).toBe("toggle");
+      });
+
+      test("detects iOS UISwitch as toggle", () => {
+        const element = createElement({
+          "class": "UISwitch",
+          "checkable": true
+        });
+        expect(detector.detect(element)).toBe("toggle");
+      });
+
+      test("detects ToggleButton as toggle", () => {
+        const element = createElement({
+          "class": "android.widget.ToggleButton",
+          "checkable": true
+        });
+        expect(detector.detect(element)).toBe("toggle");
+      });
+    });
+
+    describe("dropdown detection", () => {
+      test("detects Android Spinner as dropdown", () => {
+        const element = createElement({
+          "class": "android.widget.Spinner"
+        });
+        expect(detector.detect(element)).toBe("dropdown");
+      });
+
+      test("detects AppCompat Spinner as dropdown", () => {
+        const element = createElement({
+          "class": "androidx.appcompat.widget.AppCompatSpinner"
+        });
+        expect(detector.detect(element)).toBe("dropdown");
+      });
+
+      test("detects iOS UIPickerView as dropdown", () => {
+        const element = createElement({
+          "class": "UIPickerView"
+        });
+        expect(detector.detect(element)).toBe("dropdown");
+      });
+
+      test("detects iOS UIDatePicker as dropdown", () => {
+        const element = createElement({
+          "class": "UIDatePicker"
+        });
+        expect(detector.detect(element)).toBe("dropdown");
+      });
+    });
+
+    describe("unknown detection", () => {
+      test("returns unknown for non-interactive element", () => {
+        const element = createElement({
+          "class": "android.widget.TextView"
+        });
+        expect(detector.detect(element)).toBe("unknown");
+      });
+
+      test("returns unknown for clickable-only element", () => {
+        const element = createElement({
+          "class": "android.widget.Button",
+          "clickable": true
+        });
+        expect(detector.detect(element)).toBe("unknown");
+      });
+    });
+  });
+
+  describe("isChecked", () => {
+    test("returns true for checked=true boolean", () => {
+      const element = createElement({ checked: true });
+      expect(detector.isChecked(element)).toBe(true);
+    });
+
+    test("returns true for checked='true' string", () => {
+      const element = createElement({ checked: "true" as any });
+      expect(detector.isChecked(element)).toBe(true);
+    });
+
+    test("returns false for checked=false", () => {
+      const element = createElement({ checked: false });
+      expect(detector.isChecked(element)).toBe(false);
+    });
+
+    test("returns false for undefined checked", () => {
+      const element = createElement({});
+      expect(detector.isChecked(element)).toBe(false);
+    });
+  });
+
+  describe("getTextValue", () => {
+    test("returns text when present", () => {
+      const element = createElement({ text: "Hello World" });
+      expect(detector.getTextValue(element)).toBe("Hello World");
+    });
+
+    test("returns empty string when text is undefined", () => {
+      const element = createElement({});
+      expect(detector.getTextValue(element)).toBe("");
+    });
+
+    test("returns empty string when text is not a string", () => {
+      const element = createElement({ text: 123 as any });
+      expect(detector.getTextValue(element)).toBe("");
+    });
+  });
+});

--- a/test/features/action/SetUIState.test.ts
+++ b/test/features/action/SetUIState.test.ts
@@ -1,0 +1,439 @@
+import { beforeEach, describe, expect, test } from "bun:test";
+import { SetUIState } from "../../../src/features/action/SetUIState";
+import { BootedDevice, Element, ObserveResult, ViewHierarchyResult } from "../../../src/models";
+import { FakeTimer } from "../../fakes/FakeTimer";
+import {
+  FakeTapOnElement,
+  FakeInputText,
+  FakeClearText,
+  FakeSwipeOn,
+  FakeObserveScreenForSetUIState,
+  FakeFieldTypeDetector
+} from "../../fakes/FakeSetUIStateDependencies";
+
+describe("SetUIState", () => {
+  const device: BootedDevice = {
+    name: "test-device",
+    platform: "android",
+    deviceId: "device-1"
+  };
+
+  let fakeTap: FakeTapOnElement;
+  let fakeInput: FakeInputText;
+  let fakeClear: FakeClearText;
+  let fakeSwipe: FakeSwipeOn;
+  let fakeObserve: FakeObserveScreenForSetUIState;
+  let fakeFieldTypeDetector: FakeFieldTypeDetector;
+  let fakeTimer: FakeTimer;
+
+  const createHierarchyWithElement = (element: Partial<Element>): ViewHierarchyResult => ({
+    hierarchy: {
+      node: [{
+        $: {
+          bounds: "[0,0][100,50]",
+          ...element
+        }
+      }]
+    }
+  });
+
+  const createObserveResult = (hierarchy?: ViewHierarchyResult): ObserveResult => ({
+    updatedAt: Date.now(),
+    screenSize: { width: 1080, height: 1920 },
+    systemInsets: { top: 0, right: 0, bottom: 0, left: 0 },
+    viewHierarchy: hierarchy
+  });
+
+  const createSetUIState = () => {
+    return new SetUIState(device, null, {
+      tapOnElement: fakeTap,
+      inputText: fakeInput,
+      clearText: fakeClear,
+      swipeOn: fakeSwipe,
+      observeScreen: fakeObserve,
+      fieldTypeDetector: fakeFieldTypeDetector,
+      timer: fakeTimer
+    });
+  };
+
+  beforeEach(() => {
+    fakeTap = new FakeTapOnElement();
+    fakeInput = new FakeInputText();
+    fakeClear = new FakeClearText();
+    fakeSwipe = new FakeSwipeOn();
+    fakeObserve = new FakeObserveScreenForSetUIState();
+    fakeFieldTypeDetector = new FakeFieldTypeDetector();
+    fakeTimer = new FakeTimer();
+  });
+
+  describe("text field handling", () => {
+    test("sets text field value with tap, clear, and input", async () => {
+      const hierarchy = createHierarchyWithElement({
+        "resource-id": "username",
+        "text": "",
+        "class": "android.widget.EditText"
+      });
+      fakeObserve.setResult(createObserveResult(hierarchy));
+      fakeFieldTypeDetector.setFieldType("username", "text");
+
+      const setUIState = createSetUIState();
+      const result = await setUIState.execute({
+        fields: [{ selector: { elementId: "username" }, value: "john@example.com" }],
+        verifyAfter: false  // Disable verification for this test since fake doesn't update
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.fields).toHaveLength(1);
+      expect(result.fields[0].success).toBe(true);
+      expect(result.fields[0].fieldType).toBe("text");
+
+      // Verify tap was called for focus
+      expect(fakeTap.getCallCount()).toBeGreaterThanOrEqual(1);
+      expect(fakeTap.getCalls()[0].options.action).toBe("tap");
+
+      // Verify clear was called
+      expect(fakeClear.getCallCount()).toBe(1);
+
+      // Verify input was called
+      expect(fakeInput.getCallCount()).toBe(1);
+      expect(fakeInput.getCalls()[0].text).toBe("john@example.com");
+    });
+
+    test("skips text field when already has correct value", async () => {
+      const hierarchy = createHierarchyWithElement({
+        "resource-id": "username",
+        "text": "john@example.com",
+        "class": "android.widget.EditText"
+      });
+      fakeObserve.setResult(createObserveResult(hierarchy));
+      fakeFieldTypeDetector.setFieldType("username", "text");
+      fakeFieldTypeDetector.setTextValue("username", "john@example.com");
+
+      const setUIState = createSetUIState();
+      const result = await setUIState.execute({
+        fields: [{ selector: { elementId: "username" }, value: "john@example.com" }]
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.fields[0].success).toBe(true);
+      expect(result.fields[0].skipped).toBe(true);
+
+      // No tap, clear, or input should be called
+      expect(fakeTap.getCallCount()).toBe(0);
+      expect(fakeClear.getCallCount()).toBe(0);
+      expect(fakeInput.getCallCount()).toBe(0);
+    });
+  });
+
+  describe("checkbox handling", () => {
+    test("taps checkbox when state needs to change", async () => {
+      const hierarchy = createHierarchyWithElement({
+        "resource-id": "remember_me",
+        "class": "android.widget.CheckBox",
+        "checkable": "true" as any,
+        "checked": "false" as any
+      });
+      fakeObserve.setResult(createObserveResult(hierarchy));
+      fakeFieldTypeDetector.setFieldType("remember_me", "checkbox");
+      fakeFieldTypeDetector.setChecked("remember_me", false);
+
+      const setUIState = createSetUIState();
+      const result = await setUIState.execute({
+        fields: [{ selector: { elementId: "remember_me" }, selected: true }],
+        verifyAfter: false
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.fields[0].success).toBe(true);
+      expect(result.fields[0].fieldType).toBe("checkbox");
+
+      // Verify tap was called to toggle
+      expect(fakeTap.getCallCount()).toBe(1);
+    });
+
+    test("skips checkbox when already has correct state", async () => {
+      const hierarchy = createHierarchyWithElement({
+        "resource-id": "remember_me",
+        "class": "android.widget.CheckBox",
+        "checkable": "true" as any,
+        "checked": "true" as any
+      });
+      fakeObserve.setResult(createObserveResult(hierarchy));
+      fakeFieldTypeDetector.setFieldType("remember_me", "checkbox");
+      fakeFieldTypeDetector.setChecked("remember_me", true);
+
+      const setUIState = createSetUIState();
+      const result = await setUIState.execute({
+        fields: [{ selector: { elementId: "remember_me" }, selected: true }]
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.fields[0].success).toBe(true);
+      expect(result.fields[0].skipped).toBe(true);
+
+      // No tap should be called
+      expect(fakeTap.getCallCount()).toBe(0);
+    });
+  });
+
+  describe("toggle handling", () => {
+    test("taps toggle when state needs to change", async () => {
+      const hierarchy = createHierarchyWithElement({
+        "resource-id": "dark_mode",
+        "class": "android.widget.Switch",
+        "checkable": "true" as any,
+        "checked": "true" as any
+      });
+      fakeObserve.setResult(createObserveResult(hierarchy));
+      fakeFieldTypeDetector.setFieldType("dark_mode", "toggle");
+      fakeFieldTypeDetector.setChecked("dark_mode", true);
+
+      const setUIState = createSetUIState();
+      const result = await setUIState.execute({
+        fields: [{ selector: { elementId: "dark_mode" }, selected: false }],
+        verifyAfter: false
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.fields[0].success).toBe(true);
+      expect(result.fields[0].fieldType).toBe("toggle");
+
+      // Verify tap was called to toggle off
+      expect(fakeTap.getCallCount()).toBe(1);
+    });
+  });
+
+  describe("dropdown handling", () => {
+    test("opens dropdown and selects value", async () => {
+      const hierarchy = createHierarchyWithElement({
+        "resource-id": "country",
+        "text": "Select Country",
+        "class": "android.widget.Spinner"
+      });
+      fakeObserve.setResult(createObserveResult(hierarchy));
+      fakeFieldTypeDetector.setFieldType("country", "dropdown");
+      fakeFieldTypeDetector.setTextValue("country", "Select Country");
+
+      const setUIState = createSetUIState();
+      const result = await setUIState.execute({
+        fields: [{ selector: { elementId: "country" }, value: "United States" }],
+        verifyAfter: false
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.fields[0].success).toBe(true);
+      expect(result.fields[0].fieldType).toBe("dropdown");
+
+      // Verify first tap to open dropdown
+      expect(fakeTap.getCallCount()).toBe(2);
+      expect(fakeTap.getCalls()[0].options.elementId).toBe("country");
+      // Second tap selects the value
+      expect(fakeTap.getCalls()[1].options.text).toBe("United States");
+    });
+  });
+
+  describe("scroll to find", () => {
+    test("scrolls to find element when not visible", async () => {
+      // First observation has no element
+      let callCount = 0;
+      fakeObserve.setResultFactory(() => {
+        callCount++;
+        if (callCount === 1) {
+          return createObserveResult({ hierarchy: { node: [] } });
+        }
+        return createObserveResult(createHierarchyWithElement({
+          "resource-id": "hidden_field",
+          "text": "",
+          "class": "android.widget.EditText"
+        }));
+      });
+
+      fakeFieldTypeDetector.setFieldType("hidden_field", "text");
+
+      // Configure swipe to find element
+      fakeSwipe.setElementAppearsAfterSwipe("hidden_field", {
+        "bounds": { left: 0, top: 0, right: 100, bottom: 50 },
+        "resource-id": "hidden_field",
+        "text": "",
+        "class": "android.widget.EditText"
+      });
+
+      const setUIState = createSetUIState();
+      const result = await setUIState.execute({
+        fields: [{ selector: { elementId: "hidden_field" }, value: "found!" }],
+        scrollToFind: true,
+        verifyAfter: false
+      });
+
+      expect(result.success).toBe(true);
+      expect(fakeSwipe.getCallCount()).toBeGreaterThanOrEqual(1);
+    });
+
+    test("respects scrollDirection option", async () => {
+      fakeObserve.setResult(createObserveResult({ hierarchy: { node: [] } }));
+
+      fakeSwipe.setElementAppearsAfterSwipe("field", {
+        "bounds": { left: 0, top: 0, right: 100, bottom: 50 },
+        "resource-id": "field",
+        "class": "android.widget.EditText"
+      });
+
+      const setUIState = createSetUIState();
+      await setUIState.execute({
+        fields: [{ selector: { elementId: "field" }, value: "test" }],
+        scrollToFind: true,
+        scrollDirection: "up",
+        verifyAfter: false
+      });
+
+      // First scroll should be in the specified direction
+      expect(fakeSwipe.getCalls()[0].options.direction).toBe("up");
+    });
+  });
+
+  describe("retry logic", () => {
+    test("retries up to maxRetries on failure", async () => {
+      const hierarchy = createHierarchyWithElement({
+        "resource-id": "field",
+        "text": "",
+        "class": "android.widget.EditText"
+      });
+      fakeObserve.setResult(createObserveResult(hierarchy));
+      fakeFieldTypeDetector.setFieldType("field", "text");
+
+      // Configure tap to fail
+      fakeTap.setDefaultResult({
+        success: false,
+        action: "tap",
+        element: { bounds: { left: 0, top: 0, right: 100, bottom: 50 } },
+        error: "Element not clickable"
+      });
+
+      const setUIState = createSetUIState();
+      const result = await setUIState.execute({
+        fields: [{ selector: { elementId: "field" }, value: "test" }],
+        maxRetries: 3,
+        verifyAfter: false
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.fields[0].attempts).toBe(3);
+      expect(result.fields[0].error).toContain("Failed to tap");
+    });
+  });
+
+  describe("fail fast", () => {
+    test("stops processing fields on first failure", async () => {
+      const hierarchy = createHierarchyWithElement({
+        "resource-id": "field1",
+        "text": "",
+        "class": "android.widget.EditText"
+      });
+      fakeObserve.setResult(createObserveResult(hierarchy));
+      fakeFieldTypeDetector.setFieldType("field1", "text");
+
+      // Configure tap to fail
+      fakeTap.setDefaultResult({
+        success: false,
+        action: "tap",
+        element: { bounds: { left: 0, top: 0, right: 100, bottom: 50 } },
+        error: "Element not clickable"
+      });
+
+      const setUIState = createSetUIState();
+      const result = await setUIState.execute({
+        fields: [
+          { selector: { elementId: "field1" }, value: "test1" },
+          { selector: { elementId: "field2" }, value: "test2" }
+        ],
+        maxRetries: 1,
+        verifyAfter: false
+      });
+
+      expect(result.success).toBe(false);
+      // Only first field should be processed
+      expect(result.fields).toHaveLength(1);
+      expect(result.error).toContain("Failed to tap");
+    });
+  });
+
+  describe("sensitive fields", () => {
+    test("skips verification for sensitive fields", async () => {
+      fakeObserve.setResult(createObserveResult(createHierarchyWithElement({
+        "resource-id": "password",
+        "text": "",
+        "class": "android.widget.EditText"
+      })));
+
+      fakeFieldTypeDetector.setFieldType("password", "text");
+
+      const setUIState = createSetUIState();
+      const result = await setUIState.execute({
+        fields: [{ selector: { elementId: "password" }, value: "secret123", sensitive: true }],
+        verifyAfter: true
+      });
+
+      expect(result.success).toBe(true);
+      // The field should NOT have verified=true because it's sensitive
+      expect(result.fields[0].verified).toBeUndefined();
+    });
+  });
+
+  describe("multiple fields", () => {
+    test("processes multiple fields in order", async () => {
+      const hierarchy: ViewHierarchyResult = {
+        hierarchy: {
+          node: [
+            { $: { "bounds": "[0,0][100,50]", "resource-id": "username", "text": "", "class": "android.widget.EditText" } },
+            { $: { "bounds": "[0,60][100,110]", "resource-id": "password", "text": "", "class": "android.widget.EditText" } },
+            { $: { "bounds": "[0,120][100,170]", "resource-id": "remember", "class": "android.widget.CheckBox", "checkable": "true", "checked": "false" } }
+          ]
+        }
+      };
+      fakeObserve.setResult(createObserveResult(hierarchy));
+      fakeFieldTypeDetector.setFieldType("username", "text");
+      fakeFieldTypeDetector.setFieldType("password", "text");
+      fakeFieldTypeDetector.setFieldType("remember", "checkbox");
+      fakeFieldTypeDetector.setChecked("remember", false);
+
+      const setUIState = createSetUIState();
+      const result = await setUIState.execute({
+        fields: [
+          { selector: { elementId: "username" }, value: "user@test.com" },
+          { selector: { elementId: "password" }, value: "pass123" },
+          { selector: { elementId: "remember" }, selected: true }
+        ],
+        verifyAfter: false
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.fields).toHaveLength(3);
+      expect(result.fields.every(f => f.success)).toBe(true);
+
+      // Verify input texts were in order
+      const inputCalls = fakeInput.getCalls();
+      expect(inputCalls[0].text).toBe("user@test.com");
+      expect(inputCalls[1].text).toBe("pass123");
+    });
+  });
+
+  describe("text selector", () => {
+    test("finds element by text selector", async () => {
+      const hierarchy = createHierarchyWithElement({
+        "text": "Username",
+        "class": "android.widget.EditText"
+      });
+      fakeObserve.setResult(createObserveResult(hierarchy));
+      fakeFieldTypeDetector.setFieldType("Username", "text");
+
+      const setUIState = createSetUIState();
+      const result = await setUIState.execute({
+        fields: [{ selector: { text: "Username" }, value: "john" }],
+        verifyAfter: false
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.fields[0].success).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Add `setUIState` MCP tool for declarative form field population
- Specify desired end-state rather than procedural steps (tap, clear, type)
- Auto-detects field types (text, checkbox, toggle, dropdown) for Android and iOS
- Includes automatic retry, verification, and scroll-to-find capabilities

## Implementation

| New Files | Purpose |
|-----------|---------|
| `src/models/SetUIStateOptions.ts` | Options and field spec interfaces |
| `src/models/SetUIStateResult.ts` | Result interface with per-field status |
| `src/features/action/FieldTypeDetector.ts` | Field type auto-detection logic |
| `src/features/action/SetUIState.ts` | Main feature class orchestrating tools |
| `src/server/formTools.ts` | Tool registration with Zod schemas |
| `test/fakes/FakeSetUIStateDependencies.ts` | Fakes for testing |
| `test/features/action/*.test.ts` | 41 unit tests |

## Test Plan

- [x] Build passes
- [x] Lint passes
- [x] All 41 new tests pass in <200ms
- [x] Existing action tests pass (286 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #986