### PR TITLE
feat: move device metadata and global actions from ADB to CtrlProxy

### DIFF
--- a/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/CtrlProxy.kt
+++ b/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/CtrlProxy.kt
@@ -3,6 +3,7 @@ package dev.jasonpearson.automobile.ctrlproxy
 import android.accessibilityservice.AccessibilityService
 import android.accessibilityservice.GestureDescription
 import android.annotation.SuppressLint
+import android.app.ActivityManager
 import android.app.admin.DevicePolicyManager
 import android.content.BroadcastReceiver
 import android.content.ClipData
@@ -16,6 +17,7 @@ import android.graphics.Bitmap
 import android.graphics.Path
 import android.graphics.Rect
 import android.os.Build
+import android.os.PowerManager
 import android.util.Base64
 import android.util.DisplayMetrics
 import android.util.Log
@@ -759,6 +761,10 @@ class CtrlProxy : AccessibilityService() {
               onGetPermission = { requestId, permission, requestPermission ->
                 handleGetPermission(requestId, permission, requestPermission)
               },
+              onRequestGlobalAction = { requestId, action ->
+                performGlobalActionRequest(requestId, action)
+              },
+              onRequestDeviceInfo = { requestId -> performDeviceInfoRequest(requestId) },
               onSetRecompositionTracking = { enabled -> setRecompositionTrackingEnabled(enabled) },
               onGetCurrentFocus = { requestId -> handleGetCurrentFocus(requestId) },
               onGetTraversalOrder = { requestId -> handleGetTraversalOrder(requestId) },
@@ -1181,6 +1187,149 @@ class CtrlProxy : AccessibilityService() {
     }
   }
 
