### PR TITLE
fix: gate debug-only iOS SDK features behind #if DEBUG

### DIFF
--- a/ios/auto-mobile-sdk/Sources/AutoMobileSDK/Events/SdkEventBroadcaster.swift
+++ b/ios/auto-mobile-sdk/Sources/AutoMobileSDK/Events/SdkEventBroadcaster.swift
@@ -29,18 +29,27 @@ public final class SdkEventBroadcaster: EventBroadcasting, @unchecked Sendable {
         config.waitsForConnectivity = false
         self.urlSession = URLSession(configuration: config)
 
-        // Default CtrlProxy port
+        #if DEBUG
+        // Default CtrlProxy port — only in debug builds
         self.ctrlProxyUrl = URL(string: "http://localhost:8765/sdk-events")
+        #else
+        self.ctrlProxyUrl = nil
+        #endif
     }
 
     /// Configure the CtrlProxy endpoint URL. Pass nil to disable HTTP forwarding.
+    /// No-op in release builds.
     public func setCtrlProxyUrl(_ url: URL?) {
+        #if DEBUG
         self.ctrlProxyUrl = url
+        #endif
     }
 
     public func broadcastBatch(bundleId: String?, events: [any SdkEvent]) {
         guard !events.isEmpty else { return }
+        #if DEBUG
         NSLog("[AutoMobileSDK] broadcastBatch called with \(events.count) events, ctrlProxyUrl=\(ctrlProxyUrl?.absoluteString ?? "nil")")
+        #endif
 
         let envelopes = events.compactMap { event -> SdkEventEnvelope? in
             try? SdkEventEnvelope(event)
@@ -61,6 +70,7 @@ public final class SdkEventBroadcaster: EventBroadcasting, @unchecked Sendable {
             userInfo: [Self.eventBatchUserInfoKey: data]
         )
 
+        #if DEBUG
         // HTTP POST to CtrlProxy for cross-process telemetry forwarding
         if let url = ctrlProxyUrl {
             var request = URLRequest(url: url)
@@ -76,5 +86,6 @@ public final class SdkEventBroadcaster: EventBroadcasting, @unchecked Sendable {
                 }
             }.resume()
         }
+        #endif
     }
 }

--- a/ios/auto-mobile-sdk/Sources/AutoMobileSDK/Network/AutoMobileNetwork.swift
+++ b/ios/auto-mobile-sdk/Sources/AutoMobileSDK/Network/AutoMobileNetwork.swift
@@ -49,10 +49,14 @@ public final class AutoMobileNetwork: @unchecked Sendable {
     }
 
     /// Configure whether to capture request/response bodies.
+    /// In release builds, body capture is always disabled to prevent leaking
+    /// auth tokens, credentials, or PII.
     public func setCaptureBodies(_ capture: Bool) {
+        #if DEBUG
         lock.lock()
         _captureBodies = capture
         lock.unlock()
+        #endif
     }
 
     /// Configure maximum body bytes to capture (default: 32KB).

--- a/ios/auto-mobile-sdk/Sources/AutoMobileSDK/Storage/UserDefaultsInspector.swift
+++ b/ios/auto-mobile-sdk/Sources/AutoMobileSDK/Storage/UserDefaultsInspector.swift
@@ -245,20 +245,26 @@ final class DefaultUserDefaultsDriver: UserDefaultsDriver, @unchecked Sendable {
     }
 
     func setValue(suiteName: String?, key: String, value: Any?, type: KeyValueType) {
+        #if DEBUG
         guard let defaults = resolveDefaults(suiteName: suiteName) else { return }
         defaults.set(value, forKey: key)
+        #endif
     }
 
     func removeValue(suiteName: String?, key: String) {
+        #if DEBUG
         guard let defaults = resolveDefaults(suiteName: suiteName) else { return }
         defaults.removeObject(forKey: key)
+        #endif
     }
 
     func clear(suiteName: String?) {
+        #if DEBUG
         guard let defaults = resolveDefaults(suiteName: suiteName) else { return }
         for key in defaults.dictionaryRepresentation().keys {
             defaults.removeObject(forKey: key)
         }
+        #endif
     }
 
     private func typeOf(_ value: Any) -> KeyValueType {

--- a/schemas/tool-definitions.json
+++ b/schemas/tool-definitions.json
@@ -73,7 +73,7 @@
             "android",
             "ios"
           ],
-          "description": "Platform"
+          "description": "Target platform"
         },
         "locale": {
           "description": "Locale tag (e.g., ar-SA, ja-JP)",
@@ -142,7 +142,7 @@
             "android",
             "ios"
           ],
-          "description": "Platform"
+          "description": "Target platform"
         },
         "sessionUuid": {
           "description": "Session UUID for device targeting",
@@ -194,7 +194,7 @@
             "android",
             "ios"
           ],
-          "description": "Platform"
+          "description": "Target platform"
         },
         "sessionUuid": {
           "description": "Session UUID for device targeting",
@@ -483,7 +483,7 @@
             "android",
             "ios"
           ],
-          "description": "Platform"
+          "description": "Target platform"
         },
         "sessionUuid": {
           "description": "Session UUID for device targeting",
@@ -1526,7 +1526,7 @@
             "android",
             "ios"
           ],
-          "description": "Platform"
+          "description": "Target platform"
         },
         "sessionUuid": {
           "description": "Session UUID for device targeting",
@@ -1576,7 +1576,7 @@
             "android",
             "ios"
           ],
