### PR TITLE
test(failures): assert resetInstance actually clears FailureRecorder singleton

### DIFF
--- a/test/features/failures/FailureRecorder.test.ts
+++ b/test/features/failures/FailureRecorder.test.ts
@@ -708,10 +708,18 @@ describe("FailureRecorder", () => {
   });
 
   describe("static methods", () => {
-    test("resetInstance clears singleton", () => {
+    test("resetInstance clears singleton so the next getInstance returns a fresh object", () => {
       FailureRecorder.resetInstance();
-      // Should not throw
-      expect(true).toBe(true);
+      const first = FailureRecorder.getInstance();
+      const cached = FailureRecorder.getInstance();
+      expect(cached).toBe(first); // Sanity: getInstance memoizes between resets
+
+      FailureRecorder.resetInstance();
+      const second = FailureRecorder.getInstance();
+      expect(second).toBeInstanceOf(FailureRecorder);
+      expect(second).not.toBe(first);
+
+      FailureRecorder.resetInstance(); // Leave singleton slot empty for other tests
     });
 
     test("createForTesting returns a new instance", () => {


### PR DESCRIPTION
## Summary

- The existing \`resetInstance clears singleton\` case asserted only that the call did not throw (\`expect(true).toBe(true)\`). Any regression that left a stale instance behind would not have been caught.
- Replaces the tautology with a real round-trip: \`getInstance\` → \`resetInstance\` → \`getInstance\` and asserts the second result is a fresh, different instance.
- Adds a sanity check that \`getInstance\` memoizes between resets.
- Leaves the singleton slot empty at the end so unrelated tests are unaffected.

Bug reference: bug #8 from \`/find-bugs\` triage (2026-05-19).

## Test plan

- [x] \`bun test test/features/failures/FailureRecorder.test.ts\` — 76 pass in 74 ms
- [x] Without the fix the original test would still pass; with the fix a regression that left the singleton populated would fail \`expect(second).not.toBe(first)\`