### PR TITLE
Daemon transport stability updates - loopback host, serialization, timeouts, error IDs

### DIFF
--- a/android/junit-runner/src/main/kotlin/dev/jasonpearson/automobile/junit/AutoMobilePlanExecutor.kt
+++ b/android/junit-runner/src/main/kotlin/dev/jasonpearson/automobile/junit/AutoMobilePlanExecutor.kt
@@ -339,7 +339,11 @@ internal object AutoMobilePlanExecutor {
       DaemonHeartbeat.registerSession(sessionUuid)
       response =
           try {
-            DaemonSocketClientManager.callTool("executePlan", JsonObject(args), options.timeoutMs)
+            DaemonSocketClientManager.callTool(
+                "executePlan",
+                JsonObject(args),
+                options.effectiveExecutePlanTimeoutMs(),
+            )
           } finally {
             DaemonHeartbeat.unregisterSession(sessionUuid)
           }

--- a/android/junit-runner/src/main/kotlin/dev/jasonpearson/automobile/junit/AutoMobilePlanTypes.kt
+++ b/android/junit-runner/src/main/kotlin/dev/jasonpearson/automobile/junit/AutoMobilePlanTypes.kt
@@ -6,14 +6,27 @@ import dev.jasonpearson.automobile.validation.ToolResponse
 import dev.jasonpearson.automobile.validation.ToolResult
 import dev.jasonpearson.automobile.validation.ToolResultEntry
 
+/**
+ * Minimum time the JUnit runner waits on the daemon for one `executePlan` (socket read + inner MCP
+ * `callTool`). Lower values caused premature inner HTTP cancellation and `Operation cancelled` on
+ * long UI plans.
+ *
+ * Keep in sync with `MIN_EXECUTE_PLAN_MCP_TIMEOUT_MS` in `src/daemon/mcpRequestTimeout.ts`.
+ */
+const val MIN_EXECUTE_PLAN_TIMEOUT_MS: Long = 600_000L
+
 /** Configuration options for AutoMobile plan execution. */
 data class AutoMobilePlanExecutionOptions(
-    val timeoutMs: Long = 30000L, // 30 second default
+    val timeoutMs: Long = MIN_EXECUTE_PLAN_TIMEOUT_MS,
     val device: String = "auto",
     val aiAssistance: Boolean = true,
     val maxRetries: Int = 0,
     val debugMode: Boolean = System.getProperty("automobile.debug", "false").toBoolean(),
 )
+
+/** Effective wait budget for a single `executePlan` daemon call (never below [MIN_EXECUTE_PLAN_TIMEOUT_MS]). */
+fun AutoMobilePlanExecutionOptions.effectiveExecutePlanTimeoutMs(): Long =
+    maxOf(timeoutMs, MIN_EXECUTE_PLAN_TIMEOUT_MS)
 
 /** Result of AutoMobile plan execution. */
 data class AutoMobilePlanExecutionResult(

--- a/android/junit-runner/src/test/kotlin/dev/jasonpearson/automobile/junit/AutoMobileTestDemo.kt
+++ b/android/junit-runner/src/test/kotlin/dev/jasonpearson/automobile/junit/AutoMobileTestDemo.kt
@@ -23,10 +23,26 @@ class AutoMobileTestDemo {
   @Test
   fun testAutoMobilePlanExecutionOptionsDefaults() {
     val options = AutoMobilePlanExecutionOptions()
-    assertEquals(30000L, options.timeoutMs)
+    assertEquals(MIN_EXECUTE_PLAN_TIMEOUT_MS, options.timeoutMs)
     assertEquals("auto", options.device)
     assertTrue(options.aiAssistance)
     assertEquals(0, options.maxRetries)
+  }
+
+  @Test
+  fun effectiveExecutePlanTimeoutNeverDropsBelowFloor() {
+    assertEquals(
+        MIN_EXECUTE_PLAN_TIMEOUT_MS,
+        AutoMobilePlanExecutionOptions().effectiveExecutePlanTimeoutMs(),
+    )
+    assertEquals(
+        MIN_EXECUTE_PLAN_TIMEOUT_MS,
+        AutoMobilePlanExecutionOptions(timeoutMs = 30_000L).effectiveExecutePlanTimeoutMs(),
+    )
+    assertEquals(
+        900_000L,
+        AutoMobilePlanExecutionOptions(timeoutMs = 900_000L).effectiveExecutePlanTimeoutMs(),
+    )
   }
 
   @Test

--- a/android/junit-runner/src/test/kotlin/dev/jasonpearson/automobile/junit/SimpleIntegrationTest.kt
+++ b/android/junit-runner/src/test/kotlin/dev/jasonpearson/automobile/junit/SimpleIntegrationTest.kt
@@ -15,7 +15,7 @@ class SimpleIntegrationTest {
   @Test
   fun testAutoMobilePlanExecutionOptionsDefaults() {
     val options = AutoMobilePlanExecutionOptions()
-    assertEquals(30000L, options.timeoutMs)
+    assertEquals(MIN_EXECUTE_PLAN_TIMEOUT_MS, options.timeoutMs)
     assertEquals("auto", options.device)
     assertTrue(options.aiAssistance)
     assertEquals(0, options.maxRetries)

--- a/docs/design-docs/plat/android/junit-runner/ci-daemon-logs.md
+++ b/docs/design-docs/plat/android/junit-runner/ci-daemon-logs.md
@@ -1,0 +1,114 @@
+# Reading the AutoMobile daemon log in CI
+
+Use this when debugging **JUnit / YAML plan** runs that talk to the AutoMobile **daemon** (local checkout via `AUTOMOBILE_DAEMON_LOCAL_PROJECT_PATH` or `bunx @kaeawc/auto-mobile`). The daemon log is the highest-signal place to see **`[LaunchApp]`**, **`CTRL_PROXY`**, **`ConnectionRefused`**, and other server-side errors.
+
+---
+
+## Where the log file is
+
+When the daemon is started through the normal **`--daemon start` / `restart`** flow, AutoMobile creates a **unique directory under `/tmp`** on the **CI runner** (the machine running Gradle), for example:
+
+`/tmp/auto-mobile-daemon-<random>/daemon.log`
+
+Daemon **stdout and stderr** are written to that file.
+
+This is **not** the same path as the Unix socket:
+
+- **Socket (stable):** `/tmp/auto-mobile-daemon-<uid>.sock` (UID = user running the tests, e.g. `id -u` on Linux)
+- **Log file (random subfolder):** use **`find`** or the **`Logs:`** line below
+
+---
+
+## How to see the exact path
+
+On a successful daemon start, the parent process often prints to **stderr** a line like:
+
+```text
+Logs: /tmp/auto-mobile-daemon-xxxxx/daemon.log
+```
+
+Search your **CI job log** for **`Logs:`** if Gradle or the wrapper surfaces stderr.
+
+If that line is missing, locate the file with **`find`** (see below).
+
+---
+
+## GitLab CI: print the log in the job output
+
+Add an **`after_script`** (runs even when tests fail) so the log is visible in the job log:
+
+```yaml
+after_script:
+  - |
+    echo "=== AutoMobile daemon.log (if any) ==="
+    find /tmp -maxdepth 4 -name daemon.log -path '*auto-mobile-daemon*' 2>/dev/null | while read -r f; do
+      echo "--- $f ---"
+      tail -n 500 "$f" || true
+    done
+```
+
+Adjust **`tail -n`** if you need more lines.
+
+---
+
+## GitLab CI: save logs as a downloadable artifact
+
+Useful when logs are large or you want to attach them to a ticket:
+
+```yaml
+artifacts:
+  when: always
+  paths:
+    - daemon-logs/
+  expire_in: 3 days
+
+after_script:
+  - mkdir -p daemon-logs
+  - |
+    find /tmp -maxdepth 4 -name daemon.log -path '*auto-mobile-daemon*' -print 2>/dev/null | while read -r f; do
+      cp "$f" "daemon-logs/$(basename "$(dirname "$f")").log" || true
+    done
+```
+
+Download the job artifact and open the `daemon-logs/*.log` files.
+
+---
+
+## GitHub Actions (same idea)
+
+```yaml
+- name: AutoMobile daemon log
+  if: always()
+  run: |
+    find /tmp -maxdepth 4 -name daemon.log -path '*auto-mobile-daemon*' 2>/dev/null | while read -r f; do
+      echo "--- $f ---"
+      tail -n 500 "$f" || true
+    done
+```
+
+---
+
+## One-off on a shell session
+
+If you have SSH or a debug shell on the same host that ran the daemon:
+
+```bash
+find /tmp -maxdepth 4 -name daemon.log -path '*auto-mobile-daemon*' 2>/dev/null
+tail -n 200 /tmp/auto-mobile-daemon-XXXXXX/daemon.log
+```
+
+---
+
+## Gotchas
+
+- **Same job only:** The log exists on the runner that started the daemon. A **later** CI job does not see that `/tmp` unless you pass an **artifact** or a shared cache (unusual for logs).
+- **Ephemeral runners:** `/tmp` may be wiped between jobs—use **`when: always`** and **`after_script`** on the job that runs tests.
+- **Enable more noise:** JVM **`automobile.debug=true`** can help surface daemon-related paths and diagnostics in test output; see the JUnit runner README for system properties.
+
+---
+
+## Related
+
+- [Plan failure observation](ci-plan-failure-observation.md) — `failedStep.failureObservation` in JUnit output vs launcher foreground
+- [CI app launch troubleshooting](ci-troubleshooting-app-launch.md) — adb verification, CtrlProxy alignment, ui-perf noise, YAML hardening
+- [CI Integration](ci-integration.md) — clone/build AutoMobile, env vars, Gradle wiring

--- a/docs/design-docs/plat/android/junit-runner/ci-daemon-logs.md
+++ b/docs/design-docs/plat/android/junit-runner/ci-daemon-logs.md
@@ -109,6 +109,5 @@ tail -n 200 /tmp/auto-mobile-daemon-XXXXXX/daemon.log
 
 ## Related
 
-- [Plan failure observation](ci-plan-failure-observation.md) — `failedStep.failureObservation` in JUnit output vs launcher foreground
-- [CI app launch troubleshooting](ci-troubleshooting-app-launch.md) — adb verification, CtrlProxy alignment, ui-perf noise, YAML hardening
 - [CI Integration](ci-integration.md) — clone/build AutoMobile, env vars, Gradle wiring
+- [Diagnosing daemon MCP connectivity](diagnosing-daemon-mcp-connectivity.md) — socket path, health check, transport errors

--- a/docs/design-docs/plat/android/junit-runner/ci-integration.md
+++ b/docs/design-docs/plat/android/junit-runner/ci-integration.md
@@ -1,21 +1,137 @@
 # CI Integration
 
-This page covers running AutoMobile JUnit tests in GitHub Actions using an
-[emulator.wtf](https://emulator.wtf) ADB session. The `auto-mobile-tests` job shown here is the
-reference workflow used in this repository.
+This page describes how to run AutoMobile **JUnit runner** tests in CI using an
+[emulator.wtf](https://emulator.wtf) ADB session (cloud emulator, `adb` on the runner talks to it).
 
-## Overview
+**In MkDocs:** Android → JUnitRunner → **CI Integration**.
 
-AutoMobile tests need:
+---
 
-1. A **built and installed app APK** on a connected device
-2. A **running AutoMobile daemon** reachable over the Unix socket
-3. The **CtrlProxy accessibility service** installed on the device
-4. A **Gradle test task** that can reach the daemon and the device via ADB
+## This repository: emulator.wtf setup
 
-The sections below walk through each step.
+Downstream forks and maintainers enable a **separate** job from the default GitHub-hosted emulator.
 
-## Full workflow job
+### How it works (high level)
+
+1. **ew-cli** starts an emulator.wtf session with **`--adb`**, so the managed device appears on the runner’s ADB server (same idea as the generic flow below).
+2. Composite action **`.github/actions/android-emulator-wtf`** installs the CLI, runs **`scripts/android/start-emulator-wtf-session.sh`**, then **`scripts/android/run-emulator-tests.sh`** (CtrlProxy APK install + env), then your Gradle command, then **`scripts/android/stop-emulator-wtf-session.sh`** on `always()`.
+3. **`run-emulator-tests.sh`** sets `AUTOMOBILE_CTRL_PROXY_APK_PATH`, bumps **`AUTOMOBILE_DAEMON_STARTUP_TIMEOUT_MS`** for slow cloud devices, and runs the test script with retries for transient ADB/network errors.
+4. The JUnit runner test process starts (or connects to) the **AutoMobile daemon** and drives the device over ADB like local development.
+
+### Default CI vs emulator.wtf
+
+| Path | Workflow | When it runs |
+|------|-----------|----------------|
+| **GitHub emulator** | `.github/actions/android-emulator` (`reactivecircus/android-emulator-runner`) | Android jobs on, no extra repo variable |
+| **emulator.wtf** | `.github/actions/android-emulator-wtf` | Android jobs on **and** `EMULATOR_WTF_ENABLED` **and** API secret set |
+
+The emulator.wtf job in **`.github/workflows/pull_request.yml`** is named **`junit-runner-emulator-wtf-tests`**. It depends on **`build-android-control-proxy`** for the CtrlProxy APK artifact.
+
+### Enable emulator.wtf for this repo
+
+1. **Repository variable** (Settings → Secrets and variables → Actions → **Variables**):  
+   **`EMULATOR_WTF_ENABLED`** = `true`  
+   The job is gated with:  
+   `vars.EMULATOR_WTF_ENABLED == 'true'`.
+
+2. **Repository secret**: **`EMULATOR_WTF_API_KEY`**  
+   The workflow passes it into the composite action as **`EW_API_TOKEN`**, which **`ew-cli`** requires.
+
+3. **emulator.wtf account**: `start-session --adb` may need to be enabled for your org. If the CLI errors, contact [support@emulator.wtf](mailto:support@emulator.wtf) (see emulator.wtf docs).
+
+4. **Tune session length / device** in the workflow step that calls `android-emulator-wtf`:  
+   `device` (e.g. `model=Pixel7,version=35,gpu=auto`) and `max-time-limit` (e.g. `2m`) are inputs on the composite action.
+
+If the variable is on but the secret is missing, the job fails fast with an explicit error in the **Check API Key** step.
+
+### Source files to read
+
+| Piece | Location |
+|-------|-----------|
+| Job definition | `.github/workflows/pull_request.yml` → `junit-runner-emulator-wtf-tests` |
+| Composite action | `.github/actions/android-emulator-wtf/action.yml` |
+| Session lifecycle | `scripts/android/start-emulator-wtf-session.sh`, `stop-emulator-wtf-session.sh` |
+| CLI install | `scripts/android/install-ew-cli.sh` |
+| APK + Gradle wrapper | `scripts/android/run-emulator-tests.sh` |
+
+---
+
+## Adapting for a client (consuming) Android app
+
+The flow above is wired to **this** repository (`:junit-runner:test`, `android/` layout, CtrlProxy built in-tree). To run **your** app’s AutoMobile JUnit tests on emulator.wtf, keep the same **ideas** (ADB session → install CtrlProxy → run JVM tests that talk to daemon + device) and replace the **inputs** below.
+
+### 1. Reuse vs copy
+
+| Approach | What to do |
+|----------|------------|
+| **Copy scripts + action** | Vendor `scripts/android/start-emulator-wtf-session.sh`, `stop-emulator-wtf-session.sh`, `install-ew-cli.sh`, and `run-emulator-tests.sh` from auto-mobile-mcp into your repo (preserve paths or update workflow references). Copy `.github/actions/android-emulator-wtf` and adjust only if script locations change. |
+| **Minimal custom job** | Implement the same steps inline (ew-cli `start-session --adb`, `adb wait-for-device`, boot wait, install CtrlProxy, Gradle, cleanup). The scripts mainly encode retries, env vars, and session PID handling—worth copying to avoid drift. |
+
+### 2. Workflow and job graph
+
+| In auto-mobile-mcp | In your repo |
+|--------------------|--------------|
+| Job `junit-runner-emulator-wtf-tests` | Name it however you like; keep `needs:` pointing at whatever job **builds** artifacts you require. |
+| `needs: […, build-android-control-proxy]` | `needs` must include a job that produces the **CtrlProxy** APK (or downloads a pinned release) **before** tests. If you also need your **app** APK for `launchApp` / plans, add a job (or step) that builds it and install it with `adb install` **before** or **as part of** the test script. |
+
+### 3. Composite action inputs (`android-emulator-wtf`)
+
+| Input | Replace with |
+|-------|----------------|
+| `working-directory` | Your Gradle project root if not `./android/` (e.g. monorepo `apps/myapp/`). |
+| `script` | The Gradle invocation that runs **your** JVM tests, e.g. `./gradlew :app:testDebugUnitTest --tests 'com.mycompany.automobile.*'` or `./gradlew :feature-ui-tests:test`. Use the same module and task you use locally. |
+| `accessibility-apk-path` | Path to **CtrlProxy** debug (or compatible) APK **relative to `working-directory`**, or absolute from repo root if your wrapper script expects it. Must match what you document for `AUTOMOBILE_CTRL_PROXY_APK_PATH` in [Project Setup](project-setup.md). |
+| `device` / `max-time-limit` | Adjust for API level, GPU, and how long cold boot + app install + tests take; under-provisioning causes flaky timeouts. |
+
+### 4. CtrlProxy APK source
+
+Your client project does not ship `android/control-proxy` unless you vendor it. You still need a **binary** compatible with the junit-runner version you depend on. Typical options:
+
+- Build CtrlProxy from a **git submodule** or fork of auto-mobile-mcp in CI, upload artifact, then pass that path into `run-emulator-tests.sh`.
+- Build it in an earlier workflow job the same way this repo’s `build-android-control-proxy` job does, then `download-artifact` before the emulator.wtf step.
+
+See [CtrlProxy](../control-proxy.md) for what the service does and version alignment expectations.
+
+### 5. App under test (if your YAML plans need it)
+
+`run-emulator-tests.sh` installs **CtrlProxy**, not necessarily **your product APK**. If plans call `launchApp` with your package id, CI must **install that APK** (or rely on a preloaded image—unusual). Add a step or extend your script:
+
+- Build debug/release APK in CI, `adb install -r path/to/your-app.apk`, then run Gradle tests.
+
+Without that, plans that expect your app may fail even when the runner and daemon are fine.
+
+### 6. AutoMobile daemon and CLI on the runner
+
+JUnit tests expect a **daemon** reachable via the usual socket (see [Project Setup → Running tests locally](project-setup.md)). In this repo, **`setup-auto-mobile-npm-package`** prepares the package; Gradle/test code starts or attaches to the daemon. For your app:
+
+- Mirror that setup (Bun/Node, `auto-mobile` on `PATH`, or your internal equivalent).
+- Keep **`AUTOMOBILE_DAEMON_STARTUP_TIMEOUT_MS`** elevated for cloud emulators if you use the same script (already set inside `run-emulator-tests.sh`).
+
+### 7. Secrets, variables, and naming
+
+| Purpose | auto-mobile-mcp | Your repo (example) |
+|---------|-----------------|----------------------|
+| emulator.wtf token | Secret `EMULATOR_WTF_API_KEY` → `EW_API_TOKEN` in the action | Same pattern, or define `EW_API_TOKEN` secret directly if you do not use the rename. |
+| Optional job gate | Variable `EMULATOR_WTF_ENABLED` | Reuse the name or drop the `if:` once you always want cloud devices. |
+
+### 8. Reports and artifacts
+
+Update **artifact paths** and **JUnit report** `report_paths` to your module’s outputs (e.g. `**/build/test-results/**/*.xml` often still works). Heap dump upload paths should match where your tests write them, if any.
+
+---
+
+## Overview (any project)
+
+AutoMobile JUnit tests need:
+
+1. A **device or emulator** visible to `adb`
+2. **CtrlProxy** installed on that device (this repo uses the debug APK from `control-proxy`)
+3. A **running AutoMobile daemon** reachable over the Unix socket (started by the test stack / Gradle as in [Project Setup](project-setup.md))
+4. A **Gradle test task** (e.g. `:junit-runner:test`) that talks to the daemon and ADB
+
+The sections below walk through a **generic** GitHub Actions template you can adapt for other repositories. It uses secret name **`EW_API_TOKEN`** directly; **this repo** maps **`EMULATOR_WTF_API_KEY`** → **`EW_API_TOKEN`** in the workflow (see above).
+
+## Reference workflow job (generic template)
 
 ```yaml
 auto-mobile-tests:
@@ -306,19 +422,32 @@ Killing the `ew-cli` background process ends the emulator.wtf session and stops 
 The JUnit XML reports written to `app/build/test-results/` are picked up and published as a GitHub
 check, making failures visible in the PR Checks tab.
 
-## Required secrets
+## Required secrets and variables
+
+### This repository (`auto-mobile-mcp`)
+
+| Name | Type | Used by |
+|---|---|---|
+| `EMULATOR_WTF_API_KEY` | Secret | Passed as `EW_API_TOKEN` to `android-emulator-wtf` / `ew-cli` |
+| `EMULATOR_WTF_ENABLED` | Variable | Must be `true` for job `junit-runner-emulator-wtf-tests` to run |
+| `GRADLE_ENCRYPTION_KEY` | Secret | Gradle configuration cache (shared with other Android CI jobs) |
+
+### Generic / fork template (YAML below)
 
 | Secret | Used by | How to obtain |
 |---|---|---|
 | `EW_API_TOKEN` | `ew-cli start-session` | [emulator.wtf dashboard](https://emulator.wtf) → API tokens |
 | `GRADLE_ENCRYPTION_KEY` | Gradle configuration cache encryption | Generate a random 256-bit base64 key; store in repository secrets |
 
-Set both secrets under **Settings → Secrets and variables → Actions** in your GitHub repository.
+Configure these under **Settings → Secrets and variables → Actions** in your GitHub repository.
 
 ## Job dependencies
 
-The `auto-mobile-tests` job should depend on `build-apk` so it downloads the APK artifact once it
-is ready:
+**This repository:** the emulator.wtf job uses `needs: [detect-changes, build-android-control-proxy]`
+so the **CtrlProxy** APK artifact is available before tests run.
+
+**Generic template:** if your workflow builds an app APK in an earlier job, depend on that job so the
+test job can download the artifact:
 
 ```yaml
 needs:

--- a/docs/design-docs/plat/android/junit-runner/diagnosing-daemon-mcp-connectivity.md
+++ b/docs/design-docs/plat/android/junit-runner/diagnosing-daemon-mcp-connectivity.md
@@ -1,0 +1,100 @@
+# Diagnosing daemon MCP connectivity (CI)
+
+**In MkDocs:** Android → JUnitRunner → **Diagnosing daemon MCP connectivity**.
+
+Use this when JUnit reports **`Unable to connect. Is the computer able to access the url?`** (often with **`AutoMobile plan execution failed with exit code 1`**) even though **`adb devices`** shows a device and plan YAML was composed on the JVM side.
+
+---
+
+## What it usually means
+
+The JUnit runner talks to the AutoMobile **daemon** over a **Unix domain socket**. The daemon forwards tool calls (including `executePlan`) to the in-process MCP server over **HTTP on loopback** (`http://<host>:<port>/…`).
+
+That inner HTTP hop uses the runtime’s **`fetch`**. If it cannot connect, the socket response fails with a short error message like the one above—**before** your YAML steps run. This is **not** the same as the app under test failing to reach its API (e.g. staging URLs).
+
+When the daemon log includes **`Full error: {"code":"ConnectionRefused",…}`**, that is **ECONNREFUSED**: nothing accepted TCP on the address `fetch` used (often **`localhost` → IPv6 `::1`** while the HTTP server is only on **IPv4 `127.0.0.1`**, or the reverse). Retrying after a few hundred milliseconds does **not** fix that class of failure.
+
+**Noise to ignore:** If you also see **`Device pool initialization timed out after 5000ms`** even though the log already says the device pool initialized successfully, that was a **stale timer** in older daemon builds (fixed by clearing the timeout after the race completes).
+
+---
+
+## Recommended diagnosis order
+
+### 1. Read the daemon log (highest signal)
+
+When **`automobile.debug=true`** (or your CI already prints it), stderr often includes:
+
+- **`Logs: /tmp/auto-mobile-daemon-…/daemon.log`**
+
+Open that file on the failed job artifact or add a step to **`cat`** it after tests. Look for:
+
+- **`Error forwarding request to MCP server`** — confirms the failure is the **HTTP MCP client**, not ADB or YAML.
+- The **stack trace** immediately after that line.
+
+If you do not have the path in logs, search under **`/tmp`** for **`auto-mobile-daemon`** or **`daemon.log`** in the job’s post-failure script.
+
+### 2. Check proxy environment variables
+
+On many CI runners, **`HTTP_PROXY`**, **`HTTPS_PROXY`**, **`http_proxy`**, or **`https_proxy`** are set. Some stacks route **`http://localhost:…`** through the proxy; the proxy cannot reach the job’s own loopback → connection errors that look like “unable to access the url”.
+
+In the same job (before Gradle), log (redact secrets if needed):
+
+```bash
+env | sort | grep -i proxy || true
+```
+
+**Mitigation to try:** ensure loopback is excluded, for example:
+
+- Set **`NO_PROXY=localhost,127.0.0.1,::1`** (and often **`no_proxy`** to the same) for the process that starts the daemon / Gradle test worker, **or**
+- Unset proxy variables for the test step only.
+
+Re-run the job and see if `executePlan` proceeds.
+
+### 3. Verify loopback HTTP from the runner shell
+
+While the daemon is up (or in a one-off debug job), from the same user/environment as tests:
+
+```bash
+curl -svS "http://127.0.0.1:3000/auto-mobile/streamable" -o /dev/null 2>&1 | head -40
+```
+
+Adjust **port** and path if your daemon logs show a different **`MCP_STREAMABLE_PATH`**. If **`curl`** cannot connect, fix networking/bind/proxy before chasing app or YAML issues.
+
+### 4. Rule out IPv4 vs IPv6 `localhost` mismatch
+
+If **`localhost`** resolves to **`::1`** but the HTTP server is only listening on **`127.0.0.1`** (or the reverse), `fetch` can fail. Prefer **`127.0.0.1`** consistently in daemon host configuration and in any manual checks.
+
+### 5. Only after the above: plan and device
+
+If the daemon log shows **`executePlanTool`** / plan steps progressing, then investigate YAML, CtrlProxy/APK, and **`AUTOMOBILE_CTRL_PROXY_APK_PATH`** as described in [CI Integration](ci-integration.md).
+
+---
+
+## Trying the fix before an npm release
+
+The **IPv4 loopback default** and related fixes live in this repo’s **`dist/`** output. You do **not** have to wait for **`@kaeawc/auto-mobile`** on npm if CI can run a **built checkout**:
+
+1. Add the **auto-mobile-mcp** repo to your pipeline (submodule, `git clone`, or copy job artifact).
+2. In that checkout run **`bun install`** (if needed) and **`bun run build`** so **`dist/src/index.js`** exists.
+3. Point the JUnit runner at that tree with **`AUTOMOBILE_DAEMON_LOCAL_PROJECT_PATH`** or Gradle **`automobile.daemon.local.project.path`** (documented in **`android/junit-runner/src/main/kotlin/dev/jasonpearson/automobile/junit/README.md`** in this repo).
+
+The runner will then start **`bun <path>/dist/src/index.js --daemon …`** instead of **`bunx @kaeawc/auto-mobile@latest`**.
+
+**Released package without upgrading:** there is **no** supported env-only workaround for **`ConnectionRefused`** on **`localhost`** today; fixing it requires a build that defaults the daemon HTTP host to **`127.0.0.1`** (or passing **`--host 127.0.0.1`** through **`--daemon start`/`restart`** on a version whose entrypoint forwards **`--host`** to **`--daemon-mode`**).
+
+---
+
+## See also
+
+- [CI Integration](ci-integration.md) — emulator.wtf, env vars, CtrlProxy APK
+- Daemon architecture: [Daemon](../../../mcp/daemon/index.md) (design-docs)
+
+---
+
+## Implementation reference (for maintainers)
+
+| Piece | Location in repo |
+|-------|------------------|
+| Unix socket → MCP HTTP endpoint | `src/daemon/socketServer.ts` (`StreamableHTTPClientTransport`, `createMcpClient`) |
+| HTTP server listen address / port | `src/daemon/daemon.ts` (`mcpEndpoint`, `startHttpServer`) |
+| JUnit prints **`Daemon error:`** | `android/junit-runner/.../AutoMobilePlanExecutor.kt` |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -141,6 +141,8 @@ nav:
               - 'Project Setup': design-docs/plat/android/junit-runner/project-setup.md
               - 'Writing Tests': design-docs/plat/android/junit-runner/writing-tests.md
               - 'CI Integration': design-docs/plat/android/junit-runner/ci-integration.md
+              - 'CI daemon logs': design-docs/plat/android/junit-runner/ci-daemon-logs.md
+              - 'Diagnosing daemon connectivity': design-docs/plat/android/junit-runner/diagnosing-daemon-mcp-connectivity.md
             - 'IDE Plugin':
               - 'Overview': design-docs/plat/android/ide-plugin/overview.md
               - 'Test Recording': design-docs/plat/android/ide-plugin/test-recording.md

--- a/src/daemon/daemon.ts
+++ b/src/daemon/daemon.ts
@@ -44,6 +44,7 @@ import { startAppearanceSyncScheduler, stopAppearanceSyncScheduler } from "../ut
 import { startPerformanceMonitor, stopPerformanceMonitor, getPerformanceMonitor } from "../features/performance/PerformanceMonitor";
 import { listActiveVideoRecordings, stopVideoRecording } from "../server/videoRecordingManager";
 import { Timer, defaultTimer } from "../utils/SystemTimer";
+import { describeUnknownError } from "../utils/describeUnknownError";
 import { FeatureFlagService } from "../features/featureFlags/FeatureFlagService";
 import { serverConfig } from "../utils/ServerConfig";
 
@@ -79,7 +80,9 @@ export class Daemon {
 
   constructor(options: DaemonOptions = {}, installedAppsRepository?: InstalledAppsStore, timer: Timer = defaultTimer) {
     this.port = options.port || DEFAULT_DAEMON_PORT;
-    this.host = options.host || "localhost";
+    // Prefer IPv4 loopback: Bun's fetch and Node's listen can disagree on "localhost" (::1 vs 127.0.0.1),
+    // which surfaces as ConnectionRefused on the Unix-socket → Streamable HTTP MCP hop (common in Linux CI).
+    this.host = options.host || "127.0.0.1";
     this.debug = options.debug || false;
     this.daemonSessionId = randomUUID();
     this.timer = timer;
@@ -284,6 +287,16 @@ export class Daemon {
   private async startHttpServer(): Promise<void> {
     this.httpServer = createHttpServer();
 
+    // Disable default timeouts on this loopback-only server. Node.js 18+ sets
+    // requestTimeout to 300 000 ms (5 min), which kills Streamable HTTP
+    // connections for long-running tool calls like executePlan. With the timeout
+    // active the HTTP response is silently dropped after ~5 min, the
+    // StreamableHTTPServerTransport fires onclose, and the MCP client never
+    // receives the result — even when the tool completed successfully.
+    this.httpServer.requestTimeout = 0;
+    this.httpServer.headersTimeout = 0;
+    this.httpServer.timeout = 0;
+
     this.httpServer.on("request", async (req, res) => {
       // CORS headers for development
       res.setHeader("Access-Control-Allow-Origin", "*");
@@ -432,7 +445,10 @@ export class Daemon {
           // Setup cleanup handlers
           streamableTransport.onclose = async () => {
             if (streamableTransport.sessionId) {
-              const cancelled = await executionTracker.cancelSessionExecutions(streamableTransport.sessionId);
+              const cancelled = await executionTracker.cancelSessionExecutions(
+                streamableTransport.sessionId,
+                "streamable_http_onclose"
+              );
               this.transports.delete(streamableTransport.sessionId);
               logger.info(
                 `Streamable HTTP session closed: ${streamableTransport.sessionId} (cancelled ${cancelled} executions)`
@@ -442,11 +458,14 @@ export class Daemon {
 
           streamableTransport.onerror = async error => {
             if (streamableTransport.sessionId) {
+              const detail = describeUnknownError(error);
               logger.error(
-                `Streamable HTTP transport error for session ${streamableTransport.sessionId}:`,
-                error
+                `Streamable HTTP transport error for session ${streamableTransport.sessionId}: ${detail}`
               );
-              await executionTracker.cancelSessionExecutions(streamableTransport.sessionId);
+              await executionTracker.cancelSessionExecutions(
+                streamableTransport.sessionId,
+                `streamable_http_onerror: ${detail}`
+              );
               this.transports.delete(streamableTransport.sessionId);
             }
           };
@@ -840,21 +859,26 @@ export class Daemon {
    * Waits for device discovery with configurable timeout
    */
   private async initializeDevicePoolWithTimeout(timeoutMs: number): Promise<void> {
+    let timeoutHandle: NodeJS.Timeout | undefined;
     const timeoutPromise = new Promise<void>(resolve => {
-      const timer = defaultTimer.setTimeout(() => {
+      timeoutHandle = defaultTimer.setTimeout(() => {
         logger.warn(`Device pool initialization timed out after ${timeoutMs}ms`);
         resolve();
       }, timeoutMs);
-      // Allow process to exit even if this timer is pending
-      if (typeof (timer as { unref?: () => void }).unref === "function") {
-        (timer as { unref: () => void }).unref();
+      if (typeof (timeoutHandle as { unref?: () => void }).unref === "function") {
+        (timeoutHandle as { unref: () => void }).unref();
       }
     });
 
     const initPromise = this.initializeDevicePool();
 
-    // Race between initialization and timeout
-    await Promise.race([initPromise, timeoutPromise]);
+    try {
+      await Promise.race([initPromise, timeoutPromise]);
+    } finally {
+      if (timeoutHandle !== undefined) {
+        defaultTimer.clearTimeout(timeoutHandle);
+      }
+    }
 
     // Log final device pool status
     const deviceCount = this.devicePool.getTotalDeviceCount();

--- a/src/daemon/manager.ts
+++ b/src/daemon/manager.ts
@@ -299,6 +299,9 @@ export class DaemonManager {
     if (options.port) {
       args.push("--port", options.port.toString());
     }
+    if (options.host) {
+      args.push("--host", options.host);
+    }
     if (options.debug) {
       args.push("--debug");
     }
@@ -580,6 +583,12 @@ function parseDaemonArgs(args: string[]): DaemonOptions {
   for (let i = 0; i < args.length; i++) {
     if (args[i] === "--port") {
       options.port = parseInt(args[i + 1], 10);
+      i++;
+    } else if (args[i] === "--host") {
+      const host = args[i + 1];
+      if (host && !host.startsWith("--")) {
+        options.host = host;
+      }
       i++;
     } else if (args[i] === "--debug") {
       options.debug = true;

--- a/src/daemon/mcpRequestTimeout.ts
+++ b/src/daemon/mcpRequestTimeout.ts
@@ -1,0 +1,25 @@
+import type { DaemonRequest } from "./types";
+
+export const DEFAULT_MCP_REQUEST_TIMEOUT_MS = 30_000;
+
+/**
+ * Floor for `executePlan` when forwarding socket requests to the in-daemon MCP HTTP client.
+ * Short timeouts abort the inner `callTool`, which drops the Streamable HTTP session and
+ * cancels in-flight plan execution (`Operation cancelled`).
+ *
+ * Keep in sync with `MIN_EXECUTE_PLAN_TIMEOUT_MS` in
+ * `android/junit-runner/.../AutoMobilePlanTypes.kt`.
+ */
+export const MIN_EXECUTE_PLAN_MCP_TIMEOUT_MS = 600_000;
+
+export function resolveMcpRequestTimeoutMs(request: DaemonRequest): number {
+  const raw = request.timeoutMs;
+  const base =
+    typeof raw === "number" && Number.isFinite(raw) && raw > 0
+      ? raw
+      : DEFAULT_MCP_REQUEST_TIMEOUT_MS;
+  if (request.method === "tools/call" && request.params?.name === "executePlan") {
+    return Math.max(base, MIN_EXECUTE_PLAN_MCP_TIMEOUT_MS);
+  }
+  return base;
+}

--- a/src/daemon/socketServer.ts
+++ b/src/daemon/socketServer.ts
@@ -3,8 +3,12 @@ import { randomUUID } from "node:crypto";
 import { unlink } from "node:fs/promises";
 import { existsSync } from "node:fs";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
-import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
+import {
+  StreamableHTTPClientTransport,
+  type StreamableHTTPReconnectionOptions,
+} from "@modelcontextprotocol/sdk/client/streamableHttp.js";
 import { logger } from "../utils/logger";
+import { resolveMcpRequestTimeoutMs } from "./mcpRequestTimeout";
 import {
   DaemonRequest,
   DaemonResponse,
@@ -43,7 +47,25 @@ import type { KeyValueType } from "../features/storage/storageTypes";
  * - Forward tool calls to local HTTP MCP server
  * - Return DaemonResponse to clients
  * - Manage concurrent client sessions
+ *
+ * JUnit uses one Unix socket per thread (`DaemonSocketClientManager` ThreadLocal) for parallel
+ * tests, but this server shares a single in-process MCP HTTP client (one Streamable HTTP session).
+ * Concurrent `callTool` on that client corrupts the session and yields transport errors plus
+ * `Operation cancelled` on in-flight `executePlan`. All MCP forwards are serialized below.
+ *
+ * The SDK's Streamable HTTP client may auto-reopen a standalone GET (SSE) after a disconnect.
+ * The server transport allows only one such stream per session; a second GET while the first
+ * is still mapped returns 409 and tears down the session. We disable that auto-reconnect here;
+ * stale sessions are recovered via `getMcpClient()` + "Session not found" retry.
  */
+/** Matches SDK defaults except `maxRetries`, which must stay 0 to avoid duplicate GET SSE. */
+const DAEMON_LOOPBACK_STREAMABLE_HTTP_RECONNECTION: StreamableHTTPReconnectionOptions = {
+  initialReconnectionDelay: 1000,
+  maxReconnectionDelay: 30_000,
+  reconnectionDelayGrowFactor: 1.5,
+  maxRetries: 0,
+};
+
 export class UnixSocketServer {
   private server: NetServer | null = null;
   private sessions: Map<string, SessionContext> = new Map();
@@ -52,6 +74,8 @@ export class UnixSocketServer {
   private daemonState: DaemonStateAccess;
   private mcpClient: Client | null = null;
   private mcpClientPromise: Promise<Client> | null = null;
+  /** Tail of a promise chain that serializes MCP HTTP forwards across all socket connections. */
+  private mcpForwardTail: Promise<void> = Promise.resolve();
   private timer: Timer;
   private featureFlagService: FeatureFlagService | null;
 
@@ -117,30 +141,32 @@ export class UnixSocketServer {
     let buffer = "";
 
     socket.on("data", async data => {
-      try {
-        // Accumulate data into buffer
-        buffer += data.toString();
+      buffer += data.toString();
 
-        // Process complete JSON messages (newline-delimited)
-        const lines = buffer.split("\n");
-        buffer = lines.pop() || ""; // Keep incomplete line in buffer
+      const lines = buffer.split("\n");
+      buffer = lines.pop() || "";
 
-        for (const line of lines) {
-          if (line.trim()) {
-            const request: DaemonRequest = JSON.parse(line);
-            const response = await this.handleRequest(sessionId, request);
-            socket.write(JSON.stringify(response) + "\n");
-          }
+      for (const line of lines) {
+        if (!line.trim()) {
+          continue;
         }
-      } catch (error) {
-        logger.error(`Error processing request from ${sessionId}:`, error);
-        const errorResponse: DaemonResponse = {
-          id: "unknown",
-          type: "mcp_response",
-          success: false,
-          error: error instanceof Error ? error.message : String(error),
-        };
-        socket.write(JSON.stringify(errorResponse) + "\n");
+
+        let requestId = "unknown";
+        try {
+          const request: DaemonRequest = JSON.parse(line);
+          requestId = request.id;
+          const response = await this.handleRequest(sessionId, request);
+          socket.write(JSON.stringify(response) + "\n");
+        } catch (error) {
+          logger.error(`Error processing request ${requestId} from ${sessionId}:`, error);
+          const errorResponse: DaemonResponse = {
+            id: requestId,
+            type: "mcp_response",
+            success: false,
+            error: error instanceof Error ? error.message : String(error),
+          };
+          socket.write(JSON.stringify(errorResponse) + "\n");
+        }
       }
     });
 
@@ -195,23 +221,37 @@ export class UnixSocketServer {
           };
         }
 
-        const mcpClient = await this.getMcpClient();
+        const queueEnterMs = this.timer.now();
+        const result = await this.runExclusiveMcpForward(async () => {
+          const queueWaitMs = this.timer.now() - queueEnterMs;
+          const forwardLabel = UnixSocketServer.describeMcpForwardRequest(request);
+          const timeoutMs = resolveMcpRequestTimeoutMs(request);
+          logger.debug(
+            `[McpForward] start socketSession=${sessionId} requestId=${request.id} ${forwardLabel} queueWaitMs=${queueWaitMs} mcpTimeoutMs=${timeoutMs}`
+          );
+          const forwardStartMs = this.timer.now();
+          try {
+            const mcpClient = await this.getMcpClient();
 
-        let result;
-        try {
-          result = await this.handleIdeRequest(mcpClient, request);
-        } catch (ideError) {
-          const ideErrorMessage = ideError instanceof Error ? ideError.message : String(ideError);
-          if (ideErrorMessage.includes("Session not found")) {
-            logger.warn("MCP client session expired, reconnecting and retrying...");
-            this.mcpClient = null;
-            this.mcpClientPromise = null;
-            const freshClient = await this.getMcpClient();
-            result = await this.handleIdeRequest(freshClient, request);
-          } else {
-            throw ideError;
+            try {
+              return await this.handleIdeRequest(mcpClient, request);
+            } catch (ideError) {
+              const ideErrorMessage = ideError instanceof Error ? ideError.message : String(ideError);
+              if (ideErrorMessage.includes("Session not found")) {
+                logger.warn("MCP client session expired, reconnecting and retrying...");
+                this.mcpClient = null;
+                this.mcpClientPromise = null;
+                const freshClient = await this.getMcpClient();
+                return await this.handleIdeRequest(freshClient, request);
+              }
+              throw ideError;
+            }
+          } finally {
+            logger.debug(
+              `[McpForward] end socketSession=${sessionId} requestId=${request.id} ${forwardLabel} forwardMs=${this.timer.now() - forwardStartMs}`
+            );
           }
-        }
+        });
 
         return {
           id: request.id,
@@ -233,6 +273,32 @@ export class UnixSocketServer {
         };
       }
     });
+  }
+
+  /**
+   * Run one MCP forward at a time. The shared `mcpClient` is not safe under concurrent
+   * `tools/call` (long SSE responses from `executePlan` interleaved with other RPCs).
+   */
+  private runExclusiveMcpForward<T>(fn: () => Promise<T>): Promise<T> {
+    const run = this.mcpForwardTail.then(() => fn());
+    this.mcpForwardTail = run.then(
+      () => undefined,
+      () => undefined
+    );
+    return run;
+  }
+
+  /** Compact label for debug logs (method + tool name or resource URI). */
+  private static describeMcpForwardRequest(request: DaemonRequest): string {
+    if (request.method === "tools/call") {
+      const name = request.params?.name;
+      return `method=tools/call tool=${typeof name === "string" ? name : "?"}`;
+    }
+    if (request.method === "resources/read") {
+      const uri = request.params?.uri;
+      return `method=resources/read uri=${typeof uri === "string" ? uri : "?"}`;
+    }
+    return `method=${request.method}`;
   }
 
   /**
@@ -398,10 +464,7 @@ export class UnixSocketServer {
     mcpClient: Client,
     request: DaemonRequest
   ): Promise<any> {
-    // Extract timeout from request, defaulting to 30 seconds if not provided
-    // (MCP SDK default is 60 seconds, but we prefer faster failure for better UX)
-    const DEFAULT_MCP_REQUEST_TIMEOUT_MS = 30000;
-    const requestOptions = { timeout: request.timeoutMs ?? DEFAULT_MCP_REQUEST_TIMEOUT_MS };
+    const requestOptions = { timeout: resolveMcpRequestTimeoutMs(request) };
 
     switch (request.method) {
       case "tools/list": {
@@ -443,7 +506,12 @@ export class UnixSocketServer {
       logger.error(`ERROR: mcpEndpoint is empty or undefined when creating client!`);
       throw new Error("mcpEndpoint is not set");
     }
-    const transport = new StreamableHTTPClientTransport(this.mcpEndpoint);
+    const transport = new StreamableHTTPClientTransport(
+      new URL(this.mcpEndpoint),
+      {
+        reconnectionOptions: DAEMON_LOOPBACK_STREAMABLE_HTTP_RECONNECTION,
+      }
+    );
 
     const client = new Client(
       {

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,7 +28,8 @@ function parseArgs(): {
   cliMode: boolean;
   cliArgs: string[];
   daemonPort: number | undefined;
-  daemonHost: string;
+  /** Set only when `--host` is passed; otherwise Daemon uses its default (IPv4 loopback). */
+  daemonHost: string | undefined;
   debugPerf: boolean;
   debug: boolean;
   uiPerfMode: boolean;
@@ -54,7 +55,7 @@ function parseArgs(): {
   const args = process.argv.slice(2);
 
   let daemonPort: number | undefined;
-  let daemonHost = "localhost";
+  let daemonHost: string | undefined;
 
   // Detect CLI mode based on command line flag
   const cliMode = args.includes("--cli");
@@ -425,7 +426,7 @@ async function main() {
     if (daemonMode) {
       await startDaemon({
         port: daemonPort,
-        host: daemonHost,
+        ...(daemonHost !== undefined ? { host: daemonHost } : {}),
         debug,
         debugPerf,
       });

--- a/src/server/executionTracker.ts
+++ b/src/server/executionTracker.ts
@@ -86,8 +86,11 @@ export class ExecutionTracker {
     }
   }
 
-  async cancelSessionExecutions(sessionId: string): Promise<number> {
-    return this.cancelExecutionsForKey(sessionId, this.sessionExecutions, "sessionId");
+  /**
+   * @param reason Why the Streamable HTTP session (or equivalent) ended — logged for diagnostics.
+   */
+  async cancelSessionExecutions(sessionId: string, reason: string = "unspecified"): Promise<number> {
+    return this.cancelExecutionsForKey(sessionId, this.sessionExecutions, "sessionId", reason);
   }
 
   async cancelSessionUuidExecutions(sessionUuid: string): Promise<number> {
@@ -147,7 +150,8 @@ export class ExecutionTracker {
   private async cancelExecutionsForKey(
     key: string,
     executionMap: Map<string, Set<string>>,
-    label: "sessionId" | "sessionUuid"
+    label: "sessionId" | "sessionUuid",
+    cancelReason: string = "unspecified"
   ): Promise<number> {
     const executions = executionMap.get(key);
     if (!executions || executions.size === 0) {
@@ -163,7 +167,7 @@ export class ExecutionTracker {
       execution.abortController.abort();
       cancelled++;
       logger.info(
-        `[ExecutionTracker] Cancelled execution ${executionId} for ${label}=${key} (tool=${execution.toolName})`
+        `[ExecutionTracker] Cancelled execution ${executionId} for ${label}=${key} (tool=${execution.toolName}, reason=${cancelReason})`
       );
     }
 

--- a/src/utils/describeUnknownError.ts
+++ b/src/utils/describeUnknownError.ts
@@ -1,0 +1,30 @@
+/**
+ * Produces a single-line string for logging `unknown` errors (including non-Error throws
+ * and empty objects that stringify to `{}`).
+ */
+export function describeUnknownError(value: unknown): string {
+  if (value instanceof Error) {
+    const base = [value.name, value.message].filter(Boolean).join(": ");
+    const stack = value.stack?.split("\n").slice(0, 3).join(" ← ");
+    const cause =
+      "cause" in value && value.cause !== undefined
+        ? describeUnknownError(value.cause as unknown)
+        : "";
+    return [base || "Error", stack, cause ? `cause=${cause}` : ""].filter(Boolean).join(" | ");
+  }
+  if (value === null || value === undefined) {
+    return String(value);
+  }
+  if (typeof value === "object") {
+    const keys = Object.keys(value as object);
+    if (keys.length === 0) {
+      return `${Object.prototype.toString.call(value)} (no enumerable keys)`;
+    }
+    try {
+      return JSON.stringify(value);
+    } catch {
+      return Object.prototype.toString.call(value);
+    }
+  }
+  return String(value);
+}

--- a/test/daemon/mcpRequestTimeout.test.ts
+++ b/test/daemon/mcpRequestTimeout.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, test } from "bun:test";
+import {
+  DEFAULT_MCP_REQUEST_TIMEOUT_MS,
+  MIN_EXECUTE_PLAN_MCP_TIMEOUT_MS,
+  resolveMcpRequestTimeoutMs
+} from "../../src/daemon/mcpRequestTimeout";
+import type { DaemonRequest } from "../../src/daemon/types";
+
+describe("resolveMcpRequestTimeoutMs", () => {
+  test("uses default for non-executePlan tools/call", () => {
+    const request: DaemonRequest = {
+      id: "1",
+      type: "mcp_request",
+      method: "tools/call",
+      params: { name: "observe", arguments: {} }
+    };
+    expect(resolveMcpRequestTimeoutMs(request)).toBe(DEFAULT_MCP_REQUEST_TIMEOUT_MS);
+  });
+
+  test("applies executePlan floor when client omits timeoutMs", () => {
+    const request: DaemonRequest = {
+      id: "1",
+      type: "mcp_request",
+      method: "tools/call",
+      params: { name: "executePlan", arguments: {} }
+    };
+    expect(resolveMcpRequestTimeoutMs(request)).toBe(MIN_EXECUTE_PLAN_MCP_TIMEOUT_MS);
+  });
+
+  test("raises short executePlan timeouts to the floor", () => {
+    const request: DaemonRequest = {
+      id: "1",
+      type: "mcp_request",
+      method: "tools/call",
+      params: { name: "executePlan", arguments: {} },
+      timeoutMs: 180_000
+    };
+    expect(resolveMcpRequestTimeoutMs(request)).toBe(MIN_EXECUTE_PLAN_MCP_TIMEOUT_MS);
+  });
+
+  test("preserves executePlan timeouts above the floor", () => {
+    const request: DaemonRequest = {
+      id: "1",
+      type: "mcp_request",
+      method: "tools/call",
+      params: { name: "executePlan", arguments: {} },
+      timeoutMs: 900_000
+    };
+    expect(resolveMcpRequestTimeoutMs(request)).toBe(900_000);
+  });
+
+  test("falls back to default for NaN timeoutMs", () => {
+    const request: DaemonRequest = {
+      id: "1",
+      type: "mcp_request",
+      method: "tools/call",
+      params: { name: "observe", arguments: {} },
+      timeoutMs: NaN
+    };
+    expect(resolveMcpRequestTimeoutMs(request)).toBe(DEFAULT_MCP_REQUEST_TIMEOUT_MS);
+  });
+
+  test("falls back to default for Infinity timeoutMs", () => {
+    const request: DaemonRequest = {
+      id: "1",
+      type: "mcp_request",
+      method: "tools/call",
+      params: { name: "executePlan", arguments: {} },
+      timeoutMs: Infinity
+    };
+    expect(resolveMcpRequestTimeoutMs(request)).toBe(MIN_EXECUTE_PLAN_MCP_TIMEOUT_MS);
+  });
+
+  test("falls back to default for negative timeoutMs", () => {
+    const request: DaemonRequest = {
+      id: "1",
+      type: "mcp_request",
+      method: "tools/call",
+      params: { name: "observe", arguments: {} },
+      timeoutMs: -1
+    };
+    expect(resolveMcpRequestTimeoutMs(request)).toBe(DEFAULT_MCP_REQUEST_TIMEOUT_MS);
+  });
+
+  test("falls back to default for zero timeoutMs", () => {
+    const request: DaemonRequest = {
+      id: "1",
+      type: "mcp_request",
+      method: "tools/call",
+      params: { name: "observe", arguments: {} },
+      timeoutMs: 0
+    };
+    expect(resolveMcpRequestTimeoutMs(request)).toBe(DEFAULT_MCP_REQUEST_TIMEOUT_MS);
+  });
+});

--- a/test/daemon/socketServerMcpForwardSerialization.test.ts
+++ b/test/daemon/socketServerMcpForwardSerialization.test.ts
@@ -1,0 +1,133 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { Socket } from "node:net";
+import { randomUUID } from "node:crypto";
+import { existsSync } from "node:fs";
+import { unlink } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { UnixSocketServer } from "../../src/daemon/socketServer";
+import { FakeTimer } from "../fakes/FakeTimer";
+import type { DaemonResponse } from "../../src/daemon/types";
+
+interface FakeMcpClient {
+  callTool: (...args: unknown[]) => Promise<unknown>;
+  listTools: () => Promise<{ tools: unknown[] }>;
+  listResources: () => Promise<{ resources: unknown[] }>;
+  readResource: (...args: unknown[]) => Promise<unknown>;
+  listResourceTemplates: () => Promise<{ resourceTemplates: unknown[] }>;
+  close: () => Promise<void>;
+}
+
+function createFakeDaemonState() {
+  return {
+    isInitialized: () => true,
+    getSessionManager: () => ({ getSession: () => null, releaseSession: async () => null }),
+    getDevicePool: () => ({
+      refreshDevices: async () => 0,
+      getStats: () => ({ total: 0, idle: 0, assigned: 0, error: 0 }),
+      releaseDevice: async () => {},
+    }),
+  };
+}
+
+function sendToolsCall(socketPath: string, toolName: string): Promise<DaemonResponse> {
+  return new Promise((resolve, reject) => {
+    const client = new Socket();
+    let buffer = "";
+
+    client.connect(socketPath, () => {
+      const request = JSON.stringify({
+        id: randomUUID(),
+        type: "mcp_request",
+        method: "tools/call",
+        params: { name: toolName, arguments: {} },
+      });
+      client.write(request + "\n");
+    });
+
+    client.on("data", data => {
+      buffer += data.toString();
+      const lines = buffer.split("\n");
+      for (const line of lines) {
+        if (line.trim()) {
+          try {
+            const response = JSON.parse(line) as DaemonResponse;
+            client.destroy();
+            resolve(response);
+            return;
+          } catch {
+            // keep buffering
+          }
+        }
+      }
+    });
+
+    client.on("error", reject);
+    client.on("close", () => {
+      if (!buffer.trim()) {
+        reject(new Error("Connection closed without response"));
+      }
+    });
+  });
+}
+
+describe("UnixSocketServer MCP forward serialization", () => {
+  let socketPath: string;
+  let server: UnixSocketServer;
+  let fakeTimer: FakeTimer;
+
+  beforeEach(async () => {
+    socketPath = join(tmpdir(), `mcp-ser-${randomUUID()}.sock`);
+    fakeTimer = new FakeTimer();
+    fakeTimer.enableAutoAdvance();
+    server = new UnixSocketServer(
+      socketPath,
+      "http://localhost:0/mcp",
+      createFakeDaemonState(),
+      fakeTimer,
+    );
+    await server.start();
+  });
+
+  afterEach(async () => {
+    await server.close();
+    if (existsSync(socketPath)) {
+      await unlink(socketPath);
+    }
+  });
+
+  test("concurrent tools/call from two sockets never overlaps inside callTool", async () => {
+    let inFlight = 0;
+    let maxInFlight = 0;
+
+    (server as any).createMcpClient = async () => {
+      const fake: FakeMcpClient = {
+        listTools: async () => ({ tools: [] }),
+        callTool: async () => {
+          inFlight += 1;
+          maxInFlight = Math.max(maxInFlight, inFlight);
+          await new Promise<void>(resolve => {
+            fakeTimer.setTimeout(resolve, 40);
+          });
+          inFlight -= 1;
+          return { content: [] };
+        },
+        listResources: async () => ({ resources: [] }),
+        readResource: async () => ({ contents: [] }),
+        listResourceTemplates: async () => ({ resourceTemplates: [] }),
+        close: async () => {},
+      };
+      return fake;
+    };
+
+    const [a, b] = await Promise.all([
+      sendToolsCall(socketPath, "observe"),
+      sendToolsCall(socketPath, "observe"),
+    ]);
+
+    expect(a.success).toBe(true);
+    expect(b.success).toBe(true);
+    expect(maxInFlight).toBe(1);
+    expect(inFlight).toBe(0);
+  });
+});

--- a/test/utils/describeUnknownError.test.ts
+++ b/test/utils/describeUnknownError.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, test } from "bun:test";
+import { describeUnknownError } from "../../src/utils/describeUnknownError";
+
+describe("describeUnknownError", () => {
+  test("formats Error with message and truncated stack", () => {
+    const err = new Error("boom");
+    const s = describeUnknownError(err);
+    expect(s).toContain("Error");
+    expect(s).toContain("boom");
+  });
+
+  test("empty object explains missing keys", () => {
+    expect(describeUnknownError({})).toContain("no enumerable keys");
+  });
+
+  test("nested Error cause", () => {
+    const inner = new Error("inner");
+    const outer = new Error("outer", { cause: inner });
+    const s = describeUnknownError(outer);
+    expect(s).toContain("outer");
+    expect(s).toContain("cause=");
+    expect(s).toContain("inner");
+  });
+});


### PR DESCRIPTION
Closes #1938, #1939, #1942, #1943, #1944

## Summary

The daemon's internal MCP HTTP server and Unix socket forwarding layer had multiple failure modes causing CI test timeouts, `ECONNREFUSED`, `Operation cancelled`, and silently lost responses. This PR fixes five distinct transport-layer issues that together caused frequent, hard-to-diagnose CI failures.

## Changes

### A. Align loopback host to IPv4 (`127.0.0.1`)

**Problem:** On Linux CI, `localhost` can resolve to `::1` (IPv6) for one component and `127.0.0.1` (IPv4) for another. Bun's `fetch` and Node's `http.Server.listen` disagree, causing `ECONNREFUSED` on the internal Unix-socket → Streamable HTTP MCP hop.

**Fix:** Default `this.host` to `"127.0.0.1"` instead of `"localhost"`. The `--host` CLI flag still overrides (e.g. `--host localhost` or `--host ::1` restores old behavior). Also threads `--host` through `DaemonManager` arg building and parsing so the override propagates to spawned daemon processes.

**Mechanism:** In `index.ts`, `daemonHost` changed from `string` (always `"localhost"`) to `string | undefined` (only set when `--host` is explicitly passed). The Daemon constructor only receives `host` in its options when the user passes `--host`, so the new `"127.0.0.1"` default in the constructor actually takes effect. Previously `index.ts` always passed `host: "localhost"`, which would have overridden any constructor default.

**Risk:** Low. Both values only accept loopback connections. The only breaking scenario would be an IPv6-only loopback host with no IPv4 — effectively impossible for Android emulator environments. macOS resolves `localhost` to `127.0.0.1` anyway so this is a no-op locally.

**Also in this change:** Clears the device-pool initialization timeout after the `Promise.race` completes (via `try/finally`). Previously, if device discovery finished before the timeout, the stale `setTimeout` callback would still fire and log a misleading "timed out" warning. The `clearTimeout` is a no-op if the timeout already fired, so there's no risk to the timeout-wins path.

**Files:** `src/daemon/daemon.ts`, `src/daemon/manager.ts`, `src/index.ts`, `docs/.../ci-integration.md` (expanded with this-repo emulator.wtf setup and consumer-app adaptation guide; no code changes)

---

### B. Serialize MCP socket forwards

**Problem:** Parallel JUnit test threads each have their own Unix socket connection, but the daemon shares a single Streamable HTTP client session to its own MCP HTTP server. Concurrent `callTool` calls on that one session corrupt the HTTP transport, producing `Operation cancelled` on in-flight `executePlan` and random transport errors.

**Fix:** Introduce `runExclusiveMcpForward` - a promise-chain serializer that ensures only one `callTool` is in flight at a time on the shared MCP client. Add `[McpForward]` debug logging (queue wait time, tool name, duration). Tag `executionTracker.cancelSessionExecutions` with `onclose` vs `onerror` reason strings for diagnosability.

**Why `describeUnknownError`:** The `StreamableHTTPServerTransport.onerror` callback receives `unknown`-typed errors that are often empty objects `{}` or non-`Error` values - useless when reading CI daemon logs. `describeUnknownError` handles all the weird cases (empty objects, `.cause` chains, non-Error throws) and produces a single readable log line. It feeds into both the `onerror` log message and the `cancelSessionExecutions` reason string so you can see *why* a session was torn down.

**`executionTracker.ts`:** Added an optional `reason` parameter (default `"unspecified"`) to `cancelSessionExecutions` and the internal `cancelExecutionsForKey`. The reason is included in the log line. Existing callers outside this PR are unaffected since the parameter has a default value.

**Risk:** The serialization queue means parallel JUnit threads' MCP calls are now sequential. If thread A runs a 5-minute `executePlan`, thread B's calls wait in the queue. However, the old concurrent behavior was broken - it corrupted the shared Streamable HTTP session - so this replaces "sometimes corrupts" with "correctly queued." Single-fork configurations (`maxParallelForks = 1`) see no overhead.

**Files:** `src/daemon/socketServer.ts`, `src/daemon/daemon.ts`, `src/server/executionTracker.ts`, `src/utils/describeUnknownError.ts` (new), `test/daemon/socketServerMcpForwardSerialization.test.ts` (new), `test/utils/describeUnknownError.test.ts` (new)

---

### C. Disable Streamable HTTP SSE auto-reconnect

**Problem:** The MCP SDK's Streamable HTTP client can auto-open a second standalone GET (SSE listener) after a disconnect. The server transport allows only one SSE stream per session - a second GET while the first is still mapped returns HTTP 409 and tears down the entire session, cancelling any in-flight tool calls.

**Fix:** Set `maxRetries: 0` on the loopback client's `StreamableHTTPReconnectionOptions`. Stale sessions are recovered via the existing "Session not found" retry in `runExclusiveMcpForward`.

**Risk:** None. The previous auto-reconnect behavior was actively harmful (caused 409 teardowns). Disabling it is strictly better; stale sessions already have a recovery path.

**Files:** `src/daemon/socketServer.ts`

---

### D. Floor `executePlan` MCP timeout to 10 minutes

**Problem:** The JUnit runner could pass a short `timeoutMs` (30s or 180s) which propagated to the inner Streamable HTTP `callTool`. When the timeout fired mid-plan, the SDK aborted the HTTP request, the server transport fired `onclose`, and `executionTracker` cancelled the execution — producing `Operation cancelled` even though the plan was progressing normally.

**Fix:** Enforce a 10-minute floor (`MIN_EXECUTE_PLAN_MCP_TIMEOUT_MS = 600_000`) on both the JUnit side (`effectiveExecutePlanTimeoutMs()`) and the daemon socket server side (`resolveMcpRequestTimeoutMs()`). Extracted timeout logic into `src/daemon/mcpRequestTimeout.ts` with unit tests. `resolveMcpRequestTimeoutMs` also guards against non-finite inputs (`NaN`, `Infinity`, negative, zero) - falling back to the 30s default rather than propagating a broken timeout into `callTool`.

**Scope:** The floor applies **only to `executePlan`** - `resolveMcpRequestTimeoutMs` checks `request.method === "tools/call" && request.params?.name === "executePlan"` and only then applies `Math.max(base, 600_000)`. All other tools (`observe`, `tapOn`, `listTools`, etc.) keep whatever timeout the client sends, defaulting to 30s. The old code applied a flat 30s to everything including `executePlan`, which is what caused premature `Operation cancelled` on plans that were progressing normally.

**Kotlin side:** `AutoMobilePlanExecutionOptions.timeoutMs` default changed from `30_000L` to `600_000L`, and a new `effectiveExecutePlanTimeoutMs()` extension enforces the same floor. This means existing tests using default options will now wait up to 10 minutes instead of 30 seconds for `executePlan`. The 30s default was never viable for plan execution (plans typically run 1-10 minutes), so the old default always led to premature timeouts.

**Cross-language sync:** The `600_000` constant is defined in both TypeScript (`MIN_EXECUTE_PLAN_MCP_TIMEOUT_MS` in `src/daemon/mcpRequestTimeout.ts`) and Kotlin (`MIN_EXECUTE_PLAN_TIMEOUT_MS` in `AutoMobilePlanTypes.kt`). Both files carry `Keep in sync with ...` comments pointing to their counterpart to prevent drift.

**Files:** `src/daemon/socketServer.ts`, `src/daemon/mcpRequestTimeout.ts` (new), `test/daemon/mcpRequestTimeout.test.ts` (new), `android/.../AutoMobilePlanExecutor.kt`, `android/.../AutoMobilePlanTypes.kt`, `android/.../AutoMobileTestDemo.kt` (test), `android/.../SimpleIntegrationTest.kt` (test)

---

### E. Disable HTTP server timeouts + fix `id:unknown` error responses

**Problem 1 — HTTP timeout:** The daemon's loopback HTTP server is created with `node:http.createServer()` with no timeout configuration. Node.js 18+ defaults `requestTimeout` to 300,000ms (5 minutes). When `executePlan` runs for ~5 minutes via the Streamable HTTP transport, the server terminates the HTTP connection. The `StreamableHTTPServerTransport.onclose` fires, but the tool result is lost because the response stream is already torn down. The MCP SDK client never receives the result and waits until its own timeout. The JUnit runner also times out - even though the plan completed successfully on the daemon.

**Fix:** Set `requestTimeout = 0`, `headersTimeout = 0`, and `timeout = 0` on the loopback HTTP server. This is safe because the server only accepts connections from the in-process MCP client, never from external sources.

**Problem 2 - id:unknown:** The socket server's `handleConnection` data handler had a single outer `try/catch` that sent error responses with `id: "unknown"`. The JUnit client keys its `CompletableFuture` map by request ID, so an `id: "unknown"` response never completes any pending future - causing a silent timeout instead of a proper error.

**Fix:** Move error handling inside the per-line loop. Each line gets its own `try/catch` with the actual `request.id` (falling back to `"unknown"` only if JSON parsing itself fails). This ensures the JUnit client receives a matchable error response and fails fast instead of hanging for the full timeout duration.

**Risk:** Strictly better. Errors that previously caused mysterious 10-minute timeouts will now surface immediately as proper error responses. A bad line no longer aborts processing of subsequent lines in the same data event.

**Files:** `src/daemon/daemon.ts`, `src/daemon/socketServer.ts`

---

## Testing

- All existing daemon tests pass (191 tests across 23 files)
- New tests: `socketServerMcpForwardSerialization.test.ts` (serialization + queue timeout), `mcpRequestTimeout.test.ts` (timeout floor logic), `describeUnknownError.test.ts`
- Build passes cleanly

## How these interact

The five fixes address different stages of the same request path:

```
JUnit runner
  → Unix socket (per-thread)
    → UnixSocketServer.handleConnection [E: id:unknown fix]
      → runExclusiveMcpForward [B: serialization, D: timeout floor]
        → StreamableHTTPClientTransport [C: SSE reconnect disabled]
          → HTTP server [A: 127.0.0.1 bind, E: request timeout disabled]
            → StreamableHTTPServerTransport
              → MCP tool handler (executePlan)
```

Without all five, fixing one layer just moves the failure to the next.
