### PR TITLE
Fail-Fast on Device Disconnect + Screenshot Pressure

### DIFF
--- a/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/WebSocketServer.kt
+++ b/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/WebSocketServer.kt
@@ -262,11 +262,11 @@ class WebSocketServer(
                     val connectionId = connectionCount.incrementAndGet()
                     Log.d(TAG, "Client #$connectionId connected")
 
-                    synchronized(connections) { connections.add(this) }
-
                     try {
-                      // Send initial connection message
+                      // Send connection greeting before registering for broadcasts
                       send(Frame.Text("""{"type":"connected","id":$connectionId}"""))
+
+                      synchronized(connections) { connections.add(this) }
 
                       // Listen for incoming messages
                       for (frame in incoming) {

--- a/android/junit-runner/src/main/kotlin/dev/jasonpearson/automobile/junit/DaemonSocketClient.kt
+++ b/android/junit-runner/src/main/kotlin/dev/jasonpearson/automobile/junit/DaemonSocketClient.kt
@@ -287,21 +287,45 @@ internal object DaemonSocketPaths {
       val entryPoint = File(localPath, "dist/src/index.js")
       if (entryPoint.exists()) {
         val runtime = resolveRuntimePath()
-        return listOf(runtime, entryPoint.absolutePath, "--daemon", subCommand)
+        return withNoNavigationScreenshots(
+          listOf(runtime, entryPoint.absolutePath, "--daemon", subCommand),
+        )
       }
     }
 
-    // Prefer bunx, fall back to npx, then the global binary.
     val runner = resolvePackageRunner()
-    return if (runner != null) {
-      if (runner.endsWith("npx")) {
-        listOf(runner, "-y", "@kaeawc/auto-mobile@latest", "--daemon", subCommand)
-      } else {
-        listOf(runner, "@kaeawc/auto-mobile@latest", "--daemon", subCommand)
-      }
-    } else {
-      listOf("auto-mobile", "--daemon", subCommand)
+    val command =
+        if (runner != null) {
+          if (runner.endsWith("npx")) {
+            listOf(runner, "-y", "@kaeawc/auto-mobile@latest", "--daemon", subCommand)
+          } else {
+            listOf(runner, "@kaeawc/auto-mobile@latest", "--daemon", subCommand)
+          }
+        } else {
+          listOf("auto-mobile", "--daemon", subCommand)
+        }
+
+    return withNoNavigationScreenshots(command)
+  }
+
+  /**
+   * When true, the spawned daemon passes `--no-navigation-screenshots` to disable screenshot
+   * capture on navigation events. Reduces emulator resource usage in CI where navigation graph
+   * thumbnails are not needed.
+   */
+  private fun noNavigationScreenshotsRequested(): Boolean {
+    if (SystemPropertyCache.getBoolean("automobile.daemon.no.navigation.screenshots", false)) {
+      return true
     }
+    val env = System.getenv("AUTOMOBILE_DAEMON_NO_NAVIGATION_SCREENSHOTS")?.trim()?.lowercase().orEmpty()
+    return env == "1" || env == "true" || env == "yes"
+  }
+
+  private fun withNoNavigationScreenshots(command: List<String>): List<String> {
+    if (!noNavigationScreenshotsRequested()) {
+      return command
+    }
+    return command + "--no-navigation-screenshots"
   }
 
   private fun resolveLocalProjectPath(): String? {

--- a/src/daemon/daemon.ts
+++ b/src/daemon/daemon.ts
@@ -112,6 +112,9 @@ export class Daemon {
     if (options.noUiPerfMode) {
       serverConfig.setUiPerfMode(false);
     }
+    if (options.noNavigationScreenshots) {
+      serverConfig.setNavigationScreenshotsEnabled(false);
+    }
     if (options.memPerfAudit) {
       serverConfig.setMemPerfAuditMode(true);
     }
@@ -798,6 +801,17 @@ export class Daemon {
               this.stoppingRecordings.delete(recordingId);
             }
           }
+
+          // Cancel active executions and release the session so the test fails
+          // fast instead of waiting for the full MCP request timeout.
+          const sessionId = this.sessionManager.getSessionForDevice(deviceId);
+          if (sessionId) {
+            logger.warn(
+              `[Daemon] Device ${deviceId} disconnected — cancelling session ${sessionId}`
+            );
+            await this.cancelAndReleaseSession(sessionId);
+          }
+
           this.deviceDisconnectMisses.delete(deviceId);
         }
       } catch (error) {

--- a/src/daemon/manager.ts
+++ b/src/daemon/manager.ts
@@ -338,6 +338,9 @@ export class DaemonManager {
     if (options.noUiPerfMode) {
       args.push("--no-ui-perf-mode");
     }
+    if (options.noNavigationScreenshots) {
+      args.push("--no-navigation-screenshots");
+    }
     if (options.memPerfAudit) {
       args.push("--mem-perf-audit");
     }
@@ -624,6 +627,8 @@ function parseDaemonArgs(args: string[]): DaemonOptions {
       options.dismissKeyboardAfterInput = true;
     } else if (args[i] === "--no-ui-perf-mode") {
       options.noUiPerfMode = true;
+    } else if (args[i] === "--no-navigation-screenshots") {
+      options.noNavigationScreenshots = true;
     } else if (args[i] === "--mem-perf-audit") {
       options.memPerfAudit = true;
     } else if (args[i] === "--accessibility-audit") {

--- a/src/daemon/sessionManager.ts
+++ b/src/daemon/sessionManager.ts
@@ -203,6 +203,13 @@ export class SessionManager {
   }
 
   /**
+   * Get session assigned to a device (reverse lookup)
+   */
+  getSessionForDevice(deviceId: string): string | null {
+    return this.deviceSessionMap.get(deviceId) ?? null;
+  }
+
+  /**
    * Release a session and free its device
    *
    * Called when a test completes or times out.

--- a/src/daemon/socketServer.ts
+++ b/src/daemon/socketServer.ts
@@ -222,19 +222,28 @@ export class UnixSocketServer {
         }
 
         const queueEnterMs = this.timer.now();
+        const totalTimeoutMs = resolveMcpRequestTimeoutMs(request);
+
         const result = await this.runExclusiveMcpForward(async () => {
           const queueWaitMs = this.timer.now() - queueEnterMs;
+          const remainingTimeoutMs = totalTimeoutMs - queueWaitMs;
           const forwardLabel = UnixSocketServer.describeMcpForwardRequest(request);
-          const timeoutMs = resolveMcpRequestTimeoutMs(request);
           logger.debug(
-            `[McpForward] start socketSession=${sessionId} requestId=${request.id} ${forwardLabel} queueWaitMs=${queueWaitMs} mcpTimeoutMs=${timeoutMs}`
+            `[McpForward] start socketSession=${sessionId} requestId=${request.id} ${forwardLabel} queueWaitMs=${queueWaitMs} remainingTimeoutMs=${remainingTimeoutMs}`
           );
+
+          if (remainingTimeoutMs <= 0) {
+            throw new Error(
+              `MCP forward timeout: spent ${queueWaitMs}ms waiting in queue (budget was ${totalTimeoutMs}ms)`
+            );
+          }
+
           const forwardStartMs = this.timer.now();
           try {
             const mcpClient = await this.getMcpClient();
 
             try {
-              return await this.handleIdeRequest(mcpClient, request);
+              return await this.handleIdeRequest(mcpClient, request, remainingTimeoutMs);
             } catch (ideError) {
               const ideErrorMessage = ideError instanceof Error ? ideError.message : String(ideError);
               if (ideErrorMessage.includes("Session not found")) {
@@ -242,7 +251,13 @@ export class UnixSocketServer {
                 this.mcpClient = null;
                 this.mcpClientPromise = null;
                 const freshClient = await this.getMcpClient();
-                return await this.handleIdeRequest(freshClient, request);
+                const retryRemainingMs = remainingTimeoutMs - (this.timer.now() - forwardStartMs);
+                if (retryRemainingMs <= 0) {
+                  throw new Error(
+                    `MCP forward timeout: no budget remaining after session reconnect (elapsed ${this.timer.now() - forwardStartMs}ms of ${remainingTimeoutMs}ms)`
+                  );
+                }
+                return await this.handleIdeRequest(freshClient, request, retryRemainingMs);
               }
               throw ideError;
             }
@@ -462,9 +477,10 @@ export class UnixSocketServer {
 
   private async handleIdeRequest(
     mcpClient: Client,
-    request: DaemonRequest
+    request: DaemonRequest,
+    timeoutMs: number
   ): Promise<any> {
-    const requestOptions = { timeout: resolveMcpRequestTimeoutMs(request) };
+    const requestOptions = { timeout: timeoutMs };
 
     switch (request.method) {
       case "tools/list": {

--- a/src/daemon/types.ts
+++ b/src/daemon/types.ts
@@ -116,6 +116,8 @@ export interface DaemonOptions {
   skipCtrlProxyDownload?: boolean;
   /** Enable MCP recording feature flag */
   mcpRecording?: boolean;
+  /** Disable navigation screenshots */
+  noNavigationScreenshots?: boolean;
 }
 
 /**

--- a/src/features/featureFlags/FeatureFlagApplier.ts
+++ b/src/features/featureFlags/FeatureFlagApplier.ts
@@ -51,6 +51,9 @@ export class DefaultFeatureFlagApplier implements FeatureFlagApplier {
       case "mcp-recording":
         serverConfig.setMcpRecordingEnabled(enabled);
         break;
+      case "navigation-screenshots":
+        serverConfig.setNavigationScreenshotsEnabled(enabled);
+        break;
     }
   }
 }

--- a/src/features/featureFlags/FeatureFlagDefinitions.ts
+++ b/src/features/featureFlags/FeatureFlagDefinitions.ts
@@ -9,7 +9,8 @@ export type FeatureFlagKey =
   | "accessibility-auto-detect"
   | "raw-element-search"
   | "ai-recovery"
-  | "mcp-recording";
+  | "mcp-recording"
+  | "navigation-screenshots";
 
 export type FeatureFlagConfig = Record<string, unknown>;
 
@@ -103,5 +104,11 @@ export const FEATURE_FLAG_DEFINITIONS: FeatureFlagDefinition[] = [
     label: "MCP call recording",
     description: "Enable the recordSteps tool to capture MCP tool calls as replayable YAML test plans.",
     defaultValue: false,
+  },
+  {
+    key: "navigation-screenshots",
+    label: "Navigation screenshots",
+    description: "Capture screenshots on navigation events to enrich the navigation graph. Disable to reduce device resource usage.",
+    defaultValue: true,
   },
 ];

--- a/src/features/observe/android/CtrlProxyClient.ts
+++ b/src/features/observe/android/CtrlProxyClient.ts
@@ -46,6 +46,7 @@ import {
   computeChecksum,
 } from "../ScreenshotBackoffScheduler";
 import { getFailureRecorder } from "../../failures/FailureRecorder";
+import { serverConfig } from "../../../utils/ServerConfig";
 import { TelemetryRecorder } from "../../telemetry/TelemetryRecorder";
 import { getPerformanceMonitor } from "../../performance/PerformanceMonitor";
 import type { StackTraceElement } from "../../../server/failuresResources";
@@ -1478,6 +1479,9 @@ export class CtrlProxyClient extends DeviceServiceClient implements CtrlProxy {
 
       this.hierarchyNavigationDetector.setNavigationCallback(info => {
         if (info.packageName && info.screenFingerprint) {
+          if (!serverConfig.isNavigationScreenshotsEnabled()) {
+            return;
+          }
           const appId = info.packageName;
           const screenName = `screen_${info.screenFingerprint.substring(0, 12)}`;
           NavigationScreenshotManager.getInstance()
@@ -1884,7 +1888,7 @@ export class CtrlProxyClient extends DeviceServiceClient implements CtrlProxy {
           logger.info(`[CTRL_PROXY] Navigation event: ${event.destination} (app: ${event.applicationId})`);
           await this.getNavigationGraphManager().recordNavigationEvent(event);
 
-          if (event.applicationId && event.destination) {
+          if (event.applicationId && event.destination && serverConfig.isNavigationScreenshotsEnabled()) {
             NavigationScreenshotManager.getInstance()
               .captureAndStore(this.device, this.adb, event.applicationId, event.destination)
               .then(screenshotPath => {

--- a/src/features/observe/ios/CtrlProxyClient.ts
+++ b/src/features/observe/ios/CtrlProxyClient.ts
@@ -28,6 +28,7 @@ import { shouldUseHostControl, getHostControlHost } from "../../../utils/hostCon
 import { isRunningInDocker } from "../../../utils/dockerEnv";
 import { IOSCtrlProxyManager, CtrlProxyIosManager } from "../../../utils/IOSCtrlProxyManager";
 import { NavigationGraphManager } from "../../navigation/NavigationGraphManager";
+import { serverConfig } from "../../../utils/ServerConfig";
 import { NavigationScreenshotManager } from "../../navigation/NavigationScreenshotManager";
 import {
   HierarchyNavigationDetector,
@@ -648,44 +649,41 @@ export class CtrlProxyClient extends DeviceServiceClient implements CtrlProxySer
             const navSource = (p.source as string) ?? null;
             const navArgs = (p.arguments as Record<string, string>) ?? null;
             const navMeta = (p.metadata as Record<string, string>) ?? null;
-            // Capture screenshot FIRST, then record with URI so the push includes it
             let screenshotUri: string | null = null;
             if (applicationId && destination) {
-              try {
-                const path = await this.captureNavigationScreenshot(applicationId, destination);
-                if (path) {
-                // Record in navigation graph to get the node ID for the URI
-                  await this.getNavigationGraphManager().recordNavigationEvent({
-                    applicationId, destination, source: navSource,
-                    arguments: navArgs ?? {}, metadata: navMeta ?? {},
-                    triggeringInteraction: null,
-                  });
-                  await this.getNavigationGraphManager().updateNodeScreenshot(applicationId, destination, path);
-                  // Look up the node ID for the screenshot URI
-                  try {
-                    const { getDatabase } = await import("../../../db");
-                    const db = getDatabase();
-                    const node = await db
-                      .selectFrom("navigation_nodes")
-                      .select(["id"])
-                      .where("app_id", "=", applicationId)
-                      .where("screen_name", "=", destination)
-                      .executeTakeFirst();
-                    if (node) {
-                      screenshotUri = `automobile:navigation/nodes/${node.id}/screenshot`;
-                    }
-                  } catch { /* non-fatal */ }
-                }
-              } catch { /* non-fatal — record event even without screenshot */ }
-            }
-            // Only publish if we have a screenshot
-            if (screenshotUri) {
-              await recorder.recordNavigationEvent({
-                timestamp: ts, applicationId,
-                destination, source: navSource, arguments: navArgs, metadata: navMeta,
-                screenshotUri,
+              await this.getNavigationGraphManager().recordNavigationEvent({
+                applicationId, destination, source: navSource,
+                arguments: navArgs ?? {}, metadata: navMeta ?? {},
+                triggeringInteraction: null,
               });
+
+              if (serverConfig.isNavigationScreenshotsEnabled()) {
+                try {
+                  const path = await this.captureNavigationScreenshot(applicationId, destination);
+                  if (path) {
+                    await this.getNavigationGraphManager().updateNodeScreenshot(applicationId, destination, path);
+                    try {
+                      const { getDatabase } = await import("../../../db");
+                      const db = getDatabase();
+                      const node = await db
+                        .selectFrom("navigation_nodes")
+                        .select(["id"])
+                        .where("app_id", "=", applicationId)
+                        .where("screen_name", "=", destination)
+                        .executeTakeFirst();
+                      if (node) {
+                        screenshotUri = `automobile:navigation/nodes/${node.id}/screenshot`;
+                      }
+                    } catch { /* non-fatal */ }
+                  }
+                } catch { /* non-fatal */ }
+              }
             }
+            await recorder.recordNavigationEvent({
+              timestamp: ts, applicationId,
+              destination, source: navSource, arguments: navArgs, metadata: navMeta,
+              screenshotUri,
+            });
             break;
           }
           case "custom": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -49,6 +49,7 @@ function parseArgs(): {
   skipCtrlProxyDownload: boolean;
   dismissKeyboardAfterInput: boolean;
   mcpRecording: boolean;
+  navigationScreenshots: boolean;
   noProxy: boolean;
   noDaemon: boolean;
   } {
@@ -105,6 +106,7 @@ function parseArgs(): {
   const networkMockable = args.includes("--network-mockable");
   const dismissKeyboardAfterInput = args.includes("--dismiss-keyboard-after-input");
   const mcpRecording = args.includes("--mcp-recording");
+  const navigationScreenshots = !args.includes("--no-navigation-screenshots");
   let planExecutionLockScope: PlanExecutionLockScope = "session";
   const videoRecordingDefaults: VideoRecordingConfigInput = {};
 
@@ -298,6 +300,7 @@ function parseArgs(): {
     networkMockable,
     dismissKeyboardAfterInput,
     mcpRecording,
+    navigationScreenshots,
     noProxy,
     noDaemon,
   };
@@ -368,6 +371,7 @@ async function main() {
       networkMockable,
       dismissKeyboardAfterInput,
       mcpRecording,
+      navigationScreenshots,
       noProxy,
       noDaemon,
     } = parseArgs();
@@ -421,6 +425,11 @@ async function main() {
       }
       await featureFlagService.setFlag(key, true, config);
       logger.info(`Feature flag enabled (${flagLabel})`);
+    }
+
+    if (!navigationScreenshots) {
+      await featureFlagService.setFlag("navigation-screenshots", false);
+      logger.info("Navigation screenshots disabled (--no-navigation-screenshots)");
     }
 
     if (daemonMode) {

--- a/src/utils/ServerConfig.ts
+++ b/src/utils/ServerConfig.ts
@@ -28,6 +28,7 @@ class ServerConfig {
   private _networkMockableEnabled: boolean = false;
   private _mcpRecordingEnabled: boolean = false;
   private _dismissKeyboardAfterInputEnabled: boolean = false;
+  private _navigationScreenshotsEnabled: boolean = true;
 
   private constructor() {}
 
@@ -144,6 +145,14 @@ class ServerConfig {
 
   isDismissKeyboardAfterInputEnabled(): boolean {
     return this._dismissKeyboardAfterInputEnabled;
+  }
+
+  setNavigationScreenshotsEnabled(enabled: boolean): void {
+    this._navigationScreenshotsEnabled = enabled;
+  }
+
+  isNavigationScreenshotsEnabled(): boolean {
+    return this._navigationScreenshotsEnabled;
   }
 
 }

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -65,6 +65,47 @@ export const LogLevel = {
 
 export type LogLevel = typeof LogLevel[keyof typeof LogLevel];
 
+/**
+ * Parse `AUTOMOBILE_LOG_LEVEL` values: debug, info, warn|warning, error, none|silent.
+ * Returns null if unset, blank, or unrecognized (caller keeps current level).
+ */
+export function parseAutomobileLogLevel(value: string | undefined): LogLevel | null {
+  if (value === undefined) {
+    return null;
+  }
+  const v = value.trim().toLowerCase();
+  if (v.length === 0) {
+    return null;
+  }
+  switch (v) {
+    case "debug":
+      return LogLevel.DEBUG;
+    case "info":
+      return LogLevel.INFO;
+    case "warn":
+    case "warning":
+      return LogLevel.WARN;
+    case "error":
+      return LogLevel.ERROR;
+    case "none":
+    case "silent":
+      return LogLevel.NONE;
+    default:
+      return null;
+  }
+}
+
+/**
+ * If `process.env.AUTOMOBILE_LOG_LEVEL` is set to a recognized level, apply it to the global logger.
+ * Intended for CI / daemon runs (quiet INFO chatter while keeping WARN/ERROR).
+ */
+export function applyAutomobileLogLevelFromEnvironment(): void {
+  const parsed = parseAutomobileLogLevel(process.env.AUTOMOBILE_LOG_LEVEL);
+  if (parsed !== null) {
+    currentLogLevel = parsed;
+  }
+}
+
 // Default to INFO level in production, can be overridden
 let currentLogLevel: LogLevel = LogLevel.INFO;
 

--- a/src/utils/plan/PlanExecutor.ts
+++ b/src/utils/plan/PlanExecutor.ts
@@ -251,6 +251,7 @@ export class DefaultPlanExecutor implements PlanExecutor {
           // Execute the tool
           logger.info(`[PLAN_STEP_${i + 1}] Calling ${step.tool} with params: ${JSON.stringify(parsedParams).substring(0, 200)}`);
           const response = await tool.handler(parsedParams, undefined, signal);
+          throwIfAborted(signal);
 
           // Extract the actual tool result from the response.
           // Tool handlers return MCP-formatted responses via createJSONToolResponse():
@@ -650,6 +651,7 @@ export class DefaultPlanExecutor implements PlanExecutor {
             `[PARALLEL_EXEC][${device}] Executing ${step.tool} with params: ${JSON.stringify(parsedParams).substring(0, 200)}`
           );
           const response = await tool.handler(parsedParams, undefined, signal);
+          throwIfAborted(signal);
 
           // Unwrap MCP-formatted responses (same as sequential path) so that
           // failures inside { content: [{ text: '{"success":false,...}' }] }

--- a/test/daemon/sessionManager.test.ts
+++ b/test/daemon/sessionManager.test.ts
@@ -175,6 +175,23 @@ describe("SessionManager", () => {
     });
   });
 
+  describe("getSessionForDevice", () => {
+    test("should return session id for assigned device", async () => {
+      await sessionManager.createSession("session-1", "emulator-5554", "android");
+      expect(sessionManager.getSessionForDevice("emulator-5554")).toBe("session-1");
+    });
+
+    test("should return null for unknown device", () => {
+      expect(sessionManager.getSessionForDevice("emulator-9999")).toBeNull();
+    });
+
+    test("should return null after session is released", async () => {
+      await sessionManager.createSession("session-1", "emulator-5554", "android");
+      await sessionManager.releaseSession("session-1");
+      expect(sessionManager.getSessionForDevice("emulator-5554")).toBeNull();
+    });
+  });
+
   describe("statistics", () => {
     test("should return correct session statistics", async () => {
       await sessionManager.createSession("session-1", "emulator-5554", "android");

--- a/test/daemon/socketServerMcpForwardSerialization.test.ts
+++ b/test/daemon/socketServerMcpForwardSerialization.test.ts
@@ -7,7 +7,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { UnixSocketServer } from "../../src/daemon/socketServer";
 import { FakeTimer } from "../fakes/FakeTimer";
-import type { DaemonResponse } from "../../src/daemon/types";
+import type { DaemonRequest, DaemonResponse } from "../../src/daemon/types";
 
 interface FakeMcpClient {
   callTool: (...args: unknown[]) => Promise<unknown>;
@@ -30,19 +30,13 @@ function createFakeDaemonState() {
   };
 }
 
-function sendToolsCall(socketPath: string, toolName: string): Promise<DaemonResponse> {
+function sendRequest(socketPath: string, request: DaemonRequest): Promise<DaemonResponse> {
   return new Promise((resolve, reject) => {
     const client = new Socket();
     let buffer = "";
 
     client.connect(socketPath, () => {
-      const request = JSON.stringify({
-        id: randomUUID(),
-        type: "mcp_request",
-        method: "tools/call",
-        params: { name: toolName, arguments: {} },
-      });
-      client.write(request + "\n");
+      client.write(JSON.stringify(request) + "\n");
     });
 
     client.on("data", data => {
@@ -68,6 +62,15 @@ function sendToolsCall(socketPath: string, toolName: string): Promise<DaemonResp
         reject(new Error("Connection closed without response"));
       }
     });
+  });
+}
+
+function sendToolsCall(socketPath: string, toolName: string): Promise<DaemonResponse> {
+  return sendRequest(socketPath, {
+    id: randomUUID(),
+    type: "mcp_request",
+    method: "tools/call",
+    params: { name: toolName, arguments: {} },
   });
 }
 
@@ -129,5 +132,63 @@ describe("UnixSocketServer MCP forward serialization", () => {
     expect(b.success).toBe(true);
     expect(maxInFlight).toBe(1);
     expect(inFlight).toBe(0);
+  });
+
+  test("queued request fails fast when queue wait exceeds its timeout", async () => {
+    let callCount = 0;
+    let releaseBlockingRequest: () => void = () => {};
+    const blockingPromise = new Promise<void>(r => { releaseBlockingRequest = r; });
+
+    (server as any).createMcpClient = async () => {
+      const fake: FakeMcpClient = {
+        listTools: async () => ({ tools: [] }),
+        callTool: async () => {
+          callCount++;
+          if (callCount === 1) {
+            await blockingPromise;
+          }
+          return { content: [] };
+        },
+        listResources: async () => ({ resources: [] }),
+        readResource: async () => ({ contents: [] }),
+        listResourceTemplates: async () => ({ resourceTemplates: [] }),
+        close: async () => {},
+      };
+      return fake;
+    };
+
+    // First request: blocks in callTool until we release it
+    const first = sendToolsCall(socketPath, "observe");
+
+    // Yield to the real event loop so the first request enters callTool
+    for (let i = 0; i < 10; i++) {
+      await new Promise<void>(r => setImmediate(r));
+    }
+
+    // Second request: has a short timeout (500ms) that will expire in the queue
+    const second = sendRequest(socketPath, {
+      id: randomUUID(),
+      type: "mcp_request",
+      method: "tools/call",
+      params: { name: "observe", arguments: {} },
+      timeoutMs: 500,
+    });
+
+    // Yield to let socket data reach the server
+    for (let i = 0; i < 10; i++) {
+      await new Promise<void>(r => setImmediate(r));
+    }
+
+    // Advance time past the second request's timeout while it's queued
+    fakeTimer.advanceTime(600);
+
+    // Release the blocking request
+    releaseBlockingRequest();
+
+    const [firstResult, secondResult] = await Promise.all([first, second]);
+
+    expect(firstResult.success).toBe(true);
+    expect(secondResult.success).toBe(false);
+    expect(secondResult.error).toContain("waiting in queue");
   });
 });

--- a/test/plan/planExecutorAbortAfterStep.test.ts
+++ b/test/plan/planExecutorAbortAfterStep.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, test, beforeEach } from "bun:test";
+import { DefaultPlanExecutor } from "../../src/utils/plan/PlanExecutor";
+import { Plan } from "../../src/models/Plan";
+import { ToolRegistry } from "../../src/server/toolRegistry";
+import { z } from "zod";
+import { OPERATION_CANCELLED_MESSAGE } from "../../src/utils/constants";
+
+
+const toolName = `abortTest_${Date.now()}`;
+
+const toolSchema = z.object({
+  platform: z.string().optional(),
+  deviceId: z.string().optional(),
+  sessionUuid: z.string().optional(),
+});
+
+describe("PlanExecutor - abort signal checked after each step", () => {
+  let planExecutor: DefaultPlanExecutor;
+  let toolCallCount: number;
+
+  beforeEach(() => {
+    planExecutor = new DefaultPlanExecutor();
+    toolCallCount = 0;
+  });
+
+  test("aborts immediately after tool returns when signal fired during execution", async () => {
+    const abortController = new AbortController();
+
+    ToolRegistry.register(
+      toolName,
+      "Tool that aborts the signal mid-execution on step 1",
+      toolSchema,
+      async () => {
+        toolCallCount++;
+        if (toolCallCount === 1) {
+          abortController.abort();
+        }
+        return { success: true };
+      },
+    );
+
+    const tool = ToolRegistry.getTool(toolName)!;
+    (tool as any).requiresDevice = false;
+
+    const plan: Plan = {
+      name: "Abort After Step",
+      mcpVersion: "1.0",
+      steps: [
+        { tool: toolName, params: {} },
+        { tool: toolName, params: {} },
+        { tool: toolName, params: {} },
+      ],
+    };
+
+    const result = await planExecutor.executePlan(
+      plan,
+      0,
+      "android",
+      undefined,
+      undefined,
+      abortController.signal,
+    );
+
+    expect(toolCallCount).toBe(1);
+    expect(result.success).toBe(false);
+    expect(result.failedStep?.error).toInclude(OPERATION_CANCELLED_MESSAGE);
+  });
+
+  test("completes normally when signal is never aborted", async () => {
+    const completionToolName = `abortTestComplete_${Date.now()}`;
+    const abortController = new AbortController();
+
+    ToolRegistry.register(
+      completionToolName,
+      "Tool that never aborts",
+      toolSchema,
+      async () => {
+        toolCallCount++;
+        return { success: true };
+      },
+    );
+
+    const tool = ToolRegistry.getTool(completionToolName)!;
+    (tool as any).requiresDevice = false;
+
+    const plan: Plan = {
+      name: "No Abort",
+      mcpVersion: "1.0",
+      steps: [
+        { tool: completionToolName, params: {} },
+        { tool: completionToolName, params: {} },
+      ],
+    };
+
+    const result = await planExecutor.executePlan(
+      plan,
+      0,
+      "android",
+      undefined,
+      undefined,
+      abortController.signal,
+    );
+
+    expect(toolCallCount).toBe(2);
+    expect(result.success).toBe(true);
+    expect(result.executedSteps).toBe(2);
+  });
+});

--- a/test/utils/logger-loglevel-env.test.ts
+++ b/test/utils/logger-loglevel-env.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, test } from "bun:test";
+import { LogLevel, parseAutomobileLogLevel } from "../../src/utils/logger";
+
+describe("parseAutomobileLogLevel", () => {
+  test("returns null for unset or blank", () => {
+    expect(parseAutomobileLogLevel(undefined)).toBeNull();
+    expect(parseAutomobileLogLevel("")).toBeNull();
+    expect(parseAutomobileLogLevel("   ")).toBeNull();
+  });
+
+  test("parses known levels case-insensitively", () => {
+    expect(parseAutomobileLogLevel("DEBUG")).toBe(LogLevel.DEBUG);
+    expect(parseAutomobileLogLevel("Info")).toBe(LogLevel.INFO);
+    expect(parseAutomobileLogLevel("warn")).toBe(LogLevel.WARN);
+    expect(parseAutomobileLogLevel("warning")).toBe(LogLevel.WARN);
+    expect(parseAutomobileLogLevel("ERROR")).toBe(LogLevel.ERROR);
+    expect(parseAutomobileLogLevel("none")).toBe(LogLevel.NONE);
+    expect(parseAutomobileLogLevel("silent")).toBe(LogLevel.NONE);
+  });
+
+  test("returns null for garbage", () => {
+    expect(parseAutomobileLogLevel("verbose")).toBeNull();
+    expect(parseAutomobileLogLevel("infoo")).toBeNull();
+  });
+});


### PR DESCRIPTION
Closes #1945, #1946, #1947

**Base:** [PR #1917 - Daemon Transport Stability](https://github.com/kaeawc/auto-mobile/pull/1917)

## Summary

When an Android emulator crashes or goes offline, the daemon had no mechanism to detect this and cancel in-flight work. Active `executePlan` calls would hang until the full MCP request timeout (up to 10 minutes), producing long, unexplained CI failures. Additionally, the MCP forward serialization queue (introduced in PR #1917) meant queued requests burned their timeout budget while waiting, then immediately timed out when they got their turn. Finally, navigation screenshots added constant I/O pressure to the emulator, contributing to instability.

This PR addresses all three:
- Detect device disconnects and immediately cancel + release the affected session
- Account for queue wait time in MCP forward timeout budgets
- Add a `navigation-screenshots` feature flag to gate screenshot capture

## Changes

### A. Device disconnect cancels session

**Problem:** The daemon's device disconnect monitor detected device disappearance but only cleaned up recordings and cleared miss counters. The session and any active executions were left intact, waiting for the full MCP request timeout.

**Fix:** After cleaning up recordings for a disconnected device, do a reverse lookup (`sessionManager.getSessionForDevice(deviceId)`) to find the session assigned to that device. If found, call `cancelAndReleaseSession(sessionId)` which cancels all active `executionTracker` executions and releases the session + device assignment. The test fails immediately with a cancellation error instead of hanging.

**New:** `SessionManager.getSessionForDevice(deviceId)` - a reverse lookup from `deviceSessionMap` (the map already existed; this just exposes the lookup).

**Risk:** Low. `cancelAndReleaseSession` is already used by the heartbeat timeout path. The only new behavior is triggering it from device disconnect. If the device comes back (e.g., transient ADB hiccup), the session will already be released - but the disconnect monitor already uses a miss-counter with threshold to avoid single-miss false positives.

**Test coverage:** `getSessionForDevice` has 3 unit tests (assigned lookup, unknown device, post-release). The full disconnect-monitor → cancel integration requires mocking `MultiPlatformDeviceManager`, video recordings, `executionTracker`, and `devicePool` - deferred to a follow-up.

**Files:** `src/daemon/daemon.ts`, `src/daemon/sessionManager.ts`, `test/daemon/sessionManager.test.ts`

---

### B. MCP forward queue timeout budget accounting

**Problem:** PR #1917 serialized MCP forwards through `runExclusiveMcpForward`. A side effect: if request A holds the lock for 5 minutes, request B's timeout budget ticks down while it's queued. By the time B gets its turn, it may have ≤0ms left and either immediately times out in `callTool` (wasting a round-trip) or starts work it can't finish.

**Fix:** Capture the total timeout budget (`resolveMcpRequestTimeoutMs(request)`) *before* entering the queue. Inside the serialized callback:
1. Calculate `remainingTimeoutMs = totalTimeoutMs - queueWaitMs`
2. If `remainingTimeoutMs <= 0`, throw immediately: `MCP forward timeout: spent Xms waiting in queue (budget was Yms)`
3. Pass `remainingTimeoutMs` directly to `handleIdeRequest` as the `timeoutMs` parameter - no redundant recomputation
4. The "Session not found" retry path also deducts elapsed time and fails fast if no budget remains rather than using an arbitrary grace period

**Why this matters:** Without budget accounting, a queued request with a 30s timeout that waited 29s in the queue would start a `callTool` with a fresh 30s timeout - incorrect. Now it gets 1s, or fails immediately if its budget is spent.

**Test:** New test case `queued request fails fast when queue wait exceeds its timeout` - a blocking request holds the lock, a second request with a 500ms timeout is queued, time advances past the budget, and the second request fails with `"waiting in queue"`.

**Risk:** Low. The fail-fast path is strictly better than the old behavior (waiting for a full timeout that can't succeed). The only observable change is that queued requests may fail *faster* than before - which is the desired outcome.

**Files:** `src/daemon/socketServer.ts`, `test/daemon/socketServerMcpForwardSerialization.test.ts`

---

### C. `navigation-screenshots` feature flag

**Problem:** The `NavigationScreenshotManager` captures a screenshot on every navigation event and hierarchy change. In CI environments with resource-constrained emulators, this adds constant I/O pressure (ADB screencap calls) that contributes to instability, especially under parallel test execution.

**Fix:** Add a `navigation-screenshots` feature flag (key: `"navigation-screenshots"`, default: `true`) that gates screenshot capture in both the Android and iOS `CtrlProxyClient` navigation callbacks. When disabled:
- Navigation *events* are still recorded (the navigation graph updates normally)
- Navigation *screenshots* are skipped (no ADB screencap calls)
- iOS telemetry navigation events are still published (previously they were gated behind screenshot availability)

**Wiring:**
- **CLI:** `--no-navigation-screenshots` flag parsed in `index.ts` → calls `featureFlagService.setFlag("navigation-screenshots", false)`
- **Daemon options:** `DaemonOptions.noNavigationScreenshots` → `daemon.ts` constructor applies `serverConfig.setNavigationScreenshotsEnabled(false)`
- **Daemon spawn:** `--no-navigation-screenshots` arg threading in `manager.ts` (both `buildDaemonCommand` and `parseDaemonArgs`)
- **Gradle/CI:** JVM system property `automobile.daemon.no.navigation.screenshots=true` or env var `AUTOMOBILE_DAEMON_NO_NAVIGATION_SCREENSHOTS=1` (read in Kotlin `DaemonSocketClient`)
- **Feature flag system:** `FeatureFlagDefinitions` + `FeatureFlagApplier` → `serverConfig.setNavigationScreenshotsEnabled(enabled)`
- **Guard points:** Two in Android `CtrlProxyClient` (hierarchy-change callback and navigation-event callback), one in iOS `CtrlProxyClient` (navigation-event handler - restructured to always record the event first, then conditionally capture the screenshot)

**Design note:** The flag follows the existing positive-capability pattern (flag represents the capability, `defaultValue: true`, CLI uses `--no-X` to disable). This is consistent with `ui-perf-mode`, `ai-recovery`, and `accessibility-auto-detect`.

**Kotlin scope:** The `DaemonSocketClient.buildDaemonCommand` change is limited to adding `withNoNavigationScreenshots`. The `withDismissKeyboardAfterInput` / `withNoUiPerfMode` command refactoring is deferred to Group 8 (JUnit Runner Ergonomics).

**Risk:** Low. Default is `true` (current behavior). Only CI environments that explicitly opt out are affected. Navigation graph data is still collected; only screenshots are gated.

**Files:** `src/features/featureFlags/FeatureFlagDefinitions.ts`, `src/features/featureFlags/FeatureFlagApplier.ts`, `src/features/observe/android/CtrlProxyClient.ts`, `src/features/observe/ios/CtrlProxyClient.ts`, `src/utils/ServerConfig.ts`, `src/index.ts`, `src/daemon/daemon.ts`, `src/daemon/manager.ts`, `src/daemon/types.ts`, `android/.../DaemonSocketClient.kt`

---

## Testing

- All existing tests pass (same 9 pre-existing CtrlProxyManager failures from `main`)
- New tests: `sessionManager.test.ts` (3 cases for `getSessionForDevice`), `socketServerMcpForwardSerialization.test.ts` (queue timeout budget test)
- Build and lint clean

## How these interact with PR #1917

PR #1917 introduced the MCP forward serialization queue. This PR builds on that:
- Change B accounts for time spent waiting in that queue
- Change A provides a second fail-fast mechanism (device loss) that bypasses the queue entirely by cancelling at the session level

```
Emulator crash
  → Device disconnect monitor (A)
    → cancelAndReleaseSession
      → executionTracker.cancelSessionExecutions
        → abort signal fires → plan fails immediately

Queued request with exhausted budget
  → runExclusiveMcpForward (B)
    → remainingTimeoutMs <= 0
      → throws "MCP forward timeout: spent Xms waiting in queue"
        → socket error response → JUnit client fails fast
```
