### PR TITLE
feat(ios): AVFoundation device-capture helper

### DIFF
--- a/docs/design-docs/plat/ios/screen-streaming.md
+++ b/docs/design-docs/plat/ios/screen-streaming.md
@@ -271,8 +271,10 @@ Followed by `height * bytesPerRow` bytes of BGRA pixel data.
 ## Implementation Plan
 
 ### Milestone 1: Physical Device Capture
-- [ ] Create Swift helper for AVFoundation capture
-- [ ] Implement Unix socket frame streaming
+- [x] Create Swift helper for AVFoundation capture (`ios/screen-capture/`)
+- [x] Implement frame protocol + stdout streaming
+- [x] Node-side spawn manager (`src/features/screen-stream/IOSDeviceCaptureHelper.ts`)
+- [ ] Unix socket fan-out (`video-stream.sock`)
 - [ ] Test with MCP server integration
 
 ### Milestone 2: Simulator Capture

--- a/ios/screen-capture/Package.swift
+++ b/ios/screen-capture/Package.swift
@@ -1,0 +1,35 @@
+// swift-tools-version: 5.9
+import PackageDescription
+
+let package = Package(
+    name: "ScreenCaptureHelper",
+    platforms: [
+        .macOS(.v14),
+    ],
+    products: [
+        .executable(
+            name: "screen-capture-helper",
+            targets: ["ScreenCaptureHelper"]
+        ),
+        .library(
+            name: "ScreenCaptureCore",
+            targets: ["ScreenCaptureCore"]
+        ),
+    ],
+    targets: [
+        .target(
+            name: "ScreenCaptureCore",
+            path: "Sources/ScreenCaptureCore"
+        ),
+        .executableTarget(
+            name: "ScreenCaptureHelper",
+            dependencies: ["ScreenCaptureCore"],
+            path: "Sources/ScreenCaptureHelper"
+        ),
+        .testTarget(
+            name: "ScreenCaptureCoreTests",
+            dependencies: ["ScreenCaptureCore"],
+            path: "Tests/ScreenCaptureCoreTests"
+        ),
+    ]
+)

--- a/ios/screen-capture/Sources/ScreenCaptureCore/CommandLineOptions.swift
+++ b/ios/screen-capture/Sources/ScreenCaptureCore/CommandLineOptions.swift
@@ -1,0 +1,72 @@
+import Foundation
+
+/// Parsed CLI arguments for the screen-capture helper.
+public struct CommandLineOptions: Equatable {
+    public enum Mode: Equatable {
+        case listDevices
+        case capture(deviceID: String?)
+        case help
+    }
+
+    public let mode: Mode
+
+    public init(mode: Mode) {
+        self.mode = mode
+    }
+
+    public enum ParseError: Error, Equatable {
+        case missingValue(flag: String)
+        case unknownArgument(String)
+    }
+
+    public static func parse(_ arguments: [String]) throws -> CommandLineOptions {
+        var iterator = arguments.makeIterator()
+        _ = iterator.next()
+
+        var listDevices = false
+        var deviceID: String?
+        var help = false
+
+        while let arg = iterator.next() {
+            switch arg {
+            case "--list-devices":
+                listDevices = true
+            case "--device-id":
+                guard let value = iterator.next() else {
+                    throw ParseError.missingValue(flag: arg)
+                }
+                deviceID = value
+            case "-h", "--help":
+                help = true
+            default:
+                throw ParseError.unknownArgument(arg)
+            }
+        }
+
+        if help {
+            return CommandLineOptions(mode: .help)
+        }
+        if listDevices {
+            return CommandLineOptions(mode: .listDevices)
+        }
+        return CommandLineOptions(mode: .capture(deviceID: deviceID))
+    }
+
+    public static let helpText = """
+    screen-capture-helper — AutoMobile iOS device capture helper
+
+    USAGE:
+        screen-capture-helper [--device-id <id>]
+        screen-capture-helper --list-devices
+
+    OPTIONS:
+        --list-devices       Emit discovered devices as JSON to stdout and exit.
+        --device-id <id>     uniqueID of the device to capture. If omitted, the
+                             first muxed external device is used.
+        -h, --help           Show this help.
+
+    Frames are written to stdout: 16-byte little-endian header
+    (width, height, bytesPerRow, timestampMs) followed by
+    height * bytesPerRow bytes of BGRA pixel data.
+    """
+}

--- a/ios/screen-capture/Sources/ScreenCaptureCore/DeviceInfo.swift
+++ b/ios/screen-capture/Sources/ScreenCaptureCore/DeviceInfo.swift
@@ -1,0 +1,25 @@
+import Foundation
+
+/// Serializable description of a discovered capture device. Emitted to stdout
+/// in JSON form when `screen-capture-helper --list-devices` is invoked.
+public struct DeviceInfo: Codable, Equatable {
+    public let uniqueID: String
+    public let localizedName: String
+    public let modelID: String
+    public let manufacturer: String
+
+    public init(uniqueID: String, localizedName: String, modelID: String, manufacturer: String) {
+        self.uniqueID = uniqueID
+        self.localizedName = localizedName
+        self.modelID = modelID
+        self.manufacturer = manufacturer
+    }
+}
+
+public struct DeviceListResponse: Codable, Equatable {
+    public let devices: [DeviceInfo]
+
+    public init(devices: [DeviceInfo]) {
+        self.devices = devices
+    }
+}

