### PR TITLE
feat(ios-sdk): add AutoMobileAPI protocol and default implementation for DI

### DIFF
--- a/ios/auto-mobile-sdk/Sources/AutoMobileSDK/Public/AutoMobileAPI.swift
+++ b/ios/auto-mobile-sdk/Sources/AutoMobileSDK/Public/AutoMobileAPI.swift
@@ -1,0 +1,39 @@
+import Foundation
+
+/// Core public API for the AutoMobile SDK.
+/// Enables dependency injection with any DI framework.
+public protocol AutoMobileAPI: AnyObject, Sendable {
+
+    // MARK: - Lifecycle
+    func initialize()
+    func initialize(configuration: AutoMobileConfiguration)
+    func shutdown()
+
+    // MARK: - Enable/Disable
+    var isEnabled: Bool { get }
+    func setEnabled(_ enabled: Bool)
+    var isInitialized: Bool { get }
+
+    // MARK: - Navigation
+    func addNavigationListener(_ listener: NavigationListener)
+    @discardableResult
+    func addNavigationListener(_ block: @escaping @Sendable (NavigationEvent) -> Void) -> NavigationListener
+    func removeNavigationListener(_ listener: NavigationListener)
+    func clearNavigationListeners()
+    func notifyNavigationEvent(_ event: NavigationEvent)
+    var listenerCount: Int { get }
+
+    // MARK: - Session
+    func currentSessionId() -> String?
+
+    // MARK: - Breadcrumbs & Context
+    func addBreadcrumb(message: String, category: BreadcrumbCategory, metadata: [String: String])
+    func setUserId(_ userId: String?)
+    func setTag(_ key: String, value: String)
+    func removeTag(_ key: String)
+
+    // MARK: - Status
+    var configuration: AutoMobileConfiguration? { get }
+    var bundleId: String? { get }
+    var dropReport: [DropReason: Int] { get }
+}

--- a/ios/auto-mobile-sdk/Sources/AutoMobileSDK/Public/AutoMobileCrashesAPI.swift
+++ b/ios/auto-mobile-sdk/Sources/AutoMobileSDK/Public/AutoMobileCrashesAPI.swift
@@ -1,0 +1,22 @@
+import Foundation
+
+/// Fine-grained DI surface for the SDK's crash-reporting subsystem.
+public protocol AutoMobileCrashesAPI: AnyObject, Sendable {
+    func enableSignalHandlers()
+    func setCurrentScreenProvider(_ provider: (@Sendable () -> String?)?)
+}
+
+/// Default implementation of `AutoMobileCrashesAPI` backed by `AutoMobileCrashes.shared`.
+public final class DefaultAutoMobileCrashesAPI: AutoMobileCrashesAPI, @unchecked Sendable {
+    private let crashes = AutoMobileCrashes.shared
+
+    public init() {}
+
+    public func enableSignalHandlers() {
+        crashes.enableSignalHandlers()
+    }
+
+    public func setCurrentScreenProvider(_ provider: (@Sendable () -> String?)?) {
+        crashes.currentScreenProvider = provider
+    }
+}

--- a/ios/auto-mobile-sdk/Sources/AutoMobileSDK/Public/AutoMobileNetworkAPI.swift
+++ b/ios/auto-mobile-sdk/Sources/AutoMobileSDK/Public/AutoMobileNetworkAPI.swift
@@ -1,0 +1,27 @@
+import Foundation
+
+/// Fine-grained DI surface for the SDK's network subsystem.
+public protocol AutoMobileNetworkAPI: AnyObject, Sendable {
+    func recordRequest(_ record: NetworkRequestRecord)
+    func setCaptureHeaders(_ enabled: Bool)
+    func setCaptureBodies(_ enabled: Bool)
+}
+
+/// Default implementation of `AutoMobileNetworkAPI` backed by `AutoMobileNetwork.shared`.
+public final class DefaultAutoMobileNetworkAPI: AutoMobileNetworkAPI, @unchecked Sendable {
+    private let network = AutoMobileNetwork.shared
+
+    public init() {}
+
+    public func recordRequest(_ record: NetworkRequestRecord) {
+        network.recordRequest(record)
+    }
+
+    public func setCaptureHeaders(_ enabled: Bool) {
+        network.setCaptureHeaders(enabled)
+    }
+
+    public func setCaptureBodies(_ enabled: Bool) {
+        network.setCaptureBodies(enabled)
+    }
+}

