### PR TITLE
fix: replace blanket ProGuard keep rule with targeted consumer rules

### DIFF
--- a/android/auto-mobile-sdk/consumer-rules.pro
+++ b/android/auto-mobile-sdk/consumer-rules.pro
@@ -1,3 +1,41 @@
-# AutoMobile SDK ProGuard Rules
-# Keep all public API classes and methods
--keep public class dev.jasonpearson.automobile.sdk.** { public *; }
+# AutoMobile SDK Consumer ProGuard Rules
+
+# Preserve source file names and line numbers for readable crash reports
+-keepattributes SourceFile,LineNumberTable
+
+# Keep public API entry points
+-keep public class dev.jasonpearson.automobile.sdk.AutoMobileSDK { public *; }
+-keep public class dev.jasonpearson.automobile.sdk.NavigationEvent { *; }
+-keep public class dev.jasonpearson.automobile.sdk.NavigationListener { *; }
+-keep public class dev.jasonpearson.automobile.sdk.NavigationSource { *; }
+
+# Keep crash/failure/ANR public APIs
+-keep public class dev.jasonpearson.automobile.sdk.crashes.AutoMobileCrashes { public *; }
+-keep public class dev.jasonpearson.automobile.sdk.failures.AutoMobileFailures { public *; }
+-keep public class dev.jasonpearson.automobile.sdk.failures.HandledExceptionEvent { *; }
+-keep public class dev.jasonpearson.automobile.sdk.failures.DeviceInfo { *; }
+-keep public class dev.jasonpearson.automobile.sdk.anr.AutoMobileAnr { public *; }
+
+# Keep navigation framework adapters (used via Compose)
+-keep public class dev.jasonpearson.automobile.sdk.adapters.** { public *; }
+
+# Keep public interfaces (NavigationListener, etc.)
+-keep public interface dev.jasonpearson.automobile.sdk.** { *; }
+
+# Keep network interception (consumers may reference interceptor/listener)
+-keep public class dev.jasonpearson.automobile.sdk.network.** { public *; }
+
+# Keep interaction tracking
+-keep public class dev.jasonpearson.automobile.sdk.interaction.** { public *; }
+
+# Keep protocol serialization classes (kotlinx.serialization requires these)
+-keepclassmembers class dev.jasonpearson.automobile.protocol.** {
+    *;
+}
+
+# Keep Kotlin serialization infrastructure
+-keepattributes *Annotation*
+-keep class kotlinx.serialization.** { *; }
+-keepclassmembers class * {
+    @kotlinx.serialization.Serializable <fields>;
+}

--- a/schemas/tool-definitions.json
+++ b/schemas/tool-definitions.json
@@ -73,7 +73,7 @@
             "android",
             "ios"
           ],
-          "description": "Platform"
+          "description": "Target platform"
         },
         "locale": {
           "description": "Locale tag (e.g., ar-SA, ja-JP)",
@@ -142,7 +142,7 @@
             "android",
             "ios"
           ],
-          "description": "Platform"
+          "description": "Target platform"
         },
         "sessionUuid": {
           "description": "Session UUID for device targeting",
@@ -194,7 +194,7 @@
             "android",
             "ios"
           ],
-          "description": "Platform"
+          "description": "Target platform"
         },
         "sessionUuid": {
           "description": "Session UUID for device targeting",
@@ -483,7 +483,7 @@
             "android",
             "ios"
           ],
-          "description": "Platform"
+          "description": "Target platform"
         },
         "sessionUuid": {
           "description": "Session UUID for device targeting",
@@ -1526,7 +1526,7 @@
             "android",
             "ios"
           ],
-          "description": "Platform"
+          "description": "Target platform"
         },
         "sessionUuid": {
           "description": "Session UUID for device targeting",
@@ -1576,7 +1576,7 @@
             "android",
             "ios"
           ],
-          "description": "Platform"
+          "description": "Target platform"
         },
         "sessionUuid": {
           "description": "Session UUID for device targeting",
@@ -1636,7 +1636,7 @@
             "android",
             "ios"
           ],
-          "description": "Platform"
+          "description": "Target platform"
         },
         "sessionUuid": {
           "description": "Session UUID for device targeting",
@@ -1718,7 +1718,7 @@
             "android",
             "ios"
           ],
-          "description": "Platform"
+          "description": "Target platform"
         },
         "sessionUuid": {
           "description": "Session UUID for device targeting",
@@ -1768,7 +1768,7 @@
                 "android",
                 "ios"
               ],
