### PR TITLE
refactor: add interfaces for ObserveScreen and dependencies

### DIFF
--- a/scripts/memory/stress-harness.ts
+++ b/scripts/memory/stress-harness.ts
@@ -1,7 +1,8 @@
 import fs from "node:fs";
 import path from "node:path";
 import { performance } from "node:perf_hooks";
-import { ObserveScreen } from "../../src/features/observe/ObserveScreen";
+import { RealObserveScreen } from "../../src/features/observe/ObserveScreen";
+import type { ObserveScreen } from "../../src/features/observe/interfaces/ObserveScreen";
 import { TapOnElement } from "../../src/features/action/TapOnElement";
 import { SwipeOn } from "../../src/features/action/SwipeOn";
 import { InputText } from "../../src/features/action/InputText";
@@ -292,7 +293,7 @@ export async function createStressHarness(): Promise<StressHarness> {
     fakeA11yClient as unknown as any
   );
 
-  const observeScreen = new ObserveScreen(device, fakeAdbFactory);
+  const observeScreen = new RealObserveScreen(device, fakeAdbFactory);
   (observeScreen as unknown as { viewHierarchy: ViewHierarchy }).viewHierarchy = viewHierarchy;
 
   const tapOnElement = new TapOnElement(
@@ -364,7 +365,7 @@ export async function createStressHarness(): Promise<StressHarness> {
   const cleanup = async () => {
     (AccessibilityServiceClient as unknown as { getInstance: unknown }).getInstance = originalGetInstance;
     AccessibilityServiceClient.resetInstances();
-    ObserveScreen.clearCache();
+    RealObserveScreen.clearCache();
   };
 
   return {

--- a/src/features/action/BaseVisualChange.ts
+++ b/src/features/action/BaseVisualChange.ts
@@ -1,7 +1,8 @@
 import { AdbClientFactory, defaultAdbClientFactory } from "../../utils/android-cmdline-tools/AdbClientFactory";
 import type { AdbExecutor } from "../../utils/android-cmdline-tools/interfaces/AdbExecutor";
 import { AwaitIdle } from "../observe/AwaitIdle";
-import { ObserveScreen } from "../observe/ObserveScreen";
+import { RealObserveScreen } from "../observe/ObserveScreen";
+import type { ObserveScreen } from "../observe/interfaces/ObserveScreen";
 import { Window } from "../observe/Window";
 import { logger } from "../../utils/logger";
 import { DEFAULT_FUZZY_MATCH_TOLERANCE_PERCENT } from "../../utils/constants";
@@ -72,7 +73,7 @@ export class BaseVisualChange {
       this.adb = this.adbFactory.create(device);
     }
     this.awaitIdle = new AwaitIdle(device, this.adbFactory);
-    this.observeScreen = new ObserveScreen(device, this.adbFactory);
+    this.observeScreen = new RealObserveScreen(device, this.adbFactory);
     this.window = new Window(device, this.adbFactory);
     this.predictionAnalyzer = new PredictionAnalyzer();
     this.timer = timer;

--- a/src/features/action/SetUIState.ts
+++ b/src/features/action/SetUIState.ts
@@ -12,6 +12,7 @@ import { FieldTypeDetector } from "./FieldTypeDetector";
 import { ElementUtils } from "../utility/ElementUtils";
 import { logger } from "../../utils/logger";
 import { Timer, defaultTimer } from "../../utils/SystemTimer";
+import type { ObserveScreen } from "../observe/interfaces/ObserveScreen";
 
 /**
  * Interface for TapOnElement dependency
@@ -49,19 +50,6 @@ export interface SwipeOnLike {
 }
 
 /**
- * Interface for ObserveScreen dependency
- */
-export interface ObserveScreenLike {
-  execute(
-    queryOptions?: any,
-    perf?: any,
-    skipWaitForFresh?: boolean,
-    minTimestamp?: number,
-    signal?: AbortSignal
-  ): Promise<ObserveResult>;
-}
-
-/**
  * Dependencies that can be injected for testing
  */
 export interface SetUIStateDependencies {
@@ -69,7 +57,7 @@ export interface SetUIStateDependencies {
   inputText?: InputTextLike;
   clearText?: ClearTextLike;
   swipeOn?: SwipeOnLike;
-  observeScreen?: ObserveScreenLike;
+  observeScreen?: ObserveScreen;
   fieldTypeDetector?: FieldTypeDetector;
   timer?: Timer;
 }
@@ -602,7 +590,7 @@ export class SetUIState extends BaseVisualChange {
     return new SwipeOn(this.device, this.adb);
   }
 
-  private getObserveScreen(): ObserveScreenLike {
+  private getObserveScreen(): ObserveScreen {
     if (this.dependencies.observeScreen) {
       return this.dependencies.observeScreen;
     }

--- a/src/features/action/SwipeOn.ts
+++ b/src/features/action/SwipeOn.ts
@@ -22,7 +22,7 @@ import { AccessibilityServiceClient } from "../observe/AccessibilityServiceClien
 import { XCTestServiceClient } from "../observe/XCTestServiceClient";
 import { buildElementSearchDebugContext } from "../../utils/DebugContextBuilder";
 import { SwipeResult } from "../../models/SwipeResult";
-import { ObserveScreen } from "../observe/ObserveScreen";
+import type { ObserveScreen } from "../observe/interfaces/ObserveScreen";
 import { resolveSwipeDirection } from "../../utils/swipeOnUtils";
 import { AccessibilityDetector } from "../../utils/interfaces/AccessibilityDetector";
 import { accessibilityDetector as defaultAccessibilityDetector } from "../../utils/AccessibilityDetector";
@@ -39,20 +39,9 @@ export interface GestureExecutor {
   ): Promise<SwipeResult>;
 }
 
-export interface ObserveScreenLike {
-  execute(
-    queryOptions?: import("../../models").ViewHierarchyQueryOptions,
-    perf?: PerformanceTracker,
-    skipWaitForFresh?: boolean,
-    minTimestamp?: number,
-    signal?: AbortSignal
-  ): Promise<ObserveResult>;
-  getMostRecentCachedObserveResult(): Promise<ObserveResult>;
-}
-
 export interface SwipeOnDependencies {
   executeGesture?: GestureExecutor;
-  observeScreen?: ObserveScreenLike;
+  observeScreen?: ObserveScreen;
   elementUtils?: ElementUtils;
   accessibilityDetector?: AccessibilityDetector;
 }

--- a/src/features/navigation/DefaultUIStateSetup.ts
+++ b/src/features/navigation/DefaultUIStateSetup.ts
@@ -5,7 +5,7 @@ import { ToolRegistry } from "../../server/toolRegistry";
 import { NavigationEdge, UIState } from "./NavigationGraphManager";
 import { ModalState, ScrollPosition } from "../../utils/interfaces/NavigationGraph";
 import { UIStateExtractor } from "./UIStateExtractor";
-import { ObserveScreen } from "../observe/ObserveScreen";
+import { RealObserveScreen } from "../observe/ObserveScreen";
 import { UIStateSetup } from "./interfaces/UIStateSetup";
 
 /**
@@ -162,7 +162,7 @@ export class DefaultUIStateSetup implements UIStateSetup {
    */
   private async getCurrentUIState(_platform: string): Promise<UIState | undefined> {
     try {
-      const observeScreen = new ObserveScreen(this.device, this.adb);
+      const observeScreen = new RealObserveScreen(this.device, this.adb);
       const result = await observeScreen.execute();
 
       if (!result.viewHierarchy) {

--- a/src/features/observe/AwaitIdle.ts
+++ b/src/features/observe/AwaitIdle.ts
@@ -5,8 +5,9 @@ import { Idle } from "./Idle";
 import { BootedDevice, GfxMetrics } from "../../models";
 import { PerformanceTracker, NoOpPerformanceTracker } from "../../utils/PerformanceTracker";
 import { throwIfAborted } from "../../utils/toolUtils";
+import type { AwaitIdle as AwaitIdleInterface, UiStabilityState } from "./interfaces/AwaitIdle";
 
-export class AwaitIdle {
+export class AwaitIdle implements AwaitIdleInterface {
   private adb: AdbExecutor;
   private adbFactory: AdbClientFactory;
   private idle: Idle;
@@ -68,15 +69,7 @@ export class AwaitIdle {
    * @param timeoutMs - Maximum time to wait for stability
    * @returns Promise with initialized state
    */
-  public async initializeUiStabilityTracking(packageName: string, timeoutMs: number): Promise<{
-    startTime: number;
-    lastNonIdleTime: number;
-    prevMissedVsync: number | null;
-    prevSlowUiThread: number | null;
-    prevFrameDeadlineMissed: number | null;
-    prevTotalFrames: number | null;
-    firstGfxInfoLog: boolean;
-  }> {
+  public async initializeUiStabilityTracking(packageName: string, timeoutMs: number): Promise<UiStabilityState> {
     const startTime = Date.now();
     const lastNonIdleTime = startTime;
 

--- a/src/features/observe/GetBackStack.ts
+++ b/src/features/observe/GetBackStack.ts
@@ -3,11 +3,12 @@ import type { AdbExecutor } from "../../utils/android-cmdline-tools/interfaces/A
 import { BackStackInfo, ActivityInfo, TaskInfo, BootedDevice } from "../../models";
 import { logger } from "../../utils/logger";
 import { PerformanceTracker, NoOpPerformanceTracker } from "../../utils/PerformanceTracker";
+import type { BackStack } from "./interfaces/BackStack";
 
 /**
  * Extracts back stack information from Android device using dumpsys activity
  */
-export class GetBackStack {
+export class GetBackStack implements BackStack {
   private adb: AdbExecutor;
 
   constructor(adbFactoryOrExecutor: AdbClientFactory | AdbExecutor | null = defaultAdbClientFactory, device?: BootedDevice) {

--- a/src/features/observe/GetDumpsysWindow.ts
+++ b/src/features/observe/GetDumpsysWindow.ts
@@ -5,8 +5,9 @@ import * as fs from "fs/promises";
 import * as path from "path";
 import { PerformanceTracker, NoOpPerformanceTracker } from "../../utils/PerformanceTracker";
 import { getTempDir, TEMP_SUBDIRS } from "../../utils/tempDir";
+import type { DumpsysWindow } from "./interfaces/DumpsysWindow";
 
-export class GetDumpsysWindow {
+export class GetDumpsysWindow implements DumpsysWindow {
   private adb: AdbExecutor;
   private readonly device: BootedDevice;
   private static memoryCache = new Map<string, { data: ExecResult; timestamp: number }>();

--- a/src/features/observe/GetScreenSize.ts
+++ b/src/features/observe/GetScreenSize.ts
@@ -2,14 +2,15 @@ import { AdbClientFactory, defaultAdbClientFactory } from "../../utils/android-c
 import type { AdbExecutor } from "../../utils/android-cmdline-tools/interfaces/AdbExecutor";
 import { DeviceDetection } from "../../utils/DeviceDetection";
 import { logger } from "../../utils/logger";
-import { BootedDevice, ExecResult, ScreenSize } from "../../models";
+import { BootedDevice, ExecResult, ScreenSize as ScreenSizeModel } from "../../models";
 import * as fs from "fs";
 import * as path from "path";
 import * as crypto from "crypto";
 import { PerformanceTracker, NoOpPerformanceTracker } from "../../utils/PerformanceTracker";
 import { XCTestServiceClient } from "./XCTestServiceClient";
+import type { ScreenSize } from "./interfaces/ScreenSize";
 
-export class GetScreenSize {
+export class GetScreenSize implements ScreenSize {
   private adb: AdbExecutor;
   private readonly device: BootedDevice;
   private static memoryCache = new Map<string, ScreenSize>();
@@ -55,7 +56,7 @@ export class GetScreenSize {
    * @param cacheKey - Cache key for the device
    * @returns Screen size if found, null otherwise
    */
-  private loadFromDiskCache(cacheKey: string): ScreenSize | null {
+  private loadFromDiskCache(cacheKey: string): ScreenSizeModel | null {
     try {
       const cacheFile = this.getCacheFilePath(cacheKey);
       if (fs.existsSync(cacheFile)) {
@@ -75,7 +76,7 @@ export class GetScreenSize {
    * @param cacheKey - Cache key for the device
    * @param screenSize - Screen size to cache
    */
-  private saveToDiskCache(cacheKey: string, screenSize: ScreenSize): void {
+  private saveToDiskCache(cacheKey: string, screenSize: ScreenSizeModel): void {
     try {
       // Ensure cache directory exists
       if (!fs.existsSync(GetScreenSize.cacheDir)) {
@@ -128,7 +129,7 @@ export class GetScreenSize {
    * The root node (XCUIApplication) bounds represent the full screen dimensions.
    * Format: "[left,top][right,bottom]" e.g., "[0,0][402,874]"
    */
-  private extractScreenSizeFromHierarchy(viewHierarchy: { hierarchy?: { node?: { $?: { bounds?: string } } } }): ScreenSize | null {
+  private extractScreenSizeFromHierarchy(viewHierarchy: { hierarchy?: { node?: { $?: { bounds?: string } } } }): ScreenSizeModel | null {
     const rootNode = viewHierarchy?.hierarchy?.node;
     if (!rootNode?.$?.bounds) {
       return null;
@@ -162,7 +163,7 @@ export class GetScreenSize {
    * @param rotation - Device rotation (0-3)
    * @returns Adjusted screen size
    */
-  public adjustDimensionsForRotation(width: number, height: number, rotation: number): ScreenSize {
+  public adjustDimensionsForRotation(width: number, height: number, rotation: number): ScreenSizeModel {
     // Adjust dimensions based on rotation
     // 0 = portrait, 1 = landscape (90° clockwise), 2 = portrait upside down, 3 = landscape (270° clockwise)
     if (rotation === 1 || rotation === 3) {
@@ -189,7 +190,7 @@ export class GetScreenSize {
   private async getAndroidScreenSize(
     dumpsysResult?: ExecResult,
     perf: PerformanceTracker = new NoOpPerformanceTracker()
-  ): Promise<ScreenSize> {
+  ): Promise<ScreenSizeModel> {
     // First get the physical screen size
     const { stdout } = await perf.track("adbWmSize", () =>
       this.adb.executeCommand("shell wm size")
@@ -228,7 +229,7 @@ export class GetScreenSize {
   async execute(
     dumpsysResult?: ExecResult,
     perf: PerformanceTracker = new NoOpPerformanceTracker()
-  ): Promise<ScreenSize> {
+  ): Promise<ScreenSizeModel> {
     const cacheKey = this.generateCacheKey(this.device.deviceId);
 
     // Check memory cache first

--- a/src/features/observe/GetSystemInsets.ts
+++ b/src/features/observe/GetSystemInsets.ts
@@ -1,10 +1,11 @@
 import { AdbClientFactory, defaultAdbClientFactory } from "../../utils/android-cmdline-tools/AdbClientFactory";
 import type { AdbExecutor } from "../../utils/android-cmdline-tools/interfaces/AdbExecutor";
 import { logger } from "../../utils/logger";
-import { BootedDevice, SystemInsets } from "../../models";
+import { BootedDevice, SystemInsets as SystemInsetsModel } from "../../models";
 import { ExecResult } from "../../models";
+import type { SystemInsets } from "./interfaces/SystemInsets";
 
-export class GetSystemInsets {
+export class GetSystemInsets implements SystemInsets {
   private adb: AdbExecutor;
 
   /**
@@ -81,7 +82,7 @@ export class GetSystemInsets {
    * @param dumpsysWindow - Pre-fetched dumpsys window output
    * @returns Promise with inset values
    */
-  async execute(dumpsysWindow: ExecResult): Promise<SystemInsets> {
+  async execute(dumpsysWindow: ExecResult): Promise<SystemInsetsModel> {
     try {
       // Use the full dumpsys output since we need to find status bar, nav bar, and gesture lines
       const fullOutput = dumpsysWindow.stdout;
@@ -113,7 +114,7 @@ export class GetSystemInsets {
    * Get fallback insets from alternative dumpsys output
    * @returns Promise with fallback system insets
    */
-  private async getFallbackInsets(dumpsysWindow: ExecResult): Promise<SystemInsets> {
+  private async getFallbackInsets(dumpsysWindow: ExecResult): Promise<SystemInsetsModel> {
     try {
       // Try to find status bar height
       const statusBarHeightMatch = dumpsysWindow.stdout.match(/mStatusBarHeight=(\d+)/);

--- a/src/features/observe/ObserveScreen.ts
+++ b/src/features/observe/ObserveScreen.ts
@@ -32,6 +32,16 @@ import { ScreenshotJobTracker } from "../../utils/ScreenshotJobTracker";
 import { attachRawViewHierarchy } from "../../utils/viewHierarchySearch";
 import { ElementUtils } from "../utility/ElementUtils";
 import { getTempDir, TEMP_SUBDIRS } from "../../utils/tempDir";
+import type { ObserveScreen } from "./interfaces/ObserveScreen";
+import type { ObserveScreenDependencies } from "./ObserveScreenDependencies";
+import type { ScreenSize } from "./interfaces/ScreenSize";
+import type { SystemInsets } from "./interfaces/SystemInsets";
+import type { ViewHierarchy as ViewHierarchyInterface } from "./interfaces/ViewHierarchy";
+import type { Window as WindowInterface } from "./interfaces/Window";
+import type { DumpsysWindow } from "./interfaces/DumpsysWindow";
+import type { BackStack } from "./interfaces/BackStack";
+import type { PredictiveUIState as PredictiveUIStateInterface } from "./interfaces/PredictiveUIState";
+import type { ScreenshotService } from "./interfaces/ScreenshotService";
 
 /**
  * Interface for cached observe result
@@ -44,18 +54,18 @@ interface ObserveResultCache {
 /**
  * Observe command class that combines screen details, view hierarchy and screenshot
  */
-export class ObserveScreen {
+export class RealObserveScreen implements ObserveScreen {
   private device: BootedDevice;
-  private screenSize: GetScreenSize;
-  private systemInsets: GetSystemInsets;
-  private viewHierarchy: ViewHierarchy;
-  private window: Window;
-  private screenshotUtil: TakeScreenshot;
-  private dumpsysWindow: GetDumpsysWindow;
-  private backStack: GetBackStack;
+  private screenSize: ScreenSize;
+  private systemInsets: SystemInsets;
+  private viewHierarchy: ViewHierarchyInterface;
+  private window: WindowInterface;
+  private screenshotUtil: ScreenshotService;
+  private dumpsysWindow: DumpsysWindow;
+  private backStack: BackStack;
   private adb: AdbExecutor;
   private adbFactory: AdbClientFactory;
-  private predictiveUIState: PredictiveUIState;
+  private predictiveUIState: PredictiveUIStateInterface;
 
   // Static cache for observe results
   private static observeResultCache: Map<string, ObserveResultCache> = new Map();
@@ -70,7 +80,7 @@ export class ObserveScreen {
    * Returns the most recently cached result if available and not expired.
    */
   static getRecentCachedResult(): ObserveResult | undefined {
-    if (ObserveScreen.observeResultCache.size === 0) {
+    if (RealObserveScreen.observeResultCache.size === 0) {
       return undefined;
     }
 
@@ -78,9 +88,9 @@ export class ObserveScreen {
     let mostRecentEntry: ObserveResultCache | undefined;
     let mostRecentTimestamp = 0;
 
-    for (const entry of ObserveScreen.observeResultCache.values()) {
+    for (const entry of RealObserveScreen.observeResultCache.values()) {
       const age = now - entry.timestamp;
-      if (age <= ObserveScreen.OBSERVE_RESULT_CACHE_TTL_MS && entry.timestamp > mostRecentTimestamp) {
+      if (age <= RealObserveScreen.OBSERVE_RESULT_CACHE_TTL_MS && entry.timestamp > mostRecentTimestamp) {
         mostRecentEntry = entry;
         mostRecentTimestamp = entry.timestamp;
       }
@@ -93,7 +103,7 @@ export class ObserveScreen {
    * Get the most recent cached screenshot path (if any).
    */
   static getRecentCachedScreenshotPath(): string | undefined {
-    const state = ObserveScreen.getLatestScreenshotState();
+    const state = RealObserveScreen.getLatestScreenshotState();
     return state?.path ?? undefined;
   }
 
@@ -101,7 +111,7 @@ export class ObserveScreen {
    * Get the most recent cached screenshot error (if any).
    */
   static getRecentCachedScreenshotError(): string | undefined {
-    const state = ObserveScreen.getLatestScreenshotState();
+    const state = RealObserveScreen.getLatestScreenshotState();
     return state?.error ?? undefined;
   }
 
@@ -109,16 +119,17 @@ export class ObserveScreen {
    * Clear the in-memory cache (for testing purposes).
    */
   static clearCache(): void {
-    ObserveScreen.observeResultCache.clear();
-    ObserveScreen.latestScreenshotPath = null;
-    ObserveScreen.latestScreenshotError = null;
-    ObserveScreen.latestScreenshotTimestamp = null;
+    RealObserveScreen.observeResultCache.clear();
+    RealObserveScreen.latestScreenshotPath = null;
+    RealObserveScreen.latestScreenshotError = null;
+    RealObserveScreen.latestScreenshotTimestamp = null;
     ScreenshotJobTracker.clear();
   }
 
   constructor(
     device: BootedDevice,
-    adbFactoryOrExecutor: AdbClientFactory | AdbExecutor | null = defaultAdbClientFactory
+    adbFactoryOrExecutor: AdbClientFactory | AdbExecutor | null = defaultAdbClientFactory,
+    dependencies?: ObserveScreenDependencies
   ) {
     this.device = device;
     // Detect if the argument is a factory (has create method) or an executor
@@ -134,45 +145,47 @@ export class ObserveScreen {
       this.adbFactory = defaultAdbClientFactory;
       this.adb = this.adbFactory.create(device);
     }
-    this.screenSize = new GetScreenSize(device, this.adbFactory);
-    this.systemInsets = new GetSystemInsets(device, this.adbFactory);
-    this.viewHierarchy = new ViewHierarchy(device, this.adbFactory);
-    this.window = new Window(device, this.adbFactory);
-    this.screenshotUtil = new TakeScreenshot(device, this.adbFactory);
-    this.dumpsysWindow = new GetDumpsysWindow(device, this.adbFactory);
-    this.backStack = new GetBackStack(this.adbFactory, device);
-    this.predictiveUIState = new PredictiveUIState();
+
+    // Use injected dependencies or create defaults
+    this.screenSize = dependencies?.screenSize ?? new GetScreenSize(device, this.adbFactory);
+    this.systemInsets = dependencies?.systemInsets ?? new GetSystemInsets(device, this.adbFactory);
+    this.viewHierarchy = dependencies?.viewHierarchy ?? new ViewHierarchy(device, this.adbFactory);
+    this.window = dependencies?.window ?? new Window(device, this.adbFactory);
+    this.screenshotUtil = dependencies?.screenshot ?? new TakeScreenshot(device, this.adbFactory);
+    this.dumpsysWindow = dependencies?.dumpsysWindow ?? new GetDumpsysWindow(device, this.adbFactory);
+    this.backStack = dependencies?.backStack ?? new GetBackStack(this.adbFactory, device);
+    this.predictiveUIState = dependencies?.predictiveUIState ?? new PredictiveUIState();
 
     // Ensure observe result cache directory exists
-    if (!fs.existsSync(ObserveScreen.observeResultCacheDir)) {
-      fs.mkdirSync(ObserveScreen.observeResultCacheDir, { recursive: true });
+    if (!fs.existsSync(RealObserveScreen.observeResultCacheDir)) {
+      fs.mkdirSync(RealObserveScreen.observeResultCacheDir, { recursive: true });
     }
   }
 
   private static getLatestScreenshotState(): { path: string | null; error: string | null } | null {
-    const timestamp = ObserveScreen.latestScreenshotTimestamp;
+    const timestamp = RealObserveScreen.latestScreenshotTimestamp;
     if (!timestamp) {
       return null;
     }
 
     const age = Date.now() - timestamp;
-    if (age > ObserveScreen.OBSERVE_RESULT_CACHE_TTL_MS) {
-      ObserveScreen.latestScreenshotPath = null;
-      ObserveScreen.latestScreenshotError = null;
-      ObserveScreen.latestScreenshotTimestamp = null;
+    if (age > RealObserveScreen.OBSERVE_RESULT_CACHE_TTL_MS) {
+      RealObserveScreen.latestScreenshotPath = null;
+      RealObserveScreen.latestScreenshotError = null;
+      RealObserveScreen.latestScreenshotTimestamp = null;
       return null;
     }
 
     return {
-      path: ObserveScreen.latestScreenshotPath,
-      error: ObserveScreen.latestScreenshotError
+      path: RealObserveScreen.latestScreenshotPath,
+      error: RealObserveScreen.latestScreenshotError
     };
   }
 
   private static updateLatestScreenshotCache(path?: string, error?: string): void {
-    ObserveScreen.latestScreenshotPath = path ?? null;
-    ObserveScreen.latestScreenshotError = error ?? null;
-    ObserveScreen.latestScreenshotTimestamp = Date.now();
+    RealObserveScreen.latestScreenshotPath = path ?? null;
+    RealObserveScreen.latestScreenshotError = error ?? null;
+    RealObserveScreen.latestScreenshotTimestamp = Date.now();
   }
 
   private async handleScreenshotResult(
@@ -185,25 +198,25 @@ export class ObserveScreen {
         logger.debug("[OBSERVE] Screenshot capture cancelled");
         return;
       }
-      ObserveScreen.updateLatestScreenshotCache(undefined, errorMessage);
+      RealObserveScreen.updateLatestScreenshotCache(undefined, errorMessage);
       logger.warn(`[OBSERVE] Screenshot capture failed: ${errorMessage}`);
       return;
     }
 
     if (!screenshotResult.path) {
-      ObserveScreen.updateLatestScreenshotCache(undefined, "Screenshot capture returned no file path");
+      RealObserveScreen.updateLatestScreenshotCache(undefined, "Screenshot capture returned no file path");
       logger.warn("[OBSERVE] Screenshot capture succeeded but no file path was returned");
       return;
     }
 
     const exists = await fs.pathExists(screenshotResult.path);
     if (!exists) {
-      ObserveScreen.updateLatestScreenshotCache(undefined, "Screenshot file missing after capture");
+      RealObserveScreen.updateLatestScreenshotCache(undefined, "Screenshot file missing after capture");
       logger.warn(`[OBSERVE] Screenshot capture reported success but file missing: ${screenshotResult.path}`);
       return;
     }
 
-    ObserveScreen.updateLatestScreenshotCache(screenshotResult.path);
+    RealObserveScreen.updateLatestScreenshotCache(screenshotResult.path);
   }
 
   /**
@@ -525,7 +538,7 @@ export class ObserveScreen {
     signal?: AbortSignal
   ): Promise<void> {
     if (this.device.platform === "ios") {
-      ObserveScreen.updateLatestScreenshotCache(undefined, "Screenshot capture not supported on iOS");
+      RealObserveScreen.updateLatestScreenshotCache(undefined, "Screenshot capture not supported on iOS");
       return;
     }
 
@@ -559,7 +572,7 @@ export class ObserveScreen {
         logger.debug("[OBSERVE] Screenshot capture cancelled");
         return;
       }
-      ObserveScreen.updateLatestScreenshotCache(undefined, errorMessage);
+      RealObserveScreen.updateLatestScreenshotCache(undefined, errorMessage);
       logger.warn(`[OBSERVE] Screenshot capture failed: ${errorMessage}`);
     }
   }
@@ -569,7 +582,7 @@ export class ObserveScreen {
     signal?: AbortSignal
   ): void {
     if (this.device.platform === "ios") {
-      ObserveScreen.updateLatestScreenshotCache(undefined, "Screenshot capture not supported on iOS");
+      RealObserveScreen.updateLatestScreenshotCache(undefined, "Screenshot capture not supported on iOS");
       return;
     }
 
@@ -731,7 +744,7 @@ export class ObserveScreen {
    * @returns Promise<ObserveResult | null> - Most recent cached result or null
    */
   private async checkInMemoryObserveCache(): Promise<ObserveResult | null> {
-    const cacheSize = ObserveScreen.observeResultCache.size;
+    const cacheSize = RealObserveScreen.observeResultCache.size;
     logger.info(`[OBSERVE_CACHE] Checking in-memory cache, size: ${cacheSize}`);
 
     if (cacheSize === 0) {
@@ -740,13 +753,13 @@ export class ObserveScreen {
     }
 
     const now = Date.now();
-    const ttl = ObserveScreen.OBSERVE_RESULT_CACHE_TTL_MS;
+    const ttl = RealObserveScreen.OBSERVE_RESULT_CACHE_TTL_MS;
 
     // Remove expired entries and find most recent
     const expiredKeys: string[] = [];
     let mostRecentEntry: ObserveResultCache | null = null;
 
-    for (const [key, cachedEntry] of ObserveScreen.observeResultCache.entries()) {
+    for (const [key, cachedEntry] of RealObserveScreen.observeResultCache.entries()) {
       const age = now - cachedEntry.timestamp;
 
       if (age >= ttl) {
@@ -762,7 +775,7 @@ export class ObserveScreen {
 
     // Remove expired entries
     for (const key of expiredKeys) {
-      ObserveScreen.observeResultCache.delete(key);
+      RealObserveScreen.observeResultCache.delete(key);
     }
 
     if (mostRecentEntry) {
@@ -784,7 +797,7 @@ export class ObserveScreen {
 
     try {
       // Get all JSON files in the cache directory
-      const files = await readdirAsync(ObserveScreen.observeResultCacheDir);
+      const files = await readdirAsync(RealObserveScreen.observeResultCacheDir);
       const jsonFiles = files.filter(file => file.endsWith(".json") && file.startsWith("observe_"));
 
       if (jsonFiles.length === 0) {
@@ -793,12 +806,12 @@ export class ObserveScreen {
       }
 
       const now = Date.now();
-      const ttl = ObserveScreen.OBSERVE_RESULT_CACHE_TTL_MS;
+      const ttl = RealObserveScreen.OBSERVE_RESULT_CACHE_TTL_MS;
       let mostRecentFile: { path: string, mtime: number } | null = null;
 
       // Find the most recent valid file
       for (const file of jsonFiles) {
-        const filePath = path.join(ObserveScreen.observeResultCacheDir, file);
+        const filePath = path.join(RealObserveScreen.observeResultCacheDir, file);
         const stats = await statAsync(filePath);
         const age = now - stats.mtime.getTime();
 
@@ -821,7 +834,7 @@ export class ObserveScreen {
 
         // Also update the in-memory cache
         const timestamp = mostRecentFile.mtime.toString();
-        ObserveScreen.observeResultCache.set(timestamp, {
+        RealObserveScreen.observeResultCache.set(timestamp, {
           timestamp: mostRecentFile.mtime,
           observeResult: cachedResult
         });
@@ -850,7 +863,7 @@ export class ObserveScreen {
       logger.info(`[OBSERVE_CACHE] Caching observe result with timestamp ${timestamp}`);
 
       // Cache in memory
-      ObserveScreen.observeResultCache.set(timestampKey, {
+      RealObserveScreen.observeResultCache.set(timestampKey, {
         timestamp,
         observeResult
       });
@@ -858,7 +871,7 @@ export class ObserveScreen {
       // Cache on disk
       await this.saveObserveResultToDisk(timestampKey, observeResult);
 
-      logger.info(`[OBSERVE_CACHE] Successfully cached observe result, in-memory cache size: ${ObserveScreen.observeResultCache.size}`);
+      logger.info(`[OBSERVE_CACHE] Successfully cached observe result, in-memory cache size: ${RealObserveScreen.observeResultCache.size}`);
     } catch (error) {
       logger.warn(`[OBSERVE_CACHE] Error caching observe result: ${error}`);
     }
@@ -872,7 +885,7 @@ export class ObserveScreen {
   private async saveObserveResultToDisk(timestamp: string, observeResult: ObserveResult): Promise<void> {
     try {
       const filename = `observe_${timestamp}.json`;
-      const filePath = path.join(ObserveScreen.observeResultCacheDir, filename);
+      const filePath = path.join(RealObserveScreen.observeResultCacheDir, filename);
 
       await writeFileAsync(filePath, JSON.stringify(observeResult, null, 2));
       logger.info(`[OBSERVE_CACHE] Saved observe result to disk: ${filename}`);
@@ -1097,7 +1110,7 @@ export class ObserveScreen {
    */
   private async getLatestScreenshotPath(): Promise<string | undefined> {
     try {
-      const cachedPath = ObserveScreen.getRecentCachedScreenshotPath();
+      const cachedPath = RealObserveScreen.getRecentCachedScreenshotPath();
       if (cachedPath) {
         const exists = await fs.pathExists(cachedPath);
         if (exists) {
@@ -1232,7 +1245,7 @@ export class ObserveScreen {
       logger.error("Critical error in observe command:", err);
       const errorMessage = err instanceof Error ? err.message : String(err);
       ScreenshotJobTracker.cancelJob(this.device.deviceId);
-      ObserveScreen.updateLatestScreenshotCache(undefined, `Observation failed: ${errorMessage}`);
+      RealObserveScreen.updateLatestScreenshotCache(undefined, `Observation failed: ${errorMessage}`);
       return {
         updatedAt: new Date().toISOString(),
         screenSize: { width: 0, height: 0 },

--- a/src/features/observe/ObserveScreenDependencies.ts
+++ b/src/features/observe/ObserveScreenDependencies.ts
@@ -1,0 +1,57 @@
+import type { BootedDevice } from "../../models";
+import type { AdbClientFactory } from "../../utils/android-cmdline-tools/AdbClientFactory";
+import type { ScreenshotService } from "./interfaces/ScreenshotService";
+import type { ScreenSize } from "./interfaces/ScreenSize";
+import type { SystemInsets } from "./interfaces/SystemInsets";
+import type { ViewHierarchy } from "./interfaces/ViewHierarchy";
+import type { Window } from "./interfaces/Window";
+import type { DumpsysWindow } from "./interfaces/DumpsysWindow";
+import type { BackStack } from "./interfaces/BackStack";
+import type { PredictiveUIState } from "./interfaces/PredictiveUIState";
+
+/**
+ * Dependencies for ObserveScreen that can be injected for testing.
+ * All properties are optional - defaults will be created if not provided.
+ */
+export interface ObserveScreenDependencies {
+  screenSize?: ScreenSize;
+  systemInsets?: SystemInsets;
+  viewHierarchy?: ViewHierarchy;
+  window?: Window;
+  screenshot?: ScreenshotService;
+  dumpsysWindow?: DumpsysWindow;
+  backStack?: BackStack;
+  predictiveUIState?: PredictiveUIState;
+}
+
+/**
+ * Create default dependency implementations for ObserveScreen.
+ * @param device - The booted device
+ * @param adbFactory - ADB client factory
+ * @returns Required dependencies with all implementations created
+ */
+export function createDefaultDependencies(
+  device: BootedDevice,
+  adbFactory: AdbClientFactory
+): Required<ObserveScreenDependencies> {
+  // Import implementations lazily to avoid circular dependencies
+  const { GetScreenSize } = require("./GetScreenSize");
+  const { GetSystemInsets } = require("./GetSystemInsets");
+  const { ViewHierarchy } = require("./ViewHierarchy");
+  const { Window } = require("./Window");
+  const { TakeScreenshot } = require("./TakeScreenshot");
+  const { GetDumpsysWindow } = require("./GetDumpsysWindow");
+  const { GetBackStack } = require("./GetBackStack");
+  const { PredictiveUIState } = require("./PredictiveUIState");
+
+  return {
+    screenSize: new GetScreenSize(device, adbFactory),
+    systemInsets: new GetSystemInsets(device, adbFactory),
+    viewHierarchy: new ViewHierarchy(device, adbFactory),
+    window: new Window(device, adbFactory),
+    screenshot: new TakeScreenshot(device, adbFactory),
+    dumpsysWindow: new GetDumpsysWindow(device, adbFactory),
+    backStack: new GetBackStack(adbFactory, device),
+    predictiveUIState: new PredictiveUIState()
+  };
+}

--- a/src/features/observe/PredictiveUIState.ts
+++ b/src/features/observe/PredictiveUIState.ts
@@ -10,6 +10,7 @@ import {
 import { NavigationEdge, NavigationGraphManager, UIState } from "../navigation/NavigationGraphManager";
 import { PredictionHistoryRepository } from "../../db/predictionHistoryRepository";
 import { normalizeToolArgs } from "../../utils/predictionUtils";
+import type { PredictiveUIState as PredictiveUIStateInterface } from "./interfaces/PredictiveUIState";
 
 interface InteractableElement {
   element: Element;
@@ -20,7 +21,7 @@ interface InteractableElement {
   scrollable: boolean;
 }
 
-export class PredictiveUIState {
+export class PredictiveUIState implements PredictiveUIStateInterface {
   private elementParser = new ElementParser();
   private historyRepository = new PredictionHistoryRepository();
   private readonly DEFAULT_CONFIDENCE = 0.5;

--- a/src/features/observe/ViewHierarchy.ts
+++ b/src/features/observe/ViewHierarchy.ts
@@ -20,6 +20,7 @@ import { PerformanceTracker, NoOpPerformanceTracker } from "../../utils/Performa
 import { serverConfig } from "../../utils/ServerConfig";
 import { attachRawViewHierarchy } from "../../utils/viewHierarchySearch";
 import { getTempDir, TEMP_SUBDIRS } from "../../utils/tempDir";
+import type { ViewHierarchy as ViewHierarchyInterface } from "./interfaces/ViewHierarchy";
 
 /**
  * Interface for element bounds
@@ -31,7 +32,7 @@ interface ElementBounds {
   bottom: number;
 }
 
-export class ViewHierarchy {
+export class ViewHierarchy implements ViewHierarchyInterface {
   private device: BootedDevice;
   private readonly adb: AdbExecutor;
   private adbFactory: AdbClientFactory;

--- a/src/features/observe/Window.ts
+++ b/src/features/observe/Window.ts
@@ -8,8 +8,9 @@ import * as path from "path";
 import { BootedDevice } from "../../models";
 import { PerformanceTracker, NoOpPerformanceTracker } from "../../utils/PerformanceTracker";
 import { getTempDir, TEMP_SUBDIRS } from "../../utils/tempDir";
+import type { Window as WindowInterface } from "./interfaces/Window";
 
-export class Window {
+export class Window implements WindowInterface {
   private adb: AdbExecutor;
   private cachedActiveWindow: ActiveWindowInfo | null = null;
   private readonly device: BootedDevice;

--- a/src/features/observe/interfaces/AwaitIdle.ts
+++ b/src/features/observe/interfaces/AwaitIdle.ts
@@ -1,0 +1,69 @@
+import type { GfxMetrics } from "../../../models";
+import type { PerformanceTracker } from "../../../utils/PerformanceTracker";
+
+/**
+ * State object for UI stability tracking.
+ */
+export interface UiStabilityState {
+  startTime: number;
+  lastNonIdleTime: number;
+  prevMissedVsync: number | null;
+  prevSlowUiThread: number | null;
+  prevFrameDeadlineMissed: number | null;
+  prevTotalFrames: number | null;
+  firstGfxInfoLog: boolean;
+}
+
+/**
+ * Interface for waiting for device idle/stability states.
+ */
+export interface AwaitIdle {
+  /**
+   * Wait for the device rotation to complete.
+   * @param targetRotation - The expected rotation value (0 for portrait, 1 for landscape)
+   * @param timeoutMs - Maximum time to wait in milliseconds (default: 500)
+   * @returns Promise that resolves when rotation completes or rejects on timeout
+   */
+  waitForRotation(targetRotation: number, timeoutMs?: number): Promise<void>;
+
+  /**
+   * Initialize UI stability tracking state.
+   * @param packageName - Package name to monitor
+   * @param timeoutMs - Maximum time to wait for stability
+   * @returns Promise with initialized state for use with waitForUiStabilityWithState
+   */
+  initializeUiStabilityTracking(packageName: string, timeoutMs: number): Promise<UiStabilityState>;
+
+  /**
+   * Wait for UI to become stable by monitoring frame rendering.
+   * Initializes tracking state internally.
+   * @param packageName - Package name of the app to monitor
+   * @param timeoutMs - Maximum time to wait for stability
+   * @param perf - Optional performance tracker
+   * @param signal - Optional abort signal
+   * @returns Promise that resolves with GfxMetrics when UI is stable, or null on failure
+   */
+  waitForUiStability(
+    packageName: string,
+    timeoutMs: number,
+    perf?: PerformanceTracker,
+    signal?: AbortSignal
+  ): Promise<GfxMetrics | null>;
+
+  /**
+   * Wait for UI to become stable using pre-initialized state.
+   * @param packageName - Package name of the app to monitor
+   * @param timeoutMs - Maximum time to wait for stability
+   * @param initState - Pre-initialized state from initializeUiStabilityTracking
+   * @param perf - Optional performance tracker
+   * @param signal - Optional abort signal
+   * @returns Promise that resolves with GfxMetrics when UI is stable, or null on failure
+   */
+  waitForUiStabilityWithState(
+    packageName: string,
+    timeoutMs: number,
+    initState: UiStabilityState,
+    perf?: PerformanceTracker,
+    signal?: AbortSignal
+  ): Promise<GfxMetrics | null>;
+}

--- a/src/features/observe/interfaces/BackStack.ts
+++ b/src/features/observe/interfaces/BackStack.ts
@@ -1,0 +1,15 @@
+import type { BackStackInfo } from "../../../models";
+import type { PerformanceTracker } from "../../../utils/PerformanceTracker";
+
+/**
+ * Interface for retrieving Android activity back stack information.
+ */
+export interface BackStack {
+  /**
+   * Execute dumpsys activity activities command and parse the back stack.
+   * @param perf - Optional performance tracker
+   * @param signal - Optional abort signal
+   * @returns Promise with BackStackInfo containing activities, tasks, and current activity
+   */
+  execute(perf?: PerformanceTracker, signal?: AbortSignal): Promise<BackStackInfo>;
+}

--- a/src/features/observe/interfaces/DumpsysWindow.ts
+++ b/src/features/observe/interfaces/DumpsysWindow.ts
@@ -1,0 +1,24 @@
+import type { ExecResult } from "../../../models";
+import type { PerformanceTracker } from "../../../utils/PerformanceTracker";
+
+/**
+ * Interface for retrieving and caching dumpsys window output.
+ */
+export interface DumpsysWindow {
+  /**
+   * Get cached dumpsys window data, using memory cache first, then disk cache.
+   * If no valid cache exists, fetches fresh data.
+   * @param perf - Optional performance tracker
+   * @param signal - Optional abort signal
+   * @returns Promise with ExecResult containing dumpsys window output
+   */
+  execute(perf?: PerformanceTracker, signal?: AbortSignal): Promise<ExecResult>;
+
+  /**
+   * Refresh dumpsys window data and update both memory and disk cache.
+   * @param perf - Optional performance tracker
+   * @param signal - Optional abort signal
+   * @returns Promise with fresh ExecResult
+   */
+  refresh(perf?: PerformanceTracker, signal?: AbortSignal): Promise<ExecResult>;
+}

--- a/src/features/observe/interfaces/ObserveScreen.ts
+++ b/src/features/observe/interfaces/ObserveScreen.ts
@@ -1,0 +1,32 @@
+import type { ObserveResult } from "../../../models";
+import type { ViewHierarchyQueryOptions } from "../../../models/ViewHierarchyQueryOptions";
+import type { PerformanceTracker } from "../../../utils/PerformanceTracker";
+
+/**
+ * Interface for observing device screen state.
+ */
+export interface ObserveScreen {
+  /**
+   * Execute the observe command to capture screen state.
+   * Collects view hierarchy, screen size, system insets, and other device state.
+   * @param queryOptions - Optional query options for targeted element retrieval
+   * @param perf - Optional performance tracker for timing data
+   * @param skipWaitForFresh - If true, skip WebSocket wait and go straight to sync method (default: true)
+   * @param minTimestamp - If provided, cached data must have updatedAt >= this value
+   * @param signal - Optional abort signal
+   * @returns Promise with the observation result
+   */
+  execute(
+    queryOptions?: ViewHierarchyQueryOptions,
+    perf?: PerformanceTracker,
+    skipWaitForFresh?: boolean,
+    minTimestamp?: number,
+    signal?: AbortSignal
+  ): Promise<ObserveResult>;
+
+  /**
+   * Get the most recent cached observe result from memory or disk cache.
+   * @returns Promise with the most recent cached observe result
+   */
+  getMostRecentCachedObserveResult(): Promise<ObserveResult>;
+}

--- a/src/features/observe/interfaces/PredictiveUIState.ts
+++ b/src/features/observe/interfaces/PredictiveUIState.ts
@@ -1,0 +1,14 @@
+import type { ObserveResult, Predictions } from "../../../models";
+
+/**
+ * Interface for generating predictive UI state based on navigation graph.
+ */
+export interface PredictiveUIState {
+  /**
+   * Generate predictions for likely next actions based on current screen state
+   * and navigation graph edges.
+   * @param result - Current observe result with view hierarchy
+   * @returns Promise with predictions for likely actions and interactable elements, or undefined if unavailable
+   */
+  generate(result: ObserveResult): Promise<Predictions | undefined>;
+}

--- a/src/features/observe/interfaces/ScreenSize.ts
+++ b/src/features/observe/interfaces/ScreenSize.ts
@@ -1,0 +1,16 @@
+import type { ExecResult, ScreenSize as ScreenSizeModel } from "../../../models";
+import type { PerformanceTracker } from "../../../utils/PerformanceTracker";
+
+/**
+ * Interface for retrieving device screen dimensions.
+ */
+export interface ScreenSize {
+  /**
+   * Get the screen size and resolution, accounting for device rotation.
+   * Uses caching to avoid repeated commands.
+   * @param dumpsysResult - Optional dumpsys result for rotation detection optimization
+   * @param perf - Optional performance tracker
+   * @returns Promise with width and height in pixels
+   */
+  execute(dumpsysResult?: ExecResult, perf?: PerformanceTracker): Promise<ScreenSizeModel>;
+}

--- a/src/features/observe/interfaces/SystemInsets.ts
+++ b/src/features/observe/interfaces/SystemInsets.ts
@@ -1,0 +1,13 @@
+import type { SystemInsets as SystemInsetsModel, ExecResult } from "../../../models";
+
+/**
+ * Interface for retrieving system UI insets (status bar, navigation bar, gesture areas).
+ */
+export interface SystemInsets {
+  /**
+   * Get the system UI insets using cached dumpsys window output.
+   * @param dumpsysWindow - Pre-fetched dumpsys window output
+   * @returns Promise with inset values for top (status bar), bottom (nav bar), left/right (gesture areas)
+   */
+  execute(dumpsysWindow: ExecResult): Promise<SystemInsetsModel>;
+}

--- a/src/features/observe/interfaces/ViewHierarchy.ts
+++ b/src/features/observe/interfaces/ViewHierarchy.ts
@@ -1,0 +1,61 @@
+import type { Element, ViewHierarchyResult } from "../../../models";
+import type { ViewHierarchyQueryOptions } from "../../../models/ViewHierarchyQueryOptions";
+import type { PerformanceTracker } from "../../../utils/PerformanceTracker";
+
+/**
+ * Interface for retrieving and managing view hierarchy data.
+ */
+export interface ViewHierarchy {
+  /**
+   * Retrieve the view hierarchy of the current screen.
+   * @param queryOptions - Optional query options for targeted element retrieval
+   * @param perf - Optional performance tracker for timing data
+   * @param skipWaitForFresh - If true, skip WebSocket wait and go straight to sync method
+   * @param minTimestamp - If provided, cached data must have updatedAt >= this value
+   * @param signal - Optional abort signal
+   * @returns Promise with parsed view hierarchy
+   */
+  getViewHierarchy(
+    queryOptions?: ViewHierarchyQueryOptions,
+    perf?: PerformanceTracker,
+    skipWaitForFresh?: boolean,
+    minTimestamp?: number,
+    signal?: AbortSignal
+  ): Promise<ViewHierarchyResult>;
+
+  /**
+   * Configure recomposition tracking for Compose UI debugging.
+   * @param enabled - Whether to enable recomposition tracking
+   * @param perf - Optional performance tracker
+   */
+  configureRecompositionTracking(enabled: boolean, perf?: PerformanceTracker): Promise<void>;
+
+  /**
+   * Find the focused element in the view hierarchy.
+   * @param viewHierarchy - The view hierarchy to search
+   * @returns The focused element or null if none found
+   */
+  findFocusedElement(viewHierarchy: any): Element | null;
+
+  /**
+   * Find the accessibility-focused element (TalkBack cursor position) in the view hierarchy.
+   * @param viewHierarchy - The view hierarchy to search
+   * @returns The accessibility-focused element or null if none found
+   */
+  findAccessibilityFocusedElement(viewHierarchy: any): Element | null;
+
+  /**
+   * Filter out completely offscreen nodes from the view hierarchy.
+   * @param viewHierarchy - The view hierarchy to filter
+   * @param screenWidth - Screen width in pixels
+   * @param screenHeight - Screen height in pixels
+   * @param margin - Extra margin around screen to keep near-visible elements (default 100px)
+   * @returns Filtered view hierarchy with offscreen nodes removed
+   */
+  filterOffscreenNodes(
+    viewHierarchy: any,
+    screenWidth: number,
+    screenHeight: number,
+    margin?: number
+  ): any;
+}

--- a/src/features/observe/interfaces/Window.ts
+++ b/src/features/observe/interfaces/Window.ts
@@ -1,0 +1,41 @@
+import type { ActiveWindowInfo } from "../../../models/ActiveWindowInfo";
+import type { PerformanceTracker } from "../../../utils/PerformanceTracker";
+
+/**
+ * Interface for retrieving active window information.
+ */
+export interface Window {
+  /**
+   * Get information about the active window.
+   * Uses cache unless forceRefresh is true.
+   * @param forceRefresh - Force refresh the cache (default: false)
+   * @param perf - Optional performance tracker
+   * @returns Promise with active window information (appId, activityName, layoutSeqSum)
+   */
+  getActive(forceRefresh?: boolean, perf?: PerformanceTracker): Promise<ActiveWindowInfo>;
+
+  /**
+   * Get a hash of the current activity name.
+   * Always forces a refresh to ensure current state.
+   * @param perf - Optional performance tracker
+   * @returns Promise with activity hash string
+   */
+  getActiveHash(perf?: PerformanceTracker): Promise<string>;
+
+  /**
+   * Get cached active window without refreshing.
+   * @returns Promise with cached window info or null if not cached
+   */
+  getCachedActiveWindow(): Promise<ActiveWindowInfo | null>;
+
+  /**
+   * Set cached active window from external source (e.g., UI stability waiting).
+   * @param activeWindow - The active window to cache
+   */
+  setCachedActiveWindow(activeWindow: ActiveWindowInfo): Promise<void>;
+
+  /**
+   * Clear the cached active window from memory and disk.
+   */
+  clearCache(): Promise<void>;
+}

--- a/src/features/observe/interfaces/index.ts
+++ b/src/features/observe/interfaces/index.ts
@@ -1,0 +1,14 @@
+/**
+ * Barrel export for observe feature interfaces.
+ */
+
+export type { ObserveScreen } from "./ObserveScreen";
+export type { ScreenSize } from "./ScreenSize";
+export type { SystemInsets } from "./SystemInsets";
+export type { ViewHierarchy } from "./ViewHierarchy";
+export type { Window } from "./Window";
+export type { DumpsysWindow } from "./DumpsysWindow";
+export type { BackStack } from "./BackStack";
+export type { PredictiveUIState } from "./PredictiveUIState";
+export type { AwaitIdle, UiStabilityState } from "./AwaitIdle";
+export type { ScreenshotService } from "./ScreenshotService";

--- a/src/server/observationResources.ts
+++ b/src/server/observationResources.ts
@@ -1,5 +1,5 @@
 import { ResourceRegistry, ResourceContent } from "./resourceRegistry";
-import { ObserveScreen } from "../features/observe/ObserveScreen";
+import { RealObserveScreen } from "../features/observe/ObserveScreen";
 import { logger } from "../utils/logger";
 import { stringifyToolResponse } from "../utils/toolUtils";
 import { ScreenshotJobTracker } from "../utils/ScreenshotJobTracker";
@@ -14,7 +14,7 @@ export const RESOURCE_URIS = {
 // Helper to get the latest screenshot path from cache
 async function getLatestScreenshotPath(): Promise<string | undefined> {
   try {
-    const screenshotPath = ObserveScreen.getRecentCachedScreenshotPath();
+    const screenshotPath = RealObserveScreen.getRecentCachedScreenshotPath();
     if (!screenshotPath) {
       return undefined;
     }
@@ -34,7 +34,7 @@ async function getLatestScreenshotPath(): Promise<string | undefined> {
 // Handler for latest observation resource (text/json)
 async function getLatestObservation(): Promise<ResourceContent> {
   try {
-    const cachedResult = ObserveScreen.getRecentCachedResult();
+    const cachedResult = RealObserveScreen.getRecentCachedResult();
 
     if (!cachedResult) {
       return {
@@ -67,7 +67,7 @@ async function getLatestObservation(): Promise<ResourceContent> {
 // Handler for latest screenshot resource (image/png as blob)
 async function getLatestScreenshot(): Promise<ResourceContent> {
   try {
-    const cachedResult = ObserveScreen.getRecentCachedResult();
+    const cachedResult = RealObserveScreen.getRecentCachedResult();
     if (!cachedResult) {
       return {
         uri: RESOURCE_URIS.LATEST_SCREENSHOT,
@@ -89,7 +89,7 @@ async function getLatestScreenshot(): Promise<ResourceContent> {
     }
 
     if (!screenshotPath) {
-      const screenshotError = ObserveScreen.getRecentCachedScreenshotError();
+      const screenshotError = RealObserveScreen.getRecentCachedScreenshotError();
       const errorMessage = screenshotError
         ? `No screenshot available from the latest observation: ${screenshotError}`
         : "No screenshot available. Call the 'observe' tool again to capture a screenshot.";

--- a/src/server/observeTools.ts
+++ b/src/server/observeTools.ts
@@ -3,7 +3,7 @@ import { ToolRegistry } from "./toolRegistry";
 import { ResourceRegistry } from "./resourceRegistry";
 import { RESOURCE_URIS } from "./observationResources";
 import { ActionableError } from "../models/ActionableError";
-import { ObserveScreen } from "../features/observe/ObserveScreen";
+import { RealObserveScreen } from "../features/observe/ObserveScreen";
 import { createJSONToolResponse, createStructuredToolResponse, throwIfAborted } from "../utils/toolUtils";
 import { BootedDevice, Element, ObserveResult, ViewHierarchyResult } from "../models";
 import { createGlobalPerformanceTracker } from "../utils/PerformanceTracker";
@@ -212,7 +212,7 @@ export function registerObserveTools() {
   // Observe handler
   const observeHandler = async (device: BootedDevice, args: ObserveArgs, _progress?: unknown, signal?: AbortSignal) => {
     try {
-      const observeScreen = new ObserveScreen(device);
+      const observeScreen = new RealObserveScreen(device);
       const waitFor = args.waitFor;
       const waitOutcome = waitFor
         ? await waitForObservation(observeScreen, waitFor, signal)
@@ -279,7 +279,7 @@ export function registerObserveTools() {
     args: IdentifyInteractionsOptions
   ) => {
     try {
-      const observeScreen = new ObserveScreen(device);
+      const observeScreen = new RealObserveScreen(device);
       const cachedResult = await observeScreen.getMostRecentCachedObserveResult();
       const navigationGraph = NavigationGraphManager.getInstance();
       const currentScreen = navigationGraph.getCurrentScreen();

--- a/src/server/systemTrayHelpers.ts
+++ b/src/server/systemTrayHelpers.ts
@@ -11,7 +11,7 @@ import {
   ObserveResult,
   ViewHierarchyResult
 } from "../models";
-import { ObserveScreen } from "../features/observe/ObserveScreen";
+import { RealObserveScreen } from "../features/observe/ObserveScreen";
 import { defaultAdbClientFactory } from "../utils/android-cmdline-tools/AdbClientFactory";
 import { ElementUtils } from "../features/utility/ElementUtils";
 import type { ProgressCallback } from "./toolRegistry";
@@ -57,7 +57,7 @@ let systemTrayDependencies: SystemTrayDependencies | null = null;
 export const getSystemTrayDependencies = (): SystemTrayDependencies => {
   if (!systemTrayDependencies) {
     systemTrayDependencies = {
-      observeScreenFactory: device => new ObserveScreen(device),
+      observeScreenFactory: device => new RealObserveScreen(device),
       adbFactory: device => defaultAdbClientFactory.create(device),
       timer: defaultTimer
     };

--- a/src/server/toolRegistry.ts
+++ b/src/server/toolRegistry.ts
@@ -4,7 +4,7 @@ import { DeviceSessionManager } from "../utils/DeviceSessionManager";
 import { ActionableError, BootedDevice, SomePlatform } from "../models";
 import { NavigationGraphManager } from "../features/navigation/NavigationGraphManager";
 import { UIStateExtractor } from "../features/navigation/UIStateExtractor";
-import { ObserveScreen } from "../features/observe/ObserveScreen";
+import { RealObserveScreen } from "../features/observe/ObserveScreen";
 import { serverConfig } from "../utils/ServerConfig";
 import { MemoryAudit } from "../features/memory/MemoryAudit";
 import { defaultAdbClientFactory } from "../utils/android-cmdline-tools/AdbClientFactory";
@@ -221,7 +221,7 @@ class ToolRegistryClass {
         ];
         if (navigationRelevantTools.includes(name)) {
           // Extract UI state from the most recent cached observation
-          const cachedResult = ObserveScreen.getRecentCachedResult();
+          const cachedResult = RealObserveScreen.getRecentCachedResult();
           const uiState = UIStateExtractor.extractFromObservation(cachedResult);
           NavigationGraphManager.getInstance().recordToolCall(name, args, uiState);
         }

--- a/src/utils/DeviceSessionManager.ts
+++ b/src/utils/DeviceSessionManager.ts
@@ -11,7 +11,7 @@ import type { AdbExecutor } from "./android-cmdline-tools/interfaces/AdbExecutor
 import { PlatformDeviceManager } from "./interfaces/DeviceUtils";
 import { AccessibilityServiceClient } from "../features/observe/AccessibilityServiceClient";
 import { XCTestServiceClient } from "../features/observe/XCTestServiceClient";
-import { ObserveScreen } from "../features/observe/ObserveScreen";
+import { RealObserveScreen } from "../features/observe/ObserveScreen";
 import { createPerformanceTracker } from "./PerformanceTracker";
 import { storeSetupTiming } from "../server/ToolExecutionContext";
 import { applyAppearanceOnConnect } from "./appearance/applyAppearanceOnConnect";
@@ -793,7 +793,7 @@ export class DeviceSessionManager implements DeviceSessionManager {
 
       xcTestClient.onPushUpdate(() => {
         logger.info(`[DeviceSessionManager] Received iOS UI change notification for ${deviceId}, clearing ObserveScreen cache`);
-        ObserveScreen.clearCache();
+        RealObserveScreen.clearCache();
       });
 
       DeviceSessionManager.pushUpdateListenersRegistered.add(deviceId);

--- a/test/fakes/FakeAwaitIdle.ts
+++ b/test/fakes/FakeAwaitIdle.ts
@@ -1,14 +1,31 @@
-import { ObserveResult } from "../../src/models";
+import type { AwaitIdle, UiStabilityState } from "../../src/features/observe/interfaces/AwaitIdle";
+import type { GfxMetrics } from "../../src/models";
 
 /**
  * Fake implementation of AwaitIdle for testing
  * Allows configuring idle tracking responses and asserting method calls
  */
-export class FakeAwaitIdle {
+export class FakeAwaitIdle implements AwaitIdle {
   private executedOperations: string[] = [];
   private initializeCallCount: number = 0;
   private waitForUiStabilityCallCount: number = 0;
   private waitForUiStabilityWithStateCallCount: number = 0;
+  private configuredGfxMetrics: GfxMetrics | null = null;
+  private configuredUiStabilityState: UiStabilityState | null = null;
+
+  /**
+   * Configure the GfxMetrics to be returned by waitForUiStability methods
+   */
+  configureGfxMetrics(metrics: GfxMetrics | null): void {
+    this.configuredGfxMetrics = metrics;
+  }
+
+  /**
+   * Configure the UiStabilityState to be returned by initializeUiStabilityTracking
+   */
+  configureUiStabilityState(state: UiStabilityState): void {
+    this.configuredUiStabilityState = state;
+  }
 
   /**
    * Get history of executed operations
@@ -64,19 +81,47 @@ export class FakeAwaitIdle {
 
   // Implementation of AwaitIdle interface
 
-  async initializeUiStabilityTracking(): Promise<void> {
-    this.executedOperations.push("initializeUiStabilityTracking");
+  async initializeUiStabilityTracking(packageName: string, timeoutMs: number): Promise<UiStabilityState> {
+    this.executedOperations.push(`initializeUiStabilityTracking(${packageName}, ${timeoutMs})`);
     this.initializeCallCount++;
+
+    if (this.configuredUiStabilityState) {
+      return this.configuredUiStabilityState;
+    }
+
+    const now = Date.now();
+    return {
+      startTime: now,
+      lastNonIdleTime: now,
+      prevMissedVsync: null,
+      prevSlowUiThread: null,
+      prevFrameDeadlineMissed: null,
+      prevTotalFrames: null,
+      firstGfxInfoLog: true
+    };
   }
 
-  async waitForUiStability(): Promise<void> {
-    this.executedOperations.push("waitForUiStability");
+  async waitForUiStability(
+    packageName: string,
+    timeoutMs: number,
+    _perf?: any,
+    _signal?: AbortSignal
+  ): Promise<GfxMetrics | null> {
+    this.executedOperations.push(`waitForUiStability(${packageName}, ${timeoutMs})`);
     this.waitForUiStabilityCallCount++;
+    return this.configuredGfxMetrics;
   }
 
-  async waitForUiStabilityWithState(state: ObserveResult): Promise<void> {
-    this.executedOperations.push("waitForUiStabilityWithState");
+  async waitForUiStabilityWithState(
+    packageName: string,
+    timeoutMs: number,
+    _initState: UiStabilityState,
+    _perf?: any,
+    _signal?: AbortSignal
+  ): Promise<GfxMetrics | null> {
+    this.executedOperations.push(`waitForUiStabilityWithState(${packageName}, ${timeoutMs})`);
     this.waitForUiStabilityWithStateCallCount++;
+    return this.configuredGfxMetrics;
   }
 
   async waitForRotation(targetRotation: number, timeoutMs?: number): Promise<void> {

--- a/test/fakes/FakeBackStack.ts
+++ b/test/fakes/FakeBackStack.ts
@@ -1,0 +1,86 @@
+import type { BackStack } from "../../src/features/observe/interfaces/BackStack";
+import type { BackStackInfo } from "../../src/models";
+
+/**
+ * Fake implementation of BackStack for testing.
+ * Returns configurable responses and records all calls.
+ */
+export class FakeBackStack implements BackStack {
+  private calls: { signal?: AbortSignal }[] = [];
+  private configuredBackStack: BackStackInfo = {
+    depth: 0,
+    activities: [],
+    tasks: [],
+    capturedAt: Date.now(),
+    source: "adb"
+  };
+  private shouldFail = false;
+  private failureError: Error | null = null;
+
+  /**
+   * Get the back stack (fake implementation).
+   */
+  async execute(_perf?: any, signal?: AbortSignal): Promise<BackStackInfo> {
+    if (this.shouldFail && this.failureError) {
+      throw this.failureError;
+    }
+
+    this.calls.push({ signal });
+    return { ...this.configuredBackStack, capturedAt: Date.now() };
+  }
+
+  // Test helpers
+
+  /**
+   * Configure the back stack to return.
+   */
+  configureBackStack(backStack: BackStackInfo): void {
+    this.configuredBackStack = backStack;
+  }
+
+  /**
+   * Configure to throw an error on execute().
+   */
+  setFailure(error: Error): void {
+    this.shouldFail = true;
+    this.failureError = error;
+  }
+
+  /**
+   * Clear failure configuration.
+   */
+  clearFailure(): void {
+    this.shouldFail = false;
+    this.failureError = null;
+  }
+
+  /**
+   * Get the number of execute() calls.
+   */
+  getCallCount(): number {
+    return this.calls.length;
+  }
+
+  /**
+   * Check if execute() was called.
+   */
+  wasCalled(): boolean {
+    return this.calls.length > 0;
+  }
+
+  /**
+   * Reset all state.
+   */
+  reset(): void {
+    this.calls = [];
+    this.configuredBackStack = {
+      depth: 0,
+      activities: [],
+      tasks: [],
+      capturedAt: Date.now(),
+      source: "adb"
+    };
+    this.shouldFail = false;
+    this.failureError = null;
+  }
+}

--- a/test/fakes/FakeDumpsysWindow.ts
+++ b/test/fakes/FakeDumpsysWindow.ts
@@ -1,0 +1,102 @@
+import type { DumpsysWindow } from "../../src/features/observe/interfaces/DumpsysWindow";
+import type { ExecResult } from "../../src/models";
+
+/**
+ * Fake implementation of DumpsysWindow for testing.
+ * Returns configurable responses and records all calls.
+ */
+export class FakeDumpsysWindow implements DumpsysWindow {
+  private executeCalls: { signal?: AbortSignal }[] = [];
+  private refreshCalls: { signal?: AbortSignal }[] = [];
+  private configuredResult: ExecResult = { stdout: "", stderr: "" };
+  private shouldFail = false;
+  private failureError: Error | null = null;
+
+  /**
+   * Get dumpsys window (fake implementation).
+   */
+  async execute(_perf?: any, signal?: AbortSignal): Promise<ExecResult> {
+    if (this.shouldFail && this.failureError) {
+      throw this.failureError;
+    }
+
+    this.executeCalls.push({ signal });
+    return { ...this.configuredResult };
+  }
+
+  /**
+   * Refresh dumpsys window (fake implementation).
+   */
+  async refresh(_perf?: any, signal?: AbortSignal): Promise<ExecResult> {
+    if (this.shouldFail && this.failureError) {
+      throw this.failureError;
+    }
+
+    this.refreshCalls.push({ signal });
+    return { ...this.configuredResult };
+  }
+
+  // Test helpers
+
+  /**
+   * Configure the result to return.
+   */
+  configureResult(result: ExecResult): void {
+    this.configuredResult = result;
+  }
+
+  /**
+   * Configure to throw an error on execute()/refresh().
+   */
+  setFailure(error: Error): void {
+    this.shouldFail = true;
+    this.failureError = error;
+  }
+
+  /**
+   * Clear failure configuration.
+   */
+  clearFailure(): void {
+    this.shouldFail = false;
+    this.failureError = null;
+  }
+
+  /**
+   * Get the number of execute() calls.
+   */
+  getExecuteCallCount(): number {
+    return this.executeCalls.length;
+  }
+
+  /**
+   * Get the number of refresh() calls.
+   */
+  getRefreshCallCount(): number {
+    return this.refreshCalls.length;
+  }
+
+  /**
+   * Check if execute() was called.
+   */
+  wasExecuteCalled(): boolean {
+    return this.executeCalls.length > 0;
+  }
+
+  /**
+   * Check if refresh() was called.
+   */
+  wasRefreshCalled(): boolean {
+    return this.refreshCalls.length > 0;
+  }
+
+  /**
+   * Reset all state.
+   */
+  reset(): void {
+    this.executeCalls = [];
+    this.refreshCalls = [];
+    this.configuredResult = { stdout: "", stderr: "" };
+    this.shouldFail = false;
+    this.failureError = null;
+  }
+}

--- a/test/fakes/FakeObserveScreen.ts
+++ b/test/fakes/FakeObserveScreen.ts
@@ -1,11 +1,11 @@
 import { ObserveResult } from "../../src/models";
-import { ObserveScreenLike } from "../../src/features/action/SwipeOn";
+import type { ObserveScreen } from "../../src/features/observe/interfaces/ObserveScreen";
 
 /**
  * Fake implementation of ObserveScreen for testing
  * Allows configuring observation responses and asserting method calls
  */
-export class FakeObserveScreen implements ObserveScreenLike {
+export class FakeObserveScreen implements ObserveScreen {
   private executedOperations: string[] = [];
   private configuredObserveResult: ObserveResult | null = null;
   private observeResultFactory: (() => ObserveResult) | null = null;

--- a/test/fakes/FakePredictiveUIState.ts
+++ b/test/fakes/FakePredictiveUIState.ts
@@ -1,0 +1,74 @@
+import type { PredictiveUIState } from "../../src/features/observe/interfaces/PredictiveUIState";
+import type { ObserveResult, Predictions } from "../../src/models";
+
+/**
+ * Fake implementation of PredictiveUIState for testing.
+ * Returns configurable responses and records all calls.
+ */
+export class FakePredictiveUIState implements PredictiveUIState {
+  private calls: { result: ObserveResult }[] = [];
+  private configuredPredictions: Predictions | undefined = undefined;
+  private shouldFail = false;
+  private failureError: Error | null = null;
+
+  /**
+   * Generate predictions (fake implementation).
+   */
+  async generate(result: ObserveResult): Promise<Predictions | undefined> {
+    if (this.shouldFail && this.failureError) {
+      throw this.failureError;
+    }
+
+    this.calls.push({ result });
+    return this.configuredPredictions;
+  }
+
+  // Test helpers
+
+  /**
+   * Configure the predictions to return.
+   */
+  configurePredictions(predictions: Predictions | undefined): void {
+    this.configuredPredictions = predictions;
+  }
+
+  /**
+   * Configure to throw an error on generate().
+   */
+  setFailure(error: Error): void {
+    this.shouldFail = true;
+    this.failureError = error;
+  }
+
+  /**
+   * Clear failure configuration.
+   */
+  clearFailure(): void {
+    this.shouldFail = false;
+    this.failureError = null;
+  }
+
+  /**
+   * Get the number of generate() calls.
+   */
+  getCallCount(): number {
+    return this.calls.length;
+  }
+
+  /**
+   * Check if generate() was called.
+   */
+  wasCalled(): boolean {
+    return this.calls.length > 0;
+  }
+
+  /**
+   * Reset all state.
+   */
+  reset(): void {
+    this.calls = [];
+    this.configuredPredictions = undefined;
+    this.shouldFail = false;
+    this.failureError = null;
+  }
+}

--- a/test/fakes/FakeScreenSize.ts
+++ b/test/fakes/FakeScreenSize.ts
@@ -1,0 +1,74 @@
+import type { ScreenSize } from "../../src/features/observe/interfaces/ScreenSize";
+import type { ScreenSize as ScreenSizeModel, ExecResult } from "../../src/models";
+
+/**
+ * Fake implementation of ScreenSize for testing.
+ * Returns configurable responses and records all calls.
+ */
+export class FakeScreenSize implements ScreenSize {
+  private calls: { dumpsysResult?: ExecResult }[] = [];
+  private configuredScreenSize: ScreenSizeModel = { width: 1080, height: 1920 };
+  private shouldFail = false;
+  private failureError: Error | null = null;
+
+  /**
+   * Get the screen size (fake implementation).
+   */
+  async execute(dumpsysResult?: ExecResult): Promise<ScreenSizeModel> {
+    if (this.shouldFail && this.failureError) {
+      throw this.failureError;
+    }
+
+    this.calls.push({ dumpsysResult });
+    return { ...this.configuredScreenSize };
+  }
+
+  // Test helpers
+
+  /**
+   * Configure the screen size to return.
+   */
+  configureScreenSize(size: ScreenSizeModel): void {
+    this.configuredScreenSize = size;
+  }
+
+  /**
+   * Configure to throw an error on execute().
+   */
+  setFailure(error: Error): void {
+    this.shouldFail = true;
+    this.failureError = error;
+  }
+
+  /**
+   * Clear failure configuration.
+   */
+  clearFailure(): void {
+    this.shouldFail = false;
+    this.failureError = null;
+  }
+
+  /**
+   * Get the number of execute() calls.
+   */
+  getCallCount(): number {
+    return this.calls.length;
+  }
+
+  /**
+   * Check if execute() was called.
+   */
+  wasCalled(): boolean {
+    return this.calls.length > 0;
+  }
+
+  /**
+   * Reset all state.
+   */
+  reset(): void {
+    this.calls = [];
+    this.configuredScreenSize = { width: 1080, height: 1920 };
+    this.shouldFail = false;
+    this.failureError = null;
+  }
+}

--- a/test/fakes/FakeSetUIStateDependencies.ts
+++ b/test/fakes/FakeSetUIStateDependencies.ts
@@ -5,6 +5,7 @@ import { ClearTextResult } from "../../src/models/ClearTextResult";
 import { SwipeOnResult } from "../../src/models/SwipeOnResult";
 import { FieldType } from "../../src/models/SetUIStateResult";
 import { FieldTypeDetector } from "../../src/features/action/FieldTypeDetector";
+import type { ObserveScreen } from "../../src/features/observe/interfaces/ObserveScreen";
 
 /**
  * Interface for TapOnElement dependency
@@ -39,19 +40,6 @@ export interface SwipeOnLike {
     options: { direction: string; lookFor?: { text?: string; elementId?: string } },
     progress?: any
   ): Promise<SwipeOnResult>;
-}
-
-/**
- * Interface for ObserveScreen dependency
- */
-export interface ObserveScreenLike {
-  execute(
-    queryOptions?: any,
-    perf?: any,
-    skipWaitForFresh?: boolean,
-    minTimestamp?: number,
-    signal?: AbortSignal
-  ): Promise<ObserveResult>;
 }
 
 /**
@@ -251,7 +239,7 @@ export class FakeSwipeOn implements SwipeOnLike {
 /**
  * Fake ObserveScreen for testing SetUIState
  */
-export class FakeObserveScreenForSetUIState implements ObserveScreenLike {
+export class FakeObserveScreenForSetUIState implements ObserveScreen {
   private result: ObserveResult;
   private callCount: number = 0;
   private resultFactory: (() => ObserveResult) | null = null;
@@ -300,6 +288,13 @@ export class FakeObserveScreenForSetUIState implements ObserveScreenLike {
 
   getCallCount(): number {
     return this.callCount;
+  }
+
+  async getMostRecentCachedObserveResult(): Promise<ObserveResult> {
+    if (this.resultFactory) {
+      return this.resultFactory();
+    }
+    return this.result;
   }
 
   reset(): void {

--- a/test/fakes/FakeSystemInsets.ts
+++ b/test/fakes/FakeSystemInsets.ts
@@ -1,0 +1,74 @@
+import type { SystemInsets } from "../../src/features/observe/interfaces/SystemInsets";
+import type { SystemInsets as SystemInsetsModel, ExecResult } from "../../src/models";
+
+/**
+ * Fake implementation of SystemInsets for testing.
+ * Returns configurable responses and records all calls.
+ */
+export class FakeSystemInsets implements SystemInsets {
+  private calls: { dumpsysWindow: ExecResult }[] = [];
+  private configuredInsets: SystemInsetsModel = { top: 0, right: 0, bottom: 0, left: 0 };
+  private shouldFail = false;
+  private failureError: Error | null = null;
+
+  /**
+   * Get the system insets (fake implementation).
+   */
+  async execute(dumpsysWindow: ExecResult): Promise<SystemInsetsModel> {
+    if (this.shouldFail && this.failureError) {
+      throw this.failureError;
+    }
+
+    this.calls.push({ dumpsysWindow });
+    return { ...this.configuredInsets };
+  }
+
+  // Test helpers
+
+  /**
+   * Configure the system insets to return.
+   */
+  configureInsets(insets: SystemInsetsModel): void {
+    this.configuredInsets = insets;
+  }
+
+  /**
+   * Configure to throw an error on execute().
+   */
+  setFailure(error: Error): void {
+    this.shouldFail = true;
+    this.failureError = error;
+  }
+
+  /**
+   * Clear failure configuration.
+   */
+  clearFailure(): void {
+    this.shouldFail = false;
+    this.failureError = null;
+  }
+
+  /**
+   * Get the number of execute() calls.
+   */
+  getCallCount(): number {
+    return this.calls.length;
+  }
+
+  /**
+   * Check if execute() was called.
+   */
+  wasCalled(): boolean {
+    return this.calls.length > 0;
+  }
+
+  /**
+   * Reset all state.
+   */
+  reset(): void {
+    this.calls = [];
+    this.configuredInsets = { top: 0, right: 0, bottom: 0, left: 0 };
+    this.shouldFail = false;
+    this.failureError = null;
+  }
+}

--- a/test/fakes/FakeViewHierarchy.ts
+++ b/test/fakes/FakeViewHierarchy.ts
@@ -1,0 +1,131 @@
+import type { ViewHierarchy } from "../../src/features/observe/interfaces/ViewHierarchy";
+import type { Element, ViewHierarchyResult } from "../../src/models";
+
+/**
+ * Fake implementation of ViewHierarchy for testing.
+ * Returns configurable responses and records all calls.
+ */
+export class FakeViewHierarchy implements ViewHierarchy {
+  private calls: { skipWaitForFresh?: boolean; minTimestamp?: number }[] = [];
+  private configuredHierarchy: ViewHierarchyResult = { hierarchy: {} };
+  private configuredFocusedElement: Element | null = null;
+  private configuredAccessibilityFocusedElement: Element | null = null;
+  private shouldFail = false;
+  private failureError: Error | null = null;
+
+  /**
+   * Get the view hierarchy (fake implementation).
+   */
+  async getViewHierarchy(
+    _queryOptions?: any,
+    _perf?: any,
+    skipWaitForFresh?: boolean,
+    minTimestamp?: number,
+    _signal?: AbortSignal
+  ): Promise<ViewHierarchyResult> {
+    if (this.shouldFail && this.failureError) {
+      throw this.failureError;
+    }
+
+    this.calls.push({ skipWaitForFresh, minTimestamp });
+    return { ...this.configuredHierarchy };
+  }
+
+  /**
+   * Configure recomposition tracking (fake implementation - no-op).
+   */
+  async configureRecompositionTracking(_enabled: boolean, _perf?: any): Promise<void> {
+    // No-op for testing
+  }
+
+  /**
+   * Find focused element (fake implementation).
+   */
+  findFocusedElement(_viewHierarchy: any): Element | null {
+    return this.configuredFocusedElement;
+  }
+
+  /**
+   * Find accessibility-focused element (fake implementation).
+   */
+  findAccessibilityFocusedElement(_viewHierarchy: any): Element | null {
+    return this.configuredAccessibilityFocusedElement;
+  }
+
+  /**
+   * Filter offscreen nodes (fake implementation - returns input unchanged).
+   */
+  filterOffscreenNodes(
+    viewHierarchy: any,
+    _screenWidth: number,
+    _screenHeight: number,
+    _margin?: number
+  ): any {
+    return viewHierarchy;
+  }
+
+  // Test helpers
+
+  /**
+   * Configure the view hierarchy to return.
+   */
+  configureHierarchy(hierarchy: ViewHierarchyResult): void {
+    this.configuredHierarchy = hierarchy;
+  }
+
+  /**
+   * Configure the focused element to return.
+   */
+  configureFocusedElement(element: Element | null): void {
+    this.configuredFocusedElement = element;
+  }
+
+  /**
+   * Configure the accessibility-focused element to return.
+   */
+  configureAccessibilityFocusedElement(element: Element | null): void {
+    this.configuredAccessibilityFocusedElement = element;
+  }
+
+  /**
+   * Configure to throw an error on getViewHierarchy().
+   */
+  setFailure(error: Error): void {
+    this.shouldFail = true;
+    this.failureError = error;
+  }
+
+  /**
+   * Clear failure configuration.
+   */
+  clearFailure(): void {
+    this.shouldFail = false;
+    this.failureError = null;
+  }
+
+  /**
+   * Get the number of getViewHierarchy() calls.
+   */
+  getCallCount(): number {
+    return this.calls.length;
+  }
+
+  /**
+   * Check if getViewHierarchy() was called.
+   */
+  wasCalled(): boolean {
+    return this.calls.length > 0;
+  }
+
+  /**
+   * Reset all state.
+   */
+  reset(): void {
+    this.calls = [];
+    this.configuredHierarchy = { hierarchy: {} };
+    this.configuredFocusedElement = null;
+    this.configuredAccessibilityFocusedElement = null;
+    this.shouldFail = false;
+    this.failureError = null;
+  }
+}

--- a/test/fakes/FakeWindow.ts
+++ b/test/fakes/FakeWindow.ts
@@ -1,28 +1,37 @@
 import { ActiveWindow } from "../../src/models";
+import type { Window } from "../../src/features/observe/interfaces/Window";
 
 /**
  * Fake implementation of Window for testing
  * Allows configuring window responses and asserting method calls
  */
-export class FakeWindow {
+export class FakeWindow implements Window {
   private executedOperations: string[] = [];
   private configuredCachedActiveWindow: ActiveWindow | null = null;
   private configuredActiveWindow: ActiveWindow | null = null;
   private cachedActiveWindowCallCount: number = 0;
   private getActiveCallCount: number = 0;
+  private configuredActiveHash: string = "fake-active-hash";
 
   /**
-   * Set the cached active window to be returned by getCachedActiveWindow
+   * Configure the cached active window to be returned by getCachedActiveWindow
    */
-  setCachedActiveWindow(window: ActiveWindow | null): void {
+  configureCachedActiveWindow(window: ActiveWindow | null): void {
     this.configuredCachedActiveWindow = window;
   }
 
   /**
-   * Set the active window to be returned by getActive
+   * Configure the active window to be returned by getActive
    */
-  setActiveWindow(window: ActiveWindow): void {
+  configureActiveWindow(window: ActiveWindow): void {
     this.configuredActiveWindow = window;
+  }
+
+  /**
+   * Configure the active hash to be returned by getActiveHash
+   */
+  configureActiveHash(hash: string): void {
+    this.configuredActiveHash = hash;
   }
 
   /**
@@ -84,5 +93,20 @@ export class FakeWindow {
       throw new Error("No active window configured");
     }
     return this.configuredActiveWindow;
+  }
+
+  async getActiveHash(): Promise<string> {
+    this.executedOperations.push("getActiveHash");
+    return this.configuredActiveHash;
+  }
+
+  async setCachedActiveWindow(activeWindow: ActiveWindow): Promise<void> {
+    this.executedOperations.push("setCachedActiveWindow");
+    this.configuredCachedActiveWindow = activeWindow;
+  }
+
+  async clearCache(): Promise<void> {
+    this.executedOperations.push("clearCache");
+    this.configuredCachedActiveWindow = null;
   }
 }

--- a/test/features/action/BiometricAuth.test.ts
+++ b/test/features/action/BiometricAuth.test.ts
@@ -41,8 +41,8 @@ describe("BiometricAuth", () => {
     } as BootedDevice;
 
     // Set up default fake responses
-    fakeWindow.setCachedActiveWindow(null);
-    fakeWindow.setActiveWindow({ appId: "com.test.app", activityName: "MainActivity", layoutSeqSum: 123 });
+    fakeWindow.configureCachedActiveWindow(null);
+    fakeWindow.configureActiveWindow({ appId: "com.test.app", activityName: "MainActivity", layoutSeqSum: 123 });
     fakeObserveScreen.setObserveResult(() => createObserveResult());
 
     // Set up emulator detection (device is an emulator)

--- a/test/features/action/DragAndDrop.test.ts
+++ b/test/features/action/DragAndDrop.test.ts
@@ -69,8 +69,8 @@ describe("DragAndDrop", () => {
     fakeTimer.enableAutoAdvance();
 
     fakeObserveScreen.setObserveResult(() => createObserveResult());
-    fakeWindow.setCachedActiveWindow(null);
-    fakeWindow.setActiveWindow({ appId: "com.test.app", activityName: "MainActivity", layoutSeqSum: 123 });
+    fakeWindow.configureCachedActiveWindow(null);
+    fakeWindow.configureActiveWindow({ appId: "com.test.app", activityName: "MainActivity", layoutSeqSum: 123 });
 
     managerSpy = spyOn(AndroidAccessibilityServiceManager, "getInstance").mockReturnValue({
       isAvailable: async () => true

--- a/test/features/action/HandleIntentChooser.test.ts
+++ b/test/features/action/HandleIntentChooser.test.ts
@@ -55,8 +55,8 @@ describe("HandleIntentChooser", () => {
     fakeAwaitIdle = new FakeAwaitIdle();
 
     // Set up default fake responses
-    fakeWindow.setCachedActiveWindow(null);
-    fakeWindow.setActiveWindow({ appId: "com.test.app", activityName: "MainActivity", layoutSeqSum: 123 });
+    fakeWindow.configureCachedActiveWindow(null);
+    fakeWindow.configureActiveWindow({ appId: "com.test.app", activityName: "MainActivity", layoutSeqSum: 123 });
     fakeObserveScreen.setObserveResult(mockObserveResult);
 
     // Set default intent chooser to detected

--- a/test/features/action/HomeScreen.test.ts
+++ b/test/features/action/HomeScreen.test.ts
@@ -35,8 +35,8 @@ describe("HomeScreen", () => {
     fakeAwaitIdle = new FakeAwaitIdle();
 
     // Set up default fake responses
-    fakeWindow.setCachedActiveWindow(null);
-    fakeWindow.setActiveWindow({ appId: "com.test.app", activityName: "MainActivity", layoutSeqSum: 123 });
+    fakeWindow.configureCachedActiveWindow(null);
+    fakeWindow.configureActiveWindow({ appId: "com.test.app", activityName: "MainActivity", layoutSeqSum: 123 });
 
     // Set up default observe screen responses with valid viewHierarchy
     // We need to set different results to simulate screen change
@@ -144,8 +144,8 @@ describe("HomeScreen", () => {
       const fakeObserveScreen2 = new FakeObserveScreen();
       const fakeAwaitIdle2 = new FakeAwaitIdle();
 
-      fakeWindow2.setCachedActiveWindow(null);
-      fakeWindow2.setActiveWindow({ appId: "com.test.app", activityName: "MainActivity", layoutSeqSum: 123 });
+      fakeWindow2.configureCachedActiveWindow(null);
+      fakeWindow2.configureActiveWindow({ appId: "com.test.app", activityName: "MainActivity", layoutSeqSum: 123 });
       fakeObserveScreen2.setObserveResult(() => createObserveResult());
 
       (homeScreen2 as any).observeScreen = fakeObserveScreen2;

--- a/test/features/action/ImeAction.test.ts
+++ b/test/features/action/ImeAction.test.ts
@@ -35,8 +35,8 @@ describe("ImeAction", () => {
     fakeTimer.enableAutoAdvance();
 
     // Set up default fake responses
-    fakeWindow.setCachedActiveWindow(null);
-    fakeWindow.setActiveWindow({ appId: "com.test.app", activityName: "MainActivity", layoutSeqSum: 123 });
+    fakeWindow.configureCachedActiveWindow(null);
+    fakeWindow.configureActiveWindow({ appId: "com.test.app", activityName: "MainActivity", layoutSeqSum: 123 });
 
     // Set up default observe screen responses with valid viewHierarchy
     // Use factory to generate new results on each call for change detection

--- a/test/features/action/LaunchApp.test.ts
+++ b/test/features/action/LaunchApp.test.ts
@@ -47,8 +47,8 @@ describe("LaunchApp", () => {
     fakeWindow = new FakeWindow();
 
     fakeObserveScreen.setObserveResult(createObserveResult());
-    fakeWindow.setCachedActiveWindow(null);
-    fakeWindow.setActiveWindow({ appId: packageName, activityName: "MainActivity", layoutSeqSum: 1 });
+    fakeWindow.configureCachedActiveWindow(null);
+    fakeWindow.configureActiveWindow({ appId: packageName, activityName: "MainActivity", layoutSeqSum: 1 });
 
     launchApp = new LaunchApp(device, fakeAdb as unknown as any, null, fakeTimer);
     (launchApp as any).awaitIdle = fakeAwaitIdle;
@@ -221,7 +221,7 @@ describe("LaunchApp", () => {
     iosFakeObserveScreen.setObserveResult(iosObserveResult);
     const iosFakeAwaitIdle = new FakeAwaitIdle();
     const iosFakeWindow = new FakeWindow();
-    iosFakeWindow.setCachedActiveWindow({ appId: systemBundleId, activityName: "Main", layoutSeqSum: 1 });
+    iosFakeWindow.configureCachedActiveWindow({ appId: systemBundleId, activityName: "Main", layoutSeqSum: 1 });
 
     const installedAppsProvider = new FakeInstalledAppsProvider(fakeTimer, {
       installedApps: []

--- a/test/features/action/PinchOn.test.ts
+++ b/test/features/action/PinchOn.test.ts
@@ -61,8 +61,8 @@ describe("PinchOn", () => {
     fakeAdb = new FakeAdbExecutor();
 
     fakeObserveScreen.setObserveResult(() => createObserveResult());
-    fakeWindow.setCachedActiveWindow(null);
-    fakeWindow.setActiveWindow({ appId: "com.test.app", activityName: "MainActivity", layoutSeqSum: 123 });
+    fakeWindow.configureCachedActiveWindow(null);
+    fakeWindow.configureActiveWindow({ appId: "com.test.app", activityName: "MainActivity", layoutSeqSum: 123 });
 
     managerSpy = spyOn(AndroidAccessibilityServiceManager, "getInstance").mockReturnValue({
       isAvailable: async () => true

--- a/test/features/action/RecentApps.test.ts
+++ b/test/features/action/RecentApps.test.ts
@@ -25,8 +25,8 @@ describe("RecentApps", () => {
     fakeTimer.enableAutoAdvance();
 
     // Configure default responses
-    fakeWindow.setCachedActiveWindow(null);
-    fakeWindow.setActiveWindow({ appId: "com.test.app", activityName: "MainActivity", layoutSeqSum: 123 });
+    fakeWindow.configureCachedActiveWindow(null);
+    fakeWindow.configureActiveWindow({ appId: "com.test.app", activityName: "MainActivity", layoutSeqSum: 123 });
 
     // Set up default factory function for observe results to create new objects each time
     // This is needed because BaseVisualChange compares object identity to detect changes

--- a/test/features/action/Rotate.test.ts
+++ b/test/features/action/Rotate.test.ts
@@ -52,8 +52,8 @@ describe("Rotate", () => {
     fakeTimer.enableAutoAdvance();
 
     // Configure default responses
-    fakeWindow.setCachedActiveWindow(null);
-    fakeWindow.setActiveWindow({ appId: "com.test.app", activityName: "MainActivity", layoutSeqSum: 123 });
+    fakeWindow.configureCachedActiveWindow(null);
+    fakeWindow.configureActiveWindow({ appId: "com.test.app", activityName: "MainActivity", layoutSeqSum: 123 });
 
     // Set up default observe screen responses with valid viewHierarchy
     // Use a factory to create different objects on each call (avoids BaseVisualChange

--- a/test/features/action/Shake.test.ts
+++ b/test/features/action/Shake.test.ts
@@ -33,8 +33,8 @@ describe("Shake", () => {
     fakeTimer.enableAutoAdvance();
 
     // Configure default responses
-    fakeWindow.setCachedActiveWindow(null);
-    fakeWindow.setActiveWindow({ appId: "com.test.app", activityName: "MainActivity", layoutSeqSum: 123 });
+    fakeWindow.configureCachedActiveWindow(null);
+    fakeWindow.configureActiveWindow({ appId: "com.test.app", activityName: "MainActivity", layoutSeqSum: 123 });
 
     // Set up default observe screen responses with valid viewHierarchy
     const defaultObserveResult = createObserveResult();

--- a/test/features/action/SwipeOn.test.ts
+++ b/test/features/action/SwipeOn.test.ts
@@ -66,7 +66,7 @@ describe("SwipeOn autoTarget", () => {
     fakeWindow = new FakeWindow();
     fakeTimer = new FakeTimer();
     fakeTimer.enableAutoAdvance();
-    fakeWindow.setCachedActiveWindow(null);
+    fakeWindow.configureCachedActiveWindow(null);
   });
 
   afterEach(() => {
@@ -193,7 +193,7 @@ describe("SwipeOn container overlays", () => {
     fakeWindow = new FakeWindow();
     fakeTimer = new FakeTimer();
     fakeTimer.enableAutoAdvance();
-    fakeWindow.setCachedActiveWindow(null);
+    fakeWindow.configureCachedActiveWindow(null);
   });
 
   afterEach(() => {
@@ -590,7 +590,7 @@ describe("SwipeOn boomerang", () => {
     fakeWindow = new FakeWindow();
     fakeTimer = new FakeTimer();
     fakeTimer.enableAutoAdvance();
-    fakeWindow.setCachedActiveWindow(null);
+    fakeWindow.configureCachedActiveWindow(null);
   });
 
   afterEach(() => {
@@ -656,7 +656,7 @@ describe("SwipeOn lookFor validation", () => {
     fakeWindow = new FakeWindow();
     fakeTimer = new FakeTimer();
     fakeTimer.enableAutoAdvance();
-    fakeWindow.setCachedActiveWindow(null);
+    fakeWindow.configureCachedActiveWindow(null);
   });
 
   afterEach(() => {

--- a/test/features/observe/DetectIntentChooser.test.ts
+++ b/test/features/observe/DetectIntentChooser.test.ts
@@ -55,8 +55,8 @@ describe("DetectIntentChooser", () => {
     fakeDeepLinkManager = new FakeDeepLinkManager();
 
     // Configure default responses
-    fakeWindow.setCachedActiveWindow(null);
-    fakeWindow.setActiveWindow({ appId: "com.test.app", activityName: "MainActivity", layoutSeqSum: 123 });
+    fakeWindow.configureCachedActiveWindow(null);
+    fakeWindow.configureActiveWindow({ appId: "com.test.app", activityName: "MainActivity", layoutSeqSum: 123 });
     fakeObserveScreen.setObserveResult(mockObserveResult);
     fakeDeepLinkManager.setDefaultIntentChooserDetected(true);
 

--- a/test/features/observe/ObserveScreen.test.ts
+++ b/test/features/observe/ObserveScreen.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeAll, beforeEach, describe, expect, test } from "bun:test";
-import { ObserveScreen } from "../../../src/features/observe/ObserveScreen";
+import { RealObserveScreen } from "../../../src/features/observe/ObserveScreen";
 import { FakeAdbExecutor } from "../../fakes/FakeAdbExecutor";
 import { ObserveResult } from "../../../src/models/ObserveResult";
 import { BootedDevice } from "../../../src/models/DeviceInfo";
@@ -7,19 +7,19 @@ import { logger } from "../../../src/utils/logger";
 
 describe("ObserveScreen", function() {
   describe("Unit Tests for Extracted Methods", function() {
-    let observeScreen: ObserveScreen;
+    let observeScreen: RealObserveScreen;
     let fakeAdb: FakeAdbExecutor;
     let mockDevice: BootedDevice;
 
     beforeAll(function() {
-      ObserveScreen.clearCache();
+      RealObserveScreen.clearCache();
       mockDevice = {
         deviceId: "test-device",
         name: "Test Device",
         platform: "android"
       };
       fakeAdb = new FakeAdbExecutor();
-      observeScreen = new ObserveScreen(mockDevice, fakeAdb);
+      observeScreen = new RealObserveScreen(mockDevice, fakeAdb);
     });
 
     test("should create base result with correct structure", function() {
@@ -118,7 +118,7 @@ describe("ObserveScreen", function() {
         platform: "android"
       };
       const fakeAdb = new FakeAdbExecutor();
-      const observeScreen = new ObserveScreen(mockDevice, fakeAdb);
+      const observeScreen = new RealObserveScreen(mockDevice, fakeAdb);
       viewHierarchy = (observeScreen as any).viewHierarchy;
     });
 
@@ -278,12 +278,12 @@ describe("ObserveScreen", function() {
 
   describe("Integration Tests", function() {
 
-    let observeScreen: ObserveScreen;
+    let observeScreen: RealObserveScreen;
     let mockDevice: BootedDevice;
 
     beforeEach(async function() {
       // Clear cache before each test to prevent interference between tests
-      ObserveScreen.clearCache();
+      RealObserveScreen.clearCache();
 
       // Skip integration tests by default - they require a real device
       // To run integration tests, set a real device ID
@@ -420,7 +420,7 @@ describe("ObserveScreen", function() {
         platform: "android"
       };
       // Pass fakeAdb to avoid creating real AdbClient
-      const invalidObserveScreen = new ObserveScreen(invalidDevice, fakeAdb as any);
+      const invalidObserveScreen = new RealObserveScreen(invalidDevice, fakeAdb as any);
 
       // Should still return a result object with error info
       const result = await invalidObserveScreen.execute();

--- a/test/features/utility/PostNotification.test.ts
+++ b/test/features/utility/PostNotification.test.ts
@@ -20,7 +20,7 @@ describe("PostNotification", () => {
 
     fakeAdb = new FakeAdbExecutor();
     fakeWindow = new FakeWindow();
-    fakeWindow.setCachedActiveWindow({
+    fakeWindow.configureCachedActiveWindow({
       appId: "com.example.app",
       activityName: "MainActivity",
       layoutSeqSum: 1

--- a/test/server/resources/read.test.ts
+++ b/test/server/resources/read.test.ts
@@ -1,6 +1,6 @@
 import { afterAll, afterEach, beforeAll, describe, expect, test } from "bun:test";
 import { McpTestFixture } from "../../fixtures/mcpTestFixture";
-import { ObserveScreen } from "../../../src/features/observe/ObserveScreen";
+import { RealObserveScreen } from "../../../src/features/observe/ObserveScreen";
 import * as fs from "fs/promises";
 import * as path from "path";
 import { z } from "zod";
@@ -52,7 +52,7 @@ describe("MCP Resources Read", () => {
 
   beforeAll(async () => {
     // Clear both in-memory and disk caches from previous tests
-    ObserveScreen.clearCache();
+    RealObserveScreen.clearCache();
 
     const cacheDir = path.join("/tmp/auto-mobile", "observe_results");
     try {
@@ -69,7 +69,7 @@ describe("MCP Resources Read", () => {
   });
 
   afterEach(() => {
-    ObserveScreen.clearCache();
+    RealObserveScreen.clearCache();
     ScreenshotJobTracker.resetTimer();
   });
 
@@ -172,12 +172,12 @@ describe("MCP Resources Read", () => {
       name: "Test Device",
       platform: "android"
     };
-    const observeScreen = new ObserveScreen(mockDevice, new FakeAdbExecutor());
+    const observeScreen = new RealObserveScreen(mockDevice, new FakeAdbExecutor());
     await observeScreen.cacheObserveResult(observeScreen.createBaseResult());
 
-    (ObserveScreen as any).latestScreenshotPath = null;
-    (ObserveScreen as any).latestScreenshotError = null;
-    (ObserveScreen as any).latestScreenshotTimestamp = null;
+    (RealObserveScreen as any).latestScreenshotPath = null;
+    (RealObserveScreen as any).latestScreenshotError = null;
+    (RealObserveScreen as any).latestScreenshotTimestamp = null;
 
     const screenshotDir = path.join("/tmp/auto-mobile", "screenshots");
     await fs.mkdir(screenshotDir, { recursive: true });
@@ -187,9 +187,9 @@ describe("MCP Resources Read", () => {
     ScreenshotJobTracker.startJob(mockDevice.deviceId, async signal => {
       return new Promise(resolve => {
         const timeoutId = fakeTimer.setTimeout(() => {
-          (ObserveScreen as any).latestScreenshotPath = screenshotPath;
-          (ObserveScreen as any).latestScreenshotError = null;
-          (ObserveScreen as any).latestScreenshotTimestamp = Date.now();
+          (RealObserveScreen as any).latestScreenshotPath = screenshotPath;
+          (RealObserveScreen as any).latestScreenshotError = null;
+          (RealObserveScreen as any).latestScreenshotTimestamp = Date.now();
           resolve({ success: true, path: screenshotPath });
         }, 25);
 


### PR DESCRIPTION
## Summary

Add interfaces for ObserveScreen and its 8 dependencies to enable proper unit testing with fakes and reduce coupling.

- Create 10 interfaces in `src/features/observe/interfaces/`: ObserveScreen, Window, AwaitIdle, ScreenSize, ViewHierarchy, DumpsysWindow, BackStack, SystemInsets, PredictiveUIState
- Rename `ObserveScreen` class to `RealObserveScreen` with dependency injection support via `ObserveScreenDependencies`
- Create 6 new fakes in `test/fakes/` following `FakeScreenshotService` pattern
- Fix `FakeAwaitIdle` return types to properly match interface signatures
- Update all consumers and tests to use new naming conventions

## Test Plan

- [x] `bun run build` compiles without errors
- [x] `bun run lint` passes
- [x] `bun test --bail` - all 1962 tests pass

Closes #1116

🤖 Generated with [Claude Code](https://claude.com/claude-code)