### PR TITLE
feat: add SplitPane component for 3-pane layout

### DIFF
--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/shell/SplitPane.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/shell/SplitPane.kt
@@ -106,6 +106,7 @@ fun HorizontalSplitPane(
                                 val handlePx = with(currentDensity) { dragHandleWidth.toPx() }
                                 val usable = (totalWidthPx - handlePx)
                                     .coerceAtLeast(minFirstPx + minSecondPx)
+                                if (usable <= 0f) return@detectDragGestures
                                 val newFirstPx = (fraction * usable + dragAmount.x)
                                     .coerceIn(minFirstPx, (usable - minSecondPx).coerceAtLeast(minFirstPx))
                                 val newFraction = (newFirstPx / usable)
@@ -211,6 +212,7 @@ fun VerticalSplitPane(
                                 val handlePx = with(currentDensity) { dragHandleWidth.toPx() }
                                 val usable = (totalHeightPx - handlePx)
                                     .coerceAtLeast(minFirstPx + minSecondPx)
+                                if (usable <= 0f) return@detectDragGestures
                                 val newFirstPx = (fraction * usable + dragAmount.y)
                                     .coerceIn(minFirstPx, (usable - minSecondPx).coerceAtLeast(minFirstPx))
                                 val newFraction = (newFirstPx / usable)


### PR DESCRIPTION
## Summary
- Add `HorizontalSplitPane` and `VerticalSplitPane` composables as the foundational layout primitive for the Xcode-style 3-pane shell
- Features draggable dividers with hover/drag highlighting, configurable min size constraints, and fraction persistence callbacks
- Uses idiomatic Compose `hoverable` + `MutableInteractionSource` for hover detection and `detectDragGestures` for drag handling

## Test plan
- [x] `./gradlew -p android :desktop-core:test` passes
- [x] `./gradlew -p android :desktop-core:build` passes
- [ ] Visual verification when integrated into shell layout (future unit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)