### PR TITLE
refactor: consolidate connection state types

### DIFF
--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/AutoMobileContent.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/AutoMobileContent.kt
@@ -100,7 +100,7 @@ import dev.jasonpearson.automobile.desktop.core.daemon.McpHttpClient
 import dev.jasonpearson.automobile.desktop.core.daemon.McpDaemonClient
 import dev.jasonpearson.automobile.desktop.core.daemon.DaemonSocketPaths
 import dev.jasonpearson.automobile.desktop.core.daemon.ObservationStreamClient
-import dev.jasonpearson.automobile.desktop.core.daemon.StreamConnectionState
+import dev.jasonpearson.automobile.desktop.core.connection.ConnectionState
 import dev.jasonpearson.automobile.desktop.core.daemon.FailuresPushSocketClient
 import dev.jasonpearson.automobile.desktop.core.daemon.TelemetryPushClient
 import dev.jasonpearson.automobile.desktop.core.daemon.TelemetryPushSocketClient
@@ -735,7 +735,7 @@ fun AutoMobileContent(
   LaunchedEffect(observationStreamClient) {
       val client = observationStreamClient ?: return@LaunchedEffect
       client.connectionState.collect { connectionState ->
-          if (connectionState is StreamConnectionState.Disconnected) {
+          if (connectionState is ConnectionState.Disconnected) {
               currentFps = null
               currentFrameTimeMs = null
               currentJankFrames = null

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/connection/ConnectionState.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/connection/ConnectionState.kt
@@ -1,0 +1,17 @@
+package dev.jasonpearson.automobile.desktop.core.connection
+
+sealed class ConnectionState {
+    data class Disconnected(val reason: String? = null) : ConnectionState()
+    data object Connecting : ConnectionState()
+    data class Connected(val subscribed: Boolean = false) : ConnectionState()
+    data class Reconnecting(val attempt: Int, val nextRetryMs: Long) : ConnectionState()
+    data class Error(val message: String) : ConnectionState()
+}
+
+val ConnectionState.isConnected: Boolean
+    get() = this is ConnectionState.Connected
+
+val ConnectionState.shouldReconnect: Boolean
+    get() = this is ConnectionState.Connecting ||
+            this is ConnectionState.Connected ||
+            this is ConnectionState.Reconnecting

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/FailuresPushSocketClient.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/FailuresPushSocketClient.kt
@@ -1,5 +1,8 @@
 package dev.jasonpearson.automobile.desktop.core.daemon
 
+import dev.jasonpearson.automobile.desktop.core.connection.ConnectionState
+import dev.jasonpearson.automobile.desktop.core.connection.isConnected
+import dev.jasonpearson.automobile.desktop.core.connection.shouldReconnect
 import dev.jasonpearson.automobile.desktop.core.logging.LoggerFactory
 import java.io.BufferedReader
 import java.io.BufferedWriter
@@ -57,16 +60,11 @@ class FailuresPushSocketClient {
     private var writer: BufferedWriter? = null
     private var connectionJob: Job? = null
 
-    private val _state = MutableStateFlow<FailuresPushConnectionState>(FailuresPushConnectionState.Disconnected(null))
-    val connectionState: StateFlow<FailuresPushConnectionState> = _state.asStateFlow()
+    private val _state = MutableStateFlow<ConnectionState>(ConnectionState.Disconnected(null))
+    val connectionState: StateFlow<ConnectionState> = _state.asStateFlow()
 
-    private val _isConnected: Boolean get() = _state.value is FailuresPushConnectionState.Connected
-    private val _shouldReconnect: Boolean get() {
-        val current = _state.value
-        return current is FailuresPushConnectionState.Connecting ||
-            current is FailuresPushConnectionState.Connected ||
-            current is FailuresPushConnectionState.Reconnecting
-    }
+    private val _isConnected: Boolean get() = _state.value.isConnected
+    private val _shouldReconnect: Boolean get() = _state.value.shouldReconnect
 
     // Retry configuration
     private val initialRetryDelayMs = 1000L
@@ -94,7 +92,7 @@ class FailuresPushSocketClient {
 
         // Cancel any existing connection job
         connectionJob?.cancel()
-        _state.update { FailuresPushConnectionState.Connecting }
+        _state.update { ConnectionState.Connecting }
 
         connectionJob = scope.launch {
             connectWithRetry(type, severity)
@@ -123,7 +121,7 @@ class FailuresPushSocketClient {
                     OutputStreamWriter(Channels.newOutputStream(channel!!), StandardCharsets.UTF_8)
                 )
 
-                _state.update { FailuresPushConnectionState.Connected(subscribed = false) }
+                _state.update { ConnectionState.Connected(subscribed = false) }
                 attempt = 0
                 log.info("Connected to failures push")
 
@@ -137,7 +135,7 @@ class FailuresPushSocketClient {
                 if (_shouldReconnect) {
                     log.info("Connection lost, will attempt to reconnect")
                     attempt++
-                    _state.update { FailuresPushConnectionState.Reconnecting(attempt, calculateBackoff(attempt)) }
+                    _state.update { ConnectionState.Reconnecting(attempt, calculateBackoff(attempt)) }
                 }
 
             } catch (e: Exception) {
@@ -145,7 +143,7 @@ class FailuresPushSocketClient {
 
                 if (!_shouldReconnect) {
                     log.info("Reconnection disabled, stopping connection attempts")
-                    _state.update { FailuresPushConnectionState.Disconnected("Disconnected") }
+                    _state.update { ConnectionState.Disconnected("Disconnected") }
                     return
                 }
 
@@ -153,13 +151,13 @@ class FailuresPushSocketClient {
                 val delayMs = calculateBackoff(attempt)
 
                 log.warn("Failed to connect to failures push (attempt $attempt): ${e.message}. Retrying in ${delayMs}ms")
-                _state.update { FailuresPushConnectionState.Reconnecting(attempt, delayMs) }
+                _state.update { ConnectionState.Reconnecting(attempt, delayMs) }
 
                 delay(delayMs)
             }
         }
 
-        _state.update { FailuresPushConnectionState.Disconnected("Stopped") }
+        _state.update { ConnectionState.Disconnected("Stopped") }
     }
 
     private fun calculateBackoff(attempt: Int): Long {
@@ -176,12 +174,12 @@ class FailuresPushSocketClient {
     fun disconnect() {
         val previousState = _state.value
         // Stop reconnection attempts by moving to Disconnected
-        _state.update { FailuresPushConnectionState.Disconnected(null) }
+        _state.update { ConnectionState.Disconnected(null) }
 
         connectionJob?.cancel()
         connectionJob = null
 
-        if (previousState !is FailuresPushConnectionState.Connected) {
+        if (previousState !is ConnectionState.Connected) {
             return
         }
 
@@ -225,7 +223,7 @@ class FailuresPushSocketClient {
 
         if (sendRequest(request)) {
             _state.update { current ->
-                if (current is FailuresPushConnectionState.Connected) {
+                if (current is ConnectionState.Connected) {
                     current.copy(subscribed = true)
                 } else {
                     current
@@ -351,10 +349,3 @@ data class FailureNotification(
     val message: String,
     val timestamp: Long,
 )
-
-sealed class FailuresPushConnectionState {
-    data object Connecting : FailuresPushConnectionState()
-    data class Connected(val subscribed: Boolean = false) : FailuresPushConnectionState()
-    data class Reconnecting(val attempt: Int, val nextRetryMs: Long) : FailuresPushConnectionState()
-    data class Disconnected(val reason: String?) : FailuresPushConnectionState()
-}

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/FakeTelemetryPushClient.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/FakeTelemetryPushClient.kt
@@ -1,5 +1,6 @@
 package dev.jasonpearson.automobile.desktop.core.daemon
 
+import dev.jasonpearson.automobile.desktop.core.connection.ConnectionState
 import dev.jasonpearson.automobile.desktop.core.telemetry.TelemetryDisplayEvent
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.SharedFlow
@@ -18,8 +19,8 @@ class FakeTelemetryPushClient : TelemetryPushClient {
     )
     override val telemetryEvents: SharedFlow<TelemetryDisplayEvent> = _telemetryEvents.asSharedFlow()
 
-    private val _connectionState = MutableSharedFlow<TelemetryConnectionState>(replay = 1)
-    override val connectionState: SharedFlow<TelemetryConnectionState> = _connectionState.asSharedFlow()
+    private val _connectionState = MutableSharedFlow<ConnectionState>(replay = 1)
+    override val connectionState: SharedFlow<ConnectionState> = _connectionState.asSharedFlow()
 
     private var connected = false
     private var connectCallCount = 0
@@ -30,13 +31,13 @@ class FakeTelemetryPushClient : TelemetryPushClient {
         connectCallCount++
         lastDeviceId = deviceId
         connected = true
-        _connectionState.tryEmit(TelemetryConnectionState.Connected())
+        _connectionState.tryEmit(ConnectionState.Connected())
     }
 
     override fun disconnect() {
         disconnectCallCount++
         connected = false
-        _connectionState.tryEmit(TelemetryConnectionState.Disconnected(null))
+        _connectionState.tryEmit(ConnectionState.Disconnected(null))
     }
 
     override fun isConnected(): Boolean = connected
@@ -51,8 +52,8 @@ class FakeTelemetryPushClient : TelemetryPushClient {
     fun emitEvent(event: TelemetryDisplayEvent): Boolean = _telemetryEvents.tryEmit(event)
 
     /** Set the connection state for testing. */
-    fun setConnectionState(state: TelemetryConnectionState) {
-        connected = state is TelemetryConnectionState.Connected
+    fun setConnectionState(state: ConnectionState) {
+        connected = state is ConnectionState.Connected
         _connectionState.tryEmit(state)
     }
 

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/ObservationStreamClient.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/ObservationStreamClient.kt
@@ -1,5 +1,7 @@
 package dev.jasonpearson.automobile.desktop.core.daemon
 
+import dev.jasonpearson.automobile.desktop.core.connection.ConnectionState
+import dev.jasonpearson.automobile.desktop.core.connection.isConnected
 import dev.jasonpearson.automobile.desktop.core.logging.LoggerFactory
 import java.io.BufferedReader
 import java.io.BufferedWriter
@@ -12,14 +14,17 @@ import java.nio.charset.StandardCharsets
 import java.nio.file.Files
 import java.nio.file.Path
 import java.util.UUID
-import java.util.concurrent.atomic.AtomicBoolean
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
@@ -57,8 +62,6 @@ class ObservationStreamClient {
     private var channel: SocketChannel? = null
     private var reader: BufferedReader? = null
     private var writer: BufferedWriter? = null
-    private val connected = AtomicBoolean(false)
-    private val subscribed = AtomicBoolean(false)
 
     // Flow for hierarchy updates
     private val _hierarchyUpdates = MutableSharedFlow<HierarchyStreamUpdate>(replay = 1)
@@ -81,15 +84,15 @@ class ObservationStreamClient {
     val performanceUpdates: SharedFlow<PerformanceStreamUpdate> = _performanceUpdates.asSharedFlow()
 
     // Flow for connection state
-    private val _connectionState = MutableSharedFlow<StreamConnectionState>(replay = 1)
-    val connectionState: SharedFlow<StreamConnectionState> = _connectionState.asSharedFlow()
+    private val _connectionState = MutableStateFlow<ConnectionState>(ConnectionState.Disconnected())
+    val connectionState: StateFlow<ConnectionState> = _connectionState.asStateFlow()
 
     /**
      * Connect to the observation stream socket and subscribe to updates.
      * @param deviceId Optional device ID to subscribe to. If null, subscribes to all devices.
      */
     fun connect(deviceId: String? = null) {
-        if (connected.get()) {
+        if (_connectionState.value.isConnected) {
             log.info("Already connected to observation stream")
             return
         }
@@ -97,17 +100,13 @@ class ObservationStreamClient {
         val socketPath = getSocketPath()
         log.info("Connecting to observation stream at $socketPath")
 
-        scope.launch {
-            _connectionState.emit(StreamConnectionState.Connecting)
-        }
+        _connectionState.update { ConnectionState.Connecting }
 
         try {
             val path = Path.of(socketPath)
             if (!Files.exists(path)) {
                 log.warn("Observation stream socket not found at $socketPath")
-                scope.launch {
-                    _connectionState.emit(StreamConnectionState.Disconnected("Socket not found"))
-                }
+                _connectionState.update { ConnectionState.Disconnected("Socket not found") }
                 return
             }
 
@@ -120,7 +119,7 @@ class ObservationStreamClient {
                 OutputStreamWriter(Channels.newOutputStream(channel!!), StandardCharsets.UTF_8)
             )
 
-            connected.set(true)
+            _connectionState.update { ConnectionState.Connected() }
             log.info("Connected to observation stream")
 
             // Send subscribe request
@@ -133,18 +132,18 @@ class ObservationStreamClient {
 
         } catch (e: Exception) {
             log.warn("Failed to connect to observation stream: ${e.message}")
-            scope.launch {
-                _connectionState.emit(StreamConnectionState.Disconnected(e.message))
-            }
+            _connectionState.update { ConnectionState.Disconnected(e.message) }
         }
     }
 
     fun disconnect() {
-        if (!connected.get()) return
+        if (!_connectionState.value.isConnected) return
+
+        val previousState = _connectionState.value
 
         try {
             // Send unsubscribe request
-            if (subscribed.get()) {
+            if (previousState is ConnectionState.Connected && previousState.subscribed) {
                 val request = StreamRequest(
                     id = UUID.randomUUID().toString(),
                     command = "unsubscribe",
@@ -160,15 +159,10 @@ class ObservationStreamClient {
         channel = null
         reader = null
         writer = null
-        connected.set(false)
-        subscribed.set(false)
-
-        scope.launch {
-            _connectionState.emit(StreamConnectionState.Disconnected(null))
-        }
+        _connectionState.update { ConnectionState.Disconnected() }
     }
 
-    fun isConnected(): Boolean = connected.get()
+    fun isConnected(): Boolean = _connectionState.value.isConnected
 
     /**
      * Disconnect and cancel the internal coroutine scope.
@@ -187,7 +181,13 @@ class ObservationStreamClient {
         )
 
         if (sendRequest(request)) {
-            subscribed.set(true)
+            _connectionState.update { current ->
+                if (current is ConnectionState.Connected) {
+                    current.copy(subscribed = true)
+                } else {
+                    current
+                }
+            }
             log.info("Subscribed to observation stream (device: ${deviceId ?: "all"})")
         }
     }
@@ -211,10 +211,9 @@ class ObservationStreamClient {
         val currentReader = reader ?: return
 
         try {
-            _connectionState.emit(StreamConnectionState.Connected)
             log.info("Starting message read loop")
 
-            while (connected.get()) {
+            while (_connectionState.value.isConnected) {
                 val line = currentReader.readLine() ?: break
                 if (line.isBlank()) continue
 
@@ -226,14 +225,12 @@ class ObservationStreamClient {
                     log.warn("Failed to parse observation stream message: ${e.message}", e)
                 }
             }
-            log.info("Read loop ended - connected=${connected.get()}")
+            log.info("Read loop ended - connected=${_connectionState.value.isConnected}")
         } catch (e: Exception) {
             log.warn("Error reading from observation stream: ${e.message}", e)
         }
 
-        connected.set(false)
-        subscribed.set(false)
-        _connectionState.emit(StreamConnectionState.Disconnected("Stream ended"))
+        _connectionState.update { ConnectionState.Disconnected("Stream ended") }
         log.info("Observation stream disconnected")
     }
 
@@ -339,7 +336,7 @@ class ObservationStreamClient {
      *              If null, the server returns the graph for the current foreground app.
      */
     fun requestNavigationGraph(appId: String? = null) {
-        if (!connected.get()) return
+        if (!_connectionState.value.isConnected) return
 
         val request = StreamRequest(
             id = UUID.randomUUID().toString(),
@@ -478,9 +475,3 @@ data class PerformanceStreamUpdate(
     val recompositionCount: Int?,
     val recompositionRate: Float?,
 )
-
-sealed class StreamConnectionState {
-    data object Connecting : StreamConnectionState()
-    data object Connected : StreamConnectionState()
-    data class Disconnected(val reason: String?) : StreamConnectionState()
-}

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/PerformancePushSocketClient.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/PerformancePushSocketClient.kt
@@ -1,5 +1,7 @@
 package dev.jasonpearson.automobile.desktop.core.daemon
 
+import dev.jasonpearson.automobile.desktop.core.connection.ConnectionState
+import dev.jasonpearson.automobile.desktop.core.connection.isConnected
 import dev.jasonpearson.automobile.desktop.core.logging.LoggerFactory
 import java.io.BufferedReader
 import java.io.BufferedWriter
@@ -53,10 +55,10 @@ class PerformancePushSocketClient {
     private var reader: BufferedReader? = null
     private var writer: BufferedWriter? = null
 
-    private val _state = MutableStateFlow<PushConnectionState>(PushConnectionState.Disconnected(null))
-    val connectionState: StateFlow<PushConnectionState> = _state.asStateFlow()
+    private val _state = MutableStateFlow<ConnectionState>(ConnectionState.Disconnected(null))
+    val connectionState: StateFlow<ConnectionState> = _state.asStateFlow()
 
-    private val _isConnected: Boolean get() = _state.value is PushConnectionState.Connected
+    private val _isConnected: Boolean get() = _state.value.isConnected
 
     // Flow for live performance data
     private val _performanceData = MutableSharedFlow<LivePerformanceData>(
@@ -80,13 +82,13 @@ class PerformancePushSocketClient {
         val socketPath = getSocketPath()
         log.info("Connecting to performance push at $socketPath")
 
-        _state.update { PushConnectionState.Connecting }
+        _state.update { ConnectionState.Connecting }
 
         try {
             val path = Path.of(socketPath)
             if (!Files.exists(path)) {
                 log.warn("Performance push socket not found at $socketPath")
-                _state.update { PushConnectionState.Disconnected("Socket not found") }
+                _state.update { ConnectionState.Disconnected("Socket not found") }
                 return
             }
 
@@ -99,7 +101,7 @@ class PerformancePushSocketClient {
                 OutputStreamWriter(Channels.newOutputStream(channel!!), StandardCharsets.UTF_8)
             )
 
-            _state.update { PushConnectionState.Connected(subscribed = false) }
+            _state.update { ConnectionState.Connected(subscribed = false) }
             log.info("Connected to performance push")
 
             // Send subscribe request
@@ -112,7 +114,7 @@ class PerformancePushSocketClient {
 
         } catch (e: Exception) {
             log.warn("Failed to connect to performance push: ${e.message}")
-            _state.update { PushConnectionState.Disconnected(e.message) }
+            _state.update { ConnectionState.Disconnected(e.message) }
         }
     }
 
@@ -121,7 +123,7 @@ class PerformancePushSocketClient {
 
         try {
             val currentState = _state.value
-            if (currentState is PushConnectionState.Connected && currentState.subscribed) {
+            if (currentState is ConnectionState.Connected && currentState.subscribed) {
                 val request = PushRequest(
                     id = UUID.randomUUID().toString(),
                     command = "unsubscribe",
@@ -137,7 +139,7 @@ class PerformancePushSocketClient {
         channel = null
         reader = null
         writer = null
-        _state.update { PushConnectionState.Disconnected(null) }
+        _state.update { ConnectionState.Disconnected(null) }
     }
 
     fun isConnected(): Boolean = _isConnected
@@ -152,7 +154,7 @@ class PerformancePushSocketClient {
 
         if (sendRequest(request)) {
             _state.update { current ->
-                if (current is PushConnectionState.Connected) {
+                if (current is ConnectionState.Connected) {
                     current.copy(subscribed = true)
                 } else {
                     current
@@ -201,7 +203,7 @@ class PerformancePushSocketClient {
         channel = null
         reader = null
         writer = null
-        _state.update { PushConnectionState.Disconnected("Stream ended") }
+        _state.update { ConnectionState.Disconnected("Stream ended") }
         log.info("Performance push disconnected")
     }
 
@@ -301,9 +303,3 @@ data class PerformanceThresholds(
     val ttiWarning: Float,
     val ttiCritical: Float,
 )
-
-sealed class PushConnectionState {
-    data object Connecting : PushConnectionState()
-    data class Connected(val subscribed: Boolean = false) : PushConnectionState()
-    data class Disconnected(val reason: String?) : PushConnectionState()
-}

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/TelemetryPushClient.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/TelemetryPushClient.kt
@@ -1,5 +1,6 @@
 package dev.jasonpearson.automobile.desktop.core.daemon
 
+import dev.jasonpearson.automobile.desktop.core.connection.ConnectionState
 import dev.jasonpearson.automobile.desktop.core.telemetry.TelemetryDisplayEvent
 import kotlinx.coroutines.flow.SharedFlow
 
@@ -11,7 +12,7 @@ interface TelemetryPushClient {
     val telemetryEvents: SharedFlow<TelemetryDisplayEvent>
 
     /** Flow of connection state changes. */
-    val connectionState: SharedFlow<TelemetryConnectionState>
+    val connectionState: SharedFlow<ConnectionState>
 
     /**
      * Connect to the telemetry push socket and subscribe to events.

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/TelemetryPushSocketClient.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/TelemetryPushSocketClient.kt
@@ -1,5 +1,8 @@
 package dev.jasonpearson.automobile.desktop.core.daemon
 
+import dev.jasonpearson.automobile.desktop.core.connection.ConnectionState
+import dev.jasonpearson.automobile.desktop.core.connection.isConnected
+import dev.jasonpearson.automobile.desktop.core.connection.shouldReconnect
 import dev.jasonpearson.automobile.desktop.core.logging.LoggerFactory
 import dev.jasonpearson.automobile.desktop.core.telemetry.TelemetryDisplayEvent
 import dev.jasonpearson.automobile.desktop.core.telemetry.TelemetryPushRequest
@@ -62,16 +65,11 @@ class TelemetryPushSocketClient : TelemetryPushClient {
     private var writer: BufferedWriter? = null
     private var connectionJob: Job? = null
 
-    private val _state = MutableStateFlow<TelemetryConnectionState>(TelemetryConnectionState.Disconnected(null))
-    override val connectionState: SharedFlow<TelemetryConnectionState> = _state.asStateFlow()
+    private val _state = MutableStateFlow<ConnectionState>(ConnectionState.Disconnected(null))
+    override val connectionState: SharedFlow<ConnectionState> = _state.asStateFlow()
 
-    private val _isConnected: Boolean get() = _state.value is TelemetryConnectionState.Connected
-    private val _shouldReconnect: Boolean get() {
-        val current = _state.value
-        return current is TelemetryConnectionState.Connecting ||
-            current is TelemetryConnectionState.Connected ||
-            current is TelemetryConnectionState.Reconnecting
-    }
+    private val _isConnected: Boolean get() = _state.value.isConnected
+    private val _shouldReconnect: Boolean get() = _state.value.shouldReconnect
 
     // Retry configuration
     private val initialRetryDelayMs = 1000L
@@ -99,7 +97,7 @@ class TelemetryPushSocketClient : TelemetryPushClient {
 
         subscribedDeviceId = deviceId
         connectionJob?.cancel()
-        _state.update { TelemetryConnectionState.Connecting }
+        _state.update { ConnectionState.Connecting }
 
         connectionJob = scope.launch {
             connectWithRetry()
@@ -128,7 +126,7 @@ class TelemetryPushSocketClient : TelemetryPushClient {
                     OutputStreamWriter(Channels.newOutputStream(channel!!), StandardCharsets.UTF_8)
                 )
 
-                _state.update { TelemetryConnectionState.Connected(subscribed = false) }
+                _state.update { ConnectionState.Connected(subscribed = false) }
                 attempt = 0
                 log.info("Connected to telemetry push")
 
@@ -142,7 +140,7 @@ class TelemetryPushSocketClient : TelemetryPushClient {
                 if (_shouldReconnect) {
                     log.info("Telemetry push connection lost, will attempt to reconnect")
                     attempt++
-                    _state.update { TelemetryConnectionState.Reconnecting(attempt, calculateBackoff(attempt)) }
+                    _state.update { ConnectionState.Reconnecting(attempt, calculateBackoff(attempt)) }
                 }
 
             } catch (e: Exception) {
@@ -150,7 +148,7 @@ class TelemetryPushSocketClient : TelemetryPushClient {
 
                 if (!_shouldReconnect) {
                     log.info("Telemetry push reconnection disabled, stopping")
-                    _state.update { TelemetryConnectionState.Disconnected("Disconnected") }
+                    _state.update { ConnectionState.Disconnected("Disconnected") }
                     return
                 }
 
@@ -158,13 +156,13 @@ class TelemetryPushSocketClient : TelemetryPushClient {
                 val delayMs = calculateBackoff(attempt)
 
                 log.warn("Failed to connect to telemetry push (attempt $attempt): ${e.message}. Retrying in ${delayMs}ms")
-                _state.update { TelemetryConnectionState.Reconnecting(attempt, delayMs) }
+                _state.update { ConnectionState.Reconnecting(attempt, delayMs) }
 
                 delay(delayMs)
             }
         }
 
-        _state.update { TelemetryConnectionState.Disconnected("Stopped") }
+        _state.update { ConnectionState.Disconnected("Stopped") }
     }
 
     private fun calculateBackoff(attempt: Int): Long {
@@ -178,12 +176,12 @@ class TelemetryPushSocketClient : TelemetryPushClient {
 
     override fun disconnect() {
         val previousState = _state.value
-        _state.update { TelemetryConnectionState.Disconnected(null) }
+        _state.update { ConnectionState.Disconnected(null) }
 
         connectionJob?.cancel()
         connectionJob = null
 
-        if (previousState !is TelemetryConnectionState.Connected) {
+        if (previousState !is ConnectionState.Connected) {
             return
         }
 
@@ -227,7 +225,7 @@ class TelemetryPushSocketClient : TelemetryPushClient {
 
         if (sendRequest(request)) {
             _state.update { current ->
-                if (current is TelemetryConnectionState.Connected) {
+                if (current is ConnectionState.Connected) {
                     current.copy(subscribed = true)
                 } else {
                     current
@@ -328,11 +326,4 @@ class TelemetryPushSocketClient : TelemetryPushClient {
         )
         sendRequest(request)
     }
-}
-
-sealed class TelemetryConnectionState {
-    data object Connecting : TelemetryConnectionState()
-    data class Connected(val subscribed: Boolean = false) : TelemetryConnectionState()
-    data class Reconnecting(val attempt: Int, val nextRetryMs: Long) : TelemetryConnectionState()
-    data class Disconnected(val reason: String?) : TelemetryConnectionState()
 }

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/failures/FailuresDashboard.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/failures/FailuresDashboard.kt
@@ -41,7 +41,6 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import dev.jasonpearson.automobile.desktop.core.daemon.AutoMobileClient
 import dev.jasonpearson.automobile.desktop.core.daemon.FailuresPushSocketClient
-import dev.jasonpearson.automobile.desktop.core.daemon.FailuresPushConnectionState
 import dev.jasonpearson.automobile.desktop.core.datasource.DataSourceMode
 import dev.jasonpearson.automobile.desktop.core.datasource.Result
 import dev.jasonpearson.automobile.desktop.core.time.Clock

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/layout/StreamConnectionGracePeriod.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/layout/StreamConnectionGracePeriod.kt
@@ -1,13 +1,13 @@
 package dev.jasonpearson.automobile.desktop.core.layout
 
-import dev.jasonpearson.automobile.desktop.core.daemon.StreamConnectionState
+import dev.jasonpearson.automobile.desktop.core.connection.ConnectionState
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 
 /**
- * Mediates between raw [StreamConnectionState] events and UI status updates,
+ * Mediates between raw [ConnectionState] events and UI status updates,
  * absorbing brief disconnections during reconnection to prevent the UI from
  * flashing "Device Disconnected" on transient interruptions.
  *
@@ -28,21 +28,21 @@ class StreamConnectionGracePeriod(
     private var hasBeenConnected = false
     private var gracePeriodJob: Job? = null
 
-    fun onStreamStateChange(state: StreamConnectionState) {
+    fun onStreamStateChange(state: ConnectionState) {
         when (state) {
-            is StreamConnectionState.Connected -> {
+            is ConnectionState.Connected -> {
                 gracePeriodJob?.cancel()
                 gracePeriodJob = null
                 hasBeenConnected = true
                 onStatusChange(ConnectionStatus.Connected)
             }
-            is StreamConnectionState.Connecting -> {
+            is ConnectionState.Connecting, is ConnectionState.Reconnecting -> {
                 if (!hasBeenConnected) {
                     onStatusChange(ConnectionStatus.Connecting)
                 }
                 // If previously connected, suppress — keep showing Connected
             }
-            is StreamConnectionState.Disconnected -> {
+            is ConnectionState.Disconnected, is ConnectionState.Error -> {
                 if (!hasBeenConnected) {
                     onDisconnectConfirmed()
                     return

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/telemetry/TelemetryDashboard.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/telemetry/TelemetryDashboard.kt
@@ -51,7 +51,7 @@ import androidx.compose.ui.graphics.vector.ImageVector
 import dev.jasonpearson.automobile.desktop.core.components.SearchBar
 import dev.jasonpearson.automobile.desktop.core.theme.AppIcons
 import kotlinx.coroutines.delay
-import dev.jasonpearson.automobile.desktop.core.daemon.TelemetryConnectionState
+import dev.jasonpearson.automobile.desktop.core.connection.ConnectionState
 import dev.jasonpearson.automobile.desktop.core.daemon.TelemetryPushClient
 import dev.jasonpearson.automobile.desktop.core.datasource.DataSourceMode
 import dev.jasonpearson.automobile.desktop.core.theme.SharedTheme
@@ -196,7 +196,7 @@ fun TelemetryDashboard(
         previousDeviceId = activeDeviceId
     }
     var selectedFilter by remember { mutableStateOf(CategoryFilter.All) }
-    var connectionState by remember { mutableStateOf<TelemetryConnectionState?>(null) }
+    var connectionState by remember { mutableStateOf<ConnectionState?>(null) }
     val listState = rememberLazyListState()
     val timeFormat = remember { SimpleDateFormat("HH:mm:ss.SSS", Locale.US) }
     var isPaused by remember { mutableStateOf(false) }
@@ -578,12 +578,13 @@ fun TelemetryDashboard(
 
         // Connection status bar (when disconnected)
         val state = connectionState
-        if (state != null && state !is TelemetryConnectionState.Connected) {
+        if (state != null && state !is ConnectionState.Connected) {
             val statusText = when (state) {
-                is TelemetryConnectionState.Connecting -> "Connecting..."
-                is TelemetryConnectionState.Reconnecting -> "Reconnecting (attempt ${state.attempt})..."
-                is TelemetryConnectionState.Disconnected -> "Disconnected${state.reason?.let { ": $it" } ?: ""}"
-                is TelemetryConnectionState.Connected -> ""
+                is ConnectionState.Connecting -> "Connecting..."
+                is ConnectionState.Reconnecting -> "Reconnecting (attempt ${state.attempt})..."
+                is ConnectionState.Disconnected -> "Disconnected${state.reason?.let { ": $it" } ?: ""}"
+                is ConnectionState.Error -> "Error: ${state.message}"
+                is ConnectionState.Connected -> ""
             }
             Box(
                 modifier = Modifier

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/unified/FakeUnifiedSocketClient.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/unified/FakeUnifiedSocketClient.kt
@@ -1,5 +1,6 @@
 package dev.jasonpearson.automobile.desktop.core.unified
 
+import dev.jasonpearson.automobile.desktop.core.connection.ConnectionState
 import java.util.concurrent.ConcurrentHashMap
 import kotlin.time.Duration
 import kotlinx.coroutines.flow.Flow
@@ -19,8 +20,8 @@ import kotlinx.serialization.json.JsonElement
  * - Call tracking for verification
  */
 class FakeUnifiedSocketClient : UnifiedSocketClient {
-    private val _connectionState = MutableStateFlow<UnifiedConnectionState>(UnifiedConnectionState.Disconnected)
-    override val connectionState: StateFlow<UnifiedConnectionState> = _connectionState.asStateFlow()
+    private val _connectionState = MutableStateFlow<ConnectionState>(ConnectionState.Disconnected())
+    override val connectionState: StateFlow<ConnectionState> = _connectionState.asStateFlow()
 
     private val responses = ConcurrentHashMap<String, JsonElement>()
     private val errors = ConcurrentHashMap<String, ErrorPayload>()
@@ -103,16 +104,16 @@ class FakeUnifiedSocketClient : UnifiedSocketClient {
     /**
      * Set the connection state.
      */
-    fun setConnectionState(state: UnifiedConnectionState) {
+    fun setConnectionState(state: ConnectionState) {
         _connectionState.value = state
     }
 
     override suspend fun connect() {
-        _connectionState.value = UnifiedConnectionState.Connected
+        _connectionState.value = ConnectionState.Connected()
     }
 
     override suspend fun disconnect() {
-        _connectionState.value = UnifiedConnectionState.Disconnected
+        _connectionState.value = ConnectionState.Disconnected()
     }
 
     @Suppress("UNCHECKED_CAST")

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/unified/UnifiedProtocol.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/unified/UnifiedProtocol.kt
@@ -72,17 +72,6 @@ data class SubscriptionResult(
 )
 
 /**
- * Connection state for the unified socket client.
- */
-sealed class UnifiedConnectionState {
-    data object Disconnected : UnifiedConnectionState()
-    data object Connecting : UnifiedConnectionState()
-    data object Connected : UnifiedConnectionState()
-    data class Reconnecting(val attempt: Int, val nextRetryMs: Long) : UnifiedConnectionState()
-    data class Error(val message: String) : UnifiedConnectionState()
-}
-
-/**
  * Exception thrown when a request times out.
  */
 class RequestTimeoutException(message: String) : Exception(message)

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/unified/UnifiedSocketClient.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/unified/UnifiedSocketClient.kt
@@ -1,5 +1,8 @@
 package dev.jasonpearson.automobile.desktop.core.unified
 
+import dev.jasonpearson.automobile.desktop.core.connection.ConnectionState
+import dev.jasonpearson.automobile.desktop.core.connection.isConnected
+import dev.jasonpearson.automobile.desktop.core.connection.shouldReconnect
 import dev.jasonpearson.automobile.desktop.core.logging.LoggerFactory
 import java.io.BufferedReader
 import java.io.BufferedWriter
@@ -43,7 +46,7 @@ import kotlinx.serialization.json.JsonPrimitive
  * Interface for the unified socket client.
  */
 interface UnifiedSocketClient {
-    val connectionState: StateFlow<UnifiedConnectionState>
+    val connectionState: StateFlow<ConnectionState>
 
     suspend fun connect()
     suspend fun disconnect()
@@ -104,16 +107,11 @@ class UnifiedSocketClientImpl : UnifiedSocketClient {
     private var connectionJob: Job? = null
     private var readJob: Job? = null
 
-    private val _connectionState = MutableStateFlow<UnifiedConnectionState>(UnifiedConnectionState.Disconnected)
-    override val connectionState: StateFlow<UnifiedConnectionState> = _connectionState.asStateFlow()
+    private val _connectionState = MutableStateFlow<ConnectionState>(ConnectionState.Disconnected())
+    override val connectionState: StateFlow<ConnectionState> = _connectionState.asStateFlow()
 
-    private val isConnected: Boolean get() = _connectionState.value is UnifiedConnectionState.Connected
-    private val shouldReconnect: Boolean get() {
-        val current = _connectionState.value
-        return current is UnifiedConnectionState.Connecting ||
-            current is UnifiedConnectionState.Connected ||
-            current is UnifiedConnectionState.Reconnecting
-    }
+    private val isConnected: Boolean get() = _connectionState.value.isConnected
+    private val shouldReconnect: Boolean get() = _connectionState.value.shouldReconnect
 
     // Retry configuration
     private val initialRetryDelayMs = 1000L
@@ -144,7 +142,7 @@ class UnifiedSocketClientImpl : UnifiedSocketClient {
         }
 
         connectionJob?.cancel()
-        _connectionState.update { UnifiedConnectionState.Connecting }
+        _connectionState.update { ConnectionState.Connecting }
 
         connectionJob = scope.launch {
             connectWithRetry()
@@ -173,7 +171,7 @@ class UnifiedSocketClientImpl : UnifiedSocketClient {
                     OutputStreamWriter(Channels.newOutputStream(channel!!), StandardCharsets.UTF_8)
                 )
 
-                _connectionState.update { UnifiedConnectionState.Connected }
+                _connectionState.update { ConnectionState.Connected() }
                 attempt = 0
                 log.info("Connected to unified socket")
 
@@ -189,7 +187,7 @@ class UnifiedSocketClientImpl : UnifiedSocketClient {
                     log.info("Connection lost, will attempt to reconnect")
                     attempt++
                     val delayMs = calculateBackoff(attempt)
-                    _connectionState.update { UnifiedConnectionState.Reconnecting(attempt, delayMs) }
+                    _connectionState.update { ConnectionState.Reconnecting(attempt, delayMs) }
                     failAllPendingRequests("Connection lost")
                 }
 
@@ -198,7 +196,7 @@ class UnifiedSocketClientImpl : UnifiedSocketClient {
 
                 if (!shouldReconnect) {
                     log.info("Reconnection disabled, stopping connection attempts")
-                    _connectionState.update { UnifiedConnectionState.Disconnected }
+                    _connectionState.update { ConnectionState.Disconnected() }
                     return
                 }
 
@@ -206,13 +204,13 @@ class UnifiedSocketClientImpl : UnifiedSocketClient {
                 val delayMs = calculateBackoff(attempt)
 
                 log.warn("Failed to connect to unified socket (attempt $attempt): ${e.message}. Retrying in ${delayMs}ms")
-                _connectionState.update { UnifiedConnectionState.Reconnecting(attempt, delayMs) }
+                _connectionState.update { ConnectionState.Reconnecting(attempt, delayMs) }
 
                 delay(delayMs)
             }
         }
 
-        _connectionState.update { UnifiedConnectionState.Disconnected }
+        _connectionState.update { ConnectionState.Disconnected() }
     }
 
     private fun calculateBackoff(attempt: Int): Long {
@@ -225,7 +223,7 @@ class UnifiedSocketClientImpl : UnifiedSocketClient {
     private class SocketNotFoundError(message: String) : Exception(message)
 
     override suspend fun disconnect() {
-        _connectionState.update { UnifiedConnectionState.Disconnected }
+        _connectionState.update { ConnectionState.Disconnected() }
 
         connectionJob?.cancel()
         connectionJob = null

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/FakeTelemetryPushClientTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/FakeTelemetryPushClientTest.kt
@@ -1,5 +1,6 @@
 package dev.jasonpearson.automobile.desktop.core.daemon
 
+import dev.jasonpearson.automobile.desktop.core.connection.ConnectionState
 import dev.jasonpearson.automobile.desktop.core.telemetry.TelemetryDisplayEvent
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -21,7 +22,7 @@ class FakeTelemetryPushClientTest {
 
         client.connect(null)
         assertTrue(client.isConnected())
-        assertEquals(TelemetryConnectionState.Connected(), client.connectionState.first())
+        assertEquals(ConnectionState.Connected(), client.connectionState.first())
     }
 
     @Test
@@ -33,7 +34,7 @@ class FakeTelemetryPushClientTest {
         client.disconnect()
         assertFalse(client.isConnected())
         assertEquals(
-            TelemetryConnectionState.Disconnected(null),
+            ConnectionState.Disconnected(null),
             client.connectionState.first(),
         )
     }
@@ -121,13 +122,13 @@ class FakeTelemetryPushClientTest {
     @Test
     fun `setConnectionState updates connection state flow`() = runBlocking {
         val client = FakeTelemetryPushClient()
-        val reconnecting = TelemetryConnectionState.Reconnecting(attempt = 3, nextRetryMs = 5000)
+        val reconnecting = ConnectionState.Reconnecting(attempt = 3, nextRetryMs = 5000)
 
         client.setConnectionState(reconnecting)
         assertFalse(client.isConnected())
         assertEquals(reconnecting, client.connectionState.first())
 
-        client.setConnectionState(TelemetryConnectionState.Connected())
+        client.setConnectionState(ConnectionState.Connected())
         assertTrue(client.isConnected())
     }
 

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/SocketConnectionStateTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/SocketConnectionStateTest.kt
@@ -1,6 +1,8 @@
 package dev.jasonpearson.automobile.desktop.core.daemon
 
-import dev.jasonpearson.automobile.desktop.core.unified.UnifiedConnectionState
+import dev.jasonpearson.automobile.desktop.core.connection.ConnectionState
+import dev.jasonpearson.automobile.desktop.core.connection.isConnected
+import dev.jasonpearson.automobile.desktop.core.connection.shouldReconnect
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.runBlocking
@@ -15,223 +17,148 @@ import org.junit.Test
  */
 class SocketConnectionStateTest {
 
-    // -- FailuresPushConnectionState transitions --
+    // -- ConnectionState transitions --
 
     @Test
-    fun `FailuresPush initial state is Disconnected`() {
-        val state = MutableStateFlow<FailuresPushConnectionState>(FailuresPushConnectionState.Disconnected(null))
-        assertTrue(state.value is FailuresPushConnectionState.Disconnected)
+    fun `initial state is Disconnected`() {
+        val state = MutableStateFlow<ConnectionState>(ConnectionState.Disconnected())
+        assertTrue(state.value is ConnectionState.Disconnected)
     }
 
     @Test
-    fun `FailuresPush Disconnected to Connecting transition`() {
-        val state = MutableStateFlow<FailuresPushConnectionState>(FailuresPushConnectionState.Disconnected(null))
-        state.update { FailuresPushConnectionState.Connecting }
-        assertTrue(state.value is FailuresPushConnectionState.Connecting)
+    fun `Disconnected to Connecting transition`() {
+        val state = MutableStateFlow<ConnectionState>(ConnectionState.Disconnected())
+        state.update { ConnectionState.Connecting }
+        assertTrue(state.value is ConnectionState.Connecting)
     }
 
     @Test
-    fun `FailuresPush Connecting to Connected transition`() {
-        val state = MutableStateFlow<FailuresPushConnectionState>(FailuresPushConnectionState.Connecting)
-        state.update { FailuresPushConnectionState.Connected(subscribed = false) }
+    fun `Connecting to Connected transition`() {
+        val state = MutableStateFlow<ConnectionState>(ConnectionState.Connecting)
+        state.update { ConnectionState.Connected(subscribed = false) }
         val value = state.value
-        assertTrue(value is FailuresPushConnectionState.Connected)
-        assertFalse((value as FailuresPushConnectionState.Connected).subscribed)
+        assertTrue(value is ConnectionState.Connected)
+        assertFalse((value as ConnectionState.Connected).subscribed)
     }
 
     @Test
-    fun `FailuresPush Connected subscribed flag updates atomically`() {
-        val state = MutableStateFlow<FailuresPushConnectionState>(
-            FailuresPushConnectionState.Connected(subscribed = false)
+    fun `Connected subscribed flag updates atomically`() {
+        val state = MutableStateFlow<ConnectionState>(
+            ConnectionState.Connected(subscribed = false)
         )
         state.update { current ->
-            if (current is FailuresPushConnectionState.Connected) {
+            if (current is ConnectionState.Connected) {
                 current.copy(subscribed = true)
             } else {
                 current
             }
         }
-        val value = state.value as FailuresPushConnectionState.Connected
+        val value = state.value as ConnectionState.Connected
         assertTrue(value.subscribed)
     }
 
     @Test
-    fun `FailuresPush Connected to Reconnecting transition`() {
-        val state = MutableStateFlow<FailuresPushConnectionState>(
-            FailuresPushConnectionState.Connected(subscribed = true)
+    fun `Connected to Reconnecting transition`() {
+        val state = MutableStateFlow<ConnectionState>(
+            ConnectionState.Connected(subscribed = true)
         )
-        state.update { FailuresPushConnectionState.Reconnecting(attempt = 1, nextRetryMs = 1000) }
+        state.update { ConnectionState.Reconnecting(attempt = 1, nextRetryMs = 1000) }
         val value = state.value
-        assertTrue(value is FailuresPushConnectionState.Reconnecting)
-        assertEquals(1, (value as FailuresPushConnectionState.Reconnecting).attempt)
+        assertTrue(value is ConnectionState.Reconnecting)
+        assertEquals(1, (value as ConnectionState.Reconnecting).attempt)
     }
 
     @Test
-    fun `FailuresPush Reconnecting to Connected transition`() {
-        val state = MutableStateFlow<FailuresPushConnectionState>(
-            FailuresPushConnectionState.Reconnecting(attempt = 2, nextRetryMs = 2000)
+    fun `Reconnecting to Connected transition`() {
+        val state = MutableStateFlow<ConnectionState>(
+            ConnectionState.Reconnecting(attempt = 2, nextRetryMs = 2000)
         )
-        state.update { FailuresPushConnectionState.Connected(subscribed = false) }
-        assertTrue(state.value is FailuresPushConnectionState.Connected)
+        state.update { ConnectionState.Connected(subscribed = false) }
+        assertTrue(state.value is ConnectionState.Connected)
     }
 
     @Test
-    fun `FailuresPush Reconnecting to Disconnected transition`() {
-        val state = MutableStateFlow<FailuresPushConnectionState>(
-            FailuresPushConnectionState.Reconnecting(attempt = 3, nextRetryMs = 4000)
+    fun `Reconnecting to Disconnected transition`() {
+        val state = MutableStateFlow<ConnectionState>(
+            ConnectionState.Reconnecting(attempt = 3, nextRetryMs = 4000)
         )
-        state.update { FailuresPushConnectionState.Disconnected("Stopped") }
+        state.update { ConnectionState.Disconnected("Stopped") }
         val value = state.value
-        assertTrue(value is FailuresPushConnectionState.Disconnected)
-        assertEquals("Stopped", (value as FailuresPushConnectionState.Disconnected).reason)
+        assertTrue(value is ConnectionState.Disconnected)
+        assertEquals("Stopped", (value as ConnectionState.Disconnected).reason)
     }
 
-    // -- FailuresPush derived boolean properties --
+    // -- Derived boolean properties --
 
     @Test
-    fun `FailuresPush isConnected is true only in Connected state`() {
-        val state = MutableStateFlow<FailuresPushConnectionState>(FailuresPushConnectionState.Disconnected(null))
-        assertFalse(state.value is FailuresPushConnectionState.Connected)
+    fun `isConnected is true only in Connected state`() {
+        val state = MutableStateFlow<ConnectionState>(ConnectionState.Disconnected())
+        assertFalse(state.value.isConnected)
 
-        state.update { FailuresPushConnectionState.Connecting }
-        assertFalse(state.value is FailuresPushConnectionState.Connected)
+        state.update { ConnectionState.Connecting }
+        assertFalse(state.value.isConnected)
 
-        state.update { FailuresPushConnectionState.Connected() }
-        assertTrue(state.value is FailuresPushConnectionState.Connected)
+        state.update { ConnectionState.Connected() }
+        assertTrue(state.value.isConnected)
 
-        state.update { FailuresPushConnectionState.Reconnecting(1, 1000) }
-        assertFalse(state.value is FailuresPushConnectionState.Connected)
-    }
-
-    @Test
-    fun `FailuresPush shouldReconnect is true for Connecting, Connected, Reconnecting`() {
-        fun shouldReconnect(state: FailuresPushConnectionState): Boolean {
-            return state is FailuresPushConnectionState.Connecting ||
-                state is FailuresPushConnectionState.Connected ||
-                state is FailuresPushConnectionState.Reconnecting
-        }
-
-        assertFalse(shouldReconnect(FailuresPushConnectionState.Disconnected(null)))
-        assertTrue(shouldReconnect(FailuresPushConnectionState.Connecting))
-        assertTrue(shouldReconnect(FailuresPushConnectionState.Connected()))
-        assertTrue(shouldReconnect(FailuresPushConnectionState.Reconnecting(1, 1000)))
-    }
-
-    // -- PushConnectionState (Performance) transitions --
-
-    @Test
-    fun `Push initial state is Disconnected`() {
-        val state = MutableStateFlow<PushConnectionState>(PushConnectionState.Disconnected(null))
-        assertTrue(state.value is PushConnectionState.Disconnected)
+        state.update { ConnectionState.Reconnecting(1, 1000) }
+        assertFalse(state.value.isConnected)
     }
 
     @Test
-    fun `Push Connecting to Connected to Disconnected`() {
-        val state = MutableStateFlow<PushConnectionState>(PushConnectionState.Disconnected(null))
+    fun `shouldReconnect is true for Connecting, Connected, Reconnecting`() {
+        assertFalse(ConnectionState.Disconnected().shouldReconnect)
+        assertTrue(ConnectionState.Connecting.shouldReconnect)
+        assertTrue(ConnectionState.Connected().shouldReconnect)
+        assertTrue(ConnectionState.Reconnecting(1, 1000).shouldReconnect)
+    }
 
-        state.update { PushConnectionState.Connecting }
-        assertTrue(state.value is PushConnectionState.Connecting)
+    // -- Full lifecycle transitions --
 
-        state.update { PushConnectionState.Connected(subscribed = false) }
-        assertTrue(state.value is PushConnectionState.Connected)
+    @Test
+    fun `full lifecycle transitions`() {
+        val state = MutableStateFlow<ConnectionState>(ConnectionState.Disconnected())
+
+        state.update { ConnectionState.Connecting }
+        assertTrue(state.value is ConnectionState.Connecting)
+
+        state.update { ConnectionState.Connected(subscribed = false) }
+        assertTrue(state.value is ConnectionState.Connected)
+        assertFalse((state.value as ConnectionState.Connected).subscribed)
 
         state.update { current ->
-            if (current is PushConnectionState.Connected) current.copy(subscribed = true) else current
+            if (current is ConnectionState.Connected) current.copy(subscribed = true) else current
         }
-        assertTrue((state.value as PushConnectionState.Connected).subscribed)
+        assertTrue((state.value as ConnectionState.Connected).subscribed)
 
-        state.update { PushConnectionState.Disconnected("Stream ended") }
-        assertEquals("Stream ended", (state.value as PushConnectionState.Disconnected).reason)
-    }
+        state.update { ConnectionState.Reconnecting(attempt = 1, nextRetryMs = 1000) }
+        assertTrue(state.value is ConnectionState.Reconnecting)
 
-    // -- TelemetryConnectionState transitions --
+        state.update { ConnectionState.Connected(subscribed = false) }
+        assertTrue(state.value is ConnectionState.Connected)
 
-    @Test
-    fun `Telemetry full lifecycle transitions`() {
-        val state = MutableStateFlow<TelemetryConnectionState>(TelemetryConnectionState.Disconnected(null))
-
-        state.update { TelemetryConnectionState.Connecting }
-        assertTrue(state.value is TelemetryConnectionState.Connecting)
-
-        state.update { TelemetryConnectionState.Connected(subscribed = false) }
-        assertTrue(state.value is TelemetryConnectionState.Connected)
-        assertFalse((state.value as TelemetryConnectionState.Connected).subscribed)
-
-        state.update { current ->
-            if (current is TelemetryConnectionState.Connected) current.copy(subscribed = true) else current
-        }
-        assertTrue((state.value as TelemetryConnectionState.Connected).subscribed)
-
-        state.update { TelemetryConnectionState.Reconnecting(attempt = 1, nextRetryMs = 1000) }
-        assertTrue(state.value is TelemetryConnectionState.Reconnecting)
-
-        state.update { TelemetryConnectionState.Connected(subscribed = false) }
-        assertTrue(state.value is TelemetryConnectionState.Connected)
-
-        state.update { TelemetryConnectionState.Disconnected("Stopped") }
-        assertTrue(state.value is TelemetryConnectionState.Disconnected)
+        state.update { ConnectionState.Disconnected("Stopped") }
+        assertTrue(state.value is ConnectionState.Disconnected)
     }
 
     @Test
-    fun `Telemetry shouldReconnect is true for Connecting, Connected, Reconnecting`() {
-        fun shouldReconnect(state: TelemetryConnectionState): Boolean {
-            return state is TelemetryConnectionState.Connecting ||
-                state is TelemetryConnectionState.Connected ||
-                state is TelemetryConnectionState.Reconnecting
-        }
-
-        assertFalse(shouldReconnect(TelemetryConnectionState.Disconnected(null)))
-        assertTrue(shouldReconnect(TelemetryConnectionState.Connecting))
-        assertTrue(shouldReconnect(TelemetryConnectionState.Connected()))
-        assertTrue(shouldReconnect(TelemetryConnectionState.Reconnecting(1, 1000)))
-    }
-
-    // -- UnifiedConnectionState transitions --
-
-    @Test
-    fun `Unified full lifecycle transitions`() {
-        val state = MutableStateFlow<UnifiedConnectionState>(UnifiedConnectionState.Disconnected)
-
-        state.update { UnifiedConnectionState.Connecting }
-        assertTrue(state.value is UnifiedConnectionState.Connecting)
-
-        state.update { UnifiedConnectionState.Connected }
-        assertTrue(state.value is UnifiedConnectionState.Connected)
-
-        state.update { UnifiedConnectionState.Reconnecting(1, 1000) }
-        assertTrue(state.value is UnifiedConnectionState.Reconnecting)
-
-        state.update { UnifiedConnectionState.Connected }
-        assertTrue(state.value is UnifiedConnectionState.Connected)
-
-        state.update { UnifiedConnectionState.Disconnected }
-        assertTrue(state.value is UnifiedConnectionState.Disconnected)
-    }
-
-    @Test
-    fun `Unified shouldReconnect derived property`() {
-        fun shouldReconnect(state: UnifiedConnectionState): Boolean {
-            return state is UnifiedConnectionState.Connecting ||
-                state is UnifiedConnectionState.Connected ||
-                state is UnifiedConnectionState.Reconnecting
-        }
-
-        assertFalse(shouldReconnect(UnifiedConnectionState.Disconnected))
-        assertFalse(shouldReconnect(UnifiedConnectionState.Error("test error")))
-        assertTrue(shouldReconnect(UnifiedConnectionState.Connecting))
-        assertTrue(shouldReconnect(UnifiedConnectionState.Connected))
-        assertTrue(shouldReconnect(UnifiedConnectionState.Reconnecting(1, 1000)))
+    fun `shouldReconnect excludes Disconnected and Error`() {
+        assertFalse(ConnectionState.Disconnected().shouldReconnect)
+        assertFalse(ConnectionState.Error("test error").shouldReconnect)
+        assertTrue(ConnectionState.Connecting.shouldReconnect)
+        assertTrue(ConnectionState.Connected().shouldReconnect)
+        assertTrue(ConnectionState.Reconnecting(1, 1000).shouldReconnect)
     }
 
     // -- Atomic CAS update safety --
 
     @Test
     fun `update only modifies Connected state for subscription`() {
-        val state = MutableStateFlow<FailuresPushConnectionState>(FailuresPushConnectionState.Reconnecting(1, 1000))
+        val state = MutableStateFlow<ConnectionState>(ConnectionState.Reconnecting(1, 1000))
 
         // Attempt to set subscribed on a non-Connected state should be a no-op
         state.update { current ->
-            if (current is FailuresPushConnectionState.Connected) {
+            if (current is ConnectionState.Connected) {
                 current.copy(subscribed = true)
             } else {
                 current
@@ -239,22 +166,22 @@ class SocketConnectionStateTest {
         }
 
         // State should remain Reconnecting
-        assertTrue(state.value is FailuresPushConnectionState.Reconnecting)
+        assertTrue(state.value is ConnectionState.Reconnecting)
     }
 
     @Test
     fun `concurrent state updates are atomic via MutableStateFlow`() = runBlocking {
-        val state = MutableStateFlow<FailuresPushConnectionState>(FailuresPushConnectionState.Disconnected(null))
+        val state = MutableStateFlow<ConnectionState>(ConnectionState.Disconnected())
 
         // Simulate rapid transitions
-        state.update { FailuresPushConnectionState.Connecting }
-        state.update { FailuresPushConnectionState.Connected(subscribed = false) }
+        state.update { ConnectionState.Connecting }
+        state.update { ConnectionState.Connected(subscribed = false) }
         state.update { current ->
-            if (current is FailuresPushConnectionState.Connected) current.copy(subscribed = true) else current
+            if (current is ConnectionState.Connected) current.copy(subscribed = true) else current
         }
 
         val value = state.value
-        assertTrue(value is FailuresPushConnectionState.Connected)
-        assertTrue((value as FailuresPushConnectionState.Connected).subscribed)
+        assertTrue(value is ConnectionState.Connected)
+        assertTrue((value as ConnectionState.Connected).subscribed)
     }
 }

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/layout/StreamConnectionGracePeriodTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/layout/StreamConnectionGracePeriodTest.kt
@@ -1,6 +1,6 @@
 package dev.jasonpearson.automobile.desktop.core.layout
 
-import dev.jasonpearson.automobile.desktop.core.daemon.StreamConnectionState
+import dev.jasonpearson.automobile.desktop.core.connection.ConnectionState
 import kotlinx.coroutines.test.advanceTimeBy
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
@@ -20,7 +20,7 @@ class StreamConnectionGracePeriodTest {
             onDisconnectConfirmed = { disconnected = true },
         )
 
-        gp.onStreamStateChange(StreamConnectionState.Connected)
+        gp.onStreamStateChange(ConnectionState.Connected())
 
         assertEquals(listOf(ConnectionStatus.Connected), statuses)
         assertFalse(disconnected)
@@ -35,7 +35,7 @@ class StreamConnectionGracePeriodTest {
             onDisconnectConfirmed = {},
         )
 
-        gp.onStreamStateChange(StreamConnectionState.Connecting)
+        gp.onStreamStateChange(ConnectionState.Connecting)
 
         assertEquals(listOf(ConnectionStatus.Connecting), statuses)
     }
@@ -50,10 +50,10 @@ class StreamConnectionGracePeriodTest {
         )
 
         // First connect, then reconnect
-        gp.onStreamStateChange(StreamConnectionState.Connected)
+        gp.onStreamStateChange(ConnectionState.Connected())
         statuses.clear()
 
-        gp.onStreamStateChange(StreamConnectionState.Connecting)
+        gp.onStreamStateChange(ConnectionState.Connecting)
 
         assertTrue(statuses.isEmpty(), "Connecting should be suppressed after having been connected")
     }
@@ -69,8 +69,8 @@ class StreamConnectionGracePeriodTest {
         )
 
         // Connect first, then disconnect
-        gp.onStreamStateChange(StreamConnectionState.Connected)
-        gp.onStreamStateChange(StreamConnectionState.Disconnected(reason = "test"))
+        gp.onStreamStateChange(ConnectionState.Connected())
+        gp.onStreamStateChange(ConnectionState.Disconnected(reason = "test"))
 
         // Not yet disconnected
         assertFalse(disconnected)
@@ -92,15 +92,15 @@ class StreamConnectionGracePeriodTest {
             onDisconnectConfirmed = { disconnected = true },
         )
 
-        gp.onStreamStateChange(StreamConnectionState.Connected)
+        gp.onStreamStateChange(ConnectionState.Connected())
         statuses.clear()
 
         // Disconnect starts grace period
-        gp.onStreamStateChange(StreamConnectionState.Disconnected(reason = "test"))
+        gp.onStreamStateChange(ConnectionState.Disconnected(reason = "test"))
 
         // Reconnect within grace period
         advanceTimeBy(5_000)
-        gp.onStreamStateChange(StreamConnectionState.Connected)
+        gp.onStreamStateChange(ConnectionState.Connected())
 
         // Grace period should be cancelled
         advanceTimeBy(30_000)
@@ -119,8 +119,8 @@ class StreamConnectionGracePeriodTest {
             onDisconnectConfirmed = { disconnected = true },
         )
 
-        gp.onStreamStateChange(StreamConnectionState.Connected)
-        gp.onStreamStateChange(StreamConnectionState.Disconnected(reason = "gone"))
+        gp.onStreamStateChange(ConnectionState.Connected())
+        gp.onStreamStateChange(ConnectionState.Disconnected(reason = "gone"))
 
         advanceTimeBy(30_001)
 
@@ -136,7 +136,7 @@ class StreamConnectionGracePeriodTest {
             onDisconnectConfirmed = { disconnected = true },
         )
 
-        gp.onStreamStateChange(StreamConnectionState.Disconnected(reason = "never connected"))
+        gp.onStreamStateChange(ConnectionState.Disconnected(reason = "never connected"))
 
         assertTrue(disconnected, "Disconnect should propagate immediately when never connected")
     }
@@ -153,15 +153,15 @@ class StreamConnectionGracePeriodTest {
         )
 
         // Cycle 1: connect -> disconnect -> reconnect (within grace)
-        gp.onStreamStateChange(StreamConnectionState.Connected)
-        gp.onStreamStateChange(StreamConnectionState.Disconnected(reason = "blip 1"))
+        gp.onStreamStateChange(ConnectionState.Connected())
+        gp.onStreamStateChange(ConnectionState.Disconnected(reason = "blip 1"))
         advanceTimeBy(5_000)
-        gp.onStreamStateChange(StreamConnectionState.Connected)
+        gp.onStreamStateChange(ConnectionState.Connected())
 
         // Cycle 2: disconnect -> reconnect (within grace)
-        gp.onStreamStateChange(StreamConnectionState.Disconnected(reason = "blip 2"))
+        gp.onStreamStateChange(ConnectionState.Disconnected(reason = "blip 2"))
         advanceTimeBy(10_000)
-        gp.onStreamStateChange(StreamConnectionState.Connected)
+        gp.onStreamStateChange(ConnectionState.Connected())
 
         // Let all timers expire
         advanceTimeBy(60_000)
@@ -187,8 +187,8 @@ class StreamConnectionGracePeriodTest {
             onDisconnectConfirmed = { disconnected = true },
         )
 
-        gp.onStreamStateChange(StreamConnectionState.Connected)
-        gp.onStreamStateChange(StreamConnectionState.Disconnected(reason = "test"))
+        gp.onStreamStateChange(ConnectionState.Connected())
+        gp.onStreamStateChange(ConnectionState.Disconnected(reason = "test"))
 
         gp.cancel()
 
@@ -207,10 +207,10 @@ class StreamConnectionGracePeriodTest {
             onDisconnectConfirmed = { disconnectCount++ },
         )
 
-        gp.onStreamStateChange(StreamConnectionState.Connected)
-        gp.onStreamStateChange(StreamConnectionState.Disconnected(reason = "first"))
-        gp.onStreamStateChange(StreamConnectionState.Disconnected(reason = "second"))
-        gp.onStreamStateChange(StreamConnectionState.Disconnected(reason = "third"))
+        gp.onStreamStateChange(ConnectionState.Connected())
+        gp.onStreamStateChange(ConnectionState.Disconnected(reason = "first"))
+        gp.onStreamStateChange(ConnectionState.Disconnected(reason = "second"))
+        gp.onStreamStateChange(ConnectionState.Disconnected(reason = "third"))
 
         advanceTimeBy(30_001)
 


### PR DESCRIPTION
## Summary
- Created shared `ConnectionState` sealed class in `connection` package with `Disconnected`, `Connecting`, `Connected`, `Reconnecting`, and `Error` subtypes
- Replaced 5 separate sealed classes (`UnifiedConnectionState`, `TelemetryConnectionState`, `FailuresPushConnectionState`, `PushConnectionState`, `StreamConnectionState`) across all socket clients, UI consumers, and tests
- Migrated `ObservationStreamClient` from `AtomicBoolean` + `MutableSharedFlow` to `MutableStateFlow<ConnectionState>` for consistent state management
- Added `isConnected` and `shouldReconnect` extension properties to eliminate duplicate computed properties across clients

## Test plan
- [x] `desktop-core:compileKotlin` passes (main sources)
- [x] `desktop-app:compileKotlin` passes
- [x] Pre-existing test compilation errors in `CachedNavigationDataSourceTest` and `NavigationViewModelTest` are unrelated (verified on base branch)
- [ ] Verify `desktop-core:test` passes once pre-existing test errors are fixed

🤖 Generated with [Claude Code](https://claude.com/claude-code)