### PR TITLE
refactor(snapshot): introduce shared SnapshotProvider interfaces

### DIFF
--- a/src/features/action/CaptureSnapshot.ts
+++ b/src/features/action/CaptureSnapshot.ts
@@ -1,4 +1,5 @@
 import { BootedDevice, ActionableError, DeviceSnapshotManifest, DeviceSnapshotType } from "../../models";
+import type { SnapshotCaptureProvider } from "../../utils/interfaces/SnapshotProvider";
 import { AdbClientFactory, defaultAdbClientFactory } from "../../utils/android-cmdline-tools/AdbClientFactory";
 import type { AdbExecutor } from "../../utils/android-cmdline-tools/interfaces/AdbExecutor";
 import { AndroidEmulatorClient } from "../../utils/android-cmdline-tools/AndroidEmulatorClient";
@@ -38,7 +39,7 @@ export interface CaptureSnapshotResult {
  * Capture device state snapshot
  * Supports VM snapshots for emulators and ADB-based capture for all devices
  */
-export class CaptureSnapshot {
+export class CaptureSnapshot implements SnapshotCaptureProvider {
   private device: BootedDevice;
   private adb: AdbExecutor;
   private emulator: AndroidEmulatorClient;
@@ -61,6 +62,14 @@ export class CaptureSnapshot {
     this.emulator = emulator || new AndroidEmulatorClient();
     this.store = store;
     this.timer = timer;
+  }
+
+  /**
+   * Platform-agnostic capture entry point — satisfies
+   * {@link SnapshotCaptureProvider}. Delegates to {@link execute}.
+   */
+  async capture(args: CaptureSnapshotArgs): Promise<CaptureSnapshotResult> {
+    return this.execute(args);
   }
 
   /**

--- a/src/features/action/CaptureSnapshotIos.ts
+++ b/src/features/action/CaptureSnapshotIos.ts
@@ -1,4 +1,5 @@
 import { ActionableError, BootedDevice, DeviceSnapshotManifest } from "../../models";
+import type { SnapshotCaptureProvider } from "../../utils/interfaces/SnapshotProvider";
 import type { CaptureSnapshotArgs, CaptureSnapshotResult } from "./CaptureSnapshot";
 import { DeviceSnapshotStore, SnapshotPathOptions } from "../../utils/DeviceSnapshotStore";
 import { SimCtlClient } from "../../utils/ios-cmdline-tools/SimCtlClient";
@@ -8,7 +9,7 @@ import * as path from "path";
 
 const IOS_APP_DATA_FOLDERS = ["Documents", "Library", "tmp"];
 
-export class CaptureSnapshotIos {
+export class CaptureSnapshotIos implements SnapshotCaptureProvider {
   private device: BootedDevice;
   private simctl: SimCtlClient;
   private store: DeviceSnapshotStore;
@@ -25,6 +26,14 @@ export class CaptureSnapshotIos {
     this.device = device;
     this.simctl = simctl || new SimCtlClient(device);
     this.store = store;
+  }
+
+  /**
+   * Platform-agnostic capture entry point — satisfies
+   * {@link SnapshotCaptureProvider}. Delegates to {@link execute}.
+   */
+  async capture(args: CaptureSnapshotArgs): Promise<CaptureSnapshotResult> {
+    return this.execute(args);
   }
 
   async execute(args: CaptureSnapshotArgs): Promise<CaptureSnapshotResult> {

--- a/src/features/action/RestoreSnapshot.ts
+++ b/src/features/action/RestoreSnapshot.ts
@@ -1,4 +1,5 @@
 import { BootedDevice, ActionableError, DeviceSnapshotManifest, DeviceSnapshotType } from "../../models";
+import type { SnapshotRestoreProvider } from "../../utils/interfaces/SnapshotProvider";
 import { AdbClientFactory, defaultAdbClientFactory } from "../../utils/android-cmdline-tools/AdbClientFactory";
 import type { AdbExecutor } from "../../utils/android-cmdline-tools/interfaces/AdbExecutor";
 import { AndroidEmulatorClient } from "../../utils/android-cmdline-tools/AndroidEmulatorClient";
@@ -31,7 +32,7 @@ export interface RestoreSnapshotResult {
  * Restore device state from snapshot
  * Supports VM snapshot restoration for emulators and ADB-based restore for all devices
  */
-export class RestoreSnapshot {
+export class RestoreSnapshot implements SnapshotRestoreProvider {
   private device: BootedDevice;
   private adb: AdbExecutor;
   private emulator: AndroidEmulatorClient;
@@ -54,6 +55,14 @@ export class RestoreSnapshot {
     this.emulator = emulator || new AndroidEmulatorClient();
     this.store = store;
     this.timer = timer;
+  }
+
+  /**
+   * Platform-agnostic restore entry point — satisfies
+   * {@link SnapshotRestoreProvider}. Delegates to {@link execute}.
+   */
+  async restore(args: RestoreSnapshotArgs): Promise<RestoreSnapshotResult> {
+    return this.execute(args);
   }
 
   /**

--- a/src/features/action/RestoreSnapshotIos.ts
+++ b/src/features/action/RestoreSnapshotIos.ts
@@ -1,4 +1,5 @@
 import { ActionableError, BootedDevice, DeviceSnapshotManifest } from "../../models";
+import type { SnapshotRestoreProvider } from "../../utils/interfaces/SnapshotProvider";
 import type { RestoreSnapshotArgs, RestoreSnapshotResult } from "./RestoreSnapshot";
 import { DeviceSnapshotStore, SnapshotPathOptions } from "../../utils/DeviceSnapshotStore";
 import { SimCtlClient } from "../../utils/ios-cmdline-tools/SimCtlClient";
@@ -8,7 +9,7 @@ import * as path from "path";
 
 const IOS_APP_DATA_FOLDERS = ["Documents", "Library", "tmp"];
 
-export class RestoreSnapshotIos {
+export class RestoreSnapshotIos implements SnapshotRestoreProvider {
   private device: BootedDevice;
   private simctl: SimCtlClient;
   private store: DeviceSnapshotStore;
@@ -25,6 +26,14 @@ export class RestoreSnapshotIos {
     this.device = device;
     this.simctl = simctl || new SimCtlClient(device);
     this.store = store;
+  }
+
+  /**
+   * Platform-agnostic restore entry point — satisfies
+   * {@link SnapshotRestoreProvider}. Delegates to {@link execute}.
+   */
+  async restore(args: RestoreSnapshotArgs): Promise<RestoreSnapshotResult> {
+    return this.execute(args);
   }
 
   async execute(args: RestoreSnapshotArgs): Promise<RestoreSnapshotResult> {

--- a/src/server/deviceSnapshotManager.ts
+++ b/src/server/deviceSnapshotManager.ts
@@ -9,10 +9,14 @@ import { parseDeviceSnapshotConfig } from "../features/snapshot";
 import { serverConfig } from "../utils/ServerConfig";
 import { ResourceRegistry } from "./resourceRegistry";
 import { DEVICE_SNAPSHOT_RESOURCE_URIS } from "./deviceSnapshotResourceUris";
-import { CaptureSnapshot, type CaptureSnapshotArgs, type CaptureSnapshotResult } from "../features/action/CaptureSnapshot";
-import { RestoreSnapshot, type RestoreSnapshotArgs, type RestoreSnapshotResult } from "../features/action/RestoreSnapshot";
+import { CaptureSnapshot, type CaptureSnapshotResult } from "../features/action/CaptureSnapshot";
+import { RestoreSnapshot, type RestoreSnapshotResult } from "../features/action/RestoreSnapshot";
 import { CaptureSnapshotIos } from "../features/action/CaptureSnapshotIos";
 import { RestoreSnapshotIos } from "../features/action/RestoreSnapshotIos";
+import type {
+  SnapshotCaptureProvider,
+  SnapshotRestoreProvider,
+} from "../utils/interfaces/SnapshotProvider";
 import { defaultTimer, type Timer } from "../utils/SystemTimer";
 import { logger } from "../utils/logger";
 
@@ -45,14 +49,6 @@ interface SnapshotArchiveEvictionResult {
   maxSizeBytes: number;
 }
 
-interface SnapshotCaptureAction {
-  execute(args: CaptureSnapshotArgs): Promise<CaptureSnapshotResult>;
-}
-
-interface SnapshotRestoreAction {
-  execute(args: RestoreSnapshotArgs): Promise<RestoreSnapshotResult>;
-}
-
 interface DeviceSnapshotManagerDependencies {
   snapshotRepository: DeviceSnapshotRepository;
   configRepository: DeviceSnapshotConfigRepository;
@@ -63,12 +59,12 @@ interface DeviceSnapshotManagerDependencies {
     device: BootedDevice,
     timer: Timer,
     store: DeviceSnapshotStore
-  ) => SnapshotCaptureAction;
+  ) => SnapshotCaptureProvider;
   createRestoreAction: (
     device: BootedDevice,
     timer: Timer,
     store: DeviceSnapshotStore
-  ) => SnapshotRestoreAction;
+  ) => SnapshotRestoreProvider;
 }
 
 let moduleDependencies: DeviceSnapshotManagerDependencies | null = null;
@@ -502,7 +498,7 @@ export async function captureDeviceSnapshot(
   };
 
   const captureAction = createCaptureAction(device, timer, snapshotStore);
-  const result = await captureAction.execute({
+  const result = await captureAction.capture({
     snapshotName,
     includeAppData: mergedConfig.includeAppData,
     includeSettings: mergedConfig.includeSettings,
@@ -565,7 +561,7 @@ export async function restoreDeviceSnapshot(
   const vmSnapshotTimeoutMs = args.vmSnapshotTimeoutMs ?? baseConfig.vmSnapshotTimeoutMs;
 
   const restoreAction = createRestoreAction(device, timer, snapshotStore);
-  const result = await restoreAction.execute({
+  const result = await restoreAction.restore({
     snapshotName: record.snapshotName,
     manifest: record.manifest,
     useVmSnapshot,

--- a/src/server/deviceSnapshotManager.ts
+++ b/src/server/deviceSnapshotManager.ts
@@ -55,12 +55,12 @@ interface DeviceSnapshotManagerDependencies {
   snapshotStore: DeviceSnapshotStore;
   timer: Timer;
   now: () => Date;
-  createCaptureAction: (
+  createCaptureProvider: (
     device: BootedDevice,
     timer: Timer,
     store: DeviceSnapshotStore
   ) => SnapshotCaptureProvider;
-  createRestoreAction: (
+  createRestoreProvider: (
     device: BootedDevice,
     timer: Timer,
     store: DeviceSnapshotStore
@@ -87,13 +87,13 @@ async function getDeviceSnapshotDependencies(): Promise<DeviceSnapshotManagerDep
       snapshotStore: new DeviceSnapshotStore(),
       timer: defaultTimer,
       now: () => new Date(),
-      createCaptureAction: (device, timer, store) => {
+      createCaptureProvider: (device, timer, store) => {
         if (device.platform === "ios") {
           return new CaptureSnapshotIos(device, undefined, store);
         }
         return new CaptureSnapshot(device, undefined, undefined, timer, store);
       },
-      createRestoreAction: (device, timer, store) => {
+      createRestoreProvider: (device, timer, store) => {
         if (device.platform === "ios") {
           return new RestoreSnapshotIos(device, undefined, store);
         }
@@ -115,8 +115,8 @@ export async function setDeviceSnapshotManagerDependencies(
     snapshotStore: deps.snapshotStore ?? current.snapshotStore,
     timer: deps.timer ?? current.timer,
     now: deps.now ?? current.now,
-    createCaptureAction: deps.createCaptureAction ?? current.createCaptureAction,
-    createRestoreAction: deps.createRestoreAction ?? current.createRestoreAction,
+    createCaptureProvider: deps.createCaptureProvider ?? current.createCaptureProvider,
+    createRestoreProvider: deps.createRestoreProvider ?? current.createRestoreProvider,
   };
 }
 
@@ -477,7 +477,7 @@ export async function captureDeviceSnapshot(
   result: CaptureSnapshotResult;
   evictedSnapshotNames: string[];
 }> {
-  const { snapshotRepository, snapshotStore, timer, createCaptureAction } =
+  const { snapshotRepository, snapshotStore, timer, createCaptureProvider } =
     await getDeviceSnapshotDependencies();
 
   const baseConfig = await getDeviceSnapshotConfig();
@@ -497,8 +497,8 @@ export async function captureDeviceSnapshot(
     vmSnapshotTimeoutMs: args.vmSnapshotTimeoutMs ?? baseConfig.vmSnapshotTimeoutMs,
   };
 
-  const captureAction = createCaptureAction(device, timer, snapshotStore);
-  const result = await captureAction.capture({
+  const captureProvider = createCaptureProvider(device, timer, snapshotStore);
+  const result = await captureProvider.capture({
     snapshotName,
     includeAppData: mergedConfig.includeAppData,
     includeSettings: mergedConfig.includeSettings,
@@ -540,7 +540,7 @@ export async function restoreDeviceSnapshot(
   result: RestoreSnapshotResult;
   manifest: DeviceSnapshotManifest;
 }> {
-  const { snapshotRepository, snapshotStore, timer, now, createRestoreAction } =
+  const { snapshotRepository, snapshotStore, timer, now, createRestoreProvider } =
     await getDeviceSnapshotDependencies();
 
   let record = await snapshotRepository.getSnapshot(args.snapshotName);
@@ -560,8 +560,8 @@ export async function restoreDeviceSnapshot(
   const useVmSnapshot = args.useVmSnapshot ?? baseConfig.useVmSnapshot;
   const vmSnapshotTimeoutMs = args.vmSnapshotTimeoutMs ?? baseConfig.vmSnapshotTimeoutMs;
 
-  const restoreAction = createRestoreAction(device, timer, snapshotStore);
-  const result = await restoreAction.restore({
+  const restoreProvider = createRestoreProvider(device, timer, snapshotStore);
+  const result = await restoreProvider.restore({
     snapshotName: record.snapshotName,
     manifest: record.manifest,
     useVmSnapshot,

--- a/src/utils/interfaces/SnapshotProvider.ts
+++ b/src/utils/interfaces/SnapshotProvider.ts
@@ -8,44 +8,23 @@ import type {
 } from "../../features/action/RestoreSnapshot";
 
 /**
- * Captures a device-state snapshot for the underlying platform.
+ * Captures a device-state snapshot. Implemented by `CaptureSnapshot`
+ * (Android) and `CaptureSnapshotIos` (iOS).
  *
- * Implemented by `CaptureSnapshot` (Android) and `CaptureSnapshotIos`
- * (iOS). Both already share the {@link CaptureSnapshotArgs} input and
- * {@link CaptureSnapshotResult} output, so the contract is the true
- * semantic overlap — no platform-specific fields leak into the interface.
- *
- * Platform-specific fields on the args (e.g. `appBundleIds` for iOS,
- * `userApps` for Android) are still on the shared args type and are
- * simply ignored on platforms that do not understand them — see the
- * concrete implementations for the per-platform semantics.
+ * Platform-specific fields on {@link CaptureSnapshotArgs} (`appBundleIds`
+ * iOS-only, `userApps` Android-only) are ignored on the platform that
+ * doesn't understand them — see the concrete implementations.
  */
 export interface SnapshotCaptureProvider {
   capture(args: CaptureSnapshotArgs): Promise<CaptureSnapshotResult>;
 }
 
 /**
- * Restores a previously captured device-state snapshot.
- *
- * Implemented by `RestoreSnapshot` (Android) and `RestoreSnapshotIos`
- * (iOS). The manifest carried in {@link RestoreSnapshotArgs} is what
- * lets the restore implementation route back to platform-specific
- * recovery (VM snapshot, adb backup, simctl container copy, …).
+ * Restores a previously captured snapshot. Implemented by
+ * `RestoreSnapshot` (Android) and `RestoreSnapshotIos` (iOS); the
+ * manifest in {@link RestoreSnapshotArgs} routes restore to the right
+ * platform-specific recovery path.
  */
 export interface SnapshotRestoreProvider {
   restore(args: RestoreSnapshotArgs): Promise<RestoreSnapshotResult>;
 }
-
-/**
- * Aggregate platform-agnostic snapshot interface — implementations that
- * expose both capture and restore in one object can satisfy this. The
- * `deviceSnapshotManager` factory currently returns two distinct
- * provider objects (one capture, one restore) per call; new call sites
- * that want a unified handle should depend on this type.
- *
- * Methods are deliberately limited to the shared lifecycle — capture
- * and restore — so the interface does not leak Android-specific (VM
- * snapshot, adb backup) or iOS-specific (simctl container copy)
- * concepts.
- */
-export interface SnapshotProvider extends SnapshotCaptureProvider, SnapshotRestoreProvider {}

--- a/src/utils/interfaces/SnapshotProvider.ts
+++ b/src/utils/interfaces/SnapshotProvider.ts
@@ -1,0 +1,51 @@
+import type {
+  CaptureSnapshotArgs,
+  CaptureSnapshotResult,
+} from "../../features/action/CaptureSnapshot";
+import type {
+  RestoreSnapshotArgs,
+  RestoreSnapshotResult,
+} from "../../features/action/RestoreSnapshot";
+
+/**
+ * Captures a device-state snapshot for the underlying platform.
+ *
+ * Implemented by `CaptureSnapshot` (Android) and `CaptureSnapshotIos`
+ * (iOS). Both already share the {@link CaptureSnapshotArgs} input and
+ * {@link CaptureSnapshotResult} output, so the contract is the true
+ * semantic overlap — no platform-specific fields leak into the interface.
+ *
+ * Platform-specific fields on the args (e.g. `appBundleIds` for iOS,
+ * `userApps` for Android) are still on the shared args type and are
+ * simply ignored on platforms that do not understand them — see the
+ * concrete implementations for the per-platform semantics.
+ */
+export interface SnapshotCaptureProvider {
+  capture(args: CaptureSnapshotArgs): Promise<CaptureSnapshotResult>;
+}
+
+/**
+ * Restores a previously captured device-state snapshot.
+ *
+ * Implemented by `RestoreSnapshot` (Android) and `RestoreSnapshotIos`
+ * (iOS). The manifest carried in {@link RestoreSnapshotArgs} is what
+ * lets the restore implementation route back to platform-specific
+ * recovery (VM snapshot, adb backup, simctl container copy, …).
+ */
+export interface SnapshotRestoreProvider {
+  restore(args: RestoreSnapshotArgs): Promise<RestoreSnapshotResult>;
+}
+
+/**
+ * Aggregate platform-agnostic snapshot interface — implementations that
+ * expose both capture and restore in one object can satisfy this. The
+ * `deviceSnapshotManager` factory currently returns two distinct
+ * provider objects (one capture, one restore) per call; new call sites
+ * that want a unified handle should depend on this type.
+ *
+ * Methods are deliberately limited to the shared lifecycle — capture
+ * and restore — so the interface does not leak Android-specific (VM
+ * snapshot, adb backup) or iOS-specific (simctl container copy)
+ * concepts.
+ */
+export interface SnapshotProvider extends SnapshotCaptureProvider, SnapshotRestoreProvider {}

--- a/src/utils/interfaces/index.ts
+++ b/src/utils/interfaces/index.ts
@@ -5,6 +5,11 @@ export { DeviceSessionManager } from "../DeviceSessionManager";
 export { DeepLinkManager } from "../DeepLinkManager";
 export { CtrlProxyManager } from "../CtrlProxyManager";
 export type { ProxyManager, ProxySetupResult } from "./ProxyManager";
+export type {
+  SnapshotCaptureProvider,
+  SnapshotRestoreProvider,
+  SnapshotProvider,
+} from "./SnapshotProvider";
 // Screenshot utilities - split into focused classes (Phase 3.1)
 export { ScreenshotComparator } from "../screenshot/ScreenshotComparator";
 export { PerceptualHasher } from "../screenshot/PerceptualHasher";

--- a/src/utils/interfaces/index.ts
+++ b/src/utils/interfaces/index.ts
@@ -8,7 +8,6 @@ export type { ProxyManager, ProxySetupResult } from "./ProxyManager";
 export type {
   SnapshotCaptureProvider,
   SnapshotRestoreProvider,
-  SnapshotProvider,
 } from "./SnapshotProvider";
 // Screenshot utilities - split into focused classes (Phase 3.1)
 export { ScreenshotComparator } from "../screenshot/ScreenshotComparator";

--- a/test/fakes/FakeSnapshotProvider.ts
+++ b/test/fakes/FakeSnapshotProvider.ts
@@ -1,6 +1,5 @@
 import type {
   SnapshotCaptureProvider,
-  SnapshotProvider,
   SnapshotRestoreProvider,
 } from "../../src/utils/interfaces/SnapshotProvider";
 import type {
@@ -14,13 +13,11 @@ import type {
 import type { DeviceSnapshotManifest } from "../../src/models";
 
 /**
- * Minimal fake implementation of {@link SnapshotProvider} for testing
- * the platform-agnostic contract. Records every invocation in
- * `executedOperations` and lets tests toggle failure mode.
- *
- * Mirrors the recording pattern from `FakeProxyManager`.
+ * Minimal fake covering both halves of the snapshot contract. Records
+ * invocations in `executedOperations` and lets tests toggle per-half
+ * failure modes. Mirrors the recording pattern from `FakeProxyManager`.
  */
-export class FakeSnapshotProvider implements SnapshotProvider {
+export class FakeSnapshotProvider implements SnapshotCaptureProvider, SnapshotRestoreProvider {
   private shouldCaptureFail: boolean = false;
   private shouldRestoreFail: boolean = false;
   private readonly executedOperations: string[] = [];
@@ -87,45 +84,5 @@ export class FakeSnapshotProvider implements SnapshotProvider {
       snapshotType: args.manifest.snapshotType,
       restoredAt: "1970-01-01T00:00:00.000Z",
     };
-  }
-}
-
-/**
- * Capture-only variant for cases where the test exercises only the
- * capture half of the interface.
- */
-export class FakeSnapshotCaptureProvider implements SnapshotCaptureProvider {
-  private readonly delegate = new FakeSnapshotProvider();
-
-  setShouldFail(shouldFail: boolean): void {
-    this.delegate.setCaptureShouldFail(shouldFail);
-  }
-
-  getExecutedOperations(): string[] {
-    return this.delegate.getExecutedOperations();
-  }
-
-  capture(args: CaptureSnapshotArgs): Promise<CaptureSnapshotResult> {
-    return this.delegate.capture(args);
-  }
-}
-
-/**
- * Restore-only variant for cases where the test exercises only the
- * restore half of the interface.
- */
-export class FakeSnapshotRestoreProvider implements SnapshotRestoreProvider {
-  private readonly delegate = new FakeSnapshotProvider();
-
-  setShouldFail(shouldFail: boolean): void {
-    this.delegate.setRestoreShouldFail(shouldFail);
-  }
-
-  getExecutedOperations(): string[] {
-    return this.delegate.getExecutedOperations();
-  }
-
-  restore(args: RestoreSnapshotArgs): Promise<RestoreSnapshotResult> {
-    return this.delegate.restore(args);
   }
 }

--- a/test/fakes/FakeSnapshotProvider.ts
+++ b/test/fakes/FakeSnapshotProvider.ts
@@ -1,0 +1,131 @@
+import type {
+  SnapshotCaptureProvider,
+  SnapshotProvider,
+  SnapshotRestoreProvider,
+} from "../../src/utils/interfaces/SnapshotProvider";
+import type {
+  CaptureSnapshotArgs,
+  CaptureSnapshotResult,
+} from "../../src/features/action/CaptureSnapshot";
+import type {
+  RestoreSnapshotArgs,
+  RestoreSnapshotResult,
+} from "../../src/features/action/RestoreSnapshot";
+import type { DeviceSnapshotManifest } from "../../src/models";
+
+/**
+ * Minimal fake implementation of {@link SnapshotProvider} for testing
+ * the platform-agnostic contract. Records every invocation in
+ * `executedOperations` and lets tests toggle failure mode.
+ *
+ * Mirrors the recording pattern from `FakeProxyManager`.
+ */
+export class FakeSnapshotProvider implements SnapshotProvider {
+  private shouldCaptureFail: boolean = false;
+  private shouldRestoreFail: boolean = false;
+  private readonly executedOperations: string[] = [];
+
+  setCaptureShouldFail(shouldFail: boolean): void {
+    this.shouldCaptureFail = shouldFail;
+  }
+
+  setRestoreShouldFail(shouldFail: boolean): void {
+    this.shouldRestoreFail = shouldFail;
+  }
+
+  getExecutedOperations(): string[] {
+    return [...this.executedOperations];
+  }
+
+  wasMethodCalled(operationName: string): boolean {
+    return this.executedOperations.some(op => op.includes(operationName));
+  }
+
+  getCallCount(operationName: string): number {
+    return this.executedOperations.filter(op => op.includes(operationName)).length;
+  }
+
+  clearHistory(): void {
+    this.executedOperations.length = 0;
+  }
+
+  async capture(args: CaptureSnapshotArgs): Promise<CaptureSnapshotResult> {
+    this.executedOperations.push(`capture:${args.snapshotName}`);
+
+    if (this.shouldCaptureFail) {
+      throw new Error("Fake capture failure");
+    }
+
+    const timestamp = "1970-01-01T00:00:00.000Z";
+    const manifest: DeviceSnapshotManifest = {
+      snapshotName: args.snapshotName,
+      timestamp,
+      deviceId: "fake-device",
+      deviceName: "Fake Device",
+      platform: "android",
+      snapshotType: "adb",
+      includeAppData: args.includeAppData ?? false,
+      includeSettings: args.includeSettings ?? false,
+    };
+
+    return {
+      snapshotName: args.snapshotName,
+      timestamp,
+      snapshotType: manifest.snapshotType,
+      manifest,
+    };
+  }
+
+  async restore(args: RestoreSnapshotArgs): Promise<RestoreSnapshotResult> {
+    this.executedOperations.push(`restore:${args.snapshotName}`);
+
+    if (this.shouldRestoreFail) {
+      throw new Error("Fake restore failure");
+    }
+
+    return {
+      snapshotType: args.manifest.snapshotType,
+      restoredAt: "1970-01-01T00:00:00.000Z",
+    };
+  }
+}
+
+/**
+ * Capture-only variant for cases where the test exercises only the
+ * capture half of the interface.
+ */
+export class FakeSnapshotCaptureProvider implements SnapshotCaptureProvider {
+  private readonly delegate = new FakeSnapshotProvider();
+
+  setShouldFail(shouldFail: boolean): void {
+    this.delegate.setCaptureShouldFail(shouldFail);
+  }
+
+  getExecutedOperations(): string[] {
+    return this.delegate.getExecutedOperations();
+  }
+
+  capture(args: CaptureSnapshotArgs): Promise<CaptureSnapshotResult> {
+    return this.delegate.capture(args);
+  }
+}
+
+/**
+ * Restore-only variant for cases where the test exercises only the
+ * restore half of the interface.
+ */
+export class FakeSnapshotRestoreProvider implements SnapshotRestoreProvider {
+  private readonly delegate = new FakeSnapshotProvider();
+
+  setShouldFail(shouldFail: boolean): void {
+    this.delegate.setRestoreShouldFail(shouldFail);
+  }
+
+  getExecutedOperations(): string[] {
+    return this.delegate.getExecutedOperations();
+  }
+
+  restore(args: RestoreSnapshotArgs): Promise<RestoreSnapshotResult> {
+    return this.delegate.restore(args);
+  }
+}

--- a/test/features/action/SnapshotProvider.test.ts
+++ b/test/features/action/SnapshotProvider.test.ts
@@ -1,0 +1,177 @@
+import { describe, it, expect, beforeEach } from "bun:test";
+import { FakeSnapshotProvider } from "../../fakes/FakeSnapshotProvider";
+import { CaptureSnapshot } from "../../../src/features/action/CaptureSnapshot";
+import { CaptureSnapshotIos } from "../../../src/features/action/CaptureSnapshotIos";
+import { RestoreSnapshot } from "../../../src/features/action/RestoreSnapshot";
+import { RestoreSnapshotIos } from "../../../src/features/action/RestoreSnapshotIos";
+import { FakeAdbClient } from "../../fakes/FakeAdbClient";
+import { FakeSimCtlClient } from "../../fakes/FakeSimCtlClient";
+import { FakeTimer } from "../../fakes/FakeTimer";
+import { DeviceSnapshotStore } from "../../../src/utils/DeviceSnapshotStore";
+import type { AdbClientFactory } from "../../../src/utils/android-cmdline-tools/AdbClientFactory";
+import type { BootedDevice, DeviceSnapshotManifest } from "../../../src/models";
+import type {
+  SnapshotCaptureProvider,
+  SnapshotProvider,
+  SnapshotRestoreProvider,
+} from "../../../src/utils/interfaces/SnapshotProvider";
+
+/**
+ * Sanity-check the platform-agnostic SnapshotProvider contract.
+ *
+ * Mirrors the structure of ProxyManager.test.ts: tests deliberately
+ * type their subjects as the abstract interface so a regression that
+ * drops one of the shared methods from a concrete class will surface
+ * as a compile error here before tests even run.
+ */
+describe("SnapshotProvider interface", () => {
+  describe("FakeSnapshotProvider", () => {
+    let provider: FakeSnapshotProvider;
+
+    beforeEach(() => {
+      provider = new FakeSnapshotProvider();
+    });
+
+    it("returns a CaptureSnapshotResult from capture()", async () => {
+      const result = await provider.capture({ snapshotName: "snap-1" });
+      expect(result.snapshotName).toBe("snap-1");
+      expect(typeof result.timestamp).toBe("string");
+      expect(result.snapshotType).toBe("adb");
+      expect(result.manifest.snapshotName).toBe("snap-1");
+    });
+
+    it("returns a RestoreSnapshotResult from restore()", async () => {
+      const manifest = makeManifest("snap-2");
+      const result = await provider.restore({ snapshotName: "snap-2", manifest });
+      expect(result.snapshotType).toBe(manifest.snapshotType);
+      expect(typeof result.restoredAt).toBe("string");
+    });
+
+    it("records capture and restore invocations", async () => {
+      await provider.capture({ snapshotName: "alpha" });
+      await provider.restore({ snapshotName: "beta", manifest: makeManifest("beta") });
+      await provider.capture({ snapshotName: "gamma" });
+
+      expect(provider.wasMethodCalled("capture")).toBe(true);
+      expect(provider.wasMethodCalled("restore")).toBe(true);
+      expect(provider.getCallCount("capture")).toBe(2);
+      expect(provider.getCallCount("restore")).toBe(1);
+      expect(provider.getExecutedOperations()).toContain("capture:alpha");
+      expect(provider.getExecutedOperations()).toContain("restore:beta");
+    });
+
+    it("propagates configured capture failure", async () => {
+      provider.setCaptureShouldFail(true);
+      await expect(provider.capture({ snapshotName: "boom" })).rejects.toThrow(
+        "Fake capture failure"
+      );
+    });
+
+    it("propagates configured restore failure", async () => {
+      provider.setRestoreShouldFail(true);
+      const manifest = makeManifest("boom");
+      await expect(
+        provider.restore({ snapshotName: "boom", manifest })
+      ).rejects.toThrow("Fake restore failure");
+    });
+
+    it("clears recorded history on demand", async () => {
+      await provider.capture({ snapshotName: "x" });
+      provider.clearHistory();
+      expect(provider.getExecutedOperations()).toEqual([]);
+    });
+  });
+
+  // Both platform-specific capture classes implement SnapshotCaptureProvider;
+  // both restore classes implement SnapshotRestoreProvider. Assigning them to
+  // the abstract type proves it at compile time. Behavioral assertions are
+  // covered in the existing CaptureSnapshot{,Ios}/RestoreSnapshot{,Ios} tests.
+  describe("Android CaptureSnapshot satisfies SnapshotCaptureProvider", () => {
+    it("exposes the shared capture method via the abstract type", () => {
+      const device: BootedDevice = {
+        deviceId: "emulator-5554",
+        name: "Pixel_5",
+        platform: "android",
+      };
+      const factory: AdbClientFactory = { create: () => new FakeAdbClient() as any };
+      const asProvider: SnapshotCaptureProvider = new CaptureSnapshot(
+        device,
+        factory,
+        undefined,
+        new FakeTimer(),
+        new DeviceSnapshotStore("/tmp/no-op")
+      );
+      expect(typeof asProvider.capture).toBe("function");
+    });
+  });
+
+  describe("iOS CaptureSnapshotIos satisfies SnapshotCaptureProvider", () => {
+    it("exposes the shared capture method via the abstract type", () => {
+      const device: BootedDevice = {
+        deviceId: "ios-device-1",
+        name: "iPhone 15",
+        platform: "ios",
+      };
+      const asProvider: SnapshotCaptureProvider = new CaptureSnapshotIos(
+        device,
+        new FakeSimCtlClient(),
+        new DeviceSnapshotStore("/tmp/no-op")
+      );
+      expect(typeof asProvider.capture).toBe("function");
+    });
+  });
+
+  describe("Android RestoreSnapshot satisfies SnapshotRestoreProvider", () => {
+    it("exposes the shared restore method via the abstract type", () => {
+      const device: BootedDevice = {
+        deviceId: "emulator-5554",
+        name: "Pixel_5",
+        platform: "android",
+      };
+      const factory: AdbClientFactory = { create: () => new FakeAdbClient() as any };
+      const asProvider: SnapshotRestoreProvider = new RestoreSnapshot(
+        device,
+        factory,
+        undefined,
+        new FakeTimer(),
+        new DeviceSnapshotStore("/tmp/no-op")
+      );
+      expect(typeof asProvider.restore).toBe("function");
+    });
+  });
+
+  describe("iOS RestoreSnapshotIos satisfies SnapshotRestoreProvider", () => {
+    it("exposes the shared restore method via the abstract type", () => {
+      const device: BootedDevice = {
+        deviceId: "ios-device-1",
+        name: "iPhone 15",
+        platform: "ios",
+      };
+      const asProvider: SnapshotRestoreProvider = new RestoreSnapshotIos(
+        device,
+        new FakeSimCtlClient(),
+        new DeviceSnapshotStore("/tmp/no-op")
+      );
+      expect(typeof asProvider.restore).toBe("function");
+    });
+  });
+
+  it("FakeSnapshotProvider satisfies the combined SnapshotProvider type", () => {
+    const asProvider: SnapshotProvider = new FakeSnapshotProvider();
+    expect(typeof asProvider.capture).toBe("function");
+    expect(typeof asProvider.restore).toBe("function");
+  });
+});
+
+function makeManifest(snapshotName: string): DeviceSnapshotManifest {
+  return {
+    snapshotName,
+    timestamp: "1970-01-01T00:00:00.000Z",
+    deviceId: "fake-device",
+    deviceName: "Fake Device",
+    platform: "android",
+    snapshotType: "adb",
+    includeAppData: false,
+    includeSettings: false,
+  };
+}

--- a/test/features/action/SnapshotProvider.test.ts
+++ b/test/features/action/SnapshotProvider.test.ts
@@ -12,19 +12,16 @@ import type { AdbClientFactory } from "../../../src/utils/android-cmdline-tools/
 import type { BootedDevice, DeviceSnapshotManifest } from "../../../src/models";
 import type {
   SnapshotCaptureProvider,
-  SnapshotProvider,
   SnapshotRestoreProvider,
 } from "../../../src/utils/interfaces/SnapshotProvider";
 
 /**
- * Sanity-check the platform-agnostic SnapshotProvider contract.
- *
- * Mirrors the structure of ProxyManager.test.ts: tests deliberately
- * type their subjects as the abstract interface so a regression that
- * drops one of the shared methods from a concrete class will surface
- * as a compile error here before tests even run.
+ * Sanity-check the platform-agnostic SnapshotCaptureProvider /
+ * SnapshotRestoreProvider contracts. Tests deliberately type their
+ * subjects as the abstract interfaces so a regression that drops one of
+ * the shared methods will surface as a compile error here.
  */
-describe("SnapshotProvider interface", () => {
+describe("SnapshotProvider interfaces", () => {
   describe("FakeSnapshotProvider", () => {
     let provider: FakeSnapshotProvider;
 
@@ -82,85 +79,35 @@ describe("SnapshotProvider interface", () => {
     });
   });
 
-  // Both platform-specific capture classes implement SnapshotCaptureProvider;
-  // both restore classes implement SnapshotRestoreProvider. Assigning them to
-  // the abstract type proves it at compile time. Behavioral assertions are
-  // covered in the existing CaptureSnapshot{,Ios}/RestoreSnapshot{,Ios} tests.
-  describe("Android CaptureSnapshot satisfies SnapshotCaptureProvider", () => {
-    it("exposes the shared capture method via the abstract type", () => {
-      const device: BootedDevice = {
-        deviceId: "emulator-5554",
-        name: "Pixel_5",
-        platform: "android",
-      };
-      const factory: AdbClientFactory = { create: () => new FakeAdbClient() as any };
-      const asProvider: SnapshotCaptureProvider = new CaptureSnapshot(
-        device,
-        factory,
-        undefined,
-        new FakeTimer(),
-        new DeviceSnapshotStore("/tmp/no-op")
-      );
+  // Compile-time conformance: each platform-specific concrete class is
+  // assigned to the abstract provider type. Behavioral coverage lives in
+  // the existing CaptureSnapshot{,Ios}/RestoreSnapshot{,Ios} test files.
+  const androidDevice: BootedDevice = { deviceId: "emulator-5554", name: "Pixel_5", platform: "android" };
+  const iosDevice: BootedDevice = { deviceId: "ios-device-1", name: "iPhone 15", platform: "ios" };
+  const fakeAdbFactory: AdbClientFactory = { create: () => new FakeAdbClient() as any };
+  const store = () => new DeviceSnapshotStore("/tmp/no-op");
+
+  const captureCases: ReadonlyArray<[string, () => SnapshotCaptureProvider]> = [
+    ["Android CaptureSnapshot", () => new CaptureSnapshot(androidDevice, fakeAdbFactory, undefined, new FakeTimer(), store())],
+    ["iOS CaptureSnapshotIos", () => new CaptureSnapshotIos(iosDevice, new FakeSimCtlClient(), store())],
+  ];
+  for (const [name, build] of captureCases) {
+    it(`${name} satisfies SnapshotCaptureProvider`, () => {
+      const asProvider: SnapshotCaptureProvider = build();
       expect(typeof asProvider.capture).toBe("function");
     });
-  });
+  }
 
-  describe("iOS CaptureSnapshotIos satisfies SnapshotCaptureProvider", () => {
-    it("exposes the shared capture method via the abstract type", () => {
-      const device: BootedDevice = {
-        deviceId: "ios-device-1",
-        name: "iPhone 15",
-        platform: "ios",
-      };
-      const asProvider: SnapshotCaptureProvider = new CaptureSnapshotIos(
-        device,
-        new FakeSimCtlClient(),
-        new DeviceSnapshotStore("/tmp/no-op")
-      );
-      expect(typeof asProvider.capture).toBe("function");
-    });
-  });
-
-  describe("Android RestoreSnapshot satisfies SnapshotRestoreProvider", () => {
-    it("exposes the shared restore method via the abstract type", () => {
-      const device: BootedDevice = {
-        deviceId: "emulator-5554",
-        name: "Pixel_5",
-        platform: "android",
-      };
-      const factory: AdbClientFactory = { create: () => new FakeAdbClient() as any };
-      const asProvider: SnapshotRestoreProvider = new RestoreSnapshot(
-        device,
-        factory,
-        undefined,
-        new FakeTimer(),
-        new DeviceSnapshotStore("/tmp/no-op")
-      );
+  const restoreCases: ReadonlyArray<[string, () => SnapshotRestoreProvider]> = [
+    ["Android RestoreSnapshot", () => new RestoreSnapshot(androidDevice, fakeAdbFactory, undefined, new FakeTimer(), store())],
+    ["iOS RestoreSnapshotIos", () => new RestoreSnapshotIos(iosDevice, new FakeSimCtlClient(), store())],
+  ];
+  for (const [name, build] of restoreCases) {
+    it(`${name} satisfies SnapshotRestoreProvider`, () => {
+      const asProvider: SnapshotRestoreProvider = build();
       expect(typeof asProvider.restore).toBe("function");
     });
-  });
-
-  describe("iOS RestoreSnapshotIos satisfies SnapshotRestoreProvider", () => {
-    it("exposes the shared restore method via the abstract type", () => {
-      const device: BootedDevice = {
-        deviceId: "ios-device-1",
-        name: "iPhone 15",
-        platform: "ios",
-      };
-      const asProvider: SnapshotRestoreProvider = new RestoreSnapshotIos(
-        device,
-        new FakeSimCtlClient(),
-        new DeviceSnapshotStore("/tmp/no-op")
-      );
-      expect(typeof asProvider.restore).toBe("function");
-    });
-  });
-
-  it("FakeSnapshotProvider satisfies the combined SnapshotProvider type", () => {
-    const asProvider: SnapshotProvider = new FakeSnapshotProvider();
-    expect(typeof asProvider.capture).toBe("function");
-    expect(typeof asProvider.restore).toBe("function");
-  });
+  }
 });
 
 function makeManifest(snapshotName: string): DeviceSnapshotManifest {

--- a/test/server/deviceSnapshotManager.test.ts
+++ b/test/server/deviceSnapshotManager.test.ts
@@ -44,7 +44,7 @@ describe("deviceSnapshotManager", () => {
       snapshotStore: store as any,
       timer: fakeTimer,
       now: () => new Date(fakeTimer.now()),
-      createCaptureAction: () => ({
+      createCaptureProvider: () => ({
         capture: async args => {
           captureCalls.push({ ...args });
           const timestamp = new Date(fakeTimer.now()).toISOString();
@@ -66,7 +66,7 @@ describe("deviceSnapshotManager", () => {
           };
         },
       }),
-      createRestoreAction: () => ({
+      createRestoreProvider: () => ({
         restore: async args => {
           restoreCalls.push({ ...args });
           return {

--- a/test/server/deviceSnapshotManager.test.ts
+++ b/test/server/deviceSnapshotManager.test.ts
@@ -45,7 +45,7 @@ describe("deviceSnapshotManager", () => {
       timer: fakeTimer,
       now: () => new Date(fakeTimer.now()),
       createCaptureAction: () => ({
-        execute: async args => {
+        capture: async args => {
           captureCalls.push({ ...args });
           const timestamp = new Date(fakeTimer.now()).toISOString();
           const manifest: DeviceSnapshotManifest = {
@@ -67,7 +67,7 @@ describe("deviceSnapshotManager", () => {
         },
       }),
       createRestoreAction: () => ({
-        execute: async args => {
+        restore: async args => {
           restoreCalls.push({ ...args });
           return {
             snapshotType: args.manifest.snapshotType,

--- a/test/server/snapshotTools.test.ts
+++ b/test/server/snapshotTools.test.ts
@@ -40,7 +40,7 @@ describe("snapshot tool", () => {
       snapshotStore: store as any,
       timer: fakeTimer,
       now: () => new Date(fakeTimer.now()),
-      createCaptureAction: () => ({
+      createCaptureProvider: () => ({
         capture: async args => {
           captureCalls.push({ ...args });
           const timestamp = new Date(fakeTimer.now()).toISOString();
@@ -62,7 +62,7 @@ describe("snapshot tool", () => {
           };
         },
       }),
-      createRestoreAction: () => ({
+      createRestoreProvider: () => ({
         restore: async args => {
           restoreCalls.push({ ...args });
           return {

--- a/test/server/snapshotTools.test.ts
+++ b/test/server/snapshotTools.test.ts
@@ -41,7 +41,7 @@ describe("snapshot tool", () => {
       timer: fakeTimer,
       now: () => new Date(fakeTimer.now()),
       createCaptureAction: () => ({
-        execute: async args => {
+        capture: async args => {
           captureCalls.push({ ...args });
           const timestamp = new Date(fakeTimer.now()).toISOString();
           const manifest: DeviceSnapshotManifest = {
@@ -63,7 +63,7 @@ describe("snapshot tool", () => {
         },
       }),
       createRestoreAction: () => ({
-        execute: async args => {
+        restore: async args => {
           restoreCalls.push({ ...args });
           return {
             snapshotType: args.manifest.snapshotType,


### PR DESCRIPTION
## Summary

Second in the platform-duplication refactor series (after #2182). Introduces `SnapshotCaptureProvider` and `SnapshotRestoreProvider` interfaces so `deviceSnapshotManager` and other callers can depend on platform-agnostic types rather than the concrete `CaptureSnapshot{,Ios}` / `RestoreSnapshot{,Ios}` classes.

- New `src/utils/interfaces/SnapshotProvider.ts` defines `SnapshotCaptureProvider` (Android + iOS capture) and `SnapshotRestoreProvider` (Android + iOS restore)
- All 4 concrete classes now `implements` the relevant provider interface
- `deviceSnapshotManager.ts` swaps its two local inline interfaces (`SnapshotCaptureAction` / `SnapshotRestoreAction`) for the shared ones; factory names renamed `createCaptureAction` → `createCaptureProvider` to match
- New `FakeSnapshotProvider` recording fake follows the `FakeProxyManager` convention from #2182

## Scope discipline

- Args/result types (`CaptureSnapshotArgs`, `CaptureSnapshotResult`, etc.) were already platform-agnostic — reused as-is, no parallel types introduced
- Combined `SnapshotProvider` interface considered and dropped: no production caller wanted a unified handle, and splitting capture/restore into two interfaces matches how `deviceSnapshotManager` actually consumes them
- Did NOT migrate every consumer — this PR establishes the interfaces; future call sites that only need the shared surface can adopt them

## Test plan

- [x] `bun run lint` clean
- [x] `bun build.ts` succeeds
- [x] Full `bun test --bail`: 4188 pass / 1 skip / 0 fail
- [x] 11 new unit tests in `test/features/action/SnapshotProvider.test.ts` covering both fake-based contract behavior and compile-time conformance of all 4 platform-specific classes