### PR TITLE
refactor: make hot-reload.sh delegate dependency installation to install.sh

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@kaeawc/auto-mobile",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@kaeawc/auto-mobile",
-      "version": "0.0.8",
+      "version": "0.0.9",
       "license": "Apache-2.0",
       "dependencies": {
-        "@anthropic-ai/sdk": "^0.71.2",
+        "@anthropic-ai/sdk": "^0.72.1",
         "@huggingface/transformers": "^3.8.1",
         "@modelcontextprotocol/sdk": "^1.25.2",
         "@types/js-yaml": "^4.0.9",
@@ -20,7 +20,7 @@
         "ajv-formats": "^3.0.1",
         "async-mutex": "^0.5.0",
         "fs-extra": "^11.3.3",
-        "glob": "^13.0.0",
+        "glob": "^13.0.1",
         "hono": "4.11.7",
         "jimp": "^1.6.0",
         "js-tiktoken": "^1.0.21",
@@ -74,9 +74,9 @@
       }
     },
     "node_modules/@anthropic-ai/sdk": {
-      "version": "0.71.2",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.71.2.tgz",
-      "integrity": "sha512-TGNDEUuEstk/DKu0/TflXAEt+p+p/WhTlFzEnoosvbaDU2LTjm42igSdlL0VijrKpWejtOKxX0b8A7uc+XiSAQ==",
+      "version": "0.72.1",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.72.1.tgz",
+      "integrity": "sha512-MiUnue7qN7DvLIoYHgkedN2z05mRf2CutBzjXXY2krzOhG2r/rIfISS2uVkNLikgToB5hYIzw+xp2jdOtRkqYQ==",
       "license": "MIT",
       "dependencies": {
         "json-schema-to-ts": "^3.1.1"
@@ -1408,9 +1408,9 @@
       }
     },
     "node_modules/@isaacs/brace-expansion": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@isaacs/brace-expansion/-/brace-expansion-5.0.0.tgz",
