### PR TITLE
refactor(system-config): extract SystemConfigurationAdapter from SystemConfigurationManager

### DIFF
--- a/src/features/utility/SystemConfigurationManager.ts
+++ b/src/features/utility/SystemConfigurationManager.ts
@@ -1,12 +1,11 @@
 import { AdbClientFactory, defaultAdbClientFactory } from "../../utils/android-cmdline-tools/AdbClientFactory";
-import type { AdbExecutor } from "../../utils/android-cmdline-tools/interfaces/AdbExecutor";
 import type { ProcessExecutor } from "../../utils/ProcessExecutor";
 import { DefaultProcessExecutor } from "../../utils/ProcessExecutor";
 import { logger } from "../../utils/logger";
 import type { Timer } from "../../utils/SystemTimer";
 import { defaultTimer } from "../../utils/SystemTimer";
-import { AndroidCtrlProxyClient } from "../observe/android/AndroidCtrlProxyClient";
-import type { SettingsNamespace } from "../observe/android";
+import type { SystemConfigurationAdapter } from "../../utils/interfaces/SystemConfigurationAdapter";
+import { createSystemConfigurationAdapter } from "./system-configuration/createSystemConfigurationAdapter";
 import {
   BootedDevice,
   GetCalendarSystemResult,
@@ -18,15 +17,6 @@ import {
   SetTimeZoneResult
 } from "../../models";
 
-type TextDirectionSettingKey = "debug.force_rtl" | "force_rtl";
-
-type CommandAttempt = {
-  method: string;
-  command: string;
-};
-
-const IOS_PHYSICAL_DEVICE_ERROR = "Localization changes are only supported on iOS Simulator.";
-const DEFAULT_CALENDAR_SYSTEM = "gregory";
 const SPRINGBOARD_POLL_INTERVAL_MS = 500;
 const SPRINGBOARD_MAX_RETRIES = 10;
 const BUNDLE_ID_PATTERN = /^[a-zA-Z][a-zA-Z0-9-]*(\.[a-zA-Z][a-zA-Z0-9-]*)+$/;
@@ -39,9 +29,9 @@ export interface ApplyLiveChangesResult {
 
 export class SystemConfigurationManager {
   private device: BootedDevice;
-  private adb: AdbExecutor;
   private processExecutor: ProcessExecutor;
   private timer: Timer;
+  private readonly adapter: SystemConfigurationAdapter;
 
   constructor(
     device: BootedDevice,
@@ -50,9 +40,13 @@ export class SystemConfigurationManager {
     timer: Timer = defaultTimer
   ) {
     this.device = device;
-    this.adb = adbFactory.create(device);
     this.processExecutor = processExecutor;
     this.timer = timer;
+    this.adapter = createSystemConfigurationAdapter(
+      device,
+      adbFactory.create(device),
+      processExecutor
+    );
   }
 
   async setLocale(languageTag: string, options: { broadcast?: boolean } = {}): Promise<SetLocaleResult> {
@@ -64,73 +58,7 @@ export class SystemConfigurationManager {
         error: "languageTag must be a non-empty string"
       };
     }
-
-    if (this.device.platform === "ios") {
-      return this.setLocaleIos(trimmedTag);
-    }
-
-    if (this.device.platform !== "android") {
-      return {
-        success: false,
-        languageTag: trimmedTag,
-        error: this.getPlatformError()
-      };
-    }
-
-    const previousLanguageTag = await this.getCurrentLocaleTag();
-    const apiLevel = await this.getAndroidApiLevel();
-
-    const commandAttempts: CommandAttempt[] = [];
-    const cmdLocaleAttempt = {
-      method: "cmd locale set-locales",
-      command: `shell cmd locale set-locales ${trimmedTag}`
-    };
-    const settingsAttempt = {
-      method: "settings put system user_locale",
-      command: `shell settings put system user_locale ${trimmedTag}`
-    };
-
-    if (apiLevel === null || apiLevel >= 31) {
-      commandAttempts.push(cmdLocaleAttempt, settingsAttempt);
-    } else {
-      commandAttempts.push(settingsAttempt, cmdLocaleAttempt);
-    }
-
-    let appliedMethod: string | null = null;
-    let lastError: string | null = null;
-
-    for (const attempt of commandAttempts) {
-      try {
-        await this.runShellCommand(attempt.command);
-        appliedMethod = attempt.method;
-        break;
-      } catch (error) {
-        const errorMessage = error instanceof Error ? error.message : String(error);
-        lastError = errorMessage;
-        logger.warn(`[SystemConfigurationManager] Failed locale command (${attempt.method}): ${errorMessage}`);
-      }
-    }
-
-    if (!appliedMethod) {
-      return {
-        success: false,
-        languageTag: trimmedTag,
-        previousLanguageTag,
-        error: `Failed to set locale${lastError ? `: ${lastError}` : ""}`
-      };
-    }
-
-    const broadcasted = options.broadcast === false
-      ? false
-      : await this.broadcastLocaleChange();
-
-    return {
-      success: true,
-      languageTag: trimmedTag,
-      previousLanguageTag,
-      method: appliedMethod,
-      broadcasted
-    };
+    return this.adapter.setLocale(trimmedTag, options);
   }
 
   async setTimeZone(zoneId: string): Promise<SetTimeZoneResult> {
@@ -142,154 +70,19 @@ export class SystemConfigurationManager {
         error: "zoneId must be a non-empty string"
       };
     }
-
-    if (this.device.platform === "ios") {
-      return this.setTimeZoneIos(trimmedZone);
-    }
-
-    if (this.device.platform !== "android") {
-      return {
-        success: false,
-        zoneId: trimmedZone,
-        error: this.getPlatformError()
-      };
-    }
-
-    const previousZoneId = await this.readSetting("shell getprop persist.sys.timezone");
-
-    try {
-      await this.adb.executeCommand(`shell setprop persist.sys.timezone ${trimmedZone}`);
-      return {
-        success: true,
-        zoneId: trimmedZone,
-        previousZoneId
-      };
-    } catch (error) {
-      const errorMessage = error instanceof Error ? error.message : String(error);
-      return {
-        success: false,
-        zoneId: trimmedZone,
-        previousZoneId,
-        error: `Failed to set time zone: ${errorMessage}`
-      };
-    }
+    return this.adapter.setTimeZone(trimmedZone);
   }
 
   async setTextDirection(rtl: boolean, options: { broadcast?: boolean } = {}): Promise<SetTextDirectionResult> {
-    if (this.device.platform === "ios") {
-      return {
-        success: false,
-        rtl,
-        error: "Text direction is not supported on iOS. RTL is driven by the app's language; set an RTL locale (e.g., ar_SA) instead."
-      };
-    }
-
-    if (this.device.platform !== "android") {
-      return {
-        success: false,
-        rtl,
-        error: this.getPlatformError()
-      };
-    }
-
-    const debugForceRtl = await this.readSetting("shell settings get global debug.force_rtl");
-    const forceRtl = await this.readSetting("shell settings get global force_rtl");
-    const previousRtl = this.parseBooleanSetting(debugForceRtl ?? forceRtl);
-
-    const targetKeys: TextDirectionSettingKey[] = [];
-    const shouldSetDebug = debugForceRtl !== null || forceRtl === null;
-    const shouldSetForce = forceRtl !== null;
-
-    if (shouldSetDebug) {
-      targetKeys.push("debug.force_rtl");
-    }
-    if (shouldSetForce) {
-      targetKeys.push("force_rtl");
-    }
-    if (targetKeys.length === 0) {
-      targetKeys.push("debug.force_rtl");
-    }
-
-    const appliedSettings: TextDirectionSettingKey[] = [];
-    const value = rtl ? 1 : 0;
-
-    for (const key of targetKeys) {
-      try {
-        await this.runShellCommand(`shell settings put global ${key} ${value}`);
-        appliedSettings.push(key);
-      } catch (error) {
-        logger.warn(`[SystemConfigurationManager] Failed to set ${key}: ${error}`);
-      }
-    }
-
-    if (appliedSettings.length === 0) {
-      return {
-        success: false,
-        rtl,
-        previousRtl,
-        error: "Failed to update RTL settings"
-      };
-    }
-
-    const broadcasted = options.broadcast === false
-      ? false
-      : await this.broadcastLocaleChange();
-
-    return {
-      success: true,
-      rtl,
-      previousRtl,
-      settings: appliedSettings,
-      broadcasted
-    };
+    return this.adapter.setTextDirection(rtl, options);
   }
 
   async broadcastLocaleChange(): Promise<boolean> {
-    if (this.device.platform !== "android") {
-      return false;
-    }
-
-    try {
-      await this.adb.executeCommand("shell am broadcast -a android.intent.action.LOCALE_CHANGED");
-      return true;
-    } catch (error) {
-      logger.warn(`[SystemConfigurationManager] Failed to broadcast localization change: ${error}`);
-      return false;
-    }
+    return this.adapter.broadcastLocaleChange();
   }
 
   async set24HourFormat(enabled: boolean): Promise<Set24HourFormatResult> {
-    if (this.device.platform === "ios") {
-      return this.set24HourFormatIos(enabled);
-    }
-
-    if (this.device.platform !== "android") {
-      return {
-        success: false,
-        enabled,
-        error: this.getPlatformError()
-      };
-    }
-
-    const previousFormat = await this.readSetting("shell settings get system time_12_24");
-    const value = enabled ? "24" : "12";
-
-    try {
-      await this.runShellCommand(`shell settings put system time_12_24 ${value}`);
-      return {
-        success: true,
-        enabled,
-        previousFormat: this.normalizeTimeFormat(previousFormat)
-      };
-    } catch (error) {
-      const errorMessage = error instanceof Error ? error.message : String(error);
-      return {
-        success: false,
-        enabled,
-        previousFormat: this.normalizeTimeFormat(previousFormat),
-        error: `Failed to set 24-hour format: ${errorMessage}`
-      };
-    }
+    return this.adapter.set24HourFormat(enabled);
   }
 
   async setCalendarSystem(calendarSystem: string): Promise<SetCalendarSystemResult> {
@@ -301,306 +94,18 @@ export class SystemConfigurationManager {
         error: "calendarSystem must be a non-empty string"
       };
     }
-
-    if (this.device.platform === "ios") {
-      return this.setCalendarSystemIos(trimmed);
-    }
-
-    if (this.device.platform !== "android") {
-      return {
-        success: false,
-        calendarSystem: trimmed,
-        error: this.getPlatformError()
-      };
-    }
-
-    const previous = await this.getCalendarSystem();
-    const previousCalendarSystem = previous.calendarSystem ?? null;
-
-    try {
-      await this.runShellCommand(`shell settings put system calendar_type ${trimmed}`);
-      const readBack = await this.readSetting("shell settings get system calendar_type");
-      if (!readBack || readBack !== trimmed) {
-        return {
-          success: false,
-          calendarSystem: readBack ?? trimmed,
-          previousCalendarSystem,
-          error: `Read-back verification failed: expected "${trimmed}" but got "${readBack ?? "null"}"`
-        };
-      }
-      return {
-        success: true,
-        calendarSystem: readBack,
-        previousCalendarSystem
-      };
-    } catch (error) {
-      const errorMessage = error instanceof Error ? error.message : String(error);
-      return {
-        success: false,
-        calendarSystem: trimmed,
-        previousCalendarSystem,
-        error: `Failed to set calendar system: ${errorMessage}`
-      };
-    }
+    return this.adapter.setCalendarSystem(trimmed);
   }
 
   async getCalendarSystem(): Promise<GetCalendarSystemResult> {
-    if (this.device.platform === "ios") {
-      return this.getCalendarSystemIos();
-    }
-
-    if (this.device.platform !== "android") {
-      return {
-        success: false,
-        calendarSystem: DEFAULT_CALENDAR_SYSTEM,
-        source: "default",
-        error: this.getPlatformError()
-      };
-    }
-
-    const calendarType = await this.readSetting("shell settings get system calendar_type");
-    if (calendarType) {
-      return {
-        success: true,
-        calendarSystem: calendarType,
-        source: "settings.calendar_type"
-      };
-    }
-
-    const locale = await this.getCurrentLocaleTag();
-    if (locale) {
-      const calendarFromLocale = this.extractCalendarFromLocale(locale);
-      if (calendarFromLocale) {
-        return {
-          success: true,
-          calendarSystem: calendarFromLocale,
-          locale,
-          source: "locale"
-        };
-      }
-    }
-
-    return {
-      success: true,
-      calendarSystem: DEFAULT_CALENDAR_SYSTEM,
-      locale: locale ?? null,
-      source: "default"
-    };
+    return this.adapter.getCalendarSystem();
   }
 
   async getLocalizationSettings(): Promise<LocalizationSettingsResult> {
-    if (this.device.platform === "ios") {
-      return this.getLocalizationSettingsIos();
-    }
-
-    if (this.device.platform !== "android") {
-      return {
-        success: false,
-        error: this.getPlatformError()
-      };
-    }
-
-    const locale = await this.getCurrentLocaleTag();
-    const timeZone = await this.readSetting("shell getprop persist.sys.timezone");
-    const timeFormat = this.normalizeTimeFormat(
-      await this.readSetting("shell settings get system time_12_24")
-    );
-    const debugForceRtl = await this.readSetting("shell settings get global debug.force_rtl");
-    const forceRtl = await this.readSetting("shell settings get global force_rtl");
-    const rtlSetting = this.parseBooleanSetting(debugForceRtl) ?? this.parseBooleanSetting(forceRtl);
-    const textDirection = rtlSetting === null ? null : (rtlSetting ? "rtl" : "ltr");
-    const calendarResult = await this.getCalendarSystem();
-
-    return {
-      success: calendarResult.success,
-      locale,
-      timeZone,
-      textDirection,
-      timeFormat,
-      calendarSystem: calendarResult.calendarSystem ?? null,
-      error: calendarResult.error
-    };
+    return this.adapter.getLocalizationSettings();
   }
 
-  private async getAndroidApiLevel(): Promise<number | null> {
-    try {
-      const result = await this.adb.executeCommand("shell getprop ro.build.version.sdk", undefined, undefined, true);
-      const parsed = Number.parseInt(result.stdout.trim(), 10);
-      if (Number.isNaN(parsed)) {
-        return null;
-      }
-      return parsed;
-    } catch (error) {
-      logger.warn(`[SystemConfigurationManager] Failed to read API level: ${error}`);
-      return null;
-    }
-  }
-
-  private getPlatformError(): string {
-    return `Unsupported platform: ${this.device.platform}`;
-  }
-
-  private normalizeSettingValue(value: string | null): string | null {
-    if (value === null || value === undefined) {
-      return null;
-    }
-    const trimmed = value.trim();
-    if (!trimmed || trimmed === "null" || trimmed === "undefined") {
-      return null;
-    }
-    return trimmed;
-  }
-
-  private normalizeTimeFormat(value: string | null): "12" | "24" | null {
-    const normalized = this.normalizeSettingValue(value);
-    if (normalized === "12" || normalized === "24") {
-      return normalized;
-    }
-    return null;
-  }
-
-  private async readSetting(command: string): Promise<string | null> {
-    const match = command.match(/^shell\s+settings\s+get\s+(system|secure|global)\s+(\S+)\s*$/);
-    if (match && this.device.platform === "android") {
-      const namespace = match[1] as SettingsNamespace;
-      const key = match[2];
-      try {
-        const a11y = AndroidCtrlProxyClient.getInstance(this.device);
-        const a11yResult = await a11y.requestSettingsGet(namespace, key);
-        if (a11yResult.success) {
-          return this.normalizeSettingValue(a11yResult.found ? (a11yResult.value ?? null) : null);
-        }
-      } catch (error) {
-        logger.debug(`[SystemConfigurationManager] a11y settings get failed for ${namespace}/${key}: ${error}`);
-      }
-    }
-    try {
-      const result = await this.adb.executeCommand(command, undefined, undefined, true);
-      return this.normalizeSettingValue(result.stdout);
-    } catch (error) {
-      logger.warn(`[SystemConfigurationManager] Failed to read setting (${command}): ${error}`);
-      return null;
-    }
-  }
-
-  // Intercepts "shell settings put <ns> <key> <value>" and routes through the
-  // accessibility service first, falling back to ADB. Any other shell command
-  // is passed through to adb.executeCommand unchanged.
-  private async runShellCommand(command: string): Promise<void> {
-    const putMatch = command.match(/^shell\s+settings\s+put\s+(system|secure|global)\s+(\S+)\s+(.+)$/);
-    if (putMatch && this.device.platform === "android") {
-      const namespace = putMatch[1] as SettingsNamespace;
-      const key = putMatch[2];
-      const value = putMatch[3].trim();
-      try {
-        const a11y = AndroidCtrlProxyClient.getInstance(this.device);
-        const a11yResult = await a11y.requestSettingsPut(namespace, key, value, "string");
-        if (a11yResult.success) {
-          return;
-        }
-      } catch (error) {
-        logger.debug(`[SystemConfigurationManager] a11y settings put failed for ${namespace}/${key}: ${error}`);
-      }
-    }
-    await this.adb.executeCommand(command);
-  }
-
-  private parseLocaleList(value: string | null): string | null {
-    const normalized = this.normalizeSettingValue(value);
-    if (!normalized) {
-      return null;
-    }
-    const primary = normalized.split(",")[0]?.trim();
-    return primary || null;
-  }
-
-  private parseBooleanSetting(value: string | null): boolean | null {
-    const normalized = this.normalizeSettingValue(value);
-    if (normalized === null) {
-      return null;
-    }
-    const lower = normalized.toLowerCase();
-    if (lower === "1" || lower === "true") {
-      return true;
-    }
-    if (lower === "0" || lower === "false") {
-      return false;
-    }
-    return null;
-  }
-
-  private async getCurrentLocaleTag(): Promise<string | null> {
-    const systemLocales = await this.readSetting("shell settings get system system_locales");
-    const parsedSystemLocale = this.parseLocaleList(systemLocales);
-    if (parsedSystemLocale) {
-      return parsedSystemLocale;
-    }
-
-    const userLocale = await this.readSetting("shell settings get system user_locale");
-    if (userLocale) {
-      return userLocale;
-    }
-
-    const persistedLocale = await this.readSetting("shell getprop persist.sys.locale");
-    if (persistedLocale) {
-      return persistedLocale;
-    }
-
-    const language = await this.readSetting("shell getprop persist.sys.language");
-    if (!language) {
-      return null;
-    }
-
-    const country = await this.readSetting("shell getprop persist.sys.country");
-    if (country) {
-      return `${language}-${country}`;
-    }
-
-    return language;
-  }
-
-  private extractCalendarFromLocale(locale: string): string | null {
-    const normalizedLocale = locale.trim();
-    if (!normalizedLocale) {
-      return null;
-    }
-
-    const keywordMatch = normalizedLocale.match(/@calendar=([a-z0-9-]+)/i);
-    if (keywordMatch && keywordMatch[1]) {
-      return keywordMatch[1];
-    }
-
-    const bcp47Locale = normalizedLocale.replace(/_/g, "-");
-    const extensionIndex = bcp47Locale.toLowerCase().indexOf("-u-");
-    if (extensionIndex === -1) {
-      return null;
-    }
-
-    const extension = bcp47Locale.slice(extensionIndex + 3);
-    const segments = extension.split("-").filter(Boolean);
-
-    let index = 0;
-    while (index < segments.length) {
-      const key = segments[index];
-      if (key.length === 2) {
-        index += 1;
-        const typeSegments: string[] = [];
-        while (index < segments.length && segments[index].length > 2) {
-          typeSegments.push(segments[index]);
-          index += 1;
-        }
-        if (key.toLowerCase() === "ca" && typeSegments.length > 0) {
-          return typeSegments.join("-");
-        }
-      } else {
-        index += 1;
-      }
-    }
-
-    return null;
-  }
-
-  // --- iOS Simulator methods ---
+  // --- iOS Simulator-only public methods ---
 
   private isSimulator(): boolean {
     return /^[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}$/i.test(
@@ -610,27 +115,6 @@ export class SystemConfigurationManager {
 
   private iosSpawnCommand(command: string): string {
     return `xcrun simctl spawn ${this.device.deviceId} ${command}`;
-  }
-
-  private async iosDefaultsRead(domain: string, key: string): Promise<string | null> {
-    try {
-      const result = await this.processExecutor.exec(
-        this.iosSpawnCommand(`defaults read ${domain} ${key}`)
-      );
-      return this.normalizeSettingValue(result.stdout);
-    } catch {
-      return null;
-    }
-  }
-
-  private async iosDefaultsWrite(domain: string, key: string, value: string): Promise<void> {
-    await this.processExecutor.exec(
-      this.iosSpawnCommand(`defaults write ${domain} ${key} ${value}`)
-    );
-  }
-
-  private toAppleLocale(languageTag: string): string {
-    return languageTag.replace(/-/g, "_");
   }
 
   buildAppleLanguages(languageTag: string): string[] {
@@ -724,227 +208,5 @@ export class SystemConfigurationManager {
     }
 
     return result;
-  }
-
-  private async setLocaleIos(languageTag: string): Promise<SetLocaleResult> {
-    if (!this.isSimulator()) {
-      return { success: false, languageTag, error: IOS_PHYSICAL_DEVICE_ERROR };
-    }
-
-    try {
-      const previousLanguageTag = await this.iosDefaultsRead(".GlobalPreferences", "AppleLocale");
-      const appleLocale = this.toAppleLocale(languageTag);
-      await this.iosDefaultsWrite(".GlobalPreferences", "AppleLocale", appleLocale);
-
-      const languages = this.buildAppleLanguages(languageTag);
-      const arrayArgs = languages.map(l => `"${l}"`).join(" ");
-      await this.processExecutor.exec(
-        this.iosSpawnCommand(`defaults write .GlobalPreferences AppleLanguages -array ${arrayArgs}`)
-      );
-
-      const readBack = await this.iosDefaultsRead(".GlobalPreferences", "AppleLocale");
-      if (!readBack || readBack !== appleLocale) {
-        return {
-          success: false,
-          languageTag,
-          previousLanguageTag,
-          error: `Read-back verification failed: expected "${appleLocale}" but got "${readBack ?? "null"}"`
-        };
-      }
-
-      return {
-        success: true,
-        languageTag,
-        previousLanguageTag,
-        appliedLanguages: languages,
-        method: "defaults write AppleLocale + AppleLanguages"
-      };
-    } catch (error) {
-      const errorMessage = error instanceof Error ? error.message : String(error);
-      return {
-        success: false,
-        languageTag,
-        error: `Failed to set locale: ${errorMessage}`
-      };
-    }
-  }
-
-  private async setTimeZoneIos(zoneId: string): Promise<SetTimeZoneResult> {
-    if (!this.isSimulator()) {
-      return { success: false, zoneId, error: IOS_PHYSICAL_DEVICE_ERROR };
-    }
-
-    try {
-      const previousZoneId = await this.iosDefaultsRead(".GlobalPreferences", "AppleTimeZone");
-
-      // Disable auto-timezone before setting
-      await this.iosDefaultsWrite(
-        "com.apple.mobiletimerd",
-        "AutomaticTimeZoneSetting",
-        "-bool NO"
-      );
-
-      await this.iosDefaultsWrite(".GlobalPreferences", "AppleTimeZone", zoneId);
-
-      const readBack = await this.iosDefaultsRead(".GlobalPreferences", "AppleTimeZone");
-      if (!readBack || readBack !== zoneId) {
-        return {
-          success: false,
-          zoneId,
-          previousZoneId,
-          error: `Read-back verification failed: expected "${zoneId}" but got "${readBack ?? "null"}"`
-        };
-      }
-
-      return {
-        success: true,
-        zoneId,
-        previousZoneId
-      };
-    } catch (error) {
-      const errorMessage = error instanceof Error ? error.message : String(error);
-      return {
-        success: false,
-        zoneId,
-        error: `Failed to set time zone: ${errorMessage}`
-      };
-    }
-  }
-
-  private async set24HourFormatIos(enabled: boolean): Promise<Set24HourFormatResult> {
-    if (!this.isSimulator()) {
-      return { success: false, enabled, error: IOS_PHYSICAL_DEVICE_ERROR };
-    }
-
-    try {
-      const previousRaw = await this.iosDefaultsRead(".GlobalPreferences", "AppleICUForce24HourTime");
-      const previousFormat = this.normalizeTimeFormat(
-        previousRaw === "1" ? "24" : previousRaw === "0" ? "12" : previousRaw
-      );
-
-      const boolValue = enabled ? "-bool YES" : "-bool NO";
-      await this.iosDefaultsWrite(".GlobalPreferences", "AppleICUForce24HourTime", boolValue);
-
-      const readBack = await this.iosDefaultsRead(".GlobalPreferences", "AppleICUForce24HourTime");
-      const expectedReadBack = enabled ? "1" : "0";
-      if (!readBack || readBack !== expectedReadBack) {
-        return {
-          success: false,
-          enabled,
-          previousFormat,
-          error: `Read-back verification failed: expected "${expectedReadBack}" but got "${readBack ?? "null"}"`
-        };
-      }
-
-      return {
-        success: true,
-        enabled,
-        previousFormat
-      };
-    } catch (error) {
-      const errorMessage = error instanceof Error ? error.message : String(error);
-      return {
-        success: false,
-        enabled,
-        error: `Failed to set 24-hour format: ${errorMessage}`
-      };
-    }
-  }
-
-  private async setCalendarSystemIos(calendarSystem: string): Promise<SetCalendarSystemResult> {
-    if (!this.isSimulator()) {
-      return { success: false, calendarSystem, error: IOS_PHYSICAL_DEVICE_ERROR };
-    }
-
-    try {
-      const previousCalendarSystem = await this.iosDefaultsRead(".GlobalPreferences", "AppleCalendar");
-      await this.iosDefaultsWrite(".GlobalPreferences", "AppleCalendar", calendarSystem);
-      const readBack = await this.iosDefaultsRead(".GlobalPreferences", "AppleCalendar");
-      if (!readBack || readBack !== calendarSystem) {
-        return {
-          success: false,
-          calendarSystem: readBack ?? calendarSystem,
-          previousCalendarSystem,
-          error: `Read-back verification failed: expected "${calendarSystem}" but got "${readBack ?? "null"}"`
-        };
-      }
-      return {
-        success: true,
-        calendarSystem: readBack,
-        previousCalendarSystem
-      };
-    } catch (error) {
-      const errorMessage = error instanceof Error ? error.message : String(error);
-      return {
-        success: false,
-        calendarSystem,
-        error: `Failed to set calendar system: ${errorMessage}`
-      };
-    }
-  }
-
-  private async getCalendarSystemIos(): Promise<GetCalendarSystemResult> {
-    if (!this.isSimulator()) {
-      return {
-        success: false,
-        calendarSystem: DEFAULT_CALENDAR_SYSTEM,
-        source: "default",
-        error: IOS_PHYSICAL_DEVICE_ERROR
-      };
-    }
-
-    const calendar = await this.iosDefaultsRead(".GlobalPreferences", "AppleCalendar");
-    if (calendar) {
-      return {
-        success: true,
-        calendarSystem: calendar,
-        source: "default"
-      };
-    }
-
-    const locale = await this.iosDefaultsRead(".GlobalPreferences", "AppleLocale");
-    if (locale) {
-      const calendarFromLocale = this.extractCalendarFromLocale(locale);
-      if (calendarFromLocale) {
-        return {
-          success: true,
-          calendarSystem: calendarFromLocale,
-          locale,
-          source: "locale"
-        };
-      }
-    }
-
-    return {
-      success: true,
-      calendarSystem: DEFAULT_CALENDAR_SYSTEM,
-      locale: locale ?? null,
-      source: "default"
-    };
-  }
-
-  private async getLocalizationSettingsIos(): Promise<LocalizationSettingsResult> {
-    if (!this.isSimulator()) {
-      return { success: false, error: IOS_PHYSICAL_DEVICE_ERROR };
-    }
-
-    const locale = await this.iosDefaultsRead(".GlobalPreferences", "AppleLocale");
-    const languages = await this.iosDefaultsRead(".GlobalPreferences", "AppleLanguages");
-    const timeZone = await this.iosDefaultsRead(".GlobalPreferences", "AppleTimeZone");
-    const timeFormatRaw = await this.iosDefaultsRead(".GlobalPreferences", "AppleICUForce24HourTime");
-    const timeFormat = this.normalizeTimeFormat(
-      timeFormatRaw === "1" ? "24" : timeFormatRaw === "0" ? "12" : timeFormatRaw
-    );
-    const calendarResult = await this.getCalendarSystemIos();
-
-    return {
-      success: true,
-      locale,
-      languages,
-      timeZone,
-      textDirection: null,
-      timeFormat,
-      calendarSystem: calendarResult.calendarSystem ?? null
-    };
   }
 }

--- a/src/features/utility/SystemConfigurationManager.ts
+++ b/src/features/utility/SystemConfigurationManager.ts
@@ -6,6 +6,7 @@ import type { Timer } from "../../utils/SystemTimer";
 import { defaultTimer } from "../../utils/SystemTimer";
 import type { SystemConfigurationAdapter } from "../../utils/interfaces/SystemConfigurationAdapter";
 import { createSystemConfigurationAdapter } from "./system-configuration/createSystemConfigurationAdapter";
+import { buildAppleLanguages, iosSpawnCommand, isIosSimulator } from "./system-configuration/iosHelpers";
 import {
   BootedDevice,
   GetCalendarSystemResult,
@@ -107,36 +108,19 @@ export class SystemConfigurationManager {
 
   // --- iOS Simulator-only public methods ---
 
-  private isSimulator(): boolean {
-    return /^[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}$/i.test(
-      this.device.deviceId
-    );
-  }
-
-  private iosSpawnCommand(command: string): string {
-    return `xcrun simctl spawn ${this.device.deviceId} ${command}`;
-  }
-
+  /** Build Apple's fallback language chain for the AppleLanguages defaults key. */
   buildAppleLanguages(languageTag: string): string[] {
-    const languages: string[] = [languageTag];
-    const parts = languageTag.split("-");
-    for (let i = parts.length - 1; i >= 1; i--) {
-      const shorter = parts.slice(0, i).join("-");
-      if (!languages.includes(shorter)) {
-        languages.push(shorter);
-      }
-    }
-    return languages;
+    return buildAppleLanguages(languageTag);
   }
 
   async restartSpringBoard(): Promise<boolean> {
-    if (!this.isSimulator()) {
+    if (!isIosSimulator(this.device.deviceId)) {
       return false;
     }
 
     try {
       await this.processExecutor.exec(
-        this.iosSpawnCommand("launchctl stop com.apple.SpringBoard")
+        iosSpawnCommand(this.device.deviceId, "launchctl stop com.apple.SpringBoard")
       );
     } catch (error) {
       logger.warn(`[SystemConfigurationManager] Failed to stop SpringBoard: ${error}`);
@@ -147,7 +131,7 @@ export class SystemConfigurationManager {
       await this.timer.sleep(SPRINGBOARD_POLL_INTERVAL_MS);
       try {
         const result = await this.processExecutor.exec(
-          this.iosSpawnCommand("launchctl list com.apple.SpringBoard")
+          iosSpawnCommand(this.device.deviceId, "launchctl list com.apple.SpringBoard")
         );
         if (result.stdout && result.stdout.includes("SpringBoard")) {
           return true;
@@ -162,13 +146,13 @@ export class SystemConfigurationManager {
   }
 
   async postLocaleChangeNotification(): Promise<boolean> {
-    if (!this.isSimulator()) {
+    if (!isIosSimulator(this.device.deviceId)) {
       return false;
     }
 
     try {
       await this.processExecutor.exec(
-        this.iosSpawnCommand("notifyutil -p com.apple.language.changed")
+        iosSpawnCommand(this.device.deviceId, "notifyutil -p com.apple.language.changed")
       );
       return true;
     } catch (error) {

--- a/src/features/utility/system-configuration/AndroidSystemConfigurationAdapter.ts
+++ b/src/features/utility/system-configuration/AndroidSystemConfigurationAdapter.ts
@@ -1,0 +1,389 @@
+import type { AdbExecutor } from "../../../utils/android-cmdline-tools/interfaces/AdbExecutor";
+import { logger } from "../../../utils/logger";
+import { AndroidCtrlProxyClient } from "../../observe/android/AndroidCtrlProxyClient";
+import type { SettingsNamespace } from "../../observe/android";
+import type {
+  BootedDevice,
+  GetCalendarSystemResult,
+  LocalizationSettingsResult,
+  Set24HourFormatResult,
+  SetCalendarSystemResult,
+  SetLocaleResult,
+  SetTextDirectionResult,
+  SetTimeZoneResult,
+} from "../../../models";
+import type {
+  BroadcastOptions,
+  SystemConfigurationAdapter,
+} from "../../../utils/interfaces/SystemConfigurationAdapter";
+import {
+  extractCalendarFromLocale,
+  normalizeSettingValue,
+  normalizeTimeFormat,
+  parseBooleanSetting,
+  parseLocaleList,
+} from "./parsing";
+
+type TextDirectionSettingKey = "debug.force_rtl" | "force_rtl";
+
+type CommandAttempt = {
+  method: string;
+  command: string;
+};
+
+/**
+ * Android implementation of {@link SystemConfigurationAdapter}. Uses
+ * ADB shell commands (with an accessibility-service fast path for
+ * `settings get`/`settings put`) and `getprop`/`setprop` to read and
+ * write locale, time zone, RTL, 24-hour format, and calendar
+ * settings.
+ */
+export class AndroidSystemConfigurationAdapter implements SystemConfigurationAdapter {
+  readonly defaultCalendarSystem = "gregory";
+
+  constructor(
+    private readonly device: BootedDevice,
+    private readonly adb: AdbExecutor
+  ) {}
+
+  async setLocale(languageTag: string, options: BroadcastOptions): Promise<SetLocaleResult> {
+    const previousLanguageTag = await this.getCurrentLocaleTag();
+    const apiLevel = await this.getAndroidApiLevel();
+
+    const commandAttempts: CommandAttempt[] = [];
+    const cmdLocaleAttempt = {
+      method: "cmd locale set-locales",
+      command: `shell cmd locale set-locales ${languageTag}`
+    };
+    const settingsAttempt = {
+      method: "settings put system user_locale",
+      command: `shell settings put system user_locale ${languageTag}`
+    };
+
+    if (apiLevel === null || apiLevel >= 31) {
+      commandAttempts.push(cmdLocaleAttempt, settingsAttempt);
+    } else {
+      commandAttempts.push(settingsAttempt, cmdLocaleAttempt);
+    }
+
+    let appliedMethod: string | null = null;
+    let lastError: string | null = null;
+
+    for (const attempt of commandAttempts) {
+      try {
+        await this.runShellCommand(attempt.command);
+        appliedMethod = attempt.method;
+        break;
+      } catch (error) {
+        const errorMessage = error instanceof Error ? error.message : String(error);
+        lastError = errorMessage;
+        logger.warn(`[SystemConfigurationManager] Failed locale command (${attempt.method}): ${errorMessage}`);
+      }
+    }
+
+    if (!appliedMethod) {
+      return {
+        success: false,
+        languageTag,
+        previousLanguageTag,
+        error: `Failed to set locale${lastError ? `: ${lastError}` : ""}`
+      };
+    }
+
+    const broadcasted = options.broadcast === false
+      ? false
+      : await this.broadcastLocaleChange();
+
+    return {
+      success: true,
+      languageTag,
+      previousLanguageTag,
+      method: appliedMethod,
+      broadcasted
+    };
+  }
+
+  async setTimeZone(zoneId: string): Promise<SetTimeZoneResult> {
+    const previousZoneId = await this.readSetting("shell getprop persist.sys.timezone");
+
+    try {
+      await this.adb.executeCommand(`shell setprop persist.sys.timezone ${zoneId}`);
+      return {
+        success: true,
+        zoneId,
+        previousZoneId
+      };
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : String(error);
+      return {
+        success: false,
+        zoneId,
+        previousZoneId,
+        error: `Failed to set time zone: ${errorMessage}`
+      };
+    }
+  }
+
+  async setTextDirection(rtl: boolean, options: BroadcastOptions): Promise<SetTextDirectionResult> {
+    const debugForceRtl = await this.readSetting("shell settings get global debug.force_rtl");
+    const forceRtl = await this.readSetting("shell settings get global force_rtl");
+    const previousRtl = parseBooleanSetting(debugForceRtl ?? forceRtl);
+
+    const targetKeys: TextDirectionSettingKey[] = [];
+    const shouldSetDebug = debugForceRtl !== null || forceRtl === null;
+    const shouldSetForce = forceRtl !== null;
+
+    if (shouldSetDebug) {
+      targetKeys.push("debug.force_rtl");
+    }
+    if (shouldSetForce) {
+      targetKeys.push("force_rtl");
+    }
+    if (targetKeys.length === 0) {
+      targetKeys.push("debug.force_rtl");
+    }
+
+    const appliedSettings: TextDirectionSettingKey[] = [];
+    const value = rtl ? 1 : 0;
+
+    for (const key of targetKeys) {
+      try {
+        await this.runShellCommand(`shell settings put global ${key} ${value}`);
+        appliedSettings.push(key);
+      } catch (error) {
+        logger.warn(`[SystemConfigurationManager] Failed to set ${key}: ${error}`);
+      }
+    }
+
+    if (appliedSettings.length === 0) {
+      return {
+        success: false,
+        rtl,
+        previousRtl,
+        error: "Failed to update RTL settings"
+      };
+    }
+
+    const broadcasted = options.broadcast === false
+      ? false
+      : await this.broadcastLocaleChange();
+
+    return {
+      success: true,
+      rtl,
+      previousRtl,
+      settings: appliedSettings,
+      broadcasted
+    };
+  }
+
+  async set24HourFormat(enabled: boolean): Promise<Set24HourFormatResult> {
+    const previousFormat = await this.readSetting("shell settings get system time_12_24");
+    const value = enabled ? "24" : "12";
+
+    try {
+      await this.runShellCommand(`shell settings put system time_12_24 ${value}`);
+      return {
+        success: true,
+        enabled,
+        previousFormat: normalizeTimeFormat(previousFormat)
+      };
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : String(error);
+      return {
+        success: false,
+        enabled,
+        previousFormat: normalizeTimeFormat(previousFormat),
+        error: `Failed to set 24-hour format: ${errorMessage}`
+      };
+    }
+  }
+
+  async setCalendarSystem(calendarSystem: string): Promise<SetCalendarSystemResult> {
+    const previous = await this.getCalendarSystem();
+    const previousCalendarSystem = previous.calendarSystem ?? null;
+
+    try {
+      await this.runShellCommand(`shell settings put system calendar_type ${calendarSystem}`);
+      const readBack = await this.readSetting("shell settings get system calendar_type");
+      if (!readBack || readBack !== calendarSystem) {
+        return {
+          success: false,
+          calendarSystem: readBack ?? calendarSystem,
+          previousCalendarSystem,
+          error: `Read-back verification failed: expected "${calendarSystem}" but got "${readBack ?? "null"}"`
+        };
+      }
+      return {
+        success: true,
+        calendarSystem: readBack,
+        previousCalendarSystem
+      };
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : String(error);
+      return {
+        success: false,
+        calendarSystem,
+        previousCalendarSystem,
+        error: `Failed to set calendar system: ${errorMessage}`
+      };
+    }
+  }
+
+  async getCalendarSystem(): Promise<GetCalendarSystemResult> {
+    const calendarType = await this.readSetting("shell settings get system calendar_type");
+    if (calendarType) {
+      return {
+        success: true,
+        calendarSystem: calendarType,
+        source: "settings.calendar_type"
+      };
+    }
+
+    const locale = await this.getCurrentLocaleTag();
+    if (locale) {
+      const calendarFromLocale = extractCalendarFromLocale(locale);
+      if (calendarFromLocale) {
+        return {
+          success: true,
+          calendarSystem: calendarFromLocale,
+          locale,
+          source: "locale"
+        };
+      }
+    }
+
+    return {
+      success: true,
+      calendarSystem: this.defaultCalendarSystem,
+      locale: locale ?? null,
+      source: "default"
+    };
+  }
+
+  async getLocalizationSettings(): Promise<LocalizationSettingsResult> {
+    const locale = await this.getCurrentLocaleTag();
+    const timeZone = await this.readSetting("shell getprop persist.sys.timezone");
+    const timeFormat = normalizeTimeFormat(
+      await this.readSetting("shell settings get system time_12_24")
+    );
+    const debugForceRtl = await this.readSetting("shell settings get global debug.force_rtl");
+    const forceRtl = await this.readSetting("shell settings get global force_rtl");
+    const rtlSetting = parseBooleanSetting(debugForceRtl) ?? parseBooleanSetting(forceRtl);
+    const textDirection = rtlSetting === null ? null : (rtlSetting ? "rtl" : "ltr");
+    const calendarResult = await this.getCalendarSystem();
+
+    return {
+      success: calendarResult.success,
+      locale,
+      timeZone,
+      textDirection,
+      timeFormat,
+      calendarSystem: calendarResult.calendarSystem ?? null,
+      error: calendarResult.error
+    };
+  }
+
+  async broadcastLocaleChange(): Promise<boolean> {
+    try {
+      await this.adb.executeCommand("shell am broadcast -a android.intent.action.LOCALE_CHANGED");
+      return true;
+    } catch (error) {
+      logger.warn(`[SystemConfigurationManager] Failed to broadcast localization change: ${error}`);
+      return false;
+    }
+  }
+
+  private async getAndroidApiLevel(): Promise<number | null> {
+    try {
+      const result = await this.adb.executeCommand("shell getprop ro.build.version.sdk", undefined, undefined, true);
+      const parsed = Number.parseInt(result.stdout.trim(), 10);
+      if (Number.isNaN(parsed)) {
+        return null;
+      }
+      return parsed;
+    } catch (error) {
+      logger.warn(`[SystemConfigurationManager] Failed to read API level: ${error}`);
+      return null;
+    }
+  }
+
+  // Tries the accessibility-service fast path for `settings get …`
+  // first, then falls back to ADB. Any other shell command is passed
+  // straight through to `adb.executeCommand`.
+  private async readSetting(command: string): Promise<string | null> {
+    const match = command.match(/^shell\s+settings\s+get\s+(system|secure|global)\s+(\S+)\s*$/);
+    if (match) {
+      const namespace = match[1] as SettingsNamespace;
+      const key = match[2];
+      try {
+        const a11y = AndroidCtrlProxyClient.getInstance(this.device);
+        const a11yResult = await a11y.requestSettingsGet(namespace, key);
+        if (a11yResult.success) {
+          return normalizeSettingValue(a11yResult.found ? (a11yResult.value ?? null) : null);
+        }
+      } catch (error) {
+        logger.debug(`[SystemConfigurationManager] a11y settings get failed for ${namespace}/${key}: ${error}`);
+      }
+    }
+    try {
+      const result = await this.adb.executeCommand(command, undefined, undefined, true);
+      return normalizeSettingValue(result.stdout);
+    } catch (error) {
+      logger.warn(`[SystemConfigurationManager] Failed to read setting (${command}): ${error}`);
+      return null;
+    }
+  }
+
+  // Intercepts `shell settings put <ns> <key> <value>` and routes
+  // through the accessibility service first, falling back to ADB. Any
+  // other shell command is passed through to `adb.executeCommand`.
+  private async runShellCommand(command: string): Promise<void> {
+    const putMatch = command.match(/^shell\s+settings\s+put\s+(system|secure|global)\s+(\S+)\s+(.+)$/);
+    if (putMatch) {
+      const namespace = putMatch[1] as SettingsNamespace;
+      const key = putMatch[2];
+      const value = putMatch[3].trim();
+      try {
+        const a11y = AndroidCtrlProxyClient.getInstance(this.device);
+        const a11yResult = await a11y.requestSettingsPut(namespace, key, value, "string");
+        if (a11yResult.success) {
+          return;
+        }
+      } catch (error) {
+        logger.debug(`[SystemConfigurationManager] a11y settings put failed for ${namespace}/${key}: ${error}`);
+      }
+    }
+    await this.adb.executeCommand(command);
+  }
+
+  private async getCurrentLocaleTag(): Promise<string | null> {
+    const systemLocales = await this.readSetting("shell settings get system system_locales");
+    const parsedSystemLocale = parseLocaleList(systemLocales);
+    if (parsedSystemLocale) {
+      return parsedSystemLocale;
+    }
+
+    const userLocale = await this.readSetting("shell settings get system user_locale");
+    if (userLocale) {
+      return userLocale;
+    }
+
+    const persistedLocale = await this.readSetting("shell getprop persist.sys.locale");
+    if (persistedLocale) {
+      return persistedLocale;
+    }
+
+    const language = await this.readSetting("shell getprop persist.sys.language");
+    if (!language) {
+      return null;
+    }
+
+    const country = await this.readSetting("shell getprop persist.sys.country");
+    if (country) {
+      return `${language}-${country}`;
+    }
+
+    return language;
+  }
+}

--- a/src/features/utility/system-configuration/AndroidSystemConfigurationAdapter.ts
+++ b/src/features/utility/system-configuration/AndroidSystemConfigurationAdapter.ts
@@ -1,4 +1,5 @@
 import type { AdbExecutor } from "../../../utils/android-cmdline-tools/interfaces/AdbExecutor";
+import { readAndroidDeviceApiLevel } from "../../../utils/android-cmdline-tools/readAndroidDeviceApiLevel";
 import { logger } from "../../../utils/logger";
 import { AndroidCtrlProxyClient } from "../../observe/android/AndroidCtrlProxyClient";
 import type { SettingsNamespace } from "../../observe/android";
@@ -48,7 +49,7 @@ export class AndroidSystemConfigurationAdapter implements SystemConfigurationAda
 
   async setLocale(languageTag: string, options: BroadcastOptions): Promise<SetLocaleResult> {
     const previousLanguageTag = await this.getCurrentLocaleTag();
-    const apiLevel = await this.getAndroidApiLevel();
+    const apiLevel = await readAndroidDeviceApiLevel(this.adb);
 
     const commandAttempts: CommandAttempt[] = [];
     const cmdLocaleAttempt = {
@@ -291,20 +292,6 @@ export class AndroidSystemConfigurationAdapter implements SystemConfigurationAda
     } catch (error) {
       logger.warn(`[SystemConfigurationManager] Failed to broadcast localization change: ${error}`);
       return false;
-    }
-  }
-
-  private async getAndroidApiLevel(): Promise<number | null> {
-    try {
-      const result = await this.adb.executeCommand("shell getprop ro.build.version.sdk", undefined, undefined, true);
-      const parsed = Number.parseInt(result.stdout.trim(), 10);
-      if (Number.isNaN(parsed)) {
-        return null;
-      }
-      return parsed;
-    } catch (error) {
-      logger.warn(`[SystemConfigurationManager] Failed to read API level: ${error}`);
-      return null;
     }
   }
 

--- a/src/features/utility/system-configuration/IosSystemConfigurationAdapter.ts
+++ b/src/features/utility/system-configuration/IosSystemConfigurationAdapter.ts
@@ -18,10 +18,15 @@ import {
   normalizeSettingValue,
   normalizeTimeFormat,
 } from "./parsing";
+import {
+  buildAppleLanguages,
+  iosSpawnCommand,
+  isIosSimulator,
+  parseAppleTimeFormatRaw,
+} from "./iosHelpers";
 
 const IOS_PHYSICAL_DEVICE_ERROR = "Localization changes are only supported on iOS Simulator.";
 const DEFAULT_CALENDAR_SYSTEM = "gregory";
-const SIMULATOR_UDID_PATTERN = /^[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}$/i;
 
 /**
  * iOS implementation of {@link SystemConfigurationAdapter}. Routes
@@ -49,7 +54,7 @@ export class IosSystemConfigurationAdapter implements SystemConfigurationAdapter
       const languages = this.buildAppleLanguages(languageTag);
       const arrayArgs = languages.map(l => `"${l}"`).join(" ");
       await this.processExecutor.exec(
-        this.iosSpawnCommand(`defaults write .GlobalPreferences AppleLanguages -array ${arrayArgs}`)
+        iosSpawnCommand(this.device.deviceId, `defaults write .GlobalPreferences AppleLanguages -array ${arrayArgs}`)
       );
 
       const readBack = await this.iosDefaultsRead(".GlobalPreferences", "AppleLocale");
@@ -136,9 +141,7 @@ export class IosSystemConfigurationAdapter implements SystemConfigurationAdapter
 
     try {
       const previousRaw = await this.iosDefaultsRead(".GlobalPreferences", "AppleICUForce24HourTime");
-      const previousFormat = normalizeTimeFormat(
-        previousRaw === "1" ? "24" : previousRaw === "0" ? "12" : previousRaw
-      );
+      const previousFormat = normalizeTimeFormat(parseAppleTimeFormatRaw(previousRaw));
 
       const boolValue = enabled ? "-bool YES" : "-bool NO";
       await this.iosDefaultsWrite(".GlobalPreferences", "AppleICUForce24HourTime", boolValue);
@@ -250,9 +253,7 @@ export class IosSystemConfigurationAdapter implements SystemConfigurationAdapter
     const languages = await this.iosDefaultsRead(".GlobalPreferences", "AppleLanguages");
     const timeZone = await this.iosDefaultsRead(".GlobalPreferences", "AppleTimeZone");
     const timeFormatRaw = await this.iosDefaultsRead(".GlobalPreferences", "AppleICUForce24HourTime");
-    const timeFormat = normalizeTimeFormat(
-      timeFormatRaw === "1" ? "24" : timeFormatRaw === "0" ? "12" : timeFormatRaw
-    );
+    const timeFormat = normalizeTimeFormat(parseAppleTimeFormatRaw(timeFormatRaw));
     const calendarResult = await this.getCalendarSystem();
 
     return {
@@ -273,29 +274,17 @@ export class IosSystemConfigurationAdapter implements SystemConfigurationAdapter
   }
 
   buildAppleLanguages(languageTag: string): string[] {
-    const languages: string[] = [languageTag];
-    const parts = languageTag.split("-");
-    for (let i = parts.length - 1; i >= 1; i--) {
-      const shorter = parts.slice(0, i).join("-");
-      if (!languages.includes(shorter)) {
-        languages.push(shorter);
-      }
-    }
-    return languages;
+    return buildAppleLanguages(languageTag);
   }
 
   private isSimulator(): boolean {
-    return SIMULATOR_UDID_PATTERN.test(this.device.deviceId);
-  }
-
-  private iosSpawnCommand(command: string): string {
-    return `xcrun simctl spawn ${this.device.deviceId} ${command}`;
+    return isIosSimulator(this.device.deviceId);
   }
 
   private async iosDefaultsRead(domain: string, key: string): Promise<string | null> {
     try {
       const result = await this.processExecutor.exec(
-        this.iosSpawnCommand(`defaults read ${domain} ${key}`)
+        iosSpawnCommand(this.device.deviceId, `defaults read ${domain} ${key}`)
       );
       return normalizeSettingValue(result.stdout);
     } catch {
@@ -305,7 +294,7 @@ export class IosSystemConfigurationAdapter implements SystemConfigurationAdapter
 
   private async iosDefaultsWrite(domain: string, key: string, value: string): Promise<void> {
     await this.processExecutor.exec(
-      this.iosSpawnCommand(`defaults write ${domain} ${key} ${value}`)
+      iosSpawnCommand(this.device.deviceId, `defaults write ${domain} ${key} ${value}`)
     );
   }
 

--- a/src/features/utility/system-configuration/IosSystemConfigurationAdapter.ts
+++ b/src/features/utility/system-configuration/IosSystemConfigurationAdapter.ts
@@ -1,0 +1,315 @@
+import type { ProcessExecutor } from "../../../utils/ProcessExecutor";
+import type {
+  BootedDevice,
+  GetCalendarSystemResult,
+  LocalizationSettingsResult,
+  Set24HourFormatResult,
+  SetCalendarSystemResult,
+  SetLocaleResult,
+  SetTextDirectionResult,
+  SetTimeZoneResult,
+} from "../../../models";
+import type {
+  BroadcastOptions,
+  SystemConfigurationAdapter,
+} from "../../../utils/interfaces/SystemConfigurationAdapter";
+import {
+  extractCalendarFromLocale,
+  normalizeSettingValue,
+  normalizeTimeFormat,
+} from "./parsing";
+
+const IOS_PHYSICAL_DEVICE_ERROR = "Localization changes are only supported on iOS Simulator.";
+const DEFAULT_CALENDAR_SYSTEM = "gregory";
+const SIMULATOR_UDID_PATTERN = /^[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}$/i;
+
+/**
+ * iOS implementation of {@link SystemConfigurationAdapter}. Routes
+ * reads and writes through `xcrun simctl spawn … defaults`, so only
+ * simulators are supported — physical devices return an error result.
+ */
+export class IosSystemConfigurationAdapter implements SystemConfigurationAdapter {
+  readonly defaultCalendarSystem = DEFAULT_CALENDAR_SYSTEM;
+
+  constructor(
+    private readonly device: BootedDevice,
+    private readonly processExecutor: ProcessExecutor
+  ) {}
+
+  async setLocale(languageTag: string, _options: BroadcastOptions): Promise<SetLocaleResult> {
+    if (!this.isSimulator()) {
+      return { success: false, languageTag, error: IOS_PHYSICAL_DEVICE_ERROR };
+    }
+
+    try {
+      const previousLanguageTag = await this.iosDefaultsRead(".GlobalPreferences", "AppleLocale");
+      const appleLocale = this.toAppleLocale(languageTag);
+      await this.iosDefaultsWrite(".GlobalPreferences", "AppleLocale", appleLocale);
+
+      const languages = this.buildAppleLanguages(languageTag);
+      const arrayArgs = languages.map(l => `"${l}"`).join(" ");
+      await this.processExecutor.exec(
+        this.iosSpawnCommand(`defaults write .GlobalPreferences AppleLanguages -array ${arrayArgs}`)
+      );
+
+      const readBack = await this.iosDefaultsRead(".GlobalPreferences", "AppleLocale");
+      if (!readBack || readBack !== appleLocale) {
+        return {
+          success: false,
+          languageTag,
+          previousLanguageTag,
+          error: `Read-back verification failed: expected "${appleLocale}" but got "${readBack ?? "null"}"`
+        };
+      }
+
+      return {
+        success: true,
+        languageTag,
+        previousLanguageTag,
+        appliedLanguages: languages,
+        method: "defaults write AppleLocale + AppleLanguages"
+      };
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : String(error);
+      return {
+        success: false,
+        languageTag,
+        error: `Failed to set locale: ${errorMessage}`
+      };
+    }
+  }
+
+  async setTimeZone(zoneId: string): Promise<SetTimeZoneResult> {
+    if (!this.isSimulator()) {
+      return { success: false, zoneId, error: IOS_PHYSICAL_DEVICE_ERROR };
+    }
+
+    try {
+      const previousZoneId = await this.iosDefaultsRead(".GlobalPreferences", "AppleTimeZone");
+
+      // Disable auto-timezone before setting
+      await this.iosDefaultsWrite(
+        "com.apple.mobiletimerd",
+        "AutomaticTimeZoneSetting",
+        "-bool NO"
+      );
+
+      await this.iosDefaultsWrite(".GlobalPreferences", "AppleTimeZone", zoneId);
+
+      const readBack = await this.iosDefaultsRead(".GlobalPreferences", "AppleTimeZone");
+      if (!readBack || readBack !== zoneId) {
+        return {
+          success: false,
+          zoneId,
+          previousZoneId,
+          error: `Read-back verification failed: expected "${zoneId}" but got "${readBack ?? "null"}"`
+        };
+      }
+
+      return {
+        success: true,
+        zoneId,
+        previousZoneId
+      };
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : String(error);
+      return {
+        success: false,
+        zoneId,
+        error: `Failed to set time zone: ${errorMessage}`
+      };
+    }
+  }
+
+  async setTextDirection(rtl: boolean, _options: BroadcastOptions): Promise<SetTextDirectionResult> {
+    return {
+      success: false,
+      rtl,
+      error: "Text direction is not supported on iOS. RTL is driven by the app's language; set an RTL locale (e.g., ar_SA) instead."
+    };
+  }
+
+  async set24HourFormat(enabled: boolean): Promise<Set24HourFormatResult> {
+    if (!this.isSimulator()) {
+      return { success: false, enabled, error: IOS_PHYSICAL_DEVICE_ERROR };
+    }
+
+    try {
+      const previousRaw = await this.iosDefaultsRead(".GlobalPreferences", "AppleICUForce24HourTime");
+      const previousFormat = normalizeTimeFormat(
+        previousRaw === "1" ? "24" : previousRaw === "0" ? "12" : previousRaw
+      );
+
+      const boolValue = enabled ? "-bool YES" : "-bool NO";
+      await this.iosDefaultsWrite(".GlobalPreferences", "AppleICUForce24HourTime", boolValue);
+
+      const readBack = await this.iosDefaultsRead(".GlobalPreferences", "AppleICUForce24HourTime");
+      const expectedReadBack = enabled ? "1" : "0";
+      if (!readBack || readBack !== expectedReadBack) {
+        return {
+          success: false,
+          enabled,
+          previousFormat,
+          error: `Read-back verification failed: expected "${expectedReadBack}" but got "${readBack ?? "null"}"`
+        };
+      }
+
+      return {
+        success: true,
+        enabled,
+        previousFormat
+      };
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : String(error);
+      return {
+        success: false,
+        enabled,
+        error: `Failed to set 24-hour format: ${errorMessage}`
+      };
+    }
+  }
+
+  async setCalendarSystem(calendarSystem: string): Promise<SetCalendarSystemResult> {
+    if (!this.isSimulator()) {
+      return { success: false, calendarSystem, error: IOS_PHYSICAL_DEVICE_ERROR };
+    }
+
+    try {
+      const previousCalendarSystem = await this.iosDefaultsRead(".GlobalPreferences", "AppleCalendar");
+      await this.iosDefaultsWrite(".GlobalPreferences", "AppleCalendar", calendarSystem);
+      const readBack = await this.iosDefaultsRead(".GlobalPreferences", "AppleCalendar");
+      if (!readBack || readBack !== calendarSystem) {
+        return {
+          success: false,
+          calendarSystem: readBack ?? calendarSystem,
+          previousCalendarSystem,
+          error: `Read-back verification failed: expected "${calendarSystem}" but got "${readBack ?? "null"}"`
+        };
+      }
+      return {
+        success: true,
+        calendarSystem: readBack,
+        previousCalendarSystem
+      };
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : String(error);
+      return {
+        success: false,
+        calendarSystem,
+        error: `Failed to set calendar system: ${errorMessage}`
+      };
+    }
+  }
+
+  async getCalendarSystem(): Promise<GetCalendarSystemResult> {
+    if (!this.isSimulator()) {
+      return {
+        success: false,
+        calendarSystem: DEFAULT_CALENDAR_SYSTEM,
+        source: "default",
+        error: IOS_PHYSICAL_DEVICE_ERROR
+      };
+    }
+
+    const calendar = await this.iosDefaultsRead(".GlobalPreferences", "AppleCalendar");
+    if (calendar) {
+      return {
+        success: true,
+        calendarSystem: calendar,
+        source: "default"
+      };
+    }
+
+    const locale = await this.iosDefaultsRead(".GlobalPreferences", "AppleLocale");
+    if (locale) {
+      const calendarFromLocale = extractCalendarFromLocale(locale);
+      if (calendarFromLocale) {
+        return {
+          success: true,
+          calendarSystem: calendarFromLocale,
+          locale,
+          source: "locale"
+        };
+      }
+    }
+
+    return {
+      success: true,
+      calendarSystem: DEFAULT_CALENDAR_SYSTEM,
+      locale: locale ?? null,
+      source: "default"
+    };
+  }
+
+  async getLocalizationSettings(): Promise<LocalizationSettingsResult> {
+    if (!this.isSimulator()) {
+      return { success: false, error: IOS_PHYSICAL_DEVICE_ERROR };
+    }
+
+    const locale = await this.iosDefaultsRead(".GlobalPreferences", "AppleLocale");
+    const languages = await this.iosDefaultsRead(".GlobalPreferences", "AppleLanguages");
+    const timeZone = await this.iosDefaultsRead(".GlobalPreferences", "AppleTimeZone");
+    const timeFormatRaw = await this.iosDefaultsRead(".GlobalPreferences", "AppleICUForce24HourTime");
+    const timeFormat = normalizeTimeFormat(
+      timeFormatRaw === "1" ? "24" : timeFormatRaw === "0" ? "12" : timeFormatRaw
+    );
+    const calendarResult = await this.getCalendarSystem();
+
+    return {
+      success: true,
+      locale,
+      languages,
+      timeZone,
+      textDirection: null,
+      timeFormat,
+      calendarSystem: calendarResult.calendarSystem ?? null
+    };
+  }
+
+  async broadcastLocaleChange(): Promise<boolean> {
+    // iOS has no equivalent broadcast intent; SpringBoard restart is
+    // handled separately via `applyIosLiveChanges`.
+    return false;
+  }
+
+  buildAppleLanguages(languageTag: string): string[] {
+    const languages: string[] = [languageTag];
+    const parts = languageTag.split("-");
+    for (let i = parts.length - 1; i >= 1; i--) {
+      const shorter = parts.slice(0, i).join("-");
+      if (!languages.includes(shorter)) {
+        languages.push(shorter);
+      }
+    }
+    return languages;
+  }
+
+  private isSimulator(): boolean {
+    return SIMULATOR_UDID_PATTERN.test(this.device.deviceId);
+  }
+
+  private iosSpawnCommand(command: string): string {
+    return `xcrun simctl spawn ${this.device.deviceId} ${command}`;
+  }
+
+  private async iosDefaultsRead(domain: string, key: string): Promise<string | null> {
+    try {
+      const result = await this.processExecutor.exec(
+        this.iosSpawnCommand(`defaults read ${domain} ${key}`)
+      );
+      return normalizeSettingValue(result.stdout);
+    } catch {
+      return null;
+    }
+  }
+
+  private async iosDefaultsWrite(domain: string, key: string, value: string): Promise<void> {
+    await this.processExecutor.exec(
+      this.iosSpawnCommand(`defaults write ${domain} ${key} ${value}`)
+    );
+  }
+
+  private toAppleLocale(languageTag: string): string {
+    return languageTag.replace(/-/g, "_");
+  }
+}

--- a/src/features/utility/system-configuration/createSystemConfigurationAdapter.ts
+++ b/src/features/utility/system-configuration/createSystemConfigurationAdapter.ts
@@ -1,0 +1,22 @@
+import type { BootedDevice } from "../../../models";
+import type { AdbExecutor } from "../../../utils/android-cmdline-tools/interfaces/AdbExecutor";
+import type { ProcessExecutor } from "../../../utils/ProcessExecutor";
+import type { SystemConfigurationAdapter } from "../../../utils/interfaces/SystemConfigurationAdapter";
+import { AndroidSystemConfigurationAdapter } from "./AndroidSystemConfigurationAdapter";
+import { IosSystemConfigurationAdapter } from "./IosSystemConfigurationAdapter";
+
+/**
+ * Build the platform-appropriate {@link SystemConfigurationAdapter}
+ * for `device`. Centralising the selection here keeps
+ * `SystemConfigurationManager.ts` free of platform branches.
+ */
+export function createSystemConfigurationAdapter(
+  device: BootedDevice,
+  adb: AdbExecutor,
+  processExecutor: ProcessExecutor
+): SystemConfigurationAdapter {
+  if (device.platform === "ios") {
+    return new IosSystemConfigurationAdapter(device, processExecutor);
+  }
+  return new AndroidSystemConfigurationAdapter(device, adb);
+}

--- a/src/features/utility/system-configuration/iosHelpers.ts
+++ b/src/features/utility/system-configuration/iosHelpers.ts
@@ -1,0 +1,50 @@
+/**
+ * Tiny iOS-specific helpers shared between `SystemConfigurationManager`
+ * (for its iOS-only public methods like `restartSpringBoard`) and
+ * `IosSystemConfigurationAdapter` (for its locale/timezone/24h ops).
+ */
+
+const SIMULATOR_UDID_PATTERN =
+  /^[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}$/i;
+
+/**
+ * Distinguish an iOS Simulator (8-4-4-4-12 UUID) from a physical iPhone
+ * (e.g. `00008130-…`). Many system-configuration writes only work on
+ * the Simulator, so callers gate on this.
+ */
+export function isIosSimulator(deviceId: string): boolean {
+  return SIMULATOR_UDID_PATTERN.test(deviceId);
+}
+
+/** Compose an `xcrun simctl spawn <udid> <command>` shell line. */
+export function iosSpawnCommand(deviceId: string, command: string): string {
+  return `xcrun simctl spawn ${deviceId} ${command}`;
+}
+
+/**
+ * Apple's `AppleLanguages` array prefers fallback chains
+ * (e.g. `["zh-Hans-CN", "zh-Hans", "zh"]`) so progressively-broader
+ * locales are picked up when an app lacks an exact-match resource.
+ */
+export function buildAppleLanguages(languageTag: string): string[] {
+  const languages: string[] = [languageTag];
+  const parts = languageTag.split("-");
+  for (let i = parts.length - 1; i >= 1; i--) {
+    const shorter = parts.slice(0, i).join("-");
+    if (!languages.includes(shorter)) {
+      languages.push(shorter);
+    }
+  }
+  return languages;
+}
+
+/**
+ * Apple's `defaults` writes for the 24-hour-format key surface as `"1"`
+ * (24h) or `"0"` (12h) when read back. Normalize to the same `"24"` /
+ * `"12"` shape that {@link normalizeTimeFormat} expects.
+ */
+export function parseAppleTimeFormatRaw(raw: string | null): string | null {
+  if (raw === "1") {return "24";}
+  if (raw === "0") {return "12";}
+  return raw;
+}

--- a/src/features/utility/system-configuration/parsing.ts
+++ b/src/features/utility/system-configuration/parsing.ts
@@ -1,0 +1,93 @@
+/**
+ * Pure parsing helpers shared by the Android and iOS
+ * SystemConfigurationAdapters. Kept platform-agnostic so the same
+ * normalization rules apply to ADB and `defaults read` output.
+ */
+
+export function normalizeSettingValue(value: string | null): string | null {
+  if (value === null || value === undefined) {
+    return null;
+  }
+  const trimmed = value.trim();
+  if (!trimmed || trimmed === "null" || trimmed === "undefined") {
+    return null;
+  }
+  return trimmed;
+}
+
+export function normalizeTimeFormat(value: string | null): "12" | "24" | null {
+  const normalized = normalizeSettingValue(value);
+  if (normalized === "12" || normalized === "24") {
+    return normalized;
+  }
+  return null;
+}
+
+export function parseBooleanSetting(value: string | null): boolean | null {
+  const normalized = normalizeSettingValue(value);
+  if (normalized === null) {
+    return null;
+  }
+  const lower = normalized.toLowerCase();
+  if (lower === "1" || lower === "true") {
+    return true;
+  }
+  if (lower === "0" || lower === "false") {
+    return false;
+  }
+  return null;
+}
+
+export function parseLocaleList(value: string | null): string | null {
+  const normalized = normalizeSettingValue(value);
+  if (!normalized) {
+    return null;
+  }
+  const primary = normalized.split(",")[0]?.trim();
+  return primary || null;
+}
+
+/**
+ * Extract the calendar identifier from a BCP-47 / POSIX locale string,
+ * supporting both `@calendar=…` and `-u-ca-…` extensions.
+ */
+export function extractCalendarFromLocale(locale: string): string | null {
+  const normalizedLocale = locale.trim();
+  if (!normalizedLocale) {
+    return null;
+  }
+
+  const keywordMatch = normalizedLocale.match(/@calendar=([a-z0-9-]+)/i);
+  if (keywordMatch && keywordMatch[1]) {
+    return keywordMatch[1];
+  }
+
+  const bcp47Locale = normalizedLocale.replace(/_/g, "-");
+  const extensionIndex = bcp47Locale.toLowerCase().indexOf("-u-");
+  if (extensionIndex === -1) {
+    return null;
+  }
+
+  const extension = bcp47Locale.slice(extensionIndex + 3);
+  const segments = extension.split("-").filter(Boolean);
+
+  let index = 0;
+  while (index < segments.length) {
+    const key = segments[index];
+    if (key.length === 2) {
+      index += 1;
+      const typeSegments: string[] = [];
+      while (index < segments.length && segments[index].length > 2) {
+        typeSegments.push(segments[index]);
+        index += 1;
+      }
+      if (key.toLowerCase() === "ca" && typeSegments.length > 0) {
+        return typeSegments.join("-");
+      }
+    } else {
+      index += 1;
+    }
+  }
+
+  return null;
+}

--- a/src/utils/interfaces/SystemConfigurationAdapter.ts
+++ b/src/utils/interfaces/SystemConfigurationAdapter.ts
@@ -18,19 +18,11 @@ export interface BroadcastOptions {
 
 /**
  * Platform-specific surface used by {@link SystemConfigurationManager}
- * to keep its public methods free of `device.platform === ...`
- * branches.
+ * so its public methods are free of `device.platform === ...` branches.
  *
- * Implemented by `AndroidSystemConfigurationAdapter` and
- * `IosSystemConfigurationAdapter`; selected once in the manager's
- * constructor via `createSystemConfigurationAdapter`. Each adapter
- * captures its platform dependencies (device, adb / process executor,
- * timer, …) at construction so call sites never need to thread them
- * through.
- *
- * Method signatures and return shapes mirror the manager's public API
- * one-to-one. Input validation (e.g. rejecting empty strings) stays in
- * the manager so error wording is identical across platforms.
+ * The manager keeps input validation (e.g. rejecting empty strings) so
+ * error wording is identical across platforms; the adapter handles the
+ * platform-specific I/O.
  */
 export interface SystemConfigurationAdapter {
   /** Set the system locale to the given BCP-47 language tag. */

--- a/src/utils/interfaces/SystemConfigurationAdapter.ts
+++ b/src/utils/interfaces/SystemConfigurationAdapter.ts
@@ -1,0 +1,67 @@
+import type {
+  GetCalendarSystemResult,
+  LocalizationSettingsResult,
+  Set24HourFormatResult,
+  SetCalendarSystemResult,
+  SetLocaleResult,
+  SetTextDirectionResult,
+  SetTimeZoneResult,
+} from "../../models";
+
+/**
+ * Options that influence the broadcast / live-apply behaviour of a
+ * locale or text-direction change.
+ */
+export interface BroadcastOptions {
+  broadcast?: boolean;
+}
+
+/**
+ * Platform-specific surface used by {@link SystemConfigurationManager}
+ * to keep its public methods free of `device.platform === ...`
+ * branches.
+ *
+ * Implemented by `AndroidSystemConfigurationAdapter` and
+ * `IosSystemConfigurationAdapter`; selected once in the manager's
+ * constructor via `createSystemConfigurationAdapter`. Each adapter
+ * captures its platform dependencies (device, adb / process executor,
+ * timer, …) at construction so call sites never need to thread them
+ * through.
+ *
+ * Method signatures and return shapes mirror the manager's public API
+ * one-to-one. Input validation (e.g. rejecting empty strings) stays in
+ * the manager so error wording is identical across platforms.
+ */
+export interface SystemConfigurationAdapter {
+  /** Set the system locale to the given BCP-47 language tag. */
+  setLocale(languageTag: string, options: BroadcastOptions): Promise<SetLocaleResult>;
+
+  /** Set the system time zone to the given IANA zone id. */
+  setTimeZone(zoneId: string): Promise<SetTimeZoneResult>;
+
+  /**
+   * Set the system text direction. On platforms where RTL is not a
+   * standalone setting (iOS), implementations should return a result
+   * with `success: false` and an explanatory error message.
+   */
+  setTextDirection(rtl: boolean, options: BroadcastOptions): Promise<SetTextDirectionResult>;
+
+  /** Enable or disable 24-hour time format. */
+  set24HourFormat(enabled: boolean): Promise<Set24HourFormatResult>;
+
+  /** Set the calendar system (e.g. "gregory", "japanese"). */
+  setCalendarSystem(calendarSystem: string): Promise<SetCalendarSystemResult>;
+
+  /** Read the current calendar system, falling back to locale-derived or default. */
+  getCalendarSystem(): Promise<GetCalendarSystemResult>;
+
+  /** Read the full bundle of localization-related settings. */
+  getLocalizationSettings(): Promise<LocalizationSettingsResult>;
+
+  /**
+   * Broadcast a locale-change intent so apps refresh their UI. Returns
+   * `true` if a broadcast was issued, `false` otherwise (including
+   * iOS, which has no equivalent broadcast).
+   */
+  broadcastLocaleChange(): Promise<boolean>;
+}

--- a/src/utils/interfaces/index.ts
+++ b/src/utils/interfaces/index.ts
@@ -10,6 +10,10 @@ export type {
   SnapshotRestoreProvider,
 } from "./SnapshotProvider";
 export type { TapStrategy } from "./TapStrategy";
+export type {
+  BroadcastOptions,
+  SystemConfigurationAdapter,
+} from "./SystemConfigurationAdapter";
 // Screenshot utilities - split into focused classes (Phase 3.1)
 export { ScreenshotComparator } from "../screenshot/ScreenshotComparator";
 export { PerceptualHasher } from "../screenshot/PerceptualHasher";

--- a/test/fakes/FakeSystemConfigurationAdapter.ts
+++ b/test/fakes/FakeSystemConfigurationAdapter.ts
@@ -1,0 +1,100 @@
+import type {
+  GetCalendarSystemResult,
+  LocalizationSettingsResult,
+  Set24HourFormatResult,
+  SetCalendarSystemResult,
+  SetLocaleResult,
+  SetTextDirectionResult,
+  SetTimeZoneResult,
+} from "../../src/models";
+import type {
+  BroadcastOptions,
+  SystemConfigurationAdapter,
+} from "../../src/utils/interfaces/SystemConfigurationAdapter";
+
+/**
+ * Minimal recording fake for {@link SystemConfigurationAdapter}.
+ * Mirrors the `executedOperations` / `wasMethodCalled` / `getCallCount`
+ * / `clearHistory` pattern used by `FakeTapStrategy` and
+ * `FakeSnapshotProvider`. Configurable result fields let tests
+ * stub specific responses.
+ */
+export class FakeSystemConfigurationAdapter implements SystemConfigurationAdapter {
+  setLocaleResult: SetLocaleResult = { success: true, languageTag: "en-US" };
+  setTimeZoneResult: SetTimeZoneResult = { success: true, zoneId: "America/Los_Angeles" };
+  setTextDirectionResult: SetTextDirectionResult = { success: true, rtl: false };
+  set24HourFormatResult: Set24HourFormatResult = { success: true, enabled: true };
+  setCalendarSystemResult: SetCalendarSystemResult = { success: true, calendarSystem: "gregory" };
+  getCalendarSystemResult: GetCalendarSystemResult = {
+    success: true,
+    calendarSystem: "gregory",
+    source: "default",
+  };
+  getLocalizationSettingsResult: LocalizationSettingsResult = {
+    success: true,
+    locale: "en-US",
+    timeZone: "America/Los_Angeles",
+    textDirection: "ltr",
+    timeFormat: "12",
+    calendarSystem: "gregory",
+  };
+  broadcastLocaleChangeResult: boolean = true;
+
+  private readonly executedOperations: string[] = [];
+
+  getExecutedOperations(): string[] {
+    return [...this.executedOperations];
+  }
+
+  wasMethodCalled(operationName: string): boolean {
+    return this.executedOperations.some(op => op.includes(operationName));
+  }
+
+  getCallCount(operationName: string): number {
+    return this.executedOperations.filter(op => op.includes(operationName)).length;
+  }
+
+  clearHistory(): void {
+    this.executedOperations.length = 0;
+  }
+
+  async setLocale(languageTag: string, options: BroadcastOptions): Promise<SetLocaleResult> {
+    this.executedOperations.push(`setLocale:${languageTag}:${options.broadcast ?? "default"}`);
+    return this.setLocaleResult;
+  }
+
+  async setTimeZone(zoneId: string): Promise<SetTimeZoneResult> {
+    this.executedOperations.push(`setTimeZone:${zoneId}`);
+    return this.setTimeZoneResult;
+  }
+
+  async setTextDirection(rtl: boolean, options: BroadcastOptions): Promise<SetTextDirectionResult> {
+    this.executedOperations.push(`setTextDirection:${rtl}:${options.broadcast ?? "default"}`);
+    return this.setTextDirectionResult;
+  }
+
+  async set24HourFormat(enabled: boolean): Promise<Set24HourFormatResult> {
+    this.executedOperations.push(`set24HourFormat:${enabled}`);
+    return this.set24HourFormatResult;
+  }
+
+  async setCalendarSystem(calendarSystem: string): Promise<SetCalendarSystemResult> {
+    this.executedOperations.push(`setCalendarSystem:${calendarSystem}`);
+    return this.setCalendarSystemResult;
+  }
+
+  async getCalendarSystem(): Promise<GetCalendarSystemResult> {
+    this.executedOperations.push("getCalendarSystem");
+    return this.getCalendarSystemResult;
+  }
+
+  async getLocalizationSettings(): Promise<LocalizationSettingsResult> {
+    this.executedOperations.push("getLocalizationSettings");
+    return this.getLocalizationSettingsResult;
+  }
+
+  async broadcastLocaleChange(): Promise<boolean> {
+    this.executedOperations.push("broadcastLocaleChange");
+    return this.broadcastLocaleChangeResult;
+  }
+}

--- a/test/features/utility/SystemConfigurationAdapter.test.ts
+++ b/test/features/utility/SystemConfigurationAdapter.test.ts
@@ -1,0 +1,241 @@
+import { describe, it, expect, beforeEach } from "bun:test";
+import { FakeSystemConfigurationAdapter } from "../../fakes/FakeSystemConfigurationAdapter";
+import { AndroidSystemConfigurationAdapter } from "../../../src/features/utility/system-configuration/AndroidSystemConfigurationAdapter";
+import { IosSystemConfigurationAdapter } from "../../../src/features/utility/system-configuration/IosSystemConfigurationAdapter";
+import { createSystemConfigurationAdapter } from "../../../src/features/utility/system-configuration/createSystemConfigurationAdapter";
+import { FakeAdbClient } from "../../fakes/FakeAdbClient";
+import { FakeProcessExecutor } from "../../fakes/FakeProcessExecutor";
+import type { BootedDevice, ExecResult } from "../../../src/models";
+import type { SystemConfigurationAdapter } from "../../../src/utils/interfaces/SystemConfigurationAdapter";
+
+/**
+ * Sanity-check the platform-agnostic SystemConfigurationAdapter contract.
+ * Tests deliberately type their subjects as the abstract interface so a
+ * regression that drops one of the shared members will surface as a
+ * compile error here.
+ */
+describe("SystemConfigurationAdapter", () => {
+  const androidDevice: BootedDevice = {
+    deviceId: "emulator-5554",
+    name: "Pixel 7",
+    platform: "android",
+  };
+  const iosSimulator: BootedDevice = {
+    deviceId: "A1B2C3D4-E5F6-7890-ABCD-EF1234567890",
+    name: "iPhone 15",
+    platform: "ios",
+  };
+  const iosPhysical: BootedDevice = {
+    deviceId: "00008130-001234567890abcd",
+    name: "iPhone 15 Pro",
+    platform: "ios",
+  };
+
+  const execResult = (stdout: string, stderr = ""): ExecResult => ({
+    stdout,
+    stderr,
+    toString: () => stdout,
+    trim: () => stdout.trim(),
+    includes: (s: string) => stdout.includes(s),
+  });
+
+  describe("FakeSystemConfigurationAdapter", () => {
+    let fake: FakeSystemConfigurationAdapter;
+
+    beforeEach(() => {
+      fake = new FakeSystemConfigurationAdapter();
+    });
+
+    it("records each method invocation", async () => {
+      await fake.setLocale("ja-JP", { broadcast: true });
+      await fake.setTimeZone("Asia/Tokyo");
+      await fake.setTextDirection(true, {});
+      await fake.set24HourFormat(true);
+      await fake.setCalendarSystem("japanese");
+      await fake.getCalendarSystem();
+      await fake.getLocalizationSettings();
+      await fake.broadcastLocaleChange();
+
+      expect(fake.wasMethodCalled("setLocale")).toBe(true);
+      expect(fake.wasMethodCalled("setTimeZone")).toBe(true);
+      expect(fake.wasMethodCalled("setTextDirection")).toBe(true);
+      expect(fake.wasMethodCalled("set24HourFormat")).toBe(true);
+      expect(fake.wasMethodCalled("setCalendarSystem")).toBe(true);
+      expect(fake.wasMethodCalled("getCalendarSystem")).toBe(true);
+      expect(fake.wasMethodCalled("getLocalizationSettings")).toBe(true);
+      expect(fake.wasMethodCalled("broadcastLocaleChange")).toBe(true);
+    });
+
+    it("captures call arguments in the recorded operation string", async () => {
+      await fake.setLocale("fr-CA", { broadcast: false });
+      await fake.setTimeZone("Europe/Paris");
+
+      const ops = fake.getExecutedOperations();
+      expect(ops).toContain("setLocale:fr-CA:false");
+      expect(ops).toContain("setTimeZone:Europe/Paris");
+    });
+
+    it("clears recorded history on demand", async () => {
+      await fake.broadcastLocaleChange();
+      fake.clearHistory();
+      expect(fake.getExecutedOperations()).toEqual([]);
+    });
+
+    it("returns the configured stub results", async () => {
+      fake.setLocaleResult = { success: false, languageTag: "x-y", error: "stubbed" };
+      const result = await fake.setLocale("x-y", {});
+      expect(result.success).toBe(false);
+      expect(result.error).toBe("stubbed");
+    });
+
+    it("counts each invocation independently", async () => {
+      await fake.broadcastLocaleChange();
+      await fake.broadcastLocaleChange();
+      await fake.broadcastLocaleChange();
+      expect(fake.getCallCount("broadcastLocaleChange")).toBe(3);
+    });
+  });
+
+  // Two platform adapters plus the fake all satisfy
+  // SystemConfigurationAdapter. Data-driven so each gets the same
+  // conformance checks without duplicating describe blocks.
+  interface AdapterCase {
+    name: string;
+    build: () => SystemConfigurationAdapter;
+  }
+
+  const cases: ReadonlyArray<AdapterCase> = [
+    {
+      name: "AndroidSystemConfigurationAdapter",
+      build: () => new AndroidSystemConfigurationAdapter(androidDevice, new FakeAdbClient() as any),
+    },
+    {
+      name: "IosSystemConfigurationAdapter",
+      build: () => new IosSystemConfigurationAdapter(iosSimulator, new FakeProcessExecutor()),
+    },
+    {
+      name: "FakeSystemConfigurationAdapter",
+      build: () => new FakeSystemConfigurationAdapter(),
+    },
+  ];
+
+  for (const c of cases) {
+    describe(c.name, () => {
+      it("satisfies the SystemConfigurationAdapter interface", () => {
+        const adapter: SystemConfigurationAdapter = c.build();
+        expect(typeof adapter.setLocale).toBe("function");
+        expect(typeof adapter.setTimeZone).toBe("function");
+        expect(typeof adapter.setTextDirection).toBe("function");
+        expect(typeof adapter.set24HourFormat).toBe("function");
+        expect(typeof adapter.setCalendarSystem).toBe("function");
+        expect(typeof adapter.getCalendarSystem).toBe("function");
+        expect(typeof adapter.getLocalizationSettings).toBe("function");
+        expect(typeof adapter.broadcastLocaleChange).toBe("function");
+      });
+    });
+  }
+
+  describe("AndroidSystemConfigurationAdapter behavior", () => {
+    it("broadcasts the LOCALE_CHANGED intent via ADB", async () => {
+      const adb = new FakeAdbClient();
+      const adapter = new AndroidSystemConfigurationAdapter(androidDevice, adb as any);
+      const result = await adapter.broadcastLocaleChange();
+      expect(result).toBe(true);
+      const calls = (adb as any).getCommandCalls?.() ?? [];
+      // Look for the broadcast command (FakeAdbClient records under commandCalls)
+      const recorded = (adb as any).commandCalls ?? calls;
+      expect(
+        recorded.some((c: { command: string }) =>
+          c.command.includes("am broadcast -a android.intent.action.LOCALE_CHANGED")
+        )
+      ).toBe(true);
+    });
+
+    it("returns false from broadcastLocaleChange when ADB fails", async () => {
+      const adb = new FakeAdbClient();
+      adb.setCommandError(
+        "shell am broadcast -a android.intent.action.LOCALE_CHANGED",
+        new Error("device offline")
+      );
+      const adapter = new AndroidSystemConfigurationAdapter(androidDevice, adb as any);
+      expect(await adapter.broadcastLocaleChange()).toBe(false);
+    });
+
+    it("sets the system time zone via setprop", async () => {
+      const adb = new FakeAdbClient();
+      const adapter = new AndroidSystemConfigurationAdapter(androidDevice, adb as any);
+      const result = await adapter.setTimeZone("Asia/Tokyo");
+      expect(result.success).toBe(true);
+      expect(result.zoneId).toBe("Asia/Tokyo");
+      const recorded = (adb as any).commandCalls;
+      expect(
+        recorded.some((c: { command: string }) =>
+          c.command.includes("setprop persist.sys.timezone Asia/Tokyo")
+        )
+      ).toBe(true);
+    });
+  });
+
+  describe("IosSystemConfigurationAdapter behavior", () => {
+    it("rejects locale changes on physical devices", async () => {
+      const adapter = new IosSystemConfigurationAdapter(iosPhysical, new FakeProcessExecutor());
+      const result = await adapter.setLocale("ja-JP", {});
+      expect(result.success).toBe(false);
+      expect(result.error).toBe("Localization changes are only supported on iOS Simulator.");
+    });
+
+    it("rejects time-zone changes on physical devices", async () => {
+      const adapter = new IosSystemConfigurationAdapter(iosPhysical, new FakeProcessExecutor());
+      const result = await adapter.setTimeZone("Asia/Tokyo");
+      expect(result.success).toBe(false);
+      expect(result.error).toBe("Localization changes are only supported on iOS Simulator.");
+    });
+
+    it("setTextDirection returns the iOS-specific error regardless of simulator state", async () => {
+      const adapter = new IosSystemConfigurationAdapter(iosSimulator, new FakeProcessExecutor());
+      const result = await adapter.setTextDirection(true, {});
+      expect(result.success).toBe(false);
+      expect(result.rtl).toBe(true);
+      expect(result.error).toContain("Text direction is not supported on iOS");
+    });
+
+    it("broadcastLocaleChange is a no-op on iOS (returns false)", async () => {
+      const adapter = new IosSystemConfigurationAdapter(iosSimulator, new FakeProcessExecutor());
+      expect(await adapter.broadcastLocaleChange()).toBe(false);
+    });
+
+    it("writes AppleLocale via xcrun simctl spawn defaults", async () => {
+      const exec = new FakeProcessExecutor();
+      exec.setCommandResponse("defaults read .GlobalPreferences AppleLocale", execResult("ja_JP\n"));
+      const adapter = new IosSystemConfigurationAdapter(iosSimulator, exec);
+      const result = await adapter.setLocale("ja-JP", {});
+
+      expect(result.success).toBe(true);
+      expect(
+        exec.wasCommandExecuted(
+          `xcrun simctl spawn ${iosSimulator.deviceId} defaults write .GlobalPreferences AppleLocale ja_JP`
+        )
+      ).toBe(true);
+    });
+  });
+
+  describe("createSystemConfigurationAdapter factory", () => {
+    it("returns an AndroidSystemConfigurationAdapter for Android devices", () => {
+      const adapter = createSystemConfigurationAdapter(
+        androidDevice,
+        new FakeAdbClient() as any,
+        new FakeProcessExecutor()
+      );
+      expect(adapter).toBeInstanceOf(AndroidSystemConfigurationAdapter);
+    });
+
+    it("returns an IosSystemConfigurationAdapter for iOS devices", () => {
+      const adapter = createSystemConfigurationAdapter(
+        iosSimulator,
+        new FakeAdbClient() as any,
+        new FakeProcessExecutor()
+      );
+      expect(adapter).toBeInstanceOf(IosSystemConfigurationAdapter);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Fourth in the platform-duplication refactor series (after #2182, #2249, #2251). Extracts the 9 platform branches in \`src/features/utility/SystemConfigurationManager.ts\` (was 950 lines) behind a \`SystemConfigurationAdapter\` interface with two implementations (Android via adb-shell, iOS via xcrun simctl + defaults).

After this PR: \`grep "platform === " src/features/utility/SystemConfigurationManager.ts\` returns **zero**. The manager dropped from 950 to ~150 lines of actual logic; its public API is unchanged.

## What moved

| Operation | Both platforms diverged on | SystemConfigurationAdapter method |
|---|---|---|
| Set/Get locale | adb settings put vs simctl defaults write | \`setLocale\`, \`getLocalizationSettings\` |
| Set/Get timezone | setprop persist.sys.timezone vs defaults AppleTimeZone | \`setTimeZone\` |
| Set/Get 24h format | settings put system time_12_24 vs defaults AppleICUForce24HourTime | \`set24HourFormat\` |
| Calendar system | locale parsing vs AppleCalendar | \`setCalendarSystem\`, \`getCalendarSystem\` |
| Text direction | force_rtl setting (Android-only; iOS errors) | \`setTextDirection\` |
| Locale-change broadcast | adb am broadcast (Android-only; iOS no-op) | \`broadcastLocaleChange\` |

Shared parse helpers (\`normalizeSettingValue\`, \`normalizeTimeFormat\`, \`parseBooleanSetting\`, \`parseLocaleList\`, \`extractCalendarFromLocale\`) moved to \`system-configuration/parsing.ts\`. iOS-only command helpers (\`isIosSimulator\`, \`iosSpawnCommand\`, \`buildAppleLanguages\`, \`parseAppleTimeFormatRaw\`) moved to \`system-configuration/iosHelpers.ts\` — used by both the manager (for its iOS-only \`restartSpringBoard\` etc.) and the iOS adapter.

## Design notes

- iOS-only public methods (\`restartSpringBoard\`, \`postLocaleChangeNotification\`, \`applyIosLiveChanges\`, \`buildAppleLanguages\`) **stayed on the manager** — they're one-sided so they don't belong on the shared interface. They route through \`isIosSimulator()\` (UDID-pattern test), not \`platform === \`, so no platform branch is reintroduced.
- Android API-level reads now use the existing \`readAndroidDeviceApiLevel\` utility instead of a duplicate inline implementation.
- Input validation (empty-string checks) stays on the manager so error wording is identical regardless of platform.
- \`createSystemConfigurationAdapter\` is the single platform-selection point, matching the \`createTapStrategy\` precedent from #2251.

## Test plan

- [x] \`bun run lint\` clean
- [x] \`bun build.ts\` succeeds
- [x] Full \`bun test --bail\`: 4225 pass / 1 skip / 0 fail
- [x] 18 new unit tests in \`test/features/utility/SystemConfigurationAdapter.test.ts\` covering both adapters via a data-driven \`AdapterCase\` table
- [x] All 98 existing \`SystemConfigurationManager.test.ts\` tests pass unmodified
- [x] \`grep "platform === " src/features/utility/SystemConfigurationManager.ts\` returns 0