### PR TITLE
restoring isDismissKeyboardAfterInputEnabled

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -46,6 +46,7 @@ function parseArgs(): {
   daemonCommand?: string;
   daemonArgs: string[];
   skipCtrlProxyDownload: boolean;
+  dismissKeyboardAfterInput: boolean;
   mcpRecording: boolean;
   noProxy: boolean;
   noDaemon: boolean;
@@ -101,8 +102,8 @@ function parseArgs(): {
   const rawElementSearch = args.includes("--raw-element-search");
   const skipCtrlProxyDownload = args.includes("--skip-ctrl-proxy-download") || args.includes("--skip-accessibility-download");
   const networkMockable = args.includes("--network-mockable");
-  const mcpRecording = args.includes("--mcp-recording");
   const dismissKeyboardAfterInput = args.includes("--dismiss-keyboard-after-input");
+  const mcpRecording = args.includes("--mcp-recording");
   let planExecutionLockScope: PlanExecutionLockScope = "session";
   const videoRecordingDefaults: VideoRecordingConfigInput = {};
 
@@ -294,8 +295,8 @@ function parseArgs(): {
     daemonArgs,
     skipCtrlProxyDownload,
     networkMockable,
-    mcpRecording,
     dismissKeyboardAfterInput,
+    mcpRecording,
     noProxy,
     noDaemon,
   };
@@ -364,8 +365,8 @@ async function main() {
       daemonArgs,
       skipCtrlProxyDownload,
       networkMockable,
-      mcpRecording,
       dismissKeyboardAfterInput,
+      mcpRecording,
       noProxy,
       noDaemon,
     } = parseArgs();


### PR DESCRIPTION
PR #1660 (MCP recording) and #1659 (dismissKeyboard) both branched from the same base of `ServerConfig.ts` and `index.ts`. When #1660 merged second, it clobbered the dismiss-keyboard additions from #1659. The `interactionTools.ts` call to `serverConfig.isDismissKeyboardAfterInputEnabled()` survived, but the backing field/methods in `ServerConfig` and the `--dismiss-keyboard-after-input` CLI wiring in `index.ts` were lost, causing every `inputText` call to throw `TypeError: isDismissKeyboardAfterInputEnabled is not a function`.

Restores the missing pieces in `ServerConfig.ts` (field + getter/setter) and `index.ts` (CLI flag parsing + config wiring).
