### PR TITLE
feat: add per-dashboard ViewModels for Navigation and Failures

### DIFF
--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/failures/FailuresViewModel.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/failures/FailuresViewModel.kt
@@ -1,0 +1,137 @@
+package dev.jasonpearson.automobile.desktop.core.failures
+
+import dev.jasonpearson.automobile.desktop.core.logging.LoggerFactory
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.receiveAsFlow
+import kotlinx.coroutines.launch
+
+private val LOG = LoggerFactory.getLogger("FailuresViewModel")
+
+/**
+ * UI state for the Failures dashboard.
+ */
+sealed interface FailuresUiState {
+    data object Loading : FailuresUiState
+    data class Content(
+        val failureGroups: List<FailureGroup>,
+        val selectedFailure: FailureGroup? = null,
+        val filterType: FailureType? = null,
+    ) : FailuresUiState
+    data class Error(val message: String) : FailuresUiState
+}
+
+/**
+ * Actions the Failures dashboard can dispatch.
+ */
+sealed interface FailuresAction {
+    data object Refresh : FailuresAction
+    data class SelectFailure(val failure: FailureGroup) : FailuresAction
+    data object ClearSelection : FailuresAction
+    data class FilterByType(val type: FailureType?) : FailuresAction
+    data class SelectFailureById(val failureId: String) : FailuresAction
+    data class UpdateGroups(val groups: List<FailureGroup>) : FailuresAction
+}
+
+/**
+ * One-shot effects emitted by the FailuresViewModel.
+ */
+sealed interface FailuresEffect {
+    data class OpenStackTrace(val fileName: String, val lineNumber: Int) : FailuresEffect
+    data class NavigateToScreen(val screenName: String) : FailuresEffect
+    data class NavigateToTest(val testName: String) : FailuresEffect
+}
+
+/**
+ * ViewModel for the Failures dashboard. Manages loading, filtering, and selection
+ * independent of Compose.
+ */
+class FailuresViewModel(
+    private val dataSource: FailuresDataSource,
+    private val scope: CoroutineScope,
+) {
+    private val _state = MutableStateFlow<FailuresUiState>(FailuresUiState.Loading)
+    val state: StateFlow<FailuresUiState> = _state.asStateFlow()
+
+    private val _effect = Channel<FailuresEffect>(Channel.BUFFERED)
+    val effect = _effect.receiveAsFlow()
+
+    init {
+        load()
+    }
+
+    fun onAction(action: FailuresAction) {
+        when (action) {
+            is FailuresAction.Refresh -> load()
+            is FailuresAction.SelectFailure -> selectFailure(action.failure)
+            is FailuresAction.ClearSelection -> clearSelection()
+            is FailuresAction.FilterByType -> filterByType(action.type)
+            is FailuresAction.SelectFailureById -> selectFailureById(action.failureId)
+            is FailuresAction.UpdateGroups -> updateGroups(action.groups)
+        }
+    }
+
+    private fun load() {
+        _state.value = FailuresUiState.Loading
+        scope.launch {
+            try {
+                when (val result = dataSource.getFailureGroups()) {
+                    is DataSourceResult.Success -> {
+                        LOG.info("Failures loaded: ${result.data.size} groups")
+                        _state.value = FailuresUiState.Content(failureGroups = result.data)
+                    }
+                    is DataSourceResult.Error -> {
+                        LOG.warn("Failed to load failures: ${result.message}")
+                        _state.value = FailuresUiState.Error(message = result.message)
+                    }
+                }
+            } catch (e: Exception) {
+                LOG.error("Exception loading failures", e)
+                _state.value = FailuresUiState.Error(message = e.message ?: "Unknown error")
+            }
+        }
+    }
+
+    private fun selectFailure(failure: FailureGroup) {
+        val current = _state.value
+        if (current is FailuresUiState.Content) {
+            _state.value = current.copy(selectedFailure = failure)
+        }
+    }
+
+    private fun clearSelection() {
+        val current = _state.value
+        if (current is FailuresUiState.Content) {
+            _state.value = current.copy(selectedFailure = null)
+        }
+    }
+
+    private fun filterByType(type: FailureType?) {
+        val current = _state.value
+        if (current is FailuresUiState.Content) {
+            _state.value = current.copy(filterType = type)
+        }
+    }
+
+    private fun selectFailureById(failureId: String) {
+        val current = _state.value
+        if (current is FailuresUiState.Content) {
+            val target = current.failureGroups.find { it.id == failureId }
+            if (target != null) {
+                _state.value = current.copy(selectedFailure = target)
+            }
+        }
+    }
+
+    private fun updateGroups(groups: List<FailureGroup>) {
+        val current = _state.value
+        if (current is FailuresUiState.Content) {
+            _state.value = current.copy(failureGroups = groups)
+        } else {
+            _state.value = FailuresUiState.Content(failureGroups = groups)
+        }
+    }
+}

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/navigation/NavigationViewModel.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/navigation/NavigationViewModel.kt
@@ -1,0 +1,141 @@
+package dev.jasonpearson.automobile.desktop.core.navigation
+
+import dev.jasonpearson.automobile.desktop.core.datasource.NavigationDataSource
+import dev.jasonpearson.automobile.desktop.core.datasource.NavigationGraph
+import dev.jasonpearson.automobile.desktop.core.datasource.Result
+import dev.jasonpearson.automobile.desktop.core.logging.LoggerFactory
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.receiveAsFlow
+import kotlinx.coroutines.launch
+
+private val LOG = LoggerFactory.getLogger("NavigationViewModel")
+
+/**
+ * UI state for the Navigation dashboard.
+ */
+sealed interface NavigationUiState {
+    data object Loading : NavigationUiState
+    data class Content(
+        val graph: NavigationGraph,
+        val selectedScreenId: String? = null,
+        val currentSection: NavigationSection = NavigationSection.FlowMap,
+    ) : NavigationUiState
+    data class Error(val message: String) : NavigationUiState
+}
+
+/**
+ * Actions the Navigation dashboard can dispatch.
+ */
+sealed interface NavigationAction {
+    data object Refresh : NavigationAction
+    data class SelectScreen(val screenId: String) : NavigationAction
+    data class SelectScreenByName(val screenName: String) : NavigationAction
+    data object BackToFlowMap : NavigationAction
+    data class UpdateGraph(val graph: NavigationGraph) : NavigationAction
+}
+
+/**
+ * One-shot effects emitted by the NavigationViewModel.
+ */
+sealed interface NavigationEffect {
+    data class OpenSource(val fileName: String, val lineNumber: Int) : NavigationEffect
+}
+
+/**
+ * ViewModel for the Navigation dashboard. Manages loading, state transitions,
+ * and screen selection independent of Compose.
+ */
+class NavigationViewModel(
+    private val dataSource: NavigationDataSource,
+    private val scope: CoroutineScope,
+) {
+    private val _state = MutableStateFlow<NavigationUiState>(NavigationUiState.Loading)
+    val state: StateFlow<NavigationUiState> = _state.asStateFlow()
+
+    private val _effect = Channel<NavigationEffect>(Channel.BUFFERED)
+    val effect = _effect.receiveAsFlow()
+
+    init {
+        load()
+    }
+
+    fun onAction(action: NavigationAction) {
+        when (action) {
+            is NavigationAction.Refresh -> load()
+            is NavigationAction.SelectScreen -> selectScreen(action.screenId)
+            is NavigationAction.SelectScreenByName -> selectScreenByName(action.screenName)
+            is NavigationAction.BackToFlowMap -> backToFlowMap()
+            is NavigationAction.UpdateGraph -> updateGraph(action.graph)
+        }
+    }
+
+    private fun load() {
+        _state.value = NavigationUiState.Loading
+        scope.launch {
+            try {
+                when (val result = dataSource.getNavigationGraph()) {
+                    is Result.Success -> {
+                        LOG.info("Navigation data loaded: ${result.data.screens.size} screens, ${result.data.transitions.size} transitions")
+                        _state.value = NavigationUiState.Content(graph = result.data)
+                    }
+                    is Result.Error -> {
+                        LOG.warn("Failed to load navigation data: ${result.message}")
+                        _state.value = NavigationUiState.Error(message = result.message)
+                    }
+                    is Result.Loading -> {
+                        // Keep loading state
+                    }
+                }
+            } catch (e: Exception) {
+                LOG.error("Exception loading navigation data", e)
+                _state.value = NavigationUiState.Error(message = e.message ?: "Unknown error")
+            }
+        }
+    }
+
+    private fun selectScreen(screenId: String) {
+        val current = _state.value
+        if (current is NavigationUiState.Content) {
+            _state.value = current.copy(
+                selectedScreenId = screenId,
+                currentSection = NavigationSection.ScreenDetail,
+            )
+        }
+    }
+
+    private fun selectScreenByName(screenName: String) {
+        val current = _state.value
+        if (current is NavigationUiState.Content) {
+            val screen = current.graph.screens.find { it.name == screenName }
+            if (screen != null) {
+                _state.value = current.copy(
+                    selectedScreenId = screen.id,
+                    currentSection = NavigationSection.ScreenDetail,
+                )
+            }
+        }
+    }
+
+    private fun backToFlowMap() {
+        val current = _state.value
+        if (current is NavigationUiState.Content) {
+            _state.value = current.copy(
+                selectedScreenId = null,
+                currentSection = NavigationSection.FlowMap,
+            )
+        }
+    }
+
+    private fun updateGraph(graph: NavigationGraph) {
+        val current = _state.value
+        if (current is NavigationUiState.Content) {
+            _state.value = current.copy(graph = graph)
+        } else {
+            _state.value = NavigationUiState.Content(graph = graph)
+        }
+    }
+}

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/failures/FailuresViewModelTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/failures/FailuresViewModelTest.kt
@@ -1,0 +1,221 @@
+package dev.jasonpearson.automobile.desktop.core.failures
+
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class FailuresViewModelTest {
+
+    private val testDispatcher = UnconfinedTestDispatcher()
+    private val testScope = TestScope(testDispatcher)
+
+    private fun createTestFailureGroup(id: String, type: FailureType = FailureType.Crash) = FailureGroup(
+        id = id,
+        type = type,
+        signature = "Test signature $id",
+        title = "Test title $id",
+        message = "Test message $id",
+        firstOccurrence = 0L,
+        lastOccurrence = 0L,
+        totalCount = 1,
+        uniqueSessions = 1,
+        severity = FailureSeverity.Medium,
+        deviceBreakdown = emptyList(),
+        versionBreakdown = emptyList(),
+        screenBreakdown = emptyList(),
+        failureScreens = emptyMap(),
+        stackTraceElements = emptyList(),
+        toolCallInfo = null,
+        affectedTests = emptyMap(),
+        recentCaptures = emptyList(),
+        sampleOccurrences = emptyList(),
+    )
+
+    @Test
+    fun `initial state transitions to Content on success`() = testScope.runTest {
+        val groups = listOf(createTestFailureGroup("g1"), createTestFailureGroup("g2"))
+        val dataSource = FakeFailuresDataSourceImpl(DataSourceResult.Success(groups))
+        val vm = FailuresViewModel(dataSource, this)
+
+        val state = vm.state.value
+        assertTrue("Expected Content but was $state", state is FailuresUiState.Content)
+        val content = state as FailuresUiState.Content
+        assertEquals(2, content.failureGroups.size)
+        assertNull(content.selectedFailure)
+        assertNull(content.filterType)
+    }
+
+    @Test
+    fun `transitions to Error on data source error`() = testScope.runTest {
+        val dataSource = FakeFailuresDataSourceImpl(DataSourceResult.Error("Server down"))
+        val vm = FailuresViewModel(dataSource, this)
+
+        val state = vm.state.value
+        assertTrue("Expected Error but was $state", state is FailuresUiState.Error)
+        assertEquals("Server down", (state as FailuresUiState.Error).message)
+    }
+
+    @Test
+    fun `transitions to Error on exception`() = testScope.runTest {
+        val dataSource = ThrowingFailuresDataSource(RuntimeException("Crash"))
+        val vm = FailuresViewModel(dataSource, this)
+
+        val state = vm.state.value
+        assertTrue("Expected Error but was $state", state is FailuresUiState.Error)
+        assertEquals("Crash", (state as FailuresUiState.Error).message)
+    }
+
+    @Test
+    fun `SelectFailure updates selectedFailure`() = testScope.runTest {
+        val group = createTestFailureGroup("g1")
+        val dataSource = FakeFailuresDataSourceImpl(DataSourceResult.Success(listOf(group)))
+        val vm = FailuresViewModel(dataSource, this)
+
+        vm.onAction(FailuresAction.SelectFailure(group))
+
+        val state = vm.state.value as FailuresUiState.Content
+        assertEquals(group, state.selectedFailure)
+    }
+
+    @Test
+    fun `ClearSelection clears selectedFailure`() = testScope.runTest {
+        val group = createTestFailureGroup("g1")
+        val dataSource = FakeFailuresDataSourceImpl(DataSourceResult.Success(listOf(group)))
+        val vm = FailuresViewModel(dataSource, this)
+
+        vm.onAction(FailuresAction.SelectFailure(group))
+        vm.onAction(FailuresAction.ClearSelection)
+
+        val state = vm.state.value as FailuresUiState.Content
+        assertNull(state.selectedFailure)
+    }
+
+    @Test
+    fun `FilterByType sets filterType`() = testScope.runTest {
+        val groups = listOf(
+            createTestFailureGroup("g1", FailureType.Crash),
+            createTestFailureGroup("g2", FailureType.ANR),
+        )
+        val dataSource = FakeFailuresDataSourceImpl(DataSourceResult.Success(groups))
+        val vm = FailuresViewModel(dataSource, this)
+
+        vm.onAction(FailuresAction.FilterByType(FailureType.ANR))
+
+        val state = vm.state.value as FailuresUiState.Content
+        assertEquals(FailureType.ANR, state.filterType)
+    }
+
+    @Test
+    fun `FilterByType with null clears filter`() = testScope.runTest {
+        val groups = listOf(createTestFailureGroup("g1"))
+        val dataSource = FakeFailuresDataSourceImpl(DataSourceResult.Success(groups))
+        val vm = FailuresViewModel(dataSource, this)
+
+        vm.onAction(FailuresAction.FilterByType(FailureType.Crash))
+        vm.onAction(FailuresAction.FilterByType(null))
+
+        val state = vm.state.value as FailuresUiState.Content
+        assertNull(state.filterType)
+    }
+
+    @Test
+    fun `SelectFailureById finds and selects failure`() = testScope.runTest {
+        val groups = listOf(
+            createTestFailureGroup("g1"),
+            createTestFailureGroup("g2"),
+        )
+        val dataSource = FakeFailuresDataSourceImpl(DataSourceResult.Success(groups))
+        val vm = FailuresViewModel(dataSource, this)
+
+        vm.onAction(FailuresAction.SelectFailureById("g2"))
+
+        val state = vm.state.value as FailuresUiState.Content
+        assertEquals("g2", state.selectedFailure?.id)
+    }
+
+    @Test
+    fun `SelectFailureById with unknown id does not select`() = testScope.runTest {
+        val groups = listOf(createTestFailureGroup("g1"))
+        val dataSource = FakeFailuresDataSourceImpl(DataSourceResult.Success(groups))
+        val vm = FailuresViewModel(dataSource, this)
+
+        vm.onAction(FailuresAction.SelectFailureById("nonexistent"))
+
+        val state = vm.state.value as FailuresUiState.Content
+        assertNull(state.selectedFailure)
+    }
+
+    @Test
+    fun `Refresh reloads data`() = testScope.runTest {
+        val dataSource = FakeFailuresDataSourceImpl(
+            DataSourceResult.Success(listOf(createTestFailureGroup("g1")))
+        )
+        val vm = FailuresViewModel(dataSource, this)
+
+        dataSource.result = DataSourceResult.Success(
+            listOf(createTestFailureGroup("g1"), createTestFailureGroup("g2"), createTestFailureGroup("g3"))
+        )
+        vm.onAction(FailuresAction.Refresh)
+
+        val state = vm.state.value as FailuresUiState.Content
+        assertEquals(3, state.failureGroups.size)
+    }
+
+    @Test
+    fun `UpdateGroups replaces failure groups in Content state`() = testScope.runTest {
+        val dataSource = FakeFailuresDataSourceImpl(
+            DataSourceResult.Success(listOf(createTestFailureGroup("g1")))
+        )
+        val vm = FailuresViewModel(dataSource, this)
+
+        val newGroups = listOf(createTestFailureGroup("g2"), createTestFailureGroup("g3"))
+        vm.onAction(FailuresAction.UpdateGroups(newGroups))
+
+        val state = vm.state.value as FailuresUiState.Content
+        assertEquals(2, state.failureGroups.size)
+        assertEquals("g2", state.failureGroups[0].id)
+    }
+
+    @Test
+    fun `UpdateGroups sets Content from Error state`() = testScope.runTest {
+        val dataSource = FakeFailuresDataSourceImpl(DataSourceResult.Error("initial error"))
+        val vm = FailuresViewModel(dataSource, this)
+        assertTrue(vm.state.value is FailuresUiState.Error)
+
+        val groups = listOf(createTestFailureGroup("g1"))
+        vm.onAction(FailuresAction.UpdateGroups(groups))
+
+        val state = vm.state.value as FailuresUiState.Content
+        assertEquals(1, state.failureGroups.size)
+    }
+
+    // -- Fakes --
+
+    private class FakeFailuresDataSourceImpl(
+        var result: DataSourceResult<List<FailureGroup>>,
+    ) : FailuresDataSource {
+        override suspend fun getFailureGroups(): DataSourceResult<List<FailureGroup>> = result
+        override suspend fun getTimelineData(
+            dateRange: DateRange,
+            aggregation: TimeAggregation,
+        ): DataSourceResult<TimelineData> = DataSourceResult.Success(
+            TimelineData(emptyList(), PeriodTotals(0, 0, 0, 0))
+        )
+    }
+
+    private class ThrowingFailuresDataSource(
+        private val exception: Exception,
+    ) : FailuresDataSource {
+        override suspend fun getFailureGroups(): DataSourceResult<List<FailureGroup>> = throw exception
+        override suspend fun getTimelineData(
+            dateRange: DateRange,
+            aggregation: TimeAggregation,
+        ): DataSourceResult<TimelineData> = throw exception
+    }
+}

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/navigation/NavigationViewModelTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/navigation/NavigationViewModelTest.kt
@@ -1,0 +1,171 @@
+package dev.jasonpearson.automobile.desktop.core.navigation
+
+import dev.jasonpearson.automobile.desktop.core.datasource.NavigationDataSource
+import dev.jasonpearson.automobile.desktop.core.datasource.NavigationGraph
+import dev.jasonpearson.automobile.desktop.core.datasource.Result
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class NavigationViewModelTest {
+
+    private val testDispatcher = UnconfinedTestDispatcher()
+    private val testScope = TestScope(testDispatcher)
+
+    private val testScreens = listOf(
+        ScreenNode("s1", "Login", "Composable", "com.app", 2, 0L),
+        ScreenNode("s2", "Home", "Composable", "com.app", 3, 1000L),
+    )
+    private val testTransitions = listOf(
+        ScreenTransition("t1", "Login", "Home", "tap", "Login Button", 100, 0.01f),
+    )
+    private val testGraph = NavigationGraph(screens = testScreens, transitions = testTransitions)
+
+    @Test
+    fun `initial state is Loading then transitions to Content on success`() = testScope.runTest {
+        val dataSource = FakeNavigationDataSourceImpl(Result.Success(testGraph))
+        val vm = NavigationViewModel(dataSource, this)
+
+        val state = vm.state.value
+        assertTrue("Expected Content but was $state", state is NavigationUiState.Content)
+        val content = state as NavigationUiState.Content
+        assertEquals(2, content.graph.screens.size)
+        assertEquals(1, content.graph.transitions.size)
+        assertEquals(NavigationSection.FlowMap, content.currentSection)
+    }
+
+    @Test
+    fun `transitions to Error state on data source error`() = testScope.runTest {
+        val dataSource = FakeNavigationDataSourceImpl(Result.Error("Network error"))
+        val vm = NavigationViewModel(dataSource, this)
+
+        val state = vm.state.value
+        assertTrue("Expected Error but was $state", state is NavigationUiState.Error)
+        assertEquals("Network error", (state as NavigationUiState.Error).message)
+    }
+
+    @Test
+    fun `transitions to Error state on exception`() = testScope.runTest {
+        val dataSource = ThrowingNavigationDataSource(RuntimeException("Boom"))
+        val vm = NavigationViewModel(dataSource, this)
+
+        val state = vm.state.value
+        assertTrue("Expected Error but was $state", state is NavigationUiState.Error)
+        assertEquals("Boom", (state as NavigationUiState.Error).message)
+    }
+
+    @Test
+    fun `SelectScreen action updates selectedScreenId and section`() = testScope.runTest {
+        val dataSource = FakeNavigationDataSourceImpl(Result.Success(testGraph))
+        val vm = NavigationViewModel(dataSource, this)
+
+        vm.onAction(NavigationAction.SelectScreen("s1"))
+
+        val state = vm.state.value as NavigationUiState.Content
+        assertEquals("s1", state.selectedScreenId)
+        assertEquals(NavigationSection.ScreenDetail, state.currentSection)
+    }
+
+    @Test
+    fun `SelectScreenByName action finds screen by name`() = testScope.runTest {
+        val dataSource = FakeNavigationDataSourceImpl(Result.Success(testGraph))
+        val vm = NavigationViewModel(dataSource, this)
+
+        vm.onAction(NavigationAction.SelectScreenByName("Home"))
+
+        val state = vm.state.value as NavigationUiState.Content
+        assertEquals("s2", state.selectedScreenId)
+        assertEquals(NavigationSection.ScreenDetail, state.currentSection)
+    }
+
+    @Test
+    fun `SelectScreenByName with unknown name does not change state`() = testScope.runTest {
+        val dataSource = FakeNavigationDataSourceImpl(Result.Success(testGraph))
+        val vm = NavigationViewModel(dataSource, this)
+
+        vm.onAction(NavigationAction.SelectScreenByName("NonExistent"))
+
+        val state = vm.state.value as NavigationUiState.Content
+        assertEquals(null, state.selectedScreenId)
+        assertEquals(NavigationSection.FlowMap, state.currentSection)
+    }
+
+    @Test
+    fun `BackToFlowMap resets section and selection`() = testScope.runTest {
+        val dataSource = FakeNavigationDataSourceImpl(Result.Success(testGraph))
+        val vm = NavigationViewModel(dataSource, this)
+
+        vm.onAction(NavigationAction.SelectScreen("s1"))
+        vm.onAction(NavigationAction.BackToFlowMap)
+
+        val state = vm.state.value as NavigationUiState.Content
+        assertEquals(null, state.selectedScreenId)
+        assertEquals(NavigationSection.FlowMap, state.currentSection)
+    }
+
+    @Test
+    fun `Refresh reloads data from source`() = testScope.runTest {
+        val dataSource = FakeNavigationDataSourceImpl(Result.Success(testGraph))
+        val vm = NavigationViewModel(dataSource, this)
+
+        // Change to a new graph on next call
+        val updatedGraph = NavigationGraph(
+            screens = listOf(ScreenNode("s3", "Settings", "Composable", "com.app", 1, 2000L)),
+            transitions = emptyList(),
+        )
+        dataSource.result = Result.Success(updatedGraph)
+
+        vm.onAction(NavigationAction.Refresh)
+
+        val state = vm.state.value as NavigationUiState.Content
+        assertEquals(1, state.graph.screens.size)
+        assertEquals("Settings", state.graph.screens.first().name)
+    }
+
+    @Test
+    fun `UpdateGraph updates graph in Content state`() = testScope.runTest {
+        val dataSource = FakeNavigationDataSourceImpl(Result.Success(testGraph))
+        val vm = NavigationViewModel(dataSource, this)
+
+        val newGraph = NavigationGraph(
+            screens = listOf(ScreenNode("s3", "Settings", "Composable", "com.app", 1, 2000L)),
+            transitions = emptyList(),
+        )
+        vm.onAction(NavigationAction.UpdateGraph(newGraph))
+
+        val state = vm.state.value as NavigationUiState.Content
+        assertEquals(1, state.graph.screens.size)
+        assertEquals("Settings", state.graph.screens.first().name)
+    }
+
+    @Test
+    fun `UpdateGraph sets Content from non-Content state`() = testScope.runTest {
+        val dataSource = FakeNavigationDataSourceImpl(Result.Error("initial error"))
+        val vm = NavigationViewModel(dataSource, this)
+        assertTrue(vm.state.value is NavigationUiState.Error)
+
+        vm.onAction(NavigationAction.UpdateGraph(testGraph))
+
+        val state = vm.state.value as NavigationUiState.Content
+        assertEquals(2, state.graph.screens.size)
+    }
+
+    // -- Fakes --
+
+    private class FakeNavigationDataSourceImpl(
+        var result: Result<NavigationGraph>,
+    ) : NavigationDataSource {
+        override suspend fun getNavigationGraph(): Result<NavigationGraph> = result
+    }
+
+    private class ThrowingNavigationDataSource(
+        private val exception: Exception,
+    ) : NavigationDataSource {
+        override suspend fun getNavigationGraph(): Result<NavigationGraph> = throw exception
+    }
+}


### PR DESCRIPTION
## Summary
- Add `NavigationViewModel` with State/Action/Effect pattern (Loading, Content, Error states; screen selection, graph updates)
- Add `FailuresViewModel` with State/Action/Effect pattern (Loading, Content, Error states; failure selection, filtering, group updates)
- 20 unit tests covering all state transitions for both ViewModels

## Context
This is WU-5 of the KMP Desktop App Learnings initiative (Priority Action #6: Per-dashboard ViewModels). These ViewModels extract state management out of composables into testable plain Kotlin classes, following the MoviesPot pattern with `MutableStateFlow` + `Channel<Effect>`.

## Test plan
- [x] `NavigationViewModelTest` passes (9 tests): Loading -> Content, Loading -> Error, SelectScreen, SelectScreenByName, BackToFlowMap, Refresh, UpdateGraph
- [x] `FailuresViewModelTest` passes (11 tests): Loading -> Content, Loading -> Error, SelectFailure, ClearSelection, FilterByType, SelectFailureById, Refresh, UpdateGroups
- [x] Full `desktop-core:test` suite passes
- [x] `desktop-core:compileKotlin` and `desktop-app:compileKotlin` both compile cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)