### PR TITLE
ci: reuse Kotlin coverage for CtrlProxy tests

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -862,7 +862,7 @@ jobs:
   # =============================================================================
 
   kotlin-code-coverage:
-    name: "Kotlin Code Coverage"
+    name: "Run CtrlProxy Unit Tests"
     runs-on: ubuntu-latest
     needs: detect-changes
     if: needs.detect-changes.outputs.android_should_run == 'true'
@@ -1372,32 +1372,6 @@ jobs:
         with:
           check_name: "Playground Automobile Emulator Test Report"
           report_paths: '**/build/test-results/**/*.xml'
-
-  android-control-proxy-unit-tests:
-    name: "Run CtrlProxy Unit Tests"
-    runs-on: ubuntu-latest
-    needs: detect-changes
-    if: needs.detect-changes.outputs.android_should_run == 'true'
-    defaults:
-      run:
-        working-directory: android
-    steps:
-      - name: "Git Checkout"
-        uses: actions/checkout@v6
-        with:
-          lfs: false
-
-      - uses: ./.github/actions/gradle-task-run
-        with:
-          gradle-tasks: ":control-proxy:testDebugUnitTest"
-          gradle-project-directory: "android"
-          gradle-home-directory: "~/.gradle/${{ github.job }}"
-          reuse-configuration-cache: true
-          gradle-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
-          release-keystore-base64: ${{ secrets.RELEASE_KEYSTORE_BASE64 }}
-          release-keystore-password: ${{ secrets.RELEASE_KEYSTORE_PASSWORD }}
-          release-key-alias: ${{ secrets.RELEASE_KEY_ALIAS }}
-          release-key-password: ${{ secrets.RELEASE_KEY_PASSWORD }}
 
   build-junit-runner-library:
     name: "Build JUnitRunner Library"
@@ -1991,7 +1965,7 @@ jobs:
       - junit-runner-emulator-tests
       - junit-runner-emulator-wtf-tests
       - playground-automobile-emulator-tests
-      - android-control-proxy-unit-tests
+      - kotlin-code-coverage
     runs-on: ubuntu-latest
     steps:
       - name: "Check results"
@@ -2004,7 +1978,7 @@ jobs:
             "${{ needs.junit-runner-emulator-tests.result }}" \
             "${{ needs.junit-runner-emulator-wtf-tests.result }}" \
             "${{ needs.playground-automobile-emulator-tests.result }}" \
-            "${{ needs.android-control-proxy-unit-tests.result }}" \
+            "${{ needs.kotlin-code-coverage.result }}" \
           )
           for r in "${results[@]}"; do
             if [[ "$r" == "failure" || "$r" == "cancelled" ]]; then


### PR DESCRIPTION
## Summary

- remove the standalone `Run CtrlProxy Unit Tests` job
- have the Kotlin coverage job provide that required check while running `:control-proxy:testDebugUnitTest` and the coverage report
- keep Kotlin coverage badge generation and Android gate coverage

## Testing

- `git diff --check`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/pull_request.yml"); puts "workflow yaml parsed"'`
- `actionlint -ignore 'could not parse action metadata' -ignore 'SC2086' .github/workflows/pull_request.yml`
