### PR TITLE
refactor: demote event pipeline internals to internal visibility

### DIFF
--- a/android/auto-mobile-sdk/api/auto-mobile-sdk.api
+++ b/android/auto-mobile-sdk/api/auto-mobile-sdk.api
@@ -8,6 +8,7 @@ public final class dev.jasonpearson.automobile.sdk.AutoMobileConfiguration$Build
   public final dev.jasonpearson.automobile.sdk.AutoMobileConfiguration$Builder sessionTimeoutMs(long);
   public final dev.jasonpearson.automobile.sdk.AutoMobileConfiguration$Builder eventProcessors(java.util.List<? extends dev.jasonpearson.automobile.sdk.events.EventProcessor>);
   public final dev.jasonpearson.automobile.sdk.AutoMobileConfiguration$Builder maxPendingEvents(int);
+  public final dev.jasonpearson.automobile.sdk.AutoMobileConfiguration$Builder backPressureStrategy(dev.jasonpearson.automobile.sdk.events.BackPressureStrategy);
   public final dev.jasonpearson.automobile.sdk.AutoMobileConfiguration build();
 }
 Compiled from "AutoMobileConfiguration.kt"
@@ -23,22 +24,24 @@ public final class dev.jasonpearson.automobile.sdk.AutoMobileConfiguration {
   public static final int DEFAULT_MAX_BREADCRUMBS;
   public static final long DEFAULT_SESSION_TIMEOUT_MS;
   public static final int DEFAULT_MAX_PENDING_EVENTS;
-  public dev.jasonpearson.automobile.sdk.AutoMobileConfiguration(int, long, int, long, java.util.List<? extends dev.jasonpearson.automobile.sdk.events.EventProcessor>, int);
-  public dev.jasonpearson.automobile.sdk.AutoMobileConfiguration(int, long, int, long, java.util.List, int, int, kotlin.jvm.internal.DefaultConstructorMarker);
+  public dev.jasonpearson.automobile.sdk.AutoMobileConfiguration(int, long, int, long, java.util.List<? extends dev.jasonpearson.automobile.sdk.events.EventProcessor>, int, dev.jasonpearson.automobile.sdk.events.BackPressureStrategy);
+  public dev.jasonpearson.automobile.sdk.AutoMobileConfiguration(int, long, int, long, java.util.List, int, dev.jasonpearson.automobile.sdk.events.BackPressureStrategy, int, kotlin.jvm.internal.DefaultConstructorMarker);
   public final int getBufferSize();
   public final long getFlushIntervalMs();
   public final int getMaxBreadcrumbs();
   public final long getSessionTimeoutMs();
   public final java.util.List<dev.jasonpearson.automobile.sdk.events.EventProcessor> getEventProcessors();
   public final int getMaxPendingEvents();
+  public final dev.jasonpearson.automobile.sdk.events.BackPressureStrategy getBackPressureStrategy();
   public final int component1();
   public final long component2();
   public final int component3();
   public final long component4();
   public final java.util.List<dev.jasonpearson.automobile.sdk.events.EventProcessor> component5();
   public final int component6();
-  public final dev.jasonpearson.automobile.sdk.AutoMobileConfiguration copy$auto_mobile_sdk(int, long, int, long, java.util.List<? extends dev.jasonpearson.automobile.sdk.events.EventProcessor>, int);
-  public static dev.jasonpearson.automobile.sdk.AutoMobileConfiguration copy$auto_mobile_sdk$default(dev.jasonpearson.automobile.sdk.AutoMobileConfiguration, int, long, int, long, java.util.List, int, int, java.lang.Object);
+  public final dev.jasonpearson.automobile.sdk.events.BackPressureStrategy component7();
+  public final dev.jasonpearson.automobile.sdk.AutoMobileConfiguration copy$auto_mobile_sdk(int, long, int, long, java.util.List<? extends dev.jasonpearson.automobile.sdk.events.EventProcessor>, int, dev.jasonpearson.automobile.sdk.events.BackPressureStrategy);
+  public static dev.jasonpearson.automobile.sdk.AutoMobileConfiguration copy$auto_mobile_sdk$default(dev.jasonpearson.automobile.sdk.AutoMobileConfiguration, int, long, int, long, java.util.List, int, dev.jasonpearson.automobile.sdk.events.BackPressureStrategy, int, java.lang.Object);
   public java.lang.String toString();
   public int hashCode();
   public boolean equals(java.lang.Object);
@@ -103,8 +106,6 @@ public final class dev.jasonpearson.automobile.sdk.AutoMobileSDK {
   public final void setEnabled(boolean);
   public final boolean isEnabled();
   public final int getListenerCount();
-  public final void trackEvent(java.lang.String, java.util.Map<java.lang.String, java.lang.String>);
-  public static void trackEvent$default(dev.jasonpearson.automobile.sdk.AutoMobileSDK, java.lang.String, java.util.Map, int, java.lang.Object);
   public final java.lang.String currentSessionId();
   public final void addBreadcrumb(java.lang.String, dev.jasonpearson.automobile.sdk.breadcrumbs.BreadcrumbCategory, java.util.Map<java.lang.String, java.lang.String>);
   public static void addBreadcrumb$default(dev.jasonpearson.automobile.sdk.AutoMobileSDK, java.lang.String, dev.jasonpearson.automobile.sdk.breadcrumbs.BreadcrumbCategory, java.util.Map, int, java.lang.Object);
@@ -643,6 +644,14 @@ public final class dev.jasonpearson.automobile.sdk.database.TableStructureResult
   public int hashCode();
   public boolean equals(java.lang.Object);
 }
+Compiled from "BackPressureStrategy.kt"
+public final class dev.jasonpearson.automobile.sdk.events.BackPressureStrategy extends java.lang.Enum<dev.jasonpearson.automobile.sdk.events.BackPressureStrategy> {
+  public static final dev.jasonpearson.automobile.sdk.events.BackPressureStrategy DROP_OLDEST;
+  public static final dev.jasonpearson.automobile.sdk.events.BackPressureStrategy IGNORE_NEWEST;
+  public static dev.jasonpearson.automobile.sdk.events.BackPressureStrategy[] values();
+  public static dev.jasonpearson.automobile.sdk.events.BackPressureStrategy valueOf(java.lang.String);
+  public static kotlin.enums.EnumEntries<dev.jasonpearson.automobile.sdk.events.BackPressureStrategy> getEntries();
+}
 Compiled from "DropCounter.kt"
 public final class dev.jasonpearson.automobile.sdk.events.DefaultDropCounter implements dev.jasonpearson.automobile.sdk.events.DropCounter {
   public static final int $stable;
@@ -701,7 +710,6 @@ public final class dev.jasonpearson.automobile.sdk.events.RetryPolicy {
 Compiled from "SdkEventBroadcaster.kt"
 public final class dev.jasonpearson.automobile.sdk.events.SdkEventBroadcaster {
   public static final dev.jasonpearson.automobile.sdk.events.SdkEventBroadcaster INSTANCE;
-  public static final java.lang.String ACTION_SDK_EVENT_BATCH;
   public static final int MAX_BATCH_BYTES;
   public static final int $stable;
   public final dev.jasonpearson.automobile.sdk.events.RetryPolicy getRetryPolicy$auto_mobile_sdk();
@@ -716,10 +724,14 @@ public final class dev.jasonpearson.automobile.sdk.events.SdkEventBroadcaster {
   public static java.util.List splitIntoBatches$auto_mobile_sdk$default(dev.jasonpearson.automobile.sdk.events.SdkEventBroadcaster, java.util.List, java.lang.String, int, int, java.lang.Object);
 }
 Compiled from "SdkEventBuffer.kt"
+public final class dev.jasonpearson.automobile.sdk.events.SdkEventBuffer$WhenMappings {
+  public static final int[] $EnumSwitchMapping$0;
+}
+Compiled from "SdkEventBuffer.kt"
 public final class dev.jasonpearson.automobile.sdk.events.SdkEventBuffer {
   public static final int $stable;
-  public dev.jasonpearson.automobile.sdk.events.SdkEventBuffer(int, long, kotlin.jvm.functions.Function1<? super java.util.List<? extends dev.jasonpearson.automobile.protocol.SdkEvent>, kotlin.Unit>, dev.jasonpearson.automobile.sdk.persistence.EventPersistence, java.util.concurrent.ScheduledExecutorService, dev.jasonpearson.automobile.sdk.events.DropCounter, java.util.List<? extends dev.jasonpearson.automobile.sdk.events.EventProcessor>, int);
-  public dev.jasonpearson.automobile.sdk.events.SdkEventBuffer(int, long, kotlin.jvm.functions.Function1, dev.jasonpearson.automobile.sdk.persistence.EventPersistence, java.util.concurrent.ScheduledExecutorService, dev.jasonpearson.automobile.sdk.events.DropCounter, java.util.List, int, int, kotlin.jvm.internal.DefaultConstructorMarker);
+  public dev.jasonpearson.automobile.sdk.events.SdkEventBuffer(int, long, kotlin.jvm.functions.Function1<? super java.util.List<? extends dev.jasonpearson.automobile.protocol.SdkEvent>, kotlin.Unit>, dev.jasonpearson.automobile.sdk.persistence.EventPersistence, java.util.concurrent.ScheduledExecutorService, dev.jasonpearson.automobile.sdk.events.DropCounter, java.util.List<? extends dev.jasonpearson.automobile.sdk.events.EventProcessor>, int, dev.jasonpearson.automobile.sdk.events.BackPressureStrategy);
+  public dev.jasonpearson.automobile.sdk.events.SdkEventBuffer(int, long, kotlin.jvm.functions.Function1, dev.jasonpearson.automobile.sdk.persistence.EventPersistence, java.util.concurrent.ScheduledExecutorService, dev.jasonpearson.automobile.sdk.events.DropCounter, java.util.List, int, dev.jasonpearson.automobile.sdk.events.BackPressureStrategy, int, kotlin.jvm.internal.DefaultConstructorMarker);
   public final boolean isEnabled();
   public final void setEnabled(boolean);
   public final void start();
@@ -842,25 +854,20 @@ Compiled from "AutoMobileClickTracker.kt"
 public final class dev.jasonpearson.automobile.sdk.interaction.AutoMobileClickTracker {
   public static final dev.jasonpearson.automobile.sdk.interaction.AutoMobileClickTracker INSTANCE;
   public static final int $stable;
-  public final void initialize$auto_mobile_sdk(android.app.Application, java.lang.String, dev.jasonpearson.automobile.sdk.events.SdkEventBuffer);
+  public final void initialize$auto_mobile_sdk(android.app.Application, java.lang.String);
   public final void shutdown(android.content.Context);
   public static final java.util.WeakHashMap access$getWrappedActivities$p();
   public static final void access$wrapWindowCallback(dev.jasonpearson.automobile.sdk.interaction.AutoMobileClickTracker, android.app.Activity);
   public static final android.os.Handler access$getHandler$p();
-  public static final dev.jasonpearson.automobile.sdk.events.SdkEventBuffer access$getBuffer$p();
+  public static final boolean access$isInitialized$p();
   public static final long access$getLastTapProcessedAt$p();
   public static final void access$setLastTapProcessedAt$p(long);
-  public static final java.lang.String access$getApplicationId$p();
 }
 Compiled from "AutoMobileLog.kt"
 public final class dev.jasonpearson.automobile.sdk.logging.AutoMobileLog {
   public static final dev.jasonpearson.automobile.sdk.logging.AutoMobileLog INSTANCE;
   public static final int $stable;
-  public final void initialize$auto_mobile_sdk(java.lang.String, dev.jasonpearson.automobile.sdk.events.SdkEventBuffer);
-  public final void addFilter(java.lang.String, kotlin.text.Regex, kotlin.text.Regex, int);
-  public static void addFilter$default(dev.jasonpearson.automobile.sdk.logging.AutoMobileLog, java.lang.String, kotlin.text.Regex, kotlin.text.Regex, int, int, java.lang.Object);
-  public final void removeFilter(java.lang.String);
-  public final void clearFilters();
+  public final void initialize$auto_mobile_sdk();
   public final int v(java.lang.String, java.lang.String);
   public final int v(java.lang.String, java.lang.String, java.lang.Throwable);
   public final int d(java.lang.String, java.lang.String);
@@ -873,26 +880,6 @@ public final class dev.jasonpearson.automobile.sdk.logging.AutoMobileLog {
   public final int e(java.lang.String, java.lang.String, java.lang.Throwable);
   public final int wtf(java.lang.String, java.lang.String);
   public final int wtf(java.lang.String, java.lang.String, java.lang.Throwable);
-}
-Compiled from "CompiledLogFilter.kt"
-public final class dev.jasonpearson.automobile.sdk.logging.CompiledLogFilter {
-  public static final int $stable;
-  public dev.jasonpearson.automobile.sdk.logging.CompiledLogFilter(java.lang.String, kotlin.text.Regex, kotlin.text.Regex, int);
-  public dev.jasonpearson.automobile.sdk.logging.CompiledLogFilter(java.lang.String, kotlin.text.Regex, kotlin.text.Regex, int, int, kotlin.jvm.internal.DefaultConstructorMarker);
-  public final java.lang.String getName();
-  public final kotlin.text.Regex getTagPattern();
-  public final kotlin.text.Regex getMessagePattern();
-  public final int getMinLevel();
-  public final boolean matches(java.lang.String, java.lang.String, int);
-  public final java.lang.String component1();
-  public final kotlin.text.Regex component2();
-  public final kotlin.text.Regex component3();
-  public final int component4();
-  public final dev.jasonpearson.automobile.sdk.logging.CompiledLogFilter copy(java.lang.String, kotlin.text.Regex, kotlin.text.Regex, int);
-  public static dev.jasonpearson.automobile.sdk.logging.CompiledLogFilter copy$default(dev.jasonpearson.automobile.sdk.logging.CompiledLogFilter, java.lang.String, kotlin.text.Regex, kotlin.text.Regex, int, int, java.lang.Object);
-  public java.lang.String toString();
-  public int hashCode();
-  public boolean equals(java.lang.Object);
 }
 Compiled from "SdkLogger.kt"
 public final class dev.jasonpearson.automobile.sdk.logging.DefaultSdkLogger implements dev.jasonpearson.automobile.sdk.logging.SdkLogger {
@@ -1077,6 +1064,35 @@ public final class dev.jasonpearson.automobile.sdk.network.NetworkMockRuleStore 
   public static final dev.jasonpearson.automobile.sdk.network.NetworkMockRuleStore access$getInstance$cp();
   public static final void access$setInstance$cp(dev.jasonpearson.automobile.sdk.network.NetworkMockRuleStore);
   public static final kotlinx.serialization.json.Json access$getJson$p(dev.jasonpearson.automobile.sdk.network.NetworkMockRuleStore);
+}
+Compiled from "NoOpDropCounter.kt"
+public final class dev.jasonpearson.automobile.sdk.noop.NoOpDropCounter implements dev.jasonpearson.automobile.sdk.events.DropCounter {
+  public static final dev.jasonpearson.automobile.sdk.noop.NoOpDropCounter INSTANCE;
+  public static final int $stable;
+  public void increment(dev.jasonpearson.automobile.sdk.events.DropReason, int);
+  public java.util.Map<dev.jasonpearson.automobile.sdk.events.DropReason, java.lang.Long> snapshot();
+  public void reset();
+}
+Compiled from "NoOpEventPersistence.kt"
+public final class dev.jasonpearson.automobile.sdk.noop.NoOpEventPersistence implements dev.jasonpearson.automobile.sdk.persistence.EventPersistence {
+  public static final dev.jasonpearson.automobile.sdk.noop.NoOpEventPersistence INSTANCE;
+  public static final int $stable;
+  public java.lang.String persist(java.util.List<? extends dev.jasonpearson.automobile.protocol.SdkEvent>);
+  public java.util.List<kotlin.Pair<java.lang.String, java.util.List<dev.jasonpearson.automobile.protocol.SdkEvent>>> loadPending();
+  public void removeBatch(java.lang.String);
+  public void cleanup(int);
+}
+Compiled from "NoOpEventProcessor.kt"
+public final class dev.jasonpearson.automobile.sdk.noop.NoOpEventProcessor implements dev.jasonpearson.automobile.sdk.events.EventProcessor {
+  public static final dev.jasonpearson.automobile.sdk.noop.NoOpEventProcessor INSTANCE;
+  public static final int $stable;
+  public dev.jasonpearson.automobile.protocol.SdkEvent process(dev.jasonpearson.automobile.protocol.SdkEvent);
+}
+Compiled from "NoOpNavigationListener.kt"
+public final class dev.jasonpearson.automobile.sdk.noop.NoOpNavigationListener implements dev.jasonpearson.automobile.sdk.NavigationListener {
+  public static final dev.jasonpearson.automobile.sdk.noop.NoOpNavigationListener INSTANCE;
+  public static final int $stable;
+  public void onNavigationEvent(dev.jasonpearson.automobile.sdk.NavigationEvent);
 }
 Compiled from "AutoMobileBroadcastInterceptor.kt"
 public final class dev.jasonpearson.automobile.sdk.os.AutoMobileBroadcastInterceptor$initialize$broadcastReceiver$1 extends android.content.BroadcastReceiver {

--- a/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/events/RetryPolicy.kt
+++ b/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/events/RetryPolicy.kt
@@ -7,7 +7,7 @@ package dev.jasonpearson.automobile.sdk.events
  * @param baseDelayMs Base delay in milliseconds before first retry (default 100)
  * @param maxDelayMs Upper bound on computed delay (default 2000)
  */
-data class RetryPolicy(
+internal data class RetryPolicy(
   val maxRetries: Int = 3,
   val baseDelayMs: Long = 100,
   val maxDelayMs: Long = 2000,

--- a/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/events/SdkEventBroadcaster.kt
+++ b/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/events/SdkEventBroadcaster.kt
@@ -16,10 +16,9 @@ import dev.jasonpearson.automobile.sdk.SdkConstants
  * Caps batch JSON at [MAX_BATCH_BYTES] and splits if exceeded to respect
  * the Android Intent size limit (~1MB).
  */
-object SdkEventBroadcaster {
+internal object SdkEventBroadcaster {
 
-  const val ACTION_SDK_EVENT_BATCH = "dev.jasonpearson.automobile.sdk.EVENT_BATCH"
-  internal const val MAX_BATCH_BYTES = 100_000 // 100KB per Intent — lower to avoid TransactionTooLargeException
+  const val MAX_BATCH_BYTES = 100_000 // 100KB per Intent — lower to avoid TransactionTooLargeException
 
   internal var retryPolicy: RetryPolicy = RetryPolicy()
   internal var retryHandler: Handler = Handler(Looper.getMainLooper())
@@ -95,7 +94,7 @@ object SdkEventBroadcaster {
 
   private fun sendBatchIntent(context: Context, batchJson: String, eventCount: Int = 1, attempt: Int = 0) {
     try {
-      val intent = Intent(ACTION_SDK_EVENT_BATCH).apply {
+      val intent = Intent(SdkEventSerializer.ACTION_SDK_EVENT_BATCH).apply {
         putExtra(SdkEventSerializer.EXTRA_SDK_EVENT_JSON, batchJson)
         putExtra(SdkEventSerializer.EXTRA_SDK_EVENT_TYPE, SdkEventSerializer.EventTypes.EVENT_BATCH)
         setPackage(SdkConstants.CTRL_PROXY_PACKAGE)

--- a/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/CtrlProxy.kt
+++ b/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/CtrlProxy.kt
@@ -74,7 +74,6 @@ import dev.jasonpearson.automobile.protocol.WebSocketFrameData
 import dev.jasonpearson.automobile.protocol.WebSocketFrameResponse
 import dev.jasonpearson.automobile.sdk.AutoMobileSDK
 import dev.jasonpearson.automobile.sdk.anr.AutoMobileAnr
-import dev.jasonpearson.automobile.sdk.events.SdkEventBroadcaster
 import dev.jasonpearson.automobile.sdk.crashes.AutoMobileCrashes
 import dev.jasonpearson.automobile.sdk.failures.AutoMobileFailures
 import java.io.ByteArrayOutputStream
@@ -546,7 +545,7 @@ class CtrlProxy : AccessibilityService() {
   private val eventBatchReceiver =
       object : BroadcastReceiver() {
         override fun onReceive(context: Context?, intent: Intent?) {
-          if (intent == null || intent.action != SdkEventBroadcaster.ACTION_SDK_EVENT_BATCH) {
+          if (intent == null || intent.action != SdkEventSerializer.ACTION_SDK_EVENT_BATCH) {
             return
           }
 
@@ -672,7 +671,7 @@ class CtrlProxy : AccessibilityService() {
 
       // Register broadcast receiver for SDK event batches
       val eventBatchFilter =
-          IntentFilter().apply { addAction(SdkEventBroadcaster.ACTION_SDK_EVENT_BATCH) }
+          IntentFilter().apply { addAction(SdkEventSerializer.ACTION_SDK_EVENT_BATCH) }
 
       if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
         registerReceiver(eventBatchReceiver, eventBatchFilter, RECEIVER_EXPORTED)

--- a/android/protocol/src/main/kotlin/dev/jasonpearson/automobile/protocol/SdkEventSerializer.kt
+++ b/android/protocol/src/main/kotlin/dev/jasonpearson/automobile/protocol/SdkEventSerializer.kt
@@ -32,6 +32,9 @@ import kotlinx.serialization.json.Json
  * ```
  */
 object SdkEventSerializer {
+  /** Intent action for SDK event batch broadcasts. */
+  const val ACTION_SDK_EVENT_BATCH = "dev.jasonpearson.automobile.sdk.EVENT_BATCH"
+
   /**
    * Intent extra key for the serialized event JSON.
    * Uses a namespaced key to avoid collisions with other Intent extras.

--- a/ios/auto-mobile-sdk/Sources/AutoMobileSDK/AutoMobileSDK.swift
+++ b/ios/auto-mobile-sdk/Sources/AutoMobileSDK/AutoMobileSDK.swift
@@ -261,7 +261,7 @@ public final class AutoMobileSDK: @unchecked Sendable {
     }
 
     /// The event buffer (for subsystems that need direct access).
-    public func getEventBuffer() -> SdkEventBuffer? {
+    func getEventBuffer() -> SdkEventBuffer? {
         lock.lock()
         defer { lock.unlock() }
         return eventBuffer

--- a/ios/auto-mobile-sdk/Sources/AutoMobileSDK/Events/SdkEventBroadcaster.swift
+++ b/ios/auto-mobile-sdk/Sources/AutoMobileSDK/Events/SdkEventBroadcaster.swift
@@ -1,22 +1,22 @@
 import Foundation
 
 /// Protocol for event broadcasting to allow faking in tests.
-public protocol EventBroadcasting: Sendable {
+protocol EventBroadcasting: Sendable {
     func broadcastBatch(bundleId: String?, events: [any SdkEvent])
 }
 
 /// Broadcasts SDK event batches via NotificationCenter for in-process communication
 /// and HTTP POST to CtrlProxy for cross-process telemetry forwarding.
 /// Supports disk-first persistence and retry with exponential backoff.
-public final class SdkEventBroadcaster: EventBroadcasting, @unchecked Sendable {
+final class SdkEventBroadcaster: EventBroadcasting, @unchecked Sendable {
 
-    public static let eventBatchNotification = Notification.Name(
+    static let eventBatchNotification = Notification.Name(
         "dev.jasonpearson.automobile.sdk.EVENT_BATCH"
     )
 
-    public static let eventBatchUserInfoKey = "eventBatch"
+    static let eventBatchUserInfoKey = "eventBatch"
 
-    public static let shared = SdkEventBroadcaster()
+    static let shared = SdkEventBroadcaster()
 
     /// CtrlProxy HTTP endpoint for SDK event forwarding.
     /// Set by the SDK during initialization if CtrlProxy is detected.
@@ -24,10 +24,10 @@ public final class SdkEventBroadcaster: EventBroadcasting, @unchecked Sendable {
     private let urlSession: URLSession
 
     /// Disk-first event persistence for reliable delivery.
-    public var persistence: (any EventPersisting)?
+    var persistence: (any EventPersisting)?
 
     /// Retry policy for failed HTTP delivery.
-    public var retryPolicy: RetryPolicy = RetryPolicy()
+    var retryPolicy: RetryPolicy = RetryPolicy()
 
     private init() {
         let config = URLSessionConfiguration.default
@@ -46,13 +46,13 @@ public final class SdkEventBroadcaster: EventBroadcasting, @unchecked Sendable {
 
     /// Configure the CtrlProxy endpoint URL. Pass nil to disable HTTP forwarding.
     /// No-op in release builds.
-    public func setCtrlProxyUrl(_ url: URL?) {
+    func setCtrlProxyUrl(_ url: URL?) {
         #if DEBUG
         self.ctrlProxyUrl = url
         #endif
     }
 
-    public func broadcastBatch(bundleId: String?, events: [any SdkEvent]) {
+    func broadcastBatch(bundleId: String?, events: [any SdkEvent]) {
         guard !events.isEmpty else { return }
         InternalLogger.debug("broadcastBatch called with \(events.count) events, ctrlProxyUrl=\(ctrlProxyUrl?.absoluteString ?? "nil")")
 
@@ -63,7 +63,7 @@ public final class SdkEventBroadcaster: EventBroadcasting, @unchecked Sendable {
     }
 
     /// Replay pending persisted batches (e.g., on startup after a crash).
-    public func replayPending(bundleId: String?) {
+    func replayPending(bundleId: String?) {
         guard let persistence = persistence else { return }
         for (batchId, events) in persistence.loadPending() {
             deliverBatch(bundleId: bundleId, events: events, batchId: batchId)

--- a/ios/auto-mobile-sdk/Sources/AutoMobileSDK/Events/SdkEventBuffer.swift
+++ b/ios/auto-mobile-sdk/Sources/AutoMobileSDK/Events/SdkEventBuffer.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 /// Protocol for event buffering to allow faking in tests.
-public protocol EventBuffering: AnyObject, Sendable {
+protocol EventBuffering: AnyObject, Sendable {
     var isBufferEnabled: Bool { get set }
     func add(_ event: any SdkEvent)
     func start()
@@ -11,7 +11,7 @@ public protocol EventBuffering: AnyObject, Sendable {
 }
 
 /// Thread-safe event buffer that flushes on capacity or timer.
-public final class SdkEventBuffer: EventBuffering, @unchecked Sendable {
+final class SdkEventBuffer: EventBuffering, @unchecked Sendable {
     private let maxBufferSize: Int
     private let maxPendingEvents: Int
     private let flushIntervalMs: Int
@@ -24,7 +24,7 @@ public final class SdkEventBuffer: EventBuffering, @unchecked Sendable {
     private let dropCounter: (any DropCounting)?
     private let processors: [any EventProcessing]
 
-    public init(
+    init(
         maxBufferSize: Int = 50,
         flushIntervalMs: Int = 500,
         maxPendingEvents: Int = 500,
@@ -42,7 +42,7 @@ public final class SdkEventBuffer: EventBuffering, @unchecked Sendable {
         self.onFlush = onFlush
     }
 
-    public var isBufferEnabled: Bool {
+    var isBufferEnabled: Bool {
         get {
             lock.lock()
             defer { lock.unlock() }
@@ -55,7 +55,7 @@ public final class SdkEventBuffer: EventBuffering, @unchecked Sendable {
         }
     }
 
-    public func start() {
+    func start() {
         lock.lock()
         defer { lock.unlock() }
         guard timer == nil else { return }
@@ -67,14 +67,14 @@ public final class SdkEventBuffer: EventBuffering, @unchecked Sendable {
     }
 
     /// Stop the periodic flush timer without flushing remaining events.
-    public func stop() {
+    func stop() {
         lock.lock()
         defer { lock.unlock() }
         timer?.cancel()
         timer = nil
     }
 
-    public func add(_ event: any SdkEvent) {
+    func add(_ event: any SdkEvent) {
         // Check disabled state first, before running processors
         lock.lock()
         guard _isBufferEnabled else {
@@ -118,7 +118,7 @@ public final class SdkEventBuffer: EventBuffering, @unchecked Sendable {
         }
     }
 
-    public func flush() {
+    func flush() {
         lock.lock()
         guard !buffer.isEmpty else {
             lock.unlock()
@@ -134,7 +134,7 @@ public final class SdkEventBuffer: EventBuffering, @unchecked Sendable {
         }
     }
 
-    public func shutdown() {
+    func shutdown() {
         lock.lock()
         timer?.cancel()
         timer = nil
@@ -154,19 +154,19 @@ public final class SdkEventBuffer: EventBuffering, @unchecked Sendable {
 // MARK: - Timer Abstraction
 
 /// Protocol for timer scheduling to allow faking in tests.
-public protocol TimerScheduling: AnyObject, Sendable {
+protocol TimerScheduling: AnyObject, Sendable {
     func schedule(intervalMs: Int, block: @escaping @Sendable () -> Void)
     func cancel()
 }
 
 /// GCD-based timer implementation.
-public final class GCDTimer: TimerScheduling, @unchecked Sendable {
+final class GCDTimer: TimerScheduling, @unchecked Sendable {
     private var source: DispatchSourceTimer?
     private let queue = DispatchQueue(label: "dev.jasonpearson.automobile.sdk.timer")
 
-    public init() {}
+    init() {}
 
-    public func schedule(intervalMs: Int, block: @escaping @Sendable () -> Void) {
+    func schedule(intervalMs: Int, block: @escaping @Sendable () -> Void) {
         let source = DispatchSource.makeTimerSource(queue: queue)
         source.schedule(
             deadline: .now() + .milliseconds(intervalMs),
@@ -177,7 +177,7 @@ public final class GCDTimer: TimerScheduling, @unchecked Sendable {
         self.source = source
     }
 
-    public func cancel() {
+    func cancel() {
         source?.cancel()
         source = nil
     }

--- a/ios/auto-mobile-sdk/Sources/AutoMobileSDK/Session/SessionTracker.swift
+++ b/ios/auto-mobile-sdk/Sources/AutoMobileSDK/Session/SessionTracker.swift
@@ -21,10 +21,17 @@ public final class SessionTracker: SessionTracking, @unchecked Sendable {
     private var state: State = .ended
     private var timeoutTimer: (any TimerScheduling)?
 
-    public init(
+    public convenience init(
         timeoutMs: Int = 30_000,
-        uuidProvider: @escaping () -> String = { UUID().uuidString },
-        timerFactory: @escaping () -> any TimerScheduling = { GCDTimer() }
+        uuidProvider: @escaping () -> String = { UUID().uuidString }
+    ) {
+        self.init(timeoutMs: timeoutMs, uuidProvider: uuidProvider, timerFactory: { GCDTimer() })
+    }
+
+    init(
+        timeoutMs: Int,
+        uuidProvider: @escaping () -> String,
+        timerFactory: @escaping () -> any TimerScheduling
     ) {
         self.timeoutMs = timeoutMs
         self.uuidProvider = uuidProvider

--- a/ios/auto-mobile-sdk/Sources/AutoMobileSDK/ViewBody/ViewBodyTracker.swift
+++ b/ios/auto-mobile-sdk/Sources/AutoMobileSDK/ViewBody/ViewBodyTracker.swift
@@ -31,7 +31,12 @@ public final class ViewBodyTracker: @unchecked Sendable {
     }
 
     /// Enable or disable tracking.
-    public func setEnabled(_ enabled: Bool, timerFactory: (() -> any TimerScheduling)? = nil) {
+    public func setEnabled(_ enabled: Bool) {
+        setEnabled(enabled, timerFactory: nil)
+    }
+
+    /// Enable or disable tracking (internal overload for timer injection in tests).
+    func setEnabled(_ enabled: Bool, timerFactory: (() -> any TimerScheduling)?) {
         lock.lock()
         _isEnabled = enabled
 


### PR DESCRIPTION
## Summary
- Change `SdkEventBuffer` and `SdkEventBroadcaster` to `internal` on both platforms
- Move `ACTION_SDK_EVENT_BATCH` constant to protocol module for cross-module access
- Fix leaked internal types through public APIs with convenience wrappers

## Test plan
- [x] iOS builds and all tests pass
- [x] Android `apiCheck` passes
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)