### PR TITLE
chore: bump versions to v0.0.29

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -14,7 +14,7 @@
       "name": "auto-mobile",
       "source": "./",
       "description": "Mobile device automation for Android and iOS - control devices with natural language",
-      "version": "0.0.28",
+      "version": "0.0.29",
       "author": {
         "name": "AutoMobile Contributors",
         "email": "jason.d.pearson@gmail.com"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "auto-mobile",
   "description": "Mobile device automation for Android and iOS - control devices with natural language",
-  "version": "0.0.28",
+  "version": "0.0.29",
   "author": {
     "name": "AutoMobile Contributors",
     "email": "jason.d.pearson@gmail.com"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## [v0.0.29] - 2026-05-20
+### Other
+- SelectAllText accessibility-service path crashes: AdbExecutor passed to AdbClientFactory consumer ([#2231](https://github.com/kaeawc/auto-mobile/issues/2231))
+- InputText accessibility-service path crashes: AdbExecutor passed to AdbClientFactory consumer ([#2229](https://github.com/kaeawc/auto-mobile/issues/2229))
+- ImeAction accessibility-service path crashes: AdbExecutor passed to AdbClientFactory consumer ([#2230](https://github.com/kaeawc/auto-mobile/issues/2230))
+- PinchOn accessibility-service path crashes: AdbExecutor passed to AdbClientFactory consumer ([#2228](https://github.com/kaeawc/auto-mobile/issues/2228))
+- Daemon WebSocket observation-stream setup crashes: AdbExecutor passed to AdbClientFactory consumer ([#2224](https://github.com/kaeawc/auto-mobile/issues/2224))
+- ClearText accessibility-service path crashes: AdbExecutor passed to AdbClientFactory consumer ([#2226](https://github.com/kaeawc/auto-mobile/issues/2226))
+- ExecuteGesture accessibility-service path crashes: AdbExecutor passed to AdbClientFactory consumer ([#2225](https://github.com/kaeawc/auto-mobile/issues/2225))
+- Clipboard accessibility-service path crashes: AdbExecutor passed to AdbClientFactory consumer ([#2227](https://github.com/kaeawc/auto-mobile/issues/2227))
+- Add runtime shape guard to *CtrlProxyClient.getInstance() factories ([#2223](https://github.com/kaeawc/auto-mobile/issues/2223))
+- observe waitFor screenshot loop: Operation cancelled every ~130ms until session heartbeat timeout ([#2216](https://github.com/kaeawc/auto-mobile/issues/2216))
+- Navigation screenshot path passes undefined platform causing 'Unsupported platform' error ([#2215](https://github.com/kaeawc/auto-mobile/issues/2215))
+- PerformanceAudit crashes with 'J.create is not a function' in 0.0.28 build ([#2214](https://github.com/kaeawc/auto-mobile/issues/2214))
+
 ## [v0.0.28] - 2026-05-19
 ### Added
 - feat: Android emulator telephony and SMS simulation ([#1579](https://github.com/kaeawc/auto-mobile/issues/1579)) (android)

--- a/android/control-proxy/build.gradle.kts
+++ b/android/control-proxy/build.gradle.kts
@@ -36,7 +36,7 @@ android {
     minSdk = libs.versions.build.android.minSdk.get().toInt()
     targetSdk = libs.versions.build.android.targetSdk.get().toInt()
     versionCode = 1
-    versionName = "0.0.28-SNAPSHOT"
+    versionName = "0.0.29-SNAPSHOT"
 
     testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
   }

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -140,7 +140,7 @@ org.jetbrains.dokka.experimental.gradle.pluginMode=V2Enabled
 # Maven Central Publishing
 
 # Library versions (single source of truth)
-VERSION_NAME=0.0.28-SNAPSHOT
+VERSION_NAME=0.0.29-SNAPSHOT
 GROUP=dev.jasonpearson.auto-mobile
 
 # POM metadata

--- a/android/playground/app/build.gradle.kts
+++ b/android/playground/app/build.gradle.kts
@@ -36,7 +36,7 @@ android {
     minSdk = libs.versions.build.android.minSdk.get().toInt()
     targetSdk = libs.versions.build.android.targetSdk.get().toInt()
     versionCode = 1
-    versionName = "0.0.28-SNAPSHOT"
+    versionName = "0.0.29-SNAPSHOT"
 
     testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kaeawc/auto-mobile",
-  "version": "0.0.28",
+  "version": "0.0.29",
   "description": "Mobile device interaction automation via MCP",
   "scripts": {
     "test": "bun test",

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "dev.jasonpearson/auto-mobile",
   "title": "AutoMobile",
   "description": "Mobile device interaction automation via MCP",
-  "version": "0.0.28",
+  "version": "0.0.29",
   "websiteUrl": "https://kaeawc.github.io/auto-mobile/",
   "repository": {
     "url": "https://github.com/kaeawc/auto-mobile",
@@ -13,7 +13,7 @@
     {
       "registryType": "npm",
       "identifier": "@kaeawc/auto-mobile",
-      "version": "0.0.28",
+      "version": "0.0.29",
       "runtimeHint": "bunx",
       "transport": {
         "type": "stdio"

--- a/src/constants/release.ts
+++ b/src/constants/release.ts
@@ -26,6 +26,11 @@ export interface ReleaseChecksumEntry {
  */
 export const RELEASE_CHECKSUM_REGISTRY: ReleaseChecksumEntry[] = [
   {
+    version: "0.0.29",
+    apkSha256: "b33a67c7efa84aca2b07faa965aecb3b1819b4defd441dcc8d3bf7e2af209cd8",
+    ipaSha256: "d47c1aea4495270c1489cae361286ea1439c2ba4e7d5bcfd73f66e4580a6c45d",
+  },
+  {
     version: "0.0.28",
     apkSha256: "0f683d5939bc308afe038ea1259eb29997dff38af0795136a281ad305986e40e",
     ipaSha256: "eee7accfbca717bb8b89fafd0676f10d8bb08561c3fbd7a04750c9b12c2a7104",


### PR DESCRIPTION
## Summary
- Bump versions to v0.0.29
- Update CHANGELOG.md from closed issues since the last tag
- Refresh CtrlProxy APK SHA256 checksum
- Refresh CtrlProxy iOS IPA SHA256 checksum

## Automation
- Generated by `prepare-release` workflow