--- a/ios/screen-capture/Sources/ScreenCaptureCore/FrameProtocol.swift
+++ b/ios/screen-capture/Sources/ScreenCaptureCore/FrameProtocol.swift
@@ -1,0 +1,52 @@
+import Foundation
+
+/// Binary frame protocol matching docs/design-docs/plat/ios/screen-streaming.md.
+///
+/// Wire format (header = 16 bytes, little-endian UInt32):
+///
+///     ┌──────────┬───────────┬─────────────────┬──────────────┐
+///     │ width(4) │ height(4) │ bytesPerRow (4) │ timestampMs  │
+///     └──────────┴───────────┴─────────────────┴──────────────┘
+///
+/// Followed by `height * bytesPerRow` bytes of BGRA pixel data.
+public enum FrameProtocol {
+    public static let headerSize = 16
+
+    public struct Header: Equatable {
+        public let width: UInt32
+        public let height: UInt32
+        public let bytesPerRow: UInt32
+        public let timestampMs: UInt32
+
+        public init(width: UInt32, height: UInt32, bytesPerRow: UInt32, timestampMs: UInt32) {
+            self.width = width
+            self.height = height
+            self.bytesPerRow = bytesPerRow
+            self.timestampMs = timestampMs
+        }
+    }
+
+    public static func encodeHeader(_ header: Header) -> Data {
+        var data = Data(count: headerSize)
+        data.withUnsafeMutableBytes { ptr in
+            let base = ptr.baseAddress!
+            base.storeBytes(of: header.width.littleEndian, as: UInt32.self)
+            base.advanced(by: 4).storeBytes(of: header.height.littleEndian, as: UInt32.self)
+            base.advanced(by: 8).storeBytes(of: header.bytesPerRow.littleEndian, as: UInt32.self)
+            base.advanced(by: 12).storeBytes(of: header.timestampMs.littleEndian, as: UInt32.self)
+        }
+        return data
+    }
+
+    public static func decodeHeader(_ data: Data) -> Header? {
+        guard data.count >= headerSize else { return nil }
+        return data.withUnsafeBytes { ptr -> Header in
+            let base = ptr.baseAddress!
+            let w = UInt32(littleEndian: base.load(as: UInt32.self))
+            let h = UInt32(littleEndian: base.advanced(by: 4).load(as: UInt32.self))
+            let r = UInt32(littleEndian: base.advanced(by: 8).load(as: UInt32.self))
+            let t = UInt32(littleEndian: base.advanced(by: 12).load(as: UInt32.self))
+            return Header(width: w, height: h, bytesPerRow: r, timestampMs: t)
+        }
+    }
+}

--- a/ios/screen-capture/Sources/ScreenCaptureCore/FrameWriter.swift
+++ b/ios/screen-capture/Sources/ScreenCaptureCore/FrameWriter.swift
@@ -1,0 +1,57 @@
+import Foundation
+
+/// Sink that receives encoded frames. Implementations write to stdout, a file,
+/// a Unix socket, or an in-memory buffer for tests.
+public protocol FrameSink: AnyObject {
+    func write(_ data: Data)
+}
+
+/// Writes encoded frame header + BGRA payload to a `FrameSink`.
+public final class FrameWriter {
+    private let sink: FrameSink
+    private let startTime: Date
+
+    public init(sink: FrameSink, startTime: Date = Date()) {
+        self.sink = sink
+        self.startTime = startTime
+    }
+
+    public func write(
+        width: Int,
+        height: Int,
+        bytesPerRow: Int,
+        baseAddress: UnsafeRawPointer,
+        timestamp: Date = Date()
+    ) {
+        let elapsedMs = max(0, timestamp.timeIntervalSince(startTime) * 1000)
+        let header = FrameProtocol.Header(
+            width: UInt32(width),
+            height: UInt32(height),
+            bytesPerRow: UInt32(bytesPerRow),
+            timestampMs: UInt32(truncatingIfNeeded: UInt64(elapsedMs))
+        )
+        sink.write(FrameProtocol.encodeHeader(header))
+        // bytesNoCopy avoids copying the pixel buffer into a transient Data.
+        // The caller (DeviceCaptureSession.captureOutput) holds the underlying
+        // CVPixelBuffer locked for the duration of this synchronous write.
+        let payload = Data(
+            bytesNoCopy: UnsafeMutableRawPointer(mutating: baseAddress),
+            count: bytesPerRow * height,
+            deallocator: .none
+        )
+        sink.write(payload)
+    }
+}
+
+/// Sink that writes to a `FileHandle` (e.g. `FileHandle.standardOutput`).
+public final class FileHandleFrameSink: FrameSink {
+    private let handle: FileHandle
+
+    public init(handle: FileHandle) {
+        self.handle = handle
+    }
+
+    public func write(_ data: Data) {
+        handle.write(data)
+    }
+}

--- a/ios/screen-capture/Sources/ScreenCaptureHelper/CMIOSystem.swift
+++ b/ios/screen-capture/Sources/ScreenCaptureHelper/CMIOSystem.swift
@@ -1,0 +1,26 @@
+import CoreMediaIO
+import Foundation
+
+/// Enables iOS device screen-capture devices to appear in AVFoundation. This
+/// is the same toggle QuickTime Player flips when you select an iOS device.
+///
+/// Per design doc: rapidly toggling this property can stall device discovery
+/// for up to 60 seconds, so we only flip it to `true` and leave it.
+enum CMIOSystem {
+    static func enableScreenCaptureDevices() {
+        var prop = CMIOObjectPropertyAddress(
+            mSelector: CMIOObjectPropertySelector(kCMIOHardwarePropertyAllowScreenCaptureDevices),
+            mScope: CMIOObjectPropertyScope(kCMIOObjectPropertyScopeGlobal),
+            mElement: CMIOObjectPropertyElement(kCMIOObjectPropertyElementMain)
+        )
+        var allow: UInt32 = 1
+        CMIOObjectSetPropertyData(
+            CMIOObjectID(kCMIOObjectSystemObject),
+            &prop,
+            0,
+            nil,
+            UInt32(MemoryLayout<UInt32>.size),
+            &allow
+        )
+    }
+}

--- a/ios/screen-capture/Sources/ScreenCaptureHelper/DeviceCaptureSession.swift
+++ b/ios/screen-capture/Sources/ScreenCaptureHelper/DeviceCaptureSession.swift
@@ -1,0 +1,58 @@
+import AVFoundation
+import CoreVideo
+import Foundation
+import ScreenCaptureCore
+
+/// Wraps an `AVCaptureSession` configured to deliver BGRA frames from an iOS
+/// device to a `FrameWriter`.
+final class DeviceCaptureSession: NSObject, AVCaptureVideoDataOutputSampleBufferDelegate {
+    private let session = AVCaptureSession()
+    private let output = AVCaptureVideoDataOutput()
+    private let writer: FrameWriter
+    private let queue = DispatchQueue(label: "automobile.screen-capture.frames")
+
+    init(writer: FrameWriter) {
+        self.writer = writer
+    }
+
+    func start(device: AVCaptureDevice) throws {
+        let input = try AVCaptureDeviceInput(device: device)
+
+        session.beginConfiguration()
+        if session.canAddInput(input) {
+            session.addInput(input)
+        }
+        output.alwaysDiscardsLateVideoFrames = true
+        output.videoSettings = [
+            kCVPixelBufferPixelFormatTypeKey as String: kCVPixelFormatType_32BGRA
+        ]
+        output.setSampleBufferDelegate(self, queue: queue)
+        if session.canAddOutput(output) {
+            session.addOutput(output)
+        }
+        session.commitConfiguration()
+        session.startRunning()
+    }
+
+    func stop() {
+        session.stopRunning()
+    }
+
+    func captureOutput(
+        _ output: AVCaptureOutput,
+        didOutput sampleBuffer: CMSampleBuffer,
+        from connection: AVCaptureConnection
+    ) {
+        guard let pixelBuffer = CMSampleBufferGetImageBuffer(sampleBuffer) else { return }
+        CVPixelBufferLockBaseAddress(pixelBuffer, .readOnly)
+        defer { CVPixelBufferUnlockBaseAddress(pixelBuffer, .readOnly) }
+        guard let base = CVPixelBufferGetBaseAddress(pixelBuffer) else { return }
+
+        writer.write(
+            width: CVPixelBufferGetWidth(pixelBuffer),
+            height: CVPixelBufferGetHeight(pixelBuffer),
+            bytesPerRow: CVPixelBufferGetBytesPerRow(pixelBuffer),
+            baseAddress: base
+        )
+    }
+}

