### PR TITLE
feat: multi-strategy HierarchyMerger matching for iOS SDK properties

### DIFF
--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/AutoMobileContent.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/AutoMobileContent.kt
@@ -1684,15 +1684,18 @@ fun AutoMobileContent(
                                   )
                               )
                         }
-                    // Version slider using index into sorted version list
+                    // Version slider — only shown when 2+ distinct versions exist
+                    var minIdx by remember { mutableStateOf(0f) }
+                    var maxIdxState by remember { mutableStateOf((allVersions.size - 1).coerceAtLeast(0).toFloat()) }
                     if (allVersions.size >= 2) {
                       val maxIdx = (allVersions.size - 1).toFloat()
-                      var minIdx by remember { mutableStateOf(0f) }
-                      var maxIdxState by remember { mutableStateOf(maxIdx) }
-                      val minVer = allVersions.getOrElse(minIdx.toInt()) { allVersions.first() }
+                      // Clamp state in case allVersions changed
+                      val clampedMaxIdx = maxIdxState.coerceIn(0f, maxIdx)
+                      val clampedMinIdx = minIdx.coerceIn(0f, clampedMaxIdx)
+                      val minVer = allVersions.getOrElse(clampedMinIdx.toInt()) { allVersions.first() }
                       val maxVer =
                           allVersions.getOrElse(
-                              maxIdxState.toInt().coerceAtMost(allVersions.size - 1)
+                              clampedMaxIdx.toInt().coerceAtMost(allVersions.size - 1)
                           ) {
                             allVersions.last()
                           }
@@ -1709,7 +1712,7 @@ fun AutoMobileContent(
                         )
                         Column(Modifier.weight(1f)) {
                           androidx.compose.material3.Slider(
-                              value = minIdx,
+                              value = clampedMinIdx,
                               onValueChange = { minIdx = it.coerceAtMost(maxIdxState) },
                               onValueChangeFinished = { saveFilters() },
                               valueRange = 0f..maxIdx,
@@ -1717,7 +1720,7 @@ fun AutoMobileContent(
                               modifier = Modifier.fillMaxWidth().height(16.dp),
                           )
                           androidx.compose.material3.Slider(
-                              value = maxIdxState,
+                              value = clampedMaxIdx,
                               onValueChange = { maxIdxState = it.coerceAtLeast(minIdx) },
                               onValueChangeFinished = { saveFilters() },
                               valueRange = 0f..maxIdx,
@@ -1726,109 +1729,113 @@ fun AutoMobileContent(
                           )
                         }
                       }
+                    }
 
-                      // iPhone / iPad chips
-                      Row(
-                          modifier = Modifier.padding(start = 12.dp),
-                          horizontalArrangement = Arrangement.spacedBy(4.dp),
-                      ) {
-                        FilterChip("iPhone", showIphone) {
-                          showIphone = !showIphone
-                          saveFilters()
-                        }
-                        FilterChip("iPad", showIpad) {
-                          showIpad = !showIpad
-                          saveFilters()
-                        }
+                    // iPhone / iPad chips
+                    Row(
+                        modifier = Modifier.padding(start = 12.dp),
+                        horizontalArrangement = Arrangement.spacedBy(4.dp),
+                    ) {
+                      FilterChip("iPhone", showIphone) {
+                        showIphone = !showIphone
+                        saveFilters()
                       }
-                      Spacer(Modifier.height(2.dp))
+                      FilterChip("iPad", showIpad) {
+                        showIpad = !showIpad
+                        saveFilters()
+                      }
+                    }
+                    Spacer(Modifier.height(2.dp))
 
-                      // Determine selected version range
-                      val selectedVersions =
+                    // Determine selected version range
+                    val selectedVersions =
+                        if (allVersions.size >= 2) {
                           allVersions
                               .subList(
-                                  minIdx.toInt(),
+                                  minIdx.toInt().coerceIn(0, allVersions.size - 1),
                                   (maxIdxState.toInt() + 1).coerceAtMost(allVersions.size),
                               )
                               .toSet()
+                        } else {
+                          allVersions.toSet()
+                        }
 
-                      // Filter by version range + device type
-                      val filteredIos =
-                          iosImages
-                              .filter { image ->
-                                val ver = image.iosVersion
-                                val inRange = ver == null || ver in selectedVersions
-                                val isIphone = image.name.contains("iPhone", ignoreCase = true)
-                                val isIpad = image.name.contains("iPad", ignoreCase = true)
-                                val typeOk =
-                                    when {
-                                      isIphone -> showIphone
-                                      isIpad -> showIpad
-                                      else -> true // Apple Watch, Apple TV, etc.
-                                    }
-                                inRange && typeOk
-                              }
-                              .sortedBy { it.name }
+                    // Filter by version range + device type
+                    val filteredIos =
+                        iosImages
+                            .filter { image ->
+                              val ver = image.iosVersion
+                              val inRange = ver == null || ver in selectedVersions
+                              val isIphone = image.name.contains("iPhone", ignoreCase = true)
+                              val isIpad = image.name.contains("iPad", ignoreCase = true)
+                              val typeOk =
+                                  when {
+                                    isIphone -> showIphone
+                                    isIpad -> showIpad
+                                    else -> true // Apple Watch, Apple TV, etc.
+                                  }
+                              inRange && typeOk
+                            }
+                            .sortedBy { it.name }
 
-                      // Group by version, sorted descending
-                      val iosByVersion =
-                          filteredIos
-                              .groupBy { it.iosVersion ?: "Unknown" }
-                              .toSortedMap(compareByDescending { it })
-                      iosByVersion.forEach { (version, images) ->
-                        Text(
-                            "iOS $version",
-                            fontSize = 9.sp,
-                            color = colors.text.normal.copy(alpha = 0.5f),
-                            modifier = Modifier.padding(start = 12.dp, top = 4.dp),
-                        )
-                        images.forEach { image ->
-                          Row(
-                              verticalAlignment = Alignment.CenterVertically,
+                    // Group by version, sorted descending
+                    val iosByVersion =
+                        filteredIos
+                            .groupBy { it.iosVersion ?: "Unknown" }
+                            .toSortedMap(compareByDescending { it })
+                    iosByVersion.forEach { (version, images) ->
+                      Text(
+                          "iOS $version",
+                          fontSize = 9.sp,
+                          color = colors.text.normal.copy(alpha = 0.5f),
+                          modifier = Modifier.padding(start = 12.dp, top = 4.dp),
+                      )
+                      images.forEach { image ->
+                        Row(
+                            verticalAlignment = Alignment.CenterVertically,
+                            modifier =
+                                Modifier.fillMaxWidth()
+                                    .padding(start = 16.dp, top = 1.dp, bottom = 1.dp),
+                        ) {
+                          Text(
+                              image.name,
+                              color = colors.text.normal.copy(alpha = 0.6f),
+                              fontSize = 10.sp,
+                              modifier = Modifier.weight(1f),
+                              maxLines = 1,
+                              overflow = androidx.compose.ui.text.style.TextOverflow.Ellipsis,
+                          )
+                          Text(
+                              "\u25B6",
+                              fontSize = 9.sp,
+                              color = Color(0xFF4CAF50).copy(alpha = 0.7f),
                               modifier =
-                                  Modifier.fillMaxWidth()
-                                      .padding(start = 16.dp, top = 1.dp, bottom = 1.dp),
-                          ) {
-                            Text(
-                                image.name,
-                                color = colors.text.normal.copy(alpha = 0.6f),
-                                fontSize = 10.sp,
-                                modifier = Modifier.weight(1f),
-                                maxLines = 1,
-                                overflow = androidx.compose.ui.text.style.TextOverflow.Ellipsis,
-                            )
-                            Text(
-                                "\u25B6",
-                                fontSize = 9.sp,
-                                color = Color(0xFF4CAF50).copy(alpha = 0.7f),
-                                modifier =
-                                    Modifier.clickable {
-                                          kotlinx.coroutines.GlobalScope.launch(Dispatchers.IO) {
-                                            try {
-                                              clientProvider
-                                                  ?.invoke()
-                                                  ?.startDevice(
-                                                      image.name,
-                                                      image.platform,
-                                                      image.deviceId,
-                                                  )
-                                            } catch (_: Exception) {}
-                                          }
+                                  Modifier.clickable {
+                                        kotlinx.coroutines.GlobalScope.launch(Dispatchers.IO) {
+                                          try {
+                                            clientProvider
+                                                ?.invoke()
+                                                ?.startDevice(
+                                                    image.name,
+                                                    image.platform,
+                                                    image.deviceId,
+                                                )
+                                          } catch (_: Exception) {}
                                         }
-                                        .pointerHoverIcon(PointerIcon.Hand)
-                                        .padding(4.dp),
-                            )
-                          }
+                                      }
+                                      .pointerHoverIcon(PointerIcon.Hand)
+                                      .padding(4.dp),
+                          )
                         }
                       }
-                      if (filteredIos.isEmpty())
-                          Text(
-                              "No matching simulators",
-                              fontSize = 10.sp,
-                              color = colors.text.normal.copy(alpha = 0.4f),
-                              modifier = Modifier.padding(start = 12.dp),
-                          )
                     }
+                    if (filteredIos.isEmpty())
+                        Text(
+                            "No matching simulators",
+                            fontSize = 10.sp,
+                            color = colors.text.normal.copy(alpha = 0.4f),
+                            modifier = Modifier.padding(start = 12.dp),
+                        )
                   }
                 }
               }

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/layout/HierarchyParser.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/layout/HierarchyParser.kt
@@ -95,6 +95,9 @@ private fun parseJsonObjectNode(
     val isCheckable = attrs.getString("checkable") == "true"
     val isChecked = attrs.getString("checked") == "true"
 
+    // Parse extras map (sdk.* properties from the hierarchy merger)
+    val extras = parseExtras(attrs, nodeObj)
+
     // Parse children from "node" field
     val childrenElement = nodeObj["node"]
     val children = parseChildren(childrenElement, depth + 1, elementMap, parentMap)
@@ -123,6 +126,7 @@ private fun parseJsonObjectNode(
         isChecked = isChecked,
         depth = depth,
         children = children,
+        extras = extras,
     )
 
     // Populate lookup indexes as side-effect during parsing — zero extra traversals
@@ -206,6 +210,20 @@ private fun parseChildren(
         }
         else -> emptyList()
     }
+}
+
+/**
+ * Parse the "extras" map from node JSON. Checks both the attributes object and the node itself.
+ */
+private fun parseExtras(attrs: JsonObject, nodeObj: JsonObject): Map<String, String> {
+    val extrasObj = (attrs["extras"] ?: nodeObj["extras"]) as? JsonObject ?: return emptyMap()
+    val result = mutableMapOf<String, String>()
+    for ((key, value) in extrasObj) {
+        if (value is JsonPrimitive) {
+            value.contentOrNull?.let { result[key] = it }
+        }
+    }
+    return result
 }
 
 // Extension functions for safe JSON access

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/layout/LayoutInspectorModels.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/layout/LayoutInspectorModels.kt
@@ -448,17 +448,38 @@ object LayoutInspectorMockData {
         return null
     }
 
-    // Helper to find deepest element at point
+    // Helper to find deepest element at point, preferring the smallest match.
+    // Collects all leaf-level candidates containing the point, then picks
+    // the one with the smallest area so that full-screen overlay views
+    // (e.g. _UITouchPassthroughView) don't steal taps from content beneath.
     fun findElementAt(root: UIElementInfo, x: Int, y: Int): UIElementInfo? {
         if (!root.bounds.contains(x, y)) return null
 
-        // Check children first (depth-first to find deepest)
-        for (child in root.children.reversed()) {
-            val found = findElementAt(child, x, y)
-            if (found != null) return found
+        val candidates = mutableListOf<UIElementInfo>()
+        collectDeepestAt(root, x, y, candidates)
+
+        return candidates.minByOrNull { it.bounds.area }
+    }
+
+    private fun collectDeepestAt(
+        element: UIElementInfo,
+        x: Int,
+        y: Int,
+        candidates: MutableList<UIElementInfo>,
+    ) {
+        if (!element.bounds.contains(x, y)) return
+
+        var foundChild = false
+        for (child in element.children) {
+            if (child.bounds.contains(x, y)) {
+                collectDeepestAt(child, x, y, candidates)
+                foundChild = true
+            }
         }
 
-        return root
+        if (!foundChild) {
+            candidates.add(element)
+        }
     }
 
     // Helper to get path from root to element

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/layout/PropertyInspectorPanel.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/layout/PropertyInspectorPanel.kt
@@ -114,6 +114,17 @@ fun PropertyInspectorPanel(
                 }
             }
 
+            // SDK extras section (if present)
+            if (element.extras.isNotEmpty()) {
+                Spacer(Modifier.height(16.dp))
+                PropertySection(title = "SDK Properties") {
+                    for ((key, value) in element.extras.toSortedMap()) {
+                        val label = key.removePrefix("sdk.")
+                        PropertyRow(label, value)
+                    }
+                }
+            }
+
             // Text content section (if present)
             if (!element.text.isNullOrEmpty()) {
                 Spacer(Modifier.height(16.dp))

--- a/android/desktop-domain/src/main/kotlin/dev/jasonpearson/automobile/desktop/domain/LayoutModels.kt
+++ b/android/desktop-domain/src/main/kotlin/dev/jasonpearson/automobile/desktop/domain/LayoutModels.kt
@@ -16,6 +16,7 @@ public data class UIElementInfo(
     val isChecked: Boolean,
     val children: List<UIElementInfo>,
     val depth: Int,
+    val extras: Map<String, String> = emptyMap(),
 )
 
 public data class ElementBounds(
@@ -28,6 +29,7 @@ public data class ElementBounds(
     public val height: Int get() = bottom - top
     public val centerX: Int get() = left + width / 2
     public val centerY: Int get() = top + height / 2
+    public val area: Long get() = width.toLong() * height.toLong()
 
     public fun contains(x: Int, y: Int): Boolean =
         x >= left && x < right && y >= top && y < bottom

--- a/ios/Playground/Sources/Tabs/DemosTab.swift
+++ b/ios/Playground/Sources/Tabs/DemosTab.swift
@@ -114,6 +114,18 @@ struct DemosTab: View {
                         )
                     }
                 }
+
+                Section("View Hierarchy") {
+                    NavigationLink {
+                        ViewHierarchyDebugDemo()
+                    } label: {
+                        DemoRow(
+                            title: "Hierarchy Debug",
+                            description: "Test SDK walker vs accessibility tree",
+                            icon: "rectangle.3.group.fill"
+                        )
+                    }
+                }
             }
             .navigationTitle("Demos")
         }
