### PR TITLE
feat: add in-process UIView hierarchy walker to iOS SDK

### DIFF
--- a/ios/auto-mobile-sdk/Sources/AutoMobileSDK/AutoMobileSDK.swift
+++ b/ios/auto-mobile-sdk/Sources/AutoMobileSDK/AutoMobileSDK.swift
@@ -106,6 +106,9 @@ public final class AutoMobileSDK: @unchecked Sendable {
         AutoMobileNotificationObserver.shared.initialize(bundleId: resolvedBundleId, buffer: buffer)
         AutoMobileInteractionTracker.shared.initialize(bundleId: resolvedBundleId, buffer: buffer)
         ViewBodyTracker.shared.initialize(buffer: buffer, dateProvider: dateProvider)
+        #if canImport(UIKit) && !os(watchOS)
+        ViewHierarchyTracker.shared.initialize(buffer: buffer)
+        #endif
         UserDefaultsInspector.shared.initialize(buffer: buffer)
         DatabaseInspector.shared.initialize()
 
@@ -245,6 +248,9 @@ public final class AutoMobileSDK: @unchecked Sendable {
         AutoMobileNotificationObserver.shared.reset()
         AutoMobileInteractionTracker.shared.reset()
         ViewBodyTracker.shared.reset()
+        #if canImport(UIKit) && !os(watchOS)
+        ViewHierarchyTracker.shared.reset()
+        #endif
         UserDefaultsInspector.shared.reset()
         DatabaseInspector.shared.reset()
         AutoMobileNetwork.shared.reset()

--- a/ios/auto-mobile-sdk/Sources/AutoMobileSDK/Events/SdkEvent.swift
+++ b/ios/auto-mobile-sdk/Sources/AutoMobileSDK/Events/SdkEvent.swift
@@ -22,6 +22,7 @@ public enum SdkEventType: String, Codable, Sendable {
     case broadcast
     case interaction
     case storageChanged = "storage_changed"
+    case viewHierarchy = "view_hierarchy"
 }
 
 // MARK: - Event Types
@@ -319,6 +320,21 @@ public struct SdkViewBodySnapshotEvent: SdkEvent {
     ) {
         self.timestamp = timestamp
         self.snapshots = snapshots
+    }
+}
+
+/// A view hierarchy snapshot event pushed when the in-process UIView tree changes.
+public struct SdkViewHierarchyEvent: SdkEvent {
+    public private(set) var eventType: SdkEventType = .viewHierarchy
+    public let timestamp: Int64
+    public let hierarchy: SdkViewHierarchy
+
+    public init(
+        timestamp: Int64 = Int64(Date().timeIntervalSince1970 * 1000),
+        hierarchy: SdkViewHierarchy
+    ) {
+        self.timestamp = timestamp
+        self.hierarchy = hierarchy
     }
 }
 

--- a/ios/auto-mobile-sdk/Sources/AutoMobileSDK/Persistence/EventPersistence.swift
+++ b/ios/auto-mobile-sdk/Sources/AutoMobileSDK/Persistence/EventPersistence.swift
@@ -147,6 +147,8 @@ final class FileEventPersistence: EventPersisting, @unchecked Sendable {
             return try? decoder.decode(SdkInteractionEvent.self, from: data)
         case .storageChanged:
             return try? decoder.decode(SdkStorageChangedEvent.self, from: data)
+        case .viewHierarchy:
+            return try? decoder.decode(SdkViewHierarchyEvent.self, from: data)
         }
     }
 }

--- a/ios/auto-mobile-sdk/Sources/AutoMobileSDK/ViewHierarchy/SdkHierarchyServer.swift
+++ b/ios/auto-mobile-sdk/Sources/AutoMobileSDK/ViewHierarchy/SdkHierarchyServer.swift
@@ -1,0 +1,156 @@
+#if DEBUG && canImport(UIKit) && !os(watchOS)
+import Foundation
+import Network
+
+/// Minimal HTTP server running inside the target app on port 8766.
+/// Serves view hierarchy snapshots to control-proxy on demand.
+///
+/// Endpoints:
+/// - `GET /health` → `{"status":"ok"}`
+/// - `GET /hierarchy` → latest cached hierarchy (fast, no main-thread work)
+/// - `GET /hierarchy/fresh` → synchronous main-thread walk (slower but guaranteed fresh)
+final class SdkHierarchyServer: @unchecked Sendable {
+
+    static let port: UInt16 = 8766
+
+    private let lock = NSLock()
+    private var listener: NWListener?
+    private let queue = DispatchQueue(label: "dev.jasonpearson.automobile.sdk.hierarchy-server")
+    private weak var tracker: ViewHierarchyTracker?
+
+    init(tracker: ViewHierarchyTracker) {
+        self.tracker = tracker
+    }
+
+    // MARK: - Lifecycle
+
+    func start() {
+        lock.lock()
+        guard listener == nil else {
+            lock.unlock()
+            return
+        }
+
+        let parameters = NWParameters.tcp
+        parameters.allowLocalEndpointReuse = true
+
+        do {
+            let nwListener = try NWListener(using: parameters, on: NWEndpoint.Port(integerLiteral: Self.port))
+            self.listener = nwListener
+            lock.unlock()
+
+            nwListener.stateUpdateHandler = { state in
+                switch state {
+                case .ready:
+                    InternalLogger.debug("[SdkHierarchyServer] Ready on port \(Self.port)")
+                case let .failed(error):
+                    InternalLogger.debug("[SdkHierarchyServer] Failed: \(error)")
+                default:
+                    break
+                }
+            }
+
+            nwListener.newConnectionHandler = { [weak self] connection in
+                self?.handleConnection(connection)
+            }
+
+            nwListener.start(queue: queue)
+        } catch {
+            lock.unlock()
+            InternalLogger.debug("[SdkHierarchyServer] Failed to create listener: \(error)")
+        }
+    }
+
+    func stop() {
+        lock.lock()
+        let listenerToCancel = listener
+        listener = nil
+        lock.unlock()
+        listenerToCancel?.cancel()
+    }
+
+    // MARK: - Connection Handling
+
+    private func handleConnection(_ connection: NWConnection) {
+        connection.start(queue: queue)
+        connection.receive(minimumIncompleteLength: 1, maximumLength: 65536) { [weak self] data, _, _, error in
+            guard let self = self else {
+                connection.cancel()
+                return
+            }
+
+            if error != nil {
+                connection.cancel()
+                return
+            }
+
+            guard let data = data, let request = String(data: data, encoding: .utf8) else {
+                connection.cancel()
+                return
+            }
+
+            if request.contains("GET /hierarchy/fresh") {
+                self.handleFreshHierarchy(connection)
+            } else if request.contains("GET /hierarchy") {
+                self.handleCachedHierarchy(connection)
+            } else if request.contains("GET /health") {
+                self.sendResponse(connection, statusCode: 200, body: Data("{\"status\":\"ok\"}".utf8))
+            } else {
+                self.sendResponse(connection, statusCode: 404, body: Data("{\"error\":\"not_found\"}".utf8))
+            }
+        }
+    }
+
+    private func handleCachedHierarchy(_ connection: NWConnection) {
+        guard let hierarchy = tracker?.getLatestHierarchy() else {
+            sendResponse(connection, statusCode: 204, body: nil)
+            return
+        }
+        guard let data = try? JSONEncoder().encode(hierarchy) else {
+            sendResponse(connection, statusCode: 500, body: Data("{\"error\":\"encode_failed\"}".utf8))
+            return
+        }
+        sendResponse(connection, statusCode: 200, body: data)
+    }
+
+    private func handleFreshHierarchy(_ connection: NWConnection) {
+        guard let tracker = tracker else {
+            sendResponse(connection, statusCode: 503, body: Data("{\"error\":\"tracker_unavailable\"}".utf8))
+            return
+        }
+        // Already on Network.framework background queue; walkNow() dispatches to main internally
+        let hierarchy = tracker.walkNow()
+        guard let data = try? JSONEncoder().encode(hierarchy) else {
+            sendResponse(connection, statusCode: 500, body: Data("{\"error\":\"encode_failed\"}".utf8))
+            return
+        }
+        sendResponse(connection, statusCode: 200, body: data)
+    }
+
+    private func sendResponse(_ connection: NWConnection, statusCode: Int, body: Data?) {
+        let statusText: String
+        switch statusCode {
+        case 200: statusText = "OK"
+        case 204: statusText = "No Content"
+        case 404: statusText = "Not Found"
+        case 500: statusText = "Internal Server Error"
+        case 503: statusText = "Service Unavailable"
+        default: statusText = "Unknown"
+        }
+
+        let bodyData = body ?? Data()
+        var header = "HTTP/1.1 \(statusCode) \(statusText)\r\n"
+        header += "Content-Type: application/json\r\n"
+        header += "Content-Length: \(bodyData.count)\r\n"
+        header += "Connection: close\r\n"
+        header += "\r\n"
+
+        var responseData = Data(header.utf8)
+        responseData.append(bodyData)
+
+        connection.send(content: responseData, completion: .contentProcessed { _ in
+            connection.cancel()
+        })
+    }
+}
+#endif

