### PR TITLE
chore: reduce log verbosity by downgrading high-volume info logs to debug

### DIFF
--- a/src/daemon/daemonMcpProxy.ts
+++ b/src/daemon/daemonMcpProxy.ts
@@ -294,6 +294,6 @@ export class DaemonMcpProxy {
     }
     this.connected = false;
     this.invalidateCache();
-    logger.info("[DaemonMcpProxy] Disconnected from daemon");
+    logger.debug("[DaemonMcpProxy] Disconnected from daemon");
   }
 }

--- a/src/daemon/deviceDataStreamSocketServer.ts
+++ b/src/daemon/deviceDataStreamSocketServer.ts
@@ -178,7 +178,7 @@ export class DeviceDataStreamSocketServer extends PushSubscriptionSocketServer<
 
     const sentCount = this.pushToSubscribers({ message, targetDeviceId: deviceId });
     if (sentCount > 0) {
-      logger.info(`[DeviceDataStream] Pushed hierarchy_update to ${sentCount} subscribers (device: ${deviceId})`);
+      logger.debug(`[DeviceDataStream] Pushed hierarchy_update to ${sentCount} subscribers (device: ${deviceId})`);
     }
   }
 
@@ -202,7 +202,7 @@ export class DeviceDataStreamSocketServer extends PushSubscriptionSocketServer<
 
     const sentCount = this.pushToSubscribers({ message, targetDeviceId: deviceId });
     if (sentCount > 0) {
-      logger.info(`[DeviceDataStream] Pushed screenshot_update to ${sentCount} subscribers (device: ${deviceId})`);
+      logger.debug(`[DeviceDataStream] Pushed screenshot_update to ${sentCount} subscribers (device: ${deviceId})`);
     }
   }
 
@@ -219,7 +219,7 @@ export class DeviceDataStreamSocketServer extends PushSubscriptionSocketServer<
 
     const sentCount = this.pushToSubscribers({ message, targetDeviceId: null });
     if (sentCount > 0) {
-      logger.info(`[DeviceDataStream] Pushed navigation_update to ${sentCount} subscribers`);
+      logger.debug(`[DeviceDataStream] Pushed navigation_update to ${sentCount} subscribers`);
     }
   }
 
@@ -236,7 +236,7 @@ export class DeviceDataStreamSocketServer extends PushSubscriptionSocketServer<
 
     const sentCount = this.pushToSubscribers({ message, targetDeviceId: deviceId });
     if (sentCount > 0) {
-      logger.info(`[DeviceDataStream] Pushed performance_update to ${sentCount} subscribers (device: ${deviceId})`);
+      logger.debug(`[DeviceDataStream] Pushed performance_update to ${sentCount} subscribers (device: ${deviceId})`);
     }
   }
 
@@ -253,7 +253,7 @@ export class DeviceDataStreamSocketServer extends PushSubscriptionSocketServer<
 
     const sentCount = this.pushToSubscribers({ message, targetDeviceId: deviceId });
     if (sentCount > 0) {
-      logger.info(`[DeviceDataStream] Pushed storage_update to ${sentCount} subscribers (device: ${deviceId})`);
+      logger.debug(`[DeviceDataStream] Pushed storage_update to ${sentCount} subscribers (device: ${deviceId})`);
     }
   }
 

