### PR TITLE
feat: add exportPlan MCP tool for test recording export

### DIFF
--- a/schemas/tool-definitions.json
+++ b/schemas/tool-definitions.json
@@ -808,6 +808,60 @@
     }
   },
   {
+    "name": "exportPlan",
+    "description": "Stop the active test recording and export recorded interactions as a YAML plan. Returns the plan content.",
+    "inputSchema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "type": "object",
+      "properties": {
+        "recordingId": {
+          "description": "Recording ID to export (uses active recording if not specified)",
+          "type": "string"
+        },
+        "planName": {
+          "description": "Name for the exported plan (auto-generated if not specified)",
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
+    },
+    "outputSchema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "type": "object",
+      "properties": {
+        "success": {
+          "type": "boolean"
+        },
+        "recordingId": {
+          "type": "string"
+        },
+        "planName": {
+          "type": "string"
+        },
+        "planContent": {
+          "type": "string"
+        },
+        "stepCount": {
+          "type": "integer",
+          "minimum": -9007199254740991,
+          "maximum": 9007199254740991
+        },
+        "durationMs": {
+          "type": "integer",
+          "minimum": -9007199254740991,
+          "maximum": 9007199254740991
+        },
+        "error": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "success"
+      ],
+      "additionalProperties": false
+    }
+  },
+  {
     "name": "getDeepLinks",
     "description": "Query deep links for app",
     "inputSchema": {

--- a/src/server/planTools.ts
+++ b/src/server/planTools.ts
@@ -14,6 +14,7 @@ import { normalizePlanDevices } from "../utils/plan/PlanDevices";
 import { ExecutePlanStepDebugInfo } from "../models/ExecutePlanResult";
 import { serverConfig } from "../utils/ServerConfig";
 import { startVideoRecording, stopVideoRecording } from "./videoRecordingManager";
+import { stopTestRecording, getTestRecordingStatus } from "./testRecordingManager";
 
 const testMetadataSchema = z.object({
   testClass: z.string(),
@@ -440,6 +441,65 @@ const executePlanTool = async (device: BootedDevice, params: {
   }
 };
 
+// Export plan tool schema
+const exportPlanSchema = z.object({
+  recordingId: z.string().optional().describe("Recording ID to export (uses active recording if not specified)"),
+  planName: z.string().optional().describe("Name for the exported plan (auto-generated if not specified)"),
+});
+
+const exportPlanResultSchema = z.object({
+  success: z.boolean(),
+  recordingId: z.string().optional(),
+  planName: z.string().optional(),
+  planContent: z.string().optional(),
+  stepCount: z.number().int().optional(),
+  durationMs: z.number().int().optional(),
+  error: z.string().optional(),
+});
+
+// Export plan tool handler
+const exportPlanTool = async (params: {
+  recordingId?: string;
+  planName?: string;
+}): Promise<any> => {
+  try {
+    // Check if there's an active recording
+    const status = getTestRecordingStatus();
+    if (!status) {
+      return createStructuredToolResponse({
+        success: false,
+        error: "No active recording. Start a recording before exporting.",
+      });
+    }
+
+    // Validate recording ID if provided
+    if (params.recordingId && params.recordingId !== status.recordingId) {
+      return createStructuredToolResponse({
+        success: false,
+        error: `Recording ID ${params.recordingId} does not match active recording ${status.recordingId}.`,
+      });
+    }
+
+    // Stop the recording and get the plan
+    const result = await stopTestRecording(params.recordingId, params.planName);
+
+    return createStructuredToolResponse({
+      success: true,
+      recordingId: result.recordingId,
+      planName: result.planName,
+      planContent: result.planContent,
+      stepCount: result.stepCount,
+      durationMs: result.durationMs,
+    });
+  } catch (error) {
+    logger.error(`[exportPlan] Failed to export plan: ${error}`);
+    return createStructuredToolResponse({
+      success: false,
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+};
+
 // Register plan tools for daemon-backed MCP servers and CLI usage.
 export const registerPlanTools = () => {
   ToolRegistry.registerDeviceAware(
@@ -450,5 +510,15 @@ export const registerPlanTools = () => {
     false,
     false,
     { outputSchema: executePlanResultSchema }
+  );
+
+  ToolRegistry.register(
+    "exportPlan",
+    "Stop the active test recording and export recorded interactions as a YAML plan. Returns the plan content.",
+    exportPlanSchema,
+    exportPlanTool,
+    false,
+    false,
+    exportPlanResultSchema
   );
 };

--- a/test/server/exportPlanTool.test.ts
+++ b/test/server/exportPlanTool.test.ts
@@ -1,0 +1,135 @@
+import { afterEach, beforeAll, describe, expect, mock, test } from "bun:test";
+import { registerPlanTools } from "../../src/server/planTools";
+import { ToolRegistry } from "../../src/server/toolRegistry";
+
+describe("exportPlan tool", () => {
+  const mockStopTestRecording = mock(() => Promise.resolve({
+    recordingId: "rec-123",
+    startedAt: "2024-01-01T00:00:00.000Z",
+    stoppedAt: "2024-01-01T00:01:00.000Z",
+    durationMs: 60000,
+    planName: "test-plan",
+    planContent: "name: test-plan\nsteps:\n  - tool: tapOn\n    params:\n      text: Button\n",
+    stepCount: 1,
+    deviceId: "emulator-5554",
+    platform: "android",
+  }));
+
+  const mockGetTestRecordingStatus = mock(() => ({
+    recordingId: "rec-123",
+    deviceId: "emulator-5554",
+    platform: "android",
+    startedAt: "2024-01-01T00:00:00.000Z",
+    eventCount: 5,
+    durationMs: 30000,
+  }));
+
+  beforeAll(() => {
+    if (!ToolRegistry.getTool("exportPlan")) {
+      registerPlanTools();
+    }
+  });
+
+  afterEach(() => {
+    mockStopTestRecording.mockClear();
+    mockGetTestRecordingStatus.mockClear();
+  });
+
+  test("successfully exports plan from active recording", async () => {
+    mock.module("../../src/server/testRecordingManager", () => ({
+      stopTestRecording: mockStopTestRecording,
+      getTestRecordingStatus: mockGetTestRecordingStatus,
+    }));
+
+    const tool = ToolRegistry.getTool("exportPlan");
+    expect(tool).toBeDefined();
+    expect(tool!.handler).toBeDefined();
+
+    const response = await tool!.handler({});
+    const payload = JSON.parse(response.content?.[0]?.text ?? "{}");
+
+    expect(payload.success).toBe(true);
+    expect(payload.recordingId).toBe("rec-123");
+    expect(payload.planName).toBe("test-plan");
+    expect(payload.planContent).toContain("name: test-plan");
+    expect(payload.stepCount).toBe(1);
+    expect(payload.durationMs).toBe(60000);
+  });
+
+  test("returns error when no active recording", async () => {
+    mock.module("../../src/server/testRecordingManager", () => ({
+      stopTestRecording: mockStopTestRecording,
+      getTestRecordingStatus: mock(() => null),
+    }));
+
+    const tool = ToolRegistry.getTool("exportPlan");
+    expect(tool).toBeDefined();
+
+    const response = await tool!.handler({});
+    const payload = JSON.parse(response.content?.[0]?.text ?? "{}");
+
+    expect(payload.success).toBe(false);
+    expect(payload.error).toContain("No active recording");
+  });
+
+  test("returns error when recording ID does not match", async () => {
+    mock.module("../../src/server/testRecordingManager", () => ({
+      stopTestRecording: mockStopTestRecording,
+      getTestRecordingStatus: mockGetTestRecordingStatus,
+    }));
+
+    const tool = ToolRegistry.getTool("exportPlan");
+    expect(tool).toBeDefined();
+
+    const response = await tool!.handler({ recordingId: "wrong-id" });
+    const payload = JSON.parse(response.content?.[0]?.text ?? "{}");
+
+    expect(payload.success).toBe(false);
+    expect(payload.error).toContain("does not match active recording");
+  });
+
+  test("respects optional planName parameter", async () => {
+    const customPlanName = "my-custom-plan";
+    const mockStopWithName = mock(() => Promise.resolve({
+      recordingId: "rec-123",
+      startedAt: "2024-01-01T00:00:00.000Z",
+      stoppedAt: "2024-01-01T00:01:00.000Z",
+      durationMs: 60000,
+      planName: customPlanName,
+      planContent: `name: ${customPlanName}\nsteps:\n  - tool: tapOn\n    params:\n      text: Button\n`,
+      stepCount: 1,
+      deviceId: "emulator-5554",
+      platform: "android",
+    }));
+
+    mock.module("../../src/server/testRecordingManager", () => ({
+      stopTestRecording: mockStopWithName,
+      getTestRecordingStatus: mockGetTestRecordingStatus,
+    }));
+
+    const tool = ToolRegistry.getTool("exportPlan");
+    expect(tool).toBeDefined();
+
+    const response = await tool!.handler({ planName: customPlanName });
+    const payload = JSON.parse(response.content?.[0]?.text ?? "{}");
+
+    expect(payload.success).toBe(true);
+    expect(payload.planName).toBe(customPlanName);
+  });
+
+  test("respects optional recordingId parameter", async () => {
+    mock.module("../../src/server/testRecordingManager", () => ({
+      stopTestRecording: mockStopTestRecording,
+      getTestRecordingStatus: mockGetTestRecordingStatus,
+    }));
+
+    const tool = ToolRegistry.getTool("exportPlan");
+    expect(tool).toBeDefined();
+
+    const response = await tool!.handler({ recordingId: "rec-123" });
+    const payload = JSON.parse(response.content?.[0]?.text ?? "{}");
+
+    expect(payload.success).toBe(true);
+    expect(payload.recordingId).toBe("rec-123");
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `exportPlan` MCP tool that wraps existing test recording stop functionality
- Allows MCP clients to stop recording and export interactions as a YAML plan
- Complements the socket-based approach with an MCP-accessible interface

## Test Plan
- [x] Unit tests added (`test/server/exportPlanTool.test.ts`)
- [x] All 1734 tests pass
- [x] Build succeeds
- [x] Lint passes

Closes #1070

🤖 Generated with [Claude Code](https://claude.com/claude-code)