### PR TITLE
Add OpenAI MCP tool search helper

### DIFF
--- a/docs/using/openai-api.md
+++ b/docs/using/openai-api.md
@@ -1,0 +1,56 @@
+# OpenAI API
+
+AutoMobile is an MCP server. OpenAI API callers that connect to AutoMobile through a remotely exposed MCP endpoint can use OpenAI tool search by adding `defer_loading: true` to the caller-side MCP tool declaration.
+
+This is not an MCP server `_meta` field. The OpenAI API reads `defer_loading` from the `tools` array in the Responses API request.
+
+## Generate a tool declaration
+
+Use the generator to produce the JSON object for the OpenAI `tools` array:
+
+```bash
+bunx @kaeawc/auto-mobile@latest --cli openai-mcp-tool \
+  --server-url https://example.com/auto-mobile/mcp \
+  --defer-loading \
+  --require-approval always
+```
+
+Example output:
+
+```json
+{
+  "type": "mcp",
+  "server_label": "auto-mobile",
+  "server_description": "AutoMobile mobile device automation tools for Android and iOS.",
+  "server_url": "https://example.com/auto-mobile/mcp",
+  "defer_loading": true,
+  "require_approval": "always"
+}
+```
+
+Then include both the MCP declaration and `tool_search` in the Responses API request:
+
+```ts
+const response = await client.responses.create({
+  model: "gpt-5.5",
+  input: "Open the app and inspect the current screen.",
+  tools: [
+    {
+      type: "mcp",
+      server_label: "auto-mobile",
+      server_description: "AutoMobile mobile device automation tools for Android and iOS.",
+      server_url: "https://example.com/auto-mobile/mcp",
+      defer_loading: true,
+      require_approval: "always"
+    },
+    { type: "tool_search" }
+  ],
+  parallel_tool_calls: false
+});
+```
+
+## Notes
+
+- Only use `defer_loading: true` with OpenAI models and callers that support `tool_search`.
+- Keep `require_approval` strict for device automation unless your caller already has a separate review layer.
+- AutoMobile's normal stdio installation does not expose a public HTTP endpoint. Use this declaration only when AutoMobile is available through an OpenAI-reachable MCP endpoint.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -78,6 +78,7 @@ nav:
       - 'UX Exploration': using/ux-exploration.md
       - 'Reproducing Bugs': using/reproducing-bugs.md
       - 'UI Tests': using/ui-tests.md
+      - 'OpenAI API': using/openai-api.md
       - 'Performance Analysis':
           - 'Overview': using/perf-analysis/index.md
           - 'Startup': using/perf-analysis/startup.md

--- a/scripts/openai/generate-openai-mcp-tool.ts
+++ b/scripts/openai/generate-openai-mcp-tool.ts
@@ -1,0 +1,38 @@
+#!/usr/bin/env bun
+import {
+  createOpenAIMcpToolDefinition,
+  OPENAI_MCP_TOOL_USAGE,
+  parseOpenAIMcpToolCliArgs,
+} from "../../src/openai";
+
+const main = () => {
+  const options = parseOpenAIMcpToolCliArgs(Bun.argv.slice(2));
+  if (options.help) {
+    process.stdout.write(OPENAI_MCP_TOOL_USAGE);
+    return;
+  }
+
+  if (!options.serverUrl) {
+    throw new Error("--server-url is required");
+  }
+
+  const definition = createOpenAIMcpToolDefinition({
+    serverUrl: options.serverUrl,
+    serverLabel: options.serverLabel,
+    serverDescription: options.serverDescription,
+    deferLoading: options.deferLoading,
+    requireApproval: options.requireApproval,
+  });
+
+  process.stdout.write(`${JSON.stringify(definition, null, 2)}\n`);
+};
+
+if (import.meta.main) {
+  try {
+    main();
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    process.stderr.write(`Error: ${message}\n\n${OPENAI_MCP_TOOL_USAGE}`);
+    process.exit(1);
+  }
+}

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -3,6 +3,11 @@ import { logger } from "../utils/logger";
 import { ActionableError } from "../models";
 import { DaemonClient, DaemonUnavailableError } from "../daemon/client";
 import { DaemonManager } from "../daemon/manager";
