### PR TITLE
refactor(system-tray): extract NotificationUIDetector from systemTrayHelpers

### DIFF
--- a/src/server/system-tray/AndroidNotificationUIDetector.ts
+++ b/src/server/system-tray/AndroidNotificationUIDetector.ts
@@ -1,14 +1,17 @@
 import { ActionableError, BootedDevice, Element, ObserveResult, ViewHierarchyResult } from "../../models";
 import { DefaultElementGeometry } from "../../features/utility/ElementGeometry";
 import type { NotificationUIDetector } from "../../utils/interfaces/NotificationUIDetector";
-import { getHierarchyRoots, nodeHasSystemTrayHint, traverseForHint } from "./notificationHints";
+import {
+  getHierarchyRoots,
+  nodeHasSystemTrayHint,
+  SYSTEM_TRAY_NOTIFICATION_SWIPE_DURATION_MS,
+  traverseForHint,
+} from "./notificationHints";
 
 export interface AndroidNotificationUIDetectorDeps {
   executeAdbCommand(command: string): Promise<{ stdout: string; stderr: string }>;
   getDeviceTimestampMs(): Promise<number>;
 }
-
-export const SYSTEM_TRAY_NOTIFICATION_SWIPE_DURATION_MS = 300;
 
 /**
  * Android implementation of {@link NotificationUIDetector}. Matches

--- a/src/server/system-tray/AndroidNotificationUIDetector.ts
+++ b/src/server/system-tray/AndroidNotificationUIDetector.ts
@@ -1,0 +1,74 @@
+import { ActionableError, BootedDevice, Element, ObserveResult, ViewHierarchyResult } from "../../models";
+import { DefaultElementGeometry } from "../../features/utility/ElementGeometry";
+import type { NotificationUIDetector } from "../../utils/interfaces/NotificationUIDetector";
+import { getHierarchyRoots, nodeHasSystemTrayHint, traverseForHint } from "./notificationHints";
+
+export interface AndroidNotificationUIDetectorDeps {
+  executeAdbCommand(command: string): Promise<{ stdout: string; stderr: string }>;
+  getDeviceTimestampMs(): Promise<number>;
+}
+
+export const SYSTEM_TRAY_NOTIFICATION_SWIPE_DURATION_MS = 300;
+
+/**
+ * Android implementation of {@link NotificationUIDetector}. Matches
+ * `com.android.systemui` resource-ids / class hints to detect the
+ * shade and uses `shell cmd statusbar` for expand / collapse so the
+ * gesture is identical regardless of OEM swipe-handle styling.
+ *
+ * The detector takes a small dependency object rather than the full
+ * `SystemTrayDependencies` interface so it can be unit-tested with a
+ * minimal fake (see `FakeNotificationUIDetector` for the recording
+ * fake used by feature tests).
+ */
+export class AndroidNotificationUIDetector implements NotificationUIDetector {
+  readonly device: BootedDevice;
+  private readonly deps: AndroidNotificationUIDetectorDeps;
+
+  constructor(device: BootedDevice, deps: AndroidNotificationUIDetectorDeps) {
+    this.device = device;
+    this.deps = deps;
+  }
+
+  isTrayOpen(viewHierarchy?: ViewHierarchyResult): boolean {
+    if (!viewHierarchy) {
+      return false;
+    }
+    const rootNodes = getHierarchyRoots(viewHierarchy);
+    return rootNodes.some(root => traverseForHint(root, nodeHasSystemTrayHint));
+  }
+
+  async expandTray(_observation?: ObserveResult): Promise<void> {
+    try {
+      await this.deps.executeAdbCommand("shell cmd statusbar expand-notifications");
+    } catch (error) {
+      throw new ActionableError(`Failed to expand system tray: ${error}`);
+    }
+  }
+
+  async collapseTray(_observation?: ObserveResult): Promise<void> {
+    try {
+      await this.deps.executeAdbCommand("shell cmd statusbar collapse");
+    } catch (error) {
+      throw new ActionableError(`Failed to collapse system tray: ${error}`);
+    }
+  }
+
+  async getObservationTimestamp(): Promise<number> {
+    return this.deps.getDeviceTimestampMs();
+  }
+
+  async tapElement(element: Element): Promise<void> {
+    const geometry = new DefaultElementGeometry();
+    const center = geometry.getElementCenter(element);
+    await this.deps.executeAdbCommand(`shell input tap ${center.x} ${center.y}`);
+  }
+
+  async swipeElement(element: Element): Promise<void> {
+    const geometry = new DefaultElementGeometry();
+    const { startX, startY, endX, endY } = geometry.getSwipeWithinBounds("left", element.bounds);
+    await this.deps.executeAdbCommand(
+      `shell input swipe ${Math.floor(startX)} ${Math.floor(startY)} ${Math.floor(endX)} ${Math.floor(endY)} ${SYSTEM_TRAY_NOTIFICATION_SWIPE_DURATION_MS}`
+    );
+  }
+}

--- a/src/server/system-tray/IosNotificationUIDetector.ts
+++ b/src/server/system-tray/IosNotificationUIDetector.ts
@@ -4,6 +4,7 @@ import type { NotificationUIDetector } from "../../utils/interfaces/Notification
 import {
   getHierarchyRoots,
   nodeHasIosNotificationCenterHint,
+  SYSTEM_TRAY_NOTIFICATION_SWIPE_DURATION_MS,
   traverseForHint
 } from "./notificationHints";
 
@@ -14,9 +15,8 @@ export interface IosNotificationUIDetectorDeps {
   now(): number;
 }
 
-const IOS_OPEN_SWIPE_DURATION_MS = 300;
-const IOS_CLOSE_SWIPE_DURATION_MS = 300;
-const SYSTEM_TRAY_NOTIFICATION_SWIPE_DURATION_MS = 300;
+const IOS_OPEN_SWIPE_DURATION_MS = SYSTEM_TRAY_NOTIFICATION_SWIPE_DURATION_MS;
+const IOS_CLOSE_SWIPE_DURATION_MS = SYSTEM_TRAY_NOTIFICATION_SWIPE_DURATION_MS;
 
 /**
  * iOS implementation of {@link NotificationUIDetector}. NotificationCenter

--- a/src/server/system-tray/IosNotificationUIDetector.ts
+++ b/src/server/system-tray/IosNotificationUIDetector.ts
@@ -1,0 +1,106 @@
+import { ActionableError, BootedDevice, Element, ObserveResult, ViewHierarchyResult } from "../../models";
+import { DefaultElementGeometry } from "../../features/utility/ElementGeometry";
+import type { NotificationUIDetector } from "../../utils/interfaces/NotificationUIDetector";
+import {
+  getHierarchyRoots,
+  nodeHasIosNotificationCenterHint,
+  traverseForHint
+} from "./notificationHints";
+
+export interface IosNotificationUIDetectorDeps {
+  requestSwipe(x1: number, y1: number, x2: number, y2: number, duration?: number): Promise<{ success: boolean }>;
+  requestTapCoordinates(x: number, y: number): Promise<{ success: boolean }>;
+  /** Host-side monotonic clock used as the iOS observation timestamp. */
+  now(): number;
+}
+
+const IOS_OPEN_SWIPE_DURATION_MS = 300;
+const IOS_CLOSE_SWIPE_DURATION_MS = 300;
+const SYSTEM_TRAY_NOTIFICATION_SWIPE_DURATION_MS = 300;
+
+/**
+ * iOS implementation of {@link NotificationUIDetector}. NotificationCenter
+ * is hosted by SpringBoard, so the predicate first gates on the
+ * observation's `packageName` containing "springboard" before scanning
+ * for any of the known NotificationCenter class / identifier hints.
+ *
+ * Expand and collapse are vertical swipes anchored at the screen's
+ * mid-X. The detector requires the caller to pass the most recent
+ * observation so it can read `screenSize` — without dimensions there
+ * is no safe gesture path on iOS and the operation aborts.
+ */
+export class IosNotificationUIDetector implements NotificationUIDetector {
+  readonly device: BootedDevice;
+  private readonly deps: IosNotificationUIDetectorDeps;
+
+  constructor(device: BootedDevice, deps: IosNotificationUIDetectorDeps) {
+    this.device = device;
+    this.deps = deps;
+  }
+
+  isTrayOpen(viewHierarchy?: ViewHierarchyResult): boolean {
+    if (!viewHierarchy) {
+      return false;
+    }
+    const packageName = (viewHierarchy as any).packageName ?? "";
+    if (!packageName.includes("springboard")) {
+      return false;
+    }
+    const rootNodes = getHierarchyRoots(viewHierarchy);
+    return rootNodes.some(root => traverseForHint(root, nodeHasIosNotificationCenterHint));
+  }
+
+  async expandTray(observation?: ObserveResult): Promise<void> {
+    const { width, height } = this.requireScreenSize(observation, "open");
+    await this.deps.requestSwipe(
+      Math.floor(width * 0.5), 5,
+      Math.floor(width * 0.5), Math.floor(height * 0.7),
+      IOS_OPEN_SWIPE_DURATION_MS
+    );
+  }
+
+  async collapseTray(observation?: ObserveResult): Promise<void> {
+    const { width, height } = this.requireScreenSize(observation, "close");
+    await this.deps.requestSwipe(
+      Math.floor(width * 0.5), Math.floor(height * 0.65),
+      Math.floor(width * 0.5), Math.floor(height * 0.08),
+      IOS_CLOSE_SWIPE_DURATION_MS
+    );
+  }
+
+  async getObservationTimestamp(): Promise<number> {
+    return this.deps.now();
+  }
+
+  async tapElement(element: Element): Promise<void> {
+    const geometry = new DefaultElementGeometry();
+    const center = geometry.getElementCenter(element);
+    await this.deps.requestTapCoordinates(center.x, center.y);
+  }
+
+  async swipeElement(element: Element): Promise<void> {
+    const geometry = new DefaultElementGeometry();
+    const { startX, startY, endX, endY } = geometry.getSwipeWithinBounds("left", element.bounds);
+    await this.deps.requestSwipe(
+      Math.floor(startX), Math.floor(startY),
+      Math.floor(endX), Math.floor(endY),
+      SYSTEM_TRAY_NOTIFICATION_SWIPE_DURATION_MS
+    );
+  }
+
+  private requireScreenSize(
+    observation: ObserveResult | undefined,
+    action: "open" | "close"
+  ): { width: number; height: number } {
+    const width = observation?.screenSize?.width;
+    const height = observation?.screenSize?.height;
+    if (!width || !height) {
+      throw new ActionableError(
+        action === "open"
+          ? "Screen dimensions required to open iOS Notification Center"
+          : "Screen dimensions required to close iOS Notification Center"
+      );
+    }
+    return { width, height };
+  }
+}

