### PR TITLE
fix(tests): eliminate two CI flakes via deterministic fakes

### DIFF
--- a/src/utils/DeviceSessionManager.ts
+++ b/src/utils/DeviceSessionManager.ts
@@ -392,7 +392,7 @@ export class DeviceSessionManager implements DeviceSessionManager {
     this.setCurrentDevice(selectedDevice, resolvedPlatform);
     if (deviceSource !== "current") {
       await applyAppearanceOnConnect(selectedDevice);
-      await disableStylusHandwriting(selectedDevice);
+      await disableStylusHandwriting(selectedDevice, this.adbFactory);
     }
     logger.info(`[DeviceSessionManager] Using ${deviceSource} device: ${selectedDevice.deviceId}`);
     return selectedDevice;

--- a/test/features/observe/screenshot/ObserveScreenshotRecorder.test.ts
+++ b/test/features/observe/screenshot/ObserveScreenshotRecorder.test.ts
@@ -15,29 +15,21 @@ import {
 import { FakeScreenshotStateStore } from "../../../fakes/FakeScreenshotStateStore";
 
 /**
- * Poll until `predicate()` returns true or the iteration limit is reached.
- * Uses setImmediate to yield the event loop between checks. Max iterations
- * set high enough to accommodate I/O settling on resource-constrained CI.
- */
-async function eventually(predicate: () => boolean, maxIterations = 200): Promise<void> {
-  for (let i = 0; i < maxIterations; i++) {
-    if (predicate()) {
-      return;
-    }
-    await new Promise(resolve => setImmediate(resolve));
-  }
-}
-
-/**
  * Minimal fake `TrackedScreenshotService` that lets each test script the
  * `ScreenshotResult` returned by the capture and choose whether the capture
  * reports as the latest job / aborted.
+ *
+ * The promise returned from the most recent `startTrackedCapture` call is
+ * stored on `lastCapturePromise()` so tests can deterministically await
+ * completion of fire-and-forget `recorder.start()` invocations without
+ * polling.
  */
 class FakeTrackedScreenshotService implements TrackedScreenshotService {
   private nextResult: ScreenshotResult = { success: true, path: "/tmp/default.png" };
   private nextIsLatest: boolean = true;
   private nextAborted: boolean = false;
   private nextThrow: Error | null = null;
+  private lastPromise: Promise<ScreenshotResult> | null = null;
 
   setNextResult(result: ScreenshotResult): void {
     this.nextResult = result;
@@ -50,6 +42,22 @@ class FakeTrackedScreenshotService implements TrackedScreenshotService {
   }
   setNextThrow(err: Error): void {
     this.nextThrow = err;
+  }
+
+  /**
+   * Returns the promise tracked by the most recent `startTrackedCapture` call.
+   * Throws if no capture has been started. The promise has the same identity
+   * as the one returned to `recorder.start()`, so any `.finally()` handlers
+   * attached by the recorder run before the awaiter's continuation.
+   */
+  lastCapturePromise(): Promise<ScreenshotResult> {
+    if (!this.lastPromise) {
+      throw new Error("FakeTrackedScreenshotService: no capture has been started yet");
+    }
+    // Swallow rejections so `await svc.lastCapturePromise()` works for
+    // failure-path tests too; the recorder still observes the original
+    // rejection through its own chained handlers.
+    return this.lastPromise.catch(() => ({ success: false } as ScreenshotResult));
   }
 
   async execute(_options?: ScreenshotOptions, _signal?: AbortSignal): Promise<ScreenshotResult> {
@@ -90,6 +98,7 @@ class FakeTrackedScreenshotService implements TrackedScreenshotService {
       }
       return result;
     })();
+    this.lastPromise = promise;
 
     return {
       jobId: "job-1",
@@ -221,7 +230,7 @@ describe("DefaultObserveScreenshotRecorder.start", () => {
     expect(returnValue).toBeUndefined();
     expect(store.getUpdateCount()).toBe(0); // nothing yet — runs async
 
-    await eventually(() => store.getPath("test-device") === file);
+    await svc.lastCapturePromise();
 
     expect(store.getPath("test-device")).toBe(file);
   });
@@ -232,8 +241,7 @@ describe("DefaultObserveScreenshotRecorder.start", () => {
 
     recorder.start(new NoOpPerformanceTracker());
 
-    // Drain the microtask queue; non-latest completion should NOT write.
-    await eventually(() => false, 10);
+    await svc.lastCapturePromise();
 
     expect(store.getUpdateCount()).toBe(0);
   });
@@ -244,7 +252,7 @@ describe("DefaultObserveScreenshotRecorder.start", () => {
 
     recorder.start(new NoOpPerformanceTracker());
 
-    await eventually(() => false, 10);
+    await svc.lastCapturePromise();
 
     expect(store.getUpdateCount()).toBe(0);
   });
@@ -254,7 +262,7 @@ describe("DefaultObserveScreenshotRecorder.start", () => {
 
     recorder.start(new NoOpPerformanceTracker());
 
-    await eventually(() => store.getError("test-device") === "boom");
+    await svc.lastCapturePromise();
 
     expect(store.getError("test-device")).toBe("boom");
   });
@@ -281,7 +289,7 @@ describe("DefaultObserveScreenshotRecorder.start", () => {
     svc.setNextResult({ success: true, path: "/tmp/no-exist.png" });
     recorder.start(fakeTracker);
 
-    await eventually(() => calls.includes("end:screenshot"));
+    await svc.lastCapturePromise();
 
     expect(calls).toContain("start:screenshot");
     expect(calls).toContain("end:screenshot");


### PR DESCRIPTION
## Summary

Two tests have been flaking in CI. Both were caused by the production/test boundary not staying inside the injected fakes — they leaked into real time or real subprocesses.

- **`DeviceSessionManager > should resolve android device by providedDeviceId when no active device set`** (5006ms timeout). `DeviceSessionManager.ensureDeviceReady` calls `disableStylusHandwriting(selectedDevice)` after device resolution, but did not pass the manager's injected `adbFactory`. The helper defaulted to `defaultAdbClientFactory` and spawned a real `adb shell settings put secure stylus_handwriting_enabled 0` against the bogus `emulator-5554` deviceId on real timers — variable seconds of latency that occasionally blew the 5s test budget. Sibling iOS test was immune because `disableStylusHandwriting` early-returns for non-Android platforms.
  - Fix: thread `this.adbFactory` through. `FakeAdbExecutor.executeCommand` now handles it synchronously.

- **`DefaultObserveScreenshotRecorder.start > start() tracks performance via startOperation/endOperation`** (1.19ms — exited before async chain settled). The test polled with `eventually(predicate, maxIterations=200)` using bare `setImmediate`. If the in-flight chain (which includes a real `pathExists` fs call inside the fake's `onComplete`) hadn't settled by iteration 200, `eventually()` silently returned and the assertion fired on incomplete state.
  - Fix: expose `FakeTrackedScreenshotService.lastCapturePromise()` returning the same `Promise` identity the recorder receives. Tests now `await svc.lastCapturePromise()`. Microtask ordering guarantees the `.finally(endOperation)` chain attached inside `start()` runs before the test's await resumes (handlers fire in attachment order, and `start()` attaches before the test awaits).

The dead `eventually()` helper is removed.

## Verification

- Both target files: 5 consecutive stress runs all green, ~30ms (screenshot) / ~250ms (DSM).
- Full suite (`bun test`): 4053 pass, 2 skip, 0 fail.
- `turbo run lint`: clean.

## Test plan

- [x] `bun test test/features/observe/screenshot/ObserveScreenshotRecorder.test.ts`
- [x] `bun test test/utils/DeviceSessionManager.test.ts`
- [x] `bun test` (full suite)
- [x] `turbo run lint`