### PR TITLE
fix: handle grep -c exit code 1 when checking package installation

### DIFF
--- a/src/features/action/InstallApp.ts
+++ b/src/features/action/InstallApp.ts
@@ -118,9 +118,13 @@ export class InstallApp {
     if (packageName) {
       // Check if app is already installed for this user
       isInstalled = await perf.track("checkInstalled", async () => {
-        const isInstalledCmd = `shell pm list packages --user ${targetUserId} -f ${packageName} | grep -c ${packageName}`;
-        const isInstalledOutput = await this.adb.executeCommand(isInstalledCmd, undefined, undefined, true, signal);
-        return parseInt(isInstalledOutput.trim(), 10) > 0;
+        try {
+          const isInstalledCmd = `shell pm list packages --user ${targetUserId} -f ${packageName} | grep -c ${packageName}`;
+          const isInstalledOutput = await this.adb.executeCommand(isInstalledCmd, undefined, undefined, true, signal);
+          return parseInt(isInstalledOutput.trim(), 10) > 0;
+        } catch {
+          return false;
+        }
       });
     }
 

--- a/src/features/action/TerminateApp.ts
+++ b/src/features/action/TerminateApp.ts
@@ -74,9 +74,13 @@ export class TerminateApp extends BaseVisualChange {
 
       // Check if app is installed
       const isInstalled = await perf.track("checkInstalled", async () => {
-        const isInstalledCmd = `shell pm list packages --user ${targetUserId} -f ${packageName} | grep -c ${packageName}`;
-        const isInstalledOutput = await this.adb.executeCommand(isInstalledCmd, undefined, undefined, true);
-        return parseInt(isInstalledOutput.trim(), 10) > 0;
+        try {
+          const isInstalledCmd = `shell pm list packages --user ${targetUserId} -f ${packageName} | grep -c ${packageName}`;
+          const isInstalledOutput = await this.adb.executeCommand(isInstalledCmd, undefined, undefined, true);
+          return parseInt(isInstalledOutput.trim(), 10) > 0;
+        } catch {
+          return false;
+        }
       });
 
       if (!isInstalled) {

--- a/test/features/action/InstallApp.test.ts
+++ b/test/features/action/InstallApp.test.ts
@@ -450,6 +450,26 @@ describe("InstallApp", () => {
     await expect(installApp.execute(ipaPath, undefined, controller.signal)).rejects.toThrow("Operation cancelled");
   });
 
+  test("treats grep -c failure as not installed instead of throwing", async () => {
+    const apkPath = "/tmp/app-debug.apk";
+    const perf = createPerformanceTracker(true, fakeTimer);
+
+    fakeLocator.setTool({ tool: "aapt2", path: "/sdk/build-tools/35.0.0/aapt2" });
+    fakeHost.setCommandResponse("aapt2", createExecResult("package: name='com.example.app' versionCode='1'"));
+
+    fakeAdb.setUsers([{ userId: 0, name: "Owner", flags: 13, running: true }]);
+    // Simulate grep -c exiting with code 1 when package is not found
+    fakeAdb.setCommandError("grep -c com.example.app", new Error("Command failed with exit code 1"));
+    fakeAdb.setCommandResponse(`install --user 0 -r "${apkPath}"`, createExecResult("Success"));
+
+    const installApp = new InstallApp(device, fakeAdbFactory, fakeHost, fakeLocator, () => perf);
+    const result = await installApp.execute(apkPath);
+
+    expect(result.success).toBe(true);
+    expect(result.upgrade).toBe(false);
+    expect(result.packageName).toBe("com.example.app");
+  });
+
   test("detects Android upgrade when package already installed", async () => {
     const apkPath = "/tmp/app-debug.apk";
     const perf = createPerformanceTracker(true, fakeTimer);

--- a/test/features/action/TerminateApp.test.ts
+++ b/test/features/action/TerminateApp.test.ts
@@ -134,4 +134,24 @@ describe("TerminateApp (Android)", () => {
     expect(result.userId).toBe(0);
     expect(fakeAdb.wasCommandExecuted("force-stop")).toBe(false);
   });
+
+  test("treats grep -c failure as not installed instead of throwing", async () => {
+    fakeAdb.setForegroundApp(null);
+    fakeAdb.setUsers([{ userId: 0, name: "Owner", running: true }]);
+    // Simulate grep -c exiting with code 1 when package is not found
+    fakeAdb.setCommandError(
+      "grep -c com.example.app",
+      new Error("Command failed with exit code 1")
+    );
+
+    const terminateApp = new TerminateApp(androidDevice, fakeAdb as any, null, fakeTimer);
+    const result = await terminateApp.execute("com.example.app", { skipObservation: true });
+
+    expect(result.success).toBe(true);
+    expect(result.wasInstalled).toBe(false);
+    expect(result.wasRunning).toBe(false);
+    expect(result.wasForeground).toBe(false);
+    expect(result.userId).toBe(0);
+    expect(fakeAdb.wasCommandExecuted("force-stop")).toBe(false);
+  });
 });


### PR DESCRIPTION
## Summary
- `grep -c` exits with code 1 when there are zero matches, causing `executeCommand` to throw instead of returning `"0"`
- Wrapped the check in `InstallApp.ts` and `TerminateApp.ts` with try/catch so uninstalled packages are correctly detected
- Added tests for both files verifying the error case returns gracefully

## Test plan
- [x] New unit tests cover the failure case
- [x] `turbo run lint build test` passes (3886 tests, 0 failures)
- [ ] Manual: run `installApp` on a fresh APK that isn't already installed on the device

🤖 Generated with [Claude Code](https://claude.com/claude-code)