### PR TITLE
Add wall-clock abstraction

### DIFF
--- a/src/db/predictionHistoryRepository.ts
+++ b/src/db/predictionHistoryRepository.ts
@@ -8,6 +8,7 @@ import type {
 } from "./types";
 import { logger } from "../utils/logger";
 import { normalizeToolArgs } from "../utils/predictionUtils";
+import { type Clock, systemClock } from "../utils/Clock";
 
 export type PredictionErrorType = "wrong_screen" | "missing_elements" | "unexpected_elements";
 
@@ -39,9 +40,11 @@ export interface TransitionKey {
 
 export class PredictionHistoryRepository {
   private db: Kysely<Database> | null;
+  private clock: Clock;
 
-  constructor(db?: Kysely<Database>) {
+  constructor(db?: Kysely<Database>, clock: Clock = systemClock) {
     this.db = db ?? null;
+    this.clock = clock;
   }
 
   private getDb(): Kysely<Database> {
@@ -53,7 +56,7 @@ export class PredictionHistoryRepository {
 
   async recordOutcome(outcome: PredictionOutcomeRecord): Promise<void> {
     const db = this.getDb();
-    const now = new Date().toISOString();
+    const now = this.clock.nowIso();
     const toolArgs = normalizeToolArgs(outcome.toolArgs ?? undefined);
 
     const record: NewPredictionOutcome = {
@@ -99,7 +102,7 @@ export class PredictionHistoryRepository {
     correct: boolean
   ): Promise<PredictionTransitionStats> {
     const db = this.getDb();
-    const now = new Date().toISOString();
+    const now = this.clock.nowIso();
     const toolArgs = normalizeToolArgs(transition.toolArgs ?? undefined);
     const brier = Math.pow(confidence - (correct ? 1 : 0), 2);
 

--- a/src/utils/Clock.ts
+++ b/src/utils/Clock.ts
@@ -1,0 +1,59 @@
+export interface Clock {
+  now(): Date;
+  nowMs(): number;
+  nowIso(): string;
+}
+
+export class SystemClock implements Clock {
+  now(): Date {
+    return new Date();
+  }
+
+  nowMs(): number {
+    return Date.now();
+  }
+
+  nowIso(): string {
+    return new Date().toISOString();
+  }
+}
+
+export const systemClock: Clock = new SystemClock();
+
+export class FakeClock implements Clock {
+  private current: Date;
+
+  constructor(initial: Date | string | number = 0) {
+    this.current = normalizeDate(initial);
+  }
+
+  now(): Date {
+    return new Date(this.current.getTime());
+  }
+
+  nowMs(): number {
+    return this.current.getTime();
+  }
+
+  nowIso(): string {
+    return this.current.toISOString();
+  }
+
+  setNow(value: Date | string | number): void {
+    this.current = normalizeDate(value);
+  }
+
+  advance(ms: number): void {
+    if (!Number.isFinite(ms)) {
+      throw new Error(`FakeClock.advance expected a finite millisecond value, got ${ms}`);
+    }
+    this.current = new Date(this.current.getTime() + ms);
+  }
+}
+
+const normalizeDate = (value: Date | string | number): Date => {
+  if (value instanceof Date) {
+    return new Date(value.getTime());
+  }
+  return new Date(value);
+};

--- a/test/contracts/ClockContract.ts
+++ b/test/contracts/ClockContract.ts
@@ -1,0 +1,34 @@
+import { describe, expect, test } from "bun:test";
+import type { Clock } from "../../src/utils/Clock";
+
+export const runClockContract = (
+  description: string,
+  makeClock: () => Clock
+): void => {
+  describe(`Clock contract: ${description}`, function() {
+    test("now returns a Date", function() {
+      expect(makeClock().now()).toBeInstanceOf(Date);
+    });
+
+    test("nowMs returns finite integer milliseconds", function() {
+      const nowMs = makeClock().nowMs();
+
+      expect(Number.isFinite(nowMs)).toBe(true);
+      expect(Number.isInteger(nowMs)).toBe(true);
+    });
+
+    test("nowIso returns an ISO-8601 timestamp", function() {
+      expect(makeClock().nowIso()).toMatch(/\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z/);
+    });
+
+    test("now, nowMs, and nowIso describe the same instant", function() {
+      const clock = makeClock();
+      const now = clock.now();
+      const nowMs = clock.nowMs();
+      const nowIso = clock.nowIso();
+
+      expect(Math.abs(now.getTime() - nowMs)).toBeLessThan(100);
+      expect(Math.abs(new Date(nowIso).getTime() - nowMs)).toBeLessThan(100);
+    });
+  });
+};

--- a/test/contracts/runAll.test.ts
+++ b/test/contracts/runAll.test.ts
@@ -2,6 +2,7 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { DefaultChecksumCalculator } from "../../src/utils/ChecksumCalculator";
+import { FakeClock, SystemClock } from "../../src/utils/Clock";
 import { DefaultFileDownloader } from "../../src/utils/FileDownloader";
 import { DefaultHostCommandExecutor } from "../../src/utils/HostCommandExecutor";
 import { DefaultProcessExecutor } from "../../src/utils/ProcessExecutor";
@@ -14,6 +15,7 @@ import { FakeHostCommandExecutor } from "../fakes/FakeHostCommandExecutor";
 import { FakeProcessExecutor } from "../fakes/FakeProcessExecutor";
 import { FakeTimer } from "../fakes/FakeTimer";
 import { runChecksumCalculatorContract } from "./ChecksumCalculatorContract";
+import { runClockContract } from "./ClockContract";
 import {
   runHostCommandExecutorContract,
   runProcessExecutorContract
@@ -23,6 +25,9 @@ import { runFileSystemContract } from "./FileSystemContract";
 import { runTimerContract } from "./TimerContract";
 
 const quote = (value: string): string => JSON.stringify(value);
+
+runClockContract("SystemClock", () => new SystemClock());
+runClockContract("FakeClock", () => new FakeClock("2026-01-01T00:00:00.000Z"));
 
 runTimerContract("SystemTimer", () => new SystemTimer(), { realTime: true });
 runTimerContract("FakeTimer auto-advance", () => {

--- a/test/db/predictionHistoryRepository.test.ts
+++ b/test/db/predictionHistoryRepository.test.ts
@@ -4,14 +4,17 @@ import type { Database } from "../../src/db/types";
 import { PredictionHistoryRepository } from "../../src/db/predictionHistoryRepository";
 import type { PredictionOutcomeRecord, TransitionKey } from "../../src/db/predictionHistoryRepository";
 import { createTestDatabase } from "./testDbHelper";
+import { FakeClock } from "../../src/utils/Clock";
 
 describe("PredictionHistoryRepository", () => {
   let db: Kysely<Database>;
   let repo: PredictionHistoryRepository;
+  let clock: FakeClock;
 
   beforeEach(async () => {
     db = await createTestDatabase();
-    repo = new PredictionHistoryRepository(db);
+    clock = new FakeClock("2026-01-02T03:04:05.000Z");
+    repo = new PredictionHistoryRepository(db, clock);
   });
 
   afterEach(async () => {
@@ -45,11 +48,14 @@ describe("PredictionHistoryRepository", () => {
       expect(outcomes).toHaveLength(1);
       expect(outcomes[0].app_id).toBe("com.example.app");
       expect(outcomes[0].correct).toBe(1);
+      expect(outcomes[0].created_at).toBe("2026-01-02T03:04:05.000Z");
 
       const stats = await db.selectFrom("prediction_transition_stats").selectAll().execute();
       expect(stats).toHaveLength(1);
       expect(stats[0].attempts).toBe(1);
       expect(stats[0].successes).toBe(1);
+      expect(stats[0].created_at).toBe("2026-01-02T03:04:05.000Z");
+      expect(stats[0].updated_at).toBe("2026-01-02T03:04:05.000Z");
     });
 
     test("records incorrect prediction", async () => {
@@ -89,11 +95,13 @@ describe("PredictionHistoryRepository", () => {
       };
 
       await repo.upsertTransitionStats(key, 0.9, true);
+      clock.setNow("2026-01-03T03:04:05.000Z");
       const result = await repo.upsertTransitionStats(key, 0.7, false);
 
       expect(result.attempts).toBe(2);
       expect(result.successes).toBe(1);
       expect(result.total_confidence).toBeCloseTo(1.6, 5);
+      expect(result.updated_at).toBe("2026-01-03T03:04:05.000Z");
     });
 
     test("computes brier score sum", async () => {

--- a/test/utils/Clock.test.ts
+++ b/test/utils/Clock.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, test } from "bun:test";
+import { FakeClock, SystemClock } from "../../src/utils/Clock";
+
+describe("SystemClock", function() {
+  test("now returns time near Date.now", function() {
+    const clock = new SystemClock();
+    const before = Date.now();
+    const now = clock.now().getTime();
+    const after = Date.now();
+
+    expect(now).toBeGreaterThanOrEqual(before);
+    expect(now).toBeLessThanOrEqual(after);
+  });
+});
+
+describe("FakeClock", function() {
+  test("starts at the configured instant", function() {
+    const clock = new FakeClock("2026-01-01T00:00:00.000Z");
+
+    expect(clock.nowIso()).toBe("2026-01-01T00:00:00.000Z");
+  });
+
+  test("advance moves the clock by milliseconds", function() {
+    const clock = new FakeClock("2026-01-01T00:00:00.000Z");
+
+    clock.advance(1500);
+
+    expect(clock.nowIso()).toBe("2026-01-01T00:00:01.500Z");
+  });
+
+  test("setNow replaces the current instant", function() {
+    const clock = new FakeClock(0);
+
+    clock.setNow("2030-06-15T12:00:00.000Z");
+
+    expect(clock.nowIso()).toBe("2030-06-15T12:00:00.000Z");
+  });
+
+  test("now returns a defensive Date copy", function() {
+    const clock = new FakeClock("2026-01-01T00:00:00.000Z");
+
+    const now = clock.now();
+    now.setFullYear(1999);
+
+    expect(clock.nowIso()).toBe("2026-01-01T00:00:00.000Z");
+  });
+
+  test("advance rejects non-finite values", function() {
+    const clock = new FakeClock();
+
+    expect(() => clock.advance(Number.NaN)).toThrow(/finite/);
+    expect(() => clock.advance(Number.POSITIVE_INFINITY)).toThrow(/finite/);
+  });
+});


### PR DESCRIPTION
Closed intentionally. AutoMobile already has `Timer`/`SystemTimer`/`FakeTimer`, and `Timer.now()` is the existing injectable time source. We will continue with the utility adoption stack without introducing a separate `Clock` abstraction.