### PR TITLE
refactor(ios): use IOS_CTRL_PROXY_SHA256_CHECKSUM constant in builder

### DIFF
--- a/src/utils/IOSCtrlProxyBuilder.ts
+++ b/src/utils/IOSCtrlProxyBuilder.ts
@@ -9,8 +9,8 @@ import {
   IOS_CTRL_PROXY_IPA_URL,
   IOS_CTRL_PROXY_RELEASE_VERSION,
   IOS_CTRL_PROXY_RUNNER_SHA256,
+  IOS_CTRL_PROXY_SHA256_CHECKSUM,
   LATEST_RELEASE_VERSION,
-  resolveChecksum,
   resolveLatestVersion
 } from "../constants/release";
 import {
@@ -582,7 +582,7 @@ export class IOSCtrlProxyBuilder {
     if (override !== null) {
       return override;
     }
-    return resolveChecksum(IOS_CTRL_PROXY_RELEASE_VERSION, "ios");
+    return IOS_CTRL_PROXY_SHA256_CHECKSUM;
   }
 
   public getExpectedAppHash(platform: IOSCtrlProxyPlatform): string {


### PR DESCRIPTION
## Summary
- IOSCtrlProxyBuilder.getExpectedChecksum() resolved the checksum via \`resolveChecksum(IOS_CTRL_PROXY_RELEASE_VERSION, \"ios\")\` even though \`src/constants/release.ts\` exports the same value as \`IOS_CTRL_PROXY_SHA256_CHECKSUM\`. ts-prune flagged the constant as unused.
- Wire it through the exported constant for symmetry with the Android side (which uses APK_SHA256_CHECKSUM in CtrlProxyManager).
- Part of cleanup pass on dead-code issue #1874.

## Test plan
- [x] \`bun test test/utils/IOSCtrlProxyBuilder.test.ts\` passes (23 pass).
- [x] \`bun run dead-code:ts:prune\` no longer flags \`IOS_CTRL_PROXY_SHA256_CHECKSUM\`.