### PR TITLE
refactor(platform): introduce PlatformClient facade (capstone)

### DIFF
--- a/src/server/platform/createPlatformClient.ts
+++ b/src/server/platform/createPlatformClient.ts
@@ -2,7 +2,10 @@ import type { BootedDevice } from "../../models";
 import type { CtrlProxyClient } from "../../features/observe/interfaces/CtrlProxyClient";
 import type { AccessibilityDetector } from "../../utils/interfaces/AccessibilityDetector";
 import type { IosVoiceOverDetector } from "../../utils/interfaces/IosVoiceOverDetector";
+import type { NotificationUIDetector } from "../../utils/interfaces/NotificationUIDetector";
 import type { PlatformClient } from "../../utils/interfaces/PlatformClient";
+import type { SystemConfigurationAdapter } from "../../utils/interfaces/SystemConfigurationAdapter";
+import type { TapStrategy } from "../../utils/interfaces/TapStrategy";
 import type { ProcessExecutor } from "../../utils/ProcessExecutor";
 import type {
   AdbClientFactory,
@@ -31,8 +34,12 @@ export interface CreatePlatformClientOptions {
   accessibilityDetector?: AccessibilityDetector;
   iosVoiceOverDetector?: IosVoiceOverDetector;
   processExecutor?: ProcessExecutor;
-  /** Override the CtrlProxy client (e.g. inject a fake during tests). */
+  // Per-handle overrides for tests. Pass a fake instead of letting the
+  // factory build the default platform-specific implementation.
   ctrlProxy?: CtrlProxyClient;
+  tapStrategy?: TapStrategy;
+  systemConfiguration?: SystemConfigurationAdapter;
+  notificationUI?: NotificationUIDetector;
 }
 
 /**
@@ -64,27 +71,21 @@ export function createPlatformClient(
 
   const adb = adbFactory.create(device);
 
-  const tapStrategy = createTapStrategy(
-    device,
-    adb,
-    accessibilityDetector,
-    iosVoiceOverDetector
-  );
+  const tapStrategy =
+    options.tapStrategy ??
+    createTapStrategy(device, adb, accessibilityDetector, iosVoiceOverDetector);
 
-  const systemConfiguration = createSystemConfigurationAdapter(
-    device,
-    adb,
-    processExecutor
-  );
+  const systemConfiguration =
+    options.systemConfiguration ??
+    createSystemConfigurationAdapter(device, adb, processExecutor);
 
   // createNotificationUIDetector reads its dependencies lazily through
   // the supplied getter so callers that swap fakes via
   // setSystemTrayDependencies between invocations still see the latest
   // overrides — same shape as systemTrayHelpers.handleSystemTrayLookFor.
-  const notificationUI = createNotificationUIDetector(
-    device,
-    getSystemTrayDependencies
-  );
+  const notificationUI =
+    options.notificationUI ??
+    createNotificationUIDetector(device, getSystemTrayDependencies);
 
   return {
     device,

--- a/src/server/platform/createPlatformClient.ts
+++ b/src/server/platform/createPlatformClient.ts
@@ -1,0 +1,96 @@
+import type { BootedDevice } from "../../models";
+import type { CtrlProxyClient } from "../../features/observe/interfaces/CtrlProxyClient";
+import type { AccessibilityDetector } from "../../utils/interfaces/AccessibilityDetector";
+import type { IosVoiceOverDetector } from "../../utils/interfaces/IosVoiceOverDetector";
+import type { PlatformClient } from "../../utils/interfaces/PlatformClient";
+import type { ProcessExecutor } from "../../utils/ProcessExecutor";
+import type {
+  AdbClientFactory,
+} from "../../utils/android-cmdline-tools/AdbClientFactory";
+import { defaultAdbClientFactory } from "../../utils/android-cmdline-tools/AdbClientFactory";
+import { accessibilityDetector as defaultAccessibilityDetector } from "../../utils/AccessibilityDetector";
+import { iosVoiceOverDetector as defaultIosVoiceOverDetector } from "../../utils/IosVoiceOverDetector";
+import { DefaultProcessExecutor } from "../../utils/ProcessExecutor";
+import { AndroidCtrlProxyClient } from "../../features/observe/android/AndroidCtrlProxyClient";
+import { IOSCtrlProxyClient } from "../../features/observe/ios/IOSCtrlProxyClient";
+import { createTapStrategy } from "../../features/action/strategies/createTapStrategy";
+import { createSystemConfigurationAdapter } from "../../features/utility/system-configuration/createSystemConfigurationAdapter";
+import {
+  getSystemTrayDependencies,
+} from "../systemTrayHelpers";
+import { createNotificationUIDetector } from "../system-tray/createNotificationUIDetector";
+
+/**
+ * Optional injection points for {@link createPlatformClient}. All
+ * defaults reach for the same singletons the existing sub-factories
+ * use today, so callers that don't override anything get behaviour
+ * identical to constructing each handle by hand.
+ */
+export interface CreatePlatformClientOptions {
+  adbFactory?: AdbClientFactory;
+  accessibilityDetector?: AccessibilityDetector;
+  iosVoiceOverDetector?: IosVoiceOverDetector;
+  processExecutor?: ProcessExecutor;
+  /** Override the CtrlProxy client (e.g. inject a fake during tests). */
+  ctrlProxy?: CtrlProxyClient;
+}
+
+/**
+ * Build a {@link PlatformClient} for `device`. Performs exactly one
+ * `device.platform === "ios"` check and delegates the rest to the
+ * platform-agnostic sub-factories established in PRs #2251, #2253 and
+ * #2257.
+ *
+ * NOTE: This PR introduces the type + factory only. Call sites in
+ * `toolRegistry.ts` and elsewhere are migrated by follow-up PRs.
+ */
+export function createPlatformClient(
+  device: BootedDevice,
+  options: CreatePlatformClientOptions = {}
+): PlatformClient {
+  const adbFactory = options.adbFactory ?? defaultAdbClientFactory;
+  const accessibilityDetector =
+    options.accessibilityDetector ?? defaultAccessibilityDetector;
+  const iosVoiceOverDetector =
+    options.iosVoiceOverDetector ?? defaultIosVoiceOverDetector;
+  const processExecutor =
+    options.processExecutor ?? new DefaultProcessExecutor();
+
+  const ctrlProxy: CtrlProxyClient =
+    options.ctrlProxy ??
+    (device.platform === "ios"
+      ? IOSCtrlProxyClient.getInstance(device)
+      : AndroidCtrlProxyClient.getInstance(device, adbFactory));
+
+  const adb = adbFactory.create(device);
+
+  const tapStrategy = createTapStrategy(
+    device,
+    adb,
+    accessibilityDetector,
+    iosVoiceOverDetector
+  );
+
+  const systemConfiguration = createSystemConfigurationAdapter(
+    device,
+    adb,
+    processExecutor
+  );
+
+  // createNotificationUIDetector reads its dependencies lazily through
+  // the supplied getter so callers that swap fakes via
+  // setSystemTrayDependencies between invocations still see the latest
+  // overrides — same shape as systemTrayHelpers.handleSystemTrayLookFor.
+  const notificationUI = createNotificationUIDetector(
+    device,
+    getSystemTrayDependencies
+  );
+
+  return {
+    device,
+    ctrlProxy,
+    tapStrategy,
+    systemConfiguration,
+    notificationUI,
+  };
+}

--- a/src/utils/interfaces/PlatformClient.ts
+++ b/src/utils/interfaces/PlatformClient.ts
@@ -1,0 +1,36 @@
+import type { BootedDevice } from "../../models";
+import type { CtrlProxyClient } from "../../features/observe/interfaces/CtrlProxyClient";
+import type { NotificationUIDetector } from "./NotificationUIDetector";
+import type { SystemConfigurationAdapter } from "./SystemConfigurationAdapter";
+import type { TapStrategy } from "./TapStrategy";
+
+/**
+ * Facade that bundles the platform-specific handles a tool typically
+ * needs into a single object. Established in PRs #2182, #2249, #2251,
+ * #2253 and #2257, each interface in this bundle replaces one
+ * `device.platform === ...` branch inside a feature. Composing them
+ * here lets a tool wire dependencies via a single dispatch point.
+ *
+ * Why a facade rather than five constructor args: most call sites need
+ * the same combination (ctrlProxy + tapStrategy + systemConfiguration +
+ * notificationUI), so threading them individually leaks platform-
+ * dispatch concerns into every constructor. This PR establishes only
+ * the type and a default factory; existing call sites are migrated by
+ * follow-ups.
+ */
+export interface PlatformClient {
+  /** The device this client is bound to. */
+  readonly device: BootedDevice;
+
+  /** Platform-appropriate CtrlProxy client (Android / iOS). */
+  readonly ctrlProxy: CtrlProxyClient;
+
+  /** Platform-appropriate tap strategy. See PR #2251. */
+  readonly tapStrategy: TapStrategy;
+
+  /** Platform-appropriate system-configuration adapter. See PR #2253. */
+  readonly systemConfiguration: SystemConfigurationAdapter;
+
+  /** Platform-appropriate notification-UI detector. See PR #2257. */
+  readonly notificationUI: NotificationUIDetector;
+}

--- a/src/utils/interfaces/index.ts
+++ b/src/utils/interfaces/index.ts
@@ -15,6 +15,7 @@ export type {
   SystemConfigurationAdapter,
 } from "./SystemConfigurationAdapter";
 export type { NotificationUIDetector } from "./NotificationUIDetector";
+export type { PlatformClient } from "./PlatformClient";
 // Screenshot utilities - split into focused classes (Phase 3.1)
 export { ScreenshotComparator } from "../screenshot/ScreenshotComparator";
 export { PerceptualHasher } from "../screenshot/PerceptualHasher";

--- a/test/fakes/FakePlatformClient.ts
+++ b/test/fakes/FakePlatformClient.ts
@@ -6,20 +6,29 @@ import { FakeSystemConfigurationAdapter } from "./FakeSystemConfigurationAdapter
 import { FakeTapStrategy } from "./FakeTapStrategy";
 
 /**
- * Minimal composition fake for {@link PlatformClient}. Holds the
- * already-existing sub-fakes (`FakeTapStrategy`,
- * `FakeSystemConfigurationAdapter`, `FakeNotificationUIDetector`) and
- * exposes them through the facade's readonly fields.
+ * Composition fake for {@link PlatformClient}. Holds the existing
+ * sub-fakes (`FakeTapStrategy`, `FakeSystemConfigurationAdapter`,
+ * `FakeNotificationUIDetector`) and exposes them through the facade's
+ * readonly fields. Tests should reach for the sub-fake
+ * (e.g. `.tapStrategy.wasMethodCalled(...)`) to inspect interactions —
+ * this fake intentionally doesn't add its own recording layer.
  *
- * Tests should reach for the sub-fake (e.g. `.tapStrategy.wasMethodCalled(...)`)
- * to inspect interactions — this fake intentionally doesn't add its own
- * recording layer.
- *
- * `ctrlProxy` is left as a placeholder cast: most facade-aware call
- * sites that need a real-ish CtrlProxy already use `FakeCtrlProxy` for
- * the Android surface; passing a custom one via the constructor is the
- * right thing when the test exercises CtrlProxy behaviour.
+ * The default `ctrlProxy` is a Proxy that throws on any access with a
+ * pointed error, so tests that inadvertently touch it (without passing
+ * an `overrides.ctrlProxy`) get a clear failure rather than a silent
+ * `undefined is not a function`.
  */
+
+const throwingCtrlProxy = (): CtrlProxyClient =>
+  new Proxy({} as CtrlProxyClient, {
+    get(_target, prop) {
+      throw new Error(
+        `FakePlatformClient.ctrlProxy was accessed (.${String(prop)}) but no CtrlProxy was injected. ` +
+        "Pass `overrides.ctrlProxy` to the FakePlatformClient constructor."
+      );
+    },
+  });
+
 export class FakePlatformClient implements PlatformClient {
   readonly device: BootedDevice;
   readonly ctrlProxy: CtrlProxyClient;
@@ -43,9 +52,7 @@ export class FakePlatformClient implements PlatformClient {
         name: "Fake",
         platform: "android",
       } as BootedDevice);
-    this.ctrlProxy =
-      overrides.ctrlProxy ??
-      ({} as CtrlProxyClient); // Placeholder; tests that exercise CtrlProxy should inject their own.
+    this.ctrlProxy = overrides.ctrlProxy ?? throwingCtrlProxy();
     this.tapStrategy = overrides.tapStrategy ?? new FakeTapStrategy();
     this.systemConfiguration =
       overrides.systemConfiguration ?? new FakeSystemConfigurationAdapter();

--- a/test/fakes/FakePlatformClient.ts
+++ b/test/fakes/FakePlatformClient.ts
@@ -1,0 +1,55 @@
+import type { BootedDevice } from "../../src/models";
+import type { CtrlProxyClient } from "../../src/features/observe/interfaces/CtrlProxyClient";
+import type { PlatformClient } from "../../src/utils/interfaces/PlatformClient";
+import { FakeNotificationUIDetector } from "./FakeNotificationUIDetector";
+import { FakeSystemConfigurationAdapter } from "./FakeSystemConfigurationAdapter";
+import { FakeTapStrategy } from "./FakeTapStrategy";
+
+/**
+ * Minimal composition fake for {@link PlatformClient}. Holds the
+ * already-existing sub-fakes (`FakeTapStrategy`,
+ * `FakeSystemConfigurationAdapter`, `FakeNotificationUIDetector`) and
+ * exposes them through the facade's readonly fields.
+ *
+ * Tests should reach for the sub-fake (e.g. `.tapStrategy.wasMethodCalled(...)`)
+ * to inspect interactions — this fake intentionally doesn't add its own
+ * recording layer.
+ *
+ * `ctrlProxy` is left as a placeholder cast: most facade-aware call
+ * sites that need a real-ish CtrlProxy already use `FakeCtrlProxy` for
+ * the Android surface; passing a custom one via the constructor is the
+ * right thing when the test exercises CtrlProxy behaviour.
+ */
+export class FakePlatformClient implements PlatformClient {
+  readonly device: BootedDevice;
+  readonly ctrlProxy: CtrlProxyClient;
+  readonly tapStrategy: FakeTapStrategy;
+  readonly systemConfiguration: FakeSystemConfigurationAdapter;
+  readonly notificationUI: FakeNotificationUIDetector;
+
+  constructor(
+    device?: BootedDevice,
+    overrides: Partial<{
+      ctrlProxy: CtrlProxyClient;
+      tapStrategy: FakeTapStrategy;
+      systemConfiguration: FakeSystemConfigurationAdapter;
+      notificationUI: FakeNotificationUIDetector;
+    }> = {}
+  ) {
+    this.device =
+      device ??
+      ({
+        deviceId: "fake-device",
+        name: "Fake",
+        platform: "android",
+      } as BootedDevice);
+    this.ctrlProxy =
+      overrides.ctrlProxy ??
+      ({} as CtrlProxyClient); // Placeholder; tests that exercise CtrlProxy should inject their own.
+    this.tapStrategy = overrides.tapStrategy ?? new FakeTapStrategy();
+    this.systemConfiguration =
+      overrides.systemConfiguration ?? new FakeSystemConfigurationAdapter();
+    this.notificationUI =
+      overrides.notificationUI ?? new FakeNotificationUIDetector(this.device);
+  }
+}

--- a/test/server/platform/PlatformClient.test.ts
+++ b/test/server/platform/PlatformClient.test.ts
@@ -1,0 +1,163 @@
+import { describe, it, expect } from "bun:test";
+import { createPlatformClient } from "../../../src/server/platform/createPlatformClient";
+import { AndroidCtrlProxyClient } from "../../../src/features/observe/android/AndroidCtrlProxyClient";
+import { IOSCtrlProxyClient } from "../../../src/features/observe/ios/IOSCtrlProxyClient";
+import { AndroidTapStrategy } from "../../../src/features/action/strategies/AndroidTapStrategy";
+import { IosTapStrategy } from "../../../src/features/action/strategies/IosTapStrategy";
+import { AndroidSystemConfigurationAdapter } from "../../../src/features/utility/system-configuration/AndroidSystemConfigurationAdapter";
+import { IosSystemConfigurationAdapter } from "../../../src/features/utility/system-configuration/IosSystemConfigurationAdapter";
+import { AndroidNotificationUIDetector } from "../../../src/server/system-tray/AndroidNotificationUIDetector";
+import { IosNotificationUIDetector } from "../../../src/server/system-tray/IosNotificationUIDetector";
+import { FakeAdbClientFactory } from "../../fakes/FakeAdbClientFactory";
+import { FakeAccessibilityDetector } from "../../fakes/FakeAccessibilityDetector";
+import { FakeIosVoiceOverDetector } from "../../fakes/FakeIosVoiceOverDetector";
+import { FakeProcessExecutor } from "../../fakes/FakeProcessExecutor";
+import { FakePlatformClient } from "../../fakes/FakePlatformClient";
+import type { BootedDevice } from "../../../src/models";
+import type { PlatformClient } from "../../../src/utils/interfaces/PlatformClient";
+
+/**
+ * Conformance test for the PlatformClient facade. Verifies that
+ * `createPlatformClient` performs platform dispatch correctly for each
+ * of the five bundled handles, that the fake satisfies the same
+ * interface, and that the assembled object is structurally valid as a
+ * `PlatformClient`.
+ */
+describe("PlatformClient", () => {
+  const androidDevice: BootedDevice = {
+    deviceId: "emulator-5554",
+    name: "Pixel_5",
+    platform: "android",
+  };
+  const iosDevice: BootedDevice = {
+    deviceId: "00001234-ABCD",
+    name: "iPhone 15",
+    platform: "ios",
+  };
+
+  const buildOptions = () => ({
+    adbFactory: new FakeAdbClientFactory(),
+    accessibilityDetector: new FakeAccessibilityDetector(),
+    iosVoiceOverDetector: new FakeIosVoiceOverDetector(),
+    processExecutor: new FakeProcessExecutor(),
+  });
+
+  interface PlatformCase {
+    name: string;
+    device: BootedDevice;
+    expectedCtrlProxyCtor: Function;
+    expectedTapStrategyCtor: Function;
+    expectedSystemConfigCtor: Function;
+    expectedNotificationUICtor: Function;
+  }
+
+  const cases: ReadonlyArray<PlatformCase> = [
+    {
+      name: "android",
+      device: androidDevice,
+      expectedCtrlProxyCtor: AndroidCtrlProxyClient,
+      expectedTapStrategyCtor: AndroidTapStrategy,
+      expectedSystemConfigCtor: AndroidSystemConfigurationAdapter,
+      expectedNotificationUICtor: AndroidNotificationUIDetector,
+    },
+    {
+      name: "ios",
+      device: iosDevice,
+      expectedCtrlProxyCtor: IOSCtrlProxyClient,
+      expectedTapStrategyCtor: IosTapStrategy,
+      expectedSystemConfigCtor: IosSystemConfigurationAdapter,
+      expectedNotificationUICtor: IosNotificationUIDetector,
+    },
+  ];
+
+  for (const c of cases) {
+    describe(`createPlatformClient (${c.name})`, () => {
+      it("returns the platform-appropriate CtrlProxy client", () => {
+        const client = createPlatformClient(c.device, buildOptions());
+        expect(client.ctrlProxy).toBeInstanceOf(c.expectedCtrlProxyCtor);
+      });
+
+      it("returns the platform-appropriate TapStrategy", () => {
+        const client = createPlatformClient(c.device, buildOptions());
+        expect(client.tapStrategy).toBeInstanceOf(c.expectedTapStrategyCtor);
+      });
+
+      it("returns the platform-appropriate SystemConfigurationAdapter", () => {
+        const client = createPlatformClient(c.device, buildOptions());
+        expect(client.systemConfiguration).toBeInstanceOf(
+          c.expectedSystemConfigCtor
+        );
+      });
+
+      it("returns the platform-appropriate NotificationUIDetector", () => {
+        const client = createPlatformClient(c.device, buildOptions());
+        expect(client.notificationUI).toBeInstanceOf(
+          c.expectedNotificationUICtor
+        );
+      });
+
+      it("bundles the same device on the facade", () => {
+        const client = createPlatformClient(c.device, buildOptions());
+        expect(client.device).toBe(c.device);
+        expect(client.notificationUI.device).toBe(c.device);
+      });
+
+      it("satisfies the PlatformClient interface", () => {
+        const client: PlatformClient = createPlatformClient(
+          c.device,
+          buildOptions()
+        );
+        expect(client.device).toBeDefined();
+        expect(client.ctrlProxy).toBeDefined();
+        expect(typeof client.tapStrategy.isAccessibilityServiceEnabled).toBe(
+          "function"
+        );
+        expect(typeof client.systemConfiguration.setLocale).toBe("function");
+        expect(typeof client.notificationUI.isTrayOpen).toBe("function");
+      });
+    });
+  }
+
+  describe("createPlatformClient ctrlProxy override", () => {
+    it("uses the injected ctrlProxy without constructing a platform client", () => {
+      const sentinel = { sentinel: true } as any;
+      const client = createPlatformClient(androidDevice, {
+        ...buildOptions(),
+        ctrlProxy: sentinel,
+      });
+      expect(client.ctrlProxy).toBe(sentinel);
+    });
+  });
+
+  describe("FakePlatformClient", () => {
+    it("satisfies the PlatformClient interface", () => {
+      const fake = new FakePlatformClient(androidDevice);
+      const asFacade: PlatformClient = fake;
+      expect(asFacade.device).toBe(androidDevice);
+      expect(asFacade.tapStrategy).toBe(fake.tapStrategy);
+      expect(asFacade.systemConfiguration).toBe(fake.systemConfiguration);
+      expect(asFacade.notificationUI).toBe(fake.notificationUI);
+    });
+
+    it("forwards recording calls to the bundled sub-fakes", async () => {
+      const fake = new FakePlatformClient(androidDevice);
+      await fake.tapStrategy.isAccessibilityServiceEnabled();
+      await fake.systemConfiguration.setTimeZone("UTC");
+      fake.notificationUI.isTrayOpen(undefined);
+
+      expect(fake.tapStrategy.wasMethodCalled("isAccessibilityServiceEnabled"))
+        .toBe(true);
+      expect(fake.systemConfiguration.wasMethodCalled("setTimeZone"))
+        .toBe(true);
+      expect(fake.notificationUI.wasMethodCalled("isTrayOpen")).toBe(true);
+    });
+
+    it("accepts injected sub-fakes through the overrides bag", () => {
+      const tap = new FakePlatformClient().tapStrategy;
+      tap.longPressDurationMs = 12345;
+      const fake = new FakePlatformClient(iosDevice, { tapStrategy: tap });
+      expect(fake.tapStrategy.longPressDurationMs).toBe(12345);
+      expect(fake.device).toBe(iosDevice);
+    });
+  });
+});

--- a/test/server/platform/PlatformClient.test.ts
+++ b/test/server/platform/PlatformClient.test.ts
@@ -13,6 +13,9 @@ import { FakeAccessibilityDetector } from "../../fakes/FakeAccessibilityDetector
 import { FakeIosVoiceOverDetector } from "../../fakes/FakeIosVoiceOverDetector";
 import { FakeProcessExecutor } from "../../fakes/FakeProcessExecutor";
 import { FakePlatformClient } from "../../fakes/FakePlatformClient";
+import { FakeTapStrategy } from "../../fakes/FakeTapStrategy";
+import { FakeSystemConfigurationAdapter } from "../../fakes/FakeSystemConfigurationAdapter";
+import { FakeNotificationUIDetector } from "../../fakes/FakeNotificationUIDetector";
 import type { BootedDevice } from "../../../src/models";
 import type { PlatformClient } from "../../../src/utils/interfaces/PlatformClient";
 
@@ -118,7 +121,7 @@ describe("PlatformClient", () => {
     });
   }
 
