### PR TITLE
feat(ios): add DateProvider protocol for deterministic time in tests

### DIFF
--- a/ios/auto-mobile-sdk/Sources/AutoMobileSDK/AutoMobileSDK.swift
+++ b/ios/auto-mobile-sdk/Sources/AutoMobileSDK/AutoMobileSDK.swift
@@ -53,14 +53,16 @@ public final class AutoMobileSDK: @unchecked Sendable {
         let counter = DefaultDropCounter()
         _dropCounter = counter
 
+        let dateProvider: DateProvider = SystemDateProvider()
+
         // Set up disk-first event persistence
         let persistence: any EventPersisting
         if let cachesDir = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first {
             let eventsDir = cachesDir.appendingPathComponent("automobile_events")
-            persistence = FileEventPersistence(directory: eventsDir)
+            persistence = FileEventPersistence(directory: eventsDir, dateProvider: dateProvider)
         } else {
             let tmpDir = URL(fileURLWithPath: NSTemporaryDirectory()).appendingPathComponent("automobile_events")
-            persistence = FileEventPersistence(directory: tmpDir)
+            persistence = FileEventPersistence(directory: tmpDir, dateProvider: dateProvider)
         }
         self.eventPersistence = persistence
         SdkEventBroadcaster.shared.persistence = persistence
@@ -97,7 +99,7 @@ public final class AutoMobileSDK: @unchecked Sendable {
         AutoMobileOsEvents.shared.initialize(bundleId: resolvedBundleId, buffer: buffer)
         AutoMobileNotificationObserver.shared.initialize(bundleId: resolvedBundleId, buffer: buffer)
         AutoMobileInteractionTracker.shared.initialize(bundleId: resolvedBundleId, buffer: buffer)
-        ViewBodyTracker.shared.initialize(buffer: buffer)
+        ViewBodyTracker.shared.initialize(buffer: buffer, dateProvider: dateProvider)
         UserDefaultsInspector.shared.initialize(buffer: buffer)
         DatabaseInspector.shared.initialize()
 

--- a/ios/auto-mobile-sdk/Sources/AutoMobileSDK/DateProvider.swift
+++ b/ios/auto-mobile-sdk/Sources/AutoMobileSDK/DateProvider.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+/// Abstraction over date/time for deterministic testing.
+public protocol DateProvider: Sendable {
+    /// Returns the current date.
+    func now() -> Date
+}
+
+/// Default DateProvider that returns the real system time.
+public struct SystemDateProvider: DateProvider, Sendable {
+    public init() {}
+    public func now() -> Date { Date() }
+}

--- a/ios/auto-mobile-sdk/Sources/AutoMobileSDK/Persistence/EventPersistence.swift
+++ b/ios/auto-mobile-sdk/Sources/AutoMobileSDK/Persistence/EventPersistence.swift
@@ -23,15 +23,17 @@ struct PersistedEvent: Codable {
 public final class FileEventPersistence: EventPersisting, @unchecked Sendable {
     private let directory: URL
     private let lock = NSLock()
+    private let dateProvider: DateProvider
 
-    public init(directory: URL) {
+    public init(directory: URL, dateProvider: DateProvider = SystemDateProvider()) {
         self.directory = directory
+        self.dateProvider = dateProvider
         try? FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
     }
 
     public func persist(_ events: [any SdkEvent]) -> String? {
         guard !events.isEmpty else { return nil }
-        let batchId = "\(Int(Date().timeIntervalSince1970 * 1000))_\(UUID().uuidString)"
+        let batchId = "\(Int(dateProvider.now().timeIntervalSince1970 * 1000))_\(UUID().uuidString)"
         let fileURL = directory.appendingPathComponent("events_\(batchId).json")
 
         // Reuse SdkEventEnvelope which already handles type-erased encoding
@@ -96,7 +98,7 @@ public final class FileEventPersistence: EventPersisting, @unchecked Sendable {
     public func cleanup(maxAgeDays: Int = 7) {
         lock.lock()
         defer { lock.unlock() }
-        let cutoff = Date().timeIntervalSince1970 * 1000 - Double(maxAgeDays * 24 * 60 * 60 * 1000)
+        let cutoff = dateProvider.now().timeIntervalSince1970 * 1000 - Double(maxAgeDays * 24 * 60 * 60 * 1000)
         guard let files = try? FileManager.default.contentsOfDirectory(at: directory, includingPropertiesForKeys: nil)
             .filter({ $0.lastPathComponent.hasPrefix("events_") })
         else { return }

--- a/ios/auto-mobile-sdk/Sources/AutoMobileSDK/ViewBody/ViewBodyTracker.swift
+++ b/ios/auto-mobile-sdk/Sources/AutoMobileSDK/ViewBody/ViewBodyTracker.swift
@@ -12,12 +12,14 @@ public final class ViewBodyTracker: @unchecked Sendable {
     private var buffer: SdkEventBuffer?
     private var snapshotTimer: (any TimerScheduling)?
     private let snapshotIntervalMs: Int = 1000
+    private var dateProvider: DateProvider = SystemDateProvider()
 
     private init() {}
 
-    func initialize(buffer: SdkEventBuffer) {
+    func initialize(buffer: SdkEventBuffer, dateProvider: DateProvider = SystemDateProvider()) {
         lock.lock()
         self.buffer = buffer
+        self.dateProvider = dateProvider
         lock.unlock()
     }
 
@@ -60,9 +62,10 @@ public final class ViewBodyTracker: @unchecked Sendable {
         let entry = entries[id] ?? Entry(id: id, viewName: viewName)
         var updated = entry
         updated.totalCount += 1
-        updated.recentTimestamps.append(Date().timeIntervalSince1970)
+        let now = dateProvider.now().timeIntervalSince1970
+        updated.recentTimestamps.append(now)
         // Keep only timestamps from the last second for rolling average
-        let cutoff = Date().timeIntervalSince1970 - 1.0
+        let cutoff = now - 1.0
         updated.recentTimestamps.removeAll { $0 < cutoff }
         entries[id] = updated
         lock.unlock()
@@ -87,10 +90,11 @@ public final class ViewBodyTracker: @unchecked Sendable {
     public func getSnapshots() -> [ViewBodySnapshot] {
         lock.lock()
         let currentEntries = entries
+        let currentDateProvider = dateProvider
         lock.unlock()
 
         return currentEntries.values.map { entry in
-            let cutoff = Date().timeIntervalSince1970 - 1.0
+            let cutoff = currentDateProvider.now().timeIntervalSince1970 - 1.0
             let recentCount = entry.recentTimestamps.filter { $0 >= cutoff }.count
             let avgDuration = entry.durationCount > 0
                 ? entry.totalDurationMs / Double(entry.durationCount)
@@ -127,6 +131,7 @@ public final class ViewBodyTracker: @unchecked Sendable {
         entries.removeAll()
         _isEnabled = false
         buffer = nil
+        dateProvider = SystemDateProvider()
         lock.unlock()
     }
 }

--- a/ios/auto-mobile-sdk/Tests/AutoMobileSDKTests/EventPersistenceTests.swift
+++ b/ios/auto-mobile-sdk/Tests/AutoMobileSDKTests/EventPersistenceTests.swift
@@ -5,12 +5,14 @@ final class EventPersistenceTests: XCTestCase {
 
     private var tempDir: URL!
     private var persistence: FileEventPersistence!
+    private var fakeDateProvider: FakeDateProvider!
 
     override func setUp() {
         super.setUp()
         tempDir = URL(fileURLWithPath: NSTemporaryDirectory())
             .appendingPathComponent("event_persistence_tests_\(UUID().uuidString)")
-        persistence = FileEventPersistence(directory: tempDir)
+        fakeDateProvider = FakeDateProvider(initialDate: Date())
+        persistence = FileEventPersistence(directory: tempDir, dateProvider: fakeDateProvider)
     }
 
     override func tearDown() {
@@ -118,8 +120,12 @@ final class EventPersistenceTests: XCTestCase {
     // MARK: - Cleanup TTL
 
     func testCleanupRemovesOldBatches() {
+        // Use a fixed time for deterministic testing
+        let now = Date(timeIntervalSince1970: 1_700_000_000)
+        fakeDateProvider.set(now)
+
         // Create a file with an old timestamp (8 days ago)
-        let oldTs = Int(Date().timeIntervalSince1970 * 1000) - (8 * 24 * 60 * 60 * 1000)
+        let oldTs = Int(now.timeIntervalSince1970 * 1000) - (8 * 24 * 60 * 60 * 1000)
         let oldFile = tempDir.appendingPathComponent("events_\(oldTs)_OLD.json")
         let data = try! JSONSerialization.data(withJSONObject: [["eventType": "custom"]])
         try! data.write(to: oldFile)

--- a/ios/auto-mobile-sdk/Tests/AutoMobileSDKTests/Fakes.swift
+++ b/ios/auto-mobile-sdk/Tests/AutoMobileSDKTests/Fakes.swift
@@ -45,6 +45,35 @@ final class FakeTimer: TimerScheduling, @unchecked Sendable {
     }
 }
 
+// MARK: - FakeDateProvider
+
+final class FakeDateProvider: DateProvider, @unchecked Sendable {
+    private let lock = NSLock()
+    private var _currentDate: Date
+
+    init(initialDate: Date = Date(timeIntervalSince1970: 1_000_000)) {
+        _currentDate = initialDate
+    }
+
+    func now() -> Date {
+        lock.lock()
+        defer { lock.unlock() }
+        return _currentDate
+    }
+
+    func advance(by interval: TimeInterval) {
+        lock.lock()
+        _currentDate = _currentDate.addingTimeInterval(interval)
+        lock.unlock()
+    }
+
+    func set(_ date: Date) {
+        lock.lock()
+        _currentDate = date
+        lock.unlock()
+    }
+}
+
 // MARK: - FakeDropCounter
 
 final class FakeDropCounter: DropCounting, @unchecked Sendable {


### PR DESCRIPTION
## Summary
- Introduce `DateProvider` protocol with `SystemDateProvider` default implementation for abstracting `Date()` calls
- Inject `DateProvider` into `EventPersistence` and `ViewBodyTracker`, wired through `AutoMobileSDK` init
- Add `FakeDateProvider` to test fakes enabling controlled, deterministic time in unit tests

## Test plan
- [x] All 144 existing Swift tests pass with 0 failures
- [x] `EventPersistenceTests` uses `FakeDateProvider` for deterministic timestamps
- [x] No behavioral changes to production code (SystemDateProvider delegates to `Date()`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)