@@ -938,6 +950,349 @@ struct NetworkTrackingDemo: View {
         .navigationBarTitleDisplayMode(.inline)
         .trackNavigation(destination: "NetworkTrackingDemo")
     }
+}
+
+// MARK: - View Hierarchy Debug Demo
+
+/// Demo screen that exercises cases where the SDK's in-process view walker
+/// reveals information the accessibility hierarchy hides or flattens.
+struct ViewHierarchyDebugDemo: View {
+    @State private var tapCount = 0
+    @State private var longPressCount = 0
+    @State private var swipeDirection = "none"
+    @State private var sliderValue = 0.5
+    @Environment(\.autoMobileTheme) private var theme
+
+    var body: some View {
+        ScrollView {
+            VStack(spacing: 24) {
+                // 1. Combined accessibility element — hides children from a11y tree
+                combinedElementSection
+
+                // 2. Custom accessibility actions — only visible in SDK walker
+                customActionsSection
+
+                // 3. Multiple gesture recognizers on one view
+                gestureRecognizerSection
+
+                // 4. Nested opaque views with layered backgrounds
+                layeredViewsSection
+
+                // 5. Hidden views that are invisible to a11y but exist in UIView tree
+                hiddenViewsSection
+
+                // 6. UIKit representable with tap targets
+                uiKitControlSection
+
+                Spacer()
+            }
+            .padding()
+        }
+        .background(theme.background)
+        .navigationTitle("Hierarchy Debug")
+        .navigationBarTitleDisplayMode(.inline)
+        .trackNavigation(destination: "ViewHierarchyDebugDemo")
+    }
+
+    // MARK: - Section 1: Combined Accessibility Element
+
+    private var combinedElementSection: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("Combined Element")
+                .font(.headline)
+                .foregroundStyle(theme.textPrimary)
+            Text("Accessibility sees one element; SDK walker sees the children.")
+                .font(.caption)
+                .foregroundStyle(theme.textSecondary)
+
+            HStack(spacing: 12) {
+                Image(systemName: "photo.fill")
+                    .font(.largeTitle)
+                    .foregroundStyle(theme.primary)
+                    .accessibilityIdentifier("combined-image")
+
+                VStack(alignment: .leading, spacing: 4) {
+                    Text("Photo Title")
+                        .font(.body)
+                        .foregroundStyle(theme.textPrimary)
+                        .accessibilityIdentifier("combined-title")
+                    Text("Subtitle with details")
+                        .font(.caption)
+                        .foregroundStyle(theme.textSecondary)
+                        .accessibilityIdentifier("combined-subtitle")
+                    HStack(spacing: 4) {
+                        Image(systemName: "star.fill")
+                            .font(.caption2)
+                            .foregroundStyle(Color.autoMobileWarning)
+                        Text("4.8")
+                            .font(.caption2)
+                            .foregroundStyle(theme.textSecondary)
+                        Text("(128 reviews)")
+                            .font(.caption2)
+                            .foregroundStyle(theme.textSecondary)
+                    }
+                    .accessibilityIdentifier("combined-rating")
+                }
+            }
+            .padding()
+            .background(theme.surfaceVariant)
+            .cornerRadius(12)
+            .accessibilityElement(children: .combine)
+            .accessibilityIdentifier("combined-card")
+            .accessibilityLabel("Photo Title, 4.8 stars, 128 reviews")
+        }
+        .padding()
+        .background(theme.surfaceVariant.opacity(0.3))
+        .cornerRadius(12)
+    }
+
+    // MARK: - Section 2: Custom Accessibility Actions
+
+    private var customActionsSection: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("Custom Actions")
+                .font(.headline)
+                .foregroundStyle(theme.textPrimary)
+            Text("Accessibility custom actions are only visible through the SDK walker.")
+                .font(.caption)
+                .foregroundStyle(theme.textSecondary)
+
+            VStack(spacing: 12) {
+                Text("Message from Alice")
+                    .font(.body)
+                    .foregroundStyle(theme.textPrimary)
+                Text("Hey, want to grab lunch tomorrow?")
+                    .font(.subheadline)
+                    .foregroundStyle(theme.textSecondary)
+                Text("Tap count: \(tapCount)")
+                    .font(.caption)
+                    .foregroundStyle(theme.textSecondary)
+            }
+            .padding()
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(theme.surfaceVariant)
+            .cornerRadius(12)
+            .accessibilityIdentifier("message-cell")
+            .accessibilityElement(children: .combine)
+            .accessibilityAction(named: "Reply") { tapCount += 1 }
+            .accessibilityAction(named: "Forward") { tapCount += 1 }
+            .accessibilityAction(named: "Mark as Unread") { tapCount += 1 }
+            .accessibilityAction(named: "Delete") { tapCount += 1 }
+            .accessibilityAction(named: "Archive") { tapCount += 1 }
+        }
+        .padding()
+        .background(theme.surfaceVariant.opacity(0.3))
+        .cornerRadius(12)
+    }
+
+    // MARK: - Section 3: Gesture Recognizers
+
+    private var gestureRecognizerSection: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("Gesture Recognizers")
+                .font(.headline)
+                .foregroundStyle(theme.textPrimary)
+            Text("SDK walker shows gesture types; accessibility only reports 'button' trait.")
+                .font(.caption)
+                .foregroundStyle(theme.textSecondary)
+
+            VStack(spacing: 4) {
+                Text("Tap, Long Press, or Swipe")
+                    .font(.body)
+                    .foregroundStyle(theme.textPrimary)
+                Text("Taps: \(tapCount)  Long Presses: \(longPressCount)  Swipe: \(swipeDirection)")
+                    .font(.caption)
+                    .foregroundStyle(theme.textSecondary)
+            }
+            .padding(40)
+            .frame(maxWidth: .infinity)
+            .background(theme.primary.opacity(0.15))
+            .cornerRadius(16)
+            .accessibilityIdentifier("gesture-target")
+            .onTapGesture { tapCount += 1 }
+            .onLongPressGesture { longPressCount += 1 }
+            .gesture(
+                DragGesture(minimumDistance: 30)
+                    .onEnded { value in
+                        let h = value.translation.width
+                        let v = value.translation.height
+                        if abs(h) > abs(v) {
+                            swipeDirection = h > 0 ? "right" : "left"
+                        } else {
+                            swipeDirection = v > 0 ? "down" : "up"
+                        }
+                    }
+            )
+        }
+        .padding()
+        .background(theme.surfaceVariant.opacity(0.3))
+        .cornerRadius(12)
+    }
+
+    // MARK: - Section 4: Layered Views
+
+    private var layeredViewsSection: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("Layered Views")
+                .font(.headline)
+                .foregroundStyle(theme.textPrimary)
+            Text("SDK walker reveals z-order, alpha, background colors, and corner radii.")
+                .font(.caption)
+                .foregroundStyle(theme.textSecondary)
+
+            ZStack {
+                RoundedRectangle(cornerRadius: 20)
+                    .fill(Color.autoMobileRed.opacity(0.3))
+                    .frame(width: 200, height: 200)
+                    .accessibilityIdentifier("layer-back")
+
+                RoundedRectangle(cornerRadius: 16)
+                    .fill(Color.autoMobileWarning.opacity(0.5))
+                    .frame(width: 150, height: 150)
+                    .accessibilityIdentifier("layer-middle")
+
+                RoundedRectangle(cornerRadius: 12)
+                    .fill(theme.primary.opacity(0.7))
+                    .frame(width: 100, height: 100)
+                    .accessibilityIdentifier("layer-front")
+
+                Text("Top")
+                    .font(.headline)
+                    .foregroundStyle(.white)
+                    .accessibilityIdentifier("layer-label")
+            }
+            .frame(maxWidth: .infinity)
+            .accessibilityIdentifier("layered-stack")
+        }
+        .padding()
+        .background(theme.surfaceVariant.opacity(0.3))
+        .cornerRadius(12)
+    }
+
+    // MARK: - Section 5: Hidden Views
+
+    private var hiddenViewsSection: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("Hidden & Decorative Views")
+                .font(.headline)
+                .foregroundStyle(theme.textPrimary)
+            Text("Views with accessibilityHidden or zero alpha exist in the UIView tree but not the accessibility tree.")
+                .font(.caption)
+                .foregroundStyle(theme.textSecondary)
+
+            VStack(spacing: 12) {
+                Text("Visible content")
+                    .foregroundStyle(theme.textPrimary)
+                    .accessibilityIdentifier("visible-text")
+
+                Text("A11y-hidden content")
+                    .foregroundStyle(Color.autoMobileRed)
+                    .accessibilityIdentifier("a11y-hidden-text")
+                    .accessibilityHidden(true)
+
+                Text("Elements-hidden container child")
+                    .foregroundStyle(Color.autoMobileWarning)
+                    .accessibilityIdentifier("elements-hidden-child")
+
+                // Decorative divider — no a11y representation
+                Rectangle()
+                    .fill(
+                        LinearGradient(
+                            colors: [.clear, theme.primary, .clear],
+                            startPoint: .leading,
+                            endPoint: .trailing
+                        )
+                    )
+                    .frame(height: 2)
+                    .accessibilityIdentifier("decorative-divider")
+                    .accessibilityHidden(true)
+
+                Text("Below the decorative divider")
+                    .foregroundStyle(theme.textPrimary)
+                    .accessibilityIdentifier("below-divider-text")
+            }
+            .padding()
+            .background(theme.surfaceVariant)
+            .cornerRadius(12)
+            .accessibilityIdentifier("hidden-views-container")
+        }
+        .padding()
+        .background(theme.surfaceVariant.opacity(0.3))
+        .cornerRadius(12)
+    }
+
+    // MARK: - Section 6: UIKit Control
+
+    private var uiKitControlSection: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("UIKit Controls in SwiftUI")
+                .font(.headline)
+                .foregroundStyle(theme.textPrimary)
+            Text("UIViewRepresentable wraps real UIKit controls — SDK walker sees UIControl targets and actions.")
+                .font(.caption)
+                .foregroundStyle(theme.textSecondary)
+
+            StepperControlView(value: $sliderValue)
+                .frame(height: 44)
+                .accessibilityIdentifier("uikit-stepper")
+
+            Text("Value: \(String(format: "%.1f", sliderValue))")
+                .font(.caption)
+                .foregroundStyle(theme.textSecondary)
+
+            SegmentedControlView()
+                .frame(height: 44)
+                .accessibilityIdentifier("uikit-segmented")
+        }
+        .padding()
+        .background(theme.surfaceVariant.opacity(0.3))
+        .cornerRadius(12)
+    }
+}
+
+// MARK: - UIKit Representables
+
+struct StepperControlView: UIViewRepresentable {
+    @Binding var value: Double
+
+    func makeUIView(context: Context) -> UIStepper {
+        let stepper = UIStepper()
+        stepper.minimumValue = 0
+        stepper.maximumValue = 10
+        stepper.stepValue = 0.5
+        stepper.value = value
+        stepper.accessibilityIdentifier = "uikit-stepper-control"
+        stepper.addTarget(context.coordinator, action: #selector(Coordinator.valueChanged(_:)), for: .valueChanged)
+        return stepper
+    }
+
+    func updateUIView(_ uiView: UIStepper, context: Context) {
+        uiView.value = value
+    }
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(value: $value)
+    }
+
+    class Coordinator: NSObject {
+        var value: Binding<Double>
+        init(value: Binding<Double>) { self.value = value }
+
+        @objc func valueChanged(_ sender: UIStepper) {
+            value.wrappedValue = sender.value
+        }
+    }
+}
+
+struct SegmentedControlView: UIViewRepresentable {
+    func makeUIView(context: Context) -> UISegmentedControl {
+        let control = UISegmentedControl(items: ["Low", "Medium", "High"])
+        control.selectedSegmentIndex = 1
+        control.accessibilityIdentifier = "uikit-segmented-control"
+        return control
+    }
+
+    func updateUIView(_ uiView: UISegmentedControl, context: Context) {}
 }
 
 #Preview {

