### PR TITLE
test(video): cover Android screenrecord stop sequence

### DIFF
--- a/src/features/video/PlatformVideoCaptureBackend.ts
+++ b/src/features/video/PlatformVideoCaptureBackend.ts
@@ -5,6 +5,7 @@ import { promises as fsPromises } from "node:fs";
 import { pathExists } from "../../utils/filesystem/DefaultFileSystem";
 import { ActionableError, BootedDevice } from "../../models";
 import { defaultTimer } from "../../utils/SystemTimer";
+import type { Timer } from "../../utils/SystemTimer";
 import { defaultAdbClientFactory } from "../../utils/android-cmdline-tools/AdbClientFactory";
 import type { AdbClientFactory } from "../../utils/android-cmdline-tools/AdbClientFactory";
 import { SimCtlClient } from "../../utils/ios-cmdline-tools/SimCtlClient";
@@ -131,7 +132,10 @@ function clampBitrateKbps(config: VideoCaptureConfig): number {
 }
 
 export class PlatformVideoCaptureBackend implements VideoCaptureBackend {
-  constructor(private readonly adbFactory: AdbClientFactory = defaultAdbClientFactory) {}
+  constructor(
+    private readonly adbFactory: AdbClientFactory = defaultAdbClientFactory,
+    private readonly timer: Timer = defaultTimer
+  ) {}
 
   async start(config: VideoCaptureConfig): Promise<RecordingHandle> {
     const device = config.device;
@@ -180,7 +184,7 @@ export class PlatformVideoCaptureBackend implements VideoCaptureBackend {
       const gracefulExitTimeout = 10000;
       let timeoutId: NodeJS.Timeout | undefined;
       const timeoutPromise = new Promise<void>(resolve => {
-        timeoutId = defaultTimer.setTimeout(() => {
+        timeoutId = this.timer.setTimeout(() => {
           if (backendHandle.process.exitCode === null && !backendHandle.process.killed) {
             logger.info(`[VideoCapture] Sending SIGINT to host adb after pkill wait`);
             backendHandle.process.kill("SIGINT");
@@ -207,7 +211,7 @@ export class PlatformVideoCaptureBackend implements VideoCaptureBackend {
       // Give screenrecord extra time to finalize the file on device
       // Even though the process has exited, file writes may still be in progress
       logger.info(`[VideoCapture] Waiting 1 second for file to finalize on device`);
-      await defaultTimer.sleep(1000);
+      await this.timer.sleep(1000);
     } else {
       await waitForExit(backendHandle.process, backendHandle.exitPromise);
       logger.info(

--- a/test/features/video/PlatformVideoCaptureBackend.test.ts
+++ b/test/features/video/PlatformVideoCaptureBackend.test.ts
@@ -8,6 +8,9 @@ import type {
   VideoCaptureConfig,
 } from "../../../src/features/video/VideoRecorderService";
 import type { BootedDevice } from "../../../src/models";
+import { FakeAdbClientFactory } from "../../fakes/FakeAdbClientFactory";
+import { FakeChildProcess } from "../../fakes/FakeChildProcess";
+import { FakeTimer } from "../../fakes/FakeTimer";
 
 describe("PlatformVideoCaptureBackend - Unit Tests", () => {
   let backend: PlatformVideoCaptureBackend;
@@ -99,6 +102,123 @@ describe("PlatformVideoCaptureBackend - Unit Tests", () => {
       };
 
       await expect(backend.stop(invalidHandle)).rejects.toThrow();
+    });
+  });
+
+  describe("Android stop sequence (issue #1960)", () => {
+    function buildAndroidStopHandle(
+      outputPath: string,
+      fakeProcess: FakeChildProcess
+    ): RecordingHandle {
+      const androidHandle = {
+        kind: "android" as const,
+        process: fakeProcess,
+        outputStream: { end: () => undefined },
+        exitState: {
+          exitCode: fakeProcess.exitCode,
+          signal: fakeProcess.signalCode,
+          endedAt: new Date().toISOString(),
+        },
+        exitPromise: Promise.resolve(),
+        stderr: [] as string[],
+        device: {
+          platform: "android",
+          deviceId: "test-emulator",
+          name: "Test Android Emulator",
+        } satisfies BootedDevice,
+        deviceTempPath: "/sdcard/auto-mobile-test.mp4",
+      };
+
+      return {
+        recordingId: "test-stop-sequence",
+        outputPath,
+        startedAt: new Date().toISOString(),
+        backendHandle: androidHandle as any,
+      };
+    }
+
+    function spyOnKill(fakeProcess: FakeChildProcess): Array<NodeJS.Signals | number | undefined> {
+      const signals: Array<NodeJS.Signals | number | undefined> = [];
+      const originalKill = fakeProcess.kill.bind(fakeProcess);
+      fakeProcess.kill = (signal?: NodeJS.Signals | number) => {
+        signals.push(signal);
+        return originalKill(signal);
+      };
+      return signals;
+    }
+
+    test("sends device-side `pkill -2 screenrecord` as the first ADB command on stop", async () => {
+      const fakeFactory = new FakeAdbClientFactory();
+      const fakeClient = fakeFactory.getFakeClient();
+      const fakeTimer = new FakeTimer();
+      fakeTimer.enableAutoAdvance();
+
+      const backend = new PlatformVideoCaptureBackend(fakeFactory, fakeTimer);
+      const fakeProcess = new FakeChildProcess();
+      fakeProcess.exitCode = 0;
+      const handle = buildAndroidStopHandle(path.join(tempDir, "out.mp4"), fakeProcess);
+
+      // stop() will throw at the adb pull step (FakeAdbClient has no
+      // getBaseCommandParts) — but pkill must run first regardless.
+      await expect(backend.stop(handle)).rejects.toThrow();
+
+      const commands = fakeClient.getAllCommands();
+      expect(commands[0]).toBe("shell pkill -2 screenrecord");
+    });
+
+    test("does NOT signal host adb when the device-side pkill caused it to exit on its own", async () => {
+      const fakeFactory = new FakeAdbClientFactory();
+      const fakeTimer = new FakeTimer();
+      fakeTimer.enableAutoAdvance();
+
+      const backend = new PlatformVideoCaptureBackend(fakeFactory, fakeTimer);
+      const fakeProcess = new FakeChildProcess();
+      fakeProcess.exitCode = 0;
+      const killSignals = spyOnKill(fakeProcess);
+
+      const handle = buildAndroidStopHandle(path.join(tempDir, "out.mp4"), fakeProcess);
+
+      await expect(backend.stop(handle)).rejects.toThrow();
+
+      expect(killSignals).toEqual([]);
+    });
+
+    test("falls back to host SIGINT when device-side pkill fails and host adb is still running", async () => {
+      const fakeFactory = new FakeAdbClientFactory();
+      const fakeClient = fakeFactory.getFakeClient();
+      fakeClient.setCommandError(
+        "shell pkill -2 screenrecord",
+        new Error("device offline")
+      );
+      const fakeTimer = new FakeTimer();
+      fakeTimer.enableAutoAdvance();
+
+      const backend = new PlatformVideoCaptureBackend(fakeFactory, fakeTimer);
+      const fakeProcess = new FakeChildProcess();
+      // exitCode stays null → host adb still running when stop() begins
+      const killSignals: Array<NodeJS.Signals | number | undefined> = [];
+
+      let resolveExit!: () => void;
+      const exitPromise = new Promise<void>(resolve => { resolveExit = resolve; });
+
+      fakeProcess.kill = (signal?: NodeJS.Signals | number) => {
+        killSignals.push(signal);
+        if (signal === "SIGINT") {
+          fakeProcess.exitCode = 0;
+          fakeProcess.killed = true;
+          resolveExit();
+        }
+        return true;
+      };
+
+      const handle = buildAndroidStopHandle(path.join(tempDir, "out.mp4"), fakeProcess);
+      (handle.backendHandle as any).exitPromise = exitPromise;
+      (handle.backendHandle as any).exitState.exitCode = null;
+
+      await expect(backend.stop(handle)).rejects.toThrow();
+
+      expect(killSignals).toContain("SIGINT");
+      expect(fakeClient.wasCommandExecuted("shell pkill -2 screenrecord")).toBe(true);
     });
   });
 


### PR DESCRIPTION
## Summary

- [PR #1956](https://github.com/kaeawc/auto-mobile/pull/1956) landed the device-side `pkill -2 screenrecord` fix for [#1960](https://github.com/kaeawc/auto-mobile/issues/1960), but the new stop sequence had no unit coverage.
- Inject `Timer` into `PlatformVideoCaptureBackend` (matching the existing DI pattern from `DualTrackRecorder`, `FailureRecorder`, etc.) so the 1s file-finalize sleep and 10s graceful-exit timeout can be driven by `FakeTimer`.
- Add 3 unit tests pinning the behavior: `pkill -2 screenrecord` is the first ADB command on stop, the host adb is **not** signaled when it exits on its own, and host SIGINT fallback fires when device-side pkill fails while adb is still alive.

Closes #1960

## Test plan
- [x] `bun test test/features/video/PlatformVideoCaptureBackend.test.ts` — 20/20 pass in 43 ms
- [x] `bun test test/features/video/ test/server/` — 515/515 pass in 631 ms
- [x] `bun build.ts` — clean build