### PR TITLE
feat(ctrl-proxy): catch ObjC NSExceptions to prevent process crashes

### DIFF
--- a/ios/control-proxy/Package.swift
+++ b/ios/control-proxy/Package.swift
@@ -17,8 +17,13 @@ let package = Package(
     ],
     targets: [
         .target(
+            name: "ObjCExceptionCatcher",
+            path: "Sources/ObjCExceptionCatcher",
+            publicHeadersPath: "include"
+        ),
+        .target(
             name: "CtrlProxy",
-            dependencies: [],
+            dependencies: ["ObjCExceptionCatcher"],
             path: "Sources/CtrlProxy"
         ),
         .testTarget(

--- a/ios/control-proxy/Sources/CtrlProxy/ElementLocator.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/ElementLocator.swift
@@ -74,39 +74,6 @@ public class ElementLocator: ElementLocating {
             self.perfProvider = perfProvider
         }
 
-        // MARK: - Main Thread Helper
-
-        /// Executes a throwing closure on the main thread and returns the result.
-        /// XCUITest APIs must be called on the main thread.
-        private func runOnMainThread<T>(_ block: @escaping () throws -> T) throws -> T {
-            if Thread.isMainThread {
-                return try block()
-            }
-
-            var result: Result<T, Error>!
-            DispatchQueue.main.sync {
-                do {
-                    result = try .success(block())
-                } catch {
-                    result = .failure(error)
-                }
-            }
-            return try result.get()
-        }
-
-        /// Executes a non-throwing closure on the main thread and returns the result.
-        private func runOnMainThread<T>(_ block: @escaping () -> T) -> T {
-            if Thread.isMainThread {
-                return block()
-            }
-
-            var result: T!
-            DispatchQueue.main.sync {
-                result = block()
-            }
-            return result
-        }
-
         public func setApplication(_ app: XCUIApplication) {
             // Release old app reference before setting new one
             foregroundApp = nil
@@ -156,9 +123,9 @@ public class ElementLocator: ElementLocating {
         }
 
         public func getAppState(bundleId: String) -> ObservedAppState {
-            let stateRaw: UInt = runOnMainThread {
+            let stateRaw: UInt = runOnMainThreadNonThrowing({
                 XCUIApplication(bundleIdentifier: bundleId).state.rawValue
-            }
+            }, fallback: 0)
             switch stateRaw {
             case 0: return .unknown
             case 1: return .notRunning
@@ -170,9 +137,9 @@ public class ElementLocator: ElementLocating {
 
         public func awaitAppState(bundleId: String, expectedState: AppStateExpectation) -> Bool {
             for _ in 0..<10 {
-                let stateRaw: UInt = runOnMainThread {
+                let stateRaw: UInt = runOnMainThreadNonThrowing({
                     XCUIApplication(bundleIdentifier: bundleId).state.rawValue
-                }
+                }, fallback: 0)
                 let matched: Bool
                 switch expectedState {
                 case .foreground:
@@ -202,13 +169,13 @@ public class ElementLocator: ElementLocating {
             // cached instances may return stale state values
             let stateInfo: (springboardState: UInt, currentAppState: UInt?, currentBundleId: String?) =
                 perfProvider.track("checkState") {
-                    runOnMainThread {
+                    runOnMainThreadNonThrowing({
                         let sbState = self.springboard.state.rawValue
                         let freshAppState: UInt? = self.foregroundBundleId.map { bundleId in
                             XCUIApplication(bundleIdentifier: bundleId).state.rawValue
                         }
                         return (sbState, freshAppState, self.foregroundBundleId)
-                    }
+                    }, fallback: (0, nil, self.foregroundBundleId))
                 }
 
             print("[ElementLocator] ensureForegroundApp: current=\(stateInfo.currentBundleId ?? "nil") state=\(stateInfo.currentAppState.map { String($0) } ?? "nil") springboard=\(stateInfo.springboardState) observed=\(observedBundleIds)")
@@ -243,12 +210,12 @@ public class ElementLocator: ElementLocating {
         /// Returns foreground app if available and in foreground, otherwise springboard
         private var currentApplication: XCUIApplication {
             // Check state on main thread using fresh instance (cached instances return stale state)
-            let stateInfo: (state: UInt?, bundleId: String?) = runOnMainThread {
+            let stateInfo: (state: UInt?, bundleId: String?) = runOnMainThreadNonThrowing({
                 let freshState: UInt? = self.foregroundBundleId.map { bundleId in
                     XCUIApplication(bundleIdentifier: bundleId).state.rawValue
                 }
                 return (freshState, self.foregroundBundleId)
-            }
+            }, fallback: (nil, self.foregroundBundleId))
             let foregroundAppInForeground = (stateInfo.state ?? 0) >= 4 // .runningForeground only
             if let app = foregroundApp, foregroundAppInForeground {
                 return app
@@ -308,9 +275,9 @@ public class ElementLocator: ElementLocating {
             // First, try to find bundle IDs from springboard's element tree
             // This can work when apps embed their bundle ID in element identifiers
             let snapshot: XCUIElementSnapshot? = perfProvider.track("springboardSnapshot") {
-                runOnMainThread {
+                runOnMainThreadNonThrowing({
                     try? self.springboard.snapshot()
-                }
+                }, fallback: nil)
             }
 
             if let snapshot = snapshot {
@@ -325,10 +292,10 @@ public class ElementLocator: ElementLocating {
                             continue
                         }
 
-                        let stateRawValue: UInt = runOnMainThread {
+                        let stateRawValue: UInt = runOnMainThreadNonThrowing({
                             let testApp = XCUIApplication(bundleIdentifier: bundleId)
                             return testApp.state.rawValue
-                        }
+                        }, fallback: 0)
                         print("[ElementLocator] Candidate \(bundleId) state=\(stateRawValue)")
                         if stateRawValue >= 4 { // .runningForeground only
                             print("[ElementLocator] Found foreground app from springboard: \(bundleId)")
@@ -353,10 +320,10 @@ public class ElementLocator: ElementLocating {
                         continue
                     }
 
-                    let stateRawValue: UInt = runOnMainThread {
+                    let stateRawValue: UInt = runOnMainThreadNonThrowing({
                         let testApp = XCUIApplication(bundleIdentifier: bundleId)
                         return testApp.state.rawValue
-                    }
+                    }, fallback: 0)
                     print("[ElementLocator] Observed \(bundleId) state=\(stateRawValue)")
                     if stateRawValue >= 4 { // .runningForeground only
                         return bundleId
@@ -382,10 +349,10 @@ public class ElementLocator: ElementLocating {
                         continue
                     }
 
-                    let stateRawValue: UInt = runOnMainThread {
+                    let stateRawValue: UInt = runOnMainThreadNonThrowing({
                         let testApp = XCUIApplication(bundleIdentifier: bundleId)
                         return testApp.state.rawValue
-                    }
+                    }, fallback: 0)
                     if stateRawValue >= 4 { // .runningForeground only
                         print("[ElementLocator] Found foreground app from system apps: \(bundleId)")
                         return bundleId
@@ -530,8 +497,8 @@ public class ElementLocator: ElementLocating {
             // 1. Alerts in the app's own snapshot tree (permission dialogs presented within the app)
             // 2. Alerts in SpringBoard's tree (system dialogs managed by SpringBoard)
             // System permission dialogs may appear in either location depending on iOS version.
-            let systemAlerts = perfProvider.track("systemAlerts") {
-                getSystemAlerts(appSnapshot: snapshot, keyboardFocusFrame: keyboardFocusFrame)
+            let systemAlerts = try perfProvider.track("systemAlerts") {
+                try getSystemAlerts(appSnapshot: snapshot, keyboardFocusFrame: keyboardFocusFrame)
             }
 
             // If there are system alerts, include them in the hierarchy
@@ -559,7 +526,7 @@ public class ElementLocator: ElementLocating {
             // Get screen scale and dimensions for coordinate conversion
             // iOS reports bounds in points, but screenshots are in pixels
             // screenScale converts: pixels = points * screenScale
-            let (screenScale, screenWidth, screenHeight): (Float, Int, Int) = runOnMainThread {
+            let (screenScale, screenWidth, screenHeight): (Float, Int, Int) = try runOnMainThread {
                 let scale = Float(UIScreen.main.scale)
                 let bounds = UIScreen.main.bounds
                 return (scale, Int(bounds.width), Int(bounds.height))
@@ -584,14 +551,14 @@ public class ElementLocator: ElementLocating {
         /// Alert elements are extracted separately from the main hierarchy tree to ensure
         /// they are always visible as top-level children and never lost to optimization.
         /// Deduplicates by alert label text to avoid showing the same alert twice.
-        private func getSystemAlerts(appSnapshot: XCUIElementSnapshot, keyboardFocusFrame: CGRect? = nil) -> [UIElementInfo] {
+        private func getSystemAlerts(appSnapshot: XCUIElementSnapshot, keyboardFocusFrame: CGRect? = nil) throws -> [UIElementInfo] {
             // Check for alerts in the app's own snapshot tree
             let appAlerts = collectAlertElements(from: appSnapshot).map { snapshot in
                 buildElementInfoFromSnapshot(snapshot, depth: 0, screenBounds: snapshot.frame, keyboardFocusFrame: keyboardFocusFrame)
             }
 
             // Also check SpringBoard for alerts not in the app's tree
-            let springboardAlerts = getAlertsFromSpringboard(keyboardFocusFrame: keyboardFocusFrame)
+            let springboardAlerts = try getAlertsFromSpringboard(keyboardFocusFrame: keyboardFocusFrame)
 
             // Deduplicate by alert label text
             var seenLabels: Set<String> = []
@@ -626,8 +593,8 @@ public class ElementLocator: ElementLocating {
         /// Uses single snapshot() + tree traversal instead of .alerts query which can hang
         /// indefinitely on system permission dialogs, blocking the main thread.
         /// IMPORTANT: Creates a new XCUIApplication each call to avoid stale cached state.
-        private func getAlertsFromSpringboard(keyboardFocusFrame: CGRect? = nil) -> [UIElementInfo] {
-            let alertSnapshots: [XCUIElementSnapshot] = runOnMainThread {
+        private func getAlertsFromSpringboard(keyboardFocusFrame: CGRect? = nil) throws -> [UIElementInfo] {
+            let alertSnapshots: [XCUIElementSnapshot] = try runOnMainThread {
                 let freshSpringboard = XCUIApplication(bundleIdentifier: "com.apple.springboard")
                 guard let snapshot = try? freshSpringboard.snapshot() else { return [] }
                 return self.collectAlertElements(from: snapshot)
@@ -986,13 +953,6 @@ public class ElementLocator: ElementLocating {
             )]
         }
 
-        /// Legacy slow method - keeping for reference but not used
-        private func buildElementInfo(from _: XCUIElement, depth _: Int, maxDepth _: Int) -> UIElementInfo {
-            // This method accesses element properties individually which is SLOW
-            // Each property access is an IPC call to the accessibility service
-            // Use buildElementInfoFromSnapshot instead
-            fatalError("Use buildElementInfoFromSnapshot instead - this method is too slow")
-        }
 
         private func mapElementType(_ type: XCUIElement.ElementType) -> String {
             switch type {
@@ -1115,39 +1075,32 @@ public class ElementLocator: ElementLocating {
             // Query .any first (1 IPC call). If the match is a text-input type,
             // re-query with the specific type to get the outermost (parent) element
             // instead of an internal UIKit subview that shares the same identifier.
-            let element: XCUIElement = runOnMainThread {
+            guard let element: XCUIElement = runOnMainThreadNonThrowing({
                 let anyMatch = app.descendants(matching: .any)
                     .matching(identifier: resourceId).firstMatch
-                guard anyMatch.exists else { return anyMatch }
+                guard anyMatch.exists else { return nil as XCUIElement? }
 
-                // Check if the match is a text-input type that may have nested subviews
                 let matchedType = anyMatch.elementType
                 if Self.textInputElementTypes.contains(matchedType) {
-                    // Re-query with the specific type to prefer parent over internal subview
                     let typedMatch = app.descendants(matching: matchedType)
                         .matching(identifier: resourceId).firstMatch
                     if typedMatch.exists {
-                        return typedMatch
+                        return typedMatch as XCUIElement?
                     }
                 }
-                return anyMatch
-            }
-            let exists = runOnMainThread { element.exists }
-            if exists {
-                elementCache[resourceId] = element
-                return element
-            }
-            return nil
+                return anyMatch as XCUIElement?
+            }, fallback: nil) else { return nil }
+            elementCache[resourceId] = element
+            return element
         }
 
         public func findElement(byText text: String) -> Any? {
             let app = currentApplication
-            // Run on main thread since XCUITest APIs require it
-            let element: XCUIElement = runOnMainThread {
-                app.descendants(matching: .any).matching(NSPredicate(format: "label == %@", text)).firstMatch
-            }
-            let exists = runOnMainThread { element.exists }
-            return exists ? element : nil
+            return runOnMainThreadNonThrowing({
+                let match = app.descendants(matching: .any)
+                    .matching(NSPredicate(format: "label == %@", text)).firstMatch
+                return match.exists ? match as XCUIElement? : nil
+            }, fallback: nil)
         }
 
         public func getCachedElement(_ resourceId: String) -> XCUIElement? {

--- a/ios/control-proxy/Sources/CtrlProxy/GesturePerformer.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/GesturePerformer.swift
@@ -125,8 +125,8 @@ public class GesturePerformer: GesturePerforming {
         ///
         /// Returns `(hasFocus, strategy)` so the caller can log which path
         /// won. Query runs on the main thread.
-        private func detectKeyboardFocus(app: XCUIApplication) -> (Bool, String) {
-            return runOnMainThread { [springboard] in
+        private func detectKeyboardFocus(app: XCUIApplication) throws -> (Bool, String) {
+            return try runOnMainThread { [springboard] in
                 // Strategy 1: predicate
                 let byPredicate = app.descendants(matching: .any)
                     .matching(NSPredicate(format: "hasKeyboardFocus == true"))
@@ -163,9 +163,9 @@ public class GesturePerformer: GesturePerforming {
         /// it surfaces in the MCP response — not just in device logs.
         private func requireKeyboardFocus(app: XCUIApplication, context: String) throws {
             let queryStart = Date()
-            let (hasFocus, strategy) = detectKeyboardFocus(app: app)
+            let (hasFocus, strategy) = try detectKeyboardFocus(app: app)
             let elapsedMs = Int(Date().timeIntervalSince(queryStart) * 1000)
-            let appLabel = runOnMainThread { app.label }
+            let appLabel = runOnMainThreadNonThrowing({ app.label }, fallback: "unknown")
             gestureLog.debug("requireKeyboardFocus hasFocus=\(hasFocus, privacy: .public) strategy=\(strategy, privacy: .public) context=\"\(context, privacy: .public)\" elapsedMs=\(elapsedMs, privacy: .public) appLabel=\(appLabel, privacy: .public)")
 
             guard hasFocus else {
@@ -198,7 +198,7 @@ public class GesturePerformer: GesturePerforming {
             var strategy = "none"
             var iterations = 0
             while !hasFocus && Date() < deadline {
-                let result = detectKeyboardFocus(app: app)
+                let result = try detectKeyboardFocus(app: app)
                 hasFocus = result.0
                 strategy = result.1
                 iterations += 1
@@ -222,7 +222,7 @@ public class GesturePerformer: GesturePerforming {
         /// elements and their focus state, for #1925-style "no keyboard focus"
         /// failures. Returned as a single line so it fits in a WebSocket error.
         private func buildFocusDiagnostic(app: XCUIApplication, reason: String) -> String {
-            return runOnMainThread { [springboard] in
+            return runOnMainThreadNonThrowing({ [springboard] in
                 var parts: [String] = []
                 parts.append("reason=\"\(reason)\"")
                 parts.append("app.label=\"\(app.label)\"")
@@ -259,45 +259,12 @@ public class GesturePerformer: GesturePerforming {
                 parts.append("app.keyboards.count=\(app.keyboards.count)")
                 parts.append("springboard.keyboards.count=\(springboard.keyboards.count)")
                 return parts.joined(separator: " | ")
-            }
+            }, fallback: "reason=\"\(reason)\" [diagnostic collection failed]")
         }
 
         public func setApplication(_ app: XCUIApplication) {
             ownedApplication = nil
             application = app
-        }
-
-        // MARK: - Main Thread Helper
-
-        /// Executes a throwing closure on the main thread and returns the result.
-        /// XCUITest APIs must be called on the main thread.
-        private func runOnMainThread<T>(_ block: @escaping () throws -> T) throws -> T {
-            if Thread.isMainThread {
-                return try block()
-            }
-
-            var result: Result<T, Error>!
-            DispatchQueue.main.sync {
-                do {
-                    result = try .success(block())
-                } catch {
-                    result = .failure(error)
-                }
-            }
-            return try result.get()
-        }
-
-        /// Executes a non-throwing closure on the main thread and returns the result.
-        private func runOnMainThread<T>(_ block: @escaping () -> T) -> T {
-            if Thread.isMainThread {
-                return block()
-            }
-
-            var result: T!
-            DispatchQueue.main.sync {
-                result = block()
-            }
-            return result
         }
 
         // MARK: - Tap Gestures
@@ -307,7 +274,7 @@ public class GesturePerformer: GesturePerforming {
                 throw GestureError.noApplication
             }
 
-            runOnMainThread {
+            try runOnMainThread {
                 let coordinate = app.coordinate(withNormalizedOffset: .zero)
                     .withOffset(CGVector(dx: x, dy: y))
 
@@ -324,7 +291,7 @@ public class GesturePerformer: GesturePerforming {
                 throw GestureError.noApplication
             }
 
-            runOnMainThread {
+            try runOnMainThread {
                 let coordinate = app.coordinate(withNormalizedOffset: .zero)
                     .withOffset(CGVector(dx: x, dy: y))
                 coordinate.doubleTap()
@@ -336,7 +303,7 @@ public class GesturePerformer: GesturePerforming {
                 throw GestureError.noApplication
             }
 
-            runOnMainThread {
+            try runOnMainThread {
                 let coordinate = app.coordinate(withNormalizedOffset: .zero)
                     .withOffset(CGVector(dx: x, dy: y))
                 coordinate.press(forDuration: duration)
@@ -350,7 +317,7 @@ public class GesturePerformer: GesturePerforming {
                 throw GestureError.noApplication
             }
 
-            runOnMainThread {
+            try runOnMainThread {
                 let startCoordinate = app.coordinate(withNormalizedOffset: .zero)
                     .withOffset(CGVector(dx: startX, dy: startY))
                 let endCoordinate = app.coordinate(withNormalizedOffset: .zero)
@@ -380,7 +347,7 @@ public class GesturePerformer: GesturePerforming {
                 throw GestureError.noApplication
             }
 
-            runOnMainThread {
+            try runOnMainThread {
                 let startCoordinate = app.coordinate(withNormalizedOffset: .zero)
                     .withOffset(CGVector(dx: startX, dy: startY))
                 let endCoordinate = app.coordinate(withNormalizedOffset: .zero)
@@ -435,7 +402,7 @@ public class GesturePerformer: GesturePerforming {
 
             try requireKeyboardFocus(app: app, context: "ensure a text field is focused before typing")
 
-            runOnMainThread {
+            try runOnMainThread {
                 app.typeText(text)
             }
         }
@@ -584,8 +551,8 @@ public class GesturePerformer: GesturePerforming {
         /// exists somewhere but doesn't name an element, and we need an
         /// element to dispatch deletes against. Callers that hit that case
         /// should use `clearText(resourceId:)` with a concrete selector.
-        private func resolveFocusedTextElement(app: XCUIApplication) -> XCUIElement? {
-            return runOnMainThread {
+        private func resolveFocusedTextElement(app: XCUIApplication) throws -> XCUIElement? {
+            return try runOnMainThread {
                 // Strategy 1: predicate
                 let byPredicate = app.descendants(matching: .any)
                     .matching(NSPredicate(format: "hasKeyboardFocus == true"))
@@ -651,14 +618,14 @@ public class GesturePerformer: GesturePerforming {
             // Single code path — no Cmd+A/Delete fallback, because that
             // path bypasses RN's onChangeText bridge.
             try requireKeyboardFocus(app: app, context: "ensure a text field is focused before clearing")
-            guard let focused = resolveFocusedTextElement(app: app) else {
+            guard let focused = try resolveFocusedTextElement(app: app) else {
                 let diag = buildFocusDiagnostic(app: app, reason: "clearText: focus confirmed but no XCUITest-visible element resolved")
                 gestureLog.error("\(diag, privacy: .public)")
                 throw GestureError.gestureFailed(
                     "clearText could not resolve a focused text element. Pass resourceId to clear a specific field. Diagnostic: \(diag)"
                 )
             }
-            _ = runOnMainThread {
+            _ = try runOnMainThread {
                 GesturePerformer.clearViaDeletes(element: focused)
             }
         }
@@ -670,7 +637,7 @@ public class GesturePerformer: GesturePerforming {
 
             try requireKeyboardFocus(app: app, context: "ensure a text field is focused before selecting")
 
-            runOnMainThread {
+            try runOnMainThread {
                 app.typeKey("a", modifierFlags: .command)
             }
         }
@@ -682,11 +649,11 @@ public class GesturePerformer: GesturePerforming {
 
             switch action.lowercased() {
             case "done", "go", "search", "send", "next":
-                runOnMainThread {
+                try runOnMainThread {
                     app.typeText("\n")
                 }
             case "previous":
-                runOnMainThread {
+                try runOnMainThread {
                     app.typeKey(.tab, modifierFlags: .shift)
                 }
             default:
@@ -735,7 +702,7 @@ public class GesturePerformer: GesturePerforming {
                 throw GestureError.noApplication
             }
 
-            return runOnMainThread {
+            return try runOnMainThread {
                 let screenshot = app.screenshot()
                 return screenshot.pngRepresentation
             }
@@ -763,7 +730,7 @@ public class GesturePerformer: GesturePerforming {
         }
 
         public func getOrientation() -> String {
-            return runOnMainThread {
+            return runOnMainThreadNonThrowing({
                 let device = XCUIDevice.shared
 
                 switch device.orientation {
@@ -773,7 +740,7 @@ public class GesturePerformer: GesturePerforming {
                 case .landscapeRight: return "landscape_right"
                 default: return "unknown"
                 }
-            }
+            }, fallback: "unknown")
         }
 
         // MARK: - Clipboard
@@ -829,14 +796,14 @@ public class GesturePerformer: GesturePerforming {
                 guard let text = text else {
                     throw GestureError.missingParameter("text required for copy")
                 }
-                runOnMainThread {
+                try runOnMainThread {
                     UIPasteboard.general.string = text
                 }
                 GesturePerformer.writeShadow(text)
                 return nil
 
             case "clear":
-                runOnMainThread {
+                try runOnMainThread {
                     UIPasteboard.general.items = []
                 }
                 GesturePerformer.writeShadow(nil)
@@ -859,13 +826,13 @@ public class GesturePerformer: GesturePerforming {
                 try requireKeyboardFocus(app: app, context: "ensure a text field is focused before pasting")
 
                 // Use Cmd+V for real paste — handles emoji, Unicode, and is a single operation
-                runOnMainThread {
+                try runOnMainThread {
                     app.typeKey("v", modifierFlags: .command)
                 }
 
                 // iOS 16+ may show "Allow Paste" system alert (label is English-only;
                 // no reliable cross-locale alternative exists without button index)
-                handlePasteAlert()
+                try handlePasteAlert()
                 return nil
 
             default:
@@ -876,8 +843,8 @@ public class GesturePerformer: GesturePerforming {
         /// Handle iOS 16+ "Allow Paste" system alert that appears when pasting
         /// content set by another process. Checks SpringBoard for the alert button
         /// and taps it if present. No-op on iOS 15 or if already permitted.
-        private func handlePasteAlert() {
-            runOnMainThread {
+        private func handlePasteAlert() throws {
+            try runOnMainThread {
                 let allowButton = self.springboard.buttons["Allow Paste"]
                 // Quick existence check avoids full 0.5s wait when no alert is present
                 if allowButton.exists || allowButton.waitForExistence(timeout: 0.3) {
@@ -887,13 +854,13 @@ public class GesturePerformer: GesturePerforming {
         }
 
         public func pressHome() throws {
-            runOnMainThread {
+            try runOnMainThread {
                 XCUIDevice.shared.press(.home)
             }
         }
 
         public func openRecentApps() throws {
-            runOnMainThread {
+            try runOnMainThread {
                 let springboard = XCUIApplication(bundleIdentifier: "com.apple.springboard")
                 let screenSize = springboard.frame.size
                 let startCoordinate = springboard.coordinate(withNormalizedOffset: .zero)
@@ -912,32 +879,32 @@ public class GesturePerformer: GesturePerforming {
         // MARK: - App Control
 
         public func launchApp(bundleId: String) throws {
-            runOnMainThread {
+            try runOnMainThread {
                 let app = XCUIApplication(bundleIdentifier: bundleId)
                 app.launch()
             }
         }
 
         public func terminateApp(bundleId: String) throws {
-            runOnMainThread {
+            try runOnMainThread {
                 let app = XCUIApplication(bundleIdentifier: bundleId)
                 app.terminate()
             }
         }
 
         public func activateApp(bundleId: String) throws {
-            runOnMainThread {
+            try runOnMainThread {
                 let app = XCUIApplication(bundleIdentifier: bundleId)
                 app.activate()
             }
         }
 
         public func updateApplication(bundleId: String) {
-            runOnMainThread {
+            runOnMainThreadNonThrowing({
                 let app = XCUIApplication(bundleIdentifier: bundleId)
                 self.ownedApplication = app
                 self.application = app
-            }
+            }, fallback: ())
         }
 
     #else

--- a/ios/control-proxy/Sources/CtrlProxy/MainThreadRunner.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/MainThreadRunner.swift
@@ -1,0 +1,59 @@
+import Foundation
+import ObjCExceptionCatcher
+
+/// Executes a throwing closure on the main thread, catching both Swift errors and ObjC NSExceptions.
+/// XCUITest APIs must be called on the main thread and can throw NSExceptions
+/// (e.g. stale element references) that Swift try/catch cannot catch natively.
+func runOnMainThread<T>(_ block: @escaping () throws -> T) throws -> T {
+    if Thread.isMainThread {
+        return try catchingObjCException { try block() }
+    }
+
+    var result: Result<T, Error>?
+    DispatchQueue.main.sync {
+        let exception = ObjCExceptionCatcher_tryBlock {
+            do {
+                result = try .success(block())
+            } catch {
+                result = .failure(error)
+            }
+        }
+        if result == nil, let exception = exception {
+            result = .failure(ObjCExceptionError(exception: exception))
+        }
+    }
+    guard let unwrapped = result else {
+        throw ObjCExceptionError(
+            name: NSExceptionName.internalInconsistencyException.rawValue,
+            reason: "runOnMainThread: block produced neither result nor error"
+        )
+    }
+    return try unwrapped.get()
+}
+
+/// Non-throwing variant for protocol methods that cannot propagate errors.
+/// ObjC exceptions are caught and logged; the fallback value is returned.
+func runOnMainThreadNonThrowing<T>(_ block: @escaping () -> T, fallback: T) -> T {
+    if Thread.isMainThread {
+        var result: T?
+        let exception = ObjCExceptionCatcher_tryBlock {
+            result = block()
+        }
+        if let exception = exception {
+            print("[MainThread] ObjC exception in non-throwing context: \(exception.name) - \(exception.reason ?? "nil")")
+            return fallback
+        }
+        return result ?? fallback
+    }
+
+    var result: T?
+    DispatchQueue.main.sync {
+        let exception = ObjCExceptionCatcher_tryBlock {
+            result = block()
+        }
+        if let exception = exception {
+            print("[MainThread] ObjC exception in non-throwing context: \(exception.name) - \(exception.reason ?? "nil")")
+        }
+    }
+    return result ?? fallback
+}

--- a/ios/control-proxy/Sources/CtrlProxy/ObjCExceptionBridge.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/ObjCExceptionBridge.swift
@@ -1,0 +1,74 @@
+import Foundation
+import ObjCExceptionCatcher
+
+/// Error type representing a caught Objective-C NSException.
+/// Bridges ObjC exceptions into Swift's error handling so they propagate
+/// as WebSocket error responses instead of killing the process.
+public struct ObjCExceptionError: LocalizedError {
+    public let name: String
+    public let reason: String?
+
+    public var errorDescription: String? {
+        "NSException(\(name)): \(reason ?? "no reason")"
+    }
+
+    public init(name: String, reason: String?) {
+        self.name = name
+        self.reason = reason
+    }
+
+    init(exception: NSException) {
+        self.name = exception.name.rawValue
+        self.reason = exception.reason
+    }
+}
+
+/// Executes a throwing closure, catching both Swift errors and ObjC NSExceptions.
+/// NSExceptions are converted to `ObjCExceptionError`.
+public func catchingObjCException<T>(_ block: () throws -> T) throws -> T {
+    var result: T?
+    var swiftError: Error?
+
+    let exception = ObjCExceptionCatcher_tryBlock {
+        do {
+            result = try block()
+        } catch {
+            swiftError = error
+        }
+    }
+
+    if let exception = exception {
+        throw ObjCExceptionError(exception: exception)
+    }
+    if let swiftError = swiftError {
+        throw swiftError
+    }
+    guard let value = result else {
+        throw ObjCExceptionError(
+            name: NSExceptionName.internalInconsistencyException.rawValue,
+            reason: "Block completed without producing a result or error"
+        )
+    }
+    return value
+}
+
+/// Executes a non-throwing closure, catching ObjC NSExceptions.
+/// NSExceptions are converted to `ObjCExceptionError`.
+public func catchingObjCException<T>(_ block: () -> T) throws -> T {
+    var result: T?
+
+    let exception = ObjCExceptionCatcher_tryBlock {
+        result = block()
+    }
+
+    if let exception = exception {
+        throw ObjCExceptionError(exception: exception)
+    }
+    guard let value = result else {
+        throw ObjCExceptionError(
+            name: NSExceptionName.internalInconsistencyException.rawValue,
+            reason: "Block completed without producing a result"
+        )
+    }
+    return value
+}

--- a/ios/control-proxy/Sources/CtrlProxy/WebSocketServer.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/WebSocketServer.swift
@@ -154,15 +154,9 @@ public class WebSocketServer: WebSocketServing {
 
         } catch {
             print("[WebSocketServer] Error handling message: \(error)")
-            perfProvider.clear() // Clear any partial timing data on error
-            let errorResponse = WebSocketResponse.error(
-                type: "error",
-                requestId: nil,
-                error: error.localizedDescription
-            )
-            if let data = try? JSONEncoder().encode(errorResponse) {
-                connection.send(data)
-            }
+            perfProvider.clear()
+            let requestId = Self.extractRequestId(from: data)
+            Self.sendErrorResponse(connection: connection, requestId: requestId, error: error)
         }
     }
 
@@ -283,6 +277,56 @@ public class WebSocketServer: WebSocketServing {
     /// Get access to the perf provider for tracking operations
     public var perf: PerfProvider {
         perfProvider
+    }
+
+    // MARK: - Error Response Helpers
+
+    /// Sends an error response with fallback to raw JSON if encoding fails.
+    static func sendErrorResponse(connection: WebSocketConnection, requestId: String?, error: Error) {
+        let data = buildErrorResponseData(requestId: requestId, error: error)
+        connection.send(data)
+    }
+
+    /// Builds error response data, falling back to hand-crafted JSON if encoding fails.
+    static func buildErrorResponseData(requestId: String?, error: Error) -> Data {
+        let errorResponse = WebSocketResponse.error(
+            type: "error",
+            requestId: requestId,
+            error: error.localizedDescription
+        )
+
+        do {
+            let encoder = JSONEncoder()
+            encoder.outputFormatting = .sortedKeys
+            return try encoder.encode(errorResponse)
+        } catch {
+            let sanitizedError = String(
+                errorResponse.error?
+                    .prefix(500)
+                    .replacingOccurrences(of: "\\", with: "\\\\")
+                    .replacingOccurrences(of: "\"", with: "\\\"")
+                    ?? "unknown error"
+            )
+            let requestIdJSON = requestId.map { id in
+                let escaped = id
+                    .replacingOccurrences(of: "\\", with: "\\\\")
+                    .replacingOccurrences(of: "\"", with: "\\\"")
+                return "\"\(escaped)\""
+            } ?? "null"
+            let fallbackJSON = """
+            {"type":"error","success":false,"requestId":\(requestIdJSON),"error":"[encoding fallback] \(sanitizedError)","timestamp":\(Int64(Date().timeIntervalSince1970 * 1000))}
+            """
+            print("[WebSocketServer] Error response encoding failed, using fallback")
+            return fallbackJSON.data(using: .utf8) ?? Data()
+        }
+    }
+
+    /// Best-effort extraction of requestId from raw JSON data for error correlation.
+    private static func extractRequestId(from data: Data) -> String? {
+        guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            return nil
+        }
+        return json["requestId"] as? String
     }
 }
 
@@ -465,8 +509,14 @@ class WebSocketConnection {
 
     private func sendConnectedEvent() {
         let event = ConnectedEvent(id: id)
-        if let data = try? JSONEncoder().encode(event) {
+        do {
+            let data = try JSONEncoder().encode(event)
             send(data)
+        } catch {
+            let fallback = "{\"type\":\"connected\",\"id\":\(id)}"
+            if let data = fallback.data(using: .utf8) {
+                send(data)
+            }
         }
     }
 

--- a/ios/control-proxy/Sources/ObjCExceptionCatcher/ObjCExceptionCatcher.m
+++ b/ios/control-proxy/Sources/ObjCExceptionCatcher/ObjCExceptionCatcher.m
@@ -1,0 +1,11 @@
+#import "ObjCExceptionCatcher.h"
+
+NSException * _Nullable ObjCExceptionCatcher_tryBlock(void (NS_NOESCAPE ^block)(void)) {
+    @try {
+        block();
+        return nil;
+    }
+    @catch (NSException *exception) {
+        return exception;
+    }
+}

--- a/ios/control-proxy/Sources/ObjCExceptionCatcher/include/ObjCExceptionCatcher.h
+++ b/ios/control-proxy/Sources/ObjCExceptionCatcher/include/ObjCExceptionCatcher.h
@@ -1,0 +1,9 @@
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+/// Executes the given block, catching any NSException thrown.
+/// Returns the caught NSException, or nil if no exception was raised.
+FOUNDATION_EXPORT NSException * _Nullable ObjCExceptionCatcher_tryBlock(void (NS_NOESCAPE ^block)(void));
+
+NS_ASSUME_NONNULL_END

--- a/ios/control-proxy/Tests/CtrlProxyTests/CommandHandlerTests.swift
+++ b/ios/control-proxy/Tests/CtrlProxyTests/CommandHandlerTests.swift
@@ -865,6 +865,109 @@ final class CommandHandlerTests: XCTestCase {
         XCTAssertTrue(errorResponse.error?.contains("orientation") == true)
     }
 
+    // MARK: - ObjCExceptionError Propagation Tests
+
+    func testTapWithObjCExceptionReturnsErrorResponse() {
+        fakeGesturePerformer.setFailure(
+            for: "tap",
+            error: ObjCExceptionError(name: "NSRangeException", reason: "index 5 beyond bounds [0..3]")
+        )
+
+        let request = WebSocketRequest(
+            type: "request_tap_coordinates",
+            requestId: "tap-objc-err",
+            x: 100,
+            y: 200
+        )
+
+        let response = commandHandler.handle(request)
+
+        guard let errorResponse = response as? WebSocketResponse else {
+            XCTFail("Expected WebSocketResponse")
+            return
+        }
+
+        XCTAssertEqual(errorResponse.success, false)
+        XCTAssertNotNil(errorResponse.error)
+        XCTAssertTrue(errorResponse.error?.contains("NSRangeException") ?? false)
+        XCTAssertTrue(errorResponse.error?.contains("index 5 beyond bounds") ?? false)
+    }
+
+    func testSwipeWithObjCExceptionReturnsErrorResponse() {
+        fakeGesturePerformer.setFailure(
+            for: "swipe",
+            error: ObjCExceptionError(name: "NSInternalInconsistencyException", reason: "Invalid snapshot")
+        )
+
+        let request = WebSocketRequest(
+            type: "request_swipe",
+            requestId: "swipe-objc-err",
+            duration: 300,
+            x1: 100,
+            y1: 200,
+            x2: 100,
+            y2: 500
+        )
+
+        let response = commandHandler.handle(request)
+
+        guard let errorResponse = response as? WebSocketResponse else {
+            XCTFail("Expected WebSocketResponse")
+            return
+        }
+
+        XCTAssertEqual(errorResponse.success, false)
+        XCTAssertTrue(errorResponse.error?.contains("NSInternalInconsistencyException") ?? false)
+        XCTAssertTrue(errorResponse.error?.contains("Invalid snapshot") ?? false)
+    }
+
+    func testHierarchyWithObjCExceptionReturnsErrorResponse() {
+        fakeElementLocator.setShouldThrow(
+            ObjCExceptionError(name: "NSGenericException", reason: "Stale element reference")
+        )
+
+        let request = WebSocketRequest(
+            type: "request_hierarchy",
+            requestId: "hier-objc-err"
+        )
+
+        let response = commandHandler.handle(request)
+
+        guard let errorResponse = response as? WebSocketResponse else {
+            XCTFail("Expected WebSocketResponse error")
+            return
+        }
+
+        XCTAssertFalse(errorResponse.success ?? true)
+        XCTAssertTrue(errorResponse.error?.contains("NSGenericException") ?? false)
+        XCTAssertTrue(errorResponse.error?.contains("Stale element reference") ?? false)
+    }
+
+    func testLaunchAppWithObjCExceptionReturnsErrorResponse() {
+        fakeElementLocator.getAppStateResult = .notRunning
+        fakeGesturePerformer.setFailure(
+            for: "launchApp",
+            error: ObjCExceptionError(name: "NSInvalidArgumentException", reason: "App not installed")
+        )
+
+        let request = WebSocketRequest(
+            type: "request_launch_app",
+            requestId: "launch-objc-err",
+            bundleId: "com.missing.app"
+        )
+
+        let response = commandHandler.handle(request)
+
+        guard let errorResponse = response as? WebSocketResponse else {
+            XCTFail("Expected WebSocketResponse")
+            return
+        }
+
+        XCTAssertEqual(errorResponse.success, false)
+        XCTAssertTrue(errorResponse.error?.contains("NSInvalidArgumentException") ?? false)
+        XCTAssertTrue(errorResponse.error?.contains("App not installed") ?? false)
+    }
+
     // MARK: - Unknown Command Tests
 
     func testUnknownCommand() {

--- a/ios/control-proxy/Tests/CtrlProxyTests/ObjCExceptionBridgeTests.swift
+++ b/ios/control-proxy/Tests/CtrlProxyTests/ObjCExceptionBridgeTests.swift
@@ -1,0 +1,144 @@
+@testable import CtrlProxy
+import XCTest
+
+final class ObjCExceptionBridgeTests: XCTestCase {
+
+    // MARK: - Success Cases
+
+    func testCatchingObjCExceptionReturnsValueOnSuccess() throws {
+        let result = try catchingObjCException { 42 }
+        XCTAssertEqual(result, 42)
+    }
+
+    func testCatchingObjCExceptionThrowingOverloadReturnsValueOnSuccess() throws {
+        let result = try catchingObjCException { () throws -> String in
+            return "hello"
+        }
+        XCTAssertEqual(result, "hello")
+    }
+
+    // MARK: - Swift Error Passthrough
+
+    func testCatchingObjCExceptionPassesThroughSwiftError() {
+        let expectedError = CommandError.executionFailed("test failure")
+
+        XCTAssertThrowsError(
+            try catchingObjCException { () throws -> Int in
+                throw expectedError
+            }
+        ) { error in
+            guard let commandError = error as? CommandError else {
+                XCTFail("Expected CommandError, got \(type(of: error))")
+                return
+            }
+            if case .executionFailed(let message) = commandError {
+                XCTAssertEqual(message, "test failure")
+            } else {
+                XCTFail("Expected executionFailed case")
+            }
+        }
+    }
+
+    func testCatchingObjCExceptionPassesThroughNSError() {
+        let nsError = NSError(domain: "TestDomain", code: 99, userInfo: [
+            NSLocalizedDescriptionKey: "NSError passthrough",
+        ])
+
+        XCTAssertThrowsError(
+            try catchingObjCException { () throws -> Int in
+                throw nsError
+            }
+        ) { error in
+            let caught = error as NSError
+            XCTAssertEqual(caught.domain, "TestDomain")
+            XCTAssertEqual(caught.code, 99)
+        }
+    }
+
+    // MARK: - ObjCExceptionError
+
+    func testObjCExceptionErrorDescription() {
+        let error = ObjCExceptionError(name: "NSRangeException", reason: "index 5 beyond bounds [0..3]")
+        XCTAssertEqual(
+            error.errorDescription,
+            "NSException(NSRangeException): index 5 beyond bounds [0..3]"
+        )
+    }
+
+    func testObjCExceptionErrorDescriptionWithNilReason() {
+        let error = ObjCExceptionError(name: "NSInvalidArgumentException", reason: nil)
+        XCTAssertEqual(
+            error.errorDescription,
+            "NSException(NSInvalidArgumentException): no reason"
+        )
+    }
+
+    func testObjCExceptionErrorFromNSException() {
+        let exception = NSException(
+            name: .rangeException,
+            reason: "test reason",
+            userInfo: nil
+        )
+        let error = ObjCExceptionError(exception: exception)
+        XCTAssertEqual(error.name, "NSRangeException")
+        XCTAssertEqual(error.reason, "test reason")
+    }
+
+    // MARK: - WebSocketServer Error Response Helpers
+
+    func testBuildErrorResponseDataProducesValidJSON() throws {
+        let error = ObjCExceptionError(name: "NSRangeException", reason: "index out of bounds")
+        let data = WebSocketServer.buildErrorResponseData(requestId: "req-123", error: error)
+
+        let json = try JSONSerialization.jsonObject(with: data) as? [String: Any]
+        XCTAssertNotNil(json)
+        XCTAssertEqual(json?["type"] as? String, "error")
+        XCTAssertEqual(json?["success"] as? Bool, false)
+        XCTAssertEqual(json?["requestId"] as? String, "req-123")
+        let errorMessage = json?["error"] as? String
+        XCTAssertTrue(errorMessage?.contains("NSRangeException") ?? false)
+        XCTAssertTrue(errorMessage?.contains("index out of bounds") ?? false)
+    }
+
+    func testBuildErrorResponseDataWithNilRequestId() throws {
+        let error = NSError(domain: "test", code: 1, userInfo: [
+            NSLocalizedDescriptionKey: "something failed",
+        ])
+        let data = WebSocketServer.buildErrorResponseData(requestId: nil, error: error)
+
+        let json = try JSONSerialization.jsonObject(with: data) as? [String: Any]
+        XCTAssertNotNil(json)
+        XCTAssertEqual(json?["type"] as? String, "error")
+        XCTAssertEqual(json?["success"] as? Bool, false)
+        XCTAssertTrue(json?["requestId"] is NSNull || json?["requestId"] == nil)
+        let errorMessage = json?["error"] as? String
+        XCTAssertTrue(errorMessage?.contains("something failed") ?? false)
+    }
+
+    func testBuildErrorResponseDataWithSpecialCharactersInError() throws {
+        let error = ObjCExceptionError(
+            name: "NSException",
+            reason: "contains \"quotes\" and \\backslash\\ chars"
+        )
+        let data = WebSocketServer.buildErrorResponseData(requestId: "req-special", error: error)
+
+        let json = try JSONSerialization.jsonObject(with: data) as? [String: Any]
+        XCTAssertNotNil(json, "Response should always be valid JSON even with special characters")
+        XCTAssertEqual(json?["requestId"] as? String, "req-special")
+    }
+
+    func testBuildErrorResponseDataHasTimestamp() throws {
+        let beforeMs = Int64(Date().timeIntervalSince1970 * 1000)
+        let error = NSError(domain: "test", code: 0, userInfo: nil)
+        let data = WebSocketServer.buildErrorResponseData(requestId: nil, error: error)
+        let afterMs = Int64(Date().timeIntervalSince1970 * 1000)
+
+        let json = try JSONSerialization.jsonObject(with: data) as? [String: Any]
+        let timestamp = json?["timestamp"] as? Int64
+        XCTAssertNotNil(timestamp)
+        if let ts = timestamp {
+            XCTAssertGreaterThanOrEqual(ts, beforeMs)
+            XCTAssertLessThanOrEqual(ts, afterMs)
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `ObjCExceptionCatcher` SPM target (ObjC `@try/@catch` bridge) and `ObjCExceptionBridge.swift` to convert NSExceptions into Swift errors that propagate as WebSocket error responses instead of killing the process
- Hardens all XCUITest API call sites in `GesturePerformer` and `ElementLocator` via shared `runOnMainThread` / `runOnMainThreadNonThrowing` helpers that catch both Swift errors and ObjC NSExceptions
- Fixes silent error swallowing in `WebSocketServer` — encoding failures now fall back to hand-crafted JSON with requestId correlation; removes `fatalError` in dead code

## Test plan

- [x] `swift build` passes
- [x] `swift test` passes (197 tests, 0 failures)
- [x] New `ObjCExceptionBridgeTests` (11 tests) verify NSException → Error conversion, Swift error passthrough, success cases, and `buildErrorResponseData` always produces valid JSON
- [x] New `CommandHandlerTests` ObjCExceptionError cases (4 tests) verify end-to-end propagation through tap/swipe/hierarchy/launch handlers
- [ ] Manual: trigger stale element reference on iOS simulator, verify error response over WebSocket instead of crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)