### PR TITLE
observe waitFor Container + Plan Timeout Handling

### DIFF
--- a/src/server/observeTools.ts
+++ b/src/server/observeTools.ts
@@ -10,6 +10,7 @@ import { createGlobalPerformanceTracker } from "../utils/PerformanceTracker";
 import { NavigationGraphManager } from "../features/navigation/NavigationGraphManager";
 import { IdentifyInteractions, IdentifyInteractionsOptions } from "../features/observe/IdentifyInteractions";
 import { addDeviceTargetingToSchema, platformSchema } from "./toolSchemaHelpers";
+import { elementContainerSchema } from "./elementSelectorSchemas";
 import { DefaultElementFinder } from "../features/utility/ElementFinder";
 import type { ElementFinder } from "../utils/interfaces/ElementFinder";
 import { defaultTimer } from "../utils/SystemTimer";
@@ -28,15 +29,23 @@ import {
 } from "./toolOutputSchemas";
 
 // Schema definitions
-// waitFor accepts elementId OR text directly (oneOf), plus optional timeout
+// waitFor accepts elementId OR text directly (oneOf), plus optional timeout and optional container (same shape as tapOn)
+const waitForContainerField = elementContainerSchema
+  .optional()
+  .describe(
+    "Scope the match inside this container. Use when resource IDs repeat (e.g. id/name in a RecyclerView)."
+  );
+
 const waitForSchema = z.union([
   z.object({
     elementId: z.string().describe("Element resource ID / accessibility identifier"),
-    timeout: z.number().optional().describe("Wait timeout ms (default: 5000)")
+    timeout: z.number().optional().describe("Wait timeout ms (default: 5000)"),
+    container: waitForContainerField
   }),
   z.object({
     text: z.string().describe("Element text"),
-    timeout: z.number().optional().describe("Wait timeout ms (default: 5000)")
+    timeout: z.number().optional().describe("Wait timeout ms (default: 5000)"),
+    container: waitForContainerField
   })
 ]);
 
@@ -123,16 +132,29 @@ const WAIT_FOR_POLL_INTERVAL_MS = 100;
 type ObserveWaitForOptions = z.infer<typeof waitForSchema>;
 type ObserveArgs = z.infer<typeof observeSchema>;
 
