### PR TITLE
chore(logger): remove unused applyAutomobileLogLevelFromEnvironment

### DIFF
--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -95,17 +95,6 @@ export function parseAutomobileLogLevel(value: string | undefined): LogLevel | n
   }
 }
 
-/**
- * If `process.env.AUTOMOBILE_LOG_LEVEL` is set to a recognized level, apply it to the global logger.
- * Intended for CI / daemon runs (quiet INFO chatter while keeping WARN/ERROR).
- */
-export function applyAutomobileLogLevelFromEnvironment(): void {
-  const parsed = parseAutomobileLogLevel(process.env.AUTOMOBILE_LOG_LEVEL);
-  if (parsed !== null) {
-    currentLogLevel = parsed;
-  }
-}
-
 // Default to INFO level in production, can be overridden
 let currentLogLevel: LogLevel = LogLevel.INFO;
 


### PR DESCRIPTION
## Summary
- Exported helper that applied \`AUTOMOBILE_LOG_LEVEL\` from \`process.env\` to the global logger. Nothing in \`src/\` or \`test/\` ever called it.
- \`parseAutomobileLogLevel\` (the underlying parser, exercised by \`test/utils/logger-loglevel-env.test.ts\`) remains untouched. Only the unused thin wrapper goes away.
- Part of cleanup pass on dead-code issue #1874.

## Test plan
- [x] \`bun test test/utils/logger-loglevel-env.test.ts\` passes (3 pass).
- [x] \`bun run dead-code:ts:prune\` no longer flags \`applyAutomobileLogLevelFromEnvironment\`.