### PR TITLE
ci: install iOS Simulator runtime for CtrlProxy IPA build

### DIFF
--- a/.github/workflows/build-ctrl-proxy-ios-ipa.yml
+++ b/.github/workflows/build-ctrl-proxy-ios-ipa.yml
@@ -23,10 +23,13 @@ jobs:
         with:
           lfs: false
 
-      - name: "Select Xcode 26.0"
+      - name: "Select Xcode 26.3"
         uses: maxim-lobanov/setup-xcode@v1
         with:
-          xcode-version: "26.0"
+          xcode-version: "26.3"
+
+      - name: "Ensure iOS Simulator runtime"
+        uses: ./.github/actions/ensure-ios-simulator-runtime
 
       - name: "Cache Homebrew packages"
         uses: actions/cache@v5


### PR DESCRIPTION
## Summary
- The `prepare-release` workflow's CtrlProxy iOS IPA build was failing: `xcodebuild build-for-testing` could not find a destination matching `generic/platform=iOS Simulator` because the iOS 26.0 Simulator runtime was not installed on the `macos-26` runner (Xcode 26.0 slot resolves to 26.0.1 without the runtime preinstalled).
- Pin Xcode to 26.3 and add the existing `ensure-ios-simulator-runtime` composite action step, matching the pattern already used by `ios-xcode-build` in `merge.yml`.

## Test Plan
- [ ] `prepare-release` workflow succeeds at the CtrlProxy iOS IPA build step
- [ ] Generated IPA SHA256 is updated in the follow-up chore commit