### PR TITLE
fix(action): pass AdbClientFactory to AndroidCtrlProxyClient.getInstance in ClearText (#2226)

### DIFF
--- a/src/features/action/ClearText.ts
+++ b/src/features/action/ClearText.ts
@@ -64,7 +64,7 @@ export class ClearText extends BaseVisualChange {
    */
   private async executeAndroidClearText(observeResult: ObserveResult): Promise<ClearTextResult> {
     // Use accessibility service (fastest method, ~50-80ms vs ~200-500ms for ADB deletes)
-    const a11yClient = AndroidCtrlProxyClient.getInstance(this.device, this.adb);
+    const a11yClient = AndroidCtrlProxyClient.getInstance(this.device, this.adbFactory);
     const a11yResult = await a11yClient.requestClearText();
 
     if (a11yResult.success) {

--- a/test/features/action/ClearText.adbFactory.test.ts
+++ b/test/features/action/ClearText.adbFactory.test.ts
@@ -1,0 +1,45 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { ClearText } from "../../../src/features/action/ClearText";
+import { AndroidCtrlProxyClient } from "../../../src/features/observe/android";
+import { FakeAdbClientFactory } from "../../fakes/FakeAdbClientFactory";
+import type { BootedDevice, ObserveResult } from "../../../src/models";
+
+describe("ClearText accessibility-service path", () => {
+  const device: BootedDevice = { name: "device-1", platform: "android", deviceId: "device-1" };
+  let originalGetInstance: typeof AndroidCtrlProxyClient.getInstance;
+
+  beforeEach(() => {
+    originalGetInstance = AndroidCtrlProxyClient.getInstance;
+    AndroidCtrlProxyClient.resetInstances();
+  });
+
+  afterEach(() => {
+    AndroidCtrlProxyClient.getInstance = originalGetInstance;
+    AndroidCtrlProxyClient.resetInstances();
+  });
+
+  test("regression #2226: passes AdbClientFactory (not AdbExecutor) to AndroidCtrlProxyClient.getInstance", async () => {
+    const fakeFactory = new FakeAdbClientFactory();
+    const capturedArgs: unknown[] = [];
+
+    AndroidCtrlProxyClient.getInstance = ((dev: BootedDevice, adbFactory: unknown) => {
+      capturedArgs.push(adbFactory);
+      return {
+        requestClearText: async () => ({ success: true, totalTimeMs: 50 })
+      } as any;
+    }) as any;
+
+    const clearText = new ClearText(device, fakeFactory as any);
+    capturedArgs.length = 0; // ignore construction-time calls; only assert about the a11y path
+    const result = await (clearText as any).executeAndroidClearText({} as ObserveResult);
+
+    expect(result.success).toBe(true);
+    expect(capturedArgs.length).toBe(1);
+
+    const passed = capturedArgs[0] as { create?: (d: BootedDevice) => unknown };
+    expect(typeof passed.create).toBe("function");
+    // Calling create() on the factory must not throw (this is what AndroidCtrlProxyClient.getInstance does
+    // on cache-miss). The bug was passing an AdbExecutor here, which has no .create method.
+    expect(() => passed.create!(device)).not.toThrow();
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #2226 — same class of bug as #2214 (fixed in #2221).

`ClearText.executeAndroidClearText` was passing `this.adb` (an `AdbExecutor`) into `AndroidCtrlProxyClient.getInstance`, which expects an `AdbClientFactory` and synchronously calls `.create(device)` on it. On cache-miss (first ctrl-proxy call on a device) this threw `TypeError: <minified>.create is not a function`, the accessibility-service fast path failed entirely, and `clearText` silently fell back to the ~200-500ms ADB delete-keys path instead of the intended ~50-80ms a11y path.

## Changes

- `src/features/action/ClearText.ts:67` — pass `this.adbFactory` instead of `this.adb` (matches the pattern at `src/features/action/TapOnElement.ts:127`).
- New unit test `test/features/action/ClearText.adbFactory.test.ts` stubs `AndroidCtrlProxyClient.getInstance` and asserts the captured second argument has a callable `.create()`. The test fails against unfixed code (`typeof passed.create === "undefined"`) and passes with the fix.

## Test plan

- [x] `bun test test/features/action/ClearText.adbFactory.test.ts` — passes
- [x] Verified the test fails against pre-fix code
- [x] `bunx turbo run lint build` — clean