### PR TITLE
fix: handle feature flag requests in socket server to fix IDE settings page

### DIFF
--- a/android/ide-plugin/src/main/kotlin/dev/jasonpearson/automobile/ide/daemon/McpDaemonClient.kt
+++ b/android/ide-plugin/src/main/kotlin/dev/jasonpearson/automobile/ide/daemon/McpDaemonClient.kt
@@ -83,8 +83,9 @@ class McpDaemonClient(
   }
 
   override fun listFeatureFlags(): List<FeatureFlagState> {
-    val response = callTool("listFeatureFlags", JsonObject(emptyMap()))
-    val result = decodeToolResponse(json, response, FeatureFlagListResult.serializer())
+    val response = sendRequest("ide/listFeatureFlags")
+    ensureSuccess(response)
+    val result = json.decodeFromJsonElement(FeatureFlagListResult.serializer(), response.result!!)
     return result.flags
   }
 
@@ -94,8 +95,8 @@ class McpDaemonClient(
       config: JsonObject?,
   ): FeatureFlagState {
     val response =
-        callTool(
-            "setFeatureFlag",
+        sendRequest(
+            "ide/setFeatureFlag",
             buildJsonObject {
               put("key", JsonPrimitive(key))
               put("enabled", JsonPrimitive(enabled))
@@ -104,7 +105,8 @@ class McpDaemonClient(
               }
             },
         )
-    return decodeToolResponse(json, response, FeatureFlagState.serializer())
+    ensureSuccess(response)
+    return json.decodeFromJsonElement(FeatureFlagState.serializer(), response.result!!)
   }
 
   override fun listPerformanceAuditResults(

--- a/src/daemon/daemon.ts
+++ b/src/daemon/daemon.ts
@@ -40,6 +40,7 @@ import { startAppearanceSyncScheduler, stopAppearanceSyncScheduler } from "../ut
 import { startPerformanceMonitor, stopPerformanceMonitor, getPerformanceMonitor } from "../features/performance/PerformanceMonitor";
 import { listActiveVideoRecordings, stopVideoRecording } from "../server/videoRecordingManager";
 import { Timer, defaultTimer } from "../utils/SystemTimer";
+import { FeatureFlagService } from "../features/featureFlags/FeatureFlagService";
 
 const DEVICE_DISCONNECT_POLL_INTERVAL_MS = 5000;
 const DEVICE_DISCONNECT_MISS_THRESHOLD = 2;
@@ -126,7 +127,13 @@ export class Daemon {
     logger.info(`MCP_STREAMABLE_PATH: "${MCP_STREAMABLE_PATH}"`);
     const mcpEndpoint = `http://${this.host}:${this.port}${MCP_STREAMABLE_PATH}`;
     logger.info(`Creating UnixSocketServer with endpoint: "${mcpEndpoint}"`);
-    this.socketServer = new UnixSocketServer(SOCKET_PATH, mcpEndpoint);
+    this.socketServer = new UnixSocketServer(
+      SOCKET_PATH,
+      mcpEndpoint,
+      undefined,
+      undefined,
+      FeatureFlagService.getInstance()
+    );
     logger.info("Starting Unix socket server...");
     startupBenchmark.startPhase("socketServerStart");
     await this.socketServer.start();
@@ -764,7 +771,13 @@ export class Daemon {
 
         // Recreate socket server
         const mcpEndpoint = `http://${this.host}:${this.port}${MCP_STREAMABLE_PATH}`;
-        this.socketServer = new UnixSocketServer(SOCKET_PATH, mcpEndpoint);
+        this.socketServer = new UnixSocketServer(
+          SOCKET_PATH,
+          mcpEndpoint,
+          undefined,
+          undefined,
+          FeatureFlagService.getInstance()
+        );
         try {
           await this.socketServer.start();
           logger.info("Socket server restarted successfully");

--- a/src/daemon/socketServer.ts
+++ b/src/daemon/socketServer.ts
@@ -14,6 +14,8 @@ import { SOCKET_PATH } from "./constants";
 import { DaemonState } from "./daemonState";
 import { DaemonStateAccess, handleDaemonRequest } from "./daemonRequestHandlers";
 import { Timer, defaultTimer } from "../utils/SystemTimer";
+import type { FeatureFlagService } from "../features/featureFlags/FeatureFlagService";
+import type { FeatureFlagKey } from "../features/featureFlags/FeatureFlagDefinitions";
 
 /**
  * Unix Socket Server that proxies requests to the HTTP MCP server
@@ -34,17 +36,20 @@ export class UnixSocketServer {
   private mcpClient: Client | null = null;
   private mcpClientPromise: Promise<Client> | null = null;
   private timer: Timer;
+  private featureFlagService: FeatureFlagService | null;
 
   constructor(
     socketPath: string = SOCKET_PATH,
     mcpEndpoint: string,
     daemonState: DaemonStateAccess = DaemonState.getInstance(),
-    timer: Timer = defaultTimer
+    timer: Timer = defaultTimer,
+    featureFlagService: FeatureFlagService | null = null
   ) {
     this.socketPath = socketPath;
     this.mcpEndpoint = mcpEndpoint;
     this.daemonState = daemonState;
     this.timer = timer;
+    this.featureFlagService = featureFlagService;
     logger.info(`UnixSocketServer initialized with endpoint: "${mcpEndpoint}"`);
     if (!mcpEndpoint) {
       logger.error("ERROR: mcpEndpoint is empty or undefined!");
@@ -162,6 +167,17 @@ export class UnixSocketServer {
           };
         }
 
+        // Handle IDE-only requests that don't need the MCP client
+        const localResult = await this.handleLocalIdeRequest(request);
+        if (localResult !== undefined) {
+          return {
+            id: request.id,
+            type: "mcp_response",
+            success: true,
+            result: localResult,
+          };
+        }
+
         const mcpClient = await this.getMcpClient();
 
         const result = await this.handleIdeRequest(mcpClient, request);
@@ -186,6 +202,44 @@ export class UnixSocketServer {
         };
       }
     });
+  }
+
+  /**
+   * Handle IDE requests that don't require the MCP client.
+   * Returns undefined if the request should be forwarded to MCP.
+   */
+  private async handleLocalIdeRequest(
+    request: DaemonRequest
+  ): Promise<any | undefined> {
+    switch (request.method) {
+      case "ide/listFeatureFlags": {
+        if (!this.featureFlagService) {
+          throw new Error("Feature flag service not available");
+        }
+        const flags = await this.featureFlagService.listFlags();
+        return { flags };
+      }
+      case "ide/setFeatureFlag": {
+        if (!this.featureFlagService) {
+          throw new Error("Feature flag service not available");
+        }
+        const args = request.params as { key?: string; enabled?: boolean; config?: Record<string, unknown> | null };
+        if (!args.key || typeof args.enabled !== "boolean") {
+          throw new Error("setFeatureFlag requires 'key' (string) and 'enabled' (boolean) params");
+        }
+        const updated = await this.featureFlagService.setFlag(
+          args.key as FeatureFlagKey,
+          args.enabled,
+          args.config
+        );
+        return updated;
+      }
+      case "ide/ping": {
+        return { ok: true, timestamp: this.timer.now() };
+      }
+      default:
+        return undefined;
+    }
   }
 
   private async handleIdeRequest(
@@ -222,9 +276,6 @@ export class UnixSocketServer {
       case "ide/getNavigationGraph": {
         const args = request.params ?? {};
         return await mcpClient.callTool({ name: "getNavigationGraph", arguments: args }, undefined, requestOptions);
-      }
-      case "ide/ping": {
-        return { ok: true, timestamp: this.timer.now() };
       }
       default:
         throw new Error(`Unsupported daemon method: ${request.method}`);

--- a/test/daemon/socketServerFeatureFlags.test.ts
+++ b/test/daemon/socketServerFeatureFlags.test.ts
@@ -1,0 +1,153 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { Socket } from "node:net";
+import { randomUUID } from "node:crypto";
+import { existsSync } from "node:fs";
+import { unlink } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { UnixSocketServer } from "../../src/daemon/socketServer";
+import { FeatureFlagService } from "../../src/features/featureFlags/FeatureFlagService";
+import { FakeFeatureFlagRepository } from "../fakes/FakeFeatureFlagRepository";
+import { FakeFeatureFlagApplier } from "../fakes/FakeFeatureFlagApplier";
+import { FakeTimer } from "../fakes/FakeTimer";
+import type { DaemonResponse } from "../../src/daemon/types";
+
+function createTestService(): FeatureFlagService {
+  return new FeatureFlagService(
+    new FakeFeatureFlagRepository(),
+    new FakeFeatureFlagApplier(),
+    [
+      { key: "debug", label: "Debug mode", description: "Enable debug tools.", defaultValue: false },
+      { key: "ui-perf-mode", label: "UI perf", description: "Run UI perf audits.", defaultValue: true },
+    ]
+  );
+}
+
+function createFakeDaemonState() {
+  return {
+    isInitialized: () => true,
+    getSessionManager: () => ({ getSession: () => null, releaseSession: async () => null }),
+    getDevicePool: () => ({
+      refreshDevices: async () => 0,
+      getStats: () => ({ total: 0, idle: 0, assigned: 0, error: 0 }),
+      releaseDevice: async () => {},
+    }),
+  };
+}
+
+function sendRequest(socketPath: string, method: string, params: Record<string, unknown> = {}): Promise<DaemonResponse> {
+  return new Promise((resolve, reject) => {
+    const client = new Socket();
+    let buffer = "";
+
+    client.connect(socketPath, () => {
+      const request = JSON.stringify({
+        id: randomUUID(),
+        type: "mcp_request",
+        method,
+        params,
+      });
+      client.write(request + "\n");
+    });
+
+    client.on("data", data => {
+      buffer += data.toString();
+      const lines = buffer.split("\n");
+      for (const line of lines) {
+        if (line.trim()) {
+          try {
+            const response = JSON.parse(line) as DaemonResponse;
+            client.destroy();
+            resolve(response);
+            return;
+          } catch {
+            // Incomplete JSON, keep buffering
+          }
+        }
+      }
+    });
+
+    client.on("error", reject);
+    client.on("close", () => {
+      if (!buffer.trim()) {
+        reject(new Error("Connection closed without response"));
+      }
+    });
+  });
+}
+
+describe("UnixSocketServer feature flag handlers", () => {
+  let socketPath: string;
+  let server: UnixSocketServer;
+  let fakeTimer: FakeTimer;
+  let featureFlagService: FeatureFlagService;
+
+  beforeEach(async () => {
+    socketPath = join(tmpdir(), `test-ff-${randomUUID()}.sock`);
+    fakeTimer = new FakeTimer();
+    featureFlagService = createTestService();
+
+    server = new UnixSocketServer(
+      socketPath,
+      "http://localhost:0/mcp",
+      createFakeDaemonState(),
+      fakeTimer,
+      featureFlagService
+    );
+    await server.start();
+  });
+
+  afterEach(async () => {
+    await server.close();
+    if (existsSync(socketPath)) {
+      await unlink(socketPath);
+    }
+  });
+
+  test("ide/listFeatureFlags returns all flags", async () => {
+    const response = await sendRequest(socketPath, "ide/listFeatureFlags");
+
+    expect(response.success).toBe(true);
+    const result = response.result as { flags: Array<{ key: string; label: string; enabled: boolean }> };
+    expect(result.flags).toHaveLength(2);
+    expect(result.flags[0].key).toBe("debug");
+    expect(result.flags[0].enabled).toBe(false);
+    expect(result.flags[1].key).toBe("ui-perf-mode");
+    expect(result.flags[1].enabled).toBe(true);
+  });
+
+  test("ide/setFeatureFlag enables a flag", async () => {
+    const response = await sendRequest(socketPath, "ide/setFeatureFlag", {
+      key: "debug",
+      enabled: true,
+    });
+
+    expect(response.success).toBe(true);
+    const result = response.result as { key: string; enabled: boolean };
+    expect(result.key).toBe("debug");
+    expect(result.enabled).toBe(true);
+
+    // Verify persistence
+    const listResponse = await sendRequest(socketPath, "ide/listFeatureFlags");
+    const listResult = listResponse.result as { flags: Array<{ key: string; enabled: boolean }> };
+    const debugFlag = listResult.flags.find(f => f.key === "debug");
+    expect(debugFlag?.enabled).toBe(true);
+  });
+
+  test("ide/setFeatureFlag returns error for missing params", async () => {
+    const response = await sendRequest(socketPath, "ide/setFeatureFlag", {});
+
+    expect(response.success).toBe(false);
+    expect(response.error).toContain("requires");
+  });
+
+  test("ide/setFeatureFlag returns error for unknown flag", async () => {
+    const response = await sendRequest(socketPath, "ide/setFeatureFlag", {
+      key: "nonexistent",
+      enabled: true,
+    });
+
+    expect(response.success).toBe(false);
+    expect(response.error).toContain("Unknown feature flag");
+  });
+});


### PR DESCRIPTION
## Summary
- Move feature flag handling (`listFeatureFlags`, `setFeatureFlag`) from MCP tools to the Unix socket server's local request path (`ide/listFeatureFlags`, `ide/setFeatureFlag`)
- Update `McpDaemonClient` to call `sendRequest("ide/...")` instead of `callTool()` for feature flags
- Feature flags are handled directly by `FeatureFlagService` without going through MCP, preserving the token budget savings from the original removal

## Test Plan
- [x] Added 4 new tests in `socketServerFeatureFlags.test.ts` covering list, set, validation, and error handling
- [x] All 2104 tests pass
- [x] TypeScript build and lint pass
- [x] IDE plugin Gradle build passes

Closes #1213

🤖 Generated with [Claude Code](https://claude.com/claude-code)