### PR TITLE
fix(observe): coalesce in-flight screenshots during waitFor polling

### DIFF
--- a/src/features/observe/screenshot/ObserveScreenshotRecorder.ts
+++ b/src/features/observe/screenshot/ObserveScreenshotRecorder.ts
@@ -70,6 +70,11 @@ export class DefaultObserveScreenshotRecorder implements ObserveScreenshotRecord
       { format: "png" },
       {
         parentSignal: signal,
+        // Fire-and-forget: if a screencap is already in flight (e.g. mid-poll
+        // during observe waitFor), reuse it. Cancelling and restarting every
+        // ~100ms causes a self-inflicted cancel loop because screencap takes
+        // ~200-300ms — no screenshot ever completes.
+        coalesceWithPending: true,
         onComplete: async completion => {
           if (!completion.isLatest) {
             return;

--- a/src/utils/ScreenshotJobTracker.ts
+++ b/src/utils/ScreenshotJobTracker.ts
@@ -19,6 +19,15 @@ interface ScreenshotJobCompletion {
 export interface ScreenshotJobOptions {
   parentSignal?: AbortSignal;
   onComplete?: (completion: ScreenshotJobCompletion) => void | Promise<void>;
+  /**
+   * If a job is already in flight for this device and has not been aborted,
+   * return its handle instead of cancelling and starting a new one.
+   *
+   * Used by fire-and-forget callers during rapid polling (observe waitFor)
+   * to avoid a self-inflicted cancel loop where each ~100ms poll aborts the
+   * previous in-flight screencap before it can complete.
+   */
+  coalesceWithPending?: boolean;
 }
 
 interface ScreenshotJobEntry {
@@ -46,6 +55,17 @@ export class ScreenshotJobTracker {
     runner: (signal: AbortSignal) => Promise<ScreenshotResult>,
     options: ScreenshotJobOptions = {}
   ): ScreenshotJobHandle {
+    if (options.coalesceWithPending) {
+      const existing = ScreenshotJobTracker.jobs.get(deviceId);
+      if (existing && !existing.abortController.signal.aborted) {
+        return {
+          jobId: existing.jobId,
+          promise: existing.promise,
+          signal: existing.abortController.signal
+        };
+      }
+    }
+
     ScreenshotJobTracker.cancelJob(deviceId);
 
     const abortController = new AbortController();

--- a/test/features/observe/screenshot/ObserveScreenshotRecorder.test.ts
+++ b/test/features/observe/screenshot/ObserveScreenshotRecorder.test.ts
@@ -34,6 +34,7 @@ class FakeTrackedScreenshotService implements TrackedScreenshotService {
   private nextAborted: boolean = false;
   private nextThrow: Error | null = null;
   private latestPromise: Promise<ScreenshotResult> | null = null;
+  public lastTrackerOptions: ScreenshotJobOptions | null = null;
 
   setNextResult(result: ScreenshotResult): void {
     this.nextResult = result;
@@ -77,6 +78,7 @@ class FakeTrackedScreenshotService implements TrackedScreenshotService {
     _options: ScreenshotOptions = { format: "png" },
     trackerOptions: ScreenshotJobOptions = {}
   ): ScreenshotJobHandle {
+    this.lastTrackerOptions = trackerOptions;
     const abortController = new AbortController();
     const result = this.nextResult;
     const isLatest = this.nextIsLatest;
@@ -267,6 +269,16 @@ describe("DefaultObserveScreenshotRecorder.start", () => {
     await svc.lastCapturePromise();
 
     expect(store.getError("test-device")).toBe("boom");
+  });
+
+  test("start() requests coalesceWithPending so rapid polling does not cancel in-flight captures", async () => {
+    svc.setNextResult({ success: true, path: "/tmp/skip.png" });
+    svc.setNextIsLatest(false);
+
+    recorder.start(new NoOpPerformanceTracker());
+    await svc.lastCapturePromise();
+
+    expect(svc.lastTrackerOptions?.coalesceWithPending).toBe(true);
   });
 
   test("start() tracks performance via startOperation/endOperation", async () => {

--- a/test/utils/ScreenshotJobTracker.test.ts
+++ b/test/utils/ScreenshotJobTracker.test.ts
@@ -70,6 +70,100 @@ describe("ScreenshotJobTracker", () => {
     expect(result?.path).toBe("done");
   });
 
+  test("coalesceWithPending reuses an in-flight job instead of cancelling it", async () => {
+    let runnerInvocations = 0;
+    const startCoalescedJob = () => ScreenshotJobTracker.startJob(
+      "device-3",
+      signal => {
+        runnerInvocations += 1;
+        return new Promise(resolve => {
+          const timeoutId = fakeTimer.setTimeout(() => {
+            resolve({ success: true, path: "shared" });
+          }, 200);
+
+          signal.addEventListener("abort", () => {
+            fakeTimer.clearTimeout(timeoutId);
+            resolve({ success: false, error: OPERATION_CANCELLED_MESSAGE });
+          }, { once: true });
+        });
+      },
+      { coalesceWithPending: true }
+    );
+
+    const job1 = startCoalescedJob();
+    const job2 = startCoalescedJob();
+    const job3 = startCoalescedJob();
+
+    expect(job2.jobId).toBe(job1.jobId);
+    expect(job3.jobId).toBe(job1.jobId);
+
+    // Flush microtasks so the runner attaches its setTimeout before we advance time.
+    await Promise.resolve();
+    expect(runnerInvocations).toBe(1);
+
+    fakeTimer.advanceTime(200);
+    const [r1, r2, r3] = await Promise.all([job1.promise, job2.promise, job3.promise]);
+    expect(r1.success).toBe(true);
+    expect(r1.path).toBe("shared");
+    expect(r2).toBe(r1);
+    expect(r3).toBe(r1);
+  });
+
+  test("coalesceWithPending starts fresh when previous job has been aborted", async () => {
+    const job1 = ScreenshotJobTracker.startJob("device-4", signal => {
+      return new Promise(resolve => {
+        signal.addEventListener("abort", () => {
+          resolve({ success: false, error: OPERATION_CANCELLED_MESSAGE });
+        }, { once: true });
+      });
+    });
+    await Promise.resolve();
+
+    ScreenshotJobTracker.cancelJob("device-4");
+    await job1.promise;
+
+    let secondRunnerCalled = false;
+    const job2 = ScreenshotJobTracker.startJob(
+      "device-4",
+      async () => {
+        secondRunnerCalled = true;
+        return { success: true, path: "fresh" };
+      },
+      { coalesceWithPending: true }
+    );
+
+    expect(job2.jobId).not.toBe(job1.jobId);
+    const r2 = await job2.promise;
+    expect(secondRunnerCalled).toBe(true);
+    expect(r2.success).toBe(true);
+    expect(r2.path).toBe("fresh");
+  });
+
+  test("without coalesceWithPending, startJob still cancels the previous job", async () => {
+    let secondRunnerCalled = false;
+    const job1 = ScreenshotJobTracker.startJob("device-5", signal => {
+      return new Promise(resolve => {
+        signal.addEventListener("abort", () => {
+          resolve({ success: false, error: OPERATION_CANCELLED_MESSAGE });
+        }, { once: true });
+      });
+    });
+    await Promise.resolve();
+
+    const job2 = ScreenshotJobTracker.startJob("device-5", async () => {
+      secondRunnerCalled = true;
+      return { success: true, path: "replacement" };
+    });
+
+    const [r1, r2] = await Promise.all([job1.promise, job2.promise]);
+    expect(secondRunnerCalled).toBe(true);
+    expect(r1.success).toBe(false);
+    expect(r1.error).toContain(OPERATION_CANCELLED_MESSAGE);
+    expect(r2.success).toBe(true);
+    expect(r2.path).toBe("replacement");
+    expect(job2.jobId).not.toBe(job1.jobId);
+  });
+
   test("waitForCompletion returns null when the job times out", async () => {
     ScreenshotJobTracker.startJob("device-2", async signal => {
       return new Promise(resolve => {


### PR DESCRIPTION
## Summary

Fixes #2216 — `observe` with a `waitFor` condition was killing sessions with a tight 130ms screenshot cancel loop.

### Root cause

`waitForObservation` polls every 100ms ([observeTools.ts:132](https://github.com/kaeawc/auto-mobile/blob/main/src/server/observeTools.ts#L132)). Each poll calls `observeScreen.execute()`, which fires `screenshotRecorder.start()` — a fire-and-forget screenshot. Internally, [`ScreenshotJobTracker.startJob`](https://github.com/kaeawc/auto-mobile/blob/main/src/utils/ScreenshotJobTracker.ts#L49) unconditionally calls `cancelJob(deviceId)` before starting the new job.

Android `screencap` takes 200-300ms but polls arrive every 100ms, so every screenshot got aborted at ~130ms by the next poll's cancel. No screenshot ever completed; the loop ran until the session heartbeat fired ~12s later and killed the entire session.

(The `PerformanceAudit J.create` error in the issue was a red herring — `PerformanceAuditor.run` catches its own errors internally; it did not cause the cancel loop.)

### Fix

Add a `coalesceWithPending` option to `startJob`. When set, if a job is already in flight and not yet aborted, return the existing handle instead of cancelling and restarting. The fire-and-forget `ObserveScreenshotRecorder.start` passes it so rapid polling lets pending captures finish.

The awaitable `capture()` path keeps cancel-restart semantics — callers there want a fresh screenshot tied to the current observe call.

## Test plan

- [x] `bun test test/utils/ScreenshotJobTracker.test.ts` — 6 pass (3 new tests covering coalesce reuse, restart-after-abort, no-coalesce baseline)
- [x] `bun test test/features/observe/screenshot/ObserveScreenshotRecorder.test.ts` — 15 pass (1 new test verifies the flag flows through)
- [x] `turbo run lint build` — clean
- [ ] Manual repro of issue #2216 against an Android emulator with `observe { waitFor: { text: "Home", timeout: 15000 } }` on a screen without "Home" — should now return after the timeout with current screen state instead of dying.