--- a/src/daemon/devicePool.ts
+++ b/src/daemon/devicePool.ts
@@ -618,9 +618,9 @@ export class DevicePool {
    * This enables parallel test execution with limited devices.
    */
   async assignDeviceToSession(sessionId: string, platform?: Platform): Promise<string> {
-    logger.info(`[DEVICE-POOL-DEBUG] Instance #${this.instanceId}: assignDeviceToSession called for session ${sessionId}`);
-    logger.info(`[DEVICE-POOL-DEBUG] Instance #${this.instanceId}: Current devices.size: ${this.devices.size}`);
-    logger.info(`[DEVICE-POOL-DEBUG] Instance #${this.instanceId}: Device IDs: ${Array.from(this.devices.keys()).join(", ")}`);
+    logger.debug(`[DEVICE-POOL-DEBUG] Instance #${this.instanceId}: assignDeviceToSession called for session ${sessionId}`);
+    logger.debug(`[DEVICE-POOL-DEBUG] Instance #${this.instanceId}: Current devices.size: ${this.devices.size}`);
+    logger.debug(`[DEVICE-POOL-DEBUG] Instance #${this.instanceId}: Device IDs: ${Array.from(this.devices.keys()).join(", ")}`);
 
     const maxAttempts = Math.ceil(this.DEVICE_WAIT_TIMEOUT_MS / this.DEVICE_WAIT_INTERVAL_MS);
     let firstAttemptLogged = false;

--- a/src/db/navigationRepository.ts
+++ b/src/db/navigationRepository.ts
@@ -138,7 +138,7 @@ export class NavigationRepository {
       .returningAll()
       .executeTakeFirstOrThrow();
 
-    logger.info(`[NAV_REPO] New screen discovered: ${screenName} (id=${result.id})`);
+    logger.debug(`[NAV_REPO] New screen discovered: ${screenName} (id=${result.id})`);
 
     return result;
   }
@@ -256,7 +256,7 @@ export class NavigationRepository {
       .executeTakeFirstOrThrow();
 
     const toolInfo = toolName ? ` via ${toolName}` : " (unknown)";
-    logger.info(
+    logger.debug(
       `[NAV_REPO] Edge created: ${fromScreen} → ${toScreen}${toolInfo} (id=${result.id})`
     );
 

--- a/src/features/navigation/NavigationGraphManager.ts
+++ b/src/features/navigation/NavigationGraphManager.ts
@@ -1320,7 +1320,7 @@ export class NavigationGraphManager implements NavigationGraphService {
   }
 
   private notifyGraphUpdated(): void {
-    logger.info(`[NAVIGATION_GRAPH] notifyGraphUpdated called, ${this.graphUpdateListeners.length} listeners`);
+    logger.debug(`[NAVIGATION_GRAPH] notifyGraphUpdated called, ${this.graphUpdateListeners.length} listeners`);
     for (const listener of this.graphUpdateListeners) {
       try {
         listener();

--- a/src/features/observe/ObserveScreen.ts
+++ b/src/features/observe/ObserveScreen.ts
@@ -364,7 +364,7 @@ export class RealObserveScreen implements ObserveScreen {
         if (viewHierarchy.notificationPermissionDetected !== undefined) {
           result.notificationPermissionDetected = viewHierarchy.notificationPermissionDetected;
           if (viewHierarchy.notificationPermissionDetected) {
-            logger.info("[ObserveScreen] Notification permission dialog detected in view hierarchy");
+            logger.debug("[ObserveScreen] Notification permission dialog detected in view hierarchy");
           }
         }
       }
@@ -407,7 +407,7 @@ export class RealObserveScreen implements ObserveScreen {
       result.intentChooserDetected = intentChooserDetected;
 
       if (intentChooserDetected) {
-        logger.info("[ObserveScreen] Intent chooser dialog detected in view hierarchy");
+        logger.debug("[ObserveScreen] Intent chooser dialog detected in view hierarchy");
       }
     } catch (error) {
       logger.warn(`[ObserveScreen] Failed to detect intent chooser: ${error}`);
@@ -422,12 +422,12 @@ export class RealObserveScreen implements ObserveScreen {
    */
   public async collectActiveWindow(result: ObserveResult): Promise<void> {
     try {
-      logger.info("[OBSERVER] collectActiveWindow");
+      logger.debug("[OBSERVER] collectActiveWindow");
       const windowStart = this.timer.now();
 
       const activeWindow = await this.window.getActive();
 
-      logger.info(`Active window retrieval took ${this.timer.now() - windowStart}ms`);
+      logger.debug(`Active window retrieval took ${this.timer.now() - windowStart}ms`);
       if (activeWindow) {
         result.activeWindow = activeWindow;
       }
@@ -791,13 +791,13 @@ export class RealObserveScreen implements ObserveScreen {
     const startTime = this.timer.now();
 
     try {
-      logger.info("[OBSERVE_CACHE] Getting most recent cached observe result");
+      logger.debug("[OBSERVE_CACHE] Getting most recent cached observe result");
 
       // Check in-memory cache first
       const memoryResult = await this.checkInMemoryObserveCache();
       if (memoryResult) {
         const duration = this.timer.now() - startTime;
-        logger.info(`[OBSERVE_CACHE] Found recent result in memory cache (${duration}ms)`);
+        logger.debug(`[OBSERVE_CACHE] Found recent result in memory cache (${duration}ms)`);
         return memoryResult;
       }
 
@@ -805,13 +805,13 @@ export class RealObserveScreen implements ObserveScreen {
       const diskResult = await this.checkDiskObserveCache();
       if (diskResult) {
         const duration = this.timer.now() - startTime;
-        logger.info(`[OBSERVE_CACHE] Found recent result in disk cache (${duration}ms)`);
+        logger.debug(`[OBSERVE_CACHE] Found recent result in disk cache (${duration}ms)`);
         return diskResult;
       }
 
       // No cached result available
       const duration = this.timer.now() - startTime;
-      logger.info(`[OBSERVE_CACHE] No cached observe result available (${duration}ms)`);
+      logger.debug(`[OBSERVE_CACHE] No cached observe result available (${duration}ms)`);
 
       return {
         updatedAt: new Date().toISOString(),
@@ -838,10 +838,10 @@ export class RealObserveScreen implements ObserveScreen {
    */
   private async checkInMemoryObserveCache(): Promise<ObserveResult | null> {
     const cacheSize = RealObserveScreen.observeResultCache.size;
-    logger.info(`[OBSERVE_CACHE] Checking in-memory cache, size: ${cacheSize}`);
+    logger.debug(`[OBSERVE_CACHE] Checking in-memory cache, size: ${cacheSize}`);
 
     if (cacheSize === 0) {
-      logger.info("[OBSERVE_CACHE] In-memory cache is empty");
+      logger.debug("[OBSERVE_CACHE] In-memory cache is empty");
       return null;
     }
 
@@ -857,7 +857,7 @@ export class RealObserveScreen implements ObserveScreen {
 
       if (age >= ttl) {
         expiredKeys.push(key);
-        logger.info(`[OBSERVE_CACHE] Removing expired cache entry: ${key} (age: ${age}ms > TTL: ${ttl}ms)`);
+        logger.debug(`[OBSERVE_CACHE] Removing expired cache entry: ${key} (age: ${age}ms > TTL: ${ttl}ms)`);
       } else {
         // Check if this is the most recent valid entry
         if (!mostRecentEntry || cachedEntry.timestamp > mostRecentEntry.timestamp) {
@@ -873,11 +873,11 @@ export class RealObserveScreen implements ObserveScreen {
 
     if (mostRecentEntry) {
       const age = now - mostRecentEntry.timestamp;
-      logger.info(`[OBSERVE_CACHE] Found most recent in-memory result (age: ${age}ms)`);
+      logger.debug(`[OBSERVE_CACHE] Found most recent in-memory result (age: ${age}ms)`);
       return mostRecentEntry.observeResult;
     }
 
-    logger.info("[OBSERVE_CACHE] No valid entries in in-memory cache");
+    logger.debug("[OBSERVE_CACHE] No valid entries in in-memory cache");
     return null;
   }
 
@@ -886,7 +886,7 @@ export class RealObserveScreen implements ObserveScreen {
    * @returns Promise<ObserveResult | null> - Most recent cached result or null
    */
   private async checkDiskObserveCache(): Promise<ObserveResult | null> {
-    logger.info("[OBSERVE_CACHE] Checking disk cache");
+    logger.debug("[OBSERVE_CACHE] Checking disk cache");
 
     try {
       // Get all JSON files in the cache directory
@@ -894,7 +894,7 @@ export class RealObserveScreen implements ObserveScreen {
       const jsonFiles = files.filter(file => file.endsWith(".json") && file.startsWith("observe_"));
 
       if (jsonFiles.length === 0) {
-        logger.info("[OBSERVE_CACHE] No observe result files found in disk cache");
+        logger.debug("[OBSERVE_CACHE] No observe result files found in disk cache");
         return null;
       }
 
@@ -920,7 +920,7 @@ export class RealObserveScreen implements ObserveScreen {
 
       if (mostRecentFile) {
         const age = now - mostRecentFile.mtime;
-        logger.info(`[OBSERVE_CACHE] Loading most recent disk cache file (age: ${age}ms)`);
+        logger.debug(`[OBSERVE_CACHE] Loading most recent disk cache file (age: ${age}ms)`);
 
         const cacheData = await readFileAsync(mostRecentFile.path, "utf8");
         const cachedResult: ObserveResult = JSON.parse(cacheData);
@@ -932,11 +932,11 @@ export class RealObserveScreen implements ObserveScreen {
           observeResult: cachedResult
         });
 
-        logger.info(`[OBSERVE_CACHE] Updated in-memory cache from disk cache`);
+        logger.debug(`[OBSERVE_CACHE] Updated in-memory cache from disk cache`);
         return cachedResult;
       }
 
-      logger.info("[OBSERVE_CACHE] No valid files in disk cache");
+      logger.debug("[OBSERVE_CACHE] No valid files in disk cache");
       return null;
     } catch (error) {
       logger.warn(`[OBSERVE_CACHE] Error checking disk cache: ${error}`);
@@ -953,7 +953,7 @@ export class RealObserveScreen implements ObserveScreen {
     const timestampKey = timestamp.toString();
 
     try {
-      logger.info(`[OBSERVE_CACHE] Caching observe result with timestamp ${timestamp}`);
+      logger.debug(`[OBSERVE_CACHE] Caching observe result with timestamp ${timestamp}`);
 
       // Cache in memory
       RealObserveScreen.observeResultCache.set(timestampKey, {
@@ -964,7 +964,7 @@ export class RealObserveScreen implements ObserveScreen {
       // Cache on disk
       await this.saveObserveResultToDisk(timestampKey, observeResult);
 
-      logger.info(`[OBSERVE_CACHE] Successfully cached observe result, in-memory cache size: ${RealObserveScreen.observeResultCache.size}`);
+      logger.debug(`[OBSERVE_CACHE] Successfully cached observe result, in-memory cache size: ${RealObserveScreen.observeResultCache.size}`);
     } catch (error) {
       logger.warn(`[OBSERVE_CACHE] Error caching observe result: ${error}`);
     }
@@ -981,7 +981,7 @@ export class RealObserveScreen implements ObserveScreen {
       const filePath = path.join(RealObserveScreen.observeResultCacheDir, filename);
 
       await writeFileAsync(filePath, JSON.stringify(observeResult, null, 2));
-      logger.info(`[OBSERVE_CACHE] Saved observe result to disk: ${filename}`);
+      logger.debug(`[OBSERVE_CACHE] Saved observe result to disk: ${filename}`);
     } catch (error) {
       logger.warn(`[OBSERVE_CACHE] Failed to save observe result to disk: ${error}`);
     }

--- a/src/features/observe/android/CtrlProxyClient.ts
+++ b/src/features/observe/android/CtrlProxyClient.ts
@@ -800,7 +800,7 @@ export class CtrlProxyClient extends DeviceServiceClient implements CtrlProxy {
       }
 
       const requestId = this.requestManager.generateId("action");
-      logger.info(`[CTRL_PROXY] Creating action request (requestId: ${requestId}, action: ${action}, resourceId: ${resourceId})`);
+      logger.debug(`[CTRL_PROXY] Creating action request (requestId: ${requestId}, action: ${action}, resourceId: ${resourceId})`);
 
       const actionPromise = this.requestManager.register<A11yActionResult>(
         requestId, "action", timeoutMs,
@@ -813,14 +813,14 @@ export class CtrlProxyClient extends DeviceServiceClient implements CtrlProxy {
         }
         const message = JSON.stringify({ type: "request_action", requestId, action, resourceId });
         this.ws.send(message);
-        logger.info(`[CTRL_PROXY] Sent action request (requestId: ${requestId}, action: ${action}, resourceId: ${resourceId})`);
+        logger.debug(`[CTRL_PROXY] Sent action request (requestId: ${requestId}, action: ${action}, resourceId: ${resourceId})`);
       });
 
       const result = await perf.track("waitForAction", () => actionPromise);
       const clientDuration = this.timer.now() - startTime;
 
       if (result.success) {
-        logger.info(`[CTRL_PROXY] Action completed: clientTime=${clientDuration}ms, deviceTotalTime=${result.totalTimeMs}ms, action=${result.action}`);
+        logger.debug(`[CTRL_PROXY] Action completed: clientTime=${clientDuration}ms, deviceTotalTime=${result.totalTimeMs}ms, action=${result.action}`);
       } else {
         logger.warn(`[CTRL_PROXY] Action failed after ${clientDuration}ms: ${result.error}`);
       }
@@ -984,7 +984,7 @@ export class CtrlProxyClient extends DeviceServiceClient implements CtrlProxy {
 
       if (result.success) {
         const dataSize = result.data ? result.data.length : 0;
-        logger.info(`[CTRL_PROXY] Screenshot received in ${duration}ms (${dataSize} base64 chars)`);
+        logger.debug(`[CTRL_PROXY] Screenshot received in ${duration}ms (${dataSize} base64 chars)`);
       } else {
         logger.warn(`[CTRL_PROXY] Screenshot failed after ${duration}ms: ${result.error}`);
       }
@@ -1000,12 +1000,12 @@ export class CtrlProxyClient extends DeviceServiceClient implements CtrlProxy {
   async verifyServiceReady(maxAttempts: number = 5, delayMs: number = 500, timeoutMs: number = 3000): Promise<boolean> {
     const result = await this.retryExecutor.execute(
       async attempt => {
-        logger.info(`[CTRL_PROXY] Verifying service ready (attempt ${attempt}/${maxAttempts})`);
+        logger.debug(`[CTRL_PROXY] Verifying service ready (attempt ${attempt}/${maxAttempts})`);
 
         const hierarchyResult = await this.requestHierarchySync(new NoOpPerformanceTracker(), false, undefined, timeoutMs);
 
         if (hierarchyResult && hierarchyResult.hierarchy) {
-          logger.info(`[CTRL_PROXY] Service verified ready after ${attempt} attempt(s)`);
+          logger.debug(`[CTRL_PROXY] Service verified ready after ${attempt} attempt(s)`);
           return true;
         }
 
@@ -1132,12 +1132,12 @@ export class CtrlProxyClient extends DeviceServiceClient implements CtrlProxy {
         logger.debug(`[CTRL_PROXY] Port forwarding already active (localhost:${this.localPort})`);
         return;
       }
-      logger.info(`[CTRL_PROXY] Port forwarding was lost, re-establishing...`);
+      logger.debug(`[CTRL_PROXY] Port forwarding was lost, re-establishing...`);
       this.portForwardingSetup = false;
     }
 
     try {
-      logger.info(`[CTRL_PROXY] Setting up port forwarding for WebSocket: localhost:${this.localPort} → device:${PortManager.DEVICE_PORT} (device: ${this.device.deviceId})`);
+      logger.debug(`[CTRL_PROXY] Setting up port forwarding for WebSocket: localhost:${this.localPort} → device:${PortManager.DEVICE_PORT} (device: ${this.device.deviceId})`);
 
       await perf.track("clearPortForward", () =>
         this.adb.executeCommand(`forward --remove tcp:${this.localPort}`).catch(() => {})
@@ -1148,7 +1148,7 @@ export class CtrlProxyClient extends DeviceServiceClient implements CtrlProxy {
       );
 
       this.portForwardingSetup = true;
-      logger.info(`[CTRL_PROXY] Port forwarding setup complete (localhost:${this.localPort})`);
+      logger.debug(`[CTRL_PROXY] Port forwarding setup complete (localhost:${this.localPort})`);
     } catch (error) {
       logger.warn(`[CTRL_PROXY] Failed to setup port forwarding: ${error}`);
       throw error;

--- a/src/features/observe/android/CtrlProxyHierarchy.ts
+++ b/src/features/observe/android/CtrlProxyHierarchy.ts
@@ -156,7 +156,7 @@ export class CtrlProxyHierarchy {
         const duration = this.context.timer.now() - startTime;
 
         if (freshData) {
-          logger.info(`[CTRL_PROXY] Received fresh hierarchy in ${duration}ms (updatedAt: ${freshData.hierarchy.updatedAt})`);
+          logger.debug(`[CTRL_PROXY] Received fresh hierarchy in ${duration}ms (updatedAt: ${freshData.hierarchy.updatedAt})`);
           return {
             hierarchy: freshData.hierarchy,
             fresh: true,
@@ -172,7 +172,7 @@ export class CtrlProxyHierarchy {
           const currentCache = this.context.getCachedHierarchy();
           if (currentCache) {
             currentCache.fresh = false;
-            logger.info(`[CTRL_PROXY] Returning stale cached data (updatedAt: ${currentCache.hierarchy.updatedAt}), marked cache as stale`);
+            logger.debug(`[CTRL_PROXY] Returning stale cached data (updatedAt: ${currentCache.hierarchy.updatedAt}), marked cache as stale`);
             return {
               hierarchy: currentCache.hierarchy,
               fresh: false,
@@ -225,7 +225,7 @@ export class CtrlProxyHierarchy {
         AndroidCtrlProxyManager.getInstance(this.context.device, this.context.adb).isAvailable()
       );
       if (!available) {
-        logger.info("[CTRL_PROXY] Service not available, will use fallback");
+        logger.debug("[CTRL_PROXY] Service not available, will use fallback");
         perf.end();
         return null;
       }
@@ -243,7 +243,7 @@ export class CtrlProxyHierarchy {
       // If no hierarchy from WebSocket or data is stale, sync to get fresh data
       const needsSync = !hierarchyData || !isFresh;
       if (needsSync) {
-        logger.info(`[CTRL_PROXY] WebSocket returned ${hierarchyData ? "stale" : "no"} data (fresh=${isFresh}), syncing for fresh data`);
+        logger.debug(`[CTRL_PROXY] WebSocket returned ${hierarchyData ? "stale" : "no"} data (fresh=${isFresh}), syncing for fresh data`);
 
         const syncResult = await perf.track("syncRequest", () =>
           this.requestHierarchySync(perf, disableAllFiltering, signal)
@@ -255,7 +255,7 @@ export class CtrlProxyHierarchy {
             androidPerfTiming = syncResult.perfTiming;
           }
           isFresh = true;
-          logger.info("[CTRL_PROXY] Successfully retrieved hierarchy via sync ADB method");
+          logger.debug("[CTRL_PROXY] Successfully retrieved hierarchy via sync ADB method");
         } else if (!hierarchyData) {
           logger.warn("[CTRL_PROXY] Both WebSocket and sync methods failed, will use fallback");
           perf.end();
@@ -281,7 +281,7 @@ export class CtrlProxyHierarchy {
       perf.end();
 
       const duration = this.context.timer.now() - startTime;
-      logger.info(`[CTRL_PROXY] Successfully retrieved and converted hierarchy in ${duration}ms (fresh: ${isFresh}, updatedAt: ${hierarchyData!.updatedAt})`);
+      logger.debug(`[CTRL_PROXY] Successfully retrieved and converted hierarchy in ${duration}ms (fresh: ${isFresh}, updatedAt: ${hierarchyData!.updatedAt})`);
 
       return convertedHierarchy;
     } catch (error) {
@@ -307,7 +307,7 @@ export class CtrlProxyHierarchy {
     const effectiveTimeoutMs = Math.max(0, timeoutMs);
 
     try {
-      logger.info("[CTRL_PROXY] Requesting hierarchy sync via WebSocket");
+      logger.debug("[CTRL_PROXY] Requesting hierarchy sync via WebSocket");
 
       // Ensure WebSocket connection is established
       await this.context.ensureConnected(perf);
@@ -319,7 +319,7 @@ export class CtrlProxyHierarchy {
 
       // Fall back to ADB broadcast if WebSocket failed
       if (!sentViaWebSocket) {
-        logger.info("[CTRL_PROXY] Falling back to ADB broadcast");
+        logger.debug("[CTRL_PROXY] Falling back to ADB broadcast");
         const uuid = `sync_${this.context.timer.now()}_${generateSecureId()}`;
         await perf.track("sendBroadcast", async () => {
           await this.context.adb.executeCommand(
@@ -362,7 +362,7 @@ export class CtrlProxyHierarchy {
     const startTime = this.context.timer.now();
 
     try {
-      logger.info("[CTRL_PROXY] Converting accessibility service format to ViewHierarchyResult format");
+      logger.debug("[CTRL_PROXY] Converting accessibility service format to ViewHierarchyResult format");
 
       const hierarchyToConvert: AccessibilityNode | undefined = accessibilityHierarchy.hierarchy;
       const resolvedPackageName = accessibilityHierarchy.packageName;
@@ -412,7 +412,7 @@ export class CtrlProxyHierarchy {
       };
 
       const duration = this.context.timer.now() - startTime;
-      logger.info(`[CTRL_PROXY] Format conversion completed in ${duration}ms`);
+      logger.debug(`[CTRL_PROXY] Format conversion completed in ${duration}ms`);
 
       return result;
     } catch (error) {
@@ -534,7 +534,7 @@ export class CtrlProxyHierarchy {
         // Send "nudge" after staleCheckDelay
         if (!staleCheckSent && elapsed >= staleCheckDelay) {
           staleCheckSent = true;
-          logger.info(`[CTRL_PROXY] No push received after ${staleCheckDelay}ms, sending stale check request (sinceTimestamp: ${minTimestamp})`);
+          logger.debug(`[CTRL_PROXY] No push received after ${staleCheckDelay}ms, sending stale check request (sinceTimestamp: ${minTimestamp})`);
           this.sendHierarchyIfStaleRequest(minTimestamp);
         }
 

--- a/src/utils/CtrlProxyManager.ts
+++ b/src/utils/CtrlProxyManager.ts
@@ -367,7 +367,7 @@ export class AndroidCtrlProxyManager implements CtrlProxyManager {
     if (this.cachedInstallation && this.cachedInstallation.isInstalled) {
       const cacheAge = this.timer.now() - this.cachedInstallation.timestamp;
       if (cacheAge < AndroidCtrlProxyManager.STATUS_CACHE_TTL) {
-        logger.info(`[CTRL_PROXY] Using cached installation status (age: ${cacheAge}ms): ${this.cachedInstallation.isInstalled ? "installed" : "not installed"}`);
+        logger.debug(`[CTRL_PROXY] Using cached installation status (age: ${cacheAge}ms): ${this.cachedInstallation.isInstalled ? "installed" : "not installed"}`);
         return this.cachedInstallation.isInstalled;
       } else {
         this.cachedInstallation = null;
@@ -375,7 +375,7 @@ export class AndroidCtrlProxyManager implements CtrlProxyManager {
     }
 
     try {
-      logger.info("[CTRL_PROXY] Checking if accessibility service is installed");
+      logger.debug("[CTRL_PROXY] Checking if accessibility service is installed");
       const result = await this.adb.executeCommand(`shell pm list packages | grep ${AndroidCtrlProxyManager.PACKAGE}`, undefined, undefined, true);
       const isInstalled = result.stdout.includes(AndroidCtrlProxyManager.PACKAGE);
 
@@ -385,7 +385,7 @@ export class AndroidCtrlProxyManager implements CtrlProxyManager {
         timestamp: this.timer.now()
       };
 
-      logger.info(`[CTRL_PROXY] Service installation status: ${isInstalled ? "installed" : "not installed"} (cached for ${AndroidCtrlProxyManager.STATUS_CACHE_TTL / 1000 / 60} minutes)`);
+      logger.debug(`[CTRL_PROXY] Service installation status: ${isInstalled ? "installed" : "not installed"} (cached for ${AndroidCtrlProxyManager.STATUS_CACHE_TTL / 1000 / 60} minutes)`);
       return isInstalled;
     } catch (error) {
       logger.warn(`[CTRL_PROXY] Error checking installation status: ${error}`);
@@ -401,7 +401,7 @@ export class AndroidCtrlProxyManager implements CtrlProxyManager {
     if (this.cachedEnabled && this.cachedEnabled.isEnabled) {
       const cacheAge = this.timer.now() - this.cachedEnabled.timestamp;
       if (cacheAge < AndroidCtrlProxyManager.STATUS_CACHE_TTL) {
-        logger.info(`[CTRL_PROXY] Using cached enabled status (age: ${cacheAge}ms): ${this.cachedEnabled.isEnabled ? "enabled" : "disabled"}`);
+        logger.debug(`[CTRL_PROXY] Using cached enabled status (age: ${cacheAge}ms): ${this.cachedEnabled.isEnabled ? "enabled" : "disabled"}`);
         return this.cachedEnabled.isEnabled;
       } else {
         this.cachedEnabled = null;
@@ -409,7 +409,7 @@ export class AndroidCtrlProxyManager implements CtrlProxyManager {
     }
 
     try {
-      logger.info("[CTRL_PROXY] Checking if accessibility service is enabled");
+      logger.debug("[CTRL_PROXY] Checking if accessibility service is enabled");
       const result = await this.adb.executeCommand("shell settings get secure enabled_accessibility_services");
       const isEnabled = result.stdout.includes(AndroidCtrlProxyManager.PACKAGE);
 
@@ -419,7 +419,7 @@ export class AndroidCtrlProxyManager implements CtrlProxyManager {
         timestamp: this.timer.now()
       };
 
-      logger.info(`[CTRL_PROXY] Service enabled status: ${isEnabled ? "enabled" : "disabled"} (cached for ${AndroidCtrlProxyManager.STATUS_CACHE_TTL / 1000 / 60} minutes)`);
+      logger.debug(`[CTRL_PROXY] Service enabled status: ${isEnabled ? "enabled" : "disabled"} (cached for ${AndroidCtrlProxyManager.STATUS_CACHE_TTL / 1000 / 60} minutes)`);
       return isEnabled;
     } catch (error) {
       logger.warn(`[CTRL_PROXY] Error checking enabled status: ${error}`);
@@ -433,10 +433,10 @@ export class AndroidCtrlProxyManager implements CtrlProxyManager {
    */
   async isEnabledForUser(userId: number): Promise<boolean> {
     try {
-      logger.info(`[CTRL_PROXY] Checking if accessibility service is enabled for user ${userId}`);
+      logger.debug(`[CTRL_PROXY] Checking if accessibility service is enabled for user ${userId}`);
       const result = await this.adb.executeCommand(`shell settings --user ${userId} get secure enabled_accessibility_services`);
       const isEnabled = result.stdout.includes(AndroidCtrlProxyManager.PACKAGE);
-      logger.info(`[CTRL_PROXY] Service enabled status for user ${userId}: ${isEnabled ? "enabled" : "disabled"}`);
+      logger.debug(`[CTRL_PROXY] Service enabled status for user ${userId}: ${isEnabled ? "enabled" : "disabled"}`);
       return isEnabled;
     } catch (error) {
       logger.warn(`[CTRL_PROXY] Error checking enabled status for user ${userId}: ${error}`);
@@ -455,14 +455,14 @@ export class AndroidCtrlProxyManager implements CtrlProxyManager {
     if (this.cachedAvailability && this.cachedAvailability.isAvailable) {
       const cacheAge = this.timer.now() - this.cachedAvailability.timestamp;
       if (cacheAge < AndroidCtrlProxyManager.AVAILABILITY_CACHE_TTL) {
-        logger.info(`[CTRL_PROXY] Using cached overall availability (age: ${cacheAge}ms): ${this.cachedAvailability.isAvailable}`);
+        logger.debug(`[CTRL_PROXY] Using cached overall availability (age: ${cacheAge}ms): ${this.cachedAvailability.isAvailable}`);
         return this.cachedAvailability.isAvailable;
       } else {
         this.cachedAvailability = null;
       }
     }
 
-    logger.info(`[CTRL_PROXY] Checking availability (no cached result available)`);
+    logger.debug(`[CTRL_PROXY] Checking availability (no cached result available)`);
 
     try {
       // Check installation and enabled status in parallel for better performance
@@ -480,7 +480,7 @@ export class AndroidCtrlProxyManager implements CtrlProxyManager {
         timestamp: this.timer.now()
       };
 
-      logger.info(`[CTRL_PROXY] Availability check completed in ${duration}ms - Available: ${available} (cached for ${AndroidCtrlProxyManager.AVAILABILITY_CACHE_TTL / 1000 / 60} minutes)`);
+      logger.debug(`[CTRL_PROXY] Availability check completed in ${duration}ms - Available: ${available} (cached for ${AndroidCtrlProxyManager.AVAILABILITY_CACHE_TTL / 1000 / 60} minutes)`);
       return available;
     } catch (error) {
       const duration = this.timer.now() - startTime;

--- a/src/utils/android-cmdline-tools/AdbClient.ts
+++ b/src/utils/android-cmdline-tools/AdbClient.ts
@@ -296,7 +296,7 @@ export class AdbClient implements AdbExecutor {
     // Only log longer commands or ones that take significant time
     if (duration > 10 || command.includes("screencap") || command.includes("uiautomator") || command.includes("getevent")) {
       const outputSize = result.stdout.length + result.stderr.length;
-      logger.info(`[ADB] Command completed in ${duration}ms (output: ${outputSize} bytes): ${command.length > 50 ? command.substring(0, 50) + "..." : command}`);
+      logger.debug(`[ADB] Command completed in ${duration}ms (output: ${outputSize} bytes): ${command.length > 50 ? command.substring(0, 50) + "..." : command}`);
     }
 
     return result;
@@ -403,14 +403,12 @@ export class AdbClient implements AdbExecutor {
 
     // Log which device is receiving this command for parallel execution debugging
     const deviceInfo = this.device ? `[DEVICE:${this.device.deviceId}]` : "[NO-DEVICE]";
-    logger.info(`[ADB] ${deviceInfo} Executing: ${command.length > 80 ? command.substring(0, 80) + "..." : command}`);
+    logger.debug(`[ADB] ${deviceInfo} Executing: ${command.length > 80 ? command.substring(0, 80) + "..." : command}`);
 
     if (noRetry) {
       // No retry - just execute once
       try {
         const result = await this.execWithSignal(adbPath, fullArgs, maxBuffer, timeoutMs, resolvedSignal);
-        const duration = this.timer.now() - startTime;
-        logger.info(`[ADB] Command completed in ${duration}ms: ${command}`);
         return result;
       } catch (error) {
         if (resolvedSignal?.aborted) {
@@ -429,8 +427,6 @@ export class AdbClient implements AdbExecutor {
           throw new Error(OPERATION_CANCELLED_MESSAGE);
         }
         const result = await this.execWithSignal(adbPath, fullArgs, maxBuffer, timeoutMs, resolvedSignal);
-        const duration = this.timer.now() - startTime;
-        logger.info(`[ADB] Command completed in ${duration}ms: ${command}`);
         return result;
       },
       {

--- a/src/utils/android-cmdline-tools/AndroidEmulatorClient.ts
+++ b/src/utils/android-cmdline-tools/AndroidEmulatorClient.ts
@@ -845,36 +845,36 @@ export class AndroidEmulatorClient implements AndroidEmulator {
     const backgroundPoller = async () => {
       while (pollingActive && !foundDeviceId) {
         try {
-          logger.info(`Background polling iteration - checking for emulator '${avdName}'...`);
+          logger.debug(`Background polling iteration - checking for emulator '${avdName}'...`);
 
           // For local emulators, check for running devices
-          logger.info(`Checking for running local emulators...`);
+          logger.debug(`Checking for running local emulators...`);
           const runningEmulators = await this.getBootedDevices();
-          logger.info(`Device scan complete - found ${runningEmulators.length} running emulators`);
+          logger.debug(`Device scan complete - found ${runningEmulators.length} running emulators`);
 
           if (runningEmulators.length > 0) {
-            logger.info(`Found ${runningEmulators.length} running emulators: ${runningEmulators.map(e => `${e.name}(${e.deviceId})`).join(", ")}`);
+            logger.debug(`Found ${runningEmulators.length} running emulators: ${runningEmulators.map(e => `${e.name}(${e.deviceId})`).join(", ")}`);
 
             // Look for emulator by name first
             let emulator = runningEmulators.find(emu => emu.name === avdName);
-            logger.info(`Exact name match for '${avdName}': ${emulator ? `Found ${emulator.deviceId}` : "Not found"}`);
+            logger.debug(`Exact name match for '${avdName}': ${emulator ? `Found ${emulator.deviceId}` : "Not found"}`);
 
             // If not found by exact name, try to find any local emulator
             if (!emulator) {
               emulator = runningEmulators.find(emu => emu.source === "local");
               if (emulator) {
-                logger.info(`Found local emulator with deviceId ${emulator.deviceId}, but name mismatch. Expected: ${avdName}, Found: ${emulator.name}`);
+                logger.debug(`Found local emulator with deviceId ${emulator.deviceId}, but name mismatch. Expected: ${avdName}, Found: ${emulator.name}`);
               } else {
-                logger.info(`No local emulators found to use as fallback`);
+                logger.debug(`No local emulators found to use as fallback`);
               }
             }
 
             if (emulator && emulator.deviceId) {
-              logger.info(`Target emulator found: ${emulator.name} (${emulator.deviceId}) - starting readiness checks`);
+              logger.debug(`Target emulator found: ${emulator.name} (${emulator.deviceId}) - starting readiness checks`);
 
               // Check if the device is online and ready
               // Run device state and package manager checks in parallel for faster detection
-              logger.info(`[PARALLEL] Running device state and package manager checks for ${emulator.deviceId}...`);
+              logger.debug(`[PARALLEL] Running device state and package manager checks for ${emulator.deviceId}...`);
               const adb = this.adbFactory.create(emulator);
               try {
                 const [deviceStateResult, packageManagerResult] = await Promise.allSettled([
@@ -884,42 +884,42 @@ export class AndroidEmulatorClient implements AndroidEmulator {
 
                 // Check device state result
                 if (deviceStateResult.status !== "fulfilled" || packageManagerResult.status !== "fulfilled") {
-                  logger.info(`[PARALLEL] Checks not yet complete: deviceStatus: ${deviceStateResult.status}, packageManager: ${packageManagerResult.status}`);
+                  logger.debug(`[PARALLEL] Checks not yet complete: deviceStatus: ${deviceStateResult.status}, packageManager: ${packageManagerResult.status}`);
                 } else {
                   const stateOutput = deviceStateResult.value.stdout.trim();
-                  logger.info(`[PARALLEL] Package manager command completed for ${emulator.deviceId} - output: ${packageManagerResult.value.stdout.length} bytes`);
+                  logger.debug(`[PARALLEL] Package manager command completed for ${emulator.deviceId} - output: ${packageManagerResult.value.stdout.length} bytes`);
                   if (!stateOutput.includes("device")) {
-                    logger.info(`[PARALLEL] ❌ Device state check failed for ${emulator.deviceId}: state="${stateOutput}"`);
+                    logger.debug(`[PARALLEL] ❌ Device state check failed for ${emulator.deviceId}: state="${stateOutput}"`);
                   } else if (!packageManagerResult.value.stdout || !packageManagerResult.value.stdout.includes("package:")) {
-                    logger.info(`[PARALLEL] ❌ Package manager returned no packages for ${emulator.deviceId} (${packageManagerResult.value.stdout.length} bytes output)`);
+                    logger.debug(`[PARALLEL] ❌ Package manager returned no packages for ${emulator.deviceId} (${packageManagerResult.value.stdout.length} bytes output)`);
                   } else if (packageManagerResult.value.stderr || packageManagerResult.value.stderr.includes("Failure")) {
-                    logger.info(`[PARALLEL] ❌ Package manager returned failure for ${emulator.deviceId}: ${packageManagerResult.value.stderr}`);
+                    logger.debug(`[PARALLEL] ❌ Package manager returned failure for ${emulator.deviceId}: ${packageManagerResult.value.stderr}`);
                   } else {
-                    logger.info(`[PARALLEL] ✅ Device state check passed for ${emulator.deviceId}`);
-                    logger.info(`[PARALLEL] ✅ Package manager is responsive for ${emulator.deviceId} - emulator is ready!`);
-                    logger.info(`[PARALLEL] ✅ No package manager errors detected - marking emulator as ready`);
+                    logger.debug(`[PARALLEL] ✅ Device state check passed for ${emulator.deviceId}`);
+                    logger.debug(`[PARALLEL] ✅ Package manager is responsive for ${emulator.deviceId} - emulator is ready!`);
+                    logger.debug(`[PARALLEL] ✅ No package manager errors detected - marking emulator as ready`);
                     foundDeviceId = emulator.deviceId;
                     return;
                   }
                 }
               } catch (parallelError) {
-                logger.info(`[PARALLEL] ❌ Parallel checks failed for ${emulator.deviceId}: ${parallelError}`);
+                logger.debug(`[PARALLEL] ❌ Parallel checks failed for ${emulator.deviceId}: ${parallelError}`);
               }
             } else {
-              logger.info(`No suitable emulator found for '${avdName}' - will continue polling`);
+              logger.debug(`No suitable emulator found for '${avdName}' - will continue polling`);
             }
           } else {
-            logger.info(`No running emulators detected - will continue polling`);
+            logger.debug(`No running emulators detected - will continue polling`);
           }
         } catch (error) {
-          logger.info(`Background polling error (will continue): ${error}`);
+          logger.debug(`Background polling error (will continue): ${error}`);
         }
 
         // Always wait at least the minimum polling interval
-        logger.info(`Background polling cycle complete - sleeping ${pollingIntervalMs}ms before next check`);
+        logger.debug(`Background polling cycle complete - sleeping ${pollingIntervalMs}ms before next check`);
         await this.sleep(pollingIntervalMs);
       }
-      logger.info(`Background polling stopped - pollingActive: ${pollingActive}, foundDeviceId: ${foundDeviceId}`);
+      logger.debug(`Background polling stopped - pollingActive: ${pollingActive}, foundDeviceId: ${foundDeviceId}`);
     };
 
     // Start background polling immediately


### PR DESCRIPTION
## Summary
- Downgrade ~90 high-frequency operational `logger.info()` calls to `logger.debug()` across 11 files
- Remove 2 redundant ADB command completion logs in `AdbClient.ts` (duplicate of wrapper log)
- Addresses ~95%+ of INFO-level log volume (~936MB/50 files was 99.2% INFO)

Top sources silenced at INFO level:
- `DaemonMcpProxy` disconnect spam (~40.5% of all logs)
- `AdbClient` command execution/completion (~33.8%)
- `DeviceDataStream` push notifications (~5.3%)
- Emulator polling loop, observe cache, hierarchy requests, CtrlProxy status checks, navigation graph, device pool assignment logs

All diagnostic information remains accessible via DEBUG log level.

## Test Plan
- [x] `turbo run lint build test` passes (3123 tests, 0 failures)
- [x] No behavioral changes — only log level downgrades

🤖 Generated with [Claude Code](https://claude.com/claude-code)