### PR TITLE
chore: parallelize iOS and Android builds in prepare-release pipeline

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -61,11 +61,14 @@ jobs:
           release-key-alias: ${{ secrets.RELEASE_KEY_ALIAS }}
           release-key-password: ${{ secrets.RELEASE_KEY_PASSWORD }}
 
+      - name: "Copy APK to output directory"
+        run: cp android/accessibility-service/build/outputs/apk/debug/accessibility-service-debug.apk /tmp/accessibility-service-debug.apk
+
       - name: "Upload Accessibility Service APK"
         uses: actions/upload-artifact@v4
         with:
           name: accessibility-service-apk
-          path: android/accessibility-service/build/outputs/apk/debug/accessibility-service-debug.apk
+          path: /tmp/accessibility-service-debug.apk
 
   prepare:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Split the prepare-release workflow into 3 jobs: parallel iOS (macOS) and Android (ubuntu) builds, then a prepare job that fans in
- iOS and Android build artifacts are uploaded via `actions/upload-artifact@v4` so they remain available on the workflow run
- The prepare job downloads both artifacts, computes SHA256 checksums from the downloaded files, updates release constants, and creates the version bump PR

## Test plan
- [ ] Trigger prepare-release workflow and verify iOS and Android jobs run in parallel
- [ ] Verify artifacts (IPA, APK) appear on the workflow run
- [ ] Verify the prepare job correctly downloads artifacts and computes SHA256 checksums
- [ ] Verify the version bump PR is created with correct checksums

🤖 Generated with [Claude Code](https://claude.com/claude-code)