--- a/ios/screen-capture/Sources/ScreenCaptureHelper/DeviceDiscovery.swift
+++ b/ios/screen-capture/Sources/ScreenCaptureHelper/DeviceDiscovery.swift
@@ -1,0 +1,29 @@
+import AVFoundation
+import Foundation
+import ScreenCaptureCore
+
+/// Discovers USB-connected iOS devices visible to AVFoundation as external
+/// muxed (audio + video) capture devices.
+enum DeviceDiscovery {
+    static func discover() -> [AVCaptureDevice] {
+        let types: [AVCaptureDevice.DeviceType] = [.external]
+        return AVCaptureDevice.DiscoverySession(
+            deviceTypes: types,
+            mediaType: .muxed,
+            position: .unspecified
+        ).devices
+    }
+
+    static func toInfo(_ device: AVCaptureDevice) -> DeviceInfo {
+        DeviceInfo(
+            uniqueID: device.uniqueID,
+            localizedName: device.localizedName,
+            modelID: device.modelID,
+            manufacturer: device.manufacturer
+        )
+    }
+
+    static func find(uniqueID: String) -> AVCaptureDevice? {
+        discover().first { $0.uniqueID == uniqueID }
+    }
+}

--- a/ios/screen-capture/Sources/ScreenCaptureHelper/main.swift
+++ b/ios/screen-capture/Sources/ScreenCaptureHelper/main.swift
@@ -1,0 +1,100 @@
+import AVFoundation
+import Foundation
+import ScreenCaptureCore
+
+// MARK: - Logging
+
+func logError(_ message: String) {
+    FileHandle.standardError.write(Data("\(message)\n".utf8))
+}
+
+// MARK: - Argument parsing
+
+let options: CommandLineOptions
+do {
+    options = try CommandLineOptions.parse(CommandLine.arguments)
+} catch let CommandLineOptions.ParseError.missingValue(flag) {
+    logError("error: missing value for \(flag)")
+    logError(CommandLineOptions.helpText)
+    exit(2)
+} catch let CommandLineOptions.ParseError.unknownArgument(arg) {
+    logError("error: unknown argument \(arg)")
+    logError(CommandLineOptions.helpText)
+    exit(2)
+} catch {
+    logError("error: \(error)")
+    exit(2)
+}
+
+// MARK: - Dispatch
+
+switch options.mode {
+case .help:
+    print(CommandLineOptions.helpText)
+    exit(0)
+
+case .listDevices:
+    CMIOSystem.enableScreenCaptureDevices()
+    // Allow a brief moment for the system to register USB devices.
+    Thread.sleep(forTimeInterval: 0.5)
+    let infos = DeviceDiscovery.discover().map(DeviceDiscovery.toInfo)
+    let response = DeviceListResponse(devices: infos)
+    let encoder = JSONEncoder()
+    encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+    do {
+        let data = try encoder.encode(response)
+        FileHandle.standardOutput.write(data)
+        FileHandle.standardOutput.write(Data("\n".utf8))
+    } catch {
+        logError("error: failed to encode device list: \(error)")
+        exit(1)
+    }
+    exit(0)
+
+case .capture(let deviceID):
+    CMIOSystem.enableScreenCaptureDevices()
+    Thread.sleep(forTimeInterval: 0.5)
+
+    let resolved: AVCaptureDevice?
+    if let id = deviceID {
+        resolved = DeviceDiscovery.find(uniqueID: id)
+        if resolved == nil {
+            logError("error: no device with uniqueID '\(id)'")
+            exit(1)
+        }
+    } else {
+        resolved = DeviceDiscovery.discover().first
+        if resolved == nil {
+            logError("error: no muxed external capture devices found")
+            exit(1)
+        }
+    }
+    guard let device = resolved else { exit(1) }
+
+    let sink = FileHandleFrameSink(handle: .standardOutput)
+    let writer = FrameWriter(sink: sink)
+    let captureSession = DeviceCaptureSession(writer: writer)
+
+    do {
+        try captureSession.start(device: device)
+    } catch {
+        logError("error: failed to start capture session: \(error)")
+        exit(1)
+    }
+
+    // Graceful shutdown on SIGTERM/SIGINT.
+    let termSource = DispatchSource.makeSignalSource(signal: SIGTERM, queue: .main)
+    let intSource = DispatchSource.makeSignalSource(signal: SIGINT, queue: .main)
+    signal(SIGTERM, SIG_IGN)
+    signal(SIGINT, SIG_IGN)
+    let shutdown = {
+        captureSession.stop()
+        exit(0)
+    }
+    termSource.setEventHandler(handler: shutdown)
+    intSource.setEventHandler(handler: shutdown)
+    termSource.resume()
+    intSource.resume()
+
+    RunLoop.main.run()
+}

