### PR TITLE
fix(proxy): add missing APK_SHA256_CHECKSUM import

### DIFF
--- a/src/utils/CtrlProxyManager.ts
+++ b/src/utils/CtrlProxyManager.ts
@@ -5,6 +5,7 @@ import * as fs from "fs/promises";
 import * as path from "path";
 import { BootedDevice } from "../models";
 import {
+  APK_SHA256_CHECKSUM,
   APK_URL,
   RELEASE_VERSION,
   resolveChecksum


### PR DESCRIPTION
## Summary
- `doPrefetch()` referenced `APK_SHA256_CHECKSUM` at `src/utils/CtrlProxyManager.ts:226` without importing it, leaving the identifier as an undefined free variable. TypeScript was reporting this as `TS2304` and ts-prune was flagging the constant as unused.
- Existing tests passed because every test path sets `expectedChecksumOverride` via `setExpectedChecksumForTesting`, which short-circuits the `??` fallback. In production, the fallback would throw `ReferenceError`.
- Adds the missing import. Part of cleanup pass on dead-code issue #1874.

## Test plan
- [x] \`bun test test/utils/CtrlProxyManager.test.ts\` passes (55 pass).
- [x] \`bun run dead-code:ts:prune\` no longer flags \`APK_SHA256_CHECKSUM\`.
- [x] \`tsc --noEmit\` no longer reports \`TS2304\` on line 226.