### PR TITLE
Reduce idle mobile tooling log noise

### DIFF
--- a/ios/control-proxy/Sources/CtrlProxy/ElementLocator.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/ElementLocator.swift
@@ -107,6 +107,7 @@ public class ElementLocator: ElementLocating {
         /// Explicitly switch the tracked foreground app to the given bundle ID, clearing caches.
         /// Called by CommandHandler after state-changing operations (launch, terminate, home).
         public func switchForegroundApp(bundleId: String) {
+            let previousBundleId = foregroundBundleId
             foregroundApp = nil
             foregroundBundleId = nil
             elementCache.removeAll()
@@ -120,6 +121,9 @@ public class ElementLocator: ElementLocating {
             }
             foregroundBundleId = bundleId
             lastExplicitSwitchTime = DispatchTime.now().uptimeNanoseconds
+            if previousBundleId != bundleId {
+                print("[ElementLocator] Foreground app changed: \(previousBundleId ?? "nil") -> \(bundleId)")
+            }
         }
 
         public func getAppState(bundleId: String) -> ObservedAppState {
@@ -178,8 +182,6 @@ public class ElementLocator: ElementLocating {
                     }, fallback: (0, nil, self.foregroundBundleId))
                 }
 
-            print("[ElementLocator] ensureForegroundApp: current=\(stateInfo.currentBundleId ?? "nil") state=\(stateInfo.currentAppState.map { String($0) } ?? "nil") springboard=\(stateInfo.springboardState) observed=\(observedBundleIds)")
-
             let isCurrentAppInForeground = (stateInfo.currentAppState ?? 0) >=
                 4 // .runningForeground only (3 = .runningBackground)
             let isCurrentAppSpringboard = stateInfo.currentBundleId == "com.apple.springboard"
@@ -193,13 +195,11 @@ public class ElementLocator: ElementLocating {
 
             if let detectedBundleId = perfProvider.track("detectForeground", block: { detectForegroundAppBundleId() }) {
                 if detectedBundleId != foregroundBundleId {
-                    print("[ElementLocator] Switching to foreground app: \(detectedBundleId)")
                     switchForegroundApp(bundleId: detectedBundleId)
                 }
                 didFallbackToSpringboard = false
             } else if !isCurrentAppInForeground {
                 if foregroundBundleId != "com.apple.springboard" {
-                    print("[ElementLocator] WARNING: No foreground app detected, falling back to springboard")
                     switchForegroundApp(bundleId: "com.apple.springboard")
                     didFallbackToSpringboard = true
                 }
@@ -285,8 +285,6 @@ public class ElementLocator: ElementLocating {
                     var candidateBundleIds: [String] = []
                     collectBundleIdsFromElement(snapshot, into: &candidateBundleIds)
 
-                    print("[ElementLocator] Springboard candidates: \(candidateBundleIds)")
-
                     for bundleId in candidateBundleIds {
                         if bundleId == "com.apple.springboard" {
                             continue
@@ -296,9 +294,7 @@ public class ElementLocator: ElementLocating {
                             let testApp = XCUIApplication(bundleIdentifier: bundleId)
                             return testApp.state.rawValue
                         }, fallback: 0)
-                        print("[ElementLocator] Candidate \(bundleId) state=\(stateRawValue)")
                         if stateRawValue >= 4 { // .runningForeground only
-                            print("[ElementLocator] Found foreground app from springboard: \(bundleId)")
                             return bundleId
                         }
                     }
@@ -308,12 +304,11 @@ public class ElementLocator: ElementLocating {
                     return foundBundleId
                 }
             } else {
-                print("[ElementLocator] WARNING: Failed to snapshot springboard")
+                print("[ElementLocator] Failed to snapshot springboard while detecting foreground app")
             }
 
             // Fallback: Check observed bundle IDs first (apps we've seen before)
             let observedResult: String? = perfProvider.track("checkObserved") {
-                print("[ElementLocator] Checking observed bundle IDs: \(observedBundleIds)")
                 for bundleId in observedBundleIds {
                     // Skip current app (we already know it's not in foreground)
                     if bundleId == foregroundBundleId {
@@ -324,7 +319,6 @@ public class ElementLocator: ElementLocating {
                         let testApp = XCUIApplication(bundleIdentifier: bundleId)
                         return testApp.state.rawValue
                     }, fallback: 0)
-                    print("[ElementLocator] Observed \(bundleId) state=\(stateRawValue)")
                     if stateRawValue >= 4 { // .runningForeground only
                         return bundleId
                     }
@@ -354,11 +348,9 @@ public class ElementLocator: ElementLocating {
                         return testApp.state.rawValue
                     }, fallback: 0)
                     if stateRawValue >= 4 { // .runningForeground only
-                        print("[ElementLocator] Found foreground app from system apps: \(bundleId)")
                         return bundleId
                     }
                 }
-                print("[ElementLocator] No foreground app found from any source")
                 return nil
             }
         }
