### PR TITLE
fix: address TalkBack Phase 4 PR feedback (benchmark exit codes, doc field names, script schemas)

### DIFF
--- a/benchmark/talkback-detection-performance.ts
+++ b/benchmark/talkback-detection-performance.ts
@@ -166,9 +166,10 @@ function printResults(results: BenchmarkResult[]): void {
 }
 
 /**
- * Print pass/fail for each acceptance criterion
+ * Print pass/fail for each acceptance criterion.
+ * Returns true if all criteria pass, false if any fail.
  */
-function printAcceptanceCriteria(results: BenchmarkResult[]): void {
+function printAcceptanceCriteria(results: BenchmarkResult[]): boolean {
   console.log("Acceptance Criteria:");
   console.log("─".repeat(60));
 
@@ -177,6 +178,8 @@ function printAcceptanceCriteria(results: BenchmarkResult[]): void {
   const afterInvalidate = results.find(r => r.name.startsWith("3."));
   const featureFlag = results.find(r => r.name.startsWith("4."));
 
+  let allPassed = true;
+
   // Cache miss: first detection must complete within the simulated ADB time + <50ms overhead
   if (cold) {
     // The simulated ADB call takes ~30ms. Total must be <50ms overhead on top of that.
@@ -184,6 +187,7 @@ function printAcceptanceCriteria(results: BenchmarkResult[]): void {
     const simulatedAdbMs = 30;
     const overhead = cold.avgPerIteration - simulatedAdbMs;
     const pass = overhead < 50;
+    if (!pass) {allPassed = false;}
     console.log(
       `  ${pass ? "PASS" : "FAIL"} Cache miss overhead <50ms:     ${overhead.toFixed(2)} ms (total: ${cold.avgPerIteration.toFixed(2)} ms)`
     );
@@ -192,6 +196,7 @@ function printAcceptanceCriteria(results: BenchmarkResult[]): void {
   // Cache hit: warm calls must be very fast
   if (warm) {
     const pass = warm.avgPerIteration < 5;
+    if (!pass) {allPassed = false;}
     console.log(
       `  ${pass ? "PASS" : "FAIL"} Cache hit (warm) <5ms:         ${warm.avgPerIteration.toFixed(2)} ms`
     );
@@ -202,6 +207,7 @@ function printAcceptanceCriteria(results: BenchmarkResult[]): void {
     const simulatedAdbMs = 30;
     const overhead = afterInvalidate.avgPerIteration - simulatedAdbMs;
     const pass = overhead < 50;
+    if (!pass) {allPassed = false;}
     console.log(
       `  ${pass ? "PASS" : "FAIL"} Post-invalidate overhead <50ms: ${overhead.toFixed(2)} ms (total: ${afterInvalidate.avgPerIteration.toFixed(2)} ms)`
     );
@@ -210,12 +216,14 @@ function printAcceptanceCriteria(results: BenchmarkResult[]): void {
   // Feature flag override: no ADB call, must be sub-millisecond
   if (featureFlag) {
     const pass = featureFlag.avgPerIteration < 1 && featureFlag.adbCallCount === 0;
+    if (!pass) {allPassed = false;}
     console.log(
       `  ${pass ? "PASS" : "FAIL"} Feature flag override <1ms:    ${featureFlag.avgPerIteration.toFixed(3)} ms, ADB calls: ${featureFlag.adbCallCount}`
     );
   }
 
   console.log();
+  return allPassed;
 }
 
 /**
@@ -373,8 +381,12 @@ async function main() {
   // Print all results
   printResults(results);
 
-  // Print acceptance criteria pass/fail
-  printAcceptanceCriteria(results);
+  // Print acceptance criteria pass/fail and exit non-zero if any fail
+  const allPassed = printAcceptanceCriteria(results);
+  if (!allPassed) {
+    console.error("ERROR: One or more acceptance criteria failed.");
+    process.exit(1);
+  }
 
   // Summary
   const cold = results[0];
@@ -389,4 +401,7 @@ async function main() {
 }
 
 // Run benchmark
-main().catch(console.error);
+main().catch((e: unknown) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/docs/using/talkback.md
+++ b/docs/using/talkback.md
@@ -121,9 +121,9 @@ When TalkBack is enabled, `observe` includes two additional fields in its result
 ```json
 {
   "accessibilityFocusedElement": {
-    "resourceId": "com.example.app:id/btn_submit",
+    "resource-id": "com.example.app:id/btn_submit",
     "text": "Submit",
-    "contentDescription": "Submit form",
+    "content-desc": "Submit form",
     "bounds": { "left": 32, "top": 640, "right": 320, "bottom": 704 }
   }
 }

--- a/scripts/talkback-form-interaction.ts
+++ b/scripts/talkback-form-interaction.ts
@@ -14,9 +14,9 @@
  *   checked state: "Accept terms and conditions, not checked". The child
  *   TextView ("Accept terms") does not appear as a separate element.
  *
- *   When targeting a merged node, use tapOn({ contentDesc }) rather than
- *   tapOn({ text }), because the element's text field is often empty or absent
- *   on merged nodes. The content-desc is the reliable identifier.
+ *   When targeting a merged node or a field whose text is empty, use
+ *   tapOn({ elementId }) to target by resource-id. tapOn only accepts
+ *   text or elementId — contentDesc is not a supported selector.
  *
  * This script is a demonstration — it uses simulated responses to show the
  * expected call sequence and response shapes without requiring a real device.
@@ -35,8 +35,7 @@ import type { Element } from "../src/models/Element";
 
 interface TapOnArgs {
   text?: string;
-  resourceId?: string;
-  contentDesc?: string;
+  elementId?: string;
 }
 
 interface InputTextArgs {
@@ -392,8 +391,8 @@ function createMockClient(): MockClient {
 
     async tapOn(args: TapOnArgs): Promise<{ success: boolean; message: string }> {
       // Under TalkBack, tapOn issues ACTION_CLICK on the AccessibilityNodeInfo.
-      // For the merged checkbox node, the target is identified by contentDesc
-      // rather than text, because the merged parent node has no text of its own.
+      // tapOn only accepts text or elementId. For nodes with empty text (merged
+      // nodes, hint-only fields), use elementId (resource-id) to target them.
       return {
         success: true,
         message: `Tapped element (TalkBack: ACTION_CLICK on node): ${JSON.stringify(args)}`,
@@ -475,7 +474,7 @@ async function main(): Promise<void> {
     console.log(`  content-desc: "${checkboxInitial["content-desc"] ?? ""}"`);
     console.log(`  text:         "${checkboxInitial.text ?? ""}"`);
     console.log(
-      "  Note: text is empty. Use contentDesc to target this element in tapOn."
+      "  Note: text is empty. Use elementId (resource-id) to target this element in tapOn."
     );
   }
 
@@ -484,7 +483,8 @@ async function main(): Promise<void> {
   // -------------------------------------------------------------------------
   printStep(2, "Tap name field");
 
-  const tapNameResult = await client.tapOn({ contentDesc: "Full name" });
+  // text is empty on this input; use elementId (resource-id) instead
+  const tapNameResult = await client.tapOn({ elementId: "com.example.app:id/name_input" });
   printResult("tapOn result", tapNameResult);
 
   printStep(3, "Enter name");
@@ -497,7 +497,8 @@ async function main(): Promise<void> {
   // -------------------------------------------------------------------------
   printStep(4, "Tap email field");
 
-  const tapEmailResult = await client.tapOn({ contentDesc: "Email address" });
+  // text is empty on this input; use elementId (resource-id) instead
+  const tapEmailResult = await client.tapOn({ elementId: "com.example.app:id/email_input" });
   printResult("tapOn result", tapEmailResult);
 
   printStep(5, "Enter email address");
@@ -530,22 +531,25 @@ async function main(): Promise<void> {
   console.log("  label TextView) into this single accessibility node. The child");
   console.log('  TextView "Accept terms" does NOT appear separately in observe().');
   console.log("  The framework builds the content-desc from the label and the");
-  console.log("  current checked state. Use this string with tapOn({ contentDesc }).");
+  console.log("  current checked state. text is empty on the merged node.");
+  console.log("  Use elementId (resource-id) to target it reliably with tapOn.");
 
   // -------------------------------------------------------------------------
-  // Step 5: Tap the checkbox using contentDesc.
-  // Use contentDesc rather than text because the merged node's text field is
-  // empty. The content-desc is the only reliable identifier for merged nodes.
+  // Step 5: Tap the checkbox using elementId.
+  // tapOn only accepts text or elementId. Since the merged node's text field
+  // is empty, use elementId (the node's resource-id) to target it.
+  // The resource-id is stable regardless of how the content-desc changes with
+  // checked/unchecked state, making it the most reliable selector here.
   // -------------------------------------------------------------------------
-  printStep(7, "Tap merged checkbox node using contentDesc");
-  console.log("Note: text is empty on merged nodes. contentDesc is the correct");
-  console.log("      field to use for tapOn targeting.");
+  printStep(7, "Tap merged checkbox node using elementId");
+  console.log("Note: text is empty on merged nodes. Use elementId (resource-id)");
+  console.log("      to target them — tapOn does not accept contentDesc.");
   console.log(
-    `      Target content-desc: "${checkboxBeforeTap["content-desc"] ?? ""}"`
+    `      Target resource-id: "${checkboxBeforeTap["resource-id"] ?? ""}"`
   );
 
   const tapCheckboxResult = await client.tapOn({
-    contentDesc: checkboxBeforeTap["content-desc"],
+    elementId: checkboxBeforeTap["resource-id"],
   });
   printResult("tapOn result", tapCheckboxResult);
 
@@ -616,7 +620,7 @@ async function main(): Promise<void> {
   console.log("  - tapOn uses ACTION_CLICK internally (transparent to agent).");
   console.log("  - inputText uses ACTION_SET_TEXT in both modes (no change).");
   console.log("  - Merged nodes expose a combined content-desc, not child text.");
-  console.log("  - Use tapOn({ contentDesc }) to target merged accessibility nodes.");
+  console.log("  - Use tapOn({ elementId }) to target merged nodes (text is empty on them).");
   console.log("  - Checkbox state is reflected in the content-desc suffix");
   console.log('    ("not checked" vs "checked") — read it to verify toggle.');
   console.log("  - accessibilityFocusedElement tracks TalkBack cursor position.");

--- a/scripts/talkback-list-scroll.ts
+++ b/scripts/talkback-list-scroll.ts
@@ -35,23 +35,18 @@ import type { Element } from "../src/models/Element";
 
 interface TapOnArgs {
   text?: string;
-  resourceId?: string;
-  contentDesc?: string;
+  elementId?: string;
 }
 
 interface SwipeOnArgs {
-  // The element to swipe on (typically the scrollable container).
-  resourceId?: string;
-  text?: string;
+  // Container to scroll — scoped by elementId or text, matching the swipeOn schema.
+  container?: { elementId: string } | { text: string };
   // Direction of scroll — "up" scrolls content upward (ACTION_SCROLL_FORWARD).
   direction: "up" | "down" | "left" | "right";
   // When provided, AutoMobile repeats the scroll action until this element
   // becomes visible in the hierarchy or a retry limit is reached.
-  lookFor?: {
-    text?: string;
-    resourceId?: string;
-    contentDesc?: string;
-  };
+  // lookFor matches the swipeOnLookForSchema: elementId or text (not both).
+  lookFor?: { elementId: string } | { text: string };
 }
 
 interface MockClient {
@@ -397,8 +392,10 @@ async function main(): Promise<void> {
   );
   console.log("      lookFor causes AutoMobile to repeat the action until the target appears.");
 
+  // container scopes the scroll to the RecyclerView. Use { elementId } or { text },
+  // matching the swipeOn schema — top-level resourceId is not accepted.
   const swipeResult = await client.swipeOn({
-    resourceId: "com.example.app:id/item_list",
+    container: { elementId: "com.example.app:id/item_list" },
     direction: "up",
     lookFor: { text: targetText },
   });


### PR DESCRIPTION
## Summary

Follow-up to #1431 addressing bot review feedback:

- **benchmark**: `printAcceptanceCriteria` now returns a boolean; `main()` calls `process.exit(1)` when any criterion fails; top-level error handler propagates via `process.exit(1)` instead of silently logging
- **docs**: `accessibilityFocusedElement` JSON example corrected to use `resource-id` and `content-desc` (was incorrectly using `resourceId`/`contentDescription`)
- **scripts**: All demo scripts now use valid tapOn/swipeOn selector shapes — replaced invalid `contentDesc` with `elementId`, replaced top-level `resourceId` in `swipeOn` with `container: { elementId }`, aligned `lookFor` type with real `swipeOnLookForSchema`

## Test Plan

- [x] All three example scripts run cleanly
- [x] Benchmark runs and exits 0 when all criteria pass
- [x] Lint passes locally

Closes #1359 (follow-up fixes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)