### PR TITLE
fix(ios): use ViewHierarchyResult-level signals for platform detection

### DIFF
--- a/src/server/hierarchyPlatformValidator.ts
+++ b/src/server/hierarchyPlatformValidator.ts
@@ -1,0 +1,71 @@
+import type { ViewHierarchyResult } from "../models";
+
+export interface HierarchyPlatformValidation {
+  valid: boolean;
+  error?: string;
+}
+
+export interface HierarchyPlatformValidator {
+  validate(platform: "android" | "ios", viewHierarchy: ViewHierarchyResult): HierarchyPlatformValidation;
+}
+
+function isFromIos(viewHierarchy: ViewHierarchyResult): boolean {
+  if (viewHierarchy.screenScale !== undefined) {
+    return true;
+  }
+
+  const h = viewHierarchy.hierarchy as Record<string, unknown>;
+  if (h.type === "XCUIElementTypeApplication") {
+    return true;
+  }
+  if (h.elementType === "application") {
+    return true;
+  }
+  if (typeof h.bundleId === "string" && !viewHierarchy.hierarchy.node) {
+    return true;
+  }
+
+  return false;
+}
+
+function isFromAndroid(viewHierarchy: ViewHierarchyResult): boolean {
+  if (viewHierarchy.density !== undefined) {
+    return true;
+  }
+  if (viewHierarchy.sdkInt !== undefined) {
+    return true;
+  }
+  if (viewHierarchy.foregroundActivity !== undefined) {
+    return true;
+  }
+  if (viewHierarchy.hierarchy.node?.$?.class?.startsWith("android.")) {
+    return true;
+  }
+
+  return false;
+}
+
+export class RealHierarchyPlatformValidator implements HierarchyPlatformValidator {
+  validate(platform: "android" | "ios", viewHierarchy: ViewHierarchyResult): HierarchyPlatformValidation {
+    const ios = isFromIos(viewHierarchy);
+    const android = isFromAndroid(viewHierarchy);
+
+    if (platform === "android" && ios && !android) {
+      return {
+        valid: false,
+        error: "Platform mismatch detected: received iOS hierarchy for Android device. " +
+          "This may indicate a stale connection. Try calling observe again.",
+      };
+    }
+
+    if (platform === "ios" && android && !ios) {
+      return {
+        valid: false,
+        error: "Platform mismatch detected: received Android hierarchy for iOS device. " +
+          "This may indicate a stale connection. Try calling observe again.",
+      };
+    }
+
+    return { valid: true };
+  }
+}

--- a/src/server/observeTools.ts
+++ b/src/server/observeTools.ts
@@ -17,6 +17,8 @@ import { defaultTimer } from "../utils/SystemTimer";
 import { consumeSetupTiming } from "./ToolExecutionContext";
 import { AndroidCtrlProxyManager } from "../utils/CtrlProxyManager";
 import { logger } from "../utils/logger";
