### PR TITLE
chore: update CtrlProxy APK and CtrlProxy iOS IPA SHA256

### DIFF
--- a/src/constants/release.ts
+++ b/src/constants/release.ts
@@ -19,7 +19,7 @@ export const RELEASE_VERSION: string = "latest";
 export const APK_URL: string = RELEASE_VERSION === "latest"
   ? `https://github.com/kaeawc/auto-mobile/releases/latest/download/control-proxy-debug.apk`
   : `https://github.com/kaeawc/auto-mobile/releases/download/v${RELEASE_VERSION}/control-proxy-debug.apk`;
-export const APK_SHA256_CHECKSUM: string = "aa49272e44fc89b6b94950813e8b341b90c4ecfd233141120e9976ff8738520e"; // Empty = skip verification (local dev only)
+export const APK_SHA256_CHECKSUM: string = "53c9dc93392cfea199f8dda136ad10277c9e3708cf649719c241ced22c8a6ff7"; // Empty = skip verification (local dev only)
 
 /**
  * iOS CtrlProxy Release Constants
@@ -31,6 +31,6 @@ export const IOS_CTRL_PROXY_RELEASE_VERSION: string = "latest";
 export const IOS_CTRL_PROXY_IPA_URL: string = IOS_CTRL_PROXY_RELEASE_VERSION === "latest"
   ? "https://github.com/kaeawc/auto-mobile/releases/latest/download/control-proxy.ipa"
   : `https://github.com/kaeawc/auto-mobile/releases/download/v${IOS_CTRL_PROXY_RELEASE_VERSION}/control-proxy.ipa`;
-export const IOS_CTRL_PROXY_SHA256_CHECKSUM: string = "9ca869400167a4877be043185c57469c5c99c9d4b9c1ed8a31a1bcdb922adab8"; // Empty = skip verification (local dev only)
+export const IOS_CTRL_PROXY_SHA256_CHECKSUM: string = "b358a494440be601efbeff9635dc609f67b58318e6f7284a7ca9a3aaca291d13"; // Empty = skip verification (local dev only)
 export const IOS_CTRL_PROXY_APP_HASH: string = ""; // Hash of CtrlProxyApp.app (device build), empty = skip verification
 export const IOS_CTRL_PROXY_RUNNER_SHA256: string = ""; // SHA256 of runner binary (CtrlProxyUITests-Runner), empty = skip verification


### PR DESCRIPTION
## Automated Checksum Update

The nightly build produced artifacts with updated SHA256 checksums.

| Artifact | Previous | New | Changed |
|----------|----------|-----|---------|
| **APK** | `aa49272e44fc89b6b94950813e8b341b90c4ecfd233141120e9976ff8738520e` | `53c9dc93392cfea199f8dda136ad10277c9e3708cf649719c241ced22c8a6ff7` | ✅ Yes |
| **IPA** | `9ca869400167a4877be043185c57469c5c99c9d4b9c1ed8a31a1bcdb922adab8` | `b358a494440be601efbeff9635dc609f67b58318e6f7284a7ca9a3aaca291d13` | ✅ Yes |

### Why did this happen?

SHA256 checksums change when any of these change:
- Source code in `android/control-proxy/src/` or `ios/control-proxy/`
- Build configuration (`build.gradle.kts` or `project.yml`)
- Dependencies or SDK versions

### What to do

1. Review this PR to ensure the changes are expected
2. Merge when ready
3. Future releases will use these checksums for artifact verification

---
Auto-generated by the `nightly` workflow