### PR TITLE
feat: publish to official MCP registry

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -134,6 +134,15 @@ jobs:
       - name: Publish to npm
         run: npm publish --provenance --access public
 
+      - name: Install mcp-publisher
+        run: |
+          curl -L "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_linux_amd64.tar.gz" | tar xz mcp-publisher
+
+      - name: Publish to MCP Registry
+        run: |
+          ./mcp-publisher login dns --domain jasonpearson.dev --private-key "${{ secrets.MCP_DNS_PRIVATE_KEY }}"
+          ./mcp-publisher publish
+
       - name: Set up Java
         uses: actions/setup-java@v4
         with:
@@ -247,6 +256,7 @@ jobs:
           echo "- **GitHub Release:** https://github.com/${{ github.repository }}/releases/tag/${{ steps.version.outputs.tag }}" >> $GITHUB_STEP_SUMMARY
           echo "- **Maven Central:** [auto-mobile-junit-runner](https://central.sonatype.com/artifact/dev.jasonpearson.auto-mobile/auto-mobile-junit-runner)" >> $GITHUB_STEP_SUMMARY
           echo "- **Maven Central:** [auto-mobile-sdk](https://central.sonatype.com/artifact/dev.jasonpearson.auto-mobile/auto-mobile-sdk)" >> $GITHUB_STEP_SUMMARY
+          echo "- **MCP Registry:** [dev.jasonpearson/auto-mobile](https://registry.modelcontextprotocol.io/)" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "### Docker Images" >> $GITHUB_STEP_SUMMARY
           echo "\`\`\`" >> $GITHUB_STEP_SUMMARY

--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,7 @@ docs/contributing.md
 .mcp.json
 .mcp.local.json
 *.pid
+*.pem
 # IntelliJ Platform Gradle plugin artifacts
 android/ide-plugin/.intellijPlatform/
 .lycheecache

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "type": "git",
     "url": "https://github.com/kaeawc/auto-mobile.git"
   },
+  "mcpName": "dev.jasonpearson/auto-mobile",
   "publishConfig": {
     "access": "public"
   },

--- a/scripts/release/publish-mcp-registry.sh
+++ b/scripts/release/publish-mcp-registry.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+#
+# Publish AutoMobile to the MCP Registry using DNS verification.
+#
+# Prerequisites:
+#   - brew install modelcontextprotocol/tap/mcp-publisher
+#   - mcp-key.pem in repo root (Ed25519 private key)
+#   - TXT record on auto-mobile.jasonpearson.dev with matching public key
+#
+# Usage:
+#   ./scripts/release/publish-mcp-registry.sh
+#
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+KEY_FILE="$REPO_ROOT/mcp-key.pem"
+DOMAIN="jasonpearson.dev"
+
+if ! command -v mcp-publisher >/dev/null 2>&1; then
+  echo "Error: mcp-publisher not found. Install with:" >&2
+  echo "  brew install modelcontextprotocol/tap/mcp-publisher" >&2
+  exit 1
+fi
+
+if [[ ! -f "$KEY_FILE" ]]; then
+  echo "Error: $KEY_FILE not found." >&2
+  echo "Generate with: openssl genpkey -algorithm Ed25519 -out mcp-key.pem" >&2
+  exit 1
+fi
+
+if [[ ! -f "$REPO_ROOT/server.json" ]]; then
+  echo "Error: server.json not found in repo root." >&2
+  exit 1
+fi
+
+echo "Building and publishing npm package..."
+cd "$REPO_ROOT"
+bun run build
+npm publish --access public
+
+PRIVATE_KEY="$(openssl pkey -in "$KEY_FILE" -noout -text | grep -A3 "priv:" | tail -n +2 | tr -d ' :\n')"
+
+echo "Authenticating with MCP Registry via DNS ($DOMAIN)..."
+mcp-publisher login dns --domain "$DOMAIN" --private-key "$PRIVATE_KEY"
+
+echo "Publishing server.json to MCP Registry..."
+cd "$REPO_ROOT"
+mcp-publisher publish
+
+echo "Done! Verify at:"
+echo "  curl 'https://registry.modelcontextprotocol.io/v0.1/servers?search=dev.jasonpearson/auto-mobile'"

--- a/scripts/versioning/bump-versions.sh
+++ b/scripts/versioning/bump-versions.sh
@@ -91,6 +91,37 @@ PY
 update_json_version "package.json" "$new_version" "$dry_run"
 update_json_version ".claude-plugin/plugin.json" "$new_version" "$dry_run"
 
+# Update server.json top-level version and packages[0].version for MCP registry
+update_server_json_version() {
+  local path="$1"
+  local version="$2"
+  local dry="$3"
+  if [[ "$dry" == true ]]; then
+    return 0
+  fi
+  python3 - "$path" "$version" <<'PY'
+import json
+import sys
+
+path = sys.argv[1]
+version = sys.argv[2]
+
+with open(path, "r", encoding="utf-8") as handle:
+    data = json.load(handle)
+
+data["version"] = version
+
+if "packages" in data:
+    for pkg in data["packages"]:
+        pkg["version"] = version
+
+with open(path, "w", encoding="utf-8") as handle:
+    json.dump(data, handle, indent=2)
+    handle.write("\n")
+PY
+}
+update_server_json_version "server.json" "$new_version" "$dry_run"
+
 # Update VERSION_NAME in android/gradle.properties (single source of truth for Android libraries)
 update_gradle_properties_version() {
   local path="$1"

--- a/server.json
+++ b/server.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "dev.jasonpearson/auto-mobile",
+  "title": "AutoMobile",
+  "description": "Mobile device interaction automation via MCP",
+  "version": "0.0.12",
+  "websiteUrl": "https://kaeawc.github.io/auto-mobile/",
+  "repository": {
+    "url": "https://github.com/kaeawc/auto-mobile",
+    "source": "github"
+  },
+  "packages": [
+    {
+      "registryType": "npm",
+      "identifier": "@kaeawc/auto-mobile",
+      "version": "0.0.12",
+      "runtimeHint": "npx",
+      "transport": {
+        "type": "stdio"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Add `server.json` metadata file and `mcpName` in `package.json` for MCP registry ownership verification
- Add MCP registry publish step to release workflow using DNS verification with `jasonpearson.dev`
- Add local publish script (`scripts/release/publish-mcp-registry.sh`) for manual publishing
- Add `server.json` version sync to `bump-versions.sh`
- Add `*.pem` to `.gitignore`

## Test Plan
- [x] `bun run build` passes
- [x] `bun test --bail` passes (2109 tests)
- [x] `bump-versions.sh --dry-run` works correctly
- [x] YAML validation passes on release.yml
- [ ] DNS TXT record configured on `jasonpearson.dev`
- [ ] `MCP_DNS_PRIVATE_KEY` GitHub Actions secret added
- [ ] First publish verified after next release

Closes #26

🤖 Generated with [Claude Code](https://claude.com/claude-code)