### PR TITLE
refactor: extract TalkBackTapStrategy from TapOnElement

### DIFF
--- a/src/features/action/TapOnElement.ts
+++ b/src/features/action/TapOnElement.ts
@@ -31,11 +31,26 @@ import { NodeCryptoService } from "../../utils/crypto";
 import { ViewHierarchy } from "../observe/ViewHierarchy";
 import { serverConfig } from "../../utils/ServerConfig";
 import { attachRawViewHierarchy } from "../../utils/viewHierarchySearch";
-import { FocusNavigationExecutor } from "../talkback/FocusNavigationExecutor";
-import { FocusPathCalculator } from "../talkback/FocusPathCalculator";
-import { FocusElementMatcher } from "../talkback/FocusElementMatcher";
+import { TalkBackTapStrategy } from "../talkback/TalkBackTapStrategy";
+import {
+  DefaultTalkBackNavigationDriverFactory,
+  type TalkBackNavigationDriverFactory
+} from "../talkback/TalkBackNavigationDriver";
 
 type SearchUntilStats = NonNullable<TapOnElementResult["searchUntil"]>;
+
+/**
+ * Dependencies for TapOnElement that can be injected for testing.
+ */
+export interface TapOnElementDependencies {
+  visionConfig?: VisionFallbackConfig;
+  selectionStateTracker?: SelectionStateTracker;
+  accessibilityDetector?: AccessibilityDetector;
+  timer?: Timer;
+  elementSelector?: ElementSelector;
+  talkBackStrategy?: TalkBackTapStrategy;
+  talkBackDriverFactory?: TalkBackNavigationDriverFactory;
+}
 
 /**
  * Command to tap on UI element containing specified text
@@ -49,9 +64,8 @@ export class TapOnElement extends BaseVisualChange {
   private accessibilityDetector: AccessibilityDetector;
   private elementSelector: ElementSelector;
   private viewHierarchy: ViewHierarchy;
-  private focusNavigationExecutor: FocusNavigationExecutor;
-  private focusPathCalculator: FocusPathCalculator;
-  private focusElementMatcher: FocusElementMatcher;
+  private talkBackStrategy: TalkBackTapStrategy;
+  private talkBackDriverFactory: TalkBackNavigationDriverFactory;
   private static readonly SEARCH_UNTIL_DEFAULT_MS = 500;
   private static readonly SEARCH_UNTIL_MIN_MS = 100;
   private static readonly SEARCH_UNTIL_MAX_MS = 12000;
@@ -59,33 +73,21 @@ export class TapOnElement extends BaseVisualChange {
   constructor(
     device: BootedDevice,
     adb: AdbClient | null = null,
-    visionConfig?: VisionFallbackConfig,
-    selectionStateTracker?: SelectionStateTracker,
-    accessibilityDetector?: AccessibilityDetector,
-    timer?: Timer,
-    elementSelector?: ElementSelector,
-    focusNavigationExecutor?: FocusNavigationExecutor,
-    focusPathCalculator?: FocusPathCalculator,
-    focusElementMatcher?: FocusElementMatcher
+    options: TapOnElementDependencies = {}
   ) {
-    super(device, adb, timer);
+    super(device, adb, options.timer);
     this.elementUtils = new ElementUtils();
     this.elementParser = new ElementParser();
     this.accessibilityService = AccessibilityServiceClient.getInstance(device, this.adbFactory);
-    this.visionConfig = visionConfig || DEFAULT_VISION_CONFIG;
+    this.visionConfig = options.visionConfig || DEFAULT_VISION_CONFIG;
     this.viewHierarchy = new ViewHierarchy(device, this.adbFactory);
-    this.selectionStateTracker = selectionStateTracker ?? new SelectionStateTracker({
+    this.selectionStateTracker = options.selectionStateTracker ?? new SelectionStateTracker({
       screenshotCapturer: new TakeScreenshotCapturer(device, this.adbFactory)
     });
-    this.accessibilityDetector = accessibilityDetector || defaultAccessibilityDetector;
-    this.elementSelector = elementSelector ?? new DefaultElementSelector();
-    this.focusElementMatcher = focusElementMatcher ?? new FocusElementMatcher();
-    this.focusPathCalculator = focusPathCalculator ?? new FocusPathCalculator(this.focusElementMatcher);
-    this.focusNavigationExecutor = focusNavigationExecutor ?? new FocusNavigationExecutor({
-      matcher: this.focusElementMatcher,
-      pathCalculator: this.focusPathCalculator,
-      timer: this.timer
-    });
+    this.accessibilityDetector = options.accessibilityDetector || defaultAccessibilityDetector;
+    this.elementSelector = options.elementSelector ?? new DefaultElementSelector();
+    this.talkBackStrategy = options.talkBackStrategy ?? new TalkBackTapStrategy({ timer: this.timer });
+    this.talkBackDriverFactory = options.talkBackDriverFactory ?? new DefaultTalkBackNavigationDriverFactory(this.adbFactory);
   }
 
   /**
@@ -940,7 +942,7 @@ export class TapOnElement extends BaseVisualChange {
     y: number,
     element: Element,
     durationMs: number,
-    options?: TapOnElementOptions,
+    _options?: TapOnElementOptions,
     signal?: AbortSignal
   ): Promise<void> {
     const resourceId = element?.["resource-id"];
@@ -950,164 +952,44 @@ export class TapOnElement extends BaseVisualChange {
       return;
     }
 
+    const driver = this.talkBackDriverFactory.createDriver(this.device);
+
     // Try focus navigation for tap and doubleTap actions
     // Long press still uses coordinate-based approach as it's more reliable
     if (action === "tap" || action === "doubleTap") {
-      try {
-        logger.debug(`[TapOnElement] Attempting focus navigation to element with resourceId: ${resourceId}`);
+      const result = await this.talkBackStrategy.executeTap(
+        this.device.id,
+        element,
+        action as "tap" | "doubleTap",
+        driver
+      );
 
-        // Build selector from element (include bounds for disambiguation in list views)
-        const targetSelector = {
-          resourceId,
-          text: element.text as string | undefined,
-          contentDesc: element["content-desc"] as string | undefined,
-          bounds: element.bounds
-        };
-
-        // Get traversal order and current focus
-        const traversalResult = await this.accessibilityService.requestTraversalOrder();
-        if (traversalResult.error || !traversalResult.elements) {
-          throw new Error(`Failed to get traversal order: ${traversalResult.error}`);
-        }
-
-        const orderedElements = traversalResult.elements;
-        let currentFocus: Element | null = null;
-
-        // Try to get current focus from traversal result first
-        if (traversalResult.focusedIndex !== null && traversalResult.focusedIndex !== undefined) {
-          currentFocus = orderedElements[traversalResult.focusedIndex] ?? null;
-        }
-
-        // If not available, request current focus separately
-        if (!currentFocus) {
-          const focusResult = await this.accessibilityService.requestCurrentFocus();
-          if (!focusResult.error && focusResult.focusedElement) {
-            currentFocus = focusResult.focusedElement;
-          }
-        }
-
-        // Calculate navigation path
-        const navigationPath = this.focusPathCalculator.calculatePath(
-          currentFocus,
-          targetSelector,
-          orderedElements,
-          5 // verification interval
-        );
-
-        if (!navigationPath) {
-          throw new Error("Could not calculate navigation path to target element");
-        }
-
-        logger.debug(
-          `[TapOnElement] Calculated path: ${navigationPath.swipeCount} swipes ${navigationPath.direction}`
-        );
-
-        // Navigate to element
-        const navigationSuccess = await this.focusNavigationExecutor.navigateToElement(
-          this.device.id,
-          targetSelector,
-          navigationPath,
-          {
-            maxSwipes: 100,
-            verificationInterval: 5,
-            swipeDelay: 100
-          }
-        );
-
-        if (!navigationSuccess) {
-          throw new Error("Focus navigation did not reach target element");
-        }
-
-        logger.info(`[TapOnElement] Focus navigation successful, activating element`);
-
-        // Activate the focused element with double-tap gesture
-        // In TalkBack mode, a double-tap anywhere activates the focused element
-        const tapDuration = 50;
-        const screenCenterX = Math.round(x); // Use element center for gesture
-        const screenCenterY = Math.round(y);
-
-        // Perform double-tap to activate
-        const firstTap = await this.accessibilityService.requestTapCoordinates(
-          screenCenterX,
-          screenCenterY,
-          tapDuration
-        );
-
-        if (!firstTap.success) {
-          // If double-tap fails, try ACTION_CLICK on the resource-id
-          logger.warn(`[TapOnElement] Double-tap activation failed, trying ACTION_CLICK fallback`);
-          const clickResult = await this.accessibilityService.requestAction("click", resourceId);
-          if (!clickResult.success) {
-            throw new Error(`Activation failed: double-tap and ACTION_CLICK both failed`);
-          }
-          return;
-        }
-
-        await this.timer.sleep(200);
-
-        const secondTap = await this.accessibilityService.requestTapCoordinates(
-          screenCenterX,
-          screenCenterY,
-          tapDuration
-        );
-
-        if (!secondTap.success) {
-          // If second tap fails, try ACTION_CLICK as fallback
-          logger.warn(`[TapOnElement] Second tap failed, trying ACTION_CLICK fallback`);
-          const clickResult = await this.accessibilityService.requestAction("click", resourceId);
-          if (!clickResult.success) {
-            throw new Error(`Activation failed: second tap and ACTION_CLICK both failed`);
-          }
-        }
-
-        logger.info(`[TapOnElement] Element activated successfully via focus navigation`);
+      if (result.success) {
         return;
-
-      } catch (error) {
-        logger.warn(
-          `[TapOnElement] Focus navigation failed (${error instanceof Error ? error.message : String(error)}), ` +
-          `falling back to coordinate-based tap at (${x}, ${y})`
-        );
-        // Fall through to coordinate-based fallback
       }
+
+      logger.warn(
+        `[TapOnElement] Focus navigation failed (${result.error}), ` +
+        `falling back to coordinate-based tap at (${x}, ${y})`
+      );
     }
 
     // Fallback to coordinate-based taps via accessibility service dispatchGesture
-    // This is faster than ADB and precise (uses exact coordinates, not resource-id lookup)
-    // Use short duration (50ms) for tap/doubleTap to avoid being interpreted as long press
-    const tapDuration = action === "longPress" ? durationMs : 50;
+    const fallbackAction = action as "tap" | "doubleTap" | "longPress";
+    const fallbackResult = await this.talkBackStrategy.executeCoordinateFallback(
+      x,
+      y,
+      fallbackAction,
+      durationMs,
+      driver
+    );
 
-    // For double tap, we need to perform two accessibility taps
-    if (action === "doubleTap") {
-      // First tap
-      const firstResult = await this.accessibilityService.requestTapCoordinates(x, y, tapDuration);
-      if (!firstResult.success) {
-        logger.warn(
-          `[TapOnElement] First accessibility tap failed (${firstResult.error}), falling back to full ADB double tap at (${x}, ${y})`
-        );
-        await this.executeAndroidTapWithCoordinates(action, x, y, durationMs, element, signal);
-        return;
-      }
-
-      // Wait between taps (standard double-tap interval)
-      await this.timer.sleep(200);
-
-      // Second tap
-      const secondResult = await this.accessibilityService.requestTapCoordinates(x, y, tapDuration);
-      if (!secondResult.success) {
-        logger.warn(
-          `[TapOnElement] Second accessibility tap failed (${secondResult.error}), retrying full ADB double tap at (${x}, ${y})`
-        );
-        // Retry full double tap via ADB to preserve double-tap timing
-        await this.executeAndroidTapWithCoordinates(action, x, y, durationMs, element, signal);
-      }
-    } else {
-      // For single tap or long press
-      const result = await this.accessibilityService.requestTapCoordinates(x, y, tapDuration);
-      if (!result.success) {
-        logger.warn(`[TapOnElement] Accessibility coordinate tap failed (${result.error}), falling back to ADB tap at (${x}, ${y})`);
-        await this.executeAndroidTapWithCoordinates(action, x, y, durationMs, element, signal);
-      }
+    if (!fallbackResult.success) {
+      logger.warn(
+        `[TapOnElement] Accessibility coordinate tap failed (${fallbackResult.error}), ` +
+        `falling back to ADB tap at (${x}, ${y})`
+      );
+      await this.executeAndroidTapWithCoordinates(action, x, y, durationMs, element, signal);
     }
   }
 

--- a/src/features/talkback/TalkBackNavigationDriver.ts
+++ b/src/features/talkback/TalkBackNavigationDriver.ts
@@ -1,0 +1,88 @@
+import type { BootedDevice } from "../../models";
+import type { A11yActionResult, A11yTapCoordinatesResult } from "../observe/accessibility/types";
+import { AccessibilityServiceClient } from "../observe/AccessibilityServiceClient";
+import { GetScreenSize } from "../observe/GetScreenSize";
+import { AdbClientFactory, defaultAdbClientFactory } from "../../utils/android-cmdline-tools/AdbClientFactory";
+import type { FocusNavigationDriver } from "./FocusNavigationExecutor";
+
+/**
+ * Extended driver interface for TalkBack navigation that adds tap and action capabilities.
+ * This interface is used by TalkBackTapStrategy to perform element activation after navigation.
+ */
+export interface TalkBackNavigationDriver extends FocusNavigationDriver {
+  /**
+   * Request a tap at specific coordinates via accessibility service.
+   * @param x - X coordinate
+   * @param y - Y coordinate
+   * @param durationMs - Duration of the tap in milliseconds
+   */
+  requestTapCoordinates(x: number, y: number, durationMs: number): Promise<A11yTapCoordinatesResult>;
+
+  /**
+   * Request an accessibility action on an element.
+   * @param action - The action to perform (e.g., "click", "long_click")
+   * @param resourceId - Optional resource ID of the target element
+   */
+  requestAction(action: string, resourceId?: string): Promise<A11yActionResult>;
+}
+
+/**
+ * Default implementation of TalkBackNavigationDriver using AccessibilityServiceClient.
+ */
+export class DefaultTalkBackNavigationDriver implements TalkBackNavigationDriver {
+  private accessibilityService: AccessibilityServiceClient;
+  private screenSizeProvider: GetScreenSize;
+
+  constructor(accessibilityService: AccessibilityServiceClient, screenSizeProvider: GetScreenSize) {
+    this.accessibilityService = accessibilityService;
+    this.screenSizeProvider = screenSizeProvider;
+  }
+
+  async requestTraversalOrder() {
+    return this.accessibilityService.requestTraversalOrder();
+  }
+
+  async requestCurrentFocus() {
+    return this.accessibilityService.requestCurrentFocus();
+  }
+
+  async requestSwipe(x1: number, y1: number, x2: number, y2: number, durationMs: number) {
+    return this.accessibilityService.requestSwipe(x1, y1, x2, y2, durationMs);
+  }
+
+  async getScreenSize() {
+    return this.screenSizeProvider.execute();
+  }
+
+  async requestTapCoordinates(x: number, y: number, durationMs: number): Promise<A11yTapCoordinatesResult> {
+    return this.accessibilityService.requestTapCoordinates(x, y, durationMs);
+  }
+
+  async requestAction(action: string, resourceId?: string): Promise<A11yActionResult> {
+    return this.accessibilityService.requestAction(action, resourceId);
+  }
+}
+
+/**
+ * Factory interface for creating TalkBackNavigationDriver instances.
+ */
+export interface TalkBackNavigationDriverFactory {
+  createDriver(device: BootedDevice): TalkBackNavigationDriver;
+}
+
+/**
+ * Default factory implementation for TalkBackNavigationDriver.
+ */
+export class DefaultTalkBackNavigationDriverFactory implements TalkBackNavigationDriverFactory {
+  private adbFactory: AdbClientFactory;
+
+  constructor(adbFactory: AdbClientFactory = defaultAdbClientFactory) {
+    this.adbFactory = adbFactory;
+  }
+
+  createDriver(device: BootedDevice): TalkBackNavigationDriver {
+    const accessibilityService = AccessibilityServiceClient.getInstance(device, this.adbFactory);
+    const screenSizeProvider = new GetScreenSize(device, this.adbFactory);
+    return new DefaultTalkBackNavigationDriver(accessibilityService, screenSizeProvider);
+  }
+}

