### PR TITLE
fix: Android SDK security & build hygiene

### DIFF
--- a/android/auto-mobile-sdk/build.gradle.kts
+++ b/android/auto-mobile-sdk/build.gradle.kts
@@ -63,7 +63,9 @@ dependencies {
   // Compose runtime for @Composable support
   implementation(platform(libs.compose.bom))
   implementation("androidx.compose.runtime:runtime")
-  implementation(libs.bundles.compose.ui)
+  implementation(libs.bundles.compose.sdk)
+  debugImplementation(libs.compose.ui.tooling)
+  debugImplementation(libs.compose.ui.tooling.preview)
 
   // Navigation3 support for Compose navigation tracking
   implementation(libs.navigation3.runtime)

--- a/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/RecompositionTracker.kt
+++ b/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/RecompositionTracker.kt
@@ -104,15 +104,13 @@ object RecompositionTracker {
     )
   }
 
-  private const val ACCESSIBILITY_SERVICE_PACKAGE = "dev.jasonpearson.automobile.ctrlproxy"
-
   private fun broadcastSnapshot() {
     val ctx = context ?: return
     val payload = buildSnapshotJson(ctx.packageName)
     val intent =
         Intent(AutoMobileSDK.ACTION_RECOMPOSITION_SNAPSHOT).apply {
           putExtra(AutoMobileSDK.EXTRA_RECOMPOSITION_SNAPSHOT, payload)
-          setPackage(ACCESSIBILITY_SERVICE_PACKAGE)
+          setPackage(SdkConstants.CTRL_PROXY_PACKAGE)
         }
     ctx.sendBroadcast(intent)
   }
@@ -136,10 +134,16 @@ object RecompositionTracker {
     val filter = IntentFilter().apply { addAction(AutoMobileSDK.ACTION_RECOMPOSITION_CONTROL) }
 
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-      context.registerReceiver(controlReceiver, filter, Context.RECEIVER_EXPORTED)
+      context.registerReceiver(
+          controlReceiver,
+          filter,
+          SdkConstants.PERMISSION_NETWORK_CONTROL,
+          null,
+          Context.RECEIVER_EXPORTED)
     } else {
       @SuppressLint("UnspecifiedRegisterReceiverFlag")
-      context.registerReceiver(controlReceiver, filter)
+      context.registerReceiver(
+          controlReceiver, filter, SdkConstants.PERMISSION_NETWORK_CONTROL, null)
     }
   }
 

--- a/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/SdkConstants.kt
+++ b/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/SdkConstants.kt
@@ -1,0 +1,11 @@
+package dev.jasonpearson.automobile.sdk
+
+/** Shared constants used across the SDK. */
+internal object SdkConstants {
+  /** Package name of the CtrlProxy accessibility service companion app. */
+  const val CTRL_PROXY_PACKAGE = "dev.jasonpearson.automobile.ctrlproxy"
+
+  /** Signature-level permission for controlling SDK broadcast receivers. */
+  const val PERMISSION_NETWORK_CONTROL =
+      "dev.jasonpearson.automobile.sdk.permission.NETWORK_CONTROL"
+}

--- a/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/anr/AutoMobileAnr.kt
+++ b/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/anr/AutoMobileAnr.kt
@@ -12,6 +12,7 @@ import dev.jasonpearson.automobile.sdk.AutoMobileSDK
 import dev.jasonpearson.automobile.protocol.SdkAnrEvent
 import dev.jasonpearson.automobile.protocol.SdkDeviceInfo
 import dev.jasonpearson.automobile.protocol.SdkEventSerializer
+import dev.jasonpearson.automobile.sdk.SdkConstants
 
 /**
  * SDK API for detecting ANRs (Application Not Responding) from previous sessions.
@@ -36,8 +37,7 @@ import dev.jasonpearson.automobile.protocol.SdkEventSerializer
 object AutoMobileAnr {
     private const val TAG = "AutoMobileAnr"
 
-    /** Package name of the AutoMobile AccessibilityService that receives broadcasts */
-    private const val ACCESSIBILITY_SERVICE_PACKAGE = "dev.jasonpearson.automobile.ctrlproxy"
+    private const val ACCESSIBILITY_SERVICE_PACKAGE = SdkConstants.CTRL_PROXY_PACKAGE
 
     const val ACTION_ANR = "dev.jasonpearson.automobile.sdk.ANR"
 

--- a/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/crashes/AutoMobileCrashes.kt
+++ b/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/crashes/AutoMobileCrashes.kt
@@ -8,6 +8,7 @@ import dev.jasonpearson.automobile.protocol.SdkCrashEvent
 import dev.jasonpearson.automobile.sdk.AutoMobileSDK
 import dev.jasonpearson.automobile.protocol.SdkDeviceInfo
 import dev.jasonpearson.automobile.protocol.SdkEventSerializer
+import dev.jasonpearson.automobile.sdk.SdkConstants
 import dev.jasonpearson.automobile.sdk.breadcrumbs.Breadcrumb
 import dev.jasonpearson.automobile.sdk.breadcrumbs.BreadcrumbTracking
 import java.io.PrintWriter
