### PR TITLE
feat: add iOS systemTray support via CtrlProxy

### DIFF
--- a/schemas/tool-definitions.json
+++ b/schemas/tool-definitions.json
@@ -1633,7 +1633,7 @@
           ]
         },
         "dismissKeyboard": {
-          "description": "(Android only) Dismiss soft keyboard after input. Overrides server-level --dismiss-keyboard-after-input flag. Ignored on iOS.",
+          "description": "(Android only) Dismiss soft keyboard after input (default: false). Ignored on iOS.",
           "type": "boolean"
         },
         "platform": {
@@ -5496,14 +5496,15 @@
           ]
         },
         "action": {
+          "default": "tap",
+          "description": "Action type (default: tap)",
           "type": "string",
           "enum": [
             "tap",
             "doubleTap",
             "longPress",
             "focus"
-          ],
-          "description": "Action type"
+          ]
         },
         "selectionStrategy": {
           "description": "Element selection strategy when multiple matches are found (default: first)",

--- a/src/server/interactionTools.ts
+++ b/src/server/interactionTools.ts
@@ -74,8 +74,8 @@ import {
   ensureSystemTrayOpen,
   resolveNotificationTapElement,
   resolveNotificationSwipeElement,
-  tapElementWithAdb,
-  swipeElementWithAdb,
+  tapElement,
+  swipeElement,
   resolveAppLabel,
   SYSTEM_TRAY_CLEAR_MAX_ITERATIONS,
   SYSTEM_TRAY_NOTIFICATION_SWIPE_DURATION_MS,
@@ -530,14 +530,6 @@ export function registerInteractionTools() {
   // System tray handler
   const systemTrayHandler = async (device: BootedDevice, args: SystemTrayArgs, progress?: ProgressCallback) => {
     try {
-      if (args.platform === "ios") {
-        return createJSONToolResponse({
-          success: false,
-          message: "systemTray is not supported on iOS yet.",
-          action: args.action
-        });
-      }
-
       const awaitTimeoutMs = resolveSystemTrayAwaitTimeout(args.awaitTimeout);
 
       if (args.action === "open") {
@@ -606,7 +598,7 @@ export function registerInteractionTools() {
           throw new ActionableError("No notification tap target was resolved within the matched notification.");
         }
 
-        await tapElementWithAdb(device, tapMatch.element);
+        await tapElement(device, tapMatch.element);
         const { observeScreenFactory } = getSystemTrayDependencies();
         const observeScreen = observeScreenFactory(device);
         const nextObservation = await observeScreen.execute();
@@ -639,12 +631,12 @@ export function registerInteractionTools() {
           throw new ActionableError(`Notification not found after ${awaitTimeoutMs}ms.`);
         }
 
-        const swipeElement = resolveNotificationSwipeElement(match, notification, appMatchTexts);
-        if (!swipeElement) {
+        const swipeTarget = resolveNotificationSwipeElement(match, notification, appMatchTexts);
+        if (!swipeTarget) {
           throw new ActionableError("No swipeable notification element was resolved within the matched notification.");
         }
 
-        await swipeElementWithAdb(device, swipeElement);
+        await swipeElement(device, swipeTarget);
         const { observeScreenFactory } = getSystemTrayDependencies();
         const observeScreen = observeScreenFactory(device);
         const nextObservation = await observeScreen.execute();
@@ -674,12 +666,12 @@ export function registerInteractionTools() {
             break;
           }
 
-          const swipeElement = resolveNotificationSwipeElement(match, notification, appMatchTexts);
-          if (!swipeElement) {
+          const swipeTarget = resolveNotificationSwipeElement(match, notification, appMatchTexts);
+          if (!swipeTarget) {
             break;
           }
 
-          await swipeElementWithAdb(device, swipeElement);
+          await swipeElement(device, swipeTarget);
           dismissed++;
           await timer.sleep(SYSTEM_TRAY_NOTIFICATION_SWIPE_DURATION_MS + 100);
         }

--- a/src/server/systemTrayHelpers.ts
+++ b/src/server/systemTrayHelpers.ts
@@ -9,10 +9,12 @@ import {
   BootedDevice,
   Element,
   ObserveResult,
+  Platform,
   ViewHierarchyResult
 } from "../models";
 import { RealObserveScreen } from "../features/observe/ObserveScreen";
 import { defaultAdbClientFactory } from "../utils/android-cmdline-tools/AdbClientFactory";
+import { CtrlProxyClient as IOSCtrlProxyClient } from "../features/observe/ios";
 import type { ElementFinder } from "../utils/interfaces/ElementFinder";
 import { DefaultElementFinder } from "../features/utility/ElementFinder";
 import { DefaultElementGeometry } from "../features/utility/ElementGeometry";
@@ -46,9 +48,20 @@ export interface SystemTrayAdb {
   getDeviceTimestampMs(): Promise<number>;
 }
 
+export interface SystemTrayIosClient {
+  requestSwipe(
+    x1: number, y1: number, x2: number, y2: number,
+    duration?: number
+  ): Promise<{ success: boolean }>;
+  requestTapCoordinates(
+    x: number, y: number
+  ): Promise<{ success: boolean }>;
+}
+
 export interface SystemTrayDependencies {
   observeScreenFactory: (device: BootedDevice) => SystemTrayObserver;
   adbFactory: (device: BootedDevice) => SystemTrayAdb;
+  iosClientFactory?: (device: BootedDevice) => SystemTrayIosClient;
   timer: Timer;
 }
 
@@ -58,11 +71,26 @@ export interface SystemTrayDependencies {
 
 let systemTrayDependencies: SystemTrayDependencies | null = null;
 
+const defaultIosClientFactory: (device: BootedDevice) => SystemTrayIosClient = device => {
+  const client = IOSCtrlProxyClient.getInstance(device);
+  return {
+    requestSwipe: async (x1, y1, x2, y2, duration) => {
+      const result = await client.requestSwipe(x1, y1, x2, y2, duration);
+      return { success: result.success };
+    },
+    requestTapCoordinates: async (x, y) => {
+      const result = await client.requestTapCoordinates(x, y);
+      return { success: result.success };
+    }
+  };
+};
+
 export const getSystemTrayDependencies = (): SystemTrayDependencies => {
   if (!systemTrayDependencies) {
     systemTrayDependencies = {
       observeScreenFactory: device => new RealObserveScreen(device),
       adbFactory: device => defaultAdbClientFactory.create(device),
+      iosClientFactory: defaultIosClientFactory,
       timer: defaultTimer
     };
   }
@@ -74,6 +102,7 @@ export const setSystemTrayDependencies = (overrides: Partial<SystemTrayDependenc
   systemTrayDependencies = {
     observeScreenFactory: overrides.observeScreenFactory ?? current.observeScreenFactory,
     adbFactory: overrides.adbFactory ?? current.adbFactory,
+    iosClientFactory: overrides.iosClientFactory ?? current.iosClientFactory,
     timer: overrides.timer ?? current.timer
   };
 };
@@ -87,6 +116,14 @@ export const resetSystemTrayDependencies = (): void => {
 // ============================================================================
 
 const SYSTEM_TRAY_PACKAGE = "com.android.systemui";
+const IOS_NOTIFICATION_CENTER_CLASS_HINTS = [
+  "NotificationCenter",
+  "NCNotification",
+  "NotificationList",
+  "NotificationShortLookView",
+  "NotificationLongLookView",
+  "PLPlatterView"
+];
 const SYSTEM_TRAY_RESOURCE_ID_HINTS = [
   "notification_panel",
   "notification_stack",
@@ -211,24 +248,24 @@ const nodeHasSystemTrayHint = (node: any): boolean => {
   return matchesResourceId || matchesClassName;
 };
 
-const traverseForSystemTray = (node: any): boolean => {
+const traverseForHint = (node: any, predicate: (node: any) => boolean): boolean => {
   if (!node) {
     return false;
   }
 
-  if (nodeHasSystemTrayHint(node)) {
+  if (predicate(node)) {
     return true;
   }
 
   const children = node.node;
   if (Array.isArray(children)) {
     for (const child of children) {
-      if (traverseForSystemTray(child)) {
+      if (traverseForHint(child, predicate)) {
         return true;
       }
     }
   } else if (children && typeof children === "object") {
-    if (traverseForSystemTray(children)) {
+    if (traverseForHint(children, predicate)) {
       return true;
     }
   }
@@ -252,19 +289,41 @@ const getHierarchyRoots = (viewHierarchy: ViewHierarchyResult): any[] => {
   return [hierarchy];
 };
 
-const isSystemTrayOpen = (viewHierarchy?: ViewHierarchyResult): boolean => {
+const nodeHasIosNotificationCenterHint = (node: any): boolean => {
+  const props = getNodeProperties(node);
+  if (!props) {
+    return false;
+  }
+
+  const className = String(props.className ?? props.class ?? "");
+  const contentDesc = String(props["content-desc"] ?? props["ios-accessibility-label"] ?? "");
+  const identifier = String(props["resource-id"] ?? props.resourceId ?? props.identifier ?? "");
+
+  return IOS_NOTIFICATION_CENTER_CLASS_HINTS.some(
+    hint => className.includes(hint) || contentDesc.includes(hint) || identifier.includes(hint)
+  );
+};
+
+const isIosNotificationCenterOpen = (viewHierarchy: ViewHierarchyResult): boolean => {
+  const packageName = (viewHierarchy as any).packageName ?? "";
+  if (!packageName.includes("springboard")) {
+    return false;
+  }
+  const rootNodes = getHierarchyRoots(viewHierarchy);
+  return rootNodes.some(root => traverseForHint(root, nodeHasIosNotificationCenterHint));
+};
+
+const isSystemTrayOpen = (viewHierarchy?: ViewHierarchyResult, platform?: Platform): boolean => {
   if (!viewHierarchy) {
     return false;
   }
 
-  const rootNodes = getHierarchyRoots(viewHierarchy);
-  for (const rootNode of rootNodes) {
-    if (traverseForSystemTray(rootNode)) {
-      return true;
-    }
+  if (platform === "ios") {
+    return isIosNotificationCenterOpen(viewHierarchy);
   }
 
-  return false;
+  const rootNodes = getHierarchyRoots(viewHierarchy);
+  return rootNodes.some(root => traverseForHint(root, nodeHasSystemTrayHint));
 };
 
 // ============================================================================
@@ -286,7 +345,28 @@ const resolveSystemTrayObservationTimestamp = async (device: BootedDevice): Prom
   return adb.getDeviceTimestampMs();
 };
 
-const expandSystemTray = async (device: BootedDevice): Promise<void> => {
+const getIosClient = (device: BootedDevice): SystemTrayIosClient => {
+  const { iosClientFactory } = getSystemTrayDependencies();
+  if (!iosClientFactory) {
+    throw new ActionableError("iOS CtrlProxy client not configured for systemTray");
+  }
+  return iosClientFactory(device);
+};
+
+const expandSystemTray = async (device: BootedDevice, screenWidth?: number, screenHeight?: number): Promise<void> => {
+  if (device.platform === "ios") {
+    if (!screenWidth || !screenHeight) {
+      throw new ActionableError("Screen dimensions required to open iOS Notification Center");
+    }
+    const client = getIosClient(device);
+    await client.requestSwipe(
+      Math.floor(screenWidth * 0.5), 5,
+      Math.floor(screenWidth * 0.5), Math.floor(screenHeight * 0.7),
+      300
+    );
+    return;
+  }
+
   if (device.platform !== "android") {
     return;
   }
@@ -870,14 +950,15 @@ const findBestNotificationMatch = (
 const waitForSystemTrayOpen = async (
   observeScreen: SystemTrayObserver,
   minTimestamp: number,
-  awaitTimeoutMs: number
+  awaitTimeoutMs: number,
+  platform?: Platform
 ): Promise<ObserveResult> => {
   const { timer } = getSystemTrayDependencies();
   const startTime = timer.now();
   let observation = await observeScreen.execute(undefined, undefined, false, minTimestamp);
 
   while (timer.now() - startTime < awaitTimeoutMs) {
-    if (isSystemTrayOpen(observation.viewHierarchy)) {
+    if (isSystemTrayOpen(observation.viewHierarchy, platform)) {
       return observation;
     }
     await sleep(SYSTEM_TRAY_POLL_INTERVAL_MS);
@@ -897,10 +978,31 @@ export const ensureSystemTrayOpen = async (
   skipped: boolean;
   minTimestamp: number;
 }> => {
-  const { observeScreenFactory } = getSystemTrayDependencies();
+  const { observeScreenFactory, timer } = getSystemTrayDependencies();
   const observeScreen = observeScreenFactory(device);
   let observation: ObserveResult | undefined;
   let minTimestamp = 0;
+
+  if (device.platform === "ios") {
+    minTimestamp = timer.now();
+    observation = await observeScreen.execute(undefined, undefined, false, minTimestamp);
+    if (isSystemTrayOpen(observation.viewHierarchy, "ios")) {
+      return { observation, opened: false, skipped: true, minTimestamp };
+    }
+    const screenWidth = observation.screenSize?.width;
+    const screenHeight = observation.screenSize?.height;
+    await expandSystemTray(device, screenWidth, screenHeight);
+    minTimestamp = timer.now();
+    const awaitedObservation = await waitForSystemTrayOpen(
+      observeScreen, minTimestamp, awaitTimeoutMs, "ios"
+    );
+    return {
+      observation: awaitedObservation ?? observation,
+      opened: true,
+      skipped: false,
+      minTimestamp
+    };
+  }
 
   if (device.platform === "android") {
     minTimestamp = await resolveSystemTrayObservationTimestamp(device);
@@ -913,15 +1015,6 @@ export const ensureSystemTrayOpen = async (
   await expandSystemTray(device);
   if (device.platform === "android") {
     minTimestamp = await resolveSystemTrayObservationTimestamp(device);
-  }
-
-  if (device.platform !== "android") {
-    return {
-      observation,
-      opened: true,
-      skipped: false,
-      minTimestamp
-    };
   }
 
   const awaitedObservation = await waitForSystemTrayOpen(
@@ -962,7 +1055,7 @@ export const waitForNotificationMatch = async (
     }
 
     const viewHierarchy = observation.viewHierarchy;
-    if (viewHierarchy && isSystemTrayOpen(viewHierarchy)) {
+    if (viewHierarchy && isSystemTrayOpen(viewHierarchy, device.platform)) {
       const match = findBestNotificationMatch(viewHierarchy, criteria, appMatchTexts);
       if (match) {
         return { observation, match };
@@ -1041,17 +1134,33 @@ export const resolveNotificationSwipeElement = (
   return null;
 };
 
-export const tapElementWithAdb = async (device: BootedDevice, element: Element): Promise<void> => {
+export const tapElement = async (device: BootedDevice, element: Element): Promise<void> => {
   const geometry = new DefaultElementGeometry();
   const center = geometry.getElementCenter(element);
+
+  if (device.platform === "ios") {
+    await getIosClient(device).requestTapCoordinates(center.x, center.y);
+    return;
+  }
+
   const { adbFactory } = getSystemTrayDependencies();
   const adb = adbFactory(device);
   await adb.executeCommand(`shell input tap ${center.x} ${center.y}`);
 };
 
-export const swipeElementWithAdb = async (device: BootedDevice, element: Element): Promise<void> => {
+export const swipeElement = async (device: BootedDevice, element: Element): Promise<void> => {
   const geometry = new DefaultElementGeometry();
   const { startX, startY, endX, endY } = geometry.getSwipeWithinBounds("left", element.bounds);
+
+  if (device.platform === "ios") {
+    await getIosClient(device).requestSwipe(
+      Math.floor(startX), Math.floor(startY),
+      Math.floor(endX), Math.floor(endY),
+      SYSTEM_TRAY_NOTIFICATION_SWIPE_DURATION_MS
+    );
+    return;
+  }
+
   const { adbFactory } = getSystemTrayDependencies();
   const adb = adbFactory(device);
   await adb.executeCommand(

--- a/test/server/systemTray.test.ts
+++ b/test/server/systemTray.test.ts
@@ -4,10 +4,16 @@ import {
   setSystemTrayDependencies,
   waitForNotificationMatch
 } from "../../src/server/interactionTools";
+import {
+  ensureSystemTrayOpen,
+  tapElement,
+  swipeElement,
+} from "../../src/server/systemTrayHelpers";
+import type { SystemTrayIosClient } from "../../src/server/systemTrayHelpers";
 import { FakeTimer } from "../fakes/FakeTimer";
 import { FakeAdbExecutor } from "../fakes/FakeAdbExecutor";
 import { FakeObserveScreen } from "../fakes/FakeObserveScreen";
-import type { BootedDevice, ObserveResult, ViewHierarchyResult } from "../../src/models";
+import type { BootedDevice, Element, ObserveResult, ViewHierarchyResult } from "../../src/models";
 
 const POLL_INTERVAL_MS = 250;
 const SYSTEM_TRAY_PACKAGE = "com.android.systemui";
@@ -205,5 +211,246 @@ describe("systemTray find", () => {
     expect(result.observation.viewHierarchy?.packageName).toBe("com.google.android.apps.nexuslauncher");
     expect(fakeAdb.wasCommandExecuted("cmd statusbar expand-notifications")).toBe(true);
     expect(fakeObserveScreen.getExecuteCallCount()).toBeGreaterThan(1);
+  });
+});
+
+// ============================================================================
+// iOS tests
+// ============================================================================
+
+const IOS_SPRINGBOARD_PACKAGE = "com.apple.springboard";
+
+class FakeIosClient implements SystemTrayIosClient {
+  swipeCalls: Array<{ x1: number; y1: number; x2: number; y2: number; duration?: number }> = [];
+  tapCalls: Array<{ x: number; y: number }> = [];
+
+  async requestSwipe(x1: number, y1: number, x2: number, y2: number, duration?: number) {
+    this.swipeCalls.push({ x1, y1, x2, y2, duration });
+    return { success: true };
+  }
+
+  async requestTapCoordinates(x: number, y: number) {
+    this.tapCalls.push({ x, y });
+    return { success: true };
+  }
+}
+
+const iosDevice: BootedDevice = {
+  name: "iPhone_15",
+  platform: "ios",
+  deviceId: "ios-device-1",
+  source: "local"
+};
+
+const createIosObservation = (viewHierarchy?: ViewHierarchyResult): ObserveResult => ({
+  updatedAt: 0,
+  screenSize: { width: 390, height: 844 },
+  systemInsets: { top: 0, right: 0, bottom: 0, left: 0 },
+  viewHierarchy
+});
+
+const createIosAppHierarchy = (): ViewHierarchyResult => ({
+  packageName: "com.example.app",
+  hierarchy: {
+    node: {
+      $: {
+        className: "UIWindow",
+        packageName: "com.example.app",
+        bounds: "[0,0][390,844]"
+      }
+    }
+  }
+});
+
+const createIosNotificationCenterHierarchy = (title: string, body?: string): ViewHierarchyResult => ({
+  packageName: IOS_SPRINGBOARD_PACKAGE,
+  hierarchy: {
+    node: {
+      $: {
+        className: "NotificationCenter",
+        packageName: IOS_SPRINGBOARD_PACKAGE,
+        bounds: "[0,0][390,844]"
+      },
+      node: [{
+        $: {
+          "className": "NCNotificationListCell",
+          "packageName": IOS_SPRINGBOARD_PACKAGE,
+          "text": title,
+          "content-desc": body ?? "",
+          "bounds": "[10,100][380,200]"
+        }
+      }]
+    }
+  }
+});
+
+describe("iOS systemTray open", () => {
+  afterEach(() => {
+    resetSystemTrayDependencies();
+  });
+
+  test("opens notification center via swipe down", async () => {
+    const fakeTimer = new FakeTimer();
+    const fakeIosClient = new FakeIosClient();
+    const fakeObserveScreen = new SequencedObserveScreen([
+      createIosObservation(createIosAppHierarchy()),
+      createIosObservation(createIosAppHierarchy()),
+      createIosObservation(createIosNotificationCenterHierarchy("Test"))
+    ]);
+
+    setSystemTrayDependencies({
+      timer: fakeTimer,
+      iosClientFactory: () => fakeIosClient,
+      observeScreenFactory: () => fakeObserveScreen
+    });
+
+    const resultPromise = ensureSystemTrayOpen(iosDevice, 2000);
+
+    await waitForPendingSleep(fakeTimer);
+    fakeTimer.advanceTime(POLL_INTERVAL_MS);
+
+    const result = await resultPromise;
+
+    expect(result.opened).toBe(true);
+    expect(result.skipped).toBe(false);
+    expect(fakeIosClient.swipeCalls.length).toBe(1);
+    expect(fakeIosClient.swipeCalls[0].y1).toBe(5);
+    expect(fakeIosClient.swipeCalls[0].y2).toBeGreaterThan(500);
+  });
+
+  test("skips swipe if notification center is already open", async () => {
+    const fakeTimer = new FakeTimer();
+    const fakeIosClient = new FakeIosClient();
+    const fakeObserveScreen = new SequencedObserveScreen([
+      createIosObservation(createIosNotificationCenterHierarchy("Existing"))
+    ]);
+
+    setSystemTrayDependencies({
+      timer: fakeTimer,
+      iosClientFactory: () => fakeIosClient,
+      observeScreenFactory: () => fakeObserveScreen
+    });
+
+    const result = await ensureSystemTrayOpen(iosDevice, 2000);
+
+    expect(result.opened).toBe(false);
+    expect(result.skipped).toBe(true);
+    expect(fakeIosClient.swipeCalls.length).toBe(0);
+  });
+});
+
+describe("iOS systemTray find", () => {
+  afterEach(() => {
+    resetSystemTrayDependencies();
+  });
+
+  test("finds notification by title in notification center", async () => {
+    const fakeTimer = new FakeTimer();
+    const fakeIosClient = new FakeIosClient();
+    const fakeObserveScreen = new SequencedObserveScreen([
+      createIosObservation(createIosAppHierarchy()),
+      createIosObservation(createIosAppHierarchy()),
+      createIosObservation(createIosNotificationCenterHierarchy("Test Notification")),
+      createIosObservation(createIosNotificationCenterHierarchy("Test Notification"))
+    ]);
+
+    setSystemTrayDependencies({
+      timer: fakeTimer,
+      iosClientFactory: () => fakeIosClient,
+      observeScreenFactory: () => fakeObserveScreen
+    });
+
+    const resultPromise = waitForNotificationMatch(
+      iosDevice,
+      { title: "Test Notification" },
+      [],
+      2000
+    );
+
+    // First sleep: waitForSystemTrayOpen polling (NC not yet open after swipe)
+    await waitForPendingSleep(fakeTimer);
+    fakeTimer.advanceTime(POLL_INTERVAL_MS);
+
+    const result = await resultPromise;
+
+    expect(result.match).not.toBeNull();
+    expect(result.match!.match.matches.title?.text).toBe("Test Notification");
+    expect(fakeIosClient.swipeCalls.length).toBe(1);
+  });
+
+  test("does not match when notification center is closed", async () => {
+    const fakeTimer = new FakeTimer();
+    const fakeIosClient = new FakeIosClient();
+    const fakeObserveScreen = new SequencedObserveScreen([
+      createIosObservation(createIosAppHierarchy()),
+      createIosObservation(createIosAppHierarchy()),
+      createIosObservation(createIosAppHierarchy())
+    ]);
+
+    setSystemTrayDependencies({
+      timer: fakeTimer,
+      iosClientFactory: () => fakeIosClient,
+      observeScreenFactory: () => fakeObserveScreen
+    });
+
+    const resultPromise = waitForNotificationMatch(
+      iosDevice,
+      { title: "Test Notification" },
+      [],
+      500
+    );
+
+    await advancePendingSleeps(fakeTimer, 3);
+
+    const result = await resultPromise;
+
+    expect(result.match).toBeNull();
+    expect(fakeIosClient.swipeCalls.length).toBe(1);
+  });
+});
+
+describe("iOS systemTray tap and dismiss", () => {
+  afterEach(() => {
+    resetSystemTrayDependencies();
+  });
+
+  test("tapElement routes through CtrlProxy", async () => {
+    const fakeIosClient = new FakeIosClient();
+
+    setSystemTrayDependencies({
+      timer: new FakeTimer(),
+      iosClientFactory: () => fakeIosClient,
+    });
+
+    const element: Element = {
+      bounds: { left: 10, top: 100, right: 380, bottom: 200 }
+    };
+
+    await tapElement(iosDevice, element);
+
+    expect(fakeIosClient.tapCalls.length).toBe(1);
+    expect(fakeIosClient.tapCalls[0].x).toBe(195);
+    expect(fakeIosClient.tapCalls[0].y).toBe(150);
+  });
+
+  test("swipeElement routes through CtrlProxy swipe left", async () => {
+    const fakeIosClient = new FakeIosClient();
+
+    setSystemTrayDependencies({
+      timer: new FakeTimer(),
+      iosClientFactory: () => fakeIosClient,
+    });
+
+    const element: Element = {
+      bounds: { left: 10, top: 100, right: 380, bottom: 200 }
+    };
+
+    await swipeElement(iosDevice, element);
+
+    expect(fakeIosClient.swipeCalls.length).toBe(1);
+    const swipe = fakeIosClient.swipeCalls[0];
+    // Swipe left: startX > endX
+    expect(swipe.x1).toBeGreaterThan(swipe.x2);
+    expect(swipe.duration).toBe(300);
   });
 });


### PR DESCRIPTION
## Summary
- Enable full iOS systemTray parity (open, find, tap, dismiss, clearAll) by routing through CtrlProxy WebSocket gestures
- Add iOS Notification Center detection heuristics and platform-aware tap/swipe/expand helpers
- No Swift changes needed — reuses existing CtrlProxy `request_swipe`, `request_tap_coordinates`, and `request_hierarchy` commands

## Test Plan
- [x] 8 systemTray tests pass (6 new iOS + 2 existing Android)
- [x] Full suite: 3430 pass, 0 fail
- [x] Lint and build clean

Closes #1858

🤖 Generated with [Claude Code](https://claude.com/claude-code)