### PR TITLE
fix(daemon): log startup confirmation for all CI-tuning flags

### DIFF
--- a/src/cli/logCiTuningFlags.ts
+++ b/src/cli/logCiTuningFlags.ts
@@ -1,0 +1,27 @@
+import type { Logger } from "../utils/logger";
+
+export interface CiTuningFlags {
+  uiPerfMode: boolean;
+  networkMockable: boolean;
+  dismissKeyboardAfterInput: boolean;
+  noA11yIncludeNotImportantViews: boolean;
+  noA11yReportViewIds: boolean;
+}
+
+export function logCiTuningFlags(flags: CiTuningFlags, log: Logger): void {
+  if (!flags.uiPerfMode) {
+    log.info("UI performance mode disabled (--no-ui-perf-mode): TTI and displayed metrics capture skipped");
+  }
+  if (flags.networkMockable) {
+    log.info("Network mocking enabled (--network-mockable)");
+  }
+  if (flags.dismissKeyboardAfterInput) {
+    log.info("Dismiss keyboard after input enabled (--dismiss-keyboard-after-input)");
+  }
+  if (flags.noA11yIncludeNotImportantViews) {
+    log.info("Accessibility flag FLAG_INCLUDE_NOT_IMPORTANT_VIEWS disabled (--no-include-not-important-views)");
+  }
+  if (flags.noA11yReportViewIds) {
+    log.info("Accessibility flag FLAG_REPORT_VIEW_IDS disabled (--no-report-view-ids)");
+  }
+}

--- a/src/daemon/daemon.ts
+++ b/src/daemon/daemon.ts
@@ -38,6 +38,7 @@ import { IOSCtrlProxyClient } from "../features/observe/ios";
 import { NavigationGraphManager } from "../features/navigation/NavigationGraphManager";
 import { RealObserveScreen } from "../features/observe/ObserveScreen";
 import type { InstalledAppsStore } from "../db/installedAppsRepository";
+import { logCiTuningFlags } from "../cli/logCiTuningFlags";
 import { InstalledAppsRepository } from "../db/installedAppsRepository";
 import { DeviceSessionManager } from "../utils/DeviceSessionManager";
 import { startAppearanceSyncScheduler, stopAppearanceSyncScheduler } from "../utils/appearance/AppearanceSyncScheduler";
@@ -140,6 +141,17 @@ export class Daemon {
     if (options.noA11yRetrieveInteractiveWindows) {
       serverConfig.setA11yRetrieveInteractiveWindows(false);
     }
+
+    logCiTuningFlags(
+      {
+        uiPerfMode: !options.noUiPerfMode,
+        networkMockable: options.networkMockable === true,
+        dismissKeyboardAfterInput: options.dismissKeyboardAfterInput === true,
+        noA11yIncludeNotImportantViews: options.noA11yIncludeNotImportantViews === true,
+        noA11yReportViewIds: options.noA11yReportViewIds === true,
+      },
+      logger
+    );
   }
 
   /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -459,16 +459,21 @@ async function main() {
       logger.info("WaitFor polling overhead disabled (--no-waitfor-polling-overhead): screenshots and back stack skipped during observe waitFor polling");
     }
 
