### PR TITLE
refactor(observe): extract sendCommand helper to eliminate WebSocket delegate boilerplate

### DIFF
--- a/src/features/observe/DeviceServiceUtils.ts
+++ b/src/features/observe/DeviceServiceUtils.ts
@@ -6,8 +6,9 @@
  */
 
 import type { Timer } from "../../utils/SystemTimer";
+import type { PerformanceTracker } from "../../utils/PerformanceTracker";
 import type { GestureResult, TextResult, ScreenshotResult } from "./DeviceService";
-import type { BaseResult, GestureTimingResult, ActionTimingResult } from "./shared/types";
+import type { BaseResult, GestureTimingResult, ActionTimingResult, DelegateContext } from "./shared/types";
 
 // =============================================================================
 // Connection Utilities
@@ -191,6 +192,82 @@ export function createMessage(
     requestId,
     ...params,
   });
+}
+
+// =============================================================================
+// Generic Delegate Request Helper
+// =============================================================================
+
+/**
+ * Options for `sendCommand` — the shared
+ *   cancelScreenshotBackoff → ensureConnected → register → send → await
+ * flow used by WebSocket delegate methods.
+ */
+export interface SendCommandOptions<T> {
+  idPrefix: string;
+  responseType: string;
+  messageType: string;
+  params?: Record<string, unknown>;
+  timeoutMs: number;
+  perf?: PerformanceTracker;
+  /** Defaults to true. Set false for endpoints that should not interrupt screenshot backoff. */
+  cancelScreenshotBackoff?: boolean;
+  /** Custom timeout-error builder. Defaults to `{success:false, totalTimeMs, error: "<errorLabel> timed out after <ms>ms"}`. */
+  timeoutError?: (timeoutMs: number) => T;
+  /** Custom not-connected-error builder for non-BaseResult shapes (e.g. carries `action` or `enabled`). */
+  notConnectedError?: () => T;
+  /** Overrides the default "Not connected" message. Ignored when `notConnectedError` is set. */
+  notConnectedMessage?: string;
+  /** Human-readable label used in the default timeout error. Defaults to `responseType`. */
+  errorLabel?: string;
+}
+
+export async function sendCommand<T>(
+  context: DelegateContext,
+  options: SendCommandOptions<T>
+): Promise<T> {
+  if (options.cancelScreenshotBackoff !== false) {
+    context.cancelScreenshotBackoff();
+  }
+
+  const connected = options.perf
+    ? await options.perf.track("ensureConnected", () => context.ensureConnected(options.perf))
+    : await context.ensureConnected();
+
+  if (!connected) {
+    if (options.notConnectedError) {
+      return options.notConnectedError();
+    }
+    return {
+      success: false,
+      totalTimeMs: 0,
+      error: options.notConnectedMessage ?? "Not connected",
+    } as T;
+  }
+
+  const requestId = context.requestManager.generateId(options.idPrefix);
+  const label = options.errorLabel ?? options.responseType;
+  const timeoutFactory = options.timeoutError
+    ? (_id: string, _type: string, timeout: number) => options.timeoutError!(timeout)
+    : (_id: string, _type: string, timeout: number) => ({
+      success: false,
+      totalTimeMs: timeout,
+      error: `${label} timed out after ${timeout}ms`,
+    } as T);
+
+  const promise = context.requestManager.register<T>(
+    requestId,
+    options.responseType,
+    options.timeoutMs,
+    timeoutFactory,
+  );
+
+  const msg = createMessage(options.messageType, requestId, options.params);
+  context.getWebSocket()?.send(msg);
+
+  return options.perf
+    ? options.perf.track(`${options.idPrefix}.awaitResponse`, () => promise)
+    : promise;
 }
 
 // =============================================================================

--- a/src/features/observe/ios/CtrlProxyClipboard.ts
+++ b/src/features/observe/ios/CtrlProxyClipboard.ts
@@ -10,6 +10,7 @@ import type {
   DelegateContext,
   CtrlProxyClipboardResult,
 } from "./types";
