### PR TITLE
fix: check simulator boot state before CtrlProxy auto-setup

### DIFF
--- a/src/features/observe/ios/CtrlProxyClient.ts
+++ b/src/features/observe/ios/CtrlProxyClient.ts
@@ -27,6 +27,7 @@ import { PortManager } from "../../../utils/PortManager";
 import { shouldUseHostControl, getHostControlHost } from "../../../utils/hostControlClient";
 import { isRunningInDocker } from "../../../utils/dockerEnv";
 import { IOSCtrlProxyManager, CtrlProxyIosManager } from "../../../utils/IOSCtrlProxyManager";
+import { PlatformDeviceManagerFactory } from "../../../utils/factories/PlatformDeviceManagerFactory";
 import { NavigationGraphManager } from "../../navigation/NavigationGraphManager";
 import { serverConfig } from "../../../utils/ServerConfig";
 import { NavigationScreenshotManager } from "../../navigation/NavigationScreenshotManager";
@@ -56,6 +57,16 @@ export type ServiceManagerFactory = (device: BootedDevice) => CtrlProxyIosManage
 
 /** Default production factory that delegates to the real singleton. */
 const defaultServiceManagerFactory: ServiceManagerFactory = d => IOSCtrlProxyManager.getInstance(d);
+
+/**
+ * Function type that returns currently booted devices.
+ * Injected for testability — avoids coupling to PlatformDeviceManagerFactory in tests.
+ */
+export type BootedDeviceLister = () => Promise<BootedDevice[]>;
+
+/** Default production lister that queries the real device manager. */
+const defaultBootedDeviceLister: BootedDeviceLister = () =>
+  PlatformDeviceManagerFactory.getInstance().getBootedDevices("ios");
 
 /**
  * No-op factory used by createForTesting so that tests which don't supply
@@ -299,6 +310,7 @@ export class CtrlProxyClient extends DeviceServiceClient implements CtrlProxySer
 
   // Auto-setup on connection failure
   private readonly serviceManagerFactory: ServiceManagerFactory;
+  private readonly bootedDeviceLister: BootedDeviceLister;
   private isAttemptingAutoSetup: boolean = false;
 
   private constructor(
@@ -306,12 +318,14 @@ export class CtrlProxyClient extends DeviceServiceClient implements CtrlProxySer
     port: number = CtrlProxyClient.DEFAULT_PORT,
     wsFactory: WebSocketFactory = defaultWebSocketFactory,
     timer: Timer = defaultTimer,
-    serviceManagerFactory: ServiceManagerFactory = defaultServiceManagerFactory
+    serviceManagerFactory: ServiceManagerFactory = defaultServiceManagerFactory,
+    bootedDeviceLister: BootedDeviceLister = defaultBootedDeviceLister
   ) {
     super(timer, wsFactory);
     this.device = device;
     this.port = port;
     this.serviceManagerFactory = serviceManagerFactory;
+    this.bootedDeviceLister = bootedDeviceLister;
   }
 
   /**
@@ -362,9 +376,13 @@ export class CtrlProxyClient extends DeviceServiceClient implements CtrlProxySer
     port: number,
     wsFactory: WebSocketFactory,
     timer: Timer,
-    serviceManagerFactory: ServiceManagerFactory = noOpServiceManagerFactory
+    serviceManagerFactory: ServiceManagerFactory = noOpServiceManagerFactory,
+    bootedDeviceLister?: BootedDeviceLister
   ): CtrlProxyClient {
-    return new CtrlProxyClient(device, port, wsFactory, timer, serviceManagerFactory);
+    // Default test lister always reports the device as booted so existing tests
+    // are unaffected. Tests that verify boot-check behavior supply their own lister.
+    const lister = bootedDeviceLister ?? (async () => [device]);
+    return new CtrlProxyClient(device, port, wsFactory, timer, serviceManagerFactory, lister);
   }
 
   /**
@@ -410,6 +428,21 @@ export class CtrlProxyClient extends DeviceServiceClient implements CtrlProxySer
         logger.info(`[CtrlProxyClient] Service is running but WebSocket failed — transient issue, retrying connection`);
         this.connectionAttempts = 0;
         return await super.ensureConnected(perf);
+      }
+
+      // Check if the target simulator is still booted before attempting auto-setup.
+      // Without this check, xcodebuild test-without-building will re-boot the simulator
+      // as a side effect, causing phantom simulators.
+      try {
+        const bootedDevices = await this.bootedDeviceLister();
+        const stillBooted = bootedDevices.some(d => d.deviceId === this.device.deviceId);
+        if (!stillBooted) {
+          logger.info(`[CtrlProxyClient] Target simulator ${this.device.deviceId} is no longer booted, skipping auto-setup`);
+          return false;
+        }
+      } catch (error) {
+        logger.warn(`[CtrlProxyClient] Failed to check simulator boot state: ${error}`);
+        // Proceed with auto-setup on failure to check — better to attempt than to silently skip
       }
 
       logger.info(`[CtrlProxyClient] WebSocket connection failed, attempting auto-setup of CtrlProxy`);

--- a/test/features/observe/ios/CtrlProxyClientAutoSetup.test.ts
+++ b/test/features/observe/ios/CtrlProxyClientAutoSetup.test.ts
@@ -7,7 +7,7 @@ import {
 } from "../../../fakes/FakeWebSocket";
 import { FakeTimer } from "../../../fakes/FakeTimer";
 import { FakeIOSCtrlProxyManager } from "../../../fakes/FakeIOSCtrlProxyManager";
-import type { ServiceManagerFactory } from "../../../../src/features/observe/ios/CtrlProxyClient";
+import type { ServiceManagerFactory, BootedDeviceLister } from "../../../../src/features/observe/ios/CtrlProxyClient";
 
 describe("CtrlProxyClient auto-setup", function() {
   let testDevice: BootedDevice;
@@ -145,6 +145,98 @@ describe("CtrlProxyClient auto-setup", function() {
 
     // The re-entrant call should have returned false immediately
     expect(reentrantCallResult).toBe(false);
+
+    await client.close();
+  });
+
+  test("skips auto-setup when target simulator is no longer booted", async function() {
+    // Device lister returns empty — simulator has been shut down
+    const lister: BootedDeviceLister = async () => [];
+
+    const client = CtrlProxyClient.createForTesting(
+      testDevice,
+      serverPort,
+      createInstantFailureWebSocketFactory(fakeTimer),
+      fakeTimer,
+      createManagerFactory(),
+      lister
+    );
+
+    const result = await client.ensureConnected();
+
+    expect(result).toBe(false);
+    // setup should NOT have been called since the simulator is not booted
+    expect(fakeManager.wasMethodCalled("setup:force=true")).toBe(false);
+
+    await client.close();
+  });
+
+  test("skips auto-setup when a different simulator is booted", async function() {
+    // A different simulator is booted, but not our target
+    const otherDevice: BootedDevice = {
+      deviceId: "FFFFFFFF-0000-1111-2222-333333333333",
+      platform: "ios",
+      name: "iPhone 15 Simulator",
+    };
+    const lister: BootedDeviceLister = async () => [otherDevice];
+
+    const client = CtrlProxyClient.createForTesting(
+      testDevice,
+      serverPort,
+      createInstantFailureWebSocketFactory(fakeTimer),
+      fakeTimer,
+      createManagerFactory(),
+      lister
+    );
+
+    const result = await client.ensureConnected();
+
+    expect(result).toBe(false);
+    expect(fakeManager.wasMethodCalled("setup:force=true")).toBe(false);
+
+    await client.close();
+  });
+
+  test("proceeds with auto-setup when target simulator is still booted", async function() {
+    // Device lister returns our target simulator as booted
+    const lister: BootedDeviceLister = async () => [testDevice];
+
+    const client = CtrlProxyClient.createForTesting(
+      testDevice,
+      serverPort,
+      createInstantFailureWebSocketFactory(fakeTimer),
+      fakeTimer,
+      createManagerFactory(),
+      lister
+    );
+
+    await client.ensureConnected();
+
+    // setup should have been called since the simulator is booted
+    expect(fakeManager.wasMethodCalled("setup:force=true")).toBe(true);
+
+    await client.close();
+  });
+
+  test("proceeds with auto-setup when boot check fails", async function() {
+    // Device lister throws — should not prevent auto-setup
+    const lister: BootedDeviceLister = async () => {
+      throw new Error("simctl not available");
+    };
+
+    const client = CtrlProxyClient.createForTesting(
+      testDevice,
+      serverPort,
+      createInstantFailureWebSocketFactory(fakeTimer),
+      fakeTimer,
+      createManagerFactory(),
+      lister
+    );
+
+    await client.ensureConnected();
+
+    // setup should still proceed when boot check fails
+    expect(fakeManager.wasMethodCalled("setup:force=true")).toBe(true);
 
     await client.close();
   });


### PR DESCRIPTION
## Summary
- Before attempting CtrlProxy auto-setup in `ensureConnected()`, check if the target simulator is still booted via a new injectable `BootedDeviceLister`
- If the simulator has been shut down, skip auto-setup to prevent `xcodebuild test-without-building` from re-booting it as a side effect (phantom simulators)
- If the boot state check itself fails, proceed with auto-setup as a safe fallback

## Test Plan
- [x] Added test: skips auto-setup when target simulator is no longer booted
- [x] Added test: skips auto-setup when a different simulator is booted
- [x] Added test: proceeds with auto-setup when target simulator is still booted
- [x] Added test: proceeds with auto-setup when boot check fails (fallback)
- [x] All existing auto-setup tests still pass (default test lister reports device as booted)
- [x] Full test suite passes (3872 tests, 0 failures)
- [x] Lint and build pass

Closes #2052

🤖 Generated with [Claude Code](https://claude.com/claude-code)