--- a/ios/auto-mobile-sdk/Sources/AutoMobileSDK/ViewHierarchy/SdkViewNode.swift
+++ b/ios/auto-mobile-sdk/Sources/AutoMobileSDK/ViewHierarchy/SdkViewNode.swift
@@ -1,0 +1,125 @@
+import Foundation
+
+// MARK: - View Hierarchy
+
+/// Complete snapshot of the in-process UIView hierarchy.
+public struct SdkViewHierarchy: Codable, Sendable {
+    public let timestamp: Int64
+    public let bundleId: String?
+    public let screenScale: Float
+    public let screenWidth: Int
+    public let screenHeight: Int
+    public let root: SdkViewNode?
+
+    public init(
+        timestamp: Int64 = Int64(Date().timeIntervalSince1970 * 1000),
+        bundleId: String? = nil,
+        screenScale: Float,
+        screenWidth: Int,
+        screenHeight: Int,
+        root: SdkViewNode?
+    ) {
+        self.timestamp = timestamp
+        self.bundleId = bundleId
+        self.screenScale = screenScale
+        self.screenWidth = screenWidth
+        self.screenHeight = screenHeight
+        self.root = root
+    }
+}
+
+// MARK: - View Node
+
+/// A single node in the in-process UIView hierarchy tree.
+/// Contains properties only available from within the app process
+/// (gesture recognizers, traits, custom actions, background color, etc.).
+public struct SdkViewNode: Codable, Sendable {
+    public let className: String
+    public let bounds: SdkBounds
+    public let accessibilityLabel: String?
+    public let accessibilityIdentifier: String?
+    public let isAccessibilityElement: Bool
+    public let accessibilityElementsHidden: Bool
+    public let accessibilityTraits: [String]
+    public let accessibilityCustomActions: [String]
+    public let gestureRecognizers: [SdkGestureInfo]
+    public let alpha: Float
+    public let backgroundColor: String?
+    public let cornerRadius: Float
+    public let isHidden: Bool
+    public let isUserInteractionEnabled: Bool
+    public let hasTapTarget: Bool
+    public let isOccluded: Bool
+    public let children: [SdkViewNode]?
+
+    public init(
+        className: String,
+        bounds: SdkBounds,
+        accessibilityLabel: String? = nil,
+        accessibilityIdentifier: String? = nil,
+        isAccessibilityElement: Bool = false,
+        accessibilityElementsHidden: Bool = false,
+        accessibilityTraits: [String] = [],
+        accessibilityCustomActions: [String] = [],
+        gestureRecognizers: [SdkGestureInfo] = [],
+        alpha: Float = 1.0,
+        backgroundColor: String? = nil,
+        cornerRadius: Float = 0,
+        isHidden: Bool = false,
+        isUserInteractionEnabled: Bool = true,
+        hasTapTarget: Bool = false,
+        isOccluded: Bool = false,
+        children: [SdkViewNode]? = nil
+    ) {
+        self.className = className
+        self.bounds = bounds
+        self.accessibilityLabel = accessibilityLabel
+        self.accessibilityIdentifier = accessibilityIdentifier
+        self.isAccessibilityElement = isAccessibilityElement
+        self.accessibilityElementsHidden = accessibilityElementsHidden
+        self.accessibilityTraits = accessibilityTraits
+        self.accessibilityCustomActions = accessibilityCustomActions
+        self.gestureRecognizers = gestureRecognizers
+        self.alpha = alpha
+        self.backgroundColor = backgroundColor
+        self.cornerRadius = cornerRadius
+        self.isHidden = isHidden
+        self.isUserInteractionEnabled = isUserInteractionEnabled
+        self.hasTapTarget = hasTapTarget
+        self.isOccluded = isOccluded
+        self.children = children
+    }
+}
+
+// MARK: - Bounds
+
+/// Element bounds in root view coordinates.
+public struct SdkBounds: Codable, Sendable, Hashable {
+    public let left: Int
+    public let top: Int
+    public let right: Int
+    public let bottom: Int
+
+    public init(left: Int, top: Int, right: Int, bottom: Int) {
+        self.left = left
+        self.top = top
+        self.right = right
+        self.bottom = bottom
+    }
+
+    public var width: Int { right - left }
+    public var height: Int { bottom - top }
+}
+
+// MARK: - Gesture Info
+
+/// Describes a gesture recognizer attached to a view.
+public struct SdkGestureInfo: Codable, Sendable {
+    public let type: String
+    public let isEnabled: Bool
+
+    public init(type: String, isEnabled: Bool) {
+        self.type = type
+        self.isEnabled = isEnabled
+    }
+}

--- a/ios/auto-mobile-sdk/Sources/AutoMobileSDK/ViewHierarchy/ViewHierarchyTracker.swift
+++ b/ios/auto-mobile-sdk/Sources/AutoMobileSDK/ViewHierarchy/ViewHierarchyTracker.swift
@@ -1,0 +1,123 @@
+#if canImport(UIKit) && !os(watchOS)
+import Foundation
+import UIKit
+
+/// Polls the live UIView hierarchy on a timer, computes a structural hash,
+/// and pushes changes to control-proxy via the SDK event buffer.
+///
+/// Follows the same singleton + initialize/reset pattern as `ViewBodyTracker`.
+public final class ViewHierarchyTracker: @unchecked Sendable {
+    public static let shared = ViewHierarchyTracker()
+
+    private let lock = NSLock()
+    private var buffer: SdkEventBuffer?
+    private var pollTimer: (any TimerScheduling)?
+    private var _latestHierarchy: SdkViewHierarchy?
+    private var _latestHash: Int = 0
+    private let pollIntervalMs: Int = 1000
+    #if DEBUG
+    private var hierarchyServer: SdkHierarchyServer?
+    #endif
+
+    private init() {}
+
+    // MARK: - Lifecycle
+
+    func initialize(buffer: SdkEventBuffer, timerFactory: (() -> any TimerScheduling)? = nil) {
+        lock.lock()
+        self.buffer = buffer
+        let timer = timerFactory?() ?? GCDTimer()
+        self.pollTimer = timer
+        lock.unlock()
+
+        timer.schedule(intervalMs: pollIntervalMs) { [weak self] in
+            self?.poll()
+        }
+
+        #if DEBUG
+        let server = SdkHierarchyServer(tracker: self)
+        lock.lock()
+        self.hierarchyServer = server
+        lock.unlock()
+        server.start()
+        #endif
+    }
+
+    func reset() {
+        lock.lock()
+        pollTimer?.cancel()
+        pollTimer = nil
+        buffer = nil
+        _latestHierarchy = nil
+        _latestHash = 0
+        #if DEBUG
+        let server = hierarchyServer
+        hierarchyServer = nil
+        #endif
+        lock.unlock()
+
+        #if DEBUG
+        server?.stop()
+        #endif
+    }
+
+    // MARK: - On-Demand Access
+
+    /// Returns the most recently cached hierarchy snapshot (no main-thread work).
+    public func getLatestHierarchy() -> SdkViewHierarchy? {
+        lock.lock()
+        defer { lock.unlock() }
+        return _latestHierarchy
+    }
+
+    /// Performs a synchronous main-thread walk and returns the result.
+    /// Must NOT be called from the main thread (will deadlock).
+    public func walkNow() -> SdkViewHierarchy {
+        var result: SdkViewHierarchy!
+        if Thread.isMainThread {
+            result = performWalk()
+        } else {
+            DispatchQueue.main.sync {
+                result = self.performWalk()
+            }
+        }
+        lock.lock()
+        _latestHierarchy = result
+        _latestHash = ViewHierarchyWalker.computeHash(result)
+        lock.unlock()
+        return result
+    }
+
+    // MARK: - Polling
+
+    private func poll() {
+        guard AutoMobileSDK.shared.isEnabled else { return }
+
+        DispatchQueue.main.async { [weak self] in
+            self?.walkAndBroadcastIfChanged()
+        }
+    }
+
+    private func walkAndBroadcastIfChanged() {
+        let hierarchy = performWalk()
+        let hash = ViewHierarchyWalker.computeHash(hierarchy)
+
+        lock.lock()
+        let previousHash = _latestHash
+        _latestHierarchy = hierarchy
+        _latestHash = hash
+        let currentBuffer = buffer
+        lock.unlock()
+
+        guard hash != previousHash else { return }
+
+        let event = SdkViewHierarchyEvent(hierarchy: hierarchy)
+        currentBuffer?.add(event)
+    }
+
+    private func performWalk() -> SdkViewHierarchy {
+        let bundleId = AutoMobileSDK.shared.bundleId
+        return ViewHierarchyWalker.walk(bundleId: bundleId)
+    }
+}
+#endif

