### PR TITLE
feat: add SharedPreferences reading API to SDK

### DIFF
--- a/android/auto-mobile-sdk/src/debug/AndroidManifest.xml
+++ b/android/auto-mobile-sdk/src/debug/AndroidManifest.xml
@@ -21,5 +21,10 @@
       android:name="dev.jasonpearson.automobile.sdk.database.DatabaseInspectorProvider"
       android:authorities="${applicationId}.automobile.database"
       android:exported="true" />
+
+    <provider
+      android:name="dev.jasonpearson.automobile.sdk.storage.SharedPreferencesInspectorProvider"
+      android:authorities="${applicationId}.automobile.sharedprefs"
+      android:exported="true" />
   </application>
 </manifest>

--- a/android/auto-mobile-sdk/src/debug/kotlin/dev/jasonpearson/automobile/sdk/storage/SharedPreferencesInspectorProvider.kt
+++ b/android/auto-mobile-sdk/src/debug/kotlin/dev/jasonpearson/automobile/sdk/storage/SharedPreferencesInspectorProvider.kt
@@ -1,0 +1,156 @@
+package dev.jasonpearson.automobile.sdk.storage
+
+import android.content.ContentProvider
+import android.content.ContentValues
+import android.database.Cursor
+import android.net.Uri
+import android.os.Bundle
+import org.json.JSONArray
+import org.json.JSONObject
+
+/**
+ * ContentProvider for SharedPreferences inspection via ADB.
+ *
+ * This provider is only included in debug builds and allows SharedPreferences inspection via `adb
+ * shell content call` commands.
+ *
+ * Example usage:
+ * ```bash
+ * adb shell content call --uri content://com.example.app.automobile.sharedprefs \
+ *     --method listFiles
+ *
+ * adb shell content call --uri content://com.example.app.automobile.sharedprefs \
+ *     --method getPreferences --extra fileName:s:auth_prefs
+ * ```
+ */
+class SharedPreferencesInspectorProvider : ContentProvider() {
+
+  override fun onCreate(): Boolean {
+    // Always return true - actual initialization happens in call()
+    return true
+  }
+
+  override fun call(method: String, arg: String?, extras: Bundle?): Bundle {
+    val result = Bundle()
+
+    // Check if inspection is enabled
+    if (!SharedPreferencesInspector.isEnabled()) {
+      result.putBoolean("success", false)
+      result.putString("errorType", "DISABLED")
+      result.putString("error", "SharedPreferences inspection is disabled")
+      return result
+    }
+
+    try {
+      val driver = SharedPreferencesInspector.getDriver()
+      val response =
+        when (method) {
+          "listFiles" -> handleListFiles(driver)
+          "getPreferences" -> handleGetPreferences(driver, extras)
+          else -> throw IllegalArgumentException("Unknown method: $method")
+        }
+      result.putBoolean("success", true)
+      result.putString("result", response.toString())
+    } catch (e: SharedPreferencesError) {
+      result.putBoolean("success", false)
+      result.putString("errorType", e::class.simpleName ?: "UNKNOWN")
+      result.putString("error", e.message ?: "Unknown error")
+    } catch (e: IllegalArgumentException) {
+      result.putBoolean("success", false)
+      result.putString("errorType", "INVALID_ARGUMENT")
+      result.putString("error", e.message ?: "Invalid argument")
+    } catch (e: Exception) {
+      result.putBoolean("success", false)
+      result.putString("errorType", e::class.simpleName ?: "UNKNOWN")
+      result.putString("error", e.message ?: "Unknown error")
+    }
+
+    return result
+  }
+
+  private fun handleListFiles(driver: SharedPreferencesDriver): JSONObject {
+    val files = driver.getPreferenceFiles()
+    val jsonArray = JSONArray()
+
+    files.forEach { file ->
+      jsonArray.put(
+        JSONObject().apply {
+          put("name", file.name)
+          put("path", file.path)
+          put("entryCount", file.entryCount)
+        }
+      )
+    }
+
+    return JSONObject().put("files", jsonArray)
+  }
+
+  private fun handleGetPreferences(driver: SharedPreferencesDriver, extras: Bundle?): JSONObject {
+    val fileName =
+      extras?.getString("fileName") ?: throw IllegalArgumentException("fileName required")
+
+    val entries = driver.getPreferences(fileName)
+    val entriesArray = JSONArray()
+
+    entries.forEach { entry ->
+      entriesArray.put(
+        JSONObject().apply {
+          put("key", entry.key)
+          put("value", serializeValue(entry.value, entry.type))
+          put("type", entry.type.name)
+        }
+      )
+    }
+
+    // Get file descriptor for response
+    val files = driver.getPreferenceFiles()
+    val fileDescriptor = files.find { it.name == fileName }
+
+    return JSONObject().apply {
+      if (fileDescriptor != null) {
+        put(
+          "file",
+          JSONObject().apply {
+            put("name", fileDescriptor.name)
+            put("path", fileDescriptor.path)
+            put("entryCount", fileDescriptor.entryCount)
+          },
+        )
+      }
+      put("entries", entriesArray)
+    }
+  }
+
+  private fun serializeValue(value: Any?, type: KeyValueType): Any? {
+    return when (type) {
+      KeyValueType.STRING_SET -> {
+        val jsonArray = JSONArray()
+        @Suppress("UNCHECKED_CAST") (value as? Set<String>)?.forEach { jsonArray.put(it) }
+        jsonArray
+      }
+      else -> value ?: JSONObject.NULL
+    }
+  }
+
+  // Required ContentProvider methods - not used for content call
+  override fun query(
+    uri: Uri,
+    projection: Array<String>?,
+    selection: String?,
+    selectionArgs: Array<String>?,
+    sortOrder: String?,
+  ): Cursor? = null
+
+  override fun getType(uri: Uri): String? = null
+
+  override fun insert(uri: Uri, values: ContentValues?): Uri? = null
+
+  override fun delete(uri: Uri, selection: String?, selectionArgs: Array<String>?): Int = 0
+
+  override fun update(
+    uri: Uri,
+    values: ContentValues?,
+    selection: String?,
+    selectionArgs: Array<String>?,
+  ): Int = 0
+}

