### PR TITLE
chore: add maven-publish-plugin v0.34+ properties

### DIFF
--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -136,7 +136,7 @@ ksp.useKSP2=false
 # Maven Central Publishing
 
 # Library versions (single source of truth)
-VERSION_NAME=0.0.12-SNAPSHOT
+VERSION_NAME=0.0.13-SNAPSHOT
 GROUP=dev.jasonpearson.auto-mobile
 
 # POM metadata
@@ -156,3 +156,7 @@ SONATYPE_STAGING_PROFILE=dev.jasonpearson
 
 # Enable GPG signing for releases
 RELEASE_SIGNING_ENABLED=true
+
+# Vanniktech maven-publish-plugin v0.34+ properties
+mavenCentralPublishing=true
+mavenCentralAutomaticPublishing=true


### PR DESCRIPTION
## Summary
- Add `mavenCentralPublishing` and `mavenCentralAutomaticPublishing` properties required by Vanniktech maven-publish-plugin v0.34+
- Bump `VERSION_NAME` from `0.0.12-SNAPSHOT` to `0.0.13-SNAPSHOT` for next development cycle

## Test Plan
- [ ] CI passes
- [ ] Maven Central publishing still works correctly with new properties

🤖 Generated with [Claude Code](https://claude.com/claude-code)