### PR TITLE
Improve observe element discovery for action-only controls

### DIFF
--- a/src/features/action/TapOnElement.ts
+++ b/src/features/action/TapOnElement.ts
@@ -37,7 +37,7 @@ import { refreshAndroidViewHierarchy } from "./refreshAndroidViewHierarchy";
 import { boundsEqual, boundsNearlyEqual } from "../../utils/bounds";
 import { androidPreTapConsecutiveStableMatchesRequired } from "./androidPreTapStablePolicy";
 import { androidViewHierarchyIndicatesLikelyBlockingLoading } from "../../utils/androidTransientLoading";
-import { isTruthyFlag } from "../../utils/elementProperties";
+import { hasAccessibilityAction, isTruthyFlag } from "../../utils/elementProperties";
 import { TalkBackTapStrategy } from "../talkback/TalkBackTapStrategy";
 import {
   DefaultTalkBackNavigationDriverFactory,
@@ -695,19 +695,23 @@ export class TapOnElement extends BaseVisualChange {
   }
 
   private isClickableElement(element: Element): boolean {
-    return isTruthyFlag(element.clickable);
+    return isTruthyFlag(element.clickable) || hasAccessibilityAction(element.actions, "click");
   }
 
   private isLongClickableElement(element: Element): boolean {
-    return isTruthyFlag(element["long-clickable"]) || isTruthyFlag(element.longClickable);
+    return isTruthyFlag(element["long-clickable"]) ||
+      isTruthyFlag(element.longClickable) ||
+      hasAccessibilityAction(element.actions, "long_click");
   }
 
   private isClickableProps(props: Record<string, unknown>): boolean {
-    return isTruthyFlag(props.clickable);
+    return isTruthyFlag(props.clickable) || hasAccessibilityAction(props.actions, "click");
   }
 
   private isLongClickableProps(props: Record<string, unknown>): boolean {
-    return isTruthyFlag(props["long-clickable"]) || isTruthyFlag(props.longClickable);
+    return isTruthyFlag(props["long-clickable"]) ||
+      isTruthyFlag(props.longClickable) ||
+      hasAccessibilityAction(props.actions, "long_click");
   }
 
   private nodeMatchesElement(

--- a/src/features/observe/ObserveScreen.ts
+++ b/src/features/observe/ObserveScreen.ts
@@ -36,6 +36,7 @@ import { PerformanceAuditor } from "./audits/PerformanceAuditor";
 import { AccessibilityAuditor, resolveLatestScreenshotPath } from "./audits/AccessibilityAuditor";
 import { AccessibilityStateDetector } from "./audits/AccessibilityStateDetector";
 import { appendObserveError } from "./ObserveError";
+import { ObserveElementsBuilder } from "./ObserveElementsBuilder";
 
 /**
  * Observe command class that combines screen details, view hierarchy and screenshot.
@@ -60,6 +61,7 @@ export class RealObserveScreen implements ObserveScreen {
   private performanceAuditor: PerformanceAuditor;
   private accessibilityAuditor: AccessibilityAuditor;
   private accessibilityStateDetector: AccessibilityStateDetector;
+  private elementsBuilder: ObserveElementsBuilder;
 
   // ---------- Static API (kept for back-compat with resource handlers/daemon) ----------
 
@@ -192,6 +194,7 @@ export class RealObserveScreen implements ObserveScreen {
       device,
       adb: this.adb,
     });
+    this.elementsBuilder = new ObserveElementsBuilder();
   }
 
   // ---------- Public API ----------
@@ -259,6 +262,10 @@ export class RealObserveScreen implements ObserveScreen {
 
       // Phase 1+2: hierarchy + derived device state (platform-specific orchestration).
       await this.collectAllData(result, queryOptions, perf, skipWaitForFresh, minTimestamp, signal, skipBackStack);
+
+      if (result.viewHierarchy) {
+        result.elements = this.elementsBuilder.build(result.viewHierarchy, this.device.platform);
+      }
 
       // Screenshot: fire-and-forget unless an accessibility audit is configured
       // (the audit needs the screenshot file on disk before it runs).

--- a/src/features/observe/ViewHierarchy.ts
+++ b/src/features/observe/ViewHierarchy.ts
@@ -473,10 +473,23 @@ export class ViewHierarchy implements ViewHierarchyInterface {
     return Boolean(
       (props.resourceId && props.resourceId !== "") ||
       (props["resource-id"] && props["resource-id"] !== "") ||
+      (props.viewId && props.viewId !== "") ||
+      (props["view-id"] && props["view-id"] !== "") ||
       (props.text && props.text !== "") ||
       (props.contentDesc && props.contentDesc !== "") ||
       (props["content-desc"] && props["content-desc"] !== "") ||
       (props["test-tag"] && props["test-tag"] !== "") ||
+      (props.role && props.role !== "") ||
+      (props["state-description"] && props["state-description"] !== "") ||
+      (props["error-message"] && props["error-message"] !== "") ||
+      (props["hint-text"] && props["hint-text"] !== "") ||
+      (props["tooltip-text"] && props["tooltip-text"] !== "") ||
+      (props["pane-title"] && props["pane-title"] !== "") ||
+      (props["live-region"] && props["live-region"] !== "") ||
+      (props["collection-info"] && props["collection-info"] !== "") ||
+      (props["collection-item-info"] && props["collection-item-info"] !== "") ||
+      (props["range-info"] && props["range-info"] !== "") ||
+      (props["input-type"] && props["input-type"] !== "") ||
       props.recomposition ||
       props.recompositionMetrics
     );
@@ -490,11 +503,17 @@ export class ViewHierarchy implements ViewHierarchyInterface {
   meetsBooleanFilterCriteria(props: any): boolean {
     return Boolean(
       (props.clickable === "true") ||
+      (props.focusable === "true") ||
       (props.scrollable === "true") ||
       (props.focused === "true") ||
+      (props["accessibility-focused"] === "true") ||
+      (props.checkable === "true") ||
+      (props.checked === "true") ||
       (props.selected === "true") ||
       (props.selected === true) ||
-      (props["long-clickable"] === "true")
+      (props["long-clickable"] === "true") ||
+      (Array.isArray(props.actions) && props.actions.length > 0) ||
+      (props.extras && Object.keys(props.extras).length > 0)
     );
   }
 
@@ -637,16 +656,37 @@ export class ViewHierarchy implements ViewHierarchyInterface {
       "text",
       "resourceId",
       "resource-id",
+      "viewId",
+      "view-id",
       "contentDesc",
       "content-desc",
       "clickable",
       "long-clickable",
       "scrollable",
       "enabled",
+      "focusable",
+      "focused",
+      "accessibility-focused",
+      "checkable",
+      "checked",
       "selected",
       "bounds",
       "test-tag",
+      "role",
+      "state-description",
+      "error-message",
+      "hint-text",
+      "tooltip-text",
+      "pane-title",
+      "live-region",
+      "collection-info",
+      "collection-item-info",
+      "range-info",
+      "input-type",
+      "actions",
       "extras",
+      "occlusionState",
+      "occludedBy",
       "recomposition",
       "recompositionMetrics"
     ];

--- a/src/features/utility/ElementFinder.ts
+++ b/src/features/utility/ElementFinder.ts
@@ -6,7 +6,7 @@ import type { TextMatcher } from "../../utils/interfaces/TextMatcher";
 import type { ElementFinder } from "../../utils/interfaces/ElementFinder";
 import { DefaultElementParser } from "./ElementParser";
 import { DefaultTextMatcher, normalizeQuotes } from "./TextMatcher";
-import { ANDROID_INPUT_CLASSES } from "../../utils/elementProperties";
+import { ANDROID_INPUT_CLASSES, hasAccessibilityAction } from "../../utils/elementProperties";
 
 /**
  * Handles searching and selection of elements in view hierarchy
@@ -184,7 +184,7 @@ export class DefaultElementFinder implements ElementFinder {
           (
             nodeProperties["ios-role"] === "AXButton" ||
             nodeProperties.class === "Button" ||
-            nodeProperties.clickable === "true"
+            this.isClickableNode(nodeProperties)
           )
         ) {
           logger.debug("[Element] Matches clickable element with text");
@@ -284,6 +284,12 @@ export class DefaultElementFinder implements ElementFinder {
     }
 
     return null;
+  }
+
+  private isClickableNode(props: Record<string, unknown>): boolean {
+    return props.clickable === "true" ||
+      props.clickable === true ||
+      hasAccessibilityAction(props.actions, "click");
   }
 
   /**
@@ -542,7 +548,7 @@ export class DefaultElementFinder implements ElementFinder {
     for (const rootNode of rootNodes) {
       this.parser.traverseNode(rootNode, (node: any) => {
         const nodeProperties = this.parser.extractNodeProperties(node);
-        if (nodeProperties.clickable === "true" || nodeProperties.clickable === true) {
+        if (this.isClickableNode(nodeProperties)) {
           const parsedNode = this.parser.parseNodeBounds(node);
           if (parsedNode) {
             clickables.push(parsedNode);
@@ -611,7 +617,7 @@ export class DefaultElementFinder implements ElementFinder {
     for (const rootNode of searchRoots) {
       this.parser.traverseNode(rootNode, (node: any) => {
         const nodeProperties = this.parser.extractNodeProperties(node);
-        if (nodeProperties.clickable === "true" || nodeProperties.clickable === true) {
+        if (this.isClickableNode(nodeProperties)) {
           const parsedNode = this.parser.parseNodeBounds(node);
           if (parsedNode) {
             clickables.push(parsedNode);
@@ -1011,7 +1017,7 @@ export class DefaultElementFinder implements ElementFinder {
     if (hasIdMatch) {
       for (const child of childArray) {
         const childProps = this.parser.extractNodeProperties(child);
-        const isClickable = childProps.clickable === "true" || childProps.clickable === true;
+        const isClickable = this.isClickableNode(childProps);
         const childRid = childProps["resource-id"];
         const isIdMatch = typeof childRid === "string" && matchesId(childRid);
 
@@ -1075,7 +1081,7 @@ export class DefaultElementFinder implements ElementFinder {
     if (hasTextMatch) {
       for (const child of childArray) {
         const childProps = this.parser.extractNodeProperties(child);
-        const isClickable = childProps.clickable === "true" || childProps.clickable === true;
+        const isClickable = this.isClickableNode(childProps);
 
         if (isClickable && !this.nodeHasText(child, matchesText)) {
           const parsedNode = this.parser.parseNodeBounds(child);
@@ -1100,7 +1106,7 @@ export class DefaultElementFinder implements ElementFinder {
     results: Element[]
   ): boolean {
     const nodeProperties = this.parser.extractNodeProperties(node);
-    const isClickable = nodeProperties.clickable === "true" || nodeProperties.clickable === true;
+    const isClickable = this.isClickableNode(nodeProperties);
 
     // Check if this node or any descendant has matching text
     const hasMatchingText = this.nodeOrDescendantHasText(node, matchesText);

--- a/src/utils/elementProperties.ts
+++ b/src/utils/elementProperties.ts
@@ -4,6 +4,13 @@ export function isTruthyFlag(value: unknown): boolean {
   return value === true || value === "true";
 }
 
+export function hasAccessibilityAction(
+  value: unknown,
+  action: string
+): boolean {
+  return Array.isArray(value) && value.some(item => item === action);
+}
+
 export function buildContainerFromElement(element: Element): { elementId?: string; text?: string } | null {
   if (element["resource-id"]) {
     return { elementId: element["resource-id"] };

--- a/test/features/observe/ObserveScreen.test.ts
+++ b/test/features/observe/ObserveScreen.test.ts
@@ -5,6 +5,9 @@ import { FakeTimer } from "../../fakes/FakeTimer";
 import { ObserveResult } from "../../../src/models/ObserveResult";
 import { BootedDevice } from "../../../src/models/DeviceInfo";
 import { logger } from "../../../src/utils/logger";
+import { FakeObserveCacheStore } from "../../fakes/FakeObserveCacheStore";
+import { FakeViewHierarchy } from "../../fakes/FakeViewHierarchy";
+import { resetObserveCacheStore } from "../../../src/features/observe/cache/ObserveCacheRegistry";
 
 describe("ObserveScreen", function() {
   describe("Unit Tests for Extracted Methods", function() {
@@ -105,6 +108,52 @@ describe("ObserveScreen", function() {
       observeScreen.appendError(result, "");
 
       expect(result.error).toBe("");
+    });
+
+    test("should populate observable element lists", async function() {
+      const viewHierarchy = new FakeViewHierarchy();
+      viewHierarchy.configureHierarchy({
+        updatedAt: 123,
+        screenWidth: 1080,
+        screenHeight: 1920,
+        systemInsets: { top: 24, right: 0, bottom: 48, left: 0 },
+        wakefulness: "Awake",
+        hierarchy: {
+          node: {
+            bounds: "[0,0][1080,1920]",
+            node: [
+              {
+                "resource-id": "com.example:id/action",
+                bounds: "[900,1700][1020,1820]",
+                actions: ["click"],
+              },
+              {
+                text: "Ready",
+                bounds: "[0,100][200,160]",
+              },
+            ],
+          },
+        },
+      } as any);
+
+      try {
+        const screen = new RealObserveScreen(mockDevice, fakeAdb, {
+          viewHierarchy,
+          cacheStore: new FakeObserveCacheStore(new FakeTimer()),
+          performanceAuditor: { run: async () => undefined } as any,
+          accessibilityAuditor: { run: async () => undefined } as any,
+          accessibilityStateDetector: { run: async () => undefined } as any,
+        });
+
+        const result = await screen.execute({ skipScreenshot: true, skipBackStack: true });
+
+        expect(result.elements?.clickable).toHaveLength(1);
+        expect(result.elements?.clickable[0]["resource-id"]).toBe("com.example:id/action");
+        expect(result.elements?.text).toHaveLength(1);
+        expect(result.elements?.text[0].text).toBe("Ready");
+      } finally {
+        resetObserveCacheStore();
+      }
     });
   });
 

--- a/test/features/observe/ViewHierarchy.filter.test.ts
+++ b/test/features/observe/ViewHierarchy.filter.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, test } from "bun:test";
+import { ViewHierarchy } from "../../../src/features/observe/ViewHierarchy";
+
+const device = {
+  name: "test-device",
+  platform: "android",
+  deviceId: "emulator-5554",
+} as any;
+
+describe("ViewHierarchy filtering", () => {
+  test("preserves action-only interactive nodes", () => {
+    const viewHierarchy = new ViewHierarchy(device, null);
+    const result = viewHierarchy.filterViewHierarchy({
+      hierarchy: {
+        node: {
+          bounds: "[0,0][1080,1920]",
+          node: [
+            {
+              "resource-id": "com.example:id/icon_button",
+              "view-id": "com.example:id/icon_button",
+              bounds: "[900,1700][1020,1820]",
+              actions: ["click"],
+            },
+            {
+              bounds: "[0,0][10,10]",
+            },
+          ],
+        },
+      },
+    });
+
+    expect(result.hierarchy.node).toEqual({
+      "resource-id": "com.example:id/icon_button",
+      "view-id": "com.example:id/icon_button",
+      bounds: "[900,1700][1020,1820]",
+      actions: ["click"],
+    });
+  });
+});

--- a/test/features/utility/ElementFinder.test.ts
+++ b/test/features/utility/ElementFinder.test.ts
@@ -237,6 +237,16 @@ describe("DefaultElementFinder", () => {
       const results = finder.findClickableElements(hierarchy);
       expect(results).toHaveLength(1);
     });
+
+    test("treats click accessibility actions as clickable", () => {
+      const hierarchy = makeHierarchy([
+        { $: { actions: ["click"], "resource-id": "com.example:id/icon_button", bounds: "[0,0][100,50]" } },
+        { $: { actions: ["focus"], "resource-id": "com.example:id/focus_only", bounds: "[0,50][100,100]" } },
+      ]);
+      const results = finder.findClickableElements(hierarchy);
+      expect(results).toHaveLength(1);
+      expect(results[0]["resource-id"]).toBe("com.example:id/icon_button");
+    });
   });
 
   describe("isElementFocused", () => {


### PR DESCRIPTION
## Summary
- Populate observe output with derived clickable, scrollable, text, and media element lists.
- Preserve action-backed controls through hierarchy filtering and treat click/long-click actions as tappable.
- Add focused coverage for action-only controls in filtering, observe output, and element discovery.

## Test plan
- bun test test/features/observe/ViewHierarchy.test.ts test/features/utility/ElementFinder.test.ts test/features/observe/ViewHierarchy.filter.test.ts test/features/observe/ObserveScreen.test.ts test/features/action/TapOnElement.extendedSelectors.test.ts
- bun run build
- bun test

Made with [Cursor](https://cursor.com)