### PR TITLE
feat(ide-plugin): surface Compose recomposition counts in performance panel

### DIFF
--- a/android/ide-plugin/src/main/kotlin/dev/jasonpearson/automobile/ide/AutoMobileToolWindowContent.kt
+++ b/android/ide-plugin/src/main/kotlin/dev/jasonpearson/automobile/ide/AutoMobileToolWindowContent.kt
@@ -230,6 +230,7 @@ fun AutoMobileToolWindowContent() {
   var currentJankFrames by remember { mutableStateOf<Int?>(null) }
   var currentMemoryMb by remember { mutableStateOf<Float?>(null) }
   var currentTouchLatencyMs by remember { mutableStateOf<Float?>(null) }
+  var currentRecompositionRate by remember { mutableStateOf<Float?>(null) }
   var perfUpdateCounter by remember { mutableIntStateOf(0) }
 
   // Track failure counts by type for collapsed Failures panel
@@ -462,6 +463,9 @@ fun AutoMobileToolWindowContent() {
           currentJankFrames = update.jankFrames
           currentMemoryMb = update.memoryUsageMb
           currentTouchLatencyMs = update.touchLatencyMs
+          if (update.recompositionRate != null) {
+              currentRecompositionRate = update.recompositionRate
+          }
           perfUpdateCounter++
       }
   }
@@ -476,6 +480,7 @@ fun AutoMobileToolWindowContent() {
               currentJankFrames = null
               currentMemoryMb = null
               currentTouchLatencyMs = null
+              currentRecompositionRate = null
           }
       }
   }
@@ -882,6 +887,7 @@ fun AutoMobileToolWindowContent() {
                 currentJankFrames = currentJankFrames,
                 currentMemoryMb = currentMemoryMb,
                 currentTouchLatencyMs = currentTouchLatencyMs,
+                currentRecompositionRate = currentRecompositionRate,
                 updateCounter = perfUpdateCounter,
                 onNavigateToScreen = { screenName ->
                     showNavigationView = true

--- a/android/ide-plugin/src/main/kotlin/dev/jasonpearson/automobile/ide/daemon/ObservationStreamClient.kt
+++ b/android/ide-plugin/src/main/kotlin/dev/jasonpearson/automobile/ide/daemon/ObservationStreamClient.kt
@@ -311,6 +311,8 @@ class ObservationStreamClient {
                         timeToInteractiveMs = perfData.timeToInteractiveMs,
                         screenName = perfData.screenName,
                         isResponsive = perfData.isResponsive,
+                        recompositionCount = perfData.recompositionCount,
+                        recompositionRate = perfData.recompositionRate,
                     )
                     _performanceUpdates.tryEmit(update)
                     log.info("Emitted performance update to flow")
@@ -456,6 +458,8 @@ data class PerformanceStreamData(
     val timeToInteractiveMs: Float? = null,
     val screenName: String? = null,
     val isResponsive: Boolean = true,
+    val recompositionCount: Int? = null,
+    val recompositionRate: Float? = null,
 )
 
 data class PerformanceStreamUpdate(
@@ -471,6 +475,8 @@ data class PerformanceStreamUpdate(
     val timeToInteractiveMs: Float?,
     val screenName: String?,
     val isResponsive: Boolean,
+    val recompositionCount: Int?,
+    val recompositionRate: Float?,
 )
 
 sealed class StreamConnectionState {

--- a/android/ide-plugin/src/main/kotlin/dev/jasonpearson/automobile/ide/performance/PerformanceDashboard.kt
+++ b/android/ide-plugin/src/main/kotlin/dev/jasonpearson/automobile/ide/performance/PerformanceDashboard.kt
@@ -62,12 +62,13 @@ fun PerformanceDashboard(
     initialJankFrames: Int? = null,
     initialMemoryMb: Float? = null,
     initialTouchLatencyMs: Float? = null,
+    initialRecompositionRate: Float? = null,
 ) {
     var currentScreen by remember { mutableStateOf(PerformanceScreen.Overview) }
     var selectedMetric by remember { mutableStateOf<PerformanceMetric?>(null) }
 
     // Build initial run from passed metrics to avoid empty state flicker
-    val initialRun = remember(initialFps, initialFrameTimeMs, initialJankFrames, initialMemoryMb, initialTouchLatencyMs) {
+    val initialRun = remember(initialFps, initialFrameTimeMs, initialJankFrames, initialMemoryMb, initialTouchLatencyMs, initialRecompositionRate) {
         if (initialFps != null || initialMemoryMb != null) {
             val timestamp = System.currentTimeMillis()
             PerformanceRun(
@@ -141,6 +142,19 @@ fun PerformanceDashboard(
                             thresholdCritical = 200f,
                             trend = MetricTrend.Stable,
                             history = listOf(MetricDataPoint(timestamp, initialTouchLatencyMs, null)),
+                        ))
+                    }
+                    if (initialRecompositionRate != null) {
+                        add(PerformanceMetric(
+                            id = "recomposition",
+                            type = MetricType.RecompositionCount,
+                            name = "Recompositions",
+                            currentValue = initialRecompositionRate,
+                            unit = "recomp/s",
+                            thresholdWarning = 10f,
+                            thresholdCritical = 50f,
+                            trend = MetricTrend.Stable,
+                            history = listOf(MetricDataPoint(timestamp, initialRecompositionRate, null)),
                         ))
                     }
                 },
@@ -263,6 +277,20 @@ fun PerformanceDashboard(
                             history = listOf(MetricDataPoint(update.timestamp, tti, update.screenName)),
                         ))
                     }
+                    // Add recomposition rate if available
+                    update.recompositionRate?.let { rate ->
+                        add(PerformanceMetric(
+                            id = "recomposition",
+                            type = MetricType.RecompositionCount,
+                            name = "Recompositions",
+                            currentValue = rate,
+                            unit = "recomp/s",
+                            thresholdWarning = 10f,
+                            thresholdCritical = 50f,
+                            trend = MetricTrend.Stable,
+                            history = listOf(MetricDataPoint(update.timestamp, rate, update.screenName)),
+                        ))
+                    }
                 }
             } else {
                 // Update existing metrics
@@ -325,6 +353,18 @@ fun PerformanceDashboard(
                                 trend = calculateTrend(metric.currentValue, tti),
                             )
                         }
+                        MetricType.RecompositionCount -> {
+                            val rate = update.recompositionRate ?: metric.currentValue
+                            metric.copy(
+                                currentValue = rate,
+                                history = (metric.history + MetricDataPoint(
+                                    timestamp = update.timestamp,
+                                    value = rate,
+                                    screenName = update.screenName,
+                                )).takeLast(120),
+                                trend = calculateTrend(metric.currentValue, rate),
+                            )
+                        }
                         else -> metric
                     }
                 }
