### PR TITLE
fix(ide-plugin): scope recomposition cache by device and clear on null

### DIFF
--- a/android/ide-plugin/src/main/kotlin/dev/jasonpearson/automobile/ide/AutoMobileToolWindowContent.kt
+++ b/android/ide-plugin/src/main/kotlin/dev/jasonpearson/automobile/ide/AutoMobileToolWindowContent.kt
@@ -463,9 +463,7 @@ fun AutoMobileToolWindowContent() {
           currentJankFrames = update.jankFrames
           currentMemoryMb = update.memoryUsageMb
           currentTouchLatencyMs = update.touchLatencyMs
-          if (update.recompositionRate != null) {
-              currentRecompositionRate = update.recompositionRate
-          }
+          currentRecompositionRate = update.recompositionRate
           perfUpdateCounter++
       }
   }

--- a/src/features/performance/PerformanceMonitor.ts
+++ b/src/features/performance/PerformanceMonitor.ts
@@ -493,7 +493,7 @@ export class PerformanceMonitor {
 
     const observationServer = getDeviceDataStreamServer();
     if (observationServer) {
-      const recompositionSummary = RecompositionTracker.getInstance().getLatestSummary(device.packageName);
+      const recompositionSummary = RecompositionTracker.getInstance().getLatestSummary(device.deviceId, device.packageName);
       const streamData: PerformanceStreamData = {
         fps: metrics.fps ?? 0,
         frameTimeMs: metrics.frameTimeMs ?? 0,

--- a/src/features/performance/RecompositionTracker.ts
+++ b/src/features/performance/RecompositionTracker.ts
@@ -46,7 +46,7 @@ export class RecompositionTracker {
   private latestTotals = new Map<string, number>();
   private lastObservationAt: number | null = null;
   private lastInteractionAt: number | null = null;
-  private latestSummaryByPackage = new Map<string, RecompositionSummary>();
+  private latestSummaryByDevice = new Map<string, RecompositionSummary>();
   private readonly parser = new DefaultElementParser();
   private timer: Timer;
 
@@ -61,8 +61,8 @@ export class RecompositionTracker {
     return RecompositionTracker.instance;
   }
 
-  getLatestSummary(packageName: string): RecompositionSummary | undefined {
-    return this.latestSummaryByPackage.get(packageName);
+  getLatestSummary(deviceId: string, packageName: string): RecompositionSummary | undefined {
+    return this.latestSummaryByDevice.get(`${deviceId}:${packageName}`);
   }
 
   recordInteraction(): void {
@@ -97,7 +97,7 @@ export class RecompositionTracker {
 
     const packageName = result.activeWindow?.appId ?? result.viewHierarchy?.packageName;
     if (packageName) {
-      this.latestSummaryByPackage.set(packageName, summary);
+      this.latestSummaryByDevice.set(`${device.deviceId}:${packageName}`, summary);
     }
 
     this.latestTotals = new Map(metrics.map(entry => [entry.id, entry.total]));


### PR DESCRIPTION
## Summary

Follow-up fixes to #1324 based on PR review feedback:

- **P1 – Device-scoped recomposition cache**: `RecompositionTracker.getLatestSummary()` previously keyed by `packageName` alone, meaning two devices running the same package would overwrite each other's cached `RecompositionSummary`. Changed the key to `deviceId:packageName` and updated the `PerformanceMonitor` call site accordingly.

- **P2 – Clear stale recomposition values on null**: `currentRecompositionRate` in the collapsed performance panel was only updated when the incoming value was non-null, leaving stale r/s readings visible after switching to a package with no cached summary. Removed the guard so it assigns the value unconditionally (including `null` to clear the display).

## Test Plan

- [x] All 2709 TypeScript tests pass (`bun test`)
- [x] Android IDE plugin build succeeds (`./gradlew -p android :ide-plugin:build`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)