### PR TITLE
feat: AutoMobileBiometrics.overrideResult() SDK hook for deterministic biometric testing

### DIFF
--- a/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/AutoMobileSDK.kt
+++ b/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/AutoMobileSDK.kt
@@ -6,6 +6,7 @@ import dev.jasonpearson.automobile.protocol.NavigationSourceType
 import dev.jasonpearson.automobile.protocol.SdkEventSerializer
 import dev.jasonpearson.automobile.protocol.SdkNavigationEvent
 import dev.jasonpearson.automobile.sdk.anr.AutoMobileAnr
+import dev.jasonpearson.automobile.sdk.biometrics.AutoMobileBiometrics
 import dev.jasonpearson.automobile.sdk.crashes.AutoMobileCrashes
 import dev.jasonpearson.automobile.sdk.database.DatabaseInspector
 import dev.jasonpearson.automobile.sdk.failures.AutoMobileFailures
@@ -70,6 +71,7 @@ object AutoMobileSDK {
     AutoMobileFailures.initialize(this.context!!)
     AutoMobileCrashes.initialize(this.context!!)
     AutoMobileAnr.initialize(this.context!!)
+    AutoMobileBiometrics.initialize(this.context!!)
   }
 
   /**

--- a/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/biometrics/AutoMobileBiometrics.kt
+++ b/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/biometrics/AutoMobileBiometrics.kt
@@ -1,0 +1,204 @@
+package dev.jasonpearson.automobile.sdk.biometrics
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.content.IntentFilter
+import android.os.Build
+import android.util.Log
+import java.util.concurrent.atomic.AtomicReference
+
+/**
+ * SDK hook for deterministic biometric testing.
+ *
+ * Allows test code or the AutoMobile MCP server to inject a known [BiometricResult] so that
+ * `BiometricPrompt` flows are testable without requiring actual fingerprint/face hardware
+ * interaction.
+ *
+ * ## App integration
+ *
+ * 1. Initialize (called automatically by `AutoMobileSDK.initialize`):
+ *    ```kotlin
+ *    AutoMobileBiometrics.initialize(applicationContext)
+ *    ```
+ *
+ * 2. Call [consumeOverride] inside every branch of your `BiometricPrompt.AuthenticationCallback`
+ *    **before** delegating to your real handler. If an override is active it is returned and
+ *    cleared atomically; otherwise `null` is returned and you handle the real system result.
+ *
+ *    ```kotlin
+ *    val prompt = BiometricPrompt(
+ *        activity,
+ *        executor,
+ *        object : BiometricPrompt.AuthenticationCallback() {
+ *            override fun onAuthenticationSucceeded(result: BiometricPrompt.AuthenticationResult) {
+ *                when (val override = AutoMobileBiometrics.consumeOverride()) {
+ *                    is BiometricResult.Failure -> handleFailure()
+ *                    is BiometricResult.Cancel  -> handleCancel()
+ *                    is BiometricResult.Error   -> handleError(override.errorCode, override.errorMessage)
+ *                    is BiometricResult.Success, null -> handleSuccess()
+ *                }
+ *            }
+ *            override fun onAuthenticationFailed() {
+ *                when (val override = AutoMobileBiometrics.consumeOverride()) {
+ *                    is BiometricResult.Success -> handleSuccess()
+ *                    is BiometricResult.Error   -> handleError(override.errorCode, override.errorMessage)
+ *                    is BiometricResult.Cancel  -> handleCancel()
+ *                    is BiometricResult.Failure, null -> handleFailure()
+ *                }
+ *            }
+ *            override fun onAuthenticationError(errorCode: Int, errString: CharSequence) {
+ *                when (val override = AutoMobileBiometrics.consumeOverride()) {
+ *                    is BiometricResult.Success -> handleSuccess()
+ *                    is BiometricResult.Failure -> handleFailure()
+ *                    is BiometricResult.Cancel  -> handleCancel()
+ *                    is BiometricResult.Error, null -> handleError(errorCode, errString.toString())
+ *                }
+ *            }
+ *        }
+ *    )
+ *    ```
+ *
+ * 3. In test `@Before` setup, call [clearOverride] to prevent stale overrides from a previous
+ *    test from affecting the current one.
+ *
+ * ## How MCP-triggered overrides work
+ *
+ * The AutoMobile MCP `biometricAuth` tool broadcasts an override intent via ADB and then
+ * triggers the biometric callback using `adb emu finger touch` (emulator). The broadcast is
+ * received here and stored. When [consumeOverride] is called inside the app's callback the stored
+ * result is returned and the override is cleared.
+ */
+object AutoMobileBiometrics {
+
+    private const val TAG = "AutoMobileBiometrics"
+
+    /** Broadcast action sent by the AutoMobile MCP server to set a biometric override. */
+    const val ACTION_BIOMETRIC_OVERRIDE = "dev.jasonpearson.automobile.sdk.BIOMETRIC_OVERRIDE"
+
+    /** String extra: one of "SUCCESS", "FAILURE", "CANCEL", "ERROR". */
+    const val EXTRA_RESULT = "result"
+
+    /** Int extra: `BiometricPrompt.ERROR_*` constant; only used when [EXTRA_RESULT] is "ERROR". */
+    const val EXTRA_ERROR_CODE = "errorCode"
+
+    /** Long extra: override lifetime in milliseconds (default 5000). */
+    const val EXTRA_TTL_MS = "ttlMs"
+
+    private data class PendingOverride(
+        val result: BiometricResult,
+        val expiryMs: Long,
+    )
+
+    private val pendingOverride = AtomicReference<PendingOverride?>(null)
+    private var context: Context? = null
+    private var receiverRegistered = false
+
+    /**
+     * Initialize with application context. Required to receive MCP broadcast overrides.
+     * Called automatically by `AutoMobileSDK.initialize`.
+     *
+     * @param context Application context (use `applicationContext`, not activity context).
+     */
+    fun initialize(context: Context) {
+        this.context = context.applicationContext
+        registerReceiver()
+    }
+
+    /**
+     * Store a biometric override that will be returned by the next [consumeOverride] call.
+     *
+     * The override expires after [ttlMs] milliseconds to prevent stale values from leaking
+     * across test cases. Call [clearOverride] in `@Before` test setup to guarantee a clean state.
+     *
+     * Any previously stored override is replaced.
+     *
+     * @param result The result to inject into the next authentication attempt.
+     * @param ttlMs Override lifetime in milliseconds (default: 5000).
+     */
+    fun overrideResult(result: BiometricResult, ttlMs: Long = 5000L) {
+        val expiryMs = System.currentTimeMillis() + ttlMs
+        pendingOverride.set(PendingOverride(result, expiryMs))
+        Log.d(TAG, "Biometric override set: $result (expires in ${ttlMs}ms)")
+    }
+
+    /**
+     * Clear any stored override.
+     *
+     * Call this in `@Before` test setup so that stale overrides from a previous test cannot
+     * affect the current one.
+     */
+    fun clearOverride() {
+        pendingOverride.set(null)
+        Log.d(TAG, "Biometric override cleared")
+    }
+
+    /**
+     * Consume and return the stored override, or `null` if no override is active or it has expired.
+     *
+     * This method is atomic: the override is cleared when it is consumed, so it applies to only
+     * one authentication attempt.
+     *
+     * Call this inside **every** branch of your `BiometricPrompt.AuthenticationCallback` before
+     * delegating to your real authentication handler. See the class-level documentation for the
+     * recommended integration pattern.
+     *
+     * @return The stored [BiometricResult], or `null` if no override is active.
+     */
+    fun consumeOverride(): BiometricResult? {
+        val override = pendingOverride.get() ?: return null
+        if (System.currentTimeMillis() > override.expiryMs) {
+            pendingOverride.set(null)
+            Log.d(TAG, "Biometric override expired, discarding")
+            return null
+        }
+        return if (pendingOverride.compareAndSet(override, null)) {
+            Log.d(TAG, "Biometric override consumed: ${override.result}")
+            override.result
+        } else {
+            null
+        }
+    }
+
+    private fun registerReceiver() {
+        if (receiverRegistered) return
+        val ctx = context ?: return
+        try {
+            val filter = IntentFilter(ACTION_BIOMETRIC_OVERRIDE)
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                ctx.registerReceiver(broadcastReceiver, filter, Context.RECEIVER_EXPORTED)
+            } else {
+                @Suppress("UnspecifiedRegisterReceiverFlag")
+                ctx.registerReceiver(broadcastReceiver, filter)
+            }
+            receiverRegistered = true
+            Log.d(TAG, "Biometric override broadcast receiver registered")
+        } catch (e: Exception) {
+            Log.e(TAG, "Failed to register biometric override receiver", e)
+        }
+    }
+
+    private val broadcastReceiver = object : BroadcastReceiver() {
+        override fun onReceive(context: Context, intent: Intent) {
+            val resultStr = intent.getStringExtra(EXTRA_RESULT) ?: run {
+                Log.w(TAG, "Biometric override broadcast missing '$EXTRA_RESULT' extra")
+                return
+            }
+            val errorCode = intent.getIntExtra(EXTRA_ERROR_CODE, -1)
+            val ttlMs = intent.getLongExtra(EXTRA_TTL_MS, 5000L)
+
+            val result: BiometricResult = when (resultStr.uppercase()) {
+                "SUCCESS" -> BiometricResult.Success
+                "FAILURE" -> BiometricResult.Failure
+                "CANCEL" -> BiometricResult.Cancel
+                "ERROR" -> BiometricResult.Error(errorCode)
+                else -> {
+                    Log.w(TAG, "Unknown biometric override result: '$resultStr'")
+                    return
+                }
+            }
+
+            overrideResult(result, ttlMs)
+        }
+    }
+}

