### PR TITLE
chore: update CtrlProxy iOS IPA SHA256

### DIFF
--- a/src/constants/release.ts
+++ b/src/constants/release.ts
@@ -31,6 +31,6 @@ export const IOS_CTRL_PROXY_RELEASE_VERSION: string = "latest";
 export const IOS_CTRL_PROXY_IPA_URL: string = IOS_CTRL_PROXY_RELEASE_VERSION === "latest"
   ? "https://github.com/kaeawc/auto-mobile/releases/latest/download/control-proxy.ipa"
   : `https://github.com/kaeawc/auto-mobile/releases/download/v${IOS_CTRL_PROXY_RELEASE_VERSION}/control-proxy.ipa`;
-export const IOS_CTRL_PROXY_SHA256_CHECKSUM: string = "37b884ca17f18f839b3ac7eecff6239216da0fc6111b5126bf955c9c5f89f43d"; // Empty = skip verification (local dev only)
+export const IOS_CTRL_PROXY_SHA256_CHECKSUM: string = "1ec61f55cea497a75e300699db4a18cc260b6a7ccfaa43dc8e6dcfe571c6f33b"; // Empty = skip verification (local dev only)
 export const IOS_CTRL_PROXY_APP_HASH: string = ""; // Hash of CtrlProxyApp.app (device build), empty = skip verification
 export const IOS_CTRL_PROXY_RUNNER_SHA256: string = ""; // SHA256 of runner binary (CtrlProxyUITests-Runner), empty = skip verification


### PR DESCRIPTION
## Automated Checksum Update

The nightly build produced artifacts with updated SHA256 checksums.

| Artifact | Previous | New | Changed |
|----------|----------|-----|---------|
| **APK** | `69139a8ef5b6338049601801c6d3f7f74b4bea0ca0bdb39a197d2b1bebf698be` | `69139a8ef5b6338049601801c6d3f7f74b4bea0ca0bdb39a197d2b1bebf698be` | No |
| **IPA** | `37b884ca17f18f839b3ac7eecff6239216da0fc6111b5126bf955c9c5f89f43d` | `1ec61f55cea497a75e300699db4a18cc260b6a7ccfaa43dc8e6dcfe571c6f33b` | ✅ Yes |

### Why did this happen?

SHA256 checksums change when any of these change:
- Source code in `android/control-proxy/src/` or `ios/control-proxy/`
- Build configuration (`build.gradle.kts` or `project.yml`)
- Dependencies or SDK versions

### What to do

1. Review this PR to ensure the changes are expected
2. Merge when ready
3. Future releases will use these checksums for artifact verification

---
Auto-generated by the `nightly` workflow