--- a/ios/auto-mobile-sdk/Sources/AutoMobileSDK/Public/DefaultAutoMobileAPI.swift
+++ b/ios/auto-mobile-sdk/Sources/AutoMobileSDK/Public/DefaultAutoMobileAPI.swift
@@ -1,0 +1,87 @@
+import Foundation
+
+/// Default implementation of `AutoMobileAPI` backed by `AutoMobileSDK.shared`.
+public final class DefaultAutoMobileAPI: AutoMobileAPI, @unchecked Sendable {
+    private let sdk = AutoMobileSDK.shared
+
+    public init() {}
+
+    // MARK: - Lifecycle
+
+    public func initialize() {
+        sdk.initialize()
+    }
+
+    public func initialize(configuration: AutoMobileConfiguration) {
+        sdk.initialize(configuration: configuration)
+    }
+
+    public func shutdown() {
+        sdk.shutdown()
+    }
+
+    // MARK: - Enable/Disable
+
+    public var isEnabled: Bool { sdk.isEnabled }
+
+    public func setEnabled(_ enabled: Bool) {
+        sdk.setEnabled(enabled)
+    }
+
+    public var isInitialized: Bool { sdk.isInitialized }
+
+    // MARK: - Navigation
+
+    public func addNavigationListener(_ listener: NavigationListener) {
+        sdk.addNavigationListener(listener)
+    }
+
+    @discardableResult
+    public func addNavigationListener(_ block: @escaping @Sendable (NavigationEvent) -> Void) -> NavigationListener {
+        sdk.addNavigationListener(block)
+    }
+
+    public func removeNavigationListener(_ listener: NavigationListener) {
+        sdk.removeNavigationListener(listener)
+    }
+
+    public func clearNavigationListeners() {
+        sdk.clearNavigationListeners()
+    }
+
+    public func notifyNavigationEvent(_ event: NavigationEvent) {
+        sdk.notifyNavigationEvent(event)
+    }
+
+    public var listenerCount: Int { sdk.listenerCount }
+
+    // MARK: - Session
+
+    public func currentSessionId() -> String? {
+        sdk.currentSessionId()
+    }
+
+    // MARK: - Breadcrumbs & Context
+
+    public func addBreadcrumb(message: String, category: BreadcrumbCategory, metadata: [String: String]) {
+        sdk.addBreadcrumb(message: message, category: category, metadata: metadata)
+    }
+
+    public func setUserId(_ userId: String?) {
+        sdk.setUserId(userId)
+    }
+
+    public func setTag(_ key: String, value: String) {
+        sdk.setTag(key, value: value)
+    }
+
+    public func removeTag(_ key: String) {
+        sdk.removeTag(key)
+    }
+
+    // MARK: - Status
+
+    public var configuration: AutoMobileConfiguration? { sdk.configuration }
+    public var bundleId: String? { sdk.bundleId }
+    public var dropReport: [DropReason: Int] { sdk.dropReport }
+}

