### PR TITLE
refactor(ctrl-proxy): persist SDK crash/ANR via injected CrashEventSink

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .auto-mobile-config.json
 .claude/worktrees/
+.claude/scheduled_tasks.lock
 .idea
 node_modules
 .turbo

--- a/src/db/failureEventRepository.ts
+++ b/src/db/failureEventRepository.ts
@@ -100,9 +100,9 @@ export class FailureEventRepository {
       exception_class: event.exceptionClass ?? null,
       exception_message: event.exceptionMessage ?? null,
       stacktrace: event.stacktrace ?? null,
-      signal: event.signal ?? null,
-      fault_address: event.faultAddress ?? null,
-      tombstone_path: event.tombstonePath ?? null,
+      signal: null,
+      fault_address: null,
+      tombstone_path: null,
       detection_source: event.detectionSource,
       raw_log: event.rawLog ?? null,
       navigation_node_id: event.navigationNodeId ?? null,
@@ -117,7 +117,7 @@ export class FailureEventRepository {
       .executeTakeFirstOrThrow();
 
     logger.info(
-      `[FAILURE_REPO] Saved crash for ${event.packageName}: ${event.exceptionClass ?? event.signal ?? "unknown"}`
+      `[FAILURE_REPO] Saved crash for ${event.packageName}: ${event.exceptionClass ?? "unknown"}`
     );
 
     return result.id;

--- a/src/db/types.ts
+++ b/src/db/types.ts
@@ -247,7 +247,7 @@ interface CrashesTable {
   signal: string | null; // For native crashes
   fault_address: string | null; // For native crashes
   tombstone_path: string | null;
-  detection_source: "logcat" | "tombstone" | "dropbox" | "accessibility" | "process_monitor";
+  detection_source: "sdk_websocket" | "logcat" | "tombstone" | "dropbox" | "accessibility" | "process_monitor";
   raw_log: string | null;
   navigation_node_id: number | null;
   test_execution_id: number | null;
@@ -269,7 +269,7 @@ interface AnrsTable {
   cpu_usage: string | null;
   main_thread_state: string | null;
   stacktrace: string | null;
-  detection_source: "logcat" | "dropbox" | "accessibility";
+  detection_source: "sdk_websocket" | "logcat" | "dropbox" | "accessibility";
   raw_log: string | null;
   navigation_node_id: number | null;
   test_execution_id: number | null;

--- a/src/features/observe/android/AndroidCtrlProxyClient.ts
+++ b/src/features/observe/android/AndroidCtrlProxyClient.ts
@@ -46,6 +46,14 @@ import {
   computeChecksum,
 } from "../ScreenshotBackoffScheduler";
 import { getFailureRecorder } from "../../failures/FailureRecorder";
+import {
+  normalizeAnr,
+  normalizeCrash,
+  type SdkAnrPayload,
+  type SdkCrashPayload,
+} from "../crash/sdkCrashIngestion";
+import { FailureEventRepository } from "../../../db/failureEventRepository";
+import type { CrashEventSink } from "../../../utils/interfaces/CrashMonitor";
 import { serverConfig } from "../../../utils/ServerConfig";
 import { TelemetryRecorder } from "../../telemetry/TelemetryRecorder";
 import { getPerformanceMonitor } from "../../performance/PerformanceMonitor";
@@ -146,46 +154,6 @@ interface HandledExceptionEvent {
   customMessage?: string;
   currentScreen?: string;
   packageName: string;
-  appVersion?: string;
-  deviceInfo: {
-    model: string;
-    manufacturer: string;
-    osVersion: string;
-    sdkInt: number;
-  };
-}
-
-/**
- * Interface for crash event from SDK
- */
-interface CrashEvent {
-  timestamp: number;
-  exceptionClass: string;
-  message?: string;
-  stackTrace: string;
-  threadName: string;
-  currentScreen?: string;
-  packageName: string;
-  appVersion?: string;
-  deviceInfo: {
-    model: string;
-    manufacturer: string;
-    osVersion: string;
-    sdkInt: number;
-  };
-}
-
-/**
- * Interface for ANR event from SDK
- */
-interface AnrEvent {
-  timestamp: number;
-  pid: number;
-  processName: string;
-  importance: string;
-  trace?: string;
-  reason: string;
-  packageName?: string;
   appVersion?: string;
   deviceInfo: {
     model: string;
@@ -495,12 +463,12 @@ interface WsHandledExceptionEventMessage extends WsMessageBase {
 
 interface WsCrashEventMessage extends WsMessageBase {
   type: "crash_event";
-  event?: CrashEvent;
+  event?: SdkCrashPayload;
 }
 
 interface WsAnrEventMessage extends WsMessageBase {
   type: "anr_event";
-  event?: AnrEvent;
+  event?: SdkAnrPayload;
 }
 
 interface WsNetworkEventMessage extends WsMessageBase {
@@ -817,6 +785,8 @@ export class AndroidCtrlProxyClient extends DeviceServiceClient implements Andro
   private lastForegroundPackage: string | null = null;
   private lastLayoutTelemetryTimestamp = 0;
 
+  private readonly crashEventSink: CrashEventSink;
+
   // Logging tag for base class
   protected readonly logTag = "ACCESSIBILITY_SERVICE";
 
@@ -829,12 +799,14 @@ export class AndroidCtrlProxyClient extends DeviceServiceClient implements Andro
     webSocketFactory?: WebSocketFactory,
     timer?: Timer,
     installedAppsRepository?: InstalledAppsStore,
-    retryExecutor?: RetryExecutor
+    retryExecutor?: RetryExecutor,
+    crashEventSink?: CrashEventSink
   ) {
     super(timer ?? defaultTimer, webSocketFactory ?? defaultWebSocketFactory, {}, retryExecutor ?? defaultRetryExecutor);
     this.device = device;
     this.adb = adb;
     this.installedAppsRepository = installedAppsRepository ?? null;
+    this.crashEventSink = crashEventSink ?? new FailureEventRepository();
     this.localPort = PortManager.allocate(device.deviceId);
     AndroidCtrlProxyManager.getInstance(device);
   }
@@ -899,9 +871,10 @@ export class AndroidCtrlProxyClient extends DeviceServiceClient implements Andro
     webSocketFactory: (url: string) => WebSocket,
     timer?: Timer,
     installedAppsRepository?: InstalledAppsStore,
-    retryExecutor?: RetryExecutor
+    retryExecutor?: RetryExecutor,
+    crashEventSink?: CrashEventSink
   ): AndroidCtrlProxyClient {
-    return new AndroidCtrlProxyClient(device, adb, webSocketFactory, timer, installedAppsRepository, retryExecutor);
+    return new AndroidCtrlProxyClient(device, adb, webSocketFactory, timer, installedAppsRepository, retryExecutor, crashEventSink);
   }
 
   // ===========================================================================
@@ -2770,9 +2743,15 @@ export class AndroidCtrlProxyClient extends DeviceServiceClient implements Andro
     }
   }
 
-  private async handleCrashEvent(event: CrashEvent): Promise<void> {
-    logger.info(`[CTRL_PROXY] Received crash: ${event.exceptionClass} on thread ${event.threadName} from ${event.packageName}`);
+  private async persistCrash(event: SdkCrashPayload): Promise<void> {
+    try {
+      await this.crashEventSink.saveCrash(normalizeCrash(event, this.device.deviceId));
+    } catch (error) {
+      logger.error(`[CTRL_PROXY] Failed to persist crash: ${error}`);
+    }
+  }
 
+  private async recordCrashAnalytics(event: SdkCrashPayload): Promise<void> {
     try {
       const failureRecorder = getFailureRecorder();
       const stackTraceElements = this.parseStackTrace(event.stackTrace, event.packageName);
@@ -2807,12 +2786,22 @@ export class AndroidCtrlProxyClient extends DeviceServiceClient implements Andro
     }
   }
 
-  private async handleAnrEvent(event: AnrEvent): Promise<void> {
-    logger.info(`[CTRL_PROXY] Received ANR: pid=${event.pid}, process=${event.processName}, importance=${event.importance}`);
+  private async handleCrashEvent(event: SdkCrashPayload): Promise<void> {
+    logger.info(`[CTRL_PROXY] Received crash: ${event.exceptionClass} on thread ${event.threadName} from ${event.packageName}`);
+    await Promise.all([this.persistCrash(event), this.recordCrashAnalytics(event)]);
+  }
 
+  private async persistAnr(event: SdkAnrPayload): Promise<void> {
+    try {
+      await this.crashEventSink.saveAnr(normalizeAnr(event, this.device.deviceId));
+    } catch (error) {
+      logger.error(`[CTRL_PROXY] Failed to persist ANR: ${error}`);
+    }
+  }
+
+  private async recordAnrAnalytics(event: SdkAnrPayload, packageName: string): Promise<void> {
     try {
       const failureRecorder = getFailureRecorder();
-      const packageName = event.packageName ?? event.processName;
 
       // Parse stack trace if available
       const stackTraceElements = event.trace
@@ -2843,6 +2832,12 @@ export class AndroidCtrlProxyClient extends DeviceServiceClient implements Andro
     } catch (error) {
       logger.error(`[CTRL_PROXY] Failed to record ANR: ${error}`);
     }
+  }
+
+  private async handleAnrEvent(event: SdkAnrPayload): Promise<void> {
+    logger.info(`[CTRL_PROXY] Received ANR: pid=${event.pid}, process=${event.processName}, importance=${event.importance}`);
+    const packageName = event.packageName ?? event.processName;
+    await Promise.all([this.persistAnr(event), this.recordAnrAnalytics(event, packageName)]);
   }
 
   private parseStackTrace(stackTrace: string, packageName: string): StackTraceElement[] {

--- a/src/features/observe/crash/sdkCrashIngestion.ts
+++ b/src/features/observe/crash/sdkCrashIngestion.ts
@@ -1,0 +1,62 @@
+import type {
+  AnrEvent,
+  CrashDeviceInfo,
+  CrashEvent,
+} from "../../../utils/interfaces/CrashMonitor";
+
+export interface SdkCrashPayload {
+  timestamp: number;
+  exceptionClass: string;
+  message?: string;
+  stackTrace: string;
+  threadName: string;
+  currentScreen?: string;
+  packageName: string;
+  appVersion?: string;
+  deviceInfo: CrashDeviceInfo;
+}
+
+export interface SdkAnrPayload {
+  timestamp: number;
+  pid: number;
+  processName: string;
+  importance: string;
+  trace?: string;
+  reason: string;
+  packageName?: string;
+  appVersion?: string;
+  deviceInfo: CrashDeviceInfo;
+}
+
+export function normalizeCrash(payload: SdkCrashPayload, deviceId: string): CrashEvent {
+  return {
+    deviceId,
+    packageName: payload.packageName,
+    crashType: "java",
+    detectionSource: "sdk_websocket",
+    timestamp: payload.timestamp,
+    threadName: payload.threadName,
+    exceptionClass: payload.exceptionClass,
+    exceptionMessage: payload.message,
+    stacktrace: payload.stackTrace,
+    currentScreen: payload.currentScreen,
+    appVersion: payload.appVersion,
+    deviceInfo: payload.deviceInfo,
+  };
+}
+
+export function normalizeAnr(payload: SdkAnrPayload, deviceId: string): AnrEvent {
+  return {
+    deviceId,
+    packageName: payload.packageName ?? payload.processName,
+    detectionSource: "sdk_websocket",
+    timestamp: payload.timestamp,
+    processName: payload.processName,
+    pid: payload.pid,
+    reason: payload.reason,
+    stacktrace: payload.trace,
+    importance: payload.importance,
+    appVersion: payload.appVersion,
+    deviceInfo: payload.deviceInfo,
+  };
+}

--- a/src/utils/interfaces/CrashMonitor.ts
+++ b/src/utils/interfaces/CrashMonitor.ts
@@ -1,298 +1,53 @@
-import type { BootedDevice } from "../../models";
-
 /**
- * Types of crashes that can be detected
+ * Crash/ANR event shapes persisted from the on-device AutoMobile SDK over the
+ * accessibility-service WebSocket. The SDK is the sole detection source —
+ * host-side detectors (logcat, tombstone, dropbox, etc.) are out of scope
+ * because they require streaming/polling ADB calls that don't behave well
+ * over high-latency connections.
  */
-export type CrashType = "java" | "native" | "system";
 
 /**
- * Sources from which crashes can be detected
+ * Device metadata captured at crash/ANR time by the on-device SDK.
  */
-export type CrashDetectionSource =
-  | "logcat"
-  | "tombstone"
-  | "dropbox"
-  | "accessibility"
-  | "process_monitor";
+export interface CrashDeviceInfo {
+  model: string;
+  manufacturer: string;
+  osVersion: string;
+  sdkInt: number;
+}
 
 /**
- * Sources from which ANRs can be detected
- */
-export type AnrDetectionSource = "logcat" | "dropbox" | "accessibility";
-
-/**
- * Represents a detected crash event
+ * Normalized crash event written to the failure repository.
  */
 export interface CrashEvent {
   deviceId: string;
   packageName: string;
-  crashType: CrashType;
+  crashType: "java";
+  detectionSource: "sdk_websocket";
   timestamp: number;
   processName?: string;
   pid?: number;
   exceptionClass?: string;
   exceptionMessage?: string;
   stacktrace?: string;
-  signal?: string; // For native crashes (SIGSEGV, SIGABRT, etc.)
-  faultAddress?: string; // For native crashes
-  tombstonePath?: string;
-  detectionSource: CrashDetectionSource;
-  rawLog?: string;
+  threadName?: string;
+  currentScreen?: string;
+  appVersion?: string;
+  deviceInfo?: CrashDeviceInfo;
   navigationNodeId?: number;
   testExecutionId?: number;
   sessionUuid?: string;
+  rawLog?: string;
 }
 
 /**
- * Represents a detected ANR (Application Not Responding) event
+ * Normalized ANR event written to the failure repository.
  */
 export interface AnrEvent {
   deviceId: string;
   packageName: string;
+  detectionSource: "sdk_websocket";
   timestamp: number;
-  processName?: string;
-  pid?: number;
-  reason?: string; // e.g., "Input dispatching timed out"
-  activity?: string;
-  waitDurationMs?: number;
-  cpuUsage?: string;
-  mainThreadState?: string;
-  stacktrace?: string;
-  detectionSource: AnrDetectionSource;
-  rawLog?: string;
-  navigationNodeId?: number;
-  testExecutionId?: number;
-  sessionUuid?: string;
-}
-
-/**
- * Combined failure event type
- */
-export type FailureEvent = CrashEvent | AnrEvent;
-
-/**
- * Listener callback for crash events
- */
-export interface CrashEventListener {
-  (event: CrashEvent): void | Promise<void>;
-}
-
-/**
- * Listener callback for ANR events
- */
-export interface AnrEventListener {
-  (event: AnrEvent): void | Promise<void>;
-}
-
-/**
- * Interface for individual crash/ANR detectors
- * Each detector implements a specific detection method (logcat, tombstone, etc.)
- */
-export interface CrashDetector {
-  /**
-   * Unique name identifying this detector
-   */
-  readonly name: string;
-
-  /**
-   * Start monitoring for crashes on the given device
-   * @param device The device to monitor
-   * @param packageName The package to monitor (single active window)
-   */
-  start(device: BootedDevice, packageName: string): Promise<void>;
-
-  /**
-   * Stop monitoring
-   */
-  stop(): Promise<void>;
-
-  /**
-   * Check for crashes (polling mode)
-   * @returns Array of crash events detected since last check
-   */
-  checkForCrashes(): Promise<CrashEvent[]>;
-
-  /**
-   * Check for ANRs (polling mode)
-   * @returns Array of ANR events detected since last check
-   */
-  checkForAnrs(): Promise<AnrEvent[]>;
-
-  /**
-   * Whether this detector is currently running
-   */
-  isRunning(): boolean;
-
-  /**
-   * Add a listener for crash events
-   */
-  addCrashListener(listener: CrashEventListener): void;
-
-  /**
-   * Remove a crash event listener
-   */
-  removeCrashListener(listener: CrashEventListener): void;
-
-  /**
-   * Add a listener for ANR events
-   */
-  addAnrListener(listener: AnrEventListener): void;
-
-  /**
-   * Remove an ANR event listener
-   */
-  removeAnrListener(listener: AnrEventListener): void;
-}
-
-/**
- * Configuration for the crash monitor coordinator
- */
-export interface CrashMonitorConfig {
-  /**
-   * Polling interval in milliseconds (default: 1000)
-   */
-  pollingIntervalMs?: number;
-
-  /**
-   * Whether to enable logcat monitoring (default: true)
-   */
-  enableLogcat?: boolean;
-
-  /**
-   * Whether to enable tombstone analysis (default: true)
-   */
-  enableTombstone?: boolean;
-
-  /**
-   * Whether to enable dropbox monitoring (default: true)
-   */
-  enableDropbox?: boolean;
-
-  /**
-   * Whether to enable accessibility dialog detection (default: true)
-   */
-  enableAccessibility?: boolean;
-
-  /**
-   * Whether to enable process state monitoring (default: true)
-   */
-  enableProcessMonitor?: boolean;
-
-  /**
-   * Session UUID for correlating crashes with sessions
-   */
-  sessionUuid?: string;
-}
-
-/**
- * Interface for the crash monitor coordinator that manages all detectors
- */
-export interface CrashMonitor {
-  /**
-   * Start crash monitoring for a device/package
-   * @param device The device to monitor
-   * @param packageName The package to monitor
-   * @param config Optional configuration
-   */
-  start(
-    device: BootedDevice,
-    packageName: string,
-    config?: CrashMonitorConfig
-  ): Promise<void>;
-
-  /**
-   * Stop crash monitoring
-   */
-  stop(): Promise<void>;
-
-  /**
-   * Poll for new failures (crashes and ANRs)
-   * @returns Object containing arrays of new crashes and ANRs
-   */
-  poll(): Promise<{ crashes: CrashEvent[]; anrs: AnrEvent[] }>;
-
-  /**
-   * Get all crashes detected during this monitoring session
-   */
-  getCrashes(): CrashEvent[];
-
-  /**
-   * Get all ANRs detected during this monitoring session
-   */
-  getAnrs(): AnrEvent[];
-
-  /**
-   * Clear the collected crashes and ANRs
-   */
-  clearEvents(): void;
-
-  /**
-   * Whether monitoring is currently active
-   */
-  isMonitoring(): boolean;
-
-  /**
-   * Get the currently monitored package
-   */
-  getMonitoredPackage(): string | null;
-
-  /**
-   * Get the currently monitored device
-   */
-  getMonitoredDevice(): BootedDevice | null;
-
-  /**
-   * Update the navigation node ID to associate with future crashes
-   */
-  setCurrentNavigationNodeId(nodeId: number | null): void;
-
-  /**
-   * Update the test execution ID to associate with future crashes
-   */
-  setCurrentTestExecutionId(executionId: number | null): void;
-
-  /**
-   * Add a listener for crash events
-   */
-  addCrashListener(listener: CrashEventListener): void;
-
-  /**
-   * Remove a crash event listener
-   */
-  removeCrashListener(listener: CrashEventListener): void;
-
-  /**
-   * Add a listener for ANR events
-   */
-  addAnrListener(listener: AnrEventListener): void;
-
-  /**
-   * Remove an ANR event listener
-   */
-  removeAnrListener(listener: AnrEventListener): void;
-}
-
-/**
- * Result from parsing a crash log
- */
-export interface ParsedCrash {
-  crashType: CrashType;
-  packageName: string;
-  processName?: string;
-  pid?: number;
-  exceptionClass?: string;
-  exceptionMessage?: string;
-  stacktrace?: string;
-  signal?: string;
-  faultAddress?: string;
-  timestamp?: number;
-}
-
-/**
- * Result from parsing an ANR log
- */
-export interface ParsedAnr {
-  packageName: string;
   processName?: string;
   pid?: number;
   reason?: string;
@@ -301,5 +56,21 @@ export interface ParsedAnr {
   cpuUsage?: string;
   mainThreadState?: string;
   stacktrace?: string;
-  timestamp?: number;
+  importance?: string;
+  currentScreen?: string;
+  appVersion?: string;
+  deviceInfo?: CrashDeviceInfo;
+  navigationNodeId?: number;
+  testExecutionId?: number;
+  sessionUuid?: string;
+  rawLog?: string;
+}
+
+/**
+ * Minimal persistence surface for crash/ANR events. FailureEventRepository
+ * satisfies this structurally.
+ */
+export interface CrashEventSink {
+  saveCrash(event: CrashEvent): Promise<number>;
+  saveAnr(event: AnrEvent): Promise<number>;
 }

--- a/src/utils/interfaces/index.ts
+++ b/src/utils/interfaces/index.ts
@@ -57,17 +57,8 @@ export {
   SelectedElement
 } from "./NavigationGraph";
 export {
-  CrashMonitor,
-  CrashDetector,
   CrashEvent,
   AnrEvent,
-  FailureEvent,
-  CrashType,
-  CrashDetectionSource,
-  AnrDetectionSource,
-  CrashEventListener,
-  AnrEventListener,
-  CrashMonitorConfig,
-  ParsedCrash,
-  ParsedAnr,
+  CrashDeviceInfo,
+  CrashEventSink,
 } from "./CrashMonitor";

--- a/test/db/failureEventRepository.test.ts
+++ b/test/db/failureEventRepository.test.ts
@@ -12,7 +12,7 @@ function makeCrashEvent(overrides: Partial<CrashEvent> = {}): CrashEvent {
     packageName: "com.example.app",
     crashType: "java",
     timestamp: 1000000,
-    detectionSource: "logcat",
+    detectionSource: "sdk_websocket",
     exceptionClass: "java.lang.NullPointerException",
     exceptionMessage: "Attempt to invoke virtual method on null",
     stacktrace: "at com.example.app.Main.run(Main.java:42)",
@@ -25,7 +25,7 @@ function makeAnrEvent(overrides: Partial<AnrEvent> = {}): AnrEvent {
     deviceId: "emulator-5554",
     packageName: "com.example.app",
     timestamp: 2000000,
-    detectionSource: "logcat",
+    detectionSource: "sdk_websocket",
     reason: "Input dispatching timed out",
     activity: "com.example.app.MainActivity",
     waitDurationMs: 5000,
@@ -64,7 +64,7 @@ describe("FailureEventRepository", () => {
       expect(crashes[0].exception_class).toBe("java.lang.NullPointerException");
       expect(crashes[0].exception_message).toBe("Attempt to invoke virtual method on null");
       expect(crashes[0].stacktrace).toBe("at com.example.app.Main.run(Main.java:42)");
-      expect(crashes[0].detection_source).toBe("logcat");
+      expect(crashes[0].detection_source).toBe("sdk_websocket");
     });
 
     test("saves multiple crashes and returns them ordered by timestamp desc", async () => {
@@ -83,9 +83,9 @@ describe("FailureEventRepository", () => {
       const id = await repo.saveCrash({
         deviceId: "device-1",
         packageName: "com.test",
-        crashType: "native",
+        crashType: "java",
         timestamp: 5000,
-        detectionSource: "tombstone",
+        detectionSource: "sdk_websocket",
       });
       expect(id).toBeGreaterThan(0);
 
@@ -113,7 +113,7 @@ describe("FailureEventRepository", () => {
       expect(anrs[0].reason).toBe("Input dispatching timed out");
       expect(anrs[0].activity).toBe("com.example.app.MainActivity");
       expect(anrs[0].wait_duration_ms).toBe(5000);
-      expect(anrs[0].detection_source).toBe("logcat");
+      expect(anrs[0].detection_source).toBe("sdk_websocket");
     });
 
     test("saves multiple ANRs and returns them ordered by timestamp desc", async () => {
@@ -133,7 +133,7 @@ describe("FailureEventRepository", () => {
         deviceId: "device-1",
         packageName: "com.test",
         timestamp: 5000,
-        detectionSource: "logcat",
+        detectionSource: "sdk_websocket",
       });
       expect(id).toBeGreaterThan(0);
 
@@ -390,17 +390,15 @@ describe("FailureEventRepository", () => {
     test("crash records contain crash-specific fields", async () => {
       await repo.saveCrash(
         makeCrashEvent({
-          crashType: "native",
-          exceptionClass: "SIGSEGV",
-          signal: "11",
+          crashType: "java",
+          exceptionClass: "java.lang.OutOfMemoryError",
         })
       );
 
       const all = await repo.getAllFailures();
       const crash = all.find(f => f.type === "crash")!;
-      expect(crash.crashType).toBe("native");
-      expect(crash.exceptionClass).toBe("SIGSEGV");
-      expect(crash.signal).toBe("11");
+      expect(crash.crashType).toBe("java");
+      expect(crash.exceptionClass).toBe("java.lang.OutOfMemoryError");
     });
 
     test("ANR records contain ANR-specific fields", async () => {

--- a/test/fakes/FakeCrashEventSink.ts
+++ b/test/fakes/FakeCrashEventSink.ts
@@ -1,0 +1,57 @@
+import type {
+  AnrEvent,
+  CrashEvent,
+  CrashEventSink,
+} from "../../src/utils/interfaces/CrashMonitor";
+
+/**
+ * In-memory fake implementation of CrashEventSink for tests.
+ *
+ * Captures every crash/ANR event passed to it so tests can assert on what
+ * AndroidCtrlProxyClient (or any other sink consumer) persisted, without
+ * touching the database.
+ */
+export class FakeCrashEventSink implements CrashEventSink {
+  public readonly savedCrashes: CrashEvent[] = [];
+  public readonly savedAnrs: AnrEvent[] = [];
+
+  private nextCrashId = 1;
+  private nextAnrId = 1;
+  private shouldThrow: Error | null = null;
+
+  /**
+   * Force the next save call (crash or ANR) to reject with the given error.
+   * Auto-clears after one throw so subsequent saves succeed unless re-armed.
+   */
+  failNextSaveWith(error: Error): void {
+    this.shouldThrow = error;
+  }
+
+  async saveCrash(event: CrashEvent): Promise<number> {
+    this.maybeThrow();
+    this.savedCrashes.push(event);
+    return this.nextCrashId++;
+  }
+
+  async saveAnr(event: AnrEvent): Promise<number> {
+    this.maybeThrow();
+    this.savedAnrs.push(event);
+    return this.nextAnrId++;
+  }
+
+  reset(): void {
+    this.savedCrashes.length = 0;
+    this.savedAnrs.length = 0;
+    this.nextCrashId = 1;
+    this.nextAnrId = 1;
+    this.shouldThrow = null;
+  }
+
+  private maybeThrow(): void {
+    if (this.shouldThrow) {
+      const error = this.shouldThrow;
+      this.shouldThrow = null;
+      throw error;
+    }
+  }
+}

--- a/test/features/observe/crash/sdkCrashIngestion.test.ts
+++ b/test/features/observe/crash/sdkCrashIngestion.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, test } from "bun:test";
+import {
+  normalizeAnr,
+  normalizeCrash,
+  type SdkAnrPayload,
+  type SdkCrashPayload,
+} from "../../../../src/features/observe/crash/sdkCrashIngestion";
+
+function makeCrashPayload(overrides: Partial<SdkCrashPayload> = {}): SdkCrashPayload {
+  return {
+    timestamp: 1_700_000_000,
+    exceptionClass: "java.lang.NullPointerException",
+    message: "npe",
+    stackTrace: "at com.example.Main.run(Main.java:42)",
+    threadName: "main",
+    packageName: "com.example.app",
+    appVersion: "1.2.3",
+    deviceInfo: {
+      model: "Pixel 7",
+      manufacturer: "Google",
+      osVersion: "14",
+      sdkInt: 34,
+    },
+    ...overrides,
+  };
+}
+
+function makeAnrPayload(overrides: Partial<SdkAnrPayload> = {}): SdkAnrPayload {
+  return {
+    timestamp: 1_700_000_500,
+    pid: 12345,
+    processName: "com.example.app",
+    importance: "FOREGROUND",
+    reason: "Input dispatching timed out",
+    trace: "at android.os.MessageQueue.nativePollOnce(Native Method)",
+    appVersion: "1.2.3",
+    deviceInfo: {
+      model: "Pixel 7",
+      manufacturer: "Google",
+      osVersion: "14",
+      sdkInt: 34,
+    },
+    ...overrides,
+  };
+}
+
+describe("normalizeCrash", () => {
+  test("maps SDK payload fields to CrashEvent shape", () => {
+    const event = normalizeCrash(makeCrashPayload(), "emulator-5554");
+    expect(event.deviceId).toBe("emulator-5554");
+    expect(event.packageName).toBe("com.example.app");
+    expect(event.crashType).toBe("java");
+    expect(event.detectionSource).toBe("sdk_websocket");
+    expect(event.timestamp).toBe(1_700_000_000);
+    expect(event.threadName).toBe("main");
+    expect(event.exceptionClass).toBe("java.lang.NullPointerException");
+    expect(event.exceptionMessage).toBe("npe");
+    expect(event.stacktrace).toBe("at com.example.Main.run(Main.java:42)");
+    expect(event.appVersion).toBe("1.2.3");
+    expect(event.deviceInfo?.model).toBe("Pixel 7");
+  });
+
+  test("passes through currentScreen when present", () => {
+    const event = normalizeCrash(
+      makeCrashPayload({ currentScreen: "HomeScreen" }),
+      "emulator-5554"
+    );
+    expect(event.currentScreen).toBe("HomeScreen");
+  });
+
+  test("leaves optional message undefined when absent", () => {
+    const event = normalizeCrash(
+      makeCrashPayload({ message: undefined }),
+      "emulator-5554"
+    );
+    expect(event.exceptionMessage).toBeUndefined();
+  });
+});
+
+describe("normalizeAnr", () => {
+  test("maps SDK payload fields and renames trace -> stacktrace", () => {
+    const event = normalizeAnr(makeAnrPayload(), "emulator-5554");
+    expect(event.deviceId).toBe("emulator-5554");
+    expect(event.packageName).toBe("com.example.app");
+    expect(event.detectionSource).toBe("sdk_websocket");
+    expect(event.pid).toBe(12345);
+    expect(event.processName).toBe("com.example.app");
+    expect(event.importance).toBe("FOREGROUND");
+    expect(event.reason).toBe("Input dispatching timed out");
+    expect(event.stacktrace).toBe(
+      "at android.os.MessageQueue.nativePollOnce(Native Method)"
+    );
+  });
+
+  test("falls back to processName when payload packageName is absent", () => {
+    const event = normalizeAnr(
+      makeAnrPayload({ packageName: undefined, processName: "com.proc.name" }),
+      "emulator-5554"
+    );
+    expect(event.packageName).toBe("com.proc.name");
+  });
+
+  test("prefers payload packageName over processName", () => {
+    const event = normalizeAnr(
+      makeAnrPayload({ packageName: "com.payload.pkg" }),
+      "emulator-5554"
+    );
+    expect(event.packageName).toBe("com.payload.pkg");
+  });
+});


### PR DESCRIPTION
## Summary
- Trims `CrashMonitor.ts` to the four shapes the SDK pipeline actually uses (`CrashEvent`, `AnrEvent`, `CrashDeviceInfo`, `CrashEventSink`) — the host-side orchestrator (detectors, listeners, polling config, parsed-crash types) is dead weight now that the on-device AutoMobile SDK is the sole source over the accessibility-service WebSocket.
- Extracts SDK payload types + normalizers into `src/features/observe/crash/sdkCrashIngestion.ts`; adds `"sdk_websocket"` to the `detection_source` unions for crashes/ANRs.
- Injects `CrashEventSink` into `AndroidCtrlProxyClient` (default `FailureEventRepository`) and adds `FakeCrashEventSink` so the persistence path can be tested without touching the DB.
- Ignores `.claude/scheduled_tasks.lock`.

## Test plan
- [x] `turbo run lint build test` — 4028 pass, 2 skip, 0 fail (8s)
- [ ] Verify on-device SDK crash → row in `crashes` table with `detection_source = 'sdk_websocket'`
- [ ] Verify on-device SDK ANR → row in `anrs` table with `detection_source = 'sdk_websocket'`