### PR TITLE
fix(action): avoid retryIfNoChange false-positives across activity transitions

### DIFF
--- a/src/features/action/TapOnElement.ts
+++ b/src/features/action/TapOnElement.ts
@@ -50,6 +50,13 @@ import { createTapStrategy } from "./strategies/createTapStrategy";
 
 type SearchUntilStats = NonNullable<TapOnElementResult["searchUntil"]>;
 
+interface PreTapState {
+  hash: string;
+  foregroundActivity?: string;
+  packageName?: string;
+  updatedAt?: number;
+}
+
 /**
  * Dependencies for TapOnElement that can be injected for testing.
  */
@@ -218,6 +225,19 @@ export class TapOnElement extends BaseVisualChange {
       logger.debug(`[TapOnElement] Failed to hash view hierarchy: ${error}`);
       return null;
     }
+  }
+
+  private capturePreTapState(viewHierarchy: ViewHierarchyResult | null): PreTapState | null {
+    const hash = this.hashViewHierarchy(viewHierarchy);
+    if (!hash || !viewHierarchy) {
+      return null;
+    }
+    return {
+      hash,
+      foregroundActivity: viewHierarchy.foregroundActivity,
+      packageName: viewHierarchy.packageName,
+      updatedAt: viewHierarchy.updatedAt,
+    };
   }
 
   private isElementCenterOffScreen(
@@ -985,8 +1005,8 @@ export class TapOnElement extends BaseVisualChange {
             signal
           });
 
-          const preTapHash = options.retryIfNoChange
-            ? this.hashViewHierarchy(viewHierarchy)
+          const preTapState = options.retryIfNoChange
+            ? this.capturePreTapState(viewHierarchy)
             : null;
 
           // Platform-specific tap execution
@@ -1012,9 +1032,9 @@ export class TapOnElement extends BaseVisualChange {
             }
           });
 
