### PR TITLE
fix: add deviceId to tool schemas to prevent plan executor validation failures

### DIFF
--- a/src/server/toolSchemaHelpers.ts
+++ b/src/server/toolSchemaHelpers.ts
@@ -29,14 +29,6 @@ function addDeviceLabelToSchema<T extends z.ZodObject<any>>(schema: T): z.ZodObj
 /**
  * Helper to add deviceId field to tool schemas.
  *
- * The plan executor injects deviceId into steps with requiresDevice=true.
- * Tools with strict schemas must explicitly declare deviceId to avoid
- * validation failures when the plan executor injects it.
- */
-function addDeviceIdToSchema<T extends z.ZodObject<any>>(schema: T): z.ZodObject<any> {
-/**
- * Helper to add deviceId field to tool schemas.
- *
  * Authored plans should prefer device labels (`device`) rather than concrete
  * device IDs, because runtime device IDs are not known ahead of execution.
  *
@@ -45,6 +37,7 @@ function addDeviceIdToSchema<T extends z.ZodObject<any>>(schema: T): z.ZodObject
  * declare deviceId to avoid validation failures for that internal injection.
  */
 function addDeviceIdToSchema<T extends z.ZodObject<any>>(schema: T): z.ZodObject<any> {
+  return schema.extend({
     deviceId: z.string().optional().describe("Device identifier for targeting a specific device"),
   }) as z.ZodObject<any>;
 }

--- a/test/server/toolSchemaHelpers.test.ts
+++ b/test/server/toolSchemaHelpers.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, test } from "bun:test";
+import { z } from "zod";
+import { addDeviceTargetingToSchema } from "../../src/server/toolSchemaHelpers";
+
+describe("addDeviceTargetingToSchema", () => {
+  const baseSchema = z.object({
+    bundleId: z.string(),
+  }).strict();
+
+  const extended = addDeviceTargetingToSchema(baseSchema);
+
+  test("accepts base fields without device targeting", () => {
+    const result = extended.safeParse({ bundleId: "com.example.app" });
+    expect(result.success).toBe(true);
+  });
+
+  test("accepts deviceId injected by plan executor", () => {
+    const result = extended.safeParse({
+      bundleId: "com.example.app",
+      deviceId: "emulator-5554",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  test("accepts device label for multi-device plans", () => {
+    const result = extended.safeParse({
+      bundleId: "com.example.app",
+      device: "A",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  test("accepts sessionUuid for session-based targeting", () => {
+    const result = extended.safeParse({
+      bundleId: "com.example.app",
+      sessionUuid: "abc-123",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  test("accepts all device targeting fields together", () => {
+    const result = extended.safeParse({
+      bundleId: "com.example.app",
+      deviceId: "emulator-5554",
+      device: "A",
+      sessionUuid: "abc-123",
+      keepScreenAwake: true,
+    });
+    expect(result.success).toBe(true);
+  });
+
+  test("rejects unknown fields not in base or device targeting", () => {
+    const result = extended.safeParse({
+      bundleId: "com.example.app",
+      unknownField: "surprise",
+    });
+    expect(result.success).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

- The plan executor injects `deviceId` into step params for tools with `requiresDevice=true`
- Tools using strict Zod schemas (e.g. `tapOn`) reject the undeclared `deviceId` key, causing plan execution to fail with a validation error
- Add `addDeviceIdToSchema()` helper and wire it into `addDeviceTargetingToSchema()` so all tools explicitly declare `deviceId` as an optional field

## Test plan

- [x] Verified `tapOn` no longer rejects `deviceId` param when called via plan executor
- [x] Existing tool behavior unchanged (deviceId is optional)

🤖 Generated with [Claude Code](https://claude.com/claude-code)