### PR TITLE
fix(clipboard): pass AdbClientFactory to AndroidCtrlProxyClient.getInstance

### DIFF
--- a/src/features/action/Clipboard.ts
+++ b/src/features/action/Clipboard.ts
@@ -9,9 +9,11 @@ import { IOSCtrlProxyClient } from "../observe/ios";
 export class Clipboard {
   private device: BootedDevice;
   private adb: AdbExecutor;
+  private adbFactory: AdbClientFactory;
 
   constructor(device: BootedDevice, adbFactory: AdbClientFactory = defaultAdbClientFactory) {
     this.device = device;
+    this.adbFactory = adbFactory;
     this.adb = adbFactory.create(device);
   }
 
@@ -98,7 +100,7 @@ export class Clipboard {
     }
 
     // Try accessibility service first (preferred method)
-    const a11yClient = AndroidCtrlProxyClient.getInstance(this.device, this.adb);
+    const a11yClient = AndroidCtrlProxyClient.getInstance(this.device, this.adbFactory);
 
     try {
       const a11yResult = await a11yClient.requestClipboard(action, text);

--- a/test/features/action/Clipboard.test.ts
+++ b/test/features/action/Clipboard.test.ts
@@ -2,7 +2,9 @@ import { expect, describe, test, beforeEach, spyOn } from "bun:test";
 import { Clipboard } from "../../../src/features/action/Clipboard";
 import { BootedDevice } from "../../../src/models";
 import { IOSCtrlProxyClient } from "../../../src/features/observe/ios";
+import { AndroidCtrlProxyClient } from "../../../src/features/observe/android";
 import { FakeIOSCtrlProxy } from "../../fakes/FakeIOSCtrlProxy";
+import { FakeAdbClientFactory } from "../../fakes/FakeAdbClientFactory";
 
 describe("Clipboard iOS", () => {
   let clipboard: Clipboard;
@@ -119,5 +121,35 @@ describe("Clipboard iOS", () => {
 
     expect(result.success).toBe(true);
     expect(result.text).toBeUndefined();
+  });
+});
+
+describe("Clipboard Android", () => {
+  // Regression for https://github.com/kaeawc/auto-mobile/issues/2227.
+  // AndroidCtrlProxyClient.getInstance expects an AdbClientFactory and calls
+  // `.create(device)` on it. Passing the resolved AdbExecutor instead
+  // surfaces in production as `TypeError: <minified>.create is not a function`
+  // and silently breaks the a11y clipboard path.
+  test("passes the injected AdbClientFactory (not AdbExecutor) to AndroidCtrlProxyClient.getInstance", async () => {
+    const factory = new FakeAdbClientFactory();
+    const getInstanceSpy = spyOn(AndroidCtrlProxyClient, "getInstance").mockReturnValue({
+      requestClipboard: async () => ({ success: true, action: "copy", totalTimeMs: 1 }),
+    } as unknown as AndroidCtrlProxyClient);
+
+    const device: BootedDevice = {
+      name: "Test Android",
+      platform: "android",
+      deviceId: "test-android",
+    };
+    const clipboard = new Clipboard(device, factory);
+    await clipboard.execute("copy", "hello");
+
+    expect(getInstanceSpy).toHaveBeenCalled();
+    const [, passedFactory] = getInstanceSpy.mock.calls[0] as [BootedDevice, FakeAdbClientFactory];
+    expect(typeof passedFactory.create).toBe("function");
+    expect(passedFactory).toBe(factory);
+    expect(factory.wasCalledForDevice(device.deviceId)).toBe(true);
+
+    getInstanceSpy.mockRestore();
   });
 });


### PR DESCRIPTION
## Summary
- Fixes #2227. Same class of bug as #2214 / #2224 — `Clipboard.executeAndroidClipboard` passed `this.adb` (an `AdbExecutor`) to `AndroidCtrlProxyClient.getInstance`, which expects an `AdbClientFactory` and immediately calls `.create(device)` on it.
- Bun's bundler skips type-checking, so this hid behind a clean build; at runtime the minified executor surfaced as `TypeError: <minified>.create is not a function`, silently breaking the a11y clipboard path on first ctrl-proxy call per device.
- Retain the factory on the instance and pass it through. Adds a regression test that fails if the factory isn't routed through.

## Test plan
- [x] `bun test test/features/action/Clipboard.test.ts` — 8 pass (~113ms)
- [x] `bunx tsc --noEmit` — no errors on Clipboard.ts (TS2345 gone)
- [x] `bunx eslint` clean on the touched files