### PR TITLE
fix: bootstrap env and expose getAdbPathOnly for doctor

### DIFF
--- a/schemas/tool-definitions.json
+++ b/schemas/tool-definitions.json
@@ -37,6 +37,14 @@
           "description": "How long the SDK override remains active in milliseconds (default: 5000). The override is cleared after the first authentication callback or when the TTL expires.",
           "type": "number"
         },
+        "platform": {
+          "type": "string",
+          "enum": [
+            "android",
+            "ios"
+          ],
+          "description": "Target platform"
+        },
         "sessionUuid": {
           "description": "Session UUID",
           "type": "string"
@@ -344,6 +352,14 @@
           "items": {
             "type": "string"
           }
+        },
+        "platform": {
+          "type": "string",
+          "enum": [
+            "android",
+            "ios"
+          ],
+          "description": "Target platform"
         },
         "sessionUuid": {
           "description": "Session UUID",
@@ -848,6 +864,14 @@
             "minLength": 1
           }
         },
+        "platform": {
+          "type": "string",
+          "enum": [
+            "android",
+            "ios"
+          ],
+          "description": "Target platform"
+        },
         "sessionUuid": {
           "description": "Session UUID",
           "type": "string"
@@ -881,6 +905,14 @@
         "appId": {
           "type": "string",
           "description": "App package ID"
+        },
+        "platform": {
+          "type": "string",
+          "enum": [
+            "android",
+            "ios"
+          ],
+          "description": "Target platform"
         },
         "sessionUuid": {
           "description": "Session UUID",
@@ -922,6 +954,14 @@
             ]
           }
         },
+        "platform": {
+          "type": "string",
+          "enum": [
+            "android",
+            "ios"
+          ],
+          "description": "Target platform"
+        },
         "sessionUuid": {
           "description": "Session UUID",
           "type": "string"
@@ -953,6 +993,14 @@
           "type": "string",
           "minLength": 1,
           "description": "App package ID or bundle identifier"
+        },
+        "platform": {
+          "type": "string",
+          "enum": [
+            "android",
+            "ios"
+          ],
+          "description": "Target platform"
         },
         "sessionUuid": {
           "description": "Session UUID",
@@ -1802,6 +1850,14 @@
           "type": "string",
           "description": "Path to app artifact (.apk for Android, .app bundle for iOS simulator, .ipa for iOS physical device)"
         },
+        "platform": {
+          "type": "string",
+          "enum": [
+            "android",
+            "ios"
+          ],
+          "description": "Target platform"
+        },
         "sessionUuid": {
           "description": "Session UUID",
           "type": "string"
@@ -1932,6 +1988,14 @@
         "coldBoot": {
           "description": "Cold boot app (default false)",
           "type": "boolean"
+        },
+        "platform": {
+          "type": "string",
+          "enum": [
+            "android",
+            "ios"
+          ],
+          "description": "Target platform"
         },
         "sessionUuid": {
           "description": "Session UUID",
@@ -4425,6 +4489,14 @@
             "deny"
           ]
         },
+        "platform": {
+          "type": "string",
+          "enum": [
+            "android",
+            "ios"
+          ],
+          "description": "Target platform"
+        },
         "sessionUuid": {
           "description": "Session UUID",
           "type": "string"
@@ -4476,6 +4548,14 @@
           },
           "additionalProperties": false
         },
