### PR TITLE
fix: ensure observe respects platform parameter over cached iOS session

### DIFF
--- a/src/server/observeTools.ts
+++ b/src/server/observeTools.ts
@@ -264,6 +264,36 @@ export function registerObserveTools() {
         ? waitOutcome.observation
         : await observeScreen.execute(undefined, createGlobalPerformanceTracker(), true, 0, signal);
 
+      // Validate that the returned hierarchy matches the expected platform.
+      // This guards against cross-platform data contamination where an iOS
+      // hierarchy could be returned for an Android device (or vice versa).
+      if (result.viewHierarchy?.hierarchy) {
+        const hierarchy = result.viewHierarchy.hierarchy;
+        const isIosHierarchy = hierarchy.type === "XCUIElementTypeApplication"
+          || hierarchy.elementType === "application"
+          || (typeof hierarchy.bundleId === "string" && !hierarchy.node);
+        const isAndroidHierarchy = hierarchy.node !== undefined
+          || (hierarchy.$ && hierarchy.$.class);
+
+        if (device.platform === "android" && isIosHierarchy && !isAndroidHierarchy) {
+          logger.error(
+            `[observe] Platform mismatch: device ${device.deviceId} is Android but received iOS hierarchy. ` +
+            `Discarding stale iOS data to prevent cross-platform contamination.`
+          );
+          result.viewHierarchy = undefined;
+          result.error = "Platform mismatch detected: received iOS hierarchy for Android device. " +
+            "This may indicate a stale connection. Try calling observe again.";
+        } else if (device.platform === "ios" && isAndroidHierarchy && !isIosHierarchy) {
+          logger.error(
+            `[observe] Platform mismatch: device ${device.deviceId} is iOS but received Android hierarchy. ` +
+            `Discarding stale Android data to prevent cross-platform contamination.`
+          );
+          result.viewHierarchy = undefined;
+          result.error = "Platform mismatch detected: received Android hierarchy for iOS device. " +
+            "This may indicate a stale connection. Try calling observe again.";
+        }
+      }
+
       if (args.raw) {
         await observeScreen.appendRawViewHierarchy(result, signal);
       }

--- a/src/server/utilityTools.ts
+++ b/src/server/utilityTools.ts
@@ -6,6 +6,7 @@ import { DeviceState } from "../features/utility/DeviceState";
 import { logger } from "../utils/logger";
 import { createJSONToolResponse } from "../utils/toolUtils";
 import { DeviceSessionManager } from "../utils/DeviceSessionManager";
+import { RealObserveScreen } from "../features/observe/ObserveScreen";
 import { BootedDevice, Platform } from "../models";
 import { addDeviceTargetingToSchema, addSessionUuidToSchema, platformSchema } from "./toolSchemaHelpers";
 import { DaemonState } from "../daemon/daemonState";
@@ -97,7 +98,21 @@ export function registerUtilityTools() {
         logger.info(`[setActiveDevice] Bound device ${args.deviceId} to session ${args.sessionUuid}`);
       } else {
         // Legacy single-agent path: sets global active device
-        await DeviceSessionManager.getInstance().ensureDeviceReady(args.platform, args.deviceId);
+        const sessionManager = DeviceSessionManager.getInstance();
+        const previousDevice = sessionManager.getCurrentDevice();
+        const previousPlatform = sessionManager.getCurrentPlatform();
+
+        await sessionManager.ensureDeviceReady(args.platform, args.deviceId);
+
+        // When switching platforms, clear observation caches to prevent stale
+        // data from the previous platform contaminating subsequent observe calls.
+        if (previousPlatform && previousPlatform !== args.platform && previousDevice) {
+          logger.info(
+            `[setActiveDevice] Platform switch detected (${previousPlatform} -> ${args.platform}), ` +
+            `clearing observation cache for previous device ${previousDevice.deviceId}`
+          );
+          RealObserveScreen.clearCache(previousDevice.deviceId);
+        }
       }
 
       return createJSONToolResponse({

--- a/src/utils/DeviceSessionManager.ts
+++ b/src/utils/DeviceSessionManager.ts
@@ -352,7 +352,9 @@ export class DeviceSessionManager implements DeviceSessionManager {
     if (!selectedDevice && this.currentDevice && (this.currentPlatform === platform || this.currentPlatform === resolvedPlatform)) {
       logger.info(`[DeviceSessionManager] Found current device: ${this.currentDevice.deviceId}, verifying readiness`);
       try {
-        await this.verifyDevice(this.currentDevice.deviceId, platform, options);
+        // Use resolvedPlatform (always "android" | "ios") instead of platform (which may be "either")
+        // to ensure verifyDevice dispatches to the correct platform-specific verification
+        await this.verifyDevice(this.currentDevice.deviceId, resolvedPlatform, options);
         selectedDevice = this.currentDevice;
         deviceVerified = true;
         deviceSource = "current";
@@ -373,6 +375,20 @@ export class DeviceSessionManager implements DeviceSessionManager {
 
     if (!deviceVerified) {
       await this.verifyDevice(selectedDevice.deviceId, resolvedPlatform, options);
+    }
+
+    // Safety check: ensure the selected device's platform matches the resolved platform.
+    // This guards against cross-platform contamination where an iOS device could be
+    // returned when Android was explicitly requested (or vice versa).
+    if (selectedDevice.platform !== resolvedPlatform) {
+      logger.warn(
+        `[DeviceSessionManager] Platform mismatch: selected device ${selectedDevice.deviceId} ` +
+        `has platform '${selectedDevice.platform}' but resolved platform is '${resolvedPlatform}'. ` +
+        `Discarding and finding correct platform device.`
+      );
+      selectedDevice = await this.findOrStartDevice(resolvedPlatform, options);
+      deviceVerified = true;
+      deviceSource = "auto";
     }
 
     this.setCurrentDevice(selectedDevice, resolvedPlatform);

--- a/src/utils/DeviceSessionManager.ts
+++ b/src/utils/DeviceSessionManager.ts
@@ -196,8 +196,8 @@ export class DeviceSessionManager implements DeviceSessionManager {
     return DeviceSessionManager.instance;
   }
 
-  public static createInstance(provider: DeviceClientProvider): DeviceSessionManager {
-    return new DeviceSessionManager(provider);
+  public static createInstance(provider: DeviceClientProvider, adbFactory?: AdbClientFactory): DeviceSessionManager {
+    return new DeviceSessionManager(provider, adbFactory);
   }
 
   /**
@@ -387,8 +387,6 @@ export class DeviceSessionManager implements DeviceSessionManager {
         `Discarding and finding correct platform device.`
       );
       selectedDevice = await this.findOrStartDevice(resolvedPlatform, options);
-      deviceVerified = true;
-      deviceSource = "auto";
     }
 
     this.setCurrentDevice(selectedDevice, resolvedPlatform);

--- a/test/server/observePlatformValidation.test.ts
+++ b/test/server/observePlatformValidation.test.ts
@@ -1,0 +1,189 @@
+import { describe, expect, test } from "bun:test";
+import { BootedDevice, ObserveResult } from "../../src/models";
+
+/**
+ * Platform validation logic extracted for direct testing.
+ * This mirrors the validation in observeTools.ts observeHandler to verify
+ * cross-platform hierarchy detection works correctly.
+ */
+function validateHierarchyPlatform(
+  device: BootedDevice,
+  result: ObserveResult
+): { valid: boolean; error?: string } {
+  if (!result.viewHierarchy?.hierarchy) {
+    return { valid: true };
+  }
+
+  const hierarchy = result.viewHierarchy.hierarchy;
+  const isIosHierarchy = hierarchy.type === "XCUIElementTypeApplication"
+    || hierarchy.elementType === "application"
+    || (typeof hierarchy.bundleId === "string" && !hierarchy.node);
+  const isAndroidHierarchy = hierarchy.node !== undefined
+    || (hierarchy.$ && hierarchy.$.class);
+
+  if (device.platform === "android" && isIosHierarchy && !isAndroidHierarchy) {
+    return {
+      valid: false,
+      error: "Platform mismatch detected: received iOS hierarchy for Android device.",
+    };
+  }
+
+  if (device.platform === "ios" && isAndroidHierarchy && !isIosHierarchy) {
+    return {
+      valid: false,
+      error: "Platform mismatch detected: received Android hierarchy for iOS device.",
+    };
+  }
+
+  return { valid: true };
+}
+
+describe("observe platform validation", () => {
+  const androidDevice: BootedDevice = {
+    name: "emulator-5554",
+    deviceId: "emulator-5554",
+    platform: "android",
+  };
+
+  const iosDevice: BootedDevice = {
+    name: "iPhone 15",
+    deviceId: "ios-sim-1",
+    platform: "ios",
+  };
+
+  test("accepts Android hierarchy for Android device", () => {
+    const result: ObserveResult = {
+      updatedAt: Date.now(),
+      screenSize: { width: 1080, height: 1920 },
+      systemInsets: { top: 0, right: 0, bottom: 0, left: 0 },
+      viewHierarchy: {
+        hierarchy: {
+          node: {
+            $: { class: "android.widget.FrameLayout", bounds: "[0,0][1080,1920]" },
+          },
+        },
+      } as any,
+    };
+
+    const validation = validateHierarchyPlatform(androidDevice, result);
+    expect(validation.valid).toBe(true);
+  });
+
+  test("rejects iOS hierarchy for Android device", () => {
+    const result: ObserveResult = {
+      updatedAt: Date.now(),
+      screenSize: { width: 390, height: 844 },
+      systemInsets: { top: 0, right: 0, bottom: 0, left: 0 },
+      viewHierarchy: {
+        hierarchy: {
+          type: "XCUIElementTypeApplication",
+          bundleId: "com.example.app",
+          bounds: { left: 0, top: 0, right: 390, bottom: 844 },
+        },
+      } as any,
+    };
+
+    const validation = validateHierarchyPlatform(androidDevice, result);
+    expect(validation.valid).toBe(false);
+    expect(validation.error).toContain("iOS hierarchy for Android device");
+  });
+
+  test("accepts iOS hierarchy for iOS device", () => {
+    const result: ObserveResult = {
+      updatedAt: Date.now(),
+      screenSize: { width: 390, height: 844 },
+      systemInsets: { top: 0, right: 0, bottom: 0, left: 0 },
+      viewHierarchy: {
+        hierarchy: {
+          type: "XCUIElementTypeApplication",
+          bundleId: "com.example.app",
+          bounds: { left: 0, top: 0, right: 390, bottom: 844 },
+        },
+      } as any,
+    };
+
+    const validation = validateHierarchyPlatform(iosDevice, result);
+    expect(validation.valid).toBe(true);
+  });
+
+  test("rejects Android hierarchy for iOS device", () => {
+    const result: ObserveResult = {
+      updatedAt: Date.now(),
+      screenSize: { width: 1080, height: 1920 },
+      systemInsets: { top: 0, right: 0, bottom: 0, left: 0 },
+      viewHierarchy: {
+        hierarchy: {
+          node: {
+            $: { class: "android.widget.FrameLayout", bounds: "[0,0][1080,1920]" },
+          },
+        },
+      } as any,
+    };
+
+    const validation = validateHierarchyPlatform(iosDevice, result);
+    expect(validation.valid).toBe(false);
+    expect(validation.error).toContain("Android hierarchy for iOS device");
+  });
+
+  test("detects iOS hierarchy via elementType field", () => {
+    const result: ObserveResult = {
+      updatedAt: Date.now(),
+      screenSize: { width: 390, height: 844 },
+      systemInsets: { top: 0, right: 0, bottom: 0, left: 0 },
+      viewHierarchy: {
+        hierarchy: {
+          elementType: "application",
+          bundleId: "com.example.app",
+        },
+      } as any,
+    };
+
+    const validation = validateHierarchyPlatform(androidDevice, result);
+    expect(validation.valid).toBe(false);
+  });
+
+  test("detects iOS hierarchy via bundleId without node field", () => {
+    const result: ObserveResult = {
+      updatedAt: Date.now(),
+      screenSize: { width: 390, height: 844 },
+      systemInsets: { top: 0, right: 0, bottom: 0, left: 0 },
+      viewHierarchy: {
+        hierarchy: {
+          bundleId: "com.example.app",
+          children: [],
+        },
+      } as any,
+    };
+
+    const validation = validateHierarchyPlatform(androidDevice, result);
+    expect(validation.valid).toBe(false);
+  });
+
+  test("accepts when no viewHierarchy is present", () => {
+    const result: ObserveResult = {
+      updatedAt: Date.now(),
+      screenSize: { width: 0, height: 0 },
+      systemInsets: { top: 0, right: 0, bottom: 0, left: 0 },
+    };
+
+    const validation = validateHierarchyPlatform(androidDevice, result);
+    expect(validation.valid).toBe(true);
+  });
+
+  test("accepts when hierarchy has error object", () => {
+    const result: ObserveResult = {
+      updatedAt: Date.now(),
+      screenSize: { width: 0, height: 0 },
+      systemInsets: { top: 0, right: 0, bottom: 0, left: 0 },
+      viewHierarchy: {
+        hierarchy: {
+          error: "Failed to retrieve view hierarchy",
+        },
+      } as any,
+    };
+
+    // Error hierarchies don't have platform-specific markers, so they should pass
+    const validation = validateHierarchyPlatform(androidDevice, result);
+    expect(validation.valid).toBe(true);
+  });
+});

--- a/test/utils/DeviceSessionManager.test.ts
+++ b/test/utils/DeviceSessionManager.test.ts
@@ -495,4 +495,61 @@ describe("DeviceSessionManager dual-platform resolution", () => {
     expect(result.platform).toBe("android");
     expect(result.deviceId).toBe("emulator-5554");
   });
+
+  test("should verify current device using resolvedPlatform not raw platform when platform is 'either'", async () => {
+    // This test ensures that when platform="either" and currentDevice is Android,
+    // verifyDevice is called with "android" (resolvedPlatform) instead of "either" (raw platform).
+    // Bug fix: previously "either" was passed to verifyDevice which treated it as iOS.
+    const manager = DeviceSessionManager.createInstance(
+      new FakeDeviceClientProvider(fakeAdb, fakeDeviceUtils, fakeSimctl as any)
+    );
+
+    // Set current device to Android (simulating a prior setActiveDevice call)
+    manager.setCurrentDevice(androidDevice, "android");
+
+    // Call ensureDeviceReady with "either" - should use the current Android device
+    const result = await manager.ensureDeviceReady("either");
+    expect(result.platform).toBe("android");
+    expect(result.deviceId).toBe("emulator-5554");
+    // The device should still be set (not cleared by a failed iOS verification)
+    expect(manager.getCurrentPlatform()).toBe("android");
+    expect(manager.getCurrentDevice()?.deviceId).toBe("emulator-5554");
+  });
+
+  test("should return android device when platform is explicitly 'android' even with iOS active", async () => {
+    const manager = DeviceSessionManager.createInstance(
+      new FakeDeviceClientProvider(fakeAdb, fakeDeviceUtils, fakeSimctl as any)
+    );
+
+    // Set current device to iOS (simulating a prior setActiveDevice call to iOS)
+    manager.setCurrentDevice(iosDevice, "ios");
+
+    // Call ensureDeviceReady with explicit "android" platform
+    const result = await manager.ensureDeviceReady("android", "emulator-5554");
+    expect(result.platform).toBe("android");
+    expect(result.deviceId).toBe("emulator-5554");
+    // Current device should now be updated to Android
+    expect(manager.getCurrentPlatform()).toBe("android");
+  });
+
+  test("should resolve correct platform when explicitly requesting android with both devices booted", async () => {
+    // When both platforms are booted and we explicitly request Android,
+    // the returned device must always be Android even if current device was iOS.
+    // Configure fakeDeviceUtils so findOrStartDevice can find Android devices
+    fakeDeviceUtils.setBootedDevices("android", [androidDevice]);
+
+    const manager = DeviceSessionManager.createInstance(
+      new FakeDeviceClientProvider(fakeAdb, fakeDeviceUtils, fakeSimctl as any)
+    );
+
+    // Set current device to iOS first
+    manager.setCurrentDevice(iosDevice, "ios");
+
+    // Explicitly request Android without deviceId — should still resolve to Android
+    const result = await manager.ensureDeviceReady("android");
+    expect(result.platform).toBe("android");
+    expect(result.deviceId).toBe("emulator-5554");
+    // Current device should now be updated to Android
+    expect(manager.getCurrentPlatform()).toBe("android");
+  });
 });

--- a/test/utils/DeviceSessionManager.test.ts
+++ b/test/utils/DeviceSessionManager.test.ts
@@ -13,6 +13,7 @@ import { CtrlProxyClient as IOSCtrlProxyClient } from "../../src/features/observ
 import { Window } from "../../src/features/observe/Window";
 import { BootedDevice, AppearanceConfigInput } from "../../src/models";
 import { serverConfig } from "../../src/utils/ServerConfig";
+import type { AdbClientFactory } from "../../src/utils/android-cmdline-tools/AdbClientFactory";
 
 describe("DeviceSessionManager", () => {
   const device: BootedDevice = {
@@ -376,6 +377,7 @@ describe("DeviceSessionManager dual-platform resolution", () => {
   let fakeAdb: FakeAdbExecutor;
   let fakeDeviceUtils: FakeDeviceUtils;
   let fakeSimctl: FakeSimctl;
+  let fakeAdbFactory: AdbClientFactory;
   let originalGetActive: typeof Window.prototype.getActive;
   let originalAndroidCtrlProxyMgr: typeof AndroidCtrlProxyManager.getInstance;
   let originalAndroidCtrlProxyClient: typeof CtrlProxyClient.getInstance;
@@ -387,6 +389,7 @@ describe("DeviceSessionManager dual-platform resolution", () => {
     fakeAdb = new FakeAdbExecutor();
     fakeDeviceUtils = new FakeDeviceUtils();
     fakeSimctl = new FakeSimctl();
+    fakeAdbFactory = { create: () => fakeAdb };
 
     fakeAdb.setDevices([androidDevice]);
     fakeSimctl.setBootedSimulators([iosDevice]);
@@ -444,7 +447,8 @@ describe("DeviceSessionManager dual-platform resolution", () => {
 
   test("should throw when both platforms connected and no active device or deviceId", async () => {
     const manager = DeviceSessionManager.createInstance(
-      new FakeDeviceClientProvider(fakeAdb, fakeDeviceUtils, fakeSimctl as any)
+      new FakeDeviceClientProvider(fakeAdb, fakeDeviceUtils, fakeSimctl as any),
+      fakeAdbFactory
     );
 
     await expect(
@@ -454,7 +458,8 @@ describe("DeviceSessionManager dual-platform resolution", () => {
 
   test("should resolve to ios when setActiveDevice was called with ios", async () => {
     const manager = DeviceSessionManager.createInstance(
-      new FakeDeviceClientProvider(fakeAdb, fakeDeviceUtils, fakeSimctl as any)
+      new FakeDeviceClientProvider(fakeAdb, fakeDeviceUtils, fakeSimctl as any),
+      fakeAdbFactory
     );
 
     manager.setCurrentDevice(iosDevice, "ios");
@@ -466,7 +471,8 @@ describe("DeviceSessionManager dual-platform resolution", () => {
 
   test("should resolve to active platform without deviceId when setActiveDevice was called", async () => {
     const manager = DeviceSessionManager.createInstance(
-      new FakeDeviceClientProvider(fakeAdb, fakeDeviceUtils, fakeSimctl as any)
+      new FakeDeviceClientProvider(fakeAdb, fakeDeviceUtils, fakeSimctl as any),
+      fakeAdbFactory
     );
 
     manager.setCurrentDevice(iosDevice, "ios");
@@ -478,7 +484,8 @@ describe("DeviceSessionManager dual-platform resolution", () => {
 
   test("should resolve ios device by providedDeviceId when no active device set", async () => {
     const manager = DeviceSessionManager.createInstance(
-      new FakeDeviceClientProvider(fakeAdb, fakeDeviceUtils, fakeSimctl as any)
+      new FakeDeviceClientProvider(fakeAdb, fakeDeviceUtils, fakeSimctl as any),
+      fakeAdbFactory
     );
 
     const result = await manager.ensureDeviceReady("either", "ios-sim-1");
@@ -488,7 +495,8 @@ describe("DeviceSessionManager dual-platform resolution", () => {
 
   test("should resolve android device by providedDeviceId when no active device set", async () => {
     const manager = DeviceSessionManager.createInstance(
-      new FakeDeviceClientProvider(fakeAdb, fakeDeviceUtils, fakeSimctl as any)
+      new FakeDeviceClientProvider(fakeAdb, fakeDeviceUtils, fakeSimctl as any),
+      fakeAdbFactory
     );
 
     const result = await manager.ensureDeviceReady("either", "emulator-5554");
@@ -501,7 +509,8 @@ describe("DeviceSessionManager dual-platform resolution", () => {
     // verifyDevice is called with "android" (resolvedPlatform) instead of "either" (raw platform).
     // Bug fix: previously "either" was passed to verifyDevice which treated it as iOS.
     const manager = DeviceSessionManager.createInstance(
-      new FakeDeviceClientProvider(fakeAdb, fakeDeviceUtils, fakeSimctl as any)
+      new FakeDeviceClientProvider(fakeAdb, fakeDeviceUtils, fakeSimctl as any),
+      fakeAdbFactory
     );
 
     // Set current device to Android (simulating a prior setActiveDevice call)
@@ -518,7 +527,8 @@ describe("DeviceSessionManager dual-platform resolution", () => {
 
   test("should return android device when platform is explicitly 'android' even with iOS active", async () => {
     const manager = DeviceSessionManager.createInstance(
-      new FakeDeviceClientProvider(fakeAdb, fakeDeviceUtils, fakeSimctl as any)
+      new FakeDeviceClientProvider(fakeAdb, fakeDeviceUtils, fakeSimctl as any),
+      fakeAdbFactory
     );
 
     // Set current device to iOS (simulating a prior setActiveDevice call to iOS)
@@ -539,7 +549,8 @@ describe("DeviceSessionManager dual-platform resolution", () => {
     fakeDeviceUtils.setBootedDevices("android", [androidDevice]);
 
     const manager = DeviceSessionManager.createInstance(
-      new FakeDeviceClientProvider(fakeAdb, fakeDeviceUtils, fakeSimctl as any)
+      new FakeDeviceClientProvider(fakeAdb, fakeDeviceUtils, fakeSimctl as any),
+      fakeAdbFactory
     );
 
     // Set current device to iOS first


### PR DESCRIPTION
## Summary

Fixes #2053 - `observe` returns iOS hierarchy despite `setActiveDevice` to Android emulator.

- **Fix `verifyDevice` platform dispatch bug**: `ensureDeviceReady` was passing the raw `platform` parameter (which can be `"either"`) to `verifyDevice`, causing Android devices to be incorrectly routed to `verifyIosDevice`. Now passes `resolvedPlatform` (always `"android"` or `"ios"`).
- **Add platform mismatch safety check**: After device selection in `ensureDeviceReady`, validate that the selected device's platform matches the resolved platform. Discard and re-resolve if mismatched.
- **Add observe hierarchy platform validation**: Detect iOS-specific hierarchy markers (`XCUIElementTypeApplication`, `elementType`, `bundleId`) vs Android markers (`node`, `$.class`) and reject cross-platform data with a clear error message.
- **Clear stale caches on platform switch**: When `setActiveDevice` switches platforms, clear the observation cache for the previous device to prevent stale data contamination.

## Test plan

- [x] New test: `ensureDeviceReady` uses `resolvedPlatform` not raw `platform` when verifying current device
- [x] New test: returns Android device when platform explicitly `"android"` even with iOS active
- [x] New test: resolves correct platform when explicitly requesting Android with both devices booted
- [x] New test: platform validation detects iOS hierarchy on Android device (8 test cases)
- [x] All 3880 existing tests pass
- [x] `turbo run lint build test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)