### PR TITLE
docs: add SDK, Desktop App, and Event Pipeline to design docs

### DIFF
--- a/docs/design-docs/index.md
+++ b/docs/design-docs/index.md
@@ -75,6 +75,7 @@ flowchart TB
 | [Actions](mcp/tools.md) | Touch, swipe, input, and app management |
 | [Navigation Graph](mcp/nav/index.md) | Automatic screen flow mapping |
 | [Daemon](mcp/daemon/index.md) | Device pooling and test execution |
+| [SDK Event Pipeline](mcp/sdk-event-pipeline.md) | Cross-platform event tracking, crash detection, and session management |
 
 ## Design Principles
 
@@ -99,6 +100,8 @@ Feature implementation status is indicated throughout these docs using chips. Se
 | [Accessibility Service](plat/android/control-proxy.md) | Real-time view hierarchy access | <kbd>✅ Implemented</kbd> <kbd>🧪 Tested</kbd> |
 | [JUnitRunner](plat/android/junit-runner/index.md) | Test execution framework | <kbd>✅ Implemented</kbd> <kbd>🧪 Tested</kbd> |
 | [IDE Plugin](plat/android/ide-plugin/overview.md) | Android Studio integration | <kbd>✅ Implemented</kbd> |
+| [AutoMobile SDK](plat/android/auto-mobile-sdk.md) | Event tracking, crash reporting, session management, and diagnostics SDK | <kbd>✅ Implemented</kbd> <kbd>🧪 Tested</kbd> |
+| [Desktop App](plat/android/desktop-app.md) | Compose Desktop companion for monitoring and controlling sessions | <kbd>✅ Implemented</kbd> <kbd>🧪 Tested</kbd> |
 | [Work Profiles](plat/android/work-profiles.md) | Enterprise device support | <kbd>✅ Implemented</kbd> <kbd>🧪 Tested</kbd> |
 
 ### iOS
@@ -108,4 +111,5 @@ Feature implementation status is indicated throughout these docs using chips. Se
 | [iOS Overview](plat/ios/index.md) | Architecture and status | <kbd>📱 Simulator Only</kbd> |
 | [CtrlProxy iOS](plat/ios/ctrl-proxy-ios.md) | WebSocket automation server | <kbd>✅ Implemented</kbd> <kbd>🧪 Tested</kbd> |
 | [XCTestRunner](plat/ios/xctestrunner/index.md) | Test execution framework | <kbd>✅ Implemented</kbd> <kbd>🧪 Tested</kbd> |
+| [AutoMobile SDK](plat/ios/auto-mobile-sdk.md) | Event tracking, crash reporting, session management, and diagnostics SDK | <kbd>✅ Implemented</kbd> <kbd>🧪 Tested</kbd> |
 | [Xcode Integration](plat/ios/ide-plugin/overview.md) | Companion app + editor extension | <kbd>⚠️ Partial</kbd> |

--- a/docs/design-docs/status-glossary.md
+++ b/docs/design-docs/status-glossary.md
@@ -51,6 +51,8 @@ The following items are documented as designs or proposals but have **no corresp
 
 - **`AutoMobileBiometrics.overrideResult()`** — Optional SDK hook for deterministic biometric bypass in apps under test. Not implemented. See [biometrics.md](plat/android/biometrics.md).
 
+> **Note:** The AutoMobile SDK itself (event tracking, crash reporting, session management, diagnostics) is fully implemented and tested on both Android and iOS. The entry above tracks a specific optional biometric hook that remains unbuilt.
+
 #### Vision
 
 - **Hybrid vision fallback (Tier 1 local models)** — Proposed Florence-2 / PaddleOCR local model layer. Not implemented. See [vision-fallback.md](mcp/observe/vision-fallback.md).
@@ -66,6 +68,8 @@ The following items are documented as designs or proposals but have **no corresp
 - **`highlight` tool** — Fully implemented on Android; returns an unsupported error on iOS.
 - **`rawViewHierarchy` (control-proxy source)** — Android only. iOS returns XCUITest JSON.
 - **Work profile `userId` override** — Auto-detection works; manual `userId` parameter is not supported in MCP tool schemas.
+- **AutoMobile SDK event pipeline** — Event tracking, crash handling, session management, and breadcrumbs are fully implemented on both Android and iOS. The SDK Event Pipeline MCP integration is complete. See [sdk-event-pipeline.md](mcp/sdk-event-pipeline.md).
+- **Desktop App** — Compose Desktop companion app for monitoring and controlling sessions is fully implemented with Compose Desktop UI tests. See [desktop-app.md](plat/android/desktop-app.md).
 
 ### Features That Lack Test Coverage
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -123,6 +123,7 @@ nav:
           - 'Resources': design-docs/mcp/resources.md
           - 'Context Thresholds': design-docs/mcp/context-thresholds.md
           - 'Test Plan Validation': design-docs/mcp/test-plan-validation.md
+          - 'SDK Event Pipeline': design-docs/mcp/sdk-event-pipeline.md
       - 'Platform Specific':
           - 'Android':
             - 'Overview': design-docs/plat/android/index.md
@@ -130,6 +131,7 @@ nav:
             - 'Screen Streaming': design-docs/plat/android/screen-streaming.md
             - 'CtrlProxy': design-docs/plat/android/control-proxy.md
             - 'AutoMobile SDK': design-docs/plat/android/auto-mobile-sdk.md
+            - 'Desktop App': design-docs/plat/android/desktop-app.md
             - 'JUnitRunner':
               - 'Overview': design-docs/plat/android/junit-runner/index.md
               - 'Project Setup': design-docs/plat/android/junit-runner/project-setup.md
@@ -166,6 +168,7 @@ nav:
               - 'Writing Tests': design-docs/plat/ios/xctestrunner/writing-tests.md
               - 'CI Integration': design-docs/plat/ios/xctestrunner/ci-integration.md
             - 'testmanagerd': design-docs/plat/ios/testmanagerd.md
+            - 'AutoMobile SDK': design-docs/plat/ios/auto-mobile-sdk.md
             - 'Xcode Integration':
               - 'Overview': design-docs/plat/ios/ide-plugin/overview.md
               - 'Test Recording': design-docs/plat/ios/ide-plugin/test-recording.md


### PR DESCRIPTION
## Summary
- Add AutoMobile SDK (Android + iOS), Desktop App, and SDK Event Pipeline rows to the design docs index tables with status chips
- Add clarifying note in status glossary that the SDK is fully implemented (only the biometric hook remains unbuilt), and add SDK event pipeline + Desktop App to the "Features That Are Partial or Internal" section
- Add corresponding navigation entries in mkdocs.yml under Android, iOS, and MCP sections

## Test plan
- [x] `turbo run lint build test` passes (all cached, no regressions)
- [ ] Verify mkdocs renders correctly with `mkdocs serve`

🤖 Generated with [Claude Code](https://claude.com/claude-code)