### PR TITLE
fix: JSON-escape storage change values before broadcasting

### DIFF
--- a/android/accessibility-service/src/main/kotlin/dev/jasonpearson/automobile/accessibilityservice/AutoMobileAccessibilityService.kt
+++ b/android/accessibility-service/src/main/kotlin/dev/jasonpearson/automobile/accessibilityservice/AutoMobileAccessibilityService.kt
@@ -3890,7 +3890,7 @@ class AutoMobileAccessibilityService : AccessibilityService() {
           append(""","key":null""")
         }
         if (event.value != null) {
-          append(""","value":${event.value}""") // Already JSON-encoded
+          append(""","value":${jsonCompact.encodeToString(event.value)}""")
         } else {
           append(""","value":null""")
         }


### PR DESCRIPTION
## Summary

Fixes a bug in the SharedPreferences WebSocket messages feature where string values were being inserted directly into the JSON payload without proper quoting/escaping, producing invalid JSON like `"value":foo` instead of `"value":"foo"`.

## Changes

- Use `jsonCompact.encodeToString(event.value)` to properly JSON-encode the value before embedding in the message

## Test Plan

- [x] Build succeeds
- [x] Existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)