### PR TITLE
feat(ios): ScreenCaptureKit simulator window capture

### DIFF
--- a/docs/design-docs/plat/ios/screen-streaming.md
+++ b/docs/design-docs/plat/ios/screen-streaming.md
@@ -278,9 +278,11 @@ Followed by `height * bytesPerRow` bytes of BGRA pixel data.
 - [ ] Test with MCP server integration
 
 ### Milestone 2: Simulator Capture
-- [ ] Create ScreenCaptureKit-based capture for simulator windows
-- [ ] Handle simulator window discovery
-- [ ] Integrate with same Unix socket protocol
+- [x] Create ScreenCaptureKit-based capture for simulator windows (`SimulatorCaptureSession`)
+- [x] Handle simulator window discovery (`SimulatorWindowDiscovery`, `--list-simulators`)
+- [x] Unified Swift CLI handles both device and simulator targets
+- [x] Node `IOSScreenCaptureHelper` accepts `{ kind: "device" | "simulator" }` targets
+- [ ] Unix-socket fan-out (shared with Milestone 1 follow-up)
 
 ### Milestone 3: IDE Plugin Integration
 - [ ] Add raw frame receiver (simpler than Klarity H.264 path)

--- a/ios/screen-capture/Sources/ScreenCaptureCore/CommandLineOptions.swift
+++ b/ios/screen-capture/Sources/ScreenCaptureCore/CommandLineOptions.swift
@@ -5,6 +5,8 @@ public struct CommandLineOptions: Equatable {
     public enum Mode: Equatable {
         case listDevices
         case capture(deviceID: String?)
+        case listSimulators
+        case captureSimulator(windowID: UInt32)
         case help
     }
 
@@ -17,6 +19,8 @@ public struct CommandLineOptions: Equatable {
     public enum ParseError: Error, Equatable {
         case missingValue(flag: String)
         case unknownArgument(String)
+        case invalidValue(flag: String, value: String)
+        case conflictingFlags(String)
     }
 
     public static func parse(_ arguments: [String]) throws -> CommandLineOptions {
@@ -25,6 +29,8 @@ public struct CommandLineOptions: Equatable {
 
         var listDevices = false
         var deviceID: String?
+        var listSimulators = false
+        var simulatorWindowID: UInt32?
         var help = false
 
         while let arg = iterator.next() {
@@ -36,6 +42,16 @@ public struct CommandLineOptions: Equatable {
                     throw ParseError.missingValue(flag: arg)
                 }
                 deviceID = value
+            case "--list-simulators":
+                listSimulators = true
+            case "--simulator-window":
+                guard let value = iterator.next() else {
+                    throw ParseError.missingValue(flag: arg)
+                }
+                guard let parsed = UInt32(value) else {
+                    throw ParseError.invalidValue(flag: arg, value: value)
+                }
+                simulatorWindowID = parsed
             case "-h", "--help":
                 help = true
             default:
@@ -46,24 +62,50 @@ public struct CommandLineOptions: Equatable {
         if help {
             return CommandLineOptions(mode: .help)
         }
+
+        let modeFlagCount = [
+            listDevices,
+            listSimulators,
+            simulatorWindowID != nil,
+            deviceID != nil,
+        ].filter { $0 }.count
+        if modeFlagCount > 1 {
+            throw ParseError.conflictingFlags(
+                "choose one of --list-devices, --device-id, --list-simulators, --simulator-window"
+            )
+        }
+
         if listDevices {
             return CommandLineOptions(mode: .listDevices)
+        }
+        if listSimulators {
+            return CommandLineOptions(mode: .listSimulators)
+        }
+        if let windowID = simulatorWindowID {
+            return CommandLineOptions(mode: .captureSimulator(windowID: windowID))
         }
         return CommandLineOptions(mode: .capture(deviceID: deviceID))
     }
 
     public static let helpText = """
-    screen-capture-helper — AutoMobile iOS device capture helper
+    screen-capture-helper — AutoMobile iOS screen-capture helper
 
     USAGE:
         screen-capture-helper [--device-id <id>]
         screen-capture-helper --list-devices
+        screen-capture-helper --simulator-window <windowID>
+        screen-capture-helper --list-simulators
 
-    OPTIONS:
-        --list-devices       Emit discovered devices as JSON to stdout and exit.
-        --device-id <id>     uniqueID of the device to capture. If omitted, the
-                             first muxed external device is used.
-        -h, --help           Show this help.
+    DEVICE OPTIONS (USB-connected iOS devices via AVFoundation):
+        --list-devices         Emit discovered devices as JSON to stdout and exit.
+        --device-id <id>       uniqueID of the device to capture. If omitted, the
+                               first muxed external device is used.
+
+    SIMULATOR OPTIONS (macOS iOS Simulator windows via ScreenCaptureKit):
+        --list-simulators      Emit discovered simulator windows as JSON and exit.
+        --simulator-window <n> CGWindowID of the simulator window to capture.
+
+        -h, --help             Show this help.
 
     Frames are written to stdout: 16-byte little-endian header
     (width, height, bytesPerRow, timestampMs) followed by

--- a/ios/screen-capture/Sources/ScreenCaptureCore/SimulatorWindowInfo.swift
+++ b/ios/screen-capture/Sources/ScreenCaptureCore/SimulatorWindowInfo.swift
@@ -1,0 +1,42 @@
+import Foundation
+
+/// Serializable description of an iOS Simulator window discovered via
+/// ScreenCaptureKit. Emitted as JSON by `screen-capture-helper --list-simulators`.
+public struct SimulatorWindowInfo: Codable, Equatable {
+    public let windowID: UInt32
+    public let title: String?
+    public let applicationName: String
+    public let bundleIdentifier: String
+    public let processID: Int32
+    public let width: Int
+    public let height: Int
+
+    public init(
+        windowID: UInt32,
+        title: String?,
+        applicationName: String,
+        bundleIdentifier: String,
+        processID: Int32,
+        width: Int,
+        height: Int
+    ) {
+        self.windowID = windowID
+        self.title = title
+        self.applicationName = applicationName
+        self.bundleIdentifier = bundleIdentifier
+        self.processID = processID
+        self.width = width
+        self.height = height
+    }
+}
+
+public struct SimulatorWindowListResponse: Codable, Equatable {
+    public let windows: [SimulatorWindowInfo]
+
+    public init(windows: [SimulatorWindowInfo]) {
+        self.windows = windows
+    }
+}
+
+/// Bundle identifier of the iOS Simulator host application on macOS.
+public let simulatorBundleIdentifier = "com.apple.iphonesimulator"

--- a/ios/screen-capture/Sources/ScreenCaptureHelper/DeviceCaptureSession.swift
+++ b/ios/screen-capture/Sources/ScreenCaptureHelper/DeviceCaptureSession.swift
@@ -43,16 +43,6 @@ final class DeviceCaptureSession: NSObject, AVCaptureVideoDataOutputSampleBuffer
         didOutput sampleBuffer: CMSampleBuffer,
         from connection: AVCaptureConnection
     ) {
-        guard let pixelBuffer = CMSampleBufferGetImageBuffer(sampleBuffer) else { return }
-        CVPixelBufferLockBaseAddress(pixelBuffer, .readOnly)
-        defer { CVPixelBufferUnlockBaseAddress(pixelBuffer, .readOnly) }
-        guard let base = CVPixelBufferGetBaseAddress(pixelBuffer) else { return }
-
-        writer.write(
-            width: CVPixelBufferGetWidth(pixelBuffer),
-            height: CVPixelBufferGetHeight(pixelBuffer),
-            bytesPerRow: CVPixelBufferGetBytesPerRow(pixelBuffer),
-            baseAddress: base
-        )
+        writer.write(sampleBuffer: sampleBuffer)
     }
 }

--- a/ios/screen-capture/Sources/ScreenCaptureHelper/FrameWriter+PixelBuffer.swift
+++ b/ios/screen-capture/Sources/ScreenCaptureHelper/FrameWriter+PixelBuffer.swift
@@ -1,0 +1,25 @@
+import CoreMedia
+import CoreVideo
+import Foundation
+import ScreenCaptureCore
+
+extension FrameWriter {
+    /// Writes one frame from a `CMSampleBuffer`, locking the underlying pixel
+    /// buffer for the duration of the synchronous sink write. Returns `false`
+    /// when the sample buffer has no image (e.g. dropped/idle frames).
+    @discardableResult
+    func write(sampleBuffer: CMSampleBuffer) -> Bool {
+        guard let pixelBuffer = CMSampleBufferGetImageBuffer(sampleBuffer) else { return false }
+        CVPixelBufferLockBaseAddress(pixelBuffer, .readOnly)
+        defer { CVPixelBufferUnlockBaseAddress(pixelBuffer, .readOnly) }
+        guard let base = CVPixelBufferGetBaseAddress(pixelBuffer) else { return false }
+
+        write(
+            width: CVPixelBufferGetWidth(pixelBuffer),
+            height: CVPixelBufferGetHeight(pixelBuffer),
+            bytesPerRow: CVPixelBufferGetBytesPerRow(pixelBuffer),
+            baseAddress: base
+        )
+        return true
+    }
+}

--- a/ios/screen-capture/Sources/ScreenCaptureHelper/SimulatorCaptureSession.swift
+++ b/ios/screen-capture/Sources/ScreenCaptureHelper/SimulatorCaptureSession.swift
@@ -1,0 +1,69 @@
+import CoreMedia
+import CoreVideo
+import Foundation
+import ScreenCaptureKit
+import ScreenCaptureCore
+
+/// Streams BGRA frames from a single iOS Simulator window via ScreenCaptureKit.
+/// Targets up to 60fps; the writer trims to the frame protocol on the way out.
+final class SimulatorCaptureSession: NSObject, SCStreamOutput, SCStreamDelegate {
+    private let writer: FrameWriter
+    private let queue = DispatchQueue(label: "automobile.simulator-capture.frames")
+    private var stream: SCStream?
+
+    init(writer: FrameWriter) {
+        self.writer = writer
+    }
+
+    private static let kTargetFPS: Int32 = 60
+
+    func start(window: SCWindow) async throws {
+        let filter = SCContentFilter(desktopIndependentWindow: window)
+        let config = SCStreamConfiguration()
+        // Logical (points) size; the delivered CVPixelBuffer is in native
+        // pixels (2x/3x for Retina), and downstream consumers must use
+        // CVPixelBufferGetWidth/Height — not these values — to allocate sinks.
+        config.width = Int(window.frame.width)
+        config.height = Int(window.frame.height)
+        config.pixelFormat = kCVPixelFormatType_32BGRA
+        config.minimumFrameInterval = CMTime(
+            value: 1,
+            timescale: SimulatorCaptureSession.kTargetFPS
+        )
+        config.showsCursor = false
+        config.scalesToFit = false
+
+        let stream = SCStream(filter: filter, configuration: config, delegate: self)
+        try stream.addStreamOutput(self, type: .screen, sampleHandlerQueue: queue)
+        try await stream.startCapture()
+        self.stream = stream
+    }
+
+    func stop() async {
+        guard let stream = stream else { return }
+        // removeStreamOutput breaks the SCStream → self retain cycle so the
+        // session is collectable even before SCStream itself goes away.
+        try? stream.removeStreamOutput(self, type: .screen)
+        try? await stream.stopCapture()
+        self.stream = nil
+    }
+
+    // MARK: - SCStreamOutput
+
+    func stream(
+        _ stream: SCStream,
+        didOutputSampleBuffer sampleBuffer: CMSampleBuffer,
+        of type: SCStreamOutputType
+    ) {
+        guard type == .screen, sampleBuffer.isValid else { return }
+        writer.write(sampleBuffer: sampleBuffer)
+    }
+
+    // MARK: - SCStreamDelegate
+
+    func stream(_ stream: SCStream, didStopWithError error: Error) {
+        FileHandle.standardError.write(
+            Data("error: ScreenCaptureKit stream stopped: \(error)\n".utf8)
+        )
+    }
+}

--- a/ios/screen-capture/Sources/ScreenCaptureHelper/SimulatorWindowDiscovery.swift
+++ b/ios/screen-capture/Sources/ScreenCaptureHelper/SimulatorWindowDiscovery.swift
@@ -1,0 +1,37 @@
+import Foundation
+import ScreenCaptureKit
+import ScreenCaptureCore
+
+enum SimulatorWindowDiscovery {
+    /// Discovers visible iOS Simulator windows via ScreenCaptureKit.
+    /// Requires screen-recording permission; throws if the user has not granted it.
+    static func discover() async throws -> [SimulatorWindowInfo] {
+        let content = try await SCShareableContent.excludingDesktopWindows(
+            false,
+            onScreenWindowsOnly: true
+        )
+        return content.windows
+            .filter { $0.owningApplication?.bundleIdentifier == simulatorBundleIdentifier }
+            .map(toInfo)
+    }
+
+    static func find(windowID: UInt32) async throws -> SCWindow? {
+        let content = try await SCShareableContent.excludingDesktopWindows(
+            false,
+            onScreenWindowsOnly: true
+        )
+        return content.windows.first { $0.windowID == windowID }
+    }
+
+    static func toInfo(_ window: SCWindow) -> SimulatorWindowInfo {
+        SimulatorWindowInfo(
+            windowID: window.windowID,
+            title: window.title,
+            applicationName: window.owningApplication?.applicationName ?? "",
+            bundleIdentifier: window.owningApplication?.bundleIdentifier ?? "",
+            processID: window.owningApplication?.processID ?? 0,
+            width: Int(window.frame.width),
+            height: Int(window.frame.height)
+        )
+    }
+}

--- a/ios/screen-capture/Sources/ScreenCaptureHelper/main.swift
+++ b/ios/screen-capture/Sources/ScreenCaptureHelper/main.swift
@@ -1,11 +1,25 @@
 import AVFoundation
 import Foundation
+import ScreenCaptureKit
 import ScreenCaptureCore
 
 // MARK: - Logging
 
 func logError(_ message: String) {
     FileHandle.standardError.write(Data("\(message)\n".utf8))
+}
+
+func writeJSON<T: Encodable>(_ value: T) {
+    let encoder = JSONEncoder()
+    encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+    do {
+        let data = try encoder.encode(value)
+        FileHandle.standardOutput.write(data)
+        FileHandle.standardOutput.write(Data("\n".utf8))
+    } catch {
+        logError("error: failed to encode JSON: \(error)")
+        exit(1)
+    }
 }
 
 // MARK: - Argument parsing
@@ -19,6 +33,14 @@ do {
     exit(2)
 } catch let CommandLineOptions.ParseError.unknownArgument(arg) {
     logError("error: unknown argument \(arg)")
+    logError(CommandLineOptions.helpText)
+    exit(2)
+} catch let CommandLineOptions.ParseError.invalidValue(flag, value) {
+    logError("error: invalid value '\(value)' for \(flag)")
+    logError(CommandLineOptions.helpText)
+    exit(2)
+} catch let CommandLineOptions.ParseError.conflictingFlags(message) {
+    logError("error: conflicting flags — \(message)")
     logError(CommandLineOptions.helpText)
     exit(2)
 } catch {
@@ -38,18 +60,47 @@ case .listDevices:
     // Allow a brief moment for the system to register USB devices.
     Thread.sleep(forTimeInterval: 0.5)
     let infos = DeviceDiscovery.discover().map(DeviceDiscovery.toInfo)
-    let response = DeviceListResponse(devices: infos)
-    let encoder = JSONEncoder()
-    encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
-    do {
-        let data = try encoder.encode(response)
-        FileHandle.standardOutput.write(data)
-        FileHandle.standardOutput.write(Data("\n".utf8))
-    } catch {
-        logError("error: failed to encode device list: \(error)")
+    writeJSON(DeviceListResponse(devices: infos))
+    exit(0)
+
+case .listSimulators:
+    switch runBlocking({ try await SimulatorWindowDiscovery.discover() }) {
+    case .success(let windows):
+        writeJSON(SimulatorWindowListResponse(windows: windows))
+        exit(0)
+    case .failure(let error):
+        logError("error: failed to query simulator windows: \(error)")
+        logError("hint: grant Screen Recording permission to your terminal/IDE.")
         exit(1)
     }
-    exit(0)
+
+case .captureSimulator(let windowID):
+    let window: SCWindow
+    switch runBlocking({ try await SimulatorWindowDiscovery.find(windowID: windowID) }) {
+    case .success(.some(let resolved)):
+        window = resolved
+    case .success(.none):
+        logError("error: no window with CGWindowID \(windowID)")
+        exit(1)
+    case .failure(let error):
+        logError("error: failed to query simulator windows: \(error)")
+        exit(1)
+    }
+
+    let sink = FileHandleFrameSink(handle: .standardOutput)
+    let writer = FrameWriter(sink: sink)
+    let simSession = SimulatorCaptureSession(writer: writer)
+
+    if case .failure(let error) = runBlocking({ try await simSession.start(window: window) }) {
+        logError("error: failed to start simulator capture: \(error)")
+        exit(1)
+    }
+
+    installShutdownHandlers {
+        runBlocking { await simSession.stop() }
+        exit(0)
+    }
+    RunLoop.main.run()
 
 case .capture(let deviceID):
     CMIOSystem.enableScreenCaptureDevices()
@@ -82,19 +133,63 @@ case .capture(let deviceID):
         exit(1)
     }
 
-    // Graceful shutdown on SIGTERM/SIGINT.
-    let termSource = DispatchSource.makeSignalSource(signal: SIGTERM, queue: .main)
-    let intSource = DispatchSource.makeSignalSource(signal: SIGINT, queue: .main)
-    signal(SIGTERM, SIG_IGN)
-    signal(SIGINT, SIG_IGN)
-    let shutdown = {
+    installShutdownHandlers {
         captureSession.stop()
         exit(0)
     }
-    termSource.setEventHandler(handler: shutdown)
-    intSource.setEventHandler(handler: shutdown)
+    RunLoop.main.run()
+}
+
+// MARK: - Async/sync bridges
+
+func runBlocking<T>(_ body: @escaping () async throws -> T) -> Result<T, Error> {
+    let semaphore = DispatchSemaphore(value: 0)
+    var result: Result<T, Error> = .failure(CancellationError())
+    Task {
+        result = await Result { try await body() }
+        semaphore.signal()
+    }
+    semaphore.wait()
+    return result
+}
+
+func runBlocking<T>(_ body: @escaping () async -> T) -> T {
+    let semaphore = DispatchSemaphore(value: 0)
+    var result: T?
+    Task {
+        result = await body()
+        semaphore.signal()
+    }
+    semaphore.wait()
+    return result!
+}
+
+extension Result where Failure == Error {
+    init(catching body: () async throws -> Success) async {
+        do {
+            self = .success(try await body())
+        } catch {
+            self = .failure(error)
+        }
+    }
+}
+
+// MARK: - Signal handling
+
+// Retain signal sources beyond `installShutdownHandlers` to keep them alive
+// for the duration of the run loop.
+private var retainedSignalSources: [DispatchSourceSignal] = []
+
+func installShutdownHandlers(_ handler: @escaping () -> Void) {
+    let termSource = DispatchSource.makeSignalSource(signal: SIGTERM, queue: .main)
+    let intSource = DispatchSource.makeSignalSource(signal: SIGINT, queue: .main)
+    // Ignore the default disposition so the DispatchSources are the only
+    // handlers that run.
+    signal(SIGTERM, SIG_IGN)
+    signal(SIGINT, SIG_IGN)
+    termSource.setEventHandler(handler: handler)
+    intSource.setEventHandler(handler: handler)
     termSource.resume()
     intSource.resume()
-
-    RunLoop.main.run()
+    retainedSignalSources = [termSource, intSource]
 }

--- a/ios/screen-capture/Tests/ScreenCaptureCoreTests/CommandLineOptionsTests.swift
+++ b/ios/screen-capture/Tests/ScreenCaptureCoreTests/CommandLineOptionsTests.swift
@@ -49,4 +49,66 @@ final class CommandLineOptionsTests: XCTestCase {
             )
         }
     }
+
+    func testParsesListSimulators() throws {
+        let opts = try CommandLineOptions.parse([
+            "screen-capture-helper", "--list-simulators"
+        ])
+        XCTAssertEqual(opts.mode, .listSimulators)
+    }
+
+    func testParsesSimulatorWindow() throws {
+        let opts = try CommandLineOptions.parse([
+            "screen-capture-helper", "--simulator-window", "98765"
+        ])
+        XCTAssertEqual(opts.mode, .captureSimulator(windowID: 98765))
+    }
+
+    func testInvalidSimulatorWindowValueThrows() {
+        XCTAssertThrowsError(try CommandLineOptions.parse([
+            "screen-capture-helper", "--simulator-window", "not-a-number"
+        ])) { error in
+            XCTAssertEqual(
+                error as? CommandLineOptions.ParseError,
+                .invalidValue(flag: "--simulator-window", value: "not-a-number")
+            )
+        }
+    }
+
+    func testMissingSimulatorWindowValueThrows() {
+        XCTAssertThrowsError(try CommandLineOptions.parse([
+            "screen-capture-helper", "--simulator-window"
+        ])) { error in
+            XCTAssertEqual(
+                error as? CommandLineOptions.ParseError,
+                .missingValue(flag: "--simulator-window")
+            )
+        }
+    }
+
+    func testConflictingDeviceAndSimulatorFlagsThrow() {
+        XCTAssertThrowsError(try CommandLineOptions.parse([
+            "screen-capture-helper",
+            "--device-id", "abc",
+            "--simulator-window", "1",
+        ])) { error in
+            guard case CommandLineOptions.ParseError.conflictingFlags = error else {
+                XCTFail("expected conflictingFlags, got \(error)")
+                return
+            }
+        }
+    }
+
+    func testConflictingListFlagsThrow() {
+        XCTAssertThrowsError(try CommandLineOptions.parse([
+            "screen-capture-helper",
+            "--list-devices",
+            "--list-simulators",
+        ])) { error in
+            guard case CommandLineOptions.ParseError.conflictingFlags = error else {
+                XCTFail("expected conflictingFlags, got \(error)")
+                return
+            }
+        }
+    }
 }

--- a/ios/screen-capture/Tests/ScreenCaptureCoreTests/SimulatorWindowInfoTests.swift
+++ b/ios/screen-capture/Tests/ScreenCaptureCoreTests/SimulatorWindowInfoTests.swift
@@ -1,0 +1,40 @@
+import XCTest
+@testable import ScreenCaptureCore
+
+final class SimulatorWindowInfoTests: XCTestCase {
+    func testRoundTripsThroughJSON() throws {
+        let original = SimulatorWindowListResponse(windows: [
+            SimulatorWindowInfo(
+                windowID: 12345,
+                title: "iPhone 15 Pro — iOS 17.4",
+                applicationName: "Simulator",
+                bundleIdentifier: simulatorBundleIdentifier,
+                processID: 4242,
+                width: 1170,
+                height: 2532
+            )
+        ])
+        let data = try JSONEncoder().encode(original)
+        let decoded = try JSONDecoder().decode(SimulatorWindowListResponse.self, from: data)
+        XCTAssertEqual(decoded, original)
+    }
+
+    func testTitleMayBeNil() throws {
+        let info = SimulatorWindowInfo(
+            windowID: 1,
+            title: nil,
+            applicationName: "Simulator",
+            bundleIdentifier: simulatorBundleIdentifier,
+            processID: 1,
+            width: 0,
+            height: 0
+        )
+        let data = try JSONEncoder().encode(info)
+        let decoded = try JSONDecoder().decode(SimulatorWindowInfo.self, from: data)
+        XCTAssertNil(decoded.title)
+    }
+
+    func testSimulatorBundleIdentifierConstant() {
+        XCTAssertEqual(simulatorBundleIdentifier, "com.apple.iphonesimulator")
+    }
+}

--- a/src/features/screen-stream/IOSScreenCaptureHelper.ts
+++ b/src/features/screen-stream/IOSScreenCaptureHelper.ts
@@ -10,25 +10,28 @@ import {
   type MalformedFrameError,
 } from "./frameProtocol";
 
-/**
- * Minimal abstraction over `child_process.spawn` so tests can inject
- * `FakeChildProcess`. Production code uses the Node built-in.
- */
 export type HelperSpawner = (
   command: string,
   args: string[]
 ) => ChildProcessWithoutNullStreams;
 
-export interface IosDeviceCaptureHelperOptions {
+/**
+ * What the helper should capture. Either a USB-connected iOS device (via
+ * AVFoundation) or a macOS iOS Simulator window (via ScreenCaptureKit).
+ */
+export type CaptureTarget =
+  | { kind: "device"; deviceId?: string }
+  | { kind: "simulator"; windowID: number };
+
+export interface IosScreenCaptureHelperOptions {
   /** Absolute path to the compiled `screen-capture-helper` binary. */
   binaryPath: string;
-  /** Optional iOS device uniqueID. Omit to capture the first available device. */
-  deviceId?: string;
+  target: CaptureTarget;
   /** Override the spawner for tests. Defaults to `child_process.spawn`. */
   spawner?: HelperSpawner;
 }
 
-export interface IosDeviceCaptureHelperEvents {
+export interface IosScreenCaptureHelperEvents {
   frame: (frame: DecodedFrame) => void;
   malformed: (error: MalformedFrameError) => void;
   stderr: (line: string) => void;
@@ -38,42 +41,43 @@ export interface IosDeviceCaptureHelperEvents {
 
 /**
  * Spawns and supervises the Swift `screen-capture-helper` binary, forwarding
- * decoded BGRA frames to listeners. Lifecycle:
+ * decoded BGRA frames to listeners.
  *
- *     const helper = new IOSDeviceCaptureHelper({ binaryPath, deviceId });
+ *     const helper = new IOSScreenCaptureHelper({
+ *       binaryPath,
+ *       target: { kind: "simulator", windowID: 12345 },
+ *     });
  *     helper.on("frame", frame => …);
  *     helper.start();
  *     …
  *     await helper.stop();
  */
-export class IOSDeviceCaptureHelper extends EventEmitter {
+export class IOSScreenCaptureHelper extends EventEmitter {
   private readonly binaryPath: string;
-  private readonly deviceId?: string;
+  private readonly target: CaptureTarget;
   private readonly spawner: HelperSpawner;
   private readonly decoder = new FrameDecoder();
   private process: ChildProcessWithoutNullStreams | null = null;
   private stderrBuffer = "";
   private exitPromise: Promise<{ code: number | null; signal: NodeJS.Signals | null }> | null = null;
 
-  constructor(options: IosDeviceCaptureHelperOptions) {
+  constructor(options: IosScreenCaptureHelperOptions) {
     super();
     this.binaryPath = options.binaryPath;
-    this.deviceId = options.deviceId;
+    this.target = options.target;
     this.spawner = options.spawner ?? (nodeSpawn as HelperSpawner);
   }
 
-
-  override on<E extends keyof IosDeviceCaptureHelperEvents>(
+  override on<E extends keyof IosScreenCaptureHelperEvents>(
     event: E,
-    listener: IosDeviceCaptureHelperEvents[E]
+    listener: IosScreenCaptureHelperEvents[E]
   ): this {
     return super.on(event, listener as (...args: any[]) => void);
   }
 
-
-  override emit<E extends keyof IosDeviceCaptureHelperEvents>(
+  override emit<E extends keyof IosScreenCaptureHelperEvents>(
     event: E,
-    ...args: Parameters<IosDeviceCaptureHelperEvents[E]>
+    ...args: Parameters<IosScreenCaptureHelperEvents[E]>
   ): boolean {
     return super.emit(event, ...(args as any[]));
   }
@@ -85,14 +89,10 @@ export class IOSDeviceCaptureHelper extends EventEmitter {
   /** Throws if already started — instances are single-shot. */
   start(): void {
     if (this.process !== null) {
-      throw new Error("IOSDeviceCaptureHelper already started");
+      throw new Error("IOSScreenCaptureHelper already started");
     }
 
-    const args: string[] = [];
-    if (this.deviceId !== undefined) {
-      args.push("--device-id", this.deviceId);
-    }
-
+    const args = buildArgs(this.target);
     const proc = this.spawner(this.binaryPath, args);
     this.process = proc;
 
@@ -126,7 +126,7 @@ export class IOSDeviceCaptureHelper extends EventEmitter {
     });
 
     logger.debug(
-      `[IOSDeviceCaptureHelper] spawned ${this.binaryPath} pid=${proc.pid ?? "?"}`
+      `[IOSScreenCaptureHelper] spawned ${this.binaryPath} pid=${proc.pid ?? "?"}`
     );
   }
 
@@ -147,7 +147,7 @@ export class IOSDeviceCaptureHelper extends EventEmitter {
 
   private appendStderr(text: string): void {
     this.stderrBuffer += text;
-    if (this.stderrBuffer.length > IOSDeviceCaptureHelper.STDERR_BUFFER_MAX) {
+    if (this.stderrBuffer.length > IOSScreenCaptureHelper.STDERR_BUFFER_MAX) {
       // Helper sent a long line with no newline; flush to avoid unbounded growth.
       this.emit("stderr", this.stderrBuffer);
       this.stderrBuffer = "";
@@ -161,4 +161,13 @@ export class IOSDeviceCaptureHelper extends EventEmitter {
   }
 
   private static readonly STDERR_BUFFER_MAX = 64 * 1024;
+}
+
+function buildArgs(target: CaptureTarget): string[] {
+  switch (target.kind) {
+    case "device":
+      return target.deviceId !== undefined ? ["--device-id", target.deviceId] : [];
+    case "simulator":
+      return ["--simulator-window", String(target.windowID)];
+  }
 }

--- a/src/features/screen-stream/index.ts
+++ b/src/features/screen-stream/index.ts
@@ -6,8 +6,9 @@ export {
   type MalformedFrameError,
 } from "./frameProtocol";
 export {
-  IOSDeviceCaptureHelper,
+  IOSScreenCaptureHelper,
+  type CaptureTarget,
   type HelperSpawner,
-  type IosDeviceCaptureHelperOptions,
-  type IosDeviceCaptureHelperEvents,
-} from "./IOSDeviceCaptureHelper";
+  type IosScreenCaptureHelperOptions,
+  type IosScreenCaptureHelperEvents,
+} from "./IOSScreenCaptureHelper";

--- a/test/features/screen-stream/IOSScreenCaptureHelper.test.ts
+++ b/test/features/screen-stream/IOSScreenCaptureHelper.test.ts
@@ -3,7 +3,8 @@ import type { ChildProcessWithoutNullStreams } from "node:child_process";
 import { FakeChildProcess } from "../../fakes/FakeChildProcess";
 import {
   FRAME_HEADER_SIZE,
-  IOSDeviceCaptureHelper,
+  IOSScreenCaptureHelper,
+  type CaptureTarget,
   type DecodedFrame,
   type MalformedFrameError,
 } from "../../../src/features/screen-stream";
@@ -23,12 +24,14 @@ function encodeFrame(
   return Buffer.concat([header, Buffer.alloc(height * bytesPerRow, fill)]);
 }
 
-function withFakeSpawner(): { fake: FakeChildProcess; spawnArgs: { command: string; args: string[] }; helper: IOSDeviceCaptureHelper } {
+function withFakeSpawner(
+  target: CaptureTarget = { kind: "device", deviceId: "00008140-001A2B3C0AE2401E" }
+): { fake: FakeChildProcess; spawnArgs: { command: string; args: string[] }; helper: IOSScreenCaptureHelper } {
   const fake = new FakeChildProcess();
   const spawnArgs = { command: "", args: [] as string[] };
-  const helper = new IOSDeviceCaptureHelper({
+  const helper = new IOSScreenCaptureHelper({
     binaryPath: "/fake/screen-capture-helper",
-    deviceId: "00008140-001A2B3C0AE2401E",
+    target,
     spawner: (command, args) => {
       spawnArgs.command = command;
       spawnArgs.args = args;
@@ -42,8 +45,8 @@ function flush(): Promise<void> {
   return new Promise(resolve => setImmediate(resolve));
 }
 
-describe("IOSDeviceCaptureHelper", () => {
-  test("passes --device-id when constructed with one", () => {
+describe("IOSScreenCaptureHelper", () => {
+  test("passes --device-id for device target with deviceId", () => {
     const { spawnArgs, helper } = withFakeSpawner();
     helper.start();
     expect(spawnArgs.command).toBe("/fake/screen-capture-helper");
@@ -53,18 +56,16 @@ describe("IOSDeviceCaptureHelper", () => {
     ]);
   });
 
-  test("omits --device-id when no deviceId is provided", () => {
-    const fake = new FakeChildProcess();
-    const spawnArgs: string[] = [];
-    const helper = new IOSDeviceCaptureHelper({
-      binaryPath: "/fake/screen-capture-helper",
-      spawner: (_command, args) => {
-        spawnArgs.push(...args);
-        return fake as unknown as ChildProcessWithoutNullStreams;
-      },
-    });
+  test("omits --device-id when device target has no deviceId", () => {
+    const { spawnArgs, helper } = withFakeSpawner({ kind: "device" });
     helper.start();
-    expect(spawnArgs).toEqual([]);
+    expect(spawnArgs.args).toEqual([]);
+  });
+
+  test("passes --simulator-window for simulator target", () => {
+    const { spawnArgs, helper } = withFakeSpawner({ kind: "simulator", windowID: 98765 });
+    helper.start();
+    expect(spawnArgs.args).toEqual(["--simulator-window", "98765"]);
   });
 
   test("emits frame events for each decoded frame", async () => {
@@ -87,6 +88,17 @@ describe("IOSDeviceCaptureHelper", () => {
     expect(frames[1].pixels[0]).toBe(0x22);
   });
 
+  test("simulator target also emits frame events", async () => {
+    const { fake, helper } = withFakeSpawner({ kind: "simulator", windowID: 1 });
+    const frames: DecodedFrame[] = [];
+    helper.on("frame", f => frames.push(f));
+    helper.start();
+    fake.stdout.push(encodeFrame(2, 2, 8, 33, 0xfa));
+    await flush();
+    expect(frames).toHaveLength(1);
+    expect(frames[0].header.width).toBe(2);
+  });
+
   test("emits malformed events for invalid headers", async () => {
     const { fake, helper } = withFakeSpawner();
     const malformed: MalformedFrameError[] = [];
@@ -94,7 +106,7 @@ describe("IOSDeviceCaptureHelper", () => {
     helper.start();
 
     const badHeader = Buffer.alloc(FRAME_HEADER_SIZE);
-    badHeader.writeUInt32LE(0, 0); // width
+    badHeader.writeUInt32LE(0, 0);
     badHeader.writeUInt32LE(1, 4);
     badHeader.writeUInt32LE(4, 8);
     badHeader.writeUInt32LE(0, 12);
@@ -138,7 +150,7 @@ describe("IOSDeviceCaptureHelper", () => {
   test("start() throws when already running", () => {
     const { helper } = withFakeSpawner();
     helper.start();
-    expect(() => helper.start()).toThrow("IOSDeviceCaptureHelper already started");
+    expect(() => helper.start()).toThrow("IOSScreenCaptureHelper already started");
   });
 
   test("stop() sends SIGTERM and resolves with exit info", async () => {


### PR DESCRIPTION
Closes #1096. Builds on #1095 (merged in #2194).

## Summary
- Adds ScreenCaptureKit-based capture for macOS iOS Simulator windows. The Swift helper grows two new modes: `--list-simulators` (emits discovered simulator windows as JSON) and `--simulator-window <CGWindowID>` (streams that window as BGRA frames using the existing 16-byte protocol).
- Generalizes the Node-side helper: renames `IOSDeviceCaptureHelper` → `IOSScreenCaptureHelper` and replaces the `deviceId?` option with a `CaptureTarget` discriminated union that supports both device and simulator capture against a single class.
- Deduplicates the AVFoundation and ScreenCaptureKit sample-buffer handlers into a shared `FrameWriter.write(sampleBuffer:)` helper, and collapses three Swift async→sync bridges into one `runBlocking<T>` helper.

## What's in this PR
- **Swift (`ios/screen-capture/`)**
  - `SimulatorWindowDiscovery` — `SCShareableContent` filtered to `com.apple.iphonesimulator`
  - `SimulatorCaptureSession` — `SCStream` at 60 fps in 32BGRA; `stop()` calls `removeStreamOutput` to break the SCStream → self retain cycle
  - `FrameWriter+PixelBuffer.swift` — shared `write(sampleBuffer:)` used by both device and simulator paths
  - `CommandLineOptions` — `--list-simulators` / `--simulator-window <id>`, with `ParseError.invalidValue` and `.conflictingFlags`
  - `main.swift` — `runBlocking<T>` async-bridge helper (throwing + non-throwing); refactored arms
  - 9 new XCTests covering parsing, JSON shape, and conflict detection
- **TypeScript (`src/features/screen-stream/`)**
  - `IOSScreenCaptureHelper` (renamed) with `target: { kind: "device"; deviceId? } | { kind: "simulator"; windowID: number }`
  - `buildArgs(target)` picks the correct CLI flags
  - 3 new tests covering simulator target arg-building and frame decoding
- Marks Milestone 2 of `docs/design-docs/plat/ios/screen-streaming.md` complete; Unix-socket fan-out remains the shared follow-up.

## Test plan
- [x] `bun run lint` — clean
- [x] `bun test` — 4141 pass, 0 fail (20 in `test/features/screen-stream/`)
- [x] `swift build -Xswiftc -warnings-as-errors` (in `ios/screen-capture/`) — succeeds
- [x] `swift test` (in `ios/screen-capture/`) — 22 pass (9 new)
- [ ] Manual verification: `./ios/screen-capture/.build/debug/screen-capture-helper --list-simulators` against a booted simulator, then `--simulator-window <id>` piped into a frame consumer. Requires Screen Recording permission for the terminal — out of automation scope.