### PR TITLE
[codex] Fix iOS install session device coherence

### DIFF
--- a/src/daemon/devicePool.ts
+++ b/src/daemon/devicePool.ts
@@ -902,6 +902,43 @@ export class DevicePool {
   }
 
   /**
+   * Bind a known device to a session without running the pool's idle-device
+   * selection. startDevice already resolved the exact device the caller asked
+   * for, so the returned session ID must map back to that same device.
+   */
+  async bindDeviceToSession(sessionId: string, deviceId: string, platform: Platform): Promise<void> {
+    await this.assignmentMutex.runExclusive(async () => {
+      if (!this.devices.has(deviceId)) {
+        const bootedDevices = await this.deviceManager.getBootedDevices(platform);
+        const booted = bootedDevices.find(d => d.deviceId === deviceId);
+        if (booted) {
+          await this.addDevice(booted);
+        }
+      }
+
+      const device = this.devices.get(deviceId);
+      if (!device) {
+        throw new ActionableError(`Device '${deviceId}' is not available in the device pool.`);
+      }
+
+      if (device.sessionId && device.sessionId !== sessionId) {
+        throw new ActionableError(
+          `Device '${deviceId}' is already assigned to session ${device.sessionId}.`
+        );
+      }
+
+      device.sessionId = sessionId;
+      device.status = "busy";
+      device.lastUsedAt = this.nextLastUsedAt();
+      device.assignmentCount++;
+      device.errorCount = 0;
+
+      await this.sessionManager.createSession(sessionId, deviceId, platform);
+      logger.info(`Bound device ${deviceId} to session ${sessionId}`);
+    });
+  }
+
+  /**
    * Lock a device with an autolock session ID.
    *
    * Generates a new session UUID bound to the device. When autolock is enabled,

--- a/src/features/action/InstallApp.ts
+++ b/src/features/action/InstallApp.ts
@@ -322,6 +322,19 @@ export class InstallApp {
     const newBundles = this.diffSets(beforeBundleIds, afterBundleIds);
     let packageName = this.findBundleIdByPath(afterApps, appPath);
 
+    if (!packageName) {
+      const expectedBundleId = await perf.track("resolveBundleId", () => this.resolveAppBundleId(appPath));
+      if (expectedBundleId) {
+        if (!afterBundleIds.has(expectedBundleId)) {
+          throw new Error(
+            `Install reported success, but bundle ${expectedBundleId} was not present on iOS simulator ` +
+            `${this.device.deviceId} after installation.`
+          );
+        }
+        packageName = expectedBundleId;
+      }
+    }
+
     const warnings: string[] = [];
 
     if (downgraded) {

--- a/src/server/deviceTools.ts
+++ b/src/server/deviceTools.ts
@@ -391,7 +391,9 @@ export function registerDeviceTools() {
     // Always generate a session ID for consistent device interactions.
     // When autolock is enabled, lock the device to a pool-issued session UUID that
     // is enforced for all subsequent tool calls and auto-released after an idle timeout.
-    // When disabled, AutoMobile assumes a single agent and the session ID is advisory.
+    // When disabled, still bind the returned session to this exact device so callers
+    // can mix startDevice -> setActiveDevice -> session-targeted tools without the
+    // session path assigning a different simulator/device on first use.
     let sessionId: string | undefined;
     if (isDevicePoolAutolockEnabled() && DaemonState.getInstance().isInitialized()) {
       sessionId = await DaemonState.getInstance()
@@ -400,6 +402,11 @@ export function registerDeviceTools() {
     }
     if (!sessionId) {
       sessionId = randomUUID();
+      if (DaemonState.getInstance().isInitialized()) {
+        await DaemonState.getInstance()
+          .getDevicePool()
+          .bindDeviceToSession(sessionId, device.deviceId, device.platform);
+      }
     }
 
     perf.end();

--- a/test/daemon/devicePool.test.ts
+++ b/test/daemon/devicePool.test.ts
@@ -153,6 +153,26 @@ describe("DevicePool", () => {
       const device2 = await devicePool.assignDeviceToSession("session-2");
       expect(device1).toBe(device2);
     });
+
+    test("should bind a specific device to a session", async () => {
+      await devicePool.initializeWithDevices([createBootedDevice("sim-1", "ios", "iPhone 15")]);
+
+      await devicePool.bindDeviceToSession("session-1", "sim-1", "ios");
+
+      const device = devicePool.getDevice("sim-1");
+      expect(device?.sessionId).toBe("session-1");
+      expect(device?.status).toBe("busy");
+      expect(sessionManager.getSession("session-1")?.assignedDevice).toBe("sim-1");
+    });
+
+    test("should not rebind a device assigned to a different session", async () => {
+      await devicePool.initializeWithDevices([createBootedDevice("sim-1", "ios", "iPhone 15")]);
+      await devicePool.bindDeviceToSession("session-1", "sim-1", "ios");
+
+      await expect(
+        devicePool.bindDeviceToSession("session-2", "sim-1", "ios")
+      ).rejects.toThrow("already assigned to session session-1");
+    });
   });
 
   describe("assignMultipleDevices", () => {

--- a/test/features/action/InstallApp.test.ts
+++ b/test/features/action/InstallApp.test.ts
@@ -403,8 +403,9 @@ describe("InstallApp", () => {
       [],
       [{ bundleId: "com.example.a" }, { bundleId: "com.example.b" }]
     ]);
+    fakeHost.setCommandResponse("plutil", createExecResult(""));
 
-    const installApp = new InstallApp(iosSimulatorDevice, fakeAdbFactory, null, null, () => perf, sequencedSimctl);
+    const installApp = new InstallApp(iosSimulatorDevice, fakeAdbFactory, fakeHost, null, () => perf, sequencedSimctl);
     const result = await installApp.execute(appPath);
 
     expect(result.success).toBe(true);
@@ -420,13 +421,31 @@ describe("InstallApp", () => {
       [{ bundleId: "com.example.existing" }],
       [{ bundleId: "com.example.existing" }]
     ]);
+    fakeHost.setCommandResponse("plutil", createExecResult(""));
 
-    const installApp = new InstallApp(iosSimulatorDevice, fakeAdbFactory, null, null, () => perf, sequencedSimctl);
+    const installApp = new InstallApp(iosSimulatorDevice, fakeAdbFactory, fakeHost, null, () => perf, sequencedSimctl);
     const result = await installApp.execute(appPath);
 
     expect(result.success).toBe(true);
     expect(result.packageName).toBeUndefined();
     expect(result.warning).toContain("bundle ID could not be determined");
+  });
+
+  test("iOS simulator install fails when expected bundle is absent after simctl success", async () => {
+    const appPath = "/tmp/MyApp.app";
+    const perf = createPerformanceTracker(true, fakeTimer);
+    const sequencedSimctl = new SequencedFakeSimctl();
+    sequencedSimctl.setListResponses([
+      [],
+      []
+    ]);
+    fakeHost.setCommandResponse("plutil", createExecResult("com.example.app\n"));
+
+    const installApp = new InstallApp(iosSimulatorDevice, fakeAdbFactory, fakeHost, null, () => perf, sequencedSimctl);
+
+    await expect(installApp.execute(appPath)).rejects.toThrow(
+      "Install reported success, but bundle com.example.app was not present"
+    );
   });
 
   test("propagates devicectl failure for iOS physical device install", async () => {

--- a/test/server/deviceTools.startDevice.test.ts
+++ b/test/server/deviceTools.startDevice.test.ts
@@ -290,4 +290,25 @@ describe("startDevice handler", () => {
     expect(typeof result.sessionId).toBe("string");
     expect(pool.resolveAutolockSessionForMcpSession("mcp-session-1", "android")).toBe(result.sessionId);
   });
+
+  it("binds the returned sessionId to the started device when autolock is disabled", async () => {
+    const timer = new FakeTimer();
+    daemonSessionManager = new SessionManager(timer);
+    const pool = new DevicePool(daemonSessionManager, "daemon-session", timer, undefined, fakeDeviceUtils);
+    await pool.initializeWithDevices([iosDevice]);
+    DaemonState.getInstance().initialize(daemonSessionManager, pool);
+
+    fakeDeviceUtils.setBootedDevices("ios", [iosDevice]);
+    fakeMatcher.setBootedResult(iosDevice);
+
+    const result = await callStartDevice({ platform: "ios" });
+
+    expect(typeof result.sessionId).toBe("string");
+    const session = daemonSessionManager.getSession(result.sessionId as string);
+    expect(session).not.toBeNull();
+    expect(session!.assignedDevice).toBe(iosDevice.deviceId);
+    expect(session!.platform).toBe("ios");
+    expect(pool.getDevice(iosDevice.deviceId)?.sessionId).toBe(result.sessionId);
+    expect(pool.getDevice(iosDevice.deviceId)?.status).toBe("busy");
+  });
 });


### PR DESCRIPTION
## Summary
- Bind the `startDevice` session ID to the exact selected device in the daemon device pool, even when autolock is disabled.
- Verify iOS simulator installs by checking the expected bundle ID is present after `simctl install` reports success.
- Add focused regression coverage for session/device-pool coherence and false-success iOS simulator installs.

## Root Cause
`startDevice` returned a `sessionId`, but with autolock disabled that ID was not bound to the selected device in daemon session routing. A later `installApp` call with that `sessionUuid` could resolve through the session path to a different simulator than `setActiveDevice`/non-session `launchApp` used.

## Testing
- `bun test test/daemon/devicePool.test.ts`
- `bun test test/server/deviceTools.startDevice.test.ts`
- `bun test test/features/action/InstallApp.test.ts`
- `bun run lint`
- `bun run build`
- `git diff --check`

Fixes #2387
