### PR TITLE
refactor(plan): extract PlanExecutionOrchestrator from executePlan tool

### DIFF
--- a/src/server/planExecutionOrchestrator.ts
+++ b/src/server/planExecutionOrchestrator.ts
@@ -1,0 +1,630 @@
+import {
+  ActionableError,
+  BootedDevice,
+  ExecutePlanResult,
+  Platform,
+  PlanExecutionResult
+} from "../models";
+import { ExecutePlanStepDebugInfo, PlanExecutionOptions } from "../models/ExecutePlanResult";
+import { TestExecutionRepository, TestExecutionStatus, TestStepRecord } from "../db/testExecutionRepository";
+import { PlanSchemaValidator } from "../utils/plan/PlanSchemaValidator";
+import { normalizePlanDevices } from "../utils/plan/PlanDevices";
+
+type NormalizedPlanDevices = ReturnType<typeof normalizePlanDevices>;
+import { buildDeviceLabelMap, registerDeviceLabelMap } from "./deviceLabelMapping";
+import { importPlanFromYaml, executePlan } from "../utils/planUtils";
+import { DaemonState } from "../daemon/daemonState";
+import { AndroidSegmentedPlanVideoSession } from "./androidSegmentedPlanVideoSession";
+import {
+  startVideoRecording as defaultStartVideoRecording,
+  stopVideoRecording as defaultStopVideoRecording,
+} from "./videoRecordingManager";
+import { serverConfig } from "../utils/ServerConfig";
+import { defaultTimer, Timer } from "../utils/SystemTimer";
+import { logger } from "../utils/logger";
+import { ProgressCallback } from "./toolRegistry";
+import type { Plan } from "../models/Plan";
+
+/**
+ * Test metadata captured per-execution for the test-execution timing repository.
+ */
+export interface PlanExecutionTestMetadata {
+  testClass: string;
+  testMethod: string;
+  appVersion?: string;
+  gitCommit?: string;
+  targetSdk?: number;
+  jdkVersion?: string;
+  jvmTarget?: string;
+  gradleVersion?: string;
+  isCi?: boolean;
+}
+
+/**
+ * All parameters accepted by the executePlan MCP tool — modeled as a value object
+ * so the orchestrator's surface stays narrow and testable.
+ */
+export interface PlanExecutionRequest {
+  planContent: string;
+  startStep: number;
+  platform: Platform;
+  sessionUuid?: string;
+  keepScreenAwake?: boolean;
+  deviceId?: string;
+  device?: string;
+  devices?: string[];
+  deviceAllocationTimeoutMs: number;
+  abortStrategy?: "immediate" | "finish-current-step";
+  testMetadata?: PlanExecutionTestMetadata;
+  cleanupAppId?: string;
+  cleanupClearAppData?: boolean;
+  captureObserveSteps?: "summary" | "full";
+}
+
+/** Subset of videoRecordingManager APIs used by the orchestrator (so tests can inject fakes). */
+export interface VideoRecorder {
+  startVideoRecording: typeof defaultStartVideoRecording;
+  stopVideoRecording: typeof defaultStopVideoRecording;
+}
+
+/**
+ * Injectable dependencies for the orchestrator. Tests can swap any of these to
+ * exercise individual phases without spinning up a daemon or device pool.
+ *
+ * Production callers should pass an empty object — sensible defaults are wired up.
+ */
+export interface PlanExecutionDependencies {
+  /** Factory for the schema validator (lets tests skip schema loading). */
+  createSchemaValidator?: () => Pick<PlanSchemaValidator, "loadSchema" | "validateYaml">;
+  /** Repository used to record per-execution timing rows. */
+  testExecutionRepository?: TestExecutionRepository;
+  /** Clock + scheduled-task primitives, replaced by FakeTimer in tests. */
+  timer?: Timer;
+  /** Video recording manager surface — replaced by a fake in tests. */
+  videoRecorder?: VideoRecorder;
+}
+
+interface VideoState {
+  androidSession?: AndroidSegmentedPlanVideoSession;
+  iosRecordingId?: string;
+}
+
+interface FinalizedVideo {
+  videoFilePaths: string[];
+  videoRecordingIds: string[];
+}
+
+type ExecutionContext = {
+  device: BootedDevice;
+  request: PlanExecutionRequest;
+  progress?: ProgressCallback;
+  signal?: AbortSignal;
+};
+
+const HEARTBEAT_INTERVAL_MS = 30_000;
+const DEFAULT_IOS_VIDEO_MAX_DURATION_SECONDS = 300;
+
+const getDeviceType = (device: BootedDevice): "emulator" | "simulator" | "device" => {
+  if (device.platform === "android") {
+    return device.deviceId.startsWith("emulator-") ? "emulator" : "device";
+  }
+  return device.deviceId.includes("-") && device.deviceId.length > 30 ? "simulator" : "device";
+};
+
+const sharedTestExecutionRepository = new TestExecutionRepository();
+
+/**
+ * Converts debug step traces from PlanExecutor into the row shape expected by
+ * TestExecutionRepository. Exported for unit testing — used to be inlined.
+ */
+export function convertDebugStepsToRecords(
+  debugSteps: ExecutePlanStepDebugInfo[] | undefined
+): TestStepRecord[] {
+  if (!debugSteps || debugSteps.length === 0) {
+    return [];
+  }
+
+  return debugSteps.map((step, index) => {
+    const toolMatch = step.step.match(/:\s*(\w+)$/);
+    const action = toolMatch ? toolMatch[1] : step.step;
+
+    const details = step.details as { params?: Record<string, unknown>; error?: string } | undefined;
+    const params = details?.params;
+    let target: string | null = null;
+    if (params) {
+      if (params.text) {
+        target = `text="${params.text}"`;
+      } else if (params.elementId) {
+        target = `id="${params.elementId}"`;
+      } else if (params.direction) {
+        target = `direction=${params.direction}`;
+      }
+    }
+
+    return {
+      stepIndex: index,
+      action,
+      target,
+      status: step.status,
+      durationMs: step.durationMs,
+      screenName: null,
+      screenshotPath: null,
+      errorMessage: details?.error ?? null,
+      details: step.details,
+    };
+  });
+}
+
+/**
+ * Orchestrates a single executePlan invocation end-to-end.
+ *
+ * Phases (each is a private method, all tested in isolation):
+ *   1. {@link preparePlan} — base64 decode, schema validation, YAML parse, device-list reconcile
+ *   2. {@link allocateDevices} — multi-device upfront allocation with shared timeout
+ *   3. {@link startVideoRecording} — Android segmented OR iOS single-file recording
+ *   4. {@link runPlan} — delegates to planUtils.executePlan with the right options
+ *   5. {@link finalizeVideo} — stops/finalizes recording (always runs in finally)
+ *   6. {@link recordExecution} — writes a row to the test-execution timing DB
+ *
+ * The progress heartbeat (keeps SSE stream alive during long plans) and the
+ * top-level try/catch (so the tool always returns a structured response, never
+ * throws) wrap the whole sequence in {@link execute}.
+ */
+export class PlanExecutionOrchestrator {
+  private readonly device: BootedDevice;
+  private readonly request: PlanExecutionRequest;
+  private readonly progress?: ProgressCallback;
+  private readonly signal?: AbortSignal;
+  private readonly timer: Timer;
+  private readonly testExecutionRepository: TestExecutionRepository;
+  private readonly createSchemaValidator: () => Pick<PlanSchemaValidator, "loadSchema" | "validateYaml">;
+  private readonly videoRecorder: VideoRecorder;
+
+  // Set in execute(); used by all phase methods for [PERF +Xms] elapsed-time logs.
+  private perfStart = 0;
+  // Computed once in preparePlan(); reused by allocateDevices().
+  private normalizedDevices?: NormalizedPlanDevices;
+
+  constructor(context: ExecutionContext, deps: PlanExecutionDependencies = {}) {
+    this.device = context.device;
+    this.request = context.request;
+    this.progress = context.progress;
+    this.signal = context.signal;
+    this.timer = deps.timer ?? defaultTimer;
+    this.testExecutionRepository = deps.testExecutionRepository ?? sharedTestExecutionRepository;
+    this.createSchemaValidator = deps.createSchemaValidator ?? (() => new PlanSchemaValidator());
+    this.videoRecorder = deps.videoRecorder ?? {
+      startVideoRecording: defaultStartVideoRecording,
+      stopVideoRecording: defaultStopVideoRecording,
+    };
+  }
+
+  private perfLog(message: string): void {
+    logger.info(`[PERF +${this.timer.now() - this.perfStart}ms] ${message}`);
+  }
+
+  /**
+   * Run all phases, always returning a structured ExecutePlanResult.
+   * Never throws — failures are converted into `success: false` responses.
+   */
+  async execute(): Promise<ExecutePlanResult> {
+    const startTime = this.timer.now();
+    const stopHeartbeat = this.startProgressHeartbeat();
+
+    try {
+      this.perfStart = this.timer.now();
+      logger.info("=== Starting executePlanTool ===");
+      logger.info(
+        `[PERF +0ms] Device: ${this.device.platform} (${this.device.deviceId}), ` +
+        `Start Step: ${this.request.startStep}, SessionUUID: ${this.request.sessionUuid}`
+      );
+
+      const plan = await this.preparePlan();
+      const deviceMapping = await this.allocateDevices(plan);
+      const video = await this.startVideoRecording(plan);
+
+      let result: PlanExecutionResult | undefined;
+      let finalizedVideo: FinalizedVideo = { videoFilePaths: [], videoRecordingIds: [] };
+
+      try {
+        result = await this.runPlan(plan, video);
+      } finally {
+        serverConfig.setPlanExecutionActive(false);
+        finalizedVideo = await this.finalizeVideo(video);
+      }
+
+      if (!result) {
+        throw new Error("Plan execution failed without producing a result");
+      }
+
+      await this.recordExecution(result.success ? "passed" : "failed", startTime, {
+        steps: convertDebugStepsToRecords(result.debug?.steps),
+        errorMessage: result.failedStep?.error ?? undefined,
+        videoPath: finalizedVideo.videoFilePaths[0],
+      });
+
+      const response: ExecutePlanResult = {
+        success: result.success,
+        executedSteps: result.executedSteps,
+        totalSteps: result.totalSteps,
+        failedStep: result.failedStep,
+        error: result.failedStep ? result.failedStep.error : undefined,
+        platform: this.device.platform,
+        deviceId: this.device.deviceId,
+        deviceMapping,
+        ...(this.request.captureObserveSteps && result.debug ? { debug: result.debug } : {}),
+        ...(finalizedVideo.videoFilePaths.length > 0
+          ? {
+            videoFilePaths: finalizedVideo.videoFilePaths,
+            videoRecordingIds: finalizedVideo.videoRecordingIds,
+          }
+          : {}),
+      };
+
+      this.perfLog(`Returning from executePlanTool (deviceId=${this.device.deviceId})`);
+      return response;
+    } catch (error) {
+      logger.error(`[PERF] Failed to execute plan: ${error}`);
+
+      await this.recordExecution("failed", startTime, {
+        errorMessage: String(error),
+      });
+
+      const response: ExecutePlanResult = {
+        success: false,
+        executedSteps: 0,
+        totalSteps: 0,
+        error: `${error}`,
+        platform: this.device.platform,
+        deviceId: this.device.deviceId,
+      };
+
+      logger.info(`[PERF] Returning error from executePlanTool (deviceId=${this.device.deviceId})`);
+      return response;
+    } finally {
+      stopHeartbeat();
+    }
+  }
+
+  /**
+   * Decode (base64 if needed), validate schema, parse YAML, normalize devices,
+   * and reconcile any `devices` arg against the plan's own device declarations.
+   */
+  private async preparePlan(): Promise<Plan> {
+    let yamlContent = this.request.planContent;
+
+    if (yamlContent.startsWith("base64:")) {
+      this.perfLog("Decoding base64 plan content");
+      yamlContent = Buffer.from(yamlContent.substring(7), "base64").toString("utf-8");
+      this.perfLog(`Base64 content decoded (${yamlContent.length} bytes)`);
+    }
+
+    this.perfLog("Validating plan YAML schema");
+    const validator = this.createSchemaValidator();
+    await validator.loadSchema();
+    const validation = validator.validateYaml(yamlContent);
+    if (!validation.valid) {
+      const errorMessages = validation.errors?.map(err =>
+        `${err.field}: ${err.message}${err.line !== undefined ? ` (line ${err.line})` : ""}`
+      ).join("\n") || "Unknown validation error";
+
+      throw new ActionableError(
+        `Plan YAML validation failed:\n${errorMessages}\n\n` +
+        "The plan does not conform to the AutoMobile test plan schema. " +
+        "Check the schema at schemas/test-plan.schema.json for details."
+      );
+    }
+    this.perfLog("Plan YAML schema validation passed");
+
+    this.perfLog("Parsing plan from YAML");
+    const plan = importPlanFromYaml(yamlContent);
+    this.perfLog(`Plan parsed: '${plan.name}' with ${plan.steps.length} steps`);
+
+    this.normalizedDevices = normalizePlanDevices(plan.devices);
+    this.reconcileDeviceLists();
+    return plan;
+  }
+
+  private reconcileDeviceLists(): void {
+    const planDeviceLabels = this.normalizedDevices?.labels ?? [];
+    const provided = this.request.devices;
+
+    if (provided && planDeviceLabels.length > 0) {
+      const declaredSorted = [...new Set(planDeviceLabels)].sort();
+      const providedSorted = [...new Set(provided)].sort();
+      const same =
+        declaredSorted.length === providedSorted.length &&
+        declaredSorted.every((label, index) => label === providedSorted[index]);
+      if (!same) {
+        throw new ActionableError(
+          `Devices list does not match plan devices. ` +
+          `Plan devices: [${declaredSorted.join(", ")}], provided: [${providedSorted.join(", ")}].`
+        );
+      }
+    }
+  }
+
+  /**
+   * Allocate devices upfront for multi-device plans. Returns the label→deviceId
+   * mapping used in the final response, or undefined when this is a single-device
+   * plan with no labels.
+   */
+  private async allocateDevices(_plan: Plan): Promise<Record<string, string> | undefined> {
+    const normalized = this.normalizedDevices ?? { labels: [], hasDefinitions: false, definitions: [] };
+    const planDeviceLabels = normalized.labels;
+    const effectiveLabels = this.request.devices && this.request.devices.length > 0
+      ? this.request.devices
+      : planDeviceLabels;
+
+    if (!effectiveLabels || effectiveLabels.length === 0) {
+      if (this.request.device) {
+        throw new ActionableError("Device label requires a devices list to be provided.");
+      }
+      return undefined;
+    }
+
+    if (!this.request.sessionUuid) {
+      throw new ActionableError("Device labels require a sessionUuid to be provided.");
+    }
+    if (this.request.device && !effectiveLabels.includes(this.request.device)) {
+      throw new ActionableError(
+        `Device label '${this.request.device}' was not declared in devices list: ${effectiveLabels.join(", ")}`
+      );
+    }
+
+    this.perfLog("Allocating devices upfront");
+
+    if (!DaemonState.getInstance().isInitialized()) {
+      throw new ActionableError("Multi-device plans require an active daemon session.");
+    }
+
+    const devicePool = DaemonState.getInstance().getDevicePool();
+    const sessionManager = DaemonState.getInstance().getSessionManager();
+    const labelToSessionMap = buildDeviceLabelMap(effectiveLabels, this.request.sessionUuid, this.request.device);
+    const sessionIds = Object.values(labelToSessionMap);
+
+    logger.info(
+      `Requesting allocation of ${sessionIds.length} devices for labels: ${Object.keys(labelToSessionMap).join(", ")} ` +
+      `(timeout: ${this.request.deviceAllocationTimeoutMs / 1000}s)`
+    );
+
+    let sessionToDeviceMap: Map<string, string>;
+    if (normalized.hasDefinitions) {
+      const definitionMap = new Map(
+        normalized.definitions.map(definition => [definition.label, definition])
+      );
+      const requests = effectiveLabels.map(label => {
+        const definition = definitionMap.get(label);
+        if (!definition) {
+          throw new ActionableError(
+            `Device definition for label '${label}' not found in plan devices.`
+          );
+        }
+        return {
+          sessionId: labelToSessionMap[label],
+          criteria: {
+            platform: definition.platform,
+            simulatorType: definition.simulatorType,
+            iosVersion: definition.iosVersion,
+          },
+        };
+      });
+
+      sessionToDeviceMap = await devicePool.assignMultipleDevicesByCriteria(
+        requests,
+        this.request.deviceAllocationTimeoutMs
+      );
+    } else {
+      sessionToDeviceMap = await devicePool.assignMultipleDevices(
+        sessionIds,
+        this.request.deviceAllocationTimeoutMs,
+        this.request.platform
+      );
+    }
+
+    for (const sessionUuid of sessionToDeviceMap.keys()) {
+      if (!sessionManager.getSession(sessionUuid)) {
+        throw new ActionableError(
+          `Internal error: Session ${sessionUuid} not found after device allocation`
+        );
+      }
+    }
+
+    const deviceMapping: Record<string, string> = {};
+    for (const [label, sessionUuid] of Object.entries(labelToSessionMap)) {
+      const deviceId = sessionToDeviceMap.get(sessionUuid);
+      if (!deviceId) {
+        throw new ActionableError(
+          `Internal error: No device allocated for session ${sessionUuid} (label: ${label})`
+        );
+      }
+      deviceMapping[label] = deviceId;
+    }
+
+    this.perfLog("Device allocation complete");
+    for (const [label, deviceId] of Object.entries(deviceMapping)) {
+      const sessionUuid = labelToSessionMap[label];
+      this.perfLog(`  ${label} → ${deviceId} (session: ${sessionUuid})`);
+    }
+
+    await registerDeviceLabelMap(
+      this.request.sessionUuid,
+      effectiveLabels,
+      this.request.device,
+      { keepScreenAwake: this.request.keepScreenAwake, platform: this.request.platform }
+    );
+
+    return deviceMapping;
+  }
+
+  /**
+   * Start automatic plan video recording. Failures are logged and swallowed —
+   * a failing recording must never abort plan execution.
+   */
+  private async startVideoRecording(plan: Plan): Promise<VideoState> {
+    const videoOutputPrefix = `test-${plan.name}-${this.timer.now()}`;
+    const state: VideoState = {};
+
+    try {
+      this.perfLog("Starting automatic video recording for test");
+      if (this.device.platform === "android") {
+        const session = new AndroidSegmentedPlanVideoSession({
+          device: this.device,
+          outputNamePrefix: videoOutputPrefix,
+        });
+        await session.startFirstSegment();
+        state.androidSession = session;
+        this.perfLog("Android segmented video recording started");
+      } else {
+        const recording = await this.videoRecorder.startVideoRecording({
+          device: this.device,
+          outputName: videoOutputPrefix,
+          maxDurationSeconds: DEFAULT_IOS_VIDEO_MAX_DURATION_SECONDS,
+        });
+        state.iosRecordingId = recording.recordingId;
+        this.perfLog(`Video recording started: ${recording.recordingId}`);
+      }
+    } catch (videoError) {
+      logger.warn(`[PERF +${this.timer.now() - this.perfStart}ms] Failed to start automatic video recording: ${videoError}`);
+    }
+
+    return state;
+  }
+
+  private async runPlan(plan: Plan, video: VideoState): Promise<PlanExecutionResult> {
+    const planExecutionOptions = this.buildPlanExecutionOptions(video);
+    this.perfLog(`Starting plan execution on device ${this.device.deviceId} (${this.device.platform})`);
+    serverConfig.setPlanExecutionActive(true);
+    const result = await executePlan(
+      plan,
+      this.request.startStep,
+      this.request.platform,
+      this.device.deviceId,
+      this.request.sessionUuid,
+      this.signal,
+      this.request.abortStrategy,
+      planExecutionOptions
+    );
+    this.perfLog(
+      `Plan execution completed: ${result.success ? "SUCCESS" : "FAILED"} ` +
+      `(${result.executedSteps}/${result.totalSteps} steps)`
+    );
+    return result;
+  }
+
+  private buildPlanExecutionOptions(video: VideoState): PlanExecutionOptions | undefined {
+    const options: PlanExecutionOptions = {};
+    if (this.request.captureObserveSteps) {
+      options.captureObserveSteps = this.request.captureObserveSteps;
+    }
+    if (video.androidSession) {
+      options.onBeforePlanStep = video.androidSession.onBeforePlanStep;
+    }
+    return Object.keys(options).length > 0 ? options : undefined;
+  }
+
+  private async finalizeVideo(video: VideoState): Promise<FinalizedVideo> {
+    if (video.androidSession) {
+      return this.finalizeWithFallback(
+        "Finalizing segmented video recording",
+        "Failed to finalize segmented video",
+        async () => {
+          const finalized = await video.androidSession!.finalize();
+          this.perfLog(`Segmented video finalized (${finalized.filePaths.length} file(s))`);
+          return { videoFilePaths: finalized.filePaths, videoRecordingIds: finalized.recordingIds };
+        }
+      );
+    }
+    if (video.iosRecordingId) {
+      const recordingId = video.iosRecordingId;
+      return this.finalizeWithFallback(
+        `Stopping automatic video recording: ${recordingId}`,
+        "Failed to stop automatic video recording",
+        async () => {
+          const stopResult = await this.videoRecorder.stopVideoRecording(recordingId);
+          this.perfLog(`Video recording stopped successfully: ${stopResult.metadata.filePath}`);
+          return { videoFilePaths: [stopResult.metadata.filePath], videoRecordingIds: [recordingId] };
+        }
+      );
+    }
+    return { videoFilePaths: [], videoRecordingIds: [] };
+  }
+
+  private async finalizeWithFallback(
+    startMessage: string,
+    failureMessage: string,
+    finalize: () => Promise<FinalizedVideo>
+  ): Promise<FinalizedVideo> {
+    try {
+      this.perfLog(startMessage);
+      return await finalize();
+    } catch (videoError) {
+      logger.warn(`[PERF +${this.timer.now() - this.perfStart}ms] ${failureMessage}: ${videoError}`);
+      return { videoFilePaths: [], videoRecordingIds: [] };
+    }
+  }
+
+  private async recordExecution(
+    status: TestExecutionStatus,
+    startTime: number,
+    options?: {
+      steps?: TestStepRecord[];
+      errorMessage?: string;
+      videoPath?: string;
+    }
+  ): Promise<void> {
+    if (!this.request.testMetadata) {
+      return;
+    }
+    try {
+      await this.testExecutionRepository.recordExecution({
+        testClass: this.request.testMetadata.testClass,
+        testMethod: this.request.testMetadata.testMethod,
+        durationMs: this.timer.now() - startTime,
+        status,
+        timestamp: this.timer.now(),
+        deviceId: this.device.deviceId,
+        deviceName: this.device.name,
+        devicePlatform: this.device.platform,
+        deviceType: getDeviceType(this.device),
+        appVersion: this.request.testMetadata.appVersion,
+        gitCommit: this.request.testMetadata.gitCommit,
+        targetSdk: this.request.testMetadata.targetSdk,
+        jdkVersion: this.request.testMetadata.jdkVersion,
+        jvmTarget: this.request.testMetadata.jvmTarget,
+        gradleVersion: this.request.testMetadata.gradleVersion,
+        isCi: this.request.testMetadata.isCi,
+        sessionUuid: this.request.sessionUuid,
+        errorMessage: options?.errorMessage,
+        steps: options?.steps,
+        videoPath: options?.videoPath,
+      });
+    } catch (error) {
+      logger.warn(`Failed to record test execution timing: ${error}`);
+    }
+  }
+
+  /**
+   * Heartbeat keeps the SSE response stream alive during long plans (otherwise
+   * idle streams can be silently dropped, causing MCP client timeouts even on
+   * successful runs).
+   */
+  private startProgressHeartbeat(): () => void {
+    if (!this.progress) {
+      return () => {};
+    }
+    let stopped = false;
+    let count = 0;
+    const handle = this.timer.setInterval(() => {
+      if (stopped) { return; }
+      count++;
+      this.progress!(count, undefined, "executing").catch(err => {
+        logger.debug(`[executePlan] Progress heartbeat delivery failed: ${err}`);
+      });
+    }, HEARTBEAT_INTERVAL_MS);
+    return () => {
+      stopped = true;
+      this.timer.clearInterval(handle);
+    };
+  }
+}

--- a/src/server/planTools.ts
+++ b/src/server/planTools.ts
@@ -1,23 +1,14 @@
 import { z } from "zod";
 import { ToolRegistry, ProgressCallback } from "./toolRegistry";
-import { ActionableError, BootedDevice, ExecutePlanResult, PlanExecutionResult } from "../models";
-import { importPlanFromYaml, executePlan } from "../utils/planUtils";
+import { BootedDevice } from "../models";
 import { logger } from "../utils/logger";
 import { createStructuredToolResponse } from "../utils/toolUtils";
 import { Platform } from "../models";
-import { TestExecutionRepository, TestExecutionStatus, TestStepRecord } from "../db/testExecutionRepository";
 import { DEVICE_LABEL_DESCRIPTION } from "./toolSchemaHelpers";
-import { registerDeviceLabelMap, buildDeviceLabelMap } from "./deviceLabelMapping";
-import { PlanSchemaValidator } from "../utils/plan/PlanSchemaValidator";
-import { DaemonState } from "../daemon/daemonState";
-import { normalizePlanDevices } from "../utils/plan/PlanDevices";
-import { ExecutePlanStepDebugInfo } from "../models/ExecutePlanResult";
-import { startVideoRecording, stopVideoRecording } from "./videoRecordingManager";
-import { AndroidSegmentedPlanVideoSession } from "./androidSegmentedPlanVideoSession";
 import { startTestRecording, stopTestRecording, getTestRecordingStatus } from "./testRecordingManager";
 import { startMcpRecording, stopMcpRecording, getMcpRecordingStatus } from "./mcpRecordingManager";
 import { serverConfig } from "../utils/ServerConfig";
