### PR TITLE
feat(diagnostics): add end-of-run health summaries for plan execution

### DIFF
--- a/docs/design-docs/plat/android/junit-runner/project-setup.md
+++ b/docs/design-docs/plat/android/junit-runner/project-setup.md
@@ -246,6 +246,37 @@ app/scratch/test-logs/
 Each log file is named `<timestamp>_<TestClass>_<testMethod>.log` and contains the full daemon
 response, performance metrics, stdout, and stderr for the test run.
 
+### Run health summaries
+
+After every plan execution the daemon writes a JSON run-health summary that captures aggregated
+counts and latency percentiles for tool calls, screenshots, hierarchy syncs, await-idle outcomes,
+and ghost-tap retries. The file is intended for post-run triage in CI (and Slack-thread sharing)
+when a test was flaky or slow without an obvious failure.
+
+`hierarchy.syncRequests` counts WebSocket-path `getLatestHierarchy()` outcomes only (cache hit,
+fresh, stale, timeout, failed). ADB `requestHierarchySync` fallbacks inside
+`getAccessibilityHierarchy()` are not included in that total.
+
+Where the file lands:
+
+1. `$AUTOMOBILE_HEALTH_DIR` — explicit override (recommended for CI: set it to the artifact
+   directory the runner uploads, e.g. `$CI_PROJECT_DIR/health`).
+2. `~/.auto-mobile/health/` — default for local devs and ad-hoc `bunx … --daemon start` users.
+
+Filenames are `health-<ISO-timestamp>-<sessionId>.json` when called from JUnit (the sessionId is
+the JUnit session UUID), or `health-<ISO-timestamp>-adhoc-<random>.json` for ad-hoc CLI runs.
+Both formats sort lexicographically by start time, so `ls -t` (or alpha sort) gives you the
+newest run first.
+
+To pretty-print a summary on the command line:
+
+```
+bunx @kaeawc/auto-mobile@latest --cli health --path ~/.auto-mobile/health/health-2026-05-21T*.json
+```
+
+Add `--json` to emit the raw JSON instead (useful for piping into `jq` or attaching to a Slack
+upload). The CLI subcommand is purely local — it does not require a running daemon.
+
 ## Multiple modules
 
 If your project has more than one Android module with AutoMobile tests, add the dependency and

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -214,6 +214,77 @@ async function runDoctorCommand(params: Record<string, any>): Promise<void> {
 }
 
 /**
+ * Pretty-print or JSON-emit a run-health summary file. Purely local — does
+ * not contact the daemon. Usage: `automobile --cli health --path <file>`
+ * or `automobile --cli health --path <file> --json`.
+ */
+async function runHealthCommand(params: Record<string, any>): Promise<void> {
+  const filePath = params.path ?? params.file;
+  if (typeof filePath !== "string" || filePath.length === 0) {
+    console.error(
+      "Error: health requires --path <file>. Usage: --cli health --path <session.json> [--json]"
+    );
+    process.exit(1);
+  }
+  const jsonOutput = params.json === true;
+
+  const fs = await import("fs");
+  let raw: string;
+  try {
+    raw = fs.readFileSync(filePath, "utf-8");
+  } catch (error) {
+    console.error(
+      `Error: failed to read ${filePath}: ${error instanceof Error ? error.message : String(error)}`
+    );
+    process.exit(1);
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (error) {
+    console.error(
+      `Error: ${filePath} is not valid JSON: ${error instanceof Error ? error.message : String(error)}`
+    );
+    process.exit(1);
+  }
+
+  // Lightweight structural sanity check — catches "wrong file passed in" without
+  // pretending to be a real schema validator. If a field is missing here, the
+  // pretty-printer would crash with a less helpful message downstream.
+  const requiredKeys = [
+    "sessionId",
+    "startedAt",
+    "finishedAt",
+    "durationMs",
+    "toolCalls",
+    "hierarchy",
+    "awaitIdle",
+  ];
+  if (!parsed || typeof parsed !== "object") {
+    console.error(`Error: ${filePath} is not a JSON object.`);
+    process.exit(1);
+  }
+  const missing = requiredKeys.filter(k => !(k in (parsed as Record<string, unknown>)));
+  if (missing.length > 0) {
+    console.error(
+      `Error: ${filePath} does not look like a run-health summary — missing keys: ${missing.join(", ")}.`
+    );
+    process.exit(1);
+  }
+  const summary = parsed as import("../features/diagnostics/types").RunHealthSummary;
+
+  if (jsonOutput) {
+    console.log(JSON.stringify(summary, null, 2));
+    return;
+  }
+
+  const { prettyPrintRunHealth } = await import("../features/diagnostics/healthPrettyPrinter");
+  console.log(prettyPrintRunHealth(summary));
+}
+
+
+/**
  * Handle doctor command result from daemon
  */
 function handleDoctorResult(result: any, jsonOutput: boolean): void {
@@ -317,6 +388,12 @@ export async function runCliCommand(args: string[]): Promise<void> {
       return;
     }
 
+    // Special handling for health command - purely local, reads JSON from disk
+    if (toolName === "health") {
+      await runHealthCommand(params);
+      return;
+    }
+
     // All tool execution goes through daemon (mandatory)
     logger.debug(`Executing tool via daemon: ${toolName}`);
     const daemonResult = await runToolViaDaemon(toolName, params);
@@ -355,6 +432,8 @@ Examples:
   bunx @kaeawc/auto-mobile@latest --cli startDevice --avdName "pixel_7_api_34"
   bunx @kaeawc/auto-mobile@latest --cli --session-uuid abc-123-uuid observe
   bunx @kaeawc/auto-mobile@latest --cli --session-uuid $SESSION_UUID tapOn --text "Submit"
+  bunx @kaeawc/auto-mobile@latest --cli health --path build/automobile/health-*.json
+  bunx @kaeawc/auto-mobile@latest --cli health --path build/automobile/health-*.json --json
 
 Options:
   help [tool-name]              Show help for a specific tool

--- a/src/features/action/TapOnElement.ts
+++ b/src/features/action/TapOnElement.ts
@@ -19,6 +19,7 @@ import { DefaultElementFinder } from "../utility/ElementFinder";
 import { DefaultElementGeometry } from "../utility/ElementGeometry";
 import { DefaultElementSelector } from "../utility/DefaultElementSelector";
 import { logger } from "../../utils/logger";
+import { getActiveRecorder } from "../diagnostics/RunHealthRecorder";
 import { AndroidCtrlProxyClient } from "../observe/android";
 import { IOSCtrlProxyClient } from "../observe/ios";
 import { createGlobalPerformanceTracker } from "../../utils/PerformanceTracker";
@@ -1211,12 +1212,16 @@ export class TapOnElement extends BaseVisualChange {
       logger.info(
         `[TapOnElement][retryIfNoChange] Hierarchy changed after tap — tap registered`
       );
+      getActiveRecorder()?.recordGhostTapRetry("tap-registered");
       return;
     }
 
     logger.warn(
       `[TapOnElement][retryIfNoChange] Hierarchy unchanged after tap at ` +
       `(${tapPoint.x}, ${tapPoint.y}) — ghost tap detected, retrying`
+    );
+    getActiveRecorder()?.recordGhostTapRetry(
+      postTapHash ? "false-positive" : "bailed-null-hierarchy"
     );
 
     await this.timer.sleep(100);

--- a/src/features/diagnostics/RunHealthRecorder.ts
+++ b/src/features/diagnostics/RunHealthRecorder.ts
@@ -1,0 +1,336 @@
+import type { Timer } from "../../utils/SystemTimer";
+import { defaultTimer } from "../../utils/SystemTimer";
+import { logger } from "../../utils/logger";
+import { summarizeLatencies } from "./percentile";
+import type {
+  AwaitIdleOutcome,
+  DeviceInfo,
+  GhostTapRetryOutcome,
+  HierarchyOutcome,
+  RunHealthSummary,
+  ToolCallStats,
+} from "./types";
+
+
+interface ToolCallSamples {
+  successes: number;
+  failures: number;
+  durations: number[];
+}
+
+
+/**
+ * Collects per-plan health metrics in memory and serializes a summary on
+ * `finalize()`. One recorder instance per plan execution; the orchestrator
+ * brackets the lifetime via `setActiveRecorder` / `clearActiveRecorder`.
+ *
+ * Hook sites read the current recorder via `getActiveRecorder()` and no-op
+ * when no plan is in flight. The recorder is intentionally cheap (counters
+ * and arrays only); no I/O until `finalize()`.
+ */
+export class RunHealthRecorder {
+
+  public readonly sessionId: string | null;
+
+  private planName: string | null;
+
+  private readonly timer: Timer;
+
+  private readonly startedAtMs: number;
+
+  private readonly startedAtIso: string;
+
+  private device: DeviceInfo | null = null;
+
+  private readonly screenshotLatencies: number[] = [];
+
+  private readonly backStackLatencies: number[] = [];
+
+  private readonly accessibilityDetectorLatencies: number[] = [];
+
+  private hierarchyCacheHit = 0;
+
+  private hierarchyFresh = 0;
+
+  private hierarchyStale = 0;
+
+  private hierarchyTimeout = 0;
+
+  private hierarchyFailed = 0;
+
+  private readonly hierarchyFreshLatencies: number[] = [];
+
+  private awaitIdleCalls = 0;
+
+  private awaitIdleTimeouts = 0;
+
+  private awaitIdleErrors = 0;
+
+  private readonly awaitIdleDurations: number[] = [];
+
+  private readonly toolCalls: Map<string, ToolCallSamples> = new Map();
+
+  private ghostTapRegistered = 0;
+
+  private ghostTapFalsePositives = 0;
+
+  private ghostTapBailedNull = 0;
+
+
+  constructor(
+    options: {
+      sessionId: string | null;
+      planName?: string | null;
+      timer?: Timer;
+    }
+  ) {
+    this.sessionId = options.sessionId;
+    this.planName = options.planName ?? null;
+    this.timer = options.timer ?? defaultTimer;
+    this.startedAtMs = this.timer.now();
+    this.startedAtIso = new Date(this.startedAtMs).toISOString();
+  }
+
+
+  setDevice(device: DeviceInfo | null): void {
+    this.device = device;
+  }
+
+
+  setPlanName(planName: string | null): void {
+    this.planName = planName;
+  }
+
+
+  recordScreenshot(durationMs: number): void {
+    this.screenshotLatencies.push(durationMs);
+  }
+
+
+  recordBackStack(durationMs: number): void {
+    this.backStackLatencies.push(durationMs);
+  }
+
+
+  recordAccessibilityDetection(durationMs: number): void {
+    this.accessibilityDetectorLatencies.push(durationMs);
+  }
+
+
+  recordHierarchy(outcome: HierarchyOutcome, freshLatencyMs?: number): void {
+    switch (outcome) {
+      case "cache-hit":
+        this.hierarchyCacheHit++;
+        break;
+      case "fresh":
+        this.hierarchyFresh++;
+        if (freshLatencyMs !== undefined) {
+          this.hierarchyFreshLatencies.push(freshLatencyMs);
+        }
+        break;
+      case "stale":
+        this.hierarchyStale++;
+        break;
+      case "timeout":
+        this.hierarchyTimeout++;
+        break;
+      case "failed":
+        this.hierarchyFailed++;
+        break;
+    }
+  }
+
+
+  recordAwaitIdle(outcome: AwaitIdleOutcome, durationMs: number): void {
+    this.awaitIdleCalls++;
+    this.awaitIdleDurations.push(durationMs);
+    switch (outcome) {
+      case "timeout":
+        this.awaitIdleTimeouts++;
+        break;
+      case "error":
+        this.awaitIdleErrors++;
+        break;
+      case "settled":
+        break;
+    }
+  }
+
+
+  recordToolCall(toolName: string, durationMs: number, success: boolean): void {
+    const existing = this.toolCalls.get(toolName) ?? {
+      successes: 0,
+      failures: 0,
+      durations: [],
+    };
+    existing.durations.push(durationMs);
+    if (success) {
+      existing.successes++;
+    } else {
+      existing.failures++;
+    }
+    this.toolCalls.set(toolName, existing);
+  }
+
+
+  recordGhostTapRetry(outcome: GhostTapRetryOutcome): void {
+    switch (outcome) {
+      case "tap-registered":
+        this.ghostTapRegistered++;
+        break;
+      case "false-positive":
+        this.ghostTapFalsePositives++;
+        break;
+      case "bailed-null-hierarchy":
+        this.ghostTapBailedNull++;
+        break;
+    }
+  }
+
+
+  finalize(): RunHealthSummary {
+    const finishedAtMs = this.timer.now();
+    const finishedAtIso = new Date(finishedAtMs).toISOString();
+
+    const byTool: Record<string, ToolCallStats> = {};
+    let totalCalls = 0;
+    let totalSuccesses = 0;
+    let totalFailures = 0;
+    for (const [name, samples] of this.toolCalls.entries()) {
+      const latency = summarizeLatencies(samples.durations);
+      byTool[name] = {
+        count: samples.successes + samples.failures,
+        successes: samples.successes,
+        failures: samples.failures,
+        p50Ms: latency.p50Ms,
+        p90Ms: latency.p90Ms,
+        p99Ms: latency.p99Ms,
+        maxMs: latency.maxMs,
+      };
+      totalCalls += samples.successes + samples.failures;
+      totalSuccesses += samples.successes;
+      totalFailures += samples.failures;
+    }
+
+    const hierarchyTotal =
+      this.hierarchyCacheHit +
+      this.hierarchyFresh +
+      this.hierarchyStale +
+      this.hierarchyTimeout +
+      this.hierarchyFailed;
+    const ghostTapEvaluations =
+      this.ghostTapRegistered +
+      this.ghostTapFalsePositives +
+      this.ghostTapBailedNull;
+
+    return {
+      sessionId: this.sessionId,
+      planName: this.planName,
+      startedAt: this.startedAtIso,
+      finishedAt: finishedAtIso,
+      durationMs: finishedAtMs - this.startedAtMs,
+      device: this.device,
+      screenshot: {
+        count: this.screenshotLatencies.length,
+        latencyMs: summarizeLatencies(this.screenshotLatencies),
+      },
+      backStack: {
+        count: this.backStackLatencies.length,
+        latencyMs: summarizeLatencies(this.backStackLatencies),
+      },
+      accessibilityDetector: {
+        count: this.accessibilityDetectorLatencies.length,
+        latencyMs: summarizeLatencies(this.accessibilityDetectorLatencies),
+      },
+      hierarchy: {
+        syncRequests: hierarchyTotal,
+        cacheHits: this.hierarchyCacheHit,
+        freshDeliveries: this.hierarchyFresh,
+        staleCacheReturns: this.hierarchyStale,
+        timeouts: this.hierarchyTimeout,
+        failed: this.hierarchyFailed,
+        cacheHitRate: hierarchyTotal === 0 ? 0 : this.hierarchyCacheHit / hierarchyTotal,
+        stalenessRate: hierarchyTotal === 0 ? 0 : this.hierarchyStale / hierarchyTotal,
+        freshLatencyMs: summarizeLatencies(this.hierarchyFreshLatencies),
+      },
+      awaitIdle: {
+        calls: this.awaitIdleCalls,
+        timeouts: this.awaitIdleTimeouts,
+        errors: this.awaitIdleErrors,
+        timeoutRate: this.awaitIdleCalls === 0 ? 0 : this.awaitIdleTimeouts / this.awaitIdleCalls,
+        errorRate: this.awaitIdleCalls === 0 ? 0 : this.awaitIdleErrors / this.awaitIdleCalls,
+        durationMs: summarizeLatencies(this.awaitIdleDurations),
+      },
+      toolCalls: {
+        total: totalCalls,
+        successes: totalSuccesses,
+        failures: totalFailures,
+        byTool,
+      },
+      ghostTap: {
+        evaluations: ghostTapEvaluations,
+        tapRegistered: this.ghostTapRegistered,
+        falsePositives: this.ghostTapFalsePositives,
+        bailedNullHierarchy: this.ghostTapBailedNull,
+        falsePositiveRate:
+          ghostTapEvaluations === 0
+            ? 0
+            : this.ghostTapFalsePositives / ghostTapEvaluations,
+      },
+    };
+  }
+}
+
+
+// --- Active-recorder registry ---------------------------------------------
+//
+// The orchestrator installs a recorder for the duration of a plan execution.
+// Hook sites read via `getActiveRecorder()` so they don't need to plumb the
+// session/recorder reference through every call frame.
+//
+// Concurrency: only one recorder can be active at a time. Concurrent plans on
+// different sessions will not be cleanly partitioned — the most recently
+// installed recorder receives events while it is active. `setActiveRecorder`
+// emits a warn when it overwrites a different active recorder so the case is
+// visible in logs. The `PlanExecutionOrchestrator.execute()` finally block
+// guarantees `clearActiveRecorder` runs on every path, so an overwrite at
+// runtime means two orchestrators ran concurrently (not "someone forgot to
+// clear" — that path is structurally impossible given the finally bracket).
+//
+// Structural fix (future): swap this flat singleton for an AsyncLocalStorage
+// context so each plan's async chain carries its own recorder reference. That
+// removes the overwrite scenario entirely — there is no shared slot to clobber.
+
+let activeRecorder: RunHealthRecorder | null = null;
+
+
+export function setActiveRecorder(recorder: RunHealthRecorder): void {
+  if (activeRecorder !== null && activeRecorder !== recorder) {
+    logger.warn(
+      `[HEALTH] Concurrent plan execution detected: setActiveRecorder called ` +
+      `while another recorder is still active. ` +
+      `previous=${activeRecorder.sessionId ?? "(ad-hoc)"}, new=${recorder.sessionId ?? "(ad-hoc)"}. ` +
+      `Events fired during the overlap will be attributed to the new recorder; ` +
+      `the previous summary may undercount.`
+    );
+  }
+  activeRecorder = recorder;
+}
+
+
+export function clearActiveRecorder(recorder: RunHealthRecorder): void {
+  if (activeRecorder === recorder) {
+    activeRecorder = null;
+  }
+}
+
+
+export function getActiveRecorder(): RunHealthRecorder | null {
+  return activeRecorder;
+}
+
+
+/** Test-only helper for guaranteeing clean state between cases. */
+export function __resetActiveRecorderForTests(): void {
+  activeRecorder = null;
+}

--- a/src/features/diagnostics/healthLocator.ts
+++ b/src/features/diagnostics/healthLocator.ts
@@ -1,0 +1,52 @@
+import path from "path";
+
+export interface HealthLocatorOptions {
+  envValue: string | undefined;
+  homeDir: string;
+}
+
+/**
+ * Resolve the directory where end-of-run health summaries should land.
+ *
+ * Resolution order (first match wins):
+ *
+ *  1. `AUTOMOBILE_HEALTH_DIR` — explicit operator override. CI sets this to its
+ *     artifact directory so the JSON files are uploaded with the rest of the run.
+ *  2. `<homeDir>/.auto-mobile/health/` — default for local devs and ad-hoc
+ *     `bunx … --daemon start` users.
+ *
+ * The returned path is normalized but not created here; callers are responsible
+ * for `mkdir -p` on the directory before writing.
+ */
+export function resolveHealthDir(options: HealthLocatorOptions): string {
+  const { envValue, homeDir } = options;
+
+  const trimmedEnv = envValue?.trim();
+  if (trimmedEnv && trimmedEnv.length > 0) {
+    return path.resolve(trimmedEnv);
+  }
+
+  return path.join(homeDir, ".auto-mobile", "health");
+}
+
+/**
+ * Construct the filename for a run's health summary. Format chosen to:
+ *  - sort lexicographically by start time (`ls -t` or alpha-sort gives newest first),
+ *  - be safe on every common filesystem (no colons or path separators),
+ *  - encode session UUID when present so users can grep across files for a
+ *    known JUnit session,
+ *  - fall back to a short random suffix for ad-hoc runs so unrelated runs in
+ *    the same millisecond don't collide.
+ */
+export function buildHealthFilename(
+  sessionId: string | null,
+  startedAt: Date,
+  randomSuffix: string
+): string {
+  const iso = startedAt.toISOString().replace(/[:.]/g, "-");
+  if (sessionId) {
+    const safeSession = sessionId.replace(/[^a-zA-Z0-9_-]/g, "_");
+    return `health-${iso}-${safeSession}.json`;
+  }
+  return `health-${iso}-adhoc-${randomSuffix}.json`;
+}

--- a/src/features/diagnostics/healthPrettyPrinter.ts
+++ b/src/features/diagnostics/healthPrettyPrinter.ts
@@ -1,0 +1,123 @@
+import type { LatencyPercentiles, RunHealthSummary, ToolCallStats } from "./types";
+
+
+function formatPercent(value: number): string {
+  return `${(value * 100).toFixed(1)}%`;
+}
+
+
+function formatLatency(latency: LatencyPercentiles): string {
+  if (latency.count === 0) {
+    return "(no samples)";
+  }
+  return `min=${latency.minMs}ms p50=${latency.p50Ms}ms p90=${latency.p90Ms}ms p99=${latency.p99Ms}ms max=${latency.maxMs}ms`;
+}
+
+
+function formatDuration(ms: number): string {
+  if (ms < 1000) {
+    return `${ms}ms`;
+  }
+  const seconds = ms / 1000;
+  if (seconds < 60) {
+    return `${seconds.toFixed(2)}s`;
+  }
+  const minutes = Math.floor(seconds / 60);
+  const remainingSeconds = (seconds - minutes * 60).toFixed(1);
+  return `${minutes}m ${remainingSeconds}s`;
+}
+
+
+/**
+ * Render a `RunHealthSummary` as a human-readable, fixed-width report.
+ * Pure string formatting — no I/O. Consumers wire this into the CLI
+ * `--cli health <path>` subcommand or paste it into Slack threads.
+ */
+export function prettyPrintRunHealth(summary: RunHealthSummary): string {
+  const lines: string[] = [];
+
+  lines.push("AutoMobile Run Health Summary");
+  lines.push("=============================");
+  lines.push(`Session:     ${summary.sessionId ?? "(ad-hoc)"}`);
+  lines.push(`Plan:        ${summary.planName ?? "(unnamed)"}`);
+  lines.push(`Started:     ${summary.startedAt}`);
+  lines.push(`Finished:    ${summary.finishedAt}`);
+  lines.push(`Duration:    ${formatDuration(summary.durationMs)}`);
+  if (summary.device) {
+    lines.push(`Device:      ${summary.device.id ?? "?"} (${summary.device.model ?? "?"})`);
+  }
+  lines.push("");
+
+  lines.push("Tool Calls");
+  lines.push("----------");
+  lines.push(
+    `Total: ${summary.toolCalls.total} (success=${summary.toolCalls.successes}, failure=${summary.toolCalls.failures})`
+  );
+  const toolEntries = Object.entries(summary.toolCalls.byTool).sort(
+    (a, b) => b[1].count - a[1].count
+  );
+  if (toolEntries.length === 0) {
+    lines.push("  (no tool calls recorded)");
+  } else {
+    for (const [name, stats] of toolEntries) {
+      lines.push(`  ${name}: ${formatToolCallStats(stats)}`);
+    }
+  }
+  lines.push("");
+
+  lines.push("Hierarchy Sync");
+  lines.push("--------------");
+  lines.push(
+    `Requests: ${summary.hierarchy.syncRequests} ` +
+      `(cache=${summary.hierarchy.cacheHits}, fresh=${summary.hierarchy.freshDeliveries}, ` +
+      `stale=${summary.hierarchy.staleCacheReturns}, timeout=${summary.hierarchy.timeouts}, ` +
+      `failed=${summary.hierarchy.failed})`
+  );
+  lines.push(`Cache hit rate: ${formatPercent(summary.hierarchy.cacheHitRate)}`);
+  lines.push(`Staleness rate: ${formatPercent(summary.hierarchy.stalenessRate)}`);
+  lines.push(`Fresh latency:  ${formatLatency(summary.hierarchy.freshLatencyMs)}`);
+  lines.push("");
+
+  lines.push("Screenshots");
+  lines.push("-----------");
+  lines.push(`Count: ${summary.screenshot.count}`);
+  lines.push(`Latency: ${formatLatency(summary.screenshot.latencyMs)}`);
+  lines.push("");
+
+  lines.push("Await Idle");
+  lines.push("----------");
+  lines.push(
+    `Calls: ${summary.awaitIdle.calls} ` +
+      `(timeouts=${summary.awaitIdle.timeouts}, errors=${summary.awaitIdle.errors})`
+  );
+  lines.push(`Timeout rate: ${formatPercent(summary.awaitIdle.timeoutRate)}`);
+  lines.push(`Error rate:   ${formatPercent(summary.awaitIdle.errorRate)}`);
+  lines.push(`Duration: ${formatLatency(summary.awaitIdle.durationMs)}`);
+  lines.push("");
+
+  lines.push("Back Stack & A11y Detector");
+  lines.push("--------------------------");
+  lines.push(`Back stack:   count=${summary.backStack.count} ${formatLatency(summary.backStack.latencyMs)}`);
+  lines.push(
+    `A11y detect:  count=${summary.accessibilityDetector.count} ${formatLatency(summary.accessibilityDetector.latencyMs)}`
+  );
+  lines.push("");
+
+  lines.push("Ghost Tap Detection");
+  lines.push("-------------------");
+  lines.push(
+    `Evaluations: ${summary.ghostTap.evaluations} ` +
+      `(registered=${summary.ghostTap.tapRegistered}, false-positive=${summary.ghostTap.falsePositives}, bailed=${summary.ghostTap.bailedNullHierarchy})`
+  );
+  lines.push(`False-positive rate: ${formatPercent(summary.ghostTap.falsePositiveRate)}`);
+
+  return lines.join("\n");
+}
+
+
+function formatToolCallStats(stats: ToolCallStats): string {
+  return (
+    `count=${stats.count} (ok=${stats.successes}, fail=${stats.failures}) ` +
+    `p50=${stats.p50Ms}ms p90=${stats.p90Ms}ms p99=${stats.p99Ms}ms max=${stats.maxMs}ms`
+  );
+}

--- a/src/features/diagnostics/healthWriter.ts
+++ b/src/features/diagnostics/healthWriter.ts
@@ -83,6 +83,10 @@ function defaultRandomSuffix(): string {
 
 
 const defaultHealthWriterFs: HealthWriterFs = {
-  mkdirSync: (p, options) => fs.mkdirSync(p, options),
-  writeFileSync: (p, contents, encoding) => fs.writeFileSync(p, contents, encoding),
+  mkdirSync: (p, options) => fs.mkdirSync(p, { ...options, mode: 0o700 }),
+  writeFileSync: (p, contents, encoding) => fs.writeFileSync(p, contents, {
+    encoding,
+    flag: "wx",
+    mode: 0o600,
+  }),
 };

--- a/src/features/diagnostics/healthWriter.ts
+++ b/src/features/diagnostics/healthWriter.ts
@@ -1,0 +1,88 @@
+import fs from "fs";
+import path from "path";
+import os from "os";
+import { logger } from "../../utils/logger";
+import { buildHealthFilename, resolveHealthDir } from "./healthLocator";
+import type { RunHealthSummary } from "./types";
+
+
+export interface HealthWriterFs {
+  mkdirSync(p: string, options: { recursive: boolean }): void;
+  writeFileSync(p: string, contents: string, encoding: BufferEncoding): void;
+}
+
+
+export interface HealthWriter {
+  write(summary: RunHealthSummary): string | null;
+}
+
+
+export interface DefaultHealthWriterOptions {
+  envValue?: string | undefined;
+  homeDir?: string;
+  fs?: HealthWriterFs;
+  /** Test seam: override the random suffix used for ad-hoc filenames. */
+  randomSuffix?: () => string;
+}
+
+
+/**
+ * Real-fs implementation of the locator + writer. Errors during write are
+ * swallowed with a `logger.warn` so a malformed CI environment never fails
+ * the surrounding plan execution — observability must not be load-bearing.
+ */
+export class DefaultHealthWriter implements HealthWriter {
+
+  private readonly envValue: string | undefined;
+
+  private readonly homeDir: string;
+
+  private readonly fs: HealthWriterFs;
+
+  private readonly randomSuffix: () => string;
+
+
+  constructor(options: DefaultHealthWriterOptions = {}) {
+    this.envValue = options.envValue ?? process.env.AUTOMOBILE_HEALTH_DIR;
+    this.homeDir = options.homeDir ?? os.homedir();
+    this.fs = options.fs ?? defaultHealthWriterFs;
+    this.randomSuffix = options.randomSuffix ?? defaultRandomSuffix;
+  }
+
+
+  write(summary: RunHealthSummary): string | null {
+    try {
+      const dir = resolveHealthDir({
+        envValue: this.envValue,
+        homeDir: this.homeDir,
+      });
+      this.fs.mkdirSync(dir, { recursive: true });
+      const filename = buildHealthFilename(
+        summary.sessionId,
+        new Date(summary.startedAt),
+        this.randomSuffix()
+      );
+      const fullPath = path.join(dir, filename);
+      this.fs.writeFileSync(fullPath, JSON.stringify(summary, null, 2), "utf-8");
+      logger.info(`[HEALTH] Run health summary written: ${fullPath}`);
+      return fullPath;
+    } catch (error) {
+      logger.warn(
+        `[HEALTH] Failed to write run health summary: ${error instanceof Error ? error.message : String(error)}`
+      );
+      return null;
+    }
+  }
+}
+
+
+function defaultRandomSuffix(): string {
+  // 8 hex chars is plenty for "two unrelated ad-hoc runs in the same ms" collision avoidance.
+  return Math.floor(Math.random() * 0xffffffff).toString(16).padStart(8, "0");
+}
+
+
+const defaultHealthWriterFs: HealthWriterFs = {
+  mkdirSync: (p, options) => fs.mkdirSync(p, options),
+  writeFileSync: (p, contents, encoding) => fs.writeFileSync(p, contents, encoding),
+};

--- a/src/features/diagnostics/percentile.ts
+++ b/src/features/diagnostics/percentile.ts
@@ -1,0 +1,50 @@
+import type { LatencyPercentiles } from "./types";
+
+/**
+ * Linear-interpolation percentile, identical in semantics to the existing
+ * private implementation in `src/server/networkGraph.ts`. Extracted here so
+ * the run-health summary and any future diagnostics can share one
+ * implementation without depending on the networkGraph internals.
+ *
+ * `sortedAsc` must be sorted ascending. Returns 0 for an empty input.
+ */
+export function percentile(sortedAsc: number[], p: number): number {
+  if (sortedAsc.length === 0) {
+    return 0;
+  }
+  const index = (p / 100) * (sortedAsc.length - 1);
+  const lower = Math.floor(index);
+  const upper = Math.ceil(index);
+  if (lower === upper) {
+    return sortedAsc[lower];
+  }
+  return sortedAsc[lower] + (sortedAsc[upper] - sortedAsc[lower]) * (index - lower);
+}
+
+/**
+ * Roll an unsorted sample into a `LatencyPercentiles` record. Sorts internally
+ * (caller does not need to pre-sort). Empty samples produce all-zero output;
+ * callers should still emit the surrounding shape with `count: 0` so the JSON
+ * stays self-describing.
+ */
+export function summarizeLatencies(samples: number[]): LatencyPercentiles {
+  if (samples.length === 0) {
+    return {
+      count: 0,
+      minMs: 0,
+      p50Ms: 0,
+      p90Ms: 0,
+      p99Ms: 0,
+      maxMs: 0,
+    };
+  }
+  const sorted = [...samples].sort((a, b) => a - b);
+  return {
+    count: sorted.length,
+    minMs: sorted[0],
+    p50Ms: Math.round(percentile(sorted, 50)),
+    p90Ms: Math.round(percentile(sorted, 90)),
+    p99Ms: Math.round(percentile(sorted, 99)),
+    maxMs: sorted[sorted.length - 1],
+  };
+}

--- a/src/features/diagnostics/types.ts
+++ b/src/features/diagnostics/types.ts
@@ -1,0 +1,162 @@
+/**
+ * Public JSON shape for an end-of-run health summary file.
+ *
+ * No `version` field by design — these files are written and read by the same
+ * package version, never persisted across major upgrades. If we need cross-
+ * version compatibility later, add a `kind` field for self-identification
+ * (cheaper than maintaining bump rules nobody reads).
+ *
+ * Platform coverage caveat:
+ * `screenshot`, `backStack`, `accessibilityDetector`, `awaitIdle`, and
+ * `hierarchy` are populated only on Android today — the corresponding iOS
+ * code paths are separate and currently un-instrumented. iOS-only runs will
+ * see count=0 across those sections; `toolCalls` and `ghostTap` are the
+ * cross-platform metrics that remain accurate either way.
+ */
+
+export type HierarchyOutcome =
+  // Cache served the call without waiting on the WebSocket.
+  | "cache-hit"
+  // WebSocket delivered fresh data within the wait timeout.
+  | "fresh"
+  // WebSocket wait timed out, served stale cache as fallback.
+  | "stale"
+  // WebSocket wait timed out and there was no cache to fall back to.
+  | "timeout"
+  // Pre-WebSocket failure — ensureConnected returned false, the call threw,
+  // or the skipWaitForFresh path returned null. Returned `{hierarchy: null}`.
+  | "failed";
+
+export type AwaitIdleOutcome =
+  // UI reached stability within the timeout.
+  | "settled"
+  // Wait timed out without reaching stability.
+  | "timeout"
+  // Polling loop threw — recorded distinctly so timeoutRate isn't inflated by aborts.
+  | "error";
+
+export type GhostTapRetryOutcome =
+  // Post-tap hierarchy differs from pre-tap hierarchy. Tap was real; no retry needed.
+  | "tap-registered"
+  // Post-tap hierarchy is non-null and matches pre-tap. Tap presumed ghost; retry fired.
+  | "false-positive"
+  // Post-tap hierarchy unavailable (null). We can't verify; retry fired defensively.
+  | "bailed-null-hierarchy";
+
+export interface LatencyPercentiles {
+  count: number;
+  minMs: number;
+  p50Ms: number;
+  p90Ms: number;
+  p99Ms: number;
+  maxMs: number;
+}
+
+export interface ScreenshotStats {
+  count: number;
+  latencyMs: LatencyPercentiles;
+}
+
+export interface HierarchyStats {
+  /** Total hierarchy retrievals — includes cache hits, fresh deliveries, stale fallbacks, timeouts, and failed setups. */
+  syncRequests: number;
+  /** Calls served straight from the in-memory cache without waiting on the WebSocket. */
+  cacheHits: number;
+  /** WebSocket waits that delivered fresh data within the configured timeout. */
+  freshDeliveries: number;
+  /** WebSocket waits that timed out but a cached value was returned. */
+  staleCacheReturns: number;
+  /** WebSocket waits that timed out with no cache available. */
+  timeouts: number;
+  /** Pre-WebSocket failures (connection refused, ensureConnected returned false, thrown errors). */
+  failed: number;
+  /** `cacheHits / syncRequests` — high values mean we're saving WebSocket round-trips. */
+  cacheHitRate: number;
+  /** `staleCacheReturns / syncRequests` — high values indicate the WebSocket is unreliable. */
+  stalenessRate: number;
+  /**
+   * End-to-end latency for `fresh` outcomes only — measured from
+   * `getLatestHierarchy()` entry to the fresh-data return. Includes the cache
+   * check + WebSocket wait, not just the push leg.
+   */
+  freshLatencyMs: LatencyPercentiles;
+}
+
+export interface AwaitIdleStats {
+  calls: number;
+  /** Polling loop completed but never reached the stability threshold. */
+  timeouts: number;
+  /** Polling loop threw — tracked in its own counter so `timeoutRate` doesn't conflate with `errorRate`. */
+  errors: number;
+  /** `timeouts / calls`. Errors live in `errorRate` and do not inflate this number. */
+  timeoutRate: number;
+  /** `errors / calls`. Distinct bucket from `timeoutRate`. */
+  errorRate: number;
+  /**
+   * Wall-clock time spent in `awaitIdle()` across all outcomes (settled, timeout, error).
+   * Mixing is intentional — the metric answers "how long does this call take?", not
+   * "how long do successful settles take?".
+   */
+  durationMs: LatencyPercentiles;
+}
+
+export interface ToolCallStats {
+  count: number;
+  successes: number;
+  failures: number;
+  p50Ms: number;
+  p90Ms: number;
+  p99Ms: number;
+  maxMs: number;
+}
+
+export interface GhostTapStats {
+  evaluations: number;
+  tapRegistered: number;
+  falsePositives: number;
+  bailedNullHierarchy: number;
+  falsePositiveRate: number;
+}
+
+export interface BackStackStats {
+  count: number;
+  latencyMs: LatencyPercentiles;
+}
+
+export interface AccessibilityDetectorStats {
+  count: number;
+  latencyMs: LatencyPercentiles;
+}
+
+export interface RunHealthSummary {
+  /**
+   * Session UUID from the JUnit runner / `--session-uuid` CLI flag if provided,
+   * `null` for ad-hoc runs that have no session context to correlate against.
+   */
+  sessionId: string | null;
+  planName: string | null;
+  startedAt: string;
+  finishedAt: string;
+  durationMs: number;
+  device: {
+    id: string | null;
+    model: string | null;
+  } | null;
+  screenshot: ScreenshotStats;
+  backStack: BackStackStats;
+  accessibilityDetector: AccessibilityDetectorStats;
+  hierarchy: HierarchyStats;
+  awaitIdle: AwaitIdleStats;
+  toolCalls: {
+    total: number;
+    successes: number;
+    failures: number;
+    byTool: Record<string, ToolCallStats>;
+  };
+  ghostTap: GhostTapStats;
+}
+
+export interface DeviceInfo {
+  id: string | null;
+  model: string | null;
+}

--- a/src/features/observe/AwaitIdle.ts
+++ b/src/features/observe/AwaitIdle.ts
@@ -1,6 +1,7 @@
 import { AdbClientFactory, defaultAdbClientFactory } from "../../utils/android-cmdline-tools/AdbClientFactory";
 import type { AdbExecutor } from "../../utils/android-cmdline-tools/interfaces/AdbExecutor";
 import { logger } from "../../utils/logger";
+import { getActiveRecorder } from "../diagnostics/RunHealthRecorder";
 import { Idle } from "./Idle";
 import { BootedDevice, GfxMetrics } from "../../models";
 import { PerformanceTracker, NoOpPerformanceTracker } from "../../utils/PerformanceTracker";
@@ -193,6 +194,7 @@ export class AwaitIdle implements AwaitIdleInterface {
     let state = initState;
     let pollCount = 0;
     let isStable = false;
+    let errored = false;
     const finalMetrics: {
       percentile50thMs: number | null;
       percentile90thMs: number | null;
@@ -253,6 +255,7 @@ export class AwaitIdle implements AwaitIdleInterface {
       }
     } catch {
       logger.error("[AwaitIdle] Encountered an error while waiting for UI stability");
+      errored = true;
     }
 
     // Get final gfxinfo to capture percentiles
@@ -273,6 +276,8 @@ export class AwaitIdle implements AwaitIdleInterface {
     }
 
     const stabilityWaitMs = this.timer.now() - initState.startTime;
+    const awaitIdleOutcome = errored ? "error" : isStable ? "settled" : "timeout";
+    getActiveRecorder()?.recordAwaitIdle(awaitIdleOutcome, stabilityWaitMs);
 
     return {
       packageName,

--- a/src/features/observe/GetBackStack.ts
+++ b/src/features/observe/GetBackStack.ts
@@ -2,6 +2,7 @@ import { AdbClientFactory, defaultAdbClientFactory } from "../../utils/android-c
 import type { AdbExecutor } from "../../utils/android-cmdline-tools/interfaces/AdbExecutor";
 import { BackStackInfo, ActivityInfo, TaskInfo, BootedDevice } from "../../models";
 import { logger } from "../../utils/logger";
+import { getActiveRecorder } from "../diagnostics/RunHealthRecorder";
 import { PerformanceTracker, NoOpPerformanceTracker } from "../../utils/PerformanceTracker";
 import type { BackStack } from "./interfaces/BackStack";
 import { Timer, defaultTimer } from "../../utils/SystemTimer";
@@ -242,6 +243,7 @@ export class GetBackStack implements BackStack {
         `depth=${depth}, activities=${activities.length}, tasks=${tasks.length}, ` +
         `currentActivity=${currentActivity?.name || "unknown"}`
       );
+      getActiveRecorder()?.recordBackStack(duration);
 
       return backStackInfo;
     } catch (error) {

--- a/src/features/observe/TakeScreenshot.ts
+++ b/src/features/observe/TakeScreenshot.ts
@@ -15,6 +15,7 @@ import type { ScreenshotService } from "./interfaces/ScreenshotService";
 import { IOSCtrlProxyClient } from "./ios";
 import { getDeviceDataStreamServer } from "../../daemon/deviceDataStreamSocketServer";
 import { Timer, defaultTimer } from "../../utils/SystemTimer";
+import { getActiveRecorder } from "../diagnostics/RunHealthRecorder";
 
 /** Secure file mode: owner read/write only */
 const SECURE_FILE_MODE = 0o600;
@@ -361,6 +362,9 @@ export class TakeScreenshot implements ScreenshotService {
     const result = await this.adb.executeCommand(command, undefined, maxBuffer, undefined, signal);
     const cmdDuration = this.timer.now() - cmdStartTime;
     logger.info(`[SCREENSHOT] Combined ADB command took ${cmdDuration}ms`);
+    // Health hook is Android-only: TakeScreenshot routes through Android's ADB path here,
+    // while iOS captures via IOSCtrlProxyClient. See RunHealthSummary platform-coverage note.
+    getActiveRecorder()?.recordScreenshot(cmdDuration);
 
     if (!result.stdout || result.stdout.trim().length === 0) {
       throw new Error("No base64 data received from screencap command");

--- a/src/features/observe/android/CtrlProxyHierarchy.ts
+++ b/src/features/observe/android/CtrlProxyHierarchy.ts
@@ -7,6 +7,7 @@
 
 import WebSocket from "ws";
 import { logger } from "../../../utils/logger";
+import { getActiveRecorder } from "../../diagnostics/RunHealthRecorder";
 import type { PerformanceTracker, TimingEntry } from "../../../utils/PerformanceTracker";
 import { NoOpPerformanceTracker } from "../../../utils/PerformanceTracker";
 import { throwIfAborted } from "../../../utils/toolUtils";
@@ -103,6 +104,7 @@ export class CtrlProxyHierarchy {
       const connected = await perf.track("ensureConnection", () => this.context.ensureConnected(perf));
       if (!connected) {
         logger.warn("[CTRL_PROXY] Failed to establish WebSocket connection");
+        getActiveRecorder()?.recordHierarchy("failed");
         return {
           hierarchy: null,
           fresh: false
@@ -130,6 +132,7 @@ export class CtrlProxyHierarchy {
               `receivedAt=${cachedHierarchy.receivedAt}, ` +
               `updatedAt=${updatedAt}, age=${cacheAge}ms, fresh=${isFresh}`
             );
+            getActiveRecorder()?.recordHierarchy("cache-hit");
 
             return {
               hierarchy: cachedHierarchy.hierarchy,
@@ -143,6 +146,7 @@ export class CtrlProxyHierarchy {
           const isFresh = cacheAge < 1000;
           const duration = this.context.timer.now() - startTime;
           logger.debug(`[CTRL_PROXY] Cache hit: ${duration}ms (age: ${cacheAge}ms, fresh: ${isFresh}, updatedAt: ${updatedAt})`);
+          getActiveRecorder()?.recordHierarchy("cache-hit");
 
           return {
             hierarchy: cachedHierarchy.hierarchy,
@@ -173,6 +177,7 @@ export class CtrlProxyHierarchy {
             this.lastKnownPackageName = freshData.hierarchy.packageName;
           }
           logger.debug(`[CTRL_PROXY] Received fresh hierarchy in ${duration}ms (updatedAt: ${freshData.hierarchy.updatedAt})`);
+          getActiveRecorder()?.recordHierarchy("fresh", duration);
           return {
             hierarchy: freshData.hierarchy,
             fresh: true,
@@ -196,6 +201,7 @@ export class CtrlProxyHierarchy {
             }
             currentCache.fresh = false;
             logger.debug(`[CTRL_PROXY] Returning stale cached data (updatedAt: ${currentCache.hierarchy.updatedAt}), marked cache as stale`);
+            getActiveRecorder()?.recordHierarchy("stale");
             return {
               hierarchy: currentCache.hierarchy,
               fresh: false,
@@ -203,13 +209,28 @@ export class CtrlProxyHierarchy {
               perfTiming: currentCache.perfTiming
             };
           }
+          // Timeout with no cache to fall through to — count as a hard timeout
+          // and return directly so we don't double-record below.
+          getActiveRecorder()?.recordHierarchy("timeout");
+          return {
+            hierarchy: null,
+            fresh: false
+          };
         }
       } else if (skipWaitForFresh || this.shouldSkipWebSocketWait()) {
         logger.debug(`[CTRL_PROXY] Skipping WebSocket wait (skipWaitForFresh=${skipWaitForFresh}, recentTimeout=${this.shouldSkipWebSocketWait()})`);
       }
 
-      // No cached data available
-      logger.debug("[CTRL_PROXY] No cached hierarchy data available");
+      // Reached when we didn't take any of the recording branches above — counted
+      // as `failed` so the bucket sum matches actual call count.
+      const skippedWsWait = skipWaitForFresh || this.shouldSkipWebSocketWait();
+      logger.debug(
+        `[CTRL_PROXY] getLatestHierarchy returning null (failed): ` +
+        `cache=${cachedHierarchy ? "present-but-unused" : "absent"}, ` +
+        `waitForFresh=${waitForFresh}, skipWaitForFresh=${skipWaitForFresh}, ` +
+        `skippedWsWait=${skippedWsWait}`
+      );
+      getActiveRecorder()?.recordHierarchy("failed");
       return {
         hierarchy: null,
         fresh: false
@@ -217,6 +238,7 @@ export class CtrlProxyHierarchy {
     } catch (error) {
       const duration = this.context.timer.now() - startTime;
       logger.warn(`[CTRL_PROXY] Failed to get hierarchy after ${duration}ms: ${error}`);
+      getActiveRecorder()?.recordHierarchy("failed");
       return {
         hierarchy: null,
         fresh: false

--- a/src/server/planExecutionOrchestrator.ts
+++ b/src/server/planExecutionOrchestrator.ts
@@ -24,6 +24,12 @@ import { defaultTimer, Timer } from "../utils/SystemTimer";
 import { logger } from "../utils/logger";
 import { ProgressCallback } from "./toolRegistry";
 import type { Plan } from "../models/Plan";
+import {
+  RunHealthRecorder,
+  clearActiveRecorder,
+  setActiveRecorder,
+} from "../features/diagnostics/RunHealthRecorder";
+import { DefaultHealthWriter, type HealthWriter } from "../features/diagnostics/healthWriter";
 
 /**
  * Test metadata captured per-execution for the test-execution timing repository.
@@ -82,6 +88,8 @@ export interface PlanExecutionDependencies {
   timer?: Timer;
   /** Video recording manager surface — replaced by a fake in tests. */
   videoRecorder?: VideoRecorder;
+  /** Writer for end-of-run health summaries — replaced by a fake in tests. */
+  healthWriter?: HealthWriter;
 }
 
 interface VideoState {
@@ -179,11 +187,14 @@ export class PlanExecutionOrchestrator {
   private readonly testExecutionRepository: TestExecutionRepository;
   private readonly createSchemaValidator: () => Pick<PlanSchemaValidator, "loadSchema" | "validateYaml">;
   private readonly videoRecorder: VideoRecorder;
+  private readonly healthWriter: HealthWriter;
 
   // Set in execute(); used by all phase methods for [PERF +Xms] elapsed-time logs.
   private perfStart = 0;
   // Computed once in preparePlan(); reused by allocateDevices().
   private normalizedDevices?: NormalizedPlanDevices;
+  // Bracketed by execute(); fan-out target for hook sites in deeper layers.
+  private healthRecorder?: RunHealthRecorder;
 
   constructor(context: ExecutionContext, deps: PlanExecutionDependencies = {}) {
     this.device = context.device;
@@ -197,6 +208,7 @@ export class PlanExecutionOrchestrator {
       startVideoRecording: defaultStartVideoRecording,
       stopVideoRecording: defaultStopVideoRecording,
     };
+    this.healthWriter = deps.healthWriter ?? new DefaultHealthWriter();
   }
 
   private perfLog(message: string): void {
@@ -210,6 +222,16 @@ export class PlanExecutionOrchestrator {
   async execute(): Promise<ExecutePlanResult> {
     const startTime = this.timer.now();
     const stopHeartbeat = this.startProgressHeartbeat();
+
+    this.healthRecorder = new RunHealthRecorder({
+      sessionId: this.request.sessionUuid ?? null,
+      timer: this.timer,
+    });
+    this.healthRecorder.setDevice({
+      id: this.device.deviceId,
+      model: this.device.name ?? null,
+    });
+    setActiveRecorder(this.healthRecorder);
 
     try {
       this.perfStart = this.timer.now();
@@ -283,6 +305,17 @@ export class PlanExecutionOrchestrator {
       return response;
     } finally {
       stopHeartbeat();
+      if (this.healthRecorder) {
+        try {
+          const summary = this.healthRecorder.finalize();
+          this.healthWriter.write(summary);
+        } catch (error) {
+          logger.warn(
+            `[HEALTH] Failed to finalize run health summary: ${error instanceof Error ? error.message : String(error)}`
+          );
+        }
+        clearActiveRecorder(this.healthRecorder);
+      }
     }
   }
 
@@ -319,6 +352,8 @@ export class PlanExecutionOrchestrator {
     this.perfLog("Parsing plan from YAML");
     const plan = importPlanFromYaml(yamlContent);
     this.perfLog(`Plan parsed: '${plan.name}' with ${plan.steps.length} steps`);
+
+    this.healthRecorder?.setPlanName(plan.name);
 
     this.normalizedDevices = normalizePlanDevices(plan.devices);
     this.reconcileDeviceLists();

--- a/src/server/toolRegistry.ts
+++ b/src/server/toolRegistry.ts
@@ -8,6 +8,7 @@ import { RealObserveScreen } from "../features/observe/ObserveScreen";
 import { serverConfig } from "../utils/ServerConfig";
 import { MemoryAudit } from "../features/memory/MemoryAudit";
 import { TelemetryRecorder } from "../features/telemetry/TelemetryRecorder";
+import { getActiveRecorder } from "../features/diagnostics/RunHealthRecorder";
 import { defaultAdbClientFactory } from "../utils/android-cmdline-tools/AdbClientFactory";
 import { AndroidCtrlProxyClient } from "../features/observe/android";
 import { IOSCtrlProxyClient } from "../features/observe/ios";
@@ -312,6 +313,10 @@ class ToolRegistryClass {
         }
       }
 
+      // Sentinel so the catch block doesn't double-count a tool call as a
+      // failure when post-success bookkeeping (mcpRecorder, session cache,
+      // navigation graph) throws after the success-path recordToolCall fires.
+      let recordedToolCall = false;
       try {
         // Record tool call for navigation graph correlation
         // Only record UI interaction tools that may cause navigation
@@ -423,6 +428,8 @@ class ToolRegistryClass {
           error: toolError,
           args: typeof args === "object" ? args : null,
         });
+        getActiveRecorder()?.recordToolCall(name, toolDurationMs, toolSuccess);
+        recordedToolCall = true;
 
         // Record successful tool call for MCP recording (test plan generation)
         if (toolSuccess) {
@@ -465,6 +472,12 @@ class ToolRegistryClass {
 
         return response;
       } catch (error) {
+        // Record the failure before rethrowing so per-tool stats include
+        // exception failures, not just returned `{ success: false }` results.
+        // Sentinel guards against double-counting when post-success bookkeeping throws.
+        if (!recordedToolCall) {
+          getActiveRecorder()?.recordToolCall(name, this.timer.now() - toolStartMs, false);
+        }
         if (error instanceof ActionableError) {
           throw error;
         }

--- a/src/utils/AccessibilityDetector.ts
+++ b/src/utils/AccessibilityDetector.ts
@@ -1,4 +1,5 @@
 import { logger } from "./logger";
+import { getActiveRecorder } from "../features/diagnostics/RunHealthRecorder";
 import { FeatureFlagService } from "../features/featureFlags/FeatureFlagService";
 import type { AccessibilityDetector as IAccessibilityDetector, AccessibilityService } from "./interfaces/AccessibilityDetector";
 import { SystemTimer, type Timer } from "./SystemTimer";
@@ -76,6 +77,7 @@ export class DefaultAccessibilityDetector implements IAccessibilityDetector {
     const startTime = this.timer.now();
     const { enabled, service } = await this.detectAccessibilityState(deviceId, adb);
     const detectionTime = this.timer.now() - startTime;
+    getActiveRecorder()?.recordAccessibilityDetection(detectionTime);
 
     if (detectionTime > 50) {
       logger.warn(

--- a/test/features/diagnostics/RunHealthRecorder.test.ts
+++ b/test/features/diagnostics/RunHealthRecorder.test.ts
@@ -1,0 +1,228 @@
+import { afterEach, beforeEach, describe, expect, spyOn, test } from "bun:test";
+import {
+  RunHealthRecorder,
+  __resetActiveRecorderForTests,
+  clearActiveRecorder,
+  getActiveRecorder,
+  setActiveRecorder,
+} from "../../../src/features/diagnostics/RunHealthRecorder";
+import { logger } from "../../../src/utils/logger";
+import { FakeTimer } from "../../fakes/FakeTimer";
+
+
+function makeRecorder(timer: FakeTimer, sessionId = "s1", planName: string | null = "test-plan") {
+  return new RunHealthRecorder({ sessionId, planName, timer });
+}
+
+
+describe("RunHealthRecorder", function() {
+
+  beforeEach(function() {
+    __resetActiveRecorderForTests();
+  });
+
+
+  afterEach(function() {
+    __resetActiveRecorderForTests();
+  });
+
+
+  test("finalize returns a self-describing summary with zero counts when nothing was recorded", function() {
+    const timer = new FakeTimer();
+    const recorder = makeRecorder(timer);
+    timer.advanceTime(5);
+
+    const summary = recorder.finalize();
+
+    expect(summary.sessionId).toBe("s1");
+    expect(summary.planName).toBe("test-plan");
+    expect(summary.durationMs).toBe(5);
+    expect(summary.toolCalls.total).toBe(0);
+    expect(summary.hierarchy.syncRequests).toBe(0);
+    expect(summary.hierarchy.cacheHitRate).toBe(0);
+    expect(summary.hierarchy.stalenessRate).toBe(0);
+    expect(summary.awaitIdle.calls).toBe(0);
+    expect(summary.awaitIdle.errorRate).toBe(0);
+    expect(summary.ghostTap.evaluations).toBe(0);
+    expect(summary.screenshot.count).toBe(0);
+  });
+
+
+  test("screenshot recording aggregates count and latency percentiles", function() {
+    const timer = new FakeTimer();
+    const recorder = makeRecorder(timer);
+
+    recorder.recordScreenshot(100);
+    recorder.recordScreenshot(200);
+    recorder.recordScreenshot(50);
+
+    const summary = recorder.finalize();
+    expect(summary.screenshot.count).toBe(3);
+    expect(summary.screenshot.latencyMs.minMs).toBe(50);
+    expect(summary.screenshot.latencyMs.maxMs).toBe(200);
+  });
+
+
+  test("sessionId can be null for ad-hoc runs", function() {
+    const timer = new FakeTimer();
+    const recorder = new RunHealthRecorder({ sessionId: null, timer });
+    const summary = recorder.finalize();
+    expect(summary.sessionId).toBeNull();
+  });
+
+
+  test("hierarchy cache-hit/fresh/stale/timeout/failed counters and derived rates", function() {
+    const timer = new FakeTimer();
+    const recorder = makeRecorder(timer);
+
+    recorder.recordHierarchy("cache-hit");
+    recorder.recordHierarchy("cache-hit");
+    recorder.recordHierarchy("fresh", 30);
+    recorder.recordHierarchy("fresh", 40);
+    recorder.recordHierarchy("stale");
+    recorder.recordHierarchy("timeout");
+    recorder.recordHierarchy("failed");
+
+    const summary = recorder.finalize();
+    expect(summary.hierarchy.syncRequests).toBe(7);
+    expect(summary.hierarchy.cacheHits).toBe(2);
+    expect(summary.hierarchy.freshDeliveries).toBe(2);
+    expect(summary.hierarchy.staleCacheReturns).toBe(1);
+    expect(summary.hierarchy.timeouts).toBe(1);
+    expect(summary.hierarchy.failed).toBe(1);
+    expect(summary.hierarchy.cacheHitRate).toBeCloseTo(2 / 7, 3);
+    expect(summary.hierarchy.stalenessRate).toBeCloseTo(1 / 7, 3);
+    expect(summary.hierarchy.freshLatencyMs.count).toBe(2);
+  });
+
+
+  test("cache-hit calls do not contribute to fresh latency samples", function() {
+    const timer = new FakeTimer();
+    const recorder = makeRecorder(timer);
+
+    recorder.recordHierarchy("cache-hit");
+    recorder.recordHierarchy("cache-hit");
+    recorder.recordHierarchy("fresh", 100);
+
+    const summary = recorder.finalize();
+    expect(summary.hierarchy.freshLatencyMs.count).toBe(1);
+    expect(summary.hierarchy.freshLatencyMs.maxMs).toBe(100);
+  });
+
+
+  test("await idle separates settled/timeout/error into timeoutRate and errorRate", function() {
+    const timer = new FakeTimer();
+    const recorder = makeRecorder(timer);
+
+    recorder.recordAwaitIdle("settled", 100);
+    recorder.recordAwaitIdle("settled", 200);
+    recorder.recordAwaitIdle("timeout", 5000);
+    recorder.recordAwaitIdle("error", 1500);
+
+    const summary = recorder.finalize();
+    expect(summary.awaitIdle.calls).toBe(4);
+    expect(summary.awaitIdle.timeouts).toBe(1);
+    expect(summary.awaitIdle.errors).toBe(1);
+    expect(summary.awaitIdle.timeoutRate).toBeCloseTo(0.25, 2);
+    expect(summary.awaitIdle.errorRate).toBeCloseTo(0.25, 2);
+    expect(summary.awaitIdle.durationMs.count).toBe(4);
+    expect(summary.awaitIdle.durationMs.maxMs).toBe(5000);
+  });
+
+
+  test("tool call recording aggregates per-tool counts, successes, failures, and percentiles", function() {
+    const timer = new FakeTimer();
+    const recorder = makeRecorder(timer);
+
+    recorder.recordToolCall("tapOn", 100, true);
+    recorder.recordToolCall("tapOn", 200, true);
+    recorder.recordToolCall("tapOn", 300, false);
+    recorder.recordToolCall("observe", 50, true);
+
+    const summary = recorder.finalize();
+    expect(summary.toolCalls.total).toBe(4);
+    expect(summary.toolCalls.successes).toBe(3);
+    expect(summary.toolCalls.failures).toBe(1);
+
+    expect(summary.toolCalls.byTool.tapOn.count).toBe(3);
+    expect(summary.toolCalls.byTool.tapOn.successes).toBe(2);
+    expect(summary.toolCalls.byTool.tapOn.failures).toBe(1);
+    expect(summary.toolCalls.byTool.tapOn.maxMs).toBe(300);
+
+    expect(summary.toolCalls.byTool.observe.count).toBe(1);
+  });
+
+
+  test("ghost tap retry counters and false-positive rate", function() {
+    const timer = new FakeTimer();
+    const recorder = makeRecorder(timer);
+
+    recorder.recordGhostTapRetry("tap-registered");
+    recorder.recordGhostTapRetry("tap-registered");
+    recorder.recordGhostTapRetry("false-positive");
+    recorder.recordGhostTapRetry("false-positive");
+    recorder.recordGhostTapRetry("bailed-null-hierarchy");
+
+    const summary = recorder.finalize();
+    expect(summary.ghostTap.evaluations).toBe(5);
+    expect(summary.ghostTap.tapRegistered).toBe(2);
+    expect(summary.ghostTap.falsePositives).toBe(2);
+    expect(summary.ghostTap.bailedNullHierarchy).toBe(1);
+    expect(summary.ghostTap.falsePositiveRate).toBeCloseTo(0.4, 2);
+  });
+
+
+  test("device info appears in finalize output", function() {
+    const timer = new FakeTimer();
+    const recorder = makeRecorder(timer);
+
+    recorder.setDevice({ id: "emulator-5554", model: "Pixel 8" });
+
+    const summary = recorder.finalize();
+    expect(summary.device).toEqual({ id: "emulator-5554", model: "Pixel 8" });
+  });
+
+
+  test("active-recorder registry: set, get, clear", function() {
+    const timer = new FakeTimer();
+    const recorder = makeRecorder(timer);
+
+    expect(getActiveRecorder()).toBeNull();
+
+    setActiveRecorder(recorder);
+    expect(getActiveRecorder()).toBe(recorder);
+
+    clearActiveRecorder(recorder);
+    expect(getActiveRecorder()).toBeNull();
+  });
+
+
+  test("clearActiveRecorder no-ops if a different recorder is active (concurrent-plan safety)", function() {
+    const timer = new FakeTimer();
+    const r1 = makeRecorder(timer, "s1");
+    const r2 = makeRecorder(timer, "s2");
+
+    setActiveRecorder(r1);
+    setActiveRecorder(r2);
+
+    clearActiveRecorder(r1);
+
+    expect(getActiveRecorder()).toBe(r2);
+  });
+
+
+  test("setActiveRecorder warns when overwriting a different active recorder", function() {
+    const warnSpy = spyOn(logger, "warn").mockImplementation(() => {});
+    const timer = new FakeTimer();
+    const r1 = makeRecorder(timer, "s1");
+    const r2 = makeRecorder(timer, "s2");
+
+    setActiveRecorder(r1);
+    setActiveRecorder(r2);
+
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(String(warnSpy.mock.calls[0][0])).toContain("Concurrent plan execution detected");
+
+    warnSpy.mockRestore();
+  });
+});

--- a/test/features/diagnostics/healthLocator.test.ts
+++ b/test/features/diagnostics/healthLocator.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, test } from "bun:test";
+import path from "path";
+import {
+  buildHealthFilename,
+  resolveHealthDir,
+} from "../../../src/features/diagnostics/healthLocator";
+
+
+describe("resolveHealthDir", () => {
+
+  test("env var wins over home dir", () => {
+    const result = resolveHealthDir({
+      envValue: "/explicit/health",
+      homeDir: "/home/user",
+    });
+    expect(result).toBe(path.resolve("/explicit/health"));
+  });
+
+
+  test("trims whitespace and ignores empty env var", () => {
+    const result = resolveHealthDir({
+      envValue: "   ",
+      homeDir: "/home/user",
+    });
+    expect(result).toBe(path.join("/home/user", ".auto-mobile", "health"));
+  });
+
+
+  test("falls back to home dir when no env var is set", () => {
+    const result = resolveHealthDir({
+      envValue: undefined,
+      homeDir: "/home/user",
+    });
+    expect(result).toBe(path.join("/home/user", ".auto-mobile", "health"));
+  });
+});
+
+
+describe("buildHealthFilename", () => {
+
+  test("encodes ISO timestamp and session uuid into a filesystem-safe filename", () => {
+    const result = buildHealthFilename(
+      "abc-123",
+      new Date("2026-05-21T14:30:45.123Z"),
+      "deadbeef"
+    );
+    expect(result).toBe("health-2026-05-21T14-30-45-123Z-abc-123.json");
+  });
+
+
+  test("strips unsafe characters from session id", () => {
+    const result = buildHealthFilename(
+      "foo/bar:baz",
+      new Date("2026-05-21T00:00:00Z"),
+      "deadbeef"
+    );
+    expect(result).not.toContain("/");
+    expect(result).not.toContain(":");
+    expect(result).toContain("foo_bar_baz");
+  });
+
+
+  test("uses adhoc-<random> suffix when sessionId is null", () => {
+    const result = buildHealthFilename(
+      null,
+      new Date("2026-05-21T14:30:45.123Z"),
+      "deadbeef"
+    );
+    expect(result).toBe("health-2026-05-21T14-30-45-123Z-adhoc-deadbeef.json");
+  });
+
+
+  test("filenames sort lexicographically by start time", () => {
+    const earlier = buildHealthFilename(
+      "s1",
+      new Date("2026-05-21T10:00:00Z"),
+      "aaaaaaaa"
+    );
+    const later = buildHealthFilename(
+      "s1",
+      new Date("2026-05-21T11:00:00Z"),
+      "aaaaaaaa"
+    );
+    expect([later, earlier].sort()).toEqual([earlier, later]);
+  });
+});

--- a/test/features/diagnostics/healthPrettyPrinter.test.ts
+++ b/test/features/diagnostics/healthPrettyPrinter.test.ts
@@ -1,0 +1,171 @@
+import { describe, expect, test } from "bun:test";
+import { prettyPrintRunHealth } from "../../../src/features/diagnostics/healthPrettyPrinter";
+import type { RunHealthSummary } from "../../../src/features/diagnostics/types";
+
+
+function makeSummary(overrides: Partial<RunHealthSummary> = {}): RunHealthSummary {
+  return {
+    sessionId: "test-session",
+    planName: "demo-plan",
+    startedAt: "2026-05-21T14:00:00.000Z",
+    finishedAt: "2026-05-21T14:01:30.000Z",
+    durationMs: 90_000,
+    device: { id: "emulator-5554", model: "Pixel 8" },
+    screenshot: {
+      count: 5,
+      latencyMs: { count: 5, minMs: 100, p50Ms: 200, p90Ms: 400, p99Ms: 450, maxMs: 500 },
+    },
+    backStack: {
+      count: 2,
+      latencyMs: { count: 2, minMs: 50, p50Ms: 60, p90Ms: 70, p99Ms: 70, maxMs: 70 },
+    },
+    accessibilityDetector: {
+      count: 1,
+      latencyMs: { count: 1, minMs: 20, p50Ms: 20, p90Ms: 20, p99Ms: 20, maxMs: 20 },
+    },
+    hierarchy: {
+      syncRequests: 10,
+      cacheHits: 0,
+      freshDeliveries: 8,
+      staleCacheReturns: 1,
+      timeouts: 1,
+      failed: 0,
+      cacheHitRate: 0,
+      stalenessRate: 0.1,
+      freshLatencyMs: { count: 8, minMs: 10, p50Ms: 30, p90Ms: 50, p99Ms: 60, maxMs: 70 },
+    },
+    awaitIdle: {
+      calls: 3,
+      timeouts: 1,
+      errors: 0,
+      timeoutRate: 0.333,
+      errorRate: 0,
+      durationMs: { count: 3, minMs: 100, p50Ms: 200, p90Ms: 5000, p99Ms: 5000, maxMs: 5000 },
+    },
+    toolCalls: {
+      total: 4,
+      successes: 3,
+      failures: 1,
+      byTool: {
+        tapOn: { count: 3, successes: 2, failures: 1, p50Ms: 200, p90Ms: 280, p99Ms: 300, maxMs: 300 },
+        observe: { count: 1, successes: 1, failures: 0, p50Ms: 50, p90Ms: 50, p99Ms: 50, maxMs: 50 },
+      },
+    },
+    ghostTap: {
+      evaluations: 5,
+      tapRegistered: 2,
+      falsePositives: 2,
+      bailedNullHierarchy: 1,
+      falsePositiveRate: 0.4,
+    },
+    ...overrides,
+  };
+}
+
+
+describe("prettyPrintRunHealth", function() {
+
+  test("renders headline metadata", function() {
+    const output = prettyPrintRunHealth(makeSummary());
+    expect(output).toContain("AutoMobile Run Health Summary");
+    expect(output).toContain("Session:     test-session");
+    expect(output).toContain("Plan:        demo-plan");
+    expect(output).toContain("Duration:    1m 30.0s");
+    expect(output).toContain("emulator-5554");
+  });
+
+
+  test("renders tool call breakdown sorted by call count desc", function() {
+    const output = prettyPrintRunHealth(makeSummary());
+    const tapOnIdx = output.indexOf("tapOn:");
+    const observeIdx = output.indexOf("observe:");
+    expect(tapOnIdx).toBeGreaterThan(0);
+    expect(observeIdx).toBeGreaterThan(0);
+    expect(tapOnIdx).toBeLessThan(observeIdx);
+  });
+
+
+  test("renders percentages as 1-decimal", function() {
+    const output = prettyPrintRunHealth(makeSummary());
+    expect(output).toContain("Staleness rate: 10.0%");
+    expect(output).toContain("False-positive rate: 40.0%");
+  });
+
+
+  test("collapses empty latency samples to '(no samples)'", function() {
+    const output = prettyPrintRunHealth(
+      makeSummary({
+        screenshot: {
+          count: 0,
+          latencyMs: { count: 0, minMs: 0, p50Ms: 0, p90Ms: 0, p99Ms: 0, maxMs: 0 },
+        },
+      })
+    );
+    expect(output).toContain("(no samples)");
+  });
+
+
+  test("falls back to '(unnamed)' for missing plan name", function() {
+    const output = prettyPrintRunHealth(makeSummary({ planName: null }));
+    expect(output).toContain("Plan:        (unnamed)");
+  });
+
+
+  test("renders '(ad-hoc)' for null sessionId", function() {
+    const output = prettyPrintRunHealth(makeSummary({ sessionId: null }));
+    expect(output).toContain("Session:     (ad-hoc)");
+  });
+
+
+  test("renders '(no tool calls recorded)' when there are no tools", function() {
+    const output = prettyPrintRunHealth(
+      makeSummary({
+        toolCalls: { total: 0, successes: 0, failures: 0, byTool: {} },
+      })
+    );
+    expect(output).toContain("(no tool calls recorded)");
+  });
+
+
+  test("hierarchy line surfaces cache hits, failed bucket, and cache hit rate", function() {
+    const output = prettyPrintRunHealth(
+      makeSummary({
+        hierarchy: {
+          syncRequests: 8,
+          cacheHits: 4,
+          freshDeliveries: 1,
+          staleCacheReturns: 1,
+          timeouts: 0,
+          failed: 2,
+          cacheHitRate: 0.5,
+          stalenessRate: 1 / 8,
+          freshLatencyMs: { count: 1, minMs: 10, p50Ms: 10, p90Ms: 10, p99Ms: 10, maxMs: 10 },
+        },
+      })
+    );
+    expect(output).toContain("cache=4");
+    expect(output).toContain("fresh=1");
+    expect(output).toContain("failed=2");
+    expect(output).toContain("Cache hit rate: 50.0%");
+  });
+
+
+  test("await idle line surfaces error count and rate separately from timeouts", function() {
+    const output = prettyPrintRunHealth(
+      makeSummary({
+        awaitIdle: {
+          calls: 4,
+          timeouts: 1,
+          errors: 2,
+          timeoutRate: 0.25,
+          errorRate: 0.5,
+          durationMs: { count: 4, minMs: 50, p50Ms: 100, p90Ms: 500, p99Ms: 500, maxMs: 500 },
+        },
+      })
+    );
+    expect(output).toContain("timeouts=1");
+    expect(output).toContain("errors=2");
+    expect(output).toContain("Timeout rate: 25.0%");
+    expect(output).toContain("Error rate:   50.0%");
+  });
+});

--- a/test/features/diagnostics/healthWriter.test.ts
+++ b/test/features/diagnostics/healthWriter.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, test } from "bun:test";
+import path from "path";
+import {
+  DefaultHealthWriter,
+  type HealthWriterFs,
+} from "../../../src/features/diagnostics/healthWriter";
+import type { RunHealthSummary } from "../../../src/features/diagnostics/types";
+
+
+function makeSummary(overrides: Partial<RunHealthSummary> = {}): RunHealthSummary {
+  return {
+    version: 1,
+    sessionId: "session-abc",
+    planName: "demo",
+    startedAt: "2026-05-21T14:00:00.000Z",
+    finishedAt: "2026-05-21T14:00:05.000Z",
+    durationMs: 5000,
+    device: null,
+    screenshot: {
+      count: 0,
+      latencyMs: { count: 0, minMs: 0, p50Ms: 0, p90Ms: 0, p99Ms: 0, maxMs: 0 },
+    },
+    backStack: {
+      count: 0,
+      latencyMs: { count: 0, minMs: 0, p50Ms: 0, p90Ms: 0, p99Ms: 0, maxMs: 0 },
+    },
+    accessibilityDetector: {
+      count: 0,
+      latencyMs: { count: 0, minMs: 0, p50Ms: 0, p90Ms: 0, p99Ms: 0, maxMs: 0 },
+    },
+    hierarchy: {
+      syncRequests: 0,
+      freshDeliveries: 0,
+      staleCacheReturns: 0,
+      timeouts: 0,
+      stalenessRate: 0,
+      freshLatencyMs: { count: 0, minMs: 0, p50Ms: 0, p90Ms: 0, p99Ms: 0, maxMs: 0 },
+    },
+    awaitIdle: {
+      calls: 0,
+      timeouts: 0,
+      timeoutRate: 0,
+      durationMs: { count: 0, minMs: 0, p50Ms: 0, p90Ms: 0, p99Ms: 0, maxMs: 0 },
+    },
+    toolCalls: { total: 0, successes: 0, failures: 0, byTool: {} },
+    ghostTap: {
+      evaluations: 0,
+      tapRegistered: 0,
+      falsePositives: 0,
+      bailedNullHierarchy: 0,
+      falsePositiveRate: 0,
+    },
+    ...overrides,
+  };
+}
+
+
+class FakeWriterFs implements HealthWriterFs {
+
+  public readonly mkdirCalls: { p: string; recursive: boolean }[] = [];
+
+  public readonly writtenFiles: Map<string, string> = new Map();
+
+  public writeShouldThrow: Error | null = null;
+
+
+  mkdirSync(p: string, options: { recursive: boolean }): void {
+    this.mkdirCalls.push({ p, recursive: options.recursive });
+  }
+
+
+  writeFileSync(p: string, contents: string): void {
+    if (this.writeShouldThrow) {
+      throw this.writeShouldThrow;
+    }
+    this.writtenFiles.set(p, contents);
+  }
+}
+
+
+describe("DefaultHealthWriter", () => {
+
+  test("writes JSON to the resolved directory and returns the full path", () => {
+    const fakeFs = new FakeWriterFs();
+    const writer = new DefaultHealthWriter({
+      envValue: "/tmp/health",
+      homeDir: "/home/user",
+      fs: fakeFs,
+      randomSuffix: () => "deadbeef",
+    });
+
+    const fullPath = writer.write(makeSummary());
+
+    expect(fullPath).not.toBeNull();
+    expect(fakeFs.mkdirCalls[0]).toEqual({ p: path.resolve("/tmp/health"), recursive: true });
+    expect(fakeFs.writtenFiles.size).toBe(1);
+    const [writtenPath, contents] = Array.from(fakeFs.writtenFiles.entries())[0];
+    expect(writtenPath).toBe(fullPath);
+    expect(writtenPath).toContain("session-abc");
+    expect(writtenPath.endsWith(".json")).toBe(true);
+    const parsed = JSON.parse(contents);
+    expect(parsed.sessionId).toBe("session-abc");
+  });
+
+
+  test("uses the random-suffix seam for ad-hoc filenames when sessionId is null", () => {
+    const fakeFs = new FakeWriterFs();
+    const writer = new DefaultHealthWriter({
+      envValue: "/tmp/health",
+      homeDir: "/home/user",
+      fs: fakeFs,
+      randomSuffix: () => "cafebabe",
+    });
+
+    const fullPath = writer.write(makeSummary({ sessionId: null }));
+
+    expect(fullPath).not.toBeNull();
+    expect(fullPath).toContain("adhoc-cafebabe");
+  });
+
+
+  test("returns null and does not throw when the underlying write fails", () => {
+    const fakeFs = new FakeWriterFs();
+    fakeFs.writeShouldThrow = new Error("disk full");
+    const writer = new DefaultHealthWriter({
+      envValue: "/tmp/health",
+      homeDir: "/home/user",
+      fs: fakeFs,
+      randomSuffix: () => "deadbeef",
+    });
+
+    const result = writer.write(makeSummary());
+
+    expect(result).toBeNull();
+  });
+});

--- a/test/features/diagnostics/percentile.test.ts
+++ b/test/features/diagnostics/percentile.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, test } from "bun:test";
+import { percentile, summarizeLatencies } from "../../../src/features/diagnostics/percentile";
+
+
+describe("percentile", function() {
+
+  test("empty input returns 0", function() {
+    expect(percentile([], 50)).toBe(0);
+    expect(percentile([], 99)).toBe(0);
+  });
+
+
+  test("single-element returns that element for any percentile", function() {
+    expect(percentile([42], 0)).toBe(42);
+    expect(percentile([42], 50)).toBe(42);
+    expect(percentile([42], 99)).toBe(42);
+  });
+
+
+  test("p50 of even-length sample interpolates the middle", function() {
+    expect(percentile([10, 20, 30, 40], 50)).toBe(25);
+  });
+
+
+  test("p100 returns max, p0 returns min", function() {
+    const sorted = [1, 5, 10, 100];
+    expect(percentile(sorted, 0)).toBe(1);
+    expect(percentile(sorted, 100)).toBe(100);
+  });
+});
+
+
+describe("summarizeLatencies", function() {
+
+  test("empty samples produces an all-zero record with count=0", function() {
+    const result = summarizeLatencies([]);
+    expect(result).toEqual({
+      count: 0,
+      minMs: 0,
+      p50Ms: 0,
+      p90Ms: 0,
+      p99Ms: 0,
+      maxMs: 0,
+    });
+  });
+
+
+  test("sorts input internally — callers don't need to pre-sort", function() {
+    const result = summarizeLatencies([100, 1, 50, 10, 5]);
+    expect(result.minMs).toBe(1);
+    expect(result.maxMs).toBe(100);
+    expect(result.count).toBe(5);
+  });
+
+
+  test("rounds percentiles to whole milliseconds", function() {
+    const result = summarizeLatencies([10, 20]);
+    expect(Number.isInteger(result.p50Ms)).toBe(true);
+    expect(Number.isInteger(result.p90Ms)).toBe(true);
+    expect(Number.isInteger(result.p99Ms)).toBe(true);
+  });
+});

--- a/test/features/observe/AwaitIdle.errorOutcome.test.ts
+++ b/test/features/observe/AwaitIdle.errorOutcome.test.ts
@@ -1,0 +1,86 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { AwaitIdle } from "../../../src/features/observe/AwaitIdle";
+import {
+  RunHealthRecorder,
+  __resetActiveRecorderForTests,
+  clearActiveRecorder,
+  setActiveRecorder,
+} from "../../../src/features/diagnostics/RunHealthRecorder";
+import { FakeAdbExecutor } from "../../fakes/FakeAdbExecutor";
+import { FakeTimer } from "../../fakes/FakeTimer";
+import type { BootedDevice } from "../../../src/models";
+
+/**
+ * Regression coverage for the AwaitIdle catch path → `recordAwaitIdle("error", ...)`.
+ *
+ * The polling loop in `waitForUiStabilityWithState` is wrapped in try/catch so
+ * unexpected throws (abort signals, ADB blow-ups) don't crash the caller.
+ * Pre-fix, those throws were silently bucketed as "timeout" — inflating
+ * `timeoutRate`. Now the catch sets `errored=true` and the outcome is
+ * recorded distinctly as "error" so operators can tell aborts from genuine
+ * stability timeouts.
+ *
+ * We force the catch by passing an already-aborted signal, which makes the
+ * first `throwIfAborted(signal)` call inside the loop throw.
+ */
+
+const fakeDevice: BootedDevice = {
+  name: "Test Device",
+  deviceId: "emulator-5554",
+  platform: "android",
+};
+
+
+describe("AwaitIdle records 'error' outcome distinctly from 'timeout'", function() {
+
+  let recorder: RunHealthRecorder;
+
+
+  beforeEach(function() {
+    __resetActiveRecorderForTests();
+    recorder = new RunHealthRecorder({
+      sessionId: "awaitidle-error-test",
+      timer: new FakeTimer(),
+    });
+    setActiveRecorder(recorder);
+  });
+
+
+  afterEach(function() {
+    clearActiveRecorder(recorder);
+    __resetActiveRecorderForTests();
+  });
+
+
+  test("aborted signal inside the polling loop records 'error', not 'timeout'", async function() {
+    const fakeAdb = new FakeAdbExecutor();
+    const timer = new FakeTimer();
+    const awaitIdle = new AwaitIdle(fakeDevice, fakeAdb, timer);
+
+    const controller = new AbortController();
+    controller.abort();
+
+    await awaitIdle.waitForUiStabilityWithState(
+      "com.example.app",
+      5000,
+      {
+        startTime: timer.now(),
+        lastNonIdleTime: timer.now(),
+        prevMissedVsync: null,
+        prevSlowUiThread: null,
+        prevFrameDeadlineMissed: null,
+        prevTotalFrames: null,
+        firstGfxInfoLog: true,
+      },
+      undefined,
+      controller.signal
+    );
+
+    const summary = recorder.finalize();
+    expect(summary.awaitIdle.calls).toBe(1);
+    expect(summary.awaitIdle.errors).toBe(1);
+    expect(summary.awaitIdle.timeouts).toBe(0);
+    expect(summary.awaitIdle.errorRate).toBe(1);
+    expect(summary.awaitIdle.timeoutRate).toBe(0);
+  });
+});

--- a/test/features/observe/CtrlProxyClient.test.ts
+++ b/test/features/observe/CtrlProxyClient.test.ts
@@ -1,5 +1,11 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { AndroidCtrlProxyClient } from "../../../src/features/observe/android";
+import {
+  RunHealthRecorder,
+  __resetActiveRecorderForTests,
+  clearActiveRecorder,
+  setActiveRecorder,
+} from "../../../src/features/diagnostics/RunHealthRecorder";
 import { NavigationGraphManager } from "../../../src/features/navigation/NavigationGraphManager";
 import { FakeAdbExecutor } from "../../fakes/FakeAdbExecutor";
 import { AndroidCtrlProxyManager } from "../../../src/utils/CtrlProxyManager";
@@ -333,6 +339,92 @@ describe("AndroidCtrlProxyClient", function() {
         expect(result.fresh).toBe(false);
       } finally {
         await testClient.close();
+      }
+    });
+
+
+    test("records hierarchy failed when WebSocket connection cannot be established", async function() {
+      __resetActiveRecorderForTests();
+      const recorder = new RunHealthRecorder({
+        sessionId: "hierarchy-failed-test",
+        timer: fakeTimer,
+      });
+      setActiveRecorder(recorder);
+
+      const testClient = AndroidCtrlProxyClient.createForTesting(
+        testDevice,
+        fakeAdb,
+        createInstantFailureWebSocketFactory(fakeTimer),
+        fakeTimer
+      );
+
+      try {
+        await testClient.getLatestHierarchy(true, 1000);
+
+        const summary = recorder.finalize();
+        expect(summary.hierarchy.failed).toBe(1);
+        expect(summary.hierarchy.syncRequests).toBe(1);
+        expect(summary.hierarchy.freshDeliveries).toBe(0);
+      } finally {
+        await testClient.close();
+        clearActiveRecorder(recorder);
+        __resetActiveRecorderForTests();
+      }
+    });
+
+
+    test("records hierarchy cache-hit when cached data is returned without waiting for fresh", async function() {
+      const mockHierarchyData = {
+        updatedAt: fakeTimer.now(),
+        packageName: "com.example.cachehit",
+        hierarchy: {
+          text: "Cache Hit Data",
+          "resource-id": "com.example.cachehit:id/root",
+        },
+      };
+
+      const testTimer = new FakeTimer();
+      testTimer.enableAutoAdvance();
+      const { factory, getSocket } = createCapturingWebSocketFactory(testTimer);
+      const testClient = AndroidCtrlProxyClient.createForTesting(
+        testDevice,
+        fakeAdb,
+        factory,
+        testTimer
+      );
+
+      try {
+        const warmCachePromise = testClient.getLatestHierarchy(true, 2000);
+        const socket = await waitForSocket(getSocket);
+        expect(socket).not.toBeNull();
+        await waitForSocketOpen(socket);
+        socket!.simulateMessage(JSON.stringify({
+          type: "hierarchy_update",
+          timestamp: testTimer.now(),
+          data: mockHierarchyData,
+        }));
+        await testTimer.resolvePromise(warmCachePromise);
+
+        __resetActiveRecorderForTests();
+        const recorder = new RunHealthRecorder({
+          sessionId: "hierarchy-cache-hit-test",
+          timer: testTimer,
+        });
+        setActiveRecorder(recorder);
+
+        const result = await testClient.getLatestHierarchy(false, 0);
+
+        expect(result.hierarchy).not.toBeNull();
+        expect(result.hierarchy!.hierarchy.text).toBe("Cache Hit Data");
+
+        const summary = recorder.finalize();
+        expect(summary.hierarchy.cacheHits).toBe(1);
+        expect(summary.hierarchy.syncRequests).toBe(1);
+        expect(summary.hierarchy.freshDeliveries).toBe(0);
+        expect(summary.hierarchy.failed).toBe(0);
+      } finally {
+        await testClient.close();
+        __resetActiveRecorderForTests();
       }
     });
 

--- a/test/server/planExecutionOrchestrator.test.ts
+++ b/test/server/planExecutionOrchestrator.test.ts
@@ -26,6 +26,12 @@ mock.module("../../src/utils/planUtils", () => {
 });
 
 import { PlanExecutionOrchestrator, convertDebugStepsToRecords, VideoRecorder } from "../../src/server/planExecutionOrchestrator";
+import type { HealthWriter } from "../../src/features/diagnostics/healthWriter";
+import type { RunHealthSummary } from "../../src/features/diagnostics/types";
+import {
+  __resetActiveRecorderForTests,
+  getActiveRecorder,
+} from "../../src/features/diagnostics/RunHealthRecorder";
 
 const buildVideoRecorder = (
   filePath: string = "/tmp/fake-recording.mp4",
@@ -248,6 +254,143 @@ steps:
     const result = await orchestrator.execute();
     // Even though recording failed, the plan itself succeeded.
     expect(result.success).toBe(true);
+  });
+});
+
+
+class FakeHealthWriter implements HealthWriter {
+
+  public readonly written: RunHealthSummary[] = [];
+
+
+  write(summary: RunHealthSummary): string | null {
+    this.written.push(summary);
+    return "/fake/health.json";
+  }
+}
+
+
+describe("PlanExecutionOrchestrator run-health summary lifecycle", () => {
+
+  beforeEach(() => {
+    executePlanMock.mockClear();
+    executePlanMock.mockImplementation(() =>
+      Promise.resolve({
+        success: true,
+        executedSteps: 2,
+        totalSteps: 2,
+        debug: { executionTimeMs: 100, steps: [] },
+      })
+    );
+    __resetActiveRecorderForTests();
+  });
+
+
+  test("execute() installs a recorder during the inner run and clears it after", async () => {
+    const healthWriter = new FakeHealthWriter();
+    let recorderDuringRun: ReturnType<typeof getActiveRecorder> | undefined;
+    executePlanMock.mockImplementationOnce(() => {
+      // Capture the active recorder while runPlan is in flight.
+      recorderDuringRun = getActiveRecorder();
+      return Promise.resolve({
+        success: true,
+        executedSteps: 1,
+        totalSteps: 1,
+        debug: { executionTimeMs: 50, steps: [] },
+      });
+    });
+
+    const orchestrator = new PlanExecutionOrchestrator(
+      { device: iosDevice, request: { ...baseRequest, sessionUuid: "session-xyz" } },
+      { ...baseDeps(), healthWriter }
+    );
+    await orchestrator.execute();
+
+    expect(recorderDuringRun).not.toBeNull();
+    expect(recorderDuringRun?.sessionId).toBe("session-xyz");
+    expect(getActiveRecorder()).toBeNull();
+  });
+
+
+  test("execute() writes a finalized summary with plan name and device info", async () => {
+    const healthWriter = new FakeHealthWriter();
+
+    const orchestrator = new PlanExecutionOrchestrator(
+      { device: iosDevice, request: { ...baseRequest, sessionUuid: "session-abc" } },
+      { ...baseDeps(), healthWriter }
+    );
+    await orchestrator.execute();
+
+    expect(healthWriter.written).toHaveLength(1);
+    const summary = healthWriter.written[0];
+    expect(summary.sessionId).toBe("session-abc");
+    expect(summary.planName).toBe("simple-test");
+    expect(summary.device?.id).toBe(iosDevice.deviceId);
+    expect(summary.device?.model).toBe(iosDevice.name);
+  });
+
+
+  test("execute() emits sessionId=null for ad-hoc runs with no sessionUuid", async () => {
+    const healthWriter = new FakeHealthWriter();
+    const orchestrator = new PlanExecutionOrchestrator(
+      { device: iosDevice, request: baseRequest },
+      { ...baseDeps(), healthWriter }
+    );
+    await orchestrator.execute();
+    expect(healthWriter.written[0].sessionId).toBeNull();
+  });
+
+
+  test("execute() writes the summary even when the plan validation fails", async () => {
+    const healthWriter = new FakeHealthWriter();
+    const orchestrator = new PlanExecutionOrchestrator(
+      {
+        device: iosDevice,
+        request: { ...baseRequest, planContent: "not: a: valid: plan:\n  - missing" },
+      },
+      { ...baseDeps(), healthWriter }
+    );
+    const result = await orchestrator.execute();
+
+    expect(result.success).toBe(false);
+    expect(healthWriter.written).toHaveLength(1);
+    // Plan name never resolved because YAML failed schema validation.
+    expect(healthWriter.written[0].planName).toBeNull();
+  });
+
+
+  test("execute() writes the summary even when the inner runPlan returns failure", async () => {
+    const healthWriter = new FakeHealthWriter();
+    executePlanMock.mockImplementationOnce(() =>
+      Promise.resolve({
+        success: false,
+        executedSteps: 1,
+        totalSteps: 2,
+        failedStep: { stepIndex: 1, tool: "tapOn", error: "boom" },
+      })
+    );
+    const orchestrator = new PlanExecutionOrchestrator(
+      { device: iosDevice, request: baseRequest },
+      { ...baseDeps(), healthWriter }
+    );
+    await orchestrator.execute();
+    expect(healthWriter.written).toHaveLength(1);
+  });
+
+
+  test("a failing health writer never crashes the run", async () => {
+    const exploding: HealthWriter = {
+      write: () => {
+        throw new Error("writer exploded");
+      },
+    };
+    const orchestrator = new PlanExecutionOrchestrator(
+      { device: iosDevice, request: baseRequest },
+      { ...baseDeps(), healthWriter: exploding }
+    );
+    const result = await orchestrator.execute();
+    expect(result.success).toBe(true);
+    expect(getActiveRecorder()).toBeNull();
   });
 });
 

--- a/test/server/toolRegistry.sentinelDoubleCount.test.ts
+++ b/test/server/toolRegistry.sentinelDoubleCount.test.ts
@@ -1,0 +1,135 @@
+import { afterEach, beforeEach, describe, expect, test, spyOn } from "bun:test";
+import { z } from "zod";
+import { ToolRegistry } from "../../src/server/toolRegistry";
+import {
+  RunHealthRecorder,
+  __resetActiveRecorderForTests,
+  clearActiveRecorder,
+  setActiveRecorder,
+} from "../../src/features/diagnostics/RunHealthRecorder";
+import { McpCallRecorder } from "../../src/features/record/McpCallRecorder";
+import {
+  resetMcpRecordingState,
+  startMcpRecording,
+} from "../../src/server/mcpRecordingManager";
+import { FakeTimer } from "../fakes/FakeTimer";
+
+/**
+ * Regression coverage for the `recordedToolCall` sentinel in
+ * `ToolRegistry.registerDeviceAware`. The catch block guards against double-
+ * counting a tool call as a failure when **post-success bookkeeping** throws
+ * after the success-path `recordToolCall(success)` has already fired.
+ *
+ * Without the sentinel, a thrown error from `getMcpRecorder()?.record()` (or
+ * any of the other post-success hooks) would land in the catch, fire
+ * `recordToolCall(failure)`, and report 2 events for 1 invocation. With the
+ * sentinel, the catch sees `recordedToolCall === true` and skips the second
+ * record. This test forces that exact path by:
+ *   1. Spying on `McpCallRecorder.prototype.record` so it throws.
+ *   2. Starting an MCP recording so `getMcpRecorder()` returns a real recorder.
+ *   3. Registering a PLAN_RELEVANT_TOOL (so the post-success branch fires).
+ *   4. Verifying the run-health recorder ends up with exactly one event.
+ */
+
+describe("ToolRegistry sentinel — double-count protection", function() {
+
+  let recordSpy: ReturnType<typeof spyOn>;
+
+
+  beforeEach(function() {
+    ToolRegistry.clearTools();
+    __resetActiveRecorderForTests();
+    resetMcpRecordingState();
+    recordSpy = spyOn(McpCallRecorder.prototype, "record").mockImplementation(() => {
+      throw new Error("simulated post-success bookkeeping failure");
+    });
+  });
+
+
+  afterEach(function() {
+    recordSpy.mockRestore();
+    ToolRegistry.clearTools();
+    __resetActiveRecorderForTests();
+    resetMcpRecordingState();
+  });
+
+
+  test("a thrown post-success bookkeeping error does not double-count the tool call", async function() {
+    startMcpRecording();
+
+    const recorder = new RunHealthRecorder({
+      sessionId: "session-sentinel",
+      timer: new FakeTimer(),
+    });
+    setActiveRecorder(recorder);
+
+    ToolRegistry.registerDeviceAware(
+      "tapOn",
+      "Test tool that succeeds; getMcpRecorder().record() is rigged to throw afterwards",
+      z.object({
+        text: z.string().optional(),
+        platform: z.enum(["ios", "android"]).optional(),
+        sessionUuid: z.string().optional(),
+      }),
+      async () => ({ success: true }),
+      false,
+      false,
+      {
+        shouldEnsureDevice: () => false,
+        nonDeviceHandler: async () => ({ success: true }),
+      }
+    );
+
+    const tool = ToolRegistry.getTool("tapOn");
+    expect(tool).toBeDefined();
+
+    await expect(tool!.handler({ text: "hello" })).rejects.toThrow(
+      /Failed to execute tool tapOn/
+    );
+
+    expect(recordSpy).toHaveBeenCalledTimes(1);
+
+    const summary = recorder.finalize();
+    expect(summary.toolCalls.total).toBe(1);
+    expect(summary.toolCalls.successes).toBe(1);
+    expect(summary.toolCalls.failures).toBe(0);
+    expect(summary.toolCalls.byTool.tapOn.count).toBe(1);
+    expect(summary.toolCalls.byTool.tapOn.failures).toBe(0);
+
+    clearActiveRecorder(recorder);
+  });
+
+
+  test("a tool that throws before reaching the success path is recorded exactly once as a failure", async function() {
+    const recorder = new RunHealthRecorder({
+      sessionId: "session-throws-early",
+      timer: new FakeTimer(),
+    });
+    setActiveRecorder(recorder);
+
+    ToolRegistry.registerDeviceAware(
+      "tapOn",
+      "Test tool whose handler itself throws before any bookkeeping fires",
+      z.object({ platform: z.enum(["ios", "android"]).optional() }),
+      async () => ({ success: true }),
+      false,
+      false,
+      {
+        shouldEnsureDevice: () => false,
+        nonDeviceHandler: async () => {
+          throw new Error("handler exploded");
+        },
+      }
+    );
+
+    const tool = ToolRegistry.getTool("tapOn");
+    await expect(tool!.handler({})).rejects.toThrow(/Failed to execute tool tapOn/);
+
+    const summary = recorder.finalize();
+    expect(summary.toolCalls.total).toBe(1);
+    expect(summary.toolCalls.successes).toBe(0);
+    expect(summary.toolCalls.failures).toBe(1);
+
+    clearActiveRecorder(recorder);
+  });
+});


### PR DESCRIPTION
Closes #2306

Emit a JSON aggregate after every executePlan with tool, hierarchy, await-idle, and ghost-tap metrics; write to AUTOMOBILE_HEALTH_DIR or ~/.auto-mobile/health/ and pretty-print via --cli health.