### PR TITLE
refactor: clean up AutoMobileSDK entry point visibility

### DIFF
--- a/android/auto-mobile-sdk/README.md
+++ b/android/auto-mobile-sdk/README.md
@@ -153,10 +153,10 @@ AutoMobileSDK.clearNavigationListeners()
 AutoMobileSDK.setEnabled(true)
 
 // Check if tracking is enabled
-val isEnabled = AutoMobileSDK.isEnabled()
+val isEnabled = AutoMobileSDK.isTrackingEnabled
 
 // Get listener count
-val count = AutoMobileSDK.getListenerCount()
+val count = AutoMobileSDK.listenerCount
 ```
 
 ### NavigationEvent

--- a/android/auto-mobile-sdk/api/auto-mobile-sdk.api
+++ b/android/auto-mobile-sdk/api/auto-mobile-sdk.api
@@ -104,7 +104,7 @@ public final class dev.jasonpearson.automobile.sdk.AutoMobileSDK {
   public final void clearNavigationListeners();
   public final void notifyNavigationEvent(dev.jasonpearson.automobile.sdk.NavigationEvent);
   public final void setEnabled(boolean);
-  public final boolean isEnabled();
+  public final boolean isTrackingEnabled();
   public final int getListenerCount();
   public final java.lang.String currentSessionId();
   public final void addBreadcrumb(java.lang.String, dev.jasonpearson.automobile.sdk.breadcrumbs.BreadcrumbCategory, java.util.Map<java.lang.String, java.lang.String>);

--- a/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/AutoMobileSDK.kt
+++ b/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/AutoMobileSDK.kt
@@ -77,7 +77,7 @@ object AutoMobileSDK {
   internal var logger: SdkLogger = DefaultSdkLogger()
 
   private val listeners = CopyOnWriteArrayList<NavigationListener>()
-  @Volatile private var isEnabled = true
+  @Volatile private var _isEnabled = true
   @Volatile private var context: Context? = null
   @Volatile private var configuration: AutoMobileConfiguration? = null
   @Volatile private var eventBuffer: SdkEventBuffer? = null
@@ -144,7 +144,7 @@ object AutoMobileSDK {
       maxPendingEvents = configuration.maxPendingEvents,
       backPressureStrategy = configuration.backPressureStrategy,
     )
-    buffer.isEnabled = isEnabled
+    buffer.isEnabled = _isEnabled
     buffer.start()
     eventBuffer = buffer
 
@@ -201,7 +201,7 @@ object AutoMobileSDK {
       sessionLifecycleObserver = observer
       ProcessLifecycleOwner.get().lifecycle.addObserver(observer)
       RecompositionTracker.initialize(appContext)
-      RecompositionTracker.setEnabled(isEnabled)
+      RecompositionTracker.setEnabled(_isEnabled)
       AutoMobileNotifications.initialize(appContext)
       if (appContext is Application) {
         AutoMobileClickTracker.initialize(appContext, appContext.packageName)
@@ -242,7 +242,7 @@ object AutoMobileSDK {
    */
   @AnyThread
   fun notifyNavigationEvent(event: NavigationEvent) {
-    if (!isEnabled) return
+    if (!_isEnabled) return
 
     // Notify in-process listeners
     listeners.forEach { listener ->
@@ -295,16 +295,16 @@ object AutoMobileSDK {
    * @param enabled Whether navigation tracking should be enabled
    */
   fun setEnabled(enabled: Boolean) {
-    isEnabled = enabled
+    _isEnabled = enabled
     eventBuffer?.isEnabled = enabled
     RecompositionTracker.setEnabled(enabled)
   }
 
-  /** Returns whether navigation tracking is currently enabled. */
-  fun isEnabled(): Boolean = isEnabled
+  /** Whether navigation tracking is currently enabled. */
+  val isTrackingEnabled: Boolean get() = _isEnabled
 
-  /** Returns the current number of registered listeners. */
-  fun getListenerCount(): Int = listeners.size
+  /** The current number of registered listeners. */
+  val listenerCount: Int get() = listeners.size
 
   /** Returns the current session ID, or null if no active session. */
   fun currentSessionId(): String? = sessionTracker?.currentSessionId()
@@ -333,11 +333,11 @@ object AutoMobileSDK {
   }
 
   /**
-   * Returns a snapshot of drop counts by reason.
+   * A snapshot of drop counts by reason.
    *
    * Useful for diagnostics — the map is empty when no events have been dropped.
    */
-  fun getDropReport(): Map<DropReason, Long> = dropCounter?.snapshot() ?: emptyMap()
+  val dropReport: Map<DropReason, Long> get() = dropCounter?.snapshot() ?: emptyMap()
 
   /** Returns the shared event buffer, or null if not initialized. */
   internal fun getEventBuffer(): SdkEventBuffer? = eventBuffer
@@ -351,8 +351,8 @@ object AutoMobileSDK {
   /** Removes a tag from the SDK context. */
   fun removeTag(key: String) { sdkContext?.removeTag(key) }
 
-  /** Returns an immutable snapshot of the current SDK context, or null if not initialized. */
-  fun getContextSnapshot(): SdkContextSnapshot? = sdkContext?.snapshot()
+  /** An immutable snapshot of the current SDK context, or null if not initialized. */
+  val contextSnapshot: SdkContextSnapshot? get() = sdkContext?.snapshot()
 
   /**
    * Replay pending event batches from disk (events that survived process death).
@@ -415,7 +415,7 @@ object AutoMobileSDK {
     persistence = null
     RecompositionTracker.reset()
     listeners.clear()
-    isEnabled = true
+    _isEnabled = true
     configuration = null
     context = null
   }

--- a/android/auto-mobile-sdk/src/test/kotlin/dev/jasonpearson/automobile/sdk/AutoMobileSDKTest.kt
+++ b/android/auto-mobile-sdk/src/test/kotlin/dev/jasonpearson/automobile/sdk/AutoMobileSDKTest.kt
@@ -24,7 +24,7 @@ class AutoMobileSDKTest {
     val listener = NavigationListener {}
     AutoMobileSDK.addNavigationListener(listener)
 
-    assertEquals(1, AutoMobileSDK.getListenerCount())
+    assertEquals(1, AutoMobileSDK.listenerCount)
   }
 
   @Test
@@ -33,7 +33,7 @@ class AutoMobileSDKTest {
     AutoMobileSDK.addNavigationListener(listener)
     AutoMobileSDK.removeNavigationListener(listener)
 
-    assertEquals(0, AutoMobileSDK.getListenerCount())
+    assertEquals(0, AutoMobileSDK.listenerCount)
   }
 
   @Test
@@ -44,7 +44,7 @@ class AutoMobileSDKTest {
 
     AutoMobileSDK.clearNavigationListeners()
 
-    assertEquals(0, AutoMobileSDK.getListenerCount())
+    assertEquals(0, AutoMobileSDK.listenerCount)
   }
 
   @Test
@@ -97,13 +97,13 @@ class AutoMobileSDKTest {
 
   @Test
   fun `setEnabled should control tracking state`() {
-    assertTrue(AutoMobileSDK.isEnabled())
+    assertTrue(AutoMobileSDK.isTrackingEnabled)
 
     AutoMobileSDK.setEnabled(false)
-    assertFalse(AutoMobileSDK.isEnabled())
+    assertFalse(AutoMobileSDK.isTrackingEnabled)
 
     AutoMobileSDK.setEnabled(true)
-    assertTrue(AutoMobileSDK.isEnabled())
+    assertTrue(AutoMobileSDK.isTrackingEnabled)
   }
 
   @Test
@@ -133,8 +133,8 @@ class AutoMobileSDKTest {
 
     AutoMobileSDK.shutdown()
 
-    assertEquals(0, AutoMobileSDK.getListenerCount())
-    assertTrue(AutoMobileSDK.isEnabled())
+    assertEquals(0, AutoMobileSDK.listenerCount)
+    assertTrue(AutoMobileSDK.isTrackingEnabled)
     assertNull(AutoMobileSDK.getEventBuffer())
   }
 
@@ -143,7 +143,7 @@ class AutoMobileSDKTest {
     AutoMobileSDK.shutdown()
     AutoMobileSDK.shutdown()
 
-    assertEquals(0, AutoMobileSDK.getListenerCount())
+    assertEquals(0, AutoMobileSDK.listenerCount)
   }
 
   @Test

--- a/android/auto-mobile-sdk/src/test/kotlin/dev/jasonpearson/automobile/sdk/ConcurrencyTest.kt
+++ b/android/auto-mobile-sdk/src/test/kotlin/dev/jasonpearson/automobile/sdk/ConcurrencyTest.kt
@@ -42,7 +42,7 @@ class ConcurrencyTest {
     }
 
     assertTrue(latch.await(5, TimeUnit.SECONDS))
-    assertEquals(100, AutoMobileSDK.getListenerCount())
+    assertEquals(100, AutoMobileSDK.listenerCount)
 
     executor.shutdown()
     assertTrue(executor.awaitTermination(5, TimeUnit.SECONDS))
@@ -78,7 +78,7 @@ class ConcurrencyTest {
     val listeners = (1..50).map { NavigationListener {} }
     listeners.forEach { AutoMobileSDK.addNavigationListener(it) }
 
-    assertEquals(50, AutoMobileSDK.getListenerCount())
+    assertEquals(50, AutoMobileSDK.listenerCount)
 
     val executor = Executors.newFixedThreadPool(10)
     val latch = CountDownLatch(50)
@@ -91,7 +91,7 @@ class ConcurrencyTest {
     }
 
     assertTrue(latch.await(5, TimeUnit.SECONDS))
-    assertEquals(0, AutoMobileSDK.getListenerCount())
+    assertEquals(0, AutoMobileSDK.listenerCount)
 
     executor.shutdown()
     assertTrue(executor.awaitTermination(5, TimeUnit.SECONDS))
@@ -116,7 +116,7 @@ class ConcurrencyTest {
     assertTrue(latch.await(5, TimeUnit.SECONDS))
 
     // Final state should be consistent
-    val isEnabled = AutoMobileSDK.isEnabled()
+    val isEnabled = AutoMobileSDK.isTrackingEnabled
     assertTrue(isEnabled || !isEnabled) // Just verify we can read the state
 
     executor.shutdown()

--- a/ios/auto-mobile-sdk/Sources/AutoMobileSDK/AutoMobileSDK.swift
+++ b/ios/auto-mobile-sdk/Sources/AutoMobileSDK/AutoMobileSDK.swift
@@ -261,7 +261,7 @@ public final class AutoMobileSDK: @unchecked Sendable {
     }
 
     /// The event buffer (for subsystems that need direct access).
-    func getEventBuffer() -> SdkEventBuffer? {
+    internal func getEventBuffer() -> SdkEventBuffer? {
         lock.lock()
         defer { lock.unlock() }
         return eventBuffer


### PR DESCRIPTION
## Summary
- **iOS**: Change `getEventBuffer()` from `public` to `internal` -- it is an implementation detail used only by subsystems within the SDK module (e.g., `AutoMobileNotifications`), not by SDK consumers.
- **Android**: Convert Java-style getter functions to idiomatic Kotlin properties: `getListenerCount()` -> `listenerCount`, `isEnabled()` -> `isTrackingEnabled`, `getDropReport()` -> `dropReport`, `getContextSnapshot()` -> `contextSnapshot`.
- Update all tests and README documentation to use the new property syntax.
- Regenerate API surface file via `apiDump`.

## Test plan
- [x] `./gradlew -p android :auto-mobile-sdk:testDebugUnitTest` passes
- [x] `./gradlew -p android :auto-mobile-sdk:apiCheck` passes
- [x] `cd ios/auto-mobile-sdk && swift build` succeeds
- [x] `cd ios/auto-mobile-sdk && swift test` passes (151 tests, 0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)