### PR TITLE
feat: add Metro DI framework setup

### DIFF
--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -19,6 +19,7 @@ plugins {
   alias(libs.plugins.kotlin.serialization) apply false
   alias(libs.plugins.compose.compiler) apply false
   alias(libs.plugins.mavenPublish) apply false
+  alias(libs.plugins.metro) apply false
 }
 
 // Read version from gradle.properties

--- a/android/desktop-app/build.gradle.kts
+++ b/android/desktop-app/build.gradle.kts
@@ -5,6 +5,7 @@ plugins {
   alias(libs.plugins.kotlin.serialization)
   kotlin("plugin.compose")
   alias(libs.plugins.compose.multiplatform)
+  alias(libs.plugins.metro)
 }
 
 repositories {
@@ -32,6 +33,9 @@ dependencies {
   // Kotlin ecosystem
   implementation(libs.kotlinx.coroutines)
   implementation(libs.kotlinx.serialization)
+
+  // Metro DI
+  implementation(libs.metro.runtime)
 
   // Test dependencies
   testImplementation(libs.kotlin.test)

--- a/android/desktop-app/src/main/kotlin/dev/jasonpearson/automobile/desktop/Main.kt
+++ b/android/desktop-app/src/main/kotlin/dev/jasonpearson/automobile/desktop/Main.kt
@@ -7,6 +7,8 @@ import androidx.compose.ui.window.Window
 import androidx.compose.ui.window.WindowPosition
 import androidx.compose.ui.window.application
 import androidx.compose.ui.window.rememberWindowState
+import dev.jasonpearson.automobile.desktop.di.AutoMobileGraph
+import dev.zacsweers.metro.createGraphFactory
 import java.io.RandomAccessFile
 import java.nio.channels.FileLock
 import java.nio.file.Path
@@ -36,6 +38,11 @@ fun main() {
     System.err.println("AutoMobile Desktop is already running. Exiting.")
     return
   }
+
+  // Create the dependency graph via Metro-generated factory.
+  // TODO: Pass graph dependencies to AutoMobileDesktopApp once UI is wired to DI.
+  @Suppress("UNUSED_VARIABLE")
+  val graph = createGraphFactory<AutoMobileGraph.Factory>().create()
 
   // Force dark window decorations on macOS
   System.setProperty("apple.awt.application.appearance", "NSAppearanceNameDarkAqua")

--- a/android/desktop-app/src/main/kotlin/dev/jasonpearson/automobile/desktop/di/AutoMobileGraph.kt
+++ b/android/desktop-app/src/main/kotlin/dev/jasonpearson/automobile/desktop/di/AutoMobileGraph.kt
@@ -1,0 +1,30 @@
+package dev.jasonpearson.automobile.desktop.di
+
+import dev.jasonpearson.automobile.desktop.core.daemon.AutoMobileClient
+import dev.jasonpearson.automobile.desktop.core.di.AppScope
+import dev.jasonpearson.automobile.desktop.core.di.SingleIn
+import dev.jasonpearson.automobile.desktop.core.settings.SettingsProvider
+import dev.zacsweers.metro.DependencyGraph
+
+/**
+ * Application-level dependency graph for the AutoMobile desktop app.
+ *
+ * This graph is the root of the dependency tree and lives for the entire app lifecycle.
+ * All dependencies contributed with `@ContributesTo(AppScope::class)` will be included here.
+ */
+@DependencyGraph(scope = AppScope::class)
+@SingleIn(AppScope::class)
+interface AutoMobileGraph {
+
+    /** The MCP client for communicating with the AutoMobile daemon. */
+    val autoMobileClient: AutoMobileClient
+
+    /** Application settings provider. */
+    val settingsProvider: SettingsProvider
+
+    /** Factory for creating the graph. Metro generates the implementation. */
+    @DependencyGraph.Factory
+    fun interface Factory {
+        fun create(): AutoMobileGraph
+    }
+}

--- a/android/desktop-core/build.gradle.kts
+++ b/android/desktop-core/build.gradle.kts
@@ -3,6 +3,7 @@ plugins {
   alias(libs.plugins.kotlin.serialization)
   kotlin("plugin.compose")
   alias(libs.plugins.compose.multiplatform)
+  alias(libs.plugins.metro)
 }
 
 repositories {
@@ -41,6 +42,9 @@ dependencies {
   // YAML and JSON schema validation
   implementation(libs.snakeyaml)
   implementation(libs.json.schema.validator)
+
+  // Metro DI
+  implementation(libs.metro.runtime)
 
   // Test dependencies
   testImplementation(libs.kotlin.test)

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/di/AppScope.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/di/AppScope.kt
@@ -1,0 +1,11 @@
+package dev.jasonpearson.automobile.desktop.core.di
+
+/**
+ * Marker class representing the application scope in the Metro DI graph.
+ *
+ * Use this with:
+ * - `@ContributesTo(AppScope::class)` to contribute modules to the app graph
+ * - `@ContributesBinding(AppScope::class)` to contribute interface implementations
+ * - `@SingleIn(AppScope::class)` to scope dependencies to the application lifetime
+ */
+abstract class AppScope private constructor()

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/di/ApplicationModule.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/di/ApplicationModule.kt
@@ -1,0 +1,28 @@
+package dev.jasonpearson.automobile.desktop.core.di
+
+import dev.jasonpearson.automobile.desktop.core.daemon.AutoMobileClient
+import dev.jasonpearson.automobile.desktop.core.daemon.McpClientFactory
+import dev.jasonpearson.automobile.desktop.core.settings.FakeSettingsProvider
+import dev.jasonpearson.automobile.desktop.core.settings.SettingsProvider
+import dev.zacsweers.metro.ContributesTo
+import dev.zacsweers.metro.Provides
+
+/** Provides application-level dependencies for the desktop app. */
+@ContributesTo(AppScope::class)
+interface ApplicationModule {
+
+    companion object {
+
+        @Provides
+        @SingleIn(AppScope::class)
+        fun provideAutoMobileClient(): AutoMobileClient {
+            return McpClientFactory.createPreferred(null)
+        }
+
+        @Provides
+        @SingleIn(AppScope::class)
+        fun provideSettingsProvider(): SettingsProvider {
+            return FakeSettingsProvider()
+        }
+    }
+}

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/di/SingleIn.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/di/SingleIn.kt
@@ -1,0 +1,21 @@
+package dev.jasonpearson.automobile.desktop.core.di
+
+import dev.zacsweers.metro.Scope
+import kotlin.annotation.AnnotationRetention.RUNTIME
+import kotlin.reflect.KClass
+
+/**
+ * Custom scope annotation that provides type-safe scoping for dependencies.
+ *
+ * Unlike a generic singleton, this annotation requires you to specify which scope the dependency is
+ * singleton within, making it explicit and preventing accidental scope leaks.
+ *
+ * Usage:
+ * ```
+ * @SingleIn(AppScope::class)
+ * class MyRepository @Inject constructor(...)
+ * ```
+ *
+ * @param scope The scope class that this dependency is singleton within
+ */
+@Scope @Retention(RUNTIME) annotation class SingleIn(val scope: KClass<*>)

--- a/android/gradle/libs.versions.toml
+++ b/android/gradle/libs.versions.toml
@@ -66,6 +66,7 @@ okhttp = "5.3.2"
 mavenpublish = "0.36.0"
 dokka = "2.2.0"
 compose-multiplatform = "1.10.3"
+metro = "0.12.0"
 
 [plugins]
 compose-compiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "build-kotlin" }
@@ -76,6 +77,7 @@ kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", versi
 mavenPublish = { id = "com.vanniktech.maven.publish", version.ref = "mavenpublish" }
 dokka = { id = "org.jetbrains.dokka", version.ref = "dokka" }
 compose-multiplatform = { id = "org.jetbrains.compose", version.ref = "compose-multiplatform" }
+metro = { id = "dev.zacsweers.metro", version.ref = "metro" }
 
 [libraries]
 androidx-core-splashscreen = { module = "androidx.core:core-splashscreen", version.ref = "core-splashscreen" }
@@ -92,6 +94,7 @@ kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test" }
 kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "kotlinx-coroutines-test" }
 kotlinx-coroutines = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "build-kotlin-coroutines" }
 kotlinx-serialization = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinx-serialization-json" }
+metro-runtime = { module = "dev.zacsweers.metro:runtime", version.ref = "metro" }
 mockk = { module = "io.mockk:mockk", version.ref = "mockk" }
 navigation3-runtime = { module = "androidx.navigation3:navigation3-runtime", version.ref = "navigation3" }
 navigation3-ui = { module = "androidx.navigation3:navigation3-ui", version.ref = "navigation3" }


### PR DESCRIPTION
## Summary
- Add Metro 0.12.0 plugin and runtime to version catalog and build files
- Create AppScope marker, SingleIn annotation, ApplicationModule with @Provides
- Create AutoMobileGraph @DependencyGraph with Factory in desktop-app
- Wire graph creation in Main.kt via createGraphFactory

## Test plan
- [ ] Project compiles with Metro KSP code generation
- [ ] Desktop app builds successfully
- [ ] Existing tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)