--- a/ios/auto-mobile-sdk/Tests/AutoMobileSDKTests/DefaultAutoMobileAPITests.swift
+++ b/ios/auto-mobile-sdk/Tests/AutoMobileSDKTests/DefaultAutoMobileAPITests.swift
@@ -1,0 +1,117 @@
+import XCTest
+@testable import AutoMobileSDK
+
+final class DefaultAutoMobileAPITests: XCTestCase {
+    override func tearDown() {
+        AutoMobileSDK.shared.reset()
+        super.tearDown()
+    }
+
+    func testConformsToProtocol() {
+        let api: AutoMobileAPI = DefaultAutoMobileAPI()
+        XCTAssertFalse(api.isInitialized)
+    }
+
+    func testInitializeDelegatesToSharedSdk() {
+        let api: AutoMobileAPI = DefaultAutoMobileAPI()
+        XCTAssertFalse(api.isInitialized)
+        api.initialize()
+        XCTAssertTrue(api.isInitialized)
+        XCTAssertTrue(AutoMobileSDK.shared.isInitialized)
+    }
+
+    func testInitializeWithConfiguration() {
+        let api: AutoMobileAPI = DefaultAutoMobileAPI()
+        let config = AutoMobileConfiguration(bufferSize: 7)
+        api.initialize(configuration: config)
+        XCTAssertEqual(api.configuration?.bufferSize, 7)
+    }
+
+    func testSetEnabledDelegates() {
+        let api: AutoMobileAPI = DefaultAutoMobileAPI()
+        api.initialize()
+        XCTAssertTrue(api.isEnabled)
+        api.setEnabled(false)
+        XCTAssertFalse(api.isEnabled)
+        XCTAssertFalse(AutoMobileSDK.shared.isEnabled)
+        api.setEnabled(true)
+    }
+
+    func testNavigationListenersDelegate() {
+        let api: AutoMobileAPI = DefaultAutoMobileAPI()
+        api.initialize()
+
+        let listener = FakeNavigationListener()
+        api.addNavigationListener(listener)
+        XCTAssertEqual(api.listenerCount, 1)
+        XCTAssertEqual(AutoMobileSDK.shared.listenerCount, 1)
+
+        let event = NavigationEvent(destination: "Home", source: .custom)
+        api.notifyNavigationEvent(event)
+        XCTAssertEqual(listener.events.count, 1)
+
+        api.removeNavigationListener(listener)
+        XCTAssertEqual(api.listenerCount, 0)
+    }
+
+    func testClosureListenerDelegate() {
+        let api: AutoMobileAPI = DefaultAutoMobileAPI()
+        api.initialize()
+
+        let holder = NavEventHolder()
+        _ = api.addNavigationListener { event in
+            holder.set(event)
+        }
+        api.notifyNavigationEvent(NavigationEvent(destination: "Settings", source: .deepLink))
+        XCTAssertEqual(holder.event?.destination, "Settings")
+
+        api.clearNavigationListeners()
+        XCTAssertEqual(api.listenerCount, 0)
+    }
+
+    func testBreadcrumbAndTagDelegate() {
+        let api: AutoMobileAPI = DefaultAutoMobileAPI()
+        api.initialize()
+
+        api.addBreadcrumb(message: "hello", category: .custom, metadata: ["k": "v"])
+        api.setUserId("user-1")
+        api.setTag("env", value: "test")
+        api.removeTag("env")
+        XCTAssertTrue(api.isInitialized)
+    }
+
+    func testShutdownDelegates() {
+        let api: AutoMobileAPI = DefaultAutoMobileAPI()
+        api.initialize()
+        XCTAssertTrue(api.isInitialized)
+        api.shutdown()
+        XCTAssertFalse(api.isInitialized)
+        XCTAssertFalse(AutoMobileSDK.shared.isInitialized)
+    }
+
+    func testStatusAccessors() {
+        let api: AutoMobileAPI = DefaultAutoMobileAPI()
+        api.initialize()
+        XCTAssertEqual(api.bundleId, AutoMobileSDK.shared.bundleId)
+        XCTAssertEqual(api.dropReport.count, AutoMobileSDK.shared.dropReport.count)
+        XCTAssertEqual(api.currentSessionId(), AutoMobileSDK.shared.currentSessionId())
+    }
+
+    func testNetworkAndCrashesDefaults() {
+        let network: AutoMobileNetworkAPI = DefaultAutoMobileNetworkAPI()
+        network.setCaptureHeaders(true)
+        network.setCaptureBodies(false)
+
+        let crashes: AutoMobileCrashesAPI = DefaultAutoMobileCrashesAPI()
+        crashes.setCurrentScreenProvider { "Home" }
+        XCTAssertEqual(AutoMobileCrashes.shared.currentScreenProvider?(), "Home")
+        crashes.setCurrentScreenProvider(nil)
+    }
+}
+
+private final class NavEventHolder: @unchecked Sendable {
+    private let lock = NSLock()
+    private var _event: NavigationEvent?
+    var event: NavigationEvent? { lock.lock(); defer { lock.unlock() }; return _event }
+    func set(_ event: NavigationEvent) { lock.lock(); _event = event; lock.unlock() }
+}

