### PR TITLE
Add iOS back button support

### DIFF
--- a/docs/design-docs/mcp/a11y/index.md
+++ b/docs/design-docs/mcp/a11y/index.md
@@ -54,7 +54,7 @@ flowchart LR
 | `tapOn` | Coordinate tap | `ACTION_CLICK` on element |
 | `swipeOn` | Single-finger swipe | Two-finger swipe or `ACTION_SCROLL_*` |
 | `inputText` | `ACTION_SET_TEXT` | No change (already accessible) |
-| `pressButton` | Hardware keyevent | Optional `GLOBAL_ACTION_BACK` |
+| `pressButton` | Device/navigation button | Optional `GLOBAL_ACTION_BACK` |
 
 ## Topics
 
@@ -68,4 +68,3 @@ flowchart LR
 |----------|---------------|--------|
 | Android | TalkBack | <kbd>⚠️ Partial</kbd> — detection implemented, tool adaptations in progress |
 | iOS | VoiceOver | <kbd>🚧 Design Only</kbd> — planned |
-

--- a/docs/design-docs/mcp/a11y/talkback-voiceover.md
+++ b/docs/design-docs/mcp/a11y/talkback-voiceover.md
@@ -132,7 +132,7 @@ For scroll-until-visible (`lookFor`), clear accessibility focus before scrolling
 
 **inputText / clearText**: No change needed. Already uses `ACTION_SET_TEXT`, which TalkBack handles correctly.
 
-**pressButton**: Hardware keycodes work the same. Back button may exit TalkBack local context menu instead of navigating back; use `GLOBAL_ACTION_BACK` to bypass when needed.
+**pressButton**: Device and navigation buttons work the same. Back button may exit TalkBack local context menu instead of navigating back; use `GLOBAL_ACTION_BACK` to bypass when needed.
 
 **launchApp / terminateApp / installApp / startDevice / killDevice**: No change needed. App lifecycle and device management are unaffected by TalkBack state.
 

--- a/docs/design-docs/mcp/a11y/voiceover-talkback-parity.md
+++ b/docs/design-docs/mcp/a11y/voiceover-talkback-parity.md
@@ -14,7 +14,7 @@ This document compares iOS VoiceOver and Android TalkBack support in AutoMobile 
 | `tapOn` adaptation | ✅ `ACTION_CLICK` | ✅ Accessibility activation | Transparent to agent |
 | `swipeOn` / scroll adaptation | ✅ `ACTION_SCROLL_FORWARD/BACKWARD` | ✅ Accessibility scroll action | Fallback differs |
 | `inputText` / `clearText` | ✅ Unchanged | ✅ Unchanged | Both use text injection |
-| `pressButton` | ✅ Unchanged | ✅ Unchanged | Hardware keycodes |
+| `pressButton` | ✅ Unchanged | ✅ Unchanged | Device/navigation buttons |
 | `accessibilityState` in observe | ✅ `service: "talkback"` | ✅ `service: "voiceover"` | |
 | `accessibilityFocusedElement` | ✅ Reported | ❌ Not tracked | Gap — see below |
 | Programmatic enable/disable | ✅ Via ADB | ✅ Simulator only | Physical device support deferred |

--- a/docs/design-docs/plat/ios/xctestrunner/writing-tests.md
+++ b/docs/design-docs/plat/ios/xctestrunner/writing-tests.md
@@ -261,17 +261,17 @@ Types into the currently focused input field.
 
 ### `pressButton`
 
-Presses a hardware or soft button.
+Presses a device or navigation button.
 
 ```yaml
 - tool: pressButton
-  button: home
+  button: back
 ```
 
-!!! warning "Only `home` is supported on iOS"
-    The iOS runtime only supports `button: home`. Other values (`lock`, `volumeUp`, `volumeDown`)
-    are rejected with "Unsupported iOS button" at execution time. iOS has no back button —
-    use `launchApp` with `clearAppData: false` to bring an app back to the foreground.
+!!! note "Supported iOS buttons"
+    The iOS runtime supports `button: home` and `button: back`. `back` performs app-level
+    navigation through CtrlProxy because iOS has no hardware back button. Other values are
+    rejected with "Unsupported iOS button" at execution time.
 
 ### `terminateApp`
 
@@ -438,7 +438,7 @@ Plans are validated against a JSON schema before execution. Common validation er
 | Error | Cause | Fix |
 |---|---|---|
 | `Missing required property 'tool'` | A step is missing the `tool` key | Add `tool: <toolName>` to the step |
