### PR TITLE
chore: bump versions to v0.0.16

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -14,7 +14,7 @@
       "name": "auto-mobile",
       "source": "./",
       "description": "Mobile device automation for Android and iOS - control devices with natural language",
-      "version": "0.0.15",
+      "version": "0.0.16",
       "author": {
         "name": "AutoMobile Contributors",
         "email": "jason.d.pearson@gmail.com"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "auto-mobile",
   "description": "Mobile device automation for Android and iOS - control devices with natural language",
-  "version": "0.0.15",
+  "version": "0.0.16",
   "author": {
     "name": "AutoMobile Contributors",
     "email": "jason.d.pearson@gmail.com"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,34 @@
 # Changelog
 
+## [v0.0.16] - 2026-04-03
+### Added
+- IDE Plugin: Implement screen stream display in Layout Inspector ([#1033](https://github.com/kaeawc/auto-mobile/issues/1033)) (android, ios)
+- Server: Implement screen stream receiver and relay to IDE plugins ([#1032](https://github.com/kaeawc/auto-mobile/issues/1032))
+- Feature: iOS UserDefaults Inspection and Management ([#1022](https://github.com/kaeawc/auto-mobile/issues/1022)) (ios, devxp, testing)
+- feat: identify media-displaying views in hierarchy by class and role ([#1013](https://github.com/kaeawc/auto-mobile/issues/1013)) (android, a11y)
+- feat: Android version matrix testing in CI ([#835](https://github.com/kaeawc/auto-mobile/issues/835)) (android, ci, testing)
+### Changed
+- Dead Code Detection: Threshold Exceeded ([#1648](https://github.com/kaeawc/auto-mobile/issues/1648)) (automated, dead-code)
+### Fixed
+- tapOn fails to match text with Unicode curly apostrophe (U+2019) ([#1798](https://github.com/kaeawc/auto-mobile/issues/1798)) (ios)
+- Daemon disconnect cascade causes 6GB+ log flood and crash-restart loop ([#1773](https://github.com/kaeawc/auto-mobile/issues/1773))
+### Other
+- iOS: Add rotate support via CtrlProxy ([#1859](https://github.com/kaeawc/auto-mobile/issues/1859))
+- iOS: Add systemTray support via CtrlProxy ([#1858](https://github.com/kaeawc/auto-mobile/issues/1858))
+- iOS: Add recentApps support via CtrlProxy ([#1857](https://github.com/kaeawc/auto-mobile/issues/1857))
+- iOS inputText fails with dismissKeyboard enabled: isDismissKeyboardAfterInputEnabled is not a function ([#1840](https://github.com/kaeawc/auto-mobile/issues/1840))
+- setActiveDevice should allow launchApp when both platforms are connected ([#1839](https://github.com/kaeawc/auto-mobile/issues/1839))
+- inputText: should not require dismissKeyboard, default to false ([#1836](https://github.com/kaeawc/auto-mobile/issues/1836))
+- tapOn: error message when 'action' is omitted is unclear ([#1835](https://github.com/kaeawc/auto-mobile/issues/1835))
+- Auto-disable stylus handwriting on Android emulators ([#1834](https://github.com/kaeawc/auto-mobile/issues/1834))
+- CtrlProxy iOS broken on Xcode 26: checksum mismatch + simctl spawn failure ([#1833](https://github.com/kaeawc/auto-mobile/issues/1833))
+- startDevice returns generic DEVICE_NOT_FOUND when AVD userdata is corrupt ([#1672](https://github.com/kaeawc/auto-mobile/issues/1672))
+- feat: iOS simulator live locale changes (SpringBoard restart + AppleLanguages) ([#1613](https://github.com/kaeawc/auto-mobile/issues/1613))
+- test: increase Android test coverage for changeLocalization ([#1612](https://github.com/kaeawc/auto-mobile/issues/1612))
+- feat: add setCalendarSystem MCP tool (rename to calendar) ([#1611](https://github.com/kaeawc/auto-mobile/issues/1611))
+- bug: `doctor --ios` always fails with "undefined is not an object (evaluating '...runtimes.filter')" on Xcode 26.2 ([#1448](https://github.com/kaeawc/auto-mobile/issues/1448))
+- ci: run JUnitRunner emulator tests on macOS/Windows/Linux matrix ([#959](https://github.com/kaeawc/auto-mobile/issues/959)) (android, ci, testing)
+
 ## [v0.0.15] - 2026-03-26
 ### Other
 - No changes.

--- a/android/control-proxy/build.gradle.kts
+++ b/android/control-proxy/build.gradle.kts
@@ -36,7 +36,7 @@ android {
     minSdk = libs.versions.build.android.minSdk.get().toInt()
     targetSdk = libs.versions.build.android.targetSdk.get().toInt()
     versionCode = 1
-    versionName = "0.0.15-SNAPSHOT"
+    versionName = "0.0.16-SNAPSHOT"
 
     testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
   }

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -140,7 +140,7 @@ org.jetbrains.dokka.experimental.gradle.pluginMode=V2Enabled
 # Maven Central Publishing
 
 # Library versions (single source of truth)
-VERSION_NAME=0.0.15-SNAPSHOT
+VERSION_NAME=0.0.16-SNAPSHOT
 GROUP=dev.jasonpearson.auto-mobile
 
 # POM metadata

--- a/android/playground/app/build.gradle.kts
+++ b/android/playground/app/build.gradle.kts
@@ -36,7 +36,7 @@ android {
     minSdk = libs.versions.build.android.minSdk.get().toInt()
     targetSdk = libs.versions.build.android.targetSdk.get().toInt()
     versionCode = 1
-    versionName = "0.0.15-SNAPSHOT"
+    versionName = "0.0.16-SNAPSHOT"
 
     testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kaeawc/auto-mobile",
-  "version": "0.0.15",
+  "version": "0.0.16",
   "description": "Mobile device interaction automation via MCP",
   "scripts": {
     "test": "bun test",

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "dev.jasonpearson/auto-mobile",
   "title": "AutoMobile",
   "description": "Mobile device interaction automation via MCP",
-  "version": "0.0.15",
+  "version": "0.0.16",
   "websiteUrl": "https://kaeawc.github.io/auto-mobile/",
   "repository": {
     "url": "https://github.com/kaeawc/auto-mobile",
@@ -13,7 +13,7 @@
     {
       "registryType": "npm",
       "identifier": "@kaeawc/auto-mobile",
-      "version": "0.0.15",
+      "version": "0.0.16",
       "runtimeHint": "bunx",
       "transport": {
         "type": "stdio"

--- a/src/constants/release.ts
+++ b/src/constants/release.ts
@@ -26,7 +26,7 @@ export const RELEASE_VERSION: string = LATEST_RELEASE_VERSION;
 export const APK_URL: string = RELEASE_VERSION === LATEST_RELEASE_VERSION
   ? `https://github.com/kaeawc/auto-mobile/releases/latest/download/control-proxy-debug.apk`
   : `https://github.com/kaeawc/auto-mobile/releases/download/v${RELEASE_VERSION}/control-proxy-debug.apk`;
-export const APK_SHA256_CHECKSUM: string = "f773c04599fe8876dc3b5dfcaa68309614b7a3d09b62650d0cd614afd5ef1f77"; // Empty = skip verification (local dev only)
+export const APK_SHA256_CHECKSUM: string = "21d61613d8300cfc1f4fcb0bc55c3f19837e29058c8569123be8bbe5b130477e"; // Empty = skip verification (local dev only)
 
 /**
  * iOS CtrlProxy Release Constants
@@ -38,6 +38,6 @@ export const IOS_CTRL_PROXY_RELEASE_VERSION: string = LATEST_RELEASE_VERSION;
 export const IOS_CTRL_PROXY_IPA_URL: string = IOS_CTRL_PROXY_RELEASE_VERSION === LATEST_RELEASE_VERSION
   ? "https://github.com/kaeawc/auto-mobile/releases/latest/download/control-proxy.ipa"
   : `https://github.com/kaeawc/auto-mobile/releases/download/v${IOS_CTRL_PROXY_RELEASE_VERSION}/control-proxy.ipa`;
-export const IOS_CTRL_PROXY_SHA256_CHECKSUM: string = "b526d56e9ebc870120dd31dd67e5f48d805f2b840bc4e3edb56bd62e1624cb70"; // Empty = skip verification (local dev only)
+export const IOS_CTRL_PROXY_SHA256_CHECKSUM: string = "9b9378b96b7da535c3b62a035b16cf6359604a0f88800391460c76b8f8c3322b"; // Empty = skip verification (local dev only)
 export const IOS_CTRL_PROXY_APP_HASH: string = ""; // Hash of CtrlProxyApp.app (device build), empty = skip verification
 export const IOS_CTRL_PROXY_RUNNER_SHA256: string = ""; // SHA256 of runner binary (CtrlProxyUITests-Runner), empty = skip verification


### PR DESCRIPTION
## Summary
- Bump versions to v0.0.16
- Update CHANGELOG.md from closed issues since the last tag
- Refresh CtrlProxy APK SHA256 checksum
- Refresh CtrlProxy iOS IPA SHA256 checksum

## Automation
- Generated by `prepare-release` workflow