### PR TITLE
chore: update CtrlProxy iOS IPA SHA256

### DIFF
--- a/src/constants/release.ts
+++ b/src/constants/release.ts
@@ -31,6 +31,6 @@ export const IOS_CTRL_PROXY_RELEASE_VERSION: string = "latest";
 export const IOS_CTRL_PROXY_IPA_URL: string = IOS_CTRL_PROXY_RELEASE_VERSION === "latest"
   ? "https://github.com/kaeawc/auto-mobile/releases/latest/download/control-proxy.ipa"
   : `https://github.com/kaeawc/auto-mobile/releases/download/v${IOS_CTRL_PROXY_RELEASE_VERSION}/control-proxy.ipa`;
-export const IOS_CTRL_PROXY_SHA256_CHECKSUM: string = "d210ae293eaaa554e66ee2b509946eefd7c3e8946077329ab890f34073eaee47"; // Empty = skip verification (local dev only)
+export const IOS_CTRL_PROXY_SHA256_CHECKSUM: string = "e0b620d851de65c2875b6a2123c8d035d119a618a32105046f4b6d37812f83a1"; // Empty = skip verification (local dev only)
 export const IOS_CTRL_PROXY_APP_HASH: string = ""; // Hash of CtrlProxyApp.app (device build), empty = skip verification
 export const IOS_CTRL_PROXY_RUNNER_SHA256: string = ""; // SHA256 of runner binary (CtrlProxyUITests-Runner), empty = skip verification


### PR DESCRIPTION
## Automated Checksum Update

The nightly build produced artifacts with updated SHA256 checksums.

| Artifact | Previous | New | Changed |
|----------|----------|-----|---------|
| **APK** | `e67d62f7e56fe926e05f7f14d31396d9b27aa0975b0dc2c6c2456cde3eced548` | `e67d62f7e56fe926e05f7f14d31396d9b27aa0975b0dc2c6c2456cde3eced548` | No |
| **IPA** | `d210ae293eaaa554e66ee2b509946eefd7c3e8946077329ab890f34073eaee47` | `e0b620d851de65c2875b6a2123c8d035d119a618a32105046f4b6d37812f83a1` | ✅ Yes |

### Why did this happen?

SHA256 checksums change when any of these change:
- Source code in `android/control-proxy/src/` or `ios/control-proxy/`
- Build configuration (`build.gradle.kts` or `project.yml`)
- Dependencies or SDK versions

### What to do

1. Review this PR to ensure the changes are expected
2. Merge when ready
3. Future releases will use these checksums for artifact verification

---
Auto-generated by the `nightly` workflow