### PR TITLE
fix: make release constants generation portable

### DIFF
--- a/scripts/generate-release-constants.sh
+++ b/scripts/generate-release-constants.sh
@@ -71,6 +71,31 @@ sed_inplace_extended() {
   fi
 }
 
+prepend_registry_entry() {
+  local file="$1"
+  local entry="$2"
+  local marker="export const RELEASE_CHECKSUM_REGISTRY: ReleaseChecksumEntry[] = ["
+  local next_file
+  local inserted=false
+  next_file="$(mktemp)"
+
+  while IFS= read -r line || [ -n "$line" ]; do
+    printf '%s\n' "$line"
+    if [ "$line" = "$marker" ]; then
+      printf '%s\n' "$entry"
+      inserted=true
+    fi
+  done < "$file" > "$next_file"
+
+  if [ "$inserted" != true ]; then
+    rm -f "$next_file"
+    echo "ERROR: Failed to locate RELEASE_CHECKSUM_REGISTRY marker in ${file}"
+    exit 1
+  fi
+
+  mv "$next_file" "$file"
+}
+
 if [ -n "$release_version" ]; then
   # Mode: add new registry entry (requires all three)
   if [ -z "$apk_checksum" ] || [ -z "$ios_checksum" ]; then
@@ -90,9 +115,7 @@ if [ -n "$release_version" ]; then
   },"
 
   # Prepend new entry after the opening bracket of RELEASE_CHECKSUM_REGISTRY
-  sed_inplace "/^export const RELEASE_CHECKSUM_REGISTRY: ReleaseChecksumEntry\[\] = \[$/a\\
-${new_entry}
-" "$tmp_file"
+  prepend_registry_entry "$tmp_file" "$new_entry"
 
   # Cap registry at max_registry_entries
   entry_count=$(grep -c 'version: "' "$tmp_file" || true)

--- a/test/bats/generate-release-constants.bats
+++ b/test/bats/generate-release-constants.bats
@@ -1,0 +1,35 @@
+#!/usr/bin/env bats
+#
+# Tests for scripts/generate-release-constants.sh
+
+SCRIPT="scripts/generate-release-constants.sh"
+APK_SHA="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+IPA_SHA="bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+
+setup() {
+  TEST_ROOT="$(mktemp -d)"
+  mkdir -p "${TEST_ROOT}/scripts" "${TEST_ROOT}/src/constants"
+  cp "$SCRIPT" "${TEST_ROOT}/scripts/generate-release-constants.sh"
+  cp "src/constants/release.ts" "${TEST_ROOT}/src/constants/release.ts"
+  chmod +x "${TEST_ROOT}/scripts/generate-release-constants.sh"
+}
+
+teardown() {
+  rm -rf "$TEST_ROOT"
+}
+
+@test "prepends release registry entry in release mode" {
+  run env \
+    RELEASE_VERSION="0.0.25" \
+    APK_SHA256_CHECKSUM="$APK_SHA" \
+    IOS_CTRL_PROXY_SHA256_CHECKSUM="$IPA_SHA" \
+    bash "${TEST_ROOT}/scripts/generate-release-constants.sh"
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Added registry entry for version: 0.0.25"* ]]
+
+  first_version="$(grep -m1 '^[[:space:]]*version: "' "${TEST_ROOT}/src/constants/release.ts")"
+  [[ "$first_version" == *'version: "0.0.25"'* ]]
+  grep -q "apkSha256: \"${APK_SHA}\"" "${TEST_ROOT}/src/constants/release.ts"
+  grep -q "ipaSha256: \"${IPA_SHA}\"" "${TEST_ROOT}/src/constants/release.ts"
+}


### PR DESCRIPTION
## Summary
- Fix `scripts/generate-release-constants.sh` release-mode registry insertion on GNU sed
- Add BATS coverage for the prepare-release path that prepends a new checksum registry entry

## Root Cause
- The failed prepare release job hit `sed: -e expression #1, char 92: expected newer version of sed` in `Update release constants`
- The registry prepend used a BSD-compatible multiline `sed` append expression that failed on `ubuntu-latest`

## Testing
- `bats test/bats/generate-release-constants.bats`
- `bats test/bats/`
- `bash scripts/shellcheck/validate_shell_scripts.sh`
- `git diff --check`
