### PR TITLE
fix(install): use full HTTPS URL for marketplace plugin install

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -2368,14 +2368,14 @@ install_claude_marketplace() {
 
     if [[ "${DRY_RUN}" == "true" ]]; then
         DRY_RUN_LOG+=("[DRY-RUN] Install Claude Marketplace plugin")
-        log_info "[DRY-RUN] Would run: claude plugin marketplace add kaeawc/auto-mobile"
+        log_info "[DRY-RUN] Would run: claude plugin marketplace add https://github.com/kaeawc/auto-mobile"
         return 0
     fi
 
     log_info "Installing Claude Marketplace plugin..."
     local install_output
     local install_status=0
-    install_output=$(claude plugin marketplace add kaeawc/auto-mobile 2>&1) || install_status=$?
+    install_output=$(claude plugin marketplace add https://github.com/kaeawc/auto-mobile 2>&1) || install_status=$?
 
     if [[ ${install_status} -ne 0 ]]; then
         log_error "Failed to install Claude Marketplace plugin:"


### PR DESCRIPTION
## Summary
- Uses explicit HTTPS URL (`https://github.com/kaeawc/auto-mobile`) instead of `owner/repo` shorthand when calling `claude plugin marketplace add`
- Works around Claude CLI bug ([claude-code#18001](https://github.com/anthropics/claude-code/issues/18001)) where HTTPS clone failure incorrectly falls back to SSH even when SSH keys aren't configured

## Test Plan
- [ ] Run `scripts/install.sh` on a machine without SSH keys configured
- [ ] Verify marketplace plugin installs successfully via HTTPS

Closes #1559

🤖 Generated with [Claude Code](https://claude.com/claude-code)