-          if (preTapHash && this.strategy.retryTapIfNoChange) {
+          if (preTapState && this.strategy.retryTapIfNoChange) {
             await this.retryTapIfNoChange(
-              preTapHash,
+              preTapState,
               tapPoint,
               action,
               longPressDuration,
@@ -1188,7 +1208,7 @@ export class TapOnElement extends BaseVisualChange {
    * Only called when retryIfNoChange is true.
    */
   private async retryTapIfNoChange(
-    preTapHash: string,
+    preTapState: PreTapState,
     tapPoint: { x: number; y: number },
     action: string,
     longPressDuration: number,
@@ -1200,14 +1220,61 @@ export class TapOnElement extends BaseVisualChange {
   ): Promise<void> {
     await this.timer.sleep(150);
 
-    const postTapHierarchy = await this.refreshViewHierarchy(
+    let postTapHierarchy = await this.refreshViewHierarchy(
       500,
       screenSize,
       signal
     );
+
+    // The CtrlProxy push pipeline can deliver a hierarchy captured *before* the
+    // tap-triggered transition completed (debouncer + throttler windows). If the
+    // post-tap snapshot is not newer than the pre-tap one, give the device one
+    // more chance to push a fresh one before deciding it's a ghost tap.
+    if (
+      postTapHierarchy &&
+      preTapState.updatedAt !== undefined &&
+      postTapHierarchy.updatedAt !== undefined &&
+      postTapHierarchy.updatedAt <= preTapState.updatedAt
+    ) {
+      logger.info(
+        `[TapOnElement][retryIfNoChange] Post-tap snapshot stale ` +
+        `(updatedAt=${postTapHierarchy.updatedAt} <= pre=${preTapState.updatedAt}), refetching`
+      );
+      await this.timer.sleep(200);
+      postTapHierarchy = await this.refreshViewHierarchy(500, screenSize, signal);
+    }
+
+    if (postTapHierarchy) {
+      const postActivity = postTapHierarchy.foregroundActivity;
+      if (
+        preTapState.foregroundActivity &&
+        postActivity &&
+        postActivity !== preTapState.foregroundActivity
+      ) {
+        logger.info(
+          `[TapOnElement][retryIfNoChange] foregroundActivity changed ` +
+          `(${preTapState.foregroundActivity} -> ${postActivity}) — tap registered`
+        );
+        return;
+      }
+
+      const postPackage = postTapHierarchy.packageName;
+      if (
+        preTapState.packageName &&
+        postPackage &&
+        postPackage !== preTapState.packageName
+      ) {
+        logger.info(
+          `[TapOnElement][retryIfNoChange] packageName changed ` +
+          `(${preTapState.packageName} -> ${postPackage}) — tap registered`
+        );
+        return;
+      }
+    }
+
     const postTapHash = this.hashViewHierarchy(postTapHierarchy);
 
-    if (postTapHash && postTapHash !== preTapHash) {
+    if (postTapHash && postTapHash !== preTapState.hash) {
       logger.info(
         `[TapOnElement][retryIfNoChange] Hierarchy changed after tap — tap registered`
       );

--- a/test/features/action/TapOnElement.retryIfNoChange.test.ts
+++ b/test/features/action/TapOnElement.retryIfNoChange.test.ts
@@ -34,6 +34,10 @@ function createTapOnElement(): { tap: TapOnElement; timer: FakeTimer } {
 }
 
 
+function preStateFor(tap: TapOnElement, hierarchy: ViewHierarchyResult): any {
+  return (tap as any).capturePreTapState(hierarchy);
+}
+
 describe("retryTapIfNoChange", () => {
   test("does not retry when hierarchy changed after tap", async () => {
     const { tap } = createTapOnElement();
@@ -45,10 +49,8 @@ describe("retryTapIfNoChange", () => {
     let tapCallCount = 0;
     (tap as any).executeAndroidTap = async () => { tapCallCount++; };
 
-    const preTapHash = (tap as any).hashViewHierarchy(preHierarchy);
-
     await (tap as any).retryTapIfNoChange(
-      preTapHash,
+      preStateFor(tap, preHierarchy),
       { x: 60, y: 45 },
       "tap",
       0,
@@ -70,10 +72,8 @@ describe("retryTapIfNoChange", () => {
     let tapCallCount = 0;
     (tap as any).executeAndroidTap = async () => { tapCallCount++; };
 
-    const preTapHash = (tap as any).hashViewHierarchy(hierarchy);
-
     await (tap as any).retryTapIfNoChange(
-      preTapHash,
+      preStateFor(tap, hierarchy),
       { x: 60, y: 45 },
       "tap",
       0,
@@ -95,10 +95,8 @@ describe("retryTapIfNoChange", () => {
     let tapCallCount = 0;
     (tap as any).executeAndroidTap = async () => { tapCallCount++; };
 
-    const preTapHash = (tap as any).hashViewHierarchy(preHierarchy);
-
     await (tap as any).retryTapIfNoChange(
-      preTapHash,
+      preStateFor(tap, preHierarchy),
       { x: 60, y: 45 },
       "tap",
       0,
@@ -125,10 +123,8 @@ describe("retryTapIfNoChange", () => {
       return origSleep(ms);
     };
 
-    const preTapHash = (tap as any).hashViewHierarchy(hierarchy);
-
     await (tap as any).retryTapIfNoChange(
-      preTapHash,
+      preStateFor(tap, hierarchy),
       { x: 60, y: 45 },
       "tap",
       0,
@@ -139,6 +135,178 @@ describe("retryTapIfNoChange", () => {
     );
 
     expect(sleepDurations).toEqual([150, 100]);
+  });
+
+  test("does not retry when foregroundActivity changed even if hash matches", async () => {
+    const { tap } = createTapOnElement();
+    const preHierarchy = {
+      hierarchy: { node: { marker: "shared" } },
+      foregroundActivity: "com.app/.SourceActivity",
+      packageName: "com.app",
+      updatedAt: 1000,
+    } as unknown as ViewHierarchyResult;
+    const postHierarchy = {
+      hierarchy: { node: { marker: "shared" } },
+      foregroundActivity: "com.app/.DestActivity",
+      packageName: "com.app",
+      updatedAt: 2000,
+    } as unknown as ViewHierarchyResult;
+
+    (tap as any).refreshViewHierarchy = async () => postHierarchy;
+
+    let tapCallCount = 0;
+    (tap as any).executeAndroidTap = async () => { tapCallCount++; };
+
+    await (tap as any).retryTapIfNoChange(
+      preStateFor(tap, preHierarchy),
+      { x: 60, y: 45 },
+      "tap",
+      0,
+      makeElement(),
+      {},
+      false,
+      { width: 1080, height: 1920 },
+    );
+
+    expect(tapCallCount).toBe(0);
+  });
+
+  test("does not retry when packageName changed even if hash matches", async () => {
+    const { tap } = createTapOnElement();
+    const preHierarchy = {
+      hierarchy: { node: { marker: "shared" } },
+      packageName: "com.app.source",
+      updatedAt: 1000,
+    } as unknown as ViewHierarchyResult;
+    const postHierarchy = {
+      hierarchy: { node: { marker: "shared" } },
+      packageName: "com.app.dest",
+      updatedAt: 2000,
+    } as unknown as ViewHierarchyResult;
+
+    (tap as any).refreshViewHierarchy = async () => postHierarchy;
+
+    let tapCallCount = 0;
+    (tap as any).executeAndroidTap = async () => { tapCallCount++; };
+
+    await (tap as any).retryTapIfNoChange(
+      preStateFor(tap, preHierarchy),
+      { x: 60, y: 45 },
+      "tap",
+      0,
+      makeElement(),
+      {},
+      false,
+      { width: 1080, height: 1920 },
+    );
+
+    expect(tapCallCount).toBe(0);
+  });
+
+  test("refetches once when post-tap snapshot is stale, then honors transition signal", async () => {
+    const { tap } = createTapOnElement();
+    const preHierarchy = {
+      hierarchy: { node: { marker: "shared" } },
+      foregroundActivity: "com.app/.SourceActivity",
+      updatedAt: 1000,
+    } as unknown as ViewHierarchyResult;
+    // First push: stale (updatedAt <= pre). Second push: fresh, transition seen.
+    const stale = {
+      hierarchy: { node: { marker: "shared" } },
+      foregroundActivity: "com.app/.SourceActivity",
+      updatedAt: 1000,
+    } as unknown as ViewHierarchyResult;
+    const fresh = {
+      hierarchy: { node: { marker: "shared" } },
+      foregroundActivity: "com.app/.DestActivity",
+      updatedAt: 2500,
+    } as unknown as ViewHierarchyResult;
+
+    const calls: ViewHierarchyResult[] = [stale, fresh];
+    let refreshCallCount = 0;
+    (tap as any).refreshViewHierarchy = async () => {
+      refreshCallCount++;
+      return calls.shift() ?? fresh;
+    };
+
+    let tapCallCount = 0;
+    (tap as any).executeAndroidTap = async () => { tapCallCount++; };
+
+    await (tap as any).retryTapIfNoChange(
+      preStateFor(tap, preHierarchy),
+      { x: 60, y: 45 },
+      "tap",
+      0,
+      makeElement(),
+      {},
+      false,
+      { width: 1080, height: 1920 },
+    );
+
+    expect(refreshCallCount).toBe(2);
+    expect(tapCallCount).toBe(0);
+  });
+
+  test("retries when fresh refetch still shows no transition and matching hash", async () => {
+    const { tap } = createTapOnElement();
+    const preHierarchy = {
+      hierarchy: { node: { marker: "shared" } },
+      foregroundActivity: "com.app/.SourceActivity",
+      updatedAt: 1000,
+    } as unknown as ViewHierarchyResult;
+    const stale = {
+      hierarchy: { node: { marker: "shared" } },
+      foregroundActivity: "com.app/.SourceActivity",
+      updatedAt: 1000,
+    } as unknown as ViewHierarchyResult;
+    const freshUnchanged = {
+      hierarchy: { node: { marker: "shared" } },
+      foregroundActivity: "com.app/.SourceActivity",
+      updatedAt: 2500,
+    } as unknown as ViewHierarchyResult;
+
+    const calls: ViewHierarchyResult[] = [stale, freshUnchanged];
+    (tap as any).refreshViewHierarchy = async () => calls.shift() ?? freshUnchanged;
+
+    let tapCallCount = 0;
+    (tap as any).executeAndroidTap = async () => { tapCallCount++; };
+
+    await (tap as any).retryTapIfNoChange(
+      preStateFor(tap, preHierarchy),
+      { x: 60, y: 45 },
+      "tap",
+      0,
+      makeElement(),
+      {},
+      false,
+      { width: 1080, height: 1920 },
+    );
+
+    expect(tapCallCount).toBe(1);
+  });
+
+  test("falls back to hash-only behavior when transition signals absent", async () => {
+    // iOS / older accessibility runners may not populate foregroundActivity.
+    const { tap } = createTapOnElement();
+    const hierarchy = makeHierarchy("same-state");
+
+    (tap as any).refreshViewHierarchy = async () => hierarchy;
+
+    let tapCallCount = 0;
+    (tap as any).executeAndroidTap = async () => { tapCallCount++; };
+
+    await (tap as any).retryTapIfNoChange(
+      preStateFor(tap, hierarchy),
+      { x: 60, y: 45 },
+      "tap",
+      0,
+      makeElement(),
+      {},
+      false,
+      { width: 1080, height: 1920 },
+    );
+
+    expect(tapCallCount).toBe(1);
   });
 });
 
@@ -158,10 +326,8 @@ describe("retryTapIfNoChange passes isTalkBackEnabled to executeAndroidTap", () 
         capturedIsTalkBackEnabled = isTalkBack;
       };
 
-      const preTapHash = (tap as any).hashViewHierarchy(hierarchy);
-
       await (tap as any).retryTapIfNoChange(
-        preTapHash,
+        preStateFor(tap, hierarchy),
         { x: 60, y: 45 },
         "tap",
         0,


### PR DESCRIPTION
## Summary
- `retryIfNoChange` only compared a content hash of the pre/post-tap `ViewHierarchyResult`, which races against CtrlProxy's debouncer + broadcast throttler. During an activity transition, the next pushed hierarchy can still reflect the pre-transition tree, so hashes match and a destructive retry fires on the destination screen.
- Capture `foregroundActivity`, `packageName`, and `updatedAt` alongside the hash. Before retrying: if either identifier changed → the tap registered, exit. If the post-tap snapshot is not newer than the pre-tap one → refetch once to clear the throttler/debouncer window before deciding.
- Falls back to hash-only behavior when these signals are absent (iOS, older accessibility runners) — no regression on platforms that don't populate them.

Fixes #2283.

## Test plan
- [x] `bun test test/features/action/TapOnElement.retryIfNoChange.test.ts` — 13 pass (4 existing + 5 new branches covered).
- [x] `bun test test/features/action/` — 598 pass.
- [x] `turbo run lint build` — clean.
- New tests cover: activity transition with matching hash, package transition with matching hash, stale-snapshot refetch path, retry when fresh refetch still shows no transition, fallback when signals absent.