### PR TITLE
feat(desktop): left sidebar — context menu, health, app filter, favorites

### DIFF
--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/mcp/DeviceModels.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/mcp/DeviceModels.kt
@@ -36,6 +36,8 @@ data class BootedDeviceInfo(
     val isVirtual: Boolean,
     val status: String, // "booted"
     val serviceStatus: DeviceServiceStatus? = null,
+    val batteryLevel: Int? = null, // 0-100, null if unknown
+    val connectionType: String? = null, // "usb", "wifi", or null if unknown
 )
 
 @Serializable

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/shell/AppFilterSection.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/shell/AppFilterSection.kt
@@ -1,0 +1,185 @@
+package dev.jasonpearson.automobile.desktop.core.shell
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextField
+import androidx.compose.material3.TextFieldDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.input.pointer.PointerIcon
+import androidx.compose.ui.input.pointer.pointerHoverIcon
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import dev.jasonpearson.automobile.desktop.core.datasource.InstalledApp
+import dev.jasonpearson.automobile.desktop.core.theme.SharedTheme
+
+/**
+ * Searchable app filter section with a text field filter and selectable app list.
+ */
+@Composable
+fun AppFilterSection(
+    installedApps: List<InstalledApp>,
+    selectedAppId: String?,
+    onAppSelected: (String?) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val colors = SharedTheme.globalColors
+    var expanded by remember { mutableStateOf(true) }
+    var filterText by remember { mutableStateOf("") }
+
+    val filteredApps = remember(installedApps, filterText) {
+        if (filterText.isBlank()) {
+            installedApps
+        } else {
+            installedApps.filter { app ->
+                app.packageName.contains(filterText, ignoreCase = true) ||
+                    (app.displayName?.contains(filterText, ignoreCase = true) == true)
+            }
+        }
+    }
+
+    Column(
+        modifier = modifier
+            .background(colors.text.normal.copy(alpha = 0.03f), RoundedCornerShape(6.dp))
+            .padding(12.dp),
+        verticalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        CollapsibleSectionHeader(
+            title = "App Filter",
+            expanded = expanded,
+            onToggle = { expanded = !expanded },
+            trailing = {
+                if (installedApps.isNotEmpty()) {
+                    Text(
+                        "${installedApps.size}",
+                        fontSize = 10.sp,
+                        color = colors.text.normal.copy(alpha = 0.5f),
+                        maxLines = 1,
+                        softWrap = false,
+                    )
+                }
+            },
+        )
+
+        if (expanded) {
+            if (installedApps.isEmpty()) {
+                Text(
+                    "No apps available",
+                    fontSize = 11.sp,
+                    color = colors.text.normal.copy(alpha = 0.5f),
+                    maxLines = 1,
+                    softWrap = false,
+                )
+            } else {
+                // Search field
+                TextField(
+                    value = filterText,
+                    onValueChange = { filterText = it },
+                    placeholder = {
+                        Text(
+                            "Search packages...",
+                            fontSize = 11.sp,
+                            color = colors.text.normal.copy(alpha = 0.35f),
+                        )
+                    },
+                    textStyle = TextStyle(
+                        fontSize = 11.sp,
+                        color = colors.text.normal,
+                    ),
+                    singleLine = true,
+                    colors = TextFieldDefaults.colors(
+                        focusedContainerColor = colors.text.normal.copy(alpha = 0.05f),
+                        unfocusedContainerColor = colors.text.normal.copy(alpha = 0.03f),
+                        focusedIndicatorColor = colors.outlines.focused.copy(alpha = 0.5f),
+                        unfocusedIndicatorColor = Color.Transparent,
+                        cursorColor = colors.outlines.focused,
+                    ),
+                    modifier = Modifier.fillMaxWidth(),
+                )
+
+                // Clear selection option
+                if (selectedAppId != null) {
+                    Text(
+                        "Clear selection",
+                        fontSize = 10.sp,
+                        color = Color(0xFF2196F3),
+                        modifier = Modifier
+                            .clickable { onAppSelected(null) }
+                            .pointerHoverIcon(PointerIcon.Hand),
+                    )
+                }
+
+                // Filtered app list
+                filteredApps.forEach { app ->
+                    val isSelected = app.packageName == selectedAppId
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .background(
+                                if (isSelected) colors.outlines.focused.copy(alpha = 0.12f)
+                                else Color.Transparent,
+                                RoundedCornerShape(4.dp),
+                            )
+                            .clickable { onAppSelected(app.packageName) }
+                            .pointerHoverIcon(PointerIcon.Hand)
+                            .padding(horizontal = 8.dp, vertical = 3.dp),
+                        horizontalArrangement = Arrangement.SpaceBetween,
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        Column(modifier = Modifier.weight(1f)) {
+                            Text(
+                                app.displayName ?: app.packageName.substringAfterLast('.'),
+                                fontSize = 11.sp,
+                                fontWeight = if (isSelected) FontWeight.Medium else FontWeight.Normal,
+                                color = if (isSelected) colors.outlines.focused else colors.text.normal,
+                                maxLines = 1,
+                                softWrap = false,
+                                overflow = TextOverflow.Ellipsis,
+                            )
+                            Text(
+                                app.packageName,
+                                fontSize = 9.sp,
+                                color = colors.text.normal.copy(alpha = 0.45f),
+                                maxLines = 1,
+                                softWrap = false,
+                                overflow = TextOverflow.Ellipsis,
+                            )
+                        }
+                        if (app.isForeground) {
+                            Text(
+                                "FG",
+                                fontSize = 9.sp,
+                                fontWeight = FontWeight.Bold,
+                                color = Color(0xFF4CAF50),
+                            )
+                        }
+                    }
+                }
+
+                if (filteredApps.isEmpty() && filterText.isNotBlank()) {
+                    Text(
+                        "No matching apps",
+                        fontSize = 11.sp,
+                        color = colors.text.normal.copy(alpha = 0.5f),
+                    )
+                }
+            }
+        }
+    }
+}

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/shell/DeviceListSection.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/shell/DeviceListSection.kt
@@ -1,24 +1,36 @@
 package dev.jasonpearson.automobile.desktop.core.shell
 
