### PR TITLE
feat(desktop): vector icon system, dark/light toggle, typography scale

### DIFF
--- a/android/desktop-app/src/main/kotlin/dev/jasonpearson/automobile/desktop/AutoMobileDesktopApp.kt
+++ b/android/desktop-app/src/main/kotlin/dev/jasonpearson/automobile/desktop/AutoMobileDesktopApp.kt
@@ -4,19 +4,36 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import dev.jasonpearson.automobile.desktop.core.AutoMobileContent
 import dev.jasonpearson.automobile.desktop.core.platform.NoOpNotificationHandler
 import dev.jasonpearson.automobile.desktop.core.platform.SourceFileOpener
 import dev.jasonpearson.automobile.desktop.core.settings.FakeSettingsProvider
+import dev.jasonpearson.automobile.desktop.core.settings.SettingsProvider
 import dev.jasonpearson.automobile.desktop.theme.AutoMobileTheme
+
+/**
+ * Wraps a [SettingsProvider] so that [themeMode] is backed by Compose snapshot state,
+ * enabling recomposition when the user changes the theme in settings.
+ */
+private class ObservableSettingsProvider(
+    private val delegate: FakeSettingsProvider,
+) : SettingsProvider by delegate {
+  private var _themeMode by mutableStateOf(delegate.themeMode)
+  override var themeMode: String
+    get() = _themeMode
+    set(value) { _themeMode = value; delegate.themeMode = value }
+}
 
 @Composable
 fun AutoMobileDesktopApp() {
-  val settings = remember { FakeSettingsProvider() }
+  val settings = remember { ObservableSettingsProvider(FakeSettingsProvider()) }
 
-  AutoMobileTheme {
+  AutoMobileTheme(themeMode = settings.themeMode) {
     Surface(
         modifier = Modifier.fillMaxSize(),
         color = MaterialTheme.colorScheme.background,

--- a/android/desktop-app/src/main/kotlin/dev/jasonpearson/automobile/desktop/theme/AutoMobileTheme.kt
+++ b/android/desktop-app/src/main/kotlin/dev/jasonpearson/automobile/desktop/theme/AutoMobileTheme.kt
@@ -57,3 +57,19 @@ fun AutoMobileTheme(
     content = content,
   )
 }
+
+/**
+ * Overload that resolves a [themeMode] string ("dark", "light", "system") to a boolean.
+ */
+@Composable
+fun AutoMobileTheme(
+  themeMode: String,
+  content: @Composable () -> Unit,
+) {
+  val isDark = when (themeMode) {
+    "light" -> false
+    "system" -> isSystemInDarkTheme()
+    else -> true // "dark" or unknown
+  }
+  AutoMobileTheme(darkTheme = isDark, content = content)
+}

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/AutoMobileContent.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/AutoMobileContent.kt
@@ -58,6 +58,7 @@ import androidx.compose.ui.window.Popup
 import androidx.compose.ui.window.PopupProperties
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
+import dev.jasonpearson.automobile.desktop.core.theme.AppIcons
 import dev.jasonpearson.automobile.desktop.core.theme.SharedTheme
 import dev.jasonpearson.automobile.desktop.core.components.Tooltip
 import dev.jasonpearson.automobile.desktop.core.logging.LoggerFactory
@@ -194,10 +195,10 @@ fun AutoMobileContent(
   // Horizontal tabs at bottom (Navigation, Test Runs, Storage, Diagnostics)
   val horizontalTabs = remember {
       listOf(
-          HorizontalTab("test_runs", "Test Runs", "🧪"),
-          HorizontalTab("storage", "Storage", "💾"),
-          HorizontalTab("diagnostics", "Diagnostics", "🩺"),
-          HorizontalTab("telemetry", "Telemetry", "📡"),
+          HorizontalTab("test_runs", "Test Runs", AppIcons.TestRuns),
+          HorizontalTab("storage", "Storage", AppIcons.Storage),
+          HorizontalTab("diagnostics", "Diagnostics", AppIcons.Diagnostics),
+          HorizontalTab("telemetry", "Telemetry", AppIcons.Telemetry),
       )
   }
   var selectedHorizontalTabId by remember { mutableStateOf<String?>(null) }

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/settings/FakeSettingsProvider.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/settings/FakeSettingsProvider.kt
@@ -9,4 +9,5 @@ class FakeSettingsProvider(
     override var failuresDateRange: String = "24h",
     override var androidIde: String = "auto",
     override var iosIde: String = "auto",
+    override var themeMode: String = "dark",
 ) : SettingsProvider

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/settings/SettingsDialog.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/settings/SettingsDialog.kt
@@ -48,6 +48,7 @@ import androidx.compose.ui.input.pointer.pointerHoverIcon
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import dev.jasonpearson.automobile.desktop.core.theme.DesktopTypography
 import dev.jasonpearson.automobile.desktop.core.theme.SharedTheme
 
 /**
@@ -88,6 +89,27 @@ fun SettingsPanel(
       }
     }
 
+    Spacer(Modifier.height(24.dp))
+
+    // === Appearance ===
+    SectionHeader("Appearance")
+    Text(
+        "Choose the app color theme.",
+        fontSize = 12.sp,
+        color = colors.text.normal.copy(alpha = 0.6f),
+    )
+    Spacer(Modifier.height(8.dp))
+
+    var themeMode by remember { mutableStateOf(settings.themeMode) }
+    IdeSelector(
+        label = "Theme",
+        value = themeMode,
+        options = listOf("dark" to "Dark", "light" to "Light", "system" to "System"),
+        onSelected = { themeMode = it; settings.themeMode = it },
+    )
+
+    Spacer(Modifier.height(24.dp))
+    HorizontalDivider(color = colors.text.normal.copy(alpha = 0.1f))
     Spacer(Modifier.height(24.dp))
 
     // === IDE Preferences ===
@@ -442,7 +464,7 @@ private fun readConfigBoolean(config: JsonObject?, key: String, fallback: Boolea
 
 @Composable
 private fun SectionHeader(title: String) {
-  Text(title, fontSize = 16.sp, fontWeight = FontWeight.SemiBold)
+  Text(title, style = DesktopTypography.heading, fontWeight = FontWeight.SemiBold)
   Spacer(Modifier.height(8.dp))
 }
 

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/settings/SettingsProvider.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/settings/SettingsProvider.kt
@@ -11,4 +11,6 @@ interface SettingsProvider {
   var androidIde: String
   /** IDE to open Swift/ObjC files in. "auto", "xcode", "vscode" */
   var iosIde: String
+  /** Theme mode: "dark", "light", or "system" */
+  var themeMode: String
 }

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/shell/ConnectionStatusIndicator.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/shell/ConnectionStatusIndicator.kt
@@ -15,6 +15,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.compose.material3.Text
+import dev.jasonpearson.automobile.desktop.core.theme.DesktopTypography
 import dev.jasonpearson.automobile.desktop.core.theme.SharedTheme
 
 /**
@@ -48,7 +49,7 @@ fun ConnectionStatusIndicator(
             Spacer(modifier = Modifier.width(3.dp))
             Text(
                 text = label,
-                fontSize = 10.sp,
+                style = DesktopTypography.label,
                 color = textColor.copy(alpha = 0.7f),
                 lineHeight = 10.sp,
             )

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/shell/StatusBar.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/shell/StatusBar.kt
@@ -16,6 +16,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.compose.material3.Text
+import dev.jasonpearson.automobile.desktop.core.theme.DesktopTypography
 import dev.jasonpearson.automobile.desktop.core.theme.SharedTheme
 
 /**
@@ -76,7 +77,7 @@ fun StatusBar(
                 }
                 Text(
                     text = "${currentFps.toInt()} FPS",
-                    fontSize = 10.sp,
+                    style = DesktopTypography.label,
                     color = fpsColor,
                     lineHeight = 10.sp,
                 )
@@ -84,7 +85,7 @@ fun StatusBar(
             if (currentMemoryMb != null) {
                 Text(
                     text = "${"%.0f".format(currentMemoryMb)} MB",
-                    fontSize = 10.sp,
+                    style = DesktopTypography.label,
                     color = colors.text.normal.copy(alpha = 0.7f),
                     lineHeight = 10.sp,
                 )

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/tabs/HorizontalTabBar.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/tabs/HorizontalTabBar.kt
@@ -8,17 +8,19 @@ import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.input.pointer.PointerIcon
 import androidx.compose.ui.input.pointer.pointerHoverIcon
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Text
 import dev.jasonpearson.automobile.desktop.core.theme.SharedTheme
 
 /**
@@ -27,7 +29,7 @@ import dev.jasonpearson.automobile.desktop.core.theme.SharedTheme
 data class HorizontalTab(
     val id: String,
     val title: String,
-    val icon: String,
+    val icon: ImageVector,
 )
 
 /**
@@ -86,7 +88,12 @@ fun HorizontalTabBar(
                         horizontalArrangement = Arrangement.spacedBy(4.dp),
                         verticalAlignment = Alignment.CenterVertically,
                     ) {
-                        Text(tab.icon, fontSize = 12.sp)
+                        Icon(
+                            imageVector = tab.icon,
+                            contentDescription = tab.title,
+                            modifier = Modifier.size(14.dp),
+                            tint = if (isSelected) colors.text.normal else colors.text.normal.copy(alpha = 0.6f),
+                        )
                         if (showText) {
                             Text(
                                 tab.title,

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/telemetry/TelemetryDashboard.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/telemetry/TelemetryDashboard.kt
@@ -14,6 +14,7 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
@@ -43,7 +44,10 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 
+import androidx.compose.material3.Icon
+import androidx.compose.ui.graphics.vector.ImageVector
 import dev.jasonpearson.automobile.desktop.core.components.SearchBar
+import dev.jasonpearson.automobile.desktop.core.theme.AppIcons
 import kotlinx.coroutines.delay
 import dev.jasonpearson.automobile.desktop.core.daemon.TelemetryConnectionState
 import dev.jasonpearson.automobile.desktop.core.daemon.TelemetryPushClient
@@ -61,18 +65,18 @@ private const val DETAIL_PANEL_WIDTH_MAX = 600
 
 private const val MAX_EVENTS = 1000
 
-private enum class CategoryFilter(val label: String, val icon: String) {
-    All("All", "\uD83D\uDCE1"),       // 📡
-    Network("Network", "\uD83C\uDF10"), // 🌐
-    Navigation("Nav", "\uD83E\uDDED"),  // 🧭
-    Logs("Logs", "\uD83D\uDCDD"),      // 📝
-    Os("OS", "\u2699\uFE0F"),           // ⚙️
-    Custom("Custom", "\uD83C\uDFF7\uFE0F"), // 🏷️
-    Failures("Failures", "\uD83D\uDCA5"), // 💥 (crashes + ANRs + non-fatals)
-    Storage("Storage", "\uD83D\uDDC4\uFE0F"), // 🗄️
-    Layout("Layout", "\uD83C\uDFD7\uFE0F"), // 🏗️
-    Performance("Perf", "\uD83D\uDCCA"),     // 📊
-    ToolCalls("Tools", "\uD83D\uDD27"),   // 🔧
+private enum class CategoryFilter(val label: String, val icon: ImageVector) {
+    All("All", AppIcons.All),
+    Network("Network", AppIcons.Network),
+    Navigation("Nav", AppIcons.Navigation),
+    Logs("Logs", AppIcons.Logs),
+    Os("OS", AppIcons.Os),
+    Custom("Custom", AppIcons.Custom),
+    Failures("Failures", AppIcons.Failures),
+    Storage("Storage", AppIcons.StorageCategory),
+    Layout("Layout", AppIcons.Layout),
+    Performance("Perf", AppIcons.Performance),
+    ToolCalls("Tools", AppIcons.ToolCalls),
 }
 
 /**
@@ -241,7 +245,12 @@ fun TelemetryDashboard(
                         .pointerHoverIcon(PointerIcon.Hand)
                         .padding(horizontal = 6.dp, vertical = 4.dp),
                 ) {
-                    Text(sev.icon, fontSize = 11.sp)
+                    Icon(
+                        sev.icon,
+                        contentDescription = sev.label,
+                        modifier = Modifier.size(13.dp),
+                        tint = Color(sev.color),
+                    )
                 }
             }
 
@@ -261,7 +270,7 @@ fun TelemetryDashboard(
                     .clickable { events.clear(); selectedEvent = null }
                     .then(buttonModifier),
             ) {
-                Text("\uD83D\uDDD1", fontSize = 13.sp) // 🗑
+                Icon(AppIcons.Delete, contentDescription = "Clear", modifier = Modifier.size(14.dp), tint = colors.text.normal)
             }
 
             // Pause / Resume
@@ -281,7 +290,12 @@ fun TelemetryDashboard(
                     .then(buttonModifier)
                     .then(if (isPaused) Modifier.background(Color(0xFFFFA94D).copy(alpha = 0.15f), RoundedCornerShape(4.dp)) else Modifier),
             ) {
-                Text(if (isPaused) "▶" else "⏸", fontSize = 13.sp)
+                Icon(
+                    if (isPaused) AppIcons.Play else AppIcons.Pause,
+                    contentDescription = if (isPaused) "Resume" else "Pause",
+                    modifier = Modifier.size(14.dp),
+                    tint = colors.text.normal,
+                )
             }
 
             // Restart (clear + unpause + scroll to bottom)
@@ -292,7 +306,7 @@ fun TelemetryDashboard(
                     }
                     .then(buttonModifier),
             ) {
-                Text("↻", fontSize = 13.sp)
+                Icon(AppIcons.Refresh, contentDescription = "Restart", modifier = Modifier.size(14.dp), tint = colors.text.normal)
             }
 
             // Scroll to latest (bottom) + re-enable auto-scroll
@@ -308,7 +322,7 @@ fun TelemetryDashboard(
                     }
                     .then(buttonModifier),
             ) {
-                Text("↓", fontSize = 13.sp)
+                Icon(AppIcons.ScrollDown, contentDescription = "Scroll to bottom", modifier = Modifier.size(14.dp), tint = colors.text.normal)
             }
         }
 
@@ -350,7 +364,12 @@ fun TelemetryDashboard(
                             horizontalArrangement = Arrangement.spacedBy(4.dp),
                             verticalAlignment = Alignment.CenterVertically,
                         ) {
-                            Text(filter.icon, fontSize = 11.sp)
+                            Icon(
+                                filter.icon,
+                                contentDescription = filter.label,
+                                modifier = Modifier.size(13.dp),
+                                tint = if (isSelected) colors.text.normal else colors.text.normal.copy(alpha = 0.6f),
+                            )
                             if (showText) {
                                 Text(
                                     filter.label,
@@ -527,26 +546,28 @@ private fun TelemetryEventRow(
         Spacer(Modifier.width(6.dp))
 
         // Category icon
-        Text(
-            when (event) {
-                is TelemetryDisplayEvent.Network -> "\uD83C\uDF10"  // 🌐
-                is TelemetryDisplayEvent.Navigation -> "\uD83E\uDDED" // 🧭
-                is TelemetryDisplayEvent.Log -> "\uD83D\uDCDD"      // 📝
-                is TelemetryDisplayEvent.Os -> "\u2699\uFE0F"       // ⚙️
-                is TelemetryDisplayEvent.Custom -> "\uD83C\uDFF7\uFE0F" // 🏷️
+        Icon(
+            imageVector = when (event) {
+                is TelemetryDisplayEvent.Network -> AppIcons.Network
+                is TelemetryDisplayEvent.Navigation -> AppIcons.Navigation
+                is TelemetryDisplayEvent.Log -> AppIcons.Logs
+                is TelemetryDisplayEvent.Os -> AppIcons.Os
+                is TelemetryDisplayEvent.Custom -> AppIcons.Custom
                 is TelemetryDisplayEvent.Failure -> when (event.type) {
-                    "crash" -> "\uD83D\uDCA5"  // 💥
-                    "anr" -> "\u231B"           // ⌛
-                    else -> "\u26A0\uFE0F"     // ⚠️
+                    "crash" -> AppIcons.Crash
+                    "anr" -> AppIcons.Anr
+                    else -> AppIcons.NonFatal
                 }
-                is TelemetryDisplayEvent.Storage -> "\uD83D\uDDC4\uFE0F" // 🗄️
-                is TelemetryDisplayEvent.Layout -> "\uD83C\uDFD7\uFE0F"  // 🏗️
-                is TelemetryDisplayEvent.Performance -> "\uD83D\uDCCA" // 📊
-                is TelemetryDisplayEvent.Memory -> "\uD83E\uDDE0" // 🧠
-                is TelemetryDisplayEvent.ToolCall -> "\uD83D\uDD27" // 🔧
-                is TelemetryDisplayEvent.Accessibility -> "\u267F" // ♿
+                is TelemetryDisplayEvent.Storage -> AppIcons.StorageCategory
+                is TelemetryDisplayEvent.Layout -> AppIcons.Layout
+                is TelemetryDisplayEvent.Performance -> AppIcons.Performance
+                is TelemetryDisplayEvent.Memory -> AppIcons.Memory
+                is TelemetryDisplayEvent.ToolCall -> AppIcons.ToolCalls
+                is TelemetryDisplayEvent.Accessibility -> AppIcons.Accessibility
             },
-            fontSize = 10.sp,
+            contentDescription = null,
+            modifier = Modifier.size(12.dp),
+            tint = textColor.copy(alpha = 0.7f),
         )
         Spacer(Modifier.width(4.dp))
 

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/telemetry/TelemetryModels.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/telemetry/TelemetryModels.kt
@@ -1,5 +1,7 @@
 package dev.jasonpearson.automobile.desktop.core.telemetry
 
+import androidx.compose.ui.graphics.vector.ImageVector
+import dev.jasonpearson.automobile.desktop.core.theme.AppIcons
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonObject
@@ -438,10 +440,10 @@ private fun JsonObject.stringOrNull(key: String): String? =
 /**
  * Severity classification for telemetry events, used for filter toggles.
  */
-enum class EventSeverity(val label: String, val icon: String, val color: Long) {
-    Error("Errors", "\u274C", 0xFFFF6B6B),
-    Warning("Warnings", "\u26A0\uFE0F", 0xFFE0C040),
-    Info("Info", "\u2139\uFE0F", 0xFF74C0FC),
+enum class EventSeverity(val label: String, val icon: ImageVector, val color: Long) {
+    Error("Errors", AppIcons.SeverityError, 0xFFFF6B6B),
+    Warning("Warnings", AppIcons.SeverityWarning, 0xFFE0C040),
+    Info("Info", AppIcons.SeverityInfo, 0xFF74C0FC),
 }
 
 /**

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/theme/AppIcons.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/theme/AppIcons.kt
@@ -1,0 +1,79 @@
+package dev.jasonpearson.automobile.desktop.core.theme
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.Accessible
+import androidx.compose.material.icons.filled.BarChart
+import androidx.compose.material.icons.filled.Build
+import androidx.compose.material.icons.filled.Circle
+import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.Description
+import androidx.compose.material.icons.filled.Explore
+import androidx.compose.material.icons.filled.KeyboardArrowDown
+import androidx.compose.material.icons.filled.Layers
+import androidx.compose.material.icons.filled.LocalOffer
+import androidx.compose.material.icons.filled.Pause
+import androidx.compose.material.icons.filled.PlayArrow
+import androidx.compose.material.icons.filled.Public
+import androidx.compose.material.icons.filled.Refresh
+import androidx.compose.material.icons.filled.Science
+import androidx.compose.material.icons.filled.SaveAlt
+import androidx.compose.material.icons.filled.Settings
+import androidx.compose.material.icons.filled.Storage
+import androidx.compose.material.icons.filled.LocalHospital
+import androidx.compose.material.icons.filled.Memory
+import androidx.compose.material.icons.filled.Satellite
+import androidx.compose.material.icons.filled.ReportProblem
+import androidx.compose.material.icons.filled.Error
+import androidx.compose.material.icons.filled.Info
+import androidx.compose.material.icons.filled.Warning
+import androidx.compose.material.icons.filled.HourglassEmpty
+import androidx.compose.material.icons.filled.Psychology
+import androidx.compose.material.icons.filled.Tune
+import androidx.compose.ui.graphics.vector.ImageVector
+
+/**
+ * Centralized vector icon definitions for the AutoMobile desktop app.
+ * Uses Material Icons Extended where available.
+ */
+object AppIcons {
+    // -- Telemetry categories --
+    val Network: ImageVector get() = Icons.Filled.Public
+    val Navigation: ImageVector get() = Icons.Filled.Explore
+    val Logs: ImageVector get() = Icons.Filled.Description
+    val Os: ImageVector get() = Icons.Filled.Settings
+    val Custom: ImageVector get() = Icons.Filled.LocalOffer
+    val Failures: ImageVector get() = Icons.Filled.ReportProblem
+    val StorageCategory: ImageVector get() = Icons.Filled.Storage
+    val Layout: ImageVector get() = Icons.Filled.Layers
+    val Performance: ImageVector get() = Icons.Filled.BarChart
+    val ToolCalls: ImageVector get() = Icons.Filled.Build
+    val Accessibility: ImageVector get() = Icons.AutoMirrored.Filled.Accessible
+    val Memory: ImageVector get() = Icons.Filled.Psychology
+    val All: ImageVector get() = Icons.Filled.Tune
+
+    // -- Toolbar actions --
+    val Delete: ImageVector get() = Icons.Filled.Delete
+    val Pause: ImageVector get() = Icons.Filled.Pause
+    val Play: ImageVector get() = Icons.Filled.PlayArrow
+    val Refresh: ImageVector get() = Icons.Filled.Refresh
+    val ScrollDown: ImageVector get() = Icons.Filled.KeyboardArrowDown
+
+    // -- Status indicators --
+    val StatusDot: ImageVector get() = Icons.Filled.Circle
+
+    // -- Severity --
+    val SeverityError: ImageVector get() = Icons.Filled.Error
+    val SeverityWarning: ImageVector get() = Icons.Filled.Warning
+    val SeverityInfo: ImageVector get() = Icons.Filled.Info
+
+    // -- Failure subtypes --
+    val Crash: ImageVector get() = Icons.Filled.ReportProblem
+    val Anr: ImageVector get() = Icons.Filled.HourglassEmpty
+    val NonFatal: ImageVector get() = Icons.Filled.Warning
+
+    // -- Horizontal tab icons --
+    val TestRuns: ImageVector get() = Icons.Filled.Science
+    val Storage: ImageVector get() = Icons.Filled.SaveAlt
+    val Diagnostics: ImageVector get() = Icons.Filled.LocalHospital
+    val Telemetry: ImageVector get() = Icons.Filled.Satellite
+}

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/theme/SharedTheme.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/theme/SharedTheme.kt
@@ -4,6 +4,8 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.ReadOnlyComposable
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.unit.sp
 
 /**
  * Compatibility layer that maps MaterialTheme colors to a structure matching the Jewel
@@ -28,6 +30,18 @@ data class SharedGlobalColors(
     val outlines: SharedOutlineColors,
     val panelBackground: Color,
 )
+
+/**
+ * Named text styles for consistent typography across the desktop app.
+ */
+object DesktopTypography {
+  val caption = TextStyle(fontSize = 9.sp)
+  val label = TextStyle(fontSize = 10.sp)
+  val body = TextStyle(fontSize = 11.sp)
+  val bodyLarge = TextStyle(fontSize = 12.sp)
+  val title = TextStyle(fontSize = 14.sp)
+  val heading = TextStyle(fontSize = 16.sp)
+}
 
 object SharedTheme {
   val globalColors: SharedGlobalColors

--- a/android/ide-plugin/src/main/kotlin/dev/jasonpearson/automobile/ide/settings/AutoMobileSettings.kt
+++ b/android/ide-plugin/src/main/kotlin/dev/jasonpearson/automobile/ide/settings/AutoMobileSettings.kt
@@ -19,6 +19,7 @@ class AutoMobileSettings : PersistentStateComponent<AutoMobileSettings>, Setting
   override var failuresDateRange: String = "24h"  // Default to 24 hours
   override var androidIde: String = "auto"
   override var iosIde: String = "auto"
+  override var themeMode: String = "dark"
 
   override fun getState(): AutoMobileSettings = this
 


### PR DESCRIPTION
## Summary
- Replace emoji icons with consistent ImageVector icons across all UI
- Add dark/light/system theme toggle in settings
- Add named typography scale (caption, label, body, title, heading)

🤖 Generated with [Claude Code](https://claude.com/claude-code)