### PR TITLE
fix(ios): resolve foreground app for text input via ElementLocator (#1925)

### DIFF
--- a/ios/control-proxy/CtrlProxy.xcodeproj/project.pbxproj
+++ b/ios/control-proxy/CtrlProxy.xcodeproj/project.pbxproj
@@ -27,6 +27,7 @@
 		4A0FBEF6FAEF437AA17B20EA /* PerfProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = A284B6FFBE969931BB03A2FF /* PerfProvider.swift */; };
 		53A41EE5F98E771345D6EA90 /* WebSocketServer.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4CB9272A186932D89EB1072 /* WebSocketServer.swift */; };
 		5458E55CB48475D2487A49C3 /* HierarchyDebouncer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 034DC5B8A3A4FCE46CD89568 /* HierarchyDebouncer.swift */; };
+		5651AAF00833750D1DFD55CE /* Logging.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BF23F10C24C9F40E5CEC303 /* Logging.swift */; };
 		5BD7FFA4EE2841F197219322 /* DefaultStorageInspecting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1CFB4EDEE20CB1CE002E68A5 /* DefaultStorageInspecting.swift */; };
 		5DF6CF60A8796BBB8C80341C /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 0CDD96577EB9823B5FCF2585 /* Assets.xcassets */; };
 		5FDF9AE29841625DD7EFB7EC /* GesturePerformer.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2144B84CD70DB35A1030624 /* GesturePerformer.swift */; };
@@ -43,6 +44,7 @@
 		C1398B388B401E28BC727863 /* OSLogReader.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBA97A6C3A1240A055D9876C /* OSLogReader.swift */; };
 		C194D73F02D0776F0F7FCA7B /* CtrlProxy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0EE277596991C059142C485B /* CtrlProxy.swift */; };
 		C2DCB71857A14ED314300AAC /* WebSocketServer.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4CB9272A186932D89EB1072 /* WebSocketServer.swift */; };
+		C72C24EBCEFADDCA5B2C99E9 /* Logging.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BF23F10C24C9F40E5CEC303 /* Logging.swift */; };
 		CB577FE46E063BB09F5D4010 /* SdkHierarchyModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83E0B84D4CA225ECB1E09064 /* SdkHierarchyModels.swift */; };
 		CC061B4978496D75042B253A /* CommandHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77305F40F85694E983987E68 /* CommandHandler.swift */; };
 		CDEF0C911EA979C4E9C54B0B /* DefaultStorageInspecting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1CFB4EDEE20CB1CE002E68A5 /* DefaultStorageInspecting.swift */; };
@@ -121,6 +123,7 @@
 		1CFB4EDEE20CB1CE002E68A5 /* DefaultStorageInspecting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultStorageInspecting.swift; sourceTree = "<group>"; };
 		22671C94D317E15EED752E59 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		25C10BFA5B6504892F8459D7 /* CommandHandlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommandHandlerTests.swift; sourceTree = "<group>"; };
+		3BF23F10C24C9F40E5CEC303 /* Logging.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Logging.swift; sourceTree = "<group>"; };
 		3E5AAA4E2861D92C17F39B14 /* HierarchyDebouncerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HierarchyDebouncerTests.swift; sourceTree = "<group>"; };
 		42C53A4D56EE97B5BD11EC63 /* Debug.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Debug.xcconfig; sourceTree = "<group>"; };
 		5408FE8438060177DDAE7177 /* SdkHierarchyCacheTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SdkHierarchyCacheTests.swift; sourceTree = "<group>"; };
@@ -232,6 +235,7 @@
 				F2144B84CD70DB35A1030624 /* GesturePerformer.swift */,
 				034DC5B8A3A4FCE46CD89568 /* HierarchyDebouncer.swift */,
 				FAAF8CEA9B9A28B052E57E0A /* HierarchyMerger.swift */,
+				3BF23F10C24C9F40E5CEC303 /* Logging.swift */,
 				D81453AD074F2A392251CFC3 /* Models.swift */,
 				DBA97A6C3A1240A055D9876C /* OSLogReader.swift */,
 				B136EAD78CC0B932F258C265 /* PerformanceMetrics.swift */,
@@ -407,6 +411,7 @@
 				D9EF3A486E53F97C1CCB7A3B /* GesturePerformer.swift in Sources */,
 				EA65C486C9E6DBB5BFE9CA41 /* HierarchyDebouncer.swift in Sources */,
 				158C6F3B528C02BE92AA6132 /* HierarchyMerger.swift in Sources */,
+				5651AAF00833750D1DFD55CE /* Logging.swift in Sources */,
 				BD7D2FF024054ED74F17958D /* Models.swift in Sources */,
 				C1398B388B401E28BC727863 /* OSLogReader.swift in Sources */,
 				D0C171171348407EBFF5BAB7 /* PerfProvider.swift in Sources */,
@@ -446,6 +451,7 @@
 				5FDF9AE29841625DD7EFB7EC /* GesturePerformer.swift in Sources */,
 				5458E55CB48475D2487A49C3 /* HierarchyDebouncer.swift in Sources */,
 				45B926178972D1A358CFF284 /* HierarchyMerger.swift in Sources */,
+				C72C24EBCEFADDCA5B2C99E9 /* Logging.swift in Sources */,
 				BD627F44D1B9F2D3976AA0EC /* Models.swift in Sources */,
 				141E5CD4FAF4509F538E736C /* OSLogReader.swift in Sources */,
 				4A0FBEF6FAEF437AA17B20EA /* PerfProvider.swift in Sources */,

--- a/ios/control-proxy/Sources/CtrlProxy/CommandHandler.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/CommandHandler.swift
@@ -8,14 +8,8 @@ import os
 #endif
 
 /// Text-input command trace logger.