-import { defaultTimer } from "../utils/SystemTimer";
+import { PlanExecutionOrchestrator, PlanExecutionRequest } from "./planExecutionOrchestrator";
 
 const testMetadataSchema = z.object({
   testClass: z.string(),
@@ -30,8 +21,6 @@ const testMetadataSchema = z.object({
   gradleVersion: z.string().optional(),
   isCi: z.boolean().optional(),
 });
-
-type TestExecutionMetadata = z.infer<typeof testMetadataSchema>;
 
 // Execute plan tool schema
 const executePlanSchema = z.object({
@@ -91,445 +80,38 @@ const executePlanResultSchema = z.object({
   debug: executePlanDebugSchema.optional()
 }).passthrough();
 
-const testExecutionRepository = new TestExecutionRepository();
 
-const getDeviceType = (device: BootedDevice): "emulator" | "simulator" | "device" => {
-  if (device.platform === "android") {
-    return device.deviceId.startsWith("emulator-") ? "emulator" : "device";
-  }
-  return device.deviceId.includes("-") && device.deviceId.length > 30 ? "simulator" : "device";
-};
-
-// Execute plan from YAML file or content
-function convertDebugStepsToRecords(
-  debugSteps: ExecutePlanStepDebugInfo[] | undefined
-): TestStepRecord[] {
-  if (!debugSteps || debugSteps.length === 0) {
-    return [];
-  }
-
-  return debugSteps.map((step, index) => {
-    // Extract tool name from step description like "Execute step N: toolName"
-    const toolMatch = step.step.match(/:\s*(\w+)$/);
-    const action = toolMatch ? toolMatch[1] : step.step;
-
-    // Extract target from details.params if available
-    const details = step.details as { params?: Record<string, unknown>; error?: string } | undefined;
-    const params = details?.params;
-    let target: string | null = null;
-    if (params) {
-      // Try to build a target description from common params
-      if (params.text) {
-        target = `text="${params.text}"`;
-      } else if (params.elementId) {
-        target = `id="${params.elementId}"`;
-      } else if (params.direction) {
-        target = `direction=${params.direction}`;
-      }
-    }
-
-    return {
-      stepIndex: index,
-      action,
-      target,
-      status: step.status,
-      durationMs: step.durationMs,
-      screenName: null, // TODO: Track screen name during execution
-      screenshotPath: null, // TODO: Capture screenshots during execution
-      errorMessage: details?.error ?? null,
-      details: step.details,
-    };
+const executePlanTool = async (
+  device: BootedDevice,
+  params: {
+    planContent: string;
+    startStep: number;
+    platform: Platform;
+    sessionUuid?: string;
+    keepScreenAwake?: boolean;
+    deviceId?: string;
+    device?: string;
+    devices?: string[];
+    deviceAllocationTimeoutMs: number;
+    abortStrategy?: "immediate" | "finish-current-step";
+    testMetadata?: PlanExecutionRequest["testMetadata"];
+    cleanupAppId?: string;
+    cleanupClearAppData?: boolean;
+    captureObserveSteps?: "summary" | "full";
+  },
+  progress?: ProgressCallback,
+  signal?: AbortSignal
+): Promise<any> => {
+  const orchestrator = new PlanExecutionOrchestrator({
+    device,
+    request: params,
+    progress,
+    signal,
   });
-}
-
-const executePlanTool = async (device: BootedDevice, params: {
-  planContent: string;
-  startStep: number;
-  platform: Platform;
-  sessionUuid?: string;
-  keepScreenAwake?: boolean;
-  deviceId?: string;
-  device?: string;
-  devices?: string[];
-  deviceAllocationTimeoutMs: number;
-  abortStrategy?: "immediate" | "finish-current-step";
-  testMetadata?: TestExecutionMetadata;
-  cleanupAppId?: string;
-  cleanupClearAppData?: boolean;
-  captureObserveSteps?: "summary" | "full";
-}, progress?: ProgressCallback, signal?: AbortSignal): Promise<any> => {
-  const startTime = defaultTimer.now();
-
-  // Send periodic progress heartbeats to keep the SSE stream alive during
-  // long-running plan execution. Without these, the Streamable HTTP response
-  // stream can go idle and be silently dropped, causing the MCP client to
-  // time out even though the tool completed successfully.
-  let progressHeartbeatCount = 0;
-  let progressHeartbeatStopped = false;
-  const progressHeartbeat = progress
-    ? defaultTimer.setInterval(() => {
-      if (progressHeartbeatStopped) { return; }
-      progressHeartbeatCount++;
-      progress(progressHeartbeatCount, undefined, "executing").catch(err => {
-        logger.debug(`[executePlan] Progress heartbeat delivery failed: ${err}`);
-      });
-    }, 30_000)
-    : undefined;
-  const clearProgressHeartbeat = () => {
-    progressHeartbeatStopped = true;
-    if (progressHeartbeat) { defaultTimer.clearInterval(progressHeartbeat); }
-  };
-
-  const recordTestExecution = async (
-    status: TestExecutionStatus,
-    durationMs: number,
-    options?: {
-      steps?: TestStepRecord[];
-      errorMessage?: string;
-      videoPath?: string;
-    }
-  ) => {
-    if (!params.testMetadata) {
-      return;
-    }
-    try {
-      await testExecutionRepository.recordExecution({
-        testClass: params.testMetadata.testClass,
-        testMethod: params.testMetadata.testMethod,
-        durationMs,
-        status,
-        timestamp: defaultTimer.now(),
-        deviceId: device.deviceId,
-        deviceName: device.name,
-        devicePlatform: device.platform,
-        deviceType: getDeviceType(device),
-        appVersion: params.testMetadata.appVersion,
-        gitCommit: params.testMetadata.gitCommit,
-        targetSdk: params.testMetadata.targetSdk,
-        jdkVersion: params.testMetadata.jdkVersion,
-        jvmTarget: params.testMetadata.jvmTarget,
-        gradleVersion: params.testMetadata.gradleVersion,
-        isCi: params.testMetadata.isCi,
-        sessionUuid: params.sessionUuid,
-        errorMessage: options?.errorMessage,
-        steps: options?.steps,
-        videoPath: options?.videoPath,
-      });
-    } catch (error) {
-      logger.warn(`Failed to record test execution timing: ${error}`);
-    }
-  };
-
-  try {
-    const perfStart = defaultTimer.now();
-    logger.info("=== Starting executePlanTool ===");
-    logger.info(`[PERF +0ms] Device: ${device.platform} (${device.deviceId}), Start Step: ${params.startStep}, SessionUUID: ${params.sessionUuid}`);
-
-    let yamlContent = params.planContent;
-    const startStep = params.startStep;
-
-    // Decode base64 if content is base64-encoded
-    if (yamlContent.startsWith("base64:")) {
-      logger.info(`[PERF +${defaultTimer.now() - perfStart}ms] Decoding base64 plan content`);
-      const base64Content = yamlContent.substring(7); // Remove "base64:" prefix
-      yamlContent = Buffer.from(base64Content, "base64").toString("utf-8");
-      logger.info(`[PERF +${defaultTimer.now() - perfStart}ms] Base64 content decoded (${yamlContent.length} bytes)`);
-    }
-
-    // Validate YAML schema before parsing
-    logger.info(`[PERF +${defaultTimer.now() - perfStart}ms] Validating plan YAML schema`);
-    const validator = new PlanSchemaValidator();
-    await validator.loadSchema();
-    const validationResult = validator.validateYaml(yamlContent);
-
-    if (!validationResult.valid) {
-      const errorMessages = validationResult.errors?.map(err =>
-        `${err.field}: ${err.message}${err.line !== undefined ? ` (line ${err.line})` : ""}`
-      ).join("\n") || "Unknown validation error";
-
-      throw new ActionableError(
-        `Plan YAML validation failed:\n${errorMessages}\n\n` +
-        "The plan does not conform to the AutoMobile test plan schema. " +
-        "Check the schema at schemas/test-plan.schema.json for details."
-      );
-    }
-    logger.info(`[PERF +${defaultTimer.now() - perfStart}ms] Plan YAML schema validation passed`);
-
-    // Parse the plan
-    logger.info(`[PERF +${defaultTimer.now() - perfStart}ms] Parsing plan from YAML`);
-    const plan = importPlanFromYaml(yamlContent);
-    logger.info(`[PERF +${defaultTimer.now() - perfStart}ms] Plan parsed: '${plan.name}' with ${plan.steps.length} steps`);
-
-    const normalizedPlanDevices = normalizePlanDevices(plan.devices);
-    const planDeviceLabels = normalizedPlanDevices.labels;
-    const effectiveDeviceLabels = params.devices && params.devices.length > 0
-      ? params.devices
-      : planDeviceLabels;
-
-    if (params.devices && planDeviceLabels.length > 0) {
-      const declared = [...new Set(planDeviceLabels)].sort();
-      const provided = [...new Set(params.devices)].sort();
-      const sameLength = declared.length === provided.length;
-      const sameValues = sameLength && declared.every((label, index) => label === provided[index]);
-      if (!sameValues) {
-        throw new ActionableError(
-          `Devices list does not match plan devices. ` +
-          `Plan devices: [${declared.join(", ")}], provided: [${provided.join(", ")}].`
-        );
-      }
-    }
-
-    // Device allocation for multi-device plans
-    let deviceMapping: Record<string, string> | undefined;
-
-    if (effectiveDeviceLabels && effectiveDeviceLabels.length > 0) {
-      if (!params.sessionUuid) {
-        throw new ActionableError("Device labels require a sessionUuid to be provided.");
-      }
-      if (params.device && !effectiveDeviceLabels.includes(params.device)) {
-        throw new ActionableError(
-          `Device label '${params.device}' was not declared in devices list: ${effectiveDeviceLabels.join(", ")}`
-        );
-      }
-
-      // Upfront device allocation for fail-fast behavior
-      logger.info(`[PERF +${defaultTimer.now() - perfStart}ms] Allocating devices upfront`);
-
-      if (!DaemonState.getInstance().isInitialized()) {
-        throw new ActionableError("Multi-device plans require an active daemon session.");
-      }
-
-      const devicePool = DaemonState.getInstance().getDevicePool();
-      const sessionManager = DaemonState.getInstance().getSessionManager();
-
-      // Build device label map to get session UUIDs
-      const labelToSessionMap = buildDeviceLabelMap(effectiveDeviceLabels, params.sessionUuid, params.device);
-      const sessionIds = Object.values(labelToSessionMap);
-
-      logger.info(
-        `Requesting allocation of ${sessionIds.length} devices for labels: ${Object.keys(labelToSessionMap).join(", ")} ` +
-        `(timeout: ${params.deviceAllocationTimeoutMs / 1000}s)`
-      );
-
-      // Allocate all devices upfront with shared timeout
-      let sessionToDeviceMap: Map<string, string>;
-      if (normalizedPlanDevices.hasDefinitions) {
-        const definitionMap = new Map(
-          normalizedPlanDevices.definitions.map(definition => [definition.label, definition])
-        );
-        const requests = effectiveDeviceLabels.map(label => {
-          const definition = definitionMap.get(label);
-          if (!definition) {
-            throw new ActionableError(
-              `Device definition for label '${label}' not found in plan devices.`
-            );
-          }
-          return {
-            sessionId: labelToSessionMap[label],
-            criteria: {
-              platform: definition.platform,
-              simulatorType: definition.simulatorType,
-              iosVersion: definition.iosVersion,
-            },
-          };
-        });
-
-        sessionToDeviceMap = await devicePool.assignMultipleDevicesByCriteria(
-          requests,
-          params.deviceAllocationTimeoutMs
-        );
-      } else {
-        sessionToDeviceMap = await devicePool.assignMultipleDevices(
-          sessionIds,
-          params.deviceAllocationTimeoutMs,
-          params.platform
-        );
-      }
-
-      // Verify sessions were created in SessionManager for each allocated device
-      for (const sessionUuid of sessionToDeviceMap.keys()) {
-        // Device was already assigned in assignMultipleDevices via tryAssignDevice
-        // which calls sessionManager.createSession, so we just need to verify
-        const session = sessionManager.getSession(sessionUuid);
-        if (!session) {
-          throw new ActionableError(
-            `Internal error: Session ${sessionUuid} not found after device allocation`
-          );
-        }
-      }
-
-      // Build the device mapping for the result (label -> deviceId)
-      deviceMapping = {};
-      for (const [label, sessionUuid] of Object.entries(labelToSessionMap)) {
-        const deviceId = sessionToDeviceMap.get(sessionUuid);
-        if (!deviceId) {
-          throw new ActionableError(
-            `Internal error: No device allocated for session ${sessionUuid} (label: ${label})`
-          );
-        }
-        deviceMapping[label] = deviceId;
-      }
-
-      // Log the allocation result
-      logger.info(`[PERF +${defaultTimer.now() - perfStart}ms] Device allocation complete`);
-      for (const [label, deviceId] of Object.entries(deviceMapping)) {
-        const sessionUuid = labelToSessionMap[label];
-        logger.info(`[PERF +${defaultTimer.now() - perfStart}ms]   ${label} → ${deviceId} (session: ${sessionUuid})`);
-      }
-
-      // Register the device label map (sessions are already created, this just caches the mapping)
-      await registerDeviceLabelMap(
-        params.sessionUuid,
-        effectiveDeviceLabels,
-        params.device,
-        { keepScreenAwake: params.keepScreenAwake, platform: params.platform }
-      );
-    } else if (params.device) {
-      throw new ActionableError("Device label requires a devices list to be provided.");
-    }
-
-    // Start video recording for test plan execution (Android: segmented past screenrecord 180s cap)
-    const videoOutputPrefix = `test-${plan.name}-${defaultTimer.now()}`;
-    let androidVideoSession: AndroidSegmentedPlanVideoSession | undefined;
-    let iosVideoRecordingId: string | undefined;
-    try {
-      logger.info(`[PERF +${defaultTimer.now() - perfStart}ms] Starting automatic video recording for test`);
-      if (device.platform === "android") {
-        androidVideoSession = new AndroidSegmentedPlanVideoSession({
-          device,
-          outputNamePrefix: videoOutputPrefix,
-        });
-        await androidVideoSession.startFirstSegment();
-        logger.info(
-          `[PERF +${defaultTimer.now() - perfStart}ms] Android segmented video recording started`
-        );
-      } else {
-        const recording = await startVideoRecording({
-          device,
-          outputName: videoOutputPrefix,
-          maxDurationSeconds: 300,
-        });
-        iosVideoRecordingId = recording.recordingId;
-        logger.info(
-          `[PERF +${defaultTimer.now() - perfStart}ms] Video recording started: ${iosVideoRecordingId}`
-        );
-      }
-    } catch (videoError) {
-      logger.warn(`[PERF +${defaultTimer.now() - perfStart}ms] Failed to start automatic video recording: ${videoError}`);
-      androidVideoSession = undefined;
-      iosVideoRecordingId = undefined;
-    }
-
-    const planExecutionOptions =
-      params.captureObserveSteps || androidVideoSession
-        ? {
-          ...(params.captureObserveSteps
-            ? { captureObserveSteps: params.captureObserveSteps as const }
-            : {}),
-          ...(androidVideoSession
-            ? { onBeforePlanStep: androidVideoSession.onBeforePlanStep }
-            : {}),
-        }
-        : undefined;
-
-    // Execute the plan with device context, ensuring video recording is stopped in finally block
-    let result: PlanExecutionResult | undefined;
-    let videoFilePaths: string[] = [];
-    let videoRecordingIds: string[] = [];
-    try {
-      logger.info(`[PERF +${defaultTimer.now() - perfStart}ms] Starting plan execution on device ${device.deviceId} (${device.platform})`);
-      serverConfig.setPlanExecutionActive(true);
-      result = await executePlan(
-        plan,
-        startStep,
-        params.platform,
-        device.deviceId,
-        params.sessionUuid,
-        signal,
-        params.abortStrategy,
-        planExecutionOptions
-      );
-      const execDuration = defaultTimer.now() - perfStart;
-      logger.info(`[PERF +${execDuration}ms] Plan execution completed: ${result.success ? "SUCCESS" : "FAILED"} (${result.executedSteps}/${result.totalSteps} steps)`);
-    } finally {
-      serverConfig.setPlanExecutionActive(false);
-      if (androidVideoSession) {
-        try {
-          logger.info(`[PERF +${defaultTimer.now() - perfStart}ms] Finalizing segmented video recording`);
-          const finalized = await androidVideoSession.finalize();
-          videoFilePaths = finalized.filePaths;
-          videoRecordingIds = finalized.recordingIds;
-          logger.info(
-            `[PERF +${defaultTimer.now() - perfStart}ms] Segmented video finalized (${videoFilePaths.length} file(s))`
-          );
-        } catch (videoError) {
-          logger.warn(`[PERF +${defaultTimer.now() - perfStart}ms] Failed to finalize segmented video: ${videoError}`);
-        }
-      } else if (iosVideoRecordingId) {
-        try {
-          logger.info(`[PERF +${defaultTimer.now() - perfStart}ms] Stopping automatic video recording: ${iosVideoRecordingId}`);
-          const stopResult = await stopVideoRecording(iosVideoRecordingId);
-          videoFilePaths = [stopResult.metadata.filePath];
-          videoRecordingIds = [iosVideoRecordingId];
-          logger.info(`[PERF +${defaultTimer.now() - perfStart}ms] Video recording stopped successfully: ${stopResult.metadata.filePath}`);
-        } catch (videoError) {
-          logger.warn(`[PERF +${defaultTimer.now() - perfStart}ms] Failed to stop automatic video recording: ${videoError}`);
-        }
-      }
-    }
-
-    if (!result) {
-      throw new Error("Plan execution failed without producing a result");
-    }
-
-    // Capture step data and error message for recording
-    const steps = convertDebugStepsToRecords(result.debug?.steps);
-    const errorMessage = result.failedStep?.error ?? undefined;
-    const primaryVideoPath = videoFilePaths[0];
-
-    await recordTestExecution(result.success ? "passed" : "failed", defaultTimer.now() - startTime, {
-      steps,
-      errorMessage,
-      videoPath: primaryVideoPath,
-    });
-
-    const response: ExecutePlanResult = {
-      success: result.success,
-      executedSteps: result.executedSteps,
-      totalSteps: result.totalSteps,
-      failedStep: result.failedStep,
-      error: result.failedStep ? result.failedStep.error : undefined,
-      platform: device.platform,
-      deviceId: device.deviceId,
-      deviceMapping,
-      ...(params.captureObserveSteps && result.debug ? { debug: result.debug } : {}),
-      ...(videoFilePaths.length > 0 ? { videoFilePaths, videoRecordingIds } : {}),
-    };
-
-    logger.info(`[PERF +${defaultTimer.now() - perfStart}ms] Returning from executePlanTool (deviceId=${device.deviceId})`);
-    return createStructuredToolResponse(response);
-  } catch (error) {
-    logger.error(`[PERF] Failed to execute plan: ${error}`);
-
-    await recordTestExecution("failed", defaultTimer.now() - startTime, {
-      errorMessage: String(error),
-    });
-
-    const response: ExecutePlanResult = {
-      success: false,
-      executedSteps: 0,
-      totalSteps: 0,
-      error: `${error}`,
-      platform: device.platform,
-      deviceId: device.deviceId
-    };
-
-    logger.info(`[PERF] Returning error from executePlanTool (deviceId=${device.deviceId})`);
-    return createStructuredToolResponse(response);
-  } finally {
-    clearProgressHeartbeat();
-  }
+  const result = await orchestrator.execute();
+  return createStructuredToolResponse(result);
 };
+
 
 // Start test recording tool schema (empty - uses active device)
 const startTestRecordingSchema = z.object({});

--- a/test/server/planExecutionOrchestrator.test.ts
+++ b/test/server/planExecutionOrchestrator.test.ts
@@ -1,0 +1,316 @@
+import { describe, expect, test, beforeEach, mock } from "bun:test";
+import { FakeTimer } from "../fakes/FakeTimer";
+import type { BootedDevice } from "../../src/models";
+import type { TestExecutionRecord, TestExecutionRepository } from "../../src/db/testExecutionRepository";
+
+// Mock planUtils so the orchestrator's runPlan() phase is observable without
+// spinning up a real PlanExecutor. The companion test
+// planTools.executePlanThrow.test.ts mocks the same module — keep them compatible.
+const executePlanMock = mock(() =>
+  Promise.resolve({
+    success: true,
+    executedSteps: 2,
+    totalSteps: 2,
+    debug: { executionTimeMs: 100, steps: [] },
+  })
+);
+
+mock.module("../../src/utils/planUtils", () => {
+  const { YamlPlanSerializer } = require("../../src/utils/plan/PlanSerializer");
+  const serializer = new YamlPlanSerializer();
+  return {
+    importPlanFromYaml: serializer.importPlanFromYaml.bind(serializer),
+    exportPlanFromLogs: serializer.exportPlanFromLogs.bind(serializer),
+    executePlan: executePlanMock,
+  };
+});
+
+import { PlanExecutionOrchestrator, convertDebugStepsToRecords, VideoRecorder } from "../../src/server/planExecutionOrchestrator";
+
+const buildVideoRecorder = (
+  filePath: string = "/tmp/fake-recording.mp4",
+  recordingId: string = "rec-1"
+): VideoRecorder => ({
+  startVideoRecording: mock(() =>
+    Promise.resolve({ recordingId } as any)
+  ),
+  stopVideoRecording: mock(() =>
+    Promise.resolve({ metadata: { filePath } } as any)
+  ),
+});
+
+const iosDevice: BootedDevice = {
+  deviceId: "AAAA1111-BBBB-2222-CCCC-3333DDDD4444",
+  name: "iPhone 15 Sim",
+  platform: "ios",
+  status: "booted",
+};
+
+const SIMPLE_PLAN = `
+name: simple-test
+steps:
+  - tool: observe
+    params: {}
+`;
+
+class FakeTestExecutionRepository {
+  recorded: TestExecutionRecord[] = [];
+  async recordExecution(record: TestExecutionRecord): Promise<number> {
+    this.recorded.push(record);
+    return this.recorded.length;
+  }
+}
+
+const baseRequest = {
+  planContent: SIMPLE_PLAN,
+  startStep: 0,
+  platform: "ios" as const,
+  deviceAllocationTimeoutMs: 5000,
+};
+
+const baseDeps = () => ({
+  timer: new FakeTimer(),
+  videoRecorder: buildVideoRecorder(),
+});
+
+describe("PlanExecutionOrchestrator", () => {
+  beforeEach(() => {
+    executePlanMock.mockClear();
+  });
+
+  test("execute() returns a structured success result for a simple plan", async () => {
+    const orchestrator = new PlanExecutionOrchestrator(
+      { device: iosDevice, request: baseRequest },
+      baseDeps()
+    );
+    const result = await orchestrator.execute();
+
+    expect(result.success).toBe(true);
+    expect(result.executedSteps).toBe(2);
+    expect(result.totalSteps).toBe(2);
+    expect(result.platform).toBe("ios");
+    expect(result.deviceId).toBe(iosDevice.deviceId);
+    // captureObserveSteps is omitted so debug should NOT appear
+    expect(result.debug).toBeUndefined();
+    // Video paths are populated because the iOS recording stub succeeds
+    expect(result.videoFilePaths).toEqual(["/tmp/fake-recording.mp4"]);
+    expect(result.videoRecordingIds).toEqual(["rec-1"]);
+  });
+
+  test("execute() includes debug payload when captureObserveSteps is requested", async () => {
+    const orchestrator = new PlanExecutionOrchestrator(
+      { device: iosDevice, request: { ...baseRequest, captureObserveSteps: "summary" } },
+      baseDeps()
+    );
+    const result = await orchestrator.execute();
+
+    expect(result.success).toBe(true);
+    expect(result.debug).toEqual({ executionTimeMs: 100, steps: [] });
+  });
+
+  test("execute() rejects invalid YAML with a schema validation error", async () => {
+    const orchestrator = new PlanExecutionOrchestrator(
+      {
+        device: iosDevice,
+        request: { ...baseRequest, planContent: "not: a: valid: plan:\n  - missing" },
+      },
+      baseDeps()
+    );
+    const result = await orchestrator.execute();
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("Plan YAML validation failed");
+    // Should never bubble TS errors
+    expect(result.error ?? "").not.toContain("TypeError");
+  });
+
+  test("execute() decodes base64-prefixed plan content", async () => {
+    const encoded = "base64:" + Buffer.from(SIMPLE_PLAN, "utf-8").toString("base64");
+    const orchestrator = new PlanExecutionOrchestrator(
+      { device: iosDevice, request: { ...baseRequest, planContent: encoded } },
+      baseDeps()
+    );
+    const result = await orchestrator.execute();
+    expect(result.success).toBe(true);
+  });
+
+  test("execute() rejects mismatched devices arg vs plan device declarations", async () => {
+    // Plan declares devices [A, B], caller passes [A] — fail-fast.
+    const planWithDevices = `
+name: multi-device-test
+devices:
+  - A
+  - B
+steps:
+  - tool: observe
+    device: A
+    params: {}
+`;
+    const orchestrator = new PlanExecutionOrchestrator(
+      {
+        device: iosDevice,
+        request: { ...baseRequest, planContent: planWithDevices, devices: ["A"], sessionUuid: "s-1" },
+      },
+      baseDeps()
+    );
+    const result = await orchestrator.execute();
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("Devices list does not match plan devices");
+  });
+
+  test("execute() rejects device label without devices list", async () => {
+    const orchestrator = new PlanExecutionOrchestrator(
+      { device: iosDevice, request: { ...baseRequest, device: "A" } },
+      baseDeps()
+    );
+    const result = await orchestrator.execute();
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("Device label requires a devices list");
+  });
+
+  test("execute() records test execution to the repository when metadata is provided", async () => {
+    const fakeRepo = new FakeTestExecutionRepository();
+    const fakeTimer = new FakeTimer();
+
+    const orchestrator = new PlanExecutionOrchestrator(
+      {
+        device: iosDevice,
+        request: {
+          ...baseRequest,
+          testMetadata: { testClass: "FooTest", testMethod: "shouldPass" },
+        },
+      },
+      { ...baseDeps(), timer: fakeTimer, testExecutionRepository: fakeRepo as unknown as TestExecutionRepository }
+    );
+
+    const result = await orchestrator.execute();
+    expect(result.success).toBe(true);
+    expect(fakeRepo.recorded).toHaveLength(1);
+    expect(fakeRepo.recorded[0].testClass).toBe("FooTest");
+    expect(fakeRepo.recorded[0].testMethod).toBe("shouldPass");
+    expect(fakeRepo.recorded[0].status).toBe("passed");
+    expect(fakeRepo.recorded[0].deviceId).toBe(iosDevice.deviceId);
+    expect(fakeRepo.recorded[0].videoPath).toBe("/tmp/fake-recording.mp4");
+  });
+
+  test("execute() skips recording when no testMetadata is provided", async () => {
+    const fakeRepo = new FakeTestExecutionRepository();
+    const orchestrator = new PlanExecutionOrchestrator(
+      { device: iosDevice, request: baseRequest },
+      { ...baseDeps(), testExecutionRepository: fakeRepo as unknown as TestExecutionRepository }
+    );
+    await orchestrator.execute();
+    expect(fakeRepo.recorded).toHaveLength(0);
+  });
+
+  test("execute() records 'failed' status when executePlan fails", async () => {
+    const failingExecutePlan = executePlanMock;
+    failingExecutePlan.mockImplementationOnce(() =>
+      Promise.resolve({
+        success: false,
+        executedSteps: 1,
+        totalSteps: 2,
+        failedStep: { stepIndex: 1, tool: "tapOn", error: "element not found" },
+      })
+    );
+    const fakeRepo = new FakeTestExecutionRepository();
+    const orchestrator = new PlanExecutionOrchestrator(
+      {
+        device: iosDevice,
+        request: {
+          ...baseRequest,
+          testMetadata: { testClass: "FooTest", testMethod: "shouldFail" },
+        },
+      },
+      { ...baseDeps(), testExecutionRepository: fakeRepo as unknown as TestExecutionRepository }
+    );
+    const result = await orchestrator.execute();
+    expect(result.success).toBe(false);
+    expect(result.error).toBe("element not found");
+    expect(fakeRepo.recorded[0].status).toBe("failed");
+    expect(fakeRepo.recorded[0].errorMessage).toBe("element not found");
+  });
+
+  test("repository write errors are logged and do not crash the run", async () => {
+    const exploding = {
+      recordExecution: () => Promise.reject(new Error("db down")),
+    };
+    const orchestrator = new PlanExecutionOrchestrator(
+      {
+        device: iosDevice,
+        request: {
+          ...baseRequest,
+          testMetadata: { testClass: "FooTest", testMethod: "shouldNotCrash" },
+        },
+      },
+      { timer: new FakeTimer(), testExecutionRepository: exploding as unknown as TestExecutionRepository }
+    );
+    const result = await orchestrator.execute();
+    // Even though recording failed, the plan itself succeeded.
+    expect(result.success).toBe(true);
+  });
+});
+
+describe("convertDebugStepsToRecords", () => {
+  test("returns empty array for undefined / empty input", () => {
+    expect(convertDebugStepsToRecords(undefined)).toEqual([]);
+    expect(convertDebugStepsToRecords([])).toEqual([]);
+  });
+
+  test("extracts the tool name from 'Execute step N: toolName' style descriptions", () => {
+    const records = convertDebugStepsToRecords([
+      { step: "Execute step 0: tapOn", status: "completed", durationMs: 12 },
+      { step: "Execute step 1: observe", status: "completed", durationMs: 50 },
+    ]);
+    expect(records[0].action).toBe("tapOn");
+    expect(records[1].action).toBe("observe");
+    expect(records[0].stepIndex).toBe(0);
+    expect(records[1].stepIndex).toBe(1);
+  });
+
+  test("builds a target string from common params", () => {
+    const records = convertDebugStepsToRecords([
+      {
+        step: "Execute step 0: tapOn",
+        status: "completed",
+        durationMs: 12,
+        details: { params: { text: "Submit" } },
+      },
+      {
+        step: "Execute step 1: tapOn",
+        status: "completed",
+        durationMs: 9,
+        details: { params: { elementId: "submit-btn" } },
+      },
+      {
+        step: "Execute step 2: swipeOn",
+        status: "completed",
+        durationMs: 100,
+        details: { params: { direction: "up" } },
+      },
+    ]);
+    expect(records[0].target).toBe('text="Submit"');
+    expect(records[1].target).toBe('id="submit-btn"');
+    expect(records[2].target).toBe("direction=up");
+  });
+
+  test("falls back to the raw step string when no ':' suffix is present", () => {
+    const records = convertDebugStepsToRecords([
+      { step: "custom-step-name", status: "skipped", durationMs: 0 },
+    ]);
+    expect(records[0].action).toBe("custom-step-name");
+    expect(records[0].target).toBeNull();
+  });
+
+  test("propagates error messages from details", () => {
+    const records = convertDebugStepsToRecords([
+      {
+        step: "Execute step 0: tapOn",
+        status: "failed",
+        durationMs: 12,
+        details: { error: "element not found" },
+      },
+    ]);
+    expect(records[0].errorMessage).toBe("element not found");
+  });
+});


### PR DESCRIPTION
## Summary

- The `executePlanTool` MCP handler had accumulated ~400 lines of orchestration logic (YAML decode, schema validation, device allocation, video recording setup, progress heartbeat, plan execution, video finalization, test-timing DB writes) interleaved with nested try/catch/finally blocks. This PR pulls that orchestration into a dedicated `PlanExecutionOrchestrator` class with named phase methods.
- `src/server/planTools.ts`: **751 → 333 lines** (executePlan handler is now a thin wrapper that builds the orchestrator and returns its result).
- New `src/server/planExecutionOrchestrator.ts` with one method per phase: `preparePlan`, `allocateDevices`, `startVideoRecording`, `runPlan`, `finalizeVideo`, `recordExecution`. Dependencies (schema validator factory, test-execution repository, `Timer`, video recorder) are injectable so each phase is unit-testable without a daemon or real device.

## Why

- The handler was the largest "fat" MCP tool surfaced in a recent survey — multiple platform branches, retry loops, and error-recovery sequences sat inline alongside the schema parsing.
- Pulling the orchestration into a class means future work (more recording strategies, richer cleanup, alternate execution backends) doesn't keep growing the MCP wiring layer.
- Each phase is now individually unit-testable; previously only one error-path integration test (`planTools.executePlanThrow.test.ts`) covered the entire 400-line handler.

## Test plan

- [x] `bun test test/server/planExecutionOrchestrator.test.ts` — 15 new unit tests covering happy path, debug payload toggling, base64 decode, schema validation errors, device-list reconciliation, repository success/failure handling.
- [x] `bun test test/server/planTools.executePlanThrow.test.ts` — existing throw-path test still passes against the new orchestrator (no behavior change).
- [x] `bunx turbo run lint build` — clean.
- [x] `bun test` — 4070 pass (1 unrelated flake in `RestoreSnapshotIos.test.ts` that passes in isolation).