### PR TITLE
[codex] Reuse startDevice sessions for bound devices

### DIFF
--- a/src/daemon/devicePool.ts
+++ b/src/daemon/devicePool.ts
@@ -903,11 +903,11 @@ export class DevicePool {
 
   /**
    * Bind a known device to a session without running the pool's idle-device
-   * selection. startDevice already resolved the exact device the caller asked
-   * for, so the returned session ID must map back to that same device.
+   * selection. If the device is already bound to a live session, reuse that
+   * session so repeated startDevice calls stay idempotent.
    */
-  async bindDeviceToSession(sessionId: string, deviceId: string, platform: Platform): Promise<void> {
-    await this.assignmentMutex.runExclusive(async () => {
+  async bindOrReuseDeviceSession(sessionId: string, deviceId: string, platform: Platform): Promise<string> {
+    return await this.assignmentMutex.runExclusive(async () => {
       if (!this.devices.has(deviceId)) {
         const bootedDevices = await this.deviceManager.getBootedDevices(platform);
         const booted = bootedDevices.find(d => d.deviceId === deviceId);
@@ -921,10 +921,26 @@ export class DevicePool {
         throw new ActionableError(`Device '${deviceId}' is not available in the device pool.`);
       }
 
-      if (device.sessionId && device.sessionId !== sessionId) {
-        throw new ActionableError(
-          `Device '${deviceId}' is already assigned to session ${device.sessionId}.`
-        );
+      if (device.sessionId) {
+        const existingSession = this.sessionManager.getSession(device.sessionId);
+        if (
+          existingSession &&
+          existingSession.assignedDevice === deviceId &&
+          existingSession.platform === device.platform
+        ) {
+          const refreshedSession = await this.sessionManager.getOrCreateSession(existingSession.sessionId);
+          logger.info(`Reusing existing session ${refreshedSession.sessionId} for device ${deviceId}`);
+          return refreshedSession.sessionId;
+        }
+
+        if (existingSession) {
+          throw new ActionableError(
+            `Device '${deviceId}' is already assigned to session ${device.sessionId}.`
+          );
+        }
+
+        device.sessionId = null;
+        device.status = "idle";
       }
 
       device.sessionId = sessionId;
@@ -935,6 +951,7 @@ export class DevicePool {
 
       await this.sessionManager.createSession(sessionId, deviceId, platform);
       logger.info(`Bound device ${deviceId} to session ${sessionId}`);
+      return sessionId;
     });
   }
 

--- a/src/server/deviceTools.ts
+++ b/src/server/deviceTools.ts
@@ -403,9 +403,9 @@ export function registerDeviceTools() {
     if (!sessionId) {
       sessionId = randomUUID();
       if (DaemonState.getInstance().isInitialized()) {
-        await DaemonState.getInstance()
+        sessionId = await DaemonState.getInstance()
           .getDevicePool()
-          .bindDeviceToSession(sessionId, device.deviceId, device.platform);
+          .bindOrReuseDeviceSession(sessionId, device.deviceId, device.platform);
       }
     }
 

--- a/test/daemon/devicePool.test.ts
+++ b/test/daemon/devicePool.test.ts
@@ -157,21 +157,24 @@ describe("DevicePool", () => {
     test("should bind a specific device to a session", async () => {
       await devicePool.initializeWithDevices([createBootedDevice("sim-1", "ios", "iPhone 15")]);
 
-      await devicePool.bindDeviceToSession("session-1", "sim-1", "ios");
+      const sessionId = await devicePool.bindOrReuseDeviceSession("session-1", "sim-1", "ios");
 
+      expect(sessionId).toBe("session-1");
       const device = devicePool.getDevice("sim-1");
       expect(device?.sessionId).toBe("session-1");
       expect(device?.status).toBe("busy");
       expect(sessionManager.getSession("session-1")?.assignedDevice).toBe("sim-1");
     });
 
-    test("should not rebind a device assigned to a different session", async () => {
+    test("should reuse a live session when the device is already bound", async () => {
       await devicePool.initializeWithDevices([createBootedDevice("sim-1", "ios", "iPhone 15")]);
-      await devicePool.bindDeviceToSession("session-1", "sim-1", "ios");
+      await devicePool.bindOrReuseDeviceSession("session-1", "sim-1", "ios");
 
-      await expect(
-        devicePool.bindDeviceToSession("session-2", "sim-1", "ios")
-      ).rejects.toThrow("already assigned to session session-1");
+      const sessionId = await devicePool.bindOrReuseDeviceSession("session-2", "sim-1", "ios");
+
+      expect(sessionId).toBe("session-1");
+      expect(devicePool.getDevice("sim-1")?.sessionId).toBe("session-1");
+      expect(sessionManager.getSession("session-2")).toBeNull();
     });
   });
 

--- a/test/server/deviceTools.startDevice.test.ts
+++ b/test/server/deviceTools.startDevice.test.ts
@@ -291,7 +291,7 @@ describe("startDevice handler", () => {
     expect(pool.resolveAutolockSessionForMcpSession("mcp-session-1", "android")).toBe(result.sessionId);
   });
 
-  it("binds the returned sessionId to the started device when autolock is disabled", async () => {
+  it("reuses the returned sessionId for repeated startDevice calls when autolock is disabled", async () => {
     const timer = new FakeTimer();
     daemonSessionManager = new SessionManager(timer);
     const pool = new DevicePool(daemonSessionManager, "daemon-session", timer, undefined, fakeDeviceUtils);
@@ -302,8 +302,10 @@ describe("startDevice handler", () => {
     fakeMatcher.setBootedResult(iosDevice);
 
     const result = await callStartDevice({ platform: "ios" });
+    const repeated = await callStartDevice({ platform: "ios" });
 
     expect(typeof result.sessionId).toBe("string");
+    expect(repeated.sessionId).toBe(result.sessionId);
     const session = daemonSessionManager.getSession(result.sessionId as string);
     expect(session).not.toBeNull();
     expect(session!.assignedDevice).toBe(iosDevice.deviceId);


### PR DESCRIPTION
## Summary
- Reuse an existing live device-pool session when `startDevice` is called again for the same already-bound device.
- Return the reused session ID from `startDevice` instead of generating a competing UUID that fails binding.
- Refresh the reused session activity so repeated readiness checks keep the session alive.

## Context
Follow-up to merged PR #2419. Automated review noted that non-autolock `startDevice` became non-idempotent: a repeated call for the same running device generated a new UUID and then failed because the device was already bound to the first returned session.

## Testing
- `bun test test/daemon/devicePool.test.ts`
- `bun test test/server/deviceTools.startDevice.test.ts`
- `bun run lint`
- `bun run build`
- `git diff --check`