+  /** Get device wakefulness state: "Awake", "Asleep", or "Dozing". */
+  private fun getWakefulness(): String {
+    return try {
+      val powerManager = getSystemService(Context.POWER_SERVICE) as? PowerManager
+      if (powerManager == null) {
+        "Awake"
+      } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M && powerManager.isDeviceIdleMode) {
+        "Dozing"
+      } else if (powerManager.isInteractive) {
+        "Awake"
+      } else {
+        "Asleep"
+      }
+    } catch (e: Exception) {
+      Log.w(TAG, "Failed to get wakefulness", e)
+      "Awake"
+    }
+  }
+
+  /**
+   * Get the foreground activity component name and task ID. Returns a pair of (componentName,
+   * taskId) or null if unavailable.
+   */
+  @Suppress("DEPRECATION")
+  private fun getForegroundActivity(): Pair<String, Int>? {
+    return try {
+      val activityManager = getSystemService(Context.ACTIVITY_SERVICE) as? ActivityManager
+      val tasks = activityManager?.getRunningTasks(1)
+      if (!tasks.isNullOrEmpty()) {
+        val topTask = tasks[0]
+        val component = topTask.topActivity
+        if (component != null) {
+          val name = component.packageName + "/" + component.shortClassName
+          Pair(name, topTask.id)
+        } else {
+          null
+        }
+      } else {
+        null
+      }
+    } catch (e: Exception) {
+      Log.w(TAG, "Failed to get foreground activity", e)
+      null
+    }
+  }
+
+  /** Get display density in DPI. */
+  private fun getDensity(): Int {
+    return try {
+      resources.displayMetrics.densityDpi
+    } catch (e: Exception) {
+      Log.w(TAG, "Failed to get density", e)
+      0
+    }
+  }
+
+  /** Check if running on an emulator. */
+  private fun getIsEmulator(): Boolean {
+    return (Build.FINGERPRINT.startsWith("generic") ||
+        Build.FINGERPRINT.startsWith("unknown") ||
+        Build.MODEL.contains("google_sdk") ||
+        Build.MODEL.contains("Emulator") ||
+        Build.MODEL.contains("Android SDK built for x86") ||
+        Build.MANUFACTURER.contains("Genymotion") ||
+        Build.HARDWARE.contains("goldfish") ||
+        Build.HARDWARE.contains("ranchu") ||
+        Build.PRODUCT.contains("sdk_gphone") ||
+        Build.PRODUCT.contains("emulator") ||
+        Build.PRODUCT.contains("simulator"))
+  }
+
+  /**
+   * Execute a global action (back, home, recents, etc.) via the accessibility service.
+   * Returns true if the action was dispatched successfully.
+   */
+  private fun executeGlobalAction(action: String): Boolean {
+    val actionId = when (action.lowercase()) {
+      "back" -> GLOBAL_ACTION_BACK
+      "home" -> GLOBAL_ACTION_HOME
+      "recent", "recents" -> GLOBAL_ACTION_RECENTS
+      "notifications" -> GLOBAL_ACTION_NOTIFICATIONS
+      "power_dialog" -> GLOBAL_ACTION_POWER_DIALOG
+      "lock_screen" -> if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+        GLOBAL_ACTION_LOCK_SCREEN
+      } else {
+        return false
+      }
+      else -> return false
+    }
+    return performGlobalAction(actionId)
+  }
+
+  /**
+   * Handle a request_global_action WebSocket message.
+   */
+  private fun performGlobalActionRequest(requestId: String?, action: String) {
+    val startTime = System.currentTimeMillis()
+    val success = executeGlobalAction(action)
+    val totalTimeMs = System.currentTimeMillis() - startTime
+    serviceScope.launch {
+      webSocketServer?.broadcast(
+          dev.jasonpearson.automobile.protocol.GlobalActionResult(
+              timestamp = System.currentTimeMillis(),
+              requestId = requestId,
+              success = success,
+              action = action,
+              totalTimeMs = totalTimeMs,
+              error = if (!success) "Unsupported or failed action: $action" else null,
+          ),
+      )
+    }
+  }
+
+  /**
+   * Handle a request_device_info WebSocket message.
+   */
+  private fun performDeviceInfoRequest(requestId: String?) {
+    val startTime = System.currentTimeMillis()
+    val screenDimensions = getScreenDimensions()
+    val foreground = getForegroundActivity()
+    val totalTimeMs = System.currentTimeMillis() - startTime
+    serviceScope.launch {
+      webSocketServer?.broadcast(
+          dev.jasonpearson.automobile.protocol.DeviceInfoResult(
+              timestamp = System.currentTimeMillis(),
+              requestId = requestId,
+              success = true,
+              screenWidth = screenDimensions?.width,
+              screenHeight = screenDimensions?.height,
+              density = getDensity(),
+              rotation = getRotation(),
+              sdkInt = Build.VERSION.SDK_INT,
+              deviceModel = Build.MODEL,
+              isEmulator = getIsEmulator(),
+              wakefulness = getWakefulness(),
+              foregroundActivity = foreground?.first,
+              foregroundTaskId = foreground?.second,
+              totalTimeMs = totalTimeMs,
+          ),
+      )
+    }
+  }
+
   /**
    * Direct hierarchy extraction without debouncing. Used by the HierarchyDebouncer. Extracts from
    * all visible windows to capture popups, toolbars, etc.
@@ -1222,12 +1371,22 @@ class CtrlProxy : AccessibilityService() {
       )
     }
 
-    // Add screen info to the hierarchy (eliminates need for dumpsys window call on client)
+    // Add device metadata to the hierarchy (eliminates need for dumpsys calls on client)
+    val wakefulness = getWakefulness()
+    val foreground = getForegroundActivity()
+    val density = getDensity()
     return hierarchy?.copy(
         screenWidth = screenDimensions?.width,
         screenHeight = screenDimensions?.height,
         rotation = rotation,
         systemInsets = systemInsets,
+        wakefulness = wakefulness,
+        foregroundActivity = foreground?.first,
+        foregroundTaskId = foreground?.second,
+        density = density,
+        sdkInt = Build.VERSION.SDK_INT,
+        deviceModel = Build.MODEL,
+        isEmulator = getIsEmulator(),
     )
   }
 

--- a/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/WebSocketServer.kt
+++ b/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/WebSocketServer.kt
@@ -164,6 +164,8 @@ class WebSocketServer(
     private val onRequestInstallCaCertFromPath:
         ((requestId: String?, devicePath: String) -> Unit)? =
         null,
+    private val onRequestGlobalAction: ((requestId: String?, action: String) -> Unit)? = null,
+    private val onRequestDeviceInfo: ((requestId: String?) -> Unit)? = null,
     private val onGetDeviceOwnerStatus: ((requestId: String?) -> Unit)? = null,
     private val onGetPermission:
         ((requestId: String?, permission: String?, requestPermission: Boolean?) -> Unit)? =
@@ -664,6 +666,19 @@ class WebSocketServer(
           } else {
             Log.w(TAG, "remove_ca_cert request missing alias and certificate")
           }
+        }
+        "request_global_action" -> {
+          Log.d(TAG, "Received global_action request (requestId: ${request.requestId}, action: ${request.action})")
+          val action = request.action
+          if (action != null) {
+            onRequestGlobalAction?.invoke(request.requestId, action)
+          } else {
+            Log.w(TAG, "Global action request missing required action")
+          }
+        }
+        "request_device_info" -> {
+          Log.d(TAG, "Received device_info request (requestId: ${request.requestId})")
+          onRequestDeviceInfo?.invoke(request.requestId)
         }
         "get_device_owner_status" -> {
           Log.d(TAG, "Received get_device_owner_status request (requestId: ${request.requestId})")

--- a/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/models/ViewHierarchy.kt
+++ b/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/models/ViewHierarchy.kt
@@ -24,4 +24,11 @@ data class ViewHierarchy(
     val screenHeight: Int? = null,
     val rotation: Int? = null, // 0=portrait, 1=landscape90, 2=reverse, 3=landscape270
     val systemInsets: SystemInsetsInfo? = null,
+    val wakefulness: String? = null, // "Awake", "Asleep", or "Dozing"
+    val foregroundActivity: String? = null, // e.g. "com.example.app/.MainActivity"
+    val foregroundTaskId: Int? = null,
+    val density: Int? = null, // Display density in DPI
+    val sdkInt: Int? = null, // Android API level (e.g. 34)
+    val deviceModel: String? = null, // e.g. "Pixel 8"
+    val isEmulator: Boolean? = null, // Whether running on an emulator
 )

--- a/android/protocol/src/main/kotlin/dev/jasonpearson/automobile/protocol/WebSocketRequest.kt
+++ b/android/protocol/src/main/kotlin/dev/jasonpearson/automobile/protocol/WebSocketRequest.kt
@@ -309,6 +309,27 @@ data class ClearPreferences(
 ) : WebSocketRequest()
 
 // =============================================================================
+// Global Action Request
+// =============================================================================
+
+@Serializable
+@SerialName("request_global_action")
+data class RequestGlobalAction(
+  override val requestId: String? = null,
+  val action: String, // back, home, recent, notifications, power_dialog, lock_screen
+) : WebSocketRequest()
+
+// =============================================================================
+// Device Info Request
+// =============================================================================
+
+@Serializable
+@SerialName("request_device_info")
+data class RequestDeviceInfo(
+  override val requestId: String? = null,
+) : WebSocketRequest()
+
+// =============================================================================
 // Configuration Requests
 // =============================================================================
 

--- a/android/protocol/src/main/kotlin/dev/jasonpearson/automobile/protocol/WebSocketResponse.kt
+++ b/android/protocol/src/main/kotlin/dev/jasonpearson/automobile/protocol/WebSocketResponse.kt
@@ -364,6 +364,45 @@ data class PermissionResult(
 ) : WebSocketResponse()
 
 // =============================================================================
+// Global Action Result
+// =============================================================================
+
+@Serializable
+@SerialName("global_action_result")
+data class GlobalActionResult(
+  override val timestamp: Long,
+  val requestId: String? = null,
+  val success: Boolean,
+  val action: String,
+  val totalTimeMs: Long,
+  val error: String? = null,
+) : WebSocketResponse()
+
+// =============================================================================
+// Device Info Result
+// =============================================================================
+
+@Serializable
+@SerialName("device_info_result")
+data class DeviceInfoResult(
+  override val timestamp: Long,
+  val requestId: String? = null,
+  val success: Boolean,
+  val screenWidth: Int? = null,
+  val screenHeight: Int? = null,
+  val density: Int? = null,
+  val rotation: Int? = null,
+  val sdkInt: Int? = null,
+  val deviceModel: String? = null,
+  val isEmulator: Boolean? = null,
+  val wakefulness: String? = null,
+  val foregroundActivity: String? = null,
+  val foregroundTaskId: Int? = null,
+  val totalTimeMs: Long,
+  val error: String? = null,
+) : WebSocketResponse()
+
+// =============================================================================
 // Accessibility Focus Results
 // =============================================================================
 

--- a/src/features/action/HomeScreen.ts
+++ b/src/features/action/HomeScreen.ts
@@ -3,10 +3,12 @@ import { BaseVisualChange, ProgressCallback } from "./BaseVisualChange";
 import { BootedDevice, HomeScreenResult } from "../../models";
 import { createGlobalPerformanceTracker } from "../../utils/PerformanceTracker";
 import { CtrlProxyClient } from "../observe/ios";
+import { CtrlProxyClient as AndroidCtrlProxyClient } from "../observe/android";
+import { logger } from "../../utils/logger";
 
 /**
- * Navigates to the home screen using the hardware home button (keyevent 3).
- * This works universally on all Android devices regardless of navigation mode.
+ * Navigates to the home screen using the accessibility service global action
+ * (preferred) or hardware home button keyevent (fallback).
  */
 export class HomeScreen extends BaseVisualChange {
 
@@ -23,10 +25,7 @@ export class HomeScreen extends BaseVisualChange {
       async () => {
         switch (this.device.platform) {
           case "android":
-            // Press hardware home button (keycode 3) - works on all Android devices
-            await perf.track("hardwareNavigation", () =>
-              this.adb.executeCommand("shell input keyevent 3")
-            );
+            await perf.track("homeNavigation", () => this.executeAndroidHome());
             break;
           case "ios":
             await perf.track("iOSHomeNavigation", () => this.executeIosHomeNavigation());
@@ -47,6 +46,21 @@ export class HomeScreen extends BaseVisualChange {
         perf
       }
     );
+  }
+
+  private async executeAndroidHome(): Promise<void> {
+    try {
+      const client = AndroidCtrlProxyClient.getInstance(this.device);
+      const result = await client.requestGlobalAction("home", 3000);
+      if (result.success) {
+        logger.debug("[HOME] Used accessibility service global action");
+        return;
+      }
+      logger.debug(`[HOME] Global action failed (${result.error}), falling back to ADB keyevent`);
+    } catch {
+      // Fall through to ADB
+    }
+    await this.adb.executeCommand("shell input keyevent 3");
   }
 
   private async executeIosHomeNavigation(): Promise<void> {

--- a/src/features/action/PressButton.ts
+++ b/src/features/action/PressButton.ts
@@ -3,6 +3,8 @@ import { BaseVisualChange, ProgressCallback } from "./BaseVisualChange";
 import { BootedDevice, PressButtonResult } from "../../models";
 import { createGlobalPerformanceTracker } from "../../utils/PerformanceTracker";
 import { CtrlProxyClient } from "../observe/ios";
+import { CtrlProxyClient as AndroidCtrlProxyClient } from "../observe/android";
+import { logger } from "../../utils/logger";
 
 export class PressButton extends BaseVisualChange {
   constructor(device: BootedDevice, adb: AdbClient | null = null) {
@@ -63,10 +65,13 @@ export class PressButton extends BaseVisualChange {
     );
   }
 
+  // Buttons that can be handled via accessibility service global actions
+  private static readonly GLOBAL_ACTION_BUTTONS = new Set(["back", "home", "recent"]);
+
   /**
-   * Execute Android-specific button press
-   * @param button - Button name to press
-   * @returns Result of the button press operation
+   * Execute Android-specific button press.
+   * Uses accessibility service global actions for back/home/recent (faster),
+   * falls back to ADB keyevent for all buttons.
    */
   private async executeAndroidButtonPress(button: string): Promise<PressButtonResult> {
     const keyCodeMap: Record<string, number> = {
@@ -79,7 +84,8 @@ export class PressButton extends BaseVisualChange {
       "recent": 187,
     };
 
-    const keyCode = keyCodeMap[button.toLowerCase()];
+    const normalized = button.toLowerCase();
+    const keyCode = keyCodeMap[normalized];
     if (!keyCode) {
       return {
         success: false,
@@ -89,13 +95,23 @@ export class PressButton extends BaseVisualChange {
       };
     }
 
-    await this.adb.executeCommand(`shell input keyevent ${keyCode}`);
+    // Try accessibility service global action for supported buttons
+    if (PressButton.GLOBAL_ACTION_BUTTONS.has(normalized)) {
+      try {
+        const client = AndroidCtrlProxyClient.getInstance(this.device);
+        const result = await client.requestGlobalAction(normalized, 3000);
+        if (result.success) {
+          logger.debug(`[PRESS_BUTTON] Used accessibility service for ${button}`);
+          return { success: true, button, keyCode };
+        }
+        logger.debug(`[PRESS_BUTTON] Global action failed (${result.error}), falling back to ADB`);
+      } catch {
+        // Fall through to ADB
+      }
+    }
 
-    return {
-      success: true,
-      button,
-      keyCode
-    };
+    await this.adb.executeCommand(`shell input keyevent ${keyCode}`);
+    return { success: true, button, keyCode };
   }
 
   /**

--- a/src/features/action/RecentApps.ts
+++ b/src/features/action/RecentApps.ts
@@ -9,6 +9,8 @@ import { DefaultElementGeometry } from "../utility/ElementGeometry";
 import { ObserveResult } from "../../models";
 import { createGlobalPerformanceTracker } from "../../utils/PerformanceTracker";
 import { Timer, defaultTimer } from "../../utils/SystemTimer";
+import { CtrlProxyClient as AndroidCtrlProxyClient } from "../observe/android";
+import { logger } from "../../utils/logger";
 
 /**
  * Opens the recent apps screen using intelligent navigation detection
@@ -239,12 +241,20 @@ export class RecentApps extends BaseVisualChange {
    * @returns Recent apps result
    */
   private async executeHardwareNavigation(): Promise<RecentAppsResult> {
-    // Use hardware recent apps key (keycode 187)
-    await this.adb.executeCommand("shell input keyevent 187");
+    // Try accessibility service global action first
+    try {
+      const client = AndroidCtrlProxyClient.getInstance(this.device);
+      const result = await client.requestGlobalAction("recent", 3000);
+      if (result.success) {
+        logger.debug("[RECENT_APPS] Used accessibility service global action");
+        return { success: true, method: "hardware" };
+      }
+      logger.debug(`[RECENT_APPS] Global action failed (${result.error}), falling back to ADB`);
+    } catch {
+      // Fall through to ADB
+    }
 
-    return {
-      success: true,
-      method: "hardware"
-    };
+    await this.adb.executeCommand("shell input keyevent 187");
+    return { success: true, method: "hardware" };
   }
 }

--- a/src/features/navigation/DefaultUIStateSetup.ts
+++ b/src/features/navigation/DefaultUIStateSetup.ts
@@ -1,6 +1,7 @@
 import { BootedDevice } from "../../models";
 import { AdbClient } from "../../utils/android-cmdline-tools/AdbClient";
 import { logger } from "../../utils/logger";
+import { CtrlProxyClient as AndroidCtrlProxyClient } from "../observe/android";
 import { ToolRegistry } from "../../server/toolRegistry";
 import { NavigationEdge, UIState } from "./NavigationGraphManager";
 import { ModalState, ScrollPosition } from "../../utils/interfaces/NavigationGraph";
@@ -449,8 +450,18 @@ export class DefaultUIStateSetup implements UIStateSetup {
    * Press the back button.
    */
   private async pressBack(): Promise<void> {
+    try {
+      const client = AndroidCtrlProxyClient.getInstance(this.device);
+      const result = await client.requestGlobalAction("back", 3000);
+      if (result.success) {
+        logger.debug("[UI_STATE_SETUP] Pressed back via accessibility service");
+        return;
+      }
+    } catch {
+      // Fall through to ADB
+    }
     await this.adb.executeCommand("shell input keyevent 4");
-    logger.debug(`[UI_STATE_SETUP] Pressed back button`);
+    logger.debug("[UI_STATE_SETUP] Pressed back via ADB keyevent");
   }
 
   /**

--- a/src/features/navigation/Explore.ts
+++ b/src/features/navigation/Explore.ts
@@ -3,6 +3,7 @@ import { BaseVisualChange, ProgressCallback } from "../action/BaseVisualChange";
 import { AdbClient } from "../../utils/android-cmdline-tools/AdbClient";
 import { createGlobalPerformanceTracker, PerformanceTracker } from "../../utils/PerformanceTracker";
 import { logger } from "../../utils/logger";
+import { CtrlProxyClient as AndroidCtrlProxyClient } from "../observe/android";
 import { defaultNavigationGraphManager, type NavigationEdge, type NavigationGraphService } from "./NavigationGraphManager";
 import { ExportedGraph } from "../../utils/interfaces/NavigationGraph";
 import { TapOnElement } from "../action/TapOnElement";
@@ -766,8 +767,18 @@ export class Explore extends BaseVisualChange {
         );
       }
 
-      // Press back button
-      await this.adb.executeCommand("shell input keyevent KEYCODE_BACK");
+      // Press back button via accessibility service, fall back to ADB
+      let backSuccess = false;
+      try {
+        const client = AndroidCtrlProxyClient.getInstance(this.device);
+        const result = await client.requestGlobalAction("back", 3000);
+        backSuccess = result.success;
+      } catch {
+        // Fall through to ADB
+      }
+      if (!backSuccess) {
+        await this.adb.executeCommand("shell input keyevent KEYCODE_BACK");
+      }
       this.consecutiveBackCount++;
 
       // Wait briefly for navigation
@@ -790,8 +801,18 @@ export class Explore extends BaseVisualChange {
         );
       }
 
-      // Press home button
-      await this.adb.executeCommand("shell input keyevent KEYCODE_HOME");
+      // Press home button via accessibility service, fall back to ADB
+      let homeSuccess = false;
+      try {
+        const client = AndroidCtrlProxyClient.getInstance(this.device);
+        const result = await client.requestGlobalAction("home", 3000);
+        homeSuccess = result.success;
+      } catch {
+        // Fall through to ADB
+      }
+      if (!homeSuccess) {
+        await this.adb.executeCommand("shell input keyevent KEYCODE_HOME");
+      }
 
       // Wait for home screen
       await this.timer.sleep(2000);

--- a/src/features/navigation/NavigateTo.ts
+++ b/src/features/navigation/NavigateTo.ts
@@ -2,6 +2,7 @@ import { BootedDevice, NavigateToResult } from "../../models";
 import { AdbClientFactory, defaultAdbClientFactory } from "../../utils/android-cmdline-tools/AdbClientFactory";
 import type { AdbExecutor } from "../../utils/android-cmdline-tools/interfaces/AdbExecutor";
 import { logger } from "../../utils/logger";
+import { CtrlProxyClient as AndroidCtrlProxyClient } from "../observe/android";
 import { createGlobalPerformanceTracker } from "../../utils/PerformanceTracker";
 import { ToolRegistry } from "../../server/toolRegistry";
 import {
@@ -318,9 +319,19 @@ export class NavigateTo {
    * Press the back button as a fallback navigation action.
    */
   private async pressBack(): Promise<void> {
-    // Use ADB directly for back button
+    // Try accessibility service global action first, fall back to ADB
+    try {
+      const client = AndroidCtrlProxyClient.getInstance(this.device);
+      const result = await client.requestGlobalAction("back", 3000);
+      if (result.success) {
+        logger.debug("[NAVIGATE_TO] Pressed back via accessibility service");
+        return;
+      }
+    } catch {
+      // Fall through to ADB
+    }
     await this.adb.executeCommand("shell input keyevent 4");
-    logger.debug(`[NAVIGATE_TO] Pressed back button`);
+    logger.debug("[NAVIGATE_TO] Pressed back via ADB keyevent");
   }
 
   /**

--- a/src/features/observe/ObserveScreen.ts
+++ b/src/features/observe/ObserveScreen.ts
@@ -519,16 +519,12 @@ export class RealObserveScreen implements ObserveScreen {
         // Phase 1: Get view hierarchy first (includes screen info from accessibility service)
         perf.serial("phase1_hierarchy");
 
-        // Run view hierarchy and non-dumpsys operations in parallel
-        await Promise.all([
-          this.collectViewHierarchy(result, queryOptions, perf, skipWaitForFresh, minTimestamp, signal),
-          perf.track("wakefulness", () => this.collectWakefulness(result, signal)),
-          perf.track("backStack", () => this.collectBackStack(result, perf, signal)),
-        ]);
+        // Get view hierarchy (includes all device metadata from accessibility service)
+        await this.collectViewHierarchy(result, queryOptions, perf, skipWaitForFresh, minTimestamp, signal);
 
         perf.end();
 
-        // Use screen info from accessibility service (no dumpsys fallback)
+        // Use device metadata from accessibility service (no dumpsys fallback)
         const hierarchy = result.viewHierarchy;
         if (hierarchy?.screenWidth && hierarchy?.screenHeight) {
           result.screenSize = { width: hierarchy.screenWidth, height: hierarchy.screenHeight };
@@ -538,15 +534,60 @@ export class RealObserveScreen implements ObserveScreen {
           if (hierarchy.systemInsets) {
             result.systemInsets = hierarchy.systemInsets;
           }
-          logger.debug("[OBSERVE] Using screen info from accessibility service");
+          // Use wakefulness from accessibility service, fall back to ADB
+          if (hierarchy.wakefulness) {
+            result.wakefulness = hierarchy.wakefulness;
+          } else {
+            await perf.track("wakefulness", () => this.collectWakefulness(result, signal));
+          }
+          // Use foreground activity from accessibility service for activeWindow + backStack
+          if (hierarchy.foregroundActivity) {
+            const parts = hierarchy.foregroundActivity.split("/");
+            const packageName = parts[0];
+            const activityName = parts[1]?.startsWith(".")
+              ? packageName + parts[1]
+              : parts[1] || "";
+            result.activeWindow = {
+              appId: packageName,
+              activityName,
+              layoutSeqSum: 0
+            };
+            result.backStack = {
+              depth: 0,
+              activities: [{
+                name: activityName,
+                taskId: hierarchy.foregroundTaskId ?? -1,
+              }],
+              tasks: hierarchy.foregroundTaskId !== undefined && hierarchy.foregroundTaskId !== null ? [{
+                id: hierarchy.foregroundTaskId,
+                packageName,
+              }] : [],
+              currentActivity: {
+                name: activityName,
+                taskId: hierarchy.foregroundTaskId ?? -1,
+              },
+              currentTaskId: hierarchy.foregroundTaskId ?? -1,
+              capturedAt: Date.now(),
+              source: "control-proxy"
+            };
+          } else {
+            // Fall back to ADB for back stack + active window
+            await perf.track("backStack", () => this.collectBackStack(result, perf, signal));
+          }
+          logger.debug("[OBSERVE] Using device metadata from accessibility service");
         } else {
           logger.warn("[OBSERVE] No screen info from accessibility service - check if APK is updated");
+          // Fall back to ADB for all metadata
+          await Promise.all([
+            perf.track("wakefulness", () => this.collectWakefulness(result, signal)),
+            perf.track("backStack", () => this.collectBackStack(result, perf, signal)),
+          ]);
         }
 
         // Note: Offscreen filtering is now done in the Android accessibility service (Kotlin)
         // for better performance (avoids serializing/transferring filtered data)
 
-        // Populate activeWindow from view hierarchy packageName if available
+        // Populate activeWindow from view hierarchy packageName if not already set
         if (result.viewHierarchy?.packageName && !result.activeWindow) {
           result.activeWindow = {
             appId: result.viewHierarchy.packageName,

--- a/src/features/observe/android/CtrlProxyClient.ts
+++ b/src/features/observe/android/CtrlProxyClient.ts
@@ -878,6 +878,76 @@ export class CtrlProxyClient extends DeviceServiceClient implements CtrlProxy {
     }
   }
 
+  /**
+   * Execute a global action (back, home, recents, etc.) via the accessibility service.
+   */
+  async requestGlobalAction(
+    action: string,
+    timeoutMs: number = 5000,
+    perf: PerformanceTracker = new NoOpPerformanceTracker()
+  ): Promise<{ success: boolean; action: string; totalTimeMs: number; error?: string }> {
+    const startTime = this.timer.now();
+    try {
+      const connected = await perf.track("ensureConnection", () => this.connectWebSocket(perf));
+      if (!connected) {
+        return { success: false, action, totalTimeMs: this.timer.now() - startTime, error: "Failed to connect to accessibility service" };
+      }
+
+      const requestId = this.requestManager.generateId("global_action");
+      const promise = this.requestManager.register<{ success: boolean; action: string; totalTimeMs: number; error?: string }>(
+        requestId, "global_action", timeoutMs,
+        (_id, _type, timeout) => ({ success: false, action, totalTimeMs: this.timer.now() - startTime, error: `Global action timeout after ${timeout}ms` })
+      );
+
+      if (!this.ws || this.ws.readyState !== WebSocket.OPEN) {
+        throw new Error("WebSocket not connected");
+      }
+      this.ws.send(JSON.stringify({ type: "request_global_action", requestId, action }));
+      logger.debug(`[CTRL_PROXY] Sent global action request (requestId: ${requestId}, action: ${action})`);
+
+      return await promise;
+    } catch (error) {
+      return { success: false, action, totalTimeMs: this.timer.now() - startTime, error: `${error}` };
+    }
+  }
+
+  /**
+   * Request device metadata from the accessibility service.
+   */
+  async requestDeviceInfo(
+    timeoutMs: number = 5000,
+    perf: PerformanceTracker = new NoOpPerformanceTracker()
+  ): Promise<{
+    success: boolean; screenWidth?: number; screenHeight?: number; density?: number;
+    rotation?: number; sdkInt?: number; deviceModel?: string; isEmulator?: boolean;
+    wakefulness?: string; foregroundActivity?: string; foregroundTaskId?: number;
+    totalTimeMs: number; error?: string;
+  }> {
+    const startTime = this.timer.now();
+    try {
+      const connected = await perf.track("ensureConnection", () => this.connectWebSocket(perf));
+      if (!connected) {
+        return { success: false, totalTimeMs: this.timer.now() - startTime, error: "Failed to connect to accessibility service" };
+      }
+
+      const requestId = this.requestManager.generateId("device_info");
+      const promise = this.requestManager.register<any>(
+        requestId, "device_info", timeoutMs,
+        (_id, _type, timeout) => ({ success: false, totalTimeMs: this.timer.now() - startTime, error: `Device info timeout after ${timeout}ms` })
+      );
+
+      if (!this.ws || this.ws.readyState !== WebSocket.OPEN) {
+        throw new Error("WebSocket not connected");
+      }
+      this.ws.send(JSON.stringify({ type: "request_device_info", requestId }));
+      logger.debug(`[CTRL_PROXY] Sent device info request (requestId: ${requestId})`);
+
+      return await promise;
+    } catch (error) {
+      return { success: false, totalTimeMs: this.timer.now() - startTime, error: `${error}` };
+    }
+  }
+
   async requestScreenshot(timeoutMs: number = 5000, perf: PerformanceTracker = new NoOpPerformanceTracker()): Promise<ScreenshotResult> {
     const startTime = this.timer.now();
 
@@ -1306,6 +1376,30 @@ export class CtrlProxyClient extends DeviceServiceClient implements CtrlProxy {
         this.requestManager.resolve<HighlightOperationResult>(highlightMessage.requestId, {
           success: highlightMessage.success ?? false, error: highlightMessage.error,
           requestId: highlightMessage.requestId, timestamp: highlightMessage.timestamp
+        });
+      }
+
+      // Handle global action result
+      if (message.type === "global_action_result" && message.requestId) {
+        const actionMessage = message as any;
+        this.requestManager.resolve(message.requestId, {
+          success: actionMessage.success ?? false, action: actionMessage.action,
+          totalTimeMs: actionMessage.totalTimeMs ?? 0, error: actionMessage.error
+        });
+      }
+
+      // Handle device info result
+      if (message.type === "device_info_result" && message.requestId) {
+        const infoMessage = message as any;
+        this.requestManager.resolve(message.requestId, {
+          success: infoMessage.success ?? false,
+          screenWidth: infoMessage.screenWidth, screenHeight: infoMessage.screenHeight,
+          density: infoMessage.density, rotation: infoMessage.rotation,
+          sdkInt: infoMessage.sdkInt, deviceModel: infoMessage.deviceModel,
+          isEmulator: infoMessage.isEmulator, wakefulness: infoMessage.wakefulness,
+          foregroundActivity: infoMessage.foregroundActivity,
+          foregroundTaskId: infoMessage.foregroundTaskId,
+          totalTimeMs: infoMessage.totalTimeMs ?? 0, error: infoMessage.error
         });
       }
 

--- a/src/features/observe/android/CtrlProxyHierarchy.ts
+++ b/src/features/observe/android/CtrlProxyHierarchy.ts
@@ -402,7 +402,14 @@ export class CtrlProxyHierarchy {
         "screenWidth": accessibilityHierarchy.screenWidth,
         "screenHeight": accessibilityHierarchy.screenHeight,
         "rotation": accessibilityHierarchy.rotation,
-        "systemInsets": accessibilityHierarchy.systemInsets
+        "systemInsets": accessibilityHierarchy.systemInsets,
+        "wakefulness": accessibilityHierarchy.wakefulness,
+        "foregroundActivity": accessibilityHierarchy.foregroundActivity,
+        "foregroundTaskId": accessibilityHierarchy.foregroundTaskId,
+        "density": accessibilityHierarchy.density,
+        "sdkInt": accessibilityHierarchy.sdkInt,
+        "deviceModel": accessibilityHierarchy.deviceModel,
+        "isEmulator": accessibilityHierarchy.isEmulator
       };
 
       const duration = this.context.timer.now() - startTime;

--- a/src/features/observe/android/types.ts
+++ b/src/features/observe/android/types.ts
@@ -94,6 +94,20 @@ export interface AccessibilityHierarchy {
   rotation?: number;
   /** System insets (status bar, nav bar, gesture insets) */
   systemInsets?: { top: number; bottom: number; left: number; right: number };
+  /** Device wakefulness: "Awake", "Asleep", or "Dozing" */
+  wakefulness?: "Awake" | "Asleep" | "Dozing";
+  /** Foreground activity component name, e.g. "com.example.app/.MainActivity" */
+  foregroundActivity?: string;
+  /** Task ID of the foreground activity */
+  foregroundTaskId?: number;
+  /** Display density in DPI */
+  density?: number;
+  /** Android API level (e.g. 34) */
+  sdkInt?: number;
+  /** Device model (e.g. "Pixel 8") */
+  deviceModel?: string;
+  /** Whether running on an emulator */
+  isEmulator?: boolean;
 }
 
 /**

--- a/src/features/observe/interfaces/DeviceMetadataSource.ts
+++ b/src/features/observe/interfaces/DeviceMetadataSource.ts
@@ -1,0 +1,28 @@
+/**
+ * Device metadata available from the CtrlProxy accessibility service,
+ * eliminating the need for individual ADB shell commands.
+ */
+export interface DeviceMetadata {
+  screenWidth: number;
+  screenHeight: number;
+  density: number;
+  rotation: number;
+  sdkInt: number;
+  deviceModel: string;
+  isEmulator: boolean;
+  wakefulness: "Awake" | "Asleep" | "Dozing";
+  foregroundActivity?: string;
+  foregroundTaskId?: number;
+}
+
+/**
+ * Source for device metadata. Can be backed by CtrlProxy WebSocket
+ * or fall back to ADB shell commands.
+ */
+export interface DeviceMetadataSource {
+  /**
+   * Get device metadata from the on-device service.
+   * @returns Device metadata or null if the service is unavailable.
+   */
+  getDeviceMetadata(signal?: AbortSignal): Promise<DeviceMetadata | null>;
+}

--- a/src/features/observe/interfaces/GlobalActionSource.ts
+++ b/src/features/observe/interfaces/GlobalActionSource.ts
@@ -1,0 +1,25 @@
+/**
+ * Result of a global action request.
+ */
+export interface GlobalActionResult {
+  success: boolean;
+  action: string;
+  error?: string;
+}
+
+/**
+ * Source for executing global actions (back, home, recents) via the
+ * accessibility service, bypassing ADB shell input keyevent.
+ */
+export interface GlobalActionSource {
+  /**
+   * Execute a global action on the device.
+   * @param action - One of: "back", "home", "recent", "notifications", "power_dialog", "lock_screen"
+   * @param timeoutMs - Timeout for the request in milliseconds
+   * @returns Result of the action
+   */
+  executeGlobalAction(
+    action: string,
+    timeoutMs?: number
+  ): Promise<GlobalActionResult>;
+}

--- a/src/features/observe/interfaces/index.ts
+++ b/src/features/observe/interfaces/index.ts
@@ -12,3 +12,5 @@ export type { BackStack } from "./BackStack";
 export type { PredictiveUIState } from "./PredictiveUIState";
 export type { AwaitIdle, UiStabilityState } from "./AwaitIdle";
 export type { ScreenshotService } from "./ScreenshotService";
+export type { DeviceMetadataSource, DeviceMetadata } from "./DeviceMetadataSource";
+export type { GlobalActionSource, GlobalActionResult } from "./GlobalActionSource";

--- a/src/models/ViewHierarchyResult.ts
+++ b/src/models/ViewHierarchyResult.ts
@@ -43,6 +43,20 @@ export interface ViewHierarchyResult {
   rotation?: number;
   /** System insets (status bar, nav bar, gesture insets) */
   systemInsets?: { top: number; bottom: number; left: number; right: number };
+  /** Device wakefulness: "Awake", "Asleep", or "Dozing" (Android only, from accessibility service) */
+  wakefulness?: "Awake" | "Asleep" | "Dozing";
+  /** Foreground activity component name, e.g. "com.example.app/.MainActivity" (Android only) */
+  foregroundActivity?: string;
+  /** Task ID of the foreground activity (Android only) */
+  foregroundTaskId?: number;
+  /** Display density in DPI (Android only, from accessibility service) */
+  density?: number;
+  /** Android API level (Android only, from accessibility service) */
+  sdkInt?: number;
+  /** Device model (Android only, from accessibility service) */
+  deviceModel?: string;
+  /** Whether running on an emulator (Android only, from accessibility service) */
+  isEmulator?: boolean;
 }
 
 export interface Hierarchy {

--- a/test/fakes/FakeDeviceMetadataSource.test.ts
+++ b/test/fakes/FakeDeviceMetadataSource.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from "bun:test";
+import { FakeDeviceMetadataSource } from "./FakeDeviceMetadataSource";
+import type { DeviceMetadata } from "../../src/features/observe/interfaces/DeviceMetadataSource";
+
+describe("FakeDeviceMetadataSource", () => {
+  const sampleMetadata: DeviceMetadata = {
+    screenWidth: 1080,
+    screenHeight: 2400,
+    density: 440,
+    rotation: 0,
+    sdkInt: 34,
+    deviceModel: "Pixel 8",
+    isEmulator: false,
+    wakefulness: "Awake",
+    foregroundActivity: "com.example.app/.MainActivity",
+    foregroundTaskId: 42,
+  };
+
+  it("returns null by default", async () => {
+    const fake = new FakeDeviceMetadataSource();
+    expect(await fake.getDeviceMetadata()).toBeNull();
+  });
+
+  it("returns configured metadata", async () => {
+    const fake = new FakeDeviceMetadataSource();
+    fake.setMetadata(sampleMetadata);
+    const result = await fake.getDeviceMetadata();
+    expect(result).toEqual(sampleMetadata);
+  });
+
+  it("records call count", async () => {
+    const fake = new FakeDeviceMetadataSource();
+    expect(fake.getCallCount()).toBe(0);
+    await fake.getDeviceMetadata();
+    await fake.getDeviceMetadata();
+    expect(fake.getCallCount()).toBe(2);
+  });
+
+  it("resets recorded calls", async () => {
+    const fake = new FakeDeviceMetadataSource();
+    await fake.getDeviceMetadata();
+    fake.reset();
+    expect(fake.getCallCount()).toBe(0);
+  });
+
+  it("can switch from null to metadata", async () => {
+    const fake = new FakeDeviceMetadataSource();
+    expect(await fake.getDeviceMetadata()).toBeNull();
+    fake.setMetadata(sampleMetadata);
+    expect(await fake.getDeviceMetadata()).toEqual(sampleMetadata);
+  });
+
+  it("can switch back to null", async () => {
+    const fake = new FakeDeviceMetadataSource();
+    fake.setMetadata(sampleMetadata);
+    fake.setMetadata(null);
+    expect(await fake.getDeviceMetadata()).toBeNull();
+  });
+});

--- a/test/fakes/FakeDeviceMetadataSource.ts
+++ b/test/fakes/FakeDeviceMetadataSource.ts
@@ -1,0 +1,33 @@
+import type {
+  DeviceMetadataSource,
+  DeviceMetadata,
+} from "../../src/features/observe/interfaces/DeviceMetadataSource";
+
+/**
+ * Fake implementation of DeviceMetadataSource for testing.
+ * Returns configurable responses and records all calls.
+ */
+export class FakeDeviceMetadataSource implements DeviceMetadataSource {
+  private calls: { signal?: AbortSignal }[] = [];
+  private configuredMetadata: DeviceMetadata | null = null;
+
+  async getDeviceMetadata(signal?: AbortSignal): Promise<DeviceMetadata | null> {
+    this.calls.push({ signal });
+    return this.configuredMetadata;
+  }
+
+  /** Configure the metadata that will be returned. */
+  setMetadata(metadata: DeviceMetadata | null): void {
+    this.configuredMetadata = metadata;
+  }
+
+  /** Get the number of calls made. */
+  getCallCount(): number {
+    return this.calls.length;
+  }
+
+  /** Reset recorded calls. */
+  reset(): void {
+    this.calls = [];
+  }
+}

--- a/test/fakes/FakeGlobalActionSource.test.ts
+++ b/test/fakes/FakeGlobalActionSource.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from "bun:test";
+import { FakeGlobalActionSource } from "./FakeGlobalActionSource";
+
+describe("FakeGlobalActionSource", () => {
+  it("returns success by default", async () => {
+    const fake = new FakeGlobalActionSource();
+    const result = await fake.executeGlobalAction("home");
+    expect(result.success).toBe(true);
+    expect(result.action).toBe("home");
+  });
+
+  it("records calls", async () => {
+    const fake = new FakeGlobalActionSource();
+    await fake.executeGlobalAction("back", 3000);
+    await fake.executeGlobalAction("home");
+    expect(fake.getCallCount()).toBe(2);
+    expect(fake.getCalls()).toEqual([
+      { action: "back", timeoutMs: 3000 },
+      { action: "home", timeoutMs: undefined },
+    ]);
+  });
+
+  it("returns last action", async () => {
+    const fake = new FakeGlobalActionSource();
+    await fake.executeGlobalAction("back");
+    await fake.executeGlobalAction("recent");
+    expect(fake.getLastAction()).toBe("recent");
+  });
+
+  it("returns failure when configured", async () => {
+    const fake = new FakeGlobalActionSource();
+    fake.setShouldFail(true);
+    const result = await fake.executeGlobalAction("home");
+    expect(result.success).toBe(false);
+    expect(result.error).toBe("Fake failure");
+    expect(result.action).toBe("home");
+  });
+
+  it("resets recorded calls", async () => {
+    const fake = new FakeGlobalActionSource();
+    await fake.executeGlobalAction("back");
+    fake.reset();
+    expect(fake.getCallCount()).toBe(0);
+    expect(fake.getLastAction()).toBeUndefined();
+  });
+
+  it("uses action from call, not from configured result", async () => {
+    const fake = new FakeGlobalActionSource();
+    fake.setResult({ success: true, action: "configured" });
+    const result = await fake.executeGlobalAction("actual");
+    expect(result.action).toBe("actual");
+  });
+});

--- a/test/fakes/FakeGlobalActionSource.ts
+++ b/test/fakes/FakeGlobalActionSource.ts
@@ -1,0 +1,58 @@
+import type {
+  GlobalActionSource,
+  GlobalActionResult,
+} from "../../src/features/observe/interfaces/GlobalActionSource";
+
+/**
+ * Fake implementation of GlobalActionSource for testing.
+ * Returns configurable responses and records all calls.
+ */
+export class FakeGlobalActionSource implements GlobalActionSource {
+  private calls: { action: string; timeoutMs?: number }[] = [];
+  private configuredResult: GlobalActionResult = {
+    success: true,
+    action: "",
+  };
+  private shouldFail = false;
+
+  async executeGlobalAction(
+    action: string,
+    timeoutMs?: number
+  ): Promise<GlobalActionResult> {
+    this.calls.push({ action, timeoutMs });
+    if (this.shouldFail) {
+      return { success: false, action, error: "Fake failure" };
+    }
+    return { ...this.configuredResult, action };
+  }
+
+  /** Configure the result that will be returned. */
+  setResult(result: GlobalActionResult): void {
+    this.configuredResult = result;
+  }
+
+  /** Configure failure mode. */
+  setShouldFail(fail: boolean): void {
+    this.shouldFail = fail;
+  }
+
+  /** Get the recorded calls. */
+  getCalls(): { action: string; timeoutMs?: number }[] {
+    return [...this.calls];
+  }
+
+  /** Get the number of calls made. */
+  getCallCount(): number {
+    return this.calls.length;
+  }
+
+  /** Get the last action requested. */
+  getLastAction(): string | undefined {
+    return this.calls[this.calls.length - 1]?.action;
+  }
+
+  /** Reset recorded calls. */
+  reset(): void {
+    this.calls = [];
+  }
+}


### PR DESCRIPTION
## Summary
- Bundle device metadata (wakefulness, foreground activity, density, SDK level, model, emulator detection) into the CtrlProxy hierarchy WebSocket response, eliminating per-observe ADB `dumpsys`/`getprop` round-trips
- Add `request_global_action` and `request_device_info` WebSocket endpoints to CtrlProxy for back/home/recents via accessibility service `performGlobalAction`
- Wire global actions into HomeScreen, PressButton, RecentApps, NavigateTo, DefaultUIStateSetup, and Explore with ADB fallback
- Add `DeviceMetadataSource` and `GlobalActionSource` interfaces with fakes and tests

## Test plan
- [x] All 3008 TypeScript tests pass
- [x] Lint passes
- [x] Build passes
- [x] Kotlin compiles (`compileDebugKotlin` succeeds)
- [ ] Manual test on Android device with CtrlProxy connected
- [ ] Verify ADB fallback works when CtrlProxy is disconnected

🤖 Generated with [Claude Code](https://claude.com/claude-code)