### PR TITLE
chore: update accessibility service APK and XCTestService IPA SHA256

### DIFF
--- a/src/constants/release.ts
+++ b/src/constants/release.ts
@@ -19,7 +19,7 @@ export const RELEASE_VERSION: string = "latest";
 export const APK_URL: string = RELEASE_VERSION === "latest"
   ? `https://github.com/kaeawc/auto-mobile/releases/latest/download/accessibility-service-debug.apk`
   : `https://github.com/kaeawc/auto-mobile/releases/download/v${RELEASE_VERSION}/accessibility-service-debug.apk`;
-export const APK_SHA256_CHECKSUM: string = "9ba40763ee3bbefb3cbd3f0e79b78ef797f1f28e87ffa69f1dc26664c237414e"; // Empty = skip verification (local dev only)
+export const APK_SHA256_CHECKSUM: string = "a84546d99e5e17c3217c955af7b971109a30ba607fab03d00cea3afb3bbd4baf"; // Empty = skip verification (local dev only)
 
 /**
  * iOS XCTestService Release Constants
@@ -31,5 +31,5 @@ export const XCTESTSERVICE_RELEASE_VERSION: string = "latest";
 export const XCTESTSERVICE_IPA_URL: string = XCTESTSERVICE_RELEASE_VERSION === "latest"
   ? "https://github.com/kaeawc/auto-mobile/releases/latest/download/XCTestService.ipa"
   : `https://github.com/kaeawc/auto-mobile/releases/download/v${XCTESTSERVICE_RELEASE_VERSION}/XCTestService.ipa`;
-export const XCTESTSERVICE_SHA256_CHECKSUM: string = "bcc8385201f75b0448d9e859c71b944cda3cd34cf8cddadd200830a176c18ea9"; // Empty = skip verification (local dev only)
+export const XCTESTSERVICE_SHA256_CHECKSUM: string = "aa0ddce2611d5ab21d6a93aaaf58fb358ef6c635795049fe757a9d5774567378"; // Empty = skip verification (local dev only)
 export const XCTESTSERVICE_APP_HASH: string = ""; // Hash of XCTestServiceApp.app (device build), empty = skip verification


### PR DESCRIPTION
## Automated Checksum Update

The nightly build produced artifacts with updated SHA256 checksums.

| Artifact | Previous | New | Changed |
|----------|----------|-----|---------|
| **APK** | `9ba40763ee3bbefb3cbd3f0e79b78ef797f1f28e87ffa69f1dc26664c237414e` | `a84546d99e5e17c3217c955af7b971109a30ba607fab03d00cea3afb3bbd4baf` | ✅ Yes |
| **IPA** | `bcc8385201f75b0448d9e859c71b944cda3cd34cf8cddadd200830a176c18ea9` | `aa0ddce2611d5ab21d6a93aaaf58fb358ef6c635795049fe757a9d5774567378` | ✅ Yes |

### Why did this happen?

SHA256 checksums change when any of these change:
- Source code in `android/accessibility-service/src/` or `ios/XCTestService/`
- Build configuration (`build.gradle.kts` or `project.yml`)
- Dependencies or SDK versions

### What to do

1. Review this PR to ensure the changes are expected
2. Merge when ready
3. Future releases will use these checksums for artifact verification

---
Auto-generated by the `nightly` workflow