### PR TITLE
fix(observe): scrub hierarchy-derived screen metrics on cross-platform rejection

### DIFF
--- a/src/features/observe/HierarchyPlatformValidator.ts
+++ b/src/features/observe/HierarchyPlatformValidator.ts
@@ -78,9 +78,15 @@ export class RealHierarchyPlatformValidator implements HierarchyPlatformValidato
  * resource, or the navigation graph recorder — can act on stale data from the
  * other platform.
  *
- * Note: this intentionally leaves device-derived fields (wakefulness, backStack,
- * accessibilityState, screenSize/systemInsets/rotation defaults) untouched, since
- * those come from direct device queries rather than the rejected hierarchy.
+ * Screen metrics (screenSize/systemInsets/rotation/wakefulness) are reset to the
+ * base-result defaults because collectAllData() copies them from the hierarchy
+ * (e.g. the iOS logical screen size) before this scrubber runs; leaving them
+ * would mislead clients that scale tap coordinates against screenSize.
+ *
+ * Genuinely device-derived fields (backStack, accessibilityState) come from
+ * direct device queries rather than the rejected hierarchy and are left intact.
+ *
+ * Note: if you add a new hierarchy-derived field to ObserveResult, clear it here.
  */
 export function discardHierarchyDerivedData(result: ObserveResult): void {
   result.viewHierarchy = undefined;
@@ -92,6 +98,12 @@ export function discardHierarchyDerivedData(result: ObserveResult): void {
   result.notificationPermissionDetected = undefined;
   result.predictions = undefined;
   result.activeWindow = undefined;
+
+  // Screen metrics copied from the rejected hierarchy — reset to base defaults.
+  result.screenSize = { width: 0, height: 0 };
+  result.systemInsets = { top: 0, right: 0, bottom: 0, left: 0 };
+  result.rotation = undefined;
+  result.wakefulness = undefined;
 }
 
 /**

--- a/test/features/observe/HierarchyPlatformValidator.test.ts
+++ b/test/features/observe/HierarchyPlatformValidator.test.ts
@@ -233,16 +233,28 @@ describe("discardHierarchyDerivedData", () => {
     expect(result.activeWindow).toBeUndefined();
   });
 
-  test("leaves device-derived fields untouched", () => {
+  test("resets hierarchy-derived screen metrics to base defaults", () => {
     const result = contaminatedResult();
+    result.rotation = 1;
     result.wakefulness = "Awake";
+
+    discardHierarchyDerivedData(result);
+
+    // collectAllData copies these from the (now-rejected) hierarchy, so a stale
+    // iOS screen size must not survive to mislead tap-coordinate scaling.
+    expect(result.screenSize).toEqual({ width: 0, height: 0 });
+    expect(result.systemInsets).toEqual({ top: 0, right: 0, bottom: 0, left: 0 });
+    expect(result.rotation).toBeUndefined();
+    expect(result.wakefulness).toBeUndefined();
+  });
+
+  test("leaves genuinely device-derived fields untouched", () => {
+    const result = contaminatedResult();
     result.backStack = { } as never;
 
     discardHierarchyDerivedData(result);
 
-    // Screen size / insets and direct device queries are not hierarchy-derived.
-    expect(result.screenSize).toEqual({ width: 390, height: 844 });
-    expect(result.wakefulness).toBe("Awake");
+    // backStack comes from a direct device query, not the rejected hierarchy.
     expect(result.backStack).toBeDefined();
   });
 });

--- a/test/features/observe/ObserveScreenPlatformValidation.test.ts
+++ b/test/features/observe/ObserveScreenPlatformValidation.test.ts
@@ -67,6 +67,8 @@ describe("ObserveScreen.execute cross-platform hierarchy rejection", () => {
     expect(result.intentChooserDetected).toBeUndefined();
     // The iOS package must not leak through activeWindow.
     expect(result.activeWindow).toBeUndefined();
+    // The iOS logical screen size (390x844) must not survive to mislead tap scaling.
+    expect(result.screenSize).toEqual({ width: 0, height: 0 });
     expect(result.error).toContain("iOS hierarchy for Android device");
   });
 


### PR DESCRIPTION
## Summary

Follow-up to #2353 (review catch by Codex). `discardHierarchyDerivedData()` scrubs the element/state fields on a cross-platform rejection, but left the **screen metrics** — `screenSize`, `systemInsets`, `rotation`, `wakefulness`. `collectAllData()` copies those from the hierarchy (e.g. the iOS *logical* screen size, 390×844) **before** the scrubber runs, so an Android `observe` could still return an iOS screen size after the hierarchy was discarded.

That's actionable contamination: clients scale tap coordinates against `screenSize`, so wrong-platform dimensions land taps in the wrong place.

## Fix

Reset the hierarchy-derived screen metrics to the base-result defaults on rejection:

```ts
result.screenSize = { width: 0, height: 0 };
result.systemInsets = { top: 0, right: 0, bottom: 0, left: 0 };
result.rotation = undefined;
result.wakefulness = undefined;
```

`backStack`/`accessibilityState` come from direct device queries (not the rejected hierarchy) and are left intact.

## Tests
- Unit: `discardHierarchyDerivedData` resets screen metrics to defaults; device-derived `backStack` preserved.
- Integration: `ObserveScreen.execute()` on an Android device fed an iOS hierarchy returns `screenSize {0,0}` (the iOS 390×844 must not survive).

22 tests pass, lint + build clean.