--- a/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/AutoMobileSDK.kt
+++ b/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/AutoMobileSDK.kt
@@ -3,6 +3,7 @@ package dev.jasonpearson.automobile.sdk
 import android.content.Context
 import android.content.Intent
 import dev.jasonpearson.automobile.sdk.database.DatabaseInspector
+import dev.jasonpearson.automobile.sdk.storage.SharedPreferencesInspector
 import java.util.concurrent.CopyOnWriteArrayList
 
 /**
@@ -59,6 +60,7 @@ object AutoMobileSDK {
     RecompositionTracker.initialize(this.context!!)
     AutoMobileNotifications.initialize(this.context!!)
     DatabaseInspector.initialize(this.context!!)
+    SharedPreferencesInspector.initialize(this.context!!)
   }
 
   /**

--- a/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/storage/KeyValueModels.kt
+++ b/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/storage/KeyValueModels.kt
@@ -1,0 +1,43 @@
+package dev.jasonpearson.automobile.sdk.storage
+
+/** Describes a SharedPreferences file. */
+data class PreferenceFileDescriptor(
+  /** Display name of the preferences file (without .xml extension). */
+  val name: String,
+  /** Absolute path to the preferences file. */
+  val path: String,
+  /** Number of key-value entries in the file. */
+  val entryCount: Int,
+)
+
+/** A key-value pair from SharedPreferences. */
+data class KeyValuePair(
+  /** The preference key. */
+  val key: String,
+  /** The preference value. */
+  val value: Any?,
+  /** The type of the value. */
+  val type: KeyValueType,
+)
+
+/** Types of values that can be stored in SharedPreferences. */
+enum class KeyValueType {
+  STRING,
+  INT,
+  LONG,
+  FLOAT,
+  BOOLEAN,
+  STRING_SET,
+  UNKNOWN,
+}
+
+/** Listener for SharedPreferences changes. */
+fun interface OnPreferenceChangeListener {
+  /**
+   * Called when a preference changes.
+   *
+   * @param fileName The name of the preferences file that changed
+   * @param key The key that changed, or null if multiple keys changed or file was cleared
+   */
+  fun onPreferenceChanged(fileName: String, key: String?)
+}