--- a/ios/auto-mobile-sdk/api/auto-mobile-sdk.api
+++ b/ios/auto-mobile-sdk/api/auto-mobile-sdk.api
@@ -525,3 +525,45 @@ public final class ViewHierarchyTracker: @unchecked Sendable
 public enum ViewHierarchyWalker
   public static func walk(bundleId: String? = nil) -> SdkViewHierarchy
   public static func computeHash(_ hierarchy: SdkViewHierarchy) -> Int
+
+// Public/AutoMobileAPI.swift
+public protocol AutoMobileAPI: AnyObject, Sendable
+  func initialize()
+  func initialize(configuration: AutoMobileConfiguration)
+  func shutdown()
+  var isEnabled: Bool { get }
+  func setEnabled(_ enabled: Bool)
+  var isInitialized: Bool { get }
+  func addNavigationListener(_ listener: NavigationListener)
+  @discardableResult func addNavigationListener(_ block: @escaping @Sendable (NavigationEvent) -> Void) -> NavigationListener
+  func removeNavigationListener(_ listener: NavigationListener)
+  func clearNavigationListeners()
+  func notifyNavigationEvent(_ event: NavigationEvent)
+  var listenerCount: Int { get }
+  func currentSessionId() -> String?
+  func addBreadcrumb(message: String, category: BreadcrumbCategory, metadata: [String: String])
+  func setUserId(_ userId: String?)
+  func setTag(_ key: String, value: String)
+  func removeTag(_ key: String)
+  var configuration: AutoMobileConfiguration? { get }
+  var bundleId: String? { get }
+  var dropReport: [DropReason: Int] { get }
+
+// Public/DefaultAutoMobileAPI.swift
+public final class DefaultAutoMobileAPI: AutoMobileAPI, @unchecked Sendable
+  public init()
+
+// Public/AutoMobileNetworkAPI.swift
+public protocol AutoMobileNetworkAPI: AnyObject, Sendable
+  func recordRequest(_ record: NetworkRequestRecord)
+  func setCaptureHeaders(_ enabled: Bool)
+  func setCaptureBodies(_ enabled: Bool)
+public final class DefaultAutoMobileNetworkAPI: AutoMobileNetworkAPI, @unchecked Sendable
+  public init()
+
+// Public/AutoMobileCrashesAPI.swift
+public protocol AutoMobileCrashesAPI: AnyObject, Sendable
+  func enableSignalHandlers()
+  func setCurrentScreenProvider(_ provider: (@Sendable () -> String?)?)
+public final class DefaultAutoMobileCrashesAPI: AutoMobileCrashesAPI, @unchecked Sendable
+  public init()


### PR DESCRIPTION
## Summary
- Add `AutoMobileAPI` protocol + `DefaultAutoMobileAPI` so host apps can inject the SDK without writing their own wrapper
- Add optional `AutoMobileNetworkAPI` and `AutoMobileCrashesAPI` subsystem protocols with default implementations
- Per the issue, `initialize()` takes no `bundleId` — the SDK resolves it internally from `Bundle.main.bundleIdentifier`

## Test Plan
- [x] `./scripts/ios/swift-build.sh` passes
- [x] `./scripts/ios/swift-test.sh` passes (10 new tests in `DefaultAutoMobileAPITests`)
- [x] API surface file updated

Closes #1937

🤖 Generated with [Claude Code](https://claude.com/claude-code)