### PR TITLE
fix: eliminate real disk I/O in screenshot resource test to prevent flakiness

### DIFF
--- a/src/server/observationResources.ts
+++ b/src/server/observationResources.ts
@@ -3,7 +3,22 @@ import { RealObserveScreen } from "../features/observe/ObserveScreen";
 import { logger } from "../utils/logger";
 import { stringifyToolResponse } from "../utils/toolUtils";
 import { ScreenshotJobTracker } from "../utils/ScreenshotJobTracker";
-import * as fs from "fs/promises";
+import * as realFs from "fs/promises";
+
+export interface ScreenshotFileSystem {
+  stat(path: string): Promise<{ isFile(): boolean }>;
+  readFile(path: string): Promise<Buffer>;
+}
+
+let screenshotFileSystem: ScreenshotFileSystem = realFs;
+
+export function setScreenshotFileSystem(fs: ScreenshotFileSystem): void {
+  screenshotFileSystem = fs;
+}
+
+export function resetScreenshotFileSystem(): void {
+  screenshotFileSystem = realFs;
+}
 
 // Resource URIs
 export const RESOURCE_URIS = {
@@ -19,7 +34,7 @@ async function getLatestScreenshotPath(): Promise<string | undefined> {
       return undefined;
     }
 
-    const fileStat = await fs.stat(screenshotPath);
+    const fileStat = await screenshotFileSystem.stat(screenshotPath);
     if (!fileStat.isFile()) {
       return undefined;
     }
@@ -103,7 +118,7 @@ async function getLatestScreenshot(): Promise<ResourceContent> {
     }
 
     // Read the screenshot file and convert to base64
-    const imageBuffer = await fs.readFile(screenshotPath);
+    const imageBuffer = await screenshotFileSystem.readFile(screenshotPath);
     const base64Image = imageBuffer.toString("base64");
 
     // Determine mime type from file extension

--- a/test/server/resources/read.test.ts
+++ b/test/server/resources/read.test.ts
@@ -5,6 +5,7 @@ import * as fs from "fs/promises";
 import * as path from "path";
 import { z } from "zod";
 import { ScreenshotJobTracker } from "../../../src/utils/ScreenshotJobTracker";
+import { setScreenshotFileSystem, resetScreenshotFileSystem } from "../../../src/server/observationResources";
 import { FakeAdbExecutor } from "../../fakes/FakeAdbExecutor";
 import { BootedDevice } from "../../../src/models/DeviceInfo";
 import { FakeTimer } from "../../fakes/FakeTimer";
@@ -71,6 +72,7 @@ describe("MCP Resources Read", () => {
   afterEach(() => {
     RealObserveScreen.clearCache();
     ScreenshotJobTracker.resetTimer();
+    resetScreenshotFileSystem();
   });
 
   afterAll(async () => {
@@ -167,6 +169,14 @@ describe("MCP Resources Read", () => {
     const fakeTimer = new FakeTimer();
     ScreenshotJobTracker.setTimer(fakeTimer);
 
+    const fakeImageData = Buffer.from("fake screenshot data");
+    const screenshotPath = path.join("/tmp/auto-mobile", "screenshots", `screenshot_fake.png`);
+
+    setScreenshotFileSystem({
+      stat: async (_p: string) => ({ isFile: () => true }),
+      readFile: async (_p: string) => fakeImageData
+    });
+
     const mockDevice: BootedDevice = {
       deviceId: "test-device",
       name: "Test Device",
@@ -178,11 +188,6 @@ describe("MCP Resources Read", () => {
     (RealObserveScreen as any).latestScreenshotPath = null;
     (RealObserveScreen as any).latestScreenshotError = null;
     (RealObserveScreen as any).latestScreenshotTimestamp = null;
-
-    const screenshotDir = path.join("/tmp/auto-mobile", "screenshots");
-    await fs.mkdir(screenshotDir, { recursive: true });
-    const screenshotPath = path.join(screenshotDir, `screenshot_${Date.now()}.png`);
-    await fs.writeFile(screenshotPath, Buffer.from("fake screenshot data"));
 
     ScreenshotJobTracker.startJob(mockDevice.deviceId, async signal => {
       return new Promise(resolve => {
@@ -222,8 +227,6 @@ describe("MCP Resources Read", () => {
     expect(content.mimeType).toBe("image/png");
     expect(content.blob).toBeDefined();
     expect(content.blob!.length).toBeGreaterThan(0);
-
-    await fs.unlink(screenshotPath);
   });
 
   test("reading non-existent resource should throw error", async function() {


### PR DESCRIPTION
## Summary
- The test `"reading latest screenshot waits for pending capture when none cached"` was flaky on CI (seen in run #22141146548)
- Root cause: `observationResources.ts` called real `fs.stat()` + `fs.readFile()` while the test's `resolveWithFakeTimer` pump has a 2000-step `setImmediate` limit (~60ms) — on a loaded CI machine running 214 test files concurrently, those two I/O calls consumed the full budget
- Fix: add a `ScreenshotFileSystem` interface to `observationResources.ts` with `setScreenshotFileSystem`/`resetScreenshotFileSystem` exports; the test injects a synchronous fake so the pump completes in ~2–3 steps instead of 2000+

## Test Plan
- [x] `bun test test/server/resources/read.test.ts` passes (4/4)
- [x] `bun test` passes (2755 pass, 2 skip, 0 fail across 214 files)
- [x] `bun run lint` clean
- [x] `bun run build` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)