### PR TITLE
fix: use correct extracted path for gum binary in install script

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -785,7 +785,7 @@ install_bundled_gum() {
     tar -xzf "${archive_path}" -C "${temp_dir}"
 
     mkdir -p "${GUM_INSTALL_DIR}"
-    mv "${temp_dir}/gum" "${GUM_BINARY}"
+    mv "${temp_dir}"/gum_*/gum "${GUM_BINARY}"
     chmod +x "${GUM_BINARY}"
     echo "${GUM_VERSION}" > "${GUM_VERSION_FILE}"
     rm -rf "${temp_dir}"


### PR DESCRIPTION
## Summary
- The gum release tarball extracts into a versioned subdirectory (`gum_0.17.0_Darwin_arm64/`) rather than placing the binary at the root of the temp directory
- Changed `mv "${temp_dir}/gum"` to `mv "${temp_dir}"/gum_*/gum` to match the actual extracted path
- Fixes `mv: rename ... to .../gum: No such file or directory` error during install

## Test Plan
- [ ] Run `scripts/install.sh` on macOS (arm64 and x86_64)
- [ ] Run `scripts/install.sh` on Linux (arm64 and x86_64)
- [ ] Verify gum binary is correctly placed in `~/.automobile/bin/gum`

🤖 Generated with [Claude Code](https://claude.com/claude-code)