### PR TITLE
fix(ci): use step-level skips for installer jobs on docs-only PRs

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -383,18 +383,23 @@ jobs:
     name: "Installer Minimal (${{ matrix.os }})"
     runs-on: ${{ matrix.os }}
     needs: detect-changes
-    if: needs.detect-changes.outputs.docs_only != 'true'
     strategy:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
     steps:
+      - name: "Skip for docs-only changes"
+        if: needs.detect-changes.outputs.docs_only == 'true'
+        run: echo "Skipping - documentation only changes"
+
       - name: "Git Checkout"
+        if: needs.detect-changes.outputs.docs_only != 'true'
         uses: actions/checkout@v6
         with:
           lfs: false
 
       - name: "Run Installer (minimal)"
+        if: needs.detect-changes.outputs.docs_only != 'true'
         shell: bash
         continue-on-error: true
         run: |
@@ -404,6 +409,7 @@ jobs:
           echo "INSTALL_EXIT_CODE=${PIPESTATUS[0]}" >> "$GITHUB_ENV"
 
       - name: "Run Uninstaller"
+        if: needs.detect-changes.outputs.docs_only != 'true'
         shell: bash
         continue-on-error: true
         run: |
@@ -412,7 +418,7 @@ jobs:
           echo "UNINSTALL_EXIT_CODE=${PIPESTATUS[0]}" >> "$GITHUB_ENV"
 
       - name: "Upload Logs"
-        if: env.INSTALL_EXIT_CODE != '0' || env.UNINSTALL_EXIT_CODE != '0' || failure()
+        if: needs.detect-changes.outputs.docs_only != 'true' && (env.INSTALL_EXIT_CODE != '0' || env.UNINSTALL_EXIT_CODE != '0' || failure())
         uses: actions/upload-artifact@v6
         with:
           name: installer-minimal-${{ matrix.os }}-logs
@@ -420,7 +426,7 @@ jobs:
           retention-days: 7
 
       - name: "Fail on error"
-        if: env.INSTALL_EXIT_CODE != '0' || env.UNINSTALL_EXIT_CODE != '0'
+        if: needs.detect-changes.outputs.docs_only != 'true' && (env.INSTALL_EXIT_CODE != '0' || env.UNINSTALL_EXIT_CODE != '0')
         shell: bash
         run: |
           echo "Installer exit code: ${INSTALL_EXIT_CODE:-0}"
@@ -431,18 +437,23 @@ jobs:
     name: "Installer Development (${{ matrix.os }})"
     runs-on: ${{ matrix.os }}
     needs: detect-changes
-    if: needs.detect-changes.outputs.docs_only != 'true'
     strategy:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
     steps:
+      - name: "Skip for docs-only changes"
+        if: needs.detect-changes.outputs.docs_only == 'true'
+        run: echo "Skipping - documentation only changes"
+
       - name: "Git Checkout"
+        if: needs.detect-changes.outputs.docs_only != 'true'
         uses: actions/checkout@v6
         with:
           lfs: false
 
       - name: "Run Installer (development)"
+        if: needs.detect-changes.outputs.docs_only != 'true'
         shell: bash
         continue-on-error: true
         run: |
@@ -452,7 +463,7 @@ jobs:
           echo "INSTALL_EXIT_CODE=${PIPESTATUS[0]}" >> "$GITHUB_ENV"
 
       - name: "Verify runtime dependencies"
-        if: env.INSTALL_EXIT_CODE == '0'
+        if: needs.detect-changes.outputs.docs_only != 'true' && env.INSTALL_EXIT_CODE == '0'
         shell: bash
         run: |
           set -uo pipefail
@@ -493,7 +504,7 @@ jobs:
           echo "All runtime dependencies verified."
 
       - name: "Build from source"
-        if: env.INSTALL_EXIT_CODE == '0'
+        if: needs.detect-changes.outputs.docs_only != 'true' && env.INSTALL_EXIT_CODE == '0'
         shell: bash
         run: |
           export PATH="${HOME}/.bun/bin:${PATH}"
@@ -501,7 +512,7 @@ jobs:
           bunx turbo run build --output-logs=errors-only
 
       - name: "Daemon lifecycle (start → health → doctor → stop)"
-        if: env.INSTALL_EXIT_CODE == '0'
+        if: needs.detect-changes.outputs.docs_only != 'true' && env.INSTALL_EXIT_CODE == '0'
         shell: bash
         run: |
           set -uo pipefail
@@ -518,7 +529,7 @@ jobs:
           bun dist/src/index.js --daemon stop   2>&1 | tee ci-logs/daemon-stop.log
 
       - name: "Upload Logs"
-        if: env.INSTALL_EXIT_CODE != '0' || failure()
+        if: needs.detect-changes.outputs.docs_only != 'true' && (env.INSTALL_EXIT_CODE != '0' || failure())
         uses: actions/upload-artifact@v6
         with:
           name: installer-development-${{ matrix.os }}-logs
@@ -526,7 +537,7 @@ jobs:
           retention-days: 7
 
       - name: "Fail on error"
-        if: env.INSTALL_EXIT_CODE != '0'
+        if: needs.detect-changes.outputs.docs_only != 'true' && env.INSTALL_EXIT_CODE != '0'
         shell: bash
         run: |
           echo "Installer exit code: ${INSTALL_EXIT_CODE:-0}"


### PR DESCRIPTION
## Summary
- Installer CI jobs used job-level `if` to skip on docs-only changes, which prevented matrix expansion and produced uninterpolated check names like `Installer Minimal (${{ matrix.os }})` that block merges
- Moved docs_only guard from job-level to step-level conditions so the matrix always expands and each OS-specific check reports success
- Follows the same pattern already used by `mcp-build-and-test` and other matrix jobs in the workflow

## Test Plan
- [ ] Docs-only PR (#1592) should unblock once this merges and CI re-evaluates
- [ ] Installer checks should show expanded names (`ubuntu-latest`, `macos-latest`) even when skipped

Closes #1592

🤖 Generated with [Claude Code](https://claude.com/claude-code)