--- a/ios/auto-mobile-sdk/Sources/AutoMobileSDK/ViewHierarchy/ViewHierarchyWalker.swift
+++ b/ios/auto-mobile-sdk/Sources/AutoMobileSDK/ViewHierarchy/ViewHierarchyWalker.swift
@@ -98,9 +98,7 @@ public enum ViewHierarchyWalker {
 
         let occluded = isOccludedByOpaqueOverlay(frameInRoot, overlays: opaqueOverlays)
 
-        // Skip private UIKit internals
         let className = String(describing: type(of: view))
-        if className.hasPrefix("_UI") { return nil }
 
         let bounds = sdkBounds(from: frameInRoot)
         let traits = traitNames(for: view.accessibilityTraits)
@@ -114,8 +112,11 @@ public enum ViewHierarchyWalker {
         let hasTap = hasOwnInteractiveAction(view)
         let bgColor = hexColor(view.backgroundColor) ?? hexColor(view.layer.backgroundColor.flatMap { UIColor(cgColor: $0) })
 
-        // Walk children front-to-back for opaque overlay tracking
-        let subviews = view.accessibilityElements?.compactMap({ $0 as? UIView }) ?? view.subviews
+        // Walk children front-to-back for opaque overlay tracking.
+        // Always use UIView.subviews — accessibilityElements may contain
+        // non-UIView objects (e.g. SwiftUI accessibility nodes) that would
+        // cause us to miss the real view subtree.
+        let subviews = view.subviews
         var childNodes: [SdkViewNode] = []
         var childOpaqueOverlays = opaqueOverlays
 
@@ -153,9 +154,9 @@ public enum ViewHierarchyWalker {
             accessibilityTraits: traits,
             accessibilityCustomActions: customActions,
             gestureRecognizers: gestures,
-            alpha: Float(view.alpha),
+            alpha: sanitizeFloat(Float(view.alpha)),
             backgroundColor: bgColor,
-            cornerRadius: Float(view.layer.cornerRadius),
+            cornerRadius: sanitizeFloat(Float(view.layer.cornerRadius)),
             isHidden: view.isHidden,
             isUserInteractionEnabled: view.isUserInteractionEnabled,
             hasTapTarget: hasTap,
@@ -257,6 +258,12 @@ public enum ViewHierarchyWalker {
             if traits.contains(.toggleButton) { names.append("toggleButton") }
         }
         return names
+    }
+
+    // MARK: - Float Sanitization
+
+    private static func sanitizeFloat(_ value: Float) -> Float {
+        value.isFinite ? value : 0
     }
 
     // MARK: - Color Helpers

--- a/ios/control-proxy/CtrlProxy.xcodeproj/project.pbxproj
+++ b/ios/control-proxy/CtrlProxy.xcodeproj/project.pbxproj
@@ -8,14 +8,21 @@
 
 /* Begin PBXBuildFile section */
 		0377180BB666F63386C77E17 /* CommandHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77305F40F85694E983987E68 /* CommandHandler.swift */; };
+		0A4F48C4211E43B829855704 /* SdkHierarchyClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7C65BE687554E71E587B731 /* SdkHierarchyClient.swift */; };
+		0DCD8748EF0E74AD806385A5 /* SdkHierarchyCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 043D2CA5107B76077BA6301C /* SdkHierarchyCache.swift */; };
 		0E8A9A62BEF9C4E672D09764 /* PerfProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEF454F64F7AF11BD79DB97D /* PerfProviderTests.swift */; };
 		12D60B8E4D067E91189066AD /* CommandHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25C10BFA5B6504892F8459D7 /* CommandHandlerTests.swift */; };
 		141E5CD4FAF4509F538E736C /* OSLogReader.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBA97A6C3A1240A055D9876C /* OSLogReader.swift */; };
+		158C6F3B528C02BE92AA6132 /* HierarchyMerger.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAAF8CEA9B9A28B052E57E0A /* HierarchyMerger.swift */; };
 		1F968B5EDB744057F51321EF /* ElementLocator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95565999DC108319DEED894A /* ElementLocator.swift */; };
+		261F76AE6277D92BD87CFB1C /* SdkHierarchyClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7C65BE687554E71E587B731 /* SdkHierarchyClient.swift */; };
+		2ABF683DE1AD6578F8EAF168 /* SdkHierarchyCacheTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5408FE8438060177DDAE7177 /* SdkHierarchyCacheTests.swift */; };
 		2BC78956D2B04A95DA43E6FB /* Protocols.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0F9D7B74C318EE243B225B95 /* Protocols.swift */; };
+		2CFEE57D3D518C352BAB2937 /* SdkHierarchyModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83E0B84D4CA225ECB1E09064 /* SdkHierarchyModels.swift */; };
 		3841CE71EF7F67B82441E6E3 /* DisplayLinkFPSMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1044F2C47DD6B836C1E32F1C /* DisplayLinkFPSMonitor.swift */; };
 		42E706C81F51E89DEBD9C1A9 /* CtrlProxy.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 056D5DCA8003C7DFA37244C4 /* CtrlProxy.framework */; };
 		4413FD9E4C8BF4071C74D482 /* HierarchyDebouncerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E5AAA4E2861D92C17F39B14 /* HierarchyDebouncerTests.swift */; };
+		45B926178972D1A358CFF284 /* HierarchyMerger.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAAF8CEA9B9A28B052E57E0A /* HierarchyMerger.swift */; };
 		47A050F2D8153251E395B7B9 /* Protocols.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0F9D7B74C318EE243B225B95 /* Protocols.swift */; };
 		4A0FBEF6FAEF437AA17B20EA /* PerfProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = A284B6FFBE969931BB03A2FF /* PerfProvider.swift */; };
 		53A41EE5F98E771345D6EA90 /* WebSocketServer.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4CB9272A186932D89EB1072 /* WebSocketServer.swift */; };
@@ -36,14 +43,17 @@
 		C1398B388B401E28BC727863 /* OSLogReader.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBA97A6C3A1240A055D9876C /* OSLogReader.swift */; };
 		C194D73F02D0776F0F7FCA7B /* CtrlProxy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0EE277596991C059142C485B /* CtrlProxy.swift */; };
 		C2DCB71857A14ED314300AAC /* WebSocketServer.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4CB9272A186932D89EB1072 /* WebSocketServer.swift */; };
+		CB577FE46E063BB09F5D4010 /* SdkHierarchyModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83E0B84D4CA225ECB1E09064 /* SdkHierarchyModels.swift */; };
 		CC061B4978496D75042B253A /* CommandHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77305F40F85694E983987E68 /* CommandHandler.swift */; };
 		CDEF0C911EA979C4E9C54B0B /* DefaultStorageInspecting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1CFB4EDEE20CB1CE002E68A5 /* DefaultStorageInspecting.swift */; };
+		CFCA362E1EF1F3251B19BC1B /* HierarchyMergerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0F6E995191B4AF437EDB71CA /* HierarchyMergerTests.swift */; };
 		D0C171171348407EBFF5BAB7 /* PerfProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = A284B6FFBE969931BB03A2FF /* PerfProvider.swift */; };
 		D9EF3A486E53F97C1CCB7A3B /* GesturePerformer.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2144B84CD70DB35A1030624 /* GesturePerformer.swift */; };
 		DFEE186C8B4CD32EF76D995A /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 878A53A7F0EDDABDF2435E7F /* AppDelegate.swift */; };
 		E8327D679D58C8F804C064B1 /* PerformanceMetrics.swift in Sources */ = {isa = PBXBuildFile; fileRef = B136EAD78CC0B932F258C265 /* PerformanceMetrics.swift */; };
 		E8B2051927387427E1F14EC2 /* ElementLocatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7BE98EA2924A42A6CD22993 /* ElementLocatorTests.swift */; };
 		EA65C486C9E6DBB5BFE9CA41 /* HierarchyDebouncer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 034DC5B8A3A4FCE46CD89568 /* HierarchyDebouncer.swift */; };
+		EE7765F6DA0807474D52C3DD /* SdkHierarchyCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 043D2CA5107B76077BA6301C /* SdkHierarchyCache.swift */; };
 		F469E7EF16C59A99DBD519DA /* DisplayLinkFPSMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1044F2C47DD6B836C1E32F1C /* DisplayLinkFPSMonitor.swift */; };
 		F7B78DBB0517EC004EF4ECF6 /* ModelsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 184CFC1280E0802EBF53965F /* ModelsTests.swift */; };
 /* End PBXBuildFile section */
@@ -100,9 +110,11 @@
 /* Begin PBXFileReference section */
 		009A6B01284035997298367F /* CtrlProxyUITests.xctest */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.cfbundle; path = CtrlProxyUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		034DC5B8A3A4FCE46CD89568 /* HierarchyDebouncer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HierarchyDebouncer.swift; sourceTree = "<group>"; };
+		043D2CA5107B76077BA6301C /* SdkHierarchyCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SdkHierarchyCache.swift; sourceTree = "<group>"; };
 		056D5DCA8003C7DFA37244C4 /* CtrlProxy.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = CtrlProxy.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		0CDD96577EB9823B5FCF2585 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder; name = Assets.xcassets; path = CtrlProxyApp/Assets.xcassets; sourceTree = SOURCE_ROOT; };
 		0EE277596991C059142C485B /* CtrlProxy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CtrlProxy.swift; sourceTree = "<group>"; };
+		0F6E995191B4AF437EDB71CA /* HierarchyMergerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HierarchyMergerTests.swift; sourceTree = "<group>"; };
 		0F9D7B74C318EE243B225B95 /* Protocols.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Protocols.swift; sourceTree = "<group>"; };
 		1044F2C47DD6B836C1E32F1C /* DisplayLinkFPSMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DisplayLinkFPSMonitor.swift; sourceTree = "<group>"; };
 		184CFC1280E0802EBF53965F /* ModelsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModelsTests.swift; sourceTree = "<group>"; };
@@ -111,10 +123,12 @@
 		25C10BFA5B6504892F8459D7 /* CommandHandlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommandHandlerTests.swift; sourceTree = "<group>"; };
 		3E5AAA4E2861D92C17F39B14 /* HierarchyDebouncerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HierarchyDebouncerTests.swift; sourceTree = "<group>"; };
 		42C53A4D56EE97B5BD11EC63 /* Debug.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Debug.xcconfig; sourceTree = "<group>"; };
+		5408FE8438060177DDAE7177 /* SdkHierarchyCacheTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SdkHierarchyCacheTests.swift; sourceTree = "<group>"; };
 		637A2A05C90AA6E64D224651 /* CtrlProxyTests.xctest */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.cfbundle; path = CtrlProxyTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		652F5687D2FC57F3D6D4629C /* Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Release.xcconfig; sourceTree = "<group>"; };
 		77305F40F85694E983987E68 /* CommandHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommandHandler.swift; sourceTree = "<group>"; };
 		802717F6B1F37809C4806C23 /* CtrlProxyUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CtrlProxyUITests.swift; sourceTree = "<group>"; };
+		83E0B84D4CA225ECB1E09064 /* SdkHierarchyModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SdkHierarchyModels.swift; sourceTree = "<group>"; };
 		878A53A7F0EDDABDF2435E7F /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		95565999DC108319DEED894A /* ElementLocator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ElementLocator.swift; sourceTree = "<group>"; };
 		9A1B2931E58B158EE51C5F4F /* Fakes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Fakes.swift; sourceTree = "<group>"; };
@@ -126,7 +140,9 @@
 		D81453AD074F2A392251CFC3 /* Models.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Models.swift; sourceTree = "<group>"; };
 		DBA97A6C3A1240A055D9876C /* OSLogReader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OSLogReader.swift; sourceTree = "<group>"; };
 		DEF454F64F7AF11BD79DB97D /* PerfProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PerfProviderTests.swift; sourceTree = "<group>"; };
+		E7C65BE687554E71E587B731 /* SdkHierarchyClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SdkHierarchyClient.swift; sourceTree = "<group>"; };
 		F2144B84CD70DB35A1030624 /* GesturePerformer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GesturePerformer.swift; sourceTree = "<group>"; };
+		FAAF8CEA9B9A28B052E57E0A /* HierarchyMerger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HierarchyMerger.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -164,8 +180,10 @@
 				25C10BFA5B6504892F8459D7 /* CommandHandlerTests.swift */,
 				B7BE98EA2924A42A6CD22993 /* ElementLocatorTests.swift */,
 				3E5AAA4E2861D92C17F39B14 /* HierarchyDebouncerTests.swift */,
+				0F6E995191B4AF437EDB71CA /* HierarchyMergerTests.swift */,
 				184CFC1280E0802EBF53965F /* ModelsTests.swift */,
 				DEF454F64F7AF11BD79DB97D /* PerfProviderTests.swift */,
+				5408FE8438060177DDAE7177 /* SdkHierarchyCacheTests.swift */,
 			);
 			name = CtrlProxyTests;
 			path = Tests/CtrlProxyTests;
@@ -213,11 +231,15 @@
 				9A1B2931E58B158EE51C5F4F /* Fakes.swift */,
 				F2144B84CD70DB35A1030624 /* GesturePerformer.swift */,
 				034DC5B8A3A4FCE46CD89568 /* HierarchyDebouncer.swift */,
+				FAAF8CEA9B9A28B052E57E0A /* HierarchyMerger.swift */,
 				D81453AD074F2A392251CFC3 /* Models.swift */,
 				DBA97A6C3A1240A055D9876C /* OSLogReader.swift */,
 				B136EAD78CC0B932F258C265 /* PerformanceMetrics.swift */,
 				A284B6FFBE969931BB03A2FF /* PerfProvider.swift */,
 				0F9D7B74C318EE243B225B95 /* Protocols.swift */,
+				043D2CA5107B76077BA6301C /* SdkHierarchyCache.swift */,
+				E7C65BE687554E71E587B731 /* SdkHierarchyClient.swift */,
+				83E0B84D4CA225ECB1E09064 /* SdkHierarchyModels.swift */,
 				B4CB9272A186932D89EB1072 /* WebSocketServer.swift */,
 			);
 			name = CtrlProxy;
@@ -384,11 +406,15 @@
 				A603343B94D35DDF48F7AA4D /* Fakes.swift in Sources */,
 				D9EF3A486E53F97C1CCB7A3B /* GesturePerformer.swift in Sources */,
 				EA65C486C9E6DBB5BFE9CA41 /* HierarchyDebouncer.swift in Sources */,
