### PR TITLE
test(server): replace tautological expect(true) in toolRegistration happy-path

### DIFF
--- a/test/server/toolRegistration.test.ts
+++ b/test/server/toolRegistration.test.ts
@@ -392,9 +392,9 @@ describe("Tool Registration Validation (Unit Tests)", () => {
 
       fakeFs.setFile("schemas/tool-definitions.json", schemaFile);
 
-      // Should not throw
-      await validator.validateSchemaFile("schemas/tool-definitions.json");
-      expect(true).toBe(true); // Test passes if no error thrown
+      await expect(
+        validator.validateSchemaFile("schemas/tool-definitions.json")
+      ).resolves.toBeUndefined();
     });
 
     test("should detect incomplete schema definitions", async () => {


### PR DESCRIPTION
## Summary

- The \`should pass when all registered tools are in schema file\` case asserted \`expect(true).toBe(true)\` after \`await validator.validateSchemaFile(...)\`. The trailing assertion conveys nothing the implicit "await did not throw" doesn't already guarantee, so a reader can't tell what the test is actually verifying.
- Replaces it with \`await expect(validateSchemaFile(...)).resolves.toBeUndefined()\` so the assertion matches the function's signature (\`Promise<void>\`) and the intent — "happy path resolves cleanly" — is expressed as a real assertion.

Bug reference: bug #9 from \`/find-bugs\` triage (2026-05-19).

## Test plan

- [x] \`bun test test/server/toolRegistration.test.ts\` — 22 pass in 437 ms