### PR TITLE
fix(scripts): correct jq patternMatch causing dead code filter to suppress all results

### DIFF
--- a/scripts/detect-dead-code-ts.sh
+++ b/scripts/detect-dead-code-ts.sh
@@ -286,7 +286,7 @@ jq --argjson allow "$ALLOWLIST_JSON" --argjson bashUsed "$BASH_USED_JSON" '
   | map(
       . as $issue
       | ($ignorePaths | index($issue.file)) as $pathIndex
-      | ($ignorePathPatterns | map($issue.file | test(.)) | any) as $patternMatch
+      | ($ignorePathPatterns | map(. as $pat | $issue.file | test($pat)) | any) as $patternMatch
       | ($ignoreEntries | map(select(.file == $issue.file and (.name == null or .name == $issue.name))) | length) as $entryMatch
       | select($pathIndex == null and ($patternMatch | not) and $entryMatch == 0)
     )


### PR DESCRIPTION
## Summary
- Fixes a jq bug in `scripts/detect-dead-code-ts.sh` where `map($issue.file | test(.))` evaluated `.` as the piped file value rather than the current pattern in the array, causing every file to match itself as a regex
- This caused all 230+ dead code issues to be incorrectly filtered to zero, making the script silently report a clean codebase
- Fix binds the pattern before piping: `map(. as $pat | $issue.file | test($pat))`

## Test Plan
- [x] Ran `bash scripts/detect-dead-code-ts.sh` — now correctly surfaces 230 unused exports instead of 0
- [x] Verified allowlisted paths (e.g. `src/daemon/`) are still correctly filtered

🤖 Generated with [Claude Code](https://claude.com/claude-code)