+        "platform": {
+          "type": "string",
+          "enum": [
+            "android",
+            "ios"
+          ],
+          "description": "Target platform"
+        },
         "sessionUuid": {
           "description": "Session UUID",
           "type": "string"
@@ -4511,6 +4591,14 @@
         "policyAccess": {
           "type": "boolean",
           "description": "Android only: allow or revoke app notification policy / DND access"
+        },
+        "platform": {
+          "type": "string",
+          "enum": [
+            "android",
+            "ios"
+          ],
+          "description": "Target platform"
         },
         "sessionUuid": {
           "description": "Session UUID",
@@ -6885,6 +6973,14 @@
           "type": "string",
           "description": "App package ID"
         },
+        "platform": {
+          "type": "string",
+          "enum": [
+            "android",
+            "ios"
+          ],
+          "description": "Target platform"
+        },
         "sessionUuid": {
           "description": "Session UUID",
           "type": "string"
@@ -6922,6 +7018,14 @@
         "keepData": {
           "description": "Keep app data after uninstall (Android only, default false)",
           "type": "boolean"
+        },
+        "platform": {
+          "type": "string",
+          "enum": [
+            "android",
+            "ios"
+          ],
+          "description": "Target platform"
         },
         "sessionUuid": {
           "description": "Session UUID",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,9 @@
 #!/usr/bin/env bun
+import { bootstrapEnvironment } from "./utils/envBootstrap";
+
+// Run before any other imports that may resolve tool paths at module load time.
+bootstrapEnvironment();
+
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { createMcpServer } from "./server";
 import { createProxyMcpServer } from "./server/proxyServer";

--- a/src/utils/android-cmdline-tools/AdbClient.ts
+++ b/src/utils/android-cmdline-tools/AdbClient.ts
@@ -211,6 +211,14 @@ export class AdbClient implements AdbExecutor {
   }
 
   /**
+   * Public accessor for the resolved adb path. Same detection as `ensureAdbPath`,
+   * exposed for diagnostics that want the path without running an adb command.
+   */
+  async getAdbPathOnly(): Promise<string> {
+    return this.ensureAdbPath();
+  }
+
+  /**
    * Ensure ADB path is properly detected and cached
    */
   private async ensureAdbPath(): Promise<string> {

--- a/src/utils/android-cmdline-tools/interfaces/AdbExecutor.ts
+++ b/src/utils/android-cmdline-tools/interfaces/AdbExecutor.ts
@@ -50,4 +50,10 @@ export interface AdbExecutor {
    * @returns Promise with { packageName: string, userId: number } or null if no app in foreground
    */
   getForegroundApp(): Promise<{ packageName: string; userId: number } | null>;
+
+  /**
+   * Resolve and return the path to the `adb` binary without executing a command.
+   * Used by diagnostics (doctor) to surface the detected path.
+   */
+  getAdbPathOnly(): Promise<string>;
 }

--- a/src/utils/envBootstrap.ts
+++ b/src/utils/envBootstrap.ts
@@ -1,0 +1,132 @@
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+
+/**
+ * Bootstrap process.env so spawn/exec can find platform tooling even when the
+ * MCP server is launched with a stripped environment (e.g. by an embedding host
+ * that does not forward the user's shell PATH).
+ *
+ * - Adds standard system bin directories to PATH.
+ * - Defaults ANDROID_HOME to the conventional per-OS SDK install location when
+ *   it is not already set and the directory exists.
+ *
+ * Safe to call multiple times; only adds entries that are missing.
+ */
+export function bootstrapEnvironment(): void {
+  ensureSystemPath();
+  ensureAndroidHome();
+}
+
+function ensureSystemPath(): void {
+  const sep = path.delimiter;
+  const current = process.env.PATH ?? "";
+  const existing = new Set(current.split(sep).filter(Boolean));
+
+  const candidates = systemPathCandidates();
+  const additions: string[] = [];
+  for (const candidate of candidates) {
+    if (!existing.has(candidate) && directoryExists(candidate)) {
+      additions.push(candidate);
+      existing.add(candidate);
+    }
+  }
+
+  if (additions.length === 0) {
+    return;
+  }
+
+  process.env.PATH = current.length > 0
+    ? `${current}${sep}${additions.join(sep)}`
+    : additions.join(sep);
+}
+
+function ensureAndroidHome(): void {
+  if (process.env.ANDROID_HOME || process.env.ANDROID_SDK_ROOT) {
+    return;
+  }
+
+  for (const candidate of androidHomeCandidates()) {
+    if (directoryExists(candidate)) {
+      process.env.ANDROID_HOME = candidate;
+      return;
+    }
+  }
+}
+
+function systemPathCandidates(): string[] {
+  const platform = process.platform;
+  const home = os.homedir();
+
+  if (platform === "darwin") {
+    return [
+      "/usr/bin",
+      "/bin",
+      "/usr/sbin",
+      "/sbin",
+      "/usr/local/bin",
+      "/usr/local/sbin",
+      "/opt/homebrew/bin",
+      "/opt/homebrew/sbin",
+      path.join(home, "Library/Android/sdk/platform-tools"),
+      path.join(home, "Library/Android/sdk/emulator"),
+      path.join(home, "Library/Android/sdk/cmdline-tools/latest/bin"),
+    ];
+  }
+
+  if (platform === "linux") {
+    return [
+      "/usr/bin",
+      "/bin",
+      "/usr/sbin",
+      "/sbin",
+      "/usr/local/bin",
+      "/usr/local/sbin",
+      path.join(home, "Android/Sdk/platform-tools"),
+      path.join(home, "Android/Sdk/emulator"),
+      path.join(home, "Android/Sdk/cmdline-tools/latest/bin"),
+    ];
+  }
+
+  if (platform === "win32") {
+    const localAppData = process.env.LOCALAPPDATA;
+    const sdk = localAppData ? path.join(localAppData, "Android", "Sdk") : "";
+    return [
+      ...(sdk ? [
+        path.join(sdk, "platform-tools"),
+        path.join(sdk, "emulator"),
+        path.join(sdk, "cmdline-tools", "latest", "bin"),
+      ] : []),
+    ];
+  }
+
+  return [];
+}
+
+function androidHomeCandidates(): string[] {
+  const home = os.homedir();
+  const platform = process.platform;
+
+  if (platform === "darwin") {
+    return [path.join(home, "Library/Android/sdk")];
+  }
+
+  if (platform === "linux") {
+    return [path.join(home, "Android/Sdk")];
+  }
+
+  if (platform === "win32") {
+    const localAppData = process.env.LOCALAPPDATA;
+    return localAppData ? [path.join(localAppData, "Android", "Sdk")] : [];
+  }
+
+  return [];
+}
+
+function directoryExists(p: string): boolean {
+  try {
+    return fs.statSync(p).isDirectory();
+  } catch {
+    return false;
+  }
+}

--- a/src/utils/ios-cmdline-tools/SimCtlClient.ts
+++ b/src/utils/ios-cmdline-tools/SimCtlClient.ts
@@ -473,7 +473,9 @@ export class SimCtlClient implements SimCtl {
     try {
       await this.execAsync("xcrun", ["simctl", "--version"]);
       return true;
-    } catch {
+    } catch (err) {
+      logger.warn(`[iOS] isLocalSimctlAvailable failed: ${err instanceof Error ? `${err.message} (code=${(err as NodeJS.ErrnoException).code}, syscall=${(err as NodeJS.ErrnoException).syscall}, path=${(err as NodeJS.ErrnoException).path})` : String(err)}`);
+      logger.warn(`[iOS] PATH at failure: ${process.env.PATH ?? "(unset)"}`);
       return false;
     }
   }

--- a/test/fakes/FakeAdbExecutor.ts
+++ b/test/fakes/FakeAdbExecutor.ts
@@ -222,4 +222,8 @@ export class FakeAdbExecutor implements AdbExecutor {
   async getDeviceTimestampMs(): Promise<number> {
     return this.deviceTimestampMs ?? Date.now();
   }
+
+  async getAdbPathOnly(): Promise<string> {
+    return "adb";
+  }
 }

--- a/test/utils/AccessibilityDetector.test.ts
+++ b/test/utils/AccessibilityDetector.test.ts
@@ -56,6 +56,10 @@ class FakeAdbExecutor implements AdbExecutor {
     return null;
   }
 
+  async getAdbPathOnly(): Promise<string> {
+    return "adb";
+  }
+
   getCallCount(): number {
     return this.callCount;
   }


### PR DESCRIPTION
## Summary
- Add `bootstrapEnvironment()` invoked at process entry to augment `process.env.PATH` with standard system bin dirs and default `ANDROID_HOME` to the conventional per-OS SDK location when unset. Lets the MCP server resolve `xcrun`/`adb`/`emulator` without requiring the embedding host (Claude Desktop, Cursor, etc.) to forward the user's shell env.
- Add `AdbExecutor.getAdbPathOnly()` and implement on `AdbClient`. The Android doctor at `src/doctor/checks/android.ts:195` was calling a method that didn't exist on the interface, surfacing as `"$.create().getAdbPathOnly is not a function"` and failing the `ADB Installation` check even when adb was present.
- Surface the underlying error from `SimCtlClient.isLocalSimctlAvailable()` instead of swallowing it silently — makes future "simctl is not available" reports actionable.

## Test plan
- [x] \`bunx turbo run lint\` passes
- [x] \`bunx turbo run build\` passes
- [x] Doctor's ADB Installation check no longer fails with "getAdbPathOnly is not a function"
- [x] Manually verified: published-bundle MCP server can list iOS simulators, launch the Playground app, tap the search bar and run \`inputText\` end-to-end on iPhone 16 Pro / iOS 18.6 (after killing a stale long-running daemon that was masking the env improvements)