### PR TITLE
fix: replace CopyOnWriteArrayList with synchronized ArrayDeque in AutoMobileFailures

### DIFF
--- a/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/failures/AutoMobileFailures.kt
+++ b/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/failures/AutoMobileFailures.kt
@@ -10,7 +10,6 @@ import dev.jasonpearson.automobile.protocol.SdkEventSerializer
 import dev.jasonpearson.automobile.protocol.SdkHandledExceptionEvent
 import java.io.PrintWriter
 import java.io.StringWriter
-import java.util.concurrent.CopyOnWriteArrayList
 
 /**
  * SDK API for reporting handled (non-fatal) exceptions.
@@ -55,7 +54,8 @@ object AutoMobileFailures {
     const val EXTRA_SDK_INT = "sdk_int"
 
     private var context: Context? = null
-    private val recentEvents = CopyOnWriteArrayList<HandledExceptionEvent>()
+    private val recentEvents = ArrayDeque<HandledExceptionEvent>(MAX_EVENTS + 1)
+    private val eventsLock = Any()
 
     /**
      * Initialize the failures API with application context.
@@ -119,19 +119,29 @@ object AutoMobileFailures {
      *
      * @return List of recent events (up to [MAX_EVENTS])
      */
-    fun getRecentEvents(): List<HandledExceptionEvent> = recentEvents.toList()
+    fun getRecentEvents(): List<HandledExceptionEvent> {
+        synchronized(eventsLock) {
+            return recentEvents.toList()
+        }
+    }
 
     /**
      * Clear all stored events from memory.
      */
     fun clearEvents() {
-        recentEvents.clear()
+        synchronized(eventsLock) {
+            recentEvents.clear()
+        }
     }
 
     /**
      * Get the current event count.
      */
-    fun getEventCount(): Int = recentEvents.size
+    fun getEventCount(): Int {
+        synchronized(eventsLock) {
+            return recentEvents.size
+        }
+    }
 
     private fun createEvent(
         context: Context,
@@ -161,11 +171,11 @@ object AutoMobileFailures {
     }
 
     private fun storeEvent(event: HandledExceptionEvent) {
-        recentEvents.add(event)
-
-        // Trim to max size if needed (remove oldest events)
-        while (recentEvents.size > MAX_EVENTS) {
-            recentEvents.removeAt(0)
+        synchronized(eventsLock) {
+            if (recentEvents.size >= MAX_EVENTS) {
+                recentEvents.removeFirst()
+            }
+            recentEvents.addLast(event)
         }
     }
 

--- a/schemas/tool-definitions.json
+++ b/schemas/tool-definitions.json
@@ -73,7 +73,7 @@
             "android",
             "ios"
           ],
-          "description": "Platform"
+          "description": "Target platform"
         },
         "locale": {
           "description": "Locale tag (e.g., ar-SA, ja-JP)",
@@ -142,7 +142,7 @@
             "android",
             "ios"
           ],
-          "description": "Platform"
+          "description": "Target platform"
         },
         "sessionUuid": {
           "description": "Session UUID for device targeting",
@@ -194,7 +194,7 @@
             "android",
             "ios"
           ],
-          "description": "Platform"
+          "description": "Target platform"
         },
         "sessionUuid": {
           "description": "Session UUID for device targeting",
@@ -483,7 +483,7 @@
             "android",
             "ios"
           ],
-          "description": "Platform"
+          "description": "Target platform"
         },
         "sessionUuid": {
           "description": "Session UUID for device targeting",
@@ -1526,7 +1526,7 @@
             "android",
             "ios"
           ],
-          "description": "Platform"
+          "description": "Target platform"
         },
         "sessionUuid": {
           "description": "Session UUID for device targeting",
@@ -1576,7 +1576,7 @@
             "android",
             "ios"
           ],
-          "description": "Platform"
+          "description": "Target platform"
         },
         "sessionUuid": {
           "description": "Session UUID for device targeting",
@@ -1636,7 +1636,7 @@
             "android",
             "ios"
           ],
-          "description": "Platform"
+          "description": "Target platform"
         },
         "sessionUuid": {
           "description": "Session UUID for device targeting",
@@ -1718,7 +1718,7 @@
             "android",
             "ios"
           ],
-          "description": "Platform"
+          "description": "Target platform"
         },
         "sessionUuid": {
           "description": "Session UUID for device targeting",
@@ -1768,7 +1768,7 @@
                 "android",
                 "ios"
               ],
