### PR TITLE
fix: normalize Unicode quotes in text matching for tapOn

### DIFF
--- a/src/features/utility/ElementFinder.ts
+++ b/src/features/utility/ElementFinder.ts
@@ -5,7 +5,7 @@ import type { ElementParser } from "../../utils/interfaces/ElementParser";
 import type { TextMatcher } from "../../utils/interfaces/TextMatcher";
 import type { ElementFinder } from "../../utils/interfaces/ElementFinder";
 import { DefaultElementParser } from "./ElementParser";
-import { DefaultTextMatcher } from "./TextMatcher";
+import { DefaultTextMatcher, normalizeQuotes } from "./TextMatcher";
 import { ANDROID_INPUT_CLASSES } from "../../utils/elementProperties";
 
 /**
@@ -143,7 +143,7 @@ export class DefaultElementFinder implements ElementFinder {
           logger.debug("[Element] Matches text property");
           const parsedNode = this.parser.parseNodeBounds(node);
           if (parsedNode) {
-            if (nodeProperties.text === text) {
+            if (normalizeQuotes(nodeProperties.text) === normalizeQuotes(text)) {
               exactMatches.push(parsedNode);
             } else {
               partialMatches.push(parsedNode);
@@ -157,7 +157,7 @@ export class DefaultElementFinder implements ElementFinder {
           logger.debug("[Element] Matches content-desc property");
           const parsedNode = this.parser.parseNodeBounds(node);
           if (parsedNode) {
-            if (nodeProperties["content-desc"] === text) {
+            if (normalizeQuotes(nodeProperties["content-desc"]) === normalizeQuotes(text)) {
               exactMatches.push(parsedNode);
             } else {
               partialMatches.push(parsedNode);
@@ -171,7 +171,7 @@ export class DefaultElementFinder implements ElementFinder {
           logger.debug("[Element] Matches ios-accessibility-label property");
           const parsedNode = this.parser.parseNodeBounds(node);
           if (parsedNode) {
-            if (nodeProperties["ios-accessibility-label"] === text) {
+            if (normalizeQuotes(nodeProperties["ios-accessibility-label"]) === normalizeQuotes(text)) {
               exactMatches.push(parsedNode);
             } else {
               partialMatches.push(parsedNode);

--- a/src/features/utility/TextMatcher.ts
+++ b/src/features/utility/TextMatcher.ts
@@ -1,6 +1,19 @@
 import type { TextMatcher } from "../../utils/interfaces/TextMatcher";
 
 /**
+ * Normalize Unicode quotation marks and apostrophes to their ASCII equivalents.
+ * iOS and Android system dialogs frequently use smart/curly quotes that differ
+ * from the straight quotes users type.
+ */
+export function normalizeQuotes(text: string): string {
+  return text
+    .replace(/[\u2018\u2019\u201A\u201B\u2032\u0060\u00B4]/g, "'")   // single quotes/apostrophes → U+0027
+    .replace(/[\u201C\u201D\u201E\u201F\u2033\u00AB\u00BB]/g, '"')   // double quotes → U+0022
+    .replace(/[\u2010\u2011\u2012\u2013\u2014\u2015]/g, "-")         // dashes → U+002D
+    .replace(/\u2026/g, "...");                                        // ellipsis → three dots
+}
+
+/**
  * Handles text matching algorithms for element search
  */
 export class DefaultTextMatcher implements TextMatcher {
@@ -16,8 +29,8 @@ export class DefaultTextMatcher implements TextMatcher {
       return false;
     }
 
-    const str1 = caseSensitive ? text1 : text1.toLowerCase();
-    const str2 = caseSensitive ? text2 : text2.toLowerCase();
+    const str1 = caseSensitive ? normalizeQuotes(text1) : normalizeQuotes(text1).toLowerCase();
+    const str2 = caseSensitive ? normalizeQuotes(text2) : normalizeQuotes(text2).toLowerCase();
 
     // Check if either string contains the other
     return str1.includes(str2) || str2.includes(str1);
@@ -33,12 +46,12 @@ export class DefaultTextMatcher implements TextMatcher {
   createTextMatcher(text: string, partialMatch: boolean = true, caseSensitive: boolean = false): (input?: string) => boolean {
     if (!text) {return () => false;}
 
-    const searchText = caseSensitive ? text : text.toLowerCase();
+    const searchText = caseSensitive ? normalizeQuotes(text) : normalizeQuotes(text).toLowerCase();
 
     return (input?: string): boolean => {
       if (!input) {return false;}
 
-      const targetText = caseSensitive ? input : input.toLowerCase();
+      const targetText = caseSensitive ? normalizeQuotes(input) : normalizeQuotes(input).toLowerCase();
 
       return partialMatch
         ? targetText.includes(searchText)

--- a/test/features/utility/TextMatcher.test.ts
+++ b/test/features/utility/TextMatcher.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { DefaultTextMatcher } from "../../../src/features/utility/TextMatcher";
+import { DefaultTextMatcher, normalizeQuotes } from "../../../src/features/utility/TextMatcher";
 
 describe("DefaultTextMatcher", () => {
   const matcher = new DefaultTextMatcher();
@@ -92,6 +92,73 @@ describe("DefaultTextMatcher", () => {
       expect(fn("Hello")).toBe(true);
       expect(fn("hello")).toBe(false);
       expect(fn("Hello World")).toBe(false);
+    });
+  });
+
+  describe("Unicode quote normalization", () => {
+    test("matches curly single quotes against straight apostrophe", () => {
+      expect(matcher.partialTextMatch("Don't Allow", "Don\u2019t Allow")).toBe(true);
+      expect(matcher.partialTextMatch("Don't Allow", "Don\u2018t Allow")).toBe(true);
+    });
+
+    test("matches curly double quotes against straight quotes", () => {
+      expect(matcher.partialTextMatch('Allow "Reminders"', "Allow \u201CReminders\u201D")).toBe(true);
+    });
+
+    test("matches em dash against hyphen", () => {
+      expect(matcher.partialTextMatch("foo-bar", "foo\u2014bar")).toBe(true);
+      expect(matcher.partialTextMatch("foo-bar", "foo\u2013bar")).toBe(true);
+    });
+
+    test("matches ellipsis against three dots", () => {
+      expect(matcher.partialTextMatch("Loading...", "Loading\u2026")).toBe(true);
+    });
+
+    test("exact match normalizes quotes", () => {
+      const fn = matcher.createTextMatcher("Don't Allow", false);
+      expect(fn("Don\u2019t Allow")).toBe(true);
+    });
+
+    test("partial match normalizes quotes", () => {
+      const fn = matcher.createTextMatcher("Don't", true);
+      expect(fn("Don\u2019t Allow")).toBe(true);
+    });
+
+    test("case-sensitive match still normalizes quotes", () => {
+      const fn = matcher.createTextMatcher("Don't Allow", false, true);
+      expect(fn("Don\u2019t Allow")).toBe(true);
+      expect(fn("don\u2019t allow")).toBe(false);
+    });
+  });
+
+  describe("normalizeQuotes", () => {
+    test("normalizes single quote variants", () => {
+      expect(normalizeQuotes("\u2018hello\u2019")).toBe("'hello'");
+      expect(normalizeQuotes("\u201Ahello\u201B")).toBe("'hello'");
+      expect(normalizeQuotes("\u2032hello\u0060")).toBe("'hello'");
+      expect(normalizeQuotes("\u00B4hello")).toBe("'hello");
+    });
+
+    test("normalizes double quote variants", () => {
+      expect(normalizeQuotes("\u201Chello\u201D")).toBe('"hello"');
+      expect(normalizeQuotes("\u201Ehello\u201F")).toBe('"hello"');
+      expect(normalizeQuotes("\u00ABhello\u00BB")).toBe('"hello"');
+      expect(normalizeQuotes("\u2033hello")).toBe('"hello');
+    });
+
+    test("normalizes dashes", () => {
+      expect(normalizeQuotes("a\u2013b")).toBe("a-b");  // en dash
+      expect(normalizeQuotes("a\u2014b")).toBe("a-b");  // em dash
+      expect(normalizeQuotes("a\u2010b")).toBe("a-b");  // hyphen
+    });
+
+    test("normalizes ellipsis", () => {
+      expect(normalizeQuotes("wait\u2026")).toBe("wait...");
+    });
+
+    test("leaves plain ASCII unchanged", () => {
+      expect(normalizeQuotes("Don't Allow")).toBe("Don't Allow");
+      expect(normalizeQuotes('"hello"')).toBe('"hello"');
     });
   });
 });


### PR DESCRIPTION
## Summary
- Add `normalizeQuotes()` function that maps Unicode smart quotes, dashes, and ellipsis to ASCII equivalents
- Apply normalization in `TextMatcher` (affects all text-based element finding: tapOn, swipeOn, etc.) on both iOS and Android
- Fix `ElementFinder` exact-match comparisons (`=== text`) to also normalize before comparing
- 13 new tests covering all normalization categories

Closes #1798

## Test Plan
- [x] 29 TextMatcher tests pass (13 new)
- [x] 39 ElementFinder tests pass
- [x] Full test suite: 3376 tests pass
- [x] Lint and build pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)