--- a/src/features/talkback/TalkBackTapStrategy.ts
+++ b/src/features/talkback/TalkBackTapStrategy.ts
@@ -1,0 +1,293 @@
+import type { Element } from "../../models/Element";
+import { logger } from "../../utils/logger";
+import { defaultTimer, type Timer } from "../../utils/SystemTimer";
+import { FocusElementMatcher } from "./FocusElementMatcher";
+import { FocusNavigationExecutor } from "./FocusNavigationExecutor";
+import { FocusPathCalculator } from "./FocusPathCalculator";
+import type { TalkBackNavigationDriver } from "./TalkBackNavigationDriver";
+
+export interface TalkBackTapResult {
+  success: boolean;
+  method: "focus-navigation" | "coordinate-fallback";
+  error?: string;
+}
+
+export type TalkBackTapAction = "tap" | "doubleTap";
+export type TalkBackFallbackAction = "tap" | "doubleTap" | "longPress";
+
+interface TalkBackTapStrategyDependencies {
+  matcher?: FocusElementMatcher;
+  pathCalculator?: FocusPathCalculator;
+  executor?: FocusNavigationExecutor;
+  timer?: Timer;
+}
+
+/**
+ * Orchestrates TalkBack focus navigation and element activation.
+ *
+ * This strategy handles:
+ * 1. Focus navigation to target element using swipe gestures
+ * 2. Element activation via double-tap or ACTION_CLICK fallback
+ * 3. Coordinate-based fallback when focus navigation fails
+ */
+export class TalkBackTapStrategy {
+  private matcher: FocusElementMatcher;
+  private pathCalculator: FocusPathCalculator;
+  private executor: FocusNavigationExecutor;
+  private timer: Timer;
+
+  constructor(dependencies: TalkBackTapStrategyDependencies = {}) {
+    this.matcher = dependencies.matcher ?? new FocusElementMatcher();
+    this.pathCalculator = dependencies.pathCalculator ?? new FocusPathCalculator(this.matcher);
+    this.executor = dependencies.executor ?? new FocusNavigationExecutor({
+      matcher: this.matcher,
+      pathCalculator: this.pathCalculator,
+      timer: dependencies.timer
+    });
+    this.timer = dependencies.timer ?? defaultTimer;
+  }
+
+  /**
+   * Execute a tap on an element using TalkBack focus navigation.
+   *
+   * This method:
+   * 1. Builds a selector from the element
+   * 2. Gets the current traversal order and focus
+   * 3. Calculates a navigation path to the target
+   * 4. Navigates to the element
+   * 5. Activates it with double-tap (with ACTION_CLICK fallback)
+   *
+   * @param deviceId - The device ID
+   * @param element - The target element (must have resource-id)
+   * @param action - The action to perform ("tap" or "doubleTap")
+   * @param driver - The TalkBack navigation driver
+   * @returns Result indicating success/failure and method used
+   */
+  async executeTap(
+    deviceId: string,
+    element: Element,
+    action: TalkBackTapAction,
+    driver: TalkBackNavigationDriver
+  ): Promise<TalkBackTapResult> {
+    const resourceId = element?.["resource-id"];
+    if (!resourceId) {
+      return {
+        success: false,
+        method: "focus-navigation",
+        error: "Element has no resource-id"
+      };
+    }
+
+    try {
+      logger.debug(`[TalkBackTapStrategy] Attempting focus navigation to element with resourceId: ${resourceId}`);
+
+      // Build selector from element (include bounds for disambiguation in list views)
+      const targetSelector = {
+        resourceId,
+        text: element.text as string | undefined,
+        contentDesc: element["content-desc"] as string | undefined,
+        bounds: element.bounds
+      };
+
+      // Get traversal order and current focus
+      const traversalResult = await driver.requestTraversalOrder();
+      if (traversalResult.error || !traversalResult.elements) {
+        return {
+          success: false,
+          method: "focus-navigation",
+          error: `Failed to get traversal order: ${traversalResult.error}`
+        };
+      }
+
+      const orderedElements = traversalResult.elements;
+      let currentFocus: Element | null = null;
+
+      // Try to get current focus from traversal result first
+      if (traversalResult.focusedIndex !== null && traversalResult.focusedIndex !== undefined) {
+        currentFocus = orderedElements[traversalResult.focusedIndex] ?? null;
+      }
+
+      // If not available, request current focus separately
+      if (!currentFocus) {
+        const focusResult = await driver.requestCurrentFocus();
+        if (!focusResult.error && focusResult.focusedElement) {
+          currentFocus = focusResult.focusedElement;
+        }
+      }
+
+      // Calculate navigation path
+      const navigationPath = this.pathCalculator.calculatePath(
+        currentFocus,
+        targetSelector,
+        orderedElements,
+        5 // verification interval
+      );
+
+      if (!navigationPath) {
+        return {
+          success: false,
+          method: "focus-navigation",
+          error: "Could not calculate navigation path to target element"
+        };
+      }
+
+      logger.debug(
+        `[TalkBackTapStrategy] Calculated path: ${navigationPath.swipeCount} swipes ${navigationPath.direction}`
+      );
+
+      // Navigate to element
+      const navigationSuccess = await this.executor.navigateToElement(
+        deviceId,
+        targetSelector,
+        navigationPath,
+        {
+          maxSwipes: 100,
+          verificationInterval: 5,
+          swipeDelay: 100
+        }
+      );
+
+      if (!navigationSuccess) {
+        return {
+          success: false,
+          method: "focus-navigation",
+          error: "Focus navigation did not reach target element"
+        };
+      }
+
+      logger.info(`[TalkBackTapStrategy] Focus navigation successful, activating element`);
+
+      // Activate the focused element with double-tap gesture
+      const activationResult = await this.activateElement(element, driver);
+      return activationResult;
+
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : String(error);
+      logger.warn(`[TalkBackTapStrategy] Focus navigation failed: ${errorMessage}`);
+      return {
+        success: false,
+        method: "focus-navigation",
+        error: errorMessage
+      };
+    }
+  }
+
+  /**
+   * Execute a coordinate-based tap as a fallback when focus navigation fails or isn't applicable.
+   *
+   * @param x - X coordinate
+   * @param y - Y coordinate
+   * @param action - The action to perform
+   * @param durationMs - Duration for the tap (used for longPress)
+   * @param driver - The TalkBack navigation driver
+   * @returns Result indicating success/failure
+   */
+  async executeCoordinateFallback(
+    x: number,
+    y: number,
+    action: TalkBackFallbackAction,
+    durationMs: number,
+    driver: TalkBackNavigationDriver
+  ): Promise<TalkBackTapResult> {
+    const tapDuration = action === "longPress" ? durationMs : 50;
+
+    if (action === "doubleTap") {
+      // First tap
+      const firstResult = await driver.requestTapCoordinates(x, y, tapDuration);
+      if (!firstResult.success) {
+        return {
+          success: false,
+          method: "coordinate-fallback",
+          error: `First tap failed: ${firstResult.error}`
+        };
+      }
+
+      // Wait between taps (standard double-tap interval)
+      await this.timer.sleep(200);
+
+      // Second tap
+      const secondResult = await driver.requestTapCoordinates(x, y, tapDuration);
+      if (!secondResult.success) {
+        return {
+          success: false,
+          method: "coordinate-fallback",
+          error: `Second tap failed: ${secondResult.error}`
+        };
+      }
+
+      return { success: true, method: "coordinate-fallback" };
+    }
+
+    // Single tap or long press
+    const result = await driver.requestTapCoordinates(x, y, tapDuration);
+    if (!result.success) {
+      return {
+        success: false,
+        method: "coordinate-fallback",
+        error: result.error
+      };
+    }
+
+    return { success: true, method: "coordinate-fallback" };
+  }
+
+  /**
+   * Activate the currently focused element using double-tap with ACTION_CLICK fallback.
+   */
+  private async activateElement(
+    element: Element,
+    driver: TalkBackNavigationDriver
+  ): Promise<TalkBackTapResult> {
+    const resourceId = element["resource-id"];
+    const center = this.getElementCenter(element);
+    const tapDuration = 50;
+
+    // First tap of double-tap activation
+    const firstTap = await driver.requestTapCoordinates(center.x, center.y, tapDuration);
+
+    if (!firstTap.success) {
+      // If double-tap fails, try ACTION_CLICK on the resource-id
+      logger.warn(`[TalkBackTapStrategy] Double-tap activation failed, trying ACTION_CLICK fallback`);
+      const clickResult = await driver.requestAction("click", resourceId);
+      if (!clickResult.success) {
+        return {
+          success: false,
+          method: "focus-navigation",
+          error: `Activation failed: double-tap and ACTION_CLICK both failed`
+        };
+      }
+      return { success: true, method: "focus-navigation" };
+    }
+
+    await this.timer.sleep(200);
+
+    // Second tap
+    const secondTap = await driver.requestTapCoordinates(center.x, center.y, tapDuration);
+
+    if (!secondTap.success) {
+      // If second tap fails, try ACTION_CLICK as fallback
+      logger.warn(`[TalkBackTapStrategy] Second tap failed, trying ACTION_CLICK fallback`);
+      const clickResult = await driver.requestAction("click", resourceId);
+      if (!clickResult.success) {
+        return {
+          success: false,
+          method: "focus-navigation",
+          error: `Activation failed: second tap and ACTION_CLICK both failed`
+        };
+      }
+    }
+
+    logger.info(`[TalkBackTapStrategy] Element activated successfully via focus navigation`);
+    return { success: true, method: "focus-navigation" };
+  }
+
+  private getElementCenter(element: Element): { x: number; y: number } {
+    if (!element.bounds) {
+      return { x: 0, y: 0 };
+    }
+    return {
+      x: Math.round((element.bounds.left + element.bounds.right) / 2),
+      y: Math.round((element.bounds.top + element.bounds.bottom) / 2)
+    };
+  }
+}

