### PR TITLE
chore: bump versions to v0.0.30

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -14,7 +14,7 @@
       "name": "auto-mobile",
       "source": "./",
       "description": "Mobile device automation for Android and iOS - control devices with natural language",
-      "version": "0.0.29",
+      "version": "0.0.30",
       "author": {
         "name": "AutoMobile Contributors",
         "email": "jason.d.pearson@gmail.com"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "auto-mobile",
   "description": "Mobile device automation for Android and iOS - control devices with natural language",
-  "version": "0.0.29",
+  "version": "0.0.30",
   "author": {
     "name": "AutoMobile Contributors",
     "email": "jason.d.pearson@gmail.com"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [v0.0.30] - 2026-05-20
+### Other
+- Remove tapClickableParent from tapOn schema — redundant with auto-escalation ([#2248](https://github.com/kaeawc/auto-mobile/issues/2248))
+
 ## [v0.0.29] - 2026-05-20
 ### Other
 - SelectAllText accessibility-service path crashes: AdbExecutor passed to AdbClientFactory consumer ([#2231](https://github.com/kaeawc/auto-mobile/issues/2231))

--- a/android/control-proxy/build.gradle.kts
+++ b/android/control-proxy/build.gradle.kts
@@ -36,7 +36,7 @@ android {
     minSdk = libs.versions.build.android.minSdk.get().toInt()
     targetSdk = libs.versions.build.android.targetSdk.get().toInt()
     versionCode = 1
-    versionName = "0.0.29-SNAPSHOT"
+    versionName = "0.0.30-SNAPSHOT"
 
     testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
   }

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -140,7 +140,7 @@ org.jetbrains.dokka.experimental.gradle.pluginMode=V2Enabled
 # Maven Central Publishing
 
 # Library versions (single source of truth)
-VERSION_NAME=0.0.29-SNAPSHOT
+VERSION_NAME=0.0.30-SNAPSHOT
 GROUP=dev.jasonpearson.auto-mobile
 
 # POM metadata

--- a/android/playground/app/build.gradle.kts
+++ b/android/playground/app/build.gradle.kts
@@ -36,7 +36,7 @@ android {
     minSdk = libs.versions.build.android.minSdk.get().toInt()
     targetSdk = libs.versions.build.android.targetSdk.get().toInt()
     versionCode = 1
-    versionName = "0.0.29-SNAPSHOT"
+    versionName = "0.0.30-SNAPSHOT"
 
     testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kaeawc/auto-mobile",
-  "version": "0.0.29",
+  "version": "0.0.30",
   "description": "Mobile device interaction automation via MCP",
   "scripts": {
     "test": "bun test",

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "dev.jasonpearson/auto-mobile",
   "title": "AutoMobile",
   "description": "Mobile device interaction automation via MCP",
-  "version": "0.0.29",
+  "version": "0.0.30",
   "websiteUrl": "https://kaeawc.github.io/auto-mobile/",
   "repository": {
     "url": "https://github.com/kaeawc/auto-mobile",
@@ -13,7 +13,7 @@
     {
       "registryType": "npm",
       "identifier": "@kaeawc/auto-mobile",
-      "version": "0.0.29",
+      "version": "0.0.30",
       "runtimeHint": "bunx",
       "transport": {
         "type": "stdio"

--- a/src/constants/release.ts
+++ b/src/constants/release.ts
@@ -26,6 +26,11 @@ export interface ReleaseChecksumEntry {
  */
 export const RELEASE_CHECKSUM_REGISTRY: ReleaseChecksumEntry[] = [
   {
+    version: "0.0.30",
+    apkSha256: "a1be5e6240f204ee99540e99cc198f7c0b592dbaf3699330c14f6ded7d333ec3",
+    ipaSha256: "5ac285dd5be16439d3a8a8973c98606920461acfce489830e54ee20759a7b235",
+  },
+  {
     version: "0.0.29",
     apkSha256: "b33a67c7efa84aca2b07faa965aecb3b1819b4defd441dcc8d3bf7e2af209cd8",
     ipaSha256: "d47c1aea4495270c1489cae361286ea1439c2ba4e7d5bcfd73f66e4580a6c45d",


### PR DESCRIPTION
## Summary
- Bump versions to v0.0.30
- Update CHANGELOG.md from closed issues since the last tag
- Refresh CtrlProxy APK SHA256 checksum
- Refresh CtrlProxy iOS IPA SHA256 checksum

## Automation
- Generated by `prepare-release` workflow