### PR TITLE
feat: add SharedPreferences WebSocket messages for real-time storage inspection

### DIFF
--- a/android/accessibility-service/src/main/kotlin/dev/jasonpearson/automobile/accessibilityservice/AutoMobileAccessibilityService.kt
+++ b/android/accessibility-service/src/main/kotlin/dev/jasonpearson/automobile/accessibilityservice/AutoMobileAccessibilityService.kt
@@ -34,6 +34,7 @@ import dev.jasonpearson.automobile.accessibilityservice.models.ViewHierarchy
 import dev.jasonpearson.automobile.accessibilityservice.perf.PerfProvider
 import dev.jasonpearson.automobile.accessibilityservice.perf.SystemTimeProvider
 import dev.jasonpearson.automobile.accessibilityservice.perf.TimeProvider
+import dev.jasonpearson.automobile.accessibilityservice.storage.StorageSubscriptionManager
 import dev.jasonpearson.automobile.sdk.AutoMobileSDK
 import java.io.ByteArrayOutputStream
 import java.io.File
@@ -101,6 +102,12 @@ class AutoMobileAccessibilityService : AccessibilityService() {
 
   // Job for collecting navigation event updates
   private var navigationEventJob: Job? = null
+
+  // Job for collecting storage change events
+  private var storageChangeJob: Job? = null
+
+  // Storage subscription manager for SharedPreferences inspection
+  private lateinit var storageSubscriptionManager: StorageSubscriptionManager
 
   private val commandReceiver =
       object : BroadcastReceiver() {
@@ -353,8 +360,21 @@ class AutoMobileAccessibilityService : AccessibilityService() {
               }
               .launchIn(serviceScope)
 
+      // Initialize storage subscription manager for SharedPreferences inspection
+      storageSubscriptionManager = StorageSubscriptionManager(this)
+      Log.d(TAG, "Storage subscription manager initialized")
+
+      // Subscribe to storage change events and broadcast them
+      storageChangeJob =
+          storageSubscriptionManager.changeEvents
+              .onEach { event ->
+                Log.d(TAG, "Storage change: ${event.packageName}:${event.fileName} key=${event.key}")
+                broadcastStorageChange(event)
+              }
+              .launchIn(serviceScope)
+
       // Start WebSocket server with hierarchy, screenshot, swipe, text input, IME action,
-      // and clipboard callbacks
+      // clipboard, and storage callbacks
       webSocketServer =
           WebSocketServer(
               port = 8765,
@@ -443,6 +463,18 @@ class AutoMobileAccessibilityService : AccessibilityService() {
               onAddHighlight = { requestId, highlightId, shape ->
                 handleAddHighlight(requestId, highlightId, shape)
               },
+              onListPreferenceFiles = { requestId, packageName ->
+                handleListPreferenceFiles(requestId, packageName)
+              },
+              onGetPreferences = { requestId, packageName, fileName ->
+                handleGetPreferences(requestId, packageName, fileName)
+              },
+              onSubscribeStorage = { requestId, packageName, fileName ->
+                handleSubscribeStorage(requestId, packageName, fileName)
+              },
+              onUnsubscribeStorage = { requestId, packageName, fileName ->
+                handleUnsubscribeStorage(requestId, packageName, fileName)
+              },
           )
       webSocketServer.start()
       Log.d(TAG, "WebSocket server started on port 8765")
@@ -494,6 +526,13 @@ class AutoMobileAccessibilityService : AccessibilityService() {
 
     // Cancel navigation event flow subscription
     navigationEventJob?.cancel()
+
+    // Cancel storage change flow subscription and clean up manager
+    storageChangeJob?.cancel()
+    if (::storageSubscriptionManager.isInitialized) {
+      storageSubscriptionManager.destroy()
+      Log.d(TAG, "Storage subscription manager destroyed")
+    }
 
     // Reset debouncer
     if (::hierarchyDebouncer.isInitialized) {
@@ -3643,6 +3682,227 @@ class AutoMobileAccessibilityService : AccessibilityService() {
       )
     } catch (e: Exception) {
       Log.e(TAG, "Error broadcasting traversal order error", e)
+    }
+  }
+
+  // ================= Storage Inspection Methods =================
+
+  private fun handleListPreferenceFiles(requestId: String?, packageName: String) {
+    serviceScope.launch {
+      val result = storageSubscriptionManager.listPreferenceFiles(packageName)
+      result.fold(
+          onSuccess = { files ->
+            broadcastPreferenceFilesResult(requestId, packageName, files, null)
+          },
+          onFailure = { error ->
+            broadcastPreferenceFilesResult(requestId, packageName, null, error.message)
+          },
+      )
+    }
+  }
+
+  private fun handleGetPreferences(requestId: String?, packageName: String, fileName: String) {
+    serviceScope.launch {
+      val result = storageSubscriptionManager.getPreferences(packageName, fileName)
+      result.fold(
+          onSuccess = { entries ->
+            broadcastPreferencesResult(requestId, packageName, fileName, entries, null)
+          },
+          onFailure = { error ->
+            broadcastPreferencesResult(requestId, packageName, fileName, null, error.message)
+          },
+      )
+    }
+  }
+
+  private fun handleSubscribeStorage(requestId: String?, packageName: String, fileName: String) {
+    serviceScope.launch {
+      val result = storageSubscriptionManager.subscribe(packageName, fileName)
+      result.fold(
+          onSuccess = { subscription ->
+            broadcastSubscribeStorageResult(
+                requestId,
+                packageName,
+                fileName,
+                subscription.subscriptionId,
+                null,
+            )
+          },
+          onFailure = { error ->
+            broadcastSubscribeStorageResult(requestId, packageName, fileName, null, error.message)
+          },
+      )
+    }
+  }
+
+  private fun handleUnsubscribeStorage(requestId: String?, packageName: String, fileName: String) {
+    serviceScope.launch {
+      val success = storageSubscriptionManager.unsubscribe(packageName, fileName)
+      broadcastUnsubscribeStorageResult(requestId, packageName, fileName, success)
+    }
+  }
+
+  private suspend fun broadcastPreferenceFilesResult(
+      requestId: String?,
+      packageName: String,
+      files: List<dev.jasonpearson.automobile.accessibilityservice.storage.PreferenceFileInfo>?,
+      error: String?,
+  ) {
+    if (!::webSocketServer.isInitialized || !webSocketServer.isRunning()) {
+      Log.d(TAG, "WebSocket server not running, skipping preference files broadcast")
+      return
+    }
+
+    try {
+      val message = buildString {
+        append("""{"type":"preference_files","timestamp":${System.currentTimeMillis()}""")
+        if (requestId != null) {
+          append(""","requestId":"$requestId"""")
+        }
+        append(""","packageName":${jsonCompact.encodeToString(packageName)}""")
+        if (files != null) {
+          append(""","success":true,"files":${jsonCompact.encodeToString(files)}""")
+        } else {
+          append(""","success":false,"error":${jsonCompact.encodeToString(error ?: "Unknown error")}""")
+        }
+        append("}")
+      }
+      webSocketServer.broadcast(message)
+      Log.d(TAG, "Broadcasted preference files to ${webSocketServer.getConnectionCount()} clients")
+    } catch (e: Exception) {
+      Log.e(TAG, "Error broadcasting preference files", e)
+    }
+  }
+
+  private suspend fun broadcastPreferencesResult(
+      requestId: String?,
+      packageName: String,
+      fileName: String,
+      entries: List<dev.jasonpearson.automobile.accessibilityservice.storage.PreferenceEntry>?,
+      error: String?,
+  ) {
+    if (!::webSocketServer.isInitialized || !webSocketServer.isRunning()) {
+      Log.d(TAG, "WebSocket server not running, skipping preferences broadcast")
+      return
+    }
+
+    try {
+      val message = buildString {
+        append("""{"type":"preferences","timestamp":${System.currentTimeMillis()}""")
+        if (requestId != null) {
+          append(""","requestId":"$requestId"""")
+        }
+        append(""","packageName":${jsonCompact.encodeToString(packageName)}""")
+        append(""","fileName":${jsonCompact.encodeToString(fileName)}""")
+        if (entries != null) {
+          append(""","success":true,"entries":${jsonCompact.encodeToString(entries)}""")
+        } else {
+          append(""","success":false,"error":${jsonCompact.encodeToString(error ?: "Unknown error")}""")
+        }
+        append("}")
+      }
+      webSocketServer.broadcast(message)
+      Log.d(TAG, "Broadcasted preferences to ${webSocketServer.getConnectionCount()} clients")
+    } catch (e: Exception) {
+      Log.e(TAG, "Error broadcasting preferences", e)
+    }
+  }
+
+  private suspend fun broadcastSubscribeStorageResult(
+      requestId: String?,
+      packageName: String,
+      fileName: String,
+      subscriptionId: String?,
+      error: String?,
+  ) {
+    if (!::webSocketServer.isInitialized || !webSocketServer.isRunning()) {
+      Log.d(TAG, "WebSocket server not running, skipping subscribe storage broadcast")
+      return
+    }
+
+    try {
+      val message = buildString {
+        append("""{"type":"subscribe_storage_result","timestamp":${System.currentTimeMillis()}""")
+        if (requestId != null) {
+          append(""","requestId":"$requestId"""")
+        }
+        append(""","packageName":${jsonCompact.encodeToString(packageName)}""")
+        append(""","fileName":${jsonCompact.encodeToString(fileName)}""")
+        if (subscriptionId != null) {
+          append(""","success":true,"subscriptionId":${jsonCompact.encodeToString(subscriptionId)}""")
+        } else {
+          append(""","success":false,"error":${jsonCompact.encodeToString(error ?: "Unknown error")}""")
+        }
+        append("}")
+      }
+      webSocketServer.broadcast(message)
+      Log.d(TAG, "Broadcasted subscribe storage result to ${webSocketServer.getConnectionCount()} clients")
+    } catch (e: Exception) {
+      Log.e(TAG, "Error broadcasting subscribe storage result", e)
+    }
+  }
+
+  private suspend fun broadcastUnsubscribeStorageResult(
+      requestId: String?,
+      packageName: String,
+      fileName: String,
+      success: Boolean,
+  ) {
+    if (!::webSocketServer.isInitialized || !webSocketServer.isRunning()) {
+      Log.d(TAG, "WebSocket server not running, skipping unsubscribe storage broadcast")
+      return
+    }
+
+    try {
+      val message = buildString {
+        append("""{"type":"unsubscribe_storage_result","timestamp":${System.currentTimeMillis()}""")
+        if (requestId != null) {
+          append(""","requestId":"$requestId"""")
+        }
+        append(""","packageName":${jsonCompact.encodeToString(packageName)}""")
+        append(""","fileName":${jsonCompact.encodeToString(fileName)}""")
+        append(""","success":$success""")
+        append("}")
+      }
+      webSocketServer.broadcast(message)
+      Log.d(TAG, "Broadcasted unsubscribe storage result to ${webSocketServer.getConnectionCount()} clients")
+    } catch (e: Exception) {
+      Log.e(TAG, "Error broadcasting unsubscribe storage result", e)
+    }
+  }
+
+  private suspend fun broadcastStorageChange(
+      event: dev.jasonpearson.automobile.accessibilityservice.storage.PreferenceChangeEvent
+  ) {
+    if (!::webSocketServer.isInitialized || !webSocketServer.isRunning()) {
+      Log.d(TAG, "WebSocket server not running, skipping storage change broadcast")
+      return
+    }
+
+    try {
+      val message = buildString {
+        append("""{"type":"storage_changed","timestamp":${System.currentTimeMillis()}""")
+        append(""","packageName":${jsonCompact.encodeToString(event.packageName)}""")
+        append(""","fileName":${jsonCompact.encodeToString(event.fileName)}""")
+        if (event.key != null) {
+          append(""","key":${jsonCompact.encodeToString(event.key)}""")
+        } else {
+          append(""","key":null""")
+        }
+        if (event.value != null) {
+          append(""","value":${event.value}""") // Already JSON-encoded
+        } else {
+          append(""","value":null""")
+        }
+        append(""","valueType":${jsonCompact.encodeToString(event.type)}""")
+        append(""","eventTimestamp":${event.timestamp}""")
+        append(""","sequenceNumber":${event.sequenceNumber}""")
+        append("}")
+      }
+      webSocketServer.broadcast(message)
+      Log.d(TAG, "Broadcasted storage change to ${webSocketServer.getConnectionCount()} clients")
+    } catch (e: Exception) {
+      Log.e(TAG, "Error broadcasting storage change", e)
     }
   }
 }

--- a/android/accessibility-service/src/main/kotlin/dev/jasonpearson/automobile/accessibilityservice/WebSocketServer.kt
+++ b/android/accessibility-service/src/main/kotlin/dev/jasonpearson/automobile/accessibilityservice/WebSocketServer.kt
@@ -69,6 +69,9 @@ data class WebSocketRequest(
     val requestPermission: Boolean? = null,
     // Filtering/optimization control
     val disableAllFiltering: Boolean? = null, // If true, disable all filtering and optimizations
+    // Storage inspection parameters
+    val packageName: String? = null,
+    val fileName: String? = null,
 )
 
 /**
@@ -148,6 +151,17 @@ class WebSocketServer(
     private val onGetTraversalOrder: ((requestId: String?) -> Unit)? = null,
     private val onAddHighlight:
         ((requestId: String?, highlightId: String?, shape: HighlightShape?) -> Unit)? =
+        null,
+    // Storage inspection callbacks
+    private val onListPreferenceFiles: ((requestId: String?, packageName: String) -> Unit)? = null,
+    private val onGetPreferences:
+        ((requestId: String?, packageName: String, fileName: String) -> Unit)? =
+        null,
+    private val onSubscribeStorage:
+        ((requestId: String?, packageName: String, fileName: String) -> Unit)? =
+        null,
+    private val onUnsubscribeStorage:
+        ((requestId: String?, packageName: String, fileName: String) -> Unit)? =
         null,
 ) {
   companion object {
@@ -558,6 +572,45 @@ class WebSocketServer(
         "add_highlight" -> {
           Log.d(TAG, "Received add_highlight request (requestId: ${request.requestId})")
           onAddHighlight?.invoke(request.requestId, request.id, request.shape)
+        }
+        "list_preference_files" -> {
+          Log.d(TAG, "Received list_preference_files request (requestId: ${request.requestId})")
+          val packageName = request.packageName
+          if (!packageName.isNullOrBlank()) {
+            onListPreferenceFiles?.invoke(request.requestId, packageName)
+          } else {
+            Log.w(TAG, "list_preference_files request missing packageName")
+          }
+        }
+        "get_preferences" -> {
+          Log.d(TAG, "Received get_preferences request (requestId: ${request.requestId})")
+          val packageName = request.packageName
+          val fileName = request.fileName
+          if (!packageName.isNullOrBlank() && !fileName.isNullOrBlank()) {
+            onGetPreferences?.invoke(request.requestId, packageName, fileName)
+          } else {
+            Log.w(TAG, "get_preferences request missing packageName or fileName")
+          }
+        }
+        "subscribe_storage" -> {
+          Log.d(TAG, "Received subscribe_storage request (requestId: ${request.requestId})")
+          val packageName = request.packageName
+          val fileName = request.fileName
+          if (!packageName.isNullOrBlank() && !fileName.isNullOrBlank()) {
+            onSubscribeStorage?.invoke(request.requestId, packageName, fileName)
+          } else {
+            Log.w(TAG, "subscribe_storage request missing packageName or fileName")
+          }
+        }
+        "unsubscribe_storage" -> {
+          Log.d(TAG, "Received unsubscribe_storage request (requestId: ${request.requestId})")
+          val packageName = request.packageName
+          val fileName = request.fileName
+          if (!packageName.isNullOrBlank() && !fileName.isNullOrBlank()) {
+            onUnsubscribeStorage?.invoke(request.requestId, packageName, fileName)
+          } else {
+            Log.w(TAG, "unsubscribe_storage request missing packageName or fileName")
+          }
         }
         else -> {
           Log.d(TAG, "Unknown message type: ${request.type}")

--- a/android/accessibility-service/src/main/kotlin/dev/jasonpearson/automobile/accessibilityservice/storage/StorageModels.kt
+++ b/android/accessibility-service/src/main/kotlin/dev/jasonpearson/automobile/accessibilityservice/storage/StorageModels.kt
@@ -1,0 +1,46 @@
+package dev.jasonpearson.automobile.accessibilityservice.storage
+
+import kotlinx.serialization.Serializable
+
+/** Represents an active subscription to SharedPreferences file changes. */
+@Serializable
+data class StorageSubscription(
+    val packageName: String,
+    val fileName: String,
+    val subscriptionId: String = "$packageName:$fileName",
+)
+
+/** Information about a SharedPreferences file. */
+@Serializable
+data class PreferenceFileInfo(
+    val name: String,
+    val path: String,
+    val entryCount: Int,
+)
+
+/** A key-value entry from SharedPreferences. */
+@Serializable
+data class PreferenceEntry(
+    val key: String,
+    /** JSON-encoded value (null if the value itself is null). */
+    val value: String?,
+    /** Type name matching SDK KeyValueType enum. */
+    val type: String,
+)
+
+/** A change event for a preference value. */
+@Serializable
+data class PreferenceChangeEvent(
+    val packageName: String,
+    val fileName: String,
+    /** The key that changed, or null if the file was cleared. */
+    val key: String?,
+    /** JSON-encoded new value (null if key was removed). */
+    val value: String?,
+    /** Type name matching SDK KeyValueType enum. */
+    val type: String,
+    /** Timestamp when the change occurred (milliseconds since epoch). */
+    val timestamp: Long,
+    /** Monotonically increasing sequence number for ordering changes. */
+    val sequenceNumber: Long,
+)

--- a/android/accessibility-service/src/main/kotlin/dev/jasonpearson/automobile/accessibilityservice/storage/StorageSubscriptionManager.kt
+++ b/android/accessibility-service/src/main/kotlin/dev/jasonpearson/automobile/accessibilityservice/storage/StorageSubscriptionManager.kt
@@ -1,0 +1,396 @@
+package dev.jasonpearson.automobile.accessibilityservice.storage
+
+import android.content.ContentResolver
+import android.content.Context
+import android.database.ContentObserver
+import android.net.Uri
+import android.os.Bundle
+import android.os.Handler
+import android.os.Looper
+import android.util.Log
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import org.json.JSONArray
+import org.json.JSONObject
+
+/**
+ * Manages subscriptions to SharedPreferences changes across multiple target apps.
+ *
+ * Uses ContentProvider.call() to communicate with SDK-instrumented apps and ContentObserver to
+ * receive push notifications when changes occur.
+ */
+class StorageSubscriptionManager(
+    private val context: Context,
+) {
+
+  companion object {
+    private const val TAG = "StorageSubscriptionMgr"
+    private const val AUTHORITY_SUFFIX = ".automobile.sharedprefs"
+    private const val CHANGES_PATH = "changes"
+  }
+
+  /** State for a single subscription. */
+  private data class SubscriptionState(
+      val subscription: StorageSubscription,
+      var lastSequence: Long = 0,
+  )
+
+  /** State for a package being observed. */
+  private data class PackageObserverState(
+      val observer: ContentObserver,
+      val subscriptions: MutableSet<String> = mutableSetOf(), // file names
+  )
+
+  private val subscriptions = mutableMapOf<String, SubscriptionState>() // subscriptionId -> state
+  private val packageObservers = mutableMapOf<String, PackageObserverState>() // packageName -> state
+
+  private val _changeEvents = MutableSharedFlow<PreferenceChangeEvent>(extraBufferCapacity = 64)
+  val changeEvents: SharedFlow<PreferenceChangeEvent> = _changeEvents.asSharedFlow()
+
+  private val handler = Handler(Looper.getMainLooper())
+
+  /**
+   * Checks if the SDK is available and inspection is enabled for a package.
+   *
+   * @param packageName The target app package name
+   * @return Result with availability info or error
+   */
+  fun checkSdkAvailability(packageName: String): Result<SdkAvailabilityInfo> {
+    return try {
+      val authority = packageName + AUTHORITY_SUFFIX
+      val uri = Uri.parse("content://$authority")
+      val result = context.contentResolver.call(uri, "checkAvailability", null, null)
+
+      if (result == null) {
+        Result.failure(StorageError.SdkNotInstalled(packageName))
+      } else if (!result.getBoolean("success", false)) {
+        val error = result.getString("error") ?: "Unknown error"
+        val errorType = result.getString("errorType") ?: "UNKNOWN"
+        if (errorType == "DISABLED") {
+          Result.failure(StorageError.InspectionDisabled(packageName))
+        } else {
+          Result.failure(StorageError.SdkError(error))
+        }
+      } else {
+        val json = JSONObject(result.getString("result") ?: "{}")
+        Result.success(
+            SdkAvailabilityInfo(
+                available = json.optBoolean("available", false),
+                version = json.optInt("version", 0),
+            )
+        )
+      }
+    } catch (e: SecurityException) {
+      Result.failure(StorageError.SdkNotInstalled(packageName))
+    } catch (e: IllegalArgumentException) {
+      Result.failure(StorageError.SdkNotInstalled(packageName))
+    } catch (e: Exception) {
+      Log.e(TAG, "Error checking SDK availability for $packageName", e)
+      Result.failure(StorageError.SdkError(e.message ?: "Unknown error"))
+    }
+  }
+
+  /**
+   * Lists all SharedPreferences files in a package.
+   *
+   * @param packageName The target app package name
+   * @return Result with list of preference file info or error
+   */
+  fun listPreferenceFiles(packageName: String): Result<List<PreferenceFileInfo>> {
+    return try {
+      val authority = packageName + AUTHORITY_SUFFIX
+      val uri = Uri.parse("content://$authority")
+      val result = context.contentResolver.call(uri, "listFiles", null, null)
+
+      if (result == null) {
+        Result.failure(StorageError.SdkNotInstalled(packageName))
+      } else if (!result.getBoolean("success", false)) {
+        val error = result.getString("error") ?: "Unknown error"
+        Result.failure(StorageError.SdkError(error))
+      } else {
+        val json = JSONObject(result.getString("result") ?: "{}")
+        val filesArray = json.optJSONArray("files") ?: JSONArray()
+        val files =
+            (0 until filesArray.length()).map { i ->
+              val fileJson = filesArray.getJSONObject(i)
+              PreferenceFileInfo(
+                  name = fileJson.getString("name"),
+                  path = fileJson.getString("path"),
+                  entryCount = fileJson.getInt("entryCount"),
+              )
+            }
+        Result.success(files)
+      }
+    } catch (e: SecurityException) {
+      Result.failure(StorageError.SdkNotInstalled(packageName))
+    } catch (e: Exception) {
+      Log.e(TAG, "Error listing preference files for $packageName", e)
+      Result.failure(StorageError.SdkError(e.message ?: "Unknown error"))
+    }
+  }
+
+  /**
+   * Gets all preferences from a file.
+   *
+   * @param packageName The target app package name
+   * @param fileName The preferences file name
+   * @return Result with list of preference entries or error
+   */
+  fun getPreferences(packageName: String, fileName: String): Result<List<PreferenceEntry>> {
+    return try {
+      val authority = packageName + AUTHORITY_SUFFIX
+      val uri = Uri.parse("content://$authority")
+      val extras = Bundle().apply { putString("fileName", fileName) }
+      val result = context.contentResolver.call(uri, "getPreferences", null, extras)
+
+      if (result == null) {
+        Result.failure(StorageError.SdkNotInstalled(packageName))
+      } else if (!result.getBoolean("success", false)) {
+        val error = result.getString("error") ?: "Unknown error"
+        val errorType = result.getString("errorType")
+        if (errorType == "FileNotFound") {
+          Result.failure(StorageError.FileNotFound(fileName))
+        } else {
+          Result.failure(StorageError.SdkError(error))
+        }
+      } else {
+        val json = JSONObject(result.getString("result") ?: "{}")
+        val entriesArray = json.optJSONArray("entries") ?: JSONArray()
+        val entries =
+            (0 until entriesArray.length()).map { i ->
+              val entryJson = entriesArray.getJSONObject(i)
+              PreferenceEntry(
+                  key = entryJson.getString("key"),
+                  value = serializeJsonValue(entryJson.opt("value")),
+                  type = entryJson.getString("type"),
+              )
+            }
+        Result.success(entries)
+      }
+    } catch (e: SecurityException) {
+      Result.failure(StorageError.SdkNotInstalled(packageName))
+    } catch (e: Exception) {
+      Log.e(TAG, "Error getting preferences for $packageName:$fileName", e)
+      Result.failure(StorageError.SdkError(e.message ?: "Unknown error"))
+    }
+  }
+
+  /**
+   * Subscribes to changes on a SharedPreferences file.
+   *
+   * @param packageName The target app package name
+   * @param fileName The preferences file name
+   * @return Result with subscription info or error
+   */
+  fun subscribe(packageName: String, fileName: String): Result<StorageSubscription> {
+    val subscriptionId = "$packageName:$fileName"
+
+    // Check if already subscribed
+    if (subscriptions.containsKey(subscriptionId)) {
+      return Result.success(subscriptions[subscriptionId]!!.subscription)
+    }
+
+    return try {
+      val authority = packageName + AUTHORITY_SUFFIX
+      val uri = Uri.parse("content://$authority")
+      val extras = Bundle().apply { putString("fileName", fileName) }
+      val result = context.contentResolver.call(uri, "subscribeToFile", null, extras)
+
+      if (result == null) {
+        Result.failure(StorageError.SdkNotInstalled(packageName))
+      } else if (!result.getBoolean("success", false)) {
+        val error = result.getString("error") ?: "Unknown error"
+        Result.failure(StorageError.SdkError(error))
+      } else {
+        val subscription = StorageSubscription(packageName, fileName, subscriptionId)
+
+        // Track the subscription
+        subscriptions[subscriptionId] = SubscriptionState(subscription)
+
+        // Register ContentObserver for this package if not already registered
+        registerPackageObserver(packageName, fileName)
+
+        Log.d(TAG, "Subscribed to $subscriptionId")
+        Result.success(subscription)
+      }
+    } catch (e: SecurityException) {
+      Result.failure(StorageError.SdkNotInstalled(packageName))
+    } catch (e: Exception) {
+      Log.e(TAG, "Error subscribing to $packageName:$fileName", e)
+      Result.failure(StorageError.SdkError(e.message ?: "Unknown error"))
+    }
+  }
+
+  /**
+   * Unsubscribes from changes on a SharedPreferences file.
+   *
+   * @param packageName The target app package name
+   * @param fileName The preferences file name
+   * @return true if unsubscribed successfully, false if not subscribed
+   */
+  fun unsubscribe(packageName: String, fileName: String): Boolean {
+    val subscriptionId = "$packageName:$fileName"
+
+    if (!subscriptions.containsKey(subscriptionId)) {
+      return false
+    }
+
+    try {
+      val authority = packageName + AUTHORITY_SUFFIX
+      val uri = Uri.parse("content://$authority")
+      val extras = Bundle().apply { putString("fileName", fileName) }
+      context.contentResolver.call(uri, "unsubscribeFromFile", null, extras)
+    } catch (e: Exception) {
+      Log.w(TAG, "Error unsubscribing from SDK (may be expected if app was uninstalled)", e)
+    }
+
+    // Remove the subscription
+    subscriptions.remove(subscriptionId)
+
+    // Unregister package observer if no more subscriptions for this package
+    unregisterPackageObserverIfUnused(packageName, fileName)
+
+    Log.d(TAG, "Unsubscribed from $subscriptionId")
+    return true
+  }
+
+  /** Returns all active subscriptions. */
+  fun getActiveSubscriptions(): List<StorageSubscription> {
+    return subscriptions.values.map { it.subscription }
+  }
+
+  /** Cleans up all subscriptions and observers. Call when the service is destroyed. */
+  fun destroy() {
+    // Unsubscribe from all
+    subscriptions.keys.toList().forEach { subscriptionId ->
+      val parts = subscriptionId.split(":", limit = 2)
+      if (parts.size == 2) {
+        unsubscribe(parts[0], parts[1])
+      }
+    }
+
+    // Clear any remaining state
+    subscriptions.clear()
+    packageObservers.clear()
+  }
+
+  private fun registerPackageObserver(packageName: String, fileName: String) {
+    val existingState = packageObservers[packageName]
+    if (existingState != null) {
+      existingState.subscriptions.add(fileName)
+      return
+    }
+
+    val authority = packageName + AUTHORITY_SUFFIX
+    val changesUri = Uri.parse("content://$authority/$CHANGES_PATH")
+
+    val observer =
+        object : ContentObserver(handler) {
+          override fun onChange(selfChange: Boolean) {
+            super.onChange(selfChange)
+            Log.d(TAG, "ContentObserver notified for $packageName")
+            fetchChangesForPackage(packageName)
+          }
+        }
+
+    try {
+      context.contentResolver.registerContentObserver(changesUri, false, observer)
+      packageObservers[packageName] =
+          PackageObserverState(observer, mutableSetOf(fileName))
+      Log.d(TAG, "Registered ContentObserver for $packageName")
+    } catch (e: Exception) {
+      Log.e(TAG, "Failed to register ContentObserver for $packageName", e)
+    }
+  }
+
+  private fun unregisterPackageObserverIfUnused(packageName: String, fileName: String) {
+    val state = packageObservers[packageName] ?: return
+    state.subscriptions.remove(fileName)
+
+    if (state.subscriptions.isEmpty()) {
+      try {
+        context.contentResolver.unregisterContentObserver(state.observer)
+        Log.d(TAG, "Unregistered ContentObserver for $packageName")
+      } catch (e: Exception) {
+        Log.w(TAG, "Error unregistering ContentObserver", e)
+      }
+      packageObservers.remove(packageName)
+    }
+  }
+
+  private fun fetchChangesForPackage(packageName: String) {
+    val state = packageObservers[packageName] ?: return
+    val authority = packageName + AUTHORITY_SUFFIX
+    val uri = Uri.parse("content://$authority")
+
+    for (fileName in state.subscriptions.toList()) {
+      val subscriptionId = "$packageName:$fileName"
+      val subState = subscriptions[subscriptionId] ?: continue
+
+      try {
+        val extras =
+            Bundle().apply {
+              putString("fileName", fileName)
+              putLong("sinceSequence", subState.lastSequence)
+            }
+        val result = context.contentResolver.call(uri, "getChanges", null, extras)
+
+        if (result != null && result.getBoolean("success", false)) {
+          val json = JSONObject(result.getString("result") ?: "{}")
+          val changesArray = json.optJSONArray("changes") ?: JSONArray()
+
+          for (i in 0 until changesArray.length()) {
+            val changeJson = changesArray.getJSONObject(i)
+            val sequenceNumber = changeJson.getLong("sequenceNumber")
+
+            val event =
+                PreferenceChangeEvent(
+                    packageName = packageName,
+                    fileName = fileName,
+                    key = if (changeJson.isNull("key")) null else changeJson.getString("key"),
+                    value = serializeJsonValue(changeJson.opt("value")),
+                    type = changeJson.getString("type"),
+                    timestamp = changeJson.getLong("timestamp"),
+                    sequenceNumber = sequenceNumber,
+                )
+
+            _changeEvents.tryEmit(event)
+            subState.lastSequence = maxOf(subState.lastSequence, sequenceNumber)
+          }
+        }
+      } catch (e: Exception) {
+        Log.e(TAG, "Error fetching changes for $packageName:$fileName", e)
+      }
+    }
+  }
+
+  /** Converts a JSON value to a String representation for serialization. */
+  private fun serializeJsonValue(value: Any?): String? {
+    return when (value) {
+      null, JSONObject.NULL -> null
+      is JSONArray -> value.toString()
+      is JSONObject -> value.toString()
+      else -> value.toString()
+    }
+  }
+}
+
+/** Information about SDK availability. */
+data class SdkAvailabilityInfo(
+    val available: Boolean,
+    val version: Int,
+)
+
+/** Errors that can occur during storage operations. */
+sealed class StorageError(message: String) : Exception(message) {
+  class SdkNotInstalled(packageName: String) :
+      StorageError("SDK not installed in package: $packageName")
+
+  class InspectionDisabled(packageName: String) :
+      StorageError("SharedPreferences inspection is disabled in: $packageName")
+
+  class FileNotFound(fileName: String) : StorageError("Preferences file not found: $fileName")
+
+  class SdkError(message: String) : StorageError(message)
+}

--- a/android/accessibility-service/src/test/kotlin/dev/jasonpearson/automobile/accessibilityservice/storage/StorageSubscriptionManagerTest.kt
+++ b/android/accessibility-service/src/test/kotlin/dev/jasonpearson/automobile/accessibilityservice/storage/StorageSubscriptionManagerTest.kt
@@ -1,0 +1,313 @@
+package dev.jasonpearson.automobile.accessibilityservice.storage
+
+import android.content.ContentResolver
+import android.content.Context
+import android.net.Uri
+import android.os.Bundle
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class StorageSubscriptionManagerTest {
+
+  private lateinit var context: Context
+  private lateinit var contentResolver: ContentResolver
+  private lateinit var manager: StorageSubscriptionManager
+
+  @Before
+  fun setUp() {
+    contentResolver = mockk(relaxed = true)
+    context = mockk(relaxed = true)
+    every { context.contentResolver } returns contentResolver
+    manager = StorageSubscriptionManager(context)
+  }
+
+  // ================= SDK Availability Tests =================
+
+  @Test
+  fun `checkSdkAvailability returns failure when SDK not installed`() {
+    every { contentResolver.call(any<Uri>(), any(), any(), any()) } returns null
+
+    val result = manager.checkSdkAvailability("com.example.app")
+
+    assertTrue(result.isFailure)
+    assertTrue(result.exceptionOrNull() is StorageError.SdkNotInstalled)
+  }
+
+  @Test
+  fun `checkSdkAvailability returns failure when inspection disabled`() {
+    val bundle =
+        Bundle().apply {
+          putBoolean("success", false)
+          putString("errorType", "DISABLED")
+          putString("error", "Inspection is disabled")
+        }
+    every { contentResolver.call(any<Uri>(), eq("checkAvailability"), any(), any()) } returns bundle
+
+    val result = manager.checkSdkAvailability("com.example.app")
+
+    assertTrue(result.isFailure)
+    assertTrue(result.exceptionOrNull() is StorageError.InspectionDisabled)
+  }
+
+  @Test
+  fun `checkSdkAvailability returns success with version info`() {
+    val bundle =
+        Bundle().apply {
+          putBoolean("success", true)
+          putString("result", """{"available":true,"version":1}""")
+        }
+    every { contentResolver.call(any<Uri>(), eq("checkAvailability"), any(), any()) } returns bundle
+
+    val result = manager.checkSdkAvailability("com.example.app")
+
+    assertTrue(result.isSuccess)
+    val info = result.getOrNull()!!
+    assertTrue(info.available)
+    assertEquals(1, info.version)
+  }
+
+  // ================= List Preference Files Tests =================
+
+  @Test
+  fun `listPreferenceFiles returns files on success`() {
+    val bundle =
+        Bundle().apply {
+          putBoolean("success", true)
+          putString(
+              "result",
+              """{"files":[{"name":"auth","path":"/data/auth.xml","entryCount":5},{"name":"settings","path":"/data/settings.xml","entryCount":3}]}""",
+          )
+        }
+    every { contentResolver.call(any<Uri>(), eq("listFiles"), any(), any()) } returns bundle
+
+    val result = manager.listPreferenceFiles("com.example.app")
+
+    assertTrue(result.isSuccess)
+    val files = result.getOrNull()!!
+    assertEquals(2, files.size)
+    assertEquals("auth", files[0].name)
+    assertEquals(5, files[0].entryCount)
+    assertEquals("settings", files[1].name)
+    assertEquals(3, files[1].entryCount)
+  }
+
+  @Test
+  fun `listPreferenceFiles returns failure when SDK not installed`() {
+    every { contentResolver.call(any<Uri>(), eq("listFiles"), any(), any()) } returns null
+
+    val result = manager.listPreferenceFiles("com.example.app")
+
+    assertTrue(result.isFailure)
+    assertTrue(result.exceptionOrNull() is StorageError.SdkNotInstalled)
+  }
+
+  // ================= Get Preferences Tests =================
+
+  @Test
+  fun `getPreferences returns entries on success`() {
+    val bundle =
+        Bundle().apply {
+          putBoolean("success", true)
+          putString(
+              "result",
+              """{"entries":[{"key":"username","value":"john","type":"STRING"},{"key":"count","value":"42","type":"INT"}]}""",
+          )
+        }
+    every { contentResolver.call(any<Uri>(), eq("getPreferences"), any(), any()) } returns bundle
+
+    val result = manager.getPreferences("com.example.app", "auth")
+
+    assertTrue(result.isSuccess)
+    val entries = result.getOrNull()!!
+    assertEquals(2, entries.size)
+    assertEquals("username", entries[0].key)
+    assertEquals("john", entries[0].value)
+    assertEquals("STRING", entries[0].type)
+    assertEquals("count", entries[1].key)
+    assertEquals("42", entries[1].value)
+    assertEquals("INT", entries[1].type)
+  }
+
+  @Test
+  fun `getPreferences returns failure for missing file`() {
+    val bundle =
+        Bundle().apply {
+          putBoolean("success", false)
+          putString("errorType", "FileNotFound")
+          putString("error", "File not found")
+        }
+    every { contentResolver.call(any<Uri>(), eq("getPreferences"), any(), any()) } returns bundle
+
+    val result = manager.getPreferences("com.example.app", "nonexistent")
+
+    assertTrue(result.isFailure)
+    assertTrue(result.exceptionOrNull() is StorageError.FileNotFound)
+  }
+
+  // ================= Subscribe Tests =================
+
+  @Test
+  fun `subscribe returns subscription on success`() {
+    val bundle =
+        Bundle().apply {
+          putBoolean("success", true)
+          putString("result", """{"fileName":"auth","subscribed":true}""")
+        }
+    every { contentResolver.call(any<Uri>(), eq("subscribeToFile"), any(), any()) } returns bundle
+
+    val result = manager.subscribe("com.example.app", "auth")
+
+    assertTrue(result.isSuccess)
+    val subscription = result.getOrNull()!!
+    assertEquals("com.example.app", subscription.packageName)
+    assertEquals("auth", subscription.fileName)
+    assertEquals("com.example.app:auth", subscription.subscriptionId)
+  }
+
+  @Test
+  fun `subscribe returns same subscription when already subscribed`() {
+    val bundle =
+        Bundle().apply {
+          putBoolean("success", true)
+          putString("result", """{"fileName":"auth","subscribed":true}""")
+        }
+    every { contentResolver.call(any<Uri>(), eq("subscribeToFile"), any(), any()) } returns bundle
+
+    // Subscribe twice
+    val result1 = manager.subscribe("com.example.app", "auth")
+    val result2 = manager.subscribe("com.example.app", "auth")
+
+    assertTrue(result1.isSuccess)
+    assertTrue(result2.isSuccess)
+    assertEquals(result1.getOrNull()?.subscriptionId, result2.getOrNull()?.subscriptionId)
+
+    // Should only call SDK once since second subscribe reuses existing
+    verify(exactly = 1) { contentResolver.call(any<Uri>(), eq("subscribeToFile"), any(), any()) }
+  }
+
+  @Test
+  fun `subscribe registers ContentObserver`() {
+    val bundle =
+        Bundle().apply {
+          putBoolean("success", true)
+          putString("result", """{"fileName":"auth","subscribed":true}""")
+        }
+    every { contentResolver.call(any<Uri>(), eq("subscribeToFile"), any(), any()) } returns bundle
+
+    manager.subscribe("com.example.app", "auth")
+
+    verify {
+      contentResolver.registerContentObserver(
+          match { it.toString().contains("com.example.app.automobile.sharedprefs") },
+          any(),
+          any(),
+      )
+    }
+  }
+
+  // ================= Unsubscribe Tests =================
+
+  @Test
+  fun `unsubscribe returns true when subscribed`() {
+    val subscribeBundle =
+        Bundle().apply {
+          putBoolean("success", true)
+          putString("result", """{"fileName":"auth","subscribed":true}""")
+        }
+    every { contentResolver.call(any<Uri>(), eq("subscribeToFile"), any(), any()) } returns
+        subscribeBundle
+    every { contentResolver.call(any<Uri>(), eq("unsubscribeFromFile"), any(), any()) } returns
+        Bundle()
+
+    manager.subscribe("com.example.app", "auth")
+    val result = manager.unsubscribe("com.example.app", "auth")
+
+    assertTrue(result)
+  }
+
+  @Test
+  fun `unsubscribe returns false when not subscribed`() {
+    val result = manager.unsubscribe("com.example.app", "nonexistent")
+
+    assertFalse(result)
+  }
+
+  @Test
+  fun `unsubscribe unregisters ContentObserver when no more subscriptions for package`() {
+    val subscribeBundle =
+        Bundle().apply {
+          putBoolean("success", true)
+          putString("result", """{"subscribed":true}""")
+        }
+    every { contentResolver.call(any<Uri>(), eq("subscribeToFile"), any(), any()) } returns
+        subscribeBundle
+    every { contentResolver.call(any<Uri>(), eq("unsubscribeFromFile"), any(), any()) } returns
+        Bundle()
+
+    manager.subscribe("com.example.app", "auth")
+    manager.unsubscribe("com.example.app", "auth")
+
+    verify { contentResolver.unregisterContentObserver(any()) }
+  }
+
+  // ================= Active Subscriptions Tests =================
+
+  @Test
+  fun `getActiveSubscriptions returns empty list initially`() {
+    val subscriptions = manager.getActiveSubscriptions()
+
+    assertTrue(subscriptions.isEmpty())
+  }
+
+  @Test
+  fun `getActiveSubscriptions returns all active subscriptions`() {
+    val bundle =
+        Bundle().apply {
+          putBoolean("success", true)
+          putString("result", """{"subscribed":true}""")
+        }
+    every { contentResolver.call(any<Uri>(), eq("subscribeToFile"), any(), any()) } returns bundle
+
+    manager.subscribe("com.example.app1", "auth")
+    manager.subscribe("com.example.app2", "settings")
+
+    val subscriptions = manager.getActiveSubscriptions()
+
+    assertEquals(2, subscriptions.size)
+    assertTrue(subscriptions.any { it.subscriptionId == "com.example.app1:auth" })
+    assertTrue(subscriptions.any { it.subscriptionId == "com.example.app2:settings" })
+  }
+
+  // ================= Destroy Tests =================
+
+  @Test
+  fun `destroy clears all subscriptions`() {
+    val subscribeBundle =
+        Bundle().apply {
+          putBoolean("success", true)
+          putString("result", """{"subscribed":true}""")
+        }
+    every { contentResolver.call(any<Uri>(), eq("subscribeToFile"), any(), any()) } returns
+        subscribeBundle
+    every { contentResolver.call(any<Uri>(), eq("unsubscribeFromFile"), any(), any()) } returns
+        Bundle()
+
+    manager.subscribe("com.example.app", "auth")
+    manager.subscribe("com.example.app", "settings")
+
+    manager.destroy()
+
+    assertTrue(manager.getActiveSubscriptions().isEmpty())
+  }
+}

--- a/android/auto-mobile-sdk/src/debug/kotlin/dev/jasonpearson/automobile/sdk/storage/SharedPreferencesInspectorProvider.kt
+++ b/android/auto-mobile-sdk/src/debug/kotlin/dev/jasonpearson/automobile/sdk/storage/SharedPreferencesInspectorProvider.kt
@@ -42,11 +42,23 @@ class SharedPreferencesInspectorProvider : ContentProvider() {
     }
 
     try {
+      // checkAvailability doesn't require the driver to be initialized
+      if (method == "checkAvailability") {
+        val response = handleCheckAvailability()
+        result.putBoolean("success", true)
+        result.putString("result", response.toString())
+        return result
+      }
+
       val driver = SharedPreferencesInspector.getDriver()
       val response =
         when (method) {
           "listFiles" -> handleListFiles(driver)
           "getPreferences" -> handleGetPreferences(driver, extras)
+          "subscribeToFile" -> handleSubscribeToFile(driver, extras)
+          "unsubscribeFromFile" -> handleUnsubscribeFromFile(driver, extras)
+          "getChanges" -> handleGetChanges(driver, extras)
+          "getListenedFiles" -> handleGetListenedFiles(driver)
           else -> throw IllegalArgumentException("Unknown method: $method")
         }
       result.putBoolean("success", true)
@@ -130,6 +142,125 @@ class SharedPreferencesInspectorProvider : ContentProvider() {
       }
       else -> value ?: JSONObject.NULL
     }
+  }
+
+  /**
+   * Handles checkAvailability - returns SDK availability and version.
+   *
+   * This method works even when the driver isn't initialized, returning:
+   * - available: true (always true when inspection is enabled)
+   * - version: API version number for compatibility checking
+   */
+  private fun handleCheckAvailability(): JSONObject {
+    return JSONObject().apply {
+      put("available", true)
+      put("version", 1)
+    }
+  }
+
+  /**
+   * Handles subscribeToFile - starts listening for changes on a preference file.
+   *
+   * @param extras Must contain "fileName" string
+   * @return JSON with success status and subscription info
+   */
+  private fun handleSubscribeToFile(driver: SharedPreferencesDriver, extras: Bundle?): JSONObject {
+    val fileName =
+      extras?.getString("fileName") ?: throw IllegalArgumentException("fileName required")
+
+    val driverImpl =
+      driver as? SharedPreferencesDriverImpl
+        ?: throw IllegalStateException("Driver must be SharedPreferencesDriverImpl")
+
+    driverImpl.startListening(fileName)
+
+    return JSONObject().apply {
+      put("fileName", fileName)
+      put("subscribed", true)
+    }
+  }
+
+  /**
+   * Handles unsubscribeFromFile - stops listening for changes on a preference file.
+   *
+   * @param extras Must contain "fileName" string
+   * @return JSON with success status
+   */
+  private fun handleUnsubscribeFromFile(
+    driver: SharedPreferencesDriver,
+    extras: Bundle?,
+  ): JSONObject {
+    val fileName =
+      extras?.getString("fileName") ?: throw IllegalArgumentException("fileName required")
+
+    val driverImpl =
+      driver as? SharedPreferencesDriverImpl
+        ?: throw IllegalStateException("Driver must be SharedPreferencesDriverImpl")
+
+    driverImpl.stopListening(fileName)
+
+    return JSONObject().apply {
+      put("fileName", fileName)
+      put("subscribed", false)
+    }
+  }
+
+  /**
+   * Handles getChanges - returns queued changes for a file since a sequence number.
+   *
+   * @param extras Must contain "fileName" string, optionally "sinceSequence" long
+   * @return JSON with array of changes
+   */
+  private fun handleGetChanges(driver: SharedPreferencesDriver, extras: Bundle?): JSONObject {
+    val fileName =
+      extras?.getString("fileName") ?: throw IllegalArgumentException("fileName required")
+    val sinceSequence = extras?.getLong("sinceSequence", 0L) ?: 0L
+
+    val driverImpl =
+      driver as? SharedPreferencesDriverImpl
+        ?: throw IllegalStateException("Driver must be SharedPreferencesDriverImpl")
+
+    val changes = driverImpl.getQueuedChanges(fileName, sinceSequence)
+    val changesArray = JSONArray()
+
+    changes.forEach { change ->
+      changesArray.put(
+        JSONObject().apply {
+          put("fileName", change.fileName)
+          if (change.key != null) {
+            put("key", change.key)
+          } else {
+            put("key", JSONObject.NULL)
+          }
+          put("value", serializeValue(change.newValue, change.type))
+          put("type", change.type.name)
+          put("timestamp", change.timestamp)
+          put("sequenceNumber", change.sequenceNumber)
+        }
+      )
+    }
+
+    return JSONObject().apply {
+      put("fileName", fileName)
+      put("changes", changesArray)
+    }
+  }
+
+  /**
+   * Handles getListenedFiles - returns list of files currently being monitored.
+   *
+   * @return JSON with array of file names
+   */
+  private fun handleGetListenedFiles(driver: SharedPreferencesDriver): JSONObject {
+    val driverImpl =
+      driver as? SharedPreferencesDriverImpl
+        ?: throw IllegalStateException("Driver must be SharedPreferencesDriverImpl")
+
+    val files = driverImpl.getListenedFiles()
+    val filesArray = JSONArray()
+    files.forEach { filesArray.put(it) }
+
+    return JSONObject().apply { put("files", filesArray) }
   }
 
   // Required ContentProvider methods - not used for content call

--- a/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/storage/KeyValueModels.kt
+++ b/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/storage/KeyValueModels.kt
@@ -41,3 +41,23 @@ fun interface OnPreferenceChangeListener {
    */
   fun onPreferenceChanged(fileName: String, key: String?)
 }
+
+/**
+ * Represents a change to a SharedPreferences value.
+ *
+ * Used for push-based change notifications to external observers.
+ */
+data class PreferenceChange(
+  /** The name of the preferences file that changed. */
+  val fileName: String,
+  /** The key that changed, or null if the file was cleared. */
+  val key: String?,
+  /** The new value, or null if the key was removed. */
+  val newValue: Any?,
+  /** The type of the value. */
+  val type: KeyValueType,
+  /** Timestamp when the change occurred (milliseconds since epoch). */
+  val timestamp: Long,
+  /** Monotonically increasing sequence number for ordering changes. */
+  val sequenceNumber: Long,
+)

--- a/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/storage/SharedPreferencesDriverImpl.kt
+++ b/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/storage/SharedPreferencesDriverImpl.kt
@@ -2,8 +2,10 @@ package dev.jasonpearson.automobile.sdk.storage
 
 import android.content.Context
 import android.content.SharedPreferences
+import android.net.Uri
 import java.io.File
 import java.util.concurrent.CopyOnWriteArrayList
+import java.util.concurrent.atomic.AtomicLong
 
 /**
  * Android implementation of SharedPreferencesDriver that uses the SharedPreferences API.
@@ -16,9 +18,23 @@ class SharedPreferencesDriverImpl(
   private val fileSystemOperations: FileSystemOperations = RealFileSystemOperations(),
 ) : SharedPreferencesDriver {
 
+  companion object {
+    /** URI authority suffix for change notifications. */
+    const val CHANGES_AUTHORITY_SUFFIX = ".automobile.sharedprefs"
+
+    /** URI path for change notifications. */
+    const val CHANGES_PATH = "changes"
+  }
+
   private val listeners = CopyOnWriteArrayList<OnPreferenceChangeListener>()
   private val sharedPrefsListeners =
     mutableMapOf<String, SharedPreferences.OnSharedPreferenceChangeListener>()
+
+  /** Per-file change queues for push-based notifications. */
+  private val changeQueues = mutableMapOf<String, CopyOnWriteArrayList<PreferenceChange>>()
+
+  /** Monotonically increasing sequence counter for ordering changes. */
+  private val sequenceCounter = AtomicLong(0)
 
   override fun getPreferenceFiles(): List<PreferenceFileDescriptor> {
     val sharedPrefsDir = File(context.applicationInfo.dataDir, "shared_prefs")
@@ -59,15 +75,37 @@ class SharedPreferencesDriverImpl(
   /**
    * Starts listening for changes on a specific preferences file.
    *
+   * Initializes a change queue for the file and registers a listener that:
+   * 1. Captures new values and queues changes with sequence numbers
+   * 2. Notifies registered listeners
+   * 3. Signals observers via ContentResolver.notifyChange()
+   *
    * @param fileName The preferences file name
    */
   internal fun startListening(fileName: String) {
     if (sharedPrefsListeners.containsKey(fileName)) return
 
+    // Initialize change queue for this file
+    changeQueues.getOrPut(fileName) { CopyOnWriteArrayList() }
+
     val prefs = context.getSharedPreferences(fileName, Context.MODE_PRIVATE)
     val sharedPrefsListener =
-      SharedPreferences.OnSharedPreferenceChangeListener { _, key ->
+      SharedPreferences.OnSharedPreferenceChangeListener { sharedPrefs, key ->
+        // Capture the new value
+        val newValue = if (key != null) sharedPrefs.all[key] else null
+        val type = detectType(newValue)
+        val timestamp = System.currentTimeMillis()
+        val sequence = sequenceCounter.incrementAndGet()
+
+        // Queue the change
+        val change = PreferenceChange(fileName, key, newValue, type, timestamp, sequence)
+        changeQueues[fileName]?.add(change)
+
+        // Notify registered listeners
         listeners.forEach { it.onPreferenceChanged(fileName, key) }
+
+        // Signal ContentObserver watchers
+        notifyChangesAvailable()
       }
 
     prefs.registerOnSharedPreferenceChangeListener(sharedPrefsListener)
@@ -77,6 +115,8 @@ class SharedPreferencesDriverImpl(
   /**
    * Stops listening for changes on a specific preferences file.
    *
+   * Also clears any queued changes for this file.
+   *
    * @param fileName The preferences file name
    */
   internal fun stopListening(fileName: String) {
@@ -84,11 +124,66 @@ class SharedPreferencesDriverImpl(
       val prefs = context.getSharedPreferences(fileName, Context.MODE_PRIVATE)
       prefs.unregisterOnSharedPreferenceChangeListener(listener)
     }
+    changeQueues.remove(fileName)
   }
 
   /** Stops listening on all preferences files. */
   internal fun stopAllListening() {
     sharedPrefsListeners.keys.toList().forEach { stopListening(it) }
+  }
+
+  /**
+   * Checks if the driver is actively listening for changes on a specific file.
+   *
+   * @param fileName The preferences file name
+   * @return true if listening on this file
+   */
+  internal fun isListening(fileName: String): Boolean {
+    return sharedPrefsListeners.containsKey(fileName)
+  }
+
+  /**
+   * Returns the list of files currently being listened to.
+   *
+   * @return List of preference file names with active listeners
+   */
+  internal fun getListenedFiles(): List<String> {
+    return sharedPrefsListeners.keys.toList()
+  }
+
+  /**
+   * Returns queued changes for a file since the given sequence number.
+   *
+   * Changes are returned and removed from the queue. Use sinceSequence=0 to get all changes.
+   *
+   * @param fileName The preferences file name
+   * @param sinceSequence Only return changes with sequenceNumber > sinceSequence
+   * @return List of changes since the given sequence number
+   */
+  internal fun getQueuedChanges(fileName: String, sinceSequence: Long): List<PreferenceChange> {
+    val queue = changeQueues[fileName] ?: return emptyList()
+
+    // Find changes after the given sequence
+    val changes = queue.filter { it.sequenceNumber > sinceSequence }
+
+    // Remove the returned changes from the queue
+    if (changes.isNotEmpty()) {
+      queue.removeAll(changes.toSet())
+    }
+
+    return changes
+  }
+
+  /** Notifies observers that changes are available via ContentResolver. */
+  private fun notifyChangesAvailable() {
+    try {
+      val authority = context.packageName + CHANGES_AUTHORITY_SUFFIX
+      val uri = Uri.parse("content://$authority/$CHANGES_PATH")
+      context.contentResolver.notifyChange(uri, null)
+    } catch (e: Exception) {
+      // Log but don't fail if notification fails
+      android.util.Log.w("SharedPreferencesDriver", "Failed to notify change", e)
+    }
   }
 
   private fun detectType(value: Any?): KeyValueType {

--- a/android/auto-mobile-sdk/src/test/kotlin/dev/jasonpearson/automobile/sdk/storage/FakeSharedPreferencesDriver.kt
+++ b/android/auto-mobile-sdk/src/test/kotlin/dev/jasonpearson/automobile/sdk/storage/FakeSharedPreferencesDriver.kt
@@ -1,11 +1,18 @@
 package dev.jasonpearson.automobile.sdk.storage
 
 import java.util.concurrent.CopyOnWriteArrayList
+import java.util.concurrent.atomic.AtomicLong
 
 /** Fake implementation of SharedPreferencesDriver for testing. */
 class FakeSharedPreferencesDriver : SharedPreferencesDriver {
   private val preferenceFiles = mutableMapOf<String, MutableMap<String, Any?>>()
   private val listeners = CopyOnWriteArrayList<OnPreferenceChangeListener>()
+  private val listenedFiles = mutableSetOf<String>()
+  private val changeQueues = mutableMapOf<String, CopyOnWriteArrayList<PreferenceChange>>()
+  private val sequenceCounter = AtomicLong(0)
+
+  /** Whether to record changes (simulates listening). */
+  var recordChanges: Boolean = true
 
   /**
    * Sets preferences data for a file.
@@ -26,6 +33,9 @@ class FakeSharedPreferencesDriver : SharedPreferencesDriver {
    */
   fun putPreference(fileName: String, key: String, value: Any?) {
     preferenceFiles.getOrPut(fileName) { mutableMapOf() }[key] = value
+    if (isListening(fileName)) {
+      queueChange(fileName, key, value)
+    }
     notifyListeners(fileName, key)
   }
 
@@ -37,6 +47,9 @@ class FakeSharedPreferencesDriver : SharedPreferencesDriver {
    */
   fun removePreference(fileName: String, key: String) {
     preferenceFiles[fileName]?.remove(key)
+    if (isListening(fileName)) {
+      queueChange(fileName, key, null)
+    }
     notifyListeners(fileName, key)
   }
 
@@ -47,16 +60,98 @@ class FakeSharedPreferencesDriver : SharedPreferencesDriver {
    */
   fun clearPreferences(fileName: String) {
     preferenceFiles[fileName]?.clear()
+    if (isListening(fileName)) {
+      queueChange(fileName, null, null)
+    }
     notifyListeners(fileName, null)
   }
 
-  /** Clears all stored preferences data. */
+  /** Clears all stored preferences data and resets listening state. */
   fun clear() {
     preferenceFiles.clear()
+    listenedFiles.clear()
+    changeQueues.clear()
   }
 
   private fun notifyListeners(fileName: String, key: String?) {
     listeners.forEach { it.onPreferenceChanged(fileName, key) }
+  }
+
+  private fun queueChange(fileName: String, key: String?, value: Any?) {
+    if (!recordChanges) return
+
+    val change =
+      PreferenceChange(
+        fileName = fileName,
+        key = key,
+        newValue = value,
+        type = detectType(value),
+        timestamp = System.currentTimeMillis(),
+        sequenceNumber = sequenceCounter.incrementAndGet(),
+      )
+    changeQueues.getOrPut(fileName) { CopyOnWriteArrayList() }.add(change)
+  }
+
+  /**
+   * Starts listening for changes on a specific preferences file.
+   *
+   * @param fileName The preferences file name
+   */
+  fun startListening(fileName: String) {
+    if (listenedFiles.contains(fileName)) return
+    listenedFiles.add(fileName)
+    changeQueues.getOrPut(fileName) { CopyOnWriteArrayList() }
+  }
+
+  /**
+   * Stops listening for changes on a specific preferences file.
+   *
+   * @param fileName The preferences file name
+   */
+  fun stopListening(fileName: String) {
+    listenedFiles.remove(fileName)
+    changeQueues.remove(fileName)
+  }
+
+  /** Stops listening on all preferences files. */
+  fun stopAllListening() {
+    listenedFiles.clear()
+    changeQueues.clear()
+  }
+
+  /**
+   * Checks if the driver is actively listening for changes on a specific file.
+   *
+   * @param fileName The preferences file name
+   * @return true if listening on this file
+   */
+  fun isListening(fileName: String): Boolean {
+    return listenedFiles.contains(fileName)
+  }
+
+  /**
+   * Returns the list of files currently being listened to.
+   *
+   * @return List of preference file names with active listeners
+   */
+  fun getListenedFiles(): List<String> {
+    return listenedFiles.toList()
+  }
+
+  /**
+   * Returns queued changes for a file since the given sequence number.
+   *
+   * @param fileName The preferences file name
+   * @param sinceSequence Only return changes with sequenceNumber > sinceSequence
+   * @return List of changes since the given sequence number
+   */
+  fun getQueuedChanges(fileName: String, sinceSequence: Long): List<PreferenceChange> {
+    val queue = changeQueues[fileName] ?: return emptyList()
+    val changes = queue.filter { it.sequenceNumber > sinceSequence }
+    if (changes.isNotEmpty()) {
+      queue.removeAll(changes.toSet())
+    }
+    return changes
   }
 
   override fun getPreferenceFiles(): List<PreferenceFileDescriptor> {

--- a/android/auto-mobile-sdk/src/test/kotlin/dev/jasonpearson/automobile/sdk/storage/FakeSharedPreferencesDriverTest.kt
+++ b/android/auto-mobile-sdk/src/test/kotlin/dev/jasonpearson/automobile/sdk/storage/FakeSharedPreferencesDriverTest.kt
@@ -211,4 +211,178 @@ class FakeSharedPreferencesDriverTest {
 
     assertTrue(driver.getPreferenceFiles().isEmpty())
   }
+
+  // ================= Subscription/Listening Tests =================
+
+  @Test
+  fun `startListening marks file as listened`() {
+    driver.setPreferences("prefs", mapOf("key" to "value"))
+
+    assertFalse(driver.isListening("prefs"))
+
+    driver.startListening("prefs")
+
+    assertTrue(driver.isListening("prefs"))
+  }
+
+  @Test
+  fun `stopListening removes file from listened set`() {
+    driver.setPreferences("prefs", mapOf("key" to "value"))
+    driver.startListening("prefs")
+    assertTrue(driver.isListening("prefs"))
+
+    driver.stopListening("prefs")
+
+    assertFalse(driver.isListening("prefs"))
+  }
+
+  @Test
+  fun `stopAllListening clears all listened files`() {
+    driver.setPreferences("prefs1", mapOf("key" to "value"))
+    driver.setPreferences("prefs2", mapOf("key" to "value"))
+    driver.startListening("prefs1")
+    driver.startListening("prefs2")
+
+    driver.stopAllListening()
+
+    assertFalse(driver.isListening("prefs1"))
+    assertFalse(driver.isListening("prefs2"))
+    assertTrue(driver.getListenedFiles().isEmpty())
+  }
+
+  @Test
+  fun `getListenedFiles returns all listened files`() {
+    driver.setPreferences("prefs1", mapOf())
+    driver.setPreferences("prefs2", mapOf())
+    driver.startListening("prefs1")
+    driver.startListening("prefs2")
+
+    val listened = driver.getListenedFiles()
+
+    assertEquals(2, listened.size)
+    assertTrue(listened.contains("prefs1"))
+    assertTrue(listened.contains("prefs2"))
+  }
+
+  @Test
+  fun `changes are queued when listening`() {
+    driver.setPreferences("prefs", mapOf())
+    driver.startListening("prefs")
+
+    driver.putPreference("prefs", "key1", "value1")
+    driver.putPreference("prefs", "key2", 42)
+
+    val changes = driver.getQueuedChanges("prefs", 0)
+
+    assertEquals(2, changes.size)
+    assertEquals("key1", changes[0].key)
+    assertEquals("value1", changes[0].newValue)
+    assertEquals(KeyValueType.STRING, changes[0].type)
+    assertEquals("key2", changes[1].key)
+    assertEquals(42, changes[1].newValue)
+    assertEquals(KeyValueType.INT, changes[1].type)
+  }
+
+  @Test
+  fun `changes are not queued when not listening`() {
+    driver.setPreferences("prefs", mapOf())
+    // Not calling startListening
+
+    driver.putPreference("prefs", "key", "value")
+
+    val changes = driver.getQueuedChanges("prefs", 0)
+    assertTrue(changes.isEmpty())
+  }
+
+  @Test
+  fun `getQueuedChanges removes returned changes from queue`() {
+    driver.setPreferences("prefs", mapOf())
+    driver.startListening("prefs")
+
+    driver.putPreference("prefs", "key1", "value1")
+    driver.putPreference("prefs", "key2", "value2")
+
+    val firstBatch = driver.getQueuedChanges("prefs", 0)
+    assertEquals(2, firstBatch.size)
+
+    val secondBatch = driver.getQueuedChanges("prefs", 0)
+    assertTrue(secondBatch.isEmpty())
+  }
+
+  @Test
+  fun `getQueuedChanges filters by sinceSequence`() {
+    driver.setPreferences("prefs", mapOf())
+    driver.startListening("prefs")
+
+    driver.putPreference("prefs", "key1", "value1")
+    driver.putPreference("prefs", "key2", "value2")
+    driver.putPreference("prefs", "key3", "value3")
+
+    // Get all changes to capture sequence numbers
+    val allChanges = driver.getQueuedChanges("prefs", 0)
+    assertEquals(3, allChanges.size)
+
+    // Re-add changes to test filtering
+    driver.putPreference("prefs", "key4", "value4")
+    driver.putPreference("prefs", "key5", "value5")
+
+    // Get changes since sequence 3 (should only get key4 and key5)
+    val newChanges = driver.getQueuedChanges("prefs", 3)
+    assertEquals(2, newChanges.size)
+    assertEquals("key4", newChanges[0].key)
+    assertEquals("key5", newChanges[1].key)
+  }
+
+  @Test
+  fun `sequence numbers are monotonically increasing`() {
+    driver.setPreferences("prefs", mapOf())
+    driver.startListening("prefs")
+
+    driver.putPreference("prefs", "key1", "value1")
+    driver.putPreference("prefs", "key2", "value2")
+    driver.putPreference("prefs", "key3", "value3")
+
+    val changes = driver.getQueuedChanges("prefs", 0)
+
+    assertTrue(changes[0].sequenceNumber < changes[1].sequenceNumber)
+    assertTrue(changes[1].sequenceNumber < changes[2].sequenceNumber)
+  }
+
+  @Test
+  fun `remove preference queues change with null value`() {
+    driver.setPreferences("prefs", mapOf("key" to "value"))
+    driver.startListening("prefs")
+
+    driver.removePreference("prefs", "key")
+
+    val changes = driver.getQueuedChanges("prefs", 0)
+    assertEquals(1, changes.size)
+    assertEquals("key", changes[0].key)
+    assertNull(changes[0].newValue)
+  }
+
+  @Test
+  fun `clear preferences queues change with null key`() {
+    driver.setPreferences("prefs", mapOf("key1" to "v1", "key2" to "v2"))
+    driver.startListening("prefs")
+
+    driver.clearPreferences("prefs")
+
+    val changes = driver.getQueuedChanges("prefs", 0)
+    assertEquals(1, changes.size)
+    assertNull(changes[0].key)
+    assertNull(changes[0].newValue)
+  }
+
+  @Test
+  fun `stopListening clears change queue for file`() {
+    driver.setPreferences("prefs", mapOf())
+    driver.startListening("prefs")
+    driver.putPreference("prefs", "key", "value")
+
+    driver.stopListening("prefs")
+
+    val changes = driver.getQueuedChanges("prefs", 0)
+    assertTrue(changes.isEmpty())
+  }
 }


### PR DESCRIPTION
## Summary

- Add push-based real-time change notifications for SharedPreferences inspection
- SDK queues changes with sequence numbers and signals via ContentObserver
- AccessibilityService subscribes to changes and broadcasts via WebSocket
- New WebSocket message types: `list_preference_files`, `get_preferences`, `subscribe_storage`, `unsubscribe_storage`, and `storage_changed` push notifications

## Architecture

```
IDE Plugin                    AccessibilityService              Target App (SDK)
    |                                |                                |
    |-- subscribe_storage ---------> |                                |
    |                                |-- subscribeToFile (CP) ------> |
    |                                |   registers ContentObserver    |
    |                                |                                |
    |                                |<-- contentResolver.notifyChange() (on pref change)
    |                                |-- getChanges (CP) -----------> |
    |<-- storage_changed ----------- |<-- queued changes -------------|
```

## Test Plan

- [x] SDK tests pass (`./gradlew -p android :auto-mobile-sdk:testDebugUnitTest`)
- [x] AccessibilityService tests pass (`./gradlew -p android :accessibility-service:testDebugUnitTest`)
- [x] Build succeeds for both modules
- [x] ktfmt validation passes

Closes #1062

🤖 Generated with [Claude Code](https://claude.com/claude-code)