### PR TITLE
refactor(tap): extract TapStrategy interface from TapOnElement

### DIFF
--- a/src/features/action/TapOnElement.ts
+++ b/src/features/action/TapOnElement.ts
@@ -147,6 +147,7 @@ export class TapOnElement extends BaseVisualChange {
     this.iosVoiceOverDetector = options.iosVoiceOverDetector ?? defaultIosVoiceOverDetector;
     this.strategy = options.tapStrategy ?? createTapStrategy(
       device,
+      this.adb,
       this.accessibilityDetector,
       this.iosVoiceOverDetector
     );
@@ -957,7 +958,7 @@ export class TapOnElement extends BaseVisualChange {
           const selectedElementMetadata = this.buildSelectedElementMetadata(selection);
           const initialTapPoint = this.geometry.getElementCenter(element);
           let action = options.action;
-          const longPressDuration = this.getLongPressDuration(options, this.device.platform);
+          const longPressDuration = this.getLongPressDuration(options);
 
           if (action === "focus") {
             // Check if element is already focused
@@ -984,23 +985,17 @@ export class TapOnElement extends BaseVisualChange {
             options.action = "tap";
           }
 
-          const isAccessibilityServiceEnabled = await this.strategy.isAccessibilityServiceEnabled(
-            this.device,
-            this.adb,
-            IOSCtrlProxyClient.getInstance(this.device)
-          );
-          // On Android the strategy returns TalkBack state; on iOS it returns
-          // VoiceOver state. Each platform's executeTap consumes only the
-          // boolean meaningful to its own a11y service.
-          const isTalkBackEnabled = isAccessibilityServiceEnabled;
-          const isVoiceOverEnabled = isAccessibilityServiceEnabled;
+          // Strategy returns the platform-relevant boolean: TalkBack on
+          // Android, VoiceOver on iOS. Downstream call paths are split by
+          // the platform switch below, so a single flag suffices.
+          const isAccessibilityServiceEnabled = await this.strategy.isAccessibilityServiceEnabled();
           let tapElement: Element;
           let usedParent: boolean;
           const initialTapTarget = this.resolveTapTargetElement(
             element,
             viewHierarchy,
             action,
-            isTalkBackEnabled
+            isAccessibilityServiceEnabled
           );
           tapElement = initialTapTarget.element;
           usedParent = initialTapTarget.usedParent;
@@ -1010,7 +1005,7 @@ export class TapOnElement extends BaseVisualChange {
               options,
               observeResult,
               action,
-              isTalkBackEnabled,
+              isAccessibilityServiceEnabled,
               signal
             );
             if (!stable.ok) {
@@ -1057,18 +1052,18 @@ export class TapOnElement extends BaseVisualChange {
                   tapElement,
                   signal,
                   options,
-                  isTalkBackEnabled
+                  isAccessibilityServiceEnabled
                 );
                 break;
               case "ios":
-                await this.executeiOSTap(action, tapPoint.x, tapPoint.y, longPressDuration, tapElement, isVoiceOverEnabled);
+                await this.executeiOSTap(action, tapPoint.x, tapPoint.y, longPressDuration, tapElement, isAccessibilityServiceEnabled);
                 break;
               default:
                 throw new ActionableError(`Unsupported platform: ${this.device.platform}`);
             }
           });
 
-          if (preTapHash && this.strategy.shouldRetryTapIfNoChange()) {
+          if (preTapHash && this.strategy.retryTapIfNoChange) {
             await this.retryTapIfNoChange(
               preTapHash,
               tapPoint,
@@ -1466,11 +1461,11 @@ export class TapOnElement extends BaseVisualChange {
     }
   }
 
-  private getLongPressDuration(options: TapOnElementOptions, _platform: "android" | "ios"): number {
+  private getLongPressDuration(options: TapOnElementOptions): number {
     if (typeof options.duration === "number" && options.duration > 0) {
       return options.duration;
     }
-    return this.strategy.getLongPressDurationMs();
+    return this.strategy.longPressDurationMs;
   }
 
 

--- a/src/features/action/TapOnElement.ts
+++ b/src/features/action/TapOnElement.ts
@@ -33,7 +33,6 @@ import type { Timer } from "../../utils/SystemTimer";
 import { NodeCryptoService } from "../../utils/crypto";
 import { ViewHierarchy } from "../observe/ViewHierarchy";
 import { serverConfig } from "../../utils/ServerConfig";
-import { attachRawViewHierarchy } from "../../utils/viewHierarchySearch";
 import { refreshAndroidViewHierarchy } from "./refreshAndroidViewHierarchy";
 import { boundsEqual, boundsNearlyEqual } from "../../utils/bounds";
 import { androidPreTapConsecutiveStableMatchesRequired } from "./androidPreTapStablePolicy";
@@ -46,6 +45,8 @@ import {
 } from "../talkback/TalkBackNavigationDriver";
 import type { IosVoiceOverDetector } from "../../utils/interfaces/IosVoiceOverDetector";
 import { iosVoiceOverDetector as defaultIosVoiceOverDetector } from "../../utils/IosVoiceOverDetector";
+import type { TapStrategy } from "../../utils/interfaces/TapStrategy";
+import { createTapStrategy } from "./strategies/createTapStrategy";
 
 type SearchUntilStats = NonNullable<TapOnElementResult["searchUntil"]>;
 
@@ -63,6 +64,12 @@ interface TapOnElementDependencies {
   talkBackStrategy?: TalkBackTapStrategy;
   talkBackDriverFactory?: TalkBackNavigationDriverFactory;
   iosVoiceOverDetector?: IosVoiceOverDetector;
+  /**
+   * Override the platform-specific {@link TapStrategy}. Tests use this
+   * to inject a fake; production code leaves it unset so the constructor
+   * picks the right strategy based on `device.platform`.
+   */
+  tapStrategy?: TapStrategy;
 }
 
 /**
@@ -83,6 +90,7 @@ export class TapOnElement extends BaseVisualChange {
   private talkBackStrategy: TalkBackTapStrategy;
   private talkBackDriverFactory: TalkBackNavigationDriverFactory;
   private iosVoiceOverDetector: IosVoiceOverDetector;
+  private strategy: TapStrategy;
   private static readonly SEARCH_UNTIL_DEFAULT_MS = 1500;
   private static readonly SEARCH_UNTIL_MIN_MS = 100;
   private static readonly SEARCH_UNTIL_MAX_MS = 12000;
@@ -137,6 +145,11 @@ export class TapOnElement extends BaseVisualChange {
     this.talkBackStrategy = options.talkBackStrategy ?? new TalkBackTapStrategy({ timer: this.timer });
     this.talkBackDriverFactory = options.talkBackDriverFactory ?? new DefaultTalkBackNavigationDriverFactory(this.adbFactory);
     this.iosVoiceOverDetector = options.iosVoiceOverDetector ?? defaultIosVoiceOverDetector;
+    this.strategy = options.tapStrategy ?? createTapStrategy(
+      device,
+      this.accessibilityDetector,
+      this.iosVoiceOverDetector
+    );
   }
 
   /**
@@ -310,23 +323,12 @@ export class TapOnElement extends BaseVisualChange {
       return rawHierarchy;
     }
 
-    if (this.device.platform === "android") {
-      const filtered = this.viewHierarchy.filterViewHierarchy(rawHierarchy);
-      attachRawViewHierarchy(filtered, rawHierarchy);
-      return filtered;
-    }
-
-    if (this.device.platform === "ios" && screenSize?.width && screenSize?.height) {
-      const filtered = this.viewHierarchy.filterOffscreenNodes(
-        rawHierarchy,
-        screenSize.width,
-        screenSize.height
-      );
-      attachRawViewHierarchy(filtered, rawHierarchy);
-      return filtered;
-    }
-
-    return rawHierarchy;
+    const filtered = this.strategy.prepareViewHierarchyForResponse(
+      rawHierarchy,
+      this.viewHierarchy,
+      screenSize
+    );
+    return filtered ?? rawHierarchy;
   }
 
   private async refreshViewHierarchy(
@@ -982,15 +984,16 @@ export class TapOnElement extends BaseVisualChange {
             options.action = "tap";
           }
 
-          const isTalkBackEnabled = this.device.platform === "android"
-            ? (await this.accessibilityDetector.detectMethod(this.device.deviceId, this.adb)) === "talkback"
-            : false;
-          const isVoiceOverEnabled = this.device.platform === "ios"
-            ? await this.iosVoiceOverDetector.isVoiceOverEnabled(
-              this.device.deviceId,
-              IOSCtrlProxyClient.getInstance(this.device)
-            )
-            : false;
+          const isAccessibilityServiceEnabled = await this.strategy.isAccessibilityServiceEnabled(
+            this.device,
+            this.adb,
+            IOSCtrlProxyClient.getInstance(this.device)
+          );
+          // On Android the strategy returns TalkBack state; on iOS it returns
+          // VoiceOver state. Each platform's executeTap consumes only the
+          // boolean meaningful to its own a11y service.
+          const isTalkBackEnabled = isAccessibilityServiceEnabled;
+          const isVoiceOverEnabled = isAccessibilityServiceEnabled;
           let tapElement: Element;
           let usedParent: boolean;
           const initialTapTarget = this.resolveTapTargetElement(
@@ -1002,7 +1005,7 @@ export class TapOnElement extends BaseVisualChange {
           tapElement = initialTapTarget.element;
           usedParent = initialTapTarget.usedParent;
 
-          if (this.device.platform === "android" && options.preTapStability) {
+          if (this.strategy.shouldRunPreTapStability(options)) {
             const stable = await this.resolveAndroidStableTapTargetAfterRefreshes(
               options,
               observeResult,
@@ -1065,7 +1068,7 @@ export class TapOnElement extends BaseVisualChange {
             }
           });
 
-          if (preTapHash && this.device.platform === "android") {
+          if (preTapHash && this.strategy.shouldRetryTapIfNoChange()) {
             await this.retryTapIfNoChange(
               preTapHash,
               tapPoint,
@@ -1463,11 +1466,11 @@ export class TapOnElement extends BaseVisualChange {
     }
   }
 
-  private getLongPressDuration(options: TapOnElementOptions, platform: "android" | "ios"): number {
+  private getLongPressDuration(options: TapOnElementOptions, _platform: "android" | "ios"): number {
     if (typeof options.duration === "number" && options.duration > 0) {
       return options.duration;
     }
-    return platform === "android" ? 500 : 1000;
+    return this.strategy.getLongPressDurationMs();
   }
 
 

--- a/src/features/action/strategies/AndroidTapStrategy.ts
+++ b/src/features/action/strategies/AndroidTapStrategy.ts
@@ -5,7 +5,6 @@ import type {
 } from "../../../models";
 import type { TapOnElementOptions } from "../../../models/TapOnElementOptions";
 import type { AdbExecutor } from "../../../utils/android-cmdline-tools/interfaces/AdbExecutor";
-import type { IOSCtrlProxy } from "../../observe/ios";
 import type { ViewHierarchy } from "../../observe/ViewHierarchy";
 import type { AccessibilityDetector } from "../../../utils/interfaces/AccessibilityDetector";
 import { accessibilityDetector as defaultAccessibilityDetector } from "../../../utils/AccessibilityDetector";
@@ -13,17 +12,17 @@ import { attachRawViewHierarchy } from "../../../utils/viewHierarchySearch";
 import type { TapStrategy } from "../../../utils/interfaces/TapStrategy";
 
 /**
- * Android implementation of {@link TapStrategy}.
- *
- * Hierarchy filtering uses {@link ViewHierarchy.filterViewHierarchy};
- * accessibility detection consults the shared {@link AccessibilityDetector}
- * for TalkBack state. Pre-tap stability and retry-if-no-change are
- * Android-specific recovery flows so they are gated on here.
+ * Android implementation of {@link TapStrategy}. Filters the response
+ * hierarchy via {@link ViewHierarchy.filterViewHierarchy} and reports
+ * accessibility state from {@link AccessibilityDetector} (TalkBack).
  */
 export class AndroidTapStrategy implements TapStrategy {
-  private static readonly LONG_PRESS_DURATION_MS = 500;
+  readonly longPressDurationMs = 500;
+  readonly retryTapIfNoChange = true;
 
   constructor(
+    private readonly device: BootedDevice,
+    private readonly adb: AdbExecutor,
     private readonly accessibilityDetector: AccessibilityDetector = defaultAccessibilityDetector
   ) {}
 
@@ -37,24 +36,12 @@ export class AndroidTapStrategy implements TapStrategy {
     return filtered;
   }
 
-  async isAccessibilityServiceEnabled(
-    device: BootedDevice,
-    adb: AdbExecutor,
-    _iosCtrlProxy: IOSCtrlProxy
-  ): Promise<boolean> {
-    const method = await this.accessibilityDetector.detectMethod(device.deviceId, adb);
+  async isAccessibilityServiceEnabled(): Promise<boolean> {
+    const method = await this.accessibilityDetector.detectMethod(this.device.deviceId, this.adb);
     return method === "talkback";
   }
 
   shouldRunPreTapStability(options: TapOnElementOptions): boolean {
     return Boolean(options.preTapStability);
-  }
-
-  shouldRetryTapIfNoChange(): boolean {
-    return true;
-  }
-
-  getLongPressDurationMs(): number {
-    return AndroidTapStrategy.LONG_PRESS_DURATION_MS;
   }
 }

--- a/src/features/action/strategies/AndroidTapStrategy.ts
+++ b/src/features/action/strategies/AndroidTapStrategy.ts
@@ -1,0 +1,60 @@
+import type {
+  BootedDevice,
+  ObserveResult,
+  ViewHierarchyResult,
+} from "../../../models";
+import type { TapOnElementOptions } from "../../../models/TapOnElementOptions";
+import type { AdbExecutor } from "../../../utils/android-cmdline-tools/interfaces/AdbExecutor";
+import type { IOSCtrlProxy } from "../../observe/ios";
+import type { ViewHierarchy } from "../../observe/ViewHierarchy";
+import type { AccessibilityDetector } from "../../../utils/interfaces/AccessibilityDetector";
+import { accessibilityDetector as defaultAccessibilityDetector } from "../../../utils/AccessibilityDetector";
+import { attachRawViewHierarchy } from "../../../utils/viewHierarchySearch";
+import type { TapStrategy } from "../../../utils/interfaces/TapStrategy";
+
+/**
+ * Android implementation of {@link TapStrategy}.
+ *
+ * Hierarchy filtering uses {@link ViewHierarchy.filterViewHierarchy};
+ * accessibility detection consults the shared {@link AccessibilityDetector}
+ * for TalkBack state. Pre-tap stability and retry-if-no-change are
+ * Android-specific recovery flows so they are gated on here.
+ */
+export class AndroidTapStrategy implements TapStrategy {
+  private static readonly LONG_PRESS_DURATION_MS = 500;
+
+  constructor(
+    private readonly accessibilityDetector: AccessibilityDetector = defaultAccessibilityDetector
+  ) {}
+
+  prepareViewHierarchyForResponse(
+    rawHierarchy: ViewHierarchyResult,
+    viewHierarchy: ViewHierarchy,
+    _screenSize?: ObserveResult["screenSize"]
+  ): ViewHierarchyResult | null {
+    const filtered = viewHierarchy.filterViewHierarchy(rawHierarchy);
+    attachRawViewHierarchy(filtered, rawHierarchy);
+    return filtered;
+  }
+
+  async isAccessibilityServiceEnabled(
+    device: BootedDevice,
+    adb: AdbExecutor,
+    _iosCtrlProxy: IOSCtrlProxy
+  ): Promise<boolean> {
+    const method = await this.accessibilityDetector.detectMethod(device.deviceId, adb);
+    return method === "talkback";
+  }
+
+  shouldRunPreTapStability(options: TapOnElementOptions): boolean {
+    return Boolean(options.preTapStability);
+  }
+
+  shouldRetryTapIfNoChange(): boolean {
+    return true;
+  }
+
+  getLongPressDurationMs(): number {
+    return AndroidTapStrategy.LONG_PRESS_DURATION_MS;
+  }
+}

--- a/src/features/action/strategies/IosTapStrategy.ts
+++ b/src/features/action/strategies/IosTapStrategy.ts
@@ -4,27 +4,25 @@ import type {
   ViewHierarchyResult,
 } from "../../../models";
 import type { TapOnElementOptions } from "../../../models/TapOnElementOptions";
-import type { AdbExecutor } from "../../../utils/android-cmdline-tools/interfaces/AdbExecutor";
-import type { IOSCtrlProxy } from "../../observe/ios";
 import type { ViewHierarchy } from "../../observe/ViewHierarchy";
 import type { IosVoiceOverDetector } from "../../../utils/interfaces/IosVoiceOverDetector";
 import { iosVoiceOverDetector as defaultIosVoiceOverDetector } from "../../../utils/IosVoiceOverDetector";
+import { IOSCtrlProxyClient } from "../../observe/ios";
 import { attachRawViewHierarchy } from "../../../utils/viewHierarchySearch";
 import type { TapStrategy } from "../../../utils/interfaces/TapStrategy";
 
 /**
- * iOS implementation of {@link TapStrategy}.
- *
- * Hierarchy filtering uses {@link ViewHierarchy.filterOffscreenNodes}
- * (which needs `screenSize`); accessibility detection consults the
- * shared {@link IosVoiceOverDetector} for VoiceOver state. Android-only
- * recovery hooks (pre-tap stability, retry-if-no-change) are no-ops
- * on iOS.
+ * iOS implementation of {@link TapStrategy}. Filters the response
+ * hierarchy via {@link ViewHierarchy.filterOffscreenNodes} (skipped
+ * when `screenSize` is missing); reports accessibility state from
+ * {@link IosVoiceOverDetector}.
  */
 export class IosTapStrategy implements TapStrategy {
-  private static readonly LONG_PRESS_DURATION_MS = 1000;
+  readonly longPressDurationMs = 1000;
+  readonly retryTapIfNoChange = false;
 
   constructor(
+    private readonly device: BootedDevice,
     private readonly iosVoiceOverDetector: IosVoiceOverDetector = defaultIosVoiceOverDetector
   ) {}
 
@@ -45,23 +43,13 @@ export class IosTapStrategy implements TapStrategy {
     return filtered;
   }
 
-  async isAccessibilityServiceEnabled(
-    device: BootedDevice,
-    _adb: AdbExecutor,
-    iosCtrlProxy: IOSCtrlProxy
-  ): Promise<boolean> {
-    return this.iosVoiceOverDetector.isVoiceOverEnabled(device.deviceId, iosCtrlProxy);
+  async isAccessibilityServiceEnabled(): Promise<boolean> {
+    // Resolve lazily so Android paths never touch the iOS singleton.
+    const ctrlProxy = IOSCtrlProxyClient.getInstance(this.device);
+    return this.iosVoiceOverDetector.isVoiceOverEnabled(this.device.deviceId, ctrlProxy);
   }
 
   shouldRunPreTapStability(_options: TapOnElementOptions): boolean {
     return false;
-  }
-
-  shouldRetryTapIfNoChange(): boolean {
-    return false;
-  }
-
-  getLongPressDurationMs(): number {
-    return IosTapStrategy.LONG_PRESS_DURATION_MS;
   }
 }

--- a/src/features/action/strategies/IosTapStrategy.ts
+++ b/src/features/action/strategies/IosTapStrategy.ts
@@ -1,0 +1,67 @@
+import type {
+  BootedDevice,
+  ObserveResult,
+  ViewHierarchyResult,
+} from "../../../models";
+import type { TapOnElementOptions } from "../../../models/TapOnElementOptions";
+import type { AdbExecutor } from "../../../utils/android-cmdline-tools/interfaces/AdbExecutor";
+import type { IOSCtrlProxy } from "../../observe/ios";
+import type { ViewHierarchy } from "../../observe/ViewHierarchy";
+import type { IosVoiceOverDetector } from "../../../utils/interfaces/IosVoiceOverDetector";
+import { iosVoiceOverDetector as defaultIosVoiceOverDetector } from "../../../utils/IosVoiceOverDetector";
+import { attachRawViewHierarchy } from "../../../utils/viewHierarchySearch";
+import type { TapStrategy } from "../../../utils/interfaces/TapStrategy";
+
+/**
+ * iOS implementation of {@link TapStrategy}.
+ *
+ * Hierarchy filtering uses {@link ViewHierarchy.filterOffscreenNodes}
+ * (which needs `screenSize`); accessibility detection consults the
+ * shared {@link IosVoiceOverDetector} for VoiceOver state. Android-only
+ * recovery hooks (pre-tap stability, retry-if-no-change) are no-ops
+ * on iOS.
+ */
+export class IosTapStrategy implements TapStrategy {
+  private static readonly LONG_PRESS_DURATION_MS = 1000;
+
+  constructor(
+    private readonly iosVoiceOverDetector: IosVoiceOverDetector = defaultIosVoiceOverDetector
+  ) {}
+
+  prepareViewHierarchyForResponse(
+    rawHierarchy: ViewHierarchyResult,
+    viewHierarchy: ViewHierarchy,
+    screenSize?: ObserveResult["screenSize"]
+  ): ViewHierarchyResult | null {
+    if (!screenSize?.width || !screenSize?.height) {
+      return null;
+    }
+    const filtered = viewHierarchy.filterOffscreenNodes(
+      rawHierarchy,
+      screenSize.width,
+      screenSize.height
+    );
+    attachRawViewHierarchy(filtered, rawHierarchy);
+    return filtered;
+  }
+
+  async isAccessibilityServiceEnabled(
+    device: BootedDevice,
+    _adb: AdbExecutor,
+    iosCtrlProxy: IOSCtrlProxy
+  ): Promise<boolean> {
+    return this.iosVoiceOverDetector.isVoiceOverEnabled(device.deviceId, iosCtrlProxy);
+  }
+
+  shouldRunPreTapStability(_options: TapOnElementOptions): boolean {
+    return false;
+  }
+
+  shouldRetryTapIfNoChange(): boolean {
+    return false;
+  }
+
+  getLongPressDurationMs(): number {
+    return IosTapStrategy.LONG_PRESS_DURATION_MS;
+  }
+}

--- a/src/features/action/strategies/createTapStrategy.ts
+++ b/src/features/action/strategies/createTapStrategy.ts
@@ -1,4 +1,5 @@
 import type { BootedDevice } from "../../../models";
+import type { AdbExecutor } from "../../../utils/android-cmdline-tools/interfaces/AdbExecutor";
 import type { AccessibilityDetector } from "../../../utils/interfaces/AccessibilityDetector";
 import type { IosVoiceOverDetector } from "../../../utils/interfaces/IosVoiceOverDetector";
 import type { TapStrategy } from "../../../utils/interfaces/TapStrategy";
@@ -7,18 +8,17 @@ import { IosTapStrategy } from "./IosTapStrategy";
 
 /**
  * Build the platform-appropriate {@link TapStrategy} for `device`.
- *
  * Centralising the selection here keeps `TapOnElement.ts` free of
- * platform branches: it asks the factory for a strategy and never
- * inspects `device.platform` itself.
+ * platform branches.
  */
 export function createTapStrategy(
   device: BootedDevice,
+  adb: AdbExecutor,
   accessibilityDetector: AccessibilityDetector,
   iosVoiceOverDetector: IosVoiceOverDetector
 ): TapStrategy {
   if (device.platform === "ios") {
-    return new IosTapStrategy(iosVoiceOverDetector);
+    return new IosTapStrategy(device, iosVoiceOverDetector);
   }
-  return new AndroidTapStrategy(accessibilityDetector);
+  return new AndroidTapStrategy(device, adb, accessibilityDetector);
 }

--- a/src/features/action/strategies/createTapStrategy.ts
+++ b/src/features/action/strategies/createTapStrategy.ts
@@ -1,0 +1,24 @@
+import type { BootedDevice } from "../../../models";
+import type { AccessibilityDetector } from "../../../utils/interfaces/AccessibilityDetector";
+import type { IosVoiceOverDetector } from "../../../utils/interfaces/IosVoiceOverDetector";
+import type { TapStrategy } from "../../../utils/interfaces/TapStrategy";
+import { AndroidTapStrategy } from "./AndroidTapStrategy";
+import { IosTapStrategy } from "./IosTapStrategy";
+
+/**
+ * Build the platform-appropriate {@link TapStrategy} for `device`.
+ *
+ * Centralising the selection here keeps `TapOnElement.ts` free of
+ * platform branches: it asks the factory for a strategy and never
+ * inspects `device.platform` itself.
+ */
+export function createTapStrategy(
+  device: BootedDevice,
+  accessibilityDetector: AccessibilityDetector,
+  iosVoiceOverDetector: IosVoiceOverDetector
+): TapStrategy {
+  if (device.platform === "ios") {
+    return new IosTapStrategy(iosVoiceOverDetector);
+  }
+  return new AndroidTapStrategy(accessibilityDetector);
+}

--- a/src/utils/interfaces/TapStrategy.ts
+++ b/src/utils/interfaces/TapStrategy.ts
@@ -1,0 +1,69 @@
+import type { ViewHierarchyResult, ObserveResult, BootedDevice } from "../../models";
+import type { TapOnElementOptions } from "../../models/TapOnElementOptions";
+import type { AdbExecutor } from "../android-cmdline-tools/interfaces/AdbExecutor";
+import type { IOSCtrlProxy } from "../../features/observe/ios";
+import type { ViewHierarchy } from "../../features/observe/ViewHierarchy";
+
+/**
+ * Platform-specific surface used by {@link TapOnElement} to keep its
+ * top-level flow free of `device.platform === ...` branches.
+ *
+ * Implemented by `AndroidTapStrategy` and `IosTapStrategy`. The
+ * concrete strategy is selected once in the `TapOnElement` constructor
+ * based on `device.platform` so call sites never need to re-check.
+ *
+ * The interface is deliberately narrow: it covers exactly the four
+ * platform-divergent concerns inside `TapOnElement` (response hierarchy
+ * filtering, accessibility-service detection, Android-only pre-tap
+ * stability/retry-if-no-change gating, and the default long-press
+ * duration). Anything richer would leak Android- or iOS-specific
+ * concepts into the shared contract.
+ */
+export interface TapStrategy {
+  /**
+   * Post-process a raw view hierarchy for inclusion in the tap result.
+   *
+   * Android collapses the tree via `filterViewHierarchy`; iOS removes
+   * off-screen nodes via `filterOffscreenNodes` (which needs the
+   * `screenSize`, so iOS skips the filter when `screenSize` is
+   * unavailable). The method returns the filtered hierarchy, or `null`
+   * when filtering is not applicable — in which case the caller should
+   * use the raw hierarchy unchanged.
+   */
+  prepareViewHierarchyForResponse(
+    rawHierarchy: ViewHierarchyResult,
+    viewHierarchy: ViewHierarchy,
+    screenSize?: ObserveResult["screenSize"]
+  ): ViewHierarchyResult | null;
+
+  /**
+   * Whether the platform's accessibility service (TalkBack on Android,
+   * VoiceOver on iOS) is currently active. Used to route the tap
+   * through the appropriate accessibility-aware code path.
+   */
+  isAccessibilityServiceEnabled(
+    device: BootedDevice,
+    adb: AdbExecutor,
+    iosCtrlProxy: IOSCtrlProxy
+  ): Promise<boolean>;
+
+  /**
+   * Whether `TapOnElement` should run the Android-only pre-tap stability
+   * loop (re-find the element on a refreshed hierarchy until bounds
+   * settle). iOS returns `false` regardless of the option.
+   */
+  shouldRunPreTapStability(options: TapOnElementOptions): boolean;
+
+  /**
+   * Whether `TapOnElement` should re-tap when the view hierarchy hash
+   * is unchanged after the initial tap (Android-only ghost-tap recovery).
+   * iOS returns `false`.
+   */
+  shouldRetryTapIfNoChange(): boolean;
+
+  /**
+   * Default long-press duration in milliseconds when the caller has not
+   * supplied an explicit duration. Android: 500ms; iOS: 1000ms.
+   */
+  getLongPressDurationMs(): number;
+}

--- a/src/utils/interfaces/TapStrategy.ts
+++ b/src/utils/interfaces/TapStrategy.ts
@@ -1,34 +1,21 @@
-import type { ViewHierarchyResult, ObserveResult, BootedDevice } from "../../models";
+import type { ViewHierarchyResult, ObserveResult } from "../../models";
 import type { TapOnElementOptions } from "../../models/TapOnElementOptions";
-import type { AdbExecutor } from "../android-cmdline-tools/interfaces/AdbExecutor";
-import type { IOSCtrlProxy } from "../../features/observe/ios";
 import type { ViewHierarchy } from "../../features/observe/ViewHierarchy";
 
 /**
  * Platform-specific surface used by {@link TapOnElement} to keep its
  * top-level flow free of `device.platform === ...` branches.
  *
- * Implemented by `AndroidTapStrategy` and `IosTapStrategy`. The
- * concrete strategy is selected once in the `TapOnElement` constructor
- * based on `device.platform` so call sites never need to re-check.
- *
- * The interface is deliberately narrow: it covers exactly the four
- * platform-divergent concerns inside `TapOnElement` (response hierarchy
- * filtering, accessibility-service detection, Android-only pre-tap
- * stability/retry-if-no-change gating, and the default long-press
- * duration). Anything richer would leak Android- or iOS-specific
- * concepts into the shared contract.
+ * Implemented by `AndroidTapStrategy` and `IosTapStrategy`; selected
+ * once in the `TapOnElement` constructor via `createTapStrategy`. Each
+ * strategy captures its platform dependencies (device, adb, detector,
+ * …) at construction so call sites never need to thread them through.
  */
 export interface TapStrategy {
   /**
    * Post-process a raw view hierarchy for inclusion in the tap result.
-   *
-   * Android collapses the tree via `filterViewHierarchy`; iOS removes
-   * off-screen nodes via `filterOffscreenNodes` (which needs the
-   * `screenSize`, so iOS skips the filter when `screenSize` is
-   * unavailable). The method returns the filtered hierarchy, or `null`
-   * when filtering is not applicable — in which case the caller should
-   * use the raw hierarchy unchanged.
+   * Returns the filtered hierarchy, or `null` when filtering does not
+   * apply — in which case the caller uses the raw hierarchy unchanged.
    */
   prepareViewHierarchyForResponse(
     rawHierarchy: ViewHierarchyResult,
@@ -37,33 +24,20 @@ export interface TapStrategy {
   ): ViewHierarchyResult | null;
 
   /**
-   * Whether the platform's accessibility service (TalkBack on Android,
-   * VoiceOver on iOS) is currently active. Used to route the tap
-   * through the appropriate accessibility-aware code path.
+   * Whether the platform's accessibility service (TalkBack / VoiceOver)
+   * is currently active.
    */
-  isAccessibilityServiceEnabled(
-    device: BootedDevice,
-    adb: AdbExecutor,
-    iosCtrlProxy: IOSCtrlProxy
-  ): Promise<boolean>;
+  isAccessibilityServiceEnabled(): Promise<boolean>;
 
   /**
    * Whether `TapOnElement` should run the Android-only pre-tap stability
-   * loop (re-find the element on a refreshed hierarchy until bounds
-   * settle). iOS returns `false` regardless of the option.
+   * loop. iOS returns `false` regardless of `options.preTapStability`.
    */
   shouldRunPreTapStability(options: TapOnElementOptions): boolean;
 
-  /**
-   * Whether `TapOnElement` should re-tap when the view hierarchy hash
-   * is unchanged after the initial tap (Android-only ghost-tap recovery).
-   * iOS returns `false`.
-   */
-  shouldRetryTapIfNoChange(): boolean;
+  /** Re-tap when the view hierarchy hash is unchanged after a tap. */
+  readonly retryTapIfNoChange: boolean;
 
-  /**
-   * Default long-press duration in milliseconds when the caller has not
-   * supplied an explicit duration. Android: 500ms; iOS: 1000ms.
-   */
-  getLongPressDurationMs(): number;
+  /** Default long-press duration in milliseconds. */
+  readonly longPressDurationMs: number;
 }

--- a/src/utils/interfaces/index.ts
+++ b/src/utils/interfaces/index.ts
@@ -9,6 +9,7 @@ export type {
   SnapshotCaptureProvider,
   SnapshotRestoreProvider,
 } from "./SnapshotProvider";
+export type { TapStrategy } from "./TapStrategy";
 // Screenshot utilities - split into focused classes (Phase 3.1)
 export { ScreenshotComparator } from "../screenshot/ScreenshotComparator";
 export { PerceptualHasher } from "../screenshot/PerceptualHasher";

--- a/test/fakes/FakeTapStrategy.ts
+++ b/test/fakes/FakeTapStrategy.ts
@@ -1,0 +1,95 @@
+import type { TapStrategy } from "../../src/utils/interfaces/TapStrategy";
+import type {
+  BootedDevice,
+  ObserveResult,
+  ViewHierarchyResult,
+} from "../../src/models";
+import type { TapOnElementOptions } from "../../src/models/TapOnElementOptions";
+import type { AdbExecutor } from "../../src/utils/android-cmdline-tools/interfaces/AdbExecutor";
+import type { IOSCtrlProxy } from "../../src/features/observe/ios";
+import type { ViewHierarchy } from "../../src/features/observe/ViewHierarchy";
+
+/**
+ * Minimal recording fake for {@link TapStrategy}. Mirrors the
+ * `executedOperations` / `wasMethodCalled` / `getCallCount` /
+ * `clearHistory` pattern used by `FakeProxyManager` and
+ * `FakeSnapshotProvider`.
+ */
+export class FakeTapStrategy implements TapStrategy {
+  private accessibilityEnabled: boolean = false;
+  private preTapStabilityGate: boolean = false;
+  private retryIfNoChangeGate: boolean = false;
+  private longPressMs: number = 500;
+  private filterReturnsRaw: boolean = false;
+  private readonly executedOperations: string[] = [];
+
+  setAccessibilityServiceEnabled(enabled: boolean): void {
+    this.accessibilityEnabled = enabled;
+  }
+
+  setShouldRunPreTapStability(enabled: boolean): void {
+    this.preTapStabilityGate = enabled;
+  }
+
+  setShouldRetryTapIfNoChange(enabled: boolean): void {
+    this.retryIfNoChangeGate = enabled;
+  }
+
+  setLongPressDurationMs(ms: number): void {
+    this.longPressMs = ms;
+  }
+
+  /** When `true`, `prepareViewHierarchyForResponse` returns `null` (caller uses raw). */
+  setFilterReturnsRaw(returnsRaw: boolean): void {
+    this.filterReturnsRaw = returnsRaw;
+  }
+
+  getExecutedOperations(): string[] {
+    return [...this.executedOperations];
+  }
+
+  wasMethodCalled(operationName: string): boolean {
+    return this.executedOperations.some(op => op.includes(operationName));
+  }
+
+  getCallCount(operationName: string): number {
+    return this.executedOperations.filter(op => op.includes(operationName)).length;
+  }
+
+  clearHistory(): void {
+    this.executedOperations.length = 0;
+  }
+
+  prepareViewHierarchyForResponse(
+    rawHierarchy: ViewHierarchyResult,
+    _viewHierarchy: ViewHierarchy,
+    _screenSize?: ObserveResult["screenSize"]
+  ): ViewHierarchyResult | null {
+    this.executedOperations.push("prepareViewHierarchyForResponse");
+    return this.filterReturnsRaw ? null : rawHierarchy;
+  }
+
+  async isAccessibilityServiceEnabled(
+    _device: BootedDevice,
+    _adb: AdbExecutor,
+    _iosCtrlProxy: IOSCtrlProxy
+  ): Promise<boolean> {
+    this.executedOperations.push("isAccessibilityServiceEnabled");
+    return this.accessibilityEnabled;
+  }
+
+  shouldRunPreTapStability(_options: TapOnElementOptions): boolean {
+    this.executedOperations.push("shouldRunPreTapStability");
+    return this.preTapStabilityGate;
+  }
+
+  shouldRetryTapIfNoChange(): boolean {
+    this.executedOperations.push("shouldRetryTapIfNoChange");
+    return this.retryIfNoChangeGate;
+  }
+
+  getLongPressDurationMs(): number {
+    this.executedOperations.push("getLongPressDurationMs");
+    return this.longPressMs;
+  }
+}

--- a/test/fakes/FakeTapStrategy.ts
+++ b/test/fakes/FakeTapStrategy.ts
@@ -1,12 +1,9 @@
 import type { TapStrategy } from "../../src/utils/interfaces/TapStrategy";
 import type {
-  BootedDevice,
   ObserveResult,
   ViewHierarchyResult,
 } from "../../src/models";
 import type { TapOnElementOptions } from "../../src/models/TapOnElementOptions";
-import type { AdbExecutor } from "../../src/utils/android-cmdline-tools/interfaces/AdbExecutor";
-import type { IOSCtrlProxy } from "../../src/features/observe/ios";
 import type { ViewHierarchy } from "../../src/features/observe/ViewHierarchy";
 
 /**
@@ -14,12 +11,16 @@ import type { ViewHierarchy } from "../../src/features/observe/ViewHierarchy";
  * `executedOperations` / `wasMethodCalled` / `getCallCount` /
  * `clearHistory` pattern used by `FakeProxyManager` and
  * `FakeSnapshotProvider`.
+ *
+ * The interface's `readonly` fields are exposed as mutable on the fake
+ * so tests can twiddle them between assertions.
  */
 export class FakeTapStrategy implements TapStrategy {
+  longPressDurationMs: number = 500;
+  retryTapIfNoChange: boolean = false;
+
   private accessibilityEnabled: boolean = false;
   private preTapStabilityGate: boolean = false;
-  private retryIfNoChangeGate: boolean = false;
-  private longPressMs: number = 500;
   private filterReturnsRaw: boolean = false;
   private readonly executedOperations: string[] = [];
 
@@ -29,14 +30,6 @@ export class FakeTapStrategy implements TapStrategy {
 
   setShouldRunPreTapStability(enabled: boolean): void {
     this.preTapStabilityGate = enabled;
-  }
-
-  setShouldRetryTapIfNoChange(enabled: boolean): void {
-    this.retryIfNoChangeGate = enabled;
-  }
-
-  setLongPressDurationMs(ms: number): void {
-    this.longPressMs = ms;
   }
 
   /** When `true`, `prepareViewHierarchyForResponse` returns `null` (caller uses raw). */
@@ -69,11 +62,7 @@ export class FakeTapStrategy implements TapStrategy {
     return this.filterReturnsRaw ? null : rawHierarchy;
   }
 
-  async isAccessibilityServiceEnabled(
-    _device: BootedDevice,
-    _adb: AdbExecutor,
-    _iosCtrlProxy: IOSCtrlProxy
-  ): Promise<boolean> {
+  async isAccessibilityServiceEnabled(): Promise<boolean> {
     this.executedOperations.push("isAccessibilityServiceEnabled");
     return this.accessibilityEnabled;
   }
@@ -81,15 +70,5 @@ export class FakeTapStrategy implements TapStrategy {
   shouldRunPreTapStability(_options: TapOnElementOptions): boolean {
     this.executedOperations.push("shouldRunPreTapStability");
     return this.preTapStabilityGate;
-  }
-
-  shouldRetryTapIfNoChange(): boolean {
-    this.executedOperations.push("shouldRetryTapIfNoChange");
-    return this.retryIfNoChangeGate;
-  }
-
-  getLongPressDurationMs(): number {
-    this.executedOperations.push("getLongPressDurationMs");
-    return this.longPressMs;
   }
 }

--- a/test/features/action/TapStrategy.test.ts
+++ b/test/features/action/TapStrategy.test.ts
@@ -1,0 +1,250 @@
+import { describe, it, expect, beforeEach } from "bun:test";
+import { FakeTapStrategy } from "../../fakes/FakeTapStrategy";
+import { AndroidTapStrategy } from "../../../src/features/action/strategies/AndroidTapStrategy";
+import { IosTapStrategy } from "../../../src/features/action/strategies/IosTapStrategy";
+import { createTapStrategy } from "../../../src/features/action/strategies/createTapStrategy";
+import { FakeAccessibilityDetector } from "../../fakes/FakeAccessibilityDetector";
+import { FakeIosVoiceOverDetector } from "../../fakes/FakeIosVoiceOverDetector";
+import { FakeAdbClient } from "../../fakes/FakeAdbClient";
+import { FakeIOSCtrlProxy } from "../../fakes/FakeIOSCtrlProxy";
+import { ViewHierarchy } from "../../../src/features/observe/ViewHierarchy";
+import type { BootedDevice, ViewHierarchyResult } from "../../../src/models";
+import type { TapOnElementOptions } from "../../../src/models/TapOnElementOptions";
+import type { TapStrategy } from "../../../src/utils/interfaces/TapStrategy";
+
+/**
+ * Sanity-check the platform-agnostic TapStrategy contract. Tests
+ * deliberately type their subjects as the abstract interface so a
+ * regression that drops one of the shared methods will surface as a
+ * compile error here.
+ */
+describe("TapStrategy", () => {
+  const androidDevice: BootedDevice = {
+    deviceId: "emulator-5554",
+    name: "Pixel_5",
+    platform: "android",
+  };
+  const iosDevice: BootedDevice = {
+    deviceId: "00001234-ABCD",
+    name: "iPhone 15",
+    platform: "ios",
+  };
+
+  const buildAndroidViewHierarchy = (): ViewHierarchy =>
+    new ViewHierarchy(androidDevice, { create: () => new FakeAdbClient() as any });
+  const buildIosViewHierarchy = (): ViewHierarchy =>
+    new ViewHierarchy(iosDevice, { create: () => new FakeAdbClient() as any });
+
+  const minimalHierarchy: ViewHierarchyResult = {
+    hierarchy: { $: {}, node: [] },
+  } as any;
+
+  describe("FakeTapStrategy", () => {
+    let fake: FakeTapStrategy;
+
+    beforeEach(() => {
+      fake = new FakeTapStrategy();
+    });
+
+    it("records each method invocation", async () => {
+      fake.setAccessibilityServiceEnabled(true);
+      fake.setLongPressDurationMs(750);
+
+      await fake.isAccessibilityServiceEnabled(
+        androidDevice,
+        new FakeAdbClient() as any,
+        new FakeIOSCtrlProxy() as any
+      );
+      fake.getLongPressDurationMs();
+      fake.shouldRunPreTapStability({ action: "tap" } as TapOnElementOptions);
+      fake.shouldRetryTapIfNoChange();
+      fake.prepareViewHierarchyForResponse(
+        minimalHierarchy,
+        buildAndroidViewHierarchy(),
+        { width: 1080, height: 1920 }
+      );
+
+      expect(fake.wasMethodCalled("isAccessibilityServiceEnabled")).toBe(true);
+      expect(fake.wasMethodCalled("getLongPressDurationMs")).toBe(true);
+      expect(fake.wasMethodCalled("shouldRunPreTapStability")).toBe(true);
+      expect(fake.wasMethodCalled("shouldRetryTapIfNoChange")).toBe(true);
+      expect(fake.wasMethodCalled("prepareViewHierarchyForResponse")).toBe(true);
+      expect(fake.getCallCount("getLongPressDurationMs")).toBe(1);
+    });
+
+    it("clears recorded history on demand", () => {
+      fake.getLongPressDurationMs();
+      fake.clearHistory();
+      expect(fake.getExecutedOperations()).toEqual([]);
+    });
+
+    it("propagates configured accessibility-service state", async () => {
+      fake.setAccessibilityServiceEnabled(true);
+      const result = await fake.isAccessibilityServiceEnabled(
+        androidDevice,
+        new FakeAdbClient() as any,
+        new FakeIOSCtrlProxy() as any
+      );
+      expect(result).toBe(true);
+    });
+  });
+
+  describe("AndroidTapStrategy", () => {
+    let detector: FakeAccessibilityDetector;
+    let strategy: AndroidTapStrategy;
+
+    beforeEach(() => {
+      detector = new FakeAccessibilityDetector();
+      strategy = new AndroidTapStrategy(detector);
+    });
+
+    it("returns true when TalkBack is detected", async () => {
+      detector.setDetectionResult(androidDevice.deviceId, true, "talkback");
+      const enabled = await strategy.isAccessibilityServiceEnabled(
+        androidDevice,
+        new FakeAdbClient() as any,
+        new FakeIOSCtrlProxy() as any
+      );
+      expect(enabled).toBe(true);
+    });
+
+    it("returns false when accessibility service is not TalkBack", async () => {
+      detector.setDetectionResult(androidDevice.deviceId, true, "voiceover");
+      const enabled = await strategy.isAccessibilityServiceEnabled(
+        androidDevice,
+        new FakeAdbClient() as any,
+        new FakeIOSCtrlProxy() as any
+      );
+      expect(enabled).toBe(false);
+    });
+
+    it("returns 500ms default long press", () => {
+      expect(strategy.getLongPressDurationMs()).toBe(500);
+    });
+
+    it("honours options.preTapStability for pre-tap gating", () => {
+      expect(strategy.shouldRunPreTapStability({ action: "tap" } as TapOnElementOptions)).toBe(false);
+      expect(
+        strategy.shouldRunPreTapStability({ action: "tap", preTapStability: true } as TapOnElementOptions)
+      ).toBe(true);
+    });
+
+    it("always enables retry-if-no-change", () => {
+      expect(strategy.shouldRetryTapIfNoChange()).toBe(true);
+    });
+
+    it("filters the raw hierarchy via filterViewHierarchy", () => {
+      const filtered = strategy.prepareViewHierarchyForResponse(
+        minimalHierarchy,
+        buildAndroidViewHierarchy()
+      );
+      // Filter always returns a hierarchy (possibly equal to raw) — non-null
+      // means TapOnElement uses the filtered tree.
+      expect(filtered).not.toBeNull();
+    });
+  });
+
+  describe("IosTapStrategy", () => {
+    let detector: FakeIosVoiceOverDetector;
+    let strategy: IosTapStrategy;
+
+    beforeEach(() => {
+      detector = new FakeIosVoiceOverDetector();
+      strategy = new IosTapStrategy(detector);
+    });
+
+    it("routes accessibility detection to VoiceOver", async () => {
+      detector.setVoiceOverEnabled(true);
+      const enabled = await strategy.isAccessibilityServiceEnabled(
+        iosDevice,
+        new FakeAdbClient() as any,
+        new FakeIOSCtrlProxy() as any
+      );
+      expect(enabled).toBe(true);
+      expect(detector.getCallCount()).toBe(1);
+    });
+
+    it("returns false when VoiceOver is disabled", async () => {
+      detector.setVoiceOverEnabled(false);
+      const enabled = await strategy.isAccessibilityServiceEnabled(
+        iosDevice,
+        new FakeAdbClient() as any,
+        new FakeIOSCtrlProxy() as any
+      );
+      expect(enabled).toBe(false);
+    });
+
+    it("returns 1000ms default long press", () => {
+      expect(strategy.getLongPressDurationMs()).toBe(1000);
+    });
+
+    it("never runs pre-tap stability (Android-only)", () => {
+      expect(
+        strategy.shouldRunPreTapStability({ action: "tap", preTapStability: true } as TapOnElementOptions)
+      ).toBe(false);
+      expect(strategy.shouldRunPreTapStability({ action: "tap" } as TapOnElementOptions)).toBe(false);
+    });
+
+    it("never retries after tap (Android-only)", () => {
+      expect(strategy.shouldRetryTapIfNoChange()).toBe(false);
+    });
+
+    it("returns null when screenSize is missing (caller keeps raw)", () => {
+      const result = strategy.prepareViewHierarchyForResponse(
+        minimalHierarchy,
+        buildIosViewHierarchy()
+      );
+      expect(result).toBeNull();
+    });
+
+    it("filters the raw hierarchy when screenSize is provided", () => {
+      const result = strategy.prepareViewHierarchyForResponse(
+        minimalHierarchy,
+        buildIosViewHierarchy(),
+        { width: 390, height: 844 }
+      );
+      expect(result).not.toBeNull();
+    });
+  });
+
+  describe("createTapStrategy factory", () => {
+    it("returns an AndroidTapStrategy for Android devices", () => {
+      const strategy = createTapStrategy(
+        androidDevice,
+        new FakeAccessibilityDetector(),
+        new FakeIosVoiceOverDetector()
+      );
+      expect(strategy).toBeInstanceOf(AndroidTapStrategy);
+      expect(strategy.getLongPressDurationMs()).toBe(500);
+    });
+
+    it("returns an IosTapStrategy for iOS devices", () => {
+      const strategy = createTapStrategy(
+        iosDevice,
+        new FakeAccessibilityDetector(),
+        new FakeIosVoiceOverDetector()
+      );
+      expect(strategy).toBeInstanceOf(IosTapStrategy);
+      expect(strategy.getLongPressDurationMs()).toBe(1000);
+    });
+  });
+
+  // Compile-time conformance: each platform-specific concrete class is
+  // assigned to the abstract TapStrategy type. Behavioral coverage lives in
+  // the platform-specific describe blocks above.
+  const platformCases: ReadonlyArray<[string, () => TapStrategy]> = [
+    ["AndroidTapStrategy", () => new AndroidTapStrategy(new FakeAccessibilityDetector())],
+    ["IosTapStrategy", () => new IosTapStrategy(new FakeIosVoiceOverDetector())],
+    ["FakeTapStrategy", () => new FakeTapStrategy()],
+  ];
+  for (const [name, build] of platformCases) {
+    it(`${name} satisfies TapStrategy`, () => {
+      const asStrategy: TapStrategy = build();
+      expect(typeof asStrategy.prepareViewHierarchyForResponse).toBe("function");
+      expect(typeof asStrategy.isAccessibilityServiceEnabled).toBe("function");
+      expect(typeof asStrategy.shouldRunPreTapStability).toBe("function");
+      expect(typeof asStrategy.shouldRetryTapIfNoChange).toBe("function");
+      expect(typeof asStrategy.getLongPressDurationMs).toBe("function");
+    });
+  }
+});

--- a/test/features/action/TapStrategy.test.ts
+++ b/test/features/action/TapStrategy.test.ts
@@ -6,7 +6,6 @@ import { createTapStrategy } from "../../../src/features/action/strategies/creat
 import { FakeAccessibilityDetector } from "../../fakes/FakeAccessibilityDetector";
 import { FakeIosVoiceOverDetector } from "../../fakes/FakeIosVoiceOverDetector";
 import { FakeAdbClient } from "../../fakes/FakeAdbClient";
-import { FakeIOSCtrlProxy } from "../../fakes/FakeIOSCtrlProxy";
 import { ViewHierarchy } from "../../../src/features/observe/ViewHierarchy";
 import type { BootedDevice, ViewHierarchyResult } from "../../../src/models";
 import type { TapOnElementOptions } from "../../../src/models/TapOnElementOptions";
@@ -15,7 +14,7 @@ import type { TapStrategy } from "../../../src/utils/interfaces/TapStrategy";
 /**
  * Sanity-check the platform-agnostic TapStrategy contract. Tests
  * deliberately type their subjects as the abstract interface so a
- * regression that drops one of the shared methods will surface as a
+ * regression that drops one of the shared members will surface as a
  * compile error here.
  */
 describe("TapStrategy", () => {
@@ -30,10 +29,8 @@ describe("TapStrategy", () => {
     platform: "ios",
   };
 
-  const buildAndroidViewHierarchy = (): ViewHierarchy =>
-    new ViewHierarchy(androidDevice, { create: () => new FakeAdbClient() as any });
-  const buildIosViewHierarchy = (): ViewHierarchy =>
-    new ViewHierarchy(iosDevice, { create: () => new FakeAdbClient() as any });
+  const buildViewHierarchy = (device: BootedDevice): ViewHierarchy =>
+    new ViewHierarchy(device, { create: () => new FakeAdbClient() as any });
 
   const minimalHierarchy: ViewHierarchyResult = {
     hierarchy: { $: {}, node: [] },
@@ -48,162 +45,143 @@ describe("TapStrategy", () => {
 
     it("records each method invocation", async () => {
       fake.setAccessibilityServiceEnabled(true);
-      fake.setLongPressDurationMs(750);
+      fake.longPressDurationMs = 750;
 
-      await fake.isAccessibilityServiceEnabled(
-        androidDevice,
-        new FakeAdbClient() as any,
-        new FakeIOSCtrlProxy() as any
-      );
-      fake.getLongPressDurationMs();
+      await fake.isAccessibilityServiceEnabled();
       fake.shouldRunPreTapStability({ action: "tap" } as TapOnElementOptions);
-      fake.shouldRetryTapIfNoChange();
       fake.prepareViewHierarchyForResponse(
         minimalHierarchy,
-        buildAndroidViewHierarchy(),
+        buildViewHierarchy(androidDevice),
         { width: 1080, height: 1920 }
       );
 
       expect(fake.wasMethodCalled("isAccessibilityServiceEnabled")).toBe(true);
-      expect(fake.wasMethodCalled("getLongPressDurationMs")).toBe(true);
       expect(fake.wasMethodCalled("shouldRunPreTapStability")).toBe(true);
-      expect(fake.wasMethodCalled("shouldRetryTapIfNoChange")).toBe(true);
       expect(fake.wasMethodCalled("prepareViewHierarchyForResponse")).toBe(true);
-      expect(fake.getCallCount("getLongPressDurationMs")).toBe(1);
     });
 
-    it("clears recorded history on demand", () => {
-      fake.getLongPressDurationMs();
+    it("clears recorded history on demand", async () => {
+      await fake.isAccessibilityServiceEnabled();
       fake.clearHistory();
       expect(fake.getExecutedOperations()).toEqual([]);
     });
 
     it("propagates configured accessibility-service state", async () => {
       fake.setAccessibilityServiceEnabled(true);
-      const result = await fake.isAccessibilityServiceEnabled(
-        androidDevice,
-        new FakeAdbClient() as any,
-        new FakeIOSCtrlProxy() as any
-      );
-      expect(result).toBe(true);
+      expect(await fake.isAccessibilityServiceEnabled()).toBe(true);
+      fake.setAccessibilityServiceEnabled(false);
+      expect(await fake.isAccessibilityServiceEnabled()).toBe(false);
+    });
+
+    it("exposes mutable long-press and retry knobs", () => {
+      fake.longPressDurationMs = 250;
+      fake.retryTapIfNoChange = true;
+      const asStrategy: TapStrategy = fake;
+      expect(asStrategy.longPressDurationMs).toBe(250);
+      expect(asStrategy.retryTapIfNoChange).toBe(true);
     });
   });
 
-  describe("AndroidTapStrategy", () => {
-    let detector: FakeAccessibilityDetector;
-    let strategy: AndroidTapStrategy;
+  // Two platform strategies plus the fake all satisfy TapStrategy. Data-
+  // driven instead of duplicating per-platform describe blocks.
+  interface StrategyCase {
+    name: string;
+    device: BootedDevice;
+    build: () => { strategy: TapStrategy; setA11y: (enabled: boolean) => void };
+    longPressMs: number;
+    retryTapIfNoChange: boolean;
+    runsPreTapStabilityWhenRequested: boolean;
+  }
 
-    beforeEach(() => {
-      detector = new FakeAccessibilityDetector();
-      strategy = new AndroidTapStrategy(detector);
+  const cases: ReadonlyArray<StrategyCase> = [
+    {
+      name: "AndroidTapStrategy",
+      device: androidDevice,
+      build: () => {
+        const detector = new FakeAccessibilityDetector();
+        const strategy = new AndroidTapStrategy(androidDevice, new FakeAdbClient() as any, detector);
+        return {
+          strategy,
+          setA11y: enabled =>
+            detector.setDetectionResult(androidDevice.deviceId, enabled, enabled ? "talkback" : null),
+        };
+      },
+      longPressMs: 500,
+      retryTapIfNoChange: true,
+      runsPreTapStabilityWhenRequested: true,
+    },
+    {
+      name: "IosTapStrategy",
+      device: iosDevice,
+      build: () => {
+        const detector = new FakeIosVoiceOverDetector();
+        const strategy = new IosTapStrategy(iosDevice, detector);
+        return { strategy, setA11y: enabled => detector.setVoiceOverEnabled(enabled) };
+      },
+      longPressMs: 1000,
+      retryTapIfNoChange: false,
+      runsPreTapStabilityWhenRequested: false,
+    },
+  ];
+
+  for (const c of cases) {
+    describe(c.name, () => {
+      it("exposes the right long-press default", () => {
+        expect(c.build().strategy.longPressDurationMs).toBe(c.longPressMs);
+      });
+
+      it("reports the right retryTapIfNoChange policy", () => {
+        expect(c.build().strategy.retryTapIfNoChange).toBe(c.retryTapIfNoChange);
+      });
+
+      it("routes accessibility-service detection to the right detector", async () => {
+        const { strategy, setA11y } = c.build();
+        setA11y(true);
+        expect(await strategy.isAccessibilityServiceEnabled()).toBe(true);
+        setA11y(false);
+        expect(await strategy.isAccessibilityServiceEnabled()).toBe(false);
+      });
+
+      it("only runs pre-tap stability on platforms that support it", () => {
+        const { strategy } = c.build();
+        const withFlag = { action: "tap", preTapStability: true } as TapOnElementOptions;
+        const withoutFlag = { action: "tap" } as TapOnElementOptions;
+        expect(strategy.shouldRunPreTapStability(withoutFlag)).toBe(false);
+        expect(strategy.shouldRunPreTapStability(withFlag)).toBe(c.runsPreTapStabilityWhenRequested);
+      });
+
+      it("filters the response hierarchy without crashing", () => {
+        const { strategy } = c.build();
+        const result = strategy.prepareViewHierarchyForResponse(
+          minimalHierarchy,
+          buildViewHierarchy(c.device),
+          { width: 390, height: 844 }
+        );
+        // Android always returns a filtered tree; iOS returns null when
+        // screenSize is missing (covered separately below) but returns
+        // a tree when provided.
+        expect(result).not.toBeNull();
+      });
+
+      it("satisfies the TapStrategy interface", () => {
+        const asStrategy: TapStrategy = c.build().strategy;
+        expect(typeof asStrategy.prepareViewHierarchyForResponse).toBe("function");
+        expect(typeof asStrategy.isAccessibilityServiceEnabled).toBe("function");
+        expect(typeof asStrategy.shouldRunPreTapStability).toBe("function");
+        expect(typeof asStrategy.longPressDurationMs).toBe("number");
+        expect(typeof asStrategy.retryTapIfNoChange).toBe("boolean");
+      });
     });
+  }
 
-    it("returns true when TalkBack is detected", async () => {
-      detector.setDetectionResult(androidDevice.deviceId, true, "talkback");
-      const enabled = await strategy.isAccessibilityServiceEnabled(
-        androidDevice,
-        new FakeAdbClient() as any,
-        new FakeIOSCtrlProxy() as any
-      );
-      expect(enabled).toBe(true);
-    });
-
-    it("returns false when accessibility service is not TalkBack", async () => {
-      detector.setDetectionResult(androidDevice.deviceId, true, "voiceover");
-      const enabled = await strategy.isAccessibilityServiceEnabled(
-        androidDevice,
-        new FakeAdbClient() as any,
-        new FakeIOSCtrlProxy() as any
-      );
-      expect(enabled).toBe(false);
-    });
-
-    it("returns 500ms default long press", () => {
-      expect(strategy.getLongPressDurationMs()).toBe(500);
-    });
-
-    it("honours options.preTapStability for pre-tap gating", () => {
-      expect(strategy.shouldRunPreTapStability({ action: "tap" } as TapOnElementOptions)).toBe(false);
-      expect(
-        strategy.shouldRunPreTapStability({ action: "tap", preTapStability: true } as TapOnElementOptions)
-      ).toBe(true);
-    });
-
-    it("always enables retry-if-no-change", () => {
-      expect(strategy.shouldRetryTapIfNoChange()).toBe(true);
-    });
-
-    it("filters the raw hierarchy via filterViewHierarchy", () => {
-      const filtered = strategy.prepareViewHierarchyForResponse(
-        minimalHierarchy,
-        buildAndroidViewHierarchy()
-      );
-      // Filter always returns a hierarchy (possibly equal to raw) — non-null
-      // means TapOnElement uses the filtered tree.
-      expect(filtered).not.toBeNull();
-    });
-  });
-
-  describe("IosTapStrategy", () => {
-    let detector: FakeIosVoiceOverDetector;
-    let strategy: IosTapStrategy;
-
-    beforeEach(() => {
-      detector = new FakeIosVoiceOverDetector();
-      strategy = new IosTapStrategy(detector);
-    });
-
-    it("routes accessibility detection to VoiceOver", async () => {
-      detector.setVoiceOverEnabled(true);
-      const enabled = await strategy.isAccessibilityServiceEnabled(
-        iosDevice,
-        new FakeAdbClient() as any,
-        new FakeIOSCtrlProxy() as any
-      );
-      expect(enabled).toBe(true);
-      expect(detector.getCallCount()).toBe(1);
-    });
-
-    it("returns false when VoiceOver is disabled", async () => {
-      detector.setVoiceOverEnabled(false);
-      const enabled = await strategy.isAccessibilityServiceEnabled(
-        iosDevice,
-        new FakeAdbClient() as any,
-        new FakeIOSCtrlProxy() as any
-      );
-      expect(enabled).toBe(false);
-    });
-
-    it("returns 1000ms default long press", () => {
-      expect(strategy.getLongPressDurationMs()).toBe(1000);
-    });
-
-    it("never runs pre-tap stability (Android-only)", () => {
-      expect(
-        strategy.shouldRunPreTapStability({ action: "tap", preTapStability: true } as TapOnElementOptions)
-      ).toBe(false);
-      expect(strategy.shouldRunPreTapStability({ action: "tap" } as TapOnElementOptions)).toBe(false);
-    });
-
-    it("never retries after tap (Android-only)", () => {
-      expect(strategy.shouldRetryTapIfNoChange()).toBe(false);
-    });
-
-    it("returns null when screenSize is missing (caller keeps raw)", () => {
+  describe("IosTapStrategy (platform-specific edge case)", () => {
+    it("returns null when screenSize is missing so the caller keeps the raw hierarchy", () => {
+      const strategy = new IosTapStrategy(iosDevice, new FakeIosVoiceOverDetector());
       const result = strategy.prepareViewHierarchyForResponse(
         minimalHierarchy,
-        buildIosViewHierarchy()
+        buildViewHierarchy(iosDevice)
       );
       expect(result).toBeNull();
-    });
-
-    it("filters the raw hierarchy when screenSize is provided", () => {
-      const result = strategy.prepareViewHierarchyForResponse(
-        minimalHierarchy,
-        buildIosViewHierarchy(),
-        { width: 390, height: 844 }
-      );
-      expect(result).not.toBeNull();
     });
   });
 
@@ -211,40 +189,23 @@ describe("TapStrategy", () => {
     it("returns an AndroidTapStrategy for Android devices", () => {
       const strategy = createTapStrategy(
         androidDevice,
+        new FakeAdbClient() as any,
         new FakeAccessibilityDetector(),
         new FakeIosVoiceOverDetector()
       );
       expect(strategy).toBeInstanceOf(AndroidTapStrategy);
-      expect(strategy.getLongPressDurationMs()).toBe(500);
+      expect(strategy.longPressDurationMs).toBe(500);
     });
 
     it("returns an IosTapStrategy for iOS devices", () => {
       const strategy = createTapStrategy(
         iosDevice,
+        new FakeAdbClient() as any,
         new FakeAccessibilityDetector(),
         new FakeIosVoiceOverDetector()
       );
       expect(strategy).toBeInstanceOf(IosTapStrategy);
-      expect(strategy.getLongPressDurationMs()).toBe(1000);
+      expect(strategy.longPressDurationMs).toBe(1000);
     });
   });
-
-  // Compile-time conformance: each platform-specific concrete class is
-  // assigned to the abstract TapStrategy type. Behavioral coverage lives in
-  // the platform-specific describe blocks above.
-  const platformCases: ReadonlyArray<[string, () => TapStrategy]> = [
-    ["AndroidTapStrategy", () => new AndroidTapStrategy(new FakeAccessibilityDetector())],
-    ["IosTapStrategy", () => new IosTapStrategy(new FakeIosVoiceOverDetector())],
-    ["FakeTapStrategy", () => new FakeTapStrategy()],
-  ];
-  for (const [name, build] of platformCases) {
-    it(`${name} satisfies TapStrategy`, () => {
-      const asStrategy: TapStrategy = build();
-      expect(typeof asStrategy.prepareViewHierarchyForResponse).toBe("function");
-      expect(typeof asStrategy.isAccessibilityServiceEnabled).toBe("function");
-      expect(typeof asStrategy.shouldRunPreTapStability).toBe("function");
-      expect(typeof asStrategy.shouldRetryTapIfNoChange).toBe("function");
-      expect(typeof asStrategy.getLongPressDurationMs).toBe("function");
-    });
-  }
 });


### PR DESCRIPTION
## Summary

Third in the platform-duplication refactor series (after #2182, #2249). Extracts the 7 platform branches in `src/features/action/TapOnElement.ts` (~1640 lines) into a `TapStrategy` interface with two concrete implementations.

After this PR: \`grep "platform === " src/features/action/TapOnElement.ts\` returns **zero** results. The single platform-selection point lives in \`createTapStrategy()\`.

## What moved

| Concern (former branch) | TapStrategy member |
|---|---|
| Response hierarchy filter (Android filterViewHierarchy / iOS filterOffscreenNodes) | \`prepareViewHierarchyForResponse()\` |
| TalkBack vs VoiceOver detection | \`isAccessibilityServiceEnabled()\` |
| Android-only pre-tap stability gate | \`shouldRunPreTapStability(options)\` |
| Android-only retry-on-no-hash-change gate | \`retryTapIfNoChange\` (readonly field) |
| Default long-press duration (500/1000ms) | \`longPressDurationMs\` (readonly field) |

## Design notes

- Two Android-only recovery flows (pre-tap stability, retry-if-no-change) depend on private \`TapOnElement\` state. The strategy is a **gate** for these (returning bools) — the recovery code itself stays where it has natural access to its deps. This removes the platform check at the call site without forcing a circular-dependency abstraction.
- Each strategy captures \`(device, adb, detector)\` deps at construction. \`isAccessibilityServiceEnabled()\` takes no arguments — call sites don't thread both platforms' deps through every invocation.
- \`IosTapStrategy\` resolves \`IOSCtrlProxyClient\` lazily inside its method, so Android paths never touch the iOS singleton.

## Public API preservation

\`TapOnElement\` constructor signature is unchanged; the existing \`TapOnElementDependencies\` options bag gained an optional \`tapStrategy?\` field used only by tests for DI.

## Test plan

- [x] \`bun run lint\` clean
- [x] \`bun build.ts\` succeeds
- [x] Full \`bun test --bail\`: 4207 pass / 1 skip / 0 fail (26s)
- [x] 19 new TapStrategy unit tests covering both strategies via a data-driven \`StrategyCase\` table
- [x] All 9 existing TapOnElement test files (66 tests) pass unmodified
- [x] \`grep "platform === " src/features/action/TapOnElement.ts\` returns 0