### PR TITLE
fix(proxy): pass BootedDevice to AndroidCtrlProxyClient.getInstance

### DIFF
--- a/src/server/ToolExecutionContext.ts
+++ b/src/server/ToolExecutionContext.ts
@@ -173,7 +173,7 @@ async function ensureAccessibilityServiceReady(
       logger.info(`[A11yRetry] Setup succeeded on attempt ${attempt}/${MAX_ATTEMPTS}`);
     }
 
-    const accessibilityClient = AndroidCtrlProxyClient.getInstance(deviceId);
+    const accessibilityClient = AndroidCtrlProxyClient.getInstance(device);
     const connected = await perf.track("waitForConnection", () => accessibilityClient.waitForConnection());
 
     perf.end();

--- a/src/utils/AccessibilityFocusTracker.ts
+++ b/src/utils/AccessibilityFocusTracker.ts
@@ -1,8 +1,14 @@
 import { AndroidCtrlProxyClient } from "../features/observe/android";
-import { Element, CurrentFocusResult, TraversalOrderResult } from "../models/index";
+import { BootedDevice, Element, CurrentFocusResult, TraversalOrderResult } from "../models/index";
 import { PerformanceTracker, NoOpPerformanceTracker } from "./PerformanceTracker";
 import { logger } from "./logger";
 import { Timer, defaultTimer } from "./SystemTimer";
+
+const toAndroidDevice = (deviceId: string): BootedDevice => ({
+  name: deviceId,
+  deviceId,
+  platform: "android"
+});
 
 /**
  * Interface for accessibility focus tracking operations.
@@ -190,7 +196,7 @@ export class AccessibilityFocusTracker implements AccessibilityFocusService {
       }
 
       // Query accessibility service for current focus
-      const client = AndroidCtrlProxyClient.getInstance(deviceId);
+      const client = AndroidCtrlProxyClient.getInstance(toAndroidDevice(deviceId));
       const result: CurrentFocusResult = await client.requestCurrentFocus(5000, perf);
 
       if (result.error) {
@@ -242,7 +248,7 @@ export class AccessibilityFocusTracker implements AccessibilityFocusService {
       }
 
       // Query accessibility service for traversal order
-      const client = AndroidCtrlProxyClient.getInstance(deviceId);
+      const client = AndroidCtrlProxyClient.getInstance(toAndroidDevice(deviceId));
       const result: TraversalOrderResult = await client.requestTraversalOrder(5000, perf);
 
       if (result.error) {

--- a/test/server/ToolExecutionContext.test.ts
+++ b/test/server/ToolExecutionContext.test.ts
@@ -56,16 +56,24 @@ describe("ToolExecutionContext", () => {
         }
       } as any);
 
-    // Mock AndroidCtrlProxyClient to use fake WebSocket (no real connection)
-    AndroidCtrlProxyClient.getInstance = ((deviceId: string) => ({
-      waitForConnection: async () => true,
-      close: async () => {}
-    })) as any;
+    const clientCallArgs: unknown[] = [];
+    AndroidCtrlProxyClient.getInstance = ((device: unknown) => {
+      clientCallArgs.push(device);
+      return {
+        waitForConnection: async () => true,
+        close: async () => {}
+      };
+    }) as any;
 
     const context = await createToolExecutionContext("session-1", sessionManager, devicePool, sessionOptions);
 
     expect(context.deviceId).toBe("device-1");
     expect(setupCalls).toBe(1);
+    expect(clientCallArgs.length).toBeGreaterThan(0);
+    const passed = clientCallArgs[0] as BootedDevice;
+    expect(typeof passed).toBe("object");
+    expect(passed.deviceId).toBe("device-1");
+    expect(passed.platform).toBe("android");
   });
 
   test("should not run accessibility setup for existing sessions", async () => {

--- a/test/utils/AccessibilityFocusTracker.test.ts
+++ b/test/utils/AccessibilityFocusTracker.test.ts
@@ -100,6 +100,18 @@ describe("AccessibilityFocusTracker", () => {
       expect(requestCurrentFocusSpy).toHaveBeenCalledTimes(1);
     });
 
+    test("passes a fully-populated BootedDevice to AndroidCtrlProxyClient.getInstance", async () => {
+      requestCurrentFocusSpy!.mockResolvedValue(createFocusResult(null));
+
+      await tracker.getCurrentFocus(deviceId, false);
+
+      expect(getInstanceSpy).toHaveBeenCalled();
+      const passed = getInstanceSpy!.mock.calls[0][0] as { deviceId?: string; platform?: string };
+      expect(typeof passed).toBe("object");
+      expect(passed.deviceId).toBe(deviceId);
+      expect(passed.platform).toBe("android");
+    });
+
     test("bypasses cache when useCache is false", async () => {
       const focusedElement = createElement({ resourceId: "com.test:id/primary" });
       requestCurrentFocusSpy!.mockResolvedValue(createFocusResult(focusedElement));


### PR DESCRIPTION
## Summary
Fixes #2215.

Three call sites passed a bare `deviceId: string` to `AndroidCtrlProxyClient.getInstance`, which expects a `BootedDevice`. The singleton therefore stored the string as `this.device`, leaving `this.device.platform` and `this.device.deviceId` as `undefined` in any background WebSocket-driven callback that ran on that instance.

This manifested as:
- \`[SCREENSHOT] Execute failed after 0ms: Unsupported platform: undefined\` from \`TakeScreenshot.captureScreenshot\` triggered by the navigation hierarchy callback
- \`[PerformanceMonitor] Started monitoring … on undefined (android)\` because \`this.device.deviceId\` was \`undefined\`

The tool-call path resolves the device via \`DeviceSessionManager\` and worked correctly; only the background-callback path created/used the broken singleton.

### Buggy sites
- \`src/server/ToolExecutionContext.ts:176\` — passed \`deviceId\` instead of the local \`device\` object built a few lines above
- \`src/utils/AccessibilityFocusTracker.ts:193, 245\` — passed the \`deviceId\` string parameter

### Fix
- \`ToolExecutionContext\`: pass \`device\` (the existing BootedDevice).
- \`AccessibilityFocusTracker\`: small \`toAndroidDevice(deviceId)\` helper that wraps the id into a proper Android \`BootedDevice\` (the tracker is Android-only).

## Test plan
- [x] \`bun test test/server/ToolExecutionContext.test.ts test/utils/AccessibilityFocusTracker.test.ts\` — new regression tests assert the argument passed to \`getInstance\` is a \`BootedDevice\` with \`platform === \"android\"\` and the correct \`deviceId\`.
- [x] \`bunx turbo run build lint\` clean.
- [x] Full \`bun test\` suite: 4146 pass, 1 skip, 0 fail.