### PR TITLE
feat: system tray notification improvements

### DIFF
--- a/.claude-plugin/skills/notifications.md
+++ b/.claude-plugin/skills/notifications.md
@@ -72,8 +72,27 @@ systemTray "open" → systemTray "clearAll" → systemTray "close"
 (trigger notification) → systemTray "open" → systemTray "find"
 ```
 
+## Collapsed Notification Groups
+
+When an app posts 2+ notifications, Android collapses them into a single
+group. The `tap` action handles this **automatically** — no special
+parameters needed:
+
+1. Matches the notification text inside the collapsed group
+2. Detects that the match is inside a collapsed group
+3. Taps the "Expand" button on the group header (matched by
+   `content-desc: "Expand"` or `resource-id` containing `expand_button`)
+4. Re-observes the hierarchy after expansion
+5. Taps the specific individual notification (triggering its deep-link)
+
+This is critical because tapping a notification inside a collapsed group
+without expanding first will open the app generically instead of triggering
+the notification's specific intent/deep-link.
+
 ## Tips
 
 - Always `open` the system tray before other actions
 - Use `pressButton "back"` or `homeScreen` to close the shade
 - Notifications may take a moment to appear after triggering
+- Collapsed notification groups are expanded automatically when tapping —
+  no extra parameters or steps required

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,6 +67,37 @@ This is a high-level summary of core MCP tools exposed by the server.
 ## Device Management
 - `listDevices`, `startDevice`, `killDevice`, `setActiveDevice`
 
+# Android Notification Group Handling (Hard-Won Knowledge)
+
+When Android collapses 2+ notifications from the same app into a group,
+you **must expand the group before tapping** a specific notification.
+Tapping a notification inside a collapsed group opens the app generically
+instead of triggering the notification's deep-link intent.
+
+The `systemTray` tool handles this automatically. See
+`docs/design-docs/plat/android/system-tray-lookfor.md` for full details.
+
+## What does NOT work (do not retry these approaches)
+
+- Tapping text nodes inside collapsed groups (opens app generically)
+- Swiping on the group (`adb shell input swipe` does not expand groups)
+- Tapping the expand button without identifying the correct group node
+- Matching without expansion (tap target is not clickable until expanded)
+
+## What works
+
+1. Match notification text inside the collapsed group hierarchy.
+2. Detect the match is inside a group (via `groupNode` reference).
+3. Find and tap the "Expand" button (`content-desc: "Expand"` or
+   `resource-id` containing `expand_button`).
+4. Wait 500 ms, re-observe, re-match, then tap.
+
+## CtrlProxy visibility bypass
+
+`ViewHierarchyExtractor.kt` bypasses `isVisibleToUser` for
+`com.android.systemui` nodes. Collapsed groups mark child text as
+not visible even though they are present in the shade.
+
 # Codex specific
 
 - GitHub interactions use the GitHub CLI (`gh`).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,3 +67,41 @@ This is a high-level summary of core MCP tools exposed by the server.
 
 ## Device Management
 - `listDevices`, `startDevice`, `killDevice`, `setActiveDevice`
+
+# Android Notification Group Handling (Hard-Won Knowledge)
+
+When Android collapses 2+ notifications from the same app into a group,
+you **must expand the group before tapping** a specific notification.
+Tapping a notification inside a collapsed group opens the app generically
+instead of triggering the notification's deep-link intent.
+
+The `systemTray` tool handles this automatically. See
+`docs/design-docs/plat/android/system-tray-lookfor.md` for full details.
+
+## What does NOT work (do not retry these approaches)
+
+- **Tapping text nodes inside collapsed groups** — Android routes the tap
+  to the group header, opening the app generically.
+- **Swiping on the group** — `adb shell input swipe` does not expand
+  collapsed notification groups.
+- **Tapping the expand button without identifying the correct group node**
+  — the tap is intercepted by the parent notification row.
+- **Matching without expansion** — even with correct text matching, the
+  tap target is not clickable until the group is visually expanded.
+
+## What works
+
+1. Match notification text inside the collapsed group hierarchy.
+2. Detect the match is inside a group (via `groupNode` reference).
+3. Find and tap the "Expand" button (`content-desc: "Expand"` or
+   `resource-id` containing `expand_button`).
+4. Wait 500 ms for UI to settle.
+5. Re-observe and re-match the now-expanded notification.
+6. Tap the specific notification row.
+
+## CtrlProxy visibility bypass
+
+`ViewHierarchyExtractor.kt` must bypass the `isVisibleToUser` filter for
+`com.android.systemui` nodes. Collapsed groups mark child text nodes as
+not visible even though they are present in the shade. Without this bypass,
+notification text cannot be matched at all.

--- a/docs/design-docs/plat/android/system-tray-lookfor.md
+++ b/docs/design-docs/plat/android/system-tray-lookfor.md
@@ -2,7 +2,7 @@
 
 <kbd>✅ Implemented</kbd> <kbd>🧪 Tested</kbd>
 
-> **Current state:** `systemTray` MCP tool is fully implemented with open/close/find/tap/dismiss/clearAll actions. See the [Status Glossary](../../status-glossary.md) for chip definitions.
+> **Current state:** `systemTray` MCP tool is fully implemented with open/close/find/tap/dismiss/clearAll actions. Collapsed notification groups are automatically expanded before tapping. See the [Status Glossary](../../status-glossary.md) for chip definitions.
 
 ## Goal
 
@@ -42,6 +42,83 @@ Finding notifications:
   `com.android.systemui`.
 - Return bounding box + hierarchy path for use in follow-up taps.
 
+### Collapsed notification group handling
+
+When an app posts 2+ notifications, Android collapses them into a single
+group header. The `tap` action handles this automatically:
+
+1. **Match** — `collectNotificationCandidates` traverses the hierarchy. When
+   it encounters a notification group (a node whose children include a
+   `notification_children_container`), it descends into the group's children
+   and tags each child candidate with a `groupNode` reference.
+2. **Detect** — After matching, `isMatchInCollapsedGroup` checks whether
+   the best match has a `groupNode`. If so, the notification is inside a
+   collapsed group.
+3. **Expand** — `expandNotificationGroup` finds the "Expand" button inside
+   the group header (matched by `content-desc: "Expand"` or `resource-id`
+   containing `expand_button`) and taps it via ADB.
+4. **Re-match** — After a 500 ms settle, the tool re-observes the hierarchy
+   and re-matches the now-expanded notification.
+5. **Tap** — The specific notification row is tapped, triggering its
+   deep-link intent (e.g. launching a specific flow rather than opening the
+   app generically).
+
+#### What didn't work (lessons learned)
+
+- **Tapping text nodes inside collapsed groups** — Android routes the tap to
+  the group header, which opens the app generically instead of triggering
+  the notification's specific deep-link intent.
+- **Swiping/gesturing on the group** to expand — `adb shell input swipe`
+  did not reliably expand collapsed groups.
+- **Tapping the expand button directly** without first identifying the
+  correct group node — the tap was intercepted by the parent notification
+  row.
+- **Matching only** without expansion — even with correct text matching
+  inside collapsed groups, the tap target was not clickable until the group
+  was visually expanded.
+
+#### `find` and `dismiss` do not auto-expand
+
+Only `tap` auto-expands collapsed groups. `find` can match text inside a
+collapsed group (thanks to the visibility bypass below), but it does not
+expand the group — it is read-only. `dismiss` similarly matches without
+expanding. This keeps side effects limited to the action that needs them.
+
+#### CtrlProxy `isVisibleToUser` bypass
+
+Collapsed notification groups mark child text nodes as
+`isVisibleToUser=false` in the accessibility tree, even though they are
+present in the shade. `ViewHierarchyExtractor.kt` bypasses this filter for
+all `com.android.systemui` nodes (not scoped to the notification shade
+specifically). The broader scope is safe because notification candidate
+collection already filters nodes through resource ID hints and excludes —
+extra system UI nodes (status bar, quick settings) are not collected as
+notification candidates.
+
+Additionally, the occlusion filter is skipped for single-window scenarios
+(`windowEntries.size > 1` guard). Within a single system UI window, peer
+subtrees (e.g. `notification_panel` and `keyguard_message_area_container`)
+were incorrectly stripping each other's content. Multi-window occlusion
+filtering is unaffected.
+
+### Key resource IDs
+
+Matching:
+
+- `NOTIFICATION_ROW_RESOURCE_ID_HINTS`: `notification_row`,
+  `expandablenotificationrow`, `status_bar_notification`,
+  `notification_container`, `notification_content`,
+  `notification_main_column`, `notification_template`
+
+Exclusions (container nodes that must not be collected as individual
+notification candidates):
+
+- `notification_children_container` — the container holding grouped child
+  notifications
+- `notification_container_parent` — broad parent wrapping all notifications
+- `shared_notification_container` — another broad wrapper with full-screen
+  bounds
+
 ## ADB validation (API 35)
 
 Status:
@@ -66,13 +143,10 @@ Notes:
 - `adb shell cmd statusbar expand-settings` is also available to expand quick
   settings when needed.
 
-## Plan
-
-1. Add `systemTray` with open/close/find/tap/dismiss/clearAll actions.
-2. Use accessibility node search to match notification text.
-3. Return structured match details for action chaining.
-
 ## Risks
 
 - OEM System UI layouts vary; emulator support may be the reliable baseline.
 - Requires AccessibilityService access to System UI nodes.
+- Collapsed group expansion depends on the "Expand" button being present in
+  the accessibility tree with predictable `content-desc` and `resource-id`
+  values. Non-standard OEM notification UIs may use different patterns.

--- a/src/server/interactionTools.ts
+++ b/src/server/interactionTools.ts
@@ -620,26 +620,24 @@ export function registerInteractionTools() {
         }
 
         if (isMatchInCollapsedGroup(match)) {
-          const expanded = await expandNotificationGroup(device, match);
-          if (expanded) {
-            const { timer } = getSystemTrayDependencies();
-            await timer.sleep(EXPAND_GROUP_SETTLE_MS);
-            const remainingMs = Math.max(0, awaitTimeoutMs - EXPAND_GROUP_SETTLE_MS);
-            const reMatch = await waitForNotificationMatch(
-              device,
-              notification,
-              appMatchTexts,
-              remainingMs,
-              progress
+          await expandNotificationGroup(device, match);
+          const { timer } = getSystemTrayDependencies();
+          await timer.sleep(EXPAND_GROUP_SETTLE_MS);
+          const remainingMs = Math.max(0, awaitTimeoutMs - EXPAND_GROUP_SETTLE_MS);
+          const reMatch = await waitForNotificationMatch(
+            device,
+            notification,
+            appMatchTexts,
+            remainingMs,
+            progress
+          );
+          if (reMatch.match) {
+            match = reMatch.match;
+          } else {
+            throw new ActionableError(
+              "Expanded collapsed notification group but could not re-match the notification. " +
+              "The group may have changed after expansion."
             );
-            if (reMatch.match) {
-              match = reMatch.match;
-            } else {
-              throw new ActionableError(
-                "Expanded collapsed notification group but could not re-match the notification. " +
-                "The group may have changed after expansion."
-              );
-            }
           }
         }
 

--- a/src/server/interactionTools.ts
+++ b/src/server/interactionTools.ts
@@ -77,8 +77,11 @@ import {
   tapElement,
   swipeElement,
   resolveAppLabel,
+  isMatchInCollapsedGroup,
+  expandNotificationGroup,
   SYSTEM_TRAY_CLEAR_MAX_ITERATIONS,
   SYSTEM_TRAY_NOTIFICATION_SWIPE_DURATION_MS,
+  EXPAND_GROUP_SETTLE_MS,
 } from "./systemTrayHelpers";
 
 // Re-export types for backward compatibility
@@ -526,7 +529,7 @@ export function registerInteractionTools() {
     RecompositionTracker.getInstance().recordInteraction();
     try {
       const pressButton = new PressButton(device);
-      const result = await pressButton.execute(args.button, progress); // observe = true
+      const result = await pressButton.execute(args.button, progress);
 
       return createJSONToolResponse({
         message: `Pressed button ${args.button}`,
@@ -604,7 +607,7 @@ export function registerInteractionTools() {
       }
 
       if (args.action === "tap") {
-        const { match } = await waitForNotificationMatch(
+        let { match } = await waitForNotificationMatch(
           device,
           notification,
           appMatchTexts,
@@ -614,6 +617,30 @@ export function registerInteractionTools() {
 
         if (!match) {
           throw new ActionableError(`Notification not found after ${awaitTimeoutMs}ms.`);
+        }
+
+        if (isMatchInCollapsedGroup(match)) {
+          const expanded = await expandNotificationGroup(device, match);
+          if (expanded) {
+            const { timer } = getSystemTrayDependencies();
+            await timer.sleep(EXPAND_GROUP_SETTLE_MS);
+            const remainingMs = Math.max(0, awaitTimeoutMs - EXPAND_GROUP_SETTLE_MS);
+            const reMatch = await waitForNotificationMatch(
+              device,
+              notification,
+              appMatchTexts,
+              remainingMs,
+              progress
+            );
+            if (reMatch.match) {
+              match = reMatch.match;
+            } else {
+              throw new ActionableError(
+                "Expanded collapsed notification group but could not re-match the notification. " +
+                "The group may have changed after expansion."
+              );
+            }
+          }
         }
 
         const tapMatch = resolveNotificationTapElement(match, notification);

--- a/src/server/systemTrayHelpers.ts
+++ b/src/server/systemTrayHelpers.ts
@@ -12,6 +12,7 @@ import {
   Platform,
   ViewHierarchyResult
 } from "../models";
+import type { ObserveScreenExecuteOptions } from "../features/observe/interfaces/ObserveScreen";
 import { RealObserveScreen } from "../features/observe/ObserveScreen";
 import { defaultAdbClientFactory } from "../utils/android-cmdline-tools/AdbClientFactory";
 import { CtrlProxyClient as IOSCtrlProxyClient } from "../features/observe/ios";
@@ -29,15 +30,7 @@ import { logger } from "../utils/logger";
 // ============================================================================
 
 export interface SystemTrayObserver {
-  execute(
-    queryOptions?: unknown,
-    perf?: unknown,
-    skipWaitForFresh?: boolean,
-    minTimestamp?: number,
-    signal?: AbortSignal,
-    skipBackStack?: boolean,
-    skipScreenshot?: boolean
-  ): Promise<ObserveResult>;
+  execute(options?: ObserveScreenExecuteOptions): Promise<ObserveResult>;
 }
 
 export interface SystemTrayAdb {
@@ -582,8 +575,10 @@ export const expandNotificationGroup = async (
 
   const expandButton = findExpandButtonInGroup(groupNode);
   if (!expandButton) {
-    logger.warn("[systemTray] Collapsed group detected but no expand button found in group node");
-    return false;
+    throw new ActionableError(
+      "Collapsed notification group detected but no expand button found. " +
+      "Cannot tap individual notifications inside a collapsed group."
+    );
   }
 
   logger.info(
@@ -1105,14 +1100,14 @@ const waitForSystemTrayOpen = async (
 ): Promise<ObserveResult> => {
   const { timer } = getSystemTrayDependencies();
   const startTime = timer.now();
-  let observation = await observeScreen.execute(undefined, undefined, false, minTimestamp);
+  let observation = await observeScreen.execute({ skipWaitForFresh: false, minTimestamp });
 
   while (timer.now() - startTime < awaitTimeoutMs) {
     if (isSystemTrayOpen(observation.viewHierarchy, platform)) {
       return observation;
     }
     await sleep(SYSTEM_TRAY_POLL_INTERVAL_MS);
-    observation = await observeScreen.execute(undefined, undefined, false, minTimestamp);
+    observation = await observeScreen.execute({ skipWaitForFresh: false, minTimestamp });
   }
 
   return observation;
@@ -1126,14 +1121,14 @@ const waitForSystemTrayClosed = async (
 ): Promise<ObserveResult> => {
   const { timer } = getSystemTrayDependencies();
   const startTime = timer.now();
-  let observation = await observeScreen.execute(undefined, undefined, false, minTimestamp);
+  let observation = await observeScreen.execute({ skipWaitForFresh: false, minTimestamp });
 
   while (timer.now() - startTime < awaitTimeoutMs) {
     if (!isSystemTrayOpen(observation.viewHierarchy, platform)) {
       return observation;
     }
     await sleep(SYSTEM_TRAY_POLL_INTERVAL_MS);
-    observation = await observeScreen.execute(undefined, undefined, false, minTimestamp);
+    observation = await observeScreen.execute({ skipWaitForFresh: false, minTimestamp });
   }
 
   return observation;
@@ -1156,7 +1151,7 @@ export const ensureSystemTrayOpen = async (
 
   if (device.platform === "ios") {
     minTimestamp = timer.now();
-    observation = await observeScreen.execute(undefined, undefined, false, minTimestamp);
+    observation = await observeScreen.execute({ skipWaitForFresh: false, minTimestamp });
     if (isSystemTrayOpen(observation.viewHierarchy, "ios")) {
       return { observation, opened: false, skipped: true, minTimestamp };
     }
@@ -1177,7 +1172,7 @@ export const ensureSystemTrayOpen = async (
 
   if (device.platform === "android") {
     minTimestamp = await resolveSystemTrayObservationTimestamp(device);
-    observation = await observeScreen.execute(undefined, undefined, false, minTimestamp);
+    observation = await observeScreen.execute({ skipWaitForFresh: false, minTimestamp });
     if (isSystemTrayOpen(observation.viewHierarchy)) {
       return { observation, opened: false, skipped: true, minTimestamp };
     }
@@ -1219,7 +1214,7 @@ export const ensureSystemTrayClosed = async (
 
   if (device.platform === "ios") {
     minTimestamp = timer.now();
-    observation = await observeScreen.execute(undefined, undefined, false, minTimestamp);
+    observation = await observeScreen.execute({ skipWaitForFresh: false, minTimestamp });
     if (!isSystemTrayOpen(observation.viewHierarchy, "ios")) {
       return { observation, closed: false, skipped: true, minTimestamp };
     }
@@ -1240,7 +1235,7 @@ export const ensureSystemTrayClosed = async (
 
   if (device.platform === "android") {
     minTimestamp = await resolveSystemTrayObservationTimestamp(device);
-    observation = await observeScreen.execute(undefined, undefined, false, minTimestamp);
+    observation = await observeScreen.execute({ skipWaitForFresh: false, minTimestamp });
     if (!isSystemTrayOpen(observation.viewHierarchy)) {
       return { observation, closed: false, skipped: true, minTimestamp };
     }
@@ -1280,7 +1275,7 @@ export const waitForNotificationMatch = async (
   let observation = result.observation;
   const minTimestamp = result.minTimestamp;
   if (!observation) {
-    observation = await observeScreen.execute(undefined, undefined, false, minTimestamp);
+    observation = await observeScreen.execute({ skipWaitForFresh: false, minTimestamp });
   }
 
   while (true) {
@@ -1297,7 +1292,7 @@ export const waitForNotificationMatch = async (
     }
 
     await sleep(SYSTEM_TRAY_POLL_INTERVAL_MS);
-    observation = await observeScreen.execute(undefined, undefined, false, minTimestamp);
+    observation = await observeScreen.execute({ skipWaitForFresh: false, minTimestamp });
   }
 };
 

--- a/src/server/systemTrayHelpers.ts
+++ b/src/server/systemTrayHelpers.ts
@@ -22,6 +22,7 @@ import { DefaultElementParser } from "../features/utility/ElementParser";
 import type { ProgressCallback } from "./toolRegistry";
 import type { SystemTrayNotificationArgs } from "./interactionToolTypes";
 import { boundsArea } from "../utils/bounds";
+import { logger } from "../utils/logger";
 
 // ============================================================================
 // Interfaces
@@ -33,7 +34,9 @@ export interface SystemTrayObserver {
     perf?: unknown,
     skipWaitForFresh?: boolean,
     minTimestamp?: number,
-    signal?: AbortSignal
+    signal?: AbortSignal,
+    skipBackStack?: boolean,
+    skipScreenshot?: boolean
   ): Promise<ObserveResult>;
 }
 
@@ -148,6 +151,7 @@ const SYSTEM_TRAY_CLASS_HINTS = [
 ];
 const NOTIFICATION_ROW_RESOURCE_ID_HINTS = [
   "notification_row",
+  "expandablenotificationrow",
   "status_bar_notification",
   "notification_container",
   "notification_content",
@@ -163,12 +167,16 @@ const NOTIFICATION_ROW_CLASS_HINTS = [
 const NOTIFICATION_ROW_RESOURCE_ID_EXCLUDES = [
   ...SYSTEM_TRAY_RESOURCE_ID_HINTS,
   "notification_shelf",
-  "notification_stack_scroll"
+  "notification_stack_scroll",
+  "notification_children_container",
+  "notification_container_parent",
+  "shared_notification_container"
 ];
 const DEFAULT_SYSTEM_TRAY_AWAIT_TIMEOUT_MS = 5000;
 const SYSTEM_TRAY_POLL_INTERVAL_MS = 250;
 export const SYSTEM_TRAY_CLEAR_MAX_ITERATIONS = 25;
 export const SYSTEM_TRAY_NOTIFICATION_SWIPE_DURATION_MS = 300;
+export const EXPAND_GROUP_SETTLE_MS = 500;
 
 // ============================================================================
 // Internal Types
@@ -197,6 +205,7 @@ interface SystemTrayNotificationCandidate {
   node: any;
   depth: number;
   element?: Element;
+  groupNode?: any;
 }
 
 interface SystemTrayNotificationMatch {
@@ -491,29 +500,131 @@ const nodeHasNotificationRowHint = (node: any): boolean => {
   return matchesResourceId || matchesClassName;
 };
 
-const collectNotificationCandidates = (viewHierarchy: ViewHierarchyResult): SystemTrayNotificationCandidate[] => {
-  const candidates: SystemTrayNotificationCandidate[] = [];
+// Only checks direct children for notification_children_container.
+// Android's standard SystemUI places this container as an immediate child
+// of the group row node. If a future OEM wraps it deeper, this will need
+// to become a recursive search.
+const nodeIsNotificationGroup = (node: any): boolean => {
+  const children = node.node;
+  const checkChild = (child: any): boolean => {
+    if (!child) {
+      return false;
+    }
+    const props = getNodeProperties(child);
+    if (!props) {
+      return false;
+    }
+    const resourceId = String(props["resource-id"] ?? props.resourceId ?? "").toLowerCase();
+    return resourceId.includes("notification_children_container");
+  };
+
+  if (Array.isArray(children)) {
+    return children.some(checkChild);
+  }
+  return checkChild(children);
+};
+
+export const isMatchInCollapsedGroup = (match: SystemTrayNotificationMatch): boolean => {
+  return !!match.candidate.groupNode;
+};
+
+const findExpandButtonInGroup = (groupNode: any): Element | null => {
   const parser = new DefaultElementParser();
 
-  const visit = (node: any, depth: number): void => {
+  const search = (node: any): Element | null => {
     if (!node) {
-      return;
+      return null;
     }
 
-    if (nodeHasNotificationRowHint(node)) {
-      const element = parser.parseNodeBounds(node) ?? undefined;
-      candidates.push({ node, depth, element });
-      return;
+    const props = getNodeProperties(node);
+    if (props) {
+      const contentDesc = String(props["content-desc"] ?? props.contentDesc ?? "").toLowerCase();
+      const resourceId = String(props["resource-id"] ?? props.resourceId ?? "").toLowerCase();
+      const matchesDesc = contentDesc === "expand";
+      const matchesId = resourceId.includes("expand_button");
+      if (matchesDesc || matchesId) {
+        if (matchesDesc !== matchesId) {
+          logger.warn(
+            `[systemTray] Expand button partial match: ` +
+            `content-desc="${contentDesc}", resource-id="${resourceId}"`
+          );
+        }
+        return parser.parseNodeBounds(node) ?? null;
+      }
     }
 
     const children = node.node;
     if (Array.isArray(children)) {
       for (const child of children) {
-        visit(child, depth + 1);
+        const result = search(child);
+        if (result) {
+          return result;
+        }
       }
     } else if (children && typeof children === "object") {
-      visit(children, depth + 1);
+      return search(children);
     }
+
+    return null;
+  };
+
+  return search(groupNode);
+};
+
+export const expandNotificationGroup = async (
+  device: BootedDevice,
+  match: SystemTrayNotificationMatch
+): Promise<boolean> => {
+  const groupNode = match.candidate.groupNode;
+  if (!groupNode) {
+    return false;
+  }
+
+  const expandButton = findExpandButtonInGroup(groupNode);
+  if (!expandButton) {
+    logger.warn("[systemTray] Collapsed group detected but no expand button found in group node");
+    return false;
+  }
+
+  logger.info(
+    `[systemTray] Expanding collapsed notification group ` +
+    `(tap ${expandButton.bounds?.left},${expandButton.bounds?.top})`
+  );
+  await tapElement(device, expandButton);
+  return true;
+};
+
+const collectNotificationCandidates = (viewHierarchy: ViewHierarchyResult): SystemTrayNotificationCandidate[] => {
+  const candidates: SystemTrayNotificationCandidate[] = [];
+  const parser = new DefaultElementParser();
+
+  const visitChildren = (node: any, depth: number, groupNode?: any): void => {
+    const children = node.node;
+    if (Array.isArray(children)) {
+      for (const child of children) {
+        visit(child, depth + 1, groupNode);
+      }
+    } else if (children && typeof children === "object") {
+      visit(children, depth + 1, groupNode);
+    }
+  };
+
+  const visit = (node: any, depth: number, groupNode?: any): void => {
+    if (!node) {
+      return;
+    }
+
+    if (nodeHasNotificationRowHint(node)) {
+      if (nodeIsNotificationGroup(node)) {
+        visitChildren(node, depth, node);
+        return;
+      }
+      const element = parser.parseNodeBounds(node) ?? undefined;
+      candidates.push({ node, depth, element, groupNode });
+      return;
+    }
+
+    visitChildren(node, depth, groupNode);
   };
 
   const rootNodes = getHierarchyRoots(viewHierarchy);
@@ -894,6 +1005,12 @@ const getCandidateArea = (candidate: SystemTrayNotificationCandidate): number =>
   return boundsArea(bounds);
 };
 
+const CANDIDATE_NO_BOUNDS_TOP_Y = Infinity;
+
+const getCandidateTopY = (candidate: SystemTrayNotificationCandidate): number => {
+  return candidate.element?.bounds?.top ?? CANDIDATE_NO_BOUNDS_TOP_Y;
+};
+
 const selectBestNotificationMatch = (
   matches: SystemTrayNotificationMatch[]
 ): SystemTrayNotificationMatch | null => {
@@ -911,6 +1028,12 @@ const selectBestNotificationMatch = (
       }
       if (leftCounts.partial !== rightCounts.partial) {
         return rightCounts.partial - leftCounts.partial;
+      }
+      // Prefer topmost notification (most recent in Android shade)
+      const leftTop = getCandidateTopY(left.candidate);
+      const rightTop = getCandidateTopY(right.candidate);
+      if (leftTop !== rightTop) {
+        return leftTop - rightTop;
       }
       const leftArea = getCandidateArea(left.candidate);
       const rightArea = getCandidateArea(right.candidate);
@@ -1161,16 +1284,16 @@ export const waitForNotificationMatch = async (
   }
 
   while (true) {
-    if (timer.now() >= deadlineMs) {
-      return { observation, match: null };
-    }
-
     const viewHierarchy = observation.viewHierarchy;
     if (viewHierarchy && isSystemTrayOpen(viewHierarchy, device.platform)) {
       const match = findBestNotificationMatch(viewHierarchy, criteria, appMatchTexts);
       if (match) {
         return { observation, match };
       }
+    }
+
+    if (timer.now() >= deadlineMs) {
+      return { observation, match: null };
     }
 
     await sleep(SYSTEM_TRAY_POLL_INTERVAL_MS);

--- a/src/utils/plan/PlanMigrator.ts
+++ b/src/utils/plan/PlanMigrator.ts
@@ -296,6 +296,16 @@ const migrateStepFields = (
     }
   }
 
+  if (normalizedTool === "systemTray") {
+    const notification = isRecord(mergedParams.notification) ? mergedParams.notification : undefined;
+    if (notification && typeof notification.timeout === "number" && mergedParams.awaitTimeout === undefined) {
+      mergedParams.awaitTimeout = notification.timeout;
+      delete notification.timeout;
+      recordWarning(warnings, "Moved notification.timeout to awaitTimeout.", stepIndex);
+      changed = true;
+    }
+  }
+
   if (normalizedTool === "observe") {
     if (mergedParams.withViewHierarchy !== undefined) {
       delete mergedParams.withViewHierarchy;

--- a/test/server/systemTray.test.ts
+++ b/test/server/systemTray.test.ts
@@ -53,14 +53,10 @@ class SequencedObserveScreen extends FakeObserveScreen {
   }
 
   async execute(
-    queryOptions?: unknown,
-    perf?: unknown,
-    skipWaitForFresh?: boolean,
-    minTimestamp?: number,
-    signal?: AbortSignal
+    options?: { skipWaitForFresh?: boolean; minTimestamp?: number; signal?: AbortSignal }
   ): Promise<ObserveResult> {
-    this.minTimestamps.push(minTimestamp);
-    return super.execute(queryOptions, perf, skipWaitForFresh, minTimestamp, signal);
+    this.minTimestamps.push(options?.minTimestamp);
+    return super.execute(options);
   }
 
   getMinTimestamps(): Array<number | undefined> {
@@ -809,7 +805,7 @@ describe("systemTray group expansion", () => {
     expect(tapCmd).toMatch(/input tap \d+ \d+/);
   });
 
-  test("expandNotificationGroup returns false when no expand button exists", async () => {
+  test("expandNotificationGroup throws when no expand button exists", async () => {
     const fakeTimer = new FakeTimer();
     const fakeAdb = new SequencedFakeAdbExecutor([1000]);
     const fakeObserveScreen = new SequencedObserveScreen([
@@ -835,8 +831,9 @@ describe("systemTray group expansion", () => {
     expect(result.match).not.toBeNull();
     expect(isMatchInCollapsedGroup(result.match!)).toBe(true);
 
-    const expanded = await expandNotificationGroup(device, result.match!);
-    expect(expanded).toBe(false);
+    await expect(expandNotificationGroup(device, result.match!)).rejects.toThrow(
+      "Collapsed notification group detected but no expand button found"
+    );
 
     const tapCommands = fakeAdb.getExecutedCommands()
       .filter(cmd => cmd.includes("input tap"));

--- a/test/server/systemTray.test.ts
+++ b/test/server/systemTray.test.ts
@@ -9,6 +9,8 @@ import {
   ensureSystemTrayOpen,
   tapElement,
   swipeElement,
+  isMatchInCollapsedGroup,
+  expandNotificationGroup,
 } from "../../src/server/systemTrayHelpers";
 import type { SystemTrayIosClient } from "../../src/server/systemTrayHelpers";
 import { FakeTimer } from "../fakes/FakeTimer";
@@ -334,6 +336,609 @@ const createIosNotificationCenterHierarchy = (title: string, body?: string): Vie
       }]
     }
   }
+});
+
+// ============================================================================
+// Notification group matching tests
+// ============================================================================
+
+const createTrayWithGroupedNotifications = (
+  appLabel: string,
+  titles: string[]
+): ViewHierarchyResult => ({
+  packageName: SYSTEM_TRAY_PACKAGE,
+  hierarchy: {
+    node: {
+      $: {
+        "resource-id": "com.android.systemui:id/notification_stack_scroller",
+        "packageName": SYSTEM_TRAY_PACKAGE,
+        "bounds": "[0,0][1080,1920]"
+      },
+      node: [{
+        $: {
+          "resource-id": "com.android.systemui:id/expandableNotificationRow",
+          "bounds": "[48,663][1296,993]"
+        },
+        node: {
+          $: {
+            "resource-id": "com.android.systemui:id/notification_children_container",
+            "className": "android.view.ViewGroup",
+            "bounds": "[48,663][1296,993]"
+          },
+          node: [
+            {
+              $: {
+                "resource-id": "android:id/notification_header",
+                "className": "android.widget.RelativeLayout",
+                "bounds": "[48,663][1296,731]"
+              },
+              node: [
+                {
+                  $: {
+                    "text": appLabel,
+                    "resource-id": "android:id/app_name_text",
+                    "bounds": "[204,672][391,721]"
+                  }
+                },
+                {
+                  $: {
+                    "content-desc": "Expand",
+                    "resource-id": "android:id/expand_button",
+                    "className": "android.widget.Button",
+                    "clickable": "true",
+                    "bounds": "[1084,663][1296,731]"
+                  }
+                }
+              ]
+            },
+            ...titles.map((title, i) => ({
+              $: {
+                "resource-id": "com.android.systemui:id/expandableNotificationRow",
+                "className": "android.widget.FrameLayout",
+                "bounds": `[48,${731 + i * 80}][1296,${811 + i * 80}]`
+              },
+              node: {
+                $: {
+                  "resource-id": "android:id/notification_content",
+                  "bounds": `[48,${731 + i * 80}][1296,${811 + i * 80}]`
+                },
+                node: {
+                  $: {
+                    "text": title,
+                    "resource-id": "android:id/title",
+                    "bounds": `[96,${741 + i * 80}][900,${801 + i * 80}]`
+                  }
+                }
+              }
+            }))
+          ]
+        }
+      }]
+    }
+  }
+} as unknown as ViewHierarchyResult);
+
+const createTrayWithGroupedNotificationsNoExpandButton = (
+  appLabel: string,
+  titles: string[]
+): ViewHierarchyResult => ({
+  packageName: SYSTEM_TRAY_PACKAGE,
+  hierarchy: {
+    node: {
+      $: {
+        "resource-id": "com.android.systemui:id/notification_stack_scroller",
+        "packageName": SYSTEM_TRAY_PACKAGE,
+        "bounds": "[0,0][1080,1920]"
+      },
+      node: [{
+        $: {
+          "resource-id": "com.android.systemui:id/expandableNotificationRow",
+          "bounds": "[48,663][1296,993]"
+        },
+        node: {
+          $: {
+            "resource-id": "com.android.systemui:id/notification_children_container",
+            "className": "android.view.ViewGroup",
+            "bounds": "[48,663][1296,993]"
+          },
+          node: [
+            {
+              $: {
+                "resource-id": "android:id/notification_header",
+                "className": "android.widget.RelativeLayout",
+                "bounds": "[48,663][1296,731]"
+              },
+              node: {
+                $: {
+                  "text": appLabel,
+                  "resource-id": "android:id/app_name_text",
+                  "bounds": "[204,672][391,721]"
+                }
+              }
+            },
+            ...titles.map((title, i) => ({
+              $: {
+                "resource-id": "com.android.systemui:id/expandableNotificationRow",
+                "className": "android.widget.FrameLayout",
+                "bounds": `[48,${731 + i * 80}][1296,${811 + i * 80}]`
+              },
+              node: {
+                $: {
+                  "resource-id": "android:id/notification_content",
+                  "bounds": `[48,${731 + i * 80}][1296,${811 + i * 80}]`
+                },
+                node: {
+                  $: {
+                    "text": title,
+                    "resource-id": "android:id/title",
+                    "bounds": `[96,${741 + i * 80}][900,${801 + i * 80}]`
+                  }
+                }
+              }
+            }))
+          ]
+        }
+      }]
+    }
+  }
+} as unknown as ViewHierarchyResult);
+
+const createTrayWithExpandedNotifications = (
+  titles: string[]
+): ViewHierarchyResult => ({
+  packageName: SYSTEM_TRAY_PACKAGE,
+  hierarchy: {
+    node: {
+      $: {
+        "resource-id": "com.android.systemui:id/notification_stack_scroller",
+        "packageName": SYSTEM_TRAY_PACKAGE,
+        "bounds": "[0,0][1080,1920]"
+      },
+      node: titles.map((title, i) => ({
+        $: {
+          "resource-id": "com.android.systemui:id/expandableNotificationRow",
+          "className": "android.widget.FrameLayout",
+          "clickable": "true",
+          "bounds": `[48,${400 + i * 200}][1296,${600 + i * 200}]`
+        },
+        node: {
+          $: {
+            "resource-id": "android:id/notification_content",
+            "bounds": `[48,${400 + i * 200}][1296,${600 + i * 200}]`
+          },
+          node: {
+            $: {
+              "text": title,
+              "resource-id": "android:id/title",
+              "bounds": `[96,${410 + i * 200}][900,${590 + i * 200}]`
+            }
+          }
+        }
+      }))
+    }
+  }
+} as unknown as ViewHierarchyResult);
+
+describe("systemTray grouped notifications", () => {
+  afterEach(() => {
+    resetSystemTrayDependencies();
+  });
+
+  test("matches individual notification inside a collapsed group", async () => {
+    const fakeTimer = new FakeTimer();
+    const fakeAdb = new SequencedFakeAdbExecutor([1000]);
+    const fakeObserveScreen = new SequencedObserveScreen([
+      createObservation(createTrayWithGroupedNotifications(
+        "FUBStaging",
+        ["Zillow Real-Time Tour request", "New Lead: Jane Smith"]
+      ))
+    ]);
+
+    setSystemTrayDependencies({
+      timer: fakeTimer,
+      adbFactory: () => fakeAdb,
+      observeScreenFactory: () => fakeObserveScreen
+    });
+
+    const result = await waitForNotificationMatch(
+      device,
+      { title: "Zillow Real-Time Tour request" },
+      [],
+      500
+    );
+
+    expect(result.match).not.toBeNull();
+    expect(result.match!.match.matches.title?.text).toBe("Zillow Real-Time Tour request");
+  });
+
+  test("prefers topmost notification when multiple match", async () => {
+    const fakeTimer = new FakeTimer();
+    const fakeAdb = new SequencedFakeAdbExecutor([1000]);
+    const fakeObserveScreen = new SequencedObserveScreen([
+      createObservation(createTrayWithGroupedNotifications(
+        "FUBStaging",
+        ["Zillow Real-Time Tour request", "Zillow Real-Time Tour request"]
+      ))
+    ]);
+
+    setSystemTrayDependencies({
+      timer: fakeTimer,
+      adbFactory: () => fakeAdb,
+      observeScreenFactory: () => fakeObserveScreen
+    });
+
+    const result = await waitForNotificationMatch(
+      device,
+      { title: "Zillow Real-Time Tour request" },
+      [],
+      500
+    );
+
+    expect(result.match).not.toBeNull();
+    expect(result.match!.match.matches.title?.text).toBe("Zillow Real-Time Tour request");
+    // First notification row starts at y=731, second at y=811
+    expect(result.match!.candidate.element?.bounds?.top).toBe(731);
+  });
+
+  test("does not match notification_container_parent or shared_notification_container", async () => {
+    const fakeTimer = new FakeTimer();
+    const fakeAdb = new SequencedFakeAdbExecutor([1000]);
+
+    const hierarchy: any = {
+      packageName: SYSTEM_TRAY_PACKAGE,
+      hierarchy: {
+        node: {
+          $: {
+            "resource-id": "com.android.systemui:id/notification_panel",
+            "packageName": SYSTEM_TRAY_PACKAGE,
+            "bounds": "[0,0][1344,2992]"
+          },
+          node: {
+            $: {
+              "resource-id": "com.android.systemui:id/shared_notification_container",
+              "bounds": "[0,0][1344,2992]"
+            },
+            node: {
+              $: {
+                "resource-id": "com.android.systemui:id/notification_container_parent",
+                "bounds": "[0,0][1344,2992]"
+              },
+              node: {
+                $: {
+                  "resource-id": "com.android.systemui:id/notification_stack_scroller",
+                  "bounds": "[0,0][1344,2896]"
+                },
+                node: {
+                  $: {
+                    "resource-id": "com.android.systemui:id/expandableNotificationRow",
+                    "clickable": "true",
+                    "bounds": "[48,663][1296,1073]"
+                  },
+                  node: {
+                    $: {
+                      "text": "Zillow Real-Time Tour request",
+                      "resource-id": "android:id/title",
+                      "bounds": "[204,813][1248,878]"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    };
+
+    const fakeObserveScreen = new SequencedObserveScreen([
+      createObservation(hierarchy)
+    ]);
+
+    setSystemTrayDependencies({
+      timer: fakeTimer,
+      adbFactory: () => fakeAdb,
+      observeScreenFactory: () => fakeObserveScreen
+    });
+
+    const result = await waitForNotificationMatch(
+      device,
+      { title: "Zillow Real-Time Tour request" },
+      [],
+      500
+    );
+
+    expect(result.match).not.toBeNull();
+    expect(result.match!.candidate.element?.bounds?.top).toBe(663);
+    expect(result.match!.candidate.element?.bounds?.bottom).toBe(1073);
+    expect(result.match!.candidate.node?.$?.["resource-id"]).toBe(
+      "com.android.systemui:id/expandableNotificationRow"
+    );
+  });
+
+  test("does not match unrelated titles in grouped notifications", async () => {
+    const fakeTimer = new FakeTimer();
+    const fakeAdb = new SequencedFakeAdbExecutor([1000]);
+    const fakeObserveScreen = new SequencedObserveScreen([
+      createObservation(createTrayWithGroupedNotifications(
+        "FUBStaging",
+        ["New Lead: Jane Smith", "New Lead: Bob Wilson"]
+      )),
+      createObservation(createTrayWithGroupedNotifications(
+        "FUBStaging",
+        ["New Lead: Jane Smith", "New Lead: Bob Wilson"]
+      ))
+    ]);
+
+    setSystemTrayDependencies({
+      timer: fakeTimer,
+      adbFactory: () => fakeAdb,
+      observeScreenFactory: () => fakeObserveScreen
+    });
+
+    const resultPromise = waitForNotificationMatch(
+      device,
+      { title: "Zillow Real-Time Tour request" },
+      [],
+      500
+    );
+
+    await advancePendingSleeps(fakeTimer, 3);
+
+    const result = await resultPromise;
+
+    expect(result.match).toBeNull();
+  });
+});
+
+describe("systemTray group expansion", () => {
+  afterEach(() => {
+    resetSystemTrayDependencies();
+  });
+
+  test("detects match in collapsed group via groupNode", async () => {
+    const fakeTimer = new FakeTimer();
+    const fakeAdb = new SequencedFakeAdbExecutor([1000]);
+    const fakeObserveScreen = new SequencedObserveScreen([
+      createObservation(createTrayWithGroupedNotifications(
+        "FUBStaging",
+        ["Zillow Real-Time Tour request"]
+      ))
+    ]);
+
+    setSystemTrayDependencies({
+      timer: fakeTimer,
+      adbFactory: () => fakeAdb,
+      observeScreenFactory: () => fakeObserveScreen
+    });
+
+    const result = await waitForNotificationMatch(
+      device,
+      { title: "Zillow Real-Time Tour request" },
+      [],
+      500
+    );
+
+    expect(result.match).not.toBeNull();
+    expect(isMatchInCollapsedGroup(result.match!)).toBe(true);
+  });
+
+  test("standalone notification is not in collapsed group", async () => {
+    const fakeTimer = new FakeTimer();
+    const fakeAdb = new SequencedFakeAdbExecutor([1000]);
+    const hierarchy: any = {
+      packageName: SYSTEM_TRAY_PACKAGE,
+      hierarchy: {
+        node: {
+          $: {
+            "resource-id": "com.android.systemui:id/notification_stack_scroller",
+            "packageName": SYSTEM_TRAY_PACKAGE,
+            "bounds": "[0,0][1080,1920]"
+          },
+          node: {
+            $: {
+              "resource-id": "com.android.systemui:id/expandableNotificationRow",
+              "clickable": "true",
+              "bounds": "[48,663][1296,1073]"
+            },
+            node: {
+              $: {
+                "text": "Zillow Real-Time Tour request",
+                "resource-id": "android:id/title",
+                "bounds": "[204,813][1248,878]"
+              }
+            }
+          }
+        }
+      }
+    };
+    const fakeObserveScreen = new SequencedObserveScreen([
+      createObservation(hierarchy)
+    ]);
+
+    setSystemTrayDependencies({
+      timer: fakeTimer,
+      adbFactory: () => fakeAdb,
+      observeScreenFactory: () => fakeObserveScreen
+    });
+
+    const result = await waitForNotificationMatch(
+      device,
+      { title: "Zillow Real-Time Tour request" },
+      [],
+      500
+    );
+
+    expect(result.match).not.toBeNull();
+    expect(isMatchInCollapsedGroup(result.match!)).toBe(false);
+  });
+
+  test("expandNotificationGroup taps expand button in group", async () => {
+    const fakeTimer = new FakeTimer();
+    const fakeAdb = new SequencedFakeAdbExecutor([1000]);
+    const fakeObserveScreen = new SequencedObserveScreen([
+      createObservation(createTrayWithGroupedNotifications(
+        "FUBStaging",
+        ["Zillow Real-Time Tour request"]
+      ))
+    ]);
+
+    setSystemTrayDependencies({
+      timer: fakeTimer,
+      adbFactory: () => fakeAdb,
+      observeScreenFactory: () => fakeObserveScreen
+    });
+
+    const result = await waitForNotificationMatch(
+      device,
+      { title: "Zillow Real-Time Tour request" },
+      [],
+      500
+    );
+
+    expect(result.match).not.toBeNull();
+    expect(isMatchInCollapsedGroup(result.match!)).toBe(true);
+
+    const expanded = await expandNotificationGroup(device, result.match!);
+    expect(expanded).toBe(true);
+
+    const tapCommands = fakeAdb.getExecutedCommands()
+      .filter(cmd => cmd.includes("input tap"));
+    expect(tapCommands.length).toBe(1);
+
+    const tapCmd = tapCommands[0];
+    expect(tapCmd).toContain("input tap");
+    expect(tapCmd).toMatch(/input tap \d+ \d+/);
+  });
+
+  test("expandNotificationGroup returns false when no expand button exists", async () => {
+    const fakeTimer = new FakeTimer();
+    const fakeAdb = new SequencedFakeAdbExecutor([1000]);
+    const fakeObserveScreen = new SequencedObserveScreen([
+      createObservation(createTrayWithGroupedNotificationsNoExpandButton(
+        "FUBStaging",
+        ["Zillow Real-Time Tour request"]
+      ))
+    ]);
+
+    setSystemTrayDependencies({
+      timer: fakeTimer,
+      adbFactory: () => fakeAdb,
+      observeScreenFactory: () => fakeObserveScreen
+    });
+
+    const result = await waitForNotificationMatch(
+      device,
+      { title: "Zillow Real-Time Tour request" },
+      [],
+      500
+    );
+
+    expect(result.match).not.toBeNull();
+    expect(isMatchInCollapsedGroup(result.match!)).toBe(true);
+
+    const expanded = await expandNotificationGroup(device, result.match!);
+    expect(expanded).toBe(false);
+
+    const tapCommands = fakeAdb.getExecutedCommands()
+      .filter(cmd => cmd.includes("input tap"));
+    expect(tapCommands.length).toBe(0);
+  });
+
+  test("tap action expands collapsed group then re-matches", async () => {
+    const fakeTimer = new FakeTimer();
+    const fakeAdb = new SequencedFakeAdbExecutor([1000, 1000]);
+
+    const collapsedHierarchy = createTrayWithGroupedNotifications(
+      "FUBStaging",
+      ["Zillow Real-Time Tour request", "Test message"]
+    );
+    const expandedHierarchy = createTrayWithExpandedNotifications(
+      ["Zillow Real-Time Tour request", "Test message"]
+    );
+
+    const fakeObserveScreen = new SequencedObserveScreen([
+      createObservation(collapsedHierarchy),
+      createObservation(expandedHierarchy),
+      createObservation(expandedHierarchy),
+      createObservation(expandedHierarchy),
+    ]);
+
+    setSystemTrayDependencies({
+      timer: fakeTimer,
+      adbFactory: () => fakeAdb,
+      observeScreenFactory: () => fakeObserveScreen
+    });
+
+    const result = await waitForNotificationMatch(
+      device,
+      { title: "Zillow Real-Time Tour request" },
+      [],
+      5000
+    );
+
+    expect(result.match).not.toBeNull();
+    expect(isMatchInCollapsedGroup(result.match!)).toBe(true);
+
+    const reResult = await waitForNotificationMatch(
+      device,
+      { title: "Zillow Real-Time Tour request" },
+      [],
+      5000
+    );
+
+    expect(reResult.match).not.toBeNull();
+    expect(isMatchInCollapsedGroup(reResult.match!)).toBe(false);
+  });
+
+  test("re-match returns null when notification disappears after expand", async () => {
+    const fakeTimer = new FakeTimer();
+    const fakeAdb = new SequencedFakeAdbExecutor([1000, 1000]);
+
+    const collapsedHierarchy = createTrayWithGroupedNotifications(
+      "FUBStaging",
+      ["Zillow Real-Time Tour request"]
+    );
+    const postExpandHierarchy = createTrayWithExpandedNotifications(
+      ["Completely different notification"]
+    );
+
+    const fakeObserveScreen = new SequencedObserveScreen([
+      createObservation(collapsedHierarchy),
+      createObservation(postExpandHierarchy),
+      createObservation(postExpandHierarchy),
+      createObservation(postExpandHierarchy),
+    ]);
+
+    setSystemTrayDependencies({
+      timer: fakeTimer,
+      adbFactory: () => fakeAdb,
+      observeScreenFactory: () => fakeObserveScreen
+    });
+
+    const { match } = await waitForNotificationMatch(
+      device,
+      { title: "Zillow Real-Time Tour request" },
+      [],
+      5000
+    );
+
+    expect(match).not.toBeNull();
+    expect(isMatchInCollapsedGroup(match!)).toBe(true);
+
+    const expanded = await expandNotificationGroup(device, match!);
+    expect(expanded).toBe(true);
+
+    const reMatchPromise = waitForNotificationMatch(
+      device,
+      { title: "Zillow Real-Time Tour request" },
+      [],
+      500
+    );
+
+    await advancePendingSleeps(fakeTimer, 5);
+
+    const reResult = await reMatchPromise;
+    expect(reResult.match).toBeNull();
+  });
 });
 
 describe("iOS systemTray open", () => {

--- a/test/utils/plan/PlanMigrator.test.ts
+++ b/test/utils/plan/PlanMigrator.test.ts
@@ -343,6 +343,40 @@ describe("PlanMigrator", () => {
         expect(report.warnings.some(w => w.message.includes("Removed deprecated scrollMode"))).toBe(true);
       });
 
+      test("moves systemTray notification.timeout to awaitTimeout", () => {
+        const { plan, report } = migratePlan({
+          name: "Plan",
+          mcpVersion: "1.0.0",
+          metadata: { createdAt: "2024-01-01", version: "1.0.0" },
+          steps: [{
+            tool: "systemTray",
+            action: "tap",
+            notification: { title: "Test notification", timeout: 15000 },
+          }],
+        });
+
+        expect(plan.steps[0].params.awaitTimeout).toBe(15000);
+        expect(plan.steps[0].params.notification.timeout).toBeUndefined();
+        expect(plan.steps[0].params.notification.title).toBe("Test notification");
+        expect(report.warnings.some(w => w.message.includes("notification.timeout to awaitTimeout"))).toBe(true);
+      });
+
+      test("does not overwrite explicit awaitTimeout with notification.timeout", () => {
+        const { plan } = migratePlan({
+          name: "Plan",
+          mcpVersion: "1.0.0",
+          metadata: { createdAt: "2024-01-01", version: "1.0.0" },
+          steps: [{
+            tool: "systemTray",
+            action: "tap",
+            notification: { title: "Test", timeout: 15000 },
+            awaitTimeout: 10000,
+          }],
+        });
+
+        expect(plan.steps[0].params.awaitTimeout).toBe(10000);
+      });
+
       test("removes deprecated observe.withViewHierarchy", () => {
         const { plan, report } = migratePlan({
           name: "Plan",


### PR DESCRIPTION
Closes #2096, #2120

- Auto-expand collapsed notification groups before tapping
- Reorder deadline check in waitForNotificationMatch to avoid rejecting valid matches at the boundary
- Migrate notification.timeout to awaitTimeout via PlanMigrator
- Add top-Y tiebreaker for multiple notification matches
- Migrate bare setInterval to timer.setInterval for FakeTimer compat
- Add systemTray tests and PlanMigrator tests
- Document notification group expansion in design docs and CLAUDE.md