### PR TITLE
fix: skip mutable latest helper checksums

### DIFF
--- a/src/constants/release.ts
+++ b/src/constants/release.ts
@@ -12,11 +12,18 @@
  * scripts/generate-release-constants.sh
  *
  * For local development, RELEASE_VERSION "latest" fetches from the most recent
- * GitHub release, and the empty checksum skips verification (not recommended for production).
+ * GitHub release. Because the "latest" asset can change over time, runtime
+ * checksum verification is only reliable for pinned release versions.
  */
 
-export const RELEASE_VERSION: string = "latest";
-export const APK_URL: string = RELEASE_VERSION === "latest"
+export const LATEST_RELEASE_VERSION = "latest";
+
+export function usesMutableLatestRelease(version: string): boolean {
+  return version.trim().toLowerCase() === LATEST_RELEASE_VERSION;
+}
+
+export const RELEASE_VERSION: string = LATEST_RELEASE_VERSION;
+export const APK_URL: string = RELEASE_VERSION === LATEST_RELEASE_VERSION
   ? `https://github.com/kaeawc/auto-mobile/releases/latest/download/control-proxy-debug.apk`
   : `https://github.com/kaeawc/auto-mobile/releases/download/v${RELEASE_VERSION}/control-proxy-debug.apk`;
 export const APK_SHA256_CHECKSUM: string = "96f88c02e1ab63d86c7bd6d6088c21a8db947c85d59c0ec875270e81814b762b"; // Empty = skip verification (local dev only)
@@ -27,8 +34,8 @@ export const APK_SHA256_CHECKSUM: string = "96f88c02e1ab63d86c7bd6d6088c21a8db94
  * CtrlProxy is distributed via GitHub releases as a prebuilt bundle.
  * The default "latest" version targets the most recent release.
  */
-export const IOS_CTRL_PROXY_RELEASE_VERSION: string = "latest";
-export const IOS_CTRL_PROXY_IPA_URL: string = IOS_CTRL_PROXY_RELEASE_VERSION === "latest"
+export const IOS_CTRL_PROXY_RELEASE_VERSION: string = LATEST_RELEASE_VERSION;
+export const IOS_CTRL_PROXY_IPA_URL: string = IOS_CTRL_PROXY_RELEASE_VERSION === LATEST_RELEASE_VERSION
   ? "https://github.com/kaeawc/auto-mobile/releases/latest/download/control-proxy.ipa"
   : `https://github.com/kaeawc/auto-mobile/releases/download/v${IOS_CTRL_PROXY_RELEASE_VERSION}/control-proxy.ipa`;
 export const IOS_CTRL_PROXY_SHA256_CHECKSUM: string = "98d19b9bd985026d8dbc45f4374322a64fe4af10836b02c4f423d947267e9417"; // Empty = skip verification (local dev only)

--- a/src/daemon/socketServer.ts
+++ b/src/daemon/socketServer.ts
@@ -21,9 +21,11 @@ import {
   RELEASE_VERSION,
   APK_SHA256_CHECKSUM,
   APK_URL,
+  IOS_CTRL_PROXY_RELEASE_VERSION,
   IOS_CTRL_PROXY_SHA256_CHECKSUM,
   IOS_CTRL_PROXY_IPA_URL,
   IOS_CTRL_PROXY_APP_HASH,
+  usesMutableLatestRelease,
 } from "../constants/release";
 import { AndroidCtrlProxyManager } from "../utils/CtrlProxyManager";
 import { IOSCtrlProxyManager } from "../utils/IOSCtrlProxyManager";
@@ -272,13 +274,13 @@ export class UnixSocketServer {
           releaseVersion: RELEASE_VERSION,
           android: {
             ctrlProxy: {
-              expectedSha256: APK_SHA256_CHECKSUM,
+              expectedSha256: usesMutableLatestRelease(RELEASE_VERSION) ? "" : APK_SHA256_CHECKSUM,
               url: APK_URL,
             },
           },
           ios: {
             xcTestService: {
-              expectedSha256: IOS_CTRL_PROXY_SHA256_CHECKSUM,
+              expectedSha256: usesMutableLatestRelease(IOS_CTRL_PROXY_RELEASE_VERSION) ? "" : IOS_CTRL_PROXY_SHA256_CHECKSUM,
               expectedAppHash: IOS_CTRL_PROXY_APP_HASH,
               url: IOS_CTRL_PROXY_IPA_URL,
             },

--- a/src/server/bootedDeviceResources.ts
+++ b/src/server/bootedDeviceResources.ts
@@ -8,7 +8,13 @@ import type { Session } from "../daemon/sessionManager";
 import type { DevicePool } from "../daemon/devicePool";
 import { AndroidCtrlProxyManager } from "../utils/CtrlProxyManager";
 import { IOSCtrlProxyManager } from "../utils/IOSCtrlProxyManager";
-import { APK_SHA256_CHECKSUM, IOS_CTRL_PROXY_SHA256_CHECKSUM } from "../constants/release";
+import {
+  APK_SHA256_CHECKSUM,
+  IOS_CTRL_PROXY_RELEASE_VERSION,
+  IOS_CTRL_PROXY_SHA256_CHECKSUM,
+  RELEASE_VERSION,
+  usesMutableLatestRelease
+} from "../constants/release";
 import { defaultTimer } from "../utils/SystemTimer";
 
 // Resource URIs
@@ -338,7 +344,7 @@ async function queryDeviceServiceStatus(device: BootedDeviceInfo): Promise<Devic
         manager.isEnabled(),
         manager.getInstalledApkSha256(),
       ]);
