### PR TITLE
refactor(talkback): address code review findings from #1392

### DIFF
--- a/src/features/talkback/TalkBackTapStrategy.ts
+++ b/src/features/talkback/TalkBackTapStrategy.ts
@@ -8,13 +8,17 @@ import type { TalkBackNavigationDriver } from "./TalkBackNavigationDriver";
 
 export interface TalkBackTapResult {
   success: boolean;
-  method: "focus-navigation" | "coordinate-fallback";
+  /**
+   * - "focus-navigation": navigated via swipe gestures and activated with double-tap
+   * - "accessibility-action": dispatched a direct accessibility action (ACTION_CLICK / ACTION_LONG_CLICK)
+   * - "coordinate-fallback": fell back to coordinate-based gesture dispatch
+   */
+  method: "focus-navigation" | "accessibility-action" | "coordinate-fallback";
   error?: string;
 }
 
 export type TalkBackTapAction = "tap" | "doubleTap";
 export type TalkBackFallbackAction = "tap" | "doubleTap" | "longPress";
-export type TalkBackLongPressAction = "longPress";
 
 interface TalkBackTapStrategyDependencies {
   matcher?: FocusElementMatcher;
@@ -59,7 +63,7 @@ export class TalkBackTapStrategy {
    * 5. Activates it with double-tap (with ACTION_CLICK fallback)
    *
    * @param deviceId - The device ID
-   * @param element - The target element (must have resource-id)
+   * @param element - The target element (must have at least one of resource-id, text, or content-desc)
    * @param action - The action to perform ("tap" or "doubleTap")
    * @param driver - The TalkBack navigation driver
    * @returns Result indicating success/failure and method used
@@ -88,8 +92,8 @@ export class TalkBackTapStrategy {
       // Build selector from available fields (include bounds for disambiguation in list views)
       const targetSelector = {
         ...(resourceId ? { resourceId } : {}),
-        text: elementText,
-        contentDesc: elementContentDesc,
+        ...(elementText ? { text: elementText } : {}),
+        ...(elementContentDesc ? { contentDesc: elementContentDesc } : {}),
         bounds: element.bounds
       };
 
@@ -261,7 +265,7 @@ export class TalkBackTapStrategy {
       const longClickResult = await driver.requestAction("long_click", resourceId);
       if (longClickResult.success) {
         logger.info(`[TalkBackTapStrategy] Long press via ACTION_LONG_CLICK succeeded`);
-        return { success: true, method: "focus-navigation" };
+        return { success: true, method: "accessibility-action" };
       }
       logger.warn(
         `[TalkBackTapStrategy] ACTION_LONG_CLICK failed (${longClickResult.error}), ` +
@@ -298,7 +302,7 @@ export class TalkBackTapStrategy {
             error: `Activation failed: double-tap and ACTION_CLICK both failed`
           };
         }
-        return { success: true, method: "focus-navigation" };
+        return { success: true, method: "accessibility-action" };
       }
       return {
         success: false,
@@ -324,13 +328,13 @@ export class TalkBackTapStrategy {
             error: `Activation failed: second tap and ACTION_CLICK both failed`
           };
         }
-      } else {
-        return {
-          success: false,
-          method: "focus-navigation",
-          error: `Activation failed: second tap failed`
-        };
+        return { success: true, method: "accessibility-action" };
       }
+      return {
+        success: false,
+        method: "focus-navigation",
+        error: `Activation failed: second tap failed`
+      };
     }
 
     logger.info(`[TalkBackTapStrategy] Element activated successfully via focus navigation`);

--- a/test/fakes/FakeTalkBackTapStrategy.ts
+++ b/test/fakes/FakeTalkBackTapStrategy.ts
@@ -12,7 +12,7 @@ import type { TalkBackNavigationDriver } from "../../src/features/talkback/TalkB
 export class FakeTalkBackTapStrategy {
   tapResult: TalkBackTapResult = { success: true, method: "focus-navigation" };
   fallbackResult: TalkBackTapResult = { success: true, method: "coordinate-fallback" };
-  longPressResult: TalkBackTapResult = { success: true, method: "focus-navigation" };
+  longPressResult: TalkBackTapResult = { success: true, method: "accessibility-action" };
 
   tapCalls: Array<{
     deviceId: string;

--- a/test/features/action/TapOnElement.talkback.test.ts
+++ b/test/features/action/TapOnElement.talkback.test.ts
@@ -295,6 +295,48 @@ describe("TapOnElement TalkBack mode detection", () => {
       expect(result.element["resource-id"]).toBe("parent:id");
     });
 
+    test("resolves text-only child to clickable parent with resource-id under TalkBack (requireResourceId=true)", () => {
+      const viewHierarchy = {
+        hierarchy: {
+          node: {
+            $: {
+              "class": "android.widget.LinearLayout",
+              "clickable": "true",
+              "bounds": "[0,0][200,80]",
+              "resource-id": "com.example:id/settings_row"
+            },
+            node: [
+              {
+                $: {
+                  "class": "android.widget.TextView",
+                  "text": "Settings",
+                  "bounds": "[10,10][190,70]"
+                  // no resource-id
+                }
+              }
+            ]
+          }
+        }
+      } as any;
+
+      const textOnlyChild = {
+        bounds: { left: 10, top: 10, right: 190, bottom: 70 },
+        text: "Settings"
+        // no resource-id
+      } as any;
+
+      // requireResourceId=true simulates TalkBack mode
+      const result = (tapOnElement as any).resolveTapTargetElement(
+        textOnlyChild,
+        viewHierarchy,
+        "tap",
+        true
+      );
+
+      expect(result.usedParent).toBe(true);
+      expect(result.element["resource-id"]).toBe("com.example:id/settings_row");
+    });
+
     test("prefers long-clickable parent for longPress", () => {
       const viewHierarchy = {
         hierarchy: {

--- a/test/features/talkback/TalkBackTapStrategy.test.ts
+++ b/test/features/talkback/TalkBackTapStrategy.test.ts
@@ -160,10 +160,47 @@ describe("TalkBackTapStrategy", () => {
       const result = await strategy.executeTap("device-1", element, "tap", driver);
 
       expect(result.success).toBe(true);
-      expect(result.method).toBe("focus-navigation");
+      expect(result.method).toBe("accessibility-action");
       expect(driver.getTapCount()).toBe(1); // Only first tap attempted
       expect(driver.getActionCount()).toBe(1); // ACTION_CLICK fallback
       expect(driver.actionHistory[0]).toEqual({ action: "click", resourceId: "test:id/button" });
+    });
+
+    test("returns failure when text-only element activation double-tap fails (no ACTION_CLICK fallback)", async () => {
+      const element = {
+        bounds: { left: 0, top: 0, right: 100, bottom: 100 },
+        text: "Button"
+      } as Element;
+
+      driver.setElements([element], 0);
+
+      spyOn(mockExecutor, "navigateToElement").mockResolvedValue(true);
+      driver.setTapResult({ success: false, totalTimeMs: 1, error: "tap failed" });
+
+      const result = await strategy.executeTap("device-1", element, "tap", driver);
+
+      expect(result.success).toBe(false);
+      expect(result.method).toBe("focus-navigation");
+      expect(driver.getActionCount()).toBe(0); // No ACTION_CLICK attempted without resource-id
+    });
+
+    test("returns failure when text-only element second tap fails (no ACTION_CLICK fallback)", async () => {
+      const element = {
+        bounds: { left: 0, top: 0, right: 100, bottom: 100 },
+        text: "Button"
+      } as Element;
+
+      driver.setElements([element], 0);
+
+      spyOn(mockExecutor, "navigateToElement").mockResolvedValue(true);
+      driver.queueTapResult({ success: true, totalTimeMs: 1 }); // first tap succeeds
+      driver.setTapResult({ success: false, totalTimeMs: 1, error: "second tap failed" });
+
+      const result = await strategy.executeTap("device-1", element, "tap", driver);
+
+      expect(result.success).toBe(false);
+      expect(result.method).toBe("focus-navigation");
+      expect(driver.getActionCount()).toBe(0); // No ACTION_CLICK attempted without resource-id
     });
 
     test("returns error if both double-tap and ACTION_CLICK fail", async () => {
@@ -231,7 +268,7 @@ describe("TalkBackTapStrategy", () => {
       const result = await strategy.executeLongPress(50, 50, 1000, element, driver);
 
       expect(result.success).toBe(true);
-      expect(result.method).toBe("focus-navigation");
+      expect(result.method).toBe("accessibility-action");
       expect(driver.actionHistory).toHaveLength(1);
       expect(driver.actionHistory[0]).toEqual({ action: "long_click", resourceId: "test:id/button" });
       expect(driver.getTapCount()).toBe(0); // No coordinate taps


### PR DESCRIPTION
## Summary

Follow-up to #1392 addressing code review findings:

- Add `"accessibility-action"` as a distinct `TalkBackTapResult.method` value (was conflated with `"focus-navigation"` for direct ACTION_CLICK / ACTION_LONG_CLICK dispatches)
- Remove dead `TalkBackLongPressAction` type export
- Fix `targetSelector` to conditionally spread all three identifier fields (`resourceId`, `text`, `contentDesc`) consistently
- Update `@param element` JSDoc on `executeTap` to reflect text/content-desc are valid identifiers (not just resource-id)

## Test plan
- [ ] Added tests: text-only element activation failures (no ACTION_CLICK fallback when element has no resource-id)
- [ ] Added test: text-only child resolves to clickable parent with resource-id under TalkBack (`requireResourceId=true`)
- [ ] Updated existing assertions to expect `"accessibility-action"` where appropriate (ACTION_LONG_CLICK success, ACTION_CLICK fallback success)
- [ ] `bun test` passes (2820 tests)

Closes #1357

🤖 Generated with [Claude Code](https://claude.com/claude-code)