+import {
+  createOpenAIMcpToolDefinition,
+  OPENAI_MCP_TOOL_USAGE,
+  parseOpenAIMcpToolCliArgs,
+} from "../openai";
 
 // Import all tool registration functions
 import { registerObserveTools } from "../server/observeTools";
@@ -281,6 +286,28 @@ function handleToolResult(result: any, toolName: string): void {
   }
 }
 
+function runOpenAIMcpToolCommand(args: string[]): void {
+  const options = parseOpenAIMcpToolCliArgs(args);
+  if (options.help) {
+    console.log(OPENAI_MCP_TOOL_USAGE.trimEnd());
+    return;
+  }
+
+  if (!options.serverUrl) {
+    throw new ActionableError("--server-url is required");
+  }
+
+  const definition = createOpenAIMcpToolDefinition({
+    serverUrl: options.serverUrl,
+    serverLabel: options.serverLabel,
+    serverDescription: options.serverDescription,
+    deferLoading: options.deferLoading,
+    requireApproval: options.requireApproval,
+  });
+
+  console.log(JSON.stringify(definition, null, 2));
+}
+
 // Main CLI command runner
 export async function runCliCommand(args: string[]): Promise<void> {
   try {
@@ -299,6 +326,11 @@ export async function runCliCommand(args: string[]): Promise<void> {
       } else {
         showHelp();
       }
+      return;
+    }
+
+    if (args[0] === "openai-mcp-tool") {
+      runOpenAIMcpToolCommand(args.slice(1));
       return;
     }
 
@@ -347,17 +379,20 @@ AutoMobile CLI - Android Device Automation
 Usage:
   bunx @kaeawc/auto-mobile@latest --cli [--session-uuid <uuid>] <tool-name> [--param value ...]
   bunx @kaeawc/auto-mobile@latest --cli help [tool-name]
+  bunx @kaeawc/auto-mobile@latest --cli openai-mcp-tool --server-url URL [options]
 
 Examples:
   bunx @kaeawc/auto-mobile@latest --cli listDeviceImages
   bunx @kaeawc/auto-mobile@latest --cli observe
   bunx @kaeawc/auto-mobile@latest --cli tapOn --text "Submit"
   bunx @kaeawc/auto-mobile@latest --cli startDevice --avdName "pixel_7_api_34"
+  bunx @kaeawc/auto-mobile@latest --cli openai-mcp-tool --server-url https://example.com/auto-mobile/mcp --defer-loading
   bunx @kaeawc/auto-mobile@latest --cli --session-uuid abc-123-uuid observe
   bunx @kaeawc/auto-mobile@latest --cli --session-uuid $SESSION_UUID tapOn --text "Submit"
 
 Options:
   help [tool-name]              Show help for a specific tool
+  openai-mcp-tool               Generate an OpenAI Responses API MCP tool declaration
   --session-uuid <uuid>         Associate tool execution with a session (optional)
 
 Parameters:

--- a/src/openai/index.ts
+++ b/src/openai/index.ts
@@ -1,0 +1,9 @@
+export {
+  createOpenAIMcpToolDefinition,
+  OPENAI_MCP_TOOL_USAGE,
+  parseOpenAIMcpToolCliArgs,
+  type OpenAIMcpToolCliOptions,
+  type OpenAIMcpRequireApproval,
+  type OpenAIMcpToolDefinition,
+  type OpenAIMcpToolDefinitionOptions,
+} from "./openaiMcpToolDefinition";

--- a/src/openai/openaiMcpToolDefinition.ts
+++ b/src/openai/openaiMcpToolDefinition.ts
@@ -1,0 +1,147 @@
+export type OpenAIMcpRequireApproval = "always" | "never";
+
+export interface OpenAIMcpToolDefinitionOptions {
+  serverLabel?: string;
+  serverDescription?: string;
+  serverUrl: string;
+  deferLoading?: boolean;
+  requireApproval?: OpenAIMcpRequireApproval;
+}
+
+export interface OpenAIMcpToolDefinition {
+  type: "mcp";
+  server_label: string;
+  server_description?: string;
+  server_url: string;
+  defer_loading?: true;
+  require_approval?: OpenAIMcpRequireApproval;
+}
+
+export interface OpenAIMcpToolCliOptions {
+  serverUrl?: string;
+  serverLabel?: string;
+  serverDescription?: string;
+  deferLoading: boolean;
+  requireApproval?: OpenAIMcpRequireApproval;
+  help: boolean;
+}
+
+const DEFAULT_SERVER_LABEL = "auto-mobile";
+const DEFAULT_SERVER_DESCRIPTION =
+  "AutoMobile mobile device automation tools for Android and iOS.";
+
+export const OPENAI_MCP_TOOL_USAGE = `Usage:
+  bunx @kaeawc/auto-mobile@latest --cli openai-mcp-tool --server-url URL [options]
+
+Options:
+  --server-url URL             Streamable HTTP/SSE MCP endpoint exposed to OpenAI.
+  --server-label NAME          OpenAI MCP server label (default: auto-mobile).
+  --server-description TEXT    Description shown to the model.
+  --defer-loading              Add defer_loading: true for tool_search callers.
+  --require-approval MODE      OpenAI approval mode: always or never.
+  --help                       Show this help.
+`;
+
+const normalizeNonEmpty = (value: string | undefined, fallback: string): string => {
+  const normalized = value?.trim();
+  return normalized && normalized.length > 0 ? normalized : fallback;
+};
+
+const normalizeServerUrl = (value: string): string => {
+  const normalized = value.trim();
+  if (normalized.length === 0) {
+    throw new Error("OpenAI MCP server URL is required");
+  }
+
+  let parsed: URL;
+  try {
+    parsed = new URL(normalized);
+  } catch {
+    throw new Error(`Invalid OpenAI MCP server URL: ${value}`);
+  }
+
+  if (parsed.protocol !== "https:" && parsed.protocol !== "http:") {
+    throw new Error("OpenAI MCP server URL must use http or https");
+  }
+
+  return parsed.toString();
+};
+
+export const createOpenAIMcpToolDefinition = (
+  options: OpenAIMcpToolDefinitionOptions
+): OpenAIMcpToolDefinition => {
+  const definition: OpenAIMcpToolDefinition = {
+    type: "mcp",
+    server_label: normalizeNonEmpty(options.serverLabel, DEFAULT_SERVER_LABEL),
+    server_description: normalizeNonEmpty(
+      options.serverDescription,
+      DEFAULT_SERVER_DESCRIPTION
+    ),
+    server_url: normalizeServerUrl(options.serverUrl),
+  };
+
+  if (options.deferLoading) {
+    definition.defer_loading = true;
+  }
+
+  if (options.requireApproval) {
+    definition.require_approval = options.requireApproval;
+  }
+
+  return definition;
+};
+
+const readValue = (args: string[], index: number, flag: string): string => {
+  const value = args[index + 1];
+  if (!value || value.startsWith("--")) {
+    throw new Error(`${flag} requires a value`);
+  }
+  return value;
+};
+
+const parseRequireApproval = (value: string): OpenAIMcpRequireApproval => {
+  if (value === "always" || value === "never") {
+    return value;
+  }
+  throw new Error("--require-approval must be 'always' or 'never'");
+};
+
+export const parseOpenAIMcpToolCliArgs = (args: string[]): OpenAIMcpToolCliOptions => {
+  const options: OpenAIMcpToolCliOptions = {
+    deferLoading: false,
+    help: false,
+  };
+
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    switch (arg) {
+      case "--help":
+      case "-h":
+        options.help = true;
+        break;
+      case "--server-url":
+        options.serverUrl = readValue(args, i, arg);
+        i++;
+        break;
+      case "--server-label":
+        options.serverLabel = readValue(args, i, arg);
+        i++;
+        break;
+      case "--server-description":
+        options.serverDescription = readValue(args, i, arg);
+        i++;
+        break;
+      case "--defer-loading":
+        options.deferLoading = true;
+        break;
+      case "--require-approval":
+        options.requireApproval = parseRequireApproval(readValue(args, i, arg));
+        i++;
+        break;
+      default:
+        throw new Error(`Unknown option: ${arg}`);
+    }
+  }
+
+  return options;
+};

