### PR TITLE
chore: bump @anthropic-ai/sdk to 0.72.1

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "@kaeawc/auto-mobile",
       "dependencies": {
-        "@anthropic-ai/sdk": "^0.71.2",
+        "@anthropic-ai/sdk": "^0.72.1",
         "@huggingface/transformers": "^3.8.1",
         "@modelcontextprotocol/sdk": "^1.25.2",
         "@types/js-yaml": "^4.0.9",
@@ -69,7 +69,7 @@
     "tar": "7.5.4",
   },
   "packages": {
-    "@anthropic-ai/sdk": ["@anthropic-ai/sdk@0.71.2", "", { "dependencies": { "json-schema-to-ts": "^3.1.1" }, "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" }, "optionalPeers": ["zod"], "bin": { "anthropic-ai-sdk": "bin/cli" } }, "sha512-TGNDEUuEstk/DKu0/TflXAEt+p+p/WhTlFzEnoosvbaDU2LTjm42igSdlL0VijrKpWejtOKxX0b8A7uc+XiSAQ=="],
+    "@anthropic-ai/sdk": ["@anthropic-ai/sdk@0.72.1", "", { "dependencies": { "json-schema-to-ts": "^3.1.1" }, "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" }, "optionalPeers": ["zod"], "bin": { "anthropic-ai-sdk": "bin/cli" } }, "sha512-MiUnue7qN7DvLIoYHgkedN2z05mRf2CutBzjXXY2krzOhG2r/rIfISS2uVkNLikgToB5hYIzw+xp2jdOtRkqYQ=="],
 
     "@babel/code-frame": ["@babel/code-frame@7.27.1", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.27.1", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg=="],
 

