### PR TITLE
fix(release): unify CtrlProxy URL+checksum and split doctor version check

### DIFF
--- a/src/constants/release.ts
+++ b/src/constants/release.ts
@@ -107,23 +107,37 @@ export function resolveLatestVersion(): string {
   return RELEASE_CHECKSUM_REGISTRY[0].version;
 }
 
-// --- Backward-compatible exports derived from registry[0] ---
+// --- Backward-compatible exports derived from RELEASE_VERSION ---
 
 export const RELEASE_VERSION: string = LATEST_RELEASE_VERSION;
 
-function buildReleaseAssetUrl(filename: string): string {
-  const version = resolveLatestVersion();
+/**
+ * Resolve a version string to its concrete equivalent. Module-level constants
+ * (URLs, on-disk metadata, doctor checks) want a concrete version like
+ * "0.0.30", never the placeholder "latest".
+ */
+export function resolveAssetVersion(version: string): string {
   if (version === LATEST_RELEASE_VERSION) {
-    return `https://github.com/kaeawc/auto-mobile/releases/latest/download/${filename}`;
+    return resolveLatestVersion();
   }
-  return `https://github.com/kaeawc/auto-mobile/releases/download/${version}/${filename}`;
+  return version;
 }
 
-export const APK_URL: string = buildReleaseAssetUrl("control-proxy-debug.apk");
-export const APK_SHA256_CHECKSUM: string = resolveChecksum(LATEST_RELEASE_VERSION, "android");
+function buildReleaseAssetUrl(filename: string, version: string): string {
+  const assetVersion = resolveAssetVersion(version);
+  if (assetVersion === LATEST_RELEASE_VERSION) {
+    // Degenerate case: empty registry. Fall back to GitHub's redirecting
+    // /latest/download/ endpoint.
+    return `https://github.com/kaeawc/auto-mobile/releases/latest/download/${filename}`;
+  }
+  return `https://github.com/kaeawc/auto-mobile/releases/download/${assetVersion}/${filename}`;
+}
 
-export const IOS_CTRL_PROXY_RELEASE_VERSION: string = LATEST_RELEASE_VERSION;
-export const IOS_CTRL_PROXY_IPA_URL: string = buildReleaseAssetUrl("control-proxy.ipa");
-export const IOS_CTRL_PROXY_SHA256_CHECKSUM: string = resolveChecksum(LATEST_RELEASE_VERSION, "ios");
+export const APK_URL: string = buildReleaseAssetUrl("control-proxy-debug.apk", RELEASE_VERSION);
+export const APK_SHA256_CHECKSUM: string = resolveChecksum(RELEASE_VERSION, "android");
+
+export const IOS_CTRL_PROXY_RELEASE_VERSION: string = RELEASE_VERSION;
+export const IOS_CTRL_PROXY_IPA_URL: string = buildReleaseAssetUrl("control-proxy.ipa", IOS_CTRL_PROXY_RELEASE_VERSION);
+export const IOS_CTRL_PROXY_SHA256_CHECKSUM: string = resolveChecksum(IOS_CTRL_PROXY_RELEASE_VERSION, "ios");
 export const IOS_CTRL_PROXY_APP_HASH: string = ""; // Hash of CtrlProxyApp.app (device build), empty = skip verification
 export const IOS_CTRL_PROXY_RUNNER_SHA256: string = ""; // SHA256 of runner binary (CtrlProxyUITests-Runner), empty = skip verification

--- a/src/doctor/checks/automobile.ts
+++ b/src/doctor/checks/automobile.ts
@@ -6,7 +6,8 @@
 import { CheckResult } from "../types";
 import { DaemonManager } from "../../daemon/manager";
 import { getDaemonHealthReport } from "../../daemon/debugTools";
-import { RELEASE_VERSION } from "../../constants/release";
+import { LATEST_RELEASE_VERSION, RELEASE_VERSION, resolveAssetVersion } from "../../constants/release";
+import { getMcpServerVersion } from "../../utils/mcpVersion";
 import { defaultAdbClientFactory } from "../../utils/android-cmdline-tools/AdbClientFactory";
 import type { AdbClientFactory } from "../../utils/android-cmdline-tools/AdbClientFactory";
 import { AndroidCtrlProxyManager } from "../../utils/CtrlProxyManager";
@@ -15,14 +16,30 @@ import { logger } from "../../utils/logger";
 const RELEASES_URL = "https://github.com/kaeawc/auto-mobile/releases";
 
 /**
- * Check AutoMobile version
+ * Report the daemon JS package version, sourced from package.json.
  */
-export function checkVersion(): CheckResult {
+export function checkDaemonVersion(): CheckResult {
+  const version = getMcpServerVersion();
   return {
-    name: "AutoMobile Version",
+    name: "AutoMobile Daemon Version",
     status: "pass",
-    message: `Version ${RELEASE_VERSION}`,
-    value: RELEASE_VERSION,
+    message: `Version ${version}`,
+    value: version,
+  };
+}
+
+/**
+ * Report the on-device CtrlProxy release version. Distinct from the daemon
+ * version: the daemon ships its own JS via npm, but the on-device APK/IPA
+ * comes from the release registry.
+ */
+export function checkCtrlProxyVersion(): CheckResult {
+  const resolved = resolveAssetVersion(RELEASE_VERSION);
+  return {
+    name: "CtrlProxy Release Version",
+    status: "pass",
+    message: `Version ${resolved}${RELEASE_VERSION === LATEST_RELEASE_VERSION ? " (latest)" : ""}`,
+    value: resolved,
   };
 }
 
@@ -304,7 +321,8 @@ export async function checkWorkProfileAccessibility(
 export async function runAutoMobileChecks(): Promise<CheckResult[]> {
   const results: CheckResult[] = [];
 
-  results.push(checkVersion());
+  results.push(checkDaemonVersion());
+  results.push(checkCtrlProxyVersion());
   results.push(await checkDaemonStatus());
   results.push(await checkDaemonConnectivity());
   results.push(await checkCtrlProxy());

--- a/src/utils/IOSCtrlProxyBuilder.ts
+++ b/src/utils/IOSCtrlProxyBuilder.ts
@@ -11,7 +11,7 @@ import {
   IOS_CTRL_PROXY_RUNNER_SHA256,
   IOS_CTRL_PROXY_SHA256_CHECKSUM,
   LATEST_RELEASE_VERSION,
-  resolveLatestVersion
+  resolveAssetVersion
 } from "../constants/release";
 import {
   DefaultIOSCtrlProxyBundleDownloader,
@@ -691,7 +691,7 @@ export class IOSCtrlProxyBuilder {
     const appHashes = await this.computeAppHashes();
     const metadata: IOSCtrlProxyBundleMetadata = {
       checksum: this.getExpectedChecksum() || null,
-      version: resolveLatestVersion(),
+      version: resolveAssetVersion(IOS_CTRL_PROXY_RELEASE_VERSION),
       extractedAt: new Date().toISOString(),
       appHashes
     };

--- a/test/constants/release.test.ts
+++ b/test/constants/release.test.ts
@@ -1,8 +1,13 @@
 import { describe, expect, test } from "bun:test";
 import {
+  APK_SHA256_CHECKSUM,
+  APK_URL,
+  IOS_CTRL_PROXY_IPA_URL,
+  IOS_CTRL_PROXY_SHA256_CHECKSUM,
+  RELEASE_CHECKSUM_REGISTRY,
+  resolveAssetVersion,
   resolveChecksum,
   resolveLatestVersion,
-  RELEASE_CHECKSUM_REGISTRY,
   type ReleaseChecksumEntry,
 } from "../../src/constants/release";
 
@@ -65,5 +70,32 @@ describe("resolveChecksum", function() {
 describe("resolveLatestVersion", function() {
   test("returns first registry entry version", function() {
     expect(resolveLatestVersion()).toBe(RELEASE_CHECKSUM_REGISTRY[0].version);
+  });
+});
+
+describe("resolveAssetVersion", function() {
+  test("passes through concrete versions unchanged", function() {
+    expect(resolveAssetVersion("0.0.18")).toBe("0.0.18");
+  });
+
+  test("resolves the 'latest' placeholder to the newest registry entry", function() {
+    expect(resolveAssetVersion("latest")).toBe(RELEASE_CHECKSUM_REGISTRY[0].version);
+  });
+});
+
+describe("module-level URL and checksum exports", function() {
+  // Guards against the pre-existing drift between APK_URL (was keyed off
+  // resolveLatestVersion()) and APK_SHA256_CHECKSUM (was keyed off the
+  // "latest" literal). Both must resolve via the same RELEASE_VERSION path.
+  const newest = RELEASE_CHECKSUM_REGISTRY[0];
+
+  test("APK_URL and IPA_URL reference the newest registered version", function() {
+    expect(APK_URL).toContain(`/releases/download/${newest.version}/control-proxy-debug.apk`);
+    expect(IOS_CTRL_PROXY_IPA_URL).toContain(`/releases/download/${newest.version}/control-proxy.ipa`);
+  });
+
+  test("APK and IPA checksums match the newest registered entry", function() {
+    expect(APK_SHA256_CHECKSUM).toBe(newest.apkSha256);
+    expect(IOS_CTRL_PROXY_SHA256_CHECKSUM).toBe(newest.ipaSha256);
   });
 });

--- a/test/doctor/automobile.test.ts
+++ b/test/doctor/automobile.test.ts
@@ -1,27 +1,46 @@
 import { describe, test, expect, beforeEach } from "bun:test";
-import { checkVersion, checkCtrlProxy } from "../../src/doctor/checks/automobile";
-import { RELEASE_VERSION } from "../../src/constants/release";
+import {
+  checkCtrlProxy,
+  checkCtrlProxyVersion,
+  checkDaemonVersion,
+} from "../../src/doctor/checks/automobile";
+import {
+  LATEST_RELEASE_VERSION,
+  RELEASE_VERSION,
+  resolveAssetVersion,
+} from "../../src/constants/release";
+import { getMcpServerVersion } from "../../src/utils/mcpVersion";
 import { FakeAdbExecutor } from "../fakes/FakeAdbExecutor";
 import type { AdbClientFactory } from "../../src/utils/android-cmdline-tools/AdbClientFactory";
 
-describe("checkVersion", () => {
+describe("checkDaemonVersion", () => {
   test("returns pass status", () => {
-    const result = checkVersion();
-
-    expect(result.status).toBe("pass");
+    expect(checkDaemonVersion().status).toBe("pass");
   });
 
-  test("includes version in message", () => {
-    const result = checkVersion();
+  test("reports the daemon JS package version, not the CtrlProxy version", () => {
+    const result = checkDaemonVersion();
 
-    expect(result.message).toBe(`Version ${RELEASE_VERSION}`);
-    expect(result.value).toBe(RELEASE_VERSION);
+    expect(result.name).toBe("AutoMobile Daemon Version");
+    expect(result.value).toBe(getMcpServerVersion());
+    expect(result.message).toBe(`Version ${getMcpServerVersion()}`);
+  });
+});
+
+describe("checkCtrlProxyVersion", () => {
+  test("returns pass status", () => {
+    expect(checkCtrlProxyVersion().status).toBe("pass");
   });
 
-  test("has correct name", () => {
-    const result = checkVersion();
+  test("reports the concrete on-device CtrlProxy version from the registry", () => {
+    const result = checkCtrlProxyVersion();
+    const expected = resolveAssetVersion(RELEASE_VERSION);
 
-    expect(result.name).toBe("AutoMobile Version");
+    expect(result.name).toBe("CtrlProxy Release Version");
+    expect(result.value).toBe(expected);
+    if (RELEASE_VERSION === LATEST_RELEASE_VERSION) {
+      expect(result.message).toMatch(/\(latest\)$/);
+    }
   });
 });
 


### PR DESCRIPTION
Refs #2293. Extracts the two non-controversial parts of #2294: the URL/checksum drift fix and the doctor version split. Intentionally **does not** add `AUTOMOBILE_CTRL_PROXY_VERSION` — see discussion below.

## Summary

- **Drift fix.** Previously `APK_URL` was derived from `resolveLatestVersion()` while `APK_SHA256_CHECKSUM` was keyed off the literal `"latest"` string. They happen to agree today, but the two paths could diverge silently on any future refactor. Same issue on iOS, plus the bundle metadata always recorded `resolveLatestVersion()` regardless of which release the bundle actually came from. Both URL and checksum now resolve through a single `RELEASE_VERSION` via a new `resolveAssetVersion()` helper.
- **Doctor split.** `checkVersion` conflated two unrelated values — the daemon JS package version (from `package.json`) and the on-device CtrlProxy release version (from the registry). Split into `checkDaemonVersion` and `checkCtrlProxyVersion` so a mismatch is diagnosable from a single `--cli doctor` run.

## What's *not* in this PR

No `AUTOMOBILE_CTRL_PROXY_VERSION` env var. The right way to address \"a bad CtrlProxy release breaks every consumer\" is to bake a concrete `RELEASE_VERSION` into each published daemon (via `scripts/generate-release-constants.sh`) so that pinning the daemon transitively pins CtrlProxy — one knob, not two. An env-var override creates a daemon × CtrlProxy compatibility matrix we'd be on the hook for indefinitely.

## Test plan

- [x] `bun test test/constants/release.test.ts test/doctor/automobile.test.ts` — 19/19 pass
- [x] `bunx turbo run lint build` — clean
- [ ] `--cli doctor` on a real device shows both version lines