--- a/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/storage/SharedPreferencesDriver.kt
+++ b/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/storage/SharedPreferencesDriver.kt
@@ -1,0 +1,64 @@
+package dev.jasonpearson.automobile.sdk.storage
+
+import java.io.File
+
+/**
+ * Interface for SharedPreferences operations. Implementations provide access to app preferences for
+ * inspection.
+ */
+interface SharedPreferencesDriver {
+  /** Returns a list of all accessible SharedPreferences files. */
+  fun getPreferenceFiles(): List<PreferenceFileDescriptor>
+
+  /**
+   * Returns all key-value pairs from a preferences file.
+   *
+   * @param fileName The name of the preferences file (without .xml extension)
+   * @throws SharedPreferencesError.FileNotFound if the file doesn't exist
+   */
+  fun getPreferences(fileName: String): List<KeyValuePair>
+
+  /**
+   * Registers a listener to be notified when preferences change.
+   *
+   * @param listener The listener to register
+   */
+  fun registerOnChangeListener(listener: OnPreferenceChangeListener)
+
+  /**
+   * Unregisters a previously registered change listener.
+   *
+   * @param listener The listener to unregister
+   */
+  fun unregisterOnChangeListener(listener: OnPreferenceChangeListener)
+}
+
+/** Abstraction for file system operations to enable testing. */
+interface FileSystemOperations {
+  /**
+   * Lists files in a directory.
+   *
+   * @param directory The directory to list
+   * @return List of files in the directory, or empty list if directory doesn't exist
+   */
+  fun listFiles(directory: File): List<File>
+
+  /**
+   * Checks if a file exists.
+   *
+   * @param file The file to check
+   * @return true if the file exists
+   */
+  fun exists(file: File): Boolean
+}
+
+/** Real implementation of FileSystemOperations that delegates to the file system. */
+class RealFileSystemOperations : FileSystemOperations {
+  override fun listFiles(directory: File): List<File> {
+    return directory.listFiles()?.toList() ?: emptyList()
+  }
+
+  override fun exists(file: File): Boolean {
+    return file.exists()
+  }
+}

--- a/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/storage/SharedPreferencesDriverImpl.kt
+++ b/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/storage/SharedPreferencesDriverImpl.kt
@@ -1,0 +1,106 @@
+package dev.jasonpearson.automobile.sdk.storage
+
+import android.content.Context
+import android.content.SharedPreferences
+import java.io.File
+import java.util.concurrent.CopyOnWriteArrayList
+
+/**
+ * Android implementation of SharedPreferencesDriver that uses the SharedPreferences API.
+ *
+ * @param context Application context
+ * @param fileSystemOperations File system abstraction for listing preference files
+ */
+class SharedPreferencesDriverImpl(
+  private val context: Context,
+  private val fileSystemOperations: FileSystemOperations = RealFileSystemOperations(),
+) : SharedPreferencesDriver {
+
+  private val listeners = CopyOnWriteArrayList<OnPreferenceChangeListener>()
+  private val sharedPrefsListeners =
+    mutableMapOf<String, SharedPreferences.OnSharedPreferenceChangeListener>()
+
+  override fun getPreferenceFiles(): List<PreferenceFileDescriptor> {
+    val sharedPrefsDir = File(context.applicationInfo.dataDir, "shared_prefs")
+    val files = fileSystemOperations.listFiles(sharedPrefsDir)
+
+    return files
+      .filter { it.name.endsWith(".xml") }
+      .map { file ->
+        val name = file.name.removeSuffix(".xml")
+        val prefs = context.getSharedPreferences(name, Context.MODE_PRIVATE)
+        PreferenceFileDescriptor(name = name, path = file.absolutePath, entryCount = prefs.all.size)
+      }
+  }
+
+  override fun getPreferences(fileName: String): List<KeyValuePair> {
+    // Verify the file exists
+    val sharedPrefsDir = File(context.applicationInfo.dataDir, "shared_prefs")
+    val prefFile = File(sharedPrefsDir, "$fileName.xml")
+
+    if (!fileSystemOperations.exists(prefFile)) {
+      throw SharedPreferencesError.FileNotFound(fileName)
+    }
+
+    val prefs = context.getSharedPreferences(fileName, Context.MODE_PRIVATE)
+    return prefs.all.map { (key, value) ->
+      KeyValuePair(key = key, value = value, type = detectType(value))
+    }
+  }
+
+  override fun registerOnChangeListener(listener: OnPreferenceChangeListener) {
+    listeners.add(listener)
+  }
+
+  override fun unregisterOnChangeListener(listener: OnPreferenceChangeListener) {
+    listeners.remove(listener)
+  }
+
+  /**
+   * Starts listening for changes on a specific preferences file.
+   *
+   * @param fileName The preferences file name
+   */
+  internal fun startListening(fileName: String) {
+    if (sharedPrefsListeners.containsKey(fileName)) return
+
+    val prefs = context.getSharedPreferences(fileName, Context.MODE_PRIVATE)
+    val sharedPrefsListener =
+      SharedPreferences.OnSharedPreferenceChangeListener { _, key ->
+        listeners.forEach { it.onPreferenceChanged(fileName, key) }
+      }
+
+    prefs.registerOnSharedPreferenceChangeListener(sharedPrefsListener)
+    sharedPrefsListeners[fileName] = sharedPrefsListener
+  }
+
+  /**
+   * Stops listening for changes on a specific preferences file.
+   *
+   * @param fileName The preferences file name
+   */
+  internal fun stopListening(fileName: String) {
+    sharedPrefsListeners.remove(fileName)?.let { listener ->
+      val prefs = context.getSharedPreferences(fileName, Context.MODE_PRIVATE)
+      prefs.unregisterOnSharedPreferenceChangeListener(listener)
+    }
+  }
+
+  /** Stops listening on all preferences files. */
+  internal fun stopAllListening() {
+    sharedPrefsListeners.keys.toList().forEach { stopListening(it) }
+  }
+
+  private fun detectType(value: Any?): KeyValueType {
+    return when (value) {
+      null -> KeyValueType.UNKNOWN
+      is String -> KeyValueType.STRING
+      is Int -> KeyValueType.INT
+      is Long -> KeyValueType.LONG
+      is Float -> KeyValueType.FLOAT
+      is Boolean -> KeyValueType.BOOLEAN
+      is Set<*> -> KeyValueType.STRING_SET
+      else -> KeyValueType.UNKNOWN
+    }
+  }
+}

