### PR TITLE
fix: telemetry push server startup, deviceId filtering, and context race

### DIFF
--- a/android/ide-plugin/src/main/kotlin/dev/jasonpearson/automobile/ide/AutoMobileToolWindowContent.kt
+++ b/android/ide-plugin/src/main/kotlin/dev/jasonpearson/automobile/ide/AutoMobileToolWindowContent.kt
@@ -400,8 +400,8 @@ fun AutoMobileToolWindowContent() {
               failuresPushClient = failClient
 
               telClient = TelemetryPushSocketClient()
-              LOG.info("Connecting telemetry push client")
-              telClient.connect()
+              LOG.info("Connecting telemetry push client for device: $deviceId")
+              telClient.connect(deviceId = deviceId)
               telemetryPushClient = telClient
           }
       }

--- a/android/ide-plugin/src/main/kotlin/dev/jasonpearson/automobile/ide/daemon/FakeTelemetryPushClient.kt
+++ b/android/ide-plugin/src/main/kotlin/dev/jasonpearson/automobile/ide/daemon/FakeTelemetryPushClient.kt
@@ -24,9 +24,11 @@ class FakeTelemetryPushClient : TelemetryPushClient {
     private var connected = false
     private var connectCallCount = 0
     private var disconnectCallCount = 0
+    private var lastDeviceId: String? = null
 
-    override fun connect() {
+    override fun connect(deviceId: String?) {
         connectCallCount++
+        lastDeviceId = deviceId
         connected = true
         _connectionState.tryEmit(TelemetryConnectionState.Connected)
     }
@@ -59,4 +61,7 @@ class FakeTelemetryPushClient : TelemetryPushClient {
 
     /** Get the number of times [disconnect] was called. */
     fun getDisconnectCallCount(): Int = disconnectCallCount
+
+    /** Get the deviceId from the last [connect] call. */
+    fun getLastDeviceId(): String? = lastDeviceId
 }

--- a/android/ide-plugin/src/main/kotlin/dev/jasonpearson/automobile/ide/daemon/TelemetryPushClient.kt
+++ b/android/ide-plugin/src/main/kotlin/dev/jasonpearson/automobile/ide/daemon/TelemetryPushClient.kt
@@ -13,8 +13,11 @@ interface TelemetryPushClient {
     /** Flow of connection state changes. */
     val connectionState: SharedFlow<TelemetryConnectionState>
 
-    /** Connect to the telemetry push socket and subscribe to events. */
-    fun connect()
+    /**
+     * Connect to the telemetry push socket and subscribe to events.
+     * @param deviceId Optional device ID to filter server-side. Null receives all devices.
+     */
+    fun connect(deviceId: String? = null)
 
     /** Disconnect from the telemetry push socket. */
     fun disconnect()

--- a/android/ide-plugin/src/main/kotlin/dev/jasonpearson/automobile/ide/daemon/TelemetryPushSocketClient.kt
+++ b/android/ide-plugin/src/main/kotlin/dev/jasonpearson/automobile/ide/daemon/TelemetryPushSocketClient.kt
@@ -82,16 +82,19 @@ class TelemetryPushSocketClient : TelemetryPushClient {
     private val _connectionState = MutableSharedFlow<TelemetryConnectionState>(replay = 1)
     override val connectionState: SharedFlow<TelemetryConnectionState> = _connectionState.asSharedFlow()
 
+    private var subscribedDeviceId: String? = null
+
     /**
-     * Connect to the telemetry push socket and subscribe to all events.
-     * Will retry with exponential backoff if the socket is not available.
+     * Connect to the telemetry push socket and subscribe to events.
+     * @param deviceId Optional device ID for server-side filtering. Null subscribes to all devices.
      */
-    override fun connect() {
+    override fun connect(deviceId: String?) {
         if (connected.get()) {
             log.info("Already connected to telemetry push")
             return
         }
 
+        subscribedDeviceId = deviceId
         connectionJob?.cancel()
         shouldReconnect.set(true)
         reconnectAttempt.set(0)
@@ -232,12 +235,13 @@ class TelemetryPushSocketClient : TelemetryPushClient {
         val request = TelemetryPushRequest(
             id = UUID.randomUUID().toString(),
             command = "subscribe",
-            category = null, // subscribe to all, filter client-side
+            category = null, // subscribe to all categories, filter client-side
+            deviceId = subscribedDeviceId,
         )
 
         if (sendRequest(request)) {
             subscribed.set(true)
-            log.info("Subscribed to telemetry push (all categories)")
+            log.info("Subscribed to telemetry push (device: ${subscribedDeviceId ?: "all"})")
         }
     }
 

--- a/android/ide-plugin/src/main/kotlin/dev/jasonpearson/automobile/ide/telemetry/TelemetryModels.kt
+++ b/android/ide-plugin/src/main/kotlin/dev/jasonpearson/automobile/ide/telemetry/TelemetryModels.kt
@@ -16,6 +16,7 @@ data class TelemetryPushRequest(
     val id: String,
     val command: String,
     val category: String? = null,
+    val deviceId: String? = null,
 )
 
 /**

--- a/android/ide-plugin/src/test/kotlin/dev/jasonpearson/automobile/ide/daemon/FakeTelemetryPushClientTest.kt
+++ b/android/ide-plugin/src/test/kotlin/dev/jasonpearson/automobile/ide/daemon/FakeTelemetryPushClientTest.kt
@@ -19,7 +19,7 @@ class FakeTelemetryPushClientTest {
         val client = FakeTelemetryPushClient()
         assertFalse(client.isConnected())
 
-        client.connect()
+        client.connect(null)
         assertTrue(client.isConnected())
         assertEquals(TelemetryConnectionState.Connected, client.connectionState.first())
     }
@@ -27,7 +27,7 @@ class FakeTelemetryPushClientTest {
     @Test
     fun `disconnect sets disconnected state`() = runBlocking {
         val client = FakeTelemetryPushClient()
-        client.connect()
+        client.connect(null)
         assertTrue(client.isConnected())
 
         client.disconnect()
@@ -41,7 +41,7 @@ class FakeTelemetryPushClientTest {
     @Test
     fun `dispose disconnects`() {
         val client = FakeTelemetryPushClient()
-        client.connect()
+        client.connect(null)
         client.dispose()
         assertFalse(client.isConnected())
     }
@@ -52,8 +52,8 @@ class FakeTelemetryPushClientTest {
         assertEquals(0, client.getConnectCallCount())
         assertEquals(0, client.getDisconnectCallCount())
 
-        client.connect()
-        client.connect()
+        client.connect(null)
+        client.connect(null)
         assertEquals(2, client.getConnectCallCount())
 
         client.disconnect()
@@ -127,5 +127,19 @@ class FakeTelemetryPushClientTest {
 
         client.setConnectionState(TelemetryConnectionState.Connected)
         assertTrue(client.isConnected())
+    }
+
+    @Test
+    fun `connect stores deviceId`() {
+        val client = FakeTelemetryPushClient()
+        client.connect("emulator-5554")
+        assertEquals("emulator-5554", client.getLastDeviceId())
+    }
+
+    @Test
+    fun `connect with null deviceId`() {
+        val client = FakeTelemetryPushClient()
+        client.connect(null)
+        assertEquals(null, client.getLastDeviceId())
     }
 }

--- a/src/db/customEventRepository.ts
+++ b/src/db/customEventRepository.ts
@@ -70,7 +70,7 @@ export async function getCustomEvents(
 }
 
 async function cleanupIfNeeded(db?: Kysely<Database>): Promise<void> {
-  if (cleanupInProgress) return;
+  if (cleanupInProgress) {return;}
   cleanupInProgress = true;
   try {
     const d = getDb(db);

--- a/src/db/logEventRepository.ts
+++ b/src/db/logEventRepository.ts
@@ -73,7 +73,7 @@ export async function getLogEvents(
 }
 
 async function cleanupIfNeeded(db?: Kysely<Database>): Promise<void> {
-  if (cleanupInProgress) return;
+  if (cleanupInProgress) {return;}
   cleanupInProgress = true;
   try {
     const d = getDb(db);

--- a/src/db/networkEventRepository.ts
+++ b/src/db/networkEventRepository.ts
@@ -88,7 +88,7 @@ export async function getNetworkEvents(
 }
 
 async function cleanupIfNeeded(db?: Kysely<Database>): Promise<void> {
-  if (cleanupInProgress) return;
+  if (cleanupInProgress) {return;}
   cleanupInProgress = true;
   try {
     const d = getDb(db);

--- a/src/db/osEventRepository.ts
+++ b/src/db/osEventRepository.ts
@@ -70,7 +70,7 @@ export async function getOsEvents(
 }
 
 async function cleanupIfNeeded(db?: Kysely<Database>): Promise<void> {
-  if (cleanupInProgress) return;
+  if (cleanupInProgress) {return;}
   cleanupInProgress = true;
   try {
     const d = getDb(db);

--- a/src/features/telemetry/TelemetryRecorder.ts
+++ b/src/features/telemetry/TelemetryRecorder.ts
@@ -80,11 +80,9 @@ export class TelemetryRecorder {
     path: string | null;
     error: string | null;
   }): Promise<void> {
-    const input: RecordNetworkEventInput = {
-      deviceId: this.deviceId,
-      sessionId: this.sessionId,
-      ...event,
-    };
+    // Snapshot context before async work to avoid race with concurrent setContext() calls
+    const { deviceId, sessionId } = this.snapshotContext();
+    const input: RecordNetworkEventInput = { deviceId, sessionId, ...event };
 
     try {
       await this.repository.recordNetworkEvent(input);
@@ -92,7 +90,7 @@ export class TelemetryRecorder {
       logger.error(`[TelemetryRecorder] Failed to record network event: ${e}`);
     }
 
-    this.pushToSocket({ category: "network", timestamp: event.timestamp, deviceId: this.deviceId, data: event });
+    this.pushToSocket({ category: "network", timestamp: event.timestamp, deviceId, data: event });
   }
 
   async recordLogEvent(event: {
@@ -103,11 +101,8 @@ export class TelemetryRecorder {
     message: string;
     filterName: string;
   }): Promise<void> {
-    const input: RecordLogEventInput = {
-      deviceId: this.deviceId,
-      sessionId: this.sessionId,
-      ...event,
-    };
+    const { deviceId, sessionId } = this.snapshotContext();
+    const input: RecordLogEventInput = { deviceId, sessionId, ...event };
 
     try {
       await this.repository.recordLogEvent(input);
@@ -115,7 +110,7 @@ export class TelemetryRecorder {
       logger.error(`[TelemetryRecorder] Failed to record log event: ${e}`);
     }
 
-    this.pushToSocket({ category: "log", timestamp: event.timestamp, deviceId: this.deviceId, data: event });
+    this.pushToSocket({ category: "log", timestamp: event.timestamp, deviceId, data: event });
   }
 
   async recordCustomEvent(event: {
@@ -124,11 +119,8 @@ export class TelemetryRecorder {
     name: string;
     properties: Record<string, string>;
   }): Promise<void> {
-    const input: RecordCustomEventInput = {
-      deviceId: this.deviceId,
-      sessionId: this.sessionId,
-      ...event,
-    };
+    const { deviceId, sessionId } = this.snapshotContext();
+    const input: RecordCustomEventInput = { deviceId, sessionId, ...event };
 
     try {
       await this.repository.recordCustomEvent(input);
@@ -136,7 +128,7 @@ export class TelemetryRecorder {
       logger.error(`[TelemetryRecorder] Failed to record custom event: ${e}`);
     }
 
-    this.pushToSocket({ category: "custom", timestamp: event.timestamp, deviceId: this.deviceId, data: event });
+    this.pushToSocket({ category: "custom", timestamp: event.timestamp, deviceId, data: event });
   }
 
   async recordOsEvent(event: {
@@ -146,11 +138,8 @@ export class TelemetryRecorder {
     kind: string;
     details: Record<string, string> | null;
   }): Promise<void> {
-    const input: RecordOsEventInput = {
-      deviceId: this.deviceId,
-      sessionId: this.sessionId,
-      ...event,
-    };
+    const { deviceId, sessionId } = this.snapshotContext();
+    const input: RecordOsEventInput = { deviceId, sessionId, ...event };
 
     try {
       await this.repository.recordOsEvent(input);
@@ -158,7 +147,11 @@ export class TelemetryRecorder {
       logger.error(`[TelemetryRecorder] Failed to record OS event: ${e}`);
     }
 
-    this.pushToSocket({ category: "os", timestamp: event.timestamp, deviceId: this.deviceId, data: event });
+    this.pushToSocket({ category: "os", timestamp: event.timestamp, deviceId, data: event });
+  }
+
+  private snapshotContext(): { deviceId: string | null; sessionId: string | null } {
+    return { deviceId: this.deviceId, sessionId: this.sessionId };
   }
 
   private pushToSocket(event: TelemetryEvent): void {

--- a/test/features/action/LaunchApp.test.ts
+++ b/test/features/action/LaunchApp.test.ts
@@ -319,7 +319,7 @@ describe("LaunchApp", () => {
       const managerSpy = spyOn(IOSCtrlProxyManager, "getInstance").mockReturnValue({
         setTargetBundleId: (id: string) => callOrder.push(`setTargetBundleId:${id}`),
       } as unknown as IOSCtrlProxyManager);
-      spyOn(fakeCtrlProxy, "requestLaunchApp").mockImplementation(async (id) => {
+      spyOn(fakeCtrlProxy, "requestLaunchApp").mockImplementation(async id => {
         callOrder.push(`requestLaunchApp:${id}`);
         return { success: true, totalTimeMs: 10 };
       });

--- a/test/features/telemetry/TelemetryRecorder.test.ts
+++ b/test/features/telemetry/TelemetryRecorder.test.ts
@@ -233,4 +233,39 @@ describe("TelemetryRecorder", () => {
     const b = TelemetryRecorder.getInstance();
     expect(a).not.toBe(b);
   });
+
+  it("snapshots context before async write to avoid race", async () => {
+    // Simulate: start recording with device-A, then setContext to device-B
+    // before the repo write completes. Both DB write and push should use device-A.
+    let resolveWrite: (() => void) | null = null;
+    const slowRepo: TelemetryRepository = {
+      ...repo,
+      recordNetworkEvent: async input => {
+        repo.networkEvents.push(input);
+        // Block until test resolves
+        await new Promise<void>(r => { resolveWrite = r; });
+      },
+    };
+    const slowRecorder = new TelemetryRecorder(slowRepo, () => pushTarget);
+    slowRecorder.setContext("device-A", "session-A");
+
+    const promise = slowRecorder.recordNetworkEvent({
+      timestamp: 1000, applicationId: null, url: "u", method: "GET",
+      statusCode: 200, durationMs: 0, requestBodySize: 0, responseBodySize: 0,
+      protocol: null, host: null, path: null, error: null,
+    });
+
+    // Context changes while the write is in flight
+    slowRecorder.setContext("device-B", "session-B");
+
+    // Let the write complete
+    resolveWrite!();
+    await promise;
+
+    // DB should have device-A (snapshotted before await)
+    expect(repo.networkEvents[0].deviceId).toBe("device-A");
+    expect(repo.networkEvents[0].sessionId).toBe("session-A");
+    // Push should also have device-A
+    expect(pushTarget.pushedEvents[0].deviceId).toBe("device-A");
+  });
 });


### PR DESCRIPTION
## Summary
Follow-up fixes from PR review on #1535:

- **Wire telemetry push server into daemon startup**: `startTelemetryPushSocketServer()` / `stopTelemetryPushSocketServer()` was never called in `daemon.ts`, so `getTelemetryPushServer()` always returned null and no events were pushed to IDE subscribers
- **Apply deviceId filter in matchesFilter**: Subscription filter parsed deviceId but `matchesFilter` only checked category, causing multi-device sessions to receive mixed telemetry
- **Snapshot recorder context before async write**: `TelemetryRecorder` read `this.deviceId` after `await`, so concurrent `setContext()` calls could write device-A to DB but push as device-B
- **Pass deviceId in IDE subscribe command**: `TelemetryPushRequest` lacked deviceId field and `connect()` never sent it, so server-side per-device filtering was unused

## Test plan
- [x] `npx turbo run lint build test` — 3054 tests pass
- [x] `./android/gradlew -p android :ide-plugin:build` — compiles and tests pass
- [x] New test: context snapshot survives concurrent `setContext()` during async write
- [x] New tests: deviceId-only and combined category+deviceId server-side filtering

🤖 Generated with [Claude Code](https://claude.com/claude-code)