### PR TITLE
fix(pinchOn): pass AdbClientFactory to AndroidCtrlProxyClient.getInstance

### DIFF
--- a/src/features/action/PinchOn.ts
+++ b/src/features/action/PinchOn.ts
@@ -136,7 +136,7 @@ export class PinchOn extends BaseVisualChange {
       const duration = options.duration ?? 300;
       const rotationDegrees = options.rotationDegrees ?? 0;
 
-      const a11yClient = AndroidCtrlProxyClient.getInstance(this.device, this.adb);
+      const a11yClient = AndroidCtrlProxyClient.getInstance(this.device, this.adbFactory);
 
       const pinchResult = await this.observedInteraction(
         async () => {


### PR DESCRIPTION
## Summary
- Same regression class as #2214 / #2224. [`PinchOn.ts:139`](src/features/action/PinchOn.ts#L139) called `AndroidCtrlProxyClient.getInstance(this.device, this.adb)`, passing an `AdbExecutor` where the signature expects an `AdbClientFactory`.
- At runtime the first ctrl-proxy call per device crashed with `TypeError: <minified>.create is not a function` (bun build skips type-check, so it didn't show up at build time).
- Swap `this.adb` → `this.adbFactory` to match the call sites already fixed in #2221 / #2224.

Fixes #2228

## Test plan
- [x] `bunx tsc --noEmit` — clean
- [x] `bun test test/features/action/PinchOn.test.ts` — 3 pass
- [ ] Manual: invoke `pinchOn` on a fresh emulator with no prior `observe` call