### PR TITLE
Add Codex MCP policy config options

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -10,6 +10,32 @@ curl -fsSL https://raw.githubusercontent.com/kaeawc/auto-mobile/main/scripts/ins
 
 Once you've finished that, learn [how to use AutoMobile](using/ux-exploration.md)
 
+## Codex policy options
+
+When the installer configures Codex, it writes an `[mcp_servers.auto-mobile]`
+section to `~/.codex/config.toml`. You can opt in to Codex's MCP policy fields
+before running the installer:
+
+```bash
+AUTOMOBILE_CODEX_MCP_REQUIRED=true \
+AUTOMOBILE_CODEX_MCP_ENABLED_TOOLS=observe,tapOn,swipeOn,inputText \
+AUTOMOBILE_CODEX_MCP_DISABLED_TOOLS=androidDeviceShell \
+curl -fsSL https://raw.githubusercontent.com/kaeawc/auto-mobile/main/scripts/install.sh | bash
+```
+
+This produces Codex-side TOML like:
+
+```toml
+[mcp_servers.auto-mobile]
+command = "bunx"
+args = ["@kaeawc/auto-mobile@latest"]
+required = true
+enabled_tools = ["observe", "tapOn", "swipeOn", "inputText"]
+disabled_tools = ["androidDeviceShell"]
+```
+
+`disabled_tools` is applied by Codex after `enabled_tools`.
+
 ## Homebrew (macOS)
 
 AutoMobile is published to the shared `kaeawc/tap` Homebrew tap on every

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -89,6 +89,45 @@ command_exists() {
     command -v "$1" >/dev/null 2>&1
 }
 
+env_truthy() {
+    local value="${1:-}"
+    value="$(printf '%s' "${value}" | tr '[:upper:]' '[:lower:]')"
+    [[ "${value}" == "1" || "${value}" == "true" || "${value}" == "yes" || "${value}" == "on" ]]
+}
+
+toml_escape_string() {
+    local value="$1"
+    value="${value//\\/\\\\}"
+    value="${value//\"/\\\"}"
+    printf '%s' "${value}"
+}
+
+toml_array_from_csv() {
+    local csv="$1"
+    local result="["
+    local first=true
+    local item
+    local -a items
+
+    IFS=',' read -r -a items <<< "${csv}"
+    for item in "${items[@]}"; do
+        item="${item#"${item%%[![:space:]]*}"}"
+        item="${item%"${item##*[![:space:]]}"}"
+        if [[ -z "${item}" ]]; then
+            continue
+        fi
+        if [[ "${first}" == "true" ]]; then
+            first=false
+        else
+            result+=", "
+        fi
+        result+="\"$(toml_escape_string "${item}")\""
+    done
+
+    result+="]"
+    printf '%s' "${result}"
+}
+
 # Compare semver versions: returns 0 if $1 >= $2
 version_gte() {
     local v1="$1"
@@ -1775,6 +1814,16 @@ generate_auto_mobile_config_toml() {
 command = "bunx"
 args = ${args}
 EOF
+
+    if env_truthy "${AUTOMOBILE_CODEX_MCP_REQUIRED:-}"; then
+        echo "required = true"
+    fi
+    if [[ -n "${AUTOMOBILE_CODEX_MCP_ENABLED_TOOLS:-}" ]]; then
+        echo "enabled_tools = $(toml_array_from_csv "${AUTOMOBILE_CODEX_MCP_ENABLED_TOOLS}")"
+    fi
+    if [[ -n "${AUTOMOBILE_CODEX_MCP_DISABLED_TOOLS:-}" ]]; then
+        echo "disabled_tools = $(toml_array_from_csv "${AUTOMOBILE_CODEX_MCP_DISABLED_TOOLS}")"
+    fi
 
     if [[ "${has_env}" == "true" ]]; then
         echo ""


### PR DESCRIPTION
## Summary

- add opt-in Codex installer env vars for `required`, `enabled_tools`, and `disabled_tools`
- emit those policy fields in generated `[mcp_servers.auto-mobile]` TOML config
- document Codex policy options and an example install command

## Validation

- `bash -n scripts/install.sh`
- `shellcheck scripts/install.sh`
- `bash scripts/validate_mkdocs_nav.sh`
- `bash -c 'source <(sed '\\$d'\\ scripts/install.sh); AUTOMOBILE_CODEX_MCP_REQUIRED=true AUTOMOBILE_CODEX_MCP_ENABLED_TOOLS="observe,tapOn, inputText" AUTOMOBILE_CODEX_MCP_DISABLED_TOOLS="androidDeviceShell" generate_auto_mobile_config_toml minimal'`

## Notes

- A first smoke-test attempt accidentally started the interactive installer because the source command was quoted incorrectly; it exited with code 130 and made no repository changes.