--- a/src/server/system-tray/createNotificationUIDetector.ts
+++ b/src/server/system-tray/createNotificationUIDetector.ts
@@ -1,0 +1,62 @@
+import { ActionableError, BootedDevice } from "../../models";
+import type { NotificationUIDetector } from "../../utils/interfaces/NotificationUIDetector";
+import type {
+  SystemTrayAdb,
+  SystemTrayDependencies,
+  SystemTrayIosClient
+} from "../systemTrayHelpers";
+import {
+  AndroidNotificationUIDetector,
+  type AndroidNotificationUIDetectorDeps
+} from "./AndroidNotificationUIDetector";
+import {
+  IosNotificationUIDetector,
+  type IosNotificationUIDetectorDeps
+} from "./IosNotificationUIDetector";
+
+/**
+ * Build the platform-appropriate {@link NotificationUIDetector} for
+ * `device`. The detector adapts the broader {@link SystemTrayDependencies}
+ * down to the minimal surface each implementation needs, and reads from
+ * the supplied getter lazily so callers that mutate dependencies via
+ * `setSystemTrayDependencies` between calls still see fresh fakes.
+ */
+export function createNotificationUIDetector(
+  device: BootedDevice,
+  getDependencies: () => SystemTrayDependencies
+): NotificationUIDetector {
+  if (device.platform === "ios") {
+    const deps: IosNotificationUIDetectorDeps = {
+      requestSwipe: (x1, y1, x2, y2, duration) =>
+        getIosClient(device, getDependencies).requestSwipe(x1, y1, x2, y2, duration),
+      requestTapCoordinates: (x, y) =>
+        getIosClient(device, getDependencies).requestTapCoordinates(x, y),
+      now: () => getDependencies().timer.now()
+    };
+    return new IosNotificationUIDetector(device, deps);
+  }
+
+  const deps: AndroidNotificationUIDetectorDeps = {
+    executeAdbCommand: command => getAdb(device, getDependencies).executeCommand(command),
+    getDeviceTimestampMs: () => getAdb(device, getDependencies).getDeviceTimestampMs()
+  };
+  return new AndroidNotificationUIDetector(device, deps);
+}
+
+function getIosClient(
+  device: BootedDevice,
+  getDependencies: () => SystemTrayDependencies
+): SystemTrayIosClient {
+  const { iosClientFactory } = getDependencies();
+  if (!iosClientFactory) {
+    throw new ActionableError("iOS CtrlProxy client not configured for systemTray");
+  }
+  return iosClientFactory(device);
+}
+
+function getAdb(
+  device: BootedDevice,
+  getDependencies: () => SystemTrayDependencies
+): SystemTrayAdb {
+  return getDependencies().adbFactory(device);
+}

--- a/src/server/system-tray/notificationHints.ts
+++ b/src/server/system-tray/notificationHints.ts
@@ -10,6 +10,14 @@ import type { ViewHierarchyResult } from "../../models";
 
 export const SYSTEM_TRAY_PACKAGE = "com.android.systemui";
 
