### PR TITLE
feat: add breadcrumb trail for iOS SDK crash context

### DIFF
--- a/ios/auto-mobile-sdk/Sources/AutoMobileSDK/Breadcrumbs/BreadcrumbTrail.swift
+++ b/ios/auto-mobile-sdk/Sources/AutoMobileSDK/Breadcrumbs/BreadcrumbTrail.swift
@@ -1,0 +1,93 @@
+import Foundation
+
+public enum BreadcrumbCategory: String, Codable, Sendable {
+    case navigation, tap, lifecycle, network, log, custom
+}
+
+public struct Breadcrumb: Codable, Sendable {
+    public let timestamp: TimeInterval
+    public let category: BreadcrumbCategory
+    public let message: String
+    public let metadata: [String: String]
+
+    public init(
+        timestamp: TimeInterval = Date().timeIntervalSince1970,
+        category: BreadcrumbCategory,
+        message: String,
+        metadata: [String: String] = [:]
+    ) {
+        self.timestamp = timestamp
+        self.category = category
+        self.message = message
+        self.metadata = metadata
+    }
+}
+
+public protocol BreadcrumbTracking: AnyObject, Sendable {
+    func add(_ breadcrumb: Breadcrumb)
+    func snapshot() -> [Breadcrumb]
+    func clear()
+}
+
+/// Thread-safe ring buffer of recent breadcrumbs.
+public final class BreadcrumbTrail: BreadcrumbTracking, @unchecked Sendable {
+    private let lock = NSLock()
+    private let maxSize: Int
+    private var buffer: [Breadcrumb] = []
+
+    public init(maxSize: Int = 100) {
+        self.maxSize = maxSize
+        buffer.reserveCapacity(maxSize)
+    }
+
+    public func add(_ breadcrumb: Breadcrumb) {
+        lock.lock()
+        if buffer.count >= maxSize {
+            buffer.removeFirst()
+        }
+        buffer.append(breadcrumb)
+        lock.unlock()
+    }
+
+    public func snapshot() -> [Breadcrumb] {
+        lock.lock()
+        defer { lock.unlock() }
+        return Array(buffer)
+    }
+
+    public func clear() {
+        lock.lock()
+        buffer.removeAll(keepingCapacity: true)
+        lock.unlock()
+    }
+
+    // MARK: - Disk Persistence for Crash Resilience
+
+    /// Write current breadcrumbs to disk for crash recovery.
+    public func writeToDisk(directory: URL? = nil) {
+        let dir = directory ?? Self.defaultDirectory()
+        let fileURL = dir.appendingPathComponent("automobile_breadcrumbs.json")
+        let crumbs = snapshot()
+        guard let data = try? JSONEncoder().encode(crumbs) else { return }
+        try? data.write(to: fileURL, options: .atomic)
+    }
+
+    /// Load breadcrumbs saved from a previous session.
+    public static func loadFromDisk(directory: URL? = nil) -> [Breadcrumb]? {
+        let dir = directory ?? defaultDirectory()
+        let fileURL = dir.appendingPathComponent("automobile_breadcrumbs.json")
+        guard let data = try? Data(contentsOf: fileURL) else { return nil }
+        return try? JSONDecoder().decode([Breadcrumb].self, from: data)
+    }
+
+    /// Remove persisted breadcrumbs file.
+    public static func clearDisk(directory: URL? = nil) {
+        let dir = directory ?? defaultDirectory()
+        let fileURL = dir.appendingPathComponent("automobile_breadcrumbs.json")
+        try? FileManager.default.removeItem(at: fileURL)
+    }
+
+    private static func defaultDirectory() -> URL {
+        FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first!
+    }
+}