--- a/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/biometrics/BiometricResult.kt
+++ b/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/biometrics/BiometricResult.kt
@@ -1,0 +1,31 @@
+package dev.jasonpearson.automobile.sdk.biometrics
+
+/**
+ * Represents the result that [AutoMobileBiometrics.overrideResult] will inject into the next
+ * biometric authentication attempt.
+ *
+ * Used by test code or the AutoMobile MCP server to control biometric outcomes deterministically.
+ */
+sealed class BiometricResult {
+
+    /** Override: authentication succeeds. */
+    object Success : BiometricResult()
+
+    /** Override: authentication is rejected (non-matching biometric). */
+    object Failure : BiometricResult()
+
+    /** Override: authentication is cancelled by the user. */
+    object Cancel : BiometricResult()
+
+    /**
+     * Override: authentication encounters a hard error.
+     *
+     * @param errorCode One of the `BiometricPrompt.ERROR_*` constants, e.g.
+     *   `BiometricPrompt.ERROR_LOCKOUT` (7) or `BiometricPrompt.ERROR_HW_UNAVAILABLE` (1).
+     * @param errorMessage Human-readable error description (optional; defaults to empty string).
+     */
+    data class Error(
+        val errorCode: Int,
+        val errorMessage: String = "",
+    ) : BiometricResult()
+}

