### PR TITLE
chore: bump versions to v0.0.27

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -14,7 +14,7 @@
       "name": "auto-mobile",
       "source": "./",
       "description": "Mobile device automation for Android and iOS - control devices with natural language",
-      "version": "0.0.26",
+      "version": "0.0.27",
       "author": {
         "name": "AutoMobile Contributors",
         "email": "jason.d.pearson@gmail.com"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "auto-mobile",
   "description": "Mobile device automation for Android and iOS - control devices with natural language",
-  "version": "0.0.26",
+  "version": "0.0.27",
   "author": {
     "name": "AutoMobile Contributors",
     "email": "jason.d.pearson@gmail.com"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,42 @@
 # Changelog
 
+## [v0.0.27] - 2026-05-18
+### Added
+- IDE Plugin: Display exported YAML in Record Test UX after finishing ([#1073](https://github.com/kaeawc/auto-mobile/issues/1073)) (intellij plugin)
+- epic: detect image/media loading via network and view hierarchy correlation ([#1015](https://github.com/kaeawc/auto-mobile/issues/1015)) (android, research, ai)
+- feat: correlate network requests with media views for loading detection ([#1014](https://github.com/kaeawc/auto-mobile/issues/1014)) (android, ai)
+- Extend focus navigation to handle scroll-then-focus for off-screen elements ([#472](https://github.com/kaeawc/auto-mobile/issues/472)) (android, a11y)
+### Changed
+- refactor: extract sendCommand helper to eliminate WebSocket delegate boilerplate ([#1880](https://github.com/kaeawc/auto-mobile/issues/1880))
+- Chore: Test multi-device execution ([#764](https://github.com/kaeawc/auto-mobile/issues/764))
+### Other
+- PlanMigrator: notification.timeout → awaitTimeout ([#2120](https://github.com/kaeawc/auto-mobile/issues/2120))
+- Plan execution ADB contention: skip screenshots and cancel orphaned jobs ([#2119](https://github.com/kaeawc/auto-mobile/issues/2119))
+- Tap resilience: ghost tap detection and pre-tap stability ([#2118](https://github.com/kaeawc/auto-mobile/issues/2118))
+- No way to configure accessibility service flags at runtime ([#2099](https://github.com/kaeawc/auto-mobile/issues/2099))
+- Reduce ADB overhead during plan execution ([#2098](https://github.com/kaeawc/auto-mobile/issues/2098))
+- Stability failures with remote emulators and long-running tool calls ([#2097](https://github.com/kaeawc/auto-mobile/issues/2097))
+- Tapping notifications inside collapsed Android groups opens app generically instead of deep-linking ([#2096](https://github.com/kaeawc/auto-mobile/issues/2096))
+- Ghost taps - touch events fail to register regardless of input method ([#2081](https://github.com/kaeawc/auto-mobile/issues/2081))
+- ADB pipe congestion from event-driven hierarchy broadcasts causes off-screen bounds ([#2080](https://github.com/kaeawc/auto-mobile/issues/2080))
+- No way to opt into observe step capture from CI without modifying test code ([#1973](https://github.com/kaeawc/auto-mobile/issues/1973))
+- executePlan timeout too short for long UI plans - premature Operation cancelled in CI ([#1972](https://github.com/kaeawc/auto-mobile/issues/1972))
+- No MCP tool for setting Android SCHEDULE_EXACT_ALARM app op ([#1967](https://github.com/kaeawc/auto-mobile/issues/1967))
+- No MCP tool for toggling Android Do Not Disturb policy access ([#1966](https://github.com/kaeawc/auto-mobile/issues/1966))
+- executePlan silently continues past observe waitFor timeout instead of failing the step ([#1963](https://github.com/kaeawc/auto-mobile/issues/1963))
+- tapOn diagnostics lost when surfaced through executePlan - no visibility into tap mechanics ([#1961](https://github.com/kaeawc/auto-mobile/issues/1961))
+- Android screenrecord produces corrupt/truncated video files on stop ([#1960](https://github.com/kaeawc/auto-mobile/issues/1960))
+- Support segmented video recording to chain multiple screenrecord sessions past the 180-second Android cap ([#1959](https://github.com/kaeawc/auto-mobile/issues/1959))
+- No way to capture per-step observe snapshots for CI debugging ([#1958](https://github.com/kaeawc/auto-mobile/issues/1958))
+- No opt-in mechanism for pre-tap element stability verification ([#1950](https://github.com/kaeawc/auto-mobile/issues/1950))
+- Navigation screenshots add constant I/O pressure to CI emulators ([#1947](https://github.com/kaeawc/auto-mobile/issues/1947))
+- Queued MCP forward requests burn timeout budget while waiting in serialization queue ([#1946](https://github.com/kaeawc/auto-mobile/issues/1946))
+- HTTP server requestTimeout kills long plans + id:unknown error responses cause silent hangs ([#1944](https://github.com/kaeawc/auto-mobile/issues/1944))
+- executePlan MCP timeout too short - premature Operation cancelled ([#1943](https://github.com/kaeawc/auto-mobile/issues/1943))
+- Streamable HTTP SSE auto-reconnect triggers 409 session teardown ([#1942](https://github.com/kaeawc/auto-mobile/issues/1942))
+- Concurrent MCP socket forwards corrupt shared HTTP session ([#1939](https://github.com/kaeawc/auto-mobile/issues/1939))
+- Create Homebrew formula for AutoMobile ([#978](https://github.com/kaeawc/auto-mobile/issues/978)) (release engineering, env)
+
 ## [v0.0.26] - 2026-05-06
 ### Other
 - WebSocket timeout cascade causes daemon blindness after slow hierarchy extraction ([#2079](https://github.com/kaeawc/auto-mobile/issues/2079))

--- a/android/control-proxy/build.gradle.kts
+++ b/android/control-proxy/build.gradle.kts
@@ -36,7 +36,7 @@ android {
     minSdk = libs.versions.build.android.minSdk.get().toInt()
     targetSdk = libs.versions.build.android.targetSdk.get().toInt()
     versionCode = 1
-    versionName = "0.0.26-SNAPSHOT"
+    versionName = "0.0.27-SNAPSHOT"
 
     testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
   }

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -140,7 +140,7 @@ org.jetbrains.dokka.experimental.gradle.pluginMode=V2Enabled
 # Maven Central Publishing
 
 # Library versions (single source of truth)
-VERSION_NAME=0.0.26-SNAPSHOT
+VERSION_NAME=0.0.27-SNAPSHOT
 GROUP=dev.jasonpearson.auto-mobile
 
 # POM metadata

--- a/android/playground/app/build.gradle.kts
+++ b/android/playground/app/build.gradle.kts
@@ -36,7 +36,7 @@ android {
     minSdk = libs.versions.build.android.minSdk.get().toInt()
     targetSdk = libs.versions.build.android.targetSdk.get().toInt()
     versionCode = 1
-    versionName = "0.0.26-SNAPSHOT"
+    versionName = "0.0.27-SNAPSHOT"
 
     testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kaeawc/auto-mobile",
-  "version": "0.0.26",
+  "version": "0.0.27",
   "description": "Mobile device interaction automation via MCP",
   "scripts": {
     "test": "bun test",

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "dev.jasonpearson/auto-mobile",
   "title": "AutoMobile",
   "description": "Mobile device interaction automation via MCP",
-  "version": "0.0.26",
+  "version": "0.0.27",
   "websiteUrl": "https://kaeawc.github.io/auto-mobile/",
   "repository": {
     "url": "https://github.com/kaeawc/auto-mobile",
@@ -13,7 +13,7 @@
     {
       "registryType": "npm",
       "identifier": "@kaeawc/auto-mobile",
-      "version": "0.0.26",
+      "version": "0.0.27",
       "runtimeHint": "bunx",
       "transport": {
         "type": "stdio"

--- a/src/constants/release.ts
+++ b/src/constants/release.ts
@@ -26,6 +26,11 @@ export interface ReleaseChecksumEntry {
  */
 export const RELEASE_CHECKSUM_REGISTRY: ReleaseChecksumEntry[] = [
   {
+    version: "0.0.27",
+    apkSha256: "9966113ae44f38f3cf34544b1375d3c9a3706701edba45a1eec1f220b9c676cc",
+    ipaSha256: "8620de6b014df18465876334f9ba8c106292f6c3059370eea2349f1e44db4f4d",
+  },
+  {
     version: "0.0.26",
     apkSha256: "2eb2f156fd27602c85003ab8f6e00d3e06850e84f5453d75b7494aa5bbed7be0",
     ipaSha256: "905df276d2224d31cbc5aa2258d2dcc60eaeb9813727081ddd32c95394fec411",


### PR DESCRIPTION
## Summary
- Bump versions to v0.0.27
- Update CHANGELOG.md from closed issues since the last tag
- Refresh CtrlProxy APK SHA256 checksum
- Refresh CtrlProxy iOS IPA SHA256 checksum

## Automation
- Generated by `prepare-release` workflow