@@ -357,6 +397,20 @@ fun PerformanceDashboard(
                             thresholdCritical = 1500f,
                             trend = MetricTrend.Stable,
                             history = listOf(MetricDataPoint(update.timestamp, update.timeToInteractiveMs!!, update.screenName)),
+                        ))
+                    }
+                    // Add recomposition rate if it becomes available and doesn't exist
+                    if (!existingMetricTypes.contains(MetricType.RecompositionCount) && update.recompositionRate != null) {
+                        add(PerformanceMetric(
+                            id = "recomposition",
+                            type = MetricType.RecompositionCount,
+                            name = "Recompositions",
+                            currentValue = update.recompositionRate!!,
+                            unit = "recomp/s",
+                            thresholdWarning = 10f,
+                            thresholdCritical = 50f,
+                            trend = MetricTrend.Stable,
+                            history = listOf(MetricDataPoint(update.timestamp, update.recompositionRate!!, update.screenName)),
                         ))
                     }
                 }
@@ -661,6 +715,7 @@ private fun getFixedYAxisRange(metricType: MetricType): Pair<Float, Float> {
         MetricType.Jank -> 0f to 30f // 30 missed frames
         MetricType.TimeToInteractive -> 0f to 5000f // 5 seconds
         MetricType.TimeToFirstFrame -> 0f to 5000f // 5 seconds
+        MetricType.RecompositionCount -> 0f to 200f // 200 recomp/s
     }
 }
 

