### PR TITLE
fix: ensure release builds include latest CtrlProxy version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -117,7 +117,7 @@ jobs:
           TURBO_NO_UPDATE_NOTIFIER: "1"
           DO_NOT_TRACK: "1"
           NO_COLOR: "1"
-        run: turbo run build --output-logs=errors-only
+        run: turbo run build --force --output-logs=errors-only
 
       - name: Create release notes
         id: release_notes

--- a/turbo.json
+++ b/turbo.json
@@ -15,7 +15,12 @@
         "package.json"
       ],
       "outputLogs": "new-only",
-      "env": ["AUTOMOBILE_SOURCEMAP_INCLUDE_DEPS"],
+      "env": [
+        "AUTOMOBILE_SOURCEMAP_INCLUDE_DEPS",
+        "RELEASE_VERSION",
+        "APK_SHA256_CHECKSUM",
+        "IOS_CTRL_PROXY_SHA256_CHECKSUM"
+      ],
       "passThroughEnv": ["CI", "GITHUB_ACTIONS"]
     },
     "lint": {


### PR DESCRIPTION
## Summary
- Published npm package v0.0.26 shipped with only `0.0.17`/`0.0.18` in the checksum registry because Turbo served a cached build
- Added release env vars (`RELEASE_VERSION`, `APK_SHA256_CHECKSUM`, `IOS_CTRL_PROXY_SHA256_CHECKSUM`) to the `build` task's `env` array in `turbo.json` so the hash changes on release
- Added `--force` to `turbo run build` in `release.yml` as a belt-and-suspenders safeguard

## Test plan
- [x] `turbo run build` output contains the 0.0.26 checksum
- [x] `turbo run lint build test` passes (3884 tests, 0 failures)
- [x] BATS shell tests pass
- [ ] Next release publish should include all registry entries in the bundle

🤖 Generated with [Claude Code](https://claude.com/claude-code)