### PR TITLE
fix: derive UISwitch checked state from snapshot.value instead of isSelected

### DIFF
--- a/ios/XCTestService/Sources/XCTestService/ElementLocator.swift
+++ b/ios/XCTestService/Sources/XCTestService/ElementLocator.swift
@@ -640,6 +640,13 @@ public class ElementLocator: ElementLocating {
             let isScrollable = isScrollableType(snapshot.elementType)
             let isCheckable = isCheckableType(snapshot.elementType)
             let isSelected = snapshot.isSelected
+            // UISwitch reports toggle state via value ("0"/"1"), not isSelected
+            let isChecked: Bool
+            if isCheckable, let value = snapshot.value as? String {
+                isChecked = value == "1"
+            } else {
+                isChecked = isCheckable && isSelected
+            }
             let hasFocus = snapshot.hasFocus
             let isPassword = snapshot.elementType == .secureTextField
 
@@ -673,7 +680,7 @@ public class ElementLocator: ElementLocating {
                 scrollable: isScrollable ? "true" : nil,
                 password: isPassword ? "true" : nil,
                 checkable: isCheckable ? "true" : nil,
-                checked: (isCheckable && isSelected) ? "true" : nil,
+                checked: isChecked ? "true" : nil,
                 selected: isSelected ? "true" : nil,
                 longClickable: nil, // Don't include - same as clickable on iOS
                 testTag: nil, // Don't duplicate - identifier is in resourceId

--- a/ios/XCTestService/Tests/XCTestServiceTests/HierarchyDebouncerTests.swift
+++ b/ios/XCTestService/Tests/XCTestServiceTests/HierarchyDebouncerTests.swift
@@ -497,4 +497,35 @@ final class HierarchyDebouncerTests: XCTestCase {
 
         XCTAssertNotEqual(hash1, hash2, "Hash should change when clickable/enabled state changes")
     }
+
+    func testHashChangesWhenCheckedStateChanges() {
+        let hierarchyUnchecked = ViewHierarchy(
+            packageName: "com.test.app",
+            hierarchy: UIElementInfo(
+                text: "Wi-Fi",
+                className: "UISwitch",
+                bounds: ElementBounds(left: 280, top: 100, right: 340, bottom: 130),
+                checkable: "true",
+                checked: nil
+            ),
+            windowInfo: WindowInfo(id: 0, type: 1, isActive: true, isFocused: true)
+        )
+
+        let hierarchyChecked = ViewHierarchy(
+            packageName: "com.test.app",
+            hierarchy: UIElementInfo(
+                text: "Wi-Fi",
+                className: "UISwitch",
+                bounds: ElementBounds(left: 280, top: 100, right: 340, bottom: 130),
+                checkable: "true",
+                checked: "true"
+            ),
+            windowInfo: WindowInfo(id: 0, type: 1, isActive: true, isFocused: true)
+        )
+
+        let hashUnchecked = StructuralHasher.computeHash(hierarchyUnchecked)
+        let hashChecked = StructuralHasher.computeHash(hierarchyChecked)
+
+        XCTAssertNotEqual(hashUnchecked, hashChecked, "Hash should change when checked state changes")
+    }
 }


### PR DESCRIPTION
## Summary
- UISwitch reports toggle state via `snapshot.value` (`"0"`/`"1"`), not `isSelected`. The `checked` property in `ElementLocator.swift` was using `isSelected`, which never changes on toggle.
- This caused `StructuralHasher` to compute the same hash before/after toggle, so `HierarchyDebouncer` never broadcast the update and the IDE plugin never refreshed.
- Added `testHashChangesWhenCheckedStateChanges()` to verify the structural hash changes when checked state toggles.

## Test Plan
- [x] `./scripts/ios/swift-build.sh` passes
- [x] `./scripts/ios/swift-test.sh` passes (62 tests, 0 failures)
- [x] `./scripts/all_fast_validate_checks.sh` passes (8/8)
- [x] `./scripts/local/validate-ios.sh` passes

Closes #1227

🤖 Generated with [Claude Code](https://claude.com/claude-code)