### PR TITLE
perf: opt-in anthropic/alwaysLoad via AUTOMOBILE_ALWAYS_LOAD_TOOLS env var

### DIFF
--- a/src/server/toolRegistry.ts
+++ b/src/server/toolRegistry.ts
@@ -612,6 +612,9 @@ class ToolRegistryClass {
       server.registerTool(tool.name, {
         description: tool.description,
         inputSchema: tool.schema,
+        ...(process.env.AUTOMOBILE_ALWAYS_LOAD_TOOLS === "true" && {
+          _meta: { "anthropic/alwaysLoad": true },
+        }),
         ...(tool.outputSchema ? { outputSchema: tool.outputSchema } : {})
       }, wrappedHandler);
     });

--- a/src/server/toolRegistry.ts
+++ b/src/server/toolRegistry.ts
@@ -622,10 +622,12 @@ class ToolRegistryClass {
 
   // Get tools in MCP format
   getToolDefinitions() {
+    const alwaysLoad = process.env.AUTOMOBILE_ALWAYS_LOAD_TOOLS === "true";
     return this.getAllTools().map(tool => ({
       name: tool.name,
       description: tool.description,
       inputSchema: flattenTopLevelUnion(toJSONSchema(tool.schema)),
+      ...(alwaysLoad && { _meta: { "anthropic/alwaysLoad": true } }),
       ...(tool.outputSchema ? { outputSchema: toJSONSchema(tool.outputSchema) } : {})
     }));
   }


### PR DESCRIPTION
## Summary
- When `AUTOMOBILE_ALWAYS_LOAD_TOOLS=true` is set, tool registrations include `_meta: {"anthropic/alwaysLoad": true}` which tells MCP clients to always inline the full tool schema (never defer)
- This eliminates ToolSearch round-trips in Claude Code/Agent SDK consumers (~5-10s per call, 9 observed per test run)
- Opt-in only — no behavior change unless the env var is explicitly set

## Context
MCP clients like Claude Code defer tool schemas when a server has many tools (to save context tokens). The deferred tools require a ToolSearch call before they can be invoked, adding latency. The `anthropic/alwaysLoad` annotation in `_meta` prevents deferral for tools that are known to be needed.

## Test plan
- [ ] Verify no behavior change when env var is unset (default path)
- [ ] Verify tools include `_meta` annotation when `AUTOMOBILE_ALWAYS_LOAD_TOOLS=true`
- [ ] Verify ToolSearch calls disappear in a live agent run with the env var set

🤖 Generated with [Claude Code](https://claude.com/claude-code)