### PR TITLE
fix(ios): populate activeWindow for foreground app detection

### DIFF
--- a/src/features/observe/ObserveScreen.ts
+++ b/src/features/observe/ObserveScreen.ts
@@ -690,6 +690,15 @@ export class RealObserveScreen implements ObserveScreen {
           }
         }
 
+        // Populate activeWindow from view hierarchy packageName if not already set
+        if (result.viewHierarchy?.packageName && !result.activeWindow) {
+          result.activeWindow = {
+            appId: result.viewHierarchy.packageName,
+            activityName: "",
+            layoutSeqSum: 0
+          };
+        }
+
         perf.end();
         break;
     }


### PR DESCRIPTION
## Summary
- The iOS `observe` path never populated `result.activeWindow`, so the foreground app bundle ID was not reported through the standard `activeWindow` field
- Added the same `activeWindow` population pattern already used in the Android path, deriving `appId` from `viewHierarchy.packageName` (which iOS ElementLocator.swift already sets to the detected foreground app's bundleId)
- Fixes foreground app detection inconsistency where `observe` could return hierarchy data without identifying which app it belongs to

## Test plan
- [x] `turbo run lint build test` passes (3364 tests, 0 failures)
- [x] Change mirrors existing Android pattern (lines 636-642) for consistency

🤖 Generated with [Claude Code](https://claude.com/claude-code)