### PR TITLE
fix(proxy): add runtime BootedDevice shape guard to CtrlProxy factories

### DIFF
--- a/src/features/action/TapOnElement.ts
+++ b/src/features/action/TapOnElement.ts
@@ -983,11 +983,11 @@ export class TapOnElement extends BaseVisualChange {
           }
 
           const isTalkBackEnabled = this.device.platform === "android"
-            ? (await this.accessibilityDetector.detectMethod(this.device.id, this.adb)) === "talkback"
+            ? (await this.accessibilityDetector.detectMethod(this.device.deviceId, this.adb)) === "talkback"
             : false;
           const isVoiceOverEnabled = this.device.platform === "ios"
             ? await this.iosVoiceOverDetector.isVoiceOverEnabled(
-              this.device.id,
+              this.device.deviceId,
               IOSCtrlProxyClient.getInstance(this.device)
             )
             : false;
@@ -1188,7 +1188,7 @@ export class TapOnElement extends BaseVisualChange {
     // Check if TalkBack is enabled (not just any accessibility service)
     const talkBackEnabled = typeof isTalkBackEnabled === "boolean"
       ? isTalkBackEnabled
-      : (await this.accessibilityDetector.detectMethod(this.device.id, this.adb)) === "talkback";
+      : (await this.accessibilityDetector.detectMethod(this.device.deviceId, this.adb)) === "talkback";
 
     if (talkBackEnabled) {
       // TalkBack mode: Use accessibility actions with coordinate fallback
@@ -1325,7 +1325,7 @@ export class TapOnElement extends BaseVisualChange {
     // Try focus navigation for tap and doubleTap actions
     if (action === "tap" || action === "doubleTap") {
       const result = await this.talkBackStrategy.executeTap(
-        this.device.id,
+        this.device.deviceId,
         element,
         action as "tap" | "doubleTap",
         driver

--- a/src/features/action/swipeon/VoiceOverSwipeExecutor.ts
+++ b/src/features/action/swipeon/VoiceOverSwipeExecutor.ts
@@ -69,7 +69,7 @@ export class VoiceOverSwipeExecutor implements VoiceOverSwipeRunner {
     }
 
     const isVoiceOverEnabled = await this.iosVoiceOverDetector.isVoiceOverEnabled(
-      this.device.id,
+      this.device.deviceId,
       this.iosClient
     );
 

--- a/src/features/memory/MemoryAudit.ts
+++ b/src/features/memory/MemoryAudit.ts
@@ -67,14 +67,14 @@ export class MemoryAudit {
 
     // Get baseline for this app/tool combination
     const baseline = await this.baselineManager.getBaseline(
-      this.device.id,
+      this.device.deviceId,
       packageName,
       toolName
     );
 
     // Get or create thresholds
     const thresholds = await this.thresholdManager.getOrCreateThresholds(
-      this.device.id,
+      this.device.deviceId,
       packageName,
       baseline
     );
@@ -103,7 +103,7 @@ export class MemoryAudit {
     // Update baseline with new metrics (only if passed, to avoid poisoning baseline)
     if (passed) {
       await this.baselineManager.updateBaseline(
-        this.device.id,
+        this.device.deviceId,
         packageName,
         toolName,
         metrics
@@ -112,7 +112,7 @@ export class MemoryAudit {
 
     // Update threshold weights based on result
     await this.thresholdManager.updateThresholdWeight(
-      this.device.id,
+      this.device.deviceId,
       packageName,
       passed
     );
@@ -345,7 +345,7 @@ export class MemoryAudit {
       const sessionId = now.toISOString().split("T")[0]; // YYYY-MM-DD
 
       const auditResult: NewMemoryAuditResult = {
-        device_id: this.device.id,
+        device_id: this.device.deviceId,
         session_id: sessionId,
         package_name: packageName,
         tool_name: toolName,

--- a/src/features/observe/android/AndroidCtrlProxyClient.ts
+++ b/src/features/observe/android/AndroidCtrlProxyClient.ts
@@ -38,6 +38,7 @@ import { HierarchyNavigationDetector } from "../../navigation/HierarchyNavigatio
 import { InstalledAppsRepository, InstalledAppsStore } from "../../../db/installedAppsRepository";
 import { DefaultWorkProfileMonitor, WorkProfileMonitor } from "../../../utils/WorkProfileMonitor";
 import { PortManager } from "../../../utils/PortManager";
+import { requireBootedDevice } from "../../../utils/requireBootedDevice";
 import { getDeviceDataStreamServer } from "../../../daemon/deviceDataStreamSocketServer";
 import {
   ScreenshotBackoffScheduler,
@@ -815,6 +816,7 @@ export class AndroidCtrlProxyClient extends DeviceServiceClient implements Andro
    * Get singleton instance for a device
    */
   public static getInstance(device: BootedDevice, adbFactory: AdbClientFactory = defaultAdbClientFactory): AndroidCtrlProxyClient {
+    requireBootedDevice(device, "AndroidCtrlProxyClient.getInstance");
     const deviceId = device.deviceId;
     if (!AndroidCtrlProxyClient.instances.has(deviceId)) {
       logger.debug(`[CTRL_PROXY] Creating singleton for device: ${deviceId}`);

--- a/src/features/observe/ios/IOSCtrlProxyClient.ts
+++ b/src/features/observe/ios/IOSCtrlProxyClient.ts
@@ -24,6 +24,7 @@ import { ViewHierarchyQueryOptions } from "../../../models/ViewHierarchyQueryOpt
 import { PerformanceTracker, NoOpPerformanceTracker } from "../../../utils/PerformanceTracker";
 import { Timer, defaultTimer } from "../../../utils/SystemTimer";
 import { PortManager } from "../../../utils/PortManager";
+import { requireBootedDevice } from "../../../utils/requireBootedDevice";
 import { shouldUseHostControl, getHostControlHost } from "../../../utils/hostControlClient";
 import { isRunningInDocker } from "../../../utils/dockerEnv";
 import { IOSCtrlProxyManager, CtrlProxyIosManager } from "../../../utils/IOSCtrlProxyManager";
@@ -322,6 +323,7 @@ export class IOSCtrlProxyClient extends DeviceServiceClient implements IOSCtrlPr
     device: BootedDevice,
     port?: number
   ): IOSCtrlProxyClient {
+    requireBootedDevice(device, "IOSCtrlProxyClient.getInstance");
     const resolvedPort = port ?? (
       device.platform === "ios" ? PortManager.allocate(device.deviceId) : IOSCtrlProxyClient.DEFAULT_PORT
     );

--- a/src/utils/CtrlProxyManager.ts
+++ b/src/utils/CtrlProxyManager.ts
@@ -4,6 +4,7 @@ import { logger } from "./logger";
 import * as fs from "fs/promises";
 import * as path from "path";
 import { BootedDevice } from "../models";
+import { requireBootedDevice } from "./requireBootedDevice";
 import {
   APK_SHA256_CHECKSUM,
   APK_URL,
@@ -130,6 +131,7 @@ export class AndroidCtrlProxyManager implements CtrlProxyManager {
   }
 
   public static getInstance(device: BootedDevice, adbFactoryOrExecutor: AdbClientFactory | AdbExecutor | null = defaultAdbClientFactory): AndroidCtrlProxyManager {
+    requireBootedDevice(device, "AndroidCtrlProxyManager.getInstance");
     if (!AndroidCtrlProxyManager.instances.has(device.deviceId)) {
       let adb: AdbExecutor;
       let factory: AdbClientFactory;

--- a/src/utils/IOSCtrlProxyManager.ts
+++ b/src/utils/IOSCtrlProxyManager.ts
@@ -1,5 +1,6 @@
 import { logger } from "./logger";
 import { BootedDevice } from "../models";
+import { requireBootedDevice } from "./requireBootedDevice";
 import { NoOpPerformanceTracker, createGlobalPerformanceTracker, type PerformanceTracker } from "./PerformanceTracker";
 import { Timer, defaultTimer } from "./SystemTimer";
 import { IOSCtrlProxyBuilder, type CtrlProxyIosBuildResult } from "./IOSCtrlProxyBuilder";
@@ -202,6 +203,7 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
    * Get singleton instance for a device
    */
   public static getInstance(device: BootedDevice, timer?: Timer): IOSCtrlProxyManager {
+    requireBootedDevice(device, "IOSCtrlProxyManager.getInstance");
     if (!IOSCtrlProxyManager.instances.has(device.deviceId)) {
       IOSCtrlProxyManager.instances.set(
         device.deviceId,

--- a/src/utils/requireBootedDevice.ts
+++ b/src/utils/requireBootedDevice.ts
@@ -1,0 +1,26 @@
+import { BootedDevice } from "../models";
+
+/**
+ * Runtime shape guard for singleton factories keyed on `device.deviceId`.
+ *
+ * Bun skips type-checking and the codebase has pre-existing TS errors, so
+ * passing a bare deviceId string (instead of a BootedDevice) silently keys
+ * the singleton at `undefined` and surfaces later as cryptic errors from
+ * background callbacks. This boundary check converts the silent corruption
+ * into a loud, immediately-actionable stack trace at the caller.
+ */
+export function requireBootedDevice(device: unknown, fn: string): asserts device is BootedDevice {
+  const d = device as Partial<BootedDevice> | null | undefined;
+  if (
+    !d ||
+    typeof d !== "object" ||
+    typeof d.deviceId !== "string" ||
+    d.deviceId.length === 0 ||
+    (d.platform !== "android" && d.platform !== "ios")
+  ) {
+    const description = typeof device === "string"
+      ? `string "${device}"`
+      : JSON.stringify(device);
+    throw new Error(`${fn}: expected BootedDevice, got ${description}`);
+  }
+}

--- a/src/utils/requireBootedDevice.ts
+++ b/src/utils/requireBootedDevice.ts
@@ -18,9 +18,17 @@ export function requireBootedDevice(device: unknown, fn: string): asserts device
     d.deviceId.length === 0 ||
     (d.platform !== "android" && d.platform !== "ios")
   ) {
-    const description = typeof device === "string"
-      ? `string "${device}"`
-      : JSON.stringify(device);
-    throw new Error(`${fn}: expected BootedDevice, got ${description}`);
+    throw new Error(`${fn}: expected BootedDevice, got ${describeInvalidDevice(device)}`);
+  }
+}
+
+function describeInvalidDevice(device: unknown): string {
+  if (typeof device === "string") {
+    return `string "${device}"`;
+  }
+  try {
+    return JSON.stringify(device) ?? String(device);
+  } catch {
+    return Object.prototype.toString.call(device);
   }
 }

--- a/test/features/action/HandleIntentChooser.test.ts
+++ b/test/features/action/HandleIntentChooser.test.ts
@@ -1,6 +1,8 @@
 import { expect, describe, test, beforeEach } from "bun:test";
 import { HandleIntentChooser } from "../../../src/features/action/HandleIntentChooser";
-import { ObserveResult, ViewHierarchyResult } from "../../../src/models";
+import { BootedDevice, ObserveResult, ViewHierarchyResult } from "../../../src/models";
+
+const testDevice: BootedDevice = { name: "test-device", platform: "android", deviceId: "emulator-5554" };
 import { FakeDeepLinkManager } from "../../fakes/FakeDeepLinkManager";
 import { FakeObserveScreen } from "../../fakes/FakeObserveScreen";
 import { FakeWindow } from "../../fakes/FakeWindow";
@@ -63,7 +65,7 @@ describe("HandleIntentChooser", () => {
     fakeDeepLinkManager.setDefaultIntentChooserDetected(true);
 
     // Create HandleIntentChooser instance
-    handleIntentChooser = new HandleIntentChooser("test-device");
+    handleIntentChooser = new HandleIntentChooser(testDevice);
 
     // Replace the internal managers with our fakes
     (handleIntentChooser as any).deepLinkManager = fakeDeepLinkManager;
@@ -74,7 +76,7 @@ describe("HandleIntentChooser", () => {
 
   describe("constructor", () => {
     test("should create HandleIntentChooser with device ID", () => {
-      const instance = new HandleIntentChooser("test-device");
+      const instance = new HandleIntentChooser(testDevice);
       expect(instance).toBeInstanceOf(HandleIntentChooser);
     });
   });

--- a/test/features/action/RecentApps.test.ts
+++ b/test/features/action/RecentApps.test.ts
@@ -1,6 +1,8 @@
 import { expect, describe, test, beforeEach, afterEach, spyOn } from "bun:test";
 import { RecentApps } from "../../../src/features/action/RecentApps";
 import { BootedDevice, ExecResult, ObserveResult } from "../../../src/models";
+
+const testDevice: BootedDevice = { name: "test-device", platform: "android", deviceId: "emulator-5554" };
 import { IOSCtrlProxyClient } from "../../../src/features/observe/ios";
 import { FakeAdbExecutor } from "../../fakes/FakeAdbExecutor";
 import { FakeObserveScreen } from "../../fakes/FakeObserveScreen";
@@ -41,7 +43,7 @@ describe("RecentApps", () => {
     });
 
     // Inject the fakes into the feature
-    recentApps = new RecentApps("test-device", fakeAdb, fakeTimer);
+    recentApps = new RecentApps(testDevice, fakeAdb, fakeTimer);
     (recentApps as any).observeScreen = fakeObserveScreen;
     (recentApps as any).window = fakeWindow;
     (recentApps as any).awaitIdle = fakeAwaitIdle;
@@ -348,13 +350,13 @@ describe("RecentApps", () => {
 
   describe("constructor", () => {
     test("should work with null deviceId", () => {
-      const recentAppsInstance = new RecentApps("test-device", fakeAdb, fakeTimer);
+      const recentAppsInstance = new RecentApps(testDevice, fakeAdb, fakeTimer);
       expect(recentAppsInstance).toBeDefined();
     });
 
     test("should work with custom AdbClient", () => {
       const customAdb = new FakeAdbExecutor();
-      const recentAppsInstance = new RecentApps("test-device", customAdb, fakeTimer);
+      const recentAppsInstance = new RecentApps(testDevice, customAdb, fakeTimer);
       expect(recentAppsInstance).toBeDefined();
     });
   });

--- a/test/features/action/Shake.test.ts
+++ b/test/features/action/Shake.test.ts
@@ -1,6 +1,8 @@
 import { expect, describe, test, beforeEach } from "bun:test";
 import { Shake } from "../../../src/features/action/Shake";
-import { ObserveResult } from "../../../src/models";
+import { BootedDevice, ObserveResult } from "../../../src/models";
+
+const testDevice: BootedDevice = { name: "test-device", platform: "android", deviceId: "emulator-5554" };
 import { FakeAdbExecutor } from "../../fakes/FakeAdbExecutor";
 import { FakeObserveScreen } from "../../fakes/FakeObserveScreen";
 import { FakeWindow } from "../../fakes/FakeWindow";
@@ -40,7 +42,7 @@ describe("Shake", () => {
     const defaultObserveResult = createObserveResult();
     fakeObserveScreen.setObserveResult(defaultObserveResult);
 
-    shake = new Shake("test-device", fakeAdb, fakeTimer);
+    shake = new Shake(testDevice, fakeAdb, fakeTimer);
     (shake as any).observeScreen = fakeObserveScreen;
     (shake as any).window = fakeWindow;
     (shake as any).awaitIdle = fakeAwaitIdle;
@@ -218,18 +220,18 @@ describe("Shake", () => {
 
   describe("constructor", () => {
     test("should work with null deviceId", () => {
-      const shakeInstance = new Shake("test-device", fakeAdb, fakeTimer);
+      const shakeInstance = new Shake(testDevice, fakeAdb, fakeTimer);
       expect(shakeInstance).toBeDefined();
     });
 
     test("should work with custom AdbClient", () => {
       const customAdb = new FakeAdbExecutor();
-      const shakeInstance = new Shake("test-device", customAdb, fakeTimer);
+      const shakeInstance = new Shake(testDevice, customAdb, fakeTimer);
       expect(shakeInstance).toBeDefined();
     });
 
     test("should work with default timer when not provided", () => {
-      const shakeInstance = new Shake("test-device", fakeAdb);
+      const shakeInstance = new Shake(testDevice, fakeAdb);
       expect(shakeInstance).toBeDefined();
     });
   });

--- a/test/features/action/TapOnElement.extendedSelectors.test.ts
+++ b/test/features/action/TapOnElement.extendedSelectors.test.ts
@@ -9,7 +9,7 @@ const createTapOnElement = (selector: FakeElementSelector) => {
     {
       name: "test-device",
       platform: "android",
-      id: "emulator-5554",
+      deviceId: "emulator-5554",
     } as any,
     new FakeAdbClient() as any,
     {

--- a/test/features/action/TapOnElement.preTapStability.test.ts
+++ b/test/features/action/TapOnElement.preTapStability.test.ts
@@ -30,7 +30,7 @@ function createTapOnElement(): { tap: TapOnElement; timer: FakeTimer } {
     {
       name: "test-device",
       platform: "android",
-      id: "emulator-5554",
+      deviceId: "emulator-5554",
     } as any,
     new FakeAdbClient() as any,
     { timer }

--- a/test/features/action/TapOnElement.retryIfNoChange.test.ts
+++ b/test/features/action/TapOnElement.retryIfNoChange.test.ts
@@ -25,7 +25,7 @@ function createTapOnElement(): { tap: TapOnElement; timer: FakeTimer } {
     {
       name: "test-device",
       platform: "android",
-      id: "emulator-5554",
+      deviceId: "emulator-5554",
     } as any,
     new FakeAdbClient() as any,
     { timer }

--- a/test/features/action/TapOnElement.selectedElement.test.ts
+++ b/test/features/action/TapOnElement.selectedElement.test.ts
@@ -14,7 +14,7 @@ const createTapOnElement = (): TapOnElement => {
     {
       name: "test-device",
       platform: "android",
-      id: "emulator-5554",
+      deviceId: "emulator-5554",
     } as any,
     new FakeAdbClient() as any,
     {

--- a/test/features/action/TapOnElement.selectionStrategy.test.ts
+++ b/test/features/action/TapOnElement.selectionStrategy.test.ts
@@ -13,7 +13,7 @@ describe("TapOnElement selectionStrategy", () => {
       {
         name: "test-device",
         platform: "android",
-        id: "emulator-5554",
+        deviceId: "emulator-5554",
       } as any,
       new FakeAdbClient() as any,
       {

--- a/test/features/action/TapOnElement.talkback.test.ts
+++ b/test/features/action/TapOnElement.talkback.test.ts
@@ -24,7 +24,7 @@ describe("TapOnElement TalkBack mode detection", () => {
       {
         name: "test-device",
         platform: "android",
-        id: "emulator-5554",
+        deviceId: "emulator-5554",
       } as any,
       fakeAdb as any,
       {
@@ -396,7 +396,7 @@ describe("TapOnElement TalkBackTapStrategy delegation", () => {
       {
         name: "test-device",
         platform: "android",
-        id: "emulator-5554",
+        deviceId: "emulator-5554",
       } as any,
       fakeAdb as any,
       {

--- a/test/features/observe/DetectIntentChooser.test.ts
+++ b/test/features/observe/DetectIntentChooser.test.ts
@@ -1,6 +1,8 @@
 import { expect, describe, test, beforeEach } from "bun:test";
 import { DetectIntentChooser } from "../../../src/features/observe/DetectIntentChooser";
-import { ObserveResult, ViewHierarchyResult } from "../../../src/models";
+import { BootedDevice, ObserveResult, ViewHierarchyResult } from "../../../src/models";
+
+const testDevice: BootedDevice = { name: "test-device", platform: "android", deviceId: "emulator-5554" };
 import { FakeDeepLinkManager } from "../../fakes/FakeDeepLinkManager";
 import { FakeObserveScreen } from "../../fakes/FakeObserveScreen";
 import { FakeWindow } from "../../fakes/FakeWindow";
@@ -61,7 +63,7 @@ describe("DetectIntentChooser", () => {
     fakeDeepLinkManager.setDefaultIntentChooserDetected(true);
 
     // Create DetectIntentChooser instance
-    detectIntentChooser = new DetectIntentChooser("test-device");
+    detectIntentChooser = new DetectIntentChooser(testDevice);
 
     // Replace the internal managers with our fakes
     (detectIntentChooser as any).observeScreen = fakeObserveScreen;
@@ -72,7 +74,7 @@ describe("DetectIntentChooser", () => {
 
   describe("constructor", () => {
     test("should create DetectIntentChooser with device ID", () => {
-      const instance = new DetectIntentChooser("test-device");
+      const instance = new DetectIntentChooser(testDevice);
       expect(instance).toBeInstanceOf(DetectIntentChooser);
     });
   });

--- a/test/utils/requireBootedDevice.test.ts
+++ b/test/utils/requireBootedDevice.test.ts
@@ -57,6 +57,18 @@ describe("requireBootedDevice", () => {
     expect(() => requireBootedDevice({ foo: "bar" }, "MyFactory.getInstance"))
       .toThrow('MyFactory.getInstance: expected BootedDevice, got {"foo":"bar"}');
   });
+
+  test("still throws the guard error when input has a cyclic reference", () => {
+    const cyclic: Record<string, unknown> = { foo: "bar" };
+    cyclic.self = cyclic;
+    expect(() => requireBootedDevice(cyclic, FN))
+      .toThrow(new RegExp(`^${FN}: expected BootedDevice, got `));
+  });
+
+  test("still throws the guard error when input contains a BigInt", () => {
+    expect(() => requireBootedDevice({ deviceId: 5n, platform: "android" }, FN))
+      .toThrow(new RegExp(`^${FN}: expected BootedDevice, got `));
+  });
 });
 
 describe("requireBootedDevice integration with factories", () => {

--- a/test/utils/requireBootedDevice.test.ts
+++ b/test/utils/requireBootedDevice.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, test } from "bun:test";
+import { requireBootedDevice } from "../../src/utils/requireBootedDevice";
+
+const FN = "Test.getInstance";
+
+describe("requireBootedDevice", () => {
+  test("throws on a bare deviceId string", () => {
+    expect(() => requireBootedDevice("emulator-5554", FN))
+      .toThrow(`${FN}: expected BootedDevice, got string "emulator-5554"`);
+  });
+
+  test("throws on empty object", () => {
+    expect(() => requireBootedDevice({}, FN)).toThrow(/expected BootedDevice/);
+  });
+
+  test("throws on null", () => {
+    expect(() => requireBootedDevice(null, FN)).toThrow(/expected BootedDevice/);
+  });
+
+  test("throws on undefined", () => {
+    expect(() => requireBootedDevice(undefined, FN)).toThrow(/expected BootedDevice/);
+  });
+
+  test("throws on missing deviceId", () => {
+    expect(() => requireBootedDevice({ platform: "android", name: "x" }, FN))
+      .toThrow(/expected BootedDevice/);
+  });
+
+  test("throws on empty deviceId", () => {
+    expect(() => requireBootedDevice({ platform: "android", name: "x", deviceId: "" }, FN))
+      .toThrow(/expected BootedDevice/);
+  });
+
+  test("throws on missing platform", () => {
+    expect(() => requireBootedDevice({ deviceId: "emulator-5554", name: "x" }, FN))
+      .toThrow(/expected BootedDevice/);
+  });
+
+  test("throws on invalid platform", () => {
+    expect(() => requireBootedDevice({ deviceId: "emulator-5554", platform: "windows", name: "x" }, FN))
+      .toThrow(/expected BootedDevice/);
+  });
+
+  test("accepts a valid android BootedDevice", () => {
+    expect(() =>
+      requireBootedDevice({ deviceId: "emulator-5554", platform: "android", name: "Pixel" }, FN)
+    ).not.toThrow();
+  });
+
+  test("accepts a valid ios BootedDevice", () => {
+    expect(() =>
+      requireBootedDevice({ deviceId: "ABCDEF", platform: "ios", name: "iPhone 15" }, FN)
+    ).not.toThrow();
+  });
+
+  test("error includes function name and JSON-serialized object", () => {
+    expect(() => requireBootedDevice({ foo: "bar" }, "MyFactory.getInstance"))
+      .toThrow('MyFactory.getInstance: expected BootedDevice, got {"foo":"bar"}');
+  });
+});
+
+describe("requireBootedDevice integration with factories", () => {
+  test("AndroidCtrlProxyClient.getInstance throws on bare deviceId string", async () => {
+    const { AndroidCtrlProxyClient } = await import("../../src/features/observe/android/AndroidCtrlProxyClient");
+    expect(() => AndroidCtrlProxyClient.getInstance("emulator-5554" as never))
+      .toThrow(/AndroidCtrlProxyClient\.getInstance: expected BootedDevice/);
+  });
+
+  test("AndroidCtrlProxyClient.getInstance throws on empty object", async () => {
+    const { AndroidCtrlProxyClient } = await import("../../src/features/observe/android/AndroidCtrlProxyClient");
+    expect(() => AndroidCtrlProxyClient.getInstance({} as never))
+      .toThrow(/expected BootedDevice/);
+  });
+
+  test("IOSCtrlProxyClient.getInstance throws on bare deviceId string", async () => {
+    const { IOSCtrlProxyClient } = await import("../../src/features/observe/ios/IOSCtrlProxyClient");
+    expect(() => IOSCtrlProxyClient.getInstance("ABCDEF" as never))
+      .toThrow(/IOSCtrlProxyClient\.getInstance: expected BootedDevice/);
+  });
+
+  test("IOSCtrlProxyClient.getInstance throws on empty object", async () => {
+    const { IOSCtrlProxyClient } = await import("../../src/features/observe/ios/IOSCtrlProxyClient");
+    expect(() => IOSCtrlProxyClient.getInstance({} as never))
+      .toThrow(/expected BootedDevice/);
+  });
+
+  test("AndroidCtrlProxyManager.getInstance throws on bare deviceId string", async () => {
+    const { AndroidCtrlProxyManager } = await import("../../src/utils/CtrlProxyManager");
+    expect(() => AndroidCtrlProxyManager.getInstance("emulator-5554" as never))
+      .toThrow(/AndroidCtrlProxyManager\.getInstance: expected BootedDevice/);
+  });
+
+  test("AndroidCtrlProxyManager.getInstance throws on empty object", async () => {
+    const { AndroidCtrlProxyManager } = await import("../../src/utils/CtrlProxyManager");
+    expect(() => AndroidCtrlProxyManager.getInstance({} as never))
+      .toThrow(/expected BootedDevice/);
+  });
+
+  test("IOSCtrlProxyManager.getInstance throws on bare deviceId string", async () => {
+    const { IOSCtrlProxyManager } = await import("../../src/utils/IOSCtrlProxyManager");
+    expect(() => IOSCtrlProxyManager.getInstance("ABCDEF" as never))
+      .toThrow(/IOSCtrlProxyManager\.getInstance: expected BootedDevice/);
+  });
+
+  test("IOSCtrlProxyManager.getInstance throws on empty object", async () => {
+    const { IOSCtrlProxyManager } = await import("../../src/utils/IOSCtrlProxyManager");
+    expect(() => IOSCtrlProxyManager.getInstance({} as never))
+      .toThrow(/expected BootedDevice/);
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `requireBootedDevice()` shared util that throws when a factory receives anything other than a `BootedDevice` (object with non-empty `deviceId` and platform `"android"`/`"ios"`).
- Wires it into all four singleton factories keyed on `device.deviceId`:
  - `AndroidCtrlProxyClient.getInstance`
  - `IOSCtrlProxyClient.getInstance`
  - `AndroidCtrlProxyManager.getInstance`
  - `IOSCtrlProxyManager.getInstance`
- Converts the silent-corruption failure mode from #2215/#2218 (singleton keyed at `undefined`, surfacing later as `"Unsupported platform: undefined"`) into a loud, immediately-actionable stack trace at the caller.

This is a boundary check — the type system isn't catching this (Bun skips type-check; codebase has pre-existing TS errors per CLAUDE.md), and the failure has happened in production.

## Test plan

- [x] Unit tests for `requireBootedDevice` (bare string, empty object, null, undefined, missing/empty `deviceId`, missing/invalid `platform`, valid android, valid ios, error formatting)
- [x] Integration tests assert each of the four `getInstance` factories throws on `getInstance("emulator-5554")` and `getInstance({})`
- [x] `bunx turbo run lint` ✓
- [x] `bunx turbo run build` ✓
- [x] 19/19 new tests pass in ~270ms (pre-existing unrelated flake in `CtrlProxyClient.test.ts:399` reproduces on `main` too)

Fixes #2223