### PR TITLE
test(action): regression coverage for action-only tap-target resolution

### DIFF
--- a/test/features/action/TapOnElement.talkback.test.ts
+++ b/test/features/action/TapOnElement.talkback.test.ts
@@ -337,6 +337,82 @@ describe("TapOnElement TalkBack mode detection", () => {
       expect(result.element["resource-id"]).toBe("com.example:id/settings_row");
     });
 
+    test("uses parent with click action when clickable flag is absent", () => {
+      const viewHierarchy = {
+        hierarchy: {
+          node: {
+            $: {
+              "class": "android.view.View",
+              "actions": ["click"],
+              "bounds": "[0,0][240,96]",
+              "resource-id": "com.example:id/action_row"
+            },
+            node: [
+              {
+                $: {
+                  "class": "android.widget.TextView",
+                  "text": "Manage account",
+                  "bounds": "[24,24][216,72]"
+                }
+              }
+            ]
+          }
+        }
+      } as any;
+
+      const textOnlyChild = {
+        bounds: { left: 24, top: 24, right: 216, bottom: 72 },
+        text: "Manage account"
+      } as any;
+
+      const result = (tapOnElement as any).resolveTapTargetElement(
+        textOnlyChild,
+        viewHierarchy,
+        "tap",
+        true
+      );
+
+      expect(result.usedParent).toBe(true);
+      expect(result.element["resource-id"]).toBe("com.example:id/action_row");
+    });
+
+    test("uses parent with long click action for longPress when flag is absent", () => {
+      const viewHierarchy = {
+        hierarchy: {
+          node: {
+            $: {
+              "class": "android.view.View",
+              "actions": ["long_click"],
+              "bounds": "[0,0][240,96]",
+              "resource-id": "com.example:id/action_row"
+            },
+            node: {
+              $: {
+                "class": "android.widget.TextView",
+                "text": "Manage account",
+                "bounds": "[24,24][216,72]"
+              }
+            }
+          }
+        }
+      } as any;
+
+      const textOnlyChild = {
+        bounds: { left: 24, top: 24, right: 216, bottom: 72 },
+        text: "Manage account"
+      } as any;
+
+      const result = (tapOnElement as any).resolveTapTargetElement(
+        textOnlyChild,
+        viewHierarchy,
+        "longPress",
+        true
+      );
+
+      expect(result.usedParent).toBe(true);
+      expect(result.element["resource-id"]).toBe("com.example:id/action_row");
+    });
+
     test("prefers long-clickable parent for longPress", () => {
       const viewHierarchy = {
         hierarchy: {


### PR DESCRIPTION
## Summary

Follow-up to #2349. After #2349 merged, its action-aware tap-target logic landed on `main`, so this PR's production change in `TapOnElement.ts` became a duplicate and was rebased away. What remains is **net-new regression coverage** that #2349 did not include.

This PR now adds two regression tests to `TapOnElement.talkback.test.ts` that exercise `resolveTapTargetElement` directly — the tap-target-resolution seam #2349 only covered indirectly (via `ElementFinder` / `ViewHierarchy` / `ObserveScreen` tests).

## What the tests cover

Both construct a hierarchy where a clickable **parent row exposes interactivity only through an `actions` array** (no boolean `clickable` / `long-clickable` flag), with a passive text-only `TextView` child — the TalkBack/accessibility scenario.

- **`uses parent with click action when clickable flag is absent`** — matches the text-only child, calls `resolveTapTargetElement(..., "tap", true)`, and asserts the tap lifts to the parent (`usedParent: true`, parent `resource-id`) when the parent only has `actions: ["click"]`.
- **`uses parent with long click action for longPress when flag is absent`** — the `longPress` analogue: parent has only `actions: ["long_click"]`, asserts the long-press resolves to the long-click-bearing parent.

## Notes

- Production code: **no diff vs `main`** — #2349's shared `hasAccessibilityAction` helper already provides the behavior. The merge conflict was resolved in favor of #2349's shared-helper form (dropping this PR's duplicate private method).
- Tests only: +76 lines. All 21 tests in the file pass (~171ms).
