### PR TITLE
fix: resolve CI failures in BATS and doc link validation

### DIFF
--- a/.lycherc.toml
+++ b/.lycherc.toml
@@ -15,6 +15,8 @@ exclude = [
     "^https://github\\.com/jasonpearson/",
     # Docker Hub returns transient 500s that fail link checks
     "^https://hub\\.docker\\.com/",
+    # WebAIM contrast checker has unreliable uptime / timeouts in CI
+    "^https://webaim\\.org/",
 ]
 
 # Exclude specific paths

--- a/test/bats/generate-release-constants.bats
+++ b/test/bats/generate-release-constants.bats
@@ -20,16 +20,16 @@ teardown() {
 
 @test "prepends release registry entry in release mode" {
   run env \
-    RELEASE_VERSION="0.0.25" \
+    RELEASE_VERSION="99.99.99" \
     APK_SHA256_CHECKSUM="$APK_SHA" \
     IOS_CTRL_PROXY_SHA256_CHECKSUM="$IPA_SHA" \
     bash "${TEST_ROOT}/scripts/generate-release-constants.sh"
 
   [ "$status" -eq 0 ]
-  [[ "$output" == *"Added registry entry for version: 0.0.25"* ]]
+  [[ "$output" == *"Added registry entry for version: 99.99.99"* ]]
 
   first_version="$(grep -m1 '^[[:space:]]*version: "' "${TEST_ROOT}/src/constants/release.ts")"
-  [[ "$first_version" == *'version: "0.0.25"'* ]]
+  [[ "$first_version" == *'version: "99.99.99"'* ]]
   grep -q "apkSha256: \"${APK_SHA}\"" "${TEST_ROOT}/src/constants/release.ts"
   grep -q "ipaSha256: \"${IPA_SHA}\"" "${TEST_ROOT}/src/constants/release.ts"
 }


### PR DESCRIPTION
## Summary
- **BATS test fix**: The `generate-release-constants.bats` test used hardcoded version `0.0.25`, which now exists in `release.ts` after the v0.0.25 bump. The script's deduplication logic skips existing versions, so the test always failed. Changed to synthetic version `99.99.99` that won't collide with real releases.
- **Lychee fix**: Added `webaim.org` to the exclusion list since it frequently times out in CI, causing spurious failures on the doc link validation job.

These two issues are blocking all three open dependency PRs (#2082, #2083, #2074).

## Test plan
- [x] BATS test passes locally
- [ ] CI passes on this PR
- [ ] Dependency PRs pass after rebasing on main with this fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)