### PR TITLE
fix(docs): improve mermaid chart contrast for day theme WCAG AA compliance

### DIFF
--- a/docs/design-docs/index.md
+++ b/docs/design-docs/index.md
@@ -54,9 +54,9 @@ flowchart TB
     CLITools --> Android
     CLITools --> iOS
 
-    classDef client fill:#FF3300,stroke-width:0px,color:white;
+    classDef client fill:#CC2200,stroke-width:0px,color:white;
     classDef mcp fill:#525FE1,stroke-width:0px,color:white;
-    classDef external fill:#00AA55,stroke-width:0px,color:white;
+    classDef external fill:#007A3D,stroke-width:0px,color:white;
     classDef device fill:#666666,stroke-width:0px,color:white;
 
     class Agent,IDE,CLI client;

--- a/docs/design-docs/mcp/a11y/index.md
+++ b/docs/design-docs/mcp/a11y/index.md
@@ -27,9 +27,9 @@ flowchart LR
     Scroll --> Agent
     Input --> Agent
 
-    classDef detect fill:#FF3300,stroke-width:0px,color:white;
+    classDef detect fill:#CC2200,stroke-width:0px,color:white;
     classDef adapt fill:#525FE1,stroke-width:0px,color:white;
-    classDef result fill:#00AA55,stroke-width:0px,color:white;
+    classDef result fill:#007A3D,stroke-width:0px,color:white;
 
     class Auto,Cache detect;
     class Tap,Scroll,Input adapt;

--- a/docs/design-docs/mcp/context-thresholds.md
+++ b/docs/design-docs/mcp/context-thresholds.md
@@ -134,7 +134,7 @@ flowchart LR
     C --> D{"Thresholds exceeded?"};
     D -->|"yes"| E["Fail workflow"];
     D -->|"no"| F["Complete workflow"];
-    classDef decision fill:#FF3300,stroke-width:0px,color:white;
+    classDef decision fill:#CC2200,stroke-width:0px,color:white;
     classDef logic fill:#525FE1,stroke-width:0px,color:white;
     classDef result stroke-width:0px;
     class A,B,C logic;
@@ -162,7 +162,7 @@ flowchart LR
     B --> C["Update scripts/context-thresholds.json"];
     C --> D["Commit changes<br/>with PR justification"];
     D --> E["Ensure CI passes<br/>with new thresholds"];
-    classDef decision fill:#FF3300,stroke-width:0px,color:white;
+    classDef decision fill:#CC2200,stroke-width:0px,color:white;
     classDef logic fill:#525FE1,stroke-width:0px,color:white;
     classDef result stroke-width:0px;
     class A,B,C logic;

--- a/docs/design-docs/mcp/nav/fingerprinting.md
+++ b/docs/design-docs/mcp/nav/fingerprinting.md
@@ -206,7 +206,7 @@ flowchart LR
     B --> C["Filter keyboard elements<br/>from hierarchy"];
     C --> D["Attempt cached<br/>navigation ID"];
     D --> E["Degrade confidence level"];
-    classDef decision fill:#FF3300,stroke-width:0px,color:white;
+    classDef decision fill:#CC2200,stroke-width:0px,color:white;
     classDef logic fill:#525FE1,stroke-width:0px,color:white;
     classDef result stroke-width:0px;
     class A,E result;

--- a/docs/design-docs/mcp/observe/vision-fallback.md
+++ b/docs/design-docs/mcp/observe/vision-fallback.md
@@ -25,7 +25,7 @@ flowchart LR
     C --> D{"Confidence high?"};
     D -->|"yes"| E["Return alternative selectors<br/>or navigation instructions"];
     D -->|"no"| F["Return detailed error<br/>with screen context"];
-    classDef decision fill:#FF3300,stroke-width:0px,color:white;
+    classDef decision fill:#CC2200,stroke-width:0px,color:white;
     classDef logic fill:#525FE1,stroke-width:0px,color:white;
     classDef result stroke-width:0px;
     class A,E,F result;

--- a/docs/design-docs/mcp/storage/index.md
+++ b/docs/design-docs/mcp/storage/index.md
@@ -22,7 +22,7 @@ flowchart TB
     SQLite -.->|"schema updates"| Migrations
     SQLite -.->|"metadata"| Snapshots
 