--- a/ios/auto-mobile-sdk/Tests/AutoMobileSDKTests/BreadcrumbTrailTests.swift
+++ b/ios/auto-mobile-sdk/Tests/AutoMobileSDKTests/BreadcrumbTrailTests.swift
@@ -1,0 +1,121 @@
+import XCTest
+@testable import AutoMobileSDK
+
+final class BreadcrumbTrailTests: XCTestCase {
+
+    func testAddAndSnapshot() {
+        let trail = BreadcrumbTrail(maxSize: 10)
+        trail.add(Breadcrumb(category: .navigation, message: "HomeScreen"))
+        trail.add(Breadcrumb(category: .tap, message: "Button tapped"))
+
+        let crumbs = trail.snapshot()
+        XCTAssertEqual(crumbs.count, 2)
+        XCTAssertEqual(crumbs[0].category, .navigation)
+        XCTAssertEqual(crumbs[0].message, "HomeScreen")
+        XCTAssertEqual(crumbs[1].category, .tap)
+        XCTAssertEqual(crumbs[1].message, "Button tapped")
+    }
+
+    func testRingBufferOverflow() {
+        let maxSize = 5
+        let trail = BreadcrumbTrail(maxSize: maxSize)
+
+        for i in 0..<(maxSize + 10) {
+            trail.add(Breadcrumb(category: .custom, message: "msg-\(i)"))
+        }
+
+        let crumbs = trail.snapshot()
+        XCTAssertEqual(crumbs.count, maxSize)
+        // Only the last `maxSize` items should remain
+        XCTAssertEqual(crumbs.first?.message, "msg-10")
+        XCTAssertEqual(crumbs.last?.message, "msg-14")
+    }
+
+    func testClearEmpties() {
+        let trail = BreadcrumbTrail(maxSize: 10)
+        trail.add(Breadcrumb(category: .log, message: "hello"))
+        XCTAssertEqual(trail.snapshot().count, 1)
+
+        trail.clear()
+        XCTAssertTrue(trail.snapshot().isEmpty)
+    }
+
+    func testSnapshotIsACopy() {
+        let trail = BreadcrumbTrail(maxSize: 10)
+        trail.add(Breadcrumb(category: .lifecycle, message: "foreground"))
+
+        let snap1 = trail.snapshot()
+        trail.add(Breadcrumb(category: .lifecycle, message: "background"))
+        let snap2 = trail.snapshot()
+
+        XCTAssertEqual(snap1.count, 1)
+        XCTAssertEqual(snap2.count, 2)
+    }
+
+    func testThreadSafetyConcurrentAdds() {
+        let trail = BreadcrumbTrail(maxSize: 200)
+        let iterations = 100
+        let group = DispatchGroup()
+
+        for i in 0..<iterations {
+            group.enter()
+            DispatchQueue.global().async {
+                trail.add(Breadcrumb(category: .custom, message: "concurrent-\(i)"))
+                group.leave()
+            }
+        }
+
+        group.wait()
+        XCTAssertEqual(trail.snapshot().count, iterations)
+    }
+
+    func testMetadataPreserved() {
+        let trail = BreadcrumbTrail(maxSize: 10)
+        let meta = ["key": "value", "screen": "home"]
+        trail.add(Breadcrumb(category: .network, message: "GET /api", metadata: meta))
+
+        let crumb = trail.snapshot().first!
+        XCTAssertEqual(crumb.metadata["key"], "value")
+        XCTAssertEqual(crumb.metadata["screen"], "home")
+    }
+
+    // MARK: - Disk Persistence
+
+    func testWriteAndLoadFromDisk() throws {
+        let tmpDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: tmpDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tmpDir) }
+
+        let trail = BreadcrumbTrail(maxSize: 10)
+        trail.add(Breadcrumb(timestamp: 1000, category: .navigation, message: "Screen1"))
+        trail.add(Breadcrumb(timestamp: 2000, category: .tap, message: "Button"))
+        trail.writeToDisk(directory: tmpDir)
+
+        let loaded = BreadcrumbTrail.loadFromDisk(directory: tmpDir)
+        XCTAssertNotNil(loaded)
+        XCTAssertEqual(loaded?.count, 2)
+        XCTAssertEqual(loaded?[0].message, "Screen1")
+        XCTAssertEqual(loaded?[1].message, "Button")
+    }
+
+    func testClearDisk() throws {
+        let tmpDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: tmpDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tmpDir) }
+
+        let trail = BreadcrumbTrail(maxSize: 10)
+        trail.add(Breadcrumb(category: .log, message: "test"))
+        trail.writeToDisk(directory: tmpDir)
+
+        BreadcrumbTrail.clearDisk(directory: tmpDir)
+        XCTAssertNil(BreadcrumbTrail.loadFromDisk(directory: tmpDir))
+    }
+
+    func testLoadFromDiskReturnsNilWhenNoFile() {
+        let tmpDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString)
+        XCTAssertNil(BreadcrumbTrail.loadFromDisk(directory: tmpDir))
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `BreadcrumbTrail` ring buffer (default 100 items) with thread-safe concurrent access via NSLock
- Includes disk persistence (`writeToDisk`/`loadFromDisk`/`clearDisk`) for crash resilience across sessions
- Defines `BreadcrumbTracking` protocol for dependency injection and testability
- 9 unit tests covering ring buffer overflow, thread safety, metadata preservation, and disk I/O

## Test plan
- [x] All 9 `BreadcrumbTrailTests` pass via `swift test` (139 total SDK tests, 0 failures)
- [ ] Verify concurrent add safety under stress on CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)