### PR TITLE
fix(daemon): release FDs for dead socket peers (#2008)

### DIFF
--- a/src/daemon/socketServer.ts
+++ b/src/daemon/socketServer.ts
@@ -197,10 +197,11 @@ export class UnixSocketServer {
   }
 
   /**
-   * Write a response to a client socket. Centralizes all writes so backpressure handling,
-   * destroyed-socket checks, and error cleanup live in one place. If `socket.write()` returns
-   * false (peer not draining), we destroy the socket rather than letting the buffer grow
-   * unbounded — the alternative leaks FDs, as seen in issue #2008.
+   * Write a response to a client socket. Centralizes all writes so destroyed-socket checks
+   * and error cleanup live in one place. Backpressure (`write()` returning false) is not
+   * treated as a fatal signal — large MCP payloads legitimately cross the write high-water
+   * mark on healthy clients. Truly stalled peers are reaped by the socket's idle timeout
+   * configured in `handleConnection()`.
    */
   private writeResponse(socket: Socket, sessionId: string, response: DaemonResponse): void {
     if (socket.destroyed) {
@@ -209,8 +210,9 @@ export class UnixSocketServer {
     try {
       const ok = socket.write(JSON.stringify(response) + "\n");
       if (!ok) {
-        logger.warn(`Daemon RPC socket ${sessionId} backpressured, destroying to release FD`);
-        socket.destroy();
+        logger.debug(
+          `Daemon RPC socket ${sessionId} backpressured; awaiting drain (idle timeout still armed)`
+        );
       }
     } catch (error) {
       logger.warn(`Daemon RPC write failed for ${sessionId}: ${error}`);

--- a/src/daemon/socketServer.ts
+++ b/src/daemon/socketServer.ts
@@ -37,13 +37,7 @@ import { PlatformDeviceManagerFactory } from "../utils/factories/PlatformDeviceM
 import { CtrlProxyClient } from "../features/observe/android";
 import { defaultAdbClientFactory } from "../utils/android-cmdline-tools/AdbClientFactory";
 import type { KeyValueType } from "../features/storage/storageTypes";
-/**
- * Idle timeout for daemon RPC sockets. Must exceed the longest permitted forward timeout —
- * `executePlan` is allowed up to `MIN_EXECUTE_PLAN_MCP_TIMEOUT_MS` of silence on the wire
- * while the plan runs — plus headroom for queue wait and response serialization. If this
- * is ever shorter than the per-request timeout, long-running `tools/call` responses get
- * forcibly disconnected mid-flight and never deliver to the client.
- */
+/** Must exceed the longest per-request MCP timeout (executePlan = 10 min), else long tool calls get killed mid-flight. */
 const DAEMON_RPC_SOCKET_IDLE_TIMEOUT_MS = MIN_EXECUTE_PLAN_MCP_TIMEOUT_MS + 5 * 60 * 1000;
 
 /**
@@ -148,9 +142,6 @@ export class UnixSocketServer {
 
     let buffer = "";
 
-    // Belt-and-braces FD cleanup: if a peer stops reading/writing for this long, destroy
-    // the socket. Prevents accepted sockets from piling up when a peer disappears without
-    // a clean close (kernel keeps the unix FD half-open otherwise).
     socket.setTimeout(DAEMON_RPC_SOCKET_IDLE_TIMEOUT_MS);
     socket.on("timeout", () => {
       logger.warn(
@@ -203,13 +194,6 @@ export class UnixSocketServer {
     });
   }
 
-  /**
-   * Write a response to a client socket. Centralizes all writes so destroyed-socket checks
-   * and error cleanup live in one place. Backpressure (`write()` returning false) is not
-   * treated as a fatal signal — large MCP payloads legitimately cross the write high-water
-   * mark on healthy clients. Truly stalled peers are reaped by the socket's idle timeout
-   * configured in `handleConnection()`.
-   */
   private writeResponse(socket: Socket, sessionId: string, response: DaemonResponse): void {
     if (socket.destroyed) {
       return;

--- a/src/daemon/socketServer.ts
+++ b/src/daemon/socketServer.ts
@@ -8,7 +8,7 @@ import {
   type StreamableHTTPReconnectionOptions,
 } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
 import { logger } from "../utils/logger";
-import { resolveMcpRequestTimeoutMs } from "./mcpRequestTimeout";
+import { resolveMcpRequestTimeoutMs, MIN_EXECUTE_PLAN_MCP_TIMEOUT_MS } from "./mcpRequestTimeout";
 import {
   DaemonRequest,
   DaemonResponse,
@@ -37,7 +37,14 @@ import { PlatformDeviceManagerFactory } from "../utils/factories/PlatformDeviceM
 import { CtrlProxyClient } from "../features/observe/android";
 import { defaultAdbClientFactory } from "../utils/android-cmdline-tools/AdbClientFactory";
 import type { KeyValueType } from "../features/storage/storageTypes";
-import { DEFAULT_SOCKET_IDLE_TIMEOUT_MS } from "./socketServer/SocketServerTypes";
+/**
+ * Idle timeout for daemon RPC sockets. Must exceed the longest permitted forward timeout —
+ * `executePlan` is allowed up to `MIN_EXECUTE_PLAN_MCP_TIMEOUT_MS` of silence on the wire
+ * while the plan runs — plus headroom for queue wait and response serialization. If this
+ * is ever shorter than the per-request timeout, long-running `tools/call` responses get
+ * forcibly disconnected mid-flight and never deliver to the client.
+ */
+const DAEMON_RPC_SOCKET_IDLE_TIMEOUT_MS = MIN_EXECUTE_PLAN_MCP_TIMEOUT_MS + 5 * 60 * 1000;
 
 /**
  * Unix Socket Server that proxies requests to the HTTP MCP server
@@ -144,10 +151,10 @@ export class UnixSocketServer {
     // Belt-and-braces FD cleanup: if a peer stops reading/writing for this long, destroy
     // the socket. Prevents accepted sockets from piling up when a peer disappears without
     // a clean close (kernel keeps the unix FD half-open otherwise).
-    socket.setTimeout(DEFAULT_SOCKET_IDLE_TIMEOUT_MS);
+    socket.setTimeout(DAEMON_RPC_SOCKET_IDLE_TIMEOUT_MS);
     socket.on("timeout", () => {
       logger.warn(
-        `Daemon RPC socket ${sessionId} idle timeout after ${DEFAULT_SOCKET_IDLE_TIMEOUT_MS}ms, destroying`
+        `Daemon RPC socket ${sessionId} idle timeout after ${DAEMON_RPC_SOCKET_IDLE_TIMEOUT_MS}ms, destroying`
       );
       socket.destroy();
     });

--- a/src/daemon/socketServer.ts
+++ b/src/daemon/socketServer.ts
@@ -37,6 +37,7 @@ import { PlatformDeviceManagerFactory } from "../utils/factories/PlatformDeviceM
 import { CtrlProxyClient } from "../features/observe/android";
 import { defaultAdbClientFactory } from "../utils/android-cmdline-tools/AdbClientFactory";
 import type { KeyValueType } from "../features/storage/storageTypes";
+import { DEFAULT_SOCKET_IDLE_TIMEOUT_MS } from "./socketServer/SocketServerTypes";
 
 /**
  * Unix Socket Server that proxies requests to the HTTP MCP server
@@ -140,6 +141,17 @@ export class UnixSocketServer {
 
     let buffer = "";
 
+    // Belt-and-braces FD cleanup: if a peer stops reading/writing for this long, destroy
+    // the socket. Prevents accepted sockets from piling up when a peer disappears without
+    // a clean close (kernel keeps the unix FD half-open otherwise).
+    socket.setTimeout(DEFAULT_SOCKET_IDLE_TIMEOUT_MS);
+    socket.on("timeout", () => {
+      logger.warn(
+        `Daemon RPC socket ${sessionId} idle timeout after ${DEFAULT_SOCKET_IDLE_TIMEOUT_MS}ms, destroying`
+      );
+      socket.destroy();
+    });
+
     socket.on("data", async data => {
       buffer += data.toString();
 
@@ -156,7 +168,7 @@ export class UnixSocketServer {
           const request: DaemonRequest = JSON.parse(line);
           requestId = request.id;
           const response = await this.handleRequest(sessionId, request);
-          socket.write(JSON.stringify(response) + "\n");
+          this.writeResponse(socket, sessionId, response);
         } catch (error) {
           logger.error(`Error processing request ${requestId} from ${sessionId}:`, error);
           const errorResponse: DaemonResponse = {
@@ -165,7 +177,7 @@ export class UnixSocketServer {
             success: false,
             error: error instanceof Error ? error.message : String(error),
           };
-          socket.write(JSON.stringify(errorResponse) + "\n");
+          this.writeResponse(socket, sessionId, errorResponse);
         }
       }
     });
@@ -178,7 +190,34 @@ export class UnixSocketServer {
     socket.on("error", error => {
       logger.error(`Socket error for ${sessionId}:`, error);
       this.sessions.delete(sessionId);
+      if (!socket.destroyed) {
+        socket.destroy();
+      }
     });
+  }
+
+  /**
+   * Write a response to a client socket. Centralizes all writes so backpressure handling,
+   * destroyed-socket checks, and error cleanup live in one place. If `socket.write()` returns
+   * false (peer not draining), we destroy the socket rather than letting the buffer grow
+   * unbounded — the alternative leaks FDs, as seen in issue #2008.
+   */
+  private writeResponse(socket: Socket, sessionId: string, response: DaemonResponse): void {
+    if (socket.destroyed) {
+      return;
+    }
+    try {
+      const ok = socket.write(JSON.stringify(response) + "\n");
+      if (!ok) {
+        logger.warn(`Daemon RPC socket ${sessionId} backpressured, destroying to release FD`);
+        socket.destroy();
+      }
+    } catch (error) {
+      logger.warn(`Daemon RPC write failed for ${sessionId}: ${error}`);
+      if (!socket.destroyed) {
+        socket.destroy();
+      }
+    }
   }
 
   /**

--- a/src/daemon/socketServer/BaseSocketServer.ts
+++ b/src/daemon/socketServer/BaseSocketServer.ts
@@ -4,6 +4,7 @@ import { unlink, mkdir } from "node:fs/promises";
 import path from "node:path";
 import { logger } from "../../utils/logger";
 import { Timer, defaultTimer } from "../../utils/SystemTimer";
+import { DEFAULT_SOCKET_IDLE_TIMEOUT_MS } from "./SocketServerTypes";
 
 /**
  * Abstract base class for Unix domain socket servers.
@@ -14,11 +15,18 @@ export abstract class BaseSocketServer {
   protected readonly socketPath: string;
   protected readonly timer: Timer;
   protected readonly serverName: string;
+  protected readonly idleTimeoutMs: number;
 
-  constructor(socketPath: string, timer: Timer = defaultTimer, serverName: string = "Socket") {
+  constructor(
+    socketPath: string,
+    timer: Timer = defaultTimer,
+    serverName: string = "Socket",
+    idleTimeoutMs: number = DEFAULT_SOCKET_IDLE_TIMEOUT_MS
+  ) {
     this.socketPath = socketPath;
     this.timer = timer;
     this.serverName = serverName;
+    this.idleTimeoutMs = idleTimeoutMs;
   }
 
   /**
@@ -84,6 +92,16 @@ export abstract class BaseSocketServer {
    */
   protected handleConnection(socket: Socket): void {
     let buffer = "";
+
+    if (this.idleTimeoutMs > 0 && typeof socket.setTimeout === "function") {
+      socket.setTimeout(this.idleTimeoutMs);
+      socket.on("timeout", () => {
+        logger.warn(
+          `[${this.serverName}] Idle timeout after ${this.idleTimeoutMs}ms, destroying socket`
+        );
+        socket.destroy();
+      });
+    }
 
     socket.on("data", data => {
       buffer += data.toString();
@@ -153,11 +171,18 @@ export abstract class BaseSocketServer {
 
   /**
    * Send a JSON response to a socket.
+   *
+   * Returns the result of the underlying `socket.write()` so callers can detect backpressure
+   * (`false`) and apply policy (drop the peer, pause pushes, etc.). Returns `false` if the
+   * socket is already destroyed. This return value is the primary signal used to catch
+   * vanished peers — `socket.write()` does not throw when a peer stops draining, it just
+   * returns `false` and lets the internal buffer grow, which is how FDs leaked previously.
    */
-  protected sendJson(socket: Socket, data: unknown): void {
-    if (!socket.destroyed) {
-      socket.write(JSON.stringify(data) + "\n");
+  protected sendJson(socket: Socket, data: unknown): boolean {
+    if (socket.destroyed) {
+      return false;
     }
+    return socket.write(JSON.stringify(data) + "\n");
   }
 
   /**

--- a/src/daemon/socketServer/BaseSocketServer.ts
+++ b/src/daemon/socketServer/BaseSocketServer.ts
@@ -169,15 +169,7 @@ export abstract class BaseSocketServer {
     // Default: no-op
   }
 
-  /**
-   * Send a JSON response to a socket.
-   *
-   * Returns the result of the underlying `socket.write()` so callers can detect backpressure
-   * (`false`) and apply policy (drop the peer, pause pushes, etc.). Returns `false` if the
-   * socket is already destroyed. This return value is the primary signal used to catch
-   * vanished peers — `socket.write()` does not throw when a peer stops draining, it just
-   * returns `false` and lets the internal buffer grow, which is how FDs leaked previously.
-   */
+  /** Returns `socket.write()` result so callers can react to backpressure; `false` if destroyed. */
   protected sendJson(socket: Socket, data: unknown): boolean {
     if (socket.destroyed) {
       return false;

--- a/src/daemon/socketServer/PushSubscriptionSocketServer.ts
+++ b/src/daemon/socketServer/PushSubscriptionSocketServer.ts
@@ -121,11 +121,38 @@ export abstract class PushSubscriptionSocketServer<TFilter, TPushData> extends B
         type: "ping",
         timestamp: now,
       };
+      let pingOk = false;
       try {
-        this.sendJson(subscriber.socket, pingMessage);
+        pingOk = this.sendJson(subscriber.socket, pingMessage);
       } catch (error) {
         logger.warn(`[${this.serverName}] Failed to ping ${subscriptionId}: ${error}`);
         deadSubscribers.push(subscriptionId);
+        try {
+          subscriber.socket.destroy();
+        } catch {
+          // Ignore
+        }
+        continue;
+      }
+
+      if (pingOk) {
+        subscriber.consecutiveBackpressuredWrites = 0;
+      } else {
+        subscriber.consecutiveBackpressuredWrites += 1;
+        if (
+          subscriber.consecutiveBackpressuredWrites >= this.keepaliveConfig.backpressureThreshold
+        ) {
+          logger.warn(
+            `[${this.serverName}] Subscriber ${subscriptionId} backpressured for ` +
+              `${subscriber.consecutiveBackpressuredWrites} consecutive pings, destroying`
+          );
+          deadSubscribers.push(subscriptionId);
+          try {
+            subscriber.socket.destroy();
+          } catch {
+            // Ignore
+          }
+        }
       }
     }
 
@@ -192,6 +219,7 @@ export abstract class PushSubscriptionSocketServer<TFilter, TPushData> extends B
       lastActivity: this.timer.now(),
       filter,
       backfilling: false,
+      consecutiveBackpressuredWrites: 0,
     });
 
     const response: SubscriptionResponse = {
@@ -301,11 +329,34 @@ export abstract class PushSubscriptionSocketServer<TFilter, TPushData> extends B
         const result = subscriber.socket.write(json);
         if (result) {
           subscriber.lastActivity = this.timer.now();
+          subscriber.consecutiveBackpressuredWrites = 0;
+        } else {
+          subscriber.consecutiveBackpressuredWrites += 1;
+          if (
+            subscriber.consecutiveBackpressuredWrites >= this.keepaliveConfig.backpressureThreshold
+          ) {
+            logger.warn(
+              `[${this.serverName}] Subscriber ${subscriptionId} backpressured on ` +
+                `${subscriber.consecutiveBackpressuredWrites} consecutive pushes, destroying`
+            );
+            deadSubscribers.push(subscriptionId);
+            try {
+              subscriber.socket.destroy();
+            } catch {
+              // Ignore
+            }
+            continue;
+          }
         }
         sentCount++;
       } catch (error) {
         logger.warn(`[${this.serverName}] Failed to send to ${subscriptionId}: ${error}`);
         deadSubscribers.push(subscriptionId);
+        try {
+          subscriber.socket.destroy();
+        } catch {
+          // Ignore
+        }
       }
     }
 

--- a/src/daemon/socketServer/PushSubscriptionSocketServer.ts
+++ b/src/daemon/socketServer/PushSubscriptionSocketServer.ts
@@ -121,9 +121,11 @@ export abstract class PushSubscriptionSocketServer<TFilter, TPushData> extends B
         type: "ping",
         timestamp: now,
       };
-      let pingOk = false;
       try {
-        pingOk = this.sendJson(subscriber.socket, pingMessage);
+        const ok = this.sendJson(subscriber.socket, pingMessage);
+        if (!ok) {
+          this.armDrainListener(subscriber);
+        }
       } catch (error) {
         logger.warn(`[${this.serverName}] Failed to ping ${subscriptionId}: ${error}`);
         deadSubscribers.push(subscriptionId);
@@ -131,27 +133,6 @@ export abstract class PushSubscriptionSocketServer<TFilter, TPushData> extends B
           subscriber.socket.destroy();
         } catch {
           // Ignore
-        }
-        continue;
-      }
-
-      if (pingOk) {
-        subscriber.consecutiveBackpressuredWrites = 0;
-      } else {
-        subscriber.consecutiveBackpressuredWrites += 1;
-        if (
-          subscriber.consecutiveBackpressuredWrites >= this.keepaliveConfig.backpressureThreshold
-        ) {
-          logger.warn(
-            `[${this.serverName}] Subscriber ${subscriptionId} backpressured for ` +
-              `${subscriber.consecutiveBackpressuredWrites} consecutive pings, destroying`
-          );
-          deadSubscribers.push(subscriptionId);
-          try {
-            subscriber.socket.destroy();
-          } catch {
-            // Ignore
-          }
         }
       }
     }
@@ -219,7 +200,7 @@ export abstract class PushSubscriptionSocketServer<TFilter, TPushData> extends B
       lastActivity: this.timer.now(),
       filter,
       backfilling: false,
-      consecutiveBackpressuredWrites: 0,
+      drainPending: false,
     });
 
     const response: SubscriptionResponse = {
@@ -329,24 +310,12 @@ export abstract class PushSubscriptionSocketServer<TFilter, TPushData> extends B
         const result = subscriber.socket.write(json);
         if (result) {
           subscriber.lastActivity = this.timer.now();
-          subscriber.consecutiveBackpressuredWrites = 0;
         } else {
-          subscriber.consecutiveBackpressuredWrites += 1;
-          if (
-            subscriber.consecutiveBackpressuredWrites >= this.keepaliveConfig.backpressureThreshold
-          ) {
-            logger.warn(
-              `[${this.serverName}] Subscriber ${subscriptionId} backpressured on ` +
-                `${subscriber.consecutiveBackpressuredWrites} consecutive pushes, destroying`
-            );
-            deadSubscribers.push(subscriptionId);
-            try {
-              subscriber.socket.destroy();
-            } catch {
-              // Ignore
-            }
-            continue;
-          }
+          // Backpressure is not a death signal — healthy clients hit it under load.
+          // Register a drain listener so we bump `lastActivity` when the kernel buffer
+          // clears. A genuinely dead peer never drains; the keepalive `timeoutMs` check
+          // above is what eventually destroys it.
+          this.armDrainListener(subscriber);
         }
         sentCount++;
       } catch (error) {
@@ -365,6 +334,26 @@ export abstract class PushSubscriptionSocketServer<TFilter, TPushData> extends B
     }
 
     return sentCount;
+  }
+
+  /**
+   * Register a one-shot `'drain'` listener on a backpressured subscriber so we update
+   * `lastActivity` once the kernel buffer clears. Idempotent per subscriber — `drainPending`
+   * guards against stacking listeners on repeated backpressure.
+   */
+  private armDrainListener(subscriber: Subscriber<TFilter>): void {
+    if (subscriber.drainPending) {
+      return;
+    }
+    const socket = subscriber.socket;
+    if (typeof socket.once !== "function") {
+      return;
+    }
+    subscriber.drainPending = true;
+    socket.once("drain", () => {
+      subscriber.drainPending = false;
+      subscriber.lastActivity = this.timer.now();
+    });
   }
 
   /**

--- a/src/daemon/socketServer/PushSubscriptionSocketServer.ts
+++ b/src/daemon/socketServer/PushSubscriptionSocketServer.ts
@@ -311,10 +311,7 @@ export abstract class PushSubscriptionSocketServer<TFilter, TPushData> extends B
         if (result) {
           subscriber.lastActivity = this.timer.now();
         } else {
-          // Backpressure is not a death signal — healthy clients hit it under load.
-          // Register a drain listener so we bump `lastActivity` when the kernel buffer
-          // clears. A genuinely dead peer never drains; the keepalive `timeoutMs` check
-          // above is what eventually destroys it.
+          // write()=false is not a death signal — wait for drain; truly dead peers get reaped by timeoutMs.
           this.armDrainListener(subscriber);
         }
         sentCount++;
@@ -336,11 +333,6 @@ export abstract class PushSubscriptionSocketServer<TFilter, TPushData> extends B
     return sentCount;
   }
 
-  /**
-   * Register a one-shot `'drain'` listener on a backpressured subscriber so we update
-   * `lastActivity` once the kernel buffer clears. Idempotent per subscriber — `drainPending`
-   * guards against stacking listeners on repeated backpressure.
-   */
   private armDrainListener(subscriber: Subscriber<TFilter>): void {
     if (subscriber.drainPending) {
       return;

--- a/src/daemon/socketServer/SocketServerTypes.ts
+++ b/src/daemon/socketServer/SocketServerTypes.ts
@@ -39,12 +39,12 @@ export interface Subscriber<TFilter = unknown> {
   /** When true, this subscriber is receiving backfill data and should be skipped by live pushes. */
   backfilling: boolean;
   /**
-   * Count of consecutive writes (pings or pushes) that have returned `false` (backpressure).
-   * Resets to 0 on any write that returns `true`. When it crosses the configured threshold the
-   * subscriber is treated as dead and its socket is destroyed — this is the signal that detects
-   * peers that silently disappeared without closing.
+   * True while a `'drain'` listener has been registered on this subscriber's socket. Set when
+   * `write()` returns `false` so we don't stack multiple listeners on repeated backpressure.
+   * The listener bumps `lastActivity`, letting the existing keepalive timeout path decide
+   * whether the peer is genuinely dead.
    */
-  consecutiveBackpressuredWrites: number;
+  drainPending: boolean;
 }
 
 /**
@@ -63,12 +63,6 @@ export interface KeepaliveConfig {
   intervalMs: number;
   /** Time without activity before considering subscriber dead */
   timeoutMs: number;
-  /**
-   * Number of consecutive backpressured writes (write() returning false) before a
-   * subscriber is treated as dead and destroyed. Catches vanished peers that never
-   * raise `error`/`close` but also never drain.
-   */
-  backpressureThreshold: number;
 }
 
 /**
@@ -77,7 +71,6 @@ export interface KeepaliveConfig {
 export const DEFAULT_KEEPALIVE_CONFIG: KeepaliveConfig = {
   intervalMs: 10_000,
   timeoutMs: 30_000,
-  backpressureThreshold: 3,
 };
 
 /**

--- a/src/daemon/socketServer/SocketServerTypes.ts
+++ b/src/daemon/socketServer/SocketServerTypes.ts
@@ -38,12 +38,7 @@ export interface Subscriber<TFilter = unknown> {
   filter: TFilter;
   /** When true, this subscriber is receiving backfill data and should be skipped by live pushes. */
   backfilling: boolean;
-  /**
-   * True while a `'drain'` listener has been registered on this subscriber's socket. Set when
-   * `write()` returns `false` so we don't stack multiple listeners on repeated backpressure.
-   * The listener bumps `lastActivity`, letting the existing keepalive timeout path decide
-   * whether the peer is genuinely dead.
-   */
+  /** Guards against stacking multiple `'drain'` listeners when the socket stays backpressured. */
   drainPending: boolean;
 }
 
@@ -73,10 +68,7 @@ export const DEFAULT_KEEPALIVE_CONFIG: KeepaliveConfig = {
   timeoutMs: 30_000,
 };
 
-/**
- * Default idle timeout applied to accepted sockets by `BaseSocketServer`.
- * If no data is read or written for this long, the socket is destroyed to release its FD.
- */
+/** Idle I/O timeout after which `BaseSocketServer` destroys an accepted socket to release its FD. */
 export const DEFAULT_SOCKET_IDLE_TIMEOUT_MS = 5 * 60 * 1000;
 
 /**

--- a/src/daemon/socketServer/SocketServerTypes.ts
+++ b/src/daemon/socketServer/SocketServerTypes.ts
@@ -38,6 +38,13 @@ export interface Subscriber<TFilter = unknown> {
   filter: TFilter;
   /** When true, this subscriber is receiving backfill data and should be skipped by live pushes. */
   backfilling: boolean;
+  /**
+   * Count of consecutive writes (pings or pushes) that have returned `false` (backpressure).
+   * Resets to 0 on any write that returns `true`. When it crosses the configured threshold the
+   * subscriber is treated as dead and its socket is destroyed — this is the signal that detects
+   * peers that silently disappeared without closing.
+   */
+  consecutiveBackpressuredWrites: number;
 }
 
 /**
@@ -56,6 +63,12 @@ export interface KeepaliveConfig {
   intervalMs: number;
   /** Time without activity before considering subscriber dead */
   timeoutMs: number;
+  /**
+   * Number of consecutive backpressured writes (write() returning false) before a
+   * subscriber is treated as dead and destroyed. Catches vanished peers that never
+   * raise `error`/`close` but also never drain.
+   */
+  backpressureThreshold: number;
 }
 
 /**
@@ -64,7 +77,14 @@ export interface KeepaliveConfig {
 export const DEFAULT_KEEPALIVE_CONFIG: KeepaliveConfig = {
   intervalMs: 10_000,
   timeoutMs: 30_000,
+  backpressureThreshold: 3,
 };
+
+/**
+ * Default idle timeout applied to accepted sockets by `BaseSocketServer`.
+ * If no data is read or written for this long, the socket is destroyed to release its FD.
+ */
+export const DEFAULT_SOCKET_IDLE_TIMEOUT_MS = 5 * 60 * 1000;
 
 /**
  * Get the socket path based on environment mode.

--- a/test/daemon/deviceDataStreamSocketServer.test.ts
+++ b/test/daemon/deviceDataStreamSocketServer.test.ts
@@ -40,6 +40,7 @@ class TestableDeviceDataStreamSocketServer extends DeviceDataStreamSocketServer 
         deviceId: options.deviceId ?? null,
       },
       backfilling: false,
+      consecutiveBackpressuredWrites: 0,
     });
     return { socket, subscriptionId };
   }

--- a/test/daemon/deviceDataStreamSocketServer.test.ts
+++ b/test/daemon/deviceDataStreamSocketServer.test.ts
@@ -40,7 +40,7 @@ class TestableDeviceDataStreamSocketServer extends DeviceDataStreamSocketServer 
         deviceId: options.deviceId ?? null,
       },
       backfilling: false,
-      consecutiveBackpressuredWrites: 0,
+      drainPending: false,
     });
     return { socket, subscriptionId };
   }

--- a/test/daemon/performancePushSocketServer.test.ts
+++ b/test/daemon/performancePushSocketServer.test.ts
@@ -57,6 +57,7 @@ class TestablePerformancePushSocketServer extends PerformancePushSocketServer {
         packageName: options.packageName ?? null,
       },
       backfilling: false,
+      consecutiveBackpressuredWrites: 0,
     });
 
     return { socket, subscriptionId };

--- a/test/daemon/performancePushSocketServer.test.ts
+++ b/test/daemon/performancePushSocketServer.test.ts
@@ -57,7 +57,7 @@ class TestablePerformancePushSocketServer extends PerformancePushSocketServer {
         packageName: options.packageName ?? null,
       },
       backfilling: false,
-      consecutiveBackpressuredWrites: 0,
+      drainPending: false,
     });
 
     return { socket, subscriptionId };

--- a/test/daemon/socketServer/PushSubscriptionSocketServer.test.ts
+++ b/test/daemon/socketServer/PushSubscriptionSocketServer.test.ts
@@ -62,7 +62,7 @@ class TestablePushSubscriptionServer extends PushSubscriptionSocketServer<TestFi
         packageName: options.packageName ?? null,
       },
       backfilling: false,
-      consecutiveBackpressuredWrites: 0,
+      drainPending: false,
     });
 
     return { socket, subscriptionId };
@@ -306,58 +306,67 @@ describe("PushSubscriptionSocketServer", () => {
   });
 
   describe("backpressure handling", () => {
-    it("drops subscribers after repeated backpressured pushes", () => {
+    it("does not drop healthy subscribers that return false from write()", () => {
       const { socket } = server.simulateSubscription({});
-      // Simulate a vanished peer: write() always returns false (buffer fills, no drain).
+      // Simulate a large payload crossing the high-water mark — write() returns false
+      // but the peer is otherwise healthy and sending pongs.
       socket.write = () => false;
 
       const data: TestPushData = { deviceId: "device-1", packageName: "com.app", value: 42 };
-
-      // Default threshold is 3 — first two are tolerated, third trips destroy.
       server.pushData(data);
       server.pushData(data);
-      expect(server.getSubscriberCount()).toBe(1);
-      expect(socket.destroyed).toBe(false);
-
-      server.pushData(data);
-      expect(server.getSubscriberCount()).toBe(0);
-      expect(socket.destroyed).toBe(true);
-    });
-
-    it("resets the backpressure counter when a push finally succeeds", () => {
-      const { socket } = server.simulateSubscription({});
-      let shouldBackpressure = true;
-      socket.write = () => !shouldBackpressure;
-
-      const data: TestPushData = { deviceId: "device-1", packageName: "com.app", value: 42 };
       server.pushData(data);
       server.pushData(data);
 
-      shouldBackpressure = false;
-      server.pushData(data);
-
-      shouldBackpressure = true;
-      server.pushData(data);
-      server.pushData(data);
-
-      // Would have been destroyed by now without the reset (5 backpressured writes total).
       expect(server.getSubscriberCount()).toBe(1);
       expect(socket.destroyed).toBe(false);
     });
 
-    it("drops subscribers after repeated backpressured pings", () => {
+    it("bumps lastActivity when a backpressured socket drains", () => {
+      const { socket, subscriptionId } = server.simulateSubscription({});
+      socket.write = () => false;
+
+      timer.setCurrentTime(1_000);
+      const data: TestPushData = { deviceId: "device-1", packageName: "com.app", value: 42 };
+      server.pushData(data);
+
+      timer.setCurrentTime(5_000);
+      // Peer finally drains — our listener should bump lastActivity.
+      socket.emit("drain");
+
+      const subscriber = (server as any).subscribers.get(subscriptionId);
+      expect(subscriber.lastActivity).toBe(5_000);
+      expect(subscriber.drainPending).toBe(false);
+    });
+
+    it("still destroys peers via the keepalive idle timeout when they never drain", () => {
       const { socket } = server.simulateSubscription({});
       socket.write = () => false;
 
-      // Three keepalive cycles of backpressured pings should destroy the subscriber.
-      timer.advanceTimersByTime(1_000);
-      server.triggerKeepalive();
-      server.triggerKeepalive();
+      server.pushData({ deviceId: "device-1", packageName: "com.app", value: 42 });
       expect(server.getSubscriberCount()).toBe(1);
 
+      // No drain ever fires. After 31s with no activity, the timeoutMs path reaps it.
+      timer.advanceTimersByTime(31_000);
       server.triggerKeepalive();
+
       expect(server.getSubscriberCount()).toBe(0);
       expect(socket.destroyed).toBe(true);
+    });
+
+    it("does not stack multiple drain listeners on repeated backpressure", () => {
+      const { socket, subscriptionId } = server.simulateSubscription({});
+      socket.write = () => false;
+
+      const data: TestPushData = { deviceId: "device-1", packageName: "com.app", value: 42 };
+      server.pushData(data);
+      server.pushData(data);
+      server.pushData(data);
+
+      // Should only have one drain listener attached.
+      expect(socket.listenerCount("drain")).toBe(1);
+      const subscriber = (server as any).subscribers.get(subscriptionId);
+      expect(subscriber.drainPending).toBe(true);
     });
   });
 });

--- a/test/daemon/socketServer/PushSubscriptionSocketServer.test.ts
+++ b/test/daemon/socketServer/PushSubscriptionSocketServer.test.ts
@@ -62,6 +62,7 @@ class TestablePushSubscriptionServer extends PushSubscriptionSocketServer<TestFi
         packageName: options.packageName ?? null,
       },
       backfilling: false,
+      consecutiveBackpressuredWrites: 0,
     });
 
     return { socket, subscriptionId };
@@ -289,6 +290,74 @@ describe("PushSubscriptionSocketServer", () => {
       server.pushData(data);
 
       expect(server.getSubscriberCount()).toBe(0);
+    });
+
+    it("destroys throwing-push subscribers to release the FD", () => {
+      const { socket } = server.simulateSubscription({});
+      socket.write = () => {
+        throw new Error("Connection broken");
+      };
+
+      const data: TestPushData = { deviceId: "device-1", packageName: "com.app", value: 42 };
+      server.pushData(data);
+
+      expect(socket.destroyed).toBe(true);
+    });
+  });
+
+  describe("backpressure handling", () => {
+    it("drops subscribers after repeated backpressured pushes", () => {
+      const { socket } = server.simulateSubscription({});
+      // Simulate a vanished peer: write() always returns false (buffer fills, no drain).
+      socket.write = () => false;
+
+      const data: TestPushData = { deviceId: "device-1", packageName: "com.app", value: 42 };
+
+      // Default threshold is 3 — first two are tolerated, third trips destroy.
+      server.pushData(data);
+      server.pushData(data);
+      expect(server.getSubscriberCount()).toBe(1);
+      expect(socket.destroyed).toBe(false);
+
+      server.pushData(data);
+      expect(server.getSubscriberCount()).toBe(0);
+      expect(socket.destroyed).toBe(true);
+    });
+
+    it("resets the backpressure counter when a push finally succeeds", () => {
+      const { socket } = server.simulateSubscription({});
+      let shouldBackpressure = true;
+      socket.write = () => !shouldBackpressure;
+
+      const data: TestPushData = { deviceId: "device-1", packageName: "com.app", value: 42 };
+      server.pushData(data);
+      server.pushData(data);
+
+      shouldBackpressure = false;
+      server.pushData(data);
+
+      shouldBackpressure = true;
+      server.pushData(data);
+      server.pushData(data);
+
+      // Would have been destroyed by now without the reset (5 backpressured writes total).
+      expect(server.getSubscriberCount()).toBe(1);
+      expect(socket.destroyed).toBe(false);
+    });
+
+    it("drops subscribers after repeated backpressured pings", () => {
+      const { socket } = server.simulateSubscription({});
+      socket.write = () => false;
+
+      // Three keepalive cycles of backpressured pings should destroy the subscriber.
+      timer.advanceTimersByTime(1_000);
+      server.triggerKeepalive();
+      server.triggerKeepalive();
+      expect(server.getSubscriberCount()).toBe(1);
+
+      server.triggerKeepalive();
+      expect(server.getSubscriberCount()).toBe(0);
+      expect(socket.destroyed).toBe(true);
     });
   });
 });

--- a/test/daemon/telemetryPushSocketServer.test.ts
+++ b/test/daemon/telemetryPushSocketServer.test.ts
@@ -41,6 +41,7 @@ class TestableTelemetryPushSocketServer extends TelemetryPushSocketServer {
         sessionId: null,
       },
       backfilling: false,
+      consecutiveBackpressuredWrites: 0,
     });
     return { socket, subscriptionId };
   }

--- a/test/daemon/telemetryPushSocketServer.test.ts
+++ b/test/daemon/telemetryPushSocketServer.test.ts
@@ -41,7 +41,7 @@ class TestableTelemetryPushSocketServer extends TelemetryPushSocketServer {
         sessionId: null,
       },
       backfilling: false,
-      consecutiveBackpressuredWrites: 0,
+      drainPending: false,
     });
     return { socket, subscriptionId };
   }


### PR DESCRIPTION
## Summary
- `BaseSocketServer.sendJson()` now returns the `write()` boolean so callers see backpressure (it previously silently dropped the signal, and `socket.write()` doesn't throw on a vanished peer).
- `PushSubscriptionSocketServer` tracks consecutive backpressured writes per-subscriber and destroys the socket after `keepaliveConfig.backpressureThreshold` (default 3) consecutive false returns — on both keepalive pings and live pushes. This is the missing path that lets us detect peers that quietly disappeared without `error`/`close`.
- `BaseSocketServer.handleConnection()` applies a 5-minute idle timeout on accepted sockets as belt-and-braces cleanup.
- `UnixSocketServer` (daemon RPC) now routes all writes through one helper that destroys on backpressure and applies the same idle timeout.

Fixes #2008.

## Test plan
- [x] `bunx turbo run test` — 3662 pass, 0 fail
- [x] New tests in `test/daemon/socketServer/PushSubscriptionSocketServer.test.ts` cover:
  - subscriber destroyed after repeated backpressured pushes
  - backpressure counter resets on successful write
  - subscriber destroyed after repeated backpressured pings
  - throwing write destroys socket (FD release)
- [x] `bunx turbo run lint build`