### PR TITLE
ci: add Xcode 26 to iOS build and test matrix

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -277,6 +277,7 @@ jobs:
         config:
           - { name: "Xcode 15", runner: "macos-14", xcode: "15.4" }
           - { name: "Xcode 16", runner: "macos-15", xcode: "16.2" }
+          - { name: "Xcode 26", runner: "macos-26", xcode: "26.0" }
     steps:
       - name: "Git Checkout"
         uses: actions/checkout@v4
@@ -324,6 +325,7 @@ jobs:
         config:
           - { name: "Xcode 15", runner: "macos-14", xcode: "15.4" }
           - { name: "Xcode 16", runner: "macos-15", xcode: "16.2" }
+          - { name: "Xcode 26", runner: "macos-26", xcode: "26.0" }
     steps:
       - name: "Git Checkout"
         uses: actions/checkout@v4
@@ -338,7 +340,7 @@ jobs:
 
   ios-xcodegen:
     name: "Generate Xcode Projects"
-    runs-on: macos-14
+    runs-on: macos-26
     steps:
       - name: "Git Checkout"
         uses: actions/checkout@v4
@@ -359,6 +361,7 @@ jobs:
         config:
           - { name: "Xcode 15", runner: "macos-14", xcode: "15.4" }
           - { name: "Xcode 16", runner: "macos-15", xcode: "16.2" }
+          - { name: "Xcode 26", runner: "macos-26", xcode: "26.0" }
     steps:
       - name: "Git Checkout"
         uses: actions/checkout@v4

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -613,6 +613,7 @@ jobs:
         config:
           - { name: "Xcode 15", runner: "macos-14", xcode: "15.4" }
           - { name: "Xcode 16", runner: "macos-15", xcode: "16.2" }
+          - { name: "Xcode 26", runner: "macos-26", xcode: "26.0" }
     steps:
       - name: "Git Checkout"
         uses: actions/checkout@v4
@@ -661,6 +662,7 @@ jobs:
         config:
           - { name: "Xcode 15", runner: "macos-14", xcode: "15.4" }
           - { name: "Xcode 16", runner: "macos-15", xcode: "16.2" }
+          - { name: "Xcode 26", runner: "macos-26", xcode: "26.0" }
     steps:
       - name: "Git Checkout"
         uses: actions/checkout@v4
@@ -675,7 +677,7 @@ jobs:
 
   ios-xcodegen:
     name: "Generate Xcode Projects"
-    runs-on: macos-14
+    runs-on: macos-26
     needs: detect-changes
     if: needs.detect-changes.outputs.ios_should_run == 'true'
     steps:
@@ -699,6 +701,7 @@ jobs:
         config:
           - { name: "Xcode 15", runner: "macos-14", xcode: "15.4" }
           - { name: "Xcode 16", runner: "macos-15", xcode: "16.2" }
+          - { name: "Xcode 26", runner: "macos-26", xcode: "26.0" }
     steps:
       - name: "Git Checkout"
         uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- Add Xcode 26 (macos-26 runner, xcode 26.0) to `ios-swift-build`, `ios-swift-test`, and `ios-xcode-build` matrix jobs
- Update `ios-xcodegen` runner from `macos-14` to `macos-26`
- Changes applied to both `merge.yml` and `pull_request.yml`

## Test Plan
- [ ] CI passes with new matrix entries (Xcode 26 jobs will validate runner/Xcode availability)
- [ ] Existing Xcode 15 and 16 matrix entries unaffected

Closes #1207

🤖 Generated with [Claude Code](https://claude.com/claude-code)