### PR TITLE
chore: bump versions to v0.0.17

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -14,7 +14,7 @@
       "name": "auto-mobile",
       "source": "./",
       "description": "Mobile device automation for Android and iOS - control devices with natural language",
-      "version": "0.0.16",
+      "version": "0.0.17",
       "author": {
         "name": "AutoMobile Contributors",
         "email": "jason.d.pearson@gmail.com"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "auto-mobile",
   "description": "Mobile device automation for Android and iOS - control devices with natural language",
-  "version": "0.0.16",
+  "version": "0.0.17",
   "author": {
     "name": "AutoMobile Contributors",
     "email": "jason.d.pearson@gmail.com"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [v0.0.17] - 2026-04-16
+### Added
+- startDevice: accept generic parameters and return/boot matching device ([#1887](https://github.com/kaeawc/auto-mobile/issues/1887))
+- Add resource for installed app metadata (version, build number) ([#1886](https://github.com/kaeawc/auto-mobile/issues/1886))
+- Support iOS app installation in installApp ([#1885](https://github.com/kaeawc/auto-mobile/issues/1885)) (ios)
+- Add uninstallApp tool ([#1884](https://github.com/kaeawc/auto-mobile/issues/1884))
+
 ## [v0.0.16] - 2026-04-03
 ### Added
 - IDE Plugin: Implement screen stream display in Layout Inspector ([#1033](https://github.com/kaeawc/auto-mobile/issues/1033)) (android, ios)

--- a/android/control-proxy/build.gradle.kts
+++ b/android/control-proxy/build.gradle.kts
@@ -36,7 +36,7 @@ android {
     minSdk = libs.versions.build.android.minSdk.get().toInt()
     targetSdk = libs.versions.build.android.targetSdk.get().toInt()
     versionCode = 1
-    versionName = "0.0.16-SNAPSHOT"
+    versionName = "0.0.17-SNAPSHOT"
 
     testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
   }

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -140,7 +140,7 @@ org.jetbrains.dokka.experimental.gradle.pluginMode=V2Enabled
 # Maven Central Publishing
 
 # Library versions (single source of truth)
-VERSION_NAME=0.0.16-SNAPSHOT
+VERSION_NAME=0.0.17-SNAPSHOT
 GROUP=dev.jasonpearson.auto-mobile
 
 # POM metadata

--- a/android/playground/app/build.gradle.kts
+++ b/android/playground/app/build.gradle.kts
@@ -36,7 +36,7 @@ android {
     minSdk = libs.versions.build.android.minSdk.get().toInt()
     targetSdk = libs.versions.build.android.targetSdk.get().toInt()
     versionCode = 1
-    versionName = "0.0.16-SNAPSHOT"
+    versionName = "0.0.17-SNAPSHOT"
 
     testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kaeawc/auto-mobile",
-  "version": "0.0.16",
+  "version": "0.0.17",
   "description": "Mobile device interaction automation via MCP",
   "scripts": {
     "test": "bun test",

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "dev.jasonpearson/auto-mobile",
   "title": "AutoMobile",
   "description": "Mobile device interaction automation via MCP",
-  "version": "0.0.16",
+  "version": "0.0.17",
   "websiteUrl": "https://kaeawc.github.io/auto-mobile/",
   "repository": {
     "url": "https://github.com/kaeawc/auto-mobile",
@@ -13,7 +13,7 @@
     {
       "registryType": "npm",
       "identifier": "@kaeawc/auto-mobile",
-      "version": "0.0.16",
+      "version": "0.0.17",
       "runtimeHint": "bunx",
       "transport": {
         "type": "stdio"

--- a/src/constants/release.ts
+++ b/src/constants/release.ts
@@ -38,6 +38,6 @@ export const IOS_CTRL_PROXY_RELEASE_VERSION: string = LATEST_RELEASE_VERSION;
 export const IOS_CTRL_PROXY_IPA_URL: string = IOS_CTRL_PROXY_RELEASE_VERSION === LATEST_RELEASE_VERSION
   ? "https://github.com/kaeawc/auto-mobile/releases/latest/download/control-proxy.ipa"
   : `https://github.com/kaeawc/auto-mobile/releases/download/v${IOS_CTRL_PROXY_RELEASE_VERSION}/control-proxy.ipa`;
-export const IOS_CTRL_PROXY_SHA256_CHECKSUM: string = "133023cd5ba7d7f9e2673f3e8d27f77f709547b41f820295a0af8bc1fe2c6e2f"; // Empty = skip verification (local dev only)
+export const IOS_CTRL_PROXY_SHA256_CHECKSUM: string = "e4dcf064d024f2371b8fd79281000e2d49751ef95b8817d1494d685aeda746ac"; // Empty = skip verification (local dev only)
 export const IOS_CTRL_PROXY_APP_HASH: string = ""; // Hash of CtrlProxyApp.app (device build), empty = skip verification
 export const IOS_CTRL_PROXY_RUNNER_SHA256: string = ""; // SHA256 of runner binary (CtrlProxyUITests-Runner), empty = skip verification


### PR DESCRIPTION
## Summary
- Bump versions to v0.0.17
- Update CHANGELOG.md from closed issues since the last tag
- Refresh CtrlProxy APK SHA256 checksum
- Refresh CtrlProxy iOS IPA SHA256 checksum

## Automation
- Generated by `prepare-release` workflow