--- a/ios/auto-mobile-sdk/Sources/AutoMobileSDK/ViewHierarchy/ViewHierarchyWalker.swift
+++ b/ios/auto-mobile-sdk/Sources/AutoMobileSDK/ViewHierarchy/ViewHierarchyWalker.swift
@@ -1,0 +1,297 @@
+#if canImport(UIKit) && !os(watchOS)
+import UIKit
+
+/// Walks the live UIView hierarchy in-process, extracting rich properties
+/// not available through XCUITest's accessibility service.
+///
+/// Must be called on the main thread (UIView access requirement).
+/// Patterns borrowed from Slack's AccessibilityAuditor.
+public enum ViewHierarchyWalker {
+
+    // MARK: - Configuration
+
+    private static let maxDepth = 30
+
+    // MARK: - Public API
+
+    /// Walk the entire view hierarchy and return a snapshot.
+    /// Must be called on the main thread.
+    public static func walk(bundleId: String? = nil) -> SdkViewHierarchy {
+        let scale = Float(UIScreen.main.scale)
+        let screenBounds = UIScreen.main.bounds
+        let screenWidth = Int(screenBounds.width)
+        let screenHeight = Int(screenBounds.height)
+
+        let rootNode = walkWindows()
+
+        return SdkViewHierarchy(
+            bundleId: bundleId,
+            screenScale: scale,
+            screenWidth: screenWidth,
+            screenHeight: screenHeight,
+            root: rootNode
+        )
+    }
+
+    /// Compute a structural hash of a hierarchy for change detection.
+    /// Ignores bounds (which change during animations) to focus on content changes.
+    public static func computeHash(_ hierarchy: SdkViewHierarchy) -> Int {
+        var hasher = Hasher()
+        if let bundleId = hierarchy.bundleId {
+            hasher.combine(bundleId)
+        }
+        if let root = hierarchy.root {
+            hashNode(root, into: &hasher, depth: 0)
+        }
+        return hasher.finalize()
+    }
+
+    // MARK: - Window Enumeration
+
+    private static func walkWindows() -> SdkViewNode? {
+        let windows: [UIWindow]
+        if #available(iOS 15.0, *) {
+            windows = UIApplication.shared.connectedScenes
+                .compactMap { $0 as? UIWindowScene }
+                .flatMap { $0.windows }
+        } else {
+            windows = UIApplication.shared.windows
+        }
+
+        // Find topmost visible window: prefer key window, then highest window level
+        guard let keyWindow = windows
+            .filter({ !$0.isHidden && $0.alpha > 0 })
+            .max(by: { a, b in
+                if a.windowLevel != b.windowLevel { return a.windowLevel < b.windowLevel }
+                return !a.isKeyWindow && b.isKeyWindow
+            }) else {
+            return nil
+        }
+
+        var opaqueOverlays: [CGRect] = []
+        let rootBounds = keyWindow.bounds
+
+        return walkView(
+            keyWindow,
+            rootView: keyWindow,
+            rootBounds: rootBounds,
+            depth: 0,
+            opaqueOverlays: &opaqueOverlays
+        )
+    }
+
+    // MARK: - Recursive View Walk
+
+    private static func walkView(
+        _ view: UIView,
+        rootView: UIView,
+        rootBounds: CGRect,
+        depth: Int,
+        opaqueOverlays: inout [CGRect]
+    ) -> SdkViewNode? {
+        guard depth < maxDepth else { return nil }
+        guard !view.isHidden, view.alpha > 0 else { return nil }
+
+        let frameInRoot = frameInRootView(for: view, rootView: rootView)
+        guard frameInRoot.width > 0, frameInRoot.height > 0 else { return nil }
+        guard rootBounds.intersects(frameInRoot) else { return nil }
+
+        let occluded = isOccludedByOpaqueOverlay(frameInRoot, overlays: opaqueOverlays)
+
+        // Skip private UIKit internals
+        let className = String(describing: type(of: view))
+        if className.hasPrefix("_UI") { return nil }
+
+        let bounds = sdkBounds(from: frameInRoot)
+        let traits = traitNames(for: view.accessibilityTraits)
+        let customActions = (view.accessibilityCustomActions ?? []).map(\.name)
+        let gestures = (view.gestureRecognizers ?? []).map { gr in
+            SdkGestureInfo(
+                type: String(describing: type(of: gr)),
+                isEnabled: gr.isEnabled
+            )
+        }
+        let hasTap = hasOwnInteractiveAction(view)
+        let bgColor = hexColor(view.backgroundColor) ?? hexColor(view.layer.backgroundColor.flatMap { UIColor(cgColor: $0) })
+
+        // Walk children front-to-back for opaque overlay tracking
+        let subviews = view.accessibilityElements?.compactMap({ $0 as? UIView }) ?? view.subviews
+        var childNodes: [SdkViewNode] = []
+        var childOpaqueOverlays = opaqueOverlays
+
+        for child in subviews.reversed() {
+            let childFrame = frameInRootView(for: child, rootView: rootView)
+            if isOccludedByOpaqueOverlay(childFrame, overlays: childOpaqueOverlays) {
+                continue
+            }
+            if let childNode = walkView(
+                child,
+                rootView: rootView,
+                rootBounds: rootBounds,
+                depth: depth + 1,
+                opaqueOverlays: &childOpaqueOverlays
+            ) {
+                childNodes.append(childNode)
+            }
+            if isOpaqueOverlay(child) {
+                childOpaqueOverlays.append(childFrame)
+            }
+        }
+        // Reverse back to natural subview order for output
+        childNodes.reverse()
+
+        // Propagate any new opaque overlays discovered in children
+        opaqueOverlays = childOpaqueOverlays
+
+        return SdkViewNode(
+            className: className,
+            bounds: bounds,
+            accessibilityLabel: view.accessibilityLabel,
+            accessibilityIdentifier: view.accessibilityIdentifier,
+            isAccessibilityElement: view.isAccessibilityElement,
+            accessibilityElementsHidden: view.accessibilityElementsHidden,
+            accessibilityTraits: traits,
+            accessibilityCustomActions: customActions,
+            gestureRecognizers: gestures,
+            alpha: Float(view.alpha),
+            backgroundColor: bgColor,
+            cornerRadius: Float(view.layer.cornerRadius),
+            isHidden: view.isHidden,
+            isUserInteractionEnabled: view.isUserInteractionEnabled,
+            hasTapTarget: hasTap,
+            isOccluded: occluded,
+            children: childNodes.isEmpty ? nil : childNodes
+        )
+    }
+
+    // MARK: - Coordinate Conversion
+
+    private static func frameInRootView(for view: UIView, rootView: UIView) -> CGRect {
+        let frame = view.convert(view.bounds, to: rootView)
+        return CGRect(
+            x: frame.origin.x.rounded(),
+            y: frame.origin.y.rounded(),
+            width: frame.size.width.rounded(),
+            height: frame.size.height.rounded()
+        )
+    }
+
+    private static func sdkBounds(from rect: CGRect) -> SdkBounds {
+        SdkBounds(
+            left: Int(rect.origin.x),
+            top: Int(rect.origin.y),
+            right: Int(rect.origin.x + rect.width),
+            bottom: Int(rect.origin.y + rect.height)
+        )
+    }
+
+    // MARK: - Opaque Overlay Detection
+
+    private static func isOccludedByOpaqueOverlay(_ frame: CGRect, overlays: [CGRect]) -> Bool {
+        let area = frame.width * frame.height
+        guard area > 0 else { return false }
+        return overlays.contains { overlay in
+            let intersection = overlay.intersection(frame)
+            guard !intersection.isNull else { return false }
+            let intersectionArea = intersection.width * intersection.height
+            return intersectionArea / area >= 0.9
+        }
+    }
+
+    private static func isOpaqueOverlay(_ view: UIView) -> Bool {
+        guard !view.isHidden, view.alpha == 1.0 else { return false }
+        if let bg = view.backgroundColor, isOpaque(bg) { return true }
+        if let layerBg = view.layer.backgroundColor, isOpaque(UIColor(cgColor: layerBg)) { return true }
+        return false
+    }
+
+    private static func isOpaque(_ color: UIColor) -> Bool {
+        var alpha: CGFloat = 0
+        color.getRed(nil, green: nil, blue: nil, alpha: &alpha)
+        return alpha == 1.0
+    }
+
+    // MARK: - Interactive Action Detection
+
+    private static func hasOwnInteractiveAction(_ view: UIView) -> Bool {
+        if let control = view as? UIControl {
+            if !control.allTargets.isEmpty || control.showsMenuAsPrimaryAction { return true }
+        }
+        if hasContentTapGesture(view) { return true }
+        return false
+    }
+
+    /// Whether the view has a tap gesture that represents content interaction
+    /// (excludes VC root views and scroll view containers).
+    private static func hasContentTapGesture(_ view: UIView) -> Bool {
+        guard !(view.next is UIViewController) else { return false }
+        guard !(view is UIScrollView) else { return false }
+        if let gestureRecognizers = view.gestureRecognizers {
+            return gestureRecognizers.contains(where: { $0 is UITapGestureRecognizer && $0.isEnabled })
+        }
+        return false
+    }
+
+    // MARK: - Accessibility Traits
+
+    private static func traitNames(for traits: UIAccessibilityTraits) -> [String] {
+        var names: [String] = []
+        if traits.contains(.button) { names.append("button") }
+        if traits.contains(.link) { names.append("link") }
+        if traits.contains(.header) { names.append("header") }
+        if traits.contains(.searchField) { names.append("searchField") }
+        if traits.contains(.image) { names.append("image") }
+        if traits.contains(.selected) { names.append("selected") }
+        if traits.contains(.playsSound) { names.append("playsSound") }
+        if traits.contains(.keyboardKey) { names.append("keyboardKey") }
+        if traits.contains(.staticText) { names.append("staticText") }
+        if traits.contains(.summaryElement) { names.append("summaryElement") }
+        if traits.contains(.notEnabled) { names.append("notEnabled") }
+        if traits.contains(.updatesFrequently) { names.append("updatesFrequently") }
+        if traits.contains(.startsMediaSession) { names.append("startsMediaSession") }
+        if traits.contains(.adjustable) { names.append("adjustable") }
+        if traits.contains(.allowsDirectInteraction) { names.append("allowsDirectInteraction") }
+        if traits.contains(.causesPageTurn) { names.append("causesPageTurn") }
+        if traits.contains(.tabBar) { names.append("tabBar") }
+        if #available(iOS 17.0, *) {
+            if traits.contains(.toggleButton) { names.append("toggleButton") }
+        }
+        return names
+    }
+
+    // MARK: - Color Helpers
+
+    private static func hexColor(_ color: UIColor?) -> String? {
+        guard let color = color else { return nil }
+        var r: CGFloat = 0, g: CGFloat = 0, b: CGFloat = 0, a: CGFloat = 0
+        color.getRed(&r, green: &g, blue: &b, alpha: &a)
+        guard a > 0 else { return nil }
+        return String(
+            format: "#%02X%02X%02X%02X",
+            Int(r * 255), Int(g * 255), Int(b * 255), Int(a * 255)
+        )
+    }
+
+    // MARK: - Structural Hash
+
+    private static func hashNode(_ node: SdkViewNode, into hasher: inout Hasher, depth: Int) {
+        guard depth < 15 else { return }
+        hasher.combine(node.className)
+        hasher.combine(node.accessibilityLabel)
+        hasher.combine(node.accessibilityIdentifier)
+        hasher.combine(node.isAccessibilityElement)
+        hasher.combine(node.accessibilityElementsHidden)
+        hasher.combine(node.accessibilityTraits)
+        hasher.combine(node.accessibilityCustomActions)
+        hasher.combine(node.isHidden)
+        hasher.combine(node.isUserInteractionEnabled)
+        hasher.combine(node.hasTapTarget)
+        if let children = node.children {
+            hasher.combine(children.count)
+            for child in children {
+                hashNode(child, into: &hasher, depth: depth + 1)
+            }
+        }
+    }
+}
+#endif

--- a/ios/auto-mobile-sdk/Tests/AutoMobileSDKTests/ViewHierarchyTrackerTests.swift
+++ b/ios/auto-mobile-sdk/Tests/AutoMobileSDKTests/ViewHierarchyTrackerTests.swift
@@ -1,0 +1,93 @@
+#if canImport(UIKit) && !os(watchOS)
+import XCTest
+@testable import AutoMobileSDK
+
+final class ViewHierarchyTrackerTests: XCTestCase {
+
+    override func tearDown() {
+        ViewHierarchyTracker.shared.reset()
+        AutoMobileSDK.shared.reset()
+        super.tearDown()
+    }
+
+    func testInitiallyNoLatestHierarchy() {
+        XCTAssertNil(ViewHierarchyTracker.shared.getLatestHierarchy())
+    }
+
+    func testInitializeCreatesTimer() {
+        let fakeTimer = FakeTimer()
+        let fakeBuffer = FakeEventBuffer()
+
+        ViewHierarchyTracker.shared.initialize(buffer: fakeBuffer, timerFactory: { fakeTimer })
+
+        XCTAssertEqual(fakeTimer.intervalMs, 1000)
+        XCTAssertFalse(fakeTimer.isCancelled)
+    }
+
+    func testResetCancelsTimer() {
+        let fakeTimer = FakeTimer()
+        let fakeBuffer = FakeEventBuffer()
+
+        ViewHierarchyTracker.shared.initialize(buffer: fakeBuffer, timerFactory: { fakeTimer })
+        ViewHierarchyTracker.shared.reset()
+
+        XCTAssertTrue(fakeTimer.isCancelled)
+    }
+
+    func testResetClearsLatestHierarchy() {
+        let fakeTimer = FakeTimer()
+        let fakeBuffer = FakeEventBuffer()
+
+        AutoMobileSDK.shared.initialize(bundleId: "com.test.app")
+        ViewHierarchyTracker.shared.initialize(buffer: fakeBuffer, timerFactory: { fakeTimer })
+        ViewHierarchyTracker.shared.reset()
+
+        XCTAssertNil(ViewHierarchyTracker.shared.getLatestHierarchy())
+    }
+
+    func testDoubleResetIsSafe() {
+        let fakeTimer = FakeTimer()
+        let fakeBuffer = FakeEventBuffer()
+
+        ViewHierarchyTracker.shared.initialize(buffer: fakeBuffer, timerFactory: { fakeTimer })
+        ViewHierarchyTracker.shared.reset()
+        ViewHierarchyTracker.shared.reset()
+
+        XCTAssertTrue(fakeTimer.isCancelled)
+    }
+
+    func testPollDoesNotFireWhenSdkDisabled() {
+        let fakeTimer = FakeTimer()
+        let fakeBuffer = FakeEventBuffer()
+
+        // Don't initialize SDK — isEnabled will be true by default but isInitialized false
+        ViewHierarchyTracker.shared.initialize(buffer: fakeBuffer, timerFactory: { fakeTimer })
+
+        // Disable SDK
+        AutoMobileSDK.shared.setEnabled(false)
+
+        // Fire timer — should be a no-op since SDK is disabled
+        fakeTimer.fire()
+
+        // Give main queue time to process (poll dispatches to main)
+        let expectation = expectation(description: "main queue drain")
+        DispatchQueue.main.async { expectation.fulfill() }
+        wait(for: [expectation], timeout: 1.0)
+
+        XCTAssertTrue(fakeBuffer.events.isEmpty)
+    }
+
+    func testWalkNowReturnsHierarchy() {
+        let fakeTimer = FakeTimer()
+        let fakeBuffer = FakeEventBuffer()
+
+        AutoMobileSDK.shared.initialize(bundleId: "com.test.app")
+        ViewHierarchyTracker.shared.initialize(buffer: fakeBuffer, timerFactory: { fakeTimer })
+
+        let hierarchy = ViewHierarchyTracker.shared.walkNow()
+
+        XCTAssertEqual(hierarchy.bundleId, "com.test.app")
+        XCTAssertNotNil(ViewHierarchyTracker.shared.getLatestHierarchy())
+    }
+}
+#endif

--- a/ios/control-proxy/Sources/CtrlProxy/CommandHandler.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/CommandHandler.swift
@@ -12,17 +12,23 @@ public class CommandHandler: CommandHandling {
     private let gesturePerformer: GesturePerforming
     private let perfProvider: PerfProvider
     private let storageInspector: StorageInspecting?
+    private let sdkHierarchyClient: (any SdkHierarchyFetching)?
+    private let sdkHierarchyCache: (any SdkHierarchyCaching)?
 
     public init(
         elementLocator: ElementLocating,
         gesturePerformer: GesturePerforming,
         perfProvider: PerfProvider = PerfProvider.instance,
-        storageInspector: StorageInspecting? = nil
+        storageInspector: StorageInspecting? = nil,
+        sdkHierarchyClient: (any SdkHierarchyFetching)? = nil,
+        sdkHierarchyCache: (any SdkHierarchyCaching)? = nil
     ) {
         self.elementLocator = elementLocator
         self.gesturePerformer = gesturePerformer
         self.perfProvider = perfProvider
         self.storageInspector = storageInspector
+        self.sdkHierarchyClient = sdkHierarchyClient
+        self.sdkHierarchyCache = sdkHierarchyCache
     }
 
     /// Factory for testing - allows injecting fakes
@@ -30,7 +36,9 @@ public class CommandHandler: CommandHandling {
         elementLocator: ElementLocating,
         gesturePerformer: GesturePerforming,
         perfProvider: PerfProvider,
-        storageInspector: StorageInspecting? = nil
+        storageInspector: StorageInspecting? = nil,
+        sdkHierarchyClient: (any SdkHierarchyFetching)? = nil,
+        sdkHierarchyCache: (any SdkHierarchyCaching)? = nil
     )
         -> CommandHandler
     {
@@ -38,7 +46,9 @@ public class CommandHandler: CommandHandling {
             elementLocator: elementLocator,
             gesturePerformer: gesturePerformer,
             perfProvider: perfProvider,
-            storageInspector: storageInspector
+            storageInspector: storageInspector,
+            sdkHierarchyClient: sdkHierarchyClient,
+            sdkHierarchyCache: sdkHierarchyCache
         )
     }
 
@@ -178,12 +188,17 @@ public class CommandHandler: CommandHandling {
             throw CommandError.executionFailed("Failed to get view hierarchy: \(error.localizedDescription)")
         }
 
+        // Merge with SDK hierarchy: prefer cached (fast), fall back to fresh pull if no cache
+        let sdkHierarchy: SdkViewHierarchy? = sdkHierarchyCache?.latest
+            ?? sdkHierarchyClient?.fetchFreshHierarchy()
+        let enriched = HierarchyMerger.merge(xcuitest: hierarchy, sdk: sdkHierarchy)
+
         // Get accumulated timing for this operation
         let perfTimings = perfProvider.flush()
 
         return HierarchyUpdateResponse(
             requestId: request.requestId,
-            data: hierarchy,
+            data: enriched,
             perfTiming: perfTimings?.first
         )
     }

--- a/ios/control-proxy/Sources/CtrlProxy/CtrlProxy.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/CtrlProxy.swift
@@ -14,6 +14,8 @@ public class CtrlProxy {
     private let commandHandler: CommandHandler
     private let hierarchyDebouncer: HierarchyDebouncer
     private let fpsMonitor: DisplayLinkFPSMonitor
+    private let sdkHierarchyCache: SdkHierarchyCache
+    private let sdkHierarchyClient: SdkHierarchyClient
 
     #if canImport(XCTest) && os(iOS)
         private var application: XCUIApplication?
@@ -23,12 +25,16 @@ public class CtrlProxy {
     public init(port: UInt16 = defaultPort, timer: Timer = SystemTimer(), storageInspector: StorageInspecting? = DefaultStorageInspecting()) {
         elementLocator = ElementLocator()
         gesturePerformer = GesturePerformer(elementLocator: elementLocator)
+        sdkHierarchyCache = SdkHierarchyCache()
+        sdkHierarchyClient = SdkHierarchyClient()
         commandHandler = CommandHandler(
             elementLocator: elementLocator,
             gesturePerformer: gesturePerformer,
-            storageInspector: storageInspector
+            storageInspector: storageInspector,
+            sdkHierarchyClient: sdkHierarchyClient,
+            sdkHierarchyCache: sdkHierarchyCache
         )
-        server = WebSocketServer(port: port, commandHandler: commandHandler)
+        server = WebSocketServer(port: port, commandHandler: commandHandler, sdkHierarchyCache: sdkHierarchyCache)
         hierarchyDebouncer = HierarchyDebouncer(elementLocator: elementLocator, timer: timer)
         fpsMonitor = DisplayLinkFPSMonitor()
     }
@@ -68,7 +74,11 @@ public class CtrlProxy {
                     print(
                         "[CtrlProxy] Hierarchy changed (hash=\(hash), extraction=\(extractionTimeMs)ms), broadcasting"
                     )
-                    self?.server.broadcastHierarchyUpdate(hierarchy)
+                    let enriched = HierarchyMerger.merge(
+                        xcuitest: hierarchy,
+                        sdk: self?.sdkHierarchyCache.latest
+                    )
+                    self?.server.broadcastHierarchyUpdate(enriched)
                 case .unchanged:
                     // Don't broadcast unchanged results (animation mode)
                     break

--- a/ios/control-proxy/Sources/CtrlProxy/Fakes.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/Fakes.swift
@@ -613,6 +613,143 @@ public class FakeWebSocketServer: WebSocketServing {
     }
 }
 
+// MARK: - FakeSdkHierarchyFetcher
+
+/// Fake implementation of SdkHierarchyFetching for testing
+public class FakeSdkHierarchyFetcher: SdkHierarchyFetching {
+    private let lock = NSLock()
+    private var _cachedHierarchy: SdkViewHierarchy?
+    private var _freshHierarchy: SdkViewHierarchy?
+    private var _isAvailable: Bool = false
+    private var _fetchCallCount = 0
+    private var _fetchFreshCallCount = 0
+    private var _isAvailableCallCount = 0
+
+    public init() {}
+
+    // MARK: - Configuration
+
+    public func setCachedHierarchy(_ hierarchy: SdkViewHierarchy?) {
+        lock.lock()
+        _cachedHierarchy = hierarchy
+        lock.unlock()
+    }
+
+    public func setFreshHierarchy(_ hierarchy: SdkViewHierarchy?) {
+        lock.lock()
+        _freshHierarchy = hierarchy
+        lock.unlock()
+    }
+
+    public func setIsAvailable(_ available: Bool) {
+        lock.lock()
+        _isAvailable = available
+        lock.unlock()
+    }
+
+    // MARK: - Assertions
+
+    public var fetchCallCount: Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return _fetchCallCount
+    }
+
+    public var fetchFreshCallCount: Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return _fetchFreshCallCount
+    }
+
+    public var isAvailableCallCount: Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return _isAvailableCallCount
+    }
+
+    public func clearHistory() {
+        lock.lock()
+        _fetchCallCount = 0
+        _fetchFreshCallCount = 0
+        _isAvailableCallCount = 0
+        lock.unlock()
+    }
+
+    // MARK: - SdkHierarchyFetching
+
+    public func fetchHierarchy() -> SdkViewHierarchy? {
+        lock.lock()
+        _fetchCallCount += 1
+        let result = _cachedHierarchy
+        lock.unlock()
+        return result
+    }
+
+    public func fetchFreshHierarchy() -> SdkViewHierarchy? {
+        lock.lock()
+        _fetchFreshCallCount += 1
+        let result = _freshHierarchy
+        lock.unlock()
+        return result
+    }
+
+    public func isAvailable() -> Bool {
+        lock.lock()
+        _isAvailableCallCount += 1
+        let result = _isAvailable
+        lock.unlock()
+        return result
+    }
+}
+
+// MARK: - FakeSdkHierarchyCache
+
+/// Fake implementation of SdkHierarchyCaching for testing
+public class FakeSdkHierarchyCache: SdkHierarchyCaching {
+    private let lock = NSLock()
+    private var _latest: SdkViewHierarchy?
+    private var _updateCallCount = 0
+    private var _clearCallCount = 0
+
+    public init() {}
+
+    // MARK: - Assertions
+
+    public var updateCallCount: Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return _updateCallCount
+    }
+
+    public var clearCallCount: Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return _clearCallCount
+    }
+
+    // MARK: - SdkHierarchyCaching
+
+    public var latest: SdkViewHierarchy? {
+        lock.lock()
+        defer { lock.unlock() }
+        return _latest
+    }
+
+    public func update(_ hierarchy: SdkViewHierarchy) {
+        lock.lock()
+        _latest = hierarchy
+        _updateCallCount += 1
+        lock.unlock()
+    }
+
+    public func clear() {
+        lock.lock()
+        _latest = nil
+        _clearCallCount += 1
+        lock.unlock()
+    }
+}
+
 // MARK: - FakePerfProvider
 
 /// Fake implementation of PerfProvider for testing

--- a/ios/control-proxy/Sources/CtrlProxy/HierarchyMerger.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/HierarchyMerger.swift
@@ -1,0 +1,160 @@
+import Foundation
+
+/// Merges XCUITest-based `ViewHierarchy` with SDK's in-process `SdkViewHierarchy`,
+/// populating the `extras` field on each `UIElementInfo` node with `sdk.*` keys.
+///
+/// If no SDK hierarchy is available, returns the XCUITest hierarchy unchanged.
+public enum HierarchyMerger {
+
+    /// Tolerance in points for bounds matching between XCUITest and SDK nodes.
+    private static let boundsTolerance = 2
+
+    /// Merge SDK hierarchy data into the XCUITest hierarchy.
+    public static func merge(xcuitest: ViewHierarchy, sdk: SdkViewHierarchy?) -> ViewHierarchy {
+        guard let sdkRoot = sdk?.root else { return xcuitest }
+        guard let xcuitestRoot = xcuitest.hierarchy else { return xcuitest }
+
+        // Build a flat lookup from the SDK tree keyed by (className, bounds)
+        var lookup: [LookupKey: SdkViewNode] = [:]
+        buildLookup(node: sdkRoot, into: &lookup)
+
+        let enrichedRoot = enrichNode(xcuitestRoot, lookup: lookup)
+
+        return ViewHierarchy(
+            updatedAt: xcuitest.updatedAt,
+            packageName: xcuitest.packageName,
+            hierarchy: enrichedRoot,
+            windowInfo: xcuitest.windowInfo,
+            windows: xcuitest.windows,
+            screenScale: xcuitest.screenScale,
+            screenWidth: xcuitest.screenWidth,
+            screenHeight: xcuitest.screenHeight,
+            error: xcuitest.error,
+            fallbackToSpringboard: xcuitest.fallbackToSpringboard
+        )
+    }
+
+    // MARK: - Lookup
+
+    private struct LookupKey: Hashable {
+        let className: String
+        let left: Int
+        let top: Int
+        let right: Int
+        let bottom: Int
+    }
+
+    private static func buildLookup(node: SdkViewNode, into lookup: inout [LookupKey: SdkViewNode]) {
+        // Insert exact key + all tolerance variants so findMatch is O(1)
+        let tol = boundsTolerance
+        for dl in -tol...tol {
+            for dt in -tol...tol {
+                for dr in -tol...tol {
+                    for db in -tol...tol {
+                        let key = LookupKey(
+                            className: node.className,
+                            left: node.bounds.left + dl,
+                            top: node.bounds.top + dt,
+                            right: node.bounds.right + dr,
+                            bottom: node.bounds.bottom + db
+                        )
+                        if lookup[key] == nil {
+                            lookup[key] = node
+                        }
+                    }
+                }
+            }
+        }
+        if let children = node.children {
+            for child in children {
+                buildLookup(node: child, into: &lookup)
+            }
+        }
+    }
+
+    // MARK: - Matching
+
+    private static func findMatch(className: String?, bounds: ElementBounds?, in lookup: [LookupKey: SdkViewNode]) -> SdkViewNode? {
+        guard let className = className, let bounds = bounds else { return nil }
+        return lookup[LookupKey(
+            className: className,
+            left: bounds.left,
+            top: bounds.top,
+            right: bounds.right,
+            bottom: bounds.bottom
+        )]
+    }
+
+    // MARK: - Enrichment
+
+    private static func enrichNode(_ element: UIElementInfo, lookup: [LookupKey: SdkViewNode]) -> UIElementInfo {
+        let sdkNode = findMatch(className: element.className, bounds: element.bounds, in: lookup)
+        let enrichedExtras = buildExtras(existing: element.extras, sdkNode: sdkNode)
+
+        let enrichedChildren: [UIElementInfo]? = element.node?.map { enrichNode($0, lookup: lookup) }
+
+        return UIElementInfo(
+            text: element.text,
+            textSize: element.textSize,
+            contentDesc: element.contentDesc,
+            resourceId: element.resourceId,
+            className: element.className,
+            bounds: element.bounds,
+            clickable: element.clickable,
+            enabled: element.enabled,
+            focusable: element.focusable,
+            focused: element.focused,
+            accessibilityFocused: element.accessibilityFocused,
+            scrollable: element.scrollable,
+            password: element.password,
+            checkable: element.checkable,
+            checked: element.checked,
+            selected: element.selected,
+            longClickable: element.longClickable,
+            testTag: element.testTag,
+            role: element.role,
+            stateDescription: element.stateDescription,
+            errorMessage: element.errorMessage,
+            hintText: element.hintText,
+            viewId: element.viewId,
+            extras: enrichedExtras,
+            actions: element.actions,
+            node: enrichedChildren
+        )
+    }
+
+    private static func buildExtras(existing: [String: String]?, sdkNode: SdkViewNode?) -> [String: String]? {
+        guard let node = sdkNode else { return existing }
+
+        var extras = existing ?? [:]
+
+        if !node.accessibilityTraits.isEmpty {
+            extras["sdk.accessibilityTraits"] = node.accessibilityTraits.joined(separator: ",")
+        }
+        if !node.accessibilityCustomActions.isEmpty {
+            extras["sdk.accessibilityCustomActions"] = node.accessibilityCustomActions.joined(separator: ",")
+        }
+        if !node.gestureRecognizers.isEmpty {
+            let gestures = node.gestureRecognizers.map { "\($0.type)(\($0.isEnabled ? "enabled" : "disabled"))" }
+            extras["sdk.gestureRecognizers"] = gestures.joined(separator: ",")
+        }
+        if let bg = node.backgroundColor {
+            extras["sdk.backgroundColor"] = bg
+        }
+        extras["sdk.alpha"] = String(node.alpha)
+        if node.cornerRadius > 0 {
+            extras["sdk.cornerRadius"] = String(node.cornerRadius)
+        }
+        extras["sdk.isAccessibilityElement"] = String(node.isAccessibilityElement)
+        if node.accessibilityElementsHidden {
+            extras["sdk.accessibilityElementsHidden"] = "true"
+        }
+        extras["sdk.hasTapTarget"] = String(node.hasTapTarget)
+        if node.isOccluded {
+            extras["sdk.isOccluded"] = "true"
+        }
+        extras["sdk.isUserInteractionEnabled"] = String(node.isUserInteractionEnabled)
+
+        return extras.isEmpty ? nil : extras
+    }
+}

--- a/ios/control-proxy/Sources/CtrlProxy/Protocols.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/Protocols.swift
@@ -196,3 +196,25 @@ public protocol CommandHandling {
     /// Handle a request and return response
     func handle(_ request: WebSocketRequest) -> Any
 }
