### PR TITLE
test(junit-runner): tighten multi-device assertions per PR feedback

### DIFF
--- a/android/junit-runner/src/test/kotlin/dev/jasonpearson/automobile/junit/MultiDevicePlanTest.kt
+++ b/android/junit-runner/src/test/kotlin/dev/jasonpearson/automobile/junit/MultiDevicePlanTest.kt
@@ -275,11 +275,15 @@ class TwoDeviceCriticalSectionPlanTest {
       decodePlanContent(
         capturingClient.capturedArguments!!["planContent"]!!.jsonPrimitive.content
       )
-    // Scope the device assertions to only the content inside the criticalSection step so that
-    // device labels on top-level launchApp/terminateApp steps don't mask missing sub-step devices.
-    val criticalSectionBlock =
-      decoded.substringAfter("criticalSection", missingDelimiterValue = "")
-    assertTrue("criticalSection block should be present", criticalSectionBlock.isNotEmpty())
+    // Scope device assertions strictly to the criticalSection step's own params block.
+    // Search for "tool: criticalSection" (not just "criticalSection") to skip any occurrence
+    // in the plan name or description. Then trim at "\n\n  - tool:" which is the blank-line
+    // separator before the next top-level step, ensuring trailing terminateApp "device:" labels
+    // cannot satisfy the assertion if criticalSection sub-steps lose their device assignments.
+    val afterCriticalSection =
+      decoded.substringAfter("tool: criticalSection", missingDelimiterValue = "")
+    assertTrue("criticalSection tool step should be present", afterCriticalSection.isNotEmpty())
+    val criticalSectionBlock = afterCriticalSection.substringBefore("\n\n  - tool:")
     assertTrue(
       "CriticalSection sub-steps should target device A",
       criticalSectionBlock.contains("device: A"),


### PR DESCRIPTION
## Summary
- Scopes criticalSection sub-step device assertions to the YAML block after the `criticalSection` key — top-level `launchApp`/`terminateApp` device labels can no longer satisfy the check, so regressions in criticalSection serialization will be caught
- Uses device-neutral error messages in both failure tests (`"Assertion failed: expected content not visible"` and `"Timeout waiting for input element"`) so the device-label assertions verify that `failedStep.device` drives the formatted failure message, not the embedded error string

## Test Plan
- [x] All 9 multi-device tests pass
- [x] Full `junit-runner` test suite passes with no regressions

Follows up on #1312.

🤖 Generated with [Claude Code](https://claude.com/claude-code)