### PR TITLE
feat: Homebrew formula for AutoMobile CLI (#978)

### DIFF
--- a/.github/workflows/brew-formula.yml
+++ b/.github/workflows/brew-formula.yml
@@ -1,0 +1,50 @@
+---
+name: Brew Formula
+
+"on":
+  push:
+    branches: [main]
+    paths:
+      - 'Formula/auto-mobile.rb'
+      - '.github/workflows/brew-formula.yml'
+  pull_request:
+    paths:
+      - 'Formula/auto-mobile.rb'
+      - '.github/workflows/brew-formula.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  audit-and-install:
+    name: Audit and install formula
+    runs-on: macos-latest
+    env:
+      HOMEBREW_NO_AUTO_UPDATE: "1"
+      HOMEBREW_NO_ENV_HINTS: "1"
+      HOMEBREW_NO_INSTALL_FROM_API: "1"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          lfs: false
+
+      - name: Stage formula into local tap
+        run: |
+          tap_dir="$(brew --repository)/Library/Taps/kaeawc/homebrew-auto-mobile"
+          mkdir -p "${tap_dir}/Formula"
+          cp Formula/auto-mobile.rb "${tap_dir}/Formula/auto-mobile.rb"
+
+      - name: Audit formula
+        run: brew audit --strict kaeawc/auto-mobile/auto-mobile
+
+      - name: Install formula
+        run: brew install --build-from-source kaeawc/auto-mobile/auto-mobile
+
+      - name: Test formula
+        run: brew test kaeawc/auto-mobile/auto-mobile
+
+      - name: Verify CLI shim runs
+        run: |
+          auto-mobile --cli help | tee /tmp/auto-mobile-help.txt
+          grep -qi 'help\|tool\|usage' /tmp/auto-mobile-help.txt

--- a/Formula/auto-mobile.rb
+++ b/Formula/auto-mobile.rb
@@ -1,0 +1,23 @@
+class AutoMobile < Formula
+  desc "Mobile device interaction automation via MCP"
+  homepage "https://kaeawc.github.io/auto-mobile/"
+  url "https://registry.npmjs.org/@kaeawc/auto-mobile/-/auto-mobile-0.0.26.tgz"
+  sha256 "c8255eb157341f3f1ca4928644dda341816d6cbe94f3a73c303a26215b5be93c"
+  license "Apache-2.0"
+
+  depends_on "bun"
+
+  def install
+    libexec.install Dir["*"]
+    (bin/"auto-mobile").write <<~SH
+      #!/bin/bash
+      exec "#{Formula["bun"].opt_bin}/bun" "#{libexec}/dist/src/index.js" "$@"
+    SH
+    chmod 0755, bin/"auto-mobile"
+  end
+
+  test do
+    output = shell_output("#{bin}/auto-mobile --cli help 2>&1")
+    assert_match(/Usage|help|tool/i, output)
+  end
+end

--- a/docs/install.md
+++ b/docs/install.md
@@ -10,6 +10,23 @@ curl -fsSL https://raw.githubusercontent.com/kaeawc/auto-mobile/main/scripts/ins
 
 Once you've finished that, learn [how to use AutoMobile](using/ux-exploration.md)
 
+## Homebrew (macOS)
+
+AutoMobile ships a Homebrew formula that installs the `auto-mobile` CLI and its
+Bun runtime dependency. Until the formula is accepted into homebrew-core, tap
+this repository directly:
+
+``` bash title="Install via Homebrew"
+brew tap kaeawc/auto-mobile https://github.com/kaeawc/auto-mobile
+brew install auto-mobile
+```
+
+Verify the install:
+
+``` bash
+auto-mobile --cli help
+```
+
 ## Uninstalling
 
 To remove AutoMobile and its configurations, use the uninstall script:

--- a/scripts/release/update-brew-formula.sh
+++ b/scripts/release/update-brew-formula.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Update Formula/auto-mobile.rb with a new version's npm tarball URL and SHA256.
+#
+# Usage: scripts/release/update-brew-formula.sh <version>
+#
+# Resolves the published tarball from the npm registry and rewrites the
+# `url` and `sha256` lines in Formula/auto-mobile.rb in place.
+set -euo pipefail
+
+if [[ $# -ne 1 ]]; then
+  echo "usage: $0 <version>" >&2
+  exit 64
+fi
+
+VERSION="$1"
+FORMULA="Formula/auto-mobile.rb"
+PKG="@kaeawc/auto-mobile"
+TARBALL="https://registry.npmjs.org/${PKG}/-/auto-mobile-${VERSION}.tgz"
+
+if [[ ! -f "$FORMULA" ]]; then
+  echo "error: $FORMULA not found" >&2
+  exit 1
+fi
+
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+
+curl -fsSL "$TARBALL" -o "$tmp/auto-mobile-${VERSION}.tgz"
+SHA="$(shasum -a 256 "$tmp/auto-mobile-${VERSION}.tgz" | awk '{print $1}')"
+
+# Cross-platform in-place sed: write to tmp file then mv
+sed -e "s|^  url \".*\"$|  url \"${TARBALL}\"|" \
+    -e "s|^  sha256 \".*\"$|  sha256 \"${SHA}\"|" \
+    "$FORMULA" > "$tmp/formula.rb"
+mv "$tmp/formula.rb" "$FORMULA"
+
+echo "Updated $FORMULA to v${VERSION}"
+echo "  url:    $TARBALL"
+echo "  sha256: $SHA"

--- a/test/bats/update-brew-formula.bats
+++ b/test/bats/update-brew-formula.bats
@@ -1,0 +1,35 @@
+#!/usr/bin/env bats
+#
+# Tests for scripts/release/update-brew-formula.sh
+
+SCRIPT="scripts/release/update-brew-formula.sh"
+FORMULA_SRC="Formula/auto-mobile.rb"
+
+setup() {
+  TEST_ROOT="$(mktemp -d)"
+  mkdir -p "${TEST_ROOT}/Formula" "${TEST_ROOT}/scripts/release"
+  cp "$SCRIPT" "${TEST_ROOT}/scripts/release/update-brew-formula.sh"
+  cp "$FORMULA_SRC" "${TEST_ROOT}/Formula/auto-mobile.rb"
+  chmod +x "${TEST_ROOT}/scripts/release/update-brew-formula.sh"
+}
+
+teardown() {
+  rm -rf "$TEST_ROOT"
+}
+
+@test "rejects invocation without a version argument" {
+  run bash "${TEST_ROOT}/scripts/release/update-brew-formula.sh"
+  [ "$status" -eq 64 ]
+  [[ "$output" == *"usage:"* ]]
+}
+
+@test "rewrites url and sha256 for the requested npm version" {
+  cd "$TEST_ROOT"
+  run bash "scripts/release/update-brew-formula.sh" 0.0.26
+  [ "$status" -eq 0 ]
+  expected_url="https://registry.npmjs.org/@kaeawc/auto-mobile/-/auto-mobile-0.0.26.tgz"
+  grep -q "url \"${expected_url}\"" Formula/auto-mobile.rb
+  # SHA line should be a 64-char hex digest
+  sha_line="$(grep -E '^  sha256 "[0-9a-f]{64}"$' Formula/auto-mobile.rb || true)"
+  [ -n "$sha_line" ]
+}


### PR DESCRIPTION
## Summary

Closes #978. Adds a Homebrew formula so macOS users can `brew install auto-mobile`. The formula pulls the published npm tarball and shims it through Bun (the required runtime). Until/unless we submit to homebrew-core, it is consumed as a tap from this repo.

- `Formula/auto-mobile.rb` — pinned to npm `0.0.26` with sha256, depends on `bun`, installs to `libexec` and writes a small `bin/auto-mobile` shim
- `scripts/release/update-brew-formula.sh <version>` — recomputes url + sha256 from the npm registry; intended to run after `npm publish` in `release.yml`
- `test/bats/update-brew-formula.bats` — covers usage error and a real rewrite against the published tarball
- `.github/workflows/brew-formula.yml` — on changes to the formula, audits + installs + tests it on `macos-latest` via a staged local tap
- `docs/install.md` — documents the Homebrew install path

User-facing install:

```bash
brew tap kaeawc/auto-mobile https://github.com/kaeawc/auto-mobile
brew install auto-mobile
auto-mobile --cli help
```

Note: Wiring `scripts/release/update-brew-formula.sh` into `release.yml` (commit/PR the bump after `npm publish`) is intentionally left as a follow-up — keeps this PR minimal and lets the formula be validated in CI first.

## Test plan
- [x] `ruby -c Formula/auto-mobile.rb` — syntax OK
- [x] `brew audit --strict` against the staged tap — passes locally
- [x] `bats test/bats/update-brew-formula.bats` — 2/2 pass
- [x] `shellcheck scripts/release/update-brew-formula.sh` — clean
- [x] `bun scripts/validate-yaml.ts` — all workflows valid
- [ ] `Brew Formula` CI job (macos-latest) green on this PR