### PR TITLE
chore: fix dead link to local-development.md in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ Thanks for your interest in contributing to AutoMobile.
 
 ## Local Development
 
-See `docs/contributing/local-development.md` for the full setup guide. The worktree
-setup script writes your local MCP configuration to `.mcp.local.json`, which is
-gitignored. The tracked `.mcp.json` is a canonical example and should not be
-modified locally.
+Run `scripts/local-dev/hot-reload.sh` to build all components and start a background
+watcher that rebuilds and restarts on changes. The worktree setup script writes your
+local MCP configuration to `.mcp.local.json`, which is gitignored. The tracked
+`.mcp.json` is a canonical example and should not be modified locally.


### PR DESCRIPTION
## Summary
- Replaces broken reference to `docs/contributing/local-development.md` (file does not exist) with `scripts/local-dev/hot-reload.sh`, the actual local dev entry point
- No new files created; updated `CONTRIBUTING.md` in place per acceptance criteria

## Test Plan
- [ ] Verify `scripts/local-dev/hot-reload.sh` exists ✅
- [ ] Verify dead link is removed ✅

Closes #1456

🤖 Generated with [Claude Code](https://claude.com/claude-code)