### PR TITLE
chore: update XCTestService IPA SHA256

### DIFF
--- a/src/constants/release.ts
+++ b/src/constants/release.ts
@@ -31,5 +31,5 @@ export const XCTESTSERVICE_RELEASE_VERSION: string = "latest";
 export const XCTESTSERVICE_IPA_URL: string = XCTESTSERVICE_RELEASE_VERSION === "latest"
   ? "https://github.com/kaeawc/auto-mobile/releases/latest/download/XCTestService.ipa"
   : `https://github.com/kaeawc/auto-mobile/releases/download/v${XCTESTSERVICE_RELEASE_VERSION}/XCTestService.ipa`;
-export const XCTESTSERVICE_SHA256_CHECKSUM: string = "be8fbc52ace1760c9018380f363c465d527d0f4e73cfb882a49e0952a9ab62b7"; // Empty = skip verification (local dev only)
+export const XCTESTSERVICE_SHA256_CHECKSUM: string = "54ba2adb162bdc019eac61ad358a156037e19306270247d979836012f6691673"; // Empty = skip verification (local dev only)
 export const XCTESTSERVICE_APP_HASH: string = ""; // Hash of XCTestServiceApp.app (device build), empty = skip verification


### PR DESCRIPTION
## Automated Checksum Update

The XCTestService IPA was rebuilt on `main` with a different SHA256 checksum.

| | SHA256 |
|--|--------|
| **Previous** | `be8fbc52ace1760c9018380f363c465d527d0f4e73cfb882a49e0952a9ab62b7` |
| **New** | `54ba2adb162bdc019eac61ad358a156037e19306270247d979836012f6691673` |

### Why did this happen?

The SHA256 changes when any of these change:
- Source code in `ios/XCTestService/`
- Build configuration (`project.yml`)
- Dependencies or SDK versions

### What to do

1. Review this PR to ensure the change is expected
2. Merge when ready
3. Future releases will use this checksum for IPA verification

---
Auto-generated by `update-xctestservice-sha256` workflow