### PR TITLE
chore: bump versions to v0.0.11

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -14,7 +14,7 @@
       "name": "auto-mobile",
       "source": "./",
       "description": "Mobile device automation for Android and iOS - control devices with natural language",
-      "version": "0.0.10",
+      "version": "0.0.11",
       "author": {
         "name": "AutoMobile Contributors",
         "email": "jason.d.pearson@gmail.com"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "auto-mobile",
   "description": "Mobile device automation for Android and iOS - control devices with natural language",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "author": {
     "name": "AutoMobile Contributors",
     "email": "jason.d.pearson@gmail.com"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,34 @@
 # Changelog
 
+## [v0.0.11] - 2026-02-11
+### Added
+- IDE plugin: always use active (white) toolbar icon ([#1214](https://github.com/kaeawc/auto-mobile/issues/1214)) (intellij plugin)
+- Remove feature flag for video test recording ([#1203](https://github.com/kaeawc/auto-mobile/issues/1203)) (video)
+- IDE plugin: show 'Device Disconnected' when observed device becomes unavailable ([#1202](https://github.com/kaeawc/auto-mobile/issues/1202)) (intellij plugin)
+- IDE Plugin: Add full-window FileEditor mode for dashboard ([#1167](https://github.com/kaeawc/auto-mobile/issues/1167)) (intellij plugin)
+- feat: iOS version matrix testing in CI ([#836](https://github.com/kaeawc/auto-mobile/issues/836)) (ios, ci, testing)
+- Support custom accessibility rules ([#104](https://github.com/kaeawc/auto-mobile/issues/104)) (devxp, a11y)
+### Changed
+- refactor: ViewHierarchy has near-clone findFocusedElement / findAccessibilityFocusedElement ([#1191](https://github.com/kaeawc/auto-mobile/issues/1191))
+- refactor: UIStateExtractor reimplements ElementParser traversal and property extraction ([#1190](https://github.com/kaeawc/auto-mobile/issues/1190))
+- refactor: BugReport.traverseNode() reimplements ElementParser inline ([#1189](https://github.com/kaeawc/auto-mobile/issues/1189))
+- refactor: DebugSearch reimplements ElementParser, TextMatcher, and ElementFinder inline ([#1188](https://github.com/kaeawc/auto-mobile/issues/1188))
+- chore: upgrade GitHub Actions upload-artifact and download-artifact to v4.6+ ([#1158](https://github.com/kaeawc/auto-mobile/issues/1158)) (ci)
+- Dead Code Detection: Threshold Exceeded ([#1143](https://github.com/kaeawc/auto-mobile/issues/1143)) (automated, dead-code)
+### Fixed
+- IDE plugin: device disconnected notification is too aggressive ([#1244](https://github.com/kaeawc/auto-mobile/issues/1244)) (intellij plugin)
+- iOS: toggle switch tap does not trigger view hierarchy or screenshot update ([#1227](https://github.com/kaeawc/auto-mobile/issues/1227))
+- bug: IDE plugin settings page fails to load feature flags with MCP error -32603 ([#1213](https://github.com/kaeawc/auto-mobile/issues/1213)) (intellij plugin)
+- Bug: IDE plugin crashes with IllegalArgumentException when opening test plan YAML file ([#1205](https://github.com/kaeawc/auto-mobile/issues/1205)) (intellij plugin)
+- Bug: failing JUnit Runner test does not produce a failing JUnit test result ([#1204](https://github.com/kaeawc/auto-mobile/issues/1204)) (testing)
+- iOS: Unable to observe system permission dialogs in view hierarchy ([#1147](https://github.com/kaeawc/auto-mobile/issues/1147)) (ios)
+### Other
+- CI: add Xcode 26 to iOS build and test matrix ([#1207](https://github.com/kaeawc/auto-mobile/issues/1207)) (ios, ci)
+- CI: auto-retry iOS jobs when no simulator runtimes are installed on macOS runner ([#1206](https://github.com/kaeawc/auto-mobile/issues/1206)) (ios, ci)
+- CI: add macOS job for iOS Accessibility Bridge build + XCTest runner tests ([#372](https://github.com/kaeawc/auto-mobile/issues/372)) (ios, ci)
+- Publish AutoMobile Android SDK on Maven Central ([#122](https://github.com/kaeawc/auto-mobile/issues/122)) (android, ci, release engineering)
+- Publish AutoMobile JUnitRunner Library ([#121](https://github.com/kaeawc/auto-mobile/issues/121)) (android, ci, release engineering, testing)
+
 ## [v0.0.10] - 2026-02-06
 ### Added
 - Support custom accessibility rules ([#104](https://github.com/kaeawc/auto-mobile/issues/104)) (devxp, a11y)

--- a/android/accessibility-service/build.gradle.kts
+++ b/android/accessibility-service/build.gradle.kts
@@ -36,7 +36,7 @@ android {
     minSdk = libs.versions.build.android.minSdk.get().toInt()
     targetSdk = libs.versions.build.android.targetSdk.get().toInt()
     versionCode = 1
-    versionName = "0.0.10-SNAPSHOT"
+    versionName = "0.0.11-SNAPSHOT"
 
     testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
   }

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -136,7 +136,7 @@ ksp.useKSP2=false
 # Maven Central Publishing
 
 # Library versions (single source of truth)
-VERSION_NAME=0.0.10-SNAPSHOT
+VERSION_NAME=0.0.11-SNAPSHOT
 GROUP=dev.jasonpearson.auto-mobile
 
 # POM metadata

--- a/android/playground/app/build.gradle.kts
+++ b/android/playground/app/build.gradle.kts
@@ -36,7 +36,7 @@ android {
     minSdk = libs.versions.build.android.minSdk.get().toInt()
     targetSdk = libs.versions.build.android.targetSdk.get().toInt()
     versionCode = 1
-    versionName = "0.0.10-SNAPSHOT"
+    versionName = "0.0.11-SNAPSHOT"
 
     testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kaeawc/auto-mobile",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "description": "Mobile device interaction automation via MCP",
   "scripts": {
     "test": "bun test",

--- a/src/constants/release.ts
+++ b/src/constants/release.ts
@@ -31,5 +31,5 @@ export const XCTESTSERVICE_RELEASE_VERSION: string = "latest";
 export const XCTESTSERVICE_IPA_URL: string = XCTESTSERVICE_RELEASE_VERSION === "latest"
   ? "https://github.com/kaeawc/auto-mobile/releases/latest/download/XCTestService.ipa"
   : `https://github.com/kaeawc/auto-mobile/releases/download/v${XCTESTSERVICE_RELEASE_VERSION}/XCTestService.ipa`;
-export const XCTESTSERVICE_SHA256_CHECKSUM: string = "c4ad9a45a8d750e2179cbe67c28e19392a5cbf19ca93cfb6be704d5dcb99c453"; // Empty = skip verification (local dev only)
+export const XCTESTSERVICE_SHA256_CHECKSUM: string = "9ea691cd3ceaa82a7de4ac7ce5455457352437fb995c0da00b300804bcde0188"; // Empty = skip verification (local dev only)
 export const XCTESTSERVICE_APP_HASH: string = ""; // Hash of XCTestServiceApp.app (device build), empty = skip verification


### PR DESCRIPTION
## Summary
- Bump versions to v0.0.11
- Update CHANGELOG.md from closed issues since the last tag
- Refresh Accessibility Service APK SHA256 checksum
- Refresh XCTestService IPA SHA256 checksum

## Automation
- Generated by `prepare-release` workflow