### PR TITLE
refactor: migrate raw setTimeout/setInterval to Timer interface

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -160,6 +160,14 @@ export const baseRules = {
 			selector: "ImportDeclaration[source.value=/^\\..*\\.ts$/]",
 			message: "Do not use .ts extension in relative imports. Use extensionless imports instead (e.g., './foo' not './foo.ts').",
 		},
+		{
+			selector: "CallExpression[callee.name='setTimeout']",
+			message: "Use Timer.setTimeout() instead. Import { Timer, defaultTimer } from 'utils/SystemTimer'.",
+		},
+		{
+			selector: "CallExpression[callee.name='setInterval']",
+			message: "Use Timer.setInterval() instead. Import { Timer, defaultTimer } from 'utils/SystemTimer'.",
+		},
 	],
 
 	// file whitespace
@@ -213,6 +221,27 @@ export default [
 		rules: {
 			...baseRules,
 			"no-mixed-spaces-and-tabs": "off",
+		},
+	},
+	{
+		// SystemTimer.ts is the implementation that wraps raw setTimeout/setInterval
+		files: ["**/SystemTimer.ts"],
+		plugins,
+		languageOptions,
+		rules: {
+			...baseRules,
+			"no-restricted-syntax": [
+				2,
+				{
+					selector: "ImportDeclaration[source.value=/^\\..*\\.js$/]",
+					message: "Do not use .js extension in relative imports. Use extensionless imports instead (e.g., './foo' not './foo.js'). This causes MODULE_NOT_FOUND errors in tests.",
+				},
+				{
+					selector: "ImportDeclaration[source.value=/^\\..*\\.ts$/]",
+					message: "Do not use .ts extension in relative imports. Use extensionless imports instead (e.g., './foo' not './foo.ts').",
+				},
+				// setTimeout/setInterval rules intentionally omitted - this file wraps them
+			],
 		},
 	},
 ];

--- a/scripts/memory/stress-harness.ts
+++ b/scripts/memory/stress-harness.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import { performance } from "node:perf_hooks";
+import { defaultTimer } from "../../src/utils/SystemTimer";
 import { RealObserveScreen } from "../../src/features/observe/ObserveScreen";
 import type { ObserveScreen } from "../../src/features/observe/interfaces/ObserveScreen";
 import { TapOnElement } from "../../src/features/action/TapOnElement";
@@ -408,7 +409,7 @@ export async function runStressOperations(
       const elapsed = performance.now() - opStart;
       const remaining = delayMs - elapsed;
       if (remaining > 0) {
-        await new Promise(resolve => setTimeout(resolve, remaining));
+        await defaultTimer.sleep(remaining);
       }
     }
   }

--- a/src/daemon/client.ts
+++ b/src/daemon/client.ts
@@ -8,6 +8,7 @@ import {
   SOCKET_PATH,
   CONNECTION_TIMEOUT_MS,
 } from "./constants";
