### PR TITLE
fix: rename accessibility service to CtrlProxy in CI job and step names

### DIFF
--- a/.github/actions/android-emulator-wtf/action.yml
+++ b/.github/actions/android-emulator-wtf/action.yml
@@ -23,7 +23,7 @@ inputs:
     default: ""
     required: "false"
   accessibility-apk-path:
-    description: "Optional path to accessibility service APK to install before running the script"
+    description: "Optional path to CtrlProxy APK to install before running the script"
     default: ""
     required: "false"
 

--- a/.github/actions/android-emulator/action.yml
+++ b/.github/actions/android-emulator/action.yml
@@ -28,7 +28,7 @@ inputs:
     default: "./"
     required: "true"
   accessibility-apk-path:
-    description: "Optional path to accessibility service APK to install before running the script"
+    description: "Optional path to CtrlProxy APK to install before running the script"
     default: ""
     required: "false"
   gradle-home-directory:

--- a/.github/workflows/build-control-proxy-apk.yml
+++ b/.github/workflows/build-control-proxy-apk.yml
@@ -20,7 +20,7 @@ on:
 
 jobs:
   build:
-    name: "Build Accessibility Service"
+    name: "Build CtrlProxy APK"
     runs-on: ubuntu-latest
     outputs:
       sha256: ${{ steps.checksum.outputs.sha256 }}

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -445,7 +445,7 @@ jobs:
 
       - uses: ./.github/actions/setup-auto-mobile-npm-package
 
-      - name: "Download Accessibility Service APK"
+      - name: "Download CtrlProxy APK"
         uses: actions/download-artifact@v7
         with:
           name: control-proxy-apk
@@ -488,7 +488,7 @@ jobs:
 
       - uses: ./.github/actions/setup-auto-mobile-npm-package
 
-      - name: "Download Accessibility Service APK"
+      - name: "Download CtrlProxy APK"
         uses: actions/download-artifact@v7
         with:
           name: control-proxy-apk
@@ -521,7 +521,7 @@ jobs:
           report_paths: '**/build/test-results/**/*.xml'
 
   android-control-proxy-unit-tests:
-    name: "Run Accessibility Service Unit Tests"
+    name: "Run CtrlProxy Unit Tests"
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -573,7 +573,7 @@ jobs:
           path: core/build/outputs/aar/core-debug.aar
 
   build-android-control-proxy:
-    name: "Build Accessibility Service"
+    name: "Build CtrlProxy APK"
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -594,7 +594,7 @@ jobs:
           release-key-alias: ${{ secrets.RELEASE_KEY_ALIAS }}
           release-key-password: ${{ secrets.RELEASE_KEY_PASSWORD }}
 
-      - name: "Store Accessibility Service APK"
+      - name: "Upload CtrlProxy APK"
         uses: actions/upload-artifact@v6
         with:
           name: control-proxy-apk

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -111,9 +111,9 @@ jobs:
           IPA_CHANGED="${{ steps.check.outputs.ipa_changed }}"
 
           if [ "$APK_CHANGED" = "true" ] && [ "$IPA_CHANGED" = "true" ]; then
-            echo "title=chore: update accessibility service APK and CtrlProxy iOS IPA SHA256" >> $GITHUB_OUTPUT
+            echo "title=chore: update CtrlProxy APK and CtrlProxy iOS IPA SHA256" >> $GITHUB_OUTPUT
           elif [ "$APK_CHANGED" = "true" ]; then
-            echo "title=chore: update accessibility service APK SHA256" >> $GITHUB_OUTPUT
+            echo "title=chore: update CtrlProxy APK SHA256" >> $GITHUB_OUTPUT
           else
             echo "title=chore: update CtrlProxy iOS IPA SHA256" >> $GITHUB_OUTPUT
           fi

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -59,7 +59,7 @@ jobs:
           name: ctrl-proxy-ios-ipa
           path: /tmp
 
-      - name: "Download Accessibility Service APK"
+      - name: "Download CtrlProxy APK"
         uses: actions/download-artifact@v7
         with:
           name: control-proxy-apk
@@ -96,7 +96,7 @@ jobs:
             ## Summary
             - Bump versions to v${{ inputs.version }}
             - Update CHANGELOG.md from closed issues since the last tag
-            - Refresh Accessibility Service APK SHA256 checksum
+            - Refresh CtrlProxy APK SHA256 checksum
             - Refresh CtrlProxy iOS IPA SHA256 checksum
 
             ## Automation

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -90,7 +90,7 @@ jobs:
             });
 
             // Check if title matches the automated SHA256 update pattern
-            const titleMatches = pr.title === 'chore: update accessibility service APK SHA256' ||
+            const titleMatches = pr.title === 'chore: update CtrlProxy APK SHA256' ||
                                  pr.title === 'chore: update CtrlProxy iOS IPA SHA256';
 
             // Get list of changed files
