### PR TITLE
feat: add iOS accessibility scroll action for VoiceOver

### DIFF
--- a/ios/control-proxy/Sources/CtrlProxy/CommandHandler.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/CommandHandler.swift
@@ -324,7 +324,7 @@ public class CommandHandler: CommandHandling {
             throw CommandError.missingParameter("action")
         }
 
-        try gesturePerformer.performAction(action, resourceId: request.resourceId)
+        try gesturePerformer.performAction(action, resourceId: request.resourceId, label: request.label)
 
         return WebSocketResponse.success(
             type: ResponseType.actionResult.rawValue,

--- a/ios/control-proxy/Sources/CtrlProxy/Fakes.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/Fakes.swift
@@ -155,7 +155,7 @@ public class FakeGesturePerformer: GesturePerforming {
     private var setTextHistory: [TextCall] = []
     private var clearTextHistory: [String?] = []
     private var imeActionHistory: [String] = []
-    private var actionHistory: [(action: String, resourceId: String?)] = []
+    private var actionHistory: [(action: String, resourceId: String?, label: String?)] = []
     private var screenshotCallCount = 0
     private var pressHomeCallCount = 0
     private var appLaunchHistory: [String] = []
@@ -207,7 +207,7 @@ public class FakeGesturePerformer: GesturePerforming {
         imeActionHistory
     }
 
-    public func getActionHistory() -> [(action: String, resourceId: String?)] {
+    public func getActionHistory() -> [(action: String, resourceId: String?, label: String?)] {
         actionHistory
     }
 
@@ -327,9 +327,9 @@ public class FakeGesturePerformer: GesturePerforming {
         imeActionHistory.append(action)
     }
 
-    public func performAction(_ action: String, resourceId: String?) throws {
+    public func performAction(_ action: String, resourceId: String?, label: String?) throws {
         try checkFailure("action")
-        actionHistory.append((action: action, resourceId: resourceId))
+        actionHistory.append((action: action, resourceId: resourceId, label: label))
     }
 
     public func getScreenshot() throws -> Data {

--- a/ios/control-proxy/Sources/CtrlProxy/GesturePerformer.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/GesturePerformer.swift
@@ -259,32 +259,35 @@ public class GesturePerformer: GesturePerforming {
 
         // MARK: - Actions
 
-        public func performAction(_ action: String, resourceId: String? = nil) throws {
+        public func performAction(_ action: String, resourceId: String? = nil, label: String? = nil) throws {
+            var element: XCUIElement? = nil
             if let resourceId = resourceId {
-                guard let element = elementLocator.findElement(byResourceId: resourceId) as? XCUIElement else {
-                    throw GestureError.elementNotFound(resourceId)
-                }
+                element = elementLocator.findElement(byResourceId: resourceId) as? XCUIElement
+            }
+            if element == nil, let label = label {
+                element = elementLocator.findElement(byText: label) as? XCUIElement
+            }
+            guard let found = element else {
+                throw GestureError.elementNotFound(resourceId ?? label ?? "unknown")
+            }
 
-                try runOnMainThread {
-                    switch action.lowercased() {
-                    case "click", "tap":
-                        element.tap()
-                    case "long_click", "long_press":
-                        element.press(forDuration: 1.0)
-                    case "double_tap", "double_click":
-                        element.doubleTap()
-                    case "scroll_forward":
-                        element.swipeUp()
-                    case "scroll_backward":
-                        element.swipeDown()
-                    case "focus":
-                        element.tap()
-                    default:
-                        throw GestureError.notSupported("Action: \(action)")
-                    }
+            try runOnMainThread {
+                switch action.lowercased() {
+                case "click", "tap":
+                    found.tap()
+                case "long_click", "long_press":
+                    found.press(forDuration: 1.0)
+                case "double_tap", "double_click":
+                    found.doubleTap()
+                case "scroll_forward":
+                    found.swipeUp()
+                case "scroll_backward":
+                    found.swipeDown()
+                case "focus":
+                    found.tap()
+                default:
+                    throw GestureError.notSupported("Action: \(action)")
                 }
-            } else {
-                throw GestureError.elementNotFound("resourceId required for action")
             }
         }
 
@@ -435,7 +438,7 @@ public class GesturePerformer: GesturePerforming {
             throw GestureError.notSupported("XCUITest only available on iOS")
         }
 
-        public func performAction(_: String, resourceId _: String?) throws {
+        public func performAction(_: String, resourceId _: String?, label _: String?) throws {
             throw GestureError.notSupported("XCUITest only available on iOS")
         }
 

--- a/ios/control-proxy/Sources/CtrlProxy/Models.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/Models.swift
@@ -36,6 +36,7 @@ public struct WebSocketRequest: Codable {
     // Text input parameters
     public let text: String?
     public let resourceId: String?
+    public let label: String?
 
     // Action parameters
     public let action: String?
@@ -76,6 +77,7 @@ public struct WebSocketRequest: Codable {
         rotationDegrees: Float? = nil,
         text: String? = nil,
         resourceId: String? = nil,
+        label: String? = nil,
         action: String? = nil,
         bundleId: String? = nil,
         sinceTimestamp: Int64? = nil,
@@ -107,6 +109,7 @@ public struct WebSocketRequest: Codable {
         self.rotationDegrees = rotationDegrees
         self.text = text
         self.resourceId = resourceId
+        self.label = label
         self.action = action
         self.bundleId = bundleId
         self.sinceTimestamp = sinceTimestamp

--- a/ios/control-proxy/Sources/CtrlProxy/Protocols.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/Protocols.swift
@@ -74,8 +74,8 @@ public protocol GesturePerforming {
 
     // MARK: - Actions
 
-    /// Perform action on element
-    func performAction(_ action: String, resourceId: String?) throws
+    /// Perform action on element by resourceId or label (content-desc)
+    func performAction(_ action: String, resourceId: String?, label: String?) throws
 
     // MARK: - Screenshots
 

--- a/src/features/action/swipeon/SwipeOn.ts
+++ b/src/features/action/swipeon/SwipeOn.ts
@@ -429,6 +429,8 @@ export class SwipeOn extends BaseVisualChange {
               Math.floor(startY),
               Math.floor(endX),
               Math.floor(endY),
+              options.direction,
+              null, // No container for screen swipe
               gestureOptions,
               perf,
               boomerang
@@ -505,6 +507,8 @@ export class SwipeOn extends BaseVisualChange {
               Math.floor(startY),
               Math.floor(endX),
               Math.floor(endY),
+              options.direction,
+              element ?? null, // Use the container element
               gestureOptions,
               perf,
               boomerang

--- a/src/features/action/swipeon/VoiceOverSwipeExecutor.ts
+++ b/src/features/action/swipeon/VoiceOverSwipeExecutor.ts
@@ -1,4 +1,4 @@
-import { BootedDevice, GestureOptions } from "../../../models";
+import { BootedDevice, Element, GestureOptions, SwipeDirection } from "../../../models";
 import { logger } from "../../../utils/logger";
 import { PerformanceTracker, NoOpPerformanceTracker } from "../../../utils/PerformanceTracker";
 import { SwipeResult } from "../../../models/SwipeResult";
@@ -11,8 +11,12 @@ import { Timer } from "../../../utils/interfaces/Timer";
  * VoiceOverSwipeExecutor handles iOS VoiceOver-compatible swipe gestures.
  *
  * When VoiceOver is active on iOS, single-finger swipes navigate accessibility
- * focus rather than scrolling content. This executor uses 3-finger swipes
- * (multi-finger gestures) to scroll content while VoiceOver is running.
+ * focus rather than scrolling content. This executor uses the following fallback chain:
+ *
+ * 1. If a container element with resource-id is provided → accessibility scroll action
+ * 2. If a container element with content-desc is provided → accessibility scroll action (label)
+ * 3. If accessibility action fails or no container → 3-finger coordinate swipe
+ * 4. If 3-finger swipe fails → standard single-finger swipe
  *
  * Parallel to TalkBackSwipeExecutor for Android TalkBack.
  */
@@ -28,9 +32,10 @@ export class VoiceOverSwipeExecutor implements VoiceOverSwipeRunner {
   /**
    * Execute a swipe gesture with VoiceOver awareness.
    *
-   * If VoiceOver is enabled and the platform is iOS, performs a 3-finger swipe
-   * to scroll content. Falls back to standard single-finger swipe on failure
-   * or when VoiceOver is disabled.
+   * If VoiceOver is enabled and the platform is iOS:
+   *   - Tries accessibility scroll action via resource-id or content-desc
+   *   - Falls back to 3-finger swipe on failure
+   *   - Falls back to standard single-finger swipe if 3-finger also fails
    *
    * When boomerang is provided, performs a forward swipe, optional apex pause,
    * then a return swipe — using 3-finger swipes when VoiceOver is active.
@@ -39,6 +44,8 @@ export class VoiceOverSwipeExecutor implements VoiceOverSwipeRunner {
    * @param y1 - Start Y coordinate
    * @param x2 - End X coordinate
    * @param y2 - End Y coordinate
+   * @param direction - Swipe direction for mapping to scroll action
+   * @param containerElement - The scrollable container element, or null for screen swipe
    * @param gestureOptions - Optional gesture options (duration, scrollMode)
    * @param perf - Optional performance tracker
    * @param boomerang - Optional boomerang configuration
@@ -48,6 +55,8 @@ export class VoiceOverSwipeExecutor implements VoiceOverSwipeRunner {
     y1: number,
     x2: number,
     y2: number,
+    direction: SwipeDirection,
+    containerElement: Element | null,
     gestureOptions?: GestureOptions,
     perf: PerformanceTracker = new NoOpPerformanceTracker(),
     boomerang?: BoomerangConfig
@@ -76,7 +85,51 @@ export class VoiceOverSwipeExecutor implements VoiceOverSwipeRunner {
       return this.executeVoiceOverBoomerangGesture(x1, y1, x2, y2, gestureOptions, boomerang, perf);
     }
 
-    // VoiceOver is enabled: use 3-finger swipe to scroll content
+    // VoiceOver is enabled: try accessibility scroll action first
+    const scrollAction = (direction === "down" || direction === "right")
+      ? "scroll_forward"
+      : "scroll_backward";
+
+    if (containerElement) {
+      const resourceId = containerElement["resource-id"];
+      const contentDesc = containerElement["content-desc"];
+
+      if (resourceId || contentDesc) {
+        const identifier = resourceId ?? contentDesc;
+        logger.info(`[VoiceOverSwipeExecutor] VoiceOver enabled, attempting accessibility scroll (${scrollAction}) on: ${identifier}`);
+
+        try {
+          const result = await this.iosClient.requestAction(
+            scrollAction,
+            resourceId || undefined,
+            !resourceId && contentDesc ? contentDesc : undefined
+          );
+
+          if (result.success) {
+            return {
+              success: true,
+              x1,
+              y1,
+              x2,
+              y2,
+              duration: gestureOptions?.duration ?? 300,
+            };
+          }
+
+          logger.warn(
+            `[VoiceOverSwipeExecutor] Accessibility scroll failed: ${result.error ?? "unknown error"}, ` +
+            `falling back to 3-finger swipe`
+          );
+        } catch (error) {
+          logger.warn(
+            `[VoiceOverSwipeExecutor] Accessibility scroll error: ${error}, ` +
+            `falling back to 3-finger swipe`
+          );
+        }
+      }
+    }
+
+    // Fall back to 3-finger swipe to scroll content
     const duration = gestureOptions?.duration ?? 300;
     logger.info("[VoiceOverSwipeExecutor] VoiceOver enabled, using 3-finger swipe");
 

--- a/src/features/action/swipeon/types.ts
+++ b/src/features/action/swipeon/types.ts
@@ -32,6 +32,8 @@ export interface VoiceOverSwipeRunner {
     y1: number,
     x2: number,
     y2: number,
+    direction: SwipeDirection,
+    containerElement: Element | null,
     gestureOptions?: GestureOptions,
     perf?: PerformanceTracker,
     boomerang?: BoomerangConfig

--- a/src/features/observe/ios/CtrlProxyClient.ts
+++ b/src/features/observe/ios/CtrlProxyClient.ts
@@ -102,6 +102,7 @@ import type {
   CtrlProxyCachedHierarchy,
   CtrlProxyVoiceOverResult,
   CtrlProxyVoiceOverActionResult,
+  CtrlProxyActionResult,
   WebSocketMessage,
 } from "./types";
 
@@ -192,6 +193,14 @@ export interface CtrlProxyService {
   requestVoiceOverActivate(
     label: string, action: "activate" | "long_press", timeoutMs?: number, perf?: PerformanceTracker
   ): Promise<CtrlProxyVoiceOverActionResult>;
+
+  requestAction(
+    action: string,
+    resourceId?: string,
+    label?: string,
+    timeoutMs?: number,
+    perf?: PerformanceTracker
+  ): Promise<CtrlProxyActionResult>;
 
   requestMultiFingerSwipe(
     x1: number, y1: number, x2: number, y2: number,
@@ -854,6 +863,16 @@ export class CtrlProxyClient extends DeviceServiceClient implements CtrlProxySer
     perf?: PerformanceTracker
   ): Promise<CtrlProxyVoiceOverActionResult> {
     return this.voiceOver.requestVoiceOverActivate(label, action, timeoutMs, perf);
+  }
+
+  async requestAction(
+    action: string,
+    resourceId?: string,
+    label?: string,
+    timeoutMs: number = 5000,
+    perf?: PerformanceTracker
+  ): Promise<CtrlProxyActionResult> {
+    return this.voiceOver.requestAction(action, resourceId, label, timeoutMs, perf);
   }
 
   async requestMultiFingerSwipe(

--- a/src/features/observe/ios/CtrlProxyVoiceOver.ts
+++ b/src/features/observe/ios/CtrlProxyVoiceOver.ts
@@ -7,7 +7,7 @@
  */
 
 import type { PerformanceTracker } from "../../../utils/PerformanceTracker";
-import type { DelegateContext, CtrlProxyVoiceOverResult, CtrlProxyVoiceOverActionResult } from "./types";
+import type { DelegateContext, CtrlProxyVoiceOverResult, CtrlProxyVoiceOverActionResult, CtrlProxyActionResult } from "./types";
 
 /**
  * Delegate class for VoiceOver state detection via CtrlProxy WebSocket.
@@ -45,6 +45,52 @@ export class CtrlProxyVoiceOver {
     const message = {
       type: "get_voiceover_state",
       requestId,
+    };
+
+    const ws = this.context.getWebSocket();
+    ws?.send(JSON.stringify(message));
+
+    return promise;
+  }
+
+  /**
+   * Request an accessibility action on an element by resourceId or label.
+   *
+   * Used to perform scroll_forward/scroll_backward via the accessibility node system,
+   * more reliable than coordinate gestures when VoiceOver is active.
+   *
+   * @param action - The action to perform (e.g. "scroll_forward", "scroll_backward")
+   * @param resourceId - The resource-id / accessibility identifier of the target element
+   * @param label - The accessibility label (content-desc) as fallback when no resourceId
+   * @param timeoutMs - Request timeout in milliseconds (default: 5000)
+   * @param perf - Optional performance tracker
+   * @returns Action result
+   */
+  async requestAction(
+    action: string,
+    resourceId?: string,
+    label?: string,
+    timeoutMs: number = 5000,
+    perf?: PerformanceTracker
+  ): Promise<CtrlProxyActionResult> {
+    if (!await this.context.ensureConnected(perf)) {
+      return { success: false, error: "Not connected to CtrlProxy" };
+    }
+
+    const requestId = this.context.requestManager.generateId("action");
+    const promise = this.context.requestManager.register<CtrlProxyActionResult>(
+      requestId,
+      "action",
+      timeoutMs,
+      () => ({ success: false, error: "Timeout waiting for action_result" })
+    );
+
+    const message = {
+      type: "request_action",
+      requestId,
+      action,
+      resourceId: resourceId ?? null,
+      label: label ?? null,
     };
 
     const ws = this.context.getWebSocket();

--- a/src/features/observe/ios/types.ts
+++ b/src/features/observe/ios/types.ts
@@ -147,7 +147,12 @@ export type CtrlProxyPressHomeResult = BaseResult;
 export type CtrlProxyLaunchAppResult = BaseResult;
 
 /** Action result from CtrlProxy iOS */
-export type CtrlProxyActionResult = ActionTimingResult;
+export interface CtrlProxyActionResult {
+  success: boolean;
+  action?: string;
+  totalTimeMs?: number;
+  error?: string;
+}
 
 /** VoiceOver state result from CtrlProxy iOS */
 export interface CtrlProxyVoiceOverResult {

--- a/test/fakes/FakeIOSCtrlProxy.ts
+++ b/test/fakes/FakeIOSCtrlProxy.ts
@@ -17,6 +17,7 @@ import {
 import type {
   CtrlProxyVoiceOverResult,
   CtrlProxyVoiceOverActionResult,
+  CtrlProxyActionResult,
 } from "../../src/features/observe/ios/types";
 import { ViewHierarchyResult } from "../../src/models";
 import { ViewHierarchyQueryOptions } from "../../src/models/ViewHierarchyQueryOptions";
@@ -99,11 +100,18 @@ export class FakeIOSCtrlProxy implements CtrlProxyService {
   private voiceOverState: boolean = false;
   private voiceOverActivateResult: CtrlProxyVoiceOverActionResult | null = null;
   private multiFingerSwipeResult: CtrlProxySwipeResult | null = null;
+  private actionResult: CtrlProxyActionResult | null = null;
 
   // VoiceOver call history
   private voiceOverActivateHistory: Array<{
     label: string;
     action: "activate" | "long_press";
+  }> = [];
+
+  private actionHistory: Array<{
+    action: string;
+    resourceId?: string;
+    label?: string;
   }> = [];
 
   private multiFingerSwipeHistory: Array<{
@@ -220,6 +228,13 @@ export class FakeIOSCtrlProxy implements CtrlProxyService {
     this.multiFingerSwipeResult = result;
   }
 
+  /**
+   * Configure requestAction result (null = default success)
+   */
+  setActionResult(result: CtrlProxyActionResult | null): void {
+    this.actionResult = result;
+  }
+
   // MARK: - Assertion Methods
 
   /**
@@ -332,6 +347,13 @@ export class FakeIOSCtrlProxy implements CtrlProxyService {
   }
 
   /**
+   * Get requestAction call history
+   */
+  getActionHistory(): Array<{ action: string; resourceId?: string; label?: string }> {
+    return [...this.actionHistory];
+  }
+
+  /**
    * Get multi-finger swipe call history
    */
   getMultiFingerSwipeHistory(): Array<{
@@ -359,6 +381,7 @@ export class FakeIOSCtrlProxy implements CtrlProxyService {
     this.hierarchyRequestCount = 0;
     this.launchAppHistory = [];
     this.voiceOverActivateHistory = [];
+    this.actionHistory = [];
     this.multiFingerSwipeHistory = [];
   }
 
@@ -783,6 +806,29 @@ export class FakeIOSCtrlProxy implements CtrlProxyService {
       totalTimeMs: duration,
       gestureTimeMs: duration,
       perfTiming: this.performanceTiming || undefined,
+    };
+  }
+
+  async requestAction(
+    action: string,
+    resourceId?: string,
+    label?: string,
+    timeoutMs: number = 5000,
+    perf?: PerformanceTracker
+  ): Promise<CtrlProxyActionResult> {
+    await this.applyDelay("action");
+    this.checkFailure("action");
+
+    this.actionHistory.push({ action, resourceId, label });
+
+    if (this.actionResult) {
+      return this.actionResult;
+    }
+
+    return {
+      success: true,
+      action,
+      totalTimeMs: 50,
     };
   }
 

--- a/test/fakes/FakeVoiceOverSwipeExecutor.ts
+++ b/test/fakes/FakeVoiceOverSwipeExecutor.ts
@@ -1,20 +1,30 @@
-import { GestureOptions } from "../../src/models";
+import { Element, GestureOptions, SwipeDirection } from "../../src/models";
 import { SwipeResult } from "../../src/models/SwipeResult";
 import { PerformanceTracker } from "../../src/utils/PerformanceTracker";
 import { VoiceOverSwipeRunner } from "../../src/features/action/swipeon/types";
 
 export class FakeVoiceOverSwipeExecutor implements VoiceOverSwipeRunner {
-  private swipeCalls: Array<{ x1: number; y1: number; x2: number; y2: number; gestureOptions?: GestureOptions }> = [];
+  private swipeCalls: Array<{
+    x1: number;
+    y1: number;
+    x2: number;
+    y2: number;
+    direction: SwipeDirection;
+    containerElement: Element | null;
+    gestureOptions?: GestureOptions;
+  }> = [];
 
   async executeSwipeGesture(
     x1: number,
     y1: number,
     x2: number,
     y2: number,
+    direction: SwipeDirection,
+    containerElement: Element | null,
     gestureOptions?: GestureOptions,
     _perf?: PerformanceTracker
   ): Promise<SwipeResult> {
-    this.swipeCalls.push({ x1, y1, x2, y2, gestureOptions });
+    this.swipeCalls.push({ x1, y1, x2, y2, direction, containerElement, gestureOptions });
     return { success: true, x1, y1, x2, y2, duration: gestureOptions?.duration ?? 300 };
   }
 

--- a/test/features/action/swipeon/VoiceOverSwipeExecutor.test.ts
+++ b/test/features/action/swipeon/VoiceOverSwipeExecutor.test.ts
@@ -6,6 +6,7 @@ import { FakeTimer } from "../../../fakes/FakeTimer";
 import { NoOpPerformanceTracker } from "../../../../src/utils/PerformanceTracker";
 import type { GestureExecutor } from "../../../../src/features/action/swipeon/types";
 import type { SwipeResult } from "../../../../src/models/SwipeResult";
+import type { Element } from "../../../../src/models";
 
 function makeSwipeResult(overrides: Partial<SwipeResult> = {}): SwipeResult {
   return {
@@ -28,6 +29,13 @@ function makeFakeGestureExecutor(): { executor: GestureExecutor; calls: Array<{ 
     },
   };
   return { executor, calls };
+}
+
+function makeContainerElement(overrides: Partial<Element> = {}): Element {
+  return {
+    bounds: { left: 0, top: 0, right: 375, bottom: 812 },
+    ...overrides,
+  } as Element;
 }
 
 describe("VoiceOverSwipeExecutor", () => {
@@ -57,7 +65,7 @@ describe("VoiceOverSwipeExecutor", () => {
         fakeTimer
       );
 
-      const result = await voiceOverExecutor.executeSwipeGesture(100, 500, 100, 200, { duration: 300 }, perf);
+      const result = await voiceOverExecutor.executeSwipeGesture(100, 500, 100, 200, "up", null, { duration: 300 }, perf);
 
       expect(result.success).toBe(true);
       expect(calls).toHaveLength(1);
@@ -80,6 +88,7 @@ describe("VoiceOverSwipeExecutor", () => {
 
       const result = await voiceOverExecutor.executeSwipeGesture(
         100, 500, 100, 200,
+        "up", null,
         { duration: 300 },
         perf,
         { apexPauseMs: 50, returnSpeed: 1 }
@@ -106,7 +115,7 @@ describe("VoiceOverSwipeExecutor", () => {
         fakeTimer
       );
 
-      const result = await voiceOverExecutor.executeSwipeGesture(100, 500, 100, 200, { duration: 300 }, perf);
+      const result = await voiceOverExecutor.executeSwipeGesture(100, 500, 100, 200, "up", null, { duration: 300 }, perf);
 
       expect(result.success).toBe(true);
       expect(calls).toHaveLength(1);
@@ -127,6 +136,7 @@ describe("VoiceOverSwipeExecutor", () => {
 
       const result = await voiceOverExecutor.executeSwipeGesture(
         100, 500, 100, 200,
+        "up", null,
         { duration: 300 },
         perf,
         { apexPauseMs: 100, returnSpeed: 1 }
@@ -156,6 +166,7 @@ describe("VoiceOverSwipeExecutor", () => {
 
       await voiceOverExecutor.executeSwipeGesture(
         100, 500, 100, 200,
+        "up", null,
         { duration: 300 },
         perf,
         { apexPauseMs: 150, returnSpeed: 1 }
@@ -178,6 +189,7 @@ describe("VoiceOverSwipeExecutor", () => {
 
       await voiceOverExecutor.executeSwipeGesture(
         100, 500, 100, 200,
+        "up", null,
         { duration: 300 },
         perf,
         { apexPauseMs: 0, returnSpeed: 1 }
@@ -200,6 +212,7 @@ describe("VoiceOverSwipeExecutor", () => {
 
       await voiceOverExecutor.executeSwipeGesture(
         100, 500, 100, 200,
+        "up", null,
         { duration: 300 },
         perf,
         { apexPauseMs: 0, returnSpeed: 2 }
@@ -212,7 +225,7 @@ describe("VoiceOverSwipeExecutor", () => {
   });
 
   describe("iOS platform with VoiceOver enabled", () => {
-    test("uses 3-finger swipe via iosClient", async () => {
+    test("uses 3-finger swipe via iosClient when no container element", async () => {
       const { executor, calls } = makeFakeGestureExecutor();
       fakeVoiceOverDetector.setVoiceOverEnabled(true);
 
@@ -224,11 +237,13 @@ describe("VoiceOverSwipeExecutor", () => {
         fakeTimer
       );
 
-      const result = await voiceOverExecutor.executeSwipeGesture(100, 500, 100, 200, { duration: 300 }, perf);
+      const result = await voiceOverExecutor.executeSwipeGesture(100, 500, 100, 200, "up", null, { duration: 300 }, perf);
 
       expect(result.success).toBe(true);
       // Standard swipe should NOT be called
       expect(calls).toHaveLength(0);
+      // Accessibility action should NOT be called (no container)
+      expect(fakeIosClient.getActionHistory()).toHaveLength(0);
       // Multi-finger swipe should be called
       const swipeHistory = fakeIosClient.getMultiFingerSwipeHistory();
       expect(swipeHistory).toHaveLength(1);
@@ -238,6 +253,80 @@ describe("VoiceOverSwipeExecutor", () => {
       expect(swipeHistory[0].x2).toBe(100);
       expect(swipeHistory[0].y2).toBe(200);
       expect(swipeHistory[0].duration).toBe(300);
+    });
+
+    test("uses requestAction with resource-id when container has resource-id", async () => {
+      const { executor, calls } = makeFakeGestureExecutor();
+      fakeVoiceOverDetector.setVoiceOverEnabled(true);
+      const container = makeContainerElement({ "resource-id": "com.example:id/list" });
+
+      const voiceOverExecutor = new VoiceOverSwipeExecutor(
+        { platform: "ios", id: "00001234-ABCD" } as any,
+        executor,
+        fakeIosClient as any,
+        fakeVoiceOverDetector
+      );
+
+      const result = await voiceOverExecutor.executeSwipeGesture(100, 500, 100, 200, "down", container, { duration: 300 }, perf);
+
+      expect(result.success).toBe(true);
+      // Standard swipe and 3-finger swipe should NOT be called
+      expect(calls).toHaveLength(0);
+      expect(fakeIosClient.getMultiFingerSwipeHistory()).toHaveLength(0);
+      // Accessibility action should be called with resource-id
+      const actionHistory = fakeIosClient.getActionHistory();
+      expect(actionHistory).toHaveLength(1);
+      expect(actionHistory[0].action).toBe("scroll_forward");
+      expect(actionHistory[0].resourceId).toBe("com.example:id/list");
+      expect(actionHistory[0].label).toBeUndefined();
+    });
+
+    test("uses requestAction with label when container has content-desc but no resource-id", async () => {
+      const { executor, calls } = makeFakeGestureExecutor();
+      fakeVoiceOverDetector.setVoiceOverEnabled(true);
+      const container = makeContainerElement({ "content-desc": "My Scrollable List" });
+
+      const voiceOverExecutor = new VoiceOverSwipeExecutor(
+        { platform: "ios", id: "00001234-ABCD" } as any,
+        executor,
+        fakeIosClient as any,
+        fakeVoiceOverDetector
+      );
+
+      const result = await voiceOverExecutor.executeSwipeGesture(100, 500, 100, 200, "up", container, { duration: 300 }, perf);
+
+      expect(result.success).toBe(true);
+      expect(calls).toHaveLength(0);
+      expect(fakeIosClient.getMultiFingerSwipeHistory()).toHaveLength(0);
+      const actionHistory = fakeIosClient.getActionHistory();
+      expect(actionHistory).toHaveLength(1);
+      expect(actionHistory[0].action).toBe("scroll_backward");
+      expect(actionHistory[0].resourceId).toBeUndefined();
+      expect(actionHistory[0].label).toBe("My Scrollable List");
+    });
+
+    test("falls back to 3-finger swipe when requestAction fails", async () => {
+      const { executor, calls } = makeFakeGestureExecutor();
+      fakeVoiceOverDetector.setVoiceOverEnabled(true);
+      fakeIosClient.setActionResult({ success: false, error: "Element not found" });
+      const container = makeContainerElement({ "resource-id": "com.example:id/list" });
+
+      const voiceOverExecutor = new VoiceOverSwipeExecutor(
+        { platform: "ios", id: "00001234-ABCD" } as any,
+        executor,
+        fakeIosClient as any,
+        fakeVoiceOverDetector
+      );
+
+      const result = await voiceOverExecutor.executeSwipeGesture(100, 500, 100, 200, "down", container, { duration: 300 }, perf);
+
+      expect(result.success).toBe(true);
+      // Standard swipe NOT called (3-finger succeeded)
+      expect(calls).toHaveLength(0);
+      // 3-finger swipe should be called as fallback
+      const swipeHistory = fakeIosClient.getMultiFingerSwipeHistory();
+      expect(swipeHistory).toHaveLength(1);
+      expect(swipeHistory[0].fingerCount).toBe(3);
     });
 
     test("falls back to standard swipe when requestMultiFingerSwipe fails", async () => {
@@ -253,7 +342,7 @@ describe("VoiceOverSwipeExecutor", () => {
         fakeTimer
       );
 
-      const result = await voiceOverExecutor.executeSwipeGesture(100, 500, 100, 200, { duration: 300 }, perf);
+      const result = await voiceOverExecutor.executeSwipeGesture(100, 500, 100, 200, "up", null, { duration: 300 }, perf);
 
       expect(result.success).toBe(true);
       // Should fall back to standard swipe
@@ -274,10 +363,31 @@ describe("VoiceOverSwipeExecutor", () => {
         fakeTimer
       );
 
-      const result = await voiceOverExecutor.executeSwipeGesture(100, 500, 100, 200, { duration: 300 }, perf);
+      const result = await voiceOverExecutor.executeSwipeGesture(100, 500, 100, 200, "up", null, { duration: 300 }, perf);
 
       expect(result.success).toBe(true);
       // Should fall back to standard swipe
+      expect(calls).toHaveLength(1);
+    });
+
+    test("falls back to standard swipe when requestAction throws", async () => {
+      const { executor, calls } = makeFakeGestureExecutor();
+      fakeVoiceOverDetector.setVoiceOverEnabled(true);
+      fakeIosClient.setFailureMode("action", new Error("Connection lost"));
+      fakeIosClient.setMultiFingerSwipeResult({ success: false, error: "also fails", totalTimeMs: 0 });
+      const container = makeContainerElement({ "resource-id": "com.example:id/list" });
+
+      const voiceOverExecutor = new VoiceOverSwipeExecutor(
+        { platform: "ios", id: "00001234-ABCD" } as any,
+        executor,
+        fakeIosClient as any,
+        fakeVoiceOverDetector
+      );
+
+      const result = await voiceOverExecutor.executeSwipeGesture(100, 500, 100, 200, "down", container, { duration: 300 }, perf);
+
+      expect(result.success).toBe(true);
+      // Should fall back all the way to standard swipe
       expect(calls).toHaveLength(1);
     });
 
@@ -293,7 +403,7 @@ describe("VoiceOverSwipeExecutor", () => {
         fakeTimer
       );
 
-      await voiceOverExecutor.executeSwipeGesture(100, 500, 100, 200, { duration: 600 }, perf);
+      await voiceOverExecutor.executeSwipeGesture(100, 500, 100, 200, "up", null, { duration: 600 }, perf);
 
       const swipeHistory = fakeIosClient.getMultiFingerSwipeHistory();
       expect(swipeHistory[0].duration).toBe(600);
@@ -311,7 +421,7 @@ describe("VoiceOverSwipeExecutor", () => {
         fakeTimer
       );
 
-      await voiceOverExecutor.executeSwipeGesture(100, 500, 100, 200, undefined, perf);
+      await voiceOverExecutor.executeSwipeGesture(100, 500, 100, 200, "up", null, undefined, perf);
 
       const swipeHistory = fakeIosClient.getMultiFingerSwipeHistory();
       expect(swipeHistory[0].duration).toBe(300);
@@ -331,6 +441,7 @@ describe("VoiceOverSwipeExecutor", () => {
 
       const result = await voiceOverExecutor.executeSwipeGesture(
         100, 500, 100, 200,
+        "up", null,
         { duration: 300 },
         perf,
         { apexPauseMs: 0, returnSpeed: 1 }
@@ -362,6 +473,7 @@ describe("VoiceOverSwipeExecutor", () => {
 
       await voiceOverExecutor.executeSwipeGesture(
         100, 500, 100, 200,
+        "up", null,
         { duration: 300 },
         perf,
         { apexPauseMs: 150, returnSpeed: 1 }
@@ -384,6 +496,7 @@ describe("VoiceOverSwipeExecutor", () => {
 
       await voiceOverExecutor.executeSwipeGesture(
         100, 500, 100, 200,
+        "up", null,
         { duration: 300 },
         perf,
         { apexPauseMs: 0, returnSpeed: 1 }
@@ -406,6 +519,7 @@ describe("VoiceOverSwipeExecutor", () => {
 
       await voiceOverExecutor.executeSwipeGesture(
         100, 500, 100, 200,
+        "up", null,
         { duration: 300 },
         perf,
         { apexPauseMs: 0, returnSpeed: 2 }
@@ -433,6 +547,7 @@ describe("VoiceOverSwipeExecutor", () => {
 
       const result = await voiceOverExecutor.executeSwipeGesture(
         100, 500, 100, 200,
+        "up", null,
         { duration: 300 },
         perf,
         { apexPauseMs: 0, returnSpeed: 1 }
@@ -462,6 +577,7 @@ describe("VoiceOverSwipeExecutor", () => {
 
       const result = await voiceOverExecutor.executeSwipeGesture(
         100, 500, 100, 200,
+        "up", null,
         { duration: 300 },
         perf,
         { apexPauseMs: 0, returnSpeed: 1 }
@@ -497,6 +613,7 @@ describe("VoiceOverSwipeExecutor", () => {
 
       const result = await voiceOverExecutor.executeSwipeGesture(
         100, 500, 100, 200,
+        "up", null,
         { duration: 300 },
         perf,
         { apexPauseMs: 0, returnSpeed: 1 }
@@ -520,6 +637,7 @@ describe("VoiceOverSwipeExecutor", () => {
 
       const result = await voiceOverExecutor.executeSwipeGesture(
         100, 500, 100, 200,
+        "up", null,
         { duration: 300 },
         perf,
         { apexPauseMs: 100, returnSpeed: 2 }
@@ -527,6 +645,78 @@ describe("VoiceOverSwipeExecutor", () => {
 
       // forward=300, apex=100, return=150 → total=550
       expect(result.duration).toBe(550);
+    });
+
+    test("maps 'down' direction to scroll_forward", async () => {
+      const { executor } = makeFakeGestureExecutor();
+      fakeVoiceOverDetector.setVoiceOverEnabled(true);
+      const container = makeContainerElement({ "resource-id": "com.example:id/list" });
+
+      const voiceOverExecutor = new VoiceOverSwipeExecutor(
+        { platform: "ios", id: "00001234-ABCD" } as any,
+        executor,
+        fakeIosClient as any,
+        fakeVoiceOverDetector
+      );
+
+      await voiceOverExecutor.executeSwipeGesture(100, 500, 100, 200, "down", container, undefined, perf);
+
+      const actionHistory = fakeIosClient.getActionHistory();
+      expect(actionHistory[0].action).toBe("scroll_forward");
+    });
+
+    test("maps 'up' direction to scroll_backward", async () => {
+      const { executor } = makeFakeGestureExecutor();
+      fakeVoiceOverDetector.setVoiceOverEnabled(true);
+      const container = makeContainerElement({ "resource-id": "com.example:id/list" });
+
+      const voiceOverExecutor = new VoiceOverSwipeExecutor(
+        { platform: "ios", id: "00001234-ABCD" } as any,
+        executor,
+        fakeIosClient as any,
+        fakeVoiceOverDetector
+      );
+
+      await voiceOverExecutor.executeSwipeGesture(100, 500, 100, 200, "up", container, undefined, perf);
+
+      const actionHistory = fakeIosClient.getActionHistory();
+      expect(actionHistory[0].action).toBe("scroll_backward");
+    });
+
+    test("maps 'right' direction to scroll_forward", async () => {
+      const { executor } = makeFakeGestureExecutor();
+      fakeVoiceOverDetector.setVoiceOverEnabled(true);
+      const container = makeContainerElement({ "resource-id": "com.example:id/list" });
+
+      const voiceOverExecutor = new VoiceOverSwipeExecutor(
+        { platform: "ios", id: "00001234-ABCD" } as any,
+        executor,
+        fakeIosClient as any,
+        fakeVoiceOverDetector
+      );
+
+      await voiceOverExecutor.executeSwipeGesture(100, 200, 200, 200, "right", container, undefined, perf);
+
+      const actionHistory = fakeIosClient.getActionHistory();
+      expect(actionHistory[0].action).toBe("scroll_forward");
+    });
+
+    test("maps 'left' direction to scroll_backward", async () => {
+      const { executor } = makeFakeGestureExecutor();
+      fakeVoiceOverDetector.setVoiceOverEnabled(true);
+      const container = makeContainerElement({ "resource-id": "com.example:id/list" });
+
+      const voiceOverExecutor = new VoiceOverSwipeExecutor(
+        { platform: "ios", id: "00001234-ABCD" } as any,
+        executor,
+        fakeIosClient as any,
+        fakeVoiceOverDetector
+      );
+
+      await voiceOverExecutor.executeSwipeGesture(200, 200, 100, 200, "left", container, undefined, perf);
+
+      const actionHistory = fakeIosClient.getActionHistory();
+      expect(actionHistory[0].action).toBe("scroll_backward");
     });
   });
 });


### PR DESCRIPTION
## Summary

- When VoiceOver is active on iOS, coordinate swipes navigate focus instead of scrolling content
- Adds the same accessibility-node scroll path that TalkBack uses on Android: try `requestAction` (`scroll_forward`/`scroll_backward`) by resource-id, then by content-desc (label), then fall back to 3-finger swipe, then single-finger swipe
- Swift: adds `label` param to `WebSocketRequest` and `GesturePerformer.performAction` so containers with content-desc but no resource-id can be scrolled via `findElement(byText:)` on the iOS side

Closes #1452

## Test plan

- [x] 28 unit tests in `VoiceOverSwipeExecutor.test.ts` covering all fallback levels and direction mappings
- [x] Full suite: 2983 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)