### PR TITLE
chore: update accessibility service APK SHA256

### DIFF
--- a/src/constants/release.ts
+++ b/src/constants/release.ts
@@ -19,7 +19,7 @@ export const RELEASE_VERSION: string = "latest";
 export const APK_URL: string = RELEASE_VERSION === "latest"
   ? `https://github.com/kaeawc/auto-mobile/releases/latest/download/accessibility-service-debug.apk`
   : `https://github.com/kaeawc/auto-mobile/releases/download/v${RELEASE_VERSION}/accessibility-service-debug.apk`;
-export const APK_SHA256_CHECKSUM: string = "70dbd5acb5ace77f48d7a1f7348d07b9db29497be2151235d547babbe439cdc6"; // Empty = skip verification (local dev only)
+export const APK_SHA256_CHECKSUM: string = "9ee02f6e283b05aeff34783f761cb21893899421d71a063a99bd28d61396e3a5"; // Empty = skip verification (local dev only)
 
 /**
  * iOS XCTestService Release Constants


### PR DESCRIPTION
## Automated Checksum Update

The accessibility service APK was rebuilt on `main` with a different SHA256 checksum.

| | SHA256 |
|--|--------|
| **Previous** | `70dbd5acb5ace77f48d7a1f7348d07b9db29497be2151235d547babbe439cdc6` |
| **New** | `9ee02f6e283b05aeff34783f761cb21893899421d71a063a99bd28d61396e3a5` |

### Why did this happen?

The SHA256 changes when any of these change:
- Source code in `android/accessibility-service/src/`
- Build configuration (`build.gradle.kts`)
- Dependencies or SDK versions

### What to do

1. Review this PR to ensure the change is expected
2. Merge when ready
3. Future releases will use this checksum for APK verification

---
Auto-generated by `update-accessibility-service-sha256` workflow