-| `Invalid option for 'button'` | Unsupported button name | Only `home` is supported on iOS |
+| `Invalid option for 'button'` | Unsupported button name | Use `home` or `back` on iOS |
 | `waitFor` with only `timeout` | Missing `text` or `elementId` in `waitFor` | Add `text: "…"` or `elementId: "…"` |
 | `Unknown property 'foo'` | Misspelled or Android-only field | Check the [MCP Tools](../../../mcp/tools.md) reference |
 

--- a/docs/using/talkback.md
+++ b/docs/using/talkback.md
@@ -52,7 +52,7 @@ AutoMobile reads the active accessibility services from ADB secure settings when
 | `tapOn` | Coordinate-based tap | `ACTION_CLICK` on the target element |
 | `swipeOn` / scroll | Single-finger swipe | `ACTION_SCROLL_FORWARD`/`BACKWARD` or two-finger swipe |
 | `inputText` / `clearText` | `ACTION_SET_TEXT` | `ACTION_SET_TEXT` (unchanged) |
-| `pressButton` | Hardware keycode | Hardware keycode (unchanged; see note below) |
+| `pressButton` | Device/navigation button | Device/navigation button (unchanged; see note below) |
 | `launchApp`, `terminateApp`, `installApp` | Standard | Unchanged |
 
 No tool parameters change. Existing automation scripts work without modification.

--- a/docs/using/voiceover.md
+++ b/docs/using/voiceover.md
@@ -52,12 +52,14 @@ AutoMobile queries `UIAccessibility.isVoiceOverRunning` via the CtrlProxy WebSoc
 | `tapOn` | Coordinate-based tap | Accessibility activation on the target element |
 | `swipeOn` / scroll | Single-finger swipe | Accessibility scroll action or three-finger swipe |
 | `inputText` / `clearText` | Text injection | Text injection (unchanged) |
-| `pressButton` | Hardware keycode | Hardware keycode (unchanged; see note below) |
+| `pressButton` | Device/navigation button | Device/navigation button (unchanged; see note below) |
 | `launchApp`, `terminateApp`, `installApp` | Standard | Unchanged |
 
 No tool parameters change. Existing automation scripts work without modification.
 
 **Home button note.** When VoiceOver is active, the home button requires a single press to invoke rather than the swipe gesture used in standard navigation. AutoMobile handles this correctly with `pressButton({ button: "home" })`.
+
+**Back navigation note.** iOS has no hardware back button. AutoMobile maps `pressButton({ button: "back" })` to app-level back navigation through CtrlProxy.
 
 ---
 

