### PR TITLE
test: increase TypeScript code coverage

### DIFF
--- a/src/db/deviceSnapshotRepository.ts
+++ b/src/db/deviceSnapshotRepository.ts
@@ -1,6 +1,8 @@
+import type { Kysely } from "kysely";
 import { ensureMigrations, getDatabase } from "./database";
 import type { DeviceSnapshotManifest, DeviceSnapshotMetadata, DeviceSnapshotType } from "../models";
 import type {
+  Database,
   DeviceSnapshot as DbDeviceSnapshot,
   NewDeviceSnapshot,
   DeviceSnapshotUpdate,
@@ -91,9 +93,22 @@ function buildUpdatePayload(update: Partial<DeviceSnapshotRecord>): DeviceSnapsh
 }
 
 export class DeviceSnapshotRepository {
-  async insertSnapshot(record: DeviceSnapshotRecord): Promise<void> {
+  private db: Kysely<Database> | null;
+
+  constructor(db?: Kysely<Database>) {
+    this.db = db ?? null;
+  }
+
+  private async getDb(): Promise<Kysely<Database>> {
+    if (this.db) {
+      return this.db;
+    }
     await ensureMigrations();
-    const db = getDatabase();
+    return getDatabase();
+  }
+
+  async insertSnapshot(record: DeviceSnapshotRecord): Promise<void> {
+    const db = await this.getDb();
     const row: NewDeviceSnapshot = {
       snapshot_name: record.snapshotName,
       device_id: record.deviceId,
@@ -115,8 +130,7 @@ export class DeviceSnapshotRepository {
     snapshotName: string,
     update: Partial<DeviceSnapshotRecord>
   ): Promise<void> {
-    await ensureMigrations();
-    const db = getDatabase();
+    const db = await this.getDb();
     const payload = buildUpdatePayload(update);
     if (Object.keys(payload).length === 0) {
       return;
@@ -130,8 +144,7 @@ export class DeviceSnapshotRepository {
   }
 
   async getSnapshot(snapshotName: string): Promise<DeviceSnapshotRecord | null> {
-    await ensureMigrations();
-    const db = getDatabase();
+    const db = await this.getDb();
     const row = await db
       .selectFrom("device_snapshots")
       .selectAll()
@@ -142,8 +155,7 @@ export class DeviceSnapshotRepository {
   }
 
   async listSnapshots(query: DeviceSnapshotQuery = {}): Promise<DeviceSnapshotRecord[]> {
-    await ensureMigrations();
-    const db = getDatabase();
+    const db = await this.getDb();
     let builder = db
       .selectFrom("device_snapshots")
       .selectAll();
@@ -178,8 +190,7 @@ export class DeviceSnapshotRepository {
   }
 
   async deleteSnapshot(snapshotName: string): Promise<boolean> {
-    await ensureMigrations();
-    const db = getDatabase();
+    const db = await this.getDb();
     const result = await db
       .deleteFrom("device_snapshots")
       .where("snapshot_name", "=", snapshotName)

--- a/src/db/videoRecordingRepository.ts
+++ b/src/db/videoRecordingRepository.ts
@@ -1,3 +1,4 @@
+import type { Kysely } from "kysely";
 import { ensureMigrations, getDatabase } from "./database";
 import type {
   VideoFormat,
@@ -6,7 +7,7 @@ import type {
   VideoRecordingMetadata,
 } from "../models";
 import { parseVideoRecordingConfig } from "../features/video";
-import type { NewVideoRecording, VideoRecordingUpdate, VideoRecording as DbVideoRecording } from "./types";
+import type { Database, NewVideoRecording, VideoRecordingUpdate, VideoRecording as DbVideoRecording } from "./types";
 import { logger } from "../utils/logger";
 
 export type VideoRecordingStatus = "recording" | "completed" | "interrupted";
@@ -128,9 +129,22 @@ function buildUpdatePayload(update: Partial<VideoRecordingRecord>): VideoRecordi
 }
 
 export class VideoRecordingRepository {
-  async insertRecording(record: VideoRecordingRecord): Promise<void> {
+  private db: Kysely<Database> | null;
+
+  constructor(db?: Kysely<Database>) {
+    this.db = db ?? null;
+  }
+
+  private async getDb(): Promise<Kysely<Database>> {
+    if (this.db) {
+      return this.db;
+    }
     await ensureMigrations();
-    const db = getDatabase();
+    return getDatabase();
+  }
+
+  async insertRecording(record: VideoRecordingRecord): Promise<void> {
+    const db = await this.getDb();
     const row: NewVideoRecording = {
       recording_id: record.recordingId,
       device_id: record.deviceId,
@@ -158,8 +172,7 @@ export class VideoRecordingRepository {
     recordingId: string,
     update: Partial<VideoRecordingRecord>
   ): Promise<void> {
-    await ensureMigrations();
-    const db = getDatabase();
+    const db = await this.getDb();
     const payload = buildUpdatePayload(update);
     if (Object.keys(payload).length === 0) {
       return;
@@ -172,8 +185,7 @@ export class VideoRecordingRepository {
   }
 
   async getRecording(recordingId: string): Promise<VideoRecordingRecord | null> {
-    await ensureMigrations();
-    const db = getDatabase();
+    const db = await this.getDb();
     const row = await db
       .selectFrom("video_recordings")
       .selectAll()
@@ -184,8 +196,7 @@ export class VideoRecordingRepository {
   }
 
   async listRecordings(query: VideoRecordingQuery = {}): Promise<VideoRecordingRecord[]> {
-    await ensureMigrations();
-    const db = getDatabase();
+    const db = await this.getDb();
     let builder = db
       .selectFrom("video_recordings")
       .selectAll();
@@ -225,8 +236,7 @@ export class VideoRecordingRepository {
   }
 
   async deleteRecording(recordingId: string): Promise<boolean> {
-    await ensureMigrations();
-    const db = getDatabase();
+    const db = await this.getDb();
     const result = await db
       .deleteFrom("video_recordings")
       .where("recording_id", "=", recordingId)

--- a/test/db/deviceSnapshotRepository.test.ts
+++ b/test/db/deviceSnapshotRepository.test.ts
@@ -1,0 +1,211 @@
+import { beforeEach, afterEach, describe, expect, test } from "bun:test";
+import type { Kysely } from "kysely";
+import type { Database } from "../../src/db/types";
+import { DeviceSnapshotRepository } from "../../src/db/deviceSnapshotRepository";
+import type { DeviceSnapshotRecord } from "../../src/db/deviceSnapshotRepository";
+import { createTestDatabase } from "./testDbHelper";
+import type { DeviceSnapshotManifest } from "../../src/models";
+
+function makeManifest(overrides: Partial<DeviceSnapshotManifest> = {}): DeviceSnapshotManifest {
+  return {
+    snapshotName: "snap-1",
+    timestamp: "2024-01-01T00:00:00.000Z",
+    deviceId: "emulator-5554",
+    deviceName: "Pixel_6",
+    platform: "android",
+    snapshotType: "vm",
+    includeAppData: false,
+    includeSettings: false,
+    ...overrides,
+  };
+}
+
+function makeRecord(overrides: Partial<DeviceSnapshotRecord> = {}): DeviceSnapshotRecord {
+  const snapshotName = overrides.snapshotName ?? "snap-1";
+  return {
+    snapshotName,
+    deviceId: "emulator-5554",
+    deviceName: "Pixel_6",
+    platform: "android",
+    snapshotType: "vm",
+    includeAppData: false,
+    includeSettings: false,
+    createdAt: "2024-01-01T00:00:00.000Z",
+    lastAccessedAt: "2024-01-01T00:00:00.000Z",
+    sizeBytes: 1024,
+    manifest: makeManifest({ snapshotName }),
+    ...overrides,
+  };
+}
+
+describe("DeviceSnapshotRepository", () => {
+  let db: Kysely<Database>;
+  let repo: DeviceSnapshotRepository;
+
+  beforeEach(async () => {
+    db = await createTestDatabase();
+    repo = new DeviceSnapshotRepository(db);
+  });
+
+  afterEach(async () => {
+    await db.destroy();
+  });
+
+  test("insertSnapshot and getSnapshot round-trip", async () => {
+    const record = makeRecord();
+    await repo.insertSnapshot(record);
+
+    const result = await repo.getSnapshot("snap-1");
+    expect(result).not.toBeNull();
+    expect(result!.snapshotName).toBe("snap-1");
+    expect(result!.deviceId).toBe("emulator-5554");
+    expect(result!.deviceName).toBe("Pixel_6");
+    expect(result!.platform).toBe("android");
+    expect(result!.snapshotType).toBe("vm");
+    expect(result!.includeAppData).toBe(false);
+    expect(result!.includeSettings).toBe(false);
+    expect(result!.sizeBytes).toBe(1024);
+    expect(result!.manifest.snapshotName).toBe("snap-1");
+  });
+
+  test("getSnapshot returns null for unknown snapshot", async () => {
+    const result = await repo.getSnapshot("nonexistent");
+    expect(result).toBeNull();
+  });
+
+  test("listSnapshots returns all snapshots", async () => {
+    await repo.insertSnapshot(makeRecord({ snapshotName: "snap-1" }));
+    await repo.insertSnapshot(makeRecord({ snapshotName: "snap-2" }));
+
+    const results = await repo.listSnapshots();
+    expect(results).toHaveLength(2);
+  });
+
+  test("listSnapshots filters by deviceId", async () => {
+    await repo.insertSnapshot(makeRecord({ snapshotName: "snap-1", deviceId: "device-A" }));
+    await repo.insertSnapshot(makeRecord({ snapshotName: "snap-2", deviceId: "device-B" }));
+
+    const results = await repo.listSnapshots({ deviceId: "device-A" });
+    expect(results).toHaveLength(1);
+    expect(results[0].deviceId).toBe("device-A");
+  });
+
+  test("listSnapshots filters by platform", async () => {
+    await repo.insertSnapshot(makeRecord({ snapshotName: "snap-1", platform: "android" }));
+    await repo.insertSnapshot(makeRecord({ snapshotName: "snap-2", platform: "ios" }));
+
+    const results = await repo.listSnapshots({ platform: "ios" });
+    expect(results).toHaveLength(1);
+    expect(results[0].platform).toBe("ios");
+  });
+
+  test("listSnapshots filters by snapshotType", async () => {
+    await repo.insertSnapshot(makeRecord({ snapshotName: "snap-1", snapshotType: "vm" }));
+    await repo.insertSnapshot(makeRecord({ snapshotName: "snap-2", snapshotType: "adb" }));
+
+    const results = await repo.listSnapshots({ snapshotType: "adb" });
+    expect(results).toHaveLength(1);
+    expect(results[0].snapshotType).toBe("adb");
+  });
+
+  test("listSnapshots orders by lastAccessedAt", async () => {
+    await repo.insertSnapshot(
+      makeRecord({ snapshotName: "snap-old", lastAccessedAt: "2024-01-01T00:00:00.000Z" })
+    );
+    await repo.insertSnapshot(
+      makeRecord({ snapshotName: "snap-new", lastAccessedAt: "2024-06-01T00:00:00.000Z" })
+    );
+
+    const descResults = await repo.listSnapshots({ orderByLastAccessed: "desc" });
+    expect(descResults[0].snapshotName).toBe("snap-new");
+
+    const ascResults = await repo.listSnapshots({ orderByLastAccessed: "asc" });
+    expect(ascResults[0].snapshotName).toBe("snap-old");
+  });
+
+  test("listSnapshots orders by createdAt", async () => {
+    await repo.insertSnapshot(
+      makeRecord({ snapshotName: "snap-old", createdAt: "2024-01-01T00:00:00.000Z" })
+    );
+    await repo.insertSnapshot(
+      makeRecord({ snapshotName: "snap-new", createdAt: "2024-06-01T00:00:00.000Z" })
+    );
+
+    const descResults = await repo.listSnapshots({ orderByCreatedAt: "desc" });
+    expect(descResults[0].snapshotName).toBe("snap-new");
+  });
+
+  test("listSnapshots respects limit", async () => {
+    await repo.insertSnapshot(makeRecord({ snapshotName: "snap-1" }));
+    await repo.insertSnapshot(makeRecord({ snapshotName: "snap-2" }));
+    await repo.insertSnapshot(makeRecord({ snapshotName: "snap-3" }));
+
+    const results = await repo.listSnapshots({ limit: 2 });
+    expect(results).toHaveLength(2);
+  });
+
+  test("updateSnapshot modifies fields", async () => {
+    await repo.insertSnapshot(makeRecord());
+
+    await repo.updateSnapshot("snap-1", {
+      deviceName: "Pixel_7",
+      sizeBytes: 2048,
+    });
+
+    const result = await repo.getSnapshot("snap-1");
+    expect(result!.deviceName).toBe("Pixel_7");
+    expect(result!.sizeBytes).toBe(2048);
+  });
+
+  test("updateSnapshot with empty update is a no-op", async () => {
+    await repo.insertSnapshot(makeRecord());
+    await repo.updateSnapshot("snap-1", {});
+
+    const result = await repo.getSnapshot("snap-1");
+    expect(result!.snapshotName).toBe("snap-1");
+  });
+
+  test("touchSnapshot updates lastAccessedAt", async () => {
+    await repo.insertSnapshot(makeRecord());
+
+    await repo.touchSnapshot("snap-1", "2025-01-01T00:00:00.000Z");
+
+    const result = await repo.getSnapshot("snap-1");
+    expect(result!.lastAccessedAt).toBe("2025-01-01T00:00:00.000Z");
+  });
+
+  test("deleteSnapshot removes the snapshot and returns true", async () => {
+    await repo.insertSnapshot(makeRecord());
+
+    const deleted = await repo.deleteSnapshot("snap-1");
+    expect(deleted).toBe(true);
+
+    const result = await repo.getSnapshot("snap-1");
+    expect(result).toBeNull();
+  });
+
+  test("deleteSnapshot returns false for nonexistent snapshot", async () => {
+    const deleted = await repo.deleteSnapshot("nonexistent");
+    expect(deleted).toBe(false);
+  });
+
+  test("updateSnapshot can update manifest", async () => {
+    await repo.insertSnapshot(makeRecord());
+
+    const updatedManifest = makeManifest({ osVersion: "14" });
+    await repo.updateSnapshot("snap-1", { manifest: updatedManifest });
+
+    const result = await repo.getSnapshot("snap-1");
+    expect(result!.manifest.osVersion).toBe("14");
+  });
+
+  test("updateSnapshot can update boolean fields", async () => {
+    await repo.insertSnapshot(makeRecord({ includeAppData: false, includeSettings: false }));
+
+    await repo.updateSnapshot("snap-1", { includeAppData: true, includeSettings: true });
+
+    const result = await repo.getSnapshot("snap-1");
+    expect(result!.includeAppData).toBe(true);
+    expect(result!.includeSettings).toBe(true);
+  });
+});

--- a/test/db/installedAppsRepository.test.ts
+++ b/test/db/installedAppsRepository.test.ts
@@ -1,0 +1,208 @@
+import { beforeEach, afterEach, describe, expect, test } from "bun:test";
+import type { Kysely } from "kysely";
+import type { Database } from "../../src/db/types";
+import { InstalledAppsRepository } from "../../src/db/installedAppsRepository";
+import { createTestDatabase } from "./testDbHelper";
+
+describe("InstalledAppsRepository", () => {
+  let db: Kysely<Database>;
+  let repo: InstalledAppsRepository;
+
+  beforeEach(async () => {
+    db = await createTestDatabase();
+    repo = new InstalledAppsRepository(db);
+  });
+
+  afterEach(async () => {
+    await db.destroy();
+  });
+
+  test("upsertInstalledApp and listInstalledApps", async () => {
+    await repo.upsertInstalledApp("device-1", 0, "com.example.app", false, 1000);
+
+    const apps = await repo.listInstalledApps("device-1");
+    expect(apps).toHaveLength(1);
+    expect(apps[0].device_id).toBe("device-1");
+    expect(apps[0].user_id).toBe(0);
+    expect(apps[0].package_name).toBe("com.example.app");
+    expect(apps[0].is_system).toBe(0);
+    expect(apps[0].installed_at).toBe(1000);
+    expect(apps[0].last_verified_at).toBe(1000);
+  });
+
+  test("upsertInstalledApp updates existing entry on conflict", async () => {
+    await repo.upsertInstalledApp("device-1", 0, "com.example.app", false, 1000);
+    await repo.upsertInstalledApp("device-1", 0, "com.example.app", true, 2000);
+
+    const apps = await repo.listInstalledApps("device-1");
+    expect(apps).toHaveLength(1);
+    expect(apps[0].is_system).toBe(1);
+    expect(apps[0].last_verified_at).toBe(2000);
+    // installed_at should remain unchanged from original insert
+    expect(apps[0].installed_at).toBe(1000);
+  });
+
+  test("listInstalledApps returns empty for unknown device", async () => {
+    const apps = await repo.listInstalledApps("unknown-device");
+    expect(apps).toHaveLength(0);
+  });
+
+  test("replaceInstalledApps replaces all apps for a device", async () => {
+    await repo.upsertInstalledApp("device-1", 0, "com.old.app", false, 1000);
+    await repo.upsertInstalledApp("device-1", 0, "com.another.app", false, 1000);
+
+    await repo.replaceInstalledApps("device-1", [
+      {
+        device_id: "device-1",
+        user_id: 0,
+        package_name: "com.new.app",
+        is_system: 0,
+        installed_at: 2000,
+        last_verified_at: 2000,
+      },
+    ]);
+
+    const apps = await repo.listInstalledApps("device-1");
+    expect(apps).toHaveLength(1);
+    expect(apps[0].package_name).toBe("com.new.app");
+  });
+
+  test("replaceInstalledApps with empty array clears all apps", async () => {
+    await repo.upsertInstalledApp("device-1", 0, "com.example.app", false, 1000);
+
+    await repo.replaceInstalledApps("device-1", []);
+
+    const apps = await repo.listInstalledApps("device-1");
+    expect(apps).toHaveLength(0);
+  });
+
+  test("replaceInstalledApps does not affect other devices", async () => {
+    await repo.upsertInstalledApp("device-1", 0, "com.app1", false, 1000);
+    await repo.upsertInstalledApp("device-2", 0, "com.app2", false, 1000);
+
+    await repo.replaceInstalledApps("device-1", []);
+
+    const device1Apps = await repo.listInstalledApps("device-1");
+    const device2Apps = await repo.listInstalledApps("device-2");
+    expect(device1Apps).toHaveLength(0);
+    expect(device2Apps).toHaveLength(1);
+  });
+
+  test("removeInstalledApp removes specific app", async () => {
+    await repo.upsertInstalledApp("device-1", 0, "com.app1", false, 1000);
+    await repo.upsertInstalledApp("device-1", 0, "com.app2", false, 1000);
+
+    await repo.removeInstalledApp("device-1", 0, "com.app1");
+
+    const apps = await repo.listInstalledApps("device-1");
+    expect(apps).toHaveLength(1);
+    expect(apps[0].package_name).toBe("com.app2");
+  });
+
+  test("removeInstalledAppForDevice removes app across all users", async () => {
+    await repo.upsertInstalledApp("device-1", 0, "com.app1", false, 1000);
+    await repo.upsertInstalledApp("device-1", 10, "com.app1", false, 1000);
+
+    await repo.removeInstalledAppForDevice("device-1", "com.app1");
+
+    const apps = await repo.listInstalledApps("device-1");
+    expect(apps).toHaveLength(0);
+  });
+
+  test("getLatestVerification returns max last_verified_at", async () => {
+    await repo.upsertInstalledApp("device-1", 0, "com.app1", false, 1000);
+    await repo.upsertInstalledApp("device-1", 0, "com.app2", false, 2000);
+
+    const latest = await repo.getLatestVerification("device-1");
+    expect(latest).toBe(2000);
+  });
+
+  test("getLatestVerification returns null for unknown device", async () => {
+    const latest = await repo.getLatestVerification("unknown");
+    expect(latest).toBeNull();
+  });
+
+  test("getLatestVerificationForProfile filters by userId", async () => {
+    await repo.upsertInstalledApp("device-1", 0, "com.app1", false, 1000);
+    await repo.upsertInstalledApp("device-1", 10, "com.app2", false, 3000);
+
+    const latest = await repo.getLatestVerificationForProfile("device-1", 0);
+    expect(latest).toBe(1000);
+  });
+
+  test("markDeviceStale sets last_verified_at to 0 for all apps on device", async () => {
+    await repo.upsertInstalledApp("device-1", 0, "com.app1", false, 1000);
+    await repo.upsertInstalledApp("device-1", 0, "com.app2", false, 2000);
+
+    await repo.markDeviceStale("device-1");
+
+    const apps = await repo.listInstalledApps("device-1");
+    for (const app of apps) {
+      expect(app.last_verified_at).toBe(0);
+    }
+  });
+
+  test("markProfileStale only affects the specified user", async () => {
+    await repo.upsertInstalledApp("device-1", 0, "com.app1", false, 1000);
+    await repo.upsertInstalledApp("device-1", 10, "com.app2", false, 2000);
+
+    await repo.markProfileStale("device-1", 0);
+
+    const apps = await repo.listInstalledApps("device-1");
+    const user0App = apps.find(a => a.user_id === 0);
+    const user10App = apps.find(a => a.user_id === 10);
+    expect(user0App!.last_verified_at).toBe(0);
+    expect(user10App!.last_verified_at).toBe(2000);
+  });
+
+  test("touchDevice updates last_verified_at for all apps on device", async () => {
+    await repo.upsertInstalledApp("device-1", 0, "com.app1", false, 1000);
+    await repo.upsertInstalledApp("device-1", 0, "com.app2", false, 1000);
+
+    await repo.touchDevice("device-1", 5000);
+
+    const apps = await repo.listInstalledApps("device-1");
+    for (const app of apps) {
+      expect(app.last_verified_at).toBe(5000);
+    }
+  });
+
+  test("clearDeviceSession deletes all apps for device", async () => {
+    await repo.upsertInstalledApp("device-1", 0, "com.app1", false, 1000);
+    await repo.upsertInstalledApp("device-1", 0, "com.app2", false, 1000);
+
+    await repo.clearDeviceSession("device-1");
+
+    const apps = await repo.listInstalledApps("device-1");
+    expect(apps).toHaveLength(0);
+  });
+
+  test("clearDeviceSession does not affect other devices", async () => {
+    await repo.upsertInstalledApp("device-1", 0, "com.app1", false, 1000);
+    await repo.upsertInstalledApp("device-2", 0, "com.app2", false, 1000);
+
+    await repo.clearDeviceSession("device-1");
+
+    const device2Apps = await repo.listInstalledApps("device-2");
+    expect(device2Apps).toHaveLength(1);
+  });
+
+  test("setSessionTracking and clearOldDaemonSessions", async () => {
+    await repo.upsertInstalledApp("device-1", 0, "com.app1", false, 1000);
+    await repo.upsertInstalledApp("device-2", 0, "com.app2", false, 1000);
+
+    // Set session tracking for device-1
+    await repo.setSessionTracking("session-A", "device-1", 1000);
+
+    // Set session tracking for device-2 with different session
+    await repo.setSessionTracking("session-B", "device-2", 2000);
+
+    // Clear old sessions, keeping only session-A
+    await repo.clearOldDaemonSessions("session-A");
+
+    const device1Apps = await repo.listInstalledApps("device-1");
+    const device2Apps = await repo.listInstalledApps("device-2");
+    expect(device1Apps).toHaveLength(1);
+    expect(device2Apps).toHaveLength(0);
+  });
+});

--- a/test/db/testDbHelper.ts
+++ b/test/db/testDbHelper.ts
@@ -1,0 +1,15 @@
+import { Database as BunDatabase } from "bun:sqlite";
+import { Kysely } from "kysely";
+import { BunSqliteDialect } from "../../src/db/bunSqliteDialect";
+import type { Database } from "../../src/db/types";
+import { runMigrations } from "../../src/db/migrator";
+
+export async function createTestDatabase(): Promise<Kysely<Database>> {
+  const db = new Kysely<Database>({
+    dialect: new BunSqliteDialect({
+      database: new BunDatabase(":memory:"),
+    }),
+  });
+  await runMigrations(db as Kysely<unknown>);
+  return db;
+}

--- a/test/db/videoRecordingRepository.test.ts
+++ b/test/db/videoRecordingRepository.test.ts
@@ -1,0 +1,270 @@
+import { beforeEach, afterEach, describe, expect, test } from "bun:test";
+import type { Kysely } from "kysely";
+import type { Database } from "../../src/db/types";
+import { VideoRecordingRepository } from "../../src/db/videoRecordingRepository";
+import type { VideoRecordingRecord } from "../../src/db/videoRecordingRepository";
+import { createTestDatabase } from "./testDbHelper";
+import type { VideoRecordingConfig } from "../../src/models";
+
+function makeConfig(overrides: Partial<VideoRecordingConfig> = {}): VideoRecordingConfig {
+  return {
+    qualityPreset: "low",
+    targetBitrateKbps: 1000,
+    maxThroughputMbps: 5,
+    fps: 15,
+    maxArchiveSizeMb: 100,
+    format: "mp4",
+    ...overrides,
+  };
+}
+
+function makeRecord(overrides: Partial<VideoRecordingRecord> = {}): VideoRecordingRecord {
+  return {
+    recordingId: "rec-1",
+    deviceId: "emulator-5554",
+    platform: "android",
+    status: "recording",
+    fileName: "recording.mp4",
+    filePath: "/tmp/recording.mp4",
+    format: "mp4",
+    sizeBytes: 0,
+    createdAt: "2024-01-01T00:00:00.000Z",
+    startedAt: "2024-01-01T00:00:00.000Z",
+    lastAccessedAt: "2024-01-01T00:00:00.000Z",
+    config: makeConfig(),
+    ...overrides,
+  };
+}
+
+describe("VideoRecordingRepository", () => {
+  let db: Kysely<Database>;
+  let repo: VideoRecordingRepository;
+
+  beforeEach(async () => {
+    db = await createTestDatabase();
+    repo = new VideoRecordingRepository(db);
+  });
+
+  afterEach(async () => {
+    await db.destroy();
+  });
+
+  test("insertRecording and getRecording round-trip", async () => {
+    const record = makeRecord();
+    await repo.insertRecording(record);
+
+    const result = await repo.getRecording("rec-1");
+    expect(result).not.toBeNull();
+    expect(result!.recordingId).toBe("rec-1");
+    expect(result!.deviceId).toBe("emulator-5554");
+    expect(result!.platform).toBe("android");
+    expect(result!.status).toBe("recording");
+    expect(result!.fileName).toBe("recording.mp4");
+    expect(result!.filePath).toBe("/tmp/recording.mp4");
+    expect(result!.format).toBe("mp4");
+    expect(result!.sizeBytes).toBe(0);
+    expect(result!.config.qualityPreset).toBe("low");
+    expect(result!.config.fps).toBe(15);
+  });
+
+  test("getRecording returns null for unknown id", async () => {
+    const result = await repo.getRecording("nonexistent");
+    expect(result).toBeNull();
+  });
+
+  test("insertRecording with optional fields", async () => {
+    const record = makeRecord({
+      recordingId: "rec-opt",
+      outputName: "my-recording",
+      durationMs: 5000,
+      codec: "h264",
+      endedAt: "2024-01-01T00:05:00.000Z",
+      highlights: [
+        {
+          description: "button tap",
+          shape: { type: "circle", cx: 100, cy: 200, r: 30 },
+          timeline: { appearedAtSeconds: 1.0, disappearedAtSeconds: 2.0 },
+        },
+      ],
+    });
+
+    await repo.insertRecording(record);
+    const result = await repo.getRecording("rec-opt");
+    expect(result!.outputName).toBe("my-recording");
+    expect(result!.durationMs).toBe(5000);
+    expect(result!.codec).toBe("h264");
+    expect(result!.endedAt).toBe("2024-01-01T00:05:00.000Z");
+    expect(result!.highlights).toHaveLength(1);
+    expect(result!.highlights![0].description).toBe("button tap");
+  });
+
+  test("listRecordings returns all recordings", async () => {
+    await repo.insertRecording(makeRecord({ recordingId: "rec-1" }));
+    await repo.insertRecording(makeRecord({ recordingId: "rec-2" }));
+
+    const results = await repo.listRecordings();
+    expect(results).toHaveLength(2);
+  });
+
+  test("listRecordings filters by status (single)", async () => {
+    await repo.insertRecording(makeRecord({ recordingId: "rec-1", status: "recording" }));
+    await repo.insertRecording(makeRecord({ recordingId: "rec-2", status: "completed" }));
+
+    const results = await repo.listRecordings({ status: "completed" });
+    expect(results).toHaveLength(1);
+    expect(results[0].status).toBe("completed");
+  });
+
+  test("listRecordings filters by status (array)", async () => {
+    await repo.insertRecording(makeRecord({ recordingId: "rec-1", status: "recording" }));
+    await repo.insertRecording(makeRecord({ recordingId: "rec-2", status: "completed" }));
+    await repo.insertRecording(makeRecord({ recordingId: "rec-3", status: "interrupted" }));
+
+    const results = await repo.listRecordings({ status: ["completed", "interrupted"] });
+    expect(results).toHaveLength(2);
+  });
+
+  test("listRecordings filters by deviceId", async () => {
+    await repo.insertRecording(makeRecord({ recordingId: "rec-1", deviceId: "device-A" }));
+    await repo.insertRecording(makeRecord({ recordingId: "rec-2", deviceId: "device-B" }));
+
+    const results = await repo.listRecordings({ deviceId: "device-A" });
+    expect(results).toHaveLength(1);
+    expect(results[0].deviceId).toBe("device-A");
+  });
+
+  test("listRecordings filters by platform", async () => {
+    await repo.insertRecording(makeRecord({ recordingId: "rec-1", platform: "android" }));
+    await repo.insertRecording(makeRecord({ recordingId: "rec-2", platform: "ios" }));
+
+    const results = await repo.listRecordings({ platform: "ios" });
+    expect(results).toHaveLength(1);
+    expect(results[0].platform).toBe("ios");
+  });
+
+  test("listRecordings orders by lastAccessedAt", async () => {
+    await repo.insertRecording(
+      makeRecord({ recordingId: "rec-old", lastAccessedAt: "2024-01-01T00:00:00.000Z" })
+    );
+    await repo.insertRecording(
+      makeRecord({ recordingId: "rec-new", lastAccessedAt: "2024-06-01T00:00:00.000Z" })
+    );
+
+    const descResults = await repo.listRecordings({ orderByLastAccessed: "desc" });
+    expect(descResults[0].recordingId).toBe("rec-new");
+
+    const ascResults = await repo.listRecordings({ orderByLastAccessed: "asc" });
+    expect(ascResults[0].recordingId).toBe("rec-old");
+  });
+
+  test("listRecordings respects limit", async () => {
+    await repo.insertRecording(makeRecord({ recordingId: "rec-1" }));
+    await repo.insertRecording(makeRecord({ recordingId: "rec-2" }));
+    await repo.insertRecording(makeRecord({ recordingId: "rec-3" }));
+
+    const results = await repo.listRecordings({ limit: 2 });
+    expect(results).toHaveLength(2);
+  });
+
+  test("updateRecording changes status", async () => {
+    await repo.insertRecording(makeRecord({ status: "recording" }));
+
+    await repo.updateRecording("rec-1", {
+      status: "completed",
+      endedAt: "2024-01-01T00:05:00.000Z",
+      sizeBytes: 5000,
+      durationMs: 300000,
+    });
+
+    const result = await repo.getRecording("rec-1");
+    expect(result!.status).toBe("completed");
+    expect(result!.endedAt).toBe("2024-01-01T00:05:00.000Z");
+    expect(result!.sizeBytes).toBe(5000);
+    expect(result!.durationMs).toBe(300000);
+  });
+
+  test("updateRecording with empty update is a no-op", async () => {
+    await repo.insertRecording(makeRecord());
+    await repo.updateRecording("rec-1", {});
+
+    const result = await repo.getRecording("rec-1");
+    expect(result!.recordingId).toBe("rec-1");
+  });
+
+  test("getLatestRecording returns most recently accessed completed/interrupted recording", async () => {
+    await repo.insertRecording(
+      makeRecord({
+        recordingId: "rec-1",
+        status: "completed",
+        lastAccessedAt: "2024-01-01T00:00:00.000Z",
+      })
+    );
+    await repo.insertRecording(
+      makeRecord({
+        recordingId: "rec-2",
+        status: "interrupted",
+        lastAccessedAt: "2024-06-01T00:00:00.000Z",
+      })
+    );
+    await repo.insertRecording(
+      makeRecord({
+        recordingId: "rec-3",
+        status: "recording",
+        lastAccessedAt: "2024-12-01T00:00:00.000Z",
+      })
+    );
+
+    const latest = await repo.getLatestRecording();
+    expect(latest).not.toBeNull();
+    expect(latest!.recordingId).toBe("rec-2");
+  });
+
+  test("getLatestRecording returns null when no completed/interrupted recordings exist", async () => {
+    await repo.insertRecording(makeRecord({ status: "recording" }));
+
+    const latest = await repo.getLatestRecording();
+    expect(latest).toBeNull();
+  });
+
+  test("touchRecording updates lastAccessedAt", async () => {
+    await repo.insertRecording(makeRecord());
+
+    await repo.touchRecording("rec-1", "2025-06-01T00:00:00.000Z");
+
+    const result = await repo.getRecording("rec-1");
+    expect(result!.lastAccessedAt).toBe("2025-06-01T00:00:00.000Z");
+  });
+
+  test("deleteRecording removes the recording and returns true", async () => {
+    await repo.insertRecording(makeRecord());
+
+    const deleted = await repo.deleteRecording("rec-1");
+    expect(deleted).toBe(true);
+
+    const result = await repo.getRecording("rec-1");
+    expect(result).toBeNull();
+  });
+
+  test("deleteRecording returns false for nonexistent recording", async () => {
+    const deleted = await repo.deleteRecording("nonexistent");
+    expect(deleted).toBe(false);
+  });
+
+  test("updateRecording can update highlights", async () => {
+    await repo.insertRecording(makeRecord());
+
+    await repo.updateRecording("rec-1", {
+      highlights: [
+        {
+          description: "swipe gesture",
+          shape: { type: "circle", cx: 50, cy: 50, r: 20 },
+          timeline: { appearedAtSeconds: 0.5 },
+        },
+      ],
+    });
+
+    const result = await repo.getRecording("rec-1");
+    expect(result!.highlights).toHaveLength(1);
+    expect(result!.highlights![0].description).toBe("swipe gesture");
+  });
+});

--- a/test/doctor/android.test.ts
+++ b/test/doctor/android.test.ts
@@ -1,7 +1,17 @@
-import { describe, expect, test } from "bun:test";
+import { describe, expect, test, beforeEach } from "bun:test";
 import type { AndroidDoctorDependencies } from "../../src/doctor/checks/android";
-import { checkAndroidCommandLineTools } from "../../src/doctor/checks/android";
+import {
+  checkAndroidCommandLineTools,
+  checkJavaHome,
+  checkAdbInstallation,
+  checkAdbVersion,
+  checkConnectedDevices,
+} from "../../src/doctor/checks/android";
 import { FakeTimer } from "../fakes/FakeTimer";
+import { FakeAdbClientFactory } from "../fakes/FakeAdbClientFactory";
+import { FakeAdbExecutor } from "../fakes/FakeAdbExecutor";
+import type { AdbClientFactory } from "../../src/utils/android-cmdline-tools/AdbClientFactory";
+import type { BootedDevice } from "../../src/models";
 
 const baseDependencies: AndroidDoctorDependencies = {
   detectAndroidCommandLineTools: async () => [],
@@ -141,5 +151,294 @@ describe("Android doctor command line tools check", () => {
 
     expect(installCalls).toHaveLength(1);
     expect(result.status).toBe("pass");
+  });
+});
+
+describe("checkJavaHome", () => {
+  let originalJavaHome: string | undefined;
+
+  beforeEach(() => {
+    originalJavaHome = process.env.JAVA_HOME;
+  });
+
+  test("warns when JAVA_HOME is not set", async () => {
+    delete process.env.JAVA_HOME;
+    try {
+      const result = await checkJavaHome();
+      expect(result.name).toBe("JAVA_HOME");
+      expect(result.status).toBe("warn");
+      expect(result.message).toContain("JAVA_HOME environment variable not set");
+      expect(result.recommendation).toContain("Set JAVA_HOME");
+    } finally {
+      if (originalJavaHome !== undefined) {
+        process.env.JAVA_HOME = originalJavaHome;
+      } else {
+        delete process.env.JAVA_HOME;
+      }
+    }
+  });
+
+  test("warns when JAVA_HOME path does not exist", async () => {
+    process.env.JAVA_HOME = "/nonexistent/java/path/that/does/not/exist";
+    try {
+      const result = await checkJavaHome();
+      expect(result.name).toBe("JAVA_HOME");
+      expect(result.status).toBe("warn");
+      expect(result.message).toContain("path does not exist");
+      expect(result.message).toContain("/nonexistent/java/path/that/does/not/exist");
+      expect(result.recommendation).toContain("Update JAVA_HOME");
+    } finally {
+      if (originalJavaHome !== undefined) {
+        process.env.JAVA_HOME = originalJavaHome;
+      } else {
+        delete process.env.JAVA_HOME;
+      }
+    }
+  });
+
+  test("passes when JAVA_HOME is set to a valid path", async () => {
+    // Use a path that is known to exist on the system
+    process.env.JAVA_HOME = "/tmp";
+    try {
+      const result = await checkJavaHome();
+      expect(result.name).toBe("JAVA_HOME");
+      expect(result.status).toBe("pass");
+      expect(result.message).toContain("Java home directory found");
+      expect(result.value).toBe("/tmp");
+    } finally {
+      if (originalJavaHome !== undefined) {
+        process.env.JAVA_HOME = originalJavaHome;
+      } else {
+        delete process.env.JAVA_HOME;
+      }
+    }
+  });
+});
+
+describe("checkAdbInstallation", () => {
+  test("passes when ADB is available", async () => {
+    const fakeFactory: AdbClientFactory = {
+      create: () => ({
+        getAdbPathOnly: async () => "/usr/local/bin/adb",
+        executeCommand: async () => ({ stdout: "", stderr: "", toString: () => "", trim: () => "", includes: () => false }),
+        getBootedAndroidDevices: async () => [],
+        isScreenOn: async () => true,
+        getWakefulness: async () => "Awake" as const,
+        listUsers: async () => [],
+        getForegroundApp: async () => null,
+      }),
+    };
+
+    const result = await checkAdbInstallation(fakeFactory);
+    expect(result.name).toBe("ADB Installation");
+    expect(result.status).toBe("pass");
+    expect(result.message).toBe("ADB is available");
+    expect(result.value).toBe("/usr/local/bin/adb");
+  });
+
+  test("fails when ADB is not found", async () => {
+    const fakeFactory: AdbClientFactory = {
+      create: () => ({
+        getAdbPathOnly: async () => { throw new Error("adb not found in PATH"); },
+        executeCommand: async () => ({ stdout: "", stderr: "", toString: () => "", trim: () => "", includes: () => false }),
+        getBootedAndroidDevices: async () => [],
+        isScreenOn: async () => true,
+        getWakefulness: async () => "Awake" as const,
+        listUsers: async () => [],
+        getForegroundApp: async () => null,
+      }),
+    };
+
+    const result = await checkAdbInstallation(fakeFactory);
+    expect(result.name).toBe("ADB Installation");
+    expect(result.status).toBe("fail");
+    expect(result.message).toContain("ADB not found");
+    expect(result.message).toContain("adb not found in PATH");
+    expect(result.recommendation).toContain("Install Android SDK Platform-Tools");
+  });
+
+  test("fails with non-Error thrown values", async () => {
+    const fakeFactory: AdbClientFactory = {
+      create: () => ({
+        getAdbPathOnly: async () => { throw "string error"; },
+        executeCommand: async () => ({ stdout: "", stderr: "", toString: () => "", trim: () => "", includes: () => false }),
+        getBootedAndroidDevices: async () => [],
+        isScreenOn: async () => true,
+        getWakefulness: async () => "Awake" as const,
+        listUsers: async () => [],
+        getForegroundApp: async () => null,
+      }),
+    };
+
+    const result = await checkAdbInstallation(fakeFactory);
+    expect(result.status).toBe("fail");
+    expect(result.message).toContain("string error");
+  });
+});
+
+describe("checkAdbVersion", () => {
+  let fakeExecutor: FakeAdbExecutor;
+  let fakeFactory: FakeAdbClientFactory;
+
+  beforeEach(() => {
+    fakeExecutor = new FakeAdbExecutor();
+    // FakeAdbClientFactory expects FakeAdbClient, but checkAdbVersion uses
+    // executeCommand which is on AdbExecutor. We build a custom factory
+    // that returns our FakeAdbExecutor.
+    fakeFactory = new FakeAdbClientFactory(fakeExecutor as any);
+  });
+
+  test("passes and parses version from standard ADB output", async () => {
+    fakeExecutor.setCommandResponse("--version", {
+      stdout: "Android Debug Bridge version 35.0.0\nInstalled as /usr/local/bin/adb",
+      stderr: "",
+      toString: () => "Android Debug Bridge version 35.0.0",
+      trim: () => "Android Debug Bridge version 35.0.0",
+      includes: (s: string) => "Android Debug Bridge version 35.0.0".includes(s),
+    });
+
+    const result = await checkAdbVersion(fakeFactory);
+    expect(result.name).toBe("ADB Version");
+    expect(result.status).toBe("pass");
+    expect(result.message).toBe("Version 35.0.0");
+    expect(result.value).toBe("35.0.0");
+  });
+
+  test("passes with unknown version when output does not match pattern", async () => {
+    fakeExecutor.setCommandResponse("--version", {
+      stdout: "some unexpected output",
+      stderr: "",
+      toString: () => "some unexpected output",
+      trim: () => "some unexpected output",
+      includes: (s: string) => "some unexpected output".includes(s),
+    });
+
+    const result = await checkAdbVersion(fakeFactory);
+    expect(result.name).toBe("ADB Version");
+    expect(result.status).toBe("pass");
+    expect(result.message).toBe("Version unknown");
+    expect(result.value).toBe("unknown");
+  });
+
+  test("warns when executeCommand throws an error", async () => {
+    fakeExecutor.setDefaultError(new Error("ADB command failed"));
+
+    const result = await checkAdbVersion(fakeFactory);
+    expect(result.name).toBe("ADB Version");
+    expect(result.status).toBe("warn");
+    expect(result.message).toContain("Could not determine ADB version");
+    expect(result.message).toContain("ADB command failed");
+  });
+
+  test("warns with non-Error thrown values", async () => {
+    // Use a custom factory that throws a non-Error
+    const throwingFactory: AdbClientFactory = {
+      create: () => ({
+        executeCommand: async () => { throw "raw string error"; },
+        getBootedAndroidDevices: async () => [],
+        isScreenOn: async () => true,
+        getWakefulness: async () => "Awake" as const,
+        listUsers: async () => [],
+        getForegroundApp: async () => null,
+      }),
+    };
+
+    const result = await checkAdbVersion(throwingFactory);
+    expect(result.status).toBe("warn");
+    expect(result.message).toContain("raw string error");
+  });
+});
+
+describe("checkConnectedDevices", () => {
+  let fakeExecutor: FakeAdbExecutor;
+  let fakeFactory: FakeAdbClientFactory;
+
+  beforeEach(() => {
+    fakeExecutor = new FakeAdbExecutor();
+    fakeFactory = new FakeAdbClientFactory(fakeExecutor as any);
+  });
+
+  test("warns when no devices are connected", async () => {
+    fakeExecutor.setDevices([]);
+
+    const result = await checkConnectedDevices(fakeFactory);
+    expect(result.name).toBe("Connected Devices");
+    expect(result.status).toBe("warn");
+    expect(result.message).toBe("No Android devices connected");
+    expect(result.value).toBe(0);
+    expect(result.recommendation).toContain("Connect a device");
+  });
+
+  test("passes with one connected device", async () => {
+    const device: BootedDevice = {
+      name: "Pixel 7",
+      platform: "android",
+      deviceId: "emulator-5554",
+    };
+    fakeExecutor.setDevices([device]);
+
+    const result = await checkConnectedDevices(fakeFactory);
+    expect(result.name).toBe("Connected Devices");
+    expect(result.status).toBe("pass");
+    expect(result.message).toContain("1 device(s) connected");
+    expect(result.message).toContain("emulator-5554");
+    expect(result.value).toBe(1);
+  });
+
+  test("passes with multiple connected devices", async () => {
+    const devices: BootedDevice[] = [
+      { name: "Pixel 7", platform: "android", deviceId: "emulator-5554" },
+      { name: "Pixel 8", platform: "android", deviceId: "emulator-5556" },
+      { name: "Samsung Galaxy", platform: "android", deviceId: "R5CT12345" },
+    ];
+    fakeExecutor.setDevices(devices);
+
+    const result = await checkConnectedDevices(fakeFactory);
+    expect(result.name).toBe("Connected Devices");
+    expect(result.status).toBe("pass");
+    expect(result.message).toContain("3 device(s) connected");
+    expect(result.message).toContain("emulator-5554");
+    expect(result.message).toContain("emulator-5556");
+    expect(result.message).toContain("R5CT12345");
+    expect(result.value).toBe(3);
+  });
+
+  test("warns when getBootedAndroidDevices throws an error", async () => {
+    // Use a custom factory that throws on getBootedAndroidDevices
+    const throwingFactory: AdbClientFactory = {
+      create: () => ({
+        executeCommand: async () => ({ stdout: "", stderr: "", toString: () => "", trim: () => "", includes: () => false }),
+        getBootedAndroidDevices: async () => { throw new Error("adb server not running"); },
+        isScreenOn: async () => true,
+        getWakefulness: async () => "Awake" as const,
+        listUsers: async () => [],
+        getForegroundApp: async () => null,
+      }),
+    };
+
+    const result = await checkConnectedDevices(throwingFactory);
+    expect(result.name).toBe("Connected Devices");
+    expect(result.status).toBe("warn");
+    expect(result.message).toContain("Could not list devices");
+    expect(result.message).toContain("adb server not running");
+    expect(result.value).toBe(0);
+  });
+
+  test("warns with non-Error thrown values", async () => {
+    const throwingFactory: AdbClientFactory = {
+      create: () => ({
+        executeCommand: async () => ({ stdout: "", stderr: "", toString: () => "", trim: () => "", includes: () => false }),
+        getBootedAndroidDevices: async () => { throw "unexpected failure"; },
+        isScreenOn: async () => true,
+        getWakefulness: async () => "Awake" as const,
+        listUsers: async () => [],
+        getForegroundApp: async () => null,
+      }),
+    };
+
+    const result = await checkConnectedDevices(throwingFactory);
+    expect(result.status).toBe("warn");
+    expect(result.message).toContain("unexpected failure");
+    expect(result.value).toBe(0);
   });
 });

--- a/test/doctor/automobile.test.ts
+++ b/test/doctor/automobile.test.ts
@@ -1,0 +1,48 @@
+import { describe, test, expect, beforeEach } from "bun:test";
+import { checkVersion, checkAccessibilityService } from "../../src/doctor/checks/automobile";
+import { RELEASE_VERSION } from "../../src/constants/release";
+import { FakeAdbExecutor } from "../fakes/FakeAdbExecutor";
+import type { AdbClientFactory } from "../../src/utils/android-cmdline-tools/AdbClientFactory";
+
+describe("checkVersion", () => {
+  test("returns pass status", () => {
+    const result = checkVersion();
+
+    expect(result.status).toBe("pass");
+  });
+
+  test("includes version in message", () => {
+    const result = checkVersion();
+
+    expect(result.message).toBe(`Version ${RELEASE_VERSION}`);
+    expect(result.value).toBe(RELEASE_VERSION);
+  });
+
+  test("has correct name", () => {
+    const result = checkVersion();
+
+    expect(result.name).toBe("AutoMobile Version");
+  });
+});
+
+describe("checkAccessibilityService", () => {
+  let fakeAdb: FakeAdbExecutor;
+  let fakeFactory: AdbClientFactory;
+
+  beforeEach(() => {
+    fakeAdb = new FakeAdbExecutor();
+    fakeFactory = {
+      create: () => fakeAdb,
+    };
+  });
+
+  test("returns skip when no devices connected", async () => {
+    fakeAdb.setDevices([]);
+
+    const result = await checkAccessibilityService(fakeFactory);
+
+    expect(result.name).toBe("Accessibility Service");
+    expect(result.status).toBe("skip");
+    expect(result.message).toBe("No Android devices connected");
+  });
+});

--- a/test/doctor/index.test.ts
+++ b/test/doctor/index.test.ts
@@ -1,0 +1,385 @@
+import { describe, expect, test } from "bun:test";
+import { formatConsoleOutput, formatJsonOutput } from "../../src/doctor/formatter";
+import type { DoctorReport, CheckResult, DoctorSummary } from "../../src/doctor/types";
+
+function makeCheck(overrides: Partial<CheckResult> & Pick<CheckResult, "name" | "status">): CheckResult {
+  return {
+    message: overrides.status,
+    ...overrides,
+  };
+}
+
+function makeReport(overrides: Partial<DoctorReport> = {}): DoctorReport {
+  const systemChecks = overrides.system?.checks ?? [];
+  const androidChecks = overrides.android?.checks;
+  const iosChecks = overrides.ios?.checks;
+  const autoMobileChecks = overrides.autoMobile?.checks ?? [];
+
+  const allChecks = [
+    ...systemChecks,
+    ...(androidChecks ?? []),
+    ...(iosChecks ?? []),
+    ...autoMobileChecks,
+  ];
+
+  const summary: DoctorSummary = overrides.summary ?? {
+    total: allChecks.length,
+    passed: allChecks.filter(c => c.status === "pass").length,
+    warnings: allChecks.filter(c => c.status === "warn").length,
+    failed: allChecks.filter(c => c.status === "fail").length,
+    skipped: allChecks.filter(c => c.status === "skip").length,
+  };
+
+  return {
+    timestamp: "2025-01-01T00:00:00.000Z",
+    version: "1.0.0",
+    platform: "darwin",
+    arch: "arm64",
+    system: { checks: systemChecks },
+    autoMobile: { checks: autoMobileChecks },
+    summary,
+    recommendations: overrides.recommendations ?? [],
+    ...(androidChecks ? { android: { checks: androidChecks } } : {}),
+    ...(iosChecks ? { ios: { checks: iosChecks } } : {}),
+  };
+}
+
+describe("formatConsoleOutput", () => {
+  test("includes header with version, platform, and timestamp", () => {
+    const report = makeReport();
+    const output = formatConsoleOutput(report, false);
+
+    expect(output).toContain("AutoMobile Doctor");
+    expect(output).toContain("=================");
+    expect(output).toContain("Version: 1.0.0");
+    expect(output).toContain("Platform: darwin (arm64)");
+    expect(output).toContain("Timestamp: 2025-01-01T00:00:00.000Z");
+  });
+
+  test("all passing checks shows success message", () => {
+    const report = makeReport({
+      system: {
+        checks: [makeCheck({ name: "OS", status: "pass", message: "darwin" })],
+      },
+      autoMobile: {
+        checks: [makeCheck({ name: "Server", status: "pass", message: "ok" })],
+      },
+    });
+    const output = formatConsoleOutput(report, false);
+
+    expect(output).toContain("All checks passed! AutoMobile is ready to use.");
+    expect(output).toContain("Passed: 2");
+    expect(output).toContain("Warnings: 0");
+    expect(output).toContain("Failed: 0");
+  });
+
+  test("warnings shows warning message", () => {
+    const report = makeReport({
+      system: {
+        checks: [makeCheck({ name: "OS", status: "pass", message: "darwin" })],
+      },
+      autoMobile: {
+        checks: [makeCheck({ name: "Cache", status: "warn", message: "stale" })],
+      },
+    });
+    const output = formatConsoleOutput(report, false);
+
+    expect(output).toContain("warnings to review");
+    expect(output).not.toContain("Some checks failed");
+  });
+
+  test("failures shows failure message", () => {
+    const report = makeReport({
+      system: {
+        checks: [makeCheck({ name: "OS", status: "fail", message: "unsupported" })],
+      },
+      autoMobile: {
+        checks: [makeCheck({ name: "Server", status: "pass", message: "ok" })],
+      },
+    });
+    const output = formatConsoleOutput(report, false);
+
+    expect(output).toContain("Some checks failed");
+  });
+
+  test("skipped checks shows skipped count in summary", () => {
+    const report = makeReport({
+      system: {
+        checks: [makeCheck({ name: "OS", status: "pass", message: "darwin" })],
+      },
+      autoMobile: {
+        checks: [makeCheck({ name: "iOS Check", status: "skip", message: "not applicable" })],
+      },
+    });
+    const output = formatConsoleOutput(report, false);
+
+    expect(output).toContain("Skipped: 1");
+  });
+
+  test("skipped count is omitted when zero", () => {
+    const report = makeReport({
+      system: {
+        checks: [makeCheck({ name: "OS", status: "pass", message: "darwin" })],
+      },
+      autoMobile: {
+        checks: [makeCheck({ name: "Server", status: "pass", message: "ok" })],
+      },
+    });
+    const output = formatConsoleOutput(report, false);
+
+    expect(output).not.toContain("Skipped:");
+  });
+
+  test("useColors=false produces no ANSI escape codes", () => {
+    const report = makeReport({
+      system: {
+        checks: [
+          makeCheck({ name: "OS", status: "pass", message: "darwin" }),
+          makeCheck({ name: "Broken", status: "fail", message: "bad" }),
+          makeCheck({ name: "Iffy", status: "warn", message: "maybe" }),
+          makeCheck({ name: "Skipped", status: "skip", message: "n/a" }),
+        ],
+      },
+      autoMobile: { checks: [] },
+    });
+    const output = formatConsoleOutput(report, false);
+
+    expect(output).not.toContain("\x1b[");
+  });
+
+  test("useColors=true produces ANSI escape codes", () => {
+    const report = makeReport({
+      system: {
+        checks: [makeCheck({ name: "OS", status: "pass", message: "darwin" })],
+      },
+      autoMobile: { checks: [] },
+    });
+    const output = formatConsoleOutput(report, true);
+
+    expect(output).toContain("\x1b[32m");
+    expect(output).toContain("\x1b[0m");
+  });
+
+  test("check with value displays value instead of message", () => {
+    const report = makeReport({
+      system: {
+        checks: [makeCheck({ name: "OS", status: "pass", message: "the message", value: "the-value" })],
+      },
+      autoMobile: { checks: [] },
+    });
+    const output = formatConsoleOutput(report, false);
+
+    expect(output).toContain("[PASS] OS: the-value");
+    expect(output).not.toContain("the message");
+  });
+
+  test("check without value displays message", () => {
+    const report = makeReport({
+      system: {
+        checks: [makeCheck({ name: "OS", status: "pass", message: "the message" })],
+      },
+      autoMobile: { checks: [] },
+    });
+    const output = formatConsoleOutput(report, false);
+
+    expect(output).toContain("[PASS] OS: the message");
+  });
+
+  test("recommendations on warn/fail checks in autoMobile section show tips", () => {
+    const report = makeReport({
+      system: { checks: [] },
+      autoMobile: {
+        checks: [
+          makeCheck({
+            name: "ADB",
+            status: "fail",
+            message: "not found",
+            recommendation: "Install Android SDK",
+          }),
+        ],
+      },
+    });
+    const output = formatConsoleOutput(report, false);
+
+    expect(output).toContain("Tip: Install Android SDK");
+  });
+
+  test("recommendations on passing checks in autoMobile section do not show tips", () => {
+    const report = makeReport({
+      system: { checks: [] },
+      autoMobile: {
+        checks: [
+          makeCheck({
+            name: "ADB",
+            status: "pass",
+            message: "found",
+            recommendation: "Should not appear",
+          }),
+        ],
+      },
+    });
+    const output = formatConsoleOutput(report, false);
+
+    expect(output).not.toContain("Tip: Should not appear");
+  });
+
+  test("recommendations on warn/fail checks in android section show tips", () => {
+    const report = makeReport({
+      system: { checks: [] },
+      android: {
+        checks: [
+          makeCheck({
+            name: "SDK",
+            status: "warn",
+            message: "outdated",
+            recommendation: "Update SDK",
+          }),
+        ],
+      },
+      autoMobile: { checks: [] },
+    });
+    const output = formatConsoleOutput(report, false);
+
+    expect(output).toContain("--- Android Platform ---");
+    expect(output).toContain("Tip: Update SDK");
+  });
+
+  test("recommendations on warn/fail checks in ios section show tips", () => {
+    const report = makeReport({
+      system: { checks: [] },
+      ios: {
+        checks: [
+          makeCheck({
+            name: "Xcode",
+            status: "fail",
+            message: "missing",
+            recommendation: "Install Xcode",
+          }),
+        ],
+      },
+      autoMobile: { checks: [] },
+    });
+    const output = formatConsoleOutput(report, false);
+
+    expect(output).toContain("--- iOS Platform ---");
+    expect(output).toContain("Tip: Install Xcode");
+  });
+
+  test("system section does not show tips even with recommendations", () => {
+    const report = makeReport({
+      system: {
+        checks: [
+          makeCheck({
+            name: "OS",
+            status: "fail",
+            message: "unsupported",
+            recommendation: "Use macOS",
+          }),
+        ],
+      },
+      autoMobile: { checks: [] },
+    });
+    const output = formatConsoleOutput(report, false);
+
+    // System section doesn't render tips (per formatter logic)
+    expect(output).toContain("[FAIL] OS");
+    expect(output).not.toContain("Tip: Use macOS");
+  });
+
+  test("android section omitted when not present", () => {
+    const report = makeReport({
+      system: { checks: [] },
+      autoMobile: { checks: [] },
+    });
+    const output = formatConsoleOutput(report, false);
+
+    expect(output).not.toContain("--- Android Platform ---");
+  });
+
+  test("ios section omitted when not present", () => {
+    const report = makeReport({
+      system: { checks: [] },
+      autoMobile: { checks: [] },
+    });
+    const output = formatConsoleOutput(report, false);
+
+    expect(output).not.toContain("--- iOS Platform ---");
+  });
+
+  test("includes GitHub issues link", () => {
+    const report = makeReport();
+    const output = formatConsoleOutput(report, false);
+
+    expect(output).toContain("https://github.com/kaeawc/auto-mobile/issues");
+  });
+
+  test("status icons are rendered correctly", () => {
+    const report = makeReport({
+      system: {
+        checks: [
+          makeCheck({ name: "A", status: "pass" }),
+          makeCheck({ name: "B", status: "warn" }),
+          makeCheck({ name: "C", status: "fail" }),
+          makeCheck({ name: "D", status: "skip" }),
+        ],
+      },
+      autoMobile: { checks: [] },
+    });
+    const output = formatConsoleOutput(report, false);
+
+    expect(output).toContain("[PASS] A");
+    expect(output).toContain("[WARN] B");
+    expect(output).toContain("[FAIL] C");
+    expect(output).toContain("[SKIP] D");
+  });
+});
+
+describe("formatJsonOutput", () => {
+  test("returns valid JSON", () => {
+    const report = makeReport({
+      system: {
+        checks: [makeCheck({ name: "OS", status: "pass", message: "darwin" })],
+      },
+      autoMobile: { checks: [] },
+    });
+    const json = formatJsonOutput(report);
+
+    expect(() => JSON.parse(json)).not.toThrow();
+  });
+
+  test("roundtrips correctly", () => {
+    const report = makeReport({
+      system: {
+        checks: [makeCheck({ name: "OS", status: "pass", message: "darwin", value: "darwin" })],
+      },
+      android: {
+        checks: [makeCheck({ name: "ADB", status: "warn", message: "old", recommendation: "update" })],
+      },
+      autoMobile: {
+        checks: [makeCheck({ name: "Server", status: "pass", message: "running" })],
+      },
+      recommendations: ["ADB: update"],
+    });
+
+    const json = formatJsonOutput(report);
+    const parsed = JSON.parse(json) as DoctorReport;
+
+    expect(parsed.timestamp).toBe(report.timestamp);
+    expect(parsed.version).toBe(report.version);
+    expect(parsed.platform).toBe(report.platform);
+    expect(parsed.arch).toBe(report.arch);
+    expect(parsed.system.checks).toEqual(report.system.checks);
+    expect(parsed.android?.checks).toEqual(report.android?.checks);
+    expect(parsed.autoMobile.checks).toEqual(report.autoMobile.checks);
+    expect(parsed.summary).toEqual(report.summary);
+    expect(parsed.recommendations).toEqual(report.recommendations);
+  });
+
+  test("is pretty-printed with 2-space indentation", () => {
+    const report = makeReport();
+    const json = formatJsonOutput(report);
+
+    // JSON.stringify with indent 2 starts object contents at 2-space indent
+    expect(json).toContain('  "timestamp"');
+  });
+});

--- a/test/doctor/ios.test.ts
+++ b/test/doctor/ios.test.ts
@@ -2,10 +2,14 @@ import { describe, expect, test } from "bun:test";
 import type { IosDoctorDependencies } from "../../src/doctor/checks/ios";
 import {
   checkAppleDeveloperAccount,
+  checkBootedSimulators,
   checkCodeSigning,
+  checkProvisioningProfiles,
+  checkSimctlAvailable,
   checkSimulatorRuntimes,
   checkXcodeCommandLineTools,
-  checkXcodeInstallation
+  checkXcodeInstallation,
+  checkXcrunAvailable
 } from "../../src/doctor/checks/ios";
 import type { ExecResult } from "../../src/models";
 import { FakeTimer } from "../fakes/FakeTimer";
@@ -55,70 +59,362 @@ const baseDependencies: IosDoctorDependencies = {
 };
 
 describe("iOS doctor checks", () => {
-  test("fails when Xcode version is below minimum", async () => {
-    const result = await checkXcodeInstallation("15.0", {
-      ...baseDependencies,
-      execFile: async () => createExecResult("Xcode 14.2\nBuild version 14C18")
+  describe("checkXcodeInstallation", () => {
+    test("passes when version meets minimum", async () => {
+      const result = await checkXcodeInstallation("15.0", {
+        ...baseDependencies,
+        execFile: async () => createExecResult("Xcode 15.2\nBuild version 15C500b")
+      });
+
+      expect(result.status).toBe("pass");
+      expect(result.message).toContain("Xcode 15.2 installed");
+      expect(result.value).toBe("15.2");
     });
 
-    expect(result.status).toBe("fail");
-    expect(result.message).toContain("requires 15.0");
-  });
+    test("fails when Xcode version is below minimum", async () => {
+      const result = await checkXcodeInstallation("15.0", {
+        ...baseDependencies,
+        execFile: async () => createExecResult("Xcode 14.2\nBuild version 14C18")
+      });
 
-  test("passes when Command Line Tools are already installed via install flag", async () => {
-    const fakeTimer = new FakeTimer();
-    const execCalls: string[] = [];
-
-    const execFile = async () => {
-      execCalls.push("xcode-select --install");
-      await fakeTimer.sleep(0);
-      const error = new Error("Command line tools are already installed.");
-      (error as { stderr?: string }).stderr = "Command line tools are already installed.";
-      throw error;
-    };
-
-    const resultPromise = checkXcodeCommandLineTools(
-      { installXcodeCommandLineTools: true },
-      { ...baseDependencies, execFile }
-    );
-
-    fakeTimer.advanceTime(0);
-    const result = await resultPromise;
-
-    expect(execCalls).toHaveLength(1);
-    expect(result.status).toBe("pass");
-  });
-
-  test("fails when no simulator runtimes are available", async () => {
-    const result = await checkSimulatorRuntimes({
-      ...baseDependencies,
-      createSimctlClient: () => ({
-        ...baseDependencies.createSimctlClient(),
-        getRuntimes: async () => []
-      })
+      expect(result.status).toBe("fail");
+      expect(result.message).toContain("requires 15.0");
     });
 
-    expect(result.status).toBe("fail");
-    expect(result.message).toContain("No iOS simulator runtimes");
-  });
+    test("fails when unable to determine version", async () => {
+      const result = await checkXcodeInstallation("15.0", {
+        ...baseDependencies,
+        execFile: async () => createExecResult("some unexpected output")
+      });
 
-  test("warns when no code signing identities are present", async () => {
-    const result = await checkCodeSigning({
-      ...baseDependencies,
-      execFile: async () => createExecResult("  0 valid identities found")
+      expect(result.status).toBe("fail");
+      expect(result.message).toContain("Unable to determine Xcode version");
     });
 
-    expect(result.status).toBe("warn");
-    expect(result.message).toContain("No code signing identities");
-  });
+    test("skips when not on darwin", async () => {
+      const result = await checkXcodeInstallation("15.0", {
+        ...baseDependencies,
+        platform: () => "linux"
+      });
 
-  test("warns when no Apple Developer account is configured", async () => {
-    const result = await checkAppleDeveloperAccount({
-      ...baseDependencies,
-      readDir: async () => []
+      expect(result.status).toBe("skip");
+      expect(result.message).toContain("requires macOS");
     });
 
-    expect(result.status).toBe("warn");
-    expect(result.message).toContain("No Apple Developer account");
+    test("fails when xcodebuild throws", async () => {
+      const result = await checkXcodeInstallation("15.0", {
+        ...baseDependencies,
+        execFile: async () => {
+          throw new Error("xcodebuild not found");
+        }
+      });
+
+      expect(result.status).toBe("fail");
+      expect(result.message).toContain("Xcode not detected");
+      expect(result.message).toContain("xcodebuild not found");
+    });
+  });
+
+  describe("checkXcodeCommandLineTools", () => {
+    test("passes when path exists and contains CommandLineTools", async () => {
+      const result = await checkXcodeCommandLineTools({}, {
+        ...baseDependencies,
+        execFile: async () => createExecResult("/Library/Developer/CommandLineTools\n"),
+        fileExists: () => true
+      });
+
+      expect(result.status).toBe("pass");
+      expect(result.message).toBe("Command Line Tools installed");
+      expect(result.value).toBe("/Library/Developer/CommandLineTools");
+    });
+
+    test("passes when Xcode developer dir is selected", async () => {
+      const result = await checkXcodeCommandLineTools({}, {
+        ...baseDependencies,
+        execFile: async () => createExecResult("/Applications/Xcode.app/Contents/Developer\n"),
+        fileExists: () => true
+      });
+
+      expect(result.status).toBe("pass");
+      expect(result.message).toBe("Xcode developer directory selected");
+      expect(result.value).toBe("/Applications/Xcode.app/Contents/Developer");
+    });
+
+    test("fails when path doesn't exist", async () => {
+      const result = await checkXcodeCommandLineTools({}, {
+        ...baseDependencies,
+        execFile: async () => createExecResult("/Library/Developer/CommandLineTools\n"),
+        fileExists: () => false
+      });
+
+      expect(result.status).toBe("fail");
+      expect(result.message).toContain("path missing");
+    });
+
+    test("skips when not on darwin", async () => {
+      const result = await checkXcodeCommandLineTools({}, {
+        ...baseDependencies,
+        platform: () => "linux"
+      });
+
+      expect(result.status).toBe("skip");
+      expect(result.message).toContain("requires macOS");
+    });
+
+    test("passes when Command Line Tools are already installed via install flag", async () => {
+      const fakeTimer = new FakeTimer();
+      const execCalls: string[] = [];
+
+      const execFile = async () => {
+        execCalls.push("xcode-select --install");
+        await fakeTimer.sleep(0);
+        const error = new Error("Command line tools are already installed.");
+        (error as { stderr?: string }).stderr = "Command line tools are already installed.";
+        throw error;
+      };
+
+      const resultPromise = checkXcodeCommandLineTools(
+        { installXcodeCommandLineTools: true },
+        { ...baseDependencies, execFile }
+      );
+
+      fakeTimer.advanceTime(0);
+      const result = await resultPromise;
+
+      expect(execCalls).toHaveLength(1);
+      expect(result.status).toBe("pass");
+    });
+  });
+
+  describe("checkXcrunAvailable", () => {
+    test("passes when xcrun works", async () => {
+      const result = await checkXcrunAvailable({
+        ...baseDependencies,
+        execFile: async () => createExecResult("xcrun version 75.")
+      });
+
+      expect(result.status).toBe("pass");
+      expect(result.message).toBe("xcrun functional");
+    });
+
+    test("fails when xcrun fails", async () => {
+      const result = await checkXcrunAvailable({
+        ...baseDependencies,
+        execFile: async () => {
+          throw new Error("xcrun: error: unable to find utility");
+        }
+      });
+
+      expect(result.status).toBe("fail");
+      expect(result.message).toContain("xcrun not functional");
+    });
+
+    test("skips when not on darwin", async () => {
+      const result = await checkXcrunAvailable({
+        ...baseDependencies,
+        platform: () => "win32"
+      });
+
+      expect(result.status).toBe("skip");
+      expect(result.message).toContain("requires macOS");
+    });
+  });
+
+  describe("checkSimctlAvailable", () => {
+    test("passes when simctl is available", async () => {
+      const result = await checkSimctlAvailable({
+        ...baseDependencies,
+        createSimctlClient: () => ({
+          ...baseDependencies.createSimctlClient(),
+          isAvailable: async () => true
+        })
+      });
+
+      expect(result.status).toBe("pass");
+      expect(result.message).toBe("simctl functional");
+    });
+
+    test("fails when simctl is not available", async () => {
+      const result = await checkSimctlAvailable({
+        ...baseDependencies,
+        createSimctlClient: () => ({
+          ...baseDependencies.createSimctlClient(),
+          isAvailable: async () => false
+        })
+      });
+
+      expect(result.status).toBe("fail");
+      expect(result.message).toBe("simctl not available");
+    });
+
+    test("skips when not on darwin", async () => {
+      const result = await checkSimctlAvailable({
+        ...baseDependencies,
+        platform: () => "linux"
+      });
+
+      expect(result.status).toBe("skip");
+      expect(result.message).toContain("requires macOS");
+    });
+  });
+
+  describe("checkSimulatorRuntimes", () => {
+    test("fails when no simulator runtimes are available", async () => {
+      const result = await checkSimulatorRuntimes({
+        ...baseDependencies,
+        createSimctlClient: () => ({
+          ...baseDependencies.createSimctlClient(),
+          getRuntimes: async () => []
+        })
+      });
+
+      expect(result.status).toBe("fail");
+      expect(result.message).toContain("No iOS simulator runtimes");
+    });
+
+    test("passes when iOS runtimes are available", async () => {
+      const result = await checkSimulatorRuntimes({
+        ...baseDependencies,
+        createSimctlClient: () => ({
+          ...baseDependencies.createSimctlClient(),
+          getRuntimes: async () => [
+            {
+              bundlePath: "/path",
+              buildversion: "21A328",
+              runtimeRoot: "/path",
+              identifier: "com.apple.CoreSimulator.SimRuntime.iOS-17-0",
+              version: "17.0",
+              isAvailable: true,
+              name: "iOS 17.0"
+            }
+          ]
+        })
+      });
+
+      expect(result.status).toBe("pass");
+      expect(result.message).toContain("iOS 17.0");
+    });
+  });
+
+  describe("checkCodeSigning", () => {
+    test("warns when no code signing identities are present", async () => {
+      const result = await checkCodeSigning({
+        ...baseDependencies,
+        execFile: async () => createExecResult("  0 valid identities found")
+      });
+
+      expect(result.status).toBe("warn");
+      expect(result.message).toContain("No code signing identities");
+    });
+
+    test("passes when code signing identities exist", async () => {
+      const result = await checkCodeSigning({
+        ...baseDependencies,
+        execFile: async () => createExecResult("  1) ABC123 \"Apple Development: test@test.com\"\n  1 valid identities found")
+      });
+
+      expect(result.status).toBe("pass");
+      expect(result.message).toContain("1 code signing identity");
+    });
+  });
+
+  describe("checkAppleDeveloperAccount", () => {
+    test("warns when no Apple Developer account is configured", async () => {
+      const result = await checkAppleDeveloperAccount({
+        ...baseDependencies,
+        readDir: async () => []
+      });
+
+      expect(result.status).toBe("warn");
+      expect(result.message).toContain("No Apple Developer account");
+    });
+
+    test("passes when account entries exist", async () => {
+      const result = await checkAppleDeveloperAccount({
+        ...baseDependencies,
+        readDir: async () => ["account.plist"]
+      });
+
+      expect(result.status).toBe("pass");
+      expect(result.message).toContain("Apple Developer account configured");
+    });
+  });
+
+  describe("checkProvisioningProfiles", () => {
+    test("passes when profiles exist", async () => {
+      const result = await checkProvisioningProfiles({
+        ...baseDependencies,
+        readDir: async () => ["dev.mobileprovision", "dist.mobileprovision"]
+      });
+
+      expect(result.status).toBe("pass");
+      expect(result.message).toContain("2 provisioning profile(s)");
+      expect(result.value).toBe(2);
+    });
+
+    test("warns when no profiles", async () => {
+      const result = await checkProvisioningProfiles({
+        ...baseDependencies,
+        readDir: async () => []
+      });
+
+      expect(result.status).toBe("warn");
+      expect(result.message).toContain("No provisioning profiles");
+    });
+
+    test("skips when not on darwin", async () => {
+      const result = await checkProvisioningProfiles({
+        ...baseDependencies,
+        platform: () => "linux"
+      });
+
+      expect(result.status).toBe("skip");
+      expect(result.message).toContain("only available on macOS");
+    });
+  });
+
+  describe("checkBootedSimulators", () => {
+    test("passes with running simulators", async () => {
+      const result = await checkBootedSimulators({
+        ...baseDependencies,
+        createSimctlClient: () => ({
+          ...baseDependencies.createSimctlClient(),
+          getBootedSimulators: async () => [
+            { name: "iPhone 15", platform: "ios", deviceId: "ABC-123" },
+            { name: "iPad Air", platform: "ios", deviceId: "DEF-456" }
+          ]
+        })
+      });
+
+      expect(result.status).toBe("pass");
+      expect(result.message).toContain("2 simulator(s) running");
+      expect(result.message).toContain("iPhone 15");
+      expect(result.message).toContain("iPad Air");
+      expect(result.value).toBe(2);
+    });
+
+    test("passes with no simulators", async () => {
+      const result = await checkBootedSimulators({
+        ...baseDependencies,
+        createSimctlClient: () => ({
+          ...baseDependencies.createSimctlClient(),
+          getBootedSimulators: async () => []
+        })
+      });
+
+      expect(result.status).toBe("pass");
+      expect(result.message).toContain("No simulators currently running");
+      expect(result.value).toBe(0);
+    });
+
+    test("skips when not on darwin", async () => {
+      const result = await checkBootedSimulators({
+        ...baseDependencies,
+        platform: () => "linux"
+      });
+
+      expect(result.status).toBe("skip");
+      expect(result.message).toContain("only available on macOS");
+    });
   });
 });

--- a/test/doctor/system.test.ts
+++ b/test/doctor/system.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, test } from "bun:test";
+import {
+  checkOperatingSystem,
+  checkArchitecture,
+  checkRuntime,
+  runSystemChecks,
+} from "../../src/doctor/checks/system";
+
+describe("system doctor checks", () => {
+  test("checkOperatingSystem returns pass with platform info", () => {
+    const result = checkOperatingSystem();
+
+    expect(result.name).toBe("Operating System");
+    expect(result.status).toBe("pass");
+    expect(result.value).toBe(process.platform);
+    expect(result.message).toContain(process.platform);
+  });
+
+  test("checkArchitecture returns pass with arch info", () => {
+    const result = checkArchitecture();
+
+    expect(result.name).toBe("Architecture");
+    expect(result.status).toBe("pass");
+    expect(result.value).toBe(process.arch);
+    expect(result.message).toBe(process.arch);
+  });
+
+  test("checkRuntime returns pass with Bun version when running in Bun", () => {
+    const result = checkRuntime();
+
+    expect(result.name).toBe("Runtime");
+    expect(result.status).toBe("pass");
+    // Tests run under Bun, so we expect Bun version
+    const bunVersion = (globalThis as any).Bun?.version;
+    if (bunVersion) {
+      expect(result.message).toBe(`Bun ${bunVersion}`);
+      expect(result.value).toBe(`bun@${bunVersion}`);
+    } else {
+      expect(result.message).toContain("Node.js");
+      expect(result.value).toContain("node@");
+    }
+  });
+
+  test("runSystemChecks returns all three checks", () => {
+    const results = runSystemChecks();
+
+    expect(results).toHaveLength(3);
+    expect(results[0].name).toBe("Operating System");
+    expect(results[1].name).toBe("Architecture");
+    expect(results[2].name).toBe("Runtime");
+    for (const result of results) {
+      expect(result.status).toBe("pass");
+    }
+  });
+});

--- a/test/features/failures/FailureRecorder.test.ts
+++ b/test/features/failures/FailureRecorder.test.ts
@@ -1,0 +1,713 @@
+import { describe, expect, test, beforeEach } from "bun:test";
+import { FailureRecorder } from "../../../src/features/failures/FailureRecorder";
+import type {
+  RecordToolFailureInput,
+  RecordCrashInput,
+  RecordAnrInput,
+  RecordNonFatalInput,
+} from "../../../src/features/failures/FailureRecorder";
+import type { RecordFailureInput } from "../../../src/db/failureAnalyticsRepository";
+import type { StackTraceElement } from "../../../src/server/failuresResources";
+import { FakeTimer } from "../../fakes/FakeTimer";
+
+/**
+ * Fake FailureAnalyticsRepository that captures recordFailure calls in memory.
+ * Used to test FailureRecorder's signature generation, severity calculation,
+ * and input mapping without a real database.
+ */
+class FakeFailureAnalyticsRepository {
+  private recorded: RecordFailureInput[] = [];
+  private nextId = 1;
+  private shouldFail = false;
+
+  async recordFailure(input: RecordFailureInput): Promise<string> {
+    if (this.shouldFail) {
+      throw new Error("Repository failure");
+    }
+    this.recorded.push(input);
+    return `occ_${this.nextId++}`;
+  }
+
+  getRecorded(): RecordFailureInput[] {
+    return [...this.recorded];
+  }
+
+  last(): RecordFailureInput {
+    return this.recorded[this.recorded.length - 1];
+  }
+
+  setFailure(fail: boolean): void {
+    this.shouldFail = fail;
+  }
+
+  reset(): void {
+    this.recorded = [];
+    this.nextId = 1;
+    this.shouldFail = false;
+  }
+}
+
+const makeAppFrame = (overrides?: Partial<StackTraceElement>): StackTraceElement => ({
+  className: "com.example.app.MainActivity",
+  methodName: "onCreate",
+  fileName: "MainActivity.kt",
+  lineNumber: 42,
+  isAppCode: true,
+  ...overrides,
+});
+
+const makeSystemFrame = (overrides?: Partial<StackTraceElement>): StackTraceElement => ({
+  className: "android.os.Handler",
+  methodName: "handleCallback",
+  fileName: null,
+  lineNumber: null,
+  isAppCode: false,
+  ...overrides,
+});
+
+const baseContext = {
+  deviceModel: "Pixel 6",
+  os: "android-14",
+  appVersion: "1.0.0",
+  sessionId: "session-1",
+};
+
+describe("FailureRecorder", () => {
+  let repo: FakeFailureAnalyticsRepository;
+  let timer: FakeTimer;
+  let recorder: FailureRecorder;
+
+  beforeEach(() => {
+    repo = new FakeFailureAnalyticsRepository();
+    timer = new FakeTimer();
+    // Use the constructor DI to inject our fakes
+    recorder = new FailureRecorder(repo as any, timer);
+  });
+
+  describe("recordToolFailure", () => {
+    const makeInput = (overrides?: Partial<RecordToolFailureInput>): RecordToolFailureInput => ({
+      toolName: "tapOn",
+      errorMessage: "Element not found",
+      ...baseContext,
+      ...overrides,
+    });
+
+    test("records a tool failure and returns occurrence ID", async () => {
+      const result = await recorder.recordToolFailure(makeInput());
+
+      expect(result).toBe("occ_1");
+      expect(repo.getRecorded()).toHaveLength(1);
+    });
+
+    test("generates correct tool failure signature", async () => {
+      await recorder.recordToolFailure(makeInput({ errorCode: "NOT_FOUND" }));
+
+      expect(repo.last().signature).toBe("tool:tapOn:NOT_FOUND");
+    });
+
+    test("uses UNKNOWN when errorCode is missing", async () => {
+      await recorder.recordToolFailure(makeInput());
+
+      expect(repo.last().signature).toBe("tool:tapOn:UNKNOWN");
+    });
+
+    test("sets type to tool_failure", async () => {
+      await recorder.recordToolFailure(makeInput());
+
+      expect(repo.last().type).toBe("tool_failure");
+    });
+
+    test("generates title with tool name and error code", async () => {
+      await recorder.recordToolFailure(makeInput({ errorCode: "TIMEOUT" }));
+
+      expect(repo.last().title).toBe("tapOn: TIMEOUT");
+    });
+
+    test("generates title with Failed when no error code", async () => {
+      await recorder.recordToolFailure(makeInput());
+
+      expect(repo.last().title).toBe("tapOn: Failed");
+    });
+
+    test("includes tool call info with error codes", async () => {
+      await recorder.recordToolFailure(makeInput({ errorCode: "NOT_FOUND" }));
+
+      const toolCallInfo = repo.last().toolCallInfo!;
+      expect(toolCallInfo.toolName).toBe("tapOn");
+      expect(toolCallInfo.errorCodes).toEqual({ NOT_FOUND: 1 });
+    });
+
+    test("includes duration stats when durationMs is provided", async () => {
+      await recorder.recordToolFailure(makeInput({ durationMs: 500 }));
+
+      const stats = repo.last().toolCallInfo!.durationStats!;
+      expect(stats.minMs).toBe(500);
+      expect(stats.maxMs).toBe(500);
+      expect(stats.avgMs).toBe(500);
+    });
+
+    test("has null duration stats when durationMs is not provided", async () => {
+      await recorder.recordToolFailure(makeInput());
+
+      expect(repo.last().toolCallInfo!.durationStats).toBeNull();
+    });
+
+    test("extracts parameter variants from toolArgs", async () => {
+      await recorder.recordToolFailure(
+        makeInput({
+          toolArgs: { text: "Login", timeout: 5000 },
+        })
+      );
+
+      const variants = repo.last().toolCallInfo!.parameterVariants;
+      expect(variants.text).toEqual(["Login"]);
+      expect(variants.timeout).toEqual(["5000"]);
+    });
+
+    test("handles empty toolArgs", async () => {
+      await recorder.recordToolFailure(makeInput({ toolArgs: {} }));
+
+      expect(repo.last().toolCallInfo!.parameterVariants).toEqual({});
+    });
+
+    test("propagates repository errors", async () => {
+      repo.setFailure(true);
+
+      await expect(recorder.recordToolFailure(makeInput())).rejects.toThrow("Repository failure");
+    });
+  });
+
+  describe("tool failure severity", () => {
+    const makeInput = (errorCode?: string): RecordToolFailureInput => ({
+      toolName: "test",
+      errorMessage: "err",
+      errorCode,
+      ...baseContext,
+    });
+
+    test("returns medium when no error code", async () => {
+      await recorder.recordToolFailure(makeInput());
+
+      expect(repo.last().severity).toBe("medium");
+    });
+
+    test("returns critical for CRASH error codes", async () => {
+      await recorder.recordToolFailure(makeInput("APP_CRASH"));
+
+      expect(repo.last().severity).toBe("critical");
+    });
+
+    test("returns critical for FATAL error codes", async () => {
+      await recorder.recordToolFailure(makeInput("FATAL_ERROR"));
+
+      expect(repo.last().severity).toBe("critical");
+    });
+
+    test("returns high for TIMEOUT error codes", async () => {
+      await recorder.recordToolFailure(makeInput("TIMEOUT"));
+
+      expect(repo.last().severity).toBe("high");
+    });
+
+    test("returns high for CONNECTION error codes", async () => {
+      await recorder.recordToolFailure(makeInput("CONNECTION_REFUSED"));
+
+      expect(repo.last().severity).toBe("high");
+    });
+
+    test("returns high for NOT_FOUND error codes", async () => {
+      await recorder.recordToolFailure(makeInput("ELEMENT_NOT_FOUND"));
+
+      expect(repo.last().severity).toBe("high");
+    });
+
+    test("returns low for SKIPPED error codes", async () => {
+      await recorder.recordToolFailure(makeInput("SKIPPED"));
+
+      expect(repo.last().severity).toBe("low");
+    });
+
+    test("returns low for IGNORED error codes", async () => {
+      await recorder.recordToolFailure(makeInput("IGNORED"));
+
+      expect(repo.last().severity).toBe("low");
+    });
+
+    test("returns medium for unknown error codes", async () => {
+      await recorder.recordToolFailure(makeInput("SOMETHING_ELSE"));
+
+      expect(repo.last().severity).toBe("medium");
+    });
+  });
+
+  describe("recordCrash", () => {
+    const makeInput = (overrides?: Partial<RecordCrashInput>): RecordCrashInput => ({
+      exceptionType: "NullPointerException",
+      exceptionMessage: "Attempt to invoke on null reference",
+      stackTrace: [makeSystemFrame(), makeAppFrame()],
+      ...baseContext,
+      ...overrides,
+    });
+
+    test("records a crash and returns occurrence ID", async () => {
+      const result = await recorder.recordCrash(makeInput());
+
+      expect(result).toBe("occ_1");
+      expect(repo.last().type).toBe("crash");
+    });
+
+    test("generates crash signature with app frame", async () => {
+      await recorder.recordCrash(makeInput());
+
+      expect(repo.last().signature).toBe(
+        "crash:NullPointerException:com.example.app.MainActivity.onCreate"
+      );
+    });
+
+    test("falls back to exception type when no app frame", async () => {
+      await recorder.recordCrash(makeInput({ stackTrace: [makeSystemFrame()] }));
+
+      expect(repo.last().signature).toBe("crash:NullPointerException");
+    });
+
+    test("generates crash title with app frame details", async () => {
+      await recorder.recordCrash(makeInput());
+
+      expect(repo.last().title).toBe(
+        "NullPointerException in onCreate (MainActivity.kt:42)"
+      );
+    });
+
+    test("generates crash title without line number when null", async () => {
+      await recorder.recordCrash(
+        makeInput({
+          stackTrace: [makeAppFrame({ lineNumber: null })],
+        })
+      );
+
+      expect(repo.last().title).toBe(
+        "NullPointerException in onCreate (MainActivity.kt)"
+      );
+    });
+
+    test("uses className last segment when fileName is null", async () => {
+      await recorder.recordCrash(
+        makeInput({
+          stackTrace: [makeAppFrame({ fileName: null })],
+        })
+      );
+
+      expect(repo.last().title).toContain("MainActivity");
+    });
+
+    test("falls back to exception type for title when no app frame", async () => {
+      await recorder.recordCrash(makeInput({ stackTrace: [makeSystemFrame()] }));
+
+      expect(repo.last().title).toBe("NullPointerException");
+    });
+
+    test("includes stack trace in failure input", async () => {
+      const trace = [makeSystemFrame(), makeAppFrame()];
+      await recorder.recordCrash(makeInput({ stackTrace: trace }));
+
+      expect(repo.last().stackTrace).toEqual(trace);
+    });
+
+    test("constructs message from exception type and message", async () => {
+      await recorder.recordCrash(makeInput());
+
+      expect(repo.last().message).toBe(
+        "NullPointerException: Attempt to invoke on null reference"
+      );
+    });
+  });
+
+  describe("crash severity", () => {
+    const makeInput = (exceptionType: string): RecordCrashInput => ({
+      exceptionType,
+      exceptionMessage: "error",
+      stackTrace: [makeAppFrame()],
+      ...baseContext,
+    });
+
+    test("returns critical for OutOfMemory", async () => {
+      await recorder.recordCrash(makeInput("OutOfMemoryError"));
+
+      expect(repo.last().severity).toBe("critical");
+    });
+
+    test("returns critical for StackOverflow", async () => {
+      await recorder.recordCrash(makeInput("StackOverflowError"));
+
+      expect(repo.last().severity).toBe("critical");
+    });
+
+    test("returns critical for Fatal exceptions", async () => {
+      await recorder.recordCrash(makeInput("FatalException"));
+
+      expect(repo.last().severity).toBe("critical");
+    });
+
+    test("returns high for NullPointer", async () => {
+      await recorder.recordCrash(makeInput("NullPointerException"));
+
+      expect(repo.last().severity).toBe("high");
+    });
+
+    test("returns high for IllegalState", async () => {
+      await recorder.recordCrash(makeInput("IllegalStateException"));
+
+      expect(repo.last().severity).toBe("high");
+    });
+
+    test("returns high for SecurityException", async () => {
+      await recorder.recordCrash(makeInput("SecurityException"));
+
+      expect(repo.last().severity).toBe("high");
+    });
+
+    test("returns low for NumberFormat", async () => {
+      await recorder.recordCrash(makeInput("NumberFormatException"));
+
+      expect(repo.last().severity).toBe("low");
+    });
+
+    test("returns low for ParseException", async () => {
+      await recorder.recordCrash(makeInput("ParseException"));
+
+      expect(repo.last().severity).toBe("low");
+    });
+
+    test("returns medium for generic exceptions", async () => {
+      await recorder.recordCrash(makeInput("RuntimeException"));
+
+      expect(repo.last().severity).toBe("medium");
+    });
+  });
+
+  describe("recordAnr", () => {
+    const makeInput = (overrides?: Partial<RecordAnrInput>): RecordAnrInput => ({
+      reason: "Input dispatching timed out",
+      ...baseContext,
+      ...overrides,
+    });
+
+    test("records an ANR and returns occurrence ID", async () => {
+      const result = await recorder.recordAnr(makeInput());
+
+      expect(result).toBe("occ_1");
+      expect(repo.last().type).toBe("anr");
+    });
+
+    test("ANR severity is always high", async () => {
+      await recorder.recordAnr(makeInput());
+
+      expect(repo.last().severity).toBe("high");
+    });
+
+    test("generates ANR signature with app frame", async () => {
+      await recorder.recordAnr(
+        makeInput({ stackTrace: [makeSystemFrame(), makeAppFrame()] })
+      );
+
+      expect(repo.last().signature).toBe(
+        "anr:com.example.app.MainActivity.onCreate"
+      );
+    });
+
+    test("generates ANR signature with hash when no app frame", async () => {
+      await recorder.recordAnr(makeInput({ reason: "Input dispatching timed out" }));
+
+      // Should be anr:<md5-hash-first-8-chars>
+      expect(repo.last().signature).toMatch(/^anr:[a-f0-9]{8}$/);
+    });
+
+    test("generates consistent hash for same reason", async () => {
+      await recorder.recordAnr(makeInput({ reason: "same reason" }));
+      const sig1 = repo.last().signature;
+
+      await recorder.recordAnr(makeInput({ reason: "same reason" }));
+      const sig2 = repo.last().signature;
+
+      expect(sig1).toBe(sig2);
+    });
+
+    test("generates ANR title with app frame", async () => {
+      await recorder.recordAnr(
+        makeInput({
+          stackTrace: [makeAppFrame({ className: "com.example.MyService", methodName: "doWork" })],
+        })
+      );
+
+      expect(repo.last().title).toBe("ANR: MyService.doWork");
+    });
+
+    test("generates ANR title with truncated reason when no app frame", async () => {
+      const longReason = "A".repeat(100);
+      await recorder.recordAnr(makeInput({ reason: longReason }));
+
+      expect(repo.last().title).toBe(`ANR: ${"A".repeat(50)}...`);
+    });
+
+    test("generates ANR title with short reason when no app frame", async () => {
+      await recorder.recordAnr(makeInput({ reason: "Short reason" }));
+
+      expect(repo.last().title).toBe("ANR: Short reason");
+    });
+
+    test("includes duration in occurrence", async () => {
+      await recorder.recordAnr(makeInput({ durationMs: 10000 }));
+
+      expect(repo.last().occurrence.durationMs).toBe(10000);
+    });
+  });
+
+  describe("recordNonFatal", () => {
+    const makeInput = (overrides?: Partial<RecordNonFatalInput>): RecordNonFatalInput => ({
+      exceptionType: "IOException",
+      exceptionMessage: "Connection reset",
+      stackTrace: [makeAppFrame()],
+      ...baseContext,
+      ...overrides,
+    });
+
+    test("records a non-fatal and returns occurrence ID", async () => {
+      const result = await recorder.recordNonFatal(makeInput());
+
+      expect(result).toBe("occ_1");
+      expect(repo.last().type).toBe("nonfatal");
+    });
+
+    test("generates non-fatal signature with app frame", async () => {
+      await recorder.recordNonFatal(makeInput());
+
+      expect(repo.last().signature).toBe(
+        "nonfatal:IOException:com.example.app.MainActivity.onCreate"
+      );
+    });
+
+    test("falls back to exception type when no app frame", async () => {
+      await recorder.recordNonFatal(makeInput({ stackTrace: [makeSystemFrame()] }));
+
+      expect(repo.last().signature).toBe("nonfatal:IOException");
+    });
+
+    test("generates title with app frame details", async () => {
+      await recorder.recordNonFatal(makeInput());
+
+      expect(repo.last().title).toBe("IOException in onCreate (MainActivity.kt:42)");
+    });
+
+    test("falls back to exception type for title when no app frame", async () => {
+      await recorder.recordNonFatal(makeInput({ stackTrace: [makeSystemFrame()] }));
+
+      expect(repo.last().title).toBe("IOException");
+    });
+
+    test("includes customMessage in message when provided", async () => {
+      await recorder.recordNonFatal(makeInput({ customMessage: "Retrying..." }));
+
+      expect(repo.last().message).toBe("IOException: Connection reset - Retrying...");
+    });
+
+    test("omits customMessage from message when not provided", async () => {
+      await recorder.recordNonFatal(makeInput());
+
+      expect(repo.last().message).toBe("IOException: Connection reset");
+    });
+  });
+
+  describe("non-fatal severity", () => {
+    const makeInput = (exceptionType: string): RecordNonFatalInput => ({
+      exceptionType,
+      exceptionMessage: "error",
+      stackTrace: [makeAppFrame()],
+      ...baseContext,
+    });
+
+    test("returns medium for SecurityException", async () => {
+      await recorder.recordNonFatal(makeInput("SecurityException"));
+
+      expect(repo.last().severity).toBe("medium");
+    });
+
+    test("returns medium for IllegalState", async () => {
+      await recorder.recordNonFatal(makeInput("IllegalStateException"));
+
+      expect(repo.last().severity).toBe("medium");
+    });
+
+    test("returns medium for NullPointer", async () => {
+      await recorder.recordNonFatal(makeInput("NullPointerException"));
+
+      expect(repo.last().severity).toBe("medium");
+    });
+
+    test("returns low for most other exceptions", async () => {
+      await recorder.recordNonFatal(makeInput("IOException"));
+
+      expect(repo.last().severity).toBe("low");
+    });
+
+    test("returns low for unknown exceptions", async () => {
+      await recorder.recordNonFatal(makeInput("CustomException"));
+
+      expect(repo.last().severity).toBe("low");
+    });
+  });
+
+  describe("capture selection", () => {
+    test("prefers video over screenshot", async () => {
+      await recorder.recordToolFailure({
+        toolName: "tapOn",
+        errorMessage: "err",
+        ...baseContext,
+        screenshotPath: "/path/to/screenshot.png",
+        videoPath: "/path/to/video.mp4",
+      });
+
+      expect(repo.last().capture).toEqual({
+        type: "video",
+        path: "/path/to/video.mp4",
+      });
+    });
+
+    test("uses screenshot when no video", async () => {
+      await recorder.recordToolFailure({
+        toolName: "tapOn",
+        errorMessage: "err",
+        ...baseContext,
+        screenshotPath: "/path/to/screenshot.png",
+      });
+
+      expect(repo.last().capture).toEqual({
+        type: "screenshot",
+        path: "/path/to/screenshot.png",
+      });
+    });
+
+    test("returns undefined when no capture paths", async () => {
+      await recorder.recordToolFailure({
+        toolName: "tapOn",
+        errorMessage: "err",
+        ...baseContext,
+      });
+
+      expect(repo.last().capture).toBeUndefined();
+    });
+  });
+
+  describe("occurrence context", () => {
+    test("passes through device context", async () => {
+      await recorder.recordToolFailure({
+        toolName: "tapOn",
+        errorMessage: "err",
+        deviceId: "emulator-5554",
+        deviceModel: "Pixel 8",
+        os: "android-15",
+        appVersion: "2.0.0",
+        sessionId: "session-42",
+      });
+
+      const occ = repo.last().occurrence;
+      expect(occ.deviceId).toBe("emulator-5554");
+      expect(occ.deviceModel).toBe("Pixel 8");
+      expect(occ.os).toBe("android-15");
+      expect(occ.appVersion).toBe("2.0.0");
+      expect(occ.sessionId).toBe("session-42");
+    });
+
+    test("passes through screen context", async () => {
+      await recorder.recordToolFailure({
+        toolName: "tapOn",
+        errorMessage: "err",
+        ...baseContext,
+        currentScreen: "LoginScreen",
+        screensVisited: ["HomeScreen", "SettingsScreen", "LoginScreen"],
+      });
+
+      const occ = repo.last().occurrence;
+      expect(occ.screenAtFailure).toBe("LoginScreen");
+      expect(occ.screensVisited).toEqual(["HomeScreen", "SettingsScreen", "LoginScreen"]);
+    });
+
+    test("passes through test context", async () => {
+      await recorder.recordToolFailure({
+        toolName: "tapOn",
+        errorMessage: "err",
+        ...baseContext,
+        testName: "login_test",
+        testExecutionId: 123,
+      });
+
+      const occ = repo.last().occurrence;
+      expect(occ.testName).toBe("login_test");
+      expect(occ.testExecutionId).toBe(123);
+    });
+  });
+
+  describe("parameter variant extraction", () => {
+    test("converts string values directly", async () => {
+      await recorder.recordToolFailure({
+        toolName: "tapOn",
+        errorMessage: "err",
+        ...baseContext,
+        toolArgs: { text: "Submit" },
+      });
+
+      expect(repo.last().toolCallInfo!.parameterVariants).toEqual({
+        text: ["Submit"],
+      });
+    });
+
+    test("JSON-stringifies non-string values", async () => {
+      await recorder.recordToolFailure({
+        toolName: "tapOn",
+        errorMessage: "err",
+        ...baseContext,
+        toolArgs: { count: 5, enabled: true },
+      });
+
+      const variants = repo.last().toolCallInfo!.parameterVariants;
+      expect(variants.count).toEqual(["5"]);
+      expect(variants.enabled).toEqual(["true"]);
+    });
+
+    test("skips null and undefined values", async () => {
+      await recorder.recordToolFailure({
+        toolName: "tapOn",
+        errorMessage: "err",
+        ...baseContext,
+        toolArgs: { text: "Hello", empty: null, missing: undefined },
+      });
+
+      const variants = repo.last().toolCallInfo!.parameterVariants;
+      expect(variants.text).toEqual(["Hello"]);
+      expect(variants.empty).toBeUndefined();
+      expect(variants.missing).toBeUndefined();
+    });
+
+    test("returns empty variants when no toolArgs", async () => {
+      await recorder.recordToolFailure({
+        toolName: "tapOn",
+        errorMessage: "err",
+        ...baseContext,
+      });
+
+      expect(repo.last().toolCallInfo!.parameterVariants).toEqual({});
+    });
+  });
+
+  describe("static methods", () => {
+    test("resetInstance clears singleton", () => {
+      FailureRecorder.resetInstance();
+      // Should not throw
+      expect(true).toBe(true);
+    });
+
+    test("createForTesting returns a new instance", () => {
+      const instance = FailureRecorder.createForTesting(repo as any);
+      expect(instance).toBeInstanceOf(FailureRecorder);
+    });
+  });
+});

--- a/test/utils/plan/PlanMigrator.test.ts
+++ b/test/utils/plan/PlanMigrator.test.ts
@@ -1,0 +1,474 @@
+import { describe, expect, test } from "bun:test";
+import { migratePlan } from "../../../src/utils/plan/PlanMigrator";
+
+describe("PlanMigrator", () => {
+  describe("migratePlan", () => {
+    test("throws for non-object input", () => {
+      expect(() => migratePlan("not an object")).toThrow("Plan is not a valid object");
+      expect(() => migratePlan(null)).toThrow("Plan is not a valid object");
+      expect(() => migratePlan(42)).toThrow("Plan is not a valid object");
+      expect(() => migratePlan([])).toThrow("Plan is not a valid object");
+    });
+
+    test("passes through a current-version plan with minimal changes", () => {
+      const input = {
+        name: "Current Plan",
+        mcpVersion: "99.99.99",
+        metadata: {
+          createdAt: "2024-01-01T00:00:00.000Z",
+          version: "1.0.0",
+        },
+        steps: [{ tool: "tapOn", params: { text: "Hello" } }],
+      };
+
+      const { plan } = migratePlan(input);
+
+      expect(plan.name).toBe("Current Plan");
+      expect(plan.steps).toHaveLength(1);
+      expect(plan.steps[0].tool).toBe("tapOn");
+    });
+
+    describe("plan field migrations", () => {
+      test("renames planName to name", () => {
+        const { plan, report } = migratePlan({
+          planName: "Old Name",
+          steps: [{ tool: "observe", params: {} }],
+        });
+
+        expect(plan.name).toBe("Old Name");
+        expect(plan.planName).toBeUndefined();
+        expect(report.migrated).toBe(true);
+        expect(report.appliedMigrations).toContain("plan-fields");
+        expect(report.warnings.some(w => w.message.includes("Renamed planName to name"))).toBe(true);
+      });
+
+      test("moves metadata.name to plan name", () => {
+        const { plan, report } = migratePlan({
+          metadata: { name: "Meta Name" },
+          steps: [{ tool: "observe", params: {} }],
+        });
+
+        expect(plan.name).toBe("Meta Name");
+        expect(plan.metadata.name).toBeUndefined();
+        expect(report.migrated).toBe(true);
+      });
+
+      test("moves metadata.description to plan description", () => {
+        const { plan, report } = migratePlan({
+          name: "Plan",
+          metadata: { description: "Meta Description" },
+          steps: [{ tool: "observe", params: {} }],
+        });
+
+        expect(plan.description).toBe("Meta Description");
+        expect(plan.metadata.description).toBeUndefined();
+        expect(report.migrated).toBe(true);
+      });
+
+      test("maps generated timestamp to metadata.createdAt", () => {
+        const { plan, report } = migratePlan({
+          name: "Plan",
+          generated: "2024-06-15T12:00:00.000Z",
+          steps: [{ tool: "observe", params: {} }],
+        });
+
+        expect(plan.metadata.createdAt).toBe("2024-06-15T12:00:00.000Z");
+        expect(plan.generated).toBeUndefined();
+        expect(report.migrated).toBe(true);
+        expect(report.warnings.some(w => w.message.includes("generated timestamp"))).toBe(true);
+      });
+
+      test("moves top-level appId to metadata.appId", () => {
+        const { plan, report } = migratePlan({
+          name: "Plan",
+          appId: "com.example.app",
+          steps: [{ tool: "observe", params: {} }],
+        });
+
+        expect(plan.metadata.appId).toBe("com.example.app");
+        expect(plan.appId).toBeUndefined();
+        expect(report.migrated).toBe(true);
+      });
+
+      test("moves metadata.mcpVersion to top-level mcpVersion", () => {
+        const { plan, report } = migratePlan({
+          name: "Plan",
+          metadata: { mcpVersion: "1.2.3" },
+          steps: [{ tool: "observe", params: {} }],
+        });
+
+        expect(plan.mcpVersion).toBe("1.2.3");
+        expect(plan.metadata.mcpVersion).toBeUndefined();
+        expect(report.migrated).toBe(true);
+      });
+
+      test("defaults missing mcpVersion to unknown", () => {
+        const { plan, report } = migratePlan({
+          name: "Plan",
+          steps: [{ tool: "observe", params: {} }],
+        });
+
+        expect(plan.mcpVersion).toBe("unknown");
+        expect(report.migrated).toBe(true);
+        expect(report.warnings.some(w => w.message.includes("Defaulted missing mcpVersion"))).toBe(true);
+      });
+
+      test("defaults missing metadata.createdAt", () => {
+        const { plan, report } = migratePlan({
+          name: "Plan",
+          mcpVersion: "1.0.0",
+          steps: [{ tool: "observe", params: {} }],
+        });
+
+        expect(plan.metadata.createdAt).toBeDefined();
+        expect(typeof plan.metadata.createdAt).toBe("string");
+        expect(report.migrated).toBe(true);
+      });
+
+      test("defaults missing metadata.version to 1.0.0", () => {
+        const { plan, report } = migratePlan({
+          name: "Plan",
+          mcpVersion: "1.0.0",
+          steps: [{ tool: "observe", params: {} }],
+        });
+
+        expect(plan.metadata.version).toBe("1.0.0");
+        expect(report.migrated).toBe(true);
+      });
+
+      test("resets non-object metadata with warning", () => {
+        const { plan, report } = migratePlan({
+          name: "Plan",
+          metadata: "not an object",
+          steps: [{ tool: "observe", params: {} }],
+        });
+
+        expect(typeof plan.metadata).toBe("object");
+        expect(report.warnings.some(w => w.message.includes("metadata was not an object"))).toBe(true);
+      });
+    });
+
+    describe("step field migrations", () => {
+      test("renames command to tool", () => {
+        const { plan, report } = migratePlan({
+          name: "Plan",
+          mcpVersion: "1.0.0",
+          metadata: { createdAt: "2024-01-01", version: "1.0.0" },
+          steps: [{ command: "tapOn", params: { text: "Hello" } }],
+        });
+
+        expect(plan.steps[0].tool).toBe("tapOn");
+        expect(plan.steps[0].command).toBeUndefined();
+        expect(report.appliedMigrations).toContain("step-fields");
+      });
+
+      test("renames tapOnText to tapOn", () => {
+        const { plan, report } = migratePlan({
+          name: "Plan",
+          mcpVersion: "1.0.0",
+          metadata: { createdAt: "2024-01-01", version: "1.0.0" },
+          steps: [{ tool: "tapOnText", params: { text: "Hello" } }],
+        });
+
+        expect(plan.steps[0].tool).toBe("tapOn");
+        expect(report.warnings.some(w => w.message.includes("Renamed tapOnText to tapOn"))).toBe(true);
+      });
+
+      test("renames swipeOnScreen to swipeOn and defaults autoTarget", () => {
+        const { plan, report } = migratePlan({
+          name: "Plan",
+          mcpVersion: "1.0.0",
+          metadata: { createdAt: "2024-01-01", version: "1.0.0" },
+          steps: [{ tool: "swipeOnScreen", params: { direction: "up" } }],
+        });
+
+        expect(plan.steps[0].tool).toBe("swipeOn");
+        expect(plan.steps[0].params.autoTarget).toBe(false);
+        expect(report.warnings.some(w => w.message.includes("Renamed swipeOnScreen to swipeOn"))).toBe(true);
+      });
+
+      test("renames scroll to swipeOn and defaults gestureType", () => {
+        const { plan } = migratePlan({
+          name: "Plan",
+          mcpVersion: "1.0.0",
+          metadata: { createdAt: "2024-01-01", version: "1.0.0" },
+          steps: [{ tool: "scroll", params: { direction: "down" } }],
+        });
+
+        expect(plan.steps[0].tool).toBe("swipeOn");
+        expect(plan.steps[0].params.gestureType).toBe("scrollTowardsDirection");
+      });
+
+      test("renames packageName to appId for launchApp", () => {
+        const { plan } = migratePlan({
+          name: "Plan",
+          mcpVersion: "1.0.0",
+          metadata: { createdAt: "2024-01-01", version: "1.0.0" },
+          steps: [{ tool: "launchApp", params: { packageName: "com.example" } }],
+        });
+
+        expect(plan.steps[0].params.appId).toBe("com.example");
+        expect(plan.steps[0].params.packageName).toBeUndefined();
+      });
+
+      test("renames bundleId to appId for terminateApp", () => {
+        const { plan } = migratePlan({
+          name: "Plan",
+          mcpVersion: "1.0.0",
+          metadata: { createdAt: "2024-01-01", version: "1.0.0" },
+          steps: [{ tool: "terminateApp", params: { bundleId: "com.example.ios" } }],
+        });
+
+        expect(plan.steps[0].params.appId).toBe("com.example.ios");
+        expect(plan.steps[0].params.bundleId).toBeUndefined();
+      });
+
+      test("defaults tapOn.action to tap", () => {
+        const { plan } = migratePlan({
+          name: "Plan",
+          mcpVersion: "1.0.0",
+          metadata: { createdAt: "2024-01-01", version: "1.0.0" },
+          steps: [{ tool: "tapOn", params: { text: "Hello" } }],
+        });
+
+        expect(plan.steps[0].params.action).toBe("tap");
+      });
+
+      test("renames id to elementId for tapOn", () => {
+        const { plan } = migratePlan({
+          name: "Plan",
+          mcpVersion: "1.0.0",
+          metadata: { createdAt: "2024-01-01", version: "1.0.0" },
+          steps: [{ tool: "tapOn", params: { id: "submit_button" } }],
+        });
+
+        expect(plan.steps[0].params.elementId).toBe("submit_button");
+        expect(plan.steps[0].params.id).toBeUndefined();
+      });
+
+      test("renames inputText.value to text", () => {
+        const { plan } = migratePlan({
+          name: "Plan",
+          mcpVersion: "1.0.0",
+          metadata: { createdAt: "2024-01-01", version: "1.0.0" },
+          steps: [{ tool: "inputText", params: { value: "hello" } }],
+        });
+
+        expect(plan.steps[0].params.text).toBe("hello");
+        expect(plan.steps[0].params.value).toBeUndefined();
+      });
+
+      test("renames openLink.link to url", () => {
+        const { plan } = migratePlan({
+          name: "Plan",
+          mcpVersion: "1.0.0",
+          metadata: { createdAt: "2024-01-01", version: "1.0.0" },
+          steps: [{ tool: "openLink", params: { link: "https://example.com" } }],
+        });
+
+        expect(plan.steps[0].params.url).toBe("https://example.com");
+        expect(plan.steps[0].params.link).toBeUndefined();
+      });
+
+      test("migrates swipe containerElementId to container.elementId", () => {
+        const { plan } = migratePlan({
+          name: "Plan",
+          mcpVersion: "1.0.0",
+          metadata: { createdAt: "2024-01-01", version: "1.0.0" },
+          steps: [
+            {
+              tool: "swipeOn",
+              params: { direction: "up", containerElementId: "list_view" },
+            },
+          ],
+        });
+
+        expect(plan.steps[0].params.container).toEqual({ elementId: "list_view" });
+        expect(plan.steps[0].params.containerElementId).toBeUndefined();
+      });
+
+      test("migrates swipe containerText to container.text", () => {
+        const { plan } = migratePlan({
+          name: "Plan",
+          mcpVersion: "1.0.0",
+          metadata: { createdAt: "2024-01-01", version: "1.0.0" },
+          steps: [
+            {
+              tool: "swipeOn",
+              params: { direction: "up", containerText: "My List" },
+            },
+          ],
+        });
+
+        expect(plan.steps[0].params.container).toEqual({ text: "My List" });
+        expect(plan.steps[0].params.containerText).toBeUndefined();
+      });
+
+      test("maps swipe duration to speed and removes duration", () => {
+        const { plan: planSlow } = migratePlan({
+          name: "Plan",
+          mcpVersion: "1.0.0",
+          metadata: { createdAt: "2024-01-01", version: "1.0.0" },
+          steps: [{ tool: "swipeOn", params: { direction: "up", duration: 1000 } }],
+        });
+        expect(planSlow.steps[0].params.speed).toBe("slow");
+        expect(planSlow.steps[0].params.duration).toBeUndefined();
+
+        const { plan: planFast } = migratePlan({
+          name: "Plan",
+          mcpVersion: "1.0.0",
+          metadata: { createdAt: "2024-01-01", version: "1.0.0" },
+          steps: [{ tool: "swipeOn", params: { direction: "up", duration: 200 } }],
+        });
+        expect(planFast.steps[0].params.speed).toBe("fast");
+
+        const { plan: planNormal } = migratePlan({
+          name: "Plan",
+          mcpVersion: "1.0.0",
+          metadata: { createdAt: "2024-01-01", version: "1.0.0" },
+          steps: [{ tool: "swipeOn", params: { direction: "up", duration: 500 } }],
+        });
+        expect(planNormal.steps[0].params.speed).toBe("normal");
+      });
+
+      test("removes deprecated scrollMode from swipeOn", () => {
+        const { plan, report } = migratePlan({
+          name: "Plan",
+          mcpVersion: "1.0.0",
+          metadata: { createdAt: "2024-01-01", version: "1.0.0" },
+          steps: [{ tool: "swipeOn", params: { direction: "up", scrollMode: "fast" } }],
+        });
+
+        expect(plan.steps[0].params.scrollMode).toBeUndefined();
+        expect(report.warnings.some(w => w.message.includes("Removed deprecated scrollMode"))).toBe(true);
+      });
+
+      test("removes deprecated observe.withViewHierarchy", () => {
+        const { plan, report } = migratePlan({
+          name: "Plan",
+          mcpVersion: "1.0.0",
+          metadata: { createdAt: "2024-01-01", version: "1.0.0" },
+          steps: [{ tool: "observe", params: { withViewHierarchy: true } }],
+        });
+
+        expect(plan.steps[0].params.withViewHierarchy).toBeUndefined();
+        expect(report.warnings.some(w => w.message.includes("Removed deprecated observe.withViewHierarchy"))).toBe(true);
+      });
+
+      test("maps step description to label", () => {
+        const { plan, report } = migratePlan({
+          name: "Plan",
+          mcpVersion: "1.0.0",
+          metadata: { createdAt: "2024-01-01", version: "1.0.0" },
+          steps: [{ tool: "tapOn", description: "Click the button", params: { text: "Go" } }],
+        });
+
+        expect(plan.steps[0].label).toBe("Click the button");
+        expect(plan.steps[0].description).toBeUndefined();
+        expect(report.warnings.some(w => w.message.includes("Mapped step description to label"))).toBe(true);
+      });
+
+      test("merges inline step fields into params", () => {
+        const { plan } = migratePlan({
+          name: "Plan",
+          mcpVersion: "1.0.0",
+          metadata: { createdAt: "2024-01-01", version: "1.0.0" },
+          steps: [{ tool: "tapOn", text: "Hello", action: "tap" }],
+        });
+
+        expect(plan.steps[0].params.text).toBe("Hello");
+        expect(plan.steps[0].params.action).toBe("tap");
+      });
+
+      test("skips non-record steps", () => {
+        const { plan } = migratePlan({
+          name: "Plan",
+          mcpVersion: "1.0.0",
+          metadata: { createdAt: "2024-01-01", version: "1.0.0" },
+          steps: ["not a step", 42, null],
+        });
+
+        expect(plan.steps).toHaveLength(3);
+        // Non-record steps are passed through unchanged
+        expect(plan.steps[0]).toBe("not a step");
+      });
+    });
+
+    describe("migration report", () => {
+      test("reports original and target versions", () => {
+        const { report } = migratePlan({
+          name: "Plan",
+          mcpVersion: "0.5.0",
+          metadata: { createdAt: "2024-01-01", version: "1.0.0" },
+          steps: [{ tool: "observe", params: {} }],
+        });
+
+        expect(report.originalVersion).toBe("0.5.0");
+        expect(typeof report.targetVersion).toBe("string");
+      });
+
+      test("detects unknown original version", () => {
+        const { report } = migratePlan({
+          name: "Plan",
+          steps: [{ tool: "observe", params: {} }],
+        });
+
+        expect(report.originalVersion).toBe("unknown");
+      });
+
+      test("reads mcpVersion from metadata if not at top level", () => {
+        const { report } = migratePlan({
+          name: "Plan",
+          metadata: { mcpVersion: "0.3.0" },
+          steps: [{ tool: "observe", params: {} }],
+        });
+
+        expect(report.originalVersion).toBe("0.3.0");
+      });
+
+      test("reports outdated when version is older", () => {
+        const { report } = migratePlan({
+          name: "Plan",
+          mcpVersion: "0.0.1",
+          metadata: { createdAt: "2024-01-01", version: "1.0.0" },
+          steps: [{ tool: "observe", params: {} }],
+        });
+
+        expect(report.outdated).toBe(true);
+      });
+
+      test("reports not migrated when no changes needed", () => {
+        // Build a fully-specified plan that needs no migration
+        const { report } = migratePlan({
+          name: "Current",
+          mcpVersion: "99.99.99",
+          metadata: {
+            createdAt: "2024-01-01T00:00:00.000Z",
+            version: "1.0.0",
+          },
+          steps: [{ tool: "observe", params: {} }],
+        });
+
+        expect(report.migrated).toBe(false);
+        expect(report.appliedMigrations).toHaveLength(0);
+      });
+
+      test("includes step index in step warnings", () => {
+        const { report } = migratePlan({
+          name: "Plan",
+          mcpVersion: "1.0.0",
+          metadata: { createdAt: "2024-01-01", version: "1.0.0" },
+          steps: [
+            { tool: "observe", params: {} },
+            { command: "tapOn", params: { text: "Go" } },
+          ],
+        });
+
+        const stepWarnings = report.warnings.filter(w => w.stepIndex !== undefined);
+        expect(stepWarnings.length).toBeGreaterThan(0);
+        // The second step (index 1) should have had command -> tool migration
+        expect(stepWarnings.some(w => w.stepIndex === 1)).toBe(true);
+      });
+    });
+  });
+});

--- a/test/utils/plan/PlanSerializer.test.ts
+++ b/test/utils/plan/PlanSerializer.test.ts
@@ -1,0 +1,248 @@
+import { describe, expect, test } from "bun:test";
+import yaml from "js-yaml";
+import { YamlPlanSerializer } from "../../../src/utils/plan/PlanSerializer";
+import type { Plan } from "../../../src/models/Plan";
+
+/**
+ * Tests for PlanSerializer focusing on the pure importPlanFromYaml logic.
+ *
+ * exportPlanFromLogs is not tested here because it requires filesystem access
+ * (reading log directories and writing output files) without injectable dependencies.
+ */
+describe("YamlPlanSerializer", () => {
+  const serializer = new YamlPlanSerializer();
+
+  describe("importPlanFromYaml", () => {
+    test("imports a valid plan with name and steps", () => {
+      const yamlContent = yaml.dump({
+        name: "My Plan",
+        description: "A test plan",
+        mcpVersion: "1.0.0",
+        metadata: {
+          createdAt: "2024-01-01T00:00:00.000Z",
+          version: "1.0.0",
+        },
+        steps: [
+          { tool: "tapOn", params: { text: "Hello" } },
+          { tool: "inputText", params: { text: "World" } },
+        ],
+      });
+
+      const plan = serializer.importPlanFromYaml(yamlContent);
+
+      expect(plan.name).toBe("My Plan");
+      expect(plan.description).toBe("A test plan");
+      expect(plan.steps).toHaveLength(2);
+      expect(plan.steps[0].tool).toBe("tapOn");
+      expect(plan.steps[0].params).toEqual({ text: "Hello", action: "tap" });
+      expect(plan.steps[1].tool).toBe("inputText");
+      expect(plan.steps[1].params).toEqual({ text: "World" });
+      // Note: migration adds action: "tap" to tapOn steps
+    });
+
+    test("imports a minimal valid plan", () => {
+      const yamlContent = yaml.dump({
+        name: "Minimal",
+        steps: [{ tool: "observe", params: {} }],
+      });
+
+      const plan = serializer.importPlanFromYaml(yamlContent);
+
+      expect(plan.name).toBe("Minimal");
+      expect(plan.steps).toHaveLength(1);
+      expect(plan.steps[0].tool).toBe("observe");
+    });
+
+    test("applies migration for legacy planName field", () => {
+      const yamlContent = yaml.dump({
+        planName: "Legacy Plan",
+        steps: [{ tool: "tapOn", params: { text: "Go" } }],
+      });
+
+      const plan = serializer.importPlanFromYaml(yamlContent);
+
+      expect(plan.name).toBe("Legacy Plan");
+    });
+
+    test("normalizes legacy command field to tool", () => {
+      const yamlContent = yaml.dump({
+        name: "Command Plan",
+        mcpVersion: "1.0.0",
+        metadata: {
+          createdAt: "2024-01-01T00:00:00.000Z",
+          version: "1.0.0",
+        },
+        steps: [{ command: "tapOn", params: { text: "Hello" } }],
+      });
+
+      const plan = serializer.importPlanFromYaml(yamlContent);
+
+      expect(plan.steps[0].tool).toBe("tapOn");
+    });
+
+    test("normalizes inline step parameters into params object", () => {
+      const yamlContent = yaml.dump({
+        name: "Inline Params",
+        mcpVersion: "1.0.0",
+        metadata: {
+          createdAt: "2024-01-01T00:00:00.000Z",
+          version: "1.0.0",
+        },
+        steps: [{ tool: "tapOn", text: "Button", action: "tap" }],
+      });
+
+      const plan = serializer.importPlanFromYaml(yamlContent);
+
+      expect(plan.steps[0].params.text).toBe("Button");
+    });
+
+    test("sets default description when not provided", () => {
+      const yamlContent = yaml.dump({
+        name: "No Desc",
+        mcpVersion: "1.0.0",
+        metadata: {
+          createdAt: "2024-01-01T00:00:00.000Z",
+          version: "1.0.0",
+        },
+        steps: [
+          { tool: "tapOn", params: { text: "A" } },
+          { tool: "tapOn", params: { text: "B" } },
+        ],
+      });
+
+      const plan = serializer.importPlanFromYaml(yamlContent);
+
+      expect(plan.description).toBe("Plan with 2 steps");
+    });
+
+    test("preserves metadata when provided", () => {
+      const yamlContent = yaml.dump({
+        name: "With Metadata",
+        mcpVersion: "1.0.0",
+        metadata: {
+          createdAt: "2024-06-15T12:00:00.000Z",
+          version: "2.0.0",
+        },
+        steps: [{ tool: "observe", params: {} }],
+      });
+
+      const plan = serializer.importPlanFromYaml(yamlContent);
+
+      expect(plan.metadata!.createdAt).toBe("2024-06-15T12:00:00.000Z");
+      expect(plan.metadata!.version).toBe("2.0.0");
+    });
+
+    test("throws for invalid YAML syntax", () => {
+      const badYaml = "name: Test\nsteps:\n  - tool: tapOn\n    params: {invalid: [}";
+
+      expect(() => serializer.importPlanFromYaml(badYaml)).toThrow(
+        "Failed to parse plan YAML"
+      );
+    });
+
+    test("throws when name is missing", () => {
+      const yamlContent = yaml.dump({
+        steps: [{ tool: "tapOn", params: { text: "Go" } }],
+      });
+
+      // After migration, name defaults are tried; without any name source it should fail
+      expect(() => serializer.importPlanFromYaml(yamlContent)).toThrow();
+    });
+
+    test("throws when steps is missing", () => {
+      const yamlContent = yaml.dump({
+        name: "No Steps Plan",
+      });
+
+      expect(() => serializer.importPlanFromYaml(yamlContent)).toThrow();
+    });
+
+    test("throws when steps is not an array", () => {
+      const yamlContent = yaml.dump({
+        name: "Bad Steps",
+        steps: "not an array",
+      });
+
+      expect(() => serializer.importPlanFromYaml(yamlContent)).toThrow();
+    });
+
+    test("roundtrips plan through YAML serialization and deserialization", () => {
+      const originalPlan: Plan = {
+        name: "Roundtrip Plan",
+        description: "Test roundtrip",
+        mcpVersion: "1.0.0",
+        metadata: {
+          createdAt: "2024-01-01T00:00:00.000Z",
+          version: "1.0.0",
+        },
+        steps: [
+          { tool: "tapOn", params: { text: "Login", action: "tap" } },
+          { tool: "inputText", params: { text: "user@example.com" } },
+          { tool: "pressButton", params: { button: "enter" } },
+        ],
+      };
+
+      const yamlContent = yaml.dump(originalPlan, {
+        indent: 2,
+        lineWidth: -1,
+        noRefs: true,
+      });
+
+      const reimported = serializer.importPlanFromYaml(yamlContent);
+
+      expect(reimported.name).toBe(originalPlan.name);
+      expect(reimported.description).toBe(originalPlan.description);
+      expect(reimported.steps).toHaveLength(originalPlan.steps.length);
+      for (let i = 0; i < originalPlan.steps.length; i++) {
+        expect(reimported.steps[i].tool).toBe(originalPlan.steps[i].tool);
+        expect(reimported.steps[i].params).toEqual(originalPlan.steps[i].params);
+      }
+    });
+
+    test("handles plan with devices field", () => {
+      const yamlContent = yaml.dump({
+        name: "Multi Device Plan",
+        mcpVersion: "1.0.0",
+        metadata: {
+          createdAt: "2024-01-01T00:00:00.000Z",
+          version: "1.0.0",
+        },
+        devices: ["A", "B"],
+        steps: [
+          { tool: "tapOn", params: { text: "Hello", device: "A" } },
+          { tool: "tapOn", params: { text: "World", device: "B" } },
+        ],
+      });
+
+      const plan = serializer.importPlanFromYaml(yamlContent);
+
+      expect(plan.devices).toEqual(["A", "B"]);
+      expect(plan.steps[0].params.device).toBe("A");
+      expect(plan.steps[1].params.device).toBe("B");
+    });
+
+    test("handles plan with step labels", () => {
+      const yamlContent = yaml.dump({
+        name: "Labeled Plan",
+        mcpVersion: "1.0.0",
+        metadata: {
+          createdAt: "2024-01-01T00:00:00.000Z",
+          version: "1.0.0",
+        },
+        steps: [
+          { tool: "tapOn", params: { text: "Login" }, label: "Click login button" },
+        ],
+      });
+
+      const plan = serializer.importPlanFromYaml(yamlContent);
+
+      expect(plan.steps[0].label).toBe("Click login button");
+    });
+
+    test("throws for completely non-object input", () => {
+      const yamlContent = "just a string";
+
+      expect(() => serializer.importPlanFromYaml(yamlContent)).toThrow();
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add ~252 tests across 12 new test files covering doctor checks, database repositories, and pure utility functions
- Add constructor dependency injection to `DeviceSnapshotRepository` and `VideoRecordingRepository` to enable in-memory SQLite testing (backward-compatible)
- Expand existing android and iOS doctor test files with comprehensive edge case coverage

## Test coverage areas
- **Doctor checks**: system, android (20 tests), iOS (28 tests), automobile, formatter (22 tests)
- **Database repositories**: installed apps (17 tests), device snapshots (16 tests), video recordings (18 tests)
- **Pure utilities**: PlanSerializer (15 tests), PlanMigrator (36 tests), FailureRecorder (72 tests)

## Test plan
- [x] `bun test --bail` — 2351 pass, 0 fail
- [x] `bun run build` — clean
- [x] `bun run lint` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)