### PR TITLE
chore: update XCTestService IPA SHA256

### DIFF
--- a/src/constants/release.ts
+++ b/src/constants/release.ts
@@ -31,5 +31,5 @@ export const XCTESTSERVICE_RELEASE_VERSION: string = "latest";
 export const XCTESTSERVICE_IPA_URL: string = XCTESTSERVICE_RELEASE_VERSION === "latest"
   ? "https://github.com/kaeawc/auto-mobile/releases/latest/download/XCTestService.ipa"
   : `https://github.com/kaeawc/auto-mobile/releases/download/v${XCTESTSERVICE_RELEASE_VERSION}/XCTestService.ipa`;
-export const XCTESTSERVICE_SHA256_CHECKSUM: string = "ffbb85298b50a95a1498ce716ecc4262b56b6d31471747c08ec95d13b102569d"; // Empty = skip verification (local dev only)
+export const XCTESTSERVICE_SHA256_CHECKSUM: string = "c4ad9a45a8d750e2179cbe67c28e19392a5cbf19ca93cfb6be704d5dcb99c453"; // Empty = skip verification (local dev only)
 export const XCTESTSERVICE_APP_HASH: string = ""; // Hash of XCTestServiceApp.app (device build), empty = skip verification


### PR DESCRIPTION
## Automated Checksum Update

The nightly build produced artifacts with updated SHA256 checksums.

| Artifact | Previous | New | Changed |
|----------|----------|-----|---------|
| **APK** | `b7be60f2c4c26c5e7e5b04064fb139707d792badf91170a1874be72b59195ca1` | `b7be60f2c4c26c5e7e5b04064fb139707d792badf91170a1874be72b59195ca1` | No |
| **IPA** | `ffbb85298b50a95a1498ce716ecc4262b56b6d31471747c08ec95d13b102569d` | `c4ad9a45a8d750e2179cbe67c28e19392a5cbf19ca93cfb6be704d5dcb99c453` | ✅ Yes |

### Why did this happen?

SHA256 checksums change when any of these change:
- Source code in `android/accessibility-service/src/` or `ios/XCTestService/`
- Build configuration (`build.gradle.kts` or `project.yml`)
- Dependencies or SDK versions

### What to do

1. Review this PR to ensure the changes are expected
2. Merge when ready
3. Future releases will use these checksums for artifact verification

---
Auto-generated by the `nightly` workflow