--- a/ios/screen-capture/Tests/ScreenCaptureCoreTests/CommandLineOptionsTests.swift
+++ b/ios/screen-capture/Tests/ScreenCaptureCoreTests/CommandLineOptionsTests.swift
@@ -1,0 +1,52 @@
+import XCTest
+@testable import ScreenCaptureCore
+
+final class CommandLineOptionsTests: XCTestCase {
+    func testDefaultsToCaptureWithoutDeviceID() throws {
+        let opts = try CommandLineOptions.parse(["screen-capture-helper"])
+        XCTAssertEqual(opts.mode, .capture(deviceID: nil))
+    }
+
+    func testParsesDeviceID() throws {
+        let opts = try CommandLineOptions.parse([
+            "screen-capture-helper", "--device-id", "ABC123"
+        ])
+        XCTAssertEqual(opts.mode, .capture(deviceID: "ABC123"))
+    }
+
+    func testParsesListDevices() throws {
+        let opts = try CommandLineOptions.parse([
+            "screen-capture-helper", "--list-devices"
+        ])
+        XCTAssertEqual(opts.mode, .listDevices)
+    }
+
+    func testParsesHelpFlag() throws {
+        let opts = try CommandLineOptions.parse([
+            "screen-capture-helper", "--help"
+        ])
+        XCTAssertEqual(opts.mode, .help)
+    }
+
+    func testMissingDeviceIDValueThrows() {
+        XCTAssertThrowsError(try CommandLineOptions.parse([
+            "screen-capture-helper", "--device-id"
+        ])) { error in
+            XCTAssertEqual(
+                error as? CommandLineOptions.ParseError,
+                .missingValue(flag: "--device-id")
+            )
+        }
+    }
+
+    func testUnknownArgumentThrows() {
+        XCTAssertThrowsError(try CommandLineOptions.parse([
+            "screen-capture-helper", "--bogus"
+        ])) { error in
+            XCTAssertEqual(
+                error as? CommandLineOptions.ParseError,
+                .unknownArgument("--bogus")
+            )
+        }
+    }
+}

--- a/ios/screen-capture/Tests/ScreenCaptureCoreTests/DeviceInfoTests.swift
+++ b/ios/screen-capture/Tests/ScreenCaptureCoreTests/DeviceInfoTests.swift
@@ -1,0 +1,35 @@
+import XCTest
+@testable import ScreenCaptureCore
+
+final class DeviceInfoTests: XCTestCase {
+    func testRoundTripsThroughJSON() throws {
+        let original = DeviceListResponse(devices: [
+            DeviceInfo(
+                uniqueID: "00008140-001A2B3C0AE2401E",
+                localizedName: "iPhone",
+                modelID: "iPhone15,2",
+                manufacturer: "Apple"
+            )
+        ])
+        let data = try JSONEncoder().encode(original)
+        let decoded = try JSONDecoder().decode(DeviceListResponse.self, from: data)
+        XCTAssertEqual(decoded, original)
+    }
+
+    func testJSONUsesExpectedKeys() throws {
+        let device = DeviceInfo(
+            uniqueID: "id",
+            localizedName: "name",
+            modelID: "model",
+            manufacturer: "vendor"
+        )
+        let data = try JSONEncoder().encode(device)
+        let json = try XCTUnwrap(
+            JSONSerialization.jsonObject(with: data) as? [String: String]
+        )
+        XCTAssertEqual(json["uniqueID"], "id")
+        XCTAssertEqual(json["localizedName"], "name")
+        XCTAssertEqual(json["modelID"], "model")
+        XCTAssertEqual(json["manufacturer"], "vendor")
+    }
+}

--- a/ios/screen-capture/Tests/ScreenCaptureCoreTests/FrameProtocolTests.swift
+++ b/ios/screen-capture/Tests/ScreenCaptureCoreTests/FrameProtocolTests.swift
@@ -1,0 +1,38 @@
+import XCTest
+@testable import ScreenCaptureCore
+
+final class FrameProtocolTests: XCTestCase {
+    func testEncodeHeaderProducesLittleEndianBytes() {
+        let header = FrameProtocol.Header(
+            width: 0x01020304,
+            height: 0x05060708,
+            bytesPerRow: 0x090A0B0C,
+            timestampMs: 0x0D0E0F10
+        )
+        let data = FrameProtocol.encodeHeader(header)
+        XCTAssertEqual(data.count, FrameProtocol.headerSize)
+        let expected: [UInt8] = [
+            0x04, 0x03, 0x02, 0x01,
+            0x08, 0x07, 0x06, 0x05,
+            0x0C, 0x0B, 0x0A, 0x09,
+            0x10, 0x0F, 0x0E, 0x0D,
+        ]
+        XCTAssertEqual(Array(data), expected)
+    }
+
+    func testDecodeHeaderRoundTrip() {
+        let header = FrameProtocol.Header(
+            width: 1170,
+            height: 2532,
+            bytesPerRow: 4680,
+            timestampMs: 1_234_567
+        )
+        let data = FrameProtocol.encodeHeader(header)
+        XCTAssertEqual(FrameProtocol.decodeHeader(data), header)
+    }
+
+    func testDecodeRejectsShortBuffer() {
+        let truncated = Data(repeating: 0, count: FrameProtocol.headerSize - 1)
+        XCTAssertNil(FrameProtocol.decodeHeader(truncated))
+    }
+}

--- a/ios/screen-capture/Tests/ScreenCaptureCoreTests/FrameWriterTests.swift
+++ b/ios/screen-capture/Tests/ScreenCaptureCoreTests/FrameWriterTests.swift
@@ -1,0 +1,59 @@
+import XCTest
+@testable import ScreenCaptureCore
+
+final class BufferSink: FrameSink {
+    var data = Data()
+    func write(_ chunk: Data) { data.append(chunk) }
+}
+
+final class FrameWriterTests: XCTestCase {
+    func testWritesHeaderFollowedByPayload() {
+        let sink = BufferSink()
+        let start = Date(timeIntervalSince1970: 0)
+        let writer = FrameWriter(sink: sink, startTime: start)
+
+        let width = 2
+        let height = 3
+        let bytesPerRow = 8
+        // 24 bytes of BGRA: 2px × 3 rows × 4 bytes
+        let payload: [UInt8] = (0..<UInt8(bytesPerRow * height)).map { $0 }
+
+        payload.withUnsafeBufferPointer { ptr in
+            writer.write(
+                width: width,
+                height: height,
+                bytesPerRow: bytesPerRow,
+                baseAddress: UnsafeRawPointer(ptr.baseAddress!),
+                timestamp: Date(timeIntervalSince1970: 0.5)
+            )
+        }
+
+        XCTAssertEqual(sink.data.count, FrameProtocol.headerSize + bytesPerRow * height)
+        let header = FrameProtocol.decodeHeader(sink.data.prefix(FrameProtocol.headerSize))
+        XCTAssertEqual(header?.width, UInt32(width))
+        XCTAssertEqual(header?.height, UInt32(height))
+        XCTAssertEqual(header?.bytesPerRow, UInt32(bytesPerRow))
+        XCTAssertEqual(header?.timestampMs, 500)
+        XCTAssertEqual(Array(sink.data.dropFirst(FrameProtocol.headerSize)), payload)
+    }
+
+    func testTimestampClampedToZeroForPriorStartTime() {
+        let sink = BufferSink()
+        let writer = FrameWriter(
+            sink: sink,
+            startTime: Date(timeIntervalSince1970: 100)
+        )
+        let payload: [UInt8] = [0, 1, 2, 3]
+        payload.withUnsafeBufferPointer { ptr in
+            writer.write(
+                width: 1,
+                height: 1,
+                bytesPerRow: 4,
+                baseAddress: UnsafeRawPointer(ptr.baseAddress!),
+                timestamp: Date(timeIntervalSince1970: 0)
+            )
+        }
+        let header = FrameProtocol.decodeHeader(sink.data.prefix(FrameProtocol.headerSize))
+        XCTAssertEqual(header?.timestampMs, 0)
+    }
+}

