### PR TITLE
fix(daemon): bump lastHeartbeat when resolving an existing session

### DIFF
--- a/src/daemon/sessionManager.ts
+++ b/src/daemon/sessionManager.ts
@@ -161,9 +161,14 @@ export class SessionManager {
     const existing = this.getSession(sessionId);
     if (existing) {
       logger.info(`[SessionManager] Found existing session ${sessionId} with device ${existing.assignedDevice}`);
-      // Update last used time
+      // Resolving a session for a tool call is activity: extend both the idle
+      // timeout (expiresAt) and the heartbeat clock (lastHeartbeat). Without the
+      // latter, the daemon heartbeat watchdog would reap an actively-used session
+      // whose tools never write session cache (e.g. autolock CLI/agent clients
+      // that do not send explicit heartbeats).
       const now = this.timer.now();
       existing.lastUsedAt = now;
+      existing.lastHeartbeat = now;
       existing.expiresAt = now + existing.sessionTimeoutMs;
       return existing;
     }

--- a/test/daemon/devicePool.autolock.test.ts
+++ b/test/daemon/devicePool.autolock.test.ts
@@ -211,6 +211,43 @@ describe("DevicePool autolock", () => {
       ).toBe(true);
     });
 
+    it("ongoing interaction keeps an autolocked device alive past the heartbeat window", async () => {
+      // Integration: a locked device driven through repeated session resolutions
+      // (createToolExecutionContext -> getOrCreateSession on every tool call) must
+      // not be reaped by the heartbeat watchdog, because each interaction bumps
+      // lastHeartbeat. Mirrors the daemon.ts startHeartbeatMonitor() predicate.
+      const INITIAL_HEARTBEAT_GRACE_MS = 20_000;
+      const reapableAt = (session: { createdAt: number; lastHeartbeat: number; heartbeatTimeoutMs: number; hasReceivedHeartbeat: boolean }, now: number): boolean => {
+        if (!session.hasReceivedHeartbeat && now - session.createdAt < INITIAL_HEARTBEAT_GRACE_MS) {
+          return false;
+        }
+        return now - session.lastHeartbeat > session.heartbeatTimeoutMs;
+      };
+
+      await pool.initializeWithDevices([
+        { name: "Pixel 7", platform: "android", deviceId: "emulator-5554" },
+      ]);
+
+      const sessionId = await pool.autolockDevice("emulator-5554", "android");
+
+      // Simulate a client interacting every 40s for 200s — each call exceeds the
+      // old 10s heartbeat window but is well within the 60s idle window.
+      for (let elapsed = 40_000; elapsed <= 200_000; elapsed += 40_000) {
+        timer.advanceTime(40_000);
+        await sessionManager.getOrCreateSession(sessionId!);
+        const live = sessionManager.getSession(sessionId!)!;
+        expect(reapableAt(live, timer.now())).toBe(false);
+      }
+
+      // Device is still locked after 200s of active use.
+      expect(pool.getDevice("emulator-5554")!.status).toBe("busy");
+
+      // Snapshot the live session, then stop interacting: once the heartbeat window
+      // elapses with no further activity, the watchdog predicate would reap it.
+      const snapshot = { ...sessionManager.getSession(sessionId!)! };
+      expect(reapableAt(snapshot, timer.now() + 61_000)).toBe(true);
+    });
+
     it("auto-releases the device after the idle timeout (periodic cleanup)", async () => {
       await pool.initializeWithDevices([
         { name: "Pixel 7", platform: "android", deviceId: "emulator-5554" },

--- a/test/daemon/sessionManager.test.ts
+++ b/test/daemon/sessionManager.test.ts
@@ -66,6 +66,21 @@ describe("SessionManager", () => {
       expect(session2.expiresAt).toBe(initialExpiry + 10);
     });
 
+    test("should bump lastHeartbeat when resolving an existing session", async () => {
+      // The daemon heartbeat watchdog reaps sessions on a stale lastHeartbeat.
+      // Resolving a session for a tool call must count as activity, otherwise an
+      // actively-used autolock client (which sends no explicit heartbeats) would
+      // be reaped mid-use.
+      const session1 = await sessionManager.createSession("session-1", "emulator-5554", "android", 60_000, 60_000);
+      const initialHeartbeat = session1.lastHeartbeat;
+      fakeTimer.advanceTime(30_000);
+
+      const session2 = await sessionManager.getOrCreateSession("session-1");
+
+      expect(session2.lastHeartbeat).toBe(initialHeartbeat + 30_000);
+      expect(session2.lastHeartbeat).toBe(fakeTimer.now());
+    });
+
     test("should preserve custom timeout when getting existing session", async () => {
       await sessionManager.createSession("session-1", "emulator-5554", "android", 5000);
       fakeTimer.advanceTime(4000);


### PR DESCRIPTION
## Summary
Follow-up to the device pool autolock feature (#2324).

The daemon heartbeat watchdog reaps sessions whose `lastHeartbeat` is stale, but `getOrCreateSession` only extended `lastUsedAt`/`expiresAt` — not `lastHeartbeat`. An actively-interacting **autolock** client (which sends no explicit heartbeats, and whose tools may not write session cache) could therefore be reaped mid-use once its heartbeat clock went stale, releasing a device that was still in use.

- Resolving an existing session for a tool call now also bumps `lastHeartbeat`, so the watchdog correctly sees ongoing activity.

## Test plan
- [x] Unit: `lastHeartbeat` advances when `getOrCreateSession` resolves an existing session
- [x] Integration: a locked device driven through repeated session resolutions stays locked past the old 10s heartbeat window, and is reapable only once it goes idle
- [x] `bun test test/daemon test/server` — 830 pass
- [x] eslint clean on changed files