### PR TITLE
fix(perf): gate SelectionStateTracker screenshots on --no-ui-perf-mode

### DIFF
--- a/src/features/navigation/SelectionStateTracker.ts
+++ b/src/features/navigation/SelectionStateTracker.ts
@@ -1,6 +1,7 @@
 import { BootedDevice, Element, ObserveResult } from "../../models";
 import { AdbClientFactory, defaultAdbClientFactory } from "../../utils/android-cmdline-tools/AdbClientFactory";
 import { logger } from "../../utils/logger";
+import { serverConfig } from "../../utils/ServerConfig";
 import { SelectedElement } from "../../utils/interfaces/NavigationGraph";
 import { TakeScreenshot } from "../observe/TakeScreenshot";
 import { SelectionDetectionContext, SelectionStateDetector, SelectionStateDetectorLike } from "./SelectionStateDetector";
@@ -53,20 +54,28 @@ interface SelectionFinalizeRequest {
 interface SelectionStateTrackerOptions {
   detector?: SelectionStateDetectorLike;
   screenshotCapturer: ScreenshotCapturer;
+  isUiPerfModeEnabled?: () => boolean;
 }
 
 export class SelectionStateTracker {
   private detector: SelectionStateDetectorLike;
   private screenshotCapturer: ScreenshotCapturer;
+  private isUiPerfModeEnabled: () => boolean;
 
   constructor(options: SelectionStateTrackerOptions) {
     this.detector = options.detector ?? new SelectionStateDetector();
     this.screenshotCapturer = options.screenshotCapturer;
+    this.isUiPerfModeEnabled = options.isUiPerfModeEnabled ?? (() => serverConfig.isUiPerfModeEnabled());
   }
 
   async prepare(request: SelectionCaptureRequest): Promise<SelectionCaptureState | null> {
     const { observation, element, action, signal } = request;
     if (!observation?.viewHierarchy || !element) {
+      return null;
+    }
+
+    if (!this.isUiPerfModeEnabled()) {
+      logger.debug(`[SELECTION_STATE] Skip selection capture (${action}): ui-perf-mode disabled`);
       return null;
     }
 

--- a/test/features/navigation/SelectionStateTracker.test.ts
+++ b/test/features/navigation/SelectionStateTracker.test.ts
@@ -56,7 +56,8 @@ describe("SelectionStateTracker", () => {
     const capturer = new FakeScreenshotCapturer();
     const tracker = new SelectionStateTracker({
       detector,
-      screenshotCapturer: capturer
+      screenshotCapturer: capturer,
+      isUiPerfModeEnabled: () => true
     });
 
     capturer.setPaths(["before.png", "after.png"]);

--- a/test/features/navigation/SelectionStateTracker.test.ts
+++ b/test/features/navigation/SelectionStateTracker.test.ts
@@ -106,6 +106,51 @@ describe("SelectionStateTracker", () => {
     expect(contexts[0].afterScreenshotPath).toBe("after.png");
   });
 
+  test("skips capture when ui-perf-mode is disabled", async () => {
+    const detector = new FakeSelectionStateDetector();
+    const capturer = new FakeScreenshotCapturer();
+    const tracker = new SelectionStateTracker({
+      detector,
+      screenshotCapturer: capturer,
+      isUiPerfModeEnabled: () => false
+    });
+
+    const observation = createObservation(
+      createHierarchy({
+        text: "Tab1",
+        selected: "false",
+        bounds: "[0,0][10,10]"
+      })
+    );
+
+    const element: Element = {
+      bounds: { left: 0, top: 0, right: 10, bottom: 10 },
+      text: "Tab1",
+      clickable: true
+    };
+
+    const state = await tracker.prepare({
+      action: "tap",
+      observation,
+      element
+    });
+
+    expect(state).toBeNull();
+    expect(capturer.getCallCount()).toBe(0);
+
+    const selected = await tracker.finalize({
+      action: "tap",
+      selectionState: state,
+      currentObservation: observation,
+      previousObservation: observation,
+      element
+    });
+
+    expect(selected).toHaveLength(0);
+    expect(capturer.getCallCount()).toBe(0);
+    expect(detector.getContexts()).toHaveLength(0);
+  });
+
   test("skips capture when element is not selectable", async () => {
     const detector = new FakeSelectionStateDetector();
     const capturer = new FakeScreenshotCapturer();


### PR DESCRIPTION
## Summary
- `SelectionStateTracker.prepare()` now checks `serverConfig.isUiPerfModeEnabled()` and skips before/after screenshot capture when `--no-ui-perf-mode` is set.
- Eliminates ~60s of overhead per emulator.wtf run (76 screenshots @ ~800ms) and removes the ADB pipe pressure that was stalling CtrlProxy WebSocket pushes.
- Matches the gating pattern already used by `PerformanceAudit` and `LaunchApp`.

Closes #2284.

## Test plan
- [x] `bun test test/features/navigation/SelectionStateTracker.test.ts` — new test covers `--no-ui-perf-mode` path
- [x] `bun test test/features/action/TapOnElement.visionFallback.test.ts`
- [x] `turbo run lint build`