### PR TITLE
fix: gate IME visibility bypass on extractable keyboard windows

### DIFF
--- a/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/ViewHierarchyExtractor.kt
+++ b/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/ViewHierarchyExtractor.kt
@@ -198,10 +198,15 @@ class ViewHierarchyExtractor(private val recompositionStore: RecompositionStore?
     var activeWindowHasNullRoot = false
     var hasApplicationWindow = false
 
-    // Detect if an IME (keyboard) window is present
+    // Detect if an IME (keyboard) window with an extractable root is present.
     // When IME is visible, Android may mark app window nodes as isVisibleToUser=false
-    // even though they are physically visible above the keyboard
-    val hasImeWindow = windows.any { it.type == AccessibilityWindowInfo.TYPE_INPUT_METHOD }
+    // even though they are physically visible above the keyboard.
+    // Only bypass visibility filtering when the IME window has a root node, because that
+    // root contributes occlusion nodes that will properly hide elements behind the keyboard.
+    // If the IME window has a null root, it cannot participate in occlusion and we must keep
+    // the isVisibleToUser filter to avoid exposing non-interactable elements under the keyboard.
+    val hasImeWindow =
+        windows.any { it.type == AccessibilityWindowInfo.TYPE_INPUT_METHOD && it.root != null }
 
     // Extract from each window
     for (window in windows) {


### PR DESCRIPTION
## Summary
- Follow-up to #1496 — gates the `isVisibleToUser` bypass on IME windows that have a non-null root node
- If the IME window has `root == null`, it gets skipped during extraction and never contributes occlusion nodes. Without this gate, the visibility bypass would expose non-interactable elements under the keyboard with no occlusion to compensate
- Addresses review feedback from #1496

## Test Plan
- [x] All ViewHierarchyExtractor tests pass
- [x] `control-proxy:compileDebugKotlin` builds successfully

Closes #1488

🤖 Generated with [Claude Code](https://claude.com/claude-code)