-              "description": "Platform"
+              "description": "Target platform"
             }
           },
           "required": [
@@ -1850,7 +1850,7 @@
             "android",
             "ios"
           ],
-          "description": "Platform"
+          "description": "Target platform"
         }
       },
       "required": [
@@ -1867,12 +1867,12 @@
       "type": "object",
       "properties": {
         "platform": {
-          "description": "Platform",
           "type": "string",
           "enum": [
             "android",
             "ios"
-          ]
+          ],
+          "description": "Target platform"
         }
       },
       "additionalProperties": false
@@ -1891,7 +1891,7 @@
             "android",
             "ios"
           ],
-          "description": "Platform"
+          "description": "Target platform"
         },
         "waitFor": {
           "description": "Wait for element to appear before returning observation",
@@ -3615,7 +3615,7 @@
             "android",
             "ios"
           ],
-          "description": "Platform"
+          "description": "Target platform"
         },
         "sessionUuid": {
           "description": "Session UUID for device targeting",
@@ -3721,7 +3721,7 @@
             "android",
             "ios"
           ],
-          "description": "Platform"
+          "description": "Target platform"
         },
         "sessionUuid": {
           "description": "Session UUID for device targeting",
@@ -3810,7 +3810,7 @@
             "android",
             "ios"
           ],
-          "description": "Platform"
+          "description": "Target platform"
         },
         "sessionUuid": {
           "description": "Session UUID for device targeting",
@@ -3863,7 +3863,7 @@
             "android",
             "ios"
           ],
-          "description": "Platform"
+          "description": "Target platform"
         },
         "sessionUuid": {
           "description": "Session UUID for device targeting",
@@ -3915,7 +3915,7 @@
             "android",
             "ios"
           ],
-          "description": "Platform"
+          "description": "Target platform"
         },
         "sessionUuid": {
           "description": "Session UUID for device targeting",
@@ -3954,7 +3954,7 @@
             "android",
             "ios"
           ],
-          "description": "Platform"
+          "description": "Target platform"
         },
         "sessionUuid": {
           "description": "Session UUID for device targeting",
@@ -4000,7 +4000,7 @@
             "android",
             "ios"
           ],
-          "description": "Platform"
+          "description": "Target platform"
         },
         "sessionUuid": {
           "description": "Session UUID for device targeting",
@@ -4039,7 +4039,7 @@
             "android",
             "ios"
           ],
-          "description": "Platform"
+          "description": "Target platform"
         },
         "sessionUuid": {
           "description": "Session UUID for device targeting",
@@ -4081,7 +4081,7 @@
             "android",
             "ios"
           ],
-          "description": "Platform"
+          "description": "Target platform"
         },
         "sessionUuid": {
           "description": "Session UUID for device targeting",
@@ -4120,7 +4120,7 @@
             "android",
             "ios"
           ],
-          "description": "Platform"
+          "description": "Target platform"
         },
         "sessionUuid": {
           "description": "Session UUID for device targeting",
@@ -4165,7 +4165,7 @@
                 "android",
                 "ios"
               ],
-              "description": "Platform"
+              "description": "Target platform"
             },
             "deviceId": {
               "description": "Device ID",
@@ -4362,7 +4362,7 @@
             "android",
             "ios"
           ],
-          "description": "Platform"
+          "description": "Target platform"
         },
         "sessionUuid": {
           "description": "Session UUID for device targeting",
@@ -5284,7 +5284,7 @@
             "android",
             "ios"
           ],
-          "description": "Platform"
+          "description": "Target platform"
         },
         "sessionUuid": {
           "description": "Session UUID for device targeting",
@@ -5389,7 +5389,7 @@
             "android",
             "ios"
           ],
-          "description": "Platform"
+          "description": "Target platform"
         },
         "elementId": {
           "type": "string",


### PR DESCRIPTION
## Summary
- Replace the blanket `-keep public class dev.jasonpearson.automobile.sdk.** { public *; }` rule with targeted rules that only preserve the public API surface
- Add `-keepattributes SourceFile,LineNumberTable` for readable crash stack traces
- Add kotlinx.serialization infrastructure rules for the protocol module
- Internal SDK classes (database, events, logging, storage, os, testing) are now eligible for R8 optimization

## Test plan
- [x] `./gradlew -p android :auto-mobile-sdk:assembleRelease` passes
- [x] `./gradlew -p android :auto-mobile-sdk:test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)