### PR TITLE
fix: preserve JSON types for non-string storage change values

### DIFF
--- a/android/accessibility-service/src/main/kotlin/dev/jasonpearson/automobile/accessibilityservice/AutoMobileAccessibilityService.kt
+++ b/android/accessibility-service/src/main/kotlin/dev/jasonpearson/automobile/accessibilityservice/AutoMobileAccessibilityService.kt
@@ -3890,7 +3890,10 @@ class AutoMobileAccessibilityService : AccessibilityService() {
           append(""","key":null""")
         }
         if (event.value != null) {
-          append(""","value":${jsonCompact.encodeToString(event.value)}""")
+          // STRING values need JSON encoding (quotes + escaping), other types are already valid JSON
+          val jsonValue =
+              if (event.type == "STRING") jsonCompact.encodeToString(event.value) else event.value
+          append(""","value":$jsonValue""")
         } else {
           append(""","value":null""")
         }


### PR DESCRIPTION
## Summary

Fixes a regression from #1090 where all storage change values were being JSON-encoded, causing non-string types (INT, BOOLEAN, STRING_SET, etc.) to be double-encoded and arrive as strings instead of their native JSON types.

## Problem

The previous fix (#1090) used `jsonCompact.encodeToString(event.value)` for all values. However, `serializeJsonValue()` in StorageSubscriptionManager already returns:
- For strings: raw text (needs quoting)
- For numbers/booleans: valid JSON literals (e.g., `123`, `true`)
- For arrays/objects: JSON strings (e.g., `["a","b"]`)

Wrapping all values with `encodeToString()` caused numbers to become `"123"` instead of `123`.

## Solution

Only JSON-encode STRING type values (for proper quoting/escaping). Other types are already valid JSON literals and should be inserted as-is.

## Test Plan

- [x] Build succeeds
- String values: `"value":"hello"` (properly quoted)
- Int values: `"value":123` (not `"123"`)
- Boolean values: `"value":true` (not `"true"`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)