### PR TITLE
feat(action): auto-uninstall on version-downgrade install failure

### DIFF
--- a/src/features/action/InstallApp.ts
+++ b/src/features/action/InstallApp.ts
@@ -9,6 +9,7 @@ import { OPERATION_CANCELLED_MESSAGE } from "../../utils/constants";
 import { SimCtlClient } from "../../utils/ios-cmdline-tools/SimCtlClient";
 import { DeviceAppInspector } from "../../utils/ios-cmdline-tools/DeviceAppInspector";
 import { AndroidCtrlProxyClient } from "../observe/android";
+import { logger } from "../../utils/logger";
 
 export interface DeviceAppInstaller {
   installApp(deviceUdid: string, artifactPath: string): Promise<void>;
@@ -145,10 +146,36 @@ export class InstallApp {
       });
     }
 
-    const success = await perf.track("adbInstall", async () => {
-      const installOutput = await this.adb.executeCommand(`install --user ${targetUserId} -r "${artifactPath}"`, undefined, undefined, undefined, signal);
-      return installOutput.includes("Success");
-    });
+    const installArgs = `install --user ${targetUserId} -r "${artifactPath}"`;
+    let installAttempt = await perf.track("adbInstall", () => this.runAndroidInstall(installArgs, signal));
+
+    if (!installAttempt.success && this.isAndroidDowngradeError(installAttempt.output)) {
+      // The installed version is newer than the artifact. `adb install -r` cannot
+      // downgrade a package, so the default behavior is to uninstall the existing
+      // app and reinstall the provided version.
+      if (!packageName) {
+        throw new Error(
+          "Install failed because the installed version is newer (INSTALL_FAILED_VERSION_DOWNGRADE), " +
+          "but the package name could not be determined in order to uninstall it first."
+        );
+      }
+      logger.warn(`[InstallApp] Version downgrade detected for ${packageName}; uninstalling existing version and reinstalling.`);
+      await perf.track("downgradeUninstall", () => this.uninstallAndroidForDowngrade(packageName!, targetUserId, signal));
+      installAttempt = await perf.track("adbReinstall", () => this.runAndroidInstall(installArgs, signal));
+      if (installAttempt.success) {
+        warnings.push(
+          `Installed version of ${packageName} was newer than the artifact; uninstalled it and reinstalled the provided version.`
+        );
+        isInstalled = false; // The app was removed, so this is effectively a fresh install.
+      }
+    }
+
+    // Preserve prior behavior: a hard install failure (non-zero exit) surfaces as a thrown error.
+    if (!installAttempt.success && installAttempt.threw && installAttempt.error !== undefined) {
+      throw installAttempt.error;
+    }
+
+    const success = installAttempt.success;
 
     if (!packageName && beforePackages) {
       const afterPackages = success ? await perf.track("listPackagesAfter", async () => {
@@ -177,6 +204,88 @@ export class InstallApp {
     };
   }
 
+  private static readonly ANDROID_DOWNGRADE_MARKER = "INSTALL_FAILED_VERSION_DOWNGRADE";
+
+  /**
+   * Run an `adb install` command, capturing failures (whether reported as a
+   * non-zero exit / thrown error or as a "Failure [...]" line in the output)
+   * so the caller can inspect the reason without losing the original error.
+   */
+  private async runAndroidInstall(
+    installArgs: string,
+    signal?: AbortSignal
+  ): Promise<{ success: boolean; output: string; threw: boolean; error?: unknown }> {
+    try {
+      const result = await this.adb.executeCommand(installArgs, undefined, undefined, undefined, signal);
+      const output = [result.stdout, result.stderr].filter(Boolean).join("\n");
+      return { success: output.includes("Success"), output, threw: false };
+    } catch (error) {
+      if (signal?.aborted) {
+        throw error;
+      }
+      return { success: false, output: this.extractErrorText(error), threw: true, error };
+    }
+  }
+
+  private isAndroidDowngradeError(output: string): boolean {
+    return output.includes(InstallApp.ANDROID_DOWNGRADE_MARKER);
+  }
+
+  /**
+   * Fully uninstall an Android package so a lower-versioned artifact can be
+   * installed over a newer one. The uninstall is package-wide (not per-user)
+   * because the installed APK version is shared across users.
+   */
+  private async uninstallAndroidForDowngrade(packageName: string, userId: number, signal?: AbortSignal): Promise<void> {
+    try {
+      await this.adb.executeCommand(`shell am force-stop --user ${userId} ${packageName}`, undefined, undefined, true, signal);
+    } catch {
+      // Best-effort stop; proceed with uninstall regardless.
+    }
+    await this.adb.executeCommand(`uninstall ${packageName}`, undefined, undefined, undefined, signal);
+  }
+
+  private extractErrorText(error: unknown): string {
+    if (error instanceof Error) {
+      const details = error as Error & { stderr?: unknown; stdout?: unknown };
+      return [error.message, details.stderr, details.stdout]
+        .filter(value => typeof value === "string" && value.length > 0)
+        .join("\n");
+    }
+    return String(error);
+  }
+
+  /**
+   * Detect an iOS install failure caused by the installed version being newer
+   * than the artifact (simctl/devicectl downgrade rejection).
+   */
+  private isiOSDowngradeError(text: string): boolean {
+    const lower = text.toLowerCase();
+    if (lower.includes("downgrade")) {
+      return true;
+    }
+    return lower.includes("newer version") && lower.includes("already installed");
+  }
+
+  /**
+   * Read CFBundleIdentifier from a simulator .app bundle's Info.plist so the
+   * existing (newer) version can be uninstalled before a downgrade reinstall.
+   */
+  private async resolveAppBundleId(appPath: string): Promise<string | undefined> {
+    try {
+      const plistPath = path.join(appPath, "Info.plist");
+      const result = await this.hostExecutor.executeCommand(
+        "plutil",
+        ["-extract", "CFBundleIdentifier", "raw", "-o", "-", plistPath]
+      );
+      const bundleId = result.stdout.trim();
+      return bundleId || undefined;
+    } catch (error) {
+      logger.warn(`[InstallApp] Failed to read bundle identifier from ${appPath}: ${error instanceof Error ? error.message : String(error)}`);
+      return undefined;
+    }
+  }
+
   private validateiOSArtifact(ext: string): void {
     const isSimulator = this.isSimulator();
     if (isSimulator && ext === ".ipa") {
@@ -202,7 +311,7 @@ export class InstallApp {
     const beforeApps = await perf.track("listAppsBefore", () => this.simctl.listApps(this.device.deviceId));
     const beforeBundleIds = this.extractBundleIds(beforeApps);
 
-    await perf.track("simctlInstall", () => this.simctl.installApp(appPath, this.device.deviceId));
+    const downgraded = await perf.track("simctlInstall", () => this.installiOSSimulatorWithDowngradeRecovery(appPath, signal));
 
     if (signal?.aborted) {
       throw new Error(OPERATION_CANCELLED_MESSAGE);
@@ -216,6 +325,10 @@ export class InstallApp {
 
     const warnings: string[] = [];
 
+    if (downgraded) {
+      warnings.push("Installed version was newer than the artifact; uninstalled it and reinstalled the provided version.");
+    }
+
     if (!packageName) {
       if (newBundles.length === 1) {
         packageName = newBundles[0];
@@ -226,7 +339,7 @@ export class InstallApp {
       }
     }
 
-    const upgrade = packageName ? beforeBundleIds.has(packageName) : false;
+    const upgrade = downgraded ? false : (packageName ? beforeBundleIds.has(packageName) : false);
 
     return {
       success: true,
@@ -234,6 +347,42 @@ export class InstallApp {
       packageName,
       warning: warnings.length > 0 ? warnings.join(" ") : undefined
     };
+  }
+
+  /**
+   * Install on an iOS simulator, recovering from a version-downgrade rejection
+   * by uninstalling the existing (newer) app and reinstalling the artifact.
+   * Returns true if a downgrade recovery was performed.
+   */
+  private async installiOSSimulatorWithDowngradeRecovery(appPath: string, signal?: AbortSignal): Promise<boolean> {
+    try {
+      await this.simctl.installApp(appPath, this.device.deviceId);
+      return false;
+    } catch (error) {
+      const text = this.extractErrorText(error);
+      if (!this.isiOSDowngradeError(text)) {
+        throw error;
+      }
+      const bundleId = await this.resolveAppBundleId(appPath);
+      if (!bundleId) {
+        throw new Error(
+          `Install failed because the installed version is newer than the artifact, and the bundle ` +
+          `identifier could not be read from ${appPath} in order to uninstall it first. Original error: ${text}`
+        );
+      }
+      logger.warn(`[InstallApp] Version downgrade detected for ${bundleId}; uninstalling existing version and reinstalling.`);
+      try {
+        await this.simctl.terminateApp(bundleId, this.device.deviceId);
+      } catch {
+        // Best-effort terminate; proceed with uninstall regardless.
+      }
+      await this.simctl.uninstallApp(bundleId, this.device.deviceId);
+      if (signal?.aborted) {
+        throw new Error(OPERATION_CANCELLED_MESSAGE);
+      }
+      await this.simctl.installApp(appPath, this.device.deviceId);
+      return true;
+    }
   }
 
   private async executeiOSPhysical(
@@ -245,7 +394,20 @@ export class InstallApp {
       throw new Error(OPERATION_CANCELLED_MESSAGE);
     }
 
-    await perf.track("devicectlInstall", () => this.deviceAppInstaller.installApp(this.device.deviceId, ipaPath));
+    try {
+      await perf.track("devicectlInstall", () => this.deviceAppInstaller.installApp(this.device.deviceId, ipaPath));
+    } catch (error) {
+      const text = this.extractErrorText(error);
+      if (this.isiOSDowngradeError(text)) {
+        // devicectl has no downgrade flag and the bundle identifier cannot be
+        // reliably derived from the .ipa, so guide the user to uninstall first.
+        throw new Error(
+          `Install failed because a newer version is already installed on the device. ` +
+          `Uninstall the app first with uninstallApp, then reinstall. Original error: ${text}`
+        );
+      }
+      throw error;
+    }
 
     return {
       success: true,

--- a/test/fakes/FakeAdbExecutor.ts
+++ b/test/fakes/FakeAdbExecutor.ts
@@ -7,6 +7,7 @@ import { BootedDevice, ExecResult, AndroidUser } from "../../src/models";
  */
 export class FakeAdbExecutor implements AdbExecutor {
   private commandResponses: Map<string, ExecResult> = new Map();
+  private commandResponseSequences: Map<string, ExecResult[]> = new Map();
   private commandErrors: Map<string, Error> = new Map();
   private defaultResponse: ExecResult = this.createExecResult("", "");
   private defaultError: Error | null = null;
@@ -60,6 +61,20 @@ export class FakeAdbExecutor implements AdbExecutor {
     // If response already has the required methods, use it as-is; otherwise enhance it
     const enhancedResponse = this.ensureExecResultMethods(response);
     this.commandResponses.set(commandPattern, enhancedResponse);
+  }
+
+  /**
+   * Configure an ordered sequence of responses for a command pattern. Each
+   * matching call consumes the next response; the final response is repeated
+   * once the sequence is exhausted. Useful for fail-then-succeed flows.
+   * @param commandPattern - Pattern to match against executed commands (substring match)
+   * @param responses - Responses to return in order
+   */
+  setCommandResponseSequence(commandPattern: string, responses: ExecResult[]): void {
+    this.commandResponseSequences.set(
+      commandPattern,
+      responses.map(response => this.ensureExecResultMethods(response))
+    );
   }
 
   /**
@@ -186,6 +201,13 @@ export class FakeAdbExecutor implements AdbExecutor {
     // If a default error is configured, throw it
     if (this.defaultError) {
       throw this.defaultError;
+    }
+
+    // Check for sequenced responses (consumed in order) before single responses
+    for (const [pattern, responses] of this.commandResponseSequences.entries()) {
+      if (command.includes(pattern) && responses.length > 0) {
+        return responses.length > 1 ? responses.shift()! : responses[0];
+      }
     }
 
     // Check for configured responses based on pattern matching

--- a/test/features/action/InstallApp.test.ts
+++ b/test/features/action/InstallApp.test.ts
@@ -30,6 +30,19 @@ class SequencedFakeSimctl extends FakeSimctl {
   }
 }
 
+class DowngradeFakeSimctl extends SequencedFakeSimctl {
+  public installError: Error | null = null;
+  private installCalls = 0;
+
+  override async installApp(appPath: string, deviceId?: string): Promise<void> {
+    this.installCalls++;
+    if (this.installCalls === 1 && this.installError) {
+      throw this.installError;
+    }
+    return super.installApp(appPath, deviceId);
+  }
+}
+
 class FakeDeviceAppInstaller implements DeviceAppInstaller {
   public calls: Array<{ deviceUdid: string; artifactPath: string }> = [];
   public shouldThrow: Error | null = null;
@@ -547,5 +560,107 @@ describe("InstallApp", () => {
 
     expect(result.warning).toContain("Bundle ID detection is not available");
     expect(result.upgrade).toBe(false);
+  });
+
+  test("Android recovers from version downgrade by uninstalling then reinstalling", async () => {
+    const apkPath = "/tmp/app-debug.apk";
+    const perf = createPerformanceTracker(true, fakeTimer);
+
+    fakeLocator.setTool({ tool: "aapt2", path: "/sdk/build-tools/35.0.0/aapt2" });
+    fakeHost.setCommandResponse("aapt2", createExecResult("package: name='com.example.app' versionCode='1'"));
+    fakeAdb.setUsers([{ userId: 0, name: "Owner", flags: 13, running: true }]);
+    fakeAdb.setCommandResponse("shell pm list packages --user 0 -f com.example.app", createExecResult("1"));
+    fakeAdb.setCommandResponseSequence(`install --user 0 -r "${apkPath}"`, [
+      createExecResult("", "Failure [INSTALL_FAILED_VERSION_DOWNGRADE]"),
+      createExecResult("Success")
+    ]);
+
+    const installApp = new InstallApp(device, fakeAdbFactory, fakeHost, fakeLocator, () => perf);
+    const result = await installApp.execute(apkPath);
+
+    expect(result.success).toBe(true);
+    expect(result.upgrade).toBe(false);
+    expect(result.packageName).toBe("com.example.app");
+    expect(result.warning).toContain("uninstalled it and reinstalled");
+    expect(fakeAdb.wasCommandExecuted("uninstall com.example.app")).toBe(true);
+  });
+
+  test("Android downgrade without a resolvable package name surfaces a clear error", async () => {
+    const apkPath = "/tmp/app-debug.apk";
+    const perf = createPerformanceTracker(true, fakeTimer);
+
+    fakeLocator.setTool(null); // no aapt2 → package name cannot be determined
+    fakeAdb.setCommandResponse(
+      `install --user 0 -r "${apkPath}"`,
+      createExecResult("", "Failure [INSTALL_FAILED_VERSION_DOWNGRADE]")
+    );
+
+    const installApp = new InstallApp(device, fakeAdbFactory, fakeHost, fakeLocator, () => perf);
+
+    await expect(installApp.execute(apkPath)).rejects.toThrow("INSTALL_FAILED_VERSION_DOWNGRADE");
+    expect(fakeAdb.wasCommandExecuted("uninstall")).toBe(false);
+  });
+
+  test("Android non-downgrade install failure throws the original error without uninstalling", async () => {
+    const apkPath = "/tmp/app-debug.apk";
+    const perf = createPerformanceTracker(true, fakeTimer);
+
+    fakeLocator.setTool({ tool: "aapt2", path: "/sdk/build-tools/35.0.0/aapt2" });
+    fakeHost.setCommandResponse("aapt2", createExecResult("package: name='com.example.app' versionCode='1'"));
+    fakeAdb.setCommandResponse("shell pm list packages --user 0 -f com.example.app", createExecResult("0"));
+    fakeAdb.setCommandError(`install --user 0 -r "${apkPath}"`, new Error("Failure [INSTALL_FAILED_INVALID_APK]"));
+
+    const installApp = new InstallApp(device, fakeAdbFactory, fakeHost, fakeLocator, () => perf);
+
+    await expect(installApp.execute(apkPath)).rejects.toThrow("INSTALL_FAILED_INVALID_APK");
+    expect(fakeAdb.wasCommandExecuted("uninstall com.example.app")).toBe(false);
+  });
+
+  test("iOS simulator recovers from version downgrade by uninstalling then reinstalling", async () => {
+    const appPath = "/tmp/MyApp.app";
+    const perf = createPerformanceTracker(true, fakeTimer);
+    const simctl = new DowngradeFakeSimctl();
+    simctl.installError = new Error("Unable to install. A newer version of this application is already installed.");
+    simctl.setListResponses([
+      [{ bundleId: "com.example.app", bundlePath: "/tmp/MyApp.app" }],
+      [{ bundleId: "com.example.app", bundlePath: "/tmp/MyApp.app" }]
+    ]);
+    fakeHost.setCommandResponse("plutil", createExecResult("com.example.app\n"));
+
+    const installApp = new InstallApp(iosSimulatorDevice, fakeAdbFactory, fakeHost, null, () => perf, simctl);
+    const result = await installApp.execute(appPath);
+
+    expect(result.success).toBe(true);
+    expect(result.upgrade).toBe(false);
+    expect(result.warning).toContain("uninstalled it and reinstalled");
+    expect(simctl.wasMethodCalled("uninstallApp")).toBe(true);
+    expect(simctl.getMethodCalls("uninstallApp")[0].bundleId).toBe("com.example.app");
+    // Only the successful reinstall is recorded; the first attempt threw before recording.
+    expect(simctl.getMethodCallCount("installApp")).toBe(1);
+  });
+
+  test("iOS simulator downgrade fails clearly when bundle ID cannot be read", async () => {
+    const appPath = "/tmp/MyApp.app";
+    const perf = createPerformanceTracker(true, fakeTimer);
+    const simctl = new DowngradeFakeSimctl();
+    simctl.installError = new Error("A newer version of this application is already installed.");
+    simctl.setListResponses([[], []]);
+    fakeHost.setCommandResponse("plutil", createExecResult("")); // empty → unresolved bundle id
+
+    const installApp = new InstallApp(iosSimulatorDevice, fakeAdbFactory, fakeHost, null, () => perf, simctl);
+
+    await expect(installApp.execute(appPath)).rejects.toThrow("bundle identifier could not be read");
+    expect(simctl.wasMethodCalled("uninstallApp")).toBe(false);
+  });
+
+  test("iOS physical downgrade surfaces actionable uninstall guidance", async () => {
+    const ipaPath = "/tmp/MyApp.ipa";
+    const perf = createPerformanceTracker(true, fakeTimer);
+    const fakeInstaller = new FakeDeviceAppInstaller();
+    fakeInstaller.shouldThrow = new Error("Unable to Install. A newer version of this application is already installed.");
+
+    const installApp = new InstallApp(iosPhysicalDevice, fakeAdbFactory, null, null, () => perf, undefined, fakeInstaller);
+
+    await expect(installApp.execute(ipaPath)).rejects.toThrow("Uninstall the app first with uninstallApp");
   });
 });


### PR DESCRIPTION
## Summary

When `installApp` fails because the **already-installed version is newer** than the artifact (a downgrade, which `adb install -r` / simctl / devicectl reject), AutoMobile now uninstalls the existing app and retries the install automatically. This is the default behavior — no opt-in flag.

## Changes

- **Android (`.apk`)**: Install runs through `runAndroidInstall()`, capturing failures whether thrown (non-zero exit) or reported as a `Failure [...]` line. On `INSTALL_FAILED_VERSION_DOWNGRADE`, it force-stops and fully uninstalls the package, then reinstalls; a warning is surfaced and `upgrade` is reported `false`. Non-downgrade failures rethrow the original error unchanged and never trigger an uninstall. If the package name can't be determined, it throws a clear error.
- **iOS simulator (`.app`)**: On a downgrade rejection, reads `CFBundleIdentifier` from the bundle's `Info.plist` (`plutil`), terminates + uninstalls the existing app, then reinstalls. Clear error if the bundle id can't be read.
- **iOS physical (`.ipa`)**: devicectl has no downgrade flag and the bundle id can't be reliably derived from an `.ipa`, so a downgrade error is converted into actionable guidance ("uninstall first, then reinstall").

## Tests

- Added `FakeAdbExecutor.setCommandResponseSequence` for fail-then-succeed flows.
- 6 new tests: Android downgrade recovery, Android downgrade w/ unresolvable package name, Android non-downgrade failure (no spurious uninstall), iOS sim downgrade recovery, iOS sim downgrade w/ unreadable bundle id, iOS physical actionable error.
- Full action suite: 593 pass. Build + lint clean.