+const waitForContainerForFinder = (
+  waitFor: ObserveWaitForOptions
+): { elementId?: string; text?: string } | null => {
+  if (!waitFor.container) {
+    return null;
+  }
+  return "elementId" in waitFor.container
+    ? { elementId: waitFor.container.elementId }
+    : { text: waitFor.container.text };
+};
+
 const findWaitForElement = (
   finder: ElementFinder,
   waitFor: ObserveWaitForOptions,
   viewHierarchy: ViewHierarchyResult
 ): Element | null => {
+  const container = waitForContainerForFinder(waitFor);
+
   if ("elementId" in waitFor) {
     return finder.findElementByResourceId(
       viewHierarchy,
       waitFor.elementId,
-      undefined
+      container
     );
   }
 
@@ -140,7 +162,7 @@ const findWaitForElement = (
     return finder.findElementByText(
       viewHierarchy,
       waitFor.text,
-      undefined,
+      container,
       true,
       false
     );

--- a/src/utils/plan/PlanExecutor.ts
+++ b/src/utils/plan/PlanExecutor.ts
@@ -94,6 +94,45 @@ export class DefaultPlanExecutor implements PlanExecutor {
     return response;
   }
 
+  private parseStructuredToolPayload(response: unknown): Record<string, unknown> | null {
+    if (!response || typeof response !== "object") {
+      return null;
+    }
+    const r = response as Record<string, unknown>;
+    if (r.structuredContent && typeof r.structuredContent === "object") {
+      return r.structuredContent as Record<string, unknown>;
+    }
+    const content = r.content;
+    if (Array.isArray(content) && content.length > 0) {
+      const first = content[0] as Record<string, unknown>;
+      if (first?.type === "text" && typeof first.text === "string") {
+        try {
+          const parsed = JSON.parse(first.text) as unknown;
+          if (parsed && typeof parsed === "object") {
+            return parsed as Record<string, unknown>;
+          }
+        } catch {
+          return null;
+        }
+      }
+    }
+    return null;
+  }
+
+  /**
+   * Observe with waitFor returns awaitTimeout: true when the condition is not met within the timeout.
+   * The handler does not set success: false, so the executor must treat that as a failed step.
+   */
+  private observeWaitForTimedOut(response: unknown): { awaitDuration?: number } | null {
+    const payload = this.parseStructuredToolPayload(response);
+    if (!payload || payload.awaitTimeout !== true) {
+      return null;
+    }
+    return {
+      awaitDuration: typeof payload.awaitDuration === "number" ? payload.awaitDuration : undefined
+    };
+  }
+
   /**
    * Execute a plan step by step
    * @param plan Plan to execute
@@ -259,6 +298,8 @@ export class DefaultPlanExecutor implements PlanExecutor {
           const toolResult = this.extractToolResult(response);
           logger.info(`[PLAN_STEP_${i + 1}] ${step.tool} completed. Response success: ${toolResult?.success !== false ? "true" : "FALSE"}`);
 
+          const observeTimedOut = step.tool === "observe" ? this.observeWaitForTimedOut(response) : null;
+
           // Check if the response indicates failure
           if (toolResult && typeof toolResult === "object" && "success" in toolResult && toolResult.success === false) {
             const errorMsg = toolResult.error || "Unknown error";
@@ -283,6 +324,35 @@ export class DefaultPlanExecutor implements PlanExecutor {
                 stepIndex: i,
                 tool: step.tool,
                 error: String(errorMsg)
+              },
+              debug: {
+                executionTimeMs: this.timer.now() - startTime,
+                steps: debugSteps
+              }
+            };
+          }
+
+          if (observeTimedOut) {
+            const errorMsg = `observe waitFor timed out after ${observeTimedOut.awaitDuration ?? "unknown"}ms`;
+            logger.error(`[PLAN_STEP_${i + 1}] FAILED: ${step.tool} - ${errorMsg}`);
+            debugSteps.push({
+              step: `Execute step ${i + 1}: ${step.tool}`,
+              status: "failed",
+              durationMs: this.timer.now() - stepStartTime,
+              details: {
+                params: step.params,
+                error: errorMsg,
+              }
+            });
+
+            return {
+              success: false,
+              executedSteps,
+              totalSteps: plan.steps.length,
+              failedStep: {
+                stepIndex: i,
+                tool: step.tool,
+                error: errorMsg,
               },
               debug: {
                 executionTimeMs: this.timer.now() - startTime,
@@ -666,6 +736,24 @@ export class DefaultPlanExecutor implements PlanExecutor {
             const errorMsg = "error" in checkResult ? String(checkResult.error) : "Tool execution failed";
             logger.error(`[PARALLEL_EXEC][${device}] Tool failed: ${errorMsg}`);
 
+            return {
+              success: false,
+              executedSteps,
+              totalSteps: track.length,
+              failedStep: {
+                stepIndex: planIndex,
+                trackIndex,
+                tool: step.tool,
+                error: errorMsg,
+              },
+            };
+          }
+
+          const observeTimedOutParallel =
+            step.tool === "observe" ? this.observeWaitForTimedOut(response) : null;
+          if (observeTimedOutParallel) {
+            const errorMsg = `observe waitFor timed out after ${observeTimedOutParallel.awaitDuration ?? "unknown"}ms`;
+            logger.error(`[PARALLEL_EXEC][${device}] Tool failed: ${errorMsg}`);
             return {
               success: false,
               executedSteps,

--- a/test/plan/planExecutorObserveAwaitTimeout.test.ts
+++ b/test/plan/planExecutorObserveAwaitTimeout.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, test, mock, beforeEach, afterEach } from "bun:test";
+import { DefaultPlanExecutor } from "../../src/utils/plan/PlanExecutor";
+import { Plan } from "../../src/models/Plan";
+import { ToolRegistry } from "../../src/server/toolRegistry";
+import { registerObserveTools } from "../../src/server/observeTools";
+import { z } from "zod";
+import { createStructuredToolResponse } from "../../src/utils/toolUtils";
+
+describe("PlanExecutor — observe waitFor timeout", () => {
+  let planExecutor: DefaultPlanExecutor;
+
+  beforeEach(() => {
+    planExecutor = new DefaultPlanExecutor();
+    const observeSchema = z.object({
+      platform: z.string().optional(),
+      deviceId: z.string().optional(),
+      sessionUuid: z.string().optional(),
+      waitFor: z.any().optional(),
+    });
+    const observeHandler = mock(async () =>
+      createStructuredToolResponse({
+        updatedAt: Date.now(),
+        screenSize: { width: 100, height: 100 },
+        systemInsets: { left: 0, top: 0, right: 0, bottom: 0 },
+        awaitTimeout: true,
+        awaitDuration: 5000,
+      })
+    );
+    ToolRegistry.register("observe", "Mock observe timeout", observeSchema, observeHandler);
+    (ToolRegistry.getTool("observe") as { requiresDevice: boolean }).requiresDevice = true;
+
+    const noopSchema = z.object({ platform: z.string().optional() });
+    ToolRegistry.register(
+      "observeAwaitTimeoutChainNoop",
+      "noop after observe",
+      noopSchema,
+      mock(async () => createStructuredToolResponse({ success: true }))
+    );
+  });
+
+  afterEach(() => {
+    registerObserveTools();
+  });
+
+  test("fails the plan when observe returns awaitTimeout true (does not advance to next step)", async () => {
+    const plan: Plan = {
+      name: "timeout-chain",
+      steps: [
+        { tool: "observe", params: { waitFor: { elementId: "x", timeout: 1 } } },
+        { tool: "observeAwaitTimeoutChainNoop", params: {} },
+      ],
+    };
+
+    const result = await planExecutor.executePlan(plan, 0, "android", "emulator-5554");
+
+    expect(result.success).toBe(false);
+    expect(result.executedSteps).toBe(0);
+    expect(result.failedStep?.tool).toBe("observe");
+    expect(String(result.failedStep?.error)).toContain("timed out");
+    expect(String(result.failedStep?.error)).toContain("5000");
+  });
+});

--- a/test/server/observeWaitForSchema.test.ts
+++ b/test/server/observeWaitForSchema.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, test } from "bun:test";
+import { observeSchema } from "../../src/server/observeTools";
+
+describe("observeSchema waitFor.container", () => {
+  test("accepts elementId waitFor with container elementId", () => {
+    const parsed = observeSchema.parse({
+      platform: "android",
+      waitFor: {
+        elementId: "com.app:id/name",
+        timeout: 8000,
+        container: { elementId: "com.app:id/list" },
+      },
+    });
+    expect(parsed.waitFor).toMatchObject({
+      elementId: "com.app:id/name",
+      container: { elementId: "com.app:id/list" },
+    });
+  });
+
+  test("accepts text waitFor with container text", () => {
+    const parsed = observeSchema.parse({
+      platform: "android",
+      waitFor: {
+        text: "Dan Corkill",
+        container: { text: "PEOPLE" },
+      },
+    });
+    expect(parsed.waitFor).toMatchObject({
+      text: "Dan Corkill",
+      container: { text: "PEOPLE" },
+    });
+  });
+
+  test("rejects container object that includes both elementId and text", () => {
+    expect(() =>
+      observeSchema.parse({
+        platform: "android",
+        waitFor: {
+          elementId: "com.app:id/name",
+          container: { elementId: "com.app:id/list", text: "extra" },
+        },
+      })
+    ).toThrow();
+  });
+});


### PR DESCRIPTION
Closes #1962, #1963.

## Summary

Two related improvements to `observe` with `waitFor`: scoping matches inside a container element, and failing `executePlan` steps when `waitFor` times out.

## Changes

### A. waitFor `container` parameter

**Problem:** `observe` with `waitFor` matches the first element on screen with the given `elementId` or `text`. In lists (e.g. RecyclerView rows), every row shares the same resource IDs (`id/name`, `id/price`). There's no way to scope a `waitFor` match to a specific container, so it always matches the first row regardless of context.

**Example:** You want to wait for the "Premium Plan" row to appear with its price visible. Every row has `id/price`. Writing `waitFor: { elementId: "id/price" }` matches the first row's price, not Premium Plan's.

**Fix:** Added an optional `container` field to the `waitFor` schema:

```json
{
  "waitFor": {
    "elementId": "id/price",
    "container": { "text": "Premium Plan" },
    "timeout": 5000
  }
}
```

The `container` reuses the existing `elementContainerSchema` (same shape `tapOn` already uses: `{ elementId }` or `{ text }`, not both). The schema field is defined once as `waitForContainerField` and shared by both union branches. When provided, it's passed through to `ElementFinder.findElementByResourceId` / `findElementByText`, which already support container-scoped search - only the wiring was missing.

**Risk:** None. The `container` field is optional and defaults to `null`, preserving existing behavior.

**Files:** `src/server/observeTools.ts`

---

### B. Fail `executePlan` on observe `waitFor` timeout

**Problem:** When `observe` with `waitFor` times out (element never appears), the handler returns the current screen state with `awaitTimeout: true` but does *not* set `success: false`. The `PlanExecutor` only checked `success === false` to detect failures, so a timed-out `waitFor` was treated as a successful step. The plan silently continued past the missing element, eventually failing somewhere downstream with a confusing error unrelated to the actual problem.

**Example:** Step 1 launches the app, step 2 does `observe` with `waitFor: { text: "Welcome" }` to wait for the home screen. The home screen never loads. Without this fix, step 2 "succeeds" and step 3 taps whatever happens to be on screen. The test fails later with a misleading error. With this fix, step 2 fails immediately: `observe waitFor timed out after 5000ms`.

**Fix:** Added `observeWaitForTimedOut` to `PlanExecutor`. After each step completes, if the tool was `observe`, it inspects the unwrapped response for `awaitTimeout === true`. If found, it fails the step with the timeout duration in the error message. Applied to both sequential and parallel execution paths.

**Unwrapping:** MCP tool responses come in an envelope (`{ structuredContent: {...} }` or `{ content: [{ type: "text", text: "{...}" }] }`). A `parseStructuredToolPayload` helper unwraps this to access the `awaitTimeout` field. This helper is also used by Group 4's failure observation, but is self-contained here.

**Risk:** Behavior change for plans that previously silently swallowed `waitFor` timeouts. Plans where `waitFor` occasionally timed out but the test still passed downstream will now fail at the `observe` step. This is the correct behavior - a timed-out wait means the expected UI state was not reached.

**Files:** `src/utils/plan/PlanExecutor.ts`

---

## Testing

- 4 new tests across 2 files, all passing
- `observeWaitForSchema.test.ts` - container with elementId, container with text, rejects ambiguous container (both elementId and text)
- `planExecutorObserveAwaitTimeout.test.ts` - plan fails on `awaitTimeout: true` (does not advance to next step)
- Build passes cleanly

## Stats

4 files changed, +222 / -5 lines
