### PR TITLE
refactor(dsm): inject CtrlProxy managers/clients via DeviceClientProvider

### DIFF
--- a/src/utils/CtrlProxyManager.ts
+++ b/src/utils/CtrlProxyManager.ts
@@ -46,6 +46,7 @@ export interface CtrlProxyManager {
   enable(): Promise<void>;
   enableForUser(userId: number): Promise<void>;
   cleanupApk(apkPath: string): Promise<void>;
+  resetSetupState(): void;
 }
 
 interface AccessibilityVersionCheckResult {

--- a/src/utils/DeviceSessionManager.ts
+++ b/src/utils/DeviceSessionManager.ts
@@ -4,13 +4,15 @@ import { AdbClientFactory, defaultAdbClientFactory } from "./android-cmdline-too
 import { SimCtlClient } from "./ios-cmdline-tools/SimCtlClient";
 import { Window } from "../features/observe/Window";
 import { logger } from "./logger";
-import { AndroidCtrlProxyManager } from "./CtrlProxyManager";
-import { IOSCtrlProxyManager } from "./IOSCtrlProxyManager";
+import { AndroidCtrlProxyManager, CtrlProxyManager } from "./CtrlProxyManager";
+import { IOSCtrlProxyManager, CtrlProxyIosManager } from "./IOSCtrlProxyManager";
 import { AndroidEmulatorClient } from "./android-cmdline-tools/AndroidEmulatorClient";
 import type { AdbExecutor } from "./android-cmdline-tools/interfaces/AdbExecutor";
 import { PlatformDeviceManager } from "./interfaces/DeviceUtils";
 import { AndroidCtrlProxyClient } from "../features/observe/android";
+import type { AndroidCtrlProxy } from "../features/observe/android/AndroidCtrlProxyClient";
 import { IOSCtrlProxyClient } from "../features/observe/ios";
+import type { IOSCtrlProxy } from "../features/observe/ios/IOSCtrlProxyClient";
 import { RealObserveScreen } from "../features/observe/ObserveScreen";
 import { createPerformanceTracker, createGlobalPerformanceTracker } from "./PerformanceTracker";
 import { storeSetupTiming } from "../server/ToolExecutionContext";
@@ -25,6 +27,10 @@ export interface DeviceClientProvider {
   getSimctl(): SimCtlClient | undefined;
   getAndroidEmulator(): AndroidEmulatorClient | undefined;
   getDeviceUtils(): PlatformDeviceManager;
+  getAndroidCtrlProxyManager(device: BootedDevice): CtrlProxyManager;
+  getAndroidCtrlProxyClient(device: BootedDevice): AndroidCtrlProxy;
+  getIOSCtrlProxyManager(device: BootedDevice): CtrlProxyIosManager;
+  getIOSCtrlProxyClient(device: BootedDevice, port: number): IOSCtrlProxy;
 }
 
 /**
@@ -71,6 +77,22 @@ class DefaultDeviceClientProvider implements DeviceClientProvider {
       );
     }
     return this._deviceUtils;
+  }
+
+  getAndroidCtrlProxyManager(device: BootedDevice): CtrlProxyManager {
+    return AndroidCtrlProxyManager.getInstance(device);
+  }
+
+  getAndroidCtrlProxyClient(device: BootedDevice): AndroidCtrlProxy {
+    return AndroidCtrlProxyClient.getInstance(device);
+  }
+
+  getIOSCtrlProxyManager(device: BootedDevice): CtrlProxyIosManager {
+    return IOSCtrlProxyManager.getInstance(device);
+  }
+
+  getIOSCtrlProxyClient(device: BootedDevice, port: number): IOSCtrlProxy {
+    return IOSCtrlProxyClient.getInstance(device, port);
   }
 }
 
@@ -463,7 +485,7 @@ export class DeviceSessionManager implements DeviceSessionManager {
         if (options?.skipAccessibilityDownload !== undefined) { logger.warn("[DeviceSessionManager] skipAccessibilityDownload is deprecated; use skipCtrlProxyDownload instead."); } else { logger.warn("[DeviceSessionManager] skipAccessibilitySetup is deprecated; use skipCtrlProxyDownload instead."); }
       }
 
-      const accessibilityClient = AndroidCtrlProxyClient.getInstance(device);
+      const accessibilityClient = this.provider.getAndroidCtrlProxyClient(device);
       if (accessibilityClient.isConnected()) {
         // WebSocket appears connected, but verify service is actually responsive
         // This catches cases where service crashed but socket wasn't properly closed
@@ -480,7 +502,7 @@ export class DeviceSessionManager implements DeviceSessionManager {
         logger.warn(`[DeviceSessionManager] WebSocket connected but service not responsive for ${deviceId}, checking status`);
       }
 
-      const manager = AndroidCtrlProxyManager.getInstance(device);
+      const manager = this.provider.getAndroidCtrlProxyManager(device);
       const verifyCompatibilityWhenSkipping = async (): Promise<void> => {
         const isCompatible = await manager.isVersionCompatible();
         if (isCompatible) {
@@ -642,8 +664,8 @@ export class DeviceSessionManager implements DeviceSessionManager {
     try {
       const skipCtrlProxyIOSSetup = options?.skipCtrlProxyDownload ?? options?.skipAccessibilityDownload ?? options?.skipAccessibilitySetup;
 
-      const manager = IOSCtrlProxyManager.getInstance(device);
-      const xcTestClient = IOSCtrlProxyClient.getInstance(device, manager.getServicePort());
+      const manager = this.provider.getIOSCtrlProxyManager(device);
+      const xcTestClient = this.provider.getIOSCtrlProxyClient(device, manager.getServicePort());
 
       // Check if WebSocket is already connected
       if (xcTestClient.isConnected()) {
@@ -884,8 +906,8 @@ export class DeviceSessionManager implements DeviceSessionManager {
     }
 
     try {
-      const manager = IOSCtrlProxyManager.getInstance(device);
-      const xcTestClient = IOSCtrlProxyClient.getInstance(device, manager.getServicePort());
+      const manager = this.provider.getIOSCtrlProxyManager(device);
+      const xcTestClient = this.provider.getIOSCtrlProxyClient(device, manager.getServicePort());
 
       xcTestClient.onPushUpdate(() => {
         logger.info(`[DeviceSessionManager] Received iOS UI change notification for ${deviceId}, clearing ObserveScreen cache`);

--- a/src/utils/IOSCtrlProxyManager.ts
+++ b/src/utils/IOSCtrlProxyManager.ts
@@ -49,6 +49,7 @@ export interface CtrlProxyIosManager {
   setAutoRestart(enabled: boolean): void;
   isAutoRestartEnabled(): boolean;
   forceRestart(): Promise<void>;
+  resetSetupState(): void;
 }
 
 interface HostControlCtrlProxyIOSRunner {

--- a/test/fakes/FakeDeviceClientProvider.ts
+++ b/test/fakes/FakeDeviceClientProvider.ts
@@ -17,38 +17,26 @@ export interface FakeDeviceClientProviderOptions {
 }
 
 /**
- * Fake provider for testing - returns injected fakes instead of real clients.
- *
- * CtrlProxy fakes default to throw-on-use so a test that exercises a code
- * path requiring them must pass an explicit fake. This catches accidental
- * fall-throughs to real singletons in tests.
+ * Fakes default to throw-on-use: tests that exercise a code path requiring
+ * a CtrlProxy must pass an explicit fake. This prevents silent fall-through
+ * to a real singleton when a fake is forgotten.
  */
 export class FakeDeviceClientProvider implements DeviceClientProvider {
-  private readonly options: FakeDeviceClientProviderOptions;
-
   constructor(
     private readonly fakeAdb: AdbExecutor,
     private readonly fakeDeviceUtils: PlatformDeviceManager,
     private readonly fakeSimctl?: SimCtlClient,
-    options: FakeDeviceClientProviderOptions = {}
-  ) {
-    this.options = options;
-  }
+    private readonly options: FakeDeviceClientProviderOptions = {}
+  ) {}
 
-  setCtrlProxyManager(manager: CtrlProxyManager): void {
-    this.options.ctrlProxyManager = manager;
-  }
-
-  setCtrlProxyClient(client: AndroidCtrlProxy): void {
-    this.options.ctrlProxyClient = client;
-  }
-
-  setIOSCtrlProxyManager(manager: CtrlProxyIosManager): void {
-    this.options.iosCtrlProxyManager = manager;
-  }
-
-  setIOSCtrlProxyClient(client: IOSCtrlProxy): void {
-    this.options.iosCtrlProxyClient = client;
+  private require<T>(value: T | undefined, fieldName: string): T {
+    if (!value) {
+      throw new Error(
+        `FakeDeviceClientProvider: ${fieldName} fake not configured. ` +
+        `Pass it via constructor options.`
+      );
+    }
+    return value;
   }
 
   getAdb(): AdbExecutor {
@@ -60,7 +48,6 @@ export class FakeDeviceClientProvider implements DeviceClientProvider {
   }
 
   getAndroidEmulator(): AndroidEmulatorClient | undefined {
-    // Tests use fakeDeviceUtils instead
     return undefined;
   }
 
@@ -69,42 +56,18 @@ export class FakeDeviceClientProvider implements DeviceClientProvider {
   }
 
   getAndroidCtrlProxyManager(_device: BootedDevice): CtrlProxyManager {
-    if (!this.options.ctrlProxyManager) {
-      throw new Error(
-        "FakeDeviceClientProvider: ctrlProxyManager fake not configured. " +
-        "Pass it via constructor options or setCtrlProxyManager()."
-      );
-    }
-    return this.options.ctrlProxyManager;
+    return this.require(this.options.ctrlProxyManager, "ctrlProxyManager");
   }
 
   getAndroidCtrlProxyClient(_device: BootedDevice): AndroidCtrlProxy {
-    if (!this.options.ctrlProxyClient) {
-      throw new Error(
-        "FakeDeviceClientProvider: ctrlProxyClient fake not configured. " +
-        "Pass it via constructor options or setCtrlProxyClient()."
-      );
-    }
-    return this.options.ctrlProxyClient;
+    return this.require(this.options.ctrlProxyClient, "ctrlProxyClient");
   }
 
   getIOSCtrlProxyManager(_device: BootedDevice): CtrlProxyIosManager {
-    if (!this.options.iosCtrlProxyManager) {
-      throw new Error(
-        "FakeDeviceClientProvider: iosCtrlProxyManager fake not configured. " +
-        "Pass it via constructor options or setIOSCtrlProxyManager()."
-      );
-    }
-    return this.options.iosCtrlProxyManager;
+    return this.require(this.options.iosCtrlProxyManager, "iosCtrlProxyManager");
   }
 
   getIOSCtrlProxyClient(_device: BootedDevice, _port: number): IOSCtrlProxy {
-    if (!this.options.iosCtrlProxyClient) {
-      throw new Error(
-        "FakeDeviceClientProvider: iosCtrlProxyClient fake not configured. " +
-        "Pass it via constructor options or setIOSCtrlProxyClient()."
-      );
-    }
-    return this.options.iosCtrlProxyClient;
+    return this.require(this.options.iosCtrlProxyClient, "iosCtrlProxyClient");
   }
 }

--- a/test/fakes/FakeDeviceClientProvider.ts
+++ b/test/fakes/FakeDeviceClientProvider.ts
@@ -3,16 +3,53 @@ import { AdbExecutor } from "../../src/utils/android-cmdline-tools/interfaces/Ad
 import { SimCtlClient } from "../../src/utils/ios-cmdline-tools/SimCtlClient";
 import { AndroidEmulatorClient } from "../../src/utils/android-cmdline-tools/AndroidEmulatorClient";
 import { PlatformDeviceManager } from "../../src/utils/interfaces/DeviceUtils";
+import { CtrlProxyManager } from "../../src/utils/CtrlProxyManager";
+import { CtrlProxyIosManager } from "../../src/utils/IOSCtrlProxyManager";
+import type { AndroidCtrlProxy } from "../../src/features/observe/android/AndroidCtrlProxyClient";
+import type { IOSCtrlProxy } from "../../src/features/observe/ios/IOSCtrlProxyClient";
+import { BootedDevice } from "../../src/models";
+
+export interface FakeDeviceClientProviderOptions {
+  ctrlProxyManager?: CtrlProxyManager;
+  ctrlProxyClient?: AndroidCtrlProxy;
+  iosCtrlProxyManager?: CtrlProxyIosManager;
+  iosCtrlProxyClient?: IOSCtrlProxy;
+}
 
 /**
- * Fake provider for testing - returns injected fakes instead of real clients
+ * Fake provider for testing - returns injected fakes instead of real clients.
+ *
+ * CtrlProxy fakes default to throw-on-use so a test that exercises a code
+ * path requiring them must pass an explicit fake. This catches accidental
+ * fall-throughs to real singletons in tests.
  */
 export class FakeDeviceClientProvider implements DeviceClientProvider {
+  private readonly options: FakeDeviceClientProviderOptions;
+
   constructor(
     private readonly fakeAdb: AdbExecutor,
     private readonly fakeDeviceUtils: PlatformDeviceManager,
-    private readonly fakeSimctl?: SimCtlClient
-  ) {}
+    private readonly fakeSimctl?: SimCtlClient,
+    options: FakeDeviceClientProviderOptions = {}
+  ) {
+    this.options = options;
+  }
+
+  setCtrlProxyManager(manager: CtrlProxyManager): void {
+    this.options.ctrlProxyManager = manager;
+  }
+
+  setCtrlProxyClient(client: AndroidCtrlProxy): void {
+    this.options.ctrlProxyClient = client;
+  }
+
+  setIOSCtrlProxyManager(manager: CtrlProxyIosManager): void {
+    this.options.iosCtrlProxyManager = manager;
+  }
+
+  setIOSCtrlProxyClient(client: IOSCtrlProxy): void {
+    this.options.iosCtrlProxyClient = client;
+  }
 
   getAdb(): AdbExecutor {
     return this.fakeAdb;
@@ -29,5 +66,45 @@ export class FakeDeviceClientProvider implements DeviceClientProvider {
 
   getDeviceUtils(): PlatformDeviceManager {
     return this.fakeDeviceUtils;
+  }
+
+  getAndroidCtrlProxyManager(_device: BootedDevice): CtrlProxyManager {
+    if (!this.options.ctrlProxyManager) {
+      throw new Error(
+        "FakeDeviceClientProvider: ctrlProxyManager fake not configured. " +
+        "Pass it via constructor options or setCtrlProxyManager()."
+      );
+    }
+    return this.options.ctrlProxyManager;
+  }
+
+  getAndroidCtrlProxyClient(_device: BootedDevice): AndroidCtrlProxy {
+    if (!this.options.ctrlProxyClient) {
+      throw new Error(
+        "FakeDeviceClientProvider: ctrlProxyClient fake not configured. " +
+        "Pass it via constructor options or setCtrlProxyClient()."
+      );
+    }
+    return this.options.ctrlProxyClient;
+  }
+
+  getIOSCtrlProxyManager(_device: BootedDevice): CtrlProxyIosManager {
+    if (!this.options.iosCtrlProxyManager) {
+      throw new Error(
+        "FakeDeviceClientProvider: iosCtrlProxyManager fake not configured. " +
+        "Pass it via constructor options or setIOSCtrlProxyManager()."
+      );
+    }
+    return this.options.iosCtrlProxyManager;
+  }
+
+  getIOSCtrlProxyClient(_device: BootedDevice, _port: number): IOSCtrlProxy {
+    if (!this.options.iosCtrlProxyClient) {
+      throw new Error(
+        "FakeDeviceClientProvider: iosCtrlProxyClient fake not configured. " +
+        "Pass it via constructor options or setIOSCtrlProxyClient()."
+      );
+    }
+    return this.options.iosCtrlProxyClient;
   }
 }

--- a/test/fakes/FakeIOSCtrlProxyManager.ts
+++ b/test/fakes/FakeIOSCtrlProxyManager.ts
@@ -181,4 +181,8 @@ export class FakeIOSCtrlProxyManager implements CtrlProxyIosManager {
     this.executedOperations.push("forceRestart");
     this.runningState = true;
   }
+
+  resetSetupState(): void {
+    this.executedOperations.push("resetSetupState");
+  }
 }

--- a/test/utils/DeviceSessionManager.test.ts
+++ b/test/utils/DeviceSessionManager.test.ts
@@ -5,6 +5,7 @@ import { FakeDeviceUtils } from "../fakes/FakeDeviceUtils";
 import { FakeDeviceClientProvider } from "../fakes/FakeDeviceClientProvider";
 import { FakeCtrlProxyManager } from "../fakes/FakeCtrlProxyManager";
 import { FakeIOSCtrlProxyManager } from "../fakes/FakeIOSCtrlProxyManager";
+import { FakeIOSCtrlProxy } from "../fakes/FakeIOSCtrlProxy";
 import { FakeSimCtlClient } from "../fakes/FakeSimCtlClient";
 import { FakeSimctl } from "../fakes/FakeSimctl";
 import { Window } from "../../src/features/observe/Window";
@@ -12,20 +13,13 @@ import { BootedDevice, AppearanceConfigInput } from "../../src/models";
 import { serverConfig } from "../../src/utils/ServerConfig";
 import type { AdbClientFactory } from "../../src/utils/android-cmdline-tools/AdbClientFactory";
 import type { AndroidCtrlProxy } from "../../src/features/observe/android/AndroidCtrlProxyClient";
-import type { IOSCtrlProxy } from "../../src/features/observe/ios/IOSCtrlProxyClient";
 
-/**
- * Inline minimal AndroidCtrlProxy stubs are produced by this helper so each
- * test can focus on the specific connection states it cares about without
- * implementing the full surface. Cast through `unknown` to satisfy the
- * structural interface where the test only reads the configured methods.
- */
+// Inline minimal AndroidCtrlProxy where each test sets only the methods it
+// exercises — the Android fake lacks per-call `waitForConnection` /
+// `verifyServiceReady` toggles needed to cover the cache-stale and
+// "connected but not responsive" branches independently.
 function stubAndroidCtrlProxy(overrides: Partial<AndroidCtrlProxy>): AndroidCtrlProxy {
   return overrides as unknown as AndroidCtrlProxy;
-}
-
-function stubIOSCtrlProxy(overrides: Partial<IOSCtrlProxy>): IOSCtrlProxy {
-  return overrides as unknown as IOSCtrlProxy;
 }
 
 describe("DeviceSessionManager", () => {
@@ -203,15 +197,7 @@ describe("DeviceSessionManager", () => {
   });
 
   test("should skip accessibility checks when websocket is connected and service is responsive", async () => {
-    let managerTouched = false;
-    const accessibilityManager: any = new Proxy(new FakeCtrlProxyManager(), {
-      get(target, prop, receiver) {
-        if (prop !== "wasMethodCalled" && prop !== "constructor") {
-          managerTouched = true;
-        }
-        return Reflect.get(target, prop, receiver);
-      },
-    });
+    const accessibilityManager = new FakeCtrlProxyManager();
 
     const provider = new FakeDeviceClientProvider(fakeAdb, fakeDeviceUtils, undefined, {
       ctrlProxyManager: accessibilityManager,
@@ -223,7 +209,7 @@ describe("DeviceSessionManager", () => {
     const manager = DeviceSessionManager.createInstance(provider);
     await manager.ensureDeviceReady("android", "device-1");
 
-    expect(managerTouched).toBe(false);
+    expect(accessibilityManager.getExecutedOperations()).toEqual([]);
   });
 
   test("should fall through to normal flow when websocket connected but service not responsive", async () => {
@@ -246,9 +232,7 @@ describe("DeviceSessionManager", () => {
     expect(accessibilityManager.wasMethodCalled("isInstalled")).toBe(true);
   });
 
-  test("regression: provider, not static getInstance, supplies CtrlProxy collaborators", async () => {
-    // Wire fakes only via the provider — do NOT monkey-patch any static getInstance.
-    // The DSM must obtain its CtrlProxy manager + client exclusively through the provider.
+  test("CtrlProxy collaborators come from the provider, not static getInstance", async () => {
     const accessibilityManager = new FakeCtrlProxyManager();
     accessibilityManager.setInstalled(true);
     accessibilityManager.setEnabled(true);
@@ -272,9 +256,7 @@ describe("DeviceSessionManager", () => {
     expect(clientFromProvider).toBeGreaterThan(0);
   });
 
-  test("regression: FakeDeviceClientProvider throws directly when ctrlProxy fakes are missing", () => {
-    // If a test wires a fake provider without ctrlProxy fakes, the provider itself
-    // must fail loudly so the omission can't be silently masked by DSM's catch.
+  test("FakeDeviceClientProvider throws when CtrlProxy fakes are not configured", () => {
     const provider = new FakeDeviceClientProvider(fakeAdb, fakeDeviceUtils);
     expect(() => provider.getAndroidCtrlProxyClient(device)).toThrow(/ctrlProxyClient fake not configured/);
     expect(() => provider.getAndroidCtrlProxyManager(device)).toThrow(/ctrlProxyManager fake not configured/);
@@ -312,15 +294,15 @@ describe("DeviceSessionManager iOS openSimulatorApp", () => {
   ): FakeDeviceClientProvider {
     const iosManager = new FakeIOSCtrlProxyManager();
     iosManager.setSetupShouldFail(true); // skip the setup path in these tests
+    const iosClient = new FakeIOSCtrlProxy();
+    iosClient.setConnected(false);
     return new FakeDeviceClientProvider(
       fakeAdb,
       fakeDeviceUtils,
       fakeSimctl as any,
       {
         iosCtrlProxyManager: iosManager,
-        iosCtrlProxyClient: stubIOSCtrlProxy({
-          isConnected: () => false,
-        }),
+        iosCtrlProxyClient: iosClient,
       }
     );
   }
@@ -472,6 +454,8 @@ describe("DeviceSessionManager dual-platform resolution", () => {
 
     const fakeIosManager = new FakeIOSCtrlProxyManager();
     fakeIosManager.setSetupShouldFail(true);
+    const fakeIosClient = new FakeIOSCtrlProxy();
+    fakeIosClient.setConnected(false);
 
     return new FakeDeviceClientProvider(
       fakeAdb,
@@ -484,7 +468,7 @@ describe("DeviceSessionManager dual-platform resolution", () => {
           verifyServiceReady: () => Promise.resolve(true),
         }),
         iosCtrlProxyManager: fakeIosManager,
-        iosCtrlProxyClient: stubIOSCtrlProxy({ isConnected: () => false }),
+        iosCtrlProxyClient: fakeIosClient,
       }
     );
   }

--- a/test/utils/DeviceSessionManager.test.ts
+++ b/test/utils/DeviceSessionManager.test.ts
@@ -4,16 +4,29 @@ import { FakeAdbExecutor } from "../fakes/FakeAdbExecutor";
 import { FakeDeviceUtils } from "../fakes/FakeDeviceUtils";
 import { FakeDeviceClientProvider } from "../fakes/FakeDeviceClientProvider";
 import { FakeCtrlProxyManager } from "../fakes/FakeCtrlProxyManager";
+import { FakeIOSCtrlProxyManager } from "../fakes/FakeIOSCtrlProxyManager";
 import { FakeSimCtlClient } from "../fakes/FakeSimCtlClient";
 import { FakeSimctl } from "../fakes/FakeSimctl";
-import { AndroidCtrlProxyManager } from "../../src/utils/CtrlProxyManager";
-import { IOSCtrlProxyManager } from "../../src/utils/IOSCtrlProxyManager";
-import { AndroidCtrlProxyClient } from "../../src/features/observe/android";
-import { IOSCtrlProxyClient } from "../../src/features/observe/ios";
 import { Window } from "../../src/features/observe/Window";
 import { BootedDevice, AppearanceConfigInput } from "../../src/models";
 import { serverConfig } from "../../src/utils/ServerConfig";
 import type { AdbClientFactory } from "../../src/utils/android-cmdline-tools/AdbClientFactory";
+import type { AndroidCtrlProxy } from "../../src/features/observe/android/AndroidCtrlProxyClient";
+import type { IOSCtrlProxy } from "../../src/features/observe/ios/IOSCtrlProxyClient";
+
+/**
+ * Inline minimal AndroidCtrlProxy stubs are produced by this helper so each
+ * test can focus on the specific connection states it cares about without
+ * implementing the full surface. Cast through `unknown` to satisfy the
+ * structural interface where the test only reads the configured methods.
+ */
+function stubAndroidCtrlProxy(overrides: Partial<AndroidCtrlProxy>): AndroidCtrlProxy {
+  return overrides as unknown as AndroidCtrlProxy;
+}
+
+function stubIOSCtrlProxy(overrides: Partial<IOSCtrlProxy>): IOSCtrlProxy {
+  return overrides as unknown as IOSCtrlProxy;
+}
 
 describe("DeviceSessionManager", () => {
   const device: BootedDevice = {
@@ -25,8 +38,6 @@ describe("DeviceSessionManager", () => {
   let fakeAdb: FakeAdbExecutor;
   let fakeDeviceUtils: FakeDeviceUtils;
   let originalGetActive: typeof Window.prototype.getActive;
-  let originalGetInstance: typeof AndroidCtrlProxyManager.getInstance;
-  let originalAccessibilityClientGetInstance: typeof AndroidCtrlProxyClient.getInstance;
   let originalAppearanceDefaults: AppearanceConfigInput;
 
   beforeEach(() => {
@@ -50,15 +61,10 @@ describe("DeviceSessionManager", () => {
         layoutSeqSum: 0
       };
     };
-
-    originalGetInstance = AndroidCtrlProxyManager.getInstance;
-    originalAccessibilityClientGetInstance = AndroidCtrlProxyClient.getInstance;
   });
 
   afterEach(() => {
     Window.prototype.getActive = originalGetActive;
-    AndroidCtrlProxyManager.getInstance = originalGetInstance;
-    AndroidCtrlProxyClient.getInstance = originalAccessibilityClientGetInstance;
     serverConfig.setAppearanceDefaults(originalAppearanceDefaults);
   });
 
@@ -66,13 +72,12 @@ describe("DeviceSessionManager", () => {
     const accessibilityManager = new FakeCtrlProxyManager();
     accessibilityManager.setInstalled(false);
     accessibilityManager.setEnabled(false);
-    AndroidCtrlProxyManager.getInstance = () => accessibilityManager as any;
-    AndroidCtrlProxyClient.getInstance = () =>
-      ({
-        isConnected: () => false
-      } as any);
 
-    const manager = DeviceSessionManager.createInstance(new FakeDeviceClientProvider(fakeAdb, fakeDeviceUtils));
+    const provider = new FakeDeviceClientProvider(fakeAdb, fakeDeviceUtils, undefined, {
+      ctrlProxyManager: accessibilityManager,
+      ctrlProxyClient: stubAndroidCtrlProxy({ isConnected: () => false }),
+    });
+    const manager = DeviceSessionManager.createInstance(provider);
     await manager.ensureDeviceReady("android", "device-1", { skipCtrlProxyDownload: true });
 
     expect(accessibilityManager.wasMethodCalled("setup")).toBe(false);
@@ -84,14 +89,15 @@ describe("DeviceSessionManager", () => {
     accessibilityManager.setInstalled(true);
     accessibilityManager.setEnabled(false);
     accessibilityManager.setVersionCompatible(true);
-    AndroidCtrlProxyManager.getInstance = () => accessibilityManager as any;
-    AndroidCtrlProxyClient.getInstance = () =>
-      ({
-        isConnected: () => false,
-        waitForConnection: () => Promise.resolve(true)
-      } as any);
 
-    const manager = DeviceSessionManager.createInstance(new FakeDeviceClientProvider(fakeAdb, fakeDeviceUtils));
+    const provider = new FakeDeviceClientProvider(fakeAdb, fakeDeviceUtils, undefined, {
+      ctrlProxyManager: accessibilityManager,
+      ctrlProxyClient: stubAndroidCtrlProxy({
+        isConnected: () => false,
+        waitForConnection: () => Promise.resolve(true),
+      }),
+    });
+    const manager = DeviceSessionManager.createInstance(provider);
     await manager.ensureDeviceReady("android", "device-1", { skipCtrlProxyDownload: true });
 
     expect(accessibilityManager.wasMethodCalled("enable")).toBe(true);
@@ -104,14 +110,15 @@ describe("DeviceSessionManager", () => {
     accessibilityManager.setInstalled(true);
     accessibilityManager.setEnabled(true);
     accessibilityManager.setVersionCompatible(true);
-    AndroidCtrlProxyManager.getInstance = () => accessibilityManager as any;
-    AndroidCtrlProxyClient.getInstance = () =>
-      ({
-        isConnected: () => false,
-        waitForConnection: () => Promise.resolve(true)
-      } as any);
 
-    const manager = DeviceSessionManager.createInstance(new FakeDeviceClientProvider(fakeAdb, fakeDeviceUtils));
+    const provider = new FakeDeviceClientProvider(fakeAdb, fakeDeviceUtils, undefined, {
+      ctrlProxyManager: accessibilityManager,
+      ctrlProxyClient: stubAndroidCtrlProxy({
+        isConnected: () => false,
+        waitForConnection: () => Promise.resolve(true),
+      }),
+    });
+    const manager = DeviceSessionManager.createInstance(provider);
     await manager.ensureDeviceReady("android", "device-1", { skipCtrlProxyDownload: true });
 
     expect(accessibilityManager.wasMethodCalled("isVersionCompatible")).toBe(true);
@@ -123,14 +130,15 @@ describe("DeviceSessionManager", () => {
     accessibilityManager.setInstalled(true);
     accessibilityManager.setEnabled(true);
     accessibilityManager.setVersionCompatible(false);
-    AndroidCtrlProxyManager.getInstance = () => accessibilityManager as any;
-    AndroidCtrlProxyClient.getInstance = () =>
-      ({
-        isConnected: () => false,
-        waitForConnection: () => Promise.resolve(true)
-      } as any);
 
-    const manager = DeviceSessionManager.createInstance(new FakeDeviceClientProvider(fakeAdb, fakeDeviceUtils));
+    const provider = new FakeDeviceClientProvider(fakeAdb, fakeDeviceUtils, undefined, {
+      ctrlProxyManager: accessibilityManager,
+      ctrlProxyClient: stubAndroidCtrlProxy({
+        isConnected: () => false,
+        waitForConnection: () => Promise.resolve(true),
+      }),
+    });
+    const manager = DeviceSessionManager.createInstance(provider);
     await expect(
       manager.ensureDeviceReady("android", "device-1", { skipCtrlProxyDownload: true })
     ).rejects.toThrow("Accessibility service version mismatch");
@@ -140,15 +148,16 @@ describe("DeviceSessionManager", () => {
     const accessibilityManager = new FakeCtrlProxyManager();
     accessibilityManager.setInstalled(false);
     accessibilityManager.setEnabled(false);
-    AndroidCtrlProxyManager.getInstance = () => accessibilityManager as any;
-    AndroidCtrlProxyClient.getInstance = () =>
-      ({
+
+    const provider = new FakeDeviceClientProvider(fakeAdb, fakeDeviceUtils, undefined, {
+      ctrlProxyManager: accessibilityManager,
+      ctrlProxyClient: stubAndroidCtrlProxy({
         isConnected: () => false,
         waitForConnection: () => Promise.resolve(true),
-        verifyServiceReady: () => Promise.resolve(true)
-      } as any);
-
-    const manager = DeviceSessionManager.createInstance(new FakeDeviceClientProvider(fakeAdb, fakeDeviceUtils));
+        verifyServiceReady: () => Promise.resolve(true),
+      }),
+    });
+    const manager = DeviceSessionManager.createInstance(provider);
     await manager.ensureDeviceReady("android", "device-1");
 
     expect(accessibilityManager.wasMethodCalled("setup")).toBe(true);
@@ -158,14 +167,15 @@ describe("DeviceSessionManager", () => {
     const accessibilityManager = new FakeCtrlProxyManager();
     accessibilityManager.setInstalled(true);
     accessibilityManager.setEnabled(true);
-    AndroidCtrlProxyManager.getInstance = () => accessibilityManager as any;
-    AndroidCtrlProxyClient.getInstance = () =>
-      ({
-        isConnected: () => false,
-        waitForConnection: () => Promise.resolve(true)
-      } as any);
 
-    const manager = DeviceSessionManager.createInstance(new FakeDeviceClientProvider(fakeAdb, fakeDeviceUtils));
+    const provider = new FakeDeviceClientProvider(fakeAdb, fakeDeviceUtils, undefined, {
+      ctrlProxyManager: accessibilityManager,
+      ctrlProxyClient: stubAndroidCtrlProxy({
+        isConnected: () => false,
+        waitForConnection: () => Promise.resolve(true),
+      }),
+    });
+    const manager = DeviceSessionManager.createInstance(provider);
     await manager.ensureDeviceReady("android", "device-1");
 
     // When installed, enabled, and WebSocket connects - service is working, no need for setup
@@ -176,14 +186,15 @@ describe("DeviceSessionManager", () => {
     const accessibilityManager = new FakeCtrlProxyManager();
     accessibilityManager.setInstalled(true);
     accessibilityManager.setEnabled(true);
-    AndroidCtrlProxyManager.getInstance = () => accessibilityManager as any;
-    AndroidCtrlProxyClient.getInstance = () =>
-      ({
-        isConnected: () => false,
-        waitForConnection: () => Promise.resolve(false)  // WebSocket fails - cache is stale
-      } as any);
 
-    const manager = DeviceSessionManager.createInstance(new FakeDeviceClientProvider(fakeAdb, fakeDeviceUtils));
+    const provider = new FakeDeviceClientProvider(fakeAdb, fakeDeviceUtils, undefined, {
+      ctrlProxyManager: accessibilityManager,
+      ctrlProxyClient: stubAndroidCtrlProxy({
+        isConnected: () => false,
+        waitForConnection: () => Promise.resolve(false), // WebSocket fails - cache is stale
+      }),
+    });
+    const manager = DeviceSessionManager.createInstance(provider);
     await manager.ensureDeviceReady("android", "device-1");
 
     // Cache was stale (claimed installed but WebSocket failed), so setup should run
@@ -193,22 +204,23 @@ describe("DeviceSessionManager", () => {
 
   test("should skip accessibility checks when websocket is connected and service is responsive", async () => {
     let managerTouched = false;
-    AndroidCtrlProxyManager.getInstance = () => {
-      managerTouched = true;
-      return {
-        isInstalled: async () => false,
-        isEnabled: async () => false,
-        enable: async () => {},
-        setup: async () => ({ success: true, message: "ok" })
-      } as any;
-    };
-    AndroidCtrlProxyClient.getInstance = () =>
-      ({
-        isConnected: () => true,
-        verifyServiceReady: () => Promise.resolve(true)
-      } as any);
+    const accessibilityManager: any = new Proxy(new FakeCtrlProxyManager(), {
+      get(target, prop, receiver) {
+        if (prop !== "wasMethodCalled" && prop !== "constructor") {
+          managerTouched = true;
+        }
+        return Reflect.get(target, prop, receiver);
+      },
+    });
 
-    const manager = DeviceSessionManager.createInstance(new FakeDeviceClientProvider(fakeAdb, fakeDeviceUtils));
+    const provider = new FakeDeviceClientProvider(fakeAdb, fakeDeviceUtils, undefined, {
+      ctrlProxyManager: accessibilityManager,
+      ctrlProxyClient: stubAndroidCtrlProxy({
+        isConnected: () => true,
+        verifyServiceReady: () => Promise.resolve(true),
+      }),
+    });
+    const manager = DeviceSessionManager.createInstance(provider);
     await manager.ensureDeviceReady("android", "device-1");
 
     expect(managerTouched).toBe(false);
@@ -218,27 +230,62 @@ describe("DeviceSessionManager", () => {
     const accessibilityManager = new FakeCtrlProxyManager();
     accessibilityManager.setInstalled(true);
     accessibilityManager.setEnabled(true);
-    AndroidCtrlProxyManager.getInstance = () => accessibilityManager as any;
-    AndroidCtrlProxyClient.getInstance = () =>
-      ({
-        isConnected: () => true,
-        verifyServiceReady: () => Promise.resolve(false),  // Service not responsive
-        waitForConnection: () => Promise.resolve(true)
-      } as any);
 
-    const manager = DeviceSessionManager.createInstance(new FakeDeviceClientProvider(fakeAdb, fakeDeviceUtils));
+    const provider = new FakeDeviceClientProvider(fakeAdb, fakeDeviceUtils, undefined, {
+      ctrlProxyManager: accessibilityManager,
+      ctrlProxyClient: stubAndroidCtrlProxy({
+        isConnected: () => true,
+        verifyServiceReady: () => Promise.resolve(false), // Service not responsive
+        waitForConnection: () => Promise.resolve(true),
+      }),
+    });
+    const manager = DeviceSessionManager.createInstance(provider);
     await manager.ensureDeviceReady("android", "device-1");
 
     // Should have fallen through and checked status since service wasn't responsive
     expect(accessibilityManager.wasMethodCalled("isInstalled")).toBe(true);
+  });
+
+  test("regression: provider, not static getInstance, supplies CtrlProxy collaborators", async () => {
+    // Wire fakes only via the provider — do NOT monkey-patch any static getInstance.
+    // The DSM must obtain its CtrlProxy manager + client exclusively through the provider.
+    const accessibilityManager = new FakeCtrlProxyManager();
+    accessibilityManager.setInstalled(true);
+    accessibilityManager.setEnabled(true);
+
+    let clientFromProvider = 0;
+    const stubClient = stubAndroidCtrlProxy({
+      isConnected: () => {
+        clientFromProvider++;
+        return true;
+      },
+      verifyServiceReady: () => Promise.resolve(true),
+    });
+
+    const provider = new FakeDeviceClientProvider(fakeAdb, fakeDeviceUtils, undefined, {
+      ctrlProxyManager: accessibilityManager,
+      ctrlProxyClient: stubClient,
+    });
+    const manager = DeviceSessionManager.createInstance(provider);
+    await manager.ensureDeviceReady("android", "device-1");
+
+    expect(clientFromProvider).toBeGreaterThan(0);
+  });
+
+  test("regression: FakeDeviceClientProvider throws directly when ctrlProxy fakes are missing", () => {
+    // If a test wires a fake provider without ctrlProxy fakes, the provider itself
+    // must fail loudly so the omission can't be silently masked by DSM's catch.
+    const provider = new FakeDeviceClientProvider(fakeAdb, fakeDeviceUtils);
+    expect(() => provider.getAndroidCtrlProxyClient(device)).toThrow(/ctrlProxyClient fake not configured/);
+    expect(() => provider.getAndroidCtrlProxyManager(device)).toThrow(/ctrlProxyManager fake not configured/);
+    expect(() => provider.getIOSCtrlProxyManager(device)).toThrow(/iosCtrlProxyManager fake not configured/);
+    expect(() => provider.getIOSCtrlProxyClient(device, 8080)).toThrow(/iosCtrlProxyClient fake not configured/);
   });
 });
 
 describe("DeviceSessionManager iOS openSimulatorApp", () => {
   let fakeAdb: FakeAdbExecutor;
   let fakeDeviceUtils: FakeDeviceUtils;
-  let originalIOSCtrlProxyManagerGetInstance: typeof IOSCtrlProxyManager.getInstance;
-  let originalIOSCtrlProxyClientGetInstance: typeof IOSCtrlProxyClient.getInstance;
   let originalAppearanceDefaults: AppearanceConfigInput;
 
   beforeEach(() => {
@@ -252,29 +299,31 @@ describe("DeviceSessionManager iOS openSimulatorApp", () => {
       syncWithHost: false,
       defaultMode: "light"
     });
-
-    originalIOSCtrlProxyManagerGetInstance = IOSCtrlProxyManager.getInstance;
-    originalIOSCtrlProxyClientGetInstance = IOSCtrlProxyClient.getInstance;
-
-    IOSCtrlProxyManager.getInstance = () =>
-      ({
-        getServicePort: () => 8080,
-        isRunning: async () => false,
-        setup: async () => ({ success: false, error: "skipped in test" }),
-        resetSetupState: () => {},
-      } as any);
-
-    IOSCtrlProxyClient.getInstance = () =>
-      ({
-        isConnected: () => false,
-      } as any);
   });
 
   afterEach(() => {
-    IOSCtrlProxyManager.getInstance = originalIOSCtrlProxyManagerGetInstance;
-    IOSCtrlProxyClient.getInstance = originalIOSCtrlProxyClientGetInstance;
     serverConfig.setAppearanceDefaults(originalAppearanceDefaults);
   });
+
+  function buildIosProvider(
+    fakeAdb: FakeAdbExecutor,
+    fakeDeviceUtils: FakeDeviceUtils,
+    fakeSimctl: FakeSimCtlClient
+  ): FakeDeviceClientProvider {
+    const iosManager = new FakeIOSCtrlProxyManager();
+    iosManager.setSetupShouldFail(true); // skip the setup path in these tests
+    return new FakeDeviceClientProvider(
+      fakeAdb,
+      fakeDeviceUtils,
+      fakeSimctl as any,
+      {
+        iosCtrlProxyManager: iosManager,
+        iosCtrlProxyClient: stubIOSCtrlProxy({
+          isConnected: () => false,
+        }),
+      }
+    );
+  }
 
   test("should call openSimulatorApp once on the first booted iOS device verification", async () => {
     const fakeSimctl = new FakeSimCtlClient();
@@ -286,7 +335,7 @@ describe("DeviceSessionManager iOS openSimulatorApp", () => {
     });
 
     const manager = DeviceSessionManager.createInstance(
-      new FakeDeviceClientProvider(fakeAdb, fakeDeviceUtils, fakeSimctl as any)
+      buildIosProvider(fakeAdb, fakeDeviceUtils, fakeSimctl)
     );
 
     await manager.verifyIosDevice("ios-sim-1");
@@ -304,7 +353,7 @@ describe("DeviceSessionManager iOS openSimulatorApp", () => {
     });
 
     const manager = DeviceSessionManager.createInstance(
-      new FakeDeviceClientProvider(fakeAdb, fakeDeviceUtils, fakeSimctl as any)
+      buildIosProvider(fakeAdb, fakeDeviceUtils, fakeSimctl)
     );
 
     await manager.verifyIosDevice("ios-sim-1");
@@ -324,7 +373,7 @@ describe("DeviceSessionManager iOS openSimulatorApp", () => {
     });
 
     const manager = DeviceSessionManager.createInstance(
-      new FakeDeviceClientProvider(fakeAdb, fakeDeviceUtils, fakeSimctl as any)
+      buildIosProvider(fakeAdb, fakeDeviceUtils, fakeSimctl)
     );
 
     await manager.verifyIosDevice("ios-sim-1");
@@ -342,7 +391,7 @@ describe("DeviceSessionManager iOS openSimulatorApp", () => {
     });
 
     const manager = DeviceSessionManager.createInstance(
-      new FakeDeviceClientProvider(fakeAdb, fakeDeviceUtils, fakeSimctl as any)
+      buildIosProvider(fakeAdb, fakeDeviceUtils, fakeSimctl)
     );
 
     // First call: openSimulatorApp throws — flag must NOT be set
@@ -379,10 +428,6 @@ describe("DeviceSessionManager dual-platform resolution", () => {
   let fakeSimctl: FakeSimctl;
   let fakeAdbFactory: AdbClientFactory;
   let originalGetActive: typeof Window.prototype.getActive;
-  let originalAndroidCtrlProxyMgr: typeof AndroidCtrlProxyManager.getInstance;
-  let originalAndroidCtrlProxyClient: typeof AndroidCtrlProxyClient.getInstance;
-  let originalIOSCtrlProxyMgr: typeof IOSCtrlProxyManager.getInstance;
-  let originalIOSCtrlProxyClient: typeof IOSCtrlProxyClient.getInstance;
   let originalAppearanceDefaults: AppearanceConfigInput;
 
   beforeEach(() => {
@@ -412,44 +457,40 @@ describe("DeviceSessionManager dual-platform resolution", () => {
     Window.prototype.getActive = async function() {
       return { appId: "com.example.app", activityName: "MainActivity", layoutSeqSum: 0 };
     };
-
-    originalAndroidCtrlProxyMgr = AndroidCtrlProxyManager.getInstance;
-    originalAndroidCtrlProxyClient = AndroidCtrlProxyClient.getInstance;
-    originalIOSCtrlProxyMgr = IOSCtrlProxyManager.getInstance;
-    originalIOSCtrlProxyClient = IOSCtrlProxyClient.getInstance;
-
-    const fakeCtrlProxy = new FakeCtrlProxyManager();
-    fakeCtrlProxy.setInstalled(true);
-    fakeCtrlProxy.setEnabled(true);
-    fakeCtrlProxy.setVersionCompatible(true);
-    AndroidCtrlProxyManager.getInstance = () => fakeCtrlProxy as any;
-    AndroidCtrlProxyClient.getInstance = () =>
-      ({ isConnected: () => true, verifyServiceReady: () => Promise.resolve(true) }) as any;
-
-    IOSCtrlProxyManager.getInstance = () =>
-      ({
-        getServicePort: () => 8080,
-        isRunning: async () => false,
-        setup: async () => ({ success: false, error: "skipped" }),
-        resetSetupState: () => {},
-      }) as any;
-    IOSCtrlProxyClient.getInstance = () => ({ isConnected: () => false }) as any;
   });
 
   afterEach(() => {
     Window.prototype.getActive = originalGetActive;
-    AndroidCtrlProxyManager.getInstance = originalAndroidCtrlProxyMgr;
-    AndroidCtrlProxyClient.getInstance = originalAndroidCtrlProxyClient;
-    IOSCtrlProxyManager.getInstance = originalIOSCtrlProxyMgr;
-    IOSCtrlProxyClient.getInstance = originalIOSCtrlProxyClient;
     serverConfig.setAppearanceDefaults(originalAppearanceDefaults);
   });
 
-  test("should throw when both platforms connected and no active device or deviceId", async () => {
-    const manager = DeviceSessionManager.createInstance(
-      new FakeDeviceClientProvider(fakeAdb, fakeDeviceUtils, fakeSimctl as any),
-      fakeAdbFactory
+  function buildProvider(): FakeDeviceClientProvider {
+    const fakeCtrlProxy = new FakeCtrlProxyManager();
+    fakeCtrlProxy.setInstalled(true);
+    fakeCtrlProxy.setEnabled(true);
+    fakeCtrlProxy.setVersionCompatible(true);
+
+    const fakeIosManager = new FakeIOSCtrlProxyManager();
+    fakeIosManager.setSetupShouldFail(true);
+
+    return new FakeDeviceClientProvider(
+      fakeAdb,
+      fakeDeviceUtils,
+      fakeSimctl as any,
+      {
+        ctrlProxyManager: fakeCtrlProxy,
+        ctrlProxyClient: stubAndroidCtrlProxy({
+          isConnected: () => true,
+          verifyServiceReady: () => Promise.resolve(true),
+        }),
+        iosCtrlProxyManager: fakeIosManager,
+        iosCtrlProxyClient: stubIOSCtrlProxy({ isConnected: () => false }),
+      }
     );
+  }
+
+  test("should throw when both platforms connected and no active device or deviceId", async () => {
+    const manager = DeviceSessionManager.createInstance(buildProvider(), fakeAdbFactory);
 
     await expect(
       manager.ensureDeviceReady("either")
@@ -457,10 +498,7 @@ describe("DeviceSessionManager dual-platform resolution", () => {
   });
 
   test("should resolve to ios when setActiveDevice was called with ios", async () => {
-    const manager = DeviceSessionManager.createInstance(
-      new FakeDeviceClientProvider(fakeAdb, fakeDeviceUtils, fakeSimctl as any),
-      fakeAdbFactory
-    );
+    const manager = DeviceSessionManager.createInstance(buildProvider(), fakeAdbFactory);
 
     manager.setCurrentDevice(iosDevice, "ios");
 
@@ -470,10 +508,7 @@ describe("DeviceSessionManager dual-platform resolution", () => {
   });
 
   test("should resolve to active platform without deviceId when setActiveDevice was called", async () => {
-    const manager = DeviceSessionManager.createInstance(
-      new FakeDeviceClientProvider(fakeAdb, fakeDeviceUtils, fakeSimctl as any),
-      fakeAdbFactory
-    );
+    const manager = DeviceSessionManager.createInstance(buildProvider(), fakeAdbFactory);
 
     manager.setCurrentDevice(iosDevice, "ios");
 
@@ -483,10 +518,7 @@ describe("DeviceSessionManager dual-platform resolution", () => {
   });
 
   test("should resolve ios device by providedDeviceId when no active device set", async () => {
-    const manager = DeviceSessionManager.createInstance(
-      new FakeDeviceClientProvider(fakeAdb, fakeDeviceUtils, fakeSimctl as any),
-      fakeAdbFactory
-    );
+    const manager = DeviceSessionManager.createInstance(buildProvider(), fakeAdbFactory);
 
     const result = await manager.ensureDeviceReady("either", "ios-sim-1");
     expect(result.platform).toBe("ios");
@@ -494,10 +526,7 @@ describe("DeviceSessionManager dual-platform resolution", () => {
   });
 
   test("should resolve android device by providedDeviceId when no active device set", async () => {
-    const manager = DeviceSessionManager.createInstance(
-      new FakeDeviceClientProvider(fakeAdb, fakeDeviceUtils, fakeSimctl as any),
-      fakeAdbFactory
-    );
+    const manager = DeviceSessionManager.createInstance(buildProvider(), fakeAdbFactory);
 
     const result = await manager.ensureDeviceReady("either", "emulator-5554");
     expect(result.platform).toBe("android");
@@ -508,10 +537,7 @@ describe("DeviceSessionManager dual-platform resolution", () => {
     // This test ensures that when platform="either" and currentDevice is Android,
     // verifyDevice is called with "android" (resolvedPlatform) instead of "either" (raw platform).
     // Bug fix: previously "either" was passed to verifyDevice which treated it as iOS.
-    const manager = DeviceSessionManager.createInstance(
-      new FakeDeviceClientProvider(fakeAdb, fakeDeviceUtils, fakeSimctl as any),
-      fakeAdbFactory
-    );
+    const manager = DeviceSessionManager.createInstance(buildProvider(), fakeAdbFactory);
 
     // Set current device to Android (simulating a prior setActiveDevice call)
     manager.setCurrentDevice(androidDevice, "android");
@@ -526,10 +552,7 @@ describe("DeviceSessionManager dual-platform resolution", () => {
   });
 
   test("should return android device when platform is explicitly 'android' even with iOS active", async () => {
-    const manager = DeviceSessionManager.createInstance(
-      new FakeDeviceClientProvider(fakeAdb, fakeDeviceUtils, fakeSimctl as any),
-      fakeAdbFactory
-    );
+    const manager = DeviceSessionManager.createInstance(buildProvider(), fakeAdbFactory);
 
     // Set current device to iOS (simulating a prior setActiveDevice call to iOS)
     manager.setCurrentDevice(iosDevice, "ios");
@@ -548,10 +571,7 @@ describe("DeviceSessionManager dual-platform resolution", () => {
     // Configure fakeDeviceUtils so findOrStartDevice can find Android devices
     fakeDeviceUtils.setBootedDevices("android", [androidDevice]);
 
-    const manager = DeviceSessionManager.createInstance(
-      new FakeDeviceClientProvider(fakeAdb, fakeDeviceUtils, fakeSimctl as any),
-      fakeAdbFactory
-    );
+    const manager = DeviceSessionManager.createInstance(buildProvider(), fakeAdbFactory);
 
     // Set current device to iOS first
     manager.setCurrentDevice(iosDevice, "ios");


### PR DESCRIPTION
## Summary
- Extend `DeviceClientProvider` with four accessors that vend the CtrlProxy manager/client for each platform; the default provider delegates to existing static `getInstance` singletons (preserving per-device memoization).
- `DeviceSessionManager` now consumes via `this.provider.getXxx(device)` instead of reaching for `XxxClass.getInstance(device)` directly — closing the DI gap that previously forced tests to monkey-patch static methods.
- `FakeDeviceClientProvider` takes the CtrlProxy fakes via constructor options and fails loudly when a needed fake isn't wired, preventing silent fall-through to real singletons in tests.
- Tests in `test/utils/DeviceSessionManager.test.ts` no longer mutate static `getInstance` properties; they pass fakes through the provider.
- Adds `resetSetupState()` to `CtrlProxyManager` and `CtrlProxyIosManager` interfaces (already implemented by the concrete classes) so it can be called via the abstract type. `FakeIOSCtrlProxyManager` gains the matching stub.

## Test plan
- [x] `bun test test/utils/DeviceSessionManager.test.ts` — 23/23 pass
- [x] `bun test` (full suite) — 4055 pass, 2 skip, 0 fail
- [x] `turbo run lint build` — clean