--- a/ios/control-proxy/Sources/CtrlProxy/CommandHandler.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/CommandHandler.swift
@@ -105,6 +105,9 @@ public class CommandHandler: CommandHandling {
             case RequestType.requestPressHome.rawValue:
                 return try handlePressHome(request, startTime: startTime)
 
+            case RequestType.requestPressBack.rawValue:
+                return try handlePressBack(request, startTime: startTime)
+
             case RequestType.requestRecentApps.rawValue:
                 return try handleRecentApps(request, startTime: startTime)
 
@@ -447,6 +450,21 @@ public class CommandHandler: CommandHandling {
 
         return WebSocketResponse.success(
             type: ResponseType.pressHomeResult.rawValue,
+            requestId: request.requestId,
+            totalTimeMs: totalTimeMs(from: startTime)
+        )
+    }
+
+    private func handlePressBack(_ request: WebSocketRequest, startTime: Date) throws -> WebSocketResponse {
+        perfProvider.serial("handlePressBack")
+        defer { perfProvider.end() }
+
+        try perfProvider.track("pressBack") {
+            try gesturePerformer.pressBack()
+        }
+
+        return WebSocketResponse.success(
+            type: ResponseType.pressBackResult.rawValue,
             requestId: request.requestId,
             totalTimeMs: totalTimeMs(from: startTime)
         )
@@ -886,6 +904,8 @@ public class CommandHandler: CommandHandling {
             return ResponseType.selectAllResult.rawValue
         case RequestType.requestPressHome.rawValue:
             return ResponseType.pressHomeResult.rawValue
+        case RequestType.requestPressBack.rawValue:
+            return ResponseType.pressBackResult.rawValue
         case RequestType.requestAction.rawValue:
             return ResponseType.actionResult.rawValue
         case RequestType.requestLaunchApp.rawValue:

--- a/ios/control-proxy/Sources/CtrlProxy/Fakes.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/Fakes.swift
@@ -188,6 +188,7 @@ public class FakeGesturePerformer: GesturePerforming {
     private var actionHistory: [(action: String, resourceId: String?, label: String?)] = []
     private var screenshotCallCount = 0
     private var pressHomeCallCount = 0
+    private var pressBackCallCount = 0
     private var openRecentAppsCallCount = 0
     private var appLaunchHistory: [String] = []
     private var appTerminateHistory: [String] = []
@@ -258,6 +259,10 @@ public class FakeGesturePerformer: GesturePerforming {
 
     public func getPressHomeCallCount() -> Int {
         pressHomeCallCount
+    }
+
+    public func getPressBackCallCount() -> Int {
+        pressBackCallCount
     }
 
     public func getOpenRecentAppsCallCount() -> Int {
@@ -425,6 +430,11 @@ public class FakeGesturePerformer: GesturePerforming {
     public func pressHome() throws {
         try checkFailure("pressHome")
         pressHomeCallCount += 1
+    }
+
+    public func pressBack() throws {
+        try checkFailure("pressBack")
+        pressBackCallCount += 1
     }
 
     public func openRecentApps() throws {

--- a/ios/control-proxy/Sources/CtrlProxy/GesturePerformer.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/GesturePerformer.swift
@@ -394,6 +394,13 @@ public class GesturePerformer: GesturePerforming {
             return application
         }
 
+        private func resolveNavigationApp() -> XCUIApplication? {
+            if let bundleId = elementLocator.foregroundBundleId, !bundleId.isEmpty {
+                return XCUIApplication(bundleIdentifier: bundleId)
+            }
+            return application
+        }
+
         public func typeText(text: String) throws {
             guard let app = resolveTextInputApp() else {
                 throw GestureError.noApplication
@@ -760,6 +767,59 @@ public class GesturePerformer: GesturePerforming {
             }
         }
 
+        public func pressBack() throws {
+            guard let app = resolveNavigationApp() else {
+                throw GestureError.noApplication
+            }
+
+            try runOnMainThread {
+                if self.tapExplicitNavigationBarBackButton(in: app) {
+                    return
+                }
+                try self.swipeFromLeftEdge(in: app)
+            }
+        }
+
+        private func tapExplicitNavigationBarBackButton(in app: XCUIApplication) -> Bool {
+            for navigationBar in app.navigationBars.allElementsBoundByIndex where navigationBar.exists {
+                let midpoint = navigationBar.frame.midX
+                for button in navigationBar.buttons.allElementsBoundByIndex where button.exists && button.isHittable {
+                    if button.frame.midX <= midpoint && self.isExplicitBackButton(button) {
+                        button.tap()
+                        return true
+                    }
+                }
+            }
+            return false
+        }
+
+        private func isExplicitBackButton(_ button: XCUIElement) -> Bool {
+            let candidates = [button.label, button.identifier]
+                .map { $0.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() }
+                .filter { !$0.isEmpty }
+            return candidates.contains { value in
+                value == "back" || value.contains("back button") || value.contains("go back")
+            }
+        }
+
+        private func swipeFromLeftEdge(in app: XCUIApplication) throws {
+            let frame = app.frame
+            guard frame.width > 0, frame.height > 0 else {
+                throw GestureError.gestureFailed("Cannot determine application frame for back gesture")
+            }
+
+            let start = app.coordinate(withNormalizedOffset: .zero)
+                .withOffset(CGVector(dx: 2, dy: frame.height / 2))
+            let end = app.coordinate(withNormalizedOffset: .zero)
+                .withOffset(CGVector(dx: min(frame.width * 0.75, frame.width - 2), dy: frame.height / 2))
+            start.press(
+                forDuration: 0.05,
+                thenDragTo: end,
+                withVelocity: .default,
+                thenHoldForDuration: 0
+            )
+        }
+
         public func openRecentApps() throws {
             try runOnMainThread {
                 let springboard = XCUIApplication(bundleIdentifier: "com.apple.springboard")
@@ -899,6 +959,10 @@ public class GesturePerformer: GesturePerforming {
         }
 
         public func pressHome() throws {
+            throw GestureError.notSupported("XCUITest only available on iOS")
+        }
+
+        public func pressBack() throws {
             throw GestureError.notSupported("XCUITest only available on iOS")
         }
 

--- a/ios/control-proxy/Sources/CtrlProxy/Models.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/Models.swift
@@ -788,6 +788,7 @@ public enum RequestType: String {
     case requestImeAction = "request_ime_action"
     case requestSelectAll = "request_select_all"
     case requestPressHome = "request_press_home"
+    case requestPressBack = "request_press_back"
     case requestRecentApps = "request_recent_apps"
 
     // Node actions
@@ -830,6 +831,7 @@ public enum ResponseType: String {
     case imeActionResult = "ime_action_result"
     case selectAllResult = "select_all_result"
     case pressHomeResult = "press_home_result"
+    case pressBackResult = "press_back_result"
     case recentAppsResult = "recent_apps_result"
     case actionResult = "action_result"
     case launchAppResult = "launch_app_result"

--- a/ios/control-proxy/Sources/CtrlProxy/Protocols.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/Protocols.swift
@@ -138,6 +138,9 @@ public protocol GesturePerforming {
     /// Press home button
     func pressHome() throws
 
+    /// Perform app-level back navigation
+    func pressBack() throws
+
     /// Open recent apps (app switcher) via swipe-up-and-hold gesture
     func openRecentApps() throws
 

--- a/ios/control-proxy/Tests/CtrlProxyTests/CommandHandlerTests.swift
+++ b/ios/control-proxy/Tests/CtrlProxyTests/CommandHandlerTests.swift
@@ -464,6 +464,28 @@ final class CommandHandlerTests: XCTestCase {
         XCTAssertEqual(childNames, ["pressHome", "switchForegroundApp", "updateApplication"])
     }
 
+    func testPressBackSuccess() {
+        let request = WebSocketRequest(
+            type: "request_press_back",
+            requestId: "back-123"
+        )
+
+        guard let backResponse = handleRequest(request, as: WebSocketResponse.self) else { return }
+
+        XCTAssertEqual(backResponse.success, true)
+        XCTAssertEqual(backResponse.type, "press_back_result")
+        XCTAssertEqual(fakeGesturePerformer.getPressBackCallCount(), 1)
+
+        guard let perfTimings = perfProvider.flush() else {
+            XCTFail("Expected perf timing data from handlePressBack")
+            return
+        }
+        XCTAssertEqual(perfTimings.count, 1)
+        XCTAssertEqual(perfTimings[0].name, "handlePressBack")
+        let childNames = perfTimings[0].children?.map { $0.name } ?? []
+        XCTAssertEqual(childNames, ["pressBack"])
+    }
+
     func testLaunchAppSuccess() {
         // Default: app not running, no coldBoot → full launch
         fakeElementLocator.getAppStateResult = .notRunning

--- a/ios/control-proxy/Tests/CtrlProxyTests/ModelsTests.swift
+++ b/ios/control-proxy/Tests/CtrlProxyTests/ModelsTests.swift
@@ -292,6 +292,7 @@ final class ModelsTests: XCTestCase {
         XCTAssertEqual(RequestType.requestSwipe.rawValue, "request_swipe")
         XCTAssertEqual(RequestType.requestDrag.rawValue, "request_drag")
         XCTAssertEqual(RequestType.requestSetText.rawValue, "request_set_text")
+        XCTAssertEqual(RequestType.requestPressBack.rawValue, "request_press_back")
         XCTAssertEqual(RequestType.requestLaunchApp.rawValue, "request_launch_app")
     }
 
@@ -302,6 +303,7 @@ final class ModelsTests: XCTestCase {
         XCTAssertEqual(ResponseType.tapCoordinatesResult.rawValue, "tap_coordinates_result")
         XCTAssertEqual(ResponseType.swipeResult.rawValue, "swipe_result")
         XCTAssertEqual(ResponseType.screenshot.rawValue, "screenshot")
+        XCTAssertEqual(ResponseType.pressBackResult.rawValue, "press_back_result")
         XCTAssertEqual(ResponseType.launchAppResult.rawValue, "launch_app_result")
     }
 

--- a/schemas/tool-definitions.json
+++ b/schemas/tool-definitions.json
@@ -4227,7 +4227,7 @@
   },
   {
     "name": "pressButton",
-    "description": "Press hardware button",
+    "description": "Press device or navigation button",
     "inputSchema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "type": "object",

--- a/src/features/action/PressButton.ts
+++ b/src/features/action/PressButton.ts
@@ -121,7 +121,7 @@ export class PressButton extends BaseVisualChange {
    */
   private async executeiOSButtonPress(button: string): Promise<PressButtonResult> {
     const normalizedButton = button.toLowerCase();
-    if (normalizedButton !== "home") {
+    if (normalizedButton !== "home" && normalizedButton !== "back") {
       return {
         success: false,
         button,
@@ -131,14 +131,16 @@ export class PressButton extends BaseVisualChange {
     }
 
     const client = IOSCtrlProxyClient.getInstance(this.device);
-    const result = await client.requestPressHome();
+    const result = normalizedButton === "home"
+      ? await client.requestPressHome()
+      : await client.requestPressBack();
 
     if (!result.success) {
       return {
         success: false,
         button,
         keyCode: -1,
-        error: result.error ?? "Failed to press iOS home button"
+        error: result.error ?? `Failed to press iOS ${normalizedButton} button`
       };
     }
 

--- a/src/features/observe/ios/CtrlProxyNavigation.ts
+++ b/src/features/observe/ios/CtrlProxyNavigation.ts
@@ -9,6 +9,7 @@ import type { PerformanceTracker } from "../../../utils/PerformanceTracker";
 import type {
   DelegateContext,
   CtrlProxyPressHomeResult,
+  CtrlProxyPressBackResult,
   CtrlProxyRecentAppsResult,
   CtrlProxyLaunchAppResult,
   CtrlProxyRotateResult,
@@ -41,6 +42,25 @@ export class CtrlProxyNavigation {
       cancelScreenshotBackoff: false,
       notConnectedMessage: "Not connected to CtrlProxy",
       errorLabel: "Press home",
+    });
+  }
+
+  /**
+   * Request app-level back navigation.
+   */
+  async requestPressBack(
+    timeoutMs: number = 5000,
+    perf?: PerformanceTracker
+  ): Promise<CtrlProxyPressBackResult> {
+    return sendCommand<CtrlProxyPressBackResult>(this.context, {
+      idPrefix: "pressBack",
+      responseType: "press_back",
+      messageType: "request_press_back",
+      timeoutMs,
+      perf,
+      cancelScreenshotBackoff: false,
+      notConnectedMessage: "Not connected to CtrlProxy",
+      errorLabel: "Press back",
     });
   }
 

--- a/src/features/observe/ios/IOSCtrlProxyClient.ts
+++ b/src/features/observe/ios/IOSCtrlProxyClient.ts
@@ -9,7 +9,7 @@
  * - CtrlProxyText: setText, clearText, IME actions, select all
  * - CtrlProxyHierarchy: Hierarchy retrieval, caching, conversion
  * - CtrlProxyScreenshot: Screenshot capture
- * - CtrlProxyNavigation: pressHome, launchApp
+ * - CtrlProxyNavigation: pressHome, pressBack, launchApp
  */
 
 import WebSocket from "ws";
@@ -115,6 +115,7 @@ import type {
   CtrlProxyImeActionResult,
   CtrlProxySelectAllResult,
   CtrlProxyPressHomeResult,
+  CtrlProxyPressBackResult,
   CtrlProxyRecentAppsResult,
   CtrlProxyRotateResult,
   CtrlProxyLaunchAppResult,
@@ -197,6 +198,10 @@ export interface IOSCtrlProxy extends CtrlProxyClient {
   requestPressHome(
     timeoutMs?: number, perf?: PerformanceTracker
   ): Promise<CtrlProxyPressHomeResult>;
+
+  requestPressBack(
+    timeoutMs?: number, perf?: PerformanceTracker
+  ): Promise<CtrlProxyPressBackResult>;
 
   requestRecentApps(
     timeoutMs?: number, perf?: PerformanceTracker
@@ -954,6 +959,7 @@ export class IOSCtrlProxyClient extends DeviceServiceClient implements IOSCtrlPr
         case "clear_text_result":
         case "select_all_result":
         case "press_home_result":
+        case "press_back_result":
         case "recent_apps_result":
         case "launch_app_result":
           result = {
@@ -1279,6 +1285,12 @@ export class IOSCtrlProxyClient extends DeviceServiceClient implements IOSCtrlPr
     timeoutMs: number = 5000, perf?: PerformanceTracker
   ): Promise<CtrlProxyPressHomeResult> {
     return this.navigation.requestPressHome(timeoutMs, perf);
+  }
+
+  async requestPressBack(
+    timeoutMs: number = 5000, perf?: PerformanceTracker
+  ): Promise<CtrlProxyPressBackResult> {
+    return this.navigation.requestPressBack(timeoutMs, perf);
   }
 
   async requestRecentApps(

--- a/src/features/observe/ios/index.ts
+++ b/src/features/observe/ios/index.ts
@@ -38,6 +38,7 @@ export type {
   CtrlProxyImeActionResult,
   CtrlProxySelectAllResult,
   CtrlProxyPressHomeResult,
+  CtrlProxyPressBackResult,
   CtrlProxyRecentAppsResult,
   CtrlProxyRotateResult,
   CtrlProxyLaunchAppResult,

--- a/src/features/observe/ios/types.ts
+++ b/src/features/observe/ios/types.ts
@@ -155,6 +155,9 @@ export type CtrlProxySelectAllResult = BaseResult;
 /** Press home result from CtrlProxy iOS */
 export type CtrlProxyPressHomeResult = BaseResult;
 
+/** Press back result from CtrlProxy iOS */
+export type CtrlProxyPressBackResult = BaseResult;
+
 /** Rotate result from CtrlProxy iOS */
 export interface CtrlProxyRotateResult extends BaseResult {
   previousOrientation: string;

--- a/src/server/interactionTools.ts
+++ b/src/server/interactionTools.ts
@@ -981,7 +981,7 @@ export function registerInteractionTools() {
 
   ToolRegistry.registerDeviceAware(
     "pressButton",
-    "Press hardware button",
+    "Press device or navigation button",
     pressButtonSchema,
     pressButtonHandler,
     true // Supports progress notifications

--- a/test/features/observe/ios/IOSCtrlProxyClient.test.ts
+++ b/test/features/observe/ios/IOSCtrlProxyClient.test.ts
@@ -459,6 +459,44 @@ describe("IOSCtrlProxyClient", function() {
     });
   });
 
+  describe("requestPressBack", function() {
+    test("should send press back request and return result", async function() {
+      const testTimer = fakeTimer;
+
+      const { factory, getSocket } = createCapturingWebSocketFactory(testTimer);
+      const testClient = IOSCtrlProxyClient.createForTesting(
+        testDevice,
+        serverPort,
+        factory,
+        testTimer
+      );
+
+      try {
+        const resultPromise = testClient.requestPressBack(5000);
+        const socket = await waitForSocket(getSocket);
+        expect(socket).not.toBeNull();
+        await waitForSocketOpen(socket);
+        await waitForSentMessages(socket, 1);
+
+        const sentMessage = JSON.parse(socket!.sentMessages[0]);
+        expect(sentMessage.type).toBe("request_press_back");
+
+        socket!.simulateMessage(JSON.stringify({
+          type: "press_back_result",
+          requestId: sentMessage.requestId,
+          success: true,
+          totalTimeMs: 80
+        }));
+
+        const result = await resultPromise;
+        expect(result.success).toBe(true);
+        expect(result.totalTimeMs).toBe(80);
+      } finally {
+        await testClient.close();
+      }
+    });
+  });
+
   describe("connection management", function() {
     test("isConnected should return true when WebSocket is open", async function() {
       const testTimer = fakeTimer;


### PR DESCRIPTION
## Summary
- Add iOS `pressButton({ button: "back" })` support through CtrlProxy.
- Implement iOS back as app-level navigation: tap an explicit back button when present, otherwise use the left-edge back gesture.
- Update tool metadata, generated schema, and docs so `pressButton` is no longer described as hardware-only.

## Testing
- `bun test test/features/observe/ios/IOSCtrlProxyClient.test.ts test/server/toolRegistration.test.ts test/server/toolSchemaHelpers.test.ts`
- `bun run build`
- `swift test --package-path ios/control-proxy`
- `bunx eslint src/features/action/PressButton.ts src/features/observe/ios/CtrlProxyNavigation.ts src/features/observe/ios/IOSCtrlProxyClient.ts src/features/observe/ios/index.ts src/features/observe/ios/types.ts src/server/interactionTools.ts test/features/observe/ios/IOSCtrlProxyClient.test.ts test/server/toolRegistration.test.ts test/server/toolSchemaHelpers.test.ts`
