### PR TITLE
feat: show device disconnected state in IDE plugin

### DIFF
--- a/android/ide-plugin/src/main/kotlin/dev/jasonpearson/automobile/ide/AutoMobileToolWindowContent.kt
+++ b/android/ide-plugin/src/main/kotlin/dev/jasonpearson/automobile/ide/AutoMobileToolWindowContent.kt
@@ -87,6 +87,7 @@ import dev.jasonpearson.automobile.ide.daemon.McpHttpClient
 import dev.jasonpearson.automobile.ide.daemon.McpDaemonClient
 import dev.jasonpearson.automobile.ide.daemon.DaemonSocketPaths
 import dev.jasonpearson.automobile.ide.daemon.ObservationStreamClient
+import dev.jasonpearson.automobile.ide.daemon.StreamConnectionState
 import dev.jasonpearson.automobile.ide.daemon.FailuresPushSocketClient
 import dev.jasonpearson.automobile.ide.failures.FailuresVerticalPanel
 import dev.jasonpearson.automobile.ide.failures.DateRange
@@ -410,8 +411,12 @@ fun AutoMobileToolWindowContent() {
       while (true) {
           kotlinx.coroutines.delay(5000)
           if (!client.isConnected()) {
-              LOG.info("Observation stream disconnected, attempting reconnect for device: $deviceId")
-              client.connect(deviceId)
+              if (!ObservationStreamClient.socketExists()) {
+                  LOG.info("Observation stream socket missing, daemon appears down - skipping reconnect")
+              } else {
+                  LOG.info("Observation stream disconnected, attempting reconnect for device: $deviceId")
+                  client.connect(deviceId)
+              }
           }
       }
   }
@@ -457,6 +462,20 @@ fun AutoMobileToolWindowContent() {
           currentMemoryMb = update.memoryUsageMb
           currentTouchLatencyMs = update.touchLatencyMs
           perfUpdateCounter++
+      }
+  }
+
+  // Clear performance metrics when stream disconnects
+  LaunchedEffect(observationStreamClient) {
+      val client = observationStreamClient ?: return@LaunchedEffect
+      client.connectionState.collect { connectionState ->
+          if (connectionState is StreamConnectionState.Disconnected) {
+              currentFps = null
+              currentFrameTimeMs = null
+              currentJankFrames = null
+              currentMemoryMb = null
+              currentTouchLatencyMs = null
+          }
       }
   }
 
@@ -746,6 +765,10 @@ fun AutoMobileToolWindowContent() {
                 clientProvider = clientProvider,
                 observationStreamClient = observationStreamClient!!,
                 platform = platformString,
+                onRestartDaemon = {
+                    activeDeviceId = null
+                    isDevicePanelExpanded = true
+                },
             )
 
             // Right vertical panels: Failures and Performance