-  describe("createPlatformClient ctrlProxy override", () => {
+  describe("createPlatformClient overrides", () => {
     it("uses the injected ctrlProxy without constructing a platform client", () => {
       const sentinel = { sentinel: true } as any;
       const client = createPlatformClient(androidDevice, {
@@ -126,6 +129,23 @@ describe("PlatformClient", () => {
         ctrlProxy: sentinel,
       });
       expect(client.ctrlProxy).toBe(sentinel);
+    });
+
+    it("honors per-handle overrides for tapStrategy, systemConfiguration, and notificationUI", () => {
+      const tapStrategy = new FakeTapStrategy();
+      const systemConfiguration = new FakeSystemConfigurationAdapter();
+      const notificationUI = new FakeNotificationUIDetector(androidDevice);
+
+      const client = createPlatformClient(androidDevice, {
+        ...buildOptions(),
+        tapStrategy,
+        systemConfiguration,
+        notificationUI,
+      });
+
+      expect(client.tapStrategy).toBe(tapStrategy);
+      expect(client.systemConfiguration).toBe(systemConfiguration);
+      expect(client.notificationUI).toBe(notificationUI);
     });
   });
 
@@ -158,6 +178,12 @@ describe("PlatformClient", () => {
       const fake = new FakePlatformClient(iosDevice, { tapStrategy: tap });
       expect(fake.tapStrategy.longPressDurationMs).toBe(12345);
       expect(fake.device).toBe(iosDevice);
+    });
+
+    it("default ctrlProxy throws on access with a pointed message", () => {
+      const fake = new FakePlatformClient(androidDevice);
+      expect(() => (fake.ctrlProxy as any).getAccessibilityHierarchy())
+        .toThrow(/FakePlatformClient\.ctrlProxy/);
     });
   });
 });