@@ -36,8 +37,7 @@ import org.json.JSONObject
 object AutoMobileCrashes {
     private const val TAG = "AutoMobileCrashes"
 
-    /** Package name of the AutoMobile AccessibilityService that receives broadcasts */
-    private const val ACCESSIBILITY_SERVICE_PACKAGE = "dev.jasonpearson.automobile.ctrlproxy"
+    private const val ACCESSIBILITY_SERVICE_PACKAGE = SdkConstants.CTRL_PROXY_PACKAGE
 
     const val ACTION_CRASH = "dev.jasonpearson.automobile.sdk.CRASH"
     const val EXTRA_TIMESTAMP = "timestamp"

--- a/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/events/SdkEventBroadcaster.kt
+++ b/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/events/SdkEventBroadcaster.kt
@@ -7,6 +7,7 @@ import android.os.Looper
 import dev.jasonpearson.automobile.protocol.SdkEvent
 import dev.jasonpearson.automobile.protocol.SdkEventBatch
 import dev.jasonpearson.automobile.protocol.SdkEventSerializer
+import dev.jasonpearson.automobile.sdk.SdkConstants
 
 /**
  * Broadcasts batched SDK events via Intent for cross-process communication.
@@ -97,7 +98,7 @@ object SdkEventBroadcaster {
       val intent = Intent(ACTION_SDK_EVENT_BATCH).apply {
         putExtra(SdkEventSerializer.EXTRA_SDK_EVENT_JSON, batchJson)
         putExtra(SdkEventSerializer.EXTRA_SDK_EVENT_TYPE, SdkEventSerializer.EventTypes.EVENT_BATCH)
-        setPackage(ACCESSIBILITY_SERVICE_PACKAGE)
+        setPackage(SdkConstants.CTRL_PROXY_PACKAGE)
       }
       context.sendBroadcast(intent)
     } catch (_: Exception) {

--- a/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/failures/AutoMobileFailures.kt
+++ b/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/failures/AutoMobileFailures.kt
@@ -8,6 +8,7 @@ import dev.jasonpearson.automobile.protocol.SdkDeviceInfo
 import dev.jasonpearson.automobile.sdk.AutoMobileSDK
 import dev.jasonpearson.automobile.protocol.SdkEventSerializer
 import dev.jasonpearson.automobile.protocol.SdkHandledExceptionEvent
+import dev.jasonpearson.automobile.sdk.SdkConstants
 import java.io.PrintWriter
 import java.io.StringWriter
 
@@ -36,8 +37,7 @@ object AutoMobileFailures {
     private const val TAG = "AutoMobileFailures"
     private const val MAX_EVENTS = 100
 
-    /** Package name of the AutoMobile AccessibilityService that receives broadcasts */
-    private const val ACCESSIBILITY_SERVICE_PACKAGE = "dev.jasonpearson.automobile.ctrlproxy"
+    private const val ACCESSIBILITY_SERVICE_PACKAGE = SdkConstants.CTRL_PROXY_PACKAGE
 
     const val ACTION_HANDLED_EXCEPTION = "dev.jasonpearson.automobile.sdk.HANDLED_EXCEPTION"
     const val EXTRA_TIMESTAMP = "timestamp"

--- a/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/network/NetworkMockRuleStore.kt
+++ b/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/network/NetworkMockRuleStore.kt
@@ -8,6 +8,7 @@ import android.content.IntentFilter
 import android.os.Build
 import dev.jasonpearson.automobile.protocol.NetworkMockRuleDto
 import dev.jasonpearson.automobile.sdk.AutoMobileSDK
+import dev.jasonpearson.automobile.sdk.SdkConstants
 import java.util.concurrent.CopyOnWriteArrayList
 import java.util.concurrent.atomic.AtomicInteger
 import kotlinx.serialization.builtins.ListSerializer
@@ -31,8 +32,7 @@ class NetworkMockRuleStore(private val clock: () -> Long = { System.currentTimeM
     const val EXTRA_ERROR_SIM_TYPE = "error_type"
     const val EXTRA_ERROR_SIM_LIMIT = "limit"
     const val EXTRA_ERROR_SIM_EXPIRES_AT = "expires_at"
-    private const val PERMISSION_NETWORK_CONTROL =
-        "dev.jasonpearson.automobile.sdk.permission.NETWORK_CONTROL"
+    private const val PERMISSION_NETWORK_CONTROL = SdkConstants.PERMISSION_NETWORK_CONTROL
 
     @Volatile private var instance: NetworkMockRuleStore? = null
 

--- a/android/gradle/libs.versions.toml
+++ b/android/gradle/libs.versions.toml
@@ -175,6 +175,13 @@ compose-ui = [
   "compose-material",
   "compose-material-icons-extended"
 ]
+compose-sdk = [
+  "compose-ui-core",
+  "compose-ui-util",
+  "compose-ui-graphics",
+  "compose-ui-foundation",
+  "compose-material"
+]
 compose-ui-espresso-test = [
   "androidx-junit",
   "compose-ui-junit",


### PR DESCRIPTION
## Summary
- **Permission-gated receiver**: `RecompositionTracker.registerControlReceiver()` now passes the existing `signature`-level `NETWORK_CONTROL` permission to `registerReceiver()`, so only same-signed apps can send the control broadcast (previously any app could trigger it via `RECEIVER_EXPORTED`).
- **Consolidated constants**: Extracted duplicated `ACCESSIBILITY_SERVICE_PACKAGE` (5 files) and `PERMISSION_NETWORK_CONTROL` (2 files) into a single `SdkConstants` internal object.
- **Slimmed SDK Compose dependencies**: Created a `compose-sdk` version catalog bundle without `material-icons-extended` (~36 MB) or `ui-tooling`/`ui-tooling-preview`. Tooling deps are now `debugImplementation` only. The shared `compose-ui` bundle used by playground modules is unchanged.

## Test plan
- [x] `./gradlew :auto-mobile-sdk:test` passes
- [x] `./gradlew :auto-mobile-sdk:assembleRelease` passes
- [ ] Verify CtrlProxy can still send recomposition control broadcasts on a device (signature permission match)

🤖 Generated with [Claude Code](https://claude.com/claude-code)