--- a/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/storage/SharedPreferencesError.kt
+++ b/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/storage/SharedPreferencesError.kt
@@ -1,0 +1,17 @@
+package dev.jasonpearson.automobile.sdk.storage
+
+/** Sealed class representing SharedPreferences inspection errors. */
+sealed class SharedPreferencesError(message: String) : Exception(message) {
+  /** Preferences file was not found. */
+  class FileNotFound(fileName: String) :
+    SharedPreferencesError("Preferences file not found: $fileName")
+
+  /** Path is outside the app's data directory. */
+  class InvalidPath(path: String) : SharedPreferencesError("Invalid preferences path: $path")
+
+  /** SharedPreferencesInspector was not initialized with a context. */
+  class NotInitialized : SharedPreferencesError("SharedPreferencesInspector not initialized")
+
+  /** Error reading preferences. */
+  class ReadError(cause: String) : SharedPreferencesError("Read error: $cause")
+}

--- a/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/storage/SharedPreferencesInspector.kt
+++ b/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/storage/SharedPreferencesInspector.kt
@@ -1,0 +1,85 @@
+package dev.jasonpearson.automobile.sdk.storage
+
+import android.content.Context
+
+/**
+ * Public API for SharedPreferences inspection.
+ *
+ * The SharedPreferencesInspector must be initialized with a Context before use. It is disabled by
+ * default and must be explicitly enabled in debug builds.
+ *
+ * Usage:
+ * ```kotlin
+ * // In Application.onCreate() or similar initialization code
+ * AutoMobileSDK.initialize(applicationContext) // This initializes SharedPreferencesInspector
+ *
+ * // Enable inspection (typically only in debug builds)
+ * if (BuildConfig.DEBUG) {
+ *     SharedPreferencesInspector.setEnabled(true)
+ * }
+ * ```
+ */
+object SharedPreferencesInspector {
+  private var context: Context? = null
+  private var _enabled: Boolean = false
+  private var _driver: SharedPreferencesDriverImpl? = null
+
+  /**
+   * Initialize the SharedPreferencesInspector with application context.
+   *
+   * This is called internally by AutoMobileSDK.initialize().
+   *
+   * @param context Application context
+   */
+  internal fun initialize(context: Context) {
+    this.context = context.applicationContext
+    // Driver is created lazily when needed
+  }
+
+  /** Returns whether SharedPreferences inspection is enabled. */
+  fun isEnabled(): Boolean = _enabled
+
+  /**
+   * Enable or disable SharedPreferences inspection.
+   *
+   * When disabled, all ContentProvider calls will return an error. This should typically only be
+   * enabled in debug builds.
+   *
+   * @param enabled Whether to enable SharedPreferences inspection
+   */
+  fun setEnabled(enabled: Boolean) {
+    _enabled = enabled
+    if (!enabled) {
+      // Stop listening when disabled
+      _driver?.stopAllListening()
+    }
+  }
+
+  /**
+   * Get the SharedPreferences driver instance.
+   *
+   * @throws SharedPreferencesError.NotInitialized if initialize() has not been called
+   */
+  internal fun getDriver(): SharedPreferencesDriver {
+    val ctx = context ?: throw SharedPreferencesError.NotInitialized()
+
+    // Create driver lazily
+    if (_driver == null) {
+      _driver = SharedPreferencesDriverImpl(ctx)
+    }
+
+    return _driver!!
+  }
+
+  /**
+   * Reset internal state. Used for testing.
+   *
+   * @hide
+   */
+  internal fun reset() {
+    _driver?.stopAllListening()
+    _driver = null
+    _enabled = false
+    context = null
+  }
+}

