### PR TITLE
fix(ci): upgrade Turborepo cache to actions/cache@v5 on Windows

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -770,7 +770,7 @@ jobs:
 
       - name: "Cache Turborepo"
         if: needs.detect-changes.outputs.docs_only != 'true' && needs.detect-changes.outputs.sha256_only != 'true'
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: .turbo
           key: turbo-${{ matrix.os }}-${{ hashFiles('bun.lock') }}-${{ github.sha }}


### PR DESCRIPTION
## Summary
- Upgrades `actions/cache@v4` → `actions/cache@v5` for the Turborepo cache step in the Windows `mcp-build-and-test` job
- Fixes `tar.exe` + `zstd` compression failure during post-job cleanup on Windows runners

## Test plan
- [ ] Windows `mcp-build-and-test` job completes without cache errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)