--- a/android/auto-mobile-sdk/src/test/kotlin/dev/jasonpearson/automobile/sdk/biometrics/AutoMobileBiometricsTest.kt
+++ b/android/auto-mobile-sdk/src/test/kotlin/dev/jasonpearson/automobile/sdk/biometrics/AutoMobileBiometricsTest.kt
@@ -1,0 +1,148 @@
+package dev.jasonpearson.automobile.sdk.biometrics
+
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class AutoMobileBiometricsTest {
+
+    @Before
+    fun setup() {
+        AutoMobileBiometrics.clearOverride()
+    }
+
+    @After
+    fun tearDown() {
+        AutoMobileBiometrics.clearOverride()
+    }
+
+    // -------------------------------------------------------------------------
+    // consumeOverride – basic result types
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `consumeOverride returns null when no override is set`() {
+        assertNull(AutoMobileBiometrics.consumeOverride())
+    }
+
+    @Test
+    fun `consumeOverride returns Success after overrideResult Success`() {
+        AutoMobileBiometrics.overrideResult(BiometricResult.Success)
+        assertEquals(BiometricResult.Success, AutoMobileBiometrics.consumeOverride())
+    }
+
+    @Test
+    fun `consumeOverride returns Failure after overrideResult Failure`() {
+        AutoMobileBiometrics.overrideResult(BiometricResult.Failure)
+        assertEquals(BiometricResult.Failure, AutoMobileBiometrics.consumeOverride())
+    }
+
+    @Test
+    fun `consumeOverride returns Cancel after overrideResult Cancel`() {
+        AutoMobileBiometrics.overrideResult(BiometricResult.Cancel)
+        assertEquals(BiometricResult.Cancel, AutoMobileBiometrics.consumeOverride())
+    }
+
+    @Test
+    fun `consumeOverride returns Error with errorCode after overrideResult Error`() {
+        AutoMobileBiometrics.overrideResult(BiometricResult.Error(errorCode = 7))
+        val consumed = AutoMobileBiometrics.consumeOverride()
+        assertNotNull(consumed)
+        assertTrue(consumed is BiometricResult.Error)
+        assertEquals(7, (consumed as BiometricResult.Error).errorCode)
+    }
+
+    @Test
+    fun `consumeOverride returns Error with errorCode and errorMessage`() {
+        AutoMobileBiometrics.overrideResult(BiometricResult.Error(errorCode = 5, errorMessage = "Lockout"))
+        val consumed = AutoMobileBiometrics.consumeOverride()
+        assertNotNull(consumed)
+        val error = consumed as BiometricResult.Error
+        assertEquals(5, error.errorCode)
+        assertEquals("Lockout", error.errorMessage)
+    }
+
+    // -------------------------------------------------------------------------
+    // Single-use / atomicity
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `consumeOverride clears override after first call`() {
+        AutoMobileBiometrics.overrideResult(BiometricResult.Success)
+        AutoMobileBiometrics.consumeOverride()
+        assertNull(AutoMobileBiometrics.consumeOverride())
+    }
+
+    @Test
+    fun `clearOverride removes a pending override`() {
+        AutoMobileBiometrics.overrideResult(BiometricResult.Success)
+        AutoMobileBiometrics.clearOverride()
+        assertNull(AutoMobileBiometrics.consumeOverride())
+    }
+
+    @Test
+    fun `overrideResult replaces an existing override`() {
+        AutoMobileBiometrics.overrideResult(BiometricResult.Success)
+        AutoMobileBiometrics.overrideResult(BiometricResult.Failure)
+        assertEquals(BiometricResult.Failure, AutoMobileBiometrics.consumeOverride())
+    }
+
+    // -------------------------------------------------------------------------
+    // TTL expiry
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `consumeOverride returns null when override has already expired`() {
+        // Negative TTL → expiryMs is in the past immediately
+        AutoMobileBiometrics.overrideResult(BiometricResult.Success, ttlMs = -1L)
+        assertNull(AutoMobileBiometrics.consumeOverride())
+    }
+
+    @Test
+    fun `consumeOverride returns result when override has not expired`() {
+        AutoMobileBiometrics.overrideResult(BiometricResult.Failure, ttlMs = 60_000L)
+        assertEquals(BiometricResult.Failure, AutoMobileBiometrics.consumeOverride())
+    }
+
+    // -------------------------------------------------------------------------
+    // BiometricResult model
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `Error has default empty errorMessage`() {
+        val error = BiometricResult.Error(errorCode = 1)
+        assertEquals("", error.errorMessage)
+    }
+
+    @Test
+    fun `Error equality is based on errorCode and errorMessage`() {
+        assertEquals(BiometricResult.Error(7, "Lockout"), BiometricResult.Error(7, "Lockout"))
+        assertTrue(BiometricResult.Error(7) != BiometricResult.Error(5))
+    }
+
+    // -------------------------------------------------------------------------
+    // Constants
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `ACTION_BIOMETRIC_OVERRIDE has expected value`() {
+        assertEquals(
+            "dev.jasonpearson.automobile.sdk.BIOMETRIC_OVERRIDE",
+            AutoMobileBiometrics.ACTION_BIOMETRIC_OVERRIDE,
+        )
+    }
+
+    @Test
+    fun `extra key constants have expected values`() {
+        assertEquals("result", AutoMobileBiometrics.EXTRA_RESULT)
+        assertEquals("errorCode", AutoMobileBiometrics.EXTRA_ERROR_CODE)
+        assertEquals("ttlMs", AutoMobileBiometrics.EXTRA_TTL_MS)
+    }
+}

--- a/docs/design-docs/plat/android/biometrics.md
+++ b/docs/design-docs/plat/android/biometrics.md
@@ -1,8 +1,8 @@
 # Biometrics Stubbing
 
-<kbd>✅ Implemented</kbd> <kbd>🧪 Tested</kbd> <kbd>🤖 Emulator Only</kbd>
+<kbd>✅ Implemented</kbd> <kbd>🧪 Tested</kbd>
 
-> **Current state:** The `biometricAuth` MCP tool is fully implemented and tested for Android emulators via `adb emu finger touch/remove`. Physical Android devices and face/iris modalities are not supported. The optional SDK hook (`AutoMobileBiometrics.overrideResult()`) is <kbd>❌ Not Implemented</kbd>. See the [Status Glossary](../../status-glossary.md) for chip definitions.
+> **Current state:** The `biometricAuth` MCP tool is fully implemented and tested for Android emulators via `adb emu finger touch/remove`. Physical Android devices receive an SDK broadcast override (`supported: "partial"`). Face/iris modalities are not supported. The `AutoMobileBiometrics` SDK hook is <kbd>✅ Implemented</kbd>. See the [Status Glossary](../../status-glossary.md) for chip definitions.
 
 ## Goal
 
@@ -14,17 +14,21 @@ when emulator support is not sufficient.
 
 ```typescript
 biometricAuth({
-  action: "match" | "fail" | "cancel",
+  action: "match" | "fail" | "cancel" | "error",
   modality: "any" | "fingerprint" | "face",
-  fingerprintId?: number
+  fingerprintId?: number,
+  errorCode?: number,   // BiometricPrompt.ERROR_* constant; used with action: "error"
+  ttlMs?: number        // SDK override TTL in ms (default: 5000)
 })
 ```
 
 Behavior:
 
 - `modality: any` prefers fingerprint on emulator (highest support).
-- `action: match` should succeed if enrollment exists.
-- `action: fail` should simulate a non-matching biometric.
+- `action: match` — succeeds if enrollment exists.
+- `action: fail` — simulates a non-matching biometric.
+- `action: cancel` — simulates user cancellation via the SDK override.
+- `action: error` — injects a hard `BiometricPrompt` error; requires SDK integration.
 
 ## Emulator implementation (API 29/35)
 
@@ -100,22 +104,76 @@ Notes:
 
 ## App-under-test integration (AutoMobile SDK)
 
-When emulator-only support is not enough, add a debug-only SDK hook to
-bypass or simulate biometric callbacks within the app-under-test.
+`AutoMobileBiometrics` is a debug-only SDK hook that makes biometric
+authentication flows deterministic without physical hardware interaction.
 
-Suggested SDK entrypoint:
+### SDK API
 
