### PR TITLE
fix(ios): use fresh springboard instance for system alert detection

### DIFF
--- a/ios/XCTestService/Sources/XCTestService/ElementLocator.swift
+++ b/ios/XCTestService/Sources/XCTestService/ElementLocator.swift
@@ -532,16 +532,18 @@ public class ElementLocator: ElementLocating {
         /// Get alerts from the foreground app.
         /// Some iOS versions surface permission dialogs as alerts on the foreground app
         /// rather than (or in addition to) springboard.
+        /// IMPORTANT: Creates a fresh XCUIApplication instance to avoid stale cached state.
         private func getAlertsFromForegroundApp() -> [UIElementInfo] {
-            guard let app = foregroundApp else { return [] }
+            guard let bundleId = foregroundBundleId else { return [] }
 
             let alertSnapshots: [XCUIElementSnapshot] = runOnMainThread {
-                let alertCount = app.alerts.count
+                let freshApp = XCUIApplication(bundleIdentifier: bundleId)
+                let alertCount = freshApp.alerts.count
                 guard alertCount > 0 else { return [] }
 
                 var snapshots: [XCUIElementSnapshot] = []
                 for i in 0 ..< alertCount {
-                    let alert = app.alerts.element(boundBy: i)
+                    let alert = freshApp.alerts.element(boundBy: i)
                     do {
                         let snapshot = try alert.snapshot()
                         snapshots.append(snapshot)


### PR DESCRIPTION
## Summary
- Fixes system permission dialogs (location, camera, notifications) being invisible in the view hierarchy (#1147)
- The cached `self.springboard` lazy var returned stale state, causing `alerts.count` to return 0 even when alerts were present
- Creates a fresh `XCUIApplication("com.apple.springboard")` on each `getSystemAlerts()` call, matching the pattern already used by `ensureForegroundApp()`
- Also checks foreground app `.alerts` as a secondary source (some iOS versions surface permission dialogs there), with deduplication by label text

## Test plan
- [x] `./scripts/ios/swift-build.sh` — XCTestService compiles successfully
- [ ] Manual: launch app that triggers permission dialog, run `observe`, verify hierarchy includes alert buttons

🤖 Generated with [Claude Code](https://claude.com/claude-code)