### PR TITLE
docs: document iOS simulator live locale changes

### DIFF
--- a/docs/design-docs/plat/ios/simctl.md
+++ b/docs/design-docs/plat/ios/simctl.md
@@ -14,6 +14,56 @@ system-level simulator behaviors.
 - App lifecycle: install, uninstall, launch, terminate.
 - Device discovery and capability reporting.
 - Status bar configuration (demo mode) when supported.
+- Live locale and localization changes (see below).
+
+## Live locale changes
+
+<kbd>✅ Implemented</kbd>
+
+The `changeLocalization` MCP tool supports live locale changes on iOS simulators without
+requiring a manual reboot. When a locale, time zone, time format, calendar system, or
+language is changed, the server applies the settings and then forces the simulator UI to
+pick them up immediately.
+
+### How it works
+
+1. **Write settings** via `xcrun simctl spawn <udid> defaults write`:
+   - `AppleLocale` — the ICU locale identifier (underscored form, e.g. `ja_JP`).
+   - `AppleLanguages` — an ordered array of BCP 47 tags built from the requested
+     locale (e.g. `["ja-JP", "ja"]`), so UI strings resolve correctly.
+   - `AppleTimeZone`, `AppleICUForce24HourTime`, `AppleCalendar` — for the
+     remaining localization axes.
+2. **Read-back verification** — every write is read back and compared to the expected
+   value; a mismatch is reported as an error.
+3. **SpringBoard restart** — `launchctl stop com.apple.SpringBoard` inside the
+   simulator causes SpringBoard to re-launch and adopt the new preferences. The server
+   polls `launchctl list com.apple.SpringBoard` (up to 10 retries, 500 ms apart) to
+   confirm it is back.
+4. **Darwin notification** — `notifyutil -p com.apple.language.changed` tells
+   in-process observers that the locale has changed.
+5. **Optional app restart** — the `restartApp` parameter accepts a bundle ID. When
+   provided, the server terminates the app with `xcrun simctl terminate` and
+   relaunches it with `xcrun simctl launch`, so the app picks up the new locale
+   (running apps cache locale at launch). The bundle ID is validated against a strict
+   reverse-DNS pattern to prevent shell injection.
+
+### MCP tool parameters (iOS-specific)
+
+| Parameter | Description |
+|-----------|-------------|
+| `locale` | Locale tag, e.g. `ar-SA`, `ja-JP` |
+| `timeZone` | IANA zone ID, e.g. `Asia/Tokyo` |
+| `timeFormat` | `"12"` or `"24"` |
+| `calendarSystem` | e.g. `gregory`, `japanese`, `buddhist` |
+| `restartApp` | Bundle ID of an app to terminate and relaunch after the change (iOS only) |
+
+### Limitations
+
+- Simulator only; physical devices are not supported for locale changes.
+- Text direction (`textDirection` parameter) is not applicable on iOS — RTL layout is
+  driven by the app's language; set an RTL locale instead.
+- Running apps cache locale at launch. Use the `restartApp` parameter or manually
+  relaunch the app for it to pick up new settings.
 
 ## Usage patterns
 


### PR DESCRIPTION
## Summary
- Add a new "Live locale changes" section to `docs/design-docs/plat/ios/simctl.md` documenting the feature from PR #1735
- Covers the five-step flow: defaults write, read-back verification, SpringBoard restart, Darwin notification, and optional app restart
- Documents MCP tool parameters and simulator-only limitations

## Test plan
- [x] Markdown-only change; `turbo run lint build test` passes (3335 tests)
- [x] No code changes to verify beyond doc accuracy

🤖 Generated with [Claude Code](https://claude.com/claude-code)