### PR TITLE
feat(desktop): add right inspector panel for 3-pane layout

### DIFF
--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/shell/EventInspectorContent.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/shell/EventInspectorContent.kt
@@ -1,0 +1,37 @@
+package dev.jasonpearson.automobile.desktop.core.shell
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import dev.jasonpearson.automobile.desktop.core.navigation.ScreenshotLoader
+import dev.jasonpearson.automobile.desktop.core.telemetry.TelemetryDetailPanel
+import dev.jasonpearson.automobile.desktop.core.telemetry.TelemetryDisplayEvent
+import dev.jasonpearson.automobile.desktop.core.theme.SharedTheme
+import java.text.SimpleDateFormat
+import java.util.Locale
+
+/**
+ * Renders full detail for a selected telemetry event by delegating
+ * to [TelemetryDetailPanel].
+ */
+@Composable
+fun EventInspectorContent(
+    event: TelemetryDisplayEvent,
+    onClose: () -> Unit,
+    onOpenSource: ((String, Int, String) -> Unit)? = null,
+    screenshotLoader: ScreenshotLoader? = null,
+    modifier: Modifier = Modifier,
+) {
+    val timeFormat = remember { SimpleDateFormat("HH:mm:ss.SSS", Locale.US) }
+    val textColor = SharedTheme.globalColors.text.normal
+
+    TelemetryDetailPanel(
+        event = event,
+        timeFormat = timeFormat,
+        textColor = textColor,
+        onClose = onClose,
+        onOpenSource = onOpenSource,
+        screenshotLoader = screenshotLoader,
+        modifier = modifier,
+    )
+}

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/shell/InspectorEmptyState.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/shell/InspectorEmptyState.kt
@@ -1,0 +1,27 @@
+package dev.jasonpearson.automobile.desktop.core.shell
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.sp
+import dev.jasonpearson.automobile.desktop.core.theme.SharedTheme
+
+/**
+ * Placeholder shown in the right inspector panel when no event is selected.
+ */
+@Composable
+fun InspectorEmptyState(modifier: Modifier = Modifier) {
+    Box(
+        modifier = modifier.fillMaxSize(),
+        contentAlignment = Alignment.Center,
+    ) {
+        Text(
+            "Select an event to inspect",
+            fontSize = 12.sp,
+            color = SharedTheme.globalColors.text.normal.copy(alpha = 0.5f),
+        )
+    }
+}

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/shell/RightInspectorPanel.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/shell/RightInspectorPanel.kt
@@ -1,0 +1,38 @@
+package dev.jasonpearson.automobile.desktop.core.shell
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import dev.jasonpearson.automobile.desktop.core.navigation.ScreenshotLoader
+import dev.jasonpearson.automobile.desktop.core.telemetry.TelemetryDisplayEvent
+import dev.jasonpearson.automobile.desktop.core.theme.SharedTheme
+
+/**
+ * Top-level right inspector pane that switches between an empty placeholder
+ * and the event detail view based on the current selection.
+ */
+@Composable
+fun RightInspectorPanel(
+    selectedEvent: TelemetryDisplayEvent?,
+    onClose: () -> Unit,
+    onOpenSource: ((String, Int, String) -> Unit)? = null,
+    screenshotLoader: ScreenshotLoader? = null,
+    modifier: Modifier = Modifier,
+) {
+    val panelModifier = modifier
+        .fillMaxSize()
+        .background(SharedTheme.globalColors.panelBackground)
+
+    if (selectedEvent == null) {
+        InspectorEmptyState(modifier = panelModifier)
+    } else {
+        EventInspectorContent(
+            event = selectedEvent,
+            onClose = onClose,
+            onOpenSource = onOpenSource,
+            screenshotLoader = screenshotLoader,
+            modifier = panelModifier,
+        )
+    }
+}


### PR DESCRIPTION
## Summary
- Add context-dependent right inspector panel (`RightInspectorPanel.kt`) for the Xcode-style 3-pane layout
- Wraps existing `TelemetryDetailPanel` via `EventInspectorContent.kt` 
- Shows empty state placeholder (`InspectorEmptyState.kt`) when no event selected

## Test plan
- [x] `./gradlew -p android :desktop-core:build` passes
- [x] `./gradlew -p android :desktop-core:test` passes
- [ ] Visual verification after integration unit merges

🤖 Generated with [Claude Code](https://claude.com/claude-code)