### PR TITLE
refactor(setUIState): remove options, auto-detect passwords, fill in screen order

### DIFF
--- a/src/features/action/FieldTypeDetector.ts
+++ b/src/features/action/FieldTypeDetector.ts
@@ -135,6 +135,16 @@ export class FieldTypeDetector {
   }
 
   /**
+   * Check if an element is a password field
+   * @param element - The element to check
+   * @returns true if the element is a password input
+   */
+  isPasswordField(element: Element): boolean {
+    const password = element.password;
+    return password === true || password === "true";
+  }
+
+  /**
    * Check if an element is currently checked/selected
    * @param element - The element to check
    * @returns true if the element is checked/selected

--- a/src/features/action/SetUIState.ts
+++ b/src/features/action/SetUIState.ts
@@ -64,9 +64,8 @@ export interface SetUIStateDependencies {
 }
 
 const DEFAULT_MAX_RETRIES = 3;
-const DEFAULT_VERIFY_AFTER = true;
-const DEFAULT_SCROLL_TO_FIND = true;
 const DEFAULT_SCROLL_DIRECTION = "down";
+const MAX_FUTILE_SCROLLS = 3;
 
 /**
  * SetUIState - Declarative form field population tool
@@ -74,6 +73,9 @@ const DEFAULT_SCROLL_DIRECTION = "down";
  * Populates form fields by specifying desired end-state rather than procedural steps.
  * Orchestrates existing tools (TapOnElement, InputText, ClearText, SwipeOn, ObserveScreen)
  * with automatic retry and verification.
+ *
+ * Fields are processed in screen order (top-to-bottom by bounds.top) as the form is scrolled,
+ * regardless of the order provided by the caller.
  */
 export class SetUIState extends BaseVisualChange {
   private fieldTypeDetector: FieldTypeDetector;
@@ -104,54 +106,113 @@ export class SetUIState extends BaseVisualChange {
     progress?: ProgressCallback,
     signal?: AbortSignal
   ): Promise<SetUIStateResult> {
-    const maxRetries = options.maxRetries ?? DEFAULT_MAX_RETRIES;
-    const verifyAfter = options.verifyAfter ?? DEFAULT_VERIFY_AFTER;
-    const scrollToFind = options.scrollToFind ?? DEFAULT_SCROLL_TO_FIND;
     const scrollDirection = options.scrollDirection ?? DEFAULT_SCROLL_DIRECTION;
 
-    const fieldResults: FieldResult[] = [];
+    const fieldResults: FieldResult[] = new Array(options.fields.length);
+    const processed = new Set<number>();
     let totalAttempts = 0;
-    let lastObservation: ObserveResult | undefined;
 
     // Get initial observation
-    lastObservation = await this.getObserveScreen().execute(undefined, undefined, false, 0, signal);
+    let lastObservation = await this.getObserveScreen().execute(undefined, undefined, false, 0, signal);
 
-    for (const fieldSpec of options.fields) {
-      const result = await this.processField(
-        fieldSpec,
-        {
-          maxRetries,
-          verifyAfter,
-          scrollToFind,
-          scrollDirection,
-          viewHierarchy: lastObservation?.viewHierarchy
-        },
-        progress,
-        signal
+    let scrollsWithoutProgress = 0;
+    let currentDirection: "up" | "down" = scrollDirection;
+    let triedReverse = false;
+
+    while (processed.size < options.fields.length) {
+      // Find all unprocessed fields visible in the current hierarchy, sorted by bounds.top
+      const visibleFields = this.findVisibleFieldsInScreenOrder(
+        options.fields,
+        processed,
+        lastObservation?.viewHierarchy
       );
 
-      fieldResults.push(result);
-      totalAttempts += result.attempts;
+      if (visibleFields.length > 0) {
+        scrollsWithoutProgress = 0;
 
-      // Update last observation if we got one
-      if (result.success) {
+        for (const { fieldSpec, fieldIndex, element } of visibleFields) {
+          const result = await this.processField(
+            fieldSpec,
+            element,
+            progress,
+            signal
+          );
+
+          fieldResults[fieldIndex] = result;
+          processed.add(fieldIndex);
+          totalAttempts += result.attempts;
+
+          // Refresh observation after each success
+          if (result.success) {
+            const freshObs = await this.getObserveScreen().execute(undefined, undefined, false, 0, signal);
+            if (freshObs) {
+              lastObservation = freshObs;
+            }
+          }
+
+          // Fail fast on failure
+          if (!result.success) {
+            logger.warn(`[SetUIState] Field failed, stopping: ${this.describeSelector(fieldSpec.selector)}`);
+            return {
+              success: false,
+              fields: this.collectResults(fieldResults, options.fields, processed),
+              totalAttempts,
+              observation: lastObservation,
+              error: result.error ?? `Failed to set field: ${this.describeSelector(fieldSpec.selector)}`
+            };
+          }
+        }
+      } else {
+        // No visible matches — scroll to find more
+        scrollsWithoutProgress++;
+
+        if (scrollsWithoutProgress > MAX_FUTILE_SCROLLS) {
+          if (!triedReverse) {
+            // Try reverse direction
+            currentDirection = currentDirection === "down" ? "up" : "down";
+            triedReverse = true;
+            scrollsWithoutProgress = 0;
+          } else {
+            // Exhausted both directions
+            break;
+          }
+        }
+
+        // Scroll and look for any unprocessed field
+        const nextSelector = this.getNextUnprocessedSelector(options.fields, processed);
+        if (nextSelector) {
+          await this.getSwipeOn().execute(
+            { direction: currentDirection, lookFor: nextSelector },
+            progress
+          );
+        } else {
+          await this.getSwipeOn().execute(
+            { direction: currentDirection },
+            progress
+          );
+        }
+
+        // Re-observe after scroll
         const freshObs = await this.getObserveScreen().execute(undefined, undefined, false, 0, signal);
         if (freshObs) {
           lastObservation = freshObs;
         }
       }
+    }
 
-      // Fail fast: stop on first field failure after retries
-      if (!result.success) {
-        logger.warn(`[SetUIState] Field failed, stopping: ${this.describeSelector(fieldSpec.selector)}`);
-        return {
-          success: false,
-          fields: fieldResults,
-          totalAttempts,
-          observation: lastObservation,
-          error: result.error ?? `Failed to set field: ${this.describeSelector(fieldSpec.selector)}`
-        };
-      }
+    // Check for any unprocessed fields
+    if (processed.size < options.fields.length) {
+      const missing = options.fields
+        .filter((_, i) => !processed.has(i))
+        .map(f => this.describeSelector(f.selector));
+
+      return {
+        success: false,
+        fields: this.collectResults(fieldResults, options.fields, processed),
+        totalAttempts,
+        observation: lastObservation,
+        error: `Fields not found after scrolling: ${missing.join(", ")}`
+      };
     }
 
     return {
@@ -163,69 +224,97 @@ export class SetUIState extends BaseVisualChange {
   }
 
   /**
-   * Process a single field
+   * Find all unprocessed fields visible in the current hierarchy, sorted by bounds.top ascending
+   */
+  private findVisibleFieldsInScreenOrder(
+    fields: FieldSpec[],
+    processed: Set<number>,
+    viewHierarchy?: ViewHierarchyResult
+  ): Array<{ fieldSpec: FieldSpec; fieldIndex: number; element: Element }> {
+    const matches: Array<{ fieldSpec: FieldSpec; fieldIndex: number; element: Element }> = [];
+
+    for (let i = 0; i < fields.length; i++) {
+      if (processed.has(i)) continue;
+
+      const element = this.findElement(fields[i].selector, viewHierarchy);
+      if (element) {
+        matches.push({ fieldSpec: fields[i], fieldIndex: i, element });
+      }
+    }
+
+    // Sort by bounds.top ascending (screen order)
+    matches.sort((a, b) => a.element.bounds.top - b.element.bounds.top);
+
+    return matches;
+  }
+
+  /**
+   * Get a lookFor selector for the first unprocessed field
+   */
+  private getNextUnprocessedSelector(
+    fields: FieldSpec[],
+    processed: Set<number>
+  ): { text?: string; elementId?: string } | undefined {
+    for (let i = 0; i < fields.length; i++) {
+      if (processed.has(i)) continue;
+      const sel = fields[i].selector;
+      if (sel.text) return { text: sel.text };
+      if (sel.elementId) return { elementId: sel.elementId };
+    }
+    return undefined;
+  }
+
+  /**
+   * Collect results array, filling in empty slots for unprocessed fields
+   */
+  private collectResults(
+    results: FieldResult[],
+    fields: FieldSpec[],
+    processed: Set<number>
+  ): FieldResult[] {
+    const out: FieldResult[] = [];
+    for (let i = 0; i < fields.length; i++) {
+      if (processed.has(i) && results[i]) {
+        out.push(results[i]);
+      } else {
+        out.push({
+          selector: fields[i].selector,
+          success: false,
+          attempts: 0,
+          error: `Element not found: ${this.describeSelector(fields[i].selector)}`
+        });
+      }
+    }
+    return out;
+  }
+
+  /**
+   * Process a single field that has already been found
    */
   private async processField(
     fieldSpec: FieldSpec,
-    context: {
-      maxRetries: number;
-      verifyAfter: boolean;
-      scrollToFind: boolean;
-      scrollDirection: "up" | "down";
-      viewHierarchy?: ViewHierarchyResult;
-    },
+    initialElement: Element,
     progress?: ProgressCallback,
     signal?: AbortSignal
   ): Promise<FieldResult> {
     let attempts = 0;
     let lastError: string | undefined;
     let fieldType: FieldType | undefined;
-    let currentViewHierarchy = context.viewHierarchy;
+    let element = initialElement;
 
-    while (attempts < context.maxRetries) {
+    while (attempts < DEFAULT_MAX_RETRIES) {
       attempts++;
 
       try {
-        // Find the element in current hierarchy
-        let element = this.findElement(fieldSpec.selector, currentViewHierarchy);
-
-        // If not found, refresh the view hierarchy before trying scroll
-        // This handles elements that appear after async load
-        if (!element && attempts > 1) {
-          logger.info(`[SetUIState] Element not found on attempt ${attempts}, refreshing view hierarchy`);
+        // On retry, re-find the element via scroll
+        if (attempts > 1) {
           const freshObs = await this.getObserveScreen().execute(undefined, undefined, false, 0, signal);
-          if (freshObs?.viewHierarchy) {
-            currentViewHierarchy = freshObs.viewHierarchy;
-            element = this.findElement(fieldSpec.selector, currentViewHierarchy);
+          const found = freshObs?.viewHierarchy
+            ? this.findElement(fieldSpec.selector, freshObs.viewHierarchy)
+            : null;
+          if (found) {
+            element = found;
           }
-        }
-
-        // If still not found and scroll enabled, try scrolling
-        if (!element && context.scrollToFind) {
-          const scrollResult = await this.scrollToFindElement(
-            fieldSpec.selector,
-            context.scrollDirection,
-            progress
-          );
-          if (scrollResult.found && scrollResult.element) {
-            element = scrollResult.element;
-          } else if (!scrollResult.found) {
-            // Try reverse direction
-            const reverseDirection = context.scrollDirection === "down" ? "up" : "down";
-            const reverseResult = await this.scrollToFindElement(
-              fieldSpec.selector,
-              reverseDirection,
-              progress
-            );
-            if (reverseResult.found && reverseResult.element) {
-              element = reverseResult.element;
-            }
-          }
-        }
-
-        if (!element) {
-          lastError = `Element not found: ${this.describeSelector(fieldSpec.selector)}`;
-          continue;
         }
 
         // Detect field type
@@ -260,12 +349,11 @@ export class SetUIState extends BaseVisualChange {
           continue;
         }
 
-        // Verify if requested (and not sensitive)
-        // Also skip verification for iOS text/dropdown fields when value attribute is unavailable
+        // Always verify unless password field or iOS skip applies
         let verified: boolean | undefined;
-        const shouldSkipVerify = fieldSpec.sensitive ||
+        const shouldSkipVerify = this.fieldTypeDetector.isPasswordField(element) ||
           this.fieldTypeDetector.shouldSkipVerification(element, fieldType);
-        if (context.verifyAfter && !shouldSkipVerify) {
+        if (!shouldSkipVerify) {
           verified = await this.verifyFieldValue(fieldSpec, fieldType, signal);
           if (!verified) {
             lastError = `Verification failed for ${this.describeSelector(fieldSpec.selector)}`;
@@ -312,30 +400,6 @@ export class SetUIState extends BaseVisualChange {
     }
 
     return null;
-  }
-
-  /**
-   * Scroll to find an element
-   */
-  private async scrollToFindElement(
-    selector: ElementSelector,
-    direction: "up" | "down",
-    progress?: ProgressCallback
-  ): Promise<{ found: boolean; element?: Element }> {
-    const swipeOn = this.getSwipeOn();
-    const lookFor = selector.text
-      ? { text: selector.text }
-      : { elementId: selector.elementId };
-
-    const result = await swipeOn.execute(
-      { direction, lookFor },
-      progress
-    );
-
-    return {
-      found: result.found ?? false,
-      element: result.element
-    };
   }
 
   /**

--- a/src/models/SetUIStateOptions.ts
+++ b/src/models/SetUIStateOptions.ts
@@ -18,8 +18,6 @@ export interface FieldSpec {
   value?: string;
   /** Target selection state (for checkboxes and toggles) */
   selected?: boolean;
-  /** Skip verification after setting (for sensitive fields like passwords) */
-  sensitive?: boolean;
 }
 
 /**
@@ -28,12 +26,6 @@ export interface FieldSpec {
 export interface SetUIStateOptions {
   /** List of fields to set */
   fields: FieldSpec[];
-  /** Maximum retry attempts per field (default: 3) */
-  maxRetries?: number;
-  /** Verify field values after setting (default: true) */
-  verifyAfter?: boolean;
-  /** Scroll to find fields that aren't visible (default: true) */
-  scrollToFind?: boolean;
   /** Initial scroll direction when searching (default: "down") */
   scrollDirection?: "up" | "down";
 }

--- a/src/server/formTools.ts
+++ b/src/server/formTools.ts
@@ -18,8 +18,7 @@ const fieldSpecSchema = z.object({
     validateElementIdTextSelector(value, ctx, "Provide exactly one of elementId or text in selector");
   }).describe("Selector to find the field element"),
   value: z.string().optional().describe("Value to set (for text inputs and dropdowns)"),
-  selected: z.boolean().optional().describe("Target selection state (for checkboxes and toggles)"),
-  sensitive: z.boolean().optional().describe("Skip verification for sensitive fields like passwords")
+  selected: z.boolean().optional().describe("Target selection state (for checkboxes and toggles)")
 }).refine(
   data => data.value !== undefined || data.selected !== undefined,
   { message: "Provide either value (for text/dropdown) or selected (for checkbox/toggle)" }
@@ -32,12 +31,6 @@ const setUIStateSchema = z.object({
   fields: z.array(fieldSpecSchema)
     .min(1, "At least one field is required")
     .describe("List of fields to set"),
-  maxRetries: z.number().int().positive().optional()
-    .describe("Maximum retry attempts per field (default: 3)"),
-  verifyAfter: z.boolean().optional()
-    .describe("Verify field values after setting (default: true)"),
-  scrollToFind: z.boolean().optional()
-    .describe("Scroll to find fields that aren't visible (default: true)"),
   scrollDirection: z.enum(["up", "down"]).optional()
     .describe("Initial scroll direction when searching (default: down)")
 });
@@ -91,7 +84,7 @@ Example usage:
 {
   "fields": [
     { "selector": { "elementId": "username" }, "value": "john@example.com" },
-    { "selector": { "text": "Password" }, "value": "secret123", "sensitive": true },
+    { "selector": { "text": "Password" }, "value": "secret123" },
     { "selector": { "elementId": "remember_me" }, "selected": true }
   ]
 }
@@ -114,12 +107,8 @@ Example usage:
               elementId: f.selector.elementId
             },
             value: f.value,
-            selected: f.selected,
-            sensitive: f.sensitive
+            selected: f.selected
           })),
-          maxRetries: args.maxRetries,
-          verifyAfter: args.verifyAfter,
-          scrollToFind: args.scrollToFind,
           scrollDirection: args.scrollDirection
         },
         progress,

--- a/test/fakes/FakeSetUIStateDependencies.ts
+++ b/test/fakes/FakeSetUIStateDependencies.ts
@@ -312,6 +312,7 @@ export class FakeFieldTypeDetector {
   private checkedOverrides: Map<string, boolean> = new Map();
   private textOverrides: Map<string, string> = new Map();
   private skipVerificationOverrides: Map<string, boolean> = new Map();
+  private passwordOverrides: Map<string, boolean> = new Map();
   private realDetector: FieldTypeDetector = new FieldTypeDetector();
 
   detect(element: Element): FieldType {
@@ -335,6 +336,15 @@ export class FakeFieldTypeDetector {
 
   isIOSElement(element: Element): boolean {
     return this.realDetector.isIOSElement(element);
+  }
+
+  isPasswordField(element: Element): boolean {
+    const key = element["resource-id"] ?? element.text ?? "";
+    const override = this.passwordOverrides.get(key);
+    if (override !== undefined) {
+      return override;
+    }
+    return this.realDetector.isPasswordField(element);
   }
 
   shouldSkipVerification(element: Element, fieldType: FieldType): boolean {
@@ -362,10 +372,15 @@ export class FakeFieldTypeDetector {
     this.skipVerificationOverrides.set(selector, skip);
   }
 
+  setIsPasswordField(selector: string, isPassword: boolean): void {
+    this.passwordOverrides.set(selector, isPassword);
+  }
+
   reset(): void {
     this.typeOverrides.clear();
     this.checkedOverrides.clear();
     this.textOverrides.clear();
     this.skipVerificationOverrides.clear();
+    this.passwordOverrides.clear();
   }
 }

--- a/test/features/action/FieldTypeDetector.test.ts
+++ b/test/features/action/FieldTypeDetector.test.ts
@@ -190,6 +190,33 @@ describe("FieldTypeDetector", () => {
     });
   });
 
+  describe("isPasswordField", () => {
+    test("returns true for password=true boolean", () => {
+      const element = createElement({ password: true });
+      expect(detector.isPasswordField(element)).toBe(true);
+    });
+
+    test("returns true for password='true' string", () => {
+      const element = createElement({ password: "true" });
+      expect(detector.isPasswordField(element)).toBe(true);
+    });
+
+    test("returns false for password=false", () => {
+      const element = createElement({ password: false });
+      expect(detector.isPasswordField(element)).toBe(false);
+    });
+
+    test("returns false for password='false' string", () => {
+      const element = createElement({ password: "false" });
+      expect(detector.isPasswordField(element)).toBe(false);
+    });
+
+    test("returns false for undefined password", () => {
+      const element = createElement({});
+      expect(detector.isPasswordField(element)).toBe(false);
+    });
+  });
+
   describe("isChecked", () => {
     test("returns true for checked=true boolean", () => {
       const element = createElement({ checked: true });

--- a/test/features/action/SetUIState.test.ts
+++ b/test/features/action/SetUIState.test.ts
@@ -69,18 +69,30 @@ describe("SetUIState", () => {
 
   describe("text field handling", () => {
     test("sets text field value with tap, clear, and input", async () => {
-      const hierarchy = createHierarchyWithElement({
+      const initialHierarchy = createHierarchyWithElement({
         "resource-id": "username",
         "text": "",
         "class": "android.widget.EditText"
       });
-      fakeObserve.setResult(createObserveResult(hierarchy));
+      const updatedHierarchy = createHierarchyWithElement({
+        "resource-id": "username",
+        "text": "john@example.com",
+        "class": "android.widget.EditText"
+      });
+
+      let observeCallCount = 0;
+      fakeObserve.setResultFactory(() => {
+        observeCallCount++;
+        if (observeCallCount <= 1) {
+          return createObserveResult(initialHierarchy);
+        }
+        return createObserveResult(updatedHierarchy);
+      });
       fakeFieldTypeDetector.setFieldType("username", "text");
 
       const setUIState = createSetUIState();
       const result = await setUIState.execute({
-        fields: [{ selector: { elementId: "username" }, value: "john@example.com" }],
-        verifyAfter: false  // Disable verification for this test since fake doesn't update
+        fields: [{ selector: { elementId: "username" }, value: "john@example.com" }]
       });
 
       expect(result.success).toBe(true);
@@ -128,20 +140,32 @@ describe("SetUIState", () => {
 
   describe("checkbox handling", () => {
     test("taps checkbox when state needs to change", async () => {
-      const hierarchy = createHierarchyWithElement({
+      const initialHierarchy = createHierarchyWithElement({
         "resource-id": "remember_me",
         "class": "android.widget.CheckBox",
         "checkable": "true" as any,
         "checked": "false" as any
       });
-      fakeObserve.setResult(createObserveResult(hierarchy));
+      const updatedHierarchy = createHierarchyWithElement({
+        "resource-id": "remember_me",
+        "class": "android.widget.CheckBox",
+        "checkable": "true" as any,
+        "checked": "true" as any
+      });
+
+      let observeCallCount = 0;
+      fakeObserve.setResultFactory(() => {
+        observeCallCount++;
+        if (observeCallCount <= 1) {
+          return createObserveResult(initialHierarchy);
+        }
+        return createObserveResult(updatedHierarchy);
+      });
       fakeFieldTypeDetector.setFieldType("remember_me", "checkbox");
-      fakeFieldTypeDetector.setChecked("remember_me", false);
 
       const setUIState = createSetUIState();
       const result = await setUIState.execute({
-        fields: [{ selector: { elementId: "remember_me" }, selected: true }],
-        verifyAfter: false
+        fields: [{ selector: { elementId: "remember_me" }, selected: true }]
       });
 
       expect(result.success).toBe(true);
@@ -179,20 +203,32 @@ describe("SetUIState", () => {
 
   describe("toggle handling", () => {
     test("taps toggle when state needs to change", async () => {
-      const hierarchy = createHierarchyWithElement({
+      const initialHierarchy = createHierarchyWithElement({
         "resource-id": "dark_mode",
         "class": "android.widget.Switch",
         "checkable": "true" as any,
         "checked": "true" as any
       });
-      fakeObserve.setResult(createObserveResult(hierarchy));
+      const updatedHierarchy = createHierarchyWithElement({
+        "resource-id": "dark_mode",
+        "class": "android.widget.Switch",
+        "checkable": "true" as any,
+        "checked": "false" as any
+      });
+
+      let observeCallCount = 0;
+      fakeObserve.setResultFactory(() => {
+        observeCallCount++;
+        if (observeCallCount <= 1) {
+          return createObserveResult(initialHierarchy);
+        }
+        return createObserveResult(updatedHierarchy);
+      });
       fakeFieldTypeDetector.setFieldType("dark_mode", "toggle");
-      fakeFieldTypeDetector.setChecked("dark_mode", true);
 
       const setUIState = createSetUIState();
       const result = await setUIState.execute({
-        fields: [{ selector: { elementId: "dark_mode" }, selected: false }],
-        verifyAfter: false
+        fields: [{ selector: { elementId: "dark_mode" }, selected: false }]
       });
 
       expect(result.success).toBe(true);
@@ -206,19 +242,30 @@ describe("SetUIState", () => {
 
   describe("dropdown handling", () => {
     test("opens dropdown and selects value", async () => {
-      const hierarchy = createHierarchyWithElement({
+      const initialHierarchy = createHierarchyWithElement({
         "resource-id": "country",
         "text": "Select Country",
         "class": "android.widget.Spinner"
       });
-      fakeObserve.setResult(createObserveResult(hierarchy));
+      const updatedHierarchy = createHierarchyWithElement({
+        "resource-id": "country",
+        "text": "United States",
+        "class": "android.widget.Spinner"
+      });
+
+      let observeCallCount = 0;
+      fakeObserve.setResultFactory(() => {
+        observeCallCount++;
+        if (observeCallCount <= 1) {
+          return createObserveResult(initialHierarchy);
+        }
+        return createObserveResult(updatedHierarchy);
+      });
       fakeFieldTypeDetector.setFieldType("country", "dropdown");
-      fakeFieldTypeDetector.setTextValue("country", "Select Country");
 
       const setUIState = createSetUIState();
       const result = await setUIState.execute({
-        fields: [{ selector: { elementId: "country" }, value: "United States" }],
-        verifyAfter: false
+        fields: [{ selector: { elementId: "country" }, value: "United States" }]
       });
 
       expect(result.success).toBe(true);
@@ -235,35 +282,26 @@ describe("SetUIState", () => {
 
   describe("scroll to find", () => {
     test("scrolls to find element when not visible", async () => {
-      // First observation has no element
+      // First observation has no element, after scroll it appears
       let callCount = 0;
       fakeObserve.setResultFactory(() => {
         callCount++;
-        if (callCount === 1) {
+        if (callCount <= 1) {
           return createObserveResult({ hierarchy: { node: [] } });
         }
         return createObserveResult(createHierarchyWithElement({
           "resource-id": "hidden_field",
-          "text": "",
+          "text": "found!",
           "class": "android.widget.EditText"
         }));
       });
 
       fakeFieldTypeDetector.setFieldType("hidden_field", "text");
-
-      // Configure swipe to find element
-      fakeSwipe.setElementAppearsAfterSwipe("hidden_field", {
-        "bounds": { left: 0, top: 0, right: 100, bottom: 50 },
-        "resource-id": "hidden_field",
-        "text": "",
-        "class": "android.widget.EditText"
-      });
+      fakeFieldTypeDetector.setTextValue("hidden_field", "found!");
 
       const setUIState = createSetUIState();
       const result = await setUIState.execute({
-        fields: [{ selector: { elementId: "hidden_field" }, value: "found!" }],
-        scrollToFind: true,
-        verifyAfter: false
+        fields: [{ selector: { elementId: "hidden_field" }, value: "found!" }]
       });
 
       expect(result.success).toBe(true);
@@ -271,20 +309,27 @@ describe("SetUIState", () => {
     });
 
     test("respects scrollDirection option", async () => {
-      fakeObserve.setResult(createObserveResult({ hierarchy: { node: [] } }));
-
-      fakeSwipe.setElementAppearsAfterSwipe("field", {
-        "bounds": { left: 0, top: 0, right: 100, bottom: 50 },
-        "resource-id": "field",
-        "class": "android.widget.EditText"
+      // First observation: empty, second: element appears after scroll
+      let callCount = 0;
+      fakeObserve.setResultFactory(() => {
+        callCount++;
+        if (callCount <= 1) {
+          return createObserveResult({ hierarchy: { node: [] } });
+        }
+        return createObserveResult(createHierarchyWithElement({
+          "resource-id": "field",
+          "text": "test",
+          "class": "android.widget.EditText"
+        }));
       });
+
+      fakeFieldTypeDetector.setFieldType("field", "text");
+      fakeFieldTypeDetector.setTextValue("field", "test");
 
       const setUIState = createSetUIState();
       await setUIState.execute({
         fields: [{ selector: { elementId: "field" }, value: "test" }],
-        scrollToFind: true,
-        scrollDirection: "up",
-        verifyAfter: false
+        scrollDirection: "up"
       });
 
       // First scroll should be in the specified direction
@@ -312,9 +357,7 @@ describe("SetUIState", () => {
 
       const setUIState = createSetUIState();
       const result = await setUIState.execute({
-        fields: [{ selector: { elementId: "field" }, value: "test" }],
-        maxRetries: 3,
-        verifyAfter: false
+        fields: [{ selector: { elementId: "field" }, value: "test" }]
       });
 
       expect(result.success).toBe(false);
@@ -323,7 +366,7 @@ describe("SetUIState", () => {
     });
 
     test("refreshes view hierarchy between retries when element not found", async () => {
-      // Element appears after first attempt (simulating async load)
+      // Element appears after first call (simulating async load)
       let observeCallCount = 0;
       fakeObserve.setResultFactory(() => {
         observeCallCount++;
@@ -334,25 +377,21 @@ describe("SetUIState", () => {
         // Subsequent calls: element appears
         return createObserveResult(createHierarchyWithElement({
           "resource-id": "async_field",
-          "text": "",
+          "text": "loaded!",
           "class": "android.widget.EditText"
         }));
       });
 
       fakeFieldTypeDetector.setFieldType("async_field", "text");
+      fakeFieldTypeDetector.setTextValue("async_field", "loaded!");
 
       const setUIState = createSetUIState();
       const result = await setUIState.execute({
-        fields: [{ selector: { elementId: "async_field" }, value: "loaded!" }],
-        maxRetries: 3,
-        scrollToFind: false,  // Disable scroll to test hierarchy refresh
-        verifyAfter: false
+        fields: [{ selector: { elementId: "async_field" }, value: "loaded!" }]
       });
 
       expect(result.success).toBe(true);
       expect(result.fields[0].success).toBe(true);
-      // Should have taken multiple attempts
-      expect(result.fields[0].attempts).toBeGreaterThan(1);
       // Observe should have been called multiple times to refresh hierarchy
       expect(observeCallCount).toBeGreaterThan(1);
     });
@@ -381,56 +420,74 @@ describe("SetUIState", () => {
         fields: [
           { selector: { elementId: "field1" }, value: "test1" },
           { selector: { elementId: "field2" }, value: "test2" }
-        ],
-        maxRetries: 1,
-        verifyAfter: false
+        ]
       });
 
       expect(result.success).toBe(false);
-      // Only first field should be processed
-      expect(result.fields).toHaveLength(1);
+      // field1 processed (failed after 3 retries)
+      expect(result.fields[0].success).toBe(false);
+      expect(result.fields[0].attempts).toBe(3);
       expect(result.error).toContain("Failed to tap");
     });
   });
 
-  describe("sensitive fields", () => {
-    test("skips verification for sensitive fields", async () => {
+  describe("password fields", () => {
+    test("auto-detects password fields and skips verification", async () => {
       fakeObserve.setResult(createObserveResult(createHierarchyWithElement({
         "resource-id": "password",
         "text": "",
-        "class": "android.widget.EditText"
+        "class": "android.widget.EditText",
+        "password": "true"
       })));
 
       fakeFieldTypeDetector.setFieldType("password", "text");
+      fakeFieldTypeDetector.setIsPasswordField("password", true);
 
       const setUIState = createSetUIState();
       const result = await setUIState.execute({
-        fields: [{ selector: { elementId: "password" }, value: "secret123", sensitive: true }],
-        verifyAfter: true
+        fields: [{ selector: { elementId: "password" }, value: "secret123" }]
       });
 
       expect(result.success).toBe(true);
-      // The field should NOT have verified=true because it's sensitive
+      // The field should NOT have verified=true because it's a password
       expect(result.fields[0].verified).toBeUndefined();
     });
   });
 
   describe("multiple fields", () => {
-    test("processes multiple fields in order", async () => {
-      const hierarchy: ViewHierarchyResult = {
+    test("processes fields in screen order", async () => {
+      const initialHierarchy: ViewHierarchyResult = {
         hierarchy: {
           node: [
             { $: { "bounds": "[0,0][100,50]", "resource-id": "username", "text": "", "class": "android.widget.EditText" } },
-            { $: { "bounds": "[0,60][100,110]", "resource-id": "password", "text": "", "class": "android.widget.EditText" } },
+            { $: { "bounds": "[0,60][100,110]", "resource-id": "password", "text": "", "class": "android.widget.EditText", "password": "true" } },
             { $: { "bounds": "[0,120][100,170]", "resource-id": "remember", "class": "android.widget.CheckBox", "checkable": "true", "checked": "false" } }
           ]
         }
       };
-      fakeObserve.setResult(createObserveResult(hierarchy));
+      const updatedHierarchy: ViewHierarchyResult = {
+        hierarchy: {
+          node: [
+            { $: { "bounds": "[0,0][100,50]", "resource-id": "username", "text": "user@test.com", "class": "android.widget.EditText" } },
+            { $: { "bounds": "[0,60][100,110]", "resource-id": "password", "text": "", "class": "android.widget.EditText", "password": "true" } },
+            { $: { "bounds": "[0,120][100,170]", "resource-id": "remember", "class": "android.widget.CheckBox", "checkable": "true", "checked": "true" } }
+          ]
+        }
+      };
+
+      let observeCallCount = 0;
+      fakeObserve.setResultFactory(() => {
+        observeCallCount++;
+        if (observeCallCount <= 1) {
+          return createObserveResult(initialHierarchy);
+        }
+        return createObserveResult(updatedHierarchy);
+      });
+
       fakeFieldTypeDetector.setFieldType("username", "text");
       fakeFieldTypeDetector.setFieldType("password", "text");
       fakeFieldTypeDetector.setFieldType("remember", "checkbox");
-      fakeFieldTypeDetector.setChecked("remember", false);
+      fakeFieldTypeDetector.setIsPasswordField("password", true);
 
       const setUIState = createSetUIState();
       const result = await setUIState.execute({
@@ -438,8 +495,7 @@ describe("SetUIState", () => {
           { selector: { elementId: "username" }, value: "user@test.com" },
           { selector: { elementId: "password" }, value: "pass123" },
           { selector: { elementId: "remember" }, selected: true }
-        ],
-        verifyAfter: false
+        ]
       });
 
       expect(result.success).toBe(true);
@@ -451,25 +507,102 @@ describe("SetUIState", () => {
       expect(inputCalls[0].text).toBe("user@test.com");
       expect(inputCalls[1].text).toBe("pass123");
     });
+
+    test("processes fields in screen order regardless of provided order", async () => {
+      const initialHierarchy: ViewHierarchyResult = {
+        hierarchy: {
+          node: [
+            { $: { "bounds": "[0,0][100,50]", "resource-id": "top_field", "text": "", "class": "android.widget.EditText" } },
+            { $: { "bounds": "[0,200][100,250]", "resource-id": "bottom_field", "text": "", "class": "android.widget.EditText" } }
+          ]
+        }
+      };
+      const updatedHierarchy: ViewHierarchyResult = {
+        hierarchy: {
+          node: [
+            { $: { "bounds": "[0,0][100,50]", "resource-id": "top_field", "text": "first", "class": "android.widget.EditText" } },
+            { $: { "bounds": "[0,200][100,250]", "resource-id": "bottom_field", "text": "second", "class": "android.widget.EditText" } }
+          ]
+        }
+      };
+
+      let observeCallCount = 0;
+      fakeObserve.setResultFactory(() => {
+        observeCallCount++;
+        if (observeCallCount <= 1) {
+          return createObserveResult(initialHierarchy);
+        }
+        return createObserveResult(updatedHierarchy);
+      });
+
+      fakeFieldTypeDetector.setFieldType("top_field", "text");
+      fakeFieldTypeDetector.setFieldType("bottom_field", "text");
+
+      const setUIState = createSetUIState();
+      const result = await setUIState.execute({
+        fields: [
+          // Provided in reverse screen order
+          { selector: { elementId: "bottom_field" }, value: "second" },
+          { selector: { elementId: "top_field" }, value: "first" }
+        ]
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.fields).toHaveLength(2);
+
+      // Even though bottom_field was listed first, top_field (bounds.top=0) should be filled first
+      const inputCalls = fakeInput.getCalls();
+      expect(inputCalls[0].text).toBe("first");   // top_field processed first
+      expect(inputCalls[1].text).toBe("second");   // bottom_field processed second
+    });
   });
 
   describe("text selector", () => {
     test("finds element by text selector", async () => {
-      const hierarchy = createHierarchyWithElement({
+      const initialHierarchy = createHierarchyWithElement({
         "text": "Username",
+        "content-desc": "Username",
         "class": "android.widget.EditText"
       });
-      fakeObserve.setResult(createObserveResult(hierarchy));
+      const updatedHierarchy = createHierarchyWithElement({
+        "text": "john",
+        "content-desc": "Username",
+        "class": "android.widget.EditText"
+      });
+
+      let observeCallCount = 0;
+      fakeObserve.setResultFactory(() => {
+        observeCallCount++;
+        if (observeCallCount <= 1) {
+          return createObserveResult(initialHierarchy);
+        }
+        return createObserveResult(updatedHierarchy);
+      });
       fakeFieldTypeDetector.setFieldType("Username", "text");
 
       const setUIState = createSetUIState();
       const result = await setUIState.execute({
-        fields: [{ selector: { text: "Username" }, value: "john" }],
-        verifyAfter: false
+        fields: [{ selector: { text: "Username" }, value: "john" }]
       });
 
       expect(result.success).toBe(true);
       expect(result.fields[0].success).toBe(true);
+    });
+  });
+
+  describe("unprocessed fields", () => {
+    test("reports unprocessed fields when not found after scrolling", async () => {
+      // Element never appears
+      fakeObserve.setResult(createObserveResult({ hierarchy: { node: [] } }));
+
+      const setUIState = createSetUIState();
+      const result = await setUIState.execute({
+        fields: [{ selector: { elementId: "nonexistent" }, value: "test" }]
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("Fields not found after scrolling");
+      expect(result.error).toContain("nonexistent");
     });
   });
 });


### PR DESCRIPTION
## Summary
- Remove `sensitive`, `maxRetries`, `verifyAfter`, `scrollToFind` options from setUIState API — these are now hardcoded or auto-detected
- Add `isPasswordField()` to `FieldTypeDetector` for automatic password field detection via `element.password`
- Rewrite `SetUIState.execute()` to process fields in screen order (sorted by `bounds.top`) instead of caller-provided order, scrolling through the form as needed

## Test Plan
- [x] `bun run build` passes with no type errors
- [x] `bun test --bail` — all 2754 tests pass
- [x] New `isPasswordField` tests cover `true`, `"true"`, `false`, `"false"`, `undefined`
- [x] New SetUIState tests for screen-order processing, password auto-detection, and unprocessed field reporting

🤖 Generated with [Claude Code](https://claude.com/claude-code)