### PR TITLE
feat(ios): simulator capture follow-ups from #1096 review

### DIFF
--- a/docs/design-docs/plat/ios/screen-streaming.md
+++ b/docs/design-docs/plat/ios/screen-streaming.md
@@ -282,6 +282,9 @@ Followed by `height * bytesPerRow` bytes of BGRA pixel data.
 - [x] Handle simulator window discovery (`SimulatorWindowDiscovery`, `--list-simulators`)
 - [x] Unified Swift CLI handles both device and simulator targets
 - [x] Node `IOSScreenCaptureHelper` accepts `{ kind: "device" | "simulator" }` targets
+- [x] Configurable frame rate (`--simulator-fps`, default 5, range 5-60)
+- [x] Auto-reconfigure stream on size change (device rotation)
+- [x] Stderr hint when no frames arrive within 2s (silent permission denial)
 - [ ] Unix-socket fan-out (shared with Milestone 1 follow-up)
 
 ### Milestone 3: IDE Plugin Integration

--- a/ios/screen-capture/Sources/ScreenCaptureCore/CommandLineOptions.swift
+++ b/ios/screen-capture/Sources/ScreenCaptureCore/CommandLineOptions.swift
@@ -6,7 +6,7 @@ public struct CommandLineOptions: Equatable {
         case listDevices
         case capture(deviceID: String?)
         case listSimulators
-        case captureSimulator(windowID: UInt32)
+        case captureSimulator(windowID: UInt32, fps: Int)
         case help
     }
 
@@ -23,6 +23,10 @@ public struct CommandLineOptions: Equatable {
         case conflictingFlags(String)
     }
 
