### PR TITLE
fix: migrate desktop ViewModels to unified Result type and add cross-platform CI

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -130,8 +130,12 @@ jobs:
           path: android/ide-plugin/build/reports/tests/test/
 
   build-desktop-app:
-    name: "Build Desktop App"
-    runs-on: ubuntu-latest
+    name: "Build Desktop App (${{ matrix.os }})"
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
     defaults:
       run:
         working-directory: android
@@ -145,9 +149,10 @@ jobs:
         with:
           gradle-tasks: ":desktop-app:build -x test"
           gradle-project-directory: "android"
-          gradle-home-directory: "~/.gradle/${{ github.job }}"
+          gradle-home-directory: "~/.gradle/${{ github.job }}-${{ matrix.os }}"
           reuse-configuration-cache: true
           gradle-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
+          malloc-replacement: ${{ runner.os == 'Linux' && 'jemalloc' || 'none' }}
 
   desktop-app-unit-tests:
     name: "Run Desktop App Unit Tests"

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -333,10 +333,14 @@ jobs:
           path: android/ide-plugin/build/reports/tests/test/
 
   build-desktop-app:
-    name: "Build Desktop App"
-    runs-on: ubuntu-latest
+    name: "Build Desktop App (${{ matrix.os }})"
+    runs-on: ${{ matrix.os }}
     needs: detect-changes
     if: (needs.detect-changes.outputs.desktop_app_changed == 'true' || needs.detect-changes.outputs.desktop_core_changed == 'true') && needs.detect-changes.outputs.sha256_only != 'true'
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
     defaults:
       run:
         working-directory: android
@@ -350,9 +354,10 @@ jobs:
         with:
           gradle-tasks: ":desktop-app:build -x test"
           gradle-project-directory: "android"
-          gradle-home-directory: "~/.gradle/${{ github.job }}"
+          gradle-home-directory: "~/.gradle/${{ github.job }}-${{ matrix.os }}"
           reuse-configuration-cache: true
           gradle-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
+          malloc-replacement: ${{ runner.os == 'Linux' && 'jemalloc' || 'none' }}
 
   desktop-app-unit-tests:
     name: "Run Desktop App Unit Tests"

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/failures/FailuresViewModel.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/failures/FailuresViewModel.kt
@@ -1,5 +1,6 @@
 package dev.jasonpearson.automobile.desktop.core.failures
 
