### PR TITLE
fix(daemon): per-request MCP timeouts and McpTimeoutError

### DIFF
--- a/src/daemon/McpTimeoutError.ts
+++ b/src/daemon/McpTimeoutError.ts
@@ -1,0 +1,16 @@
+export class McpTimeoutError extends Error {
+  readonly toolName: string;
+  readonly timeoutMs: number;
+  readonly origin: string;
+
+  constructor(opts: { toolName: string; timeoutMs: number; origin: string; detail?: string }) {
+    const detail = opts.detail ? ` (${opts.detail})` : "";
+    super(
+      `MCP timeout: ${opts.toolName} exceeded ${opts.timeoutMs}ms at ${opts.origin}${detail}`
+    );
+    this.name = "McpTimeoutError";
+    this.toolName = opts.toolName;
+    this.timeoutMs = opts.timeoutMs;
+    this.origin = opts.origin;
+  }
+}

--- a/src/daemon/client.ts
+++ b/src/daemon/client.ts
@@ -9,7 +9,9 @@ import {
   SOCKET_PATH,
   CONNECTION_TIMEOUT_MS,
 } from "./constants";
-import { defaultTimer } from "../utils/SystemTimer";
+import { resolveMcpRequestTimeoutMs } from "./mcpRequestTimeout";
+import { McpTimeoutError } from "./McpTimeoutError";
+import { type Timer, defaultTimer } from "../utils/SystemTimer";
 
 /**
  * Custom error thrown when daemon is unavailable
@@ -35,6 +37,7 @@ export class DaemonClient {
   private socket: Socket | null = null;
   private socketPath: string;
   private connectionTimeout: number;
+  private timer: Timer;
   private pendingRequests: Map<string, {
     resolve: (value: DaemonResponse) => void;
     reject: (error: Error) => void;
@@ -45,10 +48,12 @@ export class DaemonClient {
 
   constructor(
     socketPath: string = SOCKET_PATH,
-    connectionTimeout: number = CONNECTION_TIMEOUT_MS
+    connectionTimeout: number = CONNECTION_TIMEOUT_MS,
+    timer: Timer = defaultTimer,
   ) {
     this.socketPath = socketPath;
     this.connectionTimeout = connectionTimeout;
+    this.timer = timer;
   }
 
   /**
@@ -111,7 +116,7 @@ export class DaemonClient {
     }
 
     return new Promise((resolve, reject) => {
-      const timeout = defaultTimer.setTimeout(() => {
+      const timeout = this.timer.setTimeout(() => {
         if (this.socket) {
           this.socket.destroy();
         }
@@ -123,7 +128,7 @@ export class DaemonClient {
       }, this.connectionTimeout);
 
       this.socket = createConnection(this.socketPath, () => {
-        clearTimeout(timeout);
+        this.timer.clearTimeout(timeout);
         this.connected = true;
         logger.info(`Connected to daemon at ${this.socketPath}`);
         resolve();
@@ -134,13 +139,13 @@ export class DaemonClient {
       });
 
       this.socket.on("error", error => {
-        clearTimeout(timeout);
+        this.timer.clearTimeout(timeout);
         this.connected = false;
         logger.error(`Daemon socket error: ${error.message}`);
 
         // Reject all pending requests
         for (const [, { reject, timeout }] of this.pendingRequests) {
-          clearTimeout(timeout);
+          this.timer.clearTimeout(timeout);
           reject(error);
         }
         this.pendingRequests.clear();
@@ -187,7 +192,7 @@ export class DaemonClient {
       return;
     }
 
-    clearTimeout(pending.timeout);
+    this.timer.clearTimeout(pending.timeout);
     this.pendingRequests.delete(response.id);
 
     if (response.success) {
@@ -224,7 +229,6 @@ export class DaemonClient {
 
     const requestId = randomUUID();
 
-    // Create request
     const request: DaemonRequest = {
       id: requestId,
       type: "mcp_request",
@@ -232,16 +236,20 @@ export class DaemonClient {
       params,
     };
 
-    // Send request
+    const requestTimeoutMs = Math.max(resolveMcpRequestTimeoutMs(request), this.connectionTimeout);
+    const toolName = method === "tools/call" ? params?.name ?? method : method;
+
     return new Promise((resolve, reject) => {
-      const timeout = defaultTimer.setTimeout(() => {
+      const timeout = this.timer.setTimeout(() => {
         this.pendingRequests.delete(requestId);
         reject(
-          new DaemonUnavailableError(
-            `Daemon request timeout after ${this.connectionTimeout}ms`
-          )
+          new McpTimeoutError({
+            toolName,
+            timeoutMs: requestTimeoutMs,
+            origin: "DaemonClient.sendRequest",
+          })
         );
-      }, this.connectionTimeout);
+      }, requestTimeoutMs);
 
       this.pendingRequests.set(requestId, {
         resolve: response => {
@@ -252,7 +260,7 @@ export class DaemonClient {
       });
 
       if (!this.socket) {
-        clearTimeout(timeout);
+        this.timer.clearTimeout(timeout);
         this.pendingRequests.delete(requestId);
         reject(
           new DaemonUnavailableError("Socket connection lost")
@@ -285,12 +293,14 @@ export class DaemonClient {
     };
 
     return new Promise((resolve, reject) => {
-      const timeout = defaultTimer.setTimeout(() => {
+      const timeout = this.timer.setTimeout(() => {
         this.pendingRequests.delete(requestId);
         reject(
-          new DaemonUnavailableError(
-            `Daemon request timeout after ${this.connectionTimeout}ms`
-          )
+          new McpTimeoutError({
+            toolName: method,
+            timeoutMs: this.connectionTimeout,
+            origin: "DaemonClient.callDaemonMethod",
+          })
         );
       }, this.connectionTimeout);
 
@@ -303,7 +313,7 @@ export class DaemonClient {
       });
 
       if (!this.socket) {
-        defaultTimer.clearTimeout(timeout);
+        this.timer.clearTimeout(timeout);
         this.pendingRequests.delete(requestId);
         reject(
           new DaemonUnavailableError("Socket connection lost")
@@ -328,7 +338,7 @@ export class DaemonClient {
 
     // Reject all pending requests
     for (const [, { timeout }] of this.pendingRequests) {
-      clearTimeout(timeout);
+      this.timer.clearTimeout(timeout);
     }
     this.pendingRequests.clear();
   }

--- a/src/daemon/mcpRequestTimeout.ts
+++ b/src/daemon/mcpRequestTimeout.ts
@@ -12,14 +12,26 @@ export const DEFAULT_MCP_REQUEST_TIMEOUT_MS = 30_000;
  */
 export const MIN_EXECUTE_PLAN_MCP_TIMEOUT_MS = 600_000;
 
+/**
+ * Floor for `startDevice` — cold-booting an emulator can take 45-90s depending on
+ * host performance (especially under emulation/Rosetta).
+ */
+export const MIN_START_DEVICE_MCP_TIMEOUT_MS = 180_000;
+
+const EXTENDED_TIMEOUT_TOOLS = new Set(["executePlan", "startDevice"]);
+
 export function resolveMcpRequestTimeoutMs(request: DaemonRequest): number {
   const raw = request.timeoutMs;
   const base =
     typeof raw === "number" && Number.isFinite(raw) && raw > 0
       ? raw
       : DEFAULT_MCP_REQUEST_TIMEOUT_MS;
-  if (request.method === "tools/call" && request.params?.name === "executePlan") {
-    return Math.max(base, MIN_EXECUTE_PLAN_MCP_TIMEOUT_MS);
+  if (request.method === "tools/call" && EXTENDED_TIMEOUT_TOOLS.has(request.params?.name)) {
+    const floor =
+      request.params?.name === "executePlan"
+        ? MIN_EXECUTE_PLAN_MCP_TIMEOUT_MS
+        : MIN_START_DEVICE_MCP_TIMEOUT_MS;
+    return Math.max(base, floor);
   }
   return base;
 }

--- a/src/daemon/socketServer.ts
+++ b/src/daemon/socketServer.ts
@@ -9,6 +9,7 @@ import {
 } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
 import { logger } from "../utils/logger";
 import { resolveMcpRequestTimeoutMs, MIN_EXECUTE_PLAN_MCP_TIMEOUT_MS } from "./mcpRequestTimeout";
+import { McpTimeoutError } from "./McpTimeoutError";
 import {
   DaemonRequest,
   DaemonResponse,
@@ -263,9 +264,13 @@ export class UnixSocketServer {
           );
 
           if (remainingTimeoutMs <= 0) {
-            throw new Error(
-              `MCP forward timeout: spent ${queueWaitMs}ms waiting in queue (budget was ${totalTimeoutMs}ms)`
-            );
+            const toolName = request.method === "tools/call" ? request.params?.name ?? request.method : request.method;
+            throw new McpTimeoutError({
+              toolName,
+              timeoutMs: totalTimeoutMs,
+              origin: "UnixSocketServer.handleRequest",
+              detail: `spent ${queueWaitMs}ms waiting in queue`,
+            });
           }
 
           const forwardStartMs = this.timer.now();
@@ -283,9 +288,13 @@ export class UnixSocketServer {
                 const freshClient = await this.getMcpClient();
                 const retryRemainingMs = remainingTimeoutMs - (this.timer.now() - forwardStartMs);
                 if (retryRemainingMs <= 0) {
-                  throw new Error(
-                    `MCP forward timeout: no budget remaining after session reconnect (elapsed ${this.timer.now() - forwardStartMs}ms of ${remainingTimeoutMs}ms)`
-                  );
+                  const toolName = request.method === "tools/call" ? request.params?.name ?? request.method : request.method;
+                  throw new McpTimeoutError({
+                    toolName,
+                    timeoutMs: remainingTimeoutMs,
+                    origin: "UnixSocketServer.handleRequest",
+                    detail: `no budget remaining after session reconnect (elapsed ${this.timer.now() - forwardStartMs}ms)`,
+                  });
                 }
                 return await this.handleIdeRequest(freshClient, request, retryRemainingMs);
               }

--- a/test/daemon/McpTimeoutError.test.ts
+++ b/test/daemon/McpTimeoutError.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, test } from "bun:test";
+import { McpTimeoutError } from "../../src/daemon/McpTimeoutError";
+
+describe("McpTimeoutError", () => {
+  test("formats message with tool name, timeout, and origin", () => {
+    const err = new McpTimeoutError({
+      toolName: "startDevice",
+      timeoutMs: 180_000,
+      origin: "DaemonClient.sendRequest",
+    });
+    expect(err.message).toBe(
+      "MCP timeout: startDevice exceeded 180000ms at DaemonClient.sendRequest"
+    );
+    expect(err.name).toBe("McpTimeoutError");
+    expect(err.toolName).toBe("startDevice");
+    expect(err.timeoutMs).toBe(180_000);
+    expect(err.origin).toBe("DaemonClient.sendRequest");
+  });
+
+  test("includes detail when provided", () => {
+    const err = new McpTimeoutError({
+      toolName: "executePlan",
+      timeoutMs: 600_000,
+      origin: "UnixSocketServer.handleRequest",
+      detail: "spent 601000ms waiting in queue",
+    });
+    expect(err.message).toBe(
+      "MCP timeout: executePlan exceeded 600000ms at UnixSocketServer.handleRequest (spent 601000ms waiting in queue)"
+    );
+  });
+
+  test("is an instance of Error", () => {
+    const err = new McpTimeoutError({
+      toolName: "observe",
+      timeoutMs: 30_000,
+      origin: "DaemonClient.sendRequest",
+    });
+    expect(err).toBeInstanceOf(Error);
+  });
+
+  test("has a useful stack trace", () => {
+    const err = new McpTimeoutError({
+      toolName: "startDevice",
+      timeoutMs: 180_000,
+      origin: "DaemonClient.sendRequest",
+    });
+    expect(err.stack).toContain("McpTimeoutError.test.ts");
+  });
+});

--- a/test/daemon/clientRequestTimeout.test.ts
+++ b/test/daemon/clientRequestTimeout.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, test, beforeEach } from "bun:test";
+import { Duplex } from "node:stream";
+import { DaemonClient } from "../../src/daemon/client";
+import { McpTimeoutError } from "../../src/daemon/McpTimeoutError";
+import { MIN_START_DEVICE_MCP_TIMEOUT_MS, DEFAULT_MCP_REQUEST_TIMEOUT_MS } from "../../src/daemon/mcpRequestTimeout";
+import { FakeTimer } from "../fakes/FakeTimer";
+
+function createBlackHoleSocket(): Duplex {
+  return new Duplex({
+    read() {},
+    write(_chunk, _encoding, callback) { callback(); },
+  });
+}
+
+function createConnectedClient(fakeTimer: FakeTimer, connectionTimeout = 1000): DaemonClient {
+  const client = new DaemonClient("/fake/socket", connectionTimeout, fakeTimer);
+  (client as any).connected = true;
+  (client as any).socket = createBlackHoleSocket();
+  return client;
+}
+
+describe("DaemonClient per-request timeout", () => {
+  let fakeTimer: FakeTimer;
+
+  beforeEach(() => {
+    fakeTimer = new FakeTimer();
+  });
+
+  test("startDevice uses MIN_START_DEVICE_MCP_TIMEOUT_MS", async () => {
+    const client = createConnectedClient(fakeTimer);
+
+    const promise = client.callTool("startDevice", {});
+    fakeTimer.advanceTime(MIN_START_DEVICE_MCP_TIMEOUT_MS);
+
+    try {
+      await promise;
+      expect.unreachable("should have timed out");
+    } catch (err) {
+      expect(err).toBeInstanceOf(McpTimeoutError);
+      const timeoutErr = err as McpTimeoutError;
+      expect(timeoutErr.toolName).toBe("startDevice");
+      expect(timeoutErr.timeoutMs).toBe(MIN_START_DEVICE_MCP_TIMEOUT_MS);
+      expect(timeoutErr.origin).toBe("DaemonClient.sendRequest");
+    } finally {
+      await client.close();
+    }
+  });
+
+  test("regular tool uses DEFAULT_MCP_REQUEST_TIMEOUT_MS", async () => {
+    const client = createConnectedClient(fakeTimer);
+
+    const promise = client.callTool("observe", {});
+    fakeTimer.advanceTime(DEFAULT_MCP_REQUEST_TIMEOUT_MS);
+
+    try {
+      await promise;
+      expect.unreachable("should have timed out");
+    } catch (err) {
+      expect(err).toBeInstanceOf(McpTimeoutError);
+      const timeoutErr = err as McpTimeoutError;
+      expect(timeoutErr.toolName).toBe("observe");
+      expect(timeoutErr.timeoutMs).toBe(DEFAULT_MCP_REQUEST_TIMEOUT_MS);
+      expect(timeoutErr.origin).toBe("DaemonClient.sendRequest");
+    } finally {
+      await client.close();
+    }
+  });
+
+  test("startDevice does NOT time out at the old connectionTimeout", async () => {
+    const client = createConnectedClient(fakeTimer);
+
+    const promise = client.callTool("startDevice", {});
+    fakeTimer.advanceTime(1000);
+
+    let resolved = false;
+    promise.then(() => { resolved = true; }).catch(() => { resolved = true; });
+    await new Promise(r => setImmediate(r));
+    expect(resolved).toBe(false);
+
+    await client.close();
+  });
+
+  test("callDaemonMethod uses McpTimeoutError", async () => {
+    const client = createConnectedClient(fakeTimer, 5000);
+
+    const promise = client.callDaemonMethod("daemon/status");
+    fakeTimer.advanceTime(5000);
+
+    try {
+      await promise;
+      expect.unreachable("should have timed out");
+    } catch (err) {
+      expect(err).toBeInstanceOf(McpTimeoutError);
+      const timeoutErr = err as McpTimeoutError;
+      expect(timeoutErr.toolName).toBe("daemon/status");
+      expect(timeoutErr.timeoutMs).toBe(5000);
+      expect(timeoutErr.origin).toBe("DaemonClient.callDaemonMethod");
+    } finally {
+      await client.close();
+    }
+  });
+
+  test("connectionTimeout overrides per-tool floor when larger", async () => {
+    const client = createConnectedClient(fakeTimer, 300_000);
+
+    const promise = client.callTool("startDevice", {});
+    fakeTimer.advanceTime(300_000);
+
+    try {
+      await promise;
+      expect.unreachable("should have timed out");
+    } catch (err) {
+      expect(err).toBeInstanceOf(McpTimeoutError);
+      const timeoutErr = err as McpTimeoutError;
+      expect(timeoutErr.toolName).toBe("startDevice");
+      expect(timeoutErr.timeoutMs).toBe(300_000);
+    } finally {
+      await client.close();
+    }
+  });
+});