@@ -968,7 +968,7 @@ jobs:
 
       - uses: ./.github/actions/setup-auto-mobile-npm-package
 
-      - name: "Download Accessibility Service APK"
+      - name: "Download CtrlProxy APK"
         uses: actions/download-artifact@v7
         with:
           name: control-proxy-apk
@@ -1042,7 +1042,7 @@ jobs:
           release-key-alias: ${{ secrets.RELEASE_KEY_ALIAS }}
           release-key-password: ${{ secrets.RELEASE_KEY_PASSWORD }}
 
-      - name: "Download Accessibility Service APK"
+      - name: "Download CtrlProxy APK"
         uses: actions/download-artifact@v7
         with:
           name: control-proxy-apk
@@ -1093,7 +1093,7 @@ jobs:
 
       - uses: ./.github/actions/setup-auto-mobile-npm-package
 
-      - name: "Download Accessibility Service APK"
+      - name: "Download CtrlProxy APK"
         uses: actions/download-artifact@v7
         with:
           name: control-proxy-apk
@@ -1126,7 +1126,7 @@ jobs:
           report_paths: '**/build/test-results/**/*.xml'
 
   android-control-proxy-unit-tests:
-    name: "Run Accessibility Service Unit Tests"
+    name: "Run CtrlProxy Unit Tests"
     runs-on: ubuntu-latest
     needs: detect-changes
     if: needs.detect-changes.outputs.android_should_run == 'true'
@@ -1182,7 +1182,7 @@ jobs:
           path: core/build/outputs/aar/core-debug.aar
 
   build-android-control-proxy:
-    name: "Build Accessibility Service"
+    name: "Build CtrlProxy APK"
     runs-on: ubuntu-latest
     needs: detect-changes
     if: needs.detect-changes.outputs.android_should_run == 'true'
@@ -1205,7 +1205,7 @@ jobs:
           release-key-alias: ${{ secrets.RELEASE_KEY_ALIAS }}
           release-key-password: ${{ secrets.RELEASE_KEY_PASSWORD }}
 
-      - name: "Store Accessibility Service APK"
+      - name: "Upload CtrlProxy APK"
         uses: actions/upload-artifact@v6
         with:
           name: control-proxy-apk

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,7 +57,7 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
-      - name: "Download Accessibility Service APK"
+      - name: "Download CtrlProxy APK"
         uses: actions/download-artifact@v7
         with:
           name: control-proxy-apk
@@ -135,7 +135,7 @@ jobs:
           # Add checksum to notes
           APK_CHECKSUM="${{ steps.verify_checksum.outputs.checksum }}"
           IPA_CHECKSUM="${{ steps.verify_ipa_checksum.outputs.checksum }}"
-          NOTES="${NOTES}"$'\n\n'"## Accessibility Service APK"$'\n\n'"**SHA256 Checksum:** \`${APK_CHECKSUM}\`"$'\n\n'"Download the APK from the release assets below."
+          NOTES="${NOTES}"$'\n\n'"## CtrlProxy APK"$'\n\n'"**SHA256 Checksum:** \`${APK_CHECKSUM}\`"$'\n\n'"Download the APK from the release assets below."
           NOTES="${NOTES}"$'\n\n'"## CtrlProxy iOS IPA"$'\n\n'"**SHA256 Checksum:** \`${IPA_CHECKSUM}\`"$'\n\n'"Download the IPA from the release assets below."
 
           # Save to file for GitHub release


### PR DESCRIPTION
## Summary

- Replaces all remaining `accessibility service` / `Accessibility Service` display names in CI workflows with `CtrlProxy`, completing the Android subproject rename
- Standardizes job display name `"Build Android CtrlProxy"` → `"Build CtrlProxy APK"` in `merge.yml` and `pull_request.yml` to match the reusable workflow (`build-control-proxy-apk.yml`) and the iOS parallel (`"Build CtrlProxy iOS IPA"`)
- Standardizes upload-artifact step name `"Store CtrlProxy APK"` → `"Upload CtrlProxy APK"` to match `actions/upload-artifact` naming and the reusable workflow

## Files Changed

- `.github/workflows/nightly.yml` — PR title echo strings (lines 114, 116)
- `.github/workflows/merge.yml` — job display name + upload step name
- `.github/workflows/pull_request.yml` — job display name + upload step name + PR title matcher
- `.github/workflows/build-control-proxy-apk.yml` — job display name
- `.github/workflows/prepare-release.yml` — download step name + PR body text
- `.github/workflows/release.yml` — download step name + release notes section header
- `.github/actions/android-emulator/action.yml` — input description
- `.github/actions/android-emulator-wtf/action.yml` — input description

## Verification

```
grep -r "accessibility service" .github/  # → no results
grep -r "Store CtrlProxy" .github/        # → no results
grep "Build Android CtrlProxy" .github/workflows/merge.yml .github/workflows/pull_request.yml  # → no results
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)