-      "integrity": "sha512-ZT55BDLV0yv0RBm2czMiZ+SqCGO7AvmOM3G/w2xhVPH+te0aKgFjmBvGlL1dH+ql2tgGO3MVrbb3jCKyvpgnxA==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@isaacs/brace-expansion/-/brace-expansion-5.0.1.tgz",
+      "integrity": "sha512-WMz71T1JS624nWj2n2fnYAuPovhv7EUhk69R6i9dsVyzxt5eM3bjwvgk9L+APE1TRscGysAVMANkB0jh0LQZrQ==",
       "license": "MIT",
       "dependencies": {
         "@isaacs/balanced-match": "^4.0.1"
@@ -5041,12 +5041,12 @@
       }
     },
     "node_modules/glob": {
-      "version": "13.0.0",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.0.tgz",
-      "integrity": "sha512-tvZgpqk6fz4BaNZ66ZsRaZnbHvP/jG3uKJvAZOwEVUL4RTA5nJeeLYfyN9/VA8NX/V3IBG+hkeuGpKjvELkVhA==",
+      "version": "13.0.1",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.1.tgz",
+      "integrity": "sha512-B7U/vJpE3DkJ5WXTgTpTRN63uV42DseiXXKMwG14LQBXmsdeIoHAPbU/MEo6II0k5ED74uc2ZGTC6MwHFQhF6w==",
       "license": "BlueOak-1.0.0",
       "dependencies": {
-        "minimatch": "^10.1.1",
+        "minimatch": "^10.1.2",
         "minipass": "^7.1.2",
         "path-scurry": "^2.0.0"
       },
@@ -5071,12 +5071,12 @@
       }
     },
     "node_modules/glob/node_modules/minimatch": {
-      "version": "10.1.1",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.1.1.tgz",
-      "integrity": "sha512-enIvLvRAFZYXJzkCYG5RKmPfrFArdLv+R+lbQ53BmIMLIry74bjKzX6iHAm8WYamJkhSSEabrWN5D97XnKObjQ==",
+      "version": "10.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.1.2.tgz",
+      "integrity": "sha512-fu656aJ0n2kcXwsnwnv9g24tkU5uSmOlTjd6WyyaKm2Z+h1qmY6bAjrcaIxF/BslFqbZ8UBtbJi7KgQOZD2PTw==",
       "license": "BlueOak-1.0.0",
       "dependencies": {
-        "@isaacs/brace-expansion": "^5.0.0"
+        "@isaacs/brace-expansion": "^5.0.1"
       },
       "engines": {
         "node": "20 || >=22"
@@ -7811,9 +7811,9 @@
       }
     },
     "node_modules/tar": {
-      "version": "7.5.4",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.4.tgz",
-      "integrity": "sha512-AN04xbWGrSTDmVwlI4/GTlIIwMFk/XEv7uL8aa57zuvRy6s4hdBed+lVq2fAZ89XDa7Us3ANXcE3Tvqvja1kTA==",
+      "version": "7.5.7",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.7.tgz",
+      "integrity": "sha512-fov56fJiRuThVFXD6o6/Q354S7pnWMJIVlDBYijsTNx6jKSE4pvrDTs6lUnmGvNyfJwFQQwWy3owKz1ucIhveQ==",
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "@isaacs/fs-minipass": "^4.0.0",

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -31,6 +31,8 @@ NON_INTERACTIVE=false
 RECORD_MODE=false
 PRESET=""
 CONFIGURE_MCP_CLIENTS=false
+RUN_NPM_INSTALL=false
+ENV_FILE=""
 
 # Gum bundling configuration
 GUM_VERSION="0.17.0"
@@ -84,6 +86,62 @@ fi
 
 command_exists() {
     command -v "$1" >/dev/null 2>&1
+}
+
+# Compare semver versions: returns 0 if $1 >= $2
+version_gte() {
+    local v1="$1"
+    local v2="$2"
+    local sorted
+    sorted=$(printf '%s\n%s\n' "$v1" "$v2" | sort -V | head -n1)
+    [[ "$sorted" == "$v2" ]]
+}
+
+# Required versions (populated by parse_required_versions)
+REQUIRED_BUN_VERSION=""
+REQUIRED_NODE_MAJOR=""
+
+# Parse required versions from package.json (only when IS_REPO=true)
+parse_required_versions() {
+    if [[ "${IS_REPO}" != "true" ]]; then
+        return 0
+    fi
+
+    local package_json="${PROJECT_ROOT}/package.json"
+    if [[ ! -f "${package_json}" ]]; then
+        return 0
+    fi
+
+    # Extract bun version from packageManager field (e.g., "bun@1.3.6")
+    REQUIRED_BUN_VERSION=$(grep -o '"packageManager":[[:space:]]*"bun@[^"]*"' "${package_json}" | \
+        sed 's/.*bun@\([^"]*\).*/\1/' || true)
+
+    if [[ -z "${REQUIRED_BUN_VERSION}" ]]; then
+        # Fallback to engines.bun field
+        REQUIRED_BUN_VERSION=$(grep -o '"bun":[[:space:]]*"[^"]*"' "${package_json}" | \
+            head -1 | sed 's/.*">=\{0,1\}\([0-9.]*\).*/\1/' || true)
+    fi
+
+    # Extract node major version from @types/node (e.g., "^25.0.9" -> 25)
+    REQUIRED_NODE_MAJOR=$(grep -o '"@types/node":[[:space:]]*"[^"]*"' "${package_json}" | \
+        sed 's/.*"\^\{0,1\}\([0-9]*\).*/\1/' || true)
+}
+
+# Write environment state to a file for the caller to source
+write_env_file() {
+    if [[ -z "${ENV_FILE}" ]]; then
+        return 0
+    fi
+
+    {
+        echo "export PATH=\"${PATH}\""
+        if [[ -n "${NVM_DIR:-}" ]]; then
+            echo "export NVM_DIR=\"${NVM_DIR}\""
+        fi
+        if [[ -n "${ANDROID_HOME:-}" ]]; then
+            echo "export ANDROID_HOME=\"${ANDROID_HOME}\""
+        fi
+    } > "${ENV_FILE}"
 }
 
 # Check if auto-mobile CLI is installed
@@ -140,19 +198,22 @@ Usage: ./scripts/install.sh [OPTIONS]
 Options:
   --dry-run           Show what would happen without making changes
   --record-mode       Auto-select defaults and run (for demo recording)
-  --preset NAME       Use preset configuration (minimal, development)
+  --preset NAME       Use preset configuration (minimal, development, local-dev)
   --non-interactive   Skip interactive prompts, use defaults
+  --env-file PATH     Write environment state (PATH, NVM_DIR, ANDROID_HOME) to file
   -h, --help          Show this help message
 
 Presets:
   minimal      - CLI + MCP client configuration only
   development  - Full setup with debug flags and IDE plugin (if available)
+  local-dev    - Dependencies for hot-reload development (bun, npm install)
 
 Examples:
   ./scripts/install.sh --dry-run
   ./scripts/install.sh --record-mode
   ./scripts/install.sh --preset development
   ./scripts/install.sh --preset development --non-interactive
+  ./scripts/install.sh --preset local-dev --non-interactive --env-file /tmp/env
 
 EOF
 }
