### PR TITLE
feat: iOS simulator support for changeLocalization tool

### DIFF
--- a/src/features/utility/SystemConfigurationManager.ts
+++ b/src/features/utility/SystemConfigurationManager.ts
@@ -1,5 +1,7 @@
 import { AdbClientFactory, defaultAdbClientFactory } from "../../utils/android-cmdline-tools/AdbClientFactory";
 import type { AdbExecutor } from "../../utils/android-cmdline-tools/interfaces/AdbExecutor";
+import type { ProcessExecutor } from "../../utils/ProcessExecutor";
+import { DefaultProcessExecutor } from "../../utils/ProcessExecutor";
 import { logger } from "../../utils/logger";
 import {
   BootedDevice,
@@ -18,16 +20,22 @@ type CommandAttempt = {
   command: string;
 };
 
-const IOS_STUB_ERROR = "iOS support is not implemented yet.";
+const IOS_PHYSICAL_DEVICE_ERROR = "Localization changes are only supported on iOS Simulator.";
 const DEFAULT_CALENDAR_SYSTEM = "gregory";
 
 export class SystemConfigurationManager {
   private device: BootedDevice;
   private adb: AdbExecutor;
+  private processExecutor: ProcessExecutor;
 
-  constructor(device: BootedDevice, adbFactory: AdbClientFactory = defaultAdbClientFactory) {
+  constructor(
+    device: BootedDevice,
+    adbFactory: AdbClientFactory = defaultAdbClientFactory,
+    processExecutor: ProcessExecutor = new DefaultProcessExecutor()
+  ) {
     this.device = device;
     this.adb = adbFactory.create(device);
+    this.processExecutor = processExecutor;
   }
 
   async setLocale(languageTag: string, options: { broadcast?: boolean } = {}): Promise<SetLocaleResult> {
@@ -38,6 +46,10 @@ export class SystemConfigurationManager {
         languageTag,
         error: "languageTag must be a non-empty string"
       };
+    }
+
+    if (this.device.platform === "ios") {
+      return this.setLocaleIos(trimmedTag);
     }
 
     if (this.device.platform !== "android") {
@@ -114,6 +126,10 @@ export class SystemConfigurationManager {
       };
     }
 
+    if (this.device.platform === "ios") {
+      return this.setTimeZoneIos(trimmedZone);
+    }
+
     if (this.device.platform !== "android") {
       return {
         success: false,
@@ -143,6 +159,14 @@ export class SystemConfigurationManager {
   }
 
   async setTextDirection(rtl: boolean, options: { broadcast?: boolean } = {}): Promise<SetTextDirectionResult> {
+    if (this.device.platform === "ios") {
+      return {
+        success: false,
+        rtl,
+        error: "Text direction is not supported on iOS. RTL is driven by the app's language; set an RTL locale (e.g., ar_SA) instead."
+      };
+    }
+
     if (this.device.platform !== "android") {
       return {
         success: false,
@@ -218,6 +242,10 @@ export class SystemConfigurationManager {
   }
 
   async set24HourFormat(enabled: boolean): Promise<Set24HourFormatResult> {
+    if (this.device.platform === "ios") {
+      return this.set24HourFormatIos(enabled);
+    }
+
     if (this.device.platform !== "android") {
       return {
         success: false,
@@ -248,6 +276,10 @@ export class SystemConfigurationManager {
   }
 
   async getCalendarSystem(): Promise<GetCalendarSystemResult> {
+    if (this.device.platform === "ios") {
+      return this.getCalendarSystemIos();
+    }
+
     if (this.device.platform !== "android") {
       return {
         success: false,
@@ -288,6 +320,10 @@ export class SystemConfigurationManager {
   }
 
   async getLocalizationSettings(): Promise<LocalizationSettingsResult> {
+    if (this.device.platform === "ios") {
+      return this.getLocalizationSettingsIos();
+    }
+
     if (this.device.platform !== "android") {
       return {
         success: false,
@@ -332,9 +368,6 @@ export class SystemConfigurationManager {
   }
 
   private getPlatformError(): string {
-    if (this.device.platform === "ios") {
-      return IOS_STUB_ERROR;
-    }
     return `Unsupported platform: ${this.device.platform}`;
   }
 
@@ -460,5 +493,185 @@ export class SystemConfigurationManager {
     }
 
     return null;
+  }
+
+  // --- iOS Simulator methods ---
+
+  private isSimulator(): boolean {
+    return /^[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}$/i.test(
+      this.device.deviceId
+    );
+  }
+
+  private iosSpawnCommand(command: string): string {
+    return `xcrun simctl spawn ${this.device.deviceId} ${command}`;
+  }
+
+  private async iosDefaultsRead(domain: string, key: string): Promise<string | null> {
+    try {
+      const result = await this.processExecutor.exec(
+        this.iosSpawnCommand(`defaults read ${domain} ${key}`)
+      );
+      return this.normalizeSettingValue(result.stdout);
+    } catch {
+      return null;
+    }
+  }
+
+  private async iosDefaultsWrite(domain: string, key: string, value: string): Promise<void> {
+    await this.processExecutor.exec(
+      this.iosSpawnCommand(`defaults write ${domain} ${key} ${value}`)
+    );
+  }
+
+  private toAppleLocale(languageTag: string): string {
+    return languageTag.replace(/-/g, "_");
+  }
+
+  private async setLocaleIos(languageTag: string): Promise<SetLocaleResult> {
+    if (!this.isSimulator()) {
+      return { success: false, languageTag, error: IOS_PHYSICAL_DEVICE_ERROR };
+    }
+
+    try {
+      const previousLanguageTag = await this.iosDefaultsRead(".GlobalPreferences", "AppleLocale");
+      const appleLocale = this.toAppleLocale(languageTag);
+      await this.iosDefaultsWrite(".GlobalPreferences", "AppleLocale", appleLocale);
+      return {
+        success: true,
+        languageTag,
+        previousLanguageTag,
+        method: "defaults write AppleLocale"
+      };
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : String(error);
+      return {
+        success: false,
+        languageTag,
+        error: `Failed to set locale: ${errorMessage}`
+      };
+    }
+  }
+
+  private async setTimeZoneIos(zoneId: string): Promise<SetTimeZoneResult> {
+    if (!this.isSimulator()) {
+      return { success: false, zoneId, error: IOS_PHYSICAL_DEVICE_ERROR };
+    }
+
+    try {
+      const previousZoneId = await this.iosDefaultsRead(".GlobalPreferences", "AppleTimeZone");
+
+      // Disable auto-timezone before setting
+      await this.iosDefaultsWrite(
+        "com.apple.mobiletimerd",
+        "AutomaticTimeZoneSetting",
+        "-bool NO"
+      );
+
+      await this.iosDefaultsWrite(".GlobalPreferences", "AppleTimeZone", zoneId);
+      return {
+        success: true,
+        zoneId,
+        previousZoneId
+      };
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : String(error);
+      return {
+        success: false,
+        zoneId,
+        error: `Failed to set time zone: ${errorMessage}`
+      };
+    }
+  }
+
+  private async set24HourFormatIos(enabled: boolean): Promise<Set24HourFormatResult> {
+    if (!this.isSimulator()) {
+      return { success: false, enabled, error: IOS_PHYSICAL_DEVICE_ERROR };
+    }
+
+    try {
+      const previousRaw = await this.iosDefaultsRead(".GlobalPreferences", "AppleICUForce24HourTime");
+      const previousFormat = this.normalizeTimeFormat(
+        previousRaw === "1" ? "24" : previousRaw === "0" ? "12" : previousRaw
+      );
+
+      const boolValue = enabled ? "-bool YES" : "-bool NO";
+      await this.iosDefaultsWrite(".GlobalPreferences", "AppleICUForce24HourTime", boolValue);
+      return {
+        success: true,
+        enabled,
+        previousFormat
+      };
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : String(error);
+      return {
+        success: false,
+        enabled,
+        error: `Failed to set 24-hour format: ${errorMessage}`
+      };
+    }
+  }
+
+  private async getCalendarSystemIos(): Promise<GetCalendarSystemResult> {
+    if (!this.isSimulator()) {
+      return {
+        success: false,
+        calendarSystem: DEFAULT_CALENDAR_SYSTEM,
+        source: "default",
+        error: IOS_PHYSICAL_DEVICE_ERROR
+      };
+    }
+
+    const calendar = await this.iosDefaultsRead(".GlobalPreferences", "AppleCalendar");
+    if (calendar) {
+      return {
+        success: true,
+        calendarSystem: calendar,
+        source: "default"
+      };
+    }
+
+    const locale = await this.iosDefaultsRead(".GlobalPreferences", "AppleLocale");
+    if (locale) {
+      const calendarFromLocale = this.extractCalendarFromLocale(locale);
+      if (calendarFromLocale) {
+        return {
+          success: true,
+          calendarSystem: calendarFromLocale,
+          locale,
+          source: "locale"
+        };
+      }
+    }
+
+    return {
+      success: true,
+      calendarSystem: DEFAULT_CALENDAR_SYSTEM,
+      locale: locale ?? null,
+      source: "default"
+    };
+  }
+
+  private async getLocalizationSettingsIos(): Promise<LocalizationSettingsResult> {
+    if (!this.isSimulator()) {
+      return { success: false, error: IOS_PHYSICAL_DEVICE_ERROR };
+    }
+
+    const locale = await this.iosDefaultsRead(".GlobalPreferences", "AppleLocale");
+    const timeZone = await this.iosDefaultsRead(".GlobalPreferences", "AppleTimeZone");
+    const timeFormatRaw = await this.iosDefaultsRead(".GlobalPreferences", "AppleICUForce24HourTime");
+    const timeFormat = this.normalizeTimeFormat(
+      timeFormatRaw === "1" ? "24" : timeFormatRaw === "0" ? "12" : timeFormatRaw
+    );
+    const calendarResult = await this.getCalendarSystemIos();
+
+    return {
+      success: true,
+      locale,
+      timeZone,
+      textDirection: null,
+      timeFormat,
+      calendarSystem: calendarResult.calendarSystem ?? null
+    };
   }
 }

--- a/test/features/utility/SystemConfigurationManager.test.ts
+++ b/test/features/utility/SystemConfigurationManager.test.ts
@@ -1,0 +1,329 @@
+import { describe, expect, test, beforeEach } from "bun:test";
+import { SystemConfigurationManager } from "../../../src/features/utility/SystemConfigurationManager";
+import { FakeAdbClientFactory } from "../../fakes/FakeAdbClientFactory";
+import { FakeAdbClient } from "../../fakes/FakeAdbClient";
+import { FakeProcessExecutor } from "../../fakes/FakeProcessExecutor";
+import type { BootedDevice, ExecResult } from "../../../src/models";
+
+const IOS_SIMULATOR: BootedDevice = {
+  deviceId: "A1B2C3D4-E5F6-7890-ABCD-EF1234567890",
+  name: "iPhone 15 Pro",
+  platform: "ios"
+};
+
+const IOS_PHYSICAL: BootedDevice = {
+  deviceId: "00008130-001234567890abcd",
+  name: "iPhone 15 Pro",
+  platform: "ios"
+};
+
+const ANDROID_DEVICE: BootedDevice = {
+  deviceId: "emulator-5554",
+  name: "Pixel 7",
+  platform: "android"
+};
+
+function execResult(stdout: string, stderr = ""): ExecResult {
+  return {
+    stdout,
+    stderr,
+    toString: () => stdout,
+    trim: () => stdout.trim(),
+    includes: (s: string) => stdout.includes(s)
+  };
+}
+
+describe("SystemConfigurationManager", () => {
+  let fakeAdbClient: FakeAdbClient;
+  let fakeAdbFactory: FakeAdbClientFactory;
+  let fakeExec: FakeProcessExecutor;
+
+  beforeEach(() => {
+    fakeAdbClient = new FakeAdbClient();
+    fakeAdbFactory = new FakeAdbClientFactory(fakeAdbClient);
+    fakeExec = new FakeProcessExecutor();
+  });
+
+  // --- iOS Simulator: setLocale ---
+
+  describe("iOS simulator setLocale", () => {
+    test("writes AppleLocale via defaults write", async () => {
+      fakeExec.setDefaultResponse(execResult(""));
+      const mgr = new SystemConfigurationManager(IOS_SIMULATOR, fakeAdbFactory, fakeExec);
+      const result = await mgr.setLocale("ja-JP");
+
+      expect(result.success).toBe(true);
+      expect(result.languageTag).toBe("ja-JP");
+      expect(result.method).toBe("defaults write AppleLocale");
+      expect(
+        fakeExec.wasCommandExecuted(
+          `xcrun simctl spawn ${IOS_SIMULATOR.deviceId} defaults write .GlobalPreferences AppleLocale ja_JP`
+        )
+      ).toBe(true);
+    });
+
+    test("converts BCP-47 hyphens to underscores for Apple format", async () => {
+      fakeExec.setDefaultResponse(execResult(""));
+      const mgr = new SystemConfigurationManager(IOS_SIMULATOR, fakeAdbFactory, fakeExec);
+      await mgr.setLocale("en-US");
+
+      expect(
+        fakeExec.wasCommandExecuted("AppleLocale en_US")
+      ).toBe(true);
+    });
+
+    test("reads previous locale before writing", async () => {
+      fakeExec.setCommandResponse("defaults read .GlobalPreferences AppleLocale", execResult("en_US\n"));
+      const mgr = new SystemConfigurationManager(IOS_SIMULATOR, fakeAdbFactory, fakeExec);
+      const result = await mgr.setLocale("ja-JP");
+
+      expect(result.success).toBe(true);
+      expect(result.previousLanguageTag).toBe("en_US");
+    });
+
+    test("returns error for empty languageTag", async () => {
+      const mgr = new SystemConfigurationManager(IOS_SIMULATOR, fakeAdbFactory, fakeExec);
+      const result = await mgr.setLocale("  ");
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBe("languageTag must be a non-empty string");
+    });
+
+    test("returns error for physical iOS device", async () => {
+      const mgr = new SystemConfigurationManager(IOS_PHYSICAL, fakeAdbFactory, fakeExec);
+      const result = await mgr.setLocale("ja-JP");
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBe("Localization changes are only supported on iOS Simulator.");
+      expect(fakeExec.getExecutedCommands()).toHaveLength(0);
+    });
+
+    test("returns error when defaults write fails", async () => {
+      fakeExec.setCommandResponse("defaults read", execResult(""));
+      fakeExec.setCommandResponse("defaults write", execResult("", "error"));
+      // Override to throw
+      const originalExec = fakeExec.exec.bind(fakeExec);
+      fakeExec.exec = async (command, options) => {
+        if (command.includes("defaults write .GlobalPreferences AppleLocale")) {
+          throw new Error("simctl failed");
+        }
+        return originalExec(command, options);
+      };
+
+      const mgr = new SystemConfigurationManager(IOS_SIMULATOR, fakeAdbFactory, fakeExec);
+      const result = await mgr.setLocale("ja-JP");
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("Failed to set locale");
+    });
+  });
+
+  // --- iOS Simulator: setTimeZone ---
+
+  describe("iOS simulator setTimeZone", () => {
+    test("disables auto-timezone then writes AppleTimeZone", async () => {
+      fakeExec.setDefaultResponse(execResult(""));
+      const mgr = new SystemConfigurationManager(IOS_SIMULATOR, fakeAdbFactory, fakeExec);
+      const result = await mgr.setTimeZone("Asia/Tokyo");
+
+      expect(result.success).toBe(true);
+      expect(result.zoneId).toBe("Asia/Tokyo");
+
+      const commands = fakeExec.getExecutedCommands();
+      const autoTzIndex = commands.findIndex(c => c.includes("AutomaticTimeZoneSetting"));
+      const writeIndex = commands.findIndex(c => c.includes("AppleTimeZone") && c.includes("defaults write"));
+      expect(autoTzIndex).toBeGreaterThanOrEqual(0);
+      expect(writeIndex).toBeGreaterThan(autoTzIndex);
+    });
+
+    test("disables auto-timezone with correct command", async () => {
+      fakeExec.setDefaultResponse(execResult(""));
+      const mgr = new SystemConfigurationManager(IOS_SIMULATOR, fakeAdbFactory, fakeExec);
+      await mgr.setTimeZone("America/New_York");
+
+      expect(
+        fakeExec.wasCommandExecuted(
+          `xcrun simctl spawn ${IOS_SIMULATOR.deviceId} defaults write com.apple.mobiletimerd AutomaticTimeZoneSetting -bool NO`
+        )
+      ).toBe(true);
+    });
+
+    test("reads previous timezone before writing", async () => {
+      fakeExec.setCommandResponse("defaults read .GlobalPreferences AppleTimeZone", execResult("America/Los_Angeles\n"));
+      const mgr = new SystemConfigurationManager(IOS_SIMULATOR, fakeAdbFactory, fakeExec);
+      const result = await mgr.setTimeZone("Asia/Tokyo");
+
+      expect(result.success).toBe(true);
+      expect(result.previousZoneId).toBe("America/Los_Angeles");
+    });
+
+    test("returns error for empty zoneId", async () => {
+      const mgr = new SystemConfigurationManager(IOS_SIMULATOR, fakeAdbFactory, fakeExec);
+      const result = await mgr.setTimeZone("  ");
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBe("zoneId must be a non-empty string");
+    });
+
+    test("returns error for physical iOS device", async () => {
+      const mgr = new SystemConfigurationManager(IOS_PHYSICAL, fakeAdbFactory, fakeExec);
+      const result = await mgr.setTimeZone("Asia/Tokyo");
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBe("Localization changes are only supported on iOS Simulator.");
+    });
+  });
+
+  // --- iOS Simulator: set24HourFormat ---
+
+  describe("iOS simulator set24HourFormat", () => {
+    test("writes AppleICUForce24HourTime YES for 24h", async () => {
+      fakeExec.setDefaultResponse(execResult(""));
+      const mgr = new SystemConfigurationManager(IOS_SIMULATOR, fakeAdbFactory, fakeExec);
+      const result = await mgr.set24HourFormat(true);
+
+      expect(result.success).toBe(true);
+      expect(result.enabled).toBe(true);
+      expect(
+        fakeExec.wasCommandExecuted(
+          `xcrun simctl spawn ${IOS_SIMULATOR.deviceId} defaults write .GlobalPreferences AppleICUForce24HourTime -bool YES`
+        )
+      ).toBe(true);
+    });
+
+    test("writes AppleICUForce24HourTime NO for 12h", async () => {
+      fakeExec.setDefaultResponse(execResult(""));
+      const mgr = new SystemConfigurationManager(IOS_SIMULATOR, fakeAdbFactory, fakeExec);
+      const result = await mgr.set24HourFormat(false);
+
+      expect(result.success).toBe(true);
+      expect(result.enabled).toBe(false);
+      expect(
+        fakeExec.wasCommandExecuted("AppleICUForce24HourTime -bool NO")
+      ).toBe(true);
+    });
+
+    test("reads previous format before writing", async () => {
+      fakeExec.setCommandResponse("defaults read .GlobalPreferences AppleICUForce24HourTime", execResult("1\n"));
+      const mgr = new SystemConfigurationManager(IOS_SIMULATOR, fakeAdbFactory, fakeExec);
+      const result = await mgr.set24HourFormat(false);
+
+      expect(result.success).toBe(true);
+      expect(result.previousFormat).toBe("24");
+    });
+
+    test("returns error for physical iOS device", async () => {
+      const mgr = new SystemConfigurationManager(IOS_PHYSICAL, fakeAdbFactory, fakeExec);
+      const result = await mgr.set24HourFormat(true);
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBe("Localization changes are only supported on iOS Simulator.");
+    });
+  });
+
+  // --- iOS Simulator: setTextDirection ---
+
+  describe("iOS simulator setTextDirection", () => {
+    test("returns unsupported error for iOS", async () => {
+      const mgr = new SystemConfigurationManager(IOS_SIMULATOR, fakeAdbFactory, fakeExec);
+      const result = await mgr.setTextDirection(true);
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("Text direction is not supported on iOS");
+      expect(fakeExec.getExecutedCommands()).toHaveLength(0);
+    });
+  });
+
+  // --- iOS Simulator: getLocalizationSettings ---
+
+  describe("iOS simulator getLocalizationSettings", () => {
+    test("reads all settings via defaults read", async () => {
+      fakeExec.setCommandResponse("defaults read .GlobalPreferences AppleLocale", execResult("ja_JP\n"));
+      fakeExec.setCommandResponse("defaults read .GlobalPreferences AppleTimeZone", execResult("Asia/Tokyo\n"));
+      fakeExec.setCommandResponse("defaults read .GlobalPreferences AppleICUForce24HourTime", execResult("1\n"));
+      const mgr = new SystemConfigurationManager(IOS_SIMULATOR, fakeAdbFactory, fakeExec);
+      const result = await mgr.getLocalizationSettings();
+
+      expect(result.success).toBe(true);
+      expect(result.locale).toBe("ja_JP");
+      expect(result.timeZone).toBe("Asia/Tokyo");
+      expect(result.timeFormat).toBe("24");
+      expect(result.textDirection).toBeNull();
+    });
+
+    test("returns error for physical iOS device", async () => {
+      const mgr = new SystemConfigurationManager(IOS_PHYSICAL, fakeAdbFactory, fakeExec);
+      const result = await mgr.getLocalizationSettings();
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBe("Localization changes are only supported on iOS Simulator.");
+    });
+
+    test("handles missing values gracefully", async () => {
+      fakeExec.setDefaultResponse(execResult(""));
+      const mgr = new SystemConfigurationManager(IOS_SIMULATOR, fakeAdbFactory, fakeExec);
+      const result = await mgr.getLocalizationSettings();
+
+      expect(result.success).toBe(true);
+      expect(result.locale).toBeNull();
+      expect(result.timeZone).toBeNull();
+      expect(result.timeFormat).toBeNull();
+    });
+  });
+
+  // --- iOS Simulator: getCalendarSystem ---
+
+  describe("iOS simulator getCalendarSystem", () => {
+    test("reads AppleCalendar when available", async () => {
+      fakeExec.setCommandResponse("defaults read .GlobalPreferences AppleCalendar", execResult("japanese\n"));
+      const mgr = new SystemConfigurationManager(IOS_SIMULATOR, fakeAdbFactory, fakeExec);
+      const result = await mgr.getCalendarSystem();
+
+      expect(result.success).toBe(true);
+      expect(result.calendarSystem).toBe("japanese");
+    });
+
+    test("falls back to default calendar system", async () => {
+      fakeExec.setDefaultResponse(execResult(""));
+      const mgr = new SystemConfigurationManager(IOS_SIMULATOR, fakeAdbFactory, fakeExec);
+      const result = await mgr.getCalendarSystem();
+
+      expect(result.success).toBe(true);
+      expect(result.calendarSystem).toBe("gregory");
+      expect(result.source).toBe("default");
+    });
+
+    test("returns error for physical iOS device", async () => {
+      const mgr = new SystemConfigurationManager(IOS_PHYSICAL, fakeAdbFactory, fakeExec);
+      const result = await mgr.getCalendarSystem();
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBe("Localization changes are only supported on iOS Simulator.");
+    });
+  });
+
+  // --- Android: existing behavior unchanged ---
+
+  describe("Android setLocale still works", () => {
+    test("uses adb commands for Android", async () => {
+      fakeAdbClient.setCommandResult("shell getprop ro.build.version.sdk", "33");
+      const mgr = new SystemConfigurationManager(ANDROID_DEVICE, fakeAdbFactory, fakeExec);
+      const result = await mgr.setLocale("en-US");
+
+      expect(result.success).toBe(true);
+      expect(fakeExec.getExecutedCommands()).toHaveLength(0);
+      expect(fakeAdbClient.wasCommandExecuted("cmd locale set-locales en-US")).toBe(true);
+    });
+  });
+
+  describe("Android setTimeZone still works", () => {
+    test("uses adb commands for Android", async () => {
+      const mgr = new SystemConfigurationManager(ANDROID_DEVICE, fakeAdbFactory, fakeExec);
+      const result = await mgr.setTimeZone("America/New_York");
+
+      expect(result.success).toBe(true);
+      expect(fakeExec.getExecutedCommands()).toHaveLength(0);
+      expect(fakeAdbClient.wasCommandExecuted("setprop persist.sys.timezone America/New_York")).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Implement locale, timezone, and 24-hour format changes on iOS simulators via `xcrun simctl spawn` + `defaults write` commands
- Auto-timezone is disabled before setting timezone, and previous values are captured and returned
- Text direction returns a clear unsupported message (iOS drives RTL via locale, not a system toggle)
- Physical iOS devices are handled gracefully with a descriptive error
- Existing Android behavior is completely unaffected

## Test plan
- [x] 24 new unit tests covering all iOS simulator paths (setLocale, setTimeZone, set24HourFormat, setTextDirection, getLocalizationSettings, getCalendarSystem)
- [x] Tests verify physical device rejection, previous value capture, correct `xcrun simctl spawn` commands, and BCP-47 to Apple locale conversion
- [x] All 3116 existing tests continue to pass
- [x] Lint and build pass

Closes #1578

https://claude.ai/code/session_01KrKU1P3KmmPA8fvCZrw2Kx