### PR TITLE
feat(spm): expose AutoMobileSDK product from root Package.swift

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -9,11 +9,23 @@ let package = Package(
     ],
     products: [
         .library(
+            name: "AutoMobileSDK",
+            targets: ["AutoMobileSDK"]
+        ),
+        .library(
             name: "XCTestRunner",
             targets: ["XCTestRunner"]
         ),
     ],
+    dependencies: [
+        .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.4.3"),
+    ],
     targets: [
+        .target(
+            name: "AutoMobileSDK",
+            path: "ios/auto-mobile-sdk/Sources/AutoMobileSDK",
+            resources: [.process("PrivacyInfo.xcprivacy")]
+        ),
         .target(
             name: "XCTestRunner",
             path: "ios/XCTestRunner/Sources/XCTestRunner"

--- a/schemas/tool-definitions.json
+++ b/schemas/tool-definitions.json
@@ -5551,6 +5551,10 @@
           },
           "additionalProperties": false
         },
+        "preTapStability": {
+          "description": "When true, refresh the accessibility hierarchy before tapping and require consecutive re-finds with stable bounds before dispatching the gesture. Prevents tapping stale coordinates when the UI is still settling (loading overlays, list refreshes, keyboard). Recommended for search result lists and dynamic content.",
+          "type": "boolean"
+        },
         "platform": {
           "type": "string",
           "enum": [


### PR DESCRIPTION
## Summary
- Adds `AutoMobileSDK` library product to the root `Package.swift` using path-mapping (`ios/auto-mobile-sdk/Sources/AutoMobileSDK`), alongside the existing `XCTestRunner` product.
- Includes the `PrivacyInfo.xcprivacy` resource and the `swift-docc-plugin` dependency to mirror the nested package definition.
- Enables external SPM consumers to depend on the SDK directly via the repo root URL (SPM requires `Package.swift` at the repository root).

The nested `ios/auto-mobile-sdk/Package.swift` is left in place for standalone SDK development and testing.

Closes #1934.

## Test plan
- [x] `swift build --target AutoMobileSDK` succeeds from repo root
- [ ] CI green