+    public static let defaultSimulatorFPS = 5
+    public static let minSimulatorFPS = 5
+    public static let maxSimulatorFPS = 60
+
     public static func parse(_ arguments: [String]) throws -> CommandLineOptions {
         var iterator = arguments.makeIterator()
         _ = iterator.next()
@@ -31,6 +35,7 @@ public struct CommandLineOptions: Equatable {
         var deviceID: String?
         var listSimulators = false
         var simulatorWindowID: UInt32?
+        var simulatorFPS: Int?
         var help = false
 
         while let arg = iterator.next() {
@@ -52,6 +57,18 @@ public struct CommandLineOptions: Equatable {
                     throw ParseError.invalidValue(flag: arg, value: value)
                 }
                 simulatorWindowID = parsed
+            case "--simulator-fps":
+                guard let value = iterator.next() else {
+                    throw ParseError.missingValue(flag: arg)
+                }
+                guard
+                    let parsed = Int(value),
+                    parsed >= minSimulatorFPS,
+                    parsed <= maxSimulatorFPS
+                else {
+                    throw ParseError.invalidValue(flag: arg, value: value)
+                }
+                simulatorFPS = parsed
             case "-h", "--help":
                 help = true
             default:
@@ -75,6 +92,12 @@ public struct CommandLineOptions: Equatable {
             )
         }
 
+        if simulatorFPS != nil && simulatorWindowID == nil {
+            throw ParseError.conflictingFlags(
+                "--simulator-fps requires --simulator-window"
+            )
+        }
+
         if listDevices {
             return CommandLineOptions(mode: .listDevices)
         }
@@ -82,7 +105,12 @@ public struct CommandLineOptions: Equatable {
             return CommandLineOptions(mode: .listSimulators)
         }
         if let windowID = simulatorWindowID {
-            return CommandLineOptions(mode: .captureSimulator(windowID: windowID))
+            return CommandLineOptions(
+                mode: .captureSimulator(
+                    windowID: windowID,
+                    fps: simulatorFPS ?? defaultSimulatorFPS
+                )
+            )
         }
         return CommandLineOptions(mode: .capture(deviceID: deviceID))
     }
@@ -93,19 +121,21 @@ public struct CommandLineOptions: Equatable {
     USAGE:
         screen-capture-helper [--device-id <id>]
         screen-capture-helper --list-devices
-        screen-capture-helper --simulator-window <windowID>
+        screen-capture-helper --simulator-window <windowID> [--simulator-fps <n>]
         screen-capture-helper --list-simulators
 
     DEVICE OPTIONS (USB-connected iOS devices via AVFoundation):
-        --list-devices         Emit discovered devices as JSON to stdout and exit.
-        --device-id <id>       uniqueID of the device to capture. If omitted, the
-                               first muxed external device is used.
+        --list-devices          Emit discovered devices as JSON to stdout and exit.
+        --device-id <id>        uniqueID of the device to capture. If omitted,
+                                the first muxed external device is used.
 
     SIMULATOR OPTIONS (macOS iOS Simulator windows via ScreenCaptureKit):
-        --list-simulators      Emit discovered simulator windows as JSON and exit.
-        --simulator-window <n> CGWindowID of the simulator window to capture.
+        --list-simulators       Emit discovered simulator windows as JSON.
+        --simulator-window <n>  CGWindowID of the simulator window to capture.
+        --simulator-fps <n>     Target frame rate (5-60, default 5). Higher
+                                values waste CPU for typical MCP workloads.
 
-        -h, --help             Show this help.
+        -h, --help              Show this help.
 
     Frames are written to stdout: 16-byte little-endian header
     (width, height, bytesPerRow, timestampMs) followed by

--- a/ios/screen-capture/Sources/ScreenCaptureHelper/SimulatorCaptureSession.swift
+++ b/ios/screen-capture/Sources/ScreenCaptureHelper/SimulatorCaptureSession.swift
@@ -5,33 +5,28 @@ import ScreenCaptureKit
 import ScreenCaptureCore
 
 /// Streams BGRA frames from a single iOS Simulator window via ScreenCaptureKit.
-/// Targets up to 60fps; the writer trims to the frame protocol on the way out.
+/// The frame rate is configurable (5–60); 5 is the default for typical MCP
+/// automation workloads. Size changes (e.g. device rotation) trigger a stream
+/// reconfiguration so frames don't get cropped.
 final class SimulatorCaptureSession: NSObject, SCStreamOutput, SCStreamDelegate {
     private let writer: FrameWriter
     private let queue = DispatchQueue(label: "automobile.simulator-capture.frames")
     private var stream: SCStream?
+    private var configuredPixelWidth: Int = 0
+    private var configuredPixelHeight: Int = 0
+    private var hasReceivedFrame = false
+    private var fps: Int = CommandLineOptions.defaultSimulatorFPS
 
     init(writer: FrameWriter) {
         self.writer = writer
     }
 
-    private static let kTargetFPS: Int32 = 60
-
-    func start(window: SCWindow) async throws {
+    func start(window: SCWindow, fps: Int) async throws {
+        self.fps = fps
         let filter = SCContentFilter(desktopIndependentWindow: window)
-        let config = SCStreamConfiguration()
-        // Logical (points) size; the delivered CVPixelBuffer is in native
-        // pixels (2x/3x for Retina), and downstream consumers must use
-        // CVPixelBufferGetWidth/Height — not these values — to allocate sinks.
-        config.width = Int(window.frame.width)
-        config.height = Int(window.frame.height)
-        config.pixelFormat = kCVPixelFormatType_32BGRA
-        config.minimumFrameInterval = CMTime(
-            value: 1,
-            timescale: SimulatorCaptureSession.kTargetFPS
-        )
-        config.showsCursor = false
-        config.scalesToFit = false
+        let config = SimulatorCaptureSession.makeConfiguration(window: window, fps: fps)
+        configuredPixelWidth = config.width
+        configuredPixelHeight = config.height
 
         let stream = SCStream(filter: filter, configuration: config, delegate: self)
         try stream.addStreamOutput(self, type: .screen, sampleHandlerQueue: queue)
@@ -48,6 +43,10 @@ final class SimulatorCaptureSession: NSObject, SCStreamOutput, SCStreamDelegate 
         self.stream = nil
     }
 
+    /// Whether at least one frame has been delivered since `start()`.
+    /// Used by the CLI to detect a silent screen-recording permission denial.
+    var hasReceivedAnyFrame: Bool { hasReceivedFrame }
+
     // MARK: - SCStreamOutput
 
     func stream(
@@ -56,7 +55,24 @@ final class SimulatorCaptureSession: NSObject, SCStreamOutput, SCStreamDelegate 
         of type: SCStreamOutputType
     ) {
         guard type == .screen, sampleBuffer.isValid else { return }
-        writer.write(sampleBuffer: sampleBuffer)
+
+        // Drop non-complete statuses (idle, blank, suspended, stopped) so we
+        // don't re-emit identical pixels or partial buffers.
+        if let status = SimulatorCaptureSession.frameStatus(of: sampleBuffer),
+           status != .complete {
+            return
+        }
+
+        guard let pixelBuffer = CMSampleBufferGetImageBuffer(sampleBuffer) else { return }
+        let actualWidth = CVPixelBufferGetWidth(pixelBuffer)
+        let actualHeight = CVPixelBufferGetHeight(pixelBuffer)
+        if actualWidth != configuredPixelWidth || actualHeight != configuredPixelHeight {
+            reconfigure(width: actualWidth, height: actualHeight)
+        }
+
+        if writer.write(sampleBuffer: sampleBuffer) {
+            hasReceivedFrame = true
+        }
     }
 
     // MARK: - SCStreamDelegate
@@ -65,5 +81,61 @@ final class SimulatorCaptureSession: NSObject, SCStreamOutput, SCStreamDelegate 
         FileHandle.standardError.write(
             Data("error: ScreenCaptureKit stream stopped: \(error)\n".utf8)
         )
+    }
+
+    // MARK: - Internals
+
+    private func reconfigure(width: Int, height: Int) {
+        guard let stream = stream else { return }
+        configuredPixelWidth = width
+        configuredPixelHeight = height
+
+        let updated = SCStreamConfiguration()
+        updated.width = width
+        updated.height = height
+        updated.pixelFormat = kCVPixelFormatType_32BGRA
+        updated.minimumFrameInterval = CMTime(value: 1, timescale: CMTimeScale(fps))
+        updated.showsCursor = false
+        updated.scalesToFit = false
+
+        // Fire-and-forget: if the update fails we keep using the old config and
+        // either resync on the next size change or stop with a delegate error.
+        Task {
+            do {
+                try await stream.updateConfiguration(updated)
+            } catch {
+                FileHandle.standardError.write(
+                    Data("warn: failed to update stream configuration: \(error)\n".utf8)
+                )
+            }
+        }
+    }
+
+    private static func makeConfiguration(window: SCWindow, fps: Int) -> SCStreamConfiguration {
+        let config = SCStreamConfiguration()
+        // Logical (points) size; the delivered CVPixelBuffer is in native
+        // pixels (2x/3x for Retina), and downstream consumers must use
+        // CVPixelBufferGetWidth/Height — not these values — to allocate sinks.
+        config.width = Int(window.frame.width)
+        config.height = Int(window.frame.height)
+        config.pixelFormat = kCVPixelFormatType_32BGRA
+        config.minimumFrameInterval = CMTime(value: 1, timescale: CMTimeScale(fps))
+        config.showsCursor = false
+        config.scalesToFit = false
+        return config
+    }
+
+    private static func frameStatus(of sampleBuffer: CMSampleBuffer) -> SCFrameStatus? {
+        guard
+            let attachments = CMSampleBufferGetSampleAttachmentsArray(
+                sampleBuffer, createIfNecessary: false
+            ) as? [[SCStreamFrameInfo: Any]],
+            let info = attachments.first,
+            let rawStatus = info[.status] as? Int,
+            let status = SCFrameStatus(rawValue: rawStatus)
+        else {
+            return nil
+        }
+        return status
     }
 }

--- a/ios/screen-capture/Sources/ScreenCaptureHelper/main.swift
+++ b/ios/screen-capture/Sources/ScreenCaptureHelper/main.swift
@@ -3,6 +3,10 @@ import Foundation
 import ScreenCaptureKit
 import ScreenCaptureCore
 
+// MARK: - Constants
+
+let simulatorPermissionTimeoutSeconds: TimeInterval = 2.0
+
 // MARK: - Logging
 
 func logError(_ message: String) {
@@ -74,7 +78,7 @@ case .listSimulators:
         exit(1)
     }
 
-case .captureSimulator(let windowID):
+case .captureSimulator(let windowID, let fps):
     let window: SCWindow
     switch runBlocking({ try await SimulatorWindowDiscovery.find(windowID: windowID) }) {
     case .success(.some(let resolved)):
@@ -91,9 +95,25 @@ case .captureSimulator(let windowID):
     let writer = FrameWriter(sink: sink)
     let simSession = SimulatorCaptureSession(writer: writer)
 
-    if case .failure(let error) = runBlocking({ try await simSession.start(window: window) }) {
+    if case .failure(let error) = runBlocking({
+        try await simSession.start(window: window, fps: fps)
+    }) {
         logError("error: failed to start simulator capture: \(error)")
         exit(1)
+    }
+
+    // ScreenCaptureKit silently emits no frames when the host process lacks
+    // Screen Recording permission — there's no error to surface. Emit a hint
+    // on stderr if nothing arrives within the deadline; this leaves stdout
+    // (the frame channel) untouched.
+    DispatchQueue.main.asyncAfter(deadline: .now() + simulatorPermissionTimeoutSeconds) {
+        if !simSession.hasReceivedAnyFrame {
+            logError(
+                "warn: no frames received within \(simulatorPermissionTimeoutSeconds)s. "
+                + "Grant 'Screen Recording' to your terminal/IDE in "
+                + "System Settings → Privacy & Security → Screen Recording."
+            )
+        }
     }
 
     installShutdownHandlers {

--- a/ios/screen-capture/Tests/ScreenCaptureCoreTests/CommandLineOptionsTests.swift
+++ b/ios/screen-capture/Tests/ScreenCaptureCoreTests/CommandLineOptionsTests.swift
@@ -57,11 +57,69 @@ final class CommandLineOptionsTests: XCTestCase {
         XCTAssertEqual(opts.mode, .listSimulators)
     }
 
-    func testParsesSimulatorWindow() throws {
+    func testParsesSimulatorWindowWithDefaultFPS() throws {
         let opts = try CommandLineOptions.parse([
             "screen-capture-helper", "--simulator-window", "98765"
         ])
-        XCTAssertEqual(opts.mode, .captureSimulator(windowID: 98765))
+        XCTAssertEqual(
+            opts.mode,
+            .captureSimulator(
+                windowID: 98765,
+                fps: CommandLineOptions.defaultSimulatorFPS
+            )
+        )
+    }
+
+    func testParsesSimulatorFPSWithinRange() throws {
+        let opts = try CommandLineOptions.parse([
+            "screen-capture-helper",
+            "--simulator-window", "1",
+            "--simulator-fps", "30",
+        ])
+        XCTAssertEqual(opts.mode, .captureSimulator(windowID: 1, fps: 30))
+    }
+
+    func testRejectsSimulatorFPSBelowRange() {
+        XCTAssertThrowsError(try CommandLineOptions.parse([
+            "screen-capture-helper",
+            "--simulator-window", "1",
+            "--simulator-fps", "4",
+        ])) { error in
+            XCTAssertEqual(
+                error as? CommandLineOptions.ParseError,
+                .invalidValue(flag: "--simulator-fps", value: "4")
+            )
+        }
+    }
+
+    func testRejectsSimulatorFPSAboveRange() {
+        XCTAssertThrowsError(try CommandLineOptions.parse([
+            "screen-capture-helper",
+            "--simulator-window", "1",
+            "--simulator-fps", "61",
+        ])) { error in
+            XCTAssertEqual(
+                error as? CommandLineOptions.ParseError,
+                .invalidValue(flag: "--simulator-fps", value: "61")
+            )
+        }
+    }
+
+    func testRejectsSimulatorFPSWithoutWindow() {
+        XCTAssertThrowsError(try CommandLineOptions.parse([
+            "screen-capture-helper", "--simulator-fps", "15",
+        ])) { error in
+            guard case CommandLineOptions.ParseError.conflictingFlags = error else {
+                XCTFail("expected conflictingFlags, got \(error)")
+                return
+            }
+        }
+    }
+
+    func testDefaultSimulatorFPSConstantIs5() {
+        XCTAssertEqual(CommandLineOptions.defaultSimulatorFPS, 5)
+        XCTAssertEqual(CommandLineOptions.minSimulatorFPS, 5)
+        XCTAssertEqual(CommandLineOptions.maxSimulatorFPS, 60)
     }
 
     func testInvalidSimulatorWindowValueThrows() {

--- a/src/features/screen-stream/IOSScreenCaptureHelper.ts
+++ b/src/features/screen-stream/IOSScreenCaptureHelper.ts
@@ -21,7 +21,12 @@ export type HelperSpawner = (
  */
 export type CaptureTarget =
   | { kind: "device"; deviceId?: string }
-  | { kind: "simulator"; windowID: number };
+  | { kind: "simulator"; windowID: number; fps?: number };
+
+/** Valid range for the simulator capture frame rate, mirrors the Swift CLI. */
+export const SIMULATOR_FPS_MIN = 5;
+export const SIMULATOR_FPS_MAX = 60;
+export const SIMULATOR_FPS_DEFAULT = 5;
 
 export interface IosScreenCaptureHelperOptions {
   /** Absolute path to the compiled `screen-capture-helper` binary. */
@@ -167,7 +172,21 @@ function buildArgs(target: CaptureTarget): string[] {
   switch (target.kind) {
     case "device":
       return target.deviceId !== undefined ? ["--device-id", target.deviceId] : [];
-    case "simulator":
-      return ["--simulator-window", String(target.windowID)];
+    case "simulator": {
+      const args = ["--simulator-window", String(target.windowID)];
+      if (target.fps !== undefined) {
+        if (
+          !Number.isInteger(target.fps) ||
+          target.fps < SIMULATOR_FPS_MIN ||
+          target.fps > SIMULATOR_FPS_MAX
+        ) {
+          throw new RangeError(
+            `simulator fps must be an integer in [${SIMULATOR_FPS_MIN}, ${SIMULATOR_FPS_MAX}]; got ${target.fps}`
+          );
+        }
+        args.push("--simulator-fps", String(target.fps));
+      }
+      return args;
+    }
   }
 }

--- a/src/features/screen-stream/index.ts
+++ b/src/features/screen-stream/index.ts
@@ -7,6 +7,9 @@ export {
 } from "./frameProtocol";
 export {
   IOSScreenCaptureHelper,
+  SIMULATOR_FPS_DEFAULT,
+  SIMULATOR_FPS_MAX,
+  SIMULATOR_FPS_MIN,
   type CaptureTarget,
   type HelperSpawner,
   type IosScreenCaptureHelperOptions,

--- a/test/features/screen-stream/IOSScreenCaptureHelper.test.ts
+++ b/test/features/screen-stream/IOSScreenCaptureHelper.test.ts
@@ -68,6 +68,41 @@ describe("IOSScreenCaptureHelper", () => {
     expect(spawnArgs.args).toEqual(["--simulator-window", "98765"]);
   });
 
+  test("passes --simulator-fps when fps is provided", () => {
+    const { spawnArgs, helper } = withFakeSpawner({
+      kind: "simulator",
+      windowID: 1,
+      fps: 30,
+    });
+    helper.start();
+    expect(spawnArgs.args).toEqual([
+      "--simulator-window",
+      "1",
+      "--simulator-fps",
+      "30",
+    ]);
+  });
+
+  test("rejects simulator fps outside [5, 60]", () => {
+    const fake = new FakeChildProcess();
+    const helper = new IOSScreenCaptureHelper({
+      binaryPath: "/fake/screen-capture-helper",
+      target: { kind: "simulator", windowID: 1, fps: 61 },
+      spawner: () => fake as unknown as ChildProcessWithoutNullStreams,
+    });
+    expect(() => helper.start()).toThrow(/simulator fps must be an integer in \[5, 60\]/);
+  });
+
+  test("rejects non-integer simulator fps", () => {
+    const fake = new FakeChildProcess();
+    const helper = new IOSScreenCaptureHelper({
+      binaryPath: "/fake/screen-capture-helper",
+      target: { kind: "simulator", windowID: 1, fps: 30.5 },
+      spawner: () => fake as unknown as ChildProcessWithoutNullStreams,
+    });
+    expect(() => helper.start()).toThrow(/integer/);
+  });
+
   test("emits frame events for each decoded frame", async () => {
     const { fake, helper } = withFakeSpawner();
     const frames: DecodedFrame[] = [];


### PR DESCRIPTION
Incorporates external review feedback from [#1096 comments](https://github.com/kaeawc/auto-mobile/issues/1096) that I missed in the original implementation. Thanks @m13v for the detailed ScreenCaptureKit notes.

## What changed

### Frame rate
- New `--simulator-fps <n>` flag, **default 5**, range \`[5, 60]\`. The previous hardcoded 60 fps was — to quote the reviewer — *"wasteful for MCP server use cases"*; 5-15 fps is plenty for automation.
- Swift CLI and TS \`buildArgs\` both validate the range. \`SIMULATOR_FPS_MIN/MAX/DEFAULT\` exported from \`src/features/screen-stream\` so programmatic callers can pre-validate or wire UIs.

### Stream lifecycle (rotation / resize)
- \`SimulatorCaptureSession\` reads \`SCFrameStatus\` from sample-buffer attachments and drops non-\`.complete\` frames (idle, blank, suspended, stopped) so we don't re-emit identical pixels.
- Compares actual pixel-buffer dimensions to configured dimensions per frame; on mismatch calls \`SCStream.updateConfiguration(_:)\` to re-sync. Fixes the cropped-on-rotation case m13v flagged.

### Silent permission denial
- ScreenCaptureKit returns blank frames with no error when the host process lacks Screen Recording permission. After \`startCapture()\` we schedule a 2s deadline; if \`simSession.hasReceivedAnyFrame\` is still false, emit a stderr hint pointing at System Settings → Privacy & Security → Screen Recording. Stdout (the binary frame channel) stays untouched.

## Tests
- [x] \`bun run lint\` — clean
- [x] \`bun test\` — 4145 pass, 0 fail (2 new in \`screen-stream\`)
- [x] \`swift build -Xswiftc -warnings-as-errors\` — clean on Xcode 26.3
- [x] \`swift test\` — 27 pass (5 new fps-range tests)
- [ ] Manual: rotate a booted simulator with the helper streaming, confirm frames stay correctly sized

## Notes
This is a pure follow-up to #2196 — no behavior change for callers that don't set \`fps\`. The default ramp from 60→5 is intentional and matches the reviewer's recommendation for MCP workloads.