### PR TITLE
fix(action): pass AdbClientFactory (not AdbExecutor) in a11y swipe

### DIFF
--- a/src/features/action/ExecuteGesture.ts
+++ b/src/features/action/ExecuteGesture.ts
@@ -111,7 +111,7 @@ export class ExecuteGesture extends BaseVisualChange {
     perf: PerformanceTracker = new NoOpPerformanceTracker()
   ): Promise<SwipeResult> {
     try {
-      const client = AndroidCtrlProxyClient.getInstance(this.device, this.adb);
+      const client = AndroidCtrlProxyClient.getInstance(this.device, this.adbFactory);
 
       const result = await perf.track("a11ySwipe", async () => {
         return await client.requestSwipe(x1, y1, x2, y2, duration, 5000, perf);

--- a/test/features/action/ExecuteGesture.test.ts
+++ b/test/features/action/ExecuteGesture.test.ts
@@ -1,0 +1,48 @@
+import { afterEach, describe, expect, spyOn, test } from "bun:test";
+import { ExecuteGesture } from "../../../src/features/action/ExecuteGesture";
+import { AndroidCtrlProxyClient } from "../../../src/features/observe/android";
+import { FakeAdbClientFactory } from "../../fakes/FakeAdbClientFactory";
+import type { BootedDevice } from "../../../src/models";
+
+describe("ExecuteGesture", () => {
+  const androidDevice: BootedDevice = {
+    deviceId: "test-device",
+    platform: "android",
+    name: "Test Device"
+  };
+
+  let getInstanceSpy: ReturnType<typeof spyOn> | null = null;
+
+  afterEach(() => {
+    getInstanceSpy?.mockRestore();
+    getInstanceSpy = null;
+  });
+
+  // Regression for https://github.com/kaeawc/auto-mobile/issues/2225.
+  // executeA11ySwipe called AndroidCtrlProxyClient.getInstance(device, this.adb),
+  // but getInstance expects an AdbClientFactory and immediately invokes
+  // `.create(device)`. After bundler minification this surfaced as
+  // `TypeError: <minified>.create is not a function` and crashed every
+  // a11y-mode gesture on a fresh device.
+  test("passes the AdbClientFactory (not AdbExecutor) to AndroidCtrlProxyClient.getInstance in a11y mode (regression for #2225)", async () => {
+    const factory = new FakeAdbClientFactory();
+    const fakeClient = {
+      requestSwipe: async () => ({
+        success: true,
+        totalTimeMs: 1,
+        gestureTimeMs: 1
+      })
+    } as unknown as AndroidCtrlProxyClient;
+
+    getInstanceSpy = spyOn(AndroidCtrlProxyClient, "getInstance").mockReturnValue(fakeClient);
+
+    const gesture = new ExecuteGesture(androidDevice, factory as any);
+    const result = await gesture.swipe(0, 0, 100, 100, { scrollMode: "a11y" });
+
+    expect(result.success).toBe(true);
+    expect(getInstanceSpy).toHaveBeenCalled();
+    const passed = getInstanceSpy!.mock.calls[0][1] as { create?: unknown };
+    expect(typeof passed).toBe("object");
+    expect(typeof passed.create).toBe("function");
+  });
+});


### PR DESCRIPTION
## Summary
- Same class as #2214/#2224. `ExecuteGesture.executeA11ySwipe` passed `this.adb` (an `AdbExecutor`) to `AndroidCtrlProxyClient.getInstance`, which expects an `AdbClientFactory` and calls `.create(device)` on it. After bundling/minification this crashed every a11y-mode gesture on a fresh device as `TypeError: <minified>.create is not a function`.
- Fix: pass `this.adbFactory` instead.
- Adds regression test that spies on `AndroidCtrlProxyClient.getInstance` and asserts the second argument has a callable `.create()`. With `FakeAdbClientFactory` injection, the test fails against the buggy code path (`FakeAdbClient` has no `.create`).

Fixes #2225

## Test plan
- [x] `bun test test/features/action/ExecuteGesture.test.ts` (1 pass, 205ms)
- [x] `bunx eslint` clean on changed files
- [x] `bunx tsc --noEmit` no TS2345 on ExecuteGesture