### PR TITLE
feat: implement work profile app install tracking enhancements

### DIFF
--- a/src/db/installedAppsRepository.ts
+++ b/src/db/installedAppsRepository.ts
@@ -4,6 +4,7 @@ import type { Database, InstalledApp as DbInstalledApp, NewInstalledApp } from "
 
 export interface InstalledAppsStore {
   getLatestVerification(deviceId: string): Promise<number | null>;
+  getLatestVerificationForProfile(deviceId: string, userId: number): Promise<number | null>;
   listInstalledApps(deviceId: string): Promise<DbInstalledApp[]>;
   replaceInstalledApps(deviceId: string, apps: NewInstalledApp[]): Promise<void>;
   upsertInstalledApp(
@@ -20,6 +21,7 @@ export interface InstalledAppsStore {
   ): Promise<void>;
   removeInstalledAppForDevice(deviceId: string, packageName: string): Promise<void>;
   markDeviceStale(deviceId: string): Promise<void>;
+  markProfileStale(deviceId: string, userId: number): Promise<void>;
   touchDevice(deviceId: string, timestampMs: number): Promise<void>;
   clearDeviceSession(deviceId: string): Promise<void>;
   clearOldDaemonSessions(currentDaemonSessionId: string): Promise<void>;
@@ -47,6 +49,22 @@ export class InstalledAppsRepository implements InstalledAppsStore {
       .selectFrom("installed_apps")
       .select(db.fn.max<number>("last_verified_at").as("last_verified_at"))
       .where("device_id", "=", deviceId)
+      .executeTakeFirst();
+
+    if (!row || row.last_verified_at === null || row.last_verified_at === undefined) {
+      return null;
+    }
+
+    return Number(row.last_verified_at);
+  }
+
+  async getLatestVerificationForProfile(deviceId: string, userId: number): Promise<number | null> {
+    const db = await this.getDb();
+    const row = await db
+      .selectFrom("installed_apps")
+      .select(db.fn.max<number>("last_verified_at").as("last_verified_at"))
+      .where("device_id", "=", deviceId)
+      .where("user_id", "=", userId)
       .executeTakeFirst();
 
     if (!row || row.last_verified_at === null || row.last_verified_at === undefined) {
@@ -143,6 +161,16 @@ export class InstalledAppsRepository implements InstalledAppsStore {
       .updateTable("installed_apps")
       .set({ last_verified_at: 0 })
       .where("device_id", "=", deviceId)
+      .execute();
+  }
+
+  async markProfileStale(deviceId: string, userId: number): Promise<void> {
+    const db = await this.getDb();
+    await db
+      .updateTable("installed_apps")
+      .set({ last_verified_at: 0 })
+      .where("device_id", "=", deviceId)
+      .where("user_id", "=", userId)
       .execute();
   }
 

--- a/src/doctor/checks/automobile.ts
+++ b/src/doctor/checks/automobile.ts
@@ -214,6 +214,88 @@ export async function checkAccessibilityService(
 }
 
 /**
+ * Check work profile accessibility service status
+ * Warns if work profiles exist but accessibility service is not enabled for them
+ */
+export async function checkWorkProfileAccessibility(
+  adbFactory: AdbClientFactory = defaultAdbClientFactory
+): Promise<CheckResult> {
+  try {
+    const adb = adbFactory.create();
+    const devices = await adb.getBootedAndroidDevices();
+
+    if (devices.length === 0) {
+      return {
+        name: "Work Profile Accessibility",
+        status: "skip",
+        message: "No Android devices connected",
+      };
+    }
+
+    // Check first connected device
+    const device = devices[0];
+    const deviceAdb = adbFactory.create(device);
+    const users = await deviceAdb.listUsers();
+
+    // Filter to work profiles: userId > 0, running, and flags indicate managed profile (0x30 = 48)
+    // Work profiles have FLAG_MANAGED_PROFILE (0x20) in their flags
+    const workProfiles = users.filter(
+      user => user.userId > 0 && user.running && (user.flags & 0x20) !== 0
+    );
+
+    if (workProfiles.length === 0) {
+      return {
+        name: "Work Profile Accessibility",
+        status: "pass",
+        message: "No work profiles detected",
+      };
+    }
+
+    // Check accessibility service status for each work profile
+    const profilesWithoutService: { userId: number; name: string }[] = [];
+
+    for (const profile of workProfiles) {
+      const result = await deviceAdb.executeCommand(
+        `shell settings --user ${profile.userId} get secure enabled_accessibility_services`,
+        undefined,
+        undefined,
+        true
+      );
+      const isEnabled = result.stdout.includes(AndroidAccessibilityServiceManager.PACKAGE);
+      if (!isEnabled) {
+        profilesWithoutService.push({ userId: profile.userId, name: profile.name });
+      }
+    }
+
+    if (profilesWithoutService.length === 0) {
+      return {
+        name: "Work Profile Accessibility",
+        status: "pass",
+        message: `Accessibility service enabled for ${workProfiles.length} work profile(s)`,
+      };
+    }
+
+    const profileList = profilesWithoutService
+      .map(p => `${p.name} (user ${p.userId})`)
+      .join(", ");
+
+    return {
+      name: "Work Profile Accessibility",
+      status: "warn",
+      message: `Accessibility service not enabled for work profile(s): ${profileList}`,
+      recommendation: "The accessibility service needs to be enabled in each work profile for full app install tracking. Run auto-mobile doctor or enable manually in Settings > Accessibility.",
+    };
+  } catch (error) {
+    logger.debug(`Work profile accessibility check failed: ${error}`);
+    return {
+      name: "Work Profile Accessibility",
+      status: "skip",
+      message: `Could not check: ${error instanceof Error ? error.message : String(error)}`,
+    };
+  }
+}
+
+/**
  * Run all AutoMobile checks
  */
 export async function runAutoMobileChecks(): Promise<CheckResult[]> {
@@ -223,6 +305,7 @@ export async function runAutoMobileChecks(): Promise<CheckResult[]> {
   results.push(await checkDaemonStatus());
   results.push(await checkDaemonConnectivity());
   results.push(await checkAccessibilityService());
+  results.push(await checkWorkProfileAccessibility());
 
   return results;
 }

--- a/src/features/observe/android/AccessibilityServiceClient.ts
+++ b/src/features/observe/android/AccessibilityServiceClient.ts
@@ -36,6 +36,7 @@ import { NavigationGraphManager, NavigationEvent } from "../../navigation/Naviga
 import { NavigationScreenshotManager } from "../../navigation/NavigationScreenshotManager";
 import { HierarchyNavigationDetector } from "../../navigation/HierarchyNavigationDetector";
 import { InstalledAppsRepository, InstalledAppsStore } from "../../../db/installedAppsRepository";
+import { DefaultWorkProfileMonitor, WorkProfileMonitor } from "../../../utils/WorkProfileMonitor";
 import { PortManager } from "../../../utils/PortManager";
 import { getDeviceDataStreamServer } from "../../../daemon/deviceDataStreamSocketServer";
 import {
@@ -333,6 +334,9 @@ export class AccessibilityServiceClient extends DeviceServiceClient implements A
   private screenshotBackoffScheduler: ScreenshotBackoffScheduler | null = null;
   private cachedScreenDimensions: { width: number; height: number } | null = null;
 
+  // Work profile monitor for polling profiles without accessibility service
+  private workProfileMonitor: WorkProfileMonitor | null = null;
+
   // Logging tag for base class
   protected readonly logTag = "ACCESSIBILITY_SERVICE";
 
@@ -505,6 +509,9 @@ export class AccessibilityServiceClient extends DeviceServiceClient implements A
       this.hierarchyNavigationDetector.dispose();
       this.hierarchyNavigationDetector = null;
     }
+
+    // Stop work profile monitor when connection closes
+    this.stopWorkProfileMonitor();
   }
 
   protected async setupBeforeConnect(perf: PerformanceTracker): Promise<void> {
@@ -963,6 +970,9 @@ export class AccessibilityServiceClient extends DeviceServiceClient implements A
 
   async close(): Promise<void> {
     try {
+      // Stop work profile monitor if running
+      this.stopWorkProfileMonitor();
+
       await super.close();
 
       if (this.portForwardingSetup) {
@@ -1497,6 +1507,37 @@ export class AccessibilityServiceClient extends DeviceServiceClient implements A
     return this.installedAppsRepository;
   }
 
+  /**
+   * Get or create the work profile monitor for polling profiles without accessibility service
+   */
+  getWorkProfileMonitor(): WorkProfileMonitor {
+    if (!this.workProfileMonitor) {
+      this.workProfileMonitor = new DefaultWorkProfileMonitor({
+        deviceId: this.device.deviceId,
+        adb: this.adb,
+        installedAppsStore: this.getInstalledAppsRepository(),
+        timer: this.timer
+      });
+    }
+    return this.workProfileMonitor;
+  }
+
+  /**
+   * Start the work profile monitor to poll profiles without accessibility service
+   */
+  startWorkProfileMonitor(): void {
+    this.getWorkProfileMonitor().start();
+  }
+
+  /**
+   * Stop the work profile monitor
+   */
+  stopWorkProfileMonitor(): void {
+    if (this.workProfileMonitor) {
+      this.workProfileMonitor.stop();
+    }
+  }
+
   private async handlePackageEvent(event: PackageEvent, timestamp?: number): Promise<void> {
     if (this.device.platform !== "android") {
       return;
@@ -1521,6 +1562,12 @@ export class AccessibilityServiceClient extends DeviceServiceClient implements A
       } else {
         const isSystem = event.isSystem === true;
         await repo.upsertInstalledApp(deviceId, event.userId, event.packageName, isSystem, eventTimestamp);
+      }
+
+      // Notify work profile monitor that this user has accessibility service
+      // (if we're receiving package events, the service is working for this user)
+      if (event.userId > 0 && this.workProfileMonitor) {
+        this.workProfileMonitor.setProfileHasAccessibilityService(event.userId, true);
       }
     } catch (error) {
       logger.warn(`[ACCESSIBILITY_SERVICE] Failed to apply package event: ${error}`);

--- a/src/utils/AccessibilityServiceManager.ts
+++ b/src/utils/AccessibilityServiceManager.ts
@@ -37,6 +37,7 @@ export interface AccessibilityServiceManager {
   setup(force?: boolean, perf?: PerformanceTracker): Promise<AccessibilitySetupResult>;
   isInstalled(): Promise<boolean>;
   isEnabled(): Promise<boolean>;
+  isEnabledForUser(userId: number): Promise<boolean>;
   isAvailable(): Promise<boolean>;
   getInstalledApkSha256(): Promise<string | null>;
   isVersionCompatible(): Promise<boolean>;
@@ -44,6 +45,7 @@ export interface AccessibilityServiceManager {
   downloadApk(): Promise<string>;
   install(apkPath: string): Promise<void>;
   enable(): Promise<void>;
+  enableForUser(userId: number): Promise<void>;
   cleanupApk(apkPath: string): Promise<void>;
 }
 
@@ -550,6 +552,23 @@ export class AndroidAccessibilityServiceManager implements AccessibilityServiceM
       return isEnabled;
     } catch (error) {
       logger.warn(`[ACCESSIBILITY_SERVICE] Error checking enabled status: ${error}`);
+      return false;
+    }
+  }
+
+  /**
+   * Check if Accessibility Service is enabled for a specific user profile
+   * @param userId - The Android user ID to check (e.g., 10 for work profile)
+   */
+  async isEnabledForUser(userId: number): Promise<boolean> {
+    try {
+      logger.info(`[ACCESSIBILITY_SERVICE] Checking if accessibility service is enabled for user ${userId}`);
+      const result = await this.adb.executeCommand(`shell settings --user ${userId} get secure enabled_accessibility_services`);
+      const isEnabled = result.stdout.includes(AndroidAccessibilityServiceManager.PACKAGE);
+      logger.info(`[ACCESSIBILITY_SERVICE] Service enabled status for user ${userId}: ${isEnabled ? "enabled" : "disabled"}`);
+      return isEnabled;
+    } catch (error) {
+      logger.warn(`[ACCESSIBILITY_SERVICE] Error checking enabled status for user ${userId}: ${error}`);
       return false;
     }
   }
@@ -1102,6 +1121,73 @@ export class AndroidAccessibilityServiceManager implements AccessibilityServiceM
    */
   async enable(): Promise<void> {
     return this.enableViaSettings();
+  }
+
+  /**
+   * Enable Accessibility Service for a specific user profile via adb settings commands
+   * @param userId - The Android user ID to enable for (e.g., 10 for work profile)
+   */
+  async enableForUser(userId: number): Promise<void> {
+    // Check if settings toggle is supported
+    const capabilities = await this.getToggleCapabilities();
+    if (!capabilities.supportsSettingsToggle) {
+      const errorMsg = `Settings-based accessibility toggle is not supported on this device. ${capabilities.reason || ""}`;
+      logger.error("[ACCESSIBILITY_SERVICE] " + errorMsg, { capabilities });
+      throw new Error(errorMsg);
+    }
+
+    try {
+      logger.info(`[ACCESSIBILITY_SERVICE] Enabling Accessibility Service via settings commands for user ${userId}`);
+
+      // Get current enabled services for this user
+      const result = await this.adb.executeCommand(`shell settings --user ${userId} get secure enabled_accessibility_services`);
+      let currentServices = result.stdout.trim();
+
+      // Issue #384: preserve existing enabled services; settings may return "null" or empty.
+      if (currentServices === "null" || currentServices === "") {
+        currentServices = "";
+      }
+
+      // Build the service component name
+      const serviceComponent = `${AndroidAccessibilityServiceManager.PACKAGE}/${AndroidAccessibilityServiceManager.PACKAGE}.AutoMobileAccessibilityService`;
+
+      // Check if service is already in the list
+      if (currentServices.includes(serviceComponent)) {
+        logger.info(`[ACCESSIBILITY_SERVICE] Accessibility Service is already enabled for user ${userId}`);
+      } else {
+        // Issue #384: append to the colon-separated list instead of overwriting other services.
+        const updatedServices = currentServices
+          ? `${currentServices}:${serviceComponent}`
+          : serviceComponent;
+
+        // Set updated list
+        await this.adb.executeCommand(`shell settings --user ${userId} put secure enabled_accessibility_services "${updatedServices}"`);
+        logger.info(`[ACCESSIBILITY_SERVICE] Added AutoMobile service to enabled_accessibility_services for user ${userId}`);
+      }
+
+      // Enable accessibility globally for this user
+      await this.adb.executeCommand(`shell settings --user ${userId} put secure accessibility_enabled 1`);
+      logger.info(`[ACCESSIBILITY_SERVICE] Accessibility Service enabled successfully via settings for user ${userId}`);
+
+      // Clear cache after enabling (main user cache - per-user caching not implemented)
+      this.clearAvailabilityCache();
+      // Also invalidate the accessibility detector cache so observe reports correct state
+      this.getAccessibilityDetector().invalidateCache(this.device.deviceId);
+    } catch (error) {
+      const errorMsg = error instanceof Error ? error.message : String(error);
+      const errorLower = errorMsg.toLowerCase();
+
+      // Categorize error types for clearer feedback
+      if (errorLower.includes("permission denied") || errorLower.includes("not permitted")) {
+        throw new Error(`Permission denied while enabling Accessibility Service for user ${userId}. The device may require root access, device owner status, or special shell permissions. Original error: ${errorMsg}`);
+      } else if (errorLower.includes("device not found") || errorLower.includes("no devices") || errorLower.includes("offline")) {
+        throw new Error(`Device connection lost while enabling Accessibility Service for user ${userId}. Ensure the device is connected and adb is responsive. Original error: ${errorMsg}`);
+      } else if (errorLower.includes("timeout") || errorLower.includes("timed out")) {
+        throw new Error(`Timeout while enabling Accessibility Service for user ${userId}. The device may be unresponsive. Original error: ${errorMsg}`);
+      } else {
+        throw new Error(`Failed to enable Accessibility Service via settings for user ${userId}. This may indicate an ADB communication issue or device state problem. Original error: ${errorMsg}`);
+      }
+    }
   }
 
   /**

--- a/src/utils/WorkProfileMonitor.ts
+++ b/src/utils/WorkProfileMonitor.ts
@@ -1,0 +1,226 @@
+import { Timer, defaultTimer } from "./SystemTimer";
+import { logger } from "./logger";
+import type { AdbExecutor } from "./android-cmdline-tools/interfaces/AdbExecutor";
+import type { InstalledAppsStore } from "../db/installedAppsRepository";
+
+/**
+ * Environment variable to configure polling interval (default: 5000ms)
+ */
+const DEFAULT_POLL_INTERVAL_MS = 5000;
+
+/**
+ * State tracking for a single work profile
+ */
+export interface ProfileState {
+  userId: number;
+  hasAccessibilityService: boolean;
+  lastRefreshMs: number;
+}
+
+/**
+ * Interface for monitoring work profiles and polling for package updates
+ * when accessibility service is not available
+ */
+export interface WorkProfileMonitor {
+  /**
+   * Start the polling monitor
+   */
+  start(): void;
+
+  /**
+   * Stop the polling monitor
+   */
+  stop(): void;
+
+  /**
+   * Update the accessibility service status for a profile
+   * @param userId - The user ID of the profile
+   * @param hasService - Whether the profile has accessibility service enabled
+   */
+  setProfileHasAccessibilityService(userId: number, hasService: boolean): void;
+
+  /**
+   * Get the current state of all tracked profiles
+   */
+  getProfileStates(): ProfileState[];
+
+  /**
+   * Manually trigger a refresh for a specific profile
+   * @param userId - The user ID of the profile to refresh
+   */
+  refreshProfile(userId: number): Promise<void>;
+
+  /**
+   * Check if the monitor is currently running
+   */
+  isRunning(): boolean;
+}
+
+/**
+ * Options for creating a WorkProfileMonitor
+ */
+export interface WorkProfileMonitorOptions {
+  deviceId: string;
+  adb: AdbExecutor;
+  installedAppsStore: InstalledAppsStore;
+  timer?: Timer;
+  pollIntervalMs?: number;
+}
+
+/**
+ * Default implementation of WorkProfileMonitor
+ * Polls work profiles without accessibility service at regular intervals
+ */
+export class DefaultWorkProfileMonitor implements WorkProfileMonitor {
+  private readonly deviceId: string;
+  private readonly adb: AdbExecutor;
+  private readonly installedAppsStore: InstalledAppsStore;
+  private readonly timer: Timer;
+  private readonly pollIntervalMs: number;
+  private readonly profileStates: Map<number, ProfileState> = new Map();
+  private intervalHandle: NodeJS.Timeout | null = null;
+  private running: boolean = false;
+
+  constructor(options: WorkProfileMonitorOptions) {
+    this.deviceId = options.deviceId;
+    this.adb = options.adb;
+    this.installedAppsStore = options.installedAppsStore;
+    this.timer = options.timer ?? defaultTimer;
+
+    // Allow override via environment variable
+    const envInterval = process.env.AUTOMOBILE_WORK_PROFILE_POLL_INTERVAL_MS;
+    this.pollIntervalMs = options.pollIntervalMs ??
+      (envInterval ? parseInt(envInterval, 10) : DEFAULT_POLL_INTERVAL_MS);
+  }
+
+  start(): void {
+    if (this.running) {
+      logger.debug("[WORK_PROFILE_MONITOR] Already running");
+      return;
+    }
+
+    this.running = true;
+    logger.info(`[WORK_PROFILE_MONITOR] Starting polling (interval: ${this.pollIntervalMs}ms)`);
+
+    this.intervalHandle = this.timer.setInterval(() => {
+      void this.pollStaleProfiles();
+    }, this.pollIntervalMs);
+  }
+
+  stop(): void {
+    if (!this.running) {
+      logger.debug("[WORK_PROFILE_MONITOR] Not running");
+      return;
+    }
+
+    this.running = false;
+    if (this.intervalHandle) {
+      this.timer.clearInterval(this.intervalHandle);
+      this.intervalHandle = null;
+    }
+    logger.info("[WORK_PROFILE_MONITOR] Stopped");
+  }
+
+  setProfileHasAccessibilityService(userId: number, hasService: boolean): void {
+    const existing = this.profileStates.get(userId);
+    if (existing) {
+      existing.hasAccessibilityService = hasService;
+      logger.debug(`[WORK_PROFILE_MONITOR] Updated profile ${userId} hasAccessibilityService=${hasService}`);
+    } else {
+      this.profileStates.set(userId, {
+        userId,
+        hasAccessibilityService: hasService,
+        lastRefreshMs: 0
+      });
+      logger.debug(`[WORK_PROFILE_MONITOR] Added profile ${userId} hasAccessibilityService=${hasService}`);
+    }
+  }
+
+  getProfileStates(): ProfileState[] {
+    return Array.from(this.profileStates.values());
+  }
+
+  async refreshProfile(userId: number): Promise<void> {
+    const state = this.profileStates.get(userId);
+    if (!state) {
+      logger.warn(`[WORK_PROFILE_MONITOR] No state found for profile ${userId}`);
+      return;
+    }
+
+    logger.info(`[WORK_PROFILE_MONITOR] Refreshing packages for user ${userId}`);
+
+    try {
+      const result = await this.adb.executeCommand(
+        `shell pm list packages --user ${userId}`,
+        undefined,
+        undefined,
+        true
+      );
+
+      const packages = this.parsePackageList(result.stdout);
+      const timestampMs = this.timer.now();
+
+      // Upsert each package into the repository
+      for (const pkg of packages) {
+        await this.installedAppsStore.upsertInstalledApp(
+          this.deviceId,
+          userId,
+          pkg.packageName,
+          pkg.isSystem,
+          timestampMs
+        );
+      }
+
+      state.lastRefreshMs = timestampMs;
+      logger.info(`[WORK_PROFILE_MONITOR] Refreshed ${packages.length} packages for user ${userId}`);
+    } catch (error) {
+      logger.warn(`[WORK_PROFILE_MONITOR] Failed to refresh packages for user ${userId}: ${error}`);
+    }
+  }
+
+  isRunning(): boolean {
+    return this.running;
+  }
+
+  /**
+   * Parse the output of `pm list packages` into package info
+   */
+  private parsePackageList(output: string): Array<{ packageName: string; isSystem: boolean }> {
+    const packages: Array<{ packageName: string; isSystem: boolean }> = [];
+    const lines = output.split("\n");
+
+    for (const line of lines) {
+      const trimmed = line.trim();
+      // Format: "package:com.example.app"
+      if (trimmed.startsWith("package:")) {
+        const packageName = trimmed.slice(8);
+        if (packageName) {
+          // We can't easily determine isSystem from pm list packages output
+          // Default to false; system packages are typically already installed via main user
+          packages.push({ packageName, isSystem: false });
+        }
+      }
+    }
+
+    return packages;
+  }
+
+  /**
+   * Poll all profiles that don't have accessibility service
+   */
+  private async pollStaleProfiles(): Promise<void> {
+    const profilesToRefresh = Array.from(this.profileStates.values())
+      .filter(state => !state.hasAccessibilityService);
+
+    if (profilesToRefresh.length === 0) {
+      logger.debug("[WORK_PROFILE_MONITOR] No stale profiles to refresh");
+      return;
+    }
+
+    logger.debug(`[WORK_PROFILE_MONITOR] Polling ${profilesToRefresh.length} stale profile(s)`);
+
+    for (const profile of profilesToRefresh) {
+      await this.refreshProfile(profile.userId);
+    }
+  }
+}

--- a/test/doctor/checks/workProfileAccessibility.test.ts
+++ b/test/doctor/checks/workProfileAccessibility.test.ts
@@ -1,0 +1,181 @@
+import { describe, test, expect, beforeEach } from "bun:test";
+import { checkWorkProfileAccessibility } from "../../../src/doctor/checks/automobile";
+import { FakeAdbExecutor } from "../../fakes/FakeAdbExecutor";
+import type { BootedDevice, AndroidUser } from "../../../src/models";
+import type { AdbClientFactory } from "../../../src/utils/android-cmdline-tools/AdbClientFactory";
+
+describe("checkWorkProfileAccessibility", () => {
+  let fakeAdb: FakeAdbExecutor;
+  let fakeFactory: AdbClientFactory;
+
+  beforeEach(() => {
+    fakeAdb = new FakeAdbExecutor();
+    fakeFactory = {
+      create: () => fakeAdb
+    };
+  });
+
+  test("returns skip when no devices connected", async () => {
+    fakeAdb.setDevices([]);
+
+    const result = await checkWorkProfileAccessibility(fakeFactory);
+
+    expect(result.status).toBe("skip");
+    expect(result.message).toBe("No Android devices connected");
+  });
+
+  test("returns pass when no work profiles exist", async () => {
+    const device: BootedDevice = {
+      name: "emulator-5554",
+      platform: "android",
+      deviceId: "emulator-5554"
+    };
+    fakeAdb.setDevices([device]);
+
+    // Only primary user (userId 0, flags 0x13 = 19)
+    const users: AndroidUser[] = [
+      { userId: 0, name: "Owner", flags: 0x13, running: true }
+    ];
+    fakeAdb.setUsers(users);
+
+    const result = await checkWorkProfileAccessibility(fakeFactory);
+
+    expect(result.status).toBe("pass");
+    expect(result.message).toBe("No work profiles detected");
+  });
+
+  test("returns pass when work profile has accessibility service enabled", async () => {
+    const device: BootedDevice = {
+      name: "emulator-5554",
+      platform: "android",
+      deviceId: "emulator-5554"
+    };
+    fakeAdb.setDevices([device]);
+
+    // Primary user + work profile (userId 10, flags 0x30 = 48 includes FLAG_MANAGED_PROFILE)
+    const users: AndroidUser[] = [
+      { userId: 0, name: "Owner", flags: 0x13, running: true },
+      { userId: 10, name: "Work profile", flags: 0x30, running: true }
+    ];
+    fakeAdb.setUsers(users);
+
+    // Work profile has accessibility service enabled
+    fakeAdb.setCommandResponse(
+      "settings --user 10 get secure enabled_accessibility_services",
+      {
+        stdout: "dev.jasonpearson.automobile.accessibilityservice/dev.jasonpearson.automobile.accessibilityservice.AutoMobileAccessibilityService",
+        stderr: "",
+        toString: () => "dev.jasonpearson.automobile.accessibilityservice/dev.jasonpearson.automobile.accessibilityservice.AutoMobileAccessibilityService",
+        trim: () => "dev.jasonpearson.automobile.accessibilityservice/dev.jasonpearson.automobile.accessibilityservice.AutoMobileAccessibilityService",
+        includes: (s: string) => "dev.jasonpearson.automobile.accessibilityservice/dev.jasonpearson.automobile.accessibilityservice.AutoMobileAccessibilityService".includes(s)
+      }
+    );
+
+    const result = await checkWorkProfileAccessibility(fakeFactory);
+
+    expect(result.status).toBe("pass");
+    expect(result.message).toBe("Accessibility service enabled for 1 work profile(s)");
+  });
+
+  test("returns warn when work profile is missing accessibility service", async () => {
+    const device: BootedDevice = {
+      name: "emulator-5554",
+      platform: "android",
+      deviceId: "emulator-5554"
+    };
+    fakeAdb.setDevices([device]);
+
+    // Primary user + work profile
+    const users: AndroidUser[] = [
+      { userId: 0, name: "Owner", flags: 0x13, running: true },
+      { userId: 10, name: "Work profile", flags: 0x30, running: true }
+    ];
+    fakeAdb.setUsers(users);
+
+    // Work profile does NOT have accessibility service enabled
+    fakeAdb.setCommandResponse(
+      "settings --user 10 get secure enabled_accessibility_services",
+      {
+        stdout: "null",
+        stderr: "",
+        toString: () => "null",
+        trim: () => "null",
+        includes: (s: string) => "null".includes(s)
+      }
+    );
+
+    const result = await checkWorkProfileAccessibility(fakeFactory);
+
+    expect(result.status).toBe("warn");
+    expect(result.message).toContain("Work profile (user 10)");
+    expect(result.recommendation).toContain("accessibility service needs to be enabled");
+  });
+
+  test("does not warn for non-running work profiles", async () => {
+    const device: BootedDevice = {
+      name: "emulator-5554",
+      platform: "android",
+      deviceId: "emulator-5554"
+    };
+    fakeAdb.setDevices([device]);
+
+    // Work profile exists but is not running
+    const users: AndroidUser[] = [
+      { userId: 0, name: "Owner", flags: 0x13, running: true },
+      { userId: 10, name: "Work profile", flags: 0x30, running: false }
+    ];
+    fakeAdb.setUsers(users);
+
+    const result = await checkWorkProfileAccessibility(fakeFactory);
+
+    expect(result.status).toBe("pass");
+    expect(result.message).toBe("No work profiles detected");
+  });
+
+  test("handles multiple work profiles with mixed accessibility status", async () => {
+    const device: BootedDevice = {
+      name: "emulator-5554",
+      platform: "android",
+      deviceId: "emulator-5554"
+    };
+    fakeAdb.setDevices([device]);
+
+    // Two work profiles
+    const users: AndroidUser[] = [
+      { userId: 0, name: "Owner", flags: 0x13, running: true },
+      { userId: 10, name: "Work profile 1", flags: 0x30, running: true },
+      { userId: 11, name: "Work profile 2", flags: 0x30, running: true }
+    ];
+    fakeAdb.setUsers(users);
+
+    // First work profile has service enabled
+    fakeAdb.setCommandResponse(
+      "settings --user 10 get secure enabled_accessibility_services",
+      {
+        stdout: "dev.jasonpearson.automobile.accessibilityservice/dev.jasonpearson.automobile.accessibilityservice.AutoMobileAccessibilityService",
+        stderr: "",
+        toString: () => "dev.jasonpearson.automobile.accessibilityservice/dev.jasonpearson.automobile.accessibilityservice.AutoMobileAccessibilityService",
+        trim: () => "dev.jasonpearson.automobile.accessibilityservice/dev.jasonpearson.automobile.accessibilityservice.AutoMobileAccessibilityService",
+        includes: (s: string) => "dev.jasonpearson.automobile.accessibilityservice/dev.jasonpearson.automobile.accessibilityservice.AutoMobileAccessibilityService".includes(s)
+      }
+    );
+
+    // Second work profile does NOT have service enabled
+    fakeAdb.setCommandResponse(
+      "settings --user 11 get secure enabled_accessibility_services",
+      {
+        stdout: "",
+        stderr: "",
+        toString: () => "",
+        trim: () => "",
+        includes: (s: string) => "".includes(s)
+      }
+    );
+
+    const result = await checkWorkProfileAccessibility(fakeFactory);
+
+    expect(result.status).toBe("warn");
+    expect(result.message).toContain("Work profile 2 (user 11)");
+    expect(result.message).not.toContain("Work profile 1");
+  });
+});

--- a/test/fakes/FakeAccessibilityServiceManager.ts
+++ b/test/fakes/FakeAccessibilityServiceManager.ts
@@ -17,6 +17,7 @@ export class FakeAccessibilityServiceManager implements AccessibilityServiceMana
   private shouldCleanupFail: boolean = false;
   private installedSha256: string | null = null;
   private versionCompatible: boolean = true;
+  private enabledForUsers: Map<number, boolean> = new Map();
 
   /**
    * Set whether the accessibility service is installed
@@ -107,6 +108,15 @@ export class FakeAccessibilityServiceManager implements AccessibilityServiceMana
   }
 
   /**
+   * Set whether the accessibility service is enabled for a specific user
+   * @param userId - The user ID
+   * @param enabled - Whether the service is enabled for this user
+   */
+  setEnabledForUser(userId: number, enabled: boolean): void {
+    this.enabledForUsers.set(userId, enabled);
+  }
+
+  /**
    * Get history of executed operations (for test assertions)
    * @returns Array of operation strings that were executed
    */
@@ -150,6 +160,11 @@ export class FakeAccessibilityServiceManager implements AccessibilityServiceMana
   async isEnabled(): Promise<boolean> {
     this.executedOperations.push("isEnabled");
     return this.enabledState;
+  }
+
+  async isEnabledForUser(userId: number): Promise<boolean> {
+    this.executedOperations.push(`isEnabledForUser:${userId}`);
+    return this.enabledForUsers.get(userId) ?? false;
   }
 
   async isAvailable(): Promise<boolean> {
@@ -221,6 +236,16 @@ export class FakeAccessibilityServiceManager implements AccessibilityServiceMana
     if (this.shouldEnableFail) {
       throw new Error("Failed to enable accessibility service");
     }
+  }
+
+  async enableForUser(userId: number): Promise<void> {
+    this.executedOperations.push(`enableForUser:${userId}`);
+
+    if (this.shouldEnableFail) {
+      throw new Error(`Failed to enable accessibility service for user ${userId}`);
+    }
+
+    this.enabledForUsers.set(userId, true);
   }
 
   async cleanupApk(apkPath: string): Promise<void> {

--- a/test/fakes/FakeInstalledAppsRepository.ts
+++ b/test/fakes/FakeInstalledAppsRepository.ts
@@ -18,6 +18,20 @@ export class FakeInstalledAppsRepository implements InstalledAppsStore {
     return latest;
   }
 
+  async getLatestVerificationForProfile(deviceId: string, userId: number): Promise<number | null> {
+    let latest: number | null = null;
+    for (const row of this.rows) {
+      if (row.device_id !== deviceId || row.user_id !== userId) {
+        continue;
+      }
+      const value = Number(row.last_verified_at);
+      if (latest === null || value > latest) {
+        latest = value;
+      }
+    }
+    return latest;
+  }
+
   async listInstalledApps(deviceId: string): Promise<DbInstalledApp[]> {
     return this.rows.filter(row => row.device_id === deviceId).map(row => ({ ...row }));
   }
@@ -75,6 +89,14 @@ export class FakeInstalledAppsRepository implements InstalledAppsStore {
   async markDeviceStale(deviceId: string): Promise<void> {
     for (const row of this.rows) {
       if (row.device_id === deviceId) {
+        row.last_verified_at = 0;
+      }
+    }
+  }
+
+  async markProfileStale(deviceId: string, userId: number): Promise<void> {
+    for (const row of this.rows) {
+      if (row.device_id === deviceId && row.user_id === userId) {
         row.last_verified_at = 0;
       }
     }

--- a/test/fakes/FakeWorkProfileMonitor.ts
+++ b/test/fakes/FakeWorkProfileMonitor.ts
@@ -1,0 +1,100 @@
+import type { WorkProfileMonitor, ProfileState } from "../../src/utils/WorkProfileMonitor";
+
+/**
+ * Fake implementation of WorkProfileMonitor for testing
+ * Tracks calls and allows configuring profile states
+ */
+export class FakeWorkProfileMonitor implements WorkProfileMonitor {
+  private profileStates: Map<number, ProfileState> = new Map();
+  private running: boolean = false;
+  private startCalls: number = 0;
+  private stopCalls: number = 0;
+  private refreshCalls: number[] = [];
+
+  start(): void {
+    this.running = true;
+    this.startCalls++;
+  }
+
+  stop(): void {
+    this.running = false;
+    this.stopCalls++;
+  }
+
+  setProfileHasAccessibilityService(userId: number, hasService: boolean): void {
+    const existing = this.profileStates.get(userId);
+    if (existing) {
+      existing.hasAccessibilityService = hasService;
+    } else {
+      this.profileStates.set(userId, {
+        userId,
+        hasAccessibilityService: hasService,
+        lastRefreshMs: 0
+      });
+    }
+  }
+
+  getProfileStates(): ProfileState[] {
+    return Array.from(this.profileStates.values());
+  }
+
+  async refreshProfile(userId: number): Promise<void> {
+    this.refreshCalls.push(userId);
+    const state = this.profileStates.get(userId);
+    if (state) {
+      state.lastRefreshMs = Date.now();
+    }
+  }
+
+  isRunning(): boolean {
+    return this.running;
+  }
+
+  // Test helper methods
+
+  /**
+   * Get number of times start() was called
+   */
+  getStartCallCount(): number {
+    return this.startCalls;
+  }
+
+  /**
+   * Get number of times stop() was called
+   */
+  getStopCallCount(): number {
+    return this.stopCalls;
+  }
+
+  /**
+   * Get all user IDs that had refreshProfile() called
+   */
+  getRefreshCalls(): number[] {
+    return [...this.refreshCalls];
+  }
+
+  /**
+   * Check if refreshProfile was called for a specific user
+   */
+  wasRefreshCalled(userId: number): boolean {
+    return this.refreshCalls.includes(userId);
+  }
+
+  /**
+   * Clear all call history
+   */
+  clearHistory(): void {
+    this.startCalls = 0;
+    this.stopCalls = 0;
+    this.refreshCalls = [];
+  }
+
+  /**
+   * Reset all state
+   */
+  reset(): void {
+    this.profileStates.clear();
+    this.running = false;
+    this.clearHistory();
+  }
+}

--- a/test/utils/WorkProfileMonitor.test.ts
+++ b/test/utils/WorkProfileMonitor.test.ts
@@ -1,0 +1,178 @@
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { DefaultWorkProfileMonitor } from "../../src/utils/WorkProfileMonitor";
+import { FakeTimer } from "../fakes/FakeTimer";
+import { FakeAdbExecutor } from "../fakes/FakeAdbExecutor";
+import { FakeInstalledAppsRepository } from "../fakes/FakeInstalledAppsRepository";
+
+describe("WorkProfileMonitor", () => {
+  let timer: FakeTimer;
+  let adb: FakeAdbExecutor;
+  let repo: FakeInstalledAppsRepository;
+  let monitor: DefaultWorkProfileMonitor;
+
+  beforeEach(() => {
+    timer = new FakeTimer();
+    adb = new FakeAdbExecutor();
+    repo = new FakeInstalledAppsRepository();
+
+    monitor = new DefaultWorkProfileMonitor({
+      deviceId: "emulator-5554",
+      adb,
+      installedAppsStore: repo,
+      timer,
+      pollIntervalMs: 5000
+    });
+
+    // Set up default package list response
+    adb.setCommandResponse("pm list packages --user", {
+      stdout: "package:com.example.app1\npackage:com.example.app2\n",
+      stderr: "",
+      toString: () => "package:com.example.app1\npackage:com.example.app2\n",
+      trim: () => "package:com.example.app1\npackage:com.example.app2",
+      includes: (s: string) => "package:com.example.app1\npackage:com.example.app2\n".includes(s)
+    });
+  });
+
+  afterEach(() => {
+    monitor.stop();
+    timer.reset();
+  });
+
+  test("starts and stops correctly", () => {
+    expect(monitor.isRunning()).toBe(false);
+
+    monitor.start();
+    expect(monitor.isRunning()).toBe(true);
+
+    monitor.stop();
+    expect(monitor.isRunning()).toBe(false);
+  });
+
+  test("does not double-start", () => {
+    monitor.start();
+    monitor.start(); // Should be a no-op
+
+    expect(monitor.isRunning()).toBe(true);
+    expect(timer.getPendingIntervalCount()).toBe(1);
+  });
+
+  test("tracks profile states", () => {
+    expect(monitor.getProfileStates()).toHaveLength(0);
+
+    monitor.setProfileHasAccessibilityService(10, false);
+    expect(monitor.getProfileStates()).toHaveLength(1);
+    expect(monitor.getProfileStates()[0]).toEqual({
+      userId: 10,
+      hasAccessibilityService: false,
+      lastRefreshMs: 0
+    });
+
+    monitor.setProfileHasAccessibilityService(10, true);
+    expect(monitor.getProfileStates()[0].hasAccessibilityService).toBe(true);
+  });
+
+  test("refreshes profile packages via ADB", async () => {
+    timer.setCurrentTime(1000);
+    monitor.setProfileHasAccessibilityService(10, false);
+
+    await monitor.refreshProfile(10);
+
+    // Check that packages were added to repository
+    const apps = await repo.listInstalledApps("emulator-5554");
+    expect(apps).toHaveLength(2);
+    expect(apps.map(a => a.package_name).sort()).toEqual(["com.example.app1", "com.example.app2"]);
+    expect(apps[0].user_id).toBe(10);
+
+    // Check lastRefreshMs was updated
+    const state = monitor.getProfileStates()[0];
+    expect(state.lastRefreshMs).toBe(1000);
+  });
+
+  test("polls only stale profiles (without accessibility service)", async () => {
+    monitor.setProfileHasAccessibilityService(10, false); // Should poll
+    monitor.setProfileHasAccessibilityService(11, true);  // Should NOT poll
+
+    monitor.start();
+
+    // Advance time to trigger poll
+    timer.advanceTime(5000);
+    await Promise.resolve(); // Let async operations complete
+
+    // Only user 10 should have been refreshed
+    expect(adb.wasCommandExecuted("pm list packages --user 10")).toBe(true);
+    expect(adb.wasCommandExecuted("pm list packages --user 11")).toBe(false);
+  });
+
+  test("does not poll when all profiles have accessibility service", async () => {
+    monitor.setProfileHasAccessibilityService(10, true);
+    monitor.setProfileHasAccessibilityService(11, true);
+
+    monitor.start();
+
+    // Advance time to trigger poll
+    timer.advanceTime(5000);
+    await Promise.resolve();
+
+    // No profile should have been refreshed
+    expect(adb.wasCommandExecuted("pm list packages")).toBe(false);
+  });
+
+  test("updates profile state when accessibility service becomes available", async () => {
+    monitor.setProfileHasAccessibilityService(10, false);
+    expect(monitor.getProfileStates()[0].hasAccessibilityService).toBe(false);
+
+    // Simulate accessibility service being enabled
+    monitor.setProfileHasAccessibilityService(10, true);
+    expect(monitor.getProfileStates()[0].hasAccessibilityService).toBe(true);
+
+    monitor.start();
+
+    // Advance time to trigger poll
+    timer.advanceTime(5000);
+    await Promise.resolve();
+
+    // Profile should NOT have been polled since it now has accessibility service
+    expect(adb.wasCommandExecuted("pm list packages")).toBe(false);
+  });
+
+  test("handles empty package list gracefully", async () => {
+    // Create a fresh monitor without the default package list response
+    const freshAdb = new FakeAdbExecutor();
+    const freshMonitor = new DefaultWorkProfileMonitor({
+      deviceId: "emulator-5554",
+      adb: freshAdb,
+      installedAppsStore: repo,
+      timer,
+      pollIntervalMs: 5000
+    });
+
+    // Set empty response
+    freshAdb.setDefaultResponse({
+      stdout: "",
+      stderr: "",
+      toString: () => "",
+      trim: () => "",
+      includes: () => false
+    });
+
+    freshMonitor.setProfileHasAccessibilityService(10, false);
+    await freshMonitor.refreshProfile(10);
+
+    const apps = await repo.listInstalledApps("emulator-5554");
+    expect(apps).toHaveLength(0);
+  });
+
+  test("continues polling after refresh error", async () => {
+    adb.setDefaultError(new Error("ADB connection lost"));
+
+    monitor.setProfileHasAccessibilityService(10, false);
+    monitor.start();
+
+    // First poll should fail but not crash
+    timer.advanceTime(5000);
+    await Promise.resolve();
+
+    // Monitor should still be running
+    expect(monitor.isRunning()).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- Add per-user repository methods (`getLatestVerificationForProfile`, `markProfileStale`) and accessibility service methods (`isEnabledForUser`, `enableForUser`)
- Add doctor check to warn when work profiles exist but accessibility service is not enabled
- Implement `WorkProfileMonitor` for polling profiles without accessibility service at configurable intervals
- Integrate `WorkProfileMonitor` into `AccessibilityServiceClient` to track profile states and stop polling when accessibility events are received

## Test Plan
- [x] All tests pass (`bun test --bail`)
- [x] Lint passes (`bun run lint`)
- [x] Build passes (`bun run build`)
- [x] Added tests for doctor check (`test/doctor/checks/workProfileAccessibility.test.ts`)
- [x] Added tests for WorkProfileMonitor (`test/utils/WorkProfileMonitor.test.ts`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #754