### PR TITLE
refactor(dsm): abstract RealObserveScreen.clearCache behind ObserveScreenCache

### DIFF
--- a/src/features/observe/ObserveScreen.ts
+++ b/src/features/observe/ObserveScreen.ts
@@ -101,6 +101,16 @@ export class RealObserveScreen implements ObserveScreen {
     }
   }
 
+  /**
+   * Adapter that exposes the static `clearCache` as an `ObserveScreenCache`
+   * for dependency injection.
+   */
+  static readonly defaultObserveScreenCache: import("./interfaces/ObserveScreenCache").ObserveScreenCache = {
+    clearForDevice(deviceId: string): void {
+      RealObserveScreen.clearCache(deviceId);
+    },
+  };
+
   // ---------- Constructor ----------
 
   constructor(

--- a/src/features/observe/interfaces/ObserveScreenCache.ts
+++ b/src/features/observe/interfaces/ObserveScreenCache.ts
@@ -1,0 +1,12 @@
+/**
+ * Abstraction over the process-wide ObserveScreen cache (hierarchy +
+ * screenshot stores + screenshot-job tracker). Lets non-observe code clear
+ * cached state for a device without taking a direct dependency on the
+ * concrete `RealObserveScreen` static.
+ */
+export interface ObserveScreenCache {
+  /**
+   * Clear cached observation state for a single device.
+   */
+  clearForDevice(deviceId: string): void;
+}

--- a/src/features/observe/interfaces/index.ts
+++ b/src/features/observe/interfaces/index.ts
@@ -15,3 +15,4 @@ export type { ScreenshotService } from "./ScreenshotService";
 export type { DeviceMetadataSource, DeviceMetadata } from "./DeviceMetadataSource";
 export type { GlobalActionSource, GlobalActionResult } from "./GlobalActionSource";
 export type { CtrlProxyClient } from "./CtrlProxyClient";
+export type { ObserveScreenCache } from "./ObserveScreenCache";

--- a/src/utils/DeviceSessionManager.ts
+++ b/src/utils/DeviceSessionManager.ts
@@ -15,6 +15,7 @@ import type { AndroidCtrlProxy } from "../features/observe/android/AndroidCtrlPr
 import { IOSCtrlProxyClient } from "../features/observe/ios";
 import type { IOSCtrlProxy } from "../features/observe/ios/IOSCtrlProxyClient";
 import { RealObserveScreen } from "../features/observe/ObserveScreen";
+import type { ObserveScreenCache } from "../features/observe/interfaces/ObserveScreenCache";
 import { createPerformanceTracker, createGlobalPerformanceTracker } from "./PerformanceTracker";
 import { storeSetupTiming } from "../server/ToolExecutionContext";
 import { applyAppearanceOnConnect } from "./appearance/applyAppearanceOnConnect";
@@ -33,6 +34,7 @@ export interface DeviceClientProvider {
   getIOSCtrlProxyManager(device: BootedDevice): CtrlProxyIosManager;
   getIOSCtrlProxyClient(device: BootedDevice, port: number): IOSCtrlProxy;
   getWindow(device: BootedDevice): Window;
+  getObserveScreenCache(): ObserveScreenCache;
 }
 
 /**
@@ -109,7 +111,17 @@ class DefaultDeviceClientProvider implements DeviceClientProvider {
     }
     return window;
   }
+
+  getObserveScreenCache(): ObserveScreenCache {
+    return realObserveScreenCache;
+  }
 }
+
+const realObserveScreenCache: ObserveScreenCache = {
+  clearForDevice(deviceId: string): void {
+    RealObserveScreen.clearCache(deviceId);
+  },
+};
 
 /**
  * Interface for device session management
@@ -918,9 +930,10 @@ export class DeviceSessionManager implements DeviceSessionManager {
       const manager = this.provider.getIOSCtrlProxyManager(device);
       const xcTestClient = this.provider.getIOSCtrlProxyClient(device, manager.getServicePort());
 
+      const observeCache = this.provider.getObserveScreenCache();
       xcTestClient.onPushUpdate(() => {
         logger.info(`[DeviceSessionManager] Received iOS UI change notification for ${deviceId}, clearing ObserveScreen cache`);
-        RealObserveScreen.clearCache(deviceId);
+        observeCache.clearForDevice(deviceId);
       });
 
       DeviceSessionManager.pushUpdateListenersRegistered.add(deviceId);

--- a/src/utils/DeviceSessionManager.ts
+++ b/src/utils/DeviceSessionManager.ts
@@ -113,15 +113,9 @@ class DefaultDeviceClientProvider implements DeviceClientProvider {
   }
 
   getObserveScreenCache(): ObserveScreenCache {
-    return realObserveScreenCache;
+    return RealObserveScreen.defaultObserveScreenCache;
   }
 }
-
-const realObserveScreenCache: ObserveScreenCache = {
-  clearForDevice(deviceId: string): void {
-    RealObserveScreen.clearCache(deviceId);
-  },
-};
 
 /**
  * Interface for device session management

--- a/test/fakes/FakeDeviceClientProvider.ts
+++ b/test/fakes/FakeDeviceClientProvider.ts
@@ -8,6 +8,8 @@ import { CtrlProxyIosManager } from "../../src/utils/IOSCtrlProxyManager";
 import type { AndroidCtrlProxy } from "../../src/features/observe/android/AndroidCtrlProxyClient";
 import type { IOSCtrlProxy } from "../../src/features/observe/ios/IOSCtrlProxyClient";
 import type { Window } from "../../src/features/observe/interfaces/Window";
+import type { ObserveScreenCache } from "../../src/features/observe/interfaces/ObserveScreenCache";
+import { FakeObserveScreenCache } from "./FakeObserveScreenCache";
 import { BootedDevice } from "../../src/models";
 
 export interface FakeDeviceClientProviderOptions {
@@ -16,6 +18,7 @@ export interface FakeDeviceClientProviderOptions {
   iosCtrlProxyManager?: CtrlProxyIosManager;
   iosCtrlProxyClient?: IOSCtrlProxy;
   window?: Window;
+  observeScreenCache?: ObserveScreenCache;
 }
 
 /**
@@ -75,5 +78,14 @@ export class FakeDeviceClientProvider implements DeviceClientProvider {
 
   getWindow(_device: BootedDevice): Window {
     return this.require(this.options.window, "window");
+  }
+
+  getObserveScreenCache(): ObserveScreenCache {
+    // Cache is a sink — default to a no-op fake so tests that don't care about
+    // invalidation don't have to wire one; tests that DO care pass their own.
+    if (!this.options.observeScreenCache) {
+      this.options.observeScreenCache = new FakeObserveScreenCache();
+    }
+    return this.options.observeScreenCache;
   }
 }

--- a/test/fakes/FakeDeviceClientProvider.ts
+++ b/test/fakes/FakeDeviceClientProvider.ts
@@ -27,6 +27,8 @@ export interface FakeDeviceClientProviderOptions {
  * to a real singleton when a fake is forgotten.
  */
 export class FakeDeviceClientProvider implements DeviceClientProvider {
+  private vendedObserveScreenCache: ObserveScreenCache | undefined;
+
   constructor(
     private readonly fakeAdb: AdbExecutor,
     private readonly fakeDeviceUtils: PlatformDeviceManager,
@@ -81,11 +83,15 @@ export class FakeDeviceClientProvider implements DeviceClientProvider {
   }
 
   getObserveScreenCache(): ObserveScreenCache {
-    // Cache is a sink — default to a no-op fake so tests that don't care about
-    // invalidation don't have to wire one; tests that DO care pass their own.
-    if (!this.options.observeScreenCache) {
-      this.options.observeScreenCache = new FakeObserveScreenCache();
+    // Cache is a sink — default to a recording fake so tests that don't care
+    // about invalidation don't have to wire one; tests that DO care pass their
+    // own to assert which deviceIds were cleared.
+    if (this.options.observeScreenCache) {
+      return this.options.observeScreenCache;
     }
-    return this.options.observeScreenCache;
+    if (!this.vendedObserveScreenCache) {
+      this.vendedObserveScreenCache = new FakeObserveScreenCache();
+    }
+    return this.vendedObserveScreenCache;
   }
 }

--- a/test/fakes/FakeObserveScreenCache.ts
+++ b/test/fakes/FakeObserveScreenCache.ts
@@ -1,0 +1,26 @@
+import type { ObserveScreenCache } from "../../src/features/observe/interfaces/ObserveScreenCache";
+
+/**
+ * Fake ObserveScreenCache that records every clearForDevice call.
+ * Lets tests assert cache invalidation without touching the real
+ * process-wide stores backing RealObserveScreen.clearCache.
+ */
+export class FakeObserveScreenCache implements ObserveScreenCache {
+  private readonly clearedDevices: string[] = [];
+
+  clearForDevice(deviceId: string): void {
+    this.clearedDevices.push(deviceId);
+  }
+
+  getClearedDevices(): string[] {
+    return [...this.clearedDevices];
+  }
+
+  wasClearedFor(deviceId: string): boolean {
+    return this.clearedDevices.includes(deviceId);
+  }
+
+  reset(): void {
+    this.clearedDevices.length = 0;
+  }
+}

--- a/test/utils/DeviceSessionManager.test.ts
+++ b/test/utils/DeviceSessionManager.test.ts
@@ -364,10 +364,10 @@ describe("DeviceSessionManager iOS push-update cache invalidation", () => {
     await manager.verifyIosDevice("ios-push-1");
 
     // Listener registered; cache untouched until update fires.
-    expect(captured).not.toBeNull();
+    if (!captured) {throw new Error("onPushUpdate listener never registered");}
     expect(observeCache.wasClearedFor("ios-push-1")).toBe(false);
 
-    (captured as unknown as () => void)();
+    captured();
 
     expect(observeCache.wasClearedFor("ios-push-1")).toBe(true);
     expect(observeCache.getClearedDevices()).toEqual(["ios-push-1"]);

--- a/test/utils/DeviceSessionManager.test.ts
+++ b/test/utils/DeviceSessionManager.test.ts
@@ -6,6 +6,7 @@ import { FakeDeviceClientProvider } from "../fakes/FakeDeviceClientProvider";
 import { FakeCtrlProxyManager } from "../fakes/FakeCtrlProxyManager";
 import { FakeIOSCtrlProxyManager } from "../fakes/FakeIOSCtrlProxyManager";
 import { FakeIOSCtrlProxy } from "../fakes/FakeIOSCtrlProxy";
+import { FakeObserveScreenCache } from "../fakes/FakeObserveScreenCache";
 import { FakeSimCtlClient } from "../fakes/FakeSimCtlClient";
 import { FakeSimctl } from "../fakes/FakeSimctl";
 import { FakeWindow } from "../fakes/FakeWindow";
@@ -13,6 +14,7 @@ import { BootedDevice, AppearanceConfigInput } from "../../src/models";
 import { serverConfig } from "../../src/utils/ServerConfig";
 import type { AdbClientFactory } from "../../src/utils/android-cmdline-tools/AdbClientFactory";
 import type { AndroidCtrlProxy } from "../../src/features/observe/android/AndroidCtrlProxyClient";
+import type { IOSCtrlProxy } from "../../src/features/observe/ios/IOSCtrlProxyClient";
 
 // Inline minimal AndroidCtrlProxy where each test sets only the methods it
 // exercises — the Android fake lacks per-call `waitForConnection` /
@@ -20,6 +22,10 @@ import type { AndroidCtrlProxy } from "../../src/features/observe/android/Androi
 // "connected but not responsive" branches independently.
 function stubAndroidCtrlProxy(overrides: Partial<AndroidCtrlProxy>): AndroidCtrlProxy {
   return overrides as unknown as AndroidCtrlProxy;
+}
+
+function stubIOSCtrlProxy(overrides: Partial<IOSCtrlProxy>): IOSCtrlProxy {
+  return overrides as unknown as IOSCtrlProxy;
 }
 
 function makeReadyWindow(): FakeWindow {
@@ -294,6 +300,77 @@ describe("DeviceSessionManager", () => {
 
     // Window.getActive must have been called exclusively on the injected fake.
     expect(fakeWindow.wasMethodCalled("getActive")).toBe(true);
+  });
+});
+
+describe("DeviceSessionManager iOS push-update cache invalidation", () => {
+  let fakeAdb: FakeAdbExecutor;
+  let fakeDeviceUtils: FakeDeviceUtils;
+  let originalAppearanceDefaults: AppearanceConfigInput;
+
+  beforeEach(() => {
+    fakeAdb = new FakeAdbExecutor();
+    fakeDeviceUtils = new FakeDeviceUtils();
+    originalAppearanceDefaults = serverConfig.getAppearanceDefaults();
+    serverConfig.setAppearanceDefaults({
+      ...originalAppearanceDefaults,
+      applyOnConnect: false,
+      syncWithHost: false,
+      defaultMode: "light",
+    });
+  });
+
+  afterEach(() => {
+    serverConfig.setAppearanceDefaults(originalAppearanceDefaults);
+  });
+
+  test("push update fires clearForDevice on the injected ObserveScreenCache", async () => {
+    const fakeSimctl = new FakeSimCtlClient();
+    fakeSimctl.setDeviceInfo("ios-push-1", {
+      udid: "ios-push-1",
+      name: "iPhone 15",
+      state: "Booted",
+      isAvailable: true,
+    });
+
+    const iosManager = new FakeIOSCtrlProxyManager();
+    iosManager.setRunning(true);
+
+    // Capture the push-update callback so the test can fire it on demand.
+    let captured: (() => void) | null = null;
+    const iosClient = stubIOSCtrlProxy({
+      isConnected: () => true,
+      verifyServiceReady: () => Promise.resolve(true),
+      onPushUpdate: (cb: () => void) => {
+        captured = cb;
+        return () => { captured = null; };
+      },
+    });
+
+    const observeCache = new FakeObserveScreenCache();
+
+    const provider = new FakeDeviceClientProvider(
+      fakeAdb,
+      fakeDeviceUtils,
+      fakeSimctl as any,
+      {
+        iosCtrlProxyManager: iosManager,
+        iosCtrlProxyClient: iosClient,
+        observeScreenCache: observeCache,
+      }
+    );
+
+    const manager = DeviceSessionManager.createInstance(provider);
+    await manager.verifyIosDevice("ios-push-1");
+
+    // Listener registered; cache untouched until update fires.
+    expect(captured).not.toBeNull();
+    expect(observeCache.wasClearedFor("ios-push-1")).toBe(false);
+
+    (captured as unknown as () => void)();
+
+    expect(observeCache.wasClearedFor("ios-push-1")).toBe(true);
+    expect(observeCache.getClearedDevices()).toEqual(["ios-push-1"]);
   });
 });
 


### PR DESCRIPTION
## Summary
- Introduce `ObserveScreenCache` interface (`clearForDevice(deviceId)`) and expose it via `DeviceClientProvider.getObserveScreenCache()`. The default impl lives on `RealObserveScreen.defaultObserveScreenCache` next to the static it wraps.
- `DeviceSessionManager.registerPushUpdateListener` now invalidates the cache through the injected interface instead of calling the static `RealObserveScreen.clearCache(deviceId)` directly — closing the last DSM static reach-out for this series.
- `FakeDeviceClientProvider.getObserveScreenCache()` auto-vends a `FakeObserveScreenCache` (memoized in a private field) when none is configured — the cache is a sink, so tests that don't care don't have to wire one; tests that DO care pass their own and inspect cleared deviceIds.
- New regression test wires a stub iOS client that captures the `onPushUpdate` callback, fires it, and asserts the injected cache fake saw the right deviceId.

Follow-up scope (intentionally out of this PR): three other call sites (`toolRegistry`, `utilityTools`, `daemon`) still call `RealObserveScreen.clearCache` directly. They don't take a `DeviceClientProvider` so routing them through the new interface is a separate cleanup.

## Test plan
- [x] `bun test test/utils/DeviceSessionManager.test.ts` — 25/25 pass
- [x] `bun test` (full suite) — 4057 pass, 2 skip, 0 fail
- [x] `turbo run lint build` — clean