### PR TITLE
refactor: route leftover console instrumentation to logger

### DIFF
--- a/src/features/accessibility/ContrastChecker.ts
+++ b/src/features/accessibility/ContrastChecker.ts
@@ -299,7 +299,7 @@ export class ContrastChecker {
             });
           }
         } catch (error) {
-          console.error(`Error checking contrast for element:`, error);
+          logger.error(`Error checking contrast for element:`, error);
           results.set(element, null);
         }
       }
@@ -309,7 +309,7 @@ export class ContrastChecker {
         this.cleanupCache(this.elementCache, this.config.maxCacheSize.elements);
       }
     } catch (error) {
-      console.error("Batch contrast checking error:", error);
+      logger.error("Batch contrast checking error:", error);
       // Return null for all elements on screenshot load failure
       for (const element of elements) {
         results.set(element, null);

--- a/src/features/observe/GetDumpsysWindow.ts
+++ b/src/features/observe/GetDumpsysWindow.ts
@@ -7,6 +7,7 @@ import { PerformanceTracker, NoOpPerformanceTracker } from "../../utils/Performa
 import { getTempDir, TEMP_SUBDIRS } from "../../utils/tempDir";
 import type { DumpsysWindow } from "./interfaces/DumpsysWindow";
 import { Timer, defaultTimer } from "../../utils/SystemTimer";
+import { logger } from "../../utils/logger";
 
 export class GetDumpsysWindow implements DumpsysWindow {
   private adb: AdbExecutor;
@@ -91,7 +92,7 @@ export class GetDumpsysWindow implements DumpsysWindow {
       await perf.track("saveDiskCache", () => this.saveToDiskCache(cacheEntry));
     } catch (error) {
       // Disk cache write failed, but we still return the result
-      console.warn(`Failed to write disk cache for device ${this.device.deviceId}:`, error);
+      logger.warn(`Failed to write disk cache for device ${this.device.deviceId}:`, error);
     }
 
     return result;

--- a/src/vision/ClaudeVisionClient.ts
+++ b/src/vision/ClaudeVisionClient.ts
@@ -14,6 +14,7 @@ import type {
 import type { ViewHierarchyNode } from "../models/ViewHierarchyResult";
 import type { Timer } from "../utils/SystemTimer";
 import { defaultTimer } from "../utils/SystemTimer";
+import { logger } from "../utils/logger";
 
 export class ClaudeVisionClient {
   private client: Anthropic;
@@ -86,7 +87,7 @@ export class ClaudeVisionClient {
         screenshotPath
       );
     } catch (error) {
-      console.error("Claude Vision API error:", error);
+      logger.error("Claude Vision API error:", error);
       throw error;
     }
   }

--- a/src/vision/VisionFallback.ts
+++ b/src/vision/VisionFallback.ts
@@ -12,6 +12,7 @@ import type {
 import type { ViewHierarchyNode } from "../models/ViewHierarchyResult";
 import type { Timer } from "../utils/SystemTimer";
 import { defaultTimer } from "../utils/SystemTimer";
+import { logger } from "../utils/logger";
 
 export class VisionFallback {
   private config: VisionFallbackConfig;
@@ -43,7 +44,7 @@ export class VisionFallback {
     if (this.config.cacheResults) {
       const cached = this.getCachedResult(screenshotPath, searchCriteria);
       if (cached) {
-        console.log("✓ Vision fallback: Using cached result");
+        logger.debug("Vision fallback: using cached result");
         return cached;
       }
     }
@@ -54,7 +55,7 @@ export class VisionFallback {
         throw new Error("Claude client not initialized");
       }
 
-      console.log("🔍 Vision fallback: Analyzing with Claude...");
+      logger.debug("Vision fallback: analyzing with Claude");
       const result = await this.claudeClient.analyzeUIElement(
         screenshotPath,
         searchCriteria,
@@ -63,10 +64,10 @@ export class VisionFallback {
 
       // Check if cost exceeds max
       if (result.costUsd > this.config.maxCostUsd) {
-        console.warn(`⚠️  Vision fallback cost ($${result.costUsd.toFixed(4)}) exceeds max ($${this.config.maxCostUsd})`);
+        logger.warn(`Vision fallback cost ($${result.costUsd.toFixed(4)}) exceeds max ($${this.config.maxCostUsd})`);
       }
 
-      console.log(`✓ Vision fallback complete: confidence=${result.confidence}, cost=$${result.costUsd.toFixed(4)}, time=${result.durationMs}ms`);
+      logger.debug(`Vision fallback complete: confidence=${result.confidence}, cost=$${result.costUsd.toFixed(4)}, time=${result.durationMs}ms`);
 
       // Cache result
       if (this.config.cacheResults) {


### PR DESCRIPTION
## Summary
- Routed leftover `console.*` instrumentation in vision, contrast checker, and dumpsys cache to the canonical `logger`
- Intentional bypasses kept: `logger.ts` self-fallback, `index.ts` fatal-`main()` fallback, `DEBUG_ADB_EXEC`-guarded probes in `AdbClient.ts`, and daemon CLI command output in `daemon/manager.ts`

## Test plan
- [ ] `turbo run lint build test` passes locally