### PR TITLE
fix: SSE keepalive + disconnect monitor hardening

### DIFF
--- a/src/daemon/daemon.ts
+++ b/src/daemon/daemon.ts
@@ -510,8 +510,6 @@ export class Daemon {
           ? defaultTimer.setInterval(() => {
             if (res.headersSent && !res.writableEnded && !res.destroyed) {
               res.write(":keepalive\n\n");
-            } else if (res.writableEnded || res.destroyed) {
-              defaultTimer.clearInterval(keepaliveTimer!);
             }
           }, 30_000)
           : undefined;
@@ -826,7 +824,7 @@ export class Daemon {
           }
           const misses = (this.deviceDisconnectMisses.get(deviceId) ?? 0) + 1;
           this.deviceDisconnectMisses.set(deviceId, misses);
-          logger.warn(
+          logger.info(
             `[DisconnectMonitor] Device ${deviceId} not in booted list (miss ${misses}/${DEVICE_DISCONNECT_MISS_THRESHOLD}, booted=${bootedDeviceIds.size})`
           );
           if (misses < DEVICE_DISCONNECT_MISS_THRESHOLD) {

--- a/src/daemon/daemon.ts
+++ b/src/daemon/daemon.ts
@@ -49,7 +49,7 @@ import { FeatureFlagService } from "../features/featureFlags/FeatureFlagService"
 import { serverConfig } from "../utils/ServerConfig";
 
 const DEVICE_DISCONNECT_POLL_INTERVAL_MS = 5000;
-const DEVICE_DISCONNECT_MISS_THRESHOLD = 2;
+const DEVICE_DISCONNECT_MISS_THRESHOLD = 3;
 
 /**
  * Main daemon process
@@ -501,12 +501,35 @@ export class Daemon {
           return;
         }
 
+        // SSE keepalive: prevent the fetch() response stream from going idle
+        // during long-running tool calls (e.g. executePlan at ~6-10 min).
+        // Without traffic the client-side stream silently dies; the server
+        // writes the result to a dead pipe and the client eventually times out.
+        // SSE comment lines (`:`) are ignored by EventSourceParserStream.
+        const keepaliveTimer = req.method === "POST"
+          ? defaultTimer.setInterval(() => {
+            if (res.headersSent && !res.writableEnded && !res.destroyed) {
+              res.write(":keepalive\n\n");
+            } else if (res.writableEnded || res.destroyed) {
+              defaultTimer.clearInterval(keepaliveTimer!);
+            }
+          }, 30_000)
+          : undefined;
+
+        const clearKeepalive = () => {
+          if (keepaliveTimer) {defaultTimer.clearInterval(keepaliveTimer);}
+        };
+        res.on("close", clearKeepalive);
+        res.on("finish", clearKeepalive);
+
         // Let the transport handle the request
         try {
           await streamableTransport.handleRequest(req, res, parsedBody);
         } catch (error) {
           logger.error("Streamable HTTP request handling failed:", error);
           sendJsonRpcError("Server error", error);
+        } finally {
+          clearKeepalive();
         }
       } else {
         // 404 for unknown paths
@@ -785,6 +808,17 @@ export class Daemon {
           candidateDeviceIds.add(deviceId);
         }
 
+        // When getBootedDevices returns empty but we have tracked devices, ADB
+        // itself likely failed (timeout, connection error). Counting misses in
+        // this state causes false disconnect detections on remote emulators
+        // where ADB can be intermittently slow.
+        if (bootedDeviceIds.size === 0 && candidateDeviceIds.size > 0) {
+          logger.warn(
+            `[DisconnectMonitor] ADB returned 0 devices but ${candidateDeviceIds.size} tracked — skipping miss count (ADB likely unreachable)`
+          );
+          return;
+        }
+
         for (const deviceId of candidateDeviceIds) {
           if (bootedDeviceIds.has(deviceId)) {
             this.deviceDisconnectMisses.delete(deviceId);
@@ -792,6 +826,9 @@ export class Daemon {
           }
           const misses = (this.deviceDisconnectMisses.get(deviceId) ?? 0) + 1;
           this.deviceDisconnectMisses.set(deviceId, misses);
+          logger.warn(
+            `[DisconnectMonitor] Device ${deviceId} not in booted list (miss ${misses}/${DEVICE_DISCONNECT_MISS_THRESHOLD}, booted=${bootedDeviceIds.size})`
+          );
           if (misses < DEVICE_DISCONNECT_MISS_THRESHOLD) {
             continue;
           }
@@ -832,7 +869,7 @@ export class Daemon {
           const sessionId = this.sessionManager.getSessionForDevice(deviceId);
           if (sessionId) {
             logger.warn(
-              `[Daemon] Device ${deviceId} disconnected — cancelling session ${sessionId}`
+              `[DisconnectMonitor] Device ${deviceId} confirmed disconnected after ${DEVICE_DISCONNECT_MISS_THRESHOLD} consecutive misses — cancelling session ${sessionId}`
             );
             await this.cancelAndReleaseSession(sessionId);
           }

--- a/src/daemon/daemon.ts
+++ b/src/daemon/daemon.ts
@@ -50,6 +50,7 @@ import { serverConfig } from "../utils/ServerConfig";
 
 const DEVICE_DISCONNECT_POLL_INTERVAL_MS = 5000;
 const DEVICE_DISCONNECT_MISS_THRESHOLD = 3;
+const SSE_KEEPALIVE_INTERVAL_MS = 30_000;
 
 /**
  * Main daemon process
@@ -511,7 +512,7 @@ export class Daemon {
             if (res.headersSent && !res.writableEnded && !res.destroyed) {
               res.write(":keepalive\n\n");
             }
-          }, 30_000)
+          }, SSE_KEEPALIVE_INTERVAL_MS)
           : undefined;
 
         const clearKeepalive = () => {

--- a/src/server/planTools.ts
+++ b/src/server/planTools.ts
@@ -165,8 +165,10 @@ const executePlanTool = async (device: BootedDevice, params: {
   // stream can go idle and be silently dropped, causing the MCP client to
   // time out even though the tool completed successfully.
   let progressHeartbeatCount = 0;
+  let progressHeartbeatStopped = false;
   const progressHeartbeat = progress
     ? defaultTimer.setInterval(() => {
+      if (progressHeartbeatStopped) { return; }
       progressHeartbeatCount++;
       progress(progressHeartbeatCount, undefined, "executing").catch(err => {
         logger.debug(`[executePlan] Progress heartbeat delivery failed: ${err}`);
@@ -174,7 +176,8 @@ const executePlanTool = async (device: BootedDevice, params: {
     }, 30_000)
     : undefined;
   const clearProgressHeartbeat = () => {
-    if (progressHeartbeat) {defaultTimer.clearInterval(progressHeartbeat);}
+    progressHeartbeatStopped = true;
+    if (progressHeartbeat) { defaultTimer.clearInterval(progressHeartbeat); }
   };
 
   const recordTestExecution = async (

--- a/src/server/planTools.ts
+++ b/src/server/planTools.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import { ToolRegistry } from "./toolRegistry";
+import { ToolRegistry, ProgressCallback } from "./toolRegistry";
 import { ActionableError, BootedDevice, ExecutePlanResult } from "../models";
 import { importPlanFromYaml, executePlan } from "../utils/planUtils";
 import { logger } from "../utils/logger";
@@ -157,8 +157,26 @@ const executePlanTool = async (device: BootedDevice, params: {
   cleanupAppId?: string;
   cleanupClearAppData?: boolean;
   captureObserveSteps?: "summary" | "full";
-}, _progress?: unknown, signal?: AbortSignal): Promise<any> => {
+}, progress?: ProgressCallback, signal?: AbortSignal): Promise<any> => {
   const startTime = defaultTimer.now();
+
+  // Send periodic progress heartbeats to keep the SSE stream alive during
+  // long-running plan execution. Without these, the Streamable HTTP response
+  // stream can go idle and be silently dropped, causing the MCP client to
+  // time out even though the tool completed successfully.
+  let progressHeartbeatCount = 0;
+  const progressHeartbeat = progress
+    ? defaultTimer.setInterval(() => {
+      progressHeartbeatCount++;
+      progress(progressHeartbeatCount, undefined, "executing").catch(err => {
+        logger.debug(`[executePlan] Progress heartbeat delivery failed: ${err}`);
+      });
+    }, 30_000)
+    : undefined;
+  const clearProgressHeartbeat = () => {
+    if (progressHeartbeat) {defaultTimer.clearInterval(progressHeartbeat);}
+  };
+
   const recordTestExecution = async (
     status: TestExecutionStatus,
     durationMs: number,
@@ -501,6 +519,8 @@ const executePlanTool = async (device: BootedDevice, params: {
 
     logger.info(`[PERF] Returning error from executePlanTool (deviceId=${device.deviceId})`);
     return createStructuredToolResponse(response);
+  } finally {
+    clearProgressHeartbeat();
   }
 };
 
@@ -686,7 +706,7 @@ export const registerPlanTools = () => {
     "Execute a series of tool calls from a YAML plan content. Stops execution if any step fails (success: false). Optionally can resume execution from a specific step index.",
     executePlanSchema,
     executePlanTool,
-    false,
+    true,
     false,
     { outputSchema: executePlanResultSchema }
   );

--- a/src/utils/android-cmdline-tools/AdbClient.ts
+++ b/src/utils/android-cmdline-tools/AdbClient.ts
@@ -77,7 +77,7 @@ export class AdbClient implements AdbExecutor {
   private readonly retryExecutor: RetryExecutor;
   private readonly timer: Timer;
 
-  private static readonly DEVICE_LIST_TIMEOUT_MS = 5000;
+  private static readonly DEVICE_LIST_TIMEOUT_MS = 10000;
   private static readonly MAX_ADB_RETRIES = 3;
 
   /**

--- a/src/utils/android-cmdline-tools/AndroidEmulatorClient.ts
+++ b/src/utils/android-cmdline-tools/AndroidEmulatorClient.ts
@@ -11,6 +11,8 @@ import type { AvdConfigReader } from "./AvdConfigReader";
 import { FileAvdConfigReader } from "./AvdConfigReader";
 import type { FormFactor } from "../../models/DeviceMatchCriteria";
 
+const modelNameCache = new Map<string, string>();
+
 /**
  * Interface for Android Emulator (AVD) management
  * Provides emulator lifecycle and control capabilities
@@ -684,25 +686,31 @@ export class AndroidEmulatorClient implements AndroidEmulator {
 
         let deviceName = device.deviceId; // Default fallback
 
-        try {
-          // Try to get the actual device model name
-          const adbWithDevice = this.adbFactory.create(device);
-          const result = await adbWithDevice.executeCommand(
-            "shell getprop ro.product.model",
-            infoTimeoutMs,
-            undefined,
-            true
-          );
-          const modelName = result.stdout.trim();
+        const cachedModel = modelNameCache.get(device.deviceId);
+        if (cachedModel) {
+          deviceName = cachedModel;
+          logger.info(`Got model name for ${device.deviceId}: "${cachedModel}" (cached)`);
+        } else {
+          try {
+            const adbWithDevice = this.adbFactory.create(device);
+            const result = await adbWithDevice.executeCommand(
+              "shell getprop ro.product.model",
+              infoTimeoutMs,
+              undefined,
+              true
+            );
+            const modelName = result.stdout.trim();
 
-          if (modelName && modelName !== "unknown" && modelName.length > 0) {
-            deviceName = modelName;
-            logger.info(`Got model name for ${device.deviceId}: "${modelName}"`);
-          } else {
-            logger.info(`No model name found for ${device.deviceId}, using device ID`);
+            if (modelName && modelName !== "unknown" && modelName.length > 0) {
+              deviceName = modelName;
+              modelNameCache.set(device.deviceId, modelName);
+              logger.info(`Got model name for ${device.deviceId}: "${modelName}"`);
+            } else {
+              logger.info(`No model name found for ${device.deviceId}, using device ID`);
+            }
+          } catch (error) {
+            logger.info(`Failed to get model name for ${device.deviceId}: ${error}`);
           }
-        } catch (error) {
-          logger.info(`Failed to get model name for ${device.deviceId}: ${error}`);
         }
 
         runningDevices.push({
@@ -716,7 +724,7 @@ export class AndroidEmulatorClient implements AndroidEmulator {
 
       return runningDevices;
     } catch (error) {
-      logger.error("Failed to get running emulators:", error);
+      logger.error(`[DeviceListTimeout] Failed to get running emulators (ADB likely timed out):`, error);
       return [];
     }
   }

--- a/src/utils/android-cmdline-tools/AndroidEmulatorClient.ts
+++ b/src/utils/android-cmdline-tools/AndroidEmulatorClient.ts
@@ -11,8 +11,6 @@ import type { AvdConfigReader } from "./AvdConfigReader";
 import { FileAvdConfigReader } from "./AvdConfigReader";
 import type { FormFactor } from "../../models/DeviceMatchCriteria";
 
-const modelNameCache = new Map<string, string>();
-
 /**
  * Interface for Android Emulator (AVD) management
  * Provides emulator lifecycle and control capabilities
@@ -121,6 +119,7 @@ export class AndroidEmulatorClient implements AndroidEmulator {
   private emulatorPath: string;
   private timer: Timer;
   private adbFactory: AdbClientFactory;
+  private modelNameCache = new Map<string, string>();
   private avdConfigReader: AvdConfigReader;
 
   /**
@@ -686,7 +685,7 @@ export class AndroidEmulatorClient implements AndroidEmulator {
 
         let deviceName = device.deviceId; // Default fallback
 
-        const cachedModel = modelNameCache.get(device.deviceId);
+        const cachedModel = this.modelNameCache.get(device.deviceId);
         if (cachedModel) {
           deviceName = cachedModel;
           logger.info(`Got model name for ${device.deviceId}: "${cachedModel}" (cached)`);
@@ -703,7 +702,7 @@ export class AndroidEmulatorClient implements AndroidEmulator {
 
             if (modelName && modelName !== "unknown" && modelName.length > 0) {
               deviceName = modelName;
-              modelNameCache.set(device.deviceId, modelName);
+              this.modelNameCache.set(device.deviceId, modelName);
               logger.info(`Got model name for ${device.deviceId}: "${modelName}"`);
             } else {
               logger.info(`No model name found for ${device.deviceId}, using device ID`);

--- a/test/daemon/sseKeepaliveAndDisconnect.test.ts
+++ b/test/daemon/sseKeepaliveAndDisconnect.test.ts
@@ -1,0 +1,239 @@
+import { describe, expect, test } from "bun:test";
+import { FakeTimer } from "../fakes/FakeTimer";
+
+
+const SSE_KEEPALIVE_INTERVAL_MS = 30_000;
+const DEVICE_DISCONNECT_POLL_INTERVAL_MS = 5000;
+const DEVICE_DISCONNECT_MISS_THRESHOLD = 3;
+
+
+class FakeResponse {
+  headersSent = true;
+  writableEnded = false;
+  destroyed = false;
+  written: string[] = [];
+  listeners: Map<string, Array<() => void>> = new Map();
+
+  write(data: string): void {
+    this.written.push(data);
+  }
+
+  on(event: string, callback: () => void): void {
+    if (!this.listeners.has(event)) {
+      this.listeners.set(event, []);
+    }
+    this.listeners.get(event)!.push(callback);
+  }
+
+  emit(event: string): void {
+    for (const cb of this.listeners.get(event) ?? []) {
+      cb();
+    }
+  }
+}
+
+
+describe("SSE keepalive timer", () => {
+
+  test("writes keepalive comment every interval while response is writable", () => {
+    const timer = new FakeTimer();
+    const res = new FakeResponse();
+
+    timer.setInterval(() => {
+      if (res.headersSent && !res.writableEnded && !res.destroyed) {
+        res.write(":keepalive\n\n");
+      }
+    }, SSE_KEEPALIVE_INTERVAL_MS);
+
+    timer.advanceTime(SSE_KEEPALIVE_INTERVAL_MS);
+    expect(res.written).toEqual([":keepalive\n\n"]);
+
+    timer.advanceTime(SSE_KEEPALIVE_INTERVAL_MS);
+    expect(res.written).toEqual([":keepalive\n\n", ":keepalive\n\n"]);
+  });
+
+  test("does not write keepalive before headers are sent", () => {
+    const timer = new FakeTimer();
+    const res = new FakeResponse();
+    res.headersSent = false;
+
+    timer.setInterval(() => {
+      if (res.headersSent && !res.writableEnded && !res.destroyed) {
+        res.write(":keepalive\n\n");
+      }
+    }, SSE_KEEPALIVE_INTERVAL_MS);
+
+    timer.advanceTime(SSE_KEEPALIVE_INTERVAL_MS);
+    expect(res.written).toEqual([]);
+  });
+
+  test("does not write keepalive after response ends", () => {
+    const timer = new FakeTimer();
+    const res = new FakeResponse();
+
+    timer.setInterval(() => {
+      if (res.headersSent && !res.writableEnded && !res.destroyed) {
+        res.write(":keepalive\n\n");
+      }
+    }, SSE_KEEPALIVE_INTERVAL_MS);
+
+    timer.advanceTime(SSE_KEEPALIVE_INTERVAL_MS);
+    expect(res.written.length).toBe(1);
+
+    res.writableEnded = true;
+    timer.advanceTime(SSE_KEEPALIVE_INTERVAL_MS);
+    expect(res.written.length).toBe(1);
+  });
+
+  test("does not write keepalive after response is destroyed", () => {
+    const timer = new FakeTimer();
+    const res = new FakeResponse();
+
+    timer.setInterval(() => {
+      if (res.headersSent && !res.writableEnded && !res.destroyed) {
+        res.write(":keepalive\n\n");
+      }
+    }, SSE_KEEPALIVE_INTERVAL_MS);
+
+    timer.advanceTime(SSE_KEEPALIVE_INTERVAL_MS);
+    expect(res.written.length).toBe(1);
+
+    res.destroyed = true;
+    timer.advanceTime(SSE_KEEPALIVE_INTERVAL_MS);
+    expect(res.written.length).toBe(1);
+  });
+
+  test("clearKeepalive stops the interval", () => {
+    const timer = new FakeTimer();
+    const res = new FakeResponse();
+
+    const keepaliveTimer = timer.setInterval(() => {
+      if (res.headersSent && !res.writableEnded && !res.destroyed) {
+        res.write(":keepalive\n\n");
+      }
+    }, SSE_KEEPALIVE_INTERVAL_MS);
+
+    const clearKeepalive = () => timer.clearInterval(keepaliveTimer);
+    res.on("close", clearKeepalive);
+
+    timer.advanceTime(SSE_KEEPALIVE_INTERVAL_MS);
+    expect(res.written.length).toBe(1);
+
+    res.emit("close");
+    timer.advanceTime(SSE_KEEPALIVE_INTERVAL_MS);
+    expect(res.written.length).toBe(1);
+  });
+});
+
+
+describe("disconnect monitor miss counting", () => {
+
+  const runDisconnectPoll = (
+    deviceDisconnectMisses: Map<string, number>,
+    bootedDeviceIds: Set<string>,
+    candidateDeviceIds: Set<string>,
+  ): { disconnected: string[]; skippedAdbUnreachable: boolean } => {
+    const disconnected: string[] = [];
+
+    if (bootedDeviceIds.size === 0 && candidateDeviceIds.size > 0) {
+      return { disconnected, skippedAdbUnreachable: true };
+    }
+
+    for (const deviceId of candidateDeviceIds) {
+      if (bootedDeviceIds.has(deviceId)) {
+        deviceDisconnectMisses.delete(deviceId);
+        continue;
+      }
+      const misses = (deviceDisconnectMisses.get(deviceId) ?? 0) + 1;
+      deviceDisconnectMisses.set(deviceId, misses);
+      if (misses >= DEVICE_DISCONNECT_MISS_THRESHOLD) {
+        disconnected.push(deviceId);
+      }
+    }
+
+    return { disconnected, skippedAdbUnreachable: false };
+  };
+
+  test("resets miss count when device appears in booted list", () => {
+    const misses = new Map<string, number>();
+    misses.set("device-1", 2);
+
+    runDisconnectPoll(misses, new Set(["device-1"]), new Set(["device-1"]));
+    expect(misses.has("device-1")).toBe(false);
+  });
+
+  test("increments miss count when device is absent", () => {
+    const misses = new Map<string, number>();
+
+    runDisconnectPoll(misses, new Set(), new Set(["device-1"]));
+    // ADB unreachable guard: 0 booted but 1 tracked → skip
+    expect(misses.has("device-1")).toBe(false);
+
+    // Simulate ADB returning some devices but not ours
+    runDisconnectPoll(misses, new Set(["other"]), new Set(["device-1"]));
+    expect(misses.get("device-1")).toBe(1);
+
+    runDisconnectPoll(misses, new Set(["other"]), new Set(["device-1"]));
+    expect(misses.get("device-1")).toBe(2);
+  });
+
+  test("reports disconnect after threshold consecutive misses", () => {
+    const misses = new Map<string, number>();
+
+    for (let i = 1; i < DEVICE_DISCONNECT_MISS_THRESHOLD; i++) {
+      const result = runDisconnectPoll(misses, new Set(["other"]), new Set(["device-1"]));
+      expect(result.disconnected).toEqual([]);
+    }
+
+    const result = runDisconnectPoll(misses, new Set(["other"]), new Set(["device-1"]));
+    expect(result.disconnected).toEqual(["device-1"]);
+  });
+
+  test("skips miss counting when ADB returns 0 devices (unreachable guard)", () => {
+    const misses = new Map<string, number>();
+
+    const result = runDisconnectPoll(
+      misses,
+      new Set(),
+      new Set(["device-1", "device-2"]),
+    );
+
+    expect(result.skippedAdbUnreachable).toBe(true);
+    expect(result.disconnected).toEqual([]);
+    expect(misses.size).toBe(0);
+  });
+
+  test("miss count resets after device reappears then starts over", () => {
+    const misses = new Map<string, number>();
+
+    runDisconnectPoll(misses, new Set(["other"]), new Set(["device-1"]));
+    runDisconnectPoll(misses, new Set(["other"]), new Set(["device-1"]));
+    expect(misses.get("device-1")).toBe(2);
+
+    runDisconnectPoll(misses, new Set(["device-1"]), new Set(["device-1"]));
+    expect(misses.has("device-1")).toBe(false);
+
+    runDisconnectPoll(misses, new Set(["other"]), new Set(["device-1"]));
+    expect(misses.get("device-1")).toBe(1);
+  });
+
+  test("fires at poll interval using FakeTimer", () => {
+    const timer = new FakeTimer();
+    let pollCount = 0;
+
+    timer.setInterval(() => {
+      pollCount++;
+    }, DEVICE_DISCONNECT_POLL_INTERVAL_MS);
+
+    expect(pollCount).toBe(0);
+
+    timer.advanceTime(DEVICE_DISCONNECT_POLL_INTERVAL_MS);
+    expect(pollCount).toBe(1);
+
+    timer.advanceTime(DEVICE_DISCONNECT_POLL_INTERVAL_MS);
+    expect(pollCount).toBe(2);
+
+    timer.advanceTime(DEVICE_DISCONNECT_POLL_INTERVAL_MS);
+    expect(pollCount).toBe(3);
+  });
+});


### PR DESCRIPTION
Closes #2097

- Add SSE keepalive timer (30s) to Streamable HTTP handler to prevent response stream from going idle during long plan execution
- Add progress heartbeat to executePlan tool with error logging
- Increase disconnect miss threshold from 2 to 3
- Skip miss counting when ADB returns 0 booted devices (ADB unreachable)
- Add miss count logging for disconnect monitor
- Cache ro.product.model results in AndroidEmulatorClient
- Increase ADB device list timeout from 5s to 10s