### PR TITLE
fix: permission-gate broadcasts, deduplicate daemon arg parsing, validate mock regex

### DIFF
--- a/android/auto-mobile-sdk/src/main/AndroidManifest.xml
+++ b/android/auto-mobile-sdk/src/main/AndroidManifest.xml
@@ -1,4 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+
+    <!-- Signature-level permission so only same-signed apps (CtrlProxy) can send network control broadcasts -->
+    <permission
+        android:name="dev.jasonpearson.automobile.sdk.permission.NETWORK_CONTROL"
+        android:protectionLevel="signature" />
 </manifest>

--- a/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/network/NetworkMockRuleStore.kt
+++ b/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/network/NetworkMockRuleStore.kt
@@ -31,6 +31,8 @@ class NetworkMockRuleStore(private val clock: () -> Long = { System.currentTimeM
     const val EXTRA_ERROR_SIM_TYPE = "error_type"
     const val EXTRA_ERROR_SIM_LIMIT = "limit"
     const val EXTRA_ERROR_SIM_EXPIRES_AT = "expires_at"
+    private const val PERMISSION_NETWORK_CONTROL =
+        "dev.jasonpearson.automobile.sdk.permission.NETWORK_CONTROL"
 
     @Volatile private var instance: NetworkMockRuleStore? = null
 
@@ -189,7 +191,6 @@ class NetworkMockRuleStore(private val clock: () -> Long = { System.currentTimeM
 
   fun getRuleCount(): Int = rules.size
 
-  @SuppressLint("UnspecifiedRegisterReceiverFlag")
   fun registerReceiver(context: Context) {
     val filter =
         IntentFilter().apply {
@@ -197,11 +198,12 @@ class NetworkMockRuleStore(private val clock: () -> Long = { System.currentTimeM
           addAction(ACTION_NETWORK_ERROR_SIMULATION)
         }
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-      context.registerReceiver(receiver, filter, Context.RECEIVER_EXPORTED)
+      context.registerReceiver(
+          receiver, filter, PERMISSION_NETWORK_CONTROL, null, Context.RECEIVER_EXPORTED)
     } else {
-      context.registerReceiver(receiver, filter)
+      context.registerReceiver(receiver, filter, PERMISSION_NETWORK_CONTROL, null)
     }
-    Log.d(TAG, "Registered broadcast receiver for network mock rules")
+    Log.d(TAG, "Registered broadcast receiver for network mock rules (permission-gated)")
   }
 
   fun unregisterReceiver(context: Context) {

--- a/android/control-proxy/src/main/AndroidManifest.xml
+++ b/android/control-proxy/src/main/AndroidManifest.xml
@@ -6,6 +6,7 @@
   <!-- Required for storage inspection to work with any app that has the AutoMobile SDK -->
   <!-- Note: This is appropriate for a debugging/development tool like AutoMobile -->
   <uses-permission android:name="android.permission.QUERY_ALL_PACKAGES" />
+  <uses-permission android:name="dev.jasonpearson.automobile.sdk.permission.NETWORK_CONTROL" />
 
   <!-- Permissions required for accessibility service -->
   <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />

--- a/src/daemon/manager.ts
+++ b/src/daemon/manager.ts
@@ -453,6 +453,70 @@ export class DaemonManager {
   }
 }
 
+function parseDaemonArgs(args: string[]): DaemonOptions {
+  const options: DaemonOptions = {};
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] === "--port") {
+      options.port = parseInt(args[i + 1], 10);
+      i++;
+    } else if (args[i] === "--debug") {
+      options.debug = true;
+    } else if (args[i] === "--debug-perf") {
+      options.debugPerf = true;
+    } else if (args[i] === "--plan-execution-lock-scope") {
+      const scope = args[i + 1];
+      if (scope === "global" || scope === "session") {
+        options.planExecutionLockScope = scope;
+      }
+      i++;
+    } else if (args[i] === "--video-quality" || args[i] === "--video-quality-preset") {
+      options.videoQualityPreset = args[i + 1];
+      i++;
+    } else if (args[i] === "--video-target-bitrate-kbps") {
+      options.videoTargetBitrateKbps = parseInt(args[i + 1], 10);
+      i++;
+    } else if (args[i] === "--video-max-throughput-mbps") {
+      options.videoMaxThroughputMbps = Number(args[i + 1]);
+      i++;
+    } else if (args[i] === "--video-fps") {
+      options.videoFps = parseInt(args[i + 1], 10);
+      i++;
+    } else if (args[i] === "--video-format") {
+      options.videoFormat = args[i + 1];
+      i++;
+    } else if (args[i] === "--video-archive-size-mb") {
+      options.videoMaxArchiveSizeMb = Number(args[i + 1]);
+      i++;
+    } else if (args[i] === "--network-mockable") {
+      options.networkMockable = true;
+    } else if (args[i] === "--no-ui-perf-mode") {
+      options.noUiPerfMode = true;
+    } else if (args[i] === "--mem-perf-audit") {
+      options.memPerfAudit = true;
+    } else if (args[i] === "--accessibility-audit") {
+      options.accessibilityAudit = true;
+    } else if (args[i] === "--accessibility-level") {
+      options.accessibilityLevel = args[i + 1];
+      i++;
+    } else if (args[i] === "--accessibility-failure-mode") {
+      options.accessibilityFailureMode = args[i + 1];
+      i++;
+    } else if (args[i] === "--accessibility-min-severity") {
+      options.accessibilityMinSeverity = args[i + 1];
+      i++;
+    } else if (args[i] === "--accessibility-use-baseline") {
+      options.accessibilityUseBaseline = true;
+    } else if (args[i] === "--predictive-ui" || args[i] === "--predictive") {
+      options.predictiveUi = true;
+    } else if (args[i] === "--raw-element-search") {
+      options.rawElementSearch = true;
+    } else if (args[i] === "--skip-ctrl-proxy-download" || args[i] === "--skip-accessibility-download") {
+      options.skipCtrlProxyDownload = true;
+    }
+  }
+  return options;
+}
+
 /**
  * Run daemon management command
  */
@@ -471,70 +535,7 @@ export async function runDaemonCommand(
   try {
     switch (command) {
       case "start": {
-        const options: DaemonOptions = {};
-
-        // Parse args
-        for (let i = 0; i < args.length; i++) {
-          if (args[i] === "--port") {
-            options.port = parseInt(args[i + 1], 10);
-            i++;
-          } else if (args[i] === "--debug") {
-            options.debug = true;
-          } else if (args[i] === "--debug-perf") {
-            options.debugPerf = true;
-          } else if (args[i] === "--plan-execution-lock-scope") {
-            const scope = args[i + 1];
-            if (scope === "global" || scope === "session") {
-              options.planExecutionLockScope = scope;
-            }
-            i++;
-          } else if (args[i] === "--video-quality" || args[i] === "--video-quality-preset") {
-            options.videoQualityPreset = args[i + 1];
-            i++;
-          } else if (args[i] === "--video-target-bitrate-kbps") {
-            options.videoTargetBitrateKbps = parseInt(args[i + 1], 10);
-            i++;
-          } else if (args[i] === "--video-max-throughput-mbps") {
-            options.videoMaxThroughputMbps = Number(args[i + 1]);
-            i++;
-          } else if (args[i] === "--video-fps") {
-            options.videoFps = parseInt(args[i + 1], 10);
-            i++;
-          } else if (args[i] === "--video-format") {
-            options.videoFormat = args[i + 1];
-            i++;
-          } else if (args[i] === "--video-archive-size-mb") {
-            options.videoMaxArchiveSizeMb = Number(args[i + 1]);
-            i++;
-          } else if (args[i] === "--network-mockable") {
-            options.networkMockable = true;
-          } else if (args[i] === "--no-ui-perf-mode") {
-            options.noUiPerfMode = true;
-          } else if (args[i] === "--mem-perf-audit") {
-            options.memPerfAudit = true;
-          } else if (args[i] === "--accessibility-audit") {
-            options.accessibilityAudit = true;
-          } else if (args[i] === "--accessibility-level") {
-            options.accessibilityLevel = args[i + 1];
-            i++;
-          } else if (args[i] === "--accessibility-failure-mode") {
-            options.accessibilityFailureMode = args[i + 1];
-            i++;
-          } else if (args[i] === "--accessibility-min-severity") {
-            options.accessibilityMinSeverity = args[i + 1];
-            i++;
-          } else if (args[i] === "--accessibility-use-baseline") {
-            options.accessibilityUseBaseline = true;
-          } else if (args[i] === "--predictive-ui" || args[i] === "--predictive") {
-            options.predictiveUi = true;
-          } else if (args[i] === "--raw-element-search") {
-            options.rawElementSearch = true;
-          } else if (args[i] === "--skip-ctrl-proxy-download" || args[i] === "--skip-accessibility-download") {
-            options.skipCtrlProxyDownload = true;
-          }
-        }
-
-        await manager.start(options);
+        await manager.start(parseDaemonArgs(args));
         break;
       }
 
@@ -574,45 +575,7 @@ export async function runDaemonCommand(
       }
 
       case "restart": {
-        const options: DaemonOptions = {};
-
-        // Parse args (same as start)
-        for (let i = 0; i < args.length; i++) {
-          if (args[i] === "--port") {
-            options.port = parseInt(args[i + 1], 10);
-            i++;
-          } else if (args[i] === "--debug") {
-            options.debug = true;
-          } else if (args[i] === "--debug-perf") {
-            options.debugPerf = true;
-          } else if (args[i] === "--plan-execution-lock-scope") {
-            const scope = args[i + 1];
-            if (scope === "global" || scope === "session") {
-              options.planExecutionLockScope = scope;
-            }
-            i++;
-          } else if (args[i] === "--video-quality" || args[i] === "--video-quality-preset") {
-            options.videoQualityPreset = args[i + 1];
-            i++;
-          } else if (args[i] === "--video-target-bitrate-kbps") {
-            options.videoTargetBitrateKbps = parseInt(args[i + 1], 10);
-            i++;
-          } else if (args[i] === "--video-max-throughput-mbps") {
-            options.videoMaxThroughputMbps = Number(args[i + 1]);
-            i++;
-          } else if (args[i] === "--video-fps") {
-            options.videoFps = parseInt(args[i + 1], 10);
-            i++;
-          } else if (args[i] === "--video-format") {
-            options.videoFormat = args[i + 1];
-            i++;
-          } else if (args[i] === "--video-archive-size-mb") {
-            options.videoMaxArchiveSizeMb = Number(args[i + 1]);
-            i++;
-          }
-        }
-
-        await manager.restart(options);
+        await manager.restart(parseDaemonArgs(args));
         break;
       }
 

--- a/src/server/networkTools.ts
+++ b/src/server/networkTools.ts
@@ -217,6 +217,18 @@ export function registerNetworkTools(): void {
         );
       }
 
+      // Validate regex patterns before creating the mock rule
+      try {
+        new RegExp(args.host);
+      } catch {
+        throw new ActionableError(`Invalid host regex: ${args.host}`);
+      }
+      try {
+        new RegExp(args.path);
+      } catch {
+        throw new ActionableError(`Invalid path regex: ${args.path}`);
+      }
+
       const mock = state.addMock({
         host: args.host,
         path: args.path,


### PR DESCRIPTION
## Summary
Follow-up fixes for network capture/mocking tools (#1624) that were merged before review feedback was addressed:

- **Signature-level broadcast permission**: Define `NETWORK_CONTROL` permission so only same-signed apps (CtrlProxy) can send network mock/sim broadcasts, preventing injection from third-party apps
- **Deduplicate daemon arg parsing**: Extract `parseDaemonArgs()` shared by `start` and `restart` paths so `--daemon restart` no longer silently drops flags like `--network-mockable`
- **Validate mock regex**: `mockNetwork` tool validates `host`/`path` regex before creating rules, failing fast with a clear error instead of silently skipping on the device

## Test Plan
- [x] All 3209 tests pass locally
- [x] Lint clean
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)