### PR TITLE
fix: prevent Windows mcp-build-and-test from hanging on merge workflow

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -219,6 +219,7 @@ jobs:
   mcp-build-and-test:
     name: "Node TypeScript Build and Test (${{ matrix.os }})"
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 10
     strategy:
       fail-fast: false
       matrix:
@@ -244,6 +245,9 @@ jobs:
 
       - name: "Run Tests"
         shell: bash
+        env:
+          # Force AdbClient into test mode on Windows to prevent adb daemon startup
+          AUTOMOBILE_TEST_MODE: ${{ matrix.os == 'windows-latest' && 'true' || '' }}
         run: |
           set -euo pipefail
           mkdir -p ci-logs


### PR DESCRIPTION
## Summary
- Added `timeout-minutes: 10` to the `mcp-build-and-test` job in the merge workflow (matching the PR workflow)
- Added `AUTOMOBILE_TEST_MODE` env var for Windows in the merge workflow's test step (matching the PR workflow)

The merge workflow was missing both safeguards that the PR workflow already had, causing the Windows runner to attempt starting an adb daemon (no Android SDK available), which hangs indefinitely with no timeout to kill it.

## Test plan
- [ ] Verify the next merge to main completes the Windows mcp-build-and-test job within 10 minutes instead of hanging

🤖 Generated with [Claude Code](https://claude.com/claude-code)