--- a/android/auto-mobile-sdk/src/test/kotlin/dev/jasonpearson/automobile/sdk/storage/FakeFileSystemOperations.kt
+++ b/android/auto-mobile-sdk/src/test/kotlin/dev/jasonpearson/automobile/sdk/storage/FakeFileSystemOperations.kt
@@ -1,0 +1,48 @@
+package dev.jasonpearson.automobile.sdk.storage
+
+import java.io.File
+
+/** Fake implementation of FileSystemOperations for testing. */
+class FakeFileSystemOperations : FileSystemOperations {
+  private val files = mutableMapOf<String, MutableList<File>>()
+  private val existingFiles = mutableSetOf<String>()
+
+  /**
+   * Adds a file to a directory for testing.
+   *
+   * @param directory The directory path
+   * @param file The file to add
+   */
+  fun addFile(directory: String, file: File) {
+    files.getOrPut(directory) { mutableListOf() }.add(file)
+    existingFiles.add(file.absolutePath)
+  }
+
+  /**
+   * Sets whether a file exists.
+   *
+   * @param path The file path
+   * @param exists Whether the file exists
+   */
+  fun setFileExists(path: String, exists: Boolean) {
+    if (exists) {
+      existingFiles.add(path)
+    } else {
+      existingFiles.remove(path)
+    }
+  }
+
+  /** Clears all stored file data. */
+  fun clear() {
+    files.clear()
+    existingFiles.clear()
+  }
+
+  override fun listFiles(directory: File): List<File> {
+    return files[directory.absolutePath] ?: emptyList()
+  }
+
+  override fun exists(file: File): Boolean {
+    return existingFiles.contains(file.absolutePath)
+  }
+}

