### PR TITLE
fix(observe): preserve app hierarchy when IME is up

### DIFF
--- a/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/ViewHierarchyExtractor.kt
+++ b/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/ViewHierarchyExtractor.kt
@@ -198,27 +198,12 @@ class ViewHierarchyExtractor(private val recompositionStore: RecompositionStore?
     var activeWindowHasNullRoot = false
     var hasApplicationWindow = false
 
-    // Detect if an IME (keyboard) window with an extractable root is present.
-    // When IME is visible, Android may mark app window nodes as isVisibleToUser=false
-    // even though they are physically visible above the keyboard.
-    // Only bypass visibility filtering when the IME window has a root node, because that
-    // root contributes occlusion nodes that will properly hide elements behind the keyboard.
-    // If the IME window has a null root, it cannot participate in occlusion and we must keep
-    // the isVisibleToUser filter to avoid exposing non-interactable elements under the keyboard.
-    val hasImeWindow =
-        windows.any { it.type == AccessibilityWindowInfo.TYPE_INPUT_METHOD && it.root != null }
-
-    // When the IME is visible it owns input focus, so AccessibilityWindowInfo.isActive() is true
-    // for the IME and false for the user's app underneath. Picking the "active" window in that
-    // state surfaces the keyboard's hierarchy as the main one and drops the app's. To preserve
-    // the app, identify the topmost TYPE_APPLICATION window with an extractable root and treat
-    // that as the primary window for visibility-filter bypass and mainHierarchy selection.
-    val primaryAppWindowId: Int? =
-        pickPrimaryAppWindowId(
-            windows.map {
-              WindowMeta(id = it.id, type = it.type, layer = it.layer, hasRoot = it.root != null)
-            },
-        )
+    // When an IME (keyboard) window with an extractable root is visible, Android marks the IME
+    // as the isActive/isFocused window and may mark the app's nodes as isVisibleToUser=false even
+    // though they are physically on screen above the keyboard. In that state, fall back from
+    // window.isActive to "topmost TYPE_APPLICATION window with a root" for visibility-filter
+    // bypass and mainHierarchy selection. A non-null result here means an IME is up.
+    val primaryAppWindowId: Int? = pickPrimaryAppWindowId(windows)
 
     // Extract from each window
     for (window in windows) {
@@ -272,11 +257,10 @@ class ViewHierarchyExtractor(private val recompositionStore: RecompositionStore?
             )
         )
 
-        // When IME is present and this is the primary app window, skip isVisibleToUser
-        // filtering. Android marks app nodes as not visible when an IME window overlays them,
-        // but they are still physically on screen above the keyboard. We can't rely on
-        // window.isActive here because the IME owns input focus while it is visible.
-        val skipVisibilityFilter = hasImeWindow && window.id == primaryAppWindowId
+        // When IME is up, bypass isVisibleToUser for the primary app window — Android marks
+        // its nodes as not visible behind the keyboard. primaryAppWindowId is non-null only
+        // when an IME with a root is present, so the simple id check is sufficient.
+        val skipVisibilityFilter = window.id == primaryAppWindowId
         val element =
             extractNodeInfo(
                 rootNode,
@@ -310,10 +294,9 @@ class ViewHierarchyExtractor(private val recompositionStore: RecompositionStore?
           intentChooserDetected = detectIntentChooserIndicators(processedElement)
         }
 
-        // When IME is up, the IME window reports isActive=true; prefer the app window
-        // underneath so mainHierarchy reflects the user's app, not the keyboard.
+        // When IME is up, the IME reports isActive=true; prefer the app window underneath.
         val isPrimaryWindow =
-            if (hasImeWindow) window.id == primaryAppWindowId else window.isActive
+            if (primaryAppWindowId != null) window.id == primaryAppWindowId else window.isActive
         if (isPrimaryWindow) {
           mainHierarchy = processedElement
           mainPackageName = packageName
@@ -351,7 +334,10 @@ class ViewHierarchyExtractor(private val recompositionStore: RecompositionStore?
               screenDimensions,
               dedupeTextContentDesc,
               accessibilityFocusedNode,
-              skipVisibilityFilter = hasImeWindow,
+              skipVisibilityFilter =
+                  windows.any {
+                    it.type == AccessibilityWindowInfo.TYPE_INPUT_METHOD && it.root != null
+                  },
           )
       // Skip optimization if disableAllFiltering is true
       mainHierarchy =
@@ -403,15 +389,16 @@ class ViewHierarchyExtractor(private val recompositionStore: RecompositionStore?
           }
       windowEntries.clear()
       windowEntries.addAll(filteredEntries)
-      // Re-select main hierarchy after occlusion filtering. When IME is up the IME entry is
-      // the isActive one, so fall back to the primary app window in that case.
+      // Re-select main hierarchy after occlusion filtering. When IME is up, the IME entry is
+      // the isActive one — use the primary app window id instead.
       mainHierarchy =
-          if (hasImeWindow && primaryAppWindowId != null) {
-            windowEntries.firstOrNull { it.windowId == primaryAppWindowId }?.hierarchy
-                ?: mainHierarchy
-          } else {
-            windowEntries.firstOrNull { it.isActive }?.hierarchy ?: mainHierarchy
-          }
+          windowEntries
+              .firstOrNull {
+                if (primaryAppWindowId != null) it.windowId == primaryAppWindowId
+                else it.isActive
+              }
+              ?.hierarchy
+              ?: mainHierarchy
 
       // Debug: Check if Tab text survives occlusion filtering
       mainHierarchy?.let {
@@ -563,9 +550,23 @@ class ViewHierarchyExtractor(private val recompositionStore: RecompositionStore?
   }
 
   /**
-   * Metadata about a window used for primary-window selection. Pulled into a data class so the
-   * selection logic can be unit-tested without mocking [AccessibilityWindowInfo].
+   * Selects the window id that hierarchy extraction should treat as the "primary" user-facing
+   * window when an IME is visible. Returns null when no IME with a root is present (callers
+   * should fall back to `window.isActive`).
+   *
+   * Android marks the IME's [AccessibilityWindowInfo.isActive] as true while the keyboard is
+   * showing, which would otherwise cause `mainHierarchy` selection and the `isVisibleToUser`
+   * bypass to apply to the keyboard instead of the app underneath it.
    */
+  private fun pickPrimaryAppWindowId(windows: List<AccessibilityWindowInfo>): Int? =
+      pickPrimaryAppWindowId(
+          windows.map {
+            WindowMeta(id = it.id, type = it.type, layer = it.layer, hasRoot = it.root != null)
+          },
+      )
+
+  /** Test-only metadata shape so primary-window selection can be unit-tested without mocking
+   *  [AccessibilityWindowInfo]. */
   internal data class WindowMeta(
       val id: Int,
       val type: Int,
@@ -573,24 +574,23 @@ class ViewHierarchyExtractor(private val recompositionStore: RecompositionStore?
       val hasRoot: Boolean,
   )
 
-  /**
-   * Selects the window id that hierarchy extraction should treat as the "primary" user-facing
-   * window when an IME is visible. Returns null when no IME is up (callers should fall back to
-   * `window.isActive`).
-   *
-   * Android marks the IME's [AccessibilityWindowInfo.isActive] as true while the keyboard is
-   * showing, which would otherwise cause `mainHierarchy` selection and the
-   * `isVisibleToUser` bypass to apply to the keyboard instead of the app underneath it.
-   */
+  /** Single-pass variant used by tests and by the production overload. */
   internal fun pickPrimaryAppWindowId(windows: List<WindowMeta>): Int? {
-    val hasIme =
-        windows.any { it.type == AccessibilityWindowInfo.TYPE_INPUT_METHOD && it.hasRoot }
-    if (!hasIme) return null
-    return windows
-        .asSequence()
-        .filter { it.type == AccessibilityWindowInfo.TYPE_APPLICATION && it.hasRoot }
-        .maxByOrNull { it.layer }
-        ?.id
+    var hasIme = false
+    var topAppId: Int? = null
+    var topAppLayer = Int.MIN_VALUE
+    for (w in windows) {
+      if (!w.hasRoot) continue
+      when (w.type) {
+        AccessibilityWindowInfo.TYPE_INPUT_METHOD -> hasIme = true
+        AccessibilityWindowInfo.TYPE_APPLICATION ->
+            if (w.layer > topAppLayer) {
+              topAppLayer = w.layer
+              topAppId = w.id
+            }
+      }
+    }
+    return if (hasIme) topAppId else null
   }
 
   /**
@@ -1262,7 +1262,6 @@ class ViewHierarchyExtractor(private val recompositionStore: RecompositionStore?
       val bounds: ElementBounds,
       val windowLayer: Int,
       val windowKey: Int,
-      val windowType: String,
       val order: Int,
       val subtreeEnd: Int,
   )
@@ -1352,6 +1351,10 @@ class ViewHierarchyExtractor(private val recompositionStore: RecompositionStore?
       windowEntries: List<WindowEntry>,
   ): Map<NodeKey, OcclusionInfo> {
     val nodes = mutableListOf<OcclusionNode>()
+    val imeWindowKeys =
+        windowEntries.asSequence().filter { it.windowType == "input_method" }.mapTo(
+            mutableSetOf(),
+        ) { it.windowId }
     for (windowEntry in windowEntries) {
       val hierarchy = windowEntry.hierarchy
       val windowKey = windowEntry.windowId
@@ -1360,7 +1363,6 @@ class ViewHierarchyExtractor(private val recompositionStore: RecompositionStore?
           hierarchy,
           windowKey,
           windowLayer,
-          windowEntry.windowType,
           path = "",
           orderCounter = OrderCounter(),
           nodes = nodes,
@@ -1395,14 +1397,10 @@ class ViewHierarchyExtractor(private val recompositionStore: RecompositionStore?
 
       for (j in i + 1 until sortedNodes.size) {
         val occluder = sortedNodes[j]
-        // IME windows have a transparent outer wrapper whose accessibility node tree spans far
-        // beyond the actual keyboard rectangle (the IME window bounds). Treating those wrapper
-        // nodes as occluders falsely marks the app underneath as fully hidden. Limit IME
-        // cross-window occlusion contributions to nodes whose bounds are entirely inside the
-        // IME window's reported bounds — but we don't have those at this layer. Simplest correct
-        // fix: don't let IME nodes occlude content in OTHER windows. Internal IME-vs-IME
-        // occlusion is preserved (same-window check below).
-        if (occluder.windowType == "input_method" && occluder.windowKey != node.windowKey) {
+        // Skip cross-window IME occluders: the IME's a11y root has a transparent wrapper that
+        // overstates the keyboard rectangle and would falsely mark the app underneath as hidden.
+        // Same-window IME-vs-IME occlusion is preserved by the `windowKey != node.windowKey` guard.
+        if (occluder.windowKey != node.windowKey && occluder.windowKey in imeWindowKeys) {
           continue
         }
         if (occluder.windowKey == node.windowKey) {
@@ -1477,7 +1475,6 @@ class ViewHierarchyExtractor(private val recompositionStore: RecompositionStore?
       element: UIElementInfo,
       windowKey: Int,
       windowLayer: Int,
-      windowType: String,
       path: String,
       orderCounter: OrderCounter,
       nodes: MutableList<OcclusionNode>,
@@ -1489,15 +1486,7 @@ class ViewHierarchyExtractor(private val recompositionStore: RecompositionStore?
     for ((index, child) in children.withIndex()) {
       val childPath = if (path.isBlank()) index.toString() else "$path.$index"
       val childEnd =
-          collectOcclusionNodes(
-              child,
-              windowKey,
-              windowLayer,
-              windowType,
-              childPath,
-              orderCounter,
-              nodes,
-          )
+          collectOcclusionNodes(child, windowKey, windowLayer, childPath, orderCounter, nodes)
       end = max(end, childEnd)
     }
 
@@ -1510,7 +1499,6 @@ class ViewHierarchyExtractor(private val recompositionStore: RecompositionStore?
               bounds = bounds,
               windowLayer = windowLayer,
               windowKey = windowKey,
-              windowType = windowType,
               order = start,
               subtreeEnd = end,
           )

--- a/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/ViewHierarchyExtractor.kt
+++ b/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/ViewHierarchyExtractor.kt
@@ -208,6 +208,18 @@ class ViewHierarchyExtractor(private val recompositionStore: RecompositionStore?
     val hasImeWindow =
         windows.any { it.type == AccessibilityWindowInfo.TYPE_INPUT_METHOD && it.root != null }
 
+    // When the IME is visible it owns input focus, so AccessibilityWindowInfo.isActive() is true
+    // for the IME and false for the user's app underneath. Picking the "active" window in that
+    // state surfaces the keyboard's hierarchy as the main one and drops the app's. To preserve
+    // the app, identify the topmost TYPE_APPLICATION window with an extractable root and treat
+    // that as the primary window for visibility-filter bypass and mainHierarchy selection.
+    val primaryAppWindowId: Int? =
+        pickPrimaryAppWindowId(
+            windows.map {
+              WindowMeta(id = it.id, type = it.type, layer = it.layer, hasRoot = it.root != null)
+            },
+        )
+
     // Extract from each window
     for (window in windows) {
       try {
@@ -260,13 +272,11 @@ class ViewHierarchyExtractor(private val recompositionStore: RecompositionStore?
             )
         )
 
-        // When IME is present and this is the active app window, skip isVisibleToUser
+        // When IME is present and this is the primary app window, skip isVisibleToUser
         // filtering. Android marks app nodes as not visible when an IME window overlays them,
-        // but they are still physically on screen above the keyboard.
-        val skipVisibilityFilter =
-            hasImeWindow &&
-                window.isActive &&
-                window.type == AccessibilityWindowInfo.TYPE_APPLICATION
+        // but they are still physically on screen above the keyboard. We can't rely on
+        // window.isActive here because the IME owns input focus while it is visible.
+        val skipVisibilityFilter = hasImeWindow && window.id == primaryAppWindowId
         val element =
             extractNodeInfo(
                 rootNode,
@@ -300,7 +310,11 @@ class ViewHierarchyExtractor(private val recompositionStore: RecompositionStore?
           intentChooserDetected = detectIntentChooserIndicators(processedElement)
         }
 
-        if (window.isActive) {
+        // When IME is up, the IME window reports isActive=true; prefer the app window
+        // underneath so mainHierarchy reflects the user's app, not the keyboard.
+        val isPrimaryWindow =
+            if (hasImeWindow) window.id == primaryAppWindowId else window.isActive
+        if (isPrimaryWindow) {
           mainHierarchy = processedElement
           mainPackageName = packageName
           if (notificationPermissionDetected == null && processedElement != null) {
@@ -389,7 +403,15 @@ class ViewHierarchyExtractor(private val recompositionStore: RecompositionStore?
           }
       windowEntries.clear()
       windowEntries.addAll(filteredEntries)
-      mainHierarchy = windowEntries.firstOrNull { it.isActive }?.hierarchy ?: mainHierarchy
+      // Re-select main hierarchy after occlusion filtering. When IME is up the IME entry is
+      // the isActive one, so fall back to the primary app window in that case.
+      mainHierarchy =
+          if (hasImeWindow && primaryAppWindowId != null) {
+            windowEntries.firstOrNull { it.windowId == primaryAppWindowId }?.hierarchy
+                ?: mainHierarchy
+          } else {
+            windowEntries.firstOrNull { it.isActive }?.hierarchy ?: mainHierarchy
+          }
 
       // Debug: Check if Tab text survives occlusion filtering
       mainHierarchy?.let {
@@ -538,6 +560,37 @@ class ViewHierarchyExtractor(private val recompositionStore: RecompositionStore?
       packageName: String?,
   ): Boolean {
     return detectNotificationPermissionDialog(element, packageName)
+  }
+
+  /**
+   * Metadata about a window used for primary-window selection. Pulled into a data class so the
+   * selection logic can be unit-tested without mocking [AccessibilityWindowInfo].
+   */
+  internal data class WindowMeta(
+      val id: Int,
+      val type: Int,
+      val layer: Int,
+      val hasRoot: Boolean,
+  )
+
+  /**
+   * Selects the window id that hierarchy extraction should treat as the "primary" user-facing
+   * window when an IME is visible. Returns null when no IME is up (callers should fall back to
+   * `window.isActive`).
+   *
+   * Android marks the IME's [AccessibilityWindowInfo.isActive] as true while the keyboard is
+   * showing, which would otherwise cause `mainHierarchy` selection and the
+   * `isVisibleToUser` bypass to apply to the keyboard instead of the app underneath it.
+   */
+  internal fun pickPrimaryAppWindowId(windows: List<WindowMeta>): Int? {
+    val hasIme =
+        windows.any { it.type == AccessibilityWindowInfo.TYPE_INPUT_METHOD && it.hasRoot }
+    if (!hasIme) return null
+    return windows
+        .asSequence()
+        .filter { it.type == AccessibilityWindowInfo.TYPE_APPLICATION && it.hasRoot }
+        .maxByOrNull { it.layer }
+        ?.id
   }
 
   /**

--- a/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/ViewHierarchyExtractor.kt
+++ b/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/ViewHierarchyExtractor.kt
@@ -1262,6 +1262,7 @@ class ViewHierarchyExtractor(private val recompositionStore: RecompositionStore?
       val bounds: ElementBounds,
       val windowLayer: Int,
       val windowKey: Int,
+      val windowType: String,
       val order: Int,
       val subtreeEnd: Int,
   )
@@ -1359,6 +1360,7 @@ class ViewHierarchyExtractor(private val recompositionStore: RecompositionStore?
           hierarchy,
           windowKey,
           windowLayer,
+          windowEntry.windowType,
           path = "",
           orderCounter = OrderCounter(),
           nodes = nodes,
@@ -1393,6 +1395,16 @@ class ViewHierarchyExtractor(private val recompositionStore: RecompositionStore?
 
       for (j in i + 1 until sortedNodes.size) {
         val occluder = sortedNodes[j]
+        // IME windows have a transparent outer wrapper whose accessibility node tree spans far
+        // beyond the actual keyboard rectangle (the IME window bounds). Treating those wrapper
+        // nodes as occluders falsely marks the app underneath as fully hidden. Limit IME
+        // cross-window occlusion contributions to nodes whose bounds are entirely inside the
+        // IME window's reported bounds — but we don't have those at this layer. Simplest correct
+        // fix: don't let IME nodes occlude content in OTHER windows. Internal IME-vs-IME
+        // occlusion is preserved (same-window check below).
+        if (occluder.windowType == "input_method" && occluder.windowKey != node.windowKey) {
+          continue
+        }
         if (occluder.windowKey == node.windowKey) {
           // Determine relationship between node and occluder
           val relationship =
@@ -1465,6 +1477,7 @@ class ViewHierarchyExtractor(private val recompositionStore: RecompositionStore?
       element: UIElementInfo,
       windowKey: Int,
       windowLayer: Int,
+      windowType: String,
       path: String,
       orderCounter: OrderCounter,
       nodes: MutableList<OcclusionNode>,
@@ -1476,7 +1489,15 @@ class ViewHierarchyExtractor(private val recompositionStore: RecompositionStore?
     for ((index, child) in children.withIndex()) {
       val childPath = if (path.isBlank()) index.toString() else "$path.$index"
       val childEnd =
-          collectOcclusionNodes(child, windowKey, windowLayer, childPath, orderCounter, nodes)
+          collectOcclusionNodes(
+              child,
+              windowKey,
+              windowLayer,
+              windowType,
+              childPath,
+              orderCounter,
+              nodes,
+          )
       end = max(end, childEnd)
     }
 
@@ -1489,6 +1510,7 @@ class ViewHierarchyExtractor(private val recompositionStore: RecompositionStore?
               bounds = bounds,
               windowLayer = windowLayer,
               windowKey = windowKey,
+              windowType = windowType,
               order = start,
               subtreeEnd = end,
           )

--- a/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/ViewHierarchyExtractorTest.kt
+++ b/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/ViewHierarchyExtractorTest.kt
@@ -561,6 +561,70 @@ class ViewHierarchyExtractorTest {
   }
 
   @Test
+  fun `IME wrapper spanning full screen does not occlude app window hierarchy`() {
+    // On a Pixel 10 Pro with Gboard, the IME window reports bounds matching the keyboard
+    // (e.g. y=1464..2410) but its accessibility node tree has a transparent outer wrapper
+    // spanning the entire area below the status bar (e.g. y=172..2410). If those wrapper
+    // nodes participate in cross-window occlusion, they cover ~93% of the app window; together
+    // with the status bar that pushes the app over the 0.95 hidden threshold and every Slack
+    // node gets stripped. The fix excludes IME nodes from being occluders for other windows.
+    val toolbar =
+        elementWithBounds(resourceId = "toolbar", bounds = bounds(0, 172, 1080, 400))
+    val composer =
+        elementWithBounds(resourceId = "composer", bounds = bounds(0, 1200, 1080, 1340))
+    val appRoot =
+        elementWithBounds(
+            resourceId = "app-root",
+            bounds = bounds(0, 0, 1080, 2410),
+            children = listOf(toolbar, composer),
+        )
+    // IME root reports the full transparent wrapper bounds, not the actual keyboard rect.
+    val imeWrapper =
+        elementWithBounds(
+            resourceId = "ime-wrapper",
+            bounds = bounds(0, 172, 1080, 2410),
+        )
+
+    val appEntry =
+        extractor.createWindowEntry(
+            windowId = 116,
+            windowLayer = 0,
+            hierarchy = appRoot,
+            windowType = "application",
+            isActive = true,
+            isFocused = true,
+        )
+    val imeEntry =
+        extractor.createWindowEntry(
+            windowId = 108,
+            windowLayer = 5,
+            hierarchy = imeWrapper,
+            windowType = "input_method",
+            isActive = false,
+            isFocused = false,
+        )
+    val occlusionInfo = extractor.buildOcclusionInfoForTest(listOf(appEntry, imeEntry))
+    val filtered =
+        extractor.filterOccludedHierarchyForTest(
+            element = appRoot,
+            occlusionInfo = occlusionInfo,
+            windowKey = 116,
+            path = "",
+            isRoot = true,
+        )
+
+    assertNotNull("App root must survive IME wrapper occlusion", filtered)
+    assertNotNull(
+        "Toolbar above the keyboard must remain",
+        findElementByResourceId(filtered!!, "toolbar"),
+    )
+    assertNotNull(
+        "Composer above the keyboard must remain",
+        findElementByResourceId(filtered, "composer"),
+    )
+  }
+
+  @Test
   fun `keyboard window does not remove app window hierarchy via occlusion`() {
     // Simulate the keyboard-open scenario from issue #1488:
     // App window covers full screen [0,0][1280,2856]

--- a/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/ViewHierarchyExtractorTest.kt
+++ b/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/ViewHierarchyExtractorTest.kt
@@ -1,6 +1,7 @@
 package dev.jasonpearson.automobile.ctrlproxy
 
 import android.graphics.Rect
+import android.view.accessibility.AccessibilityWindowInfo
 import dev.jasonpearson.automobile.ctrlproxy.models.ElementBounds
 import dev.jasonpearson.automobile.ctrlproxy.models.UIElementInfo
 import kotlinx.coroutines.test.runTest
@@ -460,6 +461,103 @@ class ViewHierarchyExtractorTest {
     assertEquals("hidden", filtered!!.occlusionState)
     assertEquals("occluding-root", filtered.occludedBy)
     assertNotNull(findElementByResourceId(filtered, "root-child"))
+  }
+
+  @Test
+  fun `pickPrimaryAppWindowId returns null when no IME is up`() {
+    val windows =
+        listOf(
+            ViewHierarchyExtractor.WindowMeta(
+                id = 10,
+                type = AccessibilityWindowInfo.TYPE_APPLICATION,
+                layer = 5,
+                hasRoot = true,
+            ),
+            ViewHierarchyExtractor.WindowMeta(
+                id = 11,
+                type = AccessibilityWindowInfo.TYPE_SYSTEM,
+                layer = 6,
+                hasRoot = true,
+            ),
+        )
+    assertNull(extractor.pickPrimaryAppWindowId(windows))
+  }
+
+  @Test
+  fun `pickPrimaryAppWindowId returns topmost app window when IME is up`() {
+    // Reproduces the Gboard-over-Slack scenario observed on a Pixel 10 Pro:
+    // the IME has isActive=true (owns input focus) and the app window has isActive=false,
+    // so the extractor must not rely on isActive to find the user-facing app.
+    val windows =
+        listOf(
+            ViewHierarchyExtractor.WindowMeta(
+                id = 42,
+                type = AccessibilityWindowInfo.TYPE_APPLICATION,
+                layer = 1,
+                hasRoot = true,
+            ),
+            ViewHierarchyExtractor.WindowMeta(
+                id = 99,
+                type = AccessibilityWindowInfo.TYPE_INPUT_METHOD,
+                layer = 10,
+                hasRoot = true,
+            ),
+            ViewHierarchyExtractor.WindowMeta(
+                id = 7,
+                type = AccessibilityWindowInfo.TYPE_SYSTEM,
+                layer = 20,
+                hasRoot = true,
+            ),
+        )
+    assertEquals(Integer.valueOf(42), extractor.pickPrimaryAppWindowId(windows))
+  }
+
+  @Test
+  fun `pickPrimaryAppWindowId ignores IME with null root`() {
+    // An IME window present in the windows list but without a root cannot contribute
+    // occlusion and should not trigger the primary-window remap.
+    val windows =
+        listOf(
+            ViewHierarchyExtractor.WindowMeta(
+                id = 42,
+                type = AccessibilityWindowInfo.TYPE_APPLICATION,
+                layer = 1,
+                hasRoot = true,
+            ),
+            ViewHierarchyExtractor.WindowMeta(
+                id = 99,
+                type = AccessibilityWindowInfo.TYPE_INPUT_METHOD,
+                layer = 10,
+                hasRoot = false,
+            ),
+        )
+    assertNull(extractor.pickPrimaryAppWindowId(windows))
+  }
+
+  @Test
+  fun `pickPrimaryAppWindowId picks highest-layer app window among multiple`() {
+    val windows =
+        listOf(
+            ViewHierarchyExtractor.WindowMeta(
+                id = 1,
+                type = AccessibilityWindowInfo.TYPE_APPLICATION,
+                layer = 1,
+                hasRoot = true,
+            ),
+            ViewHierarchyExtractor.WindowMeta(
+                id = 2,
+                type = AccessibilityWindowInfo.TYPE_APPLICATION,
+                layer = 3,
+                hasRoot = true,
+            ),
+            ViewHierarchyExtractor.WindowMeta(
+                id = 99,
+                type = AccessibilityWindowInfo.TYPE_INPUT_METHOD,
+                layer = 10,
+                hasRoot = true,
+            ),
+        )
+    assertEquals(Integer.valueOf(2), extractor.pickPrimaryAppWindowId(windows))
   }
 
   @Test

--- a/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/ViewHierarchyExtractorTest.kt
+++ b/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/ViewHierarchyExtractorTest.kt
@@ -509,7 +509,7 @@ class ViewHierarchyExtractorTest {
                 hasRoot = true,
             ),
         )
-    assertEquals(Integer.valueOf(42), extractor.pickPrimaryAppWindowId(windows))
+    assertEquals(42, extractor.pickPrimaryAppWindowId(windows))
   }
 
   @Test
@@ -557,7 +557,7 @@ class ViewHierarchyExtractorTest {
                 hasRoot = true,
             ),
         )
-    assertEquals(Integer.valueOf(2), extractor.pickPrimaryAppWindowId(windows))
+    assertEquals(2, extractor.pickPrimaryAppWindowId(windows))
   }
 
   @Test

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -140,7 +140,7 @@ org.jetbrains.dokka.experimental.gradle.pluginMode=V2Enabled
 # Maven Central Publishing
 
 # Library versions (single source of truth)
-VERSION_NAME=0.0.33-SNAPSHOT
+VERSION_NAME=0.0.33
 GROUP=dev.jasonpearson.auto-mobile
 
 # POM metadata


### PR DESCRIPTION
## Summary
Two related bugs in `ViewHierarchyExtractor` caused `observe` to return zero app nodes whenever a soft keyboard was up. Reproduced on a Pixel 10 Pro with Slack + Gboard; verified fixed end-to-end (44 Slack nodes returned, `tapOn` Send works, message posted).

- **Primary-window selection (aa372964).** With Gboard up, `AccessibilityWindowInfo.isActive` is `true` for the IME and `false` for the app underneath. The extractor used `isActive` to (a) pick `mainHierarchy` and (b) decide which window's nodes to bypass `isVisibleToUser` filtering on — so both decisions went to the keyboard. Added `pickPrimaryAppWindowId()` that returns the topmost `TYPE_APPLICATION` with a root whenever a usable IME is present, and use it for visibility-bypass + mainHierarchy selection + post-occlusion re-selection.
- **IME wrapper occlusion (9b4145c3).** The IME's accessibility root has a transparent wrapper spanning `[0, 172] .. [1080, 2410]` (entire area below status bar) even though its window bounds are `[0, 1464] .. [1080, 2410]` (keyboard only). Treating those wrapper nodes as cross-window occluders covered ~93% of the app window, pushed it over the 0.95 `OCCLUSION_THRESHOLD` together with the status bar, and `filterOccludedHierarchy` stripped every child. Fixed by skipping IME nodes when judging another window in `buildOcclusionInfo`. Same-window IME-vs-IME occlusion is preserved.
- **Post-review cleanup (147a4e12).** Single-pass `pickPrimaryAppWindowId`, drop redundant `hasImeWindow` guards in favor of `primaryAppWindowId != null`, collapse the post-occlusion `mainHierarchy` reassignment, derive the IME-window set once instead of carrying `windowType: String` on every `OcclusionNode`.

## Test plan
- [x] 45 unit tests pass (5 new): `pickPrimaryAppWindowId` no-IME / IME-up / null-root / multi-app, plus an IME-wrapper-occlusion regression mirroring the Pixel 10 Pro hierarchy.
- [x] End-to-end on physical Pixel 10 Pro: rebuilt control-proxy APK from this branch, `observe` over Slack with Gboard up now returns 44 Slack nodes (vs. 0 before), `tapOn({text: "Send"})` matches the content-desc-only Send button, message posted.
- [ ] No iOS work needed — iOS observe uses single-app `XCUIApplication.snapshot()` (no multi-window merge, no cross-window occlusion), so the same bug can't reproduce.