--- a/test/openai/openaiMcpToolDefinition.test.ts
+++ b/test/openai/openaiMcpToolDefinition.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, test } from "bun:test";
+import { createOpenAIMcpToolDefinition, parseOpenAIMcpToolCliArgs } from "../../src/openai";
+
+describe("createOpenAIMcpToolDefinition", () => {
+  test("creates a default AutoMobile MCP tool declaration", () => {
+    expect(createOpenAIMcpToolDefinition({
+      serverUrl: "https://example.com/auto-mobile/mcp",
+    })).toEqual({
+      type: "mcp",
+      server_label: "auto-mobile",
+      server_description: "AutoMobile mobile device automation tools for Android and iOS.",
+      server_url: "https://example.com/auto-mobile/mcp",
+    });
+  });
+
+  test("adds OpenAI tool search and approval fields when requested", () => {
+    expect(createOpenAIMcpToolDefinition({
+      serverUrl: "https://example.com/mcp",
+      serverLabel: "mobile",
+      serverDescription: "Mobile automation",
+      deferLoading: true,
+      requireApproval: "never",
+    })).toEqual({
+      type: "mcp",
+      server_label: "mobile",
+      server_description: "Mobile automation",
+      server_url: "https://example.com/mcp",
+      defer_loading: true,
+      require_approval: "never",
+    });
+  });
+
+  test("rejects invalid URLs", () => {
+    expect(() => createOpenAIMcpToolDefinition({
+      serverUrl: "not a url",
+    })).toThrow("Invalid OpenAI MCP server URL");
+
+    expect(() => createOpenAIMcpToolDefinition({
+      serverUrl: "file:///tmp/mcp",
+    })).toThrow("must use http or https");
+  });
+});
+
+describe("generate-openai-mcp-tool parseArgs", () => {
+  test("parses tool search options", () => {
+    expect(parseOpenAIMcpToolCliArgs([
+      "--server-url",
+      "https://example.com/mcp",
+      "--server-label",
+      "auto-mobile-dev",
+      "--defer-loading",
+      "--require-approval",
+      "always",
+    ])).toEqual({
+      serverUrl: "https://example.com/mcp",
+      serverLabel: "auto-mobile-dev",
+      deferLoading: true,
+      requireApproval: "always",
+      help: false,
+    });
+  });
+
+  test("rejects unknown approval modes", () => {
+    expect(() => parseOpenAIMcpToolCliArgs(["--require-approval", "sometimes"])).toThrow(
+      "--require-approval must be 'always' or 'never'"
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- add a typed OpenAI Responses API MCP tool declaration helper
- add `--cli openai-mcp-tool` to generate caller-side `defer_loading` declarations
- document OpenAI tool search usage for remotely exposed AutoMobile MCP endpoints

## Validation

- `bun test test/openai/openaiMcpToolDefinition.test.ts`
- `bun run build`
- `bash scripts/validate_mkdocs_nav.sh`
- `bun src/index.ts --cli openai-mcp-tool --server-url https://example.com/auto-mobile/mcp --defer-loading --require-approval always`

## Notes

- `bun install` without `--ignore-scripts` fails locally because `heapdump` does not build against Node 26 headers; dependencies were installed with `bun install --ignore-scripts` for validation.
