### PR TITLE
fix: dereference annotated tags in changelog script

### DIFF
--- a/scripts/changelog/update_changelog_from_issues.sh
+++ b/scripts/changelog/update_changelog_from_issues.sh
@@ -27,7 +27,7 @@ if [ -z "$SINCE_TAG" ]; then
 fi
 
 if [ -n "$SINCE_TAG" ]; then
-  SINCE_DATE=$(git show -s --format=%cI "$SINCE_TAG")
+  SINCE_DATE=$(git show -s --format=%cI "$SINCE_TAG^{commit}")
 else
   ROOT_COMMIT=$(git rev-list --max-parents=0 HEAD)
   SINCE_DATE=$(git show -s --format=%cI "$ROOT_COMMIT")


### PR DESCRIPTION
## Summary
- `git show -s --format=%cI` on annotated tags dumps tag object text before the date, causing GitHub Search API HTTP 422
- Appending `^{commit}` dereferences to the underlying commit so only the date is returned
- Fixes https://github.com/kaeawc/auto-mobile/actions/runs/23619640888/job/68803752728

## Test plan
- [x] Verified locally: `git show -s --format=%cI "v0.0.14^{commit}"` returns clean ISO date
- [ ] CI changelog step passes on this PR's workflow run

🤖 Generated with [Claude Code](https://claude.com/claude-code)