### PR TITLE
fix: address PR feedback for setUIState iOS verification and retry

### DIFF
--- a/src/features/action/FieldTypeDetector.ts
+++ b/src/features/action/FieldTypeDetector.ts
@@ -146,13 +146,49 @@ export class FieldTypeDetector {
 
   /**
    * Get the current text value of an element
+   * For iOS, the `text` property often contains the accessibility label, not the input value.
+   * iOS text fields may have a `value` property with the actual input value.
    * @param element - The element to get text from
    * @returns The text value or empty string
    */
   getTextValue(element: Element): string {
+    // For iOS elements, prefer the `value` attribute which contains the actual input value
+    // The `text` attribute on iOS often contains the accessibility label
+    if (typeof element.value === "string") {
+      return element.value;
+    }
     if (typeof element.text === "string") {
       return element.text;
     }
     return "";
+  }
+
+  /**
+   * Check if element is an iOS element based on class patterns
+   * @param element - The element to check
+   * @returns true if the element appears to be iOS
+   */
+  isIOSElement(element: Element): boolean {
+    const className = this.getClassName(element);
+    return IOS_PATTERNS.text.some(pattern => className.includes(pattern.toLowerCase())) ||
+           IOS_PATTERNS.toggle.some(pattern => className.includes(pattern.toLowerCase())) ||
+           IOS_PATTERNS.dropdown.some(pattern => className.includes(pattern.toLowerCase()));
+  }
+
+  /**
+   * Check if verification should be skipped for this element/field type combination.
+   * On iOS, text and dropdown verification is unreliable because `text` contains the
+   * accessibility label rather than the actual input value.
+   * @param element - The element to check
+   * @param fieldType - The detected field type
+   * @returns true if verification should be skipped
+   */
+  shouldSkipVerification(element: Element, fieldType: FieldType): boolean {
+    // On iOS, text verification is unreliable unless `value` attribute is available
+    if (this.isIOSElement(element) && (fieldType === "text" || fieldType === "dropdown")) {
+      // Only skip if there's no `value` attribute to verify against
+      return typeof element.value !== "string";
+    }
+    return false;
   }
 }

--- a/src/features/action/SetUIState.ts
+++ b/src/features/action/SetUIState.ts
@@ -190,15 +190,27 @@ export class SetUIState extends BaseVisualChange {
     let attempts = 0;
     let lastError: string | undefined;
     let fieldType: FieldType | undefined;
+    let currentViewHierarchy = context.viewHierarchy;
 
     while (attempts < context.maxRetries) {
       attempts++;
 
       try {
-        // Find the element
-        let element = this.findElement(fieldSpec.selector, context.viewHierarchy);
+        // Find the element in current hierarchy
+        let element = this.findElement(fieldSpec.selector, currentViewHierarchy);
 
-        // If not found and scroll enabled, try scrolling
+        // If not found, refresh the view hierarchy before trying scroll
+        // This handles elements that appear after async load
+        if (!element && attempts > 1) {
+          logger.info(`[SetUIState] Element not found on attempt ${attempts}, refreshing view hierarchy`);
+          const freshObs = await this.getObserveScreen().execute(undefined, undefined, false, 0, signal);
+          if (freshObs?.viewHierarchy) {
+            currentViewHierarchy = freshObs.viewHierarchy;
+            element = this.findElement(fieldSpec.selector, currentViewHierarchy);
+          }
+        }
+
+        // If still not found and scroll enabled, try scrolling
         if (!element && context.scrollToFind) {
           const scrollResult = await this.scrollToFindElement(
             fieldSpec.selector,
@@ -259,8 +271,11 @@ export class SetUIState extends BaseVisualChange {
         }
 
         // Verify if requested (and not sensitive)
+        // Also skip verification for iOS text/dropdown fields when value attribute is unavailable
         let verified: boolean | undefined;
-        if (context.verifyAfter && !fieldSpec.sensitive) {
+        const shouldSkipVerify = fieldSpec.sensitive ||
+          this.fieldTypeDetector.shouldSkipVerification(element, fieldType);
+        if (context.verifyAfter && !shouldSkipVerify) {
           verified = await this.verifyFieldValue(fieldSpec, fieldType, signal);
           if (!verified) {
             lastError = `Verification failed for ${this.describeSelector(fieldSpec.selector)}`;

--- a/src/server/formTools.ts
+++ b/src/server/formTools.ts
@@ -139,7 +139,7 @@ Example usage:
         })),
         totalAttempts: result.totalAttempts,
         error: result.error
-      }, result.observation);
+      });
     },
     true, // supportsProgress
     false, // debugOnly