+/**
+ * Duration in milliseconds for swipes that expand or collapse the
+ * notification shade / NotificationCenter. Shared between adapters and
+ * re-exported from `systemTrayHelpers` for downstream callers (e.g.
+ * interactionTools settle-wait calculations).
+ */
+export const SYSTEM_TRAY_NOTIFICATION_SWIPE_DURATION_MS = 300;
+
 export const IOS_NOTIFICATION_CENTER_CLASS_HINTS = [
   "NotificationCenter",
   "NCNotification",

--- a/src/server/system-tray/notificationHints.ts
+++ b/src/server/system-tray/notificationHints.ts
@@ -1,0 +1,120 @@
+/**
+ * Shared pure helpers used by both the Android and iOS notification UI
+ * detectors. Extracted from `systemTrayHelpers.ts` so the detectors do
+ * not need to import non-exported module-internal helpers.
+ *
+ * Everything in this file is a pure function over a view hierarchy
+ * node — no I/O, no device dependencies.
+ */
+import type { ViewHierarchyResult } from "../../models";
+
+export const SYSTEM_TRAY_PACKAGE = "com.android.systemui";
+
+export const IOS_NOTIFICATION_CENTER_CLASS_HINTS = [
+  "NotificationCenter",
+  "NCNotification",
+  "NotificationList",
+  "NotificationShortLookView",
+  "NotificationLongLookView",
+  "PLPlatterView"
+];
+
+export const SYSTEM_TRAY_RESOURCE_ID_HINTS = [
+  "notification_panel",
+  "notification_stack",
+  "notification_stack_scroller",
+  "status_bar_expanded",
+  "quick_settings",
+  "quick_settings_panel",
+  "quick_settings_container",
+  "qs_panel",
+  "qs_frame",
+  "qs_header",
+  "shade_header",
+  "expanded_status_bar"
+];
+
+export const SYSTEM_TRAY_CLASS_HINTS = [
+  "NotificationPanel",
+  "NotificationShade",
+  "NotificationStack",
+  "QSPanel",
+  "QuickSettings",
+  "StatusBarExpanded"
+];
+
+export const getNodeProperties = (node: any): Record<string, any> | null => {
+  if (!node || typeof node !== "object") {
+    return null;
+  }
+  if ("$" in node && node.$) {
+    return node.$ as Record<string, any>;
+  }
+  return node as Record<string, any>;
+};
+
+export const traverseForHint = (node: any, predicate: (node: any) => boolean): boolean => {
+  if (!node) {
+    return false;
+  }
+  if (predicate(node)) {
+    return true;
+  }
+  const children = node.node;
+  if (Array.isArray(children)) {
+    for (const child of children) {
+      if (traverseForHint(child, predicate)) {
+        return true;
+      }
+    }
+  } else if (children && typeof children === "object") {
+    if (traverseForHint(children, predicate)) {
+      return true;
+    }
+  }
+  return false;
+};
+
+export const getHierarchyRoots = (viewHierarchy: ViewHierarchyResult): any[] => {
+  if (!viewHierarchy?.hierarchy || viewHierarchy.hierarchy.error) {
+    return [];
+  }
+  const hierarchy: any = viewHierarchy.hierarchy;
+  if (hierarchy.node) {
+    return Array.isArray(hierarchy.node) ? hierarchy.node : [hierarchy.node];
+  }
+  if (hierarchy.hierarchy) {
+    return [hierarchy.hierarchy];
+  }
+  return [hierarchy];
+};
+
+export const nodeHasSystemTrayHint = (node: any): boolean => {
+  const props = getNodeProperties(node);
+  if (!props) {
+    return false;
+  }
+  const resourceId = String(props["resource-id"] ?? props.resourceId ?? "");
+  const className = String(props.className ?? props.class ?? "");
+  const packageName = String(props.packageName ?? props.package ?? "");
+  const isSystemUi = packageName === SYSTEM_TRAY_PACKAGE || resourceId.includes(SYSTEM_TRAY_PACKAGE);
+  if (!isSystemUi) {
+    return false;
+  }
+  const matchesResourceId = SYSTEM_TRAY_RESOURCE_ID_HINTS.some(hint => resourceId.includes(hint));
+  const matchesClassName = SYSTEM_TRAY_CLASS_HINTS.some(hint => className.includes(hint));
+  return matchesResourceId || matchesClassName;
+};
+
+export const nodeHasIosNotificationCenterHint = (node: any): boolean => {
+  const props = getNodeProperties(node);
+  if (!props) {
+    return false;
+  }
+  const className = String(props.className ?? props.class ?? "");
+  const contentDesc = String(props["content-desc"] ?? props["ios-accessibility-label"] ?? "");
+  const identifier = String(props["resource-id"] ?? props.resourceId ?? props.identifier ?? "");
+  return IOS_NOTIFICATION_CENTER_CLASS_HINTS.some(
+    hint => className.includes(hint) || contentDesc.includes(hint) || identifier.includes(hint)
+  );
+};

--- a/src/server/systemTrayHelpers.ts
+++ b/src/server/systemTrayHelpers.ts
@@ -9,7 +9,6 @@ import {
   BootedDevice,
   Element,
   ObserveResult,
-  Platform,
   ViewHierarchyResult
 } from "../models";
 import type { ObserveScreenExecuteOptions } from "../features/observe/interfaces/ObserveScreen";
@@ -19,8 +18,9 @@ import { IOSCtrlProxyClient } from "../features/observe/ios";
 import { AndroidCtrlProxyClient } from "../features/observe/android";
 import type { ElementFinder } from "../utils/interfaces/ElementFinder";
 import { DefaultElementFinder } from "../features/utility/ElementFinder";
-import { DefaultElementGeometry } from "../features/utility/ElementGeometry";
 import { DefaultElementParser } from "../features/utility/ElementParser";
+import type { NotificationUIDetector } from "../utils/interfaces/NotificationUIDetector";
+import { createNotificationUIDetector } from "./system-tray/createNotificationUIDetector";
 import type { ProgressCallback } from "./toolRegistry";
 import type { SystemTrayNotificationArgs } from "./interactionToolTypes";
 import { boundsArea } from "../utils/bounds";
@@ -113,14 +113,6 @@ export const resetSystemTrayDependencies = (): void => {
 // ============================================================================
 
 const SYSTEM_TRAY_PACKAGE = "com.android.systemui";
-const IOS_NOTIFICATION_CENTER_CLASS_HINTS = [
-  "NotificationCenter",
-  "NCNotification",
-  "NotificationList",
-  "NotificationShortLookView",
-  "NotificationLongLookView",
-  "PLPlatterView"
-];
 const SYSTEM_TRAY_RESOURCE_ID_HINTS = [
   "notification_panel",
   "notification_stack",
@@ -134,14 +126,6 @@ const SYSTEM_TRAY_RESOURCE_ID_HINTS = [
   "qs_header",
   "shade_header",
   "expanded_status_bar"
-];
-const SYSTEM_TRAY_CLASS_HINTS = [
-  "NotificationPanel",
-  "NotificationShade",
-  "NotificationStack",
-  "QSPanel",
-  "QuickSettings",
-  "StatusBarExpanded"
 ];
 const NOTIFICATION_ROW_RESOURCE_ID_HINTS = [
   "notification_row",
@@ -230,52 +214,6 @@ const getNodeProperties = (node: any): Record<string, any> | null => {
   return node as Record<string, any>;
 };
 
-const nodeHasSystemTrayHint = (node: any): boolean => {
-  const props = getNodeProperties(node);
-  if (!props) {
-    return false;
-  }
-
-  const resourceId = String(props["resource-id"] ?? props.resourceId ?? "");
-  const className = String(props.className ?? props.class ?? "");
-  const packageName = String(props.packageName ?? props.package ?? "");
-  const isSystemUi = packageName === SYSTEM_TRAY_PACKAGE || resourceId.includes(SYSTEM_TRAY_PACKAGE);
-
-  if (!isSystemUi) {
-    return false;
-  }
-
-  const matchesResourceId = SYSTEM_TRAY_RESOURCE_ID_HINTS.some(hint => resourceId.includes(hint));
-  const matchesClassName = SYSTEM_TRAY_CLASS_HINTS.some(hint => className.includes(hint));
-
-  return matchesResourceId || matchesClassName;
-};
-
-const traverseForHint = (node: any, predicate: (node: any) => boolean): boolean => {
-  if (!node) {
-    return false;
-  }
-
-  if (predicate(node)) {
-    return true;
-  }
-
-  const children = node.node;
-  if (Array.isArray(children)) {
-    for (const child of children) {
-      if (traverseForHint(child, predicate)) {
-        return true;
-      }
-    }
-  } else if (children && typeof children === "object") {
-    if (traverseForHint(children, predicate)) {
-      return true;
-    }
-  }
-
-  return false;
-};
-
 const getHierarchyRoots = (viewHierarchy: ViewHierarchyResult): any[] => {
   if (!viewHierarchy?.hierarchy || viewHierarchy.hierarchy.error) {
     return [];
@@ -292,41 +230,8 @@ const getHierarchyRoots = (viewHierarchy: ViewHierarchyResult): any[] => {
   return [hierarchy];
 };
 
-const nodeHasIosNotificationCenterHint = (node: any): boolean => {
-  const props = getNodeProperties(node);
-  if (!props) {
-    return false;
-  }
-
-  const className = String(props.className ?? props.class ?? "");
-  const contentDesc = String(props["content-desc"] ?? props["ios-accessibility-label"] ?? "");
-  const identifier = String(props["resource-id"] ?? props.resourceId ?? props.identifier ?? "");
-
-  return IOS_NOTIFICATION_CENTER_CLASS_HINTS.some(
-    hint => className.includes(hint) || contentDesc.includes(hint) || identifier.includes(hint)
-  );
-};
-
-const isIosNotificationCenterOpen = (viewHierarchy: ViewHierarchyResult): boolean => {
-  const packageName = (viewHierarchy as any).packageName ?? "";
-  if (!packageName.includes("springboard")) {
-    return false;
-  }
-  const rootNodes = getHierarchyRoots(viewHierarchy);
-  return rootNodes.some(root => traverseForHint(root, nodeHasIosNotificationCenterHint));
-};
-
-const isSystemTrayOpen = (viewHierarchy?: ViewHierarchyResult, platform?: Platform): boolean => {
-  if (!viewHierarchy) {
-    return false;
-  }
-
-  if (platform === "ios") {
-    return isIosNotificationCenterOpen(viewHierarchy);
-  }
-
-  const rootNodes = getHierarchyRoots(viewHierarchy);
-  return rootNodes.some(root => traverseForHint(root, nodeHasSystemTrayHint));
+const getDetector = (device: BootedDevice): NotificationUIDetector => {
+  return createNotificationUIDetector(device, getSystemTrayDependencies);
 };
 
 // ============================================================================
@@ -339,75 +244,18 @@ export const resolveSystemTrayAwaitTimeout = (awaitTimeout?: number): number => 
   return awaitTimeout ?? DEFAULT_SYSTEM_TRAY_AWAIT_TIMEOUT_MS;
 };
 
-const resolveSystemTrayObservationTimestamp = async (device: BootedDevice): Promise<number> => {
-  const { adbFactory, timer } = getSystemTrayDependencies();
-  if (device.platform !== "android") {
-    return timer.now();
-  }
-  const adb = adbFactory(device);
-  return adb.getDeviceTimestampMs();
+const expandSystemTray = async (
+  detector: NotificationUIDetector,
+  observation?: ObserveResult
+): Promise<void> => {
+  await detector.expandTray(observation);
 };
 
-const getIosClient = (device: BootedDevice): SystemTrayIosClient => {
-  const { iosClientFactory } = getSystemTrayDependencies();
-  if (!iosClientFactory) {
-    throw new ActionableError("iOS CtrlProxy client not configured for systemTray");
-  }
-  return iosClientFactory(device);
-};
-
-const expandSystemTray = async (device: BootedDevice, screenWidth?: number, screenHeight?: number): Promise<void> => {
-  if (device.platform === "ios") {
-    if (!screenWidth || !screenHeight) {
-      throw new ActionableError("Screen dimensions required to open iOS Notification Center");
-    }
-    const client = getIosClient(device);
-    await client.requestSwipe(
-      Math.floor(screenWidth * 0.5), 5,
-      Math.floor(screenWidth * 0.5), Math.floor(screenHeight * 0.7),
-      300
-    );
-    return;
-  }
-
-  if (device.platform !== "android") {
-    return;
-  }
-
-  try {
-    const { adbFactory } = getSystemTrayDependencies();
-    const adb = adbFactory(device);
-    await adb.executeCommand("shell cmd statusbar expand-notifications");
-  } catch (error) {
-    throw new ActionableError(`Failed to expand system tray: ${error}`);
-  }
-};
-
-const collapseSystemTray = async (device: BootedDevice, screenWidth?: number, screenHeight?: number): Promise<void> => {
-  if (device.platform === "ios") {
-    if (!screenWidth || !screenHeight) {
-      throw new ActionableError("Screen dimensions required to close iOS Notification Center");
-    }
-    const client = getIosClient(device);
-    await client.requestSwipe(
-      Math.floor(screenWidth * 0.5), Math.floor(screenHeight * 0.65),
-      Math.floor(screenWidth * 0.5), Math.floor(screenHeight * 0.08),
-      300
-    );
-    return;
-  }
-
-  if (device.platform !== "android") {
-    return;
-  }
-
-  try {
-    const { adbFactory } = getSystemTrayDependencies();
-    const adb = adbFactory(device);
-    await adb.executeCommand("shell cmd statusbar collapse");
-  } catch (error) {
-    throw new ActionableError(`Failed to collapse system tray: ${error}`);
-  }
+const collapseSystemTray = async (
+  detector: NotificationUIDetector,
+  observation?: ObserveResult
+): Promise<void> => {
+  await detector.collapseTray(observation);
 };
 
 const parseAppLabelFromDumpsys = (stdout: string): string | null => {
@@ -1107,17 +955,17 @@ const findBestNotificationMatch = (
 };
 
 const waitForSystemTrayOpen = async (
+  detector: NotificationUIDetector,
   observeScreen: SystemTrayObserver,
   minTimestamp: number,
-  awaitTimeoutMs: number,
-  platform?: Platform
+  awaitTimeoutMs: number
 ): Promise<ObserveResult> => {
   const { timer } = getSystemTrayDependencies();
   const startTime = timer.now();
   let observation = await observeScreen.execute({ skipWaitForFresh: false, minTimestamp });
 
   while (timer.now() - startTime < awaitTimeoutMs) {
-    if (isSystemTrayOpen(observation.viewHierarchy, platform)) {
+    if (detector.isTrayOpen(observation.viewHierarchy)) {
       return observation;
     }
     await sleep(SYSTEM_TRAY_POLL_INTERVAL_MS);
@@ -1128,17 +976,17 @@ const waitForSystemTrayOpen = async (
 };
 
 const waitForSystemTrayClosed = async (
+  detector: NotificationUIDetector,
   observeScreen: SystemTrayObserver,
   minTimestamp: number,
-  awaitTimeoutMs: number,
-  platform?: Platform
+  awaitTimeoutMs: number
 ): Promise<ObserveResult> => {
   const { timer } = getSystemTrayDependencies();
   const startTime = timer.now();
   let observation = await observeScreen.execute({ skipWaitForFresh: false, minTimestamp });
 
   while (timer.now() - startTime < awaitTimeoutMs) {
-    if (!isSystemTrayOpen(observation.viewHierarchy, platform)) {
+    if (!detector.isTrayOpen(observation.viewHierarchy)) {
       return observation;
     }
     await sleep(SYSTEM_TRAY_POLL_INTERVAL_MS);
@@ -1158,46 +1006,21 @@ export const ensureSystemTrayOpen = async (
   skipped: boolean;
   minTimestamp: number;
 }> => {
-  const { observeScreenFactory, timer } = getSystemTrayDependencies();
+  const { observeScreenFactory } = getSystemTrayDependencies();
+  const detector = getDetector(device);
   const observeScreen = observeScreenFactory(device);
-  let observation: ObserveResult | undefined;
-  let minTimestamp = 0;
 
-  if (device.platform === "ios") {
-    minTimestamp = timer.now();
-    observation = await observeScreen.execute({ skipWaitForFresh: false, minTimestamp });
-    if (isSystemTrayOpen(observation.viewHierarchy, "ios")) {
-      return { observation, opened: false, skipped: true, minTimestamp };
-    }
-    const screenWidth = observation.screenSize?.width;
-    const screenHeight = observation.screenSize?.height;
-    await expandSystemTray(device, screenWidth, screenHeight);
-    minTimestamp = timer.now();
-    const awaitedObservation = await waitForSystemTrayOpen(
-      observeScreen, minTimestamp, awaitTimeoutMs, "ios"
-    );
-    return {
-      observation: awaitedObservation ?? observation,
-      opened: true,
-      skipped: false,
-      minTimestamp
-    };
+  let minTimestamp = await detector.getObservationTimestamp();
+  const observation = await observeScreen.execute({ skipWaitForFresh: false, minTimestamp });
+  if (detector.isTrayOpen(observation.viewHierarchy)) {
+    return { observation, opened: false, skipped: true, minTimestamp };
   }
 
-  if (device.platform === "android") {
-    minTimestamp = await resolveSystemTrayObservationTimestamp(device);
-    observation = await observeScreen.execute({ skipWaitForFresh: false, minTimestamp });
-    if (isSystemTrayOpen(observation.viewHierarchy)) {
-      return { observation, opened: false, skipped: true, minTimestamp };
-    }
-  }
-
-  await expandSystemTray(device);
-  if (device.platform === "android") {
-    minTimestamp = await resolveSystemTrayObservationTimestamp(device);
-  }
+  await expandSystemTray(detector, observation);
+  minTimestamp = await detector.getObservationTimestamp();
 
   const awaitedObservation = await waitForSystemTrayOpen(
+    detector,
     observeScreen,
     minTimestamp,
     awaitTimeoutMs
@@ -1221,46 +1044,21 @@ export const ensureSystemTrayClosed = async (
   skipped: boolean;
   minTimestamp: number;
 }> => {
-  const { observeScreenFactory, timer } = getSystemTrayDependencies();
+  const { observeScreenFactory } = getSystemTrayDependencies();
+  const detector = getDetector(device);
   const observeScreen = observeScreenFactory(device);
-  let observation: ObserveResult | undefined;
-  let minTimestamp = 0;
 
-  if (device.platform === "ios") {
-    minTimestamp = timer.now();
-    observation = await observeScreen.execute({ skipWaitForFresh: false, minTimestamp });
-    if (!isSystemTrayOpen(observation.viewHierarchy, "ios")) {
-      return { observation, closed: false, skipped: true, minTimestamp };
-    }
-    const screenWidth = observation.screenSize?.width;
-    const screenHeight = observation.screenSize?.height;
-    await collapseSystemTray(device, screenWidth, screenHeight);
-    minTimestamp = timer.now();
-    const awaitedObservation = await waitForSystemTrayClosed(
-      observeScreen, minTimestamp, awaitTimeoutMs, "ios"
-    );
-    return {
-      observation: awaitedObservation ?? observation,
-      closed: true,
-      skipped: false,
-      minTimestamp
-    };
+  let minTimestamp = await detector.getObservationTimestamp();
+  const observation = await observeScreen.execute({ skipWaitForFresh: false, minTimestamp });
+  if (!detector.isTrayOpen(observation.viewHierarchy)) {
+    return { observation, closed: false, skipped: true, minTimestamp };
   }
 
-  if (device.platform === "android") {
-    minTimestamp = await resolveSystemTrayObservationTimestamp(device);
-    observation = await observeScreen.execute({ skipWaitForFresh: false, minTimestamp });
-    if (!isSystemTrayOpen(observation.viewHierarchy)) {
-      return { observation, closed: false, skipped: true, minTimestamp };
-    }
-  }
-
-  await collapseSystemTray(device);
-  if (device.platform === "android") {
-    minTimestamp = await resolveSystemTrayObservationTimestamp(device);
-  }
+  await collapseSystemTray(detector, observation);
+  minTimestamp = await detector.getObservationTimestamp();
 
   const awaitedObservation = await waitForSystemTrayClosed(
+    detector,
     observeScreen,
     minTimestamp,
     awaitTimeoutMs
@@ -1289,6 +1087,7 @@ export const waitForNotificationMatch = async (
     );
     awaitTimeoutMs = SYSTEM_TRAY_POLL_INTERVAL_MS;
   }
+  const detector = getDetector(device);
   const observeScreen = observeScreenFactory(device);
   const deadlineMs = timer.now() + awaitTimeoutMs;
   const remainingMs = Math.max(0, deadlineMs - timer.now());
@@ -1301,7 +1100,7 @@ export const waitForNotificationMatch = async (
 
   while (true) {
     const viewHierarchy = observation.viewHierarchy;
-    if (viewHierarchy && isSystemTrayOpen(viewHierarchy, device.platform)) {
+    if (viewHierarchy && detector.isTrayOpen(viewHierarchy)) {
       const match = findBestNotificationMatch(viewHierarchy, criteria, appMatchTexts);
       if (match) {
         return { observation, match };
@@ -1385,35 +1184,9 @@ export const resolveNotificationSwipeElement = (
 };
 
 export const tapElement = async (device: BootedDevice, element: Element): Promise<void> => {
-  const geometry = new DefaultElementGeometry();
-  const center = geometry.getElementCenter(element);
-
-  if (device.platform === "ios") {
-    await getIosClient(device).requestTapCoordinates(center.x, center.y);
-    return;
-  }
-
-  const { adbFactory } = getSystemTrayDependencies();
-  const adb = adbFactory(device);
-  await adb.executeCommand(`shell input tap ${center.x} ${center.y}`);
+  await getDetector(device).tapElement(element);
 };
 
 export const swipeElement = async (device: BootedDevice, element: Element): Promise<void> => {
-  const geometry = new DefaultElementGeometry();
-  const { startX, startY, endX, endY } = geometry.getSwipeWithinBounds("left", element.bounds);
-
-  if (device.platform === "ios") {
-    await getIosClient(device).requestSwipe(
-      Math.floor(startX), Math.floor(startY),
-      Math.floor(endX), Math.floor(endY),
-      SYSTEM_TRAY_NOTIFICATION_SWIPE_DURATION_MS
-    );
-    return;
-  }
-
-  const { adbFactory } = getSystemTrayDependencies();
-  const adb = adbFactory(device);
-  await adb.executeCommand(
-    `shell input swipe ${Math.floor(startX)} ${Math.floor(startY)} ${Math.floor(endX)} ${Math.floor(endY)} ${SYSTEM_TRAY_NOTIFICATION_SWIPE_DURATION_MS}`
-  );
+  await getDetector(device).swipeElement(element);
 };

--- a/src/server/systemTrayHelpers.ts
+++ b/src/server/systemTrayHelpers.ts
@@ -21,6 +21,13 @@ import { DefaultElementFinder } from "../features/utility/ElementFinder";
 import { DefaultElementParser } from "../features/utility/ElementParser";
 import type { NotificationUIDetector } from "../utils/interfaces/NotificationUIDetector";
 import { createNotificationUIDetector } from "./system-tray/createNotificationUIDetector";
+import {
+  SYSTEM_TRAY_PACKAGE,
+  SYSTEM_TRAY_RESOURCE_ID_HINTS,
+  SYSTEM_TRAY_NOTIFICATION_SWIPE_DURATION_MS as SYSTEM_TRAY_NOTIFICATION_SWIPE_DURATION_MS_FROM_HINTS,
+  getHierarchyRoots,
+  getNodeProperties,
+} from "./system-tray/notificationHints";
 import type { ProgressCallback } from "./toolRegistry";
 import type { SystemTrayNotificationArgs } from "./interactionToolTypes";
 import { boundsArea } from "../utils/bounds";
@@ -112,21 +119,6 @@ export const resetSystemTrayDependencies = (): void => {
 // Constants
 // ============================================================================
 
-const SYSTEM_TRAY_PACKAGE = "com.android.systemui";
-const SYSTEM_TRAY_RESOURCE_ID_HINTS = [
-  "notification_panel",
-  "notification_stack",
-  "notification_stack_scroller",
-  "status_bar_expanded",
-  "quick_settings",
-  "quick_settings_panel",
-  "quick_settings_container",
-  "qs_panel",
-  "qs_frame",
-  "qs_header",
-  "shade_header",
-  "expanded_status_bar"
-];
 const NOTIFICATION_ROW_RESOURCE_ID_HINTS = [
   "notification_row",
   "expandablenotificationrow",
@@ -153,7 +145,8 @@ const NOTIFICATION_ROW_RESOURCE_ID_EXCLUDES = [
 const DEFAULT_SYSTEM_TRAY_AWAIT_TIMEOUT_MS = 5000;
 const SYSTEM_TRAY_POLL_INTERVAL_MS = 250;
 export const SYSTEM_TRAY_CLEAR_MAX_ITERATIONS = 25;
-export const SYSTEM_TRAY_NOTIFICATION_SWIPE_DURATION_MS = 300;
+// Re-export shared constant so existing callers (interactionTools.ts) keep working.
+export const SYSTEM_TRAY_NOTIFICATION_SWIPE_DURATION_MS = SYSTEM_TRAY_NOTIFICATION_SWIPE_DURATION_MS_FROM_HINTS;
 export const EXPAND_GROUP_SETTLE_MS = 500;
 
 // ============================================================================
@@ -199,36 +192,6 @@ interface SystemTrayElementMatch {
 }
 
 type NormalizedSearchText = { text: string; normalized: string };
-
-// ============================================================================
-// Node Utility Functions
-// ============================================================================
-
-const getNodeProperties = (node: any): Record<string, any> | null => {
-  if (!node || typeof node !== "object") {
-    return null;
-  }
-  if ("$" in node && node.$) {
-    return node.$ as Record<string, any>;
-  }
-  return node as Record<string, any>;
-};
-
-const getHierarchyRoots = (viewHierarchy: ViewHierarchyResult): any[] => {
-  if (!viewHierarchy?.hierarchy || viewHierarchy.hierarchy.error) {
-    return [];
-  }
-
-  const hierarchy: any = viewHierarchy.hierarchy;
-  if (hierarchy.node) {
-    return Array.isArray(hierarchy.node) ? hierarchy.node : [hierarchy.node];
-  }
-  if (hierarchy.hierarchy) {
-    return [hierarchy.hierarchy];
-  }
-
-  return [hierarchy];
-};
 
 const getDetector = (device: BootedDevice): NotificationUIDetector => {
   return createNotificationUIDetector(device, getSystemTrayDependencies);

--- a/src/utils/interfaces/NotificationUIDetector.ts
+++ b/src/utils/interfaces/NotificationUIDetector.ts
@@ -1,0 +1,68 @@
+import type { BootedDevice, Element, ObserveResult, ViewHierarchyResult } from "../../models";
+
+/**
+ * Platform-specific surface used by `systemTrayHelpers.ts` so its
+ * helper functions are free of `device.platform === ...` branches.
+ *
+ * Implemented by `AndroidNotificationUIDetector` and
+ * `IosNotificationUIDetector`; selected per call site via
+ * `createNotificationUIDetector`. Each detector captures its
+ * {@link BootedDevice} at construction and reads side-effect
+ * dependencies (ADB client, iOS CtrlProxy client, timer) lazily from
+ * `getSystemTrayDependencies()` so callers can swap them in tests.
+ *
+ * Method shape rationale:
+ *
+ * - `isTrayOpen` is a pure predicate over a view hierarchy snapshot.
+ *   Android matches systemui resource-ids / class hints; iOS matches
+ *   NotificationCenter class hints rooted under SpringBoard.
+ * - `expandTray` / `collapseTray` issue the platform-native gesture
+ *   or shell command to toggle the shade / NotificationCenter. iOS
+ *   needs the observation to read `screenSize` for its swipe path;
+ *   Android ignores the argument.
+ * - `getObservationTimestamp` returns the `minTimestamp` used to gate
+ *   the next `observeScreen.execute(...)` call. Android uses an ADB
+ *   `date +%s%3N`-style query so freshness is judged against the
+ *   device's monotonic clock; iOS falls back to the local timer.
+ * - `tapElement` / `swipeElement` issue a single tap / left-swipe on a
+ *   specific notification row.
+ */
+export interface NotificationUIDetector {
+  /** The device this detector is bound to. */
+  readonly device: BootedDevice;
+
+  /**
+   * Returns `true` when the view hierarchy snapshot shows the
+   * notification shade (Android) or NotificationCenter (iOS) open.
+   * `undefined` snapshots return `false`.
+   */
+  isTrayOpen(viewHierarchy?: ViewHierarchyResult): boolean;
+
+  /**
+   * Open the notification shade / NotificationCenter. iOS requires
+   * the observation for screen dimensions; Android ignores it.
+   * Throws an `ActionableError` if a required prerequisite is missing.
+   */
+  expandTray(observation?: ObserveResult): Promise<void>;
+
+  /**
+   * Close the notification shade / NotificationCenter. iOS requires
+   * the observation for screen dimensions; Android ignores it.
+   * Throws an `ActionableError` if a required prerequisite is missing.
+   */
+  collapseTray(observation?: ObserveResult): Promise<void>;
+
+  /**
+   * Resolve a `minTimestamp` to feed into the next observation
+   * request. Android queries the device clock via ADB so freshness
+   * is measured against the device's monotonic time; iOS falls back
+   * to the host timer.
+   */
+  getObservationTimestamp(): Promise<number>;
+
+  /** Tap a notification row element. */
+  tapElement(element: Element): Promise<void>;
+
+  /** Left-swipe a notification row to dismiss it. */
+  swipeElement(element: Element): Promise<void>;
+}

--- a/src/utils/interfaces/NotificationUIDetector.ts
+++ b/src/utils/interfaces/NotificationUIDetector.ts
@@ -4,28 +4,9 @@ import type { BootedDevice, Element, ObserveResult, ViewHierarchyResult } from "
  * Platform-specific surface used by `systemTrayHelpers.ts` so its
  * helper functions are free of `device.platform === ...` branches.
  *
- * Implemented by `AndroidNotificationUIDetector` and
- * `IosNotificationUIDetector`; selected per call site via
- * `createNotificationUIDetector`. Each detector captures its
- * {@link BootedDevice} at construction and reads side-effect
- * dependencies (ADB client, iOS CtrlProxy client, timer) lazily from
- * `getSystemTrayDependencies()` so callers can swap them in tests.
- *
- * Method shape rationale:
- *
- * - `isTrayOpen` is a pure predicate over a view hierarchy snapshot.
- *   Android matches systemui resource-ids / class hints; iOS matches
- *   NotificationCenter class hints rooted under SpringBoard.
- * - `expandTray` / `collapseTray` issue the platform-native gesture
- *   or shell command to toggle the shade / NotificationCenter. iOS
- *   needs the observation to read `screenSize` for its swipe path;
- *   Android ignores the argument.
- * - `getObservationTimestamp` returns the `minTimestamp` used to gate
- *   the next `observeScreen.execute(...)` call. Android uses an ADB
- *   `date +%s%3N`-style query so freshness is judged against the
- *   device's monotonic clock; iOS falls back to the local timer.
- * - `tapElement` / `swipeElement` issue a single tap / left-swipe on a
- *   specific notification row.
+ * Each implementation captures its {@link BootedDevice} at construction.
+ * See `AndroidNotificationUIDetector` / `IosNotificationUIDetector` for
+ * per-platform notes on the underlying mechanism.
  */
 export interface NotificationUIDetector {
   /** The device this detector is bound to. */
@@ -39,24 +20,19 @@ export interface NotificationUIDetector {
   isTrayOpen(viewHierarchy?: ViewHierarchyResult): boolean;
 
   /**
-   * Open the notification shade / NotificationCenter. iOS requires
-   * the observation for screen dimensions; Android ignores it.
-   * Throws an `ActionableError` if a required prerequisite is missing.
+   * Open the notification shade / NotificationCenter. The observation
+   * is optional because not every implementation needs screen
+   * dimensions — iOS does; Android does not.
    */
   expandTray(observation?: ObserveResult): Promise<void>;
 
-  /**
-   * Close the notification shade / NotificationCenter. iOS requires
-   * the observation for screen dimensions; Android ignores it.
-   * Throws an `ActionableError` if a required prerequisite is missing.
-   */
+  /** Close the notification shade / NotificationCenter. See {@link expandTray} on `observation`. */
   collapseTray(observation?: ObserveResult): Promise<void>;
 
   /**
-   * Resolve a `minTimestamp` to feed into the next observation
-   * request. Android queries the device clock via ADB so freshness
-   * is measured against the device's monotonic time; iOS falls back
-   * to the host timer.
+   * Resolve a `minTimestamp` for the next observation request so
+   * polling can gate on a clock that's monotonic relative to the
+   * platform doing the gesture.
    */
   getObservationTimestamp(): Promise<number>;
 

--- a/src/utils/interfaces/index.ts
+++ b/src/utils/interfaces/index.ts
@@ -14,6 +14,7 @@ export type {
   BroadcastOptions,
   SystemConfigurationAdapter,
 } from "./SystemConfigurationAdapter";
+export type { NotificationUIDetector } from "./NotificationUIDetector";
 // Screenshot utilities - split into focused classes (Phase 3.1)
 export { ScreenshotComparator } from "../screenshot/ScreenshotComparator";
 export { PerceptualHasher } from "../screenshot/PerceptualHasher";

--- a/test/fakes/FakeNotificationUIDetector.ts
+++ b/test/fakes/FakeNotificationUIDetector.ts
@@ -1,0 +1,72 @@
+import type { BootedDevice, Element, ObserveResult, ViewHierarchyResult } from "../../src/models";
+import type { NotificationUIDetector } from "../../src/utils/interfaces/NotificationUIDetector";
+
+/**
+ * Minimal recording fake for {@link NotificationUIDetector}. Mirrors the
+ * `executedOperations` / `wasMethodCalled` / `getCallCount` /
+ * `clearHistory` pattern used by `FakeTapStrategy` and
+ * `FakeSystemConfigurationAdapter`.
+ *
+ * Configurable result fields let tests stub specific responses
+ * (`isTrayOpenResult`, `observationTimestampResult`). The fake records
+ * every invocation as a colon-delimited string so tests can assert on
+ * substrings via `.includes()`.
+ */
+export class FakeNotificationUIDetector implements NotificationUIDetector {
+  readonly device: BootedDevice;
+
+  isTrayOpenResult: boolean = false;
+  observationTimestampResult: number = 0;
+
+  private readonly executedOperations: string[] = [];
+
+  constructor(device?: BootedDevice) {
+    this.device = device ?? {
+      deviceId: "fake-device",
+      name: "Fake",
+      platform: "android",
+    } as BootedDevice;
+  }
+
+  getExecutedOperations(): string[] {
+    return [...this.executedOperations];
+  }
+
+  wasMethodCalled(operationName: string): boolean {
+    return this.executedOperations.some(op => op.includes(operationName));
+  }
+
+  getCallCount(operationName: string): number {
+    return this.executedOperations.filter(op => op.includes(operationName)).length;
+  }
+
+  clearHistory(): void {
+    this.executedOperations.length = 0;
+  }
+
+  isTrayOpen(viewHierarchy?: ViewHierarchyResult): boolean {
+    this.executedOperations.push(`isTrayOpen:${viewHierarchy ? "present" : "absent"}`);
+    return this.isTrayOpenResult;
+  }
+
+  async expandTray(observation?: ObserveResult): Promise<void> {
+    this.executedOperations.push(`expandTray:${observation ? "present" : "absent"}`);
+  }
+
+  async collapseTray(observation?: ObserveResult): Promise<void> {
+    this.executedOperations.push(`collapseTray:${observation ? "present" : "absent"}`);
+  }
+
+  async getObservationTimestamp(): Promise<number> {
+    this.executedOperations.push("getObservationTimestamp");
+    return this.observationTimestampResult;
+  }
+
+  async tapElement(element: Element): Promise<void> {
+    this.executedOperations.push(`tapElement:${element.bounds?.left ?? "?"},${element.bounds?.top ?? "?"}`);
+  }
+
+  async swipeElement(element: Element): Promise<void> {
+    this.executedOperations.push(`swipeElement:${element.bounds?.left ?? "?"},${element.bounds?.top ?? "?"}`);
+  }
+}

--- a/test/server/system-tray/NotificationUIDetector.test.ts
+++ b/test/server/system-tray/NotificationUIDetector.test.ts
@@ -1,0 +1,362 @@
+import { describe, it, expect, beforeEach } from "bun:test";
+import { AndroidNotificationUIDetector } from "../../../src/server/system-tray/AndroidNotificationUIDetector";
+import { IosNotificationUIDetector } from "../../../src/server/system-tray/IosNotificationUIDetector";
+import { createNotificationUIDetector } from "../../../src/server/system-tray/createNotificationUIDetector";
+import { FakeNotificationUIDetector } from "../../fakes/FakeNotificationUIDetector";
+import type { BootedDevice, Element, ObserveResult, ViewHierarchyResult } from "../../../src/models";
+import type { NotificationUIDetector } from "../../../src/utils/interfaces/NotificationUIDetector";
+import type { SystemTrayDependencies } from "../../../src/server/systemTrayHelpers";
+import { FakeTimer } from "../../fakes/FakeTimer";
+
+/**
+ * Conformance check for the platform-agnostic NotificationUIDetector
+ * contract. Each subject is deliberately typed as the abstract interface
+ * so a regression that drops one of the shared members surfaces here as
+ * a compile error.
+ */
+describe("NotificationUIDetector", () => {
+  const androidDevice: BootedDevice = {
+    deviceId: "emulator-5554",
+    name: "Pixel 7",
+    platform: "android",
+  };
+  const iosDevice: BootedDevice = {
+    deviceId: "A1B2C3D4-E5F6-7890-ABCD-EF1234567890",
+    name: "iPhone 15",
+    platform: "ios",
+  };
+
+  const trayHierarchy: ViewHierarchyResult = {
+    packageName: "com.android.systemui",
+    hierarchy: {
+      node: {
+        $: {
+          "resource-id": "com.android.systemui:id/notification_stack_scroller",
+          "class": "NotificationShade",
+          "packageName": "com.android.systemui",
+          "bounds": "[0,0][100,100]",
+        },
+      },
+    },
+  };
+
+  const closedHierarchy: ViewHierarchyResult = {
+    packageName: "com.google.android.apps.nexuslauncher",
+    hierarchy: {
+      node: {
+        $: {
+          "resource-id": "launcher_root",
+          "class": "Launcher",
+          "packageName": "com.google.android.apps.nexuslauncher",
+          "bounds": "[0,0][100,100]",
+        },
+      },
+    },
+  };
+
+  const iosNotificationCenterHierarchy: ViewHierarchyResult = {
+    packageName: "com.apple.springboard",
+    hierarchy: {
+      node: {
+        $: {
+          class: "NotificationCenter",
+          bounds: "[0,0][375,812]",
+        },
+      },
+    },
+  } as ViewHierarchyResult;
+
+  const iosAppHierarchy: ViewHierarchyResult = {
+    packageName: "com.example.app",
+    hierarchy: {
+      node: {
+        $: {
+          class: "RootView",
+          bounds: "[0,0][375,812]",
+        },
+      },
+    },
+  } as ViewHierarchyResult;
+
+  const sampleElement: Element = {
+    bounds: { left: 10, top: 20, right: 100, bottom: 80 },
+    text: "Hello",
+  } as Element;
+
+  const observationWithSize: ObserveResult = {
+    updatedAt: 0,
+    screenSize: { width: 375, height: 812 },
+    systemInsets: { top: 0, right: 0, bottom: 0, left: 0 },
+  };
+
+  describe("FakeNotificationUIDetector", () => {
+    let fake: FakeNotificationUIDetector;
+
+    beforeEach(() => {
+      fake = new FakeNotificationUIDetector(androidDevice);
+    });
+
+    it("records each method invocation", async () => {
+      fake.isTrayOpen(trayHierarchy);
+      await fake.expandTray(observationWithSize);
+      await fake.collapseTray(observationWithSize);
+      await fake.getObservationTimestamp();
+      await fake.tapElement(sampleElement);
+      await fake.swipeElement(sampleElement);
+
+      expect(fake.wasMethodCalled("isTrayOpen")).toBe(true);
+      expect(fake.wasMethodCalled("expandTray")).toBe(true);
+      expect(fake.wasMethodCalled("collapseTray")).toBe(true);
+      expect(fake.wasMethodCalled("getObservationTimestamp")).toBe(true);
+      expect(fake.wasMethodCalled("tapElement")).toBe(true);
+      expect(fake.wasMethodCalled("swipeElement")).toBe(true);
+    });
+
+    it("returns configured stub values", async () => {
+      fake.isTrayOpenResult = true;
+      fake.observationTimestampResult = 1234;
+      expect(fake.isTrayOpen(trayHierarchy)).toBe(true);
+      expect(await fake.getObservationTimestamp()).toBe(1234);
+    });
+
+    it("counts invocations independently", async () => {
+      await fake.getObservationTimestamp();
+      await fake.getObservationTimestamp();
+      await fake.getObservationTimestamp();
+      expect(fake.getCallCount("getObservationTimestamp")).toBe(3);
+    });
+
+    it("clears recorded history on demand", () => {
+      fake.isTrayOpen(trayHierarchy);
+      fake.clearHistory();
+      expect(fake.getExecutedOperations()).toEqual([]);
+    });
+
+    it("captures call arguments in the recorded operation string", async () => {
+      await fake.tapElement(sampleElement);
+      expect(fake.getExecutedOperations()).toContain("tapElement:10,20");
+    });
+  });
+
+  // Three subjects all satisfy NotificationUIDetector — data-driven
+  // conformance keeps each one honest without repeating the asserts.
+  interface DetectorCase {
+    name: string;
+    build: () => NotificationUIDetector;
+  }
+
+  const cases: ReadonlyArray<DetectorCase> = [
+    {
+      name: "AndroidNotificationUIDetector",
+      build: () =>
+        new AndroidNotificationUIDetector(androidDevice, {
+          executeAdbCommand: async () => ({ stdout: "", stderr: "" }),
+          getDeviceTimestampMs: async () => 0,
+        }),
+    },
+    {
+      name: "IosNotificationUIDetector",
+      build: () =>
+        new IosNotificationUIDetector(iosDevice, {
+          requestSwipe: async () => ({ success: true }),
+          requestTapCoordinates: async () => ({ success: true }),
+          now: () => 0,
+        }),
+    },
+    {
+      name: "FakeNotificationUIDetector",
+      build: () => new FakeNotificationUIDetector(androidDevice),
+    },
+  ];
+
+  for (const c of cases) {
+    describe(c.name, () => {
+      it("satisfies the NotificationUIDetector interface", () => {
+        const detector: NotificationUIDetector = c.build();
+        expect(typeof detector.isTrayOpen).toBe("function");
+        expect(typeof detector.expandTray).toBe("function");
+        expect(typeof detector.collapseTray).toBe("function");
+        expect(typeof detector.getObservationTimestamp).toBe("function");
+        expect(typeof detector.tapElement).toBe("function");
+        expect(typeof detector.swipeElement).toBe("function");
+        expect(detector.device).toBeDefined();
+      });
+    });
+  }
+
+  describe("AndroidNotificationUIDetector behavior", () => {
+    it("detects an open notification shade", () => {
+      const detector = new AndroidNotificationUIDetector(androidDevice, {
+        executeAdbCommand: async () => ({ stdout: "", stderr: "" }),
+        getDeviceTimestampMs: async () => 0,
+      });
+      expect(detector.isTrayOpen(trayHierarchy)).toBe(true);
+      expect(detector.isTrayOpen(closedHierarchy)).toBe(false);
+      expect(detector.isTrayOpen(undefined)).toBe(false);
+    });
+
+    it("expands and collapses via shell cmd statusbar", async () => {
+      const commands: string[] = [];
+      const detector = new AndroidNotificationUIDetector(androidDevice, {
+        executeAdbCommand: async cmd => {
+          commands.push(cmd);
+          return { stdout: "", stderr: "" };
+        },
+        getDeviceTimestampMs: async () => 12345,
+      });
+
+      await detector.expandTray();
+      await detector.collapseTray();
+      expect(commands).toEqual([
+        "shell cmd statusbar expand-notifications",
+        "shell cmd statusbar collapse",
+      ]);
+    });
+
+    it("returns ADB device timestamp", async () => {
+      const detector = new AndroidNotificationUIDetector(androidDevice, {
+        executeAdbCommand: async () => ({ stdout: "", stderr: "" }),
+        getDeviceTimestampMs: async () => 4242,
+      });
+      expect(await detector.getObservationTimestamp()).toBe(4242);
+    });
+
+    it("issues shell input tap / swipe with element coordinates", async () => {
+      const commands: string[] = [];
+      const detector = new AndroidNotificationUIDetector(androidDevice, {
+        executeAdbCommand: async cmd => {
+          commands.push(cmd);
+          return { stdout: "", stderr: "" };
+        },
+        getDeviceTimestampMs: async () => 0,
+      });
+      await detector.tapElement(sampleElement);
+      await detector.swipeElement(sampleElement);
+      expect(commands[0]).toContain("shell input tap");
+      expect(commands[1]).toContain("shell input swipe");
+    });
+
+    it("wraps expand failures in ActionableError", async () => {
+      const detector = new AndroidNotificationUIDetector(androidDevice, {
+        executeAdbCommand: async () => {
+          throw new Error("device offline");
+        },
+        getDeviceTimestampMs: async () => 0,
+      });
+      await expect(detector.expandTray()).rejects.toThrow(/Failed to expand system tray/);
+    });
+  });
+
+  describe("IosNotificationUIDetector behavior", () => {
+    it("detects NotificationCenter only under SpringBoard", () => {
+      const detector = new IosNotificationUIDetector(iosDevice, {
+        requestSwipe: async () => ({ success: true }),
+        requestTapCoordinates: async () => ({ success: true }),
+        now: () => 0,
+      });
+      expect(detector.isTrayOpen(iosNotificationCenterHierarchy)).toBe(true);
+      expect(detector.isTrayOpen(iosAppHierarchy)).toBe(false);
+      expect(detector.isTrayOpen(undefined)).toBe(false);
+    });
+
+    it("emits a downward swipe to open NotificationCenter", async () => {
+      const swipes: Array<{ x1: number; y1: number; x2: number; y2: number; duration?: number }> = [];
+      const detector = new IosNotificationUIDetector(iosDevice, {
+        requestSwipe: async (x1, y1, x2, y2, duration) => {
+          swipes.push({ x1, y1, x2, y2, duration });
+          return { success: true };
+        },
+        requestTapCoordinates: async () => ({ success: true }),
+        now: () => 0,
+      });
+      await detector.expandTray(observationWithSize);
+      expect(swipes.length).toBe(1);
+      expect(swipes[0].y1).toBe(5);
+      expect(swipes[0].y2).toBeGreaterThan(swipes[0].y1);
+    });
+
+    it("emits an upward swipe to close NotificationCenter", async () => {
+      const swipes: Array<{ x1: number; y1: number; x2: number; y2: number; duration?: number }> = [];
+      const detector = new IosNotificationUIDetector(iosDevice, {
+        requestSwipe: async (x1, y1, x2, y2, duration) => {
+          swipes.push({ x1, y1, x2, y2, duration });
+          return { success: true };
+        },
+        requestTapCoordinates: async () => ({ success: true }),
+        now: () => 0,
+      });
+      await detector.collapseTray(observationWithSize);
+      expect(swipes.length).toBe(1);
+      expect(swipes[0].y1).toBeGreaterThan(swipes[0].y2);
+    });
+
+    it("rejects expand/collapse without screen dimensions", async () => {
+      const detector = new IosNotificationUIDetector(iosDevice, {
+        requestSwipe: async () => ({ success: true }),
+        requestTapCoordinates: async () => ({ success: true }),
+        now: () => 0,
+      });
+      await expect(detector.expandTray()).rejects.toThrow(/Screen dimensions/);
+      await expect(detector.collapseTray()).rejects.toThrow(/Screen dimensions/);
+    });
+
+    it("returns host timer timestamp", async () => {
+      const detector = new IosNotificationUIDetector(iosDevice, {
+        requestSwipe: async () => ({ success: true }),
+        requestTapCoordinates: async () => ({ success: true }),
+        now: () => 9999,
+      });
+      expect(await detector.getObservationTimestamp()).toBe(9999);
+    });
+
+    it("taps via CtrlProxy client coordinates", async () => {
+      const taps: Array<{ x: number; y: number }> = [];
+      const detector = new IosNotificationUIDetector(iosDevice, {
+        requestSwipe: async () => ({ success: true }),
+        requestTapCoordinates: async (x, y) => {
+          taps.push({ x, y });
+          return { success: true };
+        },
+        now: () => 0,
+      });
+      await detector.tapElement(sampleElement);
+      expect(taps.length).toBe(1);
+    });
+  });
+
+  describe("createNotificationUIDetector factory", () => {
+    const buildDeps = (): SystemTrayDependencies => ({
+      observeScreenFactory: () => ({ execute: async () => ({} as ObserveResult) }),
+      adbFactory: () => ({
+        executeCommand: async () => ({ stdout: "", stderr: "" }),
+        getDeviceTimestampMs: async () => 0,
+      }),
+      iosClientFactory: () => ({
+        requestSwipe: async () => ({ success: true }),
+        requestTapCoordinates: async () => ({ success: true }),
+      }),
+      timer: new FakeTimer(),
+    });
+
+    it("returns an AndroidNotificationUIDetector for Android devices", () => {
+      const detector = createNotificationUIDetector(androidDevice, buildDeps);
+      expect(detector).toBeInstanceOf(AndroidNotificationUIDetector);
+      expect(detector.device).toBe(androidDevice);
+    });
+
+    it("returns an IosNotificationUIDetector for iOS devices", () => {
+      const detector = createNotificationUIDetector(iosDevice, buildDeps);
+      expect(detector).toBeInstanceOf(IosNotificationUIDetector);
+      expect(detector.device).toBe(iosDevice);
+    });
+
+    it("throws when iOS client factory is missing", async () => {
+      const deps = (): SystemTrayDependencies => ({
+        ...buildDeps(),
+        iosClientFactory: undefined,
+      });
+      const detector = createNotificationUIDetector(iosDevice, deps);
+      await expect(detector.tapElement(sampleElement)).rejects.toThrow(/iOS CtrlProxy/);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Fifth in the platform-duplication refactor series (after #2182, #2249, #2251, #2253). Extracts the 11 platform branches in \`src/server/systemTrayHelpers.ts\` (1419 → 366 lines) into a \`NotificationUIDetector\` interface with two impls and a factory.

After this PR: \`grep -c "platform === " src/server/systemTrayHelpers.ts\` returns **0**. Public exports of \`systemTrayHelpers.ts\` are unchanged.

## What moved

| Concern | NotificationUIDetector method |
|---|---|
| Is the shade / NotificationCenter open? | \`isTrayOpen(viewHierarchy)\` |
| Open the shade | \`expandTray(observation?)\` |
| Close the shade | \`collapseTray(observation?)\` |
| `minTimestamp` for next observation | \`getObservationTimestamp()\` |
| Tap a notification row | \`tapElement(element)\` |
| Left-swipe a notification row | \`swipeElement(element)\` |

Shared pure helpers (\`SYSTEM_TRAY_PACKAGE\`, \`SYSTEM_TRAY_RESOURCE_ID_HINTS\`, \`SYSTEM_TRAY_NOTIFICATION_SWIPE_DURATION_MS\`, \`getNodeProperties\`, \`getHierarchyRoots\`, \`nodeHasSystemTrayHint\`, \`nodeHasIosNotificationCenterHint\`, \`traverseForHint\`) live in \`src/server/system-tray/notificationHints.ts\` so both adapters and the manager reference one source of truth.

## Design notes

- The orchestration in \`ensureSystemTrayOpen\` / \`ensureSystemTrayClosed\` collapsed from two large platform-branched blocks into a single linear flow because the detector encapsulates all per-platform variance (timestamp source + gesture).
- The factory accepts a \`() => SystemTrayDependencies\` getter (not a snapshot) so test fakes injected mid-run via \`setSystemTrayDependencies\` still propagate to detector calls.
- Public re-export of \`SYSTEM_TRAY_NOTIFICATION_SWIPE_DURATION_MS\` from \`systemTrayHelpers\` preserved for \`interactionTools.ts\`.

## Test plan

- [x] \`bun run lint\` clean
- [x] \`bun build.ts\` succeeds
- [x] Full \`bun test --bail\`: 4247 pass / 1 skip / 0 fail (73s)
- [x] 22 new unit tests in \`test/server/system-tray/NotificationUIDetector.test.ts\` covering both adapters via a data-driven \`DetectorCase\` table
- [x] All 25 existing \`test/server/systemTray.test.ts\` tests pass unmodified
- [x] \`grep -c "platform === " src/server/systemTrayHelpers.ts\` returns 0