+				158C6F3B528C02BE92AA6132 /* HierarchyMerger.swift in Sources */,
 				BD7D2FF024054ED74F17958D /* Models.swift in Sources */,
 				C1398B388B401E28BC727863 /* OSLogReader.swift in Sources */,
 				D0C171171348407EBFF5BAB7 /* PerfProvider.swift in Sources */,
 				E8327D679D58C8F804C064B1 /* PerformanceMetrics.swift in Sources */,
 				47A050F2D8153251E395B7B9 /* Protocols.swift in Sources */,
+				0DCD8748EF0E74AD806385A5 /* SdkHierarchyCache.swift in Sources */,
+				0A4F48C4211E43B829855704 /* SdkHierarchyClient.swift in Sources */,
+				2CFEE57D3D518C352BAB2937 /* SdkHierarchyModels.swift in Sources */,
 				C2DCB71857A14ED314300AAC /* WebSocketServer.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -400,8 +426,10 @@
 				12D60B8E4D067E91189066AD /* CommandHandlerTests.swift in Sources */,
 				E8B2051927387427E1F14EC2 /* ElementLocatorTests.swift in Sources */,
 				4413FD9E4C8BF4071C74D482 /* HierarchyDebouncerTests.swift in Sources */,
+				CFCA362E1EF1F3251B19BC1B /* HierarchyMergerTests.swift in Sources */,
 				F7B78DBB0517EC004EF4ECF6 /* ModelsTests.swift in Sources */,
 				0E8A9A62BEF9C4E672D09764 /* PerfProviderTests.swift in Sources */,
+				2ABF683DE1AD6578F8EAF168 /* SdkHierarchyCacheTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -417,11 +445,15 @@
 				1F968B5EDB744057F51321EF /* ElementLocator.swift in Sources */,
 				5FDF9AE29841625DD7EFB7EC /* GesturePerformer.swift in Sources */,
 				5458E55CB48475D2487A49C3 /* HierarchyDebouncer.swift in Sources */,
+				45B926178972D1A358CFF284 /* HierarchyMerger.swift in Sources */,
 				BD627F44D1B9F2D3976AA0EC /* Models.swift in Sources */,
 				141E5CD4FAF4509F538E736C /* OSLogReader.swift in Sources */,
 				4A0FBEF6FAEF437AA17B20EA /* PerfProvider.swift in Sources */,
 				B55A16F80CE62B998CEBC6E0 /* PerformanceMetrics.swift in Sources */,
 				2BC78956D2B04A95DA43E6FB /* Protocols.swift in Sources */,
