### PR TITLE
fix(action): pass AdbClientFactory to AndroidCtrlProxyClient in InputText

### DIFF
--- a/src/features/action/InputText.ts
+++ b/src/features/action/InputText.ts
@@ -86,7 +86,7 @@ export class InputText extends BaseVisualChange {
   ): Promise<SendTextResult & { method?: "a11y" }> {
     // Use accessibility service exclusively (fastest method, ~10-30ms vs ~200-300ms for ADB)
     // It also natively supports Unicode without needing virtual keyboard
-    const a11yClient = AndroidCtrlProxyClient.getInstance(this.device, this.adb);
+    const a11yClient = AndroidCtrlProxyClient.getInstance(this.device, this.adbFactory);
     const a11yResult = await a11yClient.requestSetText(text, undefined, undefined, undefined, dismissKeyboard);
 
     if (a11yResult.success) {

--- a/test/features/action/InputText.test.ts
+++ b/test/features/action/InputText.test.ts
@@ -1,0 +1,56 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { InputText } from "../../../src/features/action/InputText";
+import { AndroidCtrlProxyClient } from "../../../src/features/observe/android";
+import { FakeAdbClientFactory } from "../../fakes/FakeAdbClientFactory";
+import type { BootedDevice } from "../../../src/models";
+import type { AdbClientFactory } from "../../../src/utils/android-cmdline-tools/AdbClientFactory";
+
+describe("InputText", () => {
+  const androidDevice: BootedDevice = {
+    deviceId: "input-text-device",
+    platform: "android",
+    name: "Test Device",
+  };
+
+  let originalGetInstance: typeof AndroidCtrlProxyClient.getInstance;
+
+  beforeEach(() => {
+    originalGetInstance = AndroidCtrlProxyClient.getInstance;
+    AndroidCtrlProxyClient.resetInstances();
+  });
+
+  afterEach(() => {
+    AndroidCtrlProxyClient.getInstance = originalGetInstance;
+    AndroidCtrlProxyClient.resetInstances();
+  });
+
+  // Regression for https://github.com/kaeawc/auto-mobile/issues/2229.
+  // executeAndroidTextInput calls AndroidCtrlProxyClient.getInstance, which
+  // invokes `.create(device)` on its second argument. Passing the AdbExecutor
+  // (this.adb) instead of the AdbClientFactory (this.adbFactory) surfaces in
+  // production as `TypeError: <minified>.create is not a function` on the
+  // first ctrl-proxy call per device. Asserts the factory is forwarded.
+  test("forwards adbFactory (not adb executor) to AndroidCtrlProxyClient.getInstance (regression for #2229)", async () => {
+    const factory = new FakeAdbClientFactory();
+    const inputText = new InputText(androidDevice, factory as AdbClientFactory);
+
+    let capturedFactory: unknown = undefined;
+    AndroidCtrlProxyClient.getInstance = ((device: BootedDevice, adbFactory: AdbClientFactory) => {
+      capturedFactory = adbFactory;
+      return originalGetInstance(device, adbFactory);
+    }) as typeof AndroidCtrlProxyClient.getInstance;
+
+    try {
+      await (inputText as unknown as {
+        executeAndroidTextInput: (text: string) => Promise<unknown>;
+      }).executeAndroidTextInput("hello");
+    } catch {
+      // Ignore downstream failures — we only care that getInstance was
+      // handed a factory, not an executor.
+    }
+
+    expect(capturedFactory).toBeDefined();
+    expect(typeof (capturedFactory as AdbClientFactory).create).toBe("function");
+    expect(capturedFactory).toBe(factory as unknown as AdbClientFactory);
+  });
+});


### PR DESCRIPTION
## Summary
- Fixes #2229. `InputText.executeAndroidTextInput` was handing `this.adb` (an `AdbExecutor`) to `AndroidCtrlProxyClient.getInstance`, whose second argument is an `AdbClientFactory` it immediately invokes `.create(device)` on. Production minified builds surfaced this as `TypeError: <minified>.create is not a function` on the first ctrl-proxy call per device, breaking the accessibility-service text input path.
- One-line fix: `this.adb` → `this.adbFactory` at [src/features/action/InputText.ts:89](src/features/action/InputText.ts:89).
- Adds a regression test that fakes `AndroidCtrlProxyClient.getInstance` and asserts the forwarded second argument is the injected `AdbClientFactory`, not the executor.

Same regression class as #2214 (fixed in #2221).

> [!NOTE]
> The same bug pattern also exists in `ClearText.ts:67`, `Clipboard.ts:101`, and `ImeAction.ts:90`. Out of scope for this PR — should be filed/fixed separately.

## Test plan
- [x] `bun test test/features/action/InputText.test.ts` — passes with fix, fails when fix is reverted (verified locally)
- [x] `bunx tsc --noEmit` — no new errors for InputText
- [x] `bunx turbo run lint` — clean