### PR TITLE
chore: bump versions to v0.0.31

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -14,7 +14,7 @@
       "name": "auto-mobile",
       "source": "./",
       "description": "Mobile device automation for Android and iOS - control devices with natural language",
-      "version": "0.0.30",
+      "version": "0.0.31",
       "author": {
         "name": "AutoMobile Contributors",
         "email": "jason.d.pearson@gmail.com"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "auto-mobile",
   "description": "Mobile device automation for Android and iOS - control devices with natural language",
-  "version": "0.0.30",
+  "version": "0.0.31",
   "author": {
     "name": "AutoMobile Contributors",
     "email": "jason.d.pearson@gmail.com"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [v0.0.31] - 2026-05-27
+### Changed
+- Dead Code Detection: Threshold Exceeded ([#1874](https://github.com/kaeawc/auto-mobile/issues/1874)) (automated, dead-code)
+### Other
+- Only 2 of 7 daemon CLI flags log a startup confirmation ([#2286](https://github.com/kaeawc/auto-mobile/issues/2286))
+- CtrlProxy `getLatestHierarchy` 100ms fresh-data wait too short for contended environments ([#2285](https://github.com/kaeawc/auto-mobile/issues/2285))
+- Issue 3: `SelectionStateTracker` ignores `--no-ui-perf-mode` and dominates CI ADB overhead ([#2284](https://github.com/kaeawc/auto-mobile/issues/2284))
+- `retryTapIfNoChange` throws `ReferenceError: isTalkBackEnabled is not defined` ([#2282](https://github.com/kaeawc/auto-mobile/issues/2282))
+- Bug: ReferenceError 'isTalkBackEnabled is not defined' in tapOn retryIfNoChange path ([#2277](https://github.com/kaeawc/auto-mobile/issues/2277))
+- bug(ios): observe returns "received Android hierarchy for iOS device" inside conversation views ([#2275](https://github.com/kaeawc/auto-mobile/issues/2275))
+
 ## [v0.0.30] - 2026-05-20
 ### Other
 - Remove tapClickableParent from tapOn schema — redundant with auto-escalation ([#2248](https://github.com/kaeawc/auto-mobile/issues/2248))

--- a/android/control-proxy/build.gradle.kts
+++ b/android/control-proxy/build.gradle.kts
@@ -36,7 +36,7 @@ android {
     minSdk = libs.versions.build.android.minSdk.get().toInt()
     targetSdk = libs.versions.build.android.targetSdk.get().toInt()
     versionCode = 1
-    versionName = "0.0.30-SNAPSHOT"
+    versionName = "0.0.31-SNAPSHOT"
 
     testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
   }

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -140,7 +140,7 @@ org.jetbrains.dokka.experimental.gradle.pluginMode=V2Enabled
 # Maven Central Publishing
 
 # Library versions (single source of truth)
-VERSION_NAME=0.0.30-SNAPSHOT
+VERSION_NAME=0.0.31-SNAPSHOT
 GROUP=dev.jasonpearson.auto-mobile
 
 # POM metadata

--- a/android/playground/app/build.gradle.kts
+++ b/android/playground/app/build.gradle.kts
@@ -36,7 +36,7 @@ android {
     minSdk = libs.versions.build.android.minSdk.get().toInt()
     targetSdk = libs.versions.build.android.targetSdk.get().toInt()
     versionCode = 1
-    versionName = "0.0.30-SNAPSHOT"
+    versionName = "0.0.31-SNAPSHOT"
 
     testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kaeawc/auto-mobile",
-  "version": "0.0.30",
+  "version": "0.0.31",
   "description": "Mobile device interaction automation via MCP",
   "scripts": {
     "test": "bun test",

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "dev.jasonpearson/auto-mobile",
   "title": "AutoMobile",
   "description": "Mobile device interaction automation via MCP",
-  "version": "0.0.30",
+  "version": "0.0.31",
   "websiteUrl": "https://kaeawc.github.io/auto-mobile/",
   "repository": {
     "url": "https://github.com/kaeawc/auto-mobile",
@@ -13,7 +13,7 @@
     {
       "registryType": "npm",
       "identifier": "@kaeawc/auto-mobile",
-      "version": "0.0.30",
+      "version": "0.0.31",
       "runtimeHint": "bunx",
       "transport": {
         "type": "stdio"

--- a/src/constants/release.ts
+++ b/src/constants/release.ts
@@ -26,6 +26,11 @@ export interface ReleaseChecksumEntry {
  */
 export const RELEASE_CHECKSUM_REGISTRY: ReleaseChecksumEntry[] = [
   {
+    version: "0.0.31",
+    apkSha256: "0b5802ada8d9adccdb69ee140ae788b3251832c0605d2f6baa3e9b7a78260764",
+    ipaSha256: "e60f8689fb6ddd5c06a5d2ff57569b264f407229afb986258d1ce20326dc24c7",
+  },
+  {
     version: "0.0.30",
     apkSha256: "a1be5e6240f204ee99540e99cc198f7c0b592dbaf3699330c14f6ded7d333ec3",
     ipaSha256: "5ac285dd5be16439d3a8a8973c98606920461acfce489830e54ee20759a7b235",


### PR DESCRIPTION
## Summary
- Bump versions to v0.0.31
- Update CHANGELOG.md from closed issues since the last tag
- Refresh CtrlProxy APK SHA256 checksum
- Refresh CtrlProxy iOS IPA SHA256 checksum

## Automation
- Generated by `prepare-release` workflow