-    logCiTuningFlags(
-      {
-        uiPerfMode,
-        networkMockable,
-        dismissKeyboardAfterInput,
-        noA11yIncludeNotImportantViews,
-        noA11yReportViewIds,
-      },
-      logger
-    );
+    // Only log here in direct/no-proxy mode — in proxy mode the spawned daemon
+    // process logs the flags it actually applies (see daemon.ts), avoiding
+    // false-positive logs when the proxy reuses an existing daemon.
+    if (noProxy) {
+      logCiTuningFlags(
+        {
+          uiPerfMode,
+          networkMockable,
+          dismissKeyboardAfterInput,
+          noA11yIncludeNotImportantViews,
+          noA11yReportViewIds,
+        },
+        logger
+      );
+    }
 
     if (daemonMode) {
       await startDaemon({

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,7 @@ import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js"
 import { createMcpServer } from "./server";
 import { createProxyMcpServer } from "./server/proxyServer";
 import { logger } from "./utils/logger";
+import { logCiTuningFlags } from "./cli/logCiTuningFlags";
 import { runCliCommand } from "./cli";
 import { runDaemonCommand } from "./daemon/manager";
 import { startDaemon } from "./daemon/daemon";
@@ -457,6 +458,17 @@ async function main() {
       serverConfig.setWaitForPollingOverheadEnabled(false);
       logger.info("WaitFor polling overhead disabled (--no-waitfor-polling-overhead): screenshots and back stack skipped during observe waitFor polling");
     }
+
+    logCiTuningFlags(
+      {
+        uiPerfMode,
+        networkMockable,
+        dismissKeyboardAfterInput,
+        noA11yIncludeNotImportantViews,
+        noA11yReportViewIds,
+      },
+      logger
+    );
 
     if (daemonMode) {
       await startDaemon({

--- a/test/cli/logCiTuningFlags.test.ts
+++ b/test/cli/logCiTuningFlags.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, test } from "bun:test";
+import { logCiTuningFlags, type CiTuningFlags } from "../../src/cli/logCiTuningFlags";
+import type { Logger } from "../../src/utils/logger";
+
+class FakeLogger implements Logger {
+  infos: string[] = [];
+  info(message: string): void {
+    this.infos.push(message);
+  }
+  warn(): void {}
+  error(): void {}
+  debug?(): void {}
+}
+
+const allOff: CiTuningFlags = {
+  uiPerfMode: true,
+  networkMockable: false,
+  dismissKeyboardAfterInput: false,
+  noA11yIncludeNotImportantViews: false,
+  noA11yReportViewIds: false,
+};
+
+describe("logCiTuningFlags", () => {
+  test("emits nothing when all CI-tuning flags are at default", () => {
+    const log = new FakeLogger();
+    logCiTuningFlags(allOff, log);
+    expect(log.infos).toEqual([]);
+  });
+
+  test("logs --no-ui-perf-mode when uiPerfMode is false", () => {
+    const log = new FakeLogger();
+    logCiTuningFlags({ ...allOff, uiPerfMode: false }, log);
+    expect(log.infos).toEqual([
+      "UI performance mode disabled (--no-ui-perf-mode): TTI and displayed metrics capture skipped",
+    ]);
+  });
+
+  test("logs --network-mockable when enabled", () => {
+    const log = new FakeLogger();
+    logCiTuningFlags({ ...allOff, networkMockable: true }, log);
+    expect(log.infos).toEqual(["Network mocking enabled (--network-mockable)"]);
+  });
+
+  test("logs --dismiss-keyboard-after-input when enabled", () => {
+    const log = new FakeLogger();
+    logCiTuningFlags({ ...allOff, dismissKeyboardAfterInput: true }, log);
+    expect(log.infos).toEqual([
+      "Dismiss keyboard after input enabled (--dismiss-keyboard-after-input)",
+    ]);
+  });
+
+  test("logs --no-include-not-important-views when set", () => {
+    const log = new FakeLogger();
+    logCiTuningFlags({ ...allOff, noA11yIncludeNotImportantViews: true }, log);
+    expect(log.infos).toEqual([
+      "Accessibility flag FLAG_INCLUDE_NOT_IMPORTANT_VIEWS disabled (--no-include-not-important-views)",
+    ]);
+  });
+
+  test("logs --no-report-view-ids when set", () => {
+    const log = new FakeLogger();
+    logCiTuningFlags({ ...allOff, noA11yReportViewIds: true }, log);
+    expect(log.infos).toEqual([
+      "Accessibility flag FLAG_REPORT_VIEW_IDS disabled (--no-report-view-ids)",
+    ]);
+  });
+
+  test("logs all five flags when all are active", () => {
+    const log = new FakeLogger();
+    logCiTuningFlags(
+      {
+        uiPerfMode: false,
+        networkMockable: true,
+        dismissKeyboardAfterInput: true,
+        noA11yIncludeNotImportantViews: true,
+        noA11yReportViewIds: true,
+      },
+      log
+    );
+    expect(log.infos.length).toBe(5);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds startup `logger.info` lines for the 5 CI-tuning daemon flags that were silently applied: `--no-ui-perf-mode`, `--network-mockable`, `--dismiss-keyboard-after-input`, `--no-include-not-important-views`, `--no-report-view-ids`.
- Extracts the new lines into `src/cli/logCiTuningFlags.ts` so the behavior is unit-testable.

Closes #2286.

## Test plan
- [x] `bun test test/cli/logCiTuningFlags.test.ts` — 7 pass
- [x] `bunx turbo run build lint` — green