### PR TITLE
fix(biometrics): address code review feedback on biometric auth feature

### DIFF
--- a/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/biometrics/AutoMobileBiometrics.kt
+++ b/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/biometrics/AutoMobileBiometrics.kt
@@ -6,6 +6,7 @@ import android.content.Intent
 import android.content.IntentFilter
 import android.os.Build
 import android.util.Log
+import androidx.annotation.VisibleForTesting
 import java.util.concurrent.atomic.AtomicReference
 
 /**
@@ -14,6 +15,11 @@ import java.util.concurrent.atomic.AtomicReference
  * Allows test code or the AutoMobile MCP server to inject a known [BiometricResult] so that
  * `BiometricPrompt` flows are testable without requiring actual fingerprint/face hardware
  * interaction.
+ *
+ * **Dependency configuration:** This class lives in `src/main/` so the SDK can be published as
+ * a single artifact. Apps should declare it as `debugImplementation` to prevent it from shipping
+ * in release builds. Using `implementation` instead will include the broadcast receiver in
+ * production APKs.
  *
  * ## App integration
  *
@@ -160,6 +166,7 @@ object AutoMobileBiometrics {
         }
     }
 
+    @Synchronized
     private fun registerReceiver() {
         if (receiverRegistered) return
         val ctx = context ?: return
@@ -178,27 +185,46 @@ object AutoMobileBiometrics {
         }
     }
 
-    private val broadcastReceiver = object : BroadcastReceiver() {
-        override fun onReceive(context: Context, intent: Intent) {
-            val resultStr = intent.getStringExtra(EXTRA_RESULT) ?: run {
-                Log.w(TAG, "Biometric override broadcast missing '$EXTRA_RESULT' extra")
+    /**
+     * Process an incoming biometric override broadcast intent.
+     *
+     * Visible for testing: allows unit tests to invoke the receiver logic directly
+     * without going through Android's broadcast delivery mechanism.
+     */
+    @VisibleForTesting
+    internal fun handleBroadcastIntent(intent: Intent) {
+        val resultStr = intent.getStringExtra(EXTRA_RESULT) ?: run {
+            Log.w(TAG, "Biometric override broadcast missing '$EXTRA_RESULT' extra")
+            return
+        }
+        val ttlMs = intent.getLongExtra(EXTRA_TTL_MS, 5000L)
+
+        val result: BiometricResult = when (resultStr.uppercase()) {
+            "SUCCESS" -> BiometricResult.Success
+            "FAILURE" -> BiometricResult.Failure
+            "CANCEL" -> BiometricResult.Cancel
+            "ERROR" -> {
+                val errorCode = if (intent.hasExtra(EXTRA_ERROR_CODE)) {
+                    intent.getIntExtra(EXTRA_ERROR_CODE, -1)
+                } else {
+                    Log.w(TAG, "Biometric ERROR override broadcast missing '$EXTRA_ERROR_CODE' extra; " +
+                        "app will receive Error(-1) which is not a valid BiometricPrompt.ERROR_* constant (valid values start at 1)")
+                    -1
+                }
+                BiometricResult.Error(errorCode)
+            }
+            else -> {
+                Log.w(TAG, "Unknown biometric override result: '$resultStr'")
                 return
             }
-            val errorCode = intent.getIntExtra(EXTRA_ERROR_CODE, -1)
-            val ttlMs = intent.getLongExtra(EXTRA_TTL_MS, 5000L)
+        }
 
-            val result: BiometricResult = when (resultStr.uppercase()) {
-                "SUCCESS" -> BiometricResult.Success
-                "FAILURE" -> BiometricResult.Failure
-                "CANCEL" -> BiometricResult.Cancel
-                "ERROR" -> BiometricResult.Error(errorCode)
-                else -> {
-                    Log.w(TAG, "Unknown biometric override result: '$resultStr'")
-                    return
-                }
-            }
+        overrideResult(result, ttlMs)
+    }
 
-            overrideResult(result, ttlMs)
+    private val broadcastReceiver = object : BroadcastReceiver() {
+        override fun onReceive(context: Context, intent: Intent) {
+            handleBroadcastIntent(intent)
         }
     }
 }

