### PR TITLE
chore: bump versions to v0.0.19

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -14,7 +14,7 @@
       "name": "auto-mobile",
       "source": "./",
       "description": "Mobile device automation for Android and iOS - control devices with natural language",
-      "version": "0.0.18",
+      "version": "0.0.19",
       "author": {
         "name": "AutoMobile Contributors",
         "email": "jason.d.pearson@gmail.com"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "auto-mobile",
   "description": "Mobile device automation for Android and iOS - control devices with natural language",
-  "version": "0.0.18",
+  "version": "0.0.19",
   "author": {
     "name": "AutoMobile Contributors",
     "email": "jason.d.pearson@gmail.com"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## [v0.0.19] - 2026-04-29
+### Other
+- Daemon leaks unix-domain socket FDs; accepted peers never closed (backpressure + keepalive gap) ([#2008](https://github.com/kaeawc/auto-mobile/issues/2008))
+- CI cannot configure daemon flags without pre-starting manually - no JUnit runner integration ([#1971](https://github.com/kaeawc/auto-mobile/issues/1971))
+- No way to programmatically close the notification shade - pressButton "back" is fragile ([#1969](https://github.com/kaeawc/auto-mobile/issues/1969))
+- No MCP tool for granting Android runtime permissions - permission dialogs block CI tests ([#1965](https://github.com/kaeawc/auto-mobile/issues/1965))
+- observe waitFor matches wrong element in lists - no way to scope by container ([#1962](https://github.com/kaeawc/auto-mobile/issues/1962))
+- No screen state captured when executePlan step fails - blind debugging in CI ([#1957](https://github.com/kaeawc/auto-mobile/issues/1957))
+- tapOn silently taps stale coordinates when accessibility tree changes between observe and tap ([#1948](https://github.com/kaeawc/auto-mobile/issues/1948))
+- Emulator crash leaves active sessions hanging until full MCP timeout ([#1945](https://github.com/kaeawc/auto-mobile/issues/1945))
+- ECONNREFUSED on daemon MCP hop due to IPv4/IPv6 mismatch on Linux CI ([#1938](https://github.com/kaeawc/auto-mobile/issues/1938))
+- Add AutoMobileAPI protocol and default implementation for dependency injection ([#1937](https://github.com/kaeawc/auto-mobile/issues/1937))
+- Add delegate-based network recording API as primary integration path ([#1936](https://github.com/kaeawc/auto-mobile/issues/1936))
+- Add configuration options to disable crash/signal handler subsystems ([#1935](https://github.com/kaeawc/auto-mobile/issues/1935))
+- Add AutoMobileSDK product to root Package.swift for SPM consumers ([#1934](https://github.com/kaeawc/auto-mobile/issues/1934))
+- iOS SDK walker: surface visual properties for pure SwiftUI shapes via CALayer introspection ([#1926](https://github.com/kaeawc/auto-mobile/issues/1926))
+
 ## [v0.0.18] - 2026-04-17
 ### Other
 - iOS: text entry fails despite focused UITextField with react native ([#1925](https://github.com/kaeawc/auto-mobile/issues/1925))

--- a/android/control-proxy/build.gradle.kts
+++ b/android/control-proxy/build.gradle.kts
@@ -36,7 +36,7 @@ android {
     minSdk = libs.versions.build.android.minSdk.get().toInt()
     targetSdk = libs.versions.build.android.targetSdk.get().toInt()
     versionCode = 1
-    versionName = "0.0.18-SNAPSHOT"
+    versionName = "0.0.19-SNAPSHOT"
 
     testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
   }

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -140,7 +140,7 @@ org.jetbrains.dokka.experimental.gradle.pluginMode=V2Enabled
 # Maven Central Publishing
 
 # Library versions (single source of truth)
-VERSION_NAME=0.0.18-SNAPSHOT
+VERSION_NAME=0.0.19-SNAPSHOT
 GROUP=dev.jasonpearson.auto-mobile
 
 # POM metadata

--- a/android/playground/app/build.gradle.kts
+++ b/android/playground/app/build.gradle.kts
@@ -36,7 +36,7 @@ android {
     minSdk = libs.versions.build.android.minSdk.get().toInt()
     targetSdk = libs.versions.build.android.targetSdk.get().toInt()
     versionCode = 1
-    versionName = "0.0.18-SNAPSHOT"
+    versionName = "0.0.19-SNAPSHOT"
 
     testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kaeawc/auto-mobile",
-  "version": "0.0.18",
+  "version": "0.0.19",
   "description": "Mobile device interaction automation via MCP",
   "scripts": {
     "test": "bun test",

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "dev.jasonpearson/auto-mobile",
   "title": "AutoMobile",
   "description": "Mobile device interaction automation via MCP",
-  "version": "0.0.18",
+  "version": "0.0.19",
   "websiteUrl": "https://kaeawc.github.io/auto-mobile/",
   "repository": {
     "url": "https://github.com/kaeawc/auto-mobile",
@@ -13,7 +13,7 @@
     {
       "registryType": "npm",
       "identifier": "@kaeawc/auto-mobile",
-      "version": "0.0.18",
+      "version": "0.0.19",
       "runtimeHint": "bunx",
       "transport": {
         "type": "stdio"


### PR DESCRIPTION
## Summary
- Bump versions to v0.0.19
- Update CHANGELOG.md from closed issues since the last tag
- Refresh CtrlProxy APK SHA256 checksum
- Refresh CtrlProxy iOS IPA SHA256 checksum

## Automation
- Generated by `prepare-release` workflow