### PR TITLE
fix(ios): make runBlocking Swift 5.9 compatible

### DIFF
--- a/ios/screen-capture/Sources/ScreenCaptureHelper/main.swift
+++ b/ios/screen-capture/Sources/ScreenCaptureHelper/main.swift
@@ -142,36 +142,38 @@ case .capture(let deviceID):
 
 // MARK: - Async/sync bridges
 
+// A reference box so the Task closure mutates a captured class instead of a
+// `var`. Swift 5.9 (Xcode 15) rejects `var` capture in `Task { … }` even when
+// the semaphore enforces a happens-before relationship; class capture is fine.
+private final class Box<T> {
+    var value: T
+    init(_ value: T) { self.value = value }
+}
+
 func runBlocking<T>(_ body: @escaping () async throws -> T) -> Result<T, Error> {
     let semaphore = DispatchSemaphore(value: 0)
-    var result: Result<T, Error> = .failure(CancellationError())
+    let box = Box<Result<T, Error>>(.failure(CancellationError()))
     Task {
-        result = await Result { try await body() }
+        do {
+            box.value = .success(try await body())
+        } catch {
+            box.value = .failure(error)
+        }
         semaphore.signal()
     }
     semaphore.wait()
-    return result
+    return box.value
 }
 
 func runBlocking<T>(_ body: @escaping () async -> T) -> T {
     let semaphore = DispatchSemaphore(value: 0)
-    var result: T?
+    let box = Box<T?>(nil)
     Task {
-        result = await body()
+        box.value = await body()
         semaphore.signal()
     }
     semaphore.wait()
-    return result!
-}
-
-extension Result where Failure == Error {
-    init(catching body: () async throws -> Success) async {
-        do {
-            self = .success(try await body())
-        } catch {
-            self = .failure(error)
-        }
-    }
+    return box.value!
 }
 
 // MARK: - Signal handling


### PR DESCRIPTION
Fixes the Xcode 15 build break introduced by #2196.

## Problem
The `runBlocking<T>` helpers added in [#2196](https://github.com/kaeawc/auto-mobile/pull/2196) captured a \`var result\` inside their \`Task { ... }\` closures. Swift 5.9 (Xcode 15) rejects this with *"mutation of captured var in concurrently-executing code"* even when downstream synchronization (the \`DispatchSemaphore\`) makes the access race-free. Swift 5.10+ (Xcode 26) accepts it, which is why local validation didn't catch this before merge.

## Fix
Replace the captured \`var\` with a small \`Box<T>\` reference class. The \`Task\` mutates the box's property rather than a captured var. The class is captured by reference; mutating its property bypasses the Sendable check. No behavior change — same single-writer / single-reader pattern, same \`DispatchSemaphore\` synchronization.

## Test plan
- [x] \`swift build -Xswiftc -warnings-as-errors\` (in \`ios/screen-capture/\`) — clean
- [x] \`swift test\` — 22 pass
- [ ] CI verifies Xcode 15 build comes back green