+
+// MARK: - SDK Hierarchy Protocols
+
+/// Protocol for fetching SDK view hierarchy on demand from the target app.
+public protocol SdkHierarchyFetching {
+    /// Fetch the latest cached hierarchy (fast).
+    func fetchHierarchy() -> SdkViewHierarchy?
+    /// Request a fresh hierarchy walk (slower).
+    func fetchFreshHierarchy() -> SdkViewHierarchy?
+    /// Whether the SDK hierarchy server is reachable.
+    func isAvailable() -> Bool
+}
+
+/// Protocol for accessing the cached SDK hierarchy.
+public protocol SdkHierarchyCaching {
+    /// The latest cached SDK view hierarchy, or nil if none received yet.
+    var latest: SdkViewHierarchy? { get }
+    /// Update the cached hierarchy.
+    func update(_ hierarchy: SdkViewHierarchy)
+    /// Clear the cached hierarchy.
+    func clear()
+}

--- a/ios/control-proxy/Sources/CtrlProxy/SdkHierarchyCache.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/SdkHierarchyCache.swift
@@ -1,0 +1,80 @@
+import Foundation
+
+/// Thread-safe cache holding the latest SDK view hierarchy received from the target app.
+/// Updated when the SDK POSTs hierarchy events via `/sdk-events`.
+public final class SdkHierarchyCache: SdkHierarchyCaching, @unchecked Sendable {
+    private let lock = NSLock()
+    private var _latest: SdkViewHierarchy?
+
+    public var latest: SdkViewHierarchy? {
+        lock.lock()
+        defer { lock.unlock() }
+        return _latest
+    }
+
+    public func update(_ hierarchy: SdkViewHierarchy) {
+        lock.lock()
+        _latest = hierarchy
+        lock.unlock()
+    }
+
+    public func clear() {
+        lock.lock()
+        _latest = nil
+        lock.unlock()
+    }
+}
+
+// MARK: - Extraction from SDK Event Batches
+
+/// Extracts `view_hierarchy` events from SDK event batches POSTed to `/sdk-events`
+/// and updates the provided hierarchy cache.
+public enum SdkHierarchyExtractor {
+
+    /// Matches SDK's `SdkEventType.viewHierarchy.rawValue` (separate package, can't share the enum).
+    private static let viewHierarchyEventType = "view_hierarchy"
+
+    /// Try to extract a view hierarchy event from the raw batch data.
+    /// Called on every `POST /sdk-events` — skips full decode when no hierarchy event is present.
+    public static func extractIfPresent(from batchData: Data, into cache: any SdkHierarchyCaching) {
+        // Fast path: skip full JSON decode if batch doesn't contain a hierarchy event
+        guard let jsonString = String(data: batchData, encoding: .utf8),
+              jsonString.contains(viewHierarchyEventType) else { return }
+
+        guard let batch = try? JSONDecoder().decode(SdkEventBatchEnvelope.self, from: batchData) else { return }
+
+        for event in batch.events where event.eventType == viewHierarchyEventType {
+            if let hierarchy = try? JSONDecoder().decode(SdkViewHierarchyEventPayload.self, from: event.payload) {
+                cache.update(hierarchy.hierarchy)
+            }
+        }
+    }
+}
+
+// MARK: - Minimal Decodable types for batch extraction
+
+/// Mirrors SDK's `SdkEventBatch` just enough to extract hierarchy events.
+struct SdkEventBatchEnvelope: Decodable {
+    let events: [SdkEventEnvelopeEntry]
+}
+
+struct SdkEventEnvelopeEntry: Decodable {
+    let eventType: String
+    let payload: Data
+
+    enum CodingKeys: String, CodingKey {
+        case eventType, payload
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        eventType = try container.decode(String.self, forKey: .eventType)
+        // payload is base64-encoded Data in JSON
+        payload = try container.decode(Data.self, forKey: .payload)
+    }
+}
+
+/// Mirrors SDK's `SdkViewHierarchyEvent` to extract the hierarchy payload.
+struct SdkViewHierarchyEventPayload: Decodable {
+    let hierarchy: SdkViewHierarchy
+}

--- a/ios/control-proxy/Sources/CtrlProxy/SdkHierarchyClient.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/SdkHierarchyClient.swift
@@ -1,0 +1,63 @@
+import Foundation
+
+/// HTTP client for fetching view hierarchy on demand from the SDK's in-app server (port 8766).
+/// Falls back gracefully when the SDK server isn't available (target app without SDK embedded).
+public final class SdkHierarchyClient: SdkHierarchyFetching, @unchecked Sendable {
+    private let baseURL: URL
+    private let urlSession: URLSession
+
+    public init(port: UInt16 = 8766) {
+        self.baseURL = URL(string: "http://localhost:\(port)")!
+        let config = URLSessionConfiguration.default
+        config.timeoutIntervalForRequest = 2
+        config.timeoutIntervalForResource = 5
+        config.waitsForConnectivity = false
+        self.urlSession = URLSession(configuration: config)
+    }
+
+    /// Fetch the latest cached hierarchy from the SDK (fast, no main-thread work in the target app).
+    public func fetchHierarchy() -> SdkViewHierarchy? {
+        return fetchSync(path: "/hierarchy")
+    }
+
+    /// Request a fresh hierarchy walk from the SDK (slower, involves main-thread work in the target app).
+    public func fetchFreshHierarchy() -> SdkViewHierarchy? {
+        return fetchSync(path: "/hierarchy/fresh")
+    }
+
+    /// Whether the SDK hierarchy server is reachable.
+    public func isAvailable() -> Bool {
+        return requestSync(path: "/health", session: healthSession) != nil
+    }
+
+    // MARK: - Private
+
+    private lazy var healthSession: URLSession = {
+        let config = URLSessionConfiguration.default
+        config.timeoutIntervalForRequest = 0.5
+        config.waitsForConnectivity = false
+        return URLSession(configuration: config)
+    }()
+
+    private func fetchSync(path: String) -> SdkViewHierarchy? {
+        guard let data = requestSync(path: path, session: urlSession) else { return nil }
+        return try? JSONDecoder().decode(SdkViewHierarchy.self, from: data)
+    }
+
+    private func requestSync(path: String, session: URLSession) -> Data? {
+        let url = baseURL.appendingPathComponent(path)
+        let semaphore = DispatchSemaphore(value: 0)
+        var result: Data?
+
+        session.dataTask(with: url) { data, response, _ in
+            defer { semaphore.signal() }
+            guard let http = response as? HTTPURLResponse,
+                  http.statusCode == 200,
+                  let data = data else { return }
+            result = data
+        }.resume()
+
+        semaphore.wait()
+        return result
+    }
+}

--- a/ios/control-proxy/Sources/CtrlProxy/SdkHierarchyModels.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/SdkHierarchyModels.swift
@@ -1,0 +1,90 @@
+import Foundation
+
+// MARK: - SDK View Hierarchy Models
+// Duplicated from AutoMobileSDK since the two packages have no shared dependency.
+
+/// Complete snapshot of the in-process UIView hierarchy from the SDK.
+public struct SdkViewHierarchy: Codable, Sendable {
+    public let timestamp: Int64
+    public let bundleId: String?
+    public let screenScale: Float
+    public let screenWidth: Int
+    public let screenHeight: Int
+    public let root: SdkViewNode?
+}
+
+/// A single node in the SDK's UIView hierarchy tree.
+public struct SdkViewNode: Codable, Sendable {
+    public let className: String
+    public let bounds: SdkBounds
+    public let accessibilityLabel: String?
+    public let accessibilityIdentifier: String?
+    public let isAccessibilityElement: Bool
+    public let accessibilityElementsHidden: Bool
+    public let accessibilityTraits: [String]
+    public let accessibilityCustomActions: [String]
+    public let gestureRecognizers: [SdkGestureInfo]
+    public let alpha: Float
+    public let backgroundColor: String?
+    public let cornerRadius: Float
+    public let isHidden: Bool
+    public let isUserInteractionEnabled: Bool
+    public let hasTapTarget: Bool
+    public let isOccluded: Bool
+    public let children: [SdkViewNode]?
+
+    public init(
+        className: String,
+        bounds: SdkBounds,
+        accessibilityLabel: String? = nil,
+        accessibilityIdentifier: String? = nil,
+        isAccessibilityElement: Bool = false,
+        accessibilityElementsHidden: Bool = false,
+        accessibilityTraits: [String] = [],
+        accessibilityCustomActions: [String] = [],
+        gestureRecognizers: [SdkGestureInfo] = [],
+        alpha: Float = 1.0,
+        backgroundColor: String? = nil,
+        cornerRadius: Float = 0,
+        isHidden: Bool = false,
+        isUserInteractionEnabled: Bool = true,
+        hasTapTarget: Bool = false,
+        isOccluded: Bool = false,
+        children: [SdkViewNode]? = nil
+    ) {
+        self.className = className
+        self.bounds = bounds
+        self.accessibilityLabel = accessibilityLabel
+        self.accessibilityIdentifier = accessibilityIdentifier
+        self.isAccessibilityElement = isAccessibilityElement
+        self.accessibilityElementsHidden = accessibilityElementsHidden
+        self.accessibilityTraits = accessibilityTraits
+        self.accessibilityCustomActions = accessibilityCustomActions
+        self.gestureRecognizers = gestureRecognizers
+        self.alpha = alpha
+        self.backgroundColor = backgroundColor
+        self.cornerRadius = cornerRadius
+        self.isHidden = isHidden
+        self.isUserInteractionEnabled = isUserInteractionEnabled
+        self.hasTapTarget = hasTapTarget
+        self.isOccluded = isOccluded
+        self.children = children
+    }
+}
+
+/// Element bounds in root view coordinates (matches SDK format).
+public struct SdkBounds: Codable, Sendable, Hashable {
+    public let left: Int
+    public let top: Int
+    public let right: Int
+    public let bottom: Int
+
+    public var width: Int { right - left }
+    public var height: Int { bottom - top }
+}
+
+/// Gesture recognizer info from the SDK.
+public struct SdkGestureInfo: Codable, Sendable {
+    public let type: String
+    public let isEnabled: Bool
+}