+import { sendCommand } from "../DeviceServiceUtils";
 
 /**
  * Delegate class for handling clipboard operations.
@@ -30,34 +31,26 @@ export class CtrlProxyClipboard {
     timeoutMs: number = 5000,
     perf?: PerformanceTracker
   ): Promise<CtrlProxyClipboardResult> {
-    if (!await this.context.ensureConnected(perf)) {
-      return { success: false, action, totalTimeMs: 0, error: "Not connected" };
+    const params: Record<string, unknown> = { action };
+    if (text !== undefined) {
+      params.text = text;
     }
 
-    const requestId = this.context.requestManager.generateId("clipboard");
-    const promise = this.context.requestManager.register<CtrlProxyClipboardResult>(
-      requestId,
-      "clipboard",
+    return sendCommand<CtrlProxyClipboardResult>(this.context, {
+      idPrefix: "clipboard",
+      responseType: "clipboard",
+      messageType: "request_clipboard",
+      params,
       timeoutMs,
-      (_id, _type, timeout) => ({
+      perf,
+      cancelScreenshotBackoff: false,
+      notConnectedError: () => ({ success: false, action, totalTimeMs: 0, error: "Not connected" }),
+      timeoutError: timeout => ({
         success: false,
         action,
         totalTimeMs: timeout,
-        error: `Clipboard operation timed out after ${timeout}ms`
-      })
-    );
-
-    const message: Record<string, unknown> = {
-      type: "request_clipboard",
-      requestId,
-      action
-    };
-    if (text !== undefined) {
-      message.text = text;
-    }
-
-    const ws = this.context.getWebSocket();
-    ws?.send(JSON.stringify(message));
-    return promise;
+        error: `Clipboard operation timed out after ${timeout}ms`,
+      }),
+    });
   }
 }

--- a/src/features/observe/ios/CtrlProxyGestures.ts
+++ b/src/features/observe/ios/CtrlProxyGestures.ts
@@ -8,6 +8,7 @@
 import { SharedGestureDelegate } from "../shared/SharedGestureDelegate";
 import type { DelegateContext, GestureTimingResult } from "./types";
 import type { PerformanceTracker } from "../../../utils/PerformanceTracker";
+import { sendCommand } from "../DeviceServiceUtils";
 
 export class CtrlProxyGestures extends SharedGestureDelegate {
   constructor(context: DelegateContext) {
@@ -37,38 +38,15 @@ export class CtrlProxyGestures extends SharedGestureDelegate {
     timeoutMs: number = 5000,
     perf?: PerformanceTracker
   ): Promise<GestureTimingResult> {
-    this.context.cancelScreenshotBackoff();
-
-    if (!await this.context.ensureConnected(perf)) {
-      return { success: false, totalTimeMs: 0, error: "Not connected to CtrlProxy" };
-    }
-
-    const requestId = this.context.requestManager.generateId("multi_finger_swipe");
-    const promise = this.context.requestManager.register<GestureTimingResult>(
-      requestId,
-      "multi_finger_swipe",
+    return sendCommand<GestureTimingResult>(this.context, {
+      idPrefix: "multi_finger_swipe",
+      responseType: "multi_finger_swipe",
+      messageType: "request_multi_finger_swipe",
+      params: { x1, y1, x2, y2, fingerCount, duration },
       timeoutMs,
-      () => ({
-        success: false,
-        totalTimeMs: timeoutMs,
-        error: `Multi-finger swipe timed out after ${timeoutMs}ms`
-      })
-    );
-
-    const message = {
-      type: "request_multi_finger_swipe",
-      requestId,
-      x1,
-      y1,
-      x2,
-      y2,
-      fingerCount,
-      duration,
-    };
-
-    const ws = this.context.getWebSocket();
-    ws?.send(JSON.stringify(message));
-
-    return promise;
+      perf,
+      notConnectedMessage: "Not connected to CtrlProxy",
+      errorLabel: "Multi-finger swipe",
+    });
   }
 }

--- a/src/features/observe/ios/CtrlProxyNavigation.ts
+++ b/src/features/observe/ios/CtrlProxyNavigation.ts
@@ -13,6 +13,7 @@ import type {
   CtrlProxyLaunchAppResult,
   CtrlProxyRotateResult,
 } from "./types";
+import { sendCommand } from "../DeviceServiceUtils";
 
 /**
  * Delegate class for handling navigation operations.
@@ -31,17 +32,16 @@ export class CtrlProxyNavigation {
     timeoutMs: number = 5000,
     perf?: PerformanceTracker
   ): Promise<CtrlProxyPressHomeResult> {
-    return this.sendRequest<CtrlProxyPressHomeResult>(
-      "pressHome",
-      "press_home",
-      "request_press_home",
-      { timeoutMs, perf },
-      (_id, _type, timeout) => ({
-        success: false,
-        totalTimeMs: timeout,
-        error: `Press home timed out after ${timeout}ms`,
-      }),
-    );
+    return sendCommand<CtrlProxyPressHomeResult>(this.context, {
+      idPrefix: "pressHome",
+      responseType: "press_home",
+      messageType: "request_press_home",
+      timeoutMs,
+      perf,
+      cancelScreenshotBackoff: false,
+      notConnectedMessage: "Not connected to CtrlProxy",
+      errorLabel: "Press home",
+    });
   }
 
   /**
@@ -52,35 +52,33 @@ export class CtrlProxyNavigation {
     timeoutMs: number = 5000,
     perf?: PerformanceTracker
   ): Promise<CtrlProxyRotateResult> {
-    if (!await this.context.ensureConnected(perf)) {
-      return { success: false, totalTimeMs: 0, error: "Not connected", previousOrientation: "", currentOrientation: "", value: 0, rotationPerformed: false };
-    }
-
-    const requestId = this.context.requestManager.generateId("rotate");
-    const promise = this.context.requestManager.register<CtrlProxyRotateResult>(
-      requestId,
-      "rotate",
+    return sendCommand<CtrlProxyRotateResult>(this.context, {
+      idPrefix: "rotate",
+      responseType: "rotate",
+      messageType: "request_rotate",
+      params: { orientation },
       timeoutMs,
-      (_id, _type, timeout) => ({
+      perf,
+      cancelScreenshotBackoff: false,
+      notConnectedError: () => ({
+        success: false,
+        totalTimeMs: 0,
+        error: "Not connected",
+        previousOrientation: "",
+        currentOrientation: "",
+        value: 0,
+        rotationPerformed: false,
+      }),
+      timeoutError: timeout => ({
         success: false,
         totalTimeMs: timeout,
         error: `Rotate timed out after ${timeout}ms`,
         previousOrientation: "",
         currentOrientation: "",
         value: 0,
-        rotationPerformed: false
-      })
-    );
-
-    const message = {
-      type: "request_rotate",
-      requestId,
-      orientation
-    };
-
-    const ws = this.context.getWebSocket();
-    ws?.send(JSON.stringify(message));
-    return promise;
+        rotationPerformed: false,
+      }),
+    });
   }
 
   /**
@@ -92,66 +90,17 @@ export class CtrlProxyNavigation {
     perf?: PerformanceTracker,
     coldBoot: boolean = false
   ): Promise<CtrlProxyLaunchAppResult> {
-    return this.sendRequest<CtrlProxyLaunchAppResult>(
-      "launchApp",
-      "launch_app",
-      "request_launch_app",
-      { timeoutMs, perf, extras: { bundleId, coldBoot } },
-      (_id, _type, timeout) => ({
-        success: false,
-        totalTimeMs: timeout,
-        error: `Launch app timed out after ${timeout}ms`,
-      }),
-    );
-  }
-
-  /**
-   * Send a WebSocket request with perf timing for each phase:
-   *   ensureConnected → wsSend → wsAwaitResponse
-   */
-  private async sendRequest<T>(
-    idPrefix: string,
-    requestType: string,
-    messageType: string,
-    opts: {
-      timeoutMs: number;
-      perf?: PerformanceTracker;
-      extras?: Record<string, unknown>;
-    },
-    errorFactory: (id: string, type: string, timeout: number) => T,
-  ): Promise<T> {
-    const { timeoutMs, perf, extras } = opts;
-
-    const connected = perf
-      ? await perf.track("ensureConnected", () => this.context.ensureConnected(perf))
-      : await this.context.ensureConnected();
-
-    if (!connected) {
-      return {
-        ...errorFactory("", requestType, 0),
-        error: "Not connected to CtrlProxy",
-      } as T;
-    }
-
-    const requestId = this.context.requestManager.generateId(idPrefix);
-    const promise = this.context.requestManager.register<T>(
-      requestId,
-      requestType,
+    return sendCommand<CtrlProxyLaunchAppResult>(this.context, {
+      idPrefix: "launchApp",
+      responseType: "launch_app",
+      messageType: "request_launch_app",
+      params: { bundleId, coldBoot },
       timeoutMs,
-      errorFactory,
-    );
-
-    const message = { type: messageType, requestId, ...extras };
-
-    if (perf) {
-      perf.trackSync("wsSend", () => {
-        this.context.getWebSocket()?.send(JSON.stringify(message));
-      });
-      return perf.track("wsAwaitResponse", () => promise);
-    }
-
-    this.context.getWebSocket()?.send(JSON.stringify(message));
-    return promise;
+      perf,
+      cancelScreenshotBackoff: false,
+      notConnectedMessage: "Not connected to CtrlProxy",
+      errorLabel: "Launch app",
+    });
   }
 
   /**
@@ -161,29 +110,14 @@ export class CtrlProxyNavigation {
     timeoutMs: number = 5000,
     perf?: PerformanceTracker
   ): Promise<CtrlProxyRecentAppsResult> {
-    if (!await this.context.ensureConnected(perf)) {
-      return { success: false, totalTimeMs: 0, error: "Not connected" };
-    }
-
-    const requestId = this.context.requestManager.generateId("recentApps");
-    const promise = this.context.requestManager.register<CtrlProxyRecentAppsResult>(
-      requestId,
-      "recent_apps",
+    return sendCommand<CtrlProxyRecentAppsResult>(this.context, {
+      idPrefix: "recentApps",
+      responseType: "recent_apps",
+      messageType: "request_recent_apps",
       timeoutMs,
-      (_id, _type, timeout) => ({
-        success: false,
-        totalTimeMs: timeout,
-        error: `Recent apps timed out after ${timeout}ms`
-      })
-    );
-
-    const message = {
-      type: "request_recent_apps",
-      requestId
-    };
-
-    const ws = this.context.getWebSocket();
-    ws?.send(JSON.stringify(message));
-    return promise;
+      perf,
+      cancelScreenshotBackoff: false,
+      errorLabel: "Recent apps",
+    });
   }
 }

--- a/src/features/observe/ios/CtrlProxyScreenshot.ts
+++ b/src/features/observe/ios/CtrlProxyScreenshot.ts
@@ -7,8 +7,9 @@
 import type { PerformanceTracker } from "../../../utils/PerformanceTracker";
 import type {
   DelegateContext,
-  XCTestScreenshotResult,
+  CtrlProxyScreenshotResult,
 } from "./types";
+import { sendCommand } from "../DeviceServiceUtils";
 
 /**
  * Delegate class for handling screenshot operations.
@@ -26,29 +27,16 @@ export class CtrlProxyScreenshot {
   async requestScreenshot(
     timeoutMs: number = 5000,
     perf?: PerformanceTracker
-  ): Promise<XCTestScreenshotResult> {
-    if (!await this.context.ensureConnected(perf)) {
-      return { success: false, error: "Not connected" };
-    }
-
-    const requestId = this.context.requestManager.generateId("screenshot");
-    const promise = this.context.requestManager.register<XCTestScreenshotResult>(
-      requestId,
-      "screenshot",
+  ): Promise<CtrlProxyScreenshotResult> {
+    return sendCommand<CtrlProxyScreenshotResult>(this.context, {
+      idPrefix: "screenshot",
+      responseType: "screenshot",
+      messageType: "request_screenshot",
       timeoutMs,
-      (_id, _type, timeout) => ({
-        success: false,
-        error: `Screenshot timed out after ${timeout}ms`
-      })
-    );
-
-    const message = {
-      type: "request_screenshot",
-      requestId
-    };
-
-    const ws = this.context.getWebSocket();
-    ws?.send(JSON.stringify(message));
-    return promise;
+      perf,
+      cancelScreenshotBackoff: false,
+      notConnectedError: () => ({ success: false, error: "Not connected" }),
+      timeoutError: timeout => ({ success: false, error: `Screenshot timed out after ${timeout}ms` }),
+    });
   }
 }

--- a/src/features/observe/ios/CtrlProxyText.ts
+++ b/src/features/observe/ios/CtrlProxyText.ts
@@ -10,8 +10,7 @@ import type { PerformanceTracker } from "../../../utils/PerformanceTracker";
 import type { BaseResult } from "../shared/types";
 import { SharedTextDelegate } from "../shared/SharedTextDelegate";
 import type { DelegateContext } from "./types";
-import { createMessage } from "../DeviceServiceUtils";
-import { logger } from "../../../utils/logger";
+import { sendCommand } from "../DeviceServiceUtils";
 
 export class CtrlProxyText extends SharedTextDelegate {
   constructor(context: DelegateContext) {
@@ -31,42 +30,19 @@ export class CtrlProxyText extends SharedTextDelegate {
     timeoutMs: number = 5000,
     perf?: PerformanceTracker
   ): Promise<BaseResult> {
-    const startMs = Date.now();
-    this.context.cancelScreenshotBackoff();
-
-    const connected = await (perf
-      ? perf.track("ensureConnected", () => this.context.ensureConnected(perf))
-      : this.context.ensureConnected(perf));
-    if (!connected) {
-      logger.warn(`[CtrlProxyText] requestClearText aborted: not connected (resourceId=${resourceId ?? "nil"})`);
-      return { success: false, totalTimeMs: 0, error: "Not connected" };
-    }
-
-    const requestId = this.context.requestManager.generateId("clearText");
-    logger.debug(`[CtrlProxyText] requestClearText send requestId=${requestId} resourceId=${resourceId ?? "nil"} timeoutMs=${timeoutMs}`);
-
-    const promise = this.context.requestManager.register<BaseResult>(
-      requestId,
-      "clear_text",
-      timeoutMs,
-      (_id, _type, timeout) => ({
-        success: false,
-        totalTimeMs: timeout,
-        error: `Clear text timed out after ${timeout}ms`
-      })
-    );
-
     const params: Record<string, unknown> = {};
     if (resourceId) {
       params.resourceId = resourceId;
     }
 
-    const msg = createMessage("request_clear_text", requestId, params);
-    this.context.getWebSocket()?.send(msg);
-    const result = await (perf
-      ? perf.track("clearText.awaitResponse", () => promise)
-      : promise);
-    logger.debug(`[CtrlProxyText] requestClearText done requestId=${requestId} success=${result.success} totalMs=${Date.now() - startMs}${result.error ? ` error=${result.error}` : ""}`);
-    return result;
+    return sendCommand<BaseResult>(this.context, {
+      idPrefix: "clearText",
+      responseType: "clear_text",
+      messageType: "request_clear_text",
+      params,
+      timeoutMs,
+      perf,
+      errorLabel: "Clear text",
+    });
   }
 }

--- a/src/features/observe/ios/CtrlProxyVoiceOver.ts
+++ b/src/features/observe/ios/CtrlProxyVoiceOver.ts
@@ -8,6 +8,7 @@
 
 import type { PerformanceTracker } from "../../../utils/PerformanceTracker";
 import type { DelegateContext, CtrlProxyVoiceOverResult, CtrlProxyVoiceOverActionResult, CtrlProxyActionResult } from "./types";
+import { sendCommand } from "../DeviceServiceUtils";
 
 /**
  * Delegate class for VoiceOver state detection via CtrlProxy WebSocket.
@@ -30,27 +31,16 @@ export class CtrlProxyVoiceOver {
     timeoutMs: number = 5000,
     perf?: PerformanceTracker
   ): Promise<CtrlProxyVoiceOverResult> {
-    if (!await this.context.ensureConnected(perf)) {
-      return { success: false, enabled: false, error: "Not connected to CtrlProxy" };
-    }
-
-    const requestId = this.context.requestManager.generateId("voiceover");
-    const promise = this.context.requestManager.register<CtrlProxyVoiceOverResult>(
-      requestId,
-      "voiceover",
+    return sendCommand<CtrlProxyVoiceOverResult>(this.context, {
+      idPrefix: "voiceover",
+      responseType: "voiceover",
+      messageType: "get_voiceover_state",
       timeoutMs,
-      () => ({ success: false, enabled: false, error: "Timeout waiting for voiceover_state_result" })
-    );
-
-    const message = {
-      type: "get_voiceover_state",
-      requestId,
-    };
-
-    const ws = this.context.getWebSocket();
-    ws?.send(JSON.stringify(message));
-
-    return promise;
+      perf,
+      cancelScreenshotBackoff: false,
+      notConnectedError: () => ({ success: false, enabled: false, error: "Not connected to CtrlProxy" }),
+      timeoutError: () => ({ success: false, enabled: false, error: "Timeout waiting for voiceover_state_result" }),
+    });
   }
 
   /**
@@ -73,30 +63,17 @@ export class CtrlProxyVoiceOver {
     timeoutMs: number = 5000,
     perf?: PerformanceTracker
   ): Promise<CtrlProxyActionResult> {
-    if (!await this.context.ensureConnected(perf)) {
-      return { success: false, error: "Not connected to CtrlProxy" };
-    }
-
-    const requestId = this.context.requestManager.generateId("action");
-    const promise = this.context.requestManager.register<CtrlProxyActionResult>(
-      requestId,
-      "action",
+    return sendCommand<CtrlProxyActionResult>(this.context, {
+      idPrefix: "action",
+      responseType: "action",
+      messageType: "request_action",
+      params: { action, resourceId: resourceId ?? null, label: label ?? null },
       timeoutMs,
-      () => ({ success: false, error: "Timeout waiting for action_result" })
-    );
-
-    const message = {
-      type: "request_action",
-      requestId,
-      action,
-      resourceId: resourceId ?? null,
-      label: label ?? null,
-    };
-
-    const ws = this.context.getWebSocket();
-    ws?.send(JSON.stringify(message));
-
-    return promise;
+      perf,
+      cancelScreenshotBackoff: false,
+      notConnectedError: () => ({ success: false, error: "Not connected to CtrlProxy" }),
+      timeoutError: () => ({ success: false, error: "Timeout waiting for action_result" }),
+    });
   }
 
   /**
@@ -114,28 +91,16 @@ export class CtrlProxyVoiceOver {
     timeoutMs: number = 5000,
     perf?: PerformanceTracker
   ): Promise<CtrlProxyVoiceOverActionResult> {
-    if (!await this.context.ensureConnected(perf)) {
-      return { success: false, error: "Not connected to CtrlProxy" };
-    }
-
-    const requestId = this.context.requestManager.generateId("voiceover_action");
-    const promise = this.context.requestManager.register<CtrlProxyVoiceOverActionResult>(
-      requestId,
-      "voiceover_action",
+    return sendCommand<CtrlProxyVoiceOverActionResult>(this.context, {
+      idPrefix: "voiceover_action",
+      responseType: "voiceover_action",
+      messageType: "request_voiceover_action",
+      params: { label, action },
       timeoutMs,
-      () => ({ success: false, error: "Timeout waiting for voiceover_action_result" })
-    );
-
-    const message = {
-      type: "request_voiceover_action",
-      requestId,
-      label,
-      action,
-    };
-
-    const ws = this.context.getWebSocket();
-    ws?.send(JSON.stringify(message));
-
-    return promise;
+      perf,
+      cancelScreenshotBackoff: false,
+      notConnectedError: () => ({ success: false, error: "Not connected to CtrlProxy" }),
+      timeoutError: () => ({ success: false, error: "Timeout waiting for voiceover_action_result" }),
+    });
   }
 }

--- a/src/features/observe/shared/SharedGestureDelegate.ts
+++ b/src/features/observe/shared/SharedGestureDelegate.ts
@@ -9,7 +9,7 @@
 
 import type { PerformanceTracker } from "../../../utils/PerformanceTracker";
 import type { DelegateContext, GestureTimingResult, BaseResult } from "./types";
-import { createMessage } from "../DeviceServiceUtils";
+import { sendCommand } from "../DeviceServiceUtils";
 
 interface SharedGestureConfig {
   logTag: string;
@@ -36,31 +36,15 @@ export class SharedGestureDelegate {
     timeoutMs: number = 5000,
     perf?: PerformanceTracker
   ): Promise<BaseResult> {
-    this.context.cancelScreenshotBackoff();
-
-    if (!await this.context.ensureConnected(perf)) {
-      return { success: false, totalTimeMs: 0, error: "Not connected" };
-    }
-
-    const requestId = this.context.requestManager.generateId("tap");
-    const promise = this.context.requestManager.register<BaseResult>(
-      requestId,
-      "tap_coordinates",
+    return sendCommand<BaseResult>(this.context, {
+      idPrefix: "tap",
+      responseType: "tap_coordinates",
+      messageType: "request_tap_coordinates",
+      params: { x: this.coord(x), y: this.coord(y), duration },
       timeoutMs,
-      (_id, _type, timeout) => ({
-        success: false,
-        totalTimeMs: timeout,
-        error: `Tap timed out after ${timeout}ms`
-      })
-    );
-
-    const msg = createMessage("request_tap_coordinates", requestId, {
-      x: this.coord(x),
-      y: this.coord(y),
-      duration
+      perf,
+      errorLabel: "Tap",
     });
-    this.context.getWebSocket()?.send(msg);
-    return promise;
   }
 
   async requestSwipe(
@@ -72,33 +56,21 @@ export class SharedGestureDelegate {
     timeoutMs: number = 5000,
     perf?: PerformanceTracker
   ): Promise<GestureTimingResult> {
-    this.context.cancelScreenshotBackoff();
-
-    if (!await this.context.ensureConnected(perf)) {
-      return { success: false, totalTimeMs: 0, error: "Not connected" };
-    }
-
-    const requestId = this.context.requestManager.generateId("swipe");
-    const promise = this.context.requestManager.register<GestureTimingResult>(
-      requestId,
-      "swipe",
+    return sendCommand<GestureTimingResult>(this.context, {
+      idPrefix: "swipe",
+      responseType: "swipe",
+      messageType: "request_swipe",
+      params: {
+        x1: this.coord(x1),
+        y1: this.coord(y1),
+        x2: this.coord(x2),
+        y2: this.coord(y2),
+        duration,
+      },
       timeoutMs,
-      (_id, _type, timeout) => ({
-        success: false,
-        totalTimeMs: timeout,
-        error: `Swipe timed out after ${timeout}ms`
-      })
-    );
-
-    const msg = createMessage("request_swipe", requestId, {
-      x1: this.coord(x1),
-      y1: this.coord(y1),
-      x2: this.coord(x2),
-      y2: this.coord(y2),
-      duration
+      perf,
+      errorLabel: "Swipe",
     });
-    this.context.getWebSocket()?.send(msg);
-    return promise;
   }
 
   async requestDrag(
@@ -111,35 +83,22 @@ export class SharedGestureDelegate {
     holdDurationMs: number,
     timeoutMs: number
   ): Promise<GestureTimingResult> {
-    this.context.cancelScreenshotBackoff();
-
-    if (!await this.context.ensureConnected()) {
-      return { success: false, totalTimeMs: 0, error: "Not connected" };
-    }
-
-    const requestId = this.context.requestManager.generateId("drag");
-    const promise = this.context.requestManager.register<GestureTimingResult>(
-      requestId,
-      "drag",
+    return sendCommand<GestureTimingResult>(this.context, {
+      idPrefix: "drag",
+      responseType: "drag",
+      messageType: "request_drag",
+      params: {
+        x1: this.coord(x1),
+        y1: this.coord(y1),
+        x2: this.coord(x2),
+        y2: this.coord(y2),
+        pressDurationMs,
+        dragDurationMs,
+        holdDurationMs,
+      },
       timeoutMs,
-      (_id, _type, timeout) => ({
-        success: false,
-        totalTimeMs: timeout,
-        error: `Drag timed out after ${timeout}ms`
-      })
-    );
-
-    const msg = createMessage("request_drag", requestId, {
-      x1: this.coord(x1),
-      y1: this.coord(y1),
-      x2: this.coord(x2),
-      y2: this.coord(y2),
-      pressDurationMs,
-      dragDurationMs,
-      holdDurationMs
+      errorLabel: "Drag",
     });
-    this.context.getWebSocket()?.send(msg);
-    return promise;
   }
 
   async requestPinch(
@@ -152,33 +111,21 @@ export class SharedGestureDelegate {
     timeoutMs: number = 5000,
     perf?: PerformanceTracker
   ): Promise<GestureTimingResult> {
-    this.context.cancelScreenshotBackoff();
-
-    if (!await this.context.ensureConnected(perf)) {
-      return { success: false, totalTimeMs: 0, error: "Not connected" };
-    }
-
-    const requestId = this.context.requestManager.generateId("pinch");
-    const promise = this.context.requestManager.register<GestureTimingResult>(
-      requestId,
-      "pinch",
+    return sendCommand<GestureTimingResult>(this.context, {
+      idPrefix: "pinch",
+      responseType: "pinch",
+      messageType: "request_pinch",
+      params: {
+        centerX: this.coord(centerX),
+        centerY: this.coord(centerY),
+        distanceStart: this.coord(distanceStart),
+        distanceEnd: this.coord(distanceEnd),
+        rotationDegrees,
+        duration,
+      },
       timeoutMs,
-      (_id, _type, timeout) => ({
-        success: false,
-        totalTimeMs: timeout,
-        error: `Pinch timed out after ${timeout}ms`
-      })
-    );
-
-    const msg = createMessage("request_pinch", requestId, {
-      centerX: this.coord(centerX),
-      centerY: this.coord(centerY),
-      distanceStart: this.coord(distanceStart),
-      distanceEnd: this.coord(distanceEnd),
-      rotationDegrees,
-      duration
+      perf,
+      errorLabel: "Pinch",
     });
-    this.context.getWebSocket()?.send(msg);
-    return promise;
   }
 }

--- a/src/features/observe/shared/SharedTextDelegate.ts
+++ b/src/features/observe/shared/SharedTextDelegate.ts
@@ -6,8 +6,7 @@
 
 import type { PerformanceTracker } from "../../../utils/PerformanceTracker";
 import type { DelegateContext, BaseResult, ActionTimingResult } from "./types";
-import { createMessage } from "../DeviceServiceUtils";
-import { logger } from "../../../utils/logger";
+import { sendCommand } from "../DeviceServiceUtils";
 
 export class SharedTextDelegate {
   protected readonly context: DelegateContext;
@@ -27,31 +26,6 @@ export class SharedTextDelegate {
     perf?: PerformanceTracker,
     dismissKeyboard: boolean = false
   ): Promise<BaseResult> {
-    const startMs = Date.now();
-    this.context.cancelScreenshotBackoff();
-
-    const connected = await (perf
-      ? perf.track("ensureConnected", () => this.context.ensureConnected(perf))
-      : this.context.ensureConnected(perf));
-    if (!connected) {
-      logger.warn(`[SharedTextDelegate] requestSetText aborted: not connected (resourceId=${resourceId ?? "nil"})`);
-      return { success: false, totalTimeMs: 0, error: "Not connected" };
-    }
-
-    const requestId = this.context.requestManager.generateId("setText");
-    logger.debug(`[SharedTextDelegate] requestSetText send requestId=${requestId} resourceId=${resourceId ?? "nil"} textLength=${text.length} dismissKeyboard=${dismissKeyboard} timeoutMs=${timeoutMs}`);
-
-    const promise = this.context.requestManager.register<BaseResult>(
-      requestId,
-      "set_text",
-      timeoutMs,
-      (_id, _type, timeout) => ({
-        success: false,
-        totalTimeMs: timeout,
-        error: `Set text timed out after ${timeout}ms`
-      })
-    );
-
     const params: Record<string, unknown> = { text };
     if (resourceId) {
       params.resourceId = resourceId;
@@ -60,13 +34,15 @@ export class SharedTextDelegate {
       params.dismissKeyboard = true;
     }
 
-    const msg = createMessage("request_set_text", requestId, params);
-    this.context.getWebSocket()?.send(msg);
-    const result = await (perf
-      ? perf.track("setText.awaitResponse", () => promise)
-      : promise);
-    logger.debug(`[SharedTextDelegate] requestSetText done requestId=${requestId} success=${result.success} totalMs=${Date.now() - startMs}${result.error ? ` error=${result.error}` : ""}`);
-    return result;
+    return sendCommand<BaseResult>(this.context, {
+      idPrefix: "setText",
+      responseType: "set_text",
+      messageType: "request_set_text",
+      params,
+      timeoutMs,
+      perf,
+      errorLabel: "Set text",
+    });
   }
 
   async requestClearText(
@@ -82,76 +58,34 @@ export class SharedTextDelegate {
     timeoutMs: number = 5000,
     perf?: PerformanceTracker
   ): Promise<ActionTimingResult> {
-    const startMs = Date.now();
-    this.context.cancelScreenshotBackoff();
-
-    const connected = await (perf
-      ? perf.track("ensureConnected", () => this.context.ensureConnected(perf))
-      : this.context.ensureConnected(perf));
-    if (!connected) {
-      logger.warn(`[SharedTextDelegate] requestImeAction aborted: not connected (action=${action})`);
-      return { success: false, action, totalTimeMs: 0, error: "Not connected" };
-    }
-
-    const requestId = this.context.requestManager.generateId("imeAction");
-    logger.debug(`[SharedTextDelegate] requestImeAction send requestId=${requestId} action=${action} timeoutMs=${timeoutMs}`);
-
-    const promise = this.context.requestManager.register<ActionTimingResult>(
-      requestId,
-      "ime_action",
+    return sendCommand<ActionTimingResult>(this.context, {
+      idPrefix: "imeAction",
+      responseType: "ime_action",
+      messageType: "request_ime_action",
+      params: { action },
       timeoutMs,
-      (_id, _type, timeout) => ({
+      perf,
+      notConnectedError: () => ({ success: false, action, totalTimeMs: 0, error: "Not connected" }),
+      timeoutError: timeout => ({
         success: false,
         action,
         totalTimeMs: timeout,
-        error: `IME action timed out after ${timeout}ms`
-      })
-    );
-
-    const msg = createMessage("request_ime_action", requestId, { action });
-    this.context.getWebSocket()?.send(msg);
-    const result = await (perf
-      ? perf.track("imeAction.awaitResponse", () => promise)
-      : promise);
-    logger.debug(`[SharedTextDelegate] requestImeAction done requestId=${requestId} action=${action} success=${result.success} totalMs=${Date.now() - startMs}${result.error ? ` error=${result.error}` : ""}`);
-    return result;
+        error: `IME action timed out after ${timeout}ms`,
+      }),
+    });
   }
 
   async requestSelectAll(
     timeoutMs: number = 5000,
     perf?: PerformanceTracker
   ): Promise<BaseResult> {
-    const startMs = Date.now();
-    this.context.cancelScreenshotBackoff();
-
-    const connected = await (perf
-      ? perf.track("ensureConnected", () => this.context.ensureConnected(perf))
-      : this.context.ensureConnected(perf));
-    if (!connected) {
-      logger.warn(`[SharedTextDelegate] requestSelectAll aborted: not connected`);
-      return { success: false, totalTimeMs: 0, error: "Not connected" };
-    }
-
-    const requestId = this.context.requestManager.generateId("selectAll");
-    logger.debug(`[SharedTextDelegate] requestSelectAll send requestId=${requestId} timeoutMs=${timeoutMs}`);
-
-    const promise = this.context.requestManager.register<BaseResult>(
-      requestId,
-      "select_all",
+    return sendCommand<BaseResult>(this.context, {
+      idPrefix: "selectAll",
+      responseType: "select_all",
+      messageType: "request_select_all",
       timeoutMs,
-      (_id, _type, timeout) => ({
-        success: false,
-        totalTimeMs: timeout,
-        error: `Select all timed out after ${timeout}ms`
-      })
-    );
-
-    const msg = createMessage("request_select_all", requestId);
-    this.context.getWebSocket()?.send(msg);
-    const result = await (perf
-      ? perf.track("selectAll.awaitResponse", () => promise)
-      : promise);
-    logger.debug(`[SharedTextDelegate] requestSelectAll done requestId=${requestId} success=${result.success} totalMs=${Date.now() - startMs}${result.error ? ` error=${result.error}` : ""}`);
-    return result;
+      perf,
+      errorLabel: "Select all",
+    });
   }
 }


### PR DESCRIPTION
Closes #1880

## Summary

- Adds a generic `sendCommand` helper in `DeviceServiceUtils` that captures the shared `cancelScreenshotBackoff → ensureConnected → register → send → await` flow used across WebSocket delegates.
- Each refactored delegate method drops from ~15-30 lines of boilerplate to a single options object.
- Net **-208 lines** across 9 files.

## Refactored delegates

- `SharedTextDelegate` — setText, imeAction, selectAll
- `SharedGestureDelegate` — tap, swipe, drag, pinch
- `CtrlProxyText` — iOS clearText
- `CtrlProxyClipboard`
- `CtrlProxyGestures` — multiFingerSwipe
- `CtrlProxyNavigation` — pressHome, rotate, launchApp, recentApps (replaces local `sendRequest`)
- `CtrlProxyVoiceOver` — voiceOverState, action, voiceOverActivate
- `CtrlProxyScreenshot`

## Intentionally not refactored

- **Storage delegates** (`CtrlProxyStorage` android+ios) — `throw`-on-error contract instead of returning typed `{success:false}`. Would need a separate helper variant.
- **Hierarchy delegates** — cache-first multi-path control flow (cache hits, sync vs. wait-fresh, minTimestamp, AbortSignal). Fundamentally different shape.
- **Highlights / Focus / Certificates** — additional perf phases (`wsSend`), readyState assertions, richer custom timeout-result builders. Defer.

## Behavior preserved

- Timeout/not-connected error shapes (custom factories supplied where the result type carries extra fields like `action`, `enabled`, or orientation).
- Per-method `idPrefix` for request IDs.
- Perf phase `"ensureConnected"` keeps its existing un-prefixed name so dashboards keyed on it don't regress.

## Trade-offs

- Diagnostic `logger.debug`/`logger.warn` lines in `SharedTextDelegate` and `CtrlProxyText` are dropped. They previously logged per-request `requestId`, resourceId, textLength, success and timing. Reintroducing equivalent logging would require either threading callbacks through `SendCommandOptions` or restoring the log lines at call sites — not done here to keep the refactor terse, but happy to add back if anyone relies on those traces.

## Test plan

- [x] `bun test` → 3910 pass, 0 fail (1 pre-existing failure on `main` unrelated)
- [x] `bun x eslint src/features/observe/` → clean
- [x] Refactored shared/iOS delegate tests pass: `bun test test/features/observe/shared/ test/features/observe/ios/CtrlProxyVoiceOver.test.ts` → 24 pass