### PR TITLE
chore: update XCTestService IPA SHA256

### DIFF
--- a/src/constants/release.ts
+++ b/src/constants/release.ts
@@ -31,5 +31,5 @@ export const XCTESTSERVICE_RELEASE_VERSION: string = "latest";
 export const XCTESTSERVICE_IPA_URL: string = XCTESTSERVICE_RELEASE_VERSION === "latest"
   ? "https://github.com/kaeawc/auto-mobile/releases/latest/download/XCTestService.ipa"
   : `https://github.com/kaeawc/auto-mobile/releases/download/v${XCTESTSERVICE_RELEASE_VERSION}/XCTestService.ipa`;
-export const XCTESTSERVICE_SHA256_CHECKSUM: string = "8240511e6239e3d6c2db86915863867c99e236f0028b0ef54ae7c016a9d7c3d4"; // Empty = skip verification (local dev only)
+export const XCTESTSERVICE_SHA256_CHECKSUM: string = "06e148e3848a71296ba9ed1144f99804d0e432515416d2d4bc4b2687160223c7"; // Empty = skip verification (local dev only)
 export const XCTESTSERVICE_APP_HASH: string = ""; // Hash of XCTestServiceApp.app (device build), empty = skip verification


### PR DESCRIPTION
## Automated Checksum Update

The nightly build produced artifacts with updated SHA256 checksums.

| Artifact | Previous | New | Changed |
|----------|----------|-----|---------|
| **APK** | `f03ab51aab50d08ed503a187e29f11659e0084edd58a824160b0ffa2ea200ae7` | `f03ab51aab50d08ed503a187e29f11659e0084edd58a824160b0ffa2ea200ae7` | No |
| **IPA** | `8240511e6239e3d6c2db86915863867c99e236f0028b0ef54ae7c016a9d7c3d4` | `06e148e3848a71296ba9ed1144f99804d0e432515416d2d4bc4b2687160223c7` | ✅ Yes |

### Why did this happen?

SHA256 checksums change when any of these change:
- Source code in `android/accessibility-service/src/` or `ios/XCTestService/`
- Build configuration (`build.gradle.kts` or `project.yml`)
- Dependencies or SDK versions

### What to do

1. Review this PR to ensure the changes are expected
2. Merge when ready
3. Future releases will use these checksums for artifact verification

---
Auto-generated by the `nightly` workflow