### PR TITLE
Remove test-video-recording feature flag

### DIFF
--- a/src/daemon/manager.ts
+++ b/src/daemon/manager.ts
@@ -184,9 +184,6 @@ export class DaemonManager {
     if (options.videoMaxArchiveSizeMb !== undefined) {
       args.push("--video-archive-size-mb", options.videoMaxArchiveSizeMb.toString());
     }
-    if (options.testVideoRecording) {
-      args.push("--test-video-recording");
-    }
 
     // Create secure temp directory with random suffix to prevent symlink attacks
     const tempDir = mkdtempSync(join(tmpdir(), "auto-mobile-daemon-"));
@@ -450,8 +447,6 @@ export async function runDaemonCommand(
           } else if (args[i] === "--video-archive-size-mb") {
             options.videoMaxArchiveSizeMb = Number(args[i + 1]);
             i++;
-          } else if (args[i] === "--test-video-recording") {
-            options.testVideoRecording = true;
           }
         }
 
@@ -530,8 +525,6 @@ export async function runDaemonCommand(
           } else if (args[i] === "--video-archive-size-mb") {
             options.videoMaxArchiveSizeMb = Number(args[i + 1]);
             i++;
-          } else if (args[i] === "--test-video-recording") {
-            options.testVideoRecording = true;
           }
         }
 

