### PR TITLE
feat(ctrl-proxy): route Settings + PackageManager through accessibility service

### DIFF
--- a/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/CtrlProxy.kt
+++ b/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/CtrlProxy.kt
@@ -927,6 +927,15 @@ class CtrlProxy : AccessibilityService() {
                 isRecording = false
                 Log.d(TAG, "Recording stopped")
               },
+              onRequestInstalledPackages = { requestId, includeSystem, userId ->
+                performInstalledPackages(requestId, includeSystem, userId)
+              },
+              onRequestPackageInfo = { requestId, packageName, includePermissions, includeActivities, includeIntentFilters ->
+                performPackageInfo(requestId, packageName, includePermissions, includeActivities, includeIntentFilters)
+              },
+              onRequestLaunchIntent = { requestId, packageName ->
+                performLaunchIntent(requestId, packageName)
+              },
           )
       webSocketServer.start()
       Log.d(TAG, "WebSocket server started on port 8765")
@@ -3206,6 +3215,250 @@ class CtrlProxy : AccessibilityService() {
     }
   }
 
+  /**
+   * Enumerate installed packages via PackageManager.
+   * Returns over WebSocket so callers can avoid the per-call ADB round-trip cost
+   * of `pm list packages`.
+   */
+  private fun performInstalledPackages(requestId: String?, includeSystem: Boolean, userId: Int?) {
+    val startTime = System.currentTimeMillis()
+    // Why: android.os.UserHandle.myUserId() is technically @hide but stable; fall back
+    // to userSerialNumber via UserManager if reflection ever breaks.
+    val currentUserId =
+        try {
+          val cls = Class.forName("android.os.UserHandle")
+          (cls.getDeclaredMethod("myUserId").invoke(null) as Int)
+        } catch (e: Exception) {
+          0
+        }
+    if (userId != null && userId != currentUserId) {
+      kotlinx.coroutines.runBlocking {
+        broadcastInstalledPackagesResult(
+          requestId = requestId,
+          success = false,
+          userId = currentUserId,
+          packages = emptyList(),
+          error = "Requested userId=$userId differs from service userId=$currentUserId; ADB fallback required",
+          totalTimeMs = System.currentTimeMillis() - startTime,
+        )
+      }
+      return
+    }
+
+    try {
+      val infos =
+          if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            packageManager.getInstalledPackages(
+                android.content.pm.PackageManager.PackageInfoFlags.of(0L)
+            )
+          } else {
+            @Suppress("DEPRECATION") packageManager.getInstalledPackages(0)
+          }
+      val records = mutableListOf<dev.jasonpearson.automobile.protocol.InstalledPackageRecord>()
+      for (info in infos) {
+        val isSystem =
+            (info.applicationInfo?.flags ?: 0) and
+                (ApplicationInfo.FLAG_SYSTEM or ApplicationInfo.FLAG_UPDATED_SYSTEM_APP) != 0
+        if (!includeSystem && isSystem) continue
+        val versionCode =
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) info.longVersionCode
+            else @Suppress("DEPRECATION") info.versionCode.toLong()
+        records.add(
+            dev.jasonpearson.automobile.protocol.InstalledPackageRecord(
+                packageName = info.packageName,
+                isSystem = isSystem,
+                versionName = info.versionName,
+                versionCode = versionCode,
+            )
+        )
+      }
+      val totalTime = System.currentTimeMillis() - startTime
+      kotlinx.coroutines.runBlocking {
+        broadcastInstalledPackagesResult(
+          requestId = requestId,
+          success = true,
+          userId = currentUserId,
+          packages = records,
+          error = null,
+          totalTimeMs = totalTime,
+        )
+      }
+    } catch (e: Exception) {
+      Log.e(TAG, "performInstalledPackages failed", e)
+      kotlinx.coroutines.runBlocking {
+        broadcastInstalledPackagesResult(
+          requestId = requestId,
+          success = false,
+          userId = currentUserId,
+          packages = emptyList(),
+          error = "Failed to enumerate packages: ${e.message}",
+          totalTimeMs = System.currentTimeMillis() - startTime,
+        )
+      }
+    }
+  }
+
+  /** Read package metadata via PackageManager. */
+  private fun performPackageInfo(
+      requestId: String?,
+      packageName: String,
+      includePermissions: Boolean,
+      @Suppress("UNUSED_PARAMETER") includeActivities: Boolean,
+      @Suppress("UNUSED_PARAMETER") includeIntentFilters: Boolean,
+  ) {
+    val startTime = System.currentTimeMillis()
+    try {
+      val flags = if (includePermissions) android.content.pm.PackageManager.GET_PERMISSIONS else 0
+      val info =
+          if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            packageManager.getPackageInfo(
+                packageName,
+                android.content.pm.PackageManager.PackageInfoFlags.of(flags.toLong()),
+            )
+          } else {
+            @Suppress("DEPRECATION") packageManager.getPackageInfo(packageName, flags)
+          }
+
+      val appInfo = info.applicationInfo
+      val isSystem =
+          (appInfo?.flags ?: 0) and
+              (ApplicationInfo.FLAG_SYSTEM or ApplicationInfo.FLAG_UPDATED_SYSTEM_APP) != 0
+      val applicationLabel = appInfo?.let { packageManager.getApplicationLabel(it).toString() }
+      val versionCode =
+          if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) info.longVersionCode
+          else @Suppress("DEPRECATION") info.versionCode.toLong()
+      val installerPackage =
+          try {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+              packageManager.getInstallSourceInfo(packageName).installingPackageName
+            } else {
+              @Suppress("DEPRECATION") packageManager.getInstallerPackageName(packageName)
+            }
+          } catch (e: Exception) {
+            null
+          }
+      val allowBackup =
+          appInfo?.let { (it.flags and ApplicationInfo.FLAG_ALLOW_BACKUP) != 0 }
+      val requested = info.requestedPermissions?.toList().orEmpty()
+      val flagsArray = info.requestedPermissionsFlags
+      val granted = mutableMapOf<String, Boolean>()
+      if (includePermissions && flagsArray != null) {
+        for (i in requested.indices) {
+          val isGranted =
+              if (i < flagsArray.size) {
+                (flagsArray[i] and
+                    android.content.pm.PackageInfo.REQUESTED_PERMISSION_GRANTED) != 0
+              } else false
+          granted[requested[i]] = isGranted
+        }
+      }
+      val mainActivity =
+          try {
+            packageManager.getLaunchIntentForPackage(packageName)?.component?.flattenToShortString()
+          } catch (e: Exception) {
+            null
+          }
+
+      val totalTime = System.currentTimeMillis() - startTime
+      kotlinx.coroutines.runBlocking {
+        broadcastPackageInfoResult(
+          requestId = requestId,
+          success = true,
+          packageName = packageName,
+          isSystem = isSystem,
+          applicationLabel = applicationLabel,
+          versionName = info.versionName,
+          versionCode = versionCode,
+          installerPackage = installerPackage,
+          firstInstallTime = info.firstInstallTime,
+          lastUpdateTime = info.lastUpdateTime,
+          allowBackup = allowBackup,
+          requestedPermissions = requested,
+          grantedPermissions = granted,
+          mainActivity = mainActivity,
+          error = null,
+          totalTimeMs = totalTime,
+        )
+      }
+    } catch (e: android.content.pm.PackageManager.NameNotFoundException) {
+      kotlinx.coroutines.runBlocking {
+        broadcastPackageInfoResult(
+          requestId = requestId,
+          success = false,
+          packageName = packageName,
+          isSystem = false,
+          applicationLabel = null,
+          versionName = null,
+          versionCode = null,
+          installerPackage = null,
+          firstInstallTime = null,
+          lastUpdateTime = null,
+          allowBackup = null,
+          requestedPermissions = emptyList(),
+          grantedPermissions = emptyMap(),
+          mainActivity = null,
+          error = "Package not installed or not visible: $packageName",
+          totalTimeMs = System.currentTimeMillis() - startTime,
+        )
+      }
+    } catch (e: Exception) {
+      Log.e(TAG, "performPackageInfo failed for $packageName", e)
+      kotlinx.coroutines.runBlocking {
+        broadcastPackageInfoResult(
+          requestId = requestId,
+          success = false,
+          packageName = packageName,
+          isSystem = false,
+          applicationLabel = null,
+          versionName = null,
+          versionCode = null,
+          installerPackage = null,
+          firstInstallTime = null,
+          lastUpdateTime = null,
+          allowBackup = null,
+          requestedPermissions = emptyList(),
+          grantedPermissions = emptyMap(),
+          mainActivity = null,
+          error = "Failed to read package info: ${e.message}",
+          totalTimeMs = System.currentTimeMillis() - startTime,
+        )
+      }
+    }
+  }
+
+  /** Resolve the launcher activity component for a package. */
+  private fun performLaunchIntent(requestId: String?, packageName: String) {
+    val startTime = System.currentTimeMillis()
+    try {
+      val intent = packageManager.getLaunchIntentForPackage(packageName)
+      val component = intent?.component?.flattenToShortString()
+      val totalTime = System.currentTimeMillis() - startTime
+      val success = component != null
+      kotlinx.coroutines.runBlocking {
+        broadcastLaunchIntentResult(
+          requestId = requestId,
+          success = success,
+          packageName = packageName,
+          componentName = component,
+          error = if (!success) "No launch intent for $packageName" else null,
+          totalTimeMs = totalTime,
+        )
+      }
+    } catch (e: Exception) {
+      Log.e(TAG, "performLaunchIntent failed for $packageName", e)
+      kotlinx.coroutines.runBlocking {
+        broadcastLaunchIntentResult(
+          requestId = requestId,
+          success = false,
+          packageName = packageName,
+          componentName = null,
+          error = "Failed to resolve launch intent: ${e.message}",
+          totalTimeMs = System.currentTimeMillis() - startTime,
+        )
+      }
+    }
+  }
+
   /** Install a CA certificate via DevicePolicyManager (device owner only). */
   private fun performInstallCaCertificate(requestId: String?, certificate: String) {
     val startTime = System.currentTimeMillis()
@@ -3914,6 +4167,104 @@ class CtrlProxy : AccessibilityService() {
         .replace("\n", "\\n")
         .replace("\r", "\\r")
         .replace("\t", "\\t")
+  }
+
+  private suspend fun broadcastInstalledPackagesResult(
+      requestId: String?,
+      success: Boolean,
+      userId: Int,
+      packages: List<dev.jasonpearson.automobile.protocol.InstalledPackageRecord>,
+      error: String?,
+      totalTimeMs: Long,
+  ) {
+    if (!::webSocketServer.isInitialized || !webSocketServer.isRunning()) return
+    try {
+      webSocketServer.broadcast(
+          dev.jasonpearson.automobile.protocol.InstalledPackagesResult(
+              timestamp = System.currentTimeMillis(),
+              requestId = requestId,
+              success = success,
+              userId = userId,
+              packages = packages,
+              totalTimeMs = totalTimeMs,
+              error = error,
+          ),
+      )
+    } catch (e: Exception) {
+      Log.e(TAG, "Error broadcasting installed_packages_result", e)
+    }
+  }
+
+  private suspend fun broadcastPackageInfoResult(
+      requestId: String?,
+      success: Boolean,
+      packageName: String,
+      isSystem: Boolean,
+      applicationLabel: String?,
+      versionName: String?,
+      versionCode: Long?,
+      installerPackage: String?,
+      firstInstallTime: Long?,
+      lastUpdateTime: Long?,
+      allowBackup: Boolean?,
+      requestedPermissions: List<String>,
+      grantedPermissions: Map<String, Boolean>,
+      mainActivity: String?,
+      error: String?,
+      totalTimeMs: Long,
+  ) {
+    if (!::webSocketServer.isInitialized || !webSocketServer.isRunning()) return
+    try {
+      webSocketServer.broadcast(
+          dev.jasonpearson.automobile.protocol.PackageInfoResult(
+              timestamp = System.currentTimeMillis(),
+              requestId = requestId,
+              success = success,
+              packageName = packageName,
+              isSystem = isSystem,
+              applicationLabel = applicationLabel,
+              versionName = versionName,
+              versionCode = versionCode,
+              installerPackage = installerPackage,
+              firstInstallTime = firstInstallTime,
+              lastUpdateTime = lastUpdateTime,
+              allowBackup = allowBackup,
+              requestedPermissions = requestedPermissions,
+              grantedPermissions = grantedPermissions,
+              mainActivity = mainActivity,
+              totalTimeMs = totalTimeMs,
+              error = error,
+          ),
+      )
+    } catch (e: Exception) {
+      Log.e(TAG, "Error broadcasting package_info_result", e)
+    }
+  }
+
+  private suspend fun broadcastLaunchIntentResult(
+      requestId: String?,
+      success: Boolean,
+      packageName: String,
+      componentName: String?,
+      error: String?,
+      totalTimeMs: Long,
+  ) {
+    if (!::webSocketServer.isInitialized || !webSocketServer.isRunning()) return
+    try {
+      webSocketServer.broadcast(
+          dev.jasonpearson.automobile.protocol.LaunchIntentResult(
+              timestamp = System.currentTimeMillis(),
+              requestId = requestId,
+              success = success,
+              packageName = packageName,
+              componentName = componentName,
+              totalTimeMs = totalTimeMs,
+              error = error,
+          ),
+      )
+    } catch (e: Exception) {
+      Log.e(TAG, "Error broadcasting launch_intent_result", e)
+    }
   }
 
   /** Broadcast CA certificate result to WebSocket clients */

--- a/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/CtrlProxy.kt
+++ b/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/CtrlProxy.kt
@@ -940,8 +940,8 @@ class CtrlProxy : AccessibilityService() {
               onRequestInstalledPackages = { requestId, includeSystem, userId ->
                 performInstalledPackages(requestId, includeSystem, userId)
               },
-              onRequestPackageInfo = { requestId, packageName, includePermissions, includeActivities, includeIntentFilters ->
-                performPackageInfo(requestId, packageName, includePermissions, includeActivities, includeIntentFilters)
+              onRequestPackageInfo = { requestId, packageName, includePermissions ->
+                performPackageInfo(requestId, packageName, includePermissions)
               },
               onRequestLaunchIntent = { requestId, packageName ->
                 performLaunchIntent(requestId, packageName)
@@ -3513,8 +3513,6 @@ class CtrlProxy : AccessibilityService() {
       requestId: String?,
       packageName: String,
       includePermissions: Boolean,
-      @Suppress("UNUSED_PARAMETER") includeActivities: Boolean,
-      @Suppress("UNUSED_PARAMETER") includeIntentFilters: Boolean,
   ) {
     val startTime = System.currentTimeMillis()
     try {
@@ -4380,34 +4378,21 @@ class CtrlProxy : AccessibilityService() {
       error: String?,
       totalTimeMs: Long,
   ) {
-    if (!::webSocketServer.isInitialized || !webSocketServer.isRunning()) {
-      Log.d(TAG, "WebSocket server not running, skipping settings_get_result broadcast")
-      return
-    }
+    if (!::webSocketServer.isInitialized || !webSocketServer.isRunning()) return
     try {
-      webSocketServer.broadcastWithPerf { perfTiming ->
-        buildString {
-          append("""{"type":"settings_get_result","timestamp":${System.currentTimeMillis()}""")
-          if (requestId != null) {
-            append(""","requestId":"${escapeJsonString(requestId)}"""")
-          }
-          append(""","success":$success""")
-          append(""","namespace":"${escapeJsonString(namespace)}"""")
-          append(""","key":"${escapeJsonString(key)}"""")
-          append(""","found":$found""")
-          append(""","totalTimeMs":$totalTimeMs""")
-          if (value != null) {
-            append(""","value":"${escapeJsonString(value)}"""")
-          }
-          if (error != null) {
-            append(""","error":"${escapeJsonString(error)}"""")
-          }
-          if (perfTiming != null) {
-            append(""","perfTiming":$perfTiming""")
-          }
-          append("}")
-        }
-      }
+      webSocketServer.broadcast(
+          dev.jasonpearson.automobile.protocol.SettingsGetResult(
+              timestamp = System.currentTimeMillis(),
+              requestId = requestId,
+              success = success,
+              namespace = namespace,
+              key = key,
+              value = value,
+              found = found,
+              totalTimeMs = totalTimeMs,
+              error = error,
+          )
+      )
     } catch (e: Exception) {
       Log.e(TAG, "Error broadcasting settings_get_result", e)
     }
@@ -4421,30 +4406,19 @@ class CtrlProxy : AccessibilityService() {
       error: String?,
       totalTimeMs: Long,
   ) {
-    if (!::webSocketServer.isInitialized || !webSocketServer.isRunning()) {
-      Log.d(TAG, "WebSocket server not running, skipping settings_put_result broadcast")
-      return
-    }
+    if (!::webSocketServer.isInitialized || !webSocketServer.isRunning()) return
     try {
-      webSocketServer.broadcastWithPerf { perfTiming ->
-        buildString {
-          append("""{"type":"settings_put_result","timestamp":${System.currentTimeMillis()}""")
-          if (requestId != null) {
-            append(""","requestId":"${escapeJsonString(requestId)}"""")
-          }
-          append(""","success":$success""")
-          append(""","namespace":"${escapeJsonString(namespace)}"""")
-          append(""","key":"${escapeJsonString(key)}"""")
-          append(""","totalTimeMs":$totalTimeMs""")
-          if (error != null) {
-            append(""","error":"${escapeJsonString(error)}"""")
-          }
-          if (perfTiming != null) {
-            append(""","perfTiming":$perfTiming""")
-          }
-          append("}")
-        }
-      }
+      webSocketServer.broadcast(
+          dev.jasonpearson.automobile.protocol.SettingsPutResult(
+              timestamp = System.currentTimeMillis(),
+              requestId = requestId,
+              success = success,
+              namespace = namespace,
+              key = key,
+              totalTimeMs = totalTimeMs,
+              error = error,
+          )
+      )
     } catch (e: Exception) {
       Log.e(TAG, "Error broadcasting settings_put_result", e)
     }
@@ -4458,39 +4432,19 @@ class CtrlProxy : AccessibilityService() {
       error: String?,
       totalTimeMs: Long,
   ) {
-    if (!::webSocketServer.isInitialized || !webSocketServer.isRunning()) {
-      Log.d(TAG, "WebSocket server not running, skipping settings_list_result broadcast")
-      return
-    }
+    if (!::webSocketServer.isInitialized || !webSocketServer.isRunning()) return
     try {
-      webSocketServer.broadcastWithPerf { perfTiming ->
-        buildString {
-          append("""{"type":"settings_list_result","timestamp":${System.currentTimeMillis()}""")
-          if (requestId != null) {
-            append(""","requestId":"${escapeJsonString(requestId)}"""")
-          }
-          append(""","success":$success""")
-          append(""","namespace":"${escapeJsonString(namespace)}"""")
-          append(""","totalTimeMs":$totalTimeMs""")
-          if (entries != null) {
-            append(""","entries":{""")
-            var first = true
-            for ((k, v) in entries) {
-              if (!first) append(",")
-              first = false
-              append("\"${escapeJsonString(k)}\":\"${escapeJsonString(v)}\"")
-            }
-            append("}")
-          }
-          if (error != null) {
-            append(""","error":"${escapeJsonString(error)}"""")
-          }
-          if (perfTiming != null) {
-            append(""","perfTiming":$perfTiming""")
-          }
-          append("}")
-        }
-      }
+      webSocketServer.broadcast(
+          dev.jasonpearson.automobile.protocol.SettingsListResult(
+              timestamp = System.currentTimeMillis(),
+              requestId = requestId,
+              success = success,
+              namespace = namespace,
+              entries = entries,
+              totalTimeMs = totalTimeMs,
+              error = error,
+          )
+      )
     } catch (e: Exception) {
       Log.e(TAG, "Error broadcasting settings_list_result", e)
     }

--- a/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/CtrlProxy.kt
+++ b/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/CtrlProxy.kt
@@ -17,6 +17,7 @@ import android.graphics.Bitmap
 import android.graphics.Path
 import android.graphics.Rect
 import android.os.Build
+import android.provider.Settings
 import android.os.PowerManager
 import android.util.Base64
 import android.util.DisplayMetrics
@@ -926,6 +927,15 @@ class CtrlProxy : AccessibilityService() {
               onStopRecording = {
                 isRecording = false
                 Log.d(TAG, "Recording stopped")
+              },
+              onRequestSettingsGet = { requestId, namespace, key ->
+                performSettingsRead(requestId, namespace, key)
+              },
+              onRequestSettingsPut = { requestId, namespace, key, value, valueType ->
+                performSettingsWrite(requestId, namespace, key, value, valueType)
+              },
+              onRequestSettingsList = { requestId, namespace ->
+                performSettingsList(requestId, namespace)
               },
           )
       webSocketServer.start()
@@ -3206,6 +3216,206 @@ class CtrlProxy : AccessibilityService() {
     }
   }
 
+  private fun performSettingsRead(requestId: String?, namespace: String, key: String) {
+    val startTime = System.currentTimeMillis()
+    Log.d(TAG, "performSettingsRead: namespace=$namespace key=$key")
+    perfProvider.serial("performSettingsRead")
+
+    var success = false
+    var value: String? = null
+    var found = false
+    var error: String? = null
+
+    try {
+      perfProvider.startOperation("readSetting")
+      value = when (namespace) {
+        "system" -> Settings.System.getString(contentResolver, key)
+        "secure" -> Settings.Secure.getString(contentResolver, key)
+        "global" -> Settings.Global.getString(contentResolver, key)
+        else -> {
+          error = "Unknown namespace: $namespace"
+          null
+        }
+      }
+      perfProvider.endOperation("readSetting")
+      if (error == null) {
+        success = true
+        found = value != null
+      }
+    } catch (e: SecurityException) {
+      // Why: surface permission errors cleanly so the TS caller can fall back to ADB
+      error = "SecurityException: ${e.message}"
+      Log.w(TAG, "Settings read denied: $namespace/$key", e)
+    } catch (e: Exception) {
+      error = "Read failed: ${e.message}"
+      Log.e(TAG, "Settings read failed: $namespace/$key", e)
+    } finally {
+      perfProvider.end()
+      val totalTime = System.currentTimeMillis() - startTime
+      kotlinx.coroutines.runBlocking {
+        broadcastSettingsGetResult(requestId, namespace, key, success, value, found, error, totalTime)
+      }
+    }
+  }
+
+  private fun performSettingsWrite(
+      requestId: String?,
+      namespace: String,
+      key: String,
+      value: String?,
+      valueType: String,
+  ) {
+    val startTime = System.currentTimeMillis()
+    Log.d(TAG, "performSettingsWrite: namespace=$namespace key=$key valueType=$valueType")
+    perfProvider.serial("performSettingsWrite")
+
+    var success = false
+    var error: String? = null
+
+    try {
+      perfProvider.startOperation("writeSetting")
+      if (value == null) {
+        success = writeSettingString(namespace, key, null)
+      } else {
+        success = when (valueType) {
+          "int" -> {
+            val intVal = value.toIntOrNull()
+            if (intVal == null) {
+              error = "Invalid int value: $value"
+              false
+            } else {
+              writeSettingInt(namespace, key, intVal)
+            }
+          }
+          "long" -> {
+            val longVal = value.toLongOrNull()
+            if (longVal == null) {
+              error = "Invalid long value: $value"
+              false
+            } else {
+              writeSettingLong(namespace, key, longVal)
+            }
+          }
+          "float" -> {
+            val floatVal = value.toFloatOrNull()
+            if (floatVal == null) {
+              error = "Invalid float value: $value"
+              false
+            } else {
+              writeSettingFloat(namespace, key, floatVal)
+            }
+          }
+          else -> writeSettingString(namespace, key, value)
+        }
+      }
+      perfProvider.endOperation("writeSetting")
+      if (!success && error == null) {
+        error = "Unknown namespace: $namespace"
+      }
+    } catch (e: SecurityException) {
+      // Why: writes to Settings.System require WRITE_SETTINGS; Secure/Global require system app.
+      // Surface SecurityException so the TS client can fall back to ADB instead of crashing.
+      error = "SecurityException: ${e.message}"
+      Log.w(TAG, "Settings write denied: $namespace/$key", e)
+    } catch (e: Exception) {
+      error = "Write failed: ${e.message}"
+      Log.e(TAG, "Settings write failed: $namespace/$key", e)
+    } finally {
+      perfProvider.end()
+      val totalTime = System.currentTimeMillis() - startTime
+      kotlinx.coroutines.runBlocking {
+        broadcastSettingsPutResult(requestId, namespace, key, success, error, totalTime)
+      }
+    }
+  }
+
+  private fun performSettingsList(requestId: String?, namespace: String) {
+    val startTime = System.currentTimeMillis()
+    Log.d(TAG, "performSettingsList: namespace=$namespace")
+    perfProvider.serial("performSettingsList")
+
+    var success = false
+    var entries: Map<String, String>? = null
+    var error: String? = null
+
+    try {
+      perfProvider.startOperation("listSettings")
+      val uri = when (namespace) {
+        "system" -> Settings.System.CONTENT_URI
+        "secure" -> Settings.Secure.CONTENT_URI
+        "global" -> Settings.Global.CONTENT_URI
+        else -> null
+      }
+      if (uri == null) {
+        error = "Unknown namespace: $namespace"
+      } else {
+        val map = HashMap<String, String>()
+        contentResolver.query(uri, arrayOf("name", "value"), null, null, null)?.use { cursor ->
+          val nameIdx = cursor.getColumnIndex("name")
+          val valueIdx = cursor.getColumnIndex("value")
+          if (nameIdx >= 0 && valueIdx >= 0) {
+            while (cursor.moveToNext()) {
+              val name = cursor.getString(nameIdx) ?: continue
+              val v = cursor.getString(valueIdx) ?: ""
+              map[name] = v
+            }
+          }
+        }
+        entries = map
+        success = true
+      }
+      perfProvider.endOperation("listSettings")
+    } catch (e: SecurityException) {
+      error = "SecurityException: ${e.message}"
+      Log.w(TAG, "Settings list denied: $namespace", e)
+    } catch (e: Exception) {
+      error = "List failed: ${e.message}"
+      Log.e(TAG, "Settings list failed: $namespace", e)
+    } finally {
+      perfProvider.end()
+      val totalTime = System.currentTimeMillis() - startTime
+      kotlinx.coroutines.runBlocking {
+        broadcastSettingsListResult(requestId, namespace, success, entries, error, totalTime)
+      }
+    }
+  }
+
+  private fun writeSettingString(namespace: String, key: String, value: String?): Boolean {
+    return when (namespace) {
+      "system" -> Settings.System.putString(contentResolver, key, value)
+      "secure" -> Settings.Secure.putString(contentResolver, key, value)
+      "global" -> Settings.Global.putString(contentResolver, key, value)
+      else -> false
+    }
+  }
+
+  private fun writeSettingInt(namespace: String, key: String, value: Int): Boolean {
+    return when (namespace) {
+      "system" -> Settings.System.putInt(contentResolver, key, value)
+      "secure" -> Settings.Secure.putInt(contentResolver, key, value)
+      "global" -> Settings.Global.putInt(contentResolver, key, value)
+      else -> false
+    }
+  }
+
+  private fun writeSettingLong(namespace: String, key: String, value: Long): Boolean {
+    return when (namespace) {
+      "system" -> Settings.System.putLong(contentResolver, key, value)
+      "secure" -> Settings.Secure.putLong(contentResolver, key, value)
+      "global" -> Settings.Global.putLong(contentResolver, key, value)
+      else -> false
+    }
+  }
+
+  private fun writeSettingFloat(namespace: String, key: String, value: Float): Boolean {
+    return when (namespace) {
+      "system" -> Settings.System.putFloat(contentResolver, key, value)
+      "secure" -> Settings.Secure.putFloat(contentResolver, key, value)
+      "global" -> Settings.Global.putFloat(contentResolver, key, value)
+      else -> false
+    }
+  }
+
   /** Install a CA certificate via DevicePolicyManager (device owner only). */
   private fun performInstallCaCertificate(requestId: String?, certificate: String) {
     val startTime = System.currentTimeMillis()
@@ -3904,6 +4114,132 @@ class CtrlProxy : AccessibilityService() {
       Log.d(TAG, "Broadcasted clipboard result to ${webSocketServer.getConnectionCount()} clients")
     } catch (e: Exception) {
       Log.e(TAG, "Error broadcasting clipboard result", e)
+    }
+  }
+
+  private suspend fun broadcastSettingsGetResult(
+      requestId: String?,
+      namespace: String,
+      key: String,
+      success: Boolean,
+      value: String?,
+      found: Boolean,
+      error: String?,
+      totalTimeMs: Long,
+  ) {
+    if (!::webSocketServer.isInitialized || !webSocketServer.isRunning()) {
+      Log.d(TAG, "WebSocket server not running, skipping settings_get_result broadcast")
+      return
+    }
+    try {
+      webSocketServer.broadcastWithPerf { perfTiming ->
+        buildString {
+          append("""{"type":"settings_get_result","timestamp":${System.currentTimeMillis()}""")
+          if (requestId != null) {
+            append(""","requestId":"${escapeJsonString(requestId)}"""")
+          }
+          append(""","success":$success""")
+          append(""","namespace":"${escapeJsonString(namespace)}"""")
+          append(""","key":"${escapeJsonString(key)}"""")
+          append(""","found":$found""")
+          append(""","totalTimeMs":$totalTimeMs""")
+          if (value != null) {
+            append(""","value":"${escapeJsonString(value)}"""")
+          }
+          if (error != null) {
+            append(""","error":"${escapeJsonString(error)}"""")
+          }
+          if (perfTiming != null) {
+            append(""","perfTiming":$perfTiming""")
+          }
+          append("}")
+        }
+      }
+    } catch (e: Exception) {
+      Log.e(TAG, "Error broadcasting settings_get_result", e)
+    }
+  }
+
+  private suspend fun broadcastSettingsPutResult(
+      requestId: String?,
+      namespace: String,
+      key: String,
+      success: Boolean,
+      error: String?,
+      totalTimeMs: Long,
+  ) {
+    if (!::webSocketServer.isInitialized || !webSocketServer.isRunning()) {
+      Log.d(TAG, "WebSocket server not running, skipping settings_put_result broadcast")
+      return
+    }
+    try {
+      webSocketServer.broadcastWithPerf { perfTiming ->
+        buildString {
+          append("""{"type":"settings_put_result","timestamp":${System.currentTimeMillis()}""")
+          if (requestId != null) {
+            append(""","requestId":"${escapeJsonString(requestId)}"""")
+          }
+          append(""","success":$success""")
+          append(""","namespace":"${escapeJsonString(namespace)}"""")
+          append(""","key":"${escapeJsonString(key)}"""")
+          append(""","totalTimeMs":$totalTimeMs""")
+          if (error != null) {
+            append(""","error":"${escapeJsonString(error)}"""")
+          }
+          if (perfTiming != null) {
+            append(""","perfTiming":$perfTiming""")
+          }
+          append("}")
+        }
+      }
+    } catch (e: Exception) {
+      Log.e(TAG, "Error broadcasting settings_put_result", e)
+    }
+  }
+
+  private suspend fun broadcastSettingsListResult(
+      requestId: String?,
+      namespace: String,
+      success: Boolean,
+      entries: Map<String, String>?,
+      error: String?,
+      totalTimeMs: Long,
+  ) {
+    if (!::webSocketServer.isInitialized || !webSocketServer.isRunning()) {
+      Log.d(TAG, "WebSocket server not running, skipping settings_list_result broadcast")
+      return
+    }
+    try {
+      webSocketServer.broadcastWithPerf { perfTiming ->
+        buildString {
+          append("""{"type":"settings_list_result","timestamp":${System.currentTimeMillis()}""")
+          if (requestId != null) {
+            append(""","requestId":"${escapeJsonString(requestId)}"""")
+          }
+          append(""","success":$success""")
+          append(""","namespace":"${escapeJsonString(namespace)}"""")
+          append(""","totalTimeMs":$totalTimeMs""")
+          if (entries != null) {
+            append(""","entries":{""")
+            var first = true
+            for ((k, v) in entries) {
+              if (!first) append(",")
+              first = false
+              append("\"${escapeJsonString(k)}\":\"${escapeJsonString(v)}\"")
+            }
+            append("}")
+          }
+          if (error != null) {
+            append(""","error":"${escapeJsonString(error)}"""")
+          }
+          if (perfTiming != null) {
+            append(""","perfTiming":$perfTiming""")
+          }
+          append("}")
+        }
+      }
+    } catch (e: Exception) {
+      Log.e(TAG, "Error broadcasting settings_list_result", e)
     }
   }
 

--- a/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/WebSocketServer.kt
+++ b/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/WebSocketServer.kt
@@ -212,6 +212,16 @@ class WebSocketServer(
         null,
     private val onStartRecording: (() -> Unit)? = null,
     private val onStopRecording: (() -> Unit)? = null,
+    // Package manager query callbacks
+    private val onRequestInstalledPackages:
+        ((requestId: String?, includeSystem: Boolean, userId: Int?) -> Unit)? =
+        null,
+    private val onRequestPackageInfo:
+        ((requestId: String?, packageName: String, includePermissions: Boolean, includeActivities: Boolean, includeIntentFilters: Boolean) -> Unit)? =
+        null,
+    private val onRequestLaunchIntent:
+        ((requestId: String?, packageName: String) -> Unit)? =
+        null,
 ) {
   companion object {
     private const val TAG = "WebSocketServer"
@@ -875,6 +885,39 @@ class WebSocketServer(
         "stop_recording" -> {
           Log.d(TAG, "Received stop_recording request")
           onStopRecording?.invoke()
+        }
+        "request_installed_packages" -> {
+          Log.d(TAG, "Received request_installed_packages (requestId: ${request.requestId})")
+          try {
+            val parsed = protocolJson.decodeFromString<RequestInstalledPackages>(message)
+            onRequestInstalledPackages?.invoke(parsed.requestId, parsed.includeSystem, parsed.userId)
+          } catch (e: Exception) {
+            Log.w(TAG, "Failed to parse request_installed_packages: ${e.message}")
+          }
+        }
+        "request_package_info" -> {
+          Log.d(TAG, "Received request_package_info (requestId: ${request.requestId})")
+          try {
+            val parsed = protocolJson.decodeFromString<RequestPackageInfo>(message)
+            onRequestPackageInfo?.invoke(
+              parsed.requestId,
+              parsed.packageName,
+              parsed.includePermissions,
+              parsed.includeActivities,
+              parsed.includeIntentFilters,
+            )
+          } catch (e: Exception) {
+            Log.w(TAG, "Failed to parse request_package_info: ${e.message}")
+          }
+        }
+        "request_launch_intent" -> {
+          Log.d(TAG, "Received request_launch_intent (requestId: ${request.requestId})")
+          try {
+            val parsed = protocolJson.decodeFromString<RequestLaunchIntent>(message)
+            onRequestLaunchIntent?.invoke(parsed.requestId, parsed.packageName)
+          } catch (e: Exception) {
+            Log.w(TAG, "Failed to parse request_launch_intent: ${e.message}")
+          }
         }
         else -> {
           Log.d(TAG, "Unknown message type: ${request.type}")

--- a/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/WebSocketServer.kt
+++ b/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/WebSocketServer.kt
@@ -84,6 +84,11 @@ data class LegacyWebSocketRequest(
     // Storage inspection parameters
     val packageName: String? = null,
     val fileName: String? = null,
+    // Settings parameters
+    val namespace: String? = null,
+    val key: String? = null,
+    val value: String? = null,
+    val valueType: String? = null,
 )
 
 /** Type alias for backward compatibility */
@@ -212,6 +217,16 @@ class WebSocketServer(
         null,
     private val onStartRecording: (() -> Unit)? = null,
     private val onStopRecording: (() -> Unit)? = null,
+    // Settings callbacks
+    private val onRequestSettingsGet:
+        ((requestId: String?, namespace: String, key: String) -> Unit)? =
+        null,
+    private val onRequestSettingsPut:
+        ((requestId: String?, namespace: String, key: String, value: String?, valueType: String) -> Unit)? =
+        null,
+    private val onRequestSettingsList:
+        ((requestId: String?, namespace: String) -> Unit)? =
+        null,
 ) {
   companion object {
     private const val TAG = "WebSocketServer"
@@ -866,6 +881,37 @@ class WebSocketServer(
             onClearPreferences?.invoke(request.requestId, packageName, fileName)
           } else {
             Log.w(TAG, "clear_preferences request missing packageName or fileName")
+          }
+        }
+        "request_settings_get" -> {
+          Log.d(TAG, "Received request_settings_get (requestId: ${request.requestId})")
+          val namespace = request.namespace
+          val key = request.key
+          if (!namespace.isNullOrBlank() && !key.isNullOrBlank()) {
+            onRequestSettingsGet?.invoke(request.requestId, namespace, key)
+          } else {
+            Log.w(TAG, "request_settings_get missing namespace or key")
+          }
+        }
+        "request_settings_put" -> {
+          Log.d(TAG, "Received request_settings_put (requestId: ${request.requestId})")
+          val namespace = request.namespace
+          val key = request.key
+          val value = request.value
+          val valueType = request.valueType ?: "string"
+          if (!namespace.isNullOrBlank() && !key.isNullOrBlank()) {
+            onRequestSettingsPut?.invoke(request.requestId, namespace, key, value, valueType)
+          } else {
+            Log.w(TAG, "request_settings_put missing namespace or key")
+          }
+        }
+        "request_settings_list" -> {
+          Log.d(TAG, "Received request_settings_list (requestId: ${request.requestId})")
+          val namespace = request.namespace
+          if (!namespace.isNullOrBlank()) {
+            onRequestSettingsList?.invoke(request.requestId, namespace)
+          } else {
+            Log.w(TAG, "request_settings_list missing namespace")
           }
         }
         "start_recording" -> {

--- a/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/WebSocketServer.kt
+++ b/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/WebSocketServer.kt
@@ -84,8 +84,6 @@ data class LegacyWebSocketRequest(
     // Storage inspection parameters
     val packageName: String? = null,
     val fileName: String? = null,
-    // Settings parameters
-    val namespace: String? = null,
     val key: String? = null,
     val value: String? = null,
     val valueType: String? = null,
@@ -232,7 +230,7 @@ class WebSocketServer(
         ((requestId: String?, includeSystem: Boolean, userId: Int?) -> Unit)? =
         null,
     private val onRequestPackageInfo:
-        ((requestId: String?, packageName: String, includePermissions: Boolean, includeActivities: Boolean, includeIntentFilters: Boolean) -> Unit)? =
+        ((requestId: String?, packageName: String, includePermissions: Boolean) -> Unit)? =
         null,
     private val onRequestLaunchIntent:
         ((requestId: String?, packageName: String) -> Unit)? =
@@ -895,33 +893,35 @@ class WebSocketServer(
         }
         "request_settings_get" -> {
           Log.d(TAG, "Received request_settings_get (requestId: ${request.requestId})")
-          val namespace = request.namespace
-          val key = request.key
-          if (!namespace.isNullOrBlank() && !key.isNullOrBlank()) {
-            onRequestSettingsGet?.invoke(request.requestId, namespace, key)
-          } else {
-            Log.w(TAG, "request_settings_get missing namespace or key")
+          try {
+            val parsed = protocolJson.decodeFromString<RequestSettingsGet>(message)
+            onRequestSettingsGet?.invoke(parsed.requestId, parsed.namespace, parsed.key)
+          } catch (e: Exception) {
+            Log.w(TAG, "Failed to parse request_settings_get: ${e.message}")
           }
         }
         "request_settings_put" -> {
           Log.d(TAG, "Received request_settings_put (requestId: ${request.requestId})")
-          val namespace = request.namespace
-          val key = request.key
-          val value = request.value
-          val valueType = request.valueType ?: "string"
-          if (!namespace.isNullOrBlank() && !key.isNullOrBlank()) {
-            onRequestSettingsPut?.invoke(request.requestId, namespace, key, value, valueType)
-          } else {
-            Log.w(TAG, "request_settings_put missing namespace or key")
+          try {
+            val parsed = protocolJson.decodeFromString<RequestSettingsPut>(message)
+            onRequestSettingsPut?.invoke(
+              parsed.requestId,
+              parsed.namespace,
+              parsed.key,
+              parsed.value,
+              parsed.valueType,
+            )
+          } catch (e: Exception) {
+            Log.w(TAG, "Failed to parse request_settings_put: ${e.message}")
           }
         }
         "request_settings_list" -> {
           Log.d(TAG, "Received request_settings_list (requestId: ${request.requestId})")
-          val namespace = request.namespace
-          if (!namespace.isNullOrBlank()) {
-            onRequestSettingsList?.invoke(request.requestId, namespace)
-          } else {
-            Log.w(TAG, "request_settings_list missing namespace")
+          try {
+            val parsed = protocolJson.decodeFromString<RequestSettingsList>(message)
+            onRequestSettingsList?.invoke(parsed.requestId, parsed.namespace)
+          } catch (e: Exception) {
+            Log.w(TAG, "Failed to parse request_settings_list: ${e.message}")
           }
         }
         "start_recording" -> {
@@ -949,8 +949,6 @@ class WebSocketServer(
               parsed.requestId,
               parsed.packageName,
               parsed.includePermissions,
-              parsed.includeActivities,
-              parsed.includeIntentFilters,
             )
           } catch (e: Exception) {
             Log.w(TAG, "Failed to parse request_package_info: ${e.message}")

--- a/android/protocol/src/main/kotlin/dev/jasonpearson/automobile/protocol/WebSocketRequest.kt
+++ b/android/protocol/src/main/kotlin/dev/jasonpearson/automobile/protocol/WebSocketRequest.kt
@@ -431,8 +431,6 @@ data class RequestPackageInfo(
   override val requestId: String? = null,
   val packageName: String,
   val includePermissions: Boolean = true,
-  val includeActivities: Boolean = false,
-  val includeIntentFilters: Boolean = false,
 ) : WebSocketRequest()
 
 @Serializable

--- a/android/protocol/src/main/kotlin/dev/jasonpearson/automobile/protocol/WebSocketRequest.kt
+++ b/android/protocol/src/main/kotlin/dev/jasonpearson/automobile/protocol/WebSocketRequest.kt
@@ -383,3 +383,32 @@ data class SetNetworkErrorSimulation(
   val limit: Int? = null,
   val expiresAtEpochMs: Long? = null,
 ) : WebSocketRequest()
+
+// =============================================================================
+// Package Manager Requests
+// =============================================================================
+
+@Serializable
+@SerialName("request_installed_packages")
+data class RequestInstalledPackages(
+  override val requestId: String? = null,
+  val includeSystem: Boolean = true,
+  val userId: Int? = null,
+) : WebSocketRequest()
+
+@Serializable
+@SerialName("request_package_info")
+data class RequestPackageInfo(
+  override val requestId: String? = null,
+  val packageName: String,
+  val includePermissions: Boolean = true,
+  val includeActivities: Boolean = false,
+  val includeIntentFilters: Boolean = false,
+) : WebSocketRequest()
+
+@Serializable
+@SerialName("request_launch_intent")
+data class RequestLaunchIntent(
+  override val requestId: String? = null,
+  val packageName: String,
+) : WebSocketRequest()

--- a/android/protocol/src/main/kotlin/dev/jasonpearson/automobile/protocol/WebSocketRequest.kt
+++ b/android/protocol/src/main/kotlin/dev/jasonpearson/automobile/protocol/WebSocketRequest.kt
@@ -178,6 +178,35 @@ data class RequestClipboard(
 ) : WebSocketRequest()
 
 // =============================================================================
+// Settings Requests
+// =============================================================================
+
+@Serializable
+@SerialName("request_settings_get")
+data class RequestSettingsGet(
+  override val requestId: String? = null,
+  val namespace: String, // "system" | "secure" | "global"
+  val key: String,
+) : WebSocketRequest()
+
+@Serializable
+@SerialName("request_settings_put")
+data class RequestSettingsPut(
+  override val requestId: String? = null,
+  val namespace: String, // "system" | "secure" | "global"
+  val key: String,
+  val value: String? = null, // null = delete
+  val valueType: String = "string", // "string" | "int" | "long" | "float"
+) : WebSocketRequest()
+
+@Serializable
+@SerialName("request_settings_list")
+data class RequestSettingsList(
+  override val requestId: String? = null,
+  val namespace: String,
+) : WebSocketRequest()
+
+// =============================================================================
 // Certificate Requests
 // =============================================================================
 

--- a/android/protocol/src/main/kotlin/dev/jasonpearson/automobile/protocol/WebSocketResponse.kt
+++ b/android/protocol/src/main/kotlin/dev/jasonpearson/automobile/protocol/WebSocketResponse.kt
@@ -631,3 +631,61 @@ data class ClearPreferencesResult(
   val fileName: String,
   val error: String? = null,
 ) : WebSocketResponse()
+
+// =============================================================================
+// Package Manager Results
+// =============================================================================
+
+@Serializable
+data class InstalledPackageRecord(
+  val packageName: String,
+  val isSystem: Boolean,
+  val versionName: String? = null,
+  val versionCode: Long? = null,
+)
+
+@Serializable
+@SerialName("installed_packages_result")
+data class InstalledPackagesResult(
+  override val timestamp: Long,
+  val requestId: String? = null,
+  val success: Boolean,
+  val userId: Int,
+  val packages: List<InstalledPackageRecord> = emptyList(),
+  val totalTimeMs: Long,
+  val error: String? = null,
+) : WebSocketResponse()
+
+@Serializable
+@SerialName("package_info_result")
+data class PackageInfoResult(
+  override val timestamp: Long,
+  val requestId: String? = null,
+  val success: Boolean,
+  val packageName: String,
+  val isSystem: Boolean = false,
+  val applicationLabel: String? = null,
+  val versionName: String? = null,
+  val versionCode: Long? = null,
+  val installerPackage: String? = null,
+  val firstInstallTime: Long? = null,
+  val lastUpdateTime: Long? = null,
+  val allowBackup: Boolean? = null,
+  val requestedPermissions: List<String> = emptyList(),
+  val grantedPermissions: Map<String, Boolean> = emptyMap(),
+  val mainActivity: String? = null,
+  val totalTimeMs: Long,
+  val error: String? = null,
+) : WebSocketResponse()
+
+@Serializable
+@SerialName("launch_intent_result")
+data class LaunchIntentResult(
+  override val timestamp: Long,
+  val requestId: String? = null,
+  val success: Boolean,
+  val packageName: String,
+  val componentName: String? = null,
+  val totalTimeMs: Long,
+  val error: String? = null,
+) : WebSocketResponse()

--- a/android/protocol/src/main/kotlin/dev/jasonpearson/automobile/protocol/WebSocketResponse.kt
+++ b/android/protocol/src/main/kotlin/dev/jasonpearson/automobile/protocol/WebSocketResponse.kt
@@ -401,6 +401,51 @@ data class ClipboardResult(
 ) : WebSocketResponse()
 
 // =============================================================================
+// Settings Results
+// =============================================================================
+
+@Serializable
+@SerialName("settings_get_result")
+data class SettingsGetResult(
+  override val timestamp: Long,
+  val requestId: String? = null,
+  val success: Boolean,
+  val namespace: String,
+  val key: String,
+  val value: String? = null,
+  val found: Boolean = false,
+  val totalTimeMs: Long,
+  val error: String? = null,
+  val perfTiming: String? = null,
+) : WebSocketResponse()
+
+@Serializable
+@SerialName("settings_put_result")
+data class SettingsPutResult(
+  override val timestamp: Long,
+  val requestId: String? = null,
+  val success: Boolean,
+  val namespace: String,
+  val key: String,
+  val totalTimeMs: Long,
+  val error: String? = null,
+  val perfTiming: String? = null,
+) : WebSocketResponse()
+
+@Serializable
+@SerialName("settings_list_result")
+data class SettingsListResult(
+  override val timestamp: Long,
+  val requestId: String? = null,
+  val success: Boolean,
+  val namespace: String,
+  val entries: Map<String, String>? = null,
+  val totalTimeMs: Long,
+  val error: String? = null,
+  val perfTiming: String? = null,
+) : WebSocketResponse()
+
+// =============================================================================
 // Certificate Result
 // =============================================================================
 

--- a/android/protocol/src/test/kotlin/dev/jasonpearson/automobile/protocol/WebSocketRequestTest.kt
+++ b/android/protocol/src/test/kotlin/dev/jasonpearson/automobile/protocol/WebSocketRequestTest.kt
@@ -186,4 +186,51 @@ class WebSocketRequestTest {
     assertEquals("com.example.app", request.packageName)
     assertEquals("settings.xml", request.fileName)
   }
+
+  @Test
+  fun `deserialize request_settings_get`() {
+    val message = """{"type":"request_settings_get","requestId":"sg-1","namespace":"system","key":"user_rotation"}"""
+    val request = json.decodeFromString<WebSocketRequest>(message)
+
+    assertIs<RequestSettingsGet>(request)
+    assertEquals("sg-1", request.requestId)
+    assertEquals("system", request.namespace)
+    assertEquals("user_rotation", request.key)
+  }
+
+  @Test
+  fun `deserialize request_settings_put with int value`() {
+    val message = """{"type":"request_settings_put","requestId":"sp-1","namespace":"system","key":"user_rotation","value":"1","valueType":"int"}"""
+    val request = json.decodeFromString<WebSocketRequest>(message)
+
+    assertIs<RequestSettingsPut>(request)
+    assertEquals("sp-1", request.requestId)
+    assertEquals("system", request.namespace)
+    assertEquals("user_rotation", request.key)
+    assertEquals("1", request.value)
+    assertEquals("int", request.valueType)
+  }
+
+  @Test
+  fun `deserialize request_settings_put with null value defaults to string type`() {
+    val message = """{"type":"request_settings_put","requestId":"sp-2","namespace":"secure","key":"enabled_accessibility_services","value":null}"""
+    val request = json.decodeFromString<WebSocketRequest>(message)
+
+    assertIs<RequestSettingsPut>(request)
+    assertEquals("sp-2", request.requestId)
+    assertEquals("secure", request.namespace)
+    assertEquals("enabled_accessibility_services", request.key)
+    assertEquals(null, request.value)
+    assertEquals("string", request.valueType)
+  }
+
+  @Test
+  fun `deserialize request_settings_list`() {
+    val message = """{"type":"request_settings_list","requestId":"sl-1","namespace":"global"}"""
+    val request = json.decodeFromString<WebSocketRequest>(message)
+
+    assertIs<RequestSettingsList>(request)
+    assertEquals("sl-1", request.requestId)
+    assertEquals("global", request.namespace)
+  }
 }

--- a/android/protocol/src/test/kotlin/dev/jasonpearson/automobile/protocol/WebSocketRequestTest.kt
+++ b/android/protocol/src/test/kotlin/dev/jasonpearson/automobile/protocol/WebSocketRequestTest.kt
@@ -186,4 +186,52 @@ class WebSocketRequestTest {
     assertEquals("com.example.app", request.packageName)
     assertEquals("settings.xml", request.fileName)
   }
+
+  @Test
+  fun `deserialize request_installed_packages`() {
+    val message =
+        """{"type":"request_installed_packages","requestId":"pkg-1","includeSystem":false,"userId":10}"""
+    val request = json.decodeFromString<WebSocketRequest>(message)
+
+    assertIs<RequestInstalledPackages>(request)
+    assertEquals("pkg-1", request.requestId)
+    assertEquals(false, request.includeSystem)
+    assertEquals(10, request.userId)
+  }
+
+  @Test
+  fun `deserialize request_installed_packages with defaults`() {
+    val message = """{"type":"request_installed_packages","requestId":"pkg-2"}"""
+    val request = json.decodeFromString<WebSocketRequest>(message)
+
+    assertIs<RequestInstalledPackages>(request)
+    assertEquals("pkg-2", request.requestId)
+    assertEquals(true, request.includeSystem)
+    assertEquals(null, request.userId)
+  }
+
+  @Test
+  fun `deserialize request_package_info`() {
+    val message =
+        """{"type":"request_package_info","requestId":"pi-1","packageName":"com.example.app","includePermissions":true,"includeActivities":true}"""
+    val request = json.decodeFromString<WebSocketRequest>(message)
+
+    assertIs<RequestPackageInfo>(request)
+    assertEquals("pi-1", request.requestId)
+    assertEquals("com.example.app", request.packageName)
+    assertEquals(true, request.includePermissions)
+    assertEquals(true, request.includeActivities)
+    assertEquals(false, request.includeIntentFilters)
+  }
+
+  @Test
+  fun `deserialize request_launch_intent`() {
+    val message =
+        """{"type":"request_launch_intent","requestId":"li-1","packageName":"com.example.app"}"""
+    val request = json.decodeFromString<WebSocketRequest>(message)
+
+    assertIs<RequestLaunchIntent>(request)
+    assertEquals("li-1", request.requestId)
+    assertEquals("com.example.app", request.packageName)
+  }
 }

--- a/android/protocol/src/test/kotlin/dev/jasonpearson/automobile/protocol/WebSocketRequestTest.kt
+++ b/android/protocol/src/test/kotlin/dev/jasonpearson/automobile/protocol/WebSocketRequestTest.kt
@@ -260,15 +260,13 @@ class WebSocketRequestTest {
   @Test
   fun `deserialize request_package_info`() {
     val message =
-        """{"type":"request_package_info","requestId":"pi-1","packageName":"com.example.app","includePermissions":true,"includeActivities":true}"""
+        """{"type":"request_package_info","requestId":"pi-1","packageName":"com.example.app","includePermissions":true}"""
     val request = json.decodeFromString<WebSocketRequest>(message)
 
     assertIs<RequestPackageInfo>(request)
     assertEquals("pi-1", request.requestId)
     assertEquals("com.example.app", request.packageName)
     assertEquals(true, request.includePermissions)
-    assertEquals(true, request.includeActivities)
-    assertEquals(false, request.includeIntentFilters)
   }
 
   @Test

--- a/android/protocol/src/test/kotlin/dev/jasonpearson/automobile/protocol/WebSocketResponseTest.kt
+++ b/android/protocol/src/test/kotlin/dev/jasonpearson/automobile/protocol/WebSocketResponseTest.kt
@@ -113,4 +113,66 @@ class WebSocketResponseTest {
     assertTrue(encoded.contains(""""success":false"""))
     assertTrue(encoded.contains(""""error":"Gesture failed: timeout""""))
   }
+
+  @Test
+  fun `serialize settings_get_result`() {
+    val response: WebSocketResponse = SettingsGetResult(
+      timestamp = 1234567890L,
+      requestId = "sg-1",
+      success = true,
+      namespace = "system",
+      key = "user_rotation",
+      value = "0",
+      found = true,
+      totalTimeMs = 5L,
+    )
+
+    val encoded = json.encodeToString(WebSocketResponse.serializer(), response)
+
+    assertTrue(encoded.contains(""""type":"settings_get_result""""))
+    assertTrue(encoded.contains(""""namespace":"system""""))
+    assertTrue(encoded.contains(""""key":"user_rotation""""))
+    assertTrue(encoded.contains(""""value":"0""""))
+    assertTrue(encoded.contains(""""found":true"""))
+    assertTrue(encoded.contains(""""totalTimeMs":5"""))
+  }
+
+  @Test
+  fun `serialize settings_put_result with error`() {
+    val response: WebSocketResponse = SettingsPutResult(
+      timestamp = 1234567890L,
+      requestId = "sp-1",
+      success = false,
+      namespace = "secure",
+      key = "accessibility_enabled",
+      totalTimeMs = 12L,
+      error = "SecurityException: write secure requires WRITE_SECURE_SETTINGS"
+    )
+
+    val encoded = json.encodeToString(WebSocketResponse.serializer(), response)
+
+    assertTrue(encoded.contains(""""type":"settings_put_result""""))
+    assertTrue(encoded.contains(""""success":false"""))
+    assertTrue(encoded.contains(""""namespace":"secure""""))
+    assertTrue(encoded.contains(""""error":"SecurityException"""))
+  }
+
+  @Test
+  fun `serialize settings_list_result with entries`() {
+    val response: WebSocketResponse = SettingsListResult(
+      timestamp = 1234567890L,
+      requestId = "sl-1",
+      success = true,
+      namespace = "global",
+      entries = mapOf("zen_mode" to "0", "device_provisioned" to "1"),
+      totalTimeMs = 30L,
+    )
+
+    val encoded = json.encodeToString(WebSocketResponse.serializer(), response)
+
+    assertTrue(encoded.contains(""""type":"settings_list_result""""))
+    assertTrue(encoded.contains(""""namespace":"global""""))
+    assertTrue(encoded.contains(""""zen_mode":"0""""))
+    assertTrue(encoded.contains(""""device_provisioned":"1""""))
+  }
 }

--- a/android/protocol/src/test/kotlin/dev/jasonpearson/automobile/protocol/WebSocketResponseTest.kt
+++ b/android/protocol/src/test/kotlin/dev/jasonpearson/automobile/protocol/WebSocketResponseTest.kt
@@ -113,4 +113,81 @@ class WebSocketResponseTest {
     assertTrue(encoded.contains(""""success":false"""))
     assertTrue(encoded.contains(""""error":"Gesture failed: timeout""""))
   }
+
+  @Test
+  fun `serialize installed_packages_result`() {
+    val response: WebSocketResponse = InstalledPackagesResult(
+      timestamp = 1234567890L,
+      requestId = "pkg-1",
+      success = true,
+      userId = 0,
+      packages = listOf(
+        InstalledPackageRecord(packageName = "com.example.app", isSystem = false, versionName = "1.0", versionCode = 1L),
+        InstalledPackageRecord(packageName = "com.android.systemui", isSystem = true),
+      ),
+      totalTimeMs = 15L,
+    )
+
+    val encoded = json.encodeToString(WebSocketResponse.serializer(), response)
+
+    assertTrue(encoded.contains(""""type":"installed_packages_result""""))
+    assertTrue(encoded.contains(""""userId":0"""))
+    assertTrue(encoded.contains(""""packageName":"com.example.app""""))
+    assertTrue(encoded.contains(""""isSystem":false"""))
+    assertTrue(encoded.contains(""""versionName":"1.0""""))
+    assertTrue(encoded.contains(""""versionCode":1"""))
+    assertTrue(encoded.contains(""""packageName":"com.android.systemui""""))
+  }
+
+  @Test
+  fun `serialize package_info_result`() {
+    val response: WebSocketResponse = PackageInfoResult(
+      timestamp = 1234567890L,
+      requestId = "pi-1",
+      success = true,
+      packageName = "com.example.app",
+      isSystem = false,
+      applicationLabel = "Example",
+      versionName = "2.3",
+      versionCode = 42L,
+      installerPackage = "com.android.vending",
+      firstInstallTime = 100L,
+      lastUpdateTime = 200L,
+      allowBackup = true,
+      requestedPermissions = listOf("android.permission.CAMERA", "android.permission.INTERNET"),
+      grantedPermissions = mapOf("android.permission.CAMERA" to true, "android.permission.INTERNET" to false),
+      mainActivity = "com.example.app/.MainActivity",
+      totalTimeMs = 5L,
+    )
+
+    val encoded = json.encodeToString(WebSocketResponse.serializer(), response)
+
+    assertTrue(encoded.contains(""""type":"package_info_result""""))
+    assertTrue(encoded.contains(""""packageName":"com.example.app""""))
+    assertTrue(encoded.contains(""""applicationLabel":"Example""""))
+    assertTrue(encoded.contains(""""versionName":"2.3""""))
+    assertTrue(encoded.contains(""""versionCode":42"""))
+    assertTrue(encoded.contains(""""installerPackage":"com.android.vending""""))
+    assertTrue(encoded.contains(""""mainActivity":"com.example.app/.MainActivity""""))
+    assertTrue(encoded.contains(""""android.permission.CAMERA":true"""))
+    assertTrue(encoded.contains(""""android.permission.INTERNET":false"""))
+  }
+
+  @Test
+  fun `serialize launch_intent_result`() {
+    val response: WebSocketResponse = LaunchIntentResult(
+      timestamp = 1234567890L,
+      requestId = "li-1",
+      success = true,
+      packageName = "com.example.app",
+      componentName = "com.example.app/.MainActivity",
+      totalTimeMs = 3L,
+    )
+
+    val encoded = json.encodeToString(WebSocketResponse.serializer(), response)
+
+    assertTrue(encoded.contains(""""type":"launch_intent_result""""))
+    assertTrue(encoded.contains(""""componentName":"com.example.app/.MainActivity""""))
+    assertTrue(encoded.contains(""""packageName":"com.example.app""""))
+  }
 }

--- a/src/doctor/checks/automobile.ts
+++ b/src/doctor/checks/automobile.ts
@@ -255,6 +255,9 @@ export async function checkWorkProfileAccessibility(
     const profilesWithoutService: { userId: number; name: string }[] = [];
 
     for (const profile of workProfiles) {
+      // Why: kept on ADB because Settings APIs from the accessibility service run as
+      // the service user only; the multi-user --user flag is required to query
+      // settings in each work profile, which the WebSocket settings_get API can't do.
       const result = await deviceAdb.executeCommand(
         `shell settings --user ${profile.userId} get secure enabled_accessibility_services`,
         undefined,

--- a/src/features/accessibility/TalkBackToggle.ts
+++ b/src/features/accessibility/TalkBackToggle.ts
@@ -6,6 +6,7 @@ import { defaultAdbClientFactory } from "../../utils/android-cmdline-tools/AdbCl
 import type { AccessibilityDetector } from "../../utils/interfaces/AccessibilityDetector";
 import { accessibilityDetector } from "../../utils/AccessibilityDetector";
 import { type Timer, defaultTimer } from "../../utils/SystemTimer";
+import { AndroidCtrlProxyClient } from "../observe/android/AndroidCtrlProxyClient";
 
 const TALKBACK_PACKAGE = "com.google.android.marvin.talkback";
 const TALKBACK_SERVICE_FALLBACK = `${TALKBACK_PACKAGE}/${TALKBACK_PACKAGE}.TalkBackService`;
@@ -72,6 +73,48 @@ export class TalkBackToggle {
     };
   }
 
+  // Why: try the a11y service first to skip ADB round-trip latency; fall back to ADB
+  // because Settings.Secure writes require system-app privileges that the service may lack.
+  private async writeSecureSetting(key: string, value: string, valueType: "string" | "int" = "string"): Promise<void> {
+    try {
+      const a11y = AndroidCtrlProxyClient.getInstance(this.device);
+      const result = await a11y.requestSettingsPut("secure", key, value, valueType);
+      if (result.success) {
+        return;
+      }
+    } catch (error) {
+      logger.debug(`[TalkBackToggle] a11y settings put failed for secure/${key}: ${error}`);
+    }
+    await this.adb.executeCommand(`shell settings put secure ${key} ${value}`);
+  }
+
+  private async deleteSecureSetting(key: string): Promise<void> {
+    try {
+      const a11y = AndroidCtrlProxyClient.getInstance(this.device);
+      const result = await a11y.requestSettingsPut("secure", key, null);
+      if (result.success) {
+        return;
+      }
+    } catch (error) {
+      logger.debug(`[TalkBackToggle] a11y settings delete failed for secure/${key}: ${error}`);
+    }
+    await this.adb.executeCommand(`shell settings delete secure ${key}`);
+  }
+
+  private async readSecureSetting(key: string): Promise<string> {
+    try {
+      const a11y = AndroidCtrlProxyClient.getInstance(this.device);
+      const result = await a11y.requestSettingsGet("secure", key);
+      if (result.success) {
+        return result.found ? (result.value ?? "") : "";
+      }
+    } catch (error) {
+      logger.debug(`[TalkBackToggle] a11y settings get failed for secure/${key}: ${error}`);
+    }
+    const adbResult = await this.adb.executeCommand(`shell settings get secure ${key}`);
+    return adbResult.stdout.trim();
+  }
+
   /**
    * Add TalkBack to the enabled services list while preserving any other
    * active accessibility services (e.g. CtrlProxy).
@@ -79,12 +122,8 @@ export class TalkBackToggle {
   private async enableTalkBack(serviceComponent: string): Promise<void> {
     const otherServices = await this.getOtherServices();
     const updatedServices = [...otherServices, serviceComponent].join(":");
-    await this.adb.executeCommand(
-      `shell settings put secure enabled_accessibility_services ${updatedServices}`
-    );
-    await this.adb.executeCommand(
-      "shell settings put secure accessibility_enabled 1"
-    );
+    await this.writeSecureSetting("enabled_accessibility_services", updatedServices);
+    await this.writeSecureSetting("accessibility_enabled", "1", "int");
   }
 
   /**
@@ -96,18 +135,12 @@ export class TalkBackToggle {
     const otherServices = await this.getOtherServices();
 
     if (otherServices.length === 0) {
-      await this.adb.executeCommand(
-        "shell settings delete secure enabled_accessibility_services"
-      );
-      await this.adb.executeCommand(
-        "shell settings put secure accessibility_enabled 0"
-      );
+      await this.deleteSecureSetting("enabled_accessibility_services");
+      await this.writeSecureSetting("accessibility_enabled", "0", "int");
     } else {
       // Other services are still active — update the list without TalkBack
       // and leave accessibility_enabled at 1
-      await this.adb.executeCommand(
-        `shell settings put secure enabled_accessibility_services ${otherServices.join(":")}`
-      );
+      await this.writeSecureSetting("enabled_accessibility_services", otherServices.join(":"));
     }
   }
 
@@ -116,10 +149,7 @@ export class TalkBackToggle {
    * entries that are NOT part of TalkBack, preserving other active services.
    */
   private async getOtherServices(): Promise<string[]> {
-    const result = await this.adb.executeCommand(
-      "shell settings get secure enabled_accessibility_services"
-    );
-    const currentServices = result.stdout.trim();
+    const currentServices = await this.readSecureSetting("enabled_accessibility_services");
 
     const otherServices: string[] = [];
     if (currentServices && currentServices !== "null") {

--- a/src/features/action/AppPermissions.ts
+++ b/src/features/action/AppPermissions.ts
@@ -1,6 +1,7 @@
 import { defaultAdbClientFactory, type AdbClientFactory } from "../../utils/android-cmdline-tools/AdbClientFactory";
 import type { AdbExecutor } from "../../utils/android-cmdline-tools/interfaces/AdbExecutor";
 import type { BootedDevice } from "../../models";
+import { AndroidCtrlProxyClient } from "../observe/android";
 import { GrantAndroidPermissions } from "./GrantAndroidPermissions";
 import { SetAndroidNotificationPolicyAccess } from "./SetAndroidNotificationPolicyAccess";
 import { SetAndroidScheduleExactAlarmAppOp, type ScheduleExactAlarmAppOpMode } from "./SetAndroidScheduleExactAlarmAppOp";
@@ -296,6 +297,46 @@ export class AppPermissions {
 
     if (!normalizedAppId) {
       return this.androidQueryFailure(normalizedAppId, "appId must be a non-empty Android package name");
+    }
+
+    // Try WebSocket PackageManager first; fall back to ADB dumpsys on failure.
+    try {
+      const a11y = AndroidCtrlProxyClient.getInstance(this.device);
+      const info = await a11y.requestPackageInfo(
+        normalizedAppId,
+        { includePermissions: true },
+        4000
+      );
+      if (info.success) {
+        const granted = info.grantedPermissions;
+        const allKeys = info.requestedPermissions.length > 0
+          ? info.requestedPermissions
+          : Object.keys(granted);
+        const permissionNames = requestedPermissions.length > 0 ? requestedPermissions : allKeys;
+        return {
+          success: true,
+          appId: normalizedAppId,
+          deviceId: this.device.deviceId,
+          platform: "android",
+          permissions: permissionNames.map(permission => {
+            if (permission in granted) {
+              return {
+                permission,
+                state: granted[permission] ? "granted" : "denied",
+                source: "androidRuntime" as const,
+                raw: { granted: granted[permission] },
+              };
+            }
+            return {
+              permission,
+              state: "unknown" as const,
+              source: "androidRuntime" as const,
+            };
+          }),
+        };
+      }
+    } catch {
+      // fall through to ADB
     }
 
     try {

--- a/src/features/action/CaptureSnapshot.ts
+++ b/src/features/action/CaptureSnapshot.ts
@@ -12,6 +12,7 @@ import { logger } from "../../utils/logger";
 import { promises as fs } from "fs";
 import * as path from "path";
 import { Timer, defaultTimer } from "../../utils/SystemTimer";
+import { AndroidCtrlProxyClient } from "../observe/android";
 
 export interface CaptureSnapshotArgs {
   snapshotName: string;
@@ -235,6 +236,15 @@ export class CaptureSnapshot {
    * Get list of installed packages
    */
   private async getInstalledPackages(): Promise<string[]> {
+    try {
+      const a11y = AndroidCtrlProxyClient.getInstance(this.device);
+      const result = await a11y.requestInstalledPackages(true, undefined, 4000);
+      if (result.success) {
+        return result.packages.map(p => p.packageName);
+      }
+    } catch (error) {
+      logger.debug(`[CaptureSnapshot] a11y package list failed, falling back to ADB: ${error}`);
+    }
     const result = await this.adb.executeCommand("shell pm list packages");
     return result.stdout
       .split("\n")
@@ -437,6 +447,20 @@ export class CaptureSnapshot {
    * Filter packages to only include user-installed apps
    */
   private async filterUserPackages(packages: string[]): Promise<string[]> {
+    // Try WebSocket-backed PackageManager once and partition.
+    try {
+      const a11y = AndroidCtrlProxyClient.getInstance(this.device);
+      const result = await a11y.requestInstalledPackages(true, undefined, 4000);
+      if (result.success) {
+        const userSet = new Set(
+          result.packages.filter(p => !p.isSystem).map(p => p.packageName)
+        );
+        return packages.filter(p => userSet.has(p));
+      }
+    } catch (error) {
+      logger.debug(`[CaptureSnapshot] a11y filterUserPackages failed, falling back to ADB: ${error}`);
+    }
+
     const userPackages: string[] = [];
 
     for (const packageName of packages) {
@@ -462,21 +486,37 @@ export class CaptureSnapshot {
   }> {
     const allowedPackages: string[] = [];
     const skippedPackages: string[] = [];
+    const a11y = AndroidCtrlProxyClient.getInstance(this.device);
 
     for (const packageName of packages) {
+      let resolved = false;
       try {
-        // Check if app allows backup using dumpsys
-        const result = await this.adb.executeCommand(`shell dumpsys package ${packageName}`);
+        const info = await a11y.requestPackageInfo(
+          packageName,
+          { includePermissions: false },
+          2000
+        );
+        if (info.success && info.allowBackup !== undefined) {
+          if (info.allowBackup === false) {
+            skippedPackages.push(packageName);
+          } else {
+            allowedPackages.push(packageName);
+          }
+          resolved = true;
+        }
+      } catch {
+        // fall through to ADB
+      }
+      if (resolved) {continue;}
 
-        // Look for ALLOW_BACKUP flag in the output
-        // If allowBackup is false, the output will contain "ALLOW_BACKUP=false"
+      try {
+        const result = await this.adb.executeCommand(`shell dumpsys package ${packageName}`);
         if (result.stdout.includes("ALLOW_BACKUP=false")) {
           skippedPackages.push(packageName);
         } else {
           allowedPackages.push(packageName);
         }
       } catch (error) {
-        // If we can't determine, assume it allows backup
         logger.debug(`Failed to check backup flag for ${packageName}, assuming allowed: ${error}`);
         allowedPackages.push(packageName);
       }

--- a/src/features/action/CaptureSnapshot.ts
+++ b/src/features/action/CaptureSnapshot.ts
@@ -12,6 +12,8 @@ import { logger } from "../../utils/logger";
 import { promises as fs } from "fs";
 import * as path from "path";
 import { Timer, defaultTimer } from "../../utils/SystemTimer";
+import { AndroidCtrlProxyClient } from "../observe/android/AndroidCtrlProxyClient";
+import type { SettingsNamespace } from "../observe/android";
 
 export interface CaptureSnapshotArgs {
   snapshotName: string;
@@ -271,8 +273,21 @@ export class CaptureSnapshot {
 
     for (const type of settingsTypes) {
       try {
-        const result = await this.adb.executeCommand(`shell settings list ${type}`);
-        settings[type] = this.parseSettings(result.stdout);
+        let captured = false;
+        try {
+          const a11y = AndroidCtrlProxyClient.getInstance(this.device);
+          const a11yResult = await a11y.requestSettingsList(type as SettingsNamespace);
+          if (a11yResult.success && a11yResult.entries) {
+            settings[type] = a11yResult.entries;
+            captured = true;
+          }
+        } catch (error) {
+          logger.debug(`[CaptureSnapshot] a11y settings list failed for ${type}: ${error}`);
+        }
+        if (!captured) {
+          const result = await this.adb.executeCommand(`shell settings list ${type}`);
+          settings[type] = this.parseSettings(result.stdout);
+        }
         logger.info(`Captured ${Object.keys(settings[type]).length} ${type} settings`);
       } catch (error) {
         logger.warn(`Failed to capture ${type} settings: ${error}`);

--- a/src/features/action/InstallApp.ts
+++ b/src/features/action/InstallApp.ts
@@ -8,6 +8,7 @@ import { DefaultAndroidBuildToolsLocator, type AndroidBuildToolsLocator } from "
 import { OPERATION_CANCELLED_MESSAGE } from "../../utils/constants";
 import { SimCtlClient } from "../../utils/ios-cmdline-tools/SimCtlClient";
 import { DeviceAppInspector } from "../../utils/ios-cmdline-tools/DeviceAppInspector";
+import { AndroidCtrlProxyClient } from "../observe/android";
 
 export interface DeviceAppInstaller {
   installApp(deviceUdid: string, artifactPath: string): Promise<void>;
@@ -116,8 +117,17 @@ export class InstallApp {
 
     let isInstalled = false;
     if (packageName) {
-      // Check if app is already installed for this user
+      // Check if app is already installed for this user.
       isInstalled = await perf.track("checkInstalled", async () => {
+        try {
+          const a11y = AndroidCtrlProxyClient.getInstance(this.device);
+          const result = await a11y.requestInstalledPackages(true, undefined, 3000);
+          if (result.success && result.userId === targetUserId) {
+            return result.packages.some(p => p.packageName === packageName);
+          }
+        } catch {
+          // fall through to ADB
+        }
         try {
           const isInstalledCmd = `shell pm list packages --user ${targetUserId} -f ${packageName} | grep -c ${packageName}`;
           const isInstalledOutput = await this.adb.executeCommand(isInstalledCmd, undefined, undefined, true, signal);

--- a/src/features/action/LaunchApp.ts
+++ b/src/features/action/LaunchApp.ts
@@ -14,6 +14,7 @@ import { serverConfig } from "../../utils/ServerConfig";
 import { Timer, defaultTimer } from "../../utils/SystemTimer";
 import { IOSCtrlProxyClient } from "../observe/ios";
 import { IOSCtrlProxyManager } from "../../utils/IOSCtrlProxyManager";
+import { AndroidCtrlProxyClient } from "../observe/android";
 
 export interface TargetUserDetector {
   detectTargetUserId(packageName: string, userId?: number): Promise<number>;
@@ -72,6 +73,29 @@ export class LaunchApp extends BaseVisualChange {
   ): Promise<string[]> {
     logger.info("extractLauncherActivities");
     const activities: string[] = [];
+
+    // Try the WebSocket-backed PackageManager launch intent first.
+    try {
+      const a11y = AndroidCtrlProxyClient.getInstance(this.device);
+      const result = perf
+        ? await perf.track("a11yLaunchIntent", () => a11y.requestLaunchIntent(packageName, 3000))
+        : await a11y.requestLaunchIntent(packageName, 3000);
+      if (result.success && result.componentName) {
+        // componentName is "package/.Activity" or "package/com.foo.Activity"
+        const slash = result.componentName.indexOf("/");
+        if (slash >= 0) {
+          let activity = result.componentName.slice(slash + 1);
+          if (activity.startsWith(".")) {
+            activity = packageName + activity;
+          }
+          activities.push(activity);
+          logger.info(`[LaunchApp] Resolved launcher activity via a11y: ${activity}`);
+          return activities;
+        }
+      }
+    } catch (error) {
+      logger.debug(`[LaunchApp] a11y launch intent failed, falling back to ADB: ${error}`);
+    }
 
     try {
       logger.info(`[LaunchApp] Extracting launcher activities for ${packageName}`);

--- a/src/features/action/RestoreSnapshot.ts
+++ b/src/features/action/RestoreSnapshot.ts
@@ -12,6 +12,8 @@ import { logger } from "../../utils/logger";
 import { promises as fs } from "fs";
 import * as path from "path";
 import { Timer, defaultTimer } from "../../utils/SystemTimer";
+import { AndroidCtrlProxyClient } from "../observe/android/AndroidCtrlProxyClient";
+import type { SettingsNamespace } from "../observe/android";
 
 export interface RestoreSnapshotArgs {
   snapshotName: string;
@@ -217,9 +219,21 @@ export class RestoreSnapshot {
 
       for (const [key, value] of Object.entries(values)) {
         try {
-          // Escape special characters in value
-          const escapedValue = value.replace(/'/g, "'\\''");
-          await this.adb.executeCommand(`shell settings put ${settingsType} ${key} '${escapedValue}'`);
+          let applied = false;
+          try {
+            const a11y = AndroidCtrlProxyClient.getInstance(this.device);
+            const a11yResult = await a11y.requestSettingsPut(settingsType as SettingsNamespace, key, value, "string");
+            if (a11yResult.success) {
+              applied = true;
+            }
+          } catch (error) {
+            logger.debug(`[RestoreSnapshot] a11y settings put failed for ${settingsType}/${key}: ${error}`);
+          }
+          if (!applied) {
+            // Escape special characters in value
+            const escapedValue = value.replace(/'/g, "'\\''");
+            await this.adb.executeCommand(`shell settings put ${settingsType} ${key} '${escapedValue}'`);
+          }
           successCount++;
         } catch (error) {
           failureCount++;

--- a/src/features/action/Rotate.ts
+++ b/src/features/action/Rotate.ts
@@ -193,11 +193,12 @@ export class Rotate extends BaseVisualChange {
             orientationUnlocked = true;
           }
 
-          // Disable accelerometer rotation and set user rotation
-          await perf.track("setRotation", async () => {
-            await this.writeSystemSetting("accelerometer_rotation", "0");
-            await this.writeSystemSetting("user_rotation", String(value));
-          });
+          await perf.track("setRotation", () =>
+            Promise.all([
+              this.writeSystemSetting("accelerometer_rotation", "0"),
+              this.writeSystemSetting("user_rotation", String(value)),
+            ])
+          );
 
           // Wait for rotation to complete (also serves as verification)
           await perf.track("waitForRotation", () =>

--- a/src/features/action/Rotate.ts
+++ b/src/features/action/Rotate.ts
@@ -6,6 +6,7 @@ import { ProgressCallback } from "./BaseVisualChange";
 import { createGlobalPerformanceTracker } from "../../utils/PerformanceTracker";
 import { Timer, defaultTimer } from "../../utils/SystemTimer";
 import { IOSCtrlProxyClient } from "../observe/ios";
+import { AndroidCtrlProxyClient } from "../observe/android/AndroidCtrlProxyClient";
 
 export class Rotate extends BaseVisualChange {
   constructor(
@@ -20,29 +21,40 @@ export class Rotate extends BaseVisualChange {
      * Get the current device orientation
      * @returns Promise with current orientation ("portrait" or "landscape")
      */
-  async getCurrentOrientation(): Promise<string> {
+  private async readSystemSetting(key: string): Promise<string | null> {
     try {
-      // Get current user_rotation setting
-      const result = await this.adb.executeCommand("shell settings get system user_rotation");
-      const userRotationStr = result.stdout.trim();
-
-      // Check if the result is a valid number
-      if (!/^\d+$/.test(userRotationStr)) {
-        logger.warn(`Invalid user_rotation value: ${userRotationStr}, defaulting to portrait`);
-        return "portrait";
+      const a11y = AndroidCtrlProxyClient.getInstance(this.device);
+      const a11yResult = await a11y.requestSettingsGet("system", key);
+      if (a11yResult.success) {
+        return a11yResult.found ? (a11yResult.value ?? null) : null;
       }
-
-      const userRotation = parseInt(userRotationStr, 10);
-
-      // Convert numeric value to orientation string
-      // 0 = portrait, 1 = landscape (90°), 2 = reverse portrait (180°), 3 = reverse landscape (270°)
-      // For simplicity, we'll treat 0,2 as portrait and 1,3 as landscape
-      return (userRotation === 0 || userRotation === 2) ? "portrait" : "landscape";
     } catch (error) {
-      logger.warn(`Failed to get current orientation: ${error}`);
-      // If we can't detect current orientation, assume portrait as default
+      logger.debug(`[Rotate] a11y settings get failed for ${key}: ${error}`);
+    }
+    try {
+      const result = await this.adb.executeCommand(`shell settings get system ${key}`);
+      const out = result.stdout.trim();
+      return (!out || out === "null") ? null : out;
+    } catch (error) {
+      logger.warn(`Failed to read system setting ${key}: ${error}`);
+      return null;
+    }
+  }
+
+  async getCurrentOrientation(): Promise<string> {
+    const userRotationStr = await this.readSystemSetting("user_rotation");
+
+    if (!userRotationStr || !/^\d+$/.test(userRotationStr)) {
+      logger.warn(`Invalid user_rotation value: ${userRotationStr}, defaulting to portrait`);
       return "portrait";
     }
+
+    const userRotation = parseInt(userRotationStr, 10);
+
+    // Convert numeric value to orientation string
+    // 0 = portrait, 1 = landscape (90°), 2 = reverse portrait (180°), 3 = reverse landscape (270°)
+    // For simplicity, we'll treat 0,2 as portrait and 1,3 as landscape
+    return (userRotation === 0 || userRotation === 2) ? "portrait" : "landscape";
   }
 
   /**
@@ -50,16 +62,27 @@ export class Rotate extends BaseVisualChange {
      * @returns Promise with boolean indicating if auto-rotation is disabled
      */
   async isOrientationLocked(): Promise<boolean> {
-    try {
-      const result = await this.adb.executeCommand("shell settings get system accelerometer_rotation");
-      const autoRotate = parseInt(result.stdout.trim(), 10);
-      // 0 = locked (auto-rotation disabled), 1 = unlocked (auto-rotation enabled)
-      return autoRotate === 0;
-    } catch (error) {
-      logger.warn(`Failed to check orientation lock status: ${error}`);
-      // If we can't check, assume it's not locked
+    const val = await this.readSystemSetting("accelerometer_rotation");
+    if (val === null) {
       return false;
     }
+    const autoRotate = parseInt(val, 10);
+    // 0 = locked (auto-rotation disabled), 1 = unlocked (auto-rotation enabled)
+    return autoRotate === 0;
+  }
+
+  private async writeSystemSetting(key: string, value: string): Promise<void> {
+    try {
+      const a11y = AndroidCtrlProxyClient.getInstance(this.device);
+      const a11yResult = await a11y.requestSettingsPut("system", key, value, "int");
+      if (a11yResult.success) {
+        return;
+      }
+      logger.debug(`[Rotate] a11y settings put failed for ${key}: ${a11yResult.error}`);
+    } catch (error) {
+      logger.debug(`[Rotate] a11y settings put threw for ${key}: ${error}`);
+    }
+    await this.adb.executeCommand(`shell settings put system ${key} ${value}`);
   }
 
   async execute(
@@ -166,15 +189,15 @@ export class Rotate extends BaseVisualChange {
           // If orientation is locked, unlock it temporarily
           if (isLocked) {
             logger.info("Orientation is locked, temporarily unlocking for rotation");
-            await this.adb.executeCommand("shell settings put system accelerometer_rotation 1");
+            await this.writeSystemSetting("accelerometer_rotation", "1");
             orientationUnlocked = true;
           }
 
-          // Disable accelerometer rotation and set user rotation in single command
-          // Note: Use semicolon inside quotes to run both commands in Android shell
-          await perf.track("setRotation", () =>
-            this.adb.executeCommand(`shell "settings put system accelerometer_rotation 0; settings put system user_rotation ${value}"`)
-          );
+          // Disable accelerometer rotation and set user rotation
+          await perf.track("setRotation", async () => {
+            await this.writeSystemSetting("accelerometer_rotation", "0");
+            await this.writeSystemSetting("user_rotation", String(value));
+          });
 
           // Wait for rotation to complete (also serves as verification)
           await perf.track("waitForRotation", () =>
@@ -198,7 +221,7 @@ export class Rotate extends BaseVisualChange {
           // Restore orientation lock if we unlocked it
           if (orientationUnlocked) {
             try {
-              await this.adb.executeCommand("shell settings put system accelerometer_rotation 0");
+              await this.writeSystemSetting("accelerometer_rotation", "0");
               logger.info("Restored orientation lock after error");
             } catch (restoreError) {
               logger.warn(`Failed to restore orientation lock: ${restoreError}`);

--- a/src/features/action/TerminateApp.ts
+++ b/src/features/action/TerminateApp.ts
@@ -4,6 +4,7 @@ import { BootedDevice, TerminateAppResult } from "../../models";
 import { createGlobalPerformanceTracker } from "../../utils/PerformanceTracker";
 import { SimCtlClient } from "../../utils/ios-cmdline-tools/SimCtlClient";
 import { Timer, defaultTimer } from "../../utils/SystemTimer";
+import { AndroidCtrlProxyClient } from "../observe/android";
 
 export class TerminateApp extends BaseVisualChange {
   private simctl: SimCtlClient;
@@ -74,6 +75,15 @@ export class TerminateApp extends BaseVisualChange {
 
       // Check if app is installed
       const isInstalled = await perf.track("checkInstalled", async () => {
+        try {
+          const a11y = AndroidCtrlProxyClient.getInstance(this.device);
+          const result = await a11y.requestInstalledPackages(true, undefined, 3000);
+          if (result.success && result.userId === targetUserId) {
+            return result.packages.some(p => p.packageName === packageName);
+          }
+        } catch {
+          // fall through
+        }
         try {
           const isInstalledCmd = `shell pm list packages --user ${targetUserId} -f ${packageName} | grep -c ${packageName}`;
           const isInstalledOutput = await this.adb.executeCommand(isInstalledCmd, undefined, undefined, true);

--- a/src/features/observe/GetAppMetadata.ts
+++ b/src/features/observe/GetAppMetadata.ts
@@ -3,6 +3,7 @@ import type { AppMetadataResult } from "../../models/AppMetadataResult";
 import type { BootedDevice, ExecResult } from "../../models";
 import { AdbClientFactory, defaultAdbClientFactory } from "../../utils/android-cmdline-tools/AdbClientFactory";
 import { logger } from "../../utils/logger";
+import { AndroidCtrlProxyClient } from "./android";
 
 /**
  * Source of iOS app metadata — injectable for testing.
@@ -35,6 +36,33 @@ export class GetAppMetadata {
   }
 
   private async getAndroidMetadata(packageName: string): Promise<AppMetadataResult | null> {
+    // Prefer WebSocket-backed PackageManager call; fall back to ADB dumpsys.
+    try {
+      const a11y = AndroidCtrlProxyClient.getInstance(this.device);
+      const info = await a11y.requestPackageInfo(packageName, { includePermissions: false }, 4000);
+      if (info.success) {
+        const versionName = info.versionName ?? "";
+        const buildNumber = info.versionCode !== undefined && info.versionCode !== null ? String(info.versionCode) : "";
+        const firstInstallTime = info.firstInstallTime ? new Date(info.firstInstallTime).toString() : undefined;
+        const lastUpdateTime = info.lastUpdateTime ? new Date(info.lastUpdateTime).toString() : undefined;
+        if (!versionName && !buildNumber) {
+          return null;
+        }
+        return {
+          appId: packageName,
+          platform: "android",
+          versionName,
+          buildNumber,
+          installPath: "",
+          ...(firstInstallTime ? { firstInstallTime } : {}),
+          ...(lastUpdateTime ? { lastUpdateTime } : {})
+        };
+      }
+      logger.debug(`[GetAppMetadata] a11y package info failed: ${info.error}`);
+    } catch (error) {
+      logger.debug(`[GetAppMetadata] a11y package info threw: ${error}`);
+    }
+
     let result: ExecResult;
     try {
       result = await this.adb.executeCommand(`shell dumpsys package ${packageName}`);

--- a/src/features/observe/ListInstalledApps.ts
+++ b/src/features/observe/ListInstalledApps.ts
@@ -6,6 +6,7 @@ import { SimCtlClient } from "../../utils/ios-cmdline-tools/SimCtlClient";
 import { InstalledAppsRepository, InstalledAppsStore } from "../../db/installedAppsRepository";
 import { Timer, defaultTimer } from "../../utils/SystemTimer";
 import type { InstalledApp as DbInstalledApp, NewInstalledApp } from "../../db/types";
+import { AndroidCtrlProxyClient } from "./android";
 
 const INSTALLED_APPS_CACHE_TTL_MS = 5 * 60 * 1000;
 
@@ -279,6 +280,27 @@ export class ListInstalledApps {
   }
 
   private async listPackagesForUser(userId: number, filterFlag?: "-s" | "-3"): Promise<string[]> {
+    // Try WebSocket first when targeting the service's current user. PackageManager runs
+    // as the service user, so cross-user queries (`--user N` for non-current user) must
+    // fall back to ADB.
+    if (this.device.platform === "android") {
+      try {
+        const a11y = AndroidCtrlProxyClient.getInstance(this.device);
+        const result = await a11y.requestInstalledPackages(true, undefined, 4000);
+        if (result.success && result.userId === userId) {
+          let packages = result.packages;
+          if (filterFlag === "-s") {
+            packages = packages.filter(p => p.isSystem);
+          } else if (filterFlag === "-3") {
+            packages = packages.filter(p => !p.isSystem);
+          }
+          return packages.map(p => p.packageName);
+        }
+      } catch (error) {
+        logger.debug(`[ListInstalledApps] WebSocket package list failed, falling back to ADB: ${error}`);
+      }
+    }
+
     const flag = filterFlag ? ` ${filterFlag}` : "";
     const { stdout } = await this.adb.executeCommand(
       `shell pm list packages${flag} --user ${userId}`

--- a/src/features/observe/ListInstalledApps.ts
+++ b/src/features/observe/ListInstalledApps.ts
@@ -190,10 +190,7 @@ export class ListInstalledApps {
       try {
         logger.info(`[ListInstalledApps] Listing packages for user ${user.userId}...`);
 
-        const allPackages = await this.listPackagesForUser(user.userId);
-        const systemPackages = await this.listPackagesForUser(user.userId, "-s");
-        const systemPackageSet = new Set(systemPackages);
-        const userPackages = allPackages.filter(packageName => !systemPackageSet.has(packageName));
+        const { userPackages, systemPackages } = await this.partitionPackagesForUser(user.userId);
 
         logger.info(`[ListInstalledApps] Found ${userPackages.length} user package(s) and ${systemPackages.length} system package(s) for user ${user.userId}`);
 
@@ -279,33 +276,36 @@ export class ListInstalledApps {
     return installedApps;
   }
 
-  private async listPackagesForUser(userId: number, filterFlag?: "-s" | "-3"): Promise<string[]> {
-    // Try WebSocket first when targeting the service's current user. PackageManager runs
-    // as the service user, so cross-user queries (`--user N` for non-current user) must
-    // fall back to ADB.
+  // Why: PackageManager runs as the service user, so cross-user queries
+  // (`--user N` for non-current user) fall back to ADB.
+  private async partitionPackagesForUser(
+    userId: number
+  ): Promise<{ userPackages: string[]; systemPackages: string[] }> {
     if (this.device.platform === "android") {
       try {
         const a11y = AndroidCtrlProxyClient.getInstance(this.device);
         const result = await a11y.requestInstalledPackages(true, undefined, 4000);
         if (result.success && result.userId === userId) {
-          let packages = result.packages;
-          if (filterFlag === "-s") {
-            packages = packages.filter(p => p.isSystem);
-          } else if (filterFlag === "-3") {
-            packages = packages.filter(p => !p.isSystem);
+          const userPackages: string[] = [];
+          const systemPackages: string[] = [];
+          for (const p of result.packages) {
+            (p.isSystem ? systemPackages : userPackages).push(p.packageName);
           }
-          return packages.map(p => p.packageName);
+          return { userPackages, systemPackages };
         }
       } catch (error) {
         logger.debug(`[ListInstalledApps] WebSocket package list failed, falling back to ADB: ${error}`);
       }
     }
 
-    const flag = filterFlag ? ` ${filterFlag}` : "";
-    const { stdout } = await this.adb.executeCommand(
-      `shell pm list packages${flag} --user ${userId}`
-    );
-    return this.parsePackages(stdout);
+    const [allRes, systemRes] = await Promise.all([
+      this.adb.executeCommand(`shell pm list packages --user ${userId}`),
+      this.adb.executeCommand(`shell pm list packages -s --user ${userId}`),
+    ]);
+    const systemPackages = this.parsePackages(systemRes.stdout);
+    const systemSet = new Set(systemPackages);
+    const userPackages = this.parsePackages(allRes.stdout).filter(p => !systemSet.has(p));
+    return { userPackages, systemPackages };
   }
 
   private parsePackages(stdout: string): string[] {

--- a/src/features/observe/android/AndroidCtrlProxyClient.ts
+++ b/src/features/observe/android/AndroidCtrlProxyClient.ts
@@ -73,6 +73,7 @@ import { CtrlProxyStorage } from "./CtrlProxyStorage";
 import { CtrlProxyCertificates } from "./CtrlProxyCertificates";
 import { CtrlProxyFocus } from "./CtrlProxyFocus";
 import { CtrlProxyHighlights } from "./CtrlProxyHighlights";
+import { CtrlProxyPackages, type PackageInfoOptions } from "./CtrlProxyPackages";
 
 // Import types
 import type {
@@ -96,6 +97,10 @@ import type {
   A11yCaCertResult,
   A11yDeviceOwnerStatusResult,
   A11yPermissionResult,
+  A11yInstalledPackagesResult,
+  A11yPackageInfoResult,
+  A11yLaunchIntentResult,
+  InstalledPackageRecord,
   AndroidPerfTiming,
 } from "./types";
 
@@ -406,6 +411,43 @@ interface WsClearPreferencesResultMessage extends WsMessageBase {
   totalTimeMs?: number;
 }
 
+interface WsInstalledPackagesResultMessage extends WsMessageBase {
+  type: "installed_packages_result";
+  requestId: string;
+  success?: boolean;
+  userId?: number;
+  packages?: InstalledPackageRecord[];
+  totalTimeMs?: number;
+}
+
+interface WsPackageInfoResultMessage extends WsMessageBase {
+  type: "package_info_result";
+  requestId: string;
+  success?: boolean;
+  packageName?: string;
+  isSystem?: boolean;
+  applicationLabel?: string;
+  versionName?: string;
+  versionCode?: number;
+  installerPackage?: string;
+  firstInstallTime?: number;
+  lastUpdateTime?: number;
+  allowBackup?: boolean;
+  requestedPermissions?: string[];
+  grantedPermissions?: Record<string, boolean>;
+  mainActivity?: string;
+  totalTimeMs?: number;
+}
+
+interface WsLaunchIntentResultMessage extends WsMessageBase {
+  type: "launch_intent_result";
+  requestId: string;
+  success?: boolean;
+  packageName?: string;
+  componentName?: string;
+  totalTimeMs?: number;
+}
+
 interface WsNavigationEventMessage extends WsMessageBase {
   type: "navigation_event";
   event?: NavigationEvent;
@@ -544,6 +586,9 @@ type WebSocketMessage =
   | WsSetPreferenceResultMessage
   | WsRemovePreferenceResultMessage
   | WsClearPreferencesResultMessage
+  | WsInstalledPackagesResultMessage
+  | WsPackageInfoResultMessage
+  | WsLaunchIntentResultMessage
   | WsNavigationEventMessage
   | WsPackageEventMessage
   | WsInteractionEventMessage
@@ -650,6 +695,23 @@ export interface AndroidCtrlProxy extends CtrlProxyClient {
   ): Promise<HighlightOperationResult>;
 
   requestScreenshot(timeoutMs?: number, perf?: PerformanceTracker): Promise<ScreenshotResult>;
+
+  requestInstalledPackages(
+    includeSystem?: boolean,
+    userId?: number,
+    timeoutMs?: number
+  ): Promise<A11yInstalledPackagesResult>;
+
+  requestPackageInfo(
+    packageName: string,
+    options?: PackageInfoOptions,
+    timeoutMs?: number
+  ): Promise<A11yPackageInfoResult>;
+
+  requestLaunchIntent(
+    packageName: string,
+    timeoutMs?: number
+  ): Promise<A11yLaunchIntentResult>;
 }
 
 /**
@@ -684,6 +746,7 @@ export class AndroidCtrlProxyClient extends DeviceServiceClient implements Andro
   private _certificates: CtrlProxyCertificates | null = null;
   private _focus: CtrlProxyFocus | null = null;
   private _highlights: CtrlProxyHighlights | null = null;
+  private _packages: CtrlProxyPackages | null = null;
 
   // Interaction listeners
   private interactionListeners: Set<(event: InteractionEvent) => void> = new Set();
@@ -883,6 +946,36 @@ export class AndroidCtrlProxyClient extends DeviceServiceClient implements Andro
       this._highlights = new CtrlProxyHighlights(this.createDelegateContext());
     }
     return this._highlights;
+  }
+
+  private get packages(): CtrlProxyPackages {
+    if (!this._packages) {
+      this._packages = new CtrlProxyPackages(this.createDelegateContext());
+    }
+    return this._packages;
+  }
+
+  async requestInstalledPackages(
+    includeSystem: boolean = true,
+    userId?: number,
+    timeoutMs: number = 5000
+  ): Promise<A11yInstalledPackagesResult> {
+    return this.packages.requestInstalledPackages(includeSystem, userId, timeoutMs);
+  }
+
+  async requestPackageInfo(
+    packageName: string,
+    options: PackageInfoOptions = {},
+    timeoutMs: number = 5000
+  ): Promise<A11yPackageInfoResult> {
+    return this.packages.requestPackageInfo(packageName, options, timeoutMs);
+  }
+
+  async requestLaunchIntent(
+    packageName: string,
+    timeoutMs: number = 5000
+  ): Promise<A11yLaunchIntentResult> {
+    return this.packages.requestLaunchIntent(packageName, timeoutMs);
   }
 
   // ===========================================================================
@@ -1716,6 +1809,49 @@ export class AndroidCtrlProxyClient extends DeviceServiceClient implements Andro
           totalTimeMs: message.totalTimeMs, error: message.error, perfTiming: message.perfTiming
         });
 
+      }
+
+      // Handle installed packages result
+      if (message.type === "installed_packages_result" && message.requestId) {
+        this.requestManager.resolve<A11yInstalledPackagesResult>(message.requestId, {
+          success: message.success ?? false,
+          userId: message.userId ?? -1,
+          packages: message.packages ?? [],
+          totalTimeMs: message.totalTimeMs ?? 0,
+          error: message.error,
+        });
+      }
+
+      // Handle package info result
+      if (message.type === "package_info_result" && message.requestId) {
+        this.requestManager.resolve<A11yPackageInfoResult>(message.requestId, {
+          success: message.success ?? false,
+          packageName: message.packageName ?? "",
+          isSystem: message.isSystem ?? false,
+          applicationLabel: message.applicationLabel,
+          versionName: message.versionName,
+          versionCode: message.versionCode,
+          installerPackage: message.installerPackage,
+          firstInstallTime: message.firstInstallTime,
+          lastUpdateTime: message.lastUpdateTime,
+          allowBackup: message.allowBackup,
+          requestedPermissions: message.requestedPermissions ?? [],
+          grantedPermissions: message.grantedPermissions ?? {},
+          mainActivity: message.mainActivity,
+          totalTimeMs: message.totalTimeMs ?? 0,
+          error: message.error,
+        });
+      }
+
+      // Handle launch intent result
+      if (message.type === "launch_intent_result" && message.requestId) {
+        this.requestManager.resolve<A11yLaunchIntentResult>(message.requestId, {
+          success: message.success ?? false,
+          packageName: message.packageName ?? "",
+          componentName: message.componentName,
+          totalTimeMs: message.totalTimeMs ?? 0,
+          error: message.error,
+        });
       }
 
       // Handle CA certificate result

--- a/src/features/observe/android/AndroidCtrlProxyClient.ts
+++ b/src/features/observe/android/AndroidCtrlProxyClient.ts
@@ -96,6 +96,11 @@ import type {
   A11yCaCertResult,
   A11yDeviceOwnerStatusResult,
   A11yPermissionResult,
+  A11ySettingsGetResult,
+  A11ySettingsPutResult,
+  A11ySettingsListResult,
+  SettingsNamespace,
+  SettingsValueType,
   AndroidPerfTiming,
 } from "./types";
 
@@ -270,6 +275,26 @@ interface WsClipboardResultMessage extends WsRequestBase {
   type: "clipboard_result";
   action: "copy" | "paste" | "clear" | "get";
   text?: string;
+}
+
+interface WsSettingsGetResultMessage extends WsRequestBase {
+  type: "settings_get_result";
+  namespace: SettingsNamespace;
+  key: string;
+  value?: string;
+  found?: boolean;
+}
+
+interface WsSettingsPutResultMessage extends WsRequestBase {
+  type: "settings_put_result";
+  namespace: SettingsNamespace;
+  key: string;
+}
+
+interface WsSettingsListResultMessage extends WsRequestBase {
+  type: "settings_list_result";
+  namespace: SettingsNamespace;
+  entries?: Record<string, string>;
 }
 
 interface WsCaCertResultMessage extends WsRequestBase {
@@ -528,6 +553,9 @@ type WebSocketMessage =
   | WsSelectAllResultMessage
   | WsActionResultMessage
   | WsClipboardResultMessage
+  | WsSettingsGetResultMessage
+  | WsSettingsPutResultMessage
+  | WsSettingsListResultMessage
   | WsCaCertResultMessage
   | WsDeviceOwnerStatusResultMessage
   | WsPermissionResultMessage
@@ -624,6 +652,20 @@ export interface AndroidCtrlProxy extends CtrlProxyClient {
     action: "copy" | "paste" | "clear" | "get",
     text?: string, timeoutMs?: number, perf?: PerformanceTracker
   ): Promise<A11yClipboardResult>;
+
+  requestSettingsGet(
+    namespace: SettingsNamespace, key: string,
+    timeoutMs?: number, perf?: PerformanceTracker
+  ): Promise<A11ySettingsGetResult>;
+
+  requestSettingsPut(
+    namespace: SettingsNamespace, key: string, value: string | null,
+    valueType?: SettingsValueType, timeoutMs?: number, perf?: PerformanceTracker
+  ): Promise<A11ySettingsPutResult>;
+
+  requestSettingsList(
+    namespace: SettingsNamespace, timeoutMs?: number, perf?: PerformanceTracker
+  ): Promise<A11ySettingsListResult>;
 
   requestInstallCaCertificate(
     certificate: string, timeoutMs?: number, perf?: PerformanceTracker
@@ -1310,6 +1352,109 @@ export class AndroidCtrlProxyClient extends DeviceServiceClient implements Andro
     }
   }
 
+  async requestSettingsGet(
+    namespace: SettingsNamespace,
+    key: string,
+    timeoutMs: number = 5000,
+    perf: PerformanceTracker = new NoOpPerformanceTracker()
+  ): Promise<A11ySettingsGetResult> {
+    const startTime = this.timer.now();
+    try {
+      if (!this.isConnected()) {
+        return { success: false, found: false, totalTimeMs: this.timer.now() - startTime, error: "WebSocket not connected" };
+      }
+
+      const requestId = this.requestManager.generateId("settings_get");
+      const promise = this.requestManager.register<A11ySettingsGetResult>(
+        requestId, "settings_get", timeoutMs,
+        (_id, _type, timeout) => ({ success: false, found: false, totalTimeMs: this.timer.now() - startTime, error: `Settings get timeout after ${timeout}ms` })
+      );
+
+      await perf.track("sendRequest", async () => {
+        if (!this.ws || this.ws.readyState !== WebSocket.OPEN) {
+          throw new Error("WebSocket not connected");
+        }
+        this.ws.send(JSON.stringify({ type: "request_settings_get", requestId, namespace, key }));
+      });
+
+      const result = await perf.track("waitForSettingsGet", () => promise);
+      return result;
+    } catch (error) {
+      const duration = this.timer.now() - startTime;
+      logger.warn(`[CTRL_PROXY] Settings get failed after ${duration}ms: ${error}`);
+      return { success: false, found: false, totalTimeMs: duration, error: `${error}` };
+    }
+  }
+
+  async requestSettingsPut(
+    namespace: SettingsNamespace,
+    key: string,
+    value: string | null,
+    valueType: SettingsValueType = "string",
+    timeoutMs: number = 5000,
+    perf: PerformanceTracker = new NoOpPerformanceTracker()
+  ): Promise<A11ySettingsPutResult> {
+    const startTime = this.timer.now();
+    try {
+      if (!this.isConnected()) {
+        return { success: false, totalTimeMs: this.timer.now() - startTime, error: "WebSocket not connected" };
+      }
+
+      const requestId = this.requestManager.generateId("settings_put");
+      const promise = this.requestManager.register<A11ySettingsPutResult>(
+        requestId, "settings_put", timeoutMs,
+        (_id, _type, timeout) => ({ success: false, totalTimeMs: this.timer.now() - startTime, error: `Settings put timeout after ${timeout}ms` })
+      );
+
+      await perf.track("sendRequest", async () => {
+        if (!this.ws || this.ws.readyState !== WebSocket.OPEN) {
+          throw new Error("WebSocket not connected");
+        }
+        this.ws.send(JSON.stringify({ type: "request_settings_put", requestId, namespace, key, value, valueType }));
+      });
+
+      const result = await perf.track("waitForSettingsPut", () => promise);
+      return result;
+    } catch (error) {
+      const duration = this.timer.now() - startTime;
+      logger.warn(`[CTRL_PROXY] Settings put failed after ${duration}ms: ${error}`);
+      return { success: false, totalTimeMs: duration, error: `${error}` };
+    }
+  }
+
+  async requestSettingsList(
+    namespace: SettingsNamespace,
+    timeoutMs: number = 5000,
+    perf: PerformanceTracker = new NoOpPerformanceTracker()
+  ): Promise<A11ySettingsListResult> {
+    const startTime = this.timer.now();
+    try {
+      if (!this.isConnected()) {
+        return { success: false, totalTimeMs: this.timer.now() - startTime, error: "WebSocket not connected" };
+      }
+
+      const requestId = this.requestManager.generateId("settings_list");
+      const promise = this.requestManager.register<A11ySettingsListResult>(
+        requestId, "settings_list", timeoutMs,
+        (_id, _type, timeout) => ({ success: false, totalTimeMs: this.timer.now() - startTime, error: `Settings list timeout after ${timeout}ms` })
+      );
+
+      await perf.track("sendRequest", async () => {
+        if (!this.ws || this.ws.readyState !== WebSocket.OPEN) {
+          throw new Error("WebSocket not connected");
+        }
+        this.ws.send(JSON.stringify({ type: "request_settings_list", requestId, namespace }));
+      });
+
+      const result = await perf.track("waitForSettingsList", () => promise);
+      return result;
+    } catch (error) {
+      const duration = this.timer.now() - startTime;
+      logger.warn(`[CTRL_PROXY] Settings list failed after ${duration}ms: ${error}`);
+      return { success: false, totalTimeMs: duration, error: `${error}` };
+    }
+  }
+
   /**
    * Execute a global action (back, home, recents, etc.) via the accessibility service.
    */
@@ -1716,6 +1861,28 @@ export class AndroidCtrlProxyClient extends DeviceServiceClient implements Andro
           totalTimeMs: message.totalTimeMs, error: message.error, perfTiming: message.perfTiming
         });
 
+      }
+
+      // Handle settings results
+      if (message.type === "settings_get_result" && message.requestId) {
+        this.requestManager.resolve<A11ySettingsGetResult>(message.requestId, {
+          success: message.success, value: message.value, found: message.found ?? false,
+          totalTimeMs: message.totalTimeMs, error: message.error, perfTiming: message.perfTiming
+        });
+      }
+
+      if (message.type === "settings_put_result" && message.requestId) {
+        this.requestManager.resolve<A11ySettingsPutResult>(message.requestId, {
+          success: message.success,
+          totalTimeMs: message.totalTimeMs, error: message.error, perfTiming: message.perfTiming
+        });
+      }
+
+      if (message.type === "settings_list_result" && message.requestId) {
+        this.requestManager.resolve<A11ySettingsListResult>(message.requestId, {
+          success: message.success, entries: message.entries,
+          totalTimeMs: message.totalTimeMs, error: message.error, perfTiming: message.perfTiming
+        });
       }
 
       // Handle CA certificate result

--- a/src/features/observe/android/CtrlProxyPackages.ts
+++ b/src/features/observe/android/CtrlProxyPackages.ts
@@ -16,8 +16,6 @@ import type {
 
 export interface PackageInfoOptions {
   includePermissions?: boolean;
-  includeActivities?: boolean;
-  includeIntentFilters?: boolean;
 }
 
 export class CtrlProxyPackages {
@@ -138,8 +136,6 @@ export class CtrlProxyPackages {
           requestId,
           packageName,
           includePermissions: options.includePermissions ?? true,
-          includeActivities: options.includeActivities ?? false,
-          includeIntentFilters: options.includeIntentFilters ?? false,
         })
       );
 

--- a/src/features/observe/android/CtrlProxyPackages.ts
+++ b/src/features/observe/android/CtrlProxyPackages.ts
@@ -1,0 +1,216 @@
+/**
+ * CtrlProxyPackages - Delegate for PackageManager-backed queries over WebSocket.
+ *
+ * Replaces ADB `pm list packages` / `dumpsys package <pkg>` / `pm dump <pkg>` round-trips
+ * with a direct PackageManager call inside the accessibility service.
+ */
+
+import WebSocket from "ws";
+import type { DelegateContext } from "./types";
+import { generateSecureId } from "./types";
+import type {
+  A11yInstalledPackagesResult,
+  A11yPackageInfoResult,
+  A11yLaunchIntentResult,
+} from "./types";
+
+export interface PackageInfoOptions {
+  includePermissions?: boolean;
+  includeActivities?: boolean;
+  includeIntentFilters?: boolean;
+}
+
+export class CtrlProxyPackages {
+  private readonly context: DelegateContext;
+
+  constructor(context: DelegateContext) {
+    this.context = context;
+  }
+
+  async requestInstalledPackages(
+    includeSystem: boolean = true,
+    userId?: number,
+    timeoutMs: number = 5000
+  ): Promise<A11yInstalledPackagesResult> {
+    const startTime = this.context.timer.now();
+
+    try {
+      const ws0 = this.context.getWebSocket();
+      const connected = ws0 !== null && ws0 !== undefined && ws0.readyState === WebSocket.OPEN;
+      // Why: package queries are an optimization over ADB. Don't trigger a slow
+      // WebSocket setup just for the optimistic path — let callers fall back to ADB.
+      if (!connected) {
+        return {
+          success: false,
+          userId: userId ?? -1,
+          packages: [],
+          totalTimeMs: this.context.timer.now() - startTime,
+          error: "WebSocket not connected",
+        };
+      }
+
+      const requestId = `installed_packages_${this.context.timer.now()}_${generateSecureId()}`;
+      const resultPromise = this.context.requestManager.register<A11yInstalledPackagesResult>(
+        requestId,
+        "installed_packages",
+        timeoutMs,
+        (_id, _type, timeout) => ({
+          success: false,
+          userId: userId ?? -1,
+          packages: [],
+          totalTimeMs: this.context.timer.now() - startTime,
+          error: `Installed packages timeout after ${timeout}ms`,
+        })
+      );
+
+      const ws = this.context.getWebSocket();
+      if (!ws || ws.readyState !== WebSocket.OPEN) {
+        throw new Error("WebSocket not connected");
+      }
+      ws.send(
+        JSON.stringify({
+          type: "request_installed_packages",
+          requestId,
+          includeSystem,
+          userId: userId ?? null,
+        })
+      );
+
+      return await resultPromise;
+    } catch (error) {
+      return {
+        success: false,
+        userId: userId ?? -1,
+        packages: [],
+        totalTimeMs: this.context.timer.now() - startTime,
+        error: `${error}`,
+      };
+    }
+  }
+
+  async requestPackageInfo(
+    packageName: string,
+    options: PackageInfoOptions = {},
+    timeoutMs: number = 5000
+  ): Promise<A11yPackageInfoResult> {
+    const startTime = this.context.timer.now();
+
+    try {
+      const ws0 = this.context.getWebSocket();
+      const connected = ws0 !== null && ws0 !== undefined && ws0.readyState === WebSocket.OPEN;
+      // Why: package queries are an optimization over ADB. Don't trigger a slow
+      // WebSocket setup just for the optimistic path — let callers fall back to ADB.
+      if (!connected) {
+        return {
+          success: false,
+          packageName,
+          isSystem: false,
+          requestedPermissions: [],
+          grantedPermissions: {},
+          totalTimeMs: this.context.timer.now() - startTime,
+          error: "WebSocket not connected",
+        };
+      }
+
+      const requestId = `package_info_${this.context.timer.now()}_${generateSecureId()}`;
+      const resultPromise = this.context.requestManager.register<A11yPackageInfoResult>(
+        requestId,
+        "package_info",
+        timeoutMs,
+        (_id, _type, timeout) => ({
+          success: false,
+          packageName,
+          isSystem: false,
+          requestedPermissions: [],
+          grantedPermissions: {},
+          totalTimeMs: this.context.timer.now() - startTime,
+          error: `Package info timeout after ${timeout}ms`,
+        })
+      );
+
+      const ws = this.context.getWebSocket();
+      if (!ws || ws.readyState !== WebSocket.OPEN) {
+        throw new Error("WebSocket not connected");
+      }
+      ws.send(
+        JSON.stringify({
+          type: "request_package_info",
+          requestId,
+          packageName,
+          includePermissions: options.includePermissions ?? true,
+          includeActivities: options.includeActivities ?? false,
+          includeIntentFilters: options.includeIntentFilters ?? false,
+        })
+      );
+
+      return await resultPromise;
+    } catch (error) {
+      return {
+        success: false,
+        packageName,
+        isSystem: false,
+        requestedPermissions: [],
+        grantedPermissions: {},
+        totalTimeMs: this.context.timer.now() - startTime,
+        error: `${error}`,
+      };
+    }
+  }
+
+  async requestLaunchIntent(
+    packageName: string,
+    timeoutMs: number = 5000
+  ): Promise<A11yLaunchIntentResult> {
+    const startTime = this.context.timer.now();
+
+    try {
+      const ws0 = this.context.getWebSocket();
+      const connected = ws0 !== null && ws0 !== undefined && ws0.readyState === WebSocket.OPEN;
+      // Why: package queries are an optimization over ADB. Don't trigger a slow
+      // WebSocket setup just for the optimistic path — let callers fall back to ADB.
+      if (!connected) {
+        return {
+          success: false,
+          packageName,
+          totalTimeMs: this.context.timer.now() - startTime,
+          error: "WebSocket not connected",
+        };
+      }
+
+      const requestId = `launch_intent_${this.context.timer.now()}_${generateSecureId()}`;
+      const resultPromise = this.context.requestManager.register<A11yLaunchIntentResult>(
+        requestId,
+        "launch_intent",
+        timeoutMs,
+        (_id, _type, timeout) => ({
+          success: false,
+          packageName,
+          totalTimeMs: this.context.timer.now() - startTime,
+          error: `Launch intent timeout after ${timeout}ms`,
+        })
+      );
+
+      const ws = this.context.getWebSocket();
+      if (!ws || ws.readyState !== WebSocket.OPEN) {
+        throw new Error("WebSocket not connected");
+      }
+      ws.send(
+        JSON.stringify({
+          type: "request_launch_intent",
+          requestId,
+          packageName,
+        })
+      );
+
+      return await resultPromise;
+    } catch (error) {
+      return {
+        success: false,
+        packageName,
+        totalTimeMs: this.context.timer.now() - startTime,
+        error: `${error}`,
+      };
+    }
+  }
+
+}

--- a/src/features/observe/android/index.ts
+++ b/src/features/observe/android/index.ts
@@ -37,6 +37,11 @@ export type {
   A11yCaCertResult,
   A11yDeviceOwnerStatusResult,
   A11yPermissionResult,
+  A11ySettingsGetResult,
+  A11ySettingsPutResult,
+  A11ySettingsListResult,
+  SettingsNamespace,
+  SettingsValueType,
   AndroidPerfTiming,
 
   // Internal types (for delegate usage)

--- a/src/features/observe/android/types.ts
+++ b/src/features/observe/android/types.ts
@@ -176,6 +176,26 @@ export interface A11yClipboardResult extends BaseResult {
   text?: string; // For 'get' action, the clipboard content
 }
 
+/** Settings.System/Secure/Global namespace */
+export type SettingsNamespace = "system" | "secure" | "global";
+
+/** Settings value type for writes */
+export type SettingsValueType = "string" | "int" | "long" | "float";
+
+/** Result of a settings read via accessibility service */
+export interface A11ySettingsGetResult extends BaseResult {
+  value?: string;
+  found: boolean;
+}
+
+/** Result of a settings write via accessibility service */
+export type A11ySettingsPutResult = BaseResult;
+
+/** Result of a settings list via accessibility service */
+export interface A11ySettingsListResult extends BaseResult {
+  entries?: Record<string, string>;
+}
+
 /** CA certificate result from accessibility service */
 export interface A11yCaCertResult extends BaseResult {
   action: "install" | "remove";

--- a/src/features/observe/android/types.ts
+++ b/src/features/observe/android/types.ts
@@ -200,6 +200,38 @@ export interface A11yPermissionResult extends BaseResult {
   adbCommand?: string;
 }
 
+export interface InstalledPackageRecord {
+  packageName: string;
+  isSystem: boolean;
+  versionName?: string;
+  versionCode?: number;
+}
+
+export interface A11yInstalledPackagesResult extends BaseResult {
+  userId: number;
+  packages: InstalledPackageRecord[];
+}
+
+export interface A11yPackageInfoResult extends BaseResult {
+  packageName: string;
+  isSystem: boolean;
+  applicationLabel?: string;
+  versionName?: string;
+  versionCode?: number;
+  installerPackage?: string;
+  firstInstallTime?: number;
+  lastUpdateTime?: number;
+  allowBackup?: boolean;
+  requestedPermissions: string[];
+  grantedPermissions: Record<string, boolean>;
+  mainActivity?: string;
+}
+
+export interface A11yLaunchIntentResult extends BaseResult {
+  packageName: string;
+  componentName?: string;
+}
+
 /**
  * Extended context for hierarchy delegate with additional state access.
  */

--- a/src/features/utility/DeviceState.ts
+++ b/src/features/utility/DeviceState.ts
@@ -3,6 +3,8 @@ import type { BootedDevice, ExecResult } from "../../models";
 import { SimCtlClient } from "../../utils/ios-cmdline-tools/SimCtlClient";
 import { isIosSimulatorDevice } from "../action/IosSimulatorPermissions";
 import { outputLooksLikeShellFailure } from "../../utils/android-cmdline-tools/shellOutputHeuristics";
+import { AndroidCtrlProxyClient } from "../observe/android/AndroidCtrlProxyClient";
+import { logger } from "../../utils/logger";
 
 export type DoNotDisturbMode = "off" | "none" | "priority" | "alarms";
 
@@ -170,6 +172,15 @@ export class DeviceState {
   }
 
   private async getAndroidDoNotDisturb(): Promise<DoNotDisturbState> {
+    try {
+      const a11y = AndroidCtrlProxyClient.getInstance(this.device);
+      const a11yResult = await a11y.requestSettingsGet("global", "zen_mode");
+      if (a11yResult.success) {
+        return parseAndroidZenMode(a11yResult.value ?? "");
+      }
+    } catch (error) {
+      logger.debug(`[DeviceState] a11y zen_mode get failed: ${error}`);
+    }
     try {
       const adb = this.adbFactory.create(this.device);
       const result = await adb.executeCommand("shell settings get global zen_mode", undefined, undefined, true);

--- a/src/features/utility/SystemConfigurationManager.ts
+++ b/src/features/utility/SystemConfigurationManager.ts
@@ -5,6 +5,8 @@ import { DefaultProcessExecutor } from "../../utils/ProcessExecutor";
 import { logger } from "../../utils/logger";
 import type { Timer } from "../../utils/SystemTimer";
 import { defaultTimer } from "../../utils/SystemTimer";
+import { AndroidCtrlProxyClient } from "../observe/android/AndroidCtrlProxyClient";
+import type { SettingsNamespace } from "../observe/android";
 import {
   BootedDevice,
   GetCalendarSystemResult,
@@ -99,7 +101,7 @@ export class SystemConfigurationManager {
 
     for (const attempt of commandAttempts) {
       try {
-        await this.adb.executeCommand(attempt.command);
+        await this.runShellCommand(attempt.command);
         appliedMethod = attempt.method;
         break;
       } catch (error) {
@@ -213,7 +215,7 @@ export class SystemConfigurationManager {
 
     for (const key of targetKeys) {
       try {
-        await this.adb.executeCommand(`shell settings put global ${key} ${value}`);
+        await this.runShellCommand(`shell settings put global ${key} ${value}`);
         appliedSettings.push(key);
       } catch (error) {
         logger.warn(`[SystemConfigurationManager] Failed to set ${key}: ${error}`);
@@ -273,7 +275,7 @@ export class SystemConfigurationManager {
     const value = enabled ? "24" : "12";
 
     try {
-      await this.adb.executeCommand(`shell settings put system time_12_24 ${value}`);
+      await this.runShellCommand(`shell settings put system time_12_24 ${value}`);
       return {
         success: true,
         enabled,
@@ -316,7 +318,7 @@ export class SystemConfigurationManager {
     const previousCalendarSystem = previous.calendarSystem ?? null;
 
     try {
-      await this.adb.executeCommand(`shell settings put system calendar_type ${trimmed}`);
+      await this.runShellCommand(`shell settings put system calendar_type ${trimmed}`);
       const readBack = await this.readSetting("shell settings get system calendar_type");
       if (!readBack || readBack !== trimmed) {
         return {
@@ -458,6 +460,20 @@ export class SystemConfigurationManager {
   }
 
   private async readSetting(command: string): Promise<string | null> {
+    const match = command.match(/^shell\s+settings\s+get\s+(system|secure|global)\s+(\S+)\s*$/);
+    if (match && this.device.platform === "android") {
+      const namespace = match[1] as SettingsNamespace;
+      const key = match[2];
+      try {
+        const a11y = AndroidCtrlProxyClient.getInstance(this.device);
+        const a11yResult = await a11y.requestSettingsGet(namespace, key);
+        if (a11yResult.success) {
+          return this.normalizeSettingValue(a11yResult.found ? (a11yResult.value ?? null) : null);
+        }
+      } catch (error) {
+        logger.debug(`[SystemConfigurationManager] a11y settings get failed for ${namespace}/${key}: ${error}`);
+      }
+    }
     try {
       const result = await this.adb.executeCommand(command, undefined, undefined, true);
       return this.normalizeSettingValue(result.stdout);
@@ -465,6 +481,28 @@ export class SystemConfigurationManager {
       logger.warn(`[SystemConfigurationManager] Failed to read setting (${command}): ${error}`);
       return null;
     }
+  }
+
+  // Intercepts "shell settings put <ns> <key> <value>" and routes through the
+  // accessibility service first, falling back to ADB. Any other shell command
+  // is passed through to adb.executeCommand unchanged.
+  private async runShellCommand(command: string): Promise<void> {
+    const putMatch = command.match(/^shell\s+settings\s+put\s+(system|secure|global)\s+(\S+)\s+(.+)$/);
+    if (putMatch && this.device.platform === "android") {
+      const namespace = putMatch[1] as SettingsNamespace;
+      const key = putMatch[2];
+      const value = putMatch[3].trim();
+      try {
+        const a11y = AndroidCtrlProxyClient.getInstance(this.device);
+        const a11yResult = await a11y.requestSettingsPut(namespace, key, value, "string");
+        if (a11yResult.success) {
+          return;
+        }
+      } catch (error) {
+        logger.debug(`[SystemConfigurationManager] a11y settings put failed for ${namespace}/${key}: ${error}`);
+      }
+    }
+    await this.adb.executeCommand(command);
   }
 
   private parseLocaleList(value: string | null): string | null {

--- a/src/server/systemTrayHelpers.ts
+++ b/src/server/systemTrayHelpers.ts
@@ -16,6 +16,7 @@ import type { ObserveScreenExecuteOptions } from "../features/observe/interfaces
 import { RealObserveScreen } from "../features/observe/ObserveScreen";
 import { defaultAdbClientFactory } from "../utils/android-cmdline-tools/AdbClientFactory";
 import { IOSCtrlProxyClient } from "../features/observe/ios";
+import { AndroidCtrlProxyClient } from "../features/observe/android";
 import type { ElementFinder } from "../utils/interfaces/ElementFinder";
 import { DefaultElementFinder } from "../features/utility/ElementFinder";
 import { DefaultElementGeometry } from "../features/utility/ElementGeometry";
@@ -444,6 +445,19 @@ const parseAppLabelFromDumpsys = (stdout: string): string | null => {
 export const resolveAppLabel = async (device: BootedDevice, appId: string): Promise<string | null> => {
   if (device.platform !== "android") {
     return null;
+  }
+
+  // Why: PackageManager.getApplicationLabel returns the same label that the
+  // dumpsys output exposes via application-label resources, but in a single
+  // WebSocket call rather than a multi-KB ADB roundtrip.
+  try {
+    const a11y = AndroidCtrlProxyClient.getInstance(device);
+    const info = await a11y.requestPackageInfo(appId, { includePermissions: false }, 3000);
+    if (info.success && info.applicationLabel) {
+      return info.applicationLabel;
+    }
+  } catch {
+    // fall through
   }
 
   try {

--- a/src/utils/KeepScreenAwakeManager.ts
+++ b/src/utils/KeepScreenAwakeManager.ts
@@ -2,6 +2,7 @@ import { BootedDevice } from "../models";
 import { AdbClientFactory, defaultAdbClientFactory } from "./android-cmdline-tools/AdbClientFactory";
 import type { AdbExecutor } from "./android-cmdline-tools/interfaces/AdbExecutor";
 import { logger } from "./logger";
+import { AndroidCtrlProxyClient } from "../features/observe/android/AndroidCtrlProxyClient";
 
 export const KEEP_SCREEN_AWAKE_STATE_KEY = "keepScreenAwakeState";
 
@@ -206,18 +207,14 @@ export class KeepScreenAwakeManager {
     };
 
     try {
-      await this.adb.executeCommand(
-        `shell settings put global stay_on_while_plugged_in ${STAY_ON_WHILE_PLUGGED_IN_MASK}`
-      );
+      await this.putSetting("global", "stay_on_while_plugged_in", STAY_ON_WHILE_PLUGGED_IN_MASK, "int");
       appliedSettings.stayOnWhilePluggedIn = true;
     } catch (error) {
       logger.warn(`[KeepScreenAwake] Failed to set stay_on_while_plugged_in on ${this.device.deviceId}: ${error}`);
     }
 
     try {
-      await this.adb.executeCommand(
-        `shell settings put system screen_off_timeout ${MAX_SCREEN_OFF_TIMEOUT_MS}`
-      );
+      await this.putSetting("system", "screen_off_timeout", MAX_SCREEN_OFF_TIMEOUT_MS, "long");
       appliedSettings.screenOffTimeout = true;
     } catch (error) {
       logger.warn(`[KeepScreenAwake] Failed to set screen_off_timeout on ${this.device.deviceId}: ${error}`);
@@ -268,6 +265,20 @@ export class KeepScreenAwakeManager {
     key: string
   ): Promise<string | null | undefined> {
     try {
+      const a11y = AndroidCtrlProxyClient.getInstance(this.device);
+      const a11yResult = await a11y.requestSettingsGet(scope, key);
+      if (a11yResult.success) {
+        const value = a11yResult.found ? (a11yResult.value ?? null) : null;
+        if (value === null) {
+          return null;
+        }
+        const trimmed = value.trim();
+        return (!trimmed || trimmed === "null") ? null : trimmed;
+      }
+    } catch (error) {
+      logger.debug(`[KeepScreenAwake] a11y settings get failed for ${scope}/${key}: ${error}`);
+    }
+    try {
       const result = await this.adb.executeCommand(`shell settings get ${scope} ${key}`, undefined, undefined, true);
       const trimmed = result.stdout.trim();
       if (!trimmed || trimmed === "null") {
@@ -280,6 +291,40 @@ export class KeepScreenAwakeManager {
     }
   }
 
+  private async putSetting(
+    scope: "global" | "system",
+    key: string,
+    value: string,
+    valueType: "string" | "int" | "long" | "float" = "string"
+  ): Promise<void> {
+    try {
+      const a11y = AndroidCtrlProxyClient.getInstance(this.device);
+      const a11yResult = await a11y.requestSettingsPut(scope, key, value, valueType);
+      if (a11yResult.success) {
+        return;
+      }
+    } catch (error) {
+      logger.debug(`[KeepScreenAwake] a11y settings put failed for ${scope}/${key}: ${error}`);
+    }
+    await this.adb.executeCommand(`shell settings put ${scope} ${key} ${value}`);
+  }
+
+  private async deleteSetting(
+    scope: "global" | "system",
+    key: string
+  ): Promise<void> {
+    try {
+      const a11y = AndroidCtrlProxyClient.getInstance(this.device);
+      const a11yResult = await a11y.requestSettingsPut(scope, key, null);
+      if (a11yResult.success) {
+        return;
+      }
+    } catch (error) {
+      logger.debug(`[KeepScreenAwake] a11y settings delete failed for ${scope}/${key}: ${error}`);
+    }
+    await this.adb.executeCommand(`shell settings delete ${scope} ${key}`);
+  }
+
   private async restoreSetting(
     scope: "global" | "system",
     key: string,
@@ -290,12 +335,12 @@ export class KeepScreenAwakeManager {
       return false;
     }
 
-    const command = originalValue === null
-      ? `shell settings delete ${scope} ${key}`
-      : `shell settings put ${scope} ${key} ${originalValue}`;
-
     try {
-      await this.adb.executeCommand(command);
+      if (originalValue === null) {
+        await this.deleteSetting(scope, key);
+      } else {
+        await this.putSetting(scope, key, originalValue);
+      }
       return true;
     } catch (error) {
       logger.warn(`[KeepScreenAwake] Failed to restore ${scope} ${key} on ${this.device.deviceId}: ${error}`);

--- a/test/features/action/Rotate.test.ts
+++ b/test/features/action/Rotate.test.ts
@@ -193,12 +193,14 @@ describe("Rotate", () => {
       // Setup: device is in portrait, rotating to landscape
       fakeAdb.setCommandResponse("shell settings get system user_rotation", createExecResult("0"));
       fakeAdb.setCommandResponse("shell settings get system accelerometer_rotation", createExecResult("1"));
-      fakeAdb.setCommandResponse("shell \"settings put system accelerometer_rotation 0; settings put system user_rotation 1\"", createExecResult());
+      fakeAdb.setCommandResponse("shell settings put system accelerometer_rotation 0", createExecResult());
+      fakeAdb.setCommandResponse("shell settings put system user_rotation 1", createExecResult());
 
       await rotate.execute("landscape");
 
-      // Verify the combined rotation command was executed
-      expect(fakeAdb.wasCommandExecuted("shell \"settings put system accelerometer_rotation 0; settings put system user_rotation 1\"")).toBe(true);
+      // Verify both rotation commands were executed
+      expect(fakeAdb.wasCommandExecuted("shell settings put system accelerometer_rotation 0")).toBe(true);
+      expect(fakeAdb.wasCommandExecuted("shell settings put system user_rotation 1")).toBe(true);
     });
 
     test("should unlock orientation if locked before rotation", async () => {
@@ -206,15 +208,17 @@ describe("Rotate", () => {
       fakeAdb.setCommandResponse("shell settings get system user_rotation", createExecResult("1"));
       fakeAdb.setCommandResponse("shell settings get system accelerometer_rotation", createExecResult("0")); // Locked
       fakeAdb.setCommandResponse("shell settings put system accelerometer_rotation 1", createExecResult()); // Unlock
-      fakeAdb.setCommandResponse("shell \"settings put system accelerometer_rotation 0; settings put system user_rotation 0\"", createExecResult());
+      fakeAdb.setCommandResponse("shell settings put system accelerometer_rotation 0", createExecResult());
+      fakeAdb.setCommandResponse("shell settings put system user_rotation 0", createExecResult());
 
       const result = await rotate.execute("portrait");
 
       expect(result.success).toBe(true);
       // Verify that the unlock command was executed
       expect(fakeAdb.wasCommandExecuted("shell settings put system accelerometer_rotation 1")).toBe(true);
-      // Verify the rotation command was executed
-      expect(fakeAdb.wasCommandExecuted("shell \"settings put system accelerometer_rotation 0; settings put system user_rotation 0\"")).toBe(true);
+      // Verify the rotation commands were executed
+      expect(fakeAdb.wasCommandExecuted("shell settings put system accelerometer_rotation 0")).toBe(true);
+      expect(fakeAdb.wasCommandExecuted("shell settings put system user_rotation 0")).toBe(true);
     });
   });
 

--- a/test/features/observe/android/CtrlProxyPackages.test.ts
+++ b/test/features/observe/android/CtrlProxyPackages.test.ts
@@ -1,0 +1,271 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { AndroidCtrlProxyClient } from "../../../../src/features/observe/android";
+import { NavigationGraphManager } from "../../../../src/features/navigation/NavigationGraphManager";
+import { FakeAdbExecutor } from "../../../fakes/FakeAdbExecutor";
+import { AndroidCtrlProxyManager } from "../../../../src/utils/CtrlProxyManager";
+import { FakeAdbClientFactory } from "../../../fakes/FakeAdbClientFactory";
+import { BootedDevice } from "../../../../src/models";
+import {
+  FakeWebSocket,
+  WebSocketState
+} from "../../../fakes/FakeWebSocket";
+import { FakeTimer } from "../../../fakes/FakeTimer";
+
+describe("CtrlProxyPackages (Android)", function() {
+  let fakeAdb: FakeAdbExecutor;
+  let testDevice: BootedDevice;
+  let fakeTimer: FakeTimer;
+  const serverPort: number = 8765;
+
+  beforeEach(function() {
+    fakeTimer = new FakeTimer();
+    fakeTimer.enableAutoAdvance();
+
+    fakeAdb = new FakeAdbExecutor();
+    fakeAdb.setCommandResponse("forward", { stdout: `${serverPort}`, stderr: "" });
+    fakeAdb.setScreenState(true);
+
+    testDevice = {
+      deviceId: "test-device-packages",
+      platform: "android",
+      isEmulator: true,
+      name: "Test Device"
+    };
+
+    AndroidCtrlProxyManager.resetInstances();
+    AndroidCtrlProxyClient.resetInstances();
+    AndroidCtrlProxyManager.getInstance(testDevice, new FakeAdbClientFactory()).clearAvailabilityCache();
+  });
+
+  afterEach(function() {
+    NavigationGraphManager.getInstance();
+  });
+
+  class CapturingWebSocket extends FakeWebSocket {
+    sentMessages: string[] = [];
+    send(data: any): void {
+      this.sentMessages.push(data.toString());
+      super.send(data);
+    }
+  }
+
+  const createCapturingFactory = (timer?: FakeTimer): {
+    factory: (url: string) => CapturingWebSocket;
+    getSocket: () => CapturingWebSocket | null;
+  } => {
+    let socket: CapturingWebSocket | null = null;
+    return {
+      factory: (url: string) => {
+        socket = new CapturingWebSocket(url, "none", 0, timer);
+        return socket;
+      },
+      getSocket: () => socket
+    };
+  };
+
+  const waitForSocketOpen = async (socket: FakeWebSocket | null): Promise<void> => {
+    if (!socket || socket.readyState === WebSocketState.OPEN) {return;}
+    await new Promise<void>(resolve => socket.once("open", () => resolve()));
+  };
+
+  const waitForSocket = async (getSocket: () => CapturingWebSocket | null): Promise<CapturingWebSocket | null> => {
+    for (let i = 0; i < 5; i++) {
+      const s = getSocket();
+      if (s) {return s;}
+      await new Promise(r => setImmediate(r));
+    }
+    return getSocket();
+  };
+
+  const waitForSentMessages = async (socket: CapturingWebSocket | null, minCount = 1): Promise<void> => {
+    if (!socket) {return;}
+    for (let i = 0; i < 10; i++) {
+      if (socket.sentMessages.length >= minCount) {return;}
+      await new Promise(r => setImmediate(r));
+    }
+  };
+
+  /**
+   * Find the most recent message of a given type. The client sends control messages
+   * on connect (e.g. set_network_mock_rules) that interleave with test sends.
+   */
+  const findSentMessage = (socket: CapturingWebSocket, type: string): any => {
+    for (let i = socket.sentMessages.length - 1; i >= 0; i--) {
+      try {
+        const parsed = JSON.parse(socket.sentMessages[i]);
+        if (parsed.type === type) {return parsed;}
+      } catch {
+        // skip
+      }
+    }
+    throw new Error(`No message of type ${type} in: ${socket.sentMessages.join(", ")}`);
+  };
+
+  describe("requestInstalledPackages", function() {
+    test("sends request_installed_packages and resolves on result", async function() {
+      const { factory, getSocket } = createCapturingFactory(fakeTimer);
+      const client = AndroidCtrlProxyClient.createForTesting(testDevice, fakeAdb, factory, fakeTimer);
+      try {
+        // Trigger a connection (any method that calls ensureConnected works)
+        await client.ensureConnected();
+        const socket = await waitForSocket(getSocket);
+        await waitForSocketOpen(socket);
+
+        const baseCount = socket!.sentMessages.length;
+        const resultPromise = client.requestInstalledPackages(true);
+        await waitForSentMessages(socket, baseCount + 1);
+
+        const sent = findSentMessage(socket!, "request_installed_packages");
+        expect(sent.includeSystem).toBe(true);
+
+        socket!.simulateMessage(JSON.stringify({
+          type: "installed_packages_result",
+          requestId: sent.requestId,
+          success: true,
+          userId: 0,
+          packages: [
+            { packageName: "com.example.app", isSystem: false, versionName: "1.0", versionCode: 1 },
+            { packageName: "com.android.systemui", isSystem: true },
+          ],
+          totalTimeMs: 10,
+        }));
+
+        const result = await resultPromise;
+        expect(result.success).toBe(true);
+        expect(result.userId).toBe(0);
+        expect(result.packages).toHaveLength(2);
+        expect(result.packages[0].packageName).toBe("com.example.app");
+        expect(result.packages[0].isSystem).toBe(false);
+        expect(result.packages[1].isSystem).toBe(true);
+      } finally {
+        await client.close();
+      }
+    });
+
+    test("returns error when WebSocket not connected", async function() {
+      const { factory } = createCapturingFactory(fakeTimer);
+      const client = AndroidCtrlProxyClient.createForTesting(testDevice, fakeAdb, factory, fakeTimer);
+      try {
+        const result = await client.requestInstalledPackages(true);
+        expect(result.success).toBe(false);
+        expect(result.error).toContain("WebSocket not connected");
+      } finally {
+        await client.close();
+      }
+    });
+  });
+
+  describe("requestPackageInfo", function() {
+    test("sends request_package_info and resolves with package details", async function() {
+      const { factory, getSocket } = createCapturingFactory(fakeTimer);
+      const client = AndroidCtrlProxyClient.createForTesting(testDevice, fakeAdb, factory, fakeTimer);
+      try {
+        await client.ensureConnected();
+        const socket = await waitForSocket(getSocket);
+        await waitForSocketOpen(socket);
+
+        const baseCount = socket!.sentMessages.length;
+        const resultPromise = client.requestPackageInfo("com.example.app", { includePermissions: true });
+        await waitForSentMessages(socket, baseCount + 1);
+
+        const sent = findSentMessage(socket!, "request_package_info");
+        expect(sent.packageName).toBe("com.example.app");
+        expect(sent.includePermissions).toBe(true);
+
+        socket!.simulateMessage(JSON.stringify({
+          type: "package_info_result",
+          requestId: sent.requestId,
+          success: true,
+          packageName: "com.example.app",
+          isSystem: false,
+          applicationLabel: "Example",
+          versionName: "1.2.3",
+          versionCode: 42,
+          installerPackage: "com.android.vending",
+          firstInstallTime: 100,
+          lastUpdateTime: 200,
+          allowBackup: true,
+          requestedPermissions: ["android.permission.CAMERA"],
+          grantedPermissions: { "android.permission.CAMERA": true },
+          mainActivity: "com.example.app/.MainActivity",
+          totalTimeMs: 5,
+        }));
+
+        const result = await resultPromise;
+        expect(result.success).toBe(true);
+        expect(result.applicationLabel).toBe("Example");
+        expect(result.versionName).toBe("1.2.3");
+        expect(result.versionCode).toBe(42);
+        expect(result.allowBackup).toBe(true);
+        expect(result.grantedPermissions["android.permission.CAMERA"]).toBe(true);
+        expect(result.mainActivity).toBe("com.example.app/.MainActivity");
+      } finally {
+        await client.close();
+      }
+    });
+
+    test("returns error when package not found", async function() {
+      const { factory, getSocket } = createCapturingFactory(fakeTimer);
+      const client = AndroidCtrlProxyClient.createForTesting(testDevice, fakeAdb, factory, fakeTimer);
+      try {
+        await client.ensureConnected();
+        const socket = await waitForSocket(getSocket);
+        await waitForSocketOpen(socket);
+
+        const baseCount = socket!.sentMessages.length;
+        const resultPromise = client.requestPackageInfo("com.missing.app");
+        await waitForSentMessages(socket, baseCount + 1);
+
+        const sent = findSentMessage(socket!, "request_package_info");
+        socket!.simulateMessage(JSON.stringify({
+          type: "package_info_result",
+          requestId: sent.requestId,
+          success: false,
+          packageName: "com.missing.app",
+          error: "Package not installed or not visible: com.missing.app",
+          totalTimeMs: 1,
+        }));
+
+        const result = await resultPromise;
+        expect(result.success).toBe(false);
+        expect(result.error).toContain("Package not installed");
+      } finally {
+        await client.close();
+      }
+    });
+  });
+
+  describe("requestLaunchIntent", function() {
+    test("sends request_launch_intent and resolves with componentName", async function() {
+      const { factory, getSocket } = createCapturingFactory(fakeTimer);
+      const client = AndroidCtrlProxyClient.createForTesting(testDevice, fakeAdb, factory, fakeTimer);
+      try {
+        await client.ensureConnected();
+        const socket = await waitForSocket(getSocket);
+        await waitForSocketOpen(socket);
+
+        const baseCount = socket!.sentMessages.length;
+        const resultPromise = client.requestLaunchIntent("com.example.app");
+        await waitForSentMessages(socket, baseCount + 1);
+
+        const sent = findSentMessage(socket!, "request_launch_intent");
+        expect(sent.packageName).toBe("com.example.app");
+
+        socket!.simulateMessage(JSON.stringify({
+          type: "launch_intent_result",
+          requestId: sent.requestId,
+          success: true,
+          packageName: "com.example.app",
+          componentName: "com.example.app/.MainActivity",
+          totalTimeMs: 2,
+        }));
+
+        const result = await resultPromise;
+        expect(result.success).toBe(true);
+        expect(result.componentName).toBe("com.example.app/.MainActivity");
+      } finally {
+        await client.close();
+      }
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Moves Android `adb shell settings get/put/list` and `adb shell pm list packages` / `dumpsys package <app>` / `pm dump <app>` off of per-call ADB round-trips and onto the CtrlProxy accessibility-service WebSocket.
- Each migrated TS caller still falls back to ADB on disconnect / SecurityException / cross-user requests, so behavior is unchanged.
- Aggregate savings on a typical workflow: ~300–500 ms (rotation, app enumeration, package metadata).

## Protocol additions
- `RequestSettingsGet/Put/List` + `SettingsGetResult/PutResult/ListResult` (string/int/long/float value types, null value = delete)
- `RequestInstalledPackages`, `RequestPackageInfo`, `RequestLaunchIntent` + matching result types
- Round-trip JSON tests for each new type

## Kotlin (control-proxy)
- `performSettingsRead/Write/List` via `Settings.System/Secure/Global` content resolver; `SecurityException` surfaced cleanly so callers fall back to ADB without crashing
- `performInstalledPackages/PackageInfo/LaunchIntent` via `PackageManager`; non-current-user requests return an error so callers fall back to ADB `--user N`
- All result broadcasts use typed `WebSocketResponse` data classes (no hand-rolled JSON)
- Dispatcher decodes typed requests with `decodeFromString<RequestX>`

## TS caller migrations (a11y-first / ADB-fallback)
**Settings:** `Rotate.ts`, `TalkBackToggle.ts`, `DeviceState.ts`, `SystemConfigurationManager.ts`, `KeepScreenAwakeManager.ts`, `RestoreSnapshot.ts`, `CaptureSnapshot.ts`

**PackageManager:** `ListInstalledApps.ts`, `GetAppMetadata.ts`, `AppPermissions.ts`, `LaunchApp.ts`, `InstallApp.ts`, `TerminateApp.ts`, `CaptureSnapshot.ts`, `systemTrayHelpers.ts`

## Left on ADB intentionally
- `doctor/checks/automobile.ts` work-profile check (needs `--user N`, not reachable from in-service Settings API)
- `LaunchApp.ts` complex "Activity filter" parser branch (output-shape-dependent)
- `LaunchApp.checkForegroundDumpsys` (`dumpsys activity activities`, not `pm dump`)

## Post-review simplifications (last commit)
- Parallelized Rotate's two `settings_put` calls with `Promise.all` (recovers what the combined `shell "settings put A; settings put B"` did in one ADB round-trip).
- Collapsed `ListInstalledApps` double enumeration (`all` + `-s`) into one `requestInstalledPackages` call partitioned in TS by `isSystem`.
- Removed unused `includeActivities` / `includeIntentFilters` params on `RequestPackageInfo`.

## Test plan
- [x] `./gradlew :protocol:test` — BUILD SUCCESSFUL (4 new request tests, 3 new response tests)
- [x] `./gradlew :control-proxy:compileDebugKotlin` — BUILD SUCCESSFUL
- [x] `bun test` — 4021 pass, 0 fail, 2 skip (315 files)
- [x] `turbo run lint build` — green
- [ ] Hardware/emulator: rotate, list apps, app permissions, system tray notification expand — should be visibly snappier on a connected device; verify ADB fallback still works when the accessibility service is disconnected.