### PR TITLE
fix: add timeouts to prevent hot-reload script from hanging on cleanup

### DIFF
--- a/scripts/local-dev/hot-reload.sh
+++ b/scripts/local-dev/hot-reload.sh
@@ -127,6 +127,13 @@ kill_previous() {
   if [[ -n "${pids}" ]]; then
     log_info "Killing orphaned hot-reload processes..."
     echo "${pids}" | xargs kill 2>/dev/null || true
+    sleep 1
+    # Force kill if still running
+    pids=$(pgrep -f "hot-reload.sh" 2>/dev/null | grep -v "$$" || true)
+    if [[ -n "${pids}" ]]; then
+      log_warn "Force killing orphaned hot-reload processes..."
+      echo "${pids}" | xargs kill -9 2>/dev/null || true
+    fi
   fi
 }
 
@@ -134,15 +141,42 @@ kill_previous() {
 reload_mcp_daemon() {
   log_info "Restarting MCP daemon..."
   if command -v auto-mobile >/dev/null 2>&1; then
-    auto-mobile --daemon restart --debug --debug-perf 2>&1 | while read -r line; do
-      log_info "[daemon] ${line}"
+    # Run daemon restart in background with timeout to prevent hanging
+    auto-mobile --daemon restart --debug --debug-perf >/dev/null 2>&1 &
+    local daemon_pid=$!
+
+    # Wait up to 30 seconds for daemon restart
+    local count=0
+    while kill -0 "${daemon_pid}" 2>/dev/null && [[ ${count} -lt 30 ]]; do
+      sleep 1
+      ((count++))
     done
+
+    if kill -0 "${daemon_pid}" 2>/dev/null; then
+      log_warn "Daemon restart timed out, force killing..."
+      kill -9 "${daemon_pid}" 2>/dev/null || true
+      # Also kill any daemon processes
+      local pids
+      pids=$(pgrep -f "auto-mobile.*--daemon-mode" 2>/dev/null || true)
+      if [[ -n "${pids}" ]]; then
+        echo "${pids}" | xargs kill -9 2>/dev/null || true
+      fi
+    else
+      log_info "MCP daemon restarted."
+    fi
   else
     local pids
     pids=$(pgrep -f "auto-mobile.*--daemon-mode" 2>/dev/null || true)
     if [[ -n "${pids}" ]]; then
       log_info "Killing daemon processes: ${pids}"
       echo "${pids}" | xargs kill 2>/dev/null || true
+      sleep 1
+      # Force kill if still running
+      pids=$(pgrep -f "auto-mobile.*--daemon-mode" 2>/dev/null || true)
+      if [[ -n "${pids}" ]]; then
+        log_warn "Force killing daemon processes..."
+        echo "${pids}" | xargs kill -9 2>/dev/null || true
+      fi
     fi
   fi
 }

--- a/scripts/local-dev/lib/xctestservice.sh
+++ b/scripts/local-dev/lib/xctestservice.sh
@@ -225,7 +225,19 @@ stop_xctestservice() {
   if [[ -n "${XCODEBUILD_PID}" ]] && kill -0 "${XCODEBUILD_PID}" 2>/dev/null; then
     log_info "Stopping XCTestService (PID ${XCODEBUILD_PID})..."
     kill "${XCODEBUILD_PID}" 2>/dev/null || true
-    wait "${XCODEBUILD_PID}" 2>/dev/null || true
+
+    # Wait up to 5 seconds for graceful exit
+    local count=0
+    while kill -0 "${XCODEBUILD_PID}" 2>/dev/null && [[ ${count} -lt 5 ]]; do
+      sleep 1
+      ((count++))
+    done
+
+    # Force kill if still running
+    if kill -0 "${XCODEBUILD_PID}" 2>/dev/null; then
+      log_warn "Force killing XCTestService..."
+      kill -9 "${XCODEBUILD_PID}" 2>/dev/null || true
+    fi
   fi
   XCODEBUILD_PID=""
 }


### PR DESCRIPTION
## Summary
- Fix `stop_xctestservice()` hanging due to blocking `wait` - xcodebuild often ignores SIGTERM
- Fix `reload_mcp_daemon()` hanging due to blocking `while read` loop waiting for daemon output
- Add force kill follow-up for orphaned hot-reload and daemon processes

## Changes
1. **`lib/xctestservice.sh`**: Replace `wait` with 5-second polling timeout, then `kill -9`
2. **`hot-reload.sh` - `reload_mcp_daemon()`**: Run daemon restart in background with 30-second timeout
3. **`hot-reload.sh` - `kill_previous()`**: Add force kill for orphaned processes after 1 second

## Test plan
- [ ] Run `scripts/local-dev/hot-reload.sh` and press Ctrl+C - should exit within ~5 seconds
- [ ] Verify XCTestService cleanup doesn't hang when simulator tests are running

🤖 Generated with [Claude Code](https://claude.com/claude-code)