### PR TITLE
refactor(observe): decompose ObserveScreen into composed services + structured errors

### DIFF
--- a/src/features/observe/ObserveError.ts
+++ b/src/features/observe/ObserveError.ts
@@ -1,0 +1,39 @@
+import type { ObserveResult } from "../../models";
+
+export type ObservePhase =
+  | "screenSize"
+  | "systemInsets"
+  | "rotation"
+  | "wakefulness"
+  | "backStack"
+  | "viewHierarchy"
+  | "rawViewHierarchy"
+  | "intentChooser"
+  | "activeWindow"
+  | "screenshot"
+  | "performanceAudit"
+  | "accessibilityAudit"
+  | "accessibilityState"
+  | "predictiveUI"
+  | "cache"
+  | "critical";
+
+export interface ObserveError {
+  phase: ObservePhase;
+  message: string;
+  cause?: string;
+}
+
+export function appendObserveError(result: ObserveResult, err: ObserveError): void {
+  if (!result.errors) {
+    result.errors = [];
+    // Preserve a pre-existing `error` string (set by legacy code paths or
+    // direct assignment) so the derived `error` keeps concatenating instead
+    // of overwriting it.
+    if (result.error) {
+      result.errors.push({ phase: "critical", message: result.error });
+    }
+  }
+  result.errors.push(err);
+  result.error = result.errors.map(e => e.message).join("; ");
+}

--- a/src/features/observe/ObserveScreen.ts
+++ b/src/features/observe/ObserveScreen.ts
@@ -1,8 +1,6 @@
 import { logger } from "../../utils/logger";
 import { throwIfAborted } from "../../utils/toolUtils";
-import { BootedDevice, ExecResult, ObserveResult } from "../../models";
-import { ViewHierarchyQueryOptions } from "../../models/ViewHierarchyQueryOptions";
-import { ScreenshotResult } from "../../models/ScreenshotResult";
+import { BootedDevice, ObserveResult } from "../../models";
 import { GetScreenSize } from "./GetScreenSize";
 import { GetSystemInsets } from "./GetSystemInsets";
 import { ViewHierarchy } from "./ViewHierarchy";
@@ -12,174 +10,98 @@ import { GetDumpsysWindow } from "./GetDumpsysWindow";
 import { GetBackStack } from "./GetBackStack";
 import { AdbClientFactory, defaultAdbClientFactory } from "../../utils/android-cmdline-tools/AdbClientFactory";
 import type { AdbExecutor } from "../../utils/android-cmdline-tools/interfaces/AdbExecutor";
-import { existsSync, mkdirSync } from "node:fs";
-import { pathExists } from "../../utils/filesystem/DefaultFileSystem";
-import path from "path";
-import { readdirAsync, readFileAsync, statAsync, writeFileAsync } from "../../utils/io";
-import { AndroidCtrlProxyManager } from "../../utils/CtrlProxyManager";
-import { PerformanceTracker, NoOpPerformanceTracker, processTimingData } from "../../utils/PerformanceTracker";
-import { PerformanceAudit } from "../performance/PerformanceAudit";
-import { ThresholdManager } from "../performance/ThresholdManager";
-import { DeviceCapabilitiesDetector } from "../../utils/DeviceCapabilities";
+import { NoOpPerformanceTracker, PerformanceTracker, processTimingData } from "../../utils/PerformanceTracker";
 import { serverConfig } from "../../utils/ServerConfig";
-import { WcagAudit } from "../accessibility/WcagAudit";
-import { Element } from "../../models/Element";
 import { RecompositionTracker } from "../performance/RecompositionTracker";
 import { PredictiveUIState } from "./PredictiveUIState";
-import { accessibilityDetector } from "../../utils/AccessibilityDetector";
-import { iosVoiceOverDetector } from "../../utils/IosVoiceOverDetector";
-import { FeatureFlagService } from "../featureFlags/FeatureFlagService";
-import { OPERATION_CANCELLED_MESSAGE } from "../../utils/constants";
 import { ScreenshotJobTracker } from "../../utils/ScreenshotJobTracker";
 import { Timer, defaultTimer } from "../../utils/SystemTimer";
 import { attachRawViewHierarchy } from "../../utils/viewHierarchySearch";
-import { DefaultElementParser } from "../utility/ElementParser";
-import { AndroidCtrlProxyClient } from "./android";
-import { IOSCtrlProxyClient } from "./ios";
-import { getTempDir, TEMP_SUBDIRS } from "../../utils/tempDir";
 import type { ObserveScreen, ObserveScreenExecuteOptions } from "./interfaces/ObserveScreen";
 import type { ObserveScreenDependencies } from "./ObserveScreenDependencies";
-import type { ScreenSize } from "./interfaces/ScreenSize";
-import type { SystemInsets } from "./interfaces/SystemInsets";
 import type { ViewHierarchy as ViewHierarchyInterface } from "./interfaces/ViewHierarchy";
-import type { Window as WindowInterface } from "./interfaces/Window";
 import type { DumpsysWindow } from "./interfaces/DumpsysWindow";
-import type { BackStack } from "./interfaces/BackStack";
 import type { PredictiveUIState as PredictiveUIStateInterface } from "./interfaces/PredictiveUIState";