+import { defaultTimer } from "../utils/SystemTimer";
 
 /**
  * Custom error thrown when daemon is unavailable
@@ -84,7 +85,7 @@ export class DaemonClient {
     }
 
     return new Promise((resolve, reject) => {
-      const timeout = setTimeout(() => {
+      const timeout = defaultTimer.setTimeout(() => {
         if (this.socket) {
           this.socket.destroy();
         }
@@ -207,7 +208,7 @@ export class DaemonClient {
 
     // Send request
     return new Promise((resolve, reject) => {
-      const timeout = setTimeout(() => {
+      const timeout = defaultTimer.setTimeout(() => {
         this.pendingRequests.delete(requestId);
         reject(
           new DaemonUnavailableError(
@@ -258,7 +259,7 @@ export class DaemonClient {
     };
 
     return new Promise((resolve, reject) => {
-      const timeout = setTimeout(() => {
+      const timeout = defaultTimer.setTimeout(() => {
         this.pendingRequests.delete(requestId);
         reject(
           new DaemonUnavailableError(
@@ -276,7 +277,7 @@ export class DaemonClient {
       });
 
       if (!this.socket) {
-        clearTimeout(timeout);
+        defaultTimer.clearTimeout(timeout);
         this.pendingRequests.delete(requestId);
         reject(
           new DaemonUnavailableError("Socket connection lost")

--- a/src/daemon/daemon.ts
+++ b/src/daemon/daemon.ts
@@ -37,6 +37,7 @@ import { InstalledAppsRepository } from "../db/installedAppsRepository";
 import { DeviceSessionManager } from "../utils/DeviceSessionManager";
 import { startAppearanceSyncScheduler, stopAppearanceSyncScheduler } from "../utils/appearance/AppearanceSyncScheduler";
 import { listActiveVideoRecordings, stopVideoRecording } from "../server/videoRecordingManager";
+import { defaultTimer } from "../utils/SystemTimer";
 
 const DEVICE_DISCONNECT_POLL_INTERVAL_MS = 5000;
 const DEVICE_DISCONNECT_MISS_THRESHOLD = 2;
@@ -200,7 +201,7 @@ export class Daemon {
       let resolved = false;
 
       // Timeout safety - prevent hanging forever
-      const timeout = setTimeout(() => {
+      const timeout = defaultTimer.setTimeout(() => {
         if (!resolved) {
           resolved = true;
           testServer.close(() => {
@@ -598,7 +599,7 @@ export class Daemon {
     const MAX_FAILED_CHECKS = 3; // Allow 3 consecutive failures before taking action
     let failedCheckCount = 0;
 
-    this.healthCheckTimer = setInterval(async () => {
+    this.healthCheckTimer = defaultTimer.setInterval(async () => {
       try {
         // Check if HTTP server is responsive
         if (!this.httpServer) {
@@ -642,7 +643,7 @@ export class Daemon {
     const HEARTBEAT_CHECK_INTERVAL_MS = 10000;
     const INITIAL_HEARTBEAT_GRACE_MS = 20_000;
 
-    this.heartbeatMonitorTimer = setInterval(async () => {
+    this.heartbeatMonitorTimer = defaultTimer.setInterval(async () => {
       const now = Date.now();
       const sessions = this.sessionManager.getAllSessions();
 
@@ -672,7 +673,7 @@ export class Daemon {
 
     const deviceManager = new MultiPlatformDeviceManager();
 
-    this.deviceDisconnectTimer = setInterval(async () => {
+    this.deviceDisconnectTimer = defaultTimer.setInterval(async () => {
       try {
         const bootedDevices = await deviceManager.getBootedDevices("either");
         const bootedDeviceIds = new Set(bootedDevices.map(device => device.deviceId));
@@ -773,13 +774,13 @@ export class Daemon {
    */
   private async initializeDevicePoolWithTimeout(timeoutMs: number): Promise<void> {
     const timeoutPromise = new Promise<void>(resolve => {
-      const timer = setTimeout(() => {
+      const timer = defaultTimer.setTimeout(() => {
         logger.warn(`Device pool initialization timed out after ${timeoutMs}ms`);
         resolve();
       }, timeoutMs);
       // Allow process to exit even if this timer is pending
-      if (typeof timer.unref === "function") {
-        timer.unref();
+      if (typeof (timer as { unref?: () => void }).unref === "function") {
+        (timer as { unref: () => void }).unref();
       }
     });
 
@@ -844,12 +845,12 @@ export class Daemon {
         logger.info(`[Daemon] Setting up XCTestService for iOS device ${device.id}`);
 
         const timeoutPromise = new Promise<never>((_, reject) => {
-          const timer = setTimeout(() => {
+          const timer = defaultTimer.setTimeout(() => {
             reject(new Error(`Timeout after ${PER_DEVICE_TIMEOUT_MS}ms`));
           }, PER_DEVICE_TIMEOUT_MS);
           // Allow process to exit even if this timer is pending
-          if (typeof timer.unref === "function") {
-            timer.unref();
+          if (typeof (timer as { unref?: () => void }).unref === "function") {
+            (timer as { unref: () => void }).unref();
           }
         });
 

--- a/src/daemon/manager.ts
+++ b/src/daemon/manager.ts
@@ -20,6 +20,7 @@ import {
 } from "./debugTools";
 import { DaemonClient, type DaemonClientFactory, type DaemonClientLike } from "./client";
 import { DaemonState, type DaemonStateLike } from "./daemonState";
+import { defaultTimer } from "../utils/SystemTimer";
 
 /**
  * Daemon Manager
@@ -109,7 +110,7 @@ export class DaemonManager {
       }
 
       // Wait for processes to terminate
-      await new Promise(resolve => setTimeout(resolve, 1000));
+      await defaultTimer.sleep(1000);
     }
 
     // Enforce single daemon policy: stop any existing daemon before starting
@@ -121,7 +122,7 @@ export class DaemonManager {
       );
       await this.stop();
       // Wait briefly for cleanup
-      await new Promise(resolve => setTimeout(resolve, 500));
+      await defaultTimer.sleep(500);
     }
 
     // Clean up stale socket and PID files from previous sessions
@@ -245,7 +246,7 @@ export class DaemonManager {
         process.kill(pid, "SIGKILL");
 
         // Wait a bit more
-        await new Promise(resolve => setTimeout(resolve, 1000));
+        await defaultTimer.sleep(1000);
       }
 
       // Clean up stale PID file if it exists
@@ -315,7 +316,7 @@ export class DaemonManager {
     console.log("Restarting daemon...");
     await this.stop();
     // Wait a bit before starting
-    await new Promise(resolve => setTimeout(resolve, 1000));
+    await defaultTimer.sleep(1000);
     await this.start(options);
   }
 
@@ -336,7 +337,7 @@ export class DaemonManager {
         }
       }
 
-      await new Promise(resolve => setTimeout(resolve, pollInterval));
+      await defaultTimer.sleep(pollInterval);
     }
 
     return false;
@@ -353,7 +354,7 @@ export class DaemonManager {
       if (!this.isProcessRunning(pid)) {
         return true;
       }
-      await new Promise(resolve => setTimeout(resolve, pollInterval));
+      await defaultTimer.sleep(pollInterval);
     }
 
     return false;

--- a/src/db/performanceAuditRepository.ts
+++ b/src/db/performanceAuditRepository.ts
@@ -1,6 +1,7 @@
 import { getDatabase } from "./database";
 import type { NewPerformanceAuditResult } from "./types";
 import { logger } from "../utils/logger";
+import { defaultTimer } from "../utils/SystemTimer";
 
 const RETENTION_MAX_ROWS = 10_000;
 const RETENTION_MAX_AGE_HOURS = 24;
@@ -356,7 +357,7 @@ export class PerformanceAuditRepository {
       return;
     }
 
-    pruningTimer = setInterval(() => {
+    pruningTimer = defaultTimer.setInterval(() => {
       this.pruneOldRecords().catch(error => {
         logger.warn(`[PerformanceAuditRepository] Periodic pruning error: ${error}`);
       });
@@ -373,7 +374,7 @@ export class PerformanceAuditRepository {
    */
   stopPeriodicPruning(): void {
     if (pruningTimer) {
-      clearInterval(pruningTimer);
+      defaultTimer.clearInterval(pruningTimer);
       pruningTimer = null;
       logger.info("[PerformanceAuditRepository] Stopped periodic pruning");
     }

--- a/src/features/action/InputText.ts
+++ b/src/features/action/InputText.ts
@@ -5,6 +5,7 @@ import { logger } from "../../utils/logger";
 import { createGlobalPerformanceTracker } from "../../utils/PerformanceTracker";
 import { AccessibilityServiceClient } from "../observe/AccessibilityServiceClient";
 import { XCTestServiceClient } from "../observe/XCTestServiceClient";
+import { defaultTimer } from "../../utils/SystemTimer";
 
 export class InputText extends BaseVisualChange {
   constructor(device: BootedDevice, adb: AdbClient | null = null) {
@@ -163,7 +164,7 @@ export class InputText extends BaseVisualChange {
     const keyCode = imeKeyCodeMap[imeAction];
     if (keyCode) {
       // Small delay to ensure text input is processed
-      await new Promise(resolve => setTimeout(resolve, 100));
+      await defaultTimer.sleep(100);
 
       // Execute the key event(s)
       if (keyCode.includes(" ")) {

--- a/src/features/action/SwipeOn.ts
+++ b/src/features/action/SwipeOn.ts
@@ -27,6 +27,7 @@ import { resolveSwipeDirection } from "../../utils/swipeOnUtils";
 import { AccessibilityDetector } from "../../utils/interfaces/AccessibilityDetector";
 import { accessibilityDetector as defaultAccessibilityDetector } from "../../utils/AccessibilityDetector";
 import { serverConfig } from "../../utils/ServerConfig";
+import { defaultTimer } from "../../utils/SystemTimer";
 
 export interface GestureExecutor {
   swipe(
@@ -1533,7 +1534,7 @@ export class SwipeOn extends BaseVisualChange {
     // Retry logic similar to TapOnElement
     if (!element && attempt < SwipeOn.MAX_ATTEMPTS) {
       const delayNextAttempt = Math.min(10 * Math.pow(2, attempt), 1000);
-      await new Promise(resolve => setTimeout(resolve, delayNextAttempt));
+      await defaultTimer.sleep(delayNextAttempt);
 
       let latestViewHierarchy: ViewHierarchyResult | null = null;
 

--- a/src/features/debug/BugReport.ts
+++ b/src/features/debug/BugReport.ts
@@ -5,6 +5,7 @@ import { randomBytes } from "crypto";
 import { AdbClientFactory, defaultAdbClientFactory } from "../../utils/android-cmdline-tools/AdbClientFactory";
 import type { AdbExecutor } from "../../utils/android-cmdline-tools/interfaces/AdbExecutor";
 import { logger } from "../../utils/logger";
+import { defaultTimer } from "../../utils/SystemTimer";
 import {
   BootedDevice,
   BugReportHighlightEntry,
@@ -507,7 +508,7 @@ export class BugReport {
     if (HIGHLIGHT_RENDER_DELAY_MS <= 0) {
       return;
     }
-    await new Promise(resolve => setTimeout(resolve, HIGHLIGHT_RENDER_DELAY_MS));
+    await defaultTimer.sleep(HIGHLIGHT_RENDER_DELAY_MS);
   }
 
   private buildHighlightEntries(

--- a/src/features/memory/MemoryMetricsCollector.ts
+++ b/src/features/memory/MemoryMetricsCollector.ts
@@ -5,6 +5,7 @@ import { logger } from "../../utils/logger";
 import { BootedDevice } from "../../models";
 import { PerformanceTracker, NoOpPerformanceTracker } from "../../utils/PerformanceTracker";
 import type { MemoryMetricsProvider } from "./interfaces/MemoryMetricsProvider";
+import { defaultTimer } from "../../utils/SystemTimer";
 
 /**
  * Memory snapshot from dumpsys meminfo
@@ -160,7 +161,7 @@ export class MemoryMetricsCollector implements MemoryMetricsProvider {
       );
 
       // Wait for GC to complete (small delay)
-      await new Promise(resolve => setTimeout(resolve, 500));
+      await defaultTimer.sleep(500);
 
       logger.info(`[MemoryMetricsCollector] GC triggered for ${packageName}`);
     } catch (error) {

--- a/src/features/navigation/DefaultScreenTransitionWaiter.ts
+++ b/src/features/navigation/DefaultScreenTransitionWaiter.ts
@@ -1,6 +1,7 @@
 import { logger } from "../../utils/logger";
 import { NavigationGraphManager } from "./NavigationGraphManager";
 import { ScreenTransitionWaiter } from "./interfaces/ScreenTransitionWaiter";
+import { defaultTimer } from "../../utils/SystemTimer";
 
 /**
  * Default implementation of ScreenTransitionWaiter that polls the navigation graph
@@ -45,6 +46,6 @@ export class DefaultScreenTransitionWaiter implements ScreenTransitionWaiter {
    * Sleep for the specified duration.
    */
   private sleep(ms: number): Promise<void> {
-    return new Promise(resolve => setTimeout(resolve, ms));
+    return defaultTimer.sleep(ms);
   }
 }

--- a/src/features/navigation/DefaultUIStateSetup.ts
+++ b/src/features/navigation/DefaultUIStateSetup.ts
@@ -7,6 +7,7 @@ import { ModalState, ScrollPosition } from "../../utils/interfaces/NavigationGra
 import { UIStateExtractor } from "./UIStateExtractor";
 import { RealObserveScreen } from "../observe/ObserveScreen";
 import { UIStateSetup } from "./interfaces/UIStateSetup";
+import { defaultTimer } from "../../utils/SystemTimer";
 
 /**
  * Default implementation of UIStateSetup that handles UI state alignment
@@ -456,6 +457,6 @@ export class DefaultUIStateSetup implements UIStateSetup {
    * Sleep for the specified duration.
    */
   private sleep(ms: number): Promise<void> {
-    return new Promise(resolve => setTimeout(resolve, ms));
+    return defaultTimer.sleep(ms);
   }
 }

--- a/src/features/navigation/Explore.ts
+++ b/src/features/navigation/Explore.ts
@@ -769,7 +769,7 @@ export class Explore extends BaseVisualChange {
       this.consecutiveBackCount++;
 
       // Wait briefly for navigation
-      await new Promise(resolve => setTimeout(resolve, 1000));
+      await defaultTimer.sleep(1000);
     } catch (error) {
       logger.warn(`[Explore] Failed to navigate back: ${error}`);
     }
@@ -792,7 +792,7 @@ export class Explore extends BaseVisualChange {
       await this.adb.executeCommand("shell input keyevent KEYCODE_HOME");
 
       // Wait for home screen
-      await new Promise(resolve => setTimeout(resolve, 2000));
+      await defaultTimer.sleep(2000);
 
       // Reset consecutive back count
       this.consecutiveBackCount = 0;

--- a/src/features/navigation/ExploreBlockerDetection.ts
+++ b/src/features/navigation/ExploreBlockerDetection.ts
@@ -5,6 +5,7 @@ import type { ElementParser } from "../utility/ElementParser";
 import { TapOnElement } from "../action/TapOnElement";
 import { logger } from "../../utils/logger";
 import { extractAllElements } from "./ExploreElementExtraction";
+import { defaultTimer } from "../../utils/SystemTimer";
 
 /**
  * Check if screen is a permission dialog
@@ -98,7 +99,7 @@ export async function handlePermissionDialog(
           },
           progress
         );
-        await new Promise(resolve => setTimeout(resolve, 1000));
+        await defaultTimer.sleep(1000);
         return true;
       } catch (error) {
         logger.warn(`[Explore] Failed to handle permission dialog: ${error}`);
@@ -147,7 +148,7 @@ export async function dismissDialog(
           },
           progress
         );
-        await new Promise(resolve => setTimeout(resolve, 1000));
+        await defaultTimer.sleep(1000);
         return true;
       } catch (error) {
         logger.warn(`[Explore] Failed to dismiss dialog: ${error}`);

--- a/src/features/navigation/ExploreValidateMode.ts
+++ b/src/features/navigation/ExploreValidateMode.ts
@@ -226,7 +226,7 @@ export async function validateNavigation(
   setStopReason: (reason: string) => void
 ): Promise<boolean> {
   // Wait a bit for navigation to complete
-  await new Promise(resolve => setTimeout(resolve, 500));
+  await timer.sleep(500);
 
   const actualScreen = navigationManager.getCurrentScreen() ?? "unknown";
   const success = actualScreen === expectedEdge.to;

--- a/src/features/navigation/NavigateTo.ts
+++ b/src/features/navigation/NavigateTo.ts
@@ -14,6 +14,7 @@ import { UIStateSetup } from "./interfaces/UIStateSetup";
 import { DefaultUIStateSetup } from "./DefaultUIStateSetup";
 import { ScreenTransitionWaiter } from "./interfaces/ScreenTransitionWaiter";
 import { DefaultScreenTransitionWaiter } from "./DefaultScreenTransitionWaiter";
+import { defaultTimer } from "../../utils/SystemTimer";
 
 /**
  * Options for the navigateTo tool.
@@ -132,7 +133,7 @@ export class NavigateTo {
             executedPath.push("pressButton(back)");
 
             // Small delay between presses to allow screen transitions
-            await new Promise(resolve => setTimeout(resolve, 300));
+            await defaultTimer.sleep(300);
           }
 
           // Wait for target screen
@@ -321,6 +322,6 @@ export class NavigateTo {
    * Sleep for the specified duration.
    */
   private sleep(ms: number): Promise<void> {
-    return new Promise(resolve => setTimeout(resolve, ms));
+    return defaultTimer.sleep(ms);
   }
 }

--- a/src/features/observe/AwaitIdle.ts
+++ b/src/features/observe/AwaitIdle.ts
@@ -6,6 +6,7 @@ import { BootedDevice, GfxMetrics } from "../../models";
 import { PerformanceTracker, NoOpPerformanceTracker } from "../../utils/PerformanceTracker";
 import { throwIfAborted } from "../../utils/toolUtils";
 import type { AwaitIdle as AwaitIdleInterface, UiStabilityState } from "./interfaces/AwaitIdle";
+import { defaultTimer } from "../../utils/SystemTimer";
 
 export class AwaitIdle implements AwaitIdleInterface {
   private adb: AdbExecutor;
@@ -59,7 +60,7 @@ export class AwaitIdle implements AwaitIdleInterface {
       }
 
       // Wait a short interval before checking again
-      await new Promise(resolve => setTimeout(resolve, this.pollIntervalMs));
+      await defaultTimer.sleep(this.pollIntervalMs);
     }
   }
 
@@ -246,7 +247,7 @@ export class AwaitIdle implements AwaitIdleInterface {
         }
 
         // Wait before checking again
-        await new Promise(resolve => setTimeout(resolve, this.pollIntervalMs));
+        await defaultTimer.sleep(this.pollIntervalMs);
       }
     } catch {
       logger.error("[AwaitIdle] Encountered an error while waiting for UI stability");

--- a/src/features/observe/Idle.ts
+++ b/src/features/observe/Idle.ts
@@ -3,6 +3,7 @@ import type { AdbExecutor } from "../../utils/android-cmdline-tools/interfaces/A
 import { logger } from "../../utils/logger";
 import { UiStabilityResult, TouchIdleResult, RotationCheckResult, BootedDevice } from "../../models";
 import { PerformanceTracker, NoOpPerformanceTracker } from "../../utils/PerformanceTracker";
+import { defaultTimer } from "../../utils/SystemTimer";
 
 export class Idle {
   private adb: AdbExecutor;
@@ -159,7 +160,7 @@ export class Idle {
       );
 
       // Wait for measurement period to accumulate data
-      await new Promise(resolve => setTimeout(resolve, measurementDelayMs));
+      await defaultTimer.sleep(measurementDelayMs);
 
       // Take immediate measurement with no previous state
       return await this.getUiStability(

--- a/src/features/performance/PerformanceAudit.ts
+++ b/src/features/performance/PerformanceAudit.ts
@@ -8,6 +8,7 @@ import { DeviceCapabilitiesDetector, DeviceCapabilities } from "../../utils/Devi
 import { TouchLatencyTracker } from "./TouchLatencyTracker";
 import { serverConfig } from "../../utils/ServerConfig";
 import { PerformanceAuditRepository } from "../../db/performanceAuditRepository";
+import { defaultTimer } from "../../utils/SystemTimer";
 
 /**
  * Performance metrics collected during audit
@@ -477,7 +478,7 @@ export class PerformanceAudit {
         );
 
         // Wait for check interval
-        await new Promise(resolve => setTimeout(resolve, stabilityCheckIntervalMs));
+        await defaultTimer.sleep(stabilityCheckIntervalMs);
         elapsedMs += stabilityCheckIntervalMs;
 
         // Get metrics after interval

--- a/src/features/video/FfmpegVideoProcessingBackend.ts
+++ b/src/features/video/FfmpegVideoProcessingBackend.ts
@@ -3,6 +3,7 @@ import { platform } from "node:os";
 import path from "node:path";
 import fs from "fs-extra";
 import { ActionableError, type BootedDevice } from "../../models";
+import { defaultTimer } from "../../utils/SystemTimer";
 import { defaultAdbClientFactory } from "../../utils/android-cmdline-tools/AdbClientFactory";
 import type { AdbClientFactory } from "../../utils/android-cmdline-tools/AdbClientFactory";
 import { SimCtlClient } from "../../utils/ios-cmdline-tools/SimCtlClient";
@@ -110,7 +111,7 @@ async function waitForExit(
 
   let timeoutId: NodeJS.Timeout | undefined;
   const timeoutPromise = new Promise<void>(resolve => {
-    timeoutId = setTimeout(() => {
+    timeoutId = defaultTimer.setTimeout(() => {
       if (process.exitCode === null) {
         process.kill("SIGKILL");
       }

--- a/src/features/video/PlatformVideoCaptureBackend.ts
+++ b/src/features/video/PlatformVideoCaptureBackend.ts
@@ -3,6 +3,7 @@ import path from "node:path";
 import type { WriteStream } from "node:fs";
 import fs from "fs-extra";
 import { ActionableError, BootedDevice } from "../../models";
+import { defaultTimer } from "../../utils/SystemTimer";
 import { defaultAdbClientFactory } from "../../utils/android-cmdline-tools/AdbClientFactory";
 import type { AdbClientFactory } from "../../utils/android-cmdline-tools/AdbClientFactory";
 import { SimCtlClient } from "../../utils/ios-cmdline-tools/SimCtlClient";
@@ -103,7 +104,7 @@ async function waitForExit(
 
   let timeoutId: NodeJS.Timeout | undefined;
   const timeoutPromise = new Promise<void>(resolve => {
-    timeoutId = setTimeout(() => {
+    timeoutId = defaultTimer.setTimeout(() => {
       if (process.exitCode === null) {
         process.kill("SIGKILL");
       }
@@ -169,7 +170,7 @@ export class PlatformVideoCaptureBackend implements VideoCaptureBackend {
       const gracefulExitTimeout = 10000;
       let timeoutId: NodeJS.Timeout | undefined;
       const timeoutPromise = new Promise<void>(resolve => {
-        timeoutId = setTimeout(() => {
+        timeoutId = defaultTimer.setTimeout(() => {
           if (backendHandle.process.exitCode === null) {
             logger.warn(`[VideoCapture] screenrecord did not exit gracefully, sending SIGKILL`);
             backendHandle.process.kill("SIGKILL");
@@ -189,7 +190,7 @@ export class PlatformVideoCaptureBackend implements VideoCaptureBackend {
       // Give screenrecord extra time to finalize the file on device
       // Even though the process has exited, file writes may still be in progress
       logger.info(`[VideoCapture] Waiting 1 second for file to finalize on device`);
-      await new Promise(resolve => setTimeout(resolve, 1000));
+      await defaultTimer.sleep(1000);
     } else {
       await waitForExit(backendHandle.process, backendHandle.exitPromise);
       logger.info(

--- a/src/server/CriticalSectionCoordinator.ts
+++ b/src/server/CriticalSectionCoordinator.ts
@@ -1,5 +1,6 @@
 import { Mutex } from "async-mutex";
 import { logger } from "../utils/logger";
+import { defaultTimer } from "../utils/SystemTimer";
 
 /**
  * Coordinates critical sections across multiple devices using global locks.
@@ -165,7 +166,7 @@ export class CriticalSectionCoordinator {
       this.barrierResolvers.set(lock, resolvers);
 
       // Set timeout
-      const timer = setTimeout(() => {
+      const timer = defaultTimer.setTimeout(() => {
         // Remove this resolver
         const currentResolvers = this.barrierResolvers.get(lock) || [];
         const index = currentResolvers.indexOf(resolve);
@@ -210,7 +211,7 @@ export class CriticalSectionCoordinator {
     }
 
     // Schedule new cleanup
-    const timer = setTimeout(() => {
+    const timer = defaultTimer.setTimeout(() => {
       logger.debug(`Cleaning up lock resources for "${lock}"`);
       this.locks.delete(lock);
       this.barrierCounts.delete(lock);

--- a/src/server/navigationResources.ts
+++ b/src/server/navigationResources.ts
@@ -10,6 +10,7 @@ import {
   NavigationGraphHistoryProvider
 } from "../utils/interfaces/NavigationGraph";
 import { logger } from "../utils/logger";
+import { defaultTimer } from "../utils/SystemTimer";
 
 export const NAVIGATION_RESOURCE_URIS = {
   GRAPH: "automobile:navigation/graph",
@@ -44,7 +45,7 @@ function scheduleNavigationGraphUpdate(): void {
     return;
   }
 
-  updateTimeout = setTimeout(() => {
+  updateTimeout = defaultTimer.setTimeout(() => {
     updateTimeout = null;
     void ResourceRegistry.notifyResourcesUpdated([
       NAVIGATION_RESOURCE_URIS.GRAPH,

--- a/src/utils/XCTestServiceManager.ts
+++ b/src/utils/XCTestServiceManager.ts
@@ -687,7 +687,7 @@ export class IOSXCTestServiceManager implements XCTestServiceManager {
     this.stopProcessMonitoring();
 
     // Check every 30 seconds
-    this.processMonitorInterval = setInterval(async () => {
+    this.processMonitorInterval = defaultTimer.setInterval(async () => {
       try {
         const isHealthy = await this.checkHealthEndpoint();
         this.lastHealthCheckSuccess = isHealthy;

--- a/src/utils/android-cmdline-tools/AdbClient.ts
+++ b/src/utils/android-cmdline-tools/AdbClient.ts
@@ -7,6 +7,7 @@ import { AdbExecutor } from "./interfaces/AdbExecutor";
 import { getAbortSignal } from "../AbortContext";
 import { OPERATION_CANCELLED_MESSAGE } from "../constants";
 import { RetryExecutor, defaultRetryExecutor } from "../retry/RetryExecutor";
+import { defaultTimer } from "../SystemTimer";
 
 type ExecFileAsync = (file: string, args: string[], maxBuffer?: number) => Promise<ExecResult>;
 
@@ -497,7 +498,7 @@ export class AdbClient implements AdbExecutor {
 
       let timeoutId: NodeJS.Timeout | undefined;
       if (timeoutMs) {
-        timeoutId = setTimeout(() => {
+        timeoutId = defaultTimer.setTimeout(() => {
           if (settled) {
             return;
           }

--- a/src/utils/android-cmdline-tools/AndroidEmulatorClient.ts
+++ b/src/utils/android-cmdline-tools/AndroidEmulatorClient.ts
@@ -384,9 +384,9 @@ export class AndroidEmulatorClient implements AndroidEmulator {
       let timeoutId: NodeJS.Timeout;
 
       const timeoutPromise = new Promise<ExecResult>((_, reject) => {
-        timeoutId = setTimeout(() =>
+        timeoutId = defaultTimer.setTimeout(() =>
           reject(new ActionableError(`Command timed out after ${timeoutMs}ms: ${fullCommand}`)),
-                               timeoutMs
+                                            timeoutMs
         );
       });
 
@@ -743,7 +743,7 @@ export class AndroidEmulatorClient implements AndroidEmulator {
       };
 
       // Set a timeout for startup validation (5 seconds should be enough to detect PANIC)
-      const startupTimeout = setTimeout(() => {
+      const startupTimeout = defaultTimer.setTimeout(() => {
         if (!startupValidationComplete) {
           startupValidationComplete = true;
           // If no PANIC detected and no clear success indicators, assume success

--- a/src/utils/android-cmdline-tools/avdmanager.ts
+++ b/src/utils/android-cmdline-tools/avdmanager.ts
@@ -3,6 +3,7 @@ import { existsSync } from "fs";
 import { join, resolve } from "path";
 import { ActionableError } from "../../models";
 import { logger } from "../logger";
+import { defaultTimer } from "../SystemTimer";
 import {
   detectAndroidCommandLineTools,
   getAndroidHomeWithSystemImages,
@@ -308,7 +309,7 @@ async function spawnCommand(command: string, args: string[], options: {
 
     // Set up timeout if specified
     if (options.timeout) {
-      timeoutId = setTimeout(() => {
+      timeoutId = defaultTimer.setTimeout(() => {
         child.kill("SIGTERM");
         reject(new Error(`Command timed out after ${options.timeout}ms: ${command} ${args.join(" ")}`));
       }, options.timeout);

--- a/src/utils/appearance/AppearanceSyncScheduler.ts
+++ b/src/utils/appearance/AppearanceSyncScheduler.ts
@@ -4,20 +4,26 @@ import { DeviceSessionManager } from "../DeviceSessionManager";
 import { applyAppearanceToDevice } from "../deviceAppearance";
 import { logger } from "../logger";
 import { getAppearanceConfig, resolveAppearanceMode } from "../../server/appearanceManager";
+import { Timer, defaultTimer } from "../SystemTimer";
 
 const DEFAULT_SYNC_INTERVAL_MS = 10000;
 
 class AppearanceSyncScheduler {
-  private timer: NodeJS.Timeout | null = null;
+  private intervalHandle: NodeJS.Timeout | null = null;
   private lastAppliedModes = new Map<string, AppearanceMode>();
   private pending: Promise<void> | null = null;
+  private readonly timer: Timer;
+
+  constructor(timer: Timer = defaultTimer) {
+    this.timer = timer;
+  }
 
   start(): void {
-    if (this.timer) {
+    if (this.intervalHandle) {
       return;
     }
 
-    this.timer = setInterval(() => {
+    this.intervalHandle = this.timer.setInterval(() => {
       void this.trigger();
     }, DEFAULT_SYNC_INTERVAL_MS);
 
@@ -25,9 +31,9 @@ class AppearanceSyncScheduler {
   }
 
   stop(): void {
-    if (this.timer) {
-      clearInterval(this.timer);
-      this.timer = null;
+    if (this.intervalHandle) {
+      this.timer.clearInterval(this.intervalHandle);
+      this.intervalHandle = null;
     }
     this.pending = null;
     this.lastAppliedModes.clear();

--- a/src/utils/hostControlClient.ts
+++ b/src/utils/hostControlClient.ts
@@ -8,6 +8,7 @@
 import { createConnection } from "node:net";
 import { logger } from "./logger";
 import { createExecResult } from "./execResult";
+import { defaultTimer } from "./SystemTimer";
 
 // Configuration from environment
 const HOST_CONTROL_HOST = process.env.AUTOMOBILE_HOST_CONTROL_HOST || "host.docker.internal";
@@ -121,7 +122,7 @@ async function sendCommand<T>(method: string, params?: Record<string, unknown>):
       }
     };
 
-    const timeout = setTimeout(() => {
+    const timeout = defaultTimer.setTimeout(() => {
       cleanup();
       resolve({ success: false, error: "Command timed out" });
     }, COMMAND_TIMEOUT_MS);

--- a/src/utils/hostEmulatorAutoConnect.ts
+++ b/src/utils/hostEmulatorAutoConnect.ts
@@ -16,6 +16,7 @@ import { execFile } from "child_process";
 import { promisify } from "util";
 import { logger } from "./logger";
 import { isRunningInDocker } from "./dockerEnv";
+import { defaultTimer } from "./SystemTimer";
 
 const execFileAsync = promisify(execFile);
 
@@ -77,7 +78,7 @@ async function execAdb(args: string[], timeoutMs: number = CONNECT_TIMEOUT_MS): 
     const result = await Promise.race([
       execFileAsync(adb, fullArgs),
       new Promise<never>((_, reject) =>
-        setTimeout(() => reject(new Error(`ADB command timed out after ${timeoutMs}ms`)), timeoutMs)
+        defaultTimer.setTimeout(() => reject(new Error(`ADB command timed out after ${timeoutMs}ms`)), timeoutMs)
       )
     ]);
 
@@ -203,7 +204,7 @@ async function scanAndConnect(): Promise<void> {
     // Wait for all connection attempts with a global timeout
     await Promise.race([
       Promise.allSettled(connectPromises),
-      new Promise<void>(resolve => setTimeout(resolve, 30000)) // 30s max scan time
+      new Promise<void>(resolve => defaultTimer.setTimeout(resolve, 30000)) // 30s max scan time
     ]);
 
   } catch (error) {
@@ -259,7 +260,7 @@ export async function startHostEmulatorAutoConnect(): Promise<void> {
   await scanAndConnect();
 
   // Start periodic scanning
-  scanInterval = setInterval(() => {
+  scanInterval = defaultTimer.setInterval(() => {
     scanAndConnect().catch(error => {
       logger.debug(`Periodic scan failed: ${error}`);
     });

--- a/src/utils/ios-cmdline-tools/SimCtlClient.ts
+++ b/src/utils/ios-cmdline-tools/SimCtlClient.ts
@@ -5,6 +5,7 @@ import { createExecResult } from "../execResult";
 import { isRunningInDocker } from "../dockerEnv";
 import { isHostControlAvailable, runSimctlExec, shouldUseHostControl } from "../hostControlClient";
 import { ExecResult, ActionableError, DeviceInfo, BootedDevice, ScreenSize } from "../../models";
+import { defaultTimer } from "../SystemTimer";
 
 export interface AppleDevice {
   udid: string;
@@ -388,7 +389,7 @@ export class SimCtlClient implements SimCtl {
       let timeoutId: NodeJS.Timeout;
 
       const timeoutPromise = new Promise<ExecResult>((_, reject) => {
-        timeoutId = setTimeout(
+        timeoutId = defaultTimer.setTimeout(
           () => reject(new Error(`Command timed out after ${timeoutMs}ms: ${fullCommand}`)),
           timeoutMs
         );
@@ -647,7 +648,7 @@ export class SimCtlClient implements SimCtl {
     await this.executeCommand(`boot ${udid}`);
 
     // Wait a moment for the simulator to register as booted
-    await new Promise(resolve => setTimeout(resolve, 1000));
+    await defaultTimer.sleep(1000);
 
     const bootedSimulators = await this.getBootedSimulators();
     const bootedSimulator = bootedSimulators.find(device => device.deviceId === udid);

--- a/src/utils/ios-cmdline-tools/XcodebuildClient.ts
+++ b/src/utils/ios-cmdline-tools/XcodebuildClient.ts
@@ -5,6 +5,7 @@ import { logger } from "../logger";
 import { createExecResult } from "../execResult";
 import { isRunningInDocker } from "../dockerEnv";
 import { isHostControlAvailable, runXcodebuildExec, shouldUseHostControl } from "../hostControlClient";
+import { defaultTimer } from "../SystemTimer";
 
 export interface XcodebuildCommandOptions {
   timeoutMs?: number;
@@ -93,7 +94,7 @@ export class XcodebuildClient implements Xcodebuild {
     if (timeoutMs) {
       let timeoutId: NodeJS.Timeout;
       const timeoutPromise = new Promise<ExecResult>((_, reject) => {
-        timeoutId = setTimeout(
+        timeoutId = defaultTimer.setTimeout(
           () => reject(new Error(`Command timed out after ${timeoutMs}ms: ${fullCommand}`)),
           timeoutMs
         );

--- a/src/utils/simulator.ts
+++ b/src/utils/simulator.ts
@@ -2,6 +2,7 @@ import { exec, spawn } from "child_process";
 import { promisify } from "util";
 import { logger } from "./logger";
 import { ExecResult } from "../models";
+import { defaultTimer } from "./SystemTimer";
 
 /**
  * Interface for iOS simulator utilities
@@ -330,7 +331,7 @@ export class SimCtlSimulatorManager implements AppleSimulatorManager {
         }
 
         // Wait before checking again
-        await new Promise(resolve => setTimeout(resolve, 2000));
+        await defaultTimer.sleep(2000);
       } catch (error) {
         logger.warn(`Error checking simulator boot status: ${error}`);
       }

--- a/test/fakes/FakeAccessibilityService.ts
+++ b/test/fakes/FakeAccessibilityService.ts
@@ -14,6 +14,7 @@ import {
 import { HighlightOperationResult, HighlightShape, ViewHierarchyResult } from "../../src/models";
 import { ViewHierarchyQueryOptions } from "../../src/models/ViewHierarchyQueryOptions";
 import { PerformanceTracker } from "../../src/utils/PerformanceTracker";
+import { defaultTimer } from "../../src/utils/SystemTimer";
 
 /**
  * Fake implementation of AccessibilityService for testing
@@ -270,7 +271,7 @@ export class FakeAccessibilityService implements AccessibilityService {
   private async applyDelay(operation: string): Promise<void> {
     const delay = this.operationDelays.get(operation);
     if (delay && delay > 0) {
-      await new Promise(resolve => setTimeout(resolve, delay));
+      await defaultTimer.sleep(delay);
     }
   }
 

--- a/test/fakes/FakeChildProcess.ts
+++ b/test/fakes/FakeChildProcess.ts
@@ -1,6 +1,7 @@
 import { EventEmitter } from "node:events";
 import { Readable, Writable } from "node:stream";
 import type { ChildProcessWithoutNullStreams } from "node:child_process";
+import { defaultTimer } from "../../src/utils/SystemTimer";
 
 /**
  * Fake ChildProcess for testing without spawning real processes
@@ -82,7 +83,7 @@ export class FakeChildProcess extends EventEmitter implements Partial<ChildProce
    * Simulate the spawn lifecycle
    */
   simulateSpawn(): void {
-    setTimeout(() => {
+    defaultTimer.setTimeout(() => {
       if (this.shouldError) {
         this.emit("error", new Error(this.errorMessage));
         return;
@@ -104,7 +105,7 @@ export class FakeChildProcess extends EventEmitter implements Partial<ChildProce
    * Simulate process exit
    */
   simulateExit(code: number = 0, signal: NodeJS.Signals | null = null): void {
-    setTimeout(() => {
+    defaultTimer.setTimeout(() => {
       this.exitCode = code;
       this.signalCode = signal;
       this.stdout.push(null); // End stdout stream

--- a/test/fakes/FakeScreenTransitionWaiter.ts
+++ b/test/fakes/FakeScreenTransitionWaiter.ts
@@ -1,4 +1,5 @@
 import { ScreenTransitionWaiter } from "../../src/features/navigation/interfaces/ScreenTransitionWaiter";
+import { defaultTimer } from "../../src/utils/SystemTimer";
 
 /**
  * Fake implementation of ScreenTransitionWaiter for testing.
@@ -103,7 +104,7 @@ export class FakeScreenTransitionWaiter implements ScreenTransitionWaiter {
 
     // Simulate delay if configured
     if (this.waitDelay > 0) {
-      await new Promise(resolve => setTimeout(resolve, this.waitDelay));
+      await defaultTimer.sleep(this.waitDelay);
     }
 
     // Return configured result for this screen, or default

--- a/test/fakes/FakeWriteStream.ts
+++ b/test/fakes/FakeWriteStream.ts
@@ -1,5 +1,6 @@
 import { EventEmitter } from "node:events";
 import type { WriteStream } from "node:fs";
+import { defaultTimer } from "../../src/utils/SystemTimer";
 
 /**
  * Fake WriteStream for testing file output without real filesystem I/O
@@ -160,7 +161,7 @@ export class FakeWriteStream extends EventEmitter implements Partial<WriteStream
       return;
     }
 
-    setTimeout(() => {
+    defaultTimer.setTimeout(() => {
       this.closed = true;
       this.emit("close");
       if (callback) {

--- a/test/fakes/FakeXCTestService.ts
+++ b/test/fakes/FakeXCTestService.ts
@@ -17,6 +17,7 @@ import {
 import { ViewHierarchyResult } from "../../src/models";
 import { ViewHierarchyQueryOptions } from "../../src/models/ViewHierarchyQueryOptions";
 import { PerformanceTracker } from "../../src/utils/PerformanceTracker";
+import { defaultTimer } from "../../src/utils/SystemTimer";
 
 /**
  * Fake implementation of XCTestService for testing
@@ -300,7 +301,7 @@ export class FakeXCTestService implements XCTestService {
   private async applyDelay(operation: string): Promise<void> {
     const delay = this.operationDelays.get(operation);
     if (delay && delay > 0) {
-      await new Promise(resolve => setTimeout(resolve, delay));
+      await defaultTimer.sleep(delay);
     }
   }
 

--- a/test/features/observe/ScreenshotBackoffScheduler.test.ts
+++ b/test/features/observe/ScreenshotBackoffScheduler.test.ts
@@ -6,6 +6,7 @@ import {
   computeChecksum,
 } from "../../../src/features/observe/ScreenshotBackoffScheduler";
 import { FakeTimer } from "../../fakes/FakeTimer";
+import { defaultTimer } from "../../../src/utils/SystemTimer";
 
 describe("computeChecksum", () => {
   it("returns consistent checksum for same data", () => {
@@ -344,7 +345,7 @@ describe("DefaultScreenshotBackoffScheduler", () => {
         captureCount++;
         // Simulate slow capture that takes 150ms
         if (captureDelay > 0) {
-          await new Promise(resolve => setTimeout(resolve, captureDelay));
+          await defaultTimer.sleep(captureDelay);
         }
         return { success: true, data: `screenshot-${captureCount}` };
       };

--- a/test/server/CriticalSectionCoordinator.test.ts
+++ b/test/server/CriticalSectionCoordinator.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test, beforeEach, afterEach } from "bun:test";
 import { CriticalSectionCoordinator } from "../../src/server/CriticalSectionCoordinator";
 import { FakeTimer } from "../fakes/FakeTimer";
+import { defaultTimer } from "../../src/utils/SystemTimer";
 
 describe("CriticalSectionCoordinator", () => {
   let coordinator: CriticalSectionCoordinator;
@@ -36,7 +37,7 @@ describe("CriticalSectionCoordinator", () => {
   });
 
   const wait = async (ms: number): Promise<void> => {
-    const promise = new Promise<void>(resolve => setTimeout(resolve, ms));
+    const promise = defaultTimer.sleep(ms);
     fakeTimer.advanceTime(ms);
     await promise;
   };

--- a/test/server/videoRecordingManager.test.ts
+++ b/test/server/videoRecordingManager.test.ts
@@ -17,6 +17,7 @@ import {
   startVideoRecording,
   stopVideoRecording,
 } from "../../src/server/videoRecordingManager";
+import { defaultTimer } from "../../src/utils/SystemTimer";
 
 describe("videoRecordingManager", () => {
   let fakeTimer: FakeTimer;
@@ -74,7 +75,7 @@ describe("videoRecordingManager", () => {
       }
       // Use setTimeout instead of setImmediate for more reliable cross-platform timing
       // The auto-stop callback fires async work that needs multiple event loop cycles
-      await new Promise(resolve => setTimeout(resolve, 1));
+      await defaultTimer.sleep(1);
     }
     throw new Error(`Timed out waiting for ${expected} recordings`);
   };


### PR DESCRIPTION
## Summary
- Replace all raw `setTimeout`/`setInterval` calls with Timer interface methods (`defaultTimer.setTimeout`, `defaultTimer.sleep`, etc.) for improved testability with `FakeTimer`
- Add ESLint `no-restricted-syntax` rules to prevent future raw timer usage (with exclusion for `SystemTimer.ts`)
- Migrate 40+ files across utility, server, daemon, feature, database layers, and test fakes

## Test Plan
- [x] `bun run build` passes
- [x] `bun run lint` passes (no raw timer violations)
- [x] `bun test --bail` passes (1962 tests, 0 failures)

Closes #1114

🤖 Generated with [Claude Code](https://claude.com/claude-code)