+				EE7765F6DA0807474D52C3DD /* SdkHierarchyCache.swift in Sources */,
+				261F76AE6277D92BD87CFB1C /* SdkHierarchyClient.swift in Sources */,
+				CB577FE46E063BB09F5D4010 /* SdkHierarchyModels.swift in Sources */,
 				53A41EE5F98E771345D6EA90 /* WebSocketServer.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/ios/control-proxy/Sources/CtrlProxy/HierarchyMerger.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/HierarchyMerger.swift
@@ -10,20 +10,44 @@ public enum HierarchyMerger {
     private static let boundsTolerance = 2
 
     /// Merge SDK hierarchy data into the XCUITest hierarchy.
+    ///
+    /// Two-pass merge:
+    /// 1. **Enrich** — annotate existing XCUITest nodes with `sdk.*` extras from matched SDK nodes.
+    /// 2. **Inject** — add SDK-only nodes (views absent from the XCUITest tree) as children
+    ///    of their nearest matched parent. Injected nodes carry `sdk.source=sdkWalker`.
     public static func merge(xcuitest: ViewHierarchy, sdk: SdkViewHierarchy?) -> ViewHierarchy {
         guard let sdkRoot = sdk?.root else { return xcuitest }
         guard let xcuitestRoot = xcuitest.hierarchy else { return xcuitest }
 
-        // Build a flat lookup from the SDK tree keyed by (className, bounds)
+        // Build flat lookups from the SDK tree
         var lookup: [LookupKey: SdkViewNode] = [:]
-        buildLookup(node: sdkRoot, into: &lookup)
+        var boundsLookup: [BoundsKey: SdkViewNode] = [:]
+        var identifierLookup: [String: SdkViewNode] = [:]
+        var allSdkNodes: [SdkViewNode] = []
+        buildLookup(node: sdkRoot, into: &lookup, boundsLookup: &boundsLookup, identifierLookup: &identifierLookup, allNodes: &allSdkNodes)
 
-        let enrichedRoot = enrichNode(xcuitestRoot, lookup: lookup)
+        // Pass 1: enrich existing XCUITest nodes with SDK extras
+        let enrichedRoot = enrichNode(xcuitestRoot, lookup: lookup, boundsLookup: boundsLookup, identifierLookup: identifierLookup, allSdkNodes: allSdkNodes)
+
+        // Collect the set of SDK nodes that matched an XCUITest node
+        var matchedSdkKeys: Set<LookupKey> = []
+        collectMatchedKeys(element: xcuitestRoot, lookup: lookup, boundsLookup: boundsLookup, identifierLookup: identifierLookup, allSdkNodes: allSdkNodes, matched: &matchedSdkKeys)
+
+        // Pass 2: inject SDK-only nodes as children of matched parents
+        let injectedRoot = injectSdkOnlyNodes(
+            element: enrichedRoot,
+            sdkNode: sdkRoot,
+            lookup: lookup,
+            boundsLookup: boundsLookup,
+            identifierLookup: identifierLookup,
+            allSdkNodes: allSdkNodes,
+            matchedSdkKeys: matchedSdkKeys
+        )
 
         return ViewHierarchy(
             updatedAt: xcuitest.updatedAt,
             packageName: xcuitest.packageName,
-            hierarchy: enrichedRoot,
+            hierarchy: injectedRoot,
             windowInfo: xcuitest.windowInfo,
             windows: xcuitest.windows,
             screenScale: xcuitest.screenScale,
@@ -44,54 +68,132 @@ public enum HierarchyMerger {
         let bottom: Int
     }
 
-    private static func buildLookup(node: SdkViewNode, into lookup: inout [LookupKey: SdkViewNode]) {
+    /// Bounds-only key for fallback matching when class names differ
+    /// (e.g. XCUITest "UIView" vs SDK "_UIHostingView").
+    private struct BoundsKey: Hashable {
+        let left: Int
+        let top: Int
+        let right: Int
+        let bottom: Int
+    }
+
+    private static func buildLookup(
+        node: SdkViewNode,
+        into lookup: inout [LookupKey: SdkViewNode],
+        boundsLookup: inout [BoundsKey: SdkViewNode],
+        identifierLookup: inout [String: SdkViewNode],
+        allNodes: inout [SdkViewNode]
+    ) {
+        allNodes.append(node)
         // Insert exact key + all tolerance variants so findMatch is O(1)
         let tol = boundsTolerance
         for dl in -tol...tol {
             for dt in -tol...tol {
                 for dr in -tol...tol {
                     for db in -tol...tol {
+                        let l = node.bounds.left + dl
+                        let t = node.bounds.top + dt
+                        let r = node.bounds.right + dr
+                        let b = node.bounds.bottom + db
                         let key = LookupKey(
                             className: node.className,
-                            left: node.bounds.left + dl,
-                            top: node.bounds.top + dt,
-                            right: node.bounds.right + dr,
-                            bottom: node.bounds.bottom + db
+                            left: l, top: t, right: r, bottom: b
                         )
                         if lookup[key] == nil {
                             lookup[key] = node
+                        }
+                        let bKey = BoundsKey(left: l, top: t, right: r, bottom: b)
+                        if boundsLookup[bKey] == nil {
+                            boundsLookup[bKey] = node
                         }
                     }
                 }
             }
         }
+        // Index by accessibilityIdentifier for fallback when bounds don't match
+        if let identifier = node.accessibilityIdentifier, !identifier.isEmpty {
+            if identifierLookup[identifier] == nil {
+                identifierLookup[identifier] = node
+            }
+        }
         if let children = node.children {
             for child in children {
-                buildLookup(node: child, into: &lookup)
+                buildLookup(node: child, into: &lookup, boundsLookup: &boundsLookup, identifierLookup: &identifierLookup, allNodes: &allNodes)
             }
         }
     }
 
     // MARK: - Matching
 
-    private static func findMatch(className: String?, bounds: ElementBounds?, in lookup: [LookupKey: SdkViewNode]) -> SdkViewNode? {
-        guard let className = className, let bounds = bounds else { return nil }
-        return lookup[LookupKey(
-            className: className,
-            left: bounds.left,
-            top: bounds.top,
-            right: bounds.right,
-            bottom: bounds.bottom
-        )]
+    /// Find a matching SDK node for an XCUITest element.
+    /// Strategy: (1) exact className+bounds, (2) bounds-only, (3) accessibilityIdentifier,
+    /// (4) smallest enclosing SDK node (for SwiftUI views where accessibility bounds differ from UIKit).
+    private static func findMatch(
+        className: String?,
+        resourceId: String?,
+        bounds: ElementBounds?,
+        in lookup: [LookupKey: SdkViewNode],
+        boundsLookup: [BoundsKey: SdkViewNode],
+        identifierLookup: [String: SdkViewNode],
+        allSdkNodes: [SdkViewNode]
+    ) -> SdkViewNode? {
+        if let bounds = bounds {
+            // 1. Exact match: className + bounds
+            if let className = className {
+                if let exact = lookup[LookupKey(
+                    className: className,
+                    left: bounds.left, top: bounds.top,
+                    right: bounds.right, bottom: bounds.bottom
+                )] {
+                    return exact
+                }
+            }
+            // 2. Bounds-only fallback: different class names at the same position
+            if let boundsMatch = boundsLookup[BoundsKey(
+                left: bounds.left, top: bounds.top,
+                right: bounds.right, bottom: bounds.bottom
+            )] {
+                return boundsMatch
+            }
+        }
+        // 3. Identifier fallback: match by accessibilityIdentifier when bounds differ
+        if let resourceId = resourceId, !resourceId.isEmpty {
+            if let idMatch = identifierLookup[resourceId] {
+                return idMatch
+            }
+        }
+        // 4. Smallest enclosing SDK node: find the SDK node with smallest area
+        //    that fully contains this element's bounds
+        if let bounds = bounds {
+            let tol = boundsTolerance
+            var bestNode: SdkViewNode?
+            var bestArea = Int.max
+            for node in allSdkNodes {
+                let nb = node.bounds
+                // Check containment with tolerance
+                if nb.left - tol <= bounds.left &&
+                   nb.top - tol <= bounds.top &&
+                   nb.right + tol >= bounds.right &&
+                   nb.bottom + tol >= bounds.bottom {
+                    let area = nb.width * nb.height
+                    if area < bestArea {
+                        bestArea = area
+                        bestNode = node
+                    }
+                }
+            }
+            return bestNode
+        }
+        return nil
     }
 
     // MARK: - Enrichment
 
-    private static func enrichNode(_ element: UIElementInfo, lookup: [LookupKey: SdkViewNode]) -> UIElementInfo {
-        let sdkNode = findMatch(className: element.className, bounds: element.bounds, in: lookup)
+    private static func enrichNode(_ element: UIElementInfo, lookup: [LookupKey: SdkViewNode], boundsLookup: [BoundsKey: SdkViewNode], identifierLookup: [String: SdkViewNode], allSdkNodes: [SdkViewNode]) -> UIElementInfo {
+        let sdkNode = findMatch(className: element.className, resourceId: element.resourceId, bounds: element.bounds, in: lookup, boundsLookup: boundsLookup, identifierLookup: identifierLookup, allSdkNodes: allSdkNodes)
         let enrichedExtras = buildExtras(existing: element.extras, sdkNode: sdkNode)
 
-        let enrichedChildren: [UIElementInfo]? = element.node?.map { enrichNode($0, lookup: lookup) }
+        let enrichedChildren: [UIElementInfo]? = element.node?.map { enrichNode($0, lookup: lookup, boundsLookup: boundsLookup, identifierLookup: identifierLookup, allSdkNodes: allSdkNodes) }
 
         return UIElementInfo(
             text: element.text,
@@ -156,5 +258,227 @@ public enum HierarchyMerger {
         extras["sdk.isUserInteractionEnabled"] = String(node.isUserInteractionEnabled)
 
         return extras.isEmpty ? nil : extras
+    }
+
+    // MARK: - Pass 2: SDK-Only Node Injection
+
+    /// Collect the exact lookup keys for SDK nodes that matched an XCUITest node.
+    private static func collectMatchedKeys(
+        element: UIElementInfo,
+        lookup: [LookupKey: SdkViewNode],
+        boundsLookup: [BoundsKey: SdkViewNode],
+        identifierLookup: [String: SdkViewNode],
+        allSdkNodes: [SdkViewNode],
+        matched: inout Set<LookupKey>
+    ) {
+        if let sdkNode = findMatch(className: element.className, resourceId: element.resourceId, bounds: element.bounds, in: lookup, boundsLookup: boundsLookup, identifierLookup: identifierLookup, allSdkNodes: allSdkNodes) {
+            matched.insert(exactKey(for: sdkNode))
+        }
+        if let children = element.node {
+            for child in children {
+                collectMatchedKeys(element: child, lookup: lookup, boundsLookup: boundsLookup, identifierLookup: identifierLookup, allSdkNodes: allSdkNodes, matched: &matched)
+            }
+        }
+    }
+
+    /// Walk the enriched XCUITest tree alongside the SDK tree.
+    /// For each XCUITest node that matched an SDK node, check the SDK node's children —
+    /// any SDK child that didn't match an XCUITest node gets injected.
+    private static func injectSdkOnlyNodes(
+        element: UIElementInfo,
+        sdkNode: SdkViewNode?,
+        lookup: [LookupKey: SdkViewNode],
+        boundsLookup: [BoundsKey: SdkViewNode],
+        identifierLookup: [String: SdkViewNode],
+        allSdkNodes: [SdkViewNode],
+        matchedSdkKeys: Set<LookupKey>
+    ) -> UIElementInfo {
+        // Find the SDK node that corresponds to this XCUITest element
+        let currentSdk = sdkNode ?? findMatch(
+            className: element.className,
+            resourceId: element.resourceId,
+            bounds: element.bounds,
+            in: lookup,
+            boundsLookup: boundsLookup,
+            identifierLookup: identifierLookup,
+            allSdkNodes: allSdkNodes
+        )
+
+        // Recurse into existing children, pairing each with its SDK counterpart
+        let processedChildren: [UIElementInfo]? = element.node?.map { child in
+            let childSdk = findMatch(className: child.className, resourceId: child.resourceId, bounds: child.bounds, in: lookup, boundsLookup: boundsLookup, identifierLookup: identifierLookup, allSdkNodes: allSdkNodes)
+            return injectSdkOnlyNodes(
+                element: child,
+                sdkNode: childSdk,
+                lookup: lookup,
+                boundsLookup: boundsLookup,
+                identifierLookup: identifierLookup,
+                allSdkNodes: allSdkNodes,
+                matchedSdkKeys: matchedSdkKeys
+            )
+        }
+
+        // Find SDK children of this node that have no XCUITest counterpart
+        var injected: [UIElementInfo] = []
+        if let sdkChildren = currentSdk?.children {
+            for sdkChild in sdkChildren {
+                let childKey = exactKey(for: sdkChild)
+                if !matchedSdkKeys.contains(childKey) && isWorthInjecting(sdkChild) {
+                    injected.append(convertSdkNode(sdkChild))
+                }
+            }
+        }
+
+        // If no injections needed, return as-is
+        guard !injected.isEmpty else {
+            if processedChildren != nil && processedChildren?.count != element.node?.count {
+                return element // shouldn't happen, but safety
+            }
+            return UIElementInfo(
+                text: element.text,
+                textSize: element.textSize,
+                contentDesc: element.contentDesc,
+                resourceId: element.resourceId,
+                className: element.className,
+                bounds: element.bounds,
+                clickable: element.clickable,
+                enabled: element.enabled,
+                focusable: element.focusable,
+                focused: element.focused,
+                accessibilityFocused: element.accessibilityFocused,
+                scrollable: element.scrollable,
+                password: element.password,
+                checkable: element.checkable,
+                checked: element.checked,
+                selected: element.selected,
+                longClickable: element.longClickable,
+                testTag: element.testTag,
+                role: element.role,
+                stateDescription: element.stateDescription,
+                errorMessage: element.errorMessage,
+                hintText: element.hintText,
+                viewId: element.viewId,
+                extras: element.extras,
+                actions: element.actions,
+                node: processedChildren
+            )
+        }
+
+        // Merge existing children with injected SDK-only nodes
+        var merged = processedChildren ?? []
+        merged.append(contentsOf: injected)
+
+        return UIElementInfo(
+            text: element.text,
+            textSize: element.textSize,
+            contentDesc: element.contentDesc,
+            resourceId: element.resourceId,
+            className: element.className,
+            bounds: element.bounds,
+            clickable: element.clickable,
+            enabled: element.enabled,
+            focusable: element.focusable,
+            focused: element.focused,
+            accessibilityFocused: element.accessibilityFocused,
+            scrollable: element.scrollable,
+            password: element.password,
+            checkable: element.checkable,
+            checked: element.checked,
+            selected: element.selected,
+            longClickable: element.longClickable,
+            testTag: element.testTag,
+            role: element.role,
+            stateDescription: element.stateDescription,
+            errorMessage: element.errorMessage,
+            hintText: element.hintText,
+            viewId: element.viewId,
+            extras: element.extras,
+            actions: element.actions,
+            node: merged.isEmpty ? nil : merged
+        )
+    }
+
+    /// Whether an SDK-only node is worth injecting into the XCUITest tree.
+    /// Skips purely structural container views that add no useful information.
+    private static func isWorthInjecting(_ node: SdkViewNode) -> Bool {
+        // Must have an accessibility identifier, label, custom actions, or be interactive
+        if node.accessibilityIdentifier != nil { return true }
+        if node.accessibilityLabel != nil { return true }
+        if !node.accessibilityCustomActions.isEmpty { return true }
+        if node.hasTapTarget { return true }
+        if node.accessibilityElementsHidden { return true }
+        if node.isAccessibilityElement { return true }
+        // Has meaningful visual properties (background, corner radius)
+        if node.backgroundColor != nil { return true }
+        if node.cornerRadius > 0 { return true }
+        // Has non-trivial children worth surfacing
+        if let children = node.children, children.contains(where: { isWorthInjecting($0) }) {
+            return true
+        }
+        return false
+    }
+
+    /// Convert an SDK node (and its subtree) to a UIElementInfo for injection.
+    private static func convertSdkNode(_ node: SdkViewNode) -> UIElementInfo {
+        var extras: [String: String] = ["sdk.source": "sdkWalker"]
+
+        if !node.accessibilityTraits.isEmpty {
+            extras["sdk.accessibilityTraits"] = node.accessibilityTraits.joined(separator: ",")
+        }
+        if !node.accessibilityCustomActions.isEmpty {
+            extras["sdk.accessibilityCustomActions"] = node.accessibilityCustomActions.joined(separator: ",")
+        }
+        if !node.gestureRecognizers.isEmpty {
+            let gestures = node.gestureRecognizers.map { "\($0.type)(\($0.isEnabled ? "enabled" : "disabled"))" }
+            extras["sdk.gestureRecognizers"] = gestures.joined(separator: ",")
+        }
+        if let bg = node.backgroundColor {
+            extras["sdk.backgroundColor"] = bg
+        }
+        extras["sdk.alpha"] = String(node.alpha)
+        if node.cornerRadius > 0 {
+            extras["sdk.cornerRadius"] = String(node.cornerRadius)
+        }
+        extras["sdk.isAccessibilityElement"] = String(node.isAccessibilityElement)
+        if node.accessibilityElementsHidden {
+            extras["sdk.accessibilityElementsHidden"] = "true"
+        }
+        extras["sdk.hasTapTarget"] = String(node.hasTapTarget)
+        if node.isOccluded {
+            extras["sdk.isOccluded"] = "true"
+        }
+        extras["sdk.isUserInteractionEnabled"] = String(node.isUserInteractionEnabled)
+
+        let convertedChildren: [UIElementInfo]? = node.children?.compactMap { child in
+            if isWorthInjecting(child) {
+                return convertSdkNode(child)
+            }
+            return nil
+        }
+
+        return UIElementInfo(
+            text: node.accessibilityLabel,
+            resourceId: node.accessibilityIdentifier,
+            className: node.className,
+            bounds: ElementBounds(
+                left: node.bounds.left,
+                top: node.bounds.top,
+                right: node.bounds.right,
+                bottom: node.bounds.bottom
+            ),
+            extras: extras,
+            node: convertedChildren?.isEmpty == true ? nil : convertedChildren
+        )
+    }
+
+    /// Build the exact (no tolerance) lookup key for an SDK node.
+    private static func exactKey(for node: SdkViewNode) -> LookupKey {
+        LookupKey(
+            className: node.className,
+            left: node.bounds.left,
+            top: node.bounds.top,
+            right: node.bounds.right,
+            bottom: node.bounds.bottom
+        )
     }
 }

--- a/ios/control-proxy/Sources/CtrlProxy/HierarchyMerger.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/HierarchyMerger.swift
@@ -29,9 +29,10 @@ public enum HierarchyMerger {
         // Pass 1: enrich existing XCUITest nodes with SDK extras
         let enrichedRoot = enrichNode(xcuitestRoot, lookup: lookup, boundsLookup: boundsLookup, identifierLookup: identifierLookup, allSdkNodes: allSdkNodes)
 
-        // Collect the set of SDK nodes that matched an XCUITest node
-        var matchedSdkKeys: Set<LookupKey> = []
-        collectMatchedKeys(element: xcuitestRoot, lookup: lookup, boundsLookup: boundsLookup, identifierLookup: identifierLookup, allSdkNodes: allSdkNodes, matched: &matchedSdkKeys)
+        // Collect a counted bag of SDK keys that matched an XCUITest node.
+        // Using counts (not a set) so identical-keyed siblings aren't collapsed.
+        var matchedSdkKeyCounts: [LookupKey: Int] = [:]
+        collectMatchedKeys(element: xcuitestRoot, lookup: lookup, boundsLookup: boundsLookup, identifierLookup: identifierLookup, allSdkNodes: allSdkNodes, matched: &matchedSdkKeyCounts)
 
         // Pass 2: inject SDK-only nodes as children of matched parents
         let injectedRoot = injectSdkOnlyNodes(
@@ -41,7 +42,7 @@ public enum HierarchyMerger {
             boundsLookup: boundsLookup,
             identifierLookup: identifierLookup,
             allSdkNodes: allSdkNodes,
-            matchedSdkKeys: matchedSdkKeys
+            matchedSdkKeyCounts: matchedSdkKeyCounts
         )
 
         return ViewHierarchy(
@@ -263,16 +264,18 @@ public enum HierarchyMerger {
     // MARK: - Pass 2: SDK-Only Node Injection
 
     /// Collect the exact lookup keys for SDK nodes that matched an XCUITest node.
+    /// Uses a counted bag so identical-keyed siblings each get their own match slot.
     private static func collectMatchedKeys(
         element: UIElementInfo,
         lookup: [LookupKey: SdkViewNode],
         boundsLookup: [BoundsKey: SdkViewNode],
         identifierLookup: [String: SdkViewNode],
         allSdkNodes: [SdkViewNode],
-        matched: inout Set<LookupKey>
+        matched: inout [LookupKey: Int]
     ) {
         if let sdkNode = findMatch(className: element.className, resourceId: element.resourceId, bounds: element.bounds, in: lookup, boundsLookup: boundsLookup, identifierLookup: identifierLookup, allSdkNodes: allSdkNodes) {
-            matched.insert(exactKey(for: sdkNode))
+            let key = exactKey(for: sdkNode)
+            matched[key, default: 0] += 1
         }
         if let children = element.node {
             for child in children {
@@ -291,7 +294,7 @@ public enum HierarchyMerger {
         boundsLookup: [BoundsKey: SdkViewNode],
         identifierLookup: [String: SdkViewNode],
         allSdkNodes: [SdkViewNode],
-        matchedSdkKeys: Set<LookupKey>
+        matchedSdkKeyCounts: [LookupKey: Int]
     ) -> UIElementInfo {
         // Find the SDK node that corresponds to this XCUITest element
         let currentSdk = sdkNode ?? findMatch(
@@ -314,16 +317,21 @@ public enum HierarchyMerger {
                 boundsLookup: boundsLookup,
                 identifierLookup: identifierLookup,
                 allSdkNodes: allSdkNodes,
-                matchedSdkKeys: matchedSdkKeys
+                matchedSdkKeyCounts: matchedSdkKeyCounts
             )
         }
 
-        // Find SDK children of this node that have no XCUITest counterpart
+        // Find SDK children of this node that have no XCUITest counterpart.
+        // Use a local count to handle identical siblings: if 3 SDK children share
+        // a key but only 2 were matched, the 3rd should still be injected.
         var injected: [UIElementInfo] = []
         if let sdkChildren = currentSdk?.children {
+            var localKeyCounts: [LookupKey: Int] = [:]
             for sdkChild in sdkChildren {
                 let childKey = exactKey(for: sdkChild)
-                if !matchedSdkKeys.contains(childKey) && isWorthInjecting(sdkChild) {
+                localKeyCounts[childKey, default: 0] += 1
+                let matchedCount = matchedSdkKeyCounts[childKey] ?? 0
+                if localKeyCounts[childKey]! > matchedCount && isWorthInjecting(sdkChild) {
                     injected.append(convertSdkNode(sdkChild))
                 }
             }

--- a/ios/control-proxy/Tests/CtrlProxyTests/HierarchyMergerTests.swift
+++ b/ios/control-proxy/Tests/CtrlProxyTests/HierarchyMergerTests.swift
@@ -27,6 +27,7 @@ final class HierarchyMergerTests: XCTestCase {
         className: String = "UIView",
         bounds: SdkBounds = SdkBounds(left: 0, top: 0, right: 100, bottom: 100),
         accessibilityLabel: String? = nil,
+        accessibilityIdentifier: String? = nil,
         accessibilityTraits: [String] = [],
         accessibilityCustomActions: [String] = [],
         gestureRecognizers: [SdkGestureInfo] = [],
@@ -44,6 +45,7 @@ final class HierarchyMergerTests: XCTestCase {
             className: className,
             bounds: bounds,
             accessibilityLabel: accessibilityLabel,
+            accessibilityIdentifier: accessibilityIdentifier,
             isAccessibilityElement: isAccessibilityElement,
             accessibilityElementsHidden: accessibilityElementsHidden,
             accessibilityTraits: accessibilityTraits,
@@ -176,17 +178,18 @@ final class HierarchyMergerTests: XCTestCase {
         XCTAssertNil(result.hierarchy?.extras)
     }
 
-    // MARK: - Class Name Mismatch
+    // MARK: - Class Name Mismatch (bounds-only fallback)
 
-    func testClassNameMismatchNoMatch() {
+    func testClassNameMismatchMatchesByBounds() {
         let xcuiRoot = makeElement(
-            className: "UIButton",
+            className: "UIView",
             bounds: ElementBounds(left: 10, top: 20, right: 100, bottom: 50)
         )
         let sdkRoot = makeSdkNode(
-            className: "UILabel",
+            className: "_UIHostingView",
             bounds: SdkBounds(left: 10, top: 20, right: 100, bottom: 50),
-            accessibilityTraits: ["staticText"]
+            backgroundColor: "#FF0000FF",
+            cornerRadius: 8.0
         )
 
         let result = HierarchyMerger.merge(
@@ -194,7 +197,73 @@ final class HierarchyMergerTests: XCTestCase {
             sdk: makeSdkHierarchy(root: sdkRoot)
         )
 
-        XCTAssertNil(result.hierarchy?.extras)
+        let extras = result.hierarchy?.extras
+        XCTAssertNotNil(extras, "Bounds-only fallback should match even when class names differ")
+        XCTAssertEqual(extras?["sdk.backgroundColor"], "#FF0000FF")
+        XCTAssertEqual(extras?["sdk.cornerRadius"], "8.0")
+    }
+
+    func testExactClassMatchPreferredOverBoundsOnly() {
+        let xcuiRoot = makeElement(
+            className: "UILabel",
+            bounds: ElementBounds(left: 10, top: 20, right: 100, bottom: 50)
+        )
+        let exactSdkNode = makeSdkNode(
+            className: "UILabel",
+            bounds: SdkBounds(left: 10, top: 20, right: 100, bottom: 50),
+            accessibilityTraits: ["staticText"],
+            backgroundColor: "#00FF00FF"
+        )
+        let otherSdkNode = makeSdkNode(
+            className: "_UIHostingView",
+            bounds: SdkBounds(left: 10, top: 20, right: 100, bottom: 50),
+            backgroundColor: "#FF0000FF"
+        )
+        let sdkRoot = makeSdkNode(
+            className: "UIView",
+            bounds: SdkBounds(left: 0, top: 0, right: 375, bottom: 812),
+            children: [exactSdkNode, otherSdkNode]
+        )
+        let xcuiWrapper = makeElement(
+            className: "UIView",
+            bounds: ElementBounds(left: 0, top: 0, right: 375, bottom: 812),
+            children: [xcuiRoot]
+        )
+
+        let result = HierarchyMerger.merge(
+            xcuitest: makeHierarchy(root: xcuiWrapper),
+            sdk: makeSdkHierarchy(root: sdkRoot)
+        )
+
+        let childExtras = result.hierarchy?.node?.first?.extras
+        XCTAssertEqual(childExtras?["sdk.accessibilityTraits"], "staticText")
+        XCTAssertEqual(childExtras?["sdk.backgroundColor"], "#00FF00FF")
+    }
+
+    func testIdentifierFallbackMatchesDifferentBounds() {
+        // XCUITest and SDK have different bounds but same accessibilityIdentifier
+        let xcuiWithId = UIElementInfo(
+            resourceId: "layered-stack",
+            className: "UIView",
+            bounds: ElementBounds(left: 10, top: 100, right: 200, bottom: 300)
+        )
+        let sdkRoot = makeSdkNode(
+            className: "_UIHostingView",
+            bounds: SdkBounds(left: 15, top: 105, right: 205, bottom: 305),
+            accessibilityIdentifier: "layered-stack",
+            backgroundColor: "#0000FFFF",
+            cornerRadius: 16.0
+        )
+
+        let result = HierarchyMerger.merge(
+            xcuitest: makeHierarchy(root: xcuiWithId),
+            sdk: makeSdkHierarchy(root: sdkRoot)
+        )
+
+        let extras = result.hierarchy?.extras
+        XCTAssertNotNil(extras, "Identifier fallback should match when bounds differ")
+        XCTAssertEqual(extras?["sdk.backgroundColor"], "#0000FFFF")
+        XCTAssertEqual(extras?["sdk.cornerRadius"], "16.0")
     }
 
     // MARK: - Children
@@ -295,6 +364,247 @@ final class HierarchyMergerTests: XCTestCase {
         let extras = result.hierarchy?.extras
         XCTAssertEqual(extras?["custom.key"], "custom.value")
         XCTAssertEqual(extras?["sdk.hasTapTarget"], "true")
+    }
+
+    // MARK: - SDK-Only Node Injection
+
+    func testSdkOnlyNodeWithIdentifierInjected() {
+        // XCUITest tree has a parent but is missing a child that the SDK tree has
+        let xcuiRoot = makeElement(
+            className: "UIView",
+            bounds: ElementBounds(left: 0, top: 0, right: 390, bottom: 844)
+        )
+        // SDK tree has same parent + a child with an accessibilityIdentifier
+        let sdkChild = makeSdkNode(
+            className: "UIView",
+            bounds: SdkBounds(left: 10, top: 10, right: 100, bottom: 50),
+            accessibilityIdentifier: "decorative-divider",
+            backgroundColor: "#FF0000FF",
+            cornerRadius: 4,
+            children: nil
+        )
+        let sdkRoot = makeSdkNode(
+            className: "UIView",
+            bounds: SdkBounds(left: 0, top: 0, right: 390, bottom: 844),
+            children: [sdkChild]
+        )
+
+        let result = HierarchyMerger.merge(
+            xcuitest: makeHierarchy(root: xcuiRoot),
+            sdk: makeSdkHierarchy(root: sdkRoot)
+        )
+
+        // The injected child should appear as a child of the root
+        let children = result.hierarchy?.node
+        XCTAssertNotNil(children)
+        XCTAssertEqual(children?.count, 1)
+
+        let injected = children?.first
+        XCTAssertEqual(injected?.className, "UIView")
+        XCTAssertEqual(injected?.resourceId, "decorative-divider")
+        XCTAssertEqual(injected?.extras?["sdk.source"], "sdkWalker")
+        XCTAssertEqual(injected?.extras?["sdk.backgroundColor"], "#FF0000FF")
+        XCTAssertEqual(injected?.extras?["sdk.cornerRadius"], "4.0")
+    }
+
+    func testSdkOnlyNodeWithCustomActionsInjected() {
+        let xcuiRoot = makeElement(
+            className: "UIView",
+            bounds: ElementBounds(left: 0, top: 0, right: 390, bottom: 844)
+        )
+        let sdkChild = makeSdkNode(
+            className: "UIView",
+            bounds: SdkBounds(left: 0, top: 100, right: 390, bottom: 200),
+            accessibilityLabel: "Message from Alice",
+            accessibilityCustomActions: ["Reply", "Forward", "Delete"]
+        )
+        let sdkRoot = makeSdkNode(
+            className: "UIView",
+            bounds: SdkBounds(left: 0, top: 0, right: 390, bottom: 844),
+            children: [sdkChild]
+        )
+
+        let result = HierarchyMerger.merge(
+            xcuitest: makeHierarchy(root: xcuiRoot),
+            sdk: makeSdkHierarchy(root: sdkRoot)
+        )
+
+        let injected = result.hierarchy?.node?.first
+        XCTAssertNotNil(injected)
+        XCTAssertEqual(injected?.text, "Message from Alice")
+        XCTAssertEqual(injected?.extras?["sdk.accessibilityCustomActions"], "Reply,Forward,Delete")
+        XCTAssertEqual(injected?.extras?["sdk.source"], "sdkWalker")
+    }
+
+    func testSdkOnlyNodeWithA11yHiddenInjected() {
+        let xcuiRoot = makeElement(
+            className: "UIView",
+            bounds: ElementBounds(left: 0, top: 0, right: 390, bottom: 844)
+        )
+        let sdkChild = makeSdkNode(
+            className: "UILabel",
+            bounds: SdkBounds(left: 10, top: 50, right: 200, bottom: 80),
+            accessibilityLabel: "Hidden helper text",
+            accessibilityElementsHidden: true
+        )
+        let sdkRoot = makeSdkNode(
+            className: "UIView",
+            bounds: SdkBounds(left: 0, top: 0, right: 390, bottom: 844),
+            children: [sdkChild]
+        )
+
+        let result = HierarchyMerger.merge(
+            xcuitest: makeHierarchy(root: xcuiRoot),
+            sdk: makeSdkHierarchy(root: sdkRoot)
+        )
+
+        let injected = result.hierarchy?.node?.first
+        XCTAssertNotNil(injected)
+        XCTAssertEqual(injected?.className, "UILabel")
+        XCTAssertEqual(injected?.text, "Hidden helper text")
+        XCTAssertEqual(injected?.extras?["sdk.accessibilityElementsHidden"], "true")
+        XCTAssertEqual(injected?.extras?["sdk.source"], "sdkWalker")
+    }
+
+    func testMatchedSdkNodeNotDuplicatedAsInjection() {
+        // Both trees have the same child — it should be enriched, not injected
+        let xcuiChild = makeElement(
+            className: "UILabel",
+            bounds: ElementBounds(left: 10, top: 50, right: 200, bottom: 80),
+            text: "Hello"
+        )
+        let xcuiRoot = makeElement(
+            className: "UIView",
+            bounds: ElementBounds(left: 0, top: 0, right: 390, bottom: 844),
+            children: [xcuiChild]
+        )
+        let sdkChild = makeSdkNode(
+            className: "UILabel",
+            bounds: SdkBounds(left: 10, top: 50, right: 200, bottom: 80),
+            accessibilityTraits: ["staticText"]
+        )
+        let sdkRoot = makeSdkNode(
+            className: "UIView",
+            bounds: SdkBounds(left: 0, top: 0, right: 390, bottom: 844),
+            children: [sdkChild]
+        )
+
+        let result = HierarchyMerger.merge(
+            xcuitest: makeHierarchy(root: xcuiRoot),
+            sdk: makeSdkHierarchy(root: sdkRoot)
+        )
+
+        // Should still be exactly 1 child (enriched, not duplicated)
+        XCTAssertEqual(result.hierarchy?.node?.count, 1)
+        let child = result.hierarchy?.node?.first
+        XCTAssertEqual(child?.text, "Hello")
+        XCTAssertEqual(child?.extras?["sdk.accessibilityTraits"], "staticText")
+        XCTAssertNil(child?.extras?["sdk.source"]) // Not injected, just enriched
+    }
+
+    func testStructuralOnlyNodeNotInjected() {
+        // SDK child has no identifier, label, actions, or visual properties — skip it
+        let xcuiRoot = makeElement(
+            className: "UIView",
+            bounds: ElementBounds(left: 0, top: 0, right: 390, bottom: 844)
+        )
+        let sdkChild = makeSdkNode(
+            className: "UITransitionView",
+            bounds: SdkBounds(left: 0, top: 0, right: 390, bottom: 844)
+        )
+        let sdkRoot = makeSdkNode(
+            className: "UIView",
+            bounds: SdkBounds(left: 0, top: 0, right: 390, bottom: 844),
+            children: [sdkChild]
+        )
+
+        let result = HierarchyMerger.merge(
+            xcuitest: makeHierarchy(root: xcuiRoot),
+            sdk: makeSdkHierarchy(root: sdkRoot)
+        )
+
+        // Structural-only node should not be injected
+        XCTAssertNil(result.hierarchy?.node)
+    }
+
+    func testNestedSdkOnlyChildrenInjected() {
+        // SDK-only parent with a meaningful child — both should be injected
+        let xcuiRoot = makeElement(
+            className: "UIView",
+            bounds: ElementBounds(left: 0, top: 0, right: 390, bottom: 844)
+        )
+        let sdkGrandchild = makeSdkNode(
+            className: "UIImageView",
+            bounds: SdkBounds(left: 20, top: 20, right: 60, bottom: 60),
+            accessibilityIdentifier: "nested-icon"
+        )
+        let sdkChild = makeSdkNode(
+            className: "UIView",
+            bounds: SdkBounds(left: 10, top: 10, right: 100, bottom: 100),
+            accessibilityIdentifier: "nested-container",
+            children: [sdkGrandchild]
+        )
+        let sdkRoot = makeSdkNode(
+            className: "UIView",
+            bounds: SdkBounds(left: 0, top: 0, right: 390, bottom: 844),
+            children: [sdkChild]
+        )
+
+        let result = HierarchyMerger.merge(
+            xcuitest: makeHierarchy(root: xcuiRoot),
+            sdk: makeSdkHierarchy(root: sdkRoot)
+        )
+
+        let injectedParent = result.hierarchy?.node?.first
+        XCTAssertNotNil(injectedParent)
+        XCTAssertEqual(injectedParent?.resourceId, "nested-container")
+        XCTAssertEqual(injectedParent?.extras?["sdk.source"], "sdkWalker")
+
+        let injectedChild = injectedParent?.node?.first
+        XCTAssertNotNil(injectedChild)
+        XCTAssertEqual(injectedChild?.resourceId, "nested-icon")
+        XCTAssertEqual(injectedChild?.extras?["sdk.source"], "sdkWalker")
+    }
+
+    func testInjectedNodePreservesExistingChildren() {
+        // XCUITest parent has existing children; SDK-only nodes should be appended
+        let xcuiChild = makeElement(
+            className: "UILabel",
+            bounds: ElementBounds(left: 10, top: 10, right: 200, bottom: 40),
+            text: "Existing"
+        )
+        let xcuiRoot = makeElement(
+            className: "UIView",
+            bounds: ElementBounds(left: 0, top: 0, right: 390, bottom: 844),
+            children: [xcuiChild]
+        )
+        let sdkExisting = makeSdkNode(
+            className: "UILabel",
+            bounds: SdkBounds(left: 10, top: 10, right: 200, bottom: 40)
+        )
+        let sdkNew = makeSdkNode(
+            className: "UIView",
+            bounds: SdkBounds(left: 10, top: 50, right: 200, bottom: 100),
+            accessibilityIdentifier: "sdk-only-view",
+            backgroundColor: "#00FF00FF"
+        )
+        let sdkRoot = makeSdkNode(
+            className: "UIView",
+            bounds: SdkBounds(left: 0, top: 0, right: 390, bottom: 844),
+            children: [sdkExisting, sdkNew]
+        )
+
+        let result = HierarchyMerger.merge(
+            xcuitest: makeHierarchy(root: xcuiRoot),
+            sdk: makeSdkHierarchy(root: sdkRoot)
+        )
+
+        let children = result.hierarchy?.node
+        XCTAssertEqual(children?.count, 2)
+        XCTAssertEqual(children?[0].text, "Existing")
+        XCTAssertNil(children?[0].extras?["sdk.source"])
+        XCTAssertEqual(children?[1].resourceId, "sdk-only-view")
+        XCTAssertEqual(children?[1].extras?["sdk.source"], "sdkWalker")
     }
 
     // MARK: - Hierarchy Metadata Preserved

--- a/scripts/ios/kill-all-simulators.sh
+++ b/scripts/ios/kill-all-simulators.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+#
+# Kill All iOS Simulators
+#
+# Shuts down every booted iOS simulator. Safe to run when none are running.
+#
+# Usage:
+#   ./scripts/ios/kill-all-simulators.sh
+#
+# Outputs:
+#   stderr - progress messages
+#   exit 0 - always (even if no simulators were running)
+
+set -euo pipefail
+
+BOOTED_JSON=$(xcrun simctl list devices booted --json)
+BOOTED_COUNT=$(echo "${BOOTED_JSON}" | jq '[.devices | to_entries[] | .value[]] | length')
+
+if [[ "${BOOTED_COUNT}" -eq 0 ]]; then
+  echo "No booted iOS simulators found." >&2
+  exit 0
+fi
+
+echo "Found ${BOOTED_COUNT} booted simulator(s), shutting down..." >&2
+
+# List each one before killing
+echo "${BOOTED_JSON}" | jq -r '
+  .devices | to_entries[] | .value[]
+  | "  \(.name) (\(.udid)) state=\(.state)"
+' >&2
+
+xcrun simctl shutdown all
+
+echo "All simulators shut down." >&2

--- a/scripts/ios/start-simulator.sh
+++ b/scripts/ios/start-simulator.sh
@@ -1,0 +1,185 @@
+#!/usr/bin/env bash
+#
+# Start an iOS Simulator and Wait for Readiness
+#
+# Boots an iOS simulator by name or UDID, then blocks until the device is
+# fully ready using `xcrun simctl bootstatus`. This mirrors what the
+# existing boot-simulator.sh does but accepts a device identifier directly,
+# making it useful for quick iteration and debugging boot-await timing.
+#
+# Usage:
+#   ./scripts/ios/start-simulator.sh [OPTIONS]
+#
+# Options:
+#   --udid UDID            Boot simulator by UDID
+#   --name NAME            Boot first matching simulator by name (e.g. "iPhone 16")
+#   --ios-version VERSION  Filter by iOS version when using --name (default: auto-detect)
+#   --timeout SECONDS      Boot timeout in seconds (default: 120)
+#   --prefer-booted        If a matching simulator is already booted, reuse it
+#
+# Outputs:
+#   stdout - JSON: { "udid": "...", "name": "...", "state": "Booted", "bootDurationMs": N }
+#   stderr - progress messages
+
+set -euo pipefail
+
+UDID=""
+NAME=""
+IOS_VERSION=""
+TIMEOUT_SECS=120
+PREFER_BOOTED=false
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --udid)        UDID="$2"; shift 2 ;;
+    --name)        NAME="$2"; shift 2 ;;
+    --ios-version) IOS_VERSION="$2"; shift 2 ;;
+    --timeout)     TIMEOUT_SECS="$2"; shift 2 ;;
+    --prefer-booted) PREFER_BOOTED=true; shift ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      exit 1
+      ;;
+  esac
+done
+
+if [[ -z "${UDID}" && -z "${NAME}" ]]; then
+  echo "error: must specify --udid or --name" >&2
+  exit 1
+fi
+
+# ── Helper: resolve UDID from name ───────────────────────────────────────────
+
+resolve_udid_from_name() {
+  local name="$1"
+  local version_filter="${2:-}"
+  local devices_json
+
+  devices_json=$(xcrun simctl list devices available --json)
+
+  if [[ -n "${version_filter}" ]]; then
+    # Look up runtime identifier for the requested version
+    local runtimes_json major_minor major runtime_id
+    runtimes_json=$(xcrun simctl list runtimes iOS --json)
+    major_minor="${version_filter%.*}"
+    major="${major_minor%%.*}"
+
+    pick_runtime() {
+      echo "${runtimes_json}" \
+        | jq -r --arg v "$1" '
+            [.runtimes[] | select(.version | startswith($v))]
+            | sort_by(.version) | last
+            | .identifier // empty
+          '
+    }
+
+    runtime_id=$(pick_runtime "${version_filter}")
+    [[ -z "${runtime_id}" ]] && runtime_id=$(pick_runtime "${major_minor}.")
+    [[ -z "${runtime_id}" ]] && runtime_id=$(pick_runtime "${major}.")
+
+    if [[ -z "${runtime_id}" ]]; then
+      echo "error: no runtime found for iOS ${version_filter}" >&2
+      return 1
+    fi
+
+    echo "${devices_json}" | jq -r --arg name "${name}" --arg rt "${runtime_id}" '
+      .devices | to_entries[]
+      | select(.key == $rt)
+      | .value[]
+      | select(.name | contains($name))
+      | .udid
+    ' | head -1
+  else
+    echo "${devices_json}" | jq -r --arg name "${name}" '
+      .devices | to_entries[] | .value[]
+      | select(.name | contains($name))
+      | .udid
+    ' | head -1
+  fi
+}
+
+# ── Helper: check if a UDID is already booted ────────────────────────────────
+
+is_booted() {
+  local udid="$1"
+  xcrun simctl list devices booted --json \
+    | jq -e --arg udid "${udid}" '
+        .devices | to_entries[] | .value[]
+        | select(.udid == $udid)
+      ' > /dev/null 2>&1
+}
+
+# ── Helper: get device name from UDID ────────────────────────────────────────
+
+get_device_name() {
+  local udid="$1"
+  xcrun simctl list devices --json \
+    | jq -r --arg udid "${udid}" '
+        .devices | to_entries[] | .value[]
+        | select(.udid == $udid) | .name
+      '
+}
+
+# ── Resolve target UDID ──────────────────────────────────────────────────────
+
+if [[ -z "${UDID}" ]]; then
+  echo "Resolving simulator matching '${NAME}'..." >&2
+  UDID=$(resolve_udid_from_name "${NAME}" "${IOS_VERSION}")
+  if [[ -z "${UDID}" ]]; then
+    echo "error: no available simulator matching '${NAME}'" >&2
+    xcrun simctl list devices available 2>/dev/null | head -30 >&2
+    exit 1
+  fi
+fi
+
+DEVICE_NAME=$(get_device_name "${UDID}")
+echo "Target: ${DEVICE_NAME} (${UDID})" >&2
+
+# ── Check for already-booted device ──────────────────────────────────────────
+
+if is_booted "${UDID}"; then
+  if [[ "${PREFER_BOOTED}" == "true" ]]; then
+    echo "Simulator already booted, reusing." >&2
+    jq -n --arg udid "${UDID}" --arg name "${DEVICE_NAME}" \
+      '{ udid: $udid, name: $name, state: "Booted", bootDurationMs: 0, source: "already-booted" }'
+    exit 0
+  else
+    echo "Simulator already booted. Shutting down first for clean boot..." >&2
+    xcrun simctl shutdown "${UDID}"
+    sleep 1
+  fi
+fi
+
+# ── Boot and await ────────────────────────────────────────────────────────────
+
+echo "Booting ${DEVICE_NAME}..." >&2
+millis_now() { python3 -c 'import time; print(int(time.time()*1000))'; }
+BOOT_START=$(millis_now)
+
+xcrun simctl boot "${UDID}"
+
+echo "Waiting for boot to complete (timeout: ${TIMEOUT_SECS}s)..." >&2
+
+# bootstatus -b blocks until the device is fully booted.
+# It exits 0 on success, non-zero on failure/timeout.
+if ! timeout "${TIMEOUT_SECS}" xcrun simctl bootstatus "${UDID}" -b >&2; then
+  echo "error: simulator boot did not complete within ${TIMEOUT_SECS}s" >&2
+  echo "Current state:" >&2
+  xcrun simctl list devices --json | jq --arg udid "${UDID}" '
+    .devices | to_entries[] | .value[] | select(.udid == $udid)
+  ' >&2
+  exit 1
+fi
+
+BOOT_END=$(millis_now)
+BOOT_DURATION=$(( BOOT_END - BOOT_START ))
+
+echo "Booted: ${DEVICE_NAME} (${UDID}) in ${BOOT_DURATION}ms" >&2
+
+# ── Output JSON ───────────────────────────────────────────────────────────────
+
+jq -n \
+  --arg udid "${UDID}" \
+  --arg name "${DEVICE_NAME}" \
+  --argjson durationMs "${BOOT_DURATION}" \
+  '{ udid: $udid, name: $name, state: "Booted", bootDurationMs: $durationMs, source: "cold-boot" }'

--- a/src/constants/release.ts
+++ b/src/constants/release.ts
@@ -26,7 +26,7 @@ export const RELEASE_VERSION: string = LATEST_RELEASE_VERSION;
 export const APK_URL: string = RELEASE_VERSION === LATEST_RELEASE_VERSION
   ? `https://github.com/kaeawc/auto-mobile/releases/latest/download/control-proxy-debug.apk`
   : `https://github.com/kaeawc/auto-mobile/releases/download/v${RELEASE_VERSION}/control-proxy-debug.apk`;
-export const APK_SHA256_CHECKSUM: string = "d94eab8b95cf03b6e64cf72c6e6989256e9e4ccc912a8c756072508a9abd8361"; // Empty = skip verification (local dev only)
+export const APK_SHA256_CHECKSUM: string = "3965e3cef026c9b71a142b7682f72dfe9af772e32f6e281769427e6e30b56395"; // Empty = skip verification (local dev only)
 
 /**
  * iOS CtrlProxy Release Constants

--- a/src/features/observe/ios/CtrlProxyClient.ts
+++ b/src/features/observe/ios/CtrlProxyClient.ts
@@ -896,8 +896,12 @@ export class CtrlProxyClient extends DeviceServiceClient implements CtrlProxySer
       // Record layout telemetry event using converted hierarchy (same format as observation stream)
       const converted = this.convertToViewHierarchyResult(message.data);
       this.recordLayoutTelemetryEvent(converted);
-      // Push to observation stream for IDE plugins (request-response path)
-      this.pushHierarchyToObservationStream(converted);
+      // Only push to observation stream for request-response updates (with requestId).
+      // Push messages (no requestId) are handled in the dedicated push-message branch below
+      // to avoid duplicate hierarchy events.
+      if (requestId) {
+        this.pushHierarchyToObservationStream(converted);
+      }
     }
 
     // Handle request/response messages (with requestId) first

--- a/src/features/observe/ios/CtrlProxyClient.ts
+++ b/src/features/observe/ios/CtrlProxyClient.ts
@@ -896,6 +896,8 @@ export class CtrlProxyClient extends DeviceServiceClient implements CtrlProxySer
       // Record layout telemetry event using converted hierarchy (same format as observation stream)
       const converted = this.convertToViewHierarchyResult(message.data);
       this.recordLayoutTelemetryEvent(converted);
+      // Push to observation stream for IDE plugins (request-response path)
+      this.pushHierarchyToObservationStream(converted);
     }
 
     // Handle request/response messages (with requestId) first

--- a/src/features/observe/ios/CtrlProxyHierarchy.ts
+++ b/src/features/observe/ios/CtrlProxyHierarchy.ts
@@ -18,6 +18,13 @@ import type {
   CachedHierarchy,
 } from "./types";
 
+/** Converted node format — `$` carries standard attributes, `extras` carries SDK walker data. */
+interface ConvertedNode {
+  $: Record<string, string>;
+  extras?: Record<string, string>;
+  node?: ConvertedNode[];
+}
+
 /**
  * Delegate class for handling hierarchy operations.
  */
