### PR TITLE
Schema updates - platformSchema + flattenTopLevelUnion

### DIFF
--- a/src/server/debugTools.ts
+++ b/src/server/debugTools.ts
@@ -5,7 +5,7 @@ import { DebugSearch } from "../features/debug/DebugSearch";
 import { BugReport } from "../features/debug/BugReport";
 import { createJSONToolResponse } from "../utils/toolUtils";
 import { BootedDevice, Platform } from "../models";
-import { addDeviceTargetingToSchema } from "./toolSchemaHelpers";
+import { addDeviceTargetingToSchema, platformSchema } from "./toolSchemaHelpers";
 import { isDebugModeEnabled } from "../utils/debug";
 import {
   elementContainerSchema,
@@ -43,7 +43,7 @@ export interface BugReportArgs {
 
 // Schema definitions
 const debugSearchBaseSchema = z.object({
-  platform: z.enum(["android", "ios"]).describe("Target platform"),
+  platform: platformSchema,
   text: z.string().optional().describe("Text to search for in elements"),
   elementId: elementIdTextFieldsSchema.shape.elementId.describe(
     "Element resource ID / accessibility identifier to search for"
@@ -62,7 +62,7 @@ export const debugSearchSchema = addDeviceTargetingToSchema(debugSearchBaseSchem
 });
 
 export const bugReportSchema = addDeviceTargetingToSchema(z.object({
-  platform: z.enum(["android", "ios"]).describe("Target platform"),
+  platform: platformSchema,
   appId: z.string().optional().describe("App package ID to filter logcat for specific app"),
   logcatLines: z.number().optional().describe("Number of recent logcat lines to include (default: 1000)"),
   saveDir: z.string().optional().describe("Directory to save report to")

--- a/src/server/deviceTools.ts
+++ b/src/server/deviceTools.ts
@@ -10,20 +10,21 @@ import { listActiveVideoRecordings, stopVideoRecording } from "./videoRecordingM
 import { IOSCtrlProxyManager } from "../utils/IOSCtrlProxyManager";
 import { logger } from "../utils/logger";
 import { createPerformanceTracker } from "../utils/PerformanceTracker";
+import { platformSchema } from "./toolSchemaHelpers";
 
 // Schema definitions
 export const listDeviceImagesSchema = z.object({
-  platform: z.enum(["android", "ios"]).describe("Platform")
+  platform: platformSchema
 });
 
 export const listDevicesSchema = z.object({
-  platform: z.enum(["android", "ios"]).optional().describe("Platform")
+  platform: platformSchema.optional()
 });
 
 export const startDeviceSchema = z.object({
   device: z.object({
     name: z.string().describe("Device name"),
-    platform: z.enum(["android", "ios"]).describe("Platform"),
+    platform: platformSchema,
     deviceId: z.string().optional().describe("Device ID"),
     isRunning: z.boolean().optional().describe("Running status"),
     source: z.string().optional().describe("Source (local/remote)")
@@ -35,7 +36,7 @@ export const killDeviceSchema = z.object({
   device: z.object({
     name: z.string().describe("Device image name"),
     deviceId: z.string().describe("Device ID"),
-    platform: z.enum(["android", "ios"]).describe("Platform")
+    platform: platformSchema
   })
 });
 

--- a/src/server/highlightTools.ts
+++ b/src/server/highlightTools.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import { ToolRegistry } from "./toolRegistry";
-import { addDeviceTargetingToSchema } from "./toolSchemaHelpers";
+import { addDeviceTargetingToSchema, platformSchema } from "./toolSchemaHelpers";
 import { createJSONToolResponse } from "../utils/toolUtils";
 import {
   ActionableError,
@@ -38,7 +38,7 @@ const generateHighlightId = (timer: Timer = defaultTimer): string => {
 };
 
 const highlightBaseSchema = z.object({
-  platform: z.enum(["android", "ios"]).describe("Target platform"),
+  platform: platformSchema,
   deviceId: z.string().optional().describe("Optional device ID override"),
   timeoutMs: z.number().int().positive().optional().describe("Highlight request timeout ms (default: 5000)"),
   description: z.string().optional().describe("Optional description of the highlight"),

--- a/src/server/interactionTools.ts
+++ b/src/server/interactionTools.ts
@@ -24,7 +24,7 @@ import { ListInstalledApps } from "../features/observe/ListInstalledApps";
 import { createJSONToolResponse, createStructuredToolResponse } from "../utils/toolUtils";
 import { resolveSwipeDirection } from "../utils/swipeOnUtils";
 import { RecompositionTracker } from "../features/performance/RecompositionTracker";
-import { addDeviceTargetingToSchema } from "./toolSchemaHelpers";
+import { addDeviceTargetingToSchema, platformSchema } from "./toolSchemaHelpers";
 import { serverConfig } from "../utils/ServerConfig";
 import {
   createElementIdTextSelectorSchema,
@@ -123,12 +123,12 @@ export {
 export const shakeSchema = addDeviceTargetingToSchema(z.object({
   duration: z.number().optional().describe("Shake duration in ms (default: 1000)"),
   intensity: z.number().optional().describe("Shake acceleration intensity (default: 100)"),
-  platform: z.enum(["android", "ios"]).describe("Platform")
+  platform: platformSchema
 }));
 
 export const keyboardSchema = addDeviceTargetingToSchema(z.object({
   action: z.enum(["open", "close", "detect"]).describe("Keyboard action"),
-  platform: z.enum(["android", "ios"]).describe("Platform")
+  platform: platformSchema
 }));
 
 const tapOnBaseSchema = z.object({
@@ -143,7 +143,7 @@ const tapOnBaseSchema = z.object({
   searchUntil: z.object({
     duration: z.number().min(100).max(12000).optional().describe("Polling duration (ms, default: 500)"),
   }).optional().describe("Poll for element before tapping"),
-  platform: z.enum(["android", "ios"]).describe("Platform")
+  platform: platformSchema
 }).strict();
 
 const tapOnSelectorSchema = addDeviceTargetingToSchema(
@@ -222,7 +222,7 @@ export const dragAndDropSchema = addDeviceTargetingToSchema(z.object({
   holdDurationMs: z.number().min(100).max(3000).optional().describe(
     "Hold duration ms (min: 100, max: 3000, default: 100)"
   ),
-  platform: z.enum(["android", "ios"]).describe("Platform")
+  platform: platformSchema
 }));
 
 export const swipeOnSchema = addDeviceTargetingToSchema(z.object({
@@ -239,7 +239,7 @@ export const swipeOnSchema = addDeviceTargetingToSchema(z.object({
   apexPause: z.number().min(0).max(3000).optional().describe("Pause duration at swipe apex in ms (0-3000)"),
   returnSpeed: z.number().min(0.1).max(3.0).optional().describe("Speed multiplier for return swipe (0.1-3.0)"),
   speed: z.enum(["slow", "normal", "fast"]).optional().describe("Swipe speed preset"),
-  platform: z.enum(["android", "ios"]).describe("Platform")
+  platform: platformSchema
 }));
 
 export const pinchOnSchema = addDeviceTargetingToSchema(z.object({
@@ -254,21 +254,21 @@ export const pinchOnSchema = addDeviceTargetingToSchema(z.object({
     "Container selector object to scope search. Provide { \"elementId\": \"<id>\" } or { \"text\": \"<text>\" }."
   ),
   autoTarget: z.boolean().optional().describe("Auto-target pinchable containers"),
-  platform: z.enum(["android", "ios"]).describe("Platform")
+  platform: platformSchema
 }));
 
 export const clearTextSchema = addDeviceTargetingToSchema(z.object({
-  platform: z.enum(["android", "ios"]).describe("Platform")
+  platform: platformSchema
 }));
 
 export const selectAllTextSchema = addDeviceTargetingToSchema(z.object({
-  platform: z.enum(["android", "ios"]).describe("Platform")
+  platform: platformSchema
 }));
 
 export const pressButtonSchema = addDeviceTargetingToSchema(z.object({
   button: z.enum(["home", "back", "menu", "power", "volume_up", "volume_down", "recent"])
     .describe("Button to press"),
-  platform: z.enum(["android", "ios"]).describe("Platform")
+  platform: platformSchema
 }));
 
 const systemTrayNotificationSchema = z.object({
@@ -284,7 +284,7 @@ const systemTraySchemaBase = z.object({
   ),
   notification: systemTrayNotificationSchema.optional().describe("Notification criteria to match"),
   awaitTimeout: z.number().optional().describe("Timeout in ms to wait for notification (default: 5000)"),
-  platform: z.enum(["android", "ios"]).describe("Platform")
+  platform: platformSchema
 });
 
 export const systemTraySchema = addDeviceTargetingToSchema(systemTraySchemaBase).superRefine((value, ctx) => {
@@ -320,18 +320,18 @@ export const systemTraySchema = addDeviceTargetingToSchema(systemTraySchemaBase)
 export const pressKeySchema = addDeviceTargetingToSchema(z.object({
   key: z.enum(["home", "back", "menu", "power", "volume_up", "volume_down", "recent"])
     .describe("Key to press"),
-  platform: z.enum(["android", "ios"]).describe("Platform")
+  platform: platformSchema
 }));
 
 export const stopAppSchema = addDeviceTargetingToSchema(z.object({
   appId: z.string().describe("App package ID"),
-  platform: z.enum(["android", "ios"]).describe("Platform")
+  platform: platformSchema
 }));
 
 export const clearStateSchema = addDeviceTargetingToSchema(z.object({
   appId: z.string().describe("App package ID"),
   clearKeychain: z.boolean().optional().describe("Clear iOS keychain"),
-  platform: z.enum(["android", "ios"]).describe("Platform")
+  platform: platformSchema
 }));
 
 export const inputTextSchema = addDeviceTargetingToSchema(z.object({
@@ -340,36 +340,36 @@ export const inputTextSchema = addDeviceTargetingToSchema(z.object({
     .describe("IME action after input"),
   dismissKeyboard: z.boolean().optional()
     .describe("(Android only) Dismiss soft keyboard after input. Overrides server-level --dismiss-keyboard-after-input flag. Ignored on iOS."),
-  platform: z.enum(["android", "ios"]).describe("Platform")
+  platform: platformSchema
 }));
 
 export const openLinkSchema = addDeviceTargetingToSchema(z.object({
   url: z.string().describe("URL to open"),
-  platform: z.enum(["android", "ios"]).describe("Platform")
+  platform: platformSchema
 }));
 
 export const imeActionSchema = addDeviceTargetingToSchema(z.object({
   action: z.enum(["done", "next", "search", "send", "go", "previous"]).describe("IME action"),
-  platform: z.enum(["android", "ios"]).describe("Platform")
+  platform: platformSchema
 }));
 
 export const recentAppsSchema = addDeviceTargetingToSchema(z.object({
-  platform: z.enum(["android", "ios"]).describe("Platform")
+  platform: platformSchema
 }));
 
 export const homeScreenSchema = addDeviceTargetingToSchema(z.object({
-  platform: z.enum(["android", "ios"]).describe("Platform")
+  platform: platformSchema
 }));
 
 export const rotateSchema = addDeviceTargetingToSchema(z.object({
   orientation: z.enum(["portrait", "landscape"]).describe("Orientation"),
-  platform: z.enum(["android", "ios"]).describe("Platform")
+  platform: platformSchema
 }));
 
 export const clipboardSchema = addDeviceTargetingToSchema(z.object({
   action: z.enum(["copy", "paste", "clear", "get"]).describe("Clipboard action: copy=set clipboard, paste=paste into focused field, clear=clear clipboard, get=get clipboard content"),
   text: z.string().optional().describe("Text to copy (required for 'copy' action)"),
-  platform: z.enum(["android", "ios"]).describe("Platform")
+  platform: platformSchema
 }));
 
 // ============================================================================

--- a/src/server/navigationTools.ts
+++ b/src/server/navigationTools.ts
@@ -6,16 +6,16 @@ import { NavigationGraphManager } from "../features/navigation/NavigationGraphMa
 import { Explore, ExploreOptions } from "../features/navigation/Explore";
 import { createJSONToolResponse } from "../utils/toolUtils";
 import { Platform } from "../models";
-import { addDeviceTargetingToSchema } from "./toolSchemaHelpers";
+import { addDeviceTargetingToSchema, platformSchema } from "./toolSchemaHelpers";
 
 // Schema definitions
 export const navigateToSchema = addDeviceTargetingToSchema(z.object({
   targetScreen: z.string().describe("Target screen name"),
-  platform: z.enum(["android", "ios"]).default("android")
+  platform: platformSchema.default("android")
 }));
 
 export const getNavigationGraphSchema = addDeviceTargetingToSchema(z.object({
-  platform: z.enum(["android", "ios"]).default("android")
+  platform: platformSchema.default("android")
 }));
 
 export const exploreSchema = addDeviceTargetingToSchema(z.object({
@@ -27,7 +27,7 @@ export const exploreSchema = addDeviceTargetingToSchema(z.object({
   mode: z.enum(["discover", "validate", "hybrid"]).optional().describe("Mode (default: hybrid)"),
   packageName: z.string().optional().describe("Package to limit exploration"),
   dryRun: z.boolean().optional().describe("Dry run (no interactions)"),
-  platform: z.enum(["android", "ios"]).default("android")
+  platform: platformSchema.default("android")
 }));
 
 

--- a/src/server/notificationTools.ts
+++ b/src/server/notificationTools.ts
@@ -2,7 +2,7 @@ import { z } from "zod";
 import { ToolRegistry } from "./toolRegistry";
 import { ActionableError, BootedDevice, Platform } from "../models";
 import { createJSONToolResponse } from "../utils/toolUtils";
-import { addDeviceTargetingToSchema } from "./toolSchemaHelpers";
+import { addDeviceTargetingToSchema, platformSchema } from "./toolSchemaHelpers";
 import { PostNotification, PostNotificationOptions } from "../features/utility/PostNotification";
 
 export interface PostNotificationArgs extends PostNotificationOptions {
@@ -22,7 +22,7 @@ export const postNotificationSchema = addDeviceTargetingToSchema(
     imagePath: z.string().optional().describe("Host image file path to push to /sdcard/Download/automobile when imageType is bigPicture"),
     actions: z.array(actionSchema).optional().describe("Action buttons to include"),
     channelId: z.string().optional().describe("Notification channel ID (Android only)"),
-    platform: z.enum(["android", "ios"]).describe("Platform")
+    platform: platformSchema
   })
 );
 

--- a/src/server/observeTools.ts
+++ b/src/server/observeTools.ts
@@ -9,7 +9,7 @@ import { BootedDevice, Element, ObserveResult, ViewHierarchyResult } from "../mo
 import { createGlobalPerformanceTracker } from "../utils/PerformanceTracker";
 import { NavigationGraphManager } from "../features/navigation/NavigationGraphManager";
 import { IdentifyInteractions, IdentifyInteractionsOptions } from "../features/observe/IdentifyInteractions";
-import { addDeviceTargetingToSchema } from "./toolSchemaHelpers";
+import { addDeviceTargetingToSchema, platformSchema } from "./toolSchemaHelpers";
 import { DefaultElementFinder } from "../features/utility/ElementFinder";
 import type { ElementFinder } from "../utils/interfaces/ElementFinder";
 import { defaultTimer } from "../utils/SystemTimer";
@@ -26,6 +26,7 @@ import {
   selectedElementSchema,
   systemInsetsSchema
 } from "./toolOutputSchemas";
+
 // Schema definitions
 // waitFor accepts elementId OR text directly (oneOf), plus optional timeout
 const waitForSchema = z.union([
@@ -40,7 +41,7 @@ const waitForSchema = z.union([
 ]);
 
 export const observeSchema = addDeviceTargetingToSchema(z.object({
-  platform: z.enum(["android", "ios"]).describe("Platform"),
+  platform: platformSchema,
   waitFor: waitForSchema.optional().describe("Wait for element to appear before returning observation"),
   raw: z.boolean().optional().describe("When true, include unprocessed view hierarchy in response alongside normal output (default: false)")
 }));
@@ -85,7 +86,7 @@ const observeResultSchema = z.object({
 }).passthrough();
 
 export const identifyInteractionsSchema = addDeviceTargetingToSchema(z.object({
-  platform: z.enum(["android", "ios"]).describe("Platform"),
+  platform: platformSchema,
   filter: z.object({
     types: z.array(z.enum(["navigation", "input", "action", "scroll", "toggle"]))
       .optional()

--- a/src/server/toolRegistry.ts
+++ b/src/server/toolRegistry.ts
@@ -21,6 +21,60 @@ import { getDeviceLabelMap, releaseDeviceLabelSessions } from "./deviceLabelMapp
 import { isDebugModeEnabled } from "../utils/debug";
 import { defaultTimer, type Timer } from "../utils/SystemTimer";
 
+/**
+ * The Anthropic API (and many MCP clients) reject tool input schemas that have
+ * `anyOf` or `oneOf` at the top level. Zod's `z.union()` produces exactly that.
+ * This function flattens union branches into a single `type: "object"` schema
+ * by merging all properties from every branch. Required fields are dropped because
+ * different branches require different keys.
+ *
+ * Note: `allOf` is NOT handled here — it has a different semantic (intersection)
+ * and would require a different merging strategy (all fields required, not any).
+ *
+ * Trade-off: the flattened schema loses mutual-exclusivity information, so LLMs may
+ * send invalid property combinations. The server-side Zod union still validates at
+ * runtime, but the error messages are less clear than a well-structured schema.
+ *
+ * TODO: Replace top-level z.union() usage with a discriminator field (e.g.
+ * `strategy: "text" | "id" | "clickable"`) so schemas are MCP-compliant without
+ * needing this lossy flattening step.
+ */
+export function flattenTopLevelUnion(schema: Record<string, unknown>): Record<string, unknown> {
+  const branches = (schema.anyOf ?? schema.oneOf) as Record<string, unknown>[] | undefined;
+  if (!branches || !Array.isArray(branches)) {
+    return schema;
+  }
+
+  const mergedProperties: Record<string, unknown> = {};
+  const seenAdditionalProperties = new Set<boolean | undefined>();
+
+  for (const branch of branches) {
+    const props = branch.properties as Record<string, unknown> | undefined;
+    if (props) {
+      for (const [key, value] of Object.entries(props)) {
+        if (!mergedProperties[key]) {
+          mergedProperties[key] = value;
+        }
+      }
+    }
+    if (typeof branch.additionalProperties === "boolean") {
+      seenAdditionalProperties.add(branch.additionalProperties);
+    }
+  }
+
+  const result: Record<string, unknown> = {
+    ...(schema.$schema ? { $schema: schema.$schema } : {}),
+    type: "object",
+    properties: mergedProperties,
+  };
+
+  if (seenAdditionalProperties.size === 1) {
+    result.additionalProperties = [...seenAdditionalProperties][0];
+  }
+
+  return result;
+}
+
 // Progress notification interface
 export interface ProgressCallback {
   (progress: number, total?: number, message?: string): Promise<void>;
@@ -515,7 +569,7 @@ class ToolRegistryClass {
     return this.getAllTools().map(tool => ({
       name: tool.name,
       description: tool.description,
-      inputSchema: toJSONSchema(tool.schema),
+      inputSchema: flattenTopLevelUnion(toJSONSchema(tool.schema)),
       ...(tool.outputSchema ? { outputSchema: toJSONSchema(tool.outputSchema) } : {})
     }));
   }

--- a/src/server/toolSchemaHelpers.ts
+++ b/src/server/toolSchemaHelpers.ts
@@ -1,5 +1,8 @@
 import { z } from "zod";
 
+/** Shared platform schema — single source of truth for all tool schemas. */
+export const platformSchema = z.enum(["android", "ios"]).describe("Target platform");
+
 export const DEVICE_LABEL_DESCRIPTION =
   "Device label for multi-device plans (e.g., \"A\", \"B\")";
 

--- a/src/server/utilityTools.ts
+++ b/src/server/utilityTools.ts
@@ -6,17 +6,17 @@ import { logger } from "../utils/logger";
 import { createJSONToolResponse } from "../utils/toolUtils";
 import { DeviceSessionManager } from "../utils/DeviceSessionManager";
 import { BootedDevice, Platform } from "../models";
-import { addDeviceTargetingToSchema, addSessionUuidToSchema } from "./toolSchemaHelpers";
+import { addDeviceTargetingToSchema, addSessionUuidToSchema, platformSchema } from "./toolSchemaHelpers";
 import { DaemonState } from "../daemon/daemonState";
 
 // Schema definitions
 export const setActiveDeviceSchema = addSessionUuidToSchema(z.object({
   deviceId: z.string().describe("Device ID"),
-  platform: z.enum(["android", "ios"]).describe("Platform")
+  platform: platformSchema
 }));
 
 const changeLocalizationBaseSchema = z.object({
-  platform: z.enum(["android", "ios"]).describe("Platform"),
+  platform: platformSchema,
   locale: z.string().min(1).optional().describe("Locale tag (e.g., ar-SA, ja-JP)"),
   timeZone: z.string().min(1).optional().describe("Zone ID (e.g., America/Los_Angeles)"),
   textDirection: z.enum(["ltr", "rtl"]).optional().describe("Text direction"),

--- a/src/server/videoRecordingTools.ts
+++ b/src/server/videoRecordingTools.ts
@@ -8,7 +8,7 @@ import {
   VideoQualityPreset,
 } from "../models";
 import { createJSONToolResponse } from "../utils/toolUtils";
-import { addDeviceTargetingToSchema } from "./toolSchemaHelpers";
+import { addDeviceTargetingToSchema, platformSchema } from "./toolSchemaHelpers";
 import {
   listActiveVideoRecordings,
   startVideoRecording,
@@ -59,7 +59,7 @@ const highlightSchema = z.object({
 
 const videoRecordingSchema = addDeviceTargetingToSchema(z.object({
   action: z.enum(["start", "stop"]).describe("Action to perform"),
-  platform: z.enum(["android", "ios"]).describe("Target platform"),
+  platform: platformSchema,
   deviceId: z.string().optional().describe("Optional device ID override"),
   recordingId: z.string().optional().describe("Recording ID to stop"),
   qualityPreset: z.enum(["low", "medium", "high"]).optional().describe("Recording quality preset"),

--- a/test/server/flattenTopLevelUnion.test.ts
+++ b/test/server/flattenTopLevelUnion.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, test } from "bun:test";
+import { flattenTopLevelUnion } from "../../src/server/toolRegistry";
+
+describe("flattenTopLevelUnion", () => {
+  test("returns non-union schema unchanged", () => {
+    const schema = {
+      type: "object",
+      properties: { name: { type: "string" } },
+      required: ["name"],
+    };
+    expect(flattenTopLevelUnion(schema)).toEqual(schema);
+  });
+
+  test("flattens anyOf branches into single object", () => {
+    const schema = {
+      anyOf: [
+        { type: "object", properties: { text: { type: "string" } }, required: ["text"] },
+        { type: "object", properties: { id: { type: "string" } }, required: ["id"] },
+      ],
+    };
+    const result = flattenTopLevelUnion(schema);
+    expect(result.type).toBe("object");
+    expect(result.anyOf).toBeUndefined();
+    expect((result.properties as any).text).toEqual({ type: "string" });
+    expect((result.properties as any).id).toEqual({ type: "string" });
+    expect(result.required).toBeUndefined();
+  });
+
+  test("flattens oneOf branches", () => {
+    const schema = {
+      oneOf: [
+        { type: "object", properties: { a: { type: "number" } } },
+        { type: "object", properties: { b: { type: "boolean" } } },
+      ],
+    };
+    const result = flattenTopLevelUnion(schema);
+    expect(result.type).toBe("object");
+    expect((result.properties as any).a).toEqual({ type: "number" });
+    expect((result.properties as any).b).toEqual({ type: "boolean" });
+  });
+
+  test("merges shared properties from first branch", () => {
+    const textDef = { type: "string", description: "from branch 1" };
+    const schema = {
+      anyOf: [
+        { type: "object", properties: { text: textDef, timeout: { type: "number" } } },
+        { type: "object", properties: { text: { type: "string", description: "from branch 2" }, id: { type: "string" } } },
+      ],
+    };
+    const result = flattenTopLevelUnion(schema);
+    // First-seen wins for duplicate keys
+    expect((result.properties as any).text).toEqual(textDef);
+    expect((result.properties as any).timeout).toEqual({ type: "number" });
+    expect((result.properties as any).id).toEqual({ type: "string" });
+  });
+
+  test("preserves additionalProperties when consistent across branches", () => {
+    const schema = {
+      anyOf: [
+        { type: "object", properties: {}, additionalProperties: false },
+        { type: "object", properties: {}, additionalProperties: false },
+      ],
+    };
+    const result = flattenTopLevelUnion(schema);
+    expect(result.additionalProperties).toBe(false);
+  });
+
+  test("drops additionalProperties when inconsistent across branches", () => {
+    const schema = {
+      anyOf: [
+        { type: "object", properties: {}, additionalProperties: false },
+        { type: "object", properties: {}, additionalProperties: true },
+      ],
+    };
+    const result = flattenTopLevelUnion(schema);
+    expect(result.additionalProperties).toBeUndefined();
+  });
+
+  test("preserves $schema if present", () => {
+    const schema = {
+      $schema: "https://json-schema.org/draft/2020-12/schema",
+      anyOf: [
+        { type: "object", properties: { a: { type: "string" } } },
+      ],
+    };
+    const result = flattenTopLevelUnion(schema);
+    expect(result.$schema).toBe("https://json-schema.org/draft/2020-12/schema");
+  });
+
+  test("handles empty properties in branches", () => {
+    const schema = {
+      anyOf: [
+        { type: "object" },
+        { type: "object", properties: { x: { type: "string" } } },
+      ],
+    };
+    const result = flattenTopLevelUnion(schema);
+    expect(result.type).toBe("object");
+    expect((result.properties as any).x).toEqual({ type: "string" });
+  });
+});


### PR DESCRIPTION
## Summary

Two related schema improvements:

### Centralize platform schema

Every tool file independently declared `z.enum(["android", "ios"])` for its platform field -- duplicated ~30 times across 11 files with minor description inconsistencies ("Platform" vs "Target platform"). Extracted a shared `platformSchema` in `toolSchemaHelpers.ts` and replaced every inline declaration project-wide.

### Flatten top-level Zod unions for MCP compliance

The MCP spec requires every tool's `inputSchema` to have `type: "object"` at the top level. Tools using `z.union()` produce JSON Schema with `anyOf`/`oneOf` at the top level and no `type: "object"`. The Anthropic API also rejects `anyOf`/`oneOf`/`allOf` at the top level of `input_schema`.

Added `flattenTopLevelUnion()` in `toolRegistry.ts` that detects `anyOf`/`oneOf` at the top level and merges all branches into a single `type: "object"` schema with combined properties. `required` is dropped since different branches require different keys. Applied automatically in `getToolDefinitions()`.

**Trade-off:** The flattened schema loses mutual-exclusivity info, so LLMs may send invalid property combos. Runtime Zod union validation still catches these. A TODO notes moving to discriminator fields as the longer-term fix.

## Test plan

- [ ] `bun test test/server/flattenTopLevelUnion.test.ts` passes (8 tests)
- [ ] `npx turbo run build lint` clean
- [ ] All existing tool schemas still generate valid JSON Schema
