### PR TITLE
test(daemon): extract + harden session heartbeat monitor (prompt idle release)

### DIFF
--- a/src/daemon/SessionHeartbeatMonitor.ts
+++ b/src/daemon/SessionHeartbeatMonitor.ts
@@ -1,0 +1,100 @@
+import { Timer, defaultTimer } from "../utils/SystemTimer";
+import { logger } from "../utils/logger";
+import { SessionManager, type Session } from "./sessionManager";
+
+/**
+ * Minimal view of the session store the heartbeat monitor needs.
+ */
+export interface HeartbeatSessionSource {
+  getAllSessions(): Session[];
+  /** Remove expired sessions and fire their release callbacks. */
+  cleanupExpiredSessions(): void;
+}
+
+export interface SessionHeartbeatMonitorConfig {
+  /** How often to scan for stale sessions. Default: 10s. */
+  checkIntervalMs?: number;
+  /** Grace period before a session that never sent a heartbeat is eligible. Default: 20s. */
+  graceMs?: number;
+}
+
+/**
+ * Session Heartbeat Monitor
+ *
+ * Periodically cancels sessions whose heartbeat has gone stale, freeing their
+ * devices. A session is reaped when, after the initial grace period and with no
+ * active executions, `now - lastHeartbeat` exceeds the session's heartbeat
+ * timeout.
+ *
+ * Extracted from the daemon so the reaping logic can be driven deterministically
+ * with an injected timer in tests. Behaviour is unchanged in production, where
+ * the daemon passes its default timer.
+ */
+export class SessionHeartbeatMonitor {
+  private timerHandle: NodeJS.Timeout | null = null;
+  private readonly checkIntervalMs: number;
+  private readonly graceMs: number;
+
+  constructor(
+    private readonly sessions: HeartbeatSessionSource,
+    private readonly hasActiveExecutions: (sessionId: string) => boolean,
+    private readonly reap: (sessionId: string) => Promise<void>,
+    private readonly timer: Timer = defaultTimer,
+    config: SessionHeartbeatMonitorConfig = {},
+  ) {
+    this.checkIntervalMs = config.checkIntervalMs ?? 10_000;
+    this.graceMs = config.graceMs ?? 20_000;
+  }
+
+  start(): void {
+    if (this.timerHandle) {
+      return;
+    }
+    this.timerHandle = this.timer.setInterval(() => {
+      void this.tick();
+    }, this.checkIntervalMs);
+
+    // Allow the process to exit even if the monitor is running.
+    const handle = this.timerHandle as { unref?: () => void };
+    if (handle && typeof handle.unref === "function") {
+      handle.unref();
+    }
+  }
+
+  stop(): void {
+    if (this.timerHandle) {
+      this.timer.clearInterval(this.timerHandle);
+      this.timerHandle = null;
+    }
+  }
+
+  /**
+   * Scan sessions once and reap any whose heartbeat has gone stale.
+   * Exposed for deterministic testing; also invoked on each interval tick.
+   */
+  async tick(): Promise<void> {
+    const now = this.timer.now();
+
+    // Release idle/expired sessions promptly (e.g. autolocked devices whose idle
+    // timeout has elapsed). Their idle timeout equals their heartbeat timeout, so
+    // they expire out of getAllSessions() exactly when they would become stale —
+    // sweeping here gives them the monitor's interval granularity instead of the
+    // 5-minute cleanup sweep.
+    this.sessions.cleanupExpiredSessions();
+
+    for (const session of this.sessions.getAllSessions()) {
+      if (!session.hasReceivedHeartbeat && now - session.createdAt < this.graceMs) {
+        continue;
+      }
+      if (this.hasActiveExecutions(session.sessionId)) {
+        continue;
+      }
+      const timeoutMs = session.heartbeatTimeoutMs ?? SessionManager.DEFAULT_HEARTBEAT_TIMEOUT_MS;
+      const lastHeartbeat = session.lastHeartbeat ?? session.lastUsedAt;
+      if (now - lastHeartbeat > timeoutMs) {
+        logger.warn(`Session ${session.sessionId} heartbeat timeout, cancelling`);
+        await this.reap(session.sessionId);
+      }
+    }
+  }
+}

