### PR TITLE
fix: retain long-clickable views in observe hierarchy

### DIFF
--- a/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/CtrlProxy.kt
+++ b/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/CtrlProxy.kt
@@ -1,6 +1,7 @@
 package dev.jasonpearson.automobile.ctrlproxy
 
 import android.accessibilityservice.AccessibilityService
+import android.accessibilityservice.AccessibilityServiceInfo
 import android.accessibilityservice.GestureDescription
 import android.annotation.SuppressLint
 import android.app.ActivityManager
@@ -571,9 +572,15 @@ class CtrlProxy : AccessibilityService() {
     super.onServiceConnected()
     Log.d(TAG, "onServiceConnected")
 
-    // Ensure we receive ALL accessibility event types (XML config may be cached)
+    // Ensure we receive ALL accessibility event types and include not-important views
+    // (XML config may be cached). flagIncludeNotImportantViews exposes interactive nodes
+    // (e.g. long-clickable ImageViews) that Android otherwise filters as decorative.
     serviceInfo = serviceInfo?.apply {
       eventTypes = AccessibilityEvent.TYPES_ALL_MASK
+      flags = flags or
+          AccessibilityServiceInfo.FLAG_INCLUDE_NOT_IMPORTANT_VIEWS or
+          AccessibilityServiceInfo.FLAG_REPORT_VIEW_IDS or
+          AccessibilityServiceInfo.FLAG_RETRIEVE_INTERACTIVE_WINDOWS
     }
 
     try {

--- a/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/ViewHierarchyExtractor.kt
+++ b/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/ViewHierarchyExtractor.kt
@@ -581,8 +581,12 @@ class ViewHierarchyExtractor(private val recompositionStore: RecompositionStore?
 
       // Filter nodes not actually visible to the user
       // Skip this filter when IME is present for the active app window — Android incorrectly
-      // marks app nodes as not visible when an IME window overlays them
-      if (!skipVisibilityFilter && !node.isVisibleToUser) {
+      // marks app nodes as not visible when an IME window overlays them.
+      // Also skip for interactive nodes — Android can mark long-clickable or clickable views
+      // as not visible when they lack text/content-desc (e.g. illustration ImageViews),
+      // but they must still appear in the hierarchy since users can interact with them.
+      val isInteractiveNode = node.isClickable || node.isLongClickable || node.isScrollable || node.isCheckable
+      if (!skipVisibilityFilter && !isInteractiveNode && !node.isVisibleToUser) {
         return null
       }
 

--- a/android/control-proxy/src/main/res/xml/accessibility_service_config.xml
+++ b/android/control-proxy/src/main/res/xml/accessibility_service_config.xml
@@ -2,7 +2,7 @@
 <accessibility-service xmlns:android="http://schemas.android.com/apk/res/android"
     android:description="@string/accessibility_service_description"
     android:accessibilityEventTypes="typeAllMask"
-    android:accessibilityFlags="flagReportViewIds|flagRetrieveInteractiveWindows"
+    android:accessibilityFlags="flagReportViewIds|flagRetrieveInteractiveWindows|flagIncludeNotImportantViews"
     android:accessibilityFeedbackType="feedbackGeneric"
     android:notificationTimeout="100"
     android:canRetrieveWindowContent="true"

--- a/src/features/observe/ViewHierarchy.ts
+++ b/src/features/observe/ViewHierarchy.ts
@@ -493,7 +493,8 @@ export class ViewHierarchy implements ViewHierarchyInterface {
       (props.scrollable === "true") ||
       (props.focused === "true") ||
       (props.selected === "true") ||
-      (props.selected === true)
+      (props.selected === true) ||
+      (props["long-clickable"] === "true")
     );
   }
 
@@ -639,6 +640,7 @@ export class ViewHierarchy implements ViewHierarchyInterface {
       "contentDesc",
       "content-desc",
       "clickable",
+      "long-clickable",
       "scrollable",
       "enabled",
       "selected",

--- a/test/features/observe/ViewHierarchy.test.ts
+++ b/test/features/observe/ViewHierarchy.test.ts
@@ -59,11 +59,13 @@ describe("ViewHierarchy", function() {
       const propsClickable = { clickable: "true" };
       const propsScrollable = { scrollable: "true" };
       const propsFocused = { focused: "true" };
+      const propsLongClickable = { "long-clickable": "true" };
       const propsNonBoolean = { text: "Button" };
 
       expect(viewHierarchy.meetsBooleanFilterCriteria(propsClickable)).toBe(true);
       expect(viewHierarchy.meetsBooleanFilterCriteria(propsScrollable)).toBe(true);
       expect(viewHierarchy.meetsBooleanFilterCriteria(propsFocused)).toBe(true);
+      expect(viewHierarchy.meetsBooleanFilterCriteria(propsLongClickable)).toBe(true);
       expect(viewHierarchy.meetsBooleanFilterCriteria(propsNonBoolean)).toBe(false);
     });
 
@@ -379,6 +381,25 @@ describe("ViewHierarchy", function() {
       expect(viewHierarchy.meetsStringFilterCriteria(mixedProps)).toBe(true);
       expect(viewHierarchy.meetsBooleanFilterCriteria(mixedProps)).toBe(true);
       expect(viewHierarchy.meetsFilterCriteria(mixedProps)).toBe(true);
+    });
+
+    test("should retain long-clickable-only nodes without text or content-desc", function() {
+      const longClickableImageView = {
+        "className": "android.widget.ImageView",
+        "resource-id": "com.app:id/splash_animation",
+        "long-clickable": "true",
+        "clickable": "false",
+        "bounds": "[192,1036][1088,2364]"
+      };
+
+      expect(viewHierarchy.meetsBooleanFilterCriteria(longClickableImageView)).toBe(true);
+      expect(viewHierarchy.meetsFilterCriteria(longClickableImageView)).toBe(true);
+
+      const filtered = viewHierarchy.filterSingleNode(longClickableImageView);
+      expect(filtered).toBeDefined();
+      expect(filtered).toHaveProperty("long-clickable", "true");
+      expect(filtered).toHaveProperty("resource-id", "com.app:id/splash_animation");
+      expect(filtered).toHaveProperty("bounds", "[192,1036][1088,2364]");
     });
 
     test("should clean node properties correctly with various edge cases", function() {


### PR DESCRIPTION
## Summary
- Android's accessibility service was silently dropping interactive views like long-clickable ImageViews (e.g. illustrations) that lack text or content-desc
- The `isVisibleToUser` check in `ViewHierarchyExtractor` filtered them as decorative, and the TypeScript `meetsBooleanFilterCriteria` / `cleanNodeProperties` had no `long-clickable` awareness
- Verified via `uiautomator dump` showing the node present vs raw observe output missing it entirely

## Changes
- **Android**: Bypass `isVisibleToUser` for interactive nodes (clickable, long-clickable, scrollable, checkable) in `ViewHierarchyExtractor.extractNodeInfo`
- **Android**: Add `flagIncludeNotImportantViews` to accessibility service XML config and runtime flags in `CtrlProxy.onServiceConnected`
- **TypeScript**: Add `long-clickable` to `meetsBooleanFilterCriteria` so long-clickable-only nodes pass the filter
- **TypeScript**: Add `long-clickable` to `cleanNodeProperties` `allowedProperties` so the property is preserved in output
- **Test**: Add coverage for long-clickable-only node retention

## Test Plan
- [x] All 3869 TypeScript tests pass (0 failures)
- [x] Android control-proxy compiles successfully
- [x] New test verifies long-clickable-only ImageView is retained with correct properties

🤖 Generated with [Claude Code](https://claude.com/claude-code)