### PR TITLE
fix: versioned checksum registry for CtrlProxy bundles

### DIFF
--- a/scripts/generate-release-constants.sh
+++ b/scripts/generate-release-constants.sh
@@ -4,74 +4,110 @@ set -euo pipefail
 
 constants_path="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)/src/constants/release.ts"
 release_version="${RELEASE_VERSION:-}"
-checksum="${APK_SHA256_CHECKSUM:-}"
-ios_ctrl_proxy_release_version="${IOS_CTRL_PROXY_RELEASE_VERSION:-}"
-ios_ctrl_proxy_checksum="${IOS_CTRL_PROXY_SHA256_CHECKSUM:-}"
-ios_ctrl_proxy_app_hash="${IOS_CTRL_PROXY_APP_HASH:-}"
-ios_ctrl_proxy_runner_sha256="${IOS_CTRL_PROXY_RUNNER_SHA256:-}"
+apk_checksum="${APK_SHA256_CHECKSUM:-}"
+ios_checksum="${IOS_CTRL_PROXY_SHA256_CHECKSUM:-}"
+ios_app_hash="${IOS_CTRL_PROXY_APP_HASH:-}"
+ios_runner_sha256="${IOS_CTRL_PROXY_RUNNER_SHA256:-}"
 
-if [ -z "$release_version" ] && [ -z "$checksum" ] && [ -z "$ios_ctrl_proxy_release_version" ] && [ -z "$ios_ctrl_proxy_checksum" ] && [ -z "$ios_ctrl_proxy_app_hash" ] && [ -z "$ios_ctrl_proxy_runner_sha256" ]; then
-  echo "INFO: No release environment variables set - using default constants"
+max_registry_entries=100
+
+if [ -z "$release_version" ] || [ -z "$apk_checksum" ] || [ -z "$ios_checksum" ]; then
+  echo "INFO: RELEASE_VERSION, APK_SHA256_CHECKSUM, and IOS_CTRL_PROXY_SHA256_CHECKSUM are all required"
+  echo "   Set all three to add a new registry entry"
   exit 0
 fi
 
-if [ -n "$checksum" ] && ! [[ "$checksum" =~ ^[a-f0-9]{64}$ ]]; then
+if ! [[ "$apk_checksum" =~ ^[a-f0-9]{64}$ ]]; then
   echo "ERROR: APK_SHA256_CHECKSUM must be a valid SHA256 hash (64 hex characters)"
-  echo "   Got: ${checksum}"
+  echo "   Got: ${apk_checksum}"
   exit 1
 fi
 
-if [ -n "$ios_ctrl_proxy_checksum" ] && ! [[ "$ios_ctrl_proxy_checksum" =~ ^[a-f0-9]{64}$ ]]; then
+if ! [[ "$ios_checksum" =~ ^[a-f0-9]{64}$ ]]; then
   echo "ERROR: IOS_CTRL_PROXY_SHA256_CHECKSUM must be a valid SHA256 hash (64 hex characters)"
-  echo "   Got: ${ios_ctrl_proxy_checksum}"
+  echo "   Got: ${ios_checksum}"
   exit 1
 fi
 
-if [ -n "$ios_ctrl_proxy_app_hash" ] && ! [[ "$ios_ctrl_proxy_app_hash" =~ ^[a-f0-9]{64}$ ]]; then
+if [ -n "$ios_app_hash" ] && ! [[ "$ios_app_hash" =~ ^[a-f0-9]{64}$ ]]; then
   echo "ERROR: IOS_CTRL_PROXY_APP_HASH must be a valid SHA256 hash (64 hex characters)"
-  echo "   Got: ${ios_ctrl_proxy_app_hash}"
+  echo "   Got: ${ios_app_hash}"
   exit 1
 fi
 
-if [ -n "$ios_ctrl_proxy_runner_sha256" ] && ! [[ "$ios_ctrl_proxy_runner_sha256" =~ ^[a-f0-9]{64}$ ]]; then
+if [ -n "$ios_runner_sha256" ] && ! [[ "$ios_runner_sha256" =~ ^[a-f0-9]{64}$ ]]; then
   echo "ERROR: IOS_CTRL_PROXY_RUNNER_SHA256 must be a valid SHA256 hash (64 hex characters)"
-  echo "   Got: ${ios_ctrl_proxy_runner_sha256}"
+  echo "   Got: ${ios_runner_sha256}"
   exit 1
 fi
+
+if grep -q "version: \"${release_version}\"" "$constants_path"; then
+  echo "INFO: Version ${release_version} already exists in registry — skipping"
+  exit 0
+fi
+
+new_entry="  {
+    version: \"${release_version}\",
+    apkSha256: \"${apk_checksum}\",
+    ipaSha256: \"${ios_checksum}\",
+  },"
 
 tmp_file="$(mktemp)"
 trap 'rm -f "$tmp_file"' EXIT
 
 cp "$constants_path" "$tmp_file"
 
-if [ -n "$release_version" ]; then
-  sed -E -i "" -e "s/^export const RELEASE_VERSION: string = \".*\";/export const RELEASE_VERSION: string = \"${release_version}\";/" "$tmp_file" 2>/dev/null \
-    || sed -E -i -e "s/^export const RELEASE_VERSION: string = \".*\";/export const RELEASE_VERSION: string = \"${release_version}\";/" "$tmp_file"
+# Prepend new entry after the opening bracket of RELEASE_CHECKSUM_REGISTRY
+# Match the line "export const RELEASE_CHECKSUM_REGISTRY: ReleaseChecksumEntry[] = ["
+# and insert the new entry on the next line
+if [[ "$(uname)" == "Darwin" ]]; then
+  sed -i "" "/^export const RELEASE_CHECKSUM_REGISTRY: ReleaseChecksumEntry\[\] = \[$/a\\
+${new_entry}
+" "$tmp_file"
+else
+  sed -i "/^export const RELEASE_CHECKSUM_REGISTRY: ReleaseChecksumEntry\[\] = \[$/a\\
+${new_entry}" "$tmp_file"
 fi
 