--- a/scripts/ios/swift-build.sh
+++ b/scripts/ios/swift-build.sh
@@ -57,6 +57,7 @@ echo ""
 MACOS_PACKAGES=(
     "XcodeCompanion"
     "XcodeExtension"
+    "screen-capture"
 )
 
 # iOS + macOS packages (have both platform support)

--- a/scripts/ios/swift-test.sh
+++ b/scripts/ios/swift-test.sh
@@ -70,6 +70,7 @@ TESTABLE_PACKAGES=(
     "XcodeExtension"
     "control-proxy"
     "XCTestRunner"
+    "screen-capture"
 )
 
 # iOS-only packages (tests require iOS simulator - skip in basic test run)

--- a/src/features/screen-stream/IOSDeviceCaptureHelper.ts
+++ b/src/features/screen-stream/IOSDeviceCaptureHelper.ts
@@ -1,0 +1,164 @@
+import {
+  spawn as nodeSpawn,
+  type ChildProcessWithoutNullStreams,
+} from "node:child_process";
+import { EventEmitter } from "node:events";
+import { logger } from "../../utils/logger";
+import {
+  type DecodedFrame,
+  FrameDecoder,
+  type MalformedFrameError,
+} from "./frameProtocol";
+
+/**
+ * Minimal abstraction over `child_process.spawn` so tests can inject
+ * `FakeChildProcess`. Production code uses the Node built-in.
+ */
+export type HelperSpawner = (
+  command: string,
+  args: string[]
+) => ChildProcessWithoutNullStreams;
+
+export interface IosDeviceCaptureHelperOptions {
+  /** Absolute path to the compiled `screen-capture-helper` binary. */
+  binaryPath: string;
+  /** Optional iOS device uniqueID. Omit to capture the first available device. */
+  deviceId?: string;
+  /** Override the spawner for tests. Defaults to `child_process.spawn`. */
+  spawner?: HelperSpawner;
+}
+
+export interface IosDeviceCaptureHelperEvents {
+  frame: (frame: DecodedFrame) => void;
+  malformed: (error: MalformedFrameError) => void;
+  stderr: (line: string) => void;
+  exit: (info: { code: number | null; signal: NodeJS.Signals | null }) => void;
+  error: (error: Error) => void;
+}
+
+/**
+ * Spawns and supervises the Swift `screen-capture-helper` binary, forwarding
+ * decoded BGRA frames to listeners. Lifecycle:
+ *
+ *     const helper = new IOSDeviceCaptureHelper({ binaryPath, deviceId });
+ *     helper.on("frame", frame => …);
+ *     helper.start();
+ *     …
+ *     await helper.stop();
+ */
+export class IOSDeviceCaptureHelper extends EventEmitter {
+  private readonly binaryPath: string;
+  private readonly deviceId?: string;
+  private readonly spawner: HelperSpawner;
+  private readonly decoder = new FrameDecoder();
+  private process: ChildProcessWithoutNullStreams | null = null;
+  private stderrBuffer = "";
+  private exitPromise: Promise<{ code: number | null; signal: NodeJS.Signals | null }> | null = null;
+
+  constructor(options: IosDeviceCaptureHelperOptions) {
+    super();
+    this.binaryPath = options.binaryPath;
+    this.deviceId = options.deviceId;
+    this.spawner = options.spawner ?? (nodeSpawn as HelperSpawner);
+  }
+
+
+  override on<E extends keyof IosDeviceCaptureHelperEvents>(
+    event: E,
+    listener: IosDeviceCaptureHelperEvents[E]
+  ): this {
+    return super.on(event, listener as (...args: any[]) => void);
+  }
+
+
+  override emit<E extends keyof IosDeviceCaptureHelperEvents>(
+    event: E,
+    ...args: Parameters<IosDeviceCaptureHelperEvents[E]>
+  ): boolean {
+    return super.emit(event, ...(args as any[]));
+  }
+
+  get isRunning(): boolean {
+    return this.process !== null && this.process.exitCode === null && !this.process.killed;
+  }
+
+  /** Throws if already started — instances are single-shot. */
+  start(): void {
+    if (this.process !== null) {
+      throw new Error("IOSDeviceCaptureHelper already started");
+    }
+
+    const args: string[] = [];
+    if (this.deviceId !== undefined) {
+      args.push("--device-id", this.deviceId);
+    }
+
+    const proc = this.spawner(this.binaryPath, args);
+    this.process = proc;
+
+    proc.stdout.on("data", chunk => {
+      const buf = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+      const frames = this.decoder.push(buf, err => this.emit("malformed", err));
+      for (const frame of frames) {
+        this.emit("frame", frame);
+      }
+    });
+
+    proc.stderr.on("data", chunk => {
+      const text = Buffer.isBuffer(chunk) ? chunk.toString("utf8") : String(chunk);
+      this.appendStderr(text);
+    });
+
+    proc.once("error", error => {
+      this.emit("error", error instanceof Error ? error : new Error(String(error)));
+    });
+
+    this.exitPromise = new Promise(resolve => {
+      proc.once("exit", (code, signal) => {
+        if (this.stderrBuffer.length > 0) {
+          this.emit("stderr", this.stderrBuffer);
+          this.stderrBuffer = "";
+        }
+        const info = { code, signal };
+        this.emit("exit", info);
+        resolve(info);
+      });
+    });
+
+    logger.debug(
+      `[IOSDeviceCaptureHelper] spawned ${this.binaryPath} pid=${proc.pid ?? "?"}`
+    );
+  }
+
+  /** SIGTERMs the process and awaits exit. No-op if never started or already exited. */
+  async stop(): Promise<{ code: number | null; signal: NodeJS.Signals | null } | null> {
+    const proc = this.process;
+    if (proc === null) {return null;}
+    if (proc.exitCode === null && !proc.killed) {
+      proc.kill("SIGTERM");
+    }
+    const result = await (this.exitPromise ?? Promise.resolve(null));
+    proc.stdout.removeAllListeners();
+    proc.stderr.removeAllListeners();
+    proc.removeAllListeners();
+    this.process = null;
+    return result;
+  }
+
+  private appendStderr(text: string): void {
+    this.stderrBuffer += text;
+    if (this.stderrBuffer.length > IOSDeviceCaptureHelper.STDERR_BUFFER_MAX) {
+      // Helper sent a long line with no newline; flush to avoid unbounded growth.
+      this.emit("stderr", this.stderrBuffer);
+      this.stderrBuffer = "";
+      return;
+    }
+    const lines = this.stderrBuffer.split("\n");
+    this.stderrBuffer = lines.pop() ?? "";
+    for (const line of lines) {
+      this.emit("stderr", line);
+    }
+  }
+
+  private static readonly STDERR_BUFFER_MAX = 64 * 1024;
+}

