### PR TITLE
docs(ios): fix design doc discrepancies against source code

### DIFF
--- a/docs/design-docs/plat/ios/auto-mobile-sdk.md
+++ b/docs/design-docs/plat/ios/auto-mobile-sdk.md
@@ -251,7 +251,7 @@ Body capture is always disabled in release builds to prevent leaking credentials
 
 ## Logging
 
-`AutoMobileLog` provides thin wrappers around Apple's `os.Logger` for structured logging. Logs are written to the unified logging system with `privacy: .public` redaction and are captured by OSLogStore in CtrlProxy for remote observation.
+`AutoMobileLog` provides thin wrappers around Apple's `os.Logger` for structured logging. Logs are written to the unified logging system with `privacy: .public` (non-redacted, visible in Console.app and OSLogStore). Note that `.public` disables redaction — sensitive fields such as PII or credentials must not be passed through these log methods.
 
 Log methods mirror standard log levels: `v()`, `d()`, `i()`, `w()`, `e()`, `fault()`. Each method accepts an optional `tag` parameter that is formatted as a `[tag] message` prefix.
 


### PR DESCRIPTION
## Summary
- **AutoMobileLog**: Corrected from "regex filter engine" to "os.Logger wrappers" -- the iOS implementation delegates to Apple's unified logging system, unlike Android's regex-based filter capture
- **AutoMobileConfiguration**: Added missing `eventProcessors` and `maxPendingEvents` fields that exist in code but were omitted from the doc
- **Event types**: Removed `custom` from the supported types list -- it does not exist in `SdkEventType` enum
- **Test counts**: Updated from 139 tests / 19 files to 151 tests / 20 files with corrected per-file distribution
- **Cross-platform table**: Clarified the iOS vs Android logging divergence

## Test plan
- [x] `bash scripts/validate_mkdocs_nav.sh` passes
- [x] All changes verified against actual Swift source files

🤖 Generated with [Claude Code](https://claude.com/claude-code)