### PR TITLE
fix: address PR feedback for multi-agent support

### DIFF
--- a/src/features/observe/ObserveScreen.ts
+++ b/src/features/observe/ObserveScreen.ts
@@ -173,11 +173,12 @@ export class RealObserveScreen implements ObserveScreen {
         }
       }
       RealObserveScreen.screenshotStateByDevice.delete(deviceId);
+      ScreenshotJobTracker.cancelJob(deviceId);
     } else {
       RealObserveScreen.observeResultCache.clear();
       RealObserveScreen.screenshotStateByDevice.clear();
+      ScreenshotJobTracker.clear();
     }
-    ScreenshotJobTracker.clear();
   }
 
   constructor(

--- a/src/features/observe/android/CtrlProxyClient.ts
+++ b/src/features/observe/android/CtrlProxyClient.ts
@@ -418,7 +418,14 @@ export class CtrlProxyClient extends DeviceServiceClient implements CtrlProxy {
    * Called when a tool execution context binds a session to this device.
    */
   public bindSession(sessionId: string): void {
-    this.boundSessionId = sessionId;
+    if (this.boundSessionId !== sessionId) {
+      this.boundSessionId = sessionId;
+      // Invalidate cached hierarchy detector so it picks up the new session's NavigationGraphManager
+      if (this.hierarchyNavigationDetector) {
+        this.hierarchyNavigationDetector.dispose();
+        this.hierarchyNavigationDetector = null;
+      }
+    }
   }
 
   /**

--- a/src/features/observe/ios/CtrlProxyClient.ts
+++ b/src/features/observe/ios/CtrlProxyClient.ts
@@ -318,7 +318,14 @@ export class CtrlProxyClient extends DeviceServiceClient implements CtrlProxySer
    * Bind this client to a session for multi-agent NavigationGraphManager isolation.
    */
   public bindSession(sessionId: string): void {
-    this.boundSessionId = sessionId;
+    if (this.boundSessionId !== sessionId) {
+      this.boundSessionId = sessionId;
+      // Invalidate cached hierarchy detector so it picks up the new session's NavigationGraphManager
+      if (this.hierarchyNavigationDetector) {
+        this.hierarchyNavigationDetector.dispose();
+        this.hierarchyNavigationDetector = null;
+      }
+    }
   }
 
   /**

--- a/src/server/ToolExecutionContext.ts
+++ b/src/server/ToolExecutionContext.ts
@@ -97,9 +97,7 @@ export async function createToolExecutionContext(
 
     // Start test coverage session for navigation graph tracking
     // This enables automatic tracking of screens and transitions during test execution
-    const navManager = sessionUuid
-      ? NavigationGraphManager.getInstanceForSession(sessionUuid)
-      : NavigationGraphManager.getInstance();
+    const navManager = NavigationGraphManager.getInstanceForSession(sessionUuid);
     if (navManager.getCurrentAppId()) {
       await navManager.startTestSession(sessionUuid);
       logger.info(`[ToolExecutionContext] Started test coverage tracking for session ${sessionUuid}`);

--- a/src/server/utilityTools.ts
+++ b/src/server/utilityTools.ts
@@ -8,7 +8,6 @@ import { DeviceSessionManager } from "../utils/DeviceSessionManager";
 import { BootedDevice, Platform } from "../models";
 import { addDeviceTargetingToSchema, addSessionUuidToSchema } from "./toolSchemaHelpers";
 import { DaemonState } from "../daemon/daemonState";
-import { createToolExecutionContext } from "./ToolExecutionContext";
 
 // Schema definitions
 export const setActiveDeviceSchema = addSessionUuidToSchema(z.object({
@@ -51,12 +50,22 @@ export function registerUtilityTools() {
   const setActiveDeviceHandler = async (args: SetActiveDeviceArgs & { sessionUuid?: string }) => {
     try {
       if (args.sessionUuid && DaemonState.getInstance().isInitialized()) {
-        // Session-scoped: bind device to this session only, don't mutate global state
+        // Session-scoped: bind the specific requested device to this session
         const sessionManager = DaemonState.getInstance().getSessionManager();
         const devicePool = DaemonState.getInstance().getDevicePool();
-        await createToolExecutionContext(args.sessionUuid, sessionManager, devicePool, {
-          platform: args.platform,
-        });
+        const pooledDevice = devicePool.getDevice(args.deviceId);
+        if (!pooledDevice) {
+          throw new ActionableError(`Device '${args.deviceId}' not found in device pool`);
+        }
+        // Release any existing session for this sessionUuid before rebinding
+        const existing = sessionManager.getSession(args.sessionUuid);
+        if (existing && existing.assignedDevice !== args.deviceId) {
+          await sessionManager.releaseSession(existing.sessionId);
+          await devicePool.releaseDevice(existing.assignedDevice);
+        }
+        if (!existing || existing.assignedDevice !== args.deviceId) {
+          await sessionManager.createSession(args.sessionUuid, args.deviceId, args.platform);
+        }
         logger.info(`[setActiveDevice] Bound device ${args.deviceId} to session ${args.sessionUuid}`);
       } else {
         // Legacy single-agent path: sets global active device


### PR DESCRIPTION
## Summary
Follow-up to #1620 addressing PR review feedback:

- **setActiveDevice**: Bind specific requested `deviceId` to session via `sessionManager.createSession()` instead of auto-assigning by platform — prevents session binding to wrong device
- **clearCache(deviceId)**: Scope `ScreenshotJobTracker` cleanup to single device via `cancelJob(deviceId)` instead of `clear()` — prevents canceling concurrent devices' screenshot jobs
- **bindSession**: Invalidate cached `hierarchyNavigationDetector` on session rebind so it picks up the new session's `NavigationGraphManager` (both Android and iOS)
- **ToolExecutionContext**: Remove unreachable else branch — `sessionUuid` is guaranteed truthy at that point (CodeQL warning)

## Test plan
- [x] 438 tests pass across server, daemon, ObserveScreen, CtrlProxyClient, NavigationGraphManager
- [x] `turbo run lint build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)