--- a/src/features/screen-stream/frameProtocol.ts
+++ b/src/features/screen-stream/frameProtocol.ts
@@ -1,0 +1,93 @@
+/**
+ * Decoder for the iOS screen-capture-helper wire protocol.
+ *
+ * Header (16 bytes, little-endian UInt32):
+ *   width(4) | height(4) | bytesPerRow(4) | timestampMs(4)
+ *
+ * Followed by `height * bytesPerRow` bytes of BGRA pixel data.
+ *
+ * The decoder buffers incoming chunks and emits complete frames as soon as
+ * enough bytes have arrived. It tolerates arbitrary chunking from the helper's
+ * stdout pipe.
+ */
+
+export const FRAME_HEADER_SIZE = 16;
+
+export interface FrameHeader {
+  width: number;
+  height: number;
+  bytesPerRow: number;
+  timestampMs: number;
+}
+
+export interface DecodedFrame {
+  header: FrameHeader;
+  pixels: Buffer;
+}
+
+export interface MalformedFrameError {
+  reason: "header_width_zero" | "header_height_zero" | "header_bytes_per_row_too_small";
+  header: FrameHeader;
+}
+
+export class FrameDecoder {
+  private buffer: Buffer = Buffer.alloc(0);
+  private pendingHeader: FrameHeader | null = null;
+
+  /**
+   * Append bytes from the helper's stdout stream and return any frames that
+   * have completed. Malformed headers are surfaced via `onMalformed`; the
+   * decoder discards the offending bytes and continues parsing.
+   */
+  push(chunk: Buffer, onMalformed?: (error: MalformedFrameError) => void): DecodedFrame[] {
+    if (chunk.length > 0) {
+      this.buffer = this.buffer.length === 0 ? chunk : Buffer.concat([this.buffer, chunk]);
+    }
+
+    const frames: DecodedFrame[] = [];
+
+    while (true) {
+      if (this.pendingHeader === null) {
+        if (this.buffer.length < FRAME_HEADER_SIZE) {break;}
+        const header = parseHeader(this.buffer);
+        this.buffer = this.buffer.subarray(FRAME_HEADER_SIZE);
+        const malformed = validateHeader(header);
+        if (malformed) {
+          onMalformed?.({ reason: malformed, header });
+          continue;
+        }
+        this.pendingHeader = header;
+      }
+
+      const expected = this.pendingHeader.height * this.pendingHeader.bytesPerRow;
+      if (this.buffer.length < expected) {break;}
+
+      // Copy pixels to release the underlying chunk allocation; otherwise
+      // every emitted frame pins the entire upstream buffer in memory.
+      const pixels = Buffer.from(this.buffer.subarray(0, expected));
+      this.buffer = this.buffer.subarray(expected);
+      frames.push({ header: this.pendingHeader, pixels });
+      this.pendingHeader = null;
+    }
+
+    return frames;
+  }
+}
+
+function parseHeader(buffer: Buffer): FrameHeader {
+  return {
+    width: buffer.readUInt32LE(0),
+    height: buffer.readUInt32LE(4),
+    bytesPerRow: buffer.readUInt32LE(8),
+    timestampMs: buffer.readUInt32LE(12),
+  };
+}
+
+function validateHeader(header: FrameHeader): MalformedFrameError["reason"] | null {
+  if (header.width === 0) {return "header_width_zero";}
+  if (header.height === 0) {return "header_height_zero";}
+  // BGRA is 4 bytes per pixel; bytesPerRow may include padding but must fit
+  // at least the visible pixels.
+  if (header.bytesPerRow < header.width * 4) {return "header_bytes_per_row_too_small";}
+  return null;
+}

--- a/src/features/screen-stream/index.ts
+++ b/src/features/screen-stream/index.ts
@@ -1,0 +1,13 @@
+export {
+  FRAME_HEADER_SIZE,
+  FrameDecoder,
+  type DecodedFrame,
+  type FrameHeader,
+  type MalformedFrameError,
+} from "./frameProtocol";
+export {
+  IOSDeviceCaptureHelper,
+  type HelperSpawner,
+  type IosDeviceCaptureHelperOptions,
+  type IosDeviceCaptureHelperEvents,
+} from "./IOSDeviceCaptureHelper";

