### PR TITLE
fix: make daemon-down socket check reactive via polling state

### DIFF
--- a/android/ide-plugin/src/main/kotlin/dev/jasonpearson/automobile/ide/layout/LayoutInspectorDashboard.kt
+++ b/android/ide-plugin/src/main/kotlin/dev/jasonpearson/automobile/ide/layout/LayoutInspectorDashboard.kt
@@ -105,6 +105,22 @@ fun LayoutInspectorDashboard(
         }
     }
 
+    // Poll socket existence so the UI reacts when the daemon starts or stops.
+    // Only active when disconnected/connecting — connected state doesn't need this.
+    var socketExists by remember { mutableStateOf(ObservationStreamClient.socketExists()) }
+    val isDisconnectedOrConnecting = state.connectionStatus == ConnectionStatus.Disconnected ||
+        state.connectionStatus == ConnectionStatus.Connecting
+    LaunchedEffect(isDisconnectedOrConnecting) {
+        if (isDisconnectedOrConnecting) {
+            while (true) {
+                socketExists = ObservationStreamClient.socketExists()
+                kotlinx.coroutines.delay(2000)
+            }
+        } else {
+            socketExists = true
+        }
+    }
+
     // Initial fetch as fallback (in case stream hasn't pushed yet)
     LaunchedEffect(dataSourceMode, clientProvider) {
         kotlinx.coroutines.withContext(kotlinx.coroutines.Dispatchers.IO) {
@@ -189,7 +205,7 @@ fun LayoutInspectorDashboard(
                 showTapTargetIssues = state.showTapTargetIssues,
                 onToggleTapTargetIssues = { state.toggleTapTargetIssues() },
                 connectionStatus = state.connectionStatus,
-                socketExists = ObservationStreamClient.socketExists(),
+                socketExists = socketExists,
                 onRestartDaemon = onRestartDaemon,
                 modifier = Modifier.fillMaxSize(),
                 refitTrigger = refitTrigger,  // Trigger refit when panels toggle


### PR DESCRIPTION
## Summary
- Replace the one-off `ObservationStreamClient.socketExists()` call during composition with a polled `mutableStateOf` that updates every 2s while disconnected/connecting
- Ensures the UI properly transitions between "Device Disconnected" and "Restart MCP Daemon" when the daemon socket appears or disappears after the initial disconnect
- Polling is gated to only run when disconnected/connecting — no overhead during normal connected operation

## Test Plan
- [ ] `./gradlew -p android :ide-plugin:build` passes
- [ ] Connect device, disconnect, then kill daemon — verify "Restart MCP Daemon" button appears within ~2s
- [ ] While showing "Restart MCP Daemon", restart the daemon — verify button disappears within ~2s

Closes #1202

🤖 Generated with [Claude Code](https://claude.com/claude-code)