### PR TITLE
test: add Compose UI tests for desktop-core dashboards

### DIFF
--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/test/TestDashboard.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/test/TestDashboard.kt
@@ -255,7 +255,7 @@ private enum class TestFilter {
 }
 
 @Composable
-private fun TestDashboardHome(
+internal fun TestDashboardHome(
     testRuns: List<TestRun>,
     isLoading: Boolean = false,
     error: String? = null,

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/datasource/CachedNavigationDataSourceTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/datasource/CachedNavigationDataSourceTest.kt
@@ -69,7 +69,7 @@ class CachedNavigationDataSourceTest {
     fun `caches error results too`() = runBlocking {
         val delegate = CountingNavigationDataSource(
             listOf(
-                Result.Error(Exception("fail")),
+                Result.Error(RuntimeException("fail")),
                 Result.Success(graph),
             ).iterator()
         )

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/layout/LayoutInspectorDashboardUiTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/layout/LayoutInspectorDashboardUiTest.kt
@@ -1,0 +1,240 @@
+package dev.jasonpearson.automobile.desktop.core.layout
+
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.runComposeUiTest
+import dev.jasonpearson.automobile.desktop.domain.ElementBounds
+import dev.jasonpearson.automobile.desktop.domain.UIElementInfo
+import org.junit.Test
+
+@OptIn(ExperimentalTestApi::class)
+class LayoutInspectorDashboardUiTest {
+
+    private val sampleElement = UIElementInfo(
+        id = "btn_login",
+        className = "android.widget.Button",
+        resourceId = "com.app:id/btn_login",
+        text = "Sign In",
+        contentDescription = "Login button",
+        bounds = ElementBounds(100, 200, 400, 280),
+        isClickable = true,
+        isEnabled = true,
+        isFocused = false,
+        isSelected = false,
+        isScrollable = false,
+        isCheckable = false,
+        isChecked = false,
+        depth = 2,
+        children = emptyList(),
+    )
+
+    private val sampleElementNoText = UIElementInfo(
+        id = "img_avatar",
+        className = "android.widget.ImageView",
+        resourceId = "com.app:id/avatar",
+        text = null,
+        contentDescription = "User avatar",
+        bounds = ElementBounds(50, 50, 150, 150),
+        isClickable = true,
+        isEnabled = true,
+        isFocused = false,
+        isSelected = true,
+        isScrollable = false,
+        isCheckable = false,
+        isChecked = false,
+        depth = 1,
+        children = emptyList(),
+    )
+
+    // -- PropertyInspectorPanel tests --
+
+    @Test
+    fun `shows no element selected when null`() = runComposeUiTest {
+        setContent {
+            MaterialTheme {
+                PropertyInspectorPanel(element = null)
+            }
+        }
+        onNodeWithText("No element selected").assertIsDisplayed()
+        onNodeWithText("Click on the screen or tree to select").assertIsDisplayed()
+    }
+
+    @Test
+    fun `shows element class name`() = runComposeUiTest {
+        setContent {
+            MaterialTheme {
+                PropertyInspectorPanel(element = sampleElement)
+            }
+        }
+        onNodeWithText("Button").assertIsDisplayed()
+        onNodeWithText("android.widget.Button").assertIsDisplayed()
+    }
+
+    @Test
+    fun `shows element resource id`() = runComposeUiTest {
+        setContent {
+            MaterialTheme {
+                PropertyInspectorPanel(element = sampleElement)
+            }
+        }
+        onNodeWithText("com.app:id/btn_login").assertIsDisplayed()
+    }
+
+    @Test
+    fun `shows element content description`() = runComposeUiTest {
+        setContent {
+            MaterialTheme {
+                PropertyInspectorPanel(element = sampleElement)
+            }
+        }
+        onNodeWithText("Login button").assertIsDisplayed()
+    }
+
+    @Test
+    fun `shows element bounds`() = runComposeUiTest {
+        setContent {
+            MaterialTheme {
+                PropertyInspectorPanel(element = sampleElement)
+            }
+        }
+        onNodeWithText("100, 200").assertIsDisplayed()
+        onNodeWithText("300 x 80").assertIsDisplayed()
+    }
+
+    @Test
+    fun `shows identity section header`() = runComposeUiTest {
+        setContent {
+            MaterialTheme {
+                PropertyInspectorPanel(element = sampleElement)
+            }
+        }
+        onNodeWithText("Identity").assertIsDisplayed()
+    }
+
+    @Test
+    fun `shows bounds section header`() = runComposeUiTest {
+        setContent {
+            MaterialTheme {
+                PropertyInspectorPanel(element = sampleElement)
+            }
+        }
+        onNodeWithText("Bounds").assertIsDisplayed()
+    }
+
+    @Test
+    fun `shows state section header`() = runComposeUiTest {
+        setContent {
+            MaterialTheme {
+                PropertyInspectorPanel(element = sampleElement)
+            }
+        }
+        onNodeWithText("State").assertIsDisplayed()
+    }
+
+    @Test
+    fun `shows text content when present`() = runComposeUiTest {
+        setContent {
+            MaterialTheme {
+                PropertyInspectorPanel(element = sampleElement)
+            }
+        }
+        onNodeWithText("Content").assertIsDisplayed()
+        onNodeWithText("Sign In").assertIsDisplayed()
+    }
+
+    @Test
+    fun `hides content section when text is null`() = runComposeUiTest {
+        setContent {
+            MaterialTheme {
+                PropertyInspectorPanel(element = sampleElementNoText)
+            }
+        }
+        // Content section header should not appear
+        onNodeWithText("Content").assertDoesNotExist()
+    }
+
+    @Test
+    fun `shows clickable state`() = runComposeUiTest {
+        setContent {
+            MaterialTheme {
+                PropertyInspectorPanel(element = sampleElement)
+            }
+        }
+        onNodeWithText("Clickable").assertIsDisplayed()
+        onNodeWithText("Enabled").assertIsDisplayed()
+    }
+
+    // -- BreadcrumbBar tests --
+
+    @Test
+    fun `breadcrumb bar shows nothing when no selection`() = runComposeUiTest {
+        setContent {
+            MaterialTheme {
+                BreadcrumbBar(
+                    selectedElementId = null,
+                    parentMap = emptyMap(),
+                    elementMap = emptyMap(),
+                    onElementSelected = {},
+                )
+            }
+        }
+        // BreadcrumbBar returns early when selectedElementId is null, so nothing to assert
+        // Just verify it doesn't crash
+    }
+
+    @Test
+    fun `breadcrumb bar shows path for selected element`() = runComposeUiTest {
+        val root = UIElementInfo(
+            id = "root",
+            className = "android.widget.FrameLayout",
+            resourceId = null,
+            text = null,
+            contentDescription = null,
+            bounds = ElementBounds(0, 0, 1080, 2340),
+            isClickable = false,
+            isEnabled = true,
+            isFocused = false,
+            isSelected = false,
+            isScrollable = false,
+            isCheckable = false,
+            isChecked = false,
+            depth = 0,
+            children = emptyList(),
+        )
+        val child = UIElementInfo(
+            id = "child1",
+            className = "android.widget.Button",
+            resourceId = "com.app:id/btn",
+            text = "Click",
+            contentDescription = null,
+            bounds = ElementBounds(10, 10, 200, 60),
+            isClickable = true,
+            isEnabled = true,
+            isFocused = false,
+            isSelected = false,
+            isScrollable = false,
+            isCheckable = false,
+            isChecked = false,
+            depth = 1,
+            children = emptyList(),
+        )
+
+        val parentMap = mapOf("child1" to "root")
+        val elementMap = mapOf("root" to root, "child1" to child)
+
+        setContent {
+            MaterialTheme {
+                BreadcrumbBar(
+                    selectedElementId = "child1",
+                    parentMap = parentMap,
+                    elementMap = elementMap,
+                    onElementSelected = {},
+                )
+            }
+        }
+        onNodeWithText("FrameLayout").assertIsDisplayed()
+        onNodeWithText("Button#btn").assertIsDisplayed()
+    }
+}

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/navigation/NavigationDashboardUiTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/navigation/NavigationDashboardUiTest.kt
@@ -1,0 +1,253 @@
+package dev.jasonpearson.automobile.desktop.core.navigation
+
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.onAllNodesWithText
+import androidx.compose.ui.test.onFirst
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.runComposeUiTest
+import dev.jasonpearson.automobile.desktop.domain.ScreenNode
+import dev.jasonpearson.automobile.desktop.domain.ScreenTransition
+import org.junit.Test
+
+@OptIn(ExperimentalTestApi::class)
+class NavigationDashboardUiTest {
+
+    private val sampleScreens = listOf(
+        ScreenNode("s1", "Login", "Composable", "com.app.auth", 3, 1000L),
+        ScreenNode("s2", "Home", "Activity", "com.app.main", 5, 2000L),
+        ScreenNode("s3", "Settings", "Composable", "com.app.settings", 1, 3000L),
+    )
+
+    private val sampleTransitions = listOf(
+        ScreenTransition("t1", "Login", "Home", "tap", "Login Button", 350, 0.03f),
+        ScreenTransition("t2", "Home", "Settings", "tap", "Settings Tab", 50, 0.0f),
+        ScreenTransition("t3", "Settings", "Home", "back", null, 40, 0.0f),
+    )
+
+    // -- FlowMapListView tests --
+
+    @Test
+    fun `flow map shows screen and transition counts`() = runComposeUiTest {
+        setContent {
+            MaterialTheme {
+                FlowMapListView(
+                    screens = sampleScreens,
+                    transitions = sampleTransitions,
+                    onScreenSelected = {},
+                    onTransitionSelected = {},
+                )
+            }
+        }
+        onNodeWithText("Flow Map").assertIsDisplayed()
+        onNodeWithText("3 screens discovered \u2022 3 transitions").assertIsDisplayed()
+        onNodeWithText("Screens").assertIsDisplayed()
+        onNodeWithText("Transitions").assertIsDisplayed()
+    }
+
+    @Test
+    fun `flow map shows screen names`() = runComposeUiTest {
+        setContent {
+            MaterialTheme {
+                FlowMapListView(
+                    screens = sampleScreens,
+                    transitions = sampleTransitions,
+                    onScreenSelected = {},
+                    onTransitionSelected = {},
+                )
+            }
+        }
+        // Screen names may appear in both screen rows and transition rows,
+        // so use onAllNodesWithText to verify at least one instance is displayed
+        onAllNodesWithText("Login").onFirst().assertIsDisplayed()
+        onAllNodesWithText("Home").onFirst().assertIsDisplayed()
+        onAllNodesWithText("Settings").onFirst().assertIsDisplayed()
+    }
+
+    @Test
+    fun `flow map with empty data shows zero counts`() = runComposeUiTest {
+        setContent {
+            MaterialTheme {
+                FlowMapListView(
+                    screens = emptyList(),
+                    transitions = emptyList(),
+                    onScreenSelected = {},
+                    onTransitionSelected = {},
+                )
+            }
+        }
+        onNodeWithText("0 screens discovered \u2022 0 transitions").assertIsDisplayed()
+    }
+
+    // -- ScreenDetailView tests --
+
+    @Test
+    fun `screen detail shows screen name and type`() = runComposeUiTest {
+        setContent {
+            MaterialTheme {
+                ScreenDetailView(
+                    screen = sampleScreens[0],
+                    transitions = sampleTransitions,
+                    onBack = {},
+                    onScreenSelected = {},
+                )
+            }
+        }
+        // "Login" appears in both the header and transition rows
+        onAllNodesWithText("Login").onFirst().assertIsDisplayed()
+        onNodeWithText("Composable").assertIsDisplayed()
+        onNodeWithText("com.app.auth").assertIsDisplayed()
+    }
+
+    @Test
+    fun `screen detail shows outgoing and incoming counts`() = runComposeUiTest {
+        setContent {
+            MaterialTheme {
+                ScreenDetailView(
+                    screen = sampleScreens[1], // Home
+                    transitions = sampleTransitions,
+                    onBack = {},
+                    onScreenSelected = {},
+                )
+            }
+        }
+        // Home has 1 outgoing (Home -> Settings) and 2 incoming (Login -> Home, Settings -> Home)
+        onNodeWithText("Outgoing").assertIsDisplayed()
+        onNodeWithText("Incoming").assertIsDisplayed()
+        onNodeWithText("1").assertIsDisplayed()  // outgoing count
+        onNodeWithText("2").assertIsDisplayed()  // incoming count
+    }
+
+    @Test
+    fun `screen detail shows no screenshot placeholder`() = runComposeUiTest {
+        setContent {
+            MaterialTheme {
+                ScreenDetailView(
+                    screen = sampleScreens[0],
+                    transitions = emptyList(),
+                    onBack = {},
+                    onScreenSelected = {},
+                )
+            }
+        }
+        onNodeWithText("No screenshot").assertIsDisplayed()
+    }
+
+    @Test
+    fun `screen detail shows back link`() = runComposeUiTest {
+        setContent {
+            MaterialTheme {
+                ScreenDetailView(
+                    screen = sampleScreens[0],
+                    transitions = emptyList(),
+                    onBack = {},
+                    onScreenSelected = {},
+                )
+            }
+        }
+        onNodeWithText("\u2190 Flow Map").assertIsDisplayed()
+    }
+
+    // -- TransitionDetailView tests --
+
+    @Test
+    fun `transition detail shows from and to screens`() = runComposeUiTest {
+        setContent {
+            MaterialTheme {
+                TransitionDetailView(
+                    transition = sampleTransitions[0], // Login -> Home
+                    onBack = {},
+                    onScreenSelected = {},
+                )
+            }
+        }
+        onNodeWithText("Transition Detail").assertIsDisplayed()
+        onNodeWithText("Login").assertIsDisplayed()
+        onNodeWithText("Home").assertIsDisplayed()
+    }
+
+    @Test
+    fun `transition detail shows trigger and element`() = runComposeUiTest {
+        setContent {
+            MaterialTheme {
+                TransitionDetailView(
+                    transition = sampleTransitions[0], // tap, "Login Button"
+                    onBack = {},
+                    onScreenSelected = {},
+                )
+            }
+        }
+        onNodeWithText("Tap").assertIsDisplayed()
+        onNodeWithText("Login Button").assertIsDisplayed()
+    }
+
+    @Test
+    fun `transition detail shows latency when present`() = runComposeUiTest {
+        setContent {
+            MaterialTheme {
+                TransitionDetailView(
+                    transition = sampleTransitions[0], // avgLatencyMs = 350
+                    onBack = {},
+                    onScreenSelected = {},
+                )
+            }
+        }
+        onNodeWithText("350ms").assertIsDisplayed()
+    }
+
+    @Test
+    fun `transition detail shows failure rate when present`() = runComposeUiTest {
+        setContent {
+            MaterialTheme {
+                TransitionDetailView(
+                    transition = sampleTransitions[0], // failureRate = 0.03
+                    onBack = {},
+                    onScreenSelected = {},
+                )
+            }
+        }
+        onNodeWithText("3.0%").assertIsDisplayed()
+    }
+
+    @Test
+    fun `transition detail hides latency when zero`() = runComposeUiTest {
+        val noLatency = ScreenTransition("t", "A", "B", "tap", null, 0, 0.0f)
+        setContent {
+            MaterialTheme {
+                TransitionDetailView(
+                    transition = noLatency,
+                    onBack = {},
+                    onScreenSelected = {},
+                )
+            }
+        }
+        onNodeWithText("Avg Latency").assertDoesNotExist()
+    }
+
+    // -- StatItem tests --
+
+    @Test
+    fun `stat item shows label and value`() = runComposeUiTest {
+        setContent {
+            MaterialTheme {
+                StatItem(label = "Outgoing", value = "5")
+            }
+        }
+        onNodeWithText("Outgoing").assertIsDisplayed()
+        onNodeWithText("5").assertIsDisplayed()
+    }
+
+    // -- DetailRow tests --
+
+    @Test
+    fun `detail row shows label and value`() = runComposeUiTest {
+        setContent {
+            MaterialTheme {
+                DetailRow(label = "Trigger", value = "Tap")
+            }
+        }
+        onNodeWithText("Trigger").assertIsDisplayed()
+        onNodeWithText("Tap").assertIsDisplayed()
+    }
+}

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/navigation/NavigationViewModelTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/navigation/NavigationViewModelTest.kt
@@ -41,7 +41,7 @@ class NavigationViewModelTest {
 
     @Test
     fun `transitions to Error state on data source error`() = testScope.runTest {
-        val dataSource = FakeNavigationDataSourceImpl(Result.Error(Exception("Network error")))
+        val dataSource = FakeNavigationDataSourceImpl(Result.Error(RuntimeException("Network error")))
         val vm = NavigationViewModel(dataSource, this)
 
         val state = vm.state.value
@@ -145,7 +145,7 @@ class NavigationViewModelTest {
 
     @Test
     fun `UpdateGraph sets Content from non-Content state`() = testScope.runTest {
-        val dataSource = FakeNavigationDataSourceImpl(Result.Error(Exception("initial error")))
+        val dataSource = FakeNavigationDataSourceImpl(Result.Error(RuntimeException("initial error")))
         val vm = NavigationViewModel(dataSource, this)
         assertTrue(vm.state.value is NavigationUiState.Error)
 

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/test/TestDashboardUiTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/test/TestDashboardUiTest.kt
@@ -1,0 +1,200 @@
+package dev.jasonpearson.automobile.desktop.core.test
+
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.runComposeUiTest
+import dev.jasonpearson.automobile.desktop.domain.TestPlatform
+import dev.jasonpearson.automobile.desktop.domain.TestRun
+import dev.jasonpearson.automobile.desktop.domain.TestStatus
+import dev.jasonpearson.automobile.desktop.domain.TestStep
+import org.junit.Test
+
+@OptIn(ExperimentalTestApi::class)
+class TestDashboardUiTest {
+
+    private val sampleTestRuns = listOf(
+        TestRun(
+            id = "run1",
+            testId = "test1",
+            testName = "testLoginFlow",
+            status = TestStatus.Passed,
+            startTime = 1705003600000L,
+            durationMs = 4320,
+            steps = listOf(
+                TestStep("s1", 0, "launch", "com.app", null, "Splash", 800, TestStatus.Passed),
+                TestStep("s2", 1, "tap", "Login button", null, "Login", 290, TestStatus.Passed),
+            ),
+            screensVisited = listOf("Splash", "Login", "Home"),
+            deviceId = "pixel8",
+            deviceName = "Pixel 8 API 35",
+            platform = TestPlatform.Android,
+        ),
+        TestRun(
+            id = "run2",
+            testId = "test2",
+            testName = "testSignupValidation",
+            status = TestStatus.Failed,
+            startTime = 1705003500000L,
+            durationMs = 2890,
+            steps = emptyList(),
+            screensVisited = listOf("Splash", "Login", "Signup"),
+            errorMessage = "AssertionError: Expected error toast not found",
+            deviceId = "pixel8",
+            deviceName = "Pixel 8 API 35",
+            platform = TestPlatform.Android,
+        ),
+    )
+
+    @Test
+    fun `shows loading state`() = runComposeUiTest {
+        setContent {
+            MaterialTheme {
+                TestDashboardHome(
+                    testRuns = emptyList(),
+                    isLoading = true,
+                    error = null,
+                    onRecordTest = {},
+                    onTestRunClick = {},
+                )
+            }
+        }
+        onNodeWithText("Loading test data...").assertIsDisplayed()
+    }
+
+    @Test
+    fun `shows error state`() = runComposeUiTest {
+        setContent {
+            MaterialTheme {
+                TestDashboardHome(
+                    testRuns = emptyList(),
+                    isLoading = false,
+                    error = "Connection refused",
+                    onRecordTest = {},
+                    onTestRunClick = {},
+                )
+            }
+        }
+        onNodeWithText("Connection refused").assertIsDisplayed()
+    }
+
+    @Test
+    fun `shows empty state when no test runs`() = runComposeUiTest {
+        setContent {
+            MaterialTheme {
+                TestDashboardHome(
+                    testRuns = emptyList(),
+                    isLoading = false,
+                    error = null,
+                    onRecordTest = {},
+                    onTestRunClick = {},
+                )
+            }
+        }
+        onNodeWithText("No test runs yet").assertIsDisplayed()
+        onNodeWithText("Record or run exploratory tests to see them here").assertIsDisplayed()
+    }
+
+    @Test
+    fun `shows dashboard header`() = runComposeUiTest {
+        setContent {
+            MaterialTheme {
+                TestDashboardHome(
+                    testRuns = emptyList(),
+                    isLoading = false,
+                    error = null,
+                    onRecordTest = {},
+                    onTestRunClick = {},
+                )
+            }
+        }
+        onNodeWithText("Testing").assertIsDisplayed()
+        onNodeWithText("Create, run, and analyze UI tests").assertIsDisplayed()
+    }
+
+    @Test
+    fun `shows test run names when data is loaded`() = runComposeUiTest {
+        setContent {
+            MaterialTheme {
+                TestDashboardHome(
+                    testRuns = sampleTestRuns,
+                    isLoading = false,
+                    error = null,
+                    onRecordTest = {},
+                    onTestRunClick = {},
+                )
+            }
+        }
+        onNodeWithText("testLoginFlow").assertIsDisplayed()
+        onNodeWithText("testSignupValidation").assertIsDisplayed()
+    }
+
+    @Test
+    fun `shows test run duration`() = runComposeUiTest {
+        setContent {
+            MaterialTheme {
+                TestDashboardHome(
+                    testRuns = sampleTestRuns,
+                    isLoading = false,
+                    error = null,
+                    onRecordTest = {},
+                    onTestRunClick = {},
+                )
+            }
+        }
+        onNodeWithText("4.32s").assertIsDisplayed()
+        onNodeWithText("2.89s").assertIsDisplayed()
+    }
+
+    @Test
+    fun `shows flakiness score for flaky test`() = runComposeUiTest {
+        setContent {
+            MaterialTheme {
+                TestDashboardHome(
+                    testRuns = sampleTestRuns,
+                    isLoading = false,
+                    error = null,
+                    onRecordTest = {},
+                    onTestRunClick = {},
+                )
+            }
+        }
+        // testSignupValidation has testId=test2 which maps to flakinessScore=0.15f in TestMockData
+        onNodeWithText("15% flaky").assertIsDisplayed()
+    }
+
+    @Test
+    fun `shows filter chips`() = runComposeUiTest {
+        setContent {
+            MaterialTheme {
+                TestDashboardHome(
+                    testRuns = sampleTestRuns,
+                    isLoading = false,
+                    error = null,
+                    onRecordTest = {},
+                    onTestRunClick = {},
+                )
+            }
+        }
+        onNodeWithText("Recent").assertIsDisplayed()
+        onNodeWithText("Popular").assertIsDisplayed()
+        onNodeWithText("Both").assertIsDisplayed()
+    }
+
+    @Test
+    fun `shows test runs header`() = runComposeUiTest {
+        setContent {
+            MaterialTheme {
+                TestDashboardHome(
+                    testRuns = sampleTestRuns,
+                    isLoading = false,
+                    error = null,
+                    onRecordTest = {},
+                    onTestRunClick = {},
+                )
+            }
+        }
+        onNodeWithText("Test Runs").assertIsDisplayed()
+    }
+}


### PR DESCRIPTION
## Summary
- Add Compose UI tests for `NavigationDashboard` (FlowMapListView, ScreenDetailView, TransitionDetailView, StatItem, DetailRow)
- Add Compose UI tests for `LayoutInspectorDashboard` (PropertyInspectorPanel, BreadcrumbBar)
- Add Compose UI tests for `TestDashboard` (TestDashboardHome loading, error, empty, and data states)
- Fix `Result.Error` constructor calls to use `RuntimeException` wrapper in existing tests
- Make `TestDashboardHome` internal for test accessibility

## Test plan
- [x] All new UI tests pass via `./gradlew :desktop-core:test`
- [x] Existing tests still pass (no regressions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)