### PR TITLE
fix: normalize idle device FPS in performance stream

### DIFF
--- a/android/ide-plugin/src/main/kotlin/dev/jasonpearson/automobile/ide/daemon/ObservationStreamClient.kt
+++ b/android/ide-plugin/src/main/kotlin/dev/jasonpearson/automobile/ide/daemon/ObservationStreamClient.kt
@@ -292,11 +292,17 @@ class ObservationStreamClient {
                 val perfData = response.performanceData
                 log.info("Performance update received - deviceId=${response.deviceId}, fps=${perfData?.fps}, jankFrames=${perfData?.jankFrames}, touchLatencyMs=${perfData?.touchLatencyMs}, ttiMs=${perfData?.timeToInteractiveMs}")
                 if (perfData != null) {
+                    // When jank is 0 and FPS is below 60, the device is idle (no frames
+                    // being rendered). The reported FPS gets stuck at a stale value.
+                    // Assume 60 FPS / 16.67ms frame time since nothing is janking.
+                    val isIdle = perfData.jankFrames == 0 && perfData.fps < 60f
+                    val fps = if (isIdle) 60f else perfData.fps
+                    val frameTimeMs = if (isIdle) 16.67f else perfData.frameTimeMs
                     val update = PerformanceStreamUpdate(
                         deviceId = response.deviceId,
                         timestamp = response.timestamp ?: System.currentTimeMillis(),
-                        fps = perfData.fps,
-                        frameTimeMs = perfData.frameTimeMs,
+                        fps = fps,
+                        frameTimeMs = frameTimeMs,
                         jankFrames = perfData.jankFrames,
                         droppedFrames = perfData.droppedFrames,
                         memoryUsageMb = perfData.memoryUsageMb,


### PR DESCRIPTION
## Summary
- When no frames are being rendered and jank is 0, the reported FPS can get stuck at a stale intermediate value (e.g. 20 or 40-something FPS)
- Detects idle state (jank == 0 && fps < 60) in `ObservationStreamClient` and normalizes to 60 FPS / 16.67ms frame time
- Fix is applied at the stream source so both the collapsed summary and expanded dashboard views benefit

## Test Plan
- [x] IDE plugin builds successfully
- [ ] Observe performance panel with device idle — FPS should show 60 instead of stale value
- [ ] Verify FPS still reflects real values when jank > 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)