--- a/android/auto-mobile-sdk/src/test/kotlin/dev/jasonpearson/automobile/sdk/biometrics/AutoMobileBiometricsTest.kt
+++ b/android/auto-mobile-sdk/src/test/kotlin/dev/jasonpearson/automobile/sdk/biometrics/AutoMobileBiometricsTest.kt
@@ -1,5 +1,6 @@
 package dev.jasonpearson.automobile.sdk.biometrics
 
+import android.content.Intent
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
@@ -125,6 +126,79 @@ class AutoMobileBiometricsTest {
     fun `Error equality is based on errorCode and errorMessage`() {
         assertEquals(BiometricResult.Error(7, "Lockout"), BiometricResult.Error(7, "Lockout"))
         assertTrue(BiometricResult.Error(7) != BiometricResult.Error(5))
+    }
+
+    // -------------------------------------------------------------------------
+    // Broadcast receiver round-trip (MCP integration path)
+    // Tests use handleBroadcastIntent() directly to exercise the receiver logic
+    // without relying on Android broadcast delivery infrastructure.
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `broadcast receiver sets Success override`() {
+        val intent = Intent(AutoMobileBiometrics.ACTION_BIOMETRIC_OVERRIDE).apply {
+            putExtra(AutoMobileBiometrics.EXTRA_RESULT, "SUCCESS")
+        }
+        AutoMobileBiometrics.handleBroadcastIntent(intent)
+
+        assertEquals(BiometricResult.Success, AutoMobileBiometrics.consumeOverride())
+    }
+
+    @Test
+    fun `broadcast receiver sets Failure override`() {
+        val intent = Intent(AutoMobileBiometrics.ACTION_BIOMETRIC_OVERRIDE).apply {
+            putExtra(AutoMobileBiometrics.EXTRA_RESULT, "FAILURE")
+        }
+        AutoMobileBiometrics.handleBroadcastIntent(intent)
+
+        assertEquals(BiometricResult.Failure, AutoMobileBiometrics.consumeOverride())
+    }
+
+    @Test
+    fun `broadcast receiver sets Cancel override`() {
+        val intent = Intent(AutoMobileBiometrics.ACTION_BIOMETRIC_OVERRIDE).apply {
+            putExtra(AutoMobileBiometrics.EXTRA_RESULT, "CANCEL")
+        }
+        AutoMobileBiometrics.handleBroadcastIntent(intent)
+
+        assertEquals(BiometricResult.Cancel, AutoMobileBiometrics.consumeOverride())
+    }
+
+    @Test
+    fun `broadcast receiver sets Error override with errorCode`() {
+        val intent = Intent(AutoMobileBiometrics.ACTION_BIOMETRIC_OVERRIDE).apply {
+            putExtra(AutoMobileBiometrics.EXTRA_RESULT, "ERROR")
+            putExtra(AutoMobileBiometrics.EXTRA_ERROR_CODE, 7)
+        }
+        AutoMobileBiometrics.handleBroadcastIntent(intent)
+
+        val result = AutoMobileBiometrics.consumeOverride()
+        assertNotNull(result)
+        assertTrue(result is BiometricResult.Error)
+        assertEquals(7, (result as BiometricResult.Error).errorCode)
+    }
+
+    @Test
+    fun `broadcast receiver uses -1 when errorCode extra is absent for ERROR result`() {
+        val intent = Intent(AutoMobileBiometrics.ACTION_BIOMETRIC_OVERRIDE).apply {
+            putExtra(AutoMobileBiometrics.EXTRA_RESULT, "ERROR")
+            // intentionally omit EXTRA_ERROR_CODE — app will receive Error(-1)
+        }
+        AutoMobileBiometrics.handleBroadcastIntent(intent)
+
+        val result = AutoMobileBiometrics.consumeOverride()
+        assertNotNull(result)
+        assertTrue(result is BiometricResult.Error)
+        assertEquals(-1, (result as BiometricResult.Error).errorCode)
+    }
+
+    @Test
+    fun `broadcast receiver ignores broadcast with missing result extra`() {
+        val intent = Intent(AutoMobileBiometrics.ACTION_BIOMETRIC_OVERRIDE)
+        // intentionally omit EXTRA_RESULT
+        AutoMobileBiometrics.handleBroadcastIntent(intent)
+
+        assertNull(AutoMobileBiometrics.consumeOverride())
     }
 
     // -------------------------------------------------------------------------

--- a/docs/design-docs/plat/android/biometrics.md
+++ b/docs/design-docs/plat/android/biometrics.md
@@ -177,11 +177,13 @@ be applied when the biometric prompt fires normally.
 
 ## Plan
 
-1. Implement emulator fingerprint support via `adb emu finger`.
-2. Add capability detection and clear error messages for unsupported devices.
-3. Add optional SDK hook for deterministic app-under-test flows.
+1. ✅ Implement emulator fingerprint support via `adb emu finger`.
+2. ✅ Add capability detection and clear error messages for unsupported devices.
+3. ✅ Add optional SDK hook for deterministic app-under-test flows.
 
 ## Risks
 
 - Emulator support is primarily fingerprint; face/iris is not consistent.
-- Physical devices may not allow simulation without device-owner privileges.
+- Physical device support requires app SDK integration (`AutoMobileBiometrics.consumeOverride()`).
+  The broadcast sets an override, but an actual biometric interaction is still needed to trigger
+  the callback. There is no way to programmatically inject a touch event on physical hardware.

--- a/schemas/tool-definitions.json
+++ b/schemas/tool-definitions.json
@@ -30,7 +30,7 @@
           "type": "number"
         },
         "errorCode": {
-          "description": "BiometricPrompt error code to inject when action is 'error' (e.g. 7 for ERROR_LOCKOUT, 1 for ERROR_HW_UNAVAILABLE). Requires AutoMobileBiometrics SDK integration in the app.",
+          "description": "BiometricPrompt error code to inject (e.g. 7 for ERROR_LOCKOUT, 1 for ERROR_HW_UNAVAILABLE). Only valid when action is 'error'; providing it with any other action is a validation error.",
           "type": "number"
         },
         "ttlMs": {

--- a/src/features/action/BiometricAuth.ts
+++ b/src/features/action/BiometricAuth.ts
@@ -76,6 +76,18 @@ export class BiometricAuth extends BaseVisualChange {
 
     if (!capabilityResult.isEmulator) {
       perf.end();
+      if (!broadcastOk) {
+        return {
+          success: false,
+          action: options.action,
+          modality,
+          fingerprintId: options.fingerprintId,
+          errorCode: options.errorCode,
+          supported: "partial",
+          error:
+            "SDK override broadcast failed; verify the app has AutoMobileBiometrics integrated and ADB is connected."
+        };
+      }
       return {
         success: true,
         action: options.action,
@@ -126,6 +138,13 @@ export class BiometricAuth extends BaseVisualChange {
    */
   private async sendSdkOverrideBroadcast(options: BiometricAuthOptions): Promise<boolean> {
     try {
+      if (options.action === "error" && options.errorCode === undefined) {
+        logger.warn(
+          "action 'error' sent without errorCode; app will receive BiometricResult.Error(-1) " +
+          "which is not a valid BiometricPrompt.ERROR_* constant (valid values start at 1)"
+        );
+      }
+
       const resultValue = this.actionToSdkResult(options.action);
       const ttlMs = options.ttlMs ?? DEFAULT_TTL_MS;
 
@@ -191,7 +210,7 @@ export class BiometricAuth extends BaseVisualChange {
    * For error:  touch enrolled ID 1   → onAuthenticationSucceeded (override converts to error)
    */
   private async executeBiometricAction(options: BiometricAuthOptions): Promise<BiometricAuthResult> {
-    const modality = options.modality ?? "any";
+    const modality: "any" | "fingerprint" | "face" = options.modality ?? "any";
 
     // Determine fingerprint ID
     let fingerprintId = options.fingerprintId;
@@ -249,13 +268,13 @@ export class BiometricAuth extends BaseVisualChange {
 
   private buildSuccessResult(
     options: BiometricAuthOptions,
-    modality: string,
+    modality: "any" | "fingerprint" | "face",
     fingerprintId: number
   ): BiometricAuthResult {
     const base = {
       success: true,
       action: options.action,
-      modality: modality as BiometricAuthResult["modality"],
+      modality,
       fingerprintId,
       errorCode: options.errorCode,
       supported: true as const
@@ -266,6 +285,11 @@ export class BiometricAuth extends BaseVisualChange {
         return {
           ...base,
           message: `Simulated biometric ${options.action} with fingerprint ID ${fingerprintId}. Note: Some emulators may not differentiate between enrolled and non-enrolled fingerprint IDs.`
+        };
+      case "cancel":
+        return {
+          ...base,
+          message: `Biometric cancellation dispatched (fingerprint ID ${fingerprintId}).`
         };
       case "error":
         return {

--- a/src/server/biometricTools.ts
+++ b/src/server/biometricTools.ts
@@ -23,12 +23,15 @@ export const biometricAuthSchema = addDeviceTargetingToSchema(z.object({
     "Fingerprint ID to simulate (default: 1 for 'match'/'error', 2 for 'fail'/'cancel'). Use enrolled ID (typically 1) for match/error, non-enrolled ID (typically 2) for fail/cancel."
   ),
   errorCode: z.number().optional().describe(
-    "BiometricPrompt error code to inject when action is 'error' (e.g. 7 for ERROR_LOCKOUT, 1 for ERROR_HW_UNAVAILABLE). Requires AutoMobileBiometrics SDK integration in the app."
+    "BiometricPrompt error code to inject (e.g. 7 for ERROR_LOCKOUT, 1 for ERROR_HW_UNAVAILABLE). Only valid when action is 'error'; providing it with any other action is a validation error."
   ),
   ttlMs: z.number().optional().describe(
     "How long the SDK override remains active in milliseconds (default: 5000). The override is cleared after the first authentication callback or when the TTL expires."
   )
-}));
+}).refine(
+  (data) => data.errorCode === undefined || data.action === "error",
+  { message: "errorCode is only applicable when action is 'error'", path: ["errorCode"] }
+));
 
 /**
  * Register biometric authentication tools

--- a/test/fakes/FakeAdbExecutor.ts
+++ b/test/fakes/FakeAdbExecutor.ts
@@ -7,6 +7,7 @@ import { BootedDevice, ExecResult, AndroidUser } from "../../src/models";
  */
 export class FakeAdbExecutor implements AdbExecutor {
   private commandResponses: Map<string, ExecResult> = new Map();
+  private commandErrors: Map<string, Error> = new Map();
   private defaultResponse: ExecResult = this.createExecResult("", "");
   private defaultError: Error | null = null;
   private executedCommands: string[] = [];
@@ -148,6 +149,15 @@ export class FakeAdbExecutor implements AdbExecutor {
   }
 
   /**
+   * Set an error to throw for commands matching a specific pattern
+   * @param commandPattern - Pattern to match against executed commands (substring match)
+   * @param error - Error to throw when pattern matches
+   */
+  setCommandError(commandPattern: string, error: Error): void {
+    this.commandErrors.set(commandPattern, error);
+  }
+
+  /**
    * Set default error to throw for all commands
    * @param error - Error to throw
    */
@@ -165,6 +175,13 @@ export class FakeAdbExecutor implements AdbExecutor {
     _signal?: AbortSignal
   ): Promise<ExecResult> {
     this.executedCommands.push(command);
+
+    // Check for per-command errors based on pattern matching
+    for (const [pattern, error] of this.commandErrors.entries()) {
+      if (command.includes(pattern)) {
+        throw error;
+      }
+    }
 
     // If a default error is configured, throw it
     if (this.defaultError) {

--- a/test/features/action/BiometricAuth.test.ts
+++ b/test/features/action/BiometricAuth.test.ts
@@ -170,6 +170,16 @@ describe("BiometricAuth", () => {
       expect(result.supported).toBe(true);
     });
 
+    test("should use cancellation-specific message", async () => {
+      fakeAdb.setCommandResponse("emu finger touch 2", { stdout: "", stderr: "" });
+      fakeAdb.setCommandResponse("emu finger remove 2", { stdout: "", stderr: "" });
+
+      const result = await biometricAuth.execute({ action: "cancel" });
+
+      expect(result.success).toBe(true);
+      expect(result.message).toContain("cancellation");
+    });
+
     test("should send SDK override broadcast with CANCEL for cancel", async () => {
       fakeAdb.setCommandResponse("emu finger touch 2", { stdout: "", stderr: "" });
       fakeAdb.setCommandResponse("emu finger remove 2", { stdout: "", stderr: "" });
@@ -217,6 +227,18 @@ describe("BiometricAuth", () => {
       const result = await biometricAuth.execute({ action: "error", errorCode: 7 });
 
       expect(result.message).toContain("consumeOverride");
+    });
+
+    test("should proceed when action is 'error' without errorCode (defaults to -1)", async () => {
+      fakeAdb.setCommandResponse("emu finger touch 1", { stdout: "", stderr: "" });
+      fakeAdb.setCommandResponse("emu finger remove 1", { stdout: "", stderr: "" });
+
+      const result = await biometricAuth.execute({ action: "error" }); // no errorCode
+
+      expect(result.success).toBe(true);
+      expect(result.errorCode).toBeUndefined();
+      // Message should show -1 as the default errorCode sent in the broadcast
+      expect(result.message).toContain("-1");
     });
 
     test("should use custom fingerprint ID for error action", async () => {
@@ -267,16 +289,17 @@ describe("BiometricAuth", () => {
       )).toBe(true);
     });
 
-    test("should still proceed if broadcast fails", async () => {
-      // Make broadcast fail
-      fakeAdb.setCommandResponse("BIOMETRIC_OVERRIDE", { stdout: "", stderr: "broadcast failed" });
+    test("should still proceed if broadcast throws", async () => {
+      // Make broadcast throw to simulate ADB failure
+      fakeAdb.setCommandError("BIOMETRIC_OVERRIDE", new Error("adb: device offline"));
       fakeAdb.setCommandResponse("emu finger touch 1", { stdout: "", stderr: "" });
       fakeAdb.setCommandResponse("emu finger remove 1", { stdout: "", stderr: "" });
 
       const result = await biometricAuth.execute({ action: "match" });
 
-      // Emu finger path should still work
+      // Emu finger path should still work despite broadcast failure
       expect(result.success).toBe(true);
+      expect(result.supported).toBe(true);
     });
   });
 
@@ -307,6 +330,17 @@ describe("BiometricAuth", () => {
 
       const executedCommands = fakeAdb.getExecutedCommands();
       expect(executedCommands.some(cmd => cmd.includes("emu finger"))).toBe(false);
+    });
+
+    test("should return failure when broadcast fails on physical devices", async () => {
+      fakeAdb.setCommandResponse("shell getprop ro.kernel.qemu", { stdout: "0", stderr: "" });
+      fakeAdb.setCommandError("BIOMETRIC_OVERRIDE", new Error("adb: device offline"));
+
+      const result = await biometricAuth.execute({ action: "match" });
+
+      expect(result.success).toBe(false);
+      expect(result.supported).toBe("partial");
+      expect(result.error).toContain("broadcast failed");
     });
 
     test("should support error action on physical devices via SDK broadcast", async () => {


### PR DESCRIPTION
## Summary

- **Bugs**: Fix misleading `success:true` when SDK broadcast fails on physical devices; fix false-positive warning in `handleBroadcastIntent` that fired for every non-ERROR broadcast; add warning when `action:'error'` is sent without `errorCode`
- **API**: Add Zod `.refine()` validation to reject `errorCode` on non-`error` actions; fix `cancel` result message; remove modality type cast; update schema description to reflect validation error (not silent ignore)
- **Thread safety**: Replace `@Volatile` with `@Synchronized` on `registerReceiver()` to close the TOCTOU race where two threads could both pass the guard check
- **Tests**: Add broadcast receiver round-trip tests via `handleBroadcastIntent()`; fix misleading broadcast-failure test that was testing the happy path; add `FakeAdbExecutor.setCommandError()` for per-command error injection; add `@VisibleForTesting` annotation
- **Docs**: Mark all Plan items complete; update Risks to accurately describe physical device constraints; add KDoc note on `src/main/` placement and `debugImplementation`

## Test Plan

- [x] `bun test test/features/action/BiometricAuth.test.ts` — 31 pass
- [x] `./gradlew -p android :auto-mobile-sdk:test` — BUILD SUCCESSFUL (122 tests)
- [x] `bun test --bail` — 2837 pass, 2 skip, 0 fail across 222 files

🤖 Generated with [Claude Code](https://claude.com/claude-code)