### PR TITLE
feat: add breadcrumb trail for Android SDK crash context

### DIFF
--- a/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/AutoMobileSDK.kt
+++ b/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/AutoMobileSDK.kt
@@ -10,6 +10,9 @@ import dev.jasonpearson.automobile.sdk.context.SdkContext
 import dev.jasonpearson.automobile.sdk.context.SdkContextSnapshot
 import dev.jasonpearson.automobile.sdk.anr.AutoMobileAnr
 import dev.jasonpearson.automobile.sdk.biometrics.AutoMobileBiometrics
+import dev.jasonpearson.automobile.sdk.breadcrumbs.Breadcrumb
+import dev.jasonpearson.automobile.sdk.breadcrumbs.BreadcrumbCategory
+import dev.jasonpearson.automobile.sdk.breadcrumbs.BreadcrumbTrail
 import dev.jasonpearson.automobile.sdk.crashes.AutoMobileCrashes
 import dev.jasonpearson.automobile.sdk.database.DatabaseInspector
 import dev.jasonpearson.automobile.sdk.events.SdkEventBroadcaster
@@ -67,6 +70,7 @@ object AutoMobileSDK {
   private var sessionTracker: SessionTracker? = null
   private var sessionLifecycleObserver: DefaultLifecycleObserver? = null
   private var sdkContext: SdkContext? = null
+  private var breadcrumbTrail: BreadcrumbTrail? = null
 
   const val ACTION_NAVIGATION_EVENT = "dev.jasonpearson.automobile.sdk.NAVIGATION_EVENT"
   const val EXTRA_DESTINATION = "destination"
@@ -115,6 +119,9 @@ object AutoMobileSDK {
     SharedPreferencesInspector.initialize(appContext)
     AutoMobileFailures.initialize(appContext)
     AutoMobileCrashes.initialize(appContext)
+    val trail = BreadcrumbTrail()
+    breadcrumbTrail = trail
+    AutoMobileCrashes.breadcrumbTrail = trail
     AutoMobileAnr.initialize(appContext)
     AutoMobileBiometrics.initialize(appContext)
 
@@ -191,6 +198,8 @@ object AutoMobileSDK {
       }
     }
 
+    addBreadcrumb(event.destination, BreadcrumbCategory.NAVIGATION, event.metadata)
+
     // Route navigation events through the shared event buffer so they are
     // batched and broadcast on the buffer's background thread instead of
     // blocking the caller (which is often the main thread).
@@ -249,6 +258,9 @@ object AutoMobileSDK {
    */
   fun trackEvent(name: String, properties: Map<String, String> = emptyMap()) {
     if (!isEnabled) return
+
+    addBreadcrumb(name, BreadcrumbCategory.CUSTOM, properties)
+
     val buf = eventBuffer ?: return
     buf.add(
       SdkCustomEvent(
@@ -262,6 +274,29 @@ object AutoMobileSDK {
 
   /** Returns the current session ID, or null if no active session. */
   fun currentSessionId(): String? = sessionTracker?.currentSessionId()
+
+  /**
+   * Add a breadcrumb to the trail. Breadcrumbs are attached to crash reports
+   * so that recent app activity is visible when diagnosing crashes.
+   *
+   * @param message A short description of the breadcrumb
+   * @param category The category (defaults to CUSTOM)
+   * @param metadata Optional key-value metadata
+   */
+  fun addBreadcrumb(
+    message: String,
+    category: BreadcrumbCategory = BreadcrumbCategory.CUSTOM,
+    metadata: Map<String, String> = emptyMap(),
+  ) {
+    breadcrumbTrail?.add(
+      Breadcrumb(
+        timestamp = System.currentTimeMillis(),
+        category = category,
+        message = message,
+        metadata = metadata,
+      ),
+    )
+  }
 
   /** Returns the shared event buffer, or null if not initialized. */
   internal fun getEventBuffer(): SdkEventBuffer? = eventBuffer
@@ -317,6 +352,8 @@ object AutoMobileSDK {
     eventBuffer = null
     sdkContext?.reset()
     sdkContext = null
+    breadcrumbTrail?.clear()
+    breadcrumbTrail = null
     RecompositionTracker.reset()
     listeners.clear()
     isEnabled = true

--- a/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/breadcrumbs/BreadcrumbTrail.kt
+++ b/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/breadcrumbs/BreadcrumbTrail.kt
@@ -1,0 +1,49 @@
+package dev.jasonpearson.automobile.sdk.breadcrumbs
+
+import java.util.concurrent.locks.ReentrantLock
+import kotlin.concurrent.withLock
+
+enum class BreadcrumbCategory {
+    NAVIGATION, TAP, LIFECYCLE, NETWORK, LOG, CUSTOM
+}
+
+data class Breadcrumb(
+    val timestamp: Long,
+    val category: BreadcrumbCategory,
+    val message: String,
+    val metadata: Map<String, String> = emptyMap(),
+)
+
+interface BreadcrumbTracking {
+    fun add(breadcrumb: Breadcrumb)
+    fun snapshot(): List<Breadcrumb>
+    fun clear()
+}
+
+/**
+ * Thread-safe ring buffer of recent breadcrumbs.
+ * When full, oldest breadcrumbs are evicted.
+ */
+class BreadcrumbTrail(private val maxSize: Int = 100) : BreadcrumbTracking {
+    private val lock = ReentrantLock()
+    private val deque = ArrayDeque<Breadcrumb>(maxSize)
+
+    override fun add(breadcrumb: Breadcrumb) {
+        lock.withLock {
+            if (deque.size >= maxSize) {
+                deque.removeFirst()
+            }
+            deque.addLast(breadcrumb)
+        }
+    }
+
+    override fun snapshot(): List<Breadcrumb> {
+        lock.withLock {
+            return ArrayList(deque)
+        }
+    }
+
+    override fun clear() {
+        lock.withLock { deque.clear() }
+    }
+}

--- a/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/crashes/AutoMobileCrashes.kt
+++ b/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/crashes/AutoMobileCrashes.kt
@@ -8,9 +8,13 @@ import android.util.Log
 import dev.jasonpearson.automobile.protocol.SdkCrashEvent
 import dev.jasonpearson.automobile.protocol.SdkDeviceInfo
 import dev.jasonpearson.automobile.protocol.SdkEventSerializer
+import dev.jasonpearson.automobile.sdk.breadcrumbs.Breadcrumb
+import dev.jasonpearson.automobile.sdk.breadcrumbs.BreadcrumbTracking
 import java.io.PrintWriter
 import java.io.StringWriter
 import java.util.concurrent.atomic.AtomicBoolean
+import org.json.JSONArray
+import org.json.JSONObject
 
 /**
  * SDK API for detecting and reporting unhandled crashes.
@@ -48,6 +52,10 @@ object AutoMobileCrashes {
     const val EXTRA_DEVICE_MANUFACTURER = "device_manufacturer"
     const val EXTRA_OS_VERSION = "os_version"
     const val EXTRA_SDK_INT = "sdk_int"
+    const val EXTRA_BREADCRUMBS = "breadcrumbs"
+
+    /** Maximum size in bytes for the breadcrumbs JSON extra. */
+    private const val MAX_BREADCRUMBS_BYTES = 50_000
 
     private var context: Context? = null
     @Volatile private var originalHandler: Thread.UncaughtExceptionHandler? = null
@@ -55,6 +63,9 @@ object AutoMobileCrashes {
 
     /** Provider for current screen name - set by navigation tracking */
     var currentScreenProvider: (() -> String?)? = null
+
+    /** Breadcrumb trail attached to crash reports. Set by AutoMobileSDK. */
+    var breadcrumbTrail: BreadcrumbTracking? = null
 
     /**
      * Initialize crash detection with application context.
@@ -101,6 +112,7 @@ object AutoMobileCrashes {
         originalHandler = null
         context = null
         currentScreenProvider = null
+        breadcrumbTrail = null
         Log.d(TAG, "AutoMobileCrashes uninstalled - crash detection disabled")
     }
 
@@ -209,6 +221,9 @@ object AutoMobileCrashes {
                 putExtra(EXTRA_DEVICE_MANUFACTURER, Build.MANUFACTURER)
                 putExtra(EXTRA_OS_VERSION, Build.VERSION.RELEASE)
                 putExtra(EXTRA_SDK_INT, Build.VERSION.SDK_INT)
+
+                // Attach breadcrumb trail snapshot
+                serializeBreadcrumbs()?.let { putExtra(EXTRA_BREADCRUMBS, it) }
             }
 
             ctx.sendBroadcast(intent)
@@ -222,6 +237,51 @@ object AutoMobileCrashes {
         } catch (e: Exception) {
             Log.e(TAG, "Failed to broadcast crash", e)
         }
+    }
+
+    /**
+     * Serialize the breadcrumb trail snapshot to a JSON string.
+     * If the result exceeds [MAX_BREADCRUMBS_BYTES], the oldest breadcrumbs are
+     * dropped until it fits.
+     */
+    private fun serializeBreadcrumbs(): String? {
+        val crumbs = breadcrumbTrail?.snapshot() ?: return null
+        if (crumbs.isEmpty()) return null
+
+        val json = breadcrumbsToJson(crumbs)
+        if (json.toByteArray(Charsets.UTF_8).size <= MAX_BREADCRUMBS_BYTES) return json
+
+        // Binary search for the largest suffix that fits within the size limit.
+        var lo = 1
+        var hi = crumbs.size - 1
+        var bestStart = crumbs.size // nothing fits
+        while (lo <= hi) {
+            val mid = (lo + hi) / 2
+            val candidate = breadcrumbsToJson(crumbs.subList(mid, crumbs.size))
+            if (candidate.toByteArray(Charsets.UTF_8).size <= MAX_BREADCRUMBS_BYTES) {
+                bestStart = mid
+                hi = mid - 1
+            } else {
+                lo = mid + 1
+            }
+        }
+        if (bestStart >= crumbs.size) return null
+        return breadcrumbsToJson(crumbs.subList(bestStart, crumbs.size))
+    }
+
+    private fun breadcrumbsToJson(list: List<Breadcrumb>): String {
+        val arr = JSONArray()
+        for (bc in list) {
+            val obj = JSONObject()
+            obj.put("timestamp", bc.timestamp)
+            obj.put("category", bc.category.name)
+            obj.put("message", bc.message)
+            if (bc.metadata.isNotEmpty()) {
+                obj.put("metadata", JSONObject(bc.metadata))
+            }
+            arr.put(obj)
+        }
+        return arr.toString()
     }
 
     private fun getAppVersion(context: Context): String? {

--- a/android/auto-mobile-sdk/src/test/kotlin/dev/jasonpearson/automobile/sdk/breadcrumbs/BreadcrumbTrailTest.kt
+++ b/android/auto-mobile-sdk/src/test/kotlin/dev/jasonpearson/automobile/sdk/breadcrumbs/BreadcrumbTrailTest.kt
@@ -1,0 +1,110 @@
+package dev.jasonpearson.automobile.sdk.breadcrumbs
+
+import org.junit.Assert.*
+import org.junit.Before
+import org.junit.Test
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
+
+class BreadcrumbTrailTest {
+
+    private lateinit var trail: BreadcrumbTrail
+
+    @Before
+    fun setup() {
+        trail = BreadcrumbTrail(maxSize = 5)
+    }
+
+    @Test
+    fun `snapshot returns breadcrumbs in insertion order`() {
+        val b1 = Breadcrumb(1L, BreadcrumbCategory.NAVIGATION, "screen A")
+        val b2 = Breadcrumb(2L, BreadcrumbCategory.TAP, "button X")
+        val b3 = Breadcrumb(3L, BreadcrumbCategory.CUSTOM, "event Y", mapOf("key" to "value"))
+
+        trail.add(b1)
+        trail.add(b2)
+        trail.add(b3)
+
+        assertEquals(listOf(b1, b2, b3), trail.snapshot())
+    }
+
+    @Test
+    fun `ring buffer evicts oldest when full`() {
+        val maxSize = 5
+        // Add maxSize + 10 items
+        for (i in 1..maxSize + 10) {
+            trail.add(Breadcrumb(i.toLong(), BreadcrumbCategory.LOG, "msg $i"))
+        }
+
+        val snapshot = trail.snapshot()
+        assertEquals(maxSize, snapshot.size)
+        // Only the last 5 remain (items 11..15)
+        for ((index, bc) in snapshot.withIndex()) {
+            assertEquals("msg ${index + 11}", bc.message)
+        }
+    }
+
+    @Test
+    fun `clear empties the trail`() {
+        trail.add(Breadcrumb(1L, BreadcrumbCategory.CUSTOM, "a"))
+        trail.add(Breadcrumb(2L, BreadcrumbCategory.CUSTOM, "b"))
+
+        trail.clear()
+
+        assertTrue(trail.snapshot().isEmpty())
+    }
+
+    @Test
+    fun `snapshot returns a copy`() {
+        trail.add(Breadcrumb(1L, BreadcrumbCategory.CUSTOM, "before"))
+
+        val snap = trail.snapshot()
+
+        // Modify trail after snapshot
+        trail.add(Breadcrumb(2L, BreadcrumbCategory.CUSTOM, "after"))
+
+        assertEquals(1, snap.size)
+        assertEquals("before", snap[0].message)
+    }
+
+    @Test
+    fun `concurrent adds produce correct count`() {
+        val largeTrail = BreadcrumbTrail(maxSize = 1000)
+        val threadCount = 10
+        val addsPerThread = 100
+        val latch = CountDownLatch(threadCount)
+        val executor = Executors.newFixedThreadPool(threadCount)
+
+        for (t in 0 until threadCount) {
+            executor.submit {
+                try {
+                    for (i in 0 until addsPerThread) {
+                        largeTrail.add(
+                            Breadcrumb(
+                                System.nanoTime(),
+                                BreadcrumbCategory.CUSTOM,
+                                "t$t-i$i",
+                            ),
+                        )
+                    }
+                } finally {
+                    latch.countDown()
+                }
+            }
+        }
+
+        latch.await()
+        executor.shutdown()
+
+        assertEquals(threadCount * addsPerThread, largeTrail.snapshot().size)
+    }
+
+    @Test
+    fun `default maxSize is 100`() {
+        val defaultTrail = BreadcrumbTrail()
+        for (i in 1..150) {
+            defaultTrail.add(Breadcrumb(i.toLong(), BreadcrumbCategory.CUSTOM, "msg $i"))
+        }
+        assertEquals(100, defaultTrail.snapshot().size)
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `BreadcrumbTracking` interface and `BreadcrumbTrail` ring buffer (ReentrantLock + ArrayDeque)
- Breadcrumb categories: NAVIGATION, TAP, LIFECYCLE, NETWORK, LOG, CUSTOM
- Crash handler serializes breadcrumbs as JSON Intent extra (binary search for 50KB cap)
- Auto-adds breadcrumbs on navigation events and custom events

## Test plan
- [x] Unit tests pass (`android/gradlew -p android :auto-mobile-sdk:test`)
- [ ] Verify breadcrumbs attached to crash broadcast

🤖 Generated with [Claude Code](https://claude.com/claude-code)