--- a/android/auto-mobile-sdk/src/test/kotlin/dev/jasonpearson/automobile/sdk/storage/FakeSharedPreferencesDriver.kt
+++ b/android/auto-mobile-sdk/src/test/kotlin/dev/jasonpearson/automobile/sdk/storage/FakeSharedPreferencesDriver.kt
@@ -1,0 +1,100 @@
+package dev.jasonpearson.automobile.sdk.storage
+
+import java.util.concurrent.CopyOnWriteArrayList
+
+/** Fake implementation of SharedPreferencesDriver for testing. */
+class FakeSharedPreferencesDriver : SharedPreferencesDriver {
+  private val preferenceFiles = mutableMapOf<String, MutableMap<String, Any?>>()
+  private val listeners = CopyOnWriteArrayList<OnPreferenceChangeListener>()
+
+  /**
+   * Sets preferences data for a file.
+   *
+   * @param fileName The preferences file name (without .xml extension)
+   * @param data Map of key-value pairs
+   */
+  fun setPreferences(fileName: String, data: Map<String, Any?>) {
+    preferenceFiles[fileName] = data.toMutableMap()
+  }
+
+  /**
+   * Adds a single preference to a file.
+   *
+   * @param fileName The preferences file name
+   * @param key The preference key
+   * @param value The preference value
+   */
+  fun putPreference(fileName: String, key: String, value: Any?) {
+    preferenceFiles.getOrPut(fileName) { mutableMapOf() }[key] = value
+    notifyListeners(fileName, key)
+  }
+
+  /**
+   * Removes a preference from a file.
+   *
+   * @param fileName The preferences file name
+   * @param key The preference key to remove
+   */
+  fun removePreference(fileName: String, key: String) {
+    preferenceFiles[fileName]?.remove(key)
+    notifyListeners(fileName, key)
+  }
+
+  /**
+   * Clears all preferences from a file.
+   *
+   * @param fileName The preferences file name
+   */
+  fun clearPreferences(fileName: String) {
+    preferenceFiles[fileName]?.clear()
+    notifyListeners(fileName, null)
+  }
+
+  /** Clears all stored preferences data. */
+  fun clear() {
+    preferenceFiles.clear()
+  }
+
+  private fun notifyListeners(fileName: String, key: String?) {
+    listeners.forEach { it.onPreferenceChanged(fileName, key) }
+  }
+
+  override fun getPreferenceFiles(): List<PreferenceFileDescriptor> {
+    return preferenceFiles.map { (name, data) ->
+      PreferenceFileDescriptor(
+        name = name,
+        path = "/data/data/com.example.app/shared_prefs/$name.xml",
+        entryCount = data.size,
+      )
+    }
+  }
+
+  override fun getPreferences(fileName: String): List<KeyValuePair> {
+    val data = preferenceFiles[fileName] ?: throw SharedPreferencesError.FileNotFound(fileName)
+
+    return data.map { (key, value) ->
+      KeyValuePair(key = key, value = value, type = detectType(value))
+    }
+  }
+
+  override fun registerOnChangeListener(listener: OnPreferenceChangeListener) {
+    listeners.add(listener)
+  }
+
+  override fun unregisterOnChangeListener(listener: OnPreferenceChangeListener) {
+    listeners.remove(listener)
+  }
+
+  private fun detectType(value: Any?): KeyValueType {
+    return when (value) {
+      null -> KeyValueType.UNKNOWN
+      is String -> KeyValueType.STRING
+      is Int -> KeyValueType.INT
+      is Long -> KeyValueType.LONG
+      is Float -> KeyValueType.FLOAT
+      is Boolean -> KeyValueType.BOOLEAN
+      is Set<*> -> KeyValueType.STRING_SET
+      else -> KeyValueType.UNKNOWN
+    }
+  }
+}

