### PR TITLE
fix: return null from getForegroundActivity when class name unavailable

### DIFF
--- a/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/CtrlProxy.kt
+++ b/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/CtrlProxy.kt
@@ -1224,9 +1224,9 @@ class CtrlProxy : AccessibilityService() {
           className
         }
         "$rootPackage/$shortName"
-      } else if (rootPackage != null) {
-        rootPackage
       } else {
+        // Don't return package-only value — it produces an empty activityName
+        // in ObserveScreen and prevents the ADB fallback from filling the real one
         null
       }
     } catch (e: Exception) {


### PR DESCRIPTION
## Summary
- Return `null` from `getForegroundActivity()` when `lastWindowClassName` is not yet populated (e.g. early after service start or missed `TYPE_WINDOW_STATE_CHANGED` events)
- Previously returned just the package name, which caused `ObserveScreen` to set `activityName = ""` and skip the ADB fallback that would fill the real activity name
- Also includes prior PR feedback fixes: fast-fail global actions when not connected, pass injected ADB transport, replace restricted `getRunningTasks` API, remove fake back stack synthesis

## Test plan
- [x] All 3008 tests pass
- [x] Lint and build clean
- [ ] Verify foreground activity falls back to ADB when class name is unavailable

🤖 Generated with [Claude Code](https://claude.com/claude-code)