### PR TITLE
feat: add iOS privacy manifest for App Store compliance

### DIFF
--- a/ios/auto-mobile-sdk/Package.swift
+++ b/ios/auto-mobile-sdk/Package.swift
@@ -16,7 +16,8 @@ let package = Package(
     targets: [
         .target(
             name: "AutoMobileSDK",
-            path: "Sources/AutoMobileSDK"
+            path: "Sources/AutoMobileSDK",
+            resources: [.process("PrivacyInfo.xcprivacy")]
         ),
         .testTarget(
             name: "AutoMobileSDKTests",

--- a/ios/auto-mobile-sdk/Sources/AutoMobileSDK/PrivacyInfo.xcprivacy
+++ b/ios/auto-mobile-sdk/Sources/AutoMobileSDK/PrivacyInfo.xcprivacy
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyTracking</key>
+	<false/>
+	<key>NSPrivacyTrackingDomains</key>
+	<array/>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyCollectedDataType</key>
+			<string>NSPrivacyCollectedDataTypeCrashData</string>
+			<key>NSPrivacyCollectedDataTypeLinked</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypeTracking</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypePurposes</key>
+			<array>
+				<string>NSPrivacyCollectedDataTypePurposeAppFunctionality</string>
+			</array>
+		</dict>
+		<dict>
+			<key>NSPrivacyCollectedDataType</key>
+			<string>NSPrivacyCollectedDataTypePerformanceData</string>
+			<key>NSPrivacyCollectedDataTypeLinked</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypeTracking</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypePurposes</key>
+			<array>
+				<string>NSPrivacyCollectedDataTypePurposeAppFunctionality</string>
+			</array>
+		</dict>
+	</array>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategoryUserDefaults</string>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>CA92.1</string>
+			</array>
+		</dict>
+		<dict>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategoryFileTimestamp</string>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>C617.1</string>
+			</array>
+		</dict>
+	</array>
+</dict>
+</plist>

--- a/schemas/tool-definitions.json
+++ b/schemas/tool-definitions.json
@@ -73,7 +73,7 @@
             "android",
             "ios"
           ],
-          "description": "Platform"
+          "description": "Target platform"
         },
         "locale": {
           "description": "Locale tag (e.g., ar-SA, ja-JP)",
@@ -142,7 +142,7 @@
             "android",
             "ios"
           ],
-          "description": "Platform"
+          "description": "Target platform"
         },
         "sessionUuid": {
           "description": "Session UUID for device targeting",
@@ -194,7 +194,7 @@
             "android",
             "ios"
           ],
-          "description": "Platform"
+          "description": "Target platform"
         },
         "sessionUuid": {
           "description": "Session UUID for device targeting",
@@ -483,7 +483,7 @@
             "android",
             "ios"
           ],
-          "description": "Platform"
+          "description": "Target platform"
         },
         "sessionUuid": {
           "description": "Session UUID for device targeting",
@@ -1526,7 +1526,7 @@
             "android",
             "ios"
           ],
-          "description": "Platform"
+          "description": "Target platform"
         },
         "sessionUuid": {
           "description": "Session UUID for device targeting",
@@ -1576,7 +1576,7 @@
             "android",
             "ios"
           ],
-          "description": "Platform"
+          "description": "Target platform"
         },
         "sessionUuid": {
           "description": "Session UUID for device targeting",
@@ -1636,7 +1636,7 @@
             "android",
             "ios"
           ],
-          "description": "Platform"
+          "description": "Target platform"
         },
         "sessionUuid": {
           "description": "Session UUID for device targeting",
@@ -1718,7 +1718,7 @@
             "android",
             "ios"
           ],
-          "description": "Platform"
+          "description": "Target platform"
         },
         "sessionUuid": {
           "description": "Session UUID for device targeting",
@@ -1768,7 +1768,7 @@
                 "android",
                 "ios"
               ],
-              "description": "Platform"
+              "description": "Target platform"
             }
           },
           "required": [
@@ -1850,7 +1850,7 @@
             "android",
             "ios"
           ],
