### PR TITLE
fix(daemon): pass AdbClientFactory (not AdbExecutor) to AndroidCtrlProxyClient.getInstance

### DIFF
--- a/src/daemon/daemon.ts
+++ b/src/daemon/daemon.ts
@@ -610,8 +610,7 @@ export class Daemon {
             name: pooledDevice.name,
             platform: pooledDevice.platform as "android",
           };
-          const adb = defaultAdbClientFactory.create(pooledDevice.id);
-          const client = AndroidCtrlProxyClient.getInstance(bootedDevice, adb);
+          const client = AndroidCtrlProxyClient.getInstance(bootedDevice, defaultAdbClientFactory);
           client.ensureConnected().then(connected => {
             if (connected) {
               logger.info(`[Daemon] WebSocket connected to ${pooledDevice.id} for observation stream`);


### PR DESCRIPTION
## Summary
- Fixes #2224.
- `src/daemon/daemon.ts:613` was calling `defaultAdbClientFactory.create(pooledDevice.id)` and passing the resulting `AdbExecutor` to `AndroidCtrlProxyClient.getInstance`, which expects an `AdbClientFactory` and calls `.create(device)` on it. Bun's bundler skips type-checking so the `TS2345` shipped to production; at runtime every pooled Android device crashed in WebSocket setup (swallowed by the surrounding `catch`).
- Pass `defaultAdbClientFactory` directly, matching the parameter type.

## Test plan
- [x] `bunx tsc --noEmit` no longer reports an error at this line.
- [ ] Start the daemon with an Android emulator in the pool; confirm no `[Daemon] Error setting up WebSocket` warn-log and that the observation-stream connects.