### PR TITLE
Gate performance audit behind debug perf

### DIFF
--- a/docs/design-docs/mcp/feature-flags.md
+++ b/docs/design-docs/mcp/feature-flags.md
@@ -12,7 +12,7 @@ present these flags can only be set on MCP startup as CLI args. The plan is to h
 
 **`--debug`** - Enable debug logging
 
-**`--debug-perf`** / **`--perf-debug`** - Enable performance debug output, including response performance audits
+**`--debug-perf`** - Enable performance debug output, including response performance audits
 
 ### Performance Flags
 

--- a/docs/design-docs/mcp/feature-flags.md
+++ b/docs/design-docs/mcp/feature-flags.md
@@ -12,13 +12,11 @@ present these flags can only be set on MCP startup as CLI args. The plan is to h
 
 **`--debug`** - Enable debug logging
 
-**`--debug-perf`** - Enable performance debug output
+**`--debug-perf`** / **`--perf-debug`** - Enable performance debug output, including response performance audits
 
 ### Performance Flags
 
 **`--ui-perf-mode`** - Enable UI performance monitoring
-
-**`--ui-perf-debug`** - Detailed performance logging
 
 **`--mem-perf-audit`** - Memory performance auditing
 

--- a/docs/design-docs/mcp/feature-flags.md
+++ b/docs/design-docs/mcp/feature-flags.md
@@ -12,7 +12,7 @@ present these flags can only be set on MCP startup as CLI args. The plan is to h
 
 **`--debug`** - Enable debug logging
 
-**`--debug-perf`** - Enable performance debug output, including response performance audits
+**`--debug-perf`** / **`--ui-perf-debug`** - Enable performance debug output, including response performance audits
 
 ### Performance Flags
 

--- a/src/daemon/daemon.ts
+++ b/src/daemon/daemon.ts
@@ -47,6 +47,7 @@ import { Timer, defaultTimer } from "../utils/SystemTimer";
 import { describeUnknownError } from "../utils/describeUnknownError";
 import { FeatureFlagService } from "../features/featureFlags/FeatureFlagService";
 import { serverConfig } from "../utils/ServerConfig";
+import { setDebugPerfEnabled } from "../utils/PerformanceTracker";
 
 const DEVICE_DISCONNECT_POLL_INTERVAL_MS = 5000;
 const DEVICE_DISCONNECT_MISS_THRESHOLD = 3;
