### PR TITLE
fix(ci): detect iOS Simulator runtime before building Xcode projects

### DIFF
--- a/scripts/ios/ctrl-proxy-build-for-testing.sh
+++ b/scripts/ios/ctrl-proxy-build-for-testing.sh
@@ -62,6 +62,23 @@ echo -e "${BLUE}Xcode version:${NC} ${XCODE_VERSION}"
 echo -e "${BLUE}Derived data:${NC} ${DERIVED_DATA}"
 echo ""
 
+# Ensure iOS Simulator platform is available (Xcode 26+ requires separate download)
+has_simulator_platform() {
+    xcodebuild -showsdks 2>/dev/null | grep -q "iphonesimulator" \
+        && xcrun simctl list runtimes 2>/dev/null | grep -qiE "^iOS "
+}
+
+if ! has_simulator_platform; then
+    echo -e "${YELLOW}No iOS Simulator platform detected. Attempting to install...${NC}"
+    xcodebuild -downloadPlatform iOS 2>&1 || true
+
+    if ! has_simulator_platform; then
+        echo -e "${RED}iOS Simulator platform still missing after download attempt.${NC}"
+        echo -e "${YELLOW}Install the iOS platform in Xcode > Settings > Components.${NC}"
+        exit 1
+    fi
+fi
+
 # Generate Xcode project if needed (xcodeproj is committed to git, so this is
 # only triggered in local dev when the project file is missing)
 if [ ! -d "${XCODEPROJ}" ]; then

--- a/scripts/ios/xcode-build.sh
+++ b/scripts/ios/xcode-build.sh
@@ -70,7 +70,11 @@ has_simulator_sdk() {
         echo -e "${YELLOW}(dry-run) Skipping simulator SDK detection.${NC}"
         return 0
     fi
-    xcodebuild -showsdks 2>/dev/null | grep -q "iphonesimulator"
+    # Check both that the SDK is listed AND that simulator runtimes are available.
+    # On Xcode 26+, the iOS platform may need a separate download even if SDK
+    # headers appear in -showsdks.
+    xcodebuild -showsdks 2>/dev/null | grep -q "iphonesimulator" \
+        && xcrun simctl list runtimes 2>/dev/null | grep -qiE "^iOS "
 }
 
 # Check if xcodebuild is available


### PR DESCRIPTION
## Summary
- Fixes iOS Xcode build failures on CI runners with Xcode 26.0.1 where the iOS Simulator platform is not pre-installed
- Both `xcode-build.sh` and `ctrl-proxy-build-for-testing.sh` now verify that `simctl` lists an iOS runtime (not just that the SDK appears in `-showsdks`) before attempting to build
- If the platform is missing, `ctrl-proxy-build-for-testing.sh` attempts `xcodebuild -downloadPlatform iOS` before failing

## Test plan
- [ ] Verify CI passes on Xcode 26.0.1 runners (should either auto-download the platform or fail early with clear message)
- [ ] Verify local builds still work on machines with iOS Simulator installed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <svc-devxp-claude@slack-corp.com>