### PR TITLE
fix: run npm install in hot-reload after Node 24 confirmation 

### DIFF
--- a/scripts/local-dev/lib/deps.sh
+++ b/scripts/local-dev/lib/deps.sh
@@ -436,6 +436,13 @@ ensure_dependencies() {
     return 1
   fi
 
+  # Install npm dependencies after Node and Bun are confirmed
+  log_info "Installing npm dependencies..."
+  if ! (cd "${PROJECT_ROOT}" && npm install); then
+    log_error "Failed to install npm dependencies."
+    return 1
+  fi
+
   # Check/install auto-mobile globally
   if ! ensure_auto_mobile; then
     log_error "auto-mobile global installation failed."


### PR DESCRIPTION
  Ensures `npm install` runs immediately after Node 24 and Bun are confirmed in the `hot-reload` script.
