### PR TITLE
refactor: replace BugReport inline traverseNode with ElementParser

### DIFF
--- a/src/features/debug/BugReport.ts
+++ b/src/features/debug/BugReport.ts
@@ -17,6 +17,7 @@ import {
   ViewHierarchyResult
 } from "../../models";
 import { ViewHierarchy } from "../observe/ViewHierarchy";
+import type { ViewHierarchy as ViewHierarchyContract } from "../observe/interfaces/ViewHierarchy";
 import { TakeScreenshot } from "../observe/TakeScreenshot";
 import { NoOpPerformanceTracker } from "../../utils/PerformanceTracker";
 import { VisualHighlight } from "./VisualHighlight";
@@ -88,7 +89,7 @@ export interface BugReportOptions {
 export class BugReport {
   private device: BootedDevice;
   private readonly adb: AdbExecutor;
-  private viewHierarchy: ViewHierarchy;
+  private viewHierarchy: ViewHierarchyContract;
   private takeScreenshot: TakeScreenshot;
   private visualHighlight: VisualHighlight;
   private elementParser: ElementParser;
@@ -97,14 +98,16 @@ export class BugReport {
   constructor(
     device: BootedDevice,
     adbFactory: AdbClientFactory = defaultAdbClientFactory,
-    timer: Timer = defaultTimer
+    timer: Timer = defaultTimer,
+    elementParser: ElementParser = new DefaultElementParser(),
+    viewHierarchy?: ViewHierarchyContract
   ) {
     this.device = device;
     this.adb = adbFactory.create(device);
-    this.viewHierarchy = new ViewHierarchy(device, adbFactory);
+    this.viewHierarchy = viewHierarchy ?? new ViewHierarchy(device, adbFactory);
     this.takeScreenshot = new TakeScreenshot(device, adbFactory);
     this.visualHighlight = new VisualHighlight(device, adbFactory);
-    this.elementParser = new DefaultElementParser();
+    this.elementParser = elementParser;
     this.timer = timer;
   }
 
@@ -328,7 +331,7 @@ export class BugReport {
       // Get raw XML if requested
       if (includeRaw) {
         try {
-          const rawXml = await this.viewHierarchy.executeUiAutomatorDump();
+          const rawXml = await (this.viewHierarchy as any).executeUiAutomatorDump();
           result.viewHierarchy.rawXml = rawXml;
         } catch (error) {
           result.errors?.push(`Failed to get raw hierarchy XML: ${error}`);
@@ -338,40 +341,29 @@ export class BugReport {
       // Get parsed hierarchy for element summary
       const hierarchy = await this.viewHierarchy.getViewHierarchy(undefined, perf);
 
-      if (hierarchy && hierarchy.hierarchy && hierarchy.hierarchy.node) {
-        // Traverse hierarchy to count elements and extract clickable ones
-        const clickableElements: BugReportResult["viewHierarchy"]["clickableElements"] = [];
-        let elementCount = 0;
+      if (hierarchy) {
+        const flattenedElements = this.elementParser.flattenViewHierarchy(hierarchy);
 
-        const traverseNode = (node: any) => {
-          elementCount++;
-          const attrs = node.$ || node;
+        // Count total traversed nodes (including those without valid bounds)
+        let totalTraversedNodes = 0;
+        const rootNodes = this.elementParser.extractRootNodes(hierarchy);
+        for (const rootNode of rootNodes) {
+          this.elementParser.traverseNode(rootNode, () => { totalTraversedNodes++; });
+        }
 
-          if (attrs.clickable === "true" || attrs.clickable === true) {
-            const boundsStr = attrs.bounds || "";
-            clickableElements.push({
-              resourceId: attrs["resource-id"],
-              text: attrs.text,
-              contentDesc: attrs["content-desc"],
-              bounds: boundsStr,
-              className: attrs.class || attrs.className
-            });
-          }
+        result.viewHierarchy.elementCount = flattenedElements.length;
+        result.viewHierarchy.filteredNodeCount = totalTraversedNodes - flattenedElements.length;
 
-          // Traverse children
-          const children = node.node || node.children;
-          if (Array.isArray(children)) {
-            for (const child of children) {
-              traverseNode(child);
-            }
-          } else if (children) {
-            traverseNode(children);
-          }
-        };
+        const clickableElements = flattenedElements
+          .filter(({ element }) => element.clickable === true)
+          .map(({ element, text }) => ({
+            resourceId: element["resource-id"],
+            text: text ?? element.text,
+            contentDesc: element["content-desc"],
+            bounds: element.bounds,
+            className: element["class"]
+          }));
 
-        traverseNode(hierarchy.hierarchy.node);
-
-        result.viewHierarchy.elementCount = elementCount;
         result.viewHierarchy.clickableElements = clickableElements.slice(0, 50);
       }
 

--- a/src/models/BugReportResult.ts
+++ b/src/models/BugReportResult.ts
@@ -90,13 +90,18 @@ export interface BugReportResult {
     elementCount: number;
 
     /**
+     * Number of traversed nodes that were filtered out (no valid bounds)
+     */
+    filteredNodeCount?: number;
+
+    /**
      * Clickable elements summary
      */
     clickableElements: {
       resourceId?: string;
       text?: string;
       contentDesc?: string;
-      bounds: string;
+      bounds: ElementBounds;
       className?: string;
     }[];
   };

--- a/test/features/debug/BugReport.test.ts
+++ b/test/features/debug/BugReport.test.ts
@@ -1,0 +1,182 @@
+import { describe, expect, test } from "bun:test";
+import { BugReport } from "../../../src/features/debug/BugReport";
+import type { BootedDevice, Element, ElementBounds } from "../../../src/models";
+import { FakeAdbClientFactory } from "../../fakes/FakeAdbClientFactory";
+import { FakeElementParser } from "../../fakes/FakeElementParser";
+import { FakeTimer } from "../../fakes/FakeTimer";
+import { FakeViewHierarchy } from "../../fakes/FakeViewHierarchy";
+
+describe("BugReport", () => {
+  const device: BootedDevice = {
+    deviceId: "test-device",
+    platform: "android",
+    isEmulator: true,
+    name: "Test Device"
+  };
+
+  const makeBounds = (left: number, top: number, right: number, bottom: number): ElementBounds => ({
+    left, top, right, bottom
+  });
+
+  const makeElement = (overrides: Partial<Element> = {}): Element => ({
+    bounds: makeBounds(0, 0, 100, 100),
+    ...overrides
+  });
+
+  const setup = () => {
+    const adbFactory = new FakeAdbClientFactory();
+    const timer = new FakeTimer();
+    timer.enableAutoAdvance();
+    const elementParser = new FakeElementParser();
+    const viewHierarchy = new FakeViewHierarchy();
+    const bugReport = new BugReport(device, adbFactory, timer, elementParser, viewHierarchy);
+    return { bugReport, elementParser, viewHierarchy, adbFactory, timer };
+  };
+
+  const executeHierarchyOnly = (bugReport: BugReport) =>
+    bugReport.execute({ includeScreenshot: false, includeLogcat: false, includeRawHierarchy: false });
+
+  describe("getHierarchy", () => {
+    test("sets elementCount to number of elements with valid bounds", async () => {
+      const { bugReport, elementParser, viewHierarchy } = setup();
+      viewHierarchy.configureHierarchy({ hierarchy: { node: {} } });
+      elementParser.nextFlattenedElements = [
+        { element: makeElement(), index: 0, depth: 0 },
+        { element: makeElement(), index: 1, depth: 0 },
+        { element: makeElement(), index: 2, depth: 1 }
+      ];
+      elementParser.nextRootNodes = [{ $: {} }];
+
+      const result = await executeHierarchyOnly(bugReport);
+      expect(result.viewHierarchy.elementCount).toBe(3);
+    });
+
+    test("sets filteredNodeCount to traversed nodes minus valid bounds", async () => {
+      const { bugReport, elementParser, viewHierarchy } = setup();
+      // Root with 2 children = 3 traversed nodes
+      const rootNode = {
+        $: {},
+        node: [{ $: {} }, { $: {} }]
+      };
+      viewHierarchy.configureHierarchy({ hierarchy: { node: rootNode } });
+      elementParser.nextRootNodes = [rootNode];
+      // Only 1 element has valid bounds
+      elementParser.nextFlattenedElements = [
+        { element: makeElement(), index: 0, depth: 0 }
+      ];
+
+      const result = await executeHierarchyOnly(bugReport);
+      expect(result.viewHierarchy.filteredNodeCount).toBe(2);
+    });
+
+    test("extracts clickable elements with ElementBounds objects", async () => {
+      const { bugReport, elementParser, viewHierarchy } = setup();
+      viewHierarchy.configureHierarchy({ hierarchy: { node: {} } });
+      elementParser.nextRootNodes = [{ $: {} }];
+      const bounds = makeBounds(10, 20, 110, 120);
+      elementParser.nextFlattenedElements = [
+        {
+          element: makeElement({
+            bounds,
+            "clickable": true,
+            "resource-id": "btn1",
+            "text": "Click me",
+            "content-desc": "Button",
+            "class": "android.widget.Button"
+          }),
+          index: 0,
+          depth: 0
+        }
+      ];
+
+      const result = await executeHierarchyOnly(bugReport);
+      expect(result.viewHierarchy.clickableElements).toHaveLength(1);
+      expect(result.viewHierarchy.clickableElements[0].bounds).toEqual(bounds);
+      expect(result.viewHierarchy.clickableElements[0].bounds.left).toBe(10);
+    });
+
+    test("limits clickable elements to 50", async () => {
+      const { bugReport, elementParser, viewHierarchy } = setup();
+      viewHierarchy.configureHierarchy({ hierarchy: { node: {} } });
+      elementParser.nextRootNodes = [{ $: {} }];
+      elementParser.nextFlattenedElements = Array.from({ length: 60 }, (_, i) => ({
+        element: makeElement({ "clickable": true, "resource-id": `btn${i}` }),
+        index: i,
+        depth: 0
+      }));
+
+      const result = await executeHierarchyOnly(bugReport);
+      expect(result.viewHierarchy.clickableElements).toHaveLength(50);
+    });
+
+    test("handles empty hierarchy", async () => {
+      const { bugReport, elementParser, viewHierarchy } = setup();
+      viewHierarchy.configureHierarchy({ hierarchy: {} });
+      elementParser.nextRootNodes = [];
+      elementParser.nextFlattenedElements = [];
+
+      const result = await executeHierarchyOnly(bugReport);
+      expect(result.viewHierarchy.elementCount).toBe(0);
+      expect(result.viewHierarchy.clickableElements).toHaveLength(0);
+      expect(result.errors).toEqual([]);
+    });
+
+    test("maps element properties correctly", async () => {
+      const { bugReport, elementParser, viewHierarchy } = setup();
+      viewHierarchy.configureHierarchy({ hierarchy: { node: {} } });
+      elementParser.nextRootNodes = [{ $: {} }];
+      elementParser.nextFlattenedElements = [
+        {
+          element: makeElement({
+            "clickable": true,
+            "resource-id": "com.app:id/submit",
+            "text": "raw text",
+            "content-desc": "Submit button",
+            "class": "android.widget.Button"
+          }),
+          index: 0,
+          depth: 0,
+          text: "overridden text"
+        }
+      ];
+
+      const result = await executeHierarchyOnly(bugReport);
+      const el = result.viewHierarchy.clickableElements[0];
+      expect(el.resourceId).toBe("com.app:id/submit");
+      expect(el.text).toBe("overridden text");
+      expect(el.contentDesc).toBe("Submit button");
+      expect(el.className).toBe("android.widget.Button");
+    });
+
+    test("uses element.text when flattened text is undefined", async () => {
+      const { bugReport, elementParser, viewHierarchy } = setup();
+      viewHierarchy.configureHierarchy({ hierarchy: { node: {} } });
+      elementParser.nextRootNodes = [{ $: {} }];
+      elementParser.nextFlattenedElements = [
+        {
+          element: makeElement({ clickable: true, text: "element text" }),
+          index: 0,
+          depth: 0
+        }
+      ];
+
+      const result = await executeHierarchyOnly(bugReport);
+      expect(result.viewHierarchy.clickableElements[0].text).toBe("element text");
+    });
+
+    test("excludes non-clickable elements from clickableElements", async () => {
+      const { bugReport, elementParser, viewHierarchy } = setup();
+      viewHierarchy.configureHierarchy({ hierarchy: { node: {} } });
+      elementParser.nextRootNodes = [{ $: {} }];
+      elementParser.nextFlattenedElements = [
+        { element: makeElement({ "clickable": false, "resource-id": "label" }), index: 0, depth: 0 },
+        { element: makeElement({ "clickable": true, "resource-id": "button" }), index: 1, depth: 0 },
+        { element: makeElement({ "resource-id": "text" }), index: 2, depth: 0 }
+      ];
+
+      const result = await executeHierarchyOnly(bugReport);
+      expect(result.viewHierarchy.clickableElements).toHaveLength(1);
+      expect(result.viewHierarchy.clickableElements[0].resourceId).toBe("button");
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Replace inline `traverseNode` in `BugReport.getHierarchy()` with injected `ElementParser` methods (`flattenViewHierarchy`, `extractRootNodes`, `traverseNode`)
- Make `elementParser` and `viewHierarchy` injectable via constructor for testability
- Change `clickableElements[].bounds` from `string` to `ElementBounds` and add `filteredNodeCount` tracking

## Test Plan
- [x] New unit tests for BugReport hierarchy parsing (8 tests)
- [x] Lint passes
- [x] Build passes
- [x] All 2072 tests pass

Closes #1189

🤖 Generated with [Claude Code](https://claude.com/claude-code)