### PR TITLE
fix: restart daemon when MCP server is newer than running daemon

### DIFF
--- a/src/daemon/constants.ts
+++ b/src/daemon/constants.ts
@@ -98,6 +98,13 @@ export const DAEMON_STARTUP_TIMEOUT_MS =
 export const DAEMON_SHUTDOWN_TIMEOUT_MS = 5000;
 
 /**
+ * Minimum age (ms since startedAt) before the proxy will restart a daemon on
+ * version mismatch. Prevents thrash when concurrent agents on different versions
+ * each try to "fix" the daemon to their own version.
+ */
+export const DAEMON_VERSION_RESTART_COOLDOWN_MS = 10000;
+
+/**
  * MCP streamable endpoint path
  */
 export const MCP_STREAMABLE_PATH = "/auto-mobile/streamable";

--- a/src/daemon/daemonMcpProxy.ts
+++ b/src/daemon/daemonMcpProxy.ts
@@ -1,8 +1,9 @@
 import { DaemonClient, DaemonUnavailableError, type DaemonClientLike, type DaemonClientFactory } from "./client";
-import { DaemonManager } from "./manager";
+import { DaemonManager, type DaemonManagerLike } from "./manager";
 import { logger } from "../utils/logger";
-import { SOCKET_PATH, DAEMON_STARTUP_TIMEOUT_MS, CONNECTION_TIMEOUT_MS } from "./constants";
+import { SOCKET_PATH, DAEMON_STARTUP_TIMEOUT_MS, CONNECTION_TIMEOUT_MS, DAEMON_VERSION, DAEMON_VERSION_RESTART_COOLDOWN_MS } from "./constants";
 import type { DaemonOptions } from "./types";
+import { compareVersions } from "../server/deviceMatcher";
 
 /**
  * Configuration for the DaemonMcpProxy
@@ -17,7 +18,7 @@ export interface DaemonMcpProxyConfig {
   /** Factory for creating daemon clients (for testing) */
   clientFactory?: DaemonClientFactory;
   /** Custom daemon manager (for testing) */
-  daemonManager?: DaemonManager;
+  daemonManager?: DaemonManagerLike;
   /** Options to pass when auto-starting the daemon */
   daemonOptions?: DaemonOptions;
 }