--- a/android/ide-plugin/src/main/kotlin/dev/jasonpearson/automobile/ide/daemon/ObservationStreamClient.kt
+++ b/android/ide-plugin/src/main/kotlin/dev/jasonpearson/automobile/ide/daemon/ObservationStreamClient.kt
@@ -37,7 +37,7 @@ import kotlinx.serialization.json.contentOrNull
  */
 class ObservationStreamClient {
     companion object {
-        private fun getSocketPath(): String {
+        internal fun getSocketPath(): String {
             // Check for external mode (matches the server's logic)
             val isExternalMode = System.getenv("AUTOMOBILE_EMULATOR_EXTERNAL") == "true"
             return if (isExternalMode) {
@@ -46,6 +46,8 @@ class ObservationStreamClient {
                 "${System.getProperty("user.home")}/.auto-mobile/observation-stream.sock"
             }
         }
+
+        fun socketExists(): Boolean = Files.exists(Path.of(getSocketPath()))
     }
 
     private val log = Logger.getInstance(ObservationStreamClient::class.java)

--- a/android/ide-plugin/src/main/kotlin/dev/jasonpearson/automobile/ide/layout/DeviceScreenView.kt
+++ b/android/ide-plugin/src/main/kotlin/dev/jasonpearson/automobile/ide/layout/DeviceScreenView.kt
@@ -2,6 +2,13 @@
 
 package dev.jasonpearson.automobile.ide.layout
 
+import androidx.compose.animation.core.LinearEasing
+import androidx.compose.animation.core.RepeatMode
+import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.core.infiniteRepeatable
+import androidx.compose.animation.core.rememberInfiniteTransition
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
@@ -13,8 +20,10 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -80,6 +89,9 @@ fun DeviceScreenView(
     onElementHovered: (String?) -> Unit,
     showTapTargetIssues: Boolean = false,
     onToggleTapTargetIssues: () -> Unit = {},
+    connectionStatus: ConnectionStatus = ConnectionStatus.Connected,
+    socketExists: Boolean = true,
+    onRestartDaemon: (() -> Unit)? = null,
     modifier: Modifier = Modifier,
     refitTrigger: Any? = null,  // When this changes, refit the view to center
 ) {
@@ -463,7 +475,7 @@ fun DeviceScreenView(
                                 }
                         )
                     } else {
-                        // Placeholder device frame
+                        // Placeholder device frame - context-aware based on connection status
                         Box(
                             modifier = Modifier
                                 .fillMaxSize()
@@ -471,11 +483,71 @@ fun DeviceScreenView(
                                 .border(2.dp, Color(0xFF333333), RoundedCornerShape(8.dp)),
                             contentAlignment = Alignment.Center,
                         ) {
-                            Text(
-                                "Awaiting Observation",
-                                color = colors.text.normal.copy(alpha = 0.5f),
-                                fontSize = 12.sp,
-                            )
+                            when {
+                                connectionStatus == ConnectionStatus.Disconnected && !socketExists -> {
+                                    // Daemon is down - show restart button
+                                    Column(
+                                        horizontalAlignment = Alignment.CenterHorizontally,
+                                        verticalArrangement = Arrangement.spacedBy(12.dp),
+                                    ) {
+                                        Text(
+                                            "Device Disconnected",
+                                            color = colors.text.normal.copy(alpha = 0.5f),
+                                            fontSize = 12.sp,
+                                        )
+                                        if (onRestartDaemon != null) {
+                                            Box(
+                                                modifier = Modifier
+                                                    .background(colors.text.normal.copy(alpha = 0.1f), RoundedCornerShape(4.dp))
+                                                    .border(1.dp, colors.text.normal.copy(alpha = 0.2f), RoundedCornerShape(4.dp))
+                                                    .clickable(onClick = onRestartDaemon)
+                                                    .pointerHoverIcon(PointerIcon.Hand)
+                                                    .padding(horizontal = 12.dp, vertical = 6.dp),
+                                            ) {
+                                                Text(
+                                                    "Restart MCP Daemon",
+                                                    color = colors.text.normal.copy(alpha = 0.7f),
+                                                    fontSize = 11.sp,
+                                                )
+                                            }
+                                        }
+                                    }
+                                }
+                                connectionStatus == ConnectionStatus.Disconnected -> {
+                                    // Socket exists but device gone
+                                    Text(
+                                        "Device Disconnected",
+                                        color = colors.text.normal.copy(alpha = 0.5f),
+                                        fontSize = 12.sp,
+                                    )
+                                }
+                                connectionStatus == ConnectionStatus.Connecting -> {
+                                    // Reconnecting state with spinner
+                                    Column(
+                                        horizontalAlignment = Alignment.CenterHorizontally,
+                                        verticalArrangement = Arrangement.spacedBy(8.dp),
+                                    ) {
+                                        Text(
+                                            "Device Disconnected",
+                                            color = colors.text.normal.copy(alpha = 0.5f),
+                                            fontSize = 12.sp,
+                                        )
+                                        ReconnectingSpinner()
+                                        Text(
+                                            "Reconnecting...",
+                                            color = colors.text.normal.copy(alpha = 0.25f),
+                                            fontSize = 10.sp,
+                                        )
+                                    }
+                                }
+                                else -> {
+                                    Text(
+                                        "Awaiting Observation",
+                                        color = colors.text.normal.copy(alpha = 0.5f),
+                                        fontSize = 12.sp,
+                                    )
+                                }
+                            }
                         }
                     }
                 }
@@ -623,6 +695,46 @@ private fun TapTargetComplianceToggle(
                     color = if (issueCount > 0) Color(0xFFFF6B00) else colors.text.normal.copy(alpha = 0.5f),
                 )
             }
+        }
+    }
+}
+
+/**
+ * Low-contrast reconnecting spinner with rotating dots.
+ */
+@Composable
+private fun ReconnectingSpinner() {
+    val infiniteTransition = rememberInfiniteTransition(label = "reconnecting")
+    val angle by infiniteTransition.animateFloat(
+        initialValue = 0f,
+        targetValue = 360f,
+        animationSpec = infiniteRepeatable(
+            animation = tween(durationMillis = 1200, easing = LinearEasing),
+            repeatMode = RepeatMode.Restart,
+        ),
+        label = "rotation",
+    )
+
+    val colors = JewelTheme.globalColors
+    val dotColor = colors.text.normal.copy(alpha = 0.2f)
+
+    Canvas(modifier = Modifier.size(24.dp)) {
+        val centerX = size.width / 2
+        val centerY = size.height / 2
+        val radius = size.width / 2 - 4.dp.toPx()
+        val dotRadius = 2.dp.toPx()
+        val dotCount = 8
+
+        for (i in 0 until dotCount) {
+            val dotAngle = Math.toRadians((angle + i * 360.0 / dotCount).toDouble())
+            val alpha = 0.15f + 0.15f * (i.toFloat() / dotCount)
+            val x = centerX + radius * kotlin.math.cos(dotAngle).toFloat()
+            val y = centerY + radius * kotlin.math.sin(dotAngle).toFloat()
+            drawCircle(
+                color = dotColor.copy(alpha = alpha),
+                radius = dotRadius,
+                center = androidx.compose.ui.geometry.Offset(x, y),
+            )
         }
     }
 }