--- a/test/features/screen-stream/IOSDeviceCaptureHelper.test.ts
+++ b/test/features/screen-stream/IOSDeviceCaptureHelper.test.ts
@@ -1,0 +1,184 @@
+import { describe, expect, test } from "bun:test";
+import type { ChildProcessWithoutNullStreams } from "node:child_process";
+import { FakeChildProcess } from "../../fakes/FakeChildProcess";
+import {
+  FRAME_HEADER_SIZE,
+  IOSDeviceCaptureHelper,
+  type DecodedFrame,
+  type MalformedFrameError,
+} from "../../../src/features/screen-stream";
+
+function encodeFrame(
+  width: number,
+  height: number,
+  bytesPerRow: number,
+  timestampMs: number,
+  fill: number
+): Buffer {
+  const header = Buffer.alloc(FRAME_HEADER_SIZE);
+  header.writeUInt32LE(width, 0);
+  header.writeUInt32LE(height, 4);
+  header.writeUInt32LE(bytesPerRow, 8);
+  header.writeUInt32LE(timestampMs, 12);
+  return Buffer.concat([header, Buffer.alloc(height * bytesPerRow, fill)]);
+}
+
+function withFakeSpawner(): { fake: FakeChildProcess; spawnArgs: { command: string; args: string[] }; helper: IOSDeviceCaptureHelper } {
+  const fake = new FakeChildProcess();
+  const spawnArgs = { command: "", args: [] as string[] };
+  const helper = new IOSDeviceCaptureHelper({
+    binaryPath: "/fake/screen-capture-helper",
+    deviceId: "00008140-001A2B3C0AE2401E",
+    spawner: (command, args) => {
+      spawnArgs.command = command;
+      spawnArgs.args = args;
+      return fake as unknown as ChildProcessWithoutNullStreams;
+    },
+  });
+  return { fake, spawnArgs, helper };
+}
+
+function flush(): Promise<void> {
+  return new Promise(resolve => setImmediate(resolve));
+}
+
+describe("IOSDeviceCaptureHelper", () => {
+  test("passes --device-id when constructed with one", () => {
+    const { spawnArgs, helper } = withFakeSpawner();
+    helper.start();
+    expect(spawnArgs.command).toBe("/fake/screen-capture-helper");
+    expect(spawnArgs.args).toEqual([
+      "--device-id",
+      "00008140-001A2B3C0AE2401E",
+    ]);
+  });
+
+  test("omits --device-id when no deviceId is provided", () => {
+    const fake = new FakeChildProcess();
+    const spawnArgs: string[] = [];
+    const helper = new IOSDeviceCaptureHelper({
+      binaryPath: "/fake/screen-capture-helper",
+      spawner: (_command, args) => {
+        spawnArgs.push(...args);
+        return fake as unknown as ChildProcessWithoutNullStreams;
+      },
+    });
+    helper.start();
+    expect(spawnArgs).toEqual([]);
+  });
+
+  test("emits frame events for each decoded frame", async () => {
+    const { fake, helper } = withFakeSpawner();
+    const frames: DecodedFrame[] = [];
+    helper.on("frame", f => frames.push(f));
+    helper.start();
+
+    const buf = Buffer.concat([
+      encodeFrame(1, 1, 4, 10, 0x11),
+      encodeFrame(1, 1, 4, 20, 0x22),
+    ]);
+    fake.stdout.push(buf);
+    await flush();
+
+    expect(frames).toHaveLength(2);
+    expect(frames[0].header.timestampMs).toBe(10);
+    expect(frames[1].header.timestampMs).toBe(20);
+    expect(frames[0].pixels[0]).toBe(0x11);
+    expect(frames[1].pixels[0]).toBe(0x22);
+  });
+
+  test("emits malformed events for invalid headers", async () => {
+    const { fake, helper } = withFakeSpawner();
+    const malformed: MalformedFrameError[] = [];
+    helper.on("malformed", e => malformed.push(e));
+    helper.start();
+
+    const badHeader = Buffer.alloc(FRAME_HEADER_SIZE);
+    badHeader.writeUInt32LE(0, 0); // width
+    badHeader.writeUInt32LE(1, 4);
+    badHeader.writeUInt32LE(4, 8);
+    badHeader.writeUInt32LE(0, 12);
+    fake.stdout.push(badHeader);
+    await flush();
+
+    expect(malformed).toHaveLength(1);
+    expect(malformed[0].reason).toBe("header_width_zero");
+  });
+
+  test("emits stderr lines and flushes a trailing partial line on exit", async () => {
+    const { fake, helper } = withFakeSpawner();
+    const lines: string[] = [];
+    helper.on("stderr", l => lines.push(l));
+    helper.start();
+
+    fake.stderr.push(Buffer.from("warn: device warming up\nerror: incomplete"));
+    await flush();
+    fake.stdout.push(null);
+    fake.stderr.push(null);
+    fake.emit("exit", 0, null);
+    await flush();
+
+    expect(lines).toEqual([
+      "warn: device warming up",
+      "error: incomplete",
+    ]);
+  });
+
+  test("isRunning reflects process lifecycle", async () => {
+    const { fake, helper } = withFakeSpawner();
+    expect(helper.isRunning).toBe(false);
+    helper.start();
+    expect(helper.isRunning).toBe(true);
+    fake.exitCode = 0;
+    fake.emit("exit", 0, null);
+    await flush();
+    expect(helper.isRunning).toBe(false);
+  });
+
+  test("start() throws when already running", () => {
+    const { helper } = withFakeSpawner();
+    helper.start();
+    expect(() => helper.start()).toThrow("IOSDeviceCaptureHelper already started");
+  });
+
+  test("stop() sends SIGTERM and resolves with exit info", async () => {
+    const { fake, helper } = withFakeSpawner();
+    helper.start();
+
+    const result = await helper.stop();
+
+    expect(fake.killed).toBe(true);
+    expect(result?.signal).toBe("SIGTERM");
+  });
+
+  test("stop() is a no-op when never started", async () => {
+    const { helper } = withFakeSpawner();
+    const result = await helper.stop();
+    expect(result).toBeNull();
+  });
+
+  test("emits error event when underlying process emits error", async () => {
+    const { fake, helper } = withFakeSpawner();
+    const errors: Error[] = [];
+    helper.on("error", e => errors.push(e));
+    helper.start();
+    fake.emit("error", new Error("spawn failed"));
+    await flush();
+    expect(errors).toHaveLength(1);
+    expect(errors[0].message).toBe("spawn failed");
+  });
+
+  test("flushes stderr buffer when it grows past the cap without a newline", async () => {
+    const { fake, helper } = withFakeSpawner();
+    const lines: string[] = [];
+    helper.on("stderr", l => lines.push(l));
+    helper.start();
+
+    const giant = "x".repeat(64 * 1024 + 10);
+    fake.stderr.push(Buffer.from(giant));
+    await flush();
+
+    expect(lines).toHaveLength(1);
+    expect(lines[0].length).toBeGreaterThan(64 * 1024);
+  });
+});

