### PR TITLE
fix: prevent CtrlProxy from restarting when process is alive but slow

### DIFF
--- a/src/utils/IOSCtrlProxyManager.ts
+++ b/src/utils/IOSCtrlProxyManager.ts
@@ -134,7 +134,6 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
 
   // Process monitoring
   private processMonitorInterval: ReturnType<typeof setInterval> | null = null;
-  private lastHealthCheckSuccess: boolean = false;
 
   // Auto-restart state
   private autoRestartEnabled: boolean = true;
@@ -149,7 +148,6 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
   private iproxyProcess: ChildProcess | null = null;
   private iproxyMonitorInterval: ReturnType<typeof setInterval> | null = null;
   private iproxyRestartTimeout: ReturnType<Timer["setTimeout"]> | null = null;
-  private iproxyHealthFailures: number = 0;
   private iproxyRestartAttempts: number = 0;
   private isStopping: boolean = false;
 
@@ -161,8 +159,7 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
   public static readonly APP_BUNDLE_ID = "dev.jasonpearson.automobile.ctrlproxy";
   /** Bundle ID used before the rename to CtrlProxy — uninstalled opportunistically on device setup */
   private static readonly LEGACY_APP_BUNDLE_ID = "dev.jasonpearson.automobile.XCTestServiceApp";
-  private static readonly IPROXY_HEALTH_CHECK_INTERVAL_MS = 5000;
-  private static readonly IPROXY_MAX_HEALTH_FAILURES = 2;
+  private static readonly IPROXY_MONITOR_INTERVAL_MS = 5000;
   private static readonly IPROXY_RESTART_BASE_DELAY_MS = 1000;
   private static readonly IPROXY_RESTART_MAX_DELAY_MS = 15000;
   private static readonly DEFAULT_IPROXY_START_TIMEOUT_MS = 5000;
