### PR TITLE
feat: open Simulator.app GUI automatically on iOS device activation

### DIFF
--- a/ios/control-proxy/Sources/CtrlProxy/CommandHandler.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/CommandHandler.swift
@@ -392,11 +392,16 @@ public class CommandHandler: CommandHandling {
         )
     }
 
-    private func handleGetVoiceOverState(_ request: WebSocketRequest, startTime: Date) throws -> VoiceOverStateResponse {
+    private func handleGetVoiceOverState(
+        _ request: WebSocketRequest,
+        startTime: Date
+    )
+        throws -> VoiceOverStateResponse
+    {
         #if os(iOS)
-        let enabled = UIAccessibility.isVoiceOverRunning
+            let enabled = UIAccessibility.isVoiceOverRunning
         #else
-        let enabled = false
+            let enabled = false
         #endif
 
         return VoiceOverStateResponse(

--- a/ios/control-proxy/Sources/CtrlProxy/Models.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/Models.swift
@@ -558,7 +558,7 @@ public struct VoiceOverStateResponse: Codable {
         type = ResponseType.voiceOverStateResult.rawValue
         timestamp = Int64(Date().timeIntervalSince1970 * 1000)
         self.requestId = requestId
-        self.success = true
+        success = true
         self.enabled = enabled
         self.totalTimeMs = totalTimeMs
     }

--- a/src/utils/DeviceSessionManager.ts
+++ b/src/utils/DeviceSessionManager.ts
@@ -156,6 +156,7 @@ export class DeviceSessionManager implements DeviceSessionManager {
   private readonly adbFactory: AdbClientFactory;
   private _adb: AdbExecutor | undefined;
   private window: Window | undefined;
+  private simulatorAppOpened = false;
 
   // Track devices that have push update listeners registered
   private static pushUpdateListenersRegistered: Set<string> = new Set();
@@ -574,6 +575,13 @@ export class DeviceSessionManager implements DeviceSessionManager {
       logger.info(`iOS simulator ${deviceId} is not booted (state: ${deviceInfo.state})`);
       // Note: We could auto-boot here if desired, but keeping consistent with current behavior
       return;
+    }
+
+    if (!this.simulatorAppOpened) {
+      this.simulatorAppOpened = true;
+      await this.simctl!.openSimulatorApp().catch(err =>
+        logger.warn(`[DeviceSessionManager] Failed to open Simulator.app: ${err}`)
+      );
     }
 
     // Create a device object for the CtrlProxy iOS clients

--- a/src/utils/ios-cmdline-tools/SimCtlClient.ts
+++ b/src/utils/ios-cmdline-tools/SimCtlClient.ts
@@ -206,6 +206,11 @@ export interface SimCtl {
    * @param deviceId - Optional device ID (defaults to current device or "booted")
    */
   setAppearance(mode: "light" | "dark", deviceId?: string): Promise<void>;
+
+  /**
+   * Open Simulator.app so the booted simulator is visible
+   */
+  openSimulatorApp(): Promise<void>;
 }
 
 interface SimctlHostControlRunner {
@@ -901,6 +906,10 @@ export class SimCtlClient implements SimCtl {
   async setAppearance(mode: "light" | "dark", deviceId?: string): Promise<void> {
     const targetDevice = deviceId || this.device?.deviceId || "booted";
     await this.executeCommand(`ui ${targetDevice} appearance ${mode}`);
+  }
+
+  async openSimulatorApp(): Promise<void> {
+    await this.execAsync("open", ["-a", "Simulator"]);
   }
 }
 

--- a/test/fakes/FakeDeviceClientProvider.ts
+++ b/test/fakes/FakeDeviceClientProvider.ts
@@ -10,7 +10,8 @@ import { PlatformDeviceManager } from "../../src/utils/interfaces/DeviceUtils";
 export class FakeDeviceClientProvider implements DeviceClientProvider {
   constructor(
     private readonly fakeAdb: AdbExecutor,
-    private readonly fakeDeviceUtils: PlatformDeviceManager
+    private readonly fakeDeviceUtils: PlatformDeviceManager,
+    private readonly fakeSimctl?: SimCtlClient
   ) {}
 
   getAdb(): AdbExecutor {
@@ -18,8 +19,7 @@ export class FakeDeviceClientProvider implements DeviceClientProvider {
   }
 
   getSimctl(): SimCtlClient | undefined {
-    // Tests use fakeDeviceUtils instead
-    return undefined;
+    return this.fakeSimctl;
   }
 
   getAndroidEmulator(): AndroidEmulatorClient | undefined {

--- a/test/fakes/FakeSimCtlClient.ts
+++ b/test/fakes/FakeSimCtlClient.ts
@@ -87,4 +87,8 @@ export class FakeSimCtlClient {
   async terminateApp(bundleId: string, deviceId?: string): Promise<void> {
     this.recordCall("terminateApp", { bundleId, deviceId });
   }
+
+  async openSimulatorApp(): Promise<void> {
+    this.recordCall("openSimulatorApp", {});
+  }
 }

--- a/test/utils/DeviceSessionManager.test.ts
+++ b/test/utils/DeviceSessionManager.test.ts
@@ -4,8 +4,11 @@ import { FakeAdbExecutor } from "../fakes/FakeAdbExecutor";
 import { FakeDeviceUtils } from "../fakes/FakeDeviceUtils";
 import { FakeDeviceClientProvider } from "../fakes/FakeDeviceClientProvider";
 import { FakeCtrlProxyManager } from "../fakes/FakeCtrlProxyManager";
+import { FakeSimCtlClient } from "../fakes/FakeSimCtlClient";
 import { AndroidCtrlProxyManager } from "../../src/utils/CtrlProxyManager";
+import { IOSCtrlProxyManager } from "../../src/utils/IOSCtrlProxyManager";
 import { CtrlProxyClient } from "../../src/features/observe/android";
+import { CtrlProxyClient as IOSCtrlProxyClient } from "../../src/features/observe/ios/CtrlProxyClient";
 import { Window } from "../../src/features/observe/Window";
 import { BootedDevice, AppearanceConfigInput } from "../../src/models";
 import { serverConfig } from "../../src/utils/ServerConfig";
@@ -226,5 +229,104 @@ describe("DeviceSessionManager", () => {
 
     // Should have fallen through and checked status since service wasn't responsive
     expect(accessibilityManager.wasMethodCalled("isInstalled")).toBe(true);
+  });
+});
+
+describe("DeviceSessionManager iOS openSimulatorApp", () => {
+  let fakeAdb: FakeAdbExecutor;
+  let fakeDeviceUtils: FakeDeviceUtils;
+  let originalIOSCtrlProxyManagerGetInstance: typeof IOSCtrlProxyManager.getInstance;
+  let originalIOSCtrlProxyClientGetInstance: typeof IOSCtrlProxyClient.getInstance;
+  let originalAppearanceDefaults: AppearanceConfigInput;
+
+  beforeEach(() => {
+    fakeAdb = new FakeAdbExecutor();
+    fakeDeviceUtils = new FakeDeviceUtils();
+
+    originalAppearanceDefaults = serverConfig.getAppearanceDefaults();
+    serverConfig.setAppearanceDefaults({
+      ...originalAppearanceDefaults,
+      applyOnConnect: false,
+      syncWithHost: false,
+      defaultMode: "light"
+    });
+
+    originalIOSCtrlProxyManagerGetInstance = IOSCtrlProxyManager.getInstance;
+    originalIOSCtrlProxyClientGetInstance = IOSCtrlProxyClient.getInstance;
+
+    IOSCtrlProxyManager.getInstance = () =>
+      ({
+        getServicePort: () => 8080,
+        isRunning: async () => false,
+        setup: async () => ({ success: false, error: "skipped in test" }),
+        resetSetupState: () => {},
+      } as any);
+
+    IOSCtrlProxyClient.getInstance = () =>
+      ({
+        isConnected: () => false,
+      } as any);
+  });
+
+  afterEach(() => {
+    IOSCtrlProxyManager.getInstance = originalIOSCtrlProxyManagerGetInstance;
+    IOSCtrlProxyClient.getInstance = originalIOSCtrlProxyClientGetInstance;
+    serverConfig.setAppearanceDefaults(originalAppearanceDefaults);
+  });
+
+  test("should call openSimulatorApp once on the first booted iOS device verification", async () => {
+    const fakeSimctl = new FakeSimCtlClient();
+    fakeSimctl.setDeviceInfo("ios-sim-1", {
+      udid: "ios-sim-1",
+      name: "iPhone 15",
+      state: "Booted",
+      isAvailable: true,
+    });
+
+    const manager = DeviceSessionManager.createInstance(
+      new FakeDeviceClientProvider(fakeAdb, fakeDeviceUtils, fakeSimctl as any)
+    );
+
+    await manager.verifyIosDevice("ios-sim-1");
+
+    expect(fakeSimctl.getMethodCalls("openSimulatorApp")).toHaveLength(1);
+  });
+
+  test("should not call openSimulatorApp again on subsequent verifications", async () => {
+    const fakeSimctl = new FakeSimCtlClient();
+    fakeSimctl.setDeviceInfo("ios-sim-1", {
+      udid: "ios-sim-1",
+      name: "iPhone 15",
+      state: "Booted",
+      isAvailable: true,
+    });
+
+    const manager = DeviceSessionManager.createInstance(
+      new FakeDeviceClientProvider(fakeAdb, fakeDeviceUtils, fakeSimctl as any)
+    );
+
+    await manager.verifyIosDevice("ios-sim-1");
+    await manager.verifyIosDevice("ios-sim-1");
+    await manager.verifyIosDevice("ios-sim-1");
+
+    expect(fakeSimctl.getMethodCalls("openSimulatorApp")).toHaveLength(1);
+  });
+
+  test("should not call openSimulatorApp when device is not booted", async () => {
+    const fakeSimctl = new FakeSimCtlClient();
+    fakeSimctl.setDeviceInfo("ios-sim-1", {
+      udid: "ios-sim-1",
+      name: "iPhone 15",
+      state: "Shutdown",
+      isAvailable: true,
+    });
+
+    const manager = DeviceSessionManager.createInstance(
+      new FakeDeviceClientProvider(fakeAdb, fakeDeviceUtils, fakeSimctl as any)
+    );
+
+    await manager.verifyIosDevice("ios-sim-1");
+
+    expect(fakeSimctl.getMethodCalls("openSimulatorApp")).toHaveLength(0);
   });
 });


### PR DESCRIPTION
## Summary

- iOS simulators boot headlessly via `xcrun simctl boot` — the Simulator.app GUI never opens automatically. This PR ensures it opens on the first iOS device tool call each session.
- Adds `openSimulatorApp()` to the `SimCtl` interface and `SimCtlClient` (runs `open -a Simulator` via `execFile`)
- Calls it from `verifyIosDevice()` with a session-level `simulatorAppOpened` flag to deduplicate — the GUI opens once per MCP session, preventing focus-stealing on every tap/swipe/observe
- Also applies pre-existing SwiftFormat violations in `CommandHandler.swift` and `Models.swift`

## Test Plan
- [x] 3 new unit tests: first call opens the app, dedup prevents repeat calls, no-op when simulator is not booted
- [x] `bun test test/utils/DeviceSessionManager.test.ts` — 12/12 pass
- [x] `turbo run lint build` — clean
- [x] SwiftFormat, SwiftLint, hadolint, act dry-run — all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)