--- a/test/daemon/mcpRequestTimeout.test.ts
+++ b/test/daemon/mcpRequestTimeout.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 import {
   DEFAULT_MCP_REQUEST_TIMEOUT_MS,
   MIN_EXECUTE_PLAN_MCP_TIMEOUT_MS,
+  MIN_START_DEVICE_MCP_TIMEOUT_MS,
   resolveMcpRequestTimeoutMs
 } from "../../src/daemon/mcpRequestTimeout";
 import type { DaemonRequest } from "../../src/daemon/types";
@@ -91,5 +92,37 @@ describe("resolveMcpRequestTimeoutMs", () => {
       timeoutMs: 0
     };
     expect(resolveMcpRequestTimeoutMs(request)).toBe(DEFAULT_MCP_REQUEST_TIMEOUT_MS);
+  });
+
+  test("applies startDevice floor when client omits timeoutMs", () => {
+    const request: DaemonRequest = {
+      id: "1",
+      type: "mcp_request",
+      method: "tools/call",
+      params: { name: "startDevice", arguments: {} }
+    };
+    expect(resolveMcpRequestTimeoutMs(request)).toBe(MIN_START_DEVICE_MCP_TIMEOUT_MS);
+  });
+
+  test("raises short startDevice timeouts to the floor", () => {
+    const request: DaemonRequest = {
+      id: "1",
+      type: "mcp_request",
+      method: "tools/call",
+      params: { name: "startDevice", arguments: {} },
+      timeoutMs: 60_000
+    };
+    expect(resolveMcpRequestTimeoutMs(request)).toBe(MIN_START_DEVICE_MCP_TIMEOUT_MS);
+  });
+
+  test("preserves startDevice timeouts above the floor", () => {
+    const request: DaemonRequest = {
+      id: "1",
+      type: "mcp_request",
+      method: "tools/call",
+      params: { name: "startDevice", arguments: {} },
+      timeoutMs: 300_000
+    };
+    expect(resolveMcpRequestTimeoutMs(request)).toBe(300_000);
   });
 });


### PR DESCRIPTION
## Summary
- Fix client-side timeout being shorter (120s) than server-side startDevice floor (180s), causing premature `DaemonUnavailableError` during emulator cold boot
- Add `McpTimeoutError` class that includes tool name, timeout value, and call origin for better debugging
- Add `MIN_START_DEVICE_MCP_TIMEOUT_MS` (180s) floor for `startDevice` alongside the existing `executePlan` (600s) floor
- Client now resolves timeout per-request using `resolveMcpRequestTimeoutMs` instead of a fixed global
- Inject `Timer` into `DaemonClient` for testability with `FakeTimer`

## Test plan
- [x] `McpTimeoutError.test.ts` — error formatting, instanceof, stack traces
- [x] `mcpRequestTimeout.test.ts` — startDevice floor, executePlan floor, edge cases
- [x] `clientRequestTimeout.test.ts` — client uses correct per-tool timeout via FakeTimer
- [x] All 241 daemon tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)