-      const expectedSha256 = APK_SHA256_CHECKSUM;
+      const expectedSha256 = usesMutableLatestRelease(RELEASE_VERSION) ? "" : APK_SHA256_CHECKSUM;
       const isCompatible = expectedSha256.length === 0 ||
         (installedSha256 !== null && installedSha256.toLowerCase() === expectedSha256.toLowerCase());
       return {
@@ -355,7 +361,7 @@ async function queryDeviceServiceStatus(device: BootedDeviceInfo): Promise<Devic
         manager.isInstalled(),
         manager.isRunning(),
       ]);
-      const expectedSha256 = IOS_CTRL_PROXY_SHA256_CHECKSUM;
+      const expectedSha256 = usesMutableLatestRelease(IOS_CTRL_PROXY_RELEASE_VERSION) ? "" : IOS_CTRL_PROXY_SHA256_CHECKSUM;
       return {
         installed,
         enabled: running,

--- a/src/utils/CtrlProxyManager.ts
+++ b/src/utils/CtrlProxyManager.ts
@@ -4,7 +4,12 @@ import { logger } from "./logger";
 import * as fs from "fs/promises";
 import * as path from "path";
 import { BootedDevice } from "../models";
-import { APK_URL, APK_SHA256_CHECKSUM } from "../constants/release";
+import {
+  APK_URL,
+  APK_SHA256_CHECKSUM,
+  RELEASE_VERSION,
+  usesMutableLatestRelease
+} from "../constants/release";
 import AdmZip from "adm-zip";
 import crypto from "crypto";
 import os from "os";
@@ -1364,6 +1369,10 @@ export class AndroidCtrlProxyManager implements CtrlProxyManager {
     const explicitSkip = process.env.AUTOMOBILE_SKIP_ACCESSIBILITY_CHECKSUM ??
       process.env.AUTO_MOBILE_ACCESSIBILITY_SERVICE_SHA_SKIP_CHECK;
     if (explicitSkip && (explicitSkip === "1" || explicitSkip.toLowerCase() === "true")) {
+      return true;
+    }
+    if (AndroidCtrlProxyManager.expectedChecksumOverride === null &&
+        usesMutableLatestRelease(RELEASE_VERSION)) {
       return true;
     }
     return this.getApkPathOverride() !== null;

--- a/src/utils/IOSCtrlProxyBuilder.ts
+++ b/src/utils/IOSCtrlProxyBuilder.ts
@@ -9,7 +9,8 @@ import {
   IOS_CTRL_PROXY_IPA_URL,
   IOS_CTRL_PROXY_RELEASE_VERSION,
   IOS_CTRL_PROXY_RUNNER_SHA256,
-  IOS_CTRL_PROXY_SHA256_CHECKSUM
+  IOS_CTRL_PROXY_SHA256_CHECKSUM,
+  usesMutableLatestRelease
 } from "../constants/release";
 import {
   DefaultIOSCtrlProxyBundleDownloader,
@@ -522,6 +523,9 @@ export class IOSCtrlProxyBuilder {
 
   private getExpectedChecksum(): string {
     const override = IOSCtrlProxyBuilder.expectedChecksumOverride;
+    if (override === null && usesMutableLatestRelease(IOS_CTRL_PROXY_RELEASE_VERSION)) {
+      return "";
+    }
     return override ?? IOS_CTRL_PROXY_SHA256_CHECKSUM ?? "";
   }
 

--- a/test/constants/release.test.ts
+++ b/test/constants/release.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, test } from "bun:test";
+import { usesMutableLatestRelease } from "../../src/constants/release";
+
+describe("release constants helpers", function() {
+  test("treats latest release references as mutable", function() {
+    expect(usesMutableLatestRelease("latest")).toBe(true);
+    expect(usesMutableLatestRelease("LATEST")).toBe(true);
+    expect(usesMutableLatestRelease(" latest ")).toBe(true);
+  });
+
+  test("does not treat pinned release references as mutable", function() {
+    expect(usesMutableLatestRelease("0.0.15")).toBe(false);
+    expect(usesMutableLatestRelease("v0.0.15")).toBe(false);
+    expect(usesMutableLatestRelease("")).toBe(false);
+  });
+});


### PR DESCRIPTION
## Why
`releases/latest` helper assets are mutable, so verifying them against a baked-in checksum can fail even when the downloaded CtrlProxy artifact is valid.

## What
- skip runtime checksum enforcement for Android and iOS helper downloads when the release reference is `latest`
- keep pinned releases and test overrides on the existing checksum-verification path
- align daemon and booted-device status reporting with the effective runtime checksum behavior
- add a release helper test that distinguishes mutable `latest` references from pinned versions

## Risk Assessment
Low — this only changes helper artifact validation behavior for mutable `latest` URLs, while pinned release builds still verify checksums as before.

## References
- `bun test test/constants/release.test.ts test/utils/CtrlProxyManager.test.ts test/utils/IOSCtrlProxyBuilder.test.ts`
- `bunx eslint src/constants/release.ts src/daemon/socketServer.ts src/server/bootedDeviceResources.ts src/utils/CtrlProxyManager.ts src/utils/IOSCtrlProxyBuilder.ts test/constants/release.test.ts`

Generated with Codex