### PR TITLE
ci: skip no-op PR jobs at job level

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -550,23 +550,18 @@ jobs:
     name: "Installer Minimal (${{ matrix.os }})"
     runs-on: ${{ matrix.os }}
     needs: detect-changes
+    if: needs.detect-changes.outputs.docs_only != 'true'
     strategy:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
     steps:
-      - name: "Skip for docs-only changes"
-        if: needs.detect-changes.outputs.docs_only == 'true'
-        run: echo "Skipping - documentation only changes"
-
       - name: "Git Checkout"
-        if: needs.detect-changes.outputs.docs_only != 'true'
         uses: actions/checkout@v6
         with:
           lfs: false
 
       - name: "Run Installer (minimal)"
-        if: needs.detect-changes.outputs.docs_only != 'true'
         shell: bash
         continue-on-error: true
         run: |
@@ -576,7 +571,6 @@ jobs:
           echo "INSTALL_EXIT_CODE=${PIPESTATUS[0]}" >> "$GITHUB_ENV"
 
       - name: "Run Uninstaller"
-        if: needs.detect-changes.outputs.docs_only != 'true'
         shell: bash
         continue-on-error: true
         run: |
@@ -585,7 +579,7 @@ jobs:
           echo "UNINSTALL_EXIT_CODE=${PIPESTATUS[0]}" >> "$GITHUB_ENV"
 
       - name: "Upload Logs"
-        if: needs.detect-changes.outputs.docs_only != 'true' && (env.INSTALL_EXIT_CODE != '0' || env.UNINSTALL_EXIT_CODE != '0' || failure())
+        if: env.INSTALL_EXIT_CODE != '0' || env.UNINSTALL_EXIT_CODE != '0' || failure()
         uses: actions/upload-artifact@v6
         with:
           name: installer-minimal-${{ matrix.os }}-logs
@@ -593,7 +587,7 @@ jobs:
           retention-days: 7
 
       - name: "Fail on error"
-        if: needs.detect-changes.outputs.docs_only != 'true' && (env.INSTALL_EXIT_CODE != '0' || env.UNINSTALL_EXIT_CODE != '0')
+        if: env.INSTALL_EXIT_CODE != '0' || env.UNINSTALL_EXIT_CODE != '0'
         shell: bash
         run: |
           echo "Installer exit code: ${INSTALL_EXIT_CODE:-0}"
@@ -604,23 +598,18 @@ jobs:
     name: "Installer Development (${{ matrix.os }})"
     runs-on: ${{ matrix.os }}
     needs: detect-changes
+    if: needs.detect-changes.outputs.docs_only != 'true'
     strategy:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
     steps:
-      - name: "Skip for docs-only changes"
-        if: needs.detect-changes.outputs.docs_only == 'true'
-        run: echo "Skipping - documentation only changes"
-
       - name: "Git Checkout"
-        if: needs.detect-changes.outputs.docs_only != 'true'
         uses: actions/checkout@v6
         with:
           lfs: false
 
       - name: "Run Installer (development)"
-        if: needs.detect-changes.outputs.docs_only != 'true'
         shell: bash
         continue-on-error: true
         run: |
@@ -630,11 +619,11 @@ jobs:
           echo "INSTALL_EXIT_CODE=${PIPESTATUS[0]}" >> "$GITHUB_ENV"
 
       - name: "Verify runtime dependencies"
-        if: needs.detect-changes.outputs.docs_only != 'true' && env.INSTALL_EXIT_CODE == '0'
+        if: env.INSTALL_EXIT_CODE == '0'
         run: ./scripts/ci/verify-runtime-deps.sh
 
       - name: "Build from source"
-        if: needs.detect-changes.outputs.docs_only != 'true' && env.INSTALL_EXIT_CODE == '0'
+        if: env.INSTALL_EXIT_CODE == '0'
         shell: bash
         run: |
           export PATH="${HOME}/.bun/bin:${PATH}"
@@ -642,11 +631,11 @@ jobs:
           bunx turbo run build --output-logs=errors-only
 
       - name: "Daemon lifecycle (start → health → doctor → stop)"
-        if: needs.detect-changes.outputs.docs_only != 'true' && env.INSTALL_EXIT_CODE == '0'
+        if: env.INSTALL_EXIT_CODE == '0'
         run: ./scripts/ci/daemon-lifecycle.sh
 
       - name: "Upload Logs"
-        if: needs.detect-changes.outputs.docs_only != 'true' && (env.INSTALL_EXIT_CODE != '0' || failure())
+        if: env.INSTALL_EXIT_CODE != '0' || failure()
         uses: actions/upload-artifact@v6
         with:
           name: installer-development-${{ matrix.os }}-logs
@@ -654,7 +643,7 @@ jobs:
           retention-days: 7
 
       - name: "Fail on error"
-        if: needs.detect-changes.outputs.docs_only != 'true' && env.INSTALL_EXIT_CODE != '0'
+        if: env.INSTALL_EXIT_CODE != '0'
         shell: bash
         run: |
           echo "Installer exit code: ${INSTALL_EXIT_CODE:-0}"