-///
-/// Log-level contract matches `GesturePerformer.gestureLog`:
-///   - `.debug`  — normal success path bookends (not persisted).
-///   - `.error`  — only on failures (persisted, rare, high-signal).
-///
-/// Do NOT promote success-path logs to `.info`; see GesturePerformer.swift
-/// for streaming instructions during a debug session.
-private let textInputLog = Logger(subsystem: "dev.kaeawc.automobile.ctrlproxy", category: "CommandHandler.text")
+/// See `Logging.swift` for the log-level contract shared across CtrlProxy.
+private let textInputLog = Logger(subsystem: ctrlProxyLogSubsystem, category: "CommandHandler.text")
 
 /// Handles WebSocket commands matching Android AccessibilityService protocol
 public class CommandHandler: CommandHandling {

--- a/ios/control-proxy/Sources/CtrlProxy/CommandHandler.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/CommandHandler.swift
@@ -1,10 +1,13 @@
 import Foundation
+import os
 #if canImport(XCTest) && os(iOS)
     import XCTest
 #endif
 #if os(iOS)
     import UIKit
 #endif
+
+private let textInputLog = Logger(subsystem: "dev.kaeawc.automobile.ctrlproxy", category: "CommandHandler.text")
 
 /// Handles WebSocket commands matching Android AccessibilityService protocol
 public class CommandHandler: CommandHandling {
@@ -319,12 +322,28 @@ public class CommandHandler: CommandHandling {
             throw CommandError.missingParameter("text")
         }
 
-        if let resourceId = request.resourceId {
-            try gesturePerformer.setText(resourceId: resourceId, text: text)
-        } else {
-            try gesturePerformer.typeText(text: text)
+        perfProvider.serial("handleSetText")
+        defer { perfProvider.end() }
+
+        let resourceId = request.resourceId
+        textInputLog.info("handleSetText begin resourceId=\(resourceId ?? "nil", privacy: .public) textLength=\(text.count, privacy: .public) requestId=\(request.requestId ?? "nil", privacy: .public)")
+
+        do {
+            if let resourceId = resourceId {
+                try perfProvider.track("setText.byResourceId") {
+                    try gesturePerformer.setText(resourceId: resourceId, text: text)
+                }
+            } else {
+                try perfProvider.track("typeText") {
+                    try gesturePerformer.typeText(text: text)
+                }
+            }
+        } catch {
+            textInputLog.error("handleSetText FAILED resourceId=\(resourceId ?? "nil", privacy: .public) error=\(String(describing: error), privacy: .public) elapsedMs=\(self.totalTimeMs(from: startTime), privacy: .public)")
+            throw error
         }
 
+        textInputLog.info("handleSetText OK resourceId=\(resourceId ?? "nil", privacy: .public) elapsedMs=\(self.totalTimeMs(from: startTime), privacy: .public)")
         return WebSocketResponse.success(
             type: ResponseType.setTextResult.rawValue,
             requestId: request.requestId,
@@ -333,8 +352,22 @@ public class CommandHandler: CommandHandling {
     }
 
     private func handleClearText(_ request: WebSocketRequest, startTime: Date) throws -> WebSocketResponse {
-        try gesturePerformer.clearText(resourceId: request.resourceId)
+        perfProvider.serial("handleClearText")
+        defer { perfProvider.end() }
 
+        let resourceId = request.resourceId
+        textInputLog.info("handleClearText begin resourceId=\(resourceId ?? "nil", privacy: .public) requestId=\(request.requestId ?? "nil", privacy: .public)")
+
+        do {
+            try perfProvider.track("clearText") {
+                try gesturePerformer.clearText(resourceId: resourceId)
+            }
+        } catch {
+            textInputLog.error("handleClearText FAILED resourceId=\(resourceId ?? "nil", privacy: .public) error=\(String(describing: error), privacy: .public) elapsedMs=\(self.totalTimeMs(from: startTime), privacy: .public)")
+            throw error
+        }
+
+        textInputLog.info("handleClearText OK resourceId=\(resourceId ?? "nil", privacy: .public) elapsedMs=\(self.totalTimeMs(from: startTime), privacy: .public)")
         return WebSocketResponse.success(
             type: ResponseType.clearTextResult.rawValue,
             requestId: request.requestId,
@@ -347,8 +380,21 @@ public class CommandHandler: CommandHandling {
             throw CommandError.missingParameter("action")
         }
 
-        try gesturePerformer.performImeAction(action)
+        perfProvider.serial("handleImeAction")
+        defer { perfProvider.end() }
 
+        textInputLog.info("handleImeAction begin action=\(action, privacy: .public) requestId=\(request.requestId ?? "nil", privacy: .public)")
+
+        do {
+            try perfProvider.track("imeAction") {
+                try gesturePerformer.performImeAction(action)
+            }
+        } catch {
+            textInputLog.error("handleImeAction FAILED action=\(action, privacy: .public) error=\(String(describing: error), privacy: .public) elapsedMs=\(self.totalTimeMs(from: startTime), privacy: .public)")
+            throw error
+        }
+
+        textInputLog.info("handleImeAction OK action=\(action, privacy: .public) elapsedMs=\(self.totalTimeMs(from: startTime), privacy: .public)")
         return WebSocketResponse.success(
             type: ResponseType.imeActionResult.rawValue,
             requestId: request.requestId,
@@ -357,8 +403,21 @@ public class CommandHandler: CommandHandling {
     }
 
     private func handleSelectAll(_ request: WebSocketRequest, startTime: Date) throws -> WebSocketResponse {
-        try gesturePerformer.selectAll()
+        perfProvider.serial("handleSelectAll")
+        defer { perfProvider.end() }
 
+        textInputLog.info("handleSelectAll begin requestId=\(request.requestId ?? "nil", privacy: .public)")
+
+        do {
+            try perfProvider.track("selectAll") {
+                try gesturePerformer.selectAll()
+            }
+        } catch {
+            textInputLog.error("handleSelectAll FAILED error=\(String(describing: error), privacy: .public) elapsedMs=\(self.totalTimeMs(from: startTime), privacy: .public)")
+            throw error
+        }
+
+        textInputLog.info("handleSelectAll OK elapsedMs=\(self.totalTimeMs(from: startTime), privacy: .public)")
         return WebSocketResponse.success(
             type: ResponseType.selectAllResult.rawValue,
             requestId: request.requestId,

--- a/ios/control-proxy/Sources/CtrlProxy/CommandHandler.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/CommandHandler.swift
@@ -1,5 +1,7 @@
 import Foundation
+#if canImport(os)
 import os
+#endif
 #if canImport(XCTest) && os(iOS)
     import XCTest
 #endif

--- a/ios/control-proxy/Sources/CtrlProxy/CommandHandler.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/CommandHandler.swift
@@ -7,6 +7,14 @@ import os
     import UIKit
 #endif
 
+/// Text-input command trace logger.
+///
+/// Log-level contract matches `GesturePerformer.gestureLog`:
+///   - `.debug`  — normal success path bookends (not persisted).
+///   - `.error`  — only on failures (persisted, rare, high-signal).
+///
+/// Do NOT promote success-path logs to `.info`; see GesturePerformer.swift
+/// for streaming instructions during a debug session.
 private let textInputLog = Logger(subsystem: "dev.kaeawc.automobile.ctrlproxy", category: "CommandHandler.text")
 
 /// Handles WebSocket commands matching Android AccessibilityService protocol
@@ -326,7 +334,7 @@ public class CommandHandler: CommandHandling {
         defer { perfProvider.end() }
 
         let resourceId = request.resourceId
-        textInputLog.info("handleSetText begin resourceId=\(resourceId ?? "nil", privacy: .public) textLength=\(text.count, privacy: .public) requestId=\(request.requestId ?? "nil", privacy: .public)")
+        textInputLog.debug("handleSetText begin resourceId=\(resourceId ?? "nil", privacy: .public) textLength=\(text.count, privacy: .public) requestId=\(request.requestId ?? "nil", privacy: .public)")
 
         do {
             if let resourceId = resourceId {
@@ -343,7 +351,7 @@ public class CommandHandler: CommandHandling {
             throw error
         }
 
-        textInputLog.info("handleSetText OK resourceId=\(resourceId ?? "nil", privacy: .public) elapsedMs=\(self.totalTimeMs(from: startTime), privacy: .public)")
+        textInputLog.debug("handleSetText OK resourceId=\(resourceId ?? "nil", privacy: .public) elapsedMs=\(self.totalTimeMs(from: startTime), privacy: .public)")
         return WebSocketResponse.success(
             type: ResponseType.setTextResult.rawValue,
             requestId: request.requestId,
@@ -356,7 +364,7 @@ public class CommandHandler: CommandHandling {
         defer { perfProvider.end() }
 
         let resourceId = request.resourceId
-        textInputLog.info("handleClearText begin resourceId=\(resourceId ?? "nil", privacy: .public) requestId=\(request.requestId ?? "nil", privacy: .public)")
+        textInputLog.debug("handleClearText begin resourceId=\(resourceId ?? "nil", privacy: .public) requestId=\(request.requestId ?? "nil", privacy: .public)")
 
         do {
             try perfProvider.track("clearText") {
@@ -367,7 +375,7 @@ public class CommandHandler: CommandHandling {
             throw error
         }
 
-        textInputLog.info("handleClearText OK resourceId=\(resourceId ?? "nil", privacy: .public) elapsedMs=\(self.totalTimeMs(from: startTime), privacy: .public)")
+        textInputLog.debug("handleClearText OK resourceId=\(resourceId ?? "nil", privacy: .public) elapsedMs=\(self.totalTimeMs(from: startTime), privacy: .public)")
         return WebSocketResponse.success(
             type: ResponseType.clearTextResult.rawValue,
             requestId: request.requestId,
@@ -383,7 +391,7 @@ public class CommandHandler: CommandHandling {
         perfProvider.serial("handleImeAction")
         defer { perfProvider.end() }
 
-        textInputLog.info("handleImeAction begin action=\(action, privacy: .public) requestId=\(request.requestId ?? "nil", privacy: .public)")
+        textInputLog.debug("handleImeAction begin action=\(action, privacy: .public) requestId=\(request.requestId ?? "nil", privacy: .public)")
 
         do {
             try perfProvider.track("imeAction") {
@@ -394,7 +402,7 @@ public class CommandHandler: CommandHandling {
             throw error
         }
 
-        textInputLog.info("handleImeAction OK action=\(action, privacy: .public) elapsedMs=\(self.totalTimeMs(from: startTime), privacy: .public)")
+        textInputLog.debug("handleImeAction OK action=\(action, privacy: .public) elapsedMs=\(self.totalTimeMs(from: startTime), privacy: .public)")
         return WebSocketResponse.success(
             type: ResponseType.imeActionResult.rawValue,
             requestId: request.requestId,
@@ -406,7 +414,7 @@ public class CommandHandler: CommandHandling {
         perfProvider.serial("handleSelectAll")
         defer { perfProvider.end() }
 
-        textInputLog.info("handleSelectAll begin requestId=\(request.requestId ?? "nil", privacy: .public)")
+        textInputLog.debug("handleSelectAll begin requestId=\(request.requestId ?? "nil", privacy: .public)")
 
         do {
             try perfProvider.track("selectAll") {
@@ -417,7 +425,7 @@ public class CommandHandler: CommandHandling {
             throw error
         }
 
-        textInputLog.info("handleSelectAll OK elapsedMs=\(self.totalTimeMs(from: startTime), privacy: .public)")
+        textInputLog.debug("handleSelectAll OK elapsedMs=\(self.totalTimeMs(from: startTime), privacy: .public)")
         return WebSocketResponse.success(
             type: ResponseType.selectAllResult.rawValue,
             requestId: request.requestId,

--- a/ios/control-proxy/Sources/CtrlProxy/ElementLocator.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/ElementLocator.swift
@@ -49,7 +49,7 @@ public class ElementLocator: ElementLocating {
         /// The foreground app we're currently observing (not springboard)
         /// At most one instance besides springboard should exist
         private var foregroundApp: XCUIApplication?
-        private var foregroundBundleId: String?
+        public private(set) var foregroundBundleId: String?
 
         /// Springboard app for detecting foreground app - always kept
         private lazy var springboard = XCUIApplication(bundleIdentifier: "com.apple.springboard")
@@ -1175,6 +1175,8 @@ public class ElementLocator: ElementLocating {
         public func awaitAppState(bundleId _: String, expectedState _: AppStateExpectation) -> Bool {
             return true
         }
+
+        public var foregroundBundleId: String? { nil }
     #endif
 
     // MARK: - Same-Type Child Collapsing & Sibling Dedup

--- a/ios/control-proxy/Sources/CtrlProxy/Fakes.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/Fakes.swift
@@ -106,7 +106,14 @@ public class FakeElementLocator: ElementLocating {
 
     public func switchForegroundApp(bundleId: String) {
         switchedBundleIds.append(bundleId)
+        foregroundBundleId = bundleId
     }
+
+    /// Bundle ID of the currently tracked foreground app.
+    /// Updated automatically by `switchForegroundApp`; tests can also set
+    /// it directly to simulate an out-of-band transition (e.g. MCP-side
+    /// `simctl launch` that bypasses handleLaunchApp).
+    public var foregroundBundleId: String?
 
     public func getAppState(bundleId: String) -> ObservedAppState {
         getAppStateCalls.append(bundleId)

--- a/ios/control-proxy/Sources/CtrlProxy/GesturePerformer.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/GesturePerformer.swift
@@ -471,10 +471,63 @@ public class GesturePerformer: GesturePerforming {
         /// no-progress or empty-value break conditions.
         private static let clearViaDeletesMaxIterations = 20
 
-        /// Clear a text element by looping tap + delete-burst up to
-        /// `clearViaDeletesMaxIterations` times, with an early-exit when
-        /// `element.value` reports an empty string. Returns the
-        /// approximate number of delete keystrokes dispatched.
+        /// Attempt WDA's first-tier clear strategy: dispatch a keyboard
+        /// `Clear` HID event (`kHIDPage_KeyboardOrKeypad` / `0x9C`) via the
+        /// private `XCDeviceEvent` + `-[XCUIDevice performDeviceEvent:error:]`
+        /// API. One HID event wipes the entire field through the keyboard
+        /// event pipeline (so RN's `onChangeText` fires), regardless of
+        /// content length or cursor position.
+        ///
+        /// Returns `true` if the event dispatched without error; `false`
+        /// if the private API couldn't be resolved or the call failed.
+        /// Callers should still run the delete-burst loop afterward as a
+        /// safety net — this is a fast-path optimization, not a guarantee.
+        ///
+        /// Uses `objc_msgSend` via `unsafeBitCast` + `@convention(c)`
+        /// function types so we don't have to bring `NSInvocation` into a
+        /// Swift-only target.
+        private static func tryHidKeyboardClear() -> Bool {
+            guard let eventClass = NSClassFromString("XCDeviceEvent") else {
+                gestureLog.debug("tryHidKeyboardClear: XCDeviceEvent class not found")
+                return false
+            }
+            let factorySel = NSSelectorFromString("deviceEventWithPage:usage:duration:")
+            guard let factoryMethod = class_getClassMethod(eventClass, factorySel) else {
+                gestureLog.debug("tryHidKeyboardClear: deviceEventWithPage:usage:duration: not found")
+                return false
+            }
+            typealias FactoryFn = @convention(c) (AnyClass, Selector, UInt32, UInt32, Double) -> AnyObject?
+            let factory = unsafeBitCast(method_getImplementation(factoryMethod), to: FactoryFn.self)
+            // page=0x07 kHIDPage_KeyboardOrKeypad, usage=0x9C kHIDUsage_KeyboardClear
+            guard let event = factory(eventClass, factorySel, 0x07, 0x9C, 0.01) else {
+                gestureLog.debug("tryHidKeyboardClear: factory returned nil")
+                return false
+            }
+
+            let device = XCUIDevice.shared
+            let performSel = NSSelectorFromString("performDeviceEvent:error:")
+            guard let performMethod = class_getInstanceMethod(type(of: device), performSel) else {
+                gestureLog.debug("tryHidKeyboardClear: performDeviceEvent:error: not found")
+                return false
+            }
+            typealias PerformFn = @convention(c) (XCUIDevice, Selector, AnyObject, AutoreleasingUnsafeMutablePointer<NSError?>?) -> Bool
+            let perform = unsafeBitCast(method_getImplementation(performMethod), to: PerformFn.self)
+            var nsError: NSError? = nil
+            let ok = perform(device, performSel, event, &nsError)
+            if !ok {
+                gestureLog.debug("tryHidKeyboardClear: performDeviceEvent failed error=\(nsError?.localizedDescription ?? "nil", privacy: .public)")
+            }
+            return ok
+        }
+
+        /// Clear a text element by first attempting WDA's HID `Clear` key
+        /// event (single-shot, sidesteps cursor positioning and content
+        /// length), then falling back to a loop of tap + delete-burst up
+        /// to `clearViaDeletesMaxIterations` times, with an early-exit
+        /// when `element.value` reports an empty string. Returns the
+        /// approximate number of delete keystrokes dispatched by the
+        /// fallback loop (0 if the HID clear succeeded and the field is
+        /// visibly empty to XCUITest).
         ///
         /// **Why not Cmd+A + Delete?** Bypasses React Native's
         /// `onChangeText` bridge — the native buffer clears but RN JS state
@@ -500,6 +553,12 @@ public class GesturePerformer: GesturePerforming {
         /// fields in exchange for correctness.
         @discardableResult
         private static func clearViaDeletes(element: XCUIElement) -> Int {
+            // Fast path: single HID Clear event. On native UIKit fields
+            // this typically empties the buffer in one shot; the loop
+            // below then no-ops via the isEmpty check.
+            let hidCleared = tryHidKeyboardClear()
+            gestureLog.debug("clearViaDeletes hidCleared=\(hidCleared, privacy: .public)")
+
             var totalDeleted = 0
             for iteration in 0..<clearViaDeletesMaxIterations {
                 let current = (element.value as? String) ?? ""
@@ -603,7 +662,7 @@ public class GesturePerformer: GesturePerforming {
                 }
                 try runOnMainThread {
                     try self.tapAndAwaitKeyboardFocus(app: app, element: element, resourceId: resourceId)
-                    GesturePerformer.clearViaDeletes(element: element)
+                    _ = GesturePerformer.clearViaDeletes(element: element)
                 }
                 return
             }
@@ -620,7 +679,7 @@ public class GesturePerformer: GesturePerforming {
                     "clearText could not resolve a focused text element. Pass resourceId to clear a specific field. Diagnostic: \(diag)"
                 )
             }
-            runOnMainThread {
+            _ = runOnMainThread {
                 GesturePerformer.clearViaDeletes(element: focused)
             }
         }

--- a/ios/control-proxy/Sources/CtrlProxy/GesturePerformer.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/GesturePerformer.swift
@@ -1,5 +1,7 @@
 import Foundation
+#if canImport(os)
 import os
+#endif
 #if canImport(XCTest) && os(iOS)
     import XCTest
 #endif
@@ -454,67 +456,51 @@ public class GesturePerformer: GesturePerforming {
             }
         }
 
-        /// Maximum iterations for `clearViaDeletes` before giving up. 5 is
-        /// generous — normal flows complete in 1–2 iterations.
-        private static let clearViaDeletesMaxIterations = 5
+        /// Maximum doubleTap+delete rounds in `clearViaDeletes`. Each round
+        /// removes one word-token (space/`@`/`.`-separated). 10 handles
+        /// heavily tokenized values like long email addresses.
+        private static let clearViaDeletesMaxIterations = 10
 
-        /// Clear a text element by sending per-character delete key events.
-        /// Returns the total number of delete events issued.
+        /// Clear a text element by repeating doubleTap+delete at the right
+        /// edge until the field is empty or the iteration cap is hit.
+        /// Returns the total characters removed.
         ///
-        /// **Why not Cmd+A + Delete?** Two key events are faster but bypass
-        /// React Native's `onChangeText` bridge — the native UITextField
-        /// buffer clears but RN's JS state stays stale. Per-character
-        /// deletes each fire the UIKit text-input delegate chain RN
-        /// observes, so `onChangeText` runs once per character.
-        /// `typeText("")` is a documented no-op.
+        /// **Why not Cmd+A + Delete?** Bypasses React Native's
+        /// `onChangeText` bridge — the native buffer clears but RN JS state
+        /// stays stale.
         ///
-        /// **Why the loop?** Two orthogonal failure modes:
-        ///
-        /// 1. Cursor position. A centered `element.tap()` (from
-        ///    `tapAndAwaitKeyboardFocus`) lands mid-content on populated
-        ///    fields. Delete keys only consume chars BEFORE the cursor —
-        ///    so a single pass leaves trailing content untouched. We
-        ///    reposition the cursor at the right edge (`dx=0.95`) each
-        ///    iteration so the next batch of deletes hits the remaining
-        ///    suffix.
-        ///
-        /// 2. Dropped events / RN re-render races. On iOS 18 + RN,
-        ///    `element.typeText(N×delete)` occasionally loses events when
-        ///    RN re-renders between keystrokes. The loop detects progress
-        ///    (`previousCount == currentCount` → break) and retries the
-        ///    remainder.
-        ///
-        /// Bounded by `clearViaDeletesMaxIterations` (5) to guarantee
-        /// termination even if deletes are completely ineffective.
+        /// **doubleTap + N-delete loop.** Each iteration double-taps at the
+        /// right edge (selecting the word under the cursor) then sends N
+        /// delete keystrokes (N = current field length). The double-tap fires
+        /// as a coordinate gesture so it works even when the element already
+        /// has first-responder focus. `@`/`.`/space act as word boundaries,
+        /// so email addresses like `hello@test.com` require ~5 rounds; most
+        /// form fields clear in 1–3. Sending N deletes after each selection
+        /// ensures any chars not covered by the selection (due to a partial
+        /// word-boundary selection) are also consumed before the next round.
         @discardableResult
         private static func clearViaDeletes(element: XCUIElement) -> Int {
+            let initialValue = (element.value as? String) ?? ""
+            guard !initialValue.isEmpty else { return 0 }
+
+            let endCoord = element.coordinate(withNormalizedOffset: CGVector(dx: 0.95, dy: 0.5))
             var totalDeleted = 0
-            var previousCount = -1
             for _ in 0..<clearViaDeletesMaxIterations {
-                let currentValue = (element.value as? String) ?? ""
-                let currentCount = currentValue.count
-                if currentCount == 0 { break }
-                if currentCount == previousCount {
-                    // No progress since last pass — cursor is stuck or
-                    // deletes are being dropped. Stop rather than loop
-                    // forever.
+                let before = (element.value as? String) ?? ""
+                if before.isEmpty { break }
+                endCoord.doubleTap()
+                let deleteCount = max(1, before.count)
+                element.typeText(String(repeating: XCUIKeyboardKey.delete.rawValue, count: deleteCount))
+                let after = (element.value as? String) ?? ""
+                if after.isEmpty {
+                    totalDeleted += before.count
                     break
                 }
-                previousCount = currentCount
-
-                // Reposition cursor at the right edge of the visible
-                // field bounds. For any content that fits in the visible
-                // width, this places the cursor past the last character.
-                // Uses a separate tap so the next typeText (which is the
-                // per-char delete burst) starts from end-of-content.
-                element.coordinate(withNormalizedOffset: CGVector(dx: 0.95, dy: 0.5)).tap()
-
-                let deleteString = String(
-                    repeating: XCUIKeyboardKey.delete.rawValue,
-                    count: currentCount
-                )
-                element.typeText(deleteString)
-                totalDeleted += currentCount
+                // No progress (value.isEmpty check unreliable for RN fields
+                // that return accessibilityIdentifier instead of text content
+                // — if before==after the delete was a no-op, stop looping).
+                if after == before { break }
+                totalDeleted += max(0, before.count - after.count)
             }
             return totalDeleted
         }

--- a/ios/control-proxy/Sources/CtrlProxy/GesturePerformer.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/GesturePerformer.swift
@@ -454,27 +454,69 @@ public class GesturePerformer: GesturePerforming {
             }
         }
 
-        /// Clear a text element by typing N individual delete key events.
+        /// Maximum iterations for `clearViaDeletes` before giving up. 5 is
+        /// generous — normal flows complete in 1–2 iterations.
+        private static let clearViaDeletesMaxIterations = 5
+
+        /// Clear a text element by sending per-character delete key events.
+        /// Returns the total number of delete events issued.
         ///
-        /// Cmd+A + Delete (which sends two key events total) bypasses React
-        /// Native's `onChangeText` bridge — the native UITextField buffer
-        /// clears but RN's JS state doesn't update. Per-character deletes
-        /// each fire the UIKit text-input delegate chain that RN's bridge
-        /// observes, so `onChangeText` runs for each character and RN's
-        /// state stays in sync. `typeText("")` is a documented no-op.
+        /// **Why not Cmd+A + Delete?** Two key events are faster but bypass
+        /// React Native's `onChangeText` bridge — the native UITextField
+        /// buffer clears but RN's JS state stays stale. Per-character
+        /// deletes each fire the UIKit text-input delegate chain RN
+        /// observes, so `onChangeText` runs once per character.
+        /// `typeText("")` is a documented no-op.
         ///
-        /// Returns the number of delete events sent (0 when the field was
-        /// already empty).
+        /// **Why the loop?** Two orthogonal failure modes:
+        ///
+        /// 1. Cursor position. A centered `element.tap()` (from
+        ///    `tapAndAwaitKeyboardFocus`) lands mid-content on populated
+        ///    fields. Delete keys only consume chars BEFORE the cursor —
+        ///    so a single pass leaves trailing content untouched. We
+        ///    reposition the cursor at the right edge (`dx=0.95`) each
+        ///    iteration so the next batch of deletes hits the remaining
+        ///    suffix.
+        ///
+        /// 2. Dropped events / RN re-render races. On iOS 18 + RN,
+        ///    `element.typeText(N×delete)` occasionally loses events when
+        ///    RN re-renders between keystrokes. The loop detects progress
+        ///    (`previousCount == currentCount` → break) and retries the
+        ///    remainder.
+        ///
+        /// Bounded by `clearViaDeletesMaxIterations` (5) to guarantee
+        /// termination even if deletes are completely ineffective.
         @discardableResult
         private static func clearViaDeletes(element: XCUIElement) -> Int {
-            let currentValue = (element.value as? String) ?? ""
-            guard !currentValue.isEmpty else { return 0 }
-            // XCUIKeyboardKey.delete is the backspace character; repeating it
-            // N times in a single typeText call dispatches N individual
-            // delete key events through the UIKit delegate chain.
-            let deleteString = String(repeating: XCUIKeyboardKey.delete.rawValue, count: currentValue.count)
-            element.typeText(deleteString)
-            return currentValue.count
+            var totalDeleted = 0
+            var previousCount = -1
+            for _ in 0..<clearViaDeletesMaxIterations {
+                let currentValue = (element.value as? String) ?? ""
+                let currentCount = currentValue.count
+                if currentCount == 0 { break }
+                if currentCount == previousCount {
+                    // No progress since last pass — cursor is stuck or
+                    // deletes are being dropped. Stop rather than loop
+                    // forever.
+                    break
+                }
+                previousCount = currentCount
+
+                // Reposition cursor at the right edge of the visible
+                // field bounds. For any content that fits in the visible
+                // width, this places the cursor past the last character.
+                // Uses a separate tap so the next typeText (which is the
+                // per-char delete burst) starts from end-of-content.
+                element.coordinate(withNormalizedOffset: CGVector(dx: 0.95, dy: 0.5)).tap()
+
+                let deleteString = String(
+                    repeating: XCUIKeyboardKey.delete.rawValue,
+                    count: currentCount
+                )
+                element.typeText(deleteString)
+                totalDeleted += currentCount
+            }
+            return totalDeleted
         }
 
         /// Resolve the currently-focused text-input element for the bare

--- a/ios/control-proxy/Sources/CtrlProxy/GesturePerformer.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/GesturePerformer.swift
@@ -1,7 +1,13 @@
 import Foundation
+import os
 #if canImport(XCTest) && os(iOS)
     import XCTest
 #endif
+
+/// Logger used for text-input focus diagnostics. Visible via:
+///   xcrun simctl spawn booted log show --last 1m \
+///     --predicate 'subsystem == "dev.kaeawc.automobile.ctrlproxy"'
+private let gestureLog = Logger(subsystem: "dev.kaeawc.automobile.ctrlproxy", category: "GesturePerformer")
 
 /// Performs gestures and interactions using XCUITest APIs
 public class GesturePerformer: GesturePerforming {
@@ -52,46 +58,182 @@ public class GesturePerformer: GesturePerforming {
 
         // MARK: - Keyboard Focus Helpers
 
-        /// Check that some element in the app has keyboard focus.
-        /// Throws with a contextual error message if no focus is detected.
-        private func requireKeyboardFocus(app: XCUIApplication, context: String) throws {
-            let hasFocus: Bool = runOnMainThread {
-                app.descendants(matching: .any)
+        /// Returns true if any text-input element in the snapshot has UIKit
+        /// first-responder focus (`snapshot.hasFocus`).
+        ///
+        /// Used as a fallback when the `hasKeyboardFocus == true` NSPredicate
+        /// returns no results — which happens with React Native TextInput
+        /// fields and other frameworks whose UITextField wrapper is the UIKit
+        /// first responder but does not propagate `hasKeyboardFocus` through
+        /// the XCTest accessibility bridge.
+        ///
+        /// `snapshot.hasFocus` reliably reflects UIKit first-responder state
+        /// and is what ElementLocator already uses to populate `focused: true`
+        /// in the view hierarchy — making this a symmetrical fallback.
+        ///
+        /// Credit: this technique (and the explanation above) was contributed
+        /// by the parallel "asdf" worktree during independent investigation
+        /// of the same issue; merged into the verified #1925 fix.
+        private static func snapshotHasTextInputWithFocus(_ snapshot: XCUIElementSnapshot) -> Bool {
+            let isTextInput = snapshot.elementType == .textField
+                || snapshot.elementType == .textView
+                || snapshot.elementType == .secureTextField
+                || snapshot.elementType == .other // safety net for custom wrappers (RN)
+            if isTextInput && snapshot.hasFocus {
+                return true
+            }
+            for child in snapshot.children {
+                if snapshotHasTextInputWithFocus(child) { return true }
+            }
+            return false
+        }
+
+        /// Detection strategies for keyboard focus, in order of cost:
+        ///
+        /// 1. `hasKeyboardFocus == true` NSPredicate — cheap, reliable for
+        ///    standard UIKit apps.
+        /// 2. Snapshot `hasFocus` traversal — catches React Native TextInputs
+        ///    and other frameworks whose first-responder status isn't
+        ///    exposed through `hasKeyboardFocus`.
+        /// 3. Keyboard-visibility probe — last-resort safety net; if the
+        ///    system keyboard is visible, something in the user-visible app
+        ///    must own first responder.
+        ///
+        /// Returns `(hasFocus, strategy)` so the caller can log which path
+        /// won. Query runs on the main thread.
+        private func detectKeyboardFocus(app: XCUIApplication) -> (Bool, String) {
+            return runOnMainThread { [springboard] in
+                // Strategy 1: predicate
+                let byPredicate = app.descendants(matching: .any)
                     .matching(NSPredicate(format: "hasKeyboardFocus == true"))
                     .firstMatch
                     .exists
+                if byPredicate {
+                    return (true, "predicate")
+                }
+
+                // Strategy 2: snapshot.hasFocus traversal. Skip SpringBoard —
+                // the app we want is never SpringBoard in a text-input flow.
+                if app.identifier != "com.apple.springboard" {
+                    if let snapshot = try? app.snapshot(),
+                       GesturePerformer.snapshotHasTextInputWithFocus(snapshot) {
+                        return (true, "snapshot.hasFocus")
+                    }
+                }
+
+                // Strategy 3: keyboard-visibility probe. Covers the case
+                // where neither the predicate nor the snapshot picks up
+                // focus (e.g., unknown/stale foreground bundle ID) but the
+                // user-visible keyboard proves something owns first responder.
+                if springboard.keyboards.firstMatch.exists || app.keyboards.firstMatch.exists {
+                    return (true, "keyboard-visibility")
+                }
+
+                return (false, "none")
             }
+        }
+
+        /// Check that some element in the app has keyboard focus.
+        /// Throws with a contextual error message if no focus is detected.
+        /// On failure, the thrown error embeds a focus-diagnostic summary so
+        /// it surfaces in the MCP response — not just in device logs.
+        private func requireKeyboardFocus(app: XCUIApplication, context: String) throws {
+            let queryStart = Date()
+            let (hasFocus, strategy) = detectKeyboardFocus(app: app)
+            let elapsedMs = Int(Date().timeIntervalSince(queryStart) * 1000)
+            gestureLog.info("requireKeyboardFocus hasFocus=\(hasFocus, privacy: .public) strategy=\(strategy, privacy: .public) context=\"\(context, privacy: .public)\" elapsedMs=\(elapsedMs, privacy: .public) appLabel=\(app.label, privacy: .public)")
+
             guard hasFocus else {
+                let diag = buildFocusDiagnostic(app: app, reason: "requireKeyboardFocus: \(context)")
+                gestureLog.error("\(diag, privacy: .public)")
                 throw GestureError.gestureFailed(
-                    "No element has keyboard focus — \(context)"
+                    "No element has keyboard focus — \(context). Diagnostic: \(diag)"
                 )
             }
         }
 
-        /// Tap an element and poll for keyboard focus (200ms timeout, 20ms intervals).
+        /// Tap an element and poll for keyboard focus (500ms timeout, 50ms
+        /// intervals). Uses the same 3-strategy detection as
+        /// `requireKeyboardFocus`. Timeout was extended from 200ms → 500ms
+        /// to accommodate the snapshot-based fallback, which does an extra
+        /// XPC round-trip per poll when the predicate misses.
+        ///
         /// Throws if the element does not receive focus after the tap.
         private func tapAndAwaitKeyboardFocus(
             app: XCUIApplication,
             element: XCUIElement,
             resourceId: String
         ) throws {
+            let tapStart = Date()
+            gestureLog.info("tapAndAwaitKeyboardFocus begin resourceId=\(resourceId, privacy: .public) exists=\(element.exists, privacy: .public) isHittable=\(element.isHittable, privacy: .public) type=\(element.elementType.rawValue, privacy: .public)")
             element.tap()
 
-            let deadline = Date().addingTimeInterval(0.2)
+            let deadline = Date().addingTimeInterval(0.5)
             var hasFocus = false
+            var strategy = "none"
+            var iterations = 0
             while !hasFocus && Date() < deadline {
-                hasFocus = app.descendants(matching: .any)
-                    .matching(NSPredicate(format: "hasKeyboardFocus == true"))
-                    .firstMatch
-                    .exists
+                let result = detectKeyboardFocus(app: app)
+                hasFocus = result.0
+                strategy = result.1
+                iterations += 1
                 if !hasFocus {
-                    RunLoop.current.run(until: Date().addingTimeInterval(0.02))
+                    RunLoop.current.run(until: Date().addingTimeInterval(0.05))
                 }
             }
+            let elapsedMs = Int(Date().timeIntervalSince(tapStart) * 1000)
+            gestureLog.info("tapAndAwaitKeyboardFocus done resourceId=\(resourceId, privacy: .public) hasFocus=\(hasFocus, privacy: .public) strategy=\(strategy, privacy: .public) iterations=\(iterations, privacy: .public) elapsedMs=\(elapsedMs, privacy: .public)")
+
             guard hasFocus else {
+                let diag = buildFocusDiagnostic(app: app, reason: "tapAndAwaitKeyboardFocus: \(resourceId)")
+                gestureLog.error("\(diag, privacy: .public)")
                 throw GestureError.gestureFailed(
-                    "Element '\(resourceId)' did not receive keyboard focus after tap"
+                    "Element '\(resourceId)' did not receive keyboard focus after tap. Diagnostic: \(diag)"
                 )
+            }
+        }
+
+        /// Build a compact diagnostic string enumerating candidate text-entry
+        /// elements and their focus state, for #1925-style "no keyboard focus"
+        /// failures. Returned as a single line so it fits in a WebSocket error.
+        private func buildFocusDiagnostic(app: XCUIApplication, reason: String) -> String {
+            return runOnMainThread { [springboard] in
+                var parts: [String] = []
+                parts.append("reason=\"\(reason)\"")
+                parts.append("app.label=\"\(app.label)\"")
+                parts.append("app.identifier=\"\(app.identifier)\"")
+
+                let typesToProbe: [(String, XCUIElement.ElementType)] = [
+                    ("textFields", .textField),
+                    ("secureTextFields", .secureTextField),
+                    ("textViews", .textView),
+                    ("searchFields", .searchField),
+                ]
+
+                for (name, type) in typesToProbe {
+                    let query = app.descendants(matching: type)
+                    let count = query.count
+                    parts.append("\(name).count=\(count)")
+
+                    // Only introspect a small number to avoid heavy XPC.
+                    let cap = min(count, 5)
+                    if cap > 0 {
+                        for i in 0..<cap {
+                            let el = query.element(boundBy: i)
+                            let hasFocus = (el.value(forKey: "hasKeyboardFocus") as? Bool) ?? false
+                            let identifier = el.identifier
+                            let value = (el.value as? String) ?? ""
+                            let isSelected = el.isSelected
+                            let isHittable = el.isHittable
+                            let frame = el.frame
+                            parts.append("\(name)[\(i)]={id=\"\(identifier)\",hasKeyboardFocus=\(hasFocus),isSelected=\(isSelected),isHittable=\(isHittable),value.len=\(value.count),frame=\(Int(frame.origin.x)),\(Int(frame.origin.y)),\(Int(frame.size.width)),\(Int(frame.size.height))}")
+                        }
+                    }
+                }
+
+                parts.append("app.keyboards.count=\(app.keyboards.count)")
+                parts.append("springboard.keyboards.count=\(springboard.keyboards.count)")
+                return parts.joined(separator: " | ")
             }
         }
 
@@ -239,8 +381,30 @@ public class GesturePerformer: GesturePerforming {
 
         // MARK: - Text Input
 
+        /// Resolve the XCUIApplication to use for text-input accessibility queries.
+        ///
+        /// Prefers the ElementLocator's tracked foreground bundle ID over the
+        /// (possibly stale) self.application. See issue #1925: the MCP server
+        /// launches apps via `simctl launch`, which updates ElementLocator's
+        /// tracker (through the observe path) but does NOT reach CommandHandler's
+        /// handleLaunchApp, so GesturePerformer.application stays pinned at
+        /// whatever CtrlProxy.start() initialised it to (SpringBoard / the
+        /// test host). That stale reference then returns zero textFields /
+        /// zero keyboards, making every typeText fail with "No element has
+        /// keyboard focus" — even when the app demonstrably has a focused
+        /// text field and a visible keyboard.
+        ///
+        /// Coordinate-based gestures (tap/swipe/drag/pinch) deliberately use
+        /// the SpringBoard anchor and do NOT go through this method.
+        private func resolveTextInputApp() -> XCUIApplication? {
+            if let bundleId = elementLocator.foregroundBundleId, !bundleId.isEmpty {
+                return XCUIApplication(bundleIdentifier: bundleId)
+            }
+            return application
+        }
+
         public func typeText(text: String) throws {
-            guard let app = application else {
+            guard let app = resolveTextInputApp() else {
                 throw GestureError.noApplication
             }
 
@@ -252,7 +416,7 @@ public class GesturePerformer: GesturePerforming {
         }
 
         public func setText(resourceId: String, text: String) throws {
-            guard let app = application else {
+            guard let app = resolveTextInputApp() else {
                 throw GestureError.noApplication
             }
             guard let element = elementLocator.findElement(byResourceId: resourceId) as? XCUIElement else {
@@ -273,7 +437,7 @@ public class GesturePerformer: GesturePerforming {
         }
 
         public func clearText(resourceId: String? = nil) throws {
-            guard let app = application else {
+            guard let app = resolveTextInputApp() else {
                 throw GestureError.noApplication
             }
 
@@ -300,7 +464,7 @@ public class GesturePerformer: GesturePerforming {
         }
 
         public func selectAll() throws {
-            guard let app = application else {
+            guard let app = resolveTextInputApp() else {
                 throw GestureError.noApplication
             }
 
@@ -312,7 +476,7 @@ public class GesturePerformer: GesturePerforming {
         }
 
         public func performImeAction(_ action: String) throws {
-            guard let app = application else {
+            guard let app = resolveTextInputApp() else {
                 throw GestureError.noApplication
             }
 
@@ -437,7 +601,9 @@ public class GesturePerformer: GesturePerforming {
                 return nil
 
             case "paste":
-                guard let app = application else {
+                // Use foreground-app resolution (#1925) — the clipboard paste
+                // path also needs to query the correct app for hasKeyboardFocus.
+                guard let app = resolveTextInputApp() else {
                     throw GestureError.noApplication
                 }
                 let clipboardText: String? = runOnMainThread {

--- a/ios/control-proxy/Sources/CtrlProxy/GesturePerformer.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/GesturePerformer.swift
@@ -4,8 +4,17 @@ import os
     import XCTest
 #endif
 
-/// Logger used for text-input focus diagnostics. Visible via:
-///   xcrun simctl spawn booted log show --last 1m \
+/// Logger used for text-input focus diagnostics.
+///
+/// Log-level contract:
+///   - `.debug`  — normal success path trace (not persisted; only visible when
+///                 actively streaming). Use for `begin/done` bookends.
+///   - `.error`  — only on failures; carries the focus-diagnostic summary.
+///
+/// Do NOT promote success-path logs to `.info` — `Logger.info` is persisted
+/// to the unified log store and every text input would leave durable records.
+/// Enable streaming during a debug session with:
+///   xcrun simctl spawn booted log stream --level=debug \
 ///     --predicate 'subsystem == "dev.kaeawc.automobile.ctrlproxy"'
 private let gestureLog = Logger(subsystem: "dev.kaeawc.automobile.ctrlproxy", category: "GesturePerformer")
 
@@ -141,7 +150,7 @@ public class GesturePerformer: GesturePerforming {
             let queryStart = Date()
             let (hasFocus, strategy) = detectKeyboardFocus(app: app)
             let elapsedMs = Int(Date().timeIntervalSince(queryStart) * 1000)
-            gestureLog.info("requireKeyboardFocus hasFocus=\(hasFocus, privacy: .public) strategy=\(strategy, privacy: .public) context=\"\(context, privacy: .public)\" elapsedMs=\(elapsedMs, privacy: .public) appLabel=\(app.label, privacy: .public)")
+            gestureLog.debug("requireKeyboardFocus hasFocus=\(hasFocus, privacy: .public) strategy=\(strategy, privacy: .public) context=\"\(context, privacy: .public)\" elapsedMs=\(elapsedMs, privacy: .public) appLabel=\(app.label, privacy: .public)")
 
             guard hasFocus else {
                 let diag = buildFocusDiagnostic(app: app, reason: "requireKeyboardFocus: \(context)")
@@ -165,7 +174,7 @@ public class GesturePerformer: GesturePerforming {
             resourceId: String
         ) throws {
             let tapStart = Date()
-            gestureLog.info("tapAndAwaitKeyboardFocus begin resourceId=\(resourceId, privacy: .public) exists=\(element.exists, privacy: .public) isHittable=\(element.isHittable, privacy: .public) type=\(element.elementType.rawValue, privacy: .public)")
+            gestureLog.debug("tapAndAwaitKeyboardFocus begin resourceId=\(resourceId, privacy: .public) exists=\(element.exists, privacy: .public) isHittable=\(element.isHittable, privacy: .public) type=\(element.elementType.rawValue, privacy: .public)")
             element.tap()
 
             let deadline = Date().addingTimeInterval(0.5)
@@ -182,7 +191,7 @@ public class GesturePerformer: GesturePerforming {
                 }
             }
             let elapsedMs = Int(Date().timeIntervalSince(tapStart) * 1000)
-            gestureLog.info("tapAndAwaitKeyboardFocus done resourceId=\(resourceId, privacy: .public) hasFocus=\(hasFocus, privacy: .public) strategy=\(strategy, privacy: .public) iterations=\(iterations, privacy: .public) elapsedMs=\(elapsedMs, privacy: .public)")
+            gestureLog.debug("tapAndAwaitKeyboardFocus done resourceId=\(resourceId, privacy: .public) hasFocus=\(hasFocus, privacy: .public) strategy=\(strategy, privacy: .public) iterations=\(iterations, privacy: .public) elapsedMs=\(elapsedMs, privacy: .public)")
 
             guard hasFocus else {
                 let diag = buildFocusDiagnostic(app: app, reason: "tapAndAwaitKeyboardFocus: \(resourceId)")

--- a/ios/control-proxy/Sources/CtrlProxy/GesturePerformer.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/GesturePerformer.swift
@@ -434,15 +434,36 @@ public class GesturePerformer: GesturePerforming {
 
             try runOnMainThread {
                 try self.tapAndAwaitKeyboardFocus(app: app, element: element, resourceId: resourceId)
-
-                // Select all and delete existing text via Cmd+A, Delete (O(1))
-                if let existingText = element.value as? String, !existingText.isEmpty {
-                    app.typeKey("a", modifierFlags: .command)
-                    app.typeKey(.delete, modifierFlags: [])
-                }
-
+                // Clear any existing text per-character so RN's onChangeText
+                // fires for each delete (see clearViaDeletes for rationale).
+                GesturePerformer.clearViaDeletes(element: element)
                 element.typeText(text)
             }
+        }
+
+        /// Clear a text element by typing N individual delete key events.
+        ///
+        /// We cannot use Cmd+A + Delete (which sends two key events total)
+        /// because that path bypasses React Native's `onChangeText` bridge —
+        /// the native UITextField buffer clears but RN's JS state doesn't
+        /// update. Per-character deletes each fire the UIKit text-input
+        /// delegate chain that RN's bridge observes, so onChangeText runs
+        /// for each character and RN's state stays in sync.
+        ///
+        /// `typeText("")` is a no-op, so we cannot use it either.
+        ///
+        /// Returns the number of delete events sent (0 when the field was
+        /// already empty or the length was unknown).
+        @discardableResult
+        private static func clearViaDeletes(element: XCUIElement) -> Int {
+            let currentValue = (element.value as? String) ?? ""
+            guard !currentValue.isEmpty else { return 0 }
+            // XCUIKeyboardKey.delete is the backspace character; repeating it
+            // N times in a single typeText call dispatches N individual
+            // delete key events through the UIKit delegate chain.
+            let deleteString = String(repeating: XCUIKeyboardKey.delete.rawValue, count: currentValue.count)
+            element.typeText(deleteString)
+            return currentValue.count
         }
 
         public func clearText(resourceId: String? = nil) throws {
@@ -457,17 +478,28 @@ public class GesturePerformer: GesturePerforming {
 
                 try runOnMainThread {
                     try self.tapAndAwaitKeyboardFocus(app: app, element: element, resourceId: resourceId)
-
-                    // Select all and delete via Cmd+A, Delete (O(1))
-                    app.typeKey("a", modifierFlags: .command)
-                    app.typeKey(.delete, modifierFlags: [])
+                    GesturePerformer.clearViaDeletes(element: element)
                 }
             } else {
                 try requireKeyboardFocus(app: app, context: "ensure a text field is focused before clearing")
 
                 runOnMainThread {
-                    app.typeKey("a", modifierFlags: .command)
-                    app.typeKey(.delete, modifierFlags: [])
+                    // Locate the currently-focused element so we can delete
+                    // per-character and fire RN's onChangeText for each.
+                    let focusedQuery = app.descendants(matching: .any)
+                        .matching(NSPredicate(format: "hasKeyboardFocus == true"))
+                    if focusedQuery.firstMatch.exists {
+                        GesturePerformer.clearViaDeletes(element: focusedQuery.firstMatch)
+                    } else {
+                        // Fallback: app-level Cmd+A/Delete. Reaches the UIKit
+                        // buffer even when no XCUITest-visible element owns
+                        // hasKeyboardFocus (e.g., RN wrappers — same case the
+                        // snapshot.hasFocus fallback covers for focus detection).
+                        // RN state will not update via this path; callers
+                        // should prefer the resourceId branch for RN apps.
+                        app.typeKey("a", modifierFlags: .command)
+                        app.typeKey(.delete, modifierFlags: [])
+                    }
                 }
             }
         }

--- a/ios/control-proxy/Sources/CtrlProxy/GesturePerformer.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/GesturePerformer.swift
@@ -165,7 +165,8 @@ public class GesturePerformer: GesturePerforming {
             let queryStart = Date()
             let (hasFocus, strategy) = detectKeyboardFocus(app: app)
             let elapsedMs = Int(Date().timeIntervalSince(queryStart) * 1000)
-            gestureLog.debug("requireKeyboardFocus hasFocus=\(hasFocus, privacy: .public) strategy=\(strategy, privacy: .public) context=\"\(context, privacy: .public)\" elapsedMs=\(elapsedMs, privacy: .public) appLabel=\(app.label, privacy: .public)")
+            let appLabel = runOnMainThread { app.label }
+            gestureLog.debug("requireKeyboardFocus hasFocus=\(hasFocus, privacy: .public) strategy=\(strategy, privacy: .public) context=\"\(context, privacy: .public)\" elapsedMs=\(elapsedMs, privacy: .public) appLabel=\(appLabel, privacy: .public)")
 
             guard hasFocus else {
                 let diag = buildFocusDiagnostic(app: app, reason: "requireKeyboardFocus: \(context)")
@@ -456,53 +457,45 @@ public class GesturePerformer: GesturePerforming {
             }
         }
 
-        /// Maximum doubleTap+delete rounds in `clearViaDeletes`. Each round
-        /// removes one word-token (space/`@`/`.`-separated). 10 handles
-        /// heavily tokenized values like long email addresses.
-        private static let clearViaDeletesMaxIterations = 10
+        /// Delete-burst size for `clearViaDeletes`. Sized to cover typical
+        /// form-field content (email, name, phone, password, address, OTP)
+        /// without exceeding what XCUITest's keyboard input pipeline can
+        /// ship as a single `typeText` call before falling back to touch
+        /// synthesis — which, empirically, can trigger spurious home
+        /// transitions during very long bursts. 50 chars is a safe cap.
+        /// Overkill deletes on an empty field are harmless no-ops.
+        private static let clearViaDeletesBurstSize = 50
 
-        /// Clear a text element by repeating doubleTap+delete at the right
-        /// edge until the field is empty or the iteration cap is hit.
-        /// Returns the total characters removed.
+        /// Clear a text element by positioning the cursor at the end of
+        /// content then sending a large fixed-size burst of delete
+        /// keystrokes. Returns the burst size (callers typically ignore it).
         ///
         /// **Why not Cmd+A + Delete?** Bypasses React Native's
         /// `onChangeText` bridge — the native buffer clears but RN JS state
         /// stays stale.
         ///
-        /// **doubleTap + N-delete loop.** Each iteration double-taps at the
-        /// right edge (selecting the word under the cursor) then sends N
-        /// delete keystrokes (N = current field length). The double-tap fires
-        /// as a coordinate gesture so it works even when the element already
-        /// has first-responder focus. `@`/`.`/space act as word boundaries,
-        /// so email addresses like `hello@test.com` require ~5 rounds; most
-        /// form fields clear in 1–3. Sending N deletes after each selection
-        /// ensures any chars not covered by the selection (due to a partial
-        /// word-boundary selection) are also consumed before the next round.
+        /// **Why a fixed burst and not a progress-driven loop?**
+        /// `element.value` on RN `TextInput` wrappers returns the
+        /// accessibility identifier (e.g. `"email-sign-in-email-input"`)
+        /// instead of the real content, so count- and equality-based
+        /// progress detection is unreliable. A single generous burst with
+        /// the cursor at the end sidesteps both problems.
+        ///
+        /// **Cursor positioning.** A bare tap at the right edge places the
+        /// cursor at end-of-content (iOS snaps to the last character when
+        /// the tap lands in trailing padding). We use `tap()` rather than
+        /// `doubleTap()` because doubleTap on empty padding past the text
+        /// is a no-op and doesn't reposition the cursor. Coordinate-based
+        /// so it fires even when the element already has first-responder
+        /// focus.
         @discardableResult
         private static func clearViaDeletes(element: XCUIElement) -> Int {
-            let initialValue = (element.value as? String) ?? ""
-            guard !initialValue.isEmpty else { return 0 }
-
-            let endCoord = element.coordinate(withNormalizedOffset: CGVector(dx: 0.95, dy: 0.5))
-            var totalDeleted = 0
-            for _ in 0..<clearViaDeletesMaxIterations {
-                let before = (element.value as? String) ?? ""
-                if before.isEmpty { break }
-                endCoord.doubleTap()
-                let deleteCount = max(1, before.count)
-                element.typeText(String(repeating: XCUIKeyboardKey.delete.rawValue, count: deleteCount))
-                let after = (element.value as? String) ?? ""
-                if after.isEmpty {
-                    totalDeleted += before.count
-                    break
-                }
-                // No progress (value.isEmpty check unreliable for RN fields
-                // that return accessibilityIdentifier instead of text content
-                // — if before==after the delete was a no-op, stop looping).
-                if after == before { break }
-                totalDeleted += max(0, before.count - after.count)
-            }
-            return totalDeleted
+            element.coordinate(withNormalizedOffset: CGVector(dx: 0.95, dy: 0.5)).tap()
+            element.typeText(String(
+                repeating: XCUIKeyboardKey.delete.rawValue,
+                count: clearViaDeletesBurstSize
+            ))
+            return clearViaDeletesBurstSize
         }
 
         /// Resolve the currently-focused text-input element for the bare
@@ -521,6 +514,14 @@ public class GesturePerformer: GesturePerforming {
         /// doesn't propagate `hasKeyboardFocus` but does report
         /// `snapshot.hasFocus`. More expensive (one `.snapshot()` per
         /// candidate) but only runs when the predicate misses.
+        ///
+        /// Strategy 3 (`.other` snapshot walk): `detectKeyboardFocus` treats
+        /// focused `.other` snapshots as text inputs when they expose a
+        /// non-empty `value` or `placeholderValue` (see
+        /// `snapshotLooksLikeTextInput`). Mirror that here so flows where
+        /// focus is exposed only via an `.other` wrapper can be resolved —
+        /// otherwise `requireKeyboardFocus` passes and `clearText` throws
+        /// because this method returns nil.
         ///
         /// No keyboard-visibility fallback here: visibility proves focus
         /// exists somewhere but doesn't name an element, and we need an
@@ -550,6 +551,19 @@ public class GesturePerformer: GesturePerforming {
                         let candidate = query.element(boundBy: i)
                         guard let snap = try? candidate.snapshot() else { continue }
                         if snap.hasFocus {
+                            return candidate
+                        }
+                    }
+                }
+
+                // Strategy 3: .other elements that look like text inputs
+                let otherQuery = app.otherElements
+                let otherCount = otherQuery.count
+                if otherCount > 0 {
+                    for i in 0..<otherCount {
+                        let candidate = otherQuery.element(boundBy: i)
+                        guard let snap = try? candidate.snapshot() else { continue }
+                        if snap.hasFocus && GesturePerformer.snapshotLooksLikeTextInput(snap) {
                             return candidate
                         }
                     }

--- a/ios/control-proxy/Sources/CtrlProxy/GesturePerformer.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/GesturePerformer.swift
@@ -4,19 +4,9 @@ import os
     import XCTest
 #endif
 
-/// Logger used for text-input focus diagnostics.
-///
-/// Log-level contract:
-///   - `.debug`  — normal success path trace (not persisted; only visible when
-///                 actively streaming). Use for `begin/done` bookends.
-///   - `.error`  — only on failures; carries the focus-diagnostic summary.
-///
-/// Do NOT promote success-path logs to `.info` — `Logger.info` is persisted
-/// to the unified log store and every text input would leave durable records.
-/// Enable streaming during a debug session with:
-///   xcrun simctl spawn booted log stream --level=debug \
-///     --predicate 'subsystem == "dev.kaeawc.automobile.ctrlproxy"'
-private let gestureLog = Logger(subsystem: "dev.kaeawc.automobile.ctrlproxy", category: "GesturePerformer")
+/// Logger for text-input focus diagnostics.
+/// See `Logging.swift` for the log-level contract shared across CtrlProxy.
+private let gestureLog = Logger(subsystem: ctrlProxyLogSubsystem, category: "GesturePerformer")
 
 /// Performs gestures and interactions using XCUITest APIs
 public class GesturePerformer: GesturePerforming {
@@ -71,28 +61,51 @@ public class GesturePerformer: GesturePerforming {
         /// first-responder focus (`snapshot.hasFocus`).
         ///
         /// Used as a fallback when the `hasKeyboardFocus == true` NSPredicate
-        /// returns no results — which happens with React Native TextInput
+        /// returns no results — which happens with React Native `TextInput`
         /// fields and other frameworks whose UITextField wrapper is the UIKit
         /// first responder but does not propagate `hasKeyboardFocus` through
-        /// the XCTest accessibility bridge.
+        /// the XCTest accessibility bridge. `snapshot.hasFocus` reliably
+        /// reflects UIKit first-responder state, mirroring what
+        /// `ElementLocator` uses to populate `focused: true` in the hierarchy.
         ///
-        /// `snapshot.hasFocus` reliably reflects UIKit first-responder state
-        /// and is what ElementLocator already uses to populate `focused: true`
-        /// in the view hierarchy — making this a symmetrical fallback.
+        /// For `.other` (RN wrapper views), require a non-empty `value` or
+        /// `placeholderValue` before treating the node as a text input —
+        /// otherwise any focused `.other` (a button, custom control, etc.)
+        /// would register as focused text and we'd try to delete from it.
         ///
-        /// Credit: this technique (and the explanation above) was contributed
-        /// by the parallel "asdf" worktree during independent investigation
-        /// of the same issue; merged into the verified #1925 fix.
-        private static func snapshotHasTextInputWithFocus(_ snapshot: XCUIElementSnapshot) -> Bool {
-            let isTextInput = snapshot.elementType == .textField
-                || snapshot.elementType == .textView
-                || snapshot.elementType == .secureTextField
-                || snapshot.elementType == .other // safety net for custom wrappers (RN)
-            if isTextInput && snapshot.hasFocus {
+        /// Depth-guarded at 64 to bound recursion on pathological trees.
+        private static func snapshotHasTextInputWithFocus(
+            _ snapshot: XCUIElementSnapshot,
+            depth: Int = 0
+        ) -> Bool {
+            if depth > 64 { return false }
+
+            let type = snapshot.elementType
+            let isKnownTextInput = type == .textField
+                || type == .textView
+                || type == .secureTextField
+            let isTextLikeOther = type == .other && snapshotLooksLikeTextInput(snapshot)
+
+            if (isKnownTextInput || isTextLikeOther) && snapshot.hasFocus {
                 return true
             }
             for child in snapshot.children {
-                if snapshotHasTextInputWithFocus(child) { return true }
+                if snapshotHasTextInputWithFocus(child, depth: depth + 1) { return true }
+            }
+            return false
+        }
+
+        /// Heuristic for treating an `.other`-typed snapshot as a text-input
+        /// wrapper. Text fields expose a non-empty `value` (current content)
+        /// or a `placeholderValue` (hint text); plain buttons / containers
+        /// do not. False positives would cause `clearViaDeletes` to send
+        /// delete keys to a non-text element.
+        private static func snapshotLooksLikeTextInput(_ snapshot: XCUIElementSnapshot) -> Bool {
+            if let value = snapshot.value as? String, !value.isEmpty {
+                return true
+            }
+            if let placeholder = snapshot.placeholderValue, !placeholder.isEmpty {
+                return true
             }
             return false
         }
@@ -443,17 +456,15 @@ public class GesturePerformer: GesturePerforming {
 
         /// Clear a text element by typing N individual delete key events.
         ///
-        /// We cannot use Cmd+A + Delete (which sends two key events total)
-        /// because that path bypasses React Native's `onChangeText` bridge —
-        /// the native UITextField buffer clears but RN's JS state doesn't
-        /// update. Per-character deletes each fire the UIKit text-input
-        /// delegate chain that RN's bridge observes, so onChangeText runs
-        /// for each character and RN's state stays in sync.
-        ///
-        /// `typeText("")` is a no-op, so we cannot use it either.
+        /// Cmd+A + Delete (which sends two key events total) bypasses React
+        /// Native's `onChangeText` bridge — the native UITextField buffer
+        /// clears but RN's JS state doesn't update. Per-character deletes
+        /// each fire the UIKit text-input delegate chain that RN's bridge
+        /// observes, so `onChangeText` runs for each character and RN's
+        /// state stays in sync. `typeText("")` is a documented no-op.
         ///
         /// Returns the number of delete events sent (0 when the field was
-        /// already empty or the length was unknown).
+        /// already empty).
         @discardableResult
         private static func clearViaDeletes(element: XCUIElement) -> Int {
             let currentValue = (element.value as? String) ?? ""
@@ -466,6 +477,60 @@ public class GesturePerformer: GesturePerforming {
             return currentValue.count
         }
 
+        /// Resolve the currently-focused text-input element for the bare
+        /// `clearText` / `selectAll` / `performImeAction` paths. Mirrors
+        /// `detectKeyboardFocus`'s first two strategies but returns the
+        /// actual `XCUIElement` so callers can dispatch `typeText` against
+        /// it (and have React Native's `onChangeText` bridge fire).
+        ///
+        /// Strategy 1 (predicate): `hasKeyboardFocus == true` — cheap, works
+        /// for standard UIKit apps.
+        ///
+        /// Strategy 2 (snapshot walk): iterate candidate text-input element
+        /// types (`textFields`, `secureTextFields`, `textViews`,
+        /// `searchFields`) and check each element's snapshot for
+        /// `hasFocus`. Catches RN `TextInput`s whose UITextField wrapper
+        /// doesn't propagate `hasKeyboardFocus` but does report
+        /// `snapshot.hasFocus`. More expensive (one `.snapshot()` per
+        /// candidate) but only runs when the predicate misses.
+        ///
+        /// No keyboard-visibility fallback here: visibility proves focus
+        /// exists somewhere but doesn't name an element, and we need an
+        /// element to dispatch deletes against. Callers that hit that case
+        /// should use `clearText(resourceId:)` with a concrete selector.
+        private func resolveFocusedTextElement(app: XCUIApplication) -> XCUIElement? {
+            return runOnMainThread {
+                // Strategy 1: predicate
+                let byPredicate = app.descendants(matching: .any)
+                    .matching(NSPredicate(format: "hasKeyboardFocus == true"))
+                    .firstMatch
+                if byPredicate.exists {
+                    return byPredicate
+                }
+
+                // Strategy 2: per-type snapshot traversal
+                let queries: [XCUIElementQuery] = [
+                    app.textFields,
+                    app.secureTextFields,
+                    app.textViews,
+                    app.searchFields,
+                ]
+                for query in queries {
+                    let count = query.count
+                    guard count > 0 else { continue }
+                    for i in 0..<count {
+                        let candidate = query.element(boundBy: i)
+                        guard let snap = try? candidate.snapshot() else { continue }
+                        if snap.hasFocus {
+                            return candidate
+                        }
+                    }
+                }
+
+                return nil
+            }
+        }
+
         public func clearText(resourceId: String? = nil) throws {
             guard let app = resolveTextInputApp() else {
                 throw GestureError.noApplication
@@ -475,32 +540,27 @@ public class GesturePerformer: GesturePerforming {
                 guard let element = elementLocator.findElement(byResourceId: resourceId) as? XCUIElement else {
                     throw GestureError.elementNotFound(resourceId)
                 }
-
                 try runOnMainThread {
                     try self.tapAndAwaitKeyboardFocus(app: app, element: element, resourceId: resourceId)
                     GesturePerformer.clearViaDeletes(element: element)
                 }
-            } else {
-                try requireKeyboardFocus(app: app, context: "ensure a text field is focused before clearing")
+                return
+            }
 
-                runOnMainThread {
-                    // Locate the currently-focused element so we can delete
-                    // per-character and fire RN's onChangeText for each.
-                    let focusedQuery = app.descendants(matching: .any)
-                        .matching(NSPredicate(format: "hasKeyboardFocus == true"))
-                    if focusedQuery.firstMatch.exists {
-                        GesturePerformer.clearViaDeletes(element: focusedQuery.firstMatch)
-                    } else {
-                        // Fallback: app-level Cmd+A/Delete. Reaches the UIKit
-                        // buffer even when no XCUITest-visible element owns
-                        // hasKeyboardFocus (e.g., RN wrappers — same case the
-                        // snapshot.hasFocus fallback covers for focus detection).
-                        // RN state will not update via this path; callers
-                        // should prefer the resourceId branch for RN apps.
-                        app.typeKey("a", modifierFlags: .command)
-                        app.typeKey(.delete, modifierFlags: [])
-                    }
-                }
+            // Bare clearText: require focus (3-strategy), then resolve the
+            // focused element to dispatch per-character deletes against.
+            // Single code path — no Cmd+A/Delete fallback, because that
+            // path bypasses RN's onChangeText bridge.
+            try requireKeyboardFocus(app: app, context: "ensure a text field is focused before clearing")
+            guard let focused = resolveFocusedTextElement(app: app) else {
+                let diag = buildFocusDiagnostic(app: app, reason: "clearText: focus confirmed but no XCUITest-visible element resolved")
+                gestureLog.error("\(diag, privacy: .public)")
+                throw GestureError.gestureFailed(
+                    "clearText could not resolve a focused text element. Pass resourceId to clear a specific field. Diagnostic: \(diag)"
+                )
+            }
+            runOnMainThread {
+                GesturePerformer.clearViaDeletes(element: focused)
             }
         }
 

--- a/ios/control-proxy/Sources/CtrlProxy/GesturePerformer.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/GesturePerformer.swift
@@ -457,45 +457,64 @@ public class GesturePerformer: GesturePerforming {
             }
         }
 
-        /// Delete-burst size for `clearViaDeletes`. Sized to cover typical
-        /// form-field content (email, name, phone, password, address, OTP)
-        /// without exceeding what XCUITest's keyboard input pipeline can
-        /// ship as a single `typeText` call before falling back to touch
-        /// synthesis — which, empirically, can trigger spurious home
-        /// transitions during very long bursts. 50 chars is a safe cap.
-        /// Overkill deletes on an empty field are harmless no-ops.
+        /// Delete-burst size per iteration in `clearViaDeletes`. Sized to
+        /// stay under the empirically observed threshold where XCUITest's
+        /// typeText falls back to touch synthesis (XCTouchGesturePerformer)
+        /// during very long single-string bursts, which can trigger
+        /// spurious home-screen transitions. Overkill deletes on an empty
+        /// field are harmless no-ops.
         private static let clearViaDeletesBurstSize = 50
 
-        /// Clear a text element by positioning the cursor at the end of
-        /// content then sending a large fixed-size burst of delete
-        /// keystrokes. Returns the burst size (callers typically ignore it).
+        /// Maximum loop iterations in `clearViaDeletes`. 20 × 50 = up to
+        /// 1000 chars clearable, which is far beyond any realistic form
+        /// field. The loop typically exits much earlier via the
+        /// no-progress or empty-value break conditions.
+        private static let clearViaDeletesMaxIterations = 20
+
+        /// Clear a text element by looping tap + delete-burst up to
+        /// `clearViaDeletesMaxIterations` times, with an early-exit when
+        /// `element.value` reports an empty string. Returns the
+        /// approximate number of delete keystrokes dispatched.
         ///
         /// **Why not Cmd+A + Delete?** Bypasses React Native's
         /// `onChangeText` bridge — the native buffer clears but RN JS state
         /// stays stale.
         ///
-        /// **Why a fixed burst and not a progress-driven loop?**
-        /// `element.value` on RN `TextInput` wrappers returns the
-        /// accessibility identifier (e.g. `"email-sign-in-email-input"`)
-        /// instead of the real content, so count- and equality-based
-        /// progress detection is unreliable. A single generous burst with
-        /// the cursor at the end sidesteps both problems.
+        /// **Why a loop?** A tap at `dx=0.95` does not reliably place the
+        /// cursor at end-of-content: when the text width exceeds the
+        /// field's visible width, the field scrolls to keep the cursor
+        /// visible, so the right-edge tap can land mid-text rather than in
+        /// trailing padding. A single 50-delete burst from a mid-text
+        /// cursor only consumes chars to the left of the cursor and then
+        /// no-ops on the remaining buffer. Iterating tap + burst lets us
+        /// chip away at the content regardless of cursor position.
         ///
-        /// **Cursor positioning.** A bare tap at the right edge places the
-        /// cursor at end-of-content (iOS snaps to the last character when
-        /// the tap lands in trailing padding). We use `tap()` rather than
-        /// `doubleTap()` because doubleTap on empty padding past the text
-        /// is a no-op and doesn't reposition the cursor. Coordinate-based
-        /// so it fires even when the element already has first-responder
-        /// focus.
+        /// **Why only an isEmpty early-exit, no value-equality check?**
+        /// RN `TextInput` wrappers and `placeholderValue` both tend to
+        /// surface the accessibility identifier rather than the real text
+        /// buffer or true placeholder, which would false-positive either a
+        /// "no progress" or "matches placeholder" break after a single
+        /// iteration and leave residual content. Extra deletes on an
+        /// already-empty field are harmless no-ops, so we accept the
+        /// worst-case cost of running the full iteration count on RN
+        /// fields in exchange for correctness.
         @discardableResult
         private static func clearViaDeletes(element: XCUIElement) -> Int {
-            element.coordinate(withNormalizedOffset: CGVector(dx: 0.95, dy: 0.5)).tap()
-            element.typeText(String(
-                repeating: XCUIKeyboardKey.delete.rawValue,
-                count: clearViaDeletesBurstSize
-            ))
-            return clearViaDeletesBurstSize
+            var totalDeleted = 0
+            for iteration in 0..<clearViaDeletesMaxIterations {
+                let current = (element.value as? String) ?? ""
+                gestureLog.debug("clearViaDeletes iter=\(iteration, privacy: .public) valueCount=\(current.count, privacy: .public)")
+                if current.isEmpty {
+                    break
+                }
+                element.coordinate(withNormalizedOffset: CGVector(dx: 0.95, dy: 0.5)).tap()
+                element.typeText(String(
+                    repeating: XCUIKeyboardKey.delete.rawValue,
+                    count: clearViaDeletesBurstSize
+                ))
+                totalDeleted += clearViaDeletesBurstSize
+            }
+            return totalDeleted
         }
 
         /// Resolve the currently-focused text-input element for the bare

--- a/ios/control-proxy/Sources/CtrlProxy/GesturePerformer.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/GesturePerformer.swift
@@ -471,67 +471,28 @@ public class GesturePerformer: GesturePerforming {
         /// no-progress or empty-value break conditions.
         private static let clearViaDeletesMaxIterations = 20
 
-        /// Attempt WDA's first-tier clear strategy: dispatch a keyboard
-        /// `Clear` HID event (`kHIDPage_KeyboardOrKeypad` / `0x9C`) via the
-        /// private `XCDeviceEvent` + `-[XCUIDevice performDeviceEvent:error:]`
-        /// API. One HID event wipes the entire field through the keyboard
-        /// event pipeline (so RN's `onChangeText` fires), regardless of
-        /// content length or cursor position.
-        ///
-        /// Returns `true` if the event dispatched without error; `false`
-        /// if the private API couldn't be resolved or the call failed.
-        /// Callers should still run the delete-burst loop afterward as a
-        /// safety net — this is a fast-path optimization, not a guarantee.
-        ///
-        /// Uses `objc_msgSend` via `unsafeBitCast` + `@convention(c)`
-        /// function types so we don't have to bring `NSInvocation` into a
-        /// Swift-only target.
-        private static func tryHidKeyboardClear() -> Bool {
-            guard let eventClass = NSClassFromString("XCDeviceEvent") else {
-                gestureLog.debug("tryHidKeyboardClear: XCDeviceEvent class not found")
-                return false
-            }
-            let factorySel = NSSelectorFromString("deviceEventWithPage:usage:duration:")
-            guard let factoryMethod = class_getClassMethod(eventClass, factorySel) else {
-                gestureLog.debug("tryHidKeyboardClear: deviceEventWithPage:usage:duration: not found")
-                return false
-            }
-            typealias FactoryFn = @convention(c) (AnyClass, Selector, UInt32, UInt32, Double) -> AnyObject?
-            let factory = unsafeBitCast(method_getImplementation(factoryMethod), to: FactoryFn.self)
-            // page=0x07 kHIDPage_KeyboardOrKeypad, usage=0x9C kHIDUsage_KeyboardClear
-            guard let event = factory(eventClass, factorySel, 0x07, 0x9C, 0.01) else {
-                gestureLog.debug("tryHidKeyboardClear: factory returned nil")
-                return false
-            }
-
-            let device = XCUIDevice.shared
-            let performSel = NSSelectorFromString("performDeviceEvent:error:")
-            guard let performMethod = class_getInstanceMethod(type(of: device), performSel) else {
-                gestureLog.debug("tryHidKeyboardClear: performDeviceEvent:error: not found")
-                return false
-            }
-            typealias PerformFn = @convention(c) (XCUIDevice, Selector, AnyObject, AutoreleasingUnsafeMutablePointer<NSError?>?) -> Bool
-            let perform = unsafeBitCast(method_getImplementation(performMethod), to: PerformFn.self)
-            var nsError: NSError? = nil
-            let ok = perform(device, performSel, event, &nsError)
-            if !ok {
-                gestureLog.debug("tryHidKeyboardClear: performDeviceEvent failed error=\(nsError?.localizedDescription ?? "nil", privacy: .public)")
-            }
-            return ok
-        }
-
-        /// Clear a text element by first attempting WDA's HID `Clear` key
-        /// event (single-shot, sidesteps cursor positioning and content
-        /// length), then falling back to a loop of tap + delete-burst up
-        /// to `clearViaDeletesMaxIterations` times, with an early-exit
-        /// when `element.value` reports an empty string. Returns the
-        /// approximate number of delete keystrokes dispatched by the
-        /// fallback loop (0 if the HID clear succeeded and the field is
-        /// visibly empty to XCUITest).
+        /// Clear a text element by looping tap + delete-burst up to
+        /// `clearViaDeletesMaxIterations` times, with an early-exit when
+        /// `element.value` reports an empty string. Returns the
+        /// approximate number of delete keystrokes dispatched.
         ///
         /// **Why not Cmd+A + Delete?** Bypasses React Native's
         /// `onChangeText` bridge — the native buffer clears but RN JS state
         /// stays stale.
+        ///
+        /// **Why not an HID `Clear` keyboard event (WDA's fast path)?**
+        /// We tried it with `XCDeviceEvent` + `kHIDUsage_KeyboardClear`
+        /// (0x9C) and confirmed it dispatches successfully (native
+        /// UITextField buffer went from 162 → 0 chars in ~240ms per
+        /// `element.value`). But it's a strict regression for RN: the
+        /// event bypasses RN's `onChangeText` bridge exactly like
+        /// Cmd+A+Delete does, so RN's JS state stays stale and RN
+        /// restores the content on its next re-render. Worse, it breaks
+        /// the loop's progress detection because `element.value` ends up
+        /// reading the placeholder instead of the restored text, so the
+        /// loop runs to the iteration cap without making visible
+        /// progress. The per-char delete loop is the only path that
+        /// reliably fires `onChangeText`.
         ///
         /// **Why a loop?** A tap at `dx=0.95` does not reliably place the
         /// cursor at end-of-content: when the text width exceeds the
@@ -553,12 +514,6 @@ public class GesturePerformer: GesturePerforming {
         /// fields in exchange for correctness.
         @discardableResult
         private static func clearViaDeletes(element: XCUIElement) -> Int {
-            // Fast path: single HID Clear event. On native UIKit fields
-            // this typically empties the buffer in one shot; the loop
-            // below then no-ops via the isEmpty check.
-            let hidCleared = tryHidKeyboardClear()
-            gestureLog.debug("clearViaDeletes hidCleared=\(hidCleared, privacy: .public)")
-
             var totalDeleted = 0
             for iteration in 0..<clearViaDeletesMaxIterations {
                 let current = (element.value as? String) ?? ""

--- a/ios/control-proxy/Sources/CtrlProxy/Logging.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/Logging.swift
@@ -1,5 +1,36 @@
 import Foundation
 
+#if !canImport(os)
+/// No-op `Logger` shim for non-Apple Swift toolchains where `os.Logger`
+/// isn't available. Lets the top-level `Logger(...)` declarations in
+/// `GesturePerformer.swift` / `CommandHandler.swift` and every
+/// `.debug(...)` / `.error(...)` call site compile without per-call
+/// `#if canImport(os)` guards. All logging on non-Apple platforms is a
+/// no-op — we don't run the CtrlProxy runtime there, only typecheck it.
+public enum OSLogPrivacy {
+    case `public`
+    case `private`
+}
+
+public struct OSLogInterpolation: StringInterpolationProtocol {
+    public init(literalCapacity _: Int, interpolationCount _: Int) {}
+    public mutating func appendLiteral(_: String) {}
+    public mutating func appendInterpolation<T>(_: T, privacy _: OSLogPrivacy) {}
+    public mutating func appendInterpolation<T>(_: T) {}
+}
+
+public struct OSLogMessage: ExpressibleByStringLiteral, ExpressibleByStringInterpolation {
+    public init(stringLiteral _: String) {}
+    public init(stringInterpolation _: OSLogInterpolation) {}
+}
+
+public struct Logger {
+    public init(subsystem _: String, category _: String) {}
+    public func debug(_: OSLogMessage) {}
+    public func error(_: OSLogMessage) {}
+}
+#endif
+
 /// Shared subsystem identifier for all CtrlProxy `os.Logger` output.
 ///
 /// Log-level contract across the CtrlProxy Swift sources:

--- a/ios/control-proxy/Sources/CtrlProxy/Logging.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/Logging.swift
@@ -1,0 +1,22 @@
+import Foundation
+
+/// Shared subsystem identifier for all CtrlProxy `os.Logger` output.
+///
+/// Log-level contract across the CtrlProxy Swift sources:
+///   - `.debug`  — normal success path trace. Not persisted to the unified
+///                 log store; only visible when actively streaming.
+///   - `.error`  — failures only. Persisted, rare, high-signal.
+///
+/// Do NOT promote success-path logs to `.info` — `Logger.info` is persisted
+/// and every text input would leave durable records. Enable streaming during
+/// a debug session with:
+///
+///     xcrun simctl spawn booted log stream --level=debug \
+///       --predicate 'subsystem == "dev.kaeawc.automobile.ctrlproxy"'
+///
+/// Defined as a top-level `let` so callers can write
+/// `Logger(subsystem: ctrlProxyLogSubsystem, category: "…")` without
+/// pulling in a full enum namespace. Rename-safe: a single constant for
+/// the whole package means filters in dashboards or log-show commands
+/// can't drift across files.
+let ctrlProxyLogSubsystem = "dev.kaeawc.automobile.ctrlproxy"

--- a/ios/control-proxy/Sources/CtrlProxy/Protocols.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/Protocols.swift
@@ -49,6 +49,13 @@ public protocol ElementLocating {
     /// Uses bounded polling: up to 500ms with 50ms intervals (10 attempts max).
     /// Returns true if state was reached, false if timed out.
     func awaitAppState(bundleId: String, expectedState: AppStateExpectation) -> Bool
+
+    /// Bundle ID of the currently tracked foreground app, or nil if none has
+    /// been set yet. Used by GesturePerformer's text-input paths to resolve a
+    /// fresh XCUIApplication at call time (see issue #1925) — this avoids the
+    /// drift where an MCP-side `simctl launch` updates ElementLocator's tracker
+    /// but leaves GesturePerformer pointing at a stale / empty app reference.
+    var foregroundBundleId: String? { get }
 }
 
 // MARK: - GesturePerformer Protocol

--- a/ios/control-proxy/Tests/CtrlProxyTests/ElementLocatorTests.swift
+++ b/ios/control-proxy/Tests/CtrlProxyTests/ElementLocatorTests.swift
@@ -534,4 +534,41 @@ final class ElementLocatorTests: XCTestCase {
         XCTAssertEqual(result[0].className, "UIView")
         XCTAssertEqual(result[1].text, "Enter name")
     }
+
+    // MARK: - #1925: foregroundBundleId protocol contract
+    //
+    // GesturePerformer's text-input paths (typeText, setText, clearText,
+    // selectAll, performImeAction, clipboard paste) resolve their
+    // XCUIApplication via `elementLocator.foregroundBundleId` at call time.
+    // That avoids drift when the MCP server launches apps via `simctl launch`
+    // instead of CommandHandler.handleLaunchApp. These tests pin the protocol
+    // contract so the fake stays in sync with the real ElementLocator.
+
+    func testFake_foregroundBundleId_nilByDefault() {
+        let locator = FakeElementLocator()
+        XCTAssertNil(locator.foregroundBundleId)
+    }
+
+    func testFake_foregroundBundleId_updatedBySwitchForegroundApp() {
+        let locator = FakeElementLocator()
+        locator.switchForegroundApp(bundleId: "com.example.rnexpoexamples")
+        XCTAssertEqual(locator.foregroundBundleId, "com.example.rnexpoexamples")
+    }
+
+    func testFake_foregroundBundleId_settableForOutOfBandTransitions() {
+        // Simulates the MCP `simctl launch` scenario where CommandHandler
+        // never sees handleLaunchApp but ElementLocator has latched the
+        // detected foreground app.
+        let locator = FakeElementLocator()
+        locator.foregroundBundleId = "com.snackpass.ai"
+        XCTAssertEqual(locator.foregroundBundleId, "com.snackpass.ai")
+    }
+
+    func testFake_foregroundBundleId_lastSwitchWins() {
+        let locator = FakeElementLocator()
+        locator.switchForegroundApp(bundleId: "com.example.first")
+        locator.switchForegroundApp(bundleId: "com.example.second")
+        XCTAssertEqual(locator.foregroundBundleId, "com.example.second")
+        XCTAssertEqual(locator.switchedBundleIds, ["com.example.first", "com.example.second"])
+    }
 }

--- a/src/features/action/ClearText.ts
+++ b/src/features/action/ClearText.ts
@@ -106,19 +106,21 @@ export class ClearText extends BaseVisualChange {
    * Execute iOS-specific clear text using CtrlProxy iOS.
    */
   private async executeiOSClearText(observeResult: ObserveResult): Promise<ClearTextResult> {
+    const startMs = Date.now();
+    logger.debug(`[ClearText] iOS begin`);
     try {
       const client = IOSCtrlProxyClient.getInstance(this.device);
       const result = await client.requestClearText();
 
       if (result.success) {
-        logger.info(`[ClearText] Cleared text via CtrlProxy iOS`);
+        logger.info(`[ClearText] Cleared text via CtrlProxy iOS totalMs=${Date.now() - startMs}`);
         return { success: true };
       }
 
-      logger.warn(`[ClearText] CtrlProxy iOS clear failed: ${result.error}`);
+      logger.warn(`[ClearText] CtrlProxy iOS clear failed: ${result.error} totalMs=${Date.now() - startMs}`);
       return { success: false, error: result.error };
     } catch (error) {
-      logger.error(`[ClearText] CtrlProxy iOS exception: ${error}`);
+      logger.error(`[ClearText] CtrlProxy iOS exception: ${error} totalMs=${Date.now() - startMs}`);
       return { success: false, error: String(error) };
     }
   }

--- a/src/features/action/FieldTypeDetector.ts
+++ b/src/features/action/FieldTypeDetector.ts
@@ -34,6 +34,11 @@ const ANDROID_PATTERNS = {
 const IOS_PATTERNS = {
   text: [
     "UITextField",
+    // UISecureTextField is UIKit's password input; identical behaviour to
+    // UITextField from a setUIState perspective (tap + clear + type). The
+    // masked-value verification is handled by isPasswordField +
+    // shouldSkipVerification below.
+    "UISecureTextField",
     "UITextView",
     "UISearchBar"
   ],

--- a/src/features/action/InputText.ts
+++ b/src/features/action/InputText.ts
@@ -125,11 +125,14 @@ export class InputText extends BaseVisualChange {
     text: string,
     imeAction?: "done" | "next" | "search" | "send" | "go" | "previous"
   ): Promise<SendTextResult & { method?: "a11y" }> {
+    const startMs = Date.now();
+    logger.debug(`[InputText] iOS begin textLength=${text.length} imeAction=${imeAction ?? "none"}`);
+
     const client = IOSCtrlProxyClient.getInstance(this.device);
     const result = await client.requestSetText(text);
 
     if (!result.success) {
-      logger.error(`[InputText] CtrlProxy iOS setText failed: ${result.error}`);
+      logger.error(`[InputText] CtrlProxy iOS setText failed: ${result.error} totalMs=${Date.now() - startMs}`);
       return {
         success: false,
         text,
@@ -137,6 +140,8 @@ export class InputText extends BaseVisualChange {
         method: "a11y"
       };
     }
+
+    logger.debug(`[InputText] iOS setText ok totalMs=${Date.now() - startMs}`);
 
     // Handle IME action if specified (CtrlProxy iOS supports this)
     if (imeAction) {

--- a/src/features/action/SetUIState.ts
+++ b/src/features/action/SetUIState.ts
@@ -442,24 +442,35 @@ export class SetUIState extends BaseVisualChange {
             return { success: false, error: "value is required for text fields" };
           }
 
+          const selectorDesc = this.describeSelector(fieldSpec.selector);
+
           // Tap to focus
+          logger.debug(`[SetUIState] text.tap selector=${selectorDesc}`);
+          const tapStart = Date.now();
           const tapResult = await tapOnElement.execute(
             this.buildTapOptions(fieldSpec.selector, "tap"),
             progress,
             signal
           );
+          logger.debug(`[SetUIState] text.tap done selector=${selectorDesc} success=${tapResult.success} totalMs=${Date.now() - tapStart}${tapResult.error ? ` error=${tapResult.error}` : ""}`);
           if (!tapResult.success) {
             return { success: false, error: `Failed to tap on field: ${tapResult.error}` };
           }
 
           // Clear existing text
+          logger.debug(`[SetUIState] text.clear selector=${selectorDesc}`);
+          const clearStart = Date.now();
           const clearResult = await clearText.execute(progress);
+          logger.debug(`[SetUIState] text.clear done selector=${selectorDesc} success=${clearResult.success} totalMs=${Date.now() - clearStart}${clearResult.error ? ` error=${clearResult.error}` : ""}`);
           if (!clearResult.success) {
             return { success: false, error: `Failed to clear text: ${clearResult.error}` };
           }
 
           // Input new text
+          logger.debug(`[SetUIState] text.input selector=${selectorDesc} textLength=${fieldSpec.value.length}`);
+          const inputStart = Date.now();
           const inputResult = await inputText.execute(fieldSpec.value);
+          logger.debug(`[SetUIState] text.input done selector=${selectorDesc} success=${inputResult.success} totalMs=${Date.now() - inputStart}${inputResult.error ? ` error=${inputResult.error}` : ""}`);
           if (!inputResult.success) {
             return { success: false, error: `Failed to input text: ${inputResult.error}` };
           }

--- a/src/features/observe/ios/CtrlProxyText.ts
+++ b/src/features/observe/ios/CtrlProxyText.ts
@@ -11,6 +11,7 @@ import type { BaseResult } from "../shared/types";
 import { SharedTextDelegate } from "../shared/SharedTextDelegate";
 import type { DelegateContext } from "./types";
 import { createMessage } from "../DeviceServiceUtils";
+import { logger } from "../../../utils/logger";
 
 export class CtrlProxyText extends SharedTextDelegate {
   constructor(context: DelegateContext) {
@@ -30,13 +31,20 @@ export class CtrlProxyText extends SharedTextDelegate {
     timeoutMs: number = 5000,
     perf?: PerformanceTracker
   ): Promise<BaseResult> {
+    const startMs = Date.now();
     this.context.cancelScreenshotBackoff();
 
-    if (!await this.context.ensureConnected(perf)) {
+    const connected = await (perf
+      ? perf.track("ensureConnected", () => this.context.ensureConnected(perf))
+      : this.context.ensureConnected(perf));
+    if (!connected) {
+      logger.warn(`[CtrlProxyText] requestClearText aborted: not connected (resourceId=${resourceId ?? "nil"})`);
       return { success: false, totalTimeMs: 0, error: "Not connected" };
     }
 
     const requestId = this.context.requestManager.generateId("clearText");
+    logger.debug(`[CtrlProxyText] requestClearText send requestId=${requestId} resourceId=${resourceId ?? "nil"} timeoutMs=${timeoutMs}`);
+
     const promise = this.context.requestManager.register<BaseResult>(
       requestId,
       "clear_text",
@@ -55,6 +63,10 @@ export class CtrlProxyText extends SharedTextDelegate {
 
     const msg = createMessage("request_clear_text", requestId, params);
     this.context.getWebSocket()?.send(msg);
-    return promise;
+    const result = await (perf
+      ? perf.track("clearText.awaitResponse", () => promise)
+      : promise);
+    logger.debug(`[CtrlProxyText] requestClearText done requestId=${requestId} success=${result.success} totalMs=${Date.now() - startMs}${result.error ? ` error=${result.error}` : ""}`);
+    return result;
   }
 }

--- a/src/features/observe/shared/SharedTextDelegate.ts
+++ b/src/features/observe/shared/SharedTextDelegate.ts
@@ -7,6 +7,7 @@
 import type { PerformanceTracker } from "../../../utils/PerformanceTracker";
 import type { DelegateContext, BaseResult, ActionTimingResult } from "./types";
 import { createMessage } from "../DeviceServiceUtils";
+import { logger } from "../../../utils/logger";
 
 export class SharedTextDelegate {
   protected readonly context: DelegateContext;
@@ -26,13 +27,20 @@ export class SharedTextDelegate {
     perf?: PerformanceTracker,
     dismissKeyboard: boolean = false
   ): Promise<BaseResult> {
+    const startMs = Date.now();
     this.context.cancelScreenshotBackoff();
 
-    if (!await this.context.ensureConnected(perf)) {
+    const connected = await (perf
+      ? perf.track("ensureConnected", () => this.context.ensureConnected(perf))
+      : this.context.ensureConnected(perf));
+    if (!connected) {
+      logger.warn(`[SharedTextDelegate] requestSetText aborted: not connected (resourceId=${resourceId ?? "nil"})`);
       return { success: false, totalTimeMs: 0, error: "Not connected" };
     }
 
     const requestId = this.context.requestManager.generateId("setText");
+    logger.debug(`[SharedTextDelegate] requestSetText send requestId=${requestId} resourceId=${resourceId ?? "nil"} textLength=${text.length} dismissKeyboard=${dismissKeyboard} timeoutMs=${timeoutMs}`);
+
     const promise = this.context.requestManager.register<BaseResult>(
       requestId,
       "set_text",
@@ -54,7 +62,11 @@ export class SharedTextDelegate {
 
     const msg = createMessage("request_set_text", requestId, params);
     this.context.getWebSocket()?.send(msg);
-    return promise;
+    const result = await (perf
+      ? perf.track("setText.awaitResponse", () => promise)
+      : promise);
+    logger.debug(`[SharedTextDelegate] requestSetText done requestId=${requestId} success=${result.success} totalMs=${Date.now() - startMs}${result.error ? ` error=${result.error}` : ""}`);
+    return result;
   }
 
   async requestClearText(
@@ -70,13 +82,20 @@ export class SharedTextDelegate {
     timeoutMs: number = 5000,
     perf?: PerformanceTracker
   ): Promise<ActionTimingResult> {
+    const startMs = Date.now();
     this.context.cancelScreenshotBackoff();
 
-    if (!await this.context.ensureConnected(perf)) {
+    const connected = await (perf
+      ? perf.track("ensureConnected", () => this.context.ensureConnected(perf))
+      : this.context.ensureConnected(perf));
+    if (!connected) {
+      logger.warn(`[SharedTextDelegate] requestImeAction aborted: not connected (action=${action})`);
       return { success: false, action, totalTimeMs: 0, error: "Not connected" };
     }
 
     const requestId = this.context.requestManager.generateId("imeAction");
+    logger.debug(`[SharedTextDelegate] requestImeAction send requestId=${requestId} action=${action} timeoutMs=${timeoutMs}`);
+
     const promise = this.context.requestManager.register<ActionTimingResult>(
       requestId,
       "ime_action",
@@ -91,20 +110,31 @@ export class SharedTextDelegate {
 
     const msg = createMessage("request_ime_action", requestId, { action });
     this.context.getWebSocket()?.send(msg);
-    return promise;
+    const result = await (perf
+      ? perf.track("imeAction.awaitResponse", () => promise)
+      : promise);
+    logger.debug(`[SharedTextDelegate] requestImeAction done requestId=${requestId} action=${action} success=${result.success} totalMs=${Date.now() - startMs}${result.error ? ` error=${result.error}` : ""}`);
+    return result;
   }
 
   async requestSelectAll(
     timeoutMs: number = 5000,
     perf?: PerformanceTracker
   ): Promise<BaseResult> {
+    const startMs = Date.now();
     this.context.cancelScreenshotBackoff();
 
-    if (!await this.context.ensureConnected(perf)) {
+    const connected = await (perf
+      ? perf.track("ensureConnected", () => this.context.ensureConnected(perf))
+      : this.context.ensureConnected(perf));
+    if (!connected) {
+      logger.warn(`[SharedTextDelegate] requestSelectAll aborted: not connected`);
       return { success: false, totalTimeMs: 0, error: "Not connected" };
     }
 
     const requestId = this.context.requestManager.generateId("selectAll");
+    logger.debug(`[SharedTextDelegate] requestSelectAll send requestId=${requestId} timeoutMs=${timeoutMs}`);
+
     const promise = this.context.requestManager.register<BaseResult>(
       requestId,
       "select_all",
@@ -118,6 +148,10 @@ export class SharedTextDelegate {
 
     const msg = createMessage("request_select_all", requestId);
     this.context.getWebSocket()?.send(msg);
-    return promise;
+    const result = await (perf
+      ? perf.track("selectAll.awaitResponse", () => promise)
+      : promise);
+    logger.debug(`[SharedTextDelegate] requestSelectAll done requestId=${requestId} success=${result.success} totalMs=${Date.now() - startMs}${result.error ? ` error=${result.error}` : ""}`);
+    return result;
   }
 }

--- a/test/features/action/FieldTypeDetector.test.ts
+++ b/test/features/action/FieldTypeDetector.test.ts
@@ -48,6 +48,43 @@ describe("FieldTypeDetector", () => {
         expect(detector.detect(element)).toBe("text");
       });
 
+      test("detects iOS UISecureTextField as text", () => {
+        // UITextField and UISecureTextField share identical setUIState
+        // behaviour (tap + clear + type). The substring check would not
+        // match "uisecuretextfield" against "uitextfield" (the `ui` and
+        // `textfield` tokens are non-contiguous), so UISecureTextField
+        // must be listed explicitly in IOS_PATTERNS.text.
+        const element = createElement({
+          "class": "UISecureTextField",
+          "password": "true",
+          "focusable": true,
+          "clickable": true
+        });
+        expect(detector.detect(element)).toBe("text");
+      });
+
+      test("detects iOS UISecureTextField as password field", () => {
+        const element = createElement({
+          "class": "UISecureTextField",
+          "password": "true"
+        });
+        expect(detector.isPasswordField(element)).toBe(true);
+      });
+
+      test("shouldSkipVerification true for UISecureTextField text-type", () => {
+        // Secure text fields report a masked value (e.g., "••••") that
+        // cannot be compared to the target string. The password-field
+        // branch in SetUIState.applyFieldValue relies on this skip so
+        // the setUIState op doesn't falsely fail verification.
+        const element = createElement({
+          "class": "UISecureTextField",
+          "password": "true"
+        });
+        // Without a concrete `value` attribute, iOS text verification
+        // is unreliable — detector should skip.
+        expect(detector.shouldSkipVerification(element, "text")).toBe(true);
+      });
+
       test("detects focusable + clickable as text fallback", () => {
         const element = createElement({
           "class": "com.custom.TextInput",


### PR DESCRIPTION
## Summary

Fixes #1925 — iOS text input tools (`inputText`, `clearText`, `setUIState`, `selectAllText`, `imeAction`) fail with `Gesture failed: No element has keyboard focus — ensure a text field is focused before typing` even when the target field is demonstrably focused and the keyboard is visible.

## Root cause

CtrlProxy maintains two independent `XCUIApplication` references:

| Reference | Updated when | Observed state |
|---|---|---|
| `ElementLocator.foregroundApp` | every observe (via `switchForegroundApp`) | **correct** |
| `GesturePerformer.application` | only on `CommandHandler.handleLaunchApp` | **stale** |

The MCP server launches apps via `xcrun simctl launch` (see `simctlLaunch` span in `perfTiming`), which never routes through `handleLaunchApp`. The GesturePerformer reference stays pinned to whatever `CtrlProxy.start()` initialised it to — typically SpringBoard or the test host with an empty bundle identifier. Every text gesture queries that wrong app for `hasKeyboardFocus == true` descendants, matches zero, and throws.

The initial hypothesis (RN wrappers confusing XCUITest) turned out wrong. The instrumentation added in this PR embeds a diagnostic in the thrown error that makes the real cause self-evident:

```
app.label=" " | app.identifier=""
textFields.count=0 | secureTextFields.count=0
app.keyboards.count=0 | springboard.keyboards.count=0
```

An XCUIApplication with empty identifier and zero descendants of every kind can only be the runner's own host process — not the user's app.

## Fixes

1. **Expose `foregroundBundleId` on the `ElementLocating` protocol** so `GesturePerformer` can read it.
2. **Route text-input gestures through a fresh `XCUIApplication(bundleIdentifier:)`** resolved at call time via `resolveTextInputApp()`. Coordinate gestures (`tap`, `swipe`, `drag`, `pinch`) still use the SpringBoard anchor by design.
3. **Two fallback detection strategies** (credit: parallel `asdf` worktree) for environments where even the correct app's `hasKeyboardFocus` predicate doesn't fire:
   - `snapshot.hasFocus` traversal — trusts UIKit first-responder state; catches RN `RCTUITextField` and other wrappers.
   - Keyboard-visibility probe — if the system keyboard is on screen, something owns first responder.
4. **Consolidated into `detectKeyboardFocus(app:) -> (Bool, String)`** so the winning strategy is named and logged.
5. **`clearText` uses per-character deletes** instead of `Cmd+A`+`Delete`, so React Native's `onChangeText` fires and RN JS state stays in sync with the cleared native UITextField buffer. Same approach used for `setText`'s pre-clear pass.
6. **`FieldTypeDetector` recognises `UISecureTextField`** — previously `setUIState` on iOS password inputs returned `Unknown field type: unknown` because the substring match `"uisecuretextfield".includes("uitextfield")` is `false` (`ui` and `textfield` are non-contiguous). Added `UISecureTextField` to `IOS_PATTERNS.text` plus 3 regression tests covering detection, `isPasswordField`, and `shouldSkipVerification` for masked values.

Extended `tapAndAwaitKeyboardFocus` budget from 200ms/20ms → 500ms/50ms to accommodate the snapshot fallback's extra XPC per poll.

## Logging

- `os.Logger(subsystem: "dev.kaeawc.automobile.ctrlproxy")` wraps the text-input paths in `CommandHandler` and `GesturePerformer`. Success-path bookends are `.debug` (not persisted to the unified log store) so normal operation doesn't pollute device logs; failure paths remain `.error` for persistent debuggability. Stream during a debug session with:
  ```
  xcrun simctl spawn booted log stream --level=debug \
    --predicate 'subsystem == "dev.kaeawc.automobile.ctrlproxy"'
  ```
- `buildFocusDiagnostic` embeds a compact, single-line element dump into `GestureError.gestureFailed`, so future failures are self-describing in the MCP response rather than hidden in device logs.
- TypeScript perf spans + `logger.debug` bookends across `SharedTextDelegate`, `CtrlProxyText`, `InputText`, `ClearText`, `SetUIState`.

## End-to-end verification on React Native

Against `com.example.rnexpoexamples` on iPhone 16 Pro sim (iOS 18.0), exercising every text tool the MCP exposes. All operations update both the native UITextField buffer **and** the React `onChangeText`-driven JS state:

| # | MCP call | Field | Result | Latency | RN state |
|---|---|---|---|---|---|
| 1 | `inputText "hello@test.com"` | `UITextField` | ✅ `success: true` | 783ms | `email=hello@test.com` |
| 2 | `clearText` | `UITextField` (focused) | ✅ `success: true` | 803ms | `email=` (cleared) |
| 3 | `setUIState { email }` | `UITextField` (tap+clear+type) | ✅ 1 attempt | — | `email=set-ui-state@test.com` |
| 4 | `inputText "s3cret-password"` | `UISecureTextField` | ✅ `success: true` | 684ms | `password=s3cret-password` |
| 5 | `clearText` | `UISecureTextField` (focused) | ✅ `success: true` | 807ms | `password=` (cleared) |
| 6 | `selectAllText` | `UITextField` | ✅ `success: true` | 867ms | — |
| 7 | `imeAction "done"` | `UITextField` | ✅ `success: true` | 801ms | keyboard dismissed |
| 8 | `setUIState { email, password }` | both | ✅ 2/2 succeeded, 1 attempt each | — | `password=hunter2` ✓ |

Pre-fix behaviour for every row (1–7): `success: false` with `Gesture failed: No element has keyboard focus`. Row 8 pre-fix: `success: false` on password with `Unknown field type: unknown`.

## Tests

- `ElementLocatorTests`: 4 new regression tests pinning the `FakeElementLocator.foregroundBundleId` protocol contract.
- `FieldTypeDetector.test.ts`: 3 new regression tests for `UISecureTextField` detection + password handling + verification skip.
- `./scripts/ios/swift-build.sh`: all packages green.
- `./scripts/ios/swift-test.sh`: `control-proxy` target passes (XCTestRunner empty-suite failure is pre-existing on clean `main`).
- `turbo run lint build test`: 3550+ pass / 0 fail across 272 test files.

## Known quirk (not a regression; not blocking)

When `setUIState` targets an **already-populated** text field, the clear-before-type pass sometimes leaves residual characters at the beginning (e.g. overwriting `"both-fields@test.com"` with `"final@test.com"` results in `"both-ffinal@test.com"`). The cursor lands mid-content on tap for populated fields, and per-character deletes then only remove chars before the cursor. Fixes for follow-up: move cursor to end before deleting (tap + End key, or programmatically position), or issue a SelectAll+typeText(text) pattern for the replace-populated case. Pre-existing behaviour isn't worse than before; the clear-then-type pipeline was never exercised on RN-propagated state before this PR. Does not affect empty→type or type→clear paths.

## Files

- `ios/control-proxy/Sources/CtrlProxy/Protocols.swift` — add `var foregroundBundleId: String? { get }` to `ElementLocating`.
- `ios/control-proxy/Sources/CtrlProxy/ElementLocator.swift` — expose field publicly (iOS) + non-iOS stub.
- `ios/control-proxy/Sources/CtrlProxy/Fakes.swift` — `FakeElementLocator` tracks `foregroundBundleId`, directly settable for out-of-band-transition tests.
- `ios/control-proxy/Sources/CtrlProxy/GesturePerformer.swift` — `resolveTextInputApp()`, `detectKeyboardFocus()`, `snapshotHasTextInputWithFocus()`, `buildFocusDiagnostic()`, `clearViaDeletes()`; rerouted `typeText` / `setText` / `clearText` / `selectAll` / `performImeAction` / clipboard paste.
- `ios/control-proxy/Sources/CtrlProxy/CommandHandler.swift` — perf spans + os_log bookends around text handlers.
- `ios/control-proxy/Tests/CtrlProxyTests/ElementLocatorTests.swift` — 4 protocol-contract regression tests.
- `src/features/action/FieldTypeDetector.ts` — add `UISecureTextField` to `IOS_PATTERNS.text`.
- `src/features/action/{InputText,ClearText,SetUIState}.ts` — debug bookends + timing.
- `src/features/observe/{shared/SharedTextDelegate,ios/CtrlProxyText}.ts` — perf spans + logger bookends.
- `test/features/action/FieldTypeDetector.test.ts` — 3 regression tests for UISecureTextField.

## Test plan

- [ ] CI green on Swift build + test
- [ ] CI green on TS lint + build + test
- [ ] Manual repro against #1925 reporter's Snackpass RN app confirms the keyboard-focus error no longer fires and text reaches RN state
- [ ] No regression in Android text-input paths (iOS-only fix; Android untouched)