### PR TITLE
feat: add unified SdkContext for iOS SDK event metadata

### DIFF
--- a/ios/auto-mobile-sdk/Sources/AutoMobileSDK/AutoMobileSDK.swift
+++ b/ios/auto-mobile-sdk/Sources/AutoMobileSDK/AutoMobileSDK.swift
@@ -11,6 +11,7 @@ public final class AutoMobileSDK: @unchecked Sendable {
     private var _isEnabled = true
     private var _isInitialized = false
     private var _bundleId: String?
+    private var _sdkContext: SdkContext?
     private var eventBuffer: SdkEventBuffer?
 
     private init() {}
@@ -26,6 +27,10 @@ public final class AutoMobileSDK: @unchecked Sendable {
             return
         }
         _isInitialized = true
+
+        let context = SdkContext()
+        context.appVersion = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String
+        _sdkContext = context
 
         let resolvedBundleId = bundleId ?? Bundle.main.bundleIdentifier
         _bundleId = resolvedBundleId
@@ -177,6 +182,27 @@ public final class AutoMobileSDK: @unchecked Sendable {
         return eventBuffer
     }
 
+    // MARK: - Context
+
+    /// The SDK context holding ambient state attached to events.
+    public var sdkContext: SdkContext? {
+        lock.lock()
+        defer { lock.unlock() }
+        return _sdkContext
+    }
+
+    public func setUserId(_ userId: String?) {
+        sdkContext?.userId = userId
+    }
+
+    public func setTag(_ key: String, value: String) {
+        sdkContext?.setTag(key, value: value)
+    }
+
+    public func removeTag(_ key: String) {
+        sdkContext?.removeTag(key)
+    }
+
     // MARK: - Testing Support
 
     /// Reset the SDK for testing. Not for production use.
@@ -200,6 +226,7 @@ public final class AutoMobileSDK: @unchecked Sendable {
         // to prevent deadlock: shutdown() -> onFlush -> bundleId -> lock
         lock.lock()
         let bufferToShutdown = eventBuffer
+        _sdkContext = nil
         eventBuffer = nil
         listeners.removeAll()
         _isEnabled = true

--- a/ios/auto-mobile-sdk/Sources/AutoMobileSDK/Context/SdkContext.swift
+++ b/ios/auto-mobile-sdk/Sources/AutoMobileSDK/Context/SdkContext.swift
@@ -1,0 +1,63 @@
+import Foundation
+
+/// Thread-safe mutable context holding ambient state attached to SDK events.
+public final class SdkContext: @unchecked Sendable {
+    private let lock = NSLock()
+    private var _sessionId: String?
+    private var _userId: String?
+    private var _appVersion: String?
+    private var _tags: [String: String] = [:]
+
+    public init() {}
+
+    public var sessionId: String? {
+        get { lock.lock(); defer { lock.unlock() }; return _sessionId }
+        set { lock.lock(); _sessionId = newValue; lock.unlock() }
+    }
+
+    public var userId: String? {
+        get { lock.lock(); defer { lock.unlock() }; return _userId }
+        set { lock.lock(); _userId = newValue; lock.unlock() }
+    }
+
+    public var appVersion: String? {
+        get { lock.lock(); defer { lock.unlock() }; return _appVersion }
+        set { lock.lock(); _appVersion = newValue; lock.unlock() }
+    }
+
+    public func setTag(_ key: String, value: String) {
+        lock.lock(); _tags[key] = value; lock.unlock()
+    }
+
+    public func removeTag(_ key: String) {
+        lock.lock(); _tags.removeValue(forKey: key); lock.unlock()
+    }
+
+    public func clearTags() {
+        lock.lock(); _tags.removeAll(); lock.unlock()
+    }
+
+    /// Returns an immutable snapshot.
+    public func snapshot() -> SdkContextSnapshot {
+        lock.lock()
+        defer { lock.unlock() }
+        return SdkContextSnapshot(
+            sessionId: _sessionId, userId: _userId,
+            appVersion: _appVersion, tags: _tags
+        )
+    }
+
+    public func reset() {
+        lock.lock()
+        _sessionId = nil; _userId = nil; _appVersion = nil; _tags.removeAll()
+        lock.unlock()
+    }
+}
+
+/// Immutable snapshot of SDK context.
+public struct SdkContextSnapshot: Codable, Sendable, Equatable {
+    public let sessionId: String?
+    public let userId: String?
+    public let appVersion: String?
+    public let tags: [String: String]
+}

--- a/ios/auto-mobile-sdk/Tests/AutoMobileSDKTests/SdkContextTests.swift
+++ b/ios/auto-mobile-sdk/Tests/AutoMobileSDKTests/SdkContextTests.swift
@@ -1,0 +1,164 @@
+import XCTest
+@testable import AutoMobileSDK
+
+final class SdkContextTests: XCTestCase {
+
+    // MARK: - SdkContext
+
+    func testDefaultValuesAreNil() {
+        let context = SdkContext()
+        XCTAssertNil(context.sessionId)
+        XCTAssertNil(context.userId)
+        XCTAssertNil(context.appVersion)
+    }
+
+    func testSetAndGetSessionId() {
+        let context = SdkContext()
+        context.sessionId = "session-123"
+        XCTAssertEqual(context.sessionId, "session-123")
+    }
+
+    func testSetAndGetUserId() {
+        let context = SdkContext()
+        context.userId = "user-456"
+        XCTAssertEqual(context.userId, "user-456")
+    }
+
+    func testSetAndGetAppVersion() {
+        let context = SdkContext()
+        context.appVersion = "2.1.0"
+        XCTAssertEqual(context.appVersion, "2.1.0")
+    }
+
+    func testSetAndRemoveTag() {
+        let context = SdkContext()
+        context.setTag("env", value: "production")
+        XCTAssertEqual(context.snapshot().tags["env"], "production")
+
+        context.removeTag("env")
+        XCTAssertNil(context.snapshot().tags["env"])
+    }
+
+    func testClearTags() {
+        let context = SdkContext()
+        context.setTag("a", value: "1")
+        context.setTag("b", value: "2")
+        context.clearTags()
+        XCTAssertTrue(context.snapshot().tags.isEmpty)
+    }
+
+    func testSnapshotReturnsCurrentValues() {
+        let context = SdkContext()
+        context.sessionId = "s1"
+        context.userId = "u1"
+        context.appVersion = "1.0"
+        context.setTag("key", value: "val")
+
+        let snap = context.snapshot()
+        XCTAssertEqual(snap.sessionId, "s1")
+        XCTAssertEqual(snap.userId, "u1")
+        XCTAssertEqual(snap.appVersion, "1.0")
+        XCTAssertEqual(snap.tags, ["key": "val"])
+    }
+
+    func testSnapshotIsImmutable() {
+        let context = SdkContext()
+        context.sessionId = "before"
+        let snap = context.snapshot()
+
+        context.sessionId = "after"
+        XCTAssertEqual(snap.sessionId, "before")
+        XCTAssertEqual(context.sessionId, "after")
+    }
+
+    func testReset() {
+        let context = SdkContext()
+        context.sessionId = "s"
+        context.userId = "u"
+        context.appVersion = "v"
+        context.setTag("t", value: "1")
+
+        context.reset()
+
+        XCTAssertNil(context.sessionId)
+        XCTAssertNil(context.userId)
+        XCTAssertNil(context.appVersion)
+        XCTAssertTrue(context.snapshot().tags.isEmpty)
+    }
+
+    func testConcurrentAccess() {
+        let context = SdkContext()
+        let iterations = 100
+        let expectation = XCTestExpectation(description: "concurrent access")
+        expectation.expectedFulfillmentCount = iterations * 2
+
+        for i in 0..<iterations {
+            DispatchQueue.global().async {
+                context.sessionId = "session-\(i)"
+                context.setTag("key-\(i)", value: "val-\(i)")
+                expectation.fulfill()
+            }
+            DispatchQueue.global().async {
+                _ = context.sessionId
+                _ = context.snapshot()
+                expectation.fulfill()
+            }
+        }
+
+        wait(for: [expectation], timeout: 5.0)
+        // If we get here without crashing, thread safety is confirmed
+        XCTAssertNotNil(context.sessionId)
+    }
+
+    // MARK: - SdkContextSnapshot
+
+    func testSnapshotEquatable() {
+        let a = SdkContextSnapshot(sessionId: "s", userId: "u", appVersion: "1.0", tags: ["k": "v"])
+        let b = SdkContextSnapshot(sessionId: "s", userId: "u", appVersion: "1.0", tags: ["k": "v"])
+        let c = SdkContextSnapshot(sessionId: "other", userId: "u", appVersion: "1.0", tags: ["k": "v"])
+        XCTAssertEqual(a, b)
+        XCTAssertNotEqual(a, c)
+    }
+
+    func testSnapshotCodable() throws {
+        let original = SdkContextSnapshot(sessionId: "s1", userId: "u1", appVersion: "2.0", tags: ["env": "test"])
+        let data = try JSONEncoder().encode(original)
+        let decoded = try JSONDecoder().decode(SdkContextSnapshot.self, from: data)
+        XCTAssertEqual(original, decoded)
+    }
+
+    // MARK: - SDK Integration
+
+    func testSdkContextCreatedOnInitialize() {
+        XCTAssertNil(AutoMobileSDK.shared.sdkContext)
+        AutoMobileSDK.shared.initialize(bundleId: "com.test.ctx")
+        XCTAssertNotNil(AutoMobileSDK.shared.sdkContext)
+    }
+
+    func testSdkContextNilAfterReset() {
+        AutoMobileSDK.shared.initialize(bundleId: "com.test.ctx")
+        XCTAssertNotNil(AutoMobileSDK.shared.sdkContext)
+        AutoMobileSDK.shared.reset()
+        XCTAssertNil(AutoMobileSDK.shared.sdkContext)
+    }
+
+    func testSdkConvenienceSetUserId() {
+        AutoMobileSDK.shared.initialize(bundleId: "com.test.ctx")
+        AutoMobileSDK.shared.setUserId("user-99")
+        XCTAssertEqual(AutoMobileSDK.shared.sdkContext?.userId, "user-99")
+    }
+
+    func testSdkConvenienceSetAndRemoveTag() {
+        AutoMobileSDK.shared.initialize(bundleId: "com.test.ctx")
+        AutoMobileSDK.shared.setTag("plan", value: "pro")
+        XCTAssertEqual(AutoMobileSDK.shared.sdkContext?.snapshot().tags["plan"], "pro")
+
+        AutoMobileSDK.shared.removeTag("plan")
+        XCTAssertNil(AutoMobileSDK.shared.sdkContext?.snapshot().tags["plan"])
+    }
+
+    override func tearDown() {
+        AutoMobileSDK.shared.reset()
+        super.tearDown()
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `SdkContext` class with NSLock-based thread safety
- `SdkContextSnapshot` is `Codable`, `Sendable`, `Equatable`
- Convenience methods on AutoMobileSDK: `setUserId()`, `setTag()`, `removeTag()`

## Test plan
- [x] Unit tests pass (`./scripts/ios/swift-test.sh`)
- [ ] Verify context snapshot in integration test

🤖 Generated with [Claude Code](https://claude.com/claude-code)