@@ -180,6 +241,14 @@ parse_args() {
                 RECORD_MODE=true
                 shift
                 ;;
+            --env-file)
+                if [[ -z "${2:-}" ]]; then
+                    plain_error "Missing value for --env-file"
+                    exit 1
+                fi
+                ENV_FILE="$2"
+                shift 2
+                ;;
             --help|-h)
                 show_help
                 exit 0
@@ -195,10 +264,10 @@ parse_args() {
     # Validate preset if provided
     if [[ -n "${PRESET}" ]]; then
         case "${PRESET}" in
-            minimal|development)
+            minimal|development|local-dev)
                 ;;
             *)
-                plain_error "Unknown preset: ${PRESET}. Valid options: minimal, development"
+                plain_error "Unknown preset: ${PRESET}. Valid options: minimal, development, local-dev"
                 exit 1
                 ;;
         esac
@@ -2490,6 +2559,16 @@ start_mcp_daemon() {
 }
 
 handle_bun_setup() {
+    # Enforce version requirement even if bun is already installed
+    if [[ "${BUN_INSTALLED}" == "true" ]] && [[ -n "${REQUIRED_BUN_VERSION}" ]]; then
+        local current_bun_version
+        current_bun_version=$(bun --version 2>/dev/null || true)
+        if [[ -n "${current_bun_version}" ]] && ! version_gte "${current_bun_version}" "${REQUIRED_BUN_VERSION}"; then
+            log_warn "Bun v${current_bun_version} found but v${REQUIRED_BUN_VERSION} required"
+            BUN_INSTALLED=false
+        fi
+    fi
+
     if [[ "${BUN_INSTALLED}" == "true" ]]; then
         return 0
     fi
@@ -3035,6 +3114,16 @@ apply_preset() {
             fi
             CONFIGURE_MCP_CLIENTS=true
             ;;
+        local-dev)
+            # Dependencies for hot-reload local development
+            INSTALL_BUN=true
+            RUN_NPM_INSTALL=true
+            INSTALL_IDE_PLUGIN=false
+            INSTALL_AUTOMOBILE_CLI=false
+            START_DAEMON=false
+            CONFIGURE_MCP_CLIENTS=false
+            INSTALL_CLAUDE_MARKETPLACE=false
+            ;;
         *)
             log_error "Unknown preset: ${preset_name}"
             return 1
