### PR TITLE
refactor: replace inline retry logic with DefaultRetryExecutor

### DIFF
--- a/src/daemon/devicePool.ts
+++ b/src/daemon/devicePool.ts
@@ -6,6 +6,20 @@ import { MultiPlatformDeviceManager, PlatformDeviceManager } from "../utils/devi
 import { Timer, defaultTimer } from "../utils/SystemTimer";
 import type { InstalledAppsStore } from "../db/installedAppsRepository";
 import { InstalledAppsRepository } from "../db/installedAppsRepository";
+import { RetryExecutor, defaultRetryExecutor } from "../utils/retry/RetryExecutor";
+
+/**
+ * Error class for device pool operations with retryability flag.
+ */
+export class DevicePoolError extends Error {
+  constructor(
+    message: string,
+    public readonly isRetryable: boolean
+  ) {
+    super(message);
+    this.name = "DevicePoolError";
+  }
+}
 
 /**
  * Pooled Device Status
@@ -63,6 +77,7 @@ export class DevicePool {
   private daemonSessionId: string;
   private installedAppsRepository: InstalledAppsStore;
   private deviceManager: PlatformDeviceManager;
+  private readonly retryExecutor: RetryExecutor;
 
   // Max consecutive errors before marking device as failed
   private readonly MAX_DEVICE_ERRORS = 5;
@@ -76,7 +91,8 @@ export class DevicePool {
     daemonSessionId: string,
     timer: Timer = defaultTimer,
     installedAppsRepository?: InstalledAppsStore,
-    deviceManager: PlatformDeviceManager = new MultiPlatformDeviceManager()
+    deviceManager: PlatformDeviceManager = new MultiPlatformDeviceManager(),
+    retryExecutor: RetryExecutor = defaultRetryExecutor
   ) {
     this.instanceId = ++DevicePool.instanceCounter;
     logger.info(`[DEVICE-POOL-DEBUG] Creating DevicePool instance #${this.instanceId}`);
@@ -85,6 +101,7 @@ export class DevicePool {
     this.timer = timer;
     this.installedAppsRepository = installedAppsRepository ?? new InstalledAppsRepository();
     this.deviceManager = deviceManager;
+    this.retryExecutor = retryExecutor;
   }
 
   /**
@@ -280,86 +297,104 @@ export class DevicePool {
       );
     }
 
-    // Try to assign devices with shared timeout
-    let attemptCount = 0;
+    // Try to assign devices with shared timeout using retry executor
+    const maxAttempts = Math.ceil(timeoutMs / this.DEVICE_WAIT_INTERVAL_MS);
     const assigned = new Set<string>();
+    let firstWaitLogged = false;
 
-    while (assigned.size < requiredCount) {
-      attemptCount++;
+    const result = await this.retryExecutor.execute(
+      async () => {
+        // Try to assign all remaining sessions
+        while (assigned.size < requiredCount) {
+          const sessionIndex = assigned.size;
+          const sessionId = sessionIds[sessionIndex];
+
+          const assignResult = await this.tryAssignDevice(sessionId, platform);
+
+          if (assignResult.success) {
+            assigned.add(sessionId);
+            assignments.set(sessionId, assignResult.deviceId!);
+            logger.info(
+              `[DevicePool] Allocated device ${assignResult.deviceId} to session ${sessionId} ` +
+              `(${assigned.size}/${requiredCount})`
+            );
+          } else if (!assignResult.shouldWait) {
+            // No devices at all - non-retryable error
+            const currentStats = this.getStatsForPlatform(platform);
+            throw new DevicePoolError(
+              `Failed to allocate devices: no devices available.\n` +
+              `Required: ${requiredCount} devices, allocated: ${assigned.size}\n` +
+              `Device pool status:\n` +
+              `  Total devices: ${currentStats.total}\n` +
+              `  Idle: ${currentStats.idle}\n` +
+              `  Assigned: ${currentStats.assigned}\n` +
+              `  Error: ${currentStats.error}\n\n` +
+              `Suggestions:\n` +
+              `  - Start an emulator or simulator\n` +
+              `  - Check device pool status: auto-mobile --cli listDevices\n` +
+              `  - Verify device tooling is working for the selected platform`,
+              false
+            );
+          } else {
+            // Devices busy - throw retryable error to wait
+            if (!firstWaitLogged) {
+              firstWaitLogged = true;
+              logger.info(
+                `[DevicePool] Waiting for ${requiredCount - assigned.size} more device(s) ` +
+                `(${assignResult.totalDevices} total, all currently busy)...`
+              );
+            }
+            throw new DevicePoolError("All devices busy", true);
+          }
+        }
+
+        // All devices assigned successfully
+        return assignments;
+      },
+      {
+        maxAttempts,
+        delays: this.DEVICE_WAIT_INTERVAL_MS,
+        shouldRetry: error => error instanceof DevicePoolError && error.isRetryable,
+      }
+    );
+
+    if (!result.success) {
+      // Release any devices we've assigned so far
+      for (const deviceId of assignments.values()) {
+        await this.releaseDevice(deviceId);
+      }
+
+      // Check if it was a non-retryable error
+      if (result.error instanceof DevicePoolError && !result.error.isRetryable) {
+        throw new ActionableError(result.error.message);
+      }
+
+      // Timeout case
       const elapsed = this.timer.now() - startTime;
-
-      // Check timeout
-      if (elapsed > timeoutMs) {
-        // Release any devices we've assigned so far
-        for (const deviceId of assignments.values()) {
-          await this.releaseDevice(deviceId);
-        }
-        const currentStats = this.getStatsForPlatform(platform);
-        throw new ActionableError(
-          `Timed out allocating devices after ${Math.round(elapsed / 1000)}s (${attemptCount} attempts).\n` +
-          `Required: ${requiredCount} devices, allocated: ${assigned.size}\n` +
-          `Device pool status:\n` +
-          `  Total devices: ${currentStats.total}\n` +
-          `  Idle: ${currentStats.idle}\n` +
-          `  Assigned: ${currentStats.assigned}\n` +
-          `  Error: ${currentStats.error}\n\n` +
-          `Suggestions:\n` +
-          `  - Reduce parallel test count to match available devices\n` +
-          `  - Start additional emulators or connect more physical devices\n` +
-          `  - Increase device allocation timeout\n` +
-          `  - Check if tests are properly releasing devices after completion`
-        );
-      }
-
-      // Try to assign next session
-      const sessionIndex = assigned.size;
-      const sessionId = sessionIds[sessionIndex];
-
-      const result = await this.tryAssignDevice(sessionId, platform);
-
-      if (result.success) {
-        assigned.add(sessionId);
-        assignments.set(sessionId, result.deviceId!);
-        logger.info(
-          `[DevicePool] Allocated device ${result.deviceId} to session ${sessionId} ` +
-          `(${assigned.size}/${requiredCount})`
-        );
-      } else if (!result.shouldWait) {
-        // No devices at all - this shouldn't happen as we checked earlier
-        // but handle it gracefully
-        const currentStats = this.getStatsForPlatform(platform);
-        throw new ActionableError(
-          `Failed to allocate devices: no devices available.\n` +
-          `Required: ${requiredCount} devices, allocated: ${assigned.size}\n` +
-          `Device pool status:\n` +
-          `  Total devices: ${currentStats.total}\n` +
-          `  Idle: ${currentStats.idle}\n` +
-          `  Assigned: ${currentStats.assigned}\n` +
-          `  Error: ${currentStats.error}\n\n` +
-          `Suggestions:\n` +
-          `  - Start an emulator or simulator\n` +
-          `  - Check device pool status: auto-mobile --cli listDevices\n` +
-          `  - Verify device tooling is working for the selected platform`
-        );
-      } else {
-        // Devices busy - wait and retry
-        if (attemptCount === 1) {
-          logger.info(
-            `[DevicePool] Waiting for ${requiredCount - assigned.size} more device(s) ` +
-            `(${result.totalDevices} total, all currently busy)...`
-          );
-        }
-        await this.timer.sleep(this.DEVICE_WAIT_INTERVAL_MS);
-      }
+      const currentStats = this.getStatsForPlatform(platform);
+      throw new ActionableError(
+        `Timed out allocating devices after ${Math.round(elapsed / 1000)}s (${result.attempts} attempts).\n` +
+        `Required: ${requiredCount} devices, allocated: ${assigned.size}\n` +
+        `Device pool status:\n` +
+        `  Total devices: ${currentStats.total}\n` +
+        `  Idle: ${currentStats.idle}\n` +
+        `  Assigned: ${currentStats.assigned}\n` +
+        `  Error: ${currentStats.error}\n\n` +
+        `Suggestions:\n` +
+        `  - Reduce parallel test count to match available devices\n` +
+        `  - Start additional emulators or connect more physical devices\n` +
+        `  - Increase device allocation timeout\n` +
+        `  - Check if tests are properly releasing devices after completion`
+      );
     }
 
     const totalElapsed = this.timer.now() - startTime;
     logger.info(
       `[DevicePool] Successfully allocated ${requiredCount} devices ` +
-      `in ${totalElapsed}ms (${attemptCount} attempts)`
+      `in ${totalElapsed}ms (${result.attempts} attempts)`
     );
 
-    return assignments;
+    return result.value!;
   }
 
   /**
@@ -586,71 +621,84 @@ export class DevicePool {
     logger.info(`[DEVICE-POOL-DEBUG] Instance #${this.instanceId}: assignDeviceToSession called for session ${sessionId}`);
     logger.info(`[DEVICE-POOL-DEBUG] Instance #${this.instanceId}: Current devices.size: ${this.devices.size}`);
     logger.info(`[DEVICE-POOL-DEBUG] Instance #${this.instanceId}: Device IDs: ${Array.from(this.devices.keys()).join(", ")}`);
-    const startTime = this.timer.now();
-    let attemptCount = 0;
 
-    while (true) {
-      attemptCount++;
-      const elapsed = this.timer.now() - startTime;
+    const maxAttempts = Math.ceil(this.DEVICE_WAIT_TIMEOUT_MS / this.DEVICE_WAIT_INTERVAL_MS);
+    let firstAttemptLogged = false;
 
-      // Check timeout
-      if (elapsed > this.DEVICE_WAIT_TIMEOUT_MS) {
-        const stats = this.getStatsForPlatform(platform);
-        throw new ActionableError(
-          `Timed out waiting for device after ${Math.round(elapsed / 1000)}s (${attemptCount} attempts).\n` +
-          `Session: ${sessionId}\n` +
-          `Device pool status:\n` +
-          `  Total devices: ${stats.total}\n` +
-          `  Idle: ${stats.idle}\n` +
-          `  Assigned: ${stats.assigned}\n` +
-          `  Error: ${stats.error}\n\n` +
-          `Suggestions:\n` +
-          `  - Reduce parallel test count to match available devices\n` +
-          `  - Start additional emulators or connect more physical devices\n` +
-          `  - Check if tests are properly releasing devices after completion`
-        );
-      }
+    const result = await this.retryExecutor.execute(
+      async attempt => {
+        // Try to assign device (mutex ensures atomic assignment)
+        const assignResult = await this.tryAssignDevice(sessionId, platform);
 
-      // Try to assign device (mutex ensures atomic assignment)
-      const result = await this.tryAssignDevice(sessionId, platform);
+        if (assignResult.success) {
+          if (attempt > 1) {
+            logger.info(
+              `Device ${assignResult.deviceId} assigned to session ${sessionId} ` +
+              `after ${attempt} attempts`
+            );
+          }
+          return assignResult.deviceId!;
+        }
 
-      if (result.success) {
-        if (attemptCount > 1) {
-          logger.info(
-            `Device ${result.deviceId} assigned to session ${sessionId} ` +
-            `after ${attemptCount} attempts (${elapsed}ms wait)`
+        // No device available - check if we should wait or fail
+        if (assignResult.shouldWait) {
+          // Devices exist but are busy - throw retryable error
+          if (!firstAttemptLogged) {
+            firstAttemptLogged = true;
+            logger.info(
+              `All ${assignResult.totalDevices} devices busy, ` +
+              `session ${sessionId} waiting for availability (timeout: ${this.DEVICE_WAIT_TIMEOUT_MS / 1000}s)...`
+            );
+          }
+          throw new DevicePoolError("All devices busy", true);
+        } else {
+          // No devices at all - fail immediately with non-retryable error
+          const stats = this.getStatsForPlatform(platform);
+          throw new DevicePoolError(
+            `No devices in pool to assign to session ${sessionId}.\n` +
+            `Device pool status:\n` +
+            `  Total devices: ${stats.total}\n` +
+            `  Idle: ${stats.idle}\n` +
+            `  Assigned: ${stats.assigned}\n` +
+            `  Error: ${stats.error}\n\n` +
+            `Suggestions:\n` +
+            `  - Start an emulator or connect a physical device\n` +
+            `  - Check device pool status: auto-mobile --cli listDevices\n` +
+            `  - Verify device tooling is working for the selected platform`,
+            false
           );
         }
-        return result.deviceId!;
+      },
+      {
+        maxAttempts,
+        delays: this.DEVICE_WAIT_INTERVAL_MS,
+        shouldRetry: error => error instanceof DevicePoolError && error.isRetryable,
       }
+    );
 
-      // No device available - check if we should wait or fail
-      if (result.shouldWait) {
-        // Devices exist but are busy - wait and retry
-        if (attemptCount === 1) {
-          logger.info(
-            `All ${result.totalDevices} devices busy, ` +
-            `session ${sessionId} waiting for availability (timeout: ${this.DEVICE_WAIT_TIMEOUT_MS / 1000}s)...`
-          );
-        }
-        await this.timer.sleep(this.DEVICE_WAIT_INTERVAL_MS);
-      } else {
-        // No devices at all - fail immediately
-        const stats = this.getStatsForPlatform(platform);
-        throw new ActionableError(
-          `No devices in pool to assign to session ${sessionId}.\n` +
-          `Device pool status:\n` +
-          `  Total devices: ${stats.total}\n` +
-          `  Idle: ${stats.idle}\n` +
-          `  Assigned: ${stats.assigned}\n` +
-          `  Error: ${stats.error}\n\n` +
-          `Suggestions:\n` +
-          `  - Start an emulator or connect a physical device\n` +
-          `  - Check device pool status: auto-mobile --cli listDevices\n` +
-          `  - Verify device tooling is working for the selected platform`
-        );
+    if (!result.success) {
+      // Check if it was a non-retryable error (no devices)
+      if (result.error instanceof DevicePoolError && !result.error.isRetryable) {
+        throw new ActionableError(result.error.message);
       }
+      // Timeout case - all attempts exhausted
+      const stats = this.getStatsForPlatform(platform);
+      throw new ActionableError(
+        `Timed out waiting for device after ${Math.round(this.DEVICE_WAIT_TIMEOUT_MS / 1000)}s (${result.attempts} attempts).\n` +
+        `Session: ${sessionId}\n` +
+        `Device pool status:\n` +
+        `  Total devices: ${stats.total}\n` +
+        `  Idle: ${stats.idle}\n` +
+        `  Assigned: ${stats.assigned}\n` +
+        `  Error: ${stats.error}\n\n` +
+        `Suggestions:\n` +
+        `  - Reduce parallel test count to match available devices\n` +
+        `  - Start additional emulators or connect more physical devices\n` +
+        `  - Check if tests are properly releasing devices after completion`
+      );
     }
+
+    return result.value!;
   }
 
   /**

--- a/src/features/observe/DeviceServiceClient.ts
+++ b/src/features/observe/DeviceServiceClient.ts
@@ -21,6 +21,7 @@ import { NoOpPerformanceTracker } from "../../utils/PerformanceTracker";
 import type { Timer } from "../../utils/SystemTimer";
 import { defaultTimer } from "../../utils/SystemTimer";
 import { RequestManager } from "../../utils/RequestManager";
+import { RetryExecutor, defaultRetryExecutor } from "../../utils/retry/RetryExecutor";
 
 /**
  * Factory function type for creating WebSocket instances.
@@ -85,6 +86,7 @@ export abstract class DeviceServiceClient {
   protected readonly requestManager: RequestManager;
   protected readonly webSocketFactory: WebSocketFactory;
   protected readonly config: ConnectionConfig;
+  protected readonly retryExecutor: RetryExecutor;
 
   // Logging tag for subclass identification
   protected abstract readonly logTag: string;
@@ -95,12 +97,14 @@ export abstract class DeviceServiceClient {
   protected constructor(
     timer: Timer = defaultTimer,
     webSocketFactory: WebSocketFactory = defaultWebSocketFactory,
-    config: Partial<ConnectionConfig> = {}
+    config: Partial<ConnectionConfig> = {},
+    retryExecutor: RetryExecutor = defaultRetryExecutor
   ) {
     this.timer = timer;
     this.webSocketFactory = webSocketFactory;
     this.config = { ...DEFAULT_CONNECTION_CONFIG, ...config };
     this.requestManager = new RequestManager(timer);
+    this.retryExecutor = retryExecutor;
   }
 
   // ===========================================================================
@@ -170,24 +174,34 @@ export abstract class DeviceServiceClient {
     maxAttempts: number = 10,
     delayMs: number = 300
   ): Promise<boolean> {
-    for (let attempt = 1; attempt <= maxAttempts; attempt++) {
-      // Reset connection attempts counter to allow fresh connection attempts
-      this.connectionAttempts = 0;
+    const result = await this.retryExecutor.execute(
+      async attempt => {
+        // Reset connection attempts counter to allow fresh connection attempts
+        this.connectionAttempts = 0;
 
-      const connected = await this.ensureConnected();
-      if (connected) {
-        logger.info(`[${this.logTag}] WebSocket connected after ${attempt} attempt(s) (${(attempt - 1) * delayMs}ms)`);
-        return true;
-      }
+        const connected = await this.ensureConnected();
+        if (connected) {
+          logger.info(`[${this.logTag}] WebSocket connected after ${attempt} attempt(s) (${(attempt - 1) * delayMs}ms)`);
+          return true;
+        }
 
-      if (attempt < maxAttempts) {
-        logger.debug(`[${this.logTag}] Connection attempt ${attempt}/${maxAttempts} failed, retrying in ${delayMs}ms`);
-        await new Promise(resolve => this.timer.setTimeout(resolve, delayMs));
+        throw new Error(`Connection attempt ${attempt} failed`);
+      },
+      {
+        maxAttempts,
+        delays: delayMs,
+        onRetry: (_error, attempt) => {
+          logger.debug(`[${this.logTag}] Connection attempt ${attempt}/${maxAttempts} failed, retrying in ${delayMs}ms`);
+        },
       }
+    );
+
+    if (!result.success) {
+      logger.warn(`[${this.logTag}] WebSocket not ready after ${maxAttempts} attempts (${maxAttempts * delayMs}ms)`);
+      return false;
     }
 
-    logger.warn(`[${this.logTag}] WebSocket not ready after ${maxAttempts} attempts (${maxAttempts * delayMs}ms)`);
-    return false;
+    return result.value ?? false;
   }
 
   /**

--- a/src/features/observe/accessibility/AccessibilityServiceClient.ts
+++ b/src/features/observe/accessibility/AccessibilityServiceClient.ts
@@ -57,6 +57,7 @@ import {
   WebSocketFactory,
   defaultWebSocketFactory,
 } from "../DeviceServiceClient";
+import { RetryExecutor, defaultRetryExecutor } from "../../../utils/retry/RetryExecutor";
 
 // Import delegates
 import { AccessibilityServiceGestures } from "./AccessibilityServiceGestures";
@@ -343,9 +344,10 @@ export class AccessibilityServiceClient extends DeviceServiceClient implements A
     adb: AdbExecutor,
     webSocketFactory?: WebSocketFactory,
     timer?: Timer,
-    installedAppsRepository?: InstalledAppsStore
+    installedAppsRepository?: InstalledAppsStore,
+    retryExecutor?: RetryExecutor
   ) {
-    super(timer ?? defaultTimer, webSocketFactory ?? defaultWebSocketFactory);
+    super(timer ?? defaultTimer, webSocketFactory ?? defaultWebSocketFactory, {}, retryExecutor ?? defaultRetryExecutor);
     this.device = device;
     this.adb = adb;
     this.installedAppsRepository = installedAppsRepository ?? null;
@@ -388,9 +390,10 @@ export class AccessibilityServiceClient extends DeviceServiceClient implements A
     adb: AdbClient,
     webSocketFactory: (url: string) => WebSocket,
     timer?: Timer,
-    installedAppsRepository?: InstalledAppsStore
+    installedAppsRepository?: InstalledAppsStore,
+    retryExecutor?: RetryExecutor
   ): AccessibilityServiceClient {
-    return new AccessibilityServiceClient(device, adb, webSocketFactory, timer, installedAppsRepository);
+    return new AccessibilityServiceClient(device, adb, webSocketFactory, timer, installedAppsRepository, retryExecutor);
   }
 
   // ===========================================================================
@@ -865,30 +868,35 @@ export class AccessibilityServiceClient extends DeviceServiceClient implements A
   }
 
   async verifyServiceReady(maxAttempts: number = 5, delayMs: number = 500, timeoutMs: number = 3000): Promise<boolean> {
-    for (let attempt = 1; attempt <= maxAttempts; attempt++) {
-      try {
+    const result = await this.retryExecutor.execute(
+      async attempt => {
         logger.info(`[ACCESSIBILITY_SERVICE] Verifying service ready (attempt ${attempt}/${maxAttempts})`);
 
-        const result = await this.requestHierarchySync(new NoOpPerformanceTracker(), false, undefined, timeoutMs);
+        const hierarchyResult = await this.requestHierarchySync(new NoOpPerformanceTracker(), false, undefined, timeoutMs);
 
-        if (result && result.hierarchy) {
+        if (hierarchyResult && hierarchyResult.hierarchy) {
           logger.info(`[ACCESSIBILITY_SERVICE] Service verified ready after ${attempt} attempt(s)`);
           return true;
         }
 
-        logger.debug(`[ACCESSIBILITY_SERVICE] Verification attempt ${attempt} returned no hierarchy`);
-      } catch (error) {
-        logger.debug(`[ACCESSIBILITY_SERVICE] Verification attempt ${attempt} failed: ${error instanceof Error ? error.message : String(error)}`);
+        throw new Error(`Verification attempt ${attempt} returned no hierarchy`);
+      },
+      {
+        maxAttempts,
+        delays: delayMs,
+        onRetry: (error, attempt) => {
+          logger.debug(`[ACCESSIBILITY_SERVICE] Verification attempt ${attempt} failed: ${error.message}`);
+          logger.debug(`[ACCESSIBILITY_SERVICE] Waiting ${delayMs}ms before next verification attempt`);
+        },
       }
+    );
 
-      if (attempt < maxAttempts) {
-        logger.debug(`[ACCESSIBILITY_SERVICE] Waiting ${delayMs}ms before next verification attempt`);
-        await new Promise(resolve => this.timer.setTimeout(resolve, delayMs));
-      }
+    if (!result.success) {
+      logger.warn(`[ACCESSIBILITY_SERVICE] Service not ready after ${maxAttempts} verification attempts`);
+      return false;
     }
 
-    logger.warn(`[ACCESSIBILITY_SERVICE] Service not ready after ${maxAttempts} verification attempts`);
-    return false;
+    return result.value ?? false;
   }
 
   // ===========================================================================

--- a/src/utils/android-cmdline-tools/AdbClient.ts
+++ b/src/utils/android-cmdline-tools/AdbClient.ts
@@ -6,6 +6,7 @@ import { detectAndroidCommandLineTools, getBestAndroidToolsLocation } from "./de
 import { AdbExecutor } from "./interfaces/AdbExecutor";
 import { getAbortSignal } from "../AbortContext";
 import { OPERATION_CANCELLED_MESSAGE } from "../constants";
+import { RetryExecutor, defaultRetryExecutor } from "../retry/RetryExecutor";
 
 type ExecFileAsync = (file: string, args: string[], maxBuffer?: number) => Promise<ExecResult>;
 
@@ -43,6 +44,7 @@ export class AdbClient implements AdbExecutor {
   private isTestMode: boolean;
   private activeProcesses: Set<ChildProcess> = new Set();
   private apiLevelCache: number | null | undefined;
+  private readonly retryExecutor: RetryExecutor;
 
   // Static cache for device list
   private static deviceListCache: { devices: BootedDevice[], timestamp: number } | null = null;
@@ -59,11 +61,13 @@ export class AdbClient implements AdbExecutor {
    * @param device - Optional device
    * @param execAsyncFn - promisified exec function (for testing)
    * @param spawnFn - spawn function (for testing)
+   * @param retryExecutor - retry executor for command retries (for testing)
    */
   constructor(
     device: BootedDevice | null = null,
     execAsyncFn: ((command: string, maxBuffer?: number) => Promise<ExecResult>) | ExecFileAsync | null = null,
-    spawnFn: typeof spawn | null = null
+    spawnFn: typeof spawn | null = null,
+    retryExecutor: RetryExecutor = defaultRetryExecutor
   ) {
     this.device = device;
     // Test mode if: custom execAsync provided OR global test mode flag is set
@@ -87,6 +91,7 @@ export class AdbClient implements AdbExecutor {
         : execFileAsync;
     }
     this.spawnFn = spawnFn || spawn;
+    this.retryExecutor = retryExecutor;
     // Initialize with fallback, will be updated lazily
     this.adbPath = this.getFallbackAdbPath();
 
@@ -335,11 +340,31 @@ export class AdbClient implements AdbExecutor {
   }
 
   /**
+   * Determine if an error is non-retryable (auth, syntax, or device errors).
+   * Returns true if the error should NOT be retried.
+   */
+  private isNonRetryableError(error: Error): boolean {
+    const message = error.message.toLowerCase();
+    const nonRetryablePatterns = [
+      "operation cancelled",
+      "unauthorized",
+      "authentication failed",
+      "permission denied",
+      "unknown command",
+      "invalid argument",
+      "syntax error",
+      "device not found",
+      "no devices",
+      "offline",
+    ];
+    return nonRetryablePatterns.some(pattern => message.includes(pattern));
+  }
+
+  /**
    * Internal implementation of command execution
    * @param command - The ADB command to execute
    * @param timeoutMs - Optional timeout in milliseconds
    * @param maxBuffer - Optional maximum buffer size for command output
-   * @param attempt - Current attempt number at executing this command
    * @param noRetry - Optional flag to disable retry logic for commands expected to fail
    * @returns Promise with command output
    */
@@ -347,7 +372,7 @@ export class AdbClient implements AdbExecutor {
     command: string,
     timeoutMs?: number,
     maxBuffer?: number,
-    attempt: number = 0,
+    _attempt: number = 0,
     noRetry?: boolean,
     signal?: AbortSignal
   ): Promise<ExecResult> {
@@ -361,22 +386,49 @@ export class AdbClient implements AdbExecutor {
     const deviceInfo = this.device ? `[DEVICE:${this.device.deviceId}]` : "[NO-DEVICE]";
     logger.info(`[ADB] ${deviceInfo} Executing: ${command.length > 80 ? command.substring(0, 80) + "..." : command}`);
 
-    try {
-      const result = await this.execWithSignal(adbPath, fullArgs, maxBuffer, timeoutMs, resolvedSignal);
-      const duration = Date.now() - startTime;
-      logger.info(`[ADB] Command completed in ${duration}ms: ${command}`);
-      return result;
-    } catch (error) {
-      if (resolvedSignal?.aborted) {
-        throw new Error(OPERATION_CANCELLED_MESSAGE);
+    if (noRetry) {
+      // No retry - just execute once
+      try {
+        const result = await this.execWithSignal(adbPath, fullArgs, maxBuffer, timeoutMs, resolvedSignal);
+        const duration = Date.now() - startTime;
+        logger.info(`[ADB] Command completed in ${duration}ms: ${command}`);
+        return result;
+      } catch (error) {
+        if (resolvedSignal?.aborted) {
+          throw new Error(OPERATION_CANCELLED_MESSAGE);
+        }
+        const duration = Date.now() - startTime;
+        logger.warn(`[ADB] Command failed after ${duration}ms: ${command} - ${(error as Error).message}`);
+        throw error;
       }
-      if (!noRetry && attempt < AdbClient.MAX_ADB_RETRIES) {
-        return this.executeCommandImpl(command, timeoutMs, maxBuffer, attempt + 1, noRetry, resolvedSignal);
-      }
-      const duration = Date.now() - startTime;
-      logger.warn(`[ADB] Command failed after ${duration}ms: ${command} - ${(error as Error).message}`);
-      throw error;
     }
+
+    // Use retry executor for retryable commands
+    return this.retryExecutor.executeOrThrow(
+      async () => {
+        if (resolvedSignal?.aborted) {
+          throw new Error(OPERATION_CANCELLED_MESSAGE);
+        }
+        const result = await this.execWithSignal(adbPath, fullArgs, maxBuffer, timeoutMs, resolvedSignal);
+        const duration = Date.now() - startTime;
+        logger.info(`[ADB] Command completed in ${duration}ms: ${command}`);
+        return result;
+      },
+      {
+        maxAttempts: AdbClient.MAX_ADB_RETRIES + 1,
+        delays: 0, // Immediate retry (no delay)
+        signal: resolvedSignal,
+        shouldRetry: error => {
+          if (resolvedSignal?.aborted) {
+            return false;
+          }
+          return !this.isNonRetryableError(error);
+        },
+        onRetry: (error, attempt) => {
+          logger.debug(`[ADB] Retrying command (attempt ${attempt + 1}): ${command} - ${error.message}`);
+        },
+      }
+    );
   }
 
   private async execWithSignal(

--- a/src/utils/android-cmdline-tools/AdbClientFactory.ts
+++ b/src/utils/android-cmdline-tools/AdbClientFactory.ts
@@ -1,6 +1,7 @@
 import type { BootedDevice } from "../../models";
 import type { AdbExecutor } from "./interfaces/AdbExecutor";
 import { AdbClient } from "./AdbClient";
+import type { RetryExecutor } from "../retry/RetryExecutor";
 
 /**
  * Factory interface for creating AdbClient instances.
@@ -10,17 +11,18 @@ export interface AdbClientFactory {
   /**
    * Create an AdbClient for the given device.
    * @param device - The target device (optional for device-independent operations)
+   * @param retryExecutor - Optional retry executor for command retries
    * @returns An AdbExecutor instance
    */
-  create(device?: BootedDevice | null): AdbExecutor;
+  create(device?: BootedDevice | null, retryExecutor?: RetryExecutor): AdbExecutor;
 }
 
 /**
  * Default factory that creates real AdbClient instances.
  */
 export class DefaultAdbClientFactory implements AdbClientFactory {
-  create(device?: BootedDevice | null): AdbExecutor {
-    return new AdbClient(device ?? null);
+  create(device?: BootedDevice | null, retryExecutor?: RetryExecutor): AdbExecutor {
+    return new AdbClient(device ?? null, null, null, retryExecutor);
   }
 }
 

--- a/test/daemon/devicePool.test.ts
+++ b/test/daemon/devicePool.test.ts
@@ -5,6 +5,7 @@ import { FakeTimer } from "../fakes/FakeTimer";
 import { FakeInstalledAppsRepository } from "../fakes/FakeInstalledAppsRepository";
 import { FakeDeviceManager } from "../fakes/FakeDeviceManager";
 import { BootedDevice, DeviceInfo, Platform } from "../../src/models";
+import { DefaultRetryExecutor } from "../../src/utils/retry/RetryExecutor";
 
 describe("DevicePool", () => {
   let devicePool: DevicePool;
@@ -29,7 +30,9 @@ describe("DevicePool", () => {
     sessionManager = new SessionManager(fakeTimer);
     fakeAppsRepo = new FakeInstalledAppsRepository();
     fakeDeviceManager = new FakeDeviceManager();
-    devicePool = new DevicePool(sessionManager, "test-daemon-session-id", fakeTimer, fakeAppsRepo, fakeDeviceManager);
+    // Create a RetryExecutor that uses the fakeTimer so time advancement works correctly
+    const retryExecutor = new DefaultRetryExecutor(fakeTimer);
+    devicePool = new DevicePool(sessionManager, "test-daemon-session-id", fakeTimer, fakeAppsRepo, fakeDeviceManager, retryExecutor);
   });
 
   afterEach(() => {
@@ -159,7 +162,8 @@ describe("DevicePool", () => {
         { name: "iPhone 15", platform: "ios", isRunning: false, deviceId: "sim-2" },
       ];
       const fakeDeviceManager = new FakeDeviceManager(images);
-      devicePool = new DevicePool(sessionManager, "test-daemon-session-id", fakeTimer, fakeAppsRepo, fakeDeviceManager);
+      const retryExecutor = new DefaultRetryExecutor(fakeTimer);
+      devicePool = new DevicePool(sessionManager, "test-daemon-session-id", fakeTimer, fakeAppsRepo, fakeDeviceManager, retryExecutor);
 
       await expect(
         devicePool.assignMultipleDevices(["session-a", "session-b"], 1000, "ios")

--- a/test/daemon/integration/parallelExecution.test.ts
+++ b/test/daemon/integration/parallelExecution.test.ts
@@ -4,6 +4,7 @@ import { DevicePool } from "../../../src/daemon/devicePool";
 import { FakeTimer } from "../../fakes/FakeTimer";
 import { FakeInstalledAppsRepository } from "../../fakes/FakeInstalledAppsRepository";
 import { BootedDevice } from "../../../src/models";
+import { DefaultRetryExecutor } from "../../../src/utils/retry/RetryExecutor";
 
 describe("Parallel Execution Across Multiple Devices", function() {
   let sessionManager: SessionManager;
@@ -20,7 +21,9 @@ describe("Parallel Execution Across Multiple Devices", function() {
     fakeTimer = new FakeTimer();
     sessionManager = new SessionManager(fakeTimer);
     fakeAppsRepo = new FakeInstalledAppsRepository();
-    devicePool = new DevicePool(sessionManager, "test-daemon-session-id", fakeTimer, fakeAppsRepo);
+    // Create a RetryExecutor that uses the fakeTimer so time advancement works correctly
+    const retryExecutor = new DefaultRetryExecutor(fakeTimer);
+    devicePool = new DevicePool(sessionManager, "test-daemon-session-id", fakeTimer, fakeAppsRepo, undefined, retryExecutor);
     await devicePool.initializeWithDevices([
       createBootedDevice("device-1"),
       createBootedDevice("device-2"),


### PR DESCRIPTION
## Summary
- Inject `RetryExecutor` as constructor dependency across `AdbClient`, `DeviceServiceClient`, `AccessibilityServiceClient`, and `DevicePool`
- Add `isNonRetryableError()` helper in `AdbClient` for auth/syntax/device error detection
- Add `DevicePoolError` class with `isRetryable` flag to distinguish "no devices" (non-retryable) vs "all busy" (retryable)
- Update tests to inject `DefaultRetryExecutor` with `FakeTimer` for proper time advancement

## Test Plan
- [x] `bun run lint` passes
- [x] `bun run build` passes
- [x] `bun test` passes (1962 tests)

Closes #1113

🤖 Generated with [Claude Code](https://claude.com/claude-code)