### PR TITLE
fix: add explicit buffer.flush() to flaky network interceptor tests

### DIFF
--- a/android/auto-mobile-sdk/src/test/kotlin/dev/jasonpearson/automobile/sdk/network/AutoMobileNetworkInterceptorTest.kt
+++ b/android/auto-mobile-sdk/src/test/kotlin/dev/jasonpearson/automobile/sdk/network/AutoMobileNetworkInterceptorTest.kt
@@ -74,6 +74,7 @@ class AutoMobileNetworkInterceptorTest {
             .build()
 
         interceptor.intercept(fakeChain(request = request, responseCode = 200))
+        buffer.flush()
 
         assertEquals(1, flushed.size)
         val event = flushed[0][0] as SdkNetworkRequestEvent
@@ -93,6 +94,7 @@ class AutoMobileNetworkInterceptorTest {
         val body = "x".repeat(1024)
 
         interceptor.intercept(fakeChain(responseBody = body))
+        buffer.flush()
 
         val event = flushed[0][0] as SdkNetworkRequestEvent
         assertEquals(1024L, event.responseBodySize)
@@ -104,6 +106,7 @@ class AutoMobileNetworkInterceptorTest {
         val interceptor = AutoMobileNetworkInterceptor(buffer)
 
         interceptor.intercept(fakeChain(protocol = Protocol.HTTP_2))
+        buffer.flush()
 
         val event = flushed[0][0] as SdkNetworkRequestEvent
         assertEquals("h2", event.protocol)
@@ -117,6 +120,7 @@ class AutoMobileNetworkInterceptorTest {
         assertFailsWith<IOException> {
             interceptor.intercept(fakeChain(throwOnProceed = IOException("Connection refused")))
         }
+        buffer.flush()
 
         assertEquals(1, flushed.size)
         val event = flushed[0][0] as SdkNetworkRequestEvent
@@ -145,6 +149,7 @@ class AutoMobileNetworkInterceptorTest {
             .build()
 
         interceptor.intercept(fakeChain(request = request, responseCode = 201))
+        buffer.flush()
 
         val event = flushed[0][0] as SdkNetworkRequestEvent
         assertEquals("POST", event.method)
@@ -158,6 +163,7 @@ class AutoMobileNetworkInterceptorTest {
         val interceptor = AutoMobileNetworkInterceptor(buffer)
 
         interceptor.intercept(fakeChain())
+        buffer.flush()
 
         val event = flushed[0][0] as SdkNetworkRequestEvent
         assertTrue(event.durationMs >= 0, "Duration should be non-negative")
@@ -176,6 +182,7 @@ class AutoMobileNetworkInterceptorTest {
             .build()
 
         interceptor.intercept(fakeChain(request = request))
+        buffer.flush()
 
         val event = flushed[0][0] as SdkNetworkRequestEvent
         assertNotNull(event.requestHeaders)
@@ -189,6 +196,7 @@ class AutoMobileNetworkInterceptorTest {
         val interceptor = AutoMobileNetworkInterceptor(buffer, captureHeaders = true)
 
         interceptor.intercept(fakeChain())
+        buffer.flush()
 
         val event = flushed[0][0] as SdkNetworkRequestEvent
         assertNotNull(event.responseHeaders)
@@ -202,6 +210,7 @@ class AutoMobileNetworkInterceptorTest {
         val interceptor = AutoMobileNetworkInterceptor(buffer, captureHeaders = false)
 
         interceptor.intercept(fakeChain())
+        buffer.flush()
 
         val event = flushed[0][0] as SdkNetworkRequestEvent
         assertNull(event.requestHeaders)
@@ -220,6 +229,7 @@ class AutoMobileNetworkInterceptorTest {
             .build()
 
         interceptor.intercept(fakeChain(request = request, responseCode = 201))
+        buffer.flush()
 
         val event = flushed[0][0] as SdkNetworkRequestEvent
         assertEquals("""{"name":"test"}""", event.requestBody)
@@ -231,6 +241,7 @@ class AutoMobileNetworkInterceptorTest {
         val interceptor = AutoMobileNetworkInterceptor(buffer, captureBodies = true)
 
         interceptor.intercept(fakeChain(responseBody = """{"ok":true}"""))
+        buffer.flush()
 
         val event = flushed[0][0] as SdkNetworkRequestEvent
         assertEquals("""{"ok":true}""", event.responseBody)
@@ -246,6 +257,7 @@ class AutoMobileNetworkInterceptorTest {
             .build()
 
         interceptor.intercept(fakeChain(request = request))
+        buffer.flush()
 
         val event = flushed[0][0] as SdkNetworkRequestEvent
         assertNull(event.requestBody)
@@ -262,6 +274,7 @@ class AutoMobileNetworkInterceptorTest {
             .build()
 
         interceptor.intercept(fakeChain(request = request))
+        buffer.flush()
 
         val event = flushed[0][0] as SdkNetworkRequestEvent
         assertNull(event.requestBody) // image/png is not a text type
@@ -273,6 +286,7 @@ class AutoMobileNetworkInterceptorTest {
         val interceptor = AutoMobileNetworkInterceptor(buffer)
 
         interceptor.intercept(fakeChain())
+        buffer.flush()
 
         val event = flushed[0][0] as SdkNetworkRequestEvent
         assertEquals("application/json", event.contentType)
@@ -290,6 +304,7 @@ class AutoMobileNetworkInterceptorTest {
         assertFailsWith<IOException> {
             interceptor.intercept(fakeChain(request = request, throwOnProceed = IOException("timeout")))
         }
+        buffer.flush()
 
         val event = flushed[0][0] as SdkNetworkRequestEvent
         assertNotNull(event.requestHeaders)
@@ -342,6 +357,7 @@ class AutoMobileNetworkInterceptorTest {
         assertEquals(false, chainCalled)
         assertEquals(503, response.code)
         assertEquals("""{"error":"service unavailable"}""", response.body?.string())
+        buffer.flush()
 
         val event = flushed[0][0] as SdkNetworkRequestEvent
         assertEquals(503, event.statusCode)
@@ -356,6 +372,7 @@ class AutoMobileNetworkInterceptorTest {
         val response = interceptor.intercept(fakeChain(responseCode = 200))
 
         assertEquals(200, response.code)
+        buffer.flush()
         val event = flushed[0][0] as SdkNetworkRequestEvent
         assertNull(event.error)
     }
@@ -371,6 +388,7 @@ class AutoMobileNetworkInterceptorTest {
         val response = interceptor.intercept(fakeChain())
 
         assertEquals(500, response.code)
+        buffer.flush()
         val event = flushed[0][0] as SdkNetworkRequestEvent
         assertEquals(500, event.statusCode)
         assertEquals("simulated:http500", event.error)
@@ -387,6 +405,7 @@ class AutoMobileNetworkInterceptorTest {
         assertFailsWith<java.net.SocketTimeoutException> {
             interceptor.intercept(fakeChain())
         }
+        buffer.flush()
 
         val event = flushed[0][0] as SdkNetworkRequestEvent
         assertEquals("simulated:timeout", event.error)
@@ -468,6 +487,7 @@ class AutoMobileNetworkInterceptorTest {
         val interceptor = AutoMobileNetworkInterceptor(buffer)
 
         interceptor.intercept(fakeChain())
+        buffer.flush()
 
         val event = flushed[0][0] as SdkNetworkRequestEvent
         assertNull(event.requestHeaders)


### PR DESCRIPTION
## Summary
- Added `buffer.flush()` before every `flushed[0][0]` access in `AutoMobileNetworkInterceptorTest` (20 tests)
- The `SdkEventBuffer` with `maxBufferSize = 1` relied on synchronous flush-on-add, which races under Jacoco instrumentation on CI, causing `IndexOutOfBoundsException`
- Explicit flush ensures deterministic event delivery regardless of instrumentation timing

## Test plan
- [x] All 20 tests in `AutoMobileNetworkInterceptorTest` pass locally
- [x] Tests pass with Jacoco coverage instrumentation (`testDebugUnitTest` + `createDebugUnitTestCoverageReport --rerun`)
- [ ] CI "Kotlin Code Coverage" check passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)