### PR TITLE
feat(server): require sessionUuid under autolock when multiple devices exist

### DIFF
--- a/src/server/toolRegistry.ts
+++ b/src/server/toolRegistry.ts
@@ -250,6 +250,7 @@ class ToolRegistryClass {
 
       if (shouldResolveDevice) {
         await this.enforceSessionUuidForMultipleIos(platform, sessionUuid, providedDeviceId);
+        await this.enforceSessionUuidForAutolock(platform, sessionUuid, providedDeviceId);
       }
 
       // If session UUID provided, resolve device from session
@@ -564,6 +565,49 @@ class ToolRegistryClass {
 
     throw new ActionableError(
       "Multiple iOS simulators detected. Provide sessionUuid to target a specific simulator."
+    );
+  }
+
+  /**
+   * When device pool autolock is enabled, a tool call that does not name a target
+   * (no sessionUuid and no deviceId) must not be routed to an arbitrary device if
+   * more than one candidate exists — that would defeat the per-session device
+   * ownership autolock provides. Require the sessionUuid returned by startDevice.
+   *
+   * No-op when autolock is disabled, when a target is already specified, when a
+   * device was pinned via setActiveDevice, or when only one candidate exists.
+   */
+  private async enforceSessionUuidForAutolock(
+    platform: SomePlatform,
+    sessionUuid: string | undefined,
+    providedDeviceId: string | undefined
+  ): Promise<void> {
+    if (!isDevicePoolAutolockEnabled()) {
+      return;
+    }
+    if (sessionUuid || providedDeviceId) {
+      return;
+    }
+
+    // A device pinned via setActiveDevice is an unambiguous target.
+    const currentDevice = this.deviceSessionManager.getCurrentDevice();
+    const currentPlatform = this.deviceSessionManager.getCurrentPlatform();
+    if (currentDevice && (platform === "either" || platform === currentPlatform)) {
+      return;
+    }
+
+    const connectedPlatforms = await this.deviceSessionManager.detectConnectedPlatforms();
+    const candidates = platform === "either"
+      ? connectedPlatforms
+      : connectedPlatforms.filter(device => device.platform === platform);
+
+    if (candidates.length <= 1) {
+      return;
+    }
+
+    throw new ActionableError(
+      "Device pool autolock is enabled and multiple devices are available. " +
+      "Provide the sessionId returned by 'startDevice' (or a deviceId) to target a specific device."
     );
   }
 

--- a/test/server/toolRegistry.autolockSession.test.ts
+++ b/test/server/toolRegistry.autolockSession.test.ts
@@ -1,0 +1,133 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { ToolRegistry } from "../../src/server/toolRegistry";
+import { FakeDeviceSessionManager } from "../fakes/FakeDeviceSessionManager";
+import { BootedDevice } from "../../src/models";
+import { z } from "zod";
+
+const AUTOLOCK_ENV_KEYS = [
+  "AUTOMOBILE_DEVICE_POOL_AUTOLOCK",
+  "AUTO_MOBILE_DEVICE_POOL_AUTOLOCK",
+] as const;
+
+function setAutolock(enabled: boolean): void {
+  for (const key of AUTOLOCK_ENV_KEYS) {
+    delete process.env[key];
+  }
+  if (enabled) {
+    process.env.AUTOMOBILE_DEVICE_POOL_AUTOLOCK = "1";
+  }
+}
+
+describe("ToolRegistry autolock session enforcement", () => {
+  const androidA: BootedDevice = { name: "Pixel A", deviceId: "emulator-5554", platform: "android" };
+  const androidB: BootedDevice = { name: "Pixel B", deviceId: "emulator-5556", platform: "android" };
+
+  let fakeDeviceSessionManager: FakeDeviceSessionManager;
+  let originalDeviceSessionManager: unknown;
+
+  const schema = z.object({
+    platform: z.enum(["ios", "android"]).optional(),
+    deviceId: z.string().optional(),
+    sessionUuid: z.string().optional(),
+  });
+
+  function registerTool(name: string) {
+    ToolRegistry.registerDeviceAware(name, name, schema, async () => ({ success: true }));
+    const tool = ToolRegistry.getTool(name);
+    expect(tool).toBeDefined();
+    return tool!;
+  }
+
+  beforeEach(() => {
+    ToolRegistry.clearTools();
+    fakeDeviceSessionManager = new FakeDeviceSessionManager();
+    originalDeviceSessionManager = (ToolRegistry as any).deviceSessionManager;
+    (ToolRegistry as any).deviceSessionManager = fakeDeviceSessionManager;
+  });
+
+  afterEach(() => {
+    (ToolRegistry as any).deviceSessionManager = originalDeviceSessionManager;
+    ToolRegistry.clearTools();
+    setAutolock(false);
+  });
+
+  test("requires sessionUuid when autolock is on and multiple Android devices exist", async () => {
+    setAutolock(true);
+    fakeDeviceSessionManager.setConnectedDevices([androidA, androidB]);
+
+    const tool = registerTool("autolockMultiAndroid");
+
+    await expect(tool.handler({ platform: "android" })).rejects.toThrow(
+      "Device pool autolock is enabled and multiple devices are available."
+    );
+    expect(fakeDeviceSessionManager.getEnsureDeviceReadyCallCount()).toBe(0);
+  });
+
+  test("allows the call when a sessionUuid is provided", async () => {
+    setAutolock(true);
+    fakeDeviceSessionManager.setConnectedDevices([androidA, androidB]);
+
+    const tool = registerTool("autolockWithSession");
+
+    const response = await tool.handler({ platform: "android", sessionUuid: "session-123" });
+    expect(response).toEqual({ success: true });
+    expect(fakeDeviceSessionManager.getEnsureDeviceReadyCallCount()).toBe(1);
+  });
+
+  test("allows the call when an explicit deviceId is provided", async () => {
+    setAutolock(true);
+    fakeDeviceSessionManager.setConnectedDevices([androidA, androidB]);
+
+    const tool = registerTool("autolockWithDeviceId");
+
+    const response = await tool.handler({ platform: "android", deviceId: "emulator-5556" });
+    expect(response).toEqual({ success: true });
+    expect(fakeDeviceSessionManager.getEnsureDeviceReadyCallCount()).toBe(1);
+  });
+
+  test("does not require sessionUuid when only one Android device exists", async () => {
+    setAutolock(true);
+    fakeDeviceSessionManager.setConnectedDevices([androidA]);
+
+    const tool = registerTool("autolockSingleAndroid");
+
+    const response = await tool.handler({ platform: "android" });
+    expect(response).toEqual({ success: true });
+    expect(fakeDeviceSessionManager.getEnsureDeviceReadyCallCount()).toBe(1);
+  });
+
+  test("does not require sessionUuid when autolock is disabled, even with multiple devices", async () => {
+    setAutolock(false);
+    fakeDeviceSessionManager.setConnectedDevices([androidA, androidB]);
+
+    const tool = registerTool("autolockDisabledMultiAndroid");
+
+    const response = await tool.handler({ platform: "android" });
+    expect(response).toEqual({ success: true });
+    expect(fakeDeviceSessionManager.getEnsureDeviceReadyCallCount()).toBe(1);
+  });
+
+  test("requires sessionUuid for platform 'either' when multiple devices exist", async () => {
+    setAutolock(true);
+    fakeDeviceSessionManager.setConnectedDevices([androidA, androidB]);
+
+    const tool = registerTool("autolockEitherPlatform");
+
+    await expect(tool.handler({})).rejects.toThrow(
+      "Device pool autolock is enabled and multiple devices are available."
+    );
+    expect(fakeDeviceSessionManager.getEnsureDeviceReadyCallCount()).toBe(0);
+  });
+
+  test("allows the call when a device was pinned via setActiveDevice", async () => {
+    setAutolock(true);
+    fakeDeviceSessionManager.setConnectedDevices([androidA, androidB]);
+    fakeDeviceSessionManager.setCurrentDevice(androidA, "android");
+
+    const tool = registerTool("autolockActiveDevice");
+
+    const response = await tool.handler({ platform: "android" });
+    expect(response).toEqual({ success: true });
+    expect(fakeDeviceSessionManager.getEnsureDeviceReadyCallCount()).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary
Final follow-up to the device pool autolock work (#2324, #2326, #2327).

When autolock is enabled, a device-aware tool call that names no target (no `sessionUuid`, no `deviceId`) would be routed to an arbitrary device when more than one candidate exists — defeating the per-session device ownership autolock provides. The existing guard (`enforceSessionUuidForMultipleIos`) only covered multiple iOS simulators.

- Adds `enforceSessionUuidForAutolock`: when autolock is on and >1 candidate devices exist for the requested platform, require the `sessionId` from `startDevice` (or an explicit `deviceId`).
- No-op when autolock is disabled, a target is already specified, a device is pinned via `setActiveDevice`, or only one candidate exists.

## Test plan
- [x] Unit (`FakeDeviceSessionManager`): rejects no-target call with multiple Android devices; allows with sessionUuid / deviceId / single device / setActiveDevice / autolock disabled; covers `platform: "either"`
- [x] Existing iOS guard tests still pass (no regression)
- [x] `bun test test/server test/daemon` — 845 pass
- [x] eslint clean; `bun build.ts` green