### PR TITLE
fix(vision): wrap JSON.parse in ClaudeVisionClient with controlled error

### DIFF
--- a/src/vision/ClaudeVisionClient.ts
+++ b/src/vision/ClaudeVisionClient.ts
@@ -188,7 +188,14 @@ export class ClaudeVisionClient {
     }
 
     const jsonStr = jsonMatch[1] || jsonMatch[0];
-    const parsed = JSON.parse(jsonStr);
+    let parsed: any;
+    try {
+      parsed = JSON.parse(jsonStr);
+    } catch (err) {
+      throw new Error(
+        `Failed to parse JSON from Claude response: ${(err as Error).message}`
+      );
+    }
 
     return {
       elementFound: parsed.elementFound || false,

--- a/test/vision/ClaudeVisionClient.test.ts
+++ b/test/vision/ClaudeVisionClient.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, test } from "bun:test";
+import { ClaudeVisionClient } from "../../src/vision/ClaudeVisionClient";
+
+const makeClient = () => new ClaudeVisionClient("test-key-not-used");
+
+const makeResponse = (text: string) =>
+  ({ content: [{ type: "text", text }] } as any);
+
+const callParse = (client: ClaudeVisionClient, response: unknown) =>
+  (client as any).parseClaudeResponse(response);
+
+describe("ClaudeVisionClient.parseClaudeResponse", () => {
+  test("throws a controlled error when JSON inside a code block is malformed", () => {
+    const client = makeClient();
+    const response = makeResponse("```json\n{ \"elementFound\": tr,\n```");
+
+    expect(() => callParse(client, response)).toThrow(
+      /Failed to parse JSON from Claude response/
+    );
+  });
+
+  test("throws a controlled error when JSON outside a code block is malformed", () => {
+    const client = makeClient();
+    const response = makeResponse("here is a result: { not valid json at all }");
+
+    expect(() => callParse(client, response)).toThrow(
+      /Failed to parse JSON from Claude response/
+    );
+  });
+
+  test("throws when no JSON match is present in the response", () => {
+    const client = makeClient();
+    const response = makeResponse("Claude returned only prose, no JSON here.");
+
+    expect(() => callParse(client, response)).toThrow(
+      /Failed to parse JSON from Claude response/
+    );
+  });
+
+  test("parses well-formed JSON inside a fenced code block", () => {
+    const client = makeClient();
+    const response = makeResponse(
+      "```json\n{\"elementFound\": true, \"confidence\": 0.95, \"reasoning\": \"ok\"}\n```"
+    );
+
+    const parsed = callParse(client, response);
+
+    expect(parsed.elementFound).toBe(true);
+    expect(parsed.confidence).toBe(0.95);
+    expect(parsed.reasoning).toBe("ok");
+  });
+});


### PR DESCRIPTION
## Summary

- `parseClaudeResponse` in `ClaudeVisionClient` calls `JSON.parse` on the regex-extracted JSON block without a try/catch. Any malformed or truncated LLM output throws a raw `SyntaxError` out of the MCP request, aborting the active turn with an opaque message.
- Wraps the `JSON.parse` in try/catch and rethrows a typed `Error("Failed to parse JSON from Claude response: …")` that includes the underlying `SyntaxError.message`, so callers and logs can distinguish parse failures from missing-JSON failures (which already throw a similar error from the `!jsonMatch` arm above).
- Adds `test/vision/ClaudeVisionClient.test.ts` covering malformed JSON in both fenced (` ```json `) and bare `{…}` blocks, the no-match path, and a well-formed happy path.

Bug reference: bug #1 from `/find-bugs` triage (2026-05-19).

## Test plan

- [x] `bun test test/vision/ClaudeVisionClient.test.ts` — 4 pass in 35 ms
- [x] `bun test test/vision/` — 12 pass in 34 ms (no regression in `applyVisionFallback`)
- [x] `bun build.ts` — green
- [x] Tests fail without the fix (regex requires `Failed to parse JSON from Claude response` in the thrown message; raw `SyntaxError` doesn't match)