-    classDef runtime fill:#FF3300,stroke-width:0px,color:white;
+    classDef runtime fill:#CC2200,stroke-width:0px,color:white;
     classDef storage fill:#525FE1,stroke-width:0px,color:white;
 
     class NavGraph,Sessions,Config runtime;

--- a/docs/design-docs/mcp/storage/migrations.md
+++ b/docs/design-docs/mcp/storage/migrations.md
@@ -21,7 +21,7 @@ flowchart LR
     D -->|"no"| F{"src/db/migrations exists?"};
     F -->|"yes"| G["Use src/db/migrations<br/>(running from source)"];
     F -->|"no"| H["Throw error with checked paths"];
-    classDef decision fill:#FF3300,stroke-width:0px,color:white;
+    classDef decision fill:#CC2200,stroke-width:0px,color:white;
     classDef logic fill:#525FE1,stroke-width:0px,color:white;
     classDef result stroke-width:0px;
     class A,H result;

--- a/docs/design-docs/plat/android/ide-plugin/test-recording.md
+++ b/docs/design-docs/plat/android/ide-plugin/test-recording.md
@@ -20,7 +20,7 @@ flowchart LR
     A["Start recording (IDE)"] --> B["Perform interactions in app"];
     B --> C["Stop recording"];
     C --> D["Review and edit generated YAML plan"];
-    classDef decision fill:#FF3300,stroke-width:0px,color:white;
+    classDef decision fill:#CC2200,stroke-width:0px,color:white;
     classDef logic fill:#525FE1,stroke-width:0px,color:white;
     classDef result stroke-width:0px;
     class A,B,C logic;

--- a/docs/design-docs/plat/android/observe.md
+++ b/docs/design-docs/plat/android/observe.md
@@ -20,7 +20,7 @@
     C -->|"❌"| E["uiautomator dump"];
     D --> I["Return"]
     E --> I;
-    classDef decision fill:#FF3300,stroke-width:0px,color:white;
+    classDef decision fill:#CC2200,stroke-width:0px,color:white;
     classDef logic fill:#525FE1,stroke-width:0px,color:white;
     classDef result stroke-width:0px;
     class A,G,I result;
@@ -50,7 +50,7 @@
     F -->|"❌"| E;
     E --> H["Cache"];
     H --> I["Return New Hierarchy"];
-    classDef decision fill:#FF3300,stroke-width:0px,color:white;
+    classDef decision fill:#CC2200,stroke-width:0px,color:white;
     classDef logic fill:#525FE1,stroke-width:0px,color:white;
     classDef result stroke-width:0px;
     class A,G,I result;

--- a/docs/design-docs/plat/android/work-profiles.md
+++ b/docs/design-docs/plat/android/work-profiles.md
@@ -23,7 +23,7 @@ AutoMobile automatically detects and handles work profiles across all app manage
       B -->|"no"| D{"Running work profile exists?"};
       D -->|"yes"| E["Use first running<br/>work profile"];
       D -->|"no"| F["Use primary user<br/>(user 0)"];
-      classDef decision fill:#FF3300,stroke-width:0px,color:white;
+      classDef decision fill:#CC2200,stroke-width:0px,color:white;
       classDef logic fill:#525FE1,stroke-width:0px,color:white;
       classDef result stroke-width:0px;
       class A logic;


### PR DESCRIPTION
## Summary

- Replace `#FF3300` (orange-red, 3.67:1 contrast ratio) with `#CC2200` (5.53:1) across all mermaid diagrams
- Replace `#00AA55` (bright green, 3.05:1 contrast ratio) with `#007A3D` (5.46:1) in two diagrams
- Both failing colors used white text but did not meet the WCAG AA minimum of 4.5:1 in light/day rendering environments; the existing `#525FE1` (5.14:1) and `#666666` (5.74:1) already passed and were left unchanged

## Test Plan

- [ ] Visually verify mermaid diagrams render correctly in day theme
- [ ] Verify diagrams remain readable in night theme

🤖 Generated with [Claude Code](https://claude.com/claude-code)