@@ -3233,6 +3322,9 @@ main() {
 
     log_info "Starting setup from ${PROJECT_ROOT}"
 
+    # Parse required versions from package.json (when running from repo)
+    parse_required_versions
+
     # =========================================================================
     # Detect current setup BEFORE asking any questions
     # =========================================================================
@@ -3261,6 +3353,28 @@ main() {
             log_info "Node.js: ${node_version} (via nvm)"
         else
             log_info "Node.js: ${node_version}"
+        fi
+
+        # Enforce node version requirement
+        if [[ -n "${REQUIRED_NODE_MAJOR}" ]]; then
+            local current_node_major
+            current_node_major=$(node --version 2>/dev/null | sed 's/^v//' | cut -d. -f1)
+            if [[ -n "${current_node_major}" ]] && [[ "${current_node_major}" -lt "${REQUIRED_NODE_MAJOR}" ]]; then
+                log_warn "Node.js v${current_node_major}.x found but v${REQUIRED_NODE_MAJOR}.x required"
+                # Try nvm switch if available
+                if [[ -n "${NVM_DIR:-}" ]] && [[ -s "${NVM_DIR}/nvm.sh" ]]; then
+                    # shellcheck source=/dev/null
+                    source "${NVM_DIR}/nvm.sh"
+                    if nvm ls "${REQUIRED_NODE_MAJOR}" >/dev/null 2>&1; then
+                        log_info "Switching to Node.js ${REQUIRED_NODE_MAJOR} via nvm..."
+                        nvm use "${REQUIRED_NODE_MAJOR}" >/dev/null 2>&1 || true
+                    elif [[ "${NON_INTERACTIVE}" == "true" ]]; then
+                        log_info "Installing Node.js ${REQUIRED_NODE_MAJOR} via nvm..."
+                        nvm install "${REQUIRED_NODE_MAJOR}" >/dev/null 2>&1 || true
+                        nvm use "${REQUIRED_NODE_MAJOR}" >/dev/null 2>&1 || true
+                    fi
+                fi
+            fi
         fi
     fi
 
@@ -3510,6 +3624,13 @@ main() {
     # Bun setup
     handle_bun_setup
 
+    # npm install (for local-dev preset)
+    if [[ "${RUN_NPM_INSTALL}" == "true" ]] && [[ "${IS_REPO}" == "true" ]]; then
+        if ! execute_spinner "Running npm install" bash -c "cd '${PROJECT_ROOT}' && npm install"; then
+            log_warn "npm install failed"
+        fi
+    fi
+
     # Platform-specific setup
     case "${platform_choice}" in
         Android)
@@ -3555,6 +3676,9 @@ main() {
     if [[ "${START_DAEMON}" == "true" ]]; then
         start_mcp_daemon
     fi
+
+    # Write environment state for callers (e.g., hot-reload.sh)
+    write_env_file
 
     # Print dry-run summary if applicable
     print_dry_run_summary

--- a/scripts/local-dev/lib/deps.sh
+++ b/scripts/local-dev/lib/deps.sh
@@ -2,15 +2,18 @@
 #
 # Dependency detection and installation for local development.
 #
+# Delegates heavy lifting to scripts/install.sh (--preset local-dev),
+# then performs post-install validation and local-only steps (npm link).
+#
 # Required variables (must be set before sourcing):
 #   PROJECT_ROOT - Path to project root
 #
 # Functions:
 #   parse_required_versions()  - Extract required versions from package.json
-#   ensure_gum()               - Detect and install gum for interactive prompts
-#   ensure_node()              - Detect and install/update node (nvm preferred)
-#   ensure_bun()               - Detect and install/update bun
-#   ensure_dependencies()      - Run all dependency checks
+#   version_gte()              - Semver comparison (returns 0 if $1 >= $2)
+#   ensure_gum()               - Check gum availability (installed by install.sh)
+#   ensure_auto_mobile()       - Build and npm link auto-mobile CLI
+#   ensure_dependencies()      - Run all dependency checks via install.sh
 
 # Required versions (populated by parse_required_versions)
 REQUIRED_BUN_VERSION=""
@@ -111,284 +114,9 @@ run_with_spinner() {
   fi
 }
 
-# Ensure gum is installed for interactive prompts
+# Check gum availability (install.sh handles actual installation)
 ensure_gum() {
-  if command -v gum >/dev/null 2>&1; then
-    return 0
-  fi
-
-  log_info "gum not found. Installing for interactive prompts..."
-
-  if [[ "$(uname -s)" == "Darwin" ]]; then
-    if command -v brew >/dev/null 2>&1; then
-      log_info "Installing gum via Homebrew..."
-      if brew install gum >/dev/null 2>&1; then
-        log_info "gum installed successfully."
-        return 0
-      else
-        log_warn "Failed to install gum via Homebrew."
-        return 1
-      fi
-    fi
-  elif [[ "$(uname -s)" == "Linux" ]]; then
-    if command -v apt-get >/dev/null 2>&1; then
-      log_info "Installing gum via apt..."
-      if sudo mkdir -p /etc/apt/keyrings && \
-         curl -fsSL https://repo.charm.sh/apt/gpg.key | sudo gpg --dearmor -o /etc/apt/keyrings/charm.gpg 2>/dev/null && \
-         echo "deb [signed-by=/etc/apt/keyrings/charm.gpg] https://repo.charm.sh/apt/ * *" | sudo tee /etc/apt/sources.list.d/charm.list >/dev/null && \
-         sudo apt-get update -qq && sudo apt-get install -y -qq gum; then
-        log_info "gum installed successfully."
-        return 0
-      fi
-    elif command -v dnf >/dev/null 2>&1; then
-      log_info "Installing gum via dnf..."
-      if echo '[charm]
-name=Charm
-baseurl=https://repo.charm.sh/yum/
-enabled=1
-gpgcheck=1
-gpgkey=https://repo.charm.sh/yum/gpg.key' | sudo tee /etc/yum.repos.d/charm.repo >/dev/null && \
-         sudo dnf install -y -q gum; then
-        log_info "gum installed successfully."
-        return 0
-      fi
-    elif command -v pacman >/dev/null 2>&1; then
-      log_info "Installing gum via pacman..."
-      if sudo pacman -S --noconfirm gum >/dev/null 2>&1; then
-        log_info "gum installed successfully."
-        return 0
-      fi
-    fi
-  fi
-
-  log_warn "Could not auto-install gum. Falling back to basic prompts."
-  log_warn "Install manually: https://github.com/charmbracelet/gum#installation"
-  return 1
-}
-
-# Check if nvm has a specific node version installed
-nvm_has_version() {
-  local version="$1"
-  # nvm ls returns installed versions; check if our major version is there
-  nvm ls "${version}" 2>/dev/null | grep -q "v${version}" 2>/dev/null
-}
-
-# Offer to create .nvmrc file for the project
-offer_nvmrc() {
-  local nvmrc_path="${PROJECT_ROOT}/.nvmrc"
-
-  if [[ -f "${nvmrc_path}" ]]; then
-    return 0
-  fi
-
-  if prompt_confirm "Create .nvmrc file to persist Node.js version for this project?"; then
-    echo "${REQUIRED_NODE_MAJOR}" > "${nvmrc_path}"
-    log_info "Created ${nvmrc_path} with Node.js ${REQUIRED_NODE_MAJOR}"
-  fi
-}
-
-# Ensure node is installed at the required version
-ensure_node() {
-  local current_version=""
-  local current_major=""
-  local nvmrc_path="${PROJECT_ROOT}/.nvmrc"
-
-  # Check if node is available
-  if command -v node >/dev/null 2>&1; then
-    current_version=$(node --version | sed 's/^v//')
-    current_major=$(echo "${current_version}" | cut -d. -f1)
-  fi
-
-  if [[ -n "${current_major}" && "${current_major}" -ge "${REQUIRED_NODE_MAJOR}" ]]; then
-    log_info "Node.js v${current_version} found (requires ${REQUIRED_NODE_MAJOR}.x)"
-    return 0
-  fi
-
-  if [[ -n "${current_version}" ]]; then
-    log_warn "Node.js v${current_version} found, but v${REQUIRED_NODE_MAJOR}.x required"
-  else
-    log_warn "Node.js not found"
-  fi
-
-  # Try nvm first
-  if [[ -n "${NVM_DIR:-}" ]] || [[ -d "${HOME}/.nvm" ]]; then
-    local nvm_dir="${NVM_DIR:-${HOME}/.nvm}"
-    if [[ -s "${nvm_dir}/nvm.sh" ]]; then
-      # Source nvm
-      # shellcheck disable=SC1091
-      source "${nvm_dir}/nvm.sh"
-
-      # Check if .nvmrc exists and use it
-      if [[ -f "${nvmrc_path}" ]]; then
-        log_info "Found .nvmrc, running nvm use..."
-        if nvm use 2>/dev/null; then
-          # Validate the activated version meets requirements
-          local nvmrc_version
-          nvmrc_version=$(node --version | sed 's/^v//')
-          local nvmrc_major
-          nvmrc_major=$(echo "${nvmrc_version}" | cut -d. -f1)
-          if [[ "${nvmrc_major}" -ge "${REQUIRED_NODE_MAJOR}" ]]; then
-            log_info "Node.js v${nvmrc_version} activated via .nvmrc"
-            return 0
-          else
-            log_warn ".nvmrc specifies Node.js ${nvmrc_major}.x but ${REQUIRED_NODE_MAJOR}.x required"
-            log_warn "Consider updating .nvmrc to ${REQUIRED_NODE_MAJOR}"
-          fi
-        fi
-      fi
-
-      # Check if required version is already installed
-      if nvm_has_version "${REQUIRED_NODE_MAJOR}"; then
-        log_info "Node.js ${REQUIRED_NODE_MAJOR} already installed via nvm. Switching..."
-        if nvm use "${REQUIRED_NODE_MAJOR}"; then
-          log_info "Node.js $(node --version) activated via nvm."
-          offer_nvmrc
-          return 0
-        fi
-      fi
-
-      # Version not installed, prompt to install
-      if prompt_confirm "Install Node.js ${REQUIRED_NODE_MAJOR} via nvm?"; then
-        # nvm is a shell function, not an executable, so we can't use run_with_spinner
-        # (gum spawns a subprocess that won't have the function loaded)
-        log_info "Installing Node.js ${REQUIRED_NODE_MAJOR} via nvm..."
-        if nvm install "${REQUIRED_NODE_MAJOR}"; then
-          nvm use "${REQUIRED_NODE_MAJOR}"
-          log_info "Node.js $(node --version) installed and activated via nvm."
-          offer_nvmrc
-          return 0
-        else
-          log_error "Failed to install Node.js via nvm."
-        fi
-      fi
-    fi
-  fi
-
-  # Fallback to Homebrew on macOS
-  if [[ "$(uname -s)" == "Darwin" ]] && command -v brew >/dev/null 2>&1; then
-    if prompt_confirm "Install Node.js ${REQUIRED_NODE_MAJOR} via Homebrew?"; then
-      log_info "Installing node@${REQUIRED_NODE_MAJOR} via Homebrew..."
-      if run_with_spinner "Installing Node.js ${REQUIRED_NODE_MAJOR}" brew install "node@${REQUIRED_NODE_MAJOR}"; then
-        # Link the specific version
-        brew link --overwrite "node@${REQUIRED_NODE_MAJOR}" 2>/dev/null || true
-
-        # Add to PATH if needed
-        local brew_prefix
-        brew_prefix=$(brew --prefix)
-        if [[ -d "${brew_prefix}/opt/node@${REQUIRED_NODE_MAJOR}/bin" ]]; then
-          export PATH="${brew_prefix}/opt/node@${REQUIRED_NODE_MAJOR}/bin:${PATH}"
-        fi
-
-        if command -v node >/dev/null 2>&1; then
-          log_info "Node.js $(node --version) installed via Homebrew."
-          return 0
-        fi
-      fi
-      log_error "Failed to install Node.js via Homebrew."
-    fi
-  fi
-
-  # Check again in case user installed manually
-  if command -v node >/dev/null 2>&1; then
-    current_version=$(node --version | sed 's/^v//')
-    current_major=$(echo "${current_version}" | cut -d. -f1)
-    if [[ "${current_major}" -ge "${REQUIRED_NODE_MAJOR}" ]]; then
-      return 0
-    fi
-  fi
-
-  log_error "Node.js ${REQUIRED_NODE_MAJOR}.x is required but not installed."
-  log_error "Install via nvm: nvm install ${REQUIRED_NODE_MAJOR}"
-  log_error "Or via Homebrew: brew install node@${REQUIRED_NODE_MAJOR}"
-  return 1
-}
-
-# Ensure bun is installed at the required version
-ensure_bun() {
-  local current_version=""
-
-  # Check if bun is available
-  if command -v bun >/dev/null 2>&1; then
-    current_version=$(bun --version 2>/dev/null || true)
-  fi
-
-  if [[ -n "${current_version}" ]] && version_gte "${current_version}" "${REQUIRED_BUN_VERSION}"; then
-    log_info "Bun v${current_version} found (requires >=${REQUIRED_BUN_VERSION})"
-    return 0
-  fi
-
-  if [[ -n "${current_version}" ]]; then
-    log_warn "Bun v${current_version} found, but v${REQUIRED_BUN_VERSION} required"
-
-    if prompt_confirm "Update Bun to v${REQUIRED_BUN_VERSION}?"; then
-      log_info "Updating Bun..."
-      if run_with_spinner "Updating Bun to v${REQUIRED_BUN_VERSION}" bun upgrade; then
-        current_version=$(bun --version 2>/dev/null || true)
-        if version_gte "${current_version}" "${REQUIRED_BUN_VERSION}"; then
-          log_info "Bun updated to v${current_version}."
-          return 0
-        fi
-      fi
-      log_warn "Bun upgrade didn't reach required version. Trying fresh install..."
-    fi
-  else
-    log_warn "Bun not found"
-  fi
-
-  # Install bun
-  if prompt_confirm "Install Bun v${REQUIRED_BUN_VERSION}?"; then
-    log_info "Installing Bun..."
-
-    # Try official installer
-    if run_with_spinner "Installing Bun" bash -c "curl -fsSL https://bun.sh/install | bash -s -- bun-v${REQUIRED_BUN_VERSION}"; then
-      # Source the updated profile
-      if [[ -f "${HOME}/.bashrc" ]]; then
-        # shellcheck disable=SC1091
-        source "${HOME}/.bashrc" 2>/dev/null || true
-      fi
-      if [[ -f "${HOME}/.zshrc" ]]; then
-        # shellcheck disable=SC1091
-        source "${HOME}/.zshrc" 2>/dev/null || true
-      fi
-
-      # Add bun to PATH for current session
-      if [[ -d "${HOME}/.bun/bin" ]]; then
-        export PATH="${HOME}/.bun/bin:${PATH}"
-      fi
-
-      if command -v bun >/dev/null 2>&1; then
-        current_version=$(bun --version 2>/dev/null || true)
-        log_info "Bun v${current_version} installed."
-        return 0
-      fi
-    fi
-
-    # Fallback to Homebrew on macOS
-    if [[ "$(uname -s)" == "Darwin" ]] && command -v brew >/dev/null 2>&1; then
-      log_info "Trying Homebrew installation..."
-      if run_with_spinner "Installing Bun via Homebrew" brew install oven-sh/bun/bun; then
-        if command -v bun >/dev/null 2>&1; then
-          current_version=$(bun --version 2>/dev/null || true)
-          log_info "Bun v${current_version} installed via Homebrew."
-          return 0
-        fi
-      fi
-    fi
-
-    log_error "Failed to install Bun."
-  fi
-
-  # Final check
-  if command -v bun >/dev/null 2>&1; then
-    current_version=$(bun --version 2>/dev/null || true)
-    if version_gte "${current_version}" "${REQUIRED_BUN_VERSION}"; then
-      return 0
-    fi
-  fi
-
-  log_error "Bun >=${REQUIRED_BUN_VERSION} is required but not installed."
-  log_error "Install via: curl -fsSL https://bun.sh/install | bash"
-  return 1
+  command -v gum >/dev/null 2>&1
 }
 
 # Build and install auto-mobile globally from local project
@@ -414,36 +142,63 @@ ensure_auto_mobile() {
   return 1
 }
 
-# Run all dependency checks
+# Run all dependency checks via install.sh
 ensure_dependencies() {
   log_info "Checking dependencies..."
 
-  # Parse required versions first
+  # Delegate to install.sh for gum, node, bun, and npm install
+  local env_file
+  env_file=$(mktemp)
+
+  log_info "Running install.sh --preset local-dev..."
+  if ! bash "${PROJECT_ROOT}/scripts/install.sh" \
+    --preset local-dev \
+    --non-interactive \
+    --env-file "${env_file}"; then
+    log_error "install.sh failed"
+    rm -f "${env_file}"
+    return 1
+  fi
+
+  # Source environment changes (PATH, NVM_DIR, ANDROID_HOME)
+  if [[ -f "${env_file}" ]]; then
+    # shellcheck disable=SC1090
+    source "${env_file}"
+    rm -f "${env_file}"
+  fi
+
+  # Post-install validation
   parse_required_versions
 
-  # Install gum first for better prompts during other installs
-  ensure_gum || true  # Don't fail if gum can't be installed
-
-  # Check/install node
-  if ! ensure_node; then
-    log_error "Node.js installation failed or was declined."
+  # Verify node meets requirements
+  if command -v node >/dev/null 2>&1; then
+    local node_major
+    node_major=$(node --version | sed 's/^v//' | cut -d. -f1)
+    if [[ "${node_major}" -lt "${REQUIRED_NODE_MAJOR}" ]]; then
+      log_error "Node.js v${node_major}.x found but v${REQUIRED_NODE_MAJOR}.x required after install"
+      return 1
+    fi
+    log_info "Node.js $(node --version) verified"
+  else
+    log_error "Node.js not found after install"
     return 1
   fi
 
-  # Check/install bun
-  if ! ensure_bun; then
-    log_error "Bun installation failed or was declined."
+  # Verify bun meets requirements
+  if command -v bun >/dev/null 2>&1; then
+    local bun_version
+    bun_version=$(bun --version 2>/dev/null || true)
+    if ! version_gte "${bun_version}" "${REQUIRED_BUN_VERSION}"; then
+      log_error "Bun v${bun_version} found but v${REQUIRED_BUN_VERSION} required after install"
+      return 1
+    fi
+    log_info "Bun v${bun_version} verified"
+  else
+    log_error "Bun not found after install"
     return 1
   fi
 
-  # Install npm dependencies after Node and Bun are confirmed
-  log_info "Installing npm dependencies..."
-  if ! (cd "${PROJECT_ROOT}" && npm install); then
-    log_error "Failed to install npm dependencies."
-    return 1
-  fi
-
-  # Check/install auto-mobile globally
+  # Build and npm link auto-mobile (local-dev specific)
   if ! ensure_auto_mobile; then
     log_error "auto-mobile global installation failed."
     return 1


### PR DESCRIPTION
## Summary
- Consolidates ~250 lines of duplicated dependency installation logic from `deps.sh` into `install.sh` via a new `--preset local-dev` mode
- Adds `--env-file` flag to `install.sh` so subprocess PATH/NVM_DIR/ANDROID_HOME changes propagate back to the caller
- Adds version enforcement for bun and node based on `package.json` fields (`packageManager`, `@types/node`)

## Test plan
- [x] `shellcheck` passes on `install.sh`, `deps.sh`, and `hot-reload.sh`
- [x] `bun run build` and `bun run lint` pass
- [x] `install.sh --preset local-dev --non-interactive --env-file /tmp/env` runs successfully and writes valid env file
- [x] Existing presets (`minimal`, `development`) still work in `--dry-run` mode
- [ ] End-to-end: `scripts/local-dev/hot-reload.sh --once` completes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <svc-devxp-claude@slack-corp.com>