--- a/src/daemon/types.ts
+++ b/src/daemon/types.ts
@@ -90,8 +90,6 @@ export interface DaemonOptions {
   videoFormat?: string;
   /** Default video archive size limit in MB */
   videoMaxArchiveSizeMb?: number;
-  /** Enable automatic video recording during plan execution */
-  testVideoRecording?: boolean;
 }
 
 /**

--- a/src/features/featureFlags/FeatureFlagDefinitions.ts
+++ b/src/features/featureFlags/FeatureFlagDefinitions.ts
@@ -8,8 +8,7 @@ export type FeatureFlagKey =
   | "predictive-ui"
   | "force-accessibility-mode"
   | "accessibility-auto-detect"
-  | "raw-element-search"
-  | "test-video-recording";
+  | "raw-element-search";
 
 export type FeatureFlagConfig = Record<string, unknown>;
 
@@ -94,11 +93,5 @@ export const FEATURE_FLAG_DEFINITIONS: FeatureFlagDefinition[] = [
     label: "Accessibility auto-detect",
     description: "Automatically detect and adapt to TalkBack/VoiceOver when enabled.",
     defaultValue: true,
-  },
-  {
-    key: "test-video-recording",
-    label: "Test video recording",
-    description: "Automatically record video during plan execution for test debugging.",
-    defaultValue: false,
   },
 ];

--- a/src/index.ts
+++ b/src/index.ts
@@ -101,7 +101,6 @@ function parseArgs(): {
   skipAccessibilityDownload: boolean;
   noProxy: boolean;
   noDaemon: boolean;
-  testVideoRecording: boolean;
   } {
   const args = process.argv.slice(2);
 
@@ -159,9 +158,6 @@ function parseArgs(): {
   const predictiveUi = args.includes("--predictive") || args.includes("--predictive-ui");
   const rawElementSearch = args.includes("--raw-element-search");
   const skipAccessibilityDownload = args.includes("--skip-accessibility-download");
-  const testVideoRecording =
-    args.includes("--test-video-recording") ||
-    process.env.AUTO_MOBILE_TEST_VIDEO_RECORDING === "1";
   let planExecutionLockScope: PlanExecutionLockScope = "session";
   const videoRecordingDefaults: VideoRecordingConfigInput = {};
 
@@ -364,7 +360,6 @@ function parseArgs(): {
     skipAccessibilityDownload,
     noProxy,
     noDaemon,
-    testVideoRecording,
   };
 }
 
@@ -1119,13 +1114,11 @@ async function main() {
       skipAccessibilityDownload,
       noProxy,
       noDaemon,
-      testVideoRecording,
     } = parseArgs();
 
     serverConfig.setPlanExecutionLockScope(planExecutionLockScope);
     serverConfig.setVideoRecordingDefaults(videoRecordingDefaults);
     serverConfig.setSkipAccessibilityDownload(skipAccessibilityDownload);
-    serverConfig.setTestVideoRecordingEnabled(testVideoRecording);
     if (skipAccessibilityDownload) {
       logger.info("Accessibility APK download disabled (--skip-accessibility-download)");
     } else {
@@ -1162,7 +1155,6 @@ async function main() {
       ["accessibility-audit", a11yAuditMode, "--accessibility-audit", accessibilityConfig],
       ["predictive-ui", predictiveUi, "--predictive/--predictive-ui"],
       ["raw-element-search", rawElementSearch, "--raw-element-search"],
-      ["test-video-recording", testVideoRecording, "--test-video-recording"],
     ];
 
     for (const [key, enabled, flagLabel, config] of cliOverrides) {
@@ -1220,7 +1212,6 @@ async function main() {
         videoFps: videoRecordingDefaults.fps,
         videoFormat: videoRecordingDefaults.format,
         videoMaxArchiveSizeMb: videoRecordingDefaults.maxArchiveSizeMb,
-        testVideoRecording,
       };
 
       if (useProxyMode) {

--- a/src/server/planTools.ts
+++ b/src/server/planTools.ts
@@ -12,7 +12,6 @@ import { PlanSchemaValidator } from "../utils/plan/PlanSchemaValidator";
 import { DaemonState } from "../daemon/daemonState";
 import { normalizePlanDevices } from "../utils/plan/PlanDevices";
 import { ExecutePlanStepDebugInfo } from "../models/ExecutePlanResult";
-import { serverConfig } from "../utils/ServerConfig";
 import { startVideoRecording, stopVideoRecording } from "./videoRecordingManager";
 import { startTestRecording, stopTestRecording, getTestRecordingStatus } from "./testRecordingManager";
 import { defaultTimer } from "../utils/SystemTimer";
@@ -356,23 +355,20 @@ const executePlanTool = async (device: BootedDevice, params: {
       throw new ActionableError("Device label requires a devices list to be provided.");
     }
 
-    // Start video recording if enabled
-    const testVideoRecordingEnabled = serverConfig.isTestVideoRecordingEnabled();
+    // Start video recording for test plan execution
     let videoRecordingId: string | undefined;
-    if (testVideoRecordingEnabled) {
-      try {
-        logger.info(`[PERF +${defaultTimer.now() - perfStart}ms] Starting automatic video recording for test`);
-        const recording = await startVideoRecording({
-          device,
-          outputName: `test-${plan.name}-${defaultTimer.now()}`,
-          maxDurationSeconds: 300, // 5 minutes max
-        });
-        videoRecordingId = recording.recordingId;
-        logger.info(`[PERF +${defaultTimer.now() - perfStart}ms] Video recording started: ${videoRecordingId}`);
-      } catch (videoError) {
-        logger.warn(`[PERF +${defaultTimer.now() - perfStart}ms] Failed to start automatic video recording: ${videoError}`);
-        // Continue with plan execution even if video recording fails to start
-      }
+    try {
+      logger.info(`[PERF +${defaultTimer.now() - perfStart}ms] Starting automatic video recording for test`);
+      const recording = await startVideoRecording({
+        device,
+        outputName: `test-${plan.name}-${defaultTimer.now()}`,
+        maxDurationSeconds: 300, // 5 minutes max
+      });
+      videoRecordingId = recording.recordingId;
+      logger.info(`[PERF +${defaultTimer.now() - perfStart}ms] Video recording started: ${videoRecordingId}`);
+    } catch (videoError) {
+      logger.warn(`[PERF +${defaultTimer.now() - perfStart}ms] Failed to start automatic video recording: ${videoError}`);
+      // Continue with plan execution even if video recording fails to start
     }
 
     // Execute the plan with device context, ensuring video recording is stopped in finally block

--- a/src/utils/ServerConfig.ts
+++ b/src/utils/ServerConfig.ts
@@ -26,7 +26,6 @@ class ServerConfig {
   private _deviceSnapshotDefaults: DeviceSnapshotConfigInput = {};
   private _appearanceDefaults: AppearanceConfigInput = {};
   private _skipAccessibilityDownload: boolean = false;
-  private _testVideoRecordingEnabled: boolean = false;
 
   private constructor() {}
 
@@ -129,13 +128,6 @@ class ServerConfig {
     return this._skipAccessibilityDownload;
   }
 
-  setTestVideoRecordingEnabled(enabled: boolean): void {
-    this._testVideoRecordingEnabled = enabled;
-  }
-
-  isTestVideoRecordingEnabled(): boolean {
-    return this._testVideoRecordingEnabled;
-  }
 }
 
 export const serverConfig = ServerConfig.getInstance();


### PR DESCRIPTION
## Summary
- Remove the `test-video-recording` feature flag that gated automatic video recording during plan execution
- Video recording now starts unconditionally during plan execution (feature is stable)
- Clean up CLI arg (`--test-video-recording`), env var (`AUTO_MOBILE_TEST_VIDEO_RECORDING`), daemon option, and ServerConfig methods

## Test Plan
- [x] `bun run build` passes
- [x] `bun run lint` passes
- [x] `bun test` passes (2100 tests)

Closes #1203

🤖 Generated with [Claude Code](https://claude.com/claude-code)