@@ -64,7 +65,7 @@ export interface ProxiedResourceTemplate {
 export class DaemonMcpProxy {
   private client: DaemonClientLike | null = null;
   private config: DaemonMcpProxyConfig;
-  private daemonManager: DaemonManager;
+  private daemonManager: DaemonManagerLike;
   private clientFactory: DaemonClientFactory;
   private connecting: Promise<void> | null = null;
   private connected: boolean = false;
@@ -116,14 +117,15 @@ export class DaemonMcpProxy {
     const isAvailable = await DaemonClient.isAvailable(socketPath);
 
     if (!isAvailable) {
-      if (this.config.autoStartDaemon) {
-        logger.info("[DaemonMcpProxy] Daemon not available, starting daemon...");
-        await this.startDaemon();
-      } else {
+      if (!this.config.autoStartDaemon) {
         throw new DaemonUnavailableError(
           "Daemon is not running and auto-start is disabled"
         );
       }
+      logger.info("[DaemonMcpProxy] Daemon not available, starting daemon...");
+      await this.startDaemon();
+    } else if (this.config.autoStartDaemon) {
+      await this.ensureVersionMatches();
     }
 
     // Create and connect client
@@ -131,6 +133,42 @@ export class DaemonMcpProxy {
     await this.client.connect();
     this.connected = true;
     logger.info("[DaemonMcpProxy] Connected to daemon");
+  }
+
+  /**
+   * Restart the daemon when this MCP server is strictly newer than the running daemon,
+   * so a newly-pinned or freshly-resolved-@latest client upgrades the shared daemon in place.
+   *
+   * "Newer wins, older connects anyway" — older clients attach to whatever's running,
+   * which prevents ping-pong restarts when concurrent agents are pinned to different versions.
+   *
+   * A cooldown (DAEMON_VERSION_RESTART_COOLDOWN_MS) on `startedAt` further suppresses
+   * thrash from racing restarts during a coordinated upgrade.
+   */
+  private async ensureVersionMatches(): Promise<void> {
+    const status = await this.daemonManager.status();
+    if (!status.running || !status.version) {
+      return;
+    }
+    if (compareVersions(DAEMON_VERSION, status.version) <= 0) {
+      return;
+    }
+    if (status.startedAt && Date.now() - status.startedAt < DAEMON_VERSION_RESTART_COOLDOWN_MS) {
+      logger.info(
+        `[DaemonMcpProxy] Daemon ${status.version} is older than ${DAEMON_VERSION} but was started ${Date.now() - status.startedAt}ms ago, skipping restart (cooldown)`
+      );
+      return;
+    }
+    logger.info(
+      `[DaemonMcpProxy] Daemon version ${status.version} is older than MCP server ${DAEMON_VERSION}, restarting daemon`
+    );
+    await this.daemonManager.restart(this.config.daemonOptions ?? {});
+    const ready = await this.daemonManager.waitForReady(DAEMON_STARTUP_TIMEOUT_MS);
+    if (!ready) {
+      throw new DaemonUnavailableError(
+        `Daemon failed to restart within ${DAEMON_STARTUP_TIMEOUT_MS}ms`
+      );
+    }
   }
 
   /**

--- a/src/daemon/daemonMcpProxy.ts
+++ b/src/daemon/daemonMcpProxy.ts
@@ -150,7 +150,9 @@ export class DaemonMcpProxy {
     if (!status.running || !status.version) {
       return;
     }
-    if (compareVersions(DAEMON_VERSION, status.version) <= 0) {
+    const cmp = compareVersions(DAEMON_VERSION, status.version);
+    // NaN means non-numeric version (prerelease tag, "unknown", etc.) — be conservative and skip.
+    if (!Number.isFinite(cmp) || cmp <= 0) {
       return;
     }
     if (status.startedAt && Date.now() - status.startedAt < DAEMON_VERSION_RESTART_COOLDOWN_MS) {

--- a/src/daemon/manager.ts
+++ b/src/daemon/manager.ts
@@ -392,10 +392,21 @@ export class DaemonManager implements DaemonManagerLike {
     // Open with restricted permissions (0o600 = owner read/write only)
     const logFd = openSync(logPath, "w", 0o600);
 
+    // Propagate any non-default file paths to the child so its constants module
+    // resolves to the same locations this manager polls.
+    const childEnv = { ...process.env };
+    if (this.pidFilePath !== PID_FILE_PATH) {
+      childEnv.AUTOMOBILE_DAEMON_PID_FILE_PATH = this.pidFilePath;
+    }
+    if (this.lockFilePath !== LOCK_FILE_PATH) {
+      childEnv.AUTOMOBILE_DAEMON_LOCK_FILE_PATH = this.lockFilePath;
+    }
+
     const daemonProcess = spawn(autoMobileCmd, args, {
       detached: true,
       stdio: ["ignore", logFd, logFd], // Write stdout/stderr to log file
       shell: true, // Use shell to resolve command from PATH
+      env: childEnv,
     });
 
     // Close our reference to the log file (daemon process still has it open)

--- a/src/daemon/manager.ts
+++ b/src/daemon/manager.ts
@@ -46,6 +46,17 @@ function stderrLog(message: string): void {
 }
 
 /**
+ * Surface of DaemonManager used by clients (e.g. DaemonMcpProxy).
+ * Allows injecting fakes in tests without subclassing the concrete class.
+ */
+export interface DaemonManagerLike {
+  status(): Promise<DaemonStatus>;
+  start(options?: DaemonOptions): Promise<void>;
+  restart(options?: DaemonOptions): Promise<void>;
+  waitForReady(timeout: number): Promise<boolean>;
+}
+
+/**
  * Daemon Manager
  *
  * Handles daemon lifecycle:
@@ -54,22 +65,25 @@ function stderrLog(message: string): void {
  * - Check daemon status
  * - Restart daemon
  */
-export class DaemonManager {
+export class DaemonManager implements DaemonManagerLike {
   private readonly clientFactory: DaemonClientFactory;
   private readonly stateProvider: () => DaemonStateLike;
   private readonly timer: Timer;
   private readonly lockFilePath: string;
+  private readonly pidFilePath: string;
 
   constructor(
     clientFactory: DaemonClientFactory = () => new DaemonClient(),
     stateProvider: () => DaemonStateLike = () => DaemonState.getInstance(),
     timer: Timer = defaultTimer,
-    lockFilePath: string = LOCK_FILE_PATH
+    lockFilePath: string = LOCK_FILE_PATH,
+    pidFilePath: string = PID_FILE_PATH
   ) {
     this.clientFactory = clientFactory;
     this.stateProvider = stateProvider;
     this.timer = timer;
     this.lockFilePath = lockFilePath;
+    this.pidFilePath = pidFilePath;
   }
 
   /**
@@ -266,10 +280,10 @@ export class DaemonManager {
         logger.warn(`Failed to remove stale socket file: ${error instanceof Error ? error.message : String(error)}`);
       }
     }
-    if (existsSync(PID_FILE_PATH)) {
+    if (existsSync(this.pidFilePath)) {
       logger.debug("Removing stale PID file");
       try {
-        await unlink(PID_FILE_PATH);
+        await unlink(this.pidFilePath);
       } catch (error) {
         logger.warn(`Failed to remove stale PID file: ${error instanceof Error ? error.message : String(error)}`);
       }
@@ -437,8 +451,8 @@ export class DaemonManager {
       }
 
       // Clean up stale PID file if it exists
-      if (existsSync(PID_FILE_PATH)) {
-        await unlink(PID_FILE_PATH);
+      if (existsSync(this.pidFilePath)) {
+        await unlink(this.pidFilePath);
       }
 
       stderrLog("Daemon stopped");
@@ -449,8 +463,8 @@ export class DaemonManager {
         (error.message.includes("ESRCH") || error.message.includes("EPERM"))
       ) {
         // Clean up stale PID file
-        if (existsSync(PID_FILE_PATH)) {
-          await unlink(PID_FILE_PATH);
+        if (existsSync(this.pidFilePath)) {
+          await unlink(this.pidFilePath);
         }
         stderrLog("Daemon was not running (cleaned up stale PID file)");
       } else {
@@ -464,13 +478,13 @@ export class DaemonManager {
    */
   async status(): Promise<DaemonStatus> {
     // Check if PID file exists
-    if (!existsSync(PID_FILE_PATH)) {
+    if (!existsSync(this.pidFilePath)) {
       return { running: false };
     }
 
     try {
       // Read PID file
-      const pidFileContent = await readFile(PID_FILE_PATH, "utf-8");
+      const pidFileContent = await readFile(this.pidFilePath, "utf-8");
       const pidData: PidFileData = JSON.parse(pidFileContent);
 
       // Check if process is actually running
@@ -478,7 +492,7 @@ export class DaemonManager {
 
       if (!running) {
         // Clean up stale PID file
-        await unlink(PID_FILE_PATH);
+        await unlink(this.pidFilePath);
         return { running: false };
       }
 
@@ -564,13 +578,13 @@ export class DaemonManager {
    * Get daemon PID from lock file
    */
   getPid(): number | null {
-    if (!existsSync(PID_FILE_PATH)) {
+    if (!existsSync(this.pidFilePath)) {
       return null;
     }
 
     try {
       const pidFileContent = require("fs").readFileSync(
-        PID_FILE_PATH,
+        this.pidFilePath,
         "utf-8"
       );
       const pidData: PidFileData = JSON.parse(pidFileContent);

--- a/test/daemon/daemonMcpProxy.test.ts
+++ b/test/daemon/daemonMcpProxy.test.ts
@@ -1,87 +1,13 @@
 import { describe, expect, test, spyOn } from "bun:test";
 import { DaemonMcpProxy } from "../../src/daemon/daemonMcpProxy";
-import { DaemonManager } from "../../src/daemon/manager";
-import type { DaemonClientLike } from "../../src/daemon/client";
 import { DaemonClient, DaemonUnavailableError } from "../../src/daemon/client";
+import { DAEMON_VERSION, DAEMON_VERSION_RESTART_COOLDOWN_MS } from "../../src/daemon/constants";
+import { FakeDaemonManager } from "../fakes/FakeDaemonManager";
+import { FakeDaemonClient } from "../fakes/FakeDaemonClient";
 
-/**
- * Fake DaemonClient for testing
- */
-class FakeDaemonClient implements DaemonClientLike {
-  readonly callToolCalls: Array<{ toolName: string; params: Record<string, any> }> = [];
-  readonly readResourceCalls: string[] = [];
-  readonly callDaemonMethodCalls: Array<{ method: string; params: Record<string, any> }> = [];
-  private connected = false;
-  private toolResult: any;
-  private resourceResult: any;
-  private daemonMethodResults: Map<string, any> = new Map();
-  shouldFailConnect = false;
-
-  constructor(options: {
-    toolResult?: any;
-    resourceResult?: any;
-    daemonMethodResults?: Map<string, any>;
-  } = {}) {
-    this.toolResult = options.toolResult ?? { content: [{ type: "text", text: "success" }] };
-    this.resourceResult = options.resourceResult ?? { contents: [{ uri: "test", text: "test" }] };
-    this.daemonMethodResults = options.daemonMethodResults ?? new Map();
-  }
-
-  async connect(): Promise<void> {
-    if (this.shouldFailConnect) {
-      throw new DaemonUnavailableError("Connection failed");
-    }
-    this.connected = true;
-  }
-
-  async close(): Promise<void> {
-    this.connected = false;
-  }
-
-  async callTool(toolName: string, params: Record<string, any>): Promise<any> {
-    this.callToolCalls.push({ toolName, params });
-    return this.toolResult;
-  }
-
-  async readResource(uri: string): Promise<any> {
-    this.readResourceCalls.push(uri);
-    return this.resourceResult;
-  }
-
-  async callDaemonMethod(method: string, params: Record<string, any>): Promise<any> {
-    this.callDaemonMethodCalls.push({ method, params });
-    return this.daemonMethodResults.get(method) ?? {};
-  }
-
-  isConnected(): boolean {
-    return this.connected;
-  }
-}
-
-/**
- * Fake DaemonManager for testing
- */
-class FakeDaemonManager extends DaemonManager {
-  statusResult = { running: true, pid: 1234, port: 3000, socketPath: "/tmp/test.sock" };
-  startCalled = false;
-  waitForReadyResult = true;
-
-  constructor() {
-    super();
-  }
-
-  override async status() {
-    return this.statusResult;
-  }
-
-  override async start() {
-    this.startCalled = true;
-  }
-
-  override async waitForReady(_timeout: number) {
-    return this.waitForReadyResult;
-  }
-}
+const OLDER_VERSION = "0.0.1";
+const NEWER_VERSION = "9999.0.0";
+const ANCIENT_TIMESTAMP = 1;
 
 describe("DaemonMcpProxy", () => {
   describe("connection management", () => {
@@ -144,6 +70,173 @@ describe("DaemonMcpProxy", () => {
         isAvailableSpy.mockRestore();
         await proxy.close();
       }
+    });
+
+    describe("version-mismatch handling", () => {
+      function makeProxy(opts: {
+        runningVersion?: string;
+        startedAt?: number;
+        autoStartDaemon?: boolean;
+        waitForReadyResult?: boolean;
+        daemonOptions?: { debug?: boolean; port?: number };
+      } = {}) {
+        const fakeClient = new FakeDaemonClient({
+          daemonMethodResults: new Map([["tools/list", { tools: [] }]]),
+        });
+        const fakeManager = new FakeDaemonManager();
+        fakeManager.statusResult = {
+          running: true,
+          pid: 1234,
+          port: 3000,
+          socketPath: "/tmp/test.sock",
+          ...(opts.runningVersion !== undefined ? { version: opts.runningVersion } : {}),
+          ...(opts.startedAt !== undefined ? { startedAt: opts.startedAt } : {}),
+        };
+        if (opts.waitForReadyResult !== undefined) {
+          fakeManager.waitForReadyResult = opts.waitForReadyResult;
+        }
+        const isAvailableSpy = spyOn(DaemonClient, "isAvailable").mockResolvedValue(true);
+        const proxy = new DaemonMcpProxy({
+          clientFactory: () => fakeClient,
+          daemonManager: fakeManager,
+          autoStartDaemon: opts.autoStartDaemon ?? true,
+          daemonOptions: opts.daemonOptions,
+        });
+        return { fakeClient, fakeManager, isAvailableSpy, proxy };
+      }
+
+      test("restarts daemon when MCP server version is newer", async () => {
+        const { fakeManager, isAvailableSpy, proxy } = makeProxy({
+          runningVersion: OLDER_VERSION,
+          startedAt: ANCIENT_TIMESTAMP,
+        });
+        try {
+          await proxy.listTools();
+          expect(fakeManager.restartCalled).toBe(true);
+        } finally {
+          isAvailableSpy.mockRestore();
+          await proxy.close();
+        }
+      });
+
+      test("does not restart when daemon version is newer (older client connects anyway)", async () => {
+        const { fakeClient, fakeManager, isAvailableSpy, proxy } = makeProxy({
+          runningVersion: NEWER_VERSION,
+          startedAt: ANCIENT_TIMESTAMP,
+        });
+        try {
+          await proxy.listTools();
+          expect(fakeManager.restartCalled).toBe(false);
+          expect(fakeClient.isConnected()).toBe(true);
+        } finally {
+          isAvailableSpy.mockRestore();
+          await proxy.close();
+        }
+      });
+
+      test("does not restart when versions match", async () => {
+        const { fakeManager, isAvailableSpy, proxy } = makeProxy({
+          runningVersion: DAEMON_VERSION,
+          startedAt: ANCIENT_TIMESTAMP,
+        });
+        try {
+          await proxy.listTools();
+          expect(fakeManager.restartCalled).toBe(false);
+        } finally {
+          isAvailableSpy.mockRestore();
+          await proxy.close();
+        }
+      });
+
+      test("does not restart when daemon is older but within cooldown window", async () => {
+        const { fakeClient, fakeManager, isAvailableSpy, proxy } = makeProxy({
+          runningVersion: OLDER_VERSION,
+          startedAt: Date.now() - Math.floor(DAEMON_VERSION_RESTART_COOLDOWN_MS / 2),
+        });
+        try {
+          await proxy.listTools();
+          expect(fakeManager.restartCalled).toBe(false);
+          expect(fakeClient.isConnected()).toBe(true);
+        } finally {
+          isAvailableSpy.mockRestore();
+          await proxy.close();
+        }
+      });
+
+      test("restarts older daemon once cooldown has elapsed", async () => {
+        const { fakeManager, isAvailableSpy, proxy } = makeProxy({
+          runningVersion: OLDER_VERSION,
+          startedAt: Date.now() - DAEMON_VERSION_RESTART_COOLDOWN_MS - 1000,
+        });
+        try {
+          await proxy.listTools();
+          expect(fakeManager.restartCalled).toBe(true);
+        } finally {
+          isAvailableSpy.mockRestore();
+          await proxy.close();
+        }
+      });
+
+      test("does not restart when autoStartDaemon is disabled, even when newer", async () => {
+        const { fakeClient, fakeManager, isAvailableSpy, proxy } = makeProxy({
+          runningVersion: OLDER_VERSION,
+          startedAt: ANCIENT_TIMESTAMP,
+          autoStartDaemon: false,
+        });
+        try {
+          await proxy.listTools();
+          expect(fakeManager.restartCalled).toBe(false);
+          expect(fakeClient.isConnected()).toBe(true);
+        } finally {
+          isAvailableSpy.mockRestore();
+          await proxy.close();
+        }
+      });
+
+      test("throws when restarted daemon fails to become ready", async () => {
+        const { fakeClient, fakeManager, isAvailableSpy, proxy } = makeProxy({
+          runningVersion: OLDER_VERSION,
+          startedAt: ANCIENT_TIMESTAMP,
+          waitForReadyResult: false,
+        });
+        try {
+          await expect(proxy.listTools()).rejects.toThrow(DaemonUnavailableError);
+          expect(fakeManager.restartCalled).toBe(true);
+          expect(fakeClient.isConnected()).toBe(false);
+        } finally {
+          isAvailableSpy.mockRestore();
+          await proxy.close();
+        }
+      });
+
+      test("forwards daemonOptions when restarting", async () => {
+        const { fakeManager, isAvailableSpy, proxy } = makeProxy({
+          runningVersion: OLDER_VERSION,
+          startedAt: ANCIENT_TIMESTAMP,
+          daemonOptions: { debug: true, port: 4242 },
+        });
+        try {
+          await proxy.listTools();
+          expect(fakeManager.restartCalled).toBe(true);
+          expect(fakeManager.restartOptions).toEqual({ debug: true, port: 4242 });
+        } finally {
+          isAvailableSpy.mockRestore();
+          await proxy.close();
+        }
+      });
+
+      test("does not restart when running daemon does not expose a version", async () => {
+        const { fakeManager, isAvailableSpy, proxy } = makeProxy({
+          startedAt: ANCIENT_TIMESTAMP,
+        });
+        try {
+          await proxy.listTools();
+          expect(fakeManager.restartCalled).toBe(false);
+        } finally {
+          isAvailableSpy.mockRestore();
+          await proxy.close();
+        }
+      });
     });
 
     test("throws error when auto-start is disabled and daemon not running", async () => {

--- a/test/daemon/daemonMcpProxy.test.ts
+++ b/test/daemon/daemonMcpProxy.test.ts
@@ -237,6 +237,24 @@ describe("DaemonMcpProxy", () => {
           await proxy.close();
         }
       });
+
+      test.each([
+        ["prerelease tag", "0.0.21-beta.1"],
+        ["unknown fallback", "unknown"],
+        ["empty-after-prefix", "v"],
+      ])("does not restart when version comparison is non-numeric (%s)", async (_label, runningVersion) => {
+        const { fakeManager, isAvailableSpy, proxy } = makeProxy({
+          runningVersion,
+          startedAt: ANCIENT_TIMESTAMP,
+        });
+        try {
+          await proxy.listTools();
+          expect(fakeManager.restartCalled).toBe(false);
+        } finally {
+          isAvailableSpy.mockRestore();
+          await proxy.close();
+        }
+      });
     });
 
     test("throws error when auto-start is disabled and daemon not running", async () => {

--- a/test/daemon/integration/versionMismatchRestart.test.ts
+++ b/test/daemon/integration/versionMismatchRestart.test.ts
@@ -1,0 +1,193 @@
+import { describe, expect, test, beforeEach, afterEach, spyOn } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { DaemonMcpProxy } from "../../../src/daemon/daemonMcpProxy";
+import { DaemonClient } from "../../../src/daemon/client";
+import { DaemonManager, type DaemonManagerLike } from "../../../src/daemon/manager";
+import { DAEMON_VERSION, DAEMON_VERSION_RESTART_COOLDOWN_MS } from "../../../src/daemon/constants";
+import type { DaemonOptions, DaemonStatus, PidFileData } from "../../../src/daemon/types";
+import { FakeDaemonClient } from "../../fakes/FakeDaemonClient";
+
+/**
+ * Integration test: real DaemonManager.status() reading a real PID file written
+ * to a temp path, exercising the proxy's version-mismatch decision end-to-end.
+ *
+ * The "is process running" check uses kill(pid, 0); we use process.pid so the
+ * PID is guaranteed to be alive for the duration of the test. The test stubs
+ * the spawn/restart side via a wrapper so no real daemon child is forked.
+ */
+describe("DaemonMcpProxy + real DaemonManager (version-mismatch integration)", () => {
+  let tempDir: string;
+  let pidFilePath: string;
+  let realManager: DaemonManager;
+  let isAvailableSpy: ReturnType<typeof spyOn>;
+
+  function writePidFile(fields: { version?: string; startedAt?: number }): void {
+    const data: PidFileData = {
+      pid: process.pid,
+      socketPath: join(tempDir, "test.sock"),
+      port: 0,
+      startedAt: fields.startedAt ?? 1,
+      version: fields.version ?? "",
+    };
+    writeFileSync(pidFilePath, JSON.stringify(data));
+  }
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), "automobile-version-test-"));
+    pidFilePath = join(tempDir, "test.pid");
+    realManager = new DaemonManager(undefined, undefined, undefined, undefined, pidFilePath);
+    isAvailableSpy = spyOn(DaemonClient, "isAvailable").mockResolvedValue(true);
+  });
+
+  afterEach(() => {
+    isAvailableSpy.mockRestore();
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  function makeTracked(): DaemonManagerLike & {
+    restartCalled: boolean;
+    restartOptions?: DaemonOptions;
+    startCalled: boolean;
+    waitForReadyResult: boolean;
+  } {
+    let restartCalled = false;
+    let restartOptions: DaemonOptions | undefined;
+    let startCalled = false;
+    const tracker: any = {
+      get restartCalled() { return restartCalled; },
+      get restartOptions() { return restartOptions; },
+      get startCalled() { return startCalled; },
+      waitForReadyResult: true,
+      async status(): Promise<DaemonStatus> {
+        return realManager.status();
+      },
+      async start(options?: DaemonOptions) {
+        startCalled = true;
+        restartOptions = options;
+      },
+      async restart(options?: DaemonOptions) {
+        restartCalled = true;
+        restartOptions = options;
+      },
+      async waitForReady() {
+        return tracker.waitForReadyResult;
+      },
+    };
+    return tracker;
+  }
+
+  test("real PID file with older version triggers restart", async () => {
+    writePidFile({ version: "0.0.1", startedAt: 1 });
+    const tracked = makeTracked();
+    const proxy = new DaemonMcpProxy({
+      clientFactory: () => new FakeDaemonClient(),
+      daemonManager: tracked,
+      autoStartDaemon: true,
+    });
+    try {
+      await proxy.listTools();
+      expect(tracked.restartCalled).toBe(true);
+    } finally {
+      await proxy.close();
+    }
+  });
+
+  test("real PID file with newer version does not trigger restart", async () => {
+    writePidFile({ version: "9999.0.0", startedAt: 1 });
+    const tracked = makeTracked();
+    const proxy = new DaemonMcpProxy({
+      clientFactory: () => new FakeDaemonClient(),
+      daemonManager: tracked,
+      autoStartDaemon: true,
+    });
+    try {
+      await proxy.listTools();
+      expect(tracked.restartCalled).toBe(false);
+    } finally {
+      await proxy.close();
+    }
+  });
+
+  test("real PID file with matching version does not trigger restart", async () => {
+    writePidFile({ version: DAEMON_VERSION, startedAt: 1 });
+    const tracked = makeTracked();
+    const proxy = new DaemonMcpProxy({
+      clientFactory: () => new FakeDaemonClient(),
+      daemonManager: tracked,
+      autoStartDaemon: true,
+    });
+    try {
+      await proxy.listTools();
+      expect(tracked.restartCalled).toBe(false);
+    } finally {
+      await proxy.close();
+    }
+  });
+
+  test("real PID file with older version inside cooldown window does not trigger restart", async () => {
+    writePidFile({
+      version: "0.0.1",
+      startedAt: Date.now() - Math.floor(DAEMON_VERSION_RESTART_COOLDOWN_MS / 2),
+    });
+    const tracked = makeTracked();
+    const proxy = new DaemonMcpProxy({
+      clientFactory: () => new FakeDaemonClient(),
+      daemonManager: tracked,
+      autoStartDaemon: true,
+    });
+    try {
+      await proxy.listTools();
+      expect(tracked.restartCalled).toBe(false);
+    } finally {
+      await proxy.close();
+    }
+  });
+
+  test("real PID file missing version field does not trigger restart", async () => {
+    const data = {
+      pid: process.pid,
+      socketPath: join(tempDir, "test.sock"),
+      port: 0,
+      startedAt: 1,
+    };
+    writeFileSync(pidFilePath, JSON.stringify(data));
+    const tracked = makeTracked();
+    const proxy = new DaemonMcpProxy({
+      clientFactory: () => new FakeDaemonClient(),
+      daemonManager: tracked,
+      autoStartDaemon: true,
+    });
+    try {
+      await proxy.listTools();
+      expect(tracked.restartCalled).toBe(false);
+    } finally {
+      await proxy.close();
+    }
+  });
+
+  test("PID file pointing at a dead PID is treated as not running, no restart attempted", async () => {
+    // PID 999999 is virtually never alive; status() should return running:false and unlink
+    const data: PidFileData = {
+      pid: 999999,
+      socketPath: join(tempDir, "test.sock"),
+      port: 0,
+      startedAt: 1,
+      version: "0.0.1",
+    };
+    writeFileSync(pidFilePath, JSON.stringify(data));
+    const tracked = makeTracked();
+    const proxy = new DaemonMcpProxy({
+      clientFactory: () => new FakeDaemonClient(),
+      daemonManager: tracked,
+      autoStartDaemon: true,
+    });
+    try {
+      await proxy.listTools();
+      expect(tracked.restartCalled).toBe(false);
+    } finally {
+      await proxy.close();
+    }
+  });
+});

--- a/test/fakes/FakeDaemonClient.ts
+++ b/test/fakes/FakeDaemonClient.ts
@@ -1,0 +1,55 @@
+import type { DaemonClientLike } from "../../src/daemon/client";
+import { DaemonUnavailableError } from "../../src/daemon/client";
+
+export interface FakeDaemonClientOptions {
+  toolResult?: any;
+  resourceResult?: any;
+  daemonMethodResults?: Map<string, any>;
+}
+
+export class FakeDaemonClient implements DaemonClientLike {
+  readonly callToolCalls: Array<{ toolName: string; params: Record<string, any> }> = [];
+  readonly readResourceCalls: string[] = [];
+  readonly callDaemonMethodCalls: Array<{ method: string; params: Record<string, any> }> = [];
+  private connected = false;
+  private toolResult: any;
+  private resourceResult: any;
+  private daemonMethodResults: Map<string, any>;
+  shouldFailConnect = false;
+
+  constructor(options: FakeDaemonClientOptions = {}) {
+    this.toolResult = options.toolResult ?? { content: [{ type: "text", text: "success" }] };
+    this.resourceResult = options.resourceResult ?? { contents: [{ uri: "test", text: "test" }] };
+    this.daemonMethodResults = options.daemonMethodResults ?? new Map();
+  }
+
+  async connect(): Promise<void> {
+    if (this.shouldFailConnect) {
+      throw new DaemonUnavailableError("Connection failed");
+    }
+    this.connected = true;
+  }
+
+  async close(): Promise<void> {
+    this.connected = false;
+  }
+
+  async callTool(toolName: string, params: Record<string, any>): Promise<any> {
+    this.callToolCalls.push({ toolName, params });
+    return this.toolResult;
+  }
+
+  async readResource(uri: string): Promise<any> {
+    this.readResourceCalls.push(uri);
+    return this.resourceResult;
+  }
+
+  async callDaemonMethod(method: string, params: Record<string, any>): Promise<any> {
+    this.callDaemonMethodCalls.push({ method, params });
+    return this.daemonMethodResults.get(method) ?? {};
+  }
+
+  isConnected(): boolean {
+    return this.connected;
+  }
+}

--- a/test/fakes/FakeDaemonManager.ts
+++ b/test/fakes/FakeDaemonManager.ts
@@ -1,0 +1,44 @@
+import type { DaemonManagerLike } from "../../src/daemon/manager";
+import type { DaemonStatus, DaemonOptions } from "../../src/daemon/types";
+
+/**
+ * Fake DaemonManager for testing — implements DaemonManagerLike directly,
+ * no subclassing of the concrete DaemonManager required.
+ */
+export class FakeDaemonManager implements DaemonManagerLike {
+  statusResult: DaemonStatus = {
+    running: true,
+    pid: 1234,
+    port: 3000,
+    socketPath: "/tmp/test.sock",
+  };
+  startCalled = false;
+  startCallCount = 0;
+  startOptions: DaemonOptions | undefined;
+  restartCalled = false;
+  restartCallCount = 0;
+  restartOptions: DaemonOptions | undefined;
+  waitForReadyResult = true;
+  waitForReadyCallCount = 0;
+
+  async status(): Promise<DaemonStatus> {
+    return this.statusResult;
+  }
+
+  async start(options: DaemonOptions = {}): Promise<void> {
+    this.startCalled = true;
+    this.startCallCount++;
+    this.startOptions = options;
+  }
+
+  async restart(options: DaemonOptions = {}): Promise<void> {
+    this.restartCalled = true;
+    this.restartCallCount++;
+    this.restartOptions = options;
+  }
+
+  async waitForReady(_timeout: number): Promise<boolean> {
+    this.waitForReadyCallCount++;
+    return this.waitForReadyResult;
+  }
+}


### PR DESCRIPTION
## Summary

- AutoMobile's daemon outlives MCP-server restarts by design, so when a user bumped `@kaeawc/auto-mobile@X` in their Claude config, a freshly-spawned 0.0.21 MCP server would silently keep talking to the 0.0.19 daemon left running from the previous session. Doctor reported "version: latest" because the still-alive daemon was running pre-bump code. The version field was already written to the PID file (`PidFileData.version`) — nothing compared it.
- `DaemonMcpProxy.ensureConnected` now reads daemon version + `startedAt` via `DaemonManager.status()`. When this MCP server is **strictly newer** than the running daemon (`compareVersions > 0`), it calls `daemonManager.restart()` so the daemon picks up the upgraded code on the next tool call.
- "Newer wins, older attaches" semantics: older clients (e.g. a worktree pinned to an old version, or `@latest` not yet refreshed in another session's bunx cache) connect to whatever's running rather than fighting to downgrade. This eliminates the ping-pong restart that would otherwise occur with concurrent agents on different versions.
- 10s `startedAt` cooldown (`DAEMON_VERSION_RESTART_COOLDOWN_MS`) further suppresses thrash from racing restarts during a coordinated upgrade.
- Skipped: a daemon socket-RPC for the version (handshake-time) — current PID-file roundtrip is sufficient since `ensureConnected` runs once per proxy lifetime; worth revisiting if a future protocol handshake is added.

### Production refactors (testability only, no behavior change)

- New `DaemonManagerLike` interface (mirrors existing `DaemonClientLike`); proxy now depends on the interface.
- `DaemonManager` constructor now takes optional `pidFilePath` (mirrors existing `lockFilePath` injection) so integration tests can isolate against temp paths.

### Tests

- **18 unit tests** in `test/daemon/daemonMcpProxy.test.ts`, including 9 covering newer-wins, cooldown, missing-version, autoStart-disabled, restart-failure, and `daemonOptions` forwarding. Boilerplate factored into a `makeProxy()` helper.
- **6 integration tests** in `test/daemon/integration/versionMismatchRestart.test.ts` exercising the real `DaemonManager.status()` against hand-written PID files (in temp dirs, pointing at `process.pid` for guaranteed liveness) — covering older/newer/equal/missing-version, cooldown window, and stale-PID self-cleanup.
- New shared fakes: `test/fakes/FakeDaemonClient.ts`, `test/fakes/FakeDaemonManager.ts` (promoted from inline test fixtures).

All 216 tests in `test/daemon/` pass.

## Test plan

- [x] `bun test test/daemon/daemonMcpProxy.test.ts` — 18 pass
- [x] `bun test test/daemon/integration/versionMismatchRestart.test.ts` — 6 pass
- [x] `bun test test/daemon/` — 216 pass, no regressions
- [x] `bun build.ts` — clean

### Manual smoke test recipe

```bash
bun build.ts
bun dist/src/index.js --daemon stop
MCP_SERVER_VERSION=0.0.1 bun dist/src/index.js --daemon-mode > /tmp/old-daemon.log 2>&1 &
sleep 2
bun dist/src/index.js --daemon status   # shows: Version: 0.0.1
bun -e 'import("./dist/src/daemon/daemonMcpProxy.js").then(async ({DaemonMcpProxy}) => {
  const p = new DaemonMcpProxy(); await p.listTools(); await p.close();
})'
bun dist/src/index.js --daemon status   # shows package.json version (restart fired)
```

Vary `MCP_SERVER_VERSION=9999.0.0` to verify the older-client-attaches path (no restart).