### PR TITLE
feat(ios): add AutoMobile design system to iOS Playground

### DIFF
--- a/ios/Playground/Playground.xcodeproj/project.pbxproj
+++ b/ios/Playground/Playground.xcodeproj/project.pbxproj
@@ -7,10 +7,12 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		007B2120C2735B42A20C510B /* Theme.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2F4747AC5700DF138836D5F /* Theme.swift */; };
 		15B37A3EDBAFD6BD0FC98BFC /* DemosTab.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25213AE8A9FD9A5B1EEFD97F /* DemosTab.swift */; };
 		5339DAC5909A688059ABBA80 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D01BCE22E951887741F32904 /* ContentView.swift */; };
 		54C16E199D10E281E1E316CF /* SettingsTab.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64FD18EC8D1B9A665615C374 /* SettingsTab.swift */; };
 		553F94B4D033BCA44B07AC4E /* PlaygroundApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6EA6F80147865B6F32DD526 /* PlaygroundApp.swift */; };
+		97CA6F2DE628A139094EF72D /* Colors.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B46870C2DDF4A2F73A5778B /* Colors.swift */; };
 		C437D38FD2B064F815AE6F33 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = CAC67DC1CDDC454A7BB7870A /* Assets.xcassets */; };
 		EA349DF37933D70B410F7135 /* DiscoverTab.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF86B8E1368C9B39424F13C0 /* DiscoverTab.swift */; };
 /* End PBXBuildFile section */
