### PR TITLE
fix(ci): align Xcode 26 builds with runner runtimes and re-enable coverage badge

### DIFF
--- a/.github/actions/ensure-ios-simulator-runtime/action.yml
+++ b/.github/actions/ensure-ios-simulator-runtime/action.yml
@@ -9,15 +9,15 @@ runs:
       shell: bash
       run: |
         sdk_version=$(xcrun --sdk iphonesimulator --show-sdk-version)
-        major_version="${sdk_version%%.*}"
-        echo "Xcode SDK version: ${sdk_version} (need iOS ${major_version}.x runtime)"
-        echo "major_version=${major_version}" >> "$GITHUB_OUTPUT"
+        major_minor=$(echo "${sdk_version}" | cut -d. -f1,2)
+        echo "Xcode SDK version: ${sdk_version} (need iOS ${major_minor}.x runtime)"
+        echo "major_minor=${major_minor}" >> "$GITHUB_OUTPUT"
 
         match_count=$(xcrun simctl list runtimes iOS --json \
-          | jq --arg v "${major_version}" '[.runtimes[] | select(.version | startswith($v + "."))] | length')
-        echo "Found ${match_count} iOS ${major_version}.x simulator runtime(s)"
+          | jq --arg v "${major_minor}" '[.runtimes[] | select(.version | startswith($v))] | length')
+        echo "Found ${match_count} iOS ${major_minor}.x simulator runtime(s)"
         if [ "${match_count}" -eq 0 ]; then
-          echo "::warning::No iOS ${major_version}.x simulator runtime found — downloading platform"
+          echo "::warning::No iOS ${major_minor}.x simulator runtime found — downloading platform"
           echo "needs_download=true" >> "$GITHUB_OUTPUT"
         fi
 
@@ -30,11 +30,11 @@ runs:
       if: steps.check.outputs.needs_download == 'true'
       shell: bash
       run: |
-        major_version="${{ steps.check.outputs.major_version }}"
+        major_minor="${{ steps.check.outputs.major_minor }}"
         match_count=$(xcrun simctl list runtimes iOS --json \
-          | jq --arg v "${major_version}" '[.runtimes[] | select(.version | startswith($v + "."))] | length')
-        echo "Found ${match_count} iOS ${major_version}.x simulator runtime(s) after download"
+          | jq --arg v "${major_minor}" '[.runtimes[] | select(.version | startswith($v))] | length')
+        echo "Found ${match_count} iOS ${major_minor}.x simulator runtime(s) after download"
         if [ "${match_count}" -eq 0 ]; then
-          echo "::error::Still no iOS ${major_version}.x simulator runtime after download"
+          echo "::error::Still no iOS ${major_minor}.x simulator runtime after download"
           exit 1
         fi

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -616,8 +616,6 @@ jobs:
 
   ios-xcode-build:
     name: "Build Xcode Projects (${{ matrix.config.name }})"
-    # Disabled with iOS merge cleanup.
-    if: ${{ false }}
     runs-on: ${{ matrix.config.runner }}
     needs: ios-xcodegen
     strategy:
@@ -625,7 +623,7 @@ jobs:
       matrix:
         config:
           - { name: "Xcode 15", runner: "macos-14", xcode: "15.4" }
-          - { name: "Xcode 26", runner: "macos-26", xcode: "26.0" }
+          - { name: "Xcode 26", runner: "macos-26", xcode: "26.3" }
     steps:
       - name: "Git Checkout"
         uses: actions/checkout@v6
@@ -1017,8 +1015,6 @@ jobs:
 
   ts-code-coverage:
     name: "TypeScript Code Coverage"
-    # Disabled: the badge generation step is currently failing because coverage/lcov.info is missing.
-    if: ${{ false }}
     runs-on: ubuntu-latest
     steps:
       - name: "Git Checkout"
@@ -1026,24 +1022,19 @@ jobs:
         with:
           lfs: false
 
-      - name: "Cache Turborepo"
-        uses: actions/cache@v4
-        with:
-          path: .turbo
-          key: turbo-ubuntu-latest-${{ hashFiles('bun.lock') }}-${{ github.sha }}
-          restore-keys: |
-            turbo-ubuntu-latest-${{ hashFiles('bun.lock') }}-
-            turbo-ubuntu-latest-
-
       - uses: ./.github/actions/setup-auto-mobile-npm-package
 
       - name: "Run Tests with Coverage"
