### PR TITLE
feat(daemon): device pool autolock with idle-timeout auto-release

### DIFF
--- a/src/daemon/devicePool.ts
+++ b/src/daemon/devicePool.ts
@@ -943,7 +943,12 @@ export class DevicePool {
     device.autolockSessionId = sessionId;
 
     const timeoutMs = getDevicePoolTimeoutMs();
-    await this.sessionManager.createSession(sessionId, deviceId, platform, timeoutMs);
+    // Autolock clients (CLI/agents) do not send heartbeats, so align the heartbeat
+    // timeout with the idle timeout. Otherwise the daemon's heartbeat watchdog
+    // (10s default) would reap the lock far sooner than the configured idle timeout.
+    // Interactions still bump lastHeartbeat, so an active client stays locked while
+    // a truly idle one is released after the idle timeout.
+    await this.sessionManager.createSession(sessionId, deviceId, platform, timeoutMs, timeoutMs);
     logger.info(`Autolocked device ${deviceId} with session ${sessionId} (timeout: ${timeoutMs}ms)`);
     return sessionId;
   }

--- a/src/daemon/devicePool.ts
+++ b/src/daemon/devicePool.ts
@@ -9,7 +9,7 @@ import type { InstalledAppsStore } from "../db/installedAppsRepository";
 import { InstalledAppsRepository } from "../db/installedAppsRepository";
 import { RetryExecutor, defaultRetryExecutor } from "../utils/retry/RetryExecutor";
 import { createGlobalPerformanceTracker } from "../utils/PerformanceTracker";