--- a/test/fakes/FakeTalkBackNavigationDriver.ts
+++ b/test/fakes/FakeTalkBackNavigationDriver.ts
@@ -1,0 +1,68 @@
+import type { TalkBackNavigationDriver } from "../../src/features/talkback/TalkBackNavigationDriver";
+import type { A11yActionResult, A11yTapCoordinatesResult } from "../../src/features/observe/accessibility/types";
+import { FakeFocusNavigationDriver } from "./FakeFocusNavigationDriver";
+
+/**
+ * Fake implementation of TalkBackNavigationDriver for testing.
+ * Extends FakeFocusNavigationDriver with tap and action capabilities.
+ */
+export class FakeTalkBackNavigationDriver
+  extends FakeFocusNavigationDriver
+  implements TalkBackNavigationDriver {
+  tapResult: A11yTapCoordinatesResult = { success: true, totalTimeMs: 1 };
+  actionResult: A11yActionResult = { success: true, action: "click", totalTimeMs: 1 };
+
+  tapHistory: Array<{ x: number; y: number; durationMs: number }> = [];
+  actionHistory: Array<{ action: string; resourceId?: string }> = [];
+
+  private tapOverrides: A11yTapCoordinatesResult[] = [];
+  private actionOverrides: A11yActionResult[] = [];
+
+  setTapResult(result: A11yTapCoordinatesResult): void {
+    this.tapResult = result;
+  }
+
+  setActionResult(result: A11yActionResult): void {
+    this.actionResult = result;
+  }
+
+  queueTapResult(result: A11yTapCoordinatesResult): void {
+    this.tapOverrides.push(result);
+  }
+
+  queueActionResult(result: A11yActionResult): void {
+    this.actionOverrides.push(result);
+  }
+
+  getTapCount(): number {
+    return this.tapHistory.length;
+  }
+
+  getActionCount(): number {
+    return this.actionHistory.length;
+  }
+
+  async requestTapCoordinates(
+    x: number,
+    y: number,
+    durationMs: number
+  ): Promise<A11yTapCoordinatesResult> {
+    this.tapHistory.push({ x, y, durationMs });
+
+    if (this.tapOverrides.length > 0) {
+      return this.tapOverrides.shift()!;
+    }
+
+    return this.tapResult;
+  }
+
+  async requestAction(action: string, resourceId?: string): Promise<A11yActionResult> {
+    this.actionHistory.push({ action, resourceId });
+
+    if (this.actionOverrides.length > 0) {
+      return this.actionOverrides.shift()!;
+    }
+
+    return this.actionResult;
+  }
+}

