### PR TITLE
feat(desktop): timeline toolbar & EventTimeline composable

### DIFF
--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/timeline/TimelineCanvas.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/timeline/TimelineCanvas.kt
@@ -40,32 +40,31 @@ fun TimelineCanvas(
     onEventClicked: (TelemetryDisplayEvent) -> Unit,
     modifier: Modifier = Modifier,
 ) {
-  val colors = SharedTheme.globalColors
-  val textMeasurer = rememberTextMeasurer()
-  val timeFormat = remember { SimpleDateFormat("HH:mm:ss", Locale.US) }
-  val isMac = remember { System.getProperty("os.name")?.lowercase()?.contains("mac") == true }
-  val infoColor = colors.text.info
-  val textColor = colors.text.normal
+    val colors = SharedTheme.globalColors
+    val textMeasurer = rememberTextMeasurer()
+    val timeFormat = remember { SimpleDateFormat("HH:mm:ss", Locale.US) }
+    val isMac = remember { System.getProperty("os.name")?.lowercase()?.contains("mac") == true }
+    val infoColor = colors.text.info
+    val textColor = colors.text.normal
 
-  Box(
-      modifier =
-          modifier
-              .onPointerEvent(PointerEventType.Scroll) { event ->
+    Box(
+        modifier = modifier
+            .onPointerEvent(PointerEventType.Scroll) { event ->
                 val change = event.changes.first()
-                val isZoomModifier =
-                    if (isMac) event.keyboardModifiers.isMetaPressed
-                    else event.keyboardModifiers.isCtrlPressed
+                val isZoomModifier = if (isMac) event.keyboardModifiers.isMetaPressed else event.keyboardModifiers.isCtrlPressed
                 if (isZoomModifier) {
-                  val chartWidth = (size.width - LANE_LABEL_WIDTH).coerceAtLeast(1f)
-                  val pivotFraction = (change.position.x - LANE_LABEL_WIDTH) / chartWidth
-                  state.scrollZoom(change.scrollDelta.y, pivotFraction.coerceIn(0f, 1f))
-                  change.consume()
+                    val chartWidth = (size.width - LANE_LABEL_WIDTH).coerceAtLeast(1f)
+                    val pivotFraction = (change.position.x - LANE_LABEL_WIDTH) / chartWidth
+                    state.scrollZoom(change.scrollDelta.y, pivotFraction.coerceIn(0f, 1f))
+                    change.consume()
                 }
-              }
-              .pointerInput(Unit) {
-                detectDragGestures { _, dragAmount -> state.panBy(-dragAmount.x / size.width) }
-              }
-              .pointerInput(spans) {
+            }
+            .pointerInput(Unit) {
+                detectDragGestures { _, dragAmount ->
+                    state.panBy(-dragAmount.x / size.width)
+                }
+            }
+            .pointerInput(spans) {
                 detectTapGestures { offset ->
                   val chartWidth = size.width - LANE_LABEL_WIDTH
                   val chartHeight = size.height - TIME_AXIS_HEIGHT
@@ -99,96 +98,91 @@ fun TimelineCanvas(
                     onEventClicked(nearest.event)
                   }
                 }
-              }
-  ) {
-    Canvas(Modifier.fillMaxSize()) {
-      if (activeLanes.isEmpty()) return@Canvas
-      val chartLeft = LANE_LABEL_WIDTH
-      val chartWidth = size.width - chartLeft
-      val chartHeight = size.height - TIME_AXIS_HEIGHT
-      if (chartWidth <= 0 || chartHeight <= 0) return@Canvas
-      val laneHeight = chartHeight / activeLanes.size
+            }
+    ) {
+        Canvas(Modifier.fillMaxSize()) {
+            if (activeLanes.isEmpty()) return@Canvas
+            val chartLeft = LANE_LABEL_WIDTH
+            val chartWidth = size.width - chartLeft
+            val chartHeight = size.height - TIME_AXIS_HEIGHT
+            if (chartWidth <= 0 || chartHeight <= 0) return@Canvas
+            val laneHeight = chartHeight / activeLanes.size
 
-      // Draw lane backgrounds
-      activeLanes.forEachIndexed { index, _ ->
-        val y = index * laneHeight
-        val bgAlpha = if (index % 2 == 0) 0.03f else 0.06f
-        drawRect(
-            color = textColor.copy(alpha = bgAlpha),
-            topLeft = Offset(chartLeft, y),
-            size = Size(chartWidth, laneHeight),
-        )
-      }
+            activeLanes.forEachIndexed { index, _ ->
+                val y = index * laneHeight
+                val bgAlpha = if (index % 2 == 0) 0.03f else 0.06f
+                drawRect(
+                    color = textColor.copy(alpha = bgAlpha),
+                    topLeft = Offset(chartLeft, y),
+                    size = Size(chartWidth, laneHeight),
+                )
+            }
 
-      // Draw spans
-      for (span in spans) {
-        val laneIndex = activeLanes.indexOf(span.category.laneIndex)
-        if (laneIndex < 0) continue
-        val startFrac = state.timestampToFraction(span.startMs)
-        val endFrac = state.timestampToFraction(span.endMs)
-        if (endFrac < 0f || startFrac > 1f) continue
-        val x1 = (chartLeft + startFrac * chartWidth).coerceAtLeast(chartLeft)
-        val x2 = (chartLeft + endFrac * chartWidth).coerceAtMost(chartLeft + chartWidth)
-        val spanWidth = (x2 - x1).coerceAtLeast(MIN_SPAN_WIDTH)
-        val laneY = laneIndex * laneHeight
-        val spanH = laneHeight * SPAN_HEIGHT_FRACTION
-        val spanY = laneY + (laneHeight - spanH) / 2
-        val alpha = if (span.isFiltered) 0.2f else 1.0f
-        drawRoundRect(
-            color = span.category.color.copy(alpha = alpha),
-            topLeft = Offset(x1, spanY),
-            size = Size(spanWidth, spanH),
-            cornerRadius = CornerRadius(2f, 2f),
-        )
-      }
+            for (span in spans) {
+                val laneIndex = activeLanes.indexOf(span.category.laneIndex)
+                if (laneIndex < 0) continue
+                val startFrac = state.timestampToFraction(span.startMs)
+                val endFrac = state.timestampToFraction(span.endMs)
+                if (endFrac < 0f || startFrac > 1f) continue
+                val x1 = (chartLeft + startFrac * chartWidth).coerceAtLeast(chartLeft)
+                val x2 = (chartLeft + endFrac * chartWidth).coerceAtMost(chartLeft + chartWidth)
+                val spanWidth = (x2 - x1).coerceAtLeast(MIN_SPAN_WIDTH)
+                val laneY = laneIndex * laneHeight
+                val spanH = laneHeight * SPAN_HEIGHT_FRACTION
+                val spanY = laneY + (laneHeight - spanH) / 2
+                val alpha = if (span.isFiltered) 0.2f else 1.0f
+                drawRoundRect(
+                    color = span.category.color.copy(alpha = alpha),
+                    topLeft = Offset(x1, spanY),
+                    size = Size(spanWidth, spanH),
+                    cornerRadius = CornerRadius(2f, 2f),
+                )
+            }
 
-      // Draw playhead
-      state.selectedTimestampMs?.let { ts ->
-        val frac = state.timestampToFraction(ts)
-        if (frac in 0f..1f) {
-          val x = chartLeft + frac * chartWidth
-          drawLine(
-              color = infoColor.copy(alpha = 0.8f),
-              start = Offset(x, 0f),
-              end = Offset(x, chartHeight),
-              strokeWidth = 1.5f,
-          )
+            state.selectedTimestampMs?.let { ts ->
+                val frac = state.timestampToFraction(ts)
+                if (frac in 0f..1f) {
+                    val x = chartLeft + frac * chartWidth
+                    drawLine(
+                        color = infoColor.copy(alpha = 0.8f),
+                        start = Offset(x, 0f),
+                        end = Offset(x, chartHeight),
+                        strokeWidth = 1.5f,
+                    )
+                }
+            }
+
+            val tickCount = (chartWidth / 80).toInt().coerceIn(2, 10)
+            for (i in 0..tickCount) {
+                val frac = i.toFloat() / tickCount
+                val x = chartLeft + frac * chartWidth
+                val ts = state.fractionToTimestamp(frac)
+                drawLine(
+                    color = textColor.copy(alpha = 0.2f),
+                    start = Offset(x, chartHeight),
+                    end = Offset(x, chartHeight + 4f),
+                    strokeWidth = 1f,
+                )
+                val label = timeFormat.format(Date(ts))
+                val textResult = textMeasurer.measure(label, style = TextStyle(fontSize = 8.sp))
+                drawText(
+                    textLayoutResult = textResult,
+                    color = textColor.copy(alpha = 0.4f),
+                    topLeft = Offset(x - textResult.size.width / 2f, chartHeight + 4f),
+                )
+            }
+
+            val laneLabels = mapOf(0 to "Net/Tool", 1 to "Nav/State", 2 to "Diag")
+            activeLanes.forEachIndexed { index, laneIdx ->
+                val label = laneLabels[laneIdx] ?: ""
+                val textResult = textMeasurer.measure(label, style = TextStyle(fontSize = 9.sp))
+                val laneY = index * laneHeight + laneHeight / 2 - textResult.size.height / 2
+                drawText(
+                    textLayoutResult = textResult,
+                    color = textColor.copy(alpha = 0.4f),
+                    topLeft = Offset(4f, laneY),
+                )
+            }
         }
-      }
-
-      // Draw time axis ticks
-      val tickCount = (chartWidth / 80).toInt().coerceIn(2, 10)
-      for (i in 0..tickCount) {
-        val frac = i.toFloat() / tickCount
-        val x = chartLeft + frac * chartWidth
-        val ts = state.fractionToTimestamp(frac)
-        drawLine(
-            color = textColor.copy(alpha = 0.2f),
-            start = Offset(x, chartHeight),
-            end = Offset(x, chartHeight + 4f),
-            strokeWidth = 1f,
-        )
-        val label = timeFormat.format(Date(ts))
-        val textResult = textMeasurer.measure(label, style = TextStyle(fontSize = 8.sp))
-        drawText(
-            textLayoutResult = textResult,
-            color = textColor.copy(alpha = 0.4f),
-            topLeft = Offset(x - textResult.size.width / 2f, chartHeight + 4f),
-        )
-      }
-
-      // Draw lane labels
-      val laneLabels = mapOf(0 to "Net/Tool", 1 to "Nav/State", 2 to "Diag")
-      activeLanes.forEachIndexed { index, laneIdx ->
-        val label = laneLabels[laneIdx] ?: ""
-        val textResult = textMeasurer.measure(label, style = TextStyle(fontSize = 9.sp))
-        val laneY = index * laneHeight + laneHeight / 2 - textResult.size.height / 2
-        drawText(
-            textLayoutResult = textResult,
-            color = textColor.copy(alpha = 0.4f),
-            topLeft = Offset(4f, laneY),
-        )
-      }
     }
-  }
 }

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/timeline/TimelineModels.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/timeline/TimelineModels.kt
@@ -39,8 +39,8 @@ data class TimelineSpan(
     val isFiltered: Boolean,
 )
 
-fun buildTimelineSpans(events: List<TelemetryDisplayEvent>, activeFilterCategory: String?): List<TimelineSpan> =
-    events.map { event ->
+fun buildTimelineSpans(events: List<TelemetryDisplayEvent>, activeFilterCategory: String?): List<TimelineSpan> {
+    return events.map { event ->
         val category = event.toTimelineCategory()
         val durationMs = when (event) {
             is TelemetryDisplayEvent.Network -> event.durationMs
@@ -56,6 +56,7 @@ fun buildTimelineSpans(events: List<TelemetryDisplayEvent>, activeFilterCategory
             isFiltered = activeFilterCategory != null && activeFilterCategory != "All" && category.label != activeFilterCategory,
         )
     }
+}
 
 fun activeLanes(spans: List<TimelineSpan>): List<Int> =
     spans.map { it.category.laneIndex }.distinct().sorted()

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/timeline/TimelineToolbar.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/timeline/TimelineToolbar.kt
@@ -1,9 +1,12 @@
 package dev.jasonpearson.automobile.desktop.core.timeline
 
+import androidx.compose.animation.animateColorAsState
+import androidx.compose.animation.core.tween
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.hoverable
 import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.interaction.collectIsHoveredAsState
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -12,6 +15,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -33,6 +37,7 @@ fun TimelineToolbar(
 ) {
     val colors = SharedTheme.globalColors
     val timeFormat = remember { SimpleDateFormat("HH:mm:ss", Locale.US) }
+
     Row(
         modifier = modifier
             .fillMaxWidth()
@@ -51,27 +56,42 @@ fun TimelineToolbar(
             color = colors.text.normal.copy(alpha = 0.5f),
         )
         Spacer(Modifier.width(8.dp))
-        ToolbarButton("-") { state.zoomOut() }
+        ToolbarButton(label = "-", onClick = { state.zoomOut() })
         Spacer(Modifier.width(2.dp))
-        ToolbarButton("+") { state.zoomIn() }
+        ToolbarButton(label = "+", onClick = { state.zoomIn() })
         Spacer(Modifier.width(2.dp))
-        ToolbarButton("Fit", onClick = onFitAll)
+        ToolbarButton(label = "Fit", onClick = onFitAll)
     }
 }
 
 @Composable
-private fun ToolbarButton(label: String, onClick: () -> Unit) {
+private fun ToolbarButton(
+    label: String,
+    onClick: () -> Unit,
+) {
     val colors = SharedTheme.globalColors
     val interactionSource = remember { MutableInteractionSource() }
+    val isHovered by interactionSource.collectIsHoveredAsState()
+
+    val bgColor by animateColorAsState(
+        targetValue = colors.text.normal.copy(alpha = if (isHovered) 0.10f else 0.05f),
+        animationSpec = tween(durationMillis = 100),
+        label = "toolbarBtnBg",
+    )
+
     Text(
         text = label,
         fontSize = 10.sp,
-        color = colors.text.normal.copy(alpha = 0.6f),
+        color = colors.text.normal.copy(alpha = 0.5f),
         modifier = Modifier
+            .background(bgColor)
             .hoverable(interactionSource)
-            .clickable(interactionSource = interactionSource, indication = null, onClick = onClick)
             .pointerHoverIcon(PointerIcon.Hand)
-            .background(colors.text.normal.copy(alpha = 0.05f))
+            .clickable(
+                interactionSource = interactionSource,
+                indication = null,
+                onClick = onClick,
+            )
             .padding(horizontal = 6.dp, vertical = 2.dp),
     )
 }


### PR DESCRIPTION
## Summary
- Add `TimelineToolbar` composable: 24dp status-bar-style row with "Timeline" label, span count badge, visible time range (HH:mm:ss format), and zoom/fit buttons matching `PaneToggleIcon` hover style
- Add `EventTimeline` top-level composable that assembles toolbar + canvas stub with auto-fit on initial event load and empty-state placeholder
- Add supporting types: `TimelineModels.kt` (TimelineCategory enum, TimelineSpan, buildTimelineSpans, activeLanes), `TimelineState.kt` (zoom/pan/fit state holder), `TimelineCanvas.kt` (stub)

## Test plan
- [x] `./gradlew :desktop-core:compileKotlin` passes with no errors
- [ ] Visual verification when integrated into ThreePaneShell bottom pane

🤖 Generated with [Claude Code](https://claude.com/claude-code)