-              "description": "Platform"
+              "description": "Target platform"
             }
           },
           "required": [
@@ -1850,7 +1850,7 @@
             "android",
             "ios"
           ],
-          "description": "Platform"
+          "description": "Target platform"
         }
       },
       "required": [
@@ -1867,12 +1867,12 @@
       "type": "object",
       "properties": {
         "platform": {
-          "description": "Platform",
           "type": "string",
           "enum": [
             "android",
             "ios"
-          ]
+          ],
+          "description": "Target platform"
         }
       },
       "additionalProperties": false
@@ -1891,7 +1891,7 @@
             "android",
             "ios"
           ],
-          "description": "Platform"
+          "description": "Target platform"
         },
         "waitFor": {
           "description": "Wait for element to appear before returning observation",
@@ -3615,7 +3615,7 @@
             "android",
             "ios"
           ],
-          "description": "Platform"
+          "description": "Target platform"
         },
         "sessionUuid": {
           "description": "Session UUID for device targeting",
@@ -3721,7 +3721,7 @@
             "android",
             "ios"
           ],
-          "description": "Platform"
+          "description": "Target platform"
         },
         "sessionUuid": {
           "description": "Session UUID for device targeting",
@@ -3810,7 +3810,7 @@
             "android",
             "ios"
           ],
-          "description": "Platform"
+          "description": "Target platform"
         },
         "sessionUuid": {
           "description": "Session UUID for device targeting",
@@ -3863,7 +3863,7 @@
             "android",
             "ios"
           ],
-          "description": "Platform"
+          "description": "Target platform"
         },
         "sessionUuid": {
           "description": "Session UUID for device targeting",
@@ -3915,7 +3915,7 @@
             "android",
             "ios"
           ],
-          "description": "Platform"
+          "description": "Target platform"
         },
         "sessionUuid": {
           "description": "Session UUID for device targeting",
@@ -3954,7 +3954,7 @@
             "android",
             "ios"
           ],
-          "description": "Platform"
+          "description": "Target platform"
         },
         "sessionUuid": {
           "description": "Session UUID for device targeting",
@@ -4000,7 +4000,7 @@
             "android",
             "ios"
           ],
-          "description": "Platform"
+          "description": "Target platform"
         },
         "sessionUuid": {
           "description": "Session UUID for device targeting",
@@ -4039,7 +4039,7 @@
             "android",
             "ios"
           ],
-          "description": "Platform"
+          "description": "Target platform"
         },
         "sessionUuid": {
           "description": "Session UUID for device targeting",
@@ -4081,7 +4081,7 @@
             "android",
             "ios"
           ],
-          "description": "Platform"
+          "description": "Target platform"
         },
         "sessionUuid": {
           "description": "Session UUID for device targeting",
@@ -4120,7 +4120,7 @@
             "android",
             "ios"
           ],
-          "description": "Platform"
+          "description": "Target platform"
         },
         "sessionUuid": {
           "description": "Session UUID for device targeting",
@@ -4165,7 +4165,7 @@
                 "android",
                 "ios"
               ],
-              "description": "Platform"
+              "description": "Target platform"
             },
             "deviceId": {
               "description": "Device ID",
@@ -4362,7 +4362,7 @@
             "android",
             "ios"
           ],
-          "description": "Platform"
+          "description": "Target platform"
         },
         "sessionUuid": {
           "description": "Session UUID for device targeting",
@@ -5284,7 +5284,7 @@
             "android",
             "ios"
           ],
-          "description": "Platform"
+          "description": "Target platform"
         },
         "sessionUuid": {
           "description": "Session UUID for device targeting",
@@ -5389,7 +5389,7 @@
             "android",
             "ios"
           ],
-          "description": "Platform"
+          "description": "Target platform"
         },
         "elementId": {
           "type": "string",


### PR DESCRIPTION
## Summary
- Fixes TOCTOU race condition in `AutoMobileFailures.storeEvent()` where concurrent writers could over-trim the event list
- Replaces `CopyOnWriteArrayList` with `ArrayDeque` protected by explicit `synchronized` blocks
- O(1) `removeFirst()` instead of O(n) array copy per trim operation

## Test plan
- [x] Existing unit tests pass
- [x] Concurrent stress test covers multi-threaded access

🤖 Generated with [Claude Code](https://claude.com/claude-code)