@@ -109,6 +110,9 @@ export class Daemon {
     }
     if (options.dismissKeyboardAfterInput) {
       serverConfig.setDismissKeyboardAfterInputEnabled(true);
+    }
+    if (options.debugPerf) {
+      setDebugPerfEnabled(true);
     }
     if (options.noUiPerfMode) {
       serverConfig.setUiPerfMode(false);

--- a/src/daemon/manager.ts
+++ b/src/daemon/manager.ts
@@ -623,7 +623,7 @@ function parseDaemonArgs(args: string[]): DaemonOptions {
       i++;
     } else if (args[i] === "--debug") {
       options.debug = true;
-    } else if (args[i] === "--debug-perf" || args[i] === "--perf-debug") {
+    } else if (args[i] === "--debug-perf") {
       options.debugPerf = true;
     } else if (args[i] === "--plan-execution-lock-scope") {
       const scope = args[i + 1];

--- a/src/daemon/manager.ts
+++ b/src/daemon/manager.ts
@@ -623,7 +623,7 @@ function parseDaemonArgs(args: string[]): DaemonOptions {
       i++;
     } else if (args[i] === "--debug") {
       options.debug = true;
-    } else if (args[i] === "--debug-perf") {
+    } else if (args[i] === "--debug-perf" || args[i] === "--ui-perf-debug") {
       options.debugPerf = true;
     } else if (args[i] === "--plan-execution-lock-scope") {
       const scope = args[i + 1];

--- a/src/daemon/manager.ts
+++ b/src/daemon/manager.ts
@@ -623,7 +623,7 @@ function parseDaemonArgs(args: string[]): DaemonOptions {
       i++;
     } else if (args[i] === "--debug") {
       options.debug = true;
-    } else if (args[i] === "--debug-perf") {
+    } else if (args[i] === "--debug-perf" || args[i] === "--perf-debug") {
       options.debugPerf = true;
     } else if (args[i] === "--plan-execution-lock-scope") {
       const scope = args[i + 1];

--- a/src/features/observe/audits/PerformanceAuditor.ts
+++ b/src/features/observe/audits/PerformanceAuditor.ts
@@ -1,7 +1,7 @@
 import { logger } from "../../../utils/logger";
-import { serverConfig } from "../../../utils/ServerConfig";
 import { PerformanceAudit } from "../../performance/PerformanceAudit";
 import { ThresholdManager } from "../../performance/ThresholdManager";
+import { isPerformanceAuditEnabled } from "../../performance/performanceAuditConfig";
 import { DeviceCapabilitiesDetector } from "../../../utils/DeviceCapabilities";
 import type { BootedDevice, ObserveResult } from "../../../models";
 import { defaultAdbClientFactory, type AdbClientFactory } from "../../../utils/android-cmdline-tools/AdbClientFactory";
@@ -33,12 +33,11 @@ export class PerformanceAuditor {
   constructor(opts: PerformanceAuditorOptions) {
     this.device = opts.device;
     this.adbFactory = opts.adbFactory ?? defaultAdbClientFactory;
-    this.isEnabled = opts.isEnabled ?? (() => serverConfig.isUiPerfModeEnabled());
+    this.isEnabled = opts.isEnabled ?? isPerformanceAuditEnabled;
   }
 
   async run(result: ObserveResult, perf: PerformanceTracker): Promise<void> {
-    // Check if performance audit is enabled via CLI flag
-    // This will be replaced with global configuration in issue #67
+    // Check if performance audit is enabled via CLI/config/env gates.
     if (!this.isEnabled()) {
       return;
     }

--- a/src/features/performance/performanceAuditConfig.ts
+++ b/src/features/performance/performanceAuditConfig.ts
@@ -1,0 +1,15 @@
+import { serverConfig } from "../../utils/ServerConfig";
+import { isDebugPerfEnabled } from "../../utils/PerformanceTracker";
+
+const DISABLE_PERF_AUDIT_ENV = "AUTOMOBILE_DISABLE_PERF_AUDIT";
+
+function parseEnvBoolean(value: string | undefined): boolean {
+  const normalized = value?.trim().toLowerCase();
+  return normalized === "1" || normalized === "true" || normalized === "yes";
+}
+
+export function isPerformanceAuditEnabled(): boolean {
+  return serverConfig.isUiPerfModeEnabled()
+    && isDebugPerfEnabled()
+    && !parseEnvBoolean(process.env[DISABLE_PERF_AUDIT_ENV]);
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -90,7 +90,9 @@ function parseArgs(): {
 
   // Detect debug-perf mode for performance timing and audit output
   const debugPerf =
-    args.includes("--debug-perf") || process.env.AUTOMOBILE_DEBUG_PERF === "1";
+    args.includes("--debug-perf") ||
+    args.includes("--ui-perf-debug") ||
+    process.env.AUTOMOBILE_DEBUG_PERF === "1";
 
   // Detect debug mode to enable debug tools (debugSearch, bugReport)
   const debug =
@@ -431,7 +433,7 @@ async function main() {
 
     const cliOverrides: Array<[FeatureFlagKey, boolean, string, Record<string, unknown> | null | undefined]> = [
       ["debug", debug, "--debug"],
-      ["debug-perf", debugPerf, "--debug-perf"],
+      ["debug-perf", debugPerf, "--debug-perf/--ui-perf-debug"],
       ["ui-perf-mode", uiPerfMode, "--ui-perf-mode"],
       ["mem-perf-audit", memPerfAuditMode, "--mem-perf-audit"],
       ["accessibility-audit", a11yAuditMode, "--accessibility-audit", accessibilityConfig],

--- a/src/index.ts
+++ b/src/index.ts
@@ -88,9 +88,11 @@ function parseArgs(): {
   const daemonArgs =
     daemonCommandIndex >= 0 ? args.slice(daemonCommandIndex + 2) : [];
 
-  // Detect debug-perf mode for performance timing output
+  // Detect debug-perf mode for performance timing and audit output
   const debugPerf =
-    args.includes("--debug-perf") || process.env.AUTOMOBILE_DEBUG_PERF === "1";
+    args.includes("--debug-perf") ||
+    args.includes("--perf-debug") ||
+    process.env.AUTOMOBILE_DEBUG_PERF === "1";
 
   // Detect debug mode to enable debug tools (debugSearch, bugReport)
   const debug =
@@ -431,7 +433,7 @@ async function main() {
 
     const cliOverrides: Array<[FeatureFlagKey, boolean, string, Record<string, unknown> | null | undefined]> = [
       ["debug", debug, "--debug"],
-      ["debug-perf", debugPerf, "--debug-perf"],
+      ["debug-perf", debugPerf, "--debug-perf/--perf-debug"],
       ["ui-perf-mode", uiPerfMode, "--ui-perf-mode"],
       ["mem-perf-audit", memPerfAuditMode, "--mem-perf-audit"],
       ["accessibility-audit", a11yAuditMode, "--accessibility-audit", accessibilityConfig],

--- a/src/index.ts
+++ b/src/index.ts
@@ -90,9 +90,7 @@ function parseArgs(): {
 
   // Detect debug-perf mode for performance timing and audit output
   const debugPerf =
-    args.includes("--debug-perf") ||
-    args.includes("--perf-debug") ||
-    process.env.AUTOMOBILE_DEBUG_PERF === "1";
+    args.includes("--debug-perf") || process.env.AUTOMOBILE_DEBUG_PERF === "1";
 
   // Detect debug mode to enable debug tools (debugSearch, bugReport)
   const debug =
@@ -433,7 +431,7 @@ async function main() {
 
     const cliOverrides: Array<[FeatureFlagKey, boolean, string, Record<string, unknown> | null | undefined]> = [
       ["debug", debug, "--debug"],
-      ["debug-perf", debugPerf, "--debug-perf/--perf-debug"],
+      ["debug-perf", debugPerf, "--debug-perf"],
       ["ui-perf-mode", uiPerfMode, "--ui-perf-mode"],
       ["mem-perf-audit", memPerfAuditMode, "--mem-perf-audit"],
       ["accessibility-audit", a11yAuditMode, "--accessibility-audit", accessibilityConfig],

--- a/src/models/ObserveResult.ts
+++ b/src/models/ObserveResult.ts
@@ -170,7 +170,7 @@ export interface ObserveResult {
   displayedTimeMetrics?: DisplayedTimeMetric[];
 
   /**
-   * Performance audit results (only present when --debug-perf/--perf-debug is enabled)
+   * Performance audit results (only present when --debug-perf is enabled)
    * Contains validation against thresholds and detailed diagnostics
    */
   performanceAudit?: PerformanceAuditResult;

--- a/src/models/ObserveResult.ts
+++ b/src/models/ObserveResult.ts
@@ -170,7 +170,7 @@ export interface ObserveResult {
   displayedTimeMetrics?: DisplayedTimeMetric[];
 
   /**
-   * Performance audit results (only present when --debug-perf is enabled)
+   * Performance audit results (only present when --debug-perf/--ui-perf-debug is enabled)
    * Contains validation against thresholds and detailed diagnostics
    */
   performanceAudit?: PerformanceAuditResult;

--- a/src/models/ObserveResult.ts
+++ b/src/models/ObserveResult.ts
@@ -170,7 +170,7 @@ export interface ObserveResult {
   displayedTimeMetrics?: DisplayedTimeMetric[];
 
   /**
-   * Performance audit results (when UI performance audit mode is enabled)
+   * Performance audit results (only present when --debug-perf/--perf-debug is enabled)
    * Contains validation against thresholds and detailed diagnostics
    */
   performanceAudit?: PerformanceAuditResult;

--- a/test/daemon/daemonDebugPerf.test.ts
+++ b/test/daemon/daemonDebugPerf.test.ts
@@ -1,10 +1,18 @@
 import { afterEach, describe, expect, test } from "bun:test";
 import { Daemon } from "../../src/daemon/daemon";
+import { DaemonState } from "../../src/daemon/daemonState";
 import { isDebugPerfEnabled, setDebugPerfEnabled } from "../../src/utils/PerformanceTracker";
 
 describe("Daemon debug perf option", () => {
   afterEach(() => {
     setDebugPerfEnabled(false);
+    // Constructing a Daemon initializes the global DaemonState singleton.
+    // Reset it so this test does not leak initialized state into other test
+    // files (bun shares module/singleton state across files in a run, and file
+    // execution order is platform-dependent).
+    if (DaemonState.getInstance().isInitialized()) {
+      DaemonState.getInstance().reset();
+    }
   });
 
   test("applies debugPerf option to global performance tracking", () => {

--- a/test/daemon/daemonDebugPerf.test.ts
+++ b/test/daemon/daemonDebugPerf.test.ts
@@ -1,0 +1,17 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { Daemon } from "../../src/daemon/daemon";
+import { isDebugPerfEnabled, setDebugPerfEnabled } from "../../src/utils/PerformanceTracker";
+
+describe("Daemon debug perf option", () => {
+  afterEach(() => {
+    setDebugPerfEnabled(false);
+  });
+
+  test("applies debugPerf option to global performance tracking", () => {
+    setDebugPerfEnabled(false);
+
+    new Daemon({ debugPerf: true });
+
+    expect(isDebugPerfEnabled()).toBe(true);
+  });
+});

--- a/test/features/observe/audits/PerformanceAuditor.test.ts
+++ b/test/features/observe/audits/PerformanceAuditor.test.ts
@@ -1,7 +1,8 @@
-import { describe, expect, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { PerformanceAuditor } from "../../../../src/features/observe/audits/PerformanceAuditor";
 import { FakeAdbClientFactory } from "../../../fakes/FakeAdbClientFactory";
-import { NoOpPerformanceTracker } from "../../../../src/utils/PerformanceTracker";
+import { NoOpPerformanceTracker, setDebugPerfEnabled } from "../../../../src/utils/PerformanceTracker";
+import { serverConfig } from "../../../../src/utils/ServerConfig";
 import type { BootedDevice, ObserveResult } from "../../../../src/models";
 
 function makeResult(overrides: Partial<ObserveResult> = {}): ObserveResult {
@@ -17,6 +18,26 @@ const androidDevice: BootedDevice = { deviceId: "dev-1", name: "android", platfo
 const iosDevice: BootedDevice = { deviceId: "ios-1", name: "ios", platform: "ios" };
 
 describe("PerformanceAuditor", () => {
+  const originalDisablePerfAuditEnv = process.env.AUTOMOBILE_DISABLE_PERF_AUDIT;
+  let originalUiPerfMode: boolean;
+
+  beforeEach(() => {
+    originalUiPerfMode = serverConfig.isUiPerfModeEnabled();
+    serverConfig.setUiPerfMode(true);
+    setDebugPerfEnabled(false);
+    delete process.env.AUTOMOBILE_DISABLE_PERF_AUDIT;
+  });
+
+  afterEach(() => {
+    serverConfig.setUiPerfMode(originalUiPerfMode);
+    setDebugPerfEnabled(false);
+    if (originalDisablePerfAuditEnv === undefined) {
+      delete process.env.AUTOMOBILE_DISABLE_PERF_AUDIT;
+    } else {
+      process.env.AUTOMOBILE_DISABLE_PERF_AUDIT = originalDisablePerfAuditEnv;
+    }
+  });
+
   test("does nothing when isEnabled returns false", async () => {
     const auditor = new PerformanceAuditor({
       device: androidDevice,
@@ -27,6 +48,34 @@ describe("PerformanceAuditor", () => {
     await auditor.run(result, new NoOpPerformanceTracker());
     expect(result.performanceAudit).toBeUndefined();
     expect(result.errors).toBeUndefined();
+  });
+
+  test("skips when debug perf is not enabled", async () => {
+    const factory = new FakeAdbClientFactory();
+    const auditor = new PerformanceAuditor({
+      device: androidDevice,
+      adbFactory: factory,
+    });
+    const result = makeResult({ activeWindow: { appId: "com.example", activityName: "Main" } as any });
+    await auditor.run(result, new NoOpPerformanceTracker());
+    expect(result.performanceAudit).toBeUndefined();
+    expect(result.errors).toBeUndefined();
+    expect(factory.wasCalledForDevice(androidDevice.deviceId)).toBe(false);
+  });
+
+  test("skips when AUTOMOBILE_DISABLE_PERF_AUDIT is true", async () => {
+    setDebugPerfEnabled(true);
+    process.env.AUTOMOBILE_DISABLE_PERF_AUDIT = "true";
+    const factory = new FakeAdbClientFactory();
+    const auditor = new PerformanceAuditor({
+      device: androidDevice,
+      adbFactory: factory,
+    });
+    const result = makeResult({ activeWindow: { appId: "com.example", activityName: "Main" } as any });
+    await auditor.run(result, new NoOpPerformanceTracker());
+    expect(result.performanceAudit).toBeUndefined();
+    expect(result.errors).toBeUndefined();
+    expect(factory.wasCalledForDevice(androidDevice.deviceId)).toBe(false);
   });
 
   test("skips when device platform is not android", async () => {
@@ -54,6 +103,7 @@ describe("PerformanceAuditor", () => {
   });
 
   test("audit failures do not pollute result.errors", async () => {
+    setDebugPerfEnabled(true);
     const auditor = new PerformanceAuditor({
       device: androidDevice,
       adbFactory: new FakeAdbClientFactory(),
@@ -72,6 +122,7 @@ describe("PerformanceAuditor", () => {
   // Asserting the factory is invoked proves the auditor wires the factory
   // through rather than handing those constructors an AdbExecutor.
   test("uses the injected AdbClientFactory to construct dependents (regression for #2214)", async () => {
+    setDebugPerfEnabled(true);
     const factory = new FakeAdbClientFactory();
     const auditor = new PerformanceAuditor({
       device: androidDevice,

--- a/test/plan/planExecutorSessionRouting.test.ts
+++ b/test/plan/planExecutorSessionRouting.test.ts
@@ -10,6 +10,14 @@ describe("PlanExecutor - Session-based Device Routing", () => {
 
   beforeEach(() => {
     planExecutor = new DefaultPlanExecutor();
+    // Reset daemon state up front so these tests do not depend on cleanup from
+    // other test files. bun shares singleton state across files and file
+    // execution order is platform-dependent, so a prior file that constructs a
+    // Daemon can leave the global DaemonState initialized.
+    const daemonState = DaemonState.getInstance();
+    if (daemonState.isInitialized()) {
+      daemonState.reset();
+    }
   });
 
   afterEach(() => {


### PR DESCRIPTION
## Summary
- Gate response `performanceAudit` behind explicit perf debug mode (`--debug-perf`, `--perf-debug`, or `AUTOMOBILE_DEBUG_PERF=1`).
- Keep `AUTOMOBILE_DISABLE_PERF_AUDIT=true` as a hard opt-out.
- Update docs, result comments, and targeted auditor coverage.

## Validation
- `bun test test/features/observe/audits/PerformanceAuditor.test.ts`
- `./node_modules/.bin/eslint src/features/performance/performanceAuditConfig.ts src/features/observe/audits/PerformanceAuditor.ts src/index.ts src/daemon/manager.ts src/models/ObserveResult.ts test/features/observe/audits/PerformanceAuditor.test.ts`
- `bun run build`
