### PR TITLE
refactor(proxy): introduce shared ProxyManager interface

### DIFF
--- a/src/utils/CtrlProxyManager.ts
+++ b/src/utils/CtrlProxyManager.ts
@@ -18,26 +18,23 @@ import { NoOpPerformanceTracker, createGlobalPerformanceTracker, type Performanc
 import { Timer, defaultTimer } from "./SystemTimer";
 import { type FileDownloader, DefaultFileDownloader } from "./FileDownloader";
 import { type ChecksumCalculator, DefaultChecksumCalculator } from "./ChecksumCalculator";
+import type { ProxyManager, ProxySetupResult } from "./interfaces/ProxyManager";
 
 /**
  * Result of accessibility service setup
  */
-interface AccessibilitySetupResult {
-  success: boolean;
-  message: string;
-  error?: string;
-  perfTiming?: ReturnType<PerformanceTracker["getTimings"]>;
-}
+type AccessibilitySetupResult = ProxySetupResult;
 
 /**
  * Interface for accessibility service management
+ *
+ * Extends the platform-agnostic {@link ProxyManager} interface with
+ * Android-specific accessibility-service lifecycle methods.
  */
-export interface CtrlProxyManager {
+export interface CtrlProxyManager extends ProxyManager {
   setup(force?: boolean, perf?: PerformanceTracker): Promise<AccessibilitySetupResult>;
-  isInstalled(): Promise<boolean>;
   isEnabled(): Promise<boolean>;
   isEnabledForUser(userId: number): Promise<boolean>;
-  isAvailable(): Promise<boolean>;
   getInstalledApkSha256(): Promise<string | null>;
   isVersionCompatible(): Promise<boolean>;
   ensureCompatibleVersion(): Promise<AccessibilityVersionCheckResult>;
@@ -46,7 +43,6 @@ export interface CtrlProxyManager {
   enable(): Promise<void>;
   enableForUser(userId: number): Promise<void>;
   cleanupApk(apkPath: string): Promise<void>;
-  resetSetupState(): void;
 }
 
 interface AccessibilityVersionCheckResult {

--- a/src/utils/CtrlProxyManager.ts
+++ b/src/utils/CtrlProxyManager.ts
@@ -21,18 +21,11 @@ import { type ChecksumCalculator, DefaultChecksumCalculator } from "./ChecksumCa
 import type { ProxyManager, ProxySetupResult } from "./interfaces/ProxyManager";
 
 /**
- * Result of accessibility service setup
- */
-type AccessibilitySetupResult = ProxySetupResult;
-
-/**
- * Interface for accessibility service management
- *
- * Extends the platform-agnostic {@link ProxyManager} interface with
- * Android-specific accessibility-service lifecycle methods.
+ * Android-specific accessibility-service lifecycle, extending the
+ * platform-agnostic {@link ProxyManager}.
  */
 export interface CtrlProxyManager extends ProxyManager {
-  setup(force?: boolean, perf?: PerformanceTracker): Promise<AccessibilitySetupResult>;
+  setup(force?: boolean, perf?: PerformanceTracker): Promise<ProxySetupResult>;
   isEnabled(): Promise<boolean>;
   isEnabledForUser(userId: number): Promise<boolean>;
   getInstalledApkSha256(): Promise<string | null>;
@@ -1038,7 +1031,7 @@ export class AndroidCtrlProxyManager implements CtrlProxyManager {
   /**
    * Complete setup process for Accessibility Service
    */
-  async setup(force: boolean = false, perf: PerformanceTracker = new NoOpPerformanceTracker()): Promise<AccessibilitySetupResult> {
+  async setup(force: boolean = false, perf: PerformanceTracker = new NoOpPerformanceTracker()): Promise<ProxySetupResult> {
     perf.serial("a11yServiceSetup");
     let apkPath: string | null = null;
 

--- a/src/utils/IOSCtrlProxyManager.ts
+++ b/src/utils/IOSCtrlProxyManager.ts
@@ -23,33 +23,33 @@ import {
   stopIproxy,
   stopCtrlProxyIOS
 } from "./hostControlClient";
+import type { ProxyManager, ProxySetupResult } from "./interfaces/ProxyManager";
 
 /**
  * Result of CtrlProxy setup
+ *
+ * Extends the platform-agnostic {@link ProxySetupResult} with the
+ * iOS-specific build result.
  */
-export interface CtrlProxyIosSetupResult {
-  success: boolean;
-  message: string;
-  error?: string;
+export interface CtrlProxyIosSetupResult extends ProxySetupResult {
   buildResult?: CtrlProxyIosBuildResult;
-  perfTiming?: ReturnType<PerformanceTracker["getTimings"]>;
 }
 
 /**
  * Interface for iOS CtrlProxy management
+ *
+ * Extends the platform-agnostic {@link ProxyManager} interface with
+ * iOS-specific runner process lifecycle methods.
  */
-export interface CtrlProxyIosManager {
+export interface CtrlProxyIosManager extends ProxyManager {
   setup(force?: boolean, perf?: PerformanceTracker): Promise<CtrlProxyIosSetupResult>;
-  isInstalled(): Promise<boolean>;
   isRunning(): Promise<boolean>;
-  isAvailable(): Promise<boolean>;
   start(): Promise<void>;
   stop(): Promise<void>;
   getServicePort(): number;
   setAutoRestart(enabled: boolean): void;
   isAutoRestartEnabled(): boolean;
   forceRestart(): Promise<void>;
-  resetSetupState(): void;
 }
 
 interface HostControlCtrlProxyIOSRunner {

--- a/src/utils/IOSCtrlProxyManager.ts
+++ b/src/utils/IOSCtrlProxyManager.ts
@@ -26,20 +26,16 @@ import {
 import type { ProxyManager, ProxySetupResult } from "./interfaces/ProxyManager";
 
 /**
- * Result of CtrlProxy setup
- *
- * Extends the platform-agnostic {@link ProxySetupResult} with the
- * iOS-specific build result.
+ * iOS-specific setup result; carries the build result alongside the
+ * platform-agnostic fields.
  */
 export interface CtrlProxyIosSetupResult extends ProxySetupResult {
   buildResult?: CtrlProxyIosBuildResult;
 }
 
 /**
- * Interface for iOS CtrlProxy management
- *
- * Extends the platform-agnostic {@link ProxyManager} interface with
- * iOS-specific runner process lifecycle methods.
+ * iOS-specific runner process lifecycle, extending the platform-agnostic
+ * {@link ProxyManager}.
  */
 export interface CtrlProxyIosManager extends ProxyManager {
   setup(force?: boolean, perf?: PerformanceTracker): Promise<CtrlProxyIosSetupResult>;

--- a/src/utils/interfaces/ProxyManager.ts
+++ b/src/utils/interfaces/ProxyManager.ts
@@ -29,27 +29,20 @@ export interface ProxySetupResult {
  */
 export interface ProxyManager {
   /**
-   * Whether the proxy/control service is installed on the target device.
-   * For Android this checks the accessibility service APK; for iOS it
-   * checks the CtrlProxy test bundle/app.
+   * On Android, whether the accessibility service APK is installed;
+   * on iOS, whether the CtrlProxy test bundle/app is installed.
    */
   isInstalled(): Promise<boolean>;
 
   /**
-   * Whether the service is fully available for use (installed AND
-   * active — `enabled` on Android, `running` on iOS).
+   * Whether the service is fully available: installed AND active
+   * (`enabled` on Android, `running` on iOS).
    */
   isAvailable(): Promise<boolean>;
 
-  /**
-   * Run the full setup flow (download/install/enable or build/start)
-   * idempotently. Returns a result object describing what happened.
-   */
+  /** Idempotent — repeat calls short-circuit unless `force` or {@link resetSetupState} intervenes. */
   setup(force?: boolean, perf?: PerformanceTracker): Promise<ProxySetupResult>;
 
-  /**
-   * Reset internal setup-state caches so the next `setup()` call performs
-   * a fresh attempt instead of short-circuiting on prior results.
-   */
+  /** Drop internal setup-state caches so the next {@link setup} call performs a fresh attempt. */
   resetSetupState(): void;
 }

--- a/src/utils/interfaces/ProxyManager.ts
+++ b/src/utils/interfaces/ProxyManager.ts
@@ -1,0 +1,55 @@
+import type { PerformanceTracker } from "../PerformanceTracker";
+
+/**
+ * Common setup result shared between Android and iOS proxy managers.
+ *
+ * Platform-specific result types (e.g. `CtrlProxyIosSetupResult` adding
+ * `buildResult`) may extend this shape with additional fields.
+ */
+export interface ProxySetupResult {
+  success: boolean;
+  message: string;
+  error?: string;
+  perfTiming?: ReturnType<PerformanceTracker["getTimings"]>;
+}
+
+/**
+ * Platform-agnostic interface for proxy/control-service managers.
+ *
+ * Implemented by both `AndroidCtrlProxyManager` (manages the on-device
+ * accessibility service) and `IOSCtrlProxyManager` (manages the iOS
+ * XCUITest CtrlProxy runner process). Call sites that only need the
+ * shared lifecycle surface should depend on this type rather than the
+ * concrete platform-specific manager interface.
+ *
+ * Methods deliberately limited to the true semantic overlap between
+ * platforms — installation check, overall availability, setup, and
+ * resettable setup-state — so the interface does not leak Android- or
+ * iOS-specific concepts.
+ */
+export interface ProxyManager {
+  /**
+   * Whether the proxy/control service is installed on the target device.
+   * For Android this checks the accessibility service APK; for iOS it
+   * checks the CtrlProxy test bundle/app.
+   */
+  isInstalled(): Promise<boolean>;
+
+  /**
+   * Whether the service is fully available for use (installed AND
+   * active — `enabled` on Android, `running` on iOS).
+   */
+  isAvailable(): Promise<boolean>;
+
+  /**
+   * Run the full setup flow (download/install/enable or build/start)
+   * idempotently. Returns a result object describing what happened.
+   */
+  setup(force?: boolean, perf?: PerformanceTracker): Promise<ProxySetupResult>;
+
+  /**
+   * Reset internal setup-state caches so the next `setup()` call performs
+   * a fresh attempt instead of short-circuiting on prior results.
+   */
+  resetSetupState(): void;
+}

--- a/src/utils/interfaces/index.ts
+++ b/src/utils/interfaces/index.ts
@@ -4,6 +4,7 @@ export { AppLifecycleMonitor, DefaultAppLifecycleMonitor } from "../AppLifecycle
 export { DeviceSessionManager } from "../DeviceSessionManager";
 export { DeepLinkManager } from "../DeepLinkManager";
 export { CtrlProxyManager } from "../CtrlProxyManager";
+export type { ProxyManager, ProxySetupResult } from "./ProxyManager";
 // Screenshot utilities - split into focused classes (Phase 3.1)
 export { ScreenshotComparator } from "../screenshot/ScreenshotComparator";
 export { PerceptualHasher } from "../screenshot/PerceptualHasher";

--- a/test/fakes/FakeProxyManager.ts
+++ b/test/fakes/FakeProxyManager.ts
@@ -1,0 +1,76 @@
+import type { ProxyManager, ProxySetupResult } from "../../src/utils/interfaces/ProxyManager";
+import type { PerformanceTracker } from "../../src/utils/PerformanceTracker";
+
+/**
+ * Minimal fake implementation of {@link ProxyManager} for testing the
+ * platform-agnostic contract. Larger platform-specific fakes
+ * (`FakeCtrlProxyManager`, `FakeIOSCtrlProxyManager`) implement richer
+ * sub-interfaces; this fake covers only the shared surface so that
+ * call-sites depending solely on `ProxyManager` can be exercised
+ * without pulling in either platform.
+ */
+export class FakeProxyManager implements ProxyManager {
+  private installedState: boolean = false;
+  private availableState: boolean = false;
+  private shouldSetupFail: boolean = false;
+  private readonly executedOperations: string[] = [];
+
+  setInstalled(installed: boolean): void {
+    this.installedState = installed;
+  }
+
+  setAvailable(available: boolean): void {
+    this.availableState = available;
+  }
+
+  setSetupShouldFail(shouldFail: boolean): void {
+    this.shouldSetupFail = shouldFail;
+  }
+
+  getExecutedOperations(): string[] {
+    return [...this.executedOperations];
+  }
+
+  wasMethodCalled(operationName: string): boolean {
+    return this.executedOperations.some(op => op === operationName || op.startsWith(`${operationName}:`));
+  }
+
+  getCallCount(operationName: string): number {
+    return this.executedOperations.filter(op => op === operationName || op.startsWith(`${operationName}:`)).length;
+  }
+
+  clearHistory(): void {
+    this.executedOperations.length = 0;
+  }
+
+  async isInstalled(): Promise<boolean> {
+    this.executedOperations.push("isInstalled");
+    return this.installedState;
+  }
+
+  async isAvailable(): Promise<boolean> {
+    this.executedOperations.push("isAvailable");
+    return this.availableState;
+  }
+
+  async setup(force: boolean = false, _perf?: PerformanceTracker): Promise<ProxySetupResult> {
+    this.executedOperations.push(`setup:force=${force}`);
+
+    if (this.shouldSetupFail) {
+      return {
+        success: false,
+        message: "Failed to setup proxy",
+        error: "Mock setup failure"
+      };
+    }
+
+    return {
+      success: true,
+      message: "Proxy setup succeeded"
+    };
+  }
+
+  resetSetupState(): void {
+    this.executedOperations.push("resetSetupState");
+  }
+}

--- a/test/fakes/FakeProxyManager.ts
+++ b/test/fakes/FakeProxyManager.ts
@@ -32,11 +32,11 @@ export class FakeProxyManager implements ProxyManager {
   }
 
   wasMethodCalled(operationName: string): boolean {
-    return this.executedOperations.some(op => op === operationName || op.startsWith(`${operationName}:`));
+    return this.executedOperations.some(op => op.includes(operationName));
   }
 
   getCallCount(operationName: string): number {
-    return this.executedOperations.filter(op => op === operationName || op.startsWith(`${operationName}:`)).length;
+    return this.executedOperations.filter(op => op.includes(operationName)).length;
   }
 
   clearHistory(): void {

--- a/test/utils/ProxyManager.test.ts
+++ b/test/utils/ProxyManager.test.ts
@@ -1,8 +1,8 @@
 import { describe, it, expect, beforeEach } from "bun:test";
-import { FakeProxyManager } from "../../fakes/FakeProxyManager";
-import { FakeCtrlProxyManager } from "../../fakes/FakeCtrlProxyManager";
-import { FakeIOSCtrlProxyManager } from "../../fakes/FakeIOSCtrlProxyManager";
-import type { ProxyManager } from "../../../src/utils/interfaces/ProxyManager";
+import { FakeProxyManager } from "../fakes/FakeProxyManager";
+import { FakeCtrlProxyManager } from "../fakes/FakeCtrlProxyManager";
+import { FakeIOSCtrlProxyManager } from "../fakes/FakeIOSCtrlProxyManager";
+import type { ProxyManager } from "../../src/utils/interfaces/ProxyManager";
 
 /**
  * Sanity-check the platform-agnostic ProxyManager contract.
@@ -14,7 +14,7 @@ import type { ProxyManager } from "../../../src/utils/interfaces/ProxyManager";
  */
 describe("ProxyManager interface", () => {
   describe("FakeProxyManager", () => {
-    let manager: ProxyManager & FakeProxyManager;
+    let manager: FakeProxyManager;
 
     beforeEach(() => {
       manager = new FakeProxyManager();
@@ -60,45 +60,37 @@ describe("ProxyManager interface", () => {
     });
   });
 
-  describe("Android FakeCtrlProxyManager satisfies ProxyManager", () => {
-    it("can be assigned to ProxyManager and exposes shared methods", async () => {
+  // Both platform-specific fakes implement richer sub-interfaces but
+  // must still satisfy ProxyManager. Assigning them to the abstract
+  // type proves it at compile-time; the assertions cover behavior.
+  const platformFakes: ReadonlyArray<[string, () => ProxyManager]> = [
+    ["Android FakeCtrlProxyManager", () => {
       const fake = new FakeCtrlProxyManager();
       fake.setInstalled(true);
       fake.setAvailable(true);
-
-      // Compile-time check: assigning a richer fake to the abstract type
-      // proves that FakeCtrlProxyManager (and therefore the Android
-      // manager interface it implements) satisfies ProxyManager.
-      const asProxy: ProxyManager = fake;
-
-      expect(await asProxy.isInstalled()).toBe(true);
-      expect(await asProxy.isAvailable()).toBe(true);
-
-      const result = await asProxy.setup();
-      expect(result.success).toBe(true);
-
-      asProxy.resetSetupState();
-    });
-  });
-
-  describe("iOS FakeIOSCtrlProxyManager satisfies ProxyManager", () => {
-    it("can be assigned to ProxyManager and exposes shared methods", async () => {
+      return fake;
+    }],
+    ["iOS FakeIOSCtrlProxyManager", () => {
       const fake = new FakeIOSCtrlProxyManager();
       fake.setInstalled(true);
       fake.setAvailable(true);
+      return fake;
+    }]
+  ];
 
-      // Compile-time check: assigning a richer fake to the abstract type
-      // proves that FakeIOSCtrlProxyManager (and therefore the iOS
-      // manager interface it implements) satisfies ProxyManager.
-      const asProxy: ProxyManager = fake;
+  for (const [name, build] of platformFakes) {
+    describe(`${name} satisfies ProxyManager`, () => {
+      it("exposes the shared lifecycle methods via the abstract type", async () => {
+        const asProxy: ProxyManager = build();
 
-      expect(await asProxy.isInstalled()).toBe(true);
-      expect(await asProxy.isAvailable()).toBe(true);
+        expect(await asProxy.isInstalled()).toBe(true);
+        expect(await asProxy.isAvailable()).toBe(true);
 
-      const result = await asProxy.setup();
-      expect(result.success).toBe(true);
+        const result = await asProxy.setup();
+        expect(result.success).toBe(true);
 
-      asProxy.resetSetupState();
+        asProxy.resetSetupState();
+      });
     });
-  });
+  }
 });

--- a/test/utils/interfaces/ProxyManager.test.ts
+++ b/test/utils/interfaces/ProxyManager.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect, beforeEach } from "bun:test";
+import { FakeProxyManager } from "../../fakes/FakeProxyManager";
+import { FakeCtrlProxyManager } from "../../fakes/FakeCtrlProxyManager";
+import { FakeIOSCtrlProxyManager } from "../../fakes/FakeIOSCtrlProxyManager";
+import type { ProxyManager } from "../../../src/utils/interfaces/ProxyManager";
+
+/**
+ * Sanity-check the platform-agnostic ProxyManager contract.
+ *
+ * These tests deliberately type their subjects as the abstract
+ * ProxyManager interface so a regression that drops one of the shared
+ * methods from a concrete fake will surface as a compile error here
+ * before tests even run.
+ */
+describe("ProxyManager interface", () => {
+  describe("FakeProxyManager", () => {
+    let manager: ProxyManager & FakeProxyManager;
+
+    beforeEach(() => {
+      manager = new FakeProxyManager();
+    });
+
+    it("reports installed state via the interface method", async () => {
+      manager.setInstalled(true);
+      expect(await manager.isInstalled()).toBe(true);
+      manager.setInstalled(false);
+      expect(await manager.isInstalled()).toBe(false);
+    });
+
+    it("reports availability via the interface method", async () => {
+      manager.setAvailable(true);
+      expect(await manager.isAvailable()).toBe(true);
+      manager.setAvailable(false);
+      expect(await manager.isAvailable()).toBe(false);
+    });
+
+    it("returns a ProxySetupResult from setup()", async () => {
+      const result = await manager.setup();
+      expect(result.success).toBe(true);
+      expect(typeof result.message).toBe("string");
+    });
+
+    it("propagates configured setup failure as ProxySetupResult", async () => {
+      manager.setSetupShouldFail(true);
+      const result = await manager.setup();
+      expect(result.success).toBe(false);
+      expect(result.error).toBeDefined();
+    });
+
+    it("records resetSetupState() invocations", () => {
+      manager.resetSetupState();
+      manager.resetSetupState();
+      expect(manager.getCallCount("resetSetupState")).toBe(2);
+    });
+
+    it("threads force flag through to setup()", async () => {
+      await manager.setup(true);
+      expect(manager.wasMethodCalled("setup")).toBe(true);
+      expect(manager.getExecutedOperations()).toContain("setup:force=true");
+    });
+  });
+
+  describe("Android FakeCtrlProxyManager satisfies ProxyManager", () => {
+    it("can be assigned to ProxyManager and exposes shared methods", async () => {
+      const fake = new FakeCtrlProxyManager();
+      fake.setInstalled(true);
+      fake.setAvailable(true);
+
+      // Compile-time check: assigning a richer fake to the abstract type
+      // proves that FakeCtrlProxyManager (and therefore the Android
+      // manager interface it implements) satisfies ProxyManager.
+      const asProxy: ProxyManager = fake;
+
+      expect(await asProxy.isInstalled()).toBe(true);
+      expect(await asProxy.isAvailable()).toBe(true);
+
+      const result = await asProxy.setup();
+      expect(result.success).toBe(true);
+
+      asProxy.resetSetupState();
+    });
+  });
+
+  describe("iOS FakeIOSCtrlProxyManager satisfies ProxyManager", () => {
+    it("can be assigned to ProxyManager and exposes shared methods", async () => {
+      const fake = new FakeIOSCtrlProxyManager();
+      fake.setInstalled(true);
+      fake.setAvailable(true);
+
+      // Compile-time check: assigning a richer fake to the abstract type
+      // proves that FakeIOSCtrlProxyManager (and therefore the iOS
+      // manager interface it implements) satisfies ProxyManager.
+      const asProxy: ProxyManager = fake;
+
+      expect(await asProxy.isInstalled()).toBe(true);
+      expect(await asProxy.isAvailable()).toBe(true);
+
+      const result = await asProxy.setup();
+      expect(result.success).toBe(true);
+
+      asProxy.resetSetupState();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Introduces a small platform-agnostic `ProxyManager` interface that both `CtrlProxyManager` (Android, accessibility service) and `CtrlProxyIosManager` (iOS, XCUITest runner process) extend. First step in pushing platform branching deeper in the stack — see the broader refactor map this PR is part of.

- New `src/utils/interfaces/ProxyManager.ts` defining `ProxyManager` + `ProxySetupResult`
- Both platform manager interfaces now `extends ProxyManager`; the shared `isInstalled` / `isAvailable` / `setup` / `resetSetupState` declarations are no longer duplicated in each sub-interface
- iOS `CtrlProxyIosSetupResult` now `extends ProxySetupResult` (adds `buildResult`)
- New `FakeProxyManager` test fake covering only the shared surface, conforming to existing test/fakes conventions

## Scope discipline

- The shared surface is deliberately small — `start` / `stop` / `isDirectDtxMode` / `verifyServiceReady` were considered but don't exist on the Android manager, so they stay on the platform-specific sub-interfaces. No forced abstractions.
- `DeviceSessionManager` was intentionally **not** migrated to type-hold `ProxyManager` — its call sites need platform-specific methods. Future call sites that only need the shared surface can depend on the new interface.

## Test plan

- [x] `bun run lint` clean
- [x] `bun build.ts` succeeds
- [x] Full `bun test --bail`: 4064 pass / 2 skip / 0 fail
- [x] 8 new unit tests in `test/utils/ProxyManager.test.ts` exercising both the standalone fake and the assignability of `FakeCtrlProxyManager` / `FakeIOSCtrlProxyManager` to `ProxyManager`