### PR TITLE
Fix Xcode 26.2 compatibility for runtime discovery and app detection

### DIFF
--- a/ios/XCTestService/Sources/XCTestService/CommandHandler.swift
+++ b/ios/XCTestService/Sources/XCTestService/CommandHandler.swift
@@ -333,6 +333,7 @@ public class CommandHandler: CommandHandling {
         }
 
         try gesturePerformer.launchApp(bundleId: bundleId)
+        elementLocator.trackObservedBundleId(bundleId)
 
         return WebSocketResponse.success(
             type: ResponseType.launchAppResult.rawValue,

--- a/ios/XCTestService/Sources/XCTestService/ElementLocator.swift
+++ b/ios/XCTestService/Sources/XCTestService/ElementLocator.swift
@@ -97,6 +97,10 @@ public class ElementLocator: ElementLocating {
             elementCache.removeAll()
         }
 
+        public func trackObservedBundleId(_ bundleId: String) {
+            observedBundleIds.insert(bundleId)
+        }
+
         /// Set the application to observe with its bundle ID
         public func setApplication(_ app: XCUIApplication, bundleId: String) {
             // Release old app reference before setting new one
@@ -988,6 +992,10 @@ public class ElementLocator: ElementLocating {
 
         public func findElement(byText _: String) -> Any? {
             return nil
+        }
+
+        public func trackObservedBundleId(_ bundleId: String) {
+            // no-op on non-iOS
         }
     #endif
 }

--- a/ios/XCTestService/Sources/XCTestService/Fakes.swift
+++ b/ios/XCTestService/Sources/XCTestService/Fakes.swift
@@ -89,6 +89,10 @@ public class FakeElementLocator: ElementLocating {
         findByTextHistory.append(text)
         return elements.values.first
     }
+
+    public func trackObservedBundleId(_ bundleId: String) {
+        // no-op for tests
+    }
 }
 
 // MARK: - FakeGesturePerformer

--- a/ios/XCTestService/Sources/XCTestService/Protocols.swift
+++ b/ios/XCTestService/Sources/XCTestService/Protocols.swift
@@ -13,6 +13,9 @@ public protocol ElementLocating {
 
     /// Find element by text content
     func findElement(byText text: String) -> Any?
+
+    /// Track a bundle ID so the foreground app detector can find it
+    func trackObservedBundleId(_ bundleId: String)
 }
 
 // MARK: - GesturePerformer Protocol

--- a/src/utils/ios-cmdline-tools/SimCtlClient.ts
+++ b/src/utils/ios-cmdline-tools/SimCtlClient.ts
@@ -668,8 +668,14 @@ export class SimCtlClient implements SimCtl {
    * @returns Promise with array of device types
    */
   async getDeviceTypes(): Promise<AppleDeviceType[]> {
-    const simulatorList = await this.listSimulators();
-    return simulatorList.devicetypes ?? [];
+    try {
+      const result = await this.executeCommand("list devicetypes --json");
+      const data = JSON.parse(result.stdout);
+      return data.devicetypes ?? [];
+    } catch (error) {
+      logger.warn(`Failed to get device types: ${error}`);
+      return [];
+    }
   }
 
   /**
@@ -677,8 +683,14 @@ export class SimCtlClient implements SimCtl {
    * @returns Promise with array of runtimes
    */
   async getRuntimes(): Promise<AppleDeviceRuntime[]> {
-    const simulatorList = await this.listSimulators();
-    return (simulatorList.runtimes ?? []).filter(runtime => runtime.isAvailable);
+    try {
+      const result = await this.executeCommand("list runtimes --json");
+      const data = JSON.parse(result.stdout);
+      return (data.runtimes ?? []).filter((runtime: AppleDeviceRuntime) => runtime.isAvailable);
+    } catch (error) {
+      logger.warn(`Failed to get runtimes: ${error}`);
+      return [];
+    }
   }
 
   /**

--- a/test/utils/ios-cmdline-tools/simctl.test.ts
+++ b/test/utils/ios-cmdline-tools/simctl.test.ts
@@ -223,22 +223,27 @@ describe("Simctl", function() {
     });
   });
 
-  describe("getRuntimes with missing runtimes field", function() {
-    test("should return empty array when simctl JSON has no runtimes field", async function() {
-      // Xcode 26.2 returns only {devices: {...}} from `xcrun simctl list devices --json`
+  describe("getRuntimes uses dedicated simctl command", function() {
+    test("should return runtimes from simctl list runtimes --json", async function() {
       mockExecAsync = async (file: string, args: string[]): Promise<ExecResult> => {
-        if (file === "xcrun" && args.includes("--json")) {
+        if (file === "xcrun" && args.join(" ") === "simctl list runtimes --json") {
           return createExecResult(JSON.stringify({
-            devices: {
-              "com.apple.CoreSimulator.SimRuntime.iOS-26-2": [
-                {
-                  name: "iPad Pro 13-inch (M5)",
-                  udid: "9C9EB557-D6B4-472E-8CF4-F1E0174A63C3",
-                  state: "Booted",
-                  isAvailable: true
-                }
-              ]
-            }
+            runtimes: [
+              {
+                bundlePath: "/Library/Developer/CoreSimulator/Volumes/iOS_26.2/Library/Developer/CoreSimulator/Profiles/Runtimes/iOS 26.2.simruntime",
+                identifier: "com.apple.CoreSimulator.SimRuntime.iOS-26-2",
+                isAvailable: true,
+                name: "iOS 26.2",
+                version: "26.2"
+              },
+              {
+                bundlePath: "/Library/Developer/CoreSimulator/Volumes/iOS_18.6/Library/Developer/CoreSimulator/Profiles/Runtimes/iOS 18.6.simruntime",
+                identifier: "com.apple.CoreSimulator.SimRuntime.iOS-18-6",
+                isAvailable: false,
+                name: "iOS 18.6",
+                version: "18.6"
+              }
+            ]
           }), "");
         }
         return createExecResult("", "");
@@ -246,15 +251,48 @@ describe("Simctl", function() {
 
       simctl = new Simctl(null, mockExecAsync);
       const runtimes = await simctl.getRuntimes();
-      expect(runtimes).toEqual([]);
+      expect(runtimes).toHaveLength(1);
+      expect(runtimes[0].name).toBe("iOS 26.2");
+      expect(runtimes[0].isAvailable).toBe(true);
     });
 
-    test("should return empty array from getDeviceTypes when field is missing", async function() {
+    test("should return empty array when runtimes command fails", async function() {
+      mockExecAsync = async (): Promise<ExecResult> => {
+        throw new Error("simctl failed");
+      };
+
+      simctl = new Simctl(null, mockExecAsync);
+      const runtimes = await simctl.getRuntimes();
+      expect(runtimes).toEqual([]);
+    });
+  });
+
+  describe("getDeviceTypes uses dedicated simctl command", function() {
+    test("should return device types from simctl list devicetypes --json", async function() {
       mockExecAsync = async (file: string, args: string[]): Promise<ExecResult> => {
-        if (file === "xcrun" && args.includes("--json")) {
-          return createExecResult(JSON.stringify({ devices: {} }), "");
+        if (file === "xcrun" && args.join(" ") === "simctl list devicetypes --json") {
+          return createExecResult(JSON.stringify({
+            devicetypes: [
+              {
+                name: "iPhone 17 Pro",
+                identifier: "com.apple.CoreSimulator.SimDeviceType.iPhone-17-Pro",
+                bundlePath: "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Library/Developer/CoreSimulator/Profiles/DeviceTypes/iPhone 17 Pro.simdevicetype"
+              }
+            ]
+          }), "");
         }
         return createExecResult("", "");
+      };
+
+      simctl = new Simctl(null, mockExecAsync);
+      const types = await simctl.getDeviceTypes();
+      expect(types).toHaveLength(1);
+      expect(types[0].name).toBe("iPhone 17 Pro");
+    });
+
+    test("should return empty array when devicetypes command fails", async function() {
+      mockExecAsync = async (): Promise<ExecResult> => {
+        throw new Error("simctl failed");
       };
 
       simctl = new Simctl(null, mockExecAsync);


### PR DESCRIPTION
## Summary

- **SimCtlClient**: `getRuntimes()` and `getDeviceTypes()` now use dedicated `simctl list runtimes --json` and `simctl list devicetypes --json` commands instead of relying on `simctl list devices --json`, which no longer includes runtime/devicetype data on Xcode 26.2
- **XCTestService**: `handleLaunchApp` now calls `trackObservedBundleId()` so the foreground app detector can find non-system apps (like TIDAL) after launching them via WebSocket command. Previously `observedBundleIds` was only populated at startup via `setApplication()`, which defaults to springboard in production.
- Updated tests to validate the new simctl commands and added error handling coverage

## Test plan

- [x] Full test suite passes (2778 pass, 0 fail)
- [x] Verified `simctl list runtimes --json` and `simctl list devicetypes --json` are backwards compatible (available since Xcode 10+)
- [x] Manually tested on Xcode 26.2: launched TIDAL via `request_launch_app`, confirmed XCTestService correctly observed TIDAL's view hierarchy instead of SpringBoard
- [x] codex review passed clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)