-          "description": "Platform"
+          "description": "Target platform"
         }
       },
       "required": [
@@ -1867,12 +1867,12 @@
       "type": "object",
       "properties": {
         "platform": {
-          "description": "Platform",
           "type": "string",
           "enum": [
             "android",
             "ios"
-          ]
+          ],
+          "description": "Target platform"
         }
       },
       "additionalProperties": false
@@ -1891,7 +1891,7 @@
             "android",
             "ios"
           ],
-          "description": "Platform"
+          "description": "Target platform"
         },
         "waitFor": {
           "description": "Wait for element to appear before returning observation",
@@ -3615,7 +3615,7 @@
             "android",
             "ios"
           ],
-          "description": "Platform"
+          "description": "Target platform"
         },
         "sessionUuid": {
           "description": "Session UUID for device targeting",
@@ -3721,7 +3721,7 @@
             "android",
             "ios"
           ],
-          "description": "Platform"
+          "description": "Target platform"
         },
         "sessionUuid": {
           "description": "Session UUID for device targeting",
@@ -3810,7 +3810,7 @@
             "android",
             "ios"
           ],
-          "description": "Platform"
+          "description": "Target platform"
         },
         "sessionUuid": {
           "description": "Session UUID for device targeting",
@@ -3863,7 +3863,7 @@
             "android",
             "ios"
           ],
-          "description": "Platform"
+          "description": "Target platform"
         },
         "sessionUuid": {
           "description": "Session UUID for device targeting",
@@ -3915,7 +3915,7 @@
             "android",
             "ios"
           ],
-          "description": "Platform"
+          "description": "Target platform"
         },
         "sessionUuid": {
           "description": "Session UUID for device targeting",
@@ -3954,7 +3954,7 @@
             "android",
             "ios"
           ],
-          "description": "Platform"
+          "description": "Target platform"
         },
         "sessionUuid": {
           "description": "Session UUID for device targeting",
@@ -4000,7 +4000,7 @@
             "android",
             "ios"
           ],
-          "description": "Platform"
+          "description": "Target platform"
         },
         "sessionUuid": {
           "description": "Session UUID for device targeting",
@@ -4039,7 +4039,7 @@
             "android",
             "ios"
           ],
-          "description": "Platform"
+          "description": "Target platform"
         },
         "sessionUuid": {
           "description": "Session UUID for device targeting",
@@ -4081,7 +4081,7 @@
             "android",
             "ios"
           ],
-          "description": "Platform"
+          "description": "Target platform"
         },
         "sessionUuid": {
           "description": "Session UUID for device targeting",
@@ -4120,7 +4120,7 @@
             "android",
             "ios"
           ],
-          "description": "Platform"
+          "description": "Target platform"
         },
         "sessionUuid": {
           "description": "Session UUID for device targeting",
@@ -4165,7 +4165,7 @@
                 "android",
                 "ios"
               ],
-              "description": "Platform"
+              "description": "Target platform"
             },
             "deviceId": {
               "description": "Device ID",
@@ -4362,7 +4362,7 @@
             "android",
             "ios"
           ],
-          "description": "Platform"
+          "description": "Target platform"
         },
         "sessionUuid": {
           "description": "Session UUID for device targeting",
@@ -5284,7 +5284,7 @@
             "android",
             "ios"
           ],
-          "description": "Platform"
+          "description": "Target platform"
         },
         "sessionUuid": {
           "description": "Session UUID for device targeting",
@@ -5389,7 +5389,7 @@
             "android",
             "ios"
           ],
-          "description": "Platform"
+          "description": "Target platform"
         },
         "elementId": {
           "type": "string",


### PR DESCRIPTION
## Summary
- Add `PrivacyInfo.xcprivacy` to AutoMobileSDK declaring diagnostic data collection (crash reports, performance data) not linked to user identity and not used for tracking
- Declare accessed API categories: UserDefaults (CA92.1) and file timestamps (C617.1)
- Update `Package.swift` to bundle the privacy manifest as a processed resource

## Test plan
- [x] `swift build` passes with privacy manifest bundled as resource
- [x] All 65 existing unit tests pass (`swift test`)
- [x] Privacy manifest XML validates against Apple's plist schema

🤖 Generated with [Claude Code](https://claude.com/claude-code)