### PR TITLE
Extending tapOn selectors

### DIFF
--- a/docs/design-docs/mcp/tools.md
+++ b/docs/design-docs/mcp/tools.md
@@ -8,7 +8,7 @@ Almost all other tool calls have built-in observation via the [interaction loop]
 
 #### Interactions
 
-- 👆 `tapOn` supports tap, double-tap, long press, and long-press drag actions.
+- 👆 `tapOn` supports tap, double-tap, long press, and long-press drag actions. Selector strategies include `text`, `elementId`, `clickable` (first clickable element), `siblingOfText` (clickable sibling of a text element), and `tapClickableParent` (nearest clickable ancestor of a text match).
 - 👉 `swipeOn` handles directional swipes and scrolling within container bounds.
 - ↔️ `dragAndDrop` for element-to-element moves.
 - 🔍 `pinchOn` for zoom in/out gestures.

--- a/src/features/action/TapOnElement.ts
+++ b/src/features/action/TapOnElement.ts
@@ -127,9 +127,14 @@ export class TapOnElement extends BaseVisualChange {
   }
 
   private validateOptions(options: TapOnElementOptions): string | null {
-    const selectorCount = [options.text, options.elementId].filter(Boolean).length;
+    const selectorCount = [
+      options.text,
+      options.elementId,
+      options.clickable,
+      options.siblingOfText
+    ].filter(Boolean).length;
     if (selectorCount !== 1) {
-      return "tapOn requires exactly one of text or elementId";
+      return "tapOn requires exactly one of text, elementId, clickable, or siblingOfText";
     }
 
     if (options.container) {
@@ -181,7 +186,34 @@ export class TapOnElement extends BaseVisualChange {
     viewHierarchy: ViewHierarchyResult
   ): { selection: ElementSelectionResult; containerFound: boolean } {
     const containerFound = this.isContainerAvailable(viewHierarchy, options.container);
+
+    if (options.siblingOfText) {
+      return {
+        selection: this.elementSelector.selectClickableSiblingOfText(viewHierarchy, options.siblingOfText, {
+          container: options.container,
+          fuzzyMatch: true,
+          caseSensitive: false,
+          strategy: options.selectionStrategy
+        }),
+        containerFound
+      };
+    }
+
     if (options.text) {
+      // If tapClickableParent is true, find the clickable parent containing the text
+      if (options.tapClickableParent) {
+        return {
+          selection: this.elementSelector.selectClickableParentByText(viewHierarchy, options.text, {
+            container: options.container,
+            fuzzyMatch: true,
+            caseSensitive: false,
+            strategy: options.selectionStrategy
+          }),
+          containerFound
+        };
+      }
+
+      // Standard text selection
       return {
         selection: this.elementSelector.selectByText(viewHierarchy, options.text, {
           container: options.container,
@@ -192,6 +224,7 @@ export class TapOnElement extends BaseVisualChange {
         containerFound
       };
     }
+
     if (options.elementId) {
       return {
         selection: this.elementSelector.selectByResourceId(viewHierarchy, options.elementId, {
@@ -202,7 +235,19 @@ export class TapOnElement extends BaseVisualChange {
         containerFound
       };
     }
-    throw new ActionableError("tapOn requires non-blank text or elementId to interact with");
+
+    if (options.clickable) {
+      return {
+        selection: this.elementSelector.selectClickable(viewHierarchy, {
+          container: options.container,
+          strategy: options.selectionStrategy,
+          scrollableContainer: options.scrollableContainer
+        }),
+        containerFound
+      };
+    }
+
+    throw new ActionableError("tapOn requires non-blank text, elementId, clickable, or siblingOfText to interact with");
   }
 
   private prepareViewHierarchyForResponse(
@@ -400,16 +445,18 @@ export class TapOnElement extends BaseVisualChange {
       );
     }
 
+    const containerHint = options.container
+      ? ` within container ${options.container.elementId ? `elementId '${options.container.elementId}'` : `text '${options.container.text}'`}`
+      : "";
+
     let baseError: string;
-    if (options.text) {
-      const containerHint = options.container
-        ? ` within container ${options.container.elementId ? `elementId '${options.container.elementId}'` : `text '${options.container.text}'`}`
-        : "";
+    if (options.siblingOfText) {
+      baseError = `No clickable sibling found next to element with text '${options.siblingOfText}'${containerHint}`;
+    } else if (options.text) {
       baseError = `Element not found with provided text '${options.text}'${containerHint}`;
+    } else if (options.clickable) {
+      baseError = `No clickable element found${containerHint}`;
     } else {
-      const containerHint = options.container
-        ? ` within container ${options.container.elementId ? `elementId '${options.container.elementId}'` : `text '${options.container.text}'`}`
-        : "";
       baseError = `Element not found with provided elementId '${options.elementId}'${containerHint}`;
     }
 

--- a/src/features/utility/DefaultElementSelector.ts
+++ b/src/features/utility/DefaultElementSelector.ts
@@ -58,6 +58,65 @@ export class DefaultElementSelector implements ElementSelector {
     return this.pickMatch(matches, strategy);
   }
 
+  selectClickableParentByText(
+    viewHierarchy: ViewHierarchyResult,
+    text: string,
+    options?: {
+      container?: { elementId?: string; text?: string } | null;
+      fuzzyMatch?: boolean;
+      caseSensitive?: boolean;
+      strategy?: ElementSelectionStrategy;
+    }
+  ): ElementSelectionResult {
+    const strategy = options?.strategy ?? "first";
+    const matches = this.finder.findClickableParentsContainingText(
+      viewHierarchy,
+      text,
+      options?.container ?? null,
+      options?.fuzzyMatch ?? true,
+      options?.caseSensitive ?? false
+    );
+    return this.pickMatch(matches, strategy);
+  }
+
+  selectClickable(
+    viewHierarchy: ViewHierarchyResult,
+    options?: {
+      container?: { elementId?: string; text?: string } | null;
+      strategy?: ElementSelectionStrategy;
+      scrollableContainer?: boolean;
+    }
+  ): ElementSelectionResult {
+    const strategy = options?.strategy ?? "first";
+    const matches = this.finder.findClickableElementsInContainer(
+      viewHierarchy,
+      options?.container ?? null,
+      options?.scrollableContainer ?? false
+    );
+    return this.pickMatch(matches, strategy);
+  }
+
+  selectClickableSiblingOfText(
+    viewHierarchy: ViewHierarchyResult,
+    text: string,
+    options?: {
+      container?: { elementId?: string; text?: string } | null;
+      fuzzyMatch?: boolean;
+      caseSensitive?: boolean;
+      strategy?: ElementSelectionStrategy;
+    }
+  ): ElementSelectionResult {
+    const strategy = options?.strategy ?? "first";
+    const matches = this.finder.findClickableSiblingsOfText(
+      viewHierarchy,
+      text,
+      options?.container ?? null,
+      options?.fuzzyMatch ?? true,
+      options?.caseSensitive ?? false
+    );
+    return this.pickMatch(matches, strategy);
+  }
+
   private pickMatch(matches: Element[], strategy: ElementSelectionStrategy): ElementSelectionResult {
     const totalMatches = matches.length;
     if (totalMatches === 0) {

--- a/src/features/utility/ElementFinder.ts
+++ b/src/features/utility/ElementFinder.ts
@@ -132,7 +132,7 @@ export class DefaultElementFinder implements ElementFinder {
     for (const searchNode of rootNodes) {
       this.parser.traverseNode(searchNode, (node: any) => {
         const nodeProperties = this.parser.extractNodeProperties(node);
-        logger.info(`[Element] node: ${nodeProperties["text"]} ${nodeProperties["content-desc"]} ${nodeProperties["class"]}`);
+        logger.debug(`[Element] node: ${nodeProperties["text"]} ${nodeProperties["content-desc"]} ${nodeProperties["class"]}`);
 
         // Check text attribute
         if (
@@ -140,7 +140,7 @@ export class DefaultElementFinder implements ElementFinder {
           typeof nodeProperties.text === "string" &&
           matchesText(nodeProperties.text)
         ) {
-          logger.info("[Element] Matches text property");
+          logger.debug("[Element] Matches text property");
           const parsedNode = this.parser.parseNodeBounds(node);
           if (parsedNode) {
             if (nodeProperties.text === text) {
@@ -154,7 +154,7 @@ export class DefaultElementFinder implements ElementFinder {
           typeof nodeProperties["content-desc"] === "string" &&
           matchesText(nodeProperties["content-desc"])
         ) {
-          logger.info("[Element] Matches content-desc property");
+          logger.debug("[Element] Matches content-desc property");
           const parsedNode = this.parser.parseNodeBounds(node);
           if (parsedNode) {
             if (nodeProperties["content-desc"] === text) {
@@ -168,7 +168,7 @@ export class DefaultElementFinder implements ElementFinder {
           typeof nodeProperties["ios-accessibility-label"] === "string" &&
           matchesText(nodeProperties["ios-accessibility-label"])
         ) {
-          logger.info("[Element] Matches ios-accessibility-label property");
+          logger.debug("[Element] Matches ios-accessibility-label property");
           const parsedNode = this.parser.parseNodeBounds(node);
           if (parsedNode) {
             if (nodeProperties["ios-accessibility-label"] === text) {
@@ -187,7 +187,7 @@ export class DefaultElementFinder implements ElementFinder {
             nodeProperties.clickable === "true"
           )
         ) {
-          logger.info("[Element] Matches clickable element with text");
+          logger.debug("[Element] Matches clickable element with text");
           const parsedNode = this.parser.parseNodeBounds(node);
           if (parsedNode) {
             partialMatches.push(parsedNode);
@@ -481,7 +481,6 @@ export class DefaultElementFinder implements ElementFinder {
     ];
     const scrollables: Element[] = [];
 
-    // Process each root node
     for (const rootNode of rootNodes) {
       this.parser.traverseNode(rootNode, (node: any) => {
         const nodeProperties = this.parser.extractNodeProperties(node);
@@ -540,8 +539,76 @@ export class DefaultElementFinder implements ElementFinder {
     ];
     const clickables: Element[] = [];
 
-    // Process each root node
     for (const rootNode of rootNodes) {
+      this.parser.traverseNode(rootNode, (node: any) => {
+        const nodeProperties = this.parser.extractNodeProperties(node);
+        if (nodeProperties.clickable === "true" || nodeProperties.clickable === true) {
+          const parsedNode = this.parser.parseNodeBounds(node);
+          if (parsedNode) {
+            clickables.push(parsedNode);
+          }
+        }
+      });
+    }
+
+    return clickables;
+  }
+
+  /**
+   * Find clickable elements, optionally restricted to a container.
+   * @param viewHierarchy - The view hierarchy to search
+   * @param container - Optional container to restrict search
+   * @param scrollableContainer - If true, only search within scrollable elements
+   * @returns Array of clickable elements
+   */
+  findClickableElementsInContainer(
+    viewHierarchy: ViewHierarchyResult,
+    container: { elementId?: string; text?: string } | null = null,
+    scrollableContainer: boolean = false
+  ): Element[] {
+    if (!viewHierarchy) {
+      return [];
+    }
+
+    const containerNode = container
+      ? this.findContainerNodeInternal(viewHierarchy, container)
+      : null;
+
+    if (container && !containerNode) {
+      return [];
+    }
+
+    let searchRoots = containerNode
+      ? [containerNode]
+      : [
+        ...this.parser.extractRootNodes(viewHierarchy),
+        ...this.parser.extractWindowRootNodes(viewHierarchy, "topmost-first")
+      ];
+
+    // If scrollableContainer is true, find all scrollable nodes first
+    // and then search for clickables only within those
+    if (scrollableContainer) {
+      const scrollableNodes: any[] = [];
+      for (const rootNode of searchRoots) {
+        this.parser.traverseNode(rootNode, (node: any) => {
+          const nodeProperties = this.parser.extractNodeProperties(node);
+          if (nodeProperties.scrollable === "true" || nodeProperties.scrollable === true) {
+            scrollableNodes.push(node);
+          }
+        });
+      }
+
+      if (scrollableNodes.length > 0) {
+        searchRoots = scrollableNodes;
+      } else {
+        // No scrollable containers found, return empty
+        return [];
+      }
+    }
+
+    const clickables: Element[] = [];
+
+    for (const rootNode of searchRoots) {
       this.parser.traverseNode(rootNode, (node: any) => {
         const nodeProperties = this.parser.extractNodeProperties(node);
         if (nodeProperties.clickable === "true" || nodeProperties.clickable === true) {
@@ -574,7 +641,6 @@ export class DefaultElementFinder implements ElementFinder {
     const childElements: Element[] = [];
     const parentBounds = parentElement.bounds;
 
-    // Find elements that are within the parent's bounds
     for (const rootNode of rootNodes) {
       this.parser.traverseNode(rootNode, (node: any) => {
         const nodeProperties = this.parser.extractNodeProperties(node);
@@ -734,5 +800,292 @@ export class DefaultElementFinder implements ElementFinder {
 
     // Use partial matching for text validation
     return this.textMatcher.partialTextMatch(foundElement.text, expectedText, false);
+  }
+
+  /**
+   * Find clickable parent elements that contain descendants matching the specified text.
+   * This traverses the hierarchy looking for clickable elements that have a descendant
+   * with matching text, returning the clickable parent (not the text element itself).
+   *
+   * @param viewHierarchy - The view hierarchy to search
+   * @param text - The text to search for in descendants
+   * @param container - Container element selector to restrict the search
+   * @param fuzzyMatch - Whether to use fuzzy matching
+   * @param caseSensitive - Whether to use case-sensitive matching
+   * @returns Array of clickable parent elements containing the text
+   */
+  findClickableParentsContainingText(
+    viewHierarchy: ViewHierarchyResult,
+    text: string,
+    container: { elementId?: string; text?: string } | null = null,
+    fuzzyMatch: boolean = true,
+    caseSensitive: boolean = false
+  ): Element[] {
+    if (!viewHierarchy || !text) {
+      return [];
+    }
+
+    const matchesText = this.textMatcher.createTextMatcher(text, fuzzyMatch, caseSensitive);
+    const containerNode = container
+      ? this.findContainerNodeInternal(viewHierarchy, container)
+      : null;
+
+    if (container && !containerNode) {
+      return [];
+    }
+
+    const searchRoots = containerNode
+      ? [containerNode]
+      : this.parser.extractRootNodes(viewHierarchy);
+
+    const clickableParents = this.collectClickableParentsWithTextInRoots(searchRoots, matchesText);
+
+    if (clickableParents.length > 0) {
+      return clickableParents;
+    }
+
+    // Try window roots if no match in main hierarchy
+    if (!containerNode) {
+      const windowRootGroups = this.parser.extractWindowRootGroups(viewHierarchy, "topmost-first");
+      for (const windowRoots of windowRootGroups) {
+        const windowMatches = this.collectClickableParentsWithTextInRoots(windowRoots, matchesText);
+        if (windowMatches.length > 0) {
+          return windowMatches;
+        }
+      }
+    }
+
+    return [];
+  }
+
+  /**
+   * Internal method to find clickable elements that have descendants with matching text.
+   */
+  private collectClickableParentsWithTextInRoots(
+    rootNodes: ViewHierarchyNode[],
+    matchesText: (input?: string) => boolean
+  ): Element[] {
+    const matches: Element[] = [];
+
+    for (const rootNode of rootNodes) {
+      this.findClickableParentsInNode(rootNode, matchesText, matches);
+    }
+
+    return matches;
+  }
+
+  /**
+   * Find clickable elements that are siblings of elements containing the specified text.
+   * This finds nodes that share the same parent as a text-matching node.
+   *
+   * @param viewHierarchy - The view hierarchy to search
+   * @param text - The text to search for in sibling elements
+   * @param container - Container element selector to restrict the search
+   * @param fuzzyMatch - Whether to use fuzzy matching
+   * @param caseSensitive - Whether to use case-sensitive matching
+   * @returns Array of clickable sibling elements
+   */
+  findClickableSiblingsOfText(
+    viewHierarchy: ViewHierarchyResult,
+    text: string,
+    container: { elementId?: string; text?: string } | null = null,
+    fuzzyMatch: boolean = true,
+    caseSensitive: boolean = false
+  ): Element[] {
+    if (!viewHierarchy || !text) {
+      return [];
+    }
+
+    const matchesText = this.textMatcher.createTextMatcher(text, fuzzyMatch, caseSensitive);
+    const containerNode = container
+      ? this.findContainerNodeInternal(viewHierarchy, container)
+      : null;
+
+    if (container && !containerNode) {
+      return [];
+    }
+
+    const searchRoots = containerNode
+      ? [containerNode]
+      : this.parser.extractRootNodes(viewHierarchy);
+
+    const siblings = this.collectClickableSiblingsWithTextInRoots(searchRoots, matchesText);
+
+    if (siblings.length > 0) {
+      return siblings;
+    }
+
+    // Try window roots if no match in main hierarchy
+    if (!containerNode) {
+      const windowRootGroups = this.parser.extractWindowRootGroups(viewHierarchy, "topmost-first");
+      for (const windowRoots of windowRootGroups) {
+        const windowMatches = this.collectClickableSiblingsWithTextInRoots(windowRoots, matchesText);
+        if (windowMatches.length > 0) {
+          return windowMatches;
+        }
+      }
+    }
+
+    return [];
+  }
+
+  /**
+   * Internal method to find clickable siblings of text-matching elements.
+   */
+  private collectClickableSiblingsWithTextInRoots(
+    rootNodes: ViewHierarchyNode[],
+    matchesText: (input?: string) => boolean
+  ): Element[] {
+    const results: Element[] = [];
+
+    for (const rootNode of rootNodes) {
+      this.findClickableSiblingsInNode(rootNode, matchesText, results);
+    }
+
+    return results;
+  }
+
+  /**
+   * Recursively search for clickable siblings of text-matching elements.
+   * When a node has children where one directly matches text and another is clickable,
+   * we return the clickable sibling.
+   *
+   * Uses nodeHasText (shallow) instead of nodeOrDescendantHasText (deep) to avoid
+   * false positives: a parent whose deeply-nested descendant has the text should not
+   * cause its other children to be collected as "siblings." The recursion naturally
+   * finds the correct level.
+   */
+  private findClickableSiblingsInNode(
+    node: ViewHierarchyNode,
+    matchesText: (input?: string) => boolean,
+    results: Element[]
+  ): void {
+    const children = node.node;
+    if (!children) {
+      return;
+    }
+
+    const childArray: ViewHierarchyNode[] = Array.isArray(children)
+      ? children
+      : [children];
+
+    // Check if any direct child has matching text (shallow — not descendants)
+    const hasTextMatch = childArray.some(child => this.nodeHasText(child, matchesText));
+
+    if (hasTextMatch) {
+      for (const child of childArray) {
+        const childProps = this.parser.extractNodeProperties(child);
+        const isClickable = childProps.clickable === "true" || childProps.clickable === true;
+
+        if (isClickable && !this.nodeHasText(child, matchesText)) {
+          const parsedNode = this.parser.parseNodeBounds(child);
+          if (parsedNode) {
+            results.push(parsedNode);
+          }
+        }
+      }
+    }
+
+    for (const child of childArray) {
+      this.findClickableSiblingsInNode(child, matchesText, results);
+    }
+  }
+
+  /**
+   * Recursively search for clickable elements that contain text-matching descendants.
+   */
+  private findClickableParentsInNode(
+    node: ViewHierarchyNode,
+    matchesText: (input?: string) => boolean,
+    results: Element[]
+  ): boolean {
+    const nodeProperties = this.parser.extractNodeProperties(node);
+    const isClickable = nodeProperties.clickable === "true" || nodeProperties.clickable === true;
+
+    // Check if this node or any descendant has matching text
+    const hasMatchingText = this.nodeOrDescendantHasText(node, matchesText);
+
+    if (isClickable && hasMatchingText) {
+      const parsedNode = this.parser.parseNodeBounds(node);
+      if (parsedNode) {
+        results.push(parsedNode);
+      }
+      // Don't recurse into children - we found a clickable parent
+      return true;
+    }
+
+    // Recurse into children
+    const children = node.node;
+    if (children) {
+      if (Array.isArray(children)) {
+        for (const child of children) {
+          this.findClickableParentsInNode(child, matchesText, results);
+        }
+      } else if (typeof children === "object") {
+        this.findClickableParentsInNode(children as ViewHierarchyNode, matchesText, results);
+      }
+    }
+
+    return false;
+  }
+
+  /**
+   * Check if a node itself has text matching the predicate (shallow — no descendants).
+   */
+  private nodeHasText(
+    node: ViewHierarchyNode,
+    matchesText: (input?: string) => boolean
+  ): boolean {
+    const props = this.parser.extractNodeProperties(node);
+    const text = props.text;
+    const contentDesc = props["content-desc"];
+    const iosLabel = props["ios-accessibility-label"];
+
+    return (
+      (typeof text === "string" && matchesText(text)) ||
+      (typeof contentDesc === "string" && matchesText(contentDesc)) ||
+      (typeof iosLabel === "string" && matchesText(iosLabel))
+    );
+  }
+
+  /**
+   * Check if a node or any of its descendants has text matching the predicate.
+   */
+  private nodeOrDescendantHasText(
+    node: ViewHierarchyNode,
+    matchesText: (input?: string) => boolean
+  ): boolean {
+    const nodeProperties = this.parser.extractNodeProperties(node);
+
+    // Check this node's text properties
+    const nodeText = nodeProperties.text;
+    const nodeContentDesc = nodeProperties["content-desc"];
+    const nodeIosLabel = nodeProperties["ios-accessibility-label"];
+
+    if (
+      (typeof nodeText === "string" && matchesText(nodeText)) ||
+      (typeof nodeContentDesc === "string" && matchesText(nodeContentDesc)) ||
+      (typeof nodeIosLabel === "string" && matchesText(nodeIosLabel))
+    ) {
+      return true;
+    }
+
+    // Recursively check children
+    const children = node.node;
+    if (children) {
+      if (Array.isArray(children)) {
+        for (const child of children) {
+          if (this.nodeOrDescendantHasText(child, matchesText)) {
+            return true;
+          }
+        }
+      } else if (typeof children === "object") {
+        if (this.nodeOrDescendantHasText(children as ViewHierarchyNode, matchesText)) {
+          return true;
+        }
+      }
+    }
+
+    return false;
   }
 }

--- a/src/models/TapOnElementOptions.ts
+++ b/src/models/TapOnElementOptions.ts
@@ -30,4 +30,22 @@ export interface TapOnElementOptions {
   // Optional flag to set accessibility focus before performing action (TalkBack mode)
   // If not specified, will be determined automatically based on TalkBack state
   focusFirst?: boolean;
+
+  // Optional flag to tap the nearest clickable parent that contains the text element.
+  // Useful for list items where the clickable row doesn't have a resource-id but
+  // contains children with text. Only works with text selection (not elementId).
+  tapClickableParent?: boolean;
+
+  // Select any clickable element. Use with selectionStrategy: 'first' to tap
+  // the first clickable item in a list without knowing its text or ID.
+  clickable?: boolean;
+
+  // Only search within scrollable containers (lists/RecyclerViews).
+  // Use this to avoid tapping search bars or other clickable UI elements
+  // when you want the first list item.
+  scrollableContainer?: boolean;
+
+  // Find a clickable element that is a sibling of an element containing this text.
+  // Useful for tapping checkboxes, icons, or buttons next to a specific text label.
+  siblingOfText?: string;
 }

--- a/src/server/interactionToolTypes.ts
+++ b/src/server/interactionToolTypes.ts
@@ -65,6 +65,10 @@ export interface TapOnArgs {
     duration?: number;
   };
   platform: Platform;
+  tapClickableParent?: boolean;
+  clickable?: boolean;
+  scrollableContainer?: boolean;
+  siblingOfText?: string;
 }
 
 export interface DragAndDropArgs {

--- a/src/server/interactionTools.ts
+++ b/src/server/interactionTools.ts
@@ -149,9 +149,50 @@ const tapOnSelectorSchema = addDeviceTargetingToSchema(
   tapOnBaseSchema.extend(elementIdTextFieldsSchema.shape).strict()
 );
 
-export const tapOnSchema = tapOnSelectorSchema.superRefine((value, ctx) => {
+const tapOnByIdSchema = tapOnSelectorSchema.superRefine((value, ctx) => {
   validateElementIdTextSelector(value, ctx);
 });
+
+const tapOnByTextSchema = addDeviceTargetingToSchema(
+  tapOnBaseSchema.extend({
+    text: z.string().min(1).describe("Element text"),
+    tapClickableParent: z.boolean().optional().describe(
+      "Tap the nearest clickable parent that contains the text element. " +
+      "Useful for list items where the clickable row doesn't have a resource-id " +
+      "but contains children with text."
+    )
+  }).strict()
+);
+
+const tapOnByClickableSchema = addDeviceTargetingToSchema(
+  tapOnBaseSchema.extend({
+    clickable: z.literal(true).describe(
+      "Select clickable elements. Use with selectionStrategy: 'first' to tap " +
+      "the first clickable item in a list without knowing its text or ID."
+    ),
+    scrollableContainer: z.boolean().optional().describe(
+      "Only search within scrollable containers (lists/RecyclerViews). " +
+      "Use this to avoid tapping search bars or other clickable UI elements " +
+      "when you want the first list item."
+    )
+  }).strict()
+);
+
+const tapOnBySiblingOfTextSchema = addDeviceTargetingToSchema(
+  tapOnBaseSchema.extend({
+    siblingOfText: z.string().min(1).describe(
+      "Find a clickable element that is a sibling of an element containing this text. " +
+      "Useful for tapping checkboxes, icons, or buttons next to a specific text label."
+    )
+  }).strict()
+);
+
+export const tapOnSchema = z.union([
+  tapOnByIdSchema,
+  tapOnByTextSchema,
+  tapOnByClickableSchema,
+  tapOnBySiblingOfTextSchema
+]);
 
 const tapOnResultSchema = z.object({
   success: z.boolean(),
@@ -386,6 +427,10 @@ export function registerInteractionTools() {
       action: args.action,
       duration: args.duration,
       searchUntil: args.searchUntil,
+      tapClickableParent: args.tapClickableParent,
+      clickable: args.clickable,
+      scrollableContainer: args.scrollableContainer,
+      siblingOfText: args.siblingOfText,
     }, progress);
 
     const searchStats = result.searchUntil;

--- a/test/fakes/FakeElementSelector.ts
+++ b/test/fakes/FakeElementSelector.ts
@@ -4,6 +4,13 @@ import type { ViewHierarchyResult } from "../../src/models/ViewHierarchyResult";
 import type { ElementSelectionStrategy } from "../../src/models/ElementSelectionStrategy";
 import type { ElementSelector } from "../../src/utils/interfaces/ElementSelector";
 
+/**
+ * Deterministic fake for testing code that depends on ElementSelector.
+ *
+ * Limitation: the "random" selection strategy is not modeled — the fake always
+ * returns the pre-configured nextElement regardless of strategy. Tests that need
+ * to verify randomness should test DefaultElementSelector directly.
+ */
 export class FakeElementSelector implements ElementSelector {
   lastStrategy?: ElementSelectionStrategy;
   lastText?: string;
@@ -70,6 +77,51 @@ export class FakeElementSelector implements ElementSelector {
     void viewHierarchy;
     this.lastStrategy = options?.strategy;
     this.lastResourceId = resourceId;
+    return this.buildSelectionResult(options?.strategy);
+  }
+
+  selectClickableParentByText(
+    viewHierarchy: ViewHierarchyResult,
+    text: string,
+    options?: {
+      container?: { elementId?: string; text?: string } | null;
+      fuzzyMatch?: boolean;
+      caseSensitive?: boolean;
+      strategy?: ElementSelectionStrategy;
+    }
+  ): ElementSelectionResult {
+    void viewHierarchy;
+    this.lastStrategy = options?.strategy;
+    this.lastText = text;
+    return this.buildSelectionResult(options?.strategy);
+  }
+
+  selectClickable(
+    viewHierarchy: ViewHierarchyResult,
+    options?: {
+      container?: { elementId?: string; text?: string } | null;
+      strategy?: ElementSelectionStrategy;
+      scrollableContainer?: boolean;
+    }
+  ): ElementSelectionResult {
+    void viewHierarchy;
+    this.lastStrategy = options?.strategy;
+    return this.buildSelectionResult(options?.strategy);
+  }
+
+  selectClickableSiblingOfText(
+    viewHierarchy: ViewHierarchyResult,
+    text: string,
+    options?: {
+      container?: { elementId?: string; text?: string } | null;
+      fuzzyMatch?: boolean;
+      caseSensitive?: boolean;
+      strategy?: ElementSelectionStrategy;
+    }
+  ): ElementSelectionResult {
+    void viewHierarchy;
+    this.lastStrategy = options?.strategy;
+    this.lastText = text;
     return this.buildSelectionResult(options?.strategy);
   }
 }

--- a/test/features/action/TapOnElement.extendedSelectors.test.ts
+++ b/test/features/action/TapOnElement.extendedSelectors.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, test } from "bun:test";
+import { TapOnElement } from "../../../src/features/action/TapOnElement";
+import { FakeAdbClient } from "../../fakes/FakeAdbClient";
+import { FakeElementSelector } from "../../fakes/FakeElementSelector";
+import { FakeTimer } from "../../fakes/FakeTimer";
+
+const createTapOnElement = (selector: FakeElementSelector) => {
+  return new TapOnElement(
+    {
+      name: "test-device",
+      platform: "android",
+      id: "emulator-5554",
+    } as any,
+    new FakeAdbClient() as any,
+    {
+      timer: new FakeTimer(),
+      elementSelector: selector,
+    }
+  );
+};
+
+const makeElement = () => ({
+  bounds: { left: 0, top: 0, right: 100, bottom: 50 },
+  text: "Item",
+  clickable: "true",
+} as any);
+
+describe("TapOnElement extended selectors", () => {
+  describe("validation", () => {
+    test("rejects when no selector provided", () => {
+      const selector = new FakeElementSelector(makeElement());
+      const tapOn = createTapOnElement(selector);
+      const error = (tapOn as any).validateOptions({ action: "tap" });
+      expect(error).toContain("requires exactly one");
+    });
+
+    test("rejects when multiple selectors provided", () => {
+      const selector = new FakeElementSelector(makeElement());
+      const tapOn = createTapOnElement(selector);
+      const error = (tapOn as any).validateOptions({
+        action: "tap",
+        text: "Login",
+        clickable: true,
+      });
+      expect(error).toContain("requires exactly one");
+    });
+
+    test("accepts clickable as sole selector", () => {
+      const selector = new FakeElementSelector(makeElement());
+      const tapOn = createTapOnElement(selector);
+      const error = (tapOn as any).validateOptions({
+        action: "tap",
+        clickable: true,
+      });
+      expect(error).toBeNull();
+    });
+
+    test("accepts siblingOfText as sole selector", () => {
+      const selector = new FakeElementSelector(makeElement());
+      const tapOn = createTapOnElement(selector);
+      const error = (tapOn as any).validateOptions({
+        action: "tap",
+        siblingOfText: "Label",
+      });
+      expect(error).toBeNull();
+    });
+  });
+
+  describe("findElementInHierarchy", () => {
+    test("delegates siblingOfText to selectClickableSiblingOfText", () => {
+      const selector = new FakeElementSelector(makeElement());
+      const tapOn = createTapOnElement(selector);
+
+      const result = (tapOn as any).findElementInHierarchy(
+        { siblingOfText: "Email", action: "tap" },
+        { hierarchy: { node: {} } }
+      );
+
+      expect(result.selection.element).not.toBeNull();
+      expect(selector.lastText).toBe("Email");
+    });
+
+    test("delegates tapClickableParent to selectClickableParentByText", () => {
+      const selector = new FakeElementSelector(makeElement());
+      const tapOn = createTapOnElement(selector);
+
+      const result = (tapOn as any).findElementInHierarchy(
+        { text: "John Smith", tapClickableParent: true, action: "tap" },
+        { hierarchy: { node: {} } }
+      );
+
+      expect(result.selection.element).not.toBeNull();
+      expect(selector.lastText).toBe("John Smith");
+    });
+
+    test("delegates clickable to selectClickable", () => {
+      const selector = new FakeElementSelector(makeElement());
+      const tapOn = createTapOnElement(selector);
+
+      const result = (tapOn as any).findElementInHierarchy(
+        { clickable: true, action: "tap" },
+        { hierarchy: { node: {} } }
+      );
+
+      expect(result.selection.element).not.toBeNull();
+    });
+
+    test("clickable respects selectionStrategy", () => {
+      const selector = new FakeElementSelector(makeElement());
+      const tapOn = createTapOnElement(selector);
+
+      (tapOn as any).findElementInHierarchy(
+        { clickable: true, action: "tap", selectionStrategy: "random" },
+        { hierarchy: { node: {} } }
+      );
+
+      expect(selector.lastStrategy).toBe("random");
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Three new selection strategies for `tapOn` beyond the existing text/elementId:

- **`tapClickableParent`** (boolean) -- Combined with `text`, finds the nearest clickable ancestor of the element containing that text. Useful for list items where the clickable row doesn't have a resource-id but contains children with text.
- **`clickable`** (boolean) -- Taps the first clickable element found, with optional `container`, `selectionStrategy`, and `scrollableContainer` scoping. Good for tapping the first list item without knowing its text or ID.
- **`siblingOfText`** (string) -- Finds the clickable sibling of the element with the given text. Useful for tapping checkboxes, icons, or buttons next to a specific text label.

Each strategy has a dedicated Zod schema branch in a `z.union()`, keeping runtime validation strict per-selector.

## Test plan

- [ ] `bun test test/features/action/TapOnElement.extendedSelectors.test.ts` passes (8 tests)
- [ ] `npx turbo run build lint` clean
- [ ] Existing tapOn text/elementId selectors still work (no regression)