--- a/ios/control-proxy/Sources/CtrlProxy/WebSocketServer.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/WebSocketServer.swift
@@ -42,6 +42,7 @@ public class WebSocketServer: WebSocketServing {
     private let port: UInt16
     private let commandHandler: CommandHandler
     private let perfProvider: PerfProvider
+    private let sdkHierarchyCache: SdkHierarchyCache?
     private let queue = DispatchQueue(label: "com.ctrlproxy.server")
 
     public var isRunning: Bool {
@@ -51,11 +52,13 @@ public class WebSocketServer: WebSocketServing {
     public init(
         port: UInt16 = 8765,
         commandHandler: CommandHandler,
-        perfProvider: PerfProvider = PerfProvider.instance
+        perfProvider: PerfProvider = PerfProvider.instance,
+        sdkHierarchyCache: SdkHierarchyCache? = nil
     ) {
         self.port = port
         self.commandHandler = commandHandler
         self.perfProvider = perfProvider
+        self.sdkHierarchyCache = sdkHierarchyCache
     }
 
     /// Starts the server
@@ -115,7 +118,8 @@ public class WebSocketServer: WebSocketServing {
         let connection = WebSocketConnection(
             id: connectionId,
             connection: nwConnection,
-            queue: queue
+            queue: queue,
+            sdkHierarchyCache: sdkHierarchyCache
         ) { [weak self] message in
             self?.handleMessage(message, connectionId: connectionId)
         } onClose: { [weak self] in
@@ -288,18 +292,21 @@ class WebSocketConnection {
     private let queue: DispatchQueue
     private let onMessage: (Data) -> Void
     private let onClose: () -> Void
+    private let sdkHierarchyCache: (any SdkHierarchyCaching)?
     private var isWebSocketUpgraded = false
 
     init(
         id: Int,
         connection: NWConnection,
         queue: DispatchQueue,
+        sdkHierarchyCache: (any SdkHierarchyCaching)? = nil,
         onMessage: @escaping (Data) -> Void,
         onClose: @escaping () -> Void
     ) {
         self.id = id
         self.connection = connection
         self.queue = queue
+        self.sdkHierarchyCache = sdkHierarchyCache
         self.onMessage = onMessage
         self.onClose = onClose
     }
@@ -382,6 +389,9 @@ class WebSocketConnection {
             let body = String(request[bodyRange.upperBound...])
             if let bodyData = body.data(using: .utf8), !bodyData.isEmpty {
                 SdkEventBuffer.shared.append(bodyData)
+                if let cache = sdkHierarchyCache {
+                    SdkHierarchyExtractor.extractIfPresent(from: bodyData, into: cache)
+                }
                 print("[CtrlProxy] Received SDK event batch (\(bodyData.count) bytes)")
             } else {
                 print("[CtrlProxy] POST /sdk-events: empty body after headers")

--- a/ios/control-proxy/Tests/CtrlProxyTests/HierarchyMergerTests.swift
+++ b/ios/control-proxy/Tests/CtrlProxyTests/HierarchyMergerTests.swift
@@ -1,0 +1,323 @@
+import XCTest
+@testable import CtrlProxy
+
+final class HierarchyMergerTests: XCTestCase {
+
+    // MARK: - Helpers
+
+    private func makeElement(
+        className: String = "UIView",
+        bounds: ElementBounds = ElementBounds(left: 0, top: 0, right: 100, bottom: 100),
+        text: String? = nil,
+        contentDesc: String? = nil,
+        extras: [String: String]? = nil,
+        children: [UIElementInfo]? = nil
+    ) -> UIElementInfo {
+        UIElementInfo(
+            text: text,
+            contentDesc: contentDesc,
+            className: className,
+            bounds: bounds,
+            extras: extras,
+            node: children
+        )
+    }
+
+    private func makeSdkNode(
+        className: String = "UIView",
+        bounds: SdkBounds = SdkBounds(left: 0, top: 0, right: 100, bottom: 100),
+        accessibilityLabel: String? = nil,
+        accessibilityTraits: [String] = [],
+        accessibilityCustomActions: [String] = [],
+        gestureRecognizers: [SdkGestureInfo] = [],
+        alpha: Float = 1.0,
+        backgroundColor: String? = nil,
+        cornerRadius: Float = 0,
+        isAccessibilityElement: Bool = false,
+        accessibilityElementsHidden: Bool = false,
+        hasTapTarget: Bool = false,
+        isOccluded: Bool = false,
+        isUserInteractionEnabled: Bool = true,
+        children: [SdkViewNode]? = nil
+    ) -> SdkViewNode {
+        SdkViewNode(
+            className: className,
+            bounds: bounds,
+            accessibilityLabel: accessibilityLabel,
+            isAccessibilityElement: isAccessibilityElement,
+            accessibilityElementsHidden: accessibilityElementsHidden,
+            accessibilityTraits: accessibilityTraits,
+            accessibilityCustomActions: accessibilityCustomActions,
+            gestureRecognizers: gestureRecognizers,
+            alpha: alpha,
+            backgroundColor: backgroundColor,
+            cornerRadius: cornerRadius,
+            isUserInteractionEnabled: isUserInteractionEnabled,
+            hasTapTarget: hasTapTarget,
+            isOccluded: isOccluded,
+            children: children
+        )
+    }
+
+    private func makeHierarchy(root: UIElementInfo) -> ViewHierarchy {
+        ViewHierarchy(
+            packageName: "com.test.app",
+            hierarchy: root,
+            screenScale: 3.0,
+            screenWidth: 375,
+            screenHeight: 812
+        )
+    }
+
+    private func makeSdkHierarchy(root: SdkViewNode) -> SdkViewHierarchy {
+        SdkViewHierarchy(
+            timestamp: 1000,
+            bundleId: "com.test.app",
+            screenScale: 3.0,
+            screenWidth: 375,
+            screenHeight: 812,
+            root: root
+        )
+    }
+
+    // MARK: - No SDK Hierarchy (graceful fallback)
+
+    func testMergeWithNilSdkReturnsUnchanged() {
+        let root = makeElement(text: "Hello")
+        let hierarchy = makeHierarchy(root: root)
+
+        let result = HierarchyMerger.merge(xcuitest: hierarchy, sdk: nil)
+
+        XCTAssertEqual(result.hierarchy?.text, "Hello")
+        XCTAssertNil(result.hierarchy?.extras)
+    }
+
+    func testMergeWithNilSdkRootReturnsUnchanged() {
+        let root = makeElement(text: "Hello")
+        let hierarchy = makeHierarchy(root: root)
+        let sdkHierarchy = SdkViewHierarchy(
+            timestamp: 1000, bundleId: nil, screenScale: 3.0,
+            screenWidth: 375, screenHeight: 812, root: nil
+        )
+
+        let result = HierarchyMerger.merge(xcuitest: hierarchy, sdk: sdkHierarchy)
+
+        XCTAssertNil(result.hierarchy?.extras)
+    }
+
+    // MARK: - Exact Match
+
+    func testExactBoundsMatch() {
+        let xcuiRoot = makeElement(
+            className: "UIButton",
+            bounds: ElementBounds(left: 10, top: 20, right: 110, bottom: 60)
+        )
+        let sdkRoot = makeSdkNode(
+            className: "UIButton",
+            bounds: SdkBounds(left: 10, top: 20, right: 110, bottom: 60),
+            accessibilityTraits: ["button"],
+            hasTapTarget: true
+        )
+
+        let result = HierarchyMerger.merge(
+            xcuitest: makeHierarchy(root: xcuiRoot),
+            sdk: makeSdkHierarchy(root: sdkRoot)
+        )
+
+        let extras = result.hierarchy?.extras
+        XCTAssertNotNil(extras)
+        XCTAssertEqual(extras?["sdk.accessibilityTraits"], "button")
+        XCTAssertEqual(extras?["sdk.hasTapTarget"], "true")
+    }
+
+    // MARK: - Tolerance Matching
+
+    func testBoundsToleranceMatch() {
+        let xcuiRoot = makeElement(
+            className: "UILabel",
+            bounds: ElementBounds(left: 10, top: 20, right: 100, bottom: 50)
+        )
+        // SDK bounds off by 1pt on each edge
+        let sdkRoot = makeSdkNode(
+            className: "UILabel",
+            bounds: SdkBounds(left: 11, top: 21, right: 101, bottom: 51),
+            accessibilityTraits: ["staticText"],
+            backgroundColor: "#FF0000FF"
+        )
+
+        let result = HierarchyMerger.merge(
+            xcuitest: makeHierarchy(root: xcuiRoot),
+            sdk: makeSdkHierarchy(root: sdkRoot)
+        )
+
+        let extras = result.hierarchy?.extras
+        XCTAssertNotNil(extras)
+        XCTAssertEqual(extras?["sdk.accessibilityTraits"], "staticText")
+        XCTAssertEqual(extras?["sdk.backgroundColor"], "#FF0000FF")
+    }
+
+    func testBoundsOutOfToleranceNoMatch() {
+        let xcuiRoot = makeElement(
+            className: "UILabel",
+            bounds: ElementBounds(left: 10, top: 20, right: 100, bottom: 50)
+        )
+        // SDK bounds off by 5pt — exceeds ±2 tolerance
+        let sdkRoot = makeSdkNode(
+            className: "UILabel",
+            bounds: SdkBounds(left: 15, top: 25, right: 105, bottom: 55),
+            accessibilityTraits: ["staticText"]
+        )
+
+        let result = HierarchyMerger.merge(
+            xcuitest: makeHierarchy(root: xcuiRoot),
+            sdk: makeSdkHierarchy(root: sdkRoot)
+        )
+
+        XCTAssertNil(result.hierarchy?.extras)
+    }
+
+    // MARK: - Class Name Mismatch
+
+    func testClassNameMismatchNoMatch() {
+        let xcuiRoot = makeElement(
+            className: "UIButton",
+            bounds: ElementBounds(left: 10, top: 20, right: 100, bottom: 50)
+        )
+        let sdkRoot = makeSdkNode(
+            className: "UILabel",
+            bounds: SdkBounds(left: 10, top: 20, right: 100, bottom: 50),
+            accessibilityTraits: ["staticText"]
+        )
+
+        let result = HierarchyMerger.merge(
+            xcuitest: makeHierarchy(root: xcuiRoot),
+            sdk: makeSdkHierarchy(root: sdkRoot)
+        )
+
+        XCTAssertNil(result.hierarchy?.extras)
+    }
+
+    // MARK: - Children
+
+    func testChildrenAreEnriched() {
+        let childElement = makeElement(
+            className: "UILabel",
+            bounds: ElementBounds(left: 10, top: 50, right: 200, bottom: 80)
+        )
+        let xcuiRoot = makeElement(
+            className: "UIView",
+            bounds: ElementBounds(left: 0, top: 0, right: 375, bottom: 812),
+            children: [childElement]
+        )
+
+        let childSdkNode = makeSdkNode(
+            className: "UILabel",
+            bounds: SdkBounds(left: 10, top: 50, right: 200, bottom: 80),
+            accessibilityTraits: ["header"]
+        )
+        let sdkRoot = makeSdkNode(
+            className: "UIView",
+            bounds: SdkBounds(left: 0, top: 0, right: 375, bottom: 812),
+            children: [childSdkNode]
+        )
+
+        let result = HierarchyMerger.merge(
+            xcuitest: makeHierarchy(root: xcuiRoot),
+            sdk: makeSdkHierarchy(root: sdkRoot)
+        )
+
+        let childExtras = result.hierarchy?.node?.first?.extras
+        XCTAssertEqual(childExtras?["sdk.accessibilityTraits"], "header")
+    }
+
+    // MARK: - All Extras Fields
+
+    func testAllExtrasFieldsPopulated() {
+        let xcuiRoot = makeElement(
+            className: "UIView",
+            bounds: ElementBounds(left: 0, top: 0, right: 100, bottom: 100)
+        )
+        let sdkRoot = makeSdkNode(
+            className: "UIView",
+            bounds: SdkBounds(left: 0, top: 0, right: 100, bottom: 100),
+            accessibilityTraits: ["button", "selected"],
+            accessibilityCustomActions: ["Delete", "Share"],
+            gestureRecognizers: [SdkGestureInfo(type: "UITapGestureRecognizer", isEnabled: true)],
+            alpha: 0.8,
+            backgroundColor: "#00FF00FF",
+            cornerRadius: 12.0,
+            isAccessibilityElement: true,
+            accessibilityElementsHidden: true,
+            hasTapTarget: true,
+            isOccluded: true,
+            isUserInteractionEnabled: false
+        )
+
+        let result = HierarchyMerger.merge(
+            xcuitest: makeHierarchy(root: xcuiRoot),
+            sdk: makeSdkHierarchy(root: sdkRoot)
+        )
+
+        let extras = result.hierarchy?.extras
+        XCTAssertNotNil(extras)
+        XCTAssertEqual(extras?["sdk.accessibilityTraits"], "button,selected")
+        XCTAssertEqual(extras?["sdk.accessibilityCustomActions"], "Delete,Share")
+        XCTAssertEqual(extras?["sdk.gestureRecognizers"], "UITapGestureRecognizer(enabled)")
+        XCTAssertEqual(extras?["sdk.alpha"], "0.8")
+        XCTAssertEqual(extras?["sdk.backgroundColor"], "#00FF00FF")
+        XCTAssertEqual(extras?["sdk.cornerRadius"], "12.0")
+        XCTAssertEqual(extras?["sdk.isAccessibilityElement"], "true")
+        XCTAssertEqual(extras?["sdk.accessibilityElementsHidden"], "true")
+        XCTAssertEqual(extras?["sdk.hasTapTarget"], "true")
+        XCTAssertEqual(extras?["sdk.isOccluded"], "true")
+        XCTAssertEqual(extras?["sdk.isUserInteractionEnabled"], "false")
+    }
+
+    // MARK: - Existing Extras Preserved
+
+    func testExistingExtrasPreserved() {
+        let xcuiRoot = makeElement(
+            className: "UIView",
+            bounds: ElementBounds(left: 0, top: 0, right: 100, bottom: 100),
+            extras: ["custom.key": "custom.value"]
+        )
+        let sdkRoot = makeSdkNode(
+            className: "UIView",
+            bounds: SdkBounds(left: 0, top: 0, right: 100, bottom: 100),
+            hasTapTarget: true
+        )
+
+        let result = HierarchyMerger.merge(
+            xcuitest: makeHierarchy(root: xcuiRoot),
+            sdk: makeSdkHierarchy(root: sdkRoot)
+        )
+
+        let extras = result.hierarchy?.extras
+        XCTAssertEqual(extras?["custom.key"], "custom.value")
+        XCTAssertEqual(extras?["sdk.hasTapTarget"], "true")
+    }
+
+    // MARK: - Hierarchy Metadata Preserved
+
+    func testHierarchyMetadataPreserved() {
+        let xcuiRoot = makeElement()
+        let hierarchy = ViewHierarchy(
+            updatedAt: 12345,
+            packageName: "com.test.app",
+            hierarchy: xcuiRoot,
+            screenScale: 3.0,
+            screenWidth: 375,
+            screenHeight: 812,
+            fallbackToSpringboard: true
+        )
+
+        let result = HierarchyMerger.merge(xcuitest: hierarchy, sdk: nil)
+
+        XCTAssertEqual(result.updatedAt, 12345)
+        XCTAssertEqual(result.packageName, "com.test.app")
+        XCTAssertEqual(result.screenScale, 3.0)
+        XCTAssertEqual(result.screenWidth, 375)
+        XCTAssertEqual(result.screenHeight, 812)
+        XCTAssertEqual(result.fallbackToSpringboard, true)
+    }
+}

--- a/ios/control-proxy/Tests/CtrlProxyTests/SdkHierarchyCacheTests.swift
+++ b/ios/control-proxy/Tests/CtrlProxyTests/SdkHierarchyCacheTests.swift
@@ -1,0 +1,86 @@
+import XCTest
+@testable import CtrlProxy
+
+final class SdkHierarchyCacheTests: XCTestCase {
+
+    private func makeSdkHierarchy(timestamp: Int64 = 1000) -> SdkViewHierarchy {
+        SdkViewHierarchy(
+            timestamp: timestamp,
+            bundleId: "com.test.app",
+            screenScale: 3.0,
+            screenWidth: 375,
+            screenHeight: 812,
+            root: SdkViewNode(
+                className: "UIView",
+                bounds: SdkBounds(left: 0, top: 0, right: 375, bottom: 812)
+            )
+        )
+    }
+
+    // MARK: - Basic Operations
+
+    func testInitiallyNil() {
+        let cache = SdkHierarchyCache()
+        XCTAssertNil(cache.latest)
+    }
+
+    func testUpdateAndRetrieve() {
+        let cache = SdkHierarchyCache()
+        let hierarchy = makeSdkHierarchy()
+
+        cache.update(hierarchy)
+
+        XCTAssertNotNil(cache.latest)
+        XCTAssertEqual(cache.latest?.timestamp, 1000)
+        XCTAssertEqual(cache.latest?.bundleId, "com.test.app")
+    }
+
+    func testUpdateReplacesLatest() {
+        let cache = SdkHierarchyCache()
+        cache.update(makeSdkHierarchy(timestamp: 1000))
+        cache.update(makeSdkHierarchy(timestamp: 2000))
+
+        XCTAssertEqual(cache.latest?.timestamp, 2000)
+    }
+
+    func testClearResetsToNil() {
+        let cache = SdkHierarchyCache()
+        cache.update(makeSdkHierarchy())
+
+        cache.clear()
+
+        XCTAssertNil(cache.latest)
+    }
+
+    // MARK: - Thread Safety
+
+    func testConcurrentAccess() {
+        let cache = SdkHierarchyCache()
+        let group = DispatchGroup()
+        let iterations = 100
+
+        for i in 0..<iterations {
+            group.enter()
+            DispatchQueue.global().async {
+                cache.update(self.makeSdkHierarchy(timestamp: Int64(i)))
+                _ = cache.latest
+                group.leave()
+            }
+        }
+
+        group.wait()
+        // No crash = thread-safe. Latest should be some valid value.
+        // Can't assert exact value due to race, but it should not be nil.
+        XCTAssertNotNil(cache.latest)
+    }
+
+    // MARK: - Extractor
+
+    func testExtractorWithInvalidData() {
+        let cache = SdkHierarchyCache()
+
+        SdkHierarchyExtractor.extractIfPresent(from: Data("not json".utf8), into: cache)
+
+        XCTAssertNil(cache.latest)
+    }
+}


### PR DESCRIPTION
## Summary
- Adds a UIView walker to `auto-mobile-sdk` that extracts rich hierarchy data (accessibility traits, gesture recognizers, background colors, tap targets, occlusion detection) not available through XCUITest's accessibility service
- SDK pushes hierarchy changes via existing `/sdk-events` channel and serves on-demand snapshots via HTTP server on port 8766
- Control-proxy merges SDK + XCUITest hierarchies by matching nodes on `(className, bounds)` with ±2pt tolerance, populating `extras` field with `sdk.*` keys — zero wire format changes

## New Files
**SDK:** `SdkViewNode.swift`, `ViewHierarchyWalker.swift`, `ViewHierarchyTracker.swift`, `SdkHierarchyServer.swift`
**Control-proxy:** `SdkHierarchyModels.swift`, `SdkHierarchyClient.swift`, `SdkHierarchyCache.swift`, `HierarchyMerger.swift`

## Test Plan
- [x] SDK builds (`swift build`) — 167 tests pass
- [x] Control-proxy builds (`swift build`) — 163 tests pass
- [x] HierarchyMerger: 10 tests (bounds tolerance, class matching, extras population, fallback)
- [x] SdkHierarchyCache: 6 tests (thread safety, extractor, CRUD)
- [x] ViewHierarchyTracker: 6 tests (polling, reset, walkNow)
- [ ] Integration: launch SDK app + CtrlProxy, verify enriched hierarchy over WebSocket

🤖 Generated with [Claude Code](https://claude.com/claude-code)