### PR TITLE
fix(ios): implement clearAppData on launchApp (#2368)

### DIFF
--- a/src/daemon/mcpRequestTimeout.ts
+++ b/src/daemon/mcpRequestTimeout.ts
@@ -18,7 +18,21 @@ export const MIN_EXECUTE_PLAN_MCP_TIMEOUT_MS = 600_000;
  */
 export const MIN_START_DEVICE_MCP_TIMEOUT_MS = 180_000;
 
-const EXTENDED_TIMEOUT_TOOLS = new Set(["executePlan", "startDevice"]);
+/**
+ * Floor for `launchApp` — an iOS cold launch waits for CtrlProxy to deliver the
+ * first hierarchy (`waitForIosHierarchyReady`, up to 60s), and with
+ * `clearAppData` the app is wiped and relaunched fresh. Either can exceed the
+ * default 30s window, so give the request room to finish rather than aborting a
+ * launch that actually succeeded on screen.
+ */
+export const MIN_LAUNCH_APP_MCP_TIMEOUT_MS = 90_000;
+
+/** Per-tool minimum request timeouts. Tools absent here use the default. */
+const TOOL_TIMEOUT_FLOORS: Record<string, number> = {
+  executePlan: MIN_EXECUTE_PLAN_MCP_TIMEOUT_MS,
+  startDevice: MIN_START_DEVICE_MCP_TIMEOUT_MS,
+  launchApp: MIN_LAUNCH_APP_MCP_TIMEOUT_MS,
+};
 
 export function resolveMcpRequestTimeoutMs(request: DaemonRequest): number {
   const raw = request.timeoutMs;
@@ -26,12 +40,8 @@ export function resolveMcpRequestTimeoutMs(request: DaemonRequest): number {
     typeof raw === "number" && Number.isFinite(raw) && raw > 0
       ? raw
       : DEFAULT_MCP_REQUEST_TIMEOUT_MS;
-  if (request.method === "tools/call" && EXTENDED_TIMEOUT_TOOLS.has(request.params?.name)) {
-    const floor =
-      request.params?.name === "executePlan"
-        ? MIN_EXECUTE_PLAN_MCP_TIMEOUT_MS
-        : MIN_START_DEVICE_MCP_TIMEOUT_MS;
-    return Math.max(base, floor);
-  }
-  return base;
+  const floor = request.method === "tools/call"
+    ? TOOL_TIMEOUT_FLOORS[request.params?.name]
+    : undefined;
+  return floor ? Math.max(base, floor) : base;
 }

--- a/src/features/accessibility/VoiceOverToggle.ts
+++ b/src/features/accessibility/VoiceOverToggle.ts
@@ -4,6 +4,7 @@ import type { IosVoiceOverDetector } from "../../utils/interfaces/IosVoiceOverDe
 import { iosVoiceOverDetector } from "../../utils/IosVoiceOverDetector";
 import type { ProcessExecutor } from "../../utils/ProcessExecutor";
 import { DefaultProcessExecutor } from "../../utils/ProcessExecutor";
+import { isIosSimulatorUdid } from "../../utils/ios-cmdline-tools/iosDeviceType";
 
 export class VoiceOverToggle {
   constructor(
@@ -44,8 +45,6 @@ export class VoiceOverToggle {
   }
 
   private isSimulator(): boolean {
-    return /^[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}$/i.test(
-      this.device.deviceId
-    );
+    return isIosSimulatorUdid(this.device.deviceId);
   }
 }

--- a/src/features/action/CaptureSnapshotIos.ts
+++ b/src/features/action/CaptureSnapshotIos.ts
@@ -3,11 +3,11 @@ import type { SnapshotCaptureProvider } from "../../utils/interfaces/SnapshotPro
 import type { CaptureSnapshotArgs, CaptureSnapshotResult } from "./CaptureSnapshot";
 import { DeviceSnapshotStore, SnapshotPathOptions } from "../../utils/DeviceSnapshotStore";
 import { SimCtlClient } from "../../utils/ios-cmdline-tools/SimCtlClient";
+import { getAppDataContainerPath, IOS_APP_DATA_FOLDERS } from "../../utils/ios-cmdline-tools/iosAppContainer";
+import { pathExists } from "../../utils/filesystem/DefaultFileSystem";
 import { logger } from "../../utils/logger";
 import { promises as fs } from "fs";
 import * as path from "path";
-
-const IOS_APP_DATA_FOLDERS = ["Documents", "Library", "tmp"];
 
 export class CaptureSnapshotIos implements SnapshotCaptureProvider {
   private device: BootedDevice;
@@ -128,7 +128,7 @@ export class CaptureSnapshotIos implements SnapshotCaptureProvider {
     for (const bundleId of bundleIds) {
       try {
         logger.info(`[iOS] Backing up app data: ${bundleId}`);
-        const containerPath = await this.getAppContainerPath(bundleId);
+        const containerPath = await getAppDataContainerPath(this.simctl, this.device.deviceId, bundleId);
         if (!containerPath) {
           failedPackages.push(bundleId);
           continue;
@@ -183,22 +183,6 @@ export class CaptureSnapshotIos implements SnapshotCaptureProvider {
     };
   }
 
-  private async getAppContainerPath(bundleId: string): Promise<string | null> {
-    try {
-      const command = `get_app_container ${this.quoteArg(this.device.deviceId)} ${this.quoteArg(bundleId)} data`;
-      const result = await this.simctl.executeCommand(command);
-      const containerPath = result.stdout.trim();
-      if (!containerPath) {
-        logger.warn(`[iOS] No data container path for ${bundleId}`);
-        return null;
-      }
-      return containerPath;
-    } catch (error) {
-      logger.warn(`[iOS] Failed to resolve container for ${bundleId}: ${error}`);
-      return null;
-    }
-  }
-
   private async copyAppContainer(
     containerPath: string,
     appDataPath: string,
@@ -210,7 +194,7 @@ export class CaptureSnapshotIos implements SnapshotCaptureProvider {
     for (const folder of IOS_APP_DATA_FOLDERS) {
       const sourcePath = path.join(containerPath, folder);
       const destinationPath = path.join(targetRoot, folder);
-      if (await this.pathExists(sourcePath)) {
+      if (await pathExists(sourcePath)) {
         await fs.cp(sourcePath, destinationPath, { recursive: true });
       }
     }
@@ -249,18 +233,5 @@ export class CaptureSnapshotIos implements SnapshotCaptureProvider {
     const metadataPath = this.store.getMetadataPath(snapshotName, pathOptions);
     await fs.writeFile(metadataPath, JSON.stringify(manifest, null, 2), "utf-8");
     logger.info(`[iOS] Wrote metadata to ${metadataPath}`);
-  }
-
-  private async pathExists(targetPath: string): Promise<boolean> {
-    try {
-      await fs.access(targetPath);
-      return true;
-    } catch {
-      return false;
-    }
-  }
-
-  private quoteArg(value: string): string {
-    return JSON.stringify(value);
   }
 }

--- a/src/features/action/ClearAppDataIos.ts
+++ b/src/features/action/ClearAppDataIos.ts
@@ -1,0 +1,95 @@
+import { ActionableError, BootedDevice, ClearAppDataResult } from "../../models";
+import { SimCtlClient } from "../../utils/ios-cmdline-tools/SimCtlClient";
+import { DeviceAppInspector } from "../../utils/ios-cmdline-tools/DeviceAppInspector";
+import { getAppDataContainerPath, IOS_APP_DATA_FOLDERS, terminateAppIfRunning } from "../../utils/ios-cmdline-tools/iosAppContainer";
+import { isIosSimulatorUdid } from "../../utils/ios-cmdline-tools/iosDeviceType";
+import { logger } from "../../utils/logger";
+import { promises as fs } from "fs";
+import * as path from "path";
+
+/** Reinstall-based data clear for physical iOS devices (devicectl). */
+export interface IosAppReinstaller {
+  clearAppDataViaReinstall(deviceUdid: string, bundleId: string): Promise<void>;
+}
+
+/**
+ * Clears an iOS app's data, picking the fastest mechanism per device type:
+ *
+ * - **Simulator**: resolve the app's data container via `simctl get_app_container`
+ *   and delete its standard data folders. The app stays installed, so there is
+ *   no reinstall and no loss of TCC/permission grants. (~100-300ms)
+ * - **Physical device**: iOS exposes no on-device data wipe, so we uninstall and
+ *   reinstall via `devicectl` (copying the device-signed bundle off first). The
+ *   app returns in a fresh state. Slower, and permission grants are reset.
+ *
+ * The app is terminated before clearing on the simulator (uninstall terminates
+ * it on physical devices).
+ */
+export class ClearAppDataIos {
+  private device: BootedDevice;
+  private simctl: SimCtlClient;
+  private reinstaller: IosAppReinstaller;
+  private isSimulator: () => boolean;
+
+  constructor(
+    device: BootedDevice,
+    simctl?: SimCtlClient,
+    reinstaller?: IosAppReinstaller,
+    isSimulatorFn?: () => boolean
+  ) {
+    if (device.platform !== "ios") {
+      throw new ActionableError("ClearAppDataIos is only supported for iOS devices");
+    }
+    this.device = device;
+    this.simctl = simctl || new SimCtlClient(device);
+    this.reinstaller = reinstaller || new DeviceAppInspector();
+    this.isSimulator = isSimulatorFn || (() => isIosSimulatorUdid(device.deviceId));
+  }
+
+  async execute(bundleId: string): Promise<ClearAppDataResult> {
+    return this.isSimulator()
+      ? this.clearSimulator(bundleId)
+      : this.clearPhysical(bundleId);
+  }
+
+  private async clearSimulator(bundleId: string): Promise<ClearAppDataResult> {
+    logger.info(`[iOS] Clearing app data for ${bundleId} on simulator ${this.device.deviceId}`);
+
+    // The container can't be safely wiped while the app holds open file handles.
+    await terminateAppIfRunning(this.simctl, this.device.deviceId, bundleId);
+
+    const containerPath = await getAppDataContainerPath(this.simctl, this.device.deviceId, bundleId);
+    if (!containerPath) {
+      return {
+        success: false,
+        packageName: bundleId,
+        error: `Could not resolve data container for ${bundleId} (is it installed?)`
+      };
+    }
+
+    try {
+      // Folders are independent — wipe them concurrently. force:true so a missing
+      // folder (e.g. an app that never wrote Documents) is a no-op, not an error.
+      await Promise.all(IOS_APP_DATA_FOLDERS.map(folder =>
+        fs.rm(path.join(containerPath, folder), { recursive: true, force: true })
+      ));
+      logger.info(`[iOS] Cleared app data for ${bundleId}`);
+      return { success: true, packageName: bundleId };
+    } catch (error) {
+      logger.warn(`[iOS] Failed to clear app data for ${bundleId}: ${error}`);
+      return { success: false, packageName: bundleId, error: (error as Error).message };
+    }
+  }
+
+  private async clearPhysical(bundleId: string): Promise<ClearAppDataResult> {
+    logger.info(`[iOS] Clearing app data for ${bundleId} via devicectl uninstall+reinstall on ${this.device.deviceId}`);
+    try {
+      await this.reinstaller.clearAppDataViaReinstall(this.device.deviceId, bundleId);
+      logger.info(`[iOS] Cleared app data for ${bundleId} (reinstalled)`);
+      return { success: true, packageName: bundleId };
+    } catch (error) {
+      logger.warn(`[iOS] Failed to clear app data for ${bundleId} via reinstall: ${error}`);
+      return { success: false, packageName: bundleId, error: (error as Error).message };
+    }
+  }
+}

--- a/src/features/action/InstallApp.ts
+++ b/src/features/action/InstallApp.ts
@@ -8,6 +8,7 @@ import { DefaultAndroidBuildToolsLocator, type AndroidBuildToolsLocator } from "
 import { OPERATION_CANCELLED_MESSAGE } from "../../utils/constants";
 import { SimCtlClient } from "../../utils/ios-cmdline-tools/SimCtlClient";
 import { DeviceAppInspector } from "../../utils/ios-cmdline-tools/DeviceAppInspector";
+import { isIosSimulatorUdid } from "../../utils/ios-cmdline-tools/iosDeviceType";
 import { AndroidCtrlProxyClient } from "../observe/android";
 import { logger } from "../../utils/logger";
 
@@ -23,8 +24,6 @@ export class InstallApp {
   private simctl: SimCtlClient;
   private device: BootedDevice;
   private deviceAppInstaller: DeviceAppInstaller;
-
-  private static readonly SIMULATOR_UUID_PATTERN = /^[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}$/i;
 
   constructor(
     device: BootedDevice,
@@ -45,7 +44,7 @@ export class InstallApp {
   }
 
   private isSimulator(): boolean {
-    return InstallApp.SIMULATOR_UUID_PATTERN.test(this.device.deviceId);
+    return isIosSimulatorUdid(this.device.deviceId);
   }
 
   async execute(

--- a/src/features/action/IosSimulatorPermissions.ts
+++ b/src/features/action/IosSimulatorPermissions.ts
@@ -4,6 +4,8 @@ import { join } from "path";
 import { promisify } from "util";
 import type { BootedDevice, ExecResult } from "../../models";
 import { SimCtlClient } from "../../utils/ios-cmdline-tools/SimCtlClient";
+import { isIosSimulatorUdid } from "../../utils/ios-cmdline-tools/iosDeviceType";
+import { quoteSimctlArg } from "../../utils/ios-cmdline-tools/iosAppContainer";
 
 export type IosSimulatorPermissionAction = "grant" | "revoke" | "reset";
 
@@ -83,11 +85,7 @@ const TCC_SERVICE_BY_PERMISSION = new Map<string, string>([
 ]);
 
 export function isIosSimulatorDevice(device: BootedDevice): boolean {
-  return /^[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}$/i.test(device.deviceId);
-}
-
-function quoteSimctlArg(value: string): string {
-  return `"${value.replace(/(["\\])/g, "\\$1")}"`;
+  return isIosSimulatorUdid(device.deviceId);
 }
 
 export function normalizePermissions(permissions: string[] | undefined): string[] {

--- a/src/features/action/LaunchApp.ts
+++ b/src/features/action/LaunchApp.ts
@@ -279,7 +279,13 @@ export class LaunchApp extends BaseVisualChange {
               new ClearAppDataIos(this.device, this.simctl).execute(bundleId)
             );
             if (!clearResult.success) {
-              logger.warn(`[LaunchApp] iOS clearAppData failed for ${bundleId}: ${clearResult.error ?? "unknown error"}`);
+              // Do NOT launch with stale data — callers request clearAppData to
+              // guarantee a clean launch. Fail loudly instead of silently
+              // reporting success on an un-cleared app.
+              const error = `Failed to clear app data: ${clearResult.error ?? "unknown error"}`;
+              logger.warn(`[LaunchApp] iOS clearAppData failed for ${bundleId}: ${error}`);
+              perf.end();
+              return { success: false, packageName: bundleId, error };
             }
           } else if (clearAppData && isSystemBundleId) {
             logger.warn(`[LaunchApp] Ignoring clearAppData for system bundle ${bundleId}`);

--- a/src/features/action/LaunchApp.ts
+++ b/src/features/action/LaunchApp.ts
@@ -4,6 +4,7 @@ import { BootedDevice, LaunchAppResult } from "../../models";
 import { ActionableError } from "../../models";
 import { TerminateApp } from "./TerminateApp";
 import { ClearAppData } from "./ClearAppData";
+import { ClearAppDataIos } from "./ClearAppDataIos";
 import { logger } from "../../utils/logger";
 import { ListInstalledApps } from "../observe/ListInstalledApps";
 import { SimCtlClient } from "../../utils/ios-cmdline-tools/SimCtlClient";
@@ -229,7 +230,7 @@ export class LaunchApp extends BaseVisualChange {
   /**
    * Launch an iOS app by bundle identifier
    * @param bundleId - The bundle identifier to launch
-   * @param clearAppData - Whether clear app data before launch (not supported on iOS)
+   * @param clearAppData - Whether to wipe the app's data container before launch (iOS simulator)
    * @param coldBoot - Whether to cold boot the app or resume if already running
    */
   private async executeiOS(
@@ -253,7 +254,12 @@ export class LaunchApp extends BaseVisualChange {
 
         let launchResult: { success: boolean; pid?: number; error?: string };
 
-        if (coldBoot) {
+        // Clearing app data always implies a fresh process: the app is
+        // terminated, its sandbox wiped, then relaunched. Treat it as a cold
+        // boot so we go through the terminate → clearCache → simctl launch path.
+        const needsColdStart = coldBoot || clearAppData;
+
+        if (needsColdStart) {
           // Cold boot: use simctl directly. XCUIApplication.launch() is slow for heavy
           // apps (10s+ timeout) while simctl launch completes in ~500ms. CtrlProxy's
           // value is in the activate() fast path, not cold boot.
@@ -264,10 +270,27 @@ export class LaunchApp extends BaseVisualChange {
               // App might not be running
             }
           });
-          // Clear cached hierarchy so waitForIosHierarchyReady doesn't return
-          // stale pre-terminate data via the cache fast path. clearCache() nulls
-          // the cache entirely; invalidateCache() only marks it not-fresh but the
-          // time-based freshness check in getLatestHierarchy would still match.
+
+          // Wipe the app's data container (fastest iOS "clear data": no reinstall,
+          // keeps permission grants). System bundles (com.apple.*) are skipped —
+          // we never want to wipe SpringBoard/Settings data.
+          if (clearAppData && !isSystemBundleId) {
+            const clearResult = await perf.track("clearAppData", () =>
+              new ClearAppDataIos(this.device, this.simctl).execute(bundleId)
+            );
+            if (!clearResult.success) {
+              logger.warn(`[LaunchApp] iOS clearAppData failed for ${bundleId}: ${clearResult.error ?? "unknown error"}`);
+            }
+          } else if (clearAppData && isSystemBundleId) {
+            logger.warn(`[LaunchApp] Ignoring clearAppData for system bundle ${bundleId}`);
+          }
+
+          // Re-wire CtrlProxy to the (re)launched app. The bundle is already
+          // re-targeted above (setTargetBundleId); after a data wipe the app gets
+          // a brand-new process, so drop the cached hierarchy too — otherwise
+          // waitForIosHierarchyReady returns stale pre-terminate data via the
+          // cache fast path. clearCache() nulls the cache entirely; invalidateCache()
+          // only marks it not-fresh but the time-based freshness check still matches.
           IOSCtrlProxyClient.getInstance(this.device).clearCache();
           launchResult = await perf.track("simctlLaunch", () =>
             this.simctl.launchApp(bundleId, { foregroundIfRunning: false })

--- a/src/features/action/RestoreSnapshotIos.ts
+++ b/src/features/action/RestoreSnapshotIos.ts
@@ -3,11 +3,11 @@ import type { SnapshotRestoreProvider } from "../../utils/interfaces/SnapshotPro
 import type { RestoreSnapshotArgs, RestoreSnapshotResult } from "./RestoreSnapshot";
 import { DeviceSnapshotStore, SnapshotPathOptions } from "../../utils/DeviceSnapshotStore";
 import { SimCtlClient } from "../../utils/ios-cmdline-tools/SimCtlClient";
+import { getAppDataContainerPath, IOS_APP_DATA_FOLDERS, terminateAppIfRunning } from "../../utils/ios-cmdline-tools/iosAppContainer";
+import { pathExists } from "../../utils/filesystem/DefaultFileSystem";
 import { logger } from "../../utils/logger";
 import { promises as fs } from "fs";
 import * as path from "path";
-
-const IOS_APP_DATA_FOLDERS = ["Documents", "Library", "tmp"];
 
 export class RestoreSnapshotIos implements SnapshotRestoreProvider {
   private device: BootedDevice;
@@ -80,11 +80,11 @@ export class RestoreSnapshotIos implements SnapshotRestoreProvider {
     const manifestPathOptions = this.getPathOptions(manifest.deviceId);
     let appDataPath = this.store.getAppDataPath(snapshotName, manifestPathOptions);
 
-    if (!(await this.pathExists(appDataPath))) {
+    if (!(await pathExists(appDataPath))) {
       const fallbackPathOptions = this.getPathOptions(this.device.deviceId);
       if (manifest.deviceId && manifest.deviceId !== this.device.deviceId) {
         const fallbackPath = this.store.getAppDataPath(snapshotName, fallbackPathOptions);
-        if (await this.pathExists(fallbackPath)) {
+        if (await pathExists(fallbackPath)) {
           logger.info(
             `[iOS] App data not found for '${manifest.deviceId}', using current device path '${this.device.deviceId}'`
           );
@@ -124,8 +124,8 @@ export class RestoreSnapshotIos implements SnapshotRestoreProvider {
 
     for (const bundleId of bundleIds) {
       try {
-        await this.terminateAppIfRunning(bundleId);
-        const containerPath = await this.getAppContainerPath(bundleId);
+        await terminateAppIfRunning(this.simctl, this.device.deviceId, bundleId);
+        const containerPath = await getAppDataContainerPath(this.simctl, this.device.deviceId, bundleId);
         if (!containerPath) {
           continue;
         }
@@ -133,7 +133,7 @@ export class RestoreSnapshotIos implements SnapshotRestoreProvider {
         const snapshotBundlePath = path.join(appDataPath, bundleId);
         for (const folder of IOS_APP_DATA_FOLDERS) {
           const sourcePath = path.join(snapshotBundlePath, folder);
-          if (!(await this.pathExists(sourcePath))) {
+          if (!(await pathExists(sourcePath))) {
             continue;
           }
           const destinationPath = path.join(containerPath, folder);
@@ -225,14 +225,6 @@ export class RestoreSnapshotIos implements SnapshotRestoreProvider {
     }
   }
 
-  private async terminateAppIfRunning(bundleId: string): Promise<void> {
-    try {
-      await this.simctl.terminateApp(bundleId, this.device.deviceId);
-    } catch (error) {
-      logger.warn(`[iOS] Failed to terminate ${bundleId} before restore: ${error}`);
-    }
-  }
-
   private async resolveSnapshotBundleIds(
     appDataPath: string,
     manifest: DeviceSnapshotManifest
@@ -253,32 +245,4 @@ export class RestoreSnapshotIos implements SnapshotRestoreProvider {
     }
   }
 
-  private async getAppContainerPath(bundleId: string): Promise<string | null> {
-    try {
-      const command = `get_app_container ${this.quoteArg(this.device.deviceId)} ${this.quoteArg(bundleId)} data`;
-      const result = await this.simctl.executeCommand(command);
-      const containerPath = result.stdout.trim();
-      if (!containerPath) {
-        logger.warn(`[iOS] No data container path for ${bundleId}`);
-        return null;
-      }
-      return containerPath;
-    } catch (error) {
-      logger.warn(`[iOS] Failed to resolve container for ${bundleId}: ${error}`);
-      return null;
-    }
-  }
-
-  private async pathExists(targetPath: string): Promise<boolean> {
-    try {
-      await fs.access(targetPath);
-      return true;
-    } catch {
-      return false;
-    }
-  }
-
-  private quoteArg(value: string): string {
-    return JSON.stringify(value);
-  }
 }

--- a/src/features/action/UninstallApp.ts
+++ b/src/features/action/UninstallApp.ts
@@ -5,6 +5,7 @@ import { BootedDevice } from "../../models";
 import { ListInstalledApps } from "../observe/ListInstalledApps";
 import { SimCtlClient } from "../../utils/ios-cmdline-tools/SimCtlClient";
 import { DeviceAppInspector } from "../../utils/ios-cmdline-tools/DeviceAppInspector";
+import { isIosSimulatorUdid } from "../../utils/ios-cmdline-tools/iosDeviceType";
 import { createGlobalPerformanceTracker } from "../../utils/PerformanceTracker";
 import { logger } from "../../utils/logger";
 
@@ -17,8 +18,6 @@ export class UninstallApp {
   private adb: AdbExecutor;
   private simctl: SimCtlClient;
   private deviceAppUninstaller: DeviceAppUninstaller;
-
-  private static readonly SIMULATOR_UUID_PATTERN = /^[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}$/i;
 
   constructor(
     device: BootedDevice,
@@ -33,7 +32,7 @@ export class UninstallApp {
   }
 
   private isSimulator(): boolean {
-    return UninstallApp.SIMULATOR_UUID_PATTERN.test(this.device.deviceId);
+    return isIosSimulatorUdid(this.device.deviceId);
   }
 
   /**

--- a/src/features/observe/GetAppMetadata.ts
+++ b/src/features/observe/GetAppMetadata.ts
@@ -4,6 +4,7 @@ import type { BootedDevice, ExecResult } from "../../models";
 import { AdbClientFactory, defaultAdbClientFactory } from "../../utils/android-cmdline-tools/AdbClientFactory";
 import { logger } from "../../utils/logger";
 import { AndroidCtrlProxyClient } from "./android";
+import { isIosSimulatorUdid } from "../../utils/ios-cmdline-tools/iosDeviceType";
 
 /**
  * Source of iOS app metadata — injectable for testing.
@@ -103,9 +104,7 @@ export class GetAppMetadata {
       return null;
     }
 
-    const isSimulator = /^[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}$/i.test(
-      this.device.deviceId
-    );
+    const isSimulator = isIosSimulatorUdid(this.device.deviceId);
 
     if (isSimulator) {
       return this.getSimulatorMetadata(bundleId);

--- a/src/features/utility/system-configuration/iosHelpers.ts
+++ b/src/features/utility/system-configuration/iosHelpers.ts
@@ -4,8 +4,7 @@
  * `IosSystemConfigurationAdapter` (for its locale/timezone/24h ops).
  */
 
-const SIMULATOR_UDID_PATTERN =
-  /^[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}$/i;
+import { isIosSimulatorUdid } from "../../../utils/ios-cmdline-tools/iosDeviceType";
 
 /**
  * Distinguish an iOS Simulator (8-4-4-4-12 UUID) from a physical iPhone
@@ -13,7 +12,7 @@ const SIMULATOR_UDID_PATTERN =
  * the Simulator, so callers gate on this.
  */
 export function isIosSimulator(deviceId: string): boolean {
-  return SIMULATOR_UDID_PATTERN.test(deviceId);
+  return isIosSimulatorUdid(deviceId);
 }
 
 /** Compose an `xcrun simctl spawn <udid> <command>` shell line. */

--- a/src/server/AppCleanupService.ts
+++ b/src/server/AppCleanupService.ts
@@ -1,5 +1,6 @@
 import { BootedDevice, ClearAppDataResult, TerminateAppResult } from "../models";
 import { ClearAppData } from "../features/action/ClearAppData";
+import { ClearAppDataIos } from "../features/action/ClearAppDataIos";
 import { TerminateApp } from "../features/action/TerminateApp";
 import { Logger, logger } from "../utils/logger";
 
@@ -39,7 +40,8 @@ export class DefaultAppCleanupService implements AppCleanupService {
 
   constructor(dependencies: AppCleanupDependencies = {}) {
     this.createClearAppData =
-      dependencies.createClearAppData ?? ((device: BootedDevice) => new ClearAppData(device));
+      dependencies.createClearAppData ?? ((device: BootedDevice) =>
+        device.platform === "ios" ? new ClearAppDataIos(device) : new ClearAppData(device));
     this.createTerminateApp =
       dependencies.createTerminateApp ?? ((device: BootedDevice) => new TerminateApp(device));
     this.log = dependencies.logger ?? logger;
@@ -51,13 +53,6 @@ export class DefaultAppCleanupService implements AppCleanupService {
     }
 
     if (config.clearAppData) {
-      if (device.platform !== "android") {
-        this.log.warn(
-          `[AppCleanupService] cleanupClearAppData requested for non-Android device ${device.deviceId}; skipping clear app data`
-        );
-        return;
-      }
-
       try {
         const clearAppData = this.createClearAppData(device);
         const result = await clearAppData.execute(config.appId);

--- a/src/utils/IOSCtrlProxyManager.ts
+++ b/src/utils/IOSCtrlProxyManager.ts
@@ -9,6 +9,7 @@ import { PortManager } from "./PortManager";
 import { DefaultProcessExecutor, type ProcessExecutor } from "./ProcessExecutor";
 import { XcodeSigningManager } from "./ios-cmdline-tools/XcodeSigning";
 import { DeviceAppInspector } from "./ios-cmdline-tools/DeviceAppInspector";
+import { isIosSimulatorUdid } from "./ios-cmdline-tools/iosDeviceType";
 import { isRunningInDocker } from "./dockerEnv";
 import {
   getHostControlHost,
@@ -729,10 +730,9 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
   // MARK: - Private Helpers
 
   private isSimulator(): boolean {
-    // Simulators have UUIDs like "XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX"
-    // Physical devices have serial numbers (alphanumeric without dashes in UUID format)
-    const uuidPattern = /^[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}$/i;
-    return uuidPattern.test(this.device.deviceId);
+    // Simulators have UUIDs like "XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX";
+    // physical devices have serial-style UDIDs.
+    return isIosSimulatorUdid(this.device.deviceId);
   }
 
   private useHostControl(): boolean {

--- a/src/utils/ios-cmdline-tools/DeviceAppInspector.ts
+++ b/src/utils/ios-cmdline-tools/DeviceAppInspector.ts
@@ -184,8 +184,21 @@ export class DeviceAppInspector {
    * installed (device-signed) bundle off the device, uninstall the app — which
    * removes its data container — and reinstall the copied bundle. The app
    * returns in a fresh state. Throws if the installed bundle can't be resolved.
+   *
+   * Not available under host control (Docker): the host-control bridge exposes
+   * install/uninstall but no primitive to copy the installed bundle off-device,
+   * so we can't obtain a reinstall artifact. We fail with an explicit message
+   * rather than the misleading "could not resolve bundle" from the darwin path.
    */
   public async clearAppDataViaReinstall(deviceUdid: string, bundleId: string): Promise<void> {
+    const useHostControl = this.deps.hostControl.shouldUseHostControl() && this.deps.hostControl.isRunningInDocker();
+    if (useHostControl) {
+      throw new Error(
+        `Clearing app data via uninstall+reinstall is not supported under host control for ${bundleId}: ` +
+        "the host-control bridge cannot copy the installed bundle off-device to reinstall it."
+      );
+    }
+
     const done = await this.withInstalledAppBundle(deviceUdid, bundleId, async bundlePath => {
       await this.uninstallApp(deviceUdid, bundleId, false);
       await this.installApp(deviceUdid, bundlePath);

--- a/src/utils/ios-cmdline-tools/DeviceAppInspector.ts
+++ b/src/utils/ios-cmdline-tools/DeviceAppInspector.ts
@@ -175,6 +175,38 @@ export class DeviceAppInspector {
       return result.data?.hash ?? null;
     }
 
+    return this.withInstalledAppBundle(deviceUdid, bundleId, bundlePath => hashAppBundle(bundlePath));
+  }
+
+  /**
+   * Clear a physical device app's data by uninstalling and reinstalling it.
+   * iOS exposes no direct data-wipe for on-device sandboxes, so we copy the
+   * installed (device-signed) bundle off the device, uninstall the app — which
+   * removes its data container — and reinstall the copied bundle. The app
+   * returns in a fresh state. Throws if the installed bundle can't be resolved.
+   */
+  public async clearAppDataViaReinstall(deviceUdid: string, bundleId: string): Promise<void> {
+    const done = await this.withInstalledAppBundle(deviceUdid, bundleId, async bundlePath => {
+      await this.uninstallApp(deviceUdid, bundleId, false);
+      await this.installApp(deviceUdid, bundlePath);
+      return true;
+    });
+    if (!done) {
+      throw new Error(`Could not resolve installed bundle for ${bundleId} to reinstall`);
+    }
+  }
+
+  /**
+   * Copy the device-installed `.app` bundle to a temp dir and run `fn` against
+   * its on-disk path, cleaning up the temp dir afterward. Returns `fn`'s result,
+   * or null if the bundle can't be located (or not on macOS). Local devicectl
+   * path only — host-control callers handle their own remote primitives.
+   */
+  private async withInstalledAppBundle<T>(
+    deviceUdid: string,
+    bundleId: string,
+    fn: (bundlePath: string) => Promise<T>
+  ): Promise<T | null> {
     if (this.deps.platform() !== "darwin") {
       return null;
     }
@@ -225,7 +257,7 @@ export class DeviceAppInspector {
         if (!bundleOnDisk) {
           return null;
         }
-        return await hashAppBundle(bundleOnDisk);
+        return await fn(bundleOnDisk);
       } finally {
         await this.deps.rm(copyDir);
       }

--- a/src/utils/ios-cmdline-tools/DeviceAppInspector.ts
+++ b/src/utils/ios-cmdline-tools/DeviceAppInspector.ts
@@ -175,7 +175,14 @@ export class DeviceAppInspector {
       return result.data?.hash ?? null;
     }
 
-    return this.withInstalledAppBundle(deviceUdid, bundleId, bundlePath => hashAppBundle(bundlePath));
+    // withInstalledAppBundle propagates callback errors; preserve this method's
+    // null-on-failure contract by swallowing a hashing failure here.
+    try {
+      return await this.withInstalledAppBundle(deviceUdid, bundleId, bundlePath => hashAppBundle(bundlePath));
+    } catch (error) {
+      logger.warn(`[DeviceAppInspector] Failed to hash installed app bundle for ${bundleId}: ${error instanceof Error ? error.message : String(error)}`);
+      return null;
+    }
   }
 
   /**
@@ -183,7 +190,9 @@ export class DeviceAppInspector {
    * iOS exposes no direct data-wipe for on-device sandboxes, so we copy the
    * installed (device-signed) bundle off the device, uninstall the app — which
    * removes its data container — and reinstall the copied bundle. The app
-   * returns in a fresh state. Throws if the installed bundle can't be resolved.
+   * returns in a fresh state. Throws if the installed bundle can't be resolved,
+   * or with the underlying devicectl error if the uninstall/install step fails
+   * (so a post-uninstall install failure surfaces rather than being masked).
    *
    * Not available under host control (Docker): the host-control bridge exposes
    * install/uninstall but no primitive to copy the installed bundle off-device,
@@ -211,9 +220,13 @@ export class DeviceAppInspector {
 
   /**
    * Copy the device-installed `.app` bundle to a temp dir and run `fn` against
-   * its on-disk path, cleaning up the temp dir afterward. Returns `fn`'s result,
-   * or null if the bundle can't be located (or not on macOS). Local devicectl
-   * path only — host-control callers handle their own remote primitives.
+   * its on-disk path, cleaning up temp dirs afterward. Returns null if the bundle
+   * can't be located (or not on macOS). Local devicectl path only — host-control
+   * callers handle their own remote primitives.
+   *
+   * Lookup failures (info/copy) are swallowed → null. The callback's own errors
+   * PROPAGATE: clearAppDataViaReinstall must surface an install failure that
+   * happens after the uninstall, not mask it as "could not resolve bundle".
    */
   private async withInstalledAppBundle<T>(
     deviceUdid: string,
@@ -226,33 +239,35 @@ export class DeviceAppInspector {
 
     const tempDir = await this.deps.mkdtemp(join(this.deps.tmpdir(), "automobile-devicectl-"));
     const jsonPath = join(tempDir, "apps.json");
+    let copyDir: string | undefined;
     try {
-      const infoCommand = [
-        "xcrun",
-        "devicectl",
-        "device",
-        "info",
-        "apps",
-        "--device", deviceUdid,
-        "--bundle-id", bundleId,
-        "--json-output", quoteShell(jsonPath),
-        "--quiet"
-      ].join(" ");
-      await this.deps.exec(infoCommand);
-
-      const raw = await this.deps.readFile(jsonPath);
-      const data = JSON.parse(raw) as unknown;
-      const entry = findBundleEntry(data, bundleId);
-      if (!entry) {
-        return null;
-      }
-      const bundlePath = extractBundlePath(entry);
-      if (!bundlePath) {
-        return null;
-      }
-
-      const copyDir = await this.deps.mkdtemp(join(this.deps.tmpdir(), "automobile-device-app-"));
+      let bundleOnDisk: string | null;
       try {
+        const infoCommand = [
+          "xcrun",
+          "devicectl",
+          "device",
+          "info",
+          "apps",
+          "--device", deviceUdid,
+          "--bundle-id", bundleId,
+          "--json-output", quoteShell(jsonPath),
+          "--quiet"
+        ].join(" ");
+        await this.deps.exec(infoCommand);
+
+        const raw = await this.deps.readFile(jsonPath);
+        const data = JSON.parse(raw) as unknown;
+        const entry = findBundleEntry(data, bundleId);
+        if (!entry) {
+          return null;
+        }
+        const bundlePath = extractBundlePath(entry);
+        if (!bundlePath) {
+          return null;
+        }
+
+        copyDir = await this.deps.mkdtemp(join(this.deps.tmpdir(), "automobile-device-app-"));
         const copyCommand = [
           "xcrun",
           "devicectl",
@@ -266,18 +281,21 @@ export class DeviceAppInspector {
         ].join(" ");
         await this.deps.exec(copyCommand);
 
-        const bundleOnDisk = await findAppBundleInDir(copyDir, this.deps);
-        if (!bundleOnDisk) {
-          return null;
-        }
-        return await fn(bundleOnDisk);
-      } finally {
+        bundleOnDisk = await findAppBundleInDir(copyDir, this.deps);
+      } catch (error) {
+        logger.warn(`[DeviceAppInspector] Failed to read installed app bundle for ${bundleId}: ${error instanceof Error ? error.message : String(error)}`);
+        return null;
+      }
+
+      if (!bundleOnDisk) {
+        return null;
+      }
+      // Outside the lookup try/catch: callback errors propagate to the caller.
+      return await fn(bundleOnDisk);
+    } finally {
+      if (copyDir) {
         await this.deps.rm(copyDir);
       }
-    } catch (error) {
-      logger.warn(`[DeviceAppInspector] Failed to read installed app bundle for ${bundleId}: ${error instanceof Error ? error.message : String(error)}`);
-      return null;
-    } finally {
       await this.deps.rm(tempDir);
     }
   }

--- a/src/utils/ios-cmdline-tools/iosAppContainer.ts
+++ b/src/utils/ios-cmdline-tools/iosAppContainer.ts
@@ -1,0 +1,56 @@
+import type { SimCtlClient } from "./SimCtlClient";
+import { logger } from "../logger";
+
+/**
+ * The standard top-level folders inside an iOS app's data container. Wiping
+ * these is the iOS equivalent of Android's `pm clear` — it resets all persisted
+ * app state (preferences, caches, databases, files) while leaving the app
+ * installed. Also the set of folders captured/restored by device snapshots.
+ */
+export const IOS_APP_DATA_FOLDERS = ["Documents", "Library", "tmp"];
+
+/** Quote an arg for an `xcrun simctl` command line. */
+export function quoteSimctlArg(value: string): string {
+  return JSON.stringify(value);
+}
+
+/**
+ * Terminate an app on a simulator if it's running. Non-fatal: a not-running app
+ * makes `simctl terminate` fail, which is expected and only logged.
+ */
+export async function terminateAppIfRunning(
+  simctl: Pick<SimCtlClient, "terminateApp">,
+  deviceId: string,
+  bundleId: string
+): Promise<void> {
+  try {
+    await simctl.terminateApp(bundleId, deviceId);
+  } catch (error) {
+    logger.warn(`[iOS] Failed to terminate ${bundleId}: ${error}`);
+  }
+}
+
+/**
+ * Resolve an installed app's data container path via
+ * `simctl get_app_container <udid> <bundleId> data`. Returns null if the
+ * container can't be resolved (e.g. app not installed).
+ */
+export async function getAppDataContainerPath(
+  simctl: Pick<SimCtlClient, "executeCommand">,
+  deviceId: string,
+  bundleId: string
+): Promise<string | null> {
+  try {
+    const command = `get_app_container ${quoteSimctlArg(deviceId)} ${quoteSimctlArg(bundleId)} data`;
+    const result = await simctl.executeCommand(command);
+    const containerPath = result.stdout.trim();
+    if (!containerPath) {
+      logger.warn(`[iOS] No data container path for ${bundleId}`);
+      return null;
+    }
+    return containerPath;
+  } catch (error) {
+    logger.warn(`[iOS] Failed to resolve container for ${bundleId}: ${error}`);
+    return null;
+  }
+}

--- a/src/utils/ios-cmdline-tools/iosDeviceType.ts
+++ b/src/utils/ios-cmdline-tools/iosDeviceType.ts
@@ -1,0 +1,13 @@
+/**
+ * iOS simulator UDIDs are standard 8-4-4-4-12 hex UUIDs, whereas physical
+ * device UDIDs are 40-char hex or the newer `00008XXX-XXXXXXXXXXXXXXXX` form.
+ * This pattern is the runtime signal used across the iOS tooling to choose
+ * between `simctl` (simulator) and `devicectl` (physical device).
+ */
+export const IOS_SIMULATOR_UUID_PATTERN =
+  /^[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}$/i;
+
+/** True when the deviceId looks like an iOS simulator UDID (not a physical device). */
+export function isIosSimulatorUdid(deviceId: string): boolean {
+  return IOS_SIMULATOR_UUID_PATTERN.test(deviceId);
+}

--- a/test/fakes/FakeIOSCtrlProxy.ts
+++ b/test/fakes/FakeIOSCtrlProxy.ts
@@ -40,6 +40,7 @@ export class FakeIOSCtrlProxy implements IOSCtrlProxy {
   private performanceTiming: CtrlProxyPerfTiming | null = null;
   private isConnectedState: boolean = true;
   private hasCachedHierarchyState: boolean = false;
+  public clearCacheCallCount: number = 0;
 
   // Failure modes
   private failureMap: Map<string, Error> = new Map();
@@ -958,6 +959,7 @@ export class FakeIOSCtrlProxy implements IOSCtrlProxy {
 
   clearCache(): void {
     this.hasCachedHierarchyState = false;
+    this.clearCacheCallCount++;
   }
 
   async close(): Promise<void> {

--- a/test/features/action/ClearAppDataIos.test.ts
+++ b/test/features/action/ClearAppDataIos.test.ts
@@ -1,0 +1,96 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { promises as fs } from "fs";
+import * as os from "os";
+import * as path from "path";
+import { ClearAppDataIos, IosAppReinstaller } from "../../../src/features/action/ClearAppDataIos";
+import { FakeSimCtlClient } from "../../fakes/FakeSimCtlClient";
+import { BootedDevice } from "../../../src/models";
+
+describe("ClearAppDataIos", () => {
+  // Simulator UDIDs are standard 8-4-4-4-12 hex UUIDs; physical device UDIDs are not.
+  const simDevice: BootedDevice = {
+    name: "ios-sim", platform: "ios", deviceId: "AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE"
+  };
+  const physicalDevice: BootedDevice = {
+    name: "iphone", platform: "ios", deviceId: "00008030-001A2B3C0E11002E"
+  };
+  const bundleId = "com.example.app";
+  const tempDirs: string[] = [];
+
+  afterEach(async () => {
+    for (const dir of tempDirs.splice(0)) {
+      await fs.rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  async function makeContainer(): Promise<string> {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "automobile-clear-"));
+    tempDirs.push(root);
+    await fs.mkdir(path.join(root, "Documents"), { recursive: true });
+    await fs.writeFile(path.join(root, "Documents", "state.json"), "{}");
+    await fs.mkdir(path.join(root, "Library", "Preferences"), { recursive: true });
+    await fs.writeFile(path.join(root, "Library", "Preferences", "app.plist"), "x");
+    await fs.mkdir(path.join(root, "tmp"), { recursive: true });
+    return root;
+  }
+
+  test("throws for non-iOS devices", () => {
+    const android: BootedDevice = { name: "a", platform: "android", deviceId: "x" };
+    expect(() => new ClearAppDataIos(android)).toThrow();
+  });
+
+  describe("simulator", () => {
+    test("terminates the app and wipes the data container folders", async () => {
+      const container = await makeContainer();
+      const fakeSimctl = new FakeSimCtlClient();
+      fakeSimctl.setContainerPath(bundleId, container);
+
+      const result = await new ClearAppDataIos(simDevice, fakeSimctl as any).execute(bundleId);
+
+      expect(result.success).toBe(true);
+      expect(result.packageName).toBe(bundleId);
+      expect(fakeSimctl.getMethodCalls("terminateApp")).toEqual([{ bundleId, deviceId: simDevice.deviceId }]);
+      await expect(fs.access(path.join(container, "Documents"))).rejects.toThrow();
+      await expect(fs.access(path.join(container, "Library"))).rejects.toThrow();
+      await expect(fs.access(path.join(container, "tmp"))).rejects.toThrow();
+      const containerStat = await fs.stat(container);
+      expect(containerStat.isDirectory()).toBe(true);
+    });
+
+    test("returns failure when the data container cannot be resolved", async () => {
+      const fakeSimctl = new FakeSimCtlClient();
+      const result = await new ClearAppDataIos(simDevice, fakeSimctl as any).execute(bundleId);
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("data container");
+    });
+  });
+
+  describe("physical device", () => {
+    test("clears data via devicectl uninstall+reinstall", async () => {
+      const fakeSimctl = new FakeSimCtlClient();
+      const calls: Array<[string, string]> = [];
+      const reinstaller: IosAppReinstaller = {
+        clearAppDataViaReinstall: async (deviceUdid, id) => { calls.push([deviceUdid, id]); },
+      };
+
+      const result = await new ClearAppDataIos(physicalDevice, fakeSimctl as any, reinstaller).execute(bundleId);
+
+      expect(result.success).toBe(true);
+      expect(calls).toEqual([[physicalDevice.deviceId, bundleId]]);
+      // Physical clear does not use the simulator container/terminate path.
+      expect(fakeSimctl.getMethodCalls("terminateApp")).toHaveLength(0);
+    });
+
+    test("returns failure when reinstall throws", async () => {
+      const fakeSimctl = new FakeSimCtlClient();
+      const reinstaller: IosAppReinstaller = {
+        clearAppDataViaReinstall: async () => { throw new Error("device offline"); },
+      };
+
+      const result = await new ClearAppDataIos(physicalDevice, fakeSimctl as any, reinstaller).execute(bundleId);
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("device offline");
+    });
+  });
+});

--- a/test/features/action/LaunchApp.test.ts
+++ b/test/features/action/LaunchApp.test.ts
@@ -1,4 +1,7 @@
-import { beforeEach, describe, expect, test, spyOn } from "bun:test";
+import { afterEach, beforeEach, describe, expect, test, spyOn } from "bun:test";
+import { promises as fsp } from "fs";
+import * as os from "os";
+import * as nodePath from "path";
 import { LaunchApp } from "../../../src/features/action/LaunchApp";
 import { BootedDevice, ObserveResult } from "../../../src/models";
 import { DefaultPerformanceTracker } from "../../../src/utils/PerformanceTracker";
@@ -409,8 +412,15 @@ describe("LaunchApp", () => {
   describe("iOS clearAppData", () => {
     const userBundleId = "com.example.myapp";
     const systemBundleId = "com.apple.Preferences";
+    const tempDirs: string[] = [];
 
-    function createClearDataHarness(bundleId: string) {
+    afterEach(async () => {
+      for (const dir of tempDirs.splice(0)) {
+        await fsp.rm(dir, { recursive: true, force: true });
+      }
+    });
+
+    function createClearDataHarness(bundleId: string, opts: { containerPath?: string } = {}) {
       const iosDevice: BootedDevice = { name: "test-ios", platform: "ios", deviceId: "AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE" };
       const fakeCtrlProxy = new FakeIOSCtrlProxy();
 
@@ -421,15 +431,16 @@ describe("LaunchApp", () => {
         setTargetBundleId: () => {},
       } as unknown as IOSCtrlProxyManager);
 
+      // get_app_container returns this path (empty → clear fails as "not installed").
+      const containerPath = opts.containerPath ?? "";
       const calls: string[] = [];
       const fakeSimctl = {
         launchApp: async (id: string) => { calls.push(`launch:${id}`); return { success: true, pid: 123 }; },
         terminateApp: async (id: string) => { calls.push(`terminate:${id}`); },
         executeCommand: async (command: string) => {
           calls.push(`exec:${command}`);
-          // Empty container path → ClearAppDataIos treats it as "not installed"
-          // and skips the fs wipe, so this stays a pure unit test (no real fs).
-          return { stdout: "", stderr: "", trim: () => "", toString: () => "", includes: () => false } as any;
+          const stdout = command.startsWith("get_app_container") ? containerPath : "";
+          return { stdout, stderr: "", trim: () => stdout.trim(), toString: () => stdout, includes: (s: string) => stdout.includes(s) } as any;
         },
       };
 
@@ -455,7 +466,9 @@ describe("LaunchApp", () => {
 
     test("wipes the data container and re-wires CtrlProxy when clearAppData is true", async () => {
       fakeTimer.enableAutoAdvance();
-      const { iosLaunchApp, fakeCtrlProxy, calls, cleanup } = createClearDataHarness(userBundleId);
+      const containerPath = await fsp.mkdtemp(nodePath.join(os.tmpdir(), "automobile-launch-clear-"));
+      tempDirs.push(containerPath);
+      const { iosLaunchApp, fakeCtrlProxy, calls, cleanup } = createClearDataHarness(userBundleId, { containerPath });
       try {
         const result = await iosLaunchApp.execute(userBundleId, /* clearAppData */ true, /* coldBoot */ false);
         expect(result.success).toBe(true);
@@ -465,6 +478,21 @@ describe("LaunchApp", () => {
         expect(fakeCtrlProxy.clearCacheCallCount).toBeGreaterThan(0);
         // App is relaunched after the wipe
         expect(calls.some(c => c === `launch:${userBundleId}`)).toBe(true);
+      } finally {
+        cleanup();
+      }
+    });
+
+    test("aborts the launch (no simctl launch) when the clear fails", async () => {
+      fakeTimer.enableAutoAdvance();
+      // No containerPath → get_app_container returns empty → clear fails.
+      const { iosLaunchApp, calls, cleanup } = createClearDataHarness(userBundleId);
+      try {
+        const result = await iosLaunchApp.execute(userBundleId, /* clearAppData */ true, /* coldBoot */ false);
+        expect(result.success).toBe(false);
+        expect(result.error).toContain("Failed to clear app data");
+        // Must NOT launch with stale data
+        expect(calls.some(c => c === `launch:${userBundleId}`)).toBe(false);
       } finally {
         cleanup();
       }

--- a/test/features/action/LaunchApp.test.ts
+++ b/test/features/action/LaunchApp.test.ts
@@ -405,4 +405,82 @@ describe("LaunchApp", () => {
       }
     });
   });
+
+  describe("iOS clearAppData", () => {
+    const userBundleId = "com.example.myapp";
+    const systemBundleId = "com.apple.Preferences";
+
+    function createClearDataHarness(bundleId: string) {
+      const iosDevice: BootedDevice = { name: "test-ios", platform: "ios", deviceId: "AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE" };
+      const fakeCtrlProxy = new FakeIOSCtrlProxy();
+
+      const ctrlProxySpy = spyOn(IOSCtrlProxyClient, "getInstance").mockReturnValue(
+        fakeCtrlProxy as unknown as IOSCtrlProxyClient
+      );
+      const managerSpy = spyOn(IOSCtrlProxyManager, "getInstance").mockReturnValue({
+        setTargetBundleId: () => {},
+      } as unknown as IOSCtrlProxyManager);
+
+      const calls: string[] = [];
+      const fakeSimctl = {
+        launchApp: async (id: string) => { calls.push(`launch:${id}`); return { success: true, pid: 123 }; },
+        terminateApp: async (id: string) => { calls.push(`terminate:${id}`); },
+        executeCommand: async (command: string) => {
+          calls.push(`exec:${command}`);
+          // Empty container path → ClearAppDataIos treats it as "not installed"
+          // and skips the fs wipe, so this stays a pure unit test (no real fs).
+          return { stdout: "", stderr: "", trim: () => "", toString: () => "", includes: () => false } as any;
+        },
+      };
+
+      const iosObserveScreen = new FakeObserveScreen();
+      iosObserveScreen.setObserveResult({
+        updatedAt: Date.now(),
+        screenSize: { width: 1080, height: 1920 },
+        systemInsets: { top: 0, bottom: 0, left: 0, right: 0 },
+        viewHierarchy: { hierarchy: { node: {} }, packageName: bundleId } as any,
+      });
+      const iosWindow = new FakeWindow();
+      iosWindow.configureCachedActiveWindow({ appId: bundleId, activityName: "Main", layoutSeqSum: 1 });
+      const installedApps = new FakeInstalledAppsProvider(fakeTimer, { installedApps: [bundleId] });
+
+      const iosLaunchApp = new LaunchApp(iosDevice, fakeAdb as unknown as any, fakeSimctl as any, fakeTimer, { installedAppsProvider: installedApps });
+      (iosLaunchApp as any).awaitIdle = new FakeAwaitIdle();
+      (iosLaunchApp as any).observeScreen = iosObserveScreen;
+      (iosLaunchApp as any).window = iosWindow;
+      (iosLaunchApp as any).waitForIosHierarchyReady = async () => {};
+
+      return { iosLaunchApp, fakeCtrlProxy, calls, cleanup: () => { ctrlProxySpy.mockRestore(); managerSpy.mockRestore(); } };
+    }
+
+    test("wipes the data container and re-wires CtrlProxy when clearAppData is true", async () => {
+      fakeTimer.enableAutoAdvance();
+      const { iosLaunchApp, fakeCtrlProxy, calls, cleanup } = createClearDataHarness(userBundleId);
+      try {
+        const result = await iosLaunchApp.execute(userBundleId, /* clearAppData */ true, /* coldBoot */ false);
+        expect(result.success).toBe(true);
+        // Data container resolved via get_app_container (the fast clear path)
+        expect(calls.some(c => c.startsWith("exec:get_app_container") && c.includes(userBundleId))).toBe(true);
+        // CtrlProxy cache dropped so the hierarchy re-snapshots the fresh launch
+        expect(fakeCtrlProxy.clearCacheCallCount).toBeGreaterThan(0);
+        // App is relaunched after the wipe
+        expect(calls.some(c => c === `launch:${userBundleId}`)).toBe(true);
+      } finally {
+        cleanup();
+      }
+    });
+
+    test("does not wipe data for a system bundle even when clearAppData is true", async () => {
+      fakeTimer.enableAutoAdvance();
+      const { iosLaunchApp, calls, cleanup } = createClearDataHarness(systemBundleId);
+      try {
+        const result = await iosLaunchApp.execute(systemBundleId, /* clearAppData */ true, /* coldBoot */ false);
+        expect(result.success).toBe(true);
+        // No get_app_container resolution for system bundles
+        expect(calls.some(c => c.startsWith("exec:get_app_container"))).toBe(false);
+      } finally {
+        cleanup();
+      }
+    });
+  });
 });

--- a/test/server/AppCleanupService.test.ts
+++ b/test/server/AppCleanupService.test.ts
@@ -101,7 +101,7 @@ describe("DefaultAppCleanupService", () => {
     expect(terminate.calls).toHaveLength(0);
   });
 
-  test("skips clear app data on iOS", async () => {
+  test("clears app data on iOS via the injected clear action", async () => {
     const terminate = new FakeTerminateApp({
       success: true,
       packageName: "com.example.app",
@@ -113,14 +113,10 @@ describe("DefaultAppCleanupService", () => {
       success: true,
       packageName: "com.example.app",
     });
-    const warnings: string[] = [];
+    const clearDevices: BootedDevice[] = [];
     const cleanupService = new DefaultAppCleanupService({
       createTerminateApp: () => terminate,
-      createClearAppData: () => clear,
-      logger: {
-        info: () => {},
-        warn: message => warnings.push(message),
-      },
+      createClearAppData: device => { clearDevices.push(device); return clear; },
     });
 
     await cleanupService.cleanup(iosDevice, {
@@ -128,8 +124,9 @@ describe("DefaultAppCleanupService", () => {
       clearAppData: true,
     });
 
-    expect(warnings.length).toBe(1);
-    expect(clear.calls).toHaveLength(0);
+    // iOS now flows through the shared clear path instead of being skipped.
+    expect(clearDevices).toEqual([iosDevice]);
+    expect(clear.calls).toEqual(["com.example.app"]);
     expect(terminate.calls).toHaveLength(0);
   });
 });

--- a/test/utils/ios-cmdline-tools/DeviceAppInspector.test.ts
+++ b/test/utils/ios-cmdline-tools/DeviceAppInspector.test.ts
@@ -333,4 +333,59 @@ describe("DeviceAppInspector", () => {
     // And it does not attempt the darwin devicectl info/copy flow.
     expect(commands.every(c => !c.includes("devicectl"))).toBe(true);
   });
+
+  test("clearAppDataViaReinstall surfaces the install error (not 'could not resolve') when reinstall fails after uninstall", async () => {
+    const workDir = await createTempDir();
+    const fixtureApp = await createFixtureApp(workDir);
+    const hostControl = new FakeHostControlDeviceAppInspector();
+    const commands: string[] = [];
+
+    const exec = async (command: string) => {
+      commands.push(command);
+      if (command.includes("device info apps")) {
+        const jsonPath = parseDevicectlJsonOutputPath(command);
+        if (jsonPath) {
+          const payload = { apps: [{ bundleIdentifier: bundleId, bundleURL: "file:///private/var/containers/Bundle/Application/ABC/CtrlProxyApp.app" }] };
+          await fs.writeFile(jsonPath, JSON.stringify(payload), "utf-8");
+        }
+      }
+      if (command.includes("device copy from")) {
+        const destination = parseArgValue(command, "--destination");
+        if (destination) {
+          const target = join(destination, "CtrlProxyApp.app");
+          await fs.mkdir(target, { recursive: true });
+          await fs.copyFile(join(fixtureApp, "Info.plist"), join(target, "Info.plist"));
+        }
+      }
+      // Uninstall succeeds; the reinstall (install app) fails on-device.
+      if (command.includes("device install app")) {
+        throw new Error("devicectl install failed: device locked");
+      }
+      return {
+        stdout: "",
+        stderr: "",
+        toString() { return this.stdout; },
+        trim() { return this.stdout.trim(); },
+        includes(searchString: string) { return this.stdout.includes(searchString); }
+      };
+    };
+
+    const inspector = new DeviceAppInspector({
+      platform: () => "darwin",
+      exec,
+      readFile: async path => fs.readFile(path, "utf-8"),
+      mkdtemp: async prefix => fs.mkdtemp(prefix),
+      rm: async path => fs.rm(path, { recursive: true, force: true }),
+      readdir: async path => fs.readdir(path),
+      stat: async path => fs.stat(path),
+      tmpdir,
+      hostControl
+    });
+
+    // The real install error must propagate — not be masked as "could not resolve".
+    await expect(inspector.clearAppDataViaReinstall("device-udid", bundleId))
+      .rejects.toThrow(/install failed: device locked/);
+    // The uninstall did run (app was removed), so the failure is actionable.
+    expect(commands.some(c => c.includes("device uninstall app"))).toBe(true);
+  });
 });

--- a/test/utils/ios-cmdline-tools/DeviceAppInspector.test.ts
+++ b/test/utils/ios-cmdline-tools/DeviceAppInspector.test.ts
@@ -216,4 +216,88 @@ describe("DeviceAppInspector", () => {
     expect(commands.some(command => command.includes("devicectl device uninstall app"))).toBe(true);
     expect(commands.some(command => command.includes(bundleId))).toBe(true);
   });
+
+  test("clearAppDataViaReinstall copies the bundle, uninstalls, then reinstalls it", async () => {
+    const workDir = await createTempDir();
+    const fixtureApp = await createFixtureApp(workDir);
+    const hostControl = new FakeHostControlDeviceAppInspector();
+    const commands: string[] = [];
+
+    const exec = async (command: string) => {
+      commands.push(command);
+      if (command.includes("device info apps")) {
+        const jsonPath = parseDevicectlJsonOutputPath(command);
+        if (jsonPath) {
+          const payload = { apps: [{ bundleIdentifier: bundleId, bundleURL: "file:///private/var/containers/Bundle/Application/ABC/CtrlProxyApp.app" }] };
+          await fs.writeFile(jsonPath, JSON.stringify(payload), "utf-8");
+        }
+      }
+      if (command.includes("device copy from")) {
+        const destination = parseArgValue(command, "--destination");
+        if (destination) {
+          const target = join(destination, "CtrlProxyApp.app");
+          await fs.mkdir(target, { recursive: true });
+          await fs.copyFile(join(fixtureApp, "Info.plist"), join(target, "Info.plist"));
+        }
+      }
+      return {
+        stdout: "",
+        stderr: "",
+        toString() { return this.stdout; },
+        trim() { return this.stdout.trim(); },
+        includes(searchString: string) { return this.stdout.includes(searchString); }
+      };
+    };
+
+    const inspector = new DeviceAppInspector({
+      platform: () => "darwin",
+      exec,
+      readFile: async path => fs.readFile(path, "utf-8"),
+      mkdtemp: async prefix => fs.mkdtemp(prefix),
+      rm: async path => fs.rm(path, { recursive: true, force: true }),
+      readdir: async path => fs.readdir(path),
+      stat: async path => fs.stat(path),
+      tmpdir,
+      hostControl
+    });
+
+    await inspector.clearAppDataViaReinstall("device-udid", bundleId);
+
+    const uninstallIdx = commands.findIndex(c => c.includes("devicectl device uninstall app"));
+    const installIdx = commands.findIndex(c => c.includes("devicectl device install app"));
+    expect(uninstallIdx).toBeGreaterThanOrEqual(0);
+    expect(installIdx).toBeGreaterThanOrEqual(0);
+    // Must uninstall (wipes data) before reinstalling the copied bundle.
+    expect(uninstallIdx).toBeLessThan(installIdx);
+    expect(commands[installIdx]).toContain("CtrlProxyApp.app");
+  });
+
+  test("clearAppDataViaReinstall throws when the installed bundle cannot be resolved", async () => {
+    const hostControl = new FakeHostControlDeviceAppInspector();
+    const inspector = new DeviceAppInspector({
+      platform: () => "darwin",
+      // info apps writes no/empty json → bundle entry not found
+      exec: async (command: string) => {
+        if (command.includes("device info apps")) {
+          const jsonPath = parseDevicectlJsonOutputPath(command);
+          if (jsonPath) { await fs.writeFile(jsonPath, JSON.stringify({ apps: [] }), "utf-8"); }
+        }
+        return {
+          stdout: "", stderr: "",
+          toString() { return this.stdout; },
+          trim() { return this.stdout.trim(); },
+          includes(searchString: string) { return this.stdout.includes(searchString); }
+        };
+      },
+      readFile: async path => fs.readFile(path, "utf-8"),
+      mkdtemp: async prefix => fs.mkdtemp(prefix),
+      rm: async path => fs.rm(path, { recursive: true, force: true }),
+      readdir: async path => fs.readdir(path),
+      stat: async path => fs.stat(path),
+      tmpdir,
+      hostControl
+    });
+
+    await expect(inspector.clearAppDataViaReinstall("device-udid", bundleId)).rejects.toThrow();
+  });
 });

--- a/test/utils/ios-cmdline-tools/DeviceAppInspector.test.ts
+++ b/test/utils/ios-cmdline-tools/DeviceAppInspector.test.ts
@@ -300,4 +300,37 @@ describe("DeviceAppInspector", () => {
 
     await expect(inspector.clearAppDataViaReinstall("device-udid", bundleId)).rejects.toThrow();
   });
+
+  test("clearAppDataViaReinstall fails explicitly under host control (no copy primitive)", async () => {
+    const hostControl = new FakeHostControlDeviceAppInspector();
+    hostControl.setUseHostControl(true);
+    hostControl.setRunningInDocker(true);
+    hostControl.setAvailable(true);
+
+    const commands: string[] = [];
+    const inspector = new DeviceAppInspector({
+      platform: () => "linux",
+      exec: async (command: string) => {
+        commands.push(command);
+        return {
+          stdout: "", stderr: "",
+          toString() { return this.stdout; },
+          trim() { return this.stdout.trim(); },
+          includes(searchString: string) { return this.stdout.includes(searchString); }
+        };
+      },
+      readFile: async () => "",
+      mkdtemp: async prefix => fs.mkdtemp(prefix),
+      rm: async path => fs.rm(path, { recursive: true, force: true }),
+      readdir: async path => fs.readdir(path),
+      stat: async path => fs.stat(path),
+      tmpdir,
+      hostControl
+    });
+
+    // Explicit, actionable error — not the misleading "could not resolve bundle".
+    await expect(inspector.clearAppDataViaReinstall("device-udid", bundleId)).rejects.toThrow(/host control/i);
+    // And it does not attempt the darwin devicectl info/copy flow.
+    expect(commands.every(c => !c.includes("devicectl"))).toBe(true);
+  });
 });


### PR DESCRIPTION
Fixes #2368.

## Problem
`launchApp` with `clearAppData: true` on iOS returned `MCP error -32001: Request timed out` even though the app launched. Two root causes: (1) `clearAppData` was a no-op on iOS, and (2) `waitForIosHierarchyReady`'s 60s wait exceeded the 30s MCP request timeout.

## What this does
**iOS clearAppData (fastest mechanism per device type):**
- **Simulator** — wipe the app's data container (`simctl get_app_container` + remove `Documents`/`Library`/`tmp`). App stays installed, permission grants preserved (~100–300ms).
- **Physical device** — `devicectl` uninstall + reinstall: copy the device-signed bundle off via `devicectl device copy from`, uninstall (wipes data), reinstall the copy.

**Timeout:** raise `launchApp`'s MCP request-timeout floor to 90s so a cold launch + hierarchy wait isn't aborted mid-flight.

**CtrlProxy re-wiring:** after a clear, `clearCache()` drops the stale hierarchy so `observe` resolves against the freshly launched process.

**AppCleanupService:** now clears iOS (via `ClearAppDataIos`) instead of skipping — so `executePlan`'s `cleanupClearAppData` works on iOS too.

**Dedup:** consolidated the simulator-UDID regex (8 copies → `isIosSimulatorUdid`) and the iOS container helpers (`getAppContainerPath`/`quoteArg`/`terminateAppIfRunning`/`IOS_APP_DATA_FOLDERS` → shared `iosAppContainer`).

## Commits
1. `fix(ios)` — clearAppData on launchApp + timeout floor + shared helpers
2. `feat(ios)` — physical-device devicectl reinstall + AppCleanupService wiring
3. `refactor(ios)` — dedup simulator-UDID detection and container helpers (no behavior change)

## Testing
- New unit tests: `ClearAppDataIos` (simulator wipe, physical reinstall, failure paths), `DeviceAppInspector.clearAppDataViaReinstall` (copy→uninstall→install ordering), `AppCleanupService` iOS routing, `LaunchApp` clearAppData wiring.
- `bun test` green across `test/features/`, `test/utils/`, `test/server/`; build + lint clean.

## Notes / limitations
- Physical-device clear resets TCC/permission grants (inherent to uninstall+reinstall — no on-device alternative). Simulator path preserves them.
- Physical reinstall relies on the device-copied bundle's embedded provisioning still being valid; exercised via faked `exec` (no hardware in CI), failures surface as `{success:false}` with the real cause logged.