@@ -202,7 +209,7 @@ export class CtrlProxyHierarchy {
 
     return {
       hierarchy: {
-        node: filteredNode
+        node: filteredNode ?? undefined
       },
       packageName: hierarchy.packageName,
       updatedAt: hierarchy.updatedAt,
@@ -219,7 +226,7 @@ export class CtrlProxyHierarchy {
   // Private helper methods
   // ===========================================================================
 
-  private convertNode(node: CtrlProxyNode): { $: Record<string, string>; node?: Array<{ $: Record<string, string> }> } {
+  private convertNode(node: CtrlProxyNode): ConvertedNode {
     const attrs: Record<string, string> = {};
 
     if (node.text) {attrs["text"] = node.text;}
@@ -256,7 +263,11 @@ export class CtrlProxyHierarchy {
     if (hintText) {attrs["hint-text"] = hintText;}
     if (viewId) {attrs["view-id"] = viewId;}
 
-    const result: { $: Record<string, string>; node?: Array<{ $: Record<string, string> }> } = { $: attrs };
+    const result: ConvertedNode = { $: attrs };
+
+    if (node.extras && Object.keys(node.extras).length > 0) {
+      result.extras = node.extras;
+    }
 
     if (node.node) {
       const children = Array.isArray(node.node) ? node.node : [node.node];
@@ -355,16 +366,16 @@ export class CtrlProxyHierarchy {
    * Similar to Android's optimizeHierarchy + filterViewHierarchy
    */
   private filterHierarchyNode(
-    node: { $: Record<string, string>; node?: Array<{ $: Record<string, string> }> },
+    node: ConvertedNode,
     isRoot: boolean = false
-  ): { $: Record<string, string>; node?: Array<{ $: Record<string, string> }> } | null {
+  ): ConvertedNode | null {
     const attrs = node.$ || {};
     const children = node.node || [];
 
     // Process children first (recursively)
-    const filteredChildren: Array<{ $: Record<string, string> }> = [];
+    const filteredChildren: ConvertedNode[] = [];
     for (const child of children) {
-      const filtered = this.filterHierarchyNode(child as { $: Record<string, string>; node?: Array<{ $: Record<string, string> }> });
+      const filtered = this.filterHierarchyNode(child);
       if (filtered) {
         // If child filtering returned an array (promoted grandchildren), flatten it
         if (Array.isArray(filtered)) {
@@ -378,7 +389,8 @@ export class CtrlProxyHierarchy {
     // Root node is always kept
     if (isRoot) {
       const cleanedAttrs = this.cleanAttributes(attrs);
-      const result: { $: Record<string, string>; node?: Array<{ $: Record<string, string> }> } = { $: cleanedAttrs };
+      const result: ConvertedNode = { $: cleanedAttrs };
+      if (node.extras) { result.extras = node.extras; }
       if (filteredChildren.length > 0) {
         result.node = filteredChildren;
       }
@@ -390,7 +402,7 @@ export class CtrlProxyHierarchy {
       // Promote children (collapse this wrapper)
       if (filteredChildren.length > 0) {
         // Return children to be flattened into parent
-        return filteredChildren as unknown as { $: Record<string, string>; node?: Array<{ $: Record<string, string> }> };
+        return filteredChildren as unknown as ConvertedNode;
       }
       // No children and no content - filter out completely
       return null;
@@ -413,7 +425,8 @@ export class CtrlProxyHierarchy {
     }
 
     const cleanedAttrs = this.cleanAttributes(attrs);
-    const result: { $: Record<string, string>; node?: Array<{ $: Record<string, string> }> } = { $: cleanedAttrs };
+    const result: ConvertedNode = { $: cleanedAttrs };
+    if (node.extras) { result.extras = node.extras; }
     if (filteredChildren.length > 0) {
       result.node = filteredChildren;
     }

--- a/src/features/observe/ios/types.ts
+++ b/src/features/observe/ios/types.ts
@@ -50,6 +50,7 @@ export interface CtrlProxyNode {
   errorMessage?: string;
   hintText?: string;
   actions?: string[];
+  extras?: Record<string, string>;
   node?: CtrlProxyNode | CtrlProxyNode[];
 }
 

--- a/src/server/deviceTools.ts
+++ b/src/server/deviceTools.ts
@@ -97,6 +97,7 @@ export interface DeviceToolsDependencies {
   deviceManagerFactory: () => PlatformDeviceManager;
   deviceMatcherFactory: () => DeviceMatcher;
   notifyResourcesChanged: () => Promise<void>;
+  ensureCtrlProxyReady?: (device: BootedDevice, perf: ReturnType<typeof createPerformanceTracker>) => Promise<void>;
 }
 
 async function defaultNotifyResourcesChanged(): Promise<void> {
@@ -380,7 +381,9 @@ export function registerDeviceTools() {
   ) {
     // Ensure iOS automation proxy is installed and running before returning.
     // This avoids the first observe/tap call paying the full setup cost.
-    await ensureCtrlProxyReady(device, perf);
+    const deps = getDeviceToolsDependencies();
+    const ctrlProxySetup = deps.ensureCtrlProxyReady ?? ensureCtrlProxyReady;
+    await ctrlProxySetup(device, perf);
 
     // Always generate a session ID for consistent device interactions.
     // When autolock is enabled, the session ID is enforced for all subsequent tool calls.

--- a/src/server/deviceTools.ts
+++ b/src/server/deviceTools.ts
@@ -125,6 +125,7 @@ export function setDeviceToolsDependencies(deps: Partial<DeviceToolsDependencies
     deviceManagerFactory: deps.deviceManagerFactory ?? currentDeps.deviceManagerFactory,
     deviceMatcherFactory: deps.deviceMatcherFactory ?? currentDeps.deviceMatcherFactory,
     notifyResourcesChanged: deps.notifyResourcesChanged ?? currentDeps.notifyResourcesChanged,
+    ensureCtrlProxyReady: deps.ensureCtrlProxyReady ?? currentDeps.ensureCtrlProxyReady,
   };
 }
 

--- a/src/server/deviceTools.ts
+++ b/src/server/deviceTools.ts
@@ -10,6 +10,7 @@ import { DEVICE_IMAGE_RESOURCE_URIS, notifyDeviceImageResourcesUpdated } from ".
 import { syncInstalledAppResources } from "./appResources";
 import { listActiveVideoRecordings, stopVideoRecording } from "./videoRecordingManager";
 import { IOSCtrlProxyManager } from "../utils/IOSCtrlProxyManager";
+import { CtrlProxyClient as IOSCtrlProxyClient } from "../features/observe/ios";
 import { logger } from "../utils/logger";
 import { createPerformanceTracker } from "../utils/PerformanceTracker";
 import { platformSchema } from "./toolSchemaHelpers";
@@ -40,7 +41,7 @@ const startDeviceParametersSchema = z.object({
   timeoutMs: z.number().optional().describe("Boot timeout in ms"),
 });
 
-export const startDeviceSchema = z.preprocess((input) => {
+export const startDeviceSchema = z.preprocess(input => {
   if (!input || typeof input !== "object" || Array.isArray(input)) {
     return input;
   }
@@ -328,6 +329,48 @@ export function registerDeviceTools() {
     );
   }
 
+  async function ensureCtrlProxyReady(
+    device: BootedDevice,
+    perf: ReturnType<typeof createPerformanceTracker>,
+  ) {
+    if (device.platform !== "ios") {
+      return;
+    }
+
+    perf.startOperation("ensureCtrlProxy");
+    try {
+      const manager = IOSCtrlProxyManager.getInstance(device);
+      const xcTestClient = IOSCtrlProxyClient.getInstance(device, manager.getServicePort());
+
+      // If WebSocket already connected and responsive, nothing to do
+      if (xcTestClient.isConnected()) {
+        const isReady = await xcTestClient.verifyServiceReady(2, 200, 2000);
+        if (isReady) {
+          logger.info(`[startDevice] CtrlProxy iOS already ready for ${device.deviceId}`);
+          perf.endOperation("ensureCtrlProxy");
+          return;
+        }
+      }
+
+      // Setup: download bundle if needed, start xcodebuild, wait for service
+      const setupResult = await manager.setup(false, perf);
+      if (!setupResult.success) {
+        logger.warn(`[startDevice] CtrlProxy iOS setup failed for ${device.deviceId}: ${setupResult.error ?? setupResult.message}`);
+        perf.endOperation("ensureCtrlProxy");
+        return;
+      }
+
+      // Wait for WebSocket connection and verify responsiveness
+      const connected = await xcTestClient.waitForConnection(5, 1000);
+      if (connected) {
+        await xcTestClient.verifyServiceReady(5, 1000, 5000);
+      }
+    } catch (error) {
+      logger.warn(`[startDevice] CtrlProxy iOS setup failed (non-fatal): ${error}`);
+    }
+    perf.endOperation("ensureCtrlProxy");
+  }
+
   async function buildBootedResponse(
     device: BootedDevice,
     source: "booted" | "cold-boot",
@@ -335,6 +378,10 @@ export function registerDeviceTools() {
     args: StartDeviceArgs,
     processId?: number,
   ) {
+    // Ensure iOS automation proxy is installed and running before returning.
+    // This avoids the first observe/tap call paying the full setup cost.
+    await ensureCtrlProxyReady(device, perf);
+
     // Always generate a session ID for consistent device interactions.
     // When autolock is enabled, the session ID is enforced for all subsequent tool calls.
     // When disabled, AutoMobile assumes a single agent and the session ID is advisory.

--- a/src/utils/deviceUtils.ts
+++ b/src/utils/deviceUtils.ts
@@ -184,7 +184,7 @@ export class MultiPlatformDeviceManager implements PlatformDeviceManager {
       case "android":
         return this.emulator.waitForEmulatorReady(device.name, timeoutMs, childProcess);
       case "ios":
-        return this.simctl.waitForSimulatorReady(device.deviceId ?? device.name);
+        return this.simctl.waitForSimulatorReady(device.deviceId ?? device.name, timeoutMs);
       default:
         throw new ActionableError("Unknown platform");
     }

--- a/src/utils/ios-cmdline-tools/SimCtlClient.ts
+++ b/src/utils/ios-cmdline-tools/SimCtlClient.ts
@@ -90,9 +90,10 @@ export interface SimCtl {
   /**
    * Wait for a simulator to be ready
    * @param udid - Device UDID to wait for
+   * @param timeoutMs - Maximum time to wait in milliseconds
    * @returns Promise with booted device information
    */
-  waitForSimulatorReady(udid: string): Promise<BootedDevice>;
+  waitForSimulatorReady(udid: string, timeoutMs?: number): Promise<BootedDevice>;
 
   /**
    * Get the list of available (booted and shutdown) simulator UDIDs
@@ -553,19 +554,36 @@ export class SimCtlClient implements SimCtl {
     await this.executeCommand(`shutdown ${device.deviceId}`);
   }
 
-  async waitForSimulatorReady(udid: string): Promise<BootedDevice> {
+  async waitForSimulatorReady(udid: string, timeoutMs?: number): Promise<BootedDevice> {
     const perf = createGlobalPerformanceTracker();
+
+    // Use `simctl bootstatus -b` which blocks until the simulator is fully
+    // booted (data migration complete, system app ready, springboard launched).
+    // This is far more reliable than polling `simctl list devices` for state.
+    perf.startOperation("bootstatus");
+    try {
+      await this.executeCommand(`bootstatus ${udid} -b`, timeoutMs);
+    } catch (error) {
+      perf.endOperation("bootstatus");
+      const message = error instanceof Error ? error.message : String(error);
+      // "Invalid device" means the UDID doesn't exist at all
+      if (message.includes("Invalid device")) {
+        throw new ActionableError(`Simulator with UDID ${udid} not found`);
+      }
+      throw new ActionableError(
+        `Simulator with UDID ${udid} failed to become ready: ${message}`
+      );
+    }
+    perf.endOperation("bootstatus");
+
+    // Now look up device metadata to return a full BootedDevice
     perf.startOperation("deviceLookup");
     const simulator = (await this.listSimulatorImages())
       .find(device => device.deviceId === udid);
     perf.endOperation("deviceLookup");
 
     if (!simulator) {
-      throw new ActionableError(`Simulator with UDID ${udid} not found`);
-    }
-
-    if (!simulator.isRunning) {
-      throw new ActionableError(`Simulator with UDID ${udid} is not running`);
+      throw new ActionableError(`Simulator with UDID ${udid} not found after boot`);
     }
 
     return {

--- a/test/fakes/FakeSimctl.ts
+++ b/test/fakes/FakeSimctl.ts
@@ -206,7 +206,7 @@ export class FakeSimctl implements ISimCtl {
     this.recordCall("killSimulator", { deviceId: device.deviceId });
   }
 
-  async waitForSimulatorReady(udid: string): Promise<BootedDevice> {
+  async waitForSimulatorReady(udid: string, _timeoutMs?: number): Promise<BootedDevice> {
     this.recordCall("waitForSimulatorReady", { udid });
     const simulator = this.bootedSimulators.find(s => s.deviceId === udid);
     if (simulator) {

--- a/test/server/deviceTools.startDevice.test.ts
+++ b/test/server/deviceTools.startDevice.test.ts
@@ -17,6 +17,7 @@ describe("startDevice handler", () => {
       deviceManagerFactory: () => fakeDeviceUtils,
       deviceMatcherFactory: () => fakeMatcher,
       notifyResourcesChanged: async () => {},
+      ensureCtrlProxyReady: async () => {},
     });
 
     registerDeviceTools();


### PR DESCRIPTION
## Summary
- **HierarchyMerger**: 4-strategy matching (exact className+bounds → bounds-only → accessibilityIdentifier → smallest-enclosing-node) so SDK properties like `backgroundColor`, `cornerRadius`, `alpha` appear on more nodes in the desktop property inspector — especially SwiftUI views where XCUITest and SDK walker report different class names/bounds
- **Xcode project**: Add missing file entries for HierarchyMerger, SdkHierarchyCache, SdkHierarchyModels, SdkHierarchyClient, and their tests
- **Playground DemosTab**: New demo sections (gesture recognition, layered views, hidden views, UIKit controls) for testing SDK walker enrichment
- **iOS observe pipeline**: TypeScript improvements to CtrlProxy hierarchy parsing, device tools, and SimCtl client
- **SDK walker**: ViewHierarchyWalker improvements for better property capture
- **Scripts**: New `kill-all-simulators.sh` and `start-simulator.sh` helper scripts

## Related
- Tracks with #1926 (CALayer introspection for pure SwiftUI shapes — future work)

## Test Plan
- [x] `./scripts/ios/swift-build.sh` passes
- [x] `./scripts/ios/swift-test.sh` — control-proxy tests pass (including new HierarchyMergerTests)
- [x] `./gradlew -p android :desktop-core:compileKotlin` passes
- [x] `turbo run build test` passes
- [x] Desktop app shows SDK Properties panel for iOS observation nodes

🤖 Generated with [Claude Code](https://claude.com/claude-code)