--- a/android/ide-plugin/src/main/kotlin/dev/jasonpearson/automobile/ide/layout/LayoutInspectorDashboard.kt
+++ b/android/ide-plugin/src/main/kotlin/dev/jasonpearson/automobile/ide/layout/LayoutInspectorDashboard.kt
@@ -19,6 +19,7 @@ import androidx.compose.ui.unit.dp
 import org.jetbrains.jewel.foundation.theme.JewelTheme
 import dev.jasonpearson.automobile.ide.daemon.AutoMobileClient
 import dev.jasonpearson.automobile.ide.daemon.ObservationStreamClient
+import dev.jasonpearson.automobile.ide.daemon.StreamConnectionState
 import dev.jasonpearson.automobile.ide.datasource.DataSourceMode
 import dev.jasonpearson.automobile.ide.tabs.PanelHeader
 import dev.jasonpearson.automobile.ide.tabs.VerticalCollapsibleTab
@@ -36,6 +37,7 @@ fun LayoutInspectorDashboard(
     clientProvider: (() -> AutoMobileClient)? = null,  // MCP client for real data
     observationStreamClient: ObservationStreamClient,  // Shared stream client (managed at app level)
     platform: String = "android",  // Device platform ("android" or "ios")
+    onRestartDaemon: (() -> Unit)? = null,
 ) {
     val state = rememberLayoutInspectorState()
     val colors = JewelTheme.globalColors
@@ -80,6 +82,25 @@ fun LayoutInspectorDashboard(
                     timestamp = update.timestamp,
                 )
                 dashboardLog.info("Updated state with new screenshot")
+            }
+        }
+    }
+
+    // Collect stream connection state to update layout inspector state (Real mode only)
+    if (dataSourceMode == DataSourceMode.Real) {
+        LaunchedEffect(streamClient) {
+            streamClient.connectionState.collect { connectionState ->
+                when (connectionState) {
+                    is StreamConnectionState.Connected -> {
+                        state.updateConnectionStatus(ConnectionStatus.Connected)
+                    }
+                    is StreamConnectionState.Connecting -> {
+                        state.updateConnectionStatus(ConnectionStatus.Connecting)
+                    }
+                    is StreamConnectionState.Disconnected -> {
+                        state.disconnect()
+                    }
+                }
             }
         }
     }
@@ -167,6 +188,9 @@ fun LayoutInspectorDashboard(
                 onElementHovered = { state.hoverElement(it) },
                 showTapTargetIssues = state.showTapTargetIssues,
                 onToggleTapTargetIssues = { state.toggleTapTargetIssues() },
+                connectionStatus = state.connectionStatus,
+                socketExists = ObservationStreamClient.socketExists(),
+                onRestartDaemon = onRestartDaemon,
                 modifier = Modifier.fillMaxSize(),
                 refitTrigger = refitTrigger,  // Trigger refit when panels toggle
             )

--- a/android/ide-plugin/src/main/kotlin/dev/jasonpearson/automobile/ide/layout/LayoutInspectorState.kt
+++ b/android/ide-plugin/src/main/kotlin/dev/jasonpearson/automobile/ide/layout/LayoutInspectorState.kt
@@ -253,12 +253,23 @@ class LayoutInspectorState {
     }
 
     /**
-     * Disconnect from device.
+     * Update connection status externally (e.g., from stream connection state).
+     */
+    fun updateConnectionStatus(status: ConnectionStatus) {
+        connectionStatus = status
+    }
+
+    /**
+     * Disconnect from device. Clears all device-specific stale data.
      */
     fun disconnect() {
         connectionStatus = ConnectionStatus.Disconnected
         streamingMode = StreamingMode.Paused
         screenshotData = null
+        hierarchy = null
+        selectedElementId = null
+        hoveredElementId = null
+        changedElementIds = emptySet()
     }
 
     // ========================================


### PR DESCRIPTION
## Summary
- Replace stale screenshot with context-aware "Device Disconnected" placeholder when the observed device disconnects
- Show a low-contrast reconnecting spinner when the socket file exists, or a "Restart MCP Daemon" button when the daemon is down
- Clear all stale data (view hierarchy, selection, performance metrics) on disconnect and resume live data on reconnect

## Test Plan
- [ ] `./gradlew -p android :ide-plugin:build` passes
- [ ] Connect a device in Real mode, observe layout, then disconnect — verify screenshot area shows "Device Disconnected", hierarchy panel clears, performance metrics clear
- [ ] Kill the daemon — verify "Restart MCP Daemon" button appears; clicking navigates to device panel
- [ ] Verify Fake mode is unaffected

Closes #1202

🤖 Generated with [Claude Code](https://claude.com/claude-code)