### PR TITLE
Fix legacy shifted inputText events

### DIFF
--- a/src/features/action/InputText.ts
+++ b/src/features/action/InputText.ts
@@ -13,7 +13,6 @@ export type InputTextMode = "a11y" | "eventLast" | "eventAll";
 
 interface KeyEventPlan {
   commands: string[];
-  needsTextRestore: boolean;
 }
 
 const ANDROID_KEYCOMBINATION_MIN_API_LEVEL = 31;
@@ -154,6 +153,13 @@ export class InputText extends BaseVisualChange {
     const { index, char } = split;
     const prefix = text.slice(0, index);
     const suffix = text.slice(index + 1);
+    const keyEventPlan = await this.getAsciiKeyEventPlan(char);
+    if (!keyEventPlan) {
+      logger.info(`[InputText] eventLast could not map ASCII character ${JSON.stringify(char)} to a key event; using a11y`);
+      const result = await this.executeAndroidTextInput(text, imeAction, dismissKeyboard, "a11y");
+      return { ...result, method: "a11y" };
+    }
+
     const a11yClient = AndroidCtrlProxyClient.getInstance(this.device, this.adbFactory);
 
     const prefixResult = await a11yClient.requestSetText(prefix, undefined, undefined, undefined, false);
@@ -167,16 +173,9 @@ export class InputText extends BaseVisualChange {
       };
     }
 
-    const keyEventPlan = await this.getAsciiKeyEventPlan(char);
-    if (!keyEventPlan) {
-      logger.info(`[InputText] eventLast could not map ASCII character ${JSON.stringify(char)} to a key event; using a11y`);
-      const result = await this.executeAndroidTextInput(text, imeAction, dismissKeyboard, "a11y");
-      return { ...result, method: "a11y" };
-    }
-
     await this.executeKeyEventPlan(keyEventPlan);
 
