### PR TITLE
refactor: decompose Explore.ts into focused modules

### DIFF
--- a/src/features/navigation/Explore.ts
+++ b/src/features/navigation/Explore.ts
@@ -10,164 +10,59 @@ import { SwipeOnElement } from "../action/SwipeOnElement";
 import { ElementParser } from "../utility/ElementParser";
 import { throwIfAborted } from "../../utils/toolUtils";
 import { OPERATION_CANCELLED_MESSAGE } from "../../utils/constants";
-import { createHash } from "crypto";
 import { Timer, defaultTimer } from "../../utils/SystemTimer";
 
-/**
- * Exploration strategies for explore
- */
-export type ExplorationStrategy = "breadth-first" | "depth-first" | "weighted";
+// Re-export all types for backward compatibility
+export * from "./ExploreTypes";
 
-/**
- * Exploration modes for explore
- */
-export type ExplorationMode = "discover" | "validate" | "hybrid";
+// Import types
+import type {
+  ExplorationMode,
+  ExplorationStrategy,
+  ExploreOptions,
+  ExploreResult,
+  ExploreDryRunResult,
+  ExploreExecutionResult,
+  ElementSelectionStats,
+  TrackedElement,
+  GraphTraversalState
+} from "./ExploreTypes";
 
-/**
- * Options for Explore execution
- */
-export interface ExploreOptions {
-  /** Maximum number of interactions to perform */
-  maxInteractions?: number;
+// Import element extraction functions
+import {
+  extractNavigationElements,
+  extractScrollableContainers,
+  extractAllElements,
+  getElementKey,
+  filterUnexhaustedElements
+} from "./ExploreElementExtraction";
 
-  /** Maximum time in milliseconds */
-  timeoutMs?: number;
+// Import element scoring functions
+import {
+  selectBreadthFirst,
+  selectDepthFirst,
+  selectWeighted,
+  rankElementsForDryRun,
+  getElementTarget,
+  predictOutcomeForElement
+} from "./ExploreElementScoring";
 
-  /** Strategy for selecting next interaction */
-  strategy?: ExplorationStrategy;
+// Import blocker detection functions
+import {
+  detectAndHandleBlockers,
+  isPermissionDialog,
+  handlePermissionDialog
+} from "./ExploreBlockerDetection";
 
-  /** Whether to reset to home screen periodically */
-  resetToHome?: boolean;
-
-  /** How often to reset (every N interactions) */
-  resetInterval?: number;
-
-  /** Exploration mode */
-  mode?: ExplorationMode;
-
-  /** Package name to limit exploration to */
-  packageName?: string;
-
-  /** Dry run mode (no interactions performed) */
-  dryRun?: boolean;
-}
-
-/**
- * Statistics about element selection during exploration
- */
-export interface ElementSelectionStats {
-  text?: string;
-  resourceId?: string;
-  className?: string;
-  score: number;
-  novelty: number;
-  coverage: number;
-  finalScore: number;
-}
-
-/**
- * Result of Explore execution
- */
-export interface ExploreResult {
-  success: boolean;
-  error?: string;
-  cancelled?: boolean;
-  interactionsPerformed: number;
-  screensDiscovered: number;
-  edgesAdded: number;
-  navigationGraph: ExportedGraph;
-  explorationPath: string[];
-  coverage: {
-    totalScreens: number;
-    exploredScreens: number;
-    percentage: number;
-  };
-  elementSelections?: ElementSelectionStats[];
-  observation?: ObserveResult;
-  durationMs: number;
-  stopReason?: string;
-  graphTraversal?: {
-    nodesVisited: number;
-    totalNodes: number;
-    edgesTraversed: number;
-    totalEdges: number;
-    edgeValidationResults: EdgeValidationResult[];
-    coveragePercentage: number;
-  };
-}
-
-export interface PlannedInteraction {
-  order: number;
-  action: "tapOn" | "swipeOn";
-  target: {
-    type: "text" | "id" | "coordinates";
-    value: string;
-  };
-  reason: string;
-  predictedOutcome: {
-    screen: string;
-    confidence: number;
-  };
-  whitelistStatus: "allowed" | "blocked" | "unknown";
-}
-
-export interface ExploreDryRunResult {
-  success: true;
-  dryRun: true;
-  currentScreen: {
-    name: string;
-    interactableElements: number;
-  };
-  plannedInteractions: PlannedInteraction[];
-  estimatedCoverage: {
-    screensToVisit: string[];
-    newScreensExpected: number;
-    existingScreensToRevisit: number;
-  };
-  warnings: string[];
-  observation?: ObserveResult;
-  durationMs: number;
-}
-
-export type ExploreExecutionResult = ExploreResult | ExploreDryRunResult;
-
-/**
- * Tracked element interaction state
- */
-interface TrackedElement {
-  text?: string;
-  resourceId?: string;
-  contentDesc?: string;
-  className?: string;
-  interactionCount: number;
-  lastInteractionScreen: string;
-}
-
-/**
- * Edge validation result for tracking success/failure of known transitions
- */
-export interface EdgeValidationResult {
-  edgeKey: string;
-  fromScreen: string;
-  expectedTo: string;
-  actualTo: string | null;
-  success: boolean;
-  timestamp: number;
-  error?: string;
-  matchConfidence?: number;
-}
-
-/**
- * Graph traversal state for validate mode
- */
-export interface GraphTraversalState {
-  visitedNodes: Set<string>;
-  traversedEdges: Set<string>;
-  pendingEdges: NavigationEdge[];
-  edgeValidationResults: Map<string, EdgeValidationResult>;
-  totalNodesInGraph: number;
-  totalEdgesInGraph: number;
-}
+// Import validate mode functions
+import {
+  initializeGraphTraversal,
+  markNodeVisited,
+  markEdgeTraversed,
+  selectNextEdgeToTraverse,
+  findElementMatchingEdge,
+  validateNavigation
+} from "./ExploreValidateMode";
 
 /**
  * Explore implements intelligent app navigation exploration.
@@ -195,9 +90,9 @@ export class Explore extends BaseVisualChange {
 
   // Constants for safety limits
   private static readonly MAX_CONSECUTIVE_BACKS = 5;
-  private static readonly MAX_CONSECUTIVE_NO_CHANGE = 40; // Increased to allow more exploration
+  private static readonly MAX_CONSECUTIVE_NO_CHANGE = 40;
   private static readonly MAX_LOOP_ITERATIONS = 3;
-  private static readonly DEFAULT_MAX_INTERACTIONS = 200; // Increased to allow thorough exploration
+  private static readonly DEFAULT_MAX_INTERACTIONS = 200;
   private static readonly DEFAULT_TIMEOUT_MS = 5 * 60 * 1000; // 5 minutes
   private static readonly DEFAULT_RESET_INTERVAL = 15;
   private static readonly MAX_OUT_OF_APP_ATTEMPTS = 5;
@@ -260,7 +155,7 @@ export class Explore extends BaseVisualChange {
 
       // Initialize graph traversal for validate mode
       if (mode === "validate") {
-        await this.initializeGraphTraversal();
+        this.graphTraversalState = await initializeGraphTraversal(this.navigationManager);
         logger.info(
           `[Explore] Validate mode: traversing ${this.graphTraversalState?.totalEdgesInGraph ?? 0} known edges`
         );
@@ -277,10 +172,10 @@ export class Explore extends BaseVisualChange {
 
         const viewHierarchy = observation.viewHierarchy;
         if (viewHierarchy && !viewHierarchy.hierarchy.error) {
-          const elements = this.extractAllElements(viewHierarchy);
-          if (this.isPermissionDialog(elements)) {
+          const elements = extractAllElements(viewHierarchy, this.elementParser);
+          if (isPermissionDialog(elements)) {
             logger.info("[Explore] Detected permission dialog, attempting to dismiss");
-            await this.handlePermissionDialog(elements, progress);
+            await handlePermissionDialog(elements, this.device, this.adb, progress);
             continue;
           }
         }
@@ -307,7 +202,14 @@ export class Explore extends BaseVisualChange {
         }
 
         // Check for blocker screens (auth, permissions, etc.) and handle them
-        const blockerHandled = await this.detectAndHandleBlockers(observation, progress);
+        const blockerHandled = await detectAndHandleBlockers(
+          observation,
+          this.device,
+          this.adb,
+          this.elementParser,
+          p => this.handleDeadEnd(p),
+          progress
+        );
         if (blockerHandled) {
           // Re-observe after handling blocker
           continue;
@@ -354,12 +256,14 @@ export class Explore extends BaseVisualChange {
           this.consecutiveNoChangeCount = 0;
 
           // Validate navigation in validate mode
-          if (mode === "validate" && this.currentTargetEdge) {
-            const preNavigationScreen = currentScreen ?? "unknown";
-            const validationSuccess = await this.validateNavigation(
+          if (mode === "validate" && this.currentTargetEdge && this.graphTraversalState) {
+            const validationSuccess = await validateNavigation(
               this.currentTargetEdge,
-              preNavigationScreen,
-              this.currentElementConfidence
+              this.graphTraversalState,
+              this.navigationManager,
+              this.timer,
+              this.currentElementConfidence,
+              reason => { this.stopReason = reason; }
             );
 
             if (!validationSuccess) {
@@ -500,18 +404,18 @@ export class Explore extends BaseVisualChange {
         ? await this.navigationManager.getEdgesFrom(currentScreen)
         : [];
 
-    const navigationElements = this.extractNavigationElements(viewHierarchy);
-    const scrollableContainers = this.extractScrollableContainers(viewHierarchy);
+    const navigationElements = extractNavigationElements(viewHierarchy, this.elementParser);
+    const scrollableContainers = extractScrollableContainers(viewHierarchy, this.elementParser);
     const allCandidates = [...navigationElements, ...scrollableContainers];
 
     if (allCandidates.length === 0) {
       warnings.push("No interactable elements were detected on the current screen.");
     }
 
-    const scored = this.rankElementsForDryRun(allCandidates, strategy, mode);
+    const scored = rankElementsForDryRun(allCandidates, strategy, mode, this.exploredElements);
     const plannedInteractions = scored.slice(0, maxInteractions).map((entry, index) => {
-      const target = this.getElementTarget(entry.element);
-      const predictedOutcome = this.predictOutcomeForElement(entry.element, edges);
+      const target = getElementTarget(entry.element);
+      const predictedOutcome = predictOutcomeForElement(entry.element, edges);
 
       return {
         order: index + 1,
@@ -632,8 +536,8 @@ export class Explore extends BaseVisualChange {
       }
 
       // Extract both navigation elements and scrollable containers
-      const navigationElements = this.extractNavigationElements(viewHierarchy);
-      const scrollableContainers = this.extractScrollableContainers(viewHierarchy);
+      const navigationElements = extractNavigationElements(viewHierarchy, this.elementParser);
+      const scrollableContainers = extractScrollableContainers(viewHierarchy, this.elementParser);
 
       // Combine all interaction candidates
       const allCandidates = [...navigationElements, ...scrollableContainers];
@@ -648,11 +552,11 @@ export class Explore extends BaseVisualChange {
 
         // Mark current node as visited
         if (currentScreen !== "unknown") {
-          this.markNodeVisited(currentScreen);
+          markNodeVisited(this.graphTraversalState, currentScreen);
         }
 
         // Select next edge to traverse
-        const targetEdge = this.selectNextEdgeToTraverse(currentScreen);
+        const targetEdge = selectNextEdgeToTraverse(this.graphTraversalState, currentScreen);
         if (!targetEdge) {
           logger.info("[Explore] No more edges to traverse in validate mode");
           this.stopReason = "All edges in navigation graph have been traversed";
@@ -660,7 +564,7 @@ export class Explore extends BaseVisualChange {
         }
 
         // Find element that matches the target edge
-        const match = this.findElementMatchingEdge(allCandidates, targetEdge);
+        const match = findElementMatchingEdge(allCandidates, targetEdge);
         if (!match) {
           const errorMsg =
             `Validate mode: Cannot find element matching edge ${targetEdge.from}->${targetEdge.to}. ` +
@@ -669,10 +573,12 @@ export class Explore extends BaseVisualChange {
           this.stopReason = errorMsg;
 
           // Mark edge as failed
-          this.markEdgeTraversed(
+          markEdgeTraversed(
+            this.graphTraversalState,
             targetEdge,
             null,
             false,
+            this.timer,
             "Element not found on screen"
           );
 
@@ -697,7 +603,12 @@ export class Explore extends BaseVisualChange {
       this.currentElementConfidence = 0;
 
       // Filter out exhausted elements
-      const unexhaustedElements = this.filterUnexhaustedElements(allCandidates);
+      const currentScreen = this.navigationManager.getCurrentScreen();
+      const unexhaustedElements = filterUnexhaustedElements(
+        allCandidates,
+        this.exploredElements,
+        currentScreen
+      );
 
       if (unexhaustedElements.length === 0) {
         return null;
@@ -706,12 +617,19 @@ export class Explore extends BaseVisualChange {
       // Select based on strategy
       switch (strategy) {
         case "breadth-first":
-          return this.selectBreadthFirst(unexhaustedElements);
+          return selectBreadthFirst(unexhaustedElements);
         case "depth-first":
-          return this.selectDepthFirst(unexhaustedElements);
+          return selectDepthFirst(unexhaustedElements, this.exploredElements);
         case "weighted":
-        default:
-          return this.selectWeighted(unexhaustedElements, mode);
+        default: {
+          const result = selectWeighted(unexhaustedElements, mode, this.exploredElements);
+          if (result) {
+            // Record selection stats
+            this.elementSelections.push(result.stats);
+            return result.element;
+          }
+          return null;
+        }
       }
     });
   }
@@ -761,508 +679,6 @@ export class Explore extends BaseVisualChange {
   }
 
   /**
-   * Extract elements likely to be navigation controls
-   */
-  private extractNavigationElements(viewHierarchy: any): Element[] {
-    const flatElements = this.elementParser.flattenViewHierarchy(viewHierarchy);
-    const navigationElements: Element[] = [];
-    const targetPackage = viewHierarchy.packageName;
-
-    for (const { element, depth } of flatElements) {
-      if (this.isNavigationCandidate(element)) {
-        // Filter by package name if available (keep only elements from target app)
-        if (targetPackage && element.package && element.package !== targetPackage) {
-          continue;
-        }
-
-        // Enrich element with properties from child nodes (for Compose UI)
-        const enrichedElement = this.enrichElementWithChildProperties(element);
-
-        // Store depth information for scoring
-        (enrichedElement as any).hierarchyDepth = depth;
-
-        navigationElements.push(enrichedElement);
-      }
-    }
-
-    return navigationElements;
-  }
-
-  /**
-   * Enrich element with properties from child nodes (for Compose UI elements)
-   */
-  private enrichElementWithChildProperties(element: Element): Element {
-    const enriched = { ...element };
-
-    // For Compose elements, text and className might be on child nodes
-    if ((element as any).node) {
-      const children = Array.isArray((element as any).node) ? (element as any).node : [(element as any).node];
-
-      for (const child of children) {
-        // Extract text from first child with text
-        if (!enriched.text && child.text) {
-          enriched.text = child.text;
-        }
-
-        // Extract className from first child with className
-        if (!enriched["class"] && child.className) {
-          enriched["class"] = child.className;
-        }
-
-        // Extract content-desc from first child with content-desc
-        if (!enriched["content-desc"] && child["content-desc"]) {
-          enriched["content-desc"] = child["content-desc"];
-        }
-      }
-    }
-
-    return enriched;
-  }
-
-  /**
-   * Extract scrollable containers for swiping
-   */
-  private extractScrollableContainers(viewHierarchy: any): Element[] {
-    const flatElements = this.elementParser.flattenViewHierarchy(viewHierarchy);
-    const scrollableContainers: Element[] = [];
-    const targetPackage = viewHierarchy.packageName;
-
-    for (const { element, depth } of flatElements) {
-      // Must be scrollable
-      const isScrollable = element.scrollable === true || (element.scrollable as any) === "true";
-      if (!isScrollable) {
-        continue;
-      }
-
-      // Filter by package name if available
-      if (targetPackage && element.package && element.package !== targetPackage) {
-        continue;
-      }
-
-      // Must have reasonable size for scrolling
-      if (element.bounds) {
-        const width = element.bounds.right - element.bounds.left;
-        const height = element.bounds.bottom - element.bounds.top;
-        if (width < 50 || height < 50) {
-          continue;
-        }
-      }
-
-      // Store depth information for scoring
-      (element as any).hierarchyDepth = depth;
-
-      scrollableContainers.push(element);
-    }
-
-    return scrollableContainers;
-  }
-
-  /**
-   * Check if element is a navigation candidate
-   */
-  private isNavigationCandidate(element: Element): boolean {
-    // Must be clickable (handle both boolean and string values from XML parsing)
-    const isClickable = element.clickable === true || (element.clickable as any) === "true";
-    if (!isClickable) {
-      return false;
-    }
-
-    // Must be enabled (handle both boolean and string values from XML parsing)
-    const isEnabled = element.enabled !== false && (element.enabled as any) !== "false";
-    if (!isEnabled) {
-      return false;
-    }
-
-    // Must have reasonable size
-    if (element.bounds) {
-      const width = element.bounds.right - element.bounds.left;
-      const height = element.bounds.bottom - element.bounds.top;
-      if (width < 10 || height < 10) {
-        return false;
-      }
-    }
-
-    // Check if it looks like a navigation element
-    const className = element["class"]?.toLowerCase() ?? "";
-
-    // Avoid input elements
-    if (className.includes("edittext") || className.includes("textfield")) {
-      return false;
-    }
-
-    // Avoid checkboxes and switches
-    if (className.includes("checkbox") || className.includes("switch")) {
-      return false;
-    }
-
-    return true;
-  }
-
-  /**
-   * Calculate navigation score for an element
-   */
-  private calculateNavigationScore(element: Element): number {
-    let score = 0;
-
-    const clickable = element.clickable === true || (element.clickable as any) === "true";
-    const scrollable = element.scrollable === true || (element.scrollable as any) === "true";
-
-    // Clickable bonus - clickable elements are more likely to be interactive
-    if (clickable) {
-      score += 5;
-    }
-
-    // Scrollable bonus - scrollable containers can reveal new content
-    if (scrollable) {
-      score += 3;
-    }
-
-    // Hierarchy depth bonus - linear function where closer to root = higher score
-    // Formula: max(0, 25 - depth * 2)
-    // depth 0: +25, depth 3: +19, depth 6: +13, depth 10: +5, depth 12+: 0
-    const depth = (element as any).hierarchyDepth ?? 99;
-    const depthBonus = Math.max(0, 25 - depth * 2);
-    score += depthBonus;
-
-    return Math.max(0, score);
-  }
-
-  /**
-   * Calculate novelty score based on previous interactions
-   */
-  private calculateNoveltyScore(element: Element): number {
-    const elementKey = this.getElementKey(element);
-    const tracked = this.exploredElements.get(elementKey);
-
-    // High score for never-explored elements
-    if (!tracked) {
-      return 10;
-    }
-
-    // Reduce score based on interaction count
-    return Math.max(1, 10 - tracked.interactionCount);
-  }
-
-  /**
-   * Estimate coverage gain from interacting with element
-   */
-  private estimateCoverageGain(element: Element): number {
-    // For now, use a simple heuristic based on navigation score
-    // Future: could use ML or historical data
-    const navScore = this.calculateNavigationScore(element);
-    return Math.max(1, navScore / 10);
-  }
-
-  /**
-   * Filter out elements that have been exhausted
-   */
-  private filterUnexhaustedElements(elements: Element[]): Element[] {
-    const currentScreen = this.navigationManager.getCurrentScreen();
-
-    return elements.filter(element => {
-      const elementKey = this.getElementKey(element);
-      const tracked = this.exploredElements.get(elementKey);
-
-      // Allow if never tried
-      if (!tracked) {
-        return true;
-      }
-
-      // Allow if tried on different screen
-      if (tracked.lastInteractionScreen !== currentScreen) {
-        return true;
-      }
-
-      // Filter out if tried too many times from this screen
-      return tracked.interactionCount < 2;
-    });
-  }
-
-  /**
-   * Breadth-first selection: prefer unexplored elements on current screen
-   */
-  private selectBreadthFirst(elements: Element[]): Element | null {
-    if (elements.length === 0) {
-      return null;
-    }
-
-    // Sort by navigation score
-    const sorted = elements.sort((a, b) => {
-      return this.calculateNavigationScore(b) - this.calculateNavigationScore(a);
-    });
-
-    return sorted[0];
-  }
-
-  /**
-   * Depth-first selection: follow promising paths deeply
-   */
-  private selectDepthFirst(elements: Element[]): Element | null {
-    if (elements.length === 0) {
-      return null;
-    }
-
-    // Prefer elements we haven't tried yet, then by score
-    const sorted = elements.sort((a, b) => {
-      const aNever = !this.exploredElements.has(this.getElementKey(a));
-      const bNever = !this.exploredElements.has(this.getElementKey(b));
-
-      if (aNever && !bNever) {
-        return -1;
-      }
-      if (!aNever && bNever) {
-        return 1;
-      }
-
-      return this.calculateNavigationScore(b) - this.calculateNavigationScore(a);
-    });
-
-    return sorted[0];
-  }
-
-  /**
-   * Weighted selection: balance navigation score, novelty, and coverage
-   */
-  private selectWeighted(
-    elements: Element[],
-    mode: ExplorationMode
-  ): Element | null {
-    if (elements.length === 0) {
-      return null;
-    }
-
-    // Calculate scores for each element
-    const scored = elements.map(element => {
-      const navScore = this.calculateNavigationScore(element);
-      const novelty = this.calculateNoveltyScore(element);
-      const coverage = this.estimateCoverageGain(element);
-
-      // Adjust weights based on mode
-      let finalScore: number;
-      if (mode === "discover") {
-        // Heavily favor novelty and coverage
-        finalScore = navScore * 0.3 + novelty * 0.4 + coverage * 0.3;
-      } else if (mode === "validate") {
-        // Favor previously explored elements
-        finalScore = navScore * 0.5 + (10 - novelty) * 0.3 + coverage * 0.2;
-      } else {
-        // Hybrid: balanced approach
-        finalScore = navScore * 0.4 + novelty * 0.4 + coverage * 0.2;
-      }
-
-      return {
-        element,
-        navScore,
-        novelty,
-        coverage,
-        finalScore
-      };
-    });
-
-    // Sort by final score
-    scored.sort((a, b) => b.finalScore - a.finalScore);
-
-    // Record selection stats
-    const selected = scored[0];
-    this.elementSelections.push({
-      text: selected.element.text,
-      resourceId: selected.element["resource-id"],
-      className: selected.element["class"],
-      score: selected.navScore,
-      novelty: selected.novelty,
-      coverage: selected.coverage,
-      finalScore: selected.finalScore
-    });
-
-    return selected.element;
-  }
-
-  private rankElementsForDryRun(
-    elements: Element[],
-    strategy: ExplorationStrategy,
-    mode: ExplorationMode
-  ): Array<{
-    element: Element;
-    score: number;
-    reason: string;
-    action: "tapOn" | "swipeOn";
-    whitelistStatus: "allowed" | "blocked" | "unknown";
-  }> {
-    const scored = elements.map(element => {
-      const navScore = this.calculateNavigationScore(element);
-      const novelty = this.calculateNoveltyScore(element);
-      const coverage = this.estimateCoverageGain(element);
-      const isScrollable = element.scrollable === true || (element.scrollable as any) === "true";
-
-      let score = navScore;
-      let reason = `Navigation score ${navScore.toFixed(1)}`;
-
-      if (strategy === "weighted") {
-        if (mode === "discover") {
-          score = navScore * 0.3 + novelty * 0.4 + coverage * 0.3;
-        } else if (mode === "validate") {
-          score = navScore * 0.5 + (10 - novelty) * 0.3 + coverage * 0.2;
-        } else {
-          score = navScore * 0.4 + novelty * 0.4 + coverage * 0.2;
-        }
-        reason =
-          `Weighted score ${score.toFixed(2)} ` +
-          `(nav=${navScore.toFixed(1)}, novelty=${novelty.toFixed(1)}, coverage=${coverage.toFixed(1)})`;
-      } else if (strategy === "depth-first") {
-        reason = `Depth-first preference with score ${score.toFixed(1)}`;
-      } else {
-        reason = `Breadth-first priority with score ${score.toFixed(1)}`;
-      }
-
-      return {
-        element,
-        score,
-        reason,
-        action: isScrollable ? "swipeOn" : "tapOn",
-        whitelistStatus: "unknown"
-      };
-    });
-
-    scored.sort((a, b) => b.score - a.score);
-    return scored;
-  }
-
-  private getElementTarget(element: Element): PlannedInteraction["target"] {
-    if (element.text) {
-      return { type: "text", value: element.text };
-    }
-    if (element["content-desc"]) {
-      return { type: "text", value: element["content-desc"] };
-    }
-    if (element["resource-id"]) {
-      return { type: "id", value: element["resource-id"] };
-    }
-    if (element.bounds) {
-      const x = Math.round((element.bounds.left + element.bounds.right) / 2);
-      const y = Math.round((element.bounds.top + element.bounds.bottom) / 2);
-      return { type: "coordinates", value: `${x},${y}` };
-    }
-    return { type: "coordinates", value: "0,0" };
-  }
-
-  private predictOutcomeForElement(
-    element: Element,
-    edges: NavigationEdge[]
-  ): PlannedInteraction["predictedOutcome"] {
-    if (edges.length === 0) {
-      return { screen: "unknown", confidence: 0 };
-    }
-
-    let bestScore = 0;
-    let bestScreen = "unknown";
-
-    for (const edge of edges) {
-      const score = this.scoreEdgeMatch(element, edge);
-      if (score > bestScore) {
-        bestScore = score;
-        bestScreen = edge.to;
-      }
-    }
-
-    if (bestScore <= 0) {
-      return { screen: "unknown", confidence: 0 };
-    }
-
-    return { screen: bestScreen, confidence: Math.round(bestScore * 100) / 100 };
-  }
-
-  private scoreEdgeMatch(element: Element, edge: NavigationEdge): number {
-    const uiState = edge.uiState || edge.interaction?.uiState;
-    if (!uiState) {
-      return 0;
-    }
-
-    let score = 0;
-    for (const selected of uiState.selectedElements ?? []) {
-      score = Math.max(score, this.scoreSelectedElementMatch(element, selected));
-    }
-
-    if (uiState.scrollPosition) {
-      score = Math.max(score, this.scoreScrollPositionMatch(element, uiState.scrollPosition));
-    }
-
-    return score;
-  }
-
-  private scoreSelectedElementMatch(
-    element: Element,
-    selected: { text?: string; resourceId?: string; contentDesc?: string }
-  ): number {
-    let score = 0;
-    score = Math.max(
-      score,
-      this.scoreIdentifierMatch(element["resource-id"], selected.resourceId, 0.95, 0.85)
-    );
-    score = Math.max(score, this.scoreIdentifierMatch(element.text, selected.text, 0.9, 0.7));
-    score = Math.max(
-      score,
-      this.scoreIdentifierMatch(element["content-desc"], selected.contentDesc, 0.85, 0.65)
-    );
-    return score;
-  }
-
-  private scoreScrollPositionMatch(
-    element: Element,
-    scrollPosition: {
-      container?: { text?: string; resourceId?: string; contentDesc?: string };
-      targetElement: { text?: string; resourceId?: string; contentDesc?: string };
-    }
-  ): number {
-    let score = 0;
-    if (scrollPosition.container) {
-      score = Math.max(
-        score,
-        this.scoreIdentifierMatch(element["resource-id"], scrollPosition.container.resourceId, 0.8, 0.7)
-      );
-      score = Math.max(score, this.scoreIdentifierMatch(element.text, scrollPosition.container.text, 0.75, 0.65));
-      score = Math.max(
-        score,
-        this.scoreIdentifierMatch(element["content-desc"], scrollPosition.container.contentDesc, 0.75, 0.65)
-      );
-    }
-
-    score = Math.max(
-      score,
-      this.scoreIdentifierMatch(element["resource-id"], scrollPosition.targetElement.resourceId, 0.8, 0.7)
-    );
-    score = Math.max(score, this.scoreIdentifierMatch(element.text, scrollPosition.targetElement.text, 0.75, 0.65));
-    score = Math.max(
-      score,
-      this.scoreIdentifierMatch(element["content-desc"], scrollPosition.targetElement.contentDesc, 0.75, 0.65)
-    );
-
-    return score;
-  }
-
-  private scoreIdentifierMatch(
-    value: string | undefined,
-    candidate: string | undefined,
-    fullMatchScore: number,
-    partialMatchScore: number
-  ): number {
-    if (!value || !candidate) {
-      return 0;
-    }
-    const normalizedValue = value.trim().toLowerCase();
-    const normalizedCandidate = candidate.trim().toLowerCase();
-    if (normalizedValue === normalizedCandidate) {
-      return fullMatchScore;
-    }
-    if (
-      normalizedValue.includes(normalizedCandidate) ||
-      normalizedCandidate.includes(normalizedValue)
-    ) {
-      return partialMatchScore;
-    }
-    return 0;
-  }
-
-  /**
    * Perform interaction with selected element
    */
   private async performInteraction(
@@ -1272,7 +688,7 @@ export class Explore extends BaseVisualChange {
     perf?: PerformanceTracker,
     signal?: AbortSignal
   ): Promise<boolean> {
-    const elementKey = this.getElementKey(element);
+    const elementKey = getElementKey(element);
     const currentScreen = this.navigationManager.getCurrentScreen() ?? "unknown";
 
     try {
@@ -1336,176 +752,6 @@ export class Explore extends BaseVisualChange {
   }
 
   /**
-   * Detect and handle blocker screens (login, permissions, dialogs)
-   */
-  private async detectAndHandleBlockers(
-    observation: ObserveResult,
-    progress?: ProgressCallback
-  ): Promise<boolean> {
-    const viewHierarchy = observation.viewHierarchy;
-    if (!viewHierarchy || viewHierarchy.hierarchy.error) {
-      return false;
-    }
-
-    // Look for common blocker patterns
-    const elements = this.extractAllElements(viewHierarchy);
-
-    // Check for permission dialogs
-    if (this.isPermissionDialog(elements)) {
-      logger.info("[Explore] Detected permission dialog, attempting to dismiss");
-      return await this.handlePermissionDialog(elements, progress);
-    }
-
-    // Check for login/signup screens
-    if (this.isLoginScreen(elements)) {
-      logger.info("[Explore] Detected login screen, skipping by going back");
-      await this.handleDeadEnd(progress);
-      return true;
-    }
-
-    // Check for app rating/review dialogs
-    if (this.isRatingDialog(elements)) {
-      logger.info("[Explore] Detected rating dialog, attempting to dismiss");
-      return await this.dismissDialog(elements, progress);
-    }
-
-    return false;
-  }
-
-  /**
-   * Extract all elements from hierarchy (including non-clickable)
-   */
-  private extractAllElements(viewHierarchy: any): Element[] {
-    const flatElements = this.elementParser.flattenViewHierarchy(viewHierarchy);
-    return flatElements.map(({ element }) => element);
-  }
-
-  /**
-   * Check if screen is a permission dialog
-   */
-  private isPermissionDialog(elements: Element[]): boolean {
-    const permissionKeywords = [
-      "allow",
-      "permission",
-      "access",
-      "deny",
-      "don't allow",
-      "while using",
-      "only this time"
-    ];
-
-    return elements.some(el => {
-      const text = (el.text?.toLowerCase() ?? "") + (el["content-desc"]?.toLowerCase() ?? "");
-      return permissionKeywords.some(keyword => text.includes(keyword));
-    });
-  }
-
-  /**
-   * Check if screen is a login/signup screen
-   */
-  private isLoginScreen(elements: Element[]): boolean {
-    const loginKeywords = ["login", "sign in", "sign up", "username", "password", "email"];
-    const hasEditText = elements.some(el => el["class"]?.toLowerCase().includes("edittext"));
-
-    const hasLoginText = elements.some(el => {
-      const text = (el.text?.toLowerCase() ?? "") + (el["content-desc"]?.toLowerCase() ?? "");
-      return loginKeywords.some(keyword => text.includes(keyword));
-    });
-
-    // Login screen typically has text fields and login-related text
-    return hasEditText && hasLoginText;
-  }
-
-  /**
-   * Check if screen is a rating/review dialog
-   */
-  private isRatingDialog(elements: Element[]): boolean {
-    const ratingKeywords = ["rate", "review", "feedback", "enjoy", "star"];
-
-    return elements.some(el => {
-      const text = (el.text?.toLowerCase() ?? "") + (el["content-desc"]?.toLowerCase() ?? "");
-      return ratingKeywords.some(keyword => text.includes(keyword));
-    });
-  }
-
-  /**
-   * Handle permission dialog by clicking "Allow" or similar
-   */
-  private async handlePermissionDialog(
-    elements: Element[],
-    progress?: ProgressCallback
-  ): Promise<boolean> {
-    // Look for "Allow" or "While using" buttons
-    const allowKeywords = ["allow", "while using", "only this time", "ok"];
-
-    for (const element of elements) {
-      if (!element.clickable) {
-        continue;
-      }
-
-      const text = (element.text?.toLowerCase() ?? "") + (element["content-desc"]?.toLowerCase() ?? "");
-
-      if (allowKeywords.some(keyword => text.includes(keyword))) {
-        try {
-          const tapOn = new TapOnElement(this.device, this.adb);
-          await tapOn.execute(
-            {
-              text: element.text,
-              elementId: element["resource-id"],
-              action: "tap"
-            },
-            progress
-          );
-          await new Promise(resolve => setTimeout(resolve, 1000));
-          return true;
-        } catch (error) {
-          logger.warn(`[Explore] Failed to handle permission dialog: ${error}`);
-        }
-      }
-    }
-
-    return false;
-  }
-
-  /**
-   * Dismiss dialog by clicking dismiss/close/later buttons
-   */
-  private async dismissDialog(
-    elements: Element[],
-    progress?: ProgressCallback
-  ): Promise<boolean> {
-    const dismissKeywords = ["not now", "later", "no thanks", "dismiss", "close", "skip"];
-
-    for (const element of elements) {
-      if (!element.clickable) {
-        continue;
-      }
-
-      const text = (element.text?.toLowerCase() ?? "") + (element["content-desc"]?.toLowerCase() ?? "");
-
-      if (dismissKeywords.some(keyword => text.includes(keyword))) {
-        try {
-          const tapOn = new TapOnElement(this.device, this.adb);
-          await tapOn.execute(
-            {
-              text: element.text,
-              elementId: element["resource-id"],
-              action: "tap"
-            },
-            progress
-          );
-          await new Promise(resolve => setTimeout(resolve, 1000));
-          return true;
-        } catch (error) {
-          logger.warn(`[Explore] Failed to dismiss dialog: ${error}`);
-        }
-      }
-    }
-
-    return false;
-  }
-
-  /**
    * Handle dead-end situation by going back
    */
   private async handleDeadEnd(progress?: ProgressCallback): Promise<void> {
@@ -1553,261 +799,6 @@ export class Explore extends BaseVisualChange {
     } catch (error) {
       logger.warn(`[Explore] Failed to reset to home: ${error}`);
     }
-  }
-
-  /**
-   * Generate unique key for element tracking
-   */
-  private getElementKey(element: Element): string {
-    const parts: string[] = [];
-
-    if (element["resource-id"]) {
-      parts.push(`id:${element["resource-id"]}`);
-    }
-    if (element.text) {
-      parts.push(`text:${element.text}`);
-    }
-    if (element["content-desc"]) {
-      parts.push(`desc:${element["content-desc"]}`);
-    }
-    if (element["class"]) {
-      parts.push(`class:${element["class"]}`);
-    }
-
-    return parts.join("|") || "unknown";
-  }
-
-  /**
-   * Validate that navigation matched expected edge in validate mode
-   */
-  private async validateNavigation(
-    expectedEdge: NavigationEdge,
-    preNavigationScreen: string,
-    elementConfidence: number
-  ): Promise<boolean> {
-    // Wait a bit for navigation to complete
-    await new Promise(resolve => setTimeout(resolve, 500));
-
-    const actualScreen = this.navigationManager.getCurrentScreen() ?? "unknown";
-    const success = actualScreen === expectedEdge.to;
-
-    // Mark edge as traversed with result
-    this.markEdgeTraversed(
-      expectedEdge,
-      actualScreen,
-      success,
-      success ? undefined : `Expected ${expectedEdge.to}, got ${actualScreen}`,
-      elementConfidence
-    );
-
-    if (!success) {
-      const errorMsg =
-        `Validate mode: Navigation validation failed for edge ${expectedEdge.from}->${expectedEdge.to}. ` +
-        `Expected to reach "${expectedEdge.to}", but reached "${actualScreen}". ` +
-        `App has diverged from known graph.`;
-      logger.error(`[Explore] ${errorMsg}`);
-      this.stopReason = errorMsg;
-    }
-
-    return success;
-  }
-
-  /**
-   * Find element on screen that matches a target edge
-   */
-  private findElementMatchingEdge(
-    elements: Element[],
-    edge: NavigationEdge
-  ): { element: Element; confidence: number } | null {
-    const uiState = edge.uiState || edge.interaction?.uiState;
-    if (!uiState) {
-      logger.warn(`[Explore] Edge ${edge.from}->${edge.to} has no UI state, cannot match`);
-      return null;
-    }
-
-    let bestMatch: { element: Element; confidence: number } | null = null;
-    let bestScore = 0;
-
-    for (const element of elements) {
-      // Try to match against selected elements in the edge's UI state
-      if (uiState.selectedElements && uiState.selectedElements.length > 0) {
-        for (const selected of uiState.selectedElements) {
-          const score = this.scoreSelectedElementMatch(element, selected);
-          if (score > bestScore) {
-            bestScore = score;
-            bestMatch = { element, confidence: score };
-          }
-        }
-      }
-
-      // Try to match against scroll position if present
-      if (uiState.scrollPosition) {
-        const score = this.scoreScrollPositionMatch(element, uiState.scrollPosition);
-        if (score > bestScore) {
-          bestScore = score;
-          bestMatch = { element, confidence: score };
-        }
-      }
-    }
-
-    // Require minimum confidence threshold
-    const MIN_CONFIDENCE = 0.6;
-    if (bestMatch && bestMatch.confidence >= MIN_CONFIDENCE) {
-      logger.debug(
-        `[Explore] Matched element for edge ${edge.from}->${edge.to} with confidence ${bestMatch.confidence.toFixed(2)}`
-      );
-      return bestMatch;
-    }
-
-    logger.warn(
-      `[Explore] No confident match for edge ${edge.from}->${edge.to} ` +
-        `(best score: ${bestScore.toFixed(2)}, threshold: ${MIN_CONFIDENCE})`
-    );
-    return null;
-  }
-
-  /**
-   * Initialize graph traversal state for validate mode
-   */
-  private async initializeGraphTraversal(): Promise<void> {
-    const graph = await this.navigationManager.exportGraph();
-    const allEdges: NavigationEdge[] = [];
-
-    // Collect all edges from the graph
-    for (const edge of graph.edges) {
-      allEdges.push(edge);
-    }
-
-    this.graphTraversalState = {
-      visitedNodes: new Set<string>(),
-      traversedEdges: new Set<string>(),
-      pendingEdges: [...allEdges],
-      edgeValidationResults: new Map<string, EdgeValidationResult>(),
-      totalNodesInGraph: graph.nodes.length,
-      totalEdgesInGraph: allEdges.length
-    };
-
-    logger.info(
-      `[Explore] Initialized graph traversal: ${graph.nodes.length} nodes, ${allEdges.length} edges`
-    );
-  }
-
-  /**
-   * Generate edge key for tracking
-   * Uses hash of the action/interaction to ensure uniqueness for multiple edges between same screens
-   * Format: {from}->{action_hash}->{to}
-   */
-  private getEdgeKey(edge: NavigationEdge): string {
-    const actionHash = this.hashEdgeAction(edge);
-    return `${edge.from}->${actionHash}->${edge.to}`;
-  }
-
-  /**
-   * Create a deterministic hash of the edge's action/interaction
-   * This ensures the same interaction always produces the same hash
-   */
-  private hashEdgeAction(edge: NavigationEdge): string {
-    // For edges without interactions (back button, unknown), use edge type
-    if (!edge.interaction) {
-      return createHash("sha256")
-        .update(`${edge.edgeType}`)
-        .digest("hex")
-        .substring(0, 8);
-    }
-
-    // Create a stable representation of the interaction, excluding timestamps
-    const stableData = {
-      toolName: edge.interaction.toolName,
-      // Sort args keys for stability, exclude any timestamp-like fields
-      args: Object.keys(edge.interaction.args)
-        .filter(k => !k.toLowerCase().includes("timestamp"))
-        .sort()
-        .reduce((acc, key) => {
-          acc[key] = edge.interaction!.args[key];
-          return acc;
-        }, {} as Record<string, any>),
-      // Include edge type for additional uniqueness
-      edgeType: edge.edgeType
-    };
-
-    return createHash("sha256")
-      .update(JSON.stringify(stableData))
-      .digest("hex")
-      .substring(0, 8); // Use first 8 chars for readability
-  }
-
-  /**
-   * Mark current node as visited
-   */
-  private markNodeVisited(screenName: string): void {
-    if (!this.graphTraversalState) {
-      return;
-    }
-    this.graphTraversalState.visitedNodes.add(screenName);
-  }
-
-  /**
-   * Mark edge as traversed with validation result
-   */
-  private markEdgeTraversed(
-    edge: NavigationEdge,
-    actualTo: string | null,
-    success: boolean,
-    error?: string,
-    matchConfidence?: number
-  ): void {
-    if (!this.graphTraversalState) {
-      return;
-    }
-
-    const edgeKey = this.getEdgeKey(edge);
-    this.graphTraversalState.traversedEdges.add(edgeKey);
-
-    const validationResult: EdgeValidationResult = {
-      edgeKey,
-      fromScreen: edge.from,
-      expectedTo: edge.to,
-      actualTo,
-      success,
-      timestamp: this.timer.now(),
-      error,
-      matchConfidence
-    };
-
-    this.graphTraversalState.edgeValidationResults.set(edgeKey, validationResult);
-
-    // Remove from pending edges
-    this.graphTraversalState.pendingEdges = this.graphTraversalState.pendingEdges.filter(
-      e => this.getEdgeKey(e) !== edgeKey
-    );
-
-    logger.info(
-      `[Explore] Edge ${edgeKey} validation: ${success ? "SUCCESS" : "FAILED"}` +
-        (actualTo && actualTo !== edge.to ? ` (went to ${actualTo})` : "")
-    );
-  }
-
-  /**
-   * Select next edge to traverse in validate mode
-   * Only selects edges from the current screen to avoid false divergence
-   */
-  private selectNextEdgeToTraverse(currentScreen: string): NavigationEdge | null {
-    if (!this.graphTraversalState) {
-      return null;
-    }
-
-    // Only select untraversed edges from current screen
-    // Do not attempt to navigate to other screens, as this causes false divergence
-    const untraversedFromCurrent = this.graphTraversalState.pendingEdges.filter(
-      edge => edge.from === currentScreen
-    );
-
-    if (untraversedFromCurrent.length > 0) {
-      return untraversedFromCurrent[0];
-    }
-
-    // No edges from current screen - exploration is complete or stuck
-    return null;
   }
 
   /**

--- a/src/features/navigation/ExploreBlockerDetection.ts
+++ b/src/features/navigation/ExploreBlockerDetection.ts
@@ -1,0 +1,205 @@
+import type { BootedDevice, Element, ObserveResult } from "../../models";
+import type { AdbClient } from "../../utils/android-cmdline-tools/AdbClient";
+import type { ProgressCallback } from "../action/BaseVisualChange";
+import type { ElementParser } from "../utility/ElementParser";
+import { TapOnElement } from "../action/TapOnElement";
+import { logger } from "../../utils/logger";
+import { extractAllElements } from "./ExploreElementExtraction";
+
+/**
+ * Check if screen is a permission dialog
+ */
+export function isPermissionDialog(elements: Element[]): boolean {
+  const permissionKeywords = [
+    "allow",
+    "permission",
+    "access",
+    "deny",
+    "don't allow",
+    "while using",
+    "only this time"
+  ];
+
+  return elements.some(el => {
+    const text =
+      (el.text?.toLowerCase() ?? "") + (el["content-desc"]?.toLowerCase() ?? "");
+    return permissionKeywords.some(keyword => text.includes(keyword));
+  });
+}
+
+/**
+ * Check if screen is a login/signup screen
+ */
+export function isLoginScreen(elements: Element[]): boolean {
+  const loginKeywords = [
+    "login",
+    "sign in",
+    "sign up",
+    "username",
+    "password",
+    "email"
+  ];
+  const hasEditText = elements.some(el =>
+    el["class"]?.toLowerCase().includes("edittext")
+  );
+
+  const hasLoginText = elements.some(el => {
+    const text =
+      (el.text?.toLowerCase() ?? "") + (el["content-desc"]?.toLowerCase() ?? "");
+    return loginKeywords.some(keyword => text.includes(keyword));
+  });
+
+  // Login screen typically has text fields and login-related text
+  return hasEditText && hasLoginText;
+}
+
+/**
+ * Check if screen is a rating/review dialog
+ */
+export function isRatingDialog(elements: Element[]): boolean {
+  const ratingKeywords = ["rate", "review", "feedback", "enjoy", "star"];
+
+  return elements.some(el => {
+    const text =
+      (el.text?.toLowerCase() ?? "") + (el["content-desc"]?.toLowerCase() ?? "");
+    return ratingKeywords.some(keyword => text.includes(keyword));
+  });
+}
+
+/**
+ * Handle permission dialog by clicking "Allow" or similar
+ */
+export async function handlePermissionDialog(
+  elements: Element[],
+  device: BootedDevice,
+  adb: AdbClient | null,
+  progress?: ProgressCallback
+): Promise<boolean> {
+  // Look for "Allow" or "While using" buttons
+  const allowKeywords = ["allow", "while using", "only this time", "ok"];
+
+  for (const element of elements) {
+    if (!element.clickable) {
+      continue;
+    }
+
+    const text =
+      (element.text?.toLowerCase() ?? "") +
+      (element["content-desc"]?.toLowerCase() ?? "");
+
+    if (allowKeywords.some(keyword => text.includes(keyword))) {
+      try {
+        const tapOn = new TapOnElement(device, adb);
+        await tapOn.execute(
+          {
+            text: element.text,
+            elementId: element["resource-id"],
+            action: "tap"
+          },
+          progress
+        );
+        await new Promise(resolve => setTimeout(resolve, 1000));
+        return true;
+      } catch (error) {
+        logger.warn(`[Explore] Failed to handle permission dialog: ${error}`);
+      }
+    }
+  }
+
+  return false;
+}
+
+/**
+ * Dismiss dialog by clicking dismiss/close/later buttons
+ */
+export async function dismissDialog(
+  elements: Element[],
+  device: BootedDevice,
+  adb: AdbClient | null,
+  progress?: ProgressCallback
+): Promise<boolean> {
+  const dismissKeywords = [
+    "not now",
+    "later",
+    "no thanks",
+    "dismiss",
+    "close",
+    "skip"
+  ];
+
+  for (const element of elements) {
+    if (!element.clickable) {
+      continue;
+    }
+
+    const text =
+      (element.text?.toLowerCase() ?? "") +
+      (element["content-desc"]?.toLowerCase() ?? "");
+
+    if (dismissKeywords.some(keyword => text.includes(keyword))) {
+      try {
+        const tapOn = new TapOnElement(device, adb);
+        await tapOn.execute(
+          {
+            text: element.text,
+            elementId: element["resource-id"],
+            action: "tap"
+          },
+          progress
+        );
+        await new Promise(resolve => setTimeout(resolve, 1000));
+        return true;
+      } catch (error) {
+        logger.warn(`[Explore] Failed to dismiss dialog: ${error}`);
+      }
+    }
+  }
+
+  return false;
+}
+
+/**
+ * Handler for dead end situations
+ */
+export type DeadEndHandler = (progress?: ProgressCallback) => Promise<void>;
+
+/**
+ * Detect and handle blocker screens (login, permissions, dialogs)
+ */
+export async function detectAndHandleBlockers(
+  observation: ObserveResult,
+  device: BootedDevice,
+  adb: AdbClient | null,
+  elementParser: ElementParser,
+  handleDeadEnd: DeadEndHandler,
+  progress?: ProgressCallback
+): Promise<boolean> {
+  const viewHierarchy = observation.viewHierarchy;
+  if (!viewHierarchy || viewHierarchy.hierarchy.error) {
+    return false;
+  }
+
+  // Look for common blocker patterns
+  const elements = extractAllElements(viewHierarchy, elementParser);
+
+  // Check for permission dialogs
+  if (isPermissionDialog(elements)) {
+    logger.info("[Explore] Detected permission dialog, attempting to dismiss");
+    return await handlePermissionDialog(elements, device, adb, progress);
+  }
+
+  // Check for login/signup screens
+  if (isLoginScreen(elements)) {
+    logger.info("[Explore] Detected login screen, skipping by going back");
+    await handleDeadEnd(progress);
+    return true;
+  }
+
+  // Check for app rating/review dialogs
+  if (isRatingDialog(elements)) {
+    logger.info("[Explore] Detected rating dialog, attempting to dismiss");
+    return await dismissDialog(elements, device, adb, progress);
+  }
+
+  return false;
+}

--- a/src/features/navigation/ExploreElementExtraction.ts
+++ b/src/features/navigation/ExploreElementExtraction.ts
@@ -1,0 +1,212 @@
+import type { Element } from "../../models";
+import type { ElementParser } from "../utility/ElementParser";
+import type { TrackedElement } from "./ExploreTypes";
+
+/**
+ * Extract elements likely to be navigation controls
+ */
+export function extractNavigationElements(
+  viewHierarchy: any,
+  elementParser: ElementParser
+): Element[] {
+  const flatElements = elementParser.flattenViewHierarchy(viewHierarchy);
+  const navigationElements: Element[] = [];
+  const targetPackage = viewHierarchy.packageName;
+
+  for (const { element, depth } of flatElements) {
+    if (isNavigationCandidate(element)) {
+      // Filter by package name if available (keep only elements from target app)
+      if (targetPackage && element.package && element.package !== targetPackage) {
+        continue;
+      }
+
+      // Enrich element with properties from child nodes (for Compose UI)
+      const enrichedElement = enrichElementWithChildProperties(element);
+
+      // Store depth information for scoring
+      (enrichedElement as any).hierarchyDepth = depth;
+
+      navigationElements.push(enrichedElement);
+    }
+  }
+
+  return navigationElements;
+}
+
+/**
+ * Enrich element with properties from child nodes (for Compose UI elements)
+ */
+export function enrichElementWithChildProperties(element: Element): Element {
+  const enriched = { ...element };
+
+  // For Compose elements, text and className might be on child nodes
+  if ((element as any).node) {
+    const children = Array.isArray((element as any).node)
+      ? (element as any).node
+      : [(element as any).node];
+
+    for (const child of children) {
+      // Extract text from first child with text
+      if (!enriched.text && child.text) {
+        enriched.text = child.text;
+      }
+
+      // Extract className from first child with className
+      if (!enriched["class"] && child.className) {
+        enriched["class"] = child.className;
+      }
+
+      // Extract content-desc from first child with content-desc
+      if (!enriched["content-desc"] && child["content-desc"]) {
+        enriched["content-desc"] = child["content-desc"];
+      }
+    }
+  }
+
+  return enriched;
+}
+
+/**
+ * Extract scrollable containers for swiping
+ */
+export function extractScrollableContainers(
+  viewHierarchy: any,
+  elementParser: ElementParser
+): Element[] {
+  const flatElements = elementParser.flattenViewHierarchy(viewHierarchy);
+  const scrollableContainers: Element[] = [];
+  const targetPackage = viewHierarchy.packageName;
+
+  for (const { element, depth } of flatElements) {
+    // Must be scrollable
+    const isScrollable =
+      element.scrollable === true || (element.scrollable as any) === "true";
+    if (!isScrollable) {
+      continue;
+    }
+
+    // Filter by package name if available
+    if (targetPackage && element.package && element.package !== targetPackage) {
+      continue;
+    }
+
+    // Must have reasonable size for scrolling
+    if (element.bounds) {
+      const width = element.bounds.right - element.bounds.left;
+      const height = element.bounds.bottom - element.bounds.top;
+      if (width < 50 || height < 50) {
+        continue;
+      }
+    }
+
+    // Store depth information for scoring
+    (element as any).hierarchyDepth = depth;
+
+    scrollableContainers.push(element);
+  }
+
+  return scrollableContainers;
+}
+
+/**
+ * Check if element is a navigation candidate
+ */
+export function isNavigationCandidate(element: Element): boolean {
+  // Must be clickable (handle both boolean and string values from XML parsing)
+  const isClickable =
+    element.clickable === true || (element.clickable as any) === "true";
+  if (!isClickable) {
+    return false;
+  }
+
+  // Must be enabled (handle both boolean and string values from XML parsing)
+  const isEnabled =
+    element.enabled !== false && (element.enabled as any) !== "false";
+  if (!isEnabled) {
+    return false;
+  }
+
+  // Must have reasonable size
+  if (element.bounds) {
+    const width = element.bounds.right - element.bounds.left;
+    const height = element.bounds.bottom - element.bounds.top;
+    if (width < 10 || height < 10) {
+      return false;
+    }
+  }
+
+  // Check if it looks like a navigation element
+  const className = element["class"]?.toLowerCase() ?? "";
+
+  // Avoid input elements
+  if (className.includes("edittext") || className.includes("textfield")) {
+    return false;
+  }
+
+  // Avoid checkboxes and switches
+  if (className.includes("checkbox") || className.includes("switch")) {
+    return false;
+  }
+
+  return true;
+}
+
+/**
+ * Extract all elements from hierarchy (including non-clickable)
+ */
+export function extractAllElements(
+  viewHierarchy: any,
+  elementParser: ElementParser
+): Element[] {
+  const flatElements = elementParser.flattenViewHierarchy(viewHierarchy);
+  return flatElements.map(({ element }) => element);
+}
+
+/**
+ * Generate unique key for element tracking
+ */
+export function getElementKey(element: Element): string {
+  const parts: string[] = [];
+
+  if (element["resource-id"]) {
+    parts.push(`id:${element["resource-id"]}`);
+  }
+  if (element.text) {
+    parts.push(`text:${element.text}`);
+  }
+  if (element["content-desc"]) {
+    parts.push(`desc:${element["content-desc"]}`);
+  }
+  if (element["class"]) {
+    parts.push(`class:${element["class"]}`);
+  }
+
+  return parts.join("|") || "unknown";
+}
+
+/**
+ * Filter out elements that have been exhausted
+ */
+export function filterUnexhaustedElements(
+  elements: Element[],
+  exploredElements: Map<string, TrackedElement>,
+  currentScreen: string | null
+): Element[] {
+  return elements.filter(element => {
+    const elementKey = getElementKey(element);
+    const tracked = exploredElements.get(elementKey);
+
+    // Allow if never tried
+    if (!tracked) {
+      return true;
+    }
+
+    // Allow if tried on different screen
+    if (tracked.lastInteractionScreen !== currentScreen) {
+      return true;
+    }
+
+    // Filter out if tried too many times from this screen
+    return tracked.interactionCount < 2;
+  });
+}

--- a/src/features/navigation/ExploreElementScoring.ts
+++ b/src/features/navigation/ExploreElementScoring.ts
@@ -1,0 +1,437 @@
+import type { Element } from "../../models";
+import type { NavigationEdge } from "./NavigationGraphManager";
+import type {
+  ElementSelectionStats,
+  ExplorationMode,
+  ExplorationStrategy,
+  PlannedInteraction,
+  TrackedElement
+} from "./ExploreTypes";
+import { getElementKey } from "./ExploreElementExtraction";
+
+/**
+ * Calculate navigation score for an element
+ */
+export function calculateNavigationScore(element: Element): number {
+  let score = 0;
+
+  const clickable =
+    element.clickable === true || (element.clickable as any) === "true";
+  const scrollable =
+    element.scrollable === true || (element.scrollable as any) === "true";
+
+  // Clickable bonus - clickable elements are more likely to be interactive
+  if (clickable) {
+    score += 5;
+  }
+
+  // Scrollable bonus - scrollable containers can reveal new content
+  if (scrollable) {
+    score += 3;
+  }
+
+  // Hierarchy depth bonus - linear function where closer to root = higher score
+  // Formula: max(0, 25 - depth * 2)
+  // depth 0: +25, depth 3: +19, depth 6: +13, depth 10: +5, depth 12+: 0
+  const depth = (element as any).hierarchyDepth ?? 99;
+  const depthBonus = Math.max(0, 25 - depth * 2);
+  score += depthBonus;
+
+  return Math.max(0, score);
+}
+
+/**
+ * Calculate novelty score based on previous interactions
+ */
+export function calculateNoveltyScore(
+  element: Element,
+  exploredElements: Map<string, TrackedElement>
+): number {
+  const elementKey = getElementKey(element);
+  const tracked = exploredElements.get(elementKey);
+
+  // High score for never-explored elements
+  if (!tracked) {
+    return 10;
+  }
+
+  // Reduce score based on interaction count
+  return Math.max(1, 10 - tracked.interactionCount);
+}
+
+/**
+ * Estimate coverage gain from interacting with element
+ */
+export function estimateCoverageGain(element: Element): number {
+  // For now, use a simple heuristic based on navigation score
+  // Future: could use ML or historical data
+  const navScore = calculateNavigationScore(element);
+  return Math.max(1, navScore / 10);
+}
+
+/**
+ * Breadth-first selection: prefer unexplored elements on current screen
+ */
+export function selectBreadthFirst(elements: Element[]): Element | null {
+  if (elements.length === 0) {
+    return null;
+  }
+
+  // Sort by navigation score
+  const sorted = elements.sort((a, b) => {
+    return calculateNavigationScore(b) - calculateNavigationScore(a);
+  });
+
+  return sorted[0];
+}
+
+/**
+ * Depth-first selection: follow promising paths deeply
+ */
+export function selectDepthFirst(
+  elements: Element[],
+  exploredElements: Map<string, TrackedElement>
+): Element | null {
+  if (elements.length === 0) {
+    return null;
+  }
+
+  // Prefer elements we haven't tried yet, then by score
+  const sorted = elements.sort((a, b) => {
+    const aNever = !exploredElements.has(getElementKey(a));
+    const bNever = !exploredElements.has(getElementKey(b));
+
+    if (aNever && !bNever) {
+      return -1;
+    }
+    if (!aNever && bNever) {
+      return 1;
+    }
+
+    return calculateNavigationScore(b) - calculateNavigationScore(a);
+  });
+
+  return sorted[0];
+}
+
+/**
+ * Weighted selection result with element and stats
+ */
+export interface WeightedSelectionResult {
+  element: Element;
+  stats: ElementSelectionStats;
+}
+
+/**
+ * Weighted selection: balance navigation score, novelty, and coverage
+ */
+export function selectWeighted(
+  elements: Element[],
+  mode: ExplorationMode,
+  exploredElements: Map<string, TrackedElement>
+): WeightedSelectionResult | null {
+  if (elements.length === 0) {
+    return null;
+  }
+
+  // Calculate scores for each element
+  const scored = elements.map(element => {
+    const navScore = calculateNavigationScore(element);
+    const novelty = calculateNoveltyScore(element, exploredElements);
+    const coverage = estimateCoverageGain(element);
+
+    // Adjust weights based on mode
+    let finalScore: number;
+    if (mode === "discover") {
+      // Heavily favor novelty and coverage
+      finalScore = navScore * 0.3 + novelty * 0.4 + coverage * 0.3;
+    } else if (mode === "validate") {
+      // Favor previously explored elements
+      finalScore = navScore * 0.5 + (10 - novelty) * 0.3 + coverage * 0.2;
+    } else {
+      // Hybrid: balanced approach
+      finalScore = navScore * 0.4 + novelty * 0.4 + coverage * 0.2;
+    }
+
+    return {
+      element,
+      navScore,
+      novelty,
+      coverage,
+      finalScore
+    };
+  });
+
+  // Sort by final score
+  scored.sort((a, b) => b.finalScore - a.finalScore);
+
+  // Return selection with stats
+  const selected = scored[0];
+  return {
+    element: selected.element,
+    stats: {
+      text: selected.element.text,
+      resourceId: selected.element["resource-id"],
+      className: selected.element["class"],
+      score: selected.navScore,
+      novelty: selected.novelty,
+      coverage: selected.coverage,
+      finalScore: selected.finalScore
+    }
+  };
+}
+
+/**
+ * Ranked element for dry run
+ */
+export interface RankedElement {
+  element: Element;
+  score: number;
+  reason: string;
+  action: "tapOn" | "swipeOn";
+  whitelistStatus: "allowed" | "blocked" | "unknown";
+}
+
+/**
+ * Rank elements for dry run
+ */
+export function rankElementsForDryRun(
+  elements: Element[],
+  strategy: ExplorationStrategy,
+  mode: ExplorationMode,
+  exploredElements: Map<string, TrackedElement>
+): RankedElement[] {
+  const scored = elements.map(element => {
+    const navScore = calculateNavigationScore(element);
+    const novelty = calculateNoveltyScore(element, exploredElements);
+    const coverage = estimateCoverageGain(element);
+    const isScrollable =
+      element.scrollable === true || (element.scrollable as any) === "true";
+
+    let score = navScore;
+    let reason = `Navigation score ${navScore.toFixed(1)}`;
+
+    if (strategy === "weighted") {
+      if (mode === "discover") {
+        score = navScore * 0.3 + novelty * 0.4 + coverage * 0.3;
+      } else if (mode === "validate") {
+        score = navScore * 0.5 + (10 - novelty) * 0.3 + coverage * 0.2;
+      } else {
+        score = navScore * 0.4 + novelty * 0.4 + coverage * 0.2;
+      }
+      reason =
+        `Weighted score ${score.toFixed(2)} ` +
+        `(nav=${navScore.toFixed(1)}, novelty=${novelty.toFixed(1)}, coverage=${coverage.toFixed(1)})`;
+    } else if (strategy === "depth-first") {
+      reason = `Depth-first preference with score ${score.toFixed(1)}`;
+    } else {
+      reason = `Breadth-first priority with score ${score.toFixed(1)}`;
+    }
+
+    return {
+      element,
+      score,
+      reason,
+      action: isScrollable ? "swipeOn" : "tapOn",
+      whitelistStatus: "unknown"
+    } as RankedElement;
+  });
+
+  scored.sort((a, b) => b.score - a.score);
+  return scored;
+}
+
+/**
+ * Get element target for planned interaction
+ */
+export function getElementTarget(element: Element): PlannedInteraction["target"] {
+  if (element.text) {
+    return { type: "text", value: element.text };
+  }
+  if (element["content-desc"]) {
+    return { type: "text", value: element["content-desc"] };
+  }
+  if (element["resource-id"]) {
+    return { type: "id", value: element["resource-id"] };
+  }
+  if (element.bounds) {
+    const x = Math.round((element.bounds.left + element.bounds.right) / 2);
+    const y = Math.round((element.bounds.top + element.bounds.bottom) / 2);
+    return { type: "coordinates", value: `${x},${y}` };
+  }
+  return { type: "coordinates", value: "0,0" };
+}
+
+/**
+ * Predict outcome for element based on known edges
+ */
+export function predictOutcomeForElement(
+  element: Element,
+  edges: NavigationEdge[]
+): PlannedInteraction["predictedOutcome"] {
+  if (edges.length === 0) {
+    return { screen: "unknown", confidence: 0 };
+  }
+
+  let bestScore = 0;
+  let bestScreen = "unknown";
+
+  for (const edge of edges) {
+    const score = scoreEdgeMatch(element, edge);
+    if (score > bestScore) {
+      bestScore = score;
+      bestScreen = edge.to;
+    }
+  }
+
+  if (bestScore <= 0) {
+    return { screen: "unknown", confidence: 0 };
+  }
+
+  return { screen: bestScreen, confidence: Math.round(bestScore * 100) / 100 };
+}
+
+/**
+ * Score how well an element matches an edge
+ */
+export function scoreEdgeMatch(element: Element, edge: NavigationEdge): number {
+  const uiState = edge.uiState || edge.interaction?.uiState;
+  if (!uiState) {
+    return 0;
+  }
+
+  let score = 0;
+  for (const selected of uiState.selectedElements ?? []) {
+    score = Math.max(score, scoreSelectedElementMatch(element, selected));
+  }
+
+  if (uiState.scrollPosition) {
+    score = Math.max(
+      score,
+      scoreScrollPositionMatch(element, uiState.scrollPosition)
+    );
+  }
+
+  return score;
+}
+
+/**
+ * Score match between element and selected element from edge
+ */
+export function scoreSelectedElementMatch(
+  element: Element,
+  selected: { text?: string; resourceId?: string; contentDesc?: string }
+): number {
+  let score = 0;
+  score = Math.max(
+    score,
+    scoreIdentifierMatch(element["resource-id"], selected.resourceId, 0.95, 0.85)
+  );
+  score = Math.max(
+    score,
+    scoreIdentifierMatch(element.text, selected.text, 0.9, 0.7)
+  );
+  score = Math.max(
+    score,
+    scoreIdentifierMatch(
+      element["content-desc"],
+      selected.contentDesc,
+      0.85,
+      0.65
+    )
+  );
+  return score;
+}
+
+/**
+ * Score match between element and scroll position
+ */
+export function scoreScrollPositionMatch(
+  element: Element,
+  scrollPosition: {
+    container?: { text?: string; resourceId?: string; contentDesc?: string };
+    targetElement: { text?: string; resourceId?: string; contentDesc?: string };
+  }
+): number {
+  let score = 0;
+  if (scrollPosition.container) {
+    score = Math.max(
+      score,
+      scoreIdentifierMatch(
+        element["resource-id"],
+        scrollPosition.container.resourceId,
+        0.8,
+        0.7
+      )
+    );
+    score = Math.max(
+      score,
+      scoreIdentifierMatch(element.text, scrollPosition.container.text, 0.75, 0.65)
+    );
+    score = Math.max(
+      score,
+      scoreIdentifierMatch(
+        element["content-desc"],
+        scrollPosition.container.contentDesc,
+        0.75,
+        0.65
+      )
+    );
+  }
+
+  score = Math.max(
+    score,
+    scoreIdentifierMatch(
+      element["resource-id"],
+      scrollPosition.targetElement.resourceId,
+      0.8,
+      0.7
+    )
+  );
+  score = Math.max(
+    score,
+    scoreIdentifierMatch(
+      element.text,
+      scrollPosition.targetElement.text,
+      0.75,
+      0.65
+    )
+  );
+  score = Math.max(
+    score,
+    scoreIdentifierMatch(
+      element["content-desc"],
+      scrollPosition.targetElement.contentDesc,
+      0.75,
+      0.65
+    )
+  );
+
+  return score;
+}
+
+/**
+ * Score identifier match with full and partial match scores
+ */
+export function scoreIdentifierMatch(
+  value: string | undefined,
+  candidate: string | undefined,
+  fullMatchScore: number,
+  partialMatchScore: number
+): number {
+  if (!value || !candidate) {
+    return 0;
+  }
+  const normalizedValue = value.trim().toLowerCase();
+  const normalizedCandidate = candidate.trim().toLowerCase();
+  if (normalizedValue === normalizedCandidate) {
+    return fullMatchScore;
+  }
+  if (
+    normalizedValue.includes(normalizedCandidate) ||
+    normalizedCandidate.includes(normalizedValue)
+  ) {
+    return partialMatchScore;
+  }
+  return 0;
+}

--- a/src/features/navigation/ExploreTypes.ts
+++ b/src/features/navigation/ExploreTypes.ts
@@ -1,0 +1,159 @@
+import type { ObserveResult } from "../../models";
+import type { ExportedGraph } from "../../utils/interfaces/NavigationGraph";
+import type { NavigationEdge } from "./NavigationGraphManager";
+
+/**
+ * Exploration strategies for explore
+ */
+export type ExplorationStrategy = "breadth-first" | "depth-first" | "weighted";
+
+/**
+ * Exploration modes for explore
+ */
+export type ExplorationMode = "discover" | "validate" | "hybrid";
+
+/**
+ * Options for Explore execution
+ */
+export interface ExploreOptions {
+  /** Maximum number of interactions to perform */
+  maxInteractions?: number;
+
+  /** Maximum time in milliseconds */
+  timeoutMs?: number;
+
+  /** Strategy for selecting next interaction */
+  strategy?: ExplorationStrategy;
+
+  /** Whether to reset to home screen periodically */
+  resetToHome?: boolean;
+
+  /** How often to reset (every N interactions) */
+  resetInterval?: number;
+
+  /** Exploration mode */
+  mode?: ExplorationMode;
+
+  /** Package name to limit exploration to */
+  packageName?: string;
+
+  /** Dry run mode (no interactions performed) */
+  dryRun?: boolean;
+}
+
+/**
+ * Statistics about element selection during exploration
+ */
+export interface ElementSelectionStats {
+  text?: string;
+  resourceId?: string;
+  className?: string;
+  score: number;
+  novelty: number;
+  coverage: number;
+  finalScore: number;
+}
+
+/**
+ * Edge validation result for tracking success/failure of known transitions
+ */
+export interface EdgeValidationResult {
+  edgeKey: string;
+  fromScreen: string;
+  expectedTo: string;
+  actualTo: string | null;
+  success: boolean;
+  timestamp: number;
+  error?: string;
+  matchConfidence?: number;
+}
+
+/**
+ * Result of Explore execution
+ */
+export interface ExploreResult {
+  success: boolean;
+  error?: string;
+  cancelled?: boolean;
+  interactionsPerformed: number;
+  screensDiscovered: number;
+  edgesAdded: number;
+  navigationGraph: ExportedGraph;
+  explorationPath: string[];
+  coverage: {
+    totalScreens: number;
+    exploredScreens: number;
+    percentage: number;
+  };
+  elementSelections?: ElementSelectionStats[];
+  observation?: ObserveResult;
+  durationMs: number;
+  stopReason?: string;
+  graphTraversal?: {
+    nodesVisited: number;
+    totalNodes: number;
+    edgesTraversed: number;
+    totalEdges: number;
+    edgeValidationResults: EdgeValidationResult[];
+    coveragePercentage: number;
+  };
+}
+
+export interface PlannedInteraction {
+  order: number;
+  action: "tapOn" | "swipeOn";
+  target: {
+    type: "text" | "id" | "coordinates";
+    value: string;
+  };
+  reason: string;
+  predictedOutcome: {
+    screen: string;
+    confidence: number;
+  };
+  whitelistStatus: "allowed" | "blocked" | "unknown";
+}
+
+export interface ExploreDryRunResult {
+  success: true;
+  dryRun: true;
+  currentScreen: {
+    name: string;
+    interactableElements: number;
+  };
+  plannedInteractions: PlannedInteraction[];
+  estimatedCoverage: {
+    screensToVisit: string[];
+    newScreensExpected: number;
+    existingScreensToRevisit: number;
+  };
+  warnings: string[];
+  observation?: ObserveResult;
+  durationMs: number;
+}
+
+export type ExploreExecutionResult = ExploreResult | ExploreDryRunResult;
+
+/**
+ * Tracked element interaction state
+ */
+export interface TrackedElement {
+  text?: string;
+  resourceId?: string;
+  contentDesc?: string;
+  className?: string;
+  interactionCount: number;
+  lastInteractionScreen: string;
+}
+
+/**
+ * Graph traversal state for validate mode
+ */
+export interface GraphTraversalState {
+  visitedNodes: Set<string>;
+  traversedEdges: Set<string>;
+  pendingEdges: NavigationEdge[];
+  edgeValidationResults: Map<string, EdgeValidationResult>;
+  totalNodesInGraph: number;
+  totalEdgesInGraph: number;
+}

--- a/src/features/navigation/ExploreValidateMode.ts
+++ b/src/features/navigation/ExploreValidateMode.ts
@@ -1,0 +1,255 @@
+import { createHash } from "crypto";
+import type { Element } from "../../models";
+import type { NavigationEdge, NavigationGraphManager } from "./NavigationGraphManager";
+import type { Timer } from "../../utils/SystemTimer";
+import type { EdgeValidationResult, GraphTraversalState } from "./ExploreTypes";
+import { logger } from "../../utils/logger";
+import {
+  scoreScrollPositionMatch,
+  scoreSelectedElementMatch
+} from "./ExploreElementScoring";
+
+/**
+ * Initialize graph traversal state for validate mode
+ */
+export async function initializeGraphTraversal(
+  navigationManager: NavigationGraphManager
+): Promise<GraphTraversalState> {
+  const graph = await navigationManager.exportGraph();
+  const allEdges: NavigationEdge[] = [];
+
+  // Collect all edges from the graph
+  for (const edge of graph.edges) {
+    allEdges.push(edge);
+  }
+
+  const state: GraphTraversalState = {
+    visitedNodes: new Set<string>(),
+    traversedEdges: new Set<string>(),
+    pendingEdges: [...allEdges],
+    edgeValidationResults: new Map<string, EdgeValidationResult>(),
+    totalNodesInGraph: graph.nodes.length,
+    totalEdgesInGraph: allEdges.length
+  };
+
+  logger.info(
+    `[Explore] Initialized graph traversal: ${graph.nodes.length} nodes, ${allEdges.length} edges`
+  );
+
+  return state;
+}
+
+/**
+ * Generate edge key for tracking
+ * Uses hash of the action/interaction to ensure uniqueness for multiple edges between same screens
+ * Format: {from}->{action_hash}->{to}
+ */
+export function getEdgeKey(edge: NavigationEdge): string {
+  const actionHash = hashEdgeAction(edge);
+  return `${edge.from}->${actionHash}->${edge.to}`;
+}
+
+/**
+ * Create a deterministic hash of the edge's action/interaction
+ * This ensures the same interaction always produces the same hash
+ */
+export function hashEdgeAction(edge: NavigationEdge): string {
+  // For edges without interactions (back button, unknown), use edge type
+  if (!edge.interaction) {
+    return createHash("sha256")
+      .update(`${edge.edgeType}`)
+      .digest("hex")
+      .substring(0, 8);
+  }
+
+  // Create a stable representation of the interaction, excluding timestamps
+  const stableData = {
+    toolName: edge.interaction.toolName,
+    // Sort args keys for stability, exclude any timestamp-like fields
+    args: Object.keys(edge.interaction.args)
+      .filter(k => !k.toLowerCase().includes("timestamp"))
+      .sort()
+      .reduce(
+        (acc, key) => {
+          acc[key] = edge.interaction!.args[key];
+          return acc;
+        },
+        {} as Record<string, any>
+      ),
+    // Include edge type for additional uniqueness
+    edgeType: edge.edgeType
+  };
+
+  return createHash("sha256")
+    .update(JSON.stringify(stableData))
+    .digest("hex")
+    .substring(0, 8); // Use first 8 chars for readability
+}
+
+/**
+ * Mark current node as visited
+ */
+export function markNodeVisited(
+  state: GraphTraversalState,
+  screenName: string
+): void {
+  state.visitedNodes.add(screenName);
+}
+
+/**
+ * Mark edge as traversed with validation result
+ */
+export function markEdgeTraversed(
+  state: GraphTraversalState,
+  edge: NavigationEdge,
+  actualTo: string | null,
+  success: boolean,
+  timer: Timer,
+  error?: string,
+  matchConfidence?: number
+): void {
+  const edgeKey = getEdgeKey(edge);
+  state.traversedEdges.add(edgeKey);
+
+  const validationResult: EdgeValidationResult = {
+    edgeKey,
+    fromScreen: edge.from,
+    expectedTo: edge.to,
+    actualTo,
+    success,
+    timestamp: timer.now(),
+    error,
+    matchConfidence
+  };
+
+  state.edgeValidationResults.set(edgeKey, validationResult);
+
+  // Remove from pending edges
+  state.pendingEdges = state.pendingEdges.filter(
+    e => getEdgeKey(e) !== edgeKey
+  );
+
+  logger.info(
+    `[Explore] Edge ${edgeKey} validation: ${success ? "SUCCESS" : "FAILED"}` +
+      (actualTo && actualTo !== edge.to ? ` (went to ${actualTo})` : "")
+  );
+}
+
+/**
+ * Select next edge to traverse in validate mode
+ * Only selects edges from the current screen to avoid false divergence
+ */
+export function selectNextEdgeToTraverse(
+  state: GraphTraversalState,
+  currentScreen: string
+): NavigationEdge | null {
+  // Only select untraversed edges from current screen
+  // Do not attempt to navigate to other screens, as this causes false divergence
+  const untraversedFromCurrent = state.pendingEdges.filter(
+    edge => edge.from === currentScreen
+  );
+
+  if (untraversedFromCurrent.length > 0) {
+    return untraversedFromCurrent[0];
+  }
+
+  // No edges from current screen - exploration is complete or stuck
+  return null;
+}
+
+/**
+ * Find element on screen that matches a target edge
+ */
+export function findElementMatchingEdge(
+  elements: Element[],
+  edge: NavigationEdge
+): { element: Element; confidence: number } | null {
+  const uiState = edge.uiState || edge.interaction?.uiState;
+  if (!uiState) {
+    logger.warn(
+      `[Explore] Edge ${edge.from}->${edge.to} has no UI state, cannot match`
+    );
+    return null;
+  }
+
+  let bestMatch: { element: Element; confidence: number } | null = null;
+  let bestScore = 0;
+
+  for (const element of elements) {
+    // Try to match against selected elements in the edge's UI state
+    if (uiState.selectedElements && uiState.selectedElements.length > 0) {
+      for (const selected of uiState.selectedElements) {
+        const score = scoreSelectedElementMatch(element, selected);
+        if (score > bestScore) {
+          bestScore = score;
+          bestMatch = { element, confidence: score };
+        }
+      }
+    }
+
+    // Try to match against scroll position if present
+    if (uiState.scrollPosition) {
+      const score = scoreScrollPositionMatch(element, uiState.scrollPosition);
+      if (score > bestScore) {
+        bestScore = score;
+        bestMatch = { element, confidence: score };
+      }
+    }
+  }
+
+  // Require minimum confidence threshold
+  const MIN_CONFIDENCE = 0.6;
+  if (bestMatch && bestMatch.confidence >= MIN_CONFIDENCE) {
+    logger.debug(
+      `[Explore] Matched element for edge ${edge.from}->${edge.to} with confidence ${bestMatch.confidence.toFixed(2)}`
+    );
+    return bestMatch;
+  }
+
+  logger.warn(
+    `[Explore] No confident match for edge ${edge.from}->${edge.to} ` +
+      `(best score: ${bestScore.toFixed(2)}, threshold: ${MIN_CONFIDENCE})`
+  );
+  return null;
+}
+
+/**
+ * Validate that navigation matched expected edge in validate mode
+ * Returns true if navigation succeeded, false if it diverged
+ */
+export async function validateNavigation(
+  expectedEdge: NavigationEdge,
+  state: GraphTraversalState,
+  navigationManager: NavigationGraphManager,
+  timer: Timer,
+  elementConfidence: number,
+  setStopReason: (reason: string) => void
+): Promise<boolean> {
+  // Wait a bit for navigation to complete
+  await new Promise(resolve => setTimeout(resolve, 500));
+
+  const actualScreen = navigationManager.getCurrentScreen() ?? "unknown";
+  const success = actualScreen === expectedEdge.to;
+
+  // Mark edge as traversed with result
+  markEdgeTraversed(
+    state,
+    expectedEdge,
+    actualScreen,
+    success,
+    timer,
+    success ? undefined : `Expected ${expectedEdge.to}, got ${actualScreen}`,
+    elementConfidence
+  );
+
+  if (!success) {
+    const errorMsg =
+      `Validate mode: Navigation validation failed for edge ${expectedEdge.from}->${expectedEdge.to}. ` +
+      `Expected to reach "${expectedEdge.to}", but reached "${actualScreen}". ` +
+      `App has diverged from known graph.`;
+    logger.error(`[Explore] ${errorMsg}`);
+    setStopReason(errorMsg);
+  }
+
+  return success;
+}

--- a/test/features/navigation/Explore.test.ts
+++ b/test/features/navigation/Explore.test.ts
@@ -6,6 +6,28 @@ import { AdbClient } from "../../../src/utils/android-cmdline-tools/AdbClient";
 import { FakeNavigationGraphManager } from "../../fakes/FakeNavigationGraphManager";
 import { FakeTimer } from "../../fakes/FakeTimer";
 
+// Import extracted functions for testing
+import {
+  extractNavigationElements,
+  getElementKey
+} from "../../../src/features/navigation/ExploreElementExtraction";
+import {
+  calculateNavigationScore
+} from "../../../src/features/navigation/ExploreElementScoring";
+import {
+  isPermissionDialog,
+  isLoginScreen,
+  isRatingDialog
+} from "../../../src/features/navigation/ExploreBlockerDetection";
+import {
+  initializeGraphTraversal,
+  getEdgeKey,
+  markNodeVisited,
+  markEdgeTraversed,
+  selectNextEdgeToTraverse
+} from "../../../src/features/navigation/ExploreValidateMode";
+import { ElementParser } from "../../../src/features/utility/ElementParser";
+
 describe("Explore", () => {
   let explore: Explore;
   let device: BootedDevice;
@@ -14,11 +36,13 @@ describe("Explore", () => {
   let fakeGraph: FakeNavigationGraphManager;
   let fakeTimer: FakeTimer;
   let getInstanceSpy: ReturnType<typeof spyOn> | null = null;
+  let elementParser: ElementParser;
 
   beforeEach(() => {
     fakeGraph = new FakeNavigationGraphManager();
     fakeTimer = new FakeTimer();
     fakeTimer.enableAutoAdvance();
+    elementParser = new ElementParser();
     getInstanceSpy = spyOn(NavigationGraphManager, "getInstance").mockReturnValue(
       fakeGraph as unknown as NavigationGraphManager
     );
@@ -161,8 +185,7 @@ describe("Explore", () => {
 
       const mockObservation = createMockObservation(nodes);
 
-      explore = new Explore(device, mockAdb);
-      const navElements = (explore as any).extractNavigationElements(mockObservation.viewHierarchy);
+      const navElements = extractNavigationElements(mockObservation.viewHierarchy, elementParser);
 
       // Should filter out EditText
       expect(navElements.length).toBeLessThan(nodes.length);
@@ -173,8 +196,6 @@ describe("Explore", () => {
     });
 
     test("should calculate navigation scores correctly", async () => {
-      explore = new Explore(device, mockAdb);
-
       const buttonElement = createMockElement({
         "text": "Settings",
         "class": "android.widget.Button",
@@ -191,8 +212,8 @@ describe("Explore", () => {
       // Set hierarchyDepth for tab (closer to root, should score higher)
       (tabElement as any).hierarchyDepth = 2;
 
-      const buttonScore = (explore as any).calculateNavigationScore(buttonElement);
-      const tabScore = (explore as any).calculateNavigationScore(tabElement);
+      const buttonScore = calculateNavigationScore(buttonElement);
+      const tabScore = calculateNavigationScore(tabElement);
 
       // Tab should score higher than button due to being closer to root
       // Button: 5 (clickable) + max(0, 25 - 8*2) = 5 + 9 = 14
@@ -210,8 +231,7 @@ describe("Explore", () => {
 
       const mockObservation = createMockObservation(nodes);
 
-      explore = new Explore(device, mockAdb);
-      const navElements = (explore as any).extractNavigationElements(mockObservation.viewHierarchy);
+      const navElements = extractNavigationElements(mockObservation.viewHierarchy, elementParser);
 
       // Should only include enabled clickable elements
       expect(navElements.length).toBe(1);
@@ -226,8 +246,7 @@ describe("Explore", () => {
         createMockElement({ text: "This app needs camera permission" })
       ];
 
-      explore = new Explore(device, mockAdb);
-      const isPermission = (explore as any).isPermissionDialog(elements);
+      const isPermission = isPermissionDialog(elements);
 
       expect(isPermission).toBe(true);
     });
@@ -239,8 +258,7 @@ describe("Explore", () => {
         createMockElement({ "text": "Password", "class": "android.widget.TextView" })
       ];
 
-      explore = new Explore(device, mockAdb);
-      const isLogin = (explore as any).isLoginScreen(elements);
+      const isLogin = isLoginScreen(elements);
 
       expect(isLogin).toBe(true);
     });
@@ -252,8 +270,7 @@ describe("Explore", () => {
         createMockElement({ text: "5 stars" })
       ];
 
-      explore = new Explore(device, mockAdb);
-      const isRating = (explore as any).isRatingDialog(elements);
+      const isRating = isRatingDialog(elements);
 
       expect(isRating).toBe(true);
     });
@@ -265,10 +282,9 @@ describe("Explore", () => {
         createMockElement({ text: "Profile" })
       ];
 
-      explore = new Explore(device, mockAdb);
-      const isPermission = (explore as any).isPermissionDialog(elements);
-      const isLogin = (explore as any).isLoginScreen(elements);
-      const isRating = (explore as any).isRatingDialog(elements);
+      const isPermission = isPermissionDialog(elements);
+      const isLogin = isLoginScreen(elements);
+      const isRating = isRatingDialog(elements);
 
       expect(isPermission).toBe(false);
       expect(isLogin).toBe(false);
@@ -353,8 +369,6 @@ describe("Explore", () => {
 
   describe("element tracking", () => {
     test("should generate unique element keys", async () => {
-      explore = new Explore(device, mockAdb);
-
       const element1 = createMockElement({
         "text": "Button",
         "resource-id": "com.test:id/btn"
@@ -370,9 +384,9 @@ describe("Explore", () => {
         "resource-id": "com.test:id/other"
       });
 
-      const key1 = (explore as any).getElementKey(element1);
-      const key2 = (explore as any).getElementKey(element2);
-      const key3 = (explore as any).getElementKey(element3);
+      const key1 = getElementKey(element1);
+      const key2 = getElementKey(element2);
+      const key3 = getElementKey(element3);
 
       expect(key1).toBe(key2);
       expect(key1).not.toBe(key3);
@@ -412,13 +426,9 @@ describe("Explore", () => {
         applicationId: "com.test.app"
       });
 
-      explore = new Explore(device, mockAdb);
-      (explore as any).observeScreen = mockObserveScreen;
+      // Initialize traversal using the extracted function
+      const state = await initializeGraphTraversal(navManager);
 
-      // Initialize traversal
-      await (explore as any).initializeGraphTraversal();
-
-      const state = (explore as any).graphTraversalState;
       expect(state).toBeDefined();
       expect(state.totalNodesInGraph).toBeGreaterThan(0);
       expect(state.totalEdgesInGraph).toBeGreaterThan(0);
@@ -427,48 +437,37 @@ describe("Explore", () => {
     });
 
     test("should select next edge to traverse", async () => {
-      explore = new Explore(device, mockAdb);
-      await (explore as any).initializeGraphTraversal();
-
-      const state = (explore as any).graphTraversalState;
+      const state = await initializeGraphTraversal(fakeGraph as unknown as NavigationGraphManager);
 
       // If there are any pending edges, selectNextEdgeToTraverse should return one
       if (state.pendingEdges.length > 0) {
         const firstEdge = state.pendingEdges[0];
-        const edge = (explore as any).selectNextEdgeToTraverse(firstEdge.from);
+        const edge = selectNextEdgeToTraverse(state, firstEdge.from);
         expect(edge).toBeDefined();
         expect(edge).toBe(firstEdge);
       }
 
-      // If there are no edges from current screen, it should look for any pending edge
-      const edge = (explore as any).selectNextEdgeToTraverse("NonExistentScreen");
-      if (state.pendingEdges.length > 0) {
-        expect(edge).toBeDefined();
-      } else {
-        expect(edge).toBeNull();
-      }
+      // If there are no edges from current screen, it should return null
+      const edge = selectNextEdgeToTraverse(state, "NonExistentScreen");
+      expect(edge).toBeNull();
     });
 
     test("should mark nodes as visited", async () => {
-      explore = new Explore(device, mockAdb);
-      await (explore as any).initializeGraphTraversal();
+      const state = await initializeGraphTraversal(fakeGraph as unknown as NavigationGraphManager);
 
-      const state = (explore as any).graphTraversalState;
       expect(state.visitedNodes.size).toBe(0);
 
-      (explore as any).markNodeVisited("Screen1");
+      markNodeVisited(state, "Screen1");
       expect(state.visitedNodes.size).toBe(1);
       expect(state.visitedNodes.has("Screen1")).toBe(true);
 
-      (explore as any).markNodeVisited("Screen2");
+      markNodeVisited(state, "Screen2");
       expect(state.visitedNodes.size).toBe(2);
     });
 
     test("should mark edges as traversed with validation results", async () => {
-      explore = new Explore(device, mockAdb, fakeTimer);
-      await (explore as any).initializeGraphTraversal();
+      const state = await initializeGraphTraversal(fakeGraph as unknown as NavigationGraphManager);
 
-      const state = (explore as any).graphTraversalState;
       expect(state.traversedEdges.size).toBe(0);
 
       // Create a mock edge with interaction
@@ -484,12 +483,12 @@ describe("Explore", () => {
         }
       };
 
-      (explore as any).markEdgeTraversed(mockEdge, "Screen2", true, undefined, 0.95);
+      markEdgeTraversed(state, mockEdge, "Screen2", true, fakeTimer, undefined, 0.95);
 
       expect(state.traversedEdges.size).toBe(1);
 
       // Get the actual edge key generated
-      const edgeKey = (explore as any).getEdgeKey(mockEdge);
+      const edgeKey = getEdgeKey(mockEdge);
       expect(state.traversedEdges.has(edgeKey)).toBe(true);
 
       const validation = state.edgeValidationResults.get(edgeKey);
@@ -501,10 +500,7 @@ describe("Explore", () => {
     });
 
     test("should record failed edge validation", async () => {
-      explore = new Explore(device, mockAdb, fakeTimer);
-      await (explore as any).initializeGraphTraversal();
-
-      const state = (explore as any).graphTraversalState;
+      const state = await initializeGraphTraversal(fakeGraph as unknown as NavigationGraphManager);
 
       // Create a mock edge with interaction
       const mockEdge = {
@@ -519,15 +515,17 @@ describe("Explore", () => {
         }
       };
 
-      (explore as any).markEdgeTraversed(
+      markEdgeTraversed(
+        state,
         mockEdge,
         "Screen3",
         false,
+        fakeTimer,
         "Navigation diverged",
         0.8
       );
 
-      const edgeKey = (explore as any).getEdgeKey(mockEdge);
+      const edgeKey = getEdgeKey(mockEdge);
       const validation = state.edgeValidationResults.get(edgeKey);
       expect(validation?.success).toBe(false);
       expect(validation?.expectedTo).toBe("Screen2");
@@ -536,8 +534,6 @@ describe("Explore", () => {
     });
 
     test("should generate edge keys correctly", async () => {
-      explore = new Explore(device, mockAdb, fakeTimer);
-
       // Create edges with same interaction
       const edge1 = {
         from: "Screen1",
@@ -587,10 +583,10 @@ describe("Explore", () => {
         }
       };
 
-      const key1 = (explore as any).getEdgeKey(edge1);
-      const key2 = (explore as any).getEdgeKey(edge2);
-      const key3 = (explore as any).getEdgeKey(edge3);
-      const key4 = (explore as any).getEdgeKey(edge4);
+      const key1 = getEdgeKey(edge1);
+      const key2 = getEdgeKey(edge2);
+      const key3 = getEdgeKey(edge3);
+      const key4 = getEdgeKey(edge4);
 
       // Same interaction = same key (deterministic)
       expect(key1).toBe(key2);
@@ -620,7 +616,9 @@ describe("Explore", () => {
       explore = new Explore(device, mockAdb, fakeTimer);
       (explore as any).observeScreen = mockObserveScreen;
 
-      await (explore as any).initializeGraphTraversal();
+      // Initialize traversal state on explore instance
+      (explore as any).graphTraversalState = await initializeGraphTraversal(navManager);
+      const state = (explore as any).graphTraversalState;
 
       // Mark some edges as traversed
       const mockEdge = {
@@ -634,9 +632,9 @@ describe("Explore", () => {
           timestamp: fakeTimer.now()
         }
       };
-      (explore as any).markEdgeTraversed(mockEdge, "Screen2", true);
-      (explore as any).markNodeVisited("Screen1");
-      (explore as any).markNodeVisited("Screen2");
+      markEdgeTraversed(state, mockEdge, "Screen2", true, fakeTimer);
+      markNodeVisited(state, "Screen1");
+      markNodeVisited(state, "Screen2");
 
       const initialGraph = await navManager.exportGraph();
       const result = await (explore as any).generateReport(initialGraph, Date.now(), false);

--- a/test/features/navigation/ExploreBlockerDetection.test.ts
+++ b/test/features/navigation/ExploreBlockerDetection.test.ts
@@ -1,0 +1,249 @@
+import { expect, describe, test } from "bun:test";
+import { Element } from "../../../src/models";
+import {
+  isPermissionDialog,
+  isLoginScreen,
+  isRatingDialog
+} from "../../../src/features/navigation/ExploreBlockerDetection";
+
+describe("ExploreBlockerDetection", () => {
+  function createMockElement(overrides: Partial<Element> = {}): Element {
+    return {
+      "bounds": { left: 0, top: 0, right: 100, bottom: 50 },
+      "clickable": true,
+      "enabled": true,
+      "text": "Button",
+      "class": "android.widget.Button",
+      "resource-id": "com.test:id/button",
+      ...overrides
+    } as Element;
+  }
+
+  describe("isPermissionDialog", () => {
+    test("should detect dialog with 'Allow' button", () => {
+      const elements = [
+        createMockElement({ text: "Allow" }),
+        createMockElement({ text: "Deny" })
+      ];
+
+      expect(isPermissionDialog(elements)).toBe(true);
+    });
+
+    test("should detect dialog with 'permission' text", () => {
+      const elements = [
+        createMockElement({ text: "This app needs permission to access your camera" })
+      ];
+
+      expect(isPermissionDialog(elements)).toBe(true);
+    });
+
+    test("should detect dialog with 'While using' option", () => {
+      const elements = [
+        createMockElement({ text: "While using the app" }),
+        createMockElement({ text: "Only this time" })
+      ];
+
+      expect(isPermissionDialog(elements)).toBe(true);
+    });
+
+    test("should detect dialog with 'access' text", () => {
+      const elements = [
+        createMockElement({ text: "Allow access to photos?" })
+      ];
+
+      expect(isPermissionDialog(elements)).toBe(true);
+    });
+
+    test("should detect via content-desc", () => {
+      const elements = [
+        createMockElement({ "text": "", "content-desc": "Allow permission button" })
+      ];
+
+      expect(isPermissionDialog(elements)).toBe(true);
+    });
+
+    test("should not detect regular buttons", () => {
+      const elements = [
+        createMockElement({ text: "Submit" }),
+        createMockElement({ text: "Cancel" })
+      ];
+
+      expect(isPermissionDialog(elements)).toBe(false);
+    });
+
+    test("should be case insensitive", () => {
+      const elements = [
+        createMockElement({ text: "ALLOW" }),
+        createMockElement({ text: "DENY" })
+      ];
+
+      expect(isPermissionDialog(elements)).toBe(true);
+    });
+  });
+
+  describe("isLoginScreen", () => {
+    test("should detect screen with login text and EditText", () => {
+      const elements = [
+        createMockElement({ "text": "Login", "class": "android.widget.Button" }),
+        createMockElement({ "text": "", "class": "android.widget.EditText" })
+      ];
+
+      expect(isLoginScreen(elements)).toBe(true);
+    });
+
+    test("should detect screen with sign in text", () => {
+      const elements = [
+        createMockElement({ "text": "Sign in", "class": "android.widget.Button" }),
+        createMockElement({ "text": "", "class": "android.widget.EditText" })
+      ];
+
+      expect(isLoginScreen(elements)).toBe(true);
+    });
+
+    test("should detect screen with password field", () => {
+      const elements = [
+        createMockElement({ "text": "Password", "class": "android.widget.TextView" }),
+        createMockElement({ "text": "", "class": "android.widget.EditText" })
+      ];
+
+      expect(isLoginScreen(elements)).toBe(true);
+    });
+
+    test("should detect screen with username field", () => {
+      const elements = [
+        createMockElement({ "text": "Username", "class": "android.widget.TextView" }),
+        createMockElement({ "text": "", "class": "android.widget.EditText" })
+      ];
+
+      expect(isLoginScreen(elements)).toBe(true);
+    });
+
+    test("should not detect without EditText", () => {
+      const elements = [
+        createMockElement({ "text": "Login", "class": "android.widget.Button" }),
+        createMockElement({ "text": "Password", "class": "android.widget.TextView" })
+      ];
+
+      expect(isLoginScreen(elements)).toBe(false);
+    });
+
+    test("should not detect without login keywords", () => {
+      const elements = [
+        createMockElement({ "text": "Search", "class": "android.widget.Button" }),
+        createMockElement({ "text": "", "class": "android.widget.EditText" })
+      ];
+
+      expect(isLoginScreen(elements)).toBe(false);
+    });
+
+    test("should be case insensitive", () => {
+      const elements = [
+        createMockElement({ "text": "SIGN IN", "class": "android.widget.Button" }),
+        createMockElement({ "text": "", "class": "android.widget.EditText" })
+      ];
+
+      expect(isLoginScreen(elements)).toBe(true);
+    });
+  });
+
+  describe("isRatingDialog", () => {
+    test("should detect dialog with 'rate' text", () => {
+      const elements = [
+        createMockElement({ text: "Rate this app" }),
+        createMockElement({ text: "Not now" })
+      ];
+
+      expect(isRatingDialog(elements)).toBe(true);
+    });
+
+    test("should detect dialog with 'review' text", () => {
+      const elements = [
+        createMockElement({ text: "Leave a review" }),
+        createMockElement({ text: "Later" })
+      ];
+
+      expect(isRatingDialog(elements)).toBe(true);
+    });
+
+    test("should detect dialog with 'feedback' text", () => {
+      const elements = [
+        createMockElement({ text: "Give us feedback" })
+      ];
+
+      expect(isRatingDialog(elements)).toBe(true);
+    });
+
+    test("should detect dialog with 'enjoy' text", () => {
+      const elements = [
+        createMockElement({ text: "Enjoying the app?" })
+      ];
+
+      expect(isRatingDialog(elements)).toBe(true);
+    });
+
+    test("should detect dialog with 'star' text", () => {
+      const elements = [
+        createMockElement({ text: "5 stars" }),
+        createMockElement({ text: "Submit" })
+      ];
+
+      expect(isRatingDialog(elements)).toBe(true);
+    });
+
+    test("should detect via content-desc", () => {
+      const elements = [
+        createMockElement({ "text": "", "content-desc": "Rate app dialog" })
+      ];
+
+      expect(isRatingDialog(elements)).toBe(true);
+    });
+
+    test("should not detect regular screens", () => {
+      const elements = [
+        createMockElement({ text: "Home" }),
+        createMockElement({ text: "Settings" })
+      ];
+
+      expect(isRatingDialog(elements)).toBe(false);
+    });
+
+    test("should be case insensitive", () => {
+      const elements = [
+        createMockElement({ text: "RATE THIS APP" })
+      ];
+
+      expect(isRatingDialog(elements)).toBe(true);
+    });
+  });
+
+  describe("combined blocker detection", () => {
+    test("should not detect blockers on regular navigation screens", () => {
+      const elements = [
+        createMockElement({ text: "Home" }),
+        createMockElement({ text: "Profile" }),
+        createMockElement({ text: "Settings" }),
+        createMockElement({ text: "Help" })
+      ];
+
+      expect(isPermissionDialog(elements)).toBe(false);
+      expect(isLoginScreen(elements)).toBe(false);
+      expect(isRatingDialog(elements)).toBe(false);
+    });
+
+    test("should handle empty element list", () => {
+      expect(isPermissionDialog([])).toBe(false);
+      expect(isLoginScreen([])).toBe(false);
+      expect(isRatingDialog([])).toBe(false);
+    });
+
+    test("should handle elements with missing text fields", () => {
+      const elements = [
+        createMockElement({ "text": undefined, "content-desc": undefined })
+      ];
+
+      expect(isPermissionDialog(elements)).toBe(false);
+      expect(isLoginScreen(elements)).toBe(false);
+      expect(isRatingDialog(elements)).toBe(false);
+    });
+  });
+});

--- a/test/features/navigation/ExploreElementExtraction.test.ts
+++ b/test/features/navigation/ExploreElementExtraction.test.ts
@@ -1,0 +1,343 @@
+import { expect, describe, test, beforeEach } from "bun:test";
+import { Element } from "../../../src/models";
+import { ElementParser } from "../../../src/features/utility/ElementParser";
+import {
+  extractNavigationElements,
+  enrichElementWithChildProperties,
+  extractScrollableContainers,
+  isNavigationCandidate,
+  extractAllElements,
+  getElementKey,
+  filterUnexhaustedElements
+} from "../../../src/features/navigation/ExploreElementExtraction";
+import type { TrackedElement } from "../../../src/features/navigation/ExploreTypes";
+
+describe("ExploreElementExtraction", () => {
+  let elementParser: ElementParser;
+
+  beforeEach(() => {
+    elementParser = new ElementParser();
+  });
+
+  function createMockElement(overrides: Partial<Element> = {}): Element {
+    return {
+      "bounds": { left: 0, top: 0, right: 100, bottom: 50 },
+      "clickable": true,
+      "enabled": true,
+      "text": "Button",
+      "class": "android.widget.Button",
+      "resource-id": "com.test:id/button",
+      ...overrides
+    } as Element;
+  }
+
+  function createMockViewHierarchy(nodes: any[] = [], packageName: string = "com.test.app") {
+    return {
+      hierarchy: {
+        node: nodes
+      },
+      packageName
+    };
+  }
+
+  function createMockNode(overrides: any = {}) {
+    const defaults = {
+      $: {
+        "class": "android.widget.Button",
+        "text": "Button",
+        "resource-id": "com.test:id/button",
+        "clickable": "true",
+        "enabled": "true",
+        "bounds": "[0,0][100,50]"
+      }
+    };
+
+    return {
+      $: { ...defaults.$, ...overrides },
+      bounds: { left: 0, top: 0, right: 100, bottom: 50 }
+    };
+  }
+
+  describe("isNavigationCandidate", () => {
+    test("should accept clickable and enabled elements", () => {
+      const element = createMockElement({
+        clickable: true,
+        enabled: true
+      });
+      expect(isNavigationCandidate(element)).toBe(true);
+    });
+
+    test("should reject non-clickable elements", () => {
+      const element = createMockElement({
+        clickable: false
+      });
+      expect(isNavigationCandidate(element)).toBe(false);
+    });
+
+    test("should reject disabled elements", () => {
+      const element = createMockElement({
+        enabled: false
+      });
+      expect(isNavigationCandidate(element)).toBe(false);
+    });
+
+    test("should reject EditText elements", () => {
+      const element = createMockElement({
+        "class": "android.widget.EditText"
+      });
+      expect(isNavigationCandidate(element)).toBe(false);
+    });
+
+    test("should reject Checkbox elements", () => {
+      const element = createMockElement({
+        "class": "android.widget.CheckBox"
+      });
+      expect(isNavigationCandidate(element)).toBe(false);
+    });
+
+    test("should reject elements that are too small", () => {
+      const element = createMockElement({
+        bounds: { left: 0, top: 0, right: 5, bottom: 5 }
+      });
+      expect(isNavigationCandidate(element)).toBe(false);
+    });
+
+    test("should handle string boolean values from XML", () => {
+      const element = {
+        ...createMockElement(),
+        clickable: "true" as any,
+        enabled: "true" as any
+      };
+      expect(isNavigationCandidate(element)).toBe(true);
+
+      const disabledElement = {
+        ...createMockElement(),
+        clickable: "true" as any,
+        enabled: "false" as any
+      };
+      expect(isNavigationCandidate(disabledElement)).toBe(false);
+    });
+  });
+
+  describe("extractNavigationElements", () => {
+    test("should extract clickable buttons from view hierarchy", () => {
+      const nodes = [
+        createMockNode({ text: "Settings", clickable: "true" }),
+        createMockNode({ text: "Profile", clickable: "true" })
+      ];
+      const viewHierarchy = createMockViewHierarchy(nodes);
+
+      const elements = extractNavigationElements(viewHierarchy, elementParser);
+
+      expect(elements.length).toBe(2);
+    });
+
+    test("should filter out non-clickable elements", () => {
+      const nodes = [
+        createMockNode({ text: "Settings", clickable: "true" }),
+        createMockNode({ text: "Label", clickable: "false" })
+      ];
+      const viewHierarchy = createMockViewHierarchy(nodes);
+
+      const elements = extractNavigationElements(viewHierarchy, elementParser);
+
+      expect(elements.length).toBe(1);
+      expect(elements[0].text).toBe("Settings");
+    });
+
+    test("should filter out EditText elements", () => {
+      const nodes = [
+        createMockNode({ text: "Submit", clickable: "true" }),
+        createMockNode({ "text": "", "class": "android.widget.EditText", "clickable": "true" })
+      ];
+      const viewHierarchy = createMockViewHierarchy(nodes);
+
+      const elements = extractNavigationElements(viewHierarchy, elementParser);
+
+      expect(elements.length).toBe(1);
+    });
+
+    test("should filter out elements from different packages", () => {
+      const nodes = [
+        createMockNode({ text: "In-app", clickable: "true", package: "com.test.app" }),
+        createMockNode({ text: "External", clickable: "true", package: "com.other.app" })
+      ];
+      const viewHierarchy = createMockViewHierarchy(nodes, "com.test.app");
+
+      const elements = extractNavigationElements(viewHierarchy, elementParser);
+
+      // Only the in-app element should be extracted
+      expect(elements.filter(e => e.text === "External").length).toBe(0);
+    });
+  });
+
+  describe("enrichElementWithChildProperties", () => {
+    test("should copy text from child node if parent has none", () => {
+      const element = createMockElement({ text: undefined });
+      (element as any).node = [{ text: "Child Text" }];
+
+      const enriched = enrichElementWithChildProperties(element);
+
+      expect(enriched.text).toBe("Child Text");
+    });
+
+    test("should not override existing text", () => {
+      const element = createMockElement({ text: "Parent Text" });
+      (element as any).node = [{ text: "Child Text" }];
+
+      const enriched = enrichElementWithChildProperties(element);
+
+      expect(enriched.text).toBe("Parent Text");
+    });
+
+    test("should handle missing node property", () => {
+      const element = createMockElement({ text: "Existing" });
+
+      const enriched = enrichElementWithChildProperties(element);
+
+      expect(enriched.text).toBe("Existing");
+    });
+  });
+
+  describe("extractScrollableContainers", () => {
+    test("should extract scrollable elements", () => {
+      const nodes = [
+        createMockNode({
+          scrollable: "true",
+          bounds: "[0,0][300,500]"
+        })
+      ];
+      // Manually set bounds for the test
+      nodes[0].bounds = { left: 0, top: 0, right: 300, bottom: 500 };
+      const viewHierarchy = createMockViewHierarchy(nodes);
+
+      const containers = extractScrollableContainers(viewHierarchy, elementParser);
+
+      expect(containers.length).toBe(1);
+    });
+
+    test("should filter out small scrollable elements", () => {
+      const nodes = [
+        createMockNode({
+          scrollable: "true",
+          bounds: "[0,0][30,30]"
+        })
+      ];
+      nodes[0].bounds = { left: 0, top: 0, right: 30, bottom: 30 };
+      const viewHierarchy = createMockViewHierarchy(nodes);
+
+      const containers = extractScrollableContainers(viewHierarchy, elementParser);
+
+      expect(containers.length).toBe(0);
+    });
+  });
+
+  describe("extractAllElements", () => {
+    test("should extract all elements regardless of clickability", () => {
+      const nodes = [
+        createMockNode({ text: "Clickable", clickable: "true" }),
+        createMockNode({ text: "NonClickable", clickable: "false" })
+      ];
+      const viewHierarchy = createMockViewHierarchy(nodes);
+
+      const elements = extractAllElements(viewHierarchy, elementParser);
+
+      expect(elements.length).toBe(2);
+    });
+  });
+
+  describe("getElementKey", () => {
+    test("should generate key from resource-id and text", () => {
+      const element = createMockElement({
+        "resource-id": "com.test:id/btn",
+        "text": "Click Me"
+      });
+
+      const key = getElementKey(element);
+
+      expect(key).toContain("id:com.test:id/btn");
+      expect(key).toContain("text:Click Me");
+    });
+
+    test("should generate same key for identical elements", () => {
+      const element1 = createMockElement({
+        "resource-id": "com.test:id/btn",
+        "text": "Click"
+      });
+      const element2 = createMockElement({
+        "resource-id": "com.test:id/btn",
+        "text": "Click"
+      });
+
+      expect(getElementKey(element1)).toBe(getElementKey(element2));
+    });
+
+    test("should generate different keys for different elements", () => {
+      const element1 = createMockElement({ text: "Button A" });
+      const element2 = createMockElement({ text: "Button B" });
+
+      expect(getElementKey(element1)).not.toBe(getElementKey(element2));
+    });
+
+    test("should return 'unknown' for elements with no identifying properties", () => {
+      const element = {
+        bounds: { left: 0, top: 0, right: 100, bottom: 50 },
+        clickable: true
+      } as Element;
+
+      expect(getElementKey(element)).toBe("unknown");
+    });
+  });
+
+  describe("filterUnexhaustedElements", () => {
+    test("should include elements not in tracked map", () => {
+      const elements = [
+        createMockElement({ text: "New Button" })
+      ];
+      const tracked = new Map<string, TrackedElement>();
+
+      const filtered = filterUnexhaustedElements(elements, tracked, "Screen1");
+
+      expect(filtered.length).toBe(1);
+    });
+
+    test("should include elements tried on different screen", () => {
+      const element = createMockElement({ text: "Button" });
+      const tracked = new Map<string, TrackedElement>();
+      tracked.set(getElementKey(element), {
+        interactionCount: 2,
+        lastInteractionScreen: "Screen1"
+      });
+
+      const filtered = filterUnexhaustedElements([element], tracked, "Screen2");
+
+      expect(filtered.length).toBe(1);
+    });
+
+    test("should filter out elements tried twice on same screen", () => {
+      const element = createMockElement({ text: "Button" });
+      const tracked = new Map<string, TrackedElement>();
+      tracked.set(getElementKey(element), {
+        interactionCount: 2,
+        lastInteractionScreen: "Screen1"
+      });
+
+      const filtered = filterUnexhaustedElements([element], tracked, "Screen1");
+
+      expect(filtered.length).toBe(0);
+    });
+
+    test("should include elements tried only once on same screen", () => {
+      const element = createMockElement({ text: "Button" });
+      const tracked = new Map<string, TrackedElement>();
+      tracked.set(getElementKey(element), {
+        interactionCount: 1,
+        lastInteractionScreen: "Screen1"
+      });
+
+      const filtered = filterUnexhaustedElements([element], tracked, "Screen1");
+
+      expect(filtered.length).toBe(1);
+    });
+  });
+});

--- a/test/features/navigation/ExploreElementScoring.test.ts
+++ b/test/features/navigation/ExploreElementScoring.test.ts
@@ -1,0 +1,470 @@
+import { expect, describe, test } from "bun:test";
+import { Element } from "../../../src/models";
+import {
+  calculateNavigationScore,
+  calculateNoveltyScore,
+  estimateCoverageGain,
+  selectBreadthFirst,
+  selectDepthFirst,
+  selectWeighted,
+  rankElementsForDryRun,
+  getElementTarget,
+  predictOutcomeForElement,
+  scoreEdgeMatch,
+  scoreSelectedElementMatch,
+  scoreIdentifierMatch
+} from "../../../src/features/navigation/ExploreElementScoring";
+import { getElementKey } from "../../../src/features/navigation/ExploreElementExtraction";
+import type { TrackedElement } from "../../../src/features/navigation/ExploreTypes";
+import type { NavigationEdge } from "../../../src/features/navigation/NavigationGraphManager";
+
+describe("ExploreElementScoring", () => {
+  function createMockElement(overrides: Partial<Element> = {}): Element {
+    return {
+      "bounds": { left: 0, top: 0, right: 100, bottom: 50 },
+      "clickable": true,
+      "enabled": true,
+      "text": "Button",
+      "class": "android.widget.Button",
+      "resource-id": "com.test:id/button",
+      ...overrides
+    } as Element;
+  }
+
+  describe("calculateNavigationScore", () => {
+    test("should give clickable elements a base score", () => {
+      const element = createMockElement({ clickable: true });
+      (element as any).hierarchyDepth = 99; // Deep in hierarchy, no depth bonus
+
+      const score = calculateNavigationScore(element);
+
+      expect(score).toBe(5); // Clickable bonus only
+    });
+
+    test("should give scrollable elements additional score", () => {
+      const element = createMockElement({
+        clickable: false,
+        scrollable: true
+      });
+      (element as any).hierarchyDepth = 99;
+
+      const score = calculateNavigationScore(element);
+
+      expect(score).toBe(3); // Scrollable bonus only
+    });
+
+    test("should give higher scores to elements closer to root", () => {
+      const deepElement = createMockElement();
+      (deepElement as any).hierarchyDepth = 10;
+
+      const shallowElement = createMockElement();
+      (shallowElement as any).hierarchyDepth = 2;
+
+      const deepScore = calculateNavigationScore(deepElement);
+      const shallowScore = calculateNavigationScore(shallowElement);
+
+      expect(shallowScore).toBeGreaterThan(deepScore);
+    });
+
+    test("should calculate correct depth bonus", () => {
+      const element = createMockElement({ clickable: true });
+      (element as any).hierarchyDepth = 0; // Root level
+
+      const score = calculateNavigationScore(element);
+
+      // 5 (clickable) + 25 (depth bonus at root) = 30
+      expect(score).toBe(30);
+    });
+
+    test("should handle elements with both clickable and scrollable", () => {
+      const element = createMockElement({
+        clickable: true,
+        scrollable: true
+      });
+      (element as any).hierarchyDepth = 99;
+
+      const score = calculateNavigationScore(element);
+
+      expect(score).toBe(8); // 5 (clickable) + 3 (scrollable)
+    });
+  });
+
+  describe("calculateNoveltyScore", () => {
+    test("should return max score for unexplored elements", () => {
+      const element = createMockElement();
+      const explored = new Map<string, TrackedElement>();
+
+      const score = calculateNoveltyScore(element, explored);
+
+      expect(score).toBe(10);
+    });
+
+    test("should reduce score based on interaction count", () => {
+      const element = createMockElement();
+      const explored = new Map<string, TrackedElement>();
+      explored.set(getElementKey(element), {
+        interactionCount: 3,
+        lastInteractionScreen: "Screen1"
+      });
+
+      const score = calculateNoveltyScore(element, explored);
+
+      expect(score).toBe(7); // 10 - 3
+    });
+
+    test("should return minimum score of 1 for highly explored elements", () => {
+      const element = createMockElement();
+      const explored = new Map<string, TrackedElement>();
+      explored.set(getElementKey(element), {
+        interactionCount: 100,
+        lastInteractionScreen: "Screen1"
+      });
+
+      const score = calculateNoveltyScore(element, explored);
+
+      expect(score).toBe(1);
+    });
+  });
+
+  describe("estimateCoverageGain", () => {
+    test("should return at least 1", () => {
+      const element = createMockElement();
+      (element as any).hierarchyDepth = 99;
+
+      const gain = estimateCoverageGain(element);
+
+      expect(gain).toBeGreaterThanOrEqual(1);
+    });
+
+    test("should increase with navigation score", () => {
+      const lowScoreElement = createMockElement({ clickable: false });
+      (lowScoreElement as any).hierarchyDepth = 99;
+
+      const highScoreElement = createMockElement({ clickable: true });
+      (highScoreElement as any).hierarchyDepth = 0;
+
+      const lowGain = estimateCoverageGain(lowScoreElement);
+      const highGain = estimateCoverageGain(highScoreElement);
+
+      expect(highGain).toBeGreaterThan(lowGain);
+    });
+  });
+
+  describe("selectBreadthFirst", () => {
+    test("should return null for empty array", () => {
+      expect(selectBreadthFirst([])).toBeNull();
+    });
+
+    test("should select element with highest navigation score", () => {
+      const lowScore = createMockElement({ text: "Low" });
+      (lowScore as any).hierarchyDepth = 10;
+
+      const highScore = createMockElement({ text: "High" });
+      (highScore as any).hierarchyDepth = 1;
+
+      const selected = selectBreadthFirst([lowScore, highScore]);
+
+      expect(selected?.text).toBe("High");
+    });
+  });
+
+  describe("selectDepthFirst", () => {
+    test("should return null for empty array", () => {
+      expect(selectDepthFirst([], new Map())).toBeNull();
+    });
+
+    test("should prefer unexplored elements", () => {
+      const explored = createMockElement({ text: "Explored" });
+      (explored as any).hierarchyDepth = 0; // High score
+
+      const unexplored = createMockElement({ text: "Unexplored" });
+      (unexplored as any).hierarchyDepth = 10; // Lower score
+
+      const trackedElements = new Map<string, TrackedElement>();
+      trackedElements.set(getElementKey(explored), {
+        interactionCount: 1,
+        lastInteractionScreen: "Screen1"
+      });
+
+      const selected = selectDepthFirst([explored, unexplored], trackedElements);
+
+      expect(selected?.text).toBe("Unexplored");
+    });
+
+    test("should fall back to score when all elements are explored", () => {
+      const lowScore = createMockElement({ text: "Low" });
+      (lowScore as any).hierarchyDepth = 10;
+
+      const highScore = createMockElement({ text: "High" });
+      (highScore as any).hierarchyDepth = 1;
+
+      const trackedElements = new Map<string, TrackedElement>();
+      trackedElements.set(getElementKey(lowScore), {
+        interactionCount: 1,
+        lastInteractionScreen: "Screen1"
+      });
+      trackedElements.set(getElementKey(highScore), {
+        interactionCount: 1,
+        lastInteractionScreen: "Screen1"
+      });
+
+      const selected = selectDepthFirst([lowScore, highScore], trackedElements);
+
+      expect(selected?.text).toBe("High");
+    });
+  });
+
+  describe("selectWeighted", () => {
+    test("should return null for empty array", () => {
+      expect(selectWeighted([], "discover", new Map())).toBeNull();
+    });
+
+    test("should return element and stats", () => {
+      const element = createMockElement({ text: "Test" });
+      (element as any).hierarchyDepth = 5;
+
+      const result = selectWeighted([element], "discover", new Map());
+
+      expect(result).not.toBeNull();
+      expect(result?.element.text).toBe("Test");
+      expect(result?.stats).toBeDefined();
+      expect(result?.stats.score).toBeGreaterThan(0);
+    });
+
+    test("should favor novelty in discover mode", () => {
+      // Use same depth so navigation score is similar, novelty becomes deciding factor
+      const explored = createMockElement({ text: "Explored" });
+      (explored as any).hierarchyDepth = 5;
+
+      const unexplored = createMockElement({ text: "Unexplored" });
+      (unexplored as any).hierarchyDepth = 5;
+
+      const trackedElements = new Map<string, TrackedElement>();
+      trackedElements.set(getElementKey(explored), {
+        interactionCount: 8, // High interaction count = low novelty
+        lastInteractionScreen: "Screen1"
+      });
+
+      const result = selectWeighted([explored, unexplored], "discover", trackedElements);
+
+      // In discover mode, novelty is heavily weighted (0.4), so unexplored should win
+      expect(result?.element.text).toBe("Unexplored");
+    });
+  });
+
+  describe("rankElementsForDryRun", () => {
+    test("should rank elements by score", () => {
+      const low = createMockElement({ text: "Low" });
+      (low as any).hierarchyDepth = 10;
+
+      const high = createMockElement({ text: "High" });
+      (high as any).hierarchyDepth = 1;
+
+      const ranked = rankElementsForDryRun([low, high], "weighted", "discover", new Map());
+
+      expect(ranked[0].element.text).toBe("High");
+      expect(ranked[1].element.text).toBe("Low");
+    });
+
+    test("should set action to swipeOn for scrollable elements", () => {
+      const scrollable = createMockElement({ scrollable: true });
+
+      const ranked = rankElementsForDryRun([scrollable], "weighted", "discover", new Map());
+
+      expect(ranked[0].action).toBe("swipeOn");
+    });
+
+    test("should set action to tapOn for non-scrollable elements", () => {
+      const clickable = createMockElement({ clickable: true });
+
+      const ranked = rankElementsForDryRun([clickable], "weighted", "discover", new Map());
+
+      expect(ranked[0].action).toBe("tapOn");
+    });
+  });
+
+  describe("getElementTarget", () => {
+    test("should use text as primary target", () => {
+      const element = createMockElement({ text: "Click Me" });
+
+      const target = getElementTarget(element);
+
+      expect(target.type).toBe("text");
+      expect(target.value).toBe("Click Me");
+    });
+
+    test("should use content-desc if no text", () => {
+      const element = createMockElement({
+        "text": undefined,
+        "content-desc": "Description"
+      });
+
+      const target = getElementTarget(element);
+
+      expect(target.type).toBe("text");
+      expect(target.value).toBe("Description");
+    });
+
+    test("should use resource-id if no text or content-desc", () => {
+      const element = createMockElement({
+        "text": undefined,
+        "content-desc": undefined,
+        "resource-id": "com.test:id/btn"
+      });
+
+      const target = getElementTarget(element);
+
+      expect(target.type).toBe("id");
+      expect(target.value).toBe("com.test:id/btn");
+    });
+
+    test("should use coordinates as fallback", () => {
+      const element = createMockElement({
+        "text": undefined,
+        "content-desc": undefined,
+        "resource-id": undefined
+      });
+
+      const target = getElementTarget(element);
+
+      expect(target.type).toBe("coordinates");
+      expect(target.value).toBe("50,25"); // Center of bounds
+    });
+  });
+
+  describe("predictOutcomeForElement", () => {
+    test("should return unknown for empty edges", () => {
+      const element = createMockElement();
+
+      const outcome = predictOutcomeForElement(element, []);
+
+      expect(outcome.screen).toBe("unknown");
+      expect(outcome.confidence).toBe(0);
+    });
+
+    test("should predict screen from matching edge", () => {
+      const element = createMockElement({
+        "text": "Settings",
+        "resource-id": "com.test:id/settings"
+      });
+
+      const edges: NavigationEdge[] = [
+        {
+          from: "Home",
+          to: "SettingsScreen",
+          timestamp: Date.now(),
+          edgeType: "tool",
+          uiState: {
+            selectedElements: [
+              { text: "Settings", resourceId: "com.test:id/settings", contentDesc: "" }
+            ]
+          }
+        }
+      ];
+
+      const outcome = predictOutcomeForElement(element, edges);
+
+      expect(outcome.screen).toBe("SettingsScreen");
+      expect(outcome.confidence).toBeGreaterThan(0);
+    });
+  });
+
+  describe("scoreEdgeMatch", () => {
+    test("should return 0 for edge without uiState", () => {
+      const element = createMockElement();
+      const edge: NavigationEdge = {
+        from: "A",
+        to: "B",
+        timestamp: Date.now(),
+        edgeType: "tool"
+      };
+
+      expect(scoreEdgeMatch(element, edge)).toBe(0);
+    });
+
+    test("should score based on selected elements", () => {
+      const element = createMockElement({
+        "resource-id": "com.test:id/btn"
+      });
+
+      const edge: NavigationEdge = {
+        from: "A",
+        to: "B",
+        timestamp: Date.now(),
+        edgeType: "tool",
+        uiState: {
+          selectedElements: [
+            { resourceId: "com.test:id/btn", text: "", contentDesc: "" }
+          ]
+        }
+      };
+
+      const score = scoreEdgeMatch(element, edge);
+
+      expect(score).toBeGreaterThan(0);
+    });
+  });
+
+  describe("scoreSelectedElementMatch", () => {
+    test("should match on resource-id", () => {
+      const element = createMockElement({
+        "resource-id": "com.test:id/btn"
+      });
+
+      const score = scoreSelectedElementMatch(element, {
+        resourceId: "com.test:id/btn"
+      });
+
+      expect(score).toBe(0.95);
+    });
+
+    test("should match on text", () => {
+      const element = createMockElement({
+        text: "Submit"
+      });
+
+      const score = scoreSelectedElementMatch(element, {
+        text: "Submit"
+      });
+
+      expect(score).toBe(0.9);
+    });
+
+    test("should return 0 for no match", () => {
+      const element = createMockElement({
+        "text": "A",
+        "resource-id": "x"
+      });
+
+      const score = scoreSelectedElementMatch(element, {
+        text: "B",
+        resourceId: "y"
+      });
+
+      expect(score).toBe(0);
+    });
+  });
+
+  describe("scoreIdentifierMatch", () => {
+    test("should return full score for exact match", () => {
+      expect(scoreIdentifierMatch("hello", "hello", 1.0, 0.8)).toBe(1.0);
+    });
+
+    test("should return partial score for partial match", () => {
+      expect(scoreIdentifierMatch("hello world", "hello", 1.0, 0.8)).toBe(0.8);
+    });
+
+    test("should be case insensitive", () => {
+      expect(scoreIdentifierMatch("HELLO", "hello", 1.0, 0.8)).toBe(1.0);
+    });
+
+    test("should return 0 for no match", () => {
+      expect(scoreIdentifierMatch("abc", "xyz", 1.0, 0.8)).toBe(0);
+    });
+
+    test("should return 0 for undefined values", () => {
+      expect(scoreIdentifierMatch(undefined, "test", 1.0, 0.8)).toBe(0);
+      expect(scoreIdentifierMatch("test", undefined, 1.0, 0.8)).toBe(0);
+    });
+  });
+});

--- a/test/features/navigation/ExploreValidateMode.test.ts
+++ b/test/features/navigation/ExploreValidateMode.test.ts
@@ -1,0 +1,474 @@
+import { expect, describe, test, beforeEach, afterEach, spyOn } from "bun:test";
+import { Element } from "../../../src/models";
+import { NavigationGraphManager, type NavigationEdge } from "../../../src/features/navigation/NavigationGraphManager";
+import { FakeNavigationGraphManager } from "../../fakes/FakeNavigationGraphManager";
+import { FakeTimer } from "../../fakes/FakeTimer";
+import {
+  initializeGraphTraversal,
+  getEdgeKey,
+  hashEdgeAction,
+  markNodeVisited,
+  markEdgeTraversed,
+  selectNextEdgeToTraverse,
+  findElementMatchingEdge
+} from "../../../src/features/navigation/ExploreValidateMode";
+
+describe("ExploreValidateMode", () => {
+  let fakeGraph: FakeNavigationGraphManager;
+  let fakeTimer: FakeTimer;
+  let getInstanceSpy: ReturnType<typeof spyOn> | null = null;
+
+  beforeEach(() => {
+    fakeGraph = new FakeNavigationGraphManager();
+    fakeTimer = new FakeTimer();
+    fakeTimer.enableAutoAdvance();
+    getInstanceSpy = spyOn(NavigationGraphManager, "getInstance").mockReturnValue(
+      fakeGraph as unknown as NavigationGraphManager
+    );
+  });
+
+  afterEach(() => {
+    getInstanceSpy?.mockRestore();
+  });
+
+  function createMockElement(overrides: Partial<Element> = {}): Element {
+    return {
+      "bounds": { left: 0, top: 0, right: 100, bottom: 50 },
+      "clickable": true,
+      "enabled": true,
+      "text": "Button",
+      "class": "android.widget.Button",
+      "resource-id": "com.test:id/button",
+      ...overrides
+    } as Element;
+  }
+
+  function createMockEdge(from: string, to: string, overrides: Partial<NavigationEdge> = {}): NavigationEdge {
+    return {
+      from,
+      to,
+      timestamp: Date.now(),
+      edgeType: "tool",
+      ...overrides
+    };
+  }
+
+  describe("initializeGraphTraversal", () => {
+    test("should create empty state for empty graph", async () => {
+      const state = await initializeGraphTraversal(fakeGraph as unknown as NavigationGraphManager);
+
+      expect(state.visitedNodes.size).toBe(0);
+      expect(state.traversedEdges.size).toBe(0);
+      expect(state.pendingEdges.length).toBe(0);
+      expect(state.totalNodesInGraph).toBe(0);
+      expect(state.totalEdgesInGraph).toBe(0);
+    });
+
+    test("should populate state from existing graph", async () => {
+      const navManager = NavigationGraphManager.getInstance();
+
+      navManager.recordNavigationEvent({
+        destination: "Screen1",
+        source: "TEST",
+        arguments: {},
+        metadata: {},
+        timestamp: Date.now(),
+        sequenceNumber: 1,
+        applicationId: "com.test.app"
+      });
+
+      await navManager.recordToolCall("tapOn", { text: "Button1" }, {
+        selectedElements: [{ text: "Button1", resourceId: "btn1", contentDesc: "" }]
+      });
+
+      navManager.recordNavigationEvent({
+        destination: "Screen2",
+        source: "TEST",
+        arguments: {},
+        metadata: {},
+        timestamp: Date.now(),
+        sequenceNumber: 2,
+        applicationId: "com.test.app"
+      });
+
+      const state = await initializeGraphTraversal(navManager);
+
+      expect(state.totalNodesInGraph).toBeGreaterThan(0);
+      expect(state.totalEdgesInGraph).toBeGreaterThan(0);
+      expect(state.pendingEdges.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe("getEdgeKey", () => {
+    test("should generate key in format from->hash->to", () => {
+      const edge = createMockEdge("ScreenA", "ScreenB", {
+        interaction: {
+          toolName: "tapOn",
+          args: { text: "Button" },
+          timestamp: 1000
+        }
+      });
+
+      const key = getEdgeKey(edge);
+
+      expect(key).toMatch(/^ScreenA->[a-f0-9]{8}->ScreenB$/);
+    });
+
+    test("should generate same key for identical edges", () => {
+      const edge1 = createMockEdge("A", "B", {
+        interaction: {
+          toolName: "tapOn",
+          args: { text: "Button" },
+          timestamp: 1000
+        }
+      });
+
+      const edge2 = createMockEdge("A", "B", {
+        interaction: {
+          toolName: "tapOn",
+          args: { text: "Button" },
+          timestamp: 2000 // Different timestamp
+        }
+      });
+
+      expect(getEdgeKey(edge1)).toBe(getEdgeKey(edge2));
+    });
+
+    test("should generate different keys for different interactions", () => {
+      const edge1 = createMockEdge("A", "B", {
+        interaction: {
+          toolName: "tapOn",
+          args: { text: "Button A" },
+          timestamp: 1000
+        }
+      });
+
+      const edge2 = createMockEdge("A", "B", {
+        interaction: {
+          toolName: "tapOn",
+          args: { text: "Button B" },
+          timestamp: 1000
+        }
+      });
+
+      expect(getEdgeKey(edge1)).not.toBe(getEdgeKey(edge2));
+    });
+
+    test("should generate different keys for different screens", () => {
+      const edge1 = createMockEdge("A", "B", {
+        interaction: {
+          toolName: "tapOn",
+          args: { text: "Button" },
+          timestamp: 1000
+        }
+      });
+
+      const edge2 = createMockEdge("B", "C", {
+        interaction: {
+          toolName: "tapOn",
+          args: { text: "Button" },
+          timestamp: 1000
+        }
+      });
+
+      expect(getEdgeKey(edge1)).not.toBe(getEdgeKey(edge2));
+    });
+  });
+
+  describe("hashEdgeAction", () => {
+    test("should hash edge type for edges without interaction", () => {
+      const edge = createMockEdge("A", "B", { edgeType: "back" });
+
+      const hash = hashEdgeAction(edge);
+
+      expect(hash).toHaveLength(8);
+      expect(hash).toMatch(/^[a-f0-9]+$/);
+    });
+
+    test("should create deterministic hash from interaction", () => {
+      const edge = createMockEdge("A", "B", {
+        interaction: {
+          toolName: "tapOn",
+          args: { text: "Submit" },
+          timestamp: 1000
+        }
+      });
+
+      const hash1 = hashEdgeAction(edge);
+      const hash2 = hashEdgeAction(edge);
+
+      expect(hash1).toBe(hash2);
+    });
+
+    test("should exclude timestamp fields from hash", () => {
+      const edge1 = createMockEdge("A", "B", {
+        interaction: {
+          toolName: "tapOn",
+          args: { text: "Button", timestamp: 1000 },
+          timestamp: 1000
+        }
+      });
+
+      const edge2 = createMockEdge("A", "B", {
+        interaction: {
+          toolName: "tapOn",
+          args: { text: "Button", timestamp: 2000 },
+          timestamp: 2000
+        }
+      });
+
+      expect(hashEdgeAction(edge1)).toBe(hashEdgeAction(edge2));
+    });
+  });
+
+  describe("markNodeVisited", () => {
+    test("should add node to visited set", async () => {
+      const state = await initializeGraphTraversal(fakeGraph as unknown as NavigationGraphManager);
+
+      expect(state.visitedNodes.has("Screen1")).toBe(false);
+
+      markNodeVisited(state, "Screen1");
+
+      expect(state.visitedNodes.has("Screen1")).toBe(true);
+    });
+
+    test("should not duplicate nodes", async () => {
+      const state = await initializeGraphTraversal(fakeGraph as unknown as NavigationGraphManager);
+
+      markNodeVisited(state, "Screen1");
+      markNodeVisited(state, "Screen1");
+
+      expect(state.visitedNodes.size).toBe(1);
+    });
+  });
+
+  describe("markEdgeTraversed", () => {
+    test("should add edge to traversed set", async () => {
+      const state = await initializeGraphTraversal(fakeGraph as unknown as NavigationGraphManager);
+      const edge = createMockEdge("A", "B", {
+        interaction: {
+          toolName: "tapOn",
+          args: { text: "Button" },
+          timestamp: 1000
+        }
+      });
+
+      markEdgeTraversed(state, edge, "B", true, fakeTimer);
+
+      expect(state.traversedEdges.size).toBe(1);
+      expect(state.traversedEdges.has(getEdgeKey(edge))).toBe(true);
+    });
+
+    test("should record validation result", async () => {
+      const state = await initializeGraphTraversal(fakeGraph as unknown as NavigationGraphManager);
+      const edge = createMockEdge("A", "B", {
+        interaction: {
+          toolName: "tapOn",
+          args: { text: "Button" },
+          timestamp: 1000
+        }
+      });
+
+      markEdgeTraversed(state, edge, "B", true, fakeTimer, undefined, 0.95);
+
+      const result = state.edgeValidationResults.get(getEdgeKey(edge));
+      expect(result).toBeDefined();
+      expect(result?.success).toBe(true);
+      expect(result?.expectedTo).toBe("B");
+      expect(result?.actualTo).toBe("B");
+      expect(result?.matchConfidence).toBe(0.95);
+    });
+
+    test("should record failed validation", async () => {
+      const state = await initializeGraphTraversal(fakeGraph as unknown as NavigationGraphManager);
+      const edge = createMockEdge("A", "B", {
+        interaction: {
+          toolName: "tapOn",
+          args: { text: "Button" },
+          timestamp: 1000
+        }
+      });
+
+      markEdgeTraversed(state, edge, "C", false, fakeTimer, "Went to wrong screen", 0.7);
+
+      const result = state.edgeValidationResults.get(getEdgeKey(edge));
+      expect(result?.success).toBe(false);
+      expect(result?.expectedTo).toBe("B");
+      expect(result?.actualTo).toBe("C");
+      expect(result?.error).toBe("Went to wrong screen");
+    });
+
+    test("should remove edge from pending", async () => {
+      const state = await initializeGraphTraversal(fakeGraph as unknown as NavigationGraphManager);
+      const edge = createMockEdge("A", "B", {
+        interaction: {
+          toolName: "tapOn",
+          args: { text: "Button" },
+          timestamp: 1000
+        }
+      });
+
+      state.pendingEdges.push(edge);
+      const initialLength = state.pendingEdges.length;
+
+      markEdgeTraversed(state, edge, "B", true, fakeTimer);
+
+      expect(state.pendingEdges.length).toBeLessThan(initialLength);
+    });
+  });
+
+  describe("selectNextEdgeToTraverse", () => {
+    test("should return edge from current screen", async () => {
+      const state = await initializeGraphTraversal(fakeGraph as unknown as NavigationGraphManager);
+      const edge = createMockEdge("CurrentScreen", "NextScreen", {
+        interaction: {
+          toolName: "tapOn",
+          args: { text: "Button" },
+          timestamp: 1000
+        }
+      });
+      state.pendingEdges.push(edge);
+
+      const selected = selectNextEdgeToTraverse(state, "CurrentScreen");
+
+      expect(selected).toBe(edge);
+    });
+
+    test("should return null if no edges from current screen", async () => {
+      const state = await initializeGraphTraversal(fakeGraph as unknown as NavigationGraphManager);
+      const edge = createMockEdge("OtherScreen", "NextScreen");
+      state.pendingEdges.push(edge);
+
+      const selected = selectNextEdgeToTraverse(state, "CurrentScreen");
+
+      expect(selected).toBeNull();
+    });
+
+    test("should return null for empty pending edges", async () => {
+      const state = await initializeGraphTraversal(fakeGraph as unknown as NavigationGraphManager);
+
+      const selected = selectNextEdgeToTraverse(state, "CurrentScreen");
+
+      expect(selected).toBeNull();
+    });
+
+    test("should return first matching edge", async () => {
+      const state = await initializeGraphTraversal(fakeGraph as unknown as NavigationGraphManager);
+      const edge1 = createMockEdge("Current", "A");
+      const edge2 = createMockEdge("Current", "B");
+      state.pendingEdges.push(edge1, edge2);
+
+      const selected = selectNextEdgeToTraverse(state, "Current");
+
+      expect(selected).toBe(edge1);
+    });
+  });
+
+  describe("findElementMatchingEdge", () => {
+    test("should return null for edge without uiState", () => {
+      const elements = [createMockElement({ text: "Button" })];
+      const edge = createMockEdge("A", "B");
+
+      const result = findElementMatchingEdge(elements, edge);
+
+      expect(result).toBeNull();
+    });
+
+    test("should match element by resource-id", () => {
+      const elements = [
+        createMockElement({ "resource-id": "com.test:id/btn", "text": "Click" })
+      ];
+      const edge = createMockEdge("A", "B", {
+        uiState: {
+          selectedElements: [
+            { resourceId: "com.test:id/btn", text: "", contentDesc: "" }
+          ]
+        }
+      });
+
+      const result = findElementMatchingEdge(elements, edge);
+
+      expect(result).not.toBeNull();
+      expect(result?.element["resource-id"]).toBe("com.test:id/btn");
+      expect(result?.confidence).toBeGreaterThan(0.6);
+    });
+
+    test("should match element by text", () => {
+      const elements = [
+        createMockElement({ text: "Submit Button" })
+      ];
+      const edge = createMockEdge("A", "B", {
+        uiState: {
+          selectedElements: [
+            { text: "Submit Button", resourceId: "", contentDesc: "" }
+          ]
+        }
+      });
+
+      const result = findElementMatchingEdge(elements, edge);
+
+      expect(result).not.toBeNull();
+      expect(result?.element.text).toBe("Submit Button");
+    });
+
+    test("should return null when confidence is below threshold", () => {
+      const elements = [
+        createMockElement({ "text": "Different Text", "resource-id": "different_id" })
+      ];
+      const edge = createMockEdge("A", "B", {
+        uiState: {
+          selectedElements: [
+            { text: "Submit", resourceId: "submit_btn", contentDesc: "" }
+          ]
+        }
+      });
+
+      const result = findElementMatchingEdge(elements, edge);
+
+      expect(result).toBeNull();
+    });
+
+    test("should return best match when multiple elements match", () => {
+      const elements = [
+        createMockElement({ "text": "Submit", "resource-id": "wrong_id" }),
+        createMockElement({ "text": "Submit", "resource-id": "com.test:id/submit" })
+      ];
+      const edge = createMockEdge("A", "B", {
+        uiState: {
+          selectedElements: [
+            { text: "Submit", resourceId: "com.test:id/submit", contentDesc: "" }
+          ]
+        }
+      });
+
+      const result = findElementMatchingEdge(elements, edge);
+
+      expect(result).not.toBeNull();
+      // Should match the one with both text and resource-id match
+      expect(result?.element["resource-id"]).toBe("com.test:id/submit");
+    });
+
+    test("should match using interaction uiState as fallback", () => {
+      const elements = [
+        createMockElement({ text: "Navigate" })
+      ];
+      const edge = createMockEdge("A", "B", {
+        interaction: {
+          toolName: "tapOn",
+          args: { text: "Navigate" },
+          timestamp: 1000,
+          uiState: {
+            selectedElements: [
+              { text: "Navigate", resourceId: "", contentDesc: "" }
+            ]
+          }
+        }
+      });
+
+      const result = findElementMatchingEdge(elements, edge);
+
+      expect(result).not.toBeNull();
+      expect(result?.element.text).toBe("Navigate");
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Extract `Explore.ts` (1870 lines) into 5 focused modules: types, element extraction, scoring, blocker detection, and validate mode
- Main `Explore` class now focuses on orchestration while delegating specific functionality
- Backward compatibility maintained via re-exports from `Explore.ts`

## Test Plan
- [x] All 129 tests pass across 5 test files
- [x] Build passes
- [x] Lint passes
- [x] Existing `Explore.test.ts` updated to test extracted functions directly
- [x] 4 new test files created for extracted modules

Closes #1108

🤖 Generated with [Claude Code](https://claude.com/claude-code)