--- a/test/fakes/FakeSetUIStateDependencies.ts
+++ b/test/fakes/FakeSetUIStateDependencies.ts
@@ -316,6 +316,7 @@ export class FakeFieldTypeDetector {
   private typeOverrides: Map<string, FieldType> = new Map();
   private checkedOverrides: Map<string, boolean> = new Map();
   private textOverrides: Map<string, string> = new Map();
+  private skipVerificationOverrides: Map<string, boolean> = new Map();
   private realDetector: FieldTypeDetector = new FieldTypeDetector();
 
   detect(element: Element): FieldType {
@@ -337,6 +338,19 @@ export class FakeFieldTypeDetector {
     return this.textOverrides.get(key) ?? this.realDetector.getTextValue(element);
   }
 
+  isIOSElement(element: Element): boolean {
+    return this.realDetector.isIOSElement(element);
+  }
+
+  shouldSkipVerification(element: Element, fieldType: FieldType): boolean {
+    const key = element["resource-id"] ?? element.text ?? "";
+    const override = this.skipVerificationOverrides.get(key);
+    if (override !== undefined) {
+      return override;
+    }
+    return this.realDetector.shouldSkipVerification(element, fieldType);
+  }
+
   setFieldType(selector: string, type: FieldType): void {
     this.typeOverrides.set(selector, type);
   }
@@ -349,9 +363,14 @@ export class FakeFieldTypeDetector {
     this.textOverrides.set(selector, text);
   }
 
+  setSkipVerification(selector: string, skip: boolean): void {
+    this.skipVerificationOverrides.set(selector, skip);
+  }
+
   reset(): void {
     this.typeOverrides.clear();
     this.checkedOverrides.clear();
     this.textOverrides.clear();
+    this.skipVerificationOverrides.clear();
   }
 }

--- a/test/features/action/FieldTypeDetector.test.ts
+++ b/test/features/action/FieldTypeDetector.test.ts
@@ -227,5 +227,92 @@ describe("FieldTypeDetector", () => {
       const element = createElement({ text: 123 as any });
       expect(detector.getTextValue(element)).toBe("");
     });
+
+    test("prefers value attribute over text for iOS elements", () => {
+      const element = createElement({
+        "class": "UITextField",
+        "text": "Email Address",  // This is the label
+        "value": "user@example.com"  // This is the actual input value
+      });
+      expect(detector.getTextValue(element)).toBe("user@example.com");
+    });
+
+    test("falls back to text when value is not present", () => {
+      const element = createElement({
+        "class": "UITextField",
+        "text": "Email Address"
+      });
+      expect(detector.getTextValue(element)).toBe("Email Address");
+    });
+  });
+
+  describe("isIOSElement", () => {
+    test("returns true for UITextField", () => {
+      const element = createElement({ "class": "UITextField" });
+      expect(detector.isIOSElement(element)).toBe(true);
+    });
+
+    test("returns true for UITextView", () => {
+      const element = createElement({ "class": "UITextView" });
+      expect(detector.isIOSElement(element)).toBe(true);
+    });
+
+    test("returns true for UISwitch", () => {
+      const element = createElement({ "class": "UISwitch" });
+      expect(detector.isIOSElement(element)).toBe(true);
+    });
+
+    test("returns true for UIPickerView", () => {
+      const element = createElement({ "class": "UIPickerView" });
+      expect(detector.isIOSElement(element)).toBe(true);
+    });
+
+    test("returns false for Android EditText", () => {
+      const element = createElement({ "class": "android.widget.EditText" });
+      expect(detector.isIOSElement(element)).toBe(false);
+    });
+  });
+
+  describe("shouldSkipVerification", () => {
+    test("returns true for iOS text field without value attribute", () => {
+      const element = createElement({
+        "class": "UITextField",
+        "text": "Label only"
+      });
+      expect(detector.shouldSkipVerification(element, "text")).toBe(true);
+    });
+
+    test("returns false for iOS text field with value attribute", () => {
+      const element = createElement({
+        "class": "UITextField",
+        "text": "Label",
+        "value": "actual value"
+      });
+      expect(detector.shouldSkipVerification(element, "text")).toBe(false);
+    });
+
+    test("returns true for iOS dropdown without value attribute", () => {
+      const element = createElement({
+        "class": "UIPickerView",
+        "text": "Select option"
+      });
+      expect(detector.shouldSkipVerification(element, "dropdown")).toBe(true);
+    });
+
+    test("returns false for iOS checkbox/toggle (verification works)", () => {
+      const element = createElement({
+        "class": "UISwitch",
+        "checkable": true
+      });
+      expect(detector.shouldSkipVerification(element, "toggle")).toBe(false);
+    });
+
+    test("returns false for Android text field", () => {
+      const element = createElement({
+        "class": "android.widget.EditText",
+        "text": "some value"
+      });
+      expect(detector.shouldSkipVerification(element, "text")).toBe(false);
+    });
   });
 });

