### PR TITLE
feat: add clean environment uninstall script

### DIFF
--- a/scripts/clean-env-uninstall.sh
+++ b/scripts/clean-env-uninstall.sh
@@ -203,7 +203,7 @@ remove_bun() {
     if command_exists brew && brew list oven-sh/bun/bun >/dev/null 2>&1; then
         found+=("Homebrew: oven-sh/bun/bun")
     fi
-    if command_exists npm && npm list -g @anthropic-ai/bun 2>/dev/null | grep -q bun; then
+    if command_exists npm && npm list -g bun >/dev/null 2>&1; then
         found+=("npm global bun package")
     fi
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -2566,6 +2566,73 @@ start_mcp_daemon() {
     log_info "MCP daemon is running and healthy."
 }
 
+# Install runtime dependencies needed for AutoMobile features.
+# These are not development/CI tools — they are required for end-user functionality:
+#   ffmpeg  - video recording and encoding (demoMode, videoRecording tools)
+#   vips    - native image processing via sharp (observe screenshots, image comparison)
+install_runtime_deps() {
+    local os
+    os=$(detect_os)
+
+    # ffmpeg — required for video recording features
+    if ! command_exists ffmpeg; then
+        if [[ "${os}" == "macos" ]] && command_exists brew; then
+            if [[ "${NON_INTERACTIVE}" == "true" ]]; then
+                log_info "Installing ffmpeg (required for video recording)..."
+                if run_spinner "Installing ffmpeg" brew install ffmpeg; then
+                    CHANGES_MADE=true
+                else
+                    log_warn "ffmpeg install failed — video recording will be unavailable"
+                fi
+            elif gum confirm "Install ffmpeg? (required for video recording)"; then
+                if run_spinner "Installing ffmpeg" brew install ffmpeg; then
+                    CHANGES_MADE=true
+                else
+                    log_warn "ffmpeg install failed — video recording will be unavailable"
+                fi
+            else
+                log_info "Skipped ffmpeg — install later with: brew install ffmpeg"
+            fi
+        else
+            log_warn "ffmpeg not found — video recording will be unavailable"
+            if [[ "${os}" == "macos" ]]; then
+                log_info "Install with: brew install ffmpeg"
+            else
+                log_info "Install with: apt-get install ffmpeg (or your package manager)"
+            fi
+        fi
+    fi
+
+    # vips — required by sharp for screenshot processing
+    if ! command_exists vips; then
+        if [[ "${os}" == "macos" ]] && command_exists brew; then
+            if [[ "${NON_INTERACTIVE}" == "true" ]]; then
+                log_info "Installing vips (required for image processing)..."
+                if run_spinner "Installing vips" brew install vips; then
+                    CHANGES_MADE=true
+                else
+                    log_warn "vips install failed — image processing may fall back to slower paths"
+                fi
+            elif gum confirm "Install vips? (required for image processing)"; then
+                if run_spinner "Installing vips" brew install vips; then
+                    CHANGES_MADE=true
+                else
+                    log_warn "vips install failed — image processing may fall back to slower paths"
+                fi
+            else
+                log_info "Skipped vips — install later with: brew install vips"
+            fi
+        else
+            log_warn "vips not found — image processing may fall back to slower paths"
+            if [[ "${os}" == "macos" ]]; then
+                log_info "Install with: brew install vips"
+            else
+                log_info "Install with: apt-get install libvips42 libvips-dev (or your package manager)"
+            fi
+        fi
+    fi
+}
+
 handle_bun_setup() {
     # Enforce version requirement even if bun is already installed
     if [[ "${BUN_INSTALLED}" == "true" ]] && [[ -n "${REQUIRED_BUN_VERSION}" ]]; then
@@ -3386,6 +3453,10 @@ main() {
         fi
     fi
 
+    # Check runtime dependencies
+    spin_check "Checking ffmpeg" "command -v ffmpeg >/dev/null 2>&1" || true
+    spin_check "Checking vips" "command -v vips >/dev/null 2>&1" || true
+
     # Check Android SDK
     local adb_check="command -v adb >/dev/null 2>&1 || [[ -x \"${ANDROID_HOME:-}/platform-tools/adb\" ]] || [[ -x \"${ANDROID_SDK_ROOT:-}/platform-tools/adb\" ]] || [[ -x \"${HOME}/Library/Android/sdk/platform-tools/adb\" ]] || [[ -x \"${HOME}/Android/Sdk/platform-tools/adb\" ]]"
     if spin_check "Checking Android SDK (adb)" "${adb_check}"; then
@@ -3638,6 +3709,9 @@ main() {
             log_warn "npm install failed"
         fi
     fi
+
+    # Runtime dependencies (needed for AutoMobile features)
+    install_runtime_deps
 
     # Platform-specific setup
     case "${platform_choice}" in

--- a/scripts/local-dev/lib/deps.sh
+++ b/scripts/local-dev/lib/deps.sh
@@ -13,6 +13,7 @@
 #   version_gte()              - Semver comparison (returns 0 if $1 >= $2)
 #   ensure_gum()               - Check gum availability (installed by install.sh)
 #   ensure_auto_mobile()       - Build and npm link auto-mobile CLI
+#   ensure_dev_tools()         - Install brew packages, Java, manual tools if missing
 #   ensure_dependencies()      - Run all dependency checks via install.sh
 
 # Required versions (populated by parse_required_versions)
@@ -142,6 +143,106 @@ ensure_auto_mobile() {
   return 1
 }
 
+# Install a Homebrew package if the command is not already available.
+# Usage: brew_install_if_missing <command_name> [<brew_package_name>]
+# If brew_package_name is omitted, command_name is used.
+brew_install_if_missing() {
+  local cmd="$1"
+  local pkg="${2:-$1}"
+
+  if command -v "${cmd}" >/dev/null 2>&1; then
+    return 0
+  fi
+
+  if ! command -v brew >/dev/null 2>&1; then
+    log_warn "${cmd} not found and Homebrew not available — skipping"
+    return 1
+  fi
+
+  log_info "Installing ${pkg} via Homebrew..."
+  if brew install "${pkg}"; then
+    log_info "${pkg} installed"
+  else
+    log_warn "Failed to install ${pkg}"
+    return 1
+  fi
+}
+
+# Install a Homebrew cask if the command/directory is not detected.
+brew_cask_install_if_missing() {
+  local check_cmd="$1"
+  local cask="$2"
+
+  if command -v "${check_cmd}" >/dev/null 2>&1; then
+    return 0
+  fi
+
+  if ! command -v brew >/dev/null 2>&1; then
+    log_warn "${check_cmd} not found and Homebrew not available — skipping"
+    return 1
+  fi
+
+  log_info "Installing ${cask} via Homebrew cask..."
+  if brew install --cask "${cask}"; then
+    log_info "${cask} installed"
+  else
+    log_warn "Failed to install ${cask}"
+    return 1
+  fi
+}
+
+# Ensure all development tools that clean-env-uninstall.sh removes are present.
+# Installs missing tools via Homebrew, project install scripts, or gem.
+ensure_dev_tools() {
+  log_info "Checking development tools..."
+
+  local missing=0
+
+  # --- Homebrew packages ---------------------------------------------------
+  brew_install_if_missing rg        ripgrep     || ((missing++)) || true
+  brew_install_if_missing shellcheck shellcheck  || ((missing++)) || true
+  brew_install_if_missing jq        jq          || ((missing++)) || true
+  brew_install_if_missing ffmpeg    ffmpeg       || ((missing++)) || true
+  brew_install_if_missing xmlstarlet xmlstarlet  || ((missing++)) || true
+  brew_install_if_missing swiftformat swiftformat || ((missing++)) || true
+  brew_install_if_missing swiftlint swiftlint    || ((missing++)) || true
+  brew_install_if_missing xcodegen  xcodegen     || ((missing++)) || true
+  brew_install_if_missing yq        yq           || ((missing++)) || true
+  brew_install_if_missing gum       gum          || ((missing++)) || true
+  brew_install_if_missing hadolint  hadolint     || ((missing++)) || true
+  brew_install_if_missing vips      vips         || ((missing++)) || true
+
+  # --- Java 21 (needed for Gradle / Android builds) -----------------------
+  if ! java -version 2>&1 | grep -q 'version "21'; then
+    log_info "Java 21 not detected"
+    brew_cask_install_if_missing java zulu-jdk21 || ((missing++)) || true
+  fi
+
+  # --- Manual tool installs (use project install scripts) ------------------
+  if ! command -v lychee >/dev/null 2>&1; then
+    log_info "Installing lychee..."
+    bash "${PROJECT_ROOT}/scripts/lychee/install_lychee.sh" || ((missing++)) || true
+  fi
+
+  if ! command -v ktfmt >/dev/null 2>&1; then
+    log_info "Installing ktfmt..."
+    bash "${PROJECT_ROOT}/scripts/ktfmt/install_ktfmt.sh" || ((missing++)) || true
+  fi
+
+  if ! command -v xcpretty >/dev/null 2>&1; then
+    log_info "Installing xcpretty..."
+    gem install xcpretty 2>/dev/null || ((missing++)) || true
+  fi
+
+  if [[ "${missing}" -gt 0 ]]; then
+    log_warn "${missing} tool(s) could not be installed — some features may be unavailable"
+  else
+    log_info "All development tools present."
+  fi
+
+  return 0
+}
+
 # Run all dependency checks via install.sh
 ensure_dependencies() {
   log_info "Checking dependencies..."
@@ -197,6 +298,9 @@ ensure_dependencies() {
     log_error "Bun not found after install"
     return 1
   fi
+
+  # Install development tools (brew packages, Java, manual installs)
+  ensure_dev_tools
 
   # Build and npm link auto-mobile (local-dev specific)
   if ! ensure_auto_mobile; then


### PR DESCRIPTION
## Summary
- Adds `scripts/clean-env-uninstall.sh` to remove all AutoMobile environment dependencies (Bun, Node/nvm, Homebrew packages, Java 21, manual tool installs) so the install script can be verified from a clean slate
- Supports `--dry-run`, `--all`, and `--force` flags with interactive per-category confirmation by default
- Delegates AutoMobile component removal to the existing `scripts/uninstall.sh`

## Test Plan
- [x] `shellcheck` passes clean
- [x] `--dry-run` correctly previews all removals without making changes
- [x] `--help` displays usage information

🤖 Generated with [Claude Code](https://claude.com/claude-code)