### PR TITLE
dismissKeyboard option for inputText

### DIFF
--- a/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/CtrlProxy.kt
+++ b/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/CtrlProxy.kt
@@ -819,8 +819,8 @@ class CtrlProxy : AccessibilityService() {
                     duration,
                 )
               },
-              onRequestSetText = { requestId, text, resourceId ->
-                performSetText(requestId, text, resourceId)
+              onRequestSetText = { requestId, text, resourceId, dismissKeyboard ->
+                performSetText(requestId, text, resourceId, dismissKeyboard)
               },
               onRequestImeAction = { requestId, action -> performImeAction(requestId, action) },
               onRequestSelectAll = { requestId -> performSelectAll(requestId) },
@@ -2495,7 +2495,7 @@ class CtrlProxy : AccessibilityService() {
    * Perform text input using AccessibilityService's ACTION_SET_TEXT. This is significantly faster
    * than ADB's input text command.
    */
-  private fun performSetText(requestId: String?, text: String, resourceId: String?) {
+  private fun performSetText(requestId: String?, text: String, resourceId: String?, dismissKeyboard: Boolean = false) {
     val startTime = System.currentTimeMillis()
     Log.d(TAG, "performSetText: text='${text.take(20)}...' resourceId=$resourceId")
     perfProvider.serial("performSetText")
@@ -2547,6 +2547,22 @@ class CtrlProxy : AccessibilityService() {
       perfProvider.end()
 
       Log.d(TAG, "Set text completed: success=$success")
+
+      // Dismiss the soft keyboard if requested.
+      // When enabled (via --dismiss-keyboard-after-input or per-call dismissKeyboard param),
+      // SHOW_MODE_HIDDEN suppresses the keyboard globally for the accessibility service.
+      // This prevents the keyboard from stealing touch events and accessibility focus
+      // from UI elements behind it during subsequent tapOn steps.
+      if (success && dismissKeyboard) {
+        try {
+          softKeyboardController.setShowMode(
+              android.accessibilityservice.AccessibilityService.SHOW_MODE_HIDDEN
+          )
+          Log.d(TAG, "[KeyboardDismiss] Set SHOW_MODE_HIDDEN after text injection")
+        } catch (e: Exception) {
+          Log.w(TAG, "[KeyboardDismiss] softKeyboardController failed", e)
+        }
+      }
 
       // Trigger a hierarchy refresh after successful text input
       // This ensures the next observe will get the updated text

--- a/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/WebSocketServer.kt
+++ b/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/WebSocketServer.kt
@@ -62,6 +62,7 @@ data class LegacyWebSocketRequest(
     // Text input parameters
     val text: String? = null,
     val resourceId: String? = null, // Optional: target specific element by resource-id
+    val dismissKeyboard: Boolean = false,
     // Certificate parameters
     val certificate: String? = null,
     val alias: String? = null,
@@ -148,7 +149,7 @@ class WebSocketServer(
         ) -> Unit)? =
         null,
     private val onRequestSetText:
-        ((requestId: String?, text: String, resourceId: String?) -> Unit)? =
+        ((requestId: String?, text: String, resourceId: String?, dismissKeyboard: Boolean) -> Unit)? =
         null,
     private val onRequestImeAction: ((requestId: String?, action: String) -> Unit)? = null,
     private val onRequestSelectAll: ((requestId: String?) -> Unit)? = null,
@@ -607,7 +608,7 @@ class WebSocketServer(
           Log.d(TAG, "Received set_text request (requestId: ${request.requestId})")
           val text = request.text
           if (text != null) {
-            onRequestSetText?.invoke(request.requestId, text, request.resourceId)
+            onRequestSetText?.invoke(request.requestId, text, request.resourceId, request.dismissKeyboard)
           } else {
             Log.w(TAG, "Set text request missing required text")
           }

--- a/android/protocol/src/main/kotlin/dev/jasonpearson/automobile/protocol/WebSocketRequest.kt
+++ b/android/protocol/src/main/kotlin/dev/jasonpearson/automobile/protocol/WebSocketRequest.kt
@@ -125,6 +125,7 @@ data class RequestSetText(
   override val requestId: String? = null,
   val text: String,
   val resourceId: String? = null,
+  val dismissKeyboard: Boolean = false,
 ) : WebSocketRequest()
 
 @Serializable

--- a/src/features/action/InputText.ts
+++ b/src/features/action/InputText.ts
@@ -15,7 +15,8 @@ export class InputText extends BaseVisualChange {
 
   async execute(
     text: string,
-    imeAction?: "done" | "next" | "search" | "send" | "go" | "previous"
+    imeAction?: "done" | "next" | "search" | "send" | "go" | "previous",
+    dismissKeyboard: boolean = false
   ): Promise<SendTextResult & { method?: "a11y" }> {
     const perf = createGlobalPerformanceTracker();
     perf.serial("inputText");
@@ -38,9 +39,11 @@ export class InputText extends BaseVisualChange {
           switch (this.device.platform) {
             case "android":
               return await perf.track("androidTextInput", () =>
-                this.executeAndroidTextInput(text, imeAction)
+                this.executeAndroidTextInput(text, imeAction, dismissKeyboard)
               );
             case "ios":
+              // dismissKeyboard is Android-only — it works around an emulator
+              // bug where the soft keyboard stays visible after setText.
               return await perf.track("iOSTextInput", () =>
                 this.executeiOSTextInput(text, imeAction)
               );
@@ -78,12 +81,13 @@ export class InputText extends BaseVisualChange {
    */
   private async executeAndroidTextInput(
     text: string,
-    imeAction?: "done" | "next" | "search" | "send" | "go" | "previous"
+    imeAction?: "done" | "next" | "search" | "send" | "go" | "previous",
+    dismissKeyboard: boolean = false
   ): Promise<SendTextResult & { method?: "a11y" }> {
     // Use accessibility service exclusively (fastest method, ~10-30ms vs ~200-300ms for ADB)
     // It also natively supports Unicode without needing virtual keyboard
     const a11yClient = AndroidCtrlProxyClient.getInstance(this.device, this.adb);
-    const a11yResult = await a11yClient.requestSetText(text);
+    const a11yResult = await a11yClient.requestSetText(text, undefined, undefined, undefined, dismissKeyboard);
 
     if (a11yResult.success) {
       logger.info(`[InputText] Text input via accessibility service: ${a11yResult.totalTimeMs}ms`);

--- a/src/features/observe/DeviceService.ts
+++ b/src/features/observe/DeviceService.ts
@@ -200,7 +200,8 @@ export interface DeviceService {
     text: string,
     resourceId?: string,
     timeoutMs?: number,
-    perf?: PerformanceTracker
+    perf?: PerformanceTracker,
+    dismissKeyboard?: boolean
   ): Promise<TextResult>;
 
   /**

--- a/src/features/observe/android/CtrlProxyClient.ts
+++ b/src/features/observe/android/CtrlProxyClient.ts
@@ -256,7 +256,7 @@ export interface CtrlProxy {
   ): Promise<A11yPinchResult>;
 
   requestSetText(
-    text: string, resourceId?: string, timeoutMs?: number, perf?: PerformanceTracker
+    text: string, resourceId?: string, timeoutMs?: number, perf?: PerformanceTracker, dismissKeyboard?: boolean
   ): Promise<A11ySetTextResult>;
 
   requestClearText(
@@ -714,9 +714,9 @@ export class CtrlProxyClient extends DeviceServiceClient implements CtrlProxy {
   // ===========================================================================
 
   async requestSetText(
-    text: string, resourceId?: string, timeoutMs: number = 5000, perf: PerformanceTracker = new NoOpPerformanceTracker()
+    text: string, resourceId?: string, timeoutMs: number = 5000, perf: PerformanceTracker = new NoOpPerformanceTracker(), dismissKeyboard: boolean = false
   ): Promise<A11ySetTextResult> {
-    return this.text.requestSetText(text, resourceId, timeoutMs, perf);
+    return this.text.requestSetText(text, resourceId, timeoutMs, perf, dismissKeyboard);
   }
 
   async requestClearText(

--- a/src/features/observe/ios/CtrlProxyClient.ts
+++ b/src/features/observe/ios/CtrlProxyClient.ts
@@ -160,7 +160,7 @@ export interface CtrlProxyService {
   ): Promise<CtrlProxyPinchResult>;
 
   requestSetText(
-    text: string, resourceId?: string, timeoutMs?: number, perf?: PerformanceTracker
+    text: string, resourceId?: string, timeoutMs?: number, perf?: PerformanceTracker, dismissKeyboard?: boolean
   ): Promise<CtrlProxySetTextResult>;
 
   requestClearText(
@@ -847,9 +847,9 @@ export class CtrlProxyClient extends DeviceServiceClient implements CtrlProxySer
   // ===========================================================================
 
   async requestSetText(
-    text: string, resourceId?: string, timeoutMs: number = 5000, perf?: PerformanceTracker
+    text: string, resourceId?: string, timeoutMs: number = 5000, perf?: PerformanceTracker, dismissKeyboard: boolean = false
   ): Promise<CtrlProxySetTextResult> {
-    return this.text.requestSetText(text, resourceId, timeoutMs, perf);
+    return this.text.requestSetText(text, resourceId, timeoutMs, perf, dismissKeyboard);
   }
 
   async requestClearText(

--- a/src/features/observe/shared/SharedTextDelegate.ts
+++ b/src/features/observe/shared/SharedTextDelegate.ts
@@ -15,11 +15,16 @@ export class SharedTextDelegate {
     this.context = context;
   }
 
+  /**
+   * @param dismissKeyboard Android-only. Suppresses the soft keyboard via
+   *   SHOW_MODE_HIDDEN after setText. Ignored on iOS (no handler on Swift side).
+   */
   async requestSetText(
     text: string,
     resourceId?: string,
     timeoutMs: number = 5000,
-    perf?: PerformanceTracker
+    perf?: PerformanceTracker,
+    dismissKeyboard: boolean = false
   ): Promise<BaseResult> {
     this.context.cancelScreenshotBackoff();
 
@@ -42,6 +47,9 @@ export class SharedTextDelegate {
     const params: Record<string, unknown> = { text };
     if (resourceId) {
       params.resourceId = resourceId;
+    }
+    if (dismissKeyboard) {
+      params.dismissKeyboard = true;
     }
 
     const msg = createMessage("request_set_text", requestId, params);

--- a/src/server/interactionToolTypes.ts
+++ b/src/server/interactionToolTypes.ts
@@ -43,6 +43,7 @@ export interface PressKeyArgs {
 export interface InputTextArgs {
   text: string;
   imeAction?: "done" | "next" | "search" | "send" | "go" | "previous";
+  dismissKeyboard?: boolean;
   platform: Platform;
 }
 

--- a/src/server/interactionTools.ts
+++ b/src/server/interactionTools.ts
@@ -25,6 +25,7 @@ import { createJSONToolResponse, createStructuredToolResponse } from "../utils/t
 import { resolveSwipeDirection } from "../utils/swipeOnUtils";
 import { RecompositionTracker } from "../features/performance/RecompositionTracker";
 import { addDeviceTargetingToSchema } from "./toolSchemaHelpers";
+import { serverConfig } from "../utils/ServerConfig";
 import {
   createElementIdTextSelectorSchema,
   elementContainerSchema,
@@ -334,9 +335,11 @@ export const clearStateSchema = addDeviceTargetingToSchema(z.object({
 }));
 
 export const inputTextSchema = addDeviceTargetingToSchema(z.object({
-  text: z.string().describe("Text to input"),
+  text: z.string().min(1).describe("Text to input"),
   imeAction: z.enum(["done", "next", "search", "send", "go", "previous"]).optional()
     .describe("IME action after input"),
+  dismissKeyboard: z.boolean().optional()
+    .describe("(Android only) Dismiss soft keyboard after input. Overrides server-level --dismiss-keyboard-after-input flag. Ignored on iOS."),
   platform: z.enum(["android", "ios"]).describe("Platform")
 }));
 
@@ -724,8 +727,9 @@ export function registerInteractionTools() {
   // Input text handler
   const inputTextHandler = async (device: BootedDevice, args: InputTextArgs) => {
     RecompositionTracker.getInstance().recordInteraction();
+    const dismissKeyboard = args.dismissKeyboard ?? serverConfig.isDismissKeyboardAfterInputEnabled();
     const inputText = new InputText(device);
-    const result = await inputText.execute(args.text, args.imeAction);
+    const result = await inputText.execute(args.text, args.imeAction, dismissKeyboard);
     return createJSONToolResponse({
       message: `Input text`,
       observation: result.observation,


### PR DESCRIPTION
## Summary

End-to-end feature: the Android accessibility service can now hide the soft keyboard after `inputText`. Prevents the keyboard from blocking subsequent taps and avoids issues with stylus emulators switching GBoard to full-screen handwriting mode.

New `dismissKeyboard` boolean param on `inputText`:
- Per-call override, or falls back to the server-level `--dismiss-keyboard-after-input` flag
- Android only (ignored on iOS)
- Uses `softKeyboardController.setShowMode(SHOW_MODE_HIDDEN)` via the a11y service

Plumbed through the full stack: MCP schema -> interactionTools handler -> InputText -> SharedTextDelegate -> CtrlProxy WebSocket -> Android CtrlProxy service.

## Test plan

- [ ] `npx turbo run build lint` clean
- [ ] Manual: inputText with `dismissKeyboard: true` hides keyboard on Android emulator
- [ ] Manual: inputText without flag preserves existing behavior
