### PR TITLE
Harden non-macOS iOS discovery

### DIFF
--- a/src/server/appResources.ts
+++ b/src/server/appResources.ts
@@ -323,8 +323,15 @@ function getAndroidAppsMessage(deviceId: string): string {
 
 async function findBootedDevice(deviceId: string): Promise<BootedDevice | null> {
   try {
-    const devices = await PlatformDeviceManagerFactory.getInstance().getBootedDevices("either");
-    return devices.find(device => device.deviceId === deviceId) ?? null;
+    const manager = PlatformDeviceManagerFactory.getInstance();
+    const androidDevices = await manager.getBootedDevices("android");
+    const android = androidDevices.find(device => device.deviceId === deviceId);
+    if (android) {
+      return android;
+    }
+
+    const iosDevices = await manager.getBootedDevices("ios");
+    return iosDevices.find(device => device.deviceId === deviceId) ?? null;
   } catch (error) {
     logger.warn(`[AppResources] Failed to list booted devices: ${error}`);
     return null;
@@ -516,17 +523,18 @@ async function getAppsQueryDevice(options: AppsQueryOptions): Promise<BootedDevi
     throw new Error("deviceId is required");
   }
 
-  const devices = await PlatformDeviceManagerFactory.getInstance().getBootedDevices("either");
+  const manager = PlatformDeviceManagerFactory.getInstance();
+  const platforms: Platform[] = options.platform ? [options.platform] : ["android", "ios"];
 
-  const matched = devices.find(device => device.deviceId === options.deviceId);
-  if (!matched) {
-    throw new Error(`Device not found or not booted: ${options.deviceId}`);
-  }
-  if (options.platform && matched.platform !== options.platform) {
-    throw new Error(`Device ${options.deviceId} is not a ${options.platform} device`);
+  for (const platform of platforms) {
+    const devices = await manager.getBootedDevices(platform);
+    const matched = devices.find(device => device.deviceId === options.deviceId);
+    if (matched) {
+      return matched;
+    }
   }
 
-  return matched;
+  throw new Error(`Device not found or not booted: ${options.deviceId}`);
 }
 
 async function getAppsQueryResource(

--- a/src/server/localizationResources.ts
+++ b/src/server/localizationResources.ts
@@ -23,8 +23,15 @@ interface LocalizationResourceContent {
 
 async function findBootedDevice(deviceId: string): Promise<BootedDevice | null> {
   try {
-    const devices = await PlatformDeviceManagerFactory.getInstance().getBootedDevices("either");
-    return devices.find(device => device.deviceId === deviceId) ?? null;
+    const manager = PlatformDeviceManagerFactory.getInstance();
+    const androidDevices = await manager.getBootedDevices("android");
+    const android = androidDevices.find(device => device.deviceId === deviceId);
+    if (android) {
+      return android;
+    }
+
+    const iosDevices = await manager.getBootedDevices("ios");
+    return iosDevices.find(device => device.deviceId === deviceId) ?? null;
   } catch (error) {
     logger.warn(`[LocalizationResources] Failed to list booted devices: ${error}`);
     return null;

--- a/src/utils/deviceUtils.ts
+++ b/src/utils/deviceUtils.ts
@@ -76,6 +76,32 @@ export class MultiPlatformDeviceManager implements PlatformDeviceManager {
     this.emulator = emulator || new AndroidEmulatorClient();
   }
 
+  private async canDiscoverIosLocallyOrViaHostControl(): Promise<boolean> {
+    if (process.platform === "darwin") {
+      return true;
+    }
+
+    try {
+      return await this.simctl.isAvailable();
+    } catch {
+      return false;
+    }
+  }
+
+  private async listIosDeviceImagesIfAvailable(): Promise<DeviceInfo[]> {
+    if (!(await this.canDiscoverIosLocallyOrViaHostControl())) {
+      return [];
+    }
+    return this.simctl.listSimulatorImages();
+  }
+
+  private async getBootedIosDevicesIfAvailable(): Promise<BootedDevice[]> {
+    if (!(await this.canDiscoverIosLocallyOrViaHostControl())) {
+      return [];
+    }
+    return this.simctl.getBootedSimulators();
+  }
+
   /**
    * List all available device images
    * @returns Promise with array of device image names
@@ -85,10 +111,10 @@ export class MultiPlatformDeviceManager implements PlatformDeviceManager {
       case "android":
         return this.emulator.listAvds();
       case "ios":
-        return this.simctl.listSimulatorImages();
+        return this.listIosDeviceImagesIfAvailable();
       case "either":
         const emulators = await this.emulator.listAvds();
-        const simulators = await this.simctl.listSimulatorImages();
+        const simulators = await this.listIosDeviceImagesIfAvailable();
         return [...emulators, ...simulators];
     }
   }
@@ -103,6 +129,9 @@ export class MultiPlatformDeviceManager implements PlatformDeviceManager {
       case "android":
         return this.emulator.isAvdRunning(device.name);
       case "ios":
+        if (!(await this.canDiscoverIosLocallyOrViaHostControl())) {
+          return false;
+        }
         if (device.deviceId) {
           const booted = await this.simctl.getBootedSimulators();
           return booted.some(simulator => simulator.deviceId === device.deviceId);
@@ -120,10 +149,10 @@ export class MultiPlatformDeviceManager implements PlatformDeviceManager {
       case "android":
         return this.emulator.getBootedDevices();
       case "ios":
-        return this.simctl.getBootedSimulators();
+        return this.getBootedIosDevicesIfAvailable();
       case "either":
         const emulators = await this.emulator.getBootedDevices();
-        const simulators = await this.simctl.getBootedSimulators();
+        const simulators = await this.getBootedIosDevicesIfAvailable();
         return [...emulators, ...simulators];
     }
   }

--- a/src/utils/deviceUtils.ts
+++ b/src/utils/deviceUtils.ts
@@ -92,14 +92,22 @@ export class MultiPlatformDeviceManager implements PlatformDeviceManager {
     if (!(await this.canDiscoverIosLocallyOrViaHostControl())) {
       return [];
     }
-    return this.simctl.listSimulatorImages();
+    try {
+      return await this.simctl.listSimulatorImages();
+    } catch {
+      return [];
+    }
   }
 
   private async getBootedIosDevicesIfAvailable(): Promise<BootedDevice[]> {
     if (!(await this.canDiscoverIosLocallyOrViaHostControl())) {
       return [];
     }
-    return this.simctl.getBootedSimulators();
+    try {
+      return await this.simctl.getBootedSimulators();
+    } catch {
+      return [];
+    }
   }
 
   /**

--- a/test/daemon/devicePool.test.ts
+++ b/test/daemon/devicePool.test.ts
@@ -6,6 +6,27 @@ import { FakeInstalledAppsRepository } from "../fakes/FakeInstalledAppsRepositor
 import { FakeDeviceManager } from "../fakes/FakeDeviceManager";
 import { BootedDevice, DeviceInfo, Platform } from "../../src/models";
 import { DefaultRetryExecutor } from "../../src/utils/retry/RetryExecutor";
+import { MultiPlatformDeviceManager } from "../../src/utils/deviceUtils";
+import { FakeAdbClient } from "../fakes/FakeAdbClient";
+import type { AdbClient } from "../../src/utils/android-cmdline-tools/AdbClient";
+import type { AndroidEmulatorClient } from "../../src/utils/android-cmdline-tools/AndroidEmulatorClient";
+import type { SimCtlClient } from "../../src/utils/ios-cmdline-tools/SimCtlClient";
+
+async function withProcessPlatform<T>(platform: NodeJS.Platform, fn: () => Promise<T>): Promise<T> {
+  const original = process.platform;
+  Object.defineProperty(process, "platform", {
+    value: platform,
+    configurable: true
+  });
+  try {
+    return await fn();
+  } finally {
+    Object.defineProperty(process, "platform", {
+      value: original,
+      configurable: true
+    });
+  }
+}
 
 describe("DevicePool", () => {
   let devicePool: DevicePool;
@@ -69,6 +90,44 @@ describe("DevicePool", () => {
         expect(device?.status).toBe("idle");
         expect(device?.sessionId).toBeNull();
       }
+    });
+  });
+
+  describe("refreshDevices", () => {
+    test("does not query simctl during Linux Android-only refresh", async () => {
+      await withProcessPlatform("linux", async () => {
+        let simctlBootedCalls = 0;
+        const androidDevice = createBootedDevice("emulator-5554", "android", "Pixel 8");
+        const fakeSimctl = {
+          isAvailable: async () => false,
+          getBootedSimulators: async () => {
+            simctlBootedCalls++;
+            throw new Error("simctl should not be queried");
+          }
+        } as unknown as SimCtlClient;
+        const fakeEmulator = {
+          getBootedDevices: async () => [androidDevice]
+        } as unknown as AndroidEmulatorClient;
+        const manager = new MultiPlatformDeviceManager(
+          new FakeAdbClient() as unknown as AdbClient,
+          fakeSimctl,
+          fakeEmulator
+        );
+        const pool = new DevicePool(
+          sessionManager,
+          "test-daemon-session-id",
+          fakeTimer,
+          fakeAppsRepo,
+          manager,
+          new DefaultRetryExecutor(fakeTimer)
+        );
+
+        const added = await pool.refreshDevices();
+
+        expect(added).toBe(1);
+        expect(pool.getDevice("emulator-5554")).not.toBeNull();
+        expect(simctlBootedCalls).toBe(0);
+      });
     });
   });
 

--- a/test/daemon/devicePool.test.ts
+++ b/test/daemon/devicePool.test.ts
@@ -129,6 +129,39 @@ describe("DevicePool", () => {
         expect(simctlBootedCalls).toBe(0);
       });
     });
+
+    test("keeps Android devices when Linux iOS discovery fails after availability", async () => {
+      await withProcessPlatform("linux", async () => {
+        const androidDevice = createBootedDevice("emulator-5554", "android", "Pixel 8");
+        const fakeSimctl = {
+          isAvailable: async () => true,
+          getBootedSimulators: async () => {
+            throw new Error("host-control simctl unavailable");
+          }
+        } as unknown as SimCtlClient;
+        const fakeEmulator = {
+          getBootedDevices: async () => [androidDevice]
+        } as unknown as AndroidEmulatorClient;
+        const manager = new MultiPlatformDeviceManager(
+          new FakeAdbClient() as unknown as AdbClient,
+          fakeSimctl,
+          fakeEmulator
+        );
+        const pool = new DevicePool(
+          sessionManager,
+          "test-daemon-session-id",
+          fakeTimer,
+          fakeAppsRepo,
+          manager,
+          new DefaultRetryExecutor(fakeTimer)
+        );
+
+        const added = await pool.refreshDevices();
+
+        expect(added).toBe(1);
+        expect(pool.getDevice("emulator-5554")).not.toBeNull();
+      });
+    });
   });
 
   describe("assignDeviceToSession", () => {

--- a/test/doctor/index.test.ts
+++ b/test/doctor/index.test.ts
@@ -1,6 +1,23 @@
 import { describe, expect, test } from "bun:test";
+import { runDoctor } from "../../src/doctor";
 import { formatConsoleOutput, formatJsonOutput } from "../../src/doctor/formatter";
 import type { DoctorReport, CheckResult, DoctorSummary } from "../../src/doctor/types";
+
+async function withProcessPlatform<T>(platform: NodeJS.Platform, fn: () => Promise<T>): Promise<T> {
+  const original = process.platform;
+  Object.defineProperty(process, "platform", {
+    value: platform,
+    configurable: true
+  });
+  try {
+    return await fn();
+  } finally {
+    Object.defineProperty(process, "platform", {
+      value: original,
+      configurable: true
+    });
+  }
+}
 
 function makeCheck(overrides: Partial<CheckResult> & Pick<CheckResult, "name" | "status">): CheckResult {
   return {
@@ -381,5 +398,20 @@ describe("formatJsonOutput", () => {
 
     // JSON.stringify with indent 2 starts object contents at 2-space indent
     expect(json).toContain('  "timestamp"');
+  });
+});
+
+describe("runDoctor", () => {
+  test("explicit iOS doctor on non-darwin returns skipped iOS checks promptly", async () => {
+    await withProcessPlatform("linux", async () => {
+      const startedAt = Date.now();
+      const report = await runDoctor({ ios: true });
+
+      expect(Date.now() - startedAt).toBeLessThan(5000);
+      expect(report.platform).toBe("linux");
+      expect(report.android).toBeUndefined();
+      expect(report.ios?.checks.length).toBeGreaterThan(0);
+      expect(report.ios?.checks.every(check => check.status === "skip")).toBe(true);
+    });
   });
 });

--- a/test/doctor/ios.test.ts
+++ b/test/doctor/ios.test.ts
@@ -248,17 +248,39 @@ describe("iOS doctor checks", () => {
     });
 
     test("skips when not on darwin", async () => {
+      let createSimctlClientCalls = 0;
       const result = await checkSimctlAvailable({
         ...baseDependencies,
-        platform: () => "linux"
+        platform: () => "linux",
+        createSimctlClient: () => {
+          createSimctlClientCalls++;
+          throw new Error("createSimctlClient should not be called on non-darwin");
+        }
       });
 
       expect(result.status).toBe("skip");
       expect(result.message).toContain("requires macOS");
+      expect(createSimctlClientCalls).toBe(0);
     });
   });
 
   describe("checkSimulatorRuntimes", () => {
+    test("skips without creating simctl client when not on darwin", async () => {
+      let createSimctlClientCalls = 0;
+      const result = await checkSimulatorRuntimes({
+        ...baseDependencies,
+        platform: () => "linux",
+        createSimctlClient: () => {
+          createSimctlClientCalls++;
+          throw new Error("createSimctlClient should not be called on non-darwin");
+        }
+      });
+
+      expect(result.status).toBe("skip");
+      expect(result.message).toContain("only available on macOS");
+      expect(createSimctlClientCalls).toBe(0);
+    });
+
     test("fails when no simulator runtimes are available", async () => {
       const result = await checkSimulatorRuntimes({
         ...baseDependencies,
@@ -408,13 +430,19 @@ describe("iOS doctor checks", () => {
     });
 
     test("skips when not on darwin", async () => {
+      let createSimctlClientCalls = 0;
       const result = await checkBootedSimulators({
         ...baseDependencies,
-        platform: () => "linux"
+        platform: () => "linux",
+        createSimctlClient: () => {
+          createSimctlClientCalls++;
+          throw new Error("createSimctlClient should not be called on non-darwin");
+        }
       });
 
       expect(result.status).toBe("skip");
       expect(result.message).toContain("only available on macOS");
+      expect(createSimctlClientCalls).toBe(0);
     });
   });
 });

--- a/test/utils/deviceUtils.test.ts
+++ b/test/utils/deviceUtils.test.ts
@@ -98,6 +98,35 @@ describe("MultiPlatformDeviceManager", () => {
     });
   });
 
+  test("getBootedDevices(either) preserves Android results when non-darwin iOS discovery fails after availability", async () => {
+    await withProcessPlatform("linux", async () => {
+      const androidDevice: BootedDevice = {
+        name: "Pixel 8",
+        platform: "android",
+        deviceId: "emulator-5554"
+      };
+      const fakeSimctl = {
+        isAvailable: async () => true,
+        getBootedSimulators: async () => {
+          throw new Error("host-control simctl unavailable");
+        }
+      } as unknown as SimCtlClient;
+      const fakeEmulator = {
+        getBootedDevices: async () => [androidDevice]
+      } as unknown as AndroidEmulatorClient;
+
+      const manager = new MultiPlatformDeviceManager(
+        new FakeAdbClient() as unknown as AdbClient,
+        fakeSimctl,
+        fakeEmulator
+      );
+
+      const devices = await manager.getBootedDevices("either");
+
+      expect(devices).toEqual([androidDevice]);
+    });
+  });
+
   test("listDeviceImages(either) skips iOS image discovery on non-darwin when simctl is unavailable", async () => {
     await withProcessPlatform("linux", async () => {
       let simctlListCalls = 0;
@@ -127,6 +156,35 @@ describe("MultiPlatformDeviceManager", () => {
 
       expect(devices).toEqual([androidImage]);
       expect(simctlListCalls).toBe(0);
+    });
+  });
+
+  test("listDeviceImages(either) preserves Android results when non-darwin iOS image discovery fails after availability", async () => {
+    await withProcessPlatform("linux", async () => {
+      const androidImage: DeviceInfo = {
+        name: "Pixel_8",
+        platform: "android",
+        isRunning: false
+      };
+      const fakeSimctl = {
+        isAvailable: async () => true,
+        listSimulatorImages: async () => {
+          throw new Error("host-control simctl unavailable");
+        }
+      } as unknown as SimCtlClient;
+      const fakeEmulator = {
+        listAvds: async () => [androidImage]
+      } as unknown as AndroidEmulatorClient;
+
+      const manager = new MultiPlatformDeviceManager(
+        new FakeAdbClient() as unknown as AdbClient,
+        fakeSimctl,
+        fakeEmulator
+      );
+
+      const devices = await manager.listDeviceImages("either");
+
+      expect(devices).toEqual([androidImage]);
     });
   });
 });

--- a/test/utils/deviceUtils.test.ts
+++ b/test/utils/deviceUtils.test.ts
@@ -1,13 +1,31 @@
 import { describe, expect, test } from "bun:test";
 import { MultiPlatformDeviceManager } from "../../src/utils/deviceUtils";
-import type { DeviceInfo } from "../../src/models";
+import type { BootedDevice, DeviceInfo } from "../../src/models";
 import { SimCtlClient } from "../../src/utils/ios-cmdline-tools/SimCtlClient";
 import { FakeAdbClient } from "../fakes/FakeAdbClient";
 import { AdbClient } from "../../src/utils/android-cmdline-tools/AdbClient";
+import type { AndroidEmulatorClient } from "../../src/utils/android-cmdline-tools/AndroidEmulatorClient";
+
+async function withProcessPlatform<T>(platform: NodeJS.Platform, fn: () => Promise<T>): Promise<T> {
+  const original = process.platform;
+  Object.defineProperty(process, "platform", {
+    value: platform,
+    configurable: true
+  });
+  try {
+    return await fn();
+  } finally {
+    Object.defineProperty(process, "platform", {
+      value: original,
+      configurable: true
+    });
+  }
+}
 
 describe("MultiPlatformDeviceManager", () => {
   test("isDeviceImageRunning uses UDID when present for iOS", async () => {
     const fakeSimctl = {
+      isAvailable: async () => true,
       getBootedSimulators: async () => [{ name: "iPhone 15", platform: "ios", deviceId: "booted-1" }],
       isSimulatorRunning: async () => {
         throw new Error("should not use name-based check when deviceId is present");
@@ -30,6 +48,7 @@ describe("MultiPlatformDeviceManager", () => {
 
   test("isDeviceImageRunning falls back to name-based check for iOS without UDID", async () => {
     const fakeSimctl = {
+      isAvailable: async () => true,
       getBootedSimulators: async () => [],
       isSimulatorRunning: async (name: string) => name === "iPhone 15"
     } as unknown as SimCtlClient;
@@ -45,5 +64,69 @@ describe("MultiPlatformDeviceManager", () => {
     const isRunning = await manager.isDeviceImageRunning(device);
 
     expect(isRunning).toBe(true);
+  });
+
+  test("getBootedDevices(either) skips iOS discovery on non-darwin when simctl is unavailable", async () => {
+    await withProcessPlatform("linux", async () => {
+      let simctlListCalls = 0;
+      const androidDevice: BootedDevice = {
+        name: "Pixel 8",
+        platform: "android",
+        deviceId: "emulator-5554"
+      };
+      const fakeSimctl = {
+        isAvailable: async () => false,
+        getBootedSimulators: async () => {
+          simctlListCalls++;
+          throw new Error("simctl should not be queried");
+        }
+      } as unknown as SimCtlClient;
+      const fakeEmulator = {
+        getBootedDevices: async () => [androidDevice]
+      } as unknown as AndroidEmulatorClient;
+
+      const manager = new MultiPlatformDeviceManager(
+        new FakeAdbClient() as unknown as AdbClient,
+        fakeSimctl,
+        fakeEmulator
+      );
+
+      const devices = await manager.getBootedDevices("either");
+
+      expect(devices).toEqual([androidDevice]);
+      expect(simctlListCalls).toBe(0);
+    });
+  });
+
+  test("listDeviceImages(either) skips iOS image discovery on non-darwin when simctl is unavailable", async () => {
+    await withProcessPlatform("linux", async () => {
+      let simctlListCalls = 0;
+      const androidImage: DeviceInfo = {
+        name: "Pixel_8",
+        platform: "android",
+        isRunning: false
+      };
+      const fakeSimctl = {
+        isAvailable: async () => false,
+        listSimulatorImages: async () => {
+          simctlListCalls++;
+          throw new Error("simctl should not be queried");
+        }
+      } as unknown as SimCtlClient;
+      const fakeEmulator = {
+        listAvds: async () => [androidImage]
+      } as unknown as AndroidEmulatorClient;
+
+      const manager = new MultiPlatformDeviceManager(
+        new FakeAdbClient() as unknown as AdbClient,
+        fakeSimctl,
+        fakeEmulator
+      );
+
+      const devices = await manager.listDeviceImages("either");
+
+      expect(devices).toEqual([androidImage]);
+      expect(simctlListCalls).toBe(0);
+    });
   });
 });


### PR DESCRIPTION
## Summary
- Skip local iOS/simctl discovery on non-macOS hosts unless simctl/host-control availability is confirmed.
- Preserve Android discovery results when optional iOS probing fails, including daemon device-pool refresh.
- Avoid cross-platform iOS discovery for Android-first app/localization device lookups and add Linux regression coverage for doctor and polling paths.

## Test plan
- [x] bun test test/utils/deviceUtils.test.ts test/daemon/devicePool.test.ts test/doctor/index.test.ts test/doctor/ios.test.ts


Made with [Cursor](https://cursor.com)