@@ -738,6 +727,7 @@ jobs:
     name: "Node TypeScript Build and Test (${{ matrix.os }})"
     runs-on: ${{ matrix.os }}
     needs: detect-changes
+    if: needs.detect-changes.outputs.docs_only != 'true' && needs.detect-changes.outputs.sha256_only != 'true'
     timeout-minutes: 10
     strategy:
       fail-fast: false
@@ -747,18 +737,12 @@ jobs:
           - macos-latest
           - windows-latest
     steps:
-      - name: "Skip for docs-only or SHA256-only changes"
-        if: needs.detect-changes.outputs.docs_only == 'true' || needs.detect-changes.outputs.sha256_only == 'true'
-        run: echo "Skipping - documentation or SHA256 only changes"
-
       - name: "Git Checkout"
-        if: needs.detect-changes.outputs.docs_only != 'true' && needs.detect-changes.outputs.sha256_only != 'true'
         uses: actions/checkout@v6
         with:
           lfs: false
 
       - name: "Cache Bun dependencies"
-        if: needs.detect-changes.outputs.docs_only != 'true' && needs.detect-changes.outputs.sha256_only != 'true'
         uses: actions/cache@v5
         with:
           path: |
@@ -769,7 +753,6 @@ jobs:
             bun-${{ matrix.os }}-
 
       - name: "Cache Turborepo"
-        if: needs.detect-changes.outputs.docs_only != 'true' && needs.detect-changes.outputs.sha256_only != 'true'
         uses: actions/cache@v5
         with:
           path: .turbo
@@ -779,11 +762,9 @@ jobs:
             turbo-${{ matrix.os }}-
 
       - name: "Setup Auto Mobile"
-        if: needs.detect-changes.outputs.docs_only != 'true' && needs.detect-changes.outputs.sha256_only != 'true'
         uses: ./.github/actions/setup-auto-mobile-npm-package
 
       - name: "Run Lint"
-        if: needs.detect-changes.outputs.docs_only != 'true' && needs.detect-changes.outputs.sha256_only != 'true'
         env:
           TURBO_TELEMETRY_DISABLED: "1"
           TURBO_NO_UPDATE_NOTIFIER: "1"
@@ -792,7 +773,6 @@ jobs:
         run: turbo run lint --output-logs=errors-only --log-order=grouped
 
       - name: "Run Build"
-        if: needs.detect-changes.outputs.docs_only != 'true' && needs.detect-changes.outputs.sha256_only != 'true'
         shell: bash
         env:
           TURBO_TELEMETRY_DISABLED: "1"
@@ -805,7 +785,6 @@ jobs:
           turbo run build --output-logs=errors-only --log-order=grouped 2>&1 | tee "ci-logs/bun-build-${{ matrix.os }}.log"
 
       - name: "Run Tests"
-        if: needs.detect-changes.outputs.docs_only != 'true' && needs.detect-changes.outputs.sha256_only != 'true'
         shell: bash
         env:
           # Enable debug logging on Windows to trace what's starting the adb daemon
@@ -822,7 +801,7 @@ jobs:
           turbo run test --output-logs=errors-only --log-order=grouped 2>&1 | tee "ci-logs/bun-test-${{ matrix.os }}.log"
 
       - name: "Upload Build/Test Logs"
-        if: needs.detect-changes.outputs.docs_only != 'true' && needs.detect-changes.outputs.sha256_only != 'true' && (failure() || cancelled() || matrix.os == 'windows-latest')
+        if: failure() || cancelled() || matrix.os == 'windows-latest'
         uses: actions/upload-artifact@v6
         with:
           name: mcp-build-test-logs-${{ matrix.os }}
@@ -1762,7 +1741,7 @@ jobs:
     name: "Post Consolidated Benchmark Results"
     runs-on: ubuntu-latest
     needs: [benchmark-context-thresholds, benchmark-tool-throughput, benchmark-startup, benchmark-npm-unpacked-size]
-    if: always()
+    if: ${{ always() && (needs.benchmark-context-thresholds.result != 'skipped' || needs.benchmark-tool-throughput.result != 'skipped' || needs.benchmark-startup.result != 'skipped' || needs.benchmark-npm-unpacked-size.result != 'skipped') }}
     steps:
       - name: "Download Context Benchmark Report"
         uses: actions/download-artifact@v7


### PR DESCRIPTION
## Summary

- move docs-only installer skips from per-step guards to job-level conditions
- move docs/SHA-only TypeScript matrix skips to the job level
- skip the benchmark comment job when all benchmark jobs were skipped

## Testing

- `git diff --check`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/pull_request.yml"); puts "workflow yaml parsed"'`
- `actionlint -ignore 'could not parse action metadata' -ignore 'SC2086' .github/workflows/pull_request.yml`

Note: full `actionlint .github/workflows/pull_request.yml` still reports existing local-action metadata parsing issues and existing SC2086 warnings outside this change.
