### PR TITLE
fix: upgrade bun 1.3.6 → 1.3.9 to fix allocator crash in CI

### DIFF
--- a/.github/actions/setup-auto-mobile-npm-package/action.yml
+++ b/.github/actions/setup-auto-mobile-npm-package/action.yml
@@ -13,7 +13,7 @@ runs:
     - name: "Setup Bun"
       uses: oven-sh/setup-bun@v2
       with:
-        bun-version: 1.3.6
+        bun-version: 1.3.9
 
     - name: "Install ripgrep"
       uses: ./.github/actions/setup-ripgrep

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -806,7 +806,7 @@ jobs:
       - name: "Setup Bun"
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: 1.3.6
+          bun-version: 1.3.9
 
       - uses: ./.github/actions/setup-auto-mobile-npm-package
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: 1.3.6
+          bun-version: 1.3.9
 
       - name: Set up Node.js
         uses: actions/setup-node@v4


### PR DESCRIPTION
## Summary
- Upgrade bun from 1.3.6 to 1.3.9 across all CI workflows
- Fixes `pas panic: deallocation did fail at ... Alloc bit not set in pas_segregated_page_deallocate_with_page` crash during test runs on Ubuntu CI

## Root Cause
Bun v1.3.6 has two Node-API memory bugs fixed in v1.3.7 ([changelog](https://bun.com/blog/bun-v1.3.7)):

1. **Dangling pointers in atom string table** — property name strings freed by native addon callers, but bun retained dangling pointers
2. **Premature external Buffer deallocation** — extracting `.buffer` from an external buffer freed backing data when the original Buffer was GC'd

Sharp (used in screenshot comparison tests) is a native Node-API addon that returns Buffers backed by external (libvips) memory. On Linux with bun 1.3.6, premature GC of sharp's backing data corrupts memory pages, causing the `pas_segregated_page_deallocate` panic. The crash only manifests on Ubuntu CI (not macOS) due to different memory allocator behavior.

## Test plan
- [x] All 2706 tests pass locally on bun 1.3.9
- [ ] CI passes with bun 1.3.9 (this PR validates it)

🤖 Generated with [Claude Code](https://claude.com/claude-code)