### PR TITLE
fix: set simulatorAppOpened flag only after successful open

### DIFF
--- a/src/utils/DeviceSessionManager.ts
+++ b/src/utils/DeviceSessionManager.ts
@@ -578,10 +578,12 @@ export class DeviceSessionManager implements DeviceSessionManager {
     }
 
     if (!this.simulatorAppOpened) {
-      this.simulatorAppOpened = true;
-      await this.simctl!.openSimulatorApp().catch(err =>
-        logger.warn(`[DeviceSessionManager] Failed to open Simulator.app: ${err}`)
-      );
+      try {
+        await this.simctl!.openSimulatorApp();
+        this.simulatorAppOpened = true;
+      } catch (err) {
+        logger.warn(`[DeviceSessionManager] Failed to open Simulator.app: ${err}`);
+      }
     }
 
     // Create a device object for the CtrlProxy iOS clients

--- a/test/fakes/FakeSimCtlClient.ts
+++ b/test/fakes/FakeSimCtlClient.ts
@@ -16,6 +16,11 @@ export class FakeSimCtlClient {
   private containerPaths = new Map<string, string>();
   private containerErrors = new Map<string, Error>();
   private methodCalls = new Map<string, Array<Record<string, unknown>>>();
+  private openSimulatorAppError: Error | null = null;
+
+  setOpenSimulatorAppError(error: Error | null): void {
+    this.openSimulatorAppError = error;
+  }
 
   setDeviceInfo(udid: string, info: AppleDevice | null): void {
     this.deviceInfo.set(udid, info);
@@ -90,5 +95,8 @@ export class FakeSimCtlClient {
 
   async openSimulatorApp(): Promise<void> {
     this.recordCall("openSimulatorApp", {});
+    if (this.openSimulatorAppError) {
+      throw this.openSimulatorAppError;
+    }
   }
 }

--- a/test/utils/DeviceSessionManager.test.ts
+++ b/test/utils/DeviceSessionManager.test.ts
@@ -329,4 +329,32 @@ describe("DeviceSessionManager iOS openSimulatorApp", () => {
 
     expect(fakeSimctl.getMethodCalls("openSimulatorApp")).toHaveLength(0);
   });
+
+  test("should retry openSimulatorApp on subsequent verifications after a failure", async () => {
+    const fakeSimctl = new FakeSimCtlClient();
+    fakeSimctl.setDeviceInfo("ios-sim-1", {
+      udid: "ios-sim-1",
+      name: "iPhone 15",
+      state: "Booted",
+      isAvailable: true,
+    });
+
+    const manager = DeviceSessionManager.createInstance(
+      new FakeDeviceClientProvider(fakeAdb, fakeDeviceUtils, fakeSimctl as any)
+    );
+
+    // First call: openSimulatorApp throws — flag must NOT be set
+    fakeSimctl.setOpenSimulatorAppError(new Error("open: command not found"));
+    await manager.verifyIosDevice("ios-sim-1");
+    expect(fakeSimctl.getMethodCalls("openSimulatorApp")).toHaveLength(1);
+
+    // Second call: open succeeds now — flag gets set
+    fakeSimctl.setOpenSimulatorAppError(null);
+    await manager.verifyIosDevice("ios-sim-1");
+    expect(fakeSimctl.getMethodCalls("openSimulatorApp")).toHaveLength(2);
+
+    // Third call: flag is set, no retry
+    await manager.verifyIosDevice("ios-sim-1");
+    expect(fakeSimctl.getMethodCalls("openSimulatorApp")).toHaveLength(2);
+  });
 });


### PR DESCRIPTION
## Summary

Follow-up to #1427 addressing P2 review feedback.

- **Bug**: `simulatorAppOpened` was set to `true` before `openSimulatorApp()` resolved. A transient failure (e.g. `open` binary momentarily unavailable) permanently disabled future retries for the session, leaving the simulator headless forever.
- **Fix**: Move the flag assignment inside the `try` block — it is only set on success. A failure leaves the flag `false`, so the next iOS device verification retries automatically.
- **Test**: Added `setOpenSimulatorAppError()` to `FakeSimCtlClient` and a new test that verifies the full retry-then-deduplicate sequence: fail → retry succeeds → no further retries.

## Test Plan
- [x] 13/13 tests pass (`bun test test/utils/DeviceSessionManager.test.ts`)
- [x] New test covers: failure → flag stays false → retry on next call → success → flag set → no further retries

🤖 Generated with [Claude Code](https://claude.com/claude-code)