--- a/test/features/action/SetUIState.test.ts
+++ b/test/features/action/SetUIState.test.ts
@@ -320,6 +320,41 @@ describe("SetUIState", () => {
       expect(result.fields[0].attempts).toBe(3);
       expect(result.fields[0].error).toContain("Failed to tap");
     });
+
+    test("refreshes view hierarchy between retries when element not found", async () => {
+      // Element appears after first attempt (simulating async load)
+      let observeCallCount = 0;
+      fakeObserve.setResultFactory(() => {
+        observeCallCount++;
+        if (observeCallCount <= 1) {
+          // First call: element not present
+          return createObserveResult({ hierarchy: { node: [] } });
+        }
+        // Subsequent calls: element appears
+        return createObserveResult(createHierarchyWithElement({
+          "resource-id": "async_field",
+          "text": "",
+          "class": "android.widget.EditText"
+        }));
+      });
+
+      fakeFieldTypeDetector.setFieldType("async_field", "text");
+
+      const setUIState = createSetUIState();
+      const result = await setUIState.execute({
+        fields: [{ selector: { elementId: "async_field" }, value: "loaded!" }],
+        maxRetries: 3,
+        scrollToFind: false,  // Disable scroll to test hierarchy refresh
+        verifyAfter: false
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.fields[0].success).toBe(true);
+      // Should have taken multiple attempts
+      expect(result.fields[0].attempts).toBeGreaterThan(1);
+      // Observe should have been called multiple times to refresh hierarchy
+      expect(observeCallCount).toBeGreaterThan(1);
+    });
   });
 
   describe("fail fast", () => {


### PR DESCRIPTION
## Summary

Follow-up fixes for #1079 based on PR feedback:

- **P1 - iOS verification fix**: Prefer `value` attribute over `text` for iOS elements since `text` contains the accessibility label, not the input value. Add `shouldSkipVerification()` to skip iOS text/dropdown verification when `value` attribute is unavailable.

- **P2 - Retry refresh fix**: Refresh view hierarchy between retries when element not found, handling async-loaded form elements that appear after initial observation.

- **CodeQL fix**: Remove superfluous second argument to `createStructuredToolResponse`.

## Test Plan

- [x] Build passes
- [x] Lint passes  
- [x] All 54 tests pass (13 new tests added)

🤖 Generated with [Claude Code](https://claude.com/claude-code)