### PR TITLE
chore: update XCTestService IPA SHA256

### DIFF
--- a/src/constants/release.ts
+++ b/src/constants/release.ts
@@ -31,6 +31,6 @@ export const XCTESTSERVICE_RELEASE_VERSION: string = "latest";
 export const XCTESTSERVICE_IPA_URL: string = XCTESTSERVICE_RELEASE_VERSION === "latest"
   ? "https://github.com/kaeawc/auto-mobile/releases/latest/download/XCTestService.ipa"
   : `https://github.com/kaeawc/auto-mobile/releases/download/v${XCTESTSERVICE_RELEASE_VERSION}/XCTestService.ipa`;
-export const XCTESTSERVICE_SHA256_CHECKSUM: string = "b64758b29d944d3815825af9b2148e53a2eb3e790355a07f454c6f985e86f67a"; // Empty = skip verification (local dev only)
+export const XCTESTSERVICE_SHA256_CHECKSUM: string = "61971ba3f116df1e145a01198ad500c4ebec0b5a9682e27849a7dc8ba2ee675b"; // Empty = skip verification (local dev only)
 export const XCTESTSERVICE_APP_HASH: string = ""; // Hash of XCTestServiceApp.app (device build), empty = skip verification
 export const XCTESTSERVICE_RUNNER_SHA256: string = ""; // SHA256 of runner binary (XCTestServiceUITests-Runner), empty = skip verification


### PR DESCRIPTION
## Automated Checksum Update

The nightly build produced artifacts with updated SHA256 checksums.

| Artifact | Previous | New | Changed |
|----------|----------|-----|---------|
| **APK** | `0abb3aa8888a1f47b773943437ba2f8624b9ae11c7f2df3b883b131e69969eb1` | `0abb3aa8888a1f47b773943437ba2f8624b9ae11c7f2df3b883b131e69969eb1` | No |
| **IPA** | `b64758b29d944d3815825af9b2148e53a2eb3e790355a07f454c6f985e86f67a` | `61971ba3f116df1e145a01198ad500c4ebec0b5a9682e27849a7dc8ba2ee675b` | ✅ Yes |

### Why did this happen?

SHA256 checksums change when any of these change:
- Source code in `android/accessibility-service/src/` or `ios/XCTestService/`
- Build configuration (`build.gradle.kts` or `project.yml`)
- Dependencies or SDK versions

### What to do

1. Review this PR to ensure the changes are expected
2. Merge when ready
3. Future releases will use these checksums for artifact verification

---
Auto-generated by the `nightly` workflow