### PR TITLE
refactor: replace getInstance() singletons with constructor injection

### DIFF
--- a/src/features/failures/FailureRecorder.ts
+++ b/src/features/failures/FailureRecorder.ts
@@ -117,6 +117,20 @@ export class FailureRecorder implements FailureRecorderService {
   }
 
   /**
+   * Reset the singleton instance (for testing).
+   */
+  static resetInstance(): void {
+    FailureRecorder.instance = null;
+  }
+
+  /**
+   * Create a new instance for testing with injected dependencies.
+   */
+  static createForTesting(repository?: FailureAnalyticsRepository): FailureRecorder {
+    return new FailureRecorder(repository);
+  }
+
+  /**
    * Record a tool call failure
    */
   async recordToolFailure(input: RecordToolFailureInput): Promise<string> {
@@ -382,5 +396,11 @@ export class FailureRecorder implements FailureRecorderService {
   }
 }
 
-// Export singleton instance getter
-export const getFailureRecorder = (): FailureRecorder => FailureRecorder.getInstance();
+/**
+ * Default singleton instance of FailureRecorder.
+ * Use this for production code. For testing, use FailureRecorder.createForTesting().
+ */
+export const defaultFailureRecorder: FailureRecorderService = FailureRecorder.getInstance();
+
+// Export singleton instance getter (uses defaultFailureRecorder)
+export const getFailureRecorder = (): FailureRecorderService => defaultFailureRecorder;

--- a/src/features/navigation/Explore.ts
+++ b/src/features/navigation/Explore.ts
@@ -3,7 +3,7 @@ import { BaseVisualChange, ProgressCallback } from "../action/BaseVisualChange";
 import { AdbClient } from "../../utils/android-cmdline-tools/AdbClient";
 import { createGlobalPerformanceTracker, PerformanceTracker } from "../../utils/PerformanceTracker";
 import { logger } from "../../utils/logger";
-import { NavigationGraphManager, type NavigationEdge } from "./NavigationGraphManager";
+import { defaultNavigationGraphManager, type NavigationEdge, type NavigationGraphService } from "./NavigationGraphManager";
 import { ExportedGraph } from "../../utils/interfaces/NavigationGraph";
 import { TapOnElement } from "../action/TapOnElement";
 import { SwipeOnElement } from "../action/SwipeOnElement";