--- a/android/auto-mobile-sdk/src/test/kotlin/dev/jasonpearson/automobile/sdk/storage/FakeSharedPreferencesDriverTest.kt
+++ b/android/auto-mobile-sdk/src/test/kotlin/dev/jasonpearson/automobile/sdk/storage/FakeSharedPreferencesDriverTest.kt
@@ -1,0 +1,214 @@
+package dev.jasonpearson.automobile.sdk.storage
+
+import org.junit.Assert.*
+import org.junit.Before
+import org.junit.Test
+
+class FakeSharedPreferencesDriverTest {
+
+  private lateinit var driver: FakeSharedPreferencesDriver
+
+  @Before
+  fun setUp() {
+    driver = FakeSharedPreferencesDriver()
+  }
+
+  @Test
+  fun `getPreferenceFiles returns empty list initially`() {
+    val files = driver.getPreferenceFiles()
+
+    assertTrue(files.isEmpty())
+  }
+
+  @Test
+  fun `getPreferenceFiles returns added preferences`() {
+    driver.setPreferences("auth_prefs", mapOf("token" to "abc123", "userId" to 42))
+    driver.setPreferences("settings", mapOf("darkMode" to true))
+
+    val files = driver.getPreferenceFiles()
+
+    assertEquals(2, files.size)
+    val authFile = files.find { it.name == "auth_prefs" }
+    assertNotNull(authFile)
+    assertEquals(2, authFile!!.entryCount)
+    assertTrue(authFile.path.contains("auth_prefs.xml"))
+  }
+
+  @Test
+  fun `getPreferences returns all entries for a file`() {
+    driver.setPreferences(
+      "user_prefs",
+      mapOf("name" to "John", "age" to 30, "premium" to true, "score" to 95.5f),
+    )
+
+    val prefs = driver.getPreferences("user_prefs")
+
+    assertEquals(4, prefs.size)
+
+    val namePref = prefs.find { it.key == "name" }
+    assertNotNull(namePref)
+    assertEquals("John", namePref!!.value)
+    assertEquals(KeyValueType.STRING, namePref.type)
+
+    val agePref = prefs.find { it.key == "age" }
+    assertNotNull(agePref)
+    assertEquals(30, agePref!!.value)
+    assertEquals(KeyValueType.INT, agePref.type)
+
+    val premiumPref = prefs.find { it.key == "premium" }
+    assertNotNull(premiumPref)
+    assertEquals(true, premiumPref!!.value)
+    assertEquals(KeyValueType.BOOLEAN, premiumPref.type)
+
+    val scorePref = prefs.find { it.key == "score" }
+    assertNotNull(scorePref)
+    assertEquals(95.5f, scorePref!!.value)
+    assertEquals(KeyValueType.FLOAT, scorePref.type)
+  }
+
+  @Test
+  fun `getPreferences throws FileNotFound for unknown file`() {
+    try {
+      driver.getPreferences("nonexistent")
+      fail("Expected SharedPreferencesError.FileNotFound")
+    } catch (e: SharedPreferencesError.FileNotFound) {
+      assertTrue(e.message!!.contains("nonexistent"))
+    }
+  }
+
+  @Test
+  fun `putPreference adds entry to file`() {
+    driver.putPreference("prefs", "key1", "value1")
+    driver.putPreference("prefs", "key2", 100)
+
+    val prefs = driver.getPreferences("prefs")
+
+    assertEquals(2, prefs.size)
+    assertNotNull(prefs.find { it.key == "key1" && it.value == "value1" })
+    assertNotNull(prefs.find { it.key == "key2" && it.value == 100 })
+  }
+
+  @Test
+  fun `removePreference removes entry from file`() {
+    driver.setPreferences("prefs", mapOf("key1" to "value1", "key2" to "value2"))
+
+    driver.removePreference("prefs", "key1")
+
+    val prefs = driver.getPreferences("prefs")
+    assertEquals(1, prefs.size)
+    assertNull(prefs.find { it.key == "key1" })
+    assertNotNull(prefs.find { it.key == "key2" })
+  }
+
+  @Test
+  fun `clearPreferences removes all entries from file`() {
+    driver.setPreferences("prefs", mapOf("key1" to "value1", "key2" to "value2"))
+
+    driver.clearPreferences("prefs")
+
+    val prefs = driver.getPreferences("prefs")
+    assertTrue(prefs.isEmpty())
+  }
+
+  @Test
+  fun `change listener is notified on putPreference`() {
+    var notifiedFile: String? = null
+    var notifiedKey: String? = null
+
+    driver.registerOnChangeListener { file, key ->
+      notifiedFile = file
+      notifiedKey = key
+    }
+
+    driver.putPreference("settings", "theme", "dark")
+
+    assertEquals("settings", notifiedFile)
+    assertEquals("theme", notifiedKey)
+  }
+
+  @Test
+  fun `change listener is notified on removePreference`() {
+    driver.setPreferences("settings", mapOf("theme" to "light"))
+
+    var notifiedFile: String? = null
+    var notifiedKey: String? = null
+
+    driver.registerOnChangeListener { file, key ->
+      notifiedFile = file
+      notifiedKey = key
+    }
+
+    driver.removePreference("settings", "theme")
+
+    assertEquals("settings", notifiedFile)
+    assertEquals("theme", notifiedKey)
+  }
+
+  @Test
+  fun `change listener is notified on clearPreferences with null key`() {
+    driver.setPreferences("settings", mapOf("theme" to "light"))
+
+    var notifiedFile: String? = null
+    var notifiedKey: String? = "initial"
+
+    driver.registerOnChangeListener { file, key ->
+      notifiedFile = file
+      notifiedKey = key
+    }
+
+    driver.clearPreferences("settings")
+
+    assertEquals("settings", notifiedFile)
+    assertNull(notifiedKey)
+  }
+
+  @Test
+  fun `unregistered listener is not notified`() {
+    var callCount = 0
+    val listener = OnPreferenceChangeListener { _, _ -> callCount++ }
+
+    driver.registerOnChangeListener(listener)
+    driver.putPreference("prefs", "key", "value")
+    assertEquals(1, callCount)
+
+    driver.unregisterOnChangeListener(listener)
+    driver.putPreference("prefs", "key2", "value2")
+    assertEquals(1, callCount)
+  }
+
+  @Test
+  fun `type detection works for all supported types`() {
+    driver.setPreferences(
+      "types",
+      mapOf(
+        "string" to "hello",
+        "int" to 42,
+        "long" to 9999999999L,
+        "float" to 3.14f,
+        "boolean" to false,
+        "stringSet" to setOf("a", "b", "c"),
+        "null" to null,
+      ),
+    )
+
+    val prefs = driver.getPreferences("types")
+
+    assertEquals(KeyValueType.STRING, prefs.find { it.key == "string" }?.type)
+    assertEquals(KeyValueType.INT, prefs.find { it.key == "int" }?.type)
+    assertEquals(KeyValueType.LONG, prefs.find { it.key == "long" }?.type)
+    assertEquals(KeyValueType.FLOAT, prefs.find { it.key == "float" }?.type)
+    assertEquals(KeyValueType.BOOLEAN, prefs.find { it.key == "boolean" }?.type)
+    assertEquals(KeyValueType.STRING_SET, prefs.find { it.key == "stringSet" }?.type)
+    assertEquals(KeyValueType.UNKNOWN, prefs.find { it.key == "null" }?.type)
+  }
+
+  @Test
+  fun `clear removes all preference files`() {
+    driver.setPreferences("file1", mapOf("key" to "value"))
+    driver.setPreferences("file2", mapOf("key" to "value"))
+
+    driver.clear()
+
+    assertTrue(driver.getPreferenceFiles().isEmpty())
+  }
+}

