### PR TITLE
fix(android): raise CtrlProxy fresh-hierarchy wait default from 100ms to 1s

### DIFF
--- a/src/features/observe/android/AndroidCtrlProxyClient.ts
+++ b/src/features/observe/android/AndroidCtrlProxyClient.ts
@@ -1113,13 +1113,13 @@ export class AndroidCtrlProxyClient extends DeviceServiceClient implements Andro
 
   async getLatestHierarchy(
     waitForFresh: boolean = false,
-    timeout: number = 100,
+    timeout?: number,
     perf: PerformanceTracker = new NoOpPerformanceTracker(),
     skipWaitForFresh: boolean = false,
     minTimestamp: number = 0,
     signal?: AbortSignal
   ): Promise<AccessibilityHierarchyResponse> {
-    return this.hierarchy.getLatestHierarchy(waitForFresh, timeout, perf, skipWaitForFresh, minTimestamp, signal);
+    return this.hierarchy.getLatestHierarchy(waitForFresh, timeout!, perf, skipWaitForFresh, minTimestamp, signal);
   }
 
   async requestHierarchySync(

--- a/src/features/observe/android/CtrlProxyHierarchy.ts
+++ b/src/features/observe/android/CtrlProxyHierarchy.ts
@@ -28,6 +28,14 @@ import { generateSecureId } from "./types";
  *  a cascade where every hierarchy request returns stale data. */
 const WEBSOCKET_TIMEOUT_COOLDOWN_MS = 500;
 
+/** Default wait window for a fresh WebSocket-pushed hierarchy.
+ *  Aligned with the 1s cache-freshness TTL so a contended ADB pipe
+ *  (concurrent screenshots, dumpsys, emulator transitions) has the same
+ *  headroom that the cache considers acceptable for "fresh" data.
+ *  100ms was too aggressive: under contention pushes routinely exceeded
+ *  it, silently degrading results to stale cache. See issue #2285. */
+const DEFAULT_FRESH_WAIT_MS = 1000;
+
 /**
  * Delegate class for handling hierarchy retrieval and caching.
  *
@@ -79,7 +87,7 @@ export class CtrlProxyHierarchy {
    */
   async getLatestHierarchy(
     waitForFresh: boolean = false,
-    timeout: number = 100,
+    timeout: number = DEFAULT_FRESH_WAIT_MS,
     perf: PerformanceTracker = new NoOpPerformanceTracker(),
     skipWaitForFresh: boolean = false,
     minTimestamp: number = 0,
@@ -248,7 +256,7 @@ export class CtrlProxyHierarchy {
       // Get hierarchy from WebSocket service
       const waitForFresh = !skipWaitForFresh && (cachedHierarchy === null || !cachedHierarchy.fresh);
       const response = await perf.track("getHierarchy", () =>
-        this.getLatestHierarchy(waitForFresh, 100, perf, skipWaitForFresh, minTimestamp, signal)
+        this.getLatestHierarchy(waitForFresh, DEFAULT_FRESH_WAIT_MS, perf, skipWaitForFresh, minTimestamp, signal)
       );
 
       let hierarchyData = response.hierarchy;

--- a/test/features/observe/CtrlProxyClient.test.ts
+++ b/test/features/observe/CtrlProxyClient.test.ts
@@ -267,6 +267,53 @@ describe("AndroidCtrlProxyClient", function() {
       }
     });
 
+    test("should return fresh data when WebSocket push arrives after 100ms under contention (regression #2285)", async function() {
+      // Pre-bug: default timeout was 100ms. When ADB pipe is busy (concurrent
+      // screenshots, dumpsys, etc.), the WebSocket push routinely lands after
+      // 100ms and getLatestHierarchy fell back to stale cache (~31% stale rate
+      // in CI). Default is now 1000ms, matching the cache freshness TTL.
+      const testTimer = new FakeTimer();
+      const { factory, getSocket } = createCapturingWebSocketFactory(testTimer);
+      const testClient = AndroidCtrlProxyClient.createForTesting(
+        testDevice,
+        fakeAdb,
+        factory,
+        testTimer
+      );
+
+      try {
+        // Call without specifying a timeout so we exercise the default.
+        const resultPromise = testClient.getLatestHierarchy(true);
+        const socket = await waitForSocket(getSocket);
+        expect(socket).not.toBeNull();
+        await waitForSocketOpen(socket);
+
+        // Simulate contended push delivery: advance 300ms of virtual time
+        // before the push arrives. Past the old 100ms default — with the old
+        // code the polling loop would already have cleared the interval and
+        // resolved null, returning stale cache (here: no cache → null).
+        await testTimer.advanceTimersByTimeAsync(300);
+
+        socket!.simulateMessage(JSON.stringify({
+          type: "hierarchy_update",
+          timestamp: testTimer.now(),
+          data: {
+            updatedAt: testTimer.now(),
+            packageName: "com.example.app",
+            hierarchy: { text: "Contended push" }
+          }
+        }));
+
+        const result = await testTimer.resolvePromise(resultPromise);
+
+        expect(result.fresh).toBe(true);
+        expect(result.hierarchy).not.toBeNull();
+        expect(result.hierarchy!.hierarchy.text).toBe("Contended push");
+      } finally {
+        await testClient.close();
+      }
+    });
+
     test("should handle WebSocket connection failure gracefully", async function() {
       // Use FakeWebSocket with instant failure and FakeTimer for fast, reliable test execution
       // See issues #68 (timeout race condition) and #72 (cache contamination)


### PR DESCRIPTION
## Summary

- Closes #2285. Raises `CtrlProxyHierarchy.getLatestHierarchy` default fresh-data wait from 100ms to 1000ms, aligning it with the existing 1s cache-freshness TTL.
- Under ADB pipe contention (concurrent screenshots, dumpsys, emulator transitions), WebSocket-pushed hierarchy data routinely lands after 100ms, causing the call to silently fall back to stale cache — observed ~31% stale-data rate in a 7-minute CI run.
- Centralized the default in `CtrlProxyHierarchy` so the `AndroidCtrlProxyClient` wrapper stays in sync automatically (was previously duplicating `100`).

## Test plan

- [x] New regression test `should return fresh data when WebSocket push arrives after 100ms under contention (regression #2285)` simulates a 300ms-delayed push and asserts `fresh: true`. Fails on old default, passes on new.
- [x] `bun test test/features/observe/CtrlProxyClient.test.ts` — 17/18 pass (1 unrelated pre-existing failure on `main`).
- [x] `bun test test/features/observe/` — 498/499 pass (same pre-existing failure).
- [x] `turbo run lint build` clean.