### PR TITLE
feat(record): implement getevent+A11y dual-track Android recording

### DIFF
--- a/android/accessibility-service/src/main/kotlin/dev/jasonpearson/automobile/accessibilityservice/AutoMobileAccessibilityService.kt
+++ b/android/accessibility-service/src/main/kotlin/dev/jasonpearson/automobile/accessibilityservice/AutoMobileAccessibilityService.kt
@@ -115,6 +115,9 @@ class AutoMobileAccessibilityService : AccessibilityService() {
   }
   private var lastWindowClassName: String? = null
 
+  @Volatile
+  private var isRecording: Boolean = false
+
   // Job for collecting hierarchy flow results
   private var hierarchyFlowJob: Job? = null
 
@@ -786,6 +789,14 @@ class AutoMobileAccessibilityService : AccessibilityService() {
               onClearPreferences = { requestId, packageName, fileName ->
                 handleClearPreferences(requestId, packageName, fileName)
               },
+              onStartRecording = {
+                isRecording = true
+                Log.d(TAG, "Recording started")
+              },
+              onStopRecording = {
+                isRecording = false
+                Log.d(TAG, "Recording stopped")
+              },
           )
       webSocketServer.start()
       Log.d(TAG, "WebSocket server started on port 8765")
@@ -914,13 +925,18 @@ class AutoMobileAccessibilityService : AccessibilityService() {
 
       if (event.eventType == AccessibilityEvent.TYPE_WINDOW_STATE_CHANGED) {
         lastWindowClassName = event.className?.toString()
+        if (isRecording) recordInteractionEvent(event, "windowChange")
       }
 
       when (event.eventType) {
-        AccessibilityEvent.TYPE_VIEW_CLICKED -> recordInteractionEvent(event, "tap")
-        AccessibilityEvent.TYPE_VIEW_LONG_CLICKED -> recordInteractionEvent(event, "longPress")
-        AccessibilityEvent.TYPE_VIEW_TEXT_CHANGED -> recordInteractionEvent(event, "inputText")
-        AccessibilityEvent.TYPE_VIEW_SCROLLED -> recordInteractionEvent(event, "swipe")
+        AccessibilityEvent.TYPE_VIEW_CLICKED ->
+          if (isRecording) recordInteractionEvent(event, "tap")
+        AccessibilityEvent.TYPE_VIEW_LONG_CLICKED ->
+          if (isRecording) recordInteractionEvent(event, "longPress")
+        AccessibilityEvent.TYPE_VIEW_TEXT_CHANGED ->
+          if (isRecording) recordInteractionEvent(event, "inputText")
+        AccessibilityEvent.TYPE_VIEW_SCROLLED ->
+          if (isRecording) recordInteractionEvent(event, "swipe")
       }
 
       // Delegate to the smart debouncer for content/window changes

--- a/android/accessibility-service/src/main/kotlin/dev/jasonpearson/automobile/accessibilityservice/WebSocketServer.kt
+++ b/android/accessibility-service/src/main/kotlin/dev/jasonpearson/automobile/accessibilityservice/WebSocketServer.kt
@@ -198,6 +198,8 @@ class WebSocketServer(
     private val onClearPreferences:
         ((requestId: String?, packageName: String, fileName: String) -> Unit)? =
         null,
+    private val onStartRecording: (() -> Unit)? = null,
+    private val onStopRecording: (() -> Unit)? = null,
 ) {
   companion object {
     private const val TAG = "WebSocketServer"
@@ -792,6 +794,14 @@ class WebSocketServer(
           } else {
             Log.w(TAG, "clear_preferences request missing packageName or fileName")
           }
+        }
+        "start_recording" -> {
+          Log.d(TAG, "Received start_recording request")
+          onStartRecording?.invoke()
+        }
+        "stop_recording" -> {
+          Log.d(TAG, "Received stop_recording request")
+          onStopRecording?.invoke()
         }
         else -> {
           Log.d(TAG, "Unknown message type: ${request.type}")

--- a/src/features/observe/android/AccessibilityServiceClient.ts
+++ b/src/features/observe/android/AccessibilityServiceClient.ts
@@ -967,6 +967,16 @@ export class AccessibilityServiceClient extends DeviceServiceClient implements A
     };
   }
 
+  /** Tell the Kotlin service that recording has started (enables interaction event emission). */
+  notifyRecordingStarted(): void {
+    this.sendMessage(JSON.stringify({ type: "start_recording" }));
+  }
+
+  /** Tell the Kotlin service that recording has stopped (disables interaction event emission). */
+  notifyRecordingStopped(): void {
+    this.sendMessage(JSON.stringify({ type: "stop_recording" }));
+  }
+
   // ===========================================================================
   // Hierarchy Navigation Detector
   // ===========================================================================

--- a/src/features/record/android/AxisRanges.ts
+++ b/src/features/record/android/AxisRanges.ts
@@ -1,0 +1,91 @@
+import type { AdbExecutor } from "../../../utils/android-cmdline-tools/interfaces/AdbExecutor";
+import type { TouchInputNode } from "./TouchNodeDiscovery";
+
+export interface AxisRanges {
+  xMin: number;
+  xMax: number;
+  yMin: number;
+  yMax: number;
+  /** Logical pixels from `adb shell wm size` (physical, not rotated) */
+  displayWidth: number;
+  displayHeight: number;
+  /** 0=portrait, 1=landscape90, 2=reverse-portrait, 3=landscape270 */
+  rotation: number;
+}
+
+export interface CoordScaler {
+  toScreenX(rawX: number): number;
+  toScreenY(rawY: number): number;
+}
+
+/**
+ * Build a coordinate scaler that maps raw sensor values to logical display pixels.
+ * In landscape mode (rotation 1 or 3) the sensor X axis maps to display height
+ * and sensor Y axis maps to display width.
+ */
+export function buildScaler(ranges: AxisRanges): CoordScaler {
+  const landscape = ranges.rotation === 1 || ranges.rotation === 3;
+  return {
+    toScreenX(rawX: number): number {
+      const norm = (rawX - ranges.xMin) / (ranges.xMax - ranges.xMin + 1);
+      return Math.round(norm * (landscape ? ranges.displayHeight : ranges.displayWidth));
+    },
+    toScreenY(rawY: number): number {
+      const norm = (rawY - ranges.yMin) / (ranges.yMax - ranges.yMin + 1);
+      return Math.round(norm * (landscape ? ranges.displayWidth : ranges.displayHeight));
+    },
+  };
+}
+
+/**
+ * Parse the physical display size from `adb shell wm size` output.
+ * Returns { width, height } in physical pixels (before rotation).
+ */
+export async function queryDisplaySize(
+  adb: AdbExecutor
+): Promise<{ width: number; height: number }> {
+  const { stdout } = await adb.executeCommand("shell wm size");
+  const match = stdout.match(/Physical size:\s*(\d+)x(\d+)/);
+  if (!match) {
+    throw new Error(`Could not parse display size from wm size output: ${stdout}`);
+  }
+  return { width: parseInt(match[1], 10), height: parseInt(match[2], 10) };
+}
+
+/**
+ * Parse display density from `adb shell wm density` and return dp multiplier.
+ * Falls back to 2.75 (440 dpi) if parsing fails.
+ */
+export async function queryDensity(adb: AdbExecutor): Promise<number> {
+  try {
+    const { stdout } = await adb.executeCommand("shell wm density");
+    const match = stdout.match(/Physical density:\s*(\d+)/);
+    if (match) {
+      return parseInt(match[1], 10) / 160;
+    }
+  } catch {
+    // fall through to default
+  }
+  return 2.75;
+}
+
+/**
+ * Build AxisRanges from the touch node axis info + current display size + rotation.
+ * @param rotation 0-3 from AccessibilityHierarchy.rotation
+ */
+export async function buildAxisRanges(
+  adb: AdbExecutor,
+  node: TouchInputNode,
+  rotation: number
+): Promise<AxisRanges> {
+  const { width, height } = await queryDisplaySize(adb);
+  return {
+    xMin: node.axisXMin,
+    xMax: node.axisXMax,
+    yMin: node.axisYMin,
+    yMax: node.axisYMax,
+    displayWidth: width,
+    displayHeight: height,
+    rotation,
+  };
+}

--- a/src/features/record/android/DualTrackRecorder.ts
+++ b/src/features/record/android/DualTrackRecorder.ts
@@ -1,0 +1,367 @@
+import { logger } from "../../../utils/logger";
+import type { BootedDevice, PlanStep, Element } from "../../../models";
+import type { GestureEmitter, GestureEvent, A11ySource } from "./types";
+import { AccessibilityServiceClient } from "../../observe/android";
+import { defaultAdbClientFactory } from "../../../utils/android-cmdline-tools/AdbClientFactory";
+import { discoverTouchNode } from "./TouchNodeDiscovery";
+import { buildAxisRanges, buildScaler, queryDensity } from "./AxisRanges";
+import { GetEventReader } from "./GetEventReader";
+import { defaultTimer, type Timer } from "../../../utils/SystemTimer";
+
+/** An InteractionEvent from the AccessibilityService (subset of fields we use) */
+interface ReceivedInteraction {
+  type: string;
+  timestamp: number;
+  packageName?: string;
+  screenClassName?: string;
+  element?: Partial<Element>;
+  text?: string;
+  scrollDeltaX?: number;
+  scrollDeltaY?: number;
+}
+
+interface PendingGesture {
+  gesture: GestureEvent;
+  arrivedAt: number;
+  resolved: boolean;
+}
+
+/**
+ * How long to wait for an AccessibilityService event to pair with a getevent gesture.
+ * If no A11y event arrives within this window, the gesture step is dropped with a warning.
+ */
+export const MERGE_WINDOW_MS = 100;
+
+/**
+ * Merges GestureEvents from getevent with InteractionEvents from the AccessibilityService
+ * to build AutoMobile plan steps with full gesture-type and element-identity information.
+ *
+ * Usage:
+ *   const recorder = new DualTrackRecorder(device)
+ *   await recorder.start()
+ *   // ... user interacts ...
+ *   const { steps } = await recorder.stop()
+ */
+export class DualTrackRecorder {
+  private steps: PlanStep[] = [];
+  private pendingGestures: PendingGesture[] = [];
+  private bufferedInteractions: ReceivedInteraction[] = [];
+  private lastInputText: { elementKey: string; text: string; stepIndex: number } | null = null;
+  private activeEmitter: GestureEmitter | null = null;
+  private unsubscribeA11y: (() => void) | null = null;
+  /** Reference to the real AccessibilityServiceClient when not in test mode */
+  private activeA11y: AccessibilityServiceClient | null = null;
+
+  get stepCount(): number {
+    return this.steps.length;
+  }
+
+  constructor(
+    private readonly device: BootedDevice,
+    /** Optional override for testing — defaults to a real GetEventReader */
+    private readonly gestureEmitter?: GestureEmitter,
+    /** Optional override for testing — defaults to AccessibilityServiceClient */
+    private readonly a11ySource?: A11ySource,
+    /** Optional override for testing — defaults to the system timer */
+    private readonly timer: Timer = defaultTimer
+  ) {}
+
+  async start(): Promise<void> {
+    // In real mode (no test override), obtain the AccessibilityServiceClient directly
+    // so we can send start/stop recording notifications to the Kotlin service.
+    let a11yClient: AccessibilityServiceClient | undefined;
+    if (!this.a11ySource) {
+      a11yClient = AccessibilityServiceClient.getInstance(this.device);
+    }
+
+    const a11y = this.a11ySource ?? a11yClient!;
+
+    const connected = await (a11y as { ensureConnected(): Promise<boolean> }).ensureConnected();
+    if (!connected) {
+      throw new Error(
+        "[DualTrackRecorder] Unable to connect to the accessibility service."
+      );
+    }
+
+    // Notify Kotlin service that recording is starting (enables interaction event emission)
+    if (a11yClient) {
+      a11yClient.notifyRecordingStarted();
+      this.activeA11y = a11yClient;
+    }
+
+    const emitter = this.gestureEmitter ?? (await this.createGetEventReader());
+    this.activeEmitter = emitter;
+    emitter.start(
+      e => this.handleGestureEvent(e),
+      e => logger.warn(`[DualTrackRecorder] GetEventReader error: ${e.message}`)
+    );
+
+    this.unsubscribeA11y = (a11y as AccessibilityServiceClient).onInteraction(
+      e => this.handleInteractionEvent(e as unknown as ReceivedInteraction)
+    );
+
+    logger.debug("[DualTrackRecorder] Started dual-track recording");
+  }
+
+  async stop(): Promise<{ steps: PlanStep[]; stepCount: number }> {
+    // Notify Kotlin service that recording is stopping before unsubscribing
+    this.activeA11y?.notifyRecordingStopped();
+    this.activeA11y = null;
+
+    this.unsubscribeA11y?.();
+    this.unsubscribeA11y = null;
+    this.activeEmitter?.stop();
+    this.activeEmitter = null;
+
+    // Flush pending gestures that haven't been matched yet
+    for (const pending of this.pendingGestures) {
+      if (!pending.resolved) {
+        this.resolveGesture(pending);
+      }
+    }
+    this.pendingGestures = [];
+
+    logger.debug(
+      `[DualTrackRecorder] Stopped with ${this.steps.length} steps`
+    );
+
+    return { steps: this.steps, stepCount: this.steps.length };
+  }
+
+  // -------------------------------------------------------------------------
+  // Private: event handlers
+  // -------------------------------------------------------------------------
+
+  private handleGestureEvent(gesture: GestureEvent): void {
+    if (gesture.type === "pressButton") {
+      this.steps.push(buildPressButtonStep(gesture));
+      return;
+    }
+
+    if (gesture.type === "pinch") {
+      this.steps.push(buildPinchStep(gesture));
+      return;
+    }
+
+    // tap / doubleTap / longPress / swipe → hold for merge window
+    const pending: PendingGesture = {
+      gesture,
+      arrivedAt: Date.now(),
+      resolved: false,
+    };
+    this.pendingGestures.push(pending);
+
+    this.timer.setTimeout(() => this.resolveGesture(pending), MERGE_WINDOW_MS);
+  }
+
+  private handleInteractionEvent(event: ReceivedInteraction): void {
+    if (event.type === "windowChange") {
+      // Screen navigation metadata — not a plan step
+      return;
+    }
+
+    if (event.type === "inputText") {
+      this.handleInputText(event);
+      return;
+    }
+
+    // tap / longPress / swipe — try to match a pending gesture
+    const matched = this.pendingGestures.find(
+      p =>
+        !p.resolved &&
+        isCompatibleType(p.gesture.type, event.type) &&
+        Date.now() - p.arrivedAt <= MERGE_WINDOW_MS &&
+        gestureHitsElement(p.gesture, event.element)
+    );
+
+    if (matched) {
+      matched.resolved = true;
+      const step = buildMergedStep(matched.gesture, event);
+      if (step) {this.steps.push(step);}
+    } else {
+      this.bufferedInteractions.push(event);
+    }
+  }
+
+  private resolveGesture(pending: PendingGesture): void {
+    if (pending.resolved) {return;}
+    pending.resolved = true;
+
+    // Try to match against a buffered A11y interaction
+    const idx = this.bufferedInteractions.findIndex(e =>
+      isCompatibleType(pending.gesture.type, e.type)
+    );
+
+    if (idx >= 0) {
+      const event = this.bufferedInteractions.splice(idx, 1)[0];
+      const step = buildMergedStep(pending.gesture, event);
+      if (step) {this.steps.push(step);}
+    } else {
+      logger.warn(
+        `[DualTrackRecorder] No element match for ${pending.gesture.type} ` +
+          `at (${pending.gesture.screenX}, ${pending.gesture.screenY}) — step skipped`
+      );
+    }
+  }
+
+  private handleInputText(event: ReceivedInteraction): void {
+    const elementKey = buildElementKey(event);
+    if (event.text === undefined) {return;}
+
+    // Coalesce consecutive inputText events on the same element
+    if (
+      this.lastInputText &&
+      elementKey &&
+      this.lastInputText.elementKey === elementKey &&
+      this.lastInputText.stepIndex < this.steps.length
+    ) {
+      const existing = this.steps[this.lastInputText.stepIndex];
+      if (existing && existing.tool === "inputText") {
+        existing.params.text = event.text;
+        return;
+      }
+    }
+
+    const stepIndex = this.steps.length;
+    this.steps.push({ tool: "inputText", params: { text: event.text } });
+    if (elementKey) {
+      this.lastInputText = { elementKey, text: event.text, stepIndex };
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // Private: factory
+  // -------------------------------------------------------------------------
+
+  private async createGetEventReader(): Promise<GestureEmitter> {
+    const adb = defaultAdbClientFactory.create(this.device);
+    const node = await discoverTouchNode(adb);
+    if (!node) {
+      throw new Error("[DualTrackRecorder] No multitouch input device found on this device");
+    }
+    const density = await queryDensity(adb);
+    const rotation = 0; // portrait fallback; will be overridden when A11y provides rotation
+    const ranges = await buildAxisRanges(adb, node, rotation);
+    const scaler = buildScaler(ranges);
+
+    return new GetEventReader({
+      deviceId: this.device.deviceId,
+      touchNode: node,
+      scaler,
+      density,
+    });
+  }
+}
+
+// -------------------------------------------------------------------------
+// Pure helper functions
+// -------------------------------------------------------------------------
+
+function isCompatibleType(gestureType: string, eventType: string): boolean {
+  return (
+    (gestureType === "tap" && eventType === "tap") ||
+    (gestureType === "doubleTap" && eventType === "tap") ||
+    (gestureType === "longPress" && eventType === "longPress") ||
+    (gestureType === "swipe" && eventType === "swipe")
+  );
+}
+
+function gestureHitsElement(
+  gesture: GestureEvent,
+  element?: Partial<Element>
+): boolean {
+  const bounds = element?.bounds;
+  if (!bounds || gesture.screenX === null || gesture.screenX === undefined || gesture.screenY === null || gesture.screenY === undefined) {return false;}
+  const PAD = 20;
+  return (
+    gesture.screenX >= bounds.left - PAD &&
+    gesture.screenX <= bounds.right + PAD &&
+    gesture.screenY >= bounds.top - PAD &&
+    gesture.screenY <= bounds.bottom + PAD
+  );
+}
+
+function buildSelector(
+  element?: Partial<Element>
+): { elementId: string } | { text: string } | null {
+  if (!element) {return null;}
+  const resourceId = element["resource-id"];
+  if (resourceId) {return { elementId: resourceId };}
+  const text = element.text ?? element["content-desc"];
+  if (text) {return { text };}
+  return null;
+}
+
+function buildElementKey(event: ReceivedInteraction): string | null {
+  const el = event.element;
+  if (!el) {return null;}
+  const resourceId = el["resource-id"] ?? "";
+  const contentDesc = el["content-desc"] ?? "";
+  const className = el["class"] ?? "";
+  if (!resourceId && !contentDesc && !className) {return null;}
+  return `${resourceId}|${contentDesc}|${className}`;
+}
+
+function resolveSwipeDirection(
+  scrollDeltaX?: number,
+  scrollDeltaY?: number
+): "up" | "down" | "left" | "right" | null {
+  const dx = scrollDeltaX ?? 0;
+  const dy = scrollDeltaY ?? 0;
+  if (dx === 0 && dy === 0) {return null;}
+  if (Math.abs(dx) >= Math.abs(dy)) {return dx > 0 ? "left" : "right";}
+  return dy > 0 ? "up" : "down";
+}
+
+function buildMergedStep(
+  gesture: GestureEvent,
+  event: ReceivedInteraction
+): PlanStep | null {
+  const selector = buildSelector(event.element);
+
+  switch (gesture.type) {
+    case "tap":
+      if (!selector) {return null;}
+      return { tool: "tapOn", params: { action: "tap", ...selector } };
+
+    case "doubleTap":
+      if (!selector) {return null;}
+      return { tool: "tapOn", params: { action: "doubleTap", ...selector } };
+
+    case "longPress":
+      if (!selector) {return null;}
+      return { tool: "tapOn", params: { action: "longPress", ...selector } };
+
+    case "swipe": {
+      const direction =
+        gesture.direction ?? resolveSwipeDirection(event.scrollDeltaX, event.scrollDeltaY);
+      if (!direction) {return null;}
+      const params: Record<string, unknown> = { direction };
+      if (selector) {
+        params.container =
+          "elementId" in selector
+            ? { elementId: selector.elementId }
+            : { text: selector.text };
+      }
+      if (gesture.speed === "fast") {params.speed = "fast";}
+      return { tool: "swipeOn", params };
+    }
+
+    default:
+      return null;
+  }
+}
+
+function buildPressButtonStep(gesture: GestureEvent): PlanStep {
+  return { tool: "pressButton", params: { button: gesture.button } };
+}
+
+function buildPinchStep(gesture: GestureEvent): PlanStep {
+  return {
+    tool: "pinchOn",
+    params: {
+      direction: gesture.pinchDirection,
+      scale: gesture.scale,
+    },
+  };
+}

--- a/src/features/record/android/GestureClassifier.ts
+++ b/src/features/record/android/GestureClassifier.ts
@@ -1,0 +1,238 @@
+import type { RawTouchFrame, GestureEvent } from "./types";
+import { GESTURE_THRESHOLDS } from "./types";
+import type { CoordScaler } from "./AxisRanges";
+
+interface ContactInfo {
+  /** Raw sensor position when the finger first touched */
+  startX: number;
+  startY: number;
+  arrivedAt: number;
+  /** Last known raw sensor position (updated on each active frame) */
+  lastX: number;
+  lastY: number;
+}
+
+interface LastTap {
+  screenX: number;
+  screenY: number;
+  arrivedAt: number;
+}
+
+interface PinchState {
+  initialDist: number;
+  /** Updated each frame while both fingers are active */
+  finalDist: number;
+}
+
+/**
+ * Classifies sequences of RawTouchFrame events into high-level GestureEvents.
+ *
+ * Single-finger gestures:
+ *   - tap: short, low-displacement contact
+ *   - doubleTap: two taps within DOUBLE_TAP_MS at the same location
+ *   - longPress: long, low-displacement contact
+ *   - swipe: high-displacement contact
+ *
+ * Two-finger gestures:
+ *   - pinch: two contacts with significant scale change
+ *
+ * Feed frames in order. A GestureEvent is returned when a gesture completes
+ * (on finger UP), otherwise null.
+ */
+export class GestureClassifier {
+  /** Per-slot: start position + last known position */
+  private contacts: Map<number, ContactInfo> = new Map();
+  private lastTap: LastTap | null = null;
+  private pinchState: PinchState | null = null;
+  private inTwoFingerMode = false;
+
+  /**
+   * @param scaler converts raw sensor coordinates to logical screen pixels
+   * @param densityDp dp multiplier (e.g. 420/160 = 2.625 for a 420dpi screen)
+   */
+  constructor(
+    private readonly scaler: CoordScaler,
+    private readonly densityDp: number
+  ) {}
+
+  /** Feed one frame. Returns a completed GestureEvent or null. */
+  feedFrame(frame: RawTouchFrame): GestureEvent | null {
+    // 1. Register new contacts and update last-known positions
+    for (const slot of frame.activeSlots) {
+      const existing = this.contacts.get(slot.slotId);
+      if (existing) {
+        existing.lastX = slot.x;
+        existing.lastY = slot.y;
+      } else {
+        this.contacts.set(slot.slotId, {
+          startX: slot.x,
+          startY: slot.y,
+          arrivedAt: frame.arrivedAt,
+          lastX: slot.x,
+          lastY: slot.y,
+        });
+      }
+    }
+
+    // 2. Update pinch state while 2 fingers are active
+    const activeCount = frame.activeSlots.length;
+    if (activeCount === 2) {
+      this.inTwoFingerMode = true;
+      const [a, b] = frame.activeSlots;
+      const dist = this.screenDist(a.x, a.y, b.x, b.y);
+      if (!this.pinchState) {
+        this.pinchState = { initialDist: dist, finalDist: dist };
+      } else {
+        this.pinchState.finalDist = dist;
+      }
+    }
+
+    // 3. Nothing released → nothing to emit
+    if (frame.releasedSlots.length === 0) {return null;}
+
+    // 4. Handle pinch completion
+    if (this.inTwoFingerMode && this.pinchState) {
+      // One or both fingers just lifted
+      const result = this.maybeEmitPinch(frame.arrivedAt);
+      // Clean up released contacts
+      for (const slotId of frame.releasedSlots) {
+        this.contacts.delete(slotId);
+      }
+      // If all fingers are now up, exit two-finger mode
+      if (activeCount === 0) {
+        this.inTwoFingerMode = false;
+        this.pinchState = null;
+      }
+      return result;
+    }
+
+    // 5. Single-finger gesture: exactly 1 slot released, 0 remaining
+    if (
+      !this.inTwoFingerMode &&
+      frame.releasedSlots.length === 1 &&
+      activeCount === 0
+    ) {
+      const slotId = frame.releasedSlots[0];
+      const contact = this.contacts.get(slotId);
+      this.contacts.delete(slotId);
+      if (!contact) {return null;}
+
+      const downX = this.scaler.toScreenX(contact.startX);
+      const downY = this.scaler.toScreenY(contact.startY);
+      const upX = this.scaler.toScreenX(contact.lastX);
+      const upY = this.scaler.toScreenY(contact.lastY);
+      const durationMs = frame.arrivedAt - contact.arrivedAt;
+      const displacement = dist(downX, downY, upX, upY);
+      const slopPx = GESTURE_THRESHOLDS.TOUCH_SLOP_DP * this.densityDp;
+
+      if (displacement < slopPx) {
+        return this.evaluateTapOrLongPress(downX, downY, durationMs, frame.arrivedAt);
+      }
+      return this.evaluateSwipe(downX, downY, upX, upY, durationMs, frame.arrivedAt);
+    }
+
+    // Clean up released contacts in other cases
+    for (const slotId of frame.releasedSlots) {
+      this.contacts.delete(slotId);
+    }
+    return null;
+  }
+
+  // -------------------------------------------------------------------------
+  // Private helpers
+  // -------------------------------------------------------------------------
+
+  private screenDist(rawX1: number, rawY1: number, rawX2: number, rawY2: number): number {
+    return dist(
+      this.scaler.toScreenX(rawX1),
+      this.scaler.toScreenY(rawY1),
+      this.scaler.toScreenX(rawX2),
+      this.scaler.toScreenY(rawY2)
+    );
+  }
+
+  private maybeEmitPinch(arrivedAt: number): GestureEvent | null {
+    const pinch = this.pinchState;
+    if (!pinch || pinch.initialDist === 0) {return null;}
+
+    const scale = pinch.finalDist / pinch.initialDist;
+    if (Math.abs(scale - 1.0) < GESTURE_THRESHOLDS.PINCH_MIN_SCALE_DELTA) {return null;}
+
+    return {
+      type: "pinch",
+      arrivedAt,
+      scale,
+      pinchDirection: scale < 1 ? "in" : "out",
+    };
+  }
+
+  private evaluateTapOrLongPress(
+    screenX: number,
+    screenY: number,
+    durationMs: number,
+    arrivedAt: number
+  ): GestureEvent {
+    if (durationMs >= GESTURE_THRESHOLDS.LONG_PRESS_MS) {
+      return { type: "longPress", arrivedAt, screenX, screenY, durationMs };
+    }
+
+    // Check for double-tap
+    if (this.lastTap) {
+      const timeSinceLast = arrivedAt - this.lastTap.arrivedAt;
+      const separation = dist(screenX, screenY, this.lastTap.screenX, this.lastTap.screenY);
+      const slopPx = GESTURE_THRESHOLDS.DOUBLE_TAP_SLOP_DP * this.densityDp;
+
+      if (
+        timeSinceLast <= GESTURE_THRESHOLDS.DOUBLE_TAP_MS &&
+        separation <= slopPx
+      ) {
+        this.lastTap = null;
+        return { type: "doubleTap", arrivedAt, screenX, screenY };
+      }
+    }
+
+    this.lastTap = { screenX, screenY, arrivedAt };
+    return { type: "tap", arrivedAt, screenX, screenY };
+  }
+
+  private evaluateSwipe(
+    downX: number,
+    downY: number,
+    upX: number,
+    upY: number,
+    durationMs: number,
+    arrivedAt: number
+  ): GestureEvent {
+    const dx = upX - downX;
+    const dy = upY - downY;
+    const displacement = dist(downX, downY, upX, upY);
+
+    const direction: GestureEvent["direction"] =
+      Math.abs(dx) >= Math.abs(dy)
+        ? dx > 0
+          ? "right"
+          : "left"
+        : dy > 0
+          ? "down"
+          : "up";
+
+    const velocityPxPerSec = durationMs > 0 ? (displacement / durationMs) * 1000 : 0;
+    const flingThreshPx = GESTURE_THRESHOLDS.FLING_MIN_DP_PER_S * this.densityDp;
+    const speed: GestureEvent["speed"] = velocityPxPerSec >= flingThreshPx ? "fast" : "normal";
+
+    return {
+      type: "swipe",
+      arrivedAt,
+      direction,
+      startX: downX,
+      startY: downY,
+      endX: upX,
+      endY: upY,
+      speed,
+    };
+  }
+}
+
+function dist(x1: number, y1: number, x2: number, y2: number): number {
+  return Math.sqrt((x2 - x1) ** 2 + (y2 - y1) ** 2);
+}

--- a/src/features/record/android/GetEventReader.ts
+++ b/src/features/record/android/GetEventReader.ts
@@ -1,0 +1,113 @@
+import { spawn } from "node:child_process";
+import type { ChildProcess } from "node:child_process";
+import { logger } from "../../../utils/logger";
+import type { GestureEmitter, GestureEvent } from "./types";
+import type { TouchInputNode } from "./TouchNodeDiscovery";
+import type { CoordScaler } from "./AxisRanges";
+import { TouchFrameReconstructor } from "./TouchFrameReconstructor";
+import { GestureClassifier } from "./GestureClassifier";
+
+export interface GetEventReaderOptions {
+  deviceId: string;
+  touchNode: TouchInputNode;
+  scaler: CoordScaler;
+  /** Display density in dp multiplier (e.g. 2.75 for 440dpi) */
+  density: number;
+  /** Override for testing — defaults to `spawn` from node:child_process */
+  spawnFn?: typeof spawn;
+  /** Override ADB binary path for testing — defaults to "adb" */
+  adbPath?: string;
+}
+
+/**
+ * Spawns `adb -s <deviceId> shell getevent -lt <touchNode.path>` and pipes
+ * the output through TouchFrameReconstructor → GestureClassifier.
+ *
+ * Implements GestureEmitter so it can be replaced with a fake in tests.
+ */
+export class GetEventReader implements GestureEmitter {
+  private child: ChildProcess | null = null;
+  private readonly spawnFn: typeof spawn;
+  private readonly adbPath: string;
+
+  constructor(private readonly opts: GetEventReaderOptions) {
+    this.spawnFn = opts.spawnFn ?? spawn;
+    this.adbPath = opts.adbPath ?? "adb";
+  }
+
+  start(
+    onGesture: (event: GestureEvent) => void,
+    onError?: (err: Error) => void
+  ): void {
+    if (this.child) {return;} // already running
+
+    const reconstructor = new TouchFrameReconstructor();
+    const classifier = new GestureClassifier(this.opts.scaler, this.opts.density);
+
+    const args = [
+      "-s",
+      this.opts.deviceId,
+      "shell",
+      "getevent",
+      "-lt",
+      this.opts.touchNode.path,
+    ];
+
+    logger.debug(`[GetEventReader] Spawning: ${this.adbPath} ${args.join(" ")}`);
+    this.child = this.spawnFn(this.adbPath, args);
+
+    let lineBuffer = "";
+
+    this.child.stdout?.on("data", (data: Buffer) => {
+      lineBuffer += data.toString();
+      const lines = lineBuffer.split("\n");
+      // Keep the incomplete last fragment in the buffer
+      lineBuffer = lines.pop() ?? "";
+
+      for (const line of lines) {
+        if (!line.trim()) {continue;}
+        const arrivedAt = Date.now();
+        const result = reconstructor.feedLine(line, arrivedAt);
+        if (!result) {continue;}
+
+        if (isRawTouchFrame(result)) {
+          const gesture = classifier.feedFrame(result);
+          if (gesture) {onGesture(gesture);}
+        } else {
+          // GestureEvent (pressButton)
+          onGesture(result);
+        }
+      }
+    });
+
+    this.child.stderr?.on("data", (data: Buffer) => {
+      logger.debug(`[GetEventReader] stderr: ${data.toString().trim()}`);
+    });
+
+    this.child.on("error", (err: Error) => {
+      logger.error(`[GetEventReader] spawn error: ${err.message}`);
+      onError?.(err);
+    });
+
+    this.child.on("close", (code: number | null) => {
+      if (code !== null && code !== 0) {
+        logger.warn(`[GetEventReader] getevent exited with code ${code}`);
+      }
+      this.child = null;
+    });
+  }
+
+  stop(): void {
+    if (this.child && !this.child.killed) {
+      logger.debug("[GetEventReader] Stopping getevent process");
+      this.child.kill();
+    }
+    this.child = null;
+  }
+}
+
+function isRawTouchFrame(
+  result: ReturnType<TouchFrameReconstructor["feedLine"]>
+): result is import("./types").RawTouchFrame {
+  return result !== null && "activeSlots" in result;
+}

--- a/src/features/record/android/TouchFrameReconstructor.ts
+++ b/src/features/record/android/TouchFrameReconstructor.ts
@@ -1,0 +1,154 @@
+import type { RawTouchFrame, TouchSlot, GestureEvent } from "./types";
+
+// Mapping from Linux key codes to AutoMobile button names
+const KEY_TO_BUTTON: Record<string, GestureEvent["button"]> = {
+  KEY_BACK: "back",
+  KEY_HOME: "home",
+  KEY_MENU: "menu",
+  KEY_POWER: "power",
+  KEY_VOLUMEUP: "volume_up",
+  KEY_VOLUMEDOWN: "volume_down",
+  KEY_APPSELECT: "recent",
+};
+
+/**
+ * State machine that processes `getevent -lt` text output one line at a time
+ * and emits RawTouchFrame snapshots on SYN_REPORT events.
+ *
+ * Implements Linux Multi-Touch Protocol B (slot-based, stateful).
+ *
+ * Returns:
+ *   - RawTouchFrame on EV_SYN SYN_REPORT (value 0x00000000)
+ *   - GestureEvent { type: "pressButton" } on EV_KEY KEY_* DOWN
+ *   - null for all other input lines
+ */
+export class TouchFrameReconstructor {
+  private slots: Map<number, TouchSlot> = new Map();
+  private currentSlot = 0;
+
+  /**
+   * Feed one text line from `getevent -lt` stdout.
+   *
+   * Line format: "[ 78826.389007] EV_ABS    ABS_MT_POSITION_X    000001a4"
+   */
+  feedLine(line: string, arrivedAt: number): RawTouchFrame | GestureEvent | null {
+    // Match: "[timestamp] EV_TYPE   EVENT_CODE   value"
+    const match = line.match(/^\[\s*[\d.]+\]\s+(\S+)\s+(\S+)\s+(\S+)\s*$/);
+    if (!match) {return null;}
+
+    const evType = match[1];
+    const evCode = match[2];
+    const evValue = match[3];
+
+    if (evType === "EV_ABS") {
+      this.handleAbsEvent(evCode, evValue);
+      return null;
+    }
+
+    if (evType === "EV_SYN") {
+      return this.handleSynEvent(evCode, evValue, arrivedAt);
+    }
+
+    if (evType === "EV_KEY" && evValue === "DOWN") {
+      const button = KEY_TO_BUTTON[evCode];
+      if (button) {
+        return { type: "pressButton", arrivedAt, button };
+      }
+    }
+
+    return null;
+  }
+
+  private handleAbsEvent(evCode: string, evValue: string): void {
+    const value = parseInt(evValue, 16);
+
+    switch (evCode) {
+      case "ABS_MT_SLOT":
+        this.currentSlot = value;
+        break;
+
+      case "ABS_MT_TRACKING_ID":
+        if (evValue === "ffffffff") {
+          // Finger lifted — mark slot as released
+          const slot = this.slots.get(this.currentSlot);
+          if (slot) {
+            slot.trackingId = -1;
+          }
+        } else {
+          // New or continuing contact
+          const existing = this.slots.get(this.currentSlot);
+          if (existing) {
+            existing.trackingId = value;
+          } else {
+            this.slots.set(this.currentSlot, {
+              slotId: this.currentSlot,
+              trackingId: value,
+              x: 0,
+              y: 0,
+              pressure: 0,
+            });
+          }
+        }
+        break;
+
+      case "ABS_MT_POSITION_X":
+        this.getOrCreateSlot().x = value;
+        break;
+
+      case "ABS_MT_POSITION_Y":
+        this.getOrCreateSlot().y = value;
+        break;
+
+      case "ABS_MT_PRESSURE":
+        this.getOrCreateSlot().pressure = value;
+        break;
+
+      default:
+        break;
+    }
+  }
+
+  private handleSynEvent(
+    evCode: string,
+    evValue: string,
+    arrivedAt: number
+  ): RawTouchFrame | null {
+    if (evCode !== "SYN_REPORT") {return null;}
+
+    // value 0x00000000 = SYN_REPORT (Protocol B)
+    // value 0x00000002 = SYN_MT_REPORT (Protocol A, ignored)
+    const value = parseInt(evValue, 16);
+    if (value !== 0) {return null;}
+
+    const activeSlots: TouchSlot[] = [];
+    const releasedSlots: number[] = [];
+
+    for (const [, slot] of this.slots) {
+      if (slot.trackingId >= 0) {
+        activeSlots.push({ ...slot });
+      } else {
+        releasedSlots.push(slot.slotId);
+      }
+    }
+
+    // Remove released slots from state so they don't appear in future frames
+    for (const slotId of releasedSlots) {
+      this.slots.delete(slotId);
+    }
+
+    return { arrivedAt, activeSlots, releasedSlots };
+  }
+
+  private getOrCreateSlot(): TouchSlot {
+    if (!this.slots.has(this.currentSlot)) {
+      this.slots.set(this.currentSlot, {
+        slotId: this.currentSlot,
+        trackingId: -1,
+        x: 0,
+        y: 0,
+        pressure: 0,
+      });
+    }
+    return this.slots.get(this.currentSlot)!;
+  }
+}

--- a/src/features/record/android/TouchNodeDiscovery.ts
+++ b/src/features/record/android/TouchNodeDiscovery.ts
@@ -1,0 +1,124 @@
+import type { AdbExecutor } from "../../../utils/android-cmdline-tools/interfaces/AdbExecutor";
+import { logger } from "../../../utils/logger";
+
+/** A /dev/input/eventN node that reports multitouch position */
+export interface TouchInputNode {
+  path: string;
+  name: string;
+  axisXMin: number;
+  axisXMax: number;
+  axisYMin: number;
+  axisYMax: number;
+}
+
+/**
+ * Run `shell getevent -p` and return the first input node that reports both
+ * ABS_MT_POSITION_X (0x35) and ABS_MT_POSITION_Y (0x36) with valid axis ranges.
+ */
+export async function discoverTouchNode(
+  adb: AdbExecutor
+): Promise<TouchInputNode | null> {
+  const { stdout } = await adb.executeCommand("shell getevent -p");
+  const nodes = parseTouchNodes(stdout);
+  if (nodes.length === 0) {
+    logger.warn("[TouchNodeDiscovery] No multitouch input device found");
+    return null;
+  }
+  if (nodes.length > 1) {
+    logger.debug(
+      `[TouchNodeDiscovery] Found ${nodes.length} multitouch devices, using first: ${nodes[0].path}`
+    );
+  }
+  return nodes[0];
+}
+
+/**
+ * Pure parser exposed for unit testing.
+ * Handles both `getevent -p` (hex codes) and `getevent -pl` (named codes) output.
+ */
+export function parseTouchNodes(output: string): TouchInputNode[] {
+  const lines = output.split("\n");
+  const nodes: TouchInputNode[] = [];
+
+  let currentPath: string | null = null;
+  let currentName: string | null = null;
+  let axisXMin = 0;
+  let axisXMax = 0;
+  let axisYMin = 0;
+  let axisYMax = 0;
+  let hasX = false;
+  let hasY = false;
+
+  const commitDevice = (): void => {
+    if (currentPath && hasX && hasY) {
+      nodes.push({
+        path: currentPath,
+        name: currentName ?? currentPath,
+        axisXMin,
+        axisXMax,
+        axisYMin,
+        axisYMax,
+      });
+    }
+    currentPath = null;
+    currentName = null;
+    axisXMin = axisXMax = axisYMin = axisYMax = 0;
+    hasX = hasY = false;
+  };
+
+  for (const line of lines) {
+    // New device section
+    const deviceMatch = line.match(/^add device \d+:\s+(.+)/);
+    if (deviceMatch) {
+      commitDevice();
+      currentPath = deviceMatch[1].trim();
+      continue;
+    }
+
+    if (!currentPath) {continue;}
+
+    // Device name line: `  name:     "Touchscreen"`
+    const nameMatch = line.match(/^\s+name:\s+"(.+)"/);
+    if (nameMatch) {
+      currentName = nameMatch[1];
+      continue;
+    }
+
+    // X axis – absinfo line for ABS_MT_POSITION_X (0035) in either format:
+    //   getevent -p:  "    0035  : value 0, min 0, max 1079, ..."
+    //   getevent -pl: "    ABS_MT_POSITION_X (0035): value 0, min 0, max 1079, ..."
+    if (
+      (line.includes("0035") || line.includes("ABS_MT_POSITION_X")) &&
+      line.includes("min") &&
+      line.includes("max")
+    ) {
+      const rangeMatch = line.match(/\bmin\s+(-?\d+),\s*max\s+(-?\d+)/);
+      if (rangeMatch) {
+        axisXMin = parseInt(rangeMatch[1], 10);
+        axisXMax = parseInt(rangeMatch[2], 10);
+        hasX = true;
+      }
+      continue;
+    }
+
+    // Y axis
+    if (
+      (line.includes("0036") || line.includes("ABS_MT_POSITION_Y")) &&
+      line.includes("min") &&
+      line.includes("max")
+    ) {
+      const rangeMatch = line.match(/\bmin\s+(-?\d+),\s*max\s+(-?\d+)/);
+      if (rangeMatch) {
+        axisYMin = parseInt(rangeMatch[1], 10);
+        axisYMax = parseInt(rangeMatch[2], 10);
+        hasY = true;
+      }
+      continue;
+    }
+  }
+
+  // Don't forget the last device
+  commitDevice();
+
+  return nodes;
+}

--- a/src/features/record/android/index.ts
+++ b/src/features/record/android/index.ts
@@ -1,0 +1,23 @@
+export type {
+  TouchSlot,
+  RawTouchFrame,
+  GestureEventType,
+  GestureEvent,
+  GestureEmitter,
+  A11ySource,
+} from "./types";
+export { GESTURE_THRESHOLDS } from "./types";
+
+export type { TouchInputNode } from "./TouchNodeDiscovery";
+export { discoverTouchNode, parseTouchNodes } from "./TouchNodeDiscovery";
+
+export type { AxisRanges, CoordScaler } from "./AxisRanges";
+export { buildScaler, buildAxisRanges, queryDisplaySize, queryDensity } from "./AxisRanges";
+
+export { TouchFrameReconstructor } from "./TouchFrameReconstructor";
+export { GestureClassifier } from "./GestureClassifier";
+
+export type { GetEventReaderOptions } from "./GetEventReader";
+export { GetEventReader } from "./GetEventReader";
+
+export { DualTrackRecorder, MERGE_WINDOW_MS } from "./DualTrackRecorder";

--- a/src/features/record/android/types.ts
+++ b/src/features/record/android/types.ts
@@ -1,0 +1,102 @@
+/**
+ * Shared types for Android test recording via getevent + AccessibilityService.
+ */
+
+// ---------------------------------------------------------------------------
+// Touch frame types (output of TouchFrameReconstructor)
+// ---------------------------------------------------------------------------
+
+export interface TouchSlot {
+  slotId: number;
+  /** -1 means the finger has been lifted */
+  trackingId: number;
+  /** raw sensor x coordinate */
+  x: number;
+  /** raw sensor y coordinate */
+  y: number;
+  pressure: number;
+}
+
+export interface RawTouchFrame {
+  /** Date.now() on host when the SYN_REPORT line was read */
+  arrivedAt: number;
+  /** Only slots with trackingId >= 0 */
+  activeSlots: ReadonlyArray<TouchSlot>;
+  /** slotIds whose trackingId became -1 in this frame */
+  releasedSlots: ReadonlyArray<number>;
+}
+
+// ---------------------------------------------------------------------------
+// Gesture types (output of GestureClassifier / GetEventReader)
+// ---------------------------------------------------------------------------
+
+export type GestureEventType =
+  | "tap"
+  | "doubleTap"
+  | "longPress"
+  | "swipe"
+  | "pinch"
+  | "pressButton";
+
+export interface GestureEvent {
+  type: GestureEventType;
+  /** Host time of the UP/key event that completed the gesture */
+  arrivedAt: number;
+
+  // tap / doubleTap / longPress
+  screenX?: number;
+  screenY?: number;
+  durationMs?: number;
+
+  // swipe
+  direction?: "up" | "down" | "left" | "right";
+  startX?: number;
+  startY?: number;
+  endX?: number;
+  endY?: number;
+  speed?: "slow" | "normal" | "fast";
+
+  // pinch
+  scale?: number;
+  pinchDirection?: "in" | "out";
+
+  // pressButton
+  button?: "back" | "home" | "menu" | "power" | "volume_up" | "volume_down" | "recent";
+}
+
+/** Thresholds used for gesture classification (dp units where applicable) */
+export const GESTURE_THRESHOLDS = {
+  TOUCH_SLOP_DP: 8,
+  LONG_PRESS_MS: 400,
+  TAP_TIMEOUT_MS: 100,
+  DOUBLE_TAP_MS: 300,
+  DOUBLE_TAP_SLOP_DP: 100,
+  FLING_MIN_DP_PER_S: 50,
+  PINCH_MIN_SCALE_DELTA: 0.1,
+} as const;
+
+// ---------------------------------------------------------------------------
+// Interfaces for DI / testing in DualTrackRecorder
+// ---------------------------------------------------------------------------
+
+/**
+ * Abstraction over GetEventReader for dependency injection in DualTrackRecorder.
+ * Start receives the callback so the emitter can call it when a gesture occurs.
+ */
+export interface GestureEmitter {
+  start(
+    onGesture: (event: GestureEvent) => void,
+    onError?: (err: Error) => void
+  ): void;
+  stop(): void;
+}
+
+/**
+ * Minimal subset of AccessibilityServiceClient needed by DualTrackRecorder.
+ */
+export interface A11ySource {
+  ensureConnected(): Promise<boolean>;
+  onInteraction(
+    listener: (event: { type: string; [key: string]: unknown }) => void
+  ): () => void;
+}

--- a/src/server/testRecordingManager.ts
+++ b/src/server/testRecordingManager.ts
@@ -1,11 +1,11 @@
 import { randomUUID } from "node:crypto";
 import yaml from "js-yaml";
-import { BootedDevice, Plan, PlanStep, Element } from "../models";
-import { AccessibilityServiceClient, InteractionEvent } from "../features/observe/android";
+import { BootedDevice, Plan, PlanStep } from "../models";
 import { logger } from "../utils/logger";
 import { getMcpServerVersion } from "../utils/mcpVersion";
 import { PlanValidator } from "../utils/plan/PlanValidator";
 import { defaultTimer, type Timer } from "../utils/SystemTimer";
+import { DualTrackRecorder } from "../features/record/android";
 
 export interface TestRecordingStartResult {
   recordingId: string;
@@ -40,18 +40,8 @@ interface RecordingSession {
   deviceId: string;
   platform: string;
   startedAt: number;
-  events: InteractionEvent[];
-  unsubscribe: () => void;
-  lastInputKey?: string;
-  lastInputTimestamp?: number;
-  lastInputIndex?: number;
-  lastSwipeKey?: string;
-  lastSwipeTimestamp?: number;
-  lastSwipeIndex?: number;
+  recorder: DualTrackRecorder;
 }
-
-const INPUT_COALESCE_WINDOW_MS = 800;
-const SWIPE_COALESCE_WINDOW_MS = 600;
 
 let activeRecording: RecordingSession | null = null;
 
@@ -67,215 +57,23 @@ export function getTestRecordingStatus(timer: Timer = defaultTimer): TestRecordi
     deviceId: activeRecording.deviceId,
     platform: activeRecording.platform,
     startedAt: new Date(activeRecording.startedAt).toISOString(),
-    eventCount: activeRecording.events.length,
+    eventCount: activeRecording.recorder.stepCount,
     durationMs,
   };
 }
 
-const buildElementKey = (event: InteractionEvent): string | null => {
-  const element = event.element;
-  if (!element) {
-    return null;
-  }
-  const resourceId = element["resource-id"] ?? "";
-  const contentDesc = element["content-desc"] ?? "";
-  const className = element["class"] ?? "";
-  if (!resourceId && !contentDesc && !className) {
-    return null;
-  }
-  return `${resourceId}|${contentDesc}|${className}`;
-};
-
-const recordInteraction = (session: RecordingSession, event: InteractionEvent, timer: Timer = defaultTimer): void => {
-  const elementKey = buildElementKey(event);
-  const timestamp = event.timestamp ?? timer.now();
-
-  if (event.type === "inputText" && elementKey) {
-    const lastTimestamp = session.lastInputTimestamp ?? 0;
-    if (
-      session.lastInputKey === elementKey &&
-      session.lastInputIndex !== undefined &&
-      timestamp - lastTimestamp <= INPUT_COALESCE_WINDOW_MS
-    ) {
-      const existing = session.events[session.lastInputIndex];
-      if (existing && existing.type === "inputText") {
-        existing.text = event.text ?? existing.text;
-        existing.timestamp = timestamp;
-        existing.packageName = event.packageName ?? existing.packageName;
-        existing.screenClassName = event.screenClassName ?? existing.screenClassName;
-      }
-      session.lastInputTimestamp = timestamp;
-      return;
-    }
-  }
-
-  if (event.type === "swipe" && elementKey) {
-    const lastTimestamp = session.lastSwipeTimestamp ?? 0;
-    if (
-      session.lastSwipeKey === elementKey &&
-      session.lastSwipeIndex !== undefined &&
-      timestamp - lastTimestamp <= SWIPE_COALESCE_WINDOW_MS
-    ) {
-      const existing = session.events[session.lastSwipeIndex];
-      if (existing && existing.type === "swipe") {
-        existing.scrollDeltaX = (existing.scrollDeltaX ?? 0) + (event.scrollDeltaX ?? 0);
-        existing.scrollDeltaY = (existing.scrollDeltaY ?? 0) + (event.scrollDeltaY ?? 0);
-        existing.timestamp = timestamp;
-        existing.packageName = event.packageName ?? existing.packageName;
-        existing.screenClassName = event.screenClassName ?? existing.screenClassName;
-      }
-      session.lastSwipeTimestamp = timestamp;
-      return;
-    }
-  }
-
-  session.events.push({ ...event, timestamp });
-  const eventIndex = session.events.length - 1;
-
-  if (event.type === "inputText") {
-    session.lastInputKey = elementKey ?? undefined;
-    session.lastInputTimestamp = timestamp;
-    session.lastInputIndex = eventIndex;
-  } else if (event.type === "swipe") {
-    session.lastSwipeKey = elementKey ?? undefined;
-    session.lastSwipeTimestamp = timestamp;
-    session.lastSwipeIndex = eventIndex;
-  }
-};
-
-const resolveSwipeDirection = (
-  scrollDeltaX?: number,
-  scrollDeltaY?: number
-): "up" | "down" | "left" | "right" | null => {
-  const deltaX = scrollDeltaX ?? 0;
-  const deltaY = scrollDeltaY ?? 0;
-
-  if (deltaX === 0 && deltaY === 0) {
-    return null;
-  }
-
-  if (Math.abs(deltaX) >= Math.abs(deltaY)) {
-    return deltaX > 0 ? "left" : "right";
-  }
-
-  return deltaY > 0 ? "up" : "down";
-};
-
-const buildRecordedMetadata = (event: InteractionEvent): Record<string, any> => {
-  const element = event.element;
-  const recordedElement = element
-    ? {
-      resourceId: element["resource-id"],
-      text: element.text,
-      contentDescription: element["content-desc"],
-      className: element["class"],
-      bounds: element.bounds,
-    }
-    : undefined;
-
-  return {
-    timestamp: new Date(event.timestamp).toISOString(),
-    packageName: event.packageName,
-    screenClassName: event.screenClassName,
-    element: recordedElement,
-    scrollDeltaX: event.scrollDeltaX,
-    scrollDeltaY: event.scrollDeltaY,
-  };
-};
-
-const buildSelector = (
-  element?: Partial<Element>
-): { elementId?: string; text?: string } | null => {
-  if (!element) {
-    return null;
-  }
-  const resourceId = element["resource-id"];
-  if (resourceId) {
-    return { elementId: resourceId };
-  }
-
-  const text = element.text ?? element["content-desc"];
-  if (text) {
-    return { text };
-  }
-
-  return null;
-};
-
-const buildPlanSteps = (events: InteractionEvent[]): PlanStep[] => {
-  const steps: PlanStep[] = [];
-
-  const sortedEvents = [...events].sort((a, b) => a.timestamp - b.timestamp);
-
-  for (const event of sortedEvents) {
-    if (event.type === "tap" || event.type === "longPress") {
-      const selector = buildSelector(event.element);
-      if (!selector) {
-        logger.warn("[TestRecording] Skipping tap without selector");
-        continue;
-      }
-      steps.push({
-        tool: "tapOn",
-        params: {
-          ...selector,
-          action: event.type === "longPress" ? "longPress" : "tap",
-          recorded: buildRecordedMetadata(event),
-        },
-      });
-      continue;
-    }
-
-    if (event.type === "inputText") {
-      if (event.text === undefined) {
-        logger.warn("[TestRecording] Skipping inputText without text payload");
-        continue;
-      }
-      steps.push({
-        tool: "inputText",
-        params: {
-          text: event.text,
-          recorded: buildRecordedMetadata(event),
-        },
-      });
-      continue;
-    }
-
-    if (event.type === "swipe") {
-      const direction = resolveSwipeDirection(event.scrollDeltaX, event.scrollDeltaY);
-      if (!direction) {
-        logger.warn("[TestRecording] Skipping swipe without direction");
-        continue;
-      }
-
-      const selector = buildSelector(event.element);
-      const params: Record<string, any> = {
-        direction,
-        recorded: buildRecordedMetadata(event),
-      };
-
-      if (selector) {
-        params.container = selector.elementId
-          ? { elementId: selector.elementId }
-          : { text: selector.text };
-      }
-
-      steps.push({ tool: "swipeOn", params });
-    }
-  }
-
-  return steps;
-};
-
-const buildPlan = (session: RecordingSession, planName: string): { plan: Plan; stepCount: number } => {
-  const steps = buildPlanSteps(session.events);
+const buildPlanFromSteps = (
+  steps: PlanStep[],
+  session: RecordingSession,
+  planName: string,
+  stoppedAt: number
+): { plan: Plan; stepCount: number } => {
   if (steps.length === 0) {
     throw new Error("No recorded interactions were captured.");
   }
 
-  const now = new Date();
   const startedAt = new Date(session.startedAt);
-  const durationMs = now.getTime() - session.startedAt;
-  const appId = session.events.find(event => event.packageName)?.packageName;
+  const durationMs = stoppedAt - session.startedAt;
 
   const plan: Plan = {
     name: planName,
@@ -283,17 +81,16 @@ const buildPlan = (session: RecordingSession, planName: string): { plan: Plan; s
     steps,
     mcpVersion: getMcpServerVersion(),
     metadata: {
-      createdAt: now.toISOString(),
+      createdAt: new Date(stoppedAt).toISOString(),
       version: "1.0.0",
-      appId,
       recording: {
         recordingId: session.recordingId,
         startedAt: startedAt.toISOString(),
-        stoppedAt: now.toISOString(),
+        stoppedAt: new Date(stoppedAt).toISOString(),
         durationMs,
         deviceId: session.deviceId,
         platform: session.platform,
-        interactionCount: session.events.length,
+        interactionCount: steps.length,
       },
     },
   };
@@ -332,26 +129,19 @@ export async function startTestRecording(device: BootedDevice, timer: Timer = de
     throw new Error(`Test recording is only supported on Android right now (got ${device.platform}).`);
   }
 
-  const accessibilityClient = AccessibilityServiceClient.getInstance(device);
-  const connected = await accessibilityClient.ensureConnected();
-  if (!connected) {
-    throw new Error("Unable to connect to the accessibility service for interaction capture.");
-  }
-
   const recordingId = randomUUID();
   const startedAt = timer.now();
+
+  const recorder = new DualTrackRecorder(device);
+  await recorder.start();
 
   const session: RecordingSession = {
     recordingId,
     deviceId: device.deviceId,
     platform: device.platform,
     startedAt,
-    events: [],
-    unsubscribe: () => {},
+    recorder,
   };
-
-  const unsubscribe = accessibilityClient.onInteraction(event => recordInteraction(session, event));
-  session.unsubscribe = unsubscribe;
 
   activeRecording = session;
 
@@ -381,18 +171,18 @@ export async function stopTestRecording(
     );
   }
 
-  session.unsubscribe();
+  const { steps } = await session.recorder.stop();
   activeRecording = null;
 
+  const stoppedAt = timer.now();
   const resolvedPlanName = formatPlanName(planName);
-  const { plan, stepCount } = buildPlan(session, resolvedPlanName);
+  const { plan, stepCount } = buildPlanFromSteps(steps, session, resolvedPlanName, stoppedAt);
   const planContent = yaml.dump(plan, {
     indent: 2,
     lineWidth: -1,
     noRefs: true,
   });
 
-  const stoppedAt = timer.now();
   const durationMs = stoppedAt - session.startedAt;
 
   logger.info(`[TestRecording] Stopped recording ${session.recordingId} with ${stepCount} steps`);

--- a/test/features/record/android/DualTrackRecorder.test.ts
+++ b/test/features/record/android/DualTrackRecorder.test.ts
@@ -1,0 +1,272 @@
+import { describe, test, expect, beforeEach } from "bun:test";
+import { DualTrackRecorder } from "../../../../src/features/record/android/DualTrackRecorder";
+import type { GestureEmitter, GestureEvent, A11ySource } from "../../../../src/features/record/android/types";
+import type { BootedDevice } from "../../../../src/models";
+import { FakeTimer } from "../../../fakes/FakeTimer";
+
+// ---------------------------------------------------------------------------
+// Fakes
+// ---------------------------------------------------------------------------
+
+type InteractionListener = (event: { type: string; [key: string]: unknown }) => void;
+
+class FakeGestureEmitter implements GestureEmitter {
+  private onGestureHandler?: (event: GestureEvent) => void;
+
+  start(
+    onGesture: (event: GestureEvent) => void,
+    _onError?: (err: Error) => void
+  ): void {
+    this.onGestureHandler = onGesture;
+  }
+
+  stop(): void {
+    this.onGestureHandler = undefined;
+  }
+
+  emit(event: GestureEvent): void {
+    this.onGestureHandler?.(event);
+  }
+}
+
+class FakeA11ySource implements A11ySource {
+  private listener?: InteractionListener;
+
+  async ensureConnected(): Promise<boolean> {
+    return true;
+  }
+
+  onInteraction(listener: InteractionListener): () => void {
+    this.listener = listener;
+    return () => {
+      this.listener = undefined;
+    };
+  }
+
+  emit(event: { type: string; [key: string]: unknown }): void {
+    this.listener?.(event);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const fakeDevice: BootedDevice = {
+  deviceId: "emulator-5554",
+  name: "Test Device",
+  platform: "android",
+};
+
+const TAP_ELEMENT = {
+  "resource-id": "com.example:id/login_btn",
+  "bounds": { left: 300, top: 860, right: 400, bottom: 920 },
+};
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("DualTrackRecorder", () => {
+  let fakeGestures: FakeGestureEmitter;
+  let fakeA11y: FakeA11ySource;
+  let fakeTimer: FakeTimer;
+  let recorder: DualTrackRecorder;
+
+  beforeEach(() => {
+    fakeGestures = new FakeGestureEmitter();
+    fakeA11y = new FakeA11ySource();
+    fakeTimer = new FakeTimer();
+    fakeTimer.enableAutoAdvance();
+    recorder = new DualTrackRecorder(fakeDevice, fakeGestures, fakeA11y, fakeTimer);
+  });
+
+  test("tap gesture + matching A11y element → tapOn step", async () => {
+    await recorder.start();
+
+    fakeGestures.emit({ type: "tap", arrivedAt: Date.now(), screenX: 342, screenY: 891 });
+    fakeA11y.emit({ type: "tap", timestamp: Date.now(), element: TAP_ELEMENT });
+
+    await new Promise<void>(r => setImmediate(r));
+    const { steps } = await recorder.stop();
+
+    expect(steps).toHaveLength(1);
+    expect(steps[0].tool).toBe("tapOn");
+    expect(steps[0].params.action).toBe("tap");
+    expect(steps[0].params.elementId).toBe("com.example:id/login_btn");
+  });
+
+  test("doubleTap gesture + matching A11y element → tapOn doubleTap step", async () => {
+    await recorder.start();
+
+    fakeGestures.emit({ type: "doubleTap", arrivedAt: Date.now(), screenX: 342, screenY: 891 });
+    fakeA11y.emit({ type: "tap", timestamp: Date.now(), element: TAP_ELEMENT });
+
+    await new Promise<void>(r => setImmediate(r));
+    const { steps } = await recorder.stop();
+
+    expect(steps[0].tool).toBe("tapOn");
+    expect(steps[0].params.action).toBe("doubleTap");
+  });
+
+  test("longPress gesture + matching A11y element → tapOn longPress step", async () => {
+    await recorder.start();
+
+    fakeGestures.emit({ type: "longPress", arrivedAt: Date.now(), screenX: 342, screenY: 891 });
+    fakeA11y.emit({ type: "longPress", timestamp: Date.now(), element: TAP_ELEMENT });
+
+    await new Promise<void>(r => setImmediate(r));
+    const { steps } = await recorder.stop();
+
+    expect(steps[0].tool).toBe("tapOn");
+    expect(steps[0].params.action).toBe("longPress");
+  });
+
+  test("swipe gesture with direction + A11y element → swipeOn step with direction", async () => {
+    await recorder.start();
+
+    fakeGestures.emit({
+      type: "swipe",
+      arrivedAt: Date.now(),
+      direction: "up",
+      startX: 500, startY: 800, endX: 500, endY: 200,
+    });
+    fakeA11y.emit({
+      type: "swipe",
+      timestamp: Date.now(),
+      element: { "resource-id": "com.example:id/list", "bounds": { left: 0, top: 0, right: 1080, bottom: 1920 } },
+      scrollDeltaX: 0,
+      scrollDeltaY: 100,
+    });
+
+    await new Promise<void>(r => setImmediate(r));
+    const { steps } = await recorder.stop();
+
+    expect(steps[0].tool).toBe("swipeOn");
+    // getevent direction takes precedence over A11y scrollDelta
+    expect(steps[0].params.direction).toBe("up");
+  });
+
+  test("pinch emits pinchOn immediately without waiting for A11y", async () => {
+    await recorder.start();
+
+    fakeGestures.emit({ type: "pinch", arrivedAt: Date.now(), pinchDirection: "in", scale: 0.5 });
+
+    const { steps } = await recorder.stop();
+
+    expect(steps).toHaveLength(1);
+    expect(steps[0].tool).toBe("pinchOn");
+    expect(steps[0].params.direction).toBe("in");
+    expect(steps[0].params.scale).toBe(0.5);
+  });
+
+  test("pressButton emits immediately without waiting for A11y", async () => {
+    await recorder.start();
+
+    fakeGestures.emit({ type: "pressButton", arrivedAt: Date.now(), button: "back" });
+
+    const { steps } = await recorder.stop();
+
+    expect(steps).toHaveLength(1);
+    expect(steps[0].tool).toBe("pressButton");
+    expect(steps[0].params.button).toBe("back");
+  });
+
+  test("inputText from A11y with no gesture match → inputText step", async () => {
+    await recorder.start();
+
+    fakeA11y.emit({
+      type: "inputText",
+      timestamp: Date.now(),
+      text: "hello@example.com",
+      element: { "resource-id": "com.example:id/email_field" },
+    });
+
+    const { steps } = await recorder.stop();
+
+    expect(steps).toHaveLength(1);
+    expect(steps[0].tool).toBe("inputText");
+    expect(steps[0].params.text).toBe("hello@example.com");
+  });
+
+  test("consecutive inputText events on same element are coalesced", async () => {
+    await recorder.start();
+
+    const element = { "resource-id": "com.example:id/search", "bounds": { left: 0, top: 0, right: 500, bottom: 60 } };
+    fakeA11y.emit({ type: "inputText", timestamp: 100, text: "h", element });
+    fakeA11y.emit({ type: "inputText", timestamp: 200, text: "he", element });
+    fakeA11y.emit({ type: "inputText", timestamp: 300, text: "hel", element });
+
+    const { steps } = await recorder.stop();
+    // Should be coalesced into a single step with the last text
+    expect(steps).toHaveLength(1);
+    expect(steps[0].params.text).toBe("hel");
+  });
+
+  test("tap with no matching A11y element is skipped", async () => {
+    await recorder.start();
+
+    fakeGestures.emit({ type: "tap", arrivedAt: Date.now(), screenX: 50, screenY: 50 });
+    // No A11y event emitted
+
+    await new Promise<void>(r => setImmediate(r));
+    const { steps } = await recorder.stop();
+
+    // Step is dropped because no element identity
+    expect(steps).toHaveLength(0);
+  });
+
+  test("windowChange A11y events are not emitted as steps", async () => {
+    await recorder.start();
+
+    fakeA11y.emit({ type: "windowChange", timestamp: Date.now(), packageName: "com.example" });
+    // Also add a real step to ensure we're tracking correctly
+    fakeGestures.emit({ type: "pressButton", arrivedAt: Date.now(), button: "home" });
+
+    const { steps } = await recorder.stop();
+
+    expect(steps).toHaveLength(1);
+    expect(steps[0].tool).toBe("pressButton");
+  });
+
+  test("multiple independent gestures produce multiple steps", async () => {
+    await recorder.start();
+
+    fakeGestures.emit({ type: "pressButton", arrivedAt: Date.now(), button: "back" });
+    fakeGestures.emit({ type: "pressButton", arrivedAt: Date.now(), button: "home" });
+
+    const { steps } = await recorder.stop();
+
+    expect(steps).toHaveLength(2);
+    expect(steps[0].params.button).toBe("back");
+    expect(steps[1].params.button).toBe("home");
+  });
+
+  test("stopTestRecording returns correct step count", async () => {
+    await recorder.start();
+    fakeGestures.emit({ type: "pressButton", arrivedAt: Date.now(), button: "back" });
+    const { stepCount } = await recorder.stop();
+    expect(stepCount).toBe(1);
+  });
+
+  test("A11y event with text element using content-desc falls back to text selector", async () => {
+    await recorder.start();
+
+    fakeGestures.emit({ type: "tap", arrivedAt: Date.now(), screenX: 250, screenY: 400 });
+    fakeA11y.emit({
+      type: "tap",
+      timestamp: Date.now(),
+      element: {
+        "content-desc": "Sign in",
+        "bounds": { left: 200, top: 380, right: 400, bottom: 420 },
+      },
+    });
+
+    await new Promise<void>(r => setImmediate(r));
+    const { steps } = await recorder.stop();
+
+    expect(steps[0].tool).toBe("tapOn");
+    expect(steps[0].params.text).toBe("Sign in");
+    expect(steps[0].params.elementId).toBeUndefined();
+  });
+});

--- a/test/features/record/android/GestureClassifier.test.ts
+++ b/test/features/record/android/GestureClassifier.test.ts
@@ -1,0 +1,238 @@
+import { describe, test, expect, beforeEach } from "bun:test";
+import { GestureClassifier } from "../../../../src/features/record/android/GestureClassifier";
+import { GESTURE_THRESHOLDS } from "../../../../src/features/record/android/types";
+import type { RawTouchFrame } from "../../../../src/features/record/android/types";
+import type { CoordScaler } from "../../../../src/features/record/android/AxisRanges";
+
+// Identity scaler: raw coords == screen coords
+const identityScaler: CoordScaler = {
+  toScreenX: (x: number) => x,
+  toScreenY: (y: number) => y,
+};
+
+// density = 1.0 so dp thresholds equal pixel thresholds
+const DENSITY = 1.0;
+
+function makeFrame(
+  arrivedAt: number,
+  activeSlots: Array<{ slotId: number; trackingId: number; x: number; y: number }>,
+  releasedSlots: number[] = []
+): RawTouchFrame {
+  return {
+    arrivedAt,
+    activeSlots: activeSlots.map(s => ({ ...s, pressure: 0 })),
+    releasedSlots,
+  };
+}
+
+describe("GestureClassifier", () => {
+  let c: GestureClassifier;
+
+  beforeEach(() => {
+    c = new GestureClassifier(identityScaler, DENSITY);
+  });
+
+  // -------------------------------------------------------------------------
+  // tap
+  // -------------------------------------------------------------------------
+
+  test("short low-displacement contact → tap", () => {
+    // DOWN frame
+    c.feedFrame(makeFrame(0, [{ slotId: 0, trackingId: 1, x: 500, y: 800 }]));
+    // UP frame (within TAP_TIMEOUT and below slop)
+    const result = c.feedFrame(makeFrame(50, [], [0]));
+    expect(result?.type).toBe("tap");
+    expect(result?.screenX).toBe(500);
+    expect(result?.screenY).toBe(800);
+  });
+
+  test("tap duration exactly at LONG_PRESS_MS threshold is still a tap", () => {
+    c.feedFrame(makeFrame(0, [{ slotId: 0, trackingId: 1, x: 200, y: 300 }]));
+    const result = c.feedFrame(makeFrame(GESTURE_THRESHOLDS.LONG_PRESS_MS - 1, [], [0]));
+    expect(result?.type).toBe("tap");
+  });
+
+  // -------------------------------------------------------------------------
+  // longPress
+  // -------------------------------------------------------------------------
+
+  test("long low-displacement contact → longPress with durationMs", () => {
+    c.feedFrame(makeFrame(0, [{ slotId: 0, trackingId: 1, x: 300, y: 400 }]));
+    const result = c.feedFrame(makeFrame(GESTURE_THRESHOLDS.LONG_PRESS_MS, [], [0]));
+    expect(result?.type).toBe("longPress");
+    expect(result?.durationMs).toBe(GESTURE_THRESHOLDS.LONG_PRESS_MS);
+    expect(result?.screenX).toBe(300);
+    expect(result?.screenY).toBe(400);
+  });
+
+  test("very long press reports correct duration", () => {
+    c.feedFrame(makeFrame(0, [{ slotId: 0, trackingId: 1, x: 100, y: 100 }]));
+    const result = c.feedFrame(makeFrame(2000, [], [0]));
+    expect(result?.type).toBe("longPress");
+    expect(result?.durationMs).toBe(2000);
+  });
+
+  // -------------------------------------------------------------------------
+  // doubleTap
+  // -------------------------------------------------------------------------
+
+  test("two taps at same location within DOUBLE_TAP_MS → doubleTap", () => {
+    // First tap
+    c.feedFrame(makeFrame(0, [{ slotId: 0, trackingId: 1, x: 500, y: 500 }]));
+    const tap1 = c.feedFrame(makeFrame(50, [], [0]));
+    expect(tap1?.type).toBe("tap");
+
+    // Second tap soon after, same location
+    c.feedFrame(makeFrame(100, [{ slotId: 0, trackingId: 2, x: 500, y: 500 }]));
+    const result = c.feedFrame(makeFrame(150, [], [0]));
+    expect(result?.type).toBe("doubleTap");
+    expect(result?.screenX).toBe(500);
+  });
+
+  test("two taps too far apart in time → two separate taps", () => {
+    c.feedFrame(makeFrame(0, [{ slotId: 0, trackingId: 1, x: 500, y: 500 }]));
+    const tap1 = c.feedFrame(makeFrame(50, [], [0]));
+    expect(tap1?.type).toBe("tap");
+
+    c.feedFrame(makeFrame(GESTURE_THRESHOLDS.DOUBLE_TAP_MS + 500, [{ slotId: 0, trackingId: 2, x: 500, y: 500 }]));
+    const tap2 = c.feedFrame(makeFrame(GESTURE_THRESHOLDS.DOUBLE_TAP_MS + 550, [], [0]));
+    expect(tap2?.type).toBe("tap"); // NOT doubleTap
+  });
+
+  test("two taps too far apart in space → two separate taps", () => {
+    c.feedFrame(makeFrame(0, [{ slotId: 0, trackingId: 1, x: 100, y: 100 }]));
+    const tap1 = c.feedFrame(makeFrame(50, [], [0]));
+    expect(tap1?.type).toBe("tap");
+
+    // Second tap far away
+    c.feedFrame(makeFrame(100, [{ slotId: 0, trackingId: 2, x: 900, y: 900 }]));
+    const tap2 = c.feedFrame(makeFrame(150, [], [0]));
+    expect(tap2?.type).toBe("tap");
+  });
+
+  // -------------------------------------------------------------------------
+  // swipe
+  // -------------------------------------------------------------------------
+
+  test("high-displacement horizontal contact → swipe right", () => {
+    c.feedFrame(makeFrame(0, [{ slotId: 0, trackingId: 1, x: 100, y: 500 }]));
+    // Move finger right
+    c.feedFrame(makeFrame(50, [{ slotId: 0, trackingId: 1, x: 600, y: 500 }]));
+    const result = c.feedFrame(makeFrame(100, [], [0]));
+    expect(result?.type).toBe("swipe");
+    expect(result?.direction).toBe("right");
+    expect(result?.startX).toBe(100);
+    expect(result?.endX).toBe(600);
+  });
+
+  test("high-displacement contact leftward → swipe left", () => {
+    c.feedFrame(makeFrame(0, [{ slotId: 0, trackingId: 1, x: 800, y: 500 }]));
+    c.feedFrame(makeFrame(50, [{ slotId: 0, trackingId: 1, x: 200, y: 500 }]));
+    const result = c.feedFrame(makeFrame(100, [], [0]));
+    expect(result?.direction).toBe("left");
+  });
+
+  test("downward swipe → direction down", () => {
+    c.feedFrame(makeFrame(0, [{ slotId: 0, trackingId: 1, x: 500, y: 100 }]));
+    c.feedFrame(makeFrame(50, [{ slotId: 0, trackingId: 1, x: 500, y: 800 }]));
+    const result = c.feedFrame(makeFrame(100, [], [0]));
+    expect(result?.direction).toBe("down");
+  });
+
+  test("upward swipe → direction up", () => {
+    c.feedFrame(makeFrame(0, [{ slotId: 0, trackingId: 1, x: 500, y: 900 }]));
+    c.feedFrame(makeFrame(50, [{ slotId: 0, trackingId: 1, x: 500, y: 100 }]));
+    const result = c.feedFrame(makeFrame(100, [], [0]));
+    expect(result?.direction).toBe("up");
+  });
+
+  test("high-velocity swipe → speed fast", () => {
+    // 1000px in 10ms = 100000px/s >> FLING threshold of 50dp/s (with density=1)
+    c.feedFrame(makeFrame(0, [{ slotId: 0, trackingId: 1, x: 0, y: 500 }]));
+    c.feedFrame(makeFrame(10, [{ slotId: 0, trackingId: 1, x: 1000, y: 500 }]));
+    const result = c.feedFrame(makeFrame(10, [], [0]));
+    expect(result?.speed).toBe("fast");
+  });
+
+  test("low-velocity swipe → speed normal", () => {
+    // 100px in 10000ms = very slow
+    c.feedFrame(makeFrame(0, [{ slotId: 0, trackingId: 1, x: 0, y: 500 }]));
+    c.feedFrame(makeFrame(10000, [{ slotId: 0, trackingId: 1, x: 100, y: 500 }]));
+    const result = c.feedFrame(makeFrame(10000, [], [0]));
+    expect(result?.type).toBe("swipe");
+    expect(result?.speed).toBe("normal");
+  });
+
+  // -------------------------------------------------------------------------
+  // pinch
+  // -------------------------------------------------------------------------
+
+  test("two fingers diverging → pinch out", () => {
+    // Initial: fingers close together (distance ~100px)
+    c.feedFrame(makeFrame(0, [
+      { slotId: 0, trackingId: 1, x: 450, y: 500 },
+      { slotId: 1, trackingId: 2, x: 550, y: 500 },
+    ]));
+
+    // Move apart (distance ~400px)
+    c.feedFrame(makeFrame(100, [
+      { slotId: 0, trackingId: 1, x: 300, y: 500 },
+      { slotId: 1, trackingId: 2, x: 700, y: 500 },
+    ]));
+
+    // Both fingers lift
+    const result = c.feedFrame(makeFrame(200, [], [0, 1]));
+    expect(result?.type).toBe("pinch");
+    expect(result?.pinchDirection).toBe("out");
+    expect(result?.scale).toBeGreaterThan(1);
+  });
+
+  test("two fingers converging → pinch in", () => {
+    // Initial: fingers far apart (~400px)
+    c.feedFrame(makeFrame(0, [
+      { slotId: 0, trackingId: 1, x: 300, y: 500 },
+      { slotId: 1, trackingId: 2, x: 700, y: 500 },
+    ]));
+
+    // Move together (~100px)
+    c.feedFrame(makeFrame(100, [
+      { slotId: 0, trackingId: 1, x: 450, y: 500 },
+      { slotId: 1, trackingId: 2, x: 550, y: 500 },
+    ]));
+
+    const result = c.feedFrame(makeFrame(200, [], [0, 1]));
+    expect(result?.type).toBe("pinch");
+    expect(result?.pinchDirection).toBe("in");
+    expect(result?.scale).toBeLessThan(1);
+  });
+
+  test("two-finger scale change < PINCH_MIN_SCALE_DELTA → no pinch emitted", () => {
+    // Barely any movement: distance 100 → 105 (scale ~1.05 < 1.1 threshold)
+    c.feedFrame(makeFrame(0, [
+      { slotId: 0, trackingId: 1, x: 450, y: 500 },
+      { slotId: 1, trackingId: 2, x: 550, y: 500 },
+    ]));
+    c.feedFrame(makeFrame(100, [
+      { slotId: 0, trackingId: 1, x: 448, y: 500 },
+      { slotId: 1, trackingId: 2, x: 553, y: 500 },
+    ]));
+
+    const result = c.feedFrame(makeFrame(200, [], [0, 1]));
+    expect(result).toBeNull();
+  });
+
+  // -------------------------------------------------------------------------
+  // Edge cases
+  // -------------------------------------------------------------------------
+
+  test("returns null for intermediate frames with no release", () => {
+    c.feedFrame(makeFrame(0, [{ slotId: 0, trackingId: 1, x: 100, y: 100 }]));
+    const result = c.feedFrame(makeFrame(50, [{ slotId: 0, trackingId: 1, x: 110, y: 100 }]));
+    expect(result).toBeNull();
+  });
+
+  test("DOWN frame alone returns null", () => {
+    const result = c.feedFrame(makeFrame(0, [{ slotId: 0, trackingId: 1, x: 500, y: 500 }]));
+    expect(result).toBeNull();
+  });
+});

--- a/test/features/record/android/TouchFrameReconstructor.test.ts
+++ b/test/features/record/android/TouchFrameReconstructor.test.ts
@@ -1,0 +1,182 @@
+import { describe, test, expect, beforeEach } from "bun:test";
+import { TouchFrameReconstructor } from "../../../../src/features/record/android/TouchFrameReconstructor";
+import type { RawTouchFrame, GestureEvent } from "../../../../src/features/record/android/types";
+
+// Helper: feed multiple lines and collect all non-null results
+function feedLines(
+  r: TouchFrameReconstructor,
+  lines: string[]
+): Array<RawTouchFrame | GestureEvent> {
+  const results: Array<RawTouchFrame | GestureEvent> = [];
+  let t = 1000;
+  for (const line of lines) {
+    const result = r.feedLine(line, t++);
+    if (result) {results.push(result);}
+  }
+  return results;
+}
+
+function isFrame(x: RawTouchFrame | GestureEvent): x is RawTouchFrame {
+  return "activeSlots" in x;
+}
+
+// ---------------------------------------------------------------------------
+// Test fixtures — realistic getevent -lt output
+// ---------------------------------------------------------------------------
+
+const SINGLE_FINGER_DOWN = [
+  "[  1.000000] EV_ABS    ABS_MT_TRACKING_ID   00000001",
+  "[  1.000001] EV_ABS    ABS_MT_POSITION_X    000001a4",
+  "[  1.000002] EV_ABS    ABS_MT_POSITION_Y    000002b0",
+  "[  1.000003] EV_KEY    BTN_TOUCH            DOWN",
+  "[  1.000004] EV_SYN    SYN_REPORT           00000000",
+];
+
+const SINGLE_FINGER_UP = [
+  "[  1.100000] EV_ABS    ABS_MT_TRACKING_ID   ffffffff",
+  "[  1.100001] EV_KEY    BTN_TOUCH            UP",
+  "[  1.100002] EV_SYN    SYN_REPORT           00000000",
+];
+
+const TWO_FINGER_DOWN = [
+  // Slot 0 down
+  "[  2.000000] EV_ABS    ABS_MT_SLOT          00000000",
+  "[  2.000001] EV_ABS    ABS_MT_TRACKING_ID   00000001",
+  "[  2.000002] EV_ABS    ABS_MT_POSITION_X    00000100",
+  "[  2.000003] EV_ABS    ABS_MT_POSITION_Y    00000200",
+  // Slot 1 down
+  "[  2.000004] EV_ABS    ABS_MT_SLOT          00000001",
+  "[  2.000005] EV_ABS    ABS_MT_TRACKING_ID   00000002",
+  "[  2.000006] EV_ABS    ABS_MT_POSITION_X    00000300",
+  "[  2.000007] EV_ABS    ABS_MT_POSITION_Y    00000400",
+  "[  2.000008] EV_SYN    SYN_REPORT           00000000",
+];
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("TouchFrameReconstructor", () => {
+  let r: TouchFrameReconstructor;
+
+  beforeEach(() => {
+    r = new TouchFrameReconstructor();
+  });
+
+  test("single finger tap produces two frames (DOWN then UP)", () => {
+    const results = feedLines(r, [...SINGLE_FINGER_DOWN, ...SINGLE_FINGER_UP]);
+    const frames = results.filter(isFrame);
+    expect(frames).toHaveLength(2);
+
+    const downFrame = frames[0];
+    expect(downFrame.activeSlots).toHaveLength(1);
+    expect(downFrame.releasedSlots).toHaveLength(0);
+    expect(downFrame.activeSlots[0].x).toBe(0x1a4);
+    expect(downFrame.activeSlots[0].y).toBe(0x2b0);
+    expect(downFrame.activeSlots[0].trackingId).toBe(1);
+
+    const upFrame = frames[1];
+    expect(upFrame.activeSlots).toHaveLength(0);
+    expect(upFrame.releasedSlots).toContain(0);
+  });
+
+  test("slot with trackingId ffffffff is not included in activeSlots", () => {
+    feedLines(r, SINGLE_FINGER_DOWN);
+    const results = feedLines(r, SINGLE_FINGER_UP);
+    const frames = results.filter(isFrame);
+    expect(frames[0].activeSlots).toHaveLength(0);
+    expect(frames[0].releasedSlots).toContain(0);
+  });
+
+  test("two-finger down frame has two active slots with correct positions", () => {
+    const results = feedLines(r, TWO_FINGER_DOWN);
+    const frames = results.filter(isFrame);
+    expect(frames).toHaveLength(1);
+    const frame = frames[0];
+    expect(frame.activeSlots).toHaveLength(2);
+
+    const slot0 = frame.activeSlots.find(s => s.slotId === 0);
+    const slot1 = frame.activeSlots.find(s => s.slotId === 1);
+    expect(slot0?.x).toBe(0x100);
+    expect(slot0?.y).toBe(0x200);
+    expect(slot1?.x).toBe(0x300);
+    expect(slot1?.y).toBe(0x400);
+  });
+
+  test("EV_KEY KEY_BACK DOWN emits pressButton gesture event", () => {
+    const results = feedLines(r, [
+      "[  5.000000] EV_KEY    KEY_BACK             DOWN",
+    ]);
+    expect(results).toHaveLength(1);
+    const event = results[0];
+    expect(isFrame(event)).toBe(false);
+    expect((event as GestureEvent).type).toBe("pressButton");
+    expect((event as GestureEvent).button).toBe("back");
+  });
+
+  test("EV_KEY KEY_HOME DOWN emits pressButton with button=home", () => {
+    const results = feedLines(r, ["[  5.000000] EV_KEY    KEY_HOME             DOWN"]);
+    expect((results[0] as GestureEvent).button).toBe("home");
+  });
+
+  test("EV_KEY KEY_VOLUMEUP DOWN emits pressButton with button=volume_up", () => {
+    const results = feedLines(r, ["[  5.000000] EV_KEY    KEY_VOLUMEUP         DOWN"]);
+    expect((results[0] as GestureEvent).button).toBe("volume_up");
+  });
+
+  test("EV_KEY UP events are ignored", () => {
+    const results = feedLines(r, ["[  5.000000] EV_KEY    KEY_BACK             UP"]);
+    expect(results).toHaveLength(0);
+  });
+
+  test("Protocol A SYN_MT_REPORT (value 00000002) lines are ignored", () => {
+    const results = feedLines(r, [
+      "[  1.000000] EV_ABS    ABS_MT_TRACKING_ID   00000001",
+      "[  1.000001] EV_SYN    SYN_MT_REPORT        00000002",
+    ]);
+    expect(results).toHaveLength(0);
+  });
+
+  test("SYN_REPORT emits frame with arrivedAt equal to feedLine timestamp", () => {
+    r.feedLine("[  1.000000] EV_ABS    ABS_MT_TRACKING_ID   00000001", 1000);
+    r.feedLine("[  1.000001] EV_ABS    ABS_MT_POSITION_X    00000064", 1001);
+    const frame = r.feedLine("[  1.000002] EV_SYN    SYN_REPORT           00000000", 1234);
+    expect(frame).not.toBeNull();
+    expect(isFrame(frame!)).toBe(true);
+    expect((frame as RawTouchFrame).arrivedAt).toBe(1234);
+  });
+
+  test("multiple SYN_REPORT frames maintain independent slot state", () => {
+    // Frame 1: slot 0 at x=100
+    r.feedLine("[  1.000000] EV_ABS    ABS_MT_TRACKING_ID   00000001", 100);
+    r.feedLine("[  1.000001] EV_ABS    ABS_MT_POSITION_X    00000064", 101);
+    r.feedLine("[  1.000002] EV_ABS    ABS_MT_POSITION_Y    000000c8", 102);
+    const frame1 = r.feedLine("[  1.000003] EV_SYN    SYN_REPORT           00000000", 103);
+
+    // Frame 2: x moves to 200
+    r.feedLine("[  1.016000] EV_ABS    ABS_MT_POSITION_X    000000c8", 116);
+    const frame2 = r.feedLine("[  1.016001] EV_SYN    SYN_REPORT           00000000", 117);
+
+    expect(isFrame(frame1!)).toBe(true);
+    expect(isFrame(frame2!)).toBe(true);
+    expect((frame1 as RawTouchFrame).activeSlots[0].x).toBe(0x64);
+    expect((frame2 as RawTouchFrame).activeSlots[0].x).toBe(0xc8);
+  });
+
+  test("unrecognised event lines return null", () => {
+    const result = r.feedLine("some garbage line", 1000);
+    expect(result).toBeNull();
+    const result2 = r.feedLine("[  1.0] EV_ABS    ABS_UNKNOWN    00000000", 1001);
+    expect(result2).toBeNull();
+  });
+
+  test("pressure is parsed for ABS_MT_PRESSURE events", () => {
+    r.feedLine("[  1.000000] EV_ABS    ABS_MT_TRACKING_ID   00000001", 100);
+    r.feedLine("[  1.000001] EV_ABS    ABS_MT_POSITION_X    00000064", 101);
+    r.feedLine("[  1.000002] EV_ABS    ABS_MT_POSITION_Y    000000c8", 102);
+    r.feedLine("[  1.000003] EV_ABS    ABS_MT_PRESSURE      00000064", 103);
+    const frame = r.feedLine("[  1.000004] EV_SYN    SYN_REPORT           00000000", 104);
+    expect(isFrame(frame!)).toBe(true);
+    expect((frame as RawTouchFrame).activeSlots[0].pressure).toBe(100);
+  });
+});

--- a/test/features/record/android/TouchNodeDiscovery.test.ts
+++ b/test/features/record/android/TouchNodeDiscovery.test.ts
@@ -1,0 +1,193 @@
+import { describe, test, expect, beforeEach } from "bun:test";
+import { parseTouchNodes, discoverTouchNode } from "../../../../src/features/record/android/TouchNodeDiscovery";
+import { FakeAdbExecutor } from "../../../fakes/FakeAdbExecutor";
+
+// ---------------------------------------------------------------------------
+// Sample getevent -p output fixtures
+// ---------------------------------------------------------------------------
+
+const GETEVENT_P_TWO_DEVICES = `
+add device 1: /dev/input/event0
+  name:     "gpio-keys"
+  events:
+    KEY (0001): KEY_BACK          KEY_HOME
+add device 2: /dev/input/event3
+  name:     "Touchscreen"
+  events:
+    ABS (0003): 002f  0035  0036  0039
+  absinfo:
+    002f  : value 0, min 0, max 9, fuzz 0, flat 0, resolution 0
+    0035  : value 0, min 0, max 1079, fuzz 0, flat 0, resolution 0
+    0036  : value 0, min 0, max 1919, fuzz 0, flat 0, resolution 0
+    0039  : value -1, min -1, max 65535, fuzz 0, flat 0, resolution 0
+`;
+
+const GETEVENT_PL_FORMAT = `
+add device 1: /dev/input/event3
+  name:     "sec_touchscreen"
+  events:
+    EV_ABS (0003): ABS_MT_SLOT (002f)    ABS_MT_POSITION_X (0035)
+                   ABS_MT_POSITION_Y (0036)    ABS_MT_TRACKING_ID (0039)
+  absinfo:
+    ABS_MT_SLOT (002f): value 0, min 0, max 9, fuzz 0, flat 0, resolution 0
+    ABS_MT_POSITION_X (0035): value 0, min 0, max 1079, fuzz 0, flat 0, resolution 0
+    ABS_MT_POSITION_Y (0036): value 0, min 0, max 1919, fuzz 0, flat 0, resolution 0
+    ABS_MT_TRACKING_ID (0039): value -1, min -1, max 65535, fuzz 0, flat 0, resolution 0
+`;
+
+const GETEVENT_NO_TOUCH = `
+add device 1: /dev/input/event0
+  name:     "gpio-keys"
+  events:
+    KEY (0001): KEY_BACK          KEY_HOME
+add device 2: /dev/input/event1
+  name:     "some-accel"
+  events:
+    ABS (0003): 0000  0001  0002
+  absinfo:
+    0000  : value 0, min -2048, max 2048, fuzz 0, flat 0, resolution 0
+    0001  : value 0, min -2048, max 2048, fuzz 0, flat 0, resolution 0
+    0002  : value 0, min -2048, max 2048, fuzz 0, flat 0, resolution 0
+`;
+
+const GETEVENT_MISSING_Y_AXIS = `
+add device 1: /dev/input/event3
+  name:     "BadDevice"
+  events:
+    ABS (0003): 0035
+  absinfo:
+    0035  : value 0, min 0, max 1079, fuzz 0, flat 0, resolution 0
+`;
+
+const GETEVENT_TWO_TOUCH_DEVICES = `
+add device 1: /dev/input/event3
+  name:     "Primary Touchscreen"
+  events:
+    ABS (0003): 0035  0036
+  absinfo:
+    0035  : value 0, min 0, max 1079, fuzz 0, flat 0, resolution 0
+    0036  : value 0, min 0, max 1919, fuzz 0, flat 0, resolution 0
+add device 2: /dev/input/event4
+  name:     "Secondary Touch"
+  events:
+    ABS (0003): 0035  0036
+  absinfo:
+    0035  : value 0, min 0, max 539, fuzz 0, flat 0, resolution 0
+    0036  : value 0, min 0, max 959, fuzz 0, flat 0, resolution 0
+`;
+
+// ---------------------------------------------------------------------------
+// parseTouchNodes — pure function tests
+// ---------------------------------------------------------------------------
+
+describe("parseTouchNodes", () => {
+  test("parses a single touchscreen device from getevent -p output", () => {
+    const nodes = parseTouchNodes(GETEVENT_P_TWO_DEVICES);
+    expect(nodes).toHaveLength(1);
+    const node = nodes[0];
+    expect(node.path).toBe("/dev/input/event3");
+    expect(node.name).toBe("Touchscreen");
+    expect(node.axisXMin).toBe(0);
+    expect(node.axisXMax).toBe(1079);
+    expect(node.axisYMin).toBe(0);
+    expect(node.axisYMax).toBe(1919);
+  });
+
+  test("parses getevent -pl format with named axis codes", () => {
+    const nodes = parseTouchNodes(GETEVENT_PL_FORMAT);
+    expect(nodes).toHaveLength(1);
+    expect(nodes[0].path).toBe("/dev/input/event3");
+    expect(nodes[0].name).toBe("sec_touchscreen");
+    expect(nodes[0].axisXMax).toBe(1079);
+    expect(nodes[0].axisYMax).toBe(1919);
+  });
+
+  test("returns empty array when no multitouch devices are present", () => {
+    const nodes = parseTouchNodes(GETEVENT_NO_TOUCH);
+    expect(nodes).toHaveLength(0);
+  });
+
+  test("ignores device missing Y axis (0036)", () => {
+    const nodes = parseTouchNodes(GETEVENT_MISSING_Y_AXIS);
+    expect(nodes).toHaveLength(0);
+  });
+
+  test("returns both nodes when two touchscreens are present", () => {
+    const nodes = parseTouchNodes(GETEVENT_TWO_TOUCH_DEVICES);
+    expect(nodes).toHaveLength(2);
+    expect(nodes[0].path).toBe("/dev/input/event3");
+    expect(nodes[1].path).toBe("/dev/input/event4");
+  });
+
+  test("returns empty array for empty input", () => {
+    expect(parseTouchNodes("")).toHaveLength(0);
+  });
+
+  test("handles negative axis min values", () => {
+    const output = `
+add device 1: /dev/input/event0
+  name:     "Stylus"
+  absinfo:
+    0035  : value 0, min -100, max 8900, fuzz 0, flat 0, resolution 0
+    0036  : value 0, min -200, max 4900, fuzz 0, flat 0, resolution 0
+`;
+    const nodes = parseTouchNodes(output);
+    expect(nodes).toHaveLength(1);
+    expect(nodes[0].axisXMin).toBe(-100);
+    expect(nodes[0].axisYMin).toBe(-200);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// discoverTouchNode — integration tests using FakeAdbExecutor
+// ---------------------------------------------------------------------------
+
+describe("discoverTouchNode", () => {
+  let fakeAdb: FakeAdbExecutor;
+
+  beforeEach(() => {
+    fakeAdb = new FakeAdbExecutor();
+  });
+
+  test("returns first touch node from getevent -p output", async () => {
+    fakeAdb.setCommandResponse("getevent -p", {
+      stdout: GETEVENT_P_TWO_DEVICES,
+      stderr: "",
+      toString: () => GETEVENT_P_TWO_DEVICES,
+      trim: () => GETEVENT_P_TWO_DEVICES.trim(),
+      includes: (s: string) => GETEVENT_P_TWO_DEVICES.includes(s),
+    });
+
+    const node = await discoverTouchNode(fakeAdb);
+    expect(node).not.toBeNull();
+    expect(node!.path).toBe("/dev/input/event3");
+    expect(node!.axisXMax).toBe(1079);
+    expect(node!.axisYMax).toBe(1919);
+  });
+
+  test("returns null when no touch node found", async () => {
+    fakeAdb.setCommandResponse("getevent -p", {
+      stdout: GETEVENT_NO_TOUCH,
+      stderr: "",
+      toString: () => GETEVENT_NO_TOUCH,
+      trim: () => GETEVENT_NO_TOUCH.trim(),
+      includes: (s: string) => GETEVENT_NO_TOUCH.includes(s),
+    });
+
+    const node = await discoverTouchNode(fakeAdb);
+    expect(node).toBeNull();
+  });
+
+  test("executes the correct adb command", async () => {
+    fakeAdb.setCommandResponse("getevent -p", {
+      stdout: GETEVENT_P_TWO_DEVICES,
+      stderr: "",
+      toString: () => GETEVENT_P_TWO_DEVICES,
+      trim: () => GETEVENT_P_TWO_DEVICES.trim(),
+      includes: (s: string) => GETEVENT_P_TWO_DEVICES.includes(s),
+    });
+
+    await discoverTouchNode(fakeAdb);
+    expect(fakeAdb.wasCommandExecuted("getevent -p")).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

- Adds a parallel `adb shell getevent` stream alongside the existing AccessibilityService stream to capture gesture type with precision — enabling **doubleTap**, **longPress**, **pinch**, and **pressButton** steps that the A11y-only approach could not produce
- Introduces `DualTrackRecorder` which merges both streams within a 100ms window, using getevent for gesture classification and A11y for element identity; replaces the inline `RecordingSession` in `testRecordingManager.ts`
- Kotlin side adds an `isRecording` guard so interaction events are only broadcast over WebSocket when recording is active, reducing noise during normal automation

## New components

| Module | Purpose |
|--------|---------|
| `TouchNodeDiscovery` | Finds `/dev/input/eventN` for the touchscreen via `getevent -p` |
| `TouchFrameReconstructor` | Linux MT Protocol B state machine over `getevent -lt` text lines |
| `GestureClassifier` | Classifies `RawTouchFrame` sequences into gesture events with dp thresholds |
| `GetEventReader` | Spawns `adb shell getevent -lt`, pipes through classifier |
| `DualTrackRecorder` | Merges gesture + A11y streams within 100ms merge window |

## Test plan

- [x] 53 new unit tests covering all new modules (all pass in <100ms, no real processes or ADB)
- [x] Full test suite: 2808 pass, 0 fail
- [x] TypeScript build clean
- [x] Kotlin `assembleDebug` build clean
- [x] Lint clean
- [ ] Manual e2e on a real emulator: record tap + text + swipe + back, verify exported YAML

🤖 Generated with [Claude Code](https://claude.com/claude-code)