### PR TITLE
fix(selectAll): pass AdbClientFactory to AndroidCtrlProxyClient.getInstance

### DIFF
--- a/src/features/action/SelectAllText.ts
+++ b/src/features/action/SelectAllText.ts
@@ -1,4 +1,5 @@
-import { AdbClient } from "../../utils/android-cmdline-tools/AdbClient";
+import { AdbClientFactory } from "../../utils/android-cmdline-tools/AdbClientFactory";
+import { AdbExecutor } from "../../utils/android-cmdline-tools/interfaces/AdbExecutor";
 import { BaseVisualChange, ProgressCallback } from "./BaseVisualChange";
 import { BootedDevice, SelectAllTextResult } from "../../models";
 import { createGlobalPerformanceTracker } from "../../utils/PerformanceTracker";
@@ -8,8 +9,8 @@ import { logger } from "../../utils/logger";
 
 export class SelectAllText extends BaseVisualChange {
 
-  constructor(device: BootedDevice, adb: AdbClient | null = null) {
-    super(device, adb);
+  constructor(device: BootedDevice, adbFactoryOrExecutor: AdbClientFactory | AdbExecutor | null = null) {
+    super(device, adbFactoryOrExecutor);
   }
 
   async execute(progress?: ProgressCallback): Promise<SelectAllTextResult> {
@@ -78,7 +79,7 @@ export class SelectAllText extends BaseVisualChange {
    * Uses ACTION_SET_SELECTION which is significantly faster than ADB double-tap.
    */
   private async executeAndroidSelectAll(): Promise<SelectAllTextResult> {
-    const a11yClient = AndroidCtrlProxyClient.getInstance(this.device, this.adb);
+    const a11yClient = AndroidCtrlProxyClient.getInstance(this.device, this.adbFactory);
     const a11yResult = await a11yClient.requestSelectAll();
 
     if (a11yResult.success) {

--- a/test/features/action/SelectAllText.test.ts
+++ b/test/features/action/SelectAllText.test.ts
@@ -1,0 +1,42 @@
+import { expect, describe, test, spyOn } from "bun:test";
+import { SelectAllText } from "../../../src/features/action/SelectAllText";
+import { BootedDevice } from "../../../src/models";
+import { AndroidCtrlProxyClient } from "../../../src/features/observe/android";
+import { FakeAdbClientFactory } from "../../fakes/FakeAdbClientFactory";
+
+describe("SelectAllText Android", () => {
+  // Regression for https://github.com/kaeawc/auto-mobile/issues/2231.
+  // AndroidCtrlProxyClient.getInstance expects an AdbClientFactory and calls
+  // `.create(device)` on it. Passing the resolved AdbExecutor instead
+  // surfaces in production as `TypeError: <minified>.create is not a function`
+  // and silently breaks the a11y selectAll path on first ctrl-proxy call.
+  test("passes the injected AdbClientFactory (not AdbExecutor) to AndroidCtrlProxyClient.getInstance", async () => {
+    const factory = new FakeAdbClientFactory();
+    const getInstanceSpy = spyOn(AndroidCtrlProxyClient, "getInstance").mockReturnValue({
+      requestSelectAll: async () => ({ success: true, totalTimeMs: 1 }),
+    } as unknown as AndroidCtrlProxyClient);
+
+    const device: BootedDevice = {
+      name: "Test Android",
+      platform: "android",
+      deviceId: "test-android",
+    };
+
+    const selectAllText = new SelectAllText(device, factory);
+    const observedSpy = spyOn(
+      selectAllText as unknown as { observedInteraction: (fn: () => Promise<unknown>) => Promise<unknown> },
+      "observedInteraction"
+    ).mockImplementation(async (fn: () => Promise<unknown>) => fn());
+
+    await selectAllText.execute();
+
+    expect(getInstanceSpy).toHaveBeenCalled();
+    const [, passedFactory] = getInstanceSpy.mock.calls[0] as [BootedDevice, FakeAdbClientFactory];
+    expect(typeof passedFactory.create).toBe("function");
+    expect(passedFactory).toBe(factory);
+    expect(factory.wasCalledForDevice(device.deviceId)).toBe(true);
+
+    getInstanceSpy.mockRestore();
+    observedSpy.mockRestore();
+  });
+});


### PR DESCRIPTION
## Summary
- Fix `SelectAllText.executeAndroidSelectAll` passing `this.adb` (AdbExecutor) where `AndroidCtrlProxyClient.getInstance` expects an `AdbClientFactory`. At runtime this surfaces as `TypeError: <minified>.create is not a function` on the first ctrl-proxy call per device.
- Widen the constructor to accept `AdbClientFactory | AdbExecutor | null` (matching `BaseVisualChange`) and route the factory through.
- Add regression test asserting the factory (not the executor) is passed to `AndroidCtrlProxyClient.getInstance`.

Fixes #2231. Same class as #2214 / #2227.

## Test plan
- [x] `bun test test/features/action/SelectAllText.test.ts` — passes
- [x] `bunx tsc --noEmit` clean for affected files