### PR TITLE
build(ios): enable StrictConcurrency in AutoMobileSDK

### DIFF
--- a/ios/auto-mobile-sdk/Package.swift
+++ b/ios/auto-mobile-sdk/Package.swift
@@ -17,12 +17,18 @@ let package = Package(
         .target(
             name: "AutoMobileSDK",
             path: "Sources/AutoMobileSDK",
-            resources: [.process("PrivacyInfo.xcprivacy")]
+            resources: [.process("PrivacyInfo.xcprivacy")],
+            swiftSettings: [
+                .enableExperimentalFeature("StrictConcurrency"),
+            ]
         ),
         .testTarget(
             name: "AutoMobileSDKTests",
             dependencies: ["AutoMobileSDK"],
-            path: "Tests/AutoMobileSDKTests"
+            path: "Tests/AutoMobileSDKTests",
+            swiftSettings: [
+                .enableExperimentalFeature("StrictConcurrency"),
+            ]
         ),
     ]
 )


### PR DESCRIPTION
## Summary
- Enable `StrictConcurrency` experimental feature in the iOS SDK's `Package.swift` for both the `AutoMobileSDK` target and `AutoMobileSDKTests` target
- Prepares the SDK for Swift 6 by surfacing data-race warnings at compile time
- Skipped `.unsafeFlags(["-warnings-as-errors"])` since this is a published library (unsafeFlags prevent use as a dependency)

## Test plan
- [x] `swift build` succeeds (warnings only, no errors)
- [x] `swift test` passes all 144 tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)