### PR TITLE
feat(talkback): adapt tapOn to support text/content-desc matching and longPress via ACTION_LONG_CLICK

### DIFF
--- a/src/features/action/TapOnElement.ts
+++ b/src/features/action/TapOnElement.ts
@@ -849,15 +849,11 @@ export class TapOnElement extends BaseVisualChange {
       ? isTalkBackEnabled
       : (await this.accessibilityDetector.detectMethod(this.device.id, this.adb)) === "talkback";
 
-    const resourceId = element?.["resource-id"];
-
-    // Use accessibility service only if TalkBack is enabled AND element has resource-id
-    // Otherwise fall back to coordinate-based tapping
-    if (talkBackEnabled && resourceId) {
-      // TalkBack mode: Use CtrlProxy ACTION_CLICK with coordinate fallback
+    if (talkBackEnabled) {
+      // TalkBack mode: Use accessibility actions with coordinate fallback
       await this.executeAndroidTapWithAccessibility(action, x, y, element, durationMs, options, signal);
     } else {
-      // Standard mode or no resource-id: Use coordinate-based taps
+      // Standard mode: Use coordinate-based taps
       await this.executeAndroidTapWithCoordinates(action, x, y, durationMs, element, signal);
     }
   }
@@ -886,7 +882,8 @@ export class TapOnElement extends BaseVisualChange {
 
   /**
    * Execute tap using CtrlProxy actions (TalkBack mode)
-   * Uses focus navigation when TalkBack is enabled, falls back to coordinate-based tapping if navigation fails
+   * Uses focus navigation when TalkBack is enabled, falls back to coordinate-based tapping if navigation fails.
+   * For longPress, tries ACTION_LONG_CLICK first, then coordinate gesture, then ADB.
    */
   private async executeAndroidTapWithAccessibility(
     action: string,
@@ -897,17 +894,29 @@ export class TapOnElement extends BaseVisualChange {
     _options?: TapOnElementOptions,
     signal?: AbortSignal
   ): Promise<void> {
-    const resourceId = element?.["resource-id"];
-    if (!resourceId) {
-      logger.warn("[TapOnElement] Element has no resource-id, falling back to coordinate-based tap");
-      await this.executeAndroidTapWithCoordinates(action, x, y, durationMs, element, signal);
+    const driver = this.talkBackDriverFactory.createDriver(this.device);
+
+    if (action === "longPress") {
+      // Long press: try ACTION_LONG_CLICK first, then coordinate gesture fallback
+      const longPressResult = await this.talkBackStrategy.executeLongPress(
+        x,
+        y,
+        durationMs,
+        element,
+        driver
+      );
+
+      if (!longPressResult.success) {
+        logger.warn(
+          `[TapOnElement] Long press accessibility methods failed (${longPressResult.error}), ` +
+          `falling back to ADB tap at (${x}, ${y})`
+        );
+        await this.executeAndroidTapWithCoordinates(action, x, y, durationMs, element, signal);
+      }
       return;
     }
 
-    const driver = this.talkBackDriverFactory.createDriver(this.device);
-
     // Try focus navigation for tap and doubleTap actions
-    // Long press still uses coordinate-based approach as it's more reliable
     if (action === "tap" || action === "doubleTap") {
       const result = await this.talkBackStrategy.executeTap(
         this.device.id,

--- a/src/features/talkback/TalkBackTapStrategy.ts
+++ b/src/features/talkback/TalkBackTapStrategy.ts
@@ -14,6 +14,7 @@ export interface TalkBackTapResult {
 
 export type TalkBackTapAction = "tap" | "doubleTap";
 export type TalkBackFallbackAction = "tap" | "doubleTap" | "longPress";
+export type TalkBackLongPressAction = "longPress";
 
 interface TalkBackTapStrategyDependencies {
   matcher?: FocusElementMatcher;
@@ -69,23 +70,26 @@ export class TalkBackTapStrategy {
     action: TalkBackTapAction,
     driver: TalkBackNavigationDriver
   ): Promise<TalkBackTapResult> {
-    const resourceId = element?.["resource-id"];
-    if (!resourceId) {
+    const resourceId = element?.["resource-id"] as string | undefined;
+    const elementText = element.text as string | undefined;
+    const elementContentDesc = element["content-desc"] as string | undefined;
+
+    if (!resourceId && !elementText && !elementContentDesc) {
       return {
         success: false,
         method: "focus-navigation",
-        error: "Element has no resource-id"
+        error: "Element has no resource-id, text, or content-desc for navigation"
       };
     }
 
     try {
-      logger.debug(`[TalkBackTapStrategy] Attempting focus navigation to element with resourceId: ${resourceId}`);
+      logger.debug(`[TalkBackTapStrategy] Attempting focus navigation to element (resourceId: ${resourceId}, text: ${elementText})`);
 
-      // Build selector from element (include bounds for disambiguation in list views)
+      // Build selector from available fields (include bounds for disambiguation in list views)
       const targetSelector = {
-        resourceId,
-        text: element.text as string | undefined,
-        contentDesc: element["content-desc"] as string | undefined,
+        ...(resourceId ? { resourceId } : {}),
+        text: elementText,
+        contentDesc: elementContentDesc,
         bounds: element.bounds
       };
 
@@ -232,13 +236,50 @@ export class TalkBackTapStrategy {
   }
 
   /**
+   * Execute a long press on an element using ACTION_LONG_CLICK with coordinate gesture fallback.
+   *
+   * Tries ACTION_LONG_CLICK first (requires resource-id), then falls back to
+   * a coordinate-based long press gesture via the accessibility service.
+   *
+   * @param x - X coordinate (for coordinate fallback)
+   * @param y - Y coordinate (for coordinate fallback)
+   * @param durationMs - Long press duration in milliseconds
+   * @param element - The target element
+   * @param driver - The TalkBack navigation driver
+   * @returns Result indicating success/failure and method used
+   */
+  async executeLongPress(
+    x: number,
+    y: number,
+    durationMs: number,
+    element: Element,
+    driver: TalkBackNavigationDriver
+  ): Promise<TalkBackTapResult> {
+    const resourceId = element["resource-id"] as string | undefined;
+
+    if (resourceId) {
+      const longClickResult = await driver.requestAction("long_click", resourceId);
+      if (longClickResult.success) {
+        logger.info(`[TalkBackTapStrategy] Long press via ACTION_LONG_CLICK succeeded`);
+        return { success: true, method: "focus-navigation" };
+      }
+      logger.warn(
+        `[TalkBackTapStrategy] ACTION_LONG_CLICK failed (${longClickResult.error}), ` +
+        `falling back to coordinate gesture`
+      );
+    }
+
+    return this.executeCoordinateFallback(x, y, "longPress", durationMs, driver);
+  }
+
+  /**
    * Activate the currently focused element using double-tap with ACTION_CLICK fallback.
    */
   private async activateElement(
     element: Element,
     driver: TalkBackNavigationDriver
   ): Promise<TalkBackTapResult> {
-    const resourceId = element["resource-id"];
+    const resourceId = element["resource-id"] as string | undefined;
     const center = this.getElementCenter(element);
     const tapDuration = 50;
 
@@ -246,17 +287,24 @@ export class TalkBackTapStrategy {
     const firstTap = await driver.requestTapCoordinates(center.x, center.y, tapDuration);
 
     if (!firstTap.success) {
-      // If double-tap fails, try ACTION_CLICK on the resource-id
-      logger.warn(`[TalkBackTapStrategy] Double-tap activation failed, trying ACTION_CLICK fallback`);
-      const clickResult = await driver.requestAction("click", resourceId);
-      if (!clickResult.success) {
-        return {
-          success: false,
-          method: "focus-navigation",
-          error: `Activation failed: double-tap and ACTION_CLICK both failed`
-        };
+      if (resourceId) {
+        // If double-tap fails, try ACTION_CLICK on the resource-id
+        logger.warn(`[TalkBackTapStrategy] Double-tap activation failed, trying ACTION_CLICK fallback`);
+        const clickResult = await driver.requestAction("click", resourceId);
+        if (!clickResult.success) {
+          return {
+            success: false,
+            method: "focus-navigation",
+            error: `Activation failed: double-tap and ACTION_CLICK both failed`
+          };
+        }
+        return { success: true, method: "focus-navigation" };
       }
-      return { success: true, method: "focus-navigation" };
+      return {
+        success: false,
+        method: "focus-navigation",
+        error: `Activation failed: double-tap failed`
+      };
     }
 
     await this.timer.sleep(200);
@@ -265,14 +313,22 @@ export class TalkBackTapStrategy {
     const secondTap = await driver.requestTapCoordinates(center.x, center.y, tapDuration);
 
     if (!secondTap.success) {
-      // If second tap fails, try ACTION_CLICK as fallback
-      logger.warn(`[TalkBackTapStrategy] Second tap failed, trying ACTION_CLICK fallback`);
-      const clickResult = await driver.requestAction("click", resourceId);
-      if (!clickResult.success) {
+      if (resourceId) {
+        // If second tap fails, try ACTION_CLICK as fallback
+        logger.warn(`[TalkBackTapStrategy] Second tap failed, trying ACTION_CLICK fallback`);
+        const clickResult = await driver.requestAction("click", resourceId);
+        if (!clickResult.success) {
+          return {
+            success: false,
+            method: "focus-navigation",
+            error: `Activation failed: second tap and ACTION_CLICK both failed`
+          };
+        }
+      } else {
         return {
           success: false,
           method: "focus-navigation",
-          error: `Activation failed: second tap and ACTION_CLICK both failed`
+          error: `Activation failed: second tap failed`
         };
       }
     }

--- a/test/fakes/FakeTalkBackTapStrategy.ts
+++ b/test/fakes/FakeTalkBackTapStrategy.ts
@@ -12,6 +12,7 @@ import type { TalkBackNavigationDriver } from "../../src/features/talkback/TalkB
 export class FakeTalkBackTapStrategy {
   tapResult: TalkBackTapResult = { success: true, method: "focus-navigation" };
   fallbackResult: TalkBackTapResult = { success: true, method: "coordinate-fallback" };
+  longPressResult: TalkBackTapResult = { success: true, method: "focus-navigation" };
 
   tapCalls: Array<{
     deviceId: string;
@@ -26,8 +27,16 @@ export class FakeTalkBackTapStrategy {
     durationMs: number;
   }> = [];
 
+  longPressCalls: Array<{
+    x: number;
+    y: number;
+    durationMs: number;
+    element: Element;
+  }> = [];
+
   private tapOverrides: TalkBackTapResult[] = [];
   private fallbackOverrides: TalkBackTapResult[] = [];
+  private longPressOverrides: TalkBackTapResult[] = [];
 
   setTapResult(result: TalkBackTapResult): void {
     this.tapResult = result;
@@ -37,12 +46,20 @@ export class FakeTalkBackTapStrategy {
     this.fallbackResult = result;
   }
 
+  setLongPressResult(result: TalkBackTapResult): void {
+    this.longPressResult = result;
+  }
+
   queueTapResult(result: TalkBackTapResult): void {
     this.tapOverrides.push(result);
   }
 
   queueFallbackResult(result: TalkBackTapResult): void {
     this.fallbackOverrides.push(result);
+  }
+
+  queueLongPressResult(result: TalkBackTapResult): void {
+    this.longPressOverrides.push(result);
   }
 
   async executeTap(
@@ -74,5 +91,21 @@ export class FakeTalkBackTapStrategy {
     }
 
     return this.fallbackResult;
+  }
+
+  async executeLongPress(
+    x: number,
+    y: number,
+    durationMs: number,
+    element: Element,
+    _driver: TalkBackNavigationDriver
+  ): Promise<TalkBackTapResult> {
+    this.longPressCalls.push({ x, y, durationMs, element });
+
+    if (this.longPressOverrides.length > 0) {
+      return this.longPressOverrides.shift()!;
+    }
+
+    return this.longPressResult;
   }
 }

--- a/test/features/action/TapOnElement.talkback.test.ts
+++ b/test/features/action/TapOnElement.talkback.test.ts
@@ -163,6 +163,26 @@ describe("TapOnElement TalkBack mode detection", () => {
       );
     });
 
+    test("dispatches to accessibility-based tap method for element without resource-id", async () => {
+      const element = {
+        "bounds": { left: 0, top: 0, right: 100, bottom: 100 },
+        text: "Settings",
+      } as any;
+
+      await (tapOnElement as any).executeAndroidTap(
+        "tap",
+        50,
+        50,
+        500,
+        element,
+        undefined,
+        { action: "tap" }
+      );
+
+      expect(executeAndroidTapWithAccessibility).toHaveBeenCalledTimes(1);
+      expect(executeAndroidTapWithCoordinates).not.toHaveBeenCalled();
+    });
+
     test("uses accessibility method for all action types", async () => {
       const element = {
         "bounds": { left: 0, top: 0, right: 100, bottom: 100 },
@@ -392,7 +412,7 @@ describe("TapOnElement TalkBackTapStrategy delegation", () => {
     expect(fakeTalkBackStrategy.tapCalls[0].action).toBe("doubleTap");
   });
 
-  test("skips focus navigation for longPress and uses coordinate fallback", async () => {
+  test("uses executeLongPress for longPress action", async () => {
     const element = {
       "resource-id": "test:id/button",
       "bounds": { left: 0, top: 0, right: 100, bottom: 100 }
@@ -410,14 +430,41 @@ describe("TapOnElement TalkBackTapStrategy delegation", () => {
 
     // Should not call executeTap for longPress
     expect(fakeTalkBackStrategy.tapCalls).toHaveLength(0);
-    // Should go directly to coordinate fallback
-    expect(fakeTalkBackStrategy.fallbackCalls).toHaveLength(1);
-    expect(fakeTalkBackStrategy.fallbackCalls[0]).toEqual({
+    // Should call executeLongPress (not coordinate fallback directly)
+    expect(fakeTalkBackStrategy.longPressCalls).toHaveLength(1);
+    expect(fakeTalkBackStrategy.longPressCalls[0]).toMatchObject({
       x: 50,
       y: 50,
-      action: "longPress",
-      durationMs: 1000
+      durationMs: 1000,
+      element
     });
+    expect(fakeTalkBackStrategy.fallbackCalls).toHaveLength(0);
+  });
+
+  test("falls back to ADB tap when executeLongPress fails", async () => {
+    const element = {
+      "resource-id": "test:id/button",
+      "bounds": { left: 0, top: 0, right: 100, bottom: 100 }
+    } as any;
+
+    fakeTalkBackStrategy.setLongPressResult({
+      success: false,
+      method: "coordinate-fallback",
+      error: "Long press failed"
+    });
+
+    await (tapOnElement as any).executeAndroidTapWithAccessibility(
+      "longPress",
+      50,
+      50,
+      element,
+      1000,
+      {},
+      undefined
+    );
+
+    expect(fakeTalkBackStrategy.longPressCalls).toHaveLength(1);
+    expect(executeAndroidTapWithCoordinates).toHaveBeenCalledWith("longPress", 50, 50, 1000, element, undefined);
   });
 
   test("uses coordinate fallback when focus navigation fails", async () => {
@@ -479,7 +526,7 @@ describe("TapOnElement TalkBackTapStrategy delegation", () => {
     expect(executeAndroidTapWithCoordinates).toHaveBeenCalledWith("tap", 50, 50, 500, element, undefined);
   });
 
-  test("falls back to coordinate-based tap when element has no resource-id", async () => {
+  test("routes text-only element through focus navigation", async () => {
     const element = {
       bounds: { left: 0, top: 0, right: 100, bottom: 100 },
       text: "Button without ID"
@@ -495,8 +542,41 @@ describe("TapOnElement TalkBackTapStrategy delegation", () => {
       undefined
     );
 
-    expect(fakeTalkBackStrategy.tapCalls).toHaveLength(0);
-    expect(fakeTalkBackStrategy.fallbackCalls).toHaveLength(0);
+    // Strategy is called even without resource-id
+    expect(fakeTalkBackStrategy.tapCalls).toHaveLength(1);
+    expect(fakeTalkBackStrategy.tapCalls[0].element).toBe(element);
+    expect(executeAndroidTapWithCoordinates).not.toHaveBeenCalled();
+  });
+
+  test("falls back to ADB tap when strategy returns failure for element with no identifying info", async () => {
+    const element = {
+      bounds: { left: 0, top: 0, right: 100, bottom: 100 }
+      // no text, no resource-id, no content-desc
+    } as any;
+
+    fakeTalkBackStrategy.setTapResult({
+      success: false,
+      method: "focus-navigation",
+      error: "no identifying information"
+    });
+    fakeTalkBackStrategy.setFallbackResult({
+      success: false,
+      method: "coordinate-fallback",
+      error: "fallback failed"
+    });
+
+    await (tapOnElement as any).executeAndroidTapWithAccessibility(
+      "tap",
+      50,
+      50,
+      element,
+      500,
+      {},
+      undefined
+    );
+
+    expect(fakeTalkBackStrategy.tapCalls).toHaveLength(1);
+    expect(fakeTalkBackStrategy.fallbackCalls).toHaveLength(1);
     expect(executeAndroidTapWithCoordinates).toHaveBeenCalledWith("tap", 50, 50, 500, element, undefined);
   });
 });

--- a/test/features/talkback/TalkBackTapStrategy.test.ts
+++ b/test/features/talkback/TalkBackTapStrategy.test.ts
@@ -37,17 +37,54 @@ describe("TalkBackTapStrategy", () => {
   });
 
   describe("executeTap", () => {
-    test("returns error when element has no resource-id", async () => {
+    test("returns error when element has no identifying information", async () => {
       const element = {
-        bounds: { left: 0, top: 0, right: 100, bottom: 100 },
-        text: "Button"
+        bounds: { left: 0, top: 0, right: 100, bottom: 100 }
+        // no text, no resource-id, no content-desc
       } as Element;
 
       const result = await strategy.executeTap("device-1", element, "tap", driver);
 
       expect(result.success).toBe(false);
       expect(result.method).toBe("focus-navigation");
-      expect(result.error).toContain("no resource-id");
+      expect(result.error).toBeDefined();
+    });
+
+    test("navigates using text match when element has no resource-id", async () => {
+      const element = {
+        bounds: { left: 0, top: 0, right: 100, bottom: 100 },
+        text: "Button"
+      } as Element;
+
+      driver.setElements([element], 0);
+
+      const navigateToElement = spyOn(mockExecutor, "navigateToElement")
+        .mockResolvedValue(true);
+
+      const result = await strategy.executeTap("device-1", element, "tap", driver);
+
+      expect(result.success).toBe(true);
+      expect(result.method).toBe("focus-navigation");
+      expect(navigateToElement).toHaveBeenCalledTimes(1);
+      expect(driver.getTapCount()).toBe(2); // Double-tap to activate
+    });
+
+    test("navigates using content-desc match when element has no resource-id", async () => {
+      const element = {
+        "bounds": { left: 0, top: 0, right: 100, bottom: 100 },
+        "content-desc": "Close dialog"
+      } as Element;
+
+      driver.setElements([element], 0);
+
+      const navigateToElement = spyOn(mockExecutor, "navigateToElement")
+        .mockResolvedValue(true);
+
+      const result = await strategy.executeTap("device-1", element, "tap", driver);
+
+      expect(result.success).toBe(true);
+      expect(result.method).toBe("focus-navigation");
+      expect(navigateToElement).toHaveBeenCalledTimes(1);
     });
 
     test("uses focus navigation for tap action", async () => {
@@ -179,6 +216,71 @@ describe("TalkBackTapStrategy", () => {
       expect(result.success).toBe(false);
       expect(result.method).toBe("focus-navigation");
       expect(result.error).toContain("traversal order");
+    });
+  });
+
+  describe("executeLongPress", () => {
+    test("uses ACTION_LONG_CLICK when element has resource-id", async () => {
+      const element = {
+        "resource-id": "test:id/button",
+        "bounds": { left: 0, top: 0, right: 100, bottom: 100 }
+      } as Element;
+
+      driver.setActionResult({ success: true, action: "long_click", totalTimeMs: 1 });
+
+      const result = await strategy.executeLongPress(50, 50, 1000, element, driver);
+
+      expect(result.success).toBe(true);
+      expect(result.method).toBe("focus-navigation");
+      expect(driver.actionHistory).toHaveLength(1);
+      expect(driver.actionHistory[0]).toEqual({ action: "long_click", resourceId: "test:id/button" });
+      expect(driver.getTapCount()).toBe(0); // No coordinate taps
+    });
+
+    test("falls back to coordinate gesture when ACTION_LONG_CLICK fails", async () => {
+      const element = {
+        "resource-id": "test:id/button",
+        "bounds": { left: 0, top: 0, right: 100, bottom: 100 }
+      } as Element;
+
+      driver.setActionResult({ success: false, action: "long_click", totalTimeMs: 1, error: "service unavailable" });
+
+      const result = await strategy.executeLongPress(50, 50, 1000, element, driver);
+
+      expect(result.success).toBe(true);
+      expect(result.method).toBe("coordinate-fallback");
+      expect(driver.getTapCount()).toBe(1);
+      expect(driver.tapHistory[0]).toEqual({ x: 50, y: 50, durationMs: 1000 }); // Full duration for longPress
+    });
+
+    test("uses coordinate gesture directly when element has no resource-id", async () => {
+      const element = {
+        bounds: { left: 0, top: 0, right: 100, bottom: 100 },
+        text: "Button"
+      } as Element;
+
+      const result = await strategy.executeLongPress(50, 50, 1000, element, driver);
+
+      expect(result.success).toBe(true);
+      expect(result.method).toBe("coordinate-fallback");
+      expect(driver.getActionCount()).toBe(0); // No ACTION_LONG_CLICK attempted
+      expect(driver.getTapCount()).toBe(1);
+      expect(driver.tapHistory[0]).toEqual({ x: 50, y: 50, durationMs: 1000 });
+    });
+
+    test("returns error when coordinate fallback also fails", async () => {
+      const element = {
+        "resource-id": "test:id/button",
+        "bounds": { left: 0, top: 0, right: 100, bottom: 100 }
+      } as Element;
+
+      driver.setActionResult({ success: false, action: "long_click", totalTimeMs: 1, error: "failed" });
+      driver.setTapResult({ success: false, totalTimeMs: 1, error: "gesture failed" });
+
+      const result = await strategy.executeLongPress(50, 50, 1000, element, driver);
+
+      expect(result.success).toBe(false);
+      expect(result.method).toBe("coordinate-fallback");
     });
   });
 


### PR DESCRIPTION
## Summary

- Removes the `resource-id` gate in `TapOnElement.executeAndroidTap` so all TalkBack taps route through the accessibility path, not just elements that have a resource-id
- Updates `TalkBackTapStrategy.executeTap` to match elements by `text` or `content-desc` when no `resource-id` is present
- Adds `TalkBackTapStrategy.executeLongPress` that tries `ACTION_LONG_CLICK` first (when resource-id is available) then falls back to a coordinate-based long-press gesture via the accessibility service
- Wires `executeAndroidTapWithAccessibility` to use `executeLongPress` for longPress actions, with a final ADB coordinate fallback when both accessibility methods fail
- Updates `FakeTalkBackTapStrategy` with full `executeLongPress` support and adds/updates tests covering all new behaviours

Closes #1357

## Test plan

- [x] `bun test test/features/action/TapOnElement.talkback.test.ts` — all tests pass
- [x] `bun test test/features/talkback/TalkBackTapStrategy.test.ts` — all tests pass
- [x] Verify element-without-resource-id still routes through accessibility (not coordinate fallback)
- [x] Verify longPress via ACTION_LONG_CLICK succeeds when resource-id present
- [x] Verify longPress falls back to coordinate gesture when ACTION_LONG_CLICK fails
- [x] Verify longPress falls back to ADB tap when all accessibility methods fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)