### PR TITLE
fix: SDK performance regressions and main-thread safety

### DIFF
--- a/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/AutoMobileSDK.kt
+++ b/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/AutoMobileSDK.kt
@@ -1,10 +1,10 @@
 package dev.jasonpearson.automobile.sdk
 
 import android.content.Context
-import android.content.Intent
+import android.os.Handler
+import android.os.Looper
 import dev.jasonpearson.automobile.protocol.NavigationSourceType
 import dev.jasonpearson.automobile.protocol.SdkCustomEvent
-import dev.jasonpearson.automobile.protocol.SdkEventSerializer
 import dev.jasonpearson.automobile.protocol.SdkNavigationEvent
 import dev.jasonpearson.automobile.sdk.anr.AutoMobileAnr
 import dev.jasonpearson.automobile.sdk.biometrics.AutoMobileBiometrics
@@ -85,15 +85,10 @@ object AutoMobileSDK {
     buffer.start()
     eventBuffer = buffer
 
-    // Initialize telemetry subsystems with the shared buffer
+    // Thread-safe subsystems — can initialize from any thread
     AutoMobileNetwork.initialize(appContext.packageName, buffer)
     AutoMobileLog.initialize(appContext.packageName, buffer)
-    AutoMobileOsEvents.initialize(appContext, buffer)
     AutoMobileBroadcastInterceptor.initialize(appContext, buffer)
-
-    // Initialize existing subsystems
-    RecompositionTracker.initialize(appContext)
-    AutoMobileNotifications.initialize(appContext)
     DatabaseInspector.initialize(appContext)
     SharedPreferencesInspector.initialize(appContext)
     AutoMobileFailures.initialize(appContext)
@@ -101,9 +96,15 @@ object AutoMobileSDK {
     AutoMobileAnr.initialize(appContext)
     AutoMobileBiometrics.initialize(appContext)
 
-    // Auto-track taps across all Activities (Compose, XML, React Native, etc.)
-    if (appContext is Application) {
-      AutoMobileClickTracker.initialize(appContext, appContext.packageName, buffer)
+    // Subsystems that register lifecycle observers or activity callbacks must run on main thread
+    val mainHandler = Handler(Looper.getMainLooper())
+    mainHandler.post {
+      AutoMobileOsEvents.initialize(appContext, buffer)
+      RecompositionTracker.initialize(appContext)
+      AutoMobileNotifications.initialize(appContext)
+      if (appContext is Application) {
+        AutoMobileClickTracker.initialize(appContext, appContext.packageName, buffer)
+      }
     }
   }
 
@@ -132,7 +133,7 @@ object AutoMobileSDK {
 
   /**
    * Notifies all registered listeners of a navigation event. This method is typically called by
-   * framework adapters. Also broadcasts the event via Intent for cross-process communication.
+   * framework adapters. Events are routed through the shared event buffer for async delivery.
    *
    * @param event The navigation event to emit
    */
@@ -149,44 +150,23 @@ object AutoMobileSDK {
       }
     }
 
-    // Broadcast event for cross-process communication (e.g., to accessibility service)
-    context?.let { ctx ->
-      try {
-        val timestamp = System.currentTimeMillis()
+    // Route navigation events through the shared event buffer so they are
+    // batched and broadcast on the buffer's background thread instead of
+    // blocking the caller (which is often the main thread).
+    val buf = eventBuffer ?: return
+    val ctx = context ?: return
+    val timestamp = System.currentTimeMillis()
 
-        // Create protocol event for type-safe serialization
-        val sdkEvent = SdkNavigationEvent(
-          timestamp = timestamp,
-          applicationId = ctx.packageName,
-          destination = event.destination,
-          source = event.source.toProtocolType(),
-          arguments = event.arguments.mapValues { it.value?.toString() ?: "null" },
-          metadata = event.metadata,
-        )
-
-        val intent =
-            Intent(ACTION_NAVIGATION_EVENT).apply {
-              // Type-safe serialized event (new protocol)
-              putExtra(SdkEventSerializer.EXTRA_SDK_EVENT_JSON, SdkEventSerializer.toJson(sdkEvent))
-              putExtra(SdkEventSerializer.EXTRA_SDK_EVENT_TYPE, SdkEventSerializer.EventTypes.NAVIGATION)
-
-              // Legacy extras for backward compatibility with older AccessibilityService versions
-              putExtra(EXTRA_DESTINATION, event.destination)
-              putExtra(EXTRA_SOURCE, event.source.name)
-              putExtra(EXTRA_TIMESTAMP, timestamp)
-              putExtra(EXTRA_APPLICATION_ID, ctx.packageName)
-              // Serialize arguments as strings
-              event.arguments.forEach { (key, value) ->
-                putExtra("arg_$key", value?.toString() ?: "null")
-              }
-              // Serialize metadata
-              event.metadata.forEach { (key, value) -> putExtra("meta_$key", value) }
-            }
-        ctx.sendBroadcast(intent)
-      } catch (e: Exception) {
-        e.printStackTrace()
-      }
-    }
+    buf.add(
+      SdkNavigationEvent(
+        timestamp = timestamp,
+        applicationId = ctx.packageName,
+        destination = event.destination,
+        source = event.source.toProtocolType(),
+        arguments = event.arguments.mapValues { it.value?.toString() ?: "null" },
+        metadata = event.metadata,
+      )
+    )
   }
 
   /**

--- a/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/events/SdkEventBroadcaster.kt
+++ b/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/events/SdkEventBroadcaster.kt
@@ -16,7 +16,7 @@ import dev.jasonpearson.automobile.protocol.SdkEventSerializer
 object SdkEventBroadcaster {
 
   const val ACTION_SDK_EVENT_BATCH = "dev.jasonpearson.automobile.sdk.EVENT_BATCH"
-  internal const val MAX_BATCH_BYTES = 500_000 // 500KB per Intent
+  internal const val MAX_BATCH_BYTES = 100_000 // 100KB per Intent — lower to avoid TransactionTooLargeException
 
   /**
    * Broadcast a batch of events. Called by [SdkEventBuffer] on flush.

--- a/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/interaction/AutoMobileClickTracker.kt
+++ b/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/interaction/AutoMobileClickTracker.kt
@@ -39,10 +39,14 @@ object AutoMobileClickTracker {
     private const val TAP_SLOP_PX = 20 // Max movement to still be a tap
     private const val TAP_TIMEOUT_MS = 500L // Max duration for a tap
 
+    /** Minimum interval between accessibility tree traversals to avoid piling up work. */
+    private const val TAP_DEBOUNCE_MS = 100L
+
     private var buffer: SdkEventBuffer? = null
     private var applicationId: String? = null
     private val handler = Handler(Looper.getMainLooper())
     private val wrappedActivities = java.util.WeakHashMap<Activity, Boolean>()
+    @Volatile private var lastTapProcessedAt = 0L
 
     fun initialize(application: Application, appId: String?, buffer: SdkEventBuffer) {
         this.buffer = buffer
@@ -119,6 +123,9 @@ object AutoMobileClickTracker {
 
         private fun emitTapEvent(x: Float, y: Float, durationMs: Long) {
             val buf = buffer ?: return
+            val now = System.currentTimeMillis()
+            if (now - lastTapProcessedAt < TAP_DEBOUNCE_MS) return
+            lastTapProcessedAt = now
             try {
                 val decorView = window.decorView
                 val info = findDeepestNodeAt(decorView, x.toInt(), y.toInt())


### PR DESCRIPTION
## Summary
- Post lifecycle observers and activity callbacks to main handler to avoid threading violations when SDK is initialized off the main thread
- Route navigation events through the shared event buffer for async delivery instead of blocking with synchronous Intent broadcasts
- Reduce max broadcast batch size from 500KB to 100KB to prevent `TransactionTooLargeException`
- Add 100ms tap debounce to prevent piling up accessibility tree traversals on rapid taps

## Test plan
- [x] Verify SDK initializes without crash when called from background thread
- [x] Confirm navigation events still reach the accessibility service via buffered broadcast
- [x] Test rapid tapping doesn't cause ANR or excessive accessibility tree walks
- [x] Validate playground app builds and runs correctly with these changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)