### PR TITLE
chore: bump versions to v0.0.10

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -14,7 +14,7 @@
       "name": "auto-mobile",
       "source": "./",
       "description": "Mobile device automation for Android and iOS - control devices with natural language",
-      "version": "0.0.9",
+      "version": "0.0.10",
       "author": {
         "name": "AutoMobile Contributors",
         "email": "jason.d.pearson@gmail.com"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "auto-mobile",
   "description": "Mobile device automation for Android and iOS - control devices with natural language",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "author": {
     "name": "AutoMobile Contributors",
     "email": "jason.d.pearson@gmail.com"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [v0.0.10] - 2026-02-06
+### Added
+- Support custom accessibility rules ([#104](https://github.com/kaeawc/auto-mobile/issues/104)) (devxp, a11y)
+### Other
+- chore: upgrade GitHub Actions upload-artifact and download-artifact to v4.6+ ([#1158](https://github.com/kaeawc/auto-mobile/issues/1158))
+- Publish AutoMobile Android SDK on Maven Central ([#122](https://github.com/kaeawc/auto-mobile/issues/122)) (android, ci, release engineering)
+- Publish AutoMobile JUnitRunner Library ([#121](https://github.com/kaeawc/auto-mobile/issues/121)) (android, ci, release engineering, testing)
+
 ## [v0.0.9] - 2026-02-04
 ### Added
 - Test Runners: Cascade MCP tool failures to JUnitRunner/XCTestRunner via executePlan response ([#1078](https://github.com/kaeawc/auto-mobile/issues/1078)) (android, ios, testing)

--- a/android/accessibility-service/build.gradle.kts
+++ b/android/accessibility-service/build.gradle.kts
@@ -36,7 +36,7 @@ android {
     minSdk = libs.versions.build.android.minSdk.get().toInt()
     targetSdk = libs.versions.build.android.targetSdk.get().toInt()
     versionCode = 1
-    versionName = "0.0.9-SNAPSHOT"
+    versionName = "0.0.10-SNAPSHOT"
 
     testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
   }

--- a/android/playground/app/build.gradle.kts
+++ b/android/playground/app/build.gradle.kts
@@ -36,7 +36,7 @@ android {
     minSdk = libs.versions.build.android.minSdk.get().toInt()
     targetSdk = libs.versions.build.android.targetSdk.get().toInt()
     versionCode = 1
-    versionName = "0.0.9-SNAPSHOT"
+    versionName = "0.0.10-SNAPSHOT"
 
     testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kaeawc/auto-mobile",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "description": "Mobile device interaction automation via MCP",
   "scripts": {
     "test": "bun test",

--- a/src/constants/release.ts
+++ b/src/constants/release.ts
@@ -19,7 +19,7 @@ export const RELEASE_VERSION: string = "latest";
 export const APK_URL: string = RELEASE_VERSION === "latest"
   ? `https://github.com/kaeawc/auto-mobile/releases/latest/download/accessibility-service-debug.apk`
   : `https://github.com/kaeawc/auto-mobile/releases/download/v${RELEASE_VERSION}/accessibility-service-debug.apk`;
-export const APK_SHA256_CHECKSUM: string = "9ee02f6e283b05aeff34783f761cb21893899421d71a063a99bd28d61396e3a5"; // Empty = skip verification (local dev only)
+export const APK_SHA256_CHECKSUM: string = "58789a8743cbbe48aa97132e6067a2c828f0b13bca3be4b23f10f6f70a9a5e7c"; // Empty = skip verification (local dev only)
 
 /**
  * iOS XCTestService Release Constants
@@ -31,5 +31,5 @@ export const XCTESTSERVICE_RELEASE_VERSION: string = "latest";
 export const XCTESTSERVICE_IPA_URL: string = XCTESTSERVICE_RELEASE_VERSION === "latest"
   ? "https://github.com/kaeawc/auto-mobile/releases/latest/download/XCTestService.ipa"
   : `https://github.com/kaeawc/auto-mobile/releases/download/v${XCTESTSERVICE_RELEASE_VERSION}/XCTestService.ipa`;
-export const XCTESTSERVICE_SHA256_CHECKSUM: string = ""; // Empty = skip verification (local dev only)
+export const XCTESTSERVICE_SHA256_CHECKSUM: string = "be8fbc52ace1760c9018380f363c465d527d0f4e73cfb882a49e0952a9ab62b7"; // Empty = skip verification (local dev only)
 export const XCTESTSERVICE_APP_HASH: string = ""; // Hash of XCTestServiceApp.app (device build), empty = skip verification


### PR DESCRIPTION
## Summary
- Bump versions to v0.0.10
- Update CHANGELOG.md from closed issues since the last tag
- Refresh Accessibility Service APK SHA256 checksum
- Refresh XCTestService IPA SHA256 checksum

## Automation
- Generated by `prepare-release` workflow