+import { RealHierarchyPlatformValidator } from "./hierarchyPlatformValidator";
+import type { HierarchyPlatformValidator } from "./hierarchyPlatformValidator";
 import { serverConfig } from "../utils/ServerConfig";
 import {
   accessibilityStateSchema,
@@ -265,7 +267,9 @@ const waitForObservation = async (
 };
 
 // Register tools (this will be called when this file is imported)
-export function registerObserveTools() {
+export function registerObserveTools(
+  platformValidator: HierarchyPlatformValidator = new RealHierarchyPlatformValidator()
+) {
   // Observe handler
   const observeHandler = async (device: BootedDevice, args: ObserveArgs, _progress?: unknown, signal?: AbortSignal) => {
     try {
@@ -278,33 +282,15 @@ export function registerObserveTools() {
         ? waitOutcome.observation
         : await observeScreen.execute({ perf: createGlobalPerformanceTracker(), skipWaitForFresh: true, signal });
 
-      // Validate that the returned hierarchy matches the expected platform.
-      // This guards against cross-platform data contamination where an iOS
-      // hierarchy could be returned for an Android device (or vice versa).
       if (result.viewHierarchy?.hierarchy) {
-        const hierarchy = result.viewHierarchy.hierarchy;
-        const isIosHierarchy = hierarchy.type === "XCUIElementTypeApplication"
-          || hierarchy.elementType === "application"
-          || (typeof hierarchy.bundleId === "string" && !hierarchy.node);
-        const isAndroidHierarchy = hierarchy.node !== undefined
-          || (hierarchy.$ && hierarchy.$.class);
-
-        if (device.platform === "android" && isIosHierarchy && !isAndroidHierarchy) {
+        const validation = platformValidator.validate(device.platform, result.viewHierarchy);
+        if (!validation.valid) {
           logger.error(
-            `[observe] Platform mismatch: device ${device.deviceId} is Android but received iOS hierarchy. ` +
-            `Discarding stale iOS data to prevent cross-platform contamination.`
+            `[observe] Platform mismatch: device ${device.deviceId} is ${device.platform} but received hierarchy from other platform. ` +
+            `Discarding stale data to prevent cross-platform contamination.`
           );
           result.viewHierarchy = undefined;
-          result.error = "Platform mismatch detected: received iOS hierarchy for Android device. " +
-            "This may indicate a stale connection. Try calling observe again.";
-        } else if (device.platform === "ios" && isAndroidHierarchy && !isIosHierarchy) {
-          logger.error(
-            `[observe] Platform mismatch: device ${device.deviceId} is iOS but received Android hierarchy. ` +
-            `Discarding stale Android data to prevent cross-platform contamination.`
-          );
-          result.viewHierarchy = undefined;
-          result.error = "Platform mismatch detected: received Android hierarchy for iOS device. " +
-            "This may indicate a stale connection. Try calling observe again.";
+          result.error = validation.error;
         }
       }
 

--- a/test/server/observePlatformValidation.test.ts
+++ b/test/server/observePlatformValidation.test.ts
@@ -1,189 +1,202 @@
 import { describe, expect, test } from "bun:test";
-import { BootedDevice, ObserveResult } from "../../src/models";
+import type { ViewHierarchyResult } from "../../src/models";
+import { RealHierarchyPlatformValidator } from "../../src/server/hierarchyPlatformValidator";
 
-/**
- * Platform validation logic extracted for direct testing.
- * This mirrors the validation in observeTools.ts observeHandler to verify
- * cross-platform hierarchy detection works correctly.
- */
-function validateHierarchyPlatform(
-  device: BootedDevice,
-  result: ObserveResult
-): { valid: boolean; error?: string } {
-  if (!result.viewHierarchy?.hierarchy) {
-    return { valid: true };
-  }
+describe("RealHierarchyPlatformValidator", () => {
+  const validator = new RealHierarchyPlatformValidator();
 
-  const hierarchy = result.viewHierarchy.hierarchy;
-  const isIosHierarchy = hierarchy.type === "XCUIElementTypeApplication"
-    || hierarchy.elementType === "application"
-    || (typeof hierarchy.bundleId === "string" && !hierarchy.node);
-  const isAndroidHierarchy = hierarchy.node !== undefined
-    || (hierarchy.$ && hierarchy.$.class);
-
-  if (device.platform === "android" && isIosHierarchy && !isAndroidHierarchy) {
-    return {
-      valid: false,
-      error: "Platform mismatch detected: received iOS hierarchy for Android device.",
-    };
-  }
-
-  if (device.platform === "ios" && isAndroidHierarchy && !isIosHierarchy) {
-    return {
-      valid: false,
-      error: "Platform mismatch detected: received Android hierarchy for iOS device.",
-    };
-  }
-
-  return { valid: true };
-}
-
-describe("observe platform validation", () => {
-  const androidDevice: BootedDevice = {
-    name: "emulator-5554",
-    deviceId: "emulator-5554",
-    platform: "android",
-  };
-
-  const iosDevice: BootedDevice = {
-    name: "iPhone 15",
-    deviceId: "ios-sim-1",
-    platform: "ios",
-  };
-
-  test("accepts Android hierarchy for Android device", () => {
-    const result: ObserveResult = {
-      updatedAt: Date.now(),
-      screenSize: { width: 1080, height: 1920 },
-      systemInsets: { top: 0, right: 0, bottom: 0, left: 0 },
-      viewHierarchy: {
+  describe("Android device", () => {
+    test("accepts Android hierarchy with android.* class prefix", () => {
+      const viewHierarchy: ViewHierarchyResult = {
         hierarchy: {
           node: {
             $: { class: "android.widget.FrameLayout", bounds: "[0,0][1080,1920]" },
           },
         },
-      } as any,
-    };
+        density: 440,
+        sdkInt: 34,
+        foregroundActivity: "com.example.app/.MainActivity",
+      };
 
-    const validation = validateHierarchyPlatform(androidDevice, result);
-    expect(validation.valid).toBe(true);
-  });
+      expect(validator.validate("android", viewHierarchy)).toEqual({ valid: true });
+    });
 
-  test("rejects iOS hierarchy for Android device", () => {
-    const result: ObserveResult = {
-      updatedAt: Date.now(),
-      screenSize: { width: 390, height: 844 },
-      systemInsets: { top: 0, right: 0, bottom: 0, left: 0 },
-      viewHierarchy: {
+    test("rejects raw iOS hierarchy (XCUIElementTypeApplication)", () => {
+      const viewHierarchy = {
         hierarchy: {
           type: "XCUIElementTypeApplication",
           bundleId: "com.example.app",
           bounds: { left: 0, top: 0, right: 390, bottom: 844 },
         },
-      } as any,
-    };
+        screenScale: 3.0,
+      } as unknown as ViewHierarchyResult;
 
-    const validation = validateHierarchyPlatform(androidDevice, result);
-    expect(validation.valid).toBe(false);
-    expect(validation.error).toContain("iOS hierarchy for Android device");
-  });
+      const result = validator.validate("android", viewHierarchy);
+      expect(result.valid).toBe(false);
+      expect(result.error).toContain("iOS hierarchy for Android device");
+    });
 
-  test("accepts iOS hierarchy for iOS device", () => {
-    const result: ObserveResult = {
-      updatedAt: Date.now(),
-      screenSize: { width: 390, height: 844 },
-      systemInsets: { top: 0, right: 0, bottom: 0, left: 0 },
-      viewHierarchy: {
-        hierarchy: {
-          type: "XCUIElementTypeApplication",
-          bundleId: "com.example.app",
-          bounds: { left: 0, top: 0, right: 390, bottom: 844 },
-        },
-      } as any,
-    };
-
-    const validation = validateHierarchyPlatform(iosDevice, result);
-    expect(validation.valid).toBe(true);
-  });
-
-  test("rejects Android hierarchy for iOS device", () => {
-    const result: ObserveResult = {
-      updatedAt: Date.now(),
-      screenSize: { width: 1080, height: 1920 },
-      systemInsets: { top: 0, right: 0, bottom: 0, left: 0 },
-      viewHierarchy: {
+    test("rejects converted iOS hierarchy with screenScale", () => {
+      const viewHierarchy: ViewHierarchyResult = {
         hierarchy: {
           node: {
-            $: { class: "android.widget.FrameLayout", bounds: "[0,0][1080,1920]" },
+            $: { class: "UIWindow", bounds: "[0,0][390,844]" },
+            node: [{ $: { class: "UIView", text: "Hello" } }],
           },
         },
-      } as any,
-    };
+        screenScale: 3.0,
+        screenWidth: 390,
+        screenHeight: 844,
+        packageName: "com.example.chatapp",
+      };
 
-    const validation = validateHierarchyPlatform(iosDevice, result);
-    expect(validation.valid).toBe(false);
-    expect(validation.error).toContain("Android hierarchy for iOS device");
-  });
+      const result = validator.validate("android", viewHierarchy);
+      expect(result.valid).toBe(false);
+      expect(result.error).toContain("iOS hierarchy for Android device");
+    });
 
-  test("detects iOS hierarchy via elementType field", () => {
-    const result: ObserveResult = {
-      updatedAt: Date.now(),
-      screenSize: { width: 390, height: 844 },
-      systemInsets: { top: 0, right: 0, bottom: 0, left: 0 },
-      viewHierarchy: {
+    test("rejects raw iOS hierarchy via elementType field", () => {
+      const viewHierarchy = {
         hierarchy: {
           elementType: "application",
           bundleId: "com.example.app",
         },
-      } as any,
-    };
+        screenScale: 2.0,
+      } as unknown as ViewHierarchyResult;
 
-    const validation = validateHierarchyPlatform(androidDevice, result);
-    expect(validation.valid).toBe(false);
-  });
+      const result = validator.validate("android", viewHierarchy);
+      expect(result.valid).toBe(false);
+    });
 
-  test("detects iOS hierarchy via bundleId without node field", () => {
-    const result: ObserveResult = {
-      updatedAt: Date.now(),
-      screenSize: { width: 390, height: 844 },
-      systemInsets: { top: 0, right: 0, bottom: 0, left: 0 },
-      viewHierarchy: {
+    test("rejects raw iOS hierarchy via bundleId without node", () => {
+      const viewHierarchy = {
         hierarchy: {
           bundleId: "com.example.app",
-          children: [],
         },
-      } as any,
-    };
+        screenScale: 2.0,
+      } as unknown as ViewHierarchyResult;
 
-    const validation = validateHierarchyPlatform(androidDevice, result);
-    expect(validation.valid).toBe(false);
+      const result = validator.validate("android", viewHierarchy);
+      expect(result.valid).toBe(false);
+    });
   });
 
-  test("accepts when no viewHierarchy is present", () => {
-    const result: ObserveResult = {
-      updatedAt: Date.now(),
-      screenSize: { width: 0, height: 0 },
-      systemInsets: { top: 0, right: 0, bottom: 0, left: 0 },
-    };
+  describe("iOS device", () => {
+    test("accepts converted iOS hierarchy with screenScale", () => {
+      const viewHierarchy: ViewHierarchyResult = {
+        hierarchy: {
+          node: {
+            $: { class: "UIWindow", bounds: "[0,0][390,844]" },
+            node: [
+              {
+                $: { class: "UIView", text: "Messages", clickable: "true" },
+                node: [{ $: { class: "UILabel", text: "Hello world" } }],
+              },
+            ],
+          },
+        },
+        screenScale: 3.0,
+        screenWidth: 390,
+        screenHeight: 844,
+        packageName: "com.example.chatapp",
+      };
 
-    const validation = validateHierarchyPlatform(androidDevice, result);
-    expect(validation.valid).toBe(true);
+      expect(validator.validate("ios", viewHierarchy)).toEqual({ valid: true });
+    });
+
+    test("accepts raw iOS hierarchy (XCUIElementTypeApplication)", () => {
+      const viewHierarchy = {
+        hierarchy: {
+          type: "XCUIElementTypeApplication",
+          bundleId: "com.example.app",
+          bounds: { left: 0, top: 0, right: 390, bottom: 844 },
+        },
+        screenScale: 3.0,
+      } as unknown as ViewHierarchyResult;
+
+      expect(validator.validate("ios", viewHierarchy)).toEqual({ valid: true });
+    });
+
+    test("rejects Android hierarchy with android.* class and density", () => {
+      const viewHierarchy: ViewHierarchyResult = {
+        hierarchy: {
+          node: {
+            $: { class: "android.widget.FrameLayout", bounds: "[0,0][1080,1920]" },
+          },
+        },
+        density: 440,
+        sdkInt: 34,
+        foregroundActivity: "com.example.app/.MainActivity",
+      };
+
+      const result = validator.validate("ios", viewHierarchy);
+      expect(result.valid).toBe(false);
+      expect(result.error).toContain("Android hierarchy for iOS device");
+    });
+
+    test("rejects hierarchy with sdkInt (Android-only)", () => {
+      const viewHierarchy: ViewHierarchyResult = {
+        hierarchy: {
+          node: {
+            $: { class: "android.view.View", bounds: "[0,0][1080,2400]" },
+          },
+        },
+        sdkInt: 33,
+      };
+
+      const result = validator.validate("ios", viewHierarchy);
+      expect(result.valid).toBe(false);
+    });
+
+    test("rejects hierarchy with foregroundActivity (Android-only)", () => {
+      const viewHierarchy: ViewHierarchyResult = {
+        hierarchy: {
+          node: {
+            $: { class: "android.widget.LinearLayout" },
+          },
+        },
+        foregroundActivity: "com.example/.Main",
+      };
+
+      const result = validator.validate("ios", viewHierarchy);
+      expect(result.valid).toBe(false);
+    });
   });
 
-  test("accepts when hierarchy has error object", () => {
-    const result: ObserveResult = {
-      updatedAt: Date.now(),
-      screenSize: { width: 0, height: 0 },
-      systemInsets: { top: 0, right: 0, bottom: 0, left: 0 },
-      viewHierarchy: {
+  describe("ambiguous cases", () => {
+    test("accepts hierarchy with no platform-specific signals for Android", () => {
+      const viewHierarchy: ViewHierarchyResult = {
+        hierarchy: {
+          node: {
+            $: { class: "View", text: "Hello" },
+          },
+        },
+      };
+
+      expect(validator.validate("android", viewHierarchy)).toEqual({ valid: true });
+    });
+
+    test("accepts hierarchy with no platform-specific signals for iOS", () => {
+      const viewHierarchy: ViewHierarchyResult = {
+        hierarchy: {
+          node: {
+            $: { class: "View", text: "Hello" },
+          },
+        },
+      };
+
+      expect(validator.validate("ios", viewHierarchy)).toEqual({ valid: true });
+    });
+
+    test("accepts error-only hierarchy for either platform", () => {
+      const viewHierarchy: ViewHierarchyResult = {
         hierarchy: {
           error: "Failed to retrieve view hierarchy",
         },
-      } as any,
-    };
+      };
 
-    // Error hierarchies don't have platform-specific markers, so they should pass
-    const validation = validateHierarchyPlatform(androidDevice, result);
-    expect(validation.valid).toBe(true);
+      expect(validator.validate("android", viewHierarchy)).toEqual({ valid: true });
+      expect(validator.validate("ios", viewHierarchy)).toEqual({ valid: true });
+    });
   });
 });


### PR DESCRIPTION
## Summary

- Fixes false-positive platform mismatch detection that rejected valid iOS hierarchies with "received Android hierarchy for iOS device"
- The old heuristic checked `Hierarchy`-level properties (`type`, `elementType`, `bundleId`) that are stripped during iOS→Android-compatible conversion — after conversion, `hierarchy.node` is always defined, making all iOS data look "Android"
- New approach uses `ViewHierarchyResult`-level signals (`screenScale` for iOS; `density`/`sdkInt`/`foregroundActivity` for Android) that survive the conversion, plus `android.*` class prefix check on root node
- Extracts validation into injectable `HierarchyPlatformValidator` interface with `RealHierarchyPlatformValidator` implementation

Closes #2275

## Test plan

- [x] All 13 platform validation tests pass (including new test for converted iOS hierarchy — the exact scenario that was broken)
- [x] Full test suite passes (4312 tests, 0 failures)
- [x] Build passes
- [x] Lint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)