### PR TITLE
chore: bump versions to v0.0.12

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -14,7 +14,7 @@
       "name": "auto-mobile",
       "source": "./",
       "description": "Mobile device automation for Android and iOS - control devices with natural language",
-      "version": "0.0.11",
+      "version": "0.0.12",
       "author": {
         "name": "AutoMobile Contributors",
         "email": "jason.d.pearson@gmail.com"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "auto-mobile",
   "description": "Mobile device automation for Android and iOS - control devices with natural language",
-  "version": "0.0.11",
+  "version": "0.0.12",
   "author": {
     "name": "AutoMobile Contributors",
     "email": "jason.d.pearson@gmail.com"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [v0.0.12] - 2026-02-11
+### Other
+- No changes.
+
 ## [v0.0.11] - 2026-02-11
 ### Added
 - IDE plugin: always use active (white) toolbar icon ([#1214](https://github.com/kaeawc/auto-mobile/issues/1214)) (intellij plugin)

--- a/android/accessibility-service/build.gradle.kts
+++ b/android/accessibility-service/build.gradle.kts
@@ -36,7 +36,7 @@ android {
     minSdk = libs.versions.build.android.minSdk.get().toInt()
     targetSdk = libs.versions.build.android.targetSdk.get().toInt()
     versionCode = 1
-    versionName = "0.0.11-SNAPSHOT"
+    versionName = "0.0.12-SNAPSHOT"
 
     testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
   }

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -136,7 +136,7 @@ ksp.useKSP2=false
 # Maven Central Publishing
 
 # Library versions (single source of truth)
-VERSION_NAME=0.0.11-SNAPSHOT
+VERSION_NAME=0.0.12-SNAPSHOT
 GROUP=dev.jasonpearson.auto-mobile
 
 # POM metadata

--- a/android/playground/app/build.gradle.kts
+++ b/android/playground/app/build.gradle.kts
@@ -36,7 +36,7 @@ android {
     minSdk = libs.versions.build.android.minSdk.get().toInt()
     targetSdk = libs.versions.build.android.targetSdk.get().toInt()
     versionCode = 1
-    versionName = "0.0.11-SNAPSHOT"
+    versionName = "0.0.12-SNAPSHOT"
 
     testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kaeawc/auto-mobile",
-  "version": "0.0.11",
+  "version": "0.0.12",
   "description": "Mobile device interaction automation via MCP",
   "scripts": {
     "test": "bun test",

--- a/src/constants/release.ts
+++ b/src/constants/release.ts
@@ -19,7 +19,7 @@ export const RELEASE_VERSION: string = "latest";
 export const APK_URL: string = RELEASE_VERSION === "latest"
   ? `https://github.com/kaeawc/auto-mobile/releases/latest/download/accessibility-service-debug.apk`
   : `https://github.com/kaeawc/auto-mobile/releases/download/v${RELEASE_VERSION}/accessibility-service-debug.apk`;
-export const APK_SHA256_CHECKSUM: string = "b7be60f2c4c26c5e7e5b04064fb139707d792badf91170a1874be72b59195ca1"; // Empty = skip verification (local dev only)
+export const APK_SHA256_CHECKSUM: string = "3d72af65e505485fbfd2ecbe91153e93aac6bd85ac18d3810d515fddf01750c3"; // Empty = skip verification (local dev only)
 
 /**
  * iOS XCTestService Release Constants
@@ -31,5 +31,5 @@ export const XCTESTSERVICE_RELEASE_VERSION: string = "latest";
 export const XCTESTSERVICE_IPA_URL: string = XCTESTSERVICE_RELEASE_VERSION === "latest"
   ? "https://github.com/kaeawc/auto-mobile/releases/latest/download/XCTestService.ipa"
   : `https://github.com/kaeawc/auto-mobile/releases/download/v${XCTESTSERVICE_RELEASE_VERSION}/XCTestService.ipa`;
-export const XCTESTSERVICE_SHA256_CHECKSUM: string = "9ea691cd3ceaa82a7de4ac7ce5455457352437fb995c0da00b300804bcde0188"; // Empty = skip verification (local dev only)
+export const XCTESTSERVICE_SHA256_CHECKSUM: string = "fc30bd33e38e5fd8e9eb99d71432fdb0683b224bb118967158c40dd69bfc8058"; // Empty = skip verification (local dev only)
 export const XCTESTSERVICE_APP_HASH: string = ""; // Hash of XCTestServiceApp.app (device build), empty = skip verification


### PR DESCRIPTION
## Summary
- Bump versions to v0.0.12
- Update CHANGELOG.md from closed issues since the last tag
- Refresh Accessibility Service APK SHA256 checksum
- Refresh XCTestService IPA SHA256 checksum

## Automation
- Generated by `prepare-release` workflow