### PR TITLE
refactor: extract interfaces and fakes for swipeon scroll infrastructure

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -771,8 +771,8 @@ jobs:
 #    steps:
 #      - name: "Git Checkout"
 #        uses: actions/checkout@v6
-with:
-  lfs: true
+#        with:
+#          lfs: true
 #
 #      - uses: ./.github/actions/setup-auto-mobile-npm-package
 #

--- a/ios/XCTestRunner/Sources/XCTestRunnerTests/XCTestRunnerTests.swift
+++ b/ios/XCTestRunner/Sources/XCTestRunnerTests/XCTestRunnerTests.swift
@@ -377,6 +377,7 @@ private final class FakeMCPClient: AutoMobileMCPClient {
         success: Bool,
         executedSteps: Int,
         totalSteps: Int,
+        // swiftlint:disable:next large_tuple
         failedStep: (stepIndex: Int, tool: String, error: String, device: String?)?,
         error: String?
     ) {

--- a/scripts/talkback-form-interaction.ts
+++ b/scripts/talkback-form-interaction.ts
@@ -55,30 +55,30 @@ interface MockClient {
 function makeFormScreenObserve(): ObserveResult {
   // Name field — standard EditText with a content-desc label.
   const nameField: Element = {
-    bounds: { left: 32, top: 200, right: 688, bottom: 260 },
-    text: "",
+    "bounds": { left: 32, top: 200, right: 688, bottom: 260 },
+    "text": "",
     "content-desc": "Full name",
     "resource-id": "com.example.app:id/name_input",
     "class": "android.widget.EditText",
-    clickable: true,
-    focusable: true,
-    focused: false,
+    "clickable": true,
+    "focusable": true,
+    "focused": false,
     "accessibility-focused": true,
-    enabled: true,
+    "enabled": true,
   };
 
   // Email field.
   const emailField: Element = {
-    bounds: { left: 32, top: 300, right: 688, bottom: 360 },
-    text: "",
+    "bounds": { left: 32, top: 300, right: 688, bottom: 360 },
+    "text": "",
     "content-desc": "Email address",
     "resource-id": "com.example.app:id/email_input",
     "class": "android.widget.EditText",
-    clickable: true,
-    focusable: true,
-    focused: false,
+    "clickable": true,
+    "focusable": true,
+    "focused": false,
     "accessibility-focused": false,
-    enabled: true,
+    "enabled": true,
   };
 
   // Checkbox with element merging.
@@ -95,34 +95,34 @@ function makeFormScreenObserve(): ObserveResult {
   // merging is active. Targeting the parent by content-desc is the correct
   // approach.
   const checkboxMerged: Element = {
-    bounds: { left: 32, top: 400, right: 688, bottom: 460 },
+    "bounds": { left: 32, top: 400, right: 688, bottom: 460 },
     // text is empty because the parent FrameLayout has no text of its own.
-    text: "",
+    "text": "",
     // content-desc is the merged string produced by the accessibility framework.
     "content-desc": "Accept terms and conditions, not checked",
     "resource-id": "com.example.app:id/terms_checkbox_container",
     "class": "android.widget.FrameLayout",
-    checkable: true,
-    checked: false,
-    clickable: true,
-    focusable: true,
-    focused: false,
+    "checkable": true,
+    "checked": false,
+    "clickable": true,
+    "focusable": true,
+    "focused": false,
     "accessibility-focused": false,
-    enabled: true,
+    "enabled": true,
   };
 
   // Submit button.
   const submitButton: Element = {
-    bounds: { left: 32, top: 520, right: 688, bottom: 580 },
-    text: "Submit",
+    "bounds": { left: 32, top: 520, right: 688, bottom: 580 },
+    "text": "Submit",
     "content-desc": "Submit",
     "resource-id": "com.example.app:id/submit_button",
     "class": "android.widget.Button",
-    clickable: true,
-    focusable: true,
-    focused: false,
+    "clickable": true,
+    "focusable": true,
+    "focused": false,
     "accessibility-focused": false,
-    enabled: true,
+    "enabled": true,
   };
 
   // TalkBack places its cursor on the first focusable element (the name field).
@@ -152,61 +152,61 @@ function makeCheckboxUncheckedObserve(): ObserveResult {
   // Returned after filling the name and email fields.
   // The checkbox is still unchecked; TalkBack cursor has moved to it.
   const nameField: Element = {
-    bounds: { left: 32, top: 200, right: 688, bottom: 260 },
-    text: "Jane Smith",
+    "bounds": { left: 32, top: 200, right: 688, bottom: 260 },
+    "text": "Jane Smith",
     "content-desc": "Full name",
     "resource-id": "com.example.app:id/name_input",
     "class": "android.widget.EditText",
-    clickable: true,
-    focusable: true,
-    focused: false,
+    "clickable": true,
+    "focusable": true,
+    "focused": false,
     "accessibility-focused": false,
-    enabled: true,
+    "enabled": true,
   };
 
   const emailField: Element = {
-    bounds: { left: 32, top: 300, right: 688, bottom: 360 },
-    text: "jane@example.com",
+    "bounds": { left: 32, top: 300, right: 688, bottom: 360 },
+    "text": "jane@example.com",
     "content-desc": "Email address",
     "resource-id": "com.example.app:id/email_input",
     "class": "android.widget.EditText",
-    clickable: true,
-    focusable: true,
-    focused: false,
+    "clickable": true,
+    "focusable": true,
+    "focused": false,
     "accessibility-focused": false,
-    enabled: true,
+    "enabled": true,
   };
 
   // The checkbox is not yet checked. The content-desc still ends with
   // "not checked". The agent targets this element using the full content-desc
   // string, since text is empty on the merged node.
   const checkboxUnchecked: Element = {
-    bounds: { left: 32, top: 400, right: 688, bottom: 460 },
-    text: "",
+    "bounds": { left: 32, top: 400, right: 688, bottom: 460 },
+    "text": "",
     "content-desc": "Accept terms and conditions, not checked",
     "resource-id": "com.example.app:id/terms_checkbox_container",
     "class": "android.widget.FrameLayout",
-    checkable: true,
-    checked: false,
-    clickable: true,
-    focusable: true,
-    focused: false,
+    "checkable": true,
+    "checked": false,
+    "clickable": true,
+    "focusable": true,
+    "focused": false,
     // TalkBack cursor is now on the checkbox container.
     "accessibility-focused": true,
-    enabled: true,
+    "enabled": true,
   };
 
   const submitButton: Element = {
-    bounds: { left: 32, top: 520, right: 688, bottom: 580 },
-    text: "Submit",
+    "bounds": { left: 32, top: 520, right: 688, bottom: 580 },
+    "text": "Submit",
     "content-desc": "Submit",
     "resource-id": "com.example.app:id/submit_button",
     "class": "android.widget.Button",
-    clickable: true,
-    focusable: true,
-    focused: false,
+    "clickable": true,
+    "focusable": true,
+    "focused": false,
     "accessibility-focused": false,
-    enabled: true,
+    "enabled": true,
   };
 
   return {
@@ -237,58 +237,58 @@ function makeCheckboxCheckedObserve(): ObserveResult {
   // The agent can read this to confirm the tap succeeded without needing to
   // inspect the checked field directly.
   const nameField: Element = {
-    bounds: { left: 32, top: 200, right: 688, bottom: 260 },
-    text: "Jane Smith",
+    "bounds": { left: 32, top: 200, right: 688, bottom: 260 },
+    "text": "Jane Smith",
     "content-desc": "Full name",
     "resource-id": "com.example.app:id/name_input",
     "class": "android.widget.EditText",
-    clickable: true,
-    focusable: true,
-    focused: false,
+    "clickable": true,
+    "focusable": true,
+    "focused": false,
     "accessibility-focused": false,
-    enabled: true,
+    "enabled": true,
   };
 
   const emailField: Element = {
-    bounds: { left: 32, top: 300, right: 688, bottom: 360 },
-    text: "jane@example.com",
+    "bounds": { left: 32, top: 300, right: 688, bottom: 360 },
+    "text": "jane@example.com",
     "content-desc": "Email address",
     "resource-id": "com.example.app:id/email_input",
     "class": "android.widget.EditText",
-    clickable: true,
-    focusable: true,
-    focused: false,
+    "clickable": true,
+    "focusable": true,
+    "focused": false,
     "accessibility-focused": false,
-    enabled: true,
+    "enabled": true,
   };
 
   // content-desc now ends with "checked" — the state has toggled.
   const checkboxChecked: Element = {
-    bounds: { left: 32, top: 400, right: 688, bottom: 460 },
-    text: "",
+    "bounds": { left: 32, top: 400, right: 688, bottom: 460 },
+    "text": "",
     "content-desc": "Accept terms and conditions, checked",
     "resource-id": "com.example.app:id/terms_checkbox_container",
     "class": "android.widget.FrameLayout",
-    checkable: true,
-    checked: true,
-    clickable: true,
-    focusable: true,
-    focused: false,
+    "checkable": true,
+    "checked": true,
+    "clickable": true,
+    "focusable": true,
+    "focused": false,
     "accessibility-focused": true,
-    enabled: true,
+    "enabled": true,
   };
 
   const submitButton: Element = {
-    bounds: { left: 32, top: 520, right: 688, bottom: 580 },
-    text: "Submit",
+    "bounds": { left: 32, top: 520, right: 688, bottom: 580 },
+    "text": "Submit",
     "content-desc": "Submit",
     "resource-id": "com.example.app:id/submit_button",
     "class": "android.widget.Button",
-    clickable: true,
-    focusable: true,
-    focused: false,
+    "clickable": true,
+    "focusable": true,
+    "focused": false,
     "accessibility-focused": false,
-    enabled: true,
+    "enabled": true,
   };
 
   return {
@@ -317,29 +317,29 @@ function makeSuccessScreenObserve(): ObserveResult {
   // After submit, the app navigates to a confirmation screen.
   // TalkBack auto-focuses the first element of the new screen.
   const successHeading: Element = {
-    bounds: { left: 32, top: 280, right: 688, bottom: 340 },
-    text: "Registration successful",
+    "bounds": { left: 32, top: 280, right: 688, bottom: 340 },
+    "text": "Registration successful",
     "content-desc": "Registration successful",
     "resource-id": "com.example.app:id/success_heading",
     "class": "android.widget.TextView",
-    clickable: false,
-    focusable: true,
-    focused: false,
+    "clickable": false,
+    "focusable": true,
+    "focused": false,
     "accessibility-focused": true,
-    enabled: true,
+    "enabled": true,
   };
 
   const successBody: Element = {
-    bounds: { left: 32, top: 360, right: 688, bottom: 440 },
-    text: "A confirmation email has been sent to jane@example.com.",
+    "bounds": { left: 32, top: 360, right: 688, bottom: 440 },
+    "text": "A confirmation email has been sent to jane@example.com.",
     "content-desc": "A confirmation email has been sent to jane@example.com.",
     "resource-id": "com.example.app:id/success_body",
     "class": "android.widget.TextView",
-    clickable: false,
-    focusable: true,
-    focused: false,
+    "clickable": false,
+    "focusable": true,
+    "focused": false,
     "accessibility-focused": false,
-    enabled: true,
+    "enabled": true,
   };
 
   return {
@@ -436,7 +436,7 @@ async function main(): Promise<void> {
   console.log("Scenario: Fill a registration form with name, email, a merged");
   console.log("checkbox, and a submit button while TalkBack is active.");
   console.log("Demonstrates element merging: the checkbox surfaces as a single");
-  console.log('node with a content-desc that includes the checked state.');
+  console.log("node with a content-desc that includes the checked state.");
 
   const client = createMockClient();
 

--- a/scripts/talkback-list-scroll.ts
+++ b/scripts/talkback-list-scroll.ts
@@ -62,30 +62,30 @@ interface MockClient {
 function makeListScreenObserve(): ObserveResult {
   // The list shows items 1–5. Item 15 exists but is off-screen below.
   const makeListItem = (n: number, accessibilityFocused: boolean): Element => ({
-    bounds: { left: 0, top: 80 + (n - 1) * 100, right: 720, bottom: 160 + (n - 1) * 100 },
-    text: `Item ${n}`,
+    "bounds": { left: 0, top: 80 + (n - 1) * 100, right: 720, bottom: 160 + (n - 1) * 100 },
+    "text": `Item ${n}`,
     "content-desc": `Item ${n}`,
     "resource-id": `com.example.app:id/list_item_${n}`,
     "class": "android.widget.LinearLayout",
-    clickable: true,
-    focusable: true,
-    focused: false,
+    "clickable": true,
+    "focusable": true,
+    "focused": false,
     "accessibility-focused": accessibilityFocused,
-    enabled: true,
+    "enabled": true,
   });
 
   const recyclerView: Element = {
-    bounds: { left: 0, top: 80, right: 720, bottom: 1200 },
-    text: undefined,
+    "bounds": { left: 0, top: 80, right: 720, bottom: 1200 },
+    "text": undefined,
     "content-desc": undefined,
     "resource-id": "com.example.app:id/item_list",
     "class": "androidx.recyclerview.widget.RecyclerView",
-    clickable: false,
-    focusable: false,
-    focused: false,
+    "clickable": false,
+    "focusable": false,
+    "focused": false,
     "accessibility-focused": false,
-    scrollable: true,
-    enabled: true,
+    "scrollable": true,
+    "enabled": true,
   };
 
   const visibleItems = [1, 2, 3, 4, 5].map(n => makeListItem(n, n === 1));
@@ -126,35 +126,35 @@ function makeAfterScrollObserve(): ObserveResult {
   // on accessibilityFocusedElement to confirm Item 15 is visible; it should
   // check observe().elements instead.
   const makeListItem = (n: number): Element => ({
-    bounds: {
+    "bounds": {
       left: 0,
       top: 80 + (n - 11) * 100,
       right: 720,
       bottom: 160 + (n - 11) * 100,
     },
-    text: `Item ${n}`,
+    "text": `Item ${n}`,
     "content-desc": `Item ${n}`,
     "resource-id": `com.example.app:id/list_item_${n}`,
     "class": "android.widget.LinearLayout",
-    clickable: true,
-    focusable: true,
-    focused: false,
+    "clickable": true,
+    "focusable": true,
+    "focused": false,
     "accessibility-focused": false,
-    enabled: true,
+    "enabled": true,
   });
 
   const recyclerView: Element = {
-    bounds: { left: 0, top: 80, right: 720, bottom: 1200 },
-    text: undefined,
+    "bounds": { left: 0, top: 80, right: 720, bottom: 1200 },
+    "text": undefined,
     "content-desc": undefined,
     "resource-id": "com.example.app:id/item_list",
     "class": "androidx.recyclerview.widget.RecyclerView",
-    clickable: false,
-    focusable: false,
-    focused: false,
+    "clickable": false,
+    "focusable": false,
+    "focused": false,
     "accessibility-focused": false,
-    scrollable: true,
-    enabled: true,
+    "scrollable": true,
+    "enabled": true,
   };
 
   // Item 1 is off-screen but TalkBack focus is still reported on it.
@@ -162,16 +162,16 @@ function makeAfterScrollObserve(): ObserveResult {
   // focused node persists in the accessibility tree even after it is recycled
   // out of the visible viewport.
   const offScreenItem1: Element = {
-    bounds: { left: 0, top: -920, right: 720, bottom: -840 },
-    text: "Item 1",
+    "bounds": { left: 0, top: -920, right: 720, bottom: -840 },
+    "text": "Item 1",
     "content-desc": "Item 1",
     "resource-id": "com.example.app:id/list_item_1",
     "class": "android.widget.LinearLayout",
-    clickable: true,
-    focusable: true,
-    focused: false,
+    "clickable": true,
+    "focusable": true,
+    "focused": false,
     "accessibility-focused": true,
-    enabled: true,
+    "enabled": true,
   };
 
   const visibleItems = [11, 12, 13, 14, 15].map(n => makeListItem(n));
@@ -204,29 +204,29 @@ function makeDetailScreenObserve(): ObserveResult {
   // After tapping Item 15, the detail screen loads.
   // TalkBack auto-focuses the first element on the new screen.
   const titleElement: Element = {
-    bounds: { left: 32, top: 120, right: 688, bottom: 180 },
-    text: "Item 15",
+    "bounds": { left: 32, top: 120, right: 688, bottom: 180 },
+    "text": "Item 15",
     "content-desc": "Item 15",
     "resource-id": "com.example.app:id/detail_title",
     "class": "android.widget.TextView",
-    clickable: false,
-    focusable: true,
-    focused: false,
+    "clickable": false,
+    "focusable": true,
+    "focused": false,
     "accessibility-focused": true,
-    enabled: true,
+    "enabled": true,
   };
 
   const descriptionElement: Element = {
-    bounds: { left: 32, top: 200, right: 688, bottom: 320 },
-    text: "Description for Item 15.",
+    "bounds": { left: 32, top: 200, right: 688, bottom: 320 },
+    "text": "Description for Item 15.",
     "content-desc": "Description for Item 15.",
     "resource-id": "com.example.app:id/detail_description",
     "class": "android.widget.TextView",
-    clickable: false,
-    focusable: true,
-    focused: false,
+    "clickable": false,
+    "focusable": true,
+    "focused": false,
     "accessibility-focused": false,
-    enabled: true,
+    "enabled": true,
   };
 
   return {

--- a/scripts/talkback-login-flow.ts
+++ b/scripts/talkback-login-flow.ts
@@ -48,57 +48,57 @@ interface MockClient {
 
 function makeLoginScreenObserve(): ObserveResult {
   const usernameField: Element = {
-    bounds: { left: 32, top: 280, right: 688, bottom: 340 },
-    text: "",
+    "bounds": { left: 32, top: 280, right: 688, bottom: 340 },
+    "text": "",
     "content-desc": "Username",
     "resource-id": "com.example.app:id/username_input",
     "class": "android.widget.EditText",
-    clickable: true,
-    focusable: true,
-    focused: false,
+    "clickable": true,
+    "focusable": true,
+    "focused": false,
     "accessibility-focused": false,
-    enabled: true,
+    "enabled": true,
   };
 
   const passwordField: Element = {
-    bounds: { left: 32, top: 380, right: 688, bottom: 440 },
-    text: "",
+    "bounds": { left: 32, top: 380, right: 688, bottom: 440 },
+    "text": "",
     "content-desc": "Password",
     "resource-id": "com.example.app:id/password_input",
     "class": "android.widget.EditText",
-    clickable: true,
-    focusable: true,
-    focused: false,
+    "clickable": true,
+    "focusable": true,
+    "focused": false,
     "accessibility-focused": false,
-    enabled: true,
+    "enabled": true,
   };
 
   const loginButton: Element = {
-    bounds: { left: 32, top: 500, right: 688, bottom: 560 },
-    text: "Log in",
+    "bounds": { left: 32, top: 500, right: 688, bottom: 560 },
+    "text": "Log in",
     "content-desc": "Log in",
     "resource-id": "com.example.app:id/login_button",
     "class": "android.widget.Button",
-    clickable: true,
-    focusable: true,
-    focused: false,
+    "clickable": true,
+    "focusable": true,
+    "focused": false,
     "accessibility-focused": false,
-    enabled: true,
+    "enabled": true,
   };
 
   // TalkBack places its cursor on the first focusable element on screen load.
   // The accessibilityFocusedElement field tracks where the TalkBack cursor is.
   const talkbackCursorOnHeading: Element = {
-    bounds: { left: 32, top: 180, right: 688, bottom: 240 },
-    text: "Sign in to your account",
+    "bounds": { left: 32, top: 180, right: 688, bottom: 240 },
+    "text": "Sign in to your account",
     "content-desc": "Sign in to your account",
     "resource-id": "com.example.app:id/login_heading",
     "class": "android.widget.TextView",
-    clickable: false,
-    focusable: true,
-    focused: false,
+    "clickable": false,
+    "focusable": true,
+    "focused": false,
     "accessibility-focused": true,
-    enabled: true,
+    "enabled": true,
   };
 
   return {
@@ -140,16 +140,16 @@ function makeUsernameFieldFocusedObserve(): ObserveResult {
   // coordinate tap under TalkBack only announces the element; it does not
   // activate it.
   const usernameField: Element = {
-    bounds: { left: 32, top: 280, right: 688, bottom: 340 },
-    text: "",
+    "bounds": { left: 32, top: 280, right: 688, bottom: 340 },
+    "text": "",
     "content-desc": "Username",
     "resource-id": "com.example.app:id/username_input",
     "class": "android.widget.EditText",
-    clickable: true,
-    focusable: true,
-    focused: true,
+    "clickable": true,
+    "focusable": true,
+    "focused": true,
     "accessibility-focused": true,
-    enabled: true,
+    "enabled": true,
   };
 
   return {
@@ -177,16 +177,16 @@ function makeUsernameFieldFocusedObserve(): ObserveResult {
 
 function makePostLoginObserve(): ObserveResult {
   const welcomeText: Element = {
-    bounds: { left: 32, top: 120, right: 688, bottom: 180 },
-    text: "Welcome, user@example.com",
+    "bounds": { left: 32, top: 120, right: 688, bottom: 180 },
+    "text": "Welcome, user@example.com",
     "content-desc": "Welcome, user@example.com",
     "resource-id": "com.example.app:id/welcome_message",
     "class": "android.widget.TextView",
-    clickable: false,
-    focusable: true,
-    focused: false,
+    "clickable": false,
+    "focusable": true,
+    "focused": false,
     "accessibility-focused": true,
-    enabled: true,
+    "enabled": true,
   };
 
   // On navigation to a new screen, TalkBack auto-focuses the first element.

--- a/src/features/action/swipeon/AutoTargetSelector.ts
+++ b/src/features/action/swipeon/AutoTargetSelector.ts
@@ -6,8 +6,9 @@ import {
 } from "../../../models";
 import { boundsArea, boundsEqual } from "../../../utils/bounds";
 import { getScreenBounds as getScreenBoundsFromSize } from "../../../utils/screenBounds";
+import { AutoTargetSelectorService } from "./types";
 
-export class AutoTargetSelector {
+export class AutoTargetSelector implements AutoTargetSelectorService {
   selectAutoTargetScrollable(
     scrollables: Element[],
     screenBounds: Element["bounds"] | null,

--- a/src/features/action/swipeon/OverlayDetector.ts
+++ b/src/features/action/swipeon/OverlayDetector.ts
@@ -9,11 +9,11 @@ import type { ElementFinder } from "../../../utils/interfaces/ElementFinder";
 import type { ElementGeometry } from "../../../utils/interfaces/ElementGeometry";
 import type { ElementParser } from "../../../utils/interfaces/ElementParser";
 import { DefaultElementParser } from "../../utility/ElementParser";
-import { SwipeInterval, OverlayCandidate } from "./types";
+import { SwipeInterval, OverlayCandidate, OverlayAnalyzer } from "./types";
 import { boundsArea, boundsEqual, clamp } from "../../../utils/bounds";
 import { isTruthyFlag, buildContainerFromElement } from "../../../utils/elementProperties";
 
-export class OverlayDetector {
+export class OverlayDetector implements OverlayAnalyzer {
   private static readonly OVERLAY_PADDING = 8;
   private static readonly CANDIDATE_FRACTIONS = [0.5, 0.25, 0.75, 0.15, 0.85];
 

--- a/src/features/action/swipeon/ScrollUntilVisible.ts
+++ b/src/features/action/swipeon/ScrollUntilVisible.ts
@@ -4,13 +4,13 @@ import {
   Element,
   GestureOptions,
   ObserveResult,
+  SwipeDirection,
   SwipeOnOptions,
   SwipeOnResult,
   ViewHierarchyResult
 } from "../../../models";
 import { logger } from "../../../utils/logger";
 import { PerformanceTracker, NoOpPerformanceTracker } from "../../../utils/PerformanceTracker";
-import { CtrlProxyClient as AndroidCtrlProxyClient } from "../../observe/android";
 import { CtrlProxyClient as IOSCtrlProxyClient } from "../../observe/ios";
 import type { ElementFinder } from "../../../utils/interfaces/ElementFinder";
 import type { ElementGeometry } from "../../../utils/interfaces/ElementGeometry";
@@ -18,21 +18,28 @@ import type { ObserveScreen } from "../../observe/interfaces/ObserveScreen";
 import { AccessibilityDetector } from "../../../utils/interfaces/AccessibilityDetector";
 import { serverConfig } from "../../../utils/ServerConfig";
 import { Timer } from "../../../utils/SystemTimer";
-import { SwipeOnResolvedOptions, BoomerangConfig } from "./types";
-import { OverlayDetector } from "./OverlayDetector";
-import { TalkBackSwipeExecutor } from "./TalkBackSwipeExecutor";
+import { SwipeOnResolvedOptions, BoomerangConfig, TalkBackSwipeRunner, OverlayAnalyzer, ScrollAccessibilityService } from "./types";
 import { resolveContainerSwipeCoordinates } from "./resolveContainerSwipeCoordinates";
 import { getScreenBounds } from "../../../utils/screenBounds";
+
+function oppositeDirection(dir: SwipeDirection): SwipeDirection {
+  switch (dir) {
+    case "up":    return "down";
+    case "down":  return "up";
+    case "left":  return "right";
+    case "right": return "left";
+  }
+}
 
 export interface ScrollUntilVisibleDependencies {
   device: BootedDevice;
   finder: ElementFinder;
   geometry: ElementGeometry;
   observeScreen: ObserveScreen;
-  accessibilityService: AndroidCtrlProxyClient;
+  accessibilityService: ScrollAccessibilityService;
   accessibilityDetector: AccessibilityDetector;
-  overlayDetector: OverlayDetector;
-  talkBackExecutor: TalkBackSwipeExecutor;
+  overlayDetector: OverlayAnalyzer;
+  talkBackExecutor: TalkBackSwipeRunner;
   timer: Timer;
   getDuration: (options: SwipeOnResolvedOptions) => number;
   resolveBoomerangConfig: (options: SwipeOnResolvedOptions) => BoomerangConfig | undefined;
@@ -111,7 +118,7 @@ export class ScrollUntilVisible {
     let scrollIteration = 0;
     let lastFingerprint = this.computeHierarchyFingerprint(lastObservation.viewHierarchy!);
     let unchangedScrollCount = 0;
-    const maxUnchangedScrolls = 3;
+    const maxUnchangedScrolls = 1;
 
     const target = options.lookFor!.text
       ? `text "${options.lookFor!.text}"`
@@ -130,13 +137,18 @@ export class ScrollUntilVisible {
       return accessibilityService === "talkback";
     });
 
-    // First check if element is already visible
+    // First check if element is already visible within the container bounds
     foundElement = await perf.track("initialSearch", () =>
       this.findElementInHierarchy(options.lookFor!, lastObservation.viewHierarchy!, options.container)
     );
 
+    if (foundElement && !this.isElementWithinContainer(foundElement, containerElement.bounds)) {
+      logger.info(`[SwipeOn] Found ${target} initially but it is outside container bounds (element center y=${Math.floor((foundElement.bounds.top + foundElement.bounds.bottom) / 2)}, container=[${containerElement.bounds.top},${containerElement.bounds.bottom}]), will scroll`);
+      foundElement = null;
+    }
+
     if (foundElement) {
-      logger.info(`[SwipeOn] Element already visible, no scrolling needed`);
+      logger.info(`[SwipeOn] Element already visible at bounds=${JSON.stringify(foundElement.bounds)}, no scrolling needed`);
 
       // Set accessibility focus on found element if requested
       if (isTalkBackEnabled && options.focusTarget) {
@@ -168,18 +180,39 @@ export class ScrollUntilVisible {
     );
     const swipeWarning = swipeCoordinates.warning;
 
+    // Overshoot recovery state
+    let reverseMode = false;
+    const reverseDirection = oppositeDirection(options.direction);
+    let reverseBounds = containerElement.bounds;
+    if (options.includeSystemInsets !== true && lastObservation.systemInsets) {
+      const insets = lastObservation.systemInsets;
+      reverseBounds = {
+        left: Math.max(containerElement.bounds.left, insets.left),
+        top: Math.max(containerElement.bounds.top, insets.top),
+        right: Math.min(containerElement.bounds.right, lastObservation.screenSize?.width ?? containerElement.bounds.right) - insets.right,
+        bottom: Math.min(containerElement.bounds.bottom, lastObservation.screenSize?.height ?? containerElement.bounds.bottom) - insets.bottom
+      };
+    }
+    const reverseSwipeCoords = this.computeHalfScreenReverseCoords(reverseDirection, reverseBounds);
+    const reverseOptions = { ...lookForOptions, speed: "slow" as const };
+    logger.info(`[SwipeOn] Forward swipe: direction=${options.direction}, coords=(${Math.floor(swipeCoordinates.startX)},${Math.floor(swipeCoordinates.startY)})→(${Math.floor(swipeCoordinates.endX)},${Math.floor(swipeCoordinates.endY)})`);
+    logger.info(`[SwipeOn] Reverse swipe: direction=${reverseDirection}, coords=(${Math.floor(reverseSwipeCoords.startX)},${Math.floor(reverseSwipeCoords.startY)})→(${Math.floor(reverseSwipeCoords.endX)},${Math.floor(reverseSwipeCoords.endY)}), bounds=${JSON.stringify(reverseBounds)}`);
+
     // Scroll until element is found
     while (this.deps.timer.now() - startTime < maxTime) {
       scrollIteration++;
-      logger.info(`[SwipeOn] Iteration ${scrollIteration}: elapsed=${this.deps.timer.now() - startTime}ms`);
+      logger.info(`[SwipeOn] Iteration ${scrollIteration}: elapsed=${this.deps.timer.now() - startTime}ms, reverseMode=${reverseMode}, unchangedScrollCount=${unchangedScrollCount}/${maxUnchangedScrolls}`);
 
       // Perform scroll
-      const swipeDuration = this.deps.getDuration(lookForOptions);
-      const { startX, startY, endX, endY } = swipeCoordinates;
+      const activeCoords = reverseMode ? reverseSwipeCoords : swipeCoordinates;
+      const activeDirection = reverseMode ? reverseDirection : options.direction;
+      const activeDuration = this.deps.getDuration(reverseMode ? reverseOptions : lookForOptions);
+      const { startX, startY, endX, endY } = activeCoords;
+      logger.info(`[SwipeOn] Swipe: direction=${activeDirection}, coords=(${Math.floor(startX)},${Math.floor(startY)})→(${Math.floor(endX)},${Math.floor(endY)}), duration=${activeDuration}ms`);
 
       const boomerang = this.deps.resolveBoomerangConfig(options);
       const gestureOptions: GestureOptions = {
-        duration: swipeDuration,
+        duration: activeDuration,
         scrollMode: options.scrollMode
       };
 
@@ -191,7 +224,7 @@ export class ScrollUntilVisible {
             Math.floor(startY),
             Math.floor(endX),
             Math.floor(endY),
-            options.direction,
+            activeDirection,
             containerElement,
             gestureOptions,
             perf,
@@ -218,38 +251,66 @@ export class ScrollUntilVisible {
         throw new Error("Lost observation after swipe during scroll until visible.");
       }
 
+      // Wait for scroll animation to fully settle before inspecting the hierarchy.
+      // The post-swipe observation may reflect a mid-scroll position (the accessibility service
+      // can return a cached hierarchy captured before the fling decelerates to rest). Polling
+      // until two consecutive fingerprints match ensures we evaluate lookFor against the final
+      // idle state rather than a transient mid-scroll frame.
+      const elapsedMs = this.deps.timer.now() - startTime;
+      const idleCheckMaxMs = Math.min(1500, Math.max(0, maxTime - elapsedMs - 300));
+      if (idleCheckMaxMs > 100) {
+        lastObservation = await this.waitForScrollIdle(lastObservation, idleCheckMaxMs);
+      }
+
       // Check if hierarchy changed (detect scroll end)
       const currentFingerprint = this.computeHierarchyFingerprint(lastObservation.viewHierarchy!);
+      const fingerprintChanged = currentFingerprint !== lastFingerprint;
+      logger.info(`[SwipeOn] Iteration ${scrollIteration}: hierarchy ${fingerprintChanged ? "changed" : "UNCHANGED"} (fingerprint[0:40]="${currentFingerprint.slice(0, 40)}")`);
 
-      if (currentFingerprint === lastFingerprint) {
+      if (!fingerprintChanged) {
         unchangedScrollCount++;
-        logger.info(`[SwipeOn] Iteration ${scrollIteration}: hierarchy unchanged (${unchangedScrollCount}/${maxUnchangedScrolls})`);
+        logger.info(`[SwipeOn] Iteration ${scrollIteration}: unchanged count now ${unchangedScrollCount}/${maxUnchangedScrolls}`);
 
         if (unchangedScrollCount >= maxUnchangedScrolls) {
-          perf.end();
-          const elapsed = this.deps.timer.now() - startTime;
-          throw new ActionableError(
-            `Scroll reached end of container (no change after ${maxUnchangedScrolls} scrolls). ` +
-            `${target} not found after ${scrollIteration} iterations (${elapsed}ms).`
-          );
+          if (reverseMode) {
+            // Reverse also exhausted — element truly not found
+            perf.end();
+            const elapsed = this.deps.timer.now() - startTime;
+            throw new ActionableError(
+              `Scroll reached end of container (no change after ${maxUnchangedScrolls} scrolls). ` +
+              `${target} not found after ${scrollIteration} iterations (${elapsed}ms).`
+            );
+          }
+          // Switch to reverse half-screen recovery
+          reverseMode = true;
+          unchangedScrollCount = 0;
+          logger.info(`[SwipeOn] Reached end in forward direction without finding ${target}, switching to reverse half-screen recovery`);
         }
       } else {
         unchangedScrollCount = 0;
         lastFingerprint = currentFingerprint;
       }
 
-      // Check if target element is now visible
+      logger.info(`[SwipeOn] Iteration ${scrollIteration}: searching for ${target}`);
+
+      // Check if target element is now visible within the container bounds
       foundElement = await this.findElementInHierarchy(
         options.lookFor!,
         lastObservation.viewHierarchy!,
         options.container
       );
 
+      if (foundElement && !this.isElementWithinContainer(foundElement, containerElement.bounds)) {
+        logger.info(`[SwipeOn] Found ${target} but it is outside container bounds (element center y=${Math.floor((foundElement.bounds.top + foundElement.bounds.bottom) / 2)}, container=[${containerElement.bounds.top},${containerElement.bounds.bottom}]), continuing scroll`);
+        foundElement = null;
+      }
+
       if (foundElement) {
         const elapsed = this.deps.timer.now() - startTime;
-        logger.info(`[SwipeOn] Found ${target} after ${scrollIteration} iterations (${elapsed}ms)`);
+        logger.info(`[SwipeOn] Found ${target} after ${scrollIteration} iterations (${elapsed}ms), reverseMode=${reverseMode}, bounds=${JSON.stringify(foundElement.bounds)}`);
         break;
       }
+      logger.info(`[SwipeOn] Iteration ${scrollIteration}: ${target} not yet found`);
     }
 
     if (!foundElement) {
@@ -432,7 +493,7 @@ export class ScrollUntilVisible {
       return "";
     }
 
-    return JSON.stringify(viewHierarchy.hierarchy).slice(0, 1000);
+    return JSON.stringify(viewHierarchy.hierarchy);
   }
 
   private async setAccessibilityFocusOnElement(
@@ -453,6 +514,69 @@ export class ScrollUntilVisible {
     } catch (error) {
       logger.warn(`[SwipeOn] Failed to set accessibility focus: ${error}`);
     }
+  }
+
+  private isElementWithinContainer(
+    element: Element,
+    containerBounds: { top: number; bottom: number; left: number; right: number }
+  ): boolean {
+    const centerY = (element.bounds.top + element.bounds.bottom) / 2;
+    const centerX = (element.bounds.left + element.bounds.right) / 2;
+    return (
+      centerY >= containerBounds.top &&
+      centerY <= containerBounds.bottom &&
+      centerX >= containerBounds.left &&
+      centerX <= containerBounds.right
+    );
+  }
+
+  private computeHalfScreenReverseCoords(
+    reverseDir: SwipeDirection,
+    effectiveBounds: { left: number; top: number; right: number; bottom: number }
+  ): { startX: number; startY: number; endX: number; endY: number } {
+    const cx = (effectiveBounds.left + effectiveBounds.right) / 2;
+    const cy = (effectiveBounds.top + effectiveBounds.bottom) / 2;
+    const h = effectiveBounds.bottom - effectiveBounds.top;
+    const w = effectiveBounds.right - effectiveBounds.left;
+
+    switch (reverseDir) {
+      case "down":
+        return { startX: cx, startY: effectiveBounds.top + h * 0.25, endX: cx, endY: effectiveBounds.top + h * 0.75 };
+      case "up":
+        return { startX: cx, startY: effectiveBounds.bottom - h * 0.25, endX: cx, endY: effectiveBounds.top + h * 0.25 };
+      case "right":
+        return { startX: effectiveBounds.left + w * 0.25, startY: cy, endX: effectiveBounds.left + w * 0.75, endY: cy };
+      case "left":
+        return { startX: effectiveBounds.right - w * 0.25, startY: cy, endX: effectiveBounds.left + w * 0.25, endY: cy };
+    }
+  }
+
+  private async waitForScrollIdle(
+    currentObservation: ObserveResult,
+    maxWaitMs: number
+  ): Promise<ObserveResult> {
+    if (!currentObservation.viewHierarchy) {return currentObservation;}
+    const startTime = this.deps.timer.now();
+    const pollIntervalMs = 150;
+    let previousFingerprint = this.computeHierarchyFingerprint(currentObservation.viewHierarchy);
+    let latestObservation = currentObservation;
+
+    while (this.deps.timer.now() - startTime < maxWaitMs) {
+      const newObservation = await this.deps.observeScreen.execute();
+      if (!newObservation.viewHierarchy) {break;}
+      const newFingerprint = this.computeHierarchyFingerprint(newObservation.viewHierarchy);
+      if (newFingerprint === previousFingerprint) {
+        logger.info(`[SwipeOn] Scroll settled after ${this.deps.timer.now() - startTime}ms idle check`);
+        return newObservation;
+      }
+      logger.info(`[SwipeOn] Scroll still settling (elapsed=${this.deps.timer.now() - startTime}ms), retrying in ${pollIntervalMs}ms`);
+      previousFingerprint = newFingerprint;
+      latestObservation = newObservation;
+      await this.deps.timer.sleep(pollIntervalMs);
+    }
+
+    logger.info(`[SwipeOn] Scroll idle check reached ${maxWaitMs}ms limit, proceeding`);
+    return latestObservation;
   }
 
   private resolveContainerSwipeCoordinates(

--- a/src/features/action/swipeon/SwipeOn.ts
+++ b/src/features/action/swipeon/SwipeOn.ts
@@ -33,7 +33,9 @@ import {
   GestureExecutor,
   SwipeOnDependencies,
   SwipeOnResolvedOptions,
-  BoomerangConfig
+  BoomerangConfig,
+  VoiceOverSwipeRunner,
+  AutoTargetSelectorService
 } from "./types";
 import { OverlayDetector } from "./OverlayDetector";
 import { AutoTargetSelector } from "./AutoTargetSelector";
@@ -53,9 +55,9 @@ export class SwipeOn extends BaseVisualChange {
   private accessibilityService: CtrlProxyClient;
   private accessibilityDetector: AccessibilityDetector;
   private overlayDetector: OverlayDetector;
-  private autoTargetSelector: AutoTargetSelector;
+  private autoTargetSelector: AutoTargetSelectorService;
   private talkBackExecutor: TalkBackSwipeExecutor;
-  private voiceOverExecutor: VoiceOverSwipeExecutor;
+  private voiceOverExecutor: VoiceOverSwipeRunner;
   private scrollUntilVisible: ScrollUntilVisible;
   private visionConfig: VisionFallbackConfig;
   private screenshotCapturer: ScreenshotCapturer;
@@ -85,7 +87,7 @@ export class SwipeOn extends BaseVisualChange {
 
     // Initialize extracted modules
     this.overlayDetector = new OverlayDetector(this.finder, this.geometry, parser);
-    this.autoTargetSelector = new AutoTargetSelector();
+    this.autoTargetSelector = dependencies.autoTargetSelector ?? new AutoTargetSelector();
     this.talkBackExecutor = new TalkBackSwipeExecutor(
       device,
       this.executeGesture,
@@ -94,7 +96,7 @@ export class SwipeOn extends BaseVisualChange {
       this.timer
     );
     const iosVoiceOverDetector = dependencies.iosVoiceOverDetector ?? defaultIosVoiceOverDetector;
-    this.voiceOverExecutor = new VoiceOverSwipeExecutor(
+    this.voiceOverExecutor = dependencies.voiceOverExecutor ?? new VoiceOverSwipeExecutor(
       device,
       this.executeGesture,
       IOSCtrlProxyClient.getInstance(device),
@@ -203,19 +205,24 @@ export class SwipeOn extends BaseVisualChange {
       direction: resolvedDirection.direction as SwipeDirection
     };
 
+    logger.info(`[SwipeOn] execute: direction=${normalizedOptions.direction}, lookFor=${JSON.stringify(normalizedOptions.lookFor)}, container=${JSON.stringify(normalizedOptions.container)}, speed=${normalizedOptions.speed}, autoTarget=${normalizedOptions.autoTarget}`);
+
     try {
       // Determine which mode to use
       if (normalizedOptions.lookFor) {
         // Scroll-until-visible mode
+        logger.info(`[SwipeOn] Mode: scroll-until-visible`);
         return await this.scrollUntilVisible.execute(normalizedOptions, progress, perf);
       } else if (!normalizedOptions.container) {
         const autoTargetEnabled = normalizedOptions.autoTarget !== false;
         if (!autoTargetEnabled) {
+          logger.info(`[SwipeOn] Mode: screen swipe (autoTarget disabled)`);
           return await this.executeScreenSwipe(normalizedOptions, progress, perf);
         }
 
         const scrollableContext = await this.getScrollableContext();
         if (scrollableContext.scrollables.length === 0) {
+          logger.info(`[SwipeOn] Mode: screen swipe (no scrollables found)`);
           return await this.executeScreenSwipe(normalizedOptions, progress, perf);
         }
 
@@ -229,6 +236,7 @@ export class SwipeOn extends BaseVisualChange {
         );
 
         if (!autoTargetElement) {
+          logger.info(`[SwipeOn] Mode: screen swipe (scrollables found but none matched direction=${normalizedOptions.direction})`);
           const result = await this.executeScreenSwipe(normalizedOptions, progress, perf);
           return {
             ...result,
@@ -239,6 +247,7 @@ export class SwipeOn extends BaseVisualChange {
 
         const autoTargetContainer = buildContainerFromElement(autoTargetElement);
         if (!autoTargetContainer) {
+          logger.info(`[SwipeOn] Mode: screen swipe (auto-target element has no usable identifier)`);
           const result = await this.executeScreenSwipe(normalizedOptions, progress, perf);
           return {
             ...result,
@@ -247,6 +256,7 @@ export class SwipeOn extends BaseVisualChange {
           };
         }
 
+        logger.info(`[SwipeOn] Mode: auto-target element swipe (container=${JSON.stringify(autoTargetContainer)})`);
         const autoTargetResult = await this.executeElementSwipe(
           { ...normalizedOptions, container: autoTargetContainer },
           progress,
@@ -263,6 +273,7 @@ export class SwipeOn extends BaseVisualChange {
         };
       } else {
         // Container specified = swipe within container
+        logger.info(`[SwipeOn] Mode: element swipe (explicit container=${JSON.stringify(normalizedOptions.container)})`);
         return await this.executeElementSwipe(normalizedOptions, progress, perf);
       }
     } catch (error) {

--- a/src/features/action/swipeon/TalkBackSwipeExecutor.ts
+++ b/src/features/action/swipeon/TalkBackSwipeExecutor.ts
@@ -10,10 +10,10 @@ import { PerformanceTracker, NoOpPerformanceTracker } from "../../../utils/Perfo
 import { CtrlProxyClient } from "../../observe/android";
 import { AccessibilityDetector } from "../../../utils/interfaces/AccessibilityDetector";
 import { SwipeResult } from "../../../models/SwipeResult";
-import { GestureExecutor, BoomerangConfig } from "./types";
+import { GestureExecutor, BoomerangConfig, TalkBackSwipeRunner } from "./types";
 import { Timer } from "../../../utils/interfaces/Timer";
 
-export class TalkBackSwipeExecutor {
+export class TalkBackSwipeExecutor implements TalkBackSwipeRunner {
   private static readonly DEFAULT_APEX_PAUSE_MS = 100;
   private static readonly DEFAULT_RETURN_SPEED = 1;
 
@@ -37,6 +37,7 @@ export class TalkBackSwipeExecutor {
     boomerang?: BoomerangConfig
   ): Promise<SwipeResult> {
     const boomerangEnabled = Boolean(boomerang);
+    logger.info(`[SwipeOn] executeSwipeGesture: direction=${direction}, (${x1},${y1})→(${x2},${y2}), duration=${gestureOptions?.duration}ms, boomerang=${boomerangEnabled}, container=${containerElement?.["resource-id"] ?? "none"}`);
 
     // Only check TalkBack for Android platform
     if (this.device.platform !== "android") {

--- a/src/features/action/swipeon/VoiceOverSwipeExecutor.ts
+++ b/src/features/action/swipeon/VoiceOverSwipeExecutor.ts
@@ -2,7 +2,7 @@ import { BootedDevice, GestureOptions } from "../../../models";
 import { logger } from "../../../utils/logger";
 import { PerformanceTracker, NoOpPerformanceTracker } from "../../../utils/PerformanceTracker";
 import { SwipeResult } from "../../../models/SwipeResult";
-import { GestureExecutor } from "./types";
+import { GestureExecutor, VoiceOverSwipeRunner } from "./types";
 import type { IosVoiceOverDetector } from "../../../utils/interfaces/IosVoiceOverDetector";
 import type { CtrlProxyService } from "../../observe/ios/CtrlProxyClient";
 
@@ -15,7 +15,7 @@ import type { CtrlProxyService } from "../../observe/ios/CtrlProxyClient";
  *
  * Parallel to TalkBackSwipeExecutor for Android TalkBack.
  */
-export class VoiceOverSwipeExecutor {
+export class VoiceOverSwipeExecutor implements VoiceOverSwipeRunner {
   constructor(
     private readonly device: BootedDevice,
     private readonly executeGesture: GestureExecutor,

--- a/src/features/action/swipeon/index.ts
+++ b/src/features/action/swipeon/index.ts
@@ -1,2 +1,2 @@
 export { SwipeOn } from "./SwipeOn";
-export type { GestureExecutor, SwipeOnDependencies } from "./types";
+export type { GestureExecutor, SwipeOnDependencies, VoiceOverSwipeRunner, AutoTargetSelectorService } from "./types";

--- a/src/features/action/swipeon/resolveContainerSwipeCoordinates.ts
+++ b/src/features/action/swipeon/resolveContainerSwipeCoordinates.ts
@@ -1,11 +1,10 @@
 import { Element, ObserveResult, ViewHierarchyResult } from "../../../models";
 import type { ElementGeometry } from "../../../utils/interfaces/ElementGeometry";
-import type { OverlayDetector } from "./OverlayDetector";
-import type { SwipeOnResolvedOptions } from "./types";
+import type { OverlayAnalyzer, SwipeOnResolvedOptions } from "./types";
 
 export function resolveContainerSwipeCoordinates(
   geometry: ElementGeometry,
-  overlayDetector: OverlayDetector,
+  overlayDetector: OverlayAnalyzer,
   options: SwipeOnResolvedOptions,
   viewHierarchy: ViewHierarchyResult,
   containerElement: Element,

--- a/src/features/action/swipeon/types.ts
+++ b/src/features/action/swipeon/types.ts
@@ -1,8 +1,11 @@
 import {
   Element,
   GestureOptions,
+  ObserveResult,
   SwipeDirection,
-  SwipeOnOptions
+  SwipeOnOptions,
+  ViewHierarchyQueryOptions,
+  ViewHierarchyResult
 } from "../../../models";
 import { PerformanceTracker } from "../../../utils/PerformanceTracker";
 import { SwipeResult } from "../../../models/SwipeResult";
@@ -23,6 +26,59 @@ export type OverlayCandidate = {
   zOrder: { windowRank: number; nodeOrder: number };
 };
 
+export interface VoiceOverSwipeRunner {
+  executeSwipeGesture(
+    x1: number,
+    y1: number,
+    x2: number,
+    y2: number,
+    gestureOptions?: GestureOptions,
+    perf?: PerformanceTracker
+  ): Promise<SwipeResult>;
+}
+
+export interface AutoTargetSelectorService {
+  selectAutoTargetScrollable(
+    scrollables: Element[],
+    screenBounds: Element["bounds"] | null,
+    direction: SwipeDirection
+  ): Element | null;
+
+  getScreenBounds(observeResult: ObserveResult): Element["bounds"] | null;
+
+  describeContainer(container: SwipeOnOptions["container"]): string;
+
+  mergeWarnings(...warnings: Array<string | undefined>): string | undefined;
+}
+
+export interface TalkBackSwipeRunner {
+  executeSwipeGesture(
+    x1: number,
+    y1: number,
+    x2: number,
+    y2: number,
+    direction: SwipeDirection,
+    containerElement: Element | null,
+    gestureOptions?: GestureOptions,
+    perf?: PerformanceTracker,
+    boomerang?: BoomerangConfig
+  ): Promise<SwipeResult>;
+}
+
+export interface OverlayAnalyzer {
+  collectOverlayCandidates(
+    viewHierarchy: ViewHierarchyResult,
+    container: SwipeOnOptions["container"] | undefined,
+    containerElement: Element
+  ): OverlayCandidate[];
+
+  computeSafeSwipeCoordinates(
+    direction: SwipeDirection,
+    bounds: Element["bounds"],
+    overlayBounds: Element["bounds"][]
+  ): { startX: number; startY: number; endX: number; endY: number; warning?: string } | null;
+}
+
 export interface GestureExecutor {
   swipe(
     x1: number,
@@ -34,6 +90,23 @@ export interface GestureExecutor {
   ): Promise<SwipeResult>;
 }
 
+export interface ScrollAccessibilityService {
+  requestAction(
+    action: string,
+    resourceId?: string,
+    timeoutMs?: number,
+    perf?: PerformanceTracker
+  ): Promise<{ success: boolean; error?: string; [key: string]: unknown }>;
+
+  getAccessibilityHierarchy(
+    queryOptions?: ViewHierarchyQueryOptions,
+    perf?: PerformanceTracker,
+    skipWaitForFresh?: boolean,
+    minTimestamp?: number,
+    disableAllFiltering?: boolean
+  ): Promise<ViewHierarchyResult | null>;
+}
+
 export interface SwipeOnDependencies {
   executeGesture?: GestureExecutor;
   observeScreen?: ObserveScreen;
@@ -42,6 +115,8 @@ export interface SwipeOnDependencies {
   parser?: import("../../../utils/interfaces/ElementParser").ElementParser;
   accessibilityDetector?: AccessibilityDetector;
   iosVoiceOverDetector?: IosVoiceOverDetector;
+  voiceOverExecutor?: VoiceOverSwipeRunner;
+  autoTargetSelector?: AutoTargetSelectorService;
   visionConfig?: import("../../../vision/VisionTypes").VisionFallbackConfig;
   screenshotCapturer?: import("../../navigation/SelectionStateTracker").ScreenshotCapturer;
   visionAnalyzer?: import("../../../vision/VisionTypes").VisionAnalyzer;

--- a/test/fakes/FakeAutoTargetSelector.ts
+++ b/test/fakes/FakeAutoTargetSelector.ts
@@ -1,0 +1,36 @@
+import { Element, ObserveResult, SwipeDirection, SwipeOnOptions } from "../../src/models";
+import { AutoTargetSelectorService } from "../../src/features/action/swipeon/types";
+
+export class FakeAutoTargetSelector implements AutoTargetSelectorService {
+  nextScrollable: Element | null = null;
+  nextScreenBounds: Element["bounds"] | null = null;
+  nextDescribeContainer: string = "unknown";
+  mergeWarningsResult: string | undefined = undefined;
+
+  selectAutoTargetScrollable(
+    _scrollables: Element[],
+    _screenBounds: Element["bounds"] | null,
+    _direction: SwipeDirection
+  ): Element | null {
+    return this.nextScrollable;
+  }
+
+  getScreenBounds(_observeResult: ObserveResult): Element["bounds"] | null {
+    return this.nextScreenBounds;
+  }
+
+  describeContainer(_container: SwipeOnOptions["container"]): string {
+    return this.nextDescribeContainer;
+  }
+
+  mergeWarnings(...warnings: Array<string | undefined>): string | undefined {
+    if (this.mergeWarningsResult !== undefined) {
+      return this.mergeWarningsResult;
+    }
+    const filtered = warnings.filter((w): w is string => Boolean(w));
+    if (filtered.length === 0) {
+      return undefined;
+    }
+    return Array.from(new Set(filtered)).join(" ");
+  }
+}

--- a/test/fakes/FakeCtrlProxy.ts
+++ b/test/fakes/FakeCtrlProxy.ts
@@ -7,6 +7,7 @@ import {
   A11ySetTextResult,
   A11yImeActionResult,
   A11ySelectAllResult,
+  A11yActionResult,
   AccessibilityHierarchyResponse,
   AndroidPerfTiming,
   AccessibilityHierarchy
@@ -65,6 +66,25 @@ export class FakeCtrlProxy implements CtrlProxy {
     duration?: number;
     timeoutMs?: number;
   }> = [];
+
+  private twoFingerSwipeHistory: Array<{
+    x1: number;
+    y1: number;
+    x2: number;
+    y2: number;
+    duration: number;
+    offset: number;
+    timeoutMs: number;
+  }> = [];
+
+  private actionHistory: Array<{
+    action: string;
+    resourceId?: string;
+    timeoutMs?: number;
+  }> = [];
+
+  private actionResult: A11yActionResult | null = null;
+  private twoFingerSwipeResult: A11ySwipeResult | null = null;
 
   private setTextHistory: Array<{
     text: string;
@@ -160,6 +180,22 @@ export class FakeCtrlProxy implements CtrlProxy {
     this.pinchResult = result;
   }
 
+  /**
+   * Configure the result returned by requestAction
+   * @param result - The action result to return (or null for default success)
+   */
+  setActionResult(result: A11yActionResult | null): void {
+    this.actionResult = result;
+  }
+
+  /**
+   * Configure the result returned by requestTwoFingerSwipe
+   * @param result - The swipe result to return (or null for default success)
+   */
+  setTwoFingerSwipeResult(result: A11ySwipeResult | null): void {
+    this.twoFingerSwipeResult = result;
+  }
+
   // Assertion methods
 
   /**
@@ -240,6 +276,28 @@ export class FakeCtrlProxy implements CtrlProxy {
   }
 
   /**
+   * Get the history of requestAction calls
+   */
+  getActionHistory(): Array<{ action: string; resourceId?: string; timeoutMs?: number }> {
+    return [...this.actionHistory];
+  }
+
+  /**
+   * Get the history of requestTwoFingerSwipe calls
+   */
+  getTwoFingerSwipeHistory(): Array<{
+    x1: number;
+    y1: number;
+    x2: number;
+    y2: number;
+    duration: number;
+    offset: number;
+    timeoutMs: number;
+  }> {
+    return [...this.twoFingerSwipeHistory];
+  }
+
+  /**
    * Get the number of screenshot requests made
    * @returns Number of screenshot requests
    */
@@ -263,6 +321,8 @@ export class FakeCtrlProxy implements CtrlProxy {
     this.dragHistory = [];
     this.setTextHistory = [];
     this.imeActionHistory = [];
+    this.actionHistory = [];
+    this.twoFingerSwipeHistory = [];
     this.screenshotRequestCount = 0;
     this.hierarchyRequestCount = 0;
   }
@@ -577,6 +637,56 @@ export class FakeCtrlProxy implements CtrlProxy {
       data: this.screenshotData,
       format: this.screenshotFormat,
       timestamp: Date.now()
+    };
+  }
+
+  async requestAction(
+    action: string,
+    resourceId?: string,
+    timeoutMs: number = 5000,
+    perf?: PerformanceTracker
+  ): Promise<A11yActionResult> {
+    await this.applyDelay("requestAction");
+    this.checkFailure("requestAction");
+
+    this.actionHistory.push({ action, resourceId, timeoutMs });
+
+    if (this.actionResult) {
+      return this.actionResult;
+    }
+
+    return {
+      success: true,
+      action,
+      totalTimeMs: 100,
+      perfTiming: this.performanceTiming || undefined
+    };
+  }
+
+  async requestTwoFingerSwipe(
+    x1: number,
+    y1: number,
+    x2: number,
+    y2: number,
+    duration: number = 300,
+    offset: number = 100,
+    timeoutMs: number = 5000,
+    perf?: PerformanceTracker
+  ): Promise<A11ySwipeResult> {
+    await this.applyDelay("requestTwoFingerSwipe");
+    this.checkFailure("requestTwoFingerSwipe");
+
+    this.twoFingerSwipeHistory.push({ x1, y1, x2, y2, duration, offset, timeoutMs });
+
+    if (this.twoFingerSwipeResult) {
+      return this.twoFingerSwipeResult;
+    }
+
+    return {
+      success: true,
+      totalTimeMs: duration,
+      gestureTimeMs: duration,
+      perfTiming: this.performanceTiming || undefined
     };
   }
 

--- a/test/fakes/FakeElementGeometry.ts
+++ b/test/fakes/FakeElementGeometry.ts
@@ -1,0 +1,41 @@
+import type { Element, ElementBounds } from "../../src/models";
+import type { Point } from "../../src/models/Point";
+import type { ElementGeometry } from "../../src/utils/interfaces/ElementGeometry";
+
+export class FakeElementGeometry implements ElementGeometry {
+  swipeResult = { startX: 200, startY: 700, endX: 200, endY: 200 };
+  swipeDuration = 300;
+
+  getElementCenter(_element: Element): Point {
+    return { x: 0, y: 0 };
+  }
+
+  isPointInElement(_element: Element, _x: number, _y: number): boolean {
+    return false;
+  }
+
+  isElementVisible(_element: Element, _screenWidth: number, _screenHeight: number): boolean {
+    return true;
+  }
+
+  getVisibleBounds(_element: Element, _screenWidth: number, _screenHeight: number): ElementBounds | null {
+    return null;
+  }
+
+  getSwipeWithinBounds(
+    _direction: "up" | "down" | "left" | "right",
+    _bounds: ElementBounds
+  ): { startX: number; startY: number; endX: number; endY: number } {
+    return this.swipeResult;
+  }
+
+  getSwipeDirectionForScroll(
+    direction: "up" | "down" | "left" | "right"
+  ): "up" | "down" | "left" | "right" {
+    return direction;
+  }
+
+  getSwipeDurationFromSpeed(_speed?: "slow" | "fast" | "normal"): number {
+    return this.swipeDuration;
+  }
+}

--- a/test/fakes/FakeOverlayDetector.ts
+++ b/test/fakes/FakeOverlayDetector.ts
@@ -1,0 +1,23 @@
+import { Element, SwipeDirection, SwipeOnOptions, ViewHierarchyResult } from "../../src/models";
+import { OverlayAnalyzer, OverlayCandidate } from "../../src/features/action/swipeon/types";
+
+export class FakeOverlayDetector implements OverlayAnalyzer {
+  candidates: OverlayCandidate[] = [];
+  safeCoords: { startX: number; startY: number; endX: number; endY: number; warning?: string } | null = null;
+
+  collectOverlayCandidates(
+    _viewHierarchy: ViewHierarchyResult,
+    _container: SwipeOnOptions["container"] | undefined,
+    _containerElement: Element
+  ): OverlayCandidate[] {
+    return this.candidates;
+  }
+
+  computeSafeSwipeCoordinates(
+    _direction: SwipeDirection,
+    _bounds: Element["bounds"],
+    _overlayBounds: Element["bounds"][]
+  ): { startX: number; startY: number; endX: number; endY: number; warning?: string } | null {
+    return this.safeCoords;
+  }
+}

--- a/test/fakes/FakeScrollAccessibilityService.ts
+++ b/test/fakes/FakeScrollAccessibilityService.ts
@@ -1,0 +1,34 @@
+import type { ScrollAccessibilityService } from "../../src/features/action/swipeon/types";
+
+export type RequestActionCall = {
+  action: string;
+  resourceId?: string;
+  timeoutMs?: number;
+};
+
+export class FakeScrollAccessibilityService implements ScrollAccessibilityService {
+  requestActionResult: { success: boolean; error?: string; [key: string]: unknown } = { success: true };
+  requestActionCalls: RequestActionCall[] = [];
+  private throwOnRequest: Error | null = null;
+
+  setRequestActionThrows(err: Error): void {
+    this.throwOnRequest = err;
+  }
+
+  async requestAction(
+    action: string,
+    resourceId?: string,
+    timeoutMs?: number,
+    _perf?: unknown
+  ): Promise<{ success: boolean; error?: string; [key: string]: unknown }> {
+    this.requestActionCalls.push({ action, resourceId, timeoutMs });
+    if (this.throwOnRequest) {
+      throw this.throwOnRequest;
+    }
+    return this.requestActionResult;
+  }
+
+  async getAccessibilityHierarchy(): Promise<null> {
+    return null;
+  }
+}

--- a/test/fakes/FakeTalkBackSwipeExecutor.ts
+++ b/test/fakes/FakeTalkBackSwipeExecutor.ts
@@ -1,0 +1,74 @@
+import { Element, GestureOptions, SwipeDirection } from "../../src/models";
+import { SwipeResult } from "../../src/models/SwipeResult";
+import { PerformanceTracker } from "../../src/utils/PerformanceTracker";
+import { TalkBackSwipeRunner, BoomerangConfig } from "../../src/features/action/swipeon/types";
+
+export class FakeTalkBackSwipeExecutor implements TalkBackSwipeRunner {
+  private swipeCalls: Array<{
+    x1: number;
+    y1: number;
+    x2: number;
+    y2: number;
+    direction: SwipeDirection;
+    containerElement: Element | null;
+    gestureOptions?: GestureOptions;
+  }> = [];
+
+  private nextResult: Partial<SwipeResult> | null = null;
+
+  setFailureResult(result: Partial<SwipeResult>): void {
+    this.nextResult = result;
+  }
+
+  async executeSwipeGesture(
+    x1: number,
+    y1: number,
+    x2: number,
+    y2: number,
+    direction: SwipeDirection,
+    containerElement: Element | null,
+    gestureOptions?: GestureOptions,
+    _perf?: PerformanceTracker,
+    _boomerang?: BoomerangConfig
+  ): Promise<SwipeResult> {
+    const overrideResult = this.nextResult;
+    this.nextResult = null;
+    if (overrideResult) {
+      this.swipeCalls.push({ x1, y1, x2, y2, direction, containerElement, gestureOptions });
+      return { success: false, x1, y1, x2, y2, duration: gestureOptions?.duration ?? 300, ...overrideResult };
+    }
+    this.swipeCalls.push({ x1, y1, x2, y2, direction, containerElement, gestureOptions });
+    return {
+      success: true,
+      x1,
+      y1,
+      x2,
+      y2,
+      duration: gestureOptions?.duration ?? 300
+    };
+  }
+
+  getSwipeCalls(): Array<{
+    x1: number;
+    y1: number;
+    x2: number;
+    y2: number;
+    direction: SwipeDirection;
+    containerElement: Element | null;
+    gestureOptions?: GestureOptions;
+  }> {
+    return [...this.swipeCalls];
+  }
+
+  getDirections(): SwipeDirection[] {
+    return this.swipeCalls.map(c => c.direction);
+  }
+
+  getCallCount(): number {
+    return this.swipeCalls.length;
+  }
+
+  reset(): void {
+    this.swipeCalls = [];
+  }
+}

--- a/test/fakes/FakeVoiceOverSwipeExecutor.ts
+++ b/test/fakes/FakeVoiceOverSwipeExecutor.ts
@@ -1,0 +1,24 @@
+import { GestureOptions } from "../../src/models";
+import { SwipeResult } from "../../src/models/SwipeResult";
+import { PerformanceTracker } from "../../src/utils/PerformanceTracker";
+import { VoiceOverSwipeRunner } from "../../src/features/action/swipeon/types";
+
+export class FakeVoiceOverSwipeExecutor implements VoiceOverSwipeRunner {
+  private swipeCalls: Array<{ x1: number; y1: number; x2: number; y2: number; gestureOptions?: GestureOptions }> = [];
+
+  async executeSwipeGesture(
+    x1: number,
+    y1: number,
+    x2: number,
+    y2: number,
+    gestureOptions?: GestureOptions,
+    _perf?: PerformanceTracker
+  ): Promise<SwipeResult> {
+    this.swipeCalls.push({ x1, y1, x2, y2, gestureOptions });
+    return { success: true, x1, y1, x2, y2, duration: gestureOptions?.duration ?? 300 };
+  }
+
+  getSwipeCalls() { return [...this.swipeCalls]; }
+  getCallCount() { return this.swipeCalls.length; }
+  reset() { this.swipeCalls = []; }
+}

--- a/test/features/action/swipeon/ScrollUntilVisible.overshoot.test.ts
+++ b/test/features/action/swipeon/ScrollUntilVisible.overshoot.test.ts
@@ -1,0 +1,431 @@
+import { beforeEach, describe, expect, test } from "bun:test";
+import { ScrollUntilVisible } from "../../../../src/features/action/swipeon/ScrollUntilVisible";
+import { FakeAccessibilityDetector } from "../../../fakes/FakeAccessibilityDetector";
+import { FakeElementFinder } from "../../../fakes/FakeElementFinder";
+import { FakeTimer } from "../../../fakes/FakeTimer";
+import { FakeTalkBackSwipeExecutor } from "../../../fakes/FakeTalkBackSwipeExecutor";
+import { FakeOverlayDetector } from "../../../fakes/FakeOverlayDetector";
+import { FakeScrollAccessibilityService } from "../../../fakes/FakeScrollAccessibilityService";
+import { FakeElementGeometry } from "../../../fakes/FakeElementGeometry";
+import type { BootedDevice, Element, ObserveResult } from "../../../../src/models";
+import type { OverlayCandidate, SwipeOnResolvedOptions } from "../../../../src/features/action/swipeon/types";
+
+const DEVICE: BootedDevice = {
+  name: "test-device",
+  platform: "android",
+  deviceId: "device-1"
+};
+
+const SCREEN_SIZE = { width: 400, height: 900 };
+
+const makeObserveResult = (hierarchyId: number = 0): ObserveResult => ({
+  timestamp: 0,
+  screenSize: SCREEN_SIZE,
+  systemInsets: { top: 0, right: 0, bottom: 0, left: 0 },
+  viewHierarchy: {
+    hierarchy: { node: { $: { _id: String(hierarchyId) } } }
+  }
+});
+
+const CONTAINER_ELEMENT: Element = {
+  "bounds": { left: 0, top: 0, right: 400, bottom: 900 },
+  "resource-id": "test:id/list",
+  "scrollable": true
+} as unknown as Element;
+
+const TARGET_ELEMENT: Element = {
+  "bounds": { left: 10, top: 200, right: 390, bottom: 250 },
+  "resource-id": "test:id/target",
+  "text": "Skills",
+  "scrollable": false
+} as unknown as Element;
+
+function makeScrollUntilVisible({
+  accessibilityDetector,
+  finder,
+  timer,
+  accessibilityService,
+  observeResults,
+  talkBackExecutor,
+  getDuration,
+  overlayDetector
+}: {
+  accessibilityDetector: FakeAccessibilityDetector;
+  finder: FakeElementFinder;
+  timer: FakeTimer;
+  accessibilityService: FakeScrollAccessibilityService;
+  observeResults: ObserveResult[];
+  talkBackExecutor: FakeTalkBackSwipeExecutor;
+  getDuration?: (options: SwipeOnResolvedOptions) => number;
+  overlayDetector?: FakeOverlayDetector;
+}): ScrollUntilVisible {
+  let callIdx = 0;
+
+  const fakeObserveScreen = {
+    execute: async () => observeResults[Math.min(callIdx, observeResults.length - 1)],
+    getMostRecentCachedObserveResult: async () =>
+      observeResults[Math.min(callIdx, observeResults.length - 1)]
+  };
+
+  const fakeGeometry = new FakeElementGeometry();
+
+  const fakeOverlayDetector = overlayDetector ?? new FakeOverlayDetector();
+
+  const observedInteraction = async (action: (obs: ObserveResult) => Promise<any>, _opts: any) => {
+    const obs = observeResults[Math.min(callIdx, observeResults.length - 1)];
+    const result = await action(obs);
+    callIdx++;
+    const nextObs = observeResults[Math.min(callIdx, observeResults.length - 1)];
+    return { ...result, observation: nextObs };
+  };
+
+  return new ScrollUntilVisible({
+    device: DEVICE,
+    finder: finder as any,
+    geometry: fakeGeometry,
+    observeScreen: fakeObserveScreen as any,
+    accessibilityService,
+    accessibilityDetector,
+    overlayDetector: fakeOverlayDetector,
+    talkBackExecutor,
+    timer,
+    getDuration: getDuration ?? (() => 300),
+    resolveBoomerangConfig: () => undefined,
+    buildPredictionArgs: () => ({}),
+    observedInteraction
+  });
+}
+
+const BASE_OPTIONS: SwipeOnResolvedOptions = {
+  direction: "up",
+  lookFor: { text: "Skills" }
+};
+
+describe("ScrollUntilVisible overshoot recovery", () => {
+  let detector: FakeAccessibilityDetector;
+  let finder: FakeElementFinder;
+  let timer: FakeTimer;
+  let accessibilityService: FakeScrollAccessibilityService;
+  let talkBackExecutor: FakeTalkBackSwipeExecutor;
+
+  beforeEach(() => {
+    detector = new FakeAccessibilityDetector();
+    detector.setTalkBackEnabled(false);
+    finder = new FakeElementFinder();
+    timer = new FakeTimer();
+    timer.enableAutoAdvance();
+    accessibilityService = new FakeScrollAccessibilityService();
+    talkBackExecutor = new FakeTalkBackSwipeExecutor();
+  });
+
+  test("element found in reverse after forward end-of-list", async () => {
+    finder.nextScrollableContainer = CONTAINER_ELEMENT;
+
+    // Forward phase: obs[1] same as obs[0] → 1 unchanged scroll → switch to reverseMode
+    // Reverse phase: obs[2] is different fingerprint → element found
+    let findCount = 0;
+    finder.findElementByText = (_h: any, _t: any) => {
+      findCount++;
+      // found on the 3rd call (initial check + 1 forward miss + found after reverse)
+      return findCount >= 3 ? TARGET_ELEMENT : null;
+    };
+
+    const sameObs = makeObserveResult(0);
+    const suv = makeScrollUntilVisible({
+      accessibilityDetector: detector,
+      finder,
+      timer,
+      accessibilityService,
+      // [0]=initial, [1]=same fingerprint (forward end), [2]=different (reverse finds element)
+      observeResults: [sameObs, sameObs, makeObserveResult(1)],
+      talkBackExecutor
+    });
+
+    const result = await suv.execute(BASE_OPTIONS);
+
+    expect(result.success).toBe(true);
+    expect(result.found).toBe(true);
+    expect(result.scrollIterations).toBeGreaterThan(0);
+  });
+
+  test("throws when both forward and reverse directions exhaust without finding element", async () => {
+    finder.nextScrollableContainer = CONTAINER_ELEMENT;
+    finder.nextElementByText = null; // never found
+
+    // All observations identical — both forward and reverse end-of-list trigger
+    const sameObs = makeObserveResult(99);
+    const suv = makeScrollUntilVisible({
+      accessibilityDetector: detector,
+      finder,
+      timer,
+      accessibilityService,
+      observeResults: [sameObs, sameObs, sameObs, sameObs, sameObs, sameObs, sameObs, sameObs],
+      talkBackExecutor
+    });
+
+    await expect(suv.execute(BASE_OPTIONS)).rejects.toThrow(
+      /Scroll reached end of container/
+    );
+  });
+
+  test("element found in forward direction without entering reverse mode", async () => {
+    finder.nextScrollableContainer = CONTAINER_ELEMENT;
+
+    let findCount = 0;
+    finder.findElementByText = (_h: any, _t: any) => {
+      findCount++;
+      // found after 2 forward scrolls (findCount=3: initial check + 2 post-swipe checks)
+      return findCount >= 3 ? TARGET_ELEMENT : null;
+    };
+
+    const suv = makeScrollUntilVisible({
+      accessibilityDetector: detector,
+      finder,
+      timer,
+      accessibilityService,
+      observeResults: [
+        makeObserveResult(0),
+        makeObserveResult(1),
+        makeObserveResult(2),
+        makeObserveResult(3)
+      ],
+      talkBackExecutor
+    });
+
+    const result = await suv.execute(BASE_OPTIONS);
+
+    expect(result.success).toBe(true);
+
+    // Verify that executeSwipeGesture was never called with the reversed direction ("down")
+    const allDirections = talkBackExecutor.getDirections();
+    expect(allDirections.every(d => d === "up")).toBe(true);
+  });
+
+  test("switches to opposite direction after forward end-of-list", async () => {
+    finder.nextScrollableContainer = CONTAINER_ELEMENT;
+
+    // Forward phase triggers end-of-list (1 same), then reverse finds element
+    let findCount = 0;
+    finder.findElementByText = (_h: any, _t: any) => {
+      findCount++;
+      return findCount >= 3 ? TARGET_ELEMENT : null;
+    };
+
+    const sameObs = makeObserveResult(0);
+    const suv = makeScrollUntilVisible({
+      accessibilityDetector: detector,
+      finder,
+      timer,
+      accessibilityService,
+      observeResults: [sameObs, sameObs, makeObserveResult(1)],
+      talkBackExecutor
+    });
+
+    await suv.execute(BASE_OPTIONS);
+
+    const allDirections = talkBackExecutor.getDirections();
+
+    // Forward swipes should be "up", reverse swipe should be "down"
+    expect(allDirections).toContain("up");
+    expect(allDirections).toContain("down");
+
+    // The last call should be the reversed direction
+    expect(allDirections[allDirections.length - 1]).toBe("down");
+  });
+
+  test("scroll idle detection: uses settled observation when swipe returns mid-scroll state", async () => {
+    // Scenario: observedInteraction returns a mid-scroll hierarchy (hierarchyId=1).
+    // Direct execute() calls for idle polling return a different obs (hierarchyId=2) first,
+    // then the same obs again (hierarchyId=2) → fingerprints match → settled.
+    // The element is only findable in the settled state (call 2+).
+    const obs0 = makeObserveResult(0); // initial
+    const obs1mid = makeObserveResult(1); // mid-scroll returned by observedInteraction
+    const obs2settled = makeObserveResult(2); // settled (idle poll 1 and 2 both return this)
+
+    let executeCallCount = 0;
+    const fakeObserveScreen = {
+      execute: async () => {
+        executeCallCount++;
+        if (executeCallCount === 1) {return obs0;} // initial observe
+        // Idle polls: first sees obs2settled (different from obs1mid → sleep),
+        // second also sees obs2settled (same → settled)
+        return obs2settled;
+      },
+      getMostRecentCachedObserveResult: async () => obs0,
+      appendRawViewHierarchy: async () => {}
+    };
+
+    const fakeGeometry = new FakeElementGeometry();
+    const fakeOverlayDetector = new FakeOverlayDetector();
+    const fakeDetector = new FakeAccessibilityDetector();
+    fakeDetector.setTalkBackEnabled(false);
+    const fakeFinder = new FakeElementFinder();
+    fakeFinder.nextScrollableContainer = CONTAINER_ELEMENT;
+    const fakeTimer = new FakeTimer();
+    fakeTimer.enableAutoAdvance();
+    const fakeTalkBack = new FakeTalkBackSwipeExecutor();
+    const fakeAccessibilityService = new FakeScrollAccessibilityService();
+
+    // Element not found initially; found after idle poll settles to obs2settled
+    let findCount = 0;
+    fakeFinder.findElementByText = (_h: any, _t: any) => {
+      findCount++;
+      return findCount >= 2 ? TARGET_ELEMENT : null;
+    };
+
+    // observedInteraction: always returns obs1mid as the post-swipe observation
+    const observedInteraction = async (action: (obs: ObserveResult) => Promise<any>, _opts: any) => {
+      const result = await action(obs0);
+      return { ...result, observation: obs1mid };
+    };
+
+    const suv = new ScrollUntilVisible({
+      device: DEVICE,
+      finder: fakeFinder as any,
+      geometry: fakeGeometry,
+      observeScreen: fakeObserveScreen as any,
+      accessibilityService: fakeAccessibilityService,
+      accessibilityDetector: fakeDetector,
+      overlayDetector: fakeOverlayDetector,
+      talkBackExecutor: fakeTalkBack,
+      timer: fakeTimer,
+      getDuration: () => 300,
+      resolveBoomerangConfig: () => undefined,
+      buildPredictionArgs: () => ({}),
+      observedInteraction
+    });
+
+    const result = await suv.execute(BASE_OPTIONS);
+
+    expect(result.success).toBe(true);
+    expect(result.found).toBe(true);
+    // Verify idle polls occurred: 1 initial + at least 2 idle polls
+    expect(executeCallCount).toBeGreaterThanOrEqual(3);
+  });
+
+  test("scroll idle detection: no extra sleep when observation already settled", async () => {
+    // When observedInteraction and the first idle poll return the same fingerprint,
+    // waitForScrollIdle returns immediately without sleeping.
+    finder.nextScrollableContainer = CONTAINER_ELEMENT;
+
+    let findCount = 0;
+    finder.findElementByText = (_h: any, _t: any) => {
+      findCount++;
+      return findCount >= 3 ? TARGET_ELEMENT : null;
+    };
+
+    const suv = makeScrollUntilVisible({
+      accessibilityDetector: detector,
+      finder,
+      timer,
+      accessibilityService,
+      // All distinct so fingerprints keep changing → scroll detected each iteration
+      observeResults: [
+        makeObserveResult(0),
+        makeObserveResult(1),
+        makeObserveResult(2),
+        makeObserveResult(3)
+      ],
+      talkBackExecutor
+    });
+
+    const result = await suv.execute(BASE_OPTIONS);
+
+    expect(result.success).toBe(true);
+    // In the existing helper, idle polls see the same obs as observedInteraction returned
+    // → settle immediately. Sleep calls should only come from other sources, not idle polling.
+    // Timer is in auto-advance mode so no pending sleeps remain.
+    expect(timer.getPendingSleepCount()).toBe(0);
+  });
+
+  test("reverse mode uses slow speed even when original options had fast speed", async () => {
+    finder.nextScrollableContainer = CONTAINER_ELEMENT;
+
+    // Forward phase triggers end-of-list (1 same), reverse finds element
+    let findCount = 0;
+    finder.findElementByText = (_h: any, _t: any) => {
+      findCount++;
+      return findCount >= 3 ? TARGET_ELEMENT : null;
+    };
+
+    const getDurationCalls: SwipeOnResolvedOptions[] = [];
+    const getDuration = (opts: SwipeOnResolvedOptions) => {
+      getDurationCalls.push({ ...opts });
+      return 300;
+    };
+
+    const sameObs = makeObserveResult(0);
+    const suv = makeScrollUntilVisible({
+      accessibilityDetector: detector,
+      finder,
+      timer,
+      accessibilityService,
+      observeResults: [sameObs, sameObs, makeObserveResult(1)],
+      talkBackExecutor,
+      getDuration
+    });
+
+    // Use fast speed to verify it gets overridden to slow in reverse mode
+    await suv.execute({ ...BASE_OPTIONS, speed: "fast" });
+
+    // The last getDuration call corresponds to the reverse swipe — must use "slow"
+    const lastCall = getDurationCalls[getDurationCalls.length - 1];
+    expect(lastCall.speed).toBe("slow");
+  });
+
+  test("uses safe swipe coordinates from overlay detector when overlay is present", async () => {
+    finder.nextScrollableContainer = CONTAINER_ELEMENT;
+
+    let findCount = 0;
+    finder.findElementByText = (_h: any, _t: any) => ++findCount >= 2 ? TARGET_ELEMENT : null;
+
+    const overlayDetector = new FakeOverlayDetector();
+    const candidate: OverlayCandidate = {
+      bounds: { left: 0, top: 0, right: 400, bottom: 200 },
+      overlapBounds: { left: 0, top: 0, right: 400, bottom: 200 },
+      coverage: 80000,
+      zOrder: { windowRank: 1, nodeOrder: 0 }
+    };
+    overlayDetector.candidates = [candidate];
+    overlayDetector.safeCoords = { startX: 50, startY: 600, endX: 50, endY: 300 };
+
+    const suv = makeScrollUntilVisible({
+      accessibilityDetector: detector,
+      finder,
+      timer,
+      accessibilityService,
+      observeResults: [makeObserveResult(0), makeObserveResult(1), makeObserveResult(2)],
+      talkBackExecutor,
+      overlayDetector
+    });
+
+    const result = await suv.execute(BASE_OPTIONS);
+
+    expect(result.success).toBe(true);
+    const firstSwipe = talkBackExecutor.getSwipeCalls()[0];
+    expect(firstSwipe.x1).toBe(50);
+  });
+
+  test("scroll proceeds past a failed swipe if observation is still returned", async () => {
+    finder.nextScrollableContainer = CONTAINER_ELEMENT;
+
+    let findCount = 0;
+    finder.findElementByText = (_h: any, _t: any) => ++findCount >= 3 ? TARGET_ELEMENT : null;
+
+    talkBackExecutor.setFailureResult({ success: false, error: "gesture rejected" });
+
+    const suv = makeScrollUntilVisible({
+      accessibilityDetector: detector,
+      finder,
+      timer,
+      accessibilityService,
+      observeResults: [makeObserveResult(0), makeObserveResult(1), makeObserveResult(2), makeObserveResult(3)],
+      talkBackExecutor
+    });
+
+    const result = await suv.execute(BASE_OPTIONS);
+
+    expect(result.success).toBe(true);
+    expect(talkBackExecutor.getCallCount()).toBeGreaterThanOrEqual(2);
+  });
+});

--- a/test/features/action/swipeon/ScrollUntilVisible.talkback.test.ts
+++ b/test/features/action/swipeon/ScrollUntilVisible.talkback.test.ts
@@ -1,8 +1,12 @@
-import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { beforeEach, describe, expect, test } from "bun:test";
 import { ScrollUntilVisible } from "../../../../src/features/action/swipeon/ScrollUntilVisible";
 import { FakeAccessibilityDetector } from "../../../fakes/FakeAccessibilityDetector";
 import { FakeElementFinder } from "../../../fakes/FakeElementFinder";
 import { FakeTimer } from "../../../fakes/FakeTimer";
+import { FakeTalkBackSwipeExecutor } from "../../../fakes/FakeTalkBackSwipeExecutor";
+import { FakeOverlayDetector } from "../../../fakes/FakeOverlayDetector";
+import { FakeScrollAccessibilityService } from "../../../fakes/FakeScrollAccessibilityService";
+import { FakeElementGeometry } from "../../../fakes/FakeElementGeometry";
 import type { BootedDevice, Element, ObserveResult } from "../../../../src/models";
 import type { SwipeOnResolvedOptions } from "../../../../src/features/action/swipeon/types";
 
@@ -47,9 +51,9 @@ function makeScrollUntilVisible({
   accessibilityDetector: FakeAccessibilityDetector;
   finder: FakeElementFinder;
   timer: FakeTimer;
-  accessibilityService: { requestAction: ReturnType<typeof mock> };
+  accessibilityService: FakeScrollAccessibilityService;
   observeResults: ObserveResult[];
-  talkBackExecutor: { executeSwipeGesture: ReturnType<typeof mock> };
+  talkBackExecutor: FakeTalkBackSwipeExecutor;
 }): ScrollUntilVisible {
   let callIdx = 0;
 
@@ -59,15 +63,9 @@ function makeScrollUntilVisible({
       observeResults[Math.min(callIdx, observeResults.length - 1)]
   };
 
-  const fakeGeometry = {
-    getSwipeWithinBounds: () => ({ startX: 200, startY: 700, endX: 200, endY: 200 }),
-    getSwipeDurationFromSpeed: () => 300
-  };
+  const fakeGeometry = new FakeElementGeometry();
 
-  const fakeOverlayDetector = {
-    collectOverlayCandidates: () => [],
-    computeSafeSwipeCoordinates: () => null
-  };
+  const fakeOverlayDetector = new FakeOverlayDetector();
 
   // Each observedInteraction call advances to the next observation
   const observedInteraction = async (action: (obs: ObserveResult) => Promise<any>, _opts: any) => {
@@ -81,12 +79,12 @@ function makeScrollUntilVisible({
   return new ScrollUntilVisible({
     device: DEVICE,
     finder: finder as any,
-    geometry: fakeGeometry as any,
+    geometry: fakeGeometry,
     observeScreen: fakeObserveScreen as any,
-    accessibilityService: accessibilityService as any,
+    accessibilityService,
     accessibilityDetector,
-    overlayDetector: fakeOverlayDetector as any,
-    talkBackExecutor: talkBackExecutor as any,
+    overlayDetector: fakeOverlayDetector,
+    talkBackExecutor,
     timer,
     getDuration: () => 300,
     resolveBoomerangConfig: () => undefined,
@@ -104,24 +102,16 @@ describe("ScrollUntilVisible TalkBack focus behavior", () => {
   let detector: FakeAccessibilityDetector;
   let finder: FakeElementFinder;
   let timer: FakeTimer;
-  let accessibilityService: { requestAction: ReturnType<typeof mock> };
-  let talkBackExecutor: { executeSwipeGesture: ReturnType<typeof mock> };
+  let accessibilityService: FakeScrollAccessibilityService;
+  let talkBackExecutor: FakeTalkBackSwipeExecutor;
 
   beforeEach(() => {
     detector = new FakeAccessibilityDetector();
     finder = new FakeElementFinder();
     timer = new FakeTimer();
     timer.enableAutoAdvance();
-    accessibilityService = {
-      requestAction: mock(async () => ({ success: true, action: "focus", totalTimeMs: 10 }))
-    };
-    talkBackExecutor = {
-      executeSwipeGesture: mock(async () => ({
-        success: true,
-        x1: 200, y1: 700, x2: 200, y2: 200,
-        duration: 300
-      }))
-    };
+    accessibilityService = new FakeScrollAccessibilityService();
+    talkBackExecutor = new FakeTalkBackSwipeExecutor();
   });
 
   describe("when TalkBack is disabled", () => {
@@ -146,7 +136,7 @@ describe("ScrollUntilVisible TalkBack focus behavior", () => {
 
       expect(result.success).toBe(true);
       expect(result.found).toBe(true);
-      expect(accessibilityService.requestAction).not.toHaveBeenCalled();
+      expect(accessibilityService.requestActionCalls).toHaveLength(0);
     });
 
     test("does not call requestAction(focus) when element found after scrolling", async () => {
@@ -169,7 +159,7 @@ describe("ScrollUntilVisible TalkBack focus behavior", () => {
       const result = await suv.execute({ ...BASE_OPTIONS, focusTarget: true });
 
       expect(result.success).toBe(true);
-      expect(accessibilityService.requestAction).not.toHaveBeenCalled();
+      expect(accessibilityService.requestActionCalls).toHaveLength(0);
     });
   });
 
@@ -195,7 +185,7 @@ describe("ScrollUntilVisible TalkBack focus behavior", () => {
 
       expect(result.success).toBe(true);
       expect(result.found).toBe(true);
-      expect(accessibilityService.requestAction).not.toHaveBeenCalled();
+      expect(accessibilityService.requestActionCalls).toHaveLength(0);
     });
 
     test("calls requestAction(focus, resourceId) when focusTarget:true and element already visible", async () => {
@@ -216,12 +206,11 @@ describe("ScrollUntilVisible TalkBack focus behavior", () => {
       expect(result.success).toBe(true);
       expect(result.found).toBe(true);
       expect(result.scrollIterations).toBe(0);
-      expect(accessibilityService.requestAction).toHaveBeenCalledWith(
-        "focus",
-        "test:id/target",
-        5000,
-        expect.anything()
-      );
+      expect(accessibilityService.requestActionCalls).toContainEqual({
+        action: "focus",
+        resourceId: "test:id/target",
+        timeoutMs: 5000
+      });
     });
 
     test("calls requestAction(focus) after scrolling finds element with focusTarget:true", async () => {
@@ -246,12 +235,11 @@ describe("ScrollUntilVisible TalkBack focus behavior", () => {
       expect(result.success).toBe(true);
       expect(result.found).toBe(true);
       expect(result.scrollIterations).toBeGreaterThan(0);
-      expect(accessibilityService.requestAction).toHaveBeenCalledWith(
-        "focus",
-        "test:id/target",
-        5000,
-        expect.anything()
-      );
+      expect(accessibilityService.requestActionCalls).toContainEqual({
+        action: "focus",
+        resourceId: "test:id/target",
+        timeoutMs: 5000
+      });
     });
 
     test("does not call requestAction(focus) after scrolling finds element without focusTarget", async () => {
@@ -274,7 +262,7 @@ describe("ScrollUntilVisible TalkBack focus behavior", () => {
       const result = await suv.execute(BASE_OPTIONS);
 
       expect(result.success).toBe(true);
-      expect(accessibilityService.requestAction).not.toHaveBeenCalled();
+      expect(accessibilityService.requestActionCalls).toHaveLength(0);
     });
 
     test("never calls requestAction(clear_focus) during scrolling", async () => {
@@ -301,7 +289,7 @@ describe("ScrollUntilVisible TalkBack focus behavior", () => {
 
       await suv.execute({ ...BASE_OPTIONS, focusTarget: true });
 
-      expect(accessibilityService.requestAction).not.toHaveBeenCalledWith("clear_focus", expect.anything());
+      expect(accessibilityService.requestActionCalls.some(c => c.action === "clear_focus")).toBe(false);
     });
 
     test("skips focus if found element has no resource-id", async () => {
@@ -327,13 +315,11 @@ describe("ScrollUntilVisible TalkBack focus behavior", () => {
       const result = await suv.execute({ ...BASE_OPTIONS, focusTarget: true });
 
       expect(result.success).toBe(true);
-      expect(accessibilityService.requestAction).not.toHaveBeenCalled();
+      expect(accessibilityService.requestActionCalls).toHaveLength(0);
     });
 
     test("succeeds even when requestAction(focus) throws", async () => {
-      accessibilityService.requestAction = mock(async () => {
-        throw new Error("focus action failed");
-      });
+      accessibilityService.setRequestActionThrows(new Error("focus action failed"));
 
       finder.nextScrollableContainer = CONTAINER_ELEMENT;
       finder.nextElementByText = TARGET_ELEMENT;
@@ -359,8 +345,8 @@ describe("ScrollUntilVisible end-of-list detection", () => {
   let detector: FakeAccessibilityDetector;
   let finder: FakeElementFinder;
   let timer: FakeTimer;
-  let accessibilityService: { requestAction: ReturnType<typeof mock> };
-  let talkBackExecutor: { executeSwipeGesture: ReturnType<typeof mock> };
+  let accessibilityService: FakeScrollAccessibilityService;
+  let talkBackExecutor: FakeTalkBackSwipeExecutor;
 
   beforeEach(() => {
     detector = new FakeAccessibilityDetector();
@@ -368,16 +354,8 @@ describe("ScrollUntilVisible end-of-list detection", () => {
     finder = new FakeElementFinder();
     timer = new FakeTimer();
     timer.enableAutoAdvance();
-    accessibilityService = {
-      requestAction: mock(async () => ({ success: true, action: "focus", totalTimeMs: 10 }))
-    };
-    talkBackExecutor = {
-      executeSwipeGesture: mock(async () => ({
-        success: true,
-        x1: 200, y1: 700, x2: 200, y2: 200,
-        duration: 300
-      }))
-    };
+    accessibilityService = new FakeScrollAccessibilityService();
+    talkBackExecutor = new FakeTalkBackSwipeExecutor();
   });
 
   test("throws when hierarchy unchanged for maxUnchangedScrolls iterations", async () => {
@@ -435,23 +413,23 @@ describe("ScrollUntilVisible end-of-list detection", () => {
     let findCount = 0;
     finder.findElementByText = (_h: any, _t: any) => {
       findCount++;
-      // Found after 4 scrolls
-      return findCount > 4 ? TARGET_ELEMENT : null;
+      // Found after 3 calls: initial check + 1 forward miss + 1 reverse miss + found on 4th
+      return findCount > 3 ? TARGET_ELEMENT : null;
     };
 
-    // Two same, one different, two same — the different one resets the unchanged counter
+    // One same triggers reverseMode; subsequent changes in reverse reset the counter,
+    // allowing continued scrolling until the element is found.
     const sameA = makeObserveResult(10);
-    const sameB = makeObserveResult(20);
     const suv = makeScrollUntilVisible({
       accessibilityDetector: detector,
       finder,
       timer,
       accessibilityService,
-      observeResults: [sameA, sameA, makeObserveResult(30), sameB, sameB, makeObserveResult(40)],
+      observeResults: [sameA, sameA, makeObserveResult(30), makeObserveResult(40)],
       talkBackExecutor
     });
 
-    // Should not throw despite two repeated observations in a row (count resets on change)
+    // Should not throw — hierarchy changes during reverse reset the unchanged counter
     const result = await suv.execute(BASE_OPTIONS);
     expect(result.success).toBe(true);
   });

--- a/test/features/action/swipeon/TalkBackSwipeExecutor.test.ts
+++ b/test/features/action/swipeon/TalkBackSwipeExecutor.test.ts
@@ -1,219 +1,235 @@
-import { beforeEach, describe, expect, test, spyOn } from "bun:test";
-import { SwipeOn } from "../../../../src/features/action/swipeon";
+import { beforeEach, describe, expect, test } from "bun:test";
+import { TalkBackSwipeExecutor } from "../../../../src/features/action/swipeon/TalkBackSwipeExecutor";
 import { FakeAccessibilityDetector } from "../../../fakes/FakeAccessibilityDetector";
+import { FakeGestureExecutor } from "../../../fakes/FakeGestureExecutor";
+import { FakeTimer } from "../../../fakes/FakeTimer";
+import { FakeCtrlProxy } from "../../../fakes/FakeCtrlProxy";
 import { SwipeDirection } from "../../../../src/models";
 import { NoOpPerformanceTracker } from "../../../../src/utils/PerformanceTracker";
+import type { BootedDevice } from "../../../../src/models";
 
-describe("SwipeOn TalkBack mode detection", () => {
+const ANDROID_DEVICE: BootedDevice = {
+  name: "test-device",
+  platform: "android",
+  deviceId: "emulator-5554",
+} as unknown as BootedDevice;
+
+const IOS_DEVICE: BootedDevice = {
+  name: "test-ios-device",
+  platform: "ios",
+  deviceId: "test-ios-device",
+} as unknown as BootedDevice;
+
+function makeExecutor(
+  device: BootedDevice,
+  fakeGesture: FakeGestureExecutor,
+  fakeProxy: FakeCtrlProxy,
+  fakeDetector: FakeAccessibilityDetector,
+  fakeTimer: FakeTimer
+): TalkBackSwipeExecutor {
+  return new TalkBackSwipeExecutor(
+    device,
+    fakeGesture,
+    fakeProxy as any,
+    fakeDetector,
+    fakeTimer
+  );
+}
+
+describe("TalkBackSwipeExecutor", () => {
   let fakeAccessibilityDetector: FakeAccessibilityDetector;
-  let swipeOn: SwipeOn;
-  let executeAndroidSwipeWithAccessibility: any;
-  let executeGestureSwipe: any;
+  let fakeGestureExecutor: FakeGestureExecutor;
+  let fakeTimer: FakeTimer;
+  let fakeCtrlProxy: FakeCtrlProxy;
+  let executor: TalkBackSwipeExecutor;
+  const perf = new NoOpPerformanceTracker();
 
   beforeEach(() => {
     fakeAccessibilityDetector = new FakeAccessibilityDetector();
-
-    // Create a minimal SwipeOn instance for testing
-    swipeOn = new SwipeOn(
-      {
-        name: "test-device",
-        platform: "android",
-        deviceId: "emulator-5554",
-      } as any,
-      {} as any,  // adb
-      {
-        accessibilityDetector: fakeAccessibilityDetector,
-        // Mock executeGesture to avoid actual swipe execution
-        executeGesture: {
-          swipe: async () => ({
-            success: true,
-            x1: 0,
-            y1: 0,
-            x2: 0,
-            y2: 0,
-            duration: 300
-          })
-        } as any
-      }
+    fakeGestureExecutor = new FakeGestureExecutor();
+    fakeTimer = new FakeTimer();
+    fakeTimer.enableAutoAdvance();
+    fakeCtrlProxy = new FakeCtrlProxy();
+    executor = makeExecutor(
+      ANDROID_DEVICE,
+      fakeGestureExecutor,
+      fakeCtrlProxy,
+      fakeAccessibilityDetector,
+      fakeTimer
     );
+  });
 
-    // Spy on the private methods to verify dispatch logic
-    executeAndroidSwipeWithAccessibility = spyOn(
-      (swipeOn as any).talkBackExecutor,
-      "executeAndroidSwipeWithAccessibility"
-    ).mockResolvedValue({
-      success: true,
-      x1: 100,
-      y1: 500,
-      x2: 100,
-      y2: 200,
-      duration: 300
-    });
+  describe("platform detection", () => {
+    test("uses standard swipe for iOS regardless of TalkBack state", async () => {
+      fakeAccessibilityDetector.setTalkBackEnabled(true);
 
-    executeGestureSwipe = spyOn(
-      (swipeOn as any).executeGesture,
-      "swipe"
-    ).mockResolvedValue({
-      success: true,
-      x1: 100,
-      y1: 500,
-      x2: 100,
-      y2: 200,
-      duration: 300
+      const iosExecutor = makeExecutor(
+        IOS_DEVICE,
+        fakeGestureExecutor,
+        fakeCtrlProxy,
+        fakeAccessibilityDetector,
+        fakeTimer
+      );
+
+      await iosExecutor.executeSwipeGesture(
+        100, 500, 100, 200,
+        "up" as SwipeDirection,
+        null,
+        { duration: 300 },
+        perf
+      );
+
+      expect(fakeGestureExecutor.getSwipeCalls()).toHaveLength(1);
+      expect(fakeCtrlProxy.getActionHistory()).toHaveLength(0);
+      expect(fakeCtrlProxy.getTwoFingerSwipeHistory()).toHaveLength(0);
     });
   });
 
-  describe("when TalkBack is disabled", () => {
+  describe("when TalkBack is disabled (android)", () => {
     beforeEach(() => {
       fakeAccessibilityDetector.setTalkBackEnabled(false);
     });
 
     test("dispatches to standard swipe method", async () => {
-      await (swipeOn as any).talkBackExecutor.executeSwipeGesture(
-        100,
-        500,
-        100,
-        200,
+      await executor.executeSwipeGesture(
+        100, 500, 100, 200,
         "up" as SwipeDirection,
         null,
         { duration: 300 },
-        new NoOpPerformanceTracker()
+        perf
       );
 
-      expect(executeGestureSwipe).toHaveBeenCalledTimes(1);
-      expect(executeAndroidSwipeWithAccessibility).not.toHaveBeenCalled();
+      expect(fakeGestureExecutor.getSwipeCalls()).toHaveLength(1);
+      expect(fakeCtrlProxy.getActionHistory()).toHaveLength(0);
+      expect(fakeCtrlProxy.getTwoFingerSwipeHistory()).toHaveLength(0);
     });
 
     test("uses standard swipe for all directions", async () => {
       const directions: SwipeDirection[] = ["up", "down", "left", "right"];
 
       for (const direction of directions) {
-        executeGestureSwipe.mockClear();
-        executeAndroidSwipeWithAccessibility.mockClear();
+        fakeGestureExecutor.getSwipeCalls().length = 0;
 
-        await (swipeOn as any).talkBackExecutor.executeSwipeGesture(
-          100,
-          500,
-          100,
-          200,
+        const fresh = makeExecutor(
+          ANDROID_DEVICE,
+          fakeGestureExecutor,
+          fakeCtrlProxy,
+          fakeAccessibilityDetector,
+          fakeTimer
+        );
+
+        await fresh.executeSwipeGesture(
+          100, 500, 100, 200,
           direction,
           null,
           { duration: 300 },
-          new NoOpPerformanceTracker()
+          perf
         );
 
-        expect(executeGestureSwipe).toHaveBeenCalledTimes(1);
-        expect(executeAndroidSwipeWithAccessibility).not.toHaveBeenCalled();
+        expect(fakeCtrlProxy.getActionHistory()).toHaveLength(0);
+        expect(fakeCtrlProxy.getTwoFingerSwipeHistory()).toHaveLength(0);
       }
     });
   });
 
-  describe("when TalkBack is enabled", () => {
+  describe("when TalkBack is enabled (android)", () => {
     beforeEach(() => {
       fakeAccessibilityDetector.setTalkBackEnabled(true);
     });
 
-    test("dispatches to accessibility-aware swipe method", async () => {
-      await (swipeOn as any).talkBackExecutor.executeSwipeGesture(
-        100,
-        500,
-        100,
-        200,
-        "up" as SwipeDirection,
-        null,
-        { duration: 300 },
-        new NoOpPerformanceTracker()
-      );
-
-      expect(executeAndroidSwipeWithAccessibility).toHaveBeenCalledTimes(1);
-      expect(executeGestureSwipe).not.toHaveBeenCalled();
-    });
-
-    test("passes container element to accessibility method", async () => {
+    test("dispatches to accessibility-aware swipe method when container has resource-id", async () => {
       const containerElement = {
         "bounds": { left: 0, top: 100, right: 400, bottom: 800 },
         "resource-id": "test:id/scrollView",
         "scrollable": true
       } as any;
 
-      await (swipeOn as any).talkBackExecutor.executeSwipeGesture(
-        100,
-        500,
-        100,
-        200,
+      await executor.executeSwipeGesture(
+        100, 500, 100, 200,
         "up" as SwipeDirection,
         containerElement,
         { duration: 300 },
-        new NoOpPerformanceTracker()
+        perf
       );
 
-      expect(executeAndroidSwipeWithAccessibility).toHaveBeenCalledWith(
-        100,
-        500,
-        100,
-        200,
-        "up",
-        containerElement,
+      // Should use accessibility action (not standard gesture swipe)
+      expect(fakeGestureExecutor.getSwipeCalls()).toHaveLength(0);
+      // Should have called requestAction for scroll
+      expect(fakeCtrlProxy.getActionHistory()).toHaveLength(1);
+    });
+
+    test("does not use standard gesture swipe when TalkBack is enabled", async () => {
+      await executor.executeSwipeGesture(
+        100, 500, 100, 200,
+        "up" as SwipeDirection,
+        null,
         { duration: 300 },
-        expect.any(NoOpPerformanceTracker)
+        perf
       );
+
+      expect(fakeGestureExecutor.getSwipeCalls()).toHaveLength(0);
+    });
+
+    test("uses two-finger swipe when no container provided", async () => {
+      await executor.executeSwipeGesture(
+        100, 500, 100, 200,
+        "up" as SwipeDirection,
+        null,
+        { duration: 300 },
+        perf
+      );
+
+      expect(fakeCtrlProxy.getActionHistory()).toHaveLength(0);
+      expect(fakeCtrlProxy.getTwoFingerSwipeHistory()).toHaveLength(1);
     });
 
     test("uses accessibility method for all swipe directions", async () => {
       const directions: SwipeDirection[] = ["up", "down", "left", "right"];
 
       for (const direction of directions) {
-        executeGestureSwipe.mockClear();
-        executeAndroidSwipeWithAccessibility.mockClear();
+        fakeCtrlProxy.clearHistory();
+        const fresh = makeExecutor(
+          ANDROID_DEVICE,
+          fakeGestureExecutor,
+          fakeCtrlProxy,
+          fakeAccessibilityDetector,
+          fakeTimer
+        );
 
-        await (swipeOn as any).talkBackExecutor.executeSwipeGesture(
-          100,
-          500,
-          100,
-          200,
+        await fresh.executeSwipeGesture(
+          100, 500, 100, 200,
           direction,
           null,
           { duration: 300 },
-          new NoOpPerformanceTracker()
+          perf
         );
 
-        expect(executeAndroidSwipeWithAccessibility).toHaveBeenCalledTimes(1);
-        expect(executeGestureSwipe).not.toHaveBeenCalled();
+        expect(fakeGestureExecutor.getSwipeCalls()).toHaveLength(0);
       }
     });
 
-    test("boomerang announces swipeable element instead of swiping", async () => {
-      const mockAccessibilityService = {
-        requestAction: async () => ({ success: true })
-      };
-      (swipeOn as any).talkBackExecutor.accessibilityService = mockAccessibilityService;
-      const requestActionSpy = spyOn(mockAccessibilityService, "requestAction")
-        .mockResolvedValue({ success: true });
-
+    test("boomerang mode announces swipeable element instead of swiping", async () => {
       const containerElement = {
         "resource-id": "test:id/scrollView"
       } as any;
 
-      await (swipeOn as any).talkBackExecutor.executeSwipeGesture(
-        100,
-        500,
-        100,
-        200,
+      await executor.executeSwipeGesture(
+        100, 500, 100, 200,
         "up" as SwipeDirection,
         containerElement,
         { duration: 300 },
-        new NoOpPerformanceTracker(),
+        perf,
         { apexPauseMs: 100, returnSpeed: 1 }
       );
 
-      expect(requestActionSpy).toHaveBeenCalledWith(
-        "focus",
-        "test:id/scrollView",
-        5000,
-        expect.any(NoOpPerformanceTracker)
-      );
-      expect(executeAndroidSwipeWithAccessibility).not.toHaveBeenCalled();
-      expect(executeGestureSwipe).not.toHaveBeenCalled();
+      expect(fakeCtrlProxy.getActionHistory()).toHaveLength(1);
+      expect(fakeCtrlProxy.getActionHistory()[0]).toMatchObject({
+        action: "focus",
+        resourceId: "test:id/scrollView",
+        timeoutMs: 5000
+      });
+      expect(fakeGestureExecutor.getSwipeCalls()).toHaveLength(0);
+      expect(fakeCtrlProxy.getTwoFingerSwipeHistory()).toHaveLength(0);
     });
   });
 
@@ -221,224 +237,270 @@ describe("SwipeOn TalkBack mode detection", () => {
     test("re-checks TalkBack state on subsequent swipes", async () => {
       // First swipe with TalkBack disabled
       fakeAccessibilityDetector.setTalkBackEnabled(false);
-      await (swipeOn as any).talkBackExecutor.executeSwipeGesture(
+      await executor.executeSwipeGesture(
         100, 500, 100, 200,
         "up" as SwipeDirection,
         null,
         { duration: 300 },
-        new NoOpPerformanceTracker()
+        perf
       );
-      expect(executeGestureSwipe).toHaveBeenCalledTimes(1);
+      expect(fakeGestureExecutor.getSwipeCalls()).toHaveLength(1);
 
-      executeGestureSwipe.mockClear();
-      executeAndroidSwipeWithAccessibility.mockClear();
+      fakeCtrlProxy.clearHistory();
 
       // Enable TalkBack and invalidate cache
       fakeAccessibilityDetector.setTalkBackEnabled(true);
       fakeAccessibilityDetector.invalidateCache("emulator-5554");
 
-      // Second swipe should use accessibility method
-      await (swipeOn as any).talkBackExecutor.executeSwipeGesture(
+      // Second swipe should use accessibility method (two-finger swipe since no container)
+      await executor.executeSwipeGesture(
         100, 500, 100, 200,
         "up" as SwipeDirection,
         null,
         { duration: 300 },
-        new NoOpPerformanceTracker()
+        perf
       );
 
-      expect(executeAndroidSwipeWithAccessibility).toHaveBeenCalledTimes(1);
-      expect(executeGestureSwipe).not.toHaveBeenCalled();
+      expect(fakeCtrlProxy.getTwoFingerSwipeHistory()).toHaveLength(1);
+      // Standard gesture swipe still only called once (from the first swipe above)
+      expect(fakeGestureExecutor.getSwipeCalls()).toHaveLength(1);
     });
   });
 
-  describe("platform detection", () => {
-    test("uses standard swipe for iOS regardless of TalkBack state", async () => {
-      const iosSwipeOn = new SwipeOn(
-        {
-          name: "test-device",
-          platform: "ios",
-          deviceId: "test-ios-device",
-        } as any,
-        null,
-        {
-          accessibilityDetector: fakeAccessibilityDetector,
-          executeGesture: {
-            swipe: async () => ({
-              success: true,
-              x1: 0,
-              y1: 0,
-              x2: 0,
-              y2: 0,
-              duration: 300
-            })
-          } as any
-        }
-      );
-
-      const iosExecuteGestureSwipe = spyOn(
-        (iosSwipeOn as any).executeGesture,
-        "swipe"
-      ).mockResolvedValue({
-        success: true,
-        x1: 100,
-        y1: 500,
-        x2: 100,
-        y2: 200,
-        duration: 300
-      });
-
-      // Even with TalkBack "enabled", iOS should use standard swipe
-      fakeAccessibilityDetector.setTalkBackEnabled(true);
-
-      await (iosSwipeOn as any).talkBackExecutor.executeSwipeGesture(
-        100, 500, 100, 200,
-        "up" as SwipeDirection,
-        null,
-        { duration: 300 },
-        new NoOpPerformanceTracker()
-      );
-
-      expect(iosExecuteGestureSwipe).toHaveBeenCalledTimes(1);
-    });
-  });
-
-  describe("executeAndroidSwipeWithAccessibility method", () => {
-    let mockAccessibilityService: any;
-
+  describe("executeAndroidSwipeWithAccessibility", () => {
     beforeEach(() => {
-      // Reset mocks
-      executeAndroidSwipeWithAccessibility.mockRestore();
-
-      // Mock accessibilityService
-      mockAccessibilityService = {
-        requestAction: async () => ({ success: true }),
-        requestTwoFingerSwipe: async () => ({
-          success: true,
-          totalTimeMs: 100,
-          gestureTimeMs: 50
-        })
-      };
-
-      (swipeOn as any).talkBackExecutor.accessibilityService = mockAccessibilityService;
+      fakeAccessibilityDetector.setTalkBackEnabled(true);
     });
 
-    test("tries ACTION_SCROLL when container has resource-id", async () => {
-      const requestActionSpy = spyOn(mockAccessibilityService, "requestAction")
-        .mockResolvedValue({ success: true });
-
+    test("tries ACTION_SCROLL (scroll_forward) when container has resource-id and direction is down", async () => {
       const containerElement = {
         "bounds": { left: 0, top: 100, right: 400, bottom: 800 },
         "resource-id": "test:id/scrollView",
         "scrollable": true
       } as any;
 
-      await (swipeOn as any).talkBackExecutor.executeAndroidSwipeWithAccessibility(
+      await executor.executeAndroidSwipeWithAccessibility(
         100, 500, 100, 200,
         "down" as SwipeDirection,
         containerElement,
-        { duration: 300 }
+        { duration: 300 },
+        perf
       );
 
-      // Should call scroll_forward (no clear_focus before scroll)
-      expect(requestActionSpy).toHaveBeenCalledWith("scroll_forward", "test:id/scrollView", 5000, expect.any(NoOpPerformanceTracker));
-      expect(requestActionSpy).not.toHaveBeenCalledWith("clear_focus", expect.anything());
+      expect(fakeCtrlProxy.getActionHistory()).toHaveLength(1);
+      expect(fakeCtrlProxy.getActionHistory()[0]).toMatchObject({
+        action: "scroll_forward",
+        resourceId: "test:id/scrollView",
+        timeoutMs: 5000
+      });
+      expect(fakeCtrlProxy.getTwoFingerSwipeHistory()).toHaveLength(0);
     });
 
     test("maps up direction to scroll_backward", async () => {
-      const requestActionSpy = spyOn(mockAccessibilityService, "requestAction")
-        .mockResolvedValue({ success: true });
-
       const containerElement = {
         "resource-id": "test:id/scrollView"
       } as any;
 
-      await (swipeOn as any).talkBackExecutor.executeAndroidSwipeWithAccessibility(
+      await executor.executeAndroidSwipeWithAccessibility(
         100, 500, 100, 700,
         "up" as SwipeDirection,
         containerElement,
-        { duration: 300 }
+        { duration: 300 },
+        perf
       );
 
-      expect(requestActionSpy).toHaveBeenCalledWith("scroll_backward", "test:id/scrollView", 5000, expect.any(NoOpPerformanceTracker));
+      expect(fakeCtrlProxy.getActionHistory()).toHaveLength(1);
+      expect(fakeCtrlProxy.getActionHistory()[0]).toMatchObject({
+        action: "scroll_backward",
+        resourceId: "test:id/scrollView"
+      });
+    });
+
+    test("maps right direction to scroll_forward", async () => {
+      const containerElement = {
+        "resource-id": "test:id/scrollView"
+      } as any;
+
+      await executor.executeAndroidSwipeWithAccessibility(
+        100, 200, 300, 200,
+        "right" as SwipeDirection,
+        containerElement,
+        { duration: 300 },
+        perf
+      );
+
+      expect(fakeCtrlProxy.getActionHistory()[0]).toMatchObject({
+        action: "scroll_forward"
+      });
+    });
+
+    test("maps left direction to scroll_backward", async () => {
+      const containerElement = {
+        "resource-id": "test:id/scrollView"
+      } as any;
+
+      await executor.executeAndroidSwipeWithAccessibility(
+        300, 200, 100, 200,
+        "left" as SwipeDirection,
+        containerElement,
+        { duration: 300 },
+        perf
+      );
+
+      expect(fakeCtrlProxy.getActionHistory()[0]).toMatchObject({
+        action: "scroll_backward"
+      });
     });
 
     test("falls back to two-finger swipe when ACTION_SCROLL fails", async () => {
-      spyOn(mockAccessibilityService, "requestAction")
-        .mockResolvedValue({ success: false, error: "Scroll not supported" });
-
-      const twoFingerSwipeSpy = spyOn(mockAccessibilityService, "requestTwoFingerSwipe")
-        .mockResolvedValue({
-          success: true,
-          totalTimeMs: 100,
-          gestureTimeMs: 50
-        });
+      fakeCtrlProxy.setActionResult({
+        success: false,
+        action: "scroll_backward",
+        totalTimeMs: 100,
+        error: "Scroll not supported"
+      });
 
       const containerElement = {
         "resource-id": "test:id/scrollView"
       } as any;
 
-      await (swipeOn as any).talkBackExecutor.executeAndroidSwipeWithAccessibility(
+      await executor.executeAndroidSwipeWithAccessibility(
         100, 500, 100, 200,
         "up" as SwipeDirection,
         containerElement,
-        { duration: 300 }
+        { duration: 300 },
+        perf
       );
 
-      expect(twoFingerSwipeSpy).toHaveBeenCalledWith(
-        100, 500, 100, 200,
-        300,
-        100, // Fixed offset
-        5000,
-        expect.any(NoOpPerformanceTracker)
-      );
+      expect(fakeCtrlProxy.getTwoFingerSwipeHistory()).toHaveLength(1);
+      expect(fakeCtrlProxy.getTwoFingerSwipeHistory()[0]).toMatchObject({
+        x1: 100,
+        y1: 500,
+        x2: 100,
+        y2: 200,
+        duration: 300,
+        offset: 100,
+        timeoutMs: 5000
+      });
     });
 
     test("uses two-finger swipe when container has no resource-id", async () => {
-      const requestActionSpy = spyOn(mockAccessibilityService, "requestAction");
-      const twoFingerSwipeSpy = spyOn(mockAccessibilityService, "requestTwoFingerSwipe")
-        .mockResolvedValue({
-          success: true,
-          totalTimeMs: 100,
-          gestureTimeMs: 50
-        });
-
       const containerElement = {
         "bounds": { left: 0, top: 100, right: 400, bottom: 800 },
         "scrollable": true
         // No resource-id
       } as any;
 
-      await (swipeOn as any).talkBackExecutor.executeAndroidSwipeWithAccessibility(
+      await executor.executeAndroidSwipeWithAccessibility(
         100, 500, 100, 200,
         "up" as SwipeDirection,
         containerElement,
-        { duration: 300 }
+        { duration: 300 },
+        perf
       );
 
       // Should not try ACTION_SCROLL
-      expect(requestActionSpy).not.toHaveBeenCalled();
+      expect(fakeCtrlProxy.getActionHistory()).toHaveLength(0);
       // Should use two-finger swipe
-      expect(twoFingerSwipeSpy).toHaveBeenCalled();
+      expect(fakeCtrlProxy.getTwoFingerSwipeHistory()).toHaveLength(1);
     });
 
     test("uses two-finger swipe when no container provided", async () => {
-      const requestActionSpy = spyOn(mockAccessibilityService, "requestAction");
-      const twoFingerSwipeSpy = spyOn(mockAccessibilityService, "requestTwoFingerSwipe")
-        .mockResolvedValue({
-          success: true,
-          totalTimeMs: 100,
-          gestureTimeMs: 50
-        });
-
-      await (swipeOn as any).talkBackExecutor.executeAndroidSwipeWithAccessibility(
+      await executor.executeAndroidSwipeWithAccessibility(
         100, 500, 100, 200,
         "up" as SwipeDirection,
-        null, // No container
-        { duration: 300 }
+        null,
+        { duration: 300 },
+        perf
       );
 
-      expect(requestActionSpy).not.toHaveBeenCalled();
-      expect(twoFingerSwipeSpy).toHaveBeenCalled();
+      expect(fakeCtrlProxy.getActionHistory()).toHaveLength(0);
+      expect(fakeCtrlProxy.getTwoFingerSwipeHistory()).toHaveLength(1);
+    });
+  });
+
+  describe("executeBoomerangGesture", () => {
+    test("calls swipe twice: forward then return", async () => {
+      await executor.executeBoomerangGesture(
+        100, 500, 100, 200,
+        { duration: 300 },
+        { apexPauseMs: 50, returnSpeed: 1 },
+        perf
+      );
+
+      const calls = fakeGestureExecutor.getSwipeCalls();
+      expect(calls).toHaveLength(2);
+      // Forward swipe
+      expect(calls[0]).toMatchObject({ x1: 100, y1: 500, x2: 100, y2: 200 });
+      // Return swipe (reversed coordinates)
+      expect(calls[1]).toMatchObject({ x1: 100, y1: 200, x2: 100, y2: 500 });
+    });
+
+    test("sleeps for apexPauseMs between forward and return swipe", async () => {
+      await executor.executeBoomerangGesture(
+        100, 500, 100, 200,
+        { duration: 300 },
+        { apexPauseMs: 150, returnSpeed: 1 },
+        perf
+      );
+
+      expect(fakeTimer.wasSleepCalled(150)).toBe(true);
+    });
+
+    test("does not sleep when apexPauseMs is 0", async () => {
+      await executor.executeBoomerangGesture(
+        100, 500, 100, 200,
+        { duration: 300 },
+        { apexPauseMs: 0, returnSpeed: 1 },
+        perf
+      );
+
+      expect(fakeTimer.getSleepCallCount()).toBe(0);
+    });
+
+    test("adjusts return duration based on returnSpeed", async () => {
+      await executor.executeBoomerangGesture(
+        100, 500, 100, 200,
+        { duration: 300 },
+        { apexPauseMs: 0, returnSpeed: 2 },
+        perf
+      );
+
+      const calls = fakeGestureExecutor.getSwipeCalls();
+      expect(calls).toHaveLength(2);
+      // Return swipe duration = 300 / 2 = 150
+      expect(calls[1].options?.duration).toBe(150);
+    });
+  });
+
+  describe("resolveBoomerangConfig", () => {
+    test("returns undefined when boomerang is false", () => {
+      const result = executor.resolveBoomerangConfig({ boomerang: false });
+      expect(result).toBeUndefined();
+    });
+
+    test("returns undefined when boomerang is not set", () => {
+      const result = executor.resolveBoomerangConfig({});
+      expect(result).toBeUndefined();
+    });
+
+    test("returns config with default apexPauseMs and returnSpeed when boomerang is true", () => {
+      const result = executor.resolveBoomerangConfig({ boomerang: true });
+      expect(result).toBeDefined();
+      expect(result!.apexPauseMs).toBe(100);
+      expect(result!.returnSpeed).toBe(1);
+    });
+
+    test("returns config with custom apexPause when provided", () => {
+      const result = executor.resolveBoomerangConfig({ boomerang: true, apexPause: 250 });
+      expect(result).toBeDefined();
+      expect(result!.apexPauseMs).toBe(250);
+    });
+
+    test("returns config with custom returnSpeed when provided", () => {
+      const result = executor.resolveBoomerangConfig({ boomerang: true, returnSpeed: 3 });
+      expect(result).toBeDefined();
+      expect(result!.returnSpeed).toBe(3);
     });
   });
 });


### PR DESCRIPTION
## Summary

- **Overshoot recovery**: after hitting end-of-list in the forward scroll direction, `ScrollUntilVisible` now switches to reverse half-screen slow swipes instead of immediately throwing — fixes cases where fast forward swipes overshoot the target element
- **Scroll idle detection**: `waitForScrollIdle` polls consecutive observations until fingerprints stabilise, preventing lookFor evaluation against mid-fling hierarchy snapshots
- **Interface extraction**: `TalkBackSwipeRunner`, `OverlayAnalyzer`, `VoiceOverSwipeRunner`, `AutoTargetSelectorService`, `ScrollAccessibilityService` — all `ScrollUntilVisibleDependencies` and `SwipeOnDependencies` fields now typed as interfaces rather than concrete classes
- **Dependency injection**: `VoiceOverSwipeExecutor` and `AutoTargetSelector` are now injectable via `SwipeOnDependencies` (with `??` fallback to existing construction for backward compatibility)
- **New fakes**: `FakeTalkBackSwipeExecutor`, `FakeOverlayDetector`, `FakeVoiceOverSwipeExecutor`, `FakeAutoTargetSelector`, `FakeScrollAccessibilityService`, `FakeElementGeometry` — removes all `as any` casts from `ScrollUntilVisible` test helpers
- **Standalone unit tests**: `TalkBackSwipeExecutor.test.ts` rewritten to construct the class directly (no `SwipeOn`, no `(swipeOn as any)` spying); `FakeCtrlProxy` extended with `requestAction` / `requestTwoFingerSwipe` tracking
- **New test coverage**: overshoot recovery, reverse-mode direction flip, scroll idle detection, overlay-safe swipe coordinates, failure absorption

## Test Plan
- [x] `bun run lint && bun run build` — clean
- [x] `bun test` — 2962 pass, 0 fail (up from 2948)

🤖 Generated with [Claude Code](https://claude.com/claude-code)