-```text
-AutoMobileBiometrics.overrideResult(
-  result = SUCCESS | FAILURE | CANCEL,
-  ttlMs = 5000
-)
+```kotlin
+// Initialize (called automatically by AutoMobileSDK.initialize):
+AutoMobileBiometrics.initialize(applicationContext)
+
+// Set an override (called by test code or triggered via MCP broadcast):
+AutoMobileBiometrics.overrideResult(BiometricResult.Success, ttlMs = 5000L)
+AutoMobileBiometrics.overrideResult(BiometricResult.Failure)
+AutoMobileBiometrics.overrideResult(BiometricResult.Cancel)
+AutoMobileBiometrics.overrideResult(BiometricResult.Error(errorCode = 7))
+
+// Clear a pending override (call in @Before test setup):
+AutoMobileBiometrics.clearOverride()
+
+// Consume the override inside BiometricPrompt.AuthenticationCallback:
+val override = AutoMobileBiometrics.consumeOverride()
 ```
 
-Notes:
+### App integration pattern
 
-- This is a build-time opt-in for apps we can modify.
-- It can bypass the system prompt to make tests deterministic.
+Call `consumeOverride()` inside every branch of `BiometricPrompt.AuthenticationCallback`
+before delegating to your real handler:
+
+```kotlin
+object : BiometricPrompt.AuthenticationCallback() {
+    override fun onAuthenticationSucceeded(result: BiometricPrompt.AuthenticationResult) {
+        when (val override = AutoMobileBiometrics.consumeOverride()) {
+            is BiometricResult.Failure -> handleFailure()
+            is BiometricResult.Cancel  -> handleCancel()
+            is BiometricResult.Error   -> handleError(override.errorCode, override.errorMessage)
+            is BiometricResult.Success, null -> handleSuccess()
+        }
+    }
+    override fun onAuthenticationFailed() {
+        when (val override = AutoMobileBiometrics.consumeOverride()) {
+            is BiometricResult.Success -> handleSuccess()
+            is BiometricResult.Error   -> handleError(override.errorCode, override.errorMessage)
+            is BiometricResult.Cancel  -> handleCancel()
+            is BiometricResult.Failure, null -> handleFailure()
+        }
+    }
+    override fun onAuthenticationError(errorCode: Int, errString: CharSequence) {
+        when (val override = AutoMobileBiometrics.consumeOverride()) {
+            is BiometricResult.Success -> handleSuccess()
+            is BiometricResult.Failure -> handleFailure()
+            is BiometricResult.Cancel  -> handleCancel()
+            is BiometricResult.Error, null -> handleError(errorCode, errString.toString())
+        }
+    }
+}
+```
+
+### How MCP-triggered overrides work
+
+1. `biometricAuth` MCP tool sends `am broadcast` with override → SDK stores it.
+2. MCP tool fires `adb emu finger touch 1` (emulator) to trigger the callback.
+3. App calls `consumeOverride()` → override is consumed atomically, real result is swapped.
+
+On physical devices, only the broadcast is sent (`supported: "partial"`). The override will
+be applied when the biometric prompt fires normally.
+
+### Override semantics
+
+- The override is single-use: consumed by the first `consumeOverride()` call.
+- Default TTL is 5000 ms; expired overrides are discarded.
+- Call `clearOverride()` in `@Before` test setup to prevent stale state.
 
 ## Plan
 

--- a/schemas/tool-definitions.json
+++ b/schemas/tool-definitions.json
@@ -1,7 +1,7 @@
 [
   {
     "name": "biometricAuth",
-    "description": "Simulate biometric authentication (fingerprint) on Android emulators. Trigger match/fail/cancel actions for testing biometric prompts.",
+    "description": "Simulate biometric authentication (fingerprint) on Android emulators, or inject a deterministic result via the AutoMobile SDK on any device. Supports match/fail/cancel/error actions. The SDK broadcast path requires the app to integrate AutoMobileBiometrics.consumeOverride().",
     "inputSchema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "type": "object",
@@ -11,9 +11,10 @@
           "enum": [
             "match",
             "fail",
-            "cancel"
+            "cancel",
+            "error"
           ],
-          "description": "Biometric action: 'match' triggers successful authentication, 'fail' simulates non-matching biometric, 'cancel' cancels the prompt"
+          "description": "Biometric action: 'match' triggers successful authentication, 'fail' simulates a non-matching biometric, 'cancel' cancels the prompt, 'error' injects a hard error (requires AutoMobileBiometrics SDK integration in the app)."
         },
         "modality": {
           "description": "Biometric modality (default: 'any'). Currently only 'fingerprint' is reliably supported on Android emulators. 'face' is not consistently supported.",
@@ -25,7 +26,15 @@
           ]
         },
         "fingerprintId": {
-          "description": "Fingerprint ID to simulate (default: 1 for 'match', 2 for 'fail'). Use enrolled ID (typically 1) for match, non-enrolled ID (typically 2) for fail.",
+          "description": "Fingerprint ID to simulate (default: 1 for 'match'/'error', 2 for 'fail'/'cancel'). Use enrolled ID (typically 1) for match/error, non-enrolled ID (typically 2) for fail/cancel.",
+          "type": "number"
+        },
+        "errorCode": {
+          "description": "BiometricPrompt error code to inject when action is 'error' (e.g. 7 for ERROR_LOCKOUT, 1 for ERROR_HW_UNAVAILABLE). Requires AutoMobileBiometrics SDK integration in the app.",
+          "type": "number"
+        },
+        "ttlMs": {
+          "description": "How long the SDK override remains active in milliseconds (default: 5000). The override is cleared after the first authentication callback or when the TTL expires.",
           "type": "number"
         },
         "sessionUuid": {

--- a/src/features/action/BiometricAuth.ts
+++ b/src/features/action/BiometricAuth.ts
@@ -6,10 +6,18 @@ import { logger } from "../../utils/logger";
 import { Timer, defaultTimer } from "../../utils/SystemTimer";
 
 export interface BiometricAuthOptions {
-  action: "match" | "fail" | "cancel";
+  action: "match" | "fail" | "cancel" | "error";
   modality?: "any" | "fingerprint" | "face";
   fingerprintId?: number;
+  errorCode?: number;
+  ttlMs?: number;
 }
+
+/** Broadcast action received by AutoMobileBiometrics in the app-under-test SDK. */
+const SDK_BROADCAST_ACTION = "dev.jasonpearson.automobile.sdk.BIOMETRIC_OVERRIDE";
+
+/** Default TTL for SDK overrides in milliseconds. */
+const DEFAULT_TTL_MS = 5000;
 
 export class BiometricAuth extends BaseVisualChange {
   constructor(
@@ -36,6 +44,7 @@ export class BiometricAuth extends BaseVisualChange {
         action: options.action,
         modality: options.modality ?? "any",
         fingerprintId: options.fingerprintId,
+        errorCode: options.errorCode,
         supported: false,
         error: "Biometric authentication is only supported on Android devices"
       };
@@ -50,22 +59,33 @@ export class BiometricAuth extends BaseVisualChange {
         action: options.action,
         modality,
         fingerprintId: options.fingerprintId,
+        errorCode: options.errorCode,
         supported: false,
         error: "Face biometric modality is not supported. Only 'any' and 'fingerprint' are supported on Android emulators."
       };
     }
 
+    // Send SDK override broadcast (works on emulators and physical devices)
+    const broadcastOk = await this.sendSdkOverrideBroadcast(options);
+    if (!broadcastOk) {
+      logger.warn("SDK override broadcast failed; app may not have AutoMobileBiometrics integrated");
+    }
+
     // Check if device is an emulator
     const capabilityResult = await this.checkCapability();
+
     if (!capabilityResult.isEmulator) {
       perf.end();
       return {
-        success: false,
+        success: true,
         action: options.action,
-        modality: options.modality ?? "any",
+        modality,
         fingerprintId: options.fingerprintId,
-        supported: false,
-        error: "Biometric authentication simulation is only supported on Android emulators. Physical devices are not supported."
+        errorCode: options.errorCode,
+        supported: "partial",
+        message:
+          "SDK override broadcast sent. Emulator emu finger commands are not available on physical devices. " +
+          "Ensure the app integrates AutoMobileBiometrics.consumeOverride() in its BiometricPrompt.AuthenticationCallback."
       };
     }
 
@@ -74,8 +94,9 @@ export class BiometricAuth extends BaseVisualChange {
       return {
         success: false,
         action: options.action,
-        modality: options.modality ?? "any",
+        modality,
         fingerprintId: options.fingerprintId,
+        errorCode: options.errorCode,
         supported: false,
         error: "This emulator does not support 'emu finger' commands"
       };
@@ -83,14 +104,13 @@ export class BiometricAuth extends BaseVisualChange {
 
     return this.observedInteraction(
       async () => {
-        // Execute the biometric action based on the requested type
         const result = await perf.track("executeBiometricAction", () =>
           this.executeBiometricAction(options)
         );
         return result;
       },
       {
-        changeExpected: false, // Don't override success based on view hierarchy changes
+        changeExpected: false,
         timeoutMs: 5000,
         progress,
         perf
@@ -99,11 +119,48 @@ export class BiometricAuth extends BaseVisualChange {
   }
 
   /**
+   * Send an ADB broadcast that AutoMobileBiometrics (in the app-under-test) will receive
+   * and use to override the next biometric callback result.
+   *
+   * Returns true if the broadcast command succeeded, false on error.
+   */
+  private async sendSdkOverrideBroadcast(options: BiometricAuthOptions): Promise<boolean> {
+    try {
+      const resultValue = this.actionToSdkResult(options.action);
+      const ttlMs = options.ttlMs ?? DEFAULT_TTL_MS;
+
+      let cmd =
+        `shell am broadcast -a ${SDK_BROADCAST_ACTION}` +
+        ` --es result ${resultValue}` +
+        ` --el ttlMs ${ttlMs}`;
+
+      if (options.action === "error" && options.errorCode !== undefined) {
+        cmd += ` --ei errorCode ${options.errorCode}`;
+      }
+
+      await this.adb.executeCommand(cmd);
+      return true;
+    } catch (error) {
+      logger.warn(`Failed to send SDK biometric override broadcast: ${error}`);
+      return false;
+    }
+  }
+
+  /** Map MCP action name to the string expected by AutoMobileBiometrics broadcast receiver. */
+  private actionToSdkResult(action: BiometricAuthOptions["action"]): string {
+    switch (action) {
+      case "match":  return "SUCCESS";
+      case "fail":   return "FAILURE";
+      case "cancel": return "CANCEL";
+      case "error":  return "ERROR";
+    }
+  }
+
+  /**
    * Check if the device is an emulator and supports emu finger commands
    */
   private async checkCapability(): Promise<{ isEmulator: boolean; supportsEmuFinger: boolean }> {
     try {
-      // Check if device is an emulator
       const qemuResult = await this.adb.executeCommand("shell getprop ro.kernel.qemu");
       const isEmulator = qemuResult.trim() === "1";
 
@@ -111,7 +168,6 @@ export class BiometricAuth extends BaseVisualChange {
         return { isEmulator: false, supportsEmuFinger: false };
       }
 
-      // Check if emu finger commands are available
       try {
         const emuHelpResult = await this.adb.executeCommand("emu help");
         const supportsEmuFinger = emuHelpResult.includes("finger");
@@ -127,38 +183,41 @@ export class BiometricAuth extends BaseVisualChange {
   }
 
   /**
-   * Execute the biometric action (match, fail, or cancel)
+   * Execute the biometric action via emu finger commands.
+   *
+   * For match:  touch enrolled ID 1  → onAuthenticationSucceeded
+   * For fail:   touch unenrolled ID 2 → onAuthenticationFailed
+   * For cancel: touch unenrolled ID 2 → onAuthenticationFailed (override converts to cancel)
+   * For error:  touch enrolled ID 1   → onAuthenticationSucceeded (override converts to error)
    */
   private async executeBiometricAction(options: BiometricAuthOptions): Promise<BiometricAuthResult> {
     const modality = options.modality ?? "any";
 
-    // Determine fingerprint ID based on action
+    // Determine fingerprint ID
     let fingerprintId = options.fingerprintId;
     if (fingerprintId === undefined) {
-      // Use default IDs based on action
-      fingerprintId = options.action === "match" ? 1 : 2;
+      // match and error use enrolled ID 1 to reliably trigger the success callback;
+      // fail and cancel use unenrolled ID 2.
+      fingerprintId = (options.action === "match" || options.action === "error") ? 1 : 2;
     }
 
     try {
-      // Execute fingerprint touch
       const touchResult = await this.adb.executeCommand(`emu finger touch ${fingerprintId}`);
 
-      // Check if command failed (stderr contains error message)
       if (touchResult.stderr && touchResult.stderr.trim().length > 0) {
         return {
           success: false,
           action: options.action,
           modality,
           fingerprintId,
+          errorCode: options.errorCode,
           supported: true,
           error: `emu finger touch failed: ${touchResult.stderr}`
         };
       }
 
-      // Wait a brief moment for the touch to register
       await this.timer.sleep(100);
 
-      // Release the fingerprint sensor
       const removeResult = await this.adb.executeCommand(`emu finger remove ${fingerprintId}`);
 
       if (removeResult.stderr && removeResult.stderr.trim().length > 0) {
@@ -167,34 +226,13 @@ export class BiometricAuth extends BaseVisualChange {
           action: options.action,
           modality,
           fingerprintId,
+          errorCode: options.errorCode,
           supported: true,
           error: `emu finger remove failed: ${removeResult.stderr}`
         };
       }
 
-      // For 'fail' action, we need to verify that the emulator actually differentiates IDs
-      // If it doesn't, this should be reported as an error (per user's preference)
-      if (options.action === "fail") {
-        // The expectation is that ID 2 (non-enrolled) should fail
-        // If the emulator doesn't differentiate, the user wants an error
-        return {
-          success: true,
-          action: options.action,
-          modality,
-          fingerprintId,
-          supported: true,
-          message: `Simulated biometric ${options.action} with fingerprint ID ${fingerprintId}. Note: Some emulators may not differentiate between enrolled and non-enrolled fingerprint IDs.`
-        };
-      }
-
-      return {
-        success: true,
-        action: options.action,
-        modality,
-        fingerprintId,
-        supported: true,
-        message: `Successfully simulated biometric ${options.action} with fingerprint ID ${fingerprintId}`
-      };
+      return this.buildSuccessResult(options, modality, fingerprintId);
     } catch (error) {
       logger.error(`Failed to execute biometric action: ${error}`);
       return {
@@ -202,9 +240,45 @@ export class BiometricAuth extends BaseVisualChange {
         action: options.action,
         modality,
         fingerprintId,
+        errorCode: options.errorCode,
         supported: true,
         error: `Failed to execute emu finger commands: ${error instanceof Error ? error.message : String(error)}`
       };
+    }
+  }
+
+  private buildSuccessResult(
+    options: BiometricAuthOptions,
+    modality: string,
+    fingerprintId: number
+  ): BiometricAuthResult {
+    const base = {
+      success: true,
+      action: options.action,
+      modality: modality as BiometricAuthResult["modality"],
+      fingerprintId,
+      errorCode: options.errorCode,
+      supported: true as const
+    };
+
+    switch (options.action) {
+      case "fail":
+        return {
+          ...base,
+          message: `Simulated biometric ${options.action} with fingerprint ID ${fingerprintId}. Note: Some emulators may not differentiate between enrolled and non-enrolled fingerprint IDs.`
+        };
+      case "error":
+        return {
+          ...base,
+          message:
+            `SDK override broadcast sent with ERROR (errorCode=${options.errorCode ?? -1}) and emu finger touch ${fingerprintId} fired. ` +
+            `App must call AutoMobileBiometrics.consumeOverride() in its BiometricPrompt.AuthenticationCallback.`
+        };
+      default:
+        return {
+          ...base,
+          message: `Successfully simulated biometric ${options.action} with fingerprint ID ${fingerprintId}`
+        };
     }
   }
 }

--- a/src/models/BiometricAuthResult.ts
+++ b/src/models/BiometricAuthResult.ts
@@ -5,9 +5,10 @@ import { ObserveResult } from "./ObserveResult";
  */
 export interface BiometricAuthResult {
   success: boolean;
-  action: "match" | "fail" | "cancel";
+  action: "match" | "fail" | "cancel" | "error";
   modality: "any" | "fingerprint" | "face";
   fingerprintId?: number;
+  errorCode?: number;
   supported: boolean | "partial";
   observation?: ObserveResult;
   error?: string;

--- a/src/server/biometricTools.ts
+++ b/src/server/biometricTools.ts
@@ -12,14 +12,21 @@ export interface BiometricAuthArgs extends BiometricAuthOptions {
 
 // Schema definition
 export const biometricAuthSchema = addDeviceTargetingToSchema(z.object({
-  action: z.enum(["match", "fail", "cancel"]).describe(
-    "Biometric action: 'match' triggers successful authentication, 'fail' simulates non-matching biometric, 'cancel' cancels the prompt"
+  action: z.enum(["match", "fail", "cancel", "error"]).describe(
+    "Biometric action: 'match' triggers successful authentication, 'fail' simulates a non-matching biometric, " +
+    "'cancel' cancels the prompt, 'error' injects a hard error (requires AutoMobileBiometrics SDK integration in the app)."
   ),
   modality: z.enum(["any", "fingerprint", "face"]).optional().describe(
     "Biometric modality (default: 'any'). Currently only 'fingerprint' is reliably supported on Android emulators. 'face' is not consistently supported."
   ),
   fingerprintId: z.number().optional().describe(
-    "Fingerprint ID to simulate (default: 1 for 'match', 2 for 'fail'). Use enrolled ID (typically 1) for match, non-enrolled ID (typically 2) for fail."
+    "Fingerprint ID to simulate (default: 1 for 'match'/'error', 2 for 'fail'/'cancel'). Use enrolled ID (typically 1) for match/error, non-enrolled ID (typically 2) for fail/cancel."
+  ),
+  errorCode: z.number().optional().describe(
+    "BiometricPrompt error code to inject when action is 'error' (e.g. 7 for ERROR_LOCKOUT, 1 for ERROR_HW_UNAVAILABLE). Requires AutoMobileBiometrics SDK integration in the app."
+  ),
+  ttlMs: z.number().optional().describe(
+    "How long the SDK override remains active in milliseconds (default: 5000). The override is cleared after the first authentication callback or when the TTL expires."
   )
 }));
 
@@ -38,7 +45,9 @@ export function registerBiometricTools() {
       const result = await biometricAuth.execute({
         action: args.action,
         modality: args.modality,
-        fingerprintId: args.fingerprintId
+        fingerprintId: args.fingerprintId,
+        errorCode: args.errorCode,
+        ttlMs: args.ttlMs
       }, progress);
 
       if (!result.success) {
@@ -58,7 +67,8 @@ export function registerBiometricTools() {
   // Register the tool
   ToolRegistry.registerDeviceAware(
     "biometricAuth",
-    "Simulate biometric authentication (fingerprint) on Android emulators. Trigger match/fail/cancel actions for testing biometric prompts.",
+    "Simulate biometric authentication (fingerprint) on Android emulators, or inject a deterministic result via the AutoMobile SDK on any device. " +
+    "Supports match/fail/cancel/error actions. The SDK broadcast path requires the app to integrate AutoMobileBiometrics.consumeOverride().",
     biometricAuthSchema,
     biometricAuthHandler,
     true // Supports progress notifications

--- a/test/features/action/BiometricAuth.test.ts
+++ b/test/features/action/BiometricAuth.test.ts
@@ -26,7 +26,6 @@ describe("BiometricAuth", () => {
   let device: BootedDevice;
 
   beforeEach(() => {
-    // Create fakes for testing
     fakeAdb = new FakeAdbExecutor();
     fakeObserveScreen = new FakeObserveScreen();
     fakeWindow = new FakeWindow();
@@ -34,24 +33,24 @@ describe("BiometricAuth", () => {
     fakeTimer = new FakeTimer();
     fakeTimer.enableAutoAdvance();
 
-    // Create a mock device
     device = {
       deviceId: "test-device",
       platform: "android"
     } as BootedDevice;
 
-    // Set up default fake responses
     fakeWindow.configureCachedActiveWindow(null);
     fakeWindow.configureActiveWindow({ appId: "com.test.app", activityName: "MainActivity", layoutSeqSum: 123 });
     fakeObserveScreen.setObserveResult(() => createObserveResult());
 
-    // Set up emulator detection (device is an emulator)
+    // Emulator detection
     fakeAdb.setCommandResponse("shell getprop ro.kernel.qemu", { stdout: "1", stderr: "" });
     fakeAdb.setCommandResponse("emu help", { stdout: "finger - fingerprint commands\nhelp - show this help", stderr: "" });
 
+    // SDK broadcast (matches any am broadcast command for biometric override)
+    fakeAdb.setCommandResponse("BIOMETRIC_OVERRIDE", { stdout: "Broadcast completed (1 receivers)", stderr: "" });
+
     biometricAuth = new BiometricAuth(device, fakeAdb, fakeTimer);
 
-    // Replace the internal managers with our fakes
     (biometricAuth as any).observeScreen = fakeObserveScreen;
     (biometricAuth as any).window = fakeWindow;
     (biometricAuth as any).awaitIdle = fakeAwaitIdle;
@@ -71,7 +70,6 @@ describe("BiometricAuth", () => {
       expect(result.supported).toBe(true);
       expect(result.observation).toBeDefined();
 
-      // Verify correct commands were executed
       const executedCommands = fakeAdb.getExecutedCommands();
       expect(executedCommands.some(cmd => cmd.includes("emu finger touch 1"))).toBe(true);
       expect(executedCommands.some(cmd => cmd.includes("emu finger remove 1"))).toBe(true);
@@ -106,6 +104,18 @@ describe("BiometricAuth", () => {
       expect(result.success).toBe(true);
       expect(result.modality).toBe("fingerprint");
     });
+
+    test("should send SDK override broadcast with SUCCESS for match", async () => {
+      fakeAdb.setCommandResponse("emu finger touch 1", { stdout: "", stderr: "" });
+      fakeAdb.setCommandResponse("emu finger remove 1", { stdout: "", stderr: "" });
+
+      await biometricAuth.execute({ action: "match" });
+
+      const executedCommands = fakeAdb.getExecutedCommands();
+      expect(executedCommands.some(cmd =>
+        cmd.includes("BIOMETRIC_OVERRIDE") && cmd.includes("SUCCESS")
+      )).toBe(true);
+    });
   });
 
   describe("execute - fail action", () => {
@@ -134,6 +144,18 @@ describe("BiometricAuth", () => {
       expect(result.success).toBe(true);
       expect(result.message).toContain("may not differentiate");
     });
+
+    test("should send SDK override broadcast with FAILURE for fail", async () => {
+      fakeAdb.setCommandResponse("emu finger touch 2", { stdout: "", stderr: "" });
+      fakeAdb.setCommandResponse("emu finger remove 2", { stdout: "", stderr: "" });
+
+      await biometricAuth.execute({ action: "fail" });
+
+      const executedCommands = fakeAdb.getExecutedCommands();
+      expect(executedCommands.some(cmd =>
+        cmd.includes("BIOMETRIC_OVERRIDE") && cmd.includes("FAILURE")
+      )).toBe(true);
+    });
   });
 
   describe("execute - cancel action", () => {
@@ -146,6 +168,155 @@ describe("BiometricAuth", () => {
       expect(result.success).toBe(true);
       expect(result.action).toBe("cancel");
       expect(result.supported).toBe(true);
+    });
+
+    test("should send SDK override broadcast with CANCEL for cancel", async () => {
+      fakeAdb.setCommandResponse("emu finger touch 2", { stdout: "", stderr: "" });
+      fakeAdb.setCommandResponse("emu finger remove 2", { stdout: "", stderr: "" });
+
+      await biometricAuth.execute({ action: "cancel" });
+
+      const executedCommands = fakeAdb.getExecutedCommands();
+      expect(executedCommands.some(cmd =>
+        cmd.includes("BIOMETRIC_OVERRIDE") && cmd.includes("CANCEL")
+      )).toBe(true);
+    });
+  });
+
+  describe("execute - error action", () => {
+    test("should use enrolled fingerprint ID 1 for error action", async () => {
+      fakeAdb.setCommandResponse("emu finger touch 1", { stdout: "", stderr: "" });
+      fakeAdb.setCommandResponse("emu finger remove 1", { stdout: "", stderr: "" });
+
+      const result = await biometricAuth.execute({ action: "error", errorCode: 7 });
+
+      expect(result.success).toBe(true);
+      expect(result.action).toBe("error");
+      expect(result.fingerprintId).toBe(1);
+      expect(result.errorCode).toBe(7);
+      expect(result.supported).toBe(true);
+      expect(result.observation).toBeDefined();
+    });
+
+    test("should send SDK override broadcast with ERROR and errorCode", async () => {
+      fakeAdb.setCommandResponse("emu finger touch 1", { stdout: "", stderr: "" });
+      fakeAdb.setCommandResponse("emu finger remove 1", { stdout: "", stderr: "" });
+
+      await biometricAuth.execute({ action: "error", errorCode: 7 });
+
+      const executedCommands = fakeAdb.getExecutedCommands();
+      expect(executedCommands.some(cmd =>
+        cmd.includes("BIOMETRIC_OVERRIDE") && cmd.includes("ERROR") && cmd.includes("7")
+      )).toBe(true);
+    });
+
+    test("should include SDK integration note in error action message", async () => {
+      fakeAdb.setCommandResponse("emu finger touch 1", { stdout: "", stderr: "" });
+      fakeAdb.setCommandResponse("emu finger remove 1", { stdout: "", stderr: "" });
+
+      const result = await biometricAuth.execute({ action: "error", errorCode: 7 });
+
+      expect(result.message).toContain("consumeOverride");
+    });
+
+    test("should use custom fingerprint ID for error action", async () => {
+      fakeAdb.setCommandResponse("emu finger touch 3", { stdout: "", stderr: "" });
+      fakeAdb.setCommandResponse("emu finger remove 3", { stdout: "", stderr: "" });
+
+      const result = await biometricAuth.execute({ action: "error", errorCode: 1, fingerprintId: 3 });
+
+      expect(result.fingerprintId).toBe(3);
+    });
+
+    test("should pass ttlMs to SDK broadcast", async () => {
+      fakeAdb.setCommandResponse("emu finger touch 1", { stdout: "", stderr: "" });
+      fakeAdb.setCommandResponse("emu finger remove 1", { stdout: "", stderr: "" });
+
+      await biometricAuth.execute({ action: "error", errorCode: 7, ttlMs: 10000 });
+
+      const executedCommands = fakeAdb.getExecutedCommands();
+      expect(executedCommands.some(cmd =>
+        cmd.includes("BIOMETRIC_OVERRIDE") && cmd.includes("10000")
+      )).toBe(true);
+    });
+  });
+
+  describe("SDK broadcast", () => {
+    test("should send broadcast before emu finger commands", async () => {
+      fakeAdb.setCommandResponse("emu finger touch 1", { stdout: "", stderr: "" });
+      fakeAdb.setCommandResponse("emu finger remove 1", { stdout: "", stderr: "" });
+
+      await biometricAuth.execute({ action: "match" });
+
+      const cmds = fakeAdb.getExecutedCommands();
+      const broadcastIdx = cmds.findIndex(cmd => cmd.includes("BIOMETRIC_OVERRIDE"));
+      const touchIdx = cmds.findIndex(cmd => cmd.includes("emu finger touch 1"));
+      expect(broadcastIdx).toBeGreaterThanOrEqual(0);
+      expect(touchIdx).toBeGreaterThan(broadcastIdx);
+    });
+
+    test("should include default ttlMs in broadcast", async () => {
+      fakeAdb.setCommandResponse("emu finger touch 1", { stdout: "", stderr: "" });
+      fakeAdb.setCommandResponse("emu finger remove 1", { stdout: "", stderr: "" });
+
+      await biometricAuth.execute({ action: "match" });
+
+      const executedCommands = fakeAdb.getExecutedCommands();
+      expect(executedCommands.some(cmd =>
+        cmd.includes("BIOMETRIC_OVERRIDE") && cmd.includes("ttlMs") && cmd.includes("5000")
+      )).toBe(true);
+    });
+
+    test("should still proceed if broadcast fails", async () => {
+      // Make broadcast fail
+      fakeAdb.setCommandResponse("BIOMETRIC_OVERRIDE", { stdout: "", stderr: "broadcast failed" });
+      fakeAdb.setCommandResponse("emu finger touch 1", { stdout: "", stderr: "" });
+      fakeAdb.setCommandResponse("emu finger remove 1", { stdout: "", stderr: "" });
+
+      const result = await biometricAuth.execute({ action: "match" });
+
+      // Emu finger path should still work
+      expect(result.success).toBe(true);
+    });
+  });
+
+  describe("physical device support", () => {
+    test("should return partial support on physical devices with SDK broadcast", async () => {
+      fakeAdb.setCommandResponse("shell getprop ro.kernel.qemu", { stdout: "0", stderr: "" });
+
+      const result = await biometricAuth.execute({ action: "match" });
+
+      expect(result.success).toBe(true);
+      expect(result.supported).toBe("partial");
+      expect(result.message).toContain("consumeOverride");
+    });
+
+    test("should send SDK broadcast to physical devices", async () => {
+      fakeAdb.setCommandResponse("shell getprop ro.kernel.qemu", { stdout: "0", stderr: "" });
+
+      await biometricAuth.execute({ action: "match" });
+
+      const executedCommands = fakeAdb.getExecutedCommands();
+      expect(executedCommands.some(cmd => cmd.includes("BIOMETRIC_OVERRIDE"))).toBe(true);
+    });
+
+    test("should not send emu finger commands to physical devices", async () => {
+      fakeAdb.setCommandResponse("shell getprop ro.kernel.qemu", { stdout: "0", stderr: "" });
+
+      await biometricAuth.execute({ action: "match" });
+
+      const executedCommands = fakeAdb.getExecutedCommands();
+      expect(executedCommands.some(cmd => cmd.includes("emu finger"))).toBe(false);
+    });
+
+    test("should support error action on physical devices via SDK broadcast", async () => {
+      fakeAdb.setCommandResponse("shell getprop ro.kernel.qemu", { stdout: "0", stderr: "" });
+
+      const result = await biometricAuth.execute({ action: "error", errorCode: 7 });
+
+      expect(result.success).toBe(true);
+      expect(result.supported).toBe("partial");
+      expect(result.errorCode).toBe(7);
     });
   });
 
@@ -161,19 +332,7 @@ describe("BiometricAuth", () => {
       expect(result.error).toContain("only supported on Android");
     });
 
-    test("should reject physical devices", async () => {
-      // Set device as physical (not emulator)
-      fakeAdb.setCommandResponse("shell getprop ro.kernel.qemu", { stdout: "0", stderr: "" });
-
-      const result = await biometricAuth.execute({ action: "match" });
-
-      expect(result.success).toBe(false);
-      expect(result.supported).toBe(false);
-      expect(result.error).toContain("only supported on Android emulators");
-    });
-
     test("should reject emulators without emu finger support", async () => {
-      // Device is emulator but doesn't support emu finger
       fakeAdb.setCommandResponse("shell getprop ro.kernel.qemu", { stdout: "1", stderr: "" });
       fakeAdb.setCommandResponse("emu help", { stdout: "help - show this help", stderr: "" });
 
@@ -222,14 +381,15 @@ describe("BiometricAuth", () => {
       expect(result.error).toContain("emu finger touch failed");
     });
 
-    test("should handle capability check failures gracefully", async () => {
-      // Make capability check fail
+    test("should treat capability check failures as physical device (partial support)", async () => {
+      // When getprop fails, the device is treated as a physical device (non-emulator)
+      // which returns supported: "partial" with the SDK broadcast still sent.
       fakeAdb.setCommandResponse("shell getprop ro.kernel.qemu", { stdout: "", stderr: "Error" });
 
       const result = await biometricAuth.execute({ action: "match" });
 
-      expect(result.success).toBe(false);
-      expect(result.supported).toBe(false);
+      expect(result.success).toBe(true);
+      expect(result.supported).toBe("partial");
     });
   });
 


### PR DESCRIPTION
## Summary

- Add `AutoMobileBiometrics` Android SDK hook with `overrideResult()` / `clearOverride()` / `consumeOverride()` API for injecting deterministic biometric results in tests
- Extend `biometricAuth` MCP tool with `action: "error"`, `errorCode`, and `ttlMs` — tool now sends an `am broadcast` to store the SDK override before every `emu finger` call
- Physical devices: broadcast is sent, `supported: "partial"` returned (app must integrate `consumeOverride()`)
- Override is single-use with configurable TTL (default 5 s); call `clearOverride()` in `@Before` for clean state

## Test Plan
- [x] 28 TypeScript tests pass (`bun test`)
- [x] 17 Android Robolectric unit tests pass (`./gradlew :auto-mobile-sdk:test`)
- [x] Build passes (`bun run build`)
- [x] Lint passes (`bun run lint`)

Closes #1362

🤖 Generated with [Claude Code](https://claude.com/claude-code)