-if [ -n "$checksum" ]; then
-  sed -E -i "" -e "s/^export const APK_SHA256_CHECKSUM: string = \".*\";/export const APK_SHA256_CHECKSUM: string = \"${checksum}\";/" "$tmp_file" 2>/dev/null \
-    || sed -E -i -e "s/^export const APK_SHA256_CHECKSUM: string = \".*\";/export const APK_SHA256_CHECKSUM: string = \"${checksum}\";/" "$tmp_file"
+# Cap registry at max_registry_entries by counting entries and removing excess from the end
+entry_count=$(grep -c 'version: "' "$tmp_file" || true)
+if [ "$entry_count" -gt "$max_registry_entries" ]; then
+  excess=$((entry_count - max_registry_entries))
+  # Remove the last N entries (each entry is 5 lines: {, version, apkSha256, ipaSha256, },)
+  for ((i = 0; i < excess; i++)); do
+    # Find the last occurrence of a registry entry block and remove it
+    # Work backwards: find last "  }," before "];" and remove the 5-line block
+    if [[ "$(uname)" == "Darwin" ]]; then
+      # Find the line number of the last "version:" in the registry
+      last_version_line=$(grep -n 'version: "' "$tmp_file" | tail -1 | cut -d: -f1)
+      # The block starts 1 line before (the "{" line) and ends 2 lines after (the "}," line)
+      start_line=$((last_version_line - 1))
+      end_line=$((last_version_line + 3))
+      sed -i "" "${start_line},${end_line}d" "$tmp_file"
+    else
+      last_version_line=$(grep -n 'version: "' "$tmp_file" | tail -1 | cut -d: -f1)
+      start_line=$((last_version_line - 1))
+      end_line=$((last_version_line + 3))
+      sed -i "${start_line},${end_line}d" "$tmp_file"
+    fi
+  done
 fi
 
-if [ -n "$ios_ctrl_proxy_release_version" ]; then
-  sed -E -i "" -e "s/^export const IOS_CTRL_PROXY_RELEASE_VERSION: string = \".*\";/export const IOS_CTRL_PROXY_RELEASE_VERSION: string = \"${ios_ctrl_proxy_release_version}\";/" "$tmp_file" 2>/dev/null \
-    || sed -E -i -e "s/^export const IOS_CTRL_PROXY_RELEASE_VERSION: string = \".*\";/export const IOS_CTRL_PROXY_RELEASE_VERSION: string = \"${ios_ctrl_proxy_release_version}\";/" "$tmp_file"
+# Update optional scalar constants
+if [ -n "$ios_app_hash" ]; then
+  if [[ "$(uname)" == "Darwin" ]]; then
+    sed -E -i "" "s/^export const IOS_CTRL_PROXY_APP_HASH: string = \".*\";/export const IOS_CTRL_PROXY_APP_HASH: string = \"${ios_app_hash}\";/" "$tmp_file"
+  else
+    sed -E -i "s/^export const IOS_CTRL_PROXY_APP_HASH: string = \".*\";/export const IOS_CTRL_PROXY_APP_HASH: string = \"${ios_app_hash}\";/" "$tmp_file"
+  fi
 fi
 
-if [ -n "$ios_ctrl_proxy_checksum" ]; then
-  sed -E -i "" -e "s/^export const IOS_CTRL_PROXY_SHA256_CHECKSUM: string = \".*\";/export const IOS_CTRL_PROXY_SHA256_CHECKSUM: string = \"${ios_ctrl_proxy_checksum}\";/" "$tmp_file" 2>/dev/null \
-    || sed -E -i -e "s/^export const IOS_CTRL_PROXY_SHA256_CHECKSUM: string = \".*\";/export const IOS_CTRL_PROXY_SHA256_CHECKSUM: string = \"${ios_ctrl_proxy_checksum}\";/" "$tmp_file"
-fi
-
-if [ -n "$ios_ctrl_proxy_app_hash" ]; then
-  sed -E -i "" -e "s/^export const IOS_CTRL_PROXY_APP_HASH: string = \".*\";/export const IOS_CTRL_PROXY_APP_HASH: string = \"${ios_ctrl_proxy_app_hash}\";/" "$tmp_file" 2>/dev/null \
-    || sed -E -i -e "s/^export const IOS_CTRL_PROXY_APP_HASH: string = \".*\";/export const IOS_CTRL_PROXY_APP_HASH: string = \"${ios_ctrl_proxy_app_hash}\";/" "$tmp_file"
-fi
-
-if [ -n "$ios_ctrl_proxy_runner_sha256" ]; then
-  sed -E -i "" -e "s/^export const IOS_CTRL_PROXY_RUNNER_SHA256: string = \".*\";/export const IOS_CTRL_PROXY_RUNNER_SHA256: string = \"${ios_ctrl_proxy_runner_sha256}\";/" "$tmp_file" 2>/dev/null \
-    || sed -E -i -e "s/^export const IOS_CTRL_PROXY_RUNNER_SHA256: string = \".*\";/export const IOS_CTRL_PROXY_RUNNER_SHA256: string = \"${ios_ctrl_proxy_runner_sha256}\";/" "$tmp_file"
+if [ -n "$ios_runner_sha256" ]; then
+  if [[ "$(uname)" == "Darwin" ]]; then
+    sed -E -i "" "s/^export const IOS_CTRL_PROXY_RUNNER_SHA256: string = \".*\";/export const IOS_CTRL_PROXY_RUNNER_SHA256: string = \"${ios_runner_sha256}\";/" "$tmp_file"
+  else
+    sed -E -i "s/^export const IOS_CTRL_PROXY_RUNNER_SHA256: string = \".*\";/export const IOS_CTRL_PROXY_RUNNER_SHA256: string = \"${ios_runner_sha256}\";/" "$tmp_file"
+  fi
 fi
 
 if cmp -s "$constants_path" "$tmp_file"; then
@@ -83,22 +119,13 @@ mv "$tmp_file" "$constants_path"
 trap - EXIT
 
 echo "Updated release constants:"
-if [ -n "$release_version" ]; then
-  echo "   Version: ${release_version}"
+echo "   Added registry entry for version: ${release_version}"
+echo "   APK checksum: ${apk_checksum}"
+echo "   iOS checksum: ${ios_checksum}"
+if [ -n "$ios_app_hash" ]; then
+  echo "   iOS app hash: ${ios_app_hash}"
 fi
