### PR TITLE
fix(action): address tapOn/tapAny review feedback

### DIFF
--- a/src/features/action/TapAnyElement.ts
+++ b/src/features/action/TapAnyElement.ts
@@ -100,9 +100,23 @@ export class TapAnyElement extends BaseVisualChange {
     return this.finder.hasContainerElement(viewHierarchy, container);
   }
 
+  private isElementCenterOffScreen(
+    element: Element,
+    screenSize?: ObserveResult["screenSize"]
+  ): boolean {
+    if (!screenSize?.width || !screenSize?.height || !element.bounds) {
+      return false;
+    }
+    const centerX = (element.bounds.left + element.bounds.right) / 2;
+    const centerY = (element.bounds.top + element.bounds.bottom) / 2;
+    return centerX < 0 || centerX > screenSize.width ||
+           centerY < 0 || centerY > screenSize.height;
+  }
+
   private findClickableElement(
     options: TapAnyElementOptions,
-    viewHierarchy: ViewHierarchyResult
+    viewHierarchy: ViewHierarchyResult,
+    screenSize?: ObserveResult["screenSize"]
   ): { element: Element | null; containerFound: boolean } {
     const containerFound = this.isContainerAvailable(viewHierarchy, options.container);
     const selection = this.elementSelector.selectClickable(viewHierarchy, {
@@ -110,6 +124,9 @@ export class TapAnyElement extends BaseVisualChange {
       strategy: options.selectionStrategy,
       scrollableContainer: options.scrollableContainer
     });
+    if (selection.element && this.isElementCenterOffScreen(selection.element, screenSize)) {
+      return { element: null, containerFound };
+    }
     return { element: selection.element, containerFound };
   }
 
@@ -225,9 +242,8 @@ export class TapAnyElement extends BaseVisualChange {
           let requestCount = 0;
           let changeCount = 0;
           let lastHash = this.hashViewHierarchy(viewHierarchy);
-          let latestHierarchy = viewHierarchy;
 
-          let found = this.findClickableElement(options, latestHierarchy);
+          let found = this.findClickableElement(options, viewHierarchy, observeResult.screenSize);
           let element = found.element;
           let containerFoundEver = found.containerFound;
 
@@ -246,14 +262,13 @@ export class TapAnyElement extends BaseVisualChange {
               requestCount += 1;
               if (!refreshed) {continue;}
 
-              latestHierarchy = refreshed;
               const hash = this.hashViewHierarchy(refreshed);
               if (hash && hash !== lastHash) {
                 changeCount += 1;
                 lastHash = hash;
               }
 
-              found = this.findClickableElement(options, refreshed);
+              found = this.findClickableElement(options, refreshed, observeResult.screenSize);
               element = found.element;
               containerFoundEver = containerFoundEver || found.containerFound;
               if (element) {break;}

--- a/src/features/action/TapOnElement.ts
+++ b/src/features/action/TapOnElement.ts
@@ -266,10 +266,9 @@ export class TapOnElement extends BaseVisualChange {
     if (options.elementId) {
       if (options.sibling) {
         return {
-          selection: this.elementSelector.selectClickableSiblingOfText(viewHierarchy, options.elementId, {
+          selection: this.elementSelector.selectClickableSiblingOfResourceId(viewHierarchy, options.elementId, {
             container: options.container,
-            fuzzyMatch: false,
-            caseSensitive: true,
+            partialMatch: false,
             strategy: options.selectionStrategy
           }),
           containerFound

--- a/src/features/utility/DefaultElementSelector.ts
+++ b/src/features/utility/DefaultElementSelector.ts
@@ -117,6 +117,25 @@ export class DefaultElementSelector implements ElementSelector {
     return this.pickMatch(matches, strategy);
   }
 
+  selectClickableSiblingOfResourceId(
+    viewHierarchy: ViewHierarchyResult,
+    resourceId: string,
+    options?: {
+      container?: { elementId?: string; text?: string } | null;
+      partialMatch?: boolean;
+      strategy?: ElementSelectionStrategy;
+    }
+  ): ElementSelectionResult {
+    const strategy = options?.strategy ?? "first";
+    const matches = this.finder.findClickableSiblingsOfResourceId(
+      viewHierarchy,
+      resourceId,
+      options?.container ?? null,
+      options?.partialMatch ?? false
+    );
+    return this.pickMatch(matches, strategy);
+  }
+
   private pickMatch(matches: Element[], strategy: ElementSelectionStrategy): ElementSelectionResult {
     const totalMatches = matches.length;
     if (totalMatches === 0) {

--- a/src/features/utility/ElementFinder.ts
+++ b/src/features/utility/ElementFinder.ts
@@ -929,6 +929,106 @@ export class DefaultElementFinder implements ElementFinder {
     return [];
   }
 
+  findClickableSiblingsOfResourceId(
+    viewHierarchy: ViewHierarchyResult,
+    resourceId: string,
+    container: { elementId?: string; text?: string } | null = null,
+    partialMatch: boolean = false
+  ): Element[] {
+    if (!viewHierarchy || !resourceId) {
+      return [];
+    }
+
+    const matchesId = (input?: string): boolean => {
+      if (!input) {return false;}
+      return partialMatch
+        ? input.toLowerCase().includes(resourceId.toLowerCase())
+        : input === resourceId;
+    };
+
+    const containerNode = container
+      ? this.findContainerNodeInternal(viewHierarchy, container)
+      : null;
+
+    if (container && !containerNode) {
+      return [];
+    }
+
+    const searchRoots = containerNode
+      ? [containerNode]
+      : this.parser.extractRootNodes(viewHierarchy);
+
+    const siblings = this.collectClickableSiblingsWithResourceIdInRoots(searchRoots, matchesId);
+
+    if (siblings.length > 0) {
+      return siblings;
+    }
+
+    if (!containerNode) {
+      const windowRootGroups = this.parser.extractWindowRootGroups(viewHierarchy, "topmost-first");
+      for (const windowRoots of windowRootGroups) {
+        const windowMatches = this.collectClickableSiblingsWithResourceIdInRoots(windowRoots, matchesId);
+        if (windowMatches.length > 0) {
+          return windowMatches;
+        }
+      }
+    }
+
+    return [];
+  }
+
+  private collectClickableSiblingsWithResourceIdInRoots(
+    rootNodes: ViewHierarchyNode[],
+    matchesId: (input?: string) => boolean
+  ): Element[] {
+    const results: Element[] = [];
+    for (const rootNode of rootNodes) {
+      this.findClickableSiblingsOfResourceIdInNode(rootNode, matchesId, results);
+    }
+    return results;
+  }
+
+  private findClickableSiblingsOfResourceIdInNode(
+    node: ViewHierarchyNode,
+    matchesId: (input?: string) => boolean,
+    results: Element[]
+  ): void {
+    const children = node.node;
+    if (!children) {
+      return;
+    }
+
+    const childArray: ViewHierarchyNode[] = Array.isArray(children)
+      ? children
+      : [children];
+
+    const hasIdMatch = childArray.some(child => {
+      const props = this.parser.extractNodeProperties(child);
+      const rid = props["resource-id"];
+      return typeof rid === "string" && matchesId(rid);
+    });
+
+    if (hasIdMatch) {
+      for (const child of childArray) {
+        const childProps = this.parser.extractNodeProperties(child);
+        const isClickable = childProps.clickable === "true" || childProps.clickable === true;
+        const childRid = childProps["resource-id"];
+        const isIdMatch = typeof childRid === "string" && matchesId(childRid);
+
+        if (isClickable && !isIdMatch) {
+          const parsedNode = this.parser.parseNodeBounds(child);
+          if (parsedNode) {
+            results.push(parsedNode);
+          }
+        }
+      }
+    }
+
+    for (const child of childArray) {
+      this.findClickableSiblingsOfResourceIdInNode(child, matchesId, results);
+    }
+  }
+
   /**
    * Internal method to find clickable siblings of text-matching elements.
    */

--- a/test/fakes/FakeElementSelector.ts
+++ b/test/fakes/FakeElementSelector.ts
@@ -124,4 +124,19 @@ export class FakeElementSelector implements ElementSelector {
     this.lastText = text;
     return this.buildSelectionResult(options?.strategy);
   }
+
+  selectClickableSiblingOfResourceId(
+    viewHierarchy: ViewHierarchyResult,
+    resourceId: string,
+    options?: {
+      container?: { elementId?: string; text?: string } | null;
+      partialMatch?: boolean;
+      strategy?: ElementSelectionStrategy;
+    }
+  ): ElementSelectionResult {
+    void viewHierarchy;
+    this.lastStrategy = options?.strategy;
+    this.lastResourceId = resourceId;
+    return this.buildSelectionResult(options?.strategy);
+  }
 }

--- a/test/features/action/TapAnyElement.test.ts
+++ b/test/features/action/TapAnyElement.test.ts
@@ -114,5 +114,48 @@ describe("TapAnyElement", () => {
 
       expect(result.element).toBeNull();
     });
+
+    test("filters out element whose center is off-screen", () => {
+      const offScreenElement = {
+        bounds: { left: -200, top: -200, right: -100, bottom: -100 },
+        text: "Hidden",
+        clickable: "true",
+      } as any;
+      const selector = new FakeElementSelector(offScreenElement);
+      const tapAny = createTapAnyElement(selector);
+
+      const result = (tapAny as any).findClickableElement(
+        { action: "tap" },
+        { hierarchy: { node: {} } },
+        { width: 1080, height: 1920 }
+      );
+
+      expect(result.element).toBeNull();
+    });
+
+    test("keeps element whose center is on-screen", () => {
+      const selector = new FakeElementSelector(makeElement());
+      const tapAny = createTapAnyElement(selector);
+
+      const result = (tapAny as any).findClickableElement(
+        { action: "tap" },
+        { hierarchy: { node: {} } },
+        { width: 1080, height: 1920 }
+      );
+
+      expect(result.element).not.toBeNull();
+    });
+
+    test("keeps element when screenSize is not provided", () => {
+      const selector = new FakeElementSelector(makeElement());
+      const tapAny = createTapAnyElement(selector);
+
+      const result = (tapAny as any).findClickableElement(
+        { action: "tap" },
+        { hierarchy: { node: {} } }
+      );
+
+      expect(result.element).not.toBeNull();
+    });
   });
 });

--- a/test/features/action/TapOnElement.extendedSelectors.test.ts
+++ b/test/features/action/TapOnElement.extendedSelectors.test.ts
@@ -128,7 +128,7 @@ describe("TapOnElement extended selectors", () => {
       expect(selector.lastText).toBe("Accept Terms");
     });
 
-    test("elementId + sibling delegates to selectClickableSiblingOfText", () => {
+    test("elementId + sibling delegates to selectClickableSiblingOfResourceId", () => {
       const selector = new FakeElementSelector(makeElement());
       const tapOn = createTapOnElement(selector);
 
@@ -138,7 +138,7 @@ describe("TapOnElement extended selectors", () => {
       );
 
       expect(result.selection.element).not.toBeNull();
-      expect(selector.lastText).toBe("com.app:id/label");
+      expect(selector.lastResourceId).toBe("com.app:id/label");
     });
 
     test("sibling respects selectionStrategy", () => {

--- a/test/features/utility/ElementFinder.test.ts
+++ b/test/features/utility/ElementFinder.test.ts
@@ -290,4 +290,73 @@ describe("DefaultElementFinder", () => {
       expect(finder.validateElementText(found, "Login")).toBe(false);
     });
   });
+
+  describe("findClickableSiblingsOfResourceId", () => {
+    test("returns empty for null hierarchy", () => {
+      expect(finder.findClickableSiblingsOfResourceId(null as any, "com.app:id/label")).toEqual([]);
+    });
+
+    test("returns empty for empty resourceId", () => {
+      const hierarchy = makeHierarchy([]);
+      expect(finder.findClickableSiblingsOfResourceId(hierarchy, "")).toEqual([]);
+    });
+
+    test("finds clickable sibling of node with matching resource-id", () => {
+      const hierarchy = makeHierarchy([
+        {
+          $: { bounds: "[0,0][1080,200]" },
+          node: [
+            { $: { "resource-id": "com.app:id/label", "bounds": "[0,0][500,100]" } },
+            { $: { clickable: "true", bounds: "[500,0][1080,100]" } },
+          ],
+        },
+      ]);
+      const results = finder.findClickableSiblingsOfResourceId(hierarchy, "com.app:id/label");
+      expect(results.length).toBe(1);
+      expect(results[0].bounds).toEqual({ left: 500, top: 0, right: 1080, bottom: 100 });
+    });
+
+    test("does not return the resource-id node itself even if clickable", () => {
+      const hierarchy = makeHierarchy([
+        {
+          $: { bounds: "[0,0][1080,200]" },
+          node: [
+            { $: { "resource-id": "com.app:id/label", "clickable": "true", "bounds": "[0,0][500,100]" } },
+            { $: { clickable: "true", bounds: "[500,0][1080,100]" } },
+          ],
+        },
+      ]);
+      const results = finder.findClickableSiblingsOfResourceId(hierarchy, "com.app:id/label");
+      expect(results.length).toBe(1);
+      expect(results[0].bounds).toEqual({ left: 500, top: 0, right: 1080, bottom: 100 });
+    });
+
+    test("supports partial match", () => {
+      const hierarchy = makeHierarchy([
+        {
+          $: { bounds: "[0,0][1080,200]" },
+          node: [
+            { $: { "resource-id": "com.app:id/label_title", "bounds": "[0,0][500,100]" } },
+            { $: { clickable: "true", bounds: "[500,0][1080,100]" } },
+          ],
+        },
+      ]);
+      const results = finder.findClickableSiblingsOfResourceId(hierarchy, "label_title", null, true);
+      expect(results.length).toBe(1);
+    });
+
+    test("returns empty when no sibling has the resource-id", () => {
+      const hierarchy = makeHierarchy([
+        {
+          $: { bounds: "[0,0][1080,200]" },
+          node: [
+            { $: { "resource-id": "com.app:id/other", "bounds": "[0,0][500,100]" } },
+            { $: { clickable: "true", bounds: "[500,0][1080,100]" } },
+          ],
+        },
+      ]);
+      const results = finder.findClickableSiblingsOfResourceId(hierarchy, "com.app:id/label");
+      expect(results).toEqual([]);
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- **P1 fix**: `elementId + sibling` now correctly uses `selectClickableSiblingOfResourceId` instead of routing through text-based sibling matching which can't find resource-id nodes
- **P2 fix**: `tapAny` now validates that the selected clickable element's center is on-screen before dispatching the tap, preventing taps to invalid coordinates in scrollable UIs
- **CodeQL fix**: Removed unused `latestHierarchy` variable assignment in TapAnyElement search loop

## Test plan
- [x] New unit tests for `findClickableSiblingsOfResourceId` (exact match, partial match, exclusion of matched node)
- [x] New unit tests for off-screen element filtering in `TapAnyElement.findClickableElement`
- [x] Updated `elementId + sibling` test to verify delegation to `selectClickableSiblingOfResourceId`
- [x] All 2395 existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)