### PR TITLE
feat: inline cell editing in database inspector + Android 15 write fix

### DIFF
--- a/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/database/SQLiteDatabaseDriver.kt
+++ b/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/database/SQLiteDatabaseDriver.kt
@@ -258,13 +258,20 @@ class SQLiteDatabaseDriver(private val context: Context) : DatabaseDriver {
     val db = openDatabase(databasePath, readOnly = false)
 
     try {
-      db.execSQL(query)
-      // Get rows affected via changes() function
-      val rowsAffected =
-          db.rawQuery("SELECT changes()", null).use { cursor ->
-            cursor.moveToFirst()
-            cursor.getInt(0)
-          }
+      // Use compileStatement().executeUpdateDelete() instead of execSQL().
+      //
+      // On Android 15 (API 35) with WAL-mode databases managed by Room, calling
+      // execSQL() fails with "Queries can be performed using SQLiteDatabase query
+      // or rawQuery methods only." because Android marks the secondary READWRITE
+      // connection as read-only when Room already holds the WAL write connection.
+      //
+      // compileStatement().executeUpdateDelete() bypasses the Java-level isReadOnly()
+      // check and goes directly through the native SQLite connection pool, allowing
+      // writes when Room's WAL lock is not actively held.
+      //
+      // It also returns the affected row count directly, avoiding the need for a
+      // separate SELECT changes() call on a potentially different connection.
+      val rowsAffected = db.compileStatement(query).executeUpdateDelete()
       return SQLExecutionResult.Mutation(rowsAffected = rowsAffected)
     } catch (e: Exception) {
       throw DatabaseError.SqlError(e.message ?: "Unknown SQL error")
@@ -296,6 +303,17 @@ class SQLiteDatabaseDriver(private val context: Context) : DatabaseDriver {
 
     try {
       val db = SQLiteDatabase.openDatabase(path, null, flags)
+      if (!readOnly) {
+        // Allow up to 5 seconds waiting for write locks held by Room or other connections.
+        // Without this, SQLite fails immediately with "database is locked" if the app has
+        // an active write transaction open on the same database.
+        //
+        // Use compileStatement().execute() instead of execSQL() here for the same reason
+        // as in executeMutation: on Android 15 (API 35) with WAL-mode databases, execSQL()
+        // calls throwIfReadOnly() which throws even on OPEN_READWRITE connections when Room
+        // holds the WAL write connection. compileStatement().execute() bypasses that check.
+        db.compileStatement("PRAGMA busy_timeout=5000").execute()
+      }
       openDatabases[path] = db
       return db
     } catch (e: Exception) {

--- a/android/ide-plugin/src/main/kotlin/dev/jasonpearson/automobile/ide/storage/DatabaseInspector.kt
+++ b/android/ide-plugin/src/main/kotlin/dev/jasonpearson/automobile/ide/storage/DatabaseInspector.kt
@@ -24,6 +24,7 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.BasicTextField
@@ -65,6 +66,9 @@ import androidx.compose.ui.window.Popup
 import androidx.compose.ui.window.PopupProperties
 import org.jetbrains.jewel.foundation.theme.JewelTheme
 import org.jetbrains.jewel.ui.component.Text
+import com.intellij.openapi.diagnostic.Logger
+
+private val LOG = Logger.getInstance("DatabaseInspector")
 
 /**
  * Database Inspector with tabs for Data, Structure, SQL, and Query History.
@@ -72,6 +76,7 @@ import org.jetbrains.jewel.ui.component.Text
 @Composable
 fun DatabaseInspector(
     databases: List<DatabaseInfo> = StorageMockData.databases,
+    loadError: String? = null,
     onFetchTableData: (suspend (databasePath: String, table: String) -> QueryResult)? = null,
     onExecuteSQL: (suspend (databasePath: String, query: String) -> QueryResult)? = null,
     modifier: Modifier = Modifier,
@@ -83,10 +88,10 @@ fun DatabaseInspector(
     var selectedDatabase by remember(databases) { mutableStateOf(databases.firstOrNull()) }
     var selectedTable by remember(selectedDatabase) { mutableStateOf(selectedDatabase?.tables?.firstOrNull()) }
     var viewMode by remember { mutableStateOf(DatabaseViewMode.Data) }
-    var queryText by remember { mutableStateOf("SELECT * FROM users WHERE is_active = 1") }
+    var queryText by remember { mutableStateOf("") }
     var queryResult by remember { mutableStateOf<QueryResult?>(null) }
-    var savedQueries by remember { mutableStateOf(StorageMockData.savedQueries) }
-    var queryHistory by remember { mutableStateOf(StorageMockData.queryHistory) }
+    var savedQueries by remember { mutableStateOf(emptyList<SavedQuery>()) }
+    var queryHistory by remember { mutableStateOf(emptyList<QueryHistoryEntry>()) }
     var tableData by remember { mutableStateOf<QueryResult?>(null) }
     var isLoadingData by remember { mutableStateOf(false) }
 
@@ -159,25 +164,30 @@ fun DatabaseInspector(
             }
         }
 
-        // Show info banner when no databases are available
+        // Show info/error banner when no databases are available
         if (databases.isEmpty()) {
+            val isError = loadError != null
             Box(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .background(Color(0xFF2196F3).copy(alpha = 0.1f))
+                    .background(
+                        if (isError) Color(0xFFFF5722).copy(alpha = 0.1f)
+                        else Color(0xFF2196F3).copy(alpha = 0.1f)
+                    )
                     .padding(12.dp),
             ) {
                 Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
                     Text(
-                        "No databases detected",
+                        if (isError) "Failed to load databases" else "No databases detected",
                         fontSize = 12.sp,
                         fontWeight = FontWeight.Medium,
-                        color = Color(0xFF2196F3),
+                        color = if (isError) Color(0xFFFF5722) else Color(0xFF2196F3),
                     )
                     Text(
-                        "AutoMobile can inspect databases via adb shell for debuggable apps. The SDK provides a richer inspection experience with live updates.",
+                        loadError ?: "AutoMobile can inspect databases via adb shell for debuggable apps. The SDK provides a richer inspection experience with live updates.",
                         fontSize = 11.sp,
                         color = colors.text.normal.copy(alpha = 0.7f),
+                        fontFamily = if (isError) androidx.compose.ui.text.font.FontFamily.Monospace else androidx.compose.ui.text.font.FontFamily.Default,
                     )
                 }
             }
@@ -208,6 +218,39 @@ fun DatabaseInspector(
                         DataView(
                             table = selectedTable!!,
                             result = tableData ?: StorageMockData.mockQueryResult,
+                            onUpdateCell = if (onExecuteSQL != null && onFetchTableData != null) {
+                                { tableName, columnName, newValue, pkValues ->
+                                    val db = selectedDatabase
+                                    if (db == null) {
+                                        "No database selected"
+                                    } else {
+                                        val set = "\"${columnName.replace("\"", "\"\"")}\" = ${formatSqlValue(newValue)}"
+                                        val where = pkValues.entries.joinToString(" AND ") { (col, v) ->
+                                            "\"${col.replace("\"", "\"\"")}\" = ${formatSqlValue(v?.toString())}"
+                                        }
+                                        val sql = "UPDATE \"${tableName.replace("\"", "\"\"")}\" SET $set WHERE $where"
+                                        LOG.info("onUpdateCell: executing SQL: $sql")
+                                        val updateResult = withContext(Dispatchers.IO) { onExecuteSQL(db.path, sql) }
+                                        if (updateResult.error == null) {
+                                            // Refresh table data in-place — do NOT touch isLoadingData,
+                                            // because that unmounts DataView (cancelling this coroutine
+                                            // and leaving updatingCell set forever).
+                                            val tbl = selectedTable
+                                            if (tbl != null) {
+                                                val newData = try {
+                                                    withContext(Dispatchers.IO) { onFetchTableData(db.path, tbl.name) }
+                                                } catch (_: Exception) { null }
+                                                if (newData != null) tableData = newData
+                                            }
+                                            null
+                                        } else {
+                                            val errMsg = enrichSqlError(updateResult, db).error ?: "Unknown error"
+                                            LOG.warn("onUpdateCell: update failed: $errMsg\nSQL: $sql")
+                                            "$errMsg\n\nSQL: $sql"
+                                        }
+                                    }
+                                }
+                            } else null,
                         )
                     }
                 } else {
@@ -240,19 +283,20 @@ fun DatabaseInspector(
                                         error = e.message ?: "Execution failed",
                                     )
                                 }
-                                queryResult = result
-                                queryHistory = listOf(
-                                    QueryHistoryEntry(
-                                        id = "h${System.currentTimeMillis()}",
-                                        sql = queryText,
-                                        databaseName = db.name,
-                                        executedAt = System.currentTimeMillis(),
-                                        executionTimeMs = result.executionTimeMs,
-                                        rowsAffected = result.rowCount,
-                                        success = result.error == null,
-                                        error = result.error,
-                                    )
-                                ) + queryHistory
+                                val enrichedResult = enrichSqlError(result, db)
+                                queryResult = enrichedResult
+                                val newEntry = QueryHistoryEntry(
+                                    id = "h${System.currentTimeMillis()}",
+                                    sql = queryText,
+                                    databaseName = db.name,
+                                    executedAt = System.currentTimeMillis(),
+                                    executionTimeMs = enrichedResult.executionTimeMs,
+                                    rowsAffected = enrichedResult.rowCount,
+                                    success = enrichedResult.error == null,
+                                    error = enrichedResult.error,
+                                )
+                                queryHistory = listOf(newEntry) +
+                                    queryHistory.filter { it.sql != queryText || it.databaseName != db.name }
                             }
                         } else {
                             // Fallback mock execution
@@ -425,9 +469,26 @@ private fun ViewModeTabs(
 private fun DataView(
     table: TableInfo,
     result: QueryResult,
+    onUpdateCell: (suspend (tableName: String, columnName: String, newValue: String?, pkValues: Map<String, Any?>) -> String?)? = null,
 ) {
     val colors = JewelTheme.globalColors
     val scrollState = rememberScrollState()
+    val coroutineScope = rememberCoroutineScope()
+
+    var editingCell by remember { mutableStateOf<Pair<Int, Int>?>(null) }
+    var editText by remember { mutableStateOf("") }
+    var updatingCell by remember { mutableStateOf<Pair<Int, Int>?>(null) }
+    // Triple: (rowIndex, colIndex, errorMessage)
+    var cellUpdateError by remember { mutableStateOf<Triple<Int, Int, String>?>(null) }
+
+    // Determine which column indices are primary keys
+    val pkColIndices = remember(table.columns, result.columns) {
+        table.columns
+            .filter { it.isPrimaryKey }
+            .mapNotNull { pk -> result.columns.indexOf(pk.name).takeIf { it >= 0 } }
+            .toSet()
+    }
+    val canEdit = onUpdateCell != null && pkColIndices.isNotEmpty()
 
     Column(modifier = Modifier.fillMaxSize()) {
         // Table header
@@ -438,53 +499,117 @@ private fun DataView(
                 .horizontalScroll(scrollState)
                 .padding(vertical = 8.dp),
         ) {
-            result.columns.forEach { column ->
-                Box(
-                    modifier = Modifier
-                        .width(150.dp)
-                        .padding(horizontal = 8.dp),
-                ) {
-                    Text(
-                        column,
-                        fontSize = 11.sp,
-                        fontWeight = FontWeight.SemiBold,
-                        color = colors.text.normal,
-                    )
+            result.columns.forEachIndexed { colIndex, column ->
+                Box(modifier = Modifier.width(150.dp).padding(horizontal = 8.dp)) {
+                    Row(
+                        horizontalArrangement = Arrangement.spacedBy(4.dp),
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        if (colIndex in pkColIndices) {
+                            Text("\uD83D\uDD11", fontSize = 9.sp)
+                        }
+                        Text(
+                            column,
+                            fontSize = 11.sp,
+                            fontWeight = FontWeight.SemiBold,
+                            color = colors.text.normal,
+                        )
+                    }
                 }
             }
         }
 
-        // Divider
-        Box(
-            modifier = Modifier
-                .fillMaxWidth()
-                .height(1.dp)
-                .background(colors.text.normal.copy(alpha = 0.1f))
-        )
+        Box(modifier = Modifier.fillMaxWidth().height(1.dp).background(colors.text.normal.copy(alpha = 0.1f)))
 
         // Table rows
         LazyColumn(modifier = Modifier.fillMaxSize()) {
-            items(result.rows) { row ->
+            itemsIndexed(result.rows) { rowIndex, row ->
+                val pkValues = pkColIndices.associate { pkIdx ->
+                    (result.columns.getOrNull(pkIdx) ?: "") to row.getOrNull(pkIdx)
+                }
                 Row(
                     modifier = Modifier
                         .fillMaxWidth()
                         .horizontalScroll(scrollState)
-                        .clickable { }
-                        .pointerHoverIcon(PointerIcon.Hand)
-                        .padding(vertical = 6.dp),
+                        .padding(vertical = 4.dp),
                 ) {
-                    row.forEach { cell ->
-                        Box(
-                            modifier = Modifier
-                                .width(150.dp)
-                                .padding(horizontal = 8.dp),
-                        ) {
-                            Text(
-                                cell?.toString() ?: "NULL",
-                                fontSize = 11.sp,
-                                color = if (cell == null) colors.text.normal.copy(alpha = 0.4f) else colors.text.normal,
-                                fontFamily = FontFamily.Monospace,
-                            )
+                    row.forEachIndexed { colIndex, cell ->
+                        val isEditing = editingCell == Pair(rowIndex, colIndex)
+                        val isUpdating = updatingCell == Pair(rowIndex, colIndex)
+                        val isPk = colIndex in pkColIndices
+                        val isEditable = canEdit && !isPk
+                        val hasError = cellUpdateError?.let { it.first == rowIndex && it.second == colIndex } == true
+
+                        Box(modifier = Modifier.width(150.dp).padding(horizontal = 8.dp, vertical = 2.dp)) {
+                            if (isEditing) {
+                                BasicTextField(
+                                    value = editText,
+                                    onValueChange = { editText = it },
+                                    textStyle = TextStyle(
+                                        fontSize = 11.sp,
+                                        color = colors.text.normal,
+                                        fontFamily = FontFamily.Monospace,
+                                    ),
+                                    cursorBrush = SolidColor(colors.text.normal),
+                                    singleLine = true,
+                                    modifier = Modifier
+                                        .fillMaxWidth()
+                                        .background(Color(0xFF2196F3).copy(alpha = 0.1f), RoundedCornerShape(2.dp))
+                                        .border(1.dp, Color(0xFF2196F3).copy(alpha = 0.6f), RoundedCornerShape(2.dp))
+                                        .padding(2.dp)
+                                        .onKeyEvent { event ->
+                                            when {
+                                                event.type == KeyEventType.KeyDown && event.key == Key.Enter -> {
+                                                    val colName = result.columns.getOrNull(colIndex)
+                                                        ?: return@onKeyEvent false
+                                                    val newVal = editText.takeUnless {
+                                                        it.equals("NULL", ignoreCase = true)
+                                                    }
+                                                    editingCell = null
+                                                    coroutineScope.launch {
+                                                        updatingCell = Pair(rowIndex, colIndex)
+                                                        cellUpdateError = null
+                                                        val errorMsg = try {
+                                                            onUpdateCell!!(table.name, colName, newVal, pkValues)
+                                                        } catch (e: Exception) { e.message ?: "Unknown error" }
+                                                        updatingCell = null
+                                                        if (errorMsg != null) cellUpdateError = Triple(rowIndex, colIndex, errorMsg)
+                                                    }
+                                                    true
+                                                }
+                                                event.type == KeyEventType.KeyDown && event.key == Key.Escape -> {
+                                                    editingCell = null
+                                                    true
+                                                }
+                                                else -> false
+                                            }
+                                        },
+                                )
+                            } else {
+                                Text(
+                                    text = if (isUpdating) "…" else cell?.toString() ?: "NULL",
+                                    fontSize = 11.sp,
+                                    color = when {
+                                        isUpdating -> Color(0xFF2196F3).copy(alpha = 0.7f)
+                                        hasError -> Color(0xFFFF5722)
+                                        cell == null -> colors.text.normal.copy(alpha = 0.4f)
+                                        isPk -> colors.text.normal.copy(alpha = 0.6f)
+                                        else -> colors.text.normal
+                                    },
+                                    fontFamily = FontFamily.Monospace,
+                                    modifier = if (isEditable) {
+                                        Modifier
+                                            .clickable {
+                                                editText = cell?.toString() ?: ""
+                                                editingCell = Pair(rowIndex, colIndex)
+                                                if (cellUpdateError?.let { it.first == rowIndex && it.second == colIndex } == true) {
+                                                    cellUpdateError = null
+                                                }
+                                            }
+                                            .pointerHoverIcon(PointerIcon.Text)
+                                    } else Modifier,
+                                )
+                            }
                         }
                     }
                 }
@@ -497,7 +622,37 @@ private fun DataView(
             }
         }
 
-        // Footer with row count
+        // Error banner
+        val currentError = cellUpdateError
+        if (currentError != null) {
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .background(Color(0xFFFF5722).copy(alpha = 0.12f))
+                    .padding(horizontal = 12.dp, vertical = 6.dp),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Text(
+                    "Update failed: ${currentError.third}",
+                    fontSize = 11.sp,
+                    color = Color(0xFFFF5722),
+                    fontFamily = FontFamily.Monospace,
+                    modifier = Modifier.weight(1f),
+                )
+                Text(
+                    "\u2715",
+                    fontSize = 12.sp,
+                    color = Color(0xFFFF5722).copy(alpha = 0.7f),
+                    modifier = Modifier
+                        .clickable { cellUpdateError = null }
+                        .pointerHoverIcon(PointerIcon.Hand)
+                        .padding(4.dp),
+                )
+            }
+        }
+
+        // Footer
         Row(
             modifier = Modifier
                 .fillMaxWidth()
@@ -506,7 +661,10 @@ private fun DataView(
             horizontalArrangement = Arrangement.SpaceBetween,
         ) {
             Text(
-                "${result.rowCount} rows",
+                buildString {
+                    append("${result.rowCount} rows")
+                    if (canEdit) append("  •  Click cell to edit, Enter to save, Esc to cancel")
+                },
                 fontSize = 10.sp,
                 color = colors.text.normal.copy(alpha = 0.5f),
             )
@@ -881,6 +1039,63 @@ private fun EmptyState(message: String) {
             color = colors.text.normal.copy(alpha = 0.5f),
         )
     }
+}
+
+/**
+ * Format a value for use in a SQL literal.
+ * Strings are single-quoted with internal quotes escaped; numbers are unquoted; null becomes NULL.
+ */
+private fun formatSqlValue(value: String?): String {
+    if (value == null) return "NULL"
+    val asLong = value.toLongOrNull()
+    val asDouble = value.toDoubleOrNull()
+    return when {
+        asLong != null -> asLong.toString()
+        asDouble != null -> asDouble.toString()
+        else -> "'${value.replace("'", "''")}'"
+    }
+}
+
+/**
+ * Strip the MCP error wrapper from a database error message.
+ *
+ * Converts "MCP server not available: MCP error -32603: Database error (SqlError): SQL error: ..."
+ * into just "SQL error: ..."
+ */
+private fun stripMcpWrapper(error: String): String {
+    val marker = "Database error ("
+    val idx = error.indexOf(marker)
+    if (idx >= 0) {
+        val closeParen = error.indexOf("):", idx)
+        if (closeParen >= 0) {
+            return error.substring(closeParen + 2).trim().trimEnd(':').trim()
+        }
+    }
+    return error
+}
+
+/**
+ * Enrich a SQL error result with schema context (available tables or columns).
+ */
+private fun enrichSqlError(result: QueryResult, database: DatabaseInfo): QueryResult {
+    val error = result.error ?: return result
+    val cleaned = stripMcpWrapper(error)
+    val enriched = when {
+        cleaned.contains("no such table", ignoreCase = true) -> {
+            val tables = database.tables.map { it.name }
+            if (tables.isNotEmpty()) "$cleaned\nAvailable tables: ${tables.joinToString(", ")}"
+            else cleaned
+        }
+        cleaned.contains("no such column", ignoreCase = true) -> {
+            val columns = database.tables.flatMap { table ->
+                table.columns.map { col -> "${table.name}.${col.name}" }
+            }
+            if (columns.isNotEmpty()) "$cleaned\nAvailable columns: ${columns.joinToString(", ")}"
+            else cleaned
+        }
+        else -> cleaned
+    }
+    return result.copy(error = enriched)
 }
 
 /**

--- a/android/ide-plugin/src/main/kotlin/dev/jasonpearson/automobile/ide/storage/StorageDashboard.kt
+++ b/android/ide-plugin/src/main/kotlin/dev/jasonpearson/automobile/ide/storage/StorageDashboard.kt
@@ -189,6 +189,7 @@ fun StorageDashboard(
         when (selectedTab) {
             StorageTab.Database -> DatabaseInspector(
                 databases = databases,
+                loadError = if (databases.isEmpty()) error else null,
                 onFetchTableData = onFetchTableData,
                 onExecuteSQL = onExecuteSQL,
                 modifier = Modifier.fillMaxSize(),

--- a/android/playground/app/src/main/kotlin/dev/jasonpearson/automobile/playground/MainActivity.kt
+++ b/android/playground/app/src/main/kotlin/dev/jasonpearson/automobile/playground/MainActivity.kt
@@ -14,6 +14,7 @@ import dev.jasonpearson.automobile.playground.navigation.AppNavigation
 import dev.jasonpearson.automobile.playground.navigation.DeepLinkManager
 import dev.jasonpearson.automobile.sdk.AutoMobileSDK
 import dev.jasonpearson.automobile.sdk.EnableComposeObservableApi
+import dev.jasonpearson.automobile.sdk.database.DatabaseInspector
 import dev.jasonpearson.automobile.sdk.storage.SharedPreferencesInspector
 import dev.jasonpearson.automobile.storage.AnalyticsTracker
 import dev.jasonpearson.automobile.storage.session.SessionRepository
@@ -36,8 +37,9 @@ class MainActivity : ComponentActivity() {
 
     // Initialize AutoMobile SDK for navigation tracking
     AutoMobileSDK.initialize(applicationContext)
-    // Enable SharedPreferences inspection in debug builds
+    // Enable storage and database inspection in debug builds
     SharedPreferencesInspector.setEnabled(true)
+    DatabaseInspector.setEnabled(true)
     Log.d(TAG, "AutoMobileSDK initialized")
 
     // Record session start in background

--- a/src/features/featureFlags/FeatureFlagApplier.ts
+++ b/src/features/featureFlags/FeatureFlagApplier.ts
@@ -34,9 +34,6 @@ export class DefaultFeatureFlagApplier implements FeatureFlagApplier {
       case "ui-perf-mode":
         serverConfig.setUiPerfMode(enabled);
         break;
-      case "ui-perf-debug":
-        serverConfig.setUiPerfDebugMode(enabled);
-        break;
       case "mem-perf-audit":
         serverConfig.setMemPerfAuditMode(enabled);
         break;

--- a/src/features/featureFlags/FeatureFlagDefinitions.ts
+++ b/src/features/featureFlags/FeatureFlagDefinitions.ts
@@ -2,7 +2,6 @@ export type FeatureFlagKey =
   | "debug"
   | "debug-perf"
   | "ui-perf-mode"
-  | "ui-perf-debug"
   | "mem-perf-audit"
   | "accessibility-audit"
   | "predictive-ui"
@@ -37,12 +36,6 @@ export const FEATURE_FLAG_DEFINITIONS: FeatureFlagDefinition[] = [
     key: "ui-perf-mode",
     label: "UI performance audit",
     description: "Run UI performance audits during observe.",
-    defaultValue: false,
-  },
-  {
-    key: "ui-perf-debug",
-    label: "UI performance debug",
-    description: "Capture recomposition summaries and store recomposition metrics.",
     defaultValue: false,
   },
   {

--- a/src/features/observe/ObserveScreen.ts
+++ b/src/features/observe/ObserveScreen.ts
@@ -328,7 +328,7 @@ export class RealObserveScreen implements ObserveScreen {
   ): Promise<void> {
     try {
       if (this.device.platform === "android") {
-        await this.viewHierarchy.configureRecompositionTracking(serverConfig.isUiPerfDebugModeEnabled(), perf);
+        await this.viewHierarchy.configureRecompositionTracking(true, perf);
       }
 
       const viewHierarchyStart = this.timer.now();

--- a/src/features/performance/RecompositionTracker.ts
+++ b/src/features/performance/RecompositionTracker.ts
@@ -12,7 +12,6 @@ import {
 } from "../../models";
 import { logger } from "../../utils/logger";
 import { Timer, defaultTimer } from "../../utils/SystemTimer";
-import { serverConfig } from "../../utils/ServerConfig";
 import { DefaultElementParser } from "../utility/ElementParser";
 
 const MAX_RECOMPOSITION_RECORDS = 10000;
@@ -66,18 +65,11 @@ export class RecompositionTracker {
   }
 
   recordInteraction(): void {
-    if (!serverConfig.isUiPerfDebugModeEnabled()) {
-      return;
-    }
     this.lastInteractionTotals = new Map(this.latestTotals);
     this.lastInteractionAt = this.timer.now();
   }
 
   async processObservation(result: ObserveResult, device: BootedDevice): Promise<void> {
-    if (!serverConfig.isUiPerfDebugModeEnabled()) {
-      return;
-    }
-
     if (!result.viewHierarchy?.hierarchy) {
       return;
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -84,7 +84,6 @@ function parseArgs(): {
   debugPerf: boolean;
   debug: boolean;
   uiPerfMode: boolean;
-  uiPerfDebug: boolean;
   memPerfAuditMode: boolean;
   a11yAuditMode: boolean;
   a11yLevel?: string;
@@ -144,7 +143,6 @@ function parseArgs(): {
   // UI performance mode is enabled by default (captures TTI, displayed metrics)
   // Use --no-ui-perf-mode to disable
   const uiPerfMode = !args.includes("--no-ui-perf-mode");
-  const uiPerfDebug = args.includes("--ui-perf-debug");
 
   // Detect memory performance audit mode
   const memPerfAuditMode = args.includes("--mem-perf-audit");
@@ -343,7 +341,6 @@ function parseArgs(): {
     debugPerf,
     debug,
     uiPerfMode,
-    uiPerfDebug,
     memPerfAuditMode,
     a11yAuditMode,
     a11yLevel,
@@ -1097,7 +1094,6 @@ async function main() {
       debugPerf,
       debug,
       uiPerfMode,
-      uiPerfDebug,
       memPerfAuditMode,
       a11yAuditMode,
       a11yLevel,
@@ -1150,7 +1146,6 @@ async function main() {
       ["debug", debug, "--debug"],
       ["debug-perf", debugPerf, "--debug-perf"],
       ["ui-perf-mode", uiPerfMode, "--ui-perf-mode"],
-      ["ui-perf-debug", uiPerfDebug, "--ui-perf-debug"],
       ["mem-perf-audit", memPerfAuditMode, "--mem-perf-audit"],
       ["accessibility-audit", a11yAuditMode, "--accessibility-audit", accessibilityConfig],
       ["predictive-ui", predictiveUi, "--predictive/--predictive-ui"],

--- a/src/models/ObserveResult.ts
+++ b/src/models/ObserveResult.ts
@@ -186,7 +186,7 @@ export interface ObserveResult {
   };
 
   /**
-   * Compose recomposition summary (when ui-perf-debug is enabled)
+   * Compose recomposition summary (populated when SDK is integrated in the target app)
    */
   recompositionSummary?: RecompositionSummary;
 

--- a/src/utils/ServerConfig.ts
+++ b/src/utils/ServerConfig.ts
@@ -16,7 +16,6 @@ export type PlanExecutionLockScope = "session" | "global";
 class ServerConfig {
   private static instance: ServerConfig;
   private _uiPerfModeEnabled: boolean = true;
-  private _uiPerfDebugEnabled: boolean = false;
   private _accessibilityAuditConfig: AccessibilityAuditConfig | null = null;
   private _memPerfAuditEnabled: boolean = false;
   private _predictiveUiEnabled: boolean = false;
@@ -42,14 +41,6 @@ class ServerConfig {
 
   isUiPerfModeEnabled(): boolean {
     return this._uiPerfModeEnabled;
-  }
-
-  setUiPerfDebugMode(enabled: boolean): void {
-    this._uiPerfDebugEnabled = enabled;
-  }
-
-  isUiPerfDebugModeEnabled(): boolean {
-    return this._uiPerfDebugEnabled;
   }
 
   setAccessibilityAuditConfig(config: AccessibilityAuditConfig | null): void {

--- a/test/features/featureFlags/FeatureFlagService.test.ts
+++ b/test/features/featureFlags/FeatureFlagService.test.ts
@@ -12,9 +12,9 @@ const TEST_DEFINITIONS: FeatureFlagDefinition[] = [
     defaultValue: false,
   },
   {
-    key: "ui-perf-debug",
-    label: "UI perf debug",
-    description: "ui debug",
+    key: "ui-perf-mode",
+    label: "UI perf mode",
+    description: "ui perf",
     defaultValue: true,
   },
 ];
@@ -29,9 +29,9 @@ describe("FeatureFlagService", () => {
 
     expect(flags).toHaveLength(2);
     expect(flags.find(flag => flag.key === "debug")?.enabled).toBe(false);
-    expect(flags.find(flag => flag.key === "ui-perf-debug")?.enabled).toBe(true);
+    expect(flags.find(flag => flag.key === "ui-perf-mode")?.enabled).toBe(true);
     expect(applier.applied).toContainEqual({ key: "debug", enabled: false, config: null });
-    expect(applier.applied).toContainEqual({ key: "ui-perf-debug", enabled: true, config: null });
+    expect(applier.applied).toContainEqual({ key: "ui-perf-mode", enabled: true, config: null });
   });
 
   test("updates flags and reapplies", async () => {


### PR DESCRIPTION
## Summary

- **Inline cell editing**: Click any non-primary-key cell in the database Data tab to edit in-place. Press Enter to commit (generates and executes an `UPDATE` statement), Escape to cancel. Primary key columns are marked with 🔑 and are read-only.
- **Android 15 write fix**: `execSQL()` calls `throwIfReadOnly()` which throws even on `OPEN_READWRITE` connections when Room holds the WAL write connection. Switched `executeMutation` and the `busy_timeout` PRAGMA to `compileStatement()` which bypasses the Java-level check and goes through the native SQLite connection pool directly.
- **Error UX**: Cell update errors appear in a dismissible banner showing both the error message and the SQL that was attempted. Load failures show a red error state instead of the blue info banner.
- **Recomposition tracking**: Removed `ui-perf-debug` feature flag; tracking is always-on when the SDK is integrated.
- **History deduplication**: Re-running the same SQL on the same database replaces the previous history entry instead of duplicating it.

## Test Plan
- [x] Built and installed on Android 15 (API 35) emulator
- [x] Verified `UPDATE` via ADB content call returns `success=true, rowsAffected: 1`
- [x] Verified write is persisted (follow-up SELECT confirms new value)
- [x] TypeScript build and lint pass
- [x] Android SDK and playground app build clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)