--- a/android/ide-plugin/src/main/kotlin/dev/jasonpearson/automobile/ide/performance/PerformanceModels.kt
+++ b/android/ide-plugin/src/main/kotlin/dev/jasonpearson/automobile/ide/performance/PerformanceModels.kt
@@ -5,13 +5,14 @@ enum class HealthStatus { Healthy, Warning, Critical }
 
 // Types of performance metrics
 enum class MetricType {
-    TouchLatency,      // Time from touch to first frame response
-    TimeToFirstFrame,  // How quickly the first screen renders
-    TimeToInteractive, // When the UI becomes responsive
-    Jank,              // Missed frames / UI stuttering
-    FPS,               // Frames per second time series
-    FrameTime,         // Time to render a single frame (ms)
-    Memory,            // Memory usage in MB
+    TouchLatency,       // Time from touch to first frame response
+    TimeToFirstFrame,   // How quickly the first screen renders
+    TimeToInteractive,  // When the UI becomes responsive
+    Jank,               // Missed frames / UI stuttering
+    FPS,                // Frames per second time series
+    FrameTime,          // Time to render a single frame (ms)
+    Memory,             // Memory usage in MB
+    RecompositionCount, // Compose recompositions per second
 }
 
 data class PerformanceMetric(
@@ -111,6 +112,10 @@ object PerformanceThresholds {
     // CPU usage thresholds in percent (higher is worse)
     const val CPU_WARNING_PERCENT = 50f
     const val CPU_CRITICAL_PERCENT = 80f
+
+    // Recomposition rate thresholds in recomp/s (higher is worse)
+    const val RECOMPOSITION_WARNING = 10f
+    const val RECOMPOSITION_CRITICAL = 50f
 }
 
 // Mock data for development

--- a/android/ide-plugin/src/main/kotlin/dev/jasonpearson/automobile/ide/performance/PerformanceSummary.kt
+++ b/android/ide-plugin/src/main/kotlin/dev/jasonpearson/automobile/ide/performance/PerformanceSummary.kt
@@ -30,11 +30,13 @@ fun PerformanceSummary(
     currentJankFrames: Int?,
     currentMemoryMb: Float?,
     currentTouchLatencyMs: Float?,
+    currentRecompositionRate: Float? = null,
     updateCounter: Int = 0,
     modifier: Modifier = Modifier,
 ) {
     val hasAnyMetric = currentFps != null || currentFrameTimeMs != null ||
-        currentJankFrames != null || currentMemoryMb != null || currentTouchLatencyMs != null
+        currentJankFrames != null || currentMemoryMb != null || currentTouchLatencyMs != null ||
+        currentRecompositionRate != null
 
     // Flashing indicator color alternates between green and blue on each update
     val indicatorColor = if (updateCounter % 2 == 0) {
@@ -109,6 +111,16 @@ fun PerformanceSummary(
                 else -> Color(0xFFE53935) // Red
             }
             MetricItem(value = "${currentTouchLatencyMs.toInt()}", unit = "lat", color = latencyColor)
+        }
+
+        // Recomposition rate indicator
+        if (currentRecompositionRate != null) {
+            val recompColor = when {
+                currentRecompositionRate <= 10f -> Color(0xFF4CAF50) // Green
+                currentRecompositionRate <= 50f -> Color(0xFFFF9800) // Orange
+                else -> Color(0xFFE53935) // Red
+            }
+            MetricItem(value = "${currentRecompositionRate.toInt()}", unit = "r/s", color = recompColor)
         }
 
         // Fallback when no metrics

--- a/android/ide-plugin/src/main/kotlin/dev/jasonpearson/automobile/ide/performance/PerformanceVerticalPanel.kt
+++ b/android/ide-plugin/src/main/kotlin/dev/jasonpearson/automobile/ide/performance/PerformanceVerticalPanel.kt
@@ -25,6 +25,7 @@ fun PerformanceVerticalPanel(
     currentJankFrames: Int?,
     currentMemoryMb: Float?,
     currentTouchLatencyMs: Float?,
+    currentRecompositionRate: Float? = null,
     updateCounter: Int = 0,
     onNavigateToScreen: (String) -> Unit = {},
     onNavigateToTest: (String) -> Unit = {},
@@ -47,6 +48,7 @@ fun PerformanceVerticalPanel(
                 currentJankFrames = currentJankFrames,
                 currentMemoryMb = currentMemoryMb,
                 currentTouchLatencyMs = currentTouchLatencyMs,
+                currentRecompositionRate = currentRecompositionRate,
                 updateCounter = updateCounter,
             )
         },
@@ -67,6 +69,7 @@ fun PerformanceVerticalPanel(
                 initialJankFrames = currentJankFrames,
                 initialMemoryMb = currentMemoryMb,
                 initialTouchLatencyMs = currentTouchLatencyMs,
+                initialRecompositionRate = currentRecompositionRate,
             )
         }
     }