+import dev.jasonpearson.automobile.desktop.core.datasource.Result
 import dev.jasonpearson.automobile.desktop.core.logging.LoggerFactory
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.channels.Channel
@@ -79,13 +80,16 @@ class FailuresViewModel(
         scope.launch {
             try {
                 when (val result = dataSource.getFailureGroups()) {
-                    is DataSourceResult.Success -> {
+                    is Result.Success -> {
                         LOG.info("Failures loaded: ${result.data.size} groups")
                         _state.value = FailuresUiState.Content(failureGroups = result.data)
                     }
-                    is DataSourceResult.Error -> {
+                    is Result.Error -> {
                         LOG.warn("Failed to load failures: ${result.message}")
-                        _state.value = FailuresUiState.Error(message = result.message)
+                        _state.value = FailuresUiState.Error(message = result.message ?: "Unknown error")
+                    }
+                    is Result.Loading -> {
+                        // Keep loading state
                     }
                 }
             } catch (e: Exception) {

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/navigation/NavigationViewModel.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/navigation/NavigationViewModel.kt
@@ -84,7 +84,7 @@ class NavigationViewModel(
                     }
                     is Result.Error -> {
                         LOG.warn("Failed to load navigation data: ${result.message}")
-                        _state.value = NavigationUiState.Error(message = result.message)
+                        _state.value = NavigationUiState.Error(message = result.message ?: "Unknown error")
                     }
                     is Result.Loading -> {
                         // Keep loading state

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/failures/FailuresViewModelTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/failures/FailuresViewModelTest.kt
@@ -1,5 +1,6 @@
 package dev.jasonpearson.automobile.desktop.core.failures
 
+import dev.jasonpearson.automobile.desktop.core.datasource.Result
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.TestScope
@@ -40,7 +41,7 @@ class FailuresViewModelTest {
     @Test
     fun `initial state transitions to Content on success`() = testScope.runTest {
         val groups = listOf(createTestFailureGroup("g1"), createTestFailureGroup("g2"))
-        val dataSource = FakeFailuresDataSourceImpl(DataSourceResult.Success(groups))
+        val dataSource = FakeFailuresDataSourceImpl(Result.Success(groups))
         val vm = FailuresViewModel(dataSource, this)
 
         val state = vm.state.value
@@ -53,7 +54,7 @@ class FailuresViewModelTest {
 
     @Test
     fun `transitions to Error on data source error`() = testScope.runTest {
-        val dataSource = FakeFailuresDataSourceImpl(DataSourceResult.Error("Server down"))
+        val dataSource = FakeFailuresDataSourceImpl(Result.Error(RuntimeException("Server down")))
         val vm = FailuresViewModel(dataSource, this)
 
         val state = vm.state.value
@@ -74,7 +75,7 @@ class FailuresViewModelTest {
     @Test
     fun `SelectFailure updates selectedFailure`() = testScope.runTest {
         val group = createTestFailureGroup("g1")
-        val dataSource = FakeFailuresDataSourceImpl(DataSourceResult.Success(listOf(group)))
+        val dataSource = FakeFailuresDataSourceImpl(Result.Success(listOf(group)))
         val vm = FailuresViewModel(dataSource, this)
 
         vm.onAction(FailuresAction.SelectFailure(group))
@@ -86,7 +87,7 @@ class FailuresViewModelTest {
     @Test
     fun `ClearSelection clears selectedFailure`() = testScope.runTest {
         val group = createTestFailureGroup("g1")
-        val dataSource = FakeFailuresDataSourceImpl(DataSourceResult.Success(listOf(group)))
+        val dataSource = FakeFailuresDataSourceImpl(Result.Success(listOf(group)))
         val vm = FailuresViewModel(dataSource, this)
 
         vm.onAction(FailuresAction.SelectFailure(group))
@@ -102,7 +103,7 @@ class FailuresViewModelTest {
             createTestFailureGroup("g1", FailureType.Crash),
             createTestFailureGroup("g2", FailureType.ANR),
         )
-        val dataSource = FakeFailuresDataSourceImpl(DataSourceResult.Success(groups))
+        val dataSource = FakeFailuresDataSourceImpl(Result.Success(groups))
         val vm = FailuresViewModel(dataSource, this)
 
         vm.onAction(FailuresAction.FilterByType(FailureType.ANR))
@@ -114,7 +115,7 @@ class FailuresViewModelTest {
     @Test
     fun `FilterByType with null clears filter`() = testScope.runTest {
         val groups = listOf(createTestFailureGroup("g1"))
-        val dataSource = FakeFailuresDataSourceImpl(DataSourceResult.Success(groups))
+        val dataSource = FakeFailuresDataSourceImpl(Result.Success(groups))
         val vm = FailuresViewModel(dataSource, this)
 
         vm.onAction(FailuresAction.FilterByType(FailureType.Crash))
@@ -130,7 +131,7 @@ class FailuresViewModelTest {
             createTestFailureGroup("g1"),
             createTestFailureGroup("g2"),
         )
-        val dataSource = FakeFailuresDataSourceImpl(DataSourceResult.Success(groups))
+        val dataSource = FakeFailuresDataSourceImpl(Result.Success(groups))
         val vm = FailuresViewModel(dataSource, this)
 
         vm.onAction(FailuresAction.SelectFailureById("g2"))
@@ -142,7 +143,7 @@ class FailuresViewModelTest {
     @Test
     fun `SelectFailureById with unknown id does not select`() = testScope.runTest {
         val groups = listOf(createTestFailureGroup("g1"))
-        val dataSource = FakeFailuresDataSourceImpl(DataSourceResult.Success(groups))
+        val dataSource = FakeFailuresDataSourceImpl(Result.Success(groups))
         val vm = FailuresViewModel(dataSource, this)
 
         vm.onAction(FailuresAction.SelectFailureById("nonexistent"))
@@ -154,11 +155,11 @@ class FailuresViewModelTest {
     @Test
     fun `Refresh reloads data`() = testScope.runTest {
         val dataSource = FakeFailuresDataSourceImpl(
-            DataSourceResult.Success(listOf(createTestFailureGroup("g1")))
+            Result.Success(listOf(createTestFailureGroup("g1")))
         )
         val vm = FailuresViewModel(dataSource, this)
 
-        dataSource.result = DataSourceResult.Success(
+        dataSource.result = Result.Success(
             listOf(createTestFailureGroup("g1"), createTestFailureGroup("g2"), createTestFailureGroup("g3"))
         )
         vm.onAction(FailuresAction.Refresh)
@@ -170,7 +171,7 @@ class FailuresViewModelTest {
     @Test
     fun `UpdateGroups replaces failure groups in Content state`() = testScope.runTest {
         val dataSource = FakeFailuresDataSourceImpl(
-            DataSourceResult.Success(listOf(createTestFailureGroup("g1")))
+            Result.Success(listOf(createTestFailureGroup("g1")))
         )
         val vm = FailuresViewModel(dataSource, this)
 
@@ -184,7 +185,7 @@ class FailuresViewModelTest {
 
     @Test
     fun `UpdateGroups sets Content from Error state`() = testScope.runTest {
-        val dataSource = FakeFailuresDataSourceImpl(DataSourceResult.Error("initial error"))
+        val dataSource = FakeFailuresDataSourceImpl(Result.Error(RuntimeException("initial error")))
         val vm = FailuresViewModel(dataSource, this)
         assertTrue(vm.state.value is FailuresUiState.Error)
 
@@ -198,13 +199,13 @@ class FailuresViewModelTest {
     // -- Fakes --
 
     private class FakeFailuresDataSourceImpl(
-        var result: DataSourceResult<List<FailureGroup>>,
+        var result: Result<List<FailureGroup>>,
     ) : FailuresDataSource {
-        override suspend fun getFailureGroups(): DataSourceResult<List<FailureGroup>> = result
+        override suspend fun getFailureGroups(): Result<List<FailureGroup>> = result
         override suspend fun getTimelineData(
             dateRange: DateRange,
             aggregation: TimeAggregation,
-        ): DataSourceResult<TimelineData> = DataSourceResult.Success(
+        ): Result<TimelineData> = Result.Success(
             TimelineData(emptyList(), PeriodTotals(0, 0, 0, 0))
         )
     }
@@ -212,10 +213,10 @@ class FailuresViewModelTest {
     private class ThrowingFailuresDataSource(
         private val exception: Exception,
     ) : FailuresDataSource {
-        override suspend fun getFailureGroups(): DataSourceResult<List<FailureGroup>> = throw exception
+        override suspend fun getFailureGroups(): Result<List<FailureGroup>> = throw exception
         override suspend fun getTimelineData(
             dateRange: DateRange,
             aggregation: TimeAggregation,
-        ): DataSourceResult<TimelineData> = throw exception
+        ): Result<TimelineData> = throw exception
     }
 }


### PR DESCRIPTION
## Summary
- Migrate `FailuresViewModel` and `NavigationViewModel` from removed `DataSourceResult` to unified `Result` type, fixing compile errors
- Handle nullable `Result.Error.message` with `?: "Unknown error"` fallback
- Update `FailuresViewModelTest` fakes to use `Result` type signatures
- Add mac/linux/windows matrix to `build-desktop-app` CI jobs in both PR and merge workflows (unit tests remain linux-only)
- Disable jemalloc on non-Linux runners via `malloc-replacement: none`

## Test plan
- [ ] Desktop core compiles (`./gradlew -p android :desktop-core:compileKotlin`)
- [ ] Desktop app builds on all 3 OS runners in CI
- [ ] Desktop app unit tests pass on linux runner

🤖 Generated with [Claude Code](https://claude.com/claude-code)