--- a/ios/XCTestRunner/Sources/XCTestRunner/AutoMobilePlanExecutor.swift
+++ b/ios/XCTestRunner/Sources/XCTestRunner/AutoMobilePlanExecutor.swift
@@ -812,8 +812,7 @@ public final class AutoMobilePlanExecutor {
                 if attempt > 0 {
                     logger.info("Retry attempt \(attempt + 1) of \(configuration.retryCount + 1)")
                 }
-                let result = try executeOnce(testMetadata: testMetadata)
-                return result
+                return try executeOnce(testMetadata: testMetadata)
             } catch {
                 lastError = error
                 let shouldRetry = shouldRetry(error: error, attempt: attempt)

--- a/ios/XCTestRunner/Sources/XCTestRunner/AutoMobileTestCase.swift
+++ b/ios/XCTestRunner/Sources/XCTestRunner/AutoMobileTestCase.swift
@@ -2,7 +2,7 @@ import Darwin
 import Foundation
 import XCTest
 
-// Module load logging - this runs when the test module is first loaded
+/// Module load logging - this runs when the test module is first loaded
 private let _moduleLoadLog: Void = {
     let line = "[XCTestRunner] Module loaded at \(Date())\n"
     fputs(line, stderr)

--- a/ios/XCTestRunner/Sources/XCTestRunner/XCTestObservationIntegration.swift
+++ b/ios/XCTestRunner/Sources/XCTestRunner/XCTestObservationIntegration.swift
@@ -129,7 +129,7 @@ public class AutoMobileTestObserver: NSObject, XCTestObservation {
     }
 }
 
-// Make TimingData Encodable for JSON export
+/// Make TimingData Encodable for JSON export
 extension AutoMobileTestObserver.TimingData: Encodable {
     enum CodingKeys: String, CodingKey {
         case testName, duration, startTime, endTime, passed

--- a/ios/XCTestRunner/Sources/XCTestRunnerTests/XCTestRunnerTests.swift
+++ b/ios/XCTestRunner/Sources/XCTestRunnerTests/XCTestRunnerTests.swift
@@ -10,8 +10,8 @@ final class XCTestRunnerTests: XCTestCase {
 
         mcpClient.queueResponse(success: true, executedSteps: 1, totalSteps: 1)
 
-        let config = AutoMobilePlanExecutor.Configuration(
-            transport: .streamableHttp(url: URL(string: "http://localhost:9000/auto-mobile/streamable")!),
+        let config = try AutoMobilePlanExecutor.Configuration(
+            transport: .streamableHttp(url: XCTUnwrap(URL(string: "http://localhost:9000/auto-mobile/streamable"))),
             planPath: "test-plan.yaml",
             retryCount: 0,
             timeoutSeconds: 5,
@@ -70,8 +70,8 @@ final class XCTestRunnerTests: XCTestCase {
         mcpClient.queueError(NSError(domain: "MCP", code: 1, userInfo: [NSLocalizedDescriptionKey: "Timeout"]))
         mcpClient.queueResponse(success: true, executedSteps: 1, totalSteps: 1)
 
-        let config = AutoMobilePlanExecutor.Configuration(
-            transport: .streamableHttp(url: URL(string: "http://localhost:9000/auto-mobile/streamable")!),
+        let config = try AutoMobilePlanExecutor.Configuration(
+            transport: .streamableHttp(url: XCTUnwrap(URL(string: "http://localhost:9000/auto-mobile/streamable"))),
             planPath: "retry-plan.yaml",
             retryCount: 1,
             timeoutSeconds: 5,
@@ -96,7 +96,7 @@ final class XCTestRunnerTests: XCTestCase {
         XCTAssertEqual(timer.sleeps, [1])
     }
 
-    func testExecutePlanStopsAfterRetries() {
+    func testExecutePlanStopsAfterRetries() throws {
         let planLoader = FakePlanLoader(content: "name: Fail Plan\nsteps:\n  - tool: observe")
         let mcpClient = FakeMCPClient()
         let timer = FakeTimer()
@@ -104,8 +104,8 @@ final class XCTestRunnerTests: XCTestCase {
         mcpClient.queueError(NSError(domain: "MCP", code: 1, userInfo: [NSLocalizedDescriptionKey: "Timeout"]))
         mcpClient.queueError(NSError(domain: "MCP", code: 1, userInfo: [NSLocalizedDescriptionKey: "Timeout"]))
 
-        let config = AutoMobilePlanExecutor.Configuration(
-            transport: .streamableHttp(url: URL(string: "http://localhost:9000/auto-mobile/streamable")!),
+        let config = try AutoMobilePlanExecutor.Configuration(
+            transport: .streamableHttp(url: XCTUnwrap(URL(string: "http://localhost:9000/auto-mobile/streamable"))),
             planPath: "fail-plan.yaml",
             retryCount: 1,
             timeoutSeconds: 5,
@@ -135,8 +135,8 @@ final class XCTestRunnerTests: XCTestCase {
 
         mcpClient.queueResponse(success: true, executedSteps: 1, totalSteps: 1)
 
-        let config = AutoMobilePlanExecutor.Configuration(
-            transport: .streamableHttp(url: URL(string: "http://localhost:9000/auto-mobile/streamable")!),
+        let config = try AutoMobilePlanExecutor.Configuration(
+            transport: .streamableHttp(url: XCTUnwrap(URL(string: "http://localhost:9000/auto-mobile/streamable"))),
             planPath: "sub-plan.yaml",
             retryCount: 0,
             timeoutSeconds: 5,
@@ -175,8 +175,8 @@ final class XCTestRunnerTests: XCTestCase {
 
         mcpClient.queueResponse(success: true, executedSteps: 1, totalSteps: 1)
 
-        let config = AutoMobilePlanExecutor.Configuration(
-            transport: .streamableHttp(url: URL(string: "http://localhost:9000/auto-mobile/streamable")!),
+        let config = try AutoMobilePlanExecutor.Configuration(
+            transport: .streamableHttp(url: XCTUnwrap(URL(string: "http://localhost:9000/auto-mobile/streamable"))),
             planPath: "platform-plan.yaml",
             retryCount: 0,
             timeoutSeconds: 5,
@@ -216,8 +216,8 @@ final class XCTestRunnerTests: XCTestCase {
 
         mcpClient.queueResponse(success: true, executedSteps: 1, totalSteps: 1)
 
-        let config = AutoMobilePlanExecutor.Configuration(
-            transport: .streamableHttp(url: URL(string: "http://localhost:9000/auto-mobile/streamable")!),
+        let config = try AutoMobilePlanExecutor.Configuration(
+            transport: .streamableHttp(url: XCTUnwrap(URL(string: "http://localhost:9000/auto-mobile/streamable"))),
             planPath: "multi-device.yaml",
             retryCount: 0,
             timeoutSeconds: 5,
@@ -248,7 +248,7 @@ final class XCTestRunnerTests: XCTestCase {
         XCTAssertNotNil(observer)
     }
 
-    func testExecutePlanFailureIncludesFailedStepInfo() {
+    func testExecutePlanFailureIncludesFailedStepInfo() throws {
         let planContent = "name: Fail Plan\nsteps:\n  - tool: tapOn\n    element: Submit Button"
         let planLoader = FakePlanLoader(content: planContent)
         let mcpClient = FakeMCPClient()
@@ -267,8 +267,8 @@ final class XCTestRunnerTests: XCTestCase {
             error: "Plan execution failed"
         )
 
-        let config = AutoMobilePlanExecutor.Configuration(
-            transport: .streamableHttp(url: URL(string: "http://localhost:9000/auto-mobile/streamable")!),
+        let config = try AutoMobilePlanExecutor.Configuration(
+            transport: .streamableHttp(url: XCTUnwrap(URL(string: "http://localhost:9000/auto-mobile/streamable"))),
             planPath: "fail-plan.yaml",
             retryCount: 0,
             timeoutSeconds: 5,
@@ -300,7 +300,7 @@ final class XCTestRunnerTests: XCTestCase {
         }
     }
 
-    func testExecutePlanFailureFallsBackToErrorWhenNoFailedStep() {
+    func testExecutePlanFailureFallsBackToErrorWhenNoFailedStep() throws {
         let planContent = "name: Fail Plan\nsteps:\n  - tool: observe"
         let planLoader = FakePlanLoader(content: planContent)
         let mcpClient = FakeMCPClient()
@@ -314,8 +314,8 @@ final class XCTestRunnerTests: XCTestCase {
             error: "Connection timeout"
         )
 
-        let config = AutoMobilePlanExecutor.Configuration(
-            transport: .streamableHttp(url: URL(string: "http://localhost:9000/auto-mobile/streamable")!),
+        let config = try AutoMobilePlanExecutor.Configuration(
+            transport: .streamableHttp(url: XCTUnwrap(URL(string: "http://localhost:9000/auto-mobile/streamable"))),
             planPath: "fail-plan.yaml",
             retryCount: 0,
             timeoutSeconds: 5,

--- a/ios/XCTestService/Sources/XCTestService/ElementLocator.swift
+++ b/ios/XCTestService/Sources/XCTestService/ElementLocator.swift
@@ -829,7 +829,7 @@ public class ElementLocator: ElementLocating {
         }
 
     #else
-        // Non-iOS stub implementation
+        /// Non-iOS stub implementation
         public init() {}
 
         public func getViewHierarchy(disableAllFiltering _: Bool = false) throws -> ViewHierarchy {

--- a/ios/XCTestService/Sources/XCTestService/Fakes.swift
+++ b/ios/XCTestService/Sources/XCTestService/Fakes.swift
@@ -40,11 +40,17 @@ public class FakeElementLocator: ElementLocating {
 
     // MARK: - Assertions
 
-    public var hierarchyRequestCount: Int { getHierarchyCallCount }
+    public var hierarchyRequestCount: Int {
+        getHierarchyCallCount
+    }
 
-    public func getFindByIdHistory() -> [String] { findByIdHistory }
+    public func getFindByIdHistory() -> [String] {
+        findByIdHistory
+    }
 
-    public func getFindByTextHistory() -> [String] { findByTextHistory }
+    public func getFindByTextHistory() -> [String] {
+        findByTextHistory
+    }
 
     public func clearHistory() {
         getHierarchyCallCount = 0
@@ -167,18 +173,53 @@ public class FakeGesturePerformer: GesturePerforming {
 
     // MARK: - Assertions
 
-    public func getTapHistory() -> [TapCall] { tapHistory }
-    public func getSwipeHistory() -> [SwipeCall] { swipeHistory }
-    public func getDragHistory() -> [DragCall] { dragHistory }
-    public func getPinchHistory() -> [PinchCall] { pinchHistory }
-    public func getTypeTextHistory() -> [String] { typeTextHistory }
-    public func getSetTextHistory() -> [TextCall] { setTextHistory }
-    public func getImeActionHistory() -> [String] { imeActionHistory }
-    public func getActionHistory() -> [(action: String, resourceId: String?)] { actionHistory }
-    public func getScreenshotCallCount() -> Int { screenshotCallCount }
-    public func getPressHomeCallCount() -> Int { pressHomeCallCount }
-    public func getAppLaunchHistory() -> [String] { appLaunchHistory }
-    public func getAppTerminateHistory() -> [String] { appTerminateHistory }
+    public func getTapHistory() -> [TapCall] {
+        tapHistory
+    }
+
+    public func getSwipeHistory() -> [SwipeCall] {
+        swipeHistory
+    }
+
+    public func getDragHistory() -> [DragCall] {
+        dragHistory
+    }
+
+    public func getPinchHistory() -> [PinchCall] {
+        pinchHistory
+    }
+
+    public func getTypeTextHistory() -> [String] {
+        typeTextHistory
+    }
+
+    public func getSetTextHistory() -> [TextCall] {
+        setTextHistory
+    }
+
+    public func getImeActionHistory() -> [String] {
+        imeActionHistory
+    }
+
+    public func getActionHistory() -> [(action: String, resourceId: String?)] {
+        actionHistory
+    }
+
+    public func getScreenshotCallCount() -> Int {
+        screenshotCallCount
+    }
+
+    public func getPressHomeCallCount() -> Int {
+        pressHomeCallCount
+    }
+
+    public func getAppLaunchHistory() -> [String] {
+        appLaunchHistory
+    }
+
+    public func getAppTerminateHistory() -> [String] {
+        appTerminateHistory
+    }
 
     public func clearHistory() {
         tapHistory.removeAll()
@@ -347,9 +388,17 @@ public class FakeWebSocketServer: WebSocketServing {
 
     // MARK: - Assertions
 
-    public func getBroadcastHistory() -> [Data] { broadcastHistory }
-    public func getStartCallCount() -> Int { startCallCount }
-    public func getStopCallCount() -> Int { stopCallCount }
+    public func getBroadcastHistory() -> [Data] {
+        broadcastHistory
+    }
+
+    public func getStartCallCount() -> Int {
+        startCallCount
+    }
+
+    public func getStopCallCount() -> Int {
+        stopCallCount
+    }
 
     public func clearHistory() {
         broadcastHistory.removeAll()
@@ -359,7 +408,9 @@ public class FakeWebSocketServer: WebSocketServing {
 
     // MARK: - WebSocketServing
 
-    public var isRunning: Bool { running }
+    public var isRunning: Bool {
+        running
+    }
 
     public func start() throws {
         startCallCount += 1
@@ -414,11 +465,25 @@ public class FakePerfProvider {
 
     // MARK: - Assertions
 
-    public func getSerialHistory() -> [String] { serialHistory }
-    public func getParallelHistory() -> [String] { parallelHistory }
-    public func getOperationHistory() -> [(name: String, type: String)] { operationHistory }
-    public func getEndCallCount() -> Int { endCallCount }
-    public func getFlushCallCount() -> Int { flushCallCount }
+    public func getSerialHistory() -> [String] {
+        serialHistory
+    }
+
+    public func getParallelHistory() -> [String] {
+        parallelHistory
+    }
+
+    public func getOperationHistory() -> [(name: String, type: String)] {
+        operationHistory
+    }
+
+    public func getEndCallCount() -> Int {
+        endCallCount
+    }
+
+    public func getFlushCallCount() -> Int {
+        flushCallCount
+    }
 
     public func clearHistory() {
         serialHistory.removeAll()

--- a/ios/XCTestService/Sources/XCTestService/GesturePerformer.swift
+++ b/ios/XCTestService/Sources/XCTestService/GesturePerformer.swift
@@ -366,7 +366,7 @@ public class GesturePerformer: GesturePerforming {
         }
 
     #else
-        // Non-iOS stub implementation
+        /// Non-iOS stub implementation
         private let elementLocator: ElementLocating
 
         public init(elementLocator: ElementLocating) {

--- a/ios/XCTestService/Sources/XCTestService/Models.swift
+++ b/ios/XCTestService/Sources/XCTestService/Models.swift
@@ -388,10 +388,21 @@ public struct ElementBounds: Codable {
         self.bottom = bottom
     }
 
-    public var width: Int { right - left }
-    public var height: Int { bottom - top }
-    public var centerX: Int { left + width / 2 }
-    public var centerY: Int { top + height / 2 }
+    public var width: Int {
+        right - left
+    }
+
+    public var height: Int {
+        bottom - top
+    }
+
+    public var centerX: Int {
+        left + width / 2
+    }
+
+    public var centerY: Int {
+        top + height / 2
+    }
 }
 
 // MARK: - Screenshot Response
@@ -533,7 +544,7 @@ public enum RequestType: String {
     case requestAction = "request_action"
     case requestLaunchApp = "request_launch_app"
 
-    // Clipboard
+    /// Clipboard
     case requestClipboard = "request_clipboard"
 
     // Accessibility features

--- a/ios/XCTestService/Sources/XCTestService/PerfProvider.swift
+++ b/ios/XCTestService/Sources/XCTestService/PerfProvider.swift
@@ -112,14 +112,14 @@ public class FakeTimer: Timer, @unchecked Sendable {
         return currentTime
     }
 
-    // Helper to update time in a thread-safe manner (called from non-async contexts)
+    /// Helper to update time in a thread-safe manner (called from non-async contexts)
     private func incrementTime(by milliseconds: Int64) {
         lock.lock()
         currentTime += milliseconds
         lock.unlock()
     }
 
-    // Helper to add a waiter (called from withCheckedContinuation)
+    /// Helper to add a waiter (called from withCheckedContinuation)
     private func addWaiter(_ continuation: CheckedContinuation<Void, Never>) {
         lock.lock()
         pendingWaiters.append(continuation)
@@ -294,13 +294,13 @@ public class PerfProvider {
     private let timeProvider: TimeProvider
     private let lock = NSLock()
 
-    // Stack of active timing entries (for nested operations)
+    /// Stack of active timing entries (for nested operations)
     private var entryStack: [MutablePerfEntry] = []
 
-    // Root entries that have been completed
+    /// Root entries that have been completed
     private var completedEntries: [MutablePerfEntry] = []
 
-    // Current active root entry
+    /// Current active root entry
     private var currentRoot: MutablePerfEntry?
 
     // Debounce tracking

--- a/ios/XCTestService/Sources/XCTestService/PerformanceMetrics.swift
+++ b/ios/XCTestService/Sources/XCTestService/PerformanceMetrics.swift
@@ -95,7 +95,7 @@ public class NoOpPerformanceMetricsProvider: PerformanceMetricsProvider {
         return nil
     }
 
-    public func startMonitoring(callback: @escaping @Sendable (PerformanceSnapshot) -> Void) {
+    public func startMonitoring(callback _: @escaping @Sendable (PerformanceSnapshot) -> Void) {
         lock.lock()
         defer { lock.unlock() }
         // No-op: Set flag but don't actually monitor
@@ -175,7 +175,9 @@ public class FakePerformanceMetricsProvider: PerformanceMetricsProvider {
     }
 
     /// Helper to get monitoring state synchronously.
-    private func getMonitoringState() -> (isMonitoring: Bool, callback: (@Sendable (PerformanceSnapshot) -> Void)?, intervalMs: Int64) {
+    private func getMonitoringState()
+        -> (isMonitoring: Bool, callback: (@Sendable (PerformanceSnapshot) -> Void)?, intervalMs: Int64)
+    {
         lock.lock()
         let monitoring = _isMonitoring
         let cb = monitoringCallback

--- a/ios/XCTestService/Tests/XCTestServiceTests/ModelsTests.swift
+++ b/ios/XCTestService/Tests/XCTestServiceTests/ModelsTests.swift
@@ -55,7 +55,7 @@ final class ModelsTests: XCTestCase {
         }
         """
 
-        let request = try JSONDecoder().decode(WebSocketRequest.self, from: json.data(using: .utf8)!)
+        let request = try JSONDecoder().decode(WebSocketRequest.self, from: XCTUnwrap(json.data(using: .utf8)))
 
         XCTAssertEqual(request.type, "request_tap_coordinates")
         XCTAssertEqual(request.requestId, "req-123")
@@ -76,7 +76,7 @@ final class ModelsTests: XCTestCase {
         }
         """
 
-        let request = try JSONDecoder().decode(WebSocketRequest.self, from: json.data(using: .utf8)!)
+        let request = try JSONDecoder().decode(WebSocketRequest.self, from: XCTUnwrap(json.data(using: .utf8)))
 
         XCTAssertEqual(request.type, "request_swipe")
         XCTAssertEqual(request.x1, 100)
@@ -100,7 +100,7 @@ final class ModelsTests: XCTestCase {
         }
         """
 
-        let request = try JSONDecoder().decode(WebSocketRequest.self, from: json.data(using: .utf8)!)
+        let request = try JSONDecoder().decode(WebSocketRequest.self, from: XCTUnwrap(json.data(using: .utf8)))
 
         XCTAssertEqual(request.type, "request_drag")
         XCTAssertEqual(request.pressDurationMs, 600)
@@ -110,7 +110,7 @@ final class ModelsTests: XCTestCase {
 
     // MARK: - WebSocketResponse Tests
 
-    func testWebSocketResponseSuccess() throws {
+    func testWebSocketResponseSuccess() {
         let response = WebSocketResponse.success(
             type: "tap_coordinates_result",
             requestId: "req-123",
@@ -124,7 +124,7 @@ final class ModelsTests: XCTestCase {
         XCTAssertNil(response.error)
     }
 
-    func testWebSocketResponseError() throws {
+    func testWebSocketResponseError() {
         let response = WebSocketResponse.error(
             type: "tap_coordinates_result",
             requestId: "req-123",
@@ -226,7 +226,7 @@ final class ModelsTests: XCTestCase {
         }
         """
 
-        let element = try JSONDecoder().decode(UIElementInfo.self, from: json.data(using: .utf8)!)
+        let element = try JSONDecoder().decode(UIElementInfo.self, from: XCTUnwrap(json.data(using: .utf8)))
 
         XCTAssertEqual(element.text, "Label")
         XCTAssertEqual(element.contentDesc, "Description")

--- a/ios/XCTestService/Tests/XCTestServiceTests/PerfProviderTests.swift
+++ b/ios/XCTestService/Tests/XCTestServiceTests/PerfProviderTests.swift
@@ -5,7 +5,9 @@ import XCTest
 /// about mutation of captured variables.
 private final class Box<T>: @unchecked Sendable {
     var value: T
-    init(_ value: T) { self.value = value }
+    init(_ value: T) {
+        self.value = value
+    }
 }
 
 final class PerfProviderTests: XCTestCase {

--- a/ios/XcodeCompanion/Sources/AutoMobileCompanion/Views/ContentView.swift
+++ b/ios/XcodeCompanion/Sources/AutoMobileCompanion/Views/ContentView.swift
@@ -27,7 +27,9 @@ enum SidebarTab: String, CaseIterable, Identifiable {
     case performance = "Performance"
     case flags = "Feature Flags"
 
-    var id: String { rawValue }
+    var id: String {
+        rawValue
+    }
 
     var icon: String {
         switch self {

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@anthropic-ai/sdk": "^0.71.2",
+    "@anthropic-ai/sdk": "^0.72.1",
     "@huggingface/transformers": "^3.8.1",
     "@modelcontextprotocol/sdk": "^1.25.2",
     "@types/js-yaml": "^4.0.9",


### PR DESCRIPTION
## Summary
- Bump `@anthropic-ai/sdk` from 0.71.2 to 0.72.1 (used for Claude Vision API in ClaudeVisionClient)
- Apply SwiftFormat auto-fixes across iOS codebase

## Test Plan
- [x] TypeScript lint passes
- [x] TypeScript build passes
- [x] Swift build passes
- [x] SwiftFormat validation passes
- [x] SwiftLint validation passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)