### PR TITLE
feat: add @Volatile to shared SDK fields and configurable back pressure strategy

### DIFF
--- a/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/AutoMobileConfiguration.kt
+++ b/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/AutoMobileConfiguration.kt
@@ -1,5 +1,6 @@
 package dev.jasonpearson.automobile.sdk
 
+import dev.jasonpearson.automobile.sdk.events.BackPressureStrategy
 import dev.jasonpearson.automobile.sdk.events.EventProcessor
 
 /**
@@ -25,6 +26,8 @@ data class AutoMobileConfiguration internal constructor(
   val eventProcessors: List<EventProcessor> = emptyList(),
   /** Hard cap on pending events in the buffer. Oldest events are evicted when exceeded. */
   val maxPendingEvents: Int = DEFAULT_MAX_PENDING_EVENTS,
+  /** Strategy for handling events when the buffer is full. */
+  val backPressureStrategy: BackPressureStrategy = BackPressureStrategy.DROP_OLDEST,
 ) {
 
   class Builder {
@@ -34,6 +37,7 @@ data class AutoMobileConfiguration internal constructor(
     private var sessionTimeoutMs: Long = DEFAULT_SESSION_TIMEOUT_MS
     private var eventProcessors: List<EventProcessor> = emptyList()
     private var maxPendingEvents: Int = DEFAULT_MAX_PENDING_EVENTS
+    private var backPressureStrategy: BackPressureStrategy = BackPressureStrategy.DROP_OLDEST
 
     /** Maximum events before forced flush. Must be > 0. */
     fun bufferSize(value: Int) = apply { this.bufferSize = value }
@@ -53,6 +57,9 @@ data class AutoMobileConfiguration internal constructor(
     /** Hard cap on pending events in the buffer. Must be > 0. */
     fun maxPendingEvents(value: Int) = apply { this.maxPendingEvents = value }
 
+    /** Strategy for handling events when the buffer is full. */
+    fun backPressureStrategy(value: BackPressureStrategy) = apply { this.backPressureStrategy = value }
+
     fun build(): AutoMobileConfiguration {
       require(bufferSize > 0) { "bufferSize must be > 0, was $bufferSize" }
       require(flushIntervalMs > 0) { "flushIntervalMs must be > 0, was $flushIntervalMs" }
@@ -67,6 +74,7 @@ data class AutoMobileConfiguration internal constructor(
         sessionTimeoutMs = sessionTimeoutMs,
         eventProcessors = eventProcessors,
         maxPendingEvents = maxPendingEvents,
+        backPressureStrategy = backPressureStrategy,
       )
     }
   }

--- a/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/AutoMobileSDK.kt
+++ b/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/AutoMobileSDK.kt
@@ -78,17 +78,17 @@ object AutoMobileSDK {
   internal var logger: SdkLogger = DefaultSdkLogger()
 
   private val listeners = CopyOnWriteArrayList<NavigationListener>()
-  private var isEnabled = true
-  private var context: Context? = null
-  private var configuration: AutoMobileConfiguration? = null
-  private var eventBuffer: SdkEventBuffer? = null
-  private var persistence: EventPersistence? = null
-  private var mainHandler: Handler? = null
-  private var sessionTracker: SessionTracker? = null
-  private var sessionLifecycleObserver: DefaultLifecycleObserver? = null
-  private var sdkContext: SdkContext? = null
-  private var breadcrumbTrail: BreadcrumbTrail? = null
-  private var dropCounter: DropCounter? = null
+  @Volatile private var isEnabled = true
+  @Volatile private var context: Context? = null
+  @Volatile private var configuration: AutoMobileConfiguration? = null
+  @Volatile private var eventBuffer: SdkEventBuffer? = null
+  @Volatile private var persistence: EventPersistence? = null
+  @Volatile private var mainHandler: Handler? = null
+  @Volatile private var sessionTracker: SessionTracker? = null
+  @Volatile private var sessionLifecycleObserver: DefaultLifecycleObserver? = null
+  @Volatile private var sdkContext: SdkContext? = null
+  @Volatile private var breadcrumbTrail: BreadcrumbTrail? = null
+  @Volatile private var dropCounter: DropCounter? = null
 
   const val ACTION_NAVIGATION_EVENT = "dev.jasonpearson.automobile.sdk.NAVIGATION_EVENT"
   const val EXTRA_DESTINATION = "destination"
@@ -143,6 +143,7 @@ object AutoMobileSDK {
       dropCounter = counter,
       processors = configuration.eventProcessors,
       maxPendingEvents = configuration.maxPendingEvents,
+      backPressureStrategy = configuration.backPressureStrategy,
     )
     buffer.isEnabled = isEnabled
     buffer.start()

--- a/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/events/BackPressureStrategy.kt
+++ b/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/events/BackPressureStrategy.kt
@@ -1,0 +1,11 @@
+package dev.jasonpearson.automobile.sdk.events
+
+/**
+ * Strategy for handling events when the buffer is full.
+ */
+enum class BackPressureStrategy {
+  /** Remove the oldest event to make room for the new one. */
+  DROP_OLDEST,
+  /** Reject the new event and keep existing buffer contents. */
+  IGNORE_NEWEST,
+}

--- a/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/events/SdkEventBuffer.kt
+++ b/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/events/SdkEventBuffer.kt
@@ -35,6 +35,7 @@ internal class SdkEventBuffer(
   private val dropCounter: DropCounter? = null,
   private val processors: List<EventProcessor> = emptyList(),
   private val maxPendingEvents: Int = 500,
+  private val backPressureStrategy: BackPressureStrategy = BackPressureStrategy.DROP_OLDEST,
 ) {
   private val lock = ReentrantLock()
   private val buffer = mutableListOf<SdkEvent>()
@@ -85,8 +86,16 @@ internal class SdkEventBuffer(
 
     lock.withLock {
       if (buffer.size >= maxPendingEvents) {
-        buffer.removeFirst()
-        dropCounter?.increment(DropReason.BUFFER_OVERFLOW)
+        when (backPressureStrategy) {
+          BackPressureStrategy.DROP_OLDEST -> {
+            buffer.removeFirst()
+            dropCounter?.increment(DropReason.BUFFER_OVERFLOW)
+          }
+          BackPressureStrategy.IGNORE_NEWEST -> {
+            dropCounter?.increment(DropReason.BUFFER_OVERFLOW)
+            return
+          }
+        }
       }
 
       buffer.add(current)

--- a/android/auto-mobile-sdk/src/test/kotlin/dev/jasonpearson/automobile/sdk/events/SdkEventBufferTest.kt
+++ b/android/auto-mobile-sdk/src/test/kotlin/dev/jasonpearson/automobile/sdk/events/SdkEventBufferTest.kt
@@ -276,4 +276,90 @@ class SdkEventBufferTest {
     assertEquals(1, flushed.size, "Second event should be buffered after first processor failure")
     assertEquals(1, flushed[0].size)
   }
+
+  @Test
+  fun `IGNORE_NEWEST drops incoming event when buffer full`() {
+    val flushed = mutableListOf<List<SdkEvent>>()
+    val counter = DefaultDropCounter()
+    val buffer = SdkEventBuffer(
+      maxBufferSize = 100,
+      flushIntervalMs = 60_000,
+      onFlush = { flushed.add(it) },
+      executor = Executors.newSingleThreadScheduledExecutor(),
+      dropCounter = counter,
+      maxPendingEvents = 3,
+      backPressureStrategy = BackPressureStrategy.IGNORE_NEWEST,
+    )
+
+    buffer.add(makeEvent(1))
+    buffer.add(makeEvent(2))
+    buffer.add(makeEvent(3))
+    // Buffer is now full — next event should be dropped
+    buffer.add(makeEvent(4))
+    buffer.flush()
+
+    assertEquals(1, flushed.size)
+    assertEquals(3, flushed[0].size, "Only the first 3 events should be in the buffer")
+    val timestamps = flushed[0].map { it.timestamp }
+    assertEquals(listOf(1L, 2L, 3L), timestamps, "Original events should be preserved")
+
+    val snapshot = counter.snapshot()
+    assertEquals(1L, snapshot[DropReason.BUFFER_OVERFLOW], "Dropped event should be counted")
+  }
+
+  @Test
+  fun `IGNORE_NEWEST allows events after flush frees space`() {
+    val flushed = mutableListOf<List<SdkEvent>>()
+    val buffer = SdkEventBuffer(
+      maxBufferSize = 100,
+      flushIntervalMs = 60_000,
+      onFlush = { flushed.add(it) },
+      executor = Executors.newSingleThreadScheduledExecutor(),
+      maxPendingEvents = 2,
+      backPressureStrategy = BackPressureStrategy.IGNORE_NEWEST,
+    )
+
+    buffer.add(makeEvent(1))
+    buffer.add(makeEvent(2))
+    // Buffer full — this should be dropped
+    buffer.add(makeEvent(3))
+    // Flush to free space
+    buffer.flush()
+    // Now buffer has space again
+    buffer.add(makeEvent(4))
+    buffer.flush()
+
+    assertEquals(2, flushed.size)
+    assertEquals(listOf(1L, 2L), flushed[0].map { it.timestamp })
+    assertEquals(listOf(4L), flushed[1].map { it.timestamp })
+  }
+
+  @Test
+  fun `DROP_OLDEST evicts oldest event when buffer full`() {
+    val flushed = mutableListOf<List<SdkEvent>>()
+    val counter = DefaultDropCounter()
+    val buffer = SdkEventBuffer(
+      maxBufferSize = 100,
+      flushIntervalMs = 60_000,
+      onFlush = { flushed.add(it) },
+      executor = Executors.newSingleThreadScheduledExecutor(),
+      dropCounter = counter,
+      maxPendingEvents = 3,
+      backPressureStrategy = BackPressureStrategy.DROP_OLDEST,
+    )
+
+    buffer.add(makeEvent(1))
+    buffer.add(makeEvent(2))
+    buffer.add(makeEvent(3))
+    buffer.add(makeEvent(4))
+    buffer.flush()
+
+    assertEquals(1, flushed.size)
+    assertEquals(3, flushed[0].size, "Buffer should contain maxPendingEvents events")
+    val timestamps = flushed[0].map { it.timestamp }
+    assertEquals(listOf(2L, 3L, 4L), timestamps, "Oldest event should have been evicted")
+
+    val snapshot = counter.snapshot()
+    assertEquals(1L, snapshot[DropReason.BUFFER_OVERFLOW])
+  }
 }


### PR DESCRIPTION
## Summary
- Add `@Volatile` to 11 shared mutable fields in `AutoMobileSDK` that are accessed from multiple threads without synchronization, ensuring proper cross-thread visibility.
- Introduce `BackPressureStrategy` enum (`DROP_OLDEST`, `IGNORE_NEWEST`) wired through `AutoMobileConfiguration` builder and `SdkEventBuffer`, allowing consumers to choose buffer-full behavior.
- Add 3 new tests covering `IGNORE_NEWEST` drop, `IGNORE_NEWEST` recovery after flush, and explicit `DROP_OLDEST` eviction.

## Test plan
- [x] All existing `SdkEventBufferTest` tests pass
- [x] New `IGNORE_NEWEST drops incoming event when buffer full` test passes
- [x] New `IGNORE_NEWEST allows events after flush frees space` test passes
- [x] New `DROP_OLDEST evicts oldest event when buffer full` test passes
- [x] `./gradlew -p android :auto-mobile-sdk:test` passes (BUILD SUCCESSFUL)

🤖 Generated with [Claude Code](https://claude.com/claude-code)