### PR TITLE
fix: prevent hot reload feedback loop that reboots iOS simulator

### DIFF
--- a/scripts/local-dev/hot-reload.sh
+++ b/scripts/local-dev/hot-reload.sh
@@ -83,6 +83,7 @@ LAST_TS_HASH=""
 # Track device/simulator state
 LAST_ADB_DEVICES=""
 LAST_SIMULATOR=""
+CTRL_PROXY_SIMULATOR=""      # Simulator CtrlProxy is currently targeting
 APK_NEEDS_INSTALL=false
 IOS_NEEDS_RESTART=false
 
@@ -641,8 +642,14 @@ unified_watch_loop() {
 
       if [[ "${current_simulator}" != "${LAST_SIMULATOR}" ]]; then
         if [[ -n "${current_simulator}" ]]; then
-          log_info "[iOS] Booted simulator: ${current_simulator}"
-          IOS_NEEDS_RESTART=true
+          if [[ "${current_simulator}" != "${CTRL_PROXY_SIMULATOR}" ]]; then
+            # Genuinely new/different simulator — restart CtrlProxy for it
+            log_info "[iOS] New booted simulator: ${current_simulator}"
+            IOS_NEEDS_RESTART=true
+          else
+            # Same simulator CtrlProxy is already targeting (reappeared after xcodebuild reboot)
+            log_info "[iOS] Simulator returned: ${current_simulator}"
+          fi
         else
           log_warn "[iOS] No booted simulator detected."
         fi
@@ -673,6 +680,7 @@ unified_watch_loop() {
       if [[ -n "${XCODEBUILD_PID}" ]] && ! kill -0 "${XCODEBUILD_PID}" 2>/dev/null; then
         log_warn "[iOS] CtrlProxy iOS process exited."
         XCODEBUILD_PID=""
+        CTRL_PROXY_SIMULATOR=""
         IOS_NEEDS_RESTART=true
       fi
 
@@ -680,6 +688,7 @@ unified_watch_loop() {
       if [[ "${IOS_NEEDS_RESTART}" == "true" ]] && [[ -n "${LAST_SIMULATOR}" ]]; then
         stop_ctrl_proxy_ios
         start_ctrl_proxy_ios "${LAST_SIMULATOR}"
+        CTRL_PROXY_SIMULATOR="${LAST_SIMULATOR}"
         IOS_NEEDS_RESTART=false
       fi
     fi
@@ -860,6 +869,7 @@ WATCHER_LOG="${PROJECT_ROOT}/scratch/hot-reload.log"
     if [[ -n "${initial_simulator}" ]]; then
       start_ctrl_proxy_ios "${initial_simulator}"
       LAST_SIMULATOR="${initial_simulator}"
+      CTRL_PROXY_SIMULATOR="${initial_simulator}"
     fi
   fi
 


### PR DESCRIPTION
## Summary
- Adds `CTRL_PROXY_SIMULATOR` state variable to track which simulator CtrlProxy is currently targeting
- Fixes a feedback loop where xcodebuild's own simulator reboot during test execution triggered another CtrlProxy restart, causing an infinite reboot cycle
- When the same simulator reappears after an xcodebuild reboot, the loop now logs "Simulator returned" instead of triggering a restart

## Root Cause
`start_ctrl_proxy_ios` runs `xcodebuild test[-without-building]`, which reboots the simulator. During the reboot, `get_current_simulator()` returns `""`. When the simulator comes back, `current_simulator != LAST_SIMULATOR` was always true (because `LAST_SIMULATOR` was set to `""`), triggering another restart → infinite loop.

## Fix
Track `CTRL_PROXY_SIMULATOR` separately. Only set `IOS_NEEDS_RESTART=true` when the new UDID differs from `CTRL_PROXY_SIMULATOR` (the UDID CtrlProxy was started with). A simulator reappearing with the same UDID is recognized as a normal xcodebuild reboot, not a user-initiated simulator switch.

## Test Plan
- [ ] shellcheck passes (validated locally)
- [ ] Start hot reload, make a TS change, confirm iOS simulator does not reboot repeatedly
- [ ] Boot a different simulator while hot reload is running — confirm CtrlProxy restarts for it

Closes #1353

🤖 Generated with [Claude Code](https://claude.com/claude-code)