### PR TITLE
chore: update CtrlProxy APK and CtrlProxy iOS IPA SHA256

### DIFF
--- a/src/constants/release.ts
+++ b/src/constants/release.ts
@@ -26,7 +26,7 @@ export const RELEASE_VERSION: string = LATEST_RELEASE_VERSION;
 export const APK_URL: string = RELEASE_VERSION === LATEST_RELEASE_VERSION
   ? `https://github.com/kaeawc/auto-mobile/releases/latest/download/control-proxy-debug.apk`
   : `https://github.com/kaeawc/auto-mobile/releases/download/v${RELEASE_VERSION}/control-proxy-debug.apk`;
-export const APK_SHA256_CHECKSUM: string = "75c287e0002567e135d2655a96cf7f52067e22690e096fc000ba6a67224e78cc"; // Empty = skip verification (local dev only)
+export const APK_SHA256_CHECKSUM: string = "456deacfe18b2091fa9d4ee407b3774d2b28eee9d469c515be4701a77e37f5d0"; // Empty = skip verification (local dev only)
 
 /**
  * iOS CtrlProxy Release Constants
@@ -38,6 +38,6 @@ export const IOS_CTRL_PROXY_RELEASE_VERSION: string = LATEST_RELEASE_VERSION;
 export const IOS_CTRL_PROXY_IPA_URL: string = IOS_CTRL_PROXY_RELEASE_VERSION === LATEST_RELEASE_VERSION
   ? "https://github.com/kaeawc/auto-mobile/releases/latest/download/control-proxy.ipa"
   : `https://github.com/kaeawc/auto-mobile/releases/download/v${IOS_CTRL_PROXY_RELEASE_VERSION}/control-proxy.ipa`;
-export const IOS_CTRL_PROXY_SHA256_CHECKSUM: string = "cd6652ff7958b03df953cbdbaec66985b68a61089fcaf32aafa12fd38fdee523"; // Empty = skip verification (local dev only)
+export const IOS_CTRL_PROXY_SHA256_CHECKSUM: string = "09a7e53dfce28d8ca9d1c42156e8903239338ea5dc1b53f98966610cf24f6451"; // Empty = skip verification (local dev only)
 export const IOS_CTRL_PROXY_APP_HASH: string = ""; // Hash of CtrlProxyApp.app (device build), empty = skip verification
 export const IOS_CTRL_PROXY_RUNNER_SHA256: string = ""; // SHA256 of runner binary (CtrlProxyUITests-Runner), empty = skip verification


### PR DESCRIPTION
## Automated Checksum Update

The nightly build produced artifacts with updated SHA256 checksums.

| Artifact | Previous | New | Changed |
|----------|----------|-----|---------|
| **APK** | `75c287e0002567e135d2655a96cf7f52067e22690e096fc000ba6a67224e78cc` | `456deacfe18b2091fa9d4ee407b3774d2b28eee9d469c515be4701a77e37f5d0` | ✅ Yes |
| **IPA** | `cd6652ff7958b03df953cbdbaec66985b68a61089fcaf32aafa12fd38fdee523` | `09a7e53dfce28d8ca9d1c42156e8903239338ea5dc1b53f98966610cf24f6451` | ✅ Yes |

### Why did this happen?

SHA256 checksums change when any of these change:
- Source code in `android/control-proxy/src/` or `ios/control-proxy/`
- Build configuration (`build.gradle.kts` or `project.yml`)
- Dependencies or SDK versions

### What to do

1. Review this PR to ensure the changes are expected
2. Merge when ready
3. Future releases will use these checksums for artifact verification

---
Auto-generated by the `nightly` workflow