--- a/test/fakes/FakeTalkBackTapStrategy.ts
+++ b/test/fakes/FakeTalkBackTapStrategy.ts
@@ -1,0 +1,78 @@
+import type { Element } from "../../src/models/Element";
+import type {
+  TalkBackTapResult,
+  TalkBackTapAction,
+  TalkBackFallbackAction
+} from "../../src/features/talkback/TalkBackTapStrategy";
+import type { TalkBackNavigationDriver } from "../../src/features/talkback/TalkBackNavigationDriver";
+
+/**
+ * Fake implementation of TalkBackTapStrategy for testing TapOnElement delegation.
+ */
+export class FakeTalkBackTapStrategy {
+  tapResult: TalkBackTapResult = { success: true, method: "focus-navigation" };
+  fallbackResult: TalkBackTapResult = { success: true, method: "coordinate-fallback" };
+
+  tapCalls: Array<{
+    deviceId: string;
+    element: Element;
+    action: TalkBackTapAction;
+  }> = [];
+
+  fallbackCalls: Array<{
+    x: number;
+    y: number;
+    action: TalkBackFallbackAction;
+    durationMs: number;
+  }> = [];
+
+  private tapOverrides: TalkBackTapResult[] = [];
+  private fallbackOverrides: TalkBackTapResult[] = [];
+
+  setTapResult(result: TalkBackTapResult): void {
+    this.tapResult = result;
+  }
+
+  setFallbackResult(result: TalkBackTapResult): void {
+    this.fallbackResult = result;
+  }
+
+  queueTapResult(result: TalkBackTapResult): void {
+    this.tapOverrides.push(result);
+  }
+
+  queueFallbackResult(result: TalkBackTapResult): void {
+    this.fallbackOverrides.push(result);
+  }
+
+  async executeTap(
+    deviceId: string,
+    element: Element,
+    action: TalkBackTapAction,
+    _driver: TalkBackNavigationDriver
+  ): Promise<TalkBackTapResult> {
+    this.tapCalls.push({ deviceId, element, action });
+
+    if (this.tapOverrides.length > 0) {
+      return this.tapOverrides.shift()!;
+    }
+
+    return this.tapResult;
+  }
+
+  async executeCoordinateFallback(
+    x: number,
+    y: number,
+    action: TalkBackFallbackAction,
+    durationMs: number,
+    _driver: TalkBackNavigationDriver
+  ): Promise<TalkBackTapResult> {
+    this.fallbackCalls.push({ x, y, action, durationMs });
+
+    if (this.fallbackOverrides.length > 0) {
+      return this.fallbackOverrides.shift()!;
+    }
+
+    return this.fallbackResult;
+  }
+}

