### PR TITLE
feat: add storage inspection tools for SharedPreferences/DataStore

### DIFF
--- a/src/daemon/daemon.ts
+++ b/src/daemon/daemon.ts
@@ -28,7 +28,7 @@ import { startDeviceSnapshotSocketServer, stopDeviceSnapshotSocketServer } from 
 import { startAppearanceSocketServer, stopAppearanceSocketServer } from "./appearanceSocketServer";
 import { startPerformanceStreamSocketServer, stopPerformanceStreamSocketServer } from "./performanceStreamSocketServer";
 import { startPerformancePushSocketServer, stopPerformancePushSocketServer } from "./performancePushSocketServer";
-import { startObservationStreamSocketServer, stopObservationStreamSocketServer, getObservationStreamServer } from "./observationStreamSocketServer";
+import { startDeviceDataStreamSocketServer, stopDeviceDataStreamSocketServer, getDeviceDataStreamServer } from "./deviceDataStreamSocketServer";
 import { startFailuresStreamSocketServer, stopFailuresStreamSocketServer } from "./failuresStreamSocketServer";
 import { AccessibilityServiceClient } from "../features/observe/AccessibilityServiceClient";
 import { NavigationGraphManager } from "../features/navigation/NavigationGraphManager";
@@ -134,11 +134,11 @@ export class Daemon {
     await startAppearanceSocketServer();
     await startPerformanceStreamSocketServer();
     await startPerformancePushSocketServer();
-    await startObservationStreamSocketServer();
+    await startDeviceDataStreamSocketServer();
     await startFailuresStreamSocketServer();
 
     // Wire up callback to establish WebSocket connections when IDE plugins subscribe
-    this.setupObservationStreamCallback();
+    this.setupDeviceDataStreamCallback();
 
     startAppearanceSyncScheduler();
     this.startDeviceDisconnectMonitor();
@@ -485,8 +485,8 @@ export class Daemon {
    * the WebSocket connections to Android devices are established so that
    * hierarchy updates can flow continuously.
    */
-  private setupObservationStreamCallback(): void {
-    const server = getObservationStreamServer();
+  private setupDeviceDataStreamCallback(): void {
+    const server = getDeviceDataStreamServer();
     if (!server) {
       logger.warn("[Daemon] Observation stream server not available for callback setup");
       return;
@@ -548,7 +548,7 @@ export class Daemon {
    * Set up listener for navigation graph changes.
    * When the navigation graph changes, push updates to all subscribed IDE plugins.
    */
-  private setupNavigationGraphStreamListener(server: ReturnType<typeof getObservationStreamServer>): void {
+  private setupNavigationGraphStreamListener(server: ReturnType<typeof getDeviceDataStreamServer>): void {
     if (!server) {
       return;
     }
@@ -923,7 +923,7 @@ export class Daemon {
     await stopAppearanceSocketServer();
     await stopPerformanceStreamSocketServer();
     await stopPerformancePushSocketServer();
-    await stopObservationStreamSocketServer();
+    await stopDeviceDataStreamSocketServer();
     await stopFailuresStreamSocketServer();
     stopAppearanceSyncScheduler();
 

--- a/src/daemon/deviceDataStreamSocketServer.ts
+++ b/src/daemon/deviceDataStreamSocketServer.ts
@@ -5,17 +5,20 @@ import os from "node:os";
 import path from "node:path";
 import { logger } from "../utils/logger";
 import type { ViewHierarchyResult } from "../models";
+import type { StorageChangedEvent } from "../features/storage/storageTypes";
 
 // Use /tmp for socket when running with external emulator (Docker container with mounted home)
+// NOTE: Keep legacy socket path for backward compatibility with IDE plugin
+// (android/ide-plugin/.../ObservationStreamClient.kt hardcodes this path)
 const isExternalMode = process.env.AUTOMOBILE_EMULATOR_EXTERNAL === "true";
 const DEFAULT_SOCKET_PATH = isExternalMode
   ? "/tmp/auto-mobile-observation-stream.sock"
   : path.join(os.homedir(), ".auto-mobile", "observation-stream.sock");
 
 /**
- * Request format for observation stream socket
+ * Request format for device data stream socket
  */
-interface ObservationStreamRequest {
+interface DeviceDataStreamRequest {
   id: string;
   command: "subscribe" | "unsubscribe" | "request_observation" | "pong";
   deviceId?: string; // Optional: subscribe to specific device
@@ -68,9 +71,9 @@ export interface PerformanceStreamData {
 /**
  * Response/push message format
  */
-interface ObservationStreamMessage {
+interface DeviceDataStreamMessage {
   id?: string;
-  type: "subscription_response" | "hierarchy_update" | "screenshot_update" | "navigation_update" | "performance_update" | "ping" | "pong" | "error";
+  type: "subscription_response" | "hierarchy_update" | "screenshot_update" | "navigation_update" | "performance_update" | "storage_update" | "ping" | "pong" | "error";
   success?: boolean;
   error?: string;
   deviceId?: string;
@@ -81,6 +84,7 @@ interface ObservationStreamMessage {
   screenHeight?: number;
   navigationGraph?: NavigationGraphStreamData;
   performanceData?: PerformanceStreamData;
+  storageEvent?: StorageChangedEvent;
 }
 
 /**
@@ -100,7 +104,7 @@ interface Subscriber {
 export type OnSubscriberConnectedCallback = (deviceId: string | null) => void;
 
 /**
- * Socket server that streams observation updates (hierarchy + screenshot) to connected IDE plugins.
+ * Socket server that streams device data updates (hierarchy, screenshot, storage) to connected IDE plugins.
  *
  * Unlike other socket servers which are request-response, this one maintains persistent
  * connections and pushes updates when they arrive from devices.
@@ -110,12 +114,13 @@ export type OnSubscriberConnectedCallback = (deviceId: string | null) => void;
  * - Server responds: {"id": "1", "type": "subscription_response", "success": true}
  * - Server pushes: {"type": "hierarchy_update", "deviceId": "emulator-5554", "timestamp": 123, "data": {...}}
  * - Server pushes: {"type": "screenshot_update", "deviceId": "emulator-5554", "timestamp": 123, "screenshotBase64": "..."}
+ * - Server pushes: {"type": "storage_update", "deviceId": "emulator-5554", "timestamp": 123, "storageEvent": {...}}
  */
 // Keepalive configuration
 const KEEPALIVE_INTERVAL_MS = 10_000; // Send ping every 10 seconds
 const KEEPALIVE_TIMEOUT_MS = 30_000; // Consider dead if no activity for 30 seconds
 
-export class ObservationStreamSocketServer {
+export class DeviceDataStreamSocketServer {
   private server: NetServer | null = null;
   private socketPath: string;
   private subscribers: Map<string, Subscriber> = new Map();
@@ -151,13 +156,13 @@ export class ObservationStreamSocketServer {
 
     return new Promise((resolve, reject) => {
       this.server!.listen(this.socketPath, () => {
-        logger.info(`[ObservationStream] Socket listening on ${this.socketPath}`);
+        logger.info(`[DeviceDataStream] Socket listening on ${this.socketPath}`);
         this.startKeepalive();
         resolve();
       });
 
       this.server!.on("error", error => {
-        logger.error(`[ObservationStream] Socket error: ${error}`);
+        logger.error(`[DeviceDataStream] Socket error: ${error}`);
         reject(error);
       });
     });
@@ -196,7 +201,7 @@ export class ObservationStreamSocketServer {
     for (const [subscriptionId, subscriber] of this.subscribers) {
       // Check if socket is destroyed
       if (subscriber.socket.destroyed) {
-        logger.info(`[ObservationStream] Subscriber ${subscriptionId} socket destroyed, removing`);
+        logger.info(`[DeviceDataStream] Subscriber ${subscriptionId} socket destroyed, removing`);
         deadSubscribers.push(subscriptionId);
         continue;
       }
@@ -204,7 +209,7 @@ export class ObservationStreamSocketServer {
       // Check for timeout (no activity for too long)
       const timeSinceActivity = now - subscriber.lastActivity;
       if (timeSinceActivity > KEEPALIVE_TIMEOUT_MS) {
-        logger.warn(`[ObservationStream] Subscriber ${subscriptionId} timed out (${timeSinceActivity}ms since last activity), removing`);
+        logger.warn(`[DeviceDataStream] Subscriber ${subscriptionId} timed out (${timeSinceActivity}ms since last activity), removing`);
         deadSubscribers.push(subscriptionId);
         try {
           subscriber.socket.destroy();
@@ -215,7 +220,7 @@ export class ObservationStreamSocketServer {
       }
 
       // Send ping to keep connection alive and detect broken pipes
-      const pingMessage: ObservationStreamMessage = {
+      const pingMessage: DeviceDataStreamMessage = {
         type: "ping",
         timestamp: now,
       };
@@ -223,10 +228,10 @@ export class ObservationStreamSocketServer {
         const written = subscriber.socket.write(JSON.stringify(pingMessage) + "\n");
         if (!written) {
           // Write was buffered, socket might be slow or dead
-          logger.debug(`[ObservationStream] Ping to ${subscriptionId} was buffered (backpressure)`);
+          logger.debug(`[DeviceDataStream] Ping to ${subscriptionId} was buffered (backpressure)`);
         }
       } catch (error) {
-        logger.warn(`[ObservationStream] Failed to ping ${subscriptionId}: ${error}`);
+        logger.warn(`[DeviceDataStream] Failed to ping ${subscriptionId}: ${error}`);
         deadSubscribers.push(subscriptionId);
       }
     }
@@ -234,7 +239,7 @@ export class ObservationStreamSocketServer {
     // Remove dead subscribers
     for (const subscriptionId of deadSubscribers) {
       this.subscribers.delete(subscriptionId);
-      logger.info(`[ObservationStream] Removed dead subscriber ${subscriptionId}`);
+      logger.info(`[DeviceDataStream] Removed dead subscriber ${subscriptionId}`);
     }
   }
 
@@ -274,7 +279,7 @@ export class ObservationStreamSocketServer {
    * Push a hierarchy update to all subscribers interested in this device.
    */
   pushHierarchyUpdate(deviceId: string, hierarchy: ViewHierarchyResult): void {
-    const message: ObservationStreamMessage = {
+    const message: DeviceDataStreamMessage = {
       type: "hierarchy_update",
       deviceId,
       timestamp: hierarchy.updatedAt ?? Date.now(),
@@ -293,7 +298,7 @@ export class ObservationStreamSocketServer {
     screenWidth: number,
     screenHeight: number
   ): void {
-    const message: ObservationStreamMessage = {
+    const message: DeviceDataStreamMessage = {
       type: "screenshot_update",
       deviceId,
       timestamp: Date.now(),
@@ -310,7 +315,7 @@ export class ObservationStreamSocketServer {
    * Navigation graph updates are broadcast to all subscribers (not device-specific).
    */
   pushNavigationGraphUpdate(navigationGraph: NavigationGraphStreamData): void {
-    const message: ObservationStreamMessage = {
+    const message: DeviceDataStreamMessage = {
       type: "navigation_update",
       timestamp: Date.now(),
       navigationGraph,
@@ -323,11 +328,25 @@ export class ObservationStreamSocketServer {
    * Push a performance metrics update to all subscribers interested in this device.
    */
   pushPerformanceUpdate(deviceId: string, performanceData: PerformanceStreamData): void {
-    const message: ObservationStreamMessage = {
+    const message: DeviceDataStreamMessage = {
       type: "performance_update",
       deviceId,
       timestamp: Date.now(),
       performanceData,
+    };
+
+    this.broadcastToSubscribers(deviceId, message);
+  }
+
+  /**
+   * Push a storage change event to all subscribers interested in this device.
+   */
+  pushStorageUpdate(deviceId: string, event: StorageChangedEvent): void {
+    const message: DeviceDataStreamMessage = {
+      type: "storage_update",
+      deviceId,
+      timestamp: Date.now(),
+      storageEvent: event,
     };
 
     this.broadcastToSubscribers(deviceId, message);
@@ -340,7 +359,7 @@ export class ObservationStreamSocketServer {
     return this.subscribers.size;
   }
 
-  private broadcastToSubscribers(deviceId: string, message: ObservationStreamMessage): void {
+  private broadcastToSubscribers(deviceId: string, message: DeviceDataStreamMessage): void {
     const json = JSON.stringify(message) + "\n";
     let sentCount = 0;
     const deadSubscribers: string[] = [];
@@ -350,21 +369,21 @@ export class ObservationStreamSocketServer {
       if (subscriber.deviceId === null || subscriber.deviceId === deviceId) {
         // Check if socket is already destroyed
         if (subscriber.socket.destroyed) {
-          logger.warn(`[ObservationStream] Subscriber ${subscriptionId} socket already destroyed, skipping`);
+          logger.warn(`[DeviceDataStream] Subscriber ${subscriptionId} socket already destroyed, skipping`);
           deadSubscribers.push(subscriptionId);
           continue;
         }
 
         try {
           const result = subscriber.socket.write(json);
-          logger.info(`[ObservationStream] Write to ${subscriptionId} returned: ${result}, bytes: ${json.length}`);
+          logger.info(`[DeviceDataStream] Write to ${subscriptionId} returned: ${result}, bytes: ${json.length}`);
           if (result) {
             // Update last activity on successful write
             subscriber.lastActivity = Date.now();
           }
           sentCount++;
         } catch (error) {
-          logger.warn(`[ObservationStream] Failed to send to subscriber ${subscriptionId}: ${error}`);
+          logger.warn(`[DeviceDataStream] Failed to send to subscriber ${subscriptionId}: ${error}`);
           deadSubscribers.push(subscriptionId);
         }
       }
@@ -373,15 +392,15 @@ export class ObservationStreamSocketServer {
     // Remove dead subscribers
     for (const subscriptionId of deadSubscribers) {
       this.subscribers.delete(subscriptionId);
-      logger.info(`[ObservationStream] Removed dead subscriber ${subscriptionId}`);
+      logger.info(`[DeviceDataStream] Removed dead subscriber ${subscriptionId}`);
     }
 
     if (sentCount > 0) {
-      logger.info(`[ObservationStream] Pushed ${message.type} to ${sentCount} subscribers (device: ${deviceId})`);
+      logger.info(`[DeviceDataStream] Pushed ${message.type} to ${sentCount} subscribers (device: ${deviceId})`);
     }
   }
 
-  private broadcastToAllSubscribers(message: ObservationStreamMessage): void {
+  private broadcastToAllSubscribers(message: DeviceDataStreamMessage): void {
     const json = JSON.stringify(message) + "\n";
     let sentCount = 0;
     const deadSubscribers: string[] = [];
@@ -389,21 +408,21 @@ export class ObservationStreamSocketServer {
     for (const [subscriptionId, subscriber] of this.subscribers) {
       // Check if socket is already destroyed
       if (subscriber.socket.destroyed) {
-        logger.warn(`[ObservationStream] Subscriber ${subscriptionId} socket already destroyed, skipping`);
+        logger.warn(`[DeviceDataStream] Subscriber ${subscriptionId} socket already destroyed, skipping`);
         deadSubscribers.push(subscriptionId);
         continue;
       }
 
       try {
         const result = subscriber.socket.write(json);
-        logger.debug(`[ObservationStream] Write to ${subscriptionId} returned: ${result}, bytes: ${json.length}`);
+        logger.debug(`[DeviceDataStream] Write to ${subscriptionId} returned: ${result}, bytes: ${json.length}`);
         if (result) {
           // Update last activity on successful write
           subscriber.lastActivity = Date.now();
         }
         sentCount++;
       } catch (error) {
-        logger.warn(`[ObservationStream] Failed to send to subscriber ${subscriptionId}: ${error}`);
+        logger.warn(`[DeviceDataStream] Failed to send to subscriber ${subscriptionId}: ${error}`);
         deadSubscribers.push(subscriptionId);
       }
     }
@@ -411,11 +430,11 @@ export class ObservationStreamSocketServer {
     // Remove dead subscribers
     for (const subscriptionId of deadSubscribers) {
       this.subscribers.delete(subscriptionId);
-      logger.info(`[ObservationStream] Removed dead subscriber ${subscriptionId}`);
+      logger.info(`[DeviceDataStream] Removed dead subscriber ${subscriptionId}`);
     }
 
     if (sentCount > 0) {
-      logger.info(`[ObservationStream] Pushed ${message.type} to ${sentCount} subscribers`);
+      logger.info(`[DeviceDataStream] Pushed ${message.type} to ${sentCount} subscribers`);
     }
   }
 
@@ -435,7 +454,7 @@ export class ObservationStreamSocketServer {
               subscriptionId = result.subscriptionId;
             }
           }).catch(error => {
-            logger.error(`[ObservationStream] Request error: ${error}`);
+            logger.error(`[DeviceDataStream] Request error: ${error}`);
           });
         }
       }
@@ -444,12 +463,12 @@ export class ObservationStreamSocketServer {
     socket.on("close", () => {
       if (subscriptionId) {
         this.subscribers.delete(subscriptionId);
-        logger.info(`[ObservationStream] Subscriber ${subscriptionId} disconnected`);
+        logger.info(`[DeviceDataStream] Subscriber ${subscriptionId} disconnected`);
       }
     });
 
     socket.on("error", error => {
-      logger.error(`[ObservationStream] Connection error: ${error}`);
+      logger.error(`[DeviceDataStream] Connection error: ${error}`);
       if (subscriptionId) {
         this.subscribers.delete(subscriptionId);
       }
@@ -461,7 +480,7 @@ export class ObservationStreamSocketServer {
     line: string
   ): Promise<{ subscriptionId?: string } | void> {
     try {
-      const request = JSON.parse(line) as ObservationStreamRequest;
+      const request = JSON.parse(line) as DeviceDataStreamRequest;
 
       switch (request.command) {
         case "subscribe": {
@@ -473,21 +492,21 @@ export class ObservationStreamSocketServer {
             lastActivity: Date.now(),
           });
 
-          const response: ObservationStreamMessage = {
+          const response: DeviceDataStreamMessage = {
             id: request.id,
             type: "subscription_response",
             success: true,
           };
           socket.write(JSON.stringify(response) + "\n");
 
-          logger.info(`[ObservationStream] New subscriber ${subscriptionId} (device: ${request.deviceId ?? "all"})`);
+          logger.info(`[DeviceDataStream] New subscriber ${subscriptionId} (device: ${request.deviceId ?? "all"})`);
 
           // Trigger device WebSocket connections for real-time updates
           if (this.onSubscriberConnected) {
             try {
               this.onSubscriberConnected(request.deviceId ?? null);
             } catch (error) {
-              logger.warn(`[ObservationStream] Error in onSubscriberConnected callback: ${error}`);
+              logger.warn(`[DeviceDataStream] Error in onSubscriberConnected callback: ${error}`);
             }
           }
 
@@ -499,12 +518,12 @@ export class ObservationStreamSocketServer {
           for (const [subId, subscriber] of this.subscribers) {
             if (subscriber.socket === socket) {
               this.subscribers.delete(subId);
-              logger.info(`[ObservationStream] Unsubscribed ${subId}`);
+              logger.info(`[DeviceDataStream] Unsubscribed ${subId}`);
               break;
             }
           }
 
-          const response: ObservationStreamMessage = {
+          const response: DeviceDataStreamMessage = {
             id: request.id,
             type: "subscription_response",
             success: true,
@@ -516,7 +535,7 @@ export class ObservationStreamSocketServer {
         case "request_observation": {
           // This could trigger an immediate observation request
           // For now, just acknowledge - the caller should use MCP observe tool
-          const response: ObservationStreamMessage = {
+          const response: DeviceDataStreamMessage = {
             id: request.id,
             type: "subscription_response",
             success: true,
@@ -530,7 +549,7 @@ export class ObservationStreamSocketServer {
           for (const [, subscriber] of this.subscribers) {
             if (subscriber.socket === socket) {
               subscriber.lastActivity = Date.now();
-              logger.debug(`[ObservationStream] Received pong from ${subscriber.subscriptionId}`);
+              logger.debug(`[DeviceDataStream] Received pong from ${subscriber.subscriptionId}`);
               break;
             }
           }
@@ -538,11 +557,11 @@ export class ObservationStreamSocketServer {
         }
 
         default:
-          throw new Error(`Unknown command: ${(request as any).command}`);
+          throw new Error(`Unknown command: ${(request as DeviceDataStreamRequest).command}`);
       }
     } catch (error) {
-      logger.error(`[ObservationStream] Parse error: ${error}`);
-      const errorResponse: ObservationStreamMessage = {
+      logger.error(`[DeviceDataStream] Parse error: ${error}`);
+      const errorResponse: DeviceDataStreamMessage = {
         type: "error",
         success: false,
         error: error instanceof Error ? error.message : String(error),
@@ -553,15 +572,15 @@ export class ObservationStreamSocketServer {
 }
 
 // Singleton instance
-let socketServer: ObservationStreamSocketServer | null = null;
+let socketServer: DeviceDataStreamSocketServer | null = null;
 
-export function getObservationStreamServer(): ObservationStreamSocketServer | null {
+export function getDeviceDataStreamServer(): DeviceDataStreamSocketServer | null {
   return socketServer;
 }
 
-export async function startObservationStreamSocketServer(): Promise<ObservationStreamSocketServer> {
+export async function startDeviceDataStreamSocketServer(): Promise<DeviceDataStreamSocketServer> {
   if (!socketServer) {
-    socketServer = new ObservationStreamSocketServer();
+    socketServer = new DeviceDataStreamSocketServer();
   }
   if (!socketServer.isListening()) {
     await socketServer.start();
@@ -569,10 +588,18 @@ export async function startObservationStreamSocketServer(): Promise<ObservationS
   return socketServer;
 }
 
-export async function stopObservationStreamSocketServer(): Promise<void> {
+export async function stopDeviceDataStreamSocketServer(): Promise<void> {
   if (!socketServer) {
     return;
   }
   await socketServer.close();
   socketServer = null;
 }
+
+// Legacy exports for backward compatibility during migration
+export {
+  DeviceDataStreamSocketServer as ObservationStreamSocketServer,
+  getDeviceDataStreamServer as getObservationStreamServer,
+  startDeviceDataStreamSocketServer as startObservationStreamSocketServer,
+  stopDeviceDataStreamSocketServer as stopObservationStreamSocketServer,
+};

--- a/src/features/observe/AccessibilityServiceClient.ts
+++ b/src/features/observe/AccessibilityServiceClient.ts
@@ -28,7 +28,7 @@ import { ElementParser } from "../utility/ElementParser";
 import { InstalledAppsRepository, InstalledAppsStore } from "../../db/installedAppsRepository";
 import { PortManager } from "../../utils/PortManager";
 import { RequestManager } from "../../utils/RequestManager";
-import { getObservationStreamServer } from "../../daemon/observationStreamSocketServer";
+import { getDeviceDataStreamServer } from "../../daemon/deviceDataStreamSocketServer";
 import {
   ScreenshotBackoffScheduler,
   DefaultScreenshotBackoffScheduler,
@@ -37,6 +37,16 @@ import {
 } from "./ScreenshotBackoffScheduler";
 import { getFailureRecorder } from "../failures/FailureRecorder";
 import type { StackTraceElement } from "../../server/failuresResources";
+import type {
+  PreferenceFile,
+  KeyValueEntry,
+  StorageSubscription,
+  StorageChangedEvent,
+  ListPreferenceFilesResult,
+  GetPreferencesResult,
+  SubscribeStorageResult,
+  UnsubscribeStorageResult,
+} from "../storage/storageTypes";
 
 /**
  * Generate a cryptographically secure random suffix for request IDs.
@@ -806,6 +816,9 @@ export class AccessibilityServiceClient implements AccessibilityService {
   // Highlight handling
   private pendingHighlightResolve: ((result: HighlightOperationResult) => void) | null = null;
   private pendingHighlightRequestId: string | null = null;
+
+  // Storage change listeners
+  private storageChangeListeners: Set<(event: StorageChangedEvent) => void> = new Set();
 
   // WebSocket factory for testing
   private webSocketFactory: (url: string) => WebSocket;
@@ -1820,6 +1833,50 @@ export class AccessibilityServiceClient implements AccessibilityService {
         });
       }
 
+      // Handle storage result messages
+      if (message.type === "list_preference_files_result" && message.requestId) {
+        const storageMessage = message as any;
+        logger.debug(`[ACCESSIBILITY_SERVICE] List preference files result (requestId: ${storageMessage.requestId}, success: ${storageMessage.success})`);
+        this.requestManager.resolve<ListPreferenceFilesResult>(message.requestId, {
+          success: storageMessage.success ?? false,
+          files: storageMessage.files || [],
+          totalTimeMs: storageMessage.totalTimeMs ?? 0,
+          error: storageMessage.error
+        });
+      }
+
+      if (message.type === "get_preferences_result" && message.requestId) {
+        const storageMessage = message as any;
+        logger.debug(`[ACCESSIBILITY_SERVICE] Get preferences result (requestId: ${storageMessage.requestId}, success: ${storageMessage.success})`);
+        this.requestManager.resolve<GetPreferencesResult>(message.requestId, {
+          success: storageMessage.success ?? false,
+          entries: storageMessage.entries || [],
+          totalTimeMs: storageMessage.totalTimeMs ?? 0,
+          error: storageMessage.error
+        });
+      }
+
+      if (message.type === "subscribe_storage_result" && message.requestId) {
+        const storageMessage = message as any;
+        logger.debug(`[ACCESSIBILITY_SERVICE] Subscribe storage result (requestId: ${storageMessage.requestId}, success: ${storageMessage.success})`);
+        this.requestManager.resolve<SubscribeStorageResult>(message.requestId, {
+          success: storageMessage.success ?? false,
+          subscription: storageMessage.subscription,
+          totalTimeMs: storageMessage.totalTimeMs ?? 0,
+          error: storageMessage.error
+        });
+      }
+
+      if (message.type === "unsubscribe_storage_result" && message.requestId) {
+        const storageMessage = message as any;
+        logger.debug(`[ACCESSIBILITY_SERVICE] Unsubscribe storage result (requestId: ${storageMessage.requestId}, success: ${storageMessage.success})`);
+        this.requestManager.resolve<UnsubscribeStorageResult>(message.requestId, {
+          success: storageMessage.success ?? false,
+          totalTimeMs: storageMessage.totalTimeMs ?? 0,
+          error: storageMessage.error
+        });
+      }
+
       // Handle navigation event
       if (message.type === "navigation_event") {
         const navMessage = message as any;
@@ -1877,6 +1934,30 @@ export class AccessibilityServiceClient implements AccessibilityService {
           await this.handleHandledExceptionEvent(event);
         }
       }
+
+      // Handle storage_changed push event
+      if (message.type === "storage_changed") {
+        const storageMessage = message as any;
+        const event: StorageChangedEvent = {
+          packageName: storageMessage.packageName,
+          fileName: storageMessage.fileName,
+          key: storageMessage.key ?? null,
+          value: storageMessage.value ?? null,
+          valueType: storageMessage.valueType ?? "STRING",
+          timestamp: storageMessage.timestamp ?? Date.now(),
+          sequenceNumber: storageMessage.sequenceNumber ?? 0,
+        };
+        logger.debug(`[ACCESSIBILITY_SERVICE] Storage changed: ${event.packageName}/${event.fileName} key=${event.key}`);
+
+        // Notify listeners
+        this.notifyStorageChangeListeners(event);
+
+        // Push to device data stream for IDE plugins
+        const server = getDeviceDataStreamServer();
+        if (server) {
+          server.pushStorageUpdate(this.device.deviceId, event);
+        }
+      }
     } catch (error) {
       logger.warn(`[ACCESSIBILITY_SERVICE] Error handling WebSocket message: ${error}`);
     }
@@ -1904,7 +1985,7 @@ export class AccessibilityServiceClient implements AccessibilityService {
    * Push hierarchy update to observation stream for IDE plugins.
    */
   private pushHierarchyToObservationStream(hierarchy: ViewHierarchyResult): void {
-    const server = getObservationStreamServer();
+    const server = getDeviceDataStreamServer();
     if (!server) {
       logger.debug(`[ACCESSIBILITY_SERVICE] No observation stream server available for hierarchy push`);
       return;
@@ -1923,7 +2004,7 @@ export class AccessibilityServiceClient implements AccessibilityService {
    * Push screenshot update to observation stream for IDE plugins.
    */
   private pushScreenshotToObservationStream(screenshotBase64: string): void {
-    const server = getObservationStreamServer();
+    const server = getDeviceDataStreamServer();
     if (!server) {
       return;
     }
@@ -1973,7 +2054,7 @@ export class AccessibilityServiceClient implements AccessibilityService {
     }
 
     // Check if there are any subscribers
-    const server = getObservationStreamServer();
+    const server = getDeviceDataStreamServer();
     if (!server || server.getSubscriberCount() === 0) {
       return { success: false, error: "No subscribers" };
     }
@@ -2020,7 +2101,7 @@ export class AccessibilityServiceClient implements AccessibilityService {
    */
   private startScreenshotBackoff(): void {
     // Check if there are any subscribers before starting
-    const server = getObservationStreamServer();
+    const server = getDeviceDataStreamServer();
     if (!server || server.getSubscriberCount() === 0) {
       logger.debug(`[ACCESSIBILITY_SERVICE] No observation stream subscribers, skipping screenshot backoff`);
       return;
@@ -4673,5 +4754,290 @@ export class AccessibilityServiceClient implements AccessibilityService {
       ...shape,
       bounds: normalizeBounds(shape.bounds)
     };
+  }
+
+  // ========== Storage Inspection Methods ==========
+
+  /**
+   * List all preference files for a package.
+   * Returns SharedPreferences and DataStore files accessible to the app.
+   *
+   * @param packageName - The package name of the app to inspect
+   * @param timeoutMs - Maximum time to wait for response in milliseconds
+   * @returns Promise resolving to array of preference files
+   */
+  async listPreferenceFiles(
+    packageName: string,
+    timeoutMs: number = 5000
+  ): Promise<PreferenceFile[]> {
+    const startTime = Date.now();
+
+    try {
+      // Ensure WebSocket connection is established
+      const connected = await this.connectWebSocket();
+      if (!connected) {
+        logger.warn("[ACCESSIBILITY_SERVICE] Failed to establish WebSocket connection for listPreferenceFiles");
+        throw new Error("Failed to connect to accessibility service");
+      }
+
+      const requestId = `list_preference_files_${Date.now()}_${generateSecureId()}`;
+
+      // Create promise that will be resolved when we receive the result
+      const resultPromise = this.requestManager.register<ListPreferenceFilesResult>(
+        requestId,
+        "list_preference_files",
+        timeoutMs,
+        (_id, _type, _timeout) => ({
+          success: false,
+          totalTimeMs: Date.now() - startTime,
+          error: `List preference files timeout after ${timeoutMs}ms`
+        })
+      );
+
+      // Send the request
+      if (!this.ws || this.ws.readyState !== WebSocket.OPEN) {
+        throw new Error("WebSocket not connected");
+      }
+      const message = JSON.stringify({
+        type: "list_preference_files",
+        requestId,
+        packageName
+      });
+      this.ws.send(message);
+      logger.debug(`[ACCESSIBILITY_SERVICE] Sent list_preference_files request (requestId: ${requestId}, packageName: ${packageName})`);
+
+      // Wait for response
+      const result = await resultPromise;
+
+      if (!result.success) {
+        throw new Error(result.error || "Failed to list preference files");
+      }
+
+      return result.files || [];
+    } catch (error) {
+      const duration = Date.now() - startTime;
+      logger.warn(`[ACCESSIBILITY_SERVICE] listPreferenceFiles failed after ${duration}ms: ${error}`);
+      throw error;
+    }
+  }
+
+  /**
+   * Get all key-value entries from a preference file.
+   *
+   * @param packageName - The package name of the app
+   * @param fileName - Name of the preference file
+   * @param timeoutMs - Maximum time to wait for response in milliseconds
+   * @returns Promise resolving to array of key-value entries
+   */
+  async getPreferenceEntries(
+    packageName: string,
+    fileName: string,
+    timeoutMs: number = 5000
+  ): Promise<KeyValueEntry[]> {
+    const startTime = Date.now();
+
+    try {
+      // Ensure WebSocket connection is established
+      const connected = await this.connectWebSocket();
+      if (!connected) {
+        logger.warn("[ACCESSIBILITY_SERVICE] Failed to establish WebSocket connection for getPreferenceEntries");
+        throw new Error("Failed to connect to accessibility service");
+      }
+
+      const requestId = `get_preferences_${Date.now()}_${generateSecureId()}`;
+
+      // Create promise that will be resolved when we receive the result
+      const resultPromise = this.requestManager.register<GetPreferencesResult>(
+        requestId,
+        "get_preferences",
+        timeoutMs,
+        (_id, _type, _timeout) => ({
+          success: false,
+          totalTimeMs: Date.now() - startTime,
+          error: `Get preferences timeout after ${timeoutMs}ms`
+        })
+      );
+
+      // Send the request
+      if (!this.ws || this.ws.readyState !== WebSocket.OPEN) {
+        throw new Error("WebSocket not connected");
+      }
+      const message = JSON.stringify({
+        type: "get_preferences",
+        requestId,
+        packageName,
+        fileName
+      });
+      this.ws.send(message);
+      logger.debug(`[ACCESSIBILITY_SERVICE] Sent get_preferences request (requestId: ${requestId}, packageName: ${packageName}, fileName: ${fileName})`);
+
+      // Wait for response
+      const result = await resultPromise;
+
+      if (!result.success) {
+        throw new Error(result.error || "Failed to get preference entries");
+      }
+
+      return result.entries || [];
+    } catch (error) {
+      const duration = Date.now() - startTime;
+      logger.warn(`[ACCESSIBILITY_SERVICE] getPreferenceEntries failed after ${duration}ms: ${error}`);
+      throw error;
+    }
+  }
+
+  /**
+   * Subscribe to storage changes for a preference file.
+   * Returns a subscription that can be used to unsubscribe later.
+   *
+   * @param packageName - The package name of the app
+   * @param fileName - Name of the preference file to observe
+   * @param timeoutMs - Maximum time to wait for response in milliseconds
+   * @returns Promise resolving to the subscription details
+   */
+  async subscribeStorage(
+    packageName: string,
+    fileName: string,
+    timeoutMs: number = 5000
+  ): Promise<StorageSubscription> {
+    const startTime = Date.now();
+
+    try {
+      // Ensure WebSocket connection is established
+      const connected = await this.connectWebSocket();
+      if (!connected) {
+        logger.warn("[ACCESSIBILITY_SERVICE] Failed to establish WebSocket connection for subscribeStorage");
+        throw new Error("Failed to connect to accessibility service");
+      }
+
+      const requestId = `subscribe_storage_${Date.now()}_${generateSecureId()}`;
+
+      // Create promise that will be resolved when we receive the result
+      const resultPromise = this.requestManager.register<SubscribeStorageResult>(
+        requestId,
+        "subscribe_storage",
+        timeoutMs,
+        (_id, _type, _timeout) => ({
+          success: false,
+          totalTimeMs: Date.now() - startTime,
+          error: `Subscribe storage timeout after ${timeoutMs}ms`
+        })
+      );
+
+      // Send the request
+      if (!this.ws || this.ws.readyState !== WebSocket.OPEN) {
+        throw new Error("WebSocket not connected");
+      }
+      const message = JSON.stringify({
+        type: "subscribe_storage",
+        requestId,
+        packageName,
+        fileName
+      });
+      this.ws.send(message);
+      logger.debug(`[ACCESSIBILITY_SERVICE] Sent subscribe_storage request (requestId: ${requestId}, packageName: ${packageName}, fileName: ${fileName})`);
+
+      // Wait for response
+      const result = await resultPromise;
+
+      if (!result.success || !result.subscription) {
+        throw new Error(result.error || "Failed to subscribe to storage");
+      }
+
+      logger.info(`[ACCESSIBILITY_SERVICE] Subscribed to storage changes: ${packageName}/${fileName} (subscriptionId: ${result.subscription.subscriptionId})`);
+      return result.subscription;
+    } catch (error) {
+      const duration = Date.now() - startTime;
+      logger.warn(`[ACCESSIBILITY_SERVICE] subscribeStorage failed after ${duration}ms: ${error}`);
+      throw error;
+    }
+  }
+
+  /**
+   * Unsubscribe from storage changes.
+   *
+   * @param subscriptionId - The subscription ID returned from subscribeStorage
+   * @param timeoutMs - Maximum time to wait for response in milliseconds
+   */
+  async unsubscribeStorage(
+    subscriptionId: string,
+    timeoutMs: number = 5000
+  ): Promise<void> {
+    const startTime = Date.now();
+
+    try {
+      // Ensure WebSocket connection is established
+      const connected = await this.connectWebSocket();
+      if (!connected) {
+        logger.warn("[ACCESSIBILITY_SERVICE] Failed to establish WebSocket connection for unsubscribeStorage");
+        throw new Error("Failed to connect to accessibility service");
+      }
+
+      const requestId = `unsubscribe_storage_${Date.now()}_${generateSecureId()}`;
+
+      // Create promise that will be resolved when we receive the result
+      const resultPromise = this.requestManager.register<UnsubscribeStorageResult>(
+        requestId,
+        "unsubscribe_storage",
+        timeoutMs,
+        (_id, _type, _timeout) => ({
+          success: false,
+          totalTimeMs: Date.now() - startTime,
+          error: `Unsubscribe storage timeout after ${timeoutMs}ms`
+        })
+      );
+
+      // Send the request
+      if (!this.ws || this.ws.readyState !== WebSocket.OPEN) {
+        throw new Error("WebSocket not connected");
+      }
+      const message = JSON.stringify({
+        type: "unsubscribe_storage",
+        requestId,
+        subscriptionId
+      });
+      this.ws.send(message);
+      logger.debug(`[ACCESSIBILITY_SERVICE] Sent unsubscribe_storage request (requestId: ${requestId}, subscriptionId: ${subscriptionId})`);
+
+      // Wait for response
+      const result = await resultPromise;
+
+      if (!result.success) {
+        throw new Error(result.error || "Failed to unsubscribe from storage");
+      }
+
+      logger.info(`[ACCESSIBILITY_SERVICE] Unsubscribed from storage changes (subscriptionId: ${subscriptionId})`);
+    } catch (error) {
+      const duration = Date.now() - startTime;
+      logger.warn(`[ACCESSIBILITY_SERVICE] unsubscribeStorage failed after ${duration}ms: ${error}`);
+      throw error;
+    }
+  }
+
+  /**
+   * Add a listener for storage change events.
+   * The listener will be called for all subscribed storage changes.
+   *
+   * @param callback - Function to call when storage changes occur
+   * @returns Function to remove the listener
+   */
+  addStorageChangeListener(callback: (event: StorageChangedEvent) => void): () => void {
+    this.storageChangeListeners.add(callback);
+    return () => {
+      this.storageChangeListeners.delete(callback);
+    };
+  }
+
+  /**
+   * Notify all storage change listeners of an event.
+   */
+  private notifyStorageChangeListeners(event: StorageChangedEvent): void {
+    for (const listener of this.storageChangeListeners) {
+      try {
+        listener(event);
+      } catch (error) {
+        logger.warn(`[ACCESSIBILITY_SERVICE] Storage change listener error: ${error}`);
+      }
+    }
   }
 }

--- a/src/features/observe/interfaces/StorageClient.ts
+++ b/src/features/observe/interfaces/StorageClient.ts
@@ -1,0 +1,56 @@
+import type {
+  PreferenceFile,
+  KeyValueEntry,
+  StorageSubscription,
+  StorageChangedEvent,
+} from "../../storage/storageTypes";
+
+/**
+ * Interface for storage inspection operations.
+ * Provides access to SharedPreferences and DataStore files on Android devices.
+ */
+export interface StorageClient {
+  /**
+   * List all preference files for a package.
+   * Returns SharedPreferences and DataStore files accessible to the app.
+   *
+   * @param packageName - The package name of the app to inspect
+   * @returns Promise resolving to array of preference files
+   */
+  listPreferenceFiles(packageName: string): Promise<PreferenceFile[]>;
+
+  /**
+   * Get all key-value entries from a preference file.
+   *
+   * @param packageName - The package name of the app
+   * @param fileName - Name of the preference file
+   * @returns Promise resolving to array of key-value entries
+   */
+  getPreferenceEntries(packageName: string, fileName: string): Promise<KeyValueEntry[]>;
+
+  /**
+   * Subscribe to storage changes for a preference file.
+   * Returns a subscription that can be used to unsubscribe later.
+   *
+   * @param packageName - The package name of the app
+   * @param fileName - Name of the preference file to observe
+   * @returns Promise resolving to the subscription details
+   */
+  subscribeStorage(packageName: string, fileName: string): Promise<StorageSubscription>;
+
+  /**
+   * Unsubscribe from storage changes.
+   *
+   * @param subscriptionId - The subscription ID returned from subscribeStorage
+   */
+  unsubscribeStorage(subscriptionId: string): Promise<void>;
+
+  /**
+   * Add a listener for storage change events.
+   * The listener will be called for all subscribed storage changes.
+   *
+   * @param callback - Function to call when storage changes occur
+   * @returns Function to remove the listener
+   */
+  addStorageChangeListener(callback: (event: StorageChangedEvent) => void): () => void;
+}

--- a/src/features/storage/storageTypes.ts
+++ b/src/features/storage/storageTypes.ts
@@ -1,0 +1,104 @@
+/**
+ * Storage inspection types for SharedPreferences and DataStore access.
+ * These types match the Android SDK models for storage observation.
+ */
+
+/**
+ * Information about a preference file (SharedPreferences or DataStore).
+ */
+export interface PreferenceFile {
+  /** Name of the preference file (without path) */
+  name: string;
+  /** Full path to the preference file on device */
+  path: string;
+  /** Number of key-value entries in this file */
+  entryCount: number;
+}
+
+/**
+ * Type of value stored in a key-value entry.
+ */
+export type KeyValueType = "STRING" | "INT" | "LONG" | "FLOAT" | "BOOLEAN" | "STRING_SET";
+
+/**
+ * A single key-value entry from a preference file.
+ */
+export interface KeyValueEntry {
+  /** The key name */
+  key: string;
+  /** JSON-encoded value (null if the entry was deleted) */
+  value: string | null;
+  /** Type of the stored value */
+  type: KeyValueType;
+}
+
+/**
+ * Active subscription to storage changes for a preference file.
+ */
+export interface StorageSubscription {
+  /** Package name of the app being observed */
+  packageName: string;
+  /** Name of the preference file being observed */
+  fileName: string;
+  /** Unique identifier for this subscription */
+  subscriptionId: string;
+}
+
+/**
+ * Event emitted when a storage value changes.
+ */
+export interface StorageChangedEvent {
+  /** Package name of the app where the change occurred */
+  packageName: string;
+  /** Name of the preference file that changed */
+  fileName: string;
+  /** Key that changed (null if the entire file was cleared) */
+  key: string | null;
+  /** New JSON-encoded value (null if the key was deleted or file cleared) */
+  value: string | null;
+  /** Type of the value */
+  valueType: KeyValueType;
+  /** Timestamp when the change occurred (milliseconds since epoch) */
+  timestamp: number;
+  /** Sequence number for ordering events */
+  sequenceNumber: number;
+}
+
+/**
+ * Result of a list_preference_files request.
+ */
+export interface ListPreferenceFilesResult {
+  success: boolean;
+  files?: PreferenceFile[];
+  totalTimeMs: number;
+  error?: string;
+}
+
+/**
+ * Result of a get_preferences request.
+ */
+export interface GetPreferencesResult {
+  success: boolean;
+  entries?: KeyValueEntry[];
+  totalTimeMs: number;
+  error?: string;
+}
+
+/**
+ * Result of a subscribe_storage request.
+ */
+export interface SubscribeStorageResult {
+  success: boolean;
+  subscription?: StorageSubscription;
+  totalTimeMs: number;
+  error?: string;
+}
+
+/**
+ * Result of an unsubscribe_storage request.
+ */
+export interface UnsubscribeStorageResult {
+  success: boolean;
+  totalTimeMs: number;
+  error?: string;
+}

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -52,6 +52,7 @@ import { registerLocalizationResources } from "./localizationResources";
 import { registerDeviceSnapshotResources } from "./deviceSnapshotResources";
 import { registerDatabaseResources } from "./databaseResources";
 import { registerFailuresResources } from "./failuresResources";
+import { registerStorageResources } from "./storageResources";
 import { FeatureFlagService } from "../features/featureFlags/FeatureFlagService";
 import { startupBenchmark } from "../utils/startupBenchmark";
 
@@ -163,6 +164,7 @@ export const createMcpServer = (options: McpServerOptions = {}): McpServer => {
   registerDeviceSnapshotResources();
   registerDatabaseResources();
   registerFailuresResources();
+  registerStorageResources();
   startupBenchmark.endPhase("resourceRegistration");
 
   // Create a new MCP server

--- a/src/server/storageResources.ts
+++ b/src/server/storageResources.ts
@@ -1,0 +1,284 @@
+import { ResourceRegistry, ResourceContent } from "./resourceRegistry";
+import { PlatformDeviceManagerFactory } from "../utils/factories/PlatformDeviceManagerFactory";
+import { AccessibilityServiceClient } from "../features/observe/AccessibilityServiceClient";
+import { BootedDevice } from "../models";
+import { logger } from "../utils/logger";
+import type { PreferenceFile, KeyValueEntry } from "../features/storage/storageTypes";
+
+// Resource URI templates
+export const STORAGE_RESOURCE_TEMPLATES = {
+  FILES: "automobile:devices/{deviceId}/storage/{packageName}/files",
+  ENTRIES: "automobile:devices/{deviceId}/storage/{packageName}/{fileName}/entries",
+} as const;
+
+// Cache entries for change detection
+interface StorageFilesCacheEntry {
+  files: PreferenceFile[];
+  lastUpdated: string;
+  hash: string;
+}
+
+interface StorageEntriesCacheEntry {
+  entries: KeyValueEntry[];
+  lastUpdated: string;
+  hash: string;
+}
+
+interface StorageCache {
+  files: Map<string, StorageFilesCacheEntry>; // key: `${deviceId}:${packageName}`
+  entries: Map<string, StorageEntriesCacheEntry>; // key: `${deviceId}:${packageName}:${fileName}`
+}
+
+const cache: StorageCache = {
+  files: new Map(),
+  entries: new Map()
+};
+
+/**
+ * Generate a simple hash for change detection
+ */
+function generateHash(data: unknown): string {
+  const str = JSON.stringify(data);
+  let hash = 0;
+  for (let i = 0; i < str.length; i++) {
+    const char = str.charCodeAt(i);
+    hash = ((hash << 5) - hash) + char;
+    hash = hash & hash;
+  }
+  return hash.toString(16);
+}
+
+/**
+ * Find a booted Android device by ID
+ */
+async function findBootedAndroidDevice(deviceId: string): Promise<BootedDevice | null> {
+  try {
+    const devices = await PlatformDeviceManagerFactory.getInstance().getBootedDevices("android");
+    return devices.find(d => d.deviceId === deviceId) ?? null;
+  } catch (error) {
+    logger.warn(`[StorageResources] Failed to find device ${deviceId}: ${error}`);
+    return null;
+  }
+}
+
+/**
+ * Get cache key for storage files
+ */
+function getFilesCacheKey(deviceId: string, packageName: string): string {
+  return `${deviceId}:${packageName}`;
+}
+
+/**
+ * Get cache key for storage entries
+ */
+function getEntriesCacheKey(deviceId: string, packageName: string, fileName: string): string {
+  return `${deviceId}:${packageName}:${fileName}`;
+}
+
+/**
+ * Build resource URI for storage files
+ */
+function buildFilesUri(deviceId: string, packageName: string): string {
+  return `automobile:devices/${deviceId}/storage/${encodeURIComponent(packageName)}/files`;
+}
+
+/**
+ * Build resource URI for storage entries
+ */
+function buildEntriesUri(deviceId: string, packageName: string, fileName: string): string {
+  return `automobile:devices/${deviceId}/storage/${encodeURIComponent(packageName)}/${encodeURIComponent(fileName)}/entries`;
+}
+
+/**
+ * Get storage files resource content
+ */
+async function getStorageFilesResource(params: Record<string, string>): Promise<ResourceContent> {
+  const { deviceId, packageName } = params;
+  const decodedPackage = decodeURIComponent(packageName);
+  const uri = buildFilesUri(deviceId, decodedPackage);
+
+  try {
+    const device = await findBootedAndroidDevice(deviceId);
+    if (!device) {
+      return {
+        uri,
+        mimeType: "application/json",
+        text: JSON.stringify({ error: `Device not found or not booted: ${deviceId}` }, null, 2)
+      };
+    }
+
+    const client = AccessibilityServiceClient.getInstance(device);
+    const files = await client.listPreferenceFiles(decodedPackage);
+    const lastUpdated = new Date().toISOString();
+    const hash = generateHash(files);
+
+    // Check for changes and notify
+    const cacheKey = getFilesCacheKey(deviceId, decodedPackage);
+    const cached = cache.files.get(cacheKey);
+    if (cached && cached.hash !== hash) {
+      logger.info(`[StorageResources] Storage files changed for ${decodedPackage} on ${deviceId}`);
+      void ResourceRegistry.notifyResourceUpdated(uri);
+    }
+
+    // Update cache
+    cache.files.set(cacheKey, { files, lastUpdated, hash });
+
+    return {
+      uri,
+      mimeType: "application/json",
+      text: JSON.stringify({
+        deviceId,
+        packageName: decodedPackage,
+        files,
+        totalCount: files.length,
+        lastUpdated
+      }, null, 2)
+    };
+  } catch (error) {
+    logger.error(`[StorageResources] Failed to list storage files: ${error}`);
+    return {
+      uri,
+      mimeType: "application/json",
+      text: JSON.stringify({ error: `Failed to list storage files: ${error}` }, null, 2)
+    };
+  }
+}
+
+/**
+ * Get storage entries resource content
+ */
+async function getStorageEntriesResource(params: Record<string, string>): Promise<ResourceContent> {
+  const { deviceId, packageName, fileName } = params;
+  const decodedPackage = decodeURIComponent(packageName);
+  const decodedFileName = decodeURIComponent(fileName);
+  const uri = buildEntriesUri(deviceId, decodedPackage, decodedFileName);
+
+  try {
+    const device = await findBootedAndroidDevice(deviceId);
+    if (!device) {
+      return {
+        uri,
+        mimeType: "application/json",
+        text: JSON.stringify({ error: `Device not found or not booted: ${deviceId}` }, null, 2)
+      };
+    }
+
+    const client = AccessibilityServiceClient.getInstance(device);
+    const entries = await client.getPreferenceEntries(decodedPackage, decodedFileName);
+    const lastUpdated = new Date().toISOString();
+    const hash = generateHash(entries);
+
+    // Check for changes and notify
+    const cacheKey = getEntriesCacheKey(deviceId, decodedPackage, decodedFileName);
+    const cached = cache.entries.get(cacheKey);
+    if (cached && cached.hash !== hash) {
+      logger.info(`[StorageResources] Storage entries changed for ${decodedPackage}/${decodedFileName} on ${deviceId}`);
+      void ResourceRegistry.notifyResourceUpdated(uri);
+    }
+
+    // Update cache
+    cache.entries.set(cacheKey, { entries, lastUpdated, hash });
+
+    return {
+      uri,
+      mimeType: "application/json",
+      text: JSON.stringify({
+        deviceId,
+        packageName: decodedPackage,
+        fileName: decodedFileName,
+        entries,
+        totalCount: entries.length,
+        lastUpdated
+      }, null, 2)
+    };
+  } catch (error) {
+    logger.error(`[StorageResources] Failed to get storage entries: ${error}`);
+    return {
+      uri,
+      mimeType: "application/json",
+      text: JSON.stringify({ error: `Failed to get storage entries: ${error}` }, null, 2)
+    };
+  }
+}
+
+/**
+ * Notify that storage data has changed
+ */
+export async function notifyStorageChanged(
+  deviceId: string,
+  packageName: string,
+  fileName?: string
+): Promise<void> {
+  // Notify files resource
+  await ResourceRegistry.notifyResourceUpdated(buildFilesUri(deviceId, packageName));
+
+  // If we know which file changed, notify that specifically
+  if (fileName) {
+    await ResourceRegistry.notifyResourceUpdated(
+      buildEntriesUri(deviceId, packageName, fileName)
+    );
+  }
+
+  // Invalidate relevant cache entries
+  const filesCacheKey = getFilesCacheKey(deviceId, packageName);
+  cache.files.delete(filesCacheKey);
+
+  if (fileName) {
+    const entriesCacheKey = getEntriesCacheKey(deviceId, packageName, fileName);
+    cache.entries.delete(entriesCacheKey);
+  } else {
+    // Clear all entries cache for this package
+    for (const key of cache.entries.keys()) {
+      if (key.startsWith(`${deviceId}:${packageName}:`)) {
+        cache.entries.delete(key);
+      }
+    }
+  }
+}
+
+/**
+ * Invalidate all storage caches for a device
+ */
+export function invalidateStorageCache(deviceId?: string): void {
+  if (deviceId) {
+    // Remove entries for specific device
+    for (const key of cache.files.keys()) {
+      if (key.startsWith(`${deviceId}:`)) {
+        cache.files.delete(key);
+      }
+    }
+    for (const key of cache.entries.keys()) {
+      if (key.startsWith(`${deviceId}:`)) {
+        cache.entries.delete(key);
+      }
+    }
+  } else {
+    cache.files.clear();
+    cache.entries.clear();
+  }
+}
+
+/**
+ * Register storage resources
+ */
+export function registerStorageResources(): void {
+  // Register template for listing storage files
+  ResourceRegistry.registerTemplate(
+    STORAGE_RESOURCE_TEMPLATES.FILES,
+    "App Storage Files",
+    "List all SharedPreferences and DataStore files in an Android app. Requires app to have AutoMobile SDK with storage inspection enabled.",
+    "application/json",
+    getStorageFilesResource
+  );
+
+  // Register template for getting storage entries
+  ResourceRegistry.registerTemplate(
+    STORAGE_RESOURCE_TEMPLATES.ENTRIES,
+    "Storage File Entries",
+    "Get all key-value entries from a SharedPreferences or DataStore file.",
+    "application/json",
+    getStorageEntriesResource
+  );
+
+  logger.info("[StorageResources] Registered storage resources");
+}

--- a/test/fakes/FakeStorageClient.test.ts
+++ b/test/fakes/FakeStorageClient.test.ts
@@ -1,0 +1,218 @@
+import { describe, expect, it, beforeEach } from "bun:test";
+import { FakeStorageClient } from "./FakeStorageClient";
+import type { StorageChangedEvent } from "../../src/features/storage/storageTypes";
+
+describe("FakeStorageClient", () => {
+  let client: FakeStorageClient;
+
+  beforeEach(() => {
+    client = new FakeStorageClient();
+  });
+
+  describe("listPreferenceFiles", () => {
+    it("should return empty array when no data configured", async () => {
+      const files = await client.listPreferenceFiles("com.example.app");
+      expect(files).toEqual([]);
+    });
+
+    it("should return configured preference files", async () => {
+      client.setPreferenceFiles("com.example.app", [
+        {
+          file: { name: "prefs", path: "/path/to/prefs.xml", entryCount: 3 },
+          entries: [],
+        },
+      ]);
+
+      const files = await client.listPreferenceFiles("com.example.app");
+      expect(files).toHaveLength(1);
+      expect(files[0].name).toBe("prefs");
+    });
+
+    it("should track method calls", async () => {
+      await client.listPreferenceFiles("com.example.app");
+      await client.listPreferenceFiles("com.other.app");
+
+      expect(client.wasMethodCalled("listPreferenceFiles")).toBe(true);
+      expect(client.getMethodCallCount("listPreferenceFiles")).toBe(2);
+
+      const history = client.getListPreferenceFilesHistory();
+      expect(history).toHaveLength(2);
+      expect(history[0].packageName).toBe("com.example.app");
+      expect(history[1].packageName).toBe("com.other.app");
+    });
+
+    it("should throw when failure mode is set", async () => {
+      client.setFailureMode("listPreferenceFiles", new Error("Test error"));
+
+      await expect(client.listPreferenceFiles("com.example.app")).rejects.toThrow("Test error");
+    });
+  });
+
+  describe("getPreferenceEntries", () => {
+    it("should return empty array when no data configured", async () => {
+      const entries = await client.getPreferenceEntries("com.example.app", "settings");
+      expect(entries).toEqual([]);
+    });
+
+    it("should return configured entries", async () => {
+      client.setPreferenceFiles("com.example.app", [
+        {
+          file: { name: "settings", path: "/path/to/settings.xml", entryCount: 2 },
+          entries: [
+            { key: "key1", value: '"value1"', type: "STRING" },
+            { key: "key2", value: "42", type: "INT" },
+          ],
+        },
+      ]);
+
+      const entries = await client.getPreferenceEntries("com.example.app", "settings");
+      expect(entries).toHaveLength(2);
+      expect(entries[0].key).toBe("key1");
+      expect(entries[1].key).toBe("key2");
+    });
+
+    it("should track method calls", async () => {
+      await client.getPreferenceEntries("com.example.app", "settings");
+
+      const history = client.getGetPreferenceEntriesHistory();
+      expect(history).toHaveLength(1);
+      expect(history[0]).toEqual({ packageName: "com.example.app", fileName: "settings" });
+    });
+  });
+
+  describe("subscribeStorage", () => {
+    it("should return subscription with unique ID", async () => {
+      const sub1 = await client.subscribeStorage("com.example.app", "settings");
+      const sub2 = await client.subscribeStorage("com.example.app", "other");
+
+      expect(sub1.subscriptionId).not.toBe(sub2.subscriptionId);
+      expect(sub1.packageName).toBe("com.example.app");
+      expect(sub1.fileName).toBe("settings");
+    });
+
+    it("should track active subscriptions", async () => {
+      await client.subscribeStorage("com.example.app", "settings");
+      await client.subscribeStorage("com.example.app", "other");
+
+      const subscriptions = client.getActiveSubscriptions();
+      expect(subscriptions).toHaveLength(2);
+    });
+
+    it("should track method calls", async () => {
+      await client.subscribeStorage("com.example.app", "settings");
+
+      const history = client.getSubscribeStorageHistory();
+      expect(history).toHaveLength(1);
+      expect(history[0]).toEqual({ packageName: "com.example.app", fileName: "settings" });
+    });
+  });
+
+  describe("unsubscribeStorage", () => {
+    it("should remove subscription", async () => {
+      const sub = await client.subscribeStorage("com.example.app", "settings");
+      expect(client.getActiveSubscriptions()).toHaveLength(1);
+
+      await client.unsubscribeStorage(sub.subscriptionId);
+      expect(client.getActiveSubscriptions()).toHaveLength(0);
+    });
+
+    it("should track method calls", async () => {
+      const sub = await client.subscribeStorage("com.example.app", "settings");
+      await client.unsubscribeStorage(sub.subscriptionId);
+
+      const history = client.getUnsubscribeStorageHistory();
+      expect(history).toHaveLength(1);
+      expect(history[0].subscriptionId).toBe(sub.subscriptionId);
+    });
+  });
+
+  describe("storage change listeners", () => {
+    it("should notify listeners on simulated change", async () => {
+      const receivedEvents: StorageChangedEvent[] = [];
+      client.addStorageChangeListener(event => {
+        receivedEvents.push(event);
+      });
+
+      const event: StorageChangedEvent = {
+        packageName: "com.example.app",
+        fileName: "settings",
+        key: "dark_mode",
+        value: "true",
+        valueType: "BOOLEAN",
+        timestamp: Date.now(),
+        sequenceNumber: 1,
+      };
+
+      client.simulateStorageChange(event);
+
+      expect(receivedEvents).toHaveLength(1);
+      expect(receivedEvents[0]).toEqual(event);
+    });
+
+    it("should allow removing listeners", async () => {
+      const receivedEvents: StorageChangedEvent[] = [];
+      const remove = client.addStorageChangeListener(event => {
+        receivedEvents.push(event);
+      });
+
+      expect(client.getStorageChangeListenerCount()).toBe(1);
+
+      remove();
+      expect(client.getStorageChangeListenerCount()).toBe(0);
+
+      client.simulateStorageChange({
+        packageName: "com.example.app",
+        fileName: "settings",
+        key: "test",
+        value: "value",
+        valueType: "STRING",
+        timestamp: Date.now(),
+        sequenceNumber: 1,
+      });
+
+      expect(receivedEvents).toHaveLength(0);
+    });
+  });
+
+  describe("reset", () => {
+    it("should clear all state", async () => {
+      client.setPreferenceFiles("com.example.app", [
+        { file: { name: "prefs", path: "/path", entryCount: 1 }, entries: [] },
+      ]);
+      client.setFailureMode("listPreferenceFiles", new Error("Test"));
+      await client.subscribeStorage("com.example.app", "settings");
+      client.addStorageChangeListener(() => {});
+      await client.listPreferenceFiles("com.example.app").catch(() => {});
+
+      client.reset();
+
+      // All state should be cleared
+      expect(client.getOperations()).toHaveLength(0);
+      expect(client.getActiveSubscriptions()).toHaveLength(0);
+      expect(client.getStorageChangeListenerCount()).toBe(0);
+
+      // Should not throw after reset
+      const files = await client.listPreferenceFiles("com.example.app");
+      expect(files).toEqual([]);
+    });
+  });
+
+  describe("clearOperations", () => {
+    it("should only clear operations history", async () => {
+      client.setPreferenceFiles("com.example.app", [
+        { file: { name: "prefs", path: "/path", entryCount: 1 }, entries: [] },
+      ]);
+      await client.listPreferenceFiles("com.example.app");
+
+      expect(client.getOperations()).toHaveLength(1);
+
+      client.clearOperations();
+
+      expect(client.getOperations()).toHaveLength(0);
+
+      // Data should still be there
+      const files = await client.listPreferenceFiles("com.example.app");
+      expect(files).toHaveLength(1);
+    });
+  });
+});

--- a/test/fakes/FakeStorageClient.ts
+++ b/test/fakes/FakeStorageClient.ts
@@ -1,0 +1,259 @@
+import type { StorageClient } from "../../src/features/observe/interfaces/StorageClient";
+import type {
+  PreferenceFile,
+  KeyValueEntry,
+  StorageSubscription,
+  StorageChangedEvent,
+} from "../../src/features/storage/storageTypes";
+
+/**
+ * Recorded operation for verification in tests.
+ */
+export interface RecordedStorageOperation {
+  method: string;
+  args: Record<string, unknown>;
+  timestamp: number;
+}
+
+/**
+ * Mock preference file data for testing.
+ */
+export interface MockPreferenceData {
+  file: PreferenceFile;
+  entries: KeyValueEntry[];
+}
+
+/**
+ * Fake implementation of StorageClient for testing.
+ *
+ * Provides programmatic control over storage responses without
+ * actually communicating with a device.
+ */
+export class FakeStorageClient implements StorageClient {
+  private preferenceFiles: Map<string, MockPreferenceData[]> = new Map();
+  private operations: RecordedStorageOperation[] = [];
+  private failureMode: Map<string, Error> = new Map();
+  private subscriptions: Map<string, StorageSubscription> = new Map();
+  private subscriptionCounter = 0;
+  private storageChangeListeners: Set<(event: StorageChangedEvent) => void> = new Set();
+
+  /**
+   * Add mock preference files for a package.
+   */
+  setPreferenceFiles(packageName: string, files: MockPreferenceData[]): void {
+    this.preferenceFiles.set(packageName, files);
+  }
+
+  /**
+   * Set a failure mode for a specific operation.
+   * @param operation - Operation name: "listPreferenceFiles", "getPreferenceEntries", "subscribeStorage", "unsubscribeStorage"
+   * @param error - Error to throw, or null to clear failure mode
+   */
+  setFailureMode(operation: string, error: Error | null): void {
+    if (error === null) {
+      this.failureMode.delete(operation);
+    } else {
+      this.failureMode.set(operation, error);
+    }
+  }
+
+  /**
+   * Simulate a storage change event being pushed from the device.
+   */
+  simulateStorageChange(event: StorageChangedEvent): void {
+    for (const listener of this.storageChangeListeners) {
+      listener(event);
+    }
+  }
+
+  /**
+   * List preference files for a package.
+   */
+  async listPreferenceFiles(packageName: string): Promise<PreferenceFile[]> {
+    this.recordOperation("listPreferenceFiles", { packageName });
+
+    const error = this.failureMode.get("listPreferenceFiles");
+    if (error) {
+      throw error;
+    }
+
+    const data = this.preferenceFiles.get(packageName);
+    if (!data) {
+      return [];
+    }
+
+    return data.map(d => d.file);
+  }
+
+  /**
+   * Get entries from a preference file.
+   */
+  async getPreferenceEntries(packageName: string, fileName: string): Promise<KeyValueEntry[]> {
+    this.recordOperation("getPreferenceEntries", { packageName, fileName });
+
+    const error = this.failureMode.get("getPreferenceEntries");
+    if (error) {
+      throw error;
+    }
+
+    const data = this.preferenceFiles.get(packageName);
+    if (!data) {
+      return [];
+    }
+
+    const file = data.find(d => d.file.name === fileName);
+    if (!file) {
+      return [];
+    }
+
+    return file.entries;
+  }
+
+  /**
+   * Subscribe to storage changes for a file.
+   */
+  async subscribeStorage(packageName: string, fileName: string): Promise<StorageSubscription> {
+    this.recordOperation("subscribeStorage", { packageName, fileName });
+
+    const error = this.failureMode.get("subscribeStorage");
+    if (error) {
+      throw error;
+    }
+
+    const subscriptionId = `sub-${++this.subscriptionCounter}`;
+    const subscription: StorageSubscription = {
+      packageName,
+      fileName,
+      subscriptionId,
+    };
+
+    this.subscriptions.set(subscriptionId, subscription);
+    return subscription;
+  }
+
+  /**
+   * Unsubscribe from storage changes.
+   */
+  async unsubscribeStorage(subscriptionId: string): Promise<void> {
+    this.recordOperation("unsubscribeStorage", { subscriptionId });
+
+    const error = this.failureMode.get("unsubscribeStorage");
+    if (error) {
+      throw error;
+    }
+
+    this.subscriptions.delete(subscriptionId);
+  }
+
+  /**
+   * Add a listener for storage change events.
+   */
+  addStorageChangeListener(callback: (event: StorageChangedEvent) => void): () => void {
+    this.storageChangeListeners.add(callback);
+    return () => {
+      this.storageChangeListeners.delete(callback);
+    };
+  }
+
+  // Test utility methods
+
+  /**
+   * Get all recorded operations.
+   */
+  getOperations(): RecordedStorageOperation[] {
+    return [...this.operations];
+  }
+
+  /**
+   * Get the history of listPreferenceFiles calls.
+   */
+  getListPreferenceFilesHistory(): Array<{ packageName: string }> {
+    return this.operations
+      .filter(op => op.method === "listPreferenceFiles")
+      .map(op => ({ packageName: op.args.packageName as string }));
+  }
+
+  /**
+   * Get the history of getPreferenceEntries calls.
+   */
+  getGetPreferenceEntriesHistory(): Array<{ packageName: string; fileName: string }> {
+    return this.operations
+      .filter(op => op.method === "getPreferenceEntries")
+      .map(op => ({
+        packageName: op.args.packageName as string,
+        fileName: op.args.fileName as string,
+      }));
+  }
+
+  /**
+   * Get the history of subscribeStorage calls.
+   */
+  getSubscribeStorageHistory(): Array<{ packageName: string; fileName: string }> {
+    return this.operations
+      .filter(op => op.method === "subscribeStorage")
+      .map(op => ({
+        packageName: op.args.packageName as string,
+        fileName: op.args.fileName as string,
+      }));
+  }
+
+  /**
+   * Get the history of unsubscribeStorage calls.
+   */
+  getUnsubscribeStorageHistory(): Array<{ subscriptionId: string }> {
+    return this.operations
+      .filter(op => op.method === "unsubscribeStorage")
+      .map(op => ({ subscriptionId: op.args.subscriptionId as string }));
+  }
+
+  /**
+   * Check if a specific method was called.
+   */
+  wasMethodCalled(method: string): boolean {
+    return this.operations.some(op => op.method === method);
+  }
+
+  /**
+   * Get count of times a method was called.
+   */
+  getMethodCallCount(method: string): number {
+    return this.operations.filter(op => op.method === method).length;
+  }
+
+  /**
+   * Get active subscriptions.
+   */
+  getActiveSubscriptions(): StorageSubscription[] {
+    return Array.from(this.subscriptions.values());
+  }
+
+  /**
+   * Get the number of registered storage change listeners.
+   */
+  getStorageChangeListenerCount(): number {
+    return this.storageChangeListeners.size;
+  }
+
+  /**
+   * Clear all recorded operations.
+   */
+  clearOperations(): void {
+    this.operations = [];
+  }
+
+  /**
+   * Reset all state.
+   */
+  reset(): void {
+    this.preferenceFiles.clear();
+    this.operations = [];
+    this.failureMode.clear();
+    this.subscriptions.clear();
+    this.subscriptionCounter = 0;
+    this.storageChangeListeners.clear();
+  }
+
+  private recordOperation(method: string, args: Record<string, unknown>): void {
+    this.operations.push({ method, args, timestamp: Date.now() });
+  }
+}

--- a/test/features/storage/storageTypes.test.ts
+++ b/test/features/storage/storageTypes.test.ts
@@ -1,0 +1,231 @@
+import { describe, expect, it } from "bun:test";
+import type {
+  PreferenceFile,
+  KeyValueType,
+  KeyValueEntry,
+  StorageSubscription,
+  StorageChangedEvent,
+  ListPreferenceFilesResult,
+  GetPreferencesResult,
+  SubscribeStorageResult,
+  UnsubscribeStorageResult,
+} from "../../../src/features/storage/storageTypes";
+
+describe("storageTypes", () => {
+  describe("PreferenceFile", () => {
+    it("should have correct structure", () => {
+      const file: PreferenceFile = {
+        name: "user_prefs",
+        path: "/data/data/com.example/shared_prefs/user_prefs.xml",
+        entryCount: 5,
+      };
+
+      expect(file.name).toBe("user_prefs");
+      expect(file.path).toContain("shared_prefs");
+      expect(file.entryCount).toBe(5);
+    });
+  });
+
+  describe("KeyValueType", () => {
+    it("should support all value types", () => {
+      const types: KeyValueType[] = ["STRING", "INT", "LONG", "FLOAT", "BOOLEAN", "STRING_SET"];
+      expect(types).toHaveLength(6);
+    });
+  });
+
+  describe("KeyValueEntry", () => {
+    it("should support string values", () => {
+      const entry: KeyValueEntry = {
+        key: "username",
+        value: JSON.stringify("john_doe"),
+        type: "STRING",
+      };
+
+      expect(entry.key).toBe("username");
+      expect(JSON.parse(entry.value!)).toBe("john_doe");
+      expect(entry.type).toBe("STRING");
+    });
+
+    it("should support numeric values", () => {
+      const intEntry: KeyValueEntry = {
+        key: "count",
+        value: JSON.stringify(42),
+        type: "INT",
+      };
+
+      expect(intEntry.type).toBe("INT");
+      expect(JSON.parse(intEntry.value!)).toBe(42);
+
+      const floatEntry: KeyValueEntry = {
+        key: "ratio",
+        value: JSON.stringify(3.14),
+        type: "FLOAT",
+      };
+
+      expect(floatEntry.type).toBe("FLOAT");
+      expect(JSON.parse(floatEntry.value!)).toBe(3.14);
+    });
+
+    it("should support boolean values", () => {
+      const entry: KeyValueEntry = {
+        key: "enabled",
+        value: JSON.stringify(true),
+        type: "BOOLEAN",
+      };
+
+      expect(entry.type).toBe("BOOLEAN");
+      expect(JSON.parse(entry.value!)).toBe(true);
+    });
+
+    it("should support string set values", () => {
+      const entry: KeyValueEntry = {
+        key: "tags",
+        value: JSON.stringify(["red", "green", "blue"]),
+        type: "STRING_SET",
+      };
+
+      expect(entry.type).toBe("STRING_SET");
+      expect(JSON.parse(entry.value!)).toEqual(["red", "green", "blue"]);
+    });
+
+    it("should support null values for deleted entries", () => {
+      const entry: KeyValueEntry = {
+        key: "deleted_key",
+        value: null,
+        type: "STRING",
+      };
+
+      expect(entry.value).toBeNull();
+    });
+  });
+
+  describe("StorageSubscription", () => {
+    it("should have correct structure", () => {
+      const subscription: StorageSubscription = {
+        packageName: "com.example.app",
+        fileName: "settings",
+        subscriptionId: "sub-123",
+      };
+
+      expect(subscription.packageName).toBe("com.example.app");
+      expect(subscription.fileName).toBe("settings");
+      expect(subscription.subscriptionId).toBe("sub-123");
+    });
+  });
+
+  describe("StorageChangedEvent", () => {
+    it("should represent a key change event", () => {
+      const event: StorageChangedEvent = {
+        packageName: "com.example.app",
+        fileName: "settings",
+        key: "dark_mode",
+        value: JSON.stringify(true),
+        valueType: "BOOLEAN",
+        timestamp: 1700000000000,
+        sequenceNumber: 1,
+      };
+
+      expect(event.key).toBe("dark_mode");
+      expect(JSON.parse(event.value!)).toBe(true);
+      expect(event.valueType).toBe("BOOLEAN");
+    });
+
+    it("should represent a key deletion event", () => {
+      const event: StorageChangedEvent = {
+        packageName: "com.example.app",
+        fileName: "settings",
+        key: "deprecated_setting",
+        value: null,
+        valueType: "STRING",
+        timestamp: 1700000000000,
+        sequenceNumber: 2,
+      };
+
+      expect(event.key).toBe("deprecated_setting");
+      expect(event.value).toBeNull();
+    });
+
+    it("should represent a file clear event", () => {
+      const event: StorageChangedEvent = {
+        packageName: "com.example.app",
+        fileName: "settings",
+        key: null,
+        value: null,
+        valueType: "STRING",
+        timestamp: 1700000000000,
+        sequenceNumber: 3,
+      };
+
+      expect(event.key).toBeNull();
+      expect(event.value).toBeNull();
+    });
+  });
+
+  describe("Result types", () => {
+    it("ListPreferenceFilesResult should have correct structure", () => {
+      const result: ListPreferenceFilesResult = {
+        success: true,
+        files: [
+          { name: "prefs1", path: "/path/to/prefs1.xml", entryCount: 3 },
+          { name: "prefs2", path: "/path/to/prefs2.xml", entryCount: 5 },
+        ],
+        totalTimeMs: 50,
+      };
+
+      expect(result.success).toBe(true);
+      expect(result.files).toHaveLength(2);
+      expect(result.totalTimeMs).toBe(50);
+    });
+
+    it("GetPreferencesResult should have correct structure", () => {
+      const result: GetPreferencesResult = {
+        success: true,
+        entries: [
+          { key: "key1", value: JSON.stringify("value1"), type: "STRING" },
+          { key: "key2", value: JSON.stringify(42), type: "INT" },
+        ],
+        totalTimeMs: 30,
+      };
+
+      expect(result.success).toBe(true);
+      expect(result.entries).toHaveLength(2);
+    });
+
+    it("SubscribeStorageResult should have correct structure", () => {
+      const result: SubscribeStorageResult = {
+        success: true,
+        subscription: {
+          packageName: "com.example.app",
+          fileName: "settings",
+          subscriptionId: "sub-456",
+        },
+        totalTimeMs: 20,
+      };
+
+      expect(result.success).toBe(true);
+      expect(result.subscription?.subscriptionId).toBe("sub-456");
+    });
+
+    it("UnsubscribeStorageResult should have correct structure", () => {
+      const result: UnsubscribeStorageResult = {
+        success: true,
+        totalTimeMs: 10,
+      };
+
+      expect(result.success).toBe(true);
+      expect(result.error).toBeUndefined();
+    });
+
+    it("Result types should handle errors", () => {
+      const errorResult: ListPreferenceFilesResult = {
+        success: false,
+        totalTimeMs: 100,
+        error: "Permission denied",
+      };
+
+      expect(errorResult.success).toBe(false);
+      expect(errorResult.error).toBe("Permission denied");
+      expect(errorResult.files).toBeUndefined();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Add MCP resources for inspecting Android SharedPreferences and DataStore files
- Add WebSocket handlers for `list_preference_files`, `get_preferences`, `subscribe_storage`, `unsubscribe_storage`
- Add `storage_changed` push events for real-time storage updates to IDE plugins
- Rename `ObservationStreamSocketServer` → `DeviceDataStreamSocketServer` to reflect expanded role

## Test Plan

- [x] Build passes (`bun run build`)
- [x] Lint passes (`bun run lint`)
- [x] Unit tests pass (32 new tests for storage types and FakeStorageClient)

Closes #1063

🤖 Generated with [Claude Code](https://claude.com/claude-code)