### PR TITLE
refactor(dsm): inject Window via DeviceClientProvider

### DIFF
--- a/src/utils/DeviceSessionManager.ts
+++ b/src/utils/DeviceSessionManager.ts
@@ -2,7 +2,8 @@ import { ActionableError, BootedDevice, Platform, SomePlatform } from "../models
 import { MultiPlatformDeviceManager } from "./deviceUtils";
 import { AdbClientFactory, defaultAdbClientFactory } from "./android-cmdline-tools/AdbClientFactory";
 import { SimCtlClient } from "./ios-cmdline-tools/SimCtlClient";
-import { Window } from "../features/observe/Window";
+import { Window as WindowImpl } from "../features/observe/Window";
+import type { Window } from "../features/observe/interfaces/Window";
 import { logger } from "./logger";
 import { AndroidCtrlProxyManager, CtrlProxyManager } from "./CtrlProxyManager";
 import { IOSCtrlProxyManager, CtrlProxyIosManager } from "./IOSCtrlProxyManager";
@@ -31,6 +32,7 @@ export interface DeviceClientProvider {
   getAndroidCtrlProxyClient(device: BootedDevice): AndroidCtrlProxy;
   getIOSCtrlProxyManager(device: BootedDevice): CtrlProxyIosManager;
   getIOSCtrlProxyClient(device: BootedDevice, port: number): IOSCtrlProxy;
+  getWindow(device: BootedDevice): Window;
 }
 
 /**
@@ -42,6 +44,9 @@ class DefaultDeviceClientProvider implements DeviceClientProvider {
   private _simctl: SimCtlClient | undefined;
   private _androidEmulator: AndroidEmulatorClient | undefined;
   private _deviceUtils: PlatformDeviceManager | undefined;
+  // Per-device Window cache — preserves Window's internal active-window cache
+  // across calls within a session for the same device.
+  private readonly _windows: Map<string, Window> = new Map();
 
   constructor(adbFactory: AdbClientFactory = defaultAdbClientFactory) {
     this._adbFactory = adbFactory;
@@ -93,6 +98,16 @@ class DefaultDeviceClientProvider implements DeviceClientProvider {
 
   getIOSCtrlProxyClient(device: BootedDevice, port: number): IOSCtrlProxy {
     return IOSCtrlProxyClient.getInstance(device, port);
+  }
+
+  getWindow(device: BootedDevice): Window {
+    const key = device.deviceId;
+    let window = this._windows.get(key);
+    if (!window) {
+      window = new WindowImpl(device, this._adbFactory);
+      this._windows.set(key, window);
+    }
+    return window;
   }
 }
 
@@ -178,7 +193,6 @@ export class DeviceSessionManager implements DeviceSessionManager {
   private readonly provider: DeviceClientProvider;
   private readonly adbFactory: AdbClientFactory;
   private _adb: AdbExecutor | undefined;
-  private window: Window | undefined;
   private simulatorAppOpened = false;
 
   // Track devices that have push update listeners registered
@@ -247,9 +261,6 @@ export class DeviceSessionManager implements DeviceSessionManager {
       // Update AdbClient with new device ID - need a fresh client for the new device
       this._adb = this.adbFactory.create(device);
     }
-
-    // Reset window when device changes
-    this.window = undefined;
   }
 
   /**
@@ -448,13 +459,11 @@ export class DeviceSessionManager implements DeviceSessionManager {
     try {
       logger.info(`[DeviceSessionManager] Verifying Android device ${deviceId} readiness`);
 
-      if (!this.window || this.window.getDeviceId() !== deviceId) {
-        this.window = new Window(device);
-      }
+      const window = this.provider.getWindow(device);
 
-      let activeWindow = await this.window.getActive();
+      let activeWindow = await window.getActive();
       if (!activeWindow || !activeWindow.appId || !activeWindow.activityName) {
-        activeWindow = await this.window.getActive(true);
+        activeWindow = await window.getActive(true);
         if (!activeWindow || !activeWindow.appId || !activeWindow.activityName) {
           logger.warn(`[DeviceSessionManager] Android device ${deviceId} is not fully ready`);
           if (activeWindow) {

--- a/src/utils/DeviceSessionManager.ts
+++ b/src/utils/DeviceSessionManager.ts
@@ -44,8 +44,8 @@ class DefaultDeviceClientProvider implements DeviceClientProvider {
   private _simctl: SimCtlClient | undefined;
   private _androidEmulator: AndroidEmulatorClient | undefined;
   private _deviceUtils: PlatformDeviceManager | undefined;
-  // Per-device Window cache — preserves Window's internal active-window cache
-  // across calls within a session for the same device.
+  // Keyed by device.deviceId so Window's internal active-window cache survives
+  // across calls instead of being thrown away on every resolve.
   private readonly _windows: Map<string, Window> = new Map();
 
   constructor(adbFactory: AdbClientFactory = defaultAdbClientFactory) {

--- a/test/fakes/FakeDeviceClientProvider.ts
+++ b/test/fakes/FakeDeviceClientProvider.ts
@@ -7,6 +7,7 @@ import { CtrlProxyManager } from "../../src/utils/CtrlProxyManager";
 import { CtrlProxyIosManager } from "../../src/utils/IOSCtrlProxyManager";
 import type { AndroidCtrlProxy } from "../../src/features/observe/android/AndroidCtrlProxyClient";
 import type { IOSCtrlProxy } from "../../src/features/observe/ios/IOSCtrlProxyClient";
+import type { Window } from "../../src/features/observe/interfaces/Window";
 import { BootedDevice } from "../../src/models";
 
 export interface FakeDeviceClientProviderOptions {
@@ -14,6 +15,7 @@ export interface FakeDeviceClientProviderOptions {
   ctrlProxyClient?: AndroidCtrlProxy;
   iosCtrlProxyManager?: CtrlProxyIosManager;
   iosCtrlProxyClient?: IOSCtrlProxy;
+  window?: Window;
 }
 
 /**
@@ -69,5 +71,9 @@ export class FakeDeviceClientProvider implements DeviceClientProvider {
 
   getIOSCtrlProxyClient(_device: BootedDevice, _port: number): IOSCtrlProxy {
     return this.require(this.options.iosCtrlProxyClient, "iosCtrlProxyClient");
+  }
+
+  getWindow(_device: BootedDevice): Window {
+    return this.require(this.options.window, "window");
   }
 }

--- a/test/utils/DeviceSessionManager.test.ts
+++ b/test/utils/DeviceSessionManager.test.ts
@@ -28,7 +28,7 @@ function makeReadyWindow(): FakeWindow {
     appId: "com.example.app",
     activityName: "MainActivity",
     layoutSeqSum: 0,
-  } as any);
+  });
   return w;
 }
 

--- a/test/utils/DeviceSessionManager.test.ts
+++ b/test/utils/DeviceSessionManager.test.ts
@@ -8,7 +8,7 @@ import { FakeIOSCtrlProxyManager } from "../fakes/FakeIOSCtrlProxyManager";
 import { FakeIOSCtrlProxy } from "../fakes/FakeIOSCtrlProxy";
 import { FakeSimCtlClient } from "../fakes/FakeSimCtlClient";
 import { FakeSimctl } from "../fakes/FakeSimctl";
-import { Window } from "../../src/features/observe/Window";
+import { FakeWindow } from "../fakes/FakeWindow";
 import { BootedDevice, AppearanceConfigInput } from "../../src/models";
 import { serverConfig } from "../../src/utils/ServerConfig";
 import type { AdbClientFactory } from "../../src/utils/android-cmdline-tools/AdbClientFactory";
@@ -22,6 +22,16 @@ function stubAndroidCtrlProxy(overrides: Partial<AndroidCtrlProxy>): AndroidCtrl
   return overrides as unknown as AndroidCtrlProxy;
 }
 
+function makeReadyWindow(): FakeWindow {
+  const w = new FakeWindow();
+  w.configureActiveWindow({
+    appId: "com.example.app",
+    activityName: "MainActivity",
+    layoutSeqSum: 0,
+  } as any);
+  return w;
+}
+
 describe("DeviceSessionManager", () => {
   const device: BootedDevice = {
     name: "device-1",
@@ -31,13 +41,14 @@ describe("DeviceSessionManager", () => {
 
   let fakeAdb: FakeAdbExecutor;
   let fakeDeviceUtils: FakeDeviceUtils;
-  let originalGetActive: typeof Window.prototype.getActive;
+  let fakeWindow: FakeWindow;
   let originalAppearanceDefaults: AppearanceConfigInput;
 
   beforeEach(() => {
     fakeAdb = new FakeAdbExecutor();
     fakeDeviceUtils = new FakeDeviceUtils();
     fakeAdb.setDevices([device]);
+    fakeWindow = makeReadyWindow();
 
     originalAppearanceDefaults = serverConfig.getAppearanceDefaults();
     serverConfig.setAppearanceDefaults({
@@ -46,19 +57,9 @@ describe("DeviceSessionManager", () => {
       syncWithHost: false,
       defaultMode: "light"
     });
-
-    originalGetActive = Window.prototype.getActive;
-    Window.prototype.getActive = async function() {
-      return {
-        appId: "com.example.app",
-        activityName: "MainActivity",
-        layoutSeqSum: 0
-      };
-    };
   });
 
   afterEach(() => {
-    Window.prototype.getActive = originalGetActive;
     serverConfig.setAppearanceDefaults(originalAppearanceDefaults);
   });
 
@@ -68,6 +69,7 @@ describe("DeviceSessionManager", () => {
     accessibilityManager.setEnabled(false);
 
     const provider = new FakeDeviceClientProvider(fakeAdb, fakeDeviceUtils, undefined, {
+      window: fakeWindow,
       ctrlProxyManager: accessibilityManager,
       ctrlProxyClient: stubAndroidCtrlProxy({ isConnected: () => false }),
     });
@@ -85,6 +87,7 @@ describe("DeviceSessionManager", () => {
     accessibilityManager.setVersionCompatible(true);
 
     const provider = new FakeDeviceClientProvider(fakeAdb, fakeDeviceUtils, undefined, {
+      window: fakeWindow,
       ctrlProxyManager: accessibilityManager,
       ctrlProxyClient: stubAndroidCtrlProxy({
         isConnected: () => false,
@@ -106,6 +109,7 @@ describe("DeviceSessionManager", () => {
     accessibilityManager.setVersionCompatible(true);
 
     const provider = new FakeDeviceClientProvider(fakeAdb, fakeDeviceUtils, undefined, {
+      window: fakeWindow,
       ctrlProxyManager: accessibilityManager,
       ctrlProxyClient: stubAndroidCtrlProxy({
         isConnected: () => false,
@@ -126,6 +130,7 @@ describe("DeviceSessionManager", () => {
     accessibilityManager.setVersionCompatible(false);
 
     const provider = new FakeDeviceClientProvider(fakeAdb, fakeDeviceUtils, undefined, {
+      window: fakeWindow,
       ctrlProxyManager: accessibilityManager,
       ctrlProxyClient: stubAndroidCtrlProxy({
         isConnected: () => false,
@@ -144,6 +149,7 @@ describe("DeviceSessionManager", () => {
     accessibilityManager.setEnabled(false);
 
     const provider = new FakeDeviceClientProvider(fakeAdb, fakeDeviceUtils, undefined, {
+      window: fakeWindow,
       ctrlProxyManager: accessibilityManager,
       ctrlProxyClient: stubAndroidCtrlProxy({
         isConnected: () => false,
@@ -163,6 +169,7 @@ describe("DeviceSessionManager", () => {
     accessibilityManager.setEnabled(true);
 
     const provider = new FakeDeviceClientProvider(fakeAdb, fakeDeviceUtils, undefined, {
+      window: fakeWindow,
       ctrlProxyManager: accessibilityManager,
       ctrlProxyClient: stubAndroidCtrlProxy({
         isConnected: () => false,
@@ -182,6 +189,7 @@ describe("DeviceSessionManager", () => {
     accessibilityManager.setEnabled(true);
 
     const provider = new FakeDeviceClientProvider(fakeAdb, fakeDeviceUtils, undefined, {
+      window: fakeWindow,
       ctrlProxyManager: accessibilityManager,
       ctrlProxyClient: stubAndroidCtrlProxy({
         isConnected: () => false,
@@ -200,6 +208,7 @@ describe("DeviceSessionManager", () => {
     const accessibilityManager = new FakeCtrlProxyManager();
 
     const provider = new FakeDeviceClientProvider(fakeAdb, fakeDeviceUtils, undefined, {
+      window: fakeWindow,
       ctrlProxyManager: accessibilityManager,
       ctrlProxyClient: stubAndroidCtrlProxy({
         isConnected: () => true,
@@ -218,6 +227,7 @@ describe("DeviceSessionManager", () => {
     accessibilityManager.setEnabled(true);
 
     const provider = new FakeDeviceClientProvider(fakeAdb, fakeDeviceUtils, undefined, {
+      window: fakeWindow,
       ctrlProxyManager: accessibilityManager,
       ctrlProxyClient: stubAndroidCtrlProxy({
         isConnected: () => true,
@@ -247,6 +257,7 @@ describe("DeviceSessionManager", () => {
     });
 
     const provider = new FakeDeviceClientProvider(fakeAdb, fakeDeviceUtils, undefined, {
+      window: fakeWindow,
       ctrlProxyManager: accessibilityManager,
       ctrlProxyClient: stubClient,
     });
@@ -256,12 +267,33 @@ describe("DeviceSessionManager", () => {
     expect(clientFromProvider).toBeGreaterThan(0);
   });
 
-  test("FakeDeviceClientProvider throws when CtrlProxy fakes are not configured", () => {
+  test("FakeDeviceClientProvider throws when collaborator fakes are not configured", () => {
     const provider = new FakeDeviceClientProvider(fakeAdb, fakeDeviceUtils);
     expect(() => provider.getAndroidCtrlProxyClient(device)).toThrow(/ctrlProxyClient fake not configured/);
     expect(() => provider.getAndroidCtrlProxyManager(device)).toThrow(/ctrlProxyManager fake not configured/);
     expect(() => provider.getIOSCtrlProxyManager(device)).toThrow(/iosCtrlProxyManager fake not configured/);
     expect(() => provider.getIOSCtrlProxyClient(device, 8080)).toThrow(/iosCtrlProxyClient fake not configured/);
+    expect(() => provider.getWindow(device)).toThrow(/window fake not configured/);
+  });
+
+  test("Window comes from the provider, not from `new Window(device)`", async () => {
+    const accessibilityManager = new FakeCtrlProxyManager();
+    accessibilityManager.setInstalled(true);
+    accessibilityManager.setEnabled(true);
+
+    const provider = new FakeDeviceClientProvider(fakeAdb, fakeDeviceUtils, undefined, {
+      window: fakeWindow,
+      ctrlProxyManager: accessibilityManager,
+      ctrlProxyClient: stubAndroidCtrlProxy({
+        isConnected: () => false,
+        waitForConnection: () => Promise.resolve(true),
+      }),
+    });
+    const manager = DeviceSessionManager.createInstance(provider);
+    await manager.ensureDeviceReady("android", "device-1");
+
+    // Window.getActive must have been called exclusively on the injected fake.
+    expect(fakeWindow.wasMethodCalled("getActive")).toBe(true);
   });
 });
 
@@ -409,7 +441,7 @@ describe("DeviceSessionManager dual-platform resolution", () => {
   let fakeDeviceUtils: FakeDeviceUtils;
   let fakeSimctl: FakeSimctl;
   let fakeAdbFactory: AdbClientFactory;
-  let originalGetActive: typeof Window.prototype.getActive;
+  let fakeWindow: FakeWindow;
   let originalAppearanceDefaults: AppearanceConfigInput;
 
   beforeEach(() => {
@@ -417,6 +449,7 @@ describe("DeviceSessionManager dual-platform resolution", () => {
     fakeDeviceUtils = new FakeDeviceUtils();
     fakeSimctl = new FakeSimctl();
     fakeAdbFactory = { create: () => fakeAdb };
+    fakeWindow = makeReadyWindow();
 
     fakeAdb.setDevices([androidDevice]);
     fakeSimctl.setBootedSimulators([iosDevice]);
@@ -434,15 +467,9 @@ describe("DeviceSessionManager dual-platform resolution", () => {
       syncWithHost: false,
       defaultMode: "light",
     });
-
-    originalGetActive = Window.prototype.getActive;
-    Window.prototype.getActive = async function() {
-      return { appId: "com.example.app", activityName: "MainActivity", layoutSeqSum: 0 };
-    };
   });
 
   afterEach(() => {
-    Window.prototype.getActive = originalGetActive;
     serverConfig.setAppearanceDefaults(originalAppearanceDefaults);
   });
 
@@ -462,6 +489,7 @@ describe("DeviceSessionManager dual-platform resolution", () => {
       fakeDeviceUtils,
       fakeSimctl as any,
       {
+        window: fakeWindow,
         ctrlProxyManager: fakeCtrlProxy,
         ctrlProxyClient: stubAndroidCtrlProxy({
           isConnected: () => true,


### PR DESCRIPTION
## Summary
- Add `getWindow(device): Window` to `DeviceClientProvider`. The default provider memoizes Windows by `device.deviceId` so the existing internal active-window cache survives across calls.
- `DeviceSessionManager` no longer holds a `this.window` field, no longer does `new Window(device)`, and no longer tracks the cached-Window's deviceId manually. Per-device isolation is now handled by the provider's memoization key.
- Drops the `this.window = undefined` reset in `setCurrentDevice` — unnecessary now that the cache lives on the provider.
- Tests previously monkey-patched `Window.prototype.getActive` globally; they now wire a `FakeWindow` through the provider. Adds a regression test asserting the Window comes from the provider, and extends the throw-on-missing-fake test to cover `getWindow`.

Follow-up scope (intentionally out of this PR): four other call sites still do `new Window(device, this.adbFactory)` directly — TakeScreenshot, ObserveScreen, BaseVisualChange, PostNotification. Routing them through the provider would unlock the cache-sharing across features but is outside the DSM cleanup series.

## Test plan
- [x] `bun test test/utils/DeviceSessionManager.test.ts` — 24/24 pass
- [x] `bun test` (full suite) — 4056 pass, 2 skip, 0 fail
- [x] `turbo run lint build` — clean