### PR TITLE
fix: replace base64 screenshot with file path in bugReport output

### DIFF
--- a/src/features/debug/BugReport.ts
+++ b/src/features/debug/BugReport.ts
@@ -336,9 +336,7 @@ export class BugReport {
     try {
       const screenshot = await this.takeScreenshot.execute();
       if (screenshot && screenshot.success && screenshot.path) {
-        // Read the screenshot file and convert to base64
-        const imageBuffer = await fsPromises.readFile(screenshot.path);
-        result.screenshot = imageBuffer.toString("base64");
+        result.screenshotPath = screenshot.path;
       }
     } catch (error) {
       result.errors?.push(`Failed to get screenshot: ${error}`);

--- a/src/models/BugReportResult.ts
+++ b/src/models/BugReportResult.ts
@@ -109,9 +109,9 @@ export interface BugReportResult {
   };
 
   /**
-   * Screenshot as base64 encoded image
+   * File path to saved screenshot image
    */
-  screenshot?: string;
+  screenshotPath?: string;
 
   /**
    * System window state from dumpsys


### PR DESCRIPTION
## Summary
- The `bugReport` MCP tool was embedding ~205KB of base64-encoded PNG screenshot directly in the JSON response, making it too large for MCP clients to parse
- Replaced the inline base64 `screenshot` field with a `screenshotPath` field that references the already-saved file on disk
- Reduces bugReport response size by ~89%

## Test Plan
- [x] All 2996 tests pass
- [x] Build succeeds
- [x] BugReport-specific tests (12) pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)