### PR TITLE
fix: bound cursor map growth in PerformanceAuditStreamService

### DIFF
--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/PerformanceAuditStreamService.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/PerformanceAuditStreamService.kt
@@ -1,6 +1,7 @@
 package dev.jasonpearson.automobile.desktop.core.daemon
 
 import java.time.Instant
+import java.util.LinkedHashMap
 
 data class PerformanceAuditStreamCursor(
     val lastTimestamp: String? = null,
@@ -19,14 +20,20 @@ class PerformanceAuditStreamService(
     private val clock: PerformanceAuditClock = SystemPerformanceAuditClock(),
     private val defaultWindowMs: Long = PerformanceAuditStreamCache.DEFAULT_TTL_MS,
     private val defaultLimit: Int = 200,
+    private val maxCursors: Int = DEFAULT_MAX_CURSORS,
 ) {
+  companion object {
+    const val DEFAULT_MAX_CURSORS = 100
+  }
+
   private data class FilterKey(
       val deviceId: String?,
       val sessionId: String?,
       val packageName: String?,
   )
 
-  private val cursors = mutableMapOf<FilterKey, PerformanceAuditStreamCursor>()
+  private val cursors =
+      LinkedHashMap<FilterKey, PerformanceAuditStreamCursor>(16, 0.75f, true)
 
   fun poll(filter: PerformanceAuditStreamFilter = PerformanceAuditStreamFilter()):
       PerformanceAuditStreamSnapshot {
@@ -57,6 +64,7 @@ class PerformanceAuditStreamService(
             lastTimestamp = response.lastTimestamp ?: cursor.lastTimestamp,
             lastId = response.lastId ?: cursor.lastId,
         )
+    trimCursors()
 
     return PerformanceAuditStreamSnapshot(
         cache.snapshot(filter.copy(timeWindowMs = windowMs)),
@@ -71,6 +79,15 @@ class PerformanceAuditStreamService(
   fun resetCursor(filter: PerformanceAuditStreamFilter) {
     val key = FilterKey(filter.deviceId, filter.sessionId, filter.packageName)
     cursors.remove(key)
+  }
+
+  private fun trimCursors() {
+    if (cursors.size <= maxCursors) return
+    val iterator = cursors.entries.iterator()
+    while (cursors.size > maxCursors && iterator.hasNext()) {
+      iterator.next()
+      iterator.remove()
+    }
   }
 
   private fun formatTimestamp(epochMs: Long): String {

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/PerformanceAuditStreamServiceTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/PerformanceAuditStreamServiceTest.kt
@@ -275,12 +275,59 @@ class PerformanceAuditStreamServiceTest {
     assertTrue(snapshot.results.any { it.id == 2L })
   }
 
+  @Test
+  fun `cursors evict least recently used entry when maxCursors exceeded`() {
+    val clock = FakePerformanceAuditClock(10_000L)
+    val cache = PerformanceAuditStreamCache(clock, maxEntries = 10, ttlMs = 300_000L)
+    val client = FakePerformanceAuditStreamClient(
+        listOf(
+            PerformanceAuditStreamResponse(
+                success = true,
+                results = emptyList(),
+                lastTimestamp = "2024-01-01T00:00:10Z",
+                lastId = 10L,
+            ),
+        )
+    )
+    val service = createService(client, cache, clock, maxCursors = 3)
+
+    // Add cursors for devices a, b, c (fills to capacity)
+    service.poll(PerformanceAuditStreamFilter(deviceId = "device-a"))
+    service.poll(PerformanceAuditStreamFilter(deviceId = "device-b"))
+    service.poll(PerformanceAuditStreamFilter(deviceId = "device-c"))
+
+    // Access device-a again so it becomes recently used
+    service.poll(PerformanceAuditStreamFilter(deviceId = "device-a"))
+
+    // Adding device-d should evict device-b (least recently used)
+    service.poll(PerformanceAuditStreamFilter(deviceId = "device-d"))
+
+    // Now poll device-b again - it should have no cursor (was evicted)
+    service.poll(PerformanceAuditStreamFilter(deviceId = "device-b"))
+    val deviceBRequest = client.requests.last()
+    assertNull(deviceBRequest.sinceTimestamp)
+    assertNull(deviceBRequest.sinceId)
+
+    // Poll device-a - cursor should still be present (was recently used)
+    service.poll(PerformanceAuditStreamFilter(deviceId = "device-a"))
+    val deviceARequest = client.requests.last()
+    assertEquals("2024-01-01T00:00:10Z", deviceARequest.sinceTimestamp)
+    assertEquals(10L, deviceARequest.sinceId)
+
+    // Poll device-d - cursor should still be present
+    service.poll(PerformanceAuditStreamFilter(deviceId = "device-d"))
+    val deviceDRequest = client.requests.last()
+    assertEquals("2024-01-01T00:00:10Z", deviceDRequest.sinceTimestamp)
+    assertEquals(10L, deviceDRequest.sinceId)
+  }
+
   private fun createService(
       client: FakePerformanceAuditStreamClient,
       cache: PerformanceAuditStreamCache,
       clock: FakePerformanceAuditClock,
       defaultWindowMs: Long = 300_000L,
       defaultLimit: Int = 10,
+      maxCursors: Int = PerformanceAuditStreamService.DEFAULT_MAX_CURSORS,
   ): PerformanceAuditStreamService {
     return PerformanceAuditStreamService(
         socketClient = client,
@@ -288,6 +335,7 @@ class PerformanceAuditStreamServiceTest {
         clock = clock,
         defaultWindowMs = defaultWindowMs,
         defaultLimit = defaultLimit,
+        maxCursors = maxCursors,
     )
   }
 

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/datasource/CachedNavigationDataSourceTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/datasource/CachedNavigationDataSourceTest.kt
@@ -69,7 +69,7 @@ class CachedNavigationDataSourceTest {
     fun `caches error results too`() = runBlocking {
         val delegate = CountingNavigationDataSource(
             listOf(
-                Result.Error(Exception("fail")),
+                Result.Error(RuntimeException("fail")),
                 Result.Success(graph),
             ).iterator()
         )

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/navigation/NavigationViewModelTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/navigation/NavigationViewModelTest.kt
@@ -41,7 +41,7 @@ class NavigationViewModelTest {
 
     @Test
     fun `transitions to Error state on data source error`() = testScope.runTest {
-        val dataSource = FakeNavigationDataSourceImpl(Result.Error(Exception("Network error")))
+        val dataSource = FakeNavigationDataSourceImpl(Result.Error(RuntimeException("Network error")))
         val vm = NavigationViewModel(dataSource, this)
 
         val state = vm.state.value
@@ -145,7 +145,7 @@ class NavigationViewModelTest {
 
     @Test
     fun `UpdateGraph sets Content from non-Content state`() = testScope.runTest {
-        val dataSource = FakeNavigationDataSourceImpl(Result.Error(Exception("initial error")))
+        val dataSource = FakeNavigationDataSourceImpl(Result.Error(RuntimeException("initial error")))
         val vm = NavigationViewModel(dataSource, this)
         assertTrue(vm.state.value is NavigationUiState.Error)
 


### PR DESCRIPTION
## Summary
- Add `maxCursors` parameter (default 100) with LRU eviction to `PerformanceAuditStreamService` to prevent unbounded memory growth from accumulating cursor entries for distinct filter combinations
- Use `LinkedHashMap` with access-order so least-recently-used cursors are evicted first when the limit is exceeded
- Add test verifying LRU eviction behavior
- Fix pre-existing `Result.Error` test compilation errors in `CachedNavigationDataSourceTest` and `NavigationViewModelTest` (string argument changed to `Throwable`)

## Test plan
- [x] `./gradlew :desktop-core:test` passes (301 tests, 0 failures)
- [x] LRU eviction test verifies correct cursor is evicted when capacity exceeded

🤖 Generated with [Claude Code](https://claude.com/claude-code)