### PR TITLE
fix(observe): snapshot cache file list synchronously to avoid clear+put race

### DIFF
--- a/src/features/observe/cache/FileSystemObserveCacheStore.ts
+++ b/src/features/observe/cache/FileSystemObserveCacheStore.ts
@@ -1,4 +1,4 @@
-import { mkdirSync } from "node:fs";
+import { mkdirSync, readdirSync } from "node:fs";
 import path from "path";
 import { readdirAsync, readFileAsync, statAsync, unlinkAsync, writeFileAsync } from "../../../utils/io";
 import { logger } from "../../../utils/logger";
@@ -232,23 +232,30 @@ export class FileSystemObserveCacheStore implements ObserveResultCacheStore {
   }
 
   private deleteDiskFilesMatching(predicate: (filename: string) => boolean): void {
-    // Fire-and-forget; matches the synchronous signature of the old clearCache while still cleaning disk state.
-    void (async () => {
-      try {
-        const files = await readdirAsync(this.cacheDir);
-        const matches = files.filter(predicate);
-        await Promise.all(
-          matches.map(async file => {
-            try {
-              await unlinkAsync(path.join(this.cacheDir, file));
-            } catch (error) {
-              logger.warn(`[OBSERVE_CACHE] Failed to delete cache file ${file}: ${error}`);
-            }
-          })
-        );
-      } catch (error) {
-        logger.warn(`[OBSERVE_CACHE] Failed to enumerate cache directory for cleanup: ${error}`);
-      }
-    })();
+    // Snapshot the file list synchronously before returning so a put() that
+    // races immediately after clear() cannot have its fresh file caught up in
+    // the deletion. New files written after clear() returns are not in the
+    // snapshot.
+    let matches: string[];
+    try {
+      matches = readdirSync(this.cacheDir).filter(predicate);
+    } catch (error) {
+      logger.warn(`[OBSERVE_CACHE] Failed to enumerate cache directory for cleanup: ${error}`);
+      return;
+    }
+
+    if (matches.length === 0) {
+      return;
+    }
+
+    void Promise.all(
+      matches.map(async file => {
+        try {
+          await unlinkAsync(path.join(this.cacheDir, file));
+        } catch (error) {
+          logger.warn(`[OBSERVE_CACHE] Failed to delete cache file ${file}: ${error}`);
+        }
+      })
+    );
   }
 }

--- a/test/features/observe/cache/FileSystemObserveCacheStore.test.ts
+++ b/test/features/observe/cache/FileSystemObserveCacheStore.test.ts
@@ -143,8 +143,12 @@ describe("FileSystemObserveCacheStore", function() {
     store.clear("device-1");
     await store.put("device-1", makeResult("fresh"));
 
-    // Drain microtasks/IO so any in-flight unlinks settle.
-    await new Promise(resolve => setTimeout(resolve, 50));
+    // Drain the microtask queue so any in-flight unlinks resolve. The snapshot
+    // taken inside clear() should NOT include the post-clear write, so the
+    // file count must settle at exactly one.
+    for (let i = 0; i < 20; i++) {
+      await new Promise(resolve => setImmediate(resolve));
+    }
 
     const files = readdirSync(cacheDir).filter(f => f.endsWith(".json"));
     expect(files.length).toBe(1);

--- a/test/features/observe/cache/FileSystemObserveCacheStore.test.ts
+++ b/test/features/observe/cache/FileSystemObserveCacheStore.test.ts
@@ -127,4 +127,30 @@ describe("FileSystemObserveCacheStore", function() {
     const result = await store.getMostRecent("device-1");
     expect(result).toBeUndefined();
   });
+
+  test("clear() followed immediately by put() does not delete the fresh file", async function() {
+    // Seed an existing entry so clear() has something to delete.
+    await store.put("device-1", makeResult("stale"));
+    expect(readdirSync(cacheDir).filter(f => f.endsWith(".json")).length).toBe(1);
+
+    // Advance the clock so the fresh write gets a different filename than the
+    // stale one — otherwise the keys collide and the cleanup deletes the
+    // overwritten file (a separate concern from the race).
+    timer.setCurrentTime(1_000_001);
+
+    // Race: clear() then immediate put(). The fire-and-forget cleanup must not
+    // race against the fresh write and delete it.
+    store.clear("device-1");
+    await store.put("device-1", makeResult("fresh"));
+
+    // Drain microtasks/IO so any in-flight unlinks settle.
+    await new Promise(resolve => setTimeout(resolve, 50));
+
+    const files = readdirSync(cacheDir).filter(f => f.endsWith(".json"));
+    expect(files.length).toBe(1);
+
+    // The surviving file must be the fresh one, not the stale one.
+    const restored = await store.getMostRecent("device-1");
+    expect(restored?.updatedAt).toBe("fresh");
+  });
 });


### PR DESCRIPTION
## Summary

Fix follow-up to #2149: \`FileSystemObserveCacheStore.clear()\` previously fired an async \`readdirAsync\` inside its cleanup IIFE, which left a window where a \`put()\` racing right after \`clear()\` could have its fresh file caught up in the deletion. If the directory read resolved after the new file was written, the cleanup would unlink that fresh cache file — leaving only the in-memory result and removing the disk fallback, so a restart or memory eviction could lose the latest observation.

Switch to \`readdirSync\` inside the synchronous portion of \`clear()\` so the file list is locked in before \`clear()\` returns. Subsequent \`put()\`s land on disk with filenames that aren't in the snapshot and survive.

Reported by Codex on [#2149](https://github.com/kaeawc/auto-mobile/pull/2149).

## Test plan

- [x] New test \`clear() followed immediately by put() does not delete the fresh file\` covers the race
- [x] All existing tests pass (\`bun test\`)
- [x] Lint clean