-if [ -n "$checksum" ]; then
-  echo "   APK checksum: ${checksum}"
-fi
-if [ -n "$ios_ctrl_proxy_release_version" ]; then
-  echo "   CtrlProxy iOS version: ${ios_ctrl_proxy_release_version}"
-fi
-if [ -n "$ios_ctrl_proxy_checksum" ]; then
-  echo "   CtrlProxy iOS checksum: ${ios_ctrl_proxy_checksum}"
-fi
-if [ -n "$ios_ctrl_proxy_app_hash" ]; then
-  echo "   CtrlProxy iOS app hash: ${ios_ctrl_proxy_app_hash}"
-fi
-if [ -n "$ios_ctrl_proxy_runner_sha256" ]; then
-  echo "   CtrlProxy iOS runner SHA256: ${ios_ctrl_proxy_runner_sha256}"
+if [ -n "$ios_runner_sha256" ]; then
+  echo "   iOS runner SHA256: ${ios_runner_sha256}"
 fi
 echo "   File: ${constants_path}"

--- a/src/constants/release.ts
+++ b/src/constants/release.ts
@@ -4,40 +4,73 @@
  * This file contains release-specific constants that are updated automatically.
  * The values below are defaults for local development.
  *
- * The APK checksum is updated by the merge workflow when the accessibility
- * service APK changes. The release workflow verifies the checksum matches
- * the built APK before publishing.
+ * The checksum registry is an ordered array of validated release checksums,
+ * newest first (max 100 entries). "latest" resolves to registry[0].
+ * Pinned versions (e.g. "0.0.18") do an exact lookup by version.
  *
- * During CI/CD release builds, the release version is replaced via
+ * During CI/CD release builds, new entries are prepended to the registry via
  * scripts/generate-release-constants.sh
- *
- * For local development, RELEASE_VERSION "latest" fetches from the most recent
- * GitHub release. Because the "latest" asset can change over time, runtime
- * checksum verification is only reliable for pinned release versions.
  */
 
 export const LATEST_RELEASE_VERSION = "latest";
 
-export function usesMutableLatestRelease(version: string): boolean {
-  return version.trim().toLowerCase() === LATEST_RELEASE_VERSION;
+export interface ReleaseChecksumEntry {
+  version: string;
+  apkSha256: string;
+  ipaSha256: string;
 }
 
-export const RELEASE_VERSION: string = LATEST_RELEASE_VERSION;
-export const APK_URL: string = RELEASE_VERSION === LATEST_RELEASE_VERSION
-  ? `https://github.com/kaeawc/auto-mobile/releases/latest/download/control-proxy-debug.apk`
-  : `https://github.com/kaeawc/auto-mobile/releases/download/v${RELEASE_VERSION}/control-proxy-debug.apk`;
-export const APK_SHA256_CHECKSUM: string = "8ecd4e6a33d6158188535d9020d7145bc7038de3c1ff551a0474f08de401c7b1"; // Empty = skip verification (local dev only)
+/**
+ * Ordered checksum registry, newest first. Max 100 entries.
+ * Each entry represents a validated release build.
+ */
+export const RELEASE_CHECKSUM_REGISTRY: ReleaseChecksumEntry[] = [
+  {
+    version: "0.0.18",
+    apkSha256: "8ecd4e6a33d6158188535d9020d7145bc7038de3c1ff551a0474f08de401c7b1",
+    ipaSha256: "e27ef949c6d68ffe19097a0db84284598b9ad0f3b04e887c68a9a04cf9425825",
+  },
+];
 
 /**
- * iOS CtrlProxy Release Constants
- *
- * CtrlProxy is distributed via GitHub releases as a prebuilt bundle.
- * The default "latest" version targets the most recent release.
+ * Resolve a checksum from the registry.
+ * - "latest" → registry[0] (most recent validated build)
+ * - pinned version (e.g. "0.0.18") → exact match lookup
+ * - unknown version or empty registry → ""
  */
+export function resolveChecksum(version: string, platform: "android" | "ios"): string {
+  if (RELEASE_CHECKSUM_REGISTRY.length === 0) {
+    return "";
+  }
+  const normalized = version.trim().toLowerCase();
+  const entry = normalized === LATEST_RELEASE_VERSION
+    ? RELEASE_CHECKSUM_REGISTRY[0]
+    : RELEASE_CHECKSUM_REGISTRY.find(e => e.version === version);
+  if (!entry) {
+    return "";
+  }
+  return platform === "android" ? entry.apkSha256 : entry.ipaSha256;
+}
+
+/**
+ * Version of the latest validated release in the registry.
+ * Used to construct download URLs for pinned releases.
+ */
+export function resolveLatestVersion(): string {
+  if (RELEASE_CHECKSUM_REGISTRY.length === 0) {
+    return LATEST_RELEASE_VERSION;
+  }
+  return RELEASE_CHECKSUM_REGISTRY[0].version;
+}
+
+// --- Backward-compatible exports derived from registry[0] ---
+
+export const RELEASE_VERSION: string = LATEST_RELEASE_VERSION;
+export const APK_URL: string = `https://github.com/kaeawc/auto-mobile/releases/latest/download/control-proxy-debug.apk`;
+export const APK_SHA256_CHECKSUM: string = resolveChecksum(LATEST_RELEASE_VERSION, "android");
+
 export const IOS_CTRL_PROXY_RELEASE_VERSION: string = LATEST_RELEASE_VERSION;
-export const IOS_CTRL_PROXY_IPA_URL: string = IOS_CTRL_PROXY_RELEASE_VERSION === LATEST_RELEASE_VERSION
-  ? "https://github.com/kaeawc/auto-mobile/releases/latest/download/control-proxy.ipa"
-  : `https://github.com/kaeawc/auto-mobile/releases/download/v${IOS_CTRL_PROXY_RELEASE_VERSION}/control-proxy.ipa`;
-export const IOS_CTRL_PROXY_SHA256_CHECKSUM: string = "e27ef949c6d68ffe19097a0db84284598b9ad0f3b04e887c68a9a04cf9425825"; // Empty = skip verification (local dev only)
+export const IOS_CTRL_PROXY_IPA_URL: string = "https://github.com/kaeawc/auto-mobile/releases/latest/download/control-proxy.ipa";
+export const IOS_CTRL_PROXY_SHA256_CHECKSUM: string = resolveChecksum(LATEST_RELEASE_VERSION, "ios");
 export const IOS_CTRL_PROXY_APP_HASH: string = ""; // Hash of CtrlProxyApp.app (device build), empty = skip verification
 export const IOS_CTRL_PROXY_RUNNER_SHA256: string = ""; // SHA256 of runner binary (CtrlProxyUITests-Runner), empty = skip verification

--- a/src/constants/release.ts
+++ b/src/constants/release.ts
@@ -30,6 +30,11 @@ export const RELEASE_CHECKSUM_REGISTRY: ReleaseChecksumEntry[] = [
     apkSha256: "8ecd4e6a33d6158188535d9020d7145bc7038de3c1ff551a0474f08de401c7b1",
     ipaSha256: "e27ef949c6d68ffe19097a0db84284598b9ad0f3b04e887c68a9a04cf9425825",
   },
+  {
+    version: "0.0.17",
+    apkSha256: "916033440931666644474f227c8e39d13d9c80c3515e4292cc5581fd5bd4cc2f",
+    ipaSha256: "e4dcf064d024f2371b8fd79281000e2d49751ef95b8817d1494d685aeda746ac",
+  },
 ];
 
 /**

--- a/src/constants/release.ts
+++ b/src/constants/release.ts
@@ -38,14 +38,18 @@ export const RELEASE_CHECKSUM_REGISTRY: ReleaseChecksumEntry[] = [
  * - pinned version (e.g. "0.0.18") → exact match lookup
  * - unknown version or empty registry → ""
  */
