### PR TITLE
Add reusable backoff policies

### DIFF
--- a/src/features/action/BaseVisualChange.ts
+++ b/src/features/action/BaseVisualChange.ts
@@ -14,6 +14,7 @@ import { throwIfAborted } from "../../utils/toolUtils";
 import { NavigationGraphManager } from "../navigation/NavigationGraphManager";
 import { PredictionAnalyzer, PredictionActionContext } from "../observe/PredictionAnalyzer";
 import { Timer, defaultTimer } from "../../utils/SystemTimer";
+import { sequenceBackoff } from "../../utils/Backoff";
 
 export interface ProgressCallback {
   (progress: number, total?: number, message?: string): Promise<void>;
@@ -234,7 +235,8 @@ export class BaseVisualChange {
     // Use actionStartTime as minTimestamp to ensure we get data captured after the action
     // This prevents returning stale cached data from before the action was executed
     const minTimestamp = options.actionStartTime ?? 0;
-    const retryDelaysMs = [50, 100, 200, 400];
+    const retryBackoff = sequenceBackoff([50, 100, 200, 400]);
+    const maxRetryAttempts = 4;
     const previousHash = this.hashViewHierarchy(previousObserveResult?.viewHierarchy);
 
     perf.serial("finalObserve");
@@ -261,9 +263,9 @@ export class BaseVisualChange {
       return !!previousHash && !!currentHash && previousHash === currentHash;
     };
 
-    for (let attempt = 0; attempt < retryDelaysMs.length && shouldRetry(latestObservation); attempt++) {
-      const delayMs = retryDelaysMs[attempt];
-      logger.info(`[BaseVisualChange] Observation appears stale/unchanged, retrying in ${delayMs}ms (attempt ${attempt + 1}/${retryDelaysMs.length})`);
+    for (let attempt = 0; attempt < maxRetryAttempts && shouldRetry(latestObservation); attempt++) {
+      const delayMs = retryBackoff.delayForAttempt(attempt + 1);
+      logger.info(`[BaseVisualChange] Observation appears stale/unchanged, retrying in ${delayMs}ms (attempt ${attempt + 1}/${maxRetryAttempts})`);
       await this.timer.sleep(delayMs);
       perf.serial(`finalObserve_retry_${attempt + 1}`);
       latestObservation = await this.observeScreen.execute({ queryOptions: options.queryOptions, perf, skipWaitForFresh: false, minTimestamp, signal: options.signal });

--- a/src/features/action/swipeon/ScrollUntilVisible.ts
+++ b/src/features/action/swipeon/ScrollUntilVisible.ts
@@ -21,6 +21,7 @@ import { Timer } from "../../../utils/SystemTimer";
 import { SwipeOnResolvedOptions, BoomerangConfig, TalkBackSwipeRunner, OverlayAnalyzer, ScrollAccessibilityService } from "./types";
 import { resolveContainerSwipeCoordinates } from "./resolveContainerSwipeCoordinates";
 import { getScreenBounds } from "../../../utils/screenBounds";
+import { exponentialBackoff } from "../../../utils/Backoff";
 
 function oppositeDirection(dir: SwipeDirection): SwipeDirection {
   switch (dir) {
@@ -388,7 +389,10 @@ export class ScrollUntilVisible {
 
     // Retry logic similar to TapOnElement
     if (!element && attempt < ScrollUntilVisible.MAX_ATTEMPTS) {
-      const delayNextAttempt = Math.min(10 * Math.pow(2, attempt), 1000);
+      const delayNextAttempt = exponentialBackoff({
+        initialDelayMs: 10,
+        maxDelayMs: 1000
+      }).delayForAttempt(attempt + 1);
       await this.deps.timer.sleep(delayNextAttempt);
 
       let latestViewHierarchy: ViewHierarchyResult | null = null;

--- a/src/features/video/VideoRecorderService.ts
+++ b/src/features/video/VideoRecorderService.ts
@@ -1,7 +1,6 @@
 import { promises as fsPromises, type Stats } from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { randomUUID } from "node:crypto";
 import type {
   VideoFormat,
   VideoRecordingConfig,
@@ -12,6 +11,7 @@ import type {
   VideoResolution,
 } from "../../models";
 import { logger, type Logger } from "../../utils/logger";
+import { defaultIdGenerator, type IdGenerator } from "../../utils/IdGenerator";
 
 export interface VideoCaptureConfig extends VideoRecordingConfig {
   recordingId: string;
@@ -65,7 +65,7 @@ export interface VideoRecorderServiceDependencies {
   backend: VideoCaptureBackend;
   archiveRoot?: string;
   logger?: Pick<Logger, "info" | "warn" | "error" | "debug">;
-  idGenerator?: () => string;
+  idGenerator?: IdGenerator | (() => string);
   now?: () => Date;
 }
 
@@ -131,7 +131,7 @@ export class VideoRecorderService {
   private backend: VideoCaptureBackend;
   private archiveRoot: string;
   private log: Pick<Logger, "info" | "warn" | "error" | "debug">;
-  private idGenerator: () => string;
+  private idGenerator: IdGenerator;
   private now: () => Date;
   private activeRecordings = new Map<string, ActiveRecordingState>();
 
@@ -141,7 +141,7 @@ export class VideoRecorderService {
       dependencies.archiveRoot ??
       path.join(os.homedir(), ".auto-mobile", "video-archive");
     this.log = dependencies.logger ?? logger;
-    this.idGenerator = dependencies.idGenerator ?? (() => randomUUID());
+    this.idGenerator = normalizeIdGenerator(dependencies.idGenerator);
     this.now = dependencies.now ?? (() => new Date());
   }
 
@@ -149,7 +149,7 @@ export class VideoRecorderService {
     options: StartVideoRecordingOptions = {}
   ): Promise<ActiveVideoRecording> {
     const config = parseVideoRecordingConfig(options.config);
-    const recordingId = this.idGenerator();
+    const recordingId = this.idGenerator.next();
     const startedAt = this.now().toISOString();
     const recordingDir = this.getRecordingDir(recordingId);
 
@@ -245,6 +245,16 @@ export class VideoRecorderService {
     }
   }
 }
+
+const normalizeIdGenerator = (idGenerator?: IdGenerator | (() => string)): IdGenerator => {
+  if (idGenerator === undefined) {
+    return defaultIdGenerator;
+  }
+  if (typeof idGenerator === "function") {
+    return { next: idGenerator };
+  }
+  return idGenerator;
+};
 
 function parseQualityPreset(
   value: VideoRecordingConfigInput["qualityPreset"]

--- a/src/server/deviceMatcher.ts
+++ b/src/server/deviceMatcher.ts
@@ -1,5 +1,6 @@
 import type { BootedDevice, DeviceInfo, Platform } from "../models";
 import type { DeviceMatchCriteria, FormFactor, MatchingStrategy } from "../models/DeviceMatchCriteria";
+import { defaultRandom, type Random } from "../utils/Random";
 
 /**
  * Interface for matching devices against criteria.
@@ -85,6 +86,7 @@ function matchesCriteria<T extends { platform: Platform; name: string; osVersion
 function applyStrategy<T extends { osVersion?: string }>(
   candidates: T[],
   strategy: MatchingStrategy,
+  random: Random,
 ): T | null {
   if (candidates.length === 0) {return null;}
   if (candidates.length === 1) {return candidates[0];}
@@ -99,7 +101,7 @@ function applyStrategy<T extends { osVersion?: string }>(
         compareVersions(a.osVersion ?? "0", b.osVersion ?? "0")
       )[0];
     case "RANDOM":
-      return candidates[Math.floor(Math.random() * candidates.length)];
+      return random.pick(candidates);
   }
 }
 
@@ -107,13 +109,15 @@ function applyStrategy<T extends { osVersion?: string }>(
  * Default device matcher implementation.
  */
 export class DefaultDeviceMatcher implements DeviceMatcher {
+  constructor(private readonly random: Random = defaultRandom) {}
+
   matchBootedDevice(
     criteria: DeviceMatchCriteria,
     devices: BootedDevice[],
     strategy: MatchingStrategy,
   ): BootedDevice | null {
     const filtered = devices.filter(d => matchesCriteria(d, criteria));
-    return applyStrategy(filtered, strategy);
+    return applyStrategy(filtered, strategy, this.random);
   }
 
   matchDeviceImage(
@@ -122,6 +126,6 @@ export class DefaultDeviceMatcher implements DeviceMatcher {
     strategy: MatchingStrategy,
   ): DeviceInfo | null {
     const filtered = images.filter(d => matchesCriteria(d, criteria));
-    return applyStrategy(filtered, strategy);
+    return applyStrategy(filtered, strategy, this.random);
   }
 }

--- a/src/utils/Backoff.ts
+++ b/src/utils/Backoff.ts
@@ -1,0 +1,120 @@
+import type { Random } from "./Random";
+
+export interface BackoffPolicy {
+  delayForAttempt(attempt: number): number;
+}
+
+export interface ExponentialBackoffOptions {
+  readonly initialDelayMs: number;
+  readonly multiplier?: number;
+  readonly maxDelayMs?: number;
+}
+
+export interface JitterOptions {
+  readonly factor?: number;
+  readonly random: Random;
+}
+
+export type BackoffInput =
+  | number
+  | readonly number[]
+  | BackoffPolicy
+  | ((attempt: number) => number);
+
+export const fixedBackoff = (delayMs: number): BackoffPolicy => {
+  const normalized = normalizeDelay(delayMs);
+  return {
+    delayForAttempt(attempt: number): number {
+      assertAttempt(attempt);
+      return normalized;
+    }
+  };
+};
+
+export const sequenceBackoff = (delaysMs: readonly number[]): BackoffPolicy => {
+  if (delaysMs.length === 0) {
+    throw new Error("sequenceBackoff requires at least one delay");
+  }
+
+  const normalized = delaysMs.map(normalizeDelay);
+  return {
+    delayForAttempt(attempt: number): number {
+      assertAttempt(attempt);
+      return normalized[Math.min(attempt - 1, normalized.length - 1)]!;
+    }
+  };
+};
+
+export const exponentialBackoff = (options: ExponentialBackoffOptions): BackoffPolicy => {
+  const initialDelayMs = normalizeDelay(options.initialDelayMs);
+  const multiplier = options.multiplier ?? 2;
+  const maxDelayMs = options.maxDelayMs === undefined
+    ? Number.POSITIVE_INFINITY
+    : normalizeDelay(options.maxDelayMs);
+
+  if (!Number.isFinite(multiplier) || multiplier < 1) {
+    throw new Error(`exponentialBackoff multiplier must be >= 1, got ${multiplier}`);
+  }
+
+  return {
+    delayForAttempt(attempt: number): number {
+      assertAttempt(attempt);
+      return normalizeDelay(Math.min(initialDelayMs * multiplier ** (attempt - 1), maxDelayMs));
+    }
+  };
+};
+
+export const withJitter = (policy: BackoffPolicy, options: JitterOptions): BackoffPolicy => {
+  const factor = options.factor ?? 0.2;
+  if (!Number.isFinite(factor) || factor < 0 || factor > 1) {
+    throw new Error(`withJitter factor must be between 0 and 1, got ${factor}`);
+  }
+
+  return {
+    delayForAttempt(attempt: number): number {
+      const delay = policy.delayForAttempt(attempt);
+      if (delay === 0 || factor === 0) {
+        return delay;
+      }
+
+      const spread = delay * factor;
+      const min = delay - spread;
+      const max = delay + spread;
+      return normalizeDelay(min + (max - min) * options.random.next());
+    }
+  };
+};
+
+export const normalizeBackoff = (input: BackoffInput): BackoffPolicy => {
+  if (typeof input === "number") {
+    return fixedBackoff(input);
+  }
+  if (Array.isArray(input)) {
+    return sequenceBackoff(input);
+  }
+  if (typeof input === "function") {
+    return {
+      delayForAttempt(attempt: number): number {
+        assertAttempt(attempt);
+        return normalizeDelay(input(attempt));
+      }
+    };
+  }
+  return input;
+};
+
+export const delayForAttempt = (input: BackoffInput, attempt: number): number =>
+  normalizeBackoff(input).delayForAttempt(attempt);
+
+const assertAttempt = (attempt: number): void => {
+  if (!Number.isInteger(attempt) || attempt < 1) {
+    throw new Error(`Backoff attempt must be a positive integer, got ${attempt}`);
+  }
+};
+
+const normalizeDelay = (delayMs: number): number => {
+  if (!Number.isFinite(delayMs)) {
+    throw new Error(`Backoff delay must be finite, got ${delayMs}`);
+  }
+  return Math.max(0, Math.floor(delayMs));
+};

--- a/src/utils/IOSCtrlProxyManager.ts
+++ b/src/utils/IOSCtrlProxyManager.ts
@@ -10,6 +10,7 @@ import { DefaultProcessExecutor, type ProcessExecutor } from "./ProcessExecutor"
 import { XcodeSigningManager } from "./ios-cmdline-tools/XcodeSigning";
 import { DeviceAppInspector } from "./ios-cmdline-tools/DeviceAppInspector";
 import { isRunningInDocker } from "./dockerEnv";
+import { exponentialBackoff } from "./Backoff";
 import {
   getHostControlHost,
   getCtrlProxyIOSStatus,
@@ -921,10 +922,10 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
     }
 
     this.restartAttempts++;
-    const delay = Math.min(
-      IOSCtrlProxyManager.RESTART_BASE_DELAY_MS * Math.pow(2, this.restartAttempts - 1),
-      IOSCtrlProxyManager.RESTART_MAX_DELAY_MS
-    );
+    const delay = exponentialBackoff({
+      initialDelayMs: IOSCtrlProxyManager.RESTART_BASE_DELAY_MS,
+      maxDelayMs: IOSCtrlProxyManager.RESTART_MAX_DELAY_MS
+    }).delayForAttempt(this.restartAttempts);
 
     logger.info(`[IOSCtrlProxy] Scheduling auto-restart in ${delay}ms (attempt ${this.restartAttempts}/${IOSCtrlProxyManager.MAX_RESTART_ATTEMPTS})`);
 
@@ -1396,10 +1397,10 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
     }
 
     this.iproxyRestartAttempts++;
-    const delay = Math.min(
-      IOSCtrlProxyManager.IPROXY_RESTART_BASE_DELAY_MS * Math.pow(2, this.iproxyRestartAttempts - 1),
-      IOSCtrlProxyManager.IPROXY_RESTART_MAX_DELAY_MS
-    );
+    const delay = exponentialBackoff({
+      initialDelayMs: IOSCtrlProxyManager.IPROXY_RESTART_BASE_DELAY_MS,
+      maxDelayMs: IOSCtrlProxyManager.IPROXY_RESTART_MAX_DELAY_MS
+    }).delayForAttempt(this.iproxyRestartAttempts);
 
     this.iproxyRestartTimeout = this.timer.setTimeout(() => {
       this.iproxyRestartTimeout = null;

--- a/src/utils/retry/RetryExecutor.ts
+++ b/src/utils/retry/RetryExecutor.ts
@@ -1,3 +1,4 @@
+import { type BackoffInput, delayForAttempt } from "../Backoff";
 import { Timer, defaultTimer } from "../SystemTimer";
 
 /**
@@ -14,10 +15,11 @@ interface RetryOptions {
    * Delay strategy between retries.
    * - number: Fixed delay in milliseconds
    * - number[]: Array of delays for each retry (exponential backoff pattern)
+   * - BackoffPolicy: Object with delayForAttempt(attempt)
    * - (attempt: number) => number: Function to compute delay based on attempt number
    * Default: 1000ms fixed delay
    */
-  delays?: number | number[] | ((attempt: number) => number);
+  delays?: BackoffInput;
 
   /**
    * Optional abort signal to cancel retry loop.
@@ -90,23 +92,6 @@ export const DEFAULT_RETRY_OPTIONS: Required<Omit<RetryOptions, "signal" | "shou
 };
 
 /**
- * Compute the delay for a given attempt.
- */
-function getDelay(delays: RetryOptions["delays"], attempt: number): number {
-  if (typeof delays === "number") {
-    return delays;
-  }
-  if (Array.isArray(delays)) {
-    // Use the last delay if attempt exceeds array length
-    return delays[Math.min(attempt - 1, delays.length - 1)] ?? 0;
-  }
-  if (typeof delays === "function") {
-    return delays(attempt);
-  }
-  return DEFAULT_RETRY_OPTIONS.delays as number;
-}
-
-/**
  * Default implementation of RetryExecutor.
  */
 export class DefaultRetryExecutor implements RetryExecutor {
@@ -159,7 +144,7 @@ export class DefaultRetryExecutor implements RetryExecutor {
             };
           }
 
-          const delay = getDelay(delays, attempt);
+          const delay = delayForAttempt(delays, attempt);
           onRetry?.(lastError, attempt, delay);
 
           if (delay > 0) {

--- a/test/features/video/VideoRecorderService.test.ts
+++ b/test/features/video/VideoRecorderService.test.ts
@@ -8,6 +8,7 @@ import {
   parseVideoRecordingConfig,
   DEFAULT_VIDEO_RECORDING_CONFIG,
 } from "../../../src/features/video/VideoRecorderService";
+import { CountingIdGenerator } from "../../../src/utils/IdGenerator";
 import { FakeVideoCaptureBackend } from "../../fakes/FakeVideoCaptureBackend";
 
 describe("parseVideoRecordingConfig", () => {
@@ -87,17 +88,15 @@ describe("VideoRecorderService", () => {
   let backend: FakeVideoCaptureBackend;
   let service: VideoRecorderService;
   let archiveRoot: string;
-  let idCounter: number;
 
   beforeEach(async () => {
     backend = new FakeVideoCaptureBackend();
     archiveRoot = path.join(os.tmpdir(), `video-test-${Date.now()}`);
-    idCounter = 0;
 
     service = new VideoRecorderService({
       backend,
       archiveRoot,
-      idGenerator: () => `rec-${++idCounter}`,
+      idGenerator: new CountingIdGenerator("rec"),
       now: () => new Date("2024-01-15T10:30:00.000Z"),
     });
   });

--- a/test/server/deviceMatcher.test.ts
+++ b/test/server/deviceMatcher.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "bun:test";
 import { DefaultDeviceMatcher, compareVersions } from "../../src/server/deviceMatcher";
 import type { BootedDevice, DeviceInfo } from "../../src/models";
+import { SeededRandom } from "../../src/utils/Random";
 
 const matcher = new DefaultDeviceMatcher();
 
@@ -216,6 +217,7 @@ describe("DefaultDeviceMatcher.matchBootedDevice", () => {
   });
 
   it("RANDOM strategy returns a valid candidate", () => {
+    const matcher = new DefaultDeviceMatcher(new SeededRandom(1));
     const devices = [
       bootedDevice({ deviceId: "1", osVersion: "14" }),
       bootedDevice({ deviceId: "2", osVersion: "15" }),
@@ -227,7 +229,7 @@ describe("DefaultDeviceMatcher.matchBootedDevice", () => {
       "RANDOM"
     );
     expect(result).not.toBeNull();
-    expect(["1", "2"]).toContain(result!.deviceId);
+    expect(result!.deviceId).toBe("2");
   });
 
   it("returns null for empty device list", () => {

--- a/test/utils/Backoff.test.ts
+++ b/test/utils/Backoff.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, test } from "bun:test";
+import {
+  delayForAttempt,
+  exponentialBackoff,
+  fixedBackoff,
+  sequenceBackoff,
+  withJitter
+} from "../../src/utils/Backoff";
+import { SeededRandom } from "../../src/utils/Random";
+
+describe("Backoff", function() {
+  test("fixedBackoff returns the same delay for every attempt", function() {
+    const policy = fixedBackoff(25);
+
+    expect(policy.delayForAttempt(1)).toBe(25);
+    expect(policy.delayForAttempt(4)).toBe(25);
+  });
+
+  test("sequenceBackoff clamps to the final configured delay", function() {
+    const policy = sequenceBackoff([10, 20]);
+
+    expect(policy.delayForAttempt(1)).toBe(10);
+    expect(policy.delayForAttempt(2)).toBe(20);
+    expect(policy.delayForAttempt(3)).toBe(20);
+  });
+
+  test("exponentialBackoff applies multiplier and cap", function() {
+    const policy = exponentialBackoff({
+      initialDelayMs: 50,
+      multiplier: 3,
+      maxDelayMs: 500
+    });
+
+    expect(policy.delayForAttempt(1)).toBe(50);
+    expect(policy.delayForAttempt(2)).toBe(150);
+    expect(policy.delayForAttempt(3)).toBe(450);
+    expect(policy.delayForAttempt(4)).toBe(500);
+  });
+
+  test("withJitter stays inside the configured spread", function() {
+    const policy = withJitter(fixedBackoff(100), {
+      factor: 0.1,
+      random: new SeededRandom(1)
+    });
+
+    const delay = policy.delayForAttempt(1);
+
+    expect(delay).toBeGreaterThanOrEqual(90);
+    expect(delay).toBeLessThanOrEqual(110);
+  });
+
+  test("delayForAttempt accepts callback policies", function() {
+    expect(delayForAttempt(attempt => attempt * 7, 3)).toBe(21);
+  });
+
+  test("invalid attempts and delays throw clear errors", function() {
+    expect(() => fixedBackoff(Number.POSITIVE_INFINITY)).toThrow(/finite/);
+    expect(() => fixedBackoff(1).delayForAttempt(0)).toThrow(/positive integer/);
+    expect(() => sequenceBackoff([])).toThrow(/at least one/);
+    expect(() => exponentialBackoff({ initialDelayMs: 1, multiplier: 0 })).toThrow(/multiplier/);
+  });
+});

--- a/test/utils/retry/RetryExecutor.test.ts
+++ b/test/utils/retry/RetryExecutor.test.ts
@@ -3,6 +3,7 @@ import {
   DefaultRetryExecutor,
   DEFAULT_RETRY_OPTIONS,
 } from "../../../src/utils/retry/RetryExecutor";
+import { exponentialBackoff } from "../../../src/utils/Backoff";
 import { FakeTimer } from "../../fakes/FakeTimer";
 
 describe("DefaultRetryExecutor", () => {
@@ -128,6 +129,30 @@ describe("DefaultRetryExecutor", () => {
       expect(result.success).toBe(true);
       expect(timer.wasSleepCalled(100)).toBe(true); // First retry: attempt 1 * 100
       expect(timer.wasSleepCalled(200)).toBe(true); // Second retry: attempt 2 * 100
+    });
+
+    it("respects BackoffPolicy delays", async () => {
+      timer.enableAutoAdvance();
+      let attempts = 0;
+
+      const result = await executor.execute(
+        async () => {
+          attempts++;
+          if (attempts < 4) {
+            throw new Error("Retry");
+          }
+          return "done";
+        },
+        {
+          delays: exponentialBackoff({ initialDelayMs: 50, multiplier: 2, maxDelayMs: 200 }),
+          maxAttempts: 4,
+        }
+      );
+
+      expect(result.success).toBe(true);
+      expect(timer.wasSleepCalled(50)).toBe(true);
+      expect(timer.wasSleepCalled(100)).toBe(true);
+      expect(timer.wasSleepCalled(200)).toBe(true);
     });
 
     it("aborts when signal is aborted", async () => {


### PR DESCRIPTION
## Summary
- add reusable BackoffPolicy helpers for fixed, sequence, exponential, and jittered delays
- preserve RetryExecutor compatibility with existing number/array/function delay inputs
- allow RetryExecutor to accept BackoffPolicy objects
- integrate shared backoff policies into BaseVisualChange, ScrollUntilVisible, and IOSCtrlProxyManager retry scheduling
- integrate stacked IdGenerator/Random utilities where this branch touched matching call sites: VideoRecorderService now accepts IdGenerator and DefaultDeviceMatcher accepts injectable Random
- add focused backoff, retry, and deterministic random-selection coverage

## Existing-utility check
- searched for existing generic backoff utilities before adding this
- found RetryExecutor's inline delay normalization and specialized schedulers such as ScreenshotBackoffScheduler, but no reusable BackoffPolicy helper
- before integration, searched for matching utility sites and reused the stacked IdGenerator/Random abstractions instead of adding local replacements

## Validation
- `PATH="/opt/homebrew/bin:$PATH" /opt/homebrew/bin/bun run lint`
- `/opt/homebrew/bin/bun test test/features/video/VideoRecorderService.test.ts test/server/deviceMatcher.test.ts test/utils/IOSCtrlProxyManager.test.ts test/features/action/BaseVisualChange.uiStability.test.ts test/features/action/swipeon/ScrollUntilVisible.overshoot.test.ts test/utils/Backoff.test.ts test/utils/retry/RetryExecutor.test.ts`
- `PATH="/opt/homebrew/bin:$PATH" /opt/homebrew/bin/bun run build`
- `git diff --check`

Stacked on #2300.