### PR DESCRIPTION
## Summary

**Capstone** of a 6-PR series that pushed Android/iOS platform differences into deeper layers of the TypeScript MCP server. The five preceding PRs each replaced a platform branch with a sub-interface; this PR introduces the facade that bundles them so callers can resolve all platform-specific handles in a single \`createPlatformClient(device)\` call instead of constructing each piece by hand.

This is the **minimal** version per the "establish the interface; don't chase callers" pattern of prior PRs in the series — it defines the type, the factory, and tests. **No existing call sites are migrated** in this PR; that's left to follow-ups.

## The facade

\`\`\`ts
export interface PlatformClient {
  readonly device: BootedDevice;
  readonly ctrlProxy: CtrlProxyClient;                       // existing
  readonly tapStrategy: TapStrategy;                         // PR #2251
  readonly systemConfiguration: SystemConfigurationAdapter;  // PR #2253
  readonly notificationUI: NotificationUIDetector;           // PR #2257
}
\`\`\`

\`createPlatformClient(device, options?)\` does **exactly one** \`device.platform === "ios"\` check (the CtrlProxy singleton dispatch). The three sub-factories — \`createTapStrategy\`, \`createSystemConfigurationAdapter\`, \`createNotificationUIDetector\` — handle their own dispatch internally.

## Design notes

- Snapshot capture/restore providers from PR #2249 were intentionally **omitted** — they require additional state (config repository, snapshot store) only meaningful for snapshot ops, so bundling them would have bloated facade construction without value for typical call sites.
- All four bundled handles (\`ctrlProxy\`, \`tapStrategy\`, \`systemConfiguration\`, \`notificationUI\`) can be overridden individually via \`CreatePlatformClientOptions\` for symmetric test injection.
- \`FakePlatformClient\` composes the existing recording sub-fakes (\`FakeTapStrategy\`, \`FakeSystemConfigurationAdapter\`, \`FakeNotificationUIDetector\`) — no new recording layer. The default \`ctrlProxy\` is a Proxy that throws on any access with a pointed error, so tests that inadvertently touch it get a clear failure rather than a silent \`undefined is not a function\`.

## Series recap

| # | PR | What it replaced |
|---|---|---|
| 1 | #2182 | Duplicate lifecycle methods on \`CtrlProxyManager\` / \`IOSCtrlProxyManager\` |
| 2 | #2249 | Branching between \`CaptureSnapshot\` / \`CaptureSnapshotIos\` |
| 3 | #2251 | 7 platform branches in \`TapOnElement.ts\` |
| 4 | #2253 | 9 platform branches in \`SystemConfigurationManager.ts\` (file shrank 950 → 211 lines) |
| 5 | #2257 | 11 platform branches in \`systemTrayHelpers.ts\` (file shrank 1419 → 366 lines) |
| 6 | this PR | Composition facade so callers don't reassemble the bundle themselves |

## Test plan

- [x] \`bun run lint\` clean
- [x] \`bun build.ts\` succeeds
- [x] Full \`bun test --bail\`: 4298 pass / 1 skip / 0 fail (14s)
- [x] 18 new unit tests in \`test/server/platform/PlatformClient.test.ts\` — data-driven \`PlatformCase\` loop verifying each platform produces the right concrete types for all four bundled handles, plus override symmetry and the FakePlatformClient guard tests