--- a/test/features/action/TapOnElement.selectedElement.test.ts
+++ b/test/features/action/TapOnElement.selectedElement.test.ts
@@ -17,12 +17,9 @@ const createTapOnElement = (): TapOnElement => {
       id: "emulator-5554",
     } as any,
     new FakeAdbClient() as any,
-    null,
-    null,
-    undefined,
-    undefined,
-    undefined,
-    new FakeTimer()
+    {
+      timer: new FakeTimer()
+    }
   );
 };
 

--- a/test/features/action/TapOnElement.selectionStrategy.test.ts
+++ b/test/features/action/TapOnElement.selectionStrategy.test.ts
@@ -16,11 +16,10 @@ describe("TapOnElement selectionStrategy", () => {
         id: "emulator-5554",
       } as any,
       new FakeAdbClient() as any,
-      undefined,       // visionConfig
-      undefined,       // selectionStateTracker
-      undefined,       // accessibilityDetector
-      new FakeTimer(),
-      fakeSelector
+      {
+        timer: new FakeTimer(),
+        elementSelector: fakeSelector
+      }
     );
 
     const result = (tapOnElement as any).findElementInHierarchy(

--- a/test/features/action/TapOnElement.talkback.test.ts
+++ b/test/features/action/TapOnElement.talkback.test.ts
@@ -3,6 +3,7 @@ import { TapOnElement } from "../../../src/features/action/TapOnElement";
 import { FakeAdbClient } from "../../fakes/FakeAdbClient";
 import { FakeAccessibilityDetector } from "../../fakes/FakeAccessibilityDetector";
 import { FakeTimer } from "../../fakes/FakeTimer";
+import { FakeTalkBackTapStrategy } from "../../fakes/FakeTalkBackTapStrategy";
 
 describe("TapOnElement TalkBack mode detection", () => {
   let fakeAccessibilityDetector: FakeAccessibilityDetector;
@@ -25,11 +26,11 @@ describe("TapOnElement TalkBack mode detection", () => {
         platform: "android",
         id: "emulator-5554",
       } as any,
-      fakeAdb as any,  // adb
-      undefined,       // visionConfig
-      undefined,       // selectionStateTracker
-      fakeAccessibilityDetector,
-      fakeTimer
+      fakeAdb as any,
+      {
+        accessibilityDetector: fakeAccessibilityDetector,
+        timer: fakeTimer
+      }
     );
 
     // Spy on the private methods to verify dispatch logic
@@ -129,7 +130,7 @@ describe("TapOnElement TalkBack mode detection", () => {
       expect(executeAndroidTapWithCoordinates).not.toHaveBeenCalled();
     });
 
-    test("passes options including focusFirst to accessibility method", async () => {
+    test("passes options to accessibility method", async () => {
       const element = {
         "bounds": { left: 0, top: 0, right: 100, bottom: 100 },
         "resource-id": "test:id/button",
@@ -232,208 +233,6 @@ describe("TapOnElement TalkBack mode detection", () => {
     });
   });
 
-  describe("executeAndroidTapWithAccessibility doubleTap behavior", () => {
-    let mockAccessibilityService: any;
-    let mockFocusNavigationExecutor: any;
-    let mockFocusPathCalculator: any;
-
-    beforeEach(() => {
-      executeAndroidTapWithAccessibility.mockRestore();
-
-      mockAccessibilityService = {
-        requestTapCoordinates: async () => ({ success: true, totalTimeMs: 1 }),
-        requestTraversalOrder: async () => ({
-          elements: [
-            { "resource-id": "test:id/button", "bounds": { left: 0, top: 0, right: 100, bottom: 100 } }
-          ],
-          focusedIndex: 0
-        }),
-        requestCurrentFocus: async () => ({
-          focusedElement: { "resource-id": "test:id/other", "bounds": { left: 0, top: 0, right: 50, bottom: 50 } }
-        }),
-        requestAction: async () => ({ success: true, totalTimeMs: 1 })
-      };
-
-      mockFocusPathCalculator = {
-        calculatePath: () => ({
-          currentFocusIndex: 0,
-          targetFocusIndex: 0,
-          swipeCount: 0,
-          direction: "forward" as const,
-          intermediateCheckpoints: []
-        })
-      };
-
-      mockFocusNavigationExecutor = {
-        navigateToElement: async () => true
-      };
-
-      (tapOnElement as any).accessibilityService = mockAccessibilityService;
-      (tapOnElement as any).focusPathCalculator = mockFocusPathCalculator;
-      (tapOnElement as any).focusNavigationExecutor = mockFocusNavigationExecutor;
-    });
-
-    test("uses focus navigation for tap action", async () => {
-      const navigateToElement = spyOn(mockFocusNavigationExecutor, "navigateToElement")
-        .mockResolvedValue(true);
-      const requestTapCoordinates = spyOn(mockAccessibilityService, "requestTapCoordinates")
-        .mockResolvedValue({ success: true, totalTimeMs: 1 });
-
-      const element = {
-        "resource-id": "test:id/button",
-        "bounds": { left: 0, top: 0, right: 100, bottom: 100 }
-      } as any;
-
-      await (tapOnElement as any).executeAndroidTapWithAccessibility(
-        "tap",
-        50,
-        50,
-        element,
-        500,
-        {},
-        undefined
-      );
-
-      expect(navigateToElement).toHaveBeenCalledTimes(1);
-      expect(requestTapCoordinates).toHaveBeenCalledTimes(2); // Double-tap to activate
-      expect(executeAndroidTapWithCoordinates).not.toHaveBeenCalled();
-    });
-
-    test("uses focus navigation for doubleTap action", async () => {
-      const navigateToElement = spyOn(mockFocusNavigationExecutor, "navigateToElement")
-        .mockResolvedValue(true);
-      const requestTapCoordinates = spyOn(mockAccessibilityService, "requestTapCoordinates")
-        .mockResolvedValue({ success: true, totalTimeMs: 1 });
-
-      const element = {
-        "resource-id": "test:id/button",
-        "bounds": { left: 0, top: 0, right: 100, bottom: 100 }
-      } as any;
-
-      await (tapOnElement as any).executeAndroidTapWithAccessibility(
-        "doubleTap",
-        50,
-        50,
-        element,
-        500,
-        {},
-        undefined
-      );
-
-      expect(navigateToElement).toHaveBeenCalledTimes(1);
-      expect(requestTapCoordinates).toHaveBeenCalledTimes(2); // Double-tap to activate
-      expect(executeAndroidTapWithCoordinates).not.toHaveBeenCalled();
-    });
-
-    test("skips focus navigation for longPress and uses coordinate-based tap", async () => {
-      const navigateToElement = spyOn(mockFocusNavigationExecutor, "navigateToElement");
-      const requestTapCoordinates = spyOn(mockAccessibilityService, "requestTapCoordinates")
-        .mockResolvedValue({ success: true, totalTimeMs: 1 });
-
-      const element = {
-        "resource-id": "test:id/button",
-        "bounds": { left: 0, top: 0, right: 100, bottom: 100 }
-      } as any;
-
-      await (tapOnElement as any).executeAndroidTapWithAccessibility(
-        "longPress",
-        50,
-        50,
-        element,
-        1000,
-        {},
-        undefined
-      );
-
-      expect(navigateToElement).not.toHaveBeenCalled();
-      expect(requestTapCoordinates).toHaveBeenCalledTimes(1);
-      expect(requestTapCoordinates).toHaveBeenCalledWith(50, 50, 1000); // Full duration for long press
-    });
-
-    test("falls back to coordinate tap if focus navigation fails", async () => {
-      const navigateToElement = spyOn(mockFocusNavigationExecutor, "navigateToElement")
-        .mockRejectedValue(new Error("Navigation failed"));
-      const requestTapCoordinates = spyOn(mockAccessibilityService, "requestTapCoordinates")
-        .mockResolvedValue({ success: true, totalTimeMs: 1 });
-
-      const element = {
-        "resource-id": "test:id/button",
-        "bounds": { left: 0, top: 0, right: 100, bottom: 100 }
-      } as any;
-
-      await (tapOnElement as any).executeAndroidTapWithAccessibility(
-        "tap",
-        50,
-        50,
-        element,
-        500,
-        {},
-        undefined
-      );
-
-      expect(navigateToElement).toHaveBeenCalledTimes(1);
-      expect(requestTapCoordinates).toHaveBeenCalledTimes(1); // Fallback coordinate tap
-      expect(requestTapCoordinates).toHaveBeenCalledWith(50, 50, 50); // Short duration for tap
-    });
-
-    test("uses ACTION_CLICK fallback if double-tap activation fails", async () => {
-      const navigateToElement = spyOn(mockFocusNavigationExecutor, "navigateToElement")
-        .mockResolvedValue(true);
-      const requestTapCoordinates = spyOn(mockAccessibilityService, "requestTapCoordinates")
-        .mockResolvedValueOnce({ success: false, totalTimeMs: 1, error: "tap failed" });
-      const requestAction = spyOn(mockAccessibilityService, "requestAction")
-        .mockResolvedValue({ success: true, totalTimeMs: 1 });
-
-      const element = {
-        "resource-id": "test:id/button",
-        "bounds": { left: 0, top: 0, right: 100, bottom: 100 }
-      } as any;
-
-      await (tapOnElement as any).executeAndroidTapWithAccessibility(
-        "tap",
-        50,
-        50,
-        element,
-        500,
-        {},
-        undefined
-      );
-
-      expect(navigateToElement).toHaveBeenCalledTimes(1);
-      expect(requestTapCoordinates).toHaveBeenCalledTimes(1);
-      expect(requestAction).toHaveBeenCalledTimes(1);
-      expect(requestAction).toHaveBeenCalledWith("click", "test:id/button");
-    });
-
-    test("falls back to coordinate-based tap if both navigation and activation fail", async () => {
-      const navigateToElement = spyOn(mockFocusNavigationExecutor, "navigateToElement")
-        .mockResolvedValue(true);
-      const requestTapCoordinates = spyOn(mockAccessibilityService, "requestTapCoordinates")
-        .mockResolvedValueOnce({ success: false, totalTimeMs: 1, error: "tap failed" });
-      const requestAction = spyOn(mockAccessibilityService, "requestAction")
-        .mockResolvedValue({ success: false, totalTimeMs: 1, error: "click failed" });
-
-      const element = {
-        "resource-id": "test:id/button",
-        "bounds": { left: 0, top: 0, right: 100, bottom: 100 }
-      } as any;
-
-      await (tapOnElement as any).executeAndroidTapWithAccessibility(
-        "tap",
-        50,
-        50,
-        element,
-        500,
-        {},
-        undefined
-      );
-
-      expect(navigateToElement).toHaveBeenCalledTimes(1);
-      expect(requestTapCoordinates).toHaveBeenCalledTimes(2); // One during activation attempt, one during fallback
-      expect(requestAction).toHaveBeenCalledTimes(1);
-    });
-  });
-
   describe("clickable parent resolution", () => {
     test("uses clickable parent when child is not clickable", () => {
       const viewHierarchy = {
@@ -512,5 +311,192 @@ describe("TapOnElement TalkBack mode detection", () => {
       expect(result.usedParent).toBe(true);
       expect(result.element["resource-id"]).toBe("parent:long");
     });
+  });
+});
+
+describe("TapOnElement TalkBackTapStrategy delegation", () => {
+  let fakeTalkBackStrategy: FakeTalkBackTapStrategy;
+  let fakeAccessibilityDetector: FakeAccessibilityDetector;
+  let fakeAdb: FakeAdbClient;
+  let fakeTimer: FakeTimer;
+  let tapOnElement: TapOnElement;
+  let executeAndroidTapWithCoordinates: any;
+
+  beforeEach(() => {
+    fakeAccessibilityDetector = new FakeAccessibilityDetector();
+    fakeAccessibilityDetector.setTalkBackEnabled(true);
+    fakeAdb = new FakeAdbClient();
+    fakeTimer = new FakeTimer();
+    fakeTimer.enableAutoAdvance();
+    fakeTalkBackStrategy = new FakeTalkBackTapStrategy();
+
+    tapOnElement = new TapOnElement(
+      {
+        name: "test-device",
+        platform: "android",
+        id: "emulator-5554",
+      } as any,
+      fakeAdb as any,
+      {
+        accessibilityDetector: fakeAccessibilityDetector,
+        timer: fakeTimer,
+        talkBackStrategy: fakeTalkBackStrategy
+      }
+    );
+
+    executeAndroidTapWithCoordinates = spyOn(
+      tapOnElement as any,
+      "executeAndroidTapWithCoordinates"
+    ).mockResolvedValue(undefined);
+  });
+
+  test("delegates tap to TalkBackTapStrategy.executeTap", async () => {
+    const element = {
+      "resource-id": "test:id/button",
+      "bounds": { left: 0, top: 0, right: 100, bottom: 100 }
+    } as any;
+
+    await (tapOnElement as any).executeAndroidTapWithAccessibility(
+      "tap",
+      50,
+      50,
+      element,
+      500,
+      {},
+      undefined
+    );
+
+    expect(fakeTalkBackStrategy.tapCalls).toHaveLength(1);
+    expect(fakeTalkBackStrategy.tapCalls[0].deviceId).toBe("emulator-5554");
+    expect(fakeTalkBackStrategy.tapCalls[0].element).toBe(element);
+    expect(fakeTalkBackStrategy.tapCalls[0].action).toBe("tap");
+  });
+
+  test("delegates doubleTap to TalkBackTapStrategy.executeTap", async () => {
+    const element = {
+      "resource-id": "test:id/button",
+      "bounds": { left: 0, top: 0, right: 100, bottom: 100 }
+    } as any;
+
+    await (tapOnElement as any).executeAndroidTapWithAccessibility(
+      "doubleTap",
+      50,
+      50,
+      element,
+      500,
+      {},
+      undefined
+    );
+
+    expect(fakeTalkBackStrategy.tapCalls).toHaveLength(1);
+    expect(fakeTalkBackStrategy.tapCalls[0].action).toBe("doubleTap");
+  });
+
+  test("skips focus navigation for longPress and uses coordinate fallback", async () => {
+    const element = {
+      "resource-id": "test:id/button",
+      "bounds": { left: 0, top: 0, right: 100, bottom: 100 }
+    } as any;
+
+    await (tapOnElement as any).executeAndroidTapWithAccessibility(
+      "longPress",
+      50,
+      50,
+      element,
+      1000,
+      {},
+      undefined
+    );
+
+    // Should not call executeTap for longPress
+    expect(fakeTalkBackStrategy.tapCalls).toHaveLength(0);
+    // Should go directly to coordinate fallback
+    expect(fakeTalkBackStrategy.fallbackCalls).toHaveLength(1);
+    expect(fakeTalkBackStrategy.fallbackCalls[0]).toEqual({
+      x: 50,
+      y: 50,
+      action: "longPress",
+      durationMs: 1000
+    });
+  });
+
+  test("uses coordinate fallback when focus navigation fails", async () => {
+    const element = {
+      "resource-id": "test:id/button",
+      "bounds": { left: 0, top: 0, right: 100, bottom: 100 }
+    } as any;
+
+    fakeTalkBackStrategy.setTapResult({
+      success: false,
+      method: "focus-navigation",
+      error: "Navigation failed"
+    });
+
+    await (tapOnElement as any).executeAndroidTapWithAccessibility(
+      "tap",
+      50,
+      50,
+      element,
+      500,
+      {},
+      undefined
+    );
+
+    expect(fakeTalkBackStrategy.tapCalls).toHaveLength(1);
+    expect(fakeTalkBackStrategy.fallbackCalls).toHaveLength(1);
+    expect(fakeTalkBackStrategy.fallbackCalls[0].action).toBe("tap");
+  });
+
+  test("falls back to ADB tap when coordinate fallback fails", async () => {
+    const element = {
+      "resource-id": "test:id/button",
+      "bounds": { left: 0, top: 0, right: 100, bottom: 100 }
+    } as any;
+
+    fakeTalkBackStrategy.setTapResult({
+      success: false,
+      method: "focus-navigation",
+      error: "Navigation failed"
+    });
+    fakeTalkBackStrategy.setFallbackResult({
+      success: false,
+      method: "coordinate-fallback",
+      error: "Fallback failed"
+    });
+
+    await (tapOnElement as any).executeAndroidTapWithAccessibility(
+      "tap",
+      50,
+      50,
+      element,
+      500,
+      {},
+      undefined
+    );
+
+    expect(fakeTalkBackStrategy.tapCalls).toHaveLength(1);
+    expect(fakeTalkBackStrategy.fallbackCalls).toHaveLength(1);
+    expect(executeAndroidTapWithCoordinates).toHaveBeenCalledWith("tap", 50, 50, 500, element, undefined);
+  });
+
+  test("falls back to coordinate-based tap when element has no resource-id", async () => {
+    const element = {
+      bounds: { left: 0, top: 0, right: 100, bottom: 100 },
+      text: "Button without ID"
+    } as any;
+
+    await (tapOnElement as any).executeAndroidTapWithAccessibility(
+      "tap",
+      50,
+      50,
+      element,
+      500,
+      {},
+      undefined
+    );
+
+    expect(fakeTalkBackStrategy.tapCalls).toHaveLength(0);
+    expect(fakeTalkBackStrategy.fallbackCalls).toHaveLength(0);
+    expect(executeAndroidTapWithCoordinates).toHaveBeenCalledWith("tap", 50, 50, 500, element, undefined);
   });
 });

--- a/test/features/talkback/TalkBackTapStrategy.test.ts
+++ b/test/features/talkback/TalkBackTapStrategy.test.ts
@@ -1,0 +1,247 @@
+import { beforeEach, describe, expect, test, spyOn } from "bun:test";
+import { TalkBackTapStrategy } from "../../../src/features/talkback/TalkBackTapStrategy";
+import { FakeTalkBackNavigationDriver } from "../../fakes/FakeTalkBackNavigationDriver";
+import { FakeTimer } from "../../fakes/FakeTimer";
+import { FocusNavigationExecutor } from "../../../src/features/talkback/FocusNavigationExecutor";
+import { FocusPathCalculator } from "../../../src/features/talkback/FocusPathCalculator";
+import { FocusElementMatcher } from "../../../src/features/talkback/FocusElementMatcher";
+import type { Element } from "../../../src/models/Element";
+
+describe("TalkBackTapStrategy", () => {
+  let strategy: TalkBackTapStrategy;
+  let driver: FakeTalkBackNavigationDriver;
+  let fakeTimer: FakeTimer;
+  let mockExecutor: FocusNavigationExecutor;
+  let mockPathCalculator: FocusPathCalculator;
+  let matcher: FocusElementMatcher;
+
+  beforeEach(() => {
+    fakeTimer = new FakeTimer();
+    fakeTimer.enableAutoAdvance();
+    matcher = new FocusElementMatcher();
+    mockPathCalculator = new FocusPathCalculator(matcher);
+    mockExecutor = new FocusNavigationExecutor({
+      matcher,
+      pathCalculator: mockPathCalculator,
+      timer: fakeTimer
+    });
+
+    strategy = new TalkBackTapStrategy({
+      matcher,
+      pathCalculator: mockPathCalculator,
+      executor: mockExecutor,
+      timer: fakeTimer
+    });
+
+    driver = new FakeTalkBackNavigationDriver();
+  });
+
+  describe("executeTap", () => {
+    test("returns error when element has no resource-id", async () => {
+      const element = {
+        bounds: { left: 0, top: 0, right: 100, bottom: 100 },
+        text: "Button"
+      } as Element;
+
+      const result = await strategy.executeTap("device-1", element, "tap", driver);
+
+      expect(result.success).toBe(false);
+      expect(result.method).toBe("focus-navigation");
+      expect(result.error).toContain("no resource-id");
+    });
+
+    test("uses focus navigation for tap action", async () => {
+      const element = {
+        "resource-id": "test:id/button",
+        "bounds": { left: 0, top: 0, right: 100, bottom: 100 }
+      } as Element;
+
+      // Set up driver with element in traversal order
+      driver.setElements([element], 0);
+
+      const navigateToElement = spyOn(mockExecutor, "navigateToElement")
+        .mockResolvedValue(true);
+
+      const result = await strategy.executeTap("device-1", element, "tap", driver);
+
+      expect(result.success).toBe(true);
+      expect(result.method).toBe("focus-navigation");
+      expect(navigateToElement).toHaveBeenCalledTimes(1);
+      expect(driver.getTapCount()).toBe(2); // Double-tap to activate
+    });
+
+    test("uses focus navigation for doubleTap action", async () => {
+      const element = {
+        "resource-id": "test:id/button",
+        "bounds": { left: 0, top: 0, right: 100, bottom: 100 }
+      } as Element;
+
+      driver.setElements([element], 0);
+
+      const navigateToElement = spyOn(mockExecutor, "navigateToElement")
+        .mockResolvedValue(true);
+
+      const result = await strategy.executeTap("device-1", element, "doubleTap", driver);
+
+      expect(result.success).toBe(true);
+      expect(result.method).toBe("focus-navigation");
+      expect(navigateToElement).toHaveBeenCalledTimes(1);
+      expect(driver.getTapCount()).toBe(2); // Double-tap to activate
+    });
+
+    test("returns error when focus navigation fails", async () => {
+      const element = {
+        "resource-id": "test:id/button",
+        "bounds": { left: 0, top: 0, right: 100, bottom: 100 }
+      } as Element;
+
+      driver.setElements([element], 0);
+
+      const navigateToElement = spyOn(mockExecutor, "navigateToElement")
+        .mockRejectedValue(new Error("Navigation failed"));
+
+      const result = await strategy.executeTap("device-1", element, "tap", driver);
+
+      expect(result.success).toBe(false);
+      expect(result.method).toBe("focus-navigation");
+      expect(result.error).toContain("Navigation failed");
+      expect(navigateToElement).toHaveBeenCalledTimes(1);
+    });
+
+    test("uses ACTION_CLICK fallback if double-tap activation fails", async () => {
+      const element = {
+        "resource-id": "test:id/button",
+        "bounds": { left: 0, top: 0, right: 100, bottom: 100 }
+      } as Element;
+
+      driver.setElements([element], 0);
+
+      spyOn(mockExecutor, "navigateToElement").mockResolvedValue(true);
+      driver.queueTapResult({ success: false, totalTimeMs: 1, error: "tap failed" });
+      driver.setActionResult({ success: true, action: "click", totalTimeMs: 1 });
+
+      const result = await strategy.executeTap("device-1", element, "tap", driver);
+
+      expect(result.success).toBe(true);
+      expect(result.method).toBe("focus-navigation");
+      expect(driver.getTapCount()).toBe(1); // Only first tap attempted
+      expect(driver.getActionCount()).toBe(1); // ACTION_CLICK fallback
+      expect(driver.actionHistory[0]).toEqual({ action: "click", resourceId: "test:id/button" });
+    });
+
+    test("returns error if both double-tap and ACTION_CLICK fail", async () => {
+      const element = {
+        "resource-id": "test:id/button",
+        "bounds": { left: 0, top: 0, right: 100, bottom: 100 }
+      } as Element;
+
+      driver.setElements([element], 0);
+
+      spyOn(mockExecutor, "navigateToElement").mockResolvedValue(true);
+      driver.queueTapResult({ success: false, totalTimeMs: 1, error: "tap failed" });
+      driver.setActionResult({ success: false, action: "click", totalTimeMs: 1, error: "click failed" });
+
+      const result = await strategy.executeTap("device-1", element, "tap", driver);
+
+      expect(result.success).toBe(false);
+      expect(result.method).toBe("focus-navigation");
+      expect(result.error).toContain("both failed");
+    });
+
+    test("returns error when navigation path cannot be calculated", async () => {
+      const element = {
+        "resource-id": "test:id/nonexistent",
+        "bounds": { left: 0, top: 0, right: 100, bottom: 100 }
+      } as Element;
+
+      // Element not in traversal order
+      driver.setElements([
+        { "resource-id": "test:id/other", "bounds": { left: 0, top: 0, right: 50, bottom: 50 } } as Element
+      ], 0);
+
+      const result = await strategy.executeTap("device-1", element, "tap", driver);
+
+      expect(result.success).toBe(false);
+      expect(result.method).toBe("focus-navigation");
+      expect(result.error).toContain("calculate navigation path");
+    });
+
+    test("returns error when traversal order request fails", async () => {
+      const element = {
+        "resource-id": "test:id/button",
+        "bounds": { left: 0, top: 0, right: 100, bottom: 100 }
+      } as Element;
+
+      driver.queueTraversalResult({ error: "Service unavailable", totalTimeMs: 1 });
+
+      const result = await strategy.executeTap("device-1", element, "tap", driver);
+
+      expect(result.success).toBe(false);
+      expect(result.method).toBe("focus-navigation");
+      expect(result.error).toContain("traversal order");
+    });
+  });
+
+  describe("executeCoordinateFallback", () => {
+    test("performs single tap for tap action", async () => {
+      const result = await strategy.executeCoordinateFallback(50, 50, "tap", 500, driver);
+
+      expect(result.success).toBe(true);
+      expect(result.method).toBe("coordinate-fallback");
+      expect(driver.getTapCount()).toBe(1);
+      expect(driver.tapHistory[0]).toEqual({ x: 50, y: 50, durationMs: 50 }); // Short duration for tap
+    });
+
+    test("performs double tap for doubleTap action", async () => {
+      const result = await strategy.executeCoordinateFallback(50, 50, "doubleTap", 500, driver);
+
+      expect(result.success).toBe(true);
+      expect(result.method).toBe("coordinate-fallback");
+      expect(driver.getTapCount()).toBe(2);
+      expect(driver.tapHistory[0]).toEqual({ x: 50, y: 50, durationMs: 50 });
+      expect(driver.tapHistory[1]).toEqual({ x: 50, y: 50, durationMs: 50 });
+    });
+
+    test("uses full duration for longPress action", async () => {
+      const result = await strategy.executeCoordinateFallback(50, 50, "longPress", 1000, driver);
+
+      expect(result.success).toBe(true);
+      expect(result.method).toBe("coordinate-fallback");
+      expect(driver.getTapCount()).toBe(1);
+      expect(driver.tapHistory[0]).toEqual({ x: 50, y: 50, durationMs: 1000 }); // Full duration
+    });
+
+    test("returns error when first tap of doubleTap fails", async () => {
+      driver.queueTapResult({ success: false, totalTimeMs: 1, error: "tap failed" });
+
+      const result = await strategy.executeCoordinateFallback(50, 50, "doubleTap", 500, driver);
+
+      expect(result.success).toBe(false);
+      expect(result.method).toBe("coordinate-fallback");
+      expect(result.error).toContain("First tap failed");
+      expect(driver.getTapCount()).toBe(1);
+    });
+
+    test("returns error when second tap of doubleTap fails", async () => {
+      driver.queueTapResult({ success: true, totalTimeMs: 1 });
+      driver.queueTapResult({ success: false, totalTimeMs: 1, error: "second tap failed" });
+
+      const result = await strategy.executeCoordinateFallback(50, 50, "doubleTap", 500, driver);
+
+      expect(result.success).toBe(false);
+      expect(result.method).toBe("coordinate-fallback");
+      expect(result.error).toContain("Second tap failed");
+      expect(driver.getTapCount()).toBe(2);
+    });
+
+    test("returns error when single tap fails", async () => {
+      driver.setTapResult({ success: false, totalTimeMs: 1, error: "tap failed" });
+
+      const result = await strategy.executeCoordinateFallback(50, 50, "tap", 500, driver);
+
+      expect(result.success).toBe(false);
+      expect(result.method).toBe("coordinate-fallback");
+      expect(result.error).toContain("tap failed");
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Extract TalkBackTapStrategy class to own TalkBack focus navigation orchestration
- Simplify TapOnElement constructor from 10 params to 3 using TapOnElementDependencies interface
- Add TalkBackNavigationDriver interface extending FocusNavigationDriver with tap/action capabilities
- Reduce executeAndroidTapWithAccessibility from ~176 to ~55 lines by delegating to strategy

## Test Plan
- [x] All 2088 tests pass
- [x] Lint passes
- [x] Build succeeds
- [x] New TalkBackTapStrategy.test.ts with 14 tests
- [x] Updated TapOnElement.talkback.test.ts tests delegation

Closes #1118

🤖 Generated with [Claude Code](https://claude.com/claude-code)