@@ -71,7 +71,7 @@ import {
  * avoiding redundant interactions, and efficiently covering unexplored screens.
  */
 export class Explore extends BaseVisualChange {
-  private navigationManager: NavigationGraphManager;
+  private navigationManager: NavigationGraphService;
   private exploredElements: Map<string, TrackedElement>;
   private interactionCount: number = 0;
   private explorationPath: string[] = [];
@@ -100,10 +100,11 @@ export class Explore extends BaseVisualChange {
   constructor(
     device: BootedDevice,
     adb: AdbClient | null = null,
-    timer: Timer = defaultTimer
+    timer: Timer = defaultTimer,
+    navigationManager?: NavigationGraphService
   ) {
     super(device, adb, timer);
-    this.navigationManager = NavigationGraphManager.getInstance();
+    this.navigationManager = navigationManager ?? defaultNavigationGraphManager;
     this.exploredElements = new Map();
     this.elementParser = new ElementParser();
   }

--- a/src/features/navigation/NavigateTo.ts
+++ b/src/features/navigation/NavigateTo.ts
@@ -5,8 +5,9 @@ import { logger } from "../../utils/logger";
 import { createGlobalPerformanceTracker } from "../../utils/PerformanceTracker";
 import { ToolRegistry } from "../../server/toolRegistry";
 import {
-  NavigationGraphManager,
-  ToolCallInteraction
+  defaultNavigationGraphManager,
+  ToolCallInteraction,
+  type NavigationGraphService
 } from "./NavigationGraphManager";
 import { ProgressCallback } from "../../server/toolRegistry";
 import { SmartNavigationHelper } from "./SmartNavigationHelper";
@@ -32,7 +33,7 @@ export interface NavigateToOptions {
 export class NavigateTo {
   private device: BootedDevice;
   private adb: AdbExecutor;
-  private navigationManager: NavigationGraphManager;
+  private navigationManager: NavigationGraphService;
   private uiStateSetup: UIStateSetup;
   private screenWaiter: ScreenTransitionWaiter;
 
@@ -44,11 +45,12 @@ export class NavigateTo {
     device: BootedDevice,
     adbFactory: AdbClientFactory = defaultAdbClientFactory,
     uiStateSetup: UIStateSetup | null = null,
-    screenWaiter: ScreenTransitionWaiter | null = null
+    screenWaiter: ScreenTransitionWaiter | null = null,
+    navigationManager?: NavigationGraphService
   ) {
     this.device = device;
     this.adb = adbFactory.create(device);
-    this.navigationManager = NavigationGraphManager.getInstance();
+    this.navigationManager = navigationManager ?? defaultNavigationGraphManager;
 
     // Use injected dependencies or create defaults
     this.uiStateSetup = uiStateSetup || new DefaultUIStateSetup(this.device, this.adb);

--- a/src/features/navigation/NavigationGraphManager.ts
+++ b/src/features/navigation/NavigationGraphManager.ts
@@ -56,6 +56,64 @@ export type {
   UIState,
 };
 
+/**
+ * Interface for navigation graph management operations.
+ * Provides methods for tracking screen visits, recording navigation events,
+ * and querying navigation paths.
+ */
+export interface NavigationGraphService extends NavigationGraph, NavigationGraphSummaryProvider, NavigationGraphHistoryProvider, NavigationGraphNodeResourceProvider {
+  // App management
+  setCurrentApp(appId: string): Promise<void>;
+  getCurrentAppId(): string | null;
+
+  // Screen tracking
+  getCurrentScreen(): string | null;
+  recordBackStack(backStack: BackStackInfo): Promise<void>;
+
+  // Navigation events
+  recordNavigationEvent(event: NavigationEvent): Promise<void>;
+  recordHierarchyNavigation(event: HierarchyNavigationEvent): Promise<void>;
+
+  // Tool call correlation
+  recordToolCall(toolName: string, args: Record<string, any>, uiState?: UIState): void;
+  updateScrollPosition(scrollPosition: ScrollPosition): void;
+
+  // Pathfinding
+  findPath(targetScreen: string): Promise<PathResult>;
+
+  // Graph queries
+  getKnownScreens(): Promise<string[]>;
+  getNode(screenName: string): Promise<NavigationNode | undefined>;
+  getNodeResourceById(nodeId: number): Promise<NavigationGraphNodeResource | null>;
+  getNodeResourceByScreen(screenName: string): Promise<NavigationGraphNodeResource | null>;
+  getEdgesFrom(screenName: string): Promise<NavigationEdge[]>;
+  getEdgesTo(screenName: string): Promise<NavigationEdge[]>;
+  getStats(): Promise<NavigationGraphStats>;
+
+  // Graph operations
+  clearCurrentGraph(): Promise<void>;
+  clearAllGraphs(): Promise<void>;
+  exportGraph(): Promise<ExportedGraph>;
+  exportGraphSummary(): Promise<NavigationGraphSummary>;
+  exportGraphSummaryForApp(appId: string | null): Promise<NavigationGraphSummary>;
+  exportGraphHistory(options?: { cursor?: string; limit?: number }): Promise<NavigationGraphHistoryPage>;
+
+  // Screenshot management
+  updateNodeScreenshot(appId: string, screenName: string, screenshotPath: string | null): Promise<void>;
+
+  // Suggestions
+  getSuggestions(): Promise<NavigationSuggestionInfo[]>;
+  promoteSuggestion(suggestionId: number, screenName: string): Promise<void>;
+
+  // Test coverage
+  startTestSession(sessionUuid: string): Promise<void>;
+  endTestSession(): Promise<void>;
+  getActiveTestSession(): TestCoverageSession | null;
+
+  // Listeners
+  setGraphUpdateListener(listener: (() => void | Promise<void>) | null): void;
+}
+
 type HistoryCursor = {
   timestamp: number;
   id: number;
@@ -65,7 +123,7 @@ type HistoryCursor = {
  * Manages the navigation graph with SQLite persistence.
  * Tracks screen visits and correlates navigation events with tool calls.
  */
-export class NavigationGraphManager implements NavigationGraph, NavigationGraphSummaryProvider, NavigationGraphHistoryProvider, NavigationGraphNodeResourceProvider {
+export class NavigationGraphManager implements NavigationGraphService {
   private static instance: NavigationGraphManager | null = null;
 
   private repository: NavigationRepository;
@@ -98,9 +156,12 @@ export class NavigationGraphManager implements NavigationGraph, NavigationGraphS
     startTime: number;
   } | null = null;
 
-  private constructor() {
-    this.repository = new NavigationRepository();
-    this.testCoverageRepository = new TestCoverageRepository();
+  constructor(
+    repository?: NavigationRepository,
+    testCoverageRepository?: TestCoverageRepository
+  ) {
+    this.repository = repository ?? new NavigationRepository();
+    this.testCoverageRepository = testCoverageRepository ?? new TestCoverageRepository();
   }
 
   /**
@@ -118,6 +179,16 @@ export class NavigationGraphManager implements NavigationGraph, NavigationGraphS
    */
   public static resetInstance(): void {
     NavigationGraphManager.instance = null;
+  }
+
+  /**
+   * Create a new instance for testing with injected dependencies.
+   */
+  public static createForTesting(
+    repository?: NavigationRepository,
+    testCoverageRepository?: TestCoverageRepository
+  ): NavigationGraphManager {
+    return new NavigationGraphManager(repository, testCoverageRepository);
   }
 
   /**
@@ -1286,3 +1357,9 @@ export class NavigationGraphManager implements NavigationGraph, NavigationGraphS
     return Math.min(normalized, this.HISTORY_PAGE_MAX);
   }
 }
+
+/**
+ * Default singleton instance of NavigationGraphManager.
+ * Use this for production code. For testing, use NavigationGraphManager.createForTesting().
+ */
+export const defaultNavigationGraphManager: NavigationGraphService = NavigationGraphManager.getInstance();

--- a/src/utils/AccessibilityFocusTracker.ts
+++ b/src/utils/AccessibilityFocusTracker.ts
@@ -4,6 +4,53 @@ import { PerformanceTracker, NoOpPerformanceTracker } from "./PerformanceTracker
 import { logger } from "./logger";
 
 /**
+ * Interface for accessibility focus tracking operations.
+ * Provides methods for tracking TalkBack cursor position and navigating the accessibility tree.
+ */
+export interface AccessibilityFocusService {
+  /**
+   * Get the current accessibility focus element (TalkBack cursor position).
+   */
+  getCurrentFocus(
+    deviceId: string,
+    useCache?: boolean,
+    perf?: PerformanceTracker
+  ): Promise<Element | null>;
+
+  /**
+   * Build accessibility tree in TalkBack traversal order.
+   */
+  buildTraversalOrder(
+    deviceId: string,
+    useCache?: boolean,
+    perf?: PerformanceTracker
+  ): Promise<Element[]>;
+
+  /**
+   * Find the index of an element in the traversal order.
+   */
+  findElementIndex(
+    target: ElementSelector,
+    orderedElements: Element[]
+  ): Promise<number | null>;
+
+  /**
+   * Invalidate cached focus state for a device.
+   */
+  invalidateFocus(deviceId: string): void;
+
+  /**
+   * Invalidate cached traversal order for a device.
+   */
+  invalidateTraversalOrder(deviceId: string): void;
+
+  /**
+   * Invalidate all caches for a device.
+   */
+  invalidateAll(deviceId: string): void;
+}
+
+/**
  * Cached focus state for a device
  */
 interface FocusState {
@@ -74,7 +121,7 @@ export interface ElementSelector {
  * - Caching focus state to reduce redundant queries
  * - Finding element positions in traversal order
  */
-export class AccessibilityFocusTracker {
+export class AccessibilityFocusTracker implements AccessibilityFocusService {
   /** Cache of focus states by device ID */
   private focusCache: Map<string, FocusState> = new Map();
 
@@ -87,8 +134,7 @@ export class AccessibilityFocusTracker {
   /** Singleton instance */
   private static instance: AccessibilityFocusTracker | null = null;
 
-  /** Private constructor for singleton pattern */
-  private constructor() {}
+  constructor() {}
 
   /**
    * Get the singleton instance
@@ -98,6 +144,20 @@ export class AccessibilityFocusTracker {
       AccessibilityFocusTracker.instance = new AccessibilityFocusTracker();
     }
     return AccessibilityFocusTracker.instance;
+  }
+
+  /**
+   * Reset the singleton instance (for testing).
+   */
+  static resetInstance(): void {
+    AccessibilityFocusTracker.instance = null;
+  }
+
+  /**
+   * Create a new instance for testing.
+   */
+  static createForTesting(): AccessibilityFocusTracker {
+    return new AccessibilityFocusTracker();
   }
 
   /**
@@ -354,3 +414,9 @@ export class AccessibilityFocusTracker {
     );
   }
 }
+
+/**
+ * Default singleton instance of AccessibilityFocusTracker.
+ * Use this for production code. For testing, use AccessibilityFocusTracker.createForTesting().
+ */
+export const defaultAccessibilityFocusTracker: AccessibilityFocusService = AccessibilityFocusTracker.getInstance();

--- a/test/features/navigation/Explore.test.ts
+++ b/test/features/navigation/Explore.test.ts
@@ -1,6 +1,5 @@
-import { expect, describe, test, beforeEach, afterEach, spyOn } from "bun:test";
+import { expect, describe, test, beforeEach, afterEach } from "bun:test";
 import { Explore } from "../../../src/features/navigation/Explore";
-import { NavigationGraphManager } from "../../../src/features/navigation/NavigationGraphManager";
 import { BootedDevice, Element, ObserveResult } from "../../../src/models";
 import { AdbClient } from "../../../src/utils/android-cmdline-tools/AdbClient";
 import { FakeNavigationGraphManager } from "../../fakes/FakeNavigationGraphManager";
@@ -35,7 +34,6 @@ describe("Explore", () => {
   let mockObserveScreen: any;
   let fakeGraph: FakeNavigationGraphManager;
   let fakeTimer: FakeTimer;
-  let getInstanceSpy: ReturnType<typeof spyOn> | null = null;
   let elementParser: ElementParser;
 
   beforeEach(() => {
@@ -43,9 +41,6 @@ describe("Explore", () => {
     fakeTimer = new FakeTimer();
     fakeTimer.enableAutoAdvance();
     elementParser = new ElementParser();
-    getInstanceSpy = spyOn(NavigationGraphManager, "getInstance").mockReturnValue(
-      fakeGraph as unknown as NavigationGraphManager
-    );
 
     // Create fake device
     device = {
@@ -59,7 +54,7 @@ describe("Explore", () => {
       executeCommand: async (cmd: string) => {
         if (cmd.includes("KEYCODE_BACK")) {
           // Simulate navigation event when back is pressed
-          NavigationGraphManager.getInstance().recordNavigationEvent({
+          fakeGraph.recordNavigationEvent({
             destination: "PreviousScreen",
             source: "TEST",
             arguments: {},
@@ -84,7 +79,7 @@ describe("Explore", () => {
         observeCallCount++;
         // Alternate between screens to simulate navigation
         if (observeCallCount % 2 === 0) {
-          NavigationGraphManager.getInstance().recordNavigationEvent({
+          fakeGraph.recordNavigationEvent({
             destination: `Screen${observeCallCount}`,
             source: "TEST",
             arguments: {},
@@ -103,7 +98,7 @@ describe("Explore", () => {
   });
 
   afterEach(() => {
-    getInstanceSpy?.mockRestore();
+    // No cleanup needed since we're using injected fakes
   });
 
   function createMockViewHierarchyNode(overrides: any = {}): any {
@@ -311,7 +306,7 @@ describe("Explore", () => {
         }
       } as AdbClient;
 
-      explore = new Explore(device, adbWithTracking);
+      explore = new Explore(device, adbWithTracking, fakeTimer, fakeGraph);
       (explore as any).handleDeadEnd = async () => {
         backPresses.push("back");
       };
@@ -348,7 +343,7 @@ describe("Explore", () => {
         }
       } as AdbClient;
 
-      explore = new Explore(device, adbWithTracking);
+      explore = new Explore(device, adbWithTracking, fakeTimer, fakeGraph);
       (explore as any).handleDeadEnd = async () => {
         backPresses.push("back");
       };
@@ -395,10 +390,8 @@ describe("Explore", () => {
 
   describe("graph-based navigation (validate mode)", () => {
     test("should initialize graph traversal state in validate mode", async () => {
-      const navManager = NavigationGraphManager.getInstance();
-
       // Pre-populate the graph with some nodes and edges
-      navManager.recordNavigationEvent({
+      fakeGraph.recordNavigationEvent({
         destination: "Screen1",
         source: "TEST",
         arguments: {},
@@ -408,7 +401,7 @@ describe("Explore", () => {
         applicationId: "com.test.app"
       });
 
-      await navManager.recordToolCall(
+      fakeGraph.recordToolCall(
         "tapOn",
         { text: "Button1" },
         {
@@ -416,7 +409,7 @@ describe("Explore", () => {
         }
       );
 
-      navManager.recordNavigationEvent({
+      fakeGraph.recordNavigationEvent({
         destination: "Screen2",
         source: "TEST",
         arguments: {},
@@ -426,8 +419,8 @@ describe("Explore", () => {
         applicationId: "com.test.app"
       });
 
-      // Initialize traversal using the extracted function
-      const state = await initializeGraphTraversal(navManager);
+      // Initialize traversal using the extracted function with fakeGraph
+      const state = await initializeGraphTraversal(fakeGraph);
 
       expect(state).toBeDefined();
       expect(state.totalNodesInGraph).toBeGreaterThan(0);
@@ -437,7 +430,7 @@ describe("Explore", () => {
     });
 
     test("should select next edge to traverse", async () => {
-      const state = await initializeGraphTraversal(fakeGraph as unknown as NavigationGraphManager);
+      const state = await initializeGraphTraversal(fakeGraph);
 
       // If there are any pending edges, selectNextEdgeToTraverse should return one
       if (state.pendingEdges.length > 0) {
@@ -453,7 +446,7 @@ describe("Explore", () => {
     });
 
     test("should mark nodes as visited", async () => {
-      const state = await initializeGraphTraversal(fakeGraph as unknown as NavigationGraphManager);
+      const state = await initializeGraphTraversal(fakeGraph);
 
       expect(state.visitedNodes.size).toBe(0);
 
@@ -466,7 +459,7 @@ describe("Explore", () => {
     });
 
     test("should mark edges as traversed with validation results", async () => {
-      const state = await initializeGraphTraversal(fakeGraph as unknown as NavigationGraphManager);
+      const state = await initializeGraphTraversal(fakeGraph);
 
       expect(state.traversedEdges.size).toBe(0);
 
@@ -500,7 +493,7 @@ describe("Explore", () => {
     });
 
     test("should record failed edge validation", async () => {
-      const state = await initializeGraphTraversal(fakeGraph as unknown as NavigationGraphManager);
+      const state = await initializeGraphTraversal(fakeGraph);
 
       // Create a mock edge with interaction
       const mockEdge = {
@@ -600,10 +593,8 @@ describe("Explore", () => {
     });
 
     test("should include graph traversal metrics in result", async () => {
-      const navManager = NavigationGraphManager.getInstance();
-
       // Create a simple graph
-      navManager.recordNavigationEvent({
+      fakeGraph.recordNavigationEvent({
         destination: "Screen1",
         source: "TEST",
         arguments: {},
@@ -613,11 +604,12 @@ describe("Explore", () => {
         applicationId: "com.test.app"
       });
 
-      explore = new Explore(device, mockAdb, fakeTimer);
+      // Inject fakeGraph via constructor
+      explore = new Explore(device, mockAdb, fakeTimer, fakeGraph);
       (explore as any).observeScreen = mockObserveScreen;
 
       // Initialize traversal state on explore instance
-      (explore as any).graphTraversalState = await initializeGraphTraversal(navManager);
+      (explore as any).graphTraversalState = await initializeGraphTraversal(fakeGraph);
       const state = (explore as any).graphTraversalState;
 
       // Mark some edges as traversed
@@ -636,7 +628,7 @@ describe("Explore", () => {
       markNodeVisited(state, "Screen1");
       markNodeVisited(state, "Screen2");
 
-      const initialGraph = await navManager.exportGraph();
+      const initialGraph = await fakeGraph.exportGraph();
       const result = await (explore as any).generateReport(initialGraph, Date.now(), false);
 
       expect(result.graphTraversal).toBeDefined();

--- a/test/features/navigation/NavigateTo.test.ts
+++ b/test/features/navigation/NavigateTo.test.ts
@@ -1,6 +1,5 @@
-import { expect, describe, test, beforeEach, afterEach, spyOn } from "bun:test";
+import { expect, describe, test, beforeEach, afterEach } from "bun:test";
 import { NavigateTo } from "../../../src/features/navigation/NavigateTo";
-import { NavigationGraphManager } from "../../../src/features/navigation/NavigationGraphManager";
 import { ToolRegistry } from "../../../src/server/toolRegistry";
 import { BootedDevice } from "../../../src/models";
 import { z } from "zod";
@@ -12,7 +11,6 @@ describe("NavigateTo", () => {
   let device: BootedDevice;
   let toolCallLog: Array<{ toolName: string; args: Record<string, any> }>;
   let fakeGraph: FakeNavigationGraphManager;
-  let getInstanceSpy: ReturnType<typeof spyOn> | null = null;
   let fakeAdbFactory: FakeAdbClientFactory;
 
   // Map of text -> screen to simulate navigation when tools are called
@@ -20,9 +18,6 @@ describe("NavigateTo", () => {
 
   beforeEach(async () => {
     fakeGraph = new FakeNavigationGraphManager();
-    getInstanceSpy = spyOn(NavigationGraphManager, "getInstance").mockReturnValue(
-      fakeGraph as unknown as NavigationGraphManager
-    );
     ToolRegistry.clearTools();
 
     // Create fake device
@@ -55,7 +50,7 @@ describe("NavigateTo", () => {
         // Simulate navigation by recording a navigation event
         const targetScreen = navigationMap.get(args.text);
         if (targetScreen) {
-          await NavigationGraphManager.getInstance().recordNavigationEvent({
+          await fakeGraph.recordNavigationEvent({
             destination: targetScreen,
             source: "TEST",
             arguments: {},
@@ -70,18 +65,17 @@ describe("NavigateTo", () => {
     );
 
     // Set up navigation graph with test data
-    const manager = NavigationGraphManager.getInstance();
-    await manager.setCurrentApp("com.test.app");
+    await fakeGraph.setCurrentApp("com.test.app");
   });
 
   afterEach(() => {
-    getInstanceSpy?.mockRestore();
     ToolRegistry.clearTools();
   });
 
   describe("execute", () => {
     test("should return error when no current screen", async () => {
-      navigateTo = new NavigateTo(device, fakeAdbFactory);
+      // Inject fakeGraph via constructor
+      navigateTo = new NavigateTo(device, fakeAdbFactory, null, null, fakeGraph);
 
       const result = await navigateTo.execute({
         targetScreen: "TargetScreen",
@@ -94,8 +88,7 @@ describe("NavigateTo", () => {
     });
 
     test("should return success when already on target screen", async () => {
-      const manager = NavigationGraphManager.getInstance();
-      await manager.recordNavigationEvent({
+      await fakeGraph.recordNavigationEvent({
         destination: "HomeScreen",
         source: "TEST",
         arguments: {},
@@ -104,7 +97,8 @@ describe("NavigateTo", () => {
         sequenceNumber: 0
       });
 
-      navigateTo = new NavigateTo(device, fakeAdbFactory);
+      // Inject fakeGraph via constructor
+      navigateTo = new NavigateTo(device, fakeAdbFactory, null, null, fakeGraph);
 
       const result = await navigateTo.execute({
         targetScreen: "HomeScreen",
@@ -117,8 +111,7 @@ describe("NavigateTo", () => {
     });
 
     test("should return error when no path exists", async () => {
-      const manager = NavigationGraphManager.getInstance();
-      await manager.recordNavigationEvent({
+      await fakeGraph.recordNavigationEvent({
         destination: "HomeScreen",
         source: "TEST",
         arguments: {},
@@ -127,7 +120,8 @@ describe("NavigateTo", () => {
         sequenceNumber: 0
       });
 
-      navigateTo = new NavigateTo(device, fakeAdbFactory);
+      // Inject fakeGraph via constructor
+      navigateTo = new NavigateTo(device, fakeAdbFactory, null, null, fakeGraph);
 
       const result = await navigateTo.execute({
         targetScreen: "UnknownScreen",
@@ -141,17 +135,16 @@ describe("NavigateTo", () => {
     });
 
     test("should execute tool call when path exists", async () => {
-      const manager = NavigationGraphManager.getInstance();
       const now = Date.now();
 
       // Set up navigation map so fake tool triggers navigation
       navigationMap.set("Settings", "SettingsScreen");
 
       // Record tool call before navigation (to correlate)
-      manager.recordToolCall("tapOn", { text: "Settings", action: "tap", platform: "android" });
+      fakeGraph.recordToolCall("tapOn", { text: "Settings", action: "tap", platform: "android" });
 
       // Record navigation: Home -> Settings
-      await manager.recordNavigationEvent({
+      await fakeGraph.recordNavigationEvent({
         destination: "HomeScreen",
         source: "TEST",
         arguments: {},
@@ -159,7 +152,7 @@ describe("NavigateTo", () => {
         timestamp: now,
         sequenceNumber: 0
       });
-      await manager.recordNavigationEvent({
+      await fakeGraph.recordNavigationEvent({
         destination: "SettingsScreen",
         source: "TEST",
         arguments: {},
@@ -169,7 +162,7 @@ describe("NavigateTo", () => {
       });
 
       // Go back to Home to test navigation
-      await manager.recordNavigationEvent({
+      await fakeGraph.recordNavigationEvent({
         destination: "HomeScreen",
         source: "TEST",
         arguments: {},
@@ -178,7 +171,8 @@ describe("NavigateTo", () => {
         sequenceNumber: 2
       });
 
-      navigateTo = new NavigateTo(device, fakeAdbFactory);
+      // Inject fakeGraph via constructor
+      navigateTo = new NavigateTo(device, fakeAdbFactory, null, null, fakeGraph);
 
       await navigateTo.execute({
         targetScreen: "SettingsScreen",
@@ -192,14 +186,13 @@ describe("NavigateTo", () => {
     });
 
     test("should include path in successful navigation result", async () => {
-      const manager = NavigationGraphManager.getInstance();
       const now = Date.now();
 
       // Set up navigation map so fake tool triggers navigation
       navigationMap.set("Profile", "ProfileScreen");
 
-      manager.recordToolCall("tapOn", { text: "Profile", action: "tap", platform: "android" });
-      await manager.recordNavigationEvent({
+      fakeGraph.recordToolCall("tapOn", { text: "Profile", action: "tap", platform: "android" });
+      await fakeGraph.recordNavigationEvent({
         destination: "HomeScreen",
         source: "TEST",
         arguments: {},
@@ -207,7 +200,7 @@ describe("NavigateTo", () => {
         timestamp: now,
         sequenceNumber: 0
       });
-      await manager.recordNavigationEvent({
+      await fakeGraph.recordNavigationEvent({
         destination: "ProfileScreen",
         source: "TEST",
         arguments: {},
@@ -215,7 +208,7 @@ describe("NavigateTo", () => {
         timestamp: now + 100,
         sequenceNumber: 1
       });
-      await manager.recordNavigationEvent({
+      await fakeGraph.recordNavigationEvent({
         destination: "HomeScreen",
         source: "TEST",
         arguments: {},
@@ -224,7 +217,8 @@ describe("NavigateTo", () => {
         sequenceNumber: 2
       });
 
-      navigateTo = new NavigateTo(device, fakeAdbFactory);
+      // Inject fakeGraph via constructor
+      navigateTo = new NavigateTo(device, fakeAdbFactory, null, null, fakeGraph);
 
       const result = await navigateTo.execute({
         targetScreen: "ProfileScreen",
@@ -237,15 +231,14 @@ describe("NavigateTo", () => {
     });
 
     test("should report progress during navigation", async () => {
-      const manager = NavigationGraphManager.getInstance();
       const now = Date.now();
       const progressUpdates: Array<{ current: number; total: number; message: string }> = [];
 
       // Set up navigation map so fake tool triggers navigation
       navigationMap.set("Step1", "Screen2");
 
-      manager.recordToolCall("tapOn", { text: "Step1", action: "tap", platform: "android" });
-      await manager.recordNavigationEvent({
+      fakeGraph.recordToolCall("tapOn", { text: "Step1", action: "tap", platform: "android" });
+      await fakeGraph.recordNavigationEvent({
         destination: "Screen1",
         source: "TEST",
         arguments: {},
@@ -253,7 +246,7 @@ describe("NavigateTo", () => {
         timestamp: now,
         sequenceNumber: 0
       });
-      await manager.recordNavigationEvent({
+      await fakeGraph.recordNavigationEvent({
         destination: "Screen2",
         source: "TEST",
         arguments: {},
@@ -261,7 +254,7 @@ describe("NavigateTo", () => {
         timestamp: now + 100,
         sequenceNumber: 1
       });
-      await manager.recordNavigationEvent({
+      await fakeGraph.recordNavigationEvent({
         destination: "Screen1",
         source: "TEST",
         arguments: {},
@@ -270,7 +263,8 @@ describe("NavigateTo", () => {
         sequenceNumber: 2
       });
 
-      navigateTo = new NavigateTo(device, fakeAdbFactory);
+      // Inject fakeGraph via constructor
+      navigateTo = new NavigateTo(device, fakeAdbFactory, null, null, fakeGraph);
 
       await navigateTo.execute(
         { targetScreen: "Screen2", platform: "android" },
@@ -286,8 +280,7 @@ describe("NavigateTo", () => {
     });
 
     test("should return duration in result", async () => {
-      const manager = NavigationGraphManager.getInstance();
-      await manager.recordNavigationEvent({
+      await fakeGraph.recordNavigationEvent({
         destination: "HomeScreen",
         source: "TEST",
         arguments: {},
@@ -296,7 +289,8 @@ describe("NavigateTo", () => {
         sequenceNumber: 0
       });
 
-      navigateTo = new NavigateTo(device, fakeAdbFactory);
+      // Inject fakeGraph via constructor
+      navigateTo = new NavigateTo(device, fakeAdbFactory, null, null, fakeGraph);
 
       const result = await navigateTo.execute({
         targetScreen: "HomeScreen",
@@ -311,7 +305,6 @@ describe("NavigateTo", () => {
 
   describe("multi-hop navigation", () => {
     test("should find and execute multi-hop path", async () => {
-      const manager = NavigationGraphManager.getInstance();
       const now = Date.now();
 
       // Set up navigation map so fake tools trigger navigation
@@ -319,8 +312,8 @@ describe("NavigateTo", () => {
       navigationMap.set("Advanced", "AdvancedScreen");
 
       // Create path: Home -> Settings -> Advanced
-      manager.recordToolCall("tapOn", { text: "Settings", action: "tap", platform: "android" });
-      await manager.recordNavigationEvent({
+      fakeGraph.recordToolCall("tapOn", { text: "Settings", action: "tap", platform: "android" });
+      await fakeGraph.recordNavigationEvent({
         destination: "HomeScreen",
         source: "TEST",
         arguments: {},
@@ -328,7 +321,7 @@ describe("NavigateTo", () => {
         timestamp: now,
         sequenceNumber: 0
       });
-      await manager.recordNavigationEvent({
+      await fakeGraph.recordNavigationEvent({
         destination: "SettingsScreen",
         source: "TEST",
         arguments: {},
@@ -337,8 +330,8 @@ describe("NavigateTo", () => {
         sequenceNumber: 1
       });
 
-      manager.recordToolCall("tapOn", { text: "Advanced", action: "tap", platform: "android" });
-      await manager.recordNavigationEvent({
+      fakeGraph.recordToolCall("tapOn", { text: "Advanced", action: "tap", platform: "android" });
+      await fakeGraph.recordNavigationEvent({
         destination: "AdvancedScreen",
         source: "TEST",
         arguments: {},
@@ -348,7 +341,7 @@ describe("NavigateTo", () => {
       });
 
       // Go back to Home
-      await manager.recordNavigationEvent({
+      await fakeGraph.recordNavigationEvent({
         destination: "HomeScreen",
         source: "TEST",
         arguments: {},
@@ -357,7 +350,8 @@ describe("NavigateTo", () => {
         sequenceNumber: 3
       });
 
-      navigateTo = new NavigateTo(device, fakeAdbFactory);
+      // Inject fakeGraph via constructor
+      navigateTo = new NavigateTo(device, fakeAdbFactory, null, null, fakeGraph);
 
       await navigateTo.execute({
         targetScreen: "AdvancedScreen",


### PR DESCRIPTION
## Summary
- Add `NavigationGraphService` and `AccessibilityFocusService` interfaces for testability
- Migrate `NavigationGraphManager`, `FailureRecorder`, and `AccessibilityFocusTracker` to constructor injection pattern
- Add `createForTesting()` static methods and `defaultXxx` singleton exports
- Update `Explore` and `NavigateTo` to accept optional navigation manager parameter

## Test Plan
- [x] Tests pass locally (`bun test` - 1962 pass, 0 fail)
- [x] Lint passes (`bun run lint`)
- [x] Build passes (`bun run build`)

Closes #1117

🤖 Generated with [Claude Code](https://claude.com/claude-code)