### PR TITLE
systemTray close

### DIFF
--- a/.claude-plugin/skills/notifications.md
+++ b/.claude-plugin/skills/notifications.md
@@ -12,6 +12,13 @@ Pull down the notification shade:
 systemTray with action: "open"
 ```
 
+## Close Notification Shade
+
+Collapse the shade (safe no-op if already closed). Prefer this over `pressButton` for deterministic cleanup between tests:
+```
+systemTray with action: "close"
+```
+
 ## Find Notification
 
 Search for a specific notification:
@@ -57,7 +64,7 @@ systemTray "open" → systemTray "find" → systemTray "tap"
 
 **Clear notifications before test:**
 ```
-systemTray "open" → systemTray "clearAll" → pressButton "back"
+systemTray "open" → systemTray "clearAll" → systemTray "close"
 ```
 
 **Verify notification appeared:**

--- a/docs/design-docs/plat/android/system-tray-lookfor.md
+++ b/docs/design-docs/plat/android/system-tray-lookfor.md
@@ -2,7 +2,7 @@
 
 <kbd>✅ Implemented</kbd> <kbd>🧪 Tested</kbd>
 
-> **Current state:** `systemTray` MCP tool is fully implemented with open/find/tap/dismiss/clearAll actions. See the [Status Glossary](../../status-glossary.md) for chip definitions.
+> **Current state:** `systemTray` MCP tool is fully implemented with open/close/find/tap/dismiss/clearAll actions. See the [Status Glossary](../../status-glossary.md) for chip definitions.
 
 ## Goal
 
@@ -13,7 +13,7 @@ notification by text.
 
 ```typescript
 systemTray({
-  action: "open" | "find" | "tap" | "dismiss" | "clearAll",
+  action: "open" | "close" | "find" | "tap" | "dismiss" | "clearAll",
   notification?: {
     title?: string,
     body?: string,
@@ -29,7 +29,7 @@ systemTray({
 Open/close the tray (preferred, emulator):
 
 - `adb -s <device> shell cmd statusbar expand-notifications`
-- `adb -s <device> shell cmd statusbar collapse`
+- `adb -s <device> shell cmd statusbar collapse` (also exposed as `systemTray` action `close`)
 
 Fallback (gesture):
 
@@ -68,7 +68,7 @@ Notes:
 
 ## Plan
 
-1. Add `systemTray` with open/find/tap/dismiss/clearAll actions.
+1. Add `systemTray` with open/close/find/tap/dismiss/clearAll actions.
 2. Use accessibility node search to match notification text.
 3. Return structured match details for action chaining.
 

--- a/schemas/tool-definitions.json
+++ b/schemas/tool-definitions.json
@@ -5402,7 +5402,7 @@
   },
   {
     "name": "systemTray",
-    "description": "System tray actions for notifications (open/find/tap/dismiss/clearAll)",
+    "description": "System tray actions for notifications (open/close/find/tap/dismiss/clearAll)",
     "inputSchema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "type": "object",
@@ -5411,12 +5411,13 @@
           "type": "string",
           "enum": [
             "open",
+            "close",
             "find",
             "tap",
             "dismiss",
             "clearAll"
           ],
-          "description": "Action: open=expand tray, find=search for notification, tap=tap notification, dismiss=swipe away, clearAll=dismiss all for app"
+          "description": "Action: open=expand tray, close=collapse tray/shade, find=search for notification, tap=tap notification, dismiss=swipe away, clearAll=dismiss all for app"
         },
         "notification": {
           "description": "Notification criteria to match",

--- a/src/server/interactionToolTypes.ts
+++ b/src/server/interactionToolTypes.ts
@@ -29,7 +29,7 @@ export interface SystemTrayNotificationArgs {
 }
 
 export interface SystemTrayArgs {
-  action: "open" | "find" | "tap" | "dismiss" | "clearAll";
+  action: "open" | "close" | "find" | "tap" | "dismiss" | "clearAll";
   notification?: SystemTrayNotificationArgs;
   awaitTimeout?: number;
   platform: Platform;

--- a/src/server/interactionTools.ts
+++ b/src/server/interactionTools.ts
@@ -72,6 +72,7 @@ import {
   waitForNotificationMatch,
   resolveSystemTrayAwaitTimeout,
   ensureSystemTrayOpen,
+  ensureSystemTrayClosed,
   resolveNotificationTapElement,
   resolveNotificationSwipeElement,
   tapElement,
@@ -325,8 +326,8 @@ const systemTrayNotificationSchema = z.object({
 });
 
 const systemTraySchemaBase = z.object({
-  action: z.enum(["open", "find", "tap", "dismiss", "clearAll"]).describe(
-    "Action: open=expand tray, find=search for notification, tap=tap notification, dismiss=swipe away, clearAll=dismiss all for app"
+  action: z.enum(["open", "close", "find", "tap", "dismiss", "clearAll"]).describe(
+    "Action: open=expand tray, close=collapse tray/shade, find=search for notification, tap=tap notification, dismiss=swipe away, clearAll=dismiss all for app"
   ),
   notification: systemTrayNotificationSchema.optional().describe("Notification criteria to match"),
   awaitTimeout: z.number().optional().describe("Timeout in ms to wait for notification (default: 5000)"),
@@ -336,7 +337,7 @@ const systemTraySchemaBase = z.object({
 export const systemTraySchema = addDeviceTargetingToSchema(systemTraySchemaBase).superRefine((value, ctx) => {
   const notification = value.notification ?? {};
 
-  if (value.action === "open") {
+  if (value.action === "open" || value.action === "close") {
     return;
   }
 
@@ -544,6 +545,18 @@ export function registerInteractionTools() {
           message: result.skipped
             ? "System tray already open; no swipe needed"
             : "Opened system tray by swiping down from the status bar",
+          observation: result.observation,
+          success: true,
+          skipped: result.skipped
+        });
+      }
+
+      if (args.action === "close") {
+        const result = await ensureSystemTrayClosed(device, awaitTimeoutMs, progress);
+        return createJSONToolResponse({
+          message: result.skipped
+            ? "System tray already closed; no collapse needed"
+            : "Closed system tray (collapsed notification shade)",
           observation: result.observation,
           success: true,
           skipped: result.skipped
@@ -952,7 +965,7 @@ export function registerInteractionTools() {
 
   ToolRegistry.registerDeviceAware(
     "systemTray",
-    "System tray actions for notifications (open/find/tap/dismiss/clearAll)",
+    "System tray actions for notifications (open/close/find/tap/dismiss/clearAll)",
     systemTraySchema,
     systemTrayHandler,
     true // Supports progress notifications

--- a/src/server/systemTrayHelpers.ts
+++ b/src/server/systemTrayHelpers.ts
@@ -380,6 +380,33 @@ const expandSystemTray = async (device: BootedDevice, screenWidth?: number, scre
   }
 };
 
+const collapseSystemTray = async (device: BootedDevice, screenWidth?: number, screenHeight?: number): Promise<void> => {
+  if (device.platform === "ios") {
+    if (!screenWidth || !screenHeight) {
+      throw new ActionableError("Screen dimensions required to close iOS Notification Center");
+    }
+    const client = getIosClient(device);
+    await client.requestSwipe(
+      Math.floor(screenWidth * 0.5), Math.floor(screenHeight * 0.65),
+      Math.floor(screenWidth * 0.5), Math.floor(screenHeight * 0.08),
+      300
+    );
+    return;
+  }
+
+  if (device.platform !== "android") {
+    return;
+  }
+
+  try {
+    const { adbFactory } = getSystemTrayDependencies();
+    const adb = adbFactory(device);
+    await adb.executeCommand("shell cmd statusbar collapse");
+  } catch (error) {
+    throw new ActionableError(`Failed to collapse system tray: ${error}`);
+  }
+};
+
 const parseAppLabelFromDumpsys = (stdout: string): string | null => {
   const lines = stdout.split("\n").map(line => line.trim()).filter(Boolean);
   const parseLine = (line: string): string | null => {
@@ -968,6 +995,27 @@ const waitForSystemTrayOpen = async (
   return observation;
 };
 
+const waitForSystemTrayClosed = async (
+  observeScreen: SystemTrayObserver,
+  minTimestamp: number,
+  awaitTimeoutMs: number,
+  platform?: Platform
+): Promise<ObserveResult> => {
+  const { timer } = getSystemTrayDependencies();
+  const startTime = timer.now();
+  let observation = await observeScreen.execute(undefined, undefined, false, minTimestamp);
+
+  while (timer.now() - startTime < awaitTimeoutMs) {
+    if (!isSystemTrayOpen(observation.viewHierarchy, platform)) {
+      return observation;
+    }
+    await sleep(SYSTEM_TRAY_POLL_INTERVAL_MS);
+    observation = await observeScreen.execute(undefined, undefined, false, minTimestamp);
+  }
+
+  return observation;
+};
+
 export const ensureSystemTrayOpen = async (
   device: BootedDevice,
   awaitTimeoutMs: number = DEFAULT_SYSTEM_TRAY_AWAIT_TIMEOUT_MS,
@@ -1026,6 +1074,69 @@ export const ensureSystemTrayOpen = async (
   return {
     observation: awaitedObservation ?? observation,
     opened: true,
+    skipped: false,
+    minTimestamp
+  };
+};
+
+export const ensureSystemTrayClosed = async (
+  device: BootedDevice,
+  awaitTimeoutMs: number = DEFAULT_SYSTEM_TRAY_AWAIT_TIMEOUT_MS,
+  _progress?: ProgressCallback
+): Promise<{
+  observation?: ObserveResult;
+  closed: boolean;
+  skipped: boolean;
+  minTimestamp: number;
+}> => {
+  const { observeScreenFactory, timer } = getSystemTrayDependencies();
+  const observeScreen = observeScreenFactory(device);
+  let observation: ObserveResult | undefined;
+  let minTimestamp = 0;
+
+  if (device.platform === "ios") {
+    minTimestamp = timer.now();
+    observation = await observeScreen.execute(undefined, undefined, false, minTimestamp);
+    if (!isSystemTrayOpen(observation.viewHierarchy, "ios")) {
+      return { observation, closed: false, skipped: true, minTimestamp };
+    }
+    const screenWidth = observation.screenSize?.width;
+    const screenHeight = observation.screenSize?.height;
+    await collapseSystemTray(device, screenWidth, screenHeight);
+    minTimestamp = timer.now();
+    const awaitedObservation = await waitForSystemTrayClosed(
+      observeScreen, minTimestamp, awaitTimeoutMs, "ios"
+    );
+    return {
+      observation: awaitedObservation ?? observation,
+      closed: true,
+      skipped: false,
+      minTimestamp
+    };
+  }
+
+  if (device.platform === "android") {
+    minTimestamp = await resolveSystemTrayObservationTimestamp(device);
+    observation = await observeScreen.execute(undefined, undefined, false, minTimestamp);
+    if (!isSystemTrayOpen(observation.viewHierarchy)) {
+      return { observation, closed: false, skipped: true, minTimestamp };
+    }
+  }
+
+  await collapseSystemTray(device);
+  if (device.platform === "android") {
+    minTimestamp = await resolveSystemTrayObservationTimestamp(device);
+  }
+
+  const awaitedObservation = await waitForSystemTrayClosed(
+    observeScreen,
+    minTimestamp,
+    awaitTimeoutMs
+  );
+
+  return {
+    observation: awaitedObservation ?? observation,
+    closed: true,
     skipped: false,
     minTimestamp
   };

--- a/test/server/systemTray.test.ts
+++ b/test/server/systemTray.test.ts
@@ -5,6 +5,7 @@ import {
   waitForNotificationMatch
 } from "../../src/server/interactionTools";
 import {
+  ensureSystemTrayClosed,
   ensureSystemTrayOpen,
   tapElement,
   swipeElement,
@@ -214,6 +215,57 @@ describe("systemTray find", () => {
   });
 });
 
+describe("Android systemTray close", () => {
+  afterEach(() => {
+    resetSystemTrayDependencies();
+  });
+
+  test("collapses shade when tray is open", async () => {
+    const fakeTimer = new FakeTimer();
+    const fakeAdb = new SequencedFakeAdbExecutor([1000, 2000]);
+    const fakeObserveScreen = new SequencedObserveScreen([
+      createObservation(createTrayHierarchy("Note")),
+      createObservation(createTrayHierarchy("Note")),
+      createObservation(createClosedHierarchy())
+    ]);
+
+    setSystemTrayDependencies({
+      timer: fakeTimer,
+      adbFactory: () => fakeAdb,
+      observeScreenFactory: () => fakeObserveScreen
+    });
+
+    const resultPromise = ensureSystemTrayClosed(device, 500);
+
+    await waitForPendingSleep(fakeTimer);
+    fakeTimer.advanceTime(POLL_INTERVAL_MS);
+
+    const result = await resultPromise;
+
+    expect(result.closed).toBe(true);
+    expect(result.skipped).toBe(false);
+    expect(fakeAdb.wasCommandExecuted("cmd statusbar collapse")).toBe(true);
+  });
+
+  test("skips collapse when tray is already closed", async () => {
+    const fakeTimer = new FakeTimer();
+    const fakeAdb = new SequencedFakeAdbExecutor([1000]);
+    const fakeObserveScreen = new SequencedObserveScreen([createObservation(createClosedHierarchy())]);
+
+    setSystemTrayDependencies({
+      timer: fakeTimer,
+      adbFactory: () => fakeAdb,
+      observeScreenFactory: () => fakeObserveScreen
+    });
+
+    const result = await ensureSystemTrayClosed(device, 500);
+
+    expect(result.closed).toBe(false);
+    expect(result.skipped).toBe(true);
+    expect(fakeAdb.wasCommandExecuted("cmd statusbar collapse")).toBe(false);
+  });
+});
+
 // ============================================================================
 // iOS tests
 // ============================================================================
@@ -334,6 +386,58 @@ describe("iOS systemTray open", () => {
     const result = await ensureSystemTrayOpen(iosDevice, 2000);
 
     expect(result.opened).toBe(false);
+    expect(result.skipped).toBe(true);
+    expect(fakeIosClient.swipeCalls.length).toBe(0);
+  });
+});
+
+describe("iOS systemTray close", () => {
+  afterEach(() => {
+    resetSystemTrayDependencies();
+  });
+
+  test("swipes up to close notification center when open", async () => {
+    const fakeTimer = new FakeTimer();
+    const fakeIosClient = new FakeIosClient();
+    const fakeObserveScreen = new SequencedObserveScreen([
+      createIosObservation(createIosNotificationCenterHierarchy("Test")),
+      createIosObservation(createIosNotificationCenterHierarchy("Test")),
+      createIosObservation(createIosAppHierarchy())
+    ]);
+
+    setSystemTrayDependencies({
+      timer: fakeTimer,
+      iosClientFactory: () => fakeIosClient,
+      observeScreenFactory: () => fakeObserveScreen
+    });
+
+    const resultPromise = ensureSystemTrayClosed(iosDevice, 2000);
+
+    await waitForPendingSleep(fakeTimer);
+    fakeTimer.advanceTime(POLL_INTERVAL_MS);
+
+    const result = await resultPromise;
+
+    expect(result.closed).toBe(true);
+    expect(result.skipped).toBe(false);
+    expect(fakeIosClient.swipeCalls.length).toBe(1);
+    expect(fakeIosClient.swipeCalls[0].y1).toBeGreaterThan(fakeIosClient.swipeCalls[0].y2);
+  });
+
+  test("skips swipe when notification center is already closed", async () => {
+    const fakeTimer = new FakeTimer();
+    const fakeIosClient = new FakeIosClient();
+    const fakeObserveScreen = new SequencedObserveScreen([createIosObservation(createIosAppHierarchy())]);
+
+    setSystemTrayDependencies({
+      timer: fakeTimer,
+      iosClientFactory: () => fakeIosClient,
+      observeScreenFactory: () => fakeObserveScreen
+    });
+
+    const result = await ensureSystemTrayClosed(iosDevice, 2000);
+
+    expect(result.closed).toBe(false);
     expect(result.skipped).toBe(true);
     expect(fakeIosClient.swipeCalls.length).toBe(0);
   });


### PR DESCRIPTION
Closes #1969.

## Summary

Adds a `"close"` action to the existing `systemTray` MCP tool, allowing tests to programmatically collapse the notification shade. Previously, closing the shade required `pressButton "back"` which is fragile and platform-dependent.

## Why

CI test suites that interact with notifications need to open the shade, find/tap/dismiss notifications, and then close it before continuing. The existing `systemTray` tool had `open`, `find`, `tap`, `dismiss`, and `clearAll` but no way to close the shade. Tests had to rely on `pressButton "back"`, which doesn't always collapse the shade (especially when quick settings are partially expanded) and doesn't exist on iOS.

## Changes

### Implementation

- Android: `adb shell cmd statusbar collapse` (mirrors the existing `expand-notifications` for `open`)
- iOS: swipe up gesture via CtrlProxy (reverse of the open swipe-down)
- Idempotent: observes the view hierarchy first, skips if the tray is already closed (returns `skipped: true`)

## Risk

None. Purely additive - adds one new action to an existing tool. All existing actions unchanged. The `close` implementation mirrors the existing `open` pattern exactly (same DI, same observe-before-act flow, same idempotent skip logic).

## Testing

- 12 tests in `systemTray.test.ts`, all passing (4 new for close, 8 existing)
- Android: collapse when open, skip when already closed
- iOS: swipe up when open, skip when already closed

## Stats

7 files changed, +248 / -12 lines