-        env:
-          TURBO_TELEMETRY_DISABLED: "1"
-          TURBO_NO_UPDATE_NOTIFIER: "1"
-          DO_NOT_TRACK: "1"
-          NO_COLOR: "1"
-        run: turbo run test:coverage --output-logs=errors-only
+        run: bun test --coverage --coverage-reporter=lcov --coverage-dir=coverage
+
+      - name: "Verify Coverage Output"
+        run: |
+          if [ ! -f coverage/lcov.info ]; then
+            echo "::error::coverage/lcov.info not found"
+            ls -la coverage/ 2>/dev/null || echo "coverage/ directory does not exist"
+            exit 1
+          fi
+          echo "Coverage file size: $(wc -c < coverage/lcov.info) bytes"
 
       - name: "Generate Coverage Badge"
         run: bash scripts/coverage/generate-badge.sh coverage/lcov.info coverage/ts-coverage-badge.json "TS coverage" "3178C6"

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -902,24 +902,19 @@ jobs:
         with:
           lfs: false
 
-      - name: "Cache Turborepo"
-        uses: actions/cache@v4
-        with:
-          path: .turbo
-          key: turbo-ubuntu-latest-${{ hashFiles('bun.lock') }}-${{ github.sha }}
-          restore-keys: |
-            turbo-ubuntu-latest-${{ hashFiles('bun.lock') }}-
-            turbo-ubuntu-latest-
-
       - uses: ./.github/actions/setup-auto-mobile-npm-package
 
       - name: "Run Tests with Coverage"
-        env:
-          TURBO_TELEMETRY_DISABLED: "1"
-          TURBO_NO_UPDATE_NOTIFIER: "1"
-          DO_NOT_TRACK: "1"
-          NO_COLOR: "1"
-        run: turbo run test:coverage --output-logs=errors-only
+        run: bun test --coverage --coverage-reporter=lcov --coverage-dir=coverage
+
+      - name: "Verify Coverage Output"
+        run: |
+          if [ ! -f coverage/lcov.info ]; then
+            echo "::error::coverage/lcov.info not found"
+            ls -la coverage/ 2>/dev/null || echo "coverage/ directory does not exist"
+            exit 1
+          fi
+          echo "Coverage file size: $(wc -c < coverage/lcov.info) bytes"
 
       - name: "Upload Coverage"
         uses: actions/upload-artifact@v6
@@ -1103,7 +1098,6 @@ jobs:
       matrix:
         config:
           - { name: "Xcode 15", runner: "macos-14", xcode: "15.4" }
-          - { name: "Xcode 26", runner: "macos-26", xcode: "26.0" }
           - { name: "Xcode 26.3", runner: "macos-26", xcode: "26.3" }
     steps:
       - name: "Git Checkout"
@@ -1133,10 +1127,13 @@ jobs:
         with:
           lfs: false
 
-      - name: "Select Xcode 26.0"
+      - name: "Select Xcode 26.3"
         uses: maxim-lobanov/setup-xcode@v1
         with:
-          xcode-version: "26.0"
+          xcode-version: "26.3"
+
+      - name: "Ensure iOS Simulator runtime"
+        uses: ./.github/actions/ensure-ios-simulator-runtime
 
       - name: "Install xcpretty"
         run: gem install xcpretty


### PR DESCRIPTION
## Summary
- **Xcode 26 build failures**: Removed Xcode 26.0 from the build matrix since macos-26 runners only have iOS 26.3 simulator runtimes installed. Xcode 26.0 can't find matching destinations, while 26.3 works. Also added `ensure-ios-simulator-runtime` step to ctrl-proxy build and improved the action's version matching (major.minor instead of major-only).
- **Coverage badge generation**: Re-enabled `ts-code-coverage` in both workflows. Replaced `turbo run test:coverage` with direct `bun test --coverage --coverage-reporter=lcov` to ensure `coverage/lcov.info` materializes on disk (turbo caching was preventing this). Added a verification step.
- Re-enabled the disabled `ios-xcode-build` job in the merge workflow.

## Test plan
- [ ] Verify "Build Xcode Projects (Xcode 26.3)" passes in CI (was failing as "Xcode 26" with 26.0)
- [ ] Verify "Build CtrlProxy iOS for Testing" passes with Xcode 26.3
- [ ] Verify "TypeScript Code Coverage" job passes and produces a badge artifact
- [ ] Verify "Build Xcode Projects (Xcode 15)" still passes (unchanged)
- [ ] Confirm local `turbo run lint build test` passes (3414 tests, 0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)