-          "description": "Platform"
+          "description": "Target platform"
         },
         "sessionUuid": {
           "description": "Session UUID for device targeting",
@@ -1636,7 +1636,7 @@
             "android",
             "ios"
           ],
-          "description": "Platform"
+          "description": "Target platform"
         },
         "sessionUuid": {
           "description": "Session UUID for device targeting",
@@ -1718,7 +1718,7 @@
             "android",
             "ios"
           ],
-          "description": "Platform"
+          "description": "Target platform"
         },
         "sessionUuid": {
           "description": "Session UUID for device targeting",
@@ -1768,7 +1768,7 @@
                 "android",
                 "ios"
               ],
-              "description": "Platform"
+              "description": "Target platform"
             }
           },
           "required": [
@@ -1850,7 +1850,7 @@
             "android",
             "ios"
           ],
-          "description": "Platform"
+          "description": "Target platform"
         }
       },
       "required": [
@@ -1867,12 +1867,12 @@
       "type": "object",
       "properties": {
         "platform": {
-          "description": "Platform",
           "type": "string",
           "enum": [
             "android",
             "ios"
-          ]
+          ],
+          "description": "Target platform"
         }
       },
       "additionalProperties": false
@@ -1891,7 +1891,7 @@
             "android",
             "ios"
           ],
-          "description": "Platform"
+          "description": "Target platform"
         },
         "waitFor": {
           "description": "Wait for element to appear before returning observation",
@@ -3615,7 +3615,7 @@
             "android",
             "ios"
           ],
-          "description": "Platform"
+          "description": "Target platform"
         },
         "sessionUuid": {
           "description": "Session UUID for device targeting",
@@ -3721,7 +3721,7 @@
             "android",
             "ios"
           ],
-          "description": "Platform"
+          "description": "Target platform"
         },
         "sessionUuid": {
           "description": "Session UUID for device targeting",
@@ -3810,7 +3810,7 @@
             "android",
             "ios"
           ],
-          "description": "Platform"
+          "description": "Target platform"
         },
         "sessionUuid": {
           "description": "Session UUID for device targeting",
@@ -3863,7 +3863,7 @@
             "android",
             "ios"
           ],
-          "description": "Platform"
+          "description": "Target platform"
         },
         "sessionUuid": {
           "description": "Session UUID for device targeting",
@@ -3915,7 +3915,7 @@
             "android",
             "ios"
           ],
-          "description": "Platform"
+          "description": "Target platform"
         },
         "sessionUuid": {
           "description": "Session UUID for device targeting",
@@ -3954,7 +3954,7 @@
             "android",
             "ios"
           ],
-          "description": "Platform"
+          "description": "Target platform"
         },
         "sessionUuid": {
           "description": "Session UUID for device targeting",
@@ -4000,7 +4000,7 @@
             "android",
             "ios"
           ],
-          "description": "Platform"
+          "description": "Target platform"
         },
         "sessionUuid": {
           "description": "Session UUID for device targeting",
@@ -4039,7 +4039,7 @@
             "android",
             "ios"
           ],
-          "description": "Platform"
+          "description": "Target platform"
         },
         "sessionUuid": {
           "description": "Session UUID for device targeting",
@@ -4081,7 +4081,7 @@
             "android",
             "ios"
           ],
-          "description": "Platform"
+          "description": "Target platform"
         },
         "sessionUuid": {
           "description": "Session UUID for device targeting",
@@ -4120,7 +4120,7 @@
             "android",
             "ios"
           ],
-          "description": "Platform"
+          "description": "Target platform"
         },
         "sessionUuid": {
           "description": "Session UUID for device targeting",
@@ -4165,7 +4165,7 @@
                 "android",
                 "ios"
               ],
-              "description": "Platform"
+              "description": "Target platform"
             },
             "deviceId": {
               "description": "Device ID",
@@ -4362,7 +4362,7 @@
             "android",
             "ios"
           ],
-          "description": "Platform"
+          "description": "Target platform"
         },
         "sessionUuid": {
           "description": "Session UUID for device targeting",
@@ -5284,7 +5284,7 @@
             "android",
             "ios"
           ],
-          "description": "Platform"
+          "description": "Target platform"
         },
         "sessionUuid": {
           "description": "Session UUID for device targeting",
@@ -5389,7 +5389,7 @@
             "android",
             "ios"
           ],
-          "description": "Platform"
+          "description": "Target platform"
         },
         "elementId": {
           "type": "string",


### PR DESCRIPTION
## Summary
- **SdkEventBroadcaster**: Wrapped HTTP POST to localhost:8765 CtrlProxy, ctrlProxyUrl initialization, setCtrlProxyUrl, and all NSLog calls in `#if DEBUG` guards. In release builds the URL is nil and the setter is a no-op.
- **AutoMobileNetwork**: Made `setCaptureBodies()` a no-op in release builds to prevent capturing auth tokens, credentials, or PII in HTTP request/response bodies.
- **UserDefaultsInspector**: Gated `setValue`, `removeValue`, and `clear` in `DefaultUserDefaultsDriver` behind `#if DEBUG` to prevent modifying app state in production.

## Test plan
- [x] `swift build` succeeds
- [x] `swift test` passes (65 tests, 0 failures)
- [ ] Verify release build strips debug-only code paths (compiler enforced by `#if DEBUG`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)