### PR TITLE
feat: add FakeAutoMobileClient and Turbine test dependency

### DIFF
--- a/android/desktop-core/build.gradle.kts
+++ b/android/desktop-core/build.gradle.kts
@@ -46,4 +46,5 @@ dependencies {
   testImplementation(libs.kotlin.test)
   testImplementation(libs.kotlinx.coroutines.test)
   testImplementation("junit:junit:4.13.2")
+  testImplementation(libs.turbine)
 }

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/testing/FakeAutoMobileClient.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/testing/FakeAutoMobileClient.kt
@@ -1,0 +1,279 @@
+package dev.jasonpearson.automobile.desktop.core.testing
+
+import dev.jasonpearson.automobile.desktop.core.daemon.AutoMobileClient
+import dev.jasonpearson.automobile.desktop.core.daemon.ClearKeyValueResult
+import dev.jasonpearson.automobile.desktop.core.daemon.ExecutePlanResult
+import dev.jasonpearson.automobile.desktop.core.daemon.FeatureFlagState
+import dev.jasonpearson.automobile.desktop.core.daemon.KillDeviceResult
+import dev.jasonpearson.automobile.desktop.core.daemon.McpResource
+import dev.jasonpearson.automobile.desktop.core.daemon.McpResourceContent
+import dev.jasonpearson.automobile.desktop.core.daemon.McpResourceTemplate
+import dev.jasonpearson.automobile.desktop.core.daemon.McpTool
+import dev.jasonpearson.automobile.desktop.core.daemon.ObserveResult
+import dev.jasonpearson.automobile.desktop.core.daemon.PerformanceAuditHistoryResult
+import dev.jasonpearson.automobile.desktop.core.daemon.RemoveKeyValueResult
+import dev.jasonpearson.automobile.desktop.core.daemon.SetActiveDeviceResult
+import dev.jasonpearson.automobile.desktop.core.daemon.SetKeyValueResult
+import dev.jasonpearson.automobile.desktop.core.daemon.StartDeviceResult
+import dev.jasonpearson.automobile.desktop.core.daemon.TestRecordingStartResult
+import dev.jasonpearson.automobile.desktop.core.daemon.TestRecordingStopResult
+import dev.jasonpearson.automobile.desktop.core.daemon.TestRunQuery
+import dev.jasonpearson.automobile.desktop.core.daemon.TestRunSummary
+import dev.jasonpearson.automobile.desktop.core.daemon.TestTimingQuery
+import dev.jasonpearson.automobile.desktop.core.daemon.TestTimingSummary
+import dev.jasonpearson.automobile.desktop.core.daemon.UpdateServiceResult
+import dev.jasonpearson.automobile.desktop.core.mcp.DaemonStatusResponse
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
+
+/**
+ * Reusable fake implementation of [AutoMobileClient] for testing.
+ *
+ * All methods record their call name in [calls] and return configurable values.
+ * Resource responses can be set per-URI via [setResourceResponseWithText].
+ */
+class FakeAutoMobileClient : AutoMobileClient {
+
+    /** Ordered list of method names that were called. */
+    val calls = mutableListOf<String>()
+
+    // -- Configurable return values --
+
+    override var transportName: String = "fake"
+    override var connectionDescription: String = "Fake client for testing"
+
+    var pingResult: () -> Unit = {}
+    var listResourcesResult: List<McpResource> = emptyList()
+    var listResourceTemplatesResult: List<McpResourceTemplate> = emptyList()
+    var listToolsResult: List<McpTool> = emptyList()
+    var getNavigationGraphResult: JsonElement = JsonObject(emptyMap())
+    var listFeatureFlagsResult: List<FeatureFlagState> = emptyList()
+    var setFeatureFlagResult: FeatureFlagState = FeatureFlagState(key = "", label = "", enabled = false)
+    var listPerformanceAuditResultsResult: PerformanceAuditHistoryResult =
+        PerformanceAuditHistoryResult()
+    var getTestTimingsResult: TestTimingSummary = TestTimingSummary()
+    var getTestRunsResult: TestRunSummary = TestRunSummary()
+    var startTestRecordingResult: TestRecordingStartResult =
+        TestRecordingStartResult(recordingId = "fake-id", startedAt = "2025-01-01T00:00:00Z")
+    var stopTestRecordingResult: TestRecordingStopResult = TestRecordingStopResult(
+        recordingId = "fake-id",
+        startedAt = "2025-01-01T00:00:00Z",
+        stoppedAt = "2025-01-01T00:00:01Z",
+        durationMs = 1000,
+        planName = "fake-plan",
+        planContent = "",
+        stepCount = 0,
+    )
+    var executePlanResult: ExecutePlanResult = ExecutePlanResult(success = true, executedSteps = 0, totalSteps = 0)
+    var startDeviceResult: StartDeviceResult = StartDeviceResult(success = true)
+    var setActiveDeviceResult: SetActiveDeviceResult = SetActiveDeviceResult(success = true)
+    var observeResult: ObserveResult = ObserveResult()
+    var killDeviceResult: KillDeviceResult = KillDeviceResult(success = true)
+    var getDaemonStatusResult: DaemonStatusResponse = DaemonStatusResponse()
+    var updateServiceResult: UpdateServiceResult = UpdateServiceResult(success = true)
+    var setKeyValueResult: SetKeyValueResult = SetKeyValueResult(success = true)
+    var removeKeyValueResult: RemoveKeyValueResult = RemoveKeyValueResult(success = true)
+    var clearKeyValueFileResult: ClearKeyValueResult = ClearKeyValueResult(success = true)
+    var callToolResult: JsonElement = JsonObject(emptyMap())
+    var throwOnReadResource: Exception? = null
+
+    // -- Resource response mapping --
+
+    private val resourceResponses = mutableMapOf<String, List<McpResourceContent>>()
+
+    /** Set a text resource response for a given URI. */
+    fun setResourceResponseWithText(uri: String, text: String) {
+        resourceResponses[uri] = listOf(
+            McpResourceContent(uri = uri, mimeType = "application/json", text = text),
+        )
+    }
+
+    /** Set raw resource content for a given URI. */
+    fun setResourceResponse(uri: String, contents: List<McpResourceContent>) {
+        resourceResponses[uri] = contents
+    }
+
+    // -- Recorded write calls --
+
+    data class SetKeyValueCall(
+        val deviceId: String,
+        val appId: String,
+        val fileName: String,
+        val key: String,
+        val value: String?,
+        val type: String,
+    )
+
+    data class RemoveKeyValueCall(
+        val deviceId: String,
+        val appId: String,
+        val fileName: String,
+        val key: String,
+    )
+
+    data class ClearKeyValueFileCall(
+        val deviceId: String,
+        val appId: String,
+        val fileName: String,
+    )
+
+    val setKeyValueCalls = mutableListOf<SetKeyValueCall>()
+    val removeKeyValueCalls = mutableListOf<RemoveKeyValueCall>()
+    val clearKeyValueFileCalls = mutableListOf<ClearKeyValueFileCall>()
+
+    // -- AutoMobileClient implementation --
+
+    override fun ping() {
+        calls.add("ping")
+        pingResult()
+    }
+
+    override fun listResources(): List<McpResource> {
+        calls.add("listResources")
+        return listResourcesResult
+    }
+
+    override fun listResourceTemplates(): List<McpResourceTemplate> {
+        calls.add("listResourceTemplates")
+        return listResourceTemplatesResult
+    }
+
+    override fun listTools(): List<McpTool> {
+        calls.add("listTools")
+        return listToolsResult
+    }
+
+    override fun readResource(uri: String): List<McpResourceContent> {
+        calls.add("readResource")
+        throwOnReadResource?.let { throw it }
+        return resourceResponses[uri] ?: emptyList()
+    }
+
+    override fun getNavigationGraph(platform: String): JsonElement {
+        calls.add("getNavigationGraph")
+        return getNavigationGraphResult
+    }
+
+    override fun listFeatureFlags(): List<FeatureFlagState> {
+        calls.add("listFeatureFlags")
+        return listFeatureFlagsResult
+    }
+
+    override fun setFeatureFlag(key: String, enabled: Boolean, config: JsonObject?): FeatureFlagState {
+        calls.add("setFeatureFlag")
+        return setFeatureFlagResult
+    }
+
+    override fun listPerformanceAuditResults(
+        startTime: String?,
+        endTime: String?,
+        limit: Int?,
+        offset: Int?,
+    ): PerformanceAuditHistoryResult {
+        calls.add("listPerformanceAuditResults")
+        return listPerformanceAuditResultsResult
+    }
+
+    override fun getTestTimings(query: TestTimingQuery): TestTimingSummary {
+        calls.add("getTestTimings")
+        return getTestTimingsResult
+    }
+
+    override fun getTestRuns(query: TestRunQuery): TestRunSummary {
+        calls.add("getTestRuns")
+        return getTestRunsResult
+    }
+
+    override fun startTestRecording(platform: String): TestRecordingStartResult {
+        calls.add("startTestRecording")
+        return startTestRecordingResult
+    }
+
+    override fun stopTestRecording(recordingId: String?, planName: String?): TestRecordingStopResult {
+        calls.add("stopTestRecording")
+        return stopTestRecordingResult
+    }
+
+    override fun executePlan(
+        planContent: String,
+        platform: String,
+        startStep: Int?,
+        sessionUuid: String?,
+    ): ExecutePlanResult {
+        calls.add("executePlan")
+        return executePlanResult
+    }
+
+    override fun startDevice(name: String, platform: String, deviceId: String?): StartDeviceResult {
+        calls.add("startDevice")
+        return startDeviceResult
+    }
+
+    override fun setActiveDevice(deviceId: String, platform: String): SetActiveDeviceResult {
+        calls.add("setActiveDevice")
+        return setActiveDeviceResult
+    }
+
+    override fun observe(platform: String): ObserveResult {
+        calls.add("observe")
+        return observeResult
+    }
+
+    override fun killDevice(name: String, deviceId: String, platform: String): KillDeviceResult {
+        calls.add("killDevice")
+        return killDeviceResult
+    }
+
+    override fun getDaemonStatus(): DaemonStatusResponse {
+        calls.add("getDaemonStatus")
+        return getDaemonStatusResult
+    }
+
+    override fun updateService(deviceId: String, platform: String): UpdateServiceResult {
+        calls.add("updateService")
+        return updateServiceResult
+    }
+
+    override fun setKeyValue(
+        deviceId: String,
+        appId: String,
+        fileName: String,
+        key: String,
+        value: String?,
+        type: String,
+    ): SetKeyValueResult {
+        calls.add("setKeyValue")
+        setKeyValueCalls.add(SetKeyValueCall(deviceId, appId, fileName, key, value, type))
+        return setKeyValueResult
+    }
+
+    override fun removeKeyValue(
+        deviceId: String,
+        appId: String,
+        fileName: String,
+        key: String,
+    ): RemoveKeyValueResult {
+        calls.add("removeKeyValue")
+        removeKeyValueCalls.add(RemoveKeyValueCall(deviceId, appId, fileName, key))
+        return removeKeyValueResult
+    }
+
+    override fun clearKeyValueFile(
+        deviceId: String,
+        appId: String,
+        fileName: String,
+    ): ClearKeyValueResult {
+        calls.add("clearKeyValueFile")
+        clearKeyValueFileCalls.add(ClearKeyValueFileCall(deviceId, appId, fileName))
+        return clearKeyValueFileResult
+    }
+
+    override fun callTool(name: String, arguments: JsonObject): JsonElement {
+        calls.add("callTool")
+        return callToolResult
+    }
+
+    override fun close() {
+        calls.add("close")
+    }
+}

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/TurbineExampleTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/TurbineExampleTest.kt
@@ -1,0 +1,66 @@
+package dev.jasonpearson.automobile.desktop.core.daemon
+
+import app.cash.turbine.test
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class TurbineExampleTest {
+
+    @Test
+    fun `StateFlow emits initial value`() = runBlocking {
+        val stateFlow = MutableStateFlow("initial")
+
+        stateFlow.test {
+            assertEquals("initial", awaitItem())
+            cancelAndConsumeRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `StateFlow emits updates`() = runBlocking {
+        val stateFlow = MutableStateFlow(0)
+
+        stateFlow.test {
+            assertEquals(0, awaitItem())
+
+            stateFlow.value = 1
+            assertEquals(1, awaitItem())
+
+            stateFlow.value = 2
+            assertEquals(2, awaitItem())
+
+            cancelAndConsumeRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `SharedFlow emits values to test`() = runBlocking {
+        val sharedFlow = MutableSharedFlow<String>()
+
+        sharedFlow.test {
+            sharedFlow.emit("hello")
+            assertEquals("hello", awaitItem())
+
+            sharedFlow.emit("world")
+            assertEquals("world", awaitItem())
+
+            cancelAndConsumeRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `StateFlow replays latest value on new collection`() = runBlocking {
+        val stateFlow = MutableStateFlow("a")
+        stateFlow.value = "b"
+        stateFlow.value = "c"
+
+        // A new collector sees only the latest value
+        stateFlow.test {
+            assertEquals("c", awaitItem())
+            cancelAndConsumeRemainingEvents()
+        }
+    }
+}

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/datasource/RealStorageDataSourceTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/datasource/RealStorageDataSourceTest.kt
@@ -1,18 +1,13 @@
 package dev.jasonpearson.automobile.desktop.core.datasource
 
-import dev.jasonpearson.automobile.desktop.core.daemon.AutoMobileClient
 import dev.jasonpearson.automobile.desktop.core.daemon.ClearKeyValueResult
 import dev.jasonpearson.automobile.desktop.core.daemon.McpConnectionException
-import dev.jasonpearson.automobile.desktop.core.daemon.McpResourceContent
 import dev.jasonpearson.automobile.desktop.core.daemon.RemoveKeyValueResult
 import dev.jasonpearson.automobile.desktop.core.daemon.SetKeyValueResult
-import dev.jasonpearson.automobile.desktop.core.daemon.TestRunQuery
-import dev.jasonpearson.automobile.desktop.core.daemon.TestTimingQuery
 import dev.jasonpearson.automobile.desktop.core.storage.KeyValueType
 import dev.jasonpearson.automobile.desktop.core.storage.StoragePlatform
+import dev.jasonpearson.automobile.desktop.core.testing.FakeAutoMobileClient
 import kotlinx.coroutines.runBlocking
-import kotlinx.serialization.json.JsonElement
-import kotlinx.serialization.json.JsonObject
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
@@ -32,7 +27,7 @@ class RealStorageDataSourceTest {
 
     @Test
     fun `getKeyValueFiles returns error when no deviceId`() = runBlocking {
-        val client = FakeStorageAutoMobileClient()
+        val client = FakeAutoMobileClient()
         val dataSource = RealStorageDataSource(
             clientProvider = { client },
             deviceId = null,
@@ -47,7 +42,7 @@ class RealStorageDataSourceTest {
 
     @Test
     fun `getKeyValueFiles returns error when no packageName`() = runBlocking {
-        val client = FakeStorageAutoMobileClient()
+        val client = FakeAutoMobileClient()
         val dataSource = RealStorageDataSource(
             clientProvider = { client },
             deviceId = "emulator-5554",
@@ -62,7 +57,7 @@ class RealStorageDataSourceTest {
 
     @Test
     fun `getKeyValueFiles successfully parses MCP files response`() = runBlocking {
-        val client = FakeStorageAutoMobileClient()
+        val client = FakeAutoMobileClient()
 
         // Set up files response
         val filesUri = "automobile:devices/emulator-5554/storage/com.example.app/files"
@@ -125,7 +120,7 @@ class RealStorageDataSourceTest {
 
     @Test
     fun `getKeyValueFiles handles MCP connection error`() = runBlocking {
-        val client = FakeStorageAutoMobileClient()
+        val client = FakeAutoMobileClient()
         client.throwOnReadResource = McpConnectionException("Connection failed")
 
         val dataSource = RealStorageDataSource(
@@ -142,7 +137,7 @@ class RealStorageDataSourceTest {
 
     @Test
     fun `getKeyValueFiles handles error in MCP response`() = runBlocking {
-        val client = FakeStorageAutoMobileClient()
+        val client = FakeAutoMobileClient()
 
         val filesUri = "automobile:devices/emulator-5554/storage/com.example.app/files"
         val filesResponse = """
@@ -166,7 +161,7 @@ class RealStorageDataSourceTest {
 
     @Test
     fun `getKeyValueFiles returns empty list when no files`() = runBlocking {
-        val client = FakeStorageAutoMobileClient()
+        val client = FakeAutoMobileClient()
 
         val filesUri = "automobile:devices/emulator-5554/storage/com.example.app/files"
         val filesResponse = """
@@ -194,7 +189,7 @@ class RealStorageDataSourceTest {
 
     @Test
     fun `getKeyValueFiles parses all value types correctly`() = runBlocking {
-        val client = FakeStorageAutoMobileClient()
+        val client = FakeAutoMobileClient()
 
         val filesUri = "automobile:devices/emulator-5554/storage/com.example.app/files"
         val filesResponse = """
@@ -263,7 +258,7 @@ class RealStorageDataSourceTest {
 
     @Test
     fun `getDatabases returns error when no deviceId`() = runBlocking {
-        val client = FakeStorageAutoMobileClient()
+        val client = FakeAutoMobileClient()
         val dataSource = RealStorageDataSource(
             clientProvider = { client },
             deviceId = null,
@@ -278,7 +273,7 @@ class RealStorageDataSourceTest {
 
     @Test
     fun `getDatabases returns error when no packageName`() = runBlocking {
-        val client = FakeStorageAutoMobileClient()
+        val client = FakeAutoMobileClient()
         val dataSource = RealStorageDataSource(
             clientProvider = { client },
             deviceId = "emulator-5554",
@@ -293,7 +288,7 @@ class RealStorageDataSourceTest {
 
     @Test
     fun `getDatabases successfully parses MCP databases response`() = runBlocking {
-        val client = FakeStorageAutoMobileClient()
+        val client = FakeAutoMobileClient()
 
         val dbsUri = "automobile:devices/emulator-5554/databases?appId=com.example.app"
         client.setResourceResponseWithText(dbsUri, """
@@ -362,7 +357,7 @@ class RealStorageDataSourceTest {
 
     @Test
     fun `setKeyValue returns error when no deviceId`() = runBlocking {
-        val client = FakeStorageAutoMobileClient()
+        val client = FakeAutoMobileClient()
         val dataSource = RealStorageDataSource(
             clientProvider = { client },
             deviceId = null,
@@ -377,7 +372,7 @@ class RealStorageDataSourceTest {
 
     @Test
     fun `setKeyValue returns error when no packageName`() = runBlocking {
-        val client = FakeStorageAutoMobileClient()
+        val client = FakeAutoMobileClient()
         val dataSource = RealStorageDataSource(
             clientProvider = { client },
             deviceId = "emulator-5554",
@@ -392,7 +387,7 @@ class RealStorageDataSourceTest {
 
     @Test
     fun `setKeyValue succeeds and passes correct arguments`() = runBlocking {
-        val client = FakeStorageAutoMobileClient()
+        val client = FakeAutoMobileClient()
         val dataSource = RealStorageDataSource(
             clientProvider = { client },
             deviceId = "emulator-5554",
@@ -413,7 +408,7 @@ class RealStorageDataSourceTest {
 
     @Test
     fun `setKeyValue passes null value correctly`() = runBlocking {
-        val client = FakeStorageAutoMobileClient()
+        val client = FakeAutoMobileClient()
         val dataSource = RealStorageDataSource(
             clientProvider = { client },
             deviceId = "emulator-5554",
@@ -428,7 +423,7 @@ class RealStorageDataSourceTest {
 
     @Test
     fun `setKeyValue returns error when client reports failure`() = runBlocking {
-        val client = FakeStorageAutoMobileClient()
+        val client = FakeAutoMobileClient()
         client.setKeyValueResult = SetKeyValueResult(success = false, message = "Write failed")
         val dataSource = RealStorageDataSource(
             clientProvider = { client },
@@ -456,7 +451,7 @@ class RealStorageDataSourceTest {
 
     @Test
     fun `removeKeyValue succeeds and passes correct arguments`() = runBlocking {
-        val client = FakeStorageAutoMobileClient()
+        val client = FakeAutoMobileClient()
         val dataSource = RealStorageDataSource(
             clientProvider = { client },
             deviceId = "emulator-5554",
@@ -475,7 +470,7 @@ class RealStorageDataSourceTest {
 
     @Test
     fun `removeKeyValue returns error when client reports failure`() = runBlocking {
-        val client = FakeStorageAutoMobileClient()
+        val client = FakeAutoMobileClient()
         client.removeKeyValueResult = RemoveKeyValueResult(success = false, message = "Key not found")
         val dataSource = RealStorageDataSource(
             clientProvider = { client },
@@ -503,7 +498,7 @@ class RealStorageDataSourceTest {
 
     @Test
     fun `clearKeyValueFile succeeds and passes correct arguments`() = runBlocking {
-        val client = FakeStorageAutoMobileClient()
+        val client = FakeAutoMobileClient()
         val dataSource = RealStorageDataSource(
             clientProvider = { client },
             deviceId = "emulator-5554",
@@ -521,7 +516,7 @@ class RealStorageDataSourceTest {
 
     @Test
     fun `clearKeyValueFile returns error when client reports failure`() = runBlocking {
-        val client = FakeStorageAutoMobileClient()
+        val client = FakeAutoMobileClient()
         client.clearKeyValueFileResult = ClearKeyValueResult(success = false, message = "Permission denied")
         val dataSource = RealStorageDataSource(
             clientProvider = { client },
@@ -534,85 +529,4 @@ class RealStorageDataSourceTest {
         assertTrue(result is Result.Error)
         assertTrue((result as Result.Error).message.contains("Permission denied"))
     }
-}
-
-/**
- * Fake AutoMobileClient for storage tests.
- */
-class FakeStorageAutoMobileClient : AutoMobileClient {
-    private val resourceResponses = mutableMapOf<String, McpResourceContent>()
-    var throwOnReadResource: McpConnectionException? = null
-    var readResourceCallCount = 0
-        private set
-
-    // Write operation results (configurable per test)
-    var setKeyValueResult = SetKeyValueResult(success = true)
-    var removeKeyValueResult = RemoveKeyValueResult(success = true)
-    var clearKeyValueFileResult = ClearKeyValueResult(success = true)
-
-    // Recorded write calls for assertion
-    data class SetKeyValueCall(val deviceId: String, val appId: String, val fileName: String, val key: String, val value: String?, val type: String)
-    data class RemoveKeyValueCall(val deviceId: String, val appId: String, val fileName: String, val key: String)
-    data class ClearKeyValueFileCall(val deviceId: String, val appId: String, val fileName: String)
-
-    val setKeyValueCalls = mutableListOf<SetKeyValueCall>()
-    val removeKeyValueCalls = mutableListOf<RemoveKeyValueCall>()
-    val clearKeyValueFileCalls = mutableListOf<ClearKeyValueFileCall>()
-
-    override val transportName: String = "fake"
-    override val connectionDescription: String = "Fake client for storage testing"
-
-    fun setResourceResponseWithText(uri: String, text: String) {
-        resourceResponses[uri] = McpResourceContent(
-            uri = uri,
-            mimeType = "application/json",
-            text = text
-        )
-    }
-
-    override fun readResource(uri: String): List<McpResourceContent> {
-        readResourceCallCount++
-        throwOnReadResource?.let { throw it }
-        return listOfNotNull(resourceResponses[uri])
-    }
-
-    override fun setKeyValue(deviceId: String, appId: String, fileName: String, key: String, value: String?, type: String): SetKeyValueResult {
-        setKeyValueCalls.add(SetKeyValueCall(deviceId, appId, fileName, key, value, type))
-        return setKeyValueResult
-    }
-
-    override fun removeKeyValue(deviceId: String, appId: String, fileName: String, key: String): RemoveKeyValueResult {
-        removeKeyValueCalls.add(RemoveKeyValueCall(deviceId, appId, fileName, key))
-        return removeKeyValueResult
-    }
-
-    override fun clearKeyValueFile(deviceId: String, appId: String, fileName: String): ClearKeyValueResult {
-        clearKeyValueFileCalls.add(ClearKeyValueFileCall(deviceId, appId, fileName))
-        return clearKeyValueFileResult
-    }
-
-    // Unused methods - throw to ensure they're not called unexpectedly
-    override fun ping() = notImplemented()
-    override fun listResources() = notImplemented()
-    override fun listResourceTemplates() = notImplemented()
-    override fun listTools() = notImplemented()
-    override fun getNavigationGraph(platform: String) = notImplemented()
-    override fun listFeatureFlags() = notImplemented()
-    override fun setFeatureFlag(key: String, enabled: Boolean, config: JsonObject?) = notImplemented()
-    override fun listPerformanceAuditResults(startTime: String?, endTime: String?, limit: Int?, offset: Int?) = notImplemented()
-    override fun getTestTimings(query: TestTimingQuery) = notImplemented()
-    override fun startTestRecording(platform: String) = notImplemented()
-    override fun stopTestRecording(recordingId: String?, planName: String?) = notImplemented()
-    override fun executePlan(planContent: String, platform: String, startStep: Int?, sessionUuid: String?) = notImplemented()
-    override fun startDevice(name: String, platform: String, deviceId: String?) = notImplemented()
-    override fun setActiveDevice(deviceId: String, platform: String) = notImplemented()
-    override fun getTestRuns(query: dev.jasonpearson.automobile.desktop.core.daemon.TestRunQuery) = notImplemented()
-    override fun observe(platform: String) = notImplemented()
-    override fun killDevice(name: String, deviceId: String, platform: String) = notImplemented()
-    override fun getDaemonStatus() = notImplemented()
-    override fun updateService(deviceId: String, platform: String) = notImplemented()
-    override fun callTool(name: String, arguments: JsonObject): JsonElement = notImplemented()
-
-    private fun notImplemented(): Nothing =
-        throw NotImplementedError("FakeStorageAutoMobileClient: method not implemented for testing")
 }

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/testing/FakeAutoMobileClientTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/testing/FakeAutoMobileClientTest.kt
@@ -1,0 +1,175 @@
+package dev.jasonpearson.automobile.desktop.core.testing
+
+import dev.jasonpearson.automobile.desktop.core.daemon.McpConnectionException
+import dev.jasonpearson.automobile.desktop.core.daemon.McpResource
+import dev.jasonpearson.automobile.desktop.core.daemon.McpTool
+import dev.jasonpearson.automobile.desktop.core.daemon.ObserveResult
+import dev.jasonpearson.automobile.desktop.core.daemon.ObserveScreenSize
+import dev.jasonpearson.automobile.desktop.core.daemon.SetKeyValueResult
+import dev.jasonpearson.automobile.desktop.core.daemon.StartDeviceResult
+import kotlinx.serialization.json.JsonObject
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class FakeAutoMobileClientTest {
+
+    @Test
+    fun `records method calls in order`() {
+        val client = FakeAutoMobileClient()
+
+        client.ping()
+        client.listTools()
+        client.observe()
+        client.close()
+
+        assertEquals(listOf("ping", "listTools", "observe", "close"), client.calls)
+    }
+
+    @Test
+    fun `returns configurable listTools result`() {
+        val client = FakeAutoMobileClient()
+        val tools = listOf(McpTool(name = "observe", description = "Observe screen"))
+        client.listToolsResult = tools
+
+        assertEquals(tools, client.listTools())
+    }
+
+    @Test
+    fun `returns configurable listResources result`() {
+        val client = FakeAutoMobileClient()
+        val resources = listOf(McpResource(uri = "automobile:devices", name = "devices"))
+        client.listResourcesResult = resources
+
+        assertEquals(resources, client.listResources())
+    }
+
+    @Test
+    fun `returns configurable observe result`() {
+        val client = FakeAutoMobileClient()
+        val result = ObserveResult(
+            updatedAt = 12345L,
+            screenSize = ObserveScreenSize(width = 1080, height = 1920),
+            rotation = 0,
+        )
+        client.observeResult = result
+
+        assertEquals(result, client.observe("android"))
+    }
+
+    @Test
+    fun `returns configurable startDevice result`() {
+        val client = FakeAutoMobileClient()
+        client.startDeviceResult = StartDeviceResult(success = true, deviceId = "emulator-5554")
+
+        val result = client.startDevice("Pixel", "android")
+        assertTrue(result.success)
+        assertEquals("emulator-5554", result.deviceId)
+    }
+
+    @Test
+    fun `readResource returns mapped response`() {
+        val client = FakeAutoMobileClient()
+        client.setResourceResponseWithText("automobile:test", """{"key": "value"}""")
+
+        val contents = client.readResource("automobile:test")
+        assertEquals(1, contents.size)
+        assertEquals("automobile:test", contents[0].uri)
+        assertEquals("""{"key": "value"}""", contents[0].text)
+    }
+
+    @Test
+    fun `readResource returns empty for unknown URI`() {
+        val client = FakeAutoMobileClient()
+
+        val contents = client.readResource("automobile:unknown")
+        assertTrue(contents.isEmpty())
+    }
+
+    @Test
+    fun `readResource throws when throwOnReadResource is set`() {
+        val client = FakeAutoMobileClient()
+        client.throwOnReadResource = McpConnectionException("Connection failed")
+
+        try {
+            client.readResource("automobile:test")
+            assertTrue("Should have thrown", false)
+        } catch (e: McpConnectionException) {
+            assertEquals("Connection failed", e.message)
+        }
+    }
+
+    @Test
+    fun `records setKeyValue calls with arguments`() {
+        val client = FakeAutoMobileClient()
+
+        client.setKeyValue("device-1", "com.app", "prefs", "key", "value", "STRING")
+
+        val call = client.setKeyValueCalls.single()
+        assertEquals("device-1", call.deviceId)
+        assertEquals("com.app", call.appId)
+        assertEquals("prefs", call.fileName)
+        assertEquals("key", call.key)
+        assertEquals("value", call.value)
+        assertEquals("STRING", call.type)
+        assertEquals(listOf("setKeyValue"), client.calls)
+    }
+
+    @Test
+    fun `records removeKeyValue calls with arguments`() {
+        val client = FakeAutoMobileClient()
+
+        client.removeKeyValue("device-1", "com.app", "prefs", "old_key")
+
+        val call = client.removeKeyValueCalls.single()
+        assertEquals("device-1", call.deviceId)
+        assertEquals("com.app", call.appId)
+        assertEquals("prefs", call.fileName)
+        assertEquals("old_key", call.key)
+    }
+
+    @Test
+    fun `records clearKeyValueFile calls with arguments`() {
+        val client = FakeAutoMobileClient()
+
+        client.clearKeyValueFile("device-1", "com.app", "prefs")
+
+        val call = client.clearKeyValueFileCalls.single()
+        assertEquals("device-1", call.deviceId)
+        assertEquals("com.app", call.appId)
+        assertEquals("prefs", call.fileName)
+    }
+
+    @Test
+    fun `returns configurable setKeyValue failure`() {
+        val client = FakeAutoMobileClient()
+        client.setKeyValueResult = SetKeyValueResult(success = false, message = "Write failed")
+
+        val result = client.setKeyValue("d", "a", "f", "k", "v", "STRING")
+        assertEquals(false, result.success)
+        assertEquals("Write failed", result.message)
+    }
+
+    @Test
+    fun `callTool records call and returns configured result`() {
+        val client = FakeAutoMobileClient()
+
+        client.callTool("observe", JsonObject(emptyMap()))
+
+        assertEquals(listOf("callTool"), client.calls)
+    }
+
+    @Test
+    fun `defaults return sensible empty values`() {
+        val client = FakeAutoMobileClient()
+
+        assertTrue(client.listResources().isEmpty())
+        assertTrue(client.listResourceTemplates().isEmpty())
+        assertTrue(client.listTools().isEmpty())
+        assertTrue(client.listFeatureFlags().isEmpty())
+        assertTrue(client.startDevice("name", "android").success)
+        assertTrue(client.killDevice("name", "id", "android").success)
+        assertTrue(client.setActiveDevice("id", "android").success)
+        assertTrue(client.updateService("id", "android").success)
+    }
+}

--- a/android/gradle/libs.versions.toml
+++ b/android/gradle/libs.versions.toml
@@ -46,6 +46,7 @@ robolectric = "4.16.1"
 snakeyaml = "2.6"
 json-schema-validator = "3.0.1"
 test-junit = "4.13.2"
+turbine = "1.2.0"
 test-androidx-junit = "1.3.0"
 test-androidx-espresso = "3.7.0"
 
@@ -97,6 +98,7 @@ navigation3-runtime = { module = "androidx.navigation3:navigation3-runtime", ver
 navigation3-ui = { module = "androidx.navigation3:navigation3-ui", version.ref = "navigation3" }
 
 robolectric = { module = "org.robolectric:robolectric", version.ref = "robolectric" }
+turbine = { module = "app.cash.turbine:turbine", version.ref = "turbine" }
 snakeyaml = { module = "org.yaml:snakeyaml", version.ref = "snakeyaml" }
 json-schema-validator = { module = "com.networknt:json-schema-validator", version.ref = "json-schema-validator" }
 


### PR DESCRIPTION
## Summary
- Add Turbine 1.2.0 as a test dependency for Flow testing in desktop-core
- Create reusable `FakeAutoMobileClient` in `testing` package with configurable return values, call recording, and per-URI resource responses
- Migrate `RealStorageDataSourceTest` from inline `FakeStorageAutoMobileClient` to shared `FakeAutoMobileClient`
- Add `TurbineExampleTest` demonstrating StateFlow/SharedFlow testing with Turbine's `flow.test { awaitItem() }` pattern

## Test plan
- [x] `./gradlew :desktop-core:test` passes (196 tests)
- [x] `./gradlew :desktop-core:compileKotlin` succeeds
- [x] `./gradlew :desktop-app:compileKotlin` succeeds
- [x] FakeAutoMobileClientTest verifies configurable returns and call recording
- [x] TurbineExampleTest demonstrates Turbine patterns with StateFlow and SharedFlow
- [x] RealStorageDataSourceTest works with shared FakeAutoMobileClient

🤖 Generated with [Claude Code](https://claude.com/claude-code)