### PR TITLE
chore(deps): remove unused MCP SDK and Ktor from desktop-core

### DIFF
--- a/android/desktop-core/build.gradle.kts
+++ b/android/desktop-core/build.gradle.kts
@@ -37,11 +37,6 @@ dependencies {
   implementation("org.jetbrains.kotlinx:kotlinx-coroutines-swing:1.10.2")
   implementation(libs.kotlinx.serialization)
 
-  // MCP Kotlin SDK for client communication
-  implementation("io.modelcontextprotocol:kotlin-sdk:0.10.0")
-  // Ktor client engine for MCP transport
-  implementation(libs.ktor.client.cio)
-
   // YAML and JSON schema validation
   implementation(libs.snakeyaml)
   implementation(libs.json.schema.validator)


### PR DESCRIPTION
## Summary
- Remove unused `io.modelcontextprotocol:kotlin-sdk` and `ktor-client-cio` dependencies from `desktop-core/build.gradle.kts`
- Both had zero imports in desktop-core source and test code
- Ktor remains in `control-proxy` where it's actually used (WebSocket server)

## Test Plan
- [x] `./gradlew :desktop-core:compileKotlin` passes
- [x] `./gradlew :desktop-core:test` passes (all tests green)

🤖 Generated with [Claude Code](https://claude.com/claude-code)