### PR TITLE
fix: pass parent Disposable to Alarm in TestPlanDocumentListener

### DIFF
--- a/android/ide-plugin/src/main/kotlin/dev/jasonpearson/automobile/ide/yaml/TestPlanDocumentListener.kt
+++ b/android/ide-plugin/src/main/kotlin/dev/jasonpearson/automobile/ide/yaml/TestPlanDocumentListener.kt
@@ -1,5 +1,6 @@
 package dev.jasonpearson.automobile.ide.yaml
 
+import com.intellij.openapi.Disposable
 import com.intellij.openapi.editor.event.BulkAwareDocumentListener
 import com.intellij.openapi.editor.event.DocumentEvent
 import com.intellij.util.Alarm
@@ -16,14 +17,14 @@ import dev.jasonpearson.automobile.ide.settings.AutoMobileSettings
  */
 class TestPlanDocumentListener(
     private val validationTrigger: ValidationTrigger,
+    parentDisposable: Disposable,
     private val isLintingEnabled: () -> Boolean = {
       AutoMobileSettings.getInstance().enableYamlLinting
     },
     private val delayMs: Int = 300,
 ) : BulkAwareDocumentListener {
 
-  private val alarm =
-      Alarm(Alarm.ThreadToUse.POOLED_THREAD, validationTrigger as? com.intellij.openapi.Disposable)
+  private val alarm = Alarm(Alarm.ThreadToUse.POOLED_THREAD, parentDisposable)
 
   override fun documentChanged(event: DocumentEvent) {
     if (!isLintingEnabled()) {

--- a/android/ide-plugin/src/main/kotlin/dev/jasonpearson/automobile/ide/yaml/TestPlanFileEditorListener.kt
+++ b/android/ide-plugin/src/main/kotlin/dev/jasonpearson/automobile/ide/yaml/TestPlanFileEditorListener.kt
@@ -26,7 +26,7 @@ class TestPlanFileEditorListener : FileEditorManagerListener {
         val document = FileDocumentManager.getInstance().getDocument(file) ?: return
         val project = source.project
         val validationTrigger = IntellijValidationTrigger(project)
-        val listener = TestPlanDocumentListener(validationTrigger)
+        val listener = TestPlanDocumentListener(validationTrigger, project)
         document.addDocumentListener(listener)
         listeners[file] = listener
         log.info("Attached test plan document listener to ${file.name}")

--- a/android/ide-plugin/src/test/kotlin/dev/jasonpearson/automobile/ide/yaml/TestPlanDocumentListenerTest.kt
+++ b/android/ide-plugin/src/test/kotlin/dev/jasonpearson/automobile/ide/yaml/TestPlanDocumentListenerTest.kt
@@ -24,6 +24,7 @@ class TestPlanDocumentListenerTest {
     listener =
         TestPlanDocumentListener(
             validationTrigger = fakeValidationTrigger,
+            parentDisposable = testDisposable,
             isLintingEnabled = { lintingEnabled },
             delayMs = 0, // No delay for tests
         )
@@ -104,6 +105,7 @@ class TestPlanDocumentListenerTest {
     val debouncingListener =
         TestPlanDocumentListener(
             validationTrigger = debounceTrigger,
+            parentDisposable = debounceDisposable,
             isLintingEnabled = { lintingEnabled },
             delayMs = 100, // 100ms delay
         )
@@ -141,6 +143,7 @@ class TestPlanDocumentListenerTest {
     val debouncingListener =
         TestPlanDocumentListener(
             validationTrigger = disposeTrigger,
+            parentDisposable = disposeDisposable,
             isLintingEnabled = { lintingEnabled },
             delayMs = 500, // Long delay
         )


### PR DESCRIPTION
## Summary
- Fix `IllegalArgumentException: You must provide parent Disposable for non-swing thread Alarm` when opening test plan YAML files
- Add explicit `parentDisposable: Disposable` parameter to `TestPlanDocumentListener`, replacing the fragile `as?` cast that silently returned `null` for `IntellijValidationTrigger`
- Pass `Project` as the parent disposable from `TestPlanFileEditorListener.fileOpened`

## Test Plan
- [x] IDE plugin builds successfully (`./gradlew :ide-plugin:build`)
- [x] All existing tests pass with updated constructor calls

Closes #1205

🤖 Generated with [Claude Code](https://claude.com/claude-code)