### PR TITLE
chore: extend lychee link checking to cover root markdown files

### DIFF
--- a/DOCKER.md
+++ b/DOCKER.md
@@ -4,8 +4,6 @@ This project includes Docker support for running AutoMobile in a containerized e
 
 ## For MCP Clients (Claude Desktop, Continue.dev, etc.)
 
-To use this Docker image with MCP clients, see the [MCP Client Configuration Guide](docs/mcp-docker-config.md) for complete setup instructions.
-
 **Quick example for Claude Desktop**:
 ```json
 {
@@ -49,7 +47,6 @@ docker pull kaeawc/auto-mobile:0.0
 docker pull kaeawc/auto-mobile:main-abc1234
 ```
 
-**For maintainers**: See [Docker Hub Setup Guide](docs/docker-hub-setup.md) for publishing credentials and workflow configuration.
 
 ## What's Included
 
@@ -90,10 +87,6 @@ docker-compose exec auto-mobile bash -c "cd android && ./gradlew build"
 - Docker Compose v2.0+
 - For ADB device access: Privileged mode and host networking (already configured)
 - For slim images without emulator: Host Android SDK + AVDs mounted into the container
-
-## Documentation
-
-For complete documentation, see [docs/docker.md](docs/docker.md)
 
 ## Platform Notes
 
@@ -255,4 +248,4 @@ docker build --platform=linux/amd64 -t auto-mobile:latest .
 echo '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"test","version":"1.0.0"}}}' | docker run --platform=linux/amd64 -i --rm --init auto-mobile:latest
 ```
 
-For more help, see the [full Docker documentation](docs/docker.md) and [MCP configuration guide](docs/mcp-docker-config.md).
+For more help, see the sections above or check the [FAQ](docs/faq.md).

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ It can do all this by being an MCP server that uses standard platform tools like
 - 🤖 **Fast UX Inspection** Kotlin Accessibility Service and Swift XCTestService to enable fast, accurate observations. 10x faster than the next fastest observation toolkit.
 - 🦾 **Full Touch Injection** Tap, Swipe, Pinch, Drag & Drop, Shake with automatic element targeting.
 - ♻️ **Tool Feedback** [Observations](docs/design-docs/mcp/observe/index.md) drive the [interaction loop](docs/design-docs/mcp/interaction-loop.md) for all [tool calls](docs/design-docs/mcp/tools.md).
-- 🧪 **Test Execution** [Kotlin JUnitRunner](docs/design-docs/plat/android/junit-runner/index.md) & [Swift XCTestRunner](docs/design-docs/plat/ios/xctestrunner.md) execute tests natively handling device pooling, multi-device tests, and automatically optimizing test timing.
+- 🧪 **Test Execution** [Kotlin JUnitRunner](docs/design-docs/plat/android/junit-runner/index.md) & [Swift XCTestRunner](docs/design-docs/plat/ios/xctestrunner/index.md) execute tests natively handling device pooling, multi-device tests, and automatically optimizing test timing.
 
 ## Get Started
 

--- a/scripts/lychee/validate_lychee.sh
+++ b/scripts/lychee/validate_lychee.sh
@@ -83,8 +83,8 @@ if [[ ! -f "$LYCHEE_CONFIG" ]]; then
     print_warning "Running with default configuration..."
 fi
 
-# Run lychee on docs directory
-print_status "Checking links in docs/ directory..."
+# Run lychee on docs directory and root markdown files
+print_status "Checking links in docs/ and root *.md files..."
 print_status ""
 
 cd "$PROJECT_ROOT"
@@ -117,9 +117,12 @@ suggest_similar_files() {
         fi
     fi
 
-    # Search for files with similar names in current tree
+    # Search for files with similar names in current tree (docs/ and root *.md)
     local suggestions
     suggestions=$(find docs/ -type f -name "*${basename_file}*" 2>/dev/null | head -5)
+    local root_suggestions
+    root_suggestions=$(find . -maxdepth 1 -type f -name "*${basename_file}*" 2>/dev/null | head -3)
+    suggestions="${suggestions}${root_suggestions:+$'\n'$root_suggestions}"
 
     if [[ -n "$suggestions" ]]; then
         if [[ "$found_suggestions" == false ]]; then
@@ -150,7 +153,7 @@ LYCHEE_ERRORS=$(mktemp)
 
 # Run lychee with config (if exists) or default settings
 if [[ -f "$LYCHEE_CONFIG" ]]; then
-    if lychee --config "$LYCHEE_CONFIG" $VERBOSE_FLAG "docs/" 2>&1 | tee "$LYCHEE_OUTPUT"; then
+    if lychee --config "$LYCHEE_CONFIG" $VERBOSE_FLAG "docs/" ./*.md 2>&1 | tee "$LYCHEE_OUTPUT"; then
         rm -f "$LYCHEE_OUTPUT" "$LYCHEE_ERRORS"
         print_status "✓ All links are valid"
         exit 0
@@ -191,7 +194,7 @@ if [[ -f "$LYCHEE_CONFIG" ]]; then
     fi
 else
     # Run with minimal default options
-    if lychee --max-concurrency 10 --timeout 20 $VERBOSE_FLAG "docs/" 2>&1 | tee "$LYCHEE_OUTPUT"; then
+    if lychee --max-concurrency 10 --timeout 20 $VERBOSE_FLAG "docs/" ./*.md 2>&1 | tee "$LYCHEE_OUTPUT"; then
         rm -f "$LYCHEE_OUTPUT" "$LYCHEE_ERRORS"
         print_status "✓ All links are valid"
         exit 0


### PR DESCRIPTION
## Summary
- Extends `validate_lychee.sh` to check root-level `*.md` files (README.md, CONTRIBUTING.md, DOCKER.md, etc.) in addition to `docs/`
- Fixes 4 broken links now caught by the expanded check: one moved path in README.md and three dead links in DOCKER.md pointing to deleted docs
- Shellcheck passes on the modified script

## Test Plan
- [x] `./scripts/lychee/validate_lychee.sh` passes locally (913 links, 0 errors)
- [x] `shellcheck scripts/lychee/validate_lychee.sh` passes

Closes #1457

🤖 Generated with [Claude Code](https://claude.com/claude-code)