@@ -428,7 +420,6 @@ public class ElementLocator: ElementLocating {
 
             // Use the observed app's bundle identifier for packageName
             let bundleId = foregroundBundleId ?? "com.apple.springboard"
-            print("[ElementLocator] getViewHierarchy: using bundleId=\(bundleId) fallback=\(didFallbackToSpringboard)")
 
             // Use snapshot() for fast hierarchy extraction - single IPC call captures everything
             // snapshot() captures all element data in ONE IPC call (fast!)
@@ -1068,6 +1059,7 @@ public class ElementLocator: ElementLocating {
 
         public func findElement(byResourceId resourceId: String) -> Any? {
             if let cached = elementCache[resourceId] {
+                print("[ElementLocator] Element found by resourceId=\(resourceId) source=cache")
                 return cached
             }
 
@@ -1089,18 +1081,28 @@ public class ElementLocator: ElementLocating {
                     }
                 }
                 return anyMatch as XCUIElement?
-            }, fallback: nil) else { return nil }
+            }, fallback: nil) else {
+                print("[ElementLocator] Element not found by resourceId=\(resourceId)")
+                return nil
+            }
             elementCache[resourceId] = element
+            print("[ElementLocator] Element found by resourceId=\(resourceId) source=query")
             return element
         }
 
         public func findElement(byText text: String) -> Any? {
             let app = currentApplication
-            return runOnMainThreadNonThrowing({
+            let element = runOnMainThreadNonThrowing({
                 let match = app.descendants(matching: .any)
                     .matching(NSPredicate(format: "label == %@", text)).firstMatch
                 return match.exists ? match as XCUIElement? : nil
             }, fallback: nil)
+            if element == nil {
+                print("[ElementLocator] Element not found by text=\(text)")
+            } else {
+                print("[ElementLocator] Element found by text=\(text)")
+            }
+            return element
         }
 
         public func getCachedElement(_ resourceId: String) -> XCUIElement? {

--- a/ios/control-proxy/Sources/CtrlProxy/HierarchyDebouncer.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/HierarchyDebouncer.swift
@@ -123,7 +123,6 @@ public class HierarchyDebouncer: HierarchyDebouncing {
         // Schedule first poll
         scheduleNextPoll()
 
-        print("[HierarchyDebouncer] Started with \(pollIntervalMs)ms polling interval")
     }
 
     public func stop() {
@@ -132,7 +131,6 @@ public class HierarchyDebouncer: HierarchyDebouncing {
         pollScheduled = false
         lock.unlock()
 
-        print("[HierarchyDebouncer] Stopped")
     }
 
     public func extractNow() {
@@ -213,14 +211,13 @@ public class HierarchyDebouncer: HierarchyDebouncing {
             let callback = onResult
             lock.unlock()
 
-            print("[HierarchyDebouncer] Initial state captured (hash=\(hash)), broadcasting")
-
             // Broadcast initial state so the IDE receives hierarchy immediately
             let result = HierarchyResult.changed(
                 hierarchy: hierarchy,
                 hash: hash,
                 extractionTimeMs: extractionTime
             )
+            print("[HierarchyDebouncer] Initial hierarchy broadcast hash=\(hash) extractionMs=\(extractionTime)")
             callback?(result)
         } catch {
             print("[HierarchyDebouncer] Failed to capture initial state: \(error)")
@@ -249,10 +246,8 @@ public class HierarchyDebouncer: HierarchyDebouncing {
         // Exit animation mode if window expired
         if animationMode, now >= animationEnd {
             lock.lock()
-            let skipped = skippedPollCount
             inAnimationMode = false
             lock.unlock()
-            print("[HierarchyDebouncer] Exiting animation mode after skipping \(skipped) polls")
         }
 
         extractAndCompare(skipBroadcast: false)
@@ -318,7 +313,7 @@ public class HierarchyDebouncer: HierarchyDebouncing {
                     )
 
                     print(
-                        "[HierarchyDebouncer] Structure changed (oldHash=\(oldHash), newHash=\(newHash)), broadcasting"
+                        "[HierarchyDebouncer] Hierarchy changed oldHash=\(oldHash) newHash=\(newHash) extractionMs=\(extractionTime)"
                     )
                     callback?(result)
                 }

--- a/ios/control-proxy/Sources/CtrlProxy/PerfProvider.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/PerfProvider.swift
@@ -330,9 +330,6 @@ public class PerfProvider {
         }
         entryStack.append(entry)
 
-        #if DEBUG
-            print("[PerfProvider] Started serial block: \(name)")
-        #endif
     }
 
     /// Start a new independent root block, ending any currently open blocks first.
@@ -353,9 +350,6 @@ public class PerfProvider {
         currentRoot = entry
         entryStack.append(entry)
 
-        #if DEBUG
-            print("[PerfProvider] Started independent root: \(name)")
-        #endif
     }
 
     /// Start a parallel block (operations run concurrently).
@@ -373,9 +367,6 @@ public class PerfProvider {
         }
         entryStack.append(entry)
 
-        #if DEBUG
-            print("[PerfProvider] Started parallel block: \(name)")
-        #endif
     }
 
     /// End the current block.
@@ -390,17 +381,11 @@ public class PerfProvider {
         let now = timeProvider.currentTimeMillis()
 
         guard let entry = entryStack.popLast() else {
-            #if DEBUG
-                print("[PerfProvider] end() called with no active block")
-            #endif
             return
         }
 
         entry.endTime = now
 
-        #if DEBUG
-            print("[PerfProvider] Ended block: \(entry.name) (\(now - entry.startTime)ms)")
-        #endif
 
         // If this was the root entry, move it to completed
         if entryStack.isEmpty, currentRoot === entry {
@@ -444,9 +429,6 @@ public class PerfProvider {
             entryStack.append(entry)
         }
 
-        #if DEBUG
-            print("[PerfProvider] Started operation: \(name)")
-        #endif
     }
 
     /// End tracking an operation manually.
@@ -458,20 +440,12 @@ public class PerfProvider {
 
         // Find the matching entry in the stack
         guard let entry = entryStack.last, entry.name == name else {
-            #if DEBUG
-                print(
-                    "[PerfProvider] endOperation(\(name)) called but current entry is \(entryStack.last?.name ?? "nil")"
-                )
-            #endif
             return
         }
 
         entry.endTime = now
         _ = entryStack.popLast()
 
-        #if DEBUG
-            print("[PerfProvider] Ended operation: \(name) (\(now - entry.startTime)ms)")
-        #endif
 
         // If this was the root entry, move it to completed
         if entryStack.isEmpty, currentRoot === entry {
@@ -490,9 +464,6 @@ public class PerfProvider {
         debounceCount += 1
         lastDebounceTime = timeProvider.currentTimeMillis()
 
-        #if DEBUG
-            print("[PerfProvider] Debounce recorded (total: \(debounceCount))")
-        #endif
     }
 
     // MARK: - Flush and Query

--- a/ios/control-proxy/Sources/CtrlProxy/WebSocketServer.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/WebSocketServer.swift
@@ -79,12 +79,12 @@ public class WebSocketServer: WebSocketServing {
         listener?.stateUpdateHandler = { [weak self] state in
             switch state {
             case .ready:
-                print("[WebSocketServer] Server ready on port \(self?.port ?? 0)")
+                break
             case let .failed(error):
                 print("[WebSocketServer] Server failed: \(error)")
                 self?.stop()
             case .cancelled:
-                print("[WebSocketServer] Server cancelled")
+                break
             default:
                 break
             }
@@ -95,7 +95,6 @@ public class WebSocketServer: WebSocketServing {
         }
 
         listener?.start(queue: queue)
-        print("[WebSocketServer] Starting server on port \(port)...")
     }
 
     /// Stops the server
@@ -104,7 +103,6 @@ public class WebSocketServer: WebSocketServing {
         connections.removeAll()
         listener?.cancel()
         listener = nil
-        print("[WebSocketServer] Server stopped")
     }
 
     // MARK: - Connection Handling
@@ -112,8 +110,6 @@ public class WebSocketServer: WebSocketServing {
     private func handleNewConnection(_ nwConnection: NWConnection) {
         let connectionId = nextConnectionId
         nextConnectionId += 1
-
-        print("[WebSocketServer] New connection #\(connectionId) from \(nwConnection.endpoint)")
 
         let connection = WebSocketConnection(
             id: connectionId,
@@ -124,7 +120,6 @@ public class WebSocketServer: WebSocketServing {
             self?.handleMessage(message, connectionId: connectionId)
         } onClose: { [weak self] in
             self?.connections.removeValue(forKey: connectionId)
-            print("[WebSocketServer] Connection #\(connectionId) closed")
         }
 
         connections[connectionId] = connection
@@ -136,7 +131,7 @@ public class WebSocketServer: WebSocketServing {
 
         do {
             let request = try JSONDecoder().decode(WebSocketRequest.self, from: data)
-            print("[WebSocketServer] Received: \(request.type)")
+            print("[WebSocketServer] Received request type=\(request.type) requestId=\(request.requestId ?? "nil")")
 
             // Track the entire request handling with PerfProvider
             perfProvider.serial("handleRequest:\(request.type)")
@@ -254,12 +249,6 @@ public class WebSocketServer: WebSocketServing {
             encoder.outputFormatting = .sortedKeys
             let data = try encoder.encode(response)
             broadcast(data)
-            // Only log occasionally to avoid spam (snapshot contains timestamp)
-            if Int(snapshot.timestamp) % 5000 < 500 {
-                print(
-                    "[WebSocketServer] Broadcast performance update: fps=\(snapshot.fps ?? 0), frameTime=\(snapshot.frameTimeMs ?? 0)ms"
-                )
-            }
         } catch {
             print("[WebSocketServer] Failed to encode performance update: \(error)")
         }

--- a/src/daemon/daemonState.ts
+++ b/src/daemon/daemonState.ts
@@ -60,7 +60,7 @@ export class DaemonState implements DaemonStateLike {
     }
     const stats = this.devicePool.getStats();
     const poolInstanceId = this.devicePool.instanceId;
-    logger.info(`[DAEMON-STATE-DEBUG] getDevicePool returning pool instance #${poolInstanceId} with ${stats.total} devices`);
+    logger.debug(`[DAEMON-STATE-DEBUG] getDevicePool returning pool instance #${poolInstanceId} with ${stats.total} devices`);
     return this.devicePool;
   }
 

--- a/src/features/observe/ios/IOSCtrlProxyClient.ts
+++ b/src/features/observe/ios/IOSCtrlProxyClient.ts
@@ -1154,7 +1154,7 @@ export class IOSCtrlProxyClient extends DeviceServiceClient implements IOSCtrlPr
       server.pushPerformanceUpdate(this.device.deviceId, streamData);
       // Log occasionally to avoid spam
       if (this.timer.now() % 5000 < 600) {
-        logger.info(`[IOSCtrlProxyClient] iOS FPS: ${streamData.fps.toFixed(1)}, frameTime: ${streamData.frameTimeMs.toFixed(1)}ms, memory: ${streamData.memoryUsageMb.toFixed(1)}MB`);
+        logger.debug(`[IOSCtrlProxyClient] iOS FPS: ${streamData.fps.toFixed(1)}, frameTime: ${streamData.frameTimeMs.toFixed(1)}ms, memory: ${streamData.memoryUsageMb.toFixed(1)}MB`);
       }
     } catch (error) {
       logger.warn(`[IOSCtrlProxyClient] Failed to push performance update: ${error}`);

--- a/src/utils/IOSCtrlProxyManager.ts
+++ b/src/utils/IOSCtrlProxyManager.ts
@@ -124,6 +124,21 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
   private cachedRunning: { isRunning: boolean; timestamp: number } | null = null;
   private static readonly AVAILABILITY_CACHE_TTL = 60 * 60 * 1000; // 1 hour
   private static readonly STATUS_CACHE_TTL = 30 * 1000; // 30 seconds
+  private static readonly IMPORTANT_OUTPUT_MARKERS = [
+    "error",
+    "failed",
+    "failure",
+    "fatal",
+    "exception",
+    "crash",
+    "panic",
+    "timed out",
+    "timeout",
+    "denied",
+    "unable",
+    "not found",
+    "xctestconfiguration",
+  ];
 
   // Setup state tracking
   private attemptedSetup: boolean = false;
@@ -847,7 +862,7 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
     if (child.stdout) {
       child.stdout.on("data", (data: Buffer | string) => {
         const output = data.toString().trim();
-        if (output) {
+        if (output && this.shouldPromoteCtrlProxyOutput(output)) {
           logger.info(`[CtrlProxy stdout] ${output.slice(0, 500)}`);
         }
       });
@@ -857,10 +872,23 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
       child.stderr.on("data", (data: Buffer | string) => {
         const output = data.toString().trim();
         if (output && !output.includes("Build Succeeded")) {
-          logger.warn(`[CtrlProxy stderr] ${output.slice(0, 500)}`);
+          if (this.shouldPromoteCtrlProxyOutput(output)) {
+            logger.warn(`[CtrlProxy stderr] ${output.slice(0, 500)}`);
+          } else {
+            logger.debug(`[CtrlProxy stderr] ${output.slice(0, 500)}`);
+          }
         }
       });
     }
+  }
+
+  private shouldPromoteCtrlProxyOutput(output: string): boolean {
+    if (process.env.AUTOMOBILE_CTRLPROXY_VERBOSE === "true") {
+      return true;
+    }
+
+    const lower = output.toLowerCase();
+    return IOSCtrlProxyManager.IMPORTANT_OUTPUT_MARKERS.some(marker => lower.includes(marker));
   }
 
   /**

--- a/src/utils/android-cmdline-tools/AdbClient.ts
+++ b/src/utils/android-cmdline-tools/AdbClient.ts
@@ -79,6 +79,8 @@ export class AdbClient implements AdbExecutor {
 
   private static readonly DEVICE_LIST_TIMEOUT_MS = 10000;
   private static readonly MAX_ADB_RETRIES = 3;
+  private static readonly MAX_MACOS_MISSING_ADB_PROBES = 3;
+  private static macosMissingAdbProbes = 0;
 
   /**
    * Create an AdbClient instance
@@ -387,6 +389,31 @@ export class AdbClient implements AdbExecutor {
     return nonRetryablePatterns.some(pattern => message.includes(pattern));
   }
 
+  private isMissingExecutableError(error: unknown): boolean {
+    const err = error as NodeJS.ErrnoException;
+    const message = error instanceof Error ? error.message : String(error);
+    return err.code === "ENOENT" || message.includes("ENOENT") || message.includes("Executable not found");
+  }
+
+  private shouldSkipMissingAdbProbe(): boolean {
+    if (this.isTestMode) {
+      return false;
+    }
+    return process.platform === "darwin" &&
+      AdbClient.macosMissingAdbProbes >= AdbClient.MAX_MACOS_MISSING_ADB_PROBES;
+  }
+
+  private recordMissingAdbProbe(): void {
+    if (this.isTestMode || process.platform !== "darwin") {
+      return;
+    }
+
+    AdbClient.macosMissingAdbProbes += 1;
+    if (AdbClient.macosMissingAdbProbes === AdbClient.MAX_MACOS_MISSING_ADB_PROBES) {
+      logger.debug("[ADB] adb not found after 3 probes; skipping passive Android device scans on this macOS host.");
+    }
+  }
+
   /**
    * Internal implementation of command execution
    * @param command - The ADB command to execute
@@ -423,7 +450,12 @@ export class AdbClient implements AdbExecutor {
           throw new Error(OPERATION_CANCELLED_MESSAGE);
         }
         const duration = this.timer.now() - startTime;
-        logger.warn(`[ADB] Command failed after ${duration}ms: ${command} - ${(error as Error).message}`);
+        const message = (error as Error).message;
+        if (this.isMissingExecutableError(error)) {
+          logger.debug(`[ADB] Command failed after ${duration}ms: ${command} - ${message}`);
+        } else {
+          logger.warn(`[ADB] Command failed after ${duration}ms: ${command} - ${message}`);
+        }
         throw error;
       }
     }
@@ -604,21 +636,34 @@ export class AdbClient implements AdbExecutor {
    * @returns Promise with an array of device IDs
    */
   async getBootedAndroidDevices(): Promise<BootedDevice[]> {
+    if (this.shouldSkipMissingAdbProbe()) {
+      return [];
+    }
+
     // Check cache first - TTLCache handles expiration automatically
     const cache = getDeviceListCache();
     const cachedDevices = cache.get("devices");
     if (cachedDevices) {
-      logger.info(`Getting list of connected devices (cached)`);
+      logger.debug("Getting list of connected devices (cached)");
       return cachedDevices;
     }
 
-    logger.info("Getting list of connected devices");
-    const result = await this.executeCommand(
-      "devices",
-      AdbClient.DEVICE_LIST_TIMEOUT_MS,
-      undefined,
-      true
-    );
+    logger.debug("Getting list of connected devices");
+    let result: ExecResult;
+    try {
+      result = await this.executeCommand(
+        "devices",
+        AdbClient.DEVICE_LIST_TIMEOUT_MS,
+        undefined,
+        true
+      );
+    } catch (error) {
+      if (this.isMissingExecutableError(error)) {
+        this.recordMissingAdbProbe();
+        return [];
+      }
+      throw error;
+    }
     const lines = result.stdout.split("\n").slice(1); // Skip the first line which is the header
 
     const devices = lines

--- a/src/utils/android-cmdline-tools/AndroidEmulatorClient.ts
+++ b/src/utils/android-cmdline-tools/AndroidEmulatorClient.ts
@@ -641,7 +641,7 @@ export class AndroidEmulatorClient implements AndroidEmulator {
           const result = await adbWithDevice.executeCommand("emu avd name", infoTimeoutMs, undefined, true);
           const avdName = result.stdout.trim().replace(/\r?\n.*$/, ""); // Remove any trailing newlines and additional text
 
-          logger.info(`AVD name detection for ${deviceId}: raw="${result.stdout}" (${result.stdout.length} chars), cleaned="${avdName}"`);
+          logger.debug(`AVD name detection for ${deviceId}: raw="${result.stdout}" (${result.stdout.length} chars), cleaned="${avdName}"`);
 
           runningDevices.push({
             name: avdName || `Unknown (${deviceId})`,
@@ -651,7 +651,7 @@ export class AndroidEmulatorClient implements AndroidEmulator {
           });
         } catch (error) {
           // If we can't get the AVD name, just use the device ID
-          logger.info(`Failed to get AVD name for ${deviceId}: ${error}`);
+          logger.debug(`Failed to get AVD name for ${deviceId}: ${error}`);
           runningDevices.push({
             name: `Unknown (${deviceId})`,
             platform: "android",
@@ -669,7 +669,7 @@ export class AndroidEmulatorClient implements AndroidEmulator {
             const avdName = result.stdout.trim().replace(/\r?\n.*$/, "");
 
             if (avdName) {
-              logger.info(`AVD name detection for ${device.deviceId}: raw="${result.stdout}" (${result.stdout.length} chars), cleaned="${avdName}"`);
+              logger.debug(`AVD name detection for ${device.deviceId}: raw="${result.stdout}" (${result.stdout.length} chars), cleaned="${avdName}"`);
               runningDevices.push({
                 name: avdName,
                 platform: "android",
@@ -688,7 +688,7 @@ export class AndroidEmulatorClient implements AndroidEmulator {
         const cachedModel = this.modelNameCache.get(device.deviceId);
         if (cachedModel) {
           deviceName = cachedModel;
-          logger.info(`Got model name for ${device.deviceId}: "${cachedModel}" (cached)`);
+          logger.debug(`Got model name for ${device.deviceId}: "${cachedModel}" (cached)`);
         } else {
           try {
             const adbWithDevice = this.adbFactory.create(device);
@@ -703,12 +703,12 @@ export class AndroidEmulatorClient implements AndroidEmulator {
             if (modelName && modelName !== "unknown" && modelName.length > 0) {
               deviceName = modelName;
               this.modelNameCache.set(device.deviceId, modelName);
-              logger.info(`Got model name for ${device.deviceId}: "${modelName}"`);
+              logger.debug(`Got model name for ${device.deviceId}: "${modelName}"`);
             } else {
-              logger.info(`No model name found for ${device.deviceId}, using device ID`);
+              logger.debug(`No model name found for ${device.deviceId}, using device ID`);
             }
           } catch (error) {
-            logger.info(`Failed to get model name for ${device.deviceId}: ${error}`);
+            logger.debug(`Failed to get model name for ${device.deviceId}: ${error}`);
           }
         }
 
@@ -723,7 +723,7 @@ export class AndroidEmulatorClient implements AndroidEmulator {
 
       return runningDevices;
     } catch (error) {
-      logger.error(`[DeviceListTimeout] Failed to get running emulators (ADB likely timed out):`, error);
+      logger.debug(`[DeviceListTimeout] Failed to get running emulators: ${error}`);
       return [];
     }
   }

--- a/src/utils/android-cmdline-tools/detection.ts
+++ b/src/utils/android-cmdline-tools/detection.ts
@@ -308,7 +308,7 @@ export async function detectHomebrewAndroidTools(systemDetection = createDefault
  */
 export async function detectAndroidSdkTools(systemDetection = createDefaultSystemDetection()): Promise<AndroidToolsLocation[]> {
   const locations: AndroidToolsLocation[] = [];
-  logger.info("Looking for for Android SDK tools");
+  logger.debug("Looking for Android SDK tools");
 
   // Check environment variables
   const sdkPath = getAndroidSdkFromEnvironment(systemDetection);
@@ -332,7 +332,7 @@ export async function detectAndroidSdkTools(systemDetection = createDefaultSyste
   // Check typical installation paths
   const typicalPaths = getTypicalAndroidSdkPaths(systemDetection);
   for (const sdkPath of typicalPaths) {
-    logger.info(`Checking typical path for Android SDK: ${sdkPath}`);
+    logger.debug(`Checking typical path for Android SDK: ${sdkPath}`);
     // Skip if we already found this path from environment
     const androidHome = systemDetection.getEnvVar("ANDROID_HOME");
     const androidSdkRoot = systemDetection.getEnvVar("ANDROID_SDK_ROOT");
@@ -364,14 +364,14 @@ export async function detectAndroidSdkTools(systemDetection = createDefaultSyste
 async function detectAndroidToolsInPath(systemDetection = createDefaultSystemDetection()): Promise<AndroidToolsLocation | null> {
   const availableTools: string[] = [];
   const toolPaths: Record<string, string> = {};
-  logger.info("Looking for for Android SDK tools in PATH");
+  logger.debug("Looking for Android SDK tools in PATH");
 
   // Check each tool individually
   for (const toolName of Object.keys(ANDROID_TOOLS)) {
     if (await isToolInPath(toolName, systemDetection)) {
       const toolPath = await getToolPathFromPath(toolName, systemDetection);
       if (toolPath) {
-        logger.info(`Tool ${toolName} was in PATH`);
+        logger.debug(`Tool ${toolName} was in PATH`);
         availableTools.push(toolName);
         toolPaths[toolName] = toolPath;
       }
@@ -407,20 +407,20 @@ async function detectAndroidToolsInPath(systemDetection = createDefaultSystemDet
  */
 export async function detectAndroidCommandLineTools(systemDetection = createDefaultSystemDetection()): Promise<AndroidToolsLocation[]> {
   if (cachedAndroidToolsLocations !== undefined) {
-    logger.info("Already cached Android tools locations. Returning cached result.");
+    logger.debug("Already cached Android tools locations. Returning cached result.");
     return cachedAndroidToolsLocations;
   }
 
   const locations: AndroidToolsLocation[] = [];
 
-  logger.info("Starting Android command line tools detection...");
+  logger.debug("Starting Android command line tools detection...");
 
   // 1. Check Homebrew installation (macOS only)
   try {
     const homebrewLocation = await detectHomebrewAndroidTools(systemDetection);
     if (homebrewLocation) {
       locations.push(homebrewLocation);
-      logger.info(`Found Homebrew Android tools at: ${homebrewLocation.path}`);
+      logger.debug(`Found Homebrew Android tools at: ${homebrewLocation.path}`);
     }
   } catch (error) {
     logger.warn(`Error detecting Homebrew Android tools: ${(error as Error).message}`);
@@ -431,7 +431,7 @@ export async function detectAndroidCommandLineTools(systemDetection = createDefa
     const sdkLocations = await detectAndroidSdkTools(systemDetection);
     locations.push(...sdkLocations);
     for (const location of sdkLocations) {
-      logger.info(`Found Android SDK tools at: ${location.path} (source: ${location.source})`);
+      logger.debug(`Found Android SDK tools at: ${location.path} (source: ${location.source})`);
     }
   } catch (error) {
     logger.warn(`Error detecting Android SDK tools: ${(error as Error).message}`);
@@ -442,7 +442,7 @@ export async function detectAndroidCommandLineTools(systemDetection = createDefa
     const pathLocation = await detectAndroidToolsInPath(systemDetection);
     if (pathLocation) {
       locations.push(pathLocation);
-      logger.info(`Found Android tools in PATH: ${pathLocation.available_tools.join(", ")}`);
+      logger.debug(`Found Android tools in PATH: ${pathLocation.available_tools.join(", ")}`);
     }
   } catch (error) {
     logger.warn(`Error detecting Android tools in PATH: ${(error as Error).message}`);
@@ -453,7 +453,7 @@ export async function detectAndroidCommandLineTools(systemDetection = createDefa
     index === self.findIndex(l => l.path === location.path)
   );
 
-  logger.info(`Detection complete. Found ${uniqueLocations.length} unique Android tools installations.`);
+  logger.debug(`Detection complete. Found ${uniqueLocations.length} unique Android tools installations.`);
 
   cachedAndroidToolsLocations = uniqueLocations;
   return uniqueLocations;

--- a/src/utils/ios-cmdline-tools/SimCtlClient.ts
+++ b/src/utils/ios-cmdline-tools/SimCtlClient.ts
@@ -328,10 +328,12 @@ export class SimCtlClient implements SimCtl {
   private hostControl: SimctlHostControlRunner;
   private hostControlAvailability: Promise<boolean> | null = null;
   private timer: Timer;
+  private readonly usesInjectedExecAsync: boolean;
 
   // Static cache for device list
   private static deviceListCache: { devices: DeviceInfo[], timestamp: number } | null = null;
   private static readonly DEVICE_LIST_CACHE_TTL = 5000; // 5 seconds
+  private static localSimctlAvailability: Promise<boolean> | null = null;
 
   /**
    * Create an IosUtils instance
@@ -347,6 +349,7 @@ export class SimCtlClient implements SimCtl {
     timer: Timer = defaultTimer
   ) {
     this.device = device;
+    this.usesInjectedExecAsync = execAsyncFn !== null;
     this.execAsync = execAsyncFn || execAsync;
     this.timer = timer;
     this.hostControl = hostControlRunner || {
@@ -396,7 +399,10 @@ export class SimCtlClient implements SimCtl {
     }
 
     if (!useHostControl && !(await this.isLocalSimctlAvailable())) {
-      throw new ActionableError("simctl is not available. Please install Xcode command line tools to continue.");
+      const message = process.platform === "darwin"
+        ? "simctl is not available. Please install Xcode command line tools to continue."
+        : "iOS simulator tooling is only available on macOS.";
+      throw new ActionableError(message);
     }
 
     const runCommand = () => (
@@ -453,13 +459,7 @@ export class SimCtlClient implements SimCtl {
       return this.isHostControlAvailable();
     }
 
-    try {
-      await this.execAsync("xcrun", ["simctl", "--version"]);
-      return true;
-    } catch (error) {
-      logger.warn("simctl is not available - iOS functionality requires Xcode command line tools to be installed.");
-      return false;
-    }
+    return this.isLocalSimctlAvailable();
   }
 
   private async isHostControlAvailable(): Promise<boolean> {
@@ -470,14 +470,29 @@ export class SimCtlClient implements SimCtl {
   }
 
   private async isLocalSimctlAvailable(): Promise<boolean> {
-    try {
-      await this.execAsync("xcrun", ["simctl", "--version"]);
-      return true;
-    } catch (err) {
-      logger.warn(`[iOS] isLocalSimctlAvailable failed: ${err instanceof Error ? `${err.message} (code=${(err as NodeJS.ErrnoException).code}, syscall=${(err as NodeJS.ErrnoException).syscall}, path=${(err as NodeJS.ErrnoException).path})` : String(err)}`);
-      logger.warn(`[iOS] PATH at failure: ${process.env.PATH ?? "(unset)"}`);
+    if (process.platform !== "darwin") {
       return false;
     }
+
+    if (this.usesInjectedExecAsync) {
+      try {
+        await this.execAsync("xcrun", ["simctl", "--version"]);
+        return true;
+      } catch {
+        return false;
+      }
+    }
+
+    if (!SimCtlClient.localSimctlAvailability) {
+      SimCtlClient.localSimctlAvailability = this.execAsync("xcrun", ["simctl", "--version"])
+        .then(() => true)
+        .catch(err => {
+          logger.debug(`[iOS] simctl unavailable: ${err instanceof Error ? err.message : String(err)}`);
+          return false;
+        });
+    }
+
+    return SimCtlClient.localSimctlAvailability;
   }
 
   /**
@@ -648,7 +663,7 @@ export class SimCtlClient implements SimCtl {
       devices.sort((a, b) => (a.deviceId || "").localeCompare(b.deviceId || ""));
       return devices;
     } catch (error) {
-      logger.warn(`Failed to get iOS devices: ${error}`);
+      logger.debug(`Failed to get iOS devices: ${error}`);
       return [];
     }
   }
@@ -683,7 +698,7 @@ export class SimCtlClient implements SimCtl {
       bootedDevices.sort((a, b) => a.deviceId.localeCompare(b.deviceId));
       return bootedDevices;
     } catch (error) {
-      logger.warn(`Failed to get booted iOS devices: ${error}`);
+      logger.debug(`Failed to get booted iOS devices: ${error}`);
       return [];
     }
   }

--- a/src/utils/ios-cmdline-tools/SimCtlClient.ts
+++ b/src/utils/ios-cmdline-tools/SimCtlClient.ts
@@ -470,10 +470,6 @@ export class SimCtlClient implements SimCtl {
   }
 
   private async isLocalSimctlAvailable(): Promise<boolean> {
-    if (process.platform !== "darwin") {
-      return false;
-    }
-
     if (this.usesInjectedExecAsync) {
       try {
         await this.execAsync("xcrun", ["simctl", "--version"]);
@@ -481,6 +477,10 @@ export class SimCtlClient implements SimCtl {
       } catch {
         return false;
       }
+    }
+
+    if (process.platform !== "darwin") {
+      return false;
     }
 
     if (!SimCtlClient.localSimctlAvailability) {


### PR DESCRIPTION
## Summary
- Quiet repeated passive Android/iOS tooling probes on hosts without the opposite platform setup.
- Reduce noisy iOS CtrlProxy success-path output while preserving request, hierarchy, navigation, and element lookup logs.
- Demote routine Android SDK/device discovery and daemon debug logs to debug level.

## Test plan
- `bun test test/utils/ios-cmdline-tools/simctl.test.ts test/utils/android-cmdline-tools/detection.test.ts test/utils/android-cmdline-tools/AndroidEmulatorClient-corruptImage.test.ts`
- `swift test --package-path ios/control-proxy`
- `git diff --check`


Made with [Cursor](https://cursor.com)