### PR TITLE
fix: remove xcpretty install from hot-reload deps

### DIFF
--- a/scripts/local-dev/lib/deps.sh
+++ b/scripts/local-dev/lib/deps.sh
@@ -229,11 +229,6 @@ ensure_dev_tools() {
     bash "${PROJECT_ROOT}/scripts/ktfmt/install_ktfmt.sh" || ((missing++)) || true
   fi
 
-  if ! command -v xcpretty >/dev/null 2>&1; then
-    log_info "Installing xcpretty..."
-    gem install xcpretty 2>/dev/null || ((missing++)) || true
-  fi
-
   if [[ "${missing}" -gt 0 ]]; then
     log_warn "${missing} tool(s) could not be installed — some features may be unavailable"
   else


### PR DESCRIPTION
## Summary
- Removes the `gem install xcpretty` call from `ensure_dev_tools()` in `scripts/local-dev/lib/deps.sh`
- The hot-reload build path (`build_xctestservice` in `xctestservice.sh`) uses `xcodebuild -quiet` directly — xcpretty is never involved
- The standalone `scripts/ios/xctestservice-*.sh` scripts already treat xcpretty as optional (`2>/dev/null || true`) and CI installs it separately

## Test Plan
- [x] Run `./scripts/local-dev/hot-reload.sh` and confirm it no longer spends time on xcpretty install
- [x] Confirm iOS XCTestService builds correctly via hot-reload

🤖 Generated with [Claude Code](https://claude.com/claude-code)