### PR TITLE
fix: preserve app view hierarchy when keyboard is open

### DIFF
--- a/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/ViewHierarchyExtractor.kt
+++ b/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/ViewHierarchyExtractor.kt
@@ -198,6 +198,11 @@ class ViewHierarchyExtractor(private val recompositionStore: RecompositionStore?
     var activeWindowHasNullRoot = false
     var hasApplicationWindow = false
 
+    // Detect if an IME (keyboard) window is present
+    // When IME is visible, Android may mark app window nodes as isVisibleToUser=false
+    // even though they are physically visible above the keyboard
+    val hasImeWindow = windows.any { it.type == AccessibilityWindowInfo.TYPE_INPUT_METHOD }
+
     // Extract from each window
     for (window in windows) {
       try {
@@ -250,6 +255,13 @@ class ViewHierarchyExtractor(private val recompositionStore: RecompositionStore?
             )
         )
 
+        // When IME is present and this is the active app window, skip isVisibleToUser
+        // filtering. Android marks app nodes as not visible when an IME window overlays them,
+        // but they are still physically on screen above the keyboard.
+        val skipVisibilityFilter =
+            hasImeWindow &&
+                window.isActive &&
+                window.type == AccessibilityWindowInfo.TYPE_APPLICATION
         val element =
             extractNodeInfo(
                 rootNode,
@@ -258,6 +270,7 @@ class ViewHierarchyExtractor(private val recompositionStore: RecompositionStore?
                 screenDimensions,
                 dedupeTextContentDesc,
                 accessibilityFocusedNode,
+                skipVisibilityFilter,
             )
         // Skip optimization if disableAllFiltering is true
         val processedElement =
@@ -318,6 +331,7 @@ class ViewHierarchyExtractor(private val recompositionStore: RecompositionStore?
               screenDimensions,
               dedupeTextContentDesc,
               accessibilityFocusedNode,
+              skipVisibilityFilter = hasImeWindow,
           )
       // Skip optimization if disableAllFiltering is true
       mainHierarchy =
@@ -361,7 +375,7 @@ class ViewHierarchyExtractor(private val recompositionStore: RecompositionStore?
                     occlusionInfo,
                     windowEntry.windowId,
                     path = "",
-                    isRoot = false,
+                    isRoot = true,
                 )
             hierarchy?.let { windowEntry.copy(hierarchy = it) }
           }
@@ -534,6 +548,7 @@ class ViewHierarchyExtractor(private val recompositionStore: RecompositionStore?
       screenDimensions: ScreenDimensions? = null,
       dedupeTextContentDesc: Boolean = true,
       accessibilityFocusedNode: AccessibilityNodeInfo? = null,
+      skipVisibilityFilter: Boolean = false,
   ): UIElementInfo? {
     if (depth > MAX_DEPTH) {
       return null
@@ -557,7 +572,9 @@ class ViewHierarchyExtractor(private val recompositionStore: RecompositionStore?
       }
 
       // Filter nodes not actually visible to the user
-      if (!node.isVisibleToUser) {
+      // Skip this filter when IME is present for the active app window — Android incorrectly
+      // marks app nodes as not visible when an IME window overlays them
+      if (!skipVisibilityFilter && !node.isVisibleToUser) {
         return null
       }
 
@@ -575,6 +592,7 @@ class ViewHierarchyExtractor(private val recompositionStore: RecompositionStore?
                   screenDimensions,
                   dedupeTextContentDesc,
                   accessibilityFocusedNode,
+                  skipVisibilityFilter,
               )
           if (childInfo != null) {
             children.add(childInfo)

--- a/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/ViewHierarchyExtractorTest.kt
+++ b/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/ViewHierarchyExtractorTest.kt
@@ -462,6 +462,112 @@ class ViewHierarchyExtractorTest {
     assertNotNull(findElementByResourceId(filtered, "root-child"))
   }
 
+  @Test
+  fun `keyboard window does not remove app window hierarchy via occlusion`() {
+    // Simulate the keyboard-open scenario from issue #1488:
+    // App window covers full screen [0,0][1280,2856]
+    // Keyboard (IME) window covers bottom half [0,1395][1280,2856]
+    // App elements above the keyboard should NOT be removed
+    val toolbar =
+        elementWithBounds(resourceId = "toolbar", bounds = bounds(0, 156, 1280, 400))
+    val editText =
+        elementWithBounds(resourceId = "edit-text", bounds = bounds(0, 400, 1280, 500))
+    val appRoot =
+        elementWithBounds(
+            resourceId = "app-root",
+            bounds = bounds(0, 0, 1280, 2856),
+            children = listOf(toolbar, editText),
+        )
+    val keyboardRoot =
+        elementWithBounds(resourceId = "keyboard", bounds = bounds(0, 1395, 1280, 2856))
+
+    val appEntry =
+        extractor.createWindowEntry(
+            windowId = 46,
+            windowLayer = 0,
+            hierarchy = appRoot,
+            windowType = "application",
+            isActive = true,
+            isFocused = true,
+        )
+    val imeEntry =
+        extractor.createWindowEntry(
+            windowId = 31,
+            windowLayer = 1,
+            hierarchy = keyboardRoot,
+            windowType = "input_method",
+            isActive = false,
+            isFocused = false,
+        )
+    val occlusionInfo = extractor.buildOcclusionInfoForTest(listOf(appEntry, imeEntry))
+    val filtered =
+        extractor.filterOccludedHierarchyForTest(
+            element = appRoot,
+            occlusionInfo = occlusionInfo,
+            windowKey = 46,
+            path = "",
+            isRoot = true,
+        )
+
+    assertNotNull("App root should not be removed by keyboard occlusion", filtered)
+    assertNotNull(
+        "Toolbar above keyboard should be preserved",
+        findElementByResourceId(filtered!!, "toolbar"),
+    )
+    assertNotNull(
+        "Edit text above keyboard should be preserved",
+        findElementByResourceId(filtered, "edit-text"),
+    )
+  }
+
+  @Test
+  fun `keyboard window occlusion marks elements behind keyboard as hidden`() {
+    // Element fully behind the keyboard should be marked hidden
+    val bottomElement =
+        elementWithBounds(resourceId = "bottom-item", bounds = bounds(0, 1400, 1280, 2800))
+    val appRoot =
+        elementWithBounds(
+            resourceId = "app-root",
+            bounds = bounds(0, 0, 1280, 2856),
+            children = listOf(bottomElement),
+        )
+    val keyboardRoot =
+        elementWithBounds(resourceId = "keyboard", bounds = bounds(0, 1395, 1280, 2856))
+
+    val appEntry =
+        extractor.createWindowEntry(
+            windowId = 46,
+            windowLayer = 0,
+            hierarchy = appRoot,
+            isActive = true,
+            isFocused = true,
+        )
+    val imeEntry =
+        extractor.createWindowEntry(
+            windowId = 31,
+            windowLayer = 1,
+            hierarchy = keyboardRoot,
+            isActive = false,
+            isFocused = false,
+        )
+    val occlusionInfo = extractor.buildOcclusionInfoForTest(listOf(appEntry, imeEntry))
+    val filtered =
+        extractor.filterOccludedHierarchyForTest(
+            element = appRoot,
+            occlusionInfo = occlusionInfo,
+            windowKey = 46,
+            path = "",
+            isRoot = true,
+        )
+
+    assertNotNull("App root should survive as isRoot=true", filtered)
+    // The bottom element is fully behind the keyboard, so it should be removed
+    assertNull(
+        "Element fully behind keyboard should be removed",
+        findElementByResourceId(filtered!!, "bottom-item"),
+    )
+  }
+
   // MARK: - Node Relationship Tests
 
   @Test


### PR DESCRIPTION
## Summary
- When the Android soft keyboard is open, the accessibility framework marks app window nodes as `isVisibleToUser=false`, causing the entire app hierarchy to disappear from observe results
- Skip `isVisibleToUser` filtering for the active app window when an IME window is present — the occlusion filter still properly handles elements behind the keyboard
- Fix `isRoot` parameter in occlusion filter (was hardcoded `false`, should be `true` for window roots) to prevent window root elements from being completely removed

## Test Plan
- [x] Added test: keyboard window does not remove app window hierarchy via occlusion
- [x] Added test: keyboard window occlusion marks elements behind keyboard as hidden
- [x] All existing ViewHierarchyExtractor tests pass
- [x] `control-proxy:compileDebugKotlin` builds successfully

Closes #1488

🤖 Generated with [Claude Code](https://claude.com/claude-code)