-import { DEVICE_POOL_AUTOLOCK_ENABLED, DEVICE_POOL_TIMEOUT_MS } from "./poolConfig";
+import { isDevicePoolAutolockEnabled, getDevicePoolTimeoutMs } from "./poolConfig";
 
 /**
  * Error class for device pool operations with retryability flag.
@@ -106,6 +106,11 @@ export class DevicePool {
     this.installedAppsRepository = installedAppsRepository ?? new InstalledAppsRepository();
     this.deviceManager = deviceManager;
     this.retryExecutor = retryExecutor;
+
+    // Free autolocked devices when their session expires (idle timeout auto-release).
+    this.sessionManager.onSessionRelease((sessionId, deviceId) => {
+      this.releaseAutolockedDevice(sessionId, deviceId);
+    });
   }
 
   /**
@@ -903,7 +908,7 @@ export class DevicePool {
    * @returns The generated session ID, or undefined if autolock is disabled
    */
   async autolockDevice(deviceId: string, platform: Platform): Promise<string | undefined> {
-    if (!DEVICE_POOL_AUTOLOCK_ENABLED) {
+    if (!isDevicePoolAutolockEnabled()) {
       return undefined;
     }
 
@@ -937,9 +942,62 @@ export class DevicePool {
     device.assignmentCount++;
     device.autolockSessionId = sessionId;
 
-    await this.sessionManager.createSession(sessionId, deviceId, platform, DEVICE_POOL_TIMEOUT_MS);
-    logger.info(`Autolocked device ${deviceId} with session ${sessionId} (timeout: ${DEVICE_POOL_TIMEOUT_MS}ms)`);
+    const timeoutMs = getDevicePoolTimeoutMs();
+    await this.sessionManager.createSession(sessionId, deviceId, platform, timeoutMs);
+    logger.info(`Autolocked device ${deviceId} with session ${sessionId} (timeout: ${timeoutMs}ms)`);
     return sessionId;
+  }
+
+  /**
+   * Free a device whose autolock session has been released or has expired.
+   *
+   * Invoked via the SessionManager release callback. Only acts on devices that
+   * were locked by the released session, so non-autolock sessions and devices
+   * that have since been re-locked by a different session are left untouched.
+   */
+  private releaseAutolockedDevice(sessionId: string, deviceId: string): void {
+    const device = this.devices.get(deviceId);
+    if (!device || device.autolockSessionId !== sessionId) {
+      return;
+    }
+
+    device.sessionId = null;
+    device.status = "idle";
+    device.errorCount = 0;
+    device.autolockSessionId = undefined;
+    this.lastReleasedDeviceId = deviceId;
+
+    logger.info(`Autolock idle timeout: released device ${deviceId} from session ${sessionId}`);
+  }
+
+  /**
+   * Assert that a session is permitted to interact with a device.
+   *
+   * When autolock is enabled and a device is locked to a session, only that
+   * session UUID may drive it. A mismatched or absent session UUID is rejected.
+   * No-op when autolock is disabled or the device is not locked.
+   */
+  assertAutolockAccess(deviceId: string, sessionUuid: string | undefined): void {
+    if (!isDevicePoolAutolockEnabled()) {
+      return;
+    }
+
+    const device = this.devices.get(deviceId);
+    if (!device || !device.autolockSessionId) {
+      return;
+    }
+
+    if (device.autolockSessionId !== sessionUuid) {
+      throw new ActionableError(
+        `Device '${deviceId}' is locked to another session.\n` +
+        `Autolock is enabled, so every tool call must include the sessionId ` +
+        `returned by 'startDevice' for this device.\n\n` +
+        `Options:\n` +
+        `  - Pass the sessionId from the 'startDevice' that locked this device\n` +
+        `  - Use 'startDevice' to lock a different available device\n` +
+        `  - Wait for the idle timeout to release this device`
+      );
+    }
   }
 
   /**

--- a/src/daemon/poolConfig.ts
+++ b/src/daemon/poolConfig.ts
@@ -18,26 +18,27 @@ export const DEVICE_POOL_MATCHING: MatchingStrategy =
 
 /**
  * Device pool autolock.
- * When set to "1", startDevice generates a UUID that must be used
- * for all subsequent interactions with the device.
+ * When enabled, startDevice generates a UUID that must be used
+ * for all subsequent interactions with the device, and the device is
+ * auto-released after an idle timeout. Read at call time so the daemon
+ * picks up env changes without a restart.
  */
-const autolockOverride =
-  process.env.AUTOMOBILE_DEVICE_POOL_AUTOLOCK ??
-  process.env.AUTO_MOBILE_DEVICE_POOL_AUTOLOCK;
-export const DEVICE_POOL_AUTOLOCK_ENABLED = autolockOverride === "1";
+export function isDevicePoolAutolockEnabled(): boolean {
+  const override =
+    process.env.AUTOMOBILE_DEVICE_POOL_AUTOLOCK ??
+    process.env.AUTO_MOBILE_DEVICE_POOL_AUTOLOCK;
+  return override === "1";
+}
 
 /**
  * Device pool idle timeout in milliseconds.
  * When autolock is enabled, a device is freed if no interaction
  * occurs within this duration. Default: 60 seconds.
  */
-const timeoutOverride =
-  process.env.AUTOMOBILE_DEVICE_POOL_TIMEOUT ??
-  process.env.AUTO_MOBILE_DEVICE_POOL_TIMEOUT;
-const parsedTimeout = timeoutOverride
-  ? Number.parseInt(timeoutOverride, 10)
-  : NaN;
-export const DEVICE_POOL_TIMEOUT_MS =
-  Number.isFinite(parsedTimeout) && parsedTimeout > 0
-    ? parsedTimeout * 1000
-    : 60_000;
+export function getDevicePoolTimeoutMs(): number {
+  const override =
+    process.env.AUTOMOBILE_DEVICE_POOL_TIMEOUT ??
+    process.env.AUTO_MOBILE_DEVICE_POOL_TIMEOUT;
+  const parsed = override ? Number.parseInt(override, 10) : NaN;
+  return Number.isFinite(parsed) && parsed > 0 ? parsed * 1000 : 60_000;
+}

--- a/src/daemon/sessionManager.ts
+++ b/src/daemon/sessionManager.ts
@@ -91,6 +91,7 @@ export class SessionManager {
     assignedDevice: string,
     platform: Platform,
     timeoutMs?: number,
+    heartbeatTimeoutMs?: number,
   ): Promise<Session> {
     if (this.sessions.has(sessionId)) {
       logger.warn(`Session ${sessionId} already exists, returning existing session`);
@@ -109,7 +110,7 @@ export class SessionManager {
       cacheData: {},
       lastHeartbeat: now,
       sessionTimeoutMs,
-      heartbeatTimeoutMs: SessionManager.DEFAULT_HEARTBEAT_TIMEOUT_MS,
+      heartbeatTimeoutMs: heartbeatTimeoutMs ?? SessionManager.DEFAULT_HEARTBEAT_TIMEOUT_MS,
       hasReceivedHeartbeat: false,
     };
 

--- a/src/server/deviceTools.ts
+++ b/src/server/deviceTools.ts
@@ -15,7 +15,8 @@ import { logger } from "../utils/logger";
 import { createPerformanceTracker } from "../utils/PerformanceTracker";
 import { platformSchema } from "./toolSchemaHelpers";
 import { DefaultDeviceMatcher, type DeviceMatcher } from "./deviceMatcher";
-import { DEVICE_POOL_MATCHING } from "../daemon/poolConfig";
+import { DEVICE_POOL_MATCHING, isDevicePoolAutolockEnabled } from "../daemon/poolConfig";
+import { DaemonState } from "../daemon/daemonState";
 
 // Schema definitions
 export const listDeviceImagesSchema = z.object({
@@ -387,9 +388,18 @@ export function registerDeviceTools() {
     await ctrlProxySetup(device, perf);
 
     // Always generate a session ID for consistent device interactions.
-    // When autolock is enabled, the session ID is enforced for all subsequent tool calls.
+    // When autolock is enabled, lock the device to a pool-issued session UUID that
+    // is enforced for all subsequent tool calls and auto-released after an idle timeout.
     // When disabled, AutoMobile assumes a single agent and the session ID is advisory.
-    const sessionId = randomUUID();
+    let sessionId: string | undefined;
+    if (isDevicePoolAutolockEnabled() && DaemonState.getInstance().isInitialized()) {
+      sessionId = await DaemonState.getInstance()
+        .getDevicePool()
+        .autolockDevice(device.deviceId, device.platform);
+    }
+    if (!sessionId) {
+      sessionId = randomUUID();
+    }
 
     perf.end();
     const timing = perf.getTimings();

--- a/src/server/toolRegistry.ts
+++ b/src/server/toolRegistry.ts
@@ -18,6 +18,7 @@ import { createToolExecutionContext, updateSessionCache } from "./ToolExecutionC
 import { AppCleanupService, DefaultAppCleanupService } from "./AppCleanupService";
 import { ToolCallRepository } from "../db/toolCallRepository";
 import { getDeviceLabelMap, releaseDeviceLabelSessions } from "./deviceLabelMapping";
+import { isDevicePoolAutolockEnabled } from "../daemon/poolConfig";
 import { isDebugModeEnabled } from "../utils/debug";
 import { defaultTimer, type Timer } from "../utils/SystemTimer";
 import { getMcpRecorder } from "./mcpRecordingManager";
@@ -297,6 +298,11 @@ class ToolRegistryClass {
         }
       } else {
         logger.info(`[ToolRegistry] ${name}: Skipping device resolution.`);
+      }
+
+      // Enforce autolock: a locked device may only be driven by the session that locked it.
+      if (device && isDevicePoolAutolockEnabled() && DaemonState.getInstance().isInitialized()) {
+        DaemonState.getInstance().getDevicePool().assertAutolockAccess(device.deviceId, sessionUuid);
       }
 
       // Bind session to device's CtrlProxyClient for multi-agent NavigationGraphManager isolation

--- a/test/daemon/devicePool.autolock.test.ts
+++ b/test/daemon/devicePool.autolock.test.ts
@@ -1,8 +1,24 @@
-import { describe, it, expect, beforeEach } from "bun:test";
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
 import { DevicePool } from "../../src/daemon/devicePool";
 import { SessionManager } from "../../src/daemon/sessionManager";
 import { FakeTimer } from "../fakes/FakeTimer";
 import { FakeDeviceUtils } from "../fakes/FakeDeviceUtils";
+import { ActionableError } from "../../src/models";
+
+const AUTOLOCK_ENV_KEYS = [
+  "AUTOMOBILE_DEVICE_POOL_AUTOLOCK",
+  "AUTO_MOBILE_DEVICE_POOL_AUTOLOCK",
+] as const;
+const TIMEOUT_ENV_KEYS = [
+  "AUTOMOBILE_DEVICE_POOL_TIMEOUT",
+  "AUTO_MOBILE_DEVICE_POOL_TIMEOUT",
+] as const;
+
+function clearAutolockEnv(): void {
+  for (const key of [...AUTOLOCK_ENV_KEYS, ...TIMEOUT_ENV_KEYS]) {
+    delete process.env[key];
+  }
+}
 
 describe("DevicePool autolock", () => {
   let pool: DevicePool;
@@ -11,6 +27,7 @@ describe("DevicePool autolock", () => {
   let fakeDeviceUtils: FakeDeviceUtils;
 
   beforeEach(() => {
+    clearAutolockEnv();
     timer = new FakeTimer();
     sessionManager = new SessionManager(timer);
     fakeDeviceUtils = new FakeDeviceUtils();
@@ -24,8 +41,12 @@ describe("DevicePool autolock", () => {
     );
   });
 
+  afterEach(() => {
+    clearAutolockEnv();
+  });
+
   it("autolockDevice returns undefined when autolock is disabled", async () => {
-    // DEVICE_POOL_AUTOLOCK_ENABLED defaults to false (no env var set)
+    // Autolock env not set -> disabled
     await pool.initializeWithDevices([
       { name: "Pixel 7", platform: "android", deviceId: "emulator-5554" },
     ]);
@@ -110,5 +131,159 @@ describe("DevicePool autolock", () => {
     // Would have expired without heartbeat
     timer.advanceTime(2000);
     expect(sessionManager.getSession("autolock-session")).not.toBeNull();
+  });
+
+  describe("when autolock is enabled", () => {
+    beforeEach(() => {
+      process.env.AUTOMOBILE_DEVICE_POOL_AUTOLOCK = "1";
+      // 60 second idle timeout
+      process.env.AUTOMOBILE_DEVICE_POOL_TIMEOUT = "60";
+    });
+
+    it("locks the device to a generated session UUID", async () => {
+      await pool.initializeWithDevices([
+        { name: "Pixel 7", platform: "android", deviceId: "emulator-5554" },
+      ]);
+
+      const sessionId = await pool.autolockDevice("emulator-5554", "android");
+
+      expect(sessionId).toBeDefined();
+      const device = pool.getDevice("emulator-5554")!;
+      expect(device.status).toBe("busy");
+      expect(device.sessionId).toBe(sessionId!);
+      expect(device.autolockSessionId).toBe(sessionId!);
+
+      // Session created with the configured idle timeout
+      const session = sessionManager.getSession(sessionId!);
+      expect(session).not.toBeNull();
+      expect(session!.assignedDevice).toBe("emulator-5554");
+      expect(session!.expiresAt).toBe(timer.now() + 60_000);
+    });
+
+    it("auto-releases the device after the idle timeout (periodic cleanup)", async () => {
+      await pool.initializeWithDevices([
+        { name: "Pixel 7", platform: "android", deviceId: "emulator-5554" },
+      ]);
+
+      const sessionId = await pool.autolockDevice("emulator-5554", "android");
+      expect(pool.getDevice("emulator-5554")!.status).toBe("busy");
+
+      // Advance past both the idle timeout (60s) and the cleanup interval (5 min),
+      // so the periodic cleanup fires and releases the expired session's device.
+      timer.advanceTime(6 * 60 * 1000);
+
+      const device = pool.getDevice("emulator-5554")!;
+      expect(device.status).toBe("idle");
+      expect(device.sessionId).toBeNull();
+      expect(device.autolockSessionId).toBeUndefined();
+      expect(sessionManager.getSession(sessionId!)).toBeNull();
+    });
+
+    it("auto-releases the device on lazy session expiry", async () => {
+      await pool.initializeWithDevices([
+        { name: "Pixel 7", platform: "android", deviceId: "emulator-5554" },
+      ]);
+
+      const sessionId = await pool.autolockDevice("emulator-5554", "android");
+
+      // Past the 60s timeout but before the 5-min cleanup interval.
+      timer.advanceTime(61 * 1000);
+
+      // Touching the expired session lazily expires it and fires the release callback.
+      expect(sessionManager.getSession(sessionId!)).toBeNull();
+
+      const device = pool.getDevice("emulator-5554")!;
+      expect(device.status).toBe("idle");
+      expect(device.autolockSessionId).toBeUndefined();
+    });
+
+    it("heartbeat before the idle timeout keeps the device locked", async () => {
+      await pool.initializeWithDevices([
+        { name: "Pixel 7", platform: "android", deviceId: "emulator-5554" },
+      ]);
+
+      const sessionId = await pool.autolockDevice("emulator-5554", "android");
+
+      // Just before timeout, record activity.
+      timer.advanceTime(59 * 1000);
+      sessionManager.recordHeartbeat(sessionId!);
+
+      // Another window passes; without the heartbeat this would have expired.
+      timer.advanceTime(30 * 1000);
+
+      expect(sessionManager.getSession(sessionId!)).not.toBeNull();
+      expect(pool.getDevice("emulator-5554")!.status).toBe("busy");
+    });
+
+    it("does not release a device re-locked by a different session", async () => {
+      await pool.initializeWithDevices([
+        { name: "Pixel 7", platform: "android", deviceId: "emulator-5554" },
+      ]);
+
+      const firstSession = await pool.autolockDevice("emulator-5554", "android");
+      // Simulate the device being re-locked under a new session before the old
+      // session's release callback fires.
+      const device = pool.getDevice("emulator-5554")!;
+      device.autolockSessionId = "new-session";
+      device.sessionId = "new-session";
+      device.status = "busy";
+
+      // Expire the original session.
+      timer.advanceTime(61 * 1000);
+      expect(sessionManager.getSession(firstSession!)).toBeNull();
+
+      // The stale release for the first session must not free the re-locked device.
+      const after = pool.getDevice("emulator-5554")!;
+      expect(after.status).toBe("busy");
+      expect(after.autolockSessionId).toBe("new-session");
+    });
+
+    describe("assertAutolockAccess", () => {
+      beforeEach(async () => {
+        await pool.initializeWithDevices([
+          { name: "Pixel 7", platform: "android", deviceId: "emulator-5554" },
+        ]);
+      });
+
+      it("allows the owning session", async () => {
+        const sessionId = await pool.autolockDevice("emulator-5554", "android");
+        expect(() => pool.assertAutolockAccess("emulator-5554", sessionId)).not.toThrow();
+      });
+
+      it("rejects a different session", async () => {
+        await pool.autolockDevice("emulator-5554", "android");
+        expect(() => pool.assertAutolockAccess("emulator-5554", "other-session")).toThrow(
+          ActionableError,
+        );
+      });
+
+      it("rejects an absent session", async () => {
+        await pool.autolockDevice("emulator-5554", "android");
+        expect(() => pool.assertAutolockAccess("emulator-5554", undefined)).toThrow(
+          ActionableError,
+        );
+      });
+
+      it("no-ops when the device is not locked", () => {
+        expect(() => pool.assertAutolockAccess("emulator-5554", "any-session")).not.toThrow();
+      });
+
+      it("no-ops for an unknown device", () => {
+        expect(() => pool.assertAutolockAccess("does-not-exist", undefined)).not.toThrow();
+      });
+    });
+  });
+
+  it("assertAutolockAccess no-ops when autolock is disabled even if a device is locked", async () => {
+    // Lock a device while enabled...
+    process.env.AUTOMOBILE_DEVICE_POOL_AUTOLOCK = "1";
+    await pool.initializeWithDevices([
+      { name: "Pixel 7", platform: "android", deviceId: "emulator-5554" },
+    ]);
+    await pool.autolockDevice("emulator-5554", "android");
+
+    // ...then disable autolock: enforcement is bypassed.
+    clearAutolockEnv();
+    expect(() => pool.assertAutolockAccess("emulator-5554", "mismatched")).not.toThrow();
   });
 });

--- a/test/daemon/devicePool.autolock.test.ts
+++ b/test/daemon/devicePool.autolock.test.ts
@@ -160,6 +160,57 @@ describe("DevicePool autolock", () => {
       expect(session!.expiresAt).toBe(timer.now() + 60_000);
     });
 
+    it("aligns the session heartbeat timeout with the idle timeout", async () => {
+      // The daemon heartbeat watchdog reaps sessions whose heartbeat is stale.
+      // Autolock clients do not send heartbeats, so the heartbeat timeout must
+      // match the idle timeout or the device would be released far too early.
+      await pool.initializeWithDevices([
+        { name: "Pixel 7", platform: "android", deviceId: "emulator-5554" },
+      ]);
+
+      const sessionId = await pool.autolockDevice("emulator-5554", "android");
+      const session = sessionManager.getSession(sessionId!);
+
+      expect(session!.heartbeatTimeoutMs).toBe(60_000);
+      // Not the default 10s heartbeat window that would reap a non-heartbeating client.
+      expect(session!.heartbeatTimeoutMs).not.toBe(SessionManager.DEFAULT_HEARTBEAT_TIMEOUT_MS);
+    });
+
+    it("survives the daemon heartbeat watchdog until the idle timeout", async () => {
+      // Mirrors the reaping predicate in daemon.ts startHeartbeatMonitor():
+      //   after the initial grace, a session is cancelled when
+      //   now - lastHeartbeat > heartbeatTimeoutMs (and it has no active executions).
+      const INITIAL_HEARTBEAT_GRACE_MS = 20_000;
+      const wouldReap = (createdAt: number, lastHeartbeat: number, heartbeatTimeoutMs: number, now: number, hasReceivedHeartbeat: boolean): boolean => {
+        if (!hasReceivedHeartbeat && now - createdAt < INITIAL_HEARTBEAT_GRACE_MS) {
+          return false;
+        }
+        return now - lastHeartbeat > heartbeatTimeoutMs;
+      };
+
+      await pool.initializeWithDevices([
+        { name: "Pixel 7", platform: "android", deviceId: "emulator-5554" },
+      ]);
+
+      const sessionId = await pool.autolockDevice("emulator-5554", "android");
+      const session = sessionManager.getSession(sessionId!)!;
+
+      // With the OLD 10s heartbeat timeout the watchdog would have reaped this at ~20s.
+      expect(
+        wouldReap(session.createdAt, session.lastHeartbeat, SessionManager.DEFAULT_HEARTBEAT_TIMEOUT_MS, 20_000, false)
+      ).toBe(true);
+
+      // With the aligned timeout it survives the grace + well past the old window...
+      expect(
+        wouldReap(session.createdAt, session.lastHeartbeat, session.heartbeatTimeoutMs, 30_000, false)
+      ).toBe(false);
+
+      // ...and is only reaped once the idle timeout elapses with no activity.
+      expect(
+        wouldReap(session.createdAt, session.lastHeartbeat, session.heartbeatTimeoutMs, 60_001, false)
+      ).toBe(true);
+    });
+
     it("auto-releases the device after the idle timeout (periodic cleanup)", async () => {
       await pool.initializeWithDevices([
         { name: "Pixel 7", platform: "android", deviceId: "emulator-5554" },

--- a/test/daemon/poolConfig.test.ts
+++ b/test/daemon/poolConfig.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import { isDevicePoolAutolockEnabled, getDevicePoolTimeoutMs } from "../../src/daemon/poolConfig";
+
+const ENV_KEYS = [
+  "AUTOMOBILE_DEVICE_POOL_AUTOLOCK",
+  "AUTO_MOBILE_DEVICE_POOL_AUTOLOCK",
+  "AUTOMOBILE_DEVICE_POOL_TIMEOUT",
+  "AUTO_MOBILE_DEVICE_POOL_TIMEOUT",
+] as const;
+
+function clearEnv(): void {
+  for (const key of ENV_KEYS) {
+    delete process.env[key];
+  }
+}
+
+describe("poolConfig autolock", () => {
+  beforeEach(clearEnv);
+  afterEach(clearEnv);
+
+  it("isDevicePoolAutolockEnabled defaults to false", () => {
+    expect(isDevicePoolAutolockEnabled()).toBe(false);
+  });
+
+  it("isDevicePoolAutolockEnabled is true only for '1'", () => {
+    process.env.AUTOMOBILE_DEVICE_POOL_AUTOLOCK = "1";
+    expect(isDevicePoolAutolockEnabled()).toBe(true);
+
+    process.env.AUTOMOBILE_DEVICE_POOL_AUTOLOCK = "true";
+    expect(isDevicePoolAutolockEnabled()).toBe(false);
+
+    process.env.AUTOMOBILE_DEVICE_POOL_AUTOLOCK = "0";
+    expect(isDevicePoolAutolockEnabled()).toBe(false);
+  });
+
+  it("isDevicePoolAutolockEnabled honors the AUTO_MOBILE_ alias", () => {
+    process.env.AUTO_MOBILE_DEVICE_POOL_AUTOLOCK = "1";
+    expect(isDevicePoolAutolockEnabled()).toBe(true);
+  });
+
+  it("getDevicePoolTimeoutMs defaults to 60 seconds", () => {
+    expect(getDevicePoolTimeoutMs()).toBe(60_000);
+  });
+
+  it("getDevicePoolTimeoutMs converts seconds to milliseconds", () => {
+    process.env.AUTOMOBILE_DEVICE_POOL_TIMEOUT = "120";
+    expect(getDevicePoolTimeoutMs()).toBe(120_000);
+  });
+
+  it("getDevicePoolTimeoutMs ignores invalid or non-positive values", () => {
+    process.env.AUTOMOBILE_DEVICE_POOL_TIMEOUT = "not-a-number";
+    expect(getDevicePoolTimeoutMs()).toBe(60_000);
+
+    process.env.AUTOMOBILE_DEVICE_POOL_TIMEOUT = "0";
+    expect(getDevicePoolTimeoutMs()).toBe(60_000);
+
+    process.env.AUTOMOBILE_DEVICE_POOL_TIMEOUT = "-5";
+    expect(getDevicePoolTimeoutMs()).toBe(60_000);
+  });
+});


### PR DESCRIPTION
## Summary
Wires up the device pool **autolock** feature, which was previously defined but never invoked. When `AUTOMOBILE_DEVICE_POOL_AUTOLOCK=1`, `startDevice` locks the booted device to a pool-issued session UUID that must accompany every subsequent tool call, and the device is auto-released after an idle timeout.

- `startDevice` now acquires the session via `devicePool.autolockDevice()` when autolock is enabled (was a raw `randomUUID()` that bypassed locking entirely).
- `DevicePool` frees a device when its autolock session expires (idle timeout) via an `onSessionRelease` handler, guarded against stale/re-locked devices.
- `assertAutolockAccess` rejects tool calls that target a locked device with a mismatched/absent session UUID, enforced in the `registerDeviceAware` path.
- `poolConfig` flags read env at call time (`isDevicePoolAutolockEnabled` / `getDevicePoolTimeoutMs`) so the enabled path is testable.
- Autolock sessions set `heartbeatTimeoutMs` to the idle timeout, so the daemon heartbeat watchdog (10s default) does not reap a non-heartbeating CLI/agent client before the configured idle window.

All new behavior is gated behind the autolock flag (default off); the disabled path is unchanged.

## Test plan
- [x] `bun test test/daemon test/server` — 828 pass
- [x] `bunx turbo run lint build` — green
- [x] Exercised end-to-end against two real Android emulators via an isolated daemon: lock on `startDevice`, rejection of unauthorized `observe`, success with the correct session, and idle auto-release (confirmed in daemon logs)