### PR TITLE
fix(action): use isAccessibilityServiceEnabled in retryTapIfNoChange call site

### DIFF
--- a/src/features/action/TapOnElement.ts
+++ b/src/features/action/TapOnElement.ts
@@ -1020,7 +1020,7 @@ export class TapOnElement extends BaseVisualChange {
               longPressDuration,
               tapElement,
               options,
-              isTalkBackEnabled,
+              isAccessibilityServiceEnabled,
               observeResult.screenSize,
               signal,
             );

--- a/test/features/action/TapOnElement.retryIfNoChange.test.ts
+++ b/test/features/action/TapOnElement.retryIfNoChange.test.ts
@@ -142,6 +142,40 @@ describe("retryTapIfNoChange", () => {
   });
 });
 
+describe("retryTapIfNoChange passes isTalkBackEnabled to executeAndroidTap", () => {
+  for (const talkBackEnabled of [true, false]) {
+    test(`passes isTalkBackEnabled=${talkBackEnabled} through to retry tap`, async () => {
+      const { tap } = createTapOnElement();
+      const hierarchy = makeHierarchy("same-state");
+
+      (tap as any).refreshViewHierarchy = async () => hierarchy;
+
+      let capturedIsTalkBackEnabled: boolean | undefined;
+      (tap as any).executeAndroidTap = async (
+        _action: string, _x: number, _y: number, _dur: number,
+        _el: Element, _signal: unknown, _opts: unknown, isTalkBack: boolean
+      ) => {
+        capturedIsTalkBackEnabled = isTalkBack;
+      };
+
+      const preTapHash = (tap as any).hashViewHierarchy(hierarchy);
+
+      await (tap as any).retryTapIfNoChange(
+        preTapHash,
+        { x: 60, y: 45 },
+        "tap",
+        0,
+        makeElement(),
+        {},
+        talkBackEnabled,
+        { width: 1080, height: 1920 },
+      );
+
+      expect(capturedIsTalkBackEnabled).toBe(talkBackEnabled);
+    });
+  }
+});
+
 describe("ensureTap flag expansion", () => {
   test("ensureTap enables both preTapStability and retryIfNoChange", async () => {
     const { tap } = createTapOnElement();


### PR DESCRIPTION
## Summary

- Fixes `ReferenceError: isTalkBackEnabled is not defined` thrown when `tapOn` uses `retryIfNoChange: true` or `ensureTap: true` on Android
- The call site at `TapOnElement.ts:1023` referenced `isTalkBackEnabled` which doesn't exist in `execute()` scope — replaced with the correct variable `isAccessibilityServiceEnabled` (defined at line 940)
- Adds parameterized tests verifying `isTalkBackEnabled` is correctly passed through `retryTapIfNoChange` → `executeAndroidTap` for both `true` and `false` states

Closes #2277

## Test plan

- [x] New tests pass: `retryTapIfNoChange passes isTalkBackEnabled to executeAndroidTap` (both true/false)
- [x] Existing retryIfNoChange tests pass (hierarchy changed = no retry, unchanged = retry, null = retry, sleep timings)
- [x] ensureTap flag expansion tests pass
- [x] Full test suite passes (4309 tests, 0 failures)
- [x] Build and lint pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)