### PR TITLE
chore: update accessibility service APK and XCTestService IPA SHA256

### DIFF
--- a/src/constants/release.ts
+++ b/src/constants/release.ts
@@ -19,7 +19,7 @@ export const RELEASE_VERSION: string = "latest";
 export const APK_URL: string = RELEASE_VERSION === "latest"
   ? `https://github.com/kaeawc/auto-mobile/releases/latest/download/accessibility-service-debug.apk`
   : `https://github.com/kaeawc/auto-mobile/releases/download/v${RELEASE_VERSION}/accessibility-service-debug.apk`;
-export const APK_SHA256_CHECKSUM: string = "436a90627cd11838c8fc5f7def6be4541ef70052691434b611dfd15d3477f95f"; // Empty = skip verification (local dev only)
+export const APK_SHA256_CHECKSUM: string = "f03ab51aab50d08ed503a187e29f11659e0084edd58a824160b0ffa2ea200ae7"; // Empty = skip verification (local dev only)
 
 /**
  * iOS XCTestService Release Constants
@@ -31,5 +31,5 @@ export const XCTESTSERVICE_RELEASE_VERSION: string = "latest";
 export const XCTESTSERVICE_IPA_URL: string = XCTESTSERVICE_RELEASE_VERSION === "latest"
   ? "https://github.com/kaeawc/auto-mobile/releases/latest/download/XCTestService.ipa"
   : `https://github.com/kaeawc/auto-mobile/releases/download/v${XCTESTSERVICE_RELEASE_VERSION}/XCTestService.ipa`;
-export const XCTESTSERVICE_SHA256_CHECKSUM: string = "3d767ef4b5f0753b342f3897ac05bbc884dccdf6d7ebfb0e75567ce4d9718e8b"; // Empty = skip verification (local dev only)
+export const XCTESTSERVICE_SHA256_CHECKSUM: string = "e0527d7e627d8aae2b575c92105fbc0780f4c167ed78eddd44cb890427b5e851"; // Empty = skip verification (local dev only)
 export const XCTESTSERVICE_APP_HASH: string = ""; // Hash of XCTestServiceApp.app (device build), empty = skip verification


### PR DESCRIPTION
## Automated Checksum Update

The nightly build produced artifacts with updated SHA256 checksums.

| Artifact | Previous | New | Changed |
|----------|----------|-----|---------|
| **APK** | `436a90627cd11838c8fc5f7def6be4541ef70052691434b611dfd15d3477f95f` | `f03ab51aab50d08ed503a187e29f11659e0084edd58a824160b0ffa2ea200ae7` | ✅ Yes |
| **IPA** | `3d767ef4b5f0753b342f3897ac05bbc884dccdf6d7ebfb0e75567ce4d9718e8b` | `e0527d7e627d8aae2b575c92105fbc0780f4c167ed78eddd44cb890427b5e851` | ✅ Yes |

### Why did this happen?

SHA256 checksums change when any of these change:
- Source code in `android/accessibility-service/src/` or `ios/XCTestService/`
- Build configuration (`build.gradle.kts` or `project.yml`)
- Dependencies or SDK versions

### What to do

1. Review this PR to ensure the changes are expected
2. Merge when ready
3. Future releases will use these checksums for artifact verification

---
Auto-generated by the `nightly` workflow