-export function resolveChecksum(version: string, platform: "android" | "ios"): string {
-  if (RELEASE_CHECKSUM_REGISTRY.length === 0) {
+export function resolveChecksum(
+  version: string,
+  platform: "android" | "ios",
+  registry: ReleaseChecksumEntry[] = RELEASE_CHECKSUM_REGISTRY
+): string {
+  if (registry.length === 0) {
     return "";
   }
   const normalized = version.trim().toLowerCase();
   const entry = normalized === LATEST_RELEASE_VERSION
-    ? RELEASE_CHECKSUM_REGISTRY[0]
-    : RELEASE_CHECKSUM_REGISTRY.find(e => e.version === version);
+    ? registry[0]
+    : registry.find(e => e.version === version);
   if (!entry) {
     return "";
   }

--- a/src/constants/release.ts
+++ b/src/constants/release.ts
@@ -27,8 +27,8 @@ export interface ReleaseChecksumEntry {
 export const RELEASE_CHECKSUM_REGISTRY: ReleaseChecksumEntry[] = [
   {
     version: "0.0.18",
-    apkSha256: "8ecd4e6a33d6158188535d9020d7145bc7038de3c1ff551a0474f08de401c7b1",
-    ipaSha256: "e27ef949c6d68ffe19097a0db84284598b9ad0f3b04e887c68a9a04cf9425825",
+    apkSha256: "fd3c8d9f0b8542eaad56c78b18cf8e5666367b04ae8c4af74d8aa6dd1c8d1834",
+    ipaSha256: "2a5eec63bce2f9dfc227c0732fcce67378305e945604d5eedd0e3df48e37fd39",
   },
   {
     version: "0.0.17",

--- a/src/daemon/socketServer.ts
+++ b/src/daemon/socketServer.ts
@@ -23,13 +23,11 @@ import type { FeatureFlagKey } from "../features/featureFlags/FeatureFlagDefinit
 import { getMcpServerVersion } from "../utils/mcpVersion";
 import {
   RELEASE_VERSION,
-  APK_SHA256_CHECKSUM,
   APK_URL,
   IOS_CTRL_PROXY_RELEASE_VERSION,
-  IOS_CTRL_PROXY_SHA256_CHECKSUM,
   IOS_CTRL_PROXY_IPA_URL,
   IOS_CTRL_PROXY_APP_HASH,
-  usesMutableLatestRelease,
+  resolveChecksum,
 } from "../constants/release";
 import { AndroidCtrlProxyManager } from "../utils/CtrlProxyManager";
 import { IOSCtrlProxyManager } from "../utils/IOSCtrlProxyManager";
@@ -387,13 +385,13 @@ export class UnixSocketServer {
           releaseVersion: RELEASE_VERSION,
           android: {
             ctrlProxy: {
-              expectedSha256: usesMutableLatestRelease(RELEASE_VERSION) ? "" : APK_SHA256_CHECKSUM,
+              expectedSha256: resolveChecksum(RELEASE_VERSION, "android"),
               url: APK_URL,
             },
           },
           ios: {
             xcTestService: {
-              expectedSha256: usesMutableLatestRelease(IOS_CTRL_PROXY_RELEASE_VERSION) ? "" : IOS_CTRL_PROXY_SHA256_CHECKSUM,
+              expectedSha256: resolveChecksum(IOS_CTRL_PROXY_RELEASE_VERSION, "ios"),
               expectedAppHash: IOS_CTRL_PROXY_APP_HASH,
               url: IOS_CTRL_PROXY_IPA_URL,
             },

--- a/src/server/bootedDeviceResources.ts
+++ b/src/server/bootedDeviceResources.ts
@@ -9,11 +9,9 @@ import type { DevicePool } from "../daemon/devicePool";
 import { AndroidCtrlProxyManager } from "../utils/CtrlProxyManager";
 import { IOSCtrlProxyManager } from "../utils/IOSCtrlProxyManager";
 import {
-  APK_SHA256_CHECKSUM,
   IOS_CTRL_PROXY_RELEASE_VERSION,
-  IOS_CTRL_PROXY_SHA256_CHECKSUM,
   RELEASE_VERSION,
-  usesMutableLatestRelease
+  resolveChecksum,
 } from "../constants/release";
 import { defaultTimer } from "../utils/SystemTimer";
 
@@ -344,7 +342,7 @@ async function queryDeviceServiceStatus(device: BootedDeviceInfo): Promise<Devic
         manager.isEnabled(),
         manager.getInstalledApkSha256(),
       ]);
-      const expectedSha256 = usesMutableLatestRelease(RELEASE_VERSION) ? "" : APK_SHA256_CHECKSUM;
+      const expectedSha256 = resolveChecksum(RELEASE_VERSION, "android");
       const isCompatible = expectedSha256.length === 0 ||
         (installedSha256 !== null && installedSha256.toLowerCase() === expectedSha256.toLowerCase());
       return {
@@ -361,7 +359,7 @@ async function queryDeviceServiceStatus(device: BootedDeviceInfo): Promise<Devic
         manager.isInstalled(),
         manager.isRunning(),
       ]);
-      const expectedSha256 = usesMutableLatestRelease(IOS_CTRL_PROXY_RELEASE_VERSION) ? "" : IOS_CTRL_PROXY_SHA256_CHECKSUM;
+      const expectedSha256 = resolveChecksum(IOS_CTRL_PROXY_RELEASE_VERSION, "ios");
       return {
         installed,
         enabled: running,

--- a/src/utils/CtrlProxyManager.ts
+++ b/src/utils/CtrlProxyManager.ts
@@ -6,9 +6,8 @@ import * as path from "path";
 import { BootedDevice } from "../models";
 import {
   APK_URL,
-  APK_SHA256_CHECKSUM,
   RELEASE_VERSION,
-  usesMutableLatestRelease
+  resolveChecksum
 } from "../constants/release";
 import AdmZip from "adm-zip";
 import crypto from "crypto";
@@ -1358,7 +1357,7 @@ export class AndroidCtrlProxyManager implements CtrlProxyManager {
     if (this.shouldSkipChecksum()) {
       return "";
     }
-    return AndroidCtrlProxyManager.expectedChecksumOverride ?? APK_SHA256_CHECKSUM;
+    return AndroidCtrlProxyManager.expectedChecksumOverride ?? resolveChecksum(RELEASE_VERSION, "android");
   }
 
   private isNetworkError(message: string): boolean {
@@ -1393,10 +1392,6 @@ export class AndroidCtrlProxyManager implements CtrlProxyManager {
     const explicitSkip = process.env.AUTOMOBILE_SKIP_ACCESSIBILITY_CHECKSUM ??
       process.env.AUTO_MOBILE_ACCESSIBILITY_SERVICE_SHA_SKIP_CHECK;
     if (explicitSkip && (explicitSkip === "1" || explicitSkip.toLowerCase() === "true")) {
-      return true;
-    }
-    if (AndroidCtrlProxyManager.expectedChecksumOverride === null &&
-        usesMutableLatestRelease(RELEASE_VERSION)) {
       return true;
     }
     return this.getApkPathOverride() !== null;

--- a/src/utils/IOSCtrlProxyBuilder.ts
+++ b/src/utils/IOSCtrlProxyBuilder.ts
@@ -9,8 +9,9 @@ import {
   IOS_CTRL_PROXY_IPA_URL,
   IOS_CTRL_PROXY_RELEASE_VERSION,
   IOS_CTRL_PROXY_RUNNER_SHA256,
-  IOS_CTRL_PROXY_SHA256_CHECKSUM,
-  usesMutableLatestRelease
+  LATEST_RELEASE_VERSION,
+  resolveChecksum,
+  resolveLatestVersion
 } from "../constants/release";
 import {
   DefaultIOSCtrlProxyBundleDownloader,
@@ -299,8 +300,8 @@ export class IOSCtrlProxyBuilder {
         logger.info("[IOSCtrlProxyBuilder] CtrlProxy checksum mismatch, need download");
         return true;
       }
-    } else if (!metadata || metadata.version !== IOS_CTRL_PROXY_RELEASE_VERSION) {
-      logger.info("[IOSCtrlProxyBuilder] CtrlProxy version mismatch, need download");
+    } else if (!metadata) {
+      logger.info("[IOSCtrlProxyBuilder] CtrlProxy metadata missing, need download");
       return true;
     }
 
@@ -576,10 +577,10 @@ export class IOSCtrlProxyBuilder {
 
   private getExpectedChecksum(): string {
     const override = IOSCtrlProxyBuilder.expectedChecksumOverride;
-    if (override === null && usesMutableLatestRelease(IOS_CTRL_PROXY_RELEASE_VERSION)) {
-      return "";
+    if (override !== null) {
+      return override;
     }
-    return override ?? IOS_CTRL_PROXY_SHA256_CHECKSUM ?? "";
+    return resolveChecksum(IOS_CTRL_PROXY_RELEASE_VERSION, "ios");
   }
 
   public getExpectedAppHash(platform: IOSCtrlProxyPlatform): string {
@@ -618,17 +619,25 @@ export class IOSCtrlProxyBuilder {
       await fs.copyFile(overridePath, bundlePath);
     } else {
       const expectedChecksum = this.getExpectedChecksum();
-      const metadata = await this.readBundleMetadata();
-      const versionMismatch = !metadata || metadata.version !== IOS_CTRL_PROXY_RELEASE_VERSION;
       const bundleReady = await this.isBundleValid(bundlePath, expectedChecksum);
 
-      if (!bundleReady || (expectedChecksum.length === 0 && versionMismatch)) {
-        logger.info("[IOSCtrlProxyBuilder] Downloading CtrlProxy bundle", {
-          url: this.getBundleUrl(),
-          destination: bundlePath,
-          reason: bundleReady ? "version-mismatch" : "missing-or-invalid"
-        });
-        await this.downloader.download(this.getBundleUrl(), bundlePath);
+      if (!bundleReady) {
+        const isLatest = IOS_CTRL_PROXY_RELEASE_VERSION.trim().toLowerCase() === LATEST_RELEASE_VERSION;
+        const cachedBundleExists = await this.isBundleValid(bundlePath, "");
+        try {
+          logger.info("[IOSCtrlProxyBuilder] Downloading CtrlProxy bundle", {
+            url: this.getBundleUrl(),
+            destination: bundlePath,
+            reason: "checksum-mismatch-or-missing"
+          });
+          await this.downloader.download(this.getBundleUrl(), bundlePath);
+        } catch (error) {
+          if (isLatest && cachedBundleExists) {
+            logger.warn(`[IOSCtrlProxyBuilder] Download failed, using cached bundle: ${error instanceof Error ? error.message : String(error)}`);
+            return bundlePath;
+          }
+          throw error;
+        }
       }
     }
 
@@ -680,7 +689,7 @@ export class IOSCtrlProxyBuilder {
     const appHashes = await this.computeAppHashes();
     const metadata: IOSCtrlProxyBundleMetadata = {
       checksum: this.getExpectedChecksum() || null,
-      version: IOS_CTRL_PROXY_RELEASE_VERSION,
+      version: resolveLatestVersion(),
       extractedAt: new Date().toISOString(),
       appHashes
     };

--- a/src/utils/plan/PlanExecutor.ts
+++ b/src/utils/plan/PlanExecutor.ts
@@ -196,7 +196,7 @@ export class DefaultPlanExecutor implements PlanExecutor {
           }, DefaultPlanExecutor.FAILURE_OBSERVATION_TIMEOUT_MS);
         }),
       ]);
-      if (timeoutHandle) clearTimeout(timeoutHandle);
+      if (timeoutHandle) {clearTimeout(timeoutHandle);}
 
       const raw = this.parseStructuredToolPayload(response);
       if (!raw) {

--- a/test/constants/release.test.ts
+++ b/test/constants/release.test.ts
@@ -1,16 +1,35 @@
 import { describe, expect, test } from "bun:test";
-import { usesMutableLatestRelease } from "../../src/constants/release";
+import { resolveChecksum, resolveLatestVersion, RELEASE_CHECKSUM_REGISTRY } from "../../src/constants/release";
 
 describe("release constants helpers", function() {
-  test("treats latest release references as mutable", function() {
-    expect(usesMutableLatestRelease("latest")).toBe(true);
-    expect(usesMutableLatestRelease("LATEST")).toBe(true);
-    expect(usesMutableLatestRelease(" latest ")).toBe(true);
+  test("resolveChecksum returns registry[0] for latest", function() {
+    const expected = RELEASE_CHECKSUM_REGISTRY[0];
+    expect(resolveChecksum("latest", "android")).toBe(expected.apkSha256);
+    expect(resolveChecksum("latest", "ios")).toBe(expected.ipaSha256);
   });
 
-  test("does not treat pinned release references as mutable", function() {
-    expect(usesMutableLatestRelease("0.0.15")).toBe(false);
-    expect(usesMutableLatestRelease("v0.0.15")).toBe(false);
-    expect(usesMutableLatestRelease("")).toBe(false);
+  test("resolveChecksum is case-insensitive for latest", function() {
+    const expected = RELEASE_CHECKSUM_REGISTRY[0];
+    expect(resolveChecksum("LATEST", "android")).toBe(expected.apkSha256);
+    expect(resolveChecksum(" latest ", "ios")).toBe(expected.ipaSha256);
+  });
+
+  test("resolveChecksum returns exact match for pinned version", function() {
+    const entry = RELEASE_CHECKSUM_REGISTRY[0];
+    expect(resolveChecksum(entry.version, "android")).toBe(entry.apkSha256);
+    expect(resolveChecksum(entry.version, "ios")).toBe(entry.ipaSha256);
+  });
+
+  test("resolveChecksum returns empty string for unknown version", function() {
+    expect(resolveChecksum("99.99.99", "android")).toBe("");
+    expect(resolveChecksum("99.99.99", "ios")).toBe("");
+  });
+
+  test("resolveChecksum returns empty string for empty input", function() {
+    expect(resolveChecksum("", "android")).toBe("");
+  });
+
+  test("resolveLatestVersion returns first registry entry version", function() {
+    expect(resolveLatestVersion()).toBe(RELEASE_CHECKSUM_REGISTRY[0].version);
   });
 });

--- a/test/constants/release.test.ts
+++ b/test/constants/release.test.ts
@@ -20,8 +20,8 @@ describe("resolveChecksum", function() {
   });
 
   test("pinned 0.0.18 resolves to its specific checksums", function() {
-    expect(resolveChecksum("0.0.18", "android")).toBe("8ecd4e6a33d6158188535d9020d7145bc7038de3c1ff551a0474f08de401c7b1");
-    expect(resolveChecksum("0.0.18", "ios")).toBe("e27ef949c6d68ffe19097a0db84284598b9ad0f3b04e887c68a9a04cf9425825");
+    expect(resolveChecksum("0.0.18", "android")).toBe("fd3c8d9f0b8542eaad56c78b18cf8e5666367b04ae8c4af74d8aa6dd1c8d1834");
+    expect(resolveChecksum("0.0.18", "ios")).toBe("2a5eec63bce2f9dfc227c0732fcce67378305e945604d5eedd0e3df48e37fd39");
   });
 
   test("pinned 0.0.17 resolves to its specific checksums, not latest", function() {

--- a/test/constants/release.test.ts
+++ b/test/constants/release.test.ts
@@ -6,40 +6,37 @@ import {
   type ReleaseChecksumEntry,
 } from "../../src/constants/release";
 
-const multiEntryRegistry: ReleaseChecksumEntry[] = [
-  { version: "0.0.19", apkSha256: "aaa111", ipaSha256: "bbb111" },
-  { version: "0.0.18", apkSha256: "aaa222", ipaSha256: "bbb222" },
-  { version: "0.0.17", apkSha256: "aaa333", ipaSha256: "bbb333" },
-];
-
 describe("resolveChecksum", function() {
-  test("latest resolves to registry[0]", function() {
-    const expected = RELEASE_CHECKSUM_REGISTRY[0];
-    expect(resolveChecksum("latest", "android")).toBe(expected.apkSha256);
-    expect(resolveChecksum("latest", "ios")).toBe(expected.ipaSha256);
+  test("latest resolves to registry[0] (newest entry)", function() {
+    const newest = RELEASE_CHECKSUM_REGISTRY[0];
+    expect(resolveChecksum("latest", "android")).toBe(newest.apkSha256);
+    expect(resolveChecksum("latest", "ios")).toBe(newest.ipaSha256);
   });
 
   test("latest is case-insensitive and trims whitespace", function() {
-    const expected = RELEASE_CHECKSUM_REGISTRY[0];
-    expect(resolveChecksum("LATEST", "android")).toBe(expected.apkSha256);
-    expect(resolveChecksum(" latest ", "ios")).toBe(expected.ipaSha256);
+    const newest = RELEASE_CHECKSUM_REGISTRY[0];
+    expect(resolveChecksum("LATEST", "android")).toBe(newest.apkSha256);
+    expect(resolveChecksum(" latest ", "ios")).toBe(newest.ipaSha256);
   });
 
-  test("latest resolves to newest entry in multi-entry registry", function() {
-    expect(resolveChecksum("latest", "android", multiEntryRegistry)).toBe("aaa111");
-    expect(resolveChecksum("latest", "ios", multiEntryRegistry)).toBe("bbb111");
+  test("pinned 0.0.18 resolves to its specific checksums", function() {
+    expect(resolveChecksum("0.0.18", "android")).toBe("8ecd4e6a33d6158188535d9020d7145bc7038de3c1ff551a0474f08de401c7b1");
+    expect(resolveChecksum("0.0.18", "ios")).toBe("e27ef949c6d68ffe19097a0db84284598b9ad0f3b04e887c68a9a04cf9425825");
   });
 
-  test("pinned version resolves to its specific entry, not latest", function() {
-    expect(resolveChecksum("0.0.18", "android", multiEntryRegistry)).toBe("aaa222");
-    expect(resolveChecksum("0.0.18", "ios", multiEntryRegistry)).toBe("bbb222");
-    expect(resolveChecksum("0.0.17", "android", multiEntryRegistry)).toBe("aaa333");
-    expect(resolveChecksum("0.0.17", "ios", multiEntryRegistry)).toBe("bbb333");
+  test("pinned 0.0.17 resolves to its specific checksums, not latest", function() {
+    expect(resolveChecksum("0.0.17", "android")).toBe("916033440931666644474f227c8e39d13d9c80c3515e4292cc5581fd5bd4cc2f");
+    expect(resolveChecksum("0.0.17", "ios")).toBe("e4dcf064d024f2371b8fd79281000e2d49751ef95b8817d1494d685aeda746ac");
   });
 
-  test("pinned version returns empty string when not in registry", function() {
-    expect(resolveChecksum("99.99.99", "android", multiEntryRegistry)).toBe("");
-    expect(resolveChecksum("99.99.99", "ios", multiEntryRegistry)).toBe("");
+  test("latest and pinned 0.0.17 return different checksums", function() {
+    expect(resolveChecksum("latest", "android")).not.toBe(resolveChecksum("0.0.17", "android"));
+    expect(resolveChecksum("latest", "ios")).not.toBe(resolveChecksum("0.0.17", "ios"));
+  });
+
+  test("pinned version not in registry returns empty string", function() {
+    expect(resolveChecksum("99.99.99", "android")).toBe("");
+    expect(resolveChecksum("99.99.99", "ios")).toBe("");
   });
 
   test("empty version returns empty string", function() {
@@ -47,13 +44,26 @@ describe("resolveChecksum", function() {
   });
 
   test("empty registry returns empty string", function() {
-    expect(resolveChecksum("latest", "android", [])).toBe("");
-    expect(resolveChecksum("0.0.18", "ios", [])).toBe("");
+    const empty: ReleaseChecksumEntry[] = [];
+    expect(resolveChecksum("latest", "android", empty)).toBe("");
+    expect(resolveChecksum("0.0.18", "ios", empty)).toBe("");
+  });
+
+  test("multi-entry registry resolves each version independently", function() {
+    const registry: ReleaseChecksumEntry[] = [
+      { version: "0.0.20", apkSha256: "apk20", ipaSha256: "ipa20" },
+      { version: "0.0.19", apkSha256: "apk19", ipaSha256: "ipa19" },
+      { version: "0.0.18", apkSha256: "apk18", ipaSha256: "ipa18" },
+    ];
+    expect(resolveChecksum("latest", "android", registry)).toBe("apk20");
+    expect(resolveChecksum("0.0.19", "android", registry)).toBe("apk19");
+    expect(resolveChecksum("0.0.18", "ios", registry)).toBe("ipa18");
+    expect(resolveChecksum("0.0.17", "android", registry)).toBe("");
   });
 });
 
 describe("resolveLatestVersion", function() {
   test("returns first registry entry version", function() {
-    expect(resolveLatestVersion()).toBe(RELEASE_CHECKSUM_REGISTRY[0].version);
+    expect(resolveLatestVersion()).toBe("0.0.18");
   });
 });

--- a/test/constants/release.test.ts
+++ b/test/constants/release.test.ts
@@ -1,35 +1,59 @@
 import { describe, expect, test } from "bun:test";
-import { resolveChecksum, resolveLatestVersion, RELEASE_CHECKSUM_REGISTRY } from "../../src/constants/release";
+import {
+  resolveChecksum,
+  resolveLatestVersion,
+  RELEASE_CHECKSUM_REGISTRY,
+  type ReleaseChecksumEntry,
+} from "../../src/constants/release";
 
-describe("release constants helpers", function() {
-  test("resolveChecksum returns registry[0] for latest", function() {
+const multiEntryRegistry: ReleaseChecksumEntry[] = [
+  { version: "0.0.19", apkSha256: "aaa111", ipaSha256: "bbb111" },
+  { version: "0.0.18", apkSha256: "aaa222", ipaSha256: "bbb222" },
+  { version: "0.0.17", apkSha256: "aaa333", ipaSha256: "bbb333" },
+];
+
+describe("resolveChecksum", function() {
+  test("latest resolves to registry[0]", function() {
     const expected = RELEASE_CHECKSUM_REGISTRY[0];
     expect(resolveChecksum("latest", "android")).toBe(expected.apkSha256);
     expect(resolveChecksum("latest", "ios")).toBe(expected.ipaSha256);
   });
 
-  test("resolveChecksum is case-insensitive for latest", function() {
+  test("latest is case-insensitive and trims whitespace", function() {
     const expected = RELEASE_CHECKSUM_REGISTRY[0];
     expect(resolveChecksum("LATEST", "android")).toBe(expected.apkSha256);
     expect(resolveChecksum(" latest ", "ios")).toBe(expected.ipaSha256);
   });
 
-  test("resolveChecksum returns exact match for pinned version", function() {
-    const entry = RELEASE_CHECKSUM_REGISTRY[0];
-    expect(resolveChecksum(entry.version, "android")).toBe(entry.apkSha256);
-    expect(resolveChecksum(entry.version, "ios")).toBe(entry.ipaSha256);
+  test("latest resolves to newest entry in multi-entry registry", function() {
+    expect(resolveChecksum("latest", "android", multiEntryRegistry)).toBe("aaa111");
+    expect(resolveChecksum("latest", "ios", multiEntryRegistry)).toBe("bbb111");
   });
 
-  test("resolveChecksum returns empty string for unknown version", function() {
-    expect(resolveChecksum("99.99.99", "android")).toBe("");
-    expect(resolveChecksum("99.99.99", "ios")).toBe("");
+  test("pinned version resolves to its specific entry, not latest", function() {
+    expect(resolveChecksum("0.0.18", "android", multiEntryRegistry)).toBe("aaa222");
+    expect(resolveChecksum("0.0.18", "ios", multiEntryRegistry)).toBe("bbb222");
+    expect(resolveChecksum("0.0.17", "android", multiEntryRegistry)).toBe("aaa333");
+    expect(resolveChecksum("0.0.17", "ios", multiEntryRegistry)).toBe("bbb333");
   });
 
-  test("resolveChecksum returns empty string for empty input", function() {
+  test("pinned version returns empty string when not in registry", function() {
+    expect(resolveChecksum("99.99.99", "android", multiEntryRegistry)).toBe("");
+    expect(resolveChecksum("99.99.99", "ios", multiEntryRegistry)).toBe("");
+  });
+
+  test("empty version returns empty string", function() {
     expect(resolveChecksum("", "android")).toBe("");
   });
 
-  test("resolveLatestVersion returns first registry entry version", function() {
+  test("empty registry returns empty string", function() {
+    expect(resolveChecksum("latest", "android", [])).toBe("");
+    expect(resolveChecksum("0.0.18", "ios", [])).toBe("");
+  });
+});
+
+describe("resolveLatestVersion", function() {
+  test("returns first registry entry version", function() {
     expect(resolveLatestVersion()).toBe(RELEASE_CHECKSUM_REGISTRY[0].version);
   });
 });

--- a/test/utils/IOSCtrlProxyBuilder.test.ts
+++ b/test/utils/IOSCtrlProxyBuilder.test.ts
@@ -387,7 +387,7 @@ describe("IOSCtrlProxyBuilder", function() {
       expect(result.error).toContain("checksum verification failed");
     });
 
-    test("should redownload when version changes without checksum", async function() {
+    test("should redownload when checksum changes", async function() {
       const derivedDataPath = path.join(tempDir, "DerivedData");
       const cacheDir = path.join(tempDir, "cache");
       await fs.mkdir(cacheDir, { recursive: true });
@@ -396,11 +396,21 @@ describe("IOSCtrlProxyBuilder", function() {
       await fs.writeFile(existingBundle, "a".repeat(12000));
       await fs.writeFile(
         path.join(cacheDir, "ctrl-proxy-ios-bundle.json"),
-        JSON.stringify({ checksum: null, version: "old", extractedAt: new Date().toISOString() })
+        JSON.stringify({ checksum: "old-checksum", version: "0.0.17", extractedAt: new Date().toISOString() })
       );
 
+      let callCount = 0;
       const downloader = new FakeIOSCtrlProxyBundleDownloader();
-      IOSCtrlProxyBuilder.setExpectedChecksumForTesting("");
+      const origComputeSha = downloader.computeFileSha256.bind(downloader);
+      downloader.computeFileSha256 = async (filePath: string) => {
+        callCount++;
+        if (callCount === 1) {
+          return { checksum: "old-checksum", source: "node" as const };
+        }
+        return origComputeSha(filePath);
+      };
+      downloader.checksum = "new-checksum";
+      IOSCtrlProxyBuilder.setExpectedChecksumForTesting("new-checksum");
       const builder = IOSCtrlProxyBuilder.getInstance(
         {
           derivedDataPath,

--- a/test/utils/ProcessExecutor.test.ts
+++ b/test/utils/ProcessExecutor.test.ts
@@ -3,16 +3,16 @@ import process from "process";
 import { DefaultProcessExecutor } from "../../src/utils/ProcessExecutor";
 import { DefaultHostCommandExecutor } from "../../src/utils/HostCommandExecutor";
 
-describe("DefaultProcessExecutor", function () {
+describe("DefaultProcessExecutor", function() {
   const executor = new DefaultProcessExecutor();
 
-  test("exec captures stdout", async function () {
+  test("exec captures stdout", async function() {
     const result = await executor.exec("echo hello");
     expect(result.stdout.trim()).toBe("hello");
     expect(result.stderr).toBe("");
   });
 
-  test("exec ExecResult helpers work", async function () {
+  test("exec ExecResult helpers work", async function() {
     const result = await executor.exec("echo world");
     expect(result.trim()).toBe("world");
     expect(result.toString()).toContain("world");
@@ -20,11 +20,11 @@ describe("DefaultProcessExecutor", function () {
     expect(result.includes("nope")).toBe(false);
   });
 
-  test("exec rejects on non-zero exit", async function () {
+  test("exec rejects on non-zero exit", async function() {
     await expect(executor.exec("false")).rejects.toThrow();
   });
 
-  test("spawn returns a ChildProcess", function () {
+  test("spawn returns a ChildProcess", function() {
     const child = executor.spawn("echo", ["hi"]);
     expect(child).toBeDefined();
     expect(typeof child.pid).toBe("number");
@@ -32,16 +32,16 @@ describe("DefaultProcessExecutor", function () {
   });
 });
 
-describe("DefaultHostCommandExecutor", function () {
+describe("DefaultHostCommandExecutor", function() {
   const executor = new DefaultHostCommandExecutor();
 
-  test("executeCommand captures stdout", async function () {
+  test("executeCommand captures stdout", async function() {
     const result = await executor.executeCommand("echo", ["hello"]);
     expect(result.stdout.trim()).toBe("hello");
     expect(result.stderr).toBe("");
   });
 
-  test("executeCommand ExecResult helpers work", async function () {
+  test("executeCommand ExecResult helpers work", async function() {
     const result = await executor.executeCommand("echo", ["world"]);
     expect(result.trim()).toBe("world");
     expect(result.toString()).toContain("world");
@@ -49,11 +49,11 @@ describe("DefaultHostCommandExecutor", function () {
     expect(result.includes("nope")).toBe(false);
   });
 
-  test("executeCommand rejects on non-zero exit", async function () {
+  test("executeCommand rejects on non-zero exit", async function() {
     await expect(executor.executeCommand("false")).rejects.toThrow();
   });
 
-  test("executeCommand passes multiple args", async function () {
+  test("executeCommand passes multiple args", async function() {
     const result = await executor.executeCommand(process.execPath, ["-e", "console.log('foo bar')"]);
     expect(result.stdout.trim()).toBe("foo bar");
   });


### PR DESCRIPTION
## Summary
- Replace `usesMutableLatestRelease()` with a versioned checksum registry (`RELEASE_CHECKSUM_REGISTRY`) — an ordered array of `{ version, apkSha256, ipaSha256 }` entries, newest first (max 100)
- `"latest"` now resolves to `registry[0]` so checksums are always verified, fixing stale iOS CtrlProxy bundles that were never re-downloaded
- Download failures for `"latest"` gracefully fall back to the cached bundle
- Updated `generate-release-constants.sh` to prepend new registry entries instead of sed-replacing scalar constants

## Test plan
- [x] `turbo run lint build test` — 3717 tests pass, 0 failures
- [x] `shellcheck scripts/generate-release-constants.sh` — clean
- [x] No remaining references to `usesMutableLatestRelease` in src/ or test/
- [ ] Delete `~/.automobile/ctrl-proxy-ios/` and restart MCP server — should download latest and cache with checksum
- [ ] Modify registry[0] checksum to wrong value — `needsRebuild()` should return true and re-download

🤖 Generated with [Claude Code](https://claude.com/claude-code)