### PR TITLE
feat: surface entered text on iOS UISearchBar/UITextField + clipboard fixes

### DIFF
--- a/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/ViewHierarchyExtractor.kt
+++ b/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/ViewHierarchyExtractor.kt
@@ -749,7 +749,9 @@ class ViewHierarchyExtractor(private val recompositionStore: RecompositionStore?
           }
 
       node.text?.toString()?.let {
-        text = it
+        // Mask password content to avoid leaking secrets through the hierarchy.
+        // Mirrors iOS UIElementInfo.value masking for .secureTextField.
+        text = if (node.isPassword) "•".repeat(it.length) else it
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
           textSize = node.extraRenderingInfo?.textSizeInPx
         }
@@ -1626,10 +1628,14 @@ class ViewHierarchyExtractor(private val recompositionStore: RecompositionStore?
         paneTitle = focusedNode.paneTitle?.toString()
       }
 
+      val rawFocusedText = focusedNode.text?.toString()
+      val focusedText =
+          if (rawFocusedText != null && focusedNode.isPassword) "•".repeat(rawFocusedText.length)
+          else rawFocusedText
       UIElementInfo(
           className = focusedNode.className?.toString(),
           resourceId = focusedNode.viewIdResourceName,
-          text = focusedNode.text?.toString(),
+          text = focusedText,
           contentDesc = focusedNode.contentDescription?.toString(),
           clickable = focusedNode.isClickable.toString(),
           longClickable = focusedNode.isLongClickable.toString(),
@@ -1844,10 +1850,13 @@ class ViewHierarchyExtractor(private val recompositionStore: RecompositionStore?
       val isAccessibilityFocusedBool =
           accessibilityFocusedNode != null && isSameNode(node, accessibilityFocusedNode)
 
+      val rawText = node.text?.toString()
+      val maskedText =
+          if (rawText != null && node.isPassword) "•".repeat(rawText.length) else rawText
       UIElementInfo(
           className = node.className?.toString(),
           resourceId = node.viewIdResourceName,
-          text = node.text?.toString(),
+          text = maskedText,
           contentDesc = node.contentDescription?.toString(),
           clickable = node.isClickable.toString(),
           enabled = node.isEnabled.toString(),

--- a/ios/control-proxy/Sources/CtrlProxy/ElementLocator.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/ElementLocator.swift
@@ -803,8 +803,22 @@ public class ElementLocator: ElementLocating {
             // Get label - use for text (don't duplicate in content-desc)
             let label = snapshot.label.isEmpty ? nil : snapshot.label
 
+            // For text inputs, surface the entered value separately from the
+            // accessibility label (which is typically the placeholder for
+            // UISearchBar / UITextField). Mask password content to avoid
+            // leaking secrets through the hierarchy.
+            let isTextInput = snapshot.elementType == .textField
+                || snapshot.elementType == .textView
+                || snapshot.elementType == .secureTextField
+                || snapshot.elementType == .searchField
+            var enteredValue: String?
+            if isTextInput, let raw = snapshot.value as? String, !raw.isEmpty {
+                enteredValue = isPassword ? String(repeating: "•", count: raw.count) : raw
+            }
+
             return UIElementInfo(
                 text: label,
+                value: enteredValue,
                 textSize: nil,
                 contentDesc: nil, // Don't duplicate - label is in text
                 resourceId: resId,
@@ -905,6 +919,7 @@ public class ElementLocator: ElementLocating {
             if isRoot {
                 return [UIElementInfo(
                     text: element.text,
+                    value: element.value,
                     textSize: element.textSize,
                     contentDesc: element.contentDesc,
                     resourceId: element.resourceId,
@@ -944,6 +959,7 @@ public class ElementLocator: ElementLocating {
             // Keep this element with optimized children
             return [UIElementInfo(
                 text: element.text,
+                value: element.value,
                 textSize: element.textSize,
                 contentDesc: element.contentDesc,
                 resourceId: element.resourceId,

--- a/ios/control-proxy/Sources/CtrlProxy/GesturePerformer.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/GesturePerformer.swift
@@ -514,11 +514,34 @@ public class GesturePerformer: GesturePerforming {
         /// fields in exchange for correctness.
         @discardableResult
         private static func clearViaDeletes(element: XCUIElement) -> Int {
+            // Some native text inputs (notably UISearchBar) surface their
+            // `placeholderValue` as `value` once the buffer is empty rather
+            // than returning an empty string. Without an additional exit,
+            // the loop runs the full iteration cap (~6s of no-op deletes)
+            // and the proxy round-trip exceeds the MCP request timeout.
+            //
+            // The doc above warned that a naive `value == placeholderValue`
+            // check would false-positive on RN wrappers, where both `value`
+            // and `placeholderValue` may equal the accessibility identifier
+            // and stay constant throughout typing. Guard the placeholder
+            // check by also requiring a *change* in `value` since the
+            // previous iteration — i.e., we observed real progress. RN's
+            // value never changes between iterations (its JS state restores
+            // the buffer), so the guard suppresses the false positive.
+            let placeholder = element.placeholderValue
             var totalDeleted = 0
+            var previousValue: String? = nil
             for iteration in 0..<clearViaDeletesMaxIterations {
                 let current = (element.value as? String) ?? ""
                 gestureLog.debug("clearViaDeletes iter=\(iteration, privacy: .public) valueCount=\(current.count, privacy: .public)")
                 if current.isEmpty {
+                    break
+                }
+                if let placeholder = placeholder,
+                   current == placeholder,
+                   let previous = previousValue,
+                   previous != current
+                {
                     break
                 }
                 element.coordinate(withNormalizedOffset: CGVector(dx: 0.95, dy: 0.5)).tap()
@@ -527,6 +550,7 @@ public class GesturePerformer: GesturePerforming {
                     count: clearViaDeletesBurstSize
                 ))
                 totalDeleted += clearViaDeletesBurstSize
+                previousValue = current
             }
             return totalDeleted
         }
@@ -754,12 +778,52 @@ public class GesturePerformer: GesturePerforming {
 
         // MARK: - Clipboard
 
+        /// Shadow of the most recent value this runner wrote via `copy` (or
+        /// cleared via `clear`). Used as a fallback for `get` and `paste`
+        /// when iOS's privacy-gated pasteboard read on a UI-test runner
+        /// hangs on a `Paste from <app>` system alert that no user is
+        /// available to dismiss. Without this, `runOnMainThread`'s
+        /// `DispatchQueue.main.sync` blocks indefinitely.
+        private static var clipboardShadow: String?
+        private static let clipboardShadowQueue = DispatchQueue(label: "com.automobile.ctrlproxy.clipboard-shadow")
+
+        private static func readShadow() -> String? {
+            clipboardShadowQueue.sync { clipboardShadow }
+        }
+
+        private static func writeShadow(_ value: String?) {
+            clipboardShadowQueue.sync { clipboardShadow = value }
+        }
+
+        /// Read `UIPasteboard.general.string` with a bounded timeout. The
+        /// pasteboard read can deadlock the runner on iOS 16+ when a
+        /// privacy alert is presented but no user is available to dismiss
+        /// it. Returns nil on timeout instead of blocking forever.
+        private static func readPasteboardWithTimeout(_ timeout: DispatchTimeInterval) -> String? {
+            // Skip the read entirely if there are no strings — `hasStrings`
+            // is a non-prompting synchronous check.
+            guard UIPasteboard.general.hasStrings else { return nil }
+            let semaphore = DispatchSemaphore(value: 0)
+            let box = NSMutableArray() // Heap-allocated holder so the closure can write past return
+            DispatchQueue.global(qos: .userInitiated).async {
+                if let str = UIPasteboard.general.string {
+                    box.add(str)
+                }
+                semaphore.signal()
+            }
+            if semaphore.wait(timeout: .now() + timeout) == .timedOut {
+                return nil
+            }
+            return box.firstObject as? String
+        }
+
         public func clipboard(action: String, text: String?) throws -> String? {
             switch action {
             case "get":
-                return runOnMainThread {
-                    UIPasteboard.general.string
-                }
+                let live = GesturePerformer.readPasteboardWithTimeout(.milliseconds(500))
+                let shadow = GesturePerformer.readShadow()
+                if let live = live, !live.isEmpty { return live }
+                return shadow
 
             case "copy":
                 guard let text = text else {
@@ -768,12 +832,14 @@ public class GesturePerformer: GesturePerforming {
                 runOnMainThread {
                     UIPasteboard.general.string = text
                 }
+                GesturePerformer.writeShadow(text)
                 return nil
 
             case "clear":
                 runOnMainThread {
                     UIPasteboard.general.items = []
                 }
+                GesturePerformer.writeShadow(nil)
                 return nil
 
             case "paste":
@@ -782,12 +848,13 @@ public class GesturePerformer: GesturePerforming {
                 guard let app = resolveTextInputApp() else {
                     throw GestureError.noApplication
                 }
-                let clipboardText: String? = runOnMainThread {
-                    UIPasteboard.general.string
-                }
+                // Use bounded read; fall back to shadow if iOS gates the read.
+                let pasteboardLive = GesturePerformer.readPasteboardWithTimeout(.milliseconds(500))
+                let clipboardText = pasteboardLive ?? GesturePerformer.readShadow()
                 guard let pasteText = clipboardText, !pasteText.isEmpty else {
                     throw GestureError.clipboardEmpty
                 }
+                _ = pasteText
 
                 try requireKeyboardFocus(app: app, context: "ensure a text field is focused before pasting")
 

--- a/ios/control-proxy/Sources/CtrlProxy/HierarchyMerger.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/HierarchyMerger.swift
@@ -198,6 +198,7 @@ public enum HierarchyMerger {
 
         return UIElementInfo(
             text: element.text,
+            value: element.value,
             textSize: element.textSize,
             contentDesc: element.contentDesc,
             resourceId: element.resourceId,
@@ -353,6 +354,7 @@ public enum HierarchyMerger {
             }
             return UIElementInfo(
                 text: element.text,
+                value: element.value,
                 textSize: element.textSize,
                 contentDesc: element.contentDesc,
                 resourceId: element.resourceId,
@@ -387,6 +389,7 @@ public enum HierarchyMerger {
 
         return UIElementInfo(
             text: element.text,
+            value: element.value,
             textSize: element.textSize,
             contentDesc: element.contentDesc,
             resourceId: element.resourceId,

--- a/ios/control-proxy/Sources/CtrlProxy/Models.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/Models.swift
@@ -364,6 +364,7 @@ public struct WindowInfo: Codable {
 /// UI Element information (matching Android's UIElementInfo)
 public struct UIElementInfo: Codable {
     public let text: String?
+    public let value: String?
     public let textSize: Float?
     public let contentDesc: String?
     public let resourceId: String?
@@ -391,7 +392,7 @@ public struct UIElementInfo: Codable {
     public let node: [UIElementInfo]?
 
     enum CodingKeys: String, CodingKey {
-        case text, textSize, className, bounds, clickable, enabled
+        case text, value, textSize, className, bounds, clickable, enabled
         case focusable, focused, scrollable, password, checkable, checked
         case selected, actions, node, role, testTag, extras
         case viewId = "view-id"
@@ -406,6 +407,7 @@ public struct UIElementInfo: Codable {
 
     public init(
         text: String? = nil,
+        value: String? = nil,
         textSize: Float? = nil,
         contentDesc: String? = nil,
         resourceId: String? = nil,
@@ -433,6 +435,7 @@ public struct UIElementInfo: Codable {
         node: [UIElementInfo]? = nil
     ) {
         self.text = text
+        self.value = value
         self.textSize = textSize
         self.contentDesc = contentDesc
         self.resourceId = resourceId

--- a/ios/control-proxy/Sources/CtrlProxy/WebSocketServer.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/WebSocketServer.swift
@@ -187,7 +187,9 @@ public class WebSocketServer: WebSocketServing {
         encoder.outputFormatting = .sortedKeys
 
         if var wsResponse = response as? WebSocketResponse {
-            // Inject perfTiming if present and response doesn't already have it
+            // Inject perfTiming if present and response doesn't already have it.
+            // Preserve the existing `text` payload — handlers like `clipboard get`
+            // populate it and we must not drop it during the rebuild.
             if perfTiming != nil && wsResponse.perfTiming == nil {
                 wsResponse = WebSocketResponse(
                     type: wsResponse.type,
@@ -196,6 +198,7 @@ public class WebSocketServer: WebSocketServing {
                     success: wsResponse.success,
                     totalTimeMs: wsResponse.totalTimeMs ?? totalTimeMs,
                     error: wsResponse.error,
+                    text: wsResponse.text,
                     perfTiming: perfTiming
                 )
             }

--- a/ios/control-proxy/Tests/CtrlProxyTests/ModelsTests.swift
+++ b/ios/control-proxy/Tests/CtrlProxyTests/ModelsTests.swift
@@ -304,4 +304,47 @@ final class ModelsTests: XCTestCase {
         XCTAssertEqual(ResponseType.screenshot.rawValue, "screenshot")
         XCTAssertEqual(ResponseType.launchAppResult.rawValue, "launch_app_result")
     }
+
+    // MARK: - UIElementInfo value field
+
+    func testUIElementInfoValueFieldEncodesUnderValueKey() throws {
+        let info = UIElementInfo(
+            text: "Search videos",
+            value: "hello iOS",
+            hintText: "Search videos"
+        )
+
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        let data = try encoder.encode(info)
+        let json = String(data: data, encoding: .utf8) ?? ""
+
+        XCTAssertTrue(json.contains("\"value\":\"hello iOS\""), "value should be serialized: \(json)")
+        XCTAssertTrue(json.contains("\"text\":\"Search videos\""), "text should still be present: \(json)")
+        XCTAssertTrue(json.contains("\"hint-text\":\"Search videos\""), "hint-text should be present: \(json)")
+    }
+
+    func testUIElementInfoValueFieldOmittedWhenNil() throws {
+        let info = UIElementInfo(text: "Just a label")
+
+        let data = try JSONEncoder().encode(info)
+        let json = String(data: data, encoding: .utf8) ?? ""
+
+        XCTAssertFalse(json.contains("\"value\""), "value should be omitted when nil: \(json)")
+    }
+
+    func testUIElementInfoValueRoundTrips() throws {
+        let original = UIElementInfo(
+            text: "Email",
+            value: "user@example.com",
+            password: "false"
+        )
+
+        let data = try JSONEncoder().encode(original)
+        let decoded = try JSONDecoder().decode(UIElementInfo.self, from: data)
+
+        XCTAssertEqual(decoded.text, "Email")
+        XCTAssertEqual(decoded.value, "user@example.com")
+        XCTAssertEqual(decoded.password, "false")
+    }
 }

--- a/src/features/observe/ios/CtrlProxyHierarchy.ts
+++ b/src/features/observe/ios/CtrlProxyHierarchy.ts
@@ -230,6 +230,7 @@ export class CtrlProxyHierarchy {
     const attrs: Record<string, string> = {};
 
     if (node.text) {attrs["text"] = node.text;}
+    if (node.value) {attrs["value"] = node.value;}
     const contentDesc = this.readNodeField<string>(node, "contentDesc", "content-desc");
     const resourceId = this.readNodeField<string>(node, "resourceId", "resource-id");
     const testTag = this.readNodeField<string>(node, "testTag", "test-tag");
@@ -294,6 +295,7 @@ export class CtrlProxyHierarchy {
   private hasContentProperties(attrs: Record<string, string>): boolean {
     return Boolean(
       (attrs["text"] && attrs["text"] !== "") ||
+      (attrs["value"] && attrs["value"] !== "") ||
       (attrs["resource-id"] && attrs["resource-id"] !== "") ||
       (attrs["content-desc"] && attrs["content-desc"] !== "") ||
       (attrs["test-tag"] && attrs["test-tag"] !== "") ||

--- a/src/features/observe/ios/types.ts
+++ b/src/features/observe/ios/types.ts
@@ -22,6 +22,13 @@ export type { DelegateContext } from "../shared/types";
  */
 export interface CtrlProxyNode {
   text?: string;
+  /**
+   * Entered/current value of a text-input element (UITextField, UITextView,
+   * UISearchBar, UISecureTextField). Distinct from `text` — which carries the
+   * accessibility label (often the placeholder for these elements). Password
+   * fields are masked as bullet characters before serialization.
+   */
+  value?: string;
   textSize?: number;
   contentDesc?: string;
   resourceId?: string;

--- a/test/features/observe/ios/CtrlProxyHierarchy.test.ts
+++ b/test/features/observe/ios/CtrlProxyHierarchy.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, test } from "bun:test";
+import { CtrlProxyHierarchy } from "../../../../src/features/observe/ios/CtrlProxyHierarchy";
+import type { CtrlProxyNode, HierarchyDelegateContext } from "../../../../src/features/observe/ios/types";
+
+const stubContext = {} as HierarchyDelegateContext;
+
+function findFirstNodeWith(
+  node: any,
+  predicate: (attrs: Record<string, string>) => boolean
+): any | null {
+  if (node?.$ && predicate(node.$)) {return node;}
+  for (const child of node?.node ?? []) {
+    const hit = findFirstNodeWith(child, predicate);
+    if (hit) {return hit;}
+  }
+  return null;
+}
+
+function makeHierarchy(root: CtrlProxyNode): any {
+  return {
+    updatedAt: 0,
+    packageName: "test.app",
+    hierarchy: root,
+  };
+}
+
+describe("CtrlProxyHierarchy.convertToViewHierarchyResult", () => {
+  const subject = new CtrlProxyHierarchy(stubContext);
+
+  test("surfaces `value` separately from `text` for text-input nodes", () => {
+    const root: CtrlProxyNode = {
+      className: "XCUIApplication",
+      bounds: { left: 0, top: 0, right: 100, bottom: 100 },
+      node: [
+        {
+          className: "UISearchBar",
+          text: "Search videos",
+          value: "hello iOS",
+          hintText: "Search videos",
+          bounds: { left: 0, top: 0, right: 100, bottom: 50 },
+          clickable: "true",
+        },
+      ],
+    };
+
+    const result = subject.convertToViewHierarchyResult(makeHierarchy(root));
+    const searchBar = findFirstNodeWith(
+      result.hierarchy.node,
+      attrs => attrs["class"] === "UISearchBar"
+    );
+
+    expect(searchBar).not.toBeNull();
+    expect(searchBar.$["text"]).toBe("Search videos");
+    expect(searchBar.$["value"]).toBe("hello iOS");
+    expect(searchBar.$["hint-text"]).toBe("Search videos");
+  });
+
+  test("preserves a node that has only `value` (no text/resourceId)", () => {
+    const root: CtrlProxyNode = {
+      className: "XCUIApplication",
+      bounds: { left: 0, top: 0, right: 100, bottom: 100 },
+      node: [
+        {
+          className: "UITextField",
+          value: "value-only",
+          bounds: { left: 0, top: 0, right: 100, bottom: 50 },
+          clickable: "true",
+        },
+      ],
+    };
+
+    const result = subject.convertToViewHierarchyResult(makeHierarchy(root));
+    const tf = findFirstNodeWith(
+      result.hierarchy.node,
+      attrs => attrs["class"] === "UITextField"
+    );
+
+    expect(tf).not.toBeNull();
+    expect(tf.$["value"]).toBe("value-only");
+  });
+
+  test("omits `value` attribute when absent on input", () => {
+    const root: CtrlProxyNode = {
+      className: "XCUIApplication",
+      bounds: { left: 0, top: 0, right: 100, bottom: 100 },
+      node: [
+        {
+          className: "UILabel",
+          text: "Static label",
+          bounds: { left: 0, top: 0, right: 100, bottom: 20 },
+        },
+      ],
+    };
+
+    const result = subject.convertToViewHierarchyResult(makeHierarchy(root));
+    const label = findFirstNodeWith(
+      result.hierarchy.node,
+      attrs => attrs["class"] === "UILabel"
+    );
+
+    expect(label).not.toBeNull();
+    expect(label.$["value"]).toBeUndefined();
+    expect(label.$["text"]).toBe("Static label");
+  });
+});


### PR DESCRIPTION
## Summary

Three independent regressions surfaced while testing iOS text-input flows:

- **`inputText` had no observable result** — typed content didn't appear anywhere in the view hierarchy. iOS reports the typed value through `XCElementSnapshot.value`, but the serializer mapped only `label → text` and `placeholderValue → hint-text`, dropping the entered value. Tests/tools had to rely on indirect signals (Clear-text button presence, edit-menu contents).
- **`clearText` reliably hung past the MCP proxy timeout** — even with a healthy daemon it took ~6s, exceeding the 5s proxy budget. The on-device action did complete; the response just didn't arrive in time.
- **`clipboard get` returned empty after a successful `copy`** — making the API non-round-trip-safe.

### What changed

#### iOS Swift

- **New `value: String?` field on `UIElementInfo`**, populated for `.textField` / `.textView` / `.secureTextField` / `.searchField` from `snapshot.value`. Password content is masked as `••••` (one bullet per character) before serialization. `text` continues to carry the accessibility label (which is the placeholder for these elements), `hint-text` continues to carry the placeholder, and `value` is the new channel for the actually-entered text.
- **`clearText` placeholder-equality early-exit.** On UISearchBar, an empty buffer surfaces as `element.value == placeholderValue` rather than `""`, so the existing `isEmpty` exit never fired and the loop ran the full 20×50 = 1000 deletes (~6s, exceeding the proxy timeout). Added a `value == placeholderValue` exit guarded by a "saw real progress this iteration" check, which preserves the original RN-wrapper behavior the doc string was protecting against (RN's `value` stays constant across iterations, so the progress guard suppresses false-positive breaks).
- **`WebSocketServer.encodeResponse` rebuild now preserves `text`**. The perfTiming-injection path reconstructed `WebSocketResponse` field-by-field but omitted `text`, so any handler-returned text was stripped before serialization. **This was the actual cause of `clipboard get` returning empty** (independent of pasteboard semantics). Same fields-lost-during-reconstruction pattern as `optimizeHierarchy` and `HierarchyMerger`, fixed in all 5 sites.
- **Clipboard hardening on iOS 16+.** `runOnMainThread { UIPasteboard.general.string }` can deadlock the runner waiting for a "Pasted from <app>" privacy alert that no user is present to dismiss. Added an in-memory shadow of writes plus a bounded-timeout pasteboard read on a background queue with `hasStrings` as a non-prompting empty-check. Defense in depth — secondary to the `text` preservation fix above, but useful when external clipboard reads are gated.

#### TypeScript

- `CtrlProxyNode.value?: string` added to the iOS hierarchy schema (`types.ts`) with doc comment.
- `CtrlProxyHierarchy.convertNode` surfaces it as `attrs["value"]`.
- `hasContentProperties` treats `value` as content so a value-only node isn't filtered out by the optimizer.

#### Android Kotlin (parity, not feature)

- `ViewHierarchyExtractor` masks `node.text` to `••••` when `node.isPassword` is true, at all three extraction sites (full extractor, simple-info path, focused-element path). Mirrors the iOS masking behavior.

### Tests

- **3 new TS tests** (`test/features/observe/ios/CtrlProxyHierarchy.test.ts`): `value` round-trip, value-only node preservation, value-omission-when-absent.
- **3 new Swift tests** (`ModelsTests.swift`): `UIElementInfo.value` JSON encoding under `value` key, omission when nil, round-trip decode.
- All 258 TS tests + 20 Swift Models tests pass locally.

### Verified end-to-end

After deploying to a real iOS 18 simulator runner:

```
"className": "UISearchBar",
"text": "Search videos",          // accessibility label / placeholder
"hint-text": "Search videos",     // placeholder
"value": "value-field-verify-after-restart"   // typed content (NEW)
```

`clearText` now responds in 2004ms (well under the 5s proxy timeout). `copy → get` round-trip returns the exact value copied. `clear → get` returns empty as expected.

## Test Plan

- [x] `bun test test/features/observe/ios/ test/daemon/` — 258 pass
- [x] `swift test --filter ModelsTests` (CtrlProxy package) — 20 pass
- [x] `bun build.ts` — clean
- [x] Manual: `inputText` then `observe` shows `value` field on `UISearchBar`
- [x] Manual: `clearText` returns under 2.5s with empty field
- [x] Manual: `clipboard copy "X"` → `clipboard get` returns `"X"`
- [x] Manual: `clipboard clear` → `clipboard get` returns empty
- [ ] CI green