@@ -18,8 +20,10 @@
 /* Begin PBXFileReference section */
 		0C5B41C44C18F0045A6B61C2 /* Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Release.xcconfig; sourceTree = "<group>"; };
 		25213AE8A9FD9A5B1EEFD97F /* DemosTab.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DemosTab.swift; sourceTree = "<group>"; };
+		2B46870C2DDF4A2F73A5778B /* Colors.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Colors.swift; sourceTree = "<group>"; };
 		64FD18EC8D1B9A665615C374 /* SettingsTab.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsTab.swift; sourceTree = "<group>"; };
 		BDA9169E926B14087F3B1BA2 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
+		C2F4747AC5700DF138836D5F /* Theme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Theme.swift; sourceTree = "<group>"; };
 		C6D8C10EFC976E6B3CCD16BD /* Debug.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Debug.xcconfig; sourceTree = "<group>"; };
 		C6EA6F80147865B6F32DD526 /* PlaygroundApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlaygroundApp.swift; sourceTree = "<group>"; };
 		CAC67DC1CDDC454A7BB7870A /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder; name = Assets.xcassets; path = Sources/Assets.xcassets; sourceTree = SOURCE_ROOT; };
@@ -37,6 +41,15 @@
 			name = Products;
 			sourceTree = "<group>";
 		};
+		6BB7FE49E94ED3C6DF5E9D08 /* Theme */ = {
+			isa = PBXGroup;
+			children = (
+				2B46870C2DDF4A2F73A5778B /* Colors.swift */,
+				C2F4747AC5700DF138836D5F /* Theme.swift */,
+			);
+			path = Theme;
+			sourceTree = "<group>";
+		};
 		AABC9BE64A1302199D5D2AF8 /* Sources */ = {
 			isa = PBXGroup;
 			children = (
@@ -44,6 +57,7 @@
 				BDA9169E926B14087F3B1BA2 /* Info.plist */,
 				C6EA6F80147865B6F32DD526 /* PlaygroundApp.swift */,
 				EAF2D62F55B68E2361617BFC /* Tabs */,
+				6BB7FE49E94ED3C6DF5E9D08 /* Theme */,
 			);
 			path = Sources;
 			sourceTree = "<group>";
@@ -147,11 +161,13 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				97CA6F2DE628A139094EF72D /* Colors.swift in Sources */,
 				5339DAC5909A688059ABBA80 /* ContentView.swift in Sources */,
 				15B37A3EDBAFD6BD0FC98BFC /* DemosTab.swift in Sources */,
 				EA349DF37933D70B410F7135 /* DiscoverTab.swift in Sources */,
 				553F94B4D033BCA44B07AC4E /* PlaygroundApp.swift in Sources */,
 				54C16E199D10E281E1E316CF /* SettingsTab.swift in Sources */,
+				007B2120C2735B42A20C510B /* Theme.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ios/Playground/Sources/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/ios/Playground/Sources/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,6 +1,15 @@
 {
   "colors" : [
     {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x00",
+          "green" : "0x00",
+          "red" : "0xFF"
+        }
+      },
       "idiom" : "universal"
     }
   ],

--- a/ios/Playground/Sources/ContentView.swift
+++ b/ios/Playground/Sources/ContentView.swift
@@ -8,6 +8,7 @@ enum Tab: Hashable {
 
 struct ContentView: View {
     @State private var selectedTab: Tab = .discover
+    @Environment(\.autoMobileTheme) private var theme
 
     var body: some View {
         TabView(selection: $selectedTab) {
@@ -29,9 +30,11 @@ struct ContentView: View {
                 }
                 .tag(Tab.settings)
         }
+        .tint(.autoMobileRed)
     }
 }
 
 #Preview {
     ContentView()
+        .autoMobileTheme()
 }

--- a/ios/Playground/Sources/PlaygroundApp.swift
+++ b/ios/Playground/Sources/PlaygroundApp.swift
@@ -5,6 +5,7 @@ struct PlaygroundApp: App {
     var body: some Scene {
         WindowGroup {
             ContentView()
+                .autoMobileTheme()
         }
     }
 }

--- a/ios/Playground/Sources/Tabs/DemosTab.swift
+++ b/ios/Playground/Sources/Tabs/DemosTab.swift
@@ -1,6 +1,8 @@
 import SwiftUI
 
 struct DemosTab: View {
+    @Environment(\.autoMobileTheme) private var theme
+
     var body: some View {
         NavigationStack {
             List {
@@ -79,20 +81,22 @@ struct DemoRow: View {
     let title: String
     let description: String
     let icon: String
+    @Environment(\.autoMobileTheme) private var theme
 
     var body: some View {
         HStack(spacing: 12) {
             Image(systemName: icon)
                 .font(.title2)
-                .foregroundStyle(.blue)
+                .foregroundStyle(theme.primary)
                 .frame(width: 40)
 
             VStack(alignment: .leading, spacing: 2) {
                 Text(title)
                     .font(.headline)
+                    .foregroundStyle(theme.textPrimary)
                 Text(description)
                     .font(.caption)
-                    .foregroundStyle(.secondary)
+                    .foregroundStyle(theme.textSecondary)
             }
         }
         .padding(.vertical, 4)
@@ -103,24 +107,28 @@ struct DemoRow: View {
 
 struct ScrollPerformanceDemo: View {
     private let items = (1...1000).map { "Item \($0)" }
+    @Environment(\.autoMobileTheme) private var theme
 
     var body: some View {
         List(items, id: \.self) { item in
             HStack {
                 Circle()
-                    .fill(Color.blue.gradient)
+                    .fill(theme.primary)
                     .frame(width: 40, height: 40)
 
                 VStack(alignment: .leading) {
                     Text(item)
                         .font(.headline)
+                        .foregroundStyle(theme.textPrimary)
                     Text("Scroll quickly to test performance")
                         .font(.caption)
-                        .foregroundStyle(.secondary)
+                        .foregroundStyle(theme.textSecondary)
                 }
             }
             .padding(.vertical, 4)
         }
+        .scrollContentBackground(.hidden)
+        .background(theme.background)
         .navigationTitle("Scroll Performance")
         .navigationBarTitleDisplayMode(.inline)
     }
@@ -132,6 +140,7 @@ struct AnimationDemo: View {
     @State private var isAnimating = false
     @State private var rotation: Double = 0
     @State private var scale: CGFloat = 1.0
+    @Environment(\.autoMobileTheme) private var theme
 
     var body: some View {
         ScrollView {
@@ -140,10 +149,11 @@ struct AnimationDemo: View {
                 VStack(spacing: 8) {
                     Text("Continuous Rotation")
                         .font(.headline)
+                        .foregroundStyle(theme.textPrimary)
 
                     Image(systemName: "gear")
                         .font(.system(size: 60))
-                        .foregroundStyle(.blue)
+                        .foregroundStyle(theme.primary)
                         .rotationEffect(.degrees(rotation))
                         .onAppear {
                             withAnimation(.linear(duration: 2).repeatForever(autoreverses: false)) {
@@ -156,9 +166,10 @@ struct AnimationDemo: View {
                 VStack(spacing: 8) {
                     Text("Tap to Scale")
                         .font(.headline)
+                        .foregroundStyle(theme.textPrimary)
 
                     Circle()
-                        .fill(Color.purple.gradient)
+                        .fill(Color.autoMobileRed)
                         .frame(width: 80, height: 80)
                         .scaleEffect(scale)
                         .onTapGesture {
@@ -172,22 +183,25 @@ struct AnimationDemo: View {
                 VStack(spacing: 8) {
                     Text("Toggle Animation")
                         .font(.headline)
+                        .foregroundStyle(theme.textPrimary)
 
                     RoundedRectangle(cornerRadius: 12)
-                        .fill(isAnimating ? Color.green.gradient : Color.orange.gradient)
+                        .fill(isAnimating ? theme.primary : Color.autoMobileDarkGrey)
                         .frame(width: isAnimating ? 200 : 100, height: 60)
                         .animation(.easeInOut(duration: 0.5), value: isAnimating)
 
                     Button(isAnimating ? "Reset" : "Animate") {
                         isAnimating.toggle()
                     }
-                    .buttonStyle(.bordered)
+                    .buttonStyle(.borderedProminent)
+                    .tint(theme.primary)
                 }
 
                 Spacer()
             }
             .padding()
         }
+        .background(theme.background)
         .navigationTitle("Animations")
         .navigationBarTitleDisplayMode(.inline)
     }
@@ -200,6 +214,7 @@ struct HeavyComputationDemo: View {
     @State private var isComputing = false
     @State private var progress: Double = 0
     @State private var selectedDuration: Double = 1.0
+    @Environment(\.autoMobileTheme) private var theme
 
     private let durations: [Double] = [0.5, 1.0, 2.0, 3.0, 5.0]
 
@@ -211,10 +226,11 @@ struct HeavyComputationDemo: View {
                     Text("Block Main Thread")
                         .font(.title2)
                         .fontWeight(.bold)
+                        .foregroundStyle(theme.textPrimary)
 
                     Text("This will freeze the UI completely by sleeping on the main thread. Use this to test jank detection.")
                         .font(.body)
-                        .foregroundStyle(.secondary)
+                        .foregroundStyle(theme.textSecondary)
                         .multilineTextAlignment(.center)
                         .padding(.horizontal)
 
@@ -222,7 +238,7 @@ struct HeavyComputationDemo: View {
                     VStack(spacing: 8) {
                         Text("Duration: \(String(format: "%.1f", selectedDuration))s")
                             .font(.subheadline)
-                            .foregroundStyle(.secondary)
+                            .foregroundStyle(theme.textSecondary)
 
                         Picker("Duration", selection: $selectedDuration) {
                             ForEach(durations, id: \.self) { duration in
@@ -239,10 +255,10 @@ struct HeavyComputationDemo: View {
                         Label("Block Main Thread", systemImage: "exclamationmark.triangle.fill")
                     }
                     .buttonStyle(.borderedProminent)
-                    .tint(.red)
+                    .tint(.autoMobileRed)
                 }
                 .padding()
-                .background(Color.red.opacity(0.1))
+                .background(Color.autoMobileRed.opacity(0.1))
                 .cornerRadius(12)
 
                 Divider()
@@ -253,15 +269,17 @@ struct HeavyComputationDemo: View {
                     Text("Background Computation")
                         .font(.title2)
                         .fontWeight(.bold)
+                        .foregroundStyle(theme.textPrimary)
 
                     Text("This runs intensive calculations in the background without blocking the UI.")
                         .font(.body)
-                        .foregroundStyle(.secondary)
+                        .foregroundStyle(theme.textSecondary)
                         .multilineTextAlignment(.center)
                         .padding(.horizontal)
 
                     ProgressView(value: progress)
                         .padding(.horizontal, 40)
+                        .tint(theme.primary)
 
                     Button {
                         startComputation()
@@ -274,24 +292,27 @@ struct HeavyComputationDemo: View {
                         }
                     }
                     .buttonStyle(.borderedProminent)
+                    .tint(theme.primary)
                     .disabled(isComputing)
                 }
                 .padding()
-                .background(Color.blue.opacity(0.1))
+                .background(theme.surfaceVariant)
                 .cornerRadius(12)
 
                 // Result display
                 Text(result)
                     .font(.system(.body, design: .monospaced))
+                    .foregroundStyle(theme.textPrimary)
                     .padding()
                     .frame(maxWidth: .infinity)
-                    .background(Color.secondary.opacity(0.1))
+                    .background(theme.surfaceVariant)
                     .cornerRadius(8)
 
                 Spacer()
             }
             .padding()
         }
+        .background(theme.background)
         .navigationTitle("Heavy Computation")
         .navigationBarTitleDisplayMode(.inline)
     }
@@ -455,29 +476,33 @@ struct SheetContent: View {
 
 struct AccessibilityDemo: View {
     @State private var dynamicTypeSize: DynamicTypeSize = .large
+    @Environment(\.autoMobileTheme) private var theme
 
     var body: some View {
         List {
             Section {
                 Text("Dynamic Type Preview")
                     .font(.headline)
+                    .foregroundStyle(theme.textPrimary)
 
                 Text("This text will scale with Dynamic Type settings. Try changing the text size in Settings > Accessibility > Display & Text Size.")
                     .dynamicTypeSize(dynamicTypeSize)
+                    .foregroundStyle(theme.textSecondary)
             }
 
             Section("VoiceOver Labels") {
                 HStack {
                     Image(systemName: "star.fill")
-                        .foregroundStyle(.yellow)
+                        .foregroundStyle(Color.autoMobileWarning)
                         .accessibilityLabel("Favorite")
 
                     Text("Favorite Item")
+                        .foregroundStyle(theme.textPrimary)
 
                     Spacer()
 
                     Image(systemName: "checkmark.circle.fill")
-                        .foregroundStyle(.green)
+                        .foregroundStyle(Color.autoMobileSuccess)
                         .accessibilityLabel("Completed")
                 }
                 .accessibilityElement(children: .combine)
@@ -491,32 +516,45 @@ struct AccessibilityDemo: View {
                         Text("Add Item")
                     }
                 }
+                .tint(theme.primary)
                 .accessibilityHint("Double tap to add a new item")
             }
 
-            Section("Semantic Colors") {
+            Section("AutoMobile Colors") {
                 HStack {
                     Rectangle()
-                        .fill(.primary)
+                        .fill(Color.autoMobileLalala)
                         .frame(width: 40, height: 40)
-                    Text("Primary")
+                        .cornerRadius(4)
+                    Text("Primary (Lalala)")
+                        .foregroundStyle(theme.textPrimary)
                 }
 
                 HStack {
                     Rectangle()
-                        .fill(.secondary)
+                        .fill(Color.autoMobileRed)
                         .frame(width: 40, height: 40)
-                    Text("Secondary")
+                        .cornerRadius(4)
+                    Text("Secondary (Red)")
+                        .foregroundStyle(theme.textPrimary)
                 }
 
                 HStack {
                     Rectangle()
-                        .fill(Color.accentColor)
+                        .fill(Color.autoMobileEggshell)
                         .frame(width: 40, height: 40)
-                    Text("Accent")
+                        .cornerRadius(4)
+                        .overlay(
+                            RoundedRectangle(cornerRadius: 4)
+                                .stroke(Color.autoMobileLightGrey, lineWidth: 1)
+                        )
+                    Text("Background (Eggshell)")
+                        .foregroundStyle(theme.textPrimary)
                 }
             }
         }
+        .scrollContentBackground(.hidden)
+        .background(theme.background)
         .navigationTitle("Accessibility")
         .navigationBarTitleDisplayMode(.inline)
     }
@@ -524,4 +562,5 @@ struct AccessibilityDemo: View {
 
 #Preview {
     DemosTab()
+        .autoMobileTheme()
 }

--- a/ios/Playground/Sources/Tabs/DiscoverTab.swift
+++ b/ios/Playground/Sources/Tabs/DiscoverTab.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 struct DiscoverTab: View {
     @State private var searchText = ""
+    @Environment(\.autoMobileTheme) private var theme
 
     private let videos = [
         VideoItem(id: "1", title: "Getting Started with SwiftUI", thumbnail: "video.fill", duration: "10:23"),
@@ -25,6 +26,8 @@ struct DiscoverTab: View {
                     VideoRowView(video: video)
                 }
             }
+            .scrollContentBackground(.hidden)
+            .background(theme.background)
             .navigationTitle("Discover")
             .searchable(text: $searchText, prompt: "Search videos")
             .navigationDestination(for: VideoItem.self) { video in
@@ -43,24 +46,26 @@ struct VideoItem: Identifiable, Hashable {
 
 struct VideoRowView: View {
     let video: VideoItem
+    @Environment(\.autoMobileTheme) private var theme
 
     var body: some View {
         HStack(spacing: 12) {
             Image(systemName: video.thumbnail)
                 .font(.system(size: 24))
-                .foregroundStyle(.blue)
+                .foregroundStyle(theme.primary)
                 .frame(width: 60, height: 40)
-                .background(Color.blue.opacity(0.1))
+                .background(theme.surfaceVariant)
                 .cornerRadius(8)
 
             VStack(alignment: .leading, spacing: 4) {
                 Text(video.title)
                     .font(.headline)
+                    .foregroundStyle(theme.textPrimary)
                     .lineLimit(2)
 
                 Text(video.duration)
                     .font(.caption)
-                    .foregroundStyle(.secondary)
+                    .foregroundStyle(theme.textSecondary)
             }
         }
         .padding(.vertical, 4)
@@ -69,18 +74,19 @@ struct VideoRowView: View {
 
 struct VideoDetailView: View {
     let video: VideoItem
+    @Environment(\.autoMobileTheme) private var theme
 
     var body: some View {
         VStack(spacing: 20) {
             // Video player placeholder
             ZStack {
                 Rectangle()
-                    .fill(Color.black)
+                    .fill(Color.autoMobileBlack)
                     .aspectRatio(16/9, contentMode: .fit)
 
                 Image(systemName: "play.circle.fill")
                     .font(.system(size: 60))
-                    .foregroundStyle(.white)
+                    .foregroundStyle(Color.autoMobileWhite)
             }
             .cornerRadius(12)
             .padding(.horizontal)
@@ -89,14 +95,15 @@ struct VideoDetailView: View {
                 Text(video.title)
                     .font(.title2)
                     .fontWeight(.bold)
+                    .foregroundStyle(theme.textPrimary)
 
                 Text("Duration: \(video.duration)")
                     .font(.subheadline)
-                    .foregroundStyle(.secondary)
+                    .foregroundStyle(theme.textSecondary)
 
                 Text("This is a sample video for testing the AutoMobile iOS Playground app. The video demonstrates various features and capabilities.")
                     .font(.body)
-                    .foregroundStyle(.secondary)
+                    .foregroundStyle(theme.textSecondary)
                     .padding(.top, 8)
             }
             .frame(maxWidth: .infinity, alignment: .leading)
@@ -104,6 +111,7 @@ struct VideoDetailView: View {
 
             Spacer()
         }
+        .background(theme.background)
         .navigationTitle("Video")
         .navigationBarTitleDisplayMode(.inline)
     }
@@ -111,4 +119,5 @@ struct VideoDetailView: View {
 
 #Preview {
     DiscoverTab()
+        .autoMobileTheme()
 }

--- a/ios/Playground/Sources/Tabs/SettingsTab.swift
+++ b/ios/Playground/Sources/Tabs/SettingsTab.swift
@@ -5,6 +5,7 @@ struct SettingsTab: View {
     @AppStorage("notificationsEnabled") private var notificationsEnabled = true
     @AppStorage("darkModeEnabled") private var darkModeEnabled = false
     @AppStorage("analyticsEnabled") private var analyticsEnabled = true
+    @Environment(\.autoMobileTheme) private var theme
 
     var body: some View {
         NavigationStack {
@@ -13,14 +14,15 @@ struct SettingsTab: View {
                     HStack {
                         Image(systemName: "person.circle.fill")
                             .font(.system(size: 50))
-                            .foregroundStyle(.blue)
+                            .foregroundStyle(theme.primary)
 
                         VStack(alignment: .leading) {
                             Text(userName.isEmpty ? "Guest User" : userName)
                                 .font(.headline)
+                                .foregroundStyle(theme.textPrimary)
                             Text("Tap to edit profile")
                                 .font(.caption)
-                                .foregroundStyle(.secondary)
+                                .foregroundStyle(theme.textSecondary)
                         }
                     }
                     .padding(.vertical, 8)
@@ -79,8 +81,11 @@ struct SettingsTab: View {
                     Button("Sign Out", role: .destructive) {
                         userName = ""
                     }
+                    .foregroundStyle(Color.autoMobileRed)
                 }
             }
+            .scrollContentBackground(.hidden)
+            .background(theme.background)
             .navigationTitle("Settings")
         }
     }
@@ -90,6 +95,7 @@ struct StorageSettingsView: View {
     @State private var documents: Double = 125.5
     @State private var cache: Double = 45.2
     @State private var other: Double = 12.8
+    @Environment(\.autoMobileTheme) private var theme
 
     var total: Double { documents + cache + other }
 
@@ -99,21 +105,24 @@ struct StorageSettingsView: View {
                 VStack(spacing: 16) {
                     Text(String(format: "%.1f MB", total))
                         .font(.system(size: 48, weight: .bold, design: .rounded))
+                        .foregroundStyle(theme.textPrimary)
 
                     Text("Total Storage Used")
                         .font(.subheadline)
-                        .foregroundStyle(.secondary)
+                        .foregroundStyle(theme.textSecondary)
                 }
                 .frame(maxWidth: .infinity)
                 .padding(.vertical, 20)
             }
 
             Section("Breakdown") {
-                StorageRow(title: "Documents", size: documents, color: .blue)
-                StorageRow(title: "Cache", size: cache, color: .orange)
-                StorageRow(title: "Other", size: other, color: .gray)
+                StorageRow(title: "Documents", size: documents, color: .autoMobileLalala)
+                StorageRow(title: "Cache", size: cache, color: .autoMobileRed)
+                StorageRow(title: "Other", size: other, color: .autoMobileDarkGrey)
             }
         }
+        .scrollContentBackground(.hidden)
+        .background(theme.background)
         .navigationTitle("Storage")
         .navigationBarTitleDisplayMode(.inline)
     }
@@ -143,6 +152,7 @@ struct StorageRow: View {
 struct CacheSettingsView: View {
     @State private var showingClearAlert = false
     @State private var isClearing = false
+    @Environment(\.autoMobileTheme) private var theme
 
     var body: some View {
         List {
@@ -150,15 +160,16 @@ struct CacheSettingsView: View {
                 VStack(spacing: 12) {
                     Image(systemName: "trash.circle.fill")
                         .font(.system(size: 60))
-                        .foregroundStyle(.red)
+                        .foregroundStyle(Color.autoMobileRed)
 
                     Text("45.2 MB")
                         .font(.title)
                         .fontWeight(.bold)
+                        .foregroundStyle(theme.textPrimary)
 
                     Text("Cached data can be safely cleared")
                         .font(.subheadline)
-                        .foregroundStyle(.secondary)
+                        .foregroundStyle(theme.textSecondary)
                         .multilineTextAlignment(.center)
                 }
                 .frame(maxWidth: .infinity)
@@ -179,9 +190,12 @@ struct CacheSettingsView: View {
                         Spacer()
                     }
                 }
+                .foregroundStyle(Color.autoMobileRed)
                 .disabled(isClearing)
             }
         }
+        .scrollContentBackground(.hidden)
+        .background(theme.background)
         .navigationTitle("Clear Cache")
         .navigationBarTitleDisplayMode(.inline)
         .alert("Clear Cache?", isPresented: $showingClearAlert) {
@@ -204,4 +218,5 @@ struct CacheSettingsView: View {
 
 #Preview {
     SettingsTab()
+        .autoMobileTheme()
 }

--- a/ios/Playground/Sources/Theme/Colors.swift
+++ b/ios/Playground/Sources/Theme/Colors.swift
@@ -1,0 +1,40 @@
+import SwiftUI
+
+// MARK: - Design System Color Palette
+
+extension Color {
+    // Core AutoMobile colors
+    static let autoMobileBlack = Color(hex: 0x000000)
+    static let autoMobileRed = Color(hex: 0xFF0000) // Only for standalone "AutoMobile" word/wordmark
+    static let autoMobileEggshell = Color(hex: 0xF8F8FF)
+    static let autoMobileLalala = Color(hex: 0x1A1A1A)
+    static let autoMobileWhite = Color(hex: 0xFFFFFF)
+
+    // Promo video colors
+    static let promoOrange = Color(hex: 0xFF3300)
+    static let promoBlue = Color(hex: 0x525FE1)
+
+    // Greys
+    static let autoMobileLightGrey = Color(hex: 0xBDBDBD)
+    static let autoMobileDarkGrey = Color(hex: 0x424242)
+
+    // Semantic colors for states
+    static let autoMobileSuccess = Color(hex: 0x4CAF50)
+    static let autoMobileWarning = Color(hex: 0xFF9800)
+    static let autoMobileError = Color(hex: 0xF44336)
+    static let autoMobileInfo = Color.promoBlue
+}
+
+// MARK: - Color Hex Initializer
+
+extension Color {
+    init(hex: UInt, alpha: Double = 1.0) {
+        self.init(
+            .sRGB,
+            red: Double((hex >> 16) & 0xFF) / 255.0,
+            green: Double((hex >> 8) & 0xFF) / 255.0,
+            blue: Double(hex & 0xFF) / 255.0,
+            opacity: alpha
+        )
+    }
+}

--- a/ios/Playground/Sources/Theme/Theme.swift
+++ b/ios/Playground/Sources/Theme/Theme.swift
@@ -1,0 +1,118 @@
+import SwiftUI
+
+// MARK: - AutoMobile Theme
+
+struct AutoMobileTheme {
+    let colorScheme: ColorScheme
+
+    // Primary colors
+    var primary: Color {
+        colorScheme == .dark ? .autoMobileWhite : .autoMobileLalala
+    }
+
+    var onPrimary: Color {
+        colorScheme == .dark ? .autoMobileLalala : .autoMobileWhite
+    }
+
+    // Secondary colors (red accent)
+    var secondary: Color { .autoMobileRed }
+    var onSecondary: Color { .autoMobileWhite }
+
+    // Background colors
+    var background: Color {
+        colorScheme == .dark ? .autoMobileBlack : .autoMobileEggshell
+    }
+
+    var onBackground: Color {
+        colorScheme == .dark ? .autoMobileWhite : .autoMobileLalala
+    }
+
+    // Surface colors
+    var surface: Color {
+        colorScheme == .dark ? .autoMobileLalala : .autoMobileWhite
+    }
+
+    var onSurface: Color {
+        colorScheme == .dark ? .autoMobileWhite : .autoMobileBlack
+    }
+
+    var surfaceVariant: Color {
+        colorScheme == .dark ? .autoMobileLalala : .autoMobileEggshell
+    }
+
+    // Semantic colors
+    var success: Color { .autoMobileSuccess }
+    var warning: Color { .autoMobileWarning }
+    var error: Color { .autoMobileError }
+    var info: Color { .autoMobileInfo }
+
+    // Text colors
+    var textPrimary: Color { onSurface }
+    var textSecondary: Color {
+        colorScheme == .dark ? .autoMobileLightGrey : .autoMobileDarkGrey
+    }
+}
+
+// MARK: - Environment Key
+
+private struct AutoMobileThemeKey: EnvironmentKey {
+    static let defaultValue = AutoMobileTheme(colorScheme: .light)
+}
+
+extension EnvironmentValues {
+    var autoMobileTheme: AutoMobileTheme {
+        get { self[AutoMobileThemeKey.self] }
+        set { self[AutoMobileThemeKey.self] = newValue }
+    }
+}
+
+// MARK: - Theme View Modifier
+
+struct AutoMobileThemeModifier: ViewModifier {
+    @Environment(\.colorScheme) private var colorScheme
+
+    func body(content: Content) -> some View {
+        content
+            .environment(\.autoMobileTheme, AutoMobileTheme(colorScheme: colorScheme))
+            .tint(.autoMobileRed)
+            .accentColor(.autoMobileRed)
+    }
+}
+
+extension View {
+    func autoMobileTheme() -> some View {
+        modifier(AutoMobileThemeModifier())
+    }
+}
+
+// MARK: - Themed View Helpers
+
+extension View {
+    func autoMobileSurface() -> some View {
+        modifier(AutoMobileSurfaceModifier())
+    }
+
+    func autoMobileBackground() -> some View {
+        modifier(AutoMobileBackgroundModifier())
+    }
+}
+
+struct AutoMobileSurfaceModifier: ViewModifier {
+    @Environment(\.autoMobileTheme) private var theme
+
+    func body(content: Content) -> some View {
+        content
+            .background(theme.surface)
+            .foregroundStyle(theme.onSurface)
+    }
+}
+
+struct AutoMobileBackgroundModifier: ViewModifier {
+    @Environment(\.autoMobileTheme) private var theme
+
+    func body(content: Content) -> some View {
+        content
+            .background(theme.background)
+            .foregroundStyle(theme.onBackground)
+    }
+}

--- a/ios/Playground/project.yml
+++ b/ios/Playground/project.yml
@@ -21,6 +21,7 @@ targets:
       - path: Sources
         excludes:
           - "*.xcassets"
+      - path: Sources/Theme
       - path: Sources/Assets.xcassets
         type: folder
     settings:


### PR DESCRIPTION
## Summary
- Add Theme/Colors.swift with AutoMobile color palette (black, red, eggshell, lalala, white)
- Add Theme/Theme.swift with environment-based theming for light/dark mode
- Update all iOS Playground tabs (Discover, Demos, Settings) to use theme colors
- Set accent color to AutoMobile red (#FF0000)

## Test Plan
- [x] Build succeeds for iOS Playground
- [x] App launches on iOS simulator
- [x] Theme colors match Android design system

🤖 Generated with [Claude Code](https://claude.com/claude-code)