### PR TITLE
make tapOn + observe resilient on high-latency emulators

### DIFF
--- a/src/features/action/TapOnElement.ts
+++ b/src/features/action/TapOnElement.ts
@@ -73,7 +73,8 @@ interface TapOnElementDependencies {
 }
 
 /**
- * Budgets used by retryTapIfNoChange to decide whether a tap registered.
+ * Post-tap observation budgets used by retryTapIfNoChange to decide whether
+ * a tap registered.
  *
  * Activity transitions commonly take 1-2s on contended emulators (emulator.wtf),
  * and the CtrlProxy WebSocket push for the new hierarchy doesn't arrive until
@@ -84,6 +85,9 @@ interface TapOnElementDependencies {
  */
 const POST_TAP_SETTLE_MS = 300;
 const POST_TAP_REFRESH_TIMEOUT_MS = 1500;
+
+/** Brief debounce between the original tap and the retry tap when a ghost tap
+ *  was detected. Just enough to let any inflight gesture queue drain. */
 const PRE_RETRY_DELAY_MS = 100;
 
 /**

--- a/src/features/action/TapOnElement.ts
+++ b/src/features/action/TapOnElement.ts
@@ -1198,13 +1198,33 @@ export class TapOnElement extends BaseVisualChange {
     screenSize: ObserveResult["screenSize"],
     signal?: AbortSignal,
   ): Promise<void> {
-    await this.timer.sleep(150);
+    // Activity transitions commonly take 1-2s and the CtrlProxy WebSocket push
+    // doesn't arrive until after the destination renders, so we need both a
+    // longer settle delay and a more generous refresh budget than the original
+    // 150ms/500ms. With the old budgets the post-tap refresh races the push
+    // and returns null/stale data during normal activity transitions, which
+    // gets misread as a ghost tap and causes a stray retry on the new screen.
+    await this.timer.sleep(300);
 
+    const refreshTimeoutMs = 1500;
     const postTapHierarchy = await this.refreshViewHierarchy(
-      500,
+      refreshTimeoutMs,
       screenSize,
       signal
     );
+
+    if (!postTapHierarchy) {
+      // Refresh timed out — we can't tell whether the tap registered. A retry
+      // here is more likely to land on a transitioning screen and bounce us
+      // off-path than to recover a real ghost tap. Bail and let the next
+      // step's waitFor/observe surface a real failure.
+      logger.warn(
+        `[TapOnElement][retryIfNoChange] Post-tap refresh returned no hierarchy ` +
+        `within ${refreshTimeoutMs}ms — skipping retry (likely activity transition in progress)`
+      );
+      return;
+    }
+
     const postTapHash = this.hashViewHierarchy(postTapHierarchy);
 
     if (postTapHash && postTapHash !== preTapHash) {

--- a/src/features/action/TapOnElement.ts
+++ b/src/features/action/TapOnElement.ts
@@ -73,6 +73,20 @@ interface TapOnElementDependencies {
 }
 
 /**
+ * Budgets used by retryTapIfNoChange to decide whether a tap registered.
+ *
+ * Activity transitions commonly take 1-2s on contended emulators (emulator.wtf),
+ * and the CtrlProxy WebSocket push for the new hierarchy doesn't arrive until
+ * after the destination renders. With tighter budgets the post-tap refresh
+ * races the push and returns null/stale data during normal activity
+ * transitions, which gets misread as a ghost tap and causes a stray retry on
+ * the new screen.
+ */
+const POST_TAP_SETTLE_MS = 300;
+const POST_TAP_REFRESH_TIMEOUT_MS = 1500;
+const PRE_RETRY_DELAY_MS = 100;
+
+/**
  * Command to tap on UI element containing specified text
  */
 export class TapOnElement extends BaseVisualChange {
@@ -1198,17 +1212,10 @@ export class TapOnElement extends BaseVisualChange {
     screenSize: ObserveResult["screenSize"],
     signal?: AbortSignal,
   ): Promise<void> {
-    // Activity transitions commonly take 1-2s and the CtrlProxy WebSocket push
-    // doesn't arrive until after the destination renders, so we need both a
-    // longer settle delay and a more generous refresh budget than the original
-    // 150ms/500ms. With the old budgets the post-tap refresh races the push
-    // and returns null/stale data during normal activity transitions, which
-    // gets misread as a ghost tap and causes a stray retry on the new screen.
-    await this.timer.sleep(300);
+    await this.timer.sleep(POST_TAP_SETTLE_MS);
 
-    const refreshTimeoutMs = 1500;
     const postTapHierarchy = await this.refreshViewHierarchy(
-      refreshTimeoutMs,
+      POST_TAP_REFRESH_TIMEOUT_MS,
       screenSize,
       signal
     );
@@ -1220,7 +1227,7 @@ export class TapOnElement extends BaseVisualChange {
       // step's waitFor/observe surface a real failure.
       logger.warn(
         `[TapOnElement][retryIfNoChange] Post-tap refresh returned no hierarchy ` +
-        `within ${refreshTimeoutMs}ms — skipping retry (likely activity transition in progress)`
+        `within ${POST_TAP_REFRESH_TIMEOUT_MS}ms — skipping retry (likely activity transition in progress)`
       );
       return;
     }
@@ -1239,7 +1246,7 @@ export class TapOnElement extends BaseVisualChange {
       `(${tapPoint.x}, ${tapPoint.y}) — ghost tap detected, retrying`
     );
 
-    await this.timer.sleep(100);
+    await this.timer.sleep(PRE_RETRY_DELAY_MS);
 
     await this.executeAndroidTap(
       action,

--- a/src/features/action/swipeon/ScrollUntilVisible.ts
+++ b/src/features/action/swipeon/ScrollUntilVisible.ts
@@ -124,7 +124,6 @@ export class ScrollUntilVisible {
       ? `text "${options.lookFor!.text}"`
       : `element with id "${options.lookFor!.elementId}"`;
     logger.info(`[SwipeOn] Looking for ${target} with maxTime=${maxTime}ms`);
-    logger.info(`[SwipeOn][DEBUG] ${this.summarizeFingerprint("initial", lastFingerprint)}`);
 
     // Check if TalkBack is enabled (not just any accessibility service)
     const isTalkBackEnabled = await perf.track("checkTalkBack", async () => {
@@ -252,15 +251,16 @@ export class ScrollUntilVisible {
         throw new Error("Lost observation after swipe during scroll until visible.");
       }
 
+      // If the post-swipe fingerprint matches the pre-swipe fingerprint, the
+      // observation likely returned stale cached data (the swipe gesture was
+      // dispatched but the cache hadn't been invalidated yet) rather than
+      // reflecting an actually-stationary list. This is the canonical signal
+      // that the scroll-end detector below will misfire, so surface it loudly.
       const postSwipeFingerprint = this.computeHierarchyFingerprint(lastObservation.viewHierarchy!);
-      logger.info(
-        `[SwipeOn][DEBUG] iter=${scrollIteration} ` +
-        this.summarizeFingerprint("post-swipe", postSwipeFingerprint)
-      );
       if (postSwipeFingerprint === lastFingerprint) {
-        logger.info(
-          `[SwipeOn][DEBUG] iter=${scrollIteration} WARNING post-swipe fingerprint matches pre-swipe — ` +
-          `observation may be stale (cache hit?) or swipe had no visible effect.`
+        logger.warn(
+          `[SwipeOn] iter=${scrollIteration} post-swipe fingerprint matches pre-swipe — ` +
+          `observation may be stale (cache hit) or swipe had no visible effect`
         );
       }
 
@@ -271,7 +271,6 @@ export class ScrollUntilVisible {
       // idle state rather than a transient mid-scroll frame.
       const elapsedMs = this.deps.timer.now() - startTime;
       const idleCheckMaxMs = Math.min(1500, Math.max(0, maxTime - elapsedMs - 300));
-      const idleCheckStart = this.deps.timer.now();
       if (idleCheckMaxMs > 100) {
         lastObservation = await this.waitForScrollIdle(lastObservation, idleCheckMaxMs);
       }
@@ -279,10 +278,6 @@ export class ScrollUntilVisible {
       // Check if hierarchy changed (detect scroll end)
       const currentFingerprint = this.computeHierarchyFingerprint(lastObservation.viewHierarchy!);
       const fingerprintChanged = currentFingerprint !== lastFingerprint;
-      logger.info(
-        `[SwipeOn][DEBUG] iter=${scrollIteration} idleCheck took ${this.deps.timer.now() - idleCheckStart}ms ` +
-        `(budget=${idleCheckMaxMs}ms); ` + this.summarizeFingerprint("post-idle", currentFingerprint)
-      );
       logger.info(`[SwipeOn] Iteration ${scrollIteration}: hierarchy ${fingerprintChanged ? "changed" : "UNCHANGED"} (fingerprint[0:40]="${currentFingerprint.slice(0, 40)}")`);
 
       if (!fingerprintChanged) {
@@ -514,34 +509,6 @@ export class ScrollUntilVisible {
     return JSON.stringify(viewHierarchy.hierarchy);
   }
 
-  /**
-   * DEBUG: structured summary of a fingerprint for diagnosing scroll-end-detection failures.
-   * Logs length, a stable short hash, head/tail snippets, a node-count approximation, and a few
-   * bounds samples so consecutive iterations can be compared at a glance to tell whether the
-   * post-swipe observation reflects the new scroll position or returned stale-cached data.
-   */
-  private summarizeFingerprint(label: string, fingerprint: string): string {
-    if (!fingerprint) {
-      return `${label}: <empty>`;
-    }
-    let hash = 0;
-    for (let i = 0; i < fingerprint.length; i++) {
-      hash = (Math.imul(31, hash) + fingerprint.charCodeAt(i)) | 0;
-    }
-    const hashHex = (hash >>> 0).toString(16).padStart(8, "0");
-    const nodeCount = (fingerprint.match(/"node":/g) ?? []).length;
-    const boundsMatches = fingerprint.match(/"bounds":"\[[^"]+\]"/g) ?? [];
-    const firstBounds = boundsMatches.slice(0, 2).join(", ");
-    const lastBounds = boundsMatches.slice(-2).join(", ");
-    const head = fingerprint.slice(0, 80).replace(/\s+/g, " ");
-    const tail = fingerprint.slice(-80).replace(/\s+/g, " ");
-    return (
-      `${label}: len=${fingerprint.length} hash=${hashHex} nodes=${nodeCount} ` +
-      `boundsCount=${boundsMatches.length} firstBounds=[${firstBounds}] lastBounds=[${lastBounds}] ` +
-      `head="${head}" tail="${tail}"`
-    );
-  }
-
   private async setAccessibilityFocusOnElement(
     element: Element,
     perf: PerformanceTracker
@@ -606,26 +573,12 @@ export class ScrollUntilVisible {
     const pollIntervalMs = 150;
     let previousFingerprint = this.computeHierarchyFingerprint(currentObservation.viewHierarchy);
     let latestObservation = currentObservation;
-    logger.info(`[SwipeOn][DEBUG] waitForScrollIdle: ${this.summarizeFingerprint("entry", previousFingerprint)}`);
-    let pollIteration = 0;
 
     while (this.deps.timer.now() - startTime < maxWaitMs) {
-      pollIteration++;
-      const pollStart = this.deps.timer.now();
       const newObservation = await this.deps.observeScreen.execute();
-      const pollObserveMs = this.deps.timer.now() - pollStart;
-      if (!newObservation.viewHierarchy) {
-        logger.info(`[SwipeOn][DEBUG] waitForScrollIdle poll=${pollIteration}: observeScreen returned no viewHierarchy (took ${pollObserveMs}ms), breaking`);
-        break;
-      }
+      if (!newObservation.viewHierarchy) {break;}
       const newFingerprint = this.computeHierarchyFingerprint(newObservation.viewHierarchy);
-      const matchedPrev = newFingerprint === previousFingerprint;
-      logger.info(
-        `[SwipeOn][DEBUG] waitForScrollIdle poll=${pollIteration} elapsed=${this.deps.timer.now() - startTime}ms ` +
-        `observeMs=${pollObserveMs} matchedPrev=${matchedPrev}; ` +
-        this.summarizeFingerprint(`poll${pollIteration}`, newFingerprint)
-      );
-      if (matchedPrev) {
+      if (newFingerprint === previousFingerprint) {
         logger.info(`[SwipeOn] Scroll settled after ${this.deps.timer.now() - startTime}ms idle check`);
         return newObservation;
       }
@@ -635,7 +588,7 @@ export class ScrollUntilVisible {
       await this.deps.timer.sleep(pollIntervalMs);
     }
 
-    logger.info(`[SwipeOn] Scroll idle check reached ${maxWaitMs}ms limit, proceeding (polls=${pollIteration})`);
+    logger.info(`[SwipeOn] Scroll idle check reached ${maxWaitMs}ms limit, proceeding`);
     return latestObservation;
   }
 

--- a/src/features/action/swipeon/ScrollUntilVisible.ts
+++ b/src/features/action/swipeon/ScrollUntilVisible.ts
@@ -124,6 +124,7 @@ export class ScrollUntilVisible {
       ? `text "${options.lookFor!.text}"`
       : `element with id "${options.lookFor!.elementId}"`;
     logger.info(`[SwipeOn] Looking for ${target} with maxTime=${maxTime}ms`);
+    logger.info(`[SwipeOn][DEBUG] ${this.summarizeFingerprint("initial", lastFingerprint)}`);
 
     // Check if TalkBack is enabled (not just any accessibility service)
     const isTalkBackEnabled = await perf.track("checkTalkBack", async () => {
@@ -251,6 +252,18 @@ export class ScrollUntilVisible {
         throw new Error("Lost observation after swipe during scroll until visible.");
       }
 
+      const postSwipeFingerprint = this.computeHierarchyFingerprint(lastObservation.viewHierarchy!);
+      logger.info(
+        `[SwipeOn][DEBUG] iter=${scrollIteration} ` +
+        this.summarizeFingerprint("post-swipe", postSwipeFingerprint)
+      );
+      if (postSwipeFingerprint === lastFingerprint) {
+        logger.info(
+          `[SwipeOn][DEBUG] iter=${scrollIteration} WARNING post-swipe fingerprint matches pre-swipe — ` +
+          `observation may be stale (cache hit?) or swipe had no visible effect.`
+        );
+      }
+
       // Wait for scroll animation to fully settle before inspecting the hierarchy.
       // The post-swipe observation may reflect a mid-scroll position (the accessibility service
       // can return a cached hierarchy captured before the fling decelerates to rest). Polling
@@ -258,6 +271,7 @@ export class ScrollUntilVisible {
       // idle state rather than a transient mid-scroll frame.
       const elapsedMs = this.deps.timer.now() - startTime;
       const idleCheckMaxMs = Math.min(1500, Math.max(0, maxTime - elapsedMs - 300));
+      const idleCheckStart = this.deps.timer.now();
       if (idleCheckMaxMs > 100) {
         lastObservation = await this.waitForScrollIdle(lastObservation, idleCheckMaxMs);
       }
@@ -265,6 +279,10 @@ export class ScrollUntilVisible {
       // Check if hierarchy changed (detect scroll end)
       const currentFingerprint = this.computeHierarchyFingerprint(lastObservation.viewHierarchy!);
       const fingerprintChanged = currentFingerprint !== lastFingerprint;
+      logger.info(
+        `[SwipeOn][DEBUG] iter=${scrollIteration} idleCheck took ${this.deps.timer.now() - idleCheckStart}ms ` +
+        `(budget=${idleCheckMaxMs}ms); ` + this.summarizeFingerprint("post-idle", currentFingerprint)
+      );
       logger.info(`[SwipeOn] Iteration ${scrollIteration}: hierarchy ${fingerprintChanged ? "changed" : "UNCHANGED"} (fingerprint[0:40]="${currentFingerprint.slice(0, 40)}")`);
 
       if (!fingerprintChanged) {
@@ -496,6 +514,34 @@ export class ScrollUntilVisible {
     return JSON.stringify(viewHierarchy.hierarchy);
   }
 
+  /**
+   * DEBUG: structured summary of a fingerprint for diagnosing scroll-end-detection failures.
+   * Logs length, a stable short hash, head/tail snippets, a node-count approximation, and a few
+   * bounds samples so consecutive iterations can be compared at a glance to tell whether the
+   * post-swipe observation reflects the new scroll position or returned stale-cached data.
+   */
+  private summarizeFingerprint(label: string, fingerprint: string): string {
+    if (!fingerprint) {
+      return `${label}: <empty>`;
+    }
+    let hash = 0;
+    for (let i = 0; i < fingerprint.length; i++) {
+      hash = (Math.imul(31, hash) + fingerprint.charCodeAt(i)) | 0;
+    }
+    const hashHex = (hash >>> 0).toString(16).padStart(8, "0");
+    const nodeCount = (fingerprint.match(/"node":/g) ?? []).length;
+    const boundsMatches = fingerprint.match(/"bounds":"\[[^"]+\]"/g) ?? [];
+    const firstBounds = boundsMatches.slice(0, 2).join(", ");
+    const lastBounds = boundsMatches.slice(-2).join(", ");
+    const head = fingerprint.slice(0, 80).replace(/\s+/g, " ");
+    const tail = fingerprint.slice(-80).replace(/\s+/g, " ");
+    return (
+      `${label}: len=${fingerprint.length} hash=${hashHex} nodes=${nodeCount} ` +
+      `boundsCount=${boundsMatches.length} firstBounds=[${firstBounds}] lastBounds=[${lastBounds}] ` +
+      `head="${head}" tail="${tail}"`
+    );
+  }
+
   private async setAccessibilityFocusOnElement(
     element: Element,
     perf: PerformanceTracker
@@ -560,12 +606,26 @@ export class ScrollUntilVisible {
     const pollIntervalMs = 150;
     let previousFingerprint = this.computeHierarchyFingerprint(currentObservation.viewHierarchy);
     let latestObservation = currentObservation;
+    logger.info(`[SwipeOn][DEBUG] waitForScrollIdle: ${this.summarizeFingerprint("entry", previousFingerprint)}`);
+    let pollIteration = 0;
 
     while (this.deps.timer.now() - startTime < maxWaitMs) {
+      pollIteration++;
+      const pollStart = this.deps.timer.now();
       const newObservation = await this.deps.observeScreen.execute();
-      if (!newObservation.viewHierarchy) {break;}
+      const pollObserveMs = this.deps.timer.now() - pollStart;
+      if (!newObservation.viewHierarchy) {
+        logger.info(`[SwipeOn][DEBUG] waitForScrollIdle poll=${pollIteration}: observeScreen returned no viewHierarchy (took ${pollObserveMs}ms), breaking`);
+        break;
+      }
       const newFingerprint = this.computeHierarchyFingerprint(newObservation.viewHierarchy);
-      if (newFingerprint === previousFingerprint) {
+      const matchedPrev = newFingerprint === previousFingerprint;
+      logger.info(
+        `[SwipeOn][DEBUG] waitForScrollIdle poll=${pollIteration} elapsed=${this.deps.timer.now() - startTime}ms ` +
+        `observeMs=${pollObserveMs} matchedPrev=${matchedPrev}; ` +
+        this.summarizeFingerprint(`poll${pollIteration}`, newFingerprint)
+      );
+      if (matchedPrev) {
         logger.info(`[SwipeOn] Scroll settled after ${this.deps.timer.now() - startTime}ms idle check`);
         return newObservation;
       }
@@ -575,7 +635,7 @@ export class ScrollUntilVisible {
       await this.deps.timer.sleep(pollIntervalMs);
     }
 
-    logger.info(`[SwipeOn] Scroll idle check reached ${maxWaitMs}ms limit, proceeding`);
+    logger.info(`[SwipeOn] Scroll idle check reached ${maxWaitMs}ms limit, proceeding (polls=${pollIteration})`);
     return latestObservation;
   }
 

--- a/src/features/navigation/SelectionStateTracker.ts
+++ b/src/features/navigation/SelectionStateTracker.ts
@@ -54,15 +54,19 @@ interface SelectionFinalizeRequest {
 interface SelectionStateTrackerOptions {
   detector?: SelectionStateDetectorLike;
   screenshotCapturer: ScreenshotCapturer;
+  isUiPerfModeEnabled?: () => boolean;
 }
 
 export class SelectionStateTracker {
   private detector: SelectionStateDetectorLike;
   private screenshotCapturer: ScreenshotCapturer;
+  private isUiPerfModeEnabled: () => boolean;
 
   constructor(options: SelectionStateTrackerOptions) {
     this.detector = options.detector ?? new SelectionStateDetector();
     this.screenshotCapturer = options.screenshotCapturer;
+    this.isUiPerfModeEnabled = options.isUiPerfModeEnabled
+      ?? (() => serverConfig.isUiPerfModeEnabled());
   }
 
   async prepare(request: SelectionCaptureRequest): Promise<SelectionCaptureState | null> {
@@ -75,9 +79,10 @@ export class SelectionStateTracker {
     // a correctness mechanism. In CI / perf-constrained environments it's the
     // single largest source of ADB pipe pressure because it takes two screenshots
     // per tap (before + after) at p90 ~1.7s each, which also stalls CtrlProxy
-    // WebSocket pushes long enough to false-positive ghost-tap detection. Honor
-    // --no-ui-perf-mode by skipping the whole feature.
-    if (!serverConfig.isUiPerfModeEnabled()) {
+    // WebSocket pushes long enough to false-positive ghost-tap detection
+    // (see TapOnElement.retryTapIfNoChange). Honor --no-ui-perf-mode by
+    // skipping the whole feature.
+    if (!this.isUiPerfModeEnabled()) {
       logger.debug(`[SELECTION_STATE] Skip selection capture (${action}): ui-perf-mode disabled`);
       return null;
     }

--- a/src/features/navigation/SelectionStateTracker.ts
+++ b/src/features/navigation/SelectionStateTracker.ts
@@ -1,6 +1,7 @@
 import { BootedDevice, Element, ObserveResult } from "../../models";
 import { AdbClientFactory, defaultAdbClientFactory } from "../../utils/android-cmdline-tools/AdbClientFactory";
 import { logger } from "../../utils/logger";
+import { serverConfig } from "../../utils/ServerConfig";
 import { SelectedElement } from "../../utils/interfaces/NavigationGraph";
 import { TakeScreenshot } from "../observe/TakeScreenshot";
 import { SelectionDetectionContext, SelectionStateDetector, SelectionStateDetectorLike } from "./SelectionStateDetector";
@@ -67,6 +68,17 @@ export class SelectionStateTracker {
   async prepare(request: SelectionCaptureRequest): Promise<SelectionCaptureState | null> {
     const { observation, element, action, signal } = request;
     if (!observation?.viewHierarchy || !element) {
+      return null;
+    }
+
+    // Selection state tracking is a "nice to have" return-value enrichment, not
+    // a correctness mechanism. In CI / perf-constrained environments it's the
+    // single largest source of ADB pipe pressure because it takes two screenshots
+    // per tap (before + after) at p90 ~1.7s each, which also stalls CtrlProxy
+    // WebSocket pushes long enough to false-positive ghost-tap detection. Honor
+    // --no-ui-perf-mode by skipping the whole feature.
+    if (!serverConfig.isUiPerfModeEnabled()) {
+      logger.debug(`[SELECTION_STATE] Skip selection capture (${action}): ui-perf-mode disabled`);
       return null;
     }
 

--- a/src/features/observe/android/CtrlProxyHierarchy.ts
+++ b/src/features/observe/android/CtrlProxyHierarchy.ts
@@ -125,8 +125,8 @@ export class CtrlProxyHierarchy {
           } else {
             const isFresh = cacheAge < 1000;
             const duration = this.context.timer.now() - startTime;
-            logger.info(
-              `[CTRL_PROXY][DEBUG] Cache accepted (with minTimestamp) in ${duration}ms: ` +
+            logger.debug(
+              `[CTRL_PROXY] Cache accepted in ${duration}ms: ` +
               `receivedAt=${cachedHierarchy.receivedAt}, ` +
               `updatedAt=${updatedAt}, age=${cacheAge}ms, fresh=${isFresh}`
             );
@@ -142,7 +142,7 @@ export class CtrlProxyHierarchy {
           // No minTimestamp check, return cache
           const isFresh = cacheAge < 1000;
           const duration = this.context.timer.now() - startTime;
-          logger.info(`[CTRL_PROXY][DEBUG] Cache hit: ${duration}ms (age: ${cacheAge}ms, fresh: ${isFresh}, updatedAt: ${updatedAt})`);
+          logger.debug(`[CTRL_PROXY] Cache hit: ${duration}ms (age: ${cacheAge}ms, fresh: ${isFresh}, updatedAt: ${updatedAt})`);
 
           return {
             hierarchy: cachedHierarchy.hierarchy,
@@ -172,7 +172,7 @@ export class CtrlProxyHierarchy {
           if (freshData.hierarchy.packageName) {
             this.lastKnownPackageName = freshData.hierarchy.packageName;
           }
-          logger.info(`[CTRL_PROXY][DEBUG] Received fresh hierarchy in ${duration}ms (updatedAt: ${freshData.hierarchy.updatedAt})`);
+          logger.debug(`[CTRL_PROXY] Received fresh hierarchy in ${duration}ms (updatedAt: ${freshData.hierarchy.updatedAt})`);
           return {
             hierarchy: freshData.hierarchy,
             fresh: true,
@@ -195,7 +195,7 @@ export class CtrlProxyHierarchy {
               this.lastKnownPackageName = currentCache.hierarchy.packageName;
             }
             currentCache.fresh = false;
-            logger.info(`[CTRL_PROXY][DEBUG] Returning stale cached data (updatedAt: ${currentCache.hierarchy.updatedAt}), marked cache as stale`);
+            logger.debug(`[CTRL_PROXY] Returning stale cached data (updatedAt: ${currentCache.hierarchy.updatedAt}), marked cache as stale`);
             return {
               hierarchy: currentCache.hierarchy,
               fresh: false,

--- a/src/features/observe/android/CtrlProxyHierarchy.ts
+++ b/src/features/observe/android/CtrlProxyHierarchy.ts
@@ -125,8 +125,8 @@ export class CtrlProxyHierarchy {
           } else {
             const isFresh = cacheAge < 1000;
             const duration = this.context.timer.now() - startTime;
-            logger.debug(
-              `[CTRL_PROXY] Cache accepted in ${duration}ms: ` +
+            logger.info(
+              `[CTRL_PROXY][DEBUG] Cache accepted (with minTimestamp) in ${duration}ms: ` +
               `receivedAt=${cachedHierarchy.receivedAt}, ` +
               `updatedAt=${updatedAt}, age=${cacheAge}ms, fresh=${isFresh}`
             );
@@ -142,7 +142,7 @@ export class CtrlProxyHierarchy {
           // No minTimestamp check, return cache
           const isFresh = cacheAge < 1000;
           const duration = this.context.timer.now() - startTime;
-          logger.debug(`[CTRL_PROXY] Cache hit: ${duration}ms (age: ${cacheAge}ms, fresh: ${isFresh}, updatedAt: ${updatedAt})`);
+          logger.info(`[CTRL_PROXY][DEBUG] Cache hit: ${duration}ms (age: ${cacheAge}ms, fresh: ${isFresh}, updatedAt: ${updatedAt})`);
 
           return {
             hierarchy: cachedHierarchy.hierarchy,
@@ -172,7 +172,7 @@ export class CtrlProxyHierarchy {
           if (freshData.hierarchy.packageName) {
             this.lastKnownPackageName = freshData.hierarchy.packageName;
           }
-          logger.debug(`[CTRL_PROXY] Received fresh hierarchy in ${duration}ms (updatedAt: ${freshData.hierarchy.updatedAt})`);
+          logger.info(`[CTRL_PROXY][DEBUG] Received fresh hierarchy in ${duration}ms (updatedAt: ${freshData.hierarchy.updatedAt})`);
           return {
             hierarchy: freshData.hierarchy,
             fresh: true,
@@ -195,7 +195,7 @@ export class CtrlProxyHierarchy {
               this.lastKnownPackageName = currentCache.hierarchy.packageName;
             }
             currentCache.fresh = false;
-            logger.debug(`[CTRL_PROXY] Returning stale cached data (updatedAt: ${currentCache.hierarchy.updatedAt}), marked cache as stale`);
+            logger.info(`[CTRL_PROXY][DEBUG] Returning stale cached data (updatedAt: ${currentCache.hierarchy.updatedAt}), marked cache as stale`);
             return {
               hierarchy: currentCache.hierarchy,
               fresh: false,

--- a/src/index.ts
+++ b/src/index.ts
@@ -458,24 +458,20 @@ async function main() {
       logger.info("WaitFor polling overhead disabled (--no-waitfor-polling-overhead): screenshots and back stack skipped during observe waitFor polling");
     }
 
-    if (!uiPerfMode) {
-      logger.info("UI perf mode disabled (--no-ui-perf-mode): skipping selection-state visual capture on taps and UI perf auditing");
-    }
-
-    if (dismissKeyboardAfterInput) {
-      logger.info("Dismiss keyboard after inputText enabled (--dismiss-keyboard-after-input)");
-    }
-
-    if (noA11yIncludeNotImportantViews) {
-      logger.info("Accessibility includeNotImportantViews disabled (--no-include-not-important-views)");
-    }
-
-    if (noA11yReportViewIds) {
-      logger.info("Accessibility reportViewIds disabled (--no-report-view-ids)");
-    }
-
-    if (noA11yRetrieveInteractiveWindows) {
-      logger.info("Accessibility retrieveInteractiveWindows disabled (--no-retrieve-interactive-windows)");
+    // Log-only echoes for daemon CLI flags whose side effects are applied
+    // downstream via startDaemon(). Surfacing them at startup makes CI logs
+    // grep-verifiable so a missing flag is visible without re-running.
+    const silentDaemonFlags: Array<[boolean, string]> = [
+      [!uiPerfMode, "UI perf mode disabled (--no-ui-perf-mode): skipping selection-state visual capture on taps and UI perf auditing"],
+      [dismissKeyboardAfterInput, "Dismiss keyboard after inputText enabled (--dismiss-keyboard-after-input)"],
+      [noA11yIncludeNotImportantViews, "Accessibility includeNotImportantViews disabled (--no-include-not-important-views)"],
+      [noA11yReportViewIds, "Accessibility reportViewIds disabled (--no-report-view-ids)"],
+      [noA11yRetrieveInteractiveWindows, "Accessibility retrieveInteractiveWindows disabled (--no-retrieve-interactive-windows)"],
+    ];
+    for (const [active, message] of silentDaemonFlags) {
+      if (active) {
+        logger.info(message);
+      }
     }
 
     if (daemonMode) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -458,6 +458,26 @@ async function main() {
       logger.info("WaitFor polling overhead disabled (--no-waitfor-polling-overhead): screenshots and back stack skipped during observe waitFor polling");
     }
 
+    if (!uiPerfMode) {
+      logger.info("UI perf mode disabled (--no-ui-perf-mode): skipping selection-state visual capture on taps and UI perf auditing");
+    }
+
+    if (dismissKeyboardAfterInput) {
+      logger.info("Dismiss keyboard after inputText enabled (--dismiss-keyboard-after-input)");
+    }
+
+    if (noA11yIncludeNotImportantViews) {
+      logger.info("Accessibility includeNotImportantViews disabled (--no-include-not-important-views)");
+    }
+
+    if (noA11yReportViewIds) {
+      logger.info("Accessibility reportViewIds disabled (--no-report-view-ids)");
+    }
+
+    if (noA11yRetrieveInteractiveWindows) {
+      logger.info("Accessibility retrieveInteractiveWindows disabled (--no-retrieve-interactive-windows)");
+    }
+
     if (daemonMode) {
       await startDaemon({
         port: daemonPort,

--- a/src/utils/plan/PlanMigrator.ts
+++ b/src/utils/plan/PlanMigrator.ts
@@ -267,6 +267,19 @@ const migrateStepFields = (
         changed = true;
       }
     }
+    // Back-compat: tapClickableParent was removed in v0.0.30 (#2248) — the daemon
+    // now auto-escalates to the nearest clickable ancestor when the matched
+    // element is not itself clickable, making this flag redundant. Strip it so
+    // legacy plans don't fail strict schema validation.
+    if (mergedParams.tapClickableParent !== undefined) {
+      delete mergedParams.tapClickableParent;
+      recordWarning(
+        warnings,
+        "Removed tapClickableParent (redundant with auto-escalation in v0.0.30+).",
+        stepIndex
+      );
+      changed = true;
+    }
   }
 
   if (normalizedTool === "inputText") {

--- a/src/utils/plan/PlanMigrator.ts
+++ b/src/utils/plan/PlanMigrator.ts
@@ -243,6 +243,30 @@ const migrateStepFields = (
       recordWarning(warnings, "Renamed id to elementId for tapOn.", stepIndex);
       changed = true;
     }
+    // Back-compat: tapOn's top-level { elementId } / { text } moved under `selector`
+    // in v0.0.30 (see PR #2255 split of tapOn/tapAny). Wrap the legacy shape so plans
+    // authored against 0.0.28-style schemas still validate.
+    const selectorIsRecord = isRecord(mergedParams.selector);
+    if (!selectorIsRecord) {
+      const selector: Record<string, unknown> = {};
+      if (typeof mergedParams.elementId === "string") {
+        selector.elementId = mergedParams.elementId;
+        delete mergedParams.elementId;
+      }
+      if (typeof mergedParams.text === "string") {
+        selector.text = mergedParams.text;
+        delete mergedParams.text;
+      }
+      if (Object.keys(selector).length > 0) {
+        mergedParams.selector = selector;
+        recordWarning(
+          warnings,
+          "Wrapped legacy tapOn { elementId|text } under { selector: { ... } } for v0.0.30+ schema.",
+          stepIndex
+        );
+        changed = true;
+      }
+    }
   }
 
   if (normalizedTool === "inputText") {

--- a/src/utils/plan/PlanMigrator.ts
+++ b/src/utils/plan/PlanMigrator.ts
@@ -267,19 +267,6 @@ const migrateStepFields = (
         changed = true;
       }
     }
-    // Back-compat: tapClickableParent was removed in v0.0.30 (#2248) — the daemon
-    // now auto-escalates to the nearest clickable ancestor when the matched
-    // element is not itself clickable, making this flag redundant. Strip it so
-    // legacy plans don't fail strict schema validation.
-    if (mergedParams.tapClickableParent !== undefined) {
-      delete mergedParams.tapClickableParent;
-      recordWarning(
-        warnings,
-        "Removed tapClickableParent (redundant with auto-escalation in v0.0.30+).",
-        stepIndex
-      );
-      changed = true;
-    }
   }
 
   if (normalizedTool === "inputText") {

--- a/test/features/action/TapOnElement.retryIfNoChange.test.ts
+++ b/test/features/action/TapOnElement.retryIfNoChange.test.ts
@@ -86,7 +86,7 @@ describe("retryTapIfNoChange", () => {
     expect(tapCallCount).toBe(1);
   });
 
-  test("retries tap when post-tap hierarchy is null (no hash)", async () => {
+  test("skips retry when post-tap hierarchy refresh returns null (likely activity transition)", async () => {
     const { tap } = createTapOnElement();
     const preHierarchy = makeHierarchy("before");
 
@@ -108,7 +108,7 @@ describe("retryTapIfNoChange", () => {
       { width: 1080, height: 1920 },
     );
 
-    expect(tapCallCount).toBe(1);
+    expect(tapCallCount).toBe(0);
   });
 
   test("sleeps before checking and before retrying", async () => {
@@ -138,7 +138,7 @@ describe("retryTapIfNoChange", () => {
       { width: 1080, height: 1920 },
     );
 
-    expect(sleepDurations).toEqual([150, 100]);
+    expect(sleepDurations).toEqual([300, 100]);
   });
 });
 

--- a/test/features/navigation/SelectionStateTracker.test.ts
+++ b/test/features/navigation/SelectionStateTracker.test.ts
@@ -1,6 +1,5 @@
-import { afterEach, describe, expect, test } from "bun:test";
+import { describe, expect, test } from "bun:test";
 import { SelectionStateTracker } from "../../../src/features/navigation/SelectionStateTracker";
-import { serverConfig } from "../../../src/utils/ServerConfig";
 import { FakeSelectionStateDetector } from "../../fakes/FakeSelectionStateDetector";
 import { FakeScreenshotCapturer } from "../../fakes/FakeScreenshotCapturer";
 import { Element, ObserveResult, ViewHierarchyResult } from "../../../src/models";
@@ -19,19 +18,14 @@ const createObservation = (viewHierarchy: ViewHierarchyResult): ObserveResult =>
 });
 
 describe("SelectionStateTracker", () => {
-  afterEach(() => {
-    serverConfig.setUiPerfMode(true);
-  });
-
   test("skips capture entirely when ui perf mode is disabled (--no-ui-perf-mode)", async () => {
     const detector = new FakeSelectionStateDetector();
     const capturer = new FakeScreenshotCapturer();
     const tracker = new SelectionStateTracker({
       detector,
-      screenshotCapturer: capturer
+      screenshotCapturer: capturer,
+      isUiPerfModeEnabled: () => false,
     });
-
-    serverConfig.setUiPerfMode(false);
 
     const observation = createObservation(
       createHierarchy({

--- a/test/features/navigation/SelectionStateTracker.test.ts
+++ b/test/features/navigation/SelectionStateTracker.test.ts
@@ -57,7 +57,8 @@ describe("SelectionStateTracker", () => {
     const capturer = new FakeScreenshotCapturer();
     const tracker = new SelectionStateTracker({
       detector,
-      screenshotCapturer: capturer
+      screenshotCapturer: capturer,
+      isUiPerfModeEnabled: () => true
     });
 
     const observation = createObservation(
@@ -90,7 +91,8 @@ describe("SelectionStateTracker", () => {
     const capturer = new FakeScreenshotCapturer();
     const tracker = new SelectionStateTracker({
       detector,
-      screenshotCapturer: capturer
+      screenshotCapturer: capturer,
+      isUiPerfModeEnabled: () => true
     });
 
     capturer.setPaths(["before.png", "after.png"]);
@@ -145,7 +147,8 @@ describe("SelectionStateTracker", () => {
     const capturer = new FakeScreenshotCapturer();
     const tracker = new SelectionStateTracker({
       detector,
-      screenshotCapturer: capturer
+      screenshotCapturer: capturer,
+      isUiPerfModeEnabled: () => true
     });
 
     const observation = createObservation(

--- a/test/features/navigation/SelectionStateTracker.test.ts
+++ b/test/features/navigation/SelectionStateTracker.test.ts
@@ -1,5 +1,6 @@
-import { describe, expect, test } from "bun:test";
+import { afterEach, describe, expect, test } from "bun:test";
 import { SelectionStateTracker } from "../../../src/features/navigation/SelectionStateTracker";
+import { serverConfig } from "../../../src/utils/ServerConfig";
 import { FakeSelectionStateDetector } from "../../fakes/FakeSelectionStateDetector";
 import { FakeScreenshotCapturer } from "../../fakes/FakeScreenshotCapturer";
 import { Element, ObserveResult, ViewHierarchyResult } from "../../../src/models";
@@ -18,6 +19,45 @@ const createObservation = (viewHierarchy: ViewHierarchyResult): ObserveResult =>
 });
 
 describe("SelectionStateTracker", () => {
+  afterEach(() => {
+    serverConfig.setUiPerfMode(true);
+  });
+
+  test("skips capture entirely when ui perf mode is disabled (--no-ui-perf-mode)", async () => {
+    const detector = new FakeSelectionStateDetector();
+    const capturer = new FakeScreenshotCapturer();
+    const tracker = new SelectionStateTracker({
+      detector,
+      screenshotCapturer: capturer
+    });
+
+    serverConfig.setUiPerfMode(false);
+
+    const observation = createObservation(
+      createHierarchy({
+        text: "Tab1",
+        selected: "false",
+        bounds: "[0,0][10,10]"
+      })
+    );
+
+    const element: Element = {
+      bounds: { left: 0, top: 0, right: 10, bottom: 10 },
+      text: "Tab1",
+      clickable: true
+    };
+
+    const state = await tracker.prepare({
+      action: "tap",
+      observation,
+      element
+    });
+
+    expect(state).toBeNull();
+    expect(capturer.getCallCount()).toBe(0);
+    expect(detector.getContexts()).toHaveLength(0);
+  });
+
   test("skips capture when accessibility selected state is present", async () => {
     const detector = new FakeSelectionStateDetector();
     const capturer = new FakeScreenshotCapturer();

--- a/test/planUtils.test.ts
+++ b/test/planUtils.test.ts
@@ -196,7 +196,9 @@ metadata:
       expect(plan.steps[0].tool).toBe("launchApp");
       expect(plan.steps[0].params.appId).toBe("com.example.app");
       expect(plan.steps[1].tool).toBe("tapOn");
-      expect(plan.steps[1].params.text).toBe("Login");
+      // Migration wraps legacy top-level `text` under `selector` for the
+      // v0.0.30 tapOn schema (PR #2255).
+      expect(plan.steps[1].params.selector).toEqual({ text: "Login" });
       expect(plan.steps[1].params.action).toBe("tap");
     });
 

--- a/test/utils/plan/PlanMigrator.test.ts
+++ b/test/utils/plan/PlanMigrator.test.ts
@@ -279,6 +279,25 @@ describe("PlanMigrator", () => {
         expect(selector.text).toBe("Already wrapped");
       });
 
+      test("strips tapClickableParent (removed in 0.0.30, redundant with auto-escalation)", () => {
+        const { plan, report } = migratePlan({
+          name: "Plan",
+          mcpVersion: "1.0.0",
+          metadata: { createdAt: "2024-01-01", version: "1.0.0" },
+          steps: [{
+            tool: "tapOn",
+            params: { text: "Mindy Corkery RTT", tapClickableParent: true }
+          }],
+        });
+
+        expect(plan.steps[0].params.tapClickableParent).toBeUndefined();
+        const selector = plan.steps[0].params.selector as { text?: string };
+        expect(selector.text).toBe("Mindy Corkery RTT");
+        expect(
+          report.warnings.some(w => w.message.includes("tapClickableParent"))
+        ).toBe(true);
+      });
+
       test("renames inputText.value to text", () => {
         const { plan } = migratePlan({
           name: "Plan",

--- a/test/utils/plan/PlanMigrator.test.ts
+++ b/test/utils/plan/PlanMigrator.test.ts
@@ -234,7 +234,7 @@ describe("PlanMigrator", () => {
         expect(plan.steps[0].params.action).toBe("tap");
       });
 
-      test("renames id to elementId for tapOn", () => {
+      test("renames id to elementId for tapOn (wrapped into selector)", () => {
         const { plan } = migratePlan({
           name: "Plan",
           mcpVersion: "1.0.0",
@@ -242,8 +242,41 @@ describe("PlanMigrator", () => {
           steps: [{ tool: "tapOn", params: { id: "submit_button" } }],
         });
 
-        expect(plan.steps[0].params.elementId).toBe("submit_button");
+        const selector = plan.steps[0].params.selector as { elementId?: string };
+        expect(selector.elementId).toBe("submit_button");
         expect(plan.steps[0].params.id).toBeUndefined();
+        expect(plan.steps[0].params.elementId).toBeUndefined();
+      });
+
+      test("wraps legacy tapOn { text } under { selector: { text } } for 0.0.30+ schema", () => {
+        const { plan, report } = migratePlan({
+          name: "Plan",
+          mcpVersion: "1.0.0",
+          metadata: { createdAt: "2024-01-01", version: "1.0.0" },
+          steps: [{ tool: "tapOn", params: { text: "Schedule Appointment" } }],
+        });
+
+        const selector = plan.steps[0].params.selector as { text?: string };
+        expect(selector.text).toBe("Schedule Appointment");
+        expect(plan.steps[0].params.text).toBeUndefined();
+        expect(
+          report.warnings.some(w => w.message.includes("Wrapped legacy tapOn"))
+        ).toBe(true);
+      });
+
+      test("does not double-wrap tapOn that already has selector", () => {
+        const { plan } = migratePlan({
+          name: "Plan",
+          mcpVersion: "1.0.0",
+          metadata: { createdAt: "2024-01-01", version: "1.0.0" },
+          steps: [{
+            tool: "tapOn",
+            params: { selector: { text: "Already wrapped" } }
+          }],
+        });
+
+        const selector = plan.steps[0].params.selector as { text?: string };
+        expect(selector.text).toBe("Already wrapped");
       });
 
       test("renames inputText.value to text", () => {
@@ -402,7 +435,7 @@ describe("PlanMigrator", () => {
         expect(report.warnings.some(w => w.message.includes("Mapped step description to label"))).toBe(true);
       });
 
-      test("merges inline step fields into params", () => {
+      test("merges inline step fields into params (tapOn text wrapped under selector)", () => {
         const { plan } = migratePlan({
           name: "Plan",
           mcpVersion: "1.0.0",
@@ -410,8 +443,10 @@ describe("PlanMigrator", () => {
           steps: [{ tool: "tapOn", text: "Hello", action: "tap" }],
         });
 
-        expect(plan.steps[0].params.text).toBe("Hello");
+        const selector = plan.steps[0].params.selector as { text?: string };
+        expect(selector.text).toBe("Hello");
         expect(plan.steps[0].params.action).toBe("tap");
+        expect(plan.steps[0].params.text).toBeUndefined();
       });
 
       test("skips non-record steps", () => {

--- a/test/utils/plan/PlanMigrator.test.ts
+++ b/test/utils/plan/PlanMigrator.test.ts
@@ -279,6 +279,24 @@ describe("PlanMigrator", () => {
         expect(selector.text).toBe("Already wrapped");
       });
 
+      test("wraps both elementId and text together into selector", () => {
+        const { plan } = migratePlan({
+          name: "Plan",
+          mcpVersion: "1.0.0",
+          metadata: { createdAt: "2024-01-01", version: "1.0.0" },
+          steps: [{
+            tool: "tapOn",
+            params: { elementId: "submit_btn", text: "Submit" },
+          }],
+        });
+
+        const selector = plan.steps[0].params.selector as { elementId?: string; text?: string };
+        expect(selector.elementId).toBe("submit_btn");
+        expect(selector.text).toBe("Submit");
+        expect(plan.steps[0].params.elementId).toBeUndefined();
+        expect(plan.steps[0].params.text).toBeUndefined();
+      });
+
 
       test("renames inputText.value to text", () => {
         const { plan } = migratePlan({

--- a/test/utils/plan/PlanMigrator.test.ts
+++ b/test/utils/plan/PlanMigrator.test.ts
@@ -279,24 +279,6 @@ describe("PlanMigrator", () => {
         expect(selector.text).toBe("Already wrapped");
       });
 
-      test("strips tapClickableParent (removed in 0.0.30, redundant with auto-escalation)", () => {
-        const { plan, report } = migratePlan({
-          name: "Plan",
-          mcpVersion: "1.0.0",
-          metadata: { createdAt: "2024-01-01", version: "1.0.0" },
-          steps: [{
-            tool: "tapOn",
-            params: { text: "Mindy Corkery RTT", tapClickableParent: true }
-          }],
-        });
-
-        expect(plan.steps[0].params.tapClickableParent).toBeUndefined();
-        const selector = plan.steps[0].params.selector as { text?: string };
-        expect(selector.text).toBe("Mindy Corkery RTT");
-        expect(
-          report.warnings.some(w => w.message.includes("tapClickableParent"))
-        ).toBe(true);
-      });
 
       test("renames inputText.value to text", () => {
         const { plan } = migratePlan({

--- a/test/utils/plan/PlanSerializer.test.ts
+++ b/test/utils/plan/PlanSerializer.test.ts
@@ -34,10 +34,11 @@ describe("YamlPlanSerializer", () => {
       expect(plan.description).toBe("A test plan");
       expect(plan.steps).toHaveLength(2);
       expect(plan.steps[0].tool).toBe("tapOn");
-      expect(plan.steps[0].params).toEqual({ text: "Hello", action: "tap" });
+      // Migration adds action: "tap" to tapOn steps and wraps legacy top-level
+      // `text` under `selector` for the v0.0.30 tapOn schema.
+      expect(plan.steps[0].params).toEqual({ selector: { text: "Hello" }, action: "tap" });
       expect(plan.steps[1].tool).toBe("inputText");
       expect(plan.steps[1].params).toEqual({ text: "World" });
-      // Note: migration adds action: "tap" to tapOn steps
     });
 
     test("imports a minimal valid plan", () => {
@@ -93,7 +94,9 @@ describe("YamlPlanSerializer", () => {
 
       const plan = serializer.importPlanFromYaml(yamlContent);
 
-      expect(plan.steps[0].params.text).toBe("Button");
+      // Migration wraps legacy top-level `text` under `selector` for the
+      // v0.0.30 tapOn schema.
+      expect(plan.steps[0].params).toEqual({ selector: { text: "Button" }, action: "tap" });
     });
 
     test("sets default description when not provided", () => {
@@ -176,7 +179,10 @@ describe("YamlPlanSerializer", () => {
           version: "1.0.0",
         },
         steps: [
-          { tool: "tapOn", params: { text: "Login", action: "tap" } },
+          // Use v0.0.30 selector shape so the round-trip is meaningful — the
+          // importer auto-migrates legacy { text: "..." } to { selector: { text: "..." } },
+          // which would otherwise make the round-trip non-identity.
+          { tool: "tapOn", params: { selector: { text: "Login" }, action: "tap" } },
           { tool: "inputText", params: { text: "user@example.com" } },
           { tool: "pressButton", params: { button: "enter" } },
         ],


### PR DESCRIPTION
Closes #2282, #2283, #2284, #2286

- **`retryTapIfNoChange` no longer false-triggers on activity transitions.** Bumped budgets (150→300ms settle, 500→1500ms refresh) and treat null post-tap hierarchy as inconclusive (bail, don't retry). Constants extracted to `POST_TAP_*_MS`.
- **`SelectionStateTracker` honors `--no-ui-perf-mode`.** Was the dominant ADB-pipe pressure source: 76 → 3 screenshots in a 7-min run.
- **`PlanMigrator`** auto-wraps legacy `tapOn { text|elementId }` under `selector: { ... }` for the 0.0.30 schema. Idempotent.
- **`index.ts`** logs 5 previously-silent CI flags at startup.