+import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
-import androidx.compose.material3.Text
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.CornerRadius
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.input.pointer.PointerButton
+import androidx.compose.ui.input.pointer.PointerEventType
 import androidx.compose.ui.input.pointer.PointerIcon
+import androidx.compose.ui.input.pointer.onPointerEvent
 import androidx.compose.ui.input.pointer.pointerHoverIcon
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
@@ -34,7 +46,8 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 
 /**
- * Section displaying a list of booted devices grouped by platform.
+ * Section displaying a list of booted devices grouped by platform,
+ * with context menus, health indicators, and favorite device support.
  */
 @Composable
 fun DeviceListSection(
@@ -43,6 +56,9 @@ fun DeviceListSection(
     onDeviceSelected: (deviceId: String, deviceName: String?) -> Unit,
     activeDeviceId: String?,
     suppressAutoSelect: Boolean,
+    onDeviceAction: ((deviceId: String, action: String) -> Unit)? = null,
+    favoriteDeviceIds: Set<String> = emptySet(),
+    onToggleFavorite: ((deviceId: String) -> Unit)? = null,
     modifier: Modifier = Modifier,
 ) {
     val colors = SharedTheme.globalColors
@@ -51,7 +67,7 @@ fun DeviceListSection(
     var isLoading by remember { mutableStateOf(true) }
     var error by remember { mutableStateOf<String?>(null) }
 
-    // Fetch devices – re-run when the data-source mode or connected process changes
+    // Fetch devices -- re-run when the data-source mode or connected process changes
     LaunchedEffect(dataSourceMode, connectedProcess) {
         isLoading = true
         error = null
@@ -97,6 +113,14 @@ fun DeviceListSection(
         }
     }
 
+    // Sort: favorites first, then alphabetically by name
+    val sortedDevices = remember(bootedDevices, favoriteDeviceIds) {
+        bootedDevices.sortedWith(
+            compareByDescending<BootedDeviceInfo> { it.deviceId in favoriteDeviceIds }
+                .thenBy { it.name },
+        )
+    }
+
     Column(
         modifier = modifier
             .background(colors.text.normal.copy(alpha = 0.03f), RoundedCornerShape(6.dp))
@@ -135,7 +159,7 @@ fun DeviceListSection(
                     fontSize = 10.sp,
                     color = Color(0xFFE53935),
                 )
-            } else if (!isLoading && bootedDevices.isEmpty()) {
+            } else if (!isLoading && sortedDevices.isEmpty()) {
                 Text(
                     "No devices found",
                     fontSize = 11.sp,
@@ -145,8 +169,8 @@ fun DeviceListSection(
                 )
             } else if (!isLoading) {
                 // Group by platform
-                val androidDevices = bootedDevices.filter { it.platform == "android" }
-                val iosDevices = bootedDevices.filter { it.platform == "ios" }
+                val androidDevices = sortedDevices.filter { it.platform == "android" }
+                val iosDevices = sortedDevices.filter { it.platform == "ios" }
 
                 if (androidDevices.isNotEmpty()) {
                     DevicePlatformGroup(
@@ -155,6 +179,9 @@ fun DeviceListSection(
                         devices = androidDevices,
                         activeDeviceId = activeDeviceId,
                         onDeviceSelected = onDeviceSelected,
+                        onDeviceAction = onDeviceAction,
+                        favoriteDeviceIds = favoriteDeviceIds,
+                        onToggleFavorite = onToggleFavorite,
                     )
                 }
                 if (iosDevices.isNotEmpty()) {
@@ -164,6 +191,9 @@ fun DeviceListSection(
                         devices = iosDevices,
                         activeDeviceId = activeDeviceId,
                         onDeviceSelected = onDeviceSelected,
+                        onDeviceAction = onDeviceAction,
+                        favoriteDeviceIds = favoriteDeviceIds,
+                        onToggleFavorite = onToggleFavorite,
                     )
                 }
             }
@@ -178,6 +208,9 @@ private fun DevicePlatformGroup(
     devices: List<BootedDeviceInfo>,
     activeDeviceId: String?,
     onDeviceSelected: (deviceId: String, deviceName: String?) -> Unit,
+    onDeviceAction: ((deviceId: String, action: String) -> Unit)?,
+    favoriteDeviceIds: Set<String>,
+    onToggleFavorite: ((deviceId: String) -> Unit)?,
 ) {
     val colors = SharedTheme.globalColors
 
@@ -190,40 +223,93 @@ private fun DevicePlatformGroup(
             softWrap = false,
         )
         devices.forEach { device ->
-            val isSelected = device.deviceId == activeDeviceId
-            Row(
+            DeviceRow(
+                device = device,
+                isSelected = device.deviceId == activeDeviceId,
+                isFavorite = device.deviceId in favoriteDeviceIds,
+                onSelect = { onDeviceSelected(device.deviceId, device.name) },
+                onToggleFavorite = { onToggleFavorite?.invoke(device.deviceId) },
+                onDeviceAction = onDeviceAction?.let { callback ->
+                    { action: String -> callback(device.deviceId, action) }
+                },
+            )
+        }
+    }
+}
+
+@OptIn(androidx.compose.ui.ExperimentalComposeUiApi::class)
+@Composable
+private fun DeviceRow(
+    device: BootedDeviceInfo,
+    isSelected: Boolean,
+    isFavorite: Boolean,
+    onSelect: () -> Unit,
+    onToggleFavorite: () -> Unit,
+    onDeviceAction: ((String) -> Unit)?,
+) {
+    val colors = SharedTheme.globalColors
+    var showContextMenu by remember { mutableStateOf(false) }
+
+    Box {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .background(
+                    if (isSelected) colors.outlines.focused.copy(alpha = 0.12f)
+                    else Color.Transparent,
+                    RoundedCornerShape(4.dp),
+                )
+                .clickable { onSelect() }
+                .onPointerEvent(PointerEventType.Press) { event ->
+                    if (event.button == PointerButton.Secondary) {
+                        showContextMenu = true
+                    }
+                }
+                .pointerHoverIcon(PointerIcon.Hand)
+                .padding(horizontal = 8.dp, vertical = 4.dp),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Text(
+                if (isFavorite) "\u2605" else "\u2606",
+                fontSize = 12.sp,
+                color = if (isFavorite) Color(0xFFFFC107) else colors.text.normal.copy(alpha = 0.3f),
                 modifier = Modifier
-                    .fillMaxWidth()
-                    .background(
-                        if (isSelected) colors.outlines.focused.copy(alpha = 0.12f)
-                        else Color.Transparent,
-                        RoundedCornerShape(4.dp),
-                    )
-                    .clickable { onDeviceSelected(device.deviceId, device.name) }
+                    .clickable { onToggleFavorite() }
                     .pointerHoverIcon(PointerIcon.Hand)
-                    .padding(horizontal = 8.dp, vertical = 4.dp),
-                horizontalArrangement = Arrangement.SpaceBetween,
+                    .padding(end = 4.dp),
+            )
+
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    device.name,
+                    fontSize = 12.sp,
+                    fontWeight = if (isSelected) FontWeight.Medium else FontWeight.Normal,
+                    color = colors.text.normal,
+                    maxLines = 1,
+                    softWrap = false,
+                    overflow = TextOverflow.Ellipsis,
+                )
+                Text(
+                    "${device.status} \u00B7 ${device.deviceId}",
+                    fontSize = 10.sp,
+                    color = colors.text.normal.copy(alpha = 0.5f),
+                    maxLines = 1,
+                    softWrap = false,
+                    overflow = TextOverflow.Ellipsis,
+                )
+            }
+
+            Row(
+                horizontalArrangement = Arrangement.spacedBy(4.dp),
                 verticalAlignment = Alignment.CenterVertically,
             ) {
-                Column(modifier = Modifier.weight(1f)) {
-                    Text(
-                        device.name,
-                        fontSize = 12.sp,
-                        fontWeight = if (isSelected) FontWeight.Medium else FontWeight.Normal,
-                        color = colors.text.normal,
-                        maxLines = 1,
-                        softWrap = false,
-                        overflow = TextOverflow.Ellipsis,
-                    )
-                    Text(
-                        "${device.status} \u00B7 ${device.deviceId}",
-                        fontSize = 10.sp,
-                        color = colors.text.normal.copy(alpha = 0.5f),
-                        maxLines = 1,
-                        softWrap = false,
-                        overflow = TextOverflow.Ellipsis,
-                    )
+                ConnectionTypeIcon(connectionType = device.connectionType)
+
+                if (device.batteryLevel != null) {
+                    BatteryIcon(level = device.batteryLevel)
                 }
+
                 if (isSelected) {
                     Text(
                         "\u2713",
@@ -231,6 +317,128 @@ private fun DevicePlatformGroup(
                         color = colors.outlines.focused,
                     )
                 }
+            }
+        }
+
+        DropdownMenu(
+            expanded = showContextMenu,
+            onDismissRequest = { showContextMenu = false },
+        ) {
+            DropdownMenuItem(
+                text = { Text("Take Screenshot", fontSize = 12.sp) },
+                onClick = {
+                    showContextMenu = false
+                    onDeviceAction?.invoke("screenshot")
+                },
+            )
+            DropdownMenuItem(
+                text = { Text("Reboot Device", fontSize = 12.sp) },
+                onClick = {
+                    showContextMenu = false
+                    onDeviceAction?.invoke("reboot")
+                },
+            )
+            DropdownMenuItem(
+                text = { Text("Clear App Data", fontSize = 12.sp) },
+                onClick = {
+                    showContextMenu = false
+                    onDeviceAction?.invoke("clearAppData")
+                },
+            )
+        }
+    }
+}
+
+@Composable
+private fun BatteryIcon(level: Int) {
+    val batteryColor = when {
+        level <= 15 -> Color(0xFFE53935)
+        level <= 40 -> Color(0xFFFFA726)
+        else -> Color(0xFF4CAF50)
+    }
+
+    Canvas(modifier = Modifier.size(width = 16.dp, height = 10.dp)) {
+        val bodyWidth = size.width * 0.85f
+        val bodyHeight = size.height
+        val tipWidth = size.width - bodyWidth
+        val tipHeight = bodyHeight * 0.4f
+
+        // Battery body outline
+        drawRoundRect(
+            color = Color.Gray,
+            topLeft = Offset.Zero,
+            size = Size(bodyWidth, bodyHeight),
+            cornerRadius = CornerRadius(2f, 2f),
+            style = Stroke(width = 1.5f),
+        )
+
+        // Battery tip (positive terminal)
+        drawRoundRect(
+            color = Color.Gray,
+            topLeft = Offset(bodyWidth, (bodyHeight - tipHeight) / 2f),
+            size = Size(tipWidth, tipHeight),
+            cornerRadius = CornerRadius(1f, 1f),
+        )
+
+        // Fill level
+        val fillPadding = 2f
+        val maxFillWidth = bodyWidth - fillPadding * 2
+        val fillWidth = maxFillWidth * (level / 100f)
+        if (fillWidth > 0) {
+            drawRoundRect(
+                color = batteryColor,
+                topLeft = Offset(fillPadding, fillPadding),
+                size = Size(fillWidth, bodyHeight - fillPadding * 2),
+                cornerRadius = CornerRadius(1f, 1f),
+            )
+        }
+    }
+}
+
+/**
+ * Connection type indicator icon (USB or WiFi).
+ */
+@Composable
+private fun ConnectionTypeIcon(connectionType: String?) {
+    when (connectionType) {
+        "usb" -> {
+            val color = Color(0xFF4CAF50)
+            Canvas(modifier = Modifier.size(10.dp)) {
+                val cx = size.width / 2f
+                drawLine(color, Offset(cx, 1f), Offset(cx, size.height - 1f), strokeWidth = 1.5f)
+                drawLine(color, Offset(cx - 3f, 2f), Offset(cx + 3f, 2f), strokeWidth = 1.5f)
+                drawLine(
+                    color,
+                    Offset(cx - 2f, size.height - 2f),
+                    Offset(cx + 2f, size.height - 2f),
+                    strokeWidth = 1.5f,
+                )
+            }
+        }
+        "wifi" -> {
+            val color = Color(0xFF2196F3)
+            Canvas(modifier = Modifier.size(10.dp)) {
+                val cx = size.width / 2f
+                val bottom = size.height - 1f
+                drawCircle(color, radius = 1.5f, center = Offset(cx, bottom))
+                drawArc(
+                    color = color,
+                    startAngle = 210f,
+                    sweepAngle = 120f,
+                    useCenter = false,
+                    topLeft = Offset(cx - 4f, bottom - 6f),
+                    size = Size(8f, 8f),
+                    style = Stroke(width = 1.2f),
+                )
+                drawArc(
+                    color = color,
+                    startAngle = 210f,
+                    sweepAngle = 120f,
+                    useCenter = false,
+                    topLeft = Offset(cx - 6f, bottom - 9f),
+                    size = Size(12f, 12f),
+                    style = Stroke(width = 1.2f),
+                )
             }
         }
     }

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/shell/LeftSidebarPanel.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/shell/LeftSidebarPanel.kt
@@ -12,11 +12,13 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import dev.jasonpearson.automobile.desktop.core.datasource.DataSourceMode
+import dev.jasonpearson.automobile.desktop.core.datasource.InstalledApp
 import dev.jasonpearson.automobile.desktop.core.mcp.McpProcess
 import dev.jasonpearson.automobile.desktop.core.theme.SharedTheme
 
 /**
- * Left sidebar panel composing MCP connection, daemon status, and device list sections.
+ * Left sidebar panel composing MCP connection, daemon status, device list,
+ * and app filter sections.
  */
 @Composable
 fun LeftSidebarPanel(
@@ -27,6 +29,12 @@ fun LeftSidebarPanel(
     connectedProcess: McpProcess?,
     activeDeviceId: String?,
     suppressAutoSelect: Boolean,
+    installedApps: List<InstalledApp> = emptyList(),
+    selectedAppId: String? = null,
+    onAppSelected: (String?) -> Unit = {},
+    onDeviceAction: ((deviceId: String, action: String) -> Unit)? = null,
+    favoriteDeviceIds: Set<String> = emptySet(),
+    onToggleFavorite: ((deviceId: String) -> Unit)? = null,
     modifier: Modifier = Modifier,
 ) {
     val colors = SharedTheme.globalColors
@@ -58,6 +66,16 @@ fun LeftSidebarPanel(
             onDeviceSelected = onDeviceSelected,
             activeDeviceId = activeDeviceId,
             suppressAutoSelect = suppressAutoSelect,
+            onDeviceAction = onDeviceAction,
+            favoriteDeviceIds = favoriteDeviceIds,
+            onToggleFavorite = onToggleFavorite,
+            modifier = Modifier.fillMaxWidth(),
+        )
+
+        AppFilterSection(
+            installedApps = installedApps,
+            selectedAppId = selectedAppId,
+            onAppSelected = onAppSelected,
             modifier = Modifier.fillMaxWidth(),
         )
     }


### PR DESCRIPTION
## Summary
- Right-click context menu on devices (screenshot, reboot, clear data)
- Device health indicators (battery, connection type)
- Searchable app filter with text field
- Collapsible sidebar sections with disclosure triangles
- Favorite devices with star toggle, sorted to top

🤖 Generated with [Claude Code](https://claude.com/claude-code)