### PR TITLE
fix: prevent duplicate telemetry events during subscriber backfill

### DIFF
--- a/src/daemon/socketServer/PushSubscriptionSocketServer.ts
+++ b/src/daemon/socketServer/PushSubscriptionSocketServer.ts
@@ -191,6 +191,7 @@ export abstract class PushSubscriptionSocketServer<TFilter, TPushData> extends B
       subscriptionId,
       lastActivity: this.timer.now(),
       filter,
+      backfilling: false,
     });
 
     const response: SubscriptionResponse = {
@@ -208,7 +209,7 @@ export abstract class PushSubscriptionSocketServer<TFilter, TPushData> extends B
   /**
    * Called after a new subscriber is added. Override to send backfill data.
    */
-  protected onSubscribed(_subscriptionId: string, _filter: F, _socket: Socket): void {
+  protected onSubscribed(_subscriptionId: string, _filter: TFilter, _socket: Socket): void {
     // Default: no-op
   }
 
@@ -283,6 +284,10 @@ export abstract class PushSubscriptionSocketServer<TFilter, TPushData> extends B
     const deadSubscribers: string[] = [];
 
     for (const [subscriptionId, subscriber] of this.subscribers) {
+      if (subscriber.backfilling) {
+        continue;
+      }
+
       if (!this.matchesFilter(subscriber.filter, data)) {
         continue;
       }

--- a/src/daemon/socketServer/SocketServerTypes.ts
+++ b/src/daemon/socketServer/SocketServerTypes.ts
@@ -36,6 +36,8 @@ export interface Subscriber<TFilter = unknown> {
   subscriptionId: string;
   lastActivity: number;
   filter: TFilter;
+  /** When true, this subscriber is receiving backfill data and should be skipped by live pushes. */
+  backfilling: boolean;
 }
 
 /**

--- a/src/daemon/telemetryPushSocketServer.ts
+++ b/src/daemon/telemetryPushSocketServer.ts
@@ -70,10 +70,19 @@ export class TelemetryPushSocketServer extends PushSubscriptionSocketServer<
     return true;
   }
 
-  protected override onSubscribed(_subscriptionId: string, filter: TelemetryFilter, socket: Socket): void {
+  protected override onSubscribed(subscriptionId: string, filter: TelemetryFilter, socket: Socket): void {
+    const subscriber = this.subscribers.get(subscriptionId);
+    if (subscriber) {
+      subscriber.backfilling = true;
+    }
     this.backfillRecentEvents(filter, socket).catch(err =>
       logger.warn(`[TelemetryPush] Backfill failed: ${err}`)
-    );
+    ).finally(() => {
+      const sub = this.subscribers.get(subscriptionId);
+      if (sub) {
+        sub.backfilling = false;
+      }
+    });
   }
 
   private async backfillRecentEvents(filter: TelemetryFilter, socket: Socket): Promise<void> {

--- a/test/daemon/deviceDataStreamSocketServer.test.ts
+++ b/test/daemon/deviceDataStreamSocketServer.test.ts
@@ -39,6 +39,7 @@ class TestableDeviceDataStreamSocketServer extends DeviceDataStreamSocketServer 
       filter: {
         deviceId: options.deviceId ?? null,
       },
+      backfilling: false,
     });
     return { socket, subscriptionId };
   }

--- a/test/daemon/performancePushSocketServer.test.ts
+++ b/test/daemon/performancePushSocketServer.test.ts
@@ -56,6 +56,7 @@ class TestablePerformancePushSocketServer extends PerformancePushSocketServer {
         deviceId: options.deviceId ?? null,
         packageName: options.packageName ?? null,
       },
+      backfilling: false,
     });
 
     return { socket, subscriptionId };

--- a/test/daemon/socketServer/PushSubscriptionSocketServer.test.ts
+++ b/test/daemon/socketServer/PushSubscriptionSocketServer.test.ts
@@ -61,6 +61,7 @@ class TestablePushSubscriptionServer extends PushSubscriptionSocketServer<TestFi
         deviceId: options.deviceId ?? null,
         packageName: options.packageName ?? null,
       },
+      backfilling: false,
     });
 
     return { socket, subscriptionId };

--- a/test/daemon/telemetryPushSocketServer.test.ts
+++ b/test/daemon/telemetryPushSocketServer.test.ts
@@ -38,7 +38,9 @@ class TestableTelemetryPushSocketServer extends TelemetryPushSocketServer {
       filter: {
         category: options.category ?? null,
         deviceId: options.deviceId ?? null,
+        sessionId: null,
       },
+      backfilling: false,
     });
     return { socket, subscriptionId };
   }
@@ -282,6 +284,32 @@ describe("TelemetryPushSocketServer", () => {
     server.pushTelemetryEvent(wrongCategory);
     server.pushTelemetryEvent(wrongDevice);
 
+    expect(socket.getWrittenMessages()).toHaveLength(1);
+  });
+
+  it("skips subscribers that are backfilling", () => {
+    const { socket, subscriptionId } = server.simulateSubscription({});
+
+    // Simulate backfill in progress
+    const subscriber = server.subscribers.get(subscriptionId)!;
+    subscriber.backfilling = true;
+
+    const event: TelemetryEvent = {
+      category: "log",
+      timestamp: 1000,
+      deviceId: null,
+      data: { level: 4, tag: "Test", message: "during backfill" },
+    };
+
+    server.pushTelemetryEvent(event);
+
+    // Should not receive the event while backfilling
+    expect(socket.getWrittenMessages()).toHaveLength(0);
+
+    // After backfill completes, events should flow again
+    subscriber.backfilling = false;
+
+    server.pushTelemetryEvent(event);
     expect(socket.getWrittenMessages()).toHaveLength(1);
   });
 });


### PR DESCRIPTION
## Summary
- When a desktop app subscriber connects to the telemetry push socket, it was immediately added to the live push list before backfill started. Events arriving during the async backfill were delivered twice — once live and once in the backfill results.
- Added a `backfilling` flag to the `Subscriber` interface. Subscribers are skipped by `pushToSubscribers` while backfilling is true, preventing the overlap window.
- Also fixes a pre-existing type error (`F` -> `TFilter`) in `onSubscribed` signature.

## Test Plan
- [x] All 3424 tests pass locally (0 failures)
- [x] Build passes
- [x] New test verifies events are skipped during backfill and resume after

🤖 Generated with [Claude Code](https://claude.com/claude-code)