### PR TITLE
feat: add unified SdkContext for Android SDK event metadata

### DIFF
--- a/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/AutoMobileSDK.kt
+++ b/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/AutoMobileSDK.kt
@@ -6,6 +6,8 @@ import android.os.Looper
 import dev.jasonpearson.automobile.protocol.NavigationSourceType
 import dev.jasonpearson.automobile.protocol.SdkCustomEvent
 import dev.jasonpearson.automobile.protocol.SdkNavigationEvent
+import dev.jasonpearson.automobile.sdk.context.SdkContext
+import dev.jasonpearson.automobile.sdk.context.SdkContextSnapshot
 import dev.jasonpearson.automobile.sdk.anr.AutoMobileAnr
 import dev.jasonpearson.automobile.sdk.biometrics.AutoMobileBiometrics
 import dev.jasonpearson.automobile.sdk.crashes.AutoMobileCrashes
@@ -64,6 +66,7 @@ object AutoMobileSDK {
   private var mainHandler: Handler? = null
   private var sessionTracker: SessionTracker? = null
   private var sessionLifecycleObserver: DefaultLifecycleObserver? = null
+  private var sdkContext: SdkContext? = null
 
   const val ACTION_NAVIGATION_EVENT = "dev.jasonpearson.automobile.sdk.NAVIGATION_EVENT"
   const val EXTRA_DESTINATION = "destination"
@@ -93,6 +96,15 @@ object AutoMobileSDK {
     buffer.isEnabled = isEnabled
     buffer.start()
     eventBuffer = buffer
+
+    // Initialize SDK context with app version from PackageManager
+    val ctx = SdkContext()
+    try {
+      ctx.appVersion = appContext.packageManager.getPackageInfo(appContext.packageName, 0).versionName
+    } catch (_: Exception) {
+      // PackageManager lookup may fail in test environments
+    }
+    sdkContext = ctx
 
     // Thread-safe subsystems — can initialize from any thread
     NetworkMockRuleStore.initialize(appContext)
@@ -254,6 +266,18 @@ object AutoMobileSDK {
   /** Returns the shared event buffer, or null if not initialized. */
   internal fun getEventBuffer(): SdkEventBuffer? = eventBuffer
 
+  /** Sets the user identifier on the SDK context. */
+  fun setUserId(userId: String?) { sdkContext?.userId = userId }
+
+  /** Sets a tag on the SDK context. */
+  fun setTag(key: String, value: String) { sdkContext?.setTag(key, value) }
+
+  /** Removes a tag from the SDK context. */
+  fun removeTag(key: String) { sdkContext?.removeTag(key) }
+
+  /** Returns an immutable snapshot of the current SDK context, or null if not initialized. */
+  fun getContextSnapshot(): SdkContextSnapshot? = sdkContext?.snapshot()
+
   /**
    * Shuts down the SDK, releasing all resources. After calling this method, [initialize] may be
    * called again to restart the SDK.
@@ -290,6 +314,8 @@ object AutoMobileSDK {
 
     eventBuffer?.shutdown()
     eventBuffer = null
+    sdkContext?.reset()
+    sdkContext = null
     RecompositionTracker.reset()
     listeners.clear()
     isEnabled = true

--- a/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/context/SdkContext.kt
+++ b/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/context/SdkContext.kt
@@ -1,0 +1,59 @@
+package dev.jasonpearson.automobile.sdk.context
+
+import java.util.concurrent.locks.ReentrantLock
+import kotlin.concurrent.withLock
+
+/**
+ * Thread-safe mutable context holding ambient state attached to SDK events.
+ */
+class SdkContext {
+  private val lock = ReentrantLock()
+
+  @Volatile var sessionId: String? = null
+  @Volatile var userId: String? = null
+  @Volatile var appVersion: String? = null
+
+  private val _tags = mutableMapOf<String, String>()
+
+  fun setTag(key: String, value: String) {
+    lock.withLock { _tags[key] = value }
+  }
+
+  fun removeTag(key: String) {
+    lock.withLock { _tags.remove(key) }
+  }
+
+  fun clearTags() {
+    lock.withLock { _tags.clear() }
+  }
+
+  /** Returns an immutable snapshot of the current context. */
+  fun snapshot(): SdkContextSnapshot {
+    lock.withLock {
+      return SdkContextSnapshot(
+        sessionId = sessionId,
+        userId = userId,
+        appVersion = appVersion,
+        tags = HashMap(_tags),
+      )
+    }
+  }
+
+  /** Reset all context to defaults. */
+  fun reset() {
+    lock.withLock {
+      sessionId = null
+      userId = null
+      appVersion = null
+      _tags.clear()
+    }
+  }
+}
+
+/** Immutable snapshot of SDK context at a point in time. */
+data class SdkContextSnapshot(
+  val sessionId: String?,
+  val userId: String?,
+  val appVersion: String?,
+  val tags: Map<String, String>,
+)

--- a/android/auto-mobile-sdk/src/test/kotlin/dev/jasonpearson/automobile/sdk/context/SdkContextTest.kt
+++ b/android/auto-mobile-sdk/src/test/kotlin/dev/jasonpearson/automobile/sdk/context/SdkContextTest.kt
@@ -1,0 +1,139 @@
+package dev.jasonpearson.automobile.sdk.context
+
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.CyclicBarrier
+import org.junit.Assert.*
+import org.junit.Before
+import org.junit.Test
+
+class SdkContextTest {
+
+  private lateinit var context: SdkContext
+
+  @Before
+  fun setup() {
+    context = SdkContext()
+  }
+
+  @Test
+  fun `new context has null fields and empty tags`() {
+    val snap = context.snapshot()
+    assertNull(snap.sessionId)
+    assertNull(snap.userId)
+    assertNull(snap.appVersion)
+    assertTrue(snap.tags.isEmpty())
+  }
+
+  @Test
+  fun `set and get volatile fields`() {
+    context.sessionId = "sess-1"
+    context.userId = "user-42"
+    context.appVersion = "1.2.3"
+
+    val snap = context.snapshot()
+    assertEquals("sess-1", snap.sessionId)
+    assertEquals("user-42", snap.userId)
+    assertEquals("1.2.3", snap.appVersion)
+  }
+
+  @Test
+  fun `setTag adds a tag visible in snapshot`() {
+    context.setTag("env", "production")
+    assertEquals("production", context.snapshot().tags["env"])
+  }
+
+  @Test
+  fun `removeTag removes an existing tag`() {
+    context.setTag("env", "production")
+    context.removeTag("env")
+    assertNull(context.snapshot().tags["env"])
+  }
+
+  @Test
+  fun `removeTag on missing key does not throw`() {
+    context.removeTag("nonexistent")
+    assertTrue(context.snapshot().tags.isEmpty())
+  }
+
+  @Test
+  fun `clearTags removes all tags`() {
+    context.setTag("a", "1")
+    context.setTag("b", "2")
+    context.clearTags()
+    assertTrue(context.snapshot().tags.isEmpty())
+  }
+
+  @Test
+  fun `snapshot returns immutable copy`() {
+    context.setTag("key", "before")
+    val snap = context.snapshot()
+
+    // Mutate the original context after taking a snapshot
+    context.setTag("key", "after")
+    context.setTag("new", "value")
+
+    // The snapshot should not reflect the mutations
+    assertEquals("before", snap.tags["key"])
+    assertNull(snap.tags["new"])
+  }
+
+  @Test
+  fun `reset clears all fields and tags`() {
+    context.sessionId = "sess-1"
+    context.userId = "user-42"
+    context.appVersion = "1.0.0"
+    context.setTag("env", "prod")
+
+    context.reset()
+
+    val snap = context.snapshot()
+    assertNull(snap.sessionId)
+    assertNull(snap.userId)
+    assertNull(snap.appVersion)
+    assertTrue(snap.tags.isEmpty())
+  }
+
+  @Test
+  fun `SdkContextSnapshot equality works as data class`() {
+    val a = SdkContextSnapshot("s", "u", "1.0", mapOf("k" to "v"))
+    val b = SdkContextSnapshot("s", "u", "1.0", mapOf("k" to "v"))
+    assertEquals(a, b)
+    assertEquals(a.hashCode(), b.hashCode())
+  }
+
+  @Test
+  fun `SdkContextSnapshot inequality`() {
+    val a = SdkContextSnapshot("s1", "u", "1.0", emptyMap())
+    val b = SdkContextSnapshot("s2", "u", "1.0", emptyMap())
+    assertNotEquals(a, b)
+  }
+
+  @Test
+  fun `concurrent tag mutations do not throw`() {
+    val threads = 8
+    val iterations = 200
+    val barrier = CyclicBarrier(threads)
+    val latch = CountDownLatch(threads)
+    val errors = mutableListOf<Throwable>()
+
+    repeat(threads) { t ->
+      Thread {
+        try {
+          barrier.await()
+          repeat(iterations) { i ->
+            context.setTag("t$t-$i", "v")
+            context.snapshot()
+            context.removeTag("t$t-$i")
+          }
+        } catch (e: Throwable) {
+          synchronized(errors) { errors.add(e) }
+        } finally {
+          latch.countDown()
+        }
+      }.start()
+    }
+
+    latch.await()
+    assertTrue("Concurrent mutations threw: $errors", errors.isEmpty())
+  }
+}


### PR DESCRIPTION
## Summary
- Adds `SdkContext` class with thread-safe tags, userId, sessionId, appVersion
- Exposes `setUserId()`, `setTag()`, `removeTag()`, `getContextSnapshot()` on AutoMobileSDK
- Includes comprehensive unit tests with concurrency validation

## Test plan
- [x] Unit tests pass (`android/gradlew -p android :auto-mobile-sdk:test`)
- [ ] Verify context snapshot in integration test

🤖 Generated with [Claude Code](https://claude.com/claude-code)