--- a/src/daemon/deviceDataStreamSocketServer.ts
+++ b/src/daemon/deviceDataStreamSocketServer.ts
@@ -65,6 +65,10 @@ export interface PerformanceStreamData {
   screenName: string | null;
   /** Whether the app is considered responsive */
   isResponsive: boolean;
+  /** Total Compose recompositions since the last observation (null if no data) */
+  recompositionCount: number | null;
+  /** Compose recompositions per second rolling average (null if no data) */
+  recompositionRate: number | null;
 }
 
 /**

--- a/src/features/performance/PerformanceMonitor.ts
+++ b/src/features/performance/PerformanceMonitor.ts
@@ -7,6 +7,7 @@ import {
   PerformancePushSocketServer,
 } from "../../daemon/performancePushSocketServer";
 import { getDeviceDataStreamServer, PerformanceStreamData } from "../../daemon/deviceDataStreamSocketServer";
+import { RecompositionTracker } from "./RecompositionTracker";
 import { defaultAdbClientFactory, AdbClientFactory } from "../../utils/android-cmdline-tools/AdbClientFactory";
 import { SimCtlClient, SimCtl } from "../../utils/ios-cmdline-tools/SimCtlClient";
 import { execFile } from "child_process";
@@ -492,6 +493,7 @@ export class PerformanceMonitor {
 
     const observationServer = getDeviceDataStreamServer();
     if (observationServer) {
+      const recompositionSummary = RecompositionTracker.getInstance().getLatestSummary(device.packageName);
       const streamData: PerformanceStreamData = {
         fps: metrics.fps ?? 0,
         frameTimeMs: metrics.frameTimeMs ?? 0,
@@ -503,6 +505,8 @@ export class PerformanceMonitor {
         timeToInteractiveMs: metrics.ttiMs,
         screenName: null, // Could be enhanced with current activity
         isResponsive: data.health !== "critical",
+        recompositionCount: recompositionSummary?.totalRecompositions ?? null,
+        recompositionRate: recompositionSummary?.averagePerSecond ?? null,
       };
       observationServer.pushPerformanceUpdate(device.deviceId, streamData);
     }

--- a/src/features/performance/RecompositionTracker.ts
+++ b/src/features/performance/RecompositionTracker.ts
@@ -46,6 +46,7 @@ export class RecompositionTracker {
   private latestTotals = new Map<string, number>();
   private lastObservationAt: number | null = null;
   private lastInteractionAt: number | null = null;
+  private latestSummaryByPackage = new Map<string, RecompositionSummary>();
   private readonly parser = new DefaultElementParser();
   private timer: Timer;
 
@@ -58,6 +59,10 @@ export class RecompositionTracker {
       RecompositionTracker.instance = new RecompositionTracker();
     }
     return RecompositionTracker.instance;
+  }
+
+  getLatestSummary(packageName: string): RecompositionSummary | undefined {
+    return this.latestSummaryByPackage.get(packageName);
   }
 
   recordInteraction(): void {
@@ -89,6 +94,11 @@ export class RecompositionTracker {
 
     const summary = this.buildSummary(metrics, observationTimestamp);
     result.recompositionSummary = summary;
+
+    const packageName = result.activeWindow?.appId ?? result.viewHierarchy?.packageName;
+    if (packageName) {
+      this.latestSummaryByPackage.set(packageName, summary);
+    }
 
     this.latestTotals = new Map(metrics.map(entry => [entry.id, entry.total]));
     this.lastObservationTotals = new Map(this.latestTotals);


### PR DESCRIPTION
## Summary

- Adds Compose recomposition metrics (total count and rolling recomp/s rate) from the AutoMobile Android SDK to the IDE plugin's live performance panel
- Server side: `RecompositionTracker` caches the latest `RecompositionSummary` per package so `PerformanceMonitor` includes it in every 500ms `performance_update` push via the observation stream socket
- IDE plugin: new `RecompositionCount` metric type with warning/critical thresholds (10/50 recomp/s), metric card in the dashboard overview with sparkline, and a compact "r/s" indicator in the collapsed panel sidebar

## Test Plan

- [x] All 2709 TypeScript tests pass (`bun test`)
- [x] Android IDE plugin build succeeds (`./gradlew -p android :ide-plugin:build`)
- [x] Recomposition data flows: SDK → Accessibility Service → MCP observe → `RecompositionTracker` cache → `PerformanceMonitor` push → IDE plugin stream → dashboard metric card

🤖 Generated with [Claude Code](https://claude.com/claude-code)