### PR TITLE
feat: cascade MCP tool failures to test runners with step details

### DIFF
--- a/android/junit-runner/src/main/kotlin/dev/jasonpearson/automobile/junit/AutoMobileRunner.kt
+++ b/android/junit-runner/src/main/kotlin/dev/jasonpearson/automobile/junit/AutoMobileRunner.kt
@@ -732,7 +732,7 @@ class AutoMobileRunner(private val klass: Class<*>) : BlockJUnit4ClassRunner(kla
   ): String {
     return buildString {
       if (failedStep != null) {
-        append("Test plan execution failed at step ${failedStep.stepIndex} (${failedStep.tool}):")
+        append("Test plan execution failed at step ${failedStep.stepIndex + 1} (${failedStep.tool}):")
         append("\n  Error: ${failedStep.error}")
         if (executedSteps != null && totalSteps != null) {
           append("\n  Executed: $executedSteps/$totalSteps steps")

--- a/android/junit-runner/src/test/kotlin/dev/jasonpearson/automobile/junit/AutoMobileRunnerTest.kt
+++ b/android/junit-runner/src/test/kotlin/dev/jasonpearson/automobile/junit/AutoMobileRunnerTest.kt
@@ -171,7 +171,7 @@ class AutoMobileRunnerTest {
 
     assertFalse("Parse result should indicate failure", parseResult.first)
     val errorMessage = parseResult.second
-    assertTrue("Error should contain step index", errorMessage.contains("step 3"))
+    assertTrue("Error should contain step index (1-based)", errorMessage.contains("step 4"))
     assertTrue("Error should contain tool name", errorMessage.contains("tapOn"))
     assertTrue(
         "Error should contain error text",

--- a/ios/XCTestRunner/Sources/XCTestRunner/AutoMobilePlanExecutor.swift
+++ b/ios/XCTestRunner/Sources/XCTestRunner/AutoMobilePlanExecutor.swift
@@ -992,7 +992,7 @@ public final class AutoMobilePlanExecutor {
     private func buildFailureMessage(from result: ExecutePlanResult) -> String {
         var message = ""
         if let failedStep = result.failedStep {
-            message += "Test plan execution failed at step \(failedStep.stepIndex) (\(failedStep.tool)):"
+            message += "Test plan execution failed at step \(failedStep.stepIndex + 1) (\(failedStep.tool)):"
             message += "\n  Error: \(failedStep.error)"
             message += "\n  Executed: \(result.executedSteps)/\(result.totalSteps) steps"
             if let device = failedStep.device {

--- a/ios/XCTestRunner/Sources/XCTestRunnerTests/XCTestRunnerTests.swift
+++ b/ios/XCTestRunner/Sources/XCTestRunnerTests/XCTestRunnerTests.swift
@@ -289,7 +289,7 @@ final class XCTestRunnerTests: XCTestCase {
 
         XCTAssertThrowsError(try executor.execute(testMetadata: nil)) { error in
             let errorDescription = String(describing: error)
-            XCTAssertTrue(errorDescription.contains("step 3"), "Error should contain step index")
+            XCTAssertTrue(errorDescription.contains("step 4"), "Error should contain step index (1-based)")
             XCTAssertTrue(errorDescription.contains("tapOn"), "Error should contain tool name")
             XCTAssertTrue(
                 errorDescription.contains("Element \"Submit Button\" not found on screen"),


### PR DESCRIPTION
## Summary
- When `executePlan` returns `success: false` with `failedStep` information, error messages now include detailed step context
- Added `buildFailureMessage()` helpers to both JUnitRunner (Android) and XCTestRunner (iOS)
- Error messages now show: step index, tool name, error text, executed/total steps, and device identifier

## Error Format
```
Test plan execution failed at step 3 (tapOn):
  Error: Element "Submit Button" not found on screen
  Executed: 3/10 steps
  Device: emulator-5554
```

## Test Plan
- [x] Android tests pass: `./gradlew -p android :junit-runner:test`
- [x] iOS XCTestRunner builds: `swift build` in `ios/XCTestRunner`
- [x] TypeScript validation passes: `bun run lint && bun run build && bun test`

Closes #1078

🤖 Generated with [Claude Code](https://claude.com/claude-code)