### PR TITLE
Hide test record button until recording flow is ready

### DIFF
--- a/android/ide-plugin/src/main/kotlin/dev/jasonpearson/automobile/ide/test/TestDashboard.kt
+++ b/android/ide-plugin/src/main/kotlin/dev/jasonpearson/automobile/ide/test/TestDashboard.kt
@@ -297,8 +297,8 @@ private fun TestDashboardHome(
 
     Spacer(Modifier.height(20.dp))
 
-    // Action button
-    DefaultButton(onClick = onRecordTest) { Text("Record Test") }
+    // TODO: Once we have a proper test recording flow, make this button available again
+    // DefaultButton(onClick = onRecordTest) { Text("Record Test") }
 
     Spacer(Modifier.height(24.dp))
 


### PR DESCRIPTION
## Summary
- Comment out the "Record Test" button in the IDE plugin's TestDashboard
- Added TODO to re-enable once a proper test recording flow is in place

## Test Plan
- [x] IDE plugin builds successfully (`./gradlew :ide-plugin:build`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)