-import type { ScreenshotService } from "./interfaces/ScreenshotService";
+
+import { getObserveCacheStore, setObserveCacheStore } from "./cache/ObserveCacheRegistry";
+import { getScreenshotStateStore, setScreenshotStateStore } from "./screenshot/ScreenshotStateRegistry";
+import {
+  DefaultObserveScreenshotRecorder,
+  ObserveScreenshotRecorder,
+  TrackedScreenshotService
+} from "./screenshot/ObserveScreenshotRecorder";
+import { HierarchyCollector } from "./collectors/HierarchyCollector";
+import { DeviceStateCollector } from "./collectors/DeviceStateCollector";
+import { PerformanceAuditor } from "./audits/PerformanceAuditor";
+import { AccessibilityAuditor, resolveLatestScreenshotPath } from "./audits/AccessibilityAuditor";
+import { AccessibilityStateDetector } from "./audits/AccessibilityStateDetector";
+import { appendObserveError } from "./ObserveError";
 
 /**
- * Interface for cached observe result
- */
-interface ObserveResultCache {
-  timestamp: number;
-  deviceId: string;
-  observeResult: ObserveResult;
-}
-
-/**
- * Per-device screenshot state
- */
-interface ScreenshotState {
-  path: string | null;
-  error: string | null;
-  timestamp: number;
-}
-
-/**
- * Observe command class that combines screen details, view hierarchy and screenshot
+ * Observe command class that combines screen details, view hierarchy and screenshot.
+ *
+ * State (observe-result cache, per-device screenshot state) lives on injected
+ * stores. The static methods below preserve the existing API for server
+ * resource handlers and the daemon by delegating to those stores.
  */
 export class RealObserveScreen implements ObserveScreen {
   private device: BootedDevice;
-  private screenSize: ScreenSize;
-  private systemInsets: SystemInsets;
-  private viewHierarchy: ViewHierarchyInterface;
-  private window: WindowInterface;
-  private screenshotUtil: ScreenshotService;
-  private dumpsysWindow: DumpsysWindow;
-  private backStack: BackStack;
   private adb: AdbExecutor;
   private adbFactory: AdbClientFactory;
-  private predictiveUIState: PredictiveUIStateInterface;
   private timer: Timer;
 
-  // Static cache for observe results (keyed by "deviceId:timestamp")
-  private static observeResultCache: Map<string, ObserveResultCache> = new Map();
-  private static observeResultCacheDir: string = getTempDir(TEMP_SUBDIRS.OBSERVE_RESULTS);
-  private static readonly OBSERVE_RESULT_CACHE_TTL_MS = 5 * 60 * 1000; // 5 minutes
-  // Per-device screenshot state
-  private static screenshotStateByDevice: Map<string, ScreenshotState> = new Map();
+  private viewHierarchy: ViewHierarchyInterface;
+  private dumpsysWindow: DumpsysWindow;
+  private predictiveUIState: PredictiveUIStateInterface;
 
-  /**
-   * Get the most recent cached observe result from memory (static accessor).
-   * Returns the most recently cached result across ALL devices if available and not expired.
-   */
+  private screenshotRecorder: ObserveScreenshotRecorder;
+  private hierarchyCollector: HierarchyCollector;
+  private deviceStateCollector: DeviceStateCollector;
+  private performanceAuditor: PerformanceAuditor;
+  private accessibilityAuditor: AccessibilityAuditor;
+  private accessibilityStateDetector: AccessibilityStateDetector;
+
+  // ---------- Static API (kept for back-compat with resource handlers/daemon) ----------
+
   static getRecentCachedResult(): ObserveResult | undefined {
-    return RealObserveScreen.findMostRecentCachedResult();
+    return getObserveCacheStore().getRecentInMemory();
   }
 
-  /**
-   * Get the most recent cached observe result for a specific device.
-   * Returns undefined if no valid cached result exists for that device.
-   */
   static getRecentCachedResultForDevice(deviceId: string): ObserveResult | undefined {
-    return RealObserveScreen.findMostRecentCachedResult(deviceId);
+    return getObserveCacheStore().getRecentInMemoryForDevice(deviceId);
   }
 
-  private static findMostRecentCachedResult(deviceId?: string): ObserveResult | undefined {
-    if (RealObserveScreen.observeResultCache.size === 0) {
-      return undefined;
-    }
-
-    const now = defaultTimer.now();
-    let mostRecentEntry: ObserveResultCache | undefined;
-    let mostRecentTimestamp = 0;
-
-    for (const entry of RealObserveScreen.observeResultCache.values()) {
-      if (deviceId && entry.deviceId !== deviceId) {
-        continue;
-      }
-      const age = now - entry.timestamp;
-      if (age <= RealObserveScreen.OBSERVE_RESULT_CACHE_TTL_MS && entry.timestamp > mostRecentTimestamp) {
-        mostRecentEntry = entry;
-        mostRecentTimestamp = entry.timestamp;
-      }
-    }
-
-    return mostRecentEntry?.observeResult;
-  }
-
-  /**
-   * Get the most recent cached screenshot path (if any) across all devices.
-   */
   static getRecentCachedScreenshotPath(): string | undefined {
-    const state = RealObserveScreen.findLatestScreenshotState();
-    return state?.path ?? undefined;
+    return getScreenshotStateStore().getPath();
   }
 
-  /**
-   * Get the most recent cached screenshot path for a specific device.
-   */
   static getRecentCachedScreenshotPathForDevice(deviceId: string): string | undefined {
-    const state = RealObserveScreen.findLatestScreenshotState(deviceId);
-    return state?.path ?? undefined;
+    return getScreenshotStateStore().getPath(deviceId);
   }
 
-  /**
-   * Get the most recent cached screenshot error (if any) across all devices.
-   */
   static getRecentCachedScreenshotError(): string | undefined {
-    const state = RealObserveScreen.findLatestScreenshotState();
-    return state?.error ?? undefined;
+    return getScreenshotStateStore().getError();
   }
 
-  /**
-   * Get the most recent cached screenshot error for a specific device.
-   */
   static getRecentCachedScreenshotErrorForDevice(deviceId: string): string | undefined {
-    const state = RealObserveScreen.findLatestScreenshotState(deviceId);
-    return state?.error ?? undefined;
+    return getScreenshotStateStore().getError(deviceId);
   }
 
   /**
-   * Clear the in-memory cache.
+   * Clear the in-memory cache (and disk cache).
    * @param deviceId - If provided, only clears cache for that device. Otherwise clears all.
    */
   static clearCache(deviceId?: string): void {
+    getObserveCacheStore().clear(deviceId);
+    getScreenshotStateStore().clear(deviceId);
     if (deviceId) {
-      for (const [key, entry] of RealObserveScreen.observeResultCache.entries()) {
-        if (entry.deviceId === deviceId) {
-          RealObserveScreen.observeResultCache.delete(key);
-        }
-      }
-      RealObserveScreen.screenshotStateByDevice.delete(deviceId);
       ScreenshotJobTracker.cancelJob(deviceId);
     } else {
-      RealObserveScreen.observeResultCache.clear();
-      RealObserveScreen.screenshotStateByDevice.clear();
       ScreenshotJobTracker.clear();
     }
   }
+
+  // ---------- Constructor ----------
 
   constructor(
     device: BootedDevice,
@@ -188,12 +110,10 @@ export class RealObserveScreen implements ObserveScreen {
     timer: Timer = defaultTimer
   ) {
     this.device = device;
-    // Detect if the argument is a factory (has create method) or an executor
     if (adbFactoryOrExecutor && typeof (adbFactoryOrExecutor as AdbClientFactory).create === "function") {
       this.adbFactory = adbFactoryOrExecutor as AdbClientFactory;
       this.adb = this.adbFactory.create(device);
     } else if (adbFactoryOrExecutor) {
-      // Legacy path: wrap the executor in a factory for downstream dependencies
       const executor = adbFactoryOrExecutor as AdbExecutor;
       this.adb = executor;
       this.adbFactory = { create: () => executor };
@@ -201,696 +121,93 @@ export class RealObserveScreen implements ObserveScreen {
       this.adbFactory = defaultAdbClientFactory;
       this.adb = this.adbFactory.create(device);
     }
-
-    // Use injected dependencies or create defaults
-    this.screenSize = dependencies?.screenSize ?? new GetScreenSize(device, this.adbFactory);
-    this.systemInsets = dependencies?.systemInsets ?? new GetSystemInsets(device, this.adbFactory);
-    this.viewHierarchy = dependencies?.viewHierarchy ?? new ViewHierarchy(device, this.adbFactory);
-    this.window = dependencies?.window ?? new Window(device, this.adbFactory);
-    this.screenshotUtil = dependencies?.screenshot ?? new TakeScreenshot(device, this.adbFactory);
-    this.dumpsysWindow = dependencies?.dumpsysWindow ?? new GetDumpsysWindow(device, this.adbFactory);
-    this.backStack = dependencies?.backStack ?? new GetBackStack(this.adbFactory, device);
-    this.predictiveUIState = dependencies?.predictiveUIState ?? new PredictiveUIState();
     this.timer = timer;
 
-    // Ensure observe result cache directory exists
-    if (!existsSync(RealObserveScreen.observeResultCacheDir)) {
-      mkdirSync(RealObserveScreen.observeResultCacheDir, { recursive: true });
+    // Data sources (either injected or default)
+    const screenSize = dependencies?.screenSize ?? new GetScreenSize(device, this.adbFactory);
+    const systemInsets = dependencies?.systemInsets ?? new GetSystemInsets(device, this.adbFactory);
+    this.viewHierarchy = dependencies?.viewHierarchy ?? new ViewHierarchy(device, this.adbFactory);
+    const window = dependencies?.window ?? new Window(device, this.adbFactory);
+    const screenshotUtil = dependencies?.screenshot ?? new TakeScreenshot(device, this.adbFactory);
+    this.dumpsysWindow = dependencies?.dumpsysWindow ?? new GetDumpsysWindow(device, this.adbFactory);
+    const backStack = dependencies?.backStack ?? new GetBackStack(this.adbFactory, device);
+    this.predictiveUIState = dependencies?.predictiveUIState ?? new PredictiveUIState();
+
+    // Caches: install injected stores into the registry so instance methods AND
+    // the static accessors (used by server resource handlers) share state.
+    // Tests that need isolation should call setObserveCacheStore / setScreenshotStateStore
+    // with a fake in beforeEach and resetObserveCacheStore / resetScreenshotStateStore
+    // in afterEach.
+    if (dependencies?.cacheStore) {
+      setObserveCacheStore(dependencies.cacheStore);
     }
-  }
-
-  private static findLatestScreenshotState(deviceId?: string): { path: string | null; error: string | null } | null {
-    const now = defaultTimer.now();
-
-    if (deviceId) {
-      const state = RealObserveScreen.screenshotStateByDevice.get(deviceId);
-      if (!state) {
-        return null;
-      }
-      if (now - state.timestamp > RealObserveScreen.OBSERVE_RESULT_CACHE_TTL_MS) {
-        RealObserveScreen.screenshotStateByDevice.delete(deviceId);
-        return null;
-      }
-      return { path: state.path, error: state.error };
-    }
-
-    // Find most recent across all devices
-    let mostRecent: ScreenshotState | null = null;
-    for (const [id, state] of RealObserveScreen.screenshotStateByDevice.entries()) {
-      if (now - state.timestamp > RealObserveScreen.OBSERVE_RESULT_CACHE_TTL_MS) {
-        RealObserveScreen.screenshotStateByDevice.delete(id);
-        continue;
-      }
-      if (!mostRecent || state.timestamp > mostRecent.timestamp) {
-        mostRecent = state;
-      }
+    if (dependencies?.screenshotStateStore) {
+      setScreenshotStateStore(dependencies.screenshotStateStore);
     }
 
-    if (!mostRecent) {
-      return null;
-    }
-    return { path: mostRecent.path, error: mostRecent.error };
-  }
-
-  private static updateLatestScreenshotCache(deviceId: string, path?: string, error?: string): void {
-    RealObserveScreen.screenshotStateByDevice.set(deviceId, {
-      path: path ?? null,
-      error: error ?? null,
-      timestamp: defaultTimer.now(),
+    // Composed services
+    this.screenshotRecorder = dependencies?.screenshotRecorder ?? new DefaultObserveScreenshotRecorder(
+      device,
+      screenshotUtil as TrackedScreenshotService,
+      getScreenshotStateStore()
+    );
+    this.hierarchyCollector = dependencies?.hierarchyCollector ?? new HierarchyCollector({
+      device,
+      viewHierarchy: this.viewHierarchy,
+      adb: this.adb,
+      adbFactory: this.adbFactory,
+      timer: this.timer,
+    });
+    this.deviceStateCollector = dependencies?.deviceStateCollector ?? new DeviceStateCollector({
+      device,
+      screenSize,
+      systemInsets,
+      window,
+      backStack,
+      adb: this.adb,
+      timer: this.timer,
+    });
+    this.performanceAuditor = dependencies?.performanceAuditor ?? new PerformanceAuditor({
+      device,
+      adb: this.adb,
+    });
+    this.accessibilityAuditor = dependencies?.accessibilityAuditor ?? new AccessibilityAuditor({
+      device,
+      // Prefer the recorder-backed cached path before falling back to disk scan.
+      screenshotPathResolver: () => resolveLatestScreenshotPath(
+        () => getScreenshotStateStore().getPath(this.device.deviceId)
+      ),
+    });
+    this.accessibilityStateDetector = dependencies?.accessibilityStateDetector ?? new AccessibilityStateDetector({
+      device,
+      adb: this.adb,
     });
   }
 
-  private async handleScreenshotResult(
-    screenshotResult: ScreenshotResult,
-    options: { ignoreCancel?: boolean } = {}
-  ): Promise<void> {
-    if (!screenshotResult.success) {
-      const errorMessage = screenshotResult.error || "Failed to capture screenshot";
-      if (options.ignoreCancel && errorMessage.includes(OPERATION_CANCELLED_MESSAGE)) {
-        logger.debug("[OBSERVE] Screenshot capture cancelled");
-        return;
-      }
-      RealObserveScreen.updateLatestScreenshotCache(this.device.deviceId, undefined, errorMessage);
-      logger.warn(`[OBSERVE] Screenshot capture failed: ${errorMessage}`);
-      return;
-    }
-
-    if (!screenshotResult.path) {
-      RealObserveScreen.updateLatestScreenshotCache(this.device.deviceId, undefined, "Screenshot capture returned no file path");
-      logger.warn("[OBSERVE] Screenshot capture succeeded but no file path was returned");
-      return;
-    }
-
-    const exists = await pathExists(screenshotResult.path);
-    if (!exists) {
-      RealObserveScreen.updateLatestScreenshotCache(this.device.deviceId, undefined, "Screenshot file missing after capture");
-      logger.warn(`[OBSERVE] Screenshot capture reported success but file missing: ${screenshotResult.path}`);
-      return;
-    }
-
-    RealObserveScreen.updateLatestScreenshotCache(this.device.deviceId, screenshotResult.path);
-  }
-
-  /**
-   * Collect screen size and handle errors
-   * @param dumpsysWindow - ExecResult containing dumpsys window output
-   * @param result - ObserveResult to update
-   */
-  public async collectScreenSize(dumpsysWindow: ExecResult, result: ObserveResult): Promise<void> {
-    try {
-      const screenSizeStart = this.timer.now();
-      result.screenSize = await this.screenSize.execute(dumpsysWindow);
-      logger.debug(`Screen size retrieval took ${this.timer.now() - screenSizeStart}ms`);
-    } catch (error) {
-      logger.warn("Failed to get screen size:", error);
-      this.appendError(result, "Failed to retrieve screen dimensions");
-    }
-  }
-
-  /**
-   * Collect system insets using cached dumpsys window output
-   * @param dumpsysWindow - ExecResult containing dumpsys window output
-   * @param result - ObserveResult to update
-   */
-  public async collectSystemInsets(dumpsysWindow: ExecResult, result: ObserveResult): Promise<void> {
-    try {
-      const insetsStart = this.timer.now();
-      // Pass cached dumpsys window output to avoid duplicate call
-      result.systemInsets = await this.systemInsets.execute(dumpsysWindow);
-      logger.debug(`System insets retrieval took ${this.timer.now() - insetsStart}ms`);
-    } catch (error) {
-      logger.warn("Failed to get system insets:", error);
-      this.appendError(result, "Failed to retrieve system insets");
-    }
-  }
-
-  /**
-   * Collect rotation info using cached dumpsys window output
-   * @param dumpsysWindow - ExecResult containing dumpsys window output
-   * @param result - ObserveResult to update
-   */
-  public async collectRotationInfo(dumpsysWindow: ExecResult, result: ObserveResult): Promise<void> {
-    try {
-      const rotationStart = this.timer.now();
-      const rotationMatch = dumpsysWindow.stdout.match(/mRotation=(\d)/);
-      if (rotationMatch) {
-        result.rotation = parseInt(rotationMatch[1], 10);
-      }
-      logger.debug(`Rotation info retrieval took ${this.timer.now() - rotationStart}ms`);
-    } catch (error) {
-      logger.warn("Failed to get rotation info:", error);
-    }
-  }
-
-  /**
-   * Collect wakefulness state (Android only)
-   * @param result - ObserveResult to update
-   */
-  public async collectWakefulness(result: ObserveResult, signal?: AbortSignal): Promise<void> {
-    try {
-      const wakefulness = await this.adb.getWakefulness(signal);
-      if (wakefulness) {
-        result.wakefulness = wakefulness;
-      }
-    } catch (error) {
-      logger.warn("Failed to get wakefulness state:", error);
-    }
-  }
-
-  /**
-   * Collect back stack information (Android only)
-   * @param result - ObserveResult to update
-   * @param perf - Performance tracker for timing data
-   */
-  public async collectBackStack(
-    result: ObserveResult,
-    perf: PerformanceTracker = new NoOpPerformanceTracker(),
-    signal?: AbortSignal
-  ): Promise<void> {
-    try {
-      const backStackStart = this.timer.now();
-      const backStackInfo = await this.backStack.execute(perf, signal);
-      result.backStack = backStackInfo;
-      logger.debug(`Back stack retrieval took ${this.timer.now() - backStackStart}ms`);
-    } catch (error) {
-      logger.warn("Failed to get back stack:", error);
-      this.appendError(result, "Failed to retrieve back stack information");
-    }
-  }
-
-  /**
-   * Collect view hierarchy and handle errors with accessibility service caching
-   * @param result - ObserveResult to update
-   * @param queryOptions - ViewHierarchyQueryOptions to pass to viewHierarchy.getViewHierarchy
-   * @param perf - Performance tracker for timing data
-   * @param skipWaitForFresh - If true, skip WebSocket wait and go straight to sync method
-   * @param minTimestamp - If provided, cached data must have updatedAt >= this value
-   */
-  public async collectViewHierarchy(
-    result: ObserveResult,
-    queryOptions?: ViewHierarchyQueryOptions,
-    perf: PerformanceTracker = new NoOpPerformanceTracker(),
-    skipWaitForFresh: boolean = false,
-    minTimestamp: number = 0,
-    signal?: AbortSignal
-  ): Promise<void> {
-    try {
-      if (this.device.platform === "android") {
-        await this.viewHierarchy.configureRecompositionTracking(true, perf);
-      }
-
-      const viewHierarchyStart = this.timer.now();
-      const viewHierarchy = await this.viewHierarchy.getViewHierarchy(queryOptions, perf, skipWaitForFresh, minTimestamp, signal);
-      logger.debug("Accessibility service availability cached as: true");
-
-      if (viewHierarchy) {
-        result.viewHierarchy = viewHierarchy;
-
-        // Use the updatedAt from the view hierarchy if available (from accessibility service)
-        if (viewHierarchy.updatedAt) {
-          result.updatedAt = viewHierarchy.updatedAt;
-          logger.debug(`Using updatedAt from view hierarchy: ${viewHierarchy.updatedAt}`);
-        }
-
-        const focusedElement = this.viewHierarchy.findFocusedElement(viewHierarchy);
-        if (focusedElement) {
-          result.focusedElement = focusedElement;
-          logger.debug(`Found focused element: ${focusedElement.text || focusedElement["resource-id"] || "no text/id"}`);
-        }
-
-        const accessibilityFocusedElement = this.viewHierarchy.findAccessibilityFocusedElement(viewHierarchy);
-        if (accessibilityFocusedElement) {
-          result.accessibilityFocusedElement = accessibilityFocusedElement;
-          logger.debug(`Found accessibility-focused element: ${accessibilityFocusedElement.text || accessibilityFocusedElement["resource-id"] || accessibilityFocusedElement["content-desc"] || "no text/id/desc"}`);
-        }
-
-        await this.detectIntentChooser(result);
-        if (viewHierarchy.notificationPermissionDetected !== undefined) {
-          result.notificationPermissionDetected = viewHierarchy.notificationPermissionDetected;
-          if (viewHierarchy.notificationPermissionDetected) {
-            logger.debug("[ObserveScreen] Notification permission dialog detected in view hierarchy");
-          }
-        }
-      }
-
-      logger.debug(`View hierarchy retrieval took ${this.timer.now() - viewHierarchyStart}ms`);
-    } catch (error) {
-      logger.warn("Failed to get view hierarchy:", error);
-
-      // Clear cache on failure
-      AndroidCtrlProxyManager.getInstance(this.device, this.adb).clearAvailabilityCache();
-
-      // Check if the error is due to screen being off
-      const errorStr = String(error);
-      if (
-        errorStr.includes("null root node returned by UiTestAutomationBridge") ||
-        (errorStr.includes("cat:") && errorStr.includes("No such file or directory")) ||
-        (errorStr.includes("screen appears to be off"))
-      ) {
-        this.appendError(result, "Screen appears to be off or device is locked");
-      } else {
-        this.appendError(result, "Failed to retrieve view hierarchy");
-      }
-    }
-  }
-
-  /**
-   * Detect intent chooser dialog in the view hierarchy
-   * @param result - ObserveResult to update
-   */
-  private async detectIntentChooser(result: ObserveResult): Promise<void> {
-
-    if (!result.viewHierarchy) {
-      return;
-    }
-
-    try {
-      const intentChooserDetected = result.viewHierarchy.intentChooserDetected;
-
-      // Add intent chooser detection to result
-      result.intentChooserDetected = intentChooserDetected;
-
-      if (intentChooserDetected) {
-        logger.debug("[ObserveScreen] Intent chooser dialog detected in view hierarchy");
-      }
-    } catch (error) {
-      logger.warn(`[ObserveScreen] Failed to detect intent chooser: ${error}`);
-      // Don't fail the observation if intent chooser detection fails
-    }
-  }
-
-
-  /**
-   * Collect active window information using cache if available
-   * @param result - ObserveResult to update
-   */
-  public async collectActiveWindow(result: ObserveResult): Promise<void> {
-    try {
-      logger.debug("[OBSERVER] collectActiveWindow");
-      const windowStart = this.timer.now();
-
-      const activeWindow = await this.window.getActive();
-
-      logger.debug(`Active window retrieval took ${this.timer.now() - windowStart}ms`);
-      if (activeWindow) {
-        result.activeWindow = activeWindow;
-      }
-    } catch (error) {
-      logger.warn("Failed to get active window:", error);
-      this.appendError(result, "Failed to retrieve active window information");
-    }
-  }
-
-  /**
-   * Fetch raw (unfiltered) view hierarchy from the device and attach to an existing result.
-   * On Android: requests the accessibility service hierarchy with all filtering disabled.
-   * On iOS: requests the CtrlProxy iOS hierarchy with all filtering disabled.
-   * Invalidates the shared cache after fetching so that the unfiltered snapshot does not
-   * bleed into subsequent normal observe calls.
-   */
-  private async collectRawViewHierarchyData(result: ObserveResult, signal?: AbortSignal): Promise<void> {
-    try {
-      if (this.device.platform === "android") {
-        const client = AndroidCtrlProxyClient.getInstance(this.device, this.adbFactory);
-        // Use requestHierarchySync directly to bypass the cache — getAccessibilityHierarchy
-        // with minTimestamp=0 returns any cached result, which may already be filtered.
-        const syncResult = await client.requestHierarchySync(
-          new NoOpPerformanceTracker(),
-          true, // disableAllFiltering
-          signal
-        );
-        // Invalidate the cache so the unfiltered snapshot is not served to subsequent
-        // normal observe calls that expect a filtered hierarchy.
-        client.invalidateCache();
-        if (syncResult?.hierarchy) {
-          result.rawViewHierarchy = {
-            json: JSON.stringify(syncResult.hierarchy, null, 2),
-            source: "accessibility-service",
-            timestamp: this.timer.now(),
-            device: { deviceId: this.device.deviceId, platform: this.device.platform }
-          };
-        }
-      } else {
-        const xcTestClient = IOSCtrlProxyClient.getInstance(this.device);
-        const hierarchyResult = await xcTestClient.requestHierarchySync(
-          new NoOpPerformanceTracker(),
-          true, // disableAllFiltering
-          signal
-        );
-        // Invalidate the cache so the unfiltered snapshot is not served to subsequent
-        // normal observe calls that expect a filtered hierarchy.
-        xcTestClient.invalidateCache();
-        if (hierarchyResult?.hierarchy) {
-          result.rawViewHierarchy = {
-            xcuitest: JSON.stringify(hierarchyResult.hierarchy, null, 2),
-            source: "xcuitest",
-            timestamp: this.timer.now(),
-            device: { deviceId: this.device.deviceId, platform: this.device.platform }
-          };
-        }
-      }
-    } catch (error) {
-      logger.warn("[ObserveScreen] Failed to collect raw view hierarchy:", error);
-    }
-  }
+  // ---------- Public API ----------
 
   /**
    * Fetch raw view hierarchy and attach it to an existing observe result.
    * Call this after execute() when raw hierarchy data is needed.
    */
-  public async appendRawViewHierarchy(result: ObserveResult, signal?: AbortSignal): Promise<void> {
-    await this.collectRawViewHierarchyData(result, signal);
+  async appendRawViewHierarchy(result: ObserveResult, signal?: AbortSignal): Promise<void> {
+    await this.hierarchyCollector.collectRaw(result, signal);
   }
 
   /**
-   * Collect all observation data with parallelization
-   * @param result - ObserveResult to update
-   * @param queryOptions - ViewHierarchyQueryOptions to pass to viewHierarchy.getViewHierarchy
-   * @param perf - Performance tracker for timing data
-   * @param skipWaitForFresh - If true, skip WebSocket wait and go straight to sync method
-   * @param minTimestamp - If provided, cached data must have updatedAt >= this value
-   */
-  public async collectAllData(
-    result: ObserveResult,
-    queryOptions?: ViewHierarchyQueryOptions,
-    perf: PerformanceTracker = new NoOpPerformanceTracker(),
-    skipWaitForFresh: boolean = false,
-    minTimestamp: number = 0,
-    signal?: AbortSignal,
-    skipBackStack: boolean = false
-  ): Promise<void> {
-    switch (this.device.platform) {
-      case "android":
-        // Phase 1: Get view hierarchy first (includes screen info from accessibility service)
-        perf.serial("phase1_hierarchy");
-
-        // Get view hierarchy (includes all device metadata from accessibility service)
-        await this.collectViewHierarchy(result, queryOptions, perf, skipWaitForFresh, minTimestamp, signal);
-
-        perf.end();
-
-        // Use device metadata from accessibility service (no dumpsys fallback)
-        const hierarchy = result.viewHierarchy;
-        if (hierarchy?.screenWidth && hierarchy?.screenHeight) {
-          result.screenSize = { width: hierarchy.screenWidth, height: hierarchy.screenHeight };
-          if (hierarchy.rotation !== undefined) {
-            result.rotation = hierarchy.rotation;
-          }
-          if (hierarchy.systemInsets) {
-            result.systemInsets = hierarchy.systemInsets;
-          }
-          // Use wakefulness from accessibility service, fall back to ADB
-          if (hierarchy.wakefulness) {
-            result.wakefulness = hierarchy.wakefulness;
-          } else {
-            await perf.track("wakefulness", () => this.collectWakefulness(result, signal));
-          }
-          // Use foreground activity from accessibility service for activeWindow
-          if (hierarchy.foregroundActivity) {
-            const parts = hierarchy.foregroundActivity.split("/");
-            const packageName = parts[0];
-            const activityName = parts[1]?.startsWith(".")
-              ? packageName + parts[1]
-              : parts[1] || "";
-            result.activeWindow = {
-              appId: packageName,
-              activityName,
-              layoutSeqSum: 0
-            };
-          }
-          if (!skipBackStack) {
-            await perf.track("backStack", () => this.collectBackStack(result, perf, signal));
-          }
-          logger.debug("[OBSERVE] Using device metadata from accessibility service");
-        } else {
-          logger.warn("[OBSERVE] No screen info from accessibility service - check if APK is updated");
-          // Fall back to ADB for all metadata
-          const tasks: Promise<void>[] = [
-            perf.track("wakefulness", () => this.collectWakefulness(result, signal)),
-          ];
-          if (!skipBackStack) {
-            tasks.push(perf.track("backStack", () => this.collectBackStack(result, perf, signal)));
-          }
-          await Promise.all(tasks);
-        }
-
-        // Note: Offscreen filtering is now done in the Android accessibility service (Kotlin)
-        // for better performance (avoids serializing/transferring filtered data)
-
-        // Populate activeWindow from view hierarchy packageName if not already set
-        if (result.viewHierarchy?.packageName && !result.activeWindow) {
-          result.activeWindow = {
-            appId: result.viewHierarchy.packageName,
-            activityName: "",
-            layoutSeqSum: 0
-          };
-        }
-
-        // Fallback: if activeWindow still not populated, use the Window class
-        if (!result.activeWindow) {
-          await this.collectActiveWindow(result);
-        }
-
-        if (result.notificationPermissionDetected && result.activeWindow) {
-          result.activeWindow.type = "notification_permission_dialog";
-        }
-
-        break;
-
-      case "ios":
-        // iOS-specific data collection logic here
-        perf.serial("ios_collect");
-
-        // Collect view hierarchy (fast via CtrlProxy iOS WebSocket)
-        await this.collectViewHierarchy(result, queryOptions, perf, skipWaitForFresh, minTimestamp, signal);
-
-        // Extract screen size from hierarchy
-        {
-          const extractedSize = this.extractScreenSizeFromHierarchy(result.viewHierarchy);
-          if (extractedSize) {
-            result.screenSize = extractedSize;
-            logger.debug(`[iOS] Extracted screen size from hierarchy: ${extractedSize.width}x${extractedSize.height}`);
-          } else if (result.viewHierarchy?.screenWidth && result.viewHierarchy?.screenHeight) {
-            // Fallback to screenWidth/screenHeight from CtrlProxy iOS (logical points)
-            result.screenSize = {
-              width: result.viewHierarchy.screenWidth,
-              height: result.viewHierarchy.screenHeight
-            };
-            logger.debug(`[iOS] Using screen size from CtrlProxy iOS: ${result.screenSize.width}x${result.screenSize.height}`);
-          } else {
-            logger.warn("[iOS] Failed to extract screen size from hierarchy");
-          }
-        }
-
-        // Filter out completely offscreen nodes to reduce hierarchy size
-        if (result.viewHierarchy && result.screenSize?.width > 0 && result.screenSize?.height > 0) {
-          const rawHierarchy = result.viewHierarchy;
-          result.viewHierarchy = this.viewHierarchy.filterOffscreenNodes(
-            rawHierarchy,
-            result.screenSize.width,
-            result.screenSize.height
-          );
-          if (serverConfig.isRawElementSearchEnabled()) {
-            attachRawViewHierarchy(result.viewHierarchy, rawHierarchy);
-          }
-        }
-
-        // Populate activeWindow from view hierarchy packageName if not already set
-        if (result.viewHierarchy?.packageName && !result.activeWindow) {
-          result.activeWindow = {
-            appId: result.viewHierarchy.packageName,
-            activityName: "",
-            layoutSeqSum: 0
-          };
-        }
-
-        perf.end();
-        break;
-    }
-  }
-
-  /**
-   * Capture a screenshot for the latest observation.
-   */
-  private async captureObservationScreenshot(
-    perf: PerformanceTracker = new NoOpPerformanceTracker(),
-    signal?: AbortSignal
-  ): Promise<void> {
-    try {
-      await perf.track("screenshot", async () => {
-        const { promise } = this.screenshotUtil.startTrackedCapture(
-          { format: "png" },
-          {
-            parentSignal: signal,
-            onComplete: async completion => {
-              if (!completion.isLatest) {
-                return;
-              }
-              if (completion.aborted) {
-                logger.debug("[OBSERVE] Screenshot capture cancelled");
-                return;
-              }
-              try {
-                await this.handleScreenshotResult(completion.result, { ignoreCancel: true });
-              } catch (err) {
-                logger.warn(`[OBSERVE] Failed to finalize screenshot capture: ${err}`);
-              }
-            }
-          }
-        );
-        await promise;
-      });
-    } catch (error) {
-      const errorMessage = error instanceof Error ? error.message : String(error);
-      if (errorMessage.includes(OPERATION_CANCELLED_MESSAGE)) {
-        logger.debug("[OBSERVE] Screenshot capture cancelled");
-        return;
-      }
-      RealObserveScreen.updateLatestScreenshotCache(this.device.deviceId, undefined, errorMessage);
-      logger.warn(`[OBSERVE] Screenshot capture failed: ${errorMessage}`);
-    }
-  }
-
-  private startObservationScreenshot(
-    perf: PerformanceTracker = new NoOpPerformanceTracker(),
-    signal?: AbortSignal
-  ): void {
-    perf.startOperation("screenshot");
-    const { promise } = this.screenshotUtil.startTrackedCapture(
-      { format: "png" },
-      {
-        parentSignal: signal,
-        onComplete: async completion => {
-          if (!completion.isLatest) {
-            return;
-          }
-          if (completion.aborted) {
-            logger.debug("[OBSERVE] Screenshot capture cancelled");
-            return;
-          }
-          try {
-            await this.handleScreenshotResult(completion.result, { ignoreCancel: true });
-          } catch (err) {
-            logger.warn(`[OBSERVE] Failed to finalize screenshot capture: ${err}`);
-          }
-        }
-      }
-    );
-
-    promise.finally(() => {
-      perf.endOperation("screenshot");
-    });
-  }
-
-  /**
-   * Extract screen size from view hierarchy root node bounds.
-   * Supports both Android format ("[left,top][right,bottom]") and iOS format ({left, top, right, bottom}).
-   * @param viewHierarchy - View hierarchy result
-   * @returns Screen size or null if unable to extract
-   */
-  private extractScreenSizeFromHierarchy(viewHierarchy: ObserveResult["viewHierarchy"]): { width: number; height: number } | null {
-    // Android format: hierarchy.node.$.bounds = "[0,0][402,874]"
-    const rootNode = viewHierarchy?.hierarchy?.node;
-    if (rootNode?.$?.bounds) {
-      const boundsStr = rootNode.$.bounds;
-      const match = boundsStr.match(/\[(-?\d+),(-?\d+)\]\[(-?\d+),(-?\d+)\]/);
-      if (match) {
-        const width = parseInt(match[3], 10) - parseInt(match[1], 10);
-        const height = parseInt(match[4], 10) - parseInt(match[2], 10);
-        if (width > 0 && height > 0) {
-          return { width, height };
-        }
-      }
-    }
-
-    // iOS format: hierarchy is the root XCTestNode with bounds as {left, top, right, bottom}
-    const iosHierarchy = viewHierarchy?.hierarchy;
-    if (iosHierarchy?.bounds && typeof iosHierarchy.bounds === "object" && !Array.isArray(iosHierarchy.bounds)) {
-      const { left, top, right, bottom } = iosHierarchy.bounds;
-      if (typeof right === "number" && typeof bottom === "number") {
-        const width = right - (left ?? 0);
-        const height = bottom - (top ?? 0);
-        if (width > 0 && height > 0) {
-          return { width, height };
-        }
-      }
-    }
-
-    return null;
-  }
-
-  /**
-   * Append error message to result
-   * @param result - ObserveResult to update
-   * @param newError - Error message to append
-   */
-  appendError(result: ObserveResult, newError: string): void {
-    if (result.error) {
-      result.error += `; ${newError}`;
-    } else {
-      result.error = newError;
-    }
-  }
-
-  /**
-   * Create base observe result object
-   * @returns Base ObserveResult with updatedAt and default values
-   */
-  createBaseResult(): ObserveResult {
-    return {
-      updatedAt: new Date().toISOString(),
-      screenSize: { width: 0, height: 0 },
-      systemInsets: { top: 0, right: 0, bottom: 0, left: 0 }
-    };
-  }
-
-  /**
-   * Resolve observation timestamp in milliseconds (device time if available).
-   */
-  private resolveObservationTimestampMs(result: ObserveResult): number | undefined {
-    const candidate = result.viewHierarchy?.updatedAt ?? result.updatedAt;
-    if (typeof candidate === "number" && !Number.isNaN(candidate)) {
-      return candidate;
-    }
-    if (typeof candidate === "string") {
-      const parsed = Date.parse(candidate);
-      if (!Number.isNaN(parsed)) {
-        return parsed;
-      }
-    }
-    return undefined;
-  }
-
-  /**
-   * Get the most recent cached observe result from memory or disk cache
-   * @returns Promise<ObserveResult> - The most recent cached observe result
+   * Get the most recent cached observe result from memory or disk cache.
    */
   async getMostRecentCachedObserveResult(): Promise<ObserveResult> {
     const startTime = this.timer.now();
-
     try {
       logger.debug("[OBSERVE_CACHE] Getting most recent cached observe result");
-
-      // Check in-memory cache first
-      const memoryResult = await this.checkInMemoryObserveCache();
-      if (memoryResult) {
-        const duration = this.timer.now() - startTime;
-        logger.debug(`[OBSERVE_CACHE] Found recent result in memory cache (${duration}ms)`);
-        return memoryResult;
-      }
-
-      // Check disk cache
-      const diskResult = await this.checkDiskObserveCache();
-      if (diskResult) {
-        const duration = this.timer.now() - startTime;
-        logger.debug(`[OBSERVE_CACHE] Found recent result in disk cache (${duration}ms)`);
-        return diskResult;
-      }
-
-      // No cached result available
+      const cached = await getObserveCacheStore().getMostRecent(this.device.deviceId);
       const duration = this.timer.now() - startTime;
+      if (cached) {
+        logger.debug(`[OBSERVE_CACHE] Found recent result in cache (${duration}ms)`);
+        return cached;
+      }
       logger.debug(`[OBSERVE_CACHE] No cached observe result available (${duration}ms)`);
-
       return {
         updatedAt: new Date().toISOString(),
         screenSize: { width: 0, height: 0 },
@@ -900,7 +217,6 @@ export class RealObserveScreen implements ObserveScreen {
     } catch (error) {
       const duration = this.timer.now() - startTime;
       logger.warn(`[OBSERVE_CACHE] Error getting cached observe result after ${duration}ms: ${error}`);
-
       return {
         updatedAt: new Date().toISOString(),
         screenSize: { width: 0, height: 0 },
@@ -911,438 +227,7 @@ export class RealObserveScreen implements ObserveScreen {
   }
 
   /**
-   * Check in-memory cache for most recent observe result
-   * @returns Promise<ObserveResult | null> - Most recent cached result or null
-   */
-  private async checkInMemoryObserveCache(): Promise<ObserveResult | null> {
-    const cacheSize = RealObserveScreen.observeResultCache.size;
-    const deviceId = this.device.deviceId;
-    logger.debug(`[OBSERVE_CACHE] Checking in-memory cache for device ${deviceId}, size: ${cacheSize}`);
-
-    if (cacheSize === 0) {
-      logger.debug("[OBSERVE_CACHE] In-memory cache is empty");
-      return null;
-    }
-
-    const now = this.timer.now();
-    const ttl = RealObserveScreen.OBSERVE_RESULT_CACHE_TTL_MS;
-
-    // Remove expired entries and find most recent for this device
-    const expiredKeys: string[] = [];
-    let mostRecentEntry: ObserveResultCache | null = null;
-
-    for (const [key, cachedEntry] of RealObserveScreen.observeResultCache.entries()) {
-      const age = now - cachedEntry.timestamp;
-
-      if (age >= ttl) {
-        expiredKeys.push(key);
-        logger.debug(`[OBSERVE_CACHE] Removing expired cache entry: ${key} (age: ${age}ms > TTL: ${ttl}ms)`);
-      } else if (cachedEntry.deviceId === deviceId) {
-        // Only consider entries for this device
-        if (!mostRecentEntry || cachedEntry.timestamp > mostRecentEntry.timestamp) {
-          mostRecentEntry = cachedEntry;
-        }
-      }
-    }
-
-    // Remove expired entries
-    for (const key of expiredKeys) {
-      RealObserveScreen.observeResultCache.delete(key);
-    }
-
-    if (mostRecentEntry) {
-      const age = now - mostRecentEntry.timestamp;
-      logger.debug(`[OBSERVE_CACHE] Found most recent in-memory result for device ${deviceId} (age: ${age}ms)`);
-      return mostRecentEntry.observeResult;
-    }
-
-    logger.debug(`[OBSERVE_CACHE] No valid entries in in-memory cache for device ${deviceId}`);
-    return null;
-  }
-
-  /**
-   * Check disk cache for most recent observe result
-   * @returns Promise<ObserveResult | null> - Most recent cached result or null
-   */
-  private async checkDiskObserveCache(): Promise<ObserveResult | null> {
-    logger.debug("[OBSERVE_CACHE] Checking disk cache");
-
-    try {
-      // Get JSON files in the cache directory for this device
-      const deviceId = this.device.deviceId;
-      const devicePrefix = `observe_${deviceId.replace(/:/g, "_")}_`;
-      const files = await readdirAsync(RealObserveScreen.observeResultCacheDir);
-      const jsonFiles = files.filter(file => file.endsWith(".json") && file.startsWith(devicePrefix));
-
-      if (jsonFiles.length === 0) {
-        logger.debug("[OBSERVE_CACHE] No observe result files found in disk cache");
-        return null;
-      }
-
-      const now = this.timer.now();
-      const ttl = RealObserveScreen.OBSERVE_RESULT_CACHE_TTL_MS;
-      let mostRecentFile: { path: string, mtime: number } | null = null;
-
-      // Find the most recent valid file
-      for (const file of jsonFiles) {
-        const filePath = path.join(RealObserveScreen.observeResultCacheDir, file);
-        const stats = await statAsync(filePath);
-        const age = now - stats.mtime.getTime();
-
-        if (age < ttl) {
-          if (!mostRecentFile || stats.mtime.getTime() > mostRecentFile.mtime) {
-            mostRecentFile = { path: filePath, mtime: stats.mtime.getTime() };
-          }
-        } else {
-          // TODO: Remove old file
-          logger.debug(`[OBSERVE_CACHE] Disk cache file expired: ${file} (age: ${age}ms > TTL: ${ttl}ms)`);
-        }
-      }
-
-      if (mostRecentFile) {
-        const age = now - mostRecentFile.mtime;
-        logger.debug(`[OBSERVE_CACHE] Loading most recent disk cache file (age: ${age}ms)`);
-
-        const cacheData = await readFileAsync(mostRecentFile.path, "utf8");
-        const cachedResult: ObserveResult = JSON.parse(cacheData);
-
-        // Also update the in-memory cache
-        const deviceId = this.device.deviceId;
-        const cacheKey = `${deviceId}:${mostRecentFile.mtime}`;
-        RealObserveScreen.observeResultCache.set(cacheKey, {
-          timestamp: mostRecentFile.mtime,
-          deviceId,
-          observeResult: cachedResult,
-        });
-
-        logger.debug(`[OBSERVE_CACHE] Updated in-memory cache from disk cache`);
-        return cachedResult;
-      }
-
-      logger.debug("[OBSERVE_CACHE] No valid files in disk cache");
-      return null;
-    } catch (error) {
-      logger.warn(`[OBSERVE_CACHE] Error checking disk cache: ${error}`);
-      return null;
-    }
-  }
-
-  /**
-   * Cache observe result in memory and disk
-   * @param observeResult - The observe result to cache
-   */
-  async cacheObserveResult(observeResult: ObserveResult): Promise<void> {
-    const timestamp = this.timer.now();
-    const deviceId = this.device.deviceId;
-    const cacheKey = `${deviceId}:${timestamp}`;
-
-    try {
-      logger.debug(`[OBSERVE_CACHE] Caching observe result for device ${deviceId} with timestamp ${timestamp}`);
-
-      // Cache in memory
-      RealObserveScreen.observeResultCache.set(cacheKey, {
-        timestamp,
-        deviceId,
-        observeResult,
-      });
-
-      // Cache on disk
-      await this.saveObserveResultToDisk(cacheKey, observeResult);
-
-      logger.debug(`[OBSERVE_CACHE] Successfully cached observe result, in-memory cache size: ${RealObserveScreen.observeResultCache.size}`);
-    } catch (error) {
-      logger.warn(`[OBSERVE_CACHE] Error caching observe result: ${error}`);
-    }
-  }
-
-  /**
-   * Save observe result to disk cache
-   * @param cacheKey - Cache key (deviceId:timestamp) for filename
-   * @param observeResult - The observe result to save
-   */
-  private async saveObserveResultToDisk(cacheKey: string, observeResult: ObserveResult): Promise<void> {
-    try {
-      // Replace colons with underscores for filesystem safety
-      const filename = `observe_${cacheKey.replace(/:/g, "_")}.json`;
-      const filePath = path.join(RealObserveScreen.observeResultCacheDir, filename);
-
-      await writeFileAsync(filePath, JSON.stringify(observeResult, null, 2));
-      logger.debug(`[OBSERVE_CACHE] Saved observe result to disk: ${filename}`);
-    } catch (error) {
-      logger.warn(`[OBSERVE_CACHE] Failed to save observe result to disk: ${error}`);
-    }
-  }
-
-  /**
-   * Run performance audit if enabled
-   * Checks --ui-perf-mode CLI flag to enable/disable
-   * @param result - ObserveResult to attach audit results to
-   * @param perf - Performance tracker
-   */
-  private async runPerformanceAudit(
-    result: ObserveResult,
-    perf: PerformanceTracker
-  ): Promise<void> {
-    // Check if performance audit is enabled via CLI flag
-    // This will be replaced with global configuration in issue #67
-    const auditEnabled = serverConfig.isUiPerfModeEnabled();
-
-    if (!auditEnabled) {
-      return;
-    }
-
-    // Only run on Android for now
-    if (this.device.platform !== "android") {
-      logger.debug("[PerformanceAudit] Skipping audit, only Android is supported");
-      return;
-    }
-
-    // Need an active window with app ID
-    if (!result.activeWindow?.appId) {
-      logger.debug("[PerformanceAudit] Skipping audit, no active app");
-      return;
-    }
-
-    try {
-      await perf.track("performanceAudit", async () => {
-        logger.info(`[PerformanceAudit] Running UI performance audit for ${result.activeWindow?.appId}`);
-
-        // Initialize components
-        const capabilitiesDetector = new DeviceCapabilitiesDetector(this.device, this.adb);
-        const thresholdManager = new ThresholdManager();
-        const performanceAudit = new PerformanceAudit(this.device, this.adb);
-
-        // Get device capabilities
-        const capabilities = await capabilitiesDetector.getCapabilities();
-
-        // Get or create thresholds
-        const thresholds = await thresholdManager.getOrCreateThresholds(
-          this.device.deviceId,
-          capabilities
-        );
-
-        // Run the audit
-        const auditResult = await performanceAudit.runAudit(
-          result.activeWindow!.appId,
-          thresholds,
-          result.screenSize,
-          perf
-        );
-
-        // Attach audit result to observe result
-        result.performanceAudit = auditResult;
-
-        // Update threshold weight based on result
-        const sessionId = new Date().toISOString().split("T")[0];
-        await thresholdManager.updateThresholdWeight(
-          this.device.deviceId,
-          sessionId,
-          auditResult.passed
-        );
-
-        if (!auditResult.passed) {
-          logger.warn(
-            `[PerformanceAudit] Performance audit FAILED with ${auditResult.violations.length} violations`
-          );
-        } else {
-          logger.info("[PerformanceAudit] Performance audit PASSED");
-        }
-
-        // Start continuous performance monitoring for this device/package
-        const { getPerformanceMonitor } = await import("../performance/PerformanceMonitor");
-        getPerformanceMonitor().startMonitoring(this.device.deviceId, result.activeWindow!.appId, this.device.platform);
-      });
-    } catch (error) {
-      logger.error(`[PerformanceAudit] Failed to run performance audit: ${error}`);
-      // Don't fail the entire observation if audit fails
-    }
-  }
-
-  /**
-   * Run accessibility audit if enabled
-   * Checks --accessibility-audit CLI flag to enable/disable
-   * @param result - ObserveResult to attach audit results to
-   * @param perf - Performance tracker
-   */
-  private async runAccessibilityAudit(
-    result: ObserveResult,
-    perf: PerformanceTracker
-  ): Promise<void> {
-    // Check if accessibility audit is enabled via CLI flag
-    const auditConfig = serverConfig.getAccessibilityAuditConfig();
-
-    if (!auditConfig) {
-      return;
-    }
-
-    // Only run on Android for now
-    if (this.device.platform !== "android") {
-      logger.debug("[AccessibilityAudit] Skipping audit, only Android is supported");
-      return;
-    }
-
-    // Need view hierarchy
-    if (!result.viewHierarchy?.hierarchy) {
-      logger.debug("[AccessibilityAudit] Skipping audit, no view hierarchy available");
-      return;
-    }
-
-    // Need active window for screen ID
-    if (!result.activeWindow?.appId) {
-      logger.debug("[AccessibilityAudit] Skipping audit, no active app");
-      return;
-    }
-
-    try {
-      await perf.track("accessibilityAudit", async () => {
-        logger.info(`[AccessibilityAudit] Running WCAG ${auditConfig.level} audit for ${result.activeWindow?.appId}`);
-
-        // Initialize audit
-        const wcagAudit = new WcagAudit();
-
-        // Extract elements directly from view hierarchy for audit
-        const elementParser = new DefaultElementParser();
-        const allElements: Element[] = elementParser.flattenViewHierarchy(result.viewHierarchy!)
-          .map(entry => entry.element);
-
-        // Get screenshot path if available (from TakeScreenshot cache)
-        const screenshotPath = await this.getLatestScreenshotPath();
-
-        // Run the audit
-        const auditResult = await wcagAudit.audit(
-          allElements,
-          result.viewHierarchy!.hierarchy,
-          screenshotPath,
-          result.activeWindow!.appId,
-          auditConfig
-        );
-
-        // Attach audit result to observe result
-        result.accessibilityAudit = auditResult;
-
-        if (!auditResult.summary.passed) {
-          logger.warn(
-            `[AccessibilityAudit] Accessibility audit FAILED with ${auditResult.violations.length} violations (${auditResult.summary.bySeverity.error} errors, ${auditResult.summary.bySeverity.warning} warnings)`
-          );
-        } else {
-          logger.info("[AccessibilityAudit] Accessibility audit PASSED");
-        }
-      });
-    } catch (error) {
-      logger.error(`[AccessibilityAudit] Failed to run accessibility audit: ${error}`);
-      // Don't fail the entire observation if audit fails
-    }
-  }
-
-  /**
-   * Detect accessibility state (TalkBack/VoiceOver) and attach to result
-   * @param result - ObserveResult to attach accessibility state to
-   * @param perf - Performance tracker
-   * @param signal - Abort signal
-   */
-  private async detectAccessibilityState(
-    result: ObserveResult,
-    perf: PerformanceTracker,
-    signal?: AbortSignal
-  ): Promise<void> {
-    try {
-      await perf.track("accessibilityDetection", async () => {
-        throwIfAborted(signal);
-
-        // Get feature flag service instance
-        const featureFlags = FeatureFlagService.getInstance();
-
-        if (this.device.platform === "android") {
-          // Detect TalkBack state via ADB
-          const enabled = await accessibilityDetector.isAccessibilityEnabled(
-            this.device.deviceId,
-            this.adb,
-            featureFlags
-          );
-
-          const service = await accessibilityDetector.detectMethod(
-            this.device.deviceId,
-            this.adb,
-            featureFlags
-          );
-
-          result.accessibilityState = { enabled, service };
-          logger.debug(
-            `[AccessibilityDetector] Android accessibility state: enabled=${enabled}, service=${service}`
-          );
-        } else if (this.device.platform === "ios") {
-          // Detect VoiceOver state via CtrlProxy WebSocket
-          const client = IOSCtrlProxyClient.getInstance(this.device);
-          const enabled = await iosVoiceOverDetector.isVoiceOverEnabled(
-            this.device.deviceId,
-            client,
-            featureFlags
-          );
-
-          result.accessibilityState = {
-            enabled,
-            service: enabled ? "voiceover" : "unknown",
-          };
-          logger.debug(`[IosVoiceOverDetector] iOS VoiceOver state: enabled=${enabled}`);
-        }
-      });
-    } catch (error) {
-      logger.error(`[detectAccessibilityState] Failed to detect accessibility state: ${error}`);
-      // Don't fail the entire observation if detection fails
-      // Result will simply not include accessibilityState field
-    }
-  }
-
-  /**
-   * Get the latest screenshot path from cache
-   */
-  private async getLatestScreenshotPath(): Promise<string | undefined> {
-    try {
-      const cachedPath = RealObserveScreen.getRecentCachedScreenshotPathForDevice(this.device.deviceId);
-      if (cachedPath) {
-        const exists = await pathExists(cachedPath);
-        if (exists) {
-          return cachedPath;
-        }
-      }
-
-      const cacheDir = getTempDir(TEMP_SUBDIRS.SCREENSHOTS);
-      if (!existsSync(cacheDir)) {
-        return undefined;
-      }
-
-      const files = await readdirAsync(cacheDir);
-      const imageFiles = files.filter(f => f.endsWith(".png") || f.endsWith(".webp"));
-
-      if (imageFiles.length === 0) {
-        return undefined;
-      }
-
-      // Sort by modification time (most recent first)
-      const fileStats = await Promise.all(
-        imageFiles.map(async f => {
-          const fullPath = path.join(cacheDir, f);
-          const stat = await statAsync(fullPath);
-          return { path: fullPath, mtime: stat.mtime };
-        })
-      );
-
-      fileStats.sort((a, b) => b.mtime.getTime() - a.mtime.getTime());
-
-      return fileStats[0]?.path;
-    } catch (error) {
-      logger.warn(`[AccessibilityAudit] Failed to get latest screenshot: ${error}`);
-      return undefined;
-    }
-  }
-
-  /**
-   * Execute the observe command
-   * @param queryOptions - ViewHierarchyQueryOptions to pass to viewHierarchy.getViewHierarchy
-   * @param perf - Performance tracker for timing data
-   * @param skipWaitForFresh - If true, skip WebSocket wait and go straight to sync method (default: true for direct observe calls)
-   * @param minTimestamp - If provided, cached data must have updatedAt >= this value (used after actions to ensure fresh data)
-   * @returns The observation result
+   * Execute the observe command.
    */
   async execute(options?: ObserveScreenExecuteOptions): Promise<ObserveResult> {
     const queryOptions = options?.queryOptions;
@@ -1352,41 +237,38 @@ export class RealObserveScreen implements ObserveScreen {
     const signal = options?.signal;
     const skipBackStack = options?.skipBackStack ?? false;
     const skipScreenshot = options?.skipScreenshot ?? false;
+
     try {
       logger.debug(`Executing observe command (skipWaitForFresh=${skipWaitForFresh}, minTimestamp=${minTimestamp})`);
       const startTime = this.timer.now();
       throwIfAborted(signal);
 
-      // Create base result object with timestamp
       const result = this.createBaseResult();
 
-      // Wrap entire observation in serial tracking
       perf.serial("observe");
 
-      // Collect all data components with parallelization
-      // Note: collectAllData tracks its phases internally, so we just call it directly
+      // Phase 1+2: hierarchy + derived device state (platform-specific orchestration).
       await this.collectAllData(result, queryOptions, perf, skipWaitForFresh, minTimestamp, signal, skipBackStack);
 
+      // Screenshot: fire-and-forget unless an accessibility audit is configured
+      // (the audit needs the screenshot file on disk before it runs).
       if (!skipScreenshot) {
         if (serverConfig.getAccessibilityAuditConfig()) {
-          await this.captureObservationScreenshot(perf, signal);
+          await this.screenshotRecorder.capture(perf, signal);
         } else {
-          this.startObservationScreenshot(perf, signal);
+          this.screenshotRecorder.start(perf, signal);
         }
       }
 
       // Attach recomposition metrics if enabled
       await RecompositionTracker.getInstance().processObservation(result, this.device);
 
-      // Run performance audit if enabled
-      await this.runPerformanceAudit(result, perf);
+      // Audits + accessibility state detection (each is config-gated; failures don't propagate)
+      await this.performanceAuditor.run(result, perf);
+      await this.accessibilityAuditor.run(result, perf);
+      await this.accessibilityStateDetector.run(result, perf, signal);
 
-      // Run accessibility audit if enabled
-      await this.runAccessibilityAudit(result, perf);
-
-      // Detect accessibility state (TalkBack/VoiceOver)
-      await this.detectAccessibilityState(result, perf, signal);
-
+      // Predictive UI (opt-in via config)
       if (serverConfig.isPredictiveUiEnabled()) {
         try {
           const predictions = await this.predictiveUIState.generate(result);
@@ -1399,10 +281,11 @@ export class RealObserveScreen implements ObserveScreen {
       }
 
       // Cache the result for future use
-      await perf.track("cacheResult", () => this.cacheObserveResult(result));
+      await perf.track("cacheResult", () => getObserveCacheStore().put(this.device.deviceId, result));
 
       perf.end();
 
+      // Freshness diagnostics
       const requestedAfter = minTimestamp > 0 ? minTimestamp : undefined;
       const actualTimestamp = this.resolveObservationTimestampMs(result);
       const isFresh = requestedAfter === undefined
@@ -1411,12 +294,7 @@ export class RealObserveScreen implements ObserveScreen {
       const staleDurationMs = requestedAfter !== undefined && actualTimestamp !== undefined && actualTimestamp < requestedAfter
         ? requestedAfter - actualTimestamp
         : undefined;
-      result.freshness = {
-        requestedAfter,
-        actualTimestamp,
-        isFresh,
-        staleDurationMs
-      };
+      result.freshness = { requestedAfter, actualTimestamp, isFresh, staleDurationMs };
 
       // Attach performance timing if enabled (with filtering and truncation)
       const timings = perf.getTimings();
@@ -1435,13 +313,203 @@ export class RealObserveScreen implements ObserveScreen {
       const errorMessage = err instanceof Error ? (err.stack || err.message) : String(err);
       logger.error(`Critical error in observe command: ${errorMessage}`);
       ScreenshotJobTracker.cancelJob(this.device.deviceId);
-      RealObserveScreen.updateLatestScreenshotCache(this.device.deviceId, undefined, `Observation failed: ${errorMessage}`);
-      return {
+      getScreenshotStateStore().update(this.device.deviceId, undefined, `Observation failed: ${errorMessage}`);
+      const fallback: ObserveResult = {
         updatedAt: new Date().toISOString(),
         screenSize: { width: 0, height: 0 },
         systemInsets: { top: 0, right: 0, bottom: 0, left: 0 },
-        error: "Observation failed due to device access error"
       };
+      appendObserveError(fallback, {
+        phase: "critical",
+        message: "Observation failed due to device access error",
+        cause: errorMessage
+      });
+      return fallback;
     }
+  }
+
+  // ---------- Public collector wrappers (kept for back-compat with existing tests) ----------
+
+  /**
+   * Back-compat shim: prefer `appendObserveError(result, { phase, message, cause })`.
+   * This wrapper records errors with phase "critical" so they land in `result.errors`
+   * as well as the derived `result.error` string.
+   */
+  appendError(result: ObserveResult, newError: string): void {
+    appendObserveError(result, { phase: "critical", message: newError });
+  }
+
+  /**
+   * Back-compat shim around {@link HierarchyCollector.extractScreenSize}.
+   */
+  extractScreenSizeFromHierarchy(viewHierarchy: ObserveResult["viewHierarchy"]): { width: number; height: number } | null {
+    return this.hierarchyCollector.extractScreenSize(viewHierarchy);
+  }
+
+  createBaseResult(): ObserveResult {
+    return {
+      updatedAt: new Date().toISOString(),
+      screenSize: { width: 0, height: 0 },
+      systemInsets: { top: 0, right: 0, bottom: 0, left: 0 }
+    };
+  }
+
+  /**
+   * Cache an observe result. Public for back-compat with tests.
+   */
+  async cacheObserveResult(observeResult: ObserveResult): Promise<void> {
+    await getObserveCacheStore().put(this.device.deviceId, observeResult);
+  }
+
+  // ---------- Orchestration ----------
+
+  /**
+   * Collect all observation data with platform-specific orchestration.
+   *
+   * Public + parameterized for back-compat with existing tests and for callers
+   * that need to assemble an `ObserveResult` without the full `execute()` pipeline.
+   */
+  async collectAllData(
+    result: ObserveResult,
+    queryOptions?: import("../../models/ViewHierarchyQueryOptions").ViewHierarchyQueryOptions,
+    perf: PerformanceTracker = new NoOpPerformanceTracker(),
+    skipWaitForFresh: boolean = false,
+    minTimestamp: number = 0,
+    signal?: AbortSignal,
+    skipBackStack: boolean = false
+  ): Promise<void> {
+    switch (this.device.platform) {
+      case "android":
+        perf.serial("phase1_hierarchy");
+        await this.hierarchyCollector.collect(result, queryOptions, perf, skipWaitForFresh, minTimestamp, signal);
+        perf.end();
+
+        // Prefer accessibility-service-supplied metadata for screen/insets/rotation/wakefulness/foreground.
+        const hierarchy = result.viewHierarchy;
+        if (hierarchy?.screenWidth && hierarchy?.screenHeight) {
+          result.screenSize = { width: hierarchy.screenWidth, height: hierarchy.screenHeight };
+          if (hierarchy.rotation !== undefined) {
+            result.rotation = hierarchy.rotation;
+          }
+          if (hierarchy.systemInsets) {
+            result.systemInsets = hierarchy.systemInsets;
+          }
+          if (hierarchy.foregroundActivity) {
+            const parts = hierarchy.foregroundActivity.split("/");
+            const packageName = parts[0];
+            const activityName = parts[1]?.startsWith(".")
+              ? packageName + parts[1]
+              : parts[1] || "";
+            result.activeWindow = {
+              appId: packageName,
+              activityName,
+              layoutSeqSum: 0
+            };
+          }
+          const parallelTasks: Promise<void>[] = [];
+          if (hierarchy.wakefulness) {
+            result.wakefulness = hierarchy.wakefulness;
+          } else {
+            parallelTasks.push(perf.track("wakefulness", () => this.deviceStateCollector.collectWakefulness(result, signal)));
+          }
+          if (!skipBackStack) {
+            parallelTasks.push(perf.track("backStack", () => this.deviceStateCollector.collectBackStack(result, perf, signal)));
+          }
+          if (parallelTasks.length > 0) {
+            await Promise.all(parallelTasks);
+          }
+          logger.debug("[OBSERVE] Using device metadata from accessibility service");
+        } else {
+          logger.warn("[OBSERVE] No screen info from accessibility service - check if APK is updated");
+          const tasks: Promise<void>[] = [
+            perf.track("wakefulness", () => this.deviceStateCollector.collectWakefulness(result, signal)),
+          ];
+          if (!skipBackStack) {
+            tasks.push(perf.track("backStack", () => this.deviceStateCollector.collectBackStack(result, perf, signal)));
+          }
+          await Promise.all(tasks);
+        }
+
+        // Populate activeWindow from view hierarchy packageName if not already set.
+        if (result.viewHierarchy?.packageName && !result.activeWindow) {
+          result.activeWindow = {
+            appId: result.viewHierarchy.packageName,
+            activityName: "",
+            layoutSeqSum: 0
+          };
+        }
+
+        // Fallback: if activeWindow still not populated, use the Window class.
+        if (!result.activeWindow) {
+          await this.deviceStateCollector.collectActiveWindow(result);
+        }
+
+        if (result.notificationPermissionDetected && result.activeWindow) {
+          result.activeWindow.type = "notification_permission_dialog";
+        }
+
+        break;
+
+      case "ios":
+        perf.serial("ios_collect");
+        await this.hierarchyCollector.collect(result, queryOptions, perf, skipWaitForFresh, minTimestamp, signal);
+
+        // Resolve screen size: hierarchy-derived bounds, then CtrlProxy-reported logical points.
+        const extractedSize = this.hierarchyCollector.extractScreenSize(result.viewHierarchy);
+        if (extractedSize) {
+          result.screenSize = extractedSize;
+          logger.debug(`[iOS] Extracted screen size from hierarchy: ${extractedSize.width}x${extractedSize.height}`);
+        } else if (result.viewHierarchy?.screenWidth && result.viewHierarchy?.screenHeight) {
+          result.screenSize = {
+            width: result.viewHierarchy.screenWidth,
+            height: result.viewHierarchy.screenHeight
+          };
+          logger.debug(`[iOS] Using screen size from CtrlProxy iOS: ${result.screenSize.width}x${result.screenSize.height}`);
+        } else {
+          logger.warn("[iOS] Failed to extract screen size from hierarchy");
+        }
+
+        // Filter offscreen nodes to keep payload small. Original hierarchy stays
+        // attached for raw element search when enabled.
+        if (result.viewHierarchy && result.screenSize?.width > 0 && result.screenSize?.height > 0) {
+          const rawHierarchy = result.viewHierarchy;
+          result.viewHierarchy = this.viewHierarchy.filterOffscreenNodes(
+            rawHierarchy,
+            result.screenSize.width,
+            result.screenSize.height
+          );
+          if (serverConfig.isRawElementSearchEnabled()) {
+            attachRawViewHierarchy(result.viewHierarchy, rawHierarchy);
+          }
+        }
+
+        // Populate activeWindow from view hierarchy packageName if not already set.
+        if (result.viewHierarchy?.packageName && !result.activeWindow) {
+          result.activeWindow = {
+            appId: result.viewHierarchy.packageName,
+            activityName: "",
+            layoutSeqSum: 0
+          };
+        }
+
+        perf.end();
+        break;
+    }
+  }
+
+  // ---------- Helpers ----------
+
+  private resolveObservationTimestampMs(result: ObserveResult): number | undefined {
+    const candidate = result.viewHierarchy?.updatedAt ?? result.updatedAt;
+    if (typeof candidate === "number" && !Number.isNaN(candidate)) {
+      return candidate;
+    }
+    if (typeof candidate === "string") {
+      const parsed = Date.parse(candidate);
+      if (!Number.isNaN(parsed)) {
+        return parsed;
+      }
+    }
+    return undefined;
   }
 }

--- a/src/features/observe/ObserveScreenDependencies.ts
+++ b/src/features/observe/ObserveScreenDependencies.ts
@@ -6,12 +6,21 @@ import type { Window } from "./interfaces/Window";
 import type { DumpsysWindow } from "./interfaces/DumpsysWindow";
 import type { BackStack } from "./interfaces/BackStack";
 import type { PredictiveUIState } from "./interfaces/PredictiveUIState";
+import type { ObserveResultCacheStore } from "./cache/ObserveResultCacheStore";
+import type { ScreenshotStateStore } from "./screenshot/ScreenshotStateRegistry";
+import type { ObserveScreenshotRecorder } from "./screenshot/ObserveScreenshotRecorder";
+import type { HierarchyCollector } from "./collectors/HierarchyCollector";
+import type { DeviceStateCollector } from "./collectors/DeviceStateCollector";
+import type { PerformanceAuditor } from "./audits/PerformanceAuditor";
+import type { AccessibilityAuditor } from "./audits/AccessibilityAuditor";
+import type { AccessibilityStateDetector } from "./audits/AccessibilityStateDetector";
 
 /**
  * Dependencies for ObserveScreen that can be injected for testing.
  * All properties are optional - defaults will be created if not provided.
  */
 export interface ObserveScreenDependencies {
+  // Data sources
   screenSize?: ScreenSize;
   systemInsets?: SystemInsets;
   viewHierarchy?: ViewHierarchy;
@@ -20,4 +29,17 @@ export interface ObserveScreenDependencies {
   dumpsysWindow?: DumpsysWindow;
   backStack?: BackStack;
   predictiveUIState?: PredictiveUIState;
+
+  // Cache + screenshot state — process-wide singletons used by server resource handlers.
+  // Tests can swap these to isolate state across cases.
+  cacheStore?: ObserveResultCacheStore;
+  screenshotStateStore?: ScreenshotStateStore;
+
+  // Composed services. If omitted, defaults are built from the data sources above.
+  screenshotRecorder?: ObserveScreenshotRecorder;
+  hierarchyCollector?: HierarchyCollector;
+  deviceStateCollector?: DeviceStateCollector;
+  performanceAuditor?: PerformanceAuditor;
+  accessibilityAuditor?: AccessibilityAuditor;
+  accessibilityStateDetector?: AccessibilityStateDetector;
 }

--- a/src/features/observe/audits/AccessibilityAuditor.ts
+++ b/src/features/observe/audits/AccessibilityAuditor.ts
@@ -1,0 +1,154 @@
+import { logger } from "../../../utils/logger";
+import { serverConfig } from "../../../utils/ServerConfig";
+import { pathExists } from "../../../utils/filesystem/DefaultFileSystem";
+import { statAsync } from "../../../utils/io";
+import { getTempDir, TEMP_SUBDIRS } from "../../../utils/tempDir";
+import { ScreenshotCache } from "../../../utils/screenshot/ScreenshotCache";
+import { WcagAudit } from "../../accessibility/WcagAudit";
+import { DefaultElementParser } from "../../utility/ElementParser";
+import type { BootedDevice, ObserveResult } from "../../../models";
+import type { Element } from "../../../models/Element";
+import type { PerformanceTracker } from "../../../utils/PerformanceTracker";
+import type { AccessibilityAuditConfig } from "../../../models/AccessibilityAudit";
+
+export interface AccessibilityAuditorOptions {
+  device: BootedDevice;
+  /** Resolves the latest screenshot path for visual checks */
+  screenshotPathResolver?: () => Promise<string | undefined>;
+  /** Allow tests to stub the config gate */
+  getConfig?: () => AccessibilityAuditConfig | null;
+}
+
+/**
+ * Fallback used when the per-device screenshot state has no cached path —
+ * scans the screenshots tempdir for the most recent .png/.webp by mtime.
+ */
+export async function findLatestScreenshotPath(): Promise<string | undefined> {
+  try {
+    const cacheDir = getTempDir(TEMP_SUBDIRS.SCREENSHOTS);
+    const imageFiles = await ScreenshotCache.getScreenshotFiles(cacheDir);
+    if (imageFiles.length === 0) {
+      return undefined;
+    }
+
+    const fileStats = await Promise.all(
+      imageFiles.map(async fullPath => {
+        const stat = await statAsync(fullPath);
+        return { path: fullPath, mtime: stat.mtime };
+      })
+    );
+
+    fileStats.sort((a, b) => b.mtime.getTime() - a.mtime.getTime());
+
+    return fileStats[0]?.path;
+  } catch (error) {
+    logger.warn(`[AccessibilityAudit] Failed to get latest screenshot: ${error}`);
+    return undefined;
+  }
+}
+
+/**
+ * Helper that mirrors RealObserveScreen.getLatestScreenshotPath: first checks
+ * the per-device cached path (via the supplied accessor), then falls back to
+ * scanning the screenshots tempdir.
+ */
+export async function resolveLatestScreenshotPath(
+  getCachedPath?: () => string | null | undefined
+): Promise<string | undefined> {
+  try {
+    const cachedPath = getCachedPath?.();
+    if (cachedPath) {
+      const exists = await pathExists(cachedPath);
+      if (exists) {
+        return cachedPath;
+      }
+    }
+  } catch (error) {
+    logger.warn(`[AccessibilityAudit] Failed to check cached screenshot: ${error}`);
+  }
+  return findLatestScreenshotPath();
+}
+
+/**
+ * Runs the WCAG accessibility audit and attaches the result to an ObserveResult.
+ *
+ * Audit failures are logged but never propagate as errors on the result.
+ */
+export class AccessibilityAuditor {
+  private readonly device: BootedDevice;
+  private readonly screenshotPathResolver: () => Promise<string | undefined>;
+  private readonly getConfig: () => AccessibilityAuditConfig | null;
+
+  constructor(opts: AccessibilityAuditorOptions) {
+    this.device = opts.device;
+    this.screenshotPathResolver = opts.screenshotPathResolver ?? (() => resolveLatestScreenshotPath());
+    this.getConfig = opts.getConfig ?? (() => serverConfig.getAccessibilityAuditConfig());
+  }
+
+  async run(result: ObserveResult, perf: PerformanceTracker): Promise<void> {
+    // Check if accessibility audit is enabled via CLI flag
+    const auditConfig = this.getConfig();
+
+    if (!auditConfig) {
+      return;
+    }
+
+    // Only run on Android for now
+    if (this.device.platform !== "android") {
+      logger.debug("[AccessibilityAudit] Skipping audit, only Android is supported");
+      return;
+    }
+
+    // Need view hierarchy
+    if (!result.viewHierarchy?.hierarchy) {
+      logger.debug("[AccessibilityAudit] Skipping audit, no view hierarchy available");
+      return;
+    }
+
+    // Need active window for screen ID
+    if (!result.activeWindow?.appId) {
+      logger.debug("[AccessibilityAudit] Skipping audit, no active app");
+      return;
+    }
+
+    try {
+      await perf.track("accessibilityAudit", async () => {
+        logger.info(`[AccessibilityAudit] Running WCAG ${auditConfig.level} audit for ${result.activeWindow?.appId}`);
+
+        // Initialize audit
+        const wcagAudit = new WcagAudit();
+
+        // Extract elements directly from view hierarchy for audit
+        const elementParser = new DefaultElementParser();
+        const allElements: Element[] = elementParser.flattenViewHierarchy(result.viewHierarchy!)
+          .map(entry => entry.element);
+
+        // Get screenshot path if available (from TakeScreenshot cache)
+        const screenshotPath = await this.screenshotPathResolver();
+
+        // Run the audit
+        const auditResult = await wcagAudit.audit(
+          allElements,
+          result.viewHierarchy!.hierarchy,
+          screenshotPath,
+          result.activeWindow!.appId,
+          auditConfig
+        );
+
+        // Attach audit result to observe result
+        result.accessibilityAudit = auditResult;
+
+        if (!auditResult.summary.passed) {
+          logger.warn(
+            `[AccessibilityAudit] Accessibility audit FAILED with ${auditResult.violations.length} violations (${auditResult.summary.bySeverity.error} errors, ${auditResult.summary.bySeverity.warning} warnings)`
+          );
+        } else {
+          logger.info("[AccessibilityAudit] Accessibility audit PASSED");
+        }
+      });
+    } catch (error) {
+      logger.error(`[AccessibilityAudit] Failed to run accessibility audit: ${error}`);
+      // Don't fail the entire observation if audit fails
+    }
+  }
+}

--- a/src/features/observe/audits/AccessibilityStateDetector.ts
+++ b/src/features/observe/audits/AccessibilityStateDetector.ts
@@ -1,0 +1,77 @@
+import { logger } from "../../../utils/logger";
+import { throwIfAborted } from "../../../utils/toolUtils";
+import { accessibilityDetector } from "../../../utils/AccessibilityDetector";
+import { iosVoiceOverDetector } from "../../../utils/IosVoiceOverDetector";
+import { FeatureFlagService } from "../../featureFlags/FeatureFlagService";
+import { IOSCtrlProxyClient } from "../ios";
+import type { BootedDevice, ObserveResult } from "../../../models";
+import type { AdbExecutor } from "../../../utils/android-cmdline-tools/interfaces/AdbExecutor";
+import type { PerformanceTracker } from "../../../utils/PerformanceTracker";
+
+export interface AccessibilityStateDetectorOptions {
+  device: BootedDevice;
+  adb: AdbExecutor;
+}
+
+/**
+ * Detects accessibility state (TalkBack on Android, VoiceOver on iOS) and
+ * attaches it to the ObserveResult. Failures are logged but do not propagate.
+ */
+export class AccessibilityStateDetector {
+  private readonly device: BootedDevice;
+  private readonly adb: AdbExecutor;
+
+  constructor(opts: AccessibilityStateDetectorOptions) {
+    this.device = opts.device;
+    this.adb = opts.adb;
+  }
+
+  async run(result: ObserveResult, perf: PerformanceTracker, signal?: AbortSignal): Promise<void> {
+    try {
+      await perf.track("accessibilityDetection", async () => {
+        throwIfAborted(signal);
+
+        // Get feature flag service instance
+        const featureFlags = FeatureFlagService.getInstance();
+
+        if (this.device.platform === "android") {
+          // Detect TalkBack state via ADB
+          const enabled = await accessibilityDetector.isAccessibilityEnabled(
+            this.device.deviceId,
+            this.adb,
+            featureFlags
+          );
+
+          const service = await accessibilityDetector.detectMethod(
+            this.device.deviceId,
+            this.adb,
+            featureFlags
+          );
+
+          result.accessibilityState = { enabled, service };
+          logger.debug(
+            `[AccessibilityDetector] Android accessibility state: enabled=${enabled}, service=${service}`
+          );
+        } else if (this.device.platform === "ios") {
+          // Detect VoiceOver state via CtrlProxy WebSocket
+          const client = IOSCtrlProxyClient.getInstance(this.device);
+          const enabled = await iosVoiceOverDetector.isVoiceOverEnabled(
+            this.device.deviceId,
+            client,
+            featureFlags
+          );
+
+          result.accessibilityState = {
+            enabled,
+            service: enabled ? "voiceover" : "unknown",
+          };
+          logger.debug(`[IosVoiceOverDetector] iOS VoiceOver state: enabled=${enabled}`);
+        }
+      });
+    } catch (error) {
+      logger.error(`[detectAccessibilityState] Failed to detect accessibility state: ${error}`);
+      // Don't fail the entire observation if detection fails
+      // Result will simply not include accessibilityState field
+    }
+  }
+}

--- a/src/features/observe/audits/PerformanceAuditor.ts
+++ b/src/features/observe/audits/PerformanceAuditor.ts
@@ -1,0 +1,107 @@
+import { logger } from "../../../utils/logger";
+import { serverConfig } from "../../../utils/ServerConfig";
+import { PerformanceAudit } from "../../performance/PerformanceAudit";
+import { ThresholdManager } from "../../performance/ThresholdManager";
+import { DeviceCapabilitiesDetector } from "../../../utils/DeviceCapabilities";
+import type { BootedDevice, ObserveResult } from "../../../models";
+import type { AdbExecutor } from "../../../utils/android-cmdline-tools/interfaces/AdbExecutor";
+import type { PerformanceTracker } from "../../../utils/PerformanceTracker";
+
+export interface PerformanceAuditorOptions {
+  device: BootedDevice;
+  adb: AdbExecutor;
+  /** Allow tests to stub the config gate */
+  isEnabled?: () => boolean;
+}
+
+/**
+ * Runs the UI performance audit and attaches the result to an ObserveResult.
+ *
+ * Audit failures are logged but never propagate as errors on the result
+ * (the audit is opt-in via config; a failure should not pollute observation).
+ */
+export class PerformanceAuditor {
+  private readonly device: BootedDevice;
+  private readonly adb: AdbExecutor;
+  private readonly isEnabled: () => boolean;
+
+  constructor(opts: PerformanceAuditorOptions) {
+    this.device = opts.device;
+    this.adb = opts.adb;
+    this.isEnabled = opts.isEnabled ?? (() => serverConfig.isUiPerfModeEnabled());
+  }
+
+  async run(result: ObserveResult, perf: PerformanceTracker): Promise<void> {
+    // Check if performance audit is enabled via CLI flag
+    // This will be replaced with global configuration in issue #67
+    if (!this.isEnabled()) {
+      return;
+    }
+
+    // Only run on Android for now
+    if (this.device.platform !== "android") {
+      logger.debug("[PerformanceAudit] Skipping audit, only Android is supported");
+      return;
+    }
+
+    // Need an active window with app ID
+    if (!result.activeWindow?.appId) {
+      logger.debug("[PerformanceAudit] Skipping audit, no active app");
+      return;
+    }
+
+    try {
+      await perf.track("performanceAudit", async () => {
+        logger.info(`[PerformanceAudit] Running UI performance audit for ${result.activeWindow?.appId}`);
+
+        // Initialize components
+        const capabilitiesDetector = new DeviceCapabilitiesDetector(this.device, this.adb);
+        const thresholdManager = new ThresholdManager();
+        const performanceAudit = new PerformanceAudit(this.device, this.adb);
+
+        // Get device capabilities
+        const capabilities = await capabilitiesDetector.getCapabilities();
+
+        // Get or create thresholds
+        const thresholds = await thresholdManager.getOrCreateThresholds(
+          this.device.deviceId,
+          capabilities
+        );
+
+        // Run the audit
+        const auditResult = await performanceAudit.runAudit(
+          result.activeWindow!.appId,
+          thresholds,
+          result.screenSize,
+          perf
+        );
+
+        // Attach audit result to observe result
+        result.performanceAudit = auditResult;
+
+        // Update threshold weight based on result
+        const sessionId = new Date().toISOString().split("T")[0];
+        await thresholdManager.updateThresholdWeight(
+          this.device.deviceId,
+          sessionId,
+          auditResult.passed
+        );
+
+        if (!auditResult.passed) {
+          logger.warn(
+            `[PerformanceAudit] Performance audit FAILED with ${auditResult.violations.length} violations`
+          );
+        } else {
+          logger.info("[PerformanceAudit] Performance audit PASSED");
+        }
+
+        // Start continuous performance monitoring for this device/package
+        const { getPerformanceMonitor } = await import("../../performance/PerformanceMonitor");
+        getPerformanceMonitor().startMonitoring(this.device.deviceId, result.activeWindow!.appId, this.device.platform);
+      });
+    } catch (error) {
+      logger.error(`[PerformanceAudit] Failed to run performance audit: ${error}`);
+      // Don't fail the entire observation if audit fails
+    }
+  }
+}

--- a/src/features/observe/cache/FileSystemObserveCacheStore.ts
+++ b/src/features/observe/cache/FileSystemObserveCacheStore.ts
@@ -1,0 +1,254 @@
+import { mkdirSync } from "node:fs";
+import path from "path";
+import { readdirAsync, readFileAsync, statAsync, unlinkAsync, writeFileAsync } from "../../../utils/io";
+import { logger } from "../../../utils/logger";
+import { getTempDir, TEMP_SUBDIRS } from "../../../utils/tempDir";
+import { Timer, defaultTimer } from "../../../utils/SystemTimer";
+import type { ObserveResult } from "../../../models";
+import type { ObserveResultCacheStore } from "./ObserveResultCacheStore";
+
+/**
+ * Cached entry held in memory.
+ * Mirrors the shape previously kept in `RealObserveScreen.observeResultCache`.
+ */
+interface ObserveResultCacheEntry {
+  timestamp: number;
+  deviceId: string;
+  observeResult: ObserveResult;
+}
+
+/**
+ * Five-minute TTL applied to both in-memory and on-disk cache entries.
+ * Preserves the original {@link RealObserveScreen} behaviour.
+ */
+export const OBSERVE_RESULT_CACHE_TTL_MS = 5 * 60 * 1000;
+
+/**
+ * File-system backed implementation of {@link ObserveResultCacheStore}.
+ *
+ * Behaviour parity with the previous `RealObserveScreen` static cache:
+ * - In-memory map keyed by `${deviceId}:${timestamp}`.
+ * - On-disk files named `observe_${sanitizedDeviceId}_${timestamp}.json`.
+ * - Cache directory is `getTempDir(TEMP_SUBDIRS.OBSERVE_RESULTS)`.
+ * - 5 minute TTL; expired entries are evicted from memory lazily on read.
+ */
+export class FileSystemObserveCacheStore implements ObserveResultCacheStore {
+  private readonly cache: Map<string, ObserveResultCacheEntry> = new Map();
+  private readonly cacheDir: string;
+  private readonly timer: Timer;
+
+  constructor(timer: Timer = defaultTimer, cacheDir?: string) {
+    this.timer = timer;
+    this.cacheDir = cacheDir ?? getTempDir(TEMP_SUBDIRS.OBSERVE_RESULTS);
+    this.ensureCacheDirExists();
+  }
+
+  private ensureCacheDirExists(): void {
+    mkdirSync(this.cacheDir, { recursive: true });
+  }
+
+  async put(deviceId: string, result: ObserveResult): Promise<void> {
+    const timestamp = this.timer.now();
+    const cacheKey = `${deviceId}:${timestamp}`;
+    try {
+      logger.debug(`[OBSERVE_CACHE] Caching observe result for device ${deviceId} with timestamp ${timestamp}`);
+      this.cache.set(cacheKey, { timestamp, deviceId, observeResult: result });
+      await this.saveObserveResultToDisk(cacheKey, result);
+      logger.debug(`[OBSERVE_CACHE] Successfully cached observe result, in-memory cache size: ${this.cache.size}`);
+    } catch (error) {
+      logger.warn(`[OBSERVE_CACHE] Error caching observe result: ${error}`);
+    }
+  }
+
+  async getMostRecent(deviceId: string): Promise<ObserveResult | undefined> {
+    const memoryResult = this.checkInMemory(deviceId);
+    if (memoryResult) {
+      return memoryResult;
+    }
+    return await this.checkDisk(deviceId);
+  }
+
+  getRecentInMemory(): ObserveResult | undefined {
+    return this.findMostRecentInMemory();
+  }
+
+  getRecentInMemoryForDevice(deviceId: string): ObserveResult | undefined {
+    return this.findMostRecentInMemory(deviceId);
+  }
+
+  clear(deviceId?: string): void {
+    if (deviceId) {
+      for (const [key, entry] of this.cache.entries()) {
+        if (entry.deviceId === deviceId) {
+          this.cache.delete(key);
+        }
+      }
+      this.deleteDiskFilesForDevice(deviceId);
+    } else {
+      this.cache.clear();
+      this.deleteAllDiskFiles();
+    }
+  }
+
+  /**
+   * Walk the cache map once: evict expired entries and return the most-recent
+   * live entry, optionally filtered to a device. Uses `>=` for tie-breaks so
+   * the latest insertion wins when wall-clock resolution collides with two
+   * adjacent puts.
+   */
+  private collectLiveMostRecent(deviceId?: string, verboseLog: boolean = false): ObserveResultCacheEntry | undefined {
+    if (this.cache.size === 0) {
+      return undefined;
+    }
+
+    const now = this.timer.now();
+    const expiredKeys: string[] = [];
+    let mostRecentEntry: ObserveResultCacheEntry | undefined;
+
+    for (const [key, entry] of this.cache.entries()) {
+      const age = now - entry.timestamp;
+      if (age >= OBSERVE_RESULT_CACHE_TTL_MS) {
+        expiredKeys.push(key);
+        if (verboseLog) {
+          logger.debug(`[OBSERVE_CACHE] Removing expired cache entry: ${key} (age: ${age}ms > TTL: ${OBSERVE_RESULT_CACHE_TTL_MS}ms)`);
+        }
+        continue;
+      }
+      if (deviceId && entry.deviceId !== deviceId) {
+        continue;
+      }
+      if (!mostRecentEntry || entry.timestamp >= mostRecentEntry.timestamp) {
+        mostRecentEntry = entry;
+      }
+    }
+
+    for (const key of expiredKeys) {
+      this.cache.delete(key);
+    }
+
+    return mostRecentEntry;
+  }
+
+  private findMostRecentInMemory(deviceId?: string): ObserveResult | undefined {
+    return this.collectLiveMostRecent(deviceId)?.observeResult;
+  }
+
+  private checkInMemory(deviceId: string): ObserveResult | undefined {
+    const cacheSize = this.cache.size;
+    logger.debug(`[OBSERVE_CACHE] Checking in-memory cache for device ${deviceId}, size: ${cacheSize}`);
+    if (cacheSize === 0) {
+      logger.debug("[OBSERVE_CACHE] In-memory cache is empty");
+      return undefined;
+    }
+
+    const entry = this.collectLiveMostRecent(deviceId, true);
+    if (entry) {
+      const age = this.timer.now() - entry.timestamp;
+      logger.debug(`[OBSERVE_CACHE] Found most recent in-memory result for device ${deviceId} (age: ${age}ms)`);
+      return entry.observeResult;
+    }
+
+    logger.debug(`[OBSERVE_CACHE] No valid entries in in-memory cache for device ${deviceId}`);
+    return undefined;
+  }
+
+  private async checkDisk(deviceId: string): Promise<ObserveResult | undefined> {
+    logger.debug("[OBSERVE_CACHE] Checking disk cache");
+    try {
+      const devicePrefix = `observe_${this.sanitizeDeviceId(deviceId)}_`;
+      const files = await readdirAsync(this.cacheDir);
+      const jsonFiles = files.filter(file => file.endsWith(".json") && file.startsWith(devicePrefix));
+
+      if (jsonFiles.length === 0) {
+        logger.debug("[OBSERVE_CACHE] No observe result files found in disk cache");
+        return undefined;
+      }
+
+      const now = this.timer.now();
+      let mostRecentFile: { path: string; mtime: number } | undefined;
+
+      for (const file of jsonFiles) {
+        const filePath = path.join(this.cacheDir, file);
+        const stats = await statAsync(filePath);
+        const age = now - stats.mtime.getTime();
+
+        if (age < OBSERVE_RESULT_CACHE_TTL_MS) {
+          if (!mostRecentFile || stats.mtime.getTime() > mostRecentFile.mtime) {
+            mostRecentFile = { path: filePath, mtime: stats.mtime.getTime() };
+          }
+        } else {
+          logger.debug(`[OBSERVE_CACHE] Disk cache file expired: ${file} (age: ${age}ms > TTL: ${OBSERVE_RESULT_CACHE_TTL_MS}ms)`);
+        }
+      }
+
+      if (!mostRecentFile) {
+        logger.debug("[OBSERVE_CACHE] No valid files in disk cache");
+        return undefined;
+      }
+
+      const age = now - mostRecentFile.mtime;
+      logger.debug(`[OBSERVE_CACHE] Loading most recent disk cache file (age: ${age}ms)`);
+
+      const cacheData = await readFileAsync(mostRecentFile.path, "utf8");
+      const cachedResult: ObserveResult = JSON.parse(cacheData);
+
+      // Warm the in-memory cache so subsequent reads avoid the disk round-trip.
+      const cacheKey = `${deviceId}:${mostRecentFile.mtime}`;
+      this.cache.set(cacheKey, {
+        timestamp: mostRecentFile.mtime,
+        deviceId,
+        observeResult: cachedResult,
+      });
+      logger.debug(`[OBSERVE_CACHE] Updated in-memory cache from disk cache`);
+      return cachedResult;
+    } catch (error) {
+      logger.warn(`[OBSERVE_CACHE] Error checking disk cache: ${error}`);
+      return undefined;
+    }
+  }
+
+  private async saveObserveResultToDisk(cacheKey: string, observeResult: ObserveResult): Promise<void> {
+    try {
+      const filename = `observe_${cacheKey.replace(/:/g, "_")}.json`;
+      const filePath = path.join(this.cacheDir, filename);
+      await writeFileAsync(filePath, JSON.stringify(observeResult, null, 2));
+      logger.debug(`[OBSERVE_CACHE] Saved observe result to disk: ${filename}`);
+    } catch (error) {
+      logger.warn(`[OBSERVE_CACHE] Failed to save observe result to disk: ${error}`);
+    }
+  }
+
+  private sanitizeDeviceId(deviceId: string): string {
+    return deviceId.replace(/:/g, "_");
+  }
+
+  private deleteDiskFilesForDevice(deviceId: string): void {
+    const devicePrefix = `observe_${this.sanitizeDeviceId(deviceId)}_`;
+    this.deleteDiskFilesMatching(filename => filename.endsWith(".json") && filename.startsWith(devicePrefix));
+  }
+
+  private deleteAllDiskFiles(): void {
+    this.deleteDiskFilesMatching(filename => filename.endsWith(".json") && filename.startsWith("observe_"));
+  }
+
+  private deleteDiskFilesMatching(predicate: (filename: string) => boolean): void {
+    // Fire-and-forget; matches the synchronous signature of the old clearCache while still cleaning disk state.
+    void (async () => {
+      try {
+        const files = await readdirAsync(this.cacheDir);
+        const matches = files.filter(predicate);
+        await Promise.all(
+          matches.map(async file => {
+            try {
+              await unlinkAsync(path.join(this.cacheDir, file));
+            } catch (error) {
+              logger.warn(`[OBSERVE_CACHE] Failed to delete cache file ${file}: ${error}`);
+            }
+          })
+        );
+      } catch (error) {
+        logger.warn(`[OBSERVE_CACHE] Failed to enumerate cache directory for cleanup: ${error}`);
+      }
+    })();
+  }
+}

--- a/src/features/observe/cache/ObserveCacheRegistry.ts
+++ b/src/features/observe/cache/ObserveCacheRegistry.ts
@@ -1,0 +1,24 @@
+import type { ObserveResultCacheStore } from "./ObserveResultCacheStore";
+import { FileSystemObserveCacheStore } from "./FileSystemObserveCacheStore";
+
+/**
+ * Module-level singleton for the observe-result cache store.
+ *
+ * Production code reads the cache via {@link getObserveCacheStore} (returns
+ * a {@link FileSystemObserveCacheStore} by default). Tests can replace the
+ * instance with a fake via {@link setObserveCacheStore} and restore the
+ * default with {@link resetObserveCacheStore}.
+ */
+let instance: ObserveResultCacheStore = new FileSystemObserveCacheStore();
+
+export function getObserveCacheStore(): ObserveResultCacheStore {
+  return instance;
+}
+
+export function setObserveCacheStore(store: ObserveResultCacheStore): void {
+  instance = store;
+}
+
+export function resetObserveCacheStore(): void {
+  instance = new FileSystemObserveCacheStore();
+}

--- a/src/features/observe/cache/ObserveResultCacheStore.ts
+++ b/src/features/observe/cache/ObserveResultCacheStore.ts
@@ -1,0 +1,26 @@
+import type { ObserveResult } from "../../../models";
+
+/**
+ * Storage abstraction for cached observe results.
+ *
+ * Implementations are responsible for both an in-memory cache and any
+ * durable backing store (e.g. disk). Read methods are exposed in both
+ * synchronous (memory-only) and asynchronous (memory + durable) variants
+ * so callers can pick the right tradeoff for their hot path.
+ */
+export interface ObserveResultCacheStore {
+  /** Persist (memory + disk). Returns when both writes complete. */
+  put(deviceId: string, result: ObserveResult): Promise<void>;
+
+  /** Async lookup: checks memory first, then disk; loads disk hits into memory. */
+  getMostRecent(deviceId: string): Promise<ObserveResult | undefined>;
+
+  /** Sync in-memory lookup across all devices (for resource handlers). */
+  getRecentInMemory(): ObserveResult | undefined;
+
+  /** Sync in-memory lookup for a specific device. */
+  getRecentInMemoryForDevice(deviceId: string): ObserveResult | undefined;
+
+  /** Clear memory + disk cache. If deviceId provided, only that device. */
+  clear(deviceId?: string): void;
+}

--- a/src/features/observe/collectors/DeviceStateCollector.ts
+++ b/src/features/observe/collectors/DeviceStateCollector.ts
@@ -1,0 +1,127 @@
+import { logger } from "../../../utils/logger";
+import { NoOpPerformanceTracker, PerformanceTracker } from "../../../utils/PerformanceTracker";
+import { appendObserveError } from "../ObserveError";
+import type { BootedDevice, ExecResult, ObserveResult } from "../../../models";
+import type { ScreenSize } from "../interfaces/ScreenSize";
+import type { SystemInsets } from "../interfaces/SystemInsets";
+import type { Window } from "../interfaces/Window";
+import type { BackStack } from "../interfaces/BackStack";
+import type { Timer } from "../../../utils/SystemTimer";
+import type { AdbExecutor } from "../../../utils/android-cmdline-tools/interfaces/AdbExecutor";
+
+export interface DeviceStateCollectorOptions {
+  device: BootedDevice;
+  screenSize: ScreenSize;
+  systemInsets: SystemInsets;
+  window: Window;
+  backStack: BackStack;
+  adb: AdbExecutor;
+  timer: Timer;
+}
+
+/**
+ * Collects device-level state into an ObserveResult:
+ * screen size, system insets, rotation, wakefulness, back stack, active window.
+ */
+export class DeviceStateCollector {
+  constructor(private opts: DeviceStateCollectorOptions) {}
+
+  async collectScreenSize(dumpsysWindow: ExecResult, result: ObserveResult): Promise<void> {
+    const { screenSize, timer } = this.opts;
+    try {
+      const screenSizeStart = timer.now();
+      result.screenSize = await screenSize.execute(dumpsysWindow);
+      logger.debug(`Screen size retrieval took ${timer.now() - screenSizeStart}ms`);
+    } catch (error) {
+      logger.warn("Failed to get screen size:", error);
+      appendObserveError(result, {
+        phase: "screenSize",
+        message: "Failed to retrieve screen dimensions",
+        cause: String(error)
+      });
+    }
+  }
+
+  async collectSystemInsets(dumpsysWindow: ExecResult, result: ObserveResult): Promise<void> {
+    const { systemInsets, timer } = this.opts;
+    try {
+      const insetsStart = timer.now();
+      result.systemInsets = await systemInsets.execute(dumpsysWindow);
+      logger.debug(`System insets retrieval took ${timer.now() - insetsStart}ms`);
+    } catch (error) {
+      logger.warn("Failed to get system insets:", error);
+      appendObserveError(result, {
+        phase: "systemInsets",
+        message: "Failed to retrieve system insets",
+        cause: String(error)
+      });
+    }
+  }
+
+  async collectRotationInfo(dumpsysWindow: ExecResult, result: ObserveResult): Promise<void> {
+    const { timer } = this.opts;
+    try {
+      const rotationStart = timer.now();
+      const rotationMatch = dumpsysWindow.stdout.match(/mRotation=(\d)/);
+      if (rotationMatch) {
+        result.rotation = parseInt(rotationMatch[1], 10);
+      }
+      logger.debug(`Rotation info retrieval took ${timer.now() - rotationStart}ms`);
+    } catch (error) {
+      logger.warn("Failed to get rotation info:", error);
+    }
+  }
+
+  async collectWakefulness(result: ObserveResult, signal?: AbortSignal): Promise<void> {
+    const { adb } = this.opts;
+    try {
+      const wakefulness = await adb.getWakefulness(signal);
+      if (wakefulness) {
+        result.wakefulness = wakefulness;
+      }
+    } catch (error) {
+      logger.warn("Failed to get wakefulness state:", error);
+    }
+  }
+
+  async collectBackStack(
+    result: ObserveResult,
+    perf: PerformanceTracker = new NoOpPerformanceTracker(),
+    signal?: AbortSignal
+  ): Promise<void> {
+    const { backStack, timer } = this.opts;
+    try {
+      const backStackStart = timer.now();
+      const backStackInfo = await backStack.execute(perf, signal);
+      result.backStack = backStackInfo;
+      logger.debug(`Back stack retrieval took ${timer.now() - backStackStart}ms`);
+    } catch (error) {
+      logger.warn("Failed to get back stack:", error);
+      appendObserveError(result, {
+        phase: "backStack",
+        message: "Failed to retrieve back stack information",
+        cause: String(error)
+      });
+    }
+  }
+
+  async collectActiveWindow(result: ObserveResult): Promise<void> {
+    const { window, timer } = this.opts;
+    try {
+      logger.debug("[OBSERVER] collectActiveWindow");
+      const windowStart = timer.now();
+      const activeWindow = await window.getActive();
+      logger.debug(`Active window retrieval took ${timer.now() - windowStart}ms`);
+      if (activeWindow) {
+        result.activeWindow = activeWindow;
+      }
+    } catch (error) {
+      logger.warn("Failed to get active window:", error);
+      appendObserveError(result, {
+        phase: "activeWindow",
+        message: "Failed to retrieve active window information",
+        cause: String(error)
+      });
+    }
+  }
+}

--- a/src/features/observe/collectors/HierarchyCollector.ts
+++ b/src/features/observe/collectors/HierarchyCollector.ts
@@ -1,0 +1,204 @@
+import { logger } from "../../../utils/logger";
+import { NoOpPerformanceTracker, PerformanceTracker } from "../../../utils/PerformanceTracker";
+import { AndroidCtrlProxyManager } from "../../../utils/CtrlProxyManager";
+import { AndroidCtrlProxyClient } from "../android";
+import { IOSCtrlProxyClient } from "../ios";
+import { appendObserveError } from "../ObserveError";
+import type { BootedDevice, ObserveResult } from "../../../models";
+import type { ViewHierarchyQueryOptions } from "../../../models/ViewHierarchyQueryOptions";
+import type { ViewHierarchy } from "../interfaces/ViewHierarchy";
+import type { Timer } from "../../../utils/SystemTimer";
+import type { AdbClientFactory } from "../../../utils/android-cmdline-tools/AdbClientFactory";
+import type { AdbExecutor } from "../../../utils/android-cmdline-tools/interfaces/AdbExecutor";
+
+export interface HierarchyCollectorOptions {
+  device: BootedDevice;
+  viewHierarchy: ViewHierarchy;
+  adb: AdbExecutor;
+  adbFactory: AdbClientFactory;
+  timer: Timer;
+}
+
+/**
+ * Collects view hierarchy + raw view hierarchy data into an ObserveResult.
+ * Encapsulates Android/iOS branching and structured error reporting.
+ */
+export class HierarchyCollector {
+  constructor(private opts: HierarchyCollectorOptions) {}
+
+  /**
+   * Collect view hierarchy and handle errors with accessibility service caching.
+   */
+  async collect(
+    result: ObserveResult,
+    queryOptions?: ViewHierarchyQueryOptions,
+    perf: PerformanceTracker = new NoOpPerformanceTracker(),
+    skipWaitForFresh: boolean = false,
+    minTimestamp: number = 0,
+    signal?: AbortSignal
+  ): Promise<void> {
+    const { device, viewHierarchy, adb, timer } = this.opts;
+    try {
+      if (device.platform === "android") {
+        await viewHierarchy.configureRecompositionTracking(true, perf);
+      }
+
+      const viewHierarchyStart = timer.now();
+      const hierarchy = await viewHierarchy.getViewHierarchy(queryOptions, perf, skipWaitForFresh, minTimestamp, signal);
+      logger.debug("Accessibility service availability cached as: true");
+
+      if (hierarchy) {
+        result.viewHierarchy = hierarchy;
+
+        // Use the updatedAt from the view hierarchy if available (from accessibility service)
+        if (hierarchy.updatedAt) {
+          result.updatedAt = hierarchy.updatedAt;
+          logger.debug(`Using updatedAt from view hierarchy: ${hierarchy.updatedAt}`);
+        }
+
+        const focusedElement = viewHierarchy.findFocusedElement(hierarchy);
+        if (focusedElement) {
+          result.focusedElement = focusedElement;
+          logger.debug(`Found focused element: ${focusedElement.text || focusedElement["resource-id"] || "no text/id"}`);
+        }
+
+        const accessibilityFocusedElement = viewHierarchy.findAccessibilityFocusedElement(hierarchy);
+        if (accessibilityFocusedElement) {
+          result.accessibilityFocusedElement = accessibilityFocusedElement;
+          logger.debug(`Found accessibility-focused element: ${accessibilityFocusedElement.text || accessibilityFocusedElement["resource-id"] || accessibilityFocusedElement["content-desc"] || "no text/id/desc"}`);
+        }
+
+        // Intent chooser detection (inlined; logs but does not append a structured error on failure)
+        try {
+          const intentChooserDetected = hierarchy.intentChooserDetected;
+          result.intentChooserDetected = intentChooserDetected;
+          if (intentChooserDetected) {
+            logger.debug("[ObserveScreen] Intent chooser dialog detected in view hierarchy");
+          }
+        } catch (intentError) {
+          logger.warn(`[ObserveScreen] Failed to detect intent chooser: ${intentError}`);
+          // Don't fail the observation if intent chooser detection fails
+        }
+
+        if (hierarchy.notificationPermissionDetected !== undefined) {
+          result.notificationPermissionDetected = hierarchy.notificationPermissionDetected;
+          if (hierarchy.notificationPermissionDetected) {
+            logger.debug("[ObserveScreen] Notification permission dialog detected in view hierarchy");
+          }
+        }
+      }
+
+      logger.debug(`View hierarchy retrieval took ${timer.now() - viewHierarchyStart}ms`);
+    } catch (error) {
+      logger.warn("Failed to get view hierarchy:", error);
+
+      // Clear cache on failure
+      try {
+        AndroidCtrlProxyManager.getInstance(device, adb).clearAvailabilityCache();
+      } catch (clearError) {
+        logger.debug(`[HierarchyCollector] Failed to clear availability cache: ${clearError}`);
+      }
+
+      const errorStr = String(error);
+      if (
+        errorStr.includes("null root node returned by UiTestAutomationBridge") ||
+        (errorStr.includes("cat:") && errorStr.includes("No such file or directory")) ||
+        (errorStr.includes("screen appears to be off"))
+      ) {
+        appendObserveError(result, {
+          phase: "viewHierarchy",
+          message: "Screen appears to be off or device is locked",
+          cause: errorStr
+        });
+      } else {
+        appendObserveError(result, {
+          phase: "viewHierarchy",
+          message: "Failed to retrieve view hierarchy",
+          cause: errorStr
+        });
+      }
+    }
+  }
+
+  /**
+   * Fetch raw (unfiltered) view hierarchy and attach it to the result.
+   * Invalidates the shared cache after fetching so that the unfiltered snapshot
+   * does not bleed into subsequent normal observe calls.
+   */
+  async collectRaw(result: ObserveResult, signal?: AbortSignal): Promise<void> {
+    const { device, adbFactory, timer } = this.opts;
+    try {
+      if (device.platform === "android") {
+        const client = AndroidCtrlProxyClient.getInstance(device, adbFactory);
+        const syncResult = await client.requestHierarchySync(
+          new NoOpPerformanceTracker(),
+          true, // disableAllFiltering
+          signal
+        );
+        client.invalidateCache();
+        if (syncResult?.hierarchy) {
+          result.rawViewHierarchy = {
+            json: JSON.stringify(syncResult.hierarchy, null, 2),
+            source: "accessibility-service",
+            timestamp: timer.now(),
+            device: { deviceId: device.deviceId, platform: device.platform }
+          };
+        }
+      } else {
+        const xcTestClient = IOSCtrlProxyClient.getInstance(device);
+        const hierarchyResult = await xcTestClient.requestHierarchySync(
+          new NoOpPerformanceTracker(),
+          true, // disableAllFiltering
+          signal
+        );
+        xcTestClient.invalidateCache();
+        if (hierarchyResult?.hierarchy) {
+          result.rawViewHierarchy = {
+            xcuitest: JSON.stringify(hierarchyResult.hierarchy, null, 2),
+            source: "xcuitest",
+            timestamp: timer.now(),
+            device: { deviceId: device.deviceId, platform: device.platform }
+          };
+        }
+      }
+    } catch (error) {
+      logger.warn("[ObserveScreen] Failed to collect raw view hierarchy:", error);
+    }
+  }
+
+  /**
+   * Extract screen size from view hierarchy root node bounds.
+   * Supports both Android format ("[left,top][right,bottom]") and iOS format
+   * ({left, top, right, bottom}).
+   */
+  extractScreenSize(viewHierarchy: ObserveResult["viewHierarchy"]): { width: number; height: number } | null {
+    // Android format: hierarchy.node.$.bounds = "[0,0][402,874]"
+    const rootNode = viewHierarchy?.hierarchy?.node;
+    if (rootNode?.$?.bounds) {
+      const boundsStr = rootNode.$.bounds;
+      const match = boundsStr.match(/\[(-?\d+),(-?\d+)\]\[(-?\d+),(-?\d+)\]/);
+      if (match) {
+        const width = parseInt(match[3], 10) - parseInt(match[1], 10);
+        const height = parseInt(match[4], 10) - parseInt(match[2], 10);
+        if (width > 0 && height > 0) {
+          return { width, height };
+        }
+      }
+    }
+
+    // iOS format: hierarchy is the root XCTestNode with bounds as {left, top, right, bottom}
+    const iosHierarchy = viewHierarchy?.hierarchy;
+    if (iosHierarchy?.bounds && typeof iosHierarchy.bounds === "object" && !Array.isArray(iosHierarchy.bounds)) {
+      const { left, top, right, bottom } = iosHierarchy.bounds;
+      if (typeof right === "number" && typeof bottom === "number") {
+        const width = right - (left ?? 0);
+        const height = bottom - (top ?? 0);
+        if (width > 0 && height > 0) {
+          return { width, height };
+        }
+      }
+    }
+
+    return null;
+  }
+}

--- a/src/features/observe/screenshot/ObserveScreenshotRecorder.ts
+++ b/src/features/observe/screenshot/ObserveScreenshotRecorder.ts
@@ -1,0 +1,164 @@
+import { logger } from "../../../utils/logger";
+import { BootedDevice } from "../../../models";
+import { ScreenshotResult } from "../../../models/ScreenshotResult";
+import { OPERATION_CANCELLED_MESSAGE } from "../../../utils/constants";
+import { pathExists } from "../../../utils/filesystem/DefaultFileSystem";
+import { NoOpPerformanceTracker, PerformanceTracker } from "../../../utils/PerformanceTracker";
+import type { ScreenshotJobHandle, ScreenshotJobOptions } from "../../../utils/ScreenshotJobTracker";
+import type { ScreenshotService } from "../interfaces/ScreenshotService";
+import type { ScreenshotOptions } from "../TakeScreenshot";
+import { getScreenshotStateStore, ScreenshotStateStore } from "./ScreenshotStateRegistry";
+
+/**
+ * Minimal capability surface needed by the recorder: the standard
+ * `ScreenshotService` plus the `startTrackedCapture` helper that
+ * `TakeScreenshot` exposes for fire-and-forget capture. Declared inline so the
+ * recorder compiles under strict TS without requiring changes to existing
+ * call sites in `ObserveScreen.ts`.
+ */
+export interface TrackedScreenshotService extends ScreenshotService {
+  startTrackedCapture(
+    options?: ScreenshotOptions,
+    trackerOptions?: ScreenshotJobOptions
+  ): ScreenshotJobHandle;
+}
+
+/**
+ * Orchestrates screenshot capture during observe operations.
+ *
+ * State writes (success/error/path) go through the injected
+ * `ScreenshotStateStore` so server resource handlers can read the latest
+ * cached screenshot without instantiating a recorder.
+ */
+export interface ObserveScreenshotRecorder {
+  /**
+   * Fire-and-forget capture. Returns immediately while the capture continues
+   * in the background. State is updated when the capture completes.
+   */
+  start(perf?: PerformanceTracker, signal?: AbortSignal): void;
+
+  /**
+   * Awaitable capture. The promise resolves once the capture has completed
+   * (successfully or not) and state has been updated.
+   */
+  capture(perf?: PerformanceTracker, signal?: AbortSignal): Promise<void>;
+}
+
+/**
+ * Default recorder implementation. Behaviour matches the previous in-class
+ * methods on `RealObserveScreen` (`handleScreenshotResult`,
+ * `captureObservationScreenshot`, `startObservationScreenshot`).
+ */
+export class DefaultObserveScreenshotRecorder implements ObserveScreenshotRecorder {
+  private readonly device: BootedDevice;
+  private readonly screenshotUtil: TrackedScreenshotService;
+  private readonly store: ScreenshotStateStore;
+
+  constructor(
+    device: BootedDevice,
+    screenshotUtil: TrackedScreenshotService,
+    store: ScreenshotStateStore = getScreenshotStateStore()
+  ) {
+    this.device = device;
+    this.screenshotUtil = screenshotUtil;
+    this.store = store;
+  }
+
+  start(perf: PerformanceTracker = new NoOpPerformanceTracker(), signal?: AbortSignal): void {
+    perf.startOperation("screenshot");
+    const { promise } = this.screenshotUtil.startTrackedCapture(
+      { format: "png" },
+      {
+        parentSignal: signal,
+        onComplete: async completion => {
+          if (!completion.isLatest) {
+            return;
+          }
+          if (completion.aborted) {
+            logger.debug("[OBSERVE] Screenshot capture cancelled");
+            return;
+          }
+          try {
+            await this.handleScreenshotResult(completion.result, { ignoreCancel: true });
+          } catch (err) {
+            logger.warn(`[OBSERVE] Failed to finalize screenshot capture: ${err}`);
+          }
+        }
+      }
+    );
+
+    // Swallow rejections from the chained finally so an unexpected throw inside
+    // the tracked capture doesn't surface as an unhandled rejection. The
+    // `onComplete` handler already records failures via the state store.
+    promise.finally(() => {
+      perf.endOperation("screenshot");
+    }).catch(() => { /* error already recorded in onComplete */ });
+  }
+
+  async capture(perf: PerformanceTracker = new NoOpPerformanceTracker(), signal?: AbortSignal): Promise<void> {
+    try {
+      await perf.track("screenshot", async () => {
+        const { promise } = this.screenshotUtil.startTrackedCapture(
+          { format: "png" },
+          {
+            parentSignal: signal,
+            onComplete: async completion => {
+              if (!completion.isLatest) {
+                return;
+              }
+              if (completion.aborted) {
+                logger.debug("[OBSERVE] Screenshot capture cancelled");
+                return;
+              }
+              try {
+                await this.handleScreenshotResult(completion.result, { ignoreCancel: true });
+              } catch (err) {
+                logger.warn(`[OBSERVE] Failed to finalize screenshot capture: ${err}`);
+              }
+            }
+          }
+        );
+        await promise;
+      });
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : String(error);
+      if (errorMessage.includes(OPERATION_CANCELLED_MESSAGE)) {
+        logger.debug("[OBSERVE] Screenshot capture cancelled");
+        return;
+      }
+      this.store.update(this.device.deviceId, undefined, errorMessage);
+      logger.warn(`[OBSERVE] Screenshot capture failed: ${errorMessage}`);
+    }
+  }
+
+  private async handleScreenshotResult(
+    screenshotResult: ScreenshotResult,
+    options: { ignoreCancel?: boolean } = {}
+  ): Promise<void> {
+    if (!screenshotResult.success) {
+      const errorMessage = screenshotResult.error || "Failed to capture screenshot";
+      if (options.ignoreCancel && errorMessage.includes(OPERATION_CANCELLED_MESSAGE)) {
+        logger.debug("[OBSERVE] Screenshot capture cancelled");
+        return;
+      }
+      this.store.update(this.device.deviceId, undefined, errorMessage);
+      logger.warn(`[OBSERVE] Screenshot capture failed: ${errorMessage}`);
+      return;
+    }
+
+    if (!screenshotResult.path) {
+      this.store.update(this.device.deviceId, undefined, "Screenshot capture returned no file path");
+      logger.warn("[OBSERVE] Screenshot capture succeeded but no file path was returned");
+      return;
+    }
+
+    const exists = await pathExists(screenshotResult.path);
+    if (!exists) {
+      this.store.update(this.device.deviceId, undefined, "Screenshot file missing after capture");
+      logger.warn(`[OBSERVE] Screenshot capture reported success but file missing: ${screenshotResult.path}`);
+      return;
+    }
+
+    this.store.update(this.device.deviceId, screenshotResult.path);
+  }
+}

--- a/src/features/observe/screenshot/ScreenshotStateRegistry.ts
+++ b/src/features/observe/screenshot/ScreenshotStateRegistry.ts
@@ -1,0 +1,134 @@
+import type { Timer } from "../../../utils/SystemTimer";
+import { defaultTimer } from "../../../utils/SystemTimer";
+
+/**
+ * TTL for cached per-device screenshot state. Mirrors
+ * `RealObserveScreen.OBSERVE_RESULT_CACHE_TTL_MS` so reads of the most-recent
+ * screenshot state stay aligned with the observe result cache.
+ */
+export const OBSERVE_RESULT_CACHE_TTL_MS = 5 * 60 * 1000;
+
+interface ScreenshotState {
+  path: string | null;
+  error: string | null;
+  timestamp: number;
+}
+
+/**
+ * Read/write API for the most recent screenshot path/error per device.
+ *
+ * Behaviour notes:
+ * - `update` writes the latest path/error and bumps the timestamp.
+ * - `getPath` / `getError` accept an optional device id; when omitted they
+ *   return data from the most-recently-updated device across all known
+ *   devices. Expired entries are evicted on read.
+ * - `clear` evicts a single device when an id is provided, or all devices
+ *   when called without arguments.
+ */
+export interface ScreenshotStateStore {
+  update(deviceId: string, path?: string, error?: string): void;
+  getPath(deviceId?: string): string | undefined;
+  getError(deviceId?: string): string | undefined;
+  clear(deviceId?: string): void;
+}
+
+/**
+ * In-memory implementation backed by a `Map<deviceId, ScreenshotState>`.
+ *
+ * Time is injected via a `Timer` so tests can use `FakeTimer` for TTL
+ * exercises. The default uses `defaultTimer` (wall clock) for production use.
+ */
+export class InMemoryScreenshotStateStore implements ScreenshotStateStore {
+  private states: Map<string, ScreenshotState> = new Map();
+  private timer: Timer;
+
+  constructor(timer: Timer = defaultTimer) {
+    this.timer = timer;
+  }
+
+  update(deviceId: string, path?: string, error?: string): void {
+    this.states.set(deviceId, {
+      path: path ?? null,
+      error: error ?? null,
+      timestamp: this.timer.now(),
+    });
+  }
+
+  getPath(deviceId?: string): string | undefined {
+    const state = this.findLatest(deviceId);
+    return state?.path ?? undefined;
+  }
+
+  getError(deviceId?: string): string | undefined {
+    const state = this.findLatest(deviceId);
+    return state?.error ?? undefined;
+  }
+
+  clear(deviceId?: string): void {
+    if (deviceId) {
+      this.states.delete(deviceId);
+    } else {
+      this.states.clear();
+    }
+  }
+
+  private findLatest(deviceId?: string): { path: string | null; error: string | null } | null {
+    const now = this.timer.now();
+
+    if (deviceId) {
+      const state = this.states.get(deviceId);
+      if (!state) {
+        return null;
+      }
+      if (now - state.timestamp > OBSERVE_RESULT_CACHE_TTL_MS) {
+        this.states.delete(deviceId);
+        return null;
+      }
+      return { path: state.path, error: state.error };
+    }
+
+    // Find most recent across all devices, evicting expired entries along the way.
+    let mostRecent: ScreenshotState | null = null;
+    for (const [id, state] of this.states.entries()) {
+      if (now - state.timestamp > OBSERVE_RESULT_CACHE_TTL_MS) {
+        this.states.delete(id);
+        continue;
+      }
+      if (!mostRecent || state.timestamp > mostRecent.timestamp) {
+        mostRecent = state;
+      }
+    }
+
+    if (!mostRecent) {
+      return null;
+    }
+    return { path: mostRecent.path, error: mostRecent.error };
+  }
+}
+
+let instance: ScreenshotStateStore = new InMemoryScreenshotStateStore();
+
+/**
+ * Get the process-wide screenshot state store. Server resource handlers and
+ * the observe recorder share this instance so reads remain coherent without
+ * passing the store through every call site.
+ */
+export function getScreenshotStateStore(): ScreenshotStateStore {
+  return instance;
+}
+
+/**
+ * Replace the active screenshot state store. Tests should call this to swap
+ * in a `FakeScreenshotStateStore` and remember to call
+ * `resetScreenshotStateStore` in their teardown.
+ */
+export function setScreenshotStateStore(store: ScreenshotStateStore): void {
+  instance = store;
+}
+
+/**
+ * Reset to a fresh `InMemoryScreenshotStateStore` backed by `defaultTimer`.
+ */
+export function resetScreenshotStateStore(): void {
+  instance = new InMemoryScreenshotStateStore();
+}

--- a/src/models/ObserveResult.ts
+++ b/src/models/ObserveResult.ts
@@ -13,6 +13,7 @@ import { DisplayedTimeMetric } from "./DisplayedTimeMetric";
 import { SelectedElement } from "../utils/interfaces/NavigationGraph";
 import { RawViewHierarchyResult } from "./RawViewHierarchyResult";
 import type { MediaView } from "../features/observe/IdentifyMediaViews";
+import type { ObserveError } from "../features/observe/ObserveError";
 
 export interface PredictionTarget {
   text?: string;
@@ -133,8 +134,17 @@ export interface ObserveResult {
    */
   backStack?: BackStackInfo;
 
-  /** Error message if observation failed partially or completely */
+  /** Error message if observation failed partially or completely.
+   * Back-compat derived field: equivalent to `errors.map(e => e.message).join("; ")`.
+   * Prefer reading from `errors` for structured per-phase failure info. */
   error?: string;
+
+  /**
+   * Structured per-phase errors accumulated during observation.
+   * The `error` field above is derived from this list (semicolon-joined messages)
+   * for back-compat with existing string-based consumers.
+   */
+  errors?: ObserveError[];
 
   /**
    * Element detected while waiting for a match via observe waitFor

--- a/test/fakes/FakeObserveCacheStore.ts
+++ b/test/fakes/FakeObserveCacheStore.ts
@@ -1,0 +1,103 @@
+import type { ObserveResult } from "../../src/models";
+import type { ObserveResultCacheStore } from "../../src/features/observe/cache/ObserveResultCacheStore";
+import { Timer, defaultTimer } from "../../src/utils/SystemTimer";
+
+/**
+ * Five-minute TTL — matches FileSystemObserveCacheStore.
+ */
+const TTL_MS = 5 * 60 * 1000;
+
+interface FakeCacheEntry {
+  deviceId: string;
+  timestamp: number;
+  observeResult: ObserveResult;
+}
+
+/**
+ * In-memory-only fake implementation of {@link ObserveResultCacheStore}.
+ *
+ * No disk I/O — disk reads/writes are simulated by the same in-memory map
+ * used for the memory cache. Useful for tests that want to verify cache
+ * behaviour without filesystem coupling.
+ */
+export class FakeObserveCacheStore implements ObserveResultCacheStore {
+  private readonly entries: Map<string, FakeCacheEntry> = new Map();
+  private readonly timer: Timer;
+
+  constructor(timer: Timer = defaultTimer) {
+    this.timer = timer;
+  }
+
+  async put(deviceId: string, result: ObserveResult): Promise<void> {
+    const timestamp = this.timer.now();
+    this.entries.set(`${deviceId}:${timestamp}`, {
+      deviceId,
+      timestamp,
+      observeResult: result,
+    });
+  }
+
+  async getMostRecent(deviceId: string): Promise<ObserveResult | undefined> {
+    return this.findMostRecent(deviceId);
+  }
+
+  getRecentInMemory(): ObserveResult | undefined {
+    return this.findMostRecent();
+  }
+
+  getRecentInMemoryForDevice(deviceId: string): ObserveResult | undefined {
+    return this.findMostRecent(deviceId);
+  }
+
+  clear(deviceId?: string): void {
+    if (!deviceId) {
+      this.entries.clear();
+      return;
+    }
+    for (const [key, entry] of this.entries.entries()) {
+      if (entry.deviceId === deviceId) {
+        this.entries.delete(key);
+      }
+    }
+  }
+
+  /** Test helper: number of currently-cached entries (regardless of TTL). */
+  getEntryCount(): number {
+    return this.entries.size;
+  }
+
+  /** Test helper: snapshot of every entry currently held. */
+  getAllEntries(): Array<{ deviceId: string; timestamp: number; observeResult: ObserveResult }> {
+    return Array.from(this.entries.values()).map(entry => ({
+      deviceId: entry.deviceId,
+      timestamp: entry.timestamp,
+      observeResult: entry.observeResult,
+    }));
+  }
+
+  private findMostRecent(deviceId?: string): ObserveResult | undefined {
+    if (this.entries.size === 0) {
+      return undefined;
+    }
+    const now = this.timer.now();
+    const expiredKeys: string[] = [];
+    let mostRecent: FakeCacheEntry | undefined;
+    for (const [key, entry] of this.entries.entries()) {
+      const age = now - entry.timestamp;
+      if (age >= TTL_MS) {
+        expiredKeys.push(key);
+        continue;
+      }
+      if (deviceId && entry.deviceId !== deviceId) {
+        continue;
+      }
+      if (!mostRecent || entry.timestamp > mostRecent.timestamp) {
+        mostRecent = entry;
+      }
+    }
+    for (const key of expiredKeys) {
+      this.entries.delete(key);
+    }
+    return mostRecent?.observeResult;
+  }
+}

--- a/test/fakes/FakeScreenshotStateStore.ts
+++ b/test/fakes/FakeScreenshotStateStore.ts
@@ -1,0 +1,75 @@
+import type { ScreenshotStateStore } from "../../src/features/observe/screenshot/ScreenshotStateRegistry";
+
+interface FakeScreenshotState {
+  path: string | null;
+  error: string | null;
+  timestamp: number;
+}
+
+/**
+ * Test fake for `ScreenshotStateStore`. Backed by a plain `Map`; no TTL
+ * eviction so tests have full control. Use `setNow` to control the timestamp
+ * recorded on `update`.
+ */
+export class FakeScreenshotStateStore implements ScreenshotStateStore {
+  private states: Map<string, FakeScreenshotState> = new Map();
+  private currentTime: number = 0;
+
+  setNow(time: number): void {
+    this.currentTime = time;
+  }
+
+  update(deviceId: string, path?: string, error?: string): void {
+    this.states.set(deviceId, {
+      path: path ?? null,
+      error: error ?? null,
+      timestamp: this.currentTime,
+    });
+  }
+
+  getPath(deviceId?: string): string | undefined {
+    const state = this.findLatest(deviceId);
+    return state?.path ?? undefined;
+  }
+
+  getError(deviceId?: string): string | undefined {
+    const state = this.findLatest(deviceId);
+    return state?.error ?? undefined;
+  }
+
+  clear(deviceId?: string): void {
+    if (deviceId) {
+      this.states.delete(deviceId);
+    } else {
+      this.states.clear();
+    }
+  }
+
+  // Test helpers
+
+  getStateForDevice(deviceId: string): FakeScreenshotState | undefined {
+    const state = this.states.get(deviceId);
+    return state ? { ...state } : undefined;
+  }
+
+  getAllDeviceIds(): string[] {
+    return Array.from(this.states.keys());
+  }
+
+  getUpdateCount(): number {
+    return this.states.size;
+  }
+
+  private findLatest(deviceId?: string): FakeScreenshotState | undefined {
+    if (deviceId) {
+      return this.states.get(deviceId);
+    }
+    let mostRecent: FakeScreenshotState | undefined;
+    for (const state of this.states.values()) {
+      if (!mostRecent || state.timestamp > mostRecent.timestamp) {
+        mostRecent = state;
+      }
+    }
+    return mostRecent;
+  }
+}

--- a/test/features/observe/ObserveError.test.ts
+++ b/test/features/observe/ObserveError.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, test } from "bun:test";
+import { appendObserveError } from "../../../src/features/observe/ObserveError";
+import type { ObserveResult } from "../../../src/models";
+
+function makeResult(): ObserveResult {
+  return {
+    updatedAt: 0,
+    screenSize: { width: 0, height: 0 },
+    systemInsets: { top: 0, right: 0, bottom: 0, left: 0 }
+  };
+}
+
+describe("appendObserveError", () => {
+  test("initializes errors array on first call", () => {
+    const result = makeResult();
+    expect(result.errors).toBeUndefined();
+    appendObserveError(result, { phase: "screenSize", message: "boom" });
+    expect(Array.isArray(result.errors)).toBe(true);
+    expect(result.errors!.length).toBe(1);
+    expect(result.errors![0]).toEqual({ phase: "screenSize", message: "boom" });
+  });
+
+  test("multiple calls accumulate into the errors array", () => {
+    const result = makeResult();
+    appendObserveError(result, { phase: "screenSize", message: "first" });
+    appendObserveError(result, { phase: "rotation", message: "second" });
+    appendObserveError(result, { phase: "viewHierarchy", message: "third", cause: "io" });
+    expect(result.errors!.length).toBe(3);
+    expect(result.errors!.map(e => e.phase)).toEqual([
+      "screenSize",
+      "rotation",
+      "viewHierarchy"
+    ]);
+    expect(result.errors![2].cause).toBe("io");
+  });
+
+  test("derived error string is semicolon-joined messages", () => {
+    const result = makeResult();
+    appendObserveError(result, { phase: "screenSize", message: "first" });
+    expect(result.error).toBe("first");
+    appendObserveError(result, { phase: "rotation", message: "second" });
+    expect(result.error).toBe("first; second");
+    appendObserveError(result, { phase: "viewHierarchy", message: "third" });
+    expect(result.error).toBe("first; second; third");
+  });
+
+  test("preserves a pre-existing error string by migrating it into errors[]", () => {
+    // Back-compat with the legacy `appendError(result, msg)` helper, which
+    // concatenated onto an existing `result.error` string. Code that sets
+    // `result.error` directly (without going through structured errors) keeps
+    // that value as the first entry.
+    const result = makeResult();
+    result.error = "legacy-preexisting";
+    appendObserveError(result, { phase: "critical", message: "fresh" });
+    expect(result.errors!.map(e => e.message)).toEqual(["legacy-preexisting", "fresh"]);
+    expect(result.error).toBe("legacy-preexisting; fresh");
+    appendObserveError(result, { phase: "cache", message: "next" });
+    expect(result.error).toBe("legacy-preexisting; fresh; next");
+  });
+});

--- a/test/features/observe/audits/AccessibilityAuditor.test.ts
+++ b/test/features/observe/audits/AccessibilityAuditor.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, test } from "bun:test";
+import { AccessibilityAuditor } from "../../../../src/features/observe/audits/AccessibilityAuditor";
+import { NoOpPerformanceTracker } from "../../../../src/utils/PerformanceTracker";
+import type { BootedDevice, ObserveResult } from "../../../../src/models";
+import type { AccessibilityAuditConfig } from "../../../../src/models/AccessibilityAudit";
+
+function makeResult(overrides: Partial<ObserveResult> = {}): ObserveResult {
+  return {
+    updatedAt: "2026-01-01T00:00:00.000Z",
+    screenSize: { width: 1080, height: 1920 },
+    systemInsets: { top: 0, right: 0, bottom: 0, left: 0 },
+    ...overrides,
+  } as ObserveResult;
+}
+
+const androidDevice: BootedDevice = { deviceId: "dev-1", name: "android", platform: "android" };
+const iosDevice: BootedDevice = { deviceId: "ios-1", name: "ios", platform: "ios" };
+
+const enabledConfig: AccessibilityAuditConfig = {
+  level: "AA",
+} as AccessibilityAuditConfig;
+
+describe("AccessibilityAuditor", () => {
+  test("does nothing when getConfig returns null", async () => {
+    const auditor = new AccessibilityAuditor({
+      device: androidDevice,
+      getConfig: () => null,
+    });
+    const result = makeResult({
+      activeWindow: { appId: "com.example", activityName: "Main" } as any,
+      viewHierarchy: { hierarchy: { node: {} } } as any,
+    });
+    await auditor.run(result, new NoOpPerformanceTracker());
+    expect(result.accessibilityAudit).toBeUndefined();
+    expect(result.errors).toBeUndefined();
+  });
+
+  test("skips when device platform is not android", async () => {
+    const auditor = new AccessibilityAuditor({
+      device: iosDevice,
+      getConfig: () => enabledConfig,
+    });
+    const result = makeResult({
+      activeWindow: { appId: "com.example", activityName: "Main" } as any,
+      viewHierarchy: { hierarchy: { node: {} } } as any,
+    });
+    await auditor.run(result, new NoOpPerformanceTracker());
+    expect(result.accessibilityAudit).toBeUndefined();
+    expect(result.errors).toBeUndefined();
+  });
+
+  test("skips when no view hierarchy", async () => {
+    const auditor = new AccessibilityAuditor({
+      device: androidDevice,
+      getConfig: () => enabledConfig,
+    });
+    const result = makeResult({
+      activeWindow: { appId: "com.example", activityName: "Main" } as any,
+    });
+    await auditor.run(result, new NoOpPerformanceTracker());
+    expect(result.accessibilityAudit).toBeUndefined();
+    expect(result.errors).toBeUndefined();
+  });
+
+  test("skips when no activeWindow.appId", async () => {
+    const auditor = new AccessibilityAuditor({
+      device: androidDevice,
+      getConfig: () => enabledConfig,
+    });
+    const result = makeResult({
+      viewHierarchy: { hierarchy: { node: {} } } as any,
+    });
+    await auditor.run(result, new NoOpPerformanceTracker());
+    expect(result.accessibilityAudit).toBeUndefined();
+    expect(result.errors).toBeUndefined();
+  });
+
+  test("audit failures do not pollute result.errors", async () => {
+    const auditor = new AccessibilityAuditor({
+      device: androidDevice,
+      getConfig: () => enabledConfig,
+      // Force the resolver to throw — exercises catch path.
+      screenshotPathResolver: async () => {
+        throw new Error("boom");
+      },
+    });
+    const result = makeResult({
+      activeWindow: { appId: "com.example", activityName: "Main" } as any,
+      viewHierarchy: { hierarchy: { node: {} } } as any,
+    });
+    await auditor.run(result, new NoOpPerformanceTracker());
+    expect(result.errors).toBeUndefined();
+  });
+});

--- a/test/features/observe/audits/AccessibilityStateDetector.test.ts
+++ b/test/features/observe/audits/AccessibilityStateDetector.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, test } from "bun:test";
+import { AccessibilityStateDetector } from "../../../../src/features/observe/audits/AccessibilityStateDetector";
+import { FakeAdbExecutor } from "../../../fakes/FakeAdbExecutor";
+import { NoOpPerformanceTracker } from "../../../../src/utils/PerformanceTracker";
+import { OPERATION_CANCELLED_MESSAGE } from "../../../../src/utils/constants";
+import type { BootedDevice, ObserveResult } from "../../../../src/models";
+
+function makeResult(): ObserveResult {
+  return {
+    updatedAt: "2026-01-01T00:00:00.000Z",
+    screenSize: { width: 1080, height: 1920 },
+    systemInsets: { top: 0, right: 0, bottom: 0, left: 0 },
+  } as ObserveResult;
+}
+
+const androidDevice: BootedDevice = { deviceId: "dev-1", name: "android", platform: "android" };
+
+describe("AccessibilityStateDetector", () => {
+  test("honors abort signal without polluting result.errors", async () => {
+    const detector = new AccessibilityStateDetector({
+      device: androidDevice,
+      adb: new FakeAdbExecutor(),
+    });
+    const controller = new AbortController();
+    controller.abort();
+    const result = makeResult();
+    await detector.run(result, new NoOpPerformanceTracker(), controller.signal);
+    expect(result.accessibilityState).toBeUndefined();
+    expect(result.errors).toBeUndefined();
+  });
+
+  test("detection failure does not pollute result.errors", async () => {
+    const detector = new AccessibilityStateDetector({
+      device: { ...androidDevice, platform: "unknown" as any },
+      adb: new FakeAdbExecutor(),
+    });
+    const result = makeResult();
+    await detector.run(result, new NoOpPerformanceTracker());
+    // Unknown platform branch falls through with no state assigned.
+    expect(result.accessibilityState).toBeUndefined();
+    expect(result.errors).toBeUndefined();
+  });
+
+  test("abort error message is the canonical one", () => {
+    // Sanity check on the cancelled-message constant we rely on.
+    expect(OPERATION_CANCELLED_MESSAGE).toBeTruthy();
+  });
+});

--- a/test/features/observe/audits/PerformanceAuditor.test.ts
+++ b/test/features/observe/audits/PerformanceAuditor.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, test } from "bun:test";
+import { PerformanceAuditor } from "../../../../src/features/observe/audits/PerformanceAuditor";
+import { FakeAdbExecutor } from "../../../fakes/FakeAdbExecutor";
+import { NoOpPerformanceTracker } from "../../../../src/utils/PerformanceTracker";
+import type { BootedDevice, ObserveResult } from "../../../../src/models";
+
+function makeResult(overrides: Partial<ObserveResult> = {}): ObserveResult {
+  return {
+    updatedAt: "2026-01-01T00:00:00.000Z",
+    screenSize: { width: 1080, height: 1920 },
+    systemInsets: { top: 0, right: 0, bottom: 0, left: 0 },
+    ...overrides,
+  } as ObserveResult;
+}
+
+const androidDevice: BootedDevice = { deviceId: "dev-1", name: "android", platform: "android" };
+const iosDevice: BootedDevice = { deviceId: "ios-1", name: "ios", platform: "ios" };
+
+describe("PerformanceAuditor", () => {
+  test("does nothing when isEnabled returns false", async () => {
+    const auditor = new PerformanceAuditor({
+      device: androidDevice,
+      adb: new FakeAdbExecutor(),
+      isEnabled: () => false,
+    });
+    const result = makeResult({ activeWindow: { appId: "com.example", activityName: "Main" } as any });
+    await auditor.run(result, new NoOpPerformanceTracker());
+    expect(result.performanceAudit).toBeUndefined();
+    expect(result.errors).toBeUndefined();
+  });
+
+  test("skips when device platform is not android", async () => {
+    const auditor = new PerformanceAuditor({
+      device: iosDevice,
+      adb: new FakeAdbExecutor(),
+      isEnabled: () => true,
+    });
+    const result = makeResult({ activeWindow: { appId: "com.example", activityName: "Main" } as any });
+    await auditor.run(result, new NoOpPerformanceTracker());
+    expect(result.performanceAudit).toBeUndefined();
+    expect(result.errors).toBeUndefined();
+  });
+
+  test("skips when no activeWindow.appId is set", async () => {
+    const auditor = new PerformanceAuditor({
+      device: androidDevice,
+      adb: new FakeAdbExecutor(),
+      isEnabled: () => true,
+    });
+    const result = makeResult();
+    await auditor.run(result, new NoOpPerformanceTracker());
+    expect(result.performanceAudit).toBeUndefined();
+    expect(result.errors).toBeUndefined();
+  });
+
+  test("audit failures do not pollute result.errors", async () => {
+    const auditor = new PerformanceAuditor({
+      device: androidDevice,
+      adb: new FakeAdbExecutor(),
+      isEnabled: () => true,
+    });
+    const result = makeResult({ activeWindow: { appId: "com.example", activityName: "Main" } as any });
+    // FakeAdbExecutor has no responses configured; underlying audit will fail.
+    // We just need to confirm no exception leaks and no errors are appended.
+    await auditor.run(result, new NoOpPerformanceTracker());
+    expect(result.errors).toBeUndefined();
+  });
+});

--- a/test/features/observe/cache/FileSystemObserveCacheStore.test.ts
+++ b/test/features/observe/cache/FileSystemObserveCacheStore.test.ts
@@ -1,0 +1,130 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import path from "path";
+import os from "os";
+import { mkdirSync, rmSync, readdirSync, existsSync } from "node:fs";
+import { randomUUID } from "node:crypto";
+import {
+  FileSystemObserveCacheStore,
+  OBSERVE_RESULT_CACHE_TTL_MS,
+} from "../../../../src/features/observe/cache/FileSystemObserveCacheStore";
+import { FakeTimer } from "../../../fakes/FakeTimer";
+import type { ObserveResult } from "../../../../src/models";
+
+function makeResult(label: string): ObserveResult {
+  return {
+    updatedAt: label,
+    screenSize: { width: 100, height: 200 },
+    systemInsets: { top: 0, right: 0, bottom: 0, left: 0 },
+  };
+}
+
+describe("FileSystemObserveCacheStore", function() {
+  let cacheDir: string;
+  let timer: FakeTimer;
+  let store: FileSystemObserveCacheStore;
+
+  beforeEach(function() {
+    cacheDir = path.join(os.tmpdir(), `observe-cache-test-${randomUUID()}`);
+    mkdirSync(cacheDir, { recursive: true });
+    timer = new FakeTimer();
+    timer.setCurrentTime(1_000_000);
+    store = new FileSystemObserveCacheStore(timer, cacheDir);
+  });
+
+  afterEach(function() {
+    if (existsSync(cacheDir)) {
+      rmSync(cacheDir, { recursive: true, force: true });
+    }
+  });
+
+  test("creates the cache directory on construction if missing", function() {
+    const fresh = path.join(os.tmpdir(), `observe-cache-fresh-${randomUUID()}`);
+    expect(existsSync(fresh)).toBe(false);
+    new FileSystemObserveCacheStore(timer, fresh);
+    expect(existsSync(fresh)).toBe(true);
+    rmSync(fresh, { recursive: true, force: true });
+  });
+
+  test("put then getRecentInMemoryForDevice returns the cached result", async function() {
+    const result = makeResult("a");
+    await store.put("device-1", result);
+    expect(store.getRecentInMemoryForDevice("device-1")).toBe(result);
+  });
+
+  test("put then getRecentInMemory (cross-device) returns the latest result", async function() {
+    const older = makeResult("older");
+    const newer = makeResult("newer");
+    await store.put("device-1", older);
+    timer.advanceTime(10);
+    await store.put("device-2", newer);
+    expect(store.getRecentInMemory()).toBe(newer);
+  });
+
+  test("TTL: entry older than 5 minutes is evicted from memory on read", async function() {
+    const result = makeResult("expired");
+    await store.put("device-1", result);
+    timer.advanceTime(OBSERVE_RESULT_CACHE_TTL_MS + 1);
+    expect(store.getRecentInMemoryForDevice("device-1")).toBeUndefined();
+    expect(store.getRecentInMemory()).toBeUndefined();
+  });
+
+  test("multi-device isolation: getRecentInMemoryForDevice returns only matching device", async function() {
+    const r1 = makeResult("d1");
+    const r2 = makeResult("d2");
+    await store.put("device-1", r1);
+    timer.advanceTime(5);
+    await store.put("device-2", r2);
+    expect(store.getRecentInMemoryForDevice("device-1")).toBe(r1);
+    expect(store.getRecentInMemoryForDevice("device-2")).toBe(r2);
+  });
+
+  test("disk fallback: getMostRecent restores from disk after memory clear", async function() {
+    const result = makeResult("on-disk");
+    await store.put("device-1", result);
+
+    // Drop the in-memory cache by constructing a fresh store backed by the same disk dir.
+    const reloadedTimer = new FakeTimer();
+    reloadedTimer.setCurrentTime(timer.now() + 1); // 1ms later so file is still within TTL
+    const reloaded = new FileSystemObserveCacheStore(reloadedTimer, cacheDir);
+    expect(reloaded.getRecentInMemoryForDevice("device-1")).toBeUndefined();
+    const restored = await reloaded.getMostRecent("device-1");
+    expect(restored).toBeDefined();
+    expect(restored?.updatedAt).toBe("on-disk");
+    // After getMostRecent, the entry should now be warm in memory.
+    expect(reloaded.getRecentInMemoryForDevice("device-1")).toBeDefined();
+  });
+
+  test("clear(deviceId) only removes entries for that device", async function() {
+    await store.put("device-1", makeResult("d1"));
+    timer.advanceTime(1);
+    await store.put("device-2", makeResult("d2"));
+
+    store.clear("device-1");
+    expect(store.getRecentInMemoryForDevice("device-1")).toBeUndefined();
+    expect(store.getRecentInMemoryForDevice("device-2")).toBeDefined();
+  });
+
+  test("clear() removes everything in memory", async function() {
+    await store.put("device-1", makeResult("d1"));
+    timer.advanceTime(1);
+    await store.put("device-2", makeResult("d2"));
+
+    store.clear();
+    expect(store.getRecentInMemory()).toBeUndefined();
+    expect(store.getRecentInMemoryForDevice("device-1")).toBeUndefined();
+    expect(store.getRecentInMemoryForDevice("device-2")).toBeUndefined();
+  });
+
+  test("put writes a JSON file with the sanitized device id in the name", async function() {
+    await store.put("emulator-5554:abcd", makeResult("with-colon"));
+    const files = readdirSync(cacheDir).filter(f => f.endsWith(".json"));
+    expect(files.length).toBe(1);
+    expect(files[0]).toContain("emulator-5554_abcd");
+    expect(files[0]).not.toContain(":");
+  });
+
+  test("getMostRecent returns undefined when nothing cached", async function() {
+    const result = await store.getMostRecent("device-1");
+    expect(result).toBeUndefined();
+  });
+});

--- a/test/features/observe/cache/ObserveCacheRegistry.test.ts
+++ b/test/features/observe/cache/ObserveCacheRegistry.test.ts
@@ -1,0 +1,47 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import {
+  getObserveCacheStore,
+  resetObserveCacheStore,
+  setObserveCacheStore,
+} from "../../../../src/features/observe/cache/ObserveCacheRegistry";
+import { FakeObserveCacheStore } from "../../../fakes/FakeObserveCacheStore";
+
+describe("ObserveCacheRegistry", function() {
+  afterEach(function() {
+    resetObserveCacheStore();
+  });
+
+  test("returns a default FileSystemObserveCacheStore initially", function() {
+    const store = getObserveCacheStore();
+    expect(store).toBeDefined();
+    // Default store implements the same interface; constructor name check is sufficient.
+    expect(store.constructor.name).toBe("FileSystemObserveCacheStore");
+  });
+
+  test("setObserveCacheStore swaps the singleton instance", function() {
+    const fake = new FakeObserveCacheStore();
+    setObserveCacheStore(fake);
+    expect(getObserveCacheStore()).toBe(fake);
+  });
+
+  test("resetObserveCacheStore restores a default file-system store", function() {
+    const fake = new FakeObserveCacheStore();
+    setObserveCacheStore(fake);
+    expect(getObserveCacheStore()).toBe(fake);
+    resetObserveCacheStore();
+    expect(getObserveCacheStore()).not.toBe(fake);
+    expect(getObserveCacheStore().constructor.name).toBe("FileSystemObserveCacheStore");
+  });
+
+  test("swapped store is observable via the registry getter", async function() {
+    const fake = new FakeObserveCacheStore();
+    setObserveCacheStore(fake);
+    await getObserveCacheStore().put("device-x", {
+      updatedAt: "now",
+      screenSize: { width: 1, height: 2 },
+      systemInsets: { top: 0, right: 0, bottom: 0, left: 0 },
+    });
+    expect(fake.getEntryCount()).toBe(1);
+    expect(getObserveCacheStore().getRecentInMemoryForDevice("device-x")).toBeDefined();
+  });
+});

--- a/test/features/observe/collectors/DeviceStateCollector.test.ts
+++ b/test/features/observe/collectors/DeviceStateCollector.test.ts
@@ -1,0 +1,235 @@
+import { beforeEach, describe, expect, test } from "bun:test";
+import { DeviceStateCollector } from "../../../../src/features/observe/collectors/DeviceStateCollector";
+import { FakeAdbExecutor } from "../../../fakes/FakeAdbExecutor";
+import { FakeWindow } from "../../../fakes/FakeWindow";
+import { FakeTimer } from "../../../fakes/FakeTimer";
+import type {
+  BootedDevice,
+  ExecResult,
+  ObserveResult,
+  ScreenSize as ScreenSizeModel,
+  SystemInsets as SystemInsetsModel,
+  BackStackInfo
+} from "../../../../src/models";
+import type { ScreenSize } from "../../../../src/features/observe/interfaces/ScreenSize";
+import type { SystemInsets } from "../../../../src/features/observe/interfaces/SystemInsets";
+import type { BackStack } from "../../../../src/features/observe/interfaces/BackStack";
+
+function makeResult(): ObserveResult {
+  return {
+    updatedAt: 0,
+    screenSize: { width: 0, height: 0 },
+    systemInsets: { top: 0, right: 0, bottom: 0, left: 0 }
+  };
+}
+
+function makeDevice(): BootedDevice {
+  return {
+    name: "test-device",
+    platform: "android",
+    deviceId: "test-device"
+  } as BootedDevice;
+}
+
+function makeExecResult(stdout: string): ExecResult {
+  return {
+    stdout,
+    stderr: "",
+    toString: () => stdout,
+    trim: () => stdout.trim(),
+    includes: (s: string) => stdout.includes(s)
+  };
+}
+
+// Minimal inline fakes (not used elsewhere)
+
+class FakeScreenSize implements ScreenSize {
+  configured: ScreenSizeModel = { width: 1080, height: 2400 };
+  shouldFail: Error | null = null;
+  async execute(): Promise<ScreenSizeModel> {
+    if (this.shouldFail) {
+      throw this.shouldFail;
+    }
+    return this.configured;
+  }
+}
+
+class FakeSystemInsets implements SystemInsets {
+  configured: SystemInsetsModel = { top: 100, right: 0, bottom: 50, left: 0 };
+  shouldFail: Error | null = null;
+  async execute(): Promise<SystemInsetsModel> {
+    if (this.shouldFail) {
+      throw this.shouldFail;
+    }
+    return this.configured;
+  }
+}
+
+class FakeBackStack implements BackStack {
+  configured: BackStackInfo = {
+    activities: [],
+    tasks: [],
+    currentActivity: null
+  } as unknown as BackStackInfo;
+  shouldFail: Error | null = null;
+  async execute(): Promise<BackStackInfo> {
+    if (this.shouldFail) {
+      throw this.shouldFail;
+    }
+    return this.configured;
+  }
+}
+
+describe("DeviceStateCollector", () => {
+  let fakeAdb: FakeAdbExecutor;
+  let fakeWindow: FakeWindow;
+  let fakeScreenSize: FakeScreenSize;
+  let fakeSystemInsets: FakeSystemInsets;
+  let fakeBackStack: FakeBackStack;
+  let fakeTimer: FakeTimer;
+  let collector: DeviceStateCollector;
+
+  beforeEach(() => {
+    fakeAdb = new FakeAdbExecutor();
+    fakeWindow = new FakeWindow();
+    fakeScreenSize = new FakeScreenSize();
+    fakeSystemInsets = new FakeSystemInsets();
+    fakeBackStack = new FakeBackStack();
+    fakeTimer = new FakeTimer();
+    collector = new DeviceStateCollector({
+      device: makeDevice(),
+      screenSize: fakeScreenSize,
+      systemInsets: fakeSystemInsets,
+      window: fakeWindow,
+      backStack: fakeBackStack,
+      adb: fakeAdb,
+      timer: fakeTimer
+    });
+  });
+
+  describe("collectScreenSize", () => {
+    test("populates result.screenSize on success", async () => {
+      const result = makeResult();
+      await collector.collectScreenSize(makeExecResult(""), result);
+      expect(result.screenSize).toEqual({ width: 1080, height: 2400 });
+      expect(result.errors).toBeUndefined();
+    });
+
+    test("appends screenSize error on failure", async () => {
+      fakeScreenSize.shouldFail = new Error("nope");
+      const result = makeResult();
+      await collector.collectScreenSize(makeExecResult(""), result);
+      expect(result.errors).toBeDefined();
+      expect(result.errors!.length).toBe(1);
+      expect(result.errors![0].phase).toBe("screenSize");
+      expect(result.errors![0].message).toBe("Failed to retrieve screen dimensions");
+      expect(result.errors![0].cause).toContain("nope");
+    });
+  });
+
+  describe("collectSystemInsets", () => {
+    test("populates result.systemInsets on success", async () => {
+      const result = makeResult();
+      await collector.collectSystemInsets(makeExecResult(""), result);
+      expect(result.systemInsets).toEqual({ top: 100, right: 0, bottom: 50, left: 0 });
+      expect(result.errors).toBeUndefined();
+    });
+
+    test("appends systemInsets error on failure", async () => {
+      fakeSystemInsets.shouldFail = new Error("insets fail");
+      const result = makeResult();
+      await collector.collectSystemInsets(makeExecResult(""), result);
+      expect(result.errors!.length).toBe(1);
+      expect(result.errors![0].phase).toBe("systemInsets");
+      expect(result.errors![0].message).toBe("Failed to retrieve system insets");
+    });
+  });
+
+  describe("collectRotationInfo", () => {
+    test("parses rotation from dumpsys window output", async () => {
+      const result = makeResult();
+      await collector.collectRotationInfo(makeExecResult("blah\nmRotation=3\nfoo"), result);
+      expect(result.rotation).toBe(3);
+    });
+
+    test("does not set rotation when missing", async () => {
+      const result = makeResult();
+      await collector.collectRotationInfo(makeExecResult("no rotation here"), result);
+      expect(result.rotation).toBeUndefined();
+      expect(result.errors).toBeUndefined();
+    });
+
+    test("does not append error on parse problem (logs only)", async () => {
+      // Construct exec result with broken stdout that .match throws on? .match is forgiving;
+      // The legacy code only logged warnings. Verify we never write to result.errors.
+      const result = makeResult();
+      await collector.collectRotationInfo(makeExecResult(""), result);
+      expect(result.errors).toBeUndefined();
+    });
+  });
+
+  describe("collectWakefulness", () => {
+    test("populates wakefulness on success", async () => {
+      fakeAdb.setScreenState(true, "Awake");
+      const result = makeResult();
+      await collector.collectWakefulness(result);
+      expect(result.wakefulness).toBe("Awake");
+    });
+
+    test("does not append error on failure (logs only)", async () => {
+      // Swap getWakefulness to throw
+      (fakeAdb as any).getWakefulness = async () => {
+        throw new Error("wake fail");
+      };
+      const result = makeResult();
+      await collector.collectWakefulness(result);
+      expect(result.wakefulness).toBeUndefined();
+      expect(result.errors).toBeUndefined();
+    });
+  });
+
+  describe("collectBackStack", () => {
+    test("populates backStack on success", async () => {
+      const result = makeResult();
+      await collector.collectBackStack(result);
+      expect(result.backStack).toBeDefined();
+      expect(result.errors).toBeUndefined();
+    });
+
+    test("appends backStack error on failure", async () => {
+      fakeBackStack.shouldFail = new Error("backstack fail");
+      const result = makeResult();
+      await collector.collectBackStack(result);
+      expect(result.errors!.length).toBe(1);
+      expect(result.errors![0].phase).toBe("backStack");
+      expect(result.errors![0].message).toBe("Failed to retrieve back stack information");
+    });
+  });
+
+  describe("collectActiveWindow", () => {
+    test("populates activeWindow on success", async () => {
+      fakeWindow.configureActiveWindow({
+        appId: "com.test.app",
+        activityName: "MainActivity",
+        layoutSeqSum: 1
+      });
+      const result = makeResult();
+      await collector.collectActiveWindow(result);
+      expect(result.activeWindow).toEqual({
+        appId: "com.test.app",
+        activityName: "MainActivity",
+        layoutSeqSum: 1
+      });
+      expect(result.errors).toBeUndefined();
+    });
+
+    test("appends activeWindow error on failure", async () => {
+      // FakeWindow.getActive throws when no activeWindow configured
+      const result = makeResult();
+      await collector.collectActiveWindow(result);
+      expect(result.errors!.length).toBe(1);
+      expect(result.errors![0].phase).toBe("activeWindow");
+      expect(result.errors![0].message).toBe("Failed to retrieve active window information");
+    });
+  });
+});

--- a/test/features/observe/collectors/HierarchyCollector.test.ts
+++ b/test/features/observe/collectors/HierarchyCollector.test.ts
@@ -1,0 +1,179 @@
+import { beforeEach, describe, expect, test } from "bun:test";
+import { HierarchyCollector } from "../../../../src/features/observe/collectors/HierarchyCollector";
+import { FakeViewHierarchy } from "../../../fakes/FakeViewHierarchy";
+import { FakeAdbExecutor } from "../../../fakes/FakeAdbExecutor";
+import { FakeTimer } from "../../../fakes/FakeTimer";
+import type { AdbClientFactory } from "../../../../src/utils/android-cmdline-tools/AdbClientFactory";
+import type { BootedDevice, ObserveResult, Element } from "../../../../src/models";
+
+function makeResult(): ObserveResult {
+  return {
+    updatedAt: 0,
+    screenSize: { width: 0, height: 0 },
+    systemInsets: { top: 0, right: 0, bottom: 0, left: 0 }
+  };
+}
+
+function makeDevice(platform: "android" | "ios" = "android"): BootedDevice {
+  return {
+    name: "test-device",
+    platform,
+    deviceId: "test-device"
+  } as BootedDevice;
+}
+
+function makeStubAdbFactory(adb: FakeAdbExecutor): AdbClientFactory {
+  return { create: () => adb };
+}
+
+describe("HierarchyCollector", () => {
+  let fakeViewHierarchy: FakeViewHierarchy;
+  let fakeAdb: FakeAdbExecutor;
+  let fakeTimer: FakeTimer;
+  let collector: HierarchyCollector;
+
+  beforeEach(() => {
+    fakeViewHierarchy = new FakeViewHierarchy();
+    fakeAdb = new FakeAdbExecutor();
+    fakeTimer = new FakeTimer();
+    collector = new HierarchyCollector({
+      device: makeDevice("android"),
+      viewHierarchy: fakeViewHierarchy,
+      adb: fakeAdb,
+      adbFactory: makeStubAdbFactory(fakeAdb),
+      timer: fakeTimer
+    });
+  });
+
+  describe("collect", () => {
+    test("populates viewHierarchy on success", async () => {
+      fakeViewHierarchy.configureHierarchy({
+        hierarchy: { foo: "bar" },
+        updatedAt: 12345
+      } as any);
+
+      const result = makeResult();
+      await collector.collect(result);
+
+      expect(result.viewHierarchy).toBeDefined();
+      expect(result.updatedAt).toBe(12345);
+      expect(result.errors).toBeUndefined();
+    });
+
+    test("populates focusedElement when found", async () => {
+      const focused: Element = { text: "Submit" } as Element;
+      fakeViewHierarchy.configureHierarchy({ hierarchy: {} } as any);
+      fakeViewHierarchy.configureFocusedElement(focused);
+
+      const result = makeResult();
+      await collector.collect(result);
+
+      expect(result.focusedElement).toEqual(focused);
+    });
+
+    test("populates accessibilityFocusedElement when found", async () => {
+      const a11y: Element = { "content-desc": "Submit button" } as Element;
+      fakeViewHierarchy.configureHierarchy({ hierarchy: {} } as any);
+      fakeViewHierarchy.configureAccessibilityFocusedElement(a11y);
+
+      const result = makeResult();
+      await collector.collect(result);
+
+      expect(result.accessibilityFocusedElement).toEqual(a11y);
+    });
+
+    test("populates intentChooserDetected from hierarchy", async () => {
+      fakeViewHierarchy.configureHierarchy({
+        hierarchy: {},
+        intentChooserDetected: true
+      } as any);
+
+      const result = makeResult();
+      await collector.collect(result);
+
+      expect(result.intentChooserDetected).toBe(true);
+    });
+
+    test("propagates notificationPermissionDetected", async () => {
+      fakeViewHierarchy.configureHierarchy({
+        hierarchy: {},
+        notificationPermissionDetected: true
+      } as any);
+
+      const result = makeResult();
+      await collector.collect(result);
+
+      expect(result.notificationPermissionDetected).toBe(true);
+    });
+
+    test("emits viewHierarchy error on generic failure", async () => {
+      fakeViewHierarchy.setFailure(new Error("boom"));
+
+      const result = makeResult();
+      await collector.collect(result);
+
+      expect(result.errors).toBeDefined();
+      expect(result.errors!.length).toBe(1);
+      expect(result.errors![0].phase).toBe("viewHierarchy");
+      expect(result.errors![0].message).toBe("Failed to retrieve view hierarchy");
+      expect(result.errors![0].cause).toContain("boom");
+    });
+
+    test("emits screen-off message when error indicates screen off", async () => {
+      fakeViewHierarchy.setFailure(new Error("null root node returned by UiTestAutomationBridge"));
+
+      const result = makeResult();
+      await collector.collect(result);
+
+      expect(result.errors!.length).toBe(1);
+      expect(result.errors![0].phase).toBe("viewHierarchy");
+      expect(result.errors![0].message).toBe("Screen appears to be off or device is locked");
+    });
+
+    test("emits screen-off when cat: No such file or directory pattern", async () => {
+      fakeViewHierarchy.setFailure(new Error("cat: /sdcard/foo: No such file or directory"));
+
+      const result = makeResult();
+      await collector.collect(result);
+
+      expect(result.errors![0].message).toBe("Screen appears to be off or device is locked");
+    });
+
+    test("emits screen-off when 'screen appears to be off' phrase present", async () => {
+      fakeViewHierarchy.setFailure(new Error("the screen appears to be off"));
+
+      const result = makeResult();
+      await collector.collect(result);
+
+      expect(result.errors![0].message).toBe("Screen appears to be off or device is locked");
+    });
+  });
+
+  describe("extractScreenSize", () => {
+    test("parses Android bounds format", () => {
+      const size = collector.extractScreenSize({
+        hierarchy: { node: { $: { bounds: "[0,0][1080,2400]" } } }
+      } as any);
+      expect(size).toEqual({ width: 1080, height: 2400 });
+    });
+
+    test("parses iOS bounds object format", () => {
+      const size = collector.extractScreenSize({
+        hierarchy: { bounds: { left: 0, top: 0, right: 402, bottom: 874 } }
+      } as any);
+      expect(size).toEqual({ width: 402, height: 874 });
+    });
+
+    test("returns null when bounds are missing", () => {
+      const size = collector.extractScreenSize({ hierarchy: {} } as any);
+      expect(size).toBeNull();
+    });
+
+    test("returns null when width or height is zero", () => {
+      const size = collector.extractScreenSize({
+        hierarchy: { node: { $: { bounds: "[0,0][0,0]" } } }
+      } as any);
+      expect(size).toBeNull();
+    });
+  });
+});

--- a/test/features/observe/screenshot/ObserveScreenshotRecorder.test.ts
+++ b/test/features/observe/screenshot/ObserveScreenshotRecorder.test.ts
@@ -1,0 +1,291 @@
+import { beforeEach, describe, expect, test } from "bun:test";
+import { tmpdir } from "node:os";
+import { mkdtempSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import { BootedDevice } from "../../../../src/models";
+import { ScreenshotResult } from "../../../../src/models/ScreenshotResult";
+import { OPERATION_CANCELLED_MESSAGE } from "../../../../src/utils/constants";
+import { NoOpPerformanceTracker } from "../../../../src/utils/PerformanceTracker";
+import type { ScreenshotJobHandle, ScreenshotJobOptions } from "../../../../src/utils/ScreenshotJobTracker";
+import type { ScreenshotOptions } from "../../../../src/features/observe/TakeScreenshot";
+import {
+  DefaultObserveScreenshotRecorder,
+  TrackedScreenshotService,
+} from "../../../../src/features/observe/screenshot/ObserveScreenshotRecorder";
+import { FakeScreenshotStateStore } from "../../../fakes/FakeScreenshotStateStore";
+
+/**
+ * Poll until `predicate()` returns true or the iteration limit is reached.
+ * Avoids the flakiness of counting setImmediate yields — the recorder's
+ * fire-and-forget `.finally()` chains can take a variable number of
+ * microtask boundaries to settle depending on what else the event loop is
+ * doing.
+ */
+async function eventually(predicate: () => boolean, maxIterations = 50): Promise<void> {
+  for (let i = 0; i < maxIterations; i++) {
+    if (predicate()) {
+      return;
+    }
+    await new Promise(resolve => setImmediate(resolve));
+  }
+}
+
+/**
+ * Minimal fake `TrackedScreenshotService` that lets each test script the
+ * `ScreenshotResult` returned by the capture and choose whether the capture
+ * reports as the latest job / aborted.
+ */
+class FakeTrackedScreenshotService implements TrackedScreenshotService {
+  private nextResult: ScreenshotResult = { success: true, path: "/tmp/default.png" };
+  private nextIsLatest: boolean = true;
+  private nextAborted: boolean = false;
+  private nextThrow: Error | null = null;
+
+  setNextResult(result: ScreenshotResult): void {
+    this.nextResult = result;
+  }
+  setNextIsLatest(isLatest: boolean): void {
+    this.nextIsLatest = isLatest;
+  }
+  setNextAborted(aborted: boolean): void {
+    this.nextAborted = aborted;
+  }
+  setNextThrow(err: Error): void {
+    this.nextThrow = err;
+  }
+
+  async execute(_options?: ScreenshotOptions, _signal?: AbortSignal): Promise<ScreenshotResult> {
+    return this.nextResult;
+  }
+
+  generateScreenshotPath(_timestamp: number, _options: ScreenshotOptions): string {
+    return "/tmp/path.png";
+  }
+
+  async getActivityHash(_activityHash: string | null): Promise<string> {
+    return "hash";
+  }
+
+  startTrackedCapture(
+    _options: ScreenshotOptions = { format: "png" },
+    trackerOptions: ScreenshotJobOptions = {}
+  ): ScreenshotJobHandle {
+    const abortController = new AbortController();
+    const result = this.nextResult;
+    const isLatest = this.nextIsLatest;
+    const aborted = this.nextAborted;
+    const toThrow = this.nextThrow;
+    this.nextThrow = null;
+
+    const promise: Promise<ScreenshotResult> = (async () => {
+      if (trackerOptions.onComplete) {
+        await trackerOptions.onComplete({
+          deviceId: "test-device",
+          jobId: "job-1",
+          result,
+          aborted,
+          isLatest,
+        });
+      }
+      if (toThrow) {
+        throw toThrow;
+      }
+      return result;
+    })();
+
+    return {
+      jobId: "job-1",
+      promise,
+      signal: abortController.signal,
+    };
+  }
+}
+
+const mockDevice: BootedDevice = {
+  name: "test",
+  platform: "android",
+  deviceId: "test-device",
+};
+
+describe("DefaultObserveScreenshotRecorder.capture", () => {
+  let store: FakeScreenshotStateStore;
+  let svc: FakeTrackedScreenshotService;
+  let recorder: DefaultObserveScreenshotRecorder;
+
+  beforeEach(() => {
+    store = new FakeScreenshotStateStore();
+    svc = new FakeTrackedScreenshotService();
+    recorder = new DefaultObserveScreenshotRecorder(mockDevice, svc, store);
+  });
+
+  test("success path writes path to store", async () => {
+    const dir = mkdtempSync(path.join(tmpdir(), "obs-rec-"));
+    const file = path.join(dir, "shot.png");
+    writeFileSync(file, "img");
+    svc.setNextResult({ success: true, path: file });
+
+    await recorder.capture(new NoOpPerformanceTracker());
+
+    expect(store.getPath("test-device")).toBe(file);
+    expect(store.getError("test-device")).toBeUndefined();
+  });
+
+  test("failure writes error to store", async () => {
+    svc.setNextResult({ success: false, error: "capture failed" });
+
+    await recorder.capture(new NoOpPerformanceTracker());
+
+    expect(store.getPath("test-device")).toBeUndefined();
+    expect(store.getError("test-device")).toBe("capture failed");
+  });
+
+  test("failure without explicit error message uses default", async () => {
+    svc.setNextResult({ success: false });
+
+    await recorder.capture(new NoOpPerformanceTracker());
+
+    expect(store.getError("test-device")).toBe("Failed to capture screenshot");
+  });
+
+  test("missing file path on success records descriptive error", async () => {
+    svc.setNextResult({ success: true });
+
+    await recorder.capture(new NoOpPerformanceTracker());
+
+    expect(store.getError("test-device")).toBe("Screenshot capture returned no file path");
+  });
+
+  test("success with path that no longer exists on disk records error", async () => {
+    svc.setNextResult({ success: true, path: "/tmp/does-not-exist-xyz-12345.png" });
+
+    await recorder.capture(new NoOpPerformanceTracker());
+
+    expect(store.getError("test-device")).toBe("Screenshot file missing after capture");
+    expect(store.getPath("test-device")).toBeUndefined();
+  });
+
+  test("cancelled capture does not write to store", async () => {
+    svc.setNextResult({ success: false, error: `${OPERATION_CANCELLED_MESSAGE} mid-capture` });
+
+    await recorder.capture(new NoOpPerformanceTracker());
+
+    expect(store.getUpdateCount()).toBe(0);
+  });
+
+  test("aborted completion does not write to store", async () => {
+    svc.setNextAborted(true);
+    svc.setNextResult({ success: true, path: "/tmp/x.png" });
+
+    await recorder.capture(new NoOpPerformanceTracker());
+
+    expect(store.getUpdateCount()).toBe(0);
+  });
+
+  test("non-latest completion does not write to store", async () => {
+    svc.setNextIsLatest(false);
+    svc.setNextResult({ success: true, path: "/tmp/x.png" });
+
+    await recorder.capture(new NoOpPerformanceTracker());
+
+    expect(store.getUpdateCount()).toBe(0);
+  });
+
+  test("thrown error from capture writes to store", async () => {
+    svc.setNextThrow(new Error("network down"));
+    svc.setNextResult({ success: true, path: "/tmp/skip.png" });
+    svc.setNextIsLatest(false); // avoid the onComplete success path also writing
+
+    await recorder.capture(new NoOpPerformanceTracker());
+
+    expect(store.getError("test-device")).toBe("network down");
+  });
+});
+
+describe("DefaultObserveScreenshotRecorder.start", () => {
+  let store: FakeScreenshotStateStore;
+  let svc: FakeTrackedScreenshotService;
+  let recorder: DefaultObserveScreenshotRecorder;
+
+  beforeEach(() => {
+    store = new FakeScreenshotStateStore();
+    svc = new FakeTrackedScreenshotService();
+    recorder = new DefaultObserveScreenshotRecorder(mockDevice, svc, store);
+  });
+
+  test("start() returns synchronously and eventually writes state", async () => {
+    const dir = mkdtempSync(path.join(tmpdir(), "obs-rec-"));
+    const file = path.join(dir, "shot.png");
+    writeFileSync(file, "img");
+    svc.setNextResult({ success: true, path: file });
+
+    const returnValue = recorder.start(new NoOpPerformanceTracker());
+
+    expect(returnValue).toBeUndefined();
+    expect(store.getUpdateCount()).toBe(0); // nothing yet — runs async
+
+    await eventually(() => store.getPath("test-device") === file);
+
+    expect(store.getPath("test-device")).toBe(file);
+  });
+
+  test("start() with non-latest completion does not write state", async () => {
+    svc.setNextIsLatest(false);
+    svc.setNextResult({ success: true, path: "/tmp/x.png" });
+
+    recorder.start(new NoOpPerformanceTracker());
+
+    // Drain the microtask queue; non-latest completion should NOT write.
+    await eventually(() => false, 10);
+
+    expect(store.getUpdateCount()).toBe(0);
+  });
+
+  test("start() with aborted completion does not write state", async () => {
+    svc.setNextAborted(true);
+    svc.setNextResult({ success: true, path: "/tmp/x.png" });
+
+    recorder.start(new NoOpPerformanceTracker());
+
+    await eventually(() => false, 10);
+
+    expect(store.getUpdateCount()).toBe(0);
+  });
+
+  test("start() with failed capture writes error", async () => {
+    svc.setNextResult({ success: false, error: "boom" });
+
+    recorder.start(new NoOpPerformanceTracker());
+
+    await eventually(() => store.getError("test-device") === "boom");
+
+    expect(store.getError("test-device")).toBe("boom");
+  });
+
+  test("start() tracks performance via startOperation/endOperation", async () => {
+    const calls: string[] = [];
+    const fakeTracker = {
+      serial: () => fakeTracker,
+      parallel: () => fakeTracker,
+      track: async <T>(_n: string, fn: () => Promise<T>) => fn(),
+      trackSync: <T>(_n: string, fn: () => T) => fn(),
+      end: () => fakeTracker,
+      getTimings: () => null,
+      isEnabled: () => true,
+      addExternalTiming: () => {},
+      startOperation: (name: string) => {
+        calls.push(`start:${name}`);
+      },
+      endOperation: (name: string) => {
+        calls.push(`end:${name}`);
+      },
+    };
+
+    svc.setNextResult({ success: true, path: "/tmp/no-exist.png" });
+    recorder.start(fakeTracker);
+
+    await eventually(() => calls.includes("end:screenshot"));
+
+    expect(calls).toContain("start:screenshot");
+    expect(calls).toContain("end:screenshot");
+  });
+});

--- a/test/features/observe/screenshot/ScreenshotStateRegistry.test.ts
+++ b/test/features/observe/screenshot/ScreenshotStateRegistry.test.ts
@@ -1,0 +1,188 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import {
+  InMemoryScreenshotStateStore,
+  OBSERVE_RESULT_CACHE_TTL_MS,
+  getScreenshotStateStore,
+  resetScreenshotStateStore,
+  setScreenshotStateStore,
+} from "../../../../src/features/observe/screenshot/ScreenshotStateRegistry";
+import { FakeTimer } from "../../../fakes/FakeTimer";
+import { FakeScreenshotStateStore } from "../../../fakes/FakeScreenshotStateStore";
+
+describe("InMemoryScreenshotStateStore", () => {
+  test("update + getPath round-trips for a single device", () => {
+    const timer = new FakeTimer();
+    timer.setCurrentTime(1000);
+    const store = new InMemoryScreenshotStateStore(timer);
+
+    store.update("device-A", "/tmp/screen.png");
+
+    expect(store.getPath("device-A")).toBe("/tmp/screen.png");
+    expect(store.getError("device-A")).toBeUndefined();
+  });
+
+  test("update with error clears path and stores error", () => {
+    const timer = new FakeTimer();
+    timer.setCurrentTime(1000);
+    const store = new InMemoryScreenshotStateStore(timer);
+
+    store.update("device-A", undefined, "boom");
+
+    expect(store.getPath("device-A")).toBeUndefined();
+    expect(store.getError("device-A")).toBe("boom");
+  });
+
+  test("getPath() without deviceId returns most recent across devices", () => {
+    const timer = new FakeTimer();
+    const store = new InMemoryScreenshotStateStore(timer);
+
+    timer.setCurrentTime(1000);
+    store.update("device-A", "/tmp/a.png");
+    timer.setCurrentTime(2000);
+    store.update("device-B", "/tmp/b.png");
+    timer.setCurrentTime(1500);
+    store.update("device-C", "/tmp/c.png");
+
+    // device-B has the most recent timestamp (2000)
+    expect(store.getPath()).toBe("/tmp/b.png");
+  });
+
+  test("per-device entries are isolated", () => {
+    const timer = new FakeTimer();
+    timer.setCurrentTime(1000);
+    const store = new InMemoryScreenshotStateStore(timer);
+
+    store.update("device-A", "/tmp/a.png");
+    store.update("device-B", undefined, "bad");
+
+    expect(store.getPath("device-A")).toBe("/tmp/a.png");
+    expect(store.getError("device-A")).toBeUndefined();
+    expect(store.getPath("device-B")).toBeUndefined();
+    expect(store.getError("device-B")).toBe("bad");
+  });
+
+  test("TTL expiry evicts per-device entry on read", () => {
+    const timer = new FakeTimer();
+    timer.setCurrentTime(1000);
+    const store = new InMemoryScreenshotStateStore(timer);
+
+    store.update("device-A", "/tmp/a.png");
+    expect(store.getPath("device-A")).toBe("/tmp/a.png");
+
+    // Advance just past TTL
+    timer.setCurrentTime(1000 + OBSERVE_RESULT_CACHE_TTL_MS + 1);
+    expect(store.getPath("device-A")).toBeUndefined();
+    expect(store.getError("device-A")).toBeUndefined();
+  });
+
+  test("TTL expiry evicts entries when scanning across devices", () => {
+    const timer = new FakeTimer();
+    const store = new InMemoryScreenshotStateStore(timer);
+
+    timer.setCurrentTime(1000);
+    store.update("device-A", "/tmp/a.png");
+    timer.setCurrentTime(2000);
+    store.update("device-B", "/tmp/b.png");
+
+    // Advance so device-A is expired but device-B is not
+    timer.setCurrentTime(1000 + OBSERVE_RESULT_CACHE_TTL_MS + 1);
+
+    expect(store.getPath()).toBe("/tmp/b.png");
+    // Device A should have been evicted
+    expect(store.getPath("device-A")).toBeUndefined();
+  });
+
+  test("entries within TTL are not evicted", () => {
+    const timer = new FakeTimer();
+    timer.setCurrentTime(1000);
+    const store = new InMemoryScreenshotStateStore(timer);
+
+    store.update("device-A", "/tmp/a.png");
+
+    // Advance just under TTL
+    timer.setCurrentTime(1000 + OBSERVE_RESULT_CACHE_TTL_MS - 1);
+    expect(store.getPath("device-A")).toBe("/tmp/a.png");
+  });
+
+  test("clear(deviceId) removes only the specified device", () => {
+    const timer = new FakeTimer();
+    timer.setCurrentTime(1000);
+    const store = new InMemoryScreenshotStateStore(timer);
+
+    store.update("device-A", "/tmp/a.png");
+    store.update("device-B", "/tmp/b.png");
+
+    store.clear("device-A");
+
+    expect(store.getPath("device-A")).toBeUndefined();
+    expect(store.getPath("device-B")).toBe("/tmp/b.png");
+  });
+
+  test("clear() without deviceId removes all devices", () => {
+    const timer = new FakeTimer();
+    timer.setCurrentTime(1000);
+    const store = new InMemoryScreenshotStateStore(timer);
+
+    store.update("device-A", "/tmp/a.png");
+    store.update("device-B", "/tmp/b.png");
+
+    store.clear();
+
+    expect(store.getPath()).toBeUndefined();
+    expect(store.getPath("device-A")).toBeUndefined();
+    expect(store.getPath("device-B")).toBeUndefined();
+  });
+
+  test("update overwrites prior state for the same device", () => {
+    const timer = new FakeTimer();
+    timer.setCurrentTime(1000);
+    const store = new InMemoryScreenshotStateStore(timer);
+
+    store.update("device-A", undefined, "earlier error");
+    timer.setCurrentTime(1100);
+    store.update("device-A", "/tmp/a.png");
+
+    expect(store.getPath("device-A")).toBe("/tmp/a.png");
+    expect(store.getError("device-A")).toBeUndefined();
+  });
+
+  test("returns undefined when no state exists", () => {
+    const store = new InMemoryScreenshotStateStore(new FakeTimer());
+
+    expect(store.getPath()).toBeUndefined();
+    expect(store.getError()).toBeUndefined();
+    expect(store.getPath("device-X")).toBeUndefined();
+    expect(store.getError("device-X")).toBeUndefined();
+  });
+});
+
+describe("module-level screenshot state store", () => {
+  afterEach(() => {
+    resetScreenshotStateStore();
+  });
+
+  test("getScreenshotStateStore returns a working default", () => {
+    const store = getScreenshotStateStore();
+    store.update("device-default", "/tmp/x.png");
+    expect(store.getPath("device-default")).toBe("/tmp/x.png");
+  });
+
+  test("setScreenshotStateStore swaps in a custom implementation", () => {
+    const fake = new FakeScreenshotStateStore();
+    setScreenshotStateStore(fake);
+
+    const store = getScreenshotStateStore();
+    expect(store).toBe(fake);
+
+    store.update("device-fake", "/tmp/fake.png");
+    expect(fake.getStateForDevice("device-fake")?.path).toBe("/tmp/fake.png");
+  });
+
+  test("resetScreenshotStateStore clears any swapped-in implementation", () => {
+    const fake = new FakeScreenshotStateStore();
+    setScreenshotStateStore(fake);
+    resetScreenshotStateStore();
+
+    expect(getScreenshotStateStore()).not.toBe(fake);
+  });
+});

--- a/test/server/resources/read.test.ts
+++ b/test/server/resources/read.test.ts
@@ -1,6 +1,7 @@
 import { afterAll, afterEach, beforeAll, describe, expect, test } from "bun:test";
 import { McpTestFixture } from "../../fixtures/mcpTestFixture";
 import { RealObserveScreen } from "../../../src/features/observe/ObserveScreen";
+import { getScreenshotStateStore } from "../../../src/features/observe/screenshot/ScreenshotStateRegistry";
 import * as fs from "fs/promises";
 import * as path from "path";
 import { z } from "zod";
@@ -186,16 +187,12 @@ describe("MCP Resources Read", () => {
     await observeScreen.cacheObserveResult(observeScreen.createBaseResult());
 
     // Clear any pre-existing screenshot state
-    (RealObserveScreen as any).screenshotStateByDevice.delete(mockDevice.deviceId);
+    getScreenshotStateStore().clear(mockDevice.deviceId);
 
     ScreenshotJobTracker.startJob(mockDevice.deviceId, async signal => {
       return new Promise(resolve => {
         const timeoutId = fakeTimer.setTimeout(() => {
-          (RealObserveScreen as any).screenshotStateByDevice.set(mockDevice.deviceId, {
-            path: screenshotPath,
-            error: null,
-            timestamp: Date.now(),
-          });
+          getScreenshotStateStore().update(mockDevice.deviceId, screenshotPath);
           resolve({ success: true, path: screenshotPath });
         }, 25);
 


### PR DESCRIPTION
## Summary

`ObserveScreen.ts` shrinks from 1447 → ~515 lines by lifting its concerns out into single-responsibility modules. The static mutable caches that made tests share state across cases are replaced with injectable stores plus module-singleton registries that preserve the existing static API for server resource handlers and the daemon.

**Decomposition**

- `cache/{ObserveResultCacheStore, FileSystemObserveCacheStore, ObserveCacheRegistry}`
- `screenshot/{ObserveScreenshotRecorder, ScreenshotStateRegistry}`
- `collectors/{HierarchyCollector, DeviceStateCollector}`
- `audits/{PerformanceAuditor, AccessibilityAuditor, AccessibilityStateDetector}`

**Structured errors (D)**

`ObserveResult.errors[]` holds `{phase, message, cause}` entries; the existing `.error` string stays derived for back-compat. The old `appendError` accumulator masked partial failures behind a semicolon-joined string; collectors now attribute each failure to its phase so consumers can distinguish "view hierarchy failed" from "back stack failed".

**Misc fixes uncovered along the way**

- `clearCache(deviceId)` actually deletes disk files (was memory-only, so disk would resurrect "cleared" entries on the next read).
- TTL eviction is consistent across both in-memory read paths (previously two methods had divergent policies).
- Cache tie-breaks favor latest insertion (matters when two puts land in the same millisecond).
- Android primary path parallelizes wakefulness + back-stack instead of running them serially (saves 10–30ms on the hot path).

## Test plan

- [x] All 4016 existing tests pass (`bun test`)
- [x] 114 new tests covering each new module
- [x] Lint clean (`turbo run lint`)
- [x] Build clean (`bun build.ts`)
- [x] External static API preserved (verified at 9 call sites in `src/server/`, `src/daemon/`, `src/utils/DeviceSessionManager.ts`)