### PR TITLE
Add inputText event modes

### DIFF
--- a/schemas/tool-definitions.json
+++ b/schemas/tool-definitions.json
@@ -1792,6 +1792,15 @@
           "minLength": 1,
           "description": "Text to input"
         },
+        "mode": {
+          "description": "(Android only) Text input mode. a11y (default) sets text directly. eventLast sets text with a11y up to the last printable non-whitespace ASCII character, sends that character as a real key event, then restores any suffix with a11y. eventAll clears the field with a11y, sends key events for mappable ASCII characters, and uses a11y for Unicode/emoji runs. Search fields that use autocomplete should probably try eventLast; otherwise accept the default.",
+          "type": "string",
+          "enum": [
+            "a11y",
+            "eventLast",
+            "eventAll"
+          ]
+        },
         "imeAction": {
           "description": "IME action after input",
           "type": "string",

--- a/schemas/tool-definitions.json
+++ b/schemas/tool-definitions.json
@@ -1782,7 +1782,7 @@
   },
   {
     "name": "inputText",
-    "description": "Input text",
+    "description": "Input text. The optional mode field is Android-only and ignored on iOS.",
     "inputSchema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "type": "object",
@@ -1793,7 +1793,7 @@
           "description": "Text to input"
         },
         "mode": {
-          "description": "(Android only) Text input mode. a11y (default) sets text directly. eventLast sets text with a11y up to the last printable non-whitespace ASCII character, sends that character as a real key event, then restores any suffix with a11y. eventAll clears the field with a11y, sends key events for mappable ASCII characters, and uses a11y for Unicode/emoji runs. Search fields that use autocomplete should probably try eventLast; otherwise accept the default.",
+          "description": "(Android only; ignored on iOS) Text input mode. a11y (default) sets text directly. eventLast sets text with a11y up to the last printable non-whitespace ASCII character, sends that character as a real key event, then restores any suffix with a11y. eventAll clears the field with a11y, sends key events for mappable ASCII characters, and uses a11y for Unicode/emoji runs. Search fields that use autocomplete should probably try eventLast; otherwise accept the default.",
           "type": "string",
           "enum": [
             "a11y",

--- a/src/features/action/InputText.ts
+++ b/src/features/action/InputText.ts
@@ -5,12 +5,22 @@ import { createGlobalPerformanceTracker } from "../../utils/PerformanceTracker";
 import { AndroidCtrlProxyClient } from "../observe/android";
 import { IOSCtrlProxyClient } from "../observe/ios";
 import { defaultTimer } from "../../utils/SystemTimer";
+import { readAndroidDeviceApiLevel } from "../../utils/android-cmdline-tools/readAndroidDeviceApiLevel";
 import type { AdbClientFactory } from "../../utils/android-cmdline-tools/AdbClientFactory";
 import type { AdbExecutor } from "../../utils/android-cmdline-tools/interfaces/AdbExecutor";
 
 export type InputTextMode = "a11y" | "eventLast" | "eventAll";
 
+interface KeyEventPlan {
+  commands: string[];
+  needsTextRestore: boolean;
+}
+
+const ANDROID_KEYCOMBINATION_MIN_API_LEVEL = 31;
+
 export class InputText extends BaseVisualChange {
+  private androidInputKeyCombinationSupported: boolean | undefined;
+
   constructor(device: BootedDevice, adbFactoryOrExecutor: AdbClientFactory | AdbExecutor | null = null) {
     super(device, adbFactoryOrExecutor);
     this.device = device;
@@ -157,16 +167,16 @@ export class InputText extends BaseVisualChange {
       };
     }
 
-    const keyCommand = this.getAsciiKeyEventCommand(char);
-    if (!keyCommand) {
+    const keyEventPlan = await this.getAsciiKeyEventPlan(char);
+    if (!keyEventPlan) {
       logger.info(`[InputText] eventLast could not map ASCII character ${JSON.stringify(char)} to a key event; using a11y`);
       const result = await this.executeAndroidTextInput(text, imeAction, dismissKeyboard, "a11y");
       return { ...result, method: "a11y" };
     }
 
-    await this.adb.executeCommand(keyCommand);
+    await this.executeKeyEventPlan(keyEventPlan);
 
-    if (suffix.length > 0 || dismissKeyboard) {
+    if (suffix.length > 0 || dismissKeyboard || keyEventPlan.needsTextRestore) {
       const finalResult = await a11yClient.requestSetText(text, undefined, undefined, undefined, dismissKeyboard);
       if (!finalResult.success) {
         logger.warn(`[InputText] eventLast final setText failed: ${finalResult.error}`);
@@ -197,7 +207,7 @@ export class InputText extends BaseVisualChange {
     dismissKeyboard: boolean = false
   ): Promise<SendTextResult & { method?: InputTextMode }> {
     const chars = Array.from(text);
-    if (!chars.some(char => this.getAsciiKeyEventCommand(char))) {
+    if (!await this.hasAsciiKeyEventPlan(chars)) {
       const result = await this.executeAndroidTextInput(text, imeAction, dismissKeyboard, "a11y");
       return { ...result, method: "a11y" };
     }
@@ -217,16 +227,28 @@ export class InputText extends BaseVisualChange {
     let targetText = "";
     for (let index = 0; index < chars.length; index++) {
       const char = chars[index] ?? "";
-      const keyCommand = this.getAsciiKeyEventCommand(char);
+      const keyEventPlan = await this.getAsciiKeyEventPlan(char);
 
-      if (keyCommand) {
-        await this.adb.executeCommand(keyCommand);
+      if (keyEventPlan) {
+        await this.executeKeyEventPlan(keyEventPlan);
         targetText += char;
+        if (keyEventPlan.needsTextRestore) {
+          const restoreResult = await a11yClient.requestSetText(targetText, undefined, undefined, undefined, false);
+          if (!restoreResult.success) {
+            logger.warn(`[InputText] eventAll restore setText failed after legacy key events: ${restoreResult.error}`);
+            return {
+              success: false,
+              text,
+              error: `Accessibility service setText failed after eventAll key event: ${restoreResult.error}`,
+              method: "eventAll"
+            };
+          }
+        }
         continue;
       }
 
       let unsupportedRun = char;
-      while (index + 1 < chars.length && !this.getAsciiKeyEventCommand(chars[index + 1] ?? "")) {
+      while (index + 1 < chars.length && !(await this.getAsciiKeyEventPlan(chars[index + 1] ?? ""))) {
         index++;
         unsupportedRun += chars[index] ?? "";
       }
@@ -285,17 +307,33 @@ export class InputText extends BaseVisualChange {
     return null;
   }
 
-  private getAsciiKeyEventCommand(char: string): string | null {
+  private async hasAsciiKeyEventPlan(chars: string[]): Promise<boolean> {
+    for (const char of chars) {
+      if (await this.getAsciiKeyEventPlan(char)) {
+        return true;
+      }
+    }
+
+    return false;
+  }
+
+  private async getAsciiKeyEventPlan(char: string): Promise<KeyEventPlan | null> {
     if (/^[a-z]$/.test(char)) {
-      return `shell input keyevent KEYCODE_${char.toUpperCase()}`;
+      return {
+        commands: [`shell input keyevent KEYCODE_${char.toUpperCase()}`],
+        needsTextRestore: false
+      };
     }
 
     if (/^[A-Z]$/.test(char)) {
-      return `shell input keycombination KEYCODE_SHIFT_LEFT KEYCODE_${char}`;
+      return this.createShiftedKeyEventPlan(`KEYCODE_${char}`);
     }
 
     if (/^[0-9]$/.test(char)) {
-      return `shell input keyevent KEYCODE_${char}`;
+      return {
+        commands: [`shell input keyevent KEYCODE_${char}`],
+        needsTextRestore: false
+      };
     }
 
     const directKeyCodes: Record<string, string> = {
@@ -339,15 +377,49 @@ export class InputText extends BaseVisualChange {
 
     const direct = directKeyCodes[char];
     if (direct) {
-      return `shell input keyevent ${direct}`;
+      return {
+        commands: [`shell input keyevent ${direct}`],
+        needsTextRestore: false
+      };
     }
 
     const shifted = shiftedKeyCodes[char];
     if (shifted) {
-      return `shell input keycombination KEYCODE_SHIFT_LEFT ${shifted}`;
+      return this.createShiftedKeyEventPlan(shifted);
     }
 
     return null;
+  }
+
+  private async createShiftedKeyEventPlan(baseKeyCode: string): Promise<KeyEventPlan> {
+    if (await this.supportsAndroidInputKeyCombination()) {
+      return {
+        commands: [`shell input keycombination KEYCODE_SHIFT_LEFT ${baseKeyCode}`],
+        needsTextRestore: false
+      };
+    }
+
+    return {
+      commands: [`shell input keyevent KEYCODE_SHIFT_LEFT ${baseKeyCode}`],
+      needsTextRestore: true
+    };
+  }
+
+  private async supportsAndroidInputKeyCombination(): Promise<boolean> {
+    if (this.androidInputKeyCombinationSupported !== undefined) {
+      return this.androidInputKeyCombinationSupported;
+    }
+
+    const apiLevel = await readAndroidDeviceApiLevel(this.adb);
+    this.androidInputKeyCombinationSupported =
+      apiLevel !== null && apiLevel >= ANDROID_KEYCOMBINATION_MIN_API_LEVEL;
+    return this.androidInputKeyCombinationSupported;
+  }
+
+  private async executeKeyEventPlan(plan: KeyEventPlan): Promise<void> {
+    for (const command of plan.commands) {
+      await this.adb.executeCommand(command);
+    }
   }
 
   /**

--- a/src/features/action/InputText.ts
+++ b/src/features/action/InputText.ts
@@ -1,4 +1,3 @@
-import { AdbClient } from "../../utils/android-cmdline-tools/AdbClient";
 import { BaseVisualChange } from "./BaseVisualChange";
 import { BootedDevice, SendTextResult } from "../../models";
 import { logger } from "../../utils/logger";
@@ -6,18 +5,23 @@ import { createGlobalPerformanceTracker } from "../../utils/PerformanceTracker";
 import { AndroidCtrlProxyClient } from "../observe/android";
 import { IOSCtrlProxyClient } from "../observe/ios";
 import { defaultTimer } from "../../utils/SystemTimer";
+import type { AdbClientFactory } from "../../utils/android-cmdline-tools/AdbClientFactory";
+import type { AdbExecutor } from "../../utils/android-cmdline-tools/interfaces/AdbExecutor";
+
+export type InputTextMode = "a11y" | "eventLast" | "eventAll";
 
 export class InputText extends BaseVisualChange {
-  constructor(device: BootedDevice, adb: AdbClient | null = null) {
-    super(device, adb);
+  constructor(device: BootedDevice, adbFactoryOrExecutor: AdbClientFactory | AdbExecutor | null = null) {
+    super(device, adbFactoryOrExecutor);
     this.device = device;
   }
 
   async execute(
     text: string,
     imeAction?: "done" | "next" | "search" | "send" | "go" | "previous",
-    dismissKeyboard: boolean = false
-  ): Promise<SendTextResult & { method?: "a11y" }> {
+    dismissKeyboard: boolean = false,
+    mode: InputTextMode = "a11y"
+  ): Promise<SendTextResult & { method?: InputTextMode }> {
     const perf = createGlobalPerformanceTracker();
     perf.serial("inputText");
 
@@ -39,7 +43,7 @@ export class InputText extends BaseVisualChange {
           switch (this.device.platform) {
             case "android":
               return await perf.track("androidTextInput", () =>
-                this.executeAndroidTextInput(text, imeAction, dismissKeyboard)
+                this.executeAndroidTextInput(text, imeAction, dismissKeyboard, mode)
               );
             case "ios":
               // dismissKeyboard is Android-only — it works around an emulator
@@ -59,7 +63,7 @@ export class InputText extends BaseVisualChange {
             success: false,
             text,
             error: `Failed to send text input: ${errorMessage}`,
-            method: "a11y"
+            method: this.device.platform === "android" ? mode : "a11y"
           };
         }
       },
@@ -82,8 +86,17 @@ export class InputText extends BaseVisualChange {
   private async executeAndroidTextInput(
     text: string,
     imeAction?: "done" | "next" | "search" | "send" | "go" | "previous",
-    dismissKeyboard: boolean = false
-  ): Promise<SendTextResult & { method?: "a11y" }> {
+    dismissKeyboard: boolean = false,
+    mode: InputTextMode = "a11y"
+  ): Promise<SendTextResult & { method?: InputTextMode }> {
+    if (mode === "eventLast") {
+      return this.executeAndroidEventLastTextInput(text, imeAction, dismissKeyboard);
+    }
+
+    if (mode === "eventAll") {
+      return this.executeAndroidEventAllTextInput(text, imeAction, dismissKeyboard);
+    }
+
     // Use accessibility service exclusively (fastest method, ~10-30ms vs ~200-300ms for ADB)
     // It also natively supports Unicode without needing virtual keyboard
     const a11yClient = AndroidCtrlProxyClient.getInstance(this.device, this.adbFactory);
@@ -113,6 +126,228 @@ export class InputText extends BaseVisualChange {
       error: `Accessibility service setText failed: ${a11yResult.error}`,
       method: "a11y"
     };
+  }
+
+  private async executeAndroidEventLastTextInput(
+    text: string,
+    imeAction?: "done" | "next" | "search" | "send" | "go" | "previous",
+    dismissKeyboard: boolean = false
+  ): Promise<SendTextResult & { method?: InputTextMode }> {
+    const split = this.findLastPrintableAsciiNonWhitespace(text);
+
+    if (!split) {
+      logger.info("[InputText] eventLast requested but no printable non-whitespace ASCII character was found; using a11y");
+      const result = await this.executeAndroidTextInput(text, imeAction, dismissKeyboard, "a11y");
+      return { ...result, method: "a11y" };
+    }
+
+    const { index, char } = split;
+    const prefix = text.slice(0, index);
+    const suffix = text.slice(index + 1);
+    const a11yClient = AndroidCtrlProxyClient.getInstance(this.device, this.adbFactory);
+
+    const prefixResult = await a11yClient.requestSetText(prefix, undefined, undefined, undefined, false);
+    if (!prefixResult.success) {
+      logger.warn(`[InputText] eventLast prefix setText failed: ${prefixResult.error}`);
+      return {
+        success: false,
+        text,
+        error: `Accessibility service setText failed before real key event: ${prefixResult.error}`,
+        method: "eventLast"
+      };
+    }
+
+    const keyCommand = this.getAsciiKeyEventCommand(char);
+    if (!keyCommand) {
+      logger.info(`[InputText] eventLast could not map ASCII character ${JSON.stringify(char)} to a key event; using a11y`);
+      const result = await this.executeAndroidTextInput(text, imeAction, dismissKeyboard, "a11y");
+      return { ...result, method: "a11y" };
+    }
+
+    await this.adb.executeCommand(keyCommand);
+
+    if (suffix.length > 0 || dismissKeyboard) {
+      const finalResult = await a11yClient.requestSetText(text, undefined, undefined, undefined, dismissKeyboard);
+      if (!finalResult.success) {
+        logger.warn(`[InputText] eventLast final setText failed: ${finalResult.error}`);
+        return {
+          success: false,
+          text,
+          error: `Accessibility service setText failed after real key event: ${finalResult.error}`,
+          method: "eventLast"
+        };
+      }
+    }
+
+    if (imeAction) {
+      await this.executeImeAction(imeAction);
+    }
+
+    return {
+      success: true,
+      text,
+      imeAction,
+      method: "eventLast"
+    };
+  }
+
+  private async executeAndroidEventAllTextInput(
+    text: string,
+    imeAction?: "done" | "next" | "search" | "send" | "go" | "previous",
+    dismissKeyboard: boolean = false
+  ): Promise<SendTextResult & { method?: InputTextMode }> {
+    const chars = Array.from(text);
+    if (!chars.some(char => this.getAsciiKeyEventCommand(char))) {
+      const result = await this.executeAndroidTextInput(text, imeAction, dismissKeyboard, "a11y");
+      return { ...result, method: "a11y" };
+    }
+
+    const a11yClient = AndroidCtrlProxyClient.getInstance(this.device, this.adbFactory);
+    const clearResult = await a11yClient.requestSetText("", undefined, undefined, undefined, false);
+    if (!clearResult.success) {
+      logger.warn(`[InputText] eventAll initial clear failed: ${clearResult.error}`);
+      return {
+        success: false,
+        text,
+        error: `Accessibility service setText failed before eventAll input: ${clearResult.error}`,
+        method: "eventAll"
+      };
+    }
+
+    let targetText = "";
+    for (let index = 0; index < chars.length; index++) {
+      const char = chars[index] ?? "";
+      const keyCommand = this.getAsciiKeyEventCommand(char);
+
+      if (keyCommand) {
+        await this.adb.executeCommand(keyCommand);
+        targetText += char;
+        continue;
+      }
+
+      let unsupportedRun = char;
+      while (index + 1 < chars.length && !this.getAsciiKeyEventCommand(chars[index + 1] ?? "")) {
+        index++;
+        unsupportedRun += chars[index] ?? "";
+      }
+
+      targetText += unsupportedRun;
+      const setTextResult = await a11yClient.requestSetText(targetText, undefined, undefined, undefined, false);
+      if (!setTextResult.success) {
+        logger.warn(`[InputText] eventAll setText failed for unsupported text run: ${setTextResult.error}`);
+        return {
+          success: false,
+          text,
+          error: `Accessibility service setText failed during eventAll input: ${setTextResult.error}`,
+          method: "eventAll"
+        };
+      }
+    }
+
+    if (dismissKeyboard) {
+      const finalResult = await a11yClient.requestSetText(text, undefined, undefined, undefined, true);
+      if (!finalResult.success) {
+        logger.warn(`[InputText] eventAll final setText failed: ${finalResult.error}`);
+        return {
+          success: false,
+          text,
+          error: `Accessibility service setText failed after eventAll input: ${finalResult.error}`,
+          method: "eventAll"
+        };
+      }
+    }
+
+    if (imeAction) {
+      await this.executeImeAction(imeAction);
+    }
+
+    return {
+      success: true,
+      text,
+      imeAction,
+      method: "eventAll"
+    };
+  }
+
+  private findLastPrintableAsciiNonWhitespace(text: string): { index: number; char: string } | null {
+    for (let index = text.length - 1; index >= 0; index--) {
+      const char = text[index];
+      if (!char) {
+        continue;
+      }
+
+      const code = char.charCodeAt(0);
+      if (code >= 0x21 && code <= 0x7e && !/\s/.test(char)) {
+        return { index, char };
+      }
+    }
+
+    return null;
+  }
+
+  private getAsciiKeyEventCommand(char: string): string | null {
+    if (/^[a-z]$/.test(char)) {
+      return `shell input keyevent KEYCODE_${char.toUpperCase()}`;
+    }
+
+    if (/^[A-Z]$/.test(char)) {
+      return `shell input keycombination KEYCODE_SHIFT_LEFT KEYCODE_${char}`;
+    }
+
+    if (/^[0-9]$/.test(char)) {
+      return `shell input keyevent KEYCODE_${char}`;
+    }
+
+    const directKeyCodes: Record<string, string> = {
+      " ": "KEYCODE_SPACE",
+      "-": "KEYCODE_MINUS",
+      "=": "KEYCODE_EQUALS",
+      "[": "KEYCODE_LEFT_BRACKET",
+      "]": "KEYCODE_RIGHT_BRACKET",
+      "\\": "KEYCODE_BACKSLASH",
+      ";": "KEYCODE_SEMICOLON",
+      "'": "KEYCODE_APOSTROPHE",
+      ",": "KEYCODE_COMMA",
+      ".": "KEYCODE_PERIOD",
+      "/": "KEYCODE_SLASH",
+      "`": "KEYCODE_GRAVE",
+      "@": "KEYCODE_AT"
+    };
+
+    const shiftedKeyCodes: Record<string, string> = {
+      "!": "KEYCODE_1",
+      "#": "KEYCODE_3",
+      "$": "KEYCODE_4",
+      "%": "KEYCODE_5",
+      "^": "KEYCODE_6",
+      "&": "KEYCODE_7",
+      "*": "KEYCODE_8",
+      "(": "KEYCODE_9",
+      ")": "KEYCODE_0",
+      "_": "KEYCODE_MINUS",
+      "+": "KEYCODE_EQUALS",
+      "{": "KEYCODE_LEFT_BRACKET",
+      "}": "KEYCODE_RIGHT_BRACKET",
+      "|": "KEYCODE_BACKSLASH",
+      ":": "KEYCODE_SEMICOLON",
+      "\"": "KEYCODE_APOSTROPHE",
+      "<": "KEYCODE_COMMA",
+      ">": "KEYCODE_PERIOD",
+      "?": "KEYCODE_SLASH",
+      "~": "KEYCODE_GRAVE"
+    };
+
+    const direct = directKeyCodes[char];
+    if (direct) {
+      return `shell input keyevent ${direct}`;
+    }
+
+    const shifted = shiftedKeyCodes[char];
+    if (shifted) {
+      return `shell input keycombination KEYCODE_SHIFT_LEFT ${shifted}`;
+    }
+
+    return null;
   }
 
   /**

--- a/src/server/interactionToolTypes.ts
+++ b/src/server/interactionToolTypes.ts
@@ -37,6 +37,7 @@ export interface SystemTrayArgs {
 
 export interface InputTextArgs {
   text: string;
+  mode?: "a11y" | "eventLast" | "eventAll";
   imeAction?: "done" | "next" | "search" | "send" | "go" | "previous";
   dismissKeyboard?: boolean;
   platform: Platform;

--- a/src/server/interactionTools.ts
+++ b/src/server/interactionTools.ts
@@ -371,7 +371,7 @@ export const clearStateSchema = addDeviceTargetingToSchema(z.object({
 export const inputTextSchema = addDeviceTargetingToSchema(z.object({
   text: z.string().min(1).describe("Text to input"),
   mode: z.enum(["a11y", "eventLast", "eventAll"]).optional()
-    .describe("(Android only) Text input mode. a11y (default) sets text directly. eventLast sets text with a11y up to the last printable non-whitespace ASCII character, sends that character as a real key event, then restores any suffix with a11y. eventAll clears the field with a11y, sends key events for mappable ASCII characters, and uses a11y for Unicode/emoji runs. Search fields that use autocomplete should probably try eventLast; otherwise accept the default."),
+    .describe("(Android only; ignored on iOS) Text input mode. a11y (default) sets text directly. eventLast sets text with a11y up to the last printable non-whitespace ASCII character, sends that character as a real key event, then restores any suffix with a11y. eventAll clears the field with a11y, sends key events for mappable ASCII characters, and uses a11y for Unicode/emoji runs. Search fields that use autocomplete should probably try eventLast; otherwise accept the default."),
   imeAction: z.enum(["done", "next", "search", "send", "go", "previous"]).optional()
     .describe("IME action after input"),
   dismissKeyboard: z.boolean().optional()
@@ -807,8 +807,9 @@ export function registerInteractionTools() {
   const inputTextHandler = async (device: BootedDevice, args: InputTextArgs) => {
     RecompositionTracker.getInstance().recordInteraction();
     const dismissKeyboard = args.dismissKeyboard ?? serverConfig.isDismissKeyboardAfterInputEnabled();
+    const mode = device.platform === "android" ? args.mode : undefined;
     const inputText = new InputText(device);
-    const result = await inputText.execute(args.text, args.imeAction, dismissKeyboard, args.mode);
+    const result = await inputText.execute(args.text, args.imeAction, dismissKeyboard, mode);
     return createJSONToolResponse({
       message: `Input text`,
       observation: result.observation,
@@ -996,7 +997,7 @@ export function registerInteractionTools() {
 
   ToolRegistry.registerDeviceAware(
     "inputText",
-    "Input text",
+    "Input text. The optional mode field is Android-only and ignored on iOS.",
     inputTextSchema,
     inputTextHandler,
     false // Does not support progress notifications

--- a/src/server/interactionTools.ts
+++ b/src/server/interactionTools.ts
@@ -370,6 +370,8 @@ export const clearStateSchema = addDeviceTargetingToSchema(z.object({
 
 export const inputTextSchema = addDeviceTargetingToSchema(z.object({
   text: z.string().min(1).describe("Text to input"),
+  mode: z.enum(["a11y", "eventLast", "eventAll"]).optional()
+    .describe("(Android only) Text input mode. a11y (default) sets text directly. eventLast sets text with a11y up to the last printable non-whitespace ASCII character, sends that character as a real key event, then restores any suffix with a11y. eventAll clears the field with a11y, sends key events for mappable ASCII characters, and uses a11y for Unicode/emoji runs. Search fields that use autocomplete should probably try eventLast; otherwise accept the default."),
   imeAction: z.enum(["done", "next", "search", "send", "go", "previous"]).optional()
     .describe("IME action after input"),
   dismissKeyboard: z.boolean().optional()
@@ -806,7 +808,7 @@ export function registerInteractionTools() {
     RecompositionTracker.getInstance().recordInteraction();
     const dismissKeyboard = args.dismissKeyboard ?? serverConfig.isDismissKeyboardAfterInputEnabled();
     const inputText = new InputText(device);
-    const result = await inputText.execute(args.text, args.imeAction, dismissKeyboard);
+    const result = await inputText.execute(args.text, args.imeAction, dismissKeyboard, args.mode);
     return createJSONToolResponse({
       message: `Input text`,
       observation: result.observation,

--- a/test/features/action/InputText.test.ts
+++ b/test/features/action/InputText.test.ts
@@ -2,8 +2,36 @@ import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { InputText } from "../../../src/features/action/InputText";
 import { AndroidCtrlProxyClient } from "../../../src/features/observe/android";
 import { FakeAdbClientFactory } from "../../fakes/FakeAdbClientFactory";
+import type { InputTextMode } from "../../../src/features/action/InputText";
 import type { BootedDevice } from "../../../src/models";
 import type { AdbClientFactory } from "../../../src/utils/android-cmdline-tools/AdbClientFactory";
+
+interface TestInputText {
+  executeAndroidTextInput: (
+    text: string,
+    imeAction?: undefined,
+    dismissKeyboard?: boolean,
+    mode?: InputTextMode
+  ) => Promise<{ success: boolean; error?: string; method?: string }>;
+}
+
+type RequestSetText = (
+  text: string,
+  resourceId?: string,
+  timeoutMs?: number,
+  perf?: unknown,
+  dismissKeyboard?: boolean
+) => Promise<{ success: boolean; error?: string; totalTimeMs: number }>;
+
+function testInputText(inputText: InputText): TestInputText {
+  return inputText as unknown as TestInputText;
+}
+
+function stubAndroidSetText(requestSetText: RequestSetText): void {
+  AndroidCtrlProxyClient.getInstance = (() => ({
+    requestSetText
+  })) as typeof AndroidCtrlProxyClient.getInstance;
+}
 
 describe("InputText", () => {
   const androidDevice: BootedDevice = {
@@ -52,5 +80,154 @@ describe("InputText", () => {
     expect(capturedFactory).toBeDefined();
     expect(typeof (capturedFactory as AdbClientFactory).create).toBe("function");
     expect(capturedFactory).toBe(factory as unknown as AdbClientFactory);
+  });
+
+  test("eventLast sets prefix with a11y and sends final ASCII key event", async () => {
+    const factory = new FakeAdbClientFactory();
+    const inputText = new InputText(androidDevice, factory as AdbClientFactory);
+    const setTextCalls: Array<{ text: string; dismissKeyboard?: boolean }> = [];
+
+    stubAndroidSetText(async (text, _resourceId, _timeoutMs, _perf, dismissKeyboard) => {
+      setTextCalls.push({ text, dismissKeyboard });
+      return { success: true, totalTimeMs: 1 };
+    });
+
+    const result = await testInputText(inputText).executeAndroidTextInput("@Jason Pearson", undefined, false, "eventLast");
+
+    expect(result.success).toBe(true);
+    expect(result.method).toBe("eventLast");
+    expect(setTextCalls).toEqual([{ text: "@Jason Pearso", dismissKeyboard: false }]);
+    expect(factory.getFakeClient().getAllCommands()).toEqual(["shell input keyevent KEYCODE_N"]);
+  });
+
+  test("eventLast restores suffix with final a11y setText", async () => {
+    const factory = new FakeAdbClientFactory();
+    const inputText = new InputText(androidDevice, factory as AdbClientFactory);
+    const setTextCalls: Array<{ text: string; dismissKeyboard?: boolean }> = [];
+
+    stubAndroidSetText(async (text, _resourceId, _timeoutMs, _perf, dismissKeyboard) => {
+      setTextCalls.push({ text, dismissKeyboard });
+      return { success: true, totalTimeMs: 1 };
+    });
+
+    const result = await testInputText(inputText).executeAndroidTextInput("abc def  ", undefined, false, "eventLast");
+
+    expect(result.success).toBe(true);
+    expect(setTextCalls).toEqual([
+      { text: "abc de", dismissKeyboard: false },
+      { text: "abc def  ", dismissKeyboard: false },
+    ]);
+    expect(factory.getFakeClient().getAllCommands()).toEqual(["shell input keyevent KEYCODE_F"]);
+  });
+
+  test("eventLast uses shifted key combination for uppercase ASCII", async () => {
+    const factory = new FakeAdbClientFactory();
+    const inputText = new InputText(androidDevice, factory as AdbClientFactory);
+
+    stubAndroidSetText(async () => ({ success: true, totalTimeMs: 1 }));
+
+    const result = await testInputText(inputText).executeAndroidTextInput("HellO", undefined, false, "eventLast");
+
+    expect(result.success).toBe(true);
+    expect(factory.getFakeClient().getAllCommands()).toEqual([
+      "shell input keycombination KEYCODE_SHIFT_LEFT KEYCODE_O"
+    ]);
+  });
+
+  test("eventLast falls back to a11y when no printable non-whitespace ASCII exists", async () => {
+    const factory = new FakeAdbClientFactory();
+    const inputText = new InputText(androidDevice, factory as AdbClientFactory);
+    const setTextCalls: string[] = [];
+
+    stubAndroidSetText(async text => {
+      setTextCalls.push(text);
+      return { success: true, totalTimeMs: 1 };
+    });
+
+    const result = await testInputText(inputText).executeAndroidTextInput("  你好  ", undefined, false, "eventLast");
+
+    expect(result.success).toBe(true);
+    expect(result.method).toBe("a11y");
+    expect(setTextCalls).toEqual(["  你好  "]);
+    expect(factory.getFakeClient().getAllCommands()).toEqual([]);
+  });
+
+  test("eventAll sends mappable ASCII text as key events", async () => {
+    const factory = new FakeAdbClientFactory();
+    const inputText = new InputText(androidDevice, factory as AdbClientFactory);
+    const setTextCalls: string[] = [];
+
+    stubAndroidSetText(async text => {
+      setTextCalls.push(text);
+      return { success: true, totalTimeMs: 1 };
+    });
+
+    const result = await testInputText(inputText).executeAndroidTextInput("@ab C", undefined, false, "eventAll");
+
+    expect(result.success).toBe(true);
+    expect(result.method).toBe("eventAll");
+    expect(setTextCalls).toEqual([""]);
+    expect(factory.getFakeClient().getAllCommands()).toEqual([
+      "shell input keyevent KEYCODE_AT",
+      "shell input keyevent KEYCODE_A",
+      "shell input keyevent KEYCODE_B",
+      "shell input keyevent KEYCODE_SPACE",
+      "shell input keycombination KEYCODE_SHIFT_LEFT KEYCODE_C"
+    ]);
+  });
+
+  test("eventAll alternates a11y for Unicode runs and key events for ASCII", async () => {
+    const factory = new FakeAdbClientFactory();
+    const inputText = new InputText(androidDevice, factory as AdbClientFactory);
+    const setTextCalls: string[] = [];
+
+    stubAndroidSetText(async text => {
+      setTextCalls.push(text);
+      return { success: true, totalTimeMs: 1 };
+    });
+
+    const result = await testInputText(inputText).executeAndroidTextInput("ab你好c😊d", undefined, false, "eventAll");
+
+    expect(result.success).toBe(true);
+    expect(result.method).toBe("eventAll");
+    expect(setTextCalls).toEqual(["", "ab你好", "ab你好c😊"]);
+    expect(factory.getFakeClient().getAllCommands()).toEqual([
+      "shell input keyevent KEYCODE_A",
+      "shell input keyevent KEYCODE_B",
+      "shell input keyevent KEYCODE_C",
+      "shell input keyevent KEYCODE_D"
+    ]);
+  });
+
+  test("eventAll fails before key events when initial a11y clear fails", async () => {
+    const factory = new FakeAdbClientFactory();
+    const inputText = new InputText(androidDevice, factory as AdbClientFactory);
+
+    stubAndroidSetText(async () => ({ success: false, error: "focused field missing", totalTimeMs: 1 }));
+
+    const result = await testInputText(inputText).executeAndroidTextInput("abc", undefined, false, "eventAll");
+
+    expect(result.success).toBe(false);
+    expect(result.method).toBe("eventAll");
+    expect(result.error).toContain("focused field missing");
+    expect(factory.getFakeClient().getAllCommands()).toEqual([]);
+  });
+
+  test("eventAll falls back to a11y when there are no key-event-mappable characters", async () => {
+    const factory = new FakeAdbClientFactory();
+    const inputText = new InputText(androidDevice, factory as AdbClientFactory);
+    const setTextCalls: string[] = [];
+
+    stubAndroidSetText(async text => {
+      setTextCalls.push(text);
+      return { success: true, totalTimeMs: 1 };
+    });
+
+    const result = await testInputText(inputText).executeAndroidTextInput("你好😊", undefined, false, "eventAll");
+
+    expect(result.success).toBe(true);
+    expect(result.method).toBe("a11y");
+    expect(setTextCalls).toEqual(["你好😊"]);
+    expect(factory.getFakeClient().getAllCommands()).toEqual([]);
   });
 });

--- a/test/features/action/InputText.test.ts
+++ b/test/features/action/InputText.test.ts
@@ -33,6 +33,11 @@ function stubAndroidSetText(requestSetText: RequestSetText): void {
   })) as typeof AndroidCtrlProxyClient.getInstance;
 }
 
+function inputCommands(factory: FakeAdbClientFactory): string[] {
+  return factory.getFakeClient().getAllCommands()
+    .filter(command => command.startsWith("shell input "));
+}
+
 describe("InputText", () => {
   const androidDevice: BootedDevice = {
     deviceId: "input-text-device",
@@ -97,7 +102,7 @@ describe("InputText", () => {
     expect(result.success).toBe(true);
     expect(result.method).toBe("eventLast");
     expect(setTextCalls).toEqual([{ text: "@Jason Pearso", dismissKeyboard: false }]);
-    expect(factory.getFakeClient().getAllCommands()).toEqual(["shell input keyevent KEYCODE_N"]);
+    expect(inputCommands(factory)).toEqual(["shell input keyevent KEYCODE_N"]);
   });
 
   test("eventLast restores suffix with final a11y setText", async () => {
@@ -117,20 +122,44 @@ describe("InputText", () => {
       { text: "abc de", dismissKeyboard: false },
       { text: "abc def  ", dismissKeyboard: false },
     ]);
-    expect(factory.getFakeClient().getAllCommands()).toEqual(["shell input keyevent KEYCODE_F"]);
+    expect(inputCommands(factory)).toEqual(["shell input keyevent KEYCODE_F"]);
   });
 
-  test("eventLast uses shifted key combination for uppercase ASCII", async () => {
+  test("eventLast uses shifted key combination for uppercase ASCII on Android 12+", async () => {
     const factory = new FakeAdbClientFactory();
     const inputText = new InputText(androidDevice, factory as AdbClientFactory);
+    factory.getFakeClient().setCommandResult("shell getprop ro.build.version.sdk", "31\n");
 
     stubAndroidSetText(async () => ({ success: true, totalTimeMs: 1 }));
 
     const result = await testInputText(inputText).executeAndroidTextInput("HellO", undefined, false, "eventLast");
 
     expect(result.success).toBe(true);
-    expect(factory.getFakeClient().getAllCommands()).toEqual([
+    expect(inputCommands(factory)).toEqual([
       "shell input keycombination KEYCODE_SHIFT_LEFT KEYCODE_O"
+    ]);
+  });
+
+  test("eventLast falls back to keyevent and restores text for shifted ASCII before Android 12", async () => {
+    const factory = new FakeAdbClientFactory();
+    const inputText = new InputText(androidDevice, factory as AdbClientFactory);
+    const setTextCalls: Array<{ text: string; dismissKeyboard?: boolean }> = [];
+    factory.getFakeClient().setCommandResult("shell getprop ro.build.version.sdk", "30\n");
+
+    stubAndroidSetText(async (text, _resourceId, _timeoutMs, _perf, dismissKeyboard) => {
+      setTextCalls.push({ text, dismissKeyboard });
+      return { success: true, totalTimeMs: 1 };
+    });
+
+    const result = await testInputText(inputText).executeAndroidTextInput("HellO", undefined, false, "eventLast");
+
+    expect(result.success).toBe(true);
+    expect(setTextCalls).toEqual([
+      { text: "Hell", dismissKeyboard: false },
+      { text: "HellO", dismissKeyboard: false },
+    ]);
+    expect(inputCommands(factory)).toEqual([
+      "shell input keyevent KEYCODE_SHIFT_LEFT KEYCODE_O"
     ]);
   });
 
@@ -149,13 +178,14 @@ describe("InputText", () => {
     expect(result.success).toBe(true);
     expect(result.method).toBe("a11y");
     expect(setTextCalls).toEqual(["  你好  "]);
-    expect(factory.getFakeClient().getAllCommands()).toEqual([]);
+    expect(inputCommands(factory)).toEqual([]);
   });
 
   test("eventAll sends mappable ASCII text as key events", async () => {
     const factory = new FakeAdbClientFactory();
     const inputText = new InputText(androidDevice, factory as AdbClientFactory);
     const setTextCalls: string[] = [];
+    factory.getFakeClient().setCommandResult("shell getprop ro.build.version.sdk", "31\n");
 
     stubAndroidSetText(async text => {
       setTextCalls.push(text);
@@ -167,7 +197,7 @@ describe("InputText", () => {
     expect(result.success).toBe(true);
     expect(result.method).toBe("eventAll");
     expect(setTextCalls).toEqual([""]);
-    expect(factory.getFakeClient().getAllCommands()).toEqual([
+    expect(inputCommands(factory)).toEqual([
       "shell input keyevent KEYCODE_AT",
       "shell input keyevent KEYCODE_A",
       "shell input keyevent KEYCODE_B",
@@ -191,7 +221,7 @@ describe("InputText", () => {
     expect(result.success).toBe(true);
     expect(result.method).toBe("eventAll");
     expect(setTextCalls).toEqual(["", "ab你好", "ab你好c😊"]);
-    expect(factory.getFakeClient().getAllCommands()).toEqual([
+    expect(inputCommands(factory)).toEqual([
       "shell input keyevent KEYCODE_A",
       "shell input keyevent KEYCODE_B",
       "shell input keyevent KEYCODE_C",
@@ -210,7 +240,29 @@ describe("InputText", () => {
     expect(result.success).toBe(false);
     expect(result.method).toBe("eventAll");
     expect(result.error).toContain("focused field missing");
-    expect(factory.getFakeClient().getAllCommands()).toEqual([]);
+    expect(inputCommands(factory)).toEqual([]);
+  });
+
+  test("eventAll falls back to keyevent and restores text for shifted ASCII before Android 12", async () => {
+    const factory = new FakeAdbClientFactory();
+    const inputText = new InputText(androidDevice, factory as AdbClientFactory);
+    const setTextCalls: string[] = [];
+    factory.getFakeClient().setCommandResult("shell getprop ro.build.version.sdk", "30\n");
+
+    stubAndroidSetText(async text => {
+      setTextCalls.push(text);
+      return { success: true, totalTimeMs: 1 };
+    });
+
+    const result = await testInputText(inputText).executeAndroidTextInput("aB", undefined, false, "eventAll");
+
+    expect(result.success).toBe(true);
+    expect(result.method).toBe("eventAll");
+    expect(setTextCalls).toEqual(["", "aB"]);
+    expect(inputCommands(factory)).toEqual([
+      "shell input keyevent KEYCODE_A",
+      "shell input keyevent KEYCODE_SHIFT_LEFT KEYCODE_B"
+    ]);
   });
 
   test("eventAll falls back to a11y when there are no key-event-mappable characters", async () => {
@@ -228,6 +280,6 @@ describe("InputText", () => {
     expect(result.success).toBe(true);
     expect(result.method).toBe("a11y");
     expect(setTextCalls).toEqual(["你好😊"]);
-    expect(factory.getFakeClient().getAllCommands()).toEqual([]);
+    expect(inputCommands(factory)).toEqual([]);
   });
 });

--- a/test/server/toolSchemaHelpers.test.ts
+++ b/test/server/toolSchemaHelpers.test.ts
@@ -184,3 +184,17 @@ describe("platform field accepted by all device-targeting tool schemas", () => {
     });
   }
 });
+
+describe("inputTextSchema", () => {
+  test("accepts supported Android input modes", () => {
+    for (const mode of ["a11y", "eventLast", "eventAll"]) {
+      const result = inputTextSchema.safeParse({ text: "hello", mode, platform: "android" });
+      expect(result.success).toBe(true);
+    }
+  });
+
+  test("rejects unsupported input modes", () => {
+    const result = inputTextSchema.safeParse({ text: "hello", mode: "realKeyEvents", platform: "android" });
+    expect(result.success).toBe(false);
+  });
+});

--- a/test/server/toolSchemaHelpers.test.ts
+++ b/test/server/toolSchemaHelpers.test.ts
@@ -193,6 +193,13 @@ describe("inputTextSchema", () => {
     }
   });
 
+  test("accepts input modes for iOS callers so runtime can ignore them", () => {
+    for (const mode of ["a11y", "eventLast", "eventAll"]) {
+      const result = inputTextSchema.safeParse({ text: "hello", mode, platform: "ios" });
+      expect(result.success).toBe(true);
+    }
+  });
+
   test("rejects unsupported input modes", () => {
     const result = inputTextSchema.safeParse({ text: "hello", mode: "realKeyEvents", platform: "android" });
     expect(result.success).toBe(false);


### PR DESCRIPTION
## Summary
- add Android `inputText.mode` with `a11y`, `eventLast`, and `eventAll` modes
- implement `eventLast` as a fast a11y prefix plus one real key event for autocomplete-sensitive fields
- implement `eventAll` as a11y clear plus key events for mappable ASCII, with a11y fallback for Unicode/emoji runs
- update generated tool definitions and schema coverage

## Testing
- `bun test test/features/action/InputText.test.ts`
- `bun test test/server/toolSchemaHelpers.test.ts`
- `./node_modules/.bin/eslint src/features/action/InputText.ts src/server/interactionTools.ts src/server/interactionToolTypes.ts test/features/action/InputText.test.ts test/server/toolSchemaHelpers.test.ts`
- `bun run build`
- `git diff --check`