--- a/src/daemon/daemon.ts
+++ b/src/daemon/daemon.ts
@@ -6,6 +6,7 @@ import { logger } from "../utils/logger";
 import { MultiPlatformDeviceManager } from "../utils/deviceUtils";
 import { UnixSocketServer } from "./socketServer";
 import { SessionManager } from "./sessionManager";
+import { SessionHeartbeatMonitor } from "./SessionHeartbeatMonitor";
 import { DevicePool } from "./devicePool";
 import { DaemonState } from "./daemonState";
 import {
@@ -69,7 +70,7 @@ export class Daemon {
   private host: string;
   private debug: boolean;
   private healthCheckTimer: NodeJS.Timeout | null = null;
-  private heartbeatMonitorTimer: NodeJS.Timeout | null = null;
+  private heartbeatMonitor: SessionHeartbeatMonitor | null = null;
   private deviceDisconnectTimer: NodeJS.Timeout | null = null;
   private deviceDisconnectMisses: Map<string, number> = new Map();
   private stoppingRecordings: Set<string> = new Set();
@@ -753,30 +754,13 @@ export class Daemon {
    * Start periodic heartbeat checks to cancel stale sessions
    */
   private startHeartbeatMonitor(): void {
-    const HEARTBEAT_CHECK_INTERVAL_MS = 10000;
-    const INITIAL_HEARTBEAT_GRACE_MS = 20_000;
-
-    this.heartbeatMonitorTimer = defaultTimer.setInterval(async () => {
-      const now = this.timer.now();
-      const sessions = this.sessionManager.getAllSessions();
-
-      for (const session of sessions) {
-        if (!session.hasReceivedHeartbeat && now - session.createdAt < INITIAL_HEARTBEAT_GRACE_MS) {
-          continue;
-        }
-        if (executionTracker.hasActiveSessionUuidExecutions(session.sessionId)) {
-          continue;
-        }
-        const timeoutMs = session.heartbeatTimeoutMs ?? SessionManager.DEFAULT_HEARTBEAT_TIMEOUT_MS;
-        const lastHeartbeat = session.lastHeartbeat ?? session.lastUsedAt;
-        if (now - lastHeartbeat > timeoutMs) {
-          logger.warn(`Session ${session.sessionId} heartbeat timeout, cancelling`);
-          await this.cancelAndReleaseSession(session.sessionId);
-        }
-      }
-    }, HEARTBEAT_CHECK_INTERVAL_MS);
-
-    this.heartbeatMonitorTimer.unref();
+    this.heartbeatMonitor = new SessionHeartbeatMonitor(
+      this.sessionManager,
+      sessionId => executionTracker.hasActiveSessionUuidExecutions(sessionId),
+      sessionId => this.cancelAndReleaseSession(sessionId),
+      this.timer,
+    );
+    this.heartbeatMonitor.start();
   }
 
   private startDeviceDisconnectMonitor(): void {
@@ -1069,9 +1053,9 @@ export class Daemon {
       clearInterval(this.healthCheckTimer);
       this.healthCheckTimer = null;
     }
-    if (this.heartbeatMonitorTimer) {
-      clearInterval(this.heartbeatMonitorTimer);
-      this.heartbeatMonitorTimer = null;
+    if (this.heartbeatMonitor) {
+      this.heartbeatMonitor.stop();
+      this.heartbeatMonitor = null;
     }
     if (this.deviceDisconnectTimer) {
       clearInterval(this.deviceDisconnectTimer);

--- a/src/daemon/sessionManager.ts
+++ b/src/daemon/sessionManager.ts
@@ -390,40 +390,54 @@ export class SessionManager {
   }
 
   /**
+   * Remove all expired sessions and fire release callbacks for them.
+   *
+   * Runs on the periodic cleanup timer, but is also invoked by the heartbeat
+   * monitor on its (much shorter) interval so that idle sessions — including
+   * autolocked devices, whose idle timeout equals their heartbeat timeout — are
+   * released promptly instead of waiting for the next 5-minute sweep.
+   */
+  cleanupExpiredSessions(): void {
+    const expiredSessions: string[] = [];
+
+    for (const [sessionId, session] of this.sessions) {
+      if (this.isSessionExpired(session)) {
+        expiredSessions.push(sessionId);
+      }
+    }
+
+    if (expiredSessions.length === 0) {
+      return;
+    }
+
+    logger.info(
+      `Cleaning up ${expiredSessions.length} expired sessions: ` +
+      expiredSessions.join(", ")
+    );
+
+    for (const sessionId of expiredSessions) {
+      const session = this.sessions.get(sessionId);
+      const deviceId = session?.assignedDevice;
+      this.removeSession(sessionId);
+      // Notify release callbacks so session-scoped state is cleaned up
+      if (deviceId) {
+        for (const callback of this.releaseCallbacks) {
+          try {
+            callback(sessionId, deviceId);
+          } catch (error) {
+            logger.warn(`Session cleanup callback failed for ${sessionId}: ${error}`);
+          }
+        }
+      }
+    }
+  }
+
+  /**
    * Start periodic cleanup of expired sessions
    */
   private startCleanupTimer(): void {
     this.cleanupTimer = this.timer.setInterval(() => {
-      const expiredSessions: string[] = [];
-
-      for (const [sessionId, session] of this.sessions) {
-        if (this.isSessionExpired(session)) {
-          expiredSessions.push(sessionId);
-        }
-      }
-
-      if (expiredSessions.length > 0) {
-        logger.info(
-          `Cleaning up ${expiredSessions.length} expired sessions: ` +
-          expiredSessions.join(", ")
-        );
-
-        for (const sessionId of expiredSessions) {
-          const session = this.sessions.get(sessionId);
-          const deviceId = session?.assignedDevice;
-          this.removeSession(sessionId);
-          // Notify release callbacks so session-scoped state is cleaned up
-          if (deviceId) {
-            for (const callback of this.releaseCallbacks) {
-              try {
-                callback(sessionId, deviceId);
-              } catch (error) {
-                logger.warn(`Session cleanup callback failed for ${sessionId}: ${error}`);
-              }
-            }
-          }
-        }
-      }
+      this.cleanupExpiredSessions();
     }, this.CLEANUP_INTERVAL_MS);
 
     // Allow process to exit even if timer is running

--- a/test/daemon/SessionHeartbeatMonitor.test.ts
+++ b/test/daemon/SessionHeartbeatMonitor.test.ts
@@ -1,0 +1,177 @@
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import { SessionHeartbeatMonitor } from "../../src/daemon/SessionHeartbeatMonitor";
+import { SessionManager } from "../../src/daemon/sessionManager";
+import { DevicePool } from "../../src/daemon/devicePool";
+import { FakeTimer } from "../fakes/FakeTimer";
+import { FakeDeviceUtils } from "../fakes/FakeDeviceUtils";
+
+const AUTOLOCK_ENV_KEYS = [
+  "AUTOMOBILE_DEVICE_POOL_AUTOLOCK",
+  "AUTO_MOBILE_DEVICE_POOL_AUTOLOCK",
+  "AUTOMOBILE_DEVICE_POOL_TIMEOUT",
+  "AUTO_MOBILE_DEVICE_POOL_TIMEOUT",
+] as const;
+
+function clearAutolockEnv(): void {
+  for (const key of AUTOLOCK_ENV_KEYS) {
+    delete process.env[key];
+  }
+}
+
+describe("SessionHeartbeatMonitor", () => {
+  let timer: FakeTimer;
+  let sessionManager: SessionManager;
+
+  beforeEach(() => {
+    clearAutolockEnv();
+    timer = new FakeTimer();
+    sessionManager = new SessionManager(timer);
+  });
+
+  afterEach(() => {
+    sessionManager.stopCleanupTimer();
+    clearAutolockEnv();
+  });
+
+  describe("scheduling", () => {
+    it("start registers an interval and stop clears it", () => {
+      const before = timer.getPendingIntervalCount();
+      const monitor = new SessionHeartbeatMonitor(sessionManager, () => false, async () => {}, timer);
+
+      monitor.start();
+      expect(timer.getPendingIntervalCount()).toBe(before + 1);
+
+      // Idempotent start
+      monitor.start();
+      expect(timer.getPendingIntervalCount()).toBe(before + 1);
+
+      monitor.stop();
+      expect(timer.getPendingIntervalCount()).toBe(before);
+    });
+
+    it("reaps on each interval tick", async () => {
+      await sessionManager.createSession("s1", "emulator-5554", "android", 60_000, 10_000);
+      const reaped: string[] = [];
+      const monitor = new SessionHeartbeatMonitor(
+        sessionManager,
+        () => false,
+        async sid => { reaped.push(sid); },
+        timer,
+      );
+      monitor.start();
+
+      // Within grace: interval fires but nothing is reaped.
+      timer.advanceTime(10_000);
+      expect(reaped).toEqual([]);
+
+      // Past grace (20s) and past the 10s heartbeat window with no activity: reaped.
+      timer.advanceTime(20_000);
+      await Promise.resolve();
+      expect(reaped).toEqual(["s1"]);
+
+      monitor.stop();
+    });
+  });
+
+  describe("tick reaping decision", () => {
+    it("does not reap a session still within the initial grace period", async () => {
+      await sessionManager.createSession("s1", "emulator-5554", "android", 60_000, 10_000);
+      const reaped: string[] = [];
+      const monitor = new SessionHeartbeatMonitor(sessionManager, () => false, async sid => { reaped.push(sid); }, timer);
+
+      timer.advanceTime(15_000); // < 20s grace, no heartbeat yet
+      await monitor.tick();
+
+      expect(reaped).toEqual([]);
+    });
+
+    it("reaps a stale session after the grace period", async () => {
+      await sessionManager.createSession("s1", "emulator-5554", "android", 60_000, 10_000);
+      const reaped: string[] = [];
+      const monitor = new SessionHeartbeatMonitor(sessionManager, () => false, async sid => { reaped.push(sid); }, timer);
+
+      timer.advanceTime(31_000); // past grace and past the 10s heartbeat window
+      await monitor.tick();
+
+      expect(reaped).toEqual(["s1"]);
+    });
+
+    it("skips a session with active executions", async () => {
+      await sessionManager.createSession("s1", "emulator-5554", "android", 60_000, 10_000);
+      const reaped: string[] = [];
+      const monitor = new SessionHeartbeatMonitor(sessionManager, () => true, async sid => { reaped.push(sid); }, timer);
+
+      timer.advanceTime(31_000);
+      await monitor.tick();
+
+      expect(reaped).toEqual([]);
+    });
+
+    it("respects the session's heartbeat timeout (aligned to the idle timeout)", async () => {
+      // heartbeatTimeoutMs = 60s, so a quiet session is not reaped at 31s...
+      await sessionManager.createSession("s1", "emulator-5554", "android", 60_000, 60_000);
+      const reaped: string[] = [];
+      const monitor = new SessionHeartbeatMonitor(sessionManager, () => false, async sid => { reaped.push(sid); }, timer);
+
+      timer.advanceTime(31_000);
+      await monitor.tick();
+      expect(reaped).toEqual([]);
+    });
+  });
+
+  describe("integration with DevicePool autolock", () => {
+    let pool: DevicePool;
+
+    beforeEach(async () => {
+      process.env.AUTOMOBILE_DEVICE_POOL_AUTOLOCK = "1";
+      process.env.AUTOMOBILE_DEVICE_POOL_TIMEOUT = "60"; // 60s idle timeout
+      pool = new DevicePool(sessionManager, "daemon-test", timer, undefined, new FakeDeviceUtils());
+      await pool.initializeWithDevices([
+        { name: "Pixel 7", platform: "android", deviceId: "emulator-5554" },
+      ]);
+    });
+
+    // Mirrors daemon.ts cancelAndReleaseSession (minus execution cancellation).
+    const reapVia = (mgr: SessionManager, devicePool: DevicePool) => async (sid: string): Promise<void> => {
+      const deviceId = await mgr.releaseSession(sid);
+      if (deviceId) {
+        await devicePool.releaseDevice(deviceId);
+      }
+    };
+
+    it("releases an idle autolocked device promptly after the idle timeout", async () => {
+      const sessionId = await pool.autolockDevice("emulator-5554", "android");
+      expect(pool.getDevice("emulator-5554")!.status).toBe("busy");
+
+      const monitor = new SessionHeartbeatMonitor(sessionManager, () => false, reapVia(sessionManager, pool), timer);
+
+      // Just past grace but well within the 60s idle window: still locked.
+      timer.advanceTime(30_000);
+      await monitor.tick();
+      expect(pool.getDevice("emulator-5554")!.status).toBe("busy");
+
+      // Past the idle window with no activity: swept and released on the next tick
+      // (monitor interval granularity), not the 5-minute cleanup sweep.
+      timer.advanceTime(31_000);
+      await monitor.tick();
+
+      const device = pool.getDevice("emulator-5554")!;
+      expect(device.status).toBe("idle");
+      expect(device.autolockSessionId).toBeUndefined();
+      expect(sessionManager.getSession(sessionId!)).toBeNull();
+    });
+
+    it("keeps the device locked while it is being actively used", async () => {
+      const sessionId = await pool.autolockDevice("emulator-5554", "android");
+      const monitor = new SessionHeartbeatMonitor(sessionManager, () => false, reapVia(sessionManager, pool), timer);
+
+      // Interact every 40s (exceeds old 10s window, within 60s idle window).
+      for (let i = 0; i < 5; i++) {
+        timer.advanceTime(40_000);
+        await sessionManager.getOrCreateSession(sessionId!); // bumps lastHeartbeat
+        await monitor.tick();
+        expect(pool.getDevice("emulator-5554")!.status).toBe("busy");
+      }
+    });
+  });
+});


### PR DESCRIPTION
## Summary
Follow-up to the device pool autolock work (#2324, #2326). The user asked for an integration test of the heartbeat watchdog; writing it surfaced a responsiveness gap that this PR also fixes.

- **Extracted** the inline daemon heartbeat watchdog into an injectable `SessionHeartbeatMonitor` component so the reaping logic can be driven deterministically with a `FakeTimer`. Production behaviour is unchanged (the daemon passes its default timer).
- **Fix**: an autolocked session's idle timeout equals its heartbeat timeout, so it expires out of `getAllSessions()` at the exact moment it would become heartbeat-stale — the monitor never reaped it, and idle release fell to the 5-minute cleanup sweep. The monitor now also sweeps expired sessions on each (10s) tick via a new public `SessionManager.cleanupExpiredSessions()`, so idle autolocked devices are released at monitor-interval granularity.

## Test plan
- [x] Unit: reaping decision (grace period, heartbeat timeout, active-execution skip, aligned timeout) + start/stop scheduling
- [x] Integration (real `SessionManager` + `DevicePool`): idle autolocked device released promptly after the idle timeout; actively-used device stays locked across repeated interactions
- [x] `bun test test/daemon test/server` — 838 pass
- [x] eslint clean on changed files; `bun build.ts` green