-    if (suffix.length > 0 || dismissKeyboard || keyEventPlan.needsTextRestore) {
+    if (suffix.length > 0 || dismissKeyboard) {
       const finalResult = await a11yClient.requestSetText(text, undefined, undefined, undefined, dismissKeyboard);
       if (!finalResult.success) {
         logger.warn(`[InputText] eventLast final setText failed: ${finalResult.error}`);
@@ -232,18 +231,6 @@ export class InputText extends BaseVisualChange {
       if (keyEventPlan) {
         await this.executeKeyEventPlan(keyEventPlan);
         targetText += char;
-        if (keyEventPlan.needsTextRestore) {
-          const restoreResult = await a11yClient.requestSetText(targetText, undefined, undefined, undefined, false);
-          if (!restoreResult.success) {
-            logger.warn(`[InputText] eventAll restore setText failed after legacy key events: ${restoreResult.error}`);
-            return {
-              success: false,
-              text,
-              error: `Accessibility service setText failed after eventAll key event: ${restoreResult.error}`,
-              method: "eventAll"
-            };
-          }
-        }
         continue;
       }
 
@@ -320,8 +307,7 @@ export class InputText extends BaseVisualChange {
   private async getAsciiKeyEventPlan(char: string): Promise<KeyEventPlan | null> {
     if (/^[a-z]$/.test(char)) {
       return {
-        commands: [`shell input keyevent KEYCODE_${char.toUpperCase()}`],
-        needsTextRestore: false
+        commands: [`shell input keyevent KEYCODE_${char.toUpperCase()}`]
       };
     }
 
@@ -331,8 +317,7 @@ export class InputText extends BaseVisualChange {
 
     if (/^[0-9]$/.test(char)) {
       return {
-        commands: [`shell input keyevent KEYCODE_${char}`],
-        needsTextRestore: false
+        commands: [`shell input keyevent KEYCODE_${char}`]
       };
     }
 
@@ -378,8 +363,7 @@ export class InputText extends BaseVisualChange {
     const direct = directKeyCodes[char];
     if (direct) {
       return {
-        commands: [`shell input keyevent ${direct}`],
-        needsTextRestore: false
+        commands: [`shell input keyevent ${direct}`]
       };
     }
 
@@ -391,18 +375,14 @@ export class InputText extends BaseVisualChange {
     return null;
   }
 
-  private async createShiftedKeyEventPlan(baseKeyCode: string): Promise<KeyEventPlan> {
+  private async createShiftedKeyEventPlan(baseKeyCode: string): Promise<KeyEventPlan | null> {
     if (await this.supportsAndroidInputKeyCombination()) {
       return {
-        commands: [`shell input keycombination KEYCODE_SHIFT_LEFT ${baseKeyCode}`],
-        needsTextRestore: false
+        commands: [`shell input keycombination KEYCODE_SHIFT_LEFT ${baseKeyCode}`]
       };
     }
 
-    return {
-      commands: [`shell input keyevent KEYCODE_SHIFT_LEFT ${baseKeyCode}`],
-      needsTextRestore: true
-    };
+    return null;
   }
 
   private async supportsAndroidInputKeyCombination(): Promise<boolean> {

--- a/test/features/action/InputText.test.ts
+++ b/test/features/action/InputText.test.ts
@@ -140,7 +140,7 @@ describe("InputText", () => {
     ]);
   });
 
-  test("eventLast falls back to keyevent and restores text for shifted ASCII before Android 12", async () => {
+  test("eventLast falls back to a11y for shifted ASCII before Android 12", async () => {
     const factory = new FakeAdbClientFactory();
     const inputText = new InputText(androidDevice, factory as AdbClientFactory);
     const setTextCalls: Array<{ text: string; dismissKeyboard?: boolean }> = [];
@@ -154,13 +154,11 @@ describe("InputText", () => {
     const result = await testInputText(inputText).executeAndroidTextInput("HellO", undefined, false, "eventLast");
 
     expect(result.success).toBe(true);
+    expect(result.method).toBe("a11y");
     expect(setTextCalls).toEqual([
-      { text: "Hell", dismissKeyboard: false },
       { text: "HellO", dismissKeyboard: false },
     ]);
-    expect(inputCommands(factory)).toEqual([
-      "shell input keyevent KEYCODE_SHIFT_LEFT KEYCODE_O"
-    ]);
+    expect(inputCommands(factory)).toEqual([]);
   });
 
   test("eventLast falls back to a11y when no printable non-whitespace ASCII exists", async () => {
@@ -243,7 +241,7 @@ describe("InputText", () => {
     expect(inputCommands(factory)).toEqual([]);
   });
 
-  test("eventAll falls back to keyevent and restores text for shifted ASCII before Android 12", async () => {
+  test("eventAll uses a11y instead of shifted keyevents before Android 12", async () => {
     const factory = new FakeAdbClientFactory();
     const inputText = new InputText(androidDevice, factory as AdbClientFactory);
     const setTextCalls: string[] = [];
@@ -254,15 +252,33 @@ describe("InputText", () => {
       return { success: true, totalTimeMs: 1 };
     });
 
-    const result = await testInputText(inputText).executeAndroidTextInput("aB", undefined, false, "eventAll");
+    const result = await testInputText(inputText).executeAndroidTextInput("a+B", undefined, false, "eventAll");
 
     expect(result.success).toBe(true);
     expect(result.method).toBe("eventAll");
-    expect(setTextCalls).toEqual(["", "aB"]);
+    expect(setTextCalls).toEqual(["", "a+B"]);
     expect(inputCommands(factory)).toEqual([
-      "shell input keyevent KEYCODE_A",
-      "shell input keyevent KEYCODE_SHIFT_LEFT KEYCODE_B"
+      "shell input keyevent KEYCODE_A"
     ]);
+  });
+
+  test("eventAll falls back to a11y for shifted-only text before Android 12", async () => {
+    const factory = new FakeAdbClientFactory();
+    const inputText = new InputText(androidDevice, factory as AdbClientFactory);
+    const setTextCalls: string[] = [];
+    factory.getFakeClient().setCommandResult("shell getprop ro.build.version.sdk", "30\n");
+
+    stubAndroidSetText(async text => {
+      setTextCalls.push(text);
+      return { success: true, totalTimeMs: 1 };
+    });
+
+    const result = await testInputText(inputText).executeAndroidTextInput("B+", undefined, false, "eventAll");
+
+    expect(result.success).toBe(true);
+    expect(result.method).toBe("a11y");
+    expect(setTextCalls).toEqual(["B+"]);
+    expect(inputCommands(factory)).toEqual([]);
   });
 
   test("eventAll falls back to a11y when there are no key-event-mappable characters", async () => {


### PR DESCRIPTION
## Summary
- avoid sequential `KEYCODE_SHIFT_LEFT` keyevents for shifted ASCII on Android <31
- fall back to a11y for legacy shifted `eventLast` input before mutating field text
- add regression tests covering legacy uppercase and shifted punctuation behavior

## Self-review
- checked the diff for reuse and kept the existing key-event planning helpers
- removed the obsolete text-restore path now that legacy shifted keyevents are not emitted
- tightened coverage to include shifted punctuation from the original PR feedback

## Testing
- `bun test test/features/action/InputText.test.ts`
- `bun run build`
- `bun run lint`

## Note
- Initial `bun install --frozen-lockfile` failed while compiling the dev `heapdump` dependency against Node 26. Dependencies were hydrated with `bun install --frozen-lockfile --ignore-scripts` before validation.
