### PR TITLE
feat(android): emulator telephony and SMS simulation

### DIFF
--- a/schemas/tool-definitions.json
+++ b/schemas/tool-definitions.json
@@ -3968,6 +3968,59 @@
     }
   },
   {
+    "name": "phoneCall",
+    "description": "Simulate an incoming phone call on an Android emulator via the emulator console (gsm call/accept/cancel/busy/hold). Emulator-only: physical devices return an unsupported error.",
+    "inputSchema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "type": "object",
+      "properties": {
+        "action": {
+          "type": "string",
+          "enum": [
+            "call",
+            "accept",
+            "cancel",
+            "busy",
+            "hold"
+          ],
+          "description": "Phone call action: 'call' simulates an incoming call; 'accept' answers a ringing or waiting call; 'cancel' ends the call from the network side; 'busy' rejects a waiting call with a busy signal; 'hold' puts the active call on hold (no phoneNumber required)."
+        },
+        "phoneNumber": {
+          "description": "Phone number for the call action. Required for all actions except 'hold'. Digits with optional leading '+', max 20 digits.",
+          "type": "string"
+        },
+        "platform": {
+          "type": "string",
+          "enum": [
+            "android",
+            "ios"
+          ],
+          "description": "Target platform"
+        },
+        "sessionUuid": {
+          "description": "Session UUID",
+          "type": "string"
+        },
+        "keepScreenAwake": {
+          "description": "Keep device awake",
+          "type": "boolean"
+        },
+        "device": {
+          "description": "Device label for multi-device plans (e.g., \"A\", \"B\")",
+          "type": "string"
+        },
+        "deviceId": {
+          "description": "Device ID",
+          "type": "string"
+        }
+      },
+      "required": [
+        "action"
+      ],
+      "additionalProperties": false
+    }
+  },
+  {
     "name": "pinchOn",
     "description": "Pinch to zoom",
     "inputSchema": {
@@ -4409,6 +4462,53 @@
       },
       "required": [
         "platform"
+      ],
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "sendSms",
+    "description": "Send a simulated incoming SMS to an Android emulator via the emulator console (sms send). Emulator-only: physical devices return an unsupported error.",
+    "inputSchema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "type": "object",
+      "properties": {
+        "phoneNumber": {
+          "type": "string",
+          "description": "Sender phone number for the simulated incoming SMS. Digits with optional leading '+', max 20 digits."
+        },
+        "message": {
+          "type": "string",
+          "description": "SMS message body. Max 1024 characters. Must not contain newlines, carriage returns, or NUL bytes."
+        },
+        "platform": {
+          "type": "string",
+          "enum": [
+            "android",
+            "ios"
+          ],
+          "description": "Target platform"
+        },
+        "sessionUuid": {
+          "description": "Session UUID",
+          "type": "string"
+        },
+        "keepScreenAwake": {
+          "description": "Keep device awake",
+          "type": "boolean"
+        },
+        "device": {
+          "description": "Device label for multi-device plans (e.g., \"A\", \"B\")",
+          "type": "string"
+        },
+        "deviceId": {
+          "description": "Device ID",
+          "type": "string"
+        }
+      },
+      "required": [
+        "phoneNumber",
+        "message"
       ],
       "additionalProperties": false
     }

--- a/scripts/generate-tool-definitions.ts
+++ b/scripts/generate-tool-definitions.ts
@@ -23,6 +23,7 @@ import { registerCriticalSectionTools } from "../src/server/criticalSectionTools
 import { registerVideoRecordingTools } from "../src/server/videoRecordingTools";
 import { registerSnapshotTools } from "../src/server/snapshotTools";
 import { registerBiometricTools } from "../src/server/biometricTools";
+import { registerTelephonyTools } from "../src/server/telephonyTools";
 import { registerHighlightTools } from "../src/server/highlightTools";
 import { registerDebugTools } from "../src/server/debugTools";
 
@@ -43,6 +44,7 @@ function registerAllTools(): void {
   registerVideoRecordingTools();
   registerSnapshotTools();
   registerBiometricTools();
+  registerTelephonyTools();
   registerHighlightTools();
   registerDebugTools();
 }