--- a/android/auto-mobile-sdk/src/test/kotlin/dev/jasonpearson/automobile/sdk/storage/SharedPreferencesInspectorTest.kt
+++ b/android/auto-mobile-sdk/src/test/kotlin/dev/jasonpearson/automobile/sdk/storage/SharedPreferencesInspectorTest.kt
@@ -1,0 +1,48 @@
+package dev.jasonpearson.automobile.sdk.storage
+
+import org.junit.Assert.*
+import org.junit.Before
+import org.junit.Test
+
+class SharedPreferencesInspectorTest {
+
+  @Before
+  fun setUp() {
+    SharedPreferencesInspector.reset()
+  }
+
+  @Test
+  fun `isEnabled returns false by default`() {
+    assertFalse(SharedPreferencesInspector.isEnabled())
+  }
+
+  @Test
+  fun `setEnabled updates enabled state`() {
+    SharedPreferencesInspector.setEnabled(true)
+
+    assertTrue(SharedPreferencesInspector.isEnabled())
+
+    SharedPreferencesInspector.setEnabled(false)
+
+    assertFalse(SharedPreferencesInspector.isEnabled())
+  }
+
+  @Test
+  fun `getDriver throws NotInitialized when not initialized`() {
+    try {
+      SharedPreferencesInspector.getDriver()
+      fail("Expected SharedPreferencesError.NotInitialized")
+    } catch (e: SharedPreferencesError.NotInitialized) {
+      assertTrue(e.message!!.contains("not initialized"))
+    }
+  }
+
+  @Test
+  fun `reset clears state`() {
+    SharedPreferencesInspector.setEnabled(true)
+
+    SharedPreferencesInspector.reset()
+
+    assertFalse(SharedPreferencesInspector.isEnabled())
+  }
+}


### PR DESCRIPTION
## Summary
- Add `SharedPreferencesInspector` for reading app preferences via ADB
- Follow existing `DatabaseInspector` pattern with driver interface, fake implementations, and ContentProvider
- Support all SharedPreferences types: String, Int, Long, Float, Boolean, StringSet

## Test Plan
- [x] Unit tests pass (`./gradlew -p android :auto-mobile-sdk:testDebugUnitTest --tests "*SharedPreferences*"`)
- [x] Build passes (`./gradlew -p android :auto-mobile-sdk:assembleDebug`)
- [x] Code formatted with ktfmt

## ADB Usage
```bash
# List preference files
adb shell content call --uri content://dev.jasonpearson.automobile.playground.automobile.sharedprefs --method listFiles

# Get preferences from a file
adb shell content call --uri content://dev.jasonpearson.automobile.playground.automobile.sharedprefs --method getPreferences --extra fileName:s:auth_prefs
```

Closes #1061

🤖 Generated with [Claude Code](https://claude.com/claude-code)