--- a/test/features/screen-stream/frameProtocol.test.ts
+++ b/test/features/screen-stream/frameProtocol.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, test } from "bun:test";
+import {
+  FRAME_HEADER_SIZE,
+  FrameDecoder,
+  type MalformedFrameError,
+} from "../../../src/features/screen-stream/frameProtocol";
+
+function encodeHeader(
+  width: number,
+  height: number,
+  bytesPerRow: number,
+  timestampMs: number
+): Buffer {
+  const buf = Buffer.alloc(FRAME_HEADER_SIZE);
+  buf.writeUInt32LE(width, 0);
+  buf.writeUInt32LE(height, 4);
+  buf.writeUInt32LE(bytesPerRow, 8);
+  buf.writeUInt32LE(timestampMs, 12);
+  return buf;
+}
+
+function makeFrameBytes(
+  width: number,
+  height: number,
+  bytesPerRow: number,
+  timestampMs: number,
+  fill: number
+): Buffer {
+  const header = encodeHeader(width, height, bytesPerRow, timestampMs);
+  const pixels = Buffer.alloc(height * bytesPerRow, fill);
+  return Buffer.concat([header, pixels]);
+}
+
+describe("FrameDecoder", () => {
+  test("decodes a complete frame delivered in one chunk", () => {
+    const decoder = new FrameDecoder();
+    const frame = makeFrameBytes(2, 2, 8, 100, 0xab);
+    const out = decoder.push(frame);
+    expect(out).toHaveLength(1);
+    expect(out[0].header).toEqual({
+      width: 2,
+      height: 2,
+      bytesPerRow: 8,
+      timestampMs: 100,
+    });
+    expect(out[0].pixels.length).toBe(16);
+    expect(out[0].pixels[0]).toBe(0xab);
+  });
+
+  test("buffers across multiple chunks split mid-header", () => {
+    const decoder = new FrameDecoder();
+    const frame = makeFrameBytes(1, 1, 4, 50, 0x12);
+
+    expect(decoder.push(frame.subarray(0, 3))).toHaveLength(0);
+    expect(decoder.push(frame.subarray(3, 10))).toHaveLength(0);
+    const out = decoder.push(frame.subarray(10));
+    expect(out).toHaveLength(1);
+    expect(out[0].header.timestampMs).toBe(50);
+  });
+
+  test("emits multiple frames from a single concatenated buffer", () => {
+    const decoder = new FrameDecoder();
+    const a = makeFrameBytes(1, 1, 4, 10, 0x01);
+    const b = makeFrameBytes(1, 1, 4, 20, 0x02);
+    const out = decoder.push(Buffer.concat([a, b]));
+    expect(out).toHaveLength(2);
+    expect(out[0].header.timestampMs).toBe(10);
+    expect(out[1].header.timestampMs).toBe(20);
+    expect(out[0].pixels[0]).toBe(0x01);
+    expect(out[1].pixels[0]).toBe(0x02);
+  });
+
+  test("rejects malformed header (zero width)", () => {
+    const decoder = new FrameDecoder();
+    const malformed = encodeHeader(0, 1, 4, 0);
+    const errors: MalformedFrameError[] = [];
+    const out = decoder.push(malformed, err => errors.push(err));
+    expect(out).toHaveLength(0);
+    expect(errors).toHaveLength(1);
+    expect(errors[0].reason).toBe("header_width_zero");
+  });
+
+  test("rejects bytesPerRow smaller than width*4", () => {
+    const decoder = new FrameDecoder();
+    const malformed = encodeHeader(10, 1, 8, 0); // 10*4 = 40 > 8
+    const errors: MalformedFrameError[] = [];
+    decoder.push(malformed, err => errors.push(err));
+    expect(errors[0].reason).toBe("header_bytes_per_row_too_small");
+  });
+
+  test("recovers after malformed header and decodes next valid frame", () => {
+    const decoder = new FrameDecoder();
+    const bad = encodeHeader(0, 1, 4, 0);
+    const good = makeFrameBytes(1, 1, 4, 99, 0xcd);
+    const errors: MalformedFrameError[] = [];
+    const out = decoder.push(Buffer.concat([bad, good]), err => errors.push(err));
+    expect(errors).toHaveLength(1);
+    expect(out).toHaveLength(1);
+    expect(out[0].header.timestampMs).toBe(99);
+  });
+
+  test("handles empty chunks without emitting frames", () => {
+    const decoder = new FrameDecoder();
+    expect(decoder.push(Buffer.alloc(0))).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
Closes #1095.

## Summary
- Adds the Swift helper that captures USB-connected iOS device screens via AVFoundation and streams raw BGRA frames over stdout with a 16-byte LE header (`width`, `height`, `bytesPerRow`, `timestampMs`), per `docs/design-docs/plat/ios/screen-streaming.md`.
- Adds the Node-side spawn manager that supervises the helper and parses the wire protocol, with all process plumbing behind an injectable `HelperSpawner` so tests use `FakeChildProcess`.

## What's in this PR
- **`ios/screen-capture/`** — new Swift package (macOS 14+, exec target + library)
  - `ScreenCaptureCore` (testable): `FrameProtocol`, `FrameWriter`, `DeviceInfo`, `CommandLineOptions`
  - `ScreenCaptureHelper` (executable): `CMIOSystem` toggle, `DeviceDiscovery`, `DeviceCaptureSession`, `main.swift` with `--list-devices` / `--device-id` and SIGTERM/SIGINT graceful shutdown
  - 13 XCTest cases covering header encode/decode, writer layout, JSON shape, and argument parsing
- **`src/features/screen-stream/`** — Node bridge
  - `FrameDecoder` buffers chunked stdout into complete frames; pixel slices are copied so emitted frames don't pin upstream allocations
  - `IOSDeviceCaptureHelper` emits typed `frame` / `malformed` / `stderr` / `exit` / `error` events, caps the stderr buffer at 64 KB to avoid unbounded growth, and removes all child-stream listeners on `stop()`
  - 18 Bun unit tests with `FakeChildProcess` (no real spawning)
- Wires the new package into `scripts/ios/swift-build.sh` and `scripts/ios/swift-test.sh` so CI builds and tests it alongside the existing macOS packages.
- Updates the design doc to mark Milestone 1 partially complete; Unix-socket fan-out (`video-stream.sock`) and the IDE-plugin receiver remain follow-ups (covered by separate issues).

## Test plan
- [x] `bun run lint` — clean
- [x] `bun test` — 4114 pass, 0 fail (includes 18 new tests under `test/features/screen-stream/`)
- [x] `swift build -Xswiftc -warnings-as-errors` (in `ios/screen-capture/`) — succeeds
- [x] `swift test` (in `ios/screen-capture/`) — 13 pass, 0 fail
- [ ] Manual verification on a USB-connected iPhone with `./ios/screen-capture/.build/debug/screen-capture-helper --list-devices` then piping `screen-capture-helper --device-id <id>` into a frame consumer (requires hardware; out of automation scope)