### PR TITLE
fix(plan): require explicit device on every step in multi-device plans

### DIFF
--- a/android/junit-runner/src/test/kotlin/dev/jasonpearson/automobile/junit/MultiDevicePlanTest.kt
+++ b/android/junit-runner/src/test/kotlin/dev/jasonpearson/automobile/junit/MultiDevicePlanTest.kt
@@ -253,7 +253,7 @@ class TwoDeviceCriticalSectionPlanTest {
 
   @Test
   fun `plan content includes critical section step with lock name and device count`() {
-    capturingClient.setResponse("executePlan", successResponse(executedSteps = 5, totalSteps = 5))
+    capturingClient.setResponse("executePlan", successResponse(executedSteps = 6, totalSteps = 6))
 
     AutoMobilePlanExecutor.execute(
         "test-plans/dual-device-critical-section.yaml",
@@ -272,7 +272,7 @@ class TwoDeviceCriticalSectionPlanTest {
 
   @Test
   fun `critical section contains device-specific sub-steps for device A and device B`() {
-    capturingClient.setResponse("executePlan", successResponse(executedSteps = 5, totalSteps = 5))
+    capturingClient.setResponse("executePlan", successResponse(executedSteps = 6, totalSteps = 6))
 
     AutoMobilePlanExecutor.execute(
         "test-plans/dual-device-critical-section.yaml",
@@ -284,42 +284,56 @@ class TwoDeviceCriticalSectionPlanTest {
       decodePlanContent(
         capturingClient.capturedArguments!!["planContent"]!!.jsonPrimitive.content
       )
-    // Scope device assertions strictly to the criticalSection step's own params block.
-    // Search for "tool: criticalSection" (not just "criticalSection") to skip any occurrence
-    // in the plan name or description. Then trim at "\n\n  - tool:" which is the blank-line
-    // separator before the next top-level step, ensuring trailing terminateApp "device:" labels
-    // cannot satisfy the assertion if criticalSection sub-steps lose their device assignments.
-    val afterCriticalSection =
-      decoded.substringAfter("tool: criticalSection", missingDelimiterValue = "")
-    assertTrue("criticalSection tool step should be present", afterCriticalSection.isNotEmpty())
-    val criticalSectionBlock = afterCriticalSection.substringBefore("\n\n  - tool:")
+
+    // Each device now owns its own criticalSection step that shares a lock
+    // name. Split on "tool: criticalSection" and verify both occurrences,
+    // each scoped to its own block (delimited by the blank-line "\n\n  - tool:"
+    // separator before the next top-level step).
+    val criticalSectionBlocks =
+      decoded.split("tool: criticalSection").drop(1).map { afterMarker ->
+        afterMarker.substringBefore("\n\n  - tool:")
+      }
+    assertEquals(
+      "Plan should contain a per-device criticalSection step for each device",
+      2,
+      criticalSectionBlocks.size,
+    )
+
+    val joinedBlocks = criticalSectionBlocks.joinToString(separator = "\n")
     assertTrue(
-      "CriticalSection sub-steps should target device A",
-      criticalSectionBlock.contains("device: A"),
+      "One criticalSection block should target device A",
+      criticalSectionBlocks.any { it.contains("device: A") },
     )
     assertTrue(
-      "CriticalSection sub-steps should target device B",
-      criticalSectionBlock.contains("device: B"),
+      "One criticalSection block should target device B",
+      criticalSectionBlocks.any { it.contains("device: B") },
+    )
+    assertTrue(
+      "Per-device criticalSection steps must share the same lock name",
+      joinedBlocks.contains("lock: chat-sync"),
     )
   }
 
   @Test
   fun `runner succeeds when daemon completes all steps including critical section`() {
-    // Five steps: launchApp A, launchApp B, criticalSection (coord), terminateApp A, terminateApp B
+    // Six steps: launchApp A, launchApp B, criticalSection A, criticalSection B,
+    // terminateApp A, terminateApp B. The two per-device criticalSection steps
+    // share a lock and synchronize through the coordinator.
     capturingClient.setResponse(
       "executePlan",
       buildDaemonResponse(
         JsonObject(
           mapOf(
             "success" to JsonPrimitive(true),
-            "executedSteps" to JsonPrimitive(5),
-            "totalSteps" to JsonPrimitive(5),
+            "executedSteps" to JsonPrimitive(6),
+            "totalSteps" to JsonPrimitive(6),
             "toolResults" to
               JsonArray(
                 listOf(
                   perDeviceStepResult("launchApp", "A"),
                   perDeviceStepResult("launchApp", "B"),
-                  coordinationStepResult("criticalSection"),
+                  perDeviceStepResult("criticalSection", "A"),
+                  perDeviceStepResult("criticalSection", "B"),
                   perDeviceStepResult("terminateApp", "A"),
                   perDeviceStepResult("terminateApp", "B"),
                 )
@@ -347,7 +361,7 @@ class TwoDeviceCriticalSectionPlanTest {
           mapOf(
             "success" to JsonPrimitive(false),
             "executedSteps" to JsonPrimitive(2),
-            "totalSteps" to JsonPrimitive(5),
+            "totalSteps" to JsonPrimitive(6),
             "failedStep" to
               JsonObject(
                 mapOf(
@@ -392,14 +406,6 @@ class TwoDeviceCriticalSectionPlanTest {
         "toolName" to JsonPrimitive(toolName),
         "success" to JsonPrimitive(true),
         "device" to JsonPrimitive(device),
-      )
-    )
-
-  private fun coordinationStepResult(toolName: String): JsonObject =
-    JsonObject(
-      mapOf(
-        "toolName" to JsonPrimitive(toolName),
-        "success" to JsonPrimitive(true),
       )
     )
 

--- a/android/junit-runner/src/test/resources/test-plans/dual-device-critical-section.yaml
+++ b/android/junit-runner/src/test/resources/test-plans/dual-device-critical-section.yaml
@@ -17,7 +17,11 @@ steps:
       appId: com.example.chat
     label: Launch chat app on device B
 
+  # Per-device criticalSection steps that share a lock name. The coordinator
+  # synchronizes both devices at the barrier (deviceCount: 2) before either
+  # executes its sub-steps.
   - tool: criticalSection
+    device: A
     params:
       lock: chat-sync
       deviceCount: 2
@@ -26,10 +30,18 @@ steps:
           params:
             device: A
             text: Hello from Device A
+    label: Device A sends message
+
+  - tool: criticalSection
+    device: B
+    params:
+      lock: chat-sync
+      deviceCount: 2
+      steps:
         - tool: observe
           params:
             device: B
-    label: Device A sends message, Device B observes
+    label: Device B observes incoming message
 
   - tool: terminateApp
     device: A

--- a/schemas/tool-definitions.json
+++ b/schemas/tool-definitions.json
@@ -255,12 +255,12 @@
                 "description": "Tool name to execute"
               },
               "params": {
-                "description": "Tool-specific parameters",
                 "type": "object",
                 "propertyNames": {
                   "type": "string"
                 },
-                "additionalProperties": {}
+                "additionalProperties": {},
+                "description": "Tool-specific parameters. Must include a non-empty 'device'."
               },
               "label": {
                 "description": "Optional human-readable label",
@@ -268,7 +268,8 @@
               }
             },
             "required": [
-              "tool"
+              "tool",
+              "params"
             ],
             "additionalProperties": {}
           },

--- a/src/server/criticalSectionTools.ts
+++ b/src/server/criticalSectionTools.ts
@@ -6,17 +6,30 @@ import { createJSONToolResponse, throwIfAborted } from "../utils/toolUtils";
 import { CriticalSectionCoordinator } from "./CriticalSectionCoordinator";
 import { PlanNormalizer } from "../utils/plan/PlanNormalizer";
 
-// Schema for steps inside critical section
+// Schema for steps inside critical section.
+// Every sub-step MUST declare a target `device` — there is no routing
+// fallback inside a critical section, so an undefined device would silently
+// run on whichever device acquired the lock first.
 const criticalSectionStepSchema = z
   .object({
     tool: z.string().describe("Tool name to execute"),
     params: z
       .record(z.string(), z.any())
-      .optional()
-      .describe("Tool-specific parameters"),
+      .describe("Tool-specific parameters. Must include a non-empty 'device'."),
     label: z.string().optional().describe("Optional human-readable label"),
   })
-  .passthrough();
+  .passthrough()
+  .superRefine((step, ctx) => {
+    const device = step.params?.device;
+    if (device === undefined || device === null || device === "") {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["params", "device"],
+        message:
+          "Every step inside a criticalSection must declare a non-empty 'device' parameter",
+      });
+    }
+  });
 
 type CriticalSectionStepInput = z.infer<typeof criticalSectionStepSchema>;
 

--- a/src/utils/plan/PlanExecutor.ts
+++ b/src/utils/plan/PlanExecutor.ts
@@ -514,35 +514,6 @@ export class DefaultPlanExecutor implements PlanExecutor {
             };
           }
 
-          if (observeTimedOut) {
-            const errorMsg = `observe waitFor timed out after ${observeTimedOut.awaitDuration ?? "unknown"}ms`;
-            logger.error(`[PLAN_STEP_${i + 1}] FAILED: ${step.tool} - ${errorMsg}`);
-            debugSteps.push({
-              step: `Execute step ${i + 1}: ${step.tool}`,
-              status: "failed",
-              durationMs: this.timer.now() - stepStartTime,
-              details: {
-                params: step.params,
-                error: errorMsg,
-              }
-            });
-
-            return {
-              success: false,
-              executedSteps,
-              totalSteps: plan.steps.length,
-              failedStep: {
-                stepIndex: i,
-                tool: step.tool,
-                error: errorMsg,
-              },
-              debug: {
-                executionTimeMs: this.timer.now() - startTime,
-                steps: debugSteps
-              }
-            };
-          }
-
           const completedDetails: Record<string, unknown> = {
             params: step.params,
           };

--- a/src/utils/plan/PlanPartitioner.ts
+++ b/src/utils/plan/PlanPartitioner.ts
@@ -11,27 +11,16 @@ export interface TrackedStep {
 }
 
 /**
- * Represents a critical section barrier in the execution timeline.
+ * Represents a single step in the execution timeline, tagged with the device
+ * that will execute it. Critical sections are not special — they appear as
+ * device-targeted steps just like any other tool. Coordination across devices
+ * happens inside the criticalSection handler via shared lock + deviceCount.
  */
-interface CriticalSectionBarrier {
-  type: "barrier";
-  step: PlanStep;
-  planIndex: number;
-}
-
-/**
- * Represents a regular device step in the execution timeline.
- */
-interface DeviceStepEntry {
+interface TimelineEntry {
   type: "step";
   device: string;
   trackedStep: TrackedStep;
 }
-
-/**
- * Union type for timeline entries.
- */
-type TimelineEntry = CriticalSectionBarrier | DeviceStepEntry;
 
 /**
  * Result of partitioning a plan into device tracks.
@@ -39,7 +28,7 @@ type TimelineEntry = CriticalSectionBarrier | DeviceStepEntry;
 interface PartitionedPlan {
   devices: string[];
   deviceTracks: Map<string, TrackedStep[]>; // device -> ordered steps for that device
-  timeline: TimelineEntry[]; // Ordered list of all steps and barriers
+  timeline: TimelineEntry[]; // Ordered list of every step, in plan order
 }
 
 /**
@@ -76,34 +65,11 @@ export class PlanPartitioner {
       trackPositions.set(device, 0);
     }
 
-    // Partition steps into device tracks
+    // Partition steps into device tracks. Every step — including
+    // criticalSection — must declare params.device; validation enforces this
+    // upstream so we treat a missing device as a programmer error here.
     for (let planIndex = 0; planIndex < plan.steps.length; planIndex++) {
       const step = plan.steps[planIndex];
-
-      // Critical sections are barriers that all devices must reach
-      if (step.tool === "criticalSection") {
-        timeline.push({
-          type: "barrier",
-          step,
-          planIndex,
-        });
-
-        // Add critical section to ALL device tracks at this position
-        // so each device will independently call it and coordinate via the coordinator
-        for (const device of devices) {
-          const track = deviceTracks.get(device)!;
-          const trackIndex = trackPositions.get(device)!;
-          const trackedStep: TrackedStep = {
-            step,
-            planIndex,
-            trackIndex,
-          };
-          track.push(trackedStep);
-          trackPositions.set(device, trackIndex + 1);
-        }
-
-        continue;
-      }
 
       // Regular step - assign to device track
       const device = step.params?.device;
@@ -147,8 +113,8 @@ export class PlanPartitioner {
   }
 
   /**
-   * Gets the device label for a step at a given plan index.
-   * Returns undefined for critical sections.
+   * Gets the device label for a step at a given plan index. Returns undefined
+   * only for out-of-bounds indices or plans with no device-tagged steps.
    */
   static getStepDevice(plan: Plan, planIndex: number): string | undefined {
     if (planIndex < 0 || planIndex >= plan.steps.length) {
@@ -156,10 +122,6 @@ export class PlanPartitioner {
     }
 
     const step = plan.steps[planIndex];
-    if (step.tool === "criticalSection") {
-      return undefined;
-    }
-
     return step.params?.device;
   }
 

--- a/src/utils/plan/PlanValidator.ts
+++ b/src/utils/plan/PlanValidator.ts
@@ -6,8 +6,10 @@ import { normalizePlanDevices } from "./PlanDevices";
  * Validates a plan structure and enforces multi-device rules.
  */
 export class PlanValidator {
-  // Tools that don't require device labels (exceptions to the rule)
-  private static readonly DEVICE_AGNOSTIC_TOOLS = new Set(["criticalSection"]);
+  // Tools that don't require device labels (exceptions to the rule).
+  // criticalSection is intentionally NOT here: every criticalSection step
+  // must target a specific device, just like any other tool.
+  private static readonly DEVICE_AGNOSTIC_TOOLS = new Set<string>();
 
   /**
    * Validates a plan and throws ActionableError if invalid.
@@ -32,6 +34,11 @@ export class PlanValidator {
       this.validateDevicesField(plan);
       this.validateDeviceLabelsPresent(plan);
     }
+
+    // Validate cross-step consistency for criticalSection locks. Runs even
+    // when devices aren't declared so callers get a useful error rather than
+    // a deadlock at the barrier.
+    this.validateCriticalSectionLocks(plan);
   }
 
   /**
@@ -96,8 +103,11 @@ export class PlanValidator {
   }
 
   /**
-   * Validates that all steps have device labels when devices field is present.
-   * Exception: criticalSection and other device-agnostic tools don't need labels.
+   * Validates that every step has a device label when the devices field is
+   * present. criticalSection follows the same rule for its outer step, and
+   * additionally every nested sub-step inside a criticalSection must declare
+   * a device — there is no routing fallback inside the barrier, so an
+   * undefined target would silently execute on the wrong device.
    */
   private static validateDeviceLabelsPresent(plan: Plan): void {
     if (!plan.devices || plan.devices.length === 0) {
@@ -107,26 +117,64 @@ export class PlanValidator {
     const deviceSet = new Set(normalizePlanDevices(plan.devices).labels);
     const missingLabels: Array<{ index: number; tool: string }> = [];
     const invalidLabels: Array<{ index: number; tool: string; device: string }> = [];
+    const missingInCriticalSection: Array<{
+      parentIndex: number;
+      subIndex: number;
+      tool: string;
+    }> = [];
+    const invalidInCriticalSection: Array<{
+      parentIndex: number;
+      subIndex: number;
+      tool: string;
+      device: string;
+    }> = [];
 
     for (let i = 0; i < plan.steps.length; i++) {
       const step = plan.steps[i];
 
-      // Skip device-agnostic tools
+      // Skip any device-agnostic tools (currently none — criticalSection is
+      // intentionally treated like any other device-targeted tool).
       if (this.DEVICE_AGNOSTIC_TOOLS.has(step.tool)) {
         continue;
       }
 
-      // Check if device parameter exists
+      // Every step must declare a device, including criticalSection.
       const device = step.params?.device;
-
       if (device === undefined || device === null || device === "") {
         missingLabels.push({ index: i, tool: step.tool });
-        continue;
+      } else if (!deviceSet.has(device)) {
+        invalidLabels.push({ index: i, tool: step.tool, device });
       }
 
-      // Validate device label is in the declared devices list
-      if (!deviceSet.has(device)) {
-        invalidLabels.push({ index: i, tool: step.tool, device });
+      // Additionally, criticalSection sub-steps must each declare a device.
+      if (step.tool === "criticalSection") {
+        const subSteps = step.params?.steps;
+        if (Array.isArray(subSteps)) {
+          for (let j = 0; j < subSteps.length; j++) {
+            const sub = subSteps[j];
+            if (!sub || typeof sub !== "object") {
+              continue;
+            }
+            const subParams = (sub as { params?: Record<string, unknown> }).params;
+            const subDevice = subParams?.device;
+            const subTool = String((sub as { tool?: unknown }).tool ?? "unknown");
+
+            if (subDevice === undefined || subDevice === null || subDevice === "") {
+              missingInCriticalSection.push({
+                parentIndex: i,
+                subIndex: j,
+                tool: subTool,
+              });
+            } else if (typeof subDevice !== "string" || !deviceSet.has(subDevice)) {
+              invalidInCriticalSection.push({
+                parentIndex: i,
+                subIndex: j,
+                tool: subTool,
+                device: String(subDevice),
+              });
+            }
+          }
+        }
       }
     }
 
@@ -149,6 +197,123 @@ export class PlanValidator {
       errors.push(
         `Plan declares devices [${Array.from(deviceSet).join(", ")}] but the following steps use invalid device labels: ${steps}`
       );
+    }
+
+    if (missingInCriticalSection.length > 0) {
+      const steps = missingInCriticalSection
+        .map(m => `step ${m.parentIndex}.steps[${m.subIndex}] (${m.tool})`)
+        .join(", ");
+      errors.push(
+        `Every step inside a criticalSection must declare a 'device' parameter, but the following sub-steps are missing it: ${steps}`
+      );
+    }
+
+    if (invalidInCriticalSection.length > 0) {
+      const steps = invalidInCriticalSection
+        .map(
+          m =>
+            `step ${m.parentIndex}.steps[${m.subIndex}] (${m.tool}): device="${m.device}"`
+        )
+        .join(", ");
+      errors.push(
+        `Plan declares devices [${Array.from(deviceSet).join(", ")}] but the following criticalSection sub-steps use invalid device labels: ${steps}`
+      );
+    }
+
+    if (errors.length > 0) {
+      throw new ActionableError(errors.join("\n"));
+    }
+  }
+
+  /**
+   * Validates that every criticalSection lock has a consistent contract
+   * across the steps that share it:
+   *   - All steps sharing a lock declare the same deviceCount.
+   *   - The number of steps sharing a lock equals that deviceCount (otherwise
+   *     the barrier will deadlock waiting for a device that never arrives).
+   *   - Each participating step targets a distinct device (no device can
+   *     enter the same lock twice — it would re-acquire and deadlock).
+   *
+   * These checks catch coordination bugs at validation time instead of
+   * surfacing them as a 30-second barrier timeout at runtime.
+   */
+  private static validateCriticalSectionLocks(plan: Plan): void {
+    interface LockOccurrence {
+      stepIndex: number;
+      device: unknown;
+      deviceCount: unknown;
+    }
+    const lockUsage = new Map<string, LockOccurrence[]>();
+
+    for (let i = 0; i < plan.steps.length; i++) {
+      const step = plan.steps[i];
+      if (step.tool !== "criticalSection") {
+        continue;
+      }
+      const params = step.params;
+      if (!params || typeof params !== "object") {
+        continue;
+      }
+      const lock = (params as { lock?: unknown }).lock;
+      if (typeof lock !== "string" || lock.length === 0) {
+        // Schema-level requirements are validated elsewhere; skip silently.
+        continue;
+      }
+      const occurrences = lockUsage.get(lock) ?? [];
+      occurrences.push({
+        stepIndex: i,
+        device: (params as { device?: unknown }).device,
+        deviceCount: (params as { deviceCount?: unknown }).deviceCount,
+      });
+      lockUsage.set(lock, occurrences);
+    }
+
+    const errors: string[] = [];
+
+    for (const [lock, occurrences] of lockUsage.entries()) {
+      const deviceCounts = new Set(
+        occurrences
+          .map(o => o.deviceCount)
+          .filter(c => typeof c === "number")
+      );
+
+      if (deviceCounts.size > 1) {
+        const detail = occurrences
+          .map(o => `step ${o.stepIndex} deviceCount=${String(o.deviceCount)}`)
+          .join(", ");
+        errors.push(
+          `criticalSection lock "${lock}" has inconsistent deviceCount values: ${detail}. All steps sharing a lock must declare the same deviceCount.`
+        );
+        continue;
+      }
+
+      const declaredCount =
+        deviceCounts.size === 1
+          ? (deviceCounts.values().next().value as number)
+          : undefined;
+
+      if (declaredCount !== undefined && occurrences.length !== declaredCount) {
+        errors.push(
+          `criticalSection lock "${lock}" declares deviceCount=${declaredCount} but ${occurrences.length} step${occurrences.length === 1 ? "" : "s"} reference${occurrences.length === 1 ? "s" : ""} it. Every participating device needs its own criticalSection step with this lock.`
+        );
+      }
+
+      const devicesSeen = new Map<string, number[]>();
+      for (const o of occurrences) {
+        if (typeof o.device !== "string" || o.device.length === 0) {
+          continue;
+        }
+        const list = devicesSeen.get(o.device) ?? [];
+        list.push(o.stepIndex);
+        devicesSeen.set(o.device, list);
+      }
+      for (const [device, indices] of devicesSeen.entries()) {
+        if (indices.length > 1) {
+          errors.push(
+            `criticalSection lock "${lock}" is entered twice by device "${device}" (steps ${indices.join(", ")}). Each device can participate in a given lock at most once.`
+          );
+        }
+      }
     }
 
     if (errors.length > 0) {

--- a/test/plan/PlanPartitioner.test.ts
+++ b/test/plan/PlanPartitioner.test.ts
@@ -72,7 +72,7 @@ describe("PlanPartitioner", () => {
       expect(result!.devices).toEqual(["A", "B"]);
     });
 
-    test("should add critical sections to all device tracks", () => {
+    test("should route a per-device critical section to its targeted track", () => {
       const plan: Plan = {
         name: "Plan with Critical Section",
         devices: ["A", "B"],
@@ -81,6 +81,7 @@ describe("PlanPartitioner", () => {
           {
             tool: "criticalSection",
             params: {
+              device: "A",
               lock: "sync1",
               deviceCount: 2,
               steps: [
@@ -95,30 +96,23 @@ describe("PlanPartitioner", () => {
       const result = PlanPartitioner.partition(plan);
       expect(result).not.toBeNull();
 
-      // Check device A track
+      // Device A picks up the criticalSection because it targets device A
       const trackA = result!.deviceTracks.get("A")!;
       expect(trackA).toHaveLength(2); // observe + criticalSection
       expect(trackA[0].step.tool).toBe("observe");
-      expect(trackA[0].planIndex).toBe(0);
       expect(trackA[1].step.tool).toBe("criticalSection");
-      expect(trackA[1].planIndex).toBe(1);
 
-      // Check device B track
+      // Device B only sees its own observe step
       const trackB = result!.deviceTracks.get("B")!;
-      expect(trackB).toHaveLength(2); // criticalSection + observe
-      expect(trackB[0].step.tool).toBe("criticalSection");
-      expect(trackB[0].planIndex).toBe(1);
-      expect(trackB[1].step.tool).toBe("observe");
-      expect(trackB[1].planIndex).toBe(2);
+      expect(trackB).toHaveLength(1);
+      expect(trackB[0].step.tool).toBe("observe");
 
-      // Check timeline
-      expect(result!.timeline).toHaveLength(3); // A observe (step), critical section (barrier), B observe (step)
-      const barriers = result!.timeline.filter(e => e.type === "barrier");
-      expect(barriers).toHaveLength(1);
-      expect(barriers[0].planIndex).toBe(1);
+      // Timeline has three entries, all device-tagged steps
+      expect(result!.timeline).toHaveLength(3);
+      expect(result!.timeline.every(e => e.type === "step")).toBe(true);
     });
 
-    test("should handle multiple critical sections", () => {
+    test("should handle multiple critical sections that share a lock across devices", () => {
       const plan: Plan = {
         name: "Plan with Multiple Critical Sections",
         devices: ["A", "B"],
@@ -126,12 +120,20 @@ describe("PlanPartitioner", () => {
           { tool: "observe", params: { device: "A" } },
           {
             tool: "criticalSection",
-            params: { lock: "sync1", deviceCount: 2, steps: [] },
+            params: { device: "A", lock: "sync1", deviceCount: 2, steps: [] },
+          },
+          {
+            tool: "criticalSection",
+            params: { device: "B", lock: "sync1", deviceCount: 2, steps: [] },
           },
           { tool: "tapOn", params: { device: "B" } },
           {
             tool: "criticalSection",
-            params: { lock: "sync2", deviceCount: 2, steps: [] },
+            params: { device: "A", lock: "sync2", deviceCount: 2, steps: [] },
+          },
+          {
+            tool: "criticalSection",
+            params: { device: "B", lock: "sync2", deviceCount: 2, steps: [] },
           },
           { tool: "observe", params: { device: "A" } },
         ],
@@ -140,27 +142,94 @@ describe("PlanPartitioner", () => {
       const result = PlanPartitioner.partition(plan);
       expect(result).not.toBeNull();
 
-      // Check device A track
+      // Device A: observe, cs(sync1), cs(sync2), observe
       const trackA = result!.deviceTracks.get("A")!;
-      expect(trackA).toHaveLength(4); // observe, cs1, cs2, observe
-      expect(trackA[0].step.tool).toBe("observe");
-      expect(trackA[1].step.tool).toBe("criticalSection");
-      expect(trackA[2].step.tool).toBe("criticalSection");
-      expect(trackA[3].step.tool).toBe("observe");
+      expect(trackA).toHaveLength(4);
+      expect(trackA.map(t => t.step.tool)).toEqual([
+        "observe",
+        "criticalSection",
+        "criticalSection",
+        "observe",
+      ]);
 
-      // Check device B track
+      // Device B: cs(sync1), tapOn, cs(sync2)
       const trackB = result!.deviceTracks.get("B")!;
-      expect(trackB).toHaveLength(3); // cs1, tapOn, cs2
-      expect(trackB[0].step.tool).toBe("criticalSection");
-      expect(trackB[1].step.tool).toBe("tapOn");
-      expect(trackB[2].step.tool).toBe("criticalSection");
-
-      // Check timeline has 2 barriers
-      const barriers = result!.timeline.filter(e => e.type === "barrier");
-      expect(barriers).toHaveLength(2);
+      expect(trackB).toHaveLength(3);
+      expect(trackB.map(t => t.step.tool)).toEqual([
+        "criticalSection",
+        "tapOn",
+        "criticalSection",
+      ]);
     });
 
-    test("should handle device with no steps before critical section", () => {
+    test("should route criticalSection with params.device only to that device's track", () => {
+      const plan: Plan = {
+        name: "Per-Device Critical Sections",
+        devices: ["A", "B"],
+        steps: [
+          {
+            tool: "criticalSection",
+            params: {
+              device: "A",
+              lock: "shared",
+              deviceCount: 2,
+              steps: [{ tool: "inputText", params: { device: "A", text: "hi" } }],
+            },
+          },
+          {
+            tool: "criticalSection",
+            params: {
+              device: "B",
+              lock: "shared",
+              deviceCount: 2,
+              steps: [{ tool: "observe", params: { device: "B" } }],
+            },
+          },
+        ],
+      };
+
+      const result = PlanPartitioner.partition(plan)!;
+
+      const trackA = result.deviceTracks.get("A")!;
+      const trackB = result.deviceTracks.get("B")!;
+
+      // Each device gets ONLY its own criticalSection step, not the other's
+      expect(trackA).toHaveLength(1);
+      expect(trackA[0].step.params!.device).toBe("A");
+      expect(trackA[0].planIndex).toBe(0);
+
+      expect(trackB).toHaveLength(1);
+      expect(trackB[0].step.params!.device).toBe("B");
+      expect(trackB[0].planIndex).toBe(1);
+
+      // Per-device critical sections appear as device "step" entries in the timeline,
+      // not as global barriers.
+      expect(result.timeline).toHaveLength(2);
+      expect(result.timeline[0].type).toBe("step");
+      expect(result.timeline[1].type).toBe("step");
+    });
+
+    test("should throw when criticalSection params.device references unknown device", () => {
+      const plan: Plan = {
+        name: "Invalid Per-Device Critical Section",
+        devices: ["A", "B"],
+        steps: [
+          {
+            tool: "criticalSection",
+            params: {
+              device: "C",
+              lock: "shared",
+              deviceCount: 2,
+              steps: [],
+            },
+          },
+        ],
+      };
+
+      expect(() => PlanPartitioner.partition(plan)).toThrow("unknown device");
+    });
+
+    test("should handle device with no steps before its first critical section", () => {
       const plan: Plan = {
         name: "Plan with Empty Device Track",
         devices: ["A", "B"],
@@ -169,7 +238,7 @@ describe("PlanPartitioner", () => {
           { tool: "tapOn", params: { device: "A" } },
           {
             tool: "criticalSection",
-            params: { lock: "sync1", deviceCount: 2, steps: [] },
+            params: { device: "B", lock: "sync1", deviceCount: 1, steps: [] },
           },
           { tool: "observe", params: { device: "B" } },
         ],
@@ -178,11 +247,12 @@ describe("PlanPartitioner", () => {
       const result = PlanPartitioner.partition(plan);
       expect(result).not.toBeNull();
 
-      // Device A has 3 steps
+      // Device A has 2 steps (observe + tapOn)
       const trackA = result!.deviceTracks.get("A")!;
-      expect(trackA).toHaveLength(3);
+      expect(trackA).toHaveLength(2);
 
-      // Device B has 2 steps (critical section + observe)
+      // Device B has 2 steps (criticalSection + observe), even though its
+      // first activity is a criticalSection.
       const trackB = result!.deviceTracks.get("B")!;
       expect(trackB).toHaveLength(2);
       expect(trackB[0].step.tool).toBe("criticalSection");

--- a/test/plan/PlanValidator.test.ts
+++ b/test/plan/PlanValidator.test.ts
@@ -50,9 +50,44 @@ describe("PlanValidator", () => {
       expect(() => PlanValidator.validate(plan)).not.toThrow();
     });
 
-    test("should validate critical sections without device labels", () => {
+    test("should validate per-device critical sections that share a lock", () => {
       const plan: Plan = {
-        name: "Plan with Critical Section",
+        name: "Plan with Per-Device Critical Sections",
+        devices: ["A", "B"],
+        steps: [
+          { tool: "observe", params: { device: "A" } },
+          {
+            tool: "criticalSection",
+            params: {
+              device: "A",
+              lock: "sync1",
+              deviceCount: 2,
+              steps: [
+                { tool: "tapOn", params: { text: "Sync", device: "A" } },
+              ],
+            },
+          },
+          {
+            tool: "criticalSection",
+            params: {
+              device: "B",
+              lock: "sync1",
+              deviceCount: 2,
+              steps: [
+                { tool: "observe", params: { device: "B" } },
+              ],
+            },
+          },
+          { tool: "observe", params: { device: "B" } },
+        ],
+      };
+
+      expect(() => PlanValidator.validate(plan)).not.toThrow();
+    });
+
+    test("should throw when a criticalSection step is missing its own device label", () => {
+      const plan: Plan = {
+        name: "Plan with Bare Critical Section",
         devices: ["A", "B"],
         steps: [
           { tool: "observe", params: { device: "A" } },
@@ -66,11 +101,16 @@ describe("PlanValidator", () => {
               ],
             },
           },
-          { tool: "observe", params: { device: "B" } },
         ],
       };
 
-      expect(() => PlanValidator.validate(plan)).not.toThrow();
+      expect(() => PlanValidator.validate(plan)).toThrow(ActionableError);
+      expect(() => PlanValidator.validate(plan)).toThrow(
+        "missing 'device' parameter"
+      );
+      expect(() => PlanValidator.validate(plan)).toThrow(
+        "step 1 (criticalSection)"
+      );
     });
 
     test("should throw when devices array is empty", () => {
@@ -160,6 +200,177 @@ describe("PlanValidator", () => {
       expect(() => PlanValidator.validate(plan)).toThrow(ActionableError);
       expect(() => PlanValidator.validate(plan)).toThrow(
         "invalid device labels"
+      );
+      expect(() => PlanValidator.validate(plan)).toThrow('device="C"');
+    });
+
+    test("should throw when criticalSection steps sharing a lock disagree on deviceCount", () => {
+      const plan: Plan = {
+        name: "Inconsistent deviceCount",
+        devices: ["A", "B"],
+        steps: [
+          {
+            tool: "criticalSection",
+            params: {
+              device: "A",
+              lock: "shared",
+              deviceCount: 2,
+              steps: [{ tool: "observe", params: { device: "A" } }],
+            },
+          },
+          {
+            tool: "criticalSection",
+            params: {
+              device: "B",
+              lock: "shared",
+              deviceCount: 3,
+              steps: [{ tool: "observe", params: { device: "B" } }],
+            },
+          },
+        ],
+      };
+
+      expect(() => PlanValidator.validate(plan)).toThrow(ActionableError);
+      expect(() => PlanValidator.validate(plan)).toThrow(
+        "inconsistent deviceCount values"
+      );
+    });
+
+    test("should throw when criticalSection lock has fewer steps than deviceCount", () => {
+      const plan: Plan = {
+        name: "Underpopulated lock",
+        devices: ["A", "B"],
+        steps: [
+          {
+            tool: "criticalSection",
+            params: {
+              device: "A",
+              lock: "shared",
+              deviceCount: 2,
+              steps: [{ tool: "observe", params: { device: "A" } }],
+            },
+          },
+        ],
+      };
+
+      expect(() => PlanValidator.validate(plan)).toThrow(ActionableError);
+      expect(() => PlanValidator.validate(plan)).toThrow(
+        "declares deviceCount=2 but 1 step references it"
+      );
+    });
+
+    test("should throw when the same device enters a criticalSection lock twice", () => {
+      const plan: Plan = {
+        name: "Double-entry lock",
+        devices: ["A", "B"],
+        steps: [
+          {
+            tool: "criticalSection",
+            params: {
+              device: "A",
+              lock: "shared",
+              deviceCount: 2,
+              steps: [{ tool: "observe", params: { device: "A" } }],
+            },
+          },
+          {
+            tool: "criticalSection",
+            params: {
+              device: "A",
+              lock: "shared",
+              deviceCount: 2,
+              steps: [{ tool: "tapOn", params: { device: "A" } }],
+            },
+          },
+        ],
+      };
+
+      expect(() => PlanValidator.validate(plan)).toThrow(ActionableError);
+      expect(() => PlanValidator.validate(plan)).toThrow(
+        'entered twice by device "A"'
+      );
+    });
+
+    test("should accept matched per-device criticalSection steps sharing a lock", () => {
+      const plan: Plan = {
+        name: "Well-formed dual-device critical section",
+        devices: ["A", "B"],
+        steps: [
+          {
+            tool: "criticalSection",
+            params: {
+              device: "A",
+              lock: "shared",
+              deviceCount: 2,
+              steps: [{ tool: "inputText", params: { device: "A", text: "hi" } }],
+            },
+          },
+          {
+            tool: "criticalSection",
+            params: {
+              device: "B",
+              lock: "shared",
+              deviceCount: 2,
+              steps: [{ tool: "observe", params: { device: "B" } }],
+            },
+          },
+        ],
+      };
+
+      expect(() => PlanValidator.validate(plan)).not.toThrow();
+    });
+
+    test("should throw when a criticalSection sub-step is missing device", () => {
+      const plan: Plan = {
+        name: "Invalid Critical Section Plan",
+        devices: ["A", "B"],
+        steps: [
+          { tool: "observe", params: { device: "A" } },
+          {
+            tool: "criticalSection",
+            params: {
+              lock: "sync1",
+              deviceCount: 2,
+              steps: [
+                { tool: "tapOn", params: { text: "Sync", device: "A" } },
+                { tool: "inputText", params: { text: "hi" } }, // no device
+              ],
+            },
+          },
+        ],
+      };
+
+      expect(() => PlanValidator.validate(plan)).toThrow(ActionableError);
+      expect(() => PlanValidator.validate(plan)).toThrow(
+        "Every step inside a criticalSection must declare a 'device' parameter"
+      );
+      expect(() => PlanValidator.validate(plan)).toThrow(
+        "step 1.steps[1] (inputText)"
+      );
+    });
+
+    test("should throw when a criticalSection sub-step uses an undeclared device", () => {
+      const plan: Plan = {
+        name: "Invalid Critical Section Plan",
+        devices: ["A", "B"],
+        steps: [
+          {
+            tool: "criticalSection",
+            params: {
+              lock: "sync1",
+              deviceCount: 2,
+              steps: [
+                { tool: "tapOn", params: { text: "Sync", device: "A" } },
+                { tool: "observe", params: { device: "C" } }, // undeclared
+              ],
+            },
+          },
+        ],
+      };
+
+      expect(() => PlanValidator.validate(plan)).toThrow(ActionableError);
+      expect(() => PlanValidator.validate(plan)).toThrow(
+        "criticalSection sub-steps use invalid device labels"
       );
       expect(() => PlanValidator.validate(plan)).toThrow('device="C"');
     });
@@ -348,11 +559,11 @@ describe("PlanValidator", () => {
       expect(plan.steps[2].params?.includeHierarchy).toBe(true);
       expect(plan.steps[2].params?.device).toBe("A");
 
-      // Verify criticalSection (device-agnostic tool)
+      // Verify criticalSection targets a specific device, like any other step
       expect(plan.steps[3].tool).toBe("criticalSection");
       expect(plan.steps[3].params?.lock).toBe("sync-point");
-      expect(plan.steps[3].params?.deviceCount).toBe(2);
-      expect(plan.steps[3].params?.device).toBeUndefined();
+      expect(plan.steps[3].params?.deviceCount).toBe(1);
+      expect(plan.steps[3].params?.device).toBe("A");
 
       // Verify plan passes all validation
       expect(() => PlanValidator.validate(plan)).not.toThrow();

--- a/test/resources/test-plans/yaml-anchors-test.yaml
+++ b/test/resources/test-plans/yaml-anchors-test.yaml
@@ -30,17 +30,20 @@ steps:
       device: A
     label: Observe device A with common settings
 
-  # Critical section without device parameter (device-agnostic tool)
+  # Critical section must target a specific device, just like any other step.
+  # deviceCount matches the number of per-device criticalSection steps that
+  # share this lock (just one here — device A acts alone).
   - tool: criticalSection
     params:
+      device: A
       lock: sync-point
-      deviceCount: 2
+      deviceCount: 1
       steps:
         - tool: tapOn
           params:
             device: A
             text: Sync
-    label: Critical section for synchronization
+    label: Critical section for device A
 
   # Reuse observe anchor with merge and override
   - tool: observe

--- a/test/server/criticalSectionTools.test.ts
+++ b/test/server/criticalSectionTools.test.ts
@@ -74,6 +74,39 @@ describe("criticalSection tool", () => {
     expect(() => tool!.schema.parse(invalidParams)).toThrow();
   });
 
+  test("rejects schema when a sub-step is missing the device parameter", () => {
+    const tool = ToolRegistry.getTool("criticalSection");
+    expect(tool).toBeDefined();
+
+    const invalidParams = {
+      lock: "test-lock",
+      deviceCount: 2,
+      steps: [
+        { tool: "observe", params: { device: "A" } },
+        { tool: "inputText", params: { text: "hi" } }, // no device
+      ],
+    };
+
+    expect(() => tool!.schema.parse(invalidParams)).toThrow(
+      /Every step inside a criticalSection must declare a non-empty 'device' parameter/
+    );
+  });
+
+  test("rejects schema when a sub-step's device is an empty string", () => {
+    const tool = ToolRegistry.getTool("criticalSection");
+    expect(tool).toBeDefined();
+
+    const invalidParams = {
+      lock: "test-lock",
+      deviceCount: 1,
+      steps: [{ tool: "observe", params: { device: "" } }],
+    };
+
+    expect(() => tool!.schema.parse(invalidParams)).toThrow(
+      /Every step inside a criticalSection must declare a non-empty 'device' parameter/
+    );
+  });
+
   test("rejects invalid schema - non-positive device count", () => {
     const tool = ToolRegistry.getTool("criticalSection");
     expect(tool).toBeDefined();

--- a/test/utils/plan/PlanPartitioner.test.ts
+++ b/test/utils/plan/PlanPartitioner.test.ts
@@ -74,29 +74,16 @@ describe("PlanPartitioner", () => {
       expect(phoneTracks[1].trackIndex).toBe(1);
     });
 
-    test("criticalSection creates barrier in timeline", () => {
+    test("criticalSection step lands only in its targeted device track", () => {
       const plan: Plan = {
         name: "Test",
         devices: ["phone", "tablet"],
         steps: [
           { tool: "tapOn", params: { text: "A", device: "phone" } },
-          { tool: "criticalSection", params: { name: "sync" } },
-          { tool: "tapOn", params: { text: "B", device: "tablet" } },
-        ],
-      };
-
-      const result = PlanPartitioner.partition(plan)!;
-      expect(result.timeline).toHaveLength(3);
-      expect(result.timeline[1].type).toBe("barrier");
-    });
-
-    test("criticalSection added to all device tracks", () => {
-      const plan: Plan = {
-        name: "Test",
-        devices: ["phone", "tablet"],
-        steps: [
-          { tool: "tapOn", params: { text: "A", device: "phone" } },
-          { tool: "criticalSection", params: { name: "sync" } },
+          {
+            tool: "criticalSection",
+            params: { device: "phone", lock: "sync", deviceCount: 2, steps: [] },
+          },
           { tool: "tapOn", params: { text: "B", device: "tablet" } },
         ],
       };
@@ -106,9 +93,12 @@ describe("PlanPartitioner", () => {
       const tabletTrack = result.deviceTracks.get("tablet")!;
 
       expect(phoneTrack).toHaveLength(2); // tapOn + criticalSection
-      expect(tabletTrack).toHaveLength(2); // criticalSection + tapOn
+      expect(tabletTrack).toHaveLength(1); // tapOn only
       expect(phoneTrack[1].step.tool).toBe("criticalSection");
-      expect(tabletTrack[0].step.tool).toBe("criticalSection");
+
+      // Every timeline entry is a device-tagged step (no broadcast barriers).
+      expect(result.timeline).toHaveLength(3);
+      expect(result.timeline.every(e => e.type === "step")).toBe(true);
     });
 
     test("throws on missing device parameter", () => {
@@ -138,17 +128,17 @@ describe("PlanPartitioner", () => {
         steps: [
           { tool: "tapOn", params: { text: "A", device: "phone" } },
           { tool: "tapOn", params: { text: "B", device: "tablet" } },
-          { tool: "criticalSection", params: { name: "sync" } },
+          {
+            tool: "criticalSection",
+            params: { device: "phone", lock: "sync", deviceCount: 2, steps: [] },
+          },
           { tool: "tapOn", params: { text: "C", device: "phone" } },
         ],
       };
 
       const result = PlanPartitioner.partition(plan)!;
       expect(result.timeline).toHaveLength(4);
-      expect(result.timeline[0].type).toBe("step");
-      expect(result.timeline[1].type).toBe("step");
-      expect(result.timeline[2].type).toBe("barrier");
-      expect(result.timeline[3].type).toBe("step");
+      expect(result.timeline.every(e => e.type === "step")).toBe(true);
     });
 
     test("supports device definitions", () => {

--- a/test/utils/plan/PlanValidator.test.ts
+++ b/test/utils/plan/PlanValidator.test.ts
@@ -126,7 +126,7 @@ describe("PlanValidator", () => {
       expect(() => PlanValidator.validate(plan)).toThrow(ActionableError);
     });
 
-    test("criticalSection steps do not require device label", () => {
+    test("criticalSection steps require a device label like any other step", () => {
       const plan: Plan = {
         name: "Test",
         devices: ["phone", "tablet"],
@@ -136,7 +136,10 @@ describe("PlanValidator", () => {
           { tool: "tapOn", params: { text: "Login", device: "tablet" } },
         ],
       };
-      expect(() => PlanValidator.validate(plan)).not.toThrow();
+      expect(() => PlanValidator.validate(plan)).toThrow(ActionableError);
+      expect(() => PlanValidator.validate(plan)).toThrow(
+        "missing 'device' parameter"
+      );
     });
 
     test("throws when steps use device labels without declaring devices", () => {


### PR DESCRIPTION
## Summary
- Multi-device plans now require an explicit `device` on every step, including the `criticalSection` step itself and every sub-step inside it. Validation catches the missing/invalid label instead of letting it silently route to the wrong device.
- `PlanPartitioner` drops its broadcast-to-all-devices branch for `criticalSection` and routes every step uniformly by `params.device`. The `TimelineEntry` type loses its "barrier" variant — every entry is a device-tagged step.
- New `validateCriticalSectionLocks` cross-check: across all steps sharing a lock name, `deviceCount` must agree, the step count must equal `deviceCount`, and no device may enter the same lock twice. Surfaces coordination bugs at validation time rather than as a 30 s barrier timeout at runtime.
- Drive-by: removed a duplicated `if (observeTimedOut) { … }` block in `PlanExecutor.executeSequential` (second copy was unreachable).

## Fixtures touched
- `android/.../dual-device-critical-section.yaml` splits its single `criticalSection` into per-device steps sharing `lock: chat-sync` with `deviceCount: 2`.
- `MultiDevicePlanTest.kt` adjusts step counts (5 → 6) and rewrites the YAML assertion to find both per-device blocks.
- `yaml-anchors-test.yaml` gains `device: A` on its solo `criticalSection` with `deviceCount: 1`.

Refs #764

## Test plan
- [x] `bun test test/plan test/utils/plan` → 188/188
- [ ] CI green on push
- [ ] `./gradlew -p android :junit-runner:test` (covers `MultiDevicePlanTest`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)