### PR TITLE
fix: reconnect MCP session on expiry, fix swipe direction, expand schema paths

### DIFF
--- a/src/daemon/socketServer.ts
+++ b/src/daemon/socketServer.ts
@@ -195,7 +195,21 @@ export class UnixSocketServer {
 
         const mcpClient = await this.getMcpClient();
 
-        const result = await this.handleIdeRequest(mcpClient, request);
+        let result;
+        try {
+          result = await this.handleIdeRequest(mcpClient, request);
+        } catch (ideError) {
+          const ideErrorMessage = ideError instanceof Error ? ideError.message : String(ideError);
+          if (ideErrorMessage.includes("Session not found")) {
+            logger.warn("MCP client session expired, reconnecting and retrying...");
+            this.mcpClient = null;
+            this.mcpClientPromise = null;
+            const freshClient = await this.getMcpClient();
+            result = await this.handleIdeRequest(freshClient, request);
+          } else {
+            throw ideError;
+          }
+        }
 
         return {
           id: request.id,

--- a/src/server/interactionTools.ts
+++ b/src/server/interactionTools.ts
@@ -663,11 +663,11 @@ export function registerInteractionTools() {
   const swipeOnHandler = async (device: BootedDevice, args: SwipeOnArgs, progress?: ProgressCallback) => {
     RecompositionTracker.getInstance().recordInteraction();
     const swipeOn = new SwipeOn(device);
-    const resolvedDirection = resolveSwipeDirection(args.direction, args.gestureType);
+    const resolvedDirection = resolveSwipeDirection({ direction: args.direction, gestureType: args.gestureType });
     const result = await swipeOn.execute({
       container: args.container,
       autoTarget: args.autoTarget ?? true,
-      direction: resolvedDirection,
+      direction: resolvedDirection.direction,
       lookFor: args.lookFor,
       speed: args.speed,
       includeSystemInsets: args.includeSystemInsets ?? false,

--- a/src/utils/plan/PlanSchemaValidator.ts
+++ b/src/utils/plan/PlanSchemaValidator.ts
@@ -64,6 +64,10 @@ export class PlanSchemaValidator {
     const possiblePaths = [
       // From source: src/utils/plan/PlanSchemaValidator.ts -> schemas/
       path.join(__dirname, "../../../schemas/test-plan.schema.json"),
+      // From Bun-bundled dist/src/index.js: dist/src/../../ = project root schemas/
+      path.join(__dirname, "../../schemas/test-plan.schema.json"),
+      // From dist/src/: one level up to dist/, then schemas/
+      path.join(__dirname, "../schemas/test-plan.schema.json"),
       // From dist: dist/src/utils/plan/PlanSchemaValidator.js -> dist/schemas/
       path.join(__dirname, "../../../../schemas/test-plan.schema.json"),
       // From cwd (project root)

--- a/test/daemon/socketServerMcpReconnect.test.ts
+++ b/test/daemon/socketServerMcpReconnect.test.ts
@@ -1,0 +1,204 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { Socket } from "node:net";
+import { randomUUID } from "node:crypto";
+import { existsSync } from "node:fs";
+import { unlink } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { UnixSocketServer } from "../../src/daemon/socketServer";
+import { FakeTimer } from "../fakes/FakeTimer";
+import type { DaemonResponse } from "../../src/daemon/types";
+
+/**
+ * Minimal fake MCP client interface for testing.
+ * Only implements the methods exercised by handleIdeRequest.
+ */
+interface FakeMcpClient {
+  listTools: () => Promise<{ tools: unknown[] }>;
+  callTool: (...args: unknown[]) => Promise<unknown>;
+  listResources: () => Promise<{ resources: unknown[] }>;
+  readResource: (...args: unknown[]) => Promise<unknown>;
+  listResourceTemplates: () => Promise<{ resourceTemplates: unknown[] }>;
+  close: () => Promise<void>;
+}
+
+function createFakeMcpClient(overrides: Partial<FakeMcpClient> = {}): FakeMcpClient {
+  return {
+    listTools: async () => ({ tools: [] }),
+    callTool: async () => ({ content: [] }),
+    listResources: async () => ({ resources: [] }),
+    readResource: async () => ({ contents: [] }),
+    listResourceTemplates: async () => ({ resourceTemplates: [] }),
+    close: async () => {},
+    ...overrides,
+  };
+}
+
+function createFakeDaemonState() {
+  return {
+    isInitialized: () => true,
+    getSessionManager: () => ({ getSession: () => null, releaseSession: async () => null }),
+    getDevicePool: () => ({
+      refreshDevices: async () => 0,
+      getStats: () => ({ total: 0, idle: 0, assigned: 0, error: 0 }),
+      releaseDevice: async () => {},
+    }),
+  };
+}
+
+function sendRequest(socketPath: string, method: string, params: Record<string, unknown> = {}): Promise<DaemonResponse> {
+  return new Promise((resolve, reject) => {
+    const client = new Socket();
+    let buffer = "";
+
+    client.connect(socketPath, () => {
+      const request = JSON.stringify({
+        id: randomUUID(),
+        type: "mcp_request",
+        method,
+        params,
+      });
+      client.write(request + "\n");
+    });
+
+    client.on("data", data => {
+      buffer += data.toString();
+      const lines = buffer.split("\n");
+      for (const line of lines) {
+        if (line.trim()) {
+          try {
+            const response = JSON.parse(line) as DaemonResponse;
+            client.destroy();
+            resolve(response);
+            return;
+          } catch {
+            // Incomplete JSON, keep buffering
+          }
+        }
+      }
+    });
+
+    client.on("error", reject);
+    client.on("close", () => {
+      if (!buffer.trim()) {
+        reject(new Error("Connection closed without response"));
+      }
+    });
+  });
+}
+
+describe("UnixSocketServer MCP session reconnect", () => {
+  let socketPath: string;
+  let server: UnixSocketServer;
+  let fakeTimer: FakeTimer;
+
+  beforeEach(async () => {
+    socketPath = join(tmpdir(), `mcp-rc-${randomUUID()}.sock`);
+    fakeTimer = new FakeTimer();
+    server = new UnixSocketServer(
+      socketPath,
+      "http://localhost:0/mcp",
+      createFakeDaemonState(),
+      fakeTimer,
+    );
+    await server.start();
+  });
+
+  afterEach(async () => {
+    await server.close();
+    if (existsSync(socketPath)) {
+      await unlink(socketPath);
+    }
+  });
+
+  test("retries with a fresh client when MCP throws 'Session not found'", async () => {
+    let clientsCreated = 0;
+
+    (server as any).createMcpClient = async () => {
+      const clientIndex = ++clientsCreated;
+      return createFakeMcpClient({
+        listTools: async () => {
+          if (clientIndex === 1) {
+            throw new Error("Session not found");
+          }
+          return { tools: [{ name: "observe" }] };
+        },
+      });
+    };
+
+    const response = await sendRequest(socketPath, "tools/list");
+
+    expect(response.success).toBe(true);
+    expect(clientsCreated).toBe(2);
+    const result = response.result as { tools: Array<{ name: string }> };
+    expect(result.tools).toHaveLength(1);
+    expect(result.tools[0].name).toBe("observe");
+  });
+
+  test("resets cached client before reconnecting so getMcpClient creates a fresh one", async () => {
+    let clientsCreated = 0;
+
+    (server as any).createMcpClient = async () => {
+      ++clientsCreated;
+      return createFakeMcpClient({
+        listTools: async () => {
+          if (clientsCreated === 1) {
+            throw new Error("Session not found: MCP session expired");
+          }
+          return { tools: [] };
+        },
+      });
+    };
+
+    await sendRequest(socketPath, "tools/list");
+
+    // After reconnect, mcpClient should hold the fresh client
+    expect((server as any).mcpClient).not.toBeNull();
+    expect(clientsCreated).toBe(2);
+  });
+
+  test("does not retry on non-session errors and returns failure", async () => {
+    let clientsCreated = 0;
+
+    (server as any).createMcpClient = async () => {
+      ++clientsCreated;
+      return createFakeMcpClient({
+        listTools: async () => {
+          throw new Error("Connection refused");
+        },
+      });
+    };
+
+    const response = await sendRequest(socketPath, "tools/list");
+
+    expect(response.success).toBe(false);
+    expect(response.error).toContain("Connection refused");
+    // Only one client created — no retry
+    expect(clientsCreated).toBe(1);
+  });
+
+  test("subsequent requests reuse the reconnected client without creating another", async () => {
+    let clientsCreated = 0;
+
+    (server as any).createMcpClient = async () => {
+      ++clientsCreated;
+      const isFailing = clientsCreated === 1;
+      return createFakeMcpClient({
+        listTools: async () => {
+          if (isFailing) throw new Error("Session not found");
+          return { tools: [] };
+        },
+      });
+    };
+
+    // First request triggers reconnect (2 clients)
+    const first = await sendRequest(socketPath, "tools/list");
+    expect(first.success).toBe(true);
+    expect(clientsCreated).toBe(2);
+
+    // Second request reuses the cached client (still 2 clients)
+    const second = await sendRequest(socketPath, "tools/list");
+    expect(second.success).toBe(true);
+    expect(clientsCreated).toBe(2);
+  });
+});

--- a/test/utils/swipeOnUtils.test.ts
+++ b/test/utils/swipeOnUtils.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect } from "bun:test";
+import { resolveSwipeDirection, SCROLL_TO_FINGER_DIRECTION } from "../../src/utils/swipeOnUtils";
+import { SwipeDirection } from "../../src/models";
+
+describe("SCROLL_TO_FINGER_DIRECTION", () => {
+  it("maps all four scroll directions to their finger-swipe inverses", () => {
+    expect(SCROLL_TO_FINGER_DIRECTION.up).toBe("down");
+    expect(SCROLL_TO_FINGER_DIRECTION.down).toBe("up");
+    expect(SCROLL_TO_FINGER_DIRECTION.left).toBe("right");
+    expect(SCROLL_TO_FINGER_DIRECTION.right).toBe("left");
+  });
+});
+
+describe("resolveSwipeDirection", () => {
+  describe("missing direction", () => {
+    it("returns an error when direction is undefined", () => {
+      const result = resolveSwipeDirection({ direction: undefined });
+      expect(result.error).toBe("direction is required");
+      expect(result.direction).toBeUndefined();
+    });
+  });
+
+  describe("swipeFingerTowardsDirection (default)", () => {
+    it("returns direction unchanged when no gestureType provided", () => {
+      const result = resolveSwipeDirection({ direction: "up" });
+      expect(result.direction).toBe("up");
+      expect(result.error).toBeUndefined();
+      expect(result.message).toContain("up");
+      expect(result.message).toContain("finger");
+    });
+
+    it("returns direction unchanged for explicit swipeFingerTowardsDirection", () => {
+      const directions: SwipeDirection[] = ["up", "down", "left", "right"];
+      for (const direction of directions) {
+        const result = resolveSwipeDirection({ direction, gestureType: "swipeFingerTowardsDirection" });
+        expect(result.direction).toBe(direction);
+        expect(result.error).toBeUndefined();
+      }
+    });
+  });
+
+  describe("scrollTowardsDirection", () => {
+    it("inverts 'up' to 'down' (scroll content up → finger moves down)", () => {
+      const result = resolveSwipeDirection({ direction: "up", gestureType: "scrollTowardsDirection" });
+      expect(result.direction).toBe("down");
+      expect(result.error).toBeUndefined();
+      expect(result.message).toContain("above");
+    });
+
+    it("inverts 'down' to 'up' (scroll content down → finger moves up)", () => {
+      const result = resolveSwipeDirection({ direction: "down", gestureType: "scrollTowardsDirection" });
+      expect(result.direction).toBe("up");
+      expect(result.error).toBeUndefined();
+      expect(result.message).toContain("below");
+    });
+
+    it("inverts 'left' to 'right' (scroll content left → finger moves right)", () => {
+      const result = resolveSwipeDirection({ direction: "left", gestureType: "scrollTowardsDirection" });
+      expect(result.direction).toBe("right");
+      expect(result.error).toBeUndefined();
+      expect(result.message).toContain("from left");
+    });
+
+    it("inverts 'right' to 'left' (scroll content right → finger moves left)", () => {
+      const result = resolveSwipeDirection({ direction: "right", gestureType: "scrollTowardsDirection" });
+      expect(result.direction).toBe("left");
+      expect(result.error).toBeUndefined();
+      expect(result.message).toContain("from right");
+    });
+
+    it("includes the original scroll direction in the message", () => {
+      const result = resolveSwipeDirection({ direction: "up", gestureType: "scrollTowardsDirection" });
+      expect(result.message).toContain("up");
+    });
+  });
+
+  describe("regression: object API required (not positional args)", () => {
+    it("returns error when direction field is missing from options object", () => {
+      // The old call site used resolveSwipeDirection(args.direction, args.gestureType) with
+      // positional args. The function signature requires an options object. Passing a string
+      // as the options object results in direction being undefined inside the function.
+      const stringAsOptions = "up" as any;
+      const result = resolveSwipeDirection(stringAsOptions);
+      expect(result.error).toBe("direction is required");
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- **MCP session reconnect**: When the Streamable HTTP session expires and `handleIdeRequest` throws \"Session not found\", the daemon now clears the cached client and retries transparently with a fresh connection
- **Swipe direction bug**: Fixed `resolveSwipeDirection` call in `interactionTools.ts` to use the object API `{ direction, gestureType }` instead of positional args, and extract `.direction` from the returned `ResolvedSwipeDirection` object
- **Schema path fallbacks**: Added two more candidate paths in `PlanSchemaValidator` for Bun-bundled `dist/` layouts

## Test Plan
- [x] New `test/utils/swipeOnUtils.test.ts` — covers all four scroll direction inversions, finger gesture pass-through, missing direction error, and the regression case (string passed as options)
- [x] New `test/daemon/socketServerMcpReconnect.test.ts` — covers retry on session expiry, no retry on other errors, client reuse after reconnect
- [x] All 2912 existing tests pass, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)