@@ -405,6 +402,13 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
   private async startInternal(): Promise<void> {
     logger.info("[IOSCtrlProxy] Starting CtrlProxy");
     this.isStopping = false;
+
+    // Prefer process liveness check over health endpoint: a busy-but-alive CtrlProxy
+    // would fail the HTTP health check and incorrectly trigger a restart.
+    if (await this.isCtrlProxyProcessAlive()) {
+      logger.info("[IOSCtrlProxy] CtrlProxy process is alive, skipping start");
+      return;
+    }
 
     if (await this.isRunning()) {
       logger.info("[IOSCtrlProxy] Service is already running");
@@ -759,10 +763,9 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
     this.stopProcessMonitoring();
 
     // Check every 30 seconds
-    this.processMonitorInterval = defaultTimer.setInterval(async () => {
+    this.processMonitorInterval = this.timer.setInterval(async () => {
       try {
         const isHealthy = await this.checkHealthEndpoint();
-        this.lastHealthCheckSuccess = isHealthy;
 
         if (!isHealthy && this.xcTestProcessId) {
           // Check if process is still running
@@ -784,7 +787,7 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
    */
   private stopProcessMonitoring(): void {
     if (this.processMonitorInterval) {
-      clearInterval(this.processMonitorInterval);
+      this.timer.clearInterval(this.processMonitorInterval);
       this.processMonitorInterval = null;
     }
   }
@@ -893,6 +896,48 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
     } catch {
       return false;
     }
+  }
+
+  /**
+   * Check if the tracked CtrlProxy process is alive.
+   * Used by startInternal() to skip spawning when the process is merely slow.
+   */
+  private async isCtrlProxyProcessAlive(): Promise<boolean> {
+    if (!this.xcTestProcessId) {
+      return false;
+    }
+    if (this.useHostControl()) {
+      try {
+        const status = await this.hostControl.status({
+          deviceId: this.device.deviceId,
+          pid: this.xcTestProcessId
+        });
+        return status.success && (status.data?.running ?? false);
+      } catch {
+        return false;
+      }
+    }
+    return this.isProcessRunning(this.xcTestProcessId);
+  }
+
+  /**
+   * Check if the tracked iproxy process is alive.
+   * Used by startIproxyMonitoring() so it only restarts the tunnel when the
+   * process actually died, not when CtrlProxy is temporarily slow.
+   */
+  private async isIproxyProcessAlive(): Promise<boolean> {
+    if (!this.iproxyProcessId) {
+      return false;
+    }
+    if (this.useHostControl()) {
+      try {
+        const status = await this.hostControl.getIproxyStatus({ pid: this.iproxyProcessId });
+        return status.success && (status.data?.running ?? false);
+      } catch {
+        return false;
+      }
+    }
+    return this.isProcessRunning(this.iproxyProcessId);
   }
 
   private async startOnDevice(): Promise<void> {
@@ -1076,7 +1121,6 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
 
       this.iproxyProcessId = result.data.pid;
       this.iproxyProcess = null;
-      this.iproxyHealthFailures = 0;
       await this.waitForIproxyStartup();
       return;
     }
@@ -1100,7 +1144,6 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
 
     this.iproxyProcessId = child.pid;
     this.iproxyProcess = child;
-    this.iproxyHealthFailures = 0;
     this.captureIproxyOutput(child);
 
     child.on("exit", () => {
@@ -1156,7 +1199,6 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
     this.iproxyProcessId = null;
     this.iproxyProcess = null;
     this.iproxyRestartAttempts = 0;
-    this.iproxyHealthFailures = 0;
   }
 
   private async waitForIproxyStartup(): Promise<void> {
@@ -1193,7 +1235,9 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
 
     this.iproxyRestartTimeout = this.timer.setTimeout(() => {
       this.iproxyRestartTimeout = null;
-      void this.startIproxyTunnel().catch(error => {
+      void this.startIproxyTunnel().then(() => {
+        this.startIproxyMonitoring();
+      }).catch(error => {
         logger.warn(`[IOSCtrlProxy] Failed to restart iproxy: ${error instanceof Error ? error.message : String(error)}`);
       });
     }, delay);
@@ -1213,22 +1257,20 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
           return;
         }
 
-        const tunnelHealthy = await this.checkHealthEndpoint();
-        if (tunnelHealthy) {
-          this.iproxyHealthFailures = 0;
-          return;
-        }
-
-        this.iproxyHealthFailures++;
-        if (this.iproxyHealthFailures >= IOSCtrlProxyManager.IPROXY_MAX_HEALTH_FAILURES) {
-          logger.warn("[IOSCtrlProxy] iproxy health check failed, restarting tunnel");
+        // Check iproxy process liveness — not CtrlProxy health. A temporarily slow
+        // CtrlProxy would fail a health check even though the tunnel is fine; restarting
+        // the tunnel in that case is harmful. CtrlProxy's own health is covered by the
+        // separate 30 s process monitor.
+        const iproxyAlive = await this.isIproxyProcessAlive();
+        if (!iproxyAlive) {
+          logger.warn("[IOSCtrlProxy] iproxy process is no longer running, scheduling restart");
           await this.stopIproxyTunnel();
           this.scheduleIproxyRestart();
         }
       } catch (error) {
         logger.warn(`[IOSCtrlProxy] iproxy monitor error: ${error instanceof Error ? error.message : String(error)}`);
       }
-    }, IOSCtrlProxyManager.IPROXY_HEALTH_CHECK_INTERVAL_MS);
+    }, IOSCtrlProxyManager.IPROXY_MONITOR_INTERVAL_MS);
   }
 
   private stopIproxyMonitoring(): void {

--- a/test/utils/IOSCtrlProxyManager.test.ts
+++ b/test/utils/IOSCtrlProxyManager.test.ts
@@ -154,6 +154,141 @@ describe("IOSCtrlProxyManager", function() {
       expect(fakeExecutor.getSpawnedProcesses().length).toBe(2);
     });
   });
+
+  describe("restart prevention", function() {
+    let physicalDevice: BootedDevice;
+    let fakeExecutor: FakeProcessExecutor;
+
+    beforeEach(function() {
+      physicalDevice = {
+        deviceId: "00008030001E28C11E",
+        platform: "ios",
+        name: "iPhone"
+      };
+      fakeExecutor = new FakeProcessExecutor();
+    });
+
+    test("start() skips spawning when tracked CtrlProxy PID is alive", async function() {
+      const manager = IOSCtrlProxyManager.createForTestingWithDeps(
+        testDevice, // simulator UUID
+        fakeTimer,
+        undefined,
+        fakeExecutor
+      );
+
+      // Simulate an already-tracked process (as if startOnSimulator ran previously)
+      (manager as unknown as { xcTestProcessId: number }).xcTestProcessId = 12345;
+
+      // Health check fails (CtrlProxy appears busy/unresponsive) — this used to trigger a restart
+      fakeExecutor.setCommandResponse("curl -s", createExecResult("", ""));
+      // kill -0 succeeds by default (FakeProcessExecutor never throws) → process alive
+
+      fakeTimer.enableAutoAdvance();
+      await manager.start();
+
+      // Process is alive → no simctl spawn or exec for starting the binary
+      expect(fakeExecutor.wasCommandExecuted("simctl")).toBe(false);
+      expect(fakeExecutor.getSpawnedProcesses().length).toBe(0);
+    });
+
+    test("startProcessMonitoring uses the injected timer so tests can control it", function() {
+      const manager = IOSCtrlProxyManager.createForTestingWithDeps(
+        testDevice,
+        fakeTimer,
+        undefined,
+        fakeExecutor
+      );
+
+      expect(fakeTimer.getPendingIntervals().length).toBe(0);
+
+      (manager as unknown as { startProcessMonitoring: () => void }).startProcessMonitoring();
+
+      expect(fakeTimer.getPendingIntervals().length).toBe(1);
+      expect(fakeTimer.getPendingIntervals()[0]).toBe(30000);
+    });
+
+    describe("iproxy monitor uses process liveness not health endpoint", function() {
+      beforeEach(function() {
+        fakeExecutor.setCommandResponse("idevice_id -l", createExecResult(`${physicalDevice.deviceId}\n`, ""));
+      });
+
+      test("does not restart iproxy when process is alive even if health check fails", async function() {
+        const fakeProcess = new FakeChildProcess();
+        fakeExecutor.setNextSpawnProcess(fakeProcess);
+        const manager = IOSCtrlProxyManager.createForTestingWithDeps(
+          physicalDevice, fakeTimer, undefined, fakeExecutor
+        );
+
+        await (manager as unknown as { startIproxyTunnel: () => Promise<void> }).startIproxyTunnel();
+        expect(fakeExecutor.getSpawnedProcesses().length).toBe(1);
+
+        // Health endpoint fails (would have triggered restart in old code)
+        fakeExecutor.setCommandResponse("curl -s", createExecResult("", ""));
+        // kill -0 succeeds by default → iproxy process alive
+
+        (manager as unknown as { startIproxyMonitoring: () => void }).startIproxyMonitoring();
+
+        // Fire one monitor interval
+        fakeTimer.advanceTime(5000);
+        for (let i = 0; i < 5; i++) {await Promise.resolve();}
+
+        // iproxy is alive → no restart scheduled
+        expect(fakeExecutor.getSpawnedProcesses().length).toBe(1);
+      });
+
+      test("restarts iproxy when iproxyProcessId is null (process gone)", async function() {
+        const fakeProcess1 = new FakeChildProcess();
+        const fakeProcess2 = new FakeChildProcess();
+        fakeExecutor.setNextSpawnProcess(fakeProcess1);
+        const manager = IOSCtrlProxyManager.createForTestingWithDeps(
+          physicalDevice, fakeTimer, undefined, fakeExecutor
+        );
+
+        await (manager as unknown as { startIproxyTunnel: () => Promise<void> }).startIproxyTunnel();
+
+        // Simulate iproxy process dying between monitor ticks (clears tracking state)
+        (manager as unknown as { iproxyProcessId: null }).iproxyProcessId = null;
+        (manager as unknown as { iproxyProcess: null }).iproxyProcess = null;
+
+        fakeExecutor.setNextSpawnProcess(fakeProcess2);
+
+        (manager as unknown as { startIproxyMonitoring: () => void }).startIproxyMonitoring();
+
+        // Fire monitor — sees no tracked process → schedules restart
+        fakeTimer.advanceTime(5000);
+        for (let i = 0; i < 5; i++) {await Promise.resolve();}
+
+        // Fire restart timer (first attempt = 1000 ms base delay)
+        fakeTimer.advanceTime(1000);
+        for (let i = 0; i < 5; i++) {await Promise.resolve();}
+
+        expect(fakeExecutor.getSpawnedProcesses().length).toBe(2);
+      });
+
+      test("resumes iproxy monitoring after scheduled restart completes", async function() {
+        const fakeProcess1 = new FakeChildProcess();
+        const fakeProcess2 = new FakeChildProcess();
+        fakeExecutor.setNextSpawnProcess(fakeProcess1);
+        const manager = IOSCtrlProxyManager.createForTestingWithDeps(
+          physicalDevice, fakeTimer, undefined, fakeExecutor
+        );
+
+        await (manager as unknown as { startIproxyTunnel: () => Promise<void> }).startIproxyTunnel();
+
+        // Process exit triggers scheduleIproxyRestart
+        fakeProcess1.emit("exit", 1, null);
+
+        fakeExecutor.setNextSpawnProcess(fakeProcess2);
+
+        // Fire restart timer (1000 ms base delay for first attempt)
+        fakeTimer.advanceTime(1000);
+        for (let i = 0; i < 5; i++) {await Promise.resolve();}
+
+        // After restart, startIproxyMonitoring() should have been called → new interval pending
+        expect(fakeTimer.getPendingIntervals().length).toBe(1);
+      });
+    });
+  });
 });
 
 function createExecResult(stdout: string, stderr: string): ExecResult {


### PR DESCRIPTION
## Summary

Fixes #1354 — CtrlProxy was restarting multiple times per minute during hot reload and normal MCP use.

Three root causes were identified and fixed:

- **Spurious spawning (simulators)**: `startInternal()` used the HTTP health endpoint as its only liveness gate. A busy-but-alive CtrlProxy would time out the 2 s health check → `isRunning()` returned `false` → a duplicate `simctl spawn` process was launched, fought over the port, crashed, and triggered the auto-restart loop. Fixed by adding `isCtrlProxyProcessAlive()` (`kill -0 PID` or `hostControl.status()`) checked *before* the health endpoint — if the process is alive, skip spawning.

- **iproxy monitor triggered CtrlProxy restarts (physical devices)**: `startIproxyMonitoring()` called `checkHealthEndpoint()` to decide whether to restart iproxy. A slow CtrlProxy caused iproxy to be killed unnecessarily, which disconnected the WebSocket → `ensureConnected()` called `setup(true)` → health check still failing → CtrlProxy restarted too. Fixed by replacing the health check with `isIproxyProcessAlive()` — the monitor now only restarts the tunnel when the iproxy process itself has died.

- **No monitoring after programmatic iproxy restart**: After `scheduleIproxyRestart()` fired and called `startIproxyTunnel()`, `startIproxyMonitoring()` was never called, leaving the tunnel unmonitored. Fixed by calling `startIproxyMonitoring()` in the `.then()` of the restart.

Additional cleanup: switched `processMonitorInterval` from `defaultTimer` to `this.timer` (testability), removed dead state (`lastHealthCheckSuccess`, `iproxyHealthFailures`, `IPROXY_MAX_HEALTH_FAILURES`).

## Test Plan
- [x] 5 new unit tests covering each fix (liveness gate, timer injection, iproxy monitor alive/dead/resume)
- [x] All 2917 existing tests still pass
- [x] Lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)