--- a/src/features/action/Telephony.ts
+++ b/src/features/action/Telephony.ts
@@ -1,0 +1,196 @@
+import {
+  BootedDevice,
+  PhoneCallAction,
+  PhoneCallResult,
+  SendSmsResult
+} from "../../models";
+import {
+  EmulatorConsoleClient,
+  RealEmulatorConsoleClient,
+  FileEmulatorConsoleAuthTokenReader,
+  NetEmulatorConsoleTransport,
+  consolePortFromSerial
+} from "../../utils/android-cmdline-tools/EmulatorConsoleClient";
+import { AdbClientFactory, defaultAdbClientFactory } from "../../utils/android-cmdline-tools/AdbClientFactory";
+import type { AdbExecutor } from "../../utils/android-cmdline-tools/interfaces/AdbExecutor";
+import { logger } from "../../utils/logger";
+
+/**
+ * Factory for building an EmulatorConsoleClient for a specific emulator console port.
+ * Injectable so tests can substitute a fake without hitting the network.
+ */
+export type EmulatorConsoleClientFactory = (port: number) => EmulatorConsoleClient;
+
+export const defaultEmulatorConsoleClientFactory: EmulatorConsoleClientFactory = (port: number) =>
+  new RealEmulatorConsoleClient(
+    port,
+    new NetEmulatorConsoleTransport(),
+    new FileEmulatorConsoleAuthTokenReader()
+  );
+
+export interface PhoneCallOptions {
+  action: PhoneCallAction;
+  phoneNumber?: string;
+}
+
+export interface SendSmsOptions {
+  phoneNumber: string;
+  message: string;
+}
+
+export class Telephony {
+  private readonly adb: AdbExecutor;
+
+  constructor(
+    private readonly device: BootedDevice,
+    adbFactoryOrExecutor: AdbClientFactory | AdbExecutor | null = defaultAdbClientFactory,
+    private readonly consoleFactory: EmulatorConsoleClientFactory = defaultEmulatorConsoleClientFactory
+  ) {
+    if (adbFactoryOrExecutor && typeof (adbFactoryOrExecutor as AdbClientFactory).create === "function") {
+      this.adb = (adbFactoryOrExecutor as AdbClientFactory).create(device);
+    } else if (adbFactoryOrExecutor) {
+      this.adb = adbFactoryOrExecutor as AdbExecutor;
+    } else {
+      this.adb = defaultAdbClientFactory.create(device);
+    }
+  }
+
+  async phoneCall(options: PhoneCallOptions): Promise<PhoneCallResult> {
+    const platformError = this.requireAndroid<PhoneCallResult>(() => ({
+      success: false,
+      action: options.action,
+      phoneNumber: options.phoneNumber,
+      supported: false,
+      error: "Emulator telephony is only supported on Android emulators"
+    }));
+    if (platformError) { return platformError; }
+
+    if (options.action !== "hold" && !options.phoneNumber) {
+      return {
+        success: false,
+        action: options.action,
+        supported: true,
+        error: `phoneNumber is required for action '${options.action}'`
+      };
+    }
+
+    const client = await this.resolveClient<PhoneCallResult>(() => ({
+      success: false,
+      action: options.action,
+      phoneNumber: options.phoneNumber,
+      supported: false,
+      error: this.unsupportedDeviceMessage()
+    }));
+    if ("error" in client) { return client.error; }
+
+    try {
+      switch (options.action) {
+        case "call":   await client.value.gsmCall(options.phoneNumber!);   break;
+        case "accept": await client.value.gsmAccept(options.phoneNumber!); break;
+        case "cancel": await client.value.gsmCancel(options.phoneNumber!); break;
+        case "busy":   await client.value.gsmBusy(options.phoneNumber!);   break;
+        case "hold":   await client.value.gsmHold();                       break;
+      }
+      return {
+        success: true,
+        action: options.action,
+        phoneNumber: options.phoneNumber,
+        supported: true,
+        message: this.phoneCallSuccessMessage(options)
+      };
+    } catch (error) {
+      return {
+        success: false,
+        action: options.action,
+        phoneNumber: options.phoneNumber,
+        supported: true,
+        error: error instanceof Error ? error.message : String(error)
+      };
+    }
+  }
+
+  async sendSms(options: SendSmsOptions): Promise<SendSmsResult> {
+    const platformError = this.requireAndroid<SendSmsResult>(() => ({
+      success: false,
+      phoneNumber: options.phoneNumber,
+      messageLength: options.message?.length ?? 0,
+      supported: false,
+      error: "Emulator telephony is only supported on Android emulators"
+    }));
+    if (platformError) { return platformError; }
+
+    const client = await this.resolveClient<SendSmsResult>(() => ({
+      success: false,
+      phoneNumber: options.phoneNumber,
+      messageLength: options.message?.length ?? 0,
+      supported: false,
+      error: this.unsupportedDeviceMessage()
+    }));
+    if ("error" in client) { return client.error; }
+
+    try {
+      await client.value.smsSend(options.phoneNumber, options.message);
+      return {
+        success: true,
+        phoneNumber: options.phoneNumber,
+        messageLength: options.message.length,
+        supported: true,
+        message: `Delivered simulated SMS from ${options.phoneNumber} (${options.message.length} chars)`
+      };
+    } catch (error) {
+      return {
+        success: false,
+        phoneNumber: options.phoneNumber,
+        messageLength: options.message.length,
+        supported: true,
+        error: error instanceof Error ? error.message : String(error)
+      };
+    }
+  }
+
+  private requireAndroid<T>(build: () => T): T | null {
+    if (this.device.platform !== "android") {
+      return build();
+    }
+    return null;
+  }
+
+  private async resolveClient<T>(buildError: () => T): Promise<{ value: EmulatorConsoleClient } | { error: T }> {
+    const port = consolePortFromSerial(this.device.deviceId);
+    if (port === null) {
+      return { error: buildError() };
+    }
+    const isEmulator = await this.isEmulator();
+    if (!isEmulator) {
+      return { error: buildError() };
+    }
+    return { value: this.consoleFactory(port) };
+  }
+
+  private async isEmulator(): Promise<boolean> {
+    try {
+      const result = await this.adb.executeCommand("shell getprop ro.kernel.qemu");
+      return result.stdout.trim() === "1";
+    } catch (error) {
+      logger.warn(`Telephony: failed to probe emulator state for ${this.device.deviceId}: ${error}`);
+      return false;
+    }
+  }
+
+  private unsupportedDeviceMessage(): string {
+    return (
+      `Device '${this.device.deviceId}' does not appear to be an Android emulator. ` +
+      `Emulator console telephony (gsm/sms) is only available on emulators with serials of the form 'emulator-<port>'.`
+    );
+  }
+
+  private phoneCallSuccessMessage(options: PhoneCallOptions): string {
+    switch (options.action) {
+      case "call":   return `Simulated incoming call from ${options.phoneNumber}`;
+      case "accept": return `Accepted call ${options.phoneNumber}`;
+      case "cancel": return `Cancelled call ${options.phoneNumber}`;
+      case "busy":   return `Rejected call ${options.phoneNumber} with busy signal`;
+      case "hold":   return "Put active call on hold";
+    }
+  }
+}

--- a/src/models/TelephonyResult.ts
+++ b/src/models/TelephonyResult.ts
@@ -1,0 +1,19 @@
+export type PhoneCallAction = "call" | "accept" | "cancel" | "busy" | "hold";
+
+export interface PhoneCallResult {
+  success: boolean;
+  action: PhoneCallAction;
+  phoneNumber?: string;
+  supported: boolean;
+  message?: string;
+  error?: string;
+}
+
+export interface SendSmsResult {
+  success: boolean;
+  phoneNumber: string;
+  messageLength: number;
+  supported: boolean;
+  message?: string;
+  error?: string;
+}

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -79,6 +79,7 @@ export * from "./TapOnElementOptions";
 export * from "./TapOnElementResult";
 export * from "./TapOptions";
 export * from "./TapResult";
+export * from "./TelephonyResult";
 export * from "./TerminateAppResult";
 export * from "./TouchIdleResult";
 export * from "./TraversalOrderResult";

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -33,6 +33,7 @@ import { registerCriticalSectionTools } from "./criticalSectionTools";
 import { registerVideoRecordingTools } from "./videoRecordingTools";
 import { registerSnapshotTools } from "./snapshotTools";
 import { registerBiometricTools } from "./biometricTools";
+import { registerTelephonyTools } from "./telephonyTools";
 import { registerHighlightTools } from "./highlightTools";
 import { registerDatabaseTools } from "./databaseTools";
 import { registerStorageTools } from "./storageTools";
@@ -152,6 +153,7 @@ export const createMcpServer = (options: McpServerOptions = {}): McpServer => {
   registerVideoRecordingTools();
   registerSnapshotTools();
   registerBiometricTools();
+  registerTelephonyTools();
   registerHighlightTools();
   registerDatabaseTools();
   registerStorageTools();

--- a/src/server/telephonyTools.ts
+++ b/src/server/telephonyTools.ts
@@ -1,0 +1,86 @@
+import { z } from "zod";
+import { ToolRegistry, ProgressCallback } from "./toolRegistry";
+import { Telephony, PhoneCallOptions, SendSmsOptions } from "../features/action/Telephony";
+import { ActionableError, BootedDevice } from "../models";
+import { createJSONToolResponse } from "../utils/toolUtils";
+import { addDeviceTargetingToSchema } from "./toolSchemaHelpers";
+
+export const phoneCallSchema = addDeviceTargetingToSchema(z.object({
+  action: z.enum(["call", "accept", "cancel", "busy", "hold"]).describe(
+    "Phone call action: 'call' simulates an incoming call; 'accept' answers a ringing or waiting call; " +
+    "'cancel' ends the call from the network side; 'busy' rejects a waiting call with a busy signal; " +
+    "'hold' puts the active call on hold (no phoneNumber required)."
+  ),
+  phoneNumber: z.string().optional().describe(
+    "Phone number for the call action. Required for all actions except 'hold'. " +
+    "Digits with optional leading '+', max 20 digits."
+  )
+}));
+
+export const sendSmsSchema = addDeviceTargetingToSchema(z.object({
+  phoneNumber: z.string().describe(
+    "Sender phone number for the simulated incoming SMS. Digits with optional leading '+', max 20 digits."
+  ),
+  message: z.string().describe(
+    "SMS message body. Max 1024 characters. Must not contain newlines, carriage returns, or NUL bytes."
+  )
+}));
+
+export interface PhoneCallArgs extends PhoneCallOptions {}
+export interface SendSmsArgs extends SendSmsOptions {}
+
+export function registerTelephonyTools() {
+  const phoneCallHandler = async (
+    device: BootedDevice,
+    args: PhoneCallArgs,
+    _progress?: ProgressCallback
+  ) => {
+    const telephony = new Telephony(device);
+    const result = await telephony.phoneCall({
+      action: args.action,
+      phoneNumber: args.phoneNumber
+    });
+    if (!result.success) {
+      throw new ActionableError(result.error || `Failed to execute phoneCall ${args.action}`);
+    }
+    return createJSONToolResponse({
+      message: result.message || `Phone call ${args.action} executed`,
+      ...result
+    });
+  };
+
+  const sendSmsHandler = async (
+    device: BootedDevice,
+    args: SendSmsArgs,
+    _progress?: ProgressCallback
+  ) => {
+    const telephony = new Telephony(device);
+    const result = await telephony.sendSms({
+      phoneNumber: args.phoneNumber,
+      message: args.message
+    });
+    if (!result.success) {
+      throw new ActionableError(result.error || "Failed to send simulated SMS");
+    }
+    return createJSONToolResponse({
+      message: result.message || "Simulated SMS delivered",
+      ...result
+    });
+  };
+
+  ToolRegistry.registerDeviceAware(
+    "phoneCall",
+    "Simulate an incoming phone call on an Android emulator via the emulator console (gsm call/accept/cancel/busy/hold). " +
+    "Emulator-only: physical devices return an unsupported error.",
+    phoneCallSchema,
+    phoneCallHandler
+  );
+
+  ToolRegistry.registerDeviceAware(
+    "sendSms",
+    "Send a simulated incoming SMS to an Android emulator via the emulator console (sms send). " +
+    "Emulator-only: physical devices return an unsupported error.",
+    sendSmsSchema,
+    sendSmsHandler
+  );
+}

--- a/src/utils/android-cmdline-tools/EmulatorConsoleClient.ts
+++ b/src/utils/android-cmdline-tools/EmulatorConsoleClient.ts
@@ -1,0 +1,182 @@
+import * as net from "node:net";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import * as os from "node:os";
+import { ActionableError } from "../../models";
+import { logger } from "../logger";
+import { Timer, defaultTimer } from "../SystemTimer";
+
+/**
+ * High-level client for the Android emulator console protocol (telnet, port 5554+).
+ * Each operation opens a fresh connection, authenticates with the token from
+ * ~/.emulator_console_auth_token, sends commands, and closes.
+ */
+export interface EmulatorConsoleClient {
+  gsmCall(phoneNumber: string): Promise<void>;
+  gsmAccept(phoneNumber: string): Promise<void>;
+  gsmCancel(phoneNumber: string): Promise<void>;
+  gsmBusy(phoneNumber: string): Promise<void>;
+  gsmHold(): Promise<void>;
+  smsSend(phoneNumber: string, message: string): Promise<void>;
+}
+
+/**
+ * Transport for the emulator-console TCP session. Implementations open a TCP
+ * socket, perform `auth <token>` if a token is provided, send each command on
+ * its own line, then send `quit` and close. The aggregated server output is
+ * returned so callers can detect `KO:` failure prefixes.
+ */
+export interface EmulatorConsoleTransport {
+  execute(host: string, port: number, authToken: string | null, commands: string[]): Promise<string>;
+}
+
+/**
+ * Reads the emulator console auth token from disk. The token lives in
+ * ~/.emulator_console_auth_token by default; if the file is missing the
+ * console accepts an empty auth line.
+ */
+export interface EmulatorConsoleAuthTokenReader {
+  read(): Promise<string | null>;
+}
+
+export class FileEmulatorConsoleAuthTokenReader implements EmulatorConsoleAuthTokenReader {
+  constructor(private readonly tokenPath: string = path.join(os.homedir(), ".emulator_console_auth_token")) {}
+
+  async read(): Promise<string | null> {
+    try {
+      const content = await fs.promises.readFile(this.tokenPath, "utf-8");
+      const trimmed = content.trim();
+      return trimmed.length > 0 ? trimmed : null;
+    } catch (error) {
+      const err = error as NodeJS.ErrnoException;
+      if (err.code === "ENOENT") {
+        return null;
+      }
+      logger.warn(`Failed to read emulator console auth token from ${this.tokenPath}: ${err.message}`);
+      return null;
+    }
+  }
+}
+
+const KO_REGEX = /^KO:\s*(.+)$/m;
+
+export class NetEmulatorConsoleTransport implements EmulatorConsoleTransport {
+  constructor(
+    private readonly connect: (port: number, host: string) => net.Socket = net.connect,
+    private readonly timeoutMs: number = 5000,
+    private readonly timer: Timer = defaultTimer
+  ) {}
+
+  execute(host: string, port: number, authToken: string | null, commands: string[]): Promise<string> {
+    return new Promise((resolve, reject) => {
+      let settled = false;
+      let buffer = "";
+
+      const socket = this.connect(port, host);
+      socket.setEncoding("utf-8");
+
+      const finish = (err: Error | null, output?: string) => {
+        if (settled) { return; }
+        settled = true;
+        socket.removeAllListeners();
+        socket.destroy();
+        if (err) { reject(err); } else { resolve(output ?? buffer); }
+      };
+
+      const timeoutHandle = this.timer.setTimeout(
+        () => finish(new ActionableError(`Emulator console connection to ${host}:${port} timed out after ${this.timeoutMs}ms`)),
+        this.timeoutMs
+      );
+
+      socket.on("error", err => {
+        this.timer.clearTimeout(timeoutHandle);
+        finish(new ActionableError(`Emulator console connection to ${host}:${port} failed: ${err.message}`));
+      });
+      socket.on("close", () => {
+        this.timer.clearTimeout(timeoutHandle);
+        finish(null, buffer);
+      });
+      socket.on("data", chunk => {
+        buffer += chunk.toString();
+      });
+      socket.on("connect", () => {
+        const lines: string[] = [];
+        if (authToken !== null) {
+          lines.push(`auth ${authToken}`);
+        }
+        lines.push(...commands);
+        lines.push("quit");
+        socket.write(`${lines.join("\n")}\n`);
+      });
+    });
+  }
+}
+
+export function consolePortFromSerial(deviceId: string): number | null {
+  const match = /^emulator-(\d+)$/.exec(deviceId);
+  if (!match) { return null; }
+  const port = Number.parseInt(match[1], 10);
+  if (!Number.isFinite(port) || port <= 0 || port > 65535) { return null; }
+  return port;
+}
+
+function validatePhoneNumber(phoneNumber: string): string {
+  const trimmed = phoneNumber.trim();
+  if (!/^\+?[0-9]{1,20}$/.test(trimmed)) {
+    throw new ActionableError(
+      `Invalid phone number '${phoneNumber}'. Expected digits with optional leading '+' (max 20 digits).`
+    );
+  }
+  return trimmed;
+}
+
+function validateSmsMessage(message: string): string {
+  // Newlines would terminate the command on the wire; carriage returns and NULs would too.
+  if (/[\r\n\0]/.test(message)) {
+    throw new ActionableError("SMS message must not contain newline, carriage return, or NUL characters.");
+  }
+  if (message.length === 0) {
+    throw new ActionableError("SMS message must not be empty.");
+  }
+  if (message.length > 1024) {
+    throw new ActionableError(`SMS message must be 1024 characters or fewer (got ${message.length}).`);
+  }
+  return message;
+}
+
+export class RealEmulatorConsoleClient implements EmulatorConsoleClient {
+  constructor(
+    private readonly port: number,
+    private readonly transport: EmulatorConsoleTransport,
+    private readonly tokenReader: EmulatorConsoleAuthTokenReader
+  ) {}
+
+  private async runCommands(commands: string[]): Promise<void> {
+    const token = await this.tokenReader.read();
+    const output = await this.transport.execute("localhost", this.port, token, commands);
+    const ko = KO_REGEX.exec(output);
+    if (ko) {
+      throw new ActionableError(`Emulator console rejected command: ${ko[1].trim()}`);
+    }
+  }
+
+  private async gsmCommand(verb: "call" | "accept" | "cancel" | "busy", phoneNumber: string): Promise<void> {
+    const number = validatePhoneNumber(phoneNumber);
+    await this.runCommands([`gsm ${verb} ${number}`]);
+  }
+
+  gsmCall(phoneNumber: string): Promise<void> { return this.gsmCommand("call", phoneNumber); }
+  gsmAccept(phoneNumber: string): Promise<void> { return this.gsmCommand("accept", phoneNumber); }
+  gsmCancel(phoneNumber: string): Promise<void> { return this.gsmCommand("cancel", phoneNumber); }
+  gsmBusy(phoneNumber: string): Promise<void> { return this.gsmCommand("busy", phoneNumber); }
+
+  async gsmHold(): Promise<void> {
+    await this.runCommands(["gsm hold"]);
+  }
+
+  async smsSend(phoneNumber: string, message: string): Promise<void> {
+    const number = validatePhoneNumber(phoneNumber);
+    const safeMessage = validateSmsMessage(message);
+    await this.runCommands([`sms send ${number} ${safeMessage}`]);
+  }
+}

--- a/test/fakes/FakeEmulatorConsoleClient.ts
+++ b/test/fakes/FakeEmulatorConsoleClient.ts
@@ -1,0 +1,34 @@
+import { EmulatorConsoleClient } from "../../src/utils/android-cmdline-tools/EmulatorConsoleClient";
+
+export interface RecordedConsoleCall {
+  method: "gsmCall" | "gsmAccept" | "gsmCancel" | "gsmBusy" | "gsmHold" | "smsSend";
+  args: string[];
+}
+
+export class FakeEmulatorConsoleClient implements EmulatorConsoleClient {
+  public readonly calls: RecordedConsoleCall[] = [];
+  public failures: Map<RecordedConsoleCall["method"], Error> = new Map();
+
+  failNext(method: RecordedConsoleCall["method"], error: Error): void {
+    this.failures.set(method, error);
+  }
+
+  private record(method: RecordedConsoleCall["method"], args: string[]): Promise<void> {
+    this.calls.push({ method, args });
+    const failure = this.failures.get(method);
+    if (failure) {
+      this.failures.delete(method);
+      return Promise.reject(failure);
+    }
+    return Promise.resolve();
+  }
+
+  gsmCall(phoneNumber: string): Promise<void> { return this.record("gsmCall", [phoneNumber]); }
+  gsmAccept(phoneNumber: string): Promise<void> { return this.record("gsmAccept", [phoneNumber]); }
+  gsmCancel(phoneNumber: string): Promise<void> { return this.record("gsmCancel", [phoneNumber]); }
+  gsmBusy(phoneNumber: string): Promise<void> { return this.record("gsmBusy", [phoneNumber]); }
+  gsmHold(): Promise<void> { return this.record("gsmHold", []); }
+  smsSend(phoneNumber: string, message: string): Promise<void> {
+    return this.record("smsSend", [phoneNumber, message]);
+  }
+}

--- a/test/features/action/Telephony.test.ts
+++ b/test/features/action/Telephony.test.ts
@@ -1,0 +1,145 @@
+import { expect, describe, test, beforeEach } from "bun:test";
+import { Telephony } from "../../../src/features/action/Telephony";
+import { BootedDevice } from "../../../src/models";
+import { FakeAdbExecutor } from "../../fakes/FakeAdbExecutor";
+import { FakeEmulatorConsoleClient } from "../../fakes/FakeEmulatorConsoleClient";
+
+describe("Telephony", () => {
+  let adb: FakeAdbExecutor;
+  let consoleClient: FakeEmulatorConsoleClient;
+  let device: BootedDevice;
+  let telephony: Telephony;
+
+  beforeEach(() => {
+    adb = new FakeAdbExecutor();
+    adb.setCommandResponse("shell getprop ro.kernel.qemu", { stdout: "1", stderr: "" });
+
+    consoleClient = new FakeEmulatorConsoleClient();
+    device = { deviceId: "emulator-5554", platform: "android", name: "Pixel_5" } as BootedDevice;
+    telephony = new Telephony(device, adb, () => consoleClient);
+  });
+
+  describe("phoneCall", () => {
+    test("call action dispatches gsmCall on the emulator console", async () => {
+      const result = await telephony.phoneCall({ action: "call", phoneNumber: "+15551234567" });
+
+      expect(result.success).toBe(true);
+      expect(result.action).toBe("call");
+      expect(result.phoneNumber).toBe("+15551234567");
+      expect(result.supported).toBe(true);
+      expect(consoleClient.calls).toEqual([{ method: "gsmCall", args: ["+15551234567"] }]);
+    });
+
+    test("accept/cancel/busy actions each route to their corresponding console command", async () => {
+      await telephony.phoneCall({ action: "accept", phoneNumber: "5551234567" });
+      await telephony.phoneCall({ action: "cancel", phoneNumber: "5551234567" });
+      await telephony.phoneCall({ action: "busy", phoneNumber: "5551234567" });
+
+      expect(consoleClient.calls.map(c => c.method)).toEqual(["gsmAccept", "gsmCancel", "gsmBusy"]);
+    });
+
+    test("hold action does not require a phoneNumber", async () => {
+      const result = await telephony.phoneCall({ action: "hold" });
+
+      expect(result.success).toBe(true);
+      expect(consoleClient.calls).toEqual([{ method: "gsmHold", args: [] }]);
+    });
+
+    test("call/accept/cancel/busy without phoneNumber return a validation error without contacting the console", async () => {
+      const result = await telephony.phoneCall({ action: "call" });
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("phoneNumber is required");
+      expect(consoleClient.calls.length).toBe(0);
+    });
+
+    test("returns supported:false on iOS devices", async () => {
+      device = { deviceId: "00008101-001C711E0EE0001E", platform: "ios", name: "iPhone" } as BootedDevice;
+      telephony = new Telephony(device, adb, () => consoleClient);
+
+      const result = await telephony.phoneCall({ action: "call", phoneNumber: "5551234567" });
+
+      expect(result.success).toBe(false);
+      expect(result.supported).toBe(false);
+      expect(result.error).toContain("only supported on Android emulators");
+      expect(consoleClient.calls.length).toBe(0);
+    });
+
+    test("returns supported:false for a physical Android device (non-emulator serial)", async () => {
+      device = { deviceId: "HT85N1A02890", platform: "android", name: "Pixel" } as BootedDevice;
+      telephony = new Telephony(device, adb, () => consoleClient);
+
+      const result = await telephony.phoneCall({ action: "call", phoneNumber: "5551234567" });
+
+      expect(result.success).toBe(false);
+      expect(result.supported).toBe(false);
+      expect(result.error).toContain("does not appear to be an Android emulator");
+      expect(consoleClient.calls.length).toBe(0);
+    });
+
+    test("returns supported:false when ro.kernel.qemu is not '1' even for emulator-NNNN serials", async () => {
+      adb.setCommandResponse("shell getprop ro.kernel.qemu", { stdout: "", stderr: "" });
+
+      const result = await telephony.phoneCall({ action: "call", phoneNumber: "5551234567" });
+
+      expect(result.success).toBe(false);
+      expect(result.supported).toBe(false);
+      expect(consoleClient.calls.length).toBe(0);
+    });
+
+    test("surfaces emulator console failures in the result", async () => {
+      consoleClient.failNext("gsmCall", new Error("Emulator console rejected command: invalid number"));
+
+      const result = await telephony.phoneCall({ action: "call", phoneNumber: "5551234567" });
+
+      expect(result.success).toBe(false);
+      expect(result.supported).toBe(true);
+      expect(result.error).toContain("invalid number");
+    });
+  });
+
+  describe("sendSms", () => {
+    test("delivers a simulated SMS via the emulator console", async () => {
+      const result = await telephony.sendSms({ phoneNumber: "+15551234567", message: "Hello, world!" });
+
+      expect(result.success).toBe(true);
+      expect(result.phoneNumber).toBe("+15551234567");
+      expect(result.messageLength).toBe("Hello, world!".length);
+      expect(consoleClient.calls).toEqual([{ method: "smsSend", args: ["+15551234567", "Hello, world!"] }]);
+    });
+
+    test("returns supported:false on physical devices", async () => {
+      device = { deviceId: "HT85N1A02890", platform: "android", name: "Pixel" } as BootedDevice;
+      telephony = new Telephony(device, adb, () => consoleClient);
+
+      const result = await telephony.sendSms({ phoneNumber: "5551234567", message: "hi" });
+
+      expect(result.success).toBe(false);
+      expect(result.supported).toBe(false);
+      expect(consoleClient.calls.length).toBe(0);
+    });
+
+    test("surfaces validation errors from the emulator console client", async () => {
+      consoleClient.failNext("smsSend", new Error("SMS message must not contain newline, carriage return, or NUL characters."));
+
+      const result = await telephony.sendSms({ phoneNumber: "5551234567", message: "anything" });
+
+      expect(result.success).toBe(false);
+      expect(result.supported).toBe(true);
+      expect(result.error).toContain("must not contain newline");
+    });
+
+    test("uses port from the device serial when constructing the console client", async () => {
+      let receivedPort = -1;
+      device = { deviceId: "emulator-5560", platform: "android", name: "Pixel_5" } as BootedDevice;
+      telephony = new Telephony(device, adb, port => {
+        receivedPort = port;
+        return consoleClient;
+      });
+
+      await telephony.sendSms({ phoneNumber: "5551234567", message: "hi" });
+
+      expect(receivedPort).toBe(5560);
+    });
+  });
+});

--- a/test/utils/android-cmdline-tools/EmulatorConsoleClient.test.ts
+++ b/test/utils/android-cmdline-tools/EmulatorConsoleClient.test.ts
@@ -1,0 +1,124 @@
+import { expect, describe, test, beforeEach } from "bun:test";
+import {
+  consolePortFromSerial,
+  EmulatorConsoleAuthTokenReader,
+  RealEmulatorConsoleClient,
+  EmulatorConsoleTransport
+} from "../../../src/utils/android-cmdline-tools/EmulatorConsoleClient";
+
+class RecordingTransport implements EmulatorConsoleTransport {
+  public calls: { host: string; port: number; authToken: string | null; commands: string[] }[] = [];
+  public nextOutput: string = "OK\n";
+  public failWith: Error | null = null;
+
+  async execute(host: string, port: number, authToken: string | null, commands: string[]): Promise<string> {
+    this.calls.push({ host, port, authToken, commands });
+    if (this.failWith) { throw this.failWith; }
+    return this.nextOutput;
+  }
+}
+
+class StaticTokenReader implements EmulatorConsoleAuthTokenReader {
+  constructor(private token: string | null) {}
+  async read(): Promise<string | null> { return this.token; }
+}
+
+describe("consolePortFromSerial", () => {
+  test("extracts port from emulator-NNNN serial", () => {
+    expect(consolePortFromSerial("emulator-5554")).toBe(5554);
+    expect(consolePortFromSerial("emulator-5556")).toBe(5556);
+    expect(consolePortFromSerial("emulator-5600")).toBe(5600);
+  });
+
+  test("returns null for non-emulator serials", () => {
+    expect(consolePortFromSerial("HT85N1A02890")).toBeNull();
+    expect(consolePortFromSerial("00008101-001C711E0EE0001E")).toBeNull();
+    expect(consolePortFromSerial("emulator-abc")).toBeNull();
+    expect(consolePortFromSerial("emulator-")).toBeNull();
+    expect(consolePortFromSerial("")).toBeNull();
+  });
+
+  test("rejects ports outside the valid TCP range", () => {
+    expect(consolePortFromSerial("emulator-0")).toBeNull();
+    expect(consolePortFromSerial("emulator-65536")).toBeNull();
+  });
+});
+
+describe("RealEmulatorConsoleClient", () => {
+  let transport: RecordingTransport;
+  let tokenReader: StaticTokenReader;
+  let client: RealEmulatorConsoleClient;
+
+  beforeEach(() => {
+    transport = new RecordingTransport();
+    tokenReader = new StaticTokenReader("test-token");
+    client = new RealEmulatorConsoleClient(5554, transport, tokenReader);
+  });
+
+  test("gsmCall sends `gsm call <number>` with auth token", async () => {
+    await client.gsmCall("+15551234567");
+
+    expect(transport.calls.length).toBe(1);
+    expect(transport.calls[0].host).toBe("localhost");
+    expect(transport.calls[0].port).toBe(5554);
+    expect(transport.calls[0].authToken).toBe("test-token");
+    expect(transport.calls[0].commands).toEqual(["gsm call +15551234567"]);
+  });
+
+  test("gsmAccept/gsmCancel/gsmBusy each send their respective command", async () => {
+    await client.gsmAccept("5551234567");
+    await client.gsmCancel("5551234567");
+    await client.gsmBusy("5551234567");
+
+    expect(transport.calls.map(c => c.commands[0])).toEqual([
+      "gsm accept 5551234567",
+      "gsm cancel 5551234567",
+      "gsm busy 5551234567",
+    ]);
+  });
+
+  test("gsmHold sends `gsm hold` without a number", async () => {
+    await client.gsmHold();
+    expect(transport.calls[0].commands).toEqual(["gsm hold"]);
+  });
+
+  test("smsSend sends `sms send <number> <message>`", async () => {
+    await client.smsSend("+15551234567", "Hello, world!");
+    expect(transport.calls[0].commands).toEqual(["sms send +15551234567 Hello, world!"]);
+  });
+
+  test("falls back to null auth token when reader returns null", async () => {
+    client = new RealEmulatorConsoleClient(5554, transport, new StaticTokenReader(null));
+    await client.gsmCall("5551234567");
+    expect(transport.calls[0].authToken).toBeNull();
+  });
+
+  test("invalid phone numbers throw ActionableError before reaching the transport", async () => {
+    await expect(client.gsmCall("not-a-number")).rejects.toThrow(/Invalid phone number/);
+    await expect(client.gsmCall("5551234567 ; rm -rf /")).rejects.toThrow(/Invalid phone number/);
+    await expect(client.smsSend("abc", "hi")).rejects.toThrow(/Invalid phone number/);
+    expect(transport.calls.length).toBe(0);
+  });
+
+  test("rejects SMS messages with newline or NUL characters", async () => {
+    await expect(client.smsSend("5551234567", "line1\nline2")).rejects.toThrow(/newline/);
+    await expect(client.smsSend("5551234567", "with\0nul")).rejects.toThrow(/newline/);
+    await expect(client.smsSend("5551234567", "")).rejects.toThrow(/must not be empty/);
+    expect(transport.calls.length).toBe(0);
+  });
+
+  test("rejects SMS messages longer than 1024 characters", async () => {
+    const tooLong = "a".repeat(1025);
+    await expect(client.smsSend("5551234567", tooLong)).rejects.toThrow(/1024 characters/);
+  });
+
+  test("throws ActionableError when transport output contains a KO: response", async () => {
+    transport.nextOutput = "Android Console: type 'help' for a list of commands\nOK\nKO: unknown command\n";
+    await expect(client.gsmCall("5551234567")).rejects.toThrow(/Emulator console rejected command: unknown command/);
+  });
+
+  test("propagates transport errors", async () => {
+    transport.failWith = new Error("ECONNREFUSED");
+    await expect(client.smsSend("5551234567", "hi")).rejects.toThrow(/ECONNREFUSED/);
+  });
+});


### PR DESCRIPTION
## Summary

Closes #1579.

Adds two MCP tools that drive the Android emulator console (telnet on port 5554+) to simulate inbound calls and SMS without a physical PSTN:

- **`phoneCall`** — actions `call` / `accept` / `cancel` / `busy` / `hold` (maps to emulator `gsm` commands)
- **`sendSms`** — deliver simulated incoming SMS (`sms send`)

Emulator-only: physical devices return an unsupported error, derived from the device serial (`emulator-<port>`) and `ro.kernel.qemu`.

### Architecture

- `EmulatorConsoleClient` (interface) + `RealEmulatorConsoleClient` — high-level GSM/SMS surface
- `EmulatorConsoleTransport` (interface) + `NetEmulatorConsoleTransport` — connect-per-command TCP session, sends `auth <token>` then commands then `quit`
- `EmulatorConsoleAuthTokenReader` (interface) + `FileEmulatorConsoleAuthTokenReader` — reads `~/.emulator_console_auth_token`
- `Telephony` feature action — platform/emulator gate, dispatches to the console client
- `consolePortFromSerial("emulator-5554") → 5554` — strict serial parser

Validation: phone numbers must match `\+?[0-9]{1,20}`; SMS messages reject newline/CR/NUL and are capped at 1024 chars (server-side belt + Zod schema suspenders).

## Test plan

- [x] `bun test test/utils/android-cmdline-tools/EmulatorConsoleClient.test.ts test/features/action/Telephony.test.ts` — 25/25 pass (~50ms)
- [x] Full `bun turbo run test` — 4104 pass, 2 skipped, 0 fail
- [x] `bun turbo run lint build` — clean
- [x] `schemas/tool-definitions.json` regenerated (`phoneCall`, `sendSms` entries land alphabetically)
- [ ] Manual smoke against an emulator + AVD with default auth token: verify incoming call UI, accept/cancel transitions, and an SMS arrives in Messages