### PR TITLE
test(observe): re-enable hierarchy-update navigation-graph seeding test

### DIFF
--- a/test/features/observe/CtrlProxyClient.test.ts
+++ b/test/features/observe/CtrlProxyClient.test.ts
@@ -289,7 +289,7 @@ describe("AndroidCtrlProxyClient", function() {
       }
     });
 
-    test.skip("should seed navigation graph from hierarchy updates", async function() {
+    test("should seed navigation graph from hierarchy updates", async function() {
       NavigationGraphManager.resetInstance();
       const navManager = NavigationGraphManager.getInstance();
 
@@ -324,8 +324,13 @@ describe("AndroidCtrlProxyClient", function() {
         }));
 
         await resultPromise;
-        // Allow async event handlers to process (navigation graph update is async)
+        // HierarchyNavigationDetector debounces via setTimeout(100ms); in autoAdvance
+        // mode the FakeTimer dispatches that via setImmediate, not as a microtask.
+        // Drain setImmediate so the debounce callback runs, then drain microtasks so
+        // the async setCurrentApp call inside recordHierarchyNavigation reaches its
+        // first synchronous assignment (this.currentAppId = appId).
         for (let i = 0; i < 10; i++) {
+          await new Promise<void>(resolve => setImmediate(resolve));
           await testTimer.advanceTimersByTimeAsync(1);
         }
 


### PR DESCRIPTION
## Summary

- Re-enables the previously \`test.skip\`ped \`should seed navigation graph from hierarchy updates\` case in [test/features/observe/CtrlProxyClient.test.ts](test/features/observe/CtrlProxyClient.test.ts:292). It covers the WebSocket \`hierarchy_update\` → \`HierarchyNavigationDetector.onHierarchyUpdate\` → \`NavigationGraphManager.recordHierarchyNavigation\` → \`setCurrentApp\` pipeline, asserting the package name seeds \`currentAppId\` and (per the named-nodes-only feature) does not set \`currentScreen\`.
- The original test silently passed because of \`test.skip\`. Re-enabling it surfaced an infrastructure gap: \`HierarchyNavigationDetector\` debounces via \`setTimeout(100ms)\`, but the FakeTimer's \`autoAdvance\` mode dispatches that callback via \`setImmediate\` (a macrotask). The test loop only drained microtasks via \`advanceTimersByTimeAsync\`, so the debounce callback never ran.
- Drain \`setImmediate\` in addition to microtasks each iteration so the debounce callback fires and the async \`setCurrentApp\` call reaches its synchronous \`this.currentAppId = appId\` before the assertion. No production code change required.

Bug reference: bug #10 from \`/find-bugs\` triage (2026-05-19).

## Test plan

- [x] \`bun test test/features/observe/CtrlProxyClient.test.ts --test-name-pattern=\"should seed navigation graph from hierarchy updates\"\` — 1 pass in 164 ms
- [x] Full \`bun test\` suite — 4143 tests, 0 fail (the previously-failing case now contributes one additional passing assertion)