### PR TITLE
Add iOS keyboard operations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ npm-debug.log*
 
 # Places to locally write while thinking or planning
 /scratch
+/research
 /ci-logs
 /roadmap
 /blog

--- a/ios/control-proxy/Sources/CtrlProxy/CommandHandler.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/CommandHandler.swift
@@ -102,6 +102,12 @@ public class CommandHandler: CommandHandling {
             case RequestType.requestSelectAll.rawValue:
                 return try handleSelectAll(request, startTime: startTime)
 
+            case RequestType.requestKeyboard.rawValue:
+                return try handleKeyboard(request, startTime: startTime)
+
+            case RequestType.requestPressButton.rawValue:
+                return try handlePressButton(request, startTime: startTime)
+
             case RequestType.requestPressHome.rawValue:
                 return try handlePressHome(request, startTime: startTime)
 
@@ -427,6 +433,69 @@ public class CommandHandler: CommandHandling {
         textInputLog.debug("handleSelectAll OK elapsedMs=\(self.totalTimeMs(from: startTime), privacy: .public)")
         return WebSocketResponse.success(
             type: ResponseType.selectAllResult.rawValue,
+            requestId: request.requestId,
+            totalTimeMs: totalTimeMs(from: startTime)
+        )
+    }
+
+    private func handleKeyboard(_ request: WebSocketRequest, startTime: Date) throws -> KeyboardResponse {
+        guard let action = request.action else {
+            throw CommandError.missingParameter("action")
+        }
+
+        perfProvider.serial("handleKeyboard")
+        defer { perfProvider.end() }
+
+        let open = try perfProvider.track("keyboard") {
+            try gesturePerformer.keyboard(action: action)
+        }
+        let success = keyboardActionSucceeded(action: action, open: open)
+
+        return KeyboardResponse(
+            requestId: request.requestId,
+            success: success,
+            open: open,
+            totalTimeMs: totalTimeMs(from: startTime),
+            error: success ? nil : "Keyboard did not \(action.lowercased())"
+        )
+    }
+
+    private func keyboardActionSucceeded(action: String, open: Bool) -> Bool {
+        switch action.lowercased() {
+        case "detect":
+            return true
+        case "open":
+            return open
+        case "close":
+            return !open
+        default:
+            return false
+        }
+    }
+
+    private func handlePressButton(_ request: WebSocketRequest, startTime: Date) throws -> WebSocketResponse {
+        guard let button = request.action else {
+            throw CommandError.missingParameter("action")
+        }
+
+        perfProvider.serial("handlePressButton")
+        defer { perfProvider.end() }
+
+        try perfProvider.track("pressButton") {
+            try gesturePerformer.pressButton(button)
+        }
+
+        if button.lowercased() == "home" || button.lowercased() == "recent" {
+            perfProvider.track("switchForegroundApp") {
+                elementLocator.switchForegroundApp(bundleId: "com.apple.springboard")
+            }
+            perfProvider.track("updateApplication") {
+                gesturePerformer.updateApplication(bundleId: "com.apple.springboard")
+            }
+        }
+
+        return WebSocketResponse.success(
+            type: ResponseType.pressButtonResult.rawValue,
             requestId: request.requestId,
             totalTimeMs: totalTimeMs(from: startTime)
         )
@@ -902,10 +971,16 @@ public class CommandHandler: CommandHandling {
             return ResponseType.imeActionResult.rawValue
         case RequestType.requestSelectAll.rawValue:
             return ResponseType.selectAllResult.rawValue
+        case RequestType.requestKeyboard.rawValue:
+            return ResponseType.keyboardResult.rawValue
+        case RequestType.requestPressButton.rawValue:
+            return ResponseType.pressButtonResult.rawValue
         case RequestType.requestPressHome.rawValue:
             return ResponseType.pressHomeResult.rawValue
         case RequestType.requestPressBack.rawValue:
             return ResponseType.pressBackResult.rawValue
+        case RequestType.requestRecentApps.rawValue:
+            return ResponseType.recentAppsResult.rawValue
         case RequestType.requestAction.rawValue:
             return ResponseType.actionResult.rawValue
         case RequestType.requestLaunchApp.rawValue:

--- a/ios/control-proxy/Sources/CtrlProxy/Fakes.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/Fakes.swift
@@ -185,10 +185,14 @@ public class FakeGesturePerformer: GesturePerforming {
     private var clearTextHistory: [String?] = []
     private var selectAllCallCount: Int = 0
     private var imeActionHistory: [String] = []
+    private var keyboardHistory: [String] = []
+    private var keyboardOpen = false
+    private var nextKeyboardResult: Bool?
     private var actionHistory: [(action: String, resourceId: String?, label: String?)] = []
     private var screenshotCallCount = 0
     private var pressHomeCallCount = 0
     private var pressBackCallCount = 0
+    private var pressButtonHistory: [String] = []
     private var openRecentAppsCallCount = 0
     private var appLaunchHistory: [String] = []
     private var appTerminateHistory: [String] = []
@@ -249,6 +253,18 @@ public class FakeGesturePerformer: GesturePerforming {
         imeActionHistory
     }
 
+    public func getKeyboardHistory() -> [String] {
+        keyboardHistory
+    }
+
+    public func setKeyboardOpen(_ open: Bool) {
+        keyboardOpen = open
+    }
+
+    public func setNextKeyboardResult(_ open: Bool) {
+        nextKeyboardResult = open
+    }
+
     public func getActionHistory() -> [(action: String, resourceId: String?, label: String?)] {
         actionHistory
     }
@@ -263,6 +279,10 @@ public class FakeGesturePerformer: GesturePerforming {
 
     public func getPressBackCallCount() -> Int {
         pressBackCallCount
+    }
+
+    public func getPressButtonHistory() -> [String] {
+        pressButtonHistory
     }
 
     public func getOpenRecentAppsCallCount() -> Int {
@@ -297,9 +317,15 @@ public class FakeGesturePerformer: GesturePerforming {
         clearTextHistory.removeAll()
         selectAllCallCount = 0
         imeActionHistory.removeAll()
+        keyboardHistory.removeAll()
+        keyboardOpen = false
+        nextKeyboardResult = nil
         actionHistory.removeAll()
         screenshotCallCount = 0
         pressHomeCallCount = 0
+        pressBackCallCount = 0
+        pressButtonHistory.removeAll()
+        openRecentAppsCallCount = 0
         appLaunchHistory.removeAll()
         appTerminateHistory.removeAll()
         clipboardHistory.removeAll()
@@ -388,6 +414,25 @@ public class FakeGesturePerformer: GesturePerforming {
         imeActionHistory.append(action)
     }
 
+    public func keyboard(action: String) throws -> Bool {
+        try checkFailure("keyboard")
+        keyboardHistory.append(action)
+        if let result = nextKeyboardResult {
+            nextKeyboardResult = nil
+            keyboardOpen = result
+            return result
+        }
+        switch action {
+        case "open":
+            keyboardOpen = true
+        case "close":
+            keyboardOpen = false
+        default:
+            break
+        }
+        return keyboardOpen
+    }
+
     public func clipboard(action: String, text: String?) throws -> String? {
         try checkFailure("clipboard")
         clipboardHistory.append((action: action, text: text))
@@ -435,6 +480,11 @@ public class FakeGesturePerformer: GesturePerforming {
     public func pressBack() throws {
         try checkFailure("pressBack")
         pressBackCallCount += 1
+    }
+
+    public func pressButton(_ button: String) throws {
+        try checkFailure("pressButton")
+        pressButtonHistory.append(button)
     }
 
     public func openRecentApps() throws {

--- a/ios/control-proxy/Sources/CtrlProxy/GesturePerformer.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/GesturePerformer.swift
@@ -569,6 +569,48 @@ public class GesturePerformer: GesturePerforming {
             }
         }
 
+        public func keyboard(action: String) throws -> Bool {
+            guard let app = resolveTextInputApp() else {
+                throw GestureError.noApplication
+            }
+
+            switch action.lowercased() {
+            case "detect":
+                return isKeyboardVisible(app: app)
+            case "open":
+                if isKeyboardVisible(app: app) {
+                    return true
+                }
+                guard let focused = resolveFocusedTextElement(app: app) else {
+                    throw GestureError.notSupported("No focused text input to open keyboard")
+                }
+                try runOnMainThread {
+                    focused.tap()
+                }
+                return isKeyboardVisible(app: app)
+            case "close":
+                if !isKeyboardVisible(app: app) {
+                    return false
+                }
+                try typeKeyboardKey(.escape, app: app)
+                return isKeyboardVisible(app: app)
+            default:
+                throw GestureError.notSupported("Keyboard action: \(action)")
+            }
+        }
+
+        private func isKeyboardVisible(app: XCUIApplication) -> Bool {
+            return (try? runOnMainThread {
+                app.keyboards.firstMatch.exists || self.springboard.keyboards.firstMatch.exists
+            }) ?? false
+        }
+
+        private func typeKeyboardKey(_ key: XCUIKeyboardKey, app: XCUIApplication) throws {
+            try runOnMainThread {
+                app.typeKey(key, modifierFlags: [])
+            }
+        }
+
         // MARK: - Actions
 
         public func performAction(_ action: String, resourceId: String? = nil, label: String? = nil) throws {
@@ -820,6 +862,21 @@ public class GesturePerformer: GesturePerforming {
             )
         }
 
+        public func pressButton(_ button: String) throws {
+            switch button.lowercased() {
+            case "home":
+                try pressHome()
+            case "recent":
+                try openRecentApps()
+            case "back":
+                try pressBack()
+            case "menu", "power", "volume_up", "volume_down":
+                throw GestureError.notSupported("iOS simulator button: \(button)")
+            default:
+                throw GestureError.notSupported("Button: \(button)")
+            }
+        }
+
         public func openRecentApps() throws {
             try runOnMainThread {
                 let springboard = XCUIApplication(bundleIdentifier: "com.apple.springboard")
@@ -938,6 +995,10 @@ public class GesturePerformer: GesturePerforming {
             throw GestureError.notSupported("XCUITest only available on iOS")
         }
 
+        public func keyboard(action _: String) throws -> Bool {
+            throw GestureError.notSupported("XCUITest only available on iOS")
+        }
+
         public func performAction(_: String, resourceId _: String?, label _: String?) throws {
             throw GestureError.notSupported("XCUITest only available on iOS")
         }
@@ -963,6 +1024,10 @@ public class GesturePerformer: GesturePerforming {
         }
 
         public func pressBack() throws {
+            throw GestureError.notSupported("XCUITest only available on iOS")
+        }
+
+        public func pressButton(_: String) throws {
             throw GestureError.notSupported("XCUITest only available on iOS")
         }
 

--- a/ios/control-proxy/Sources/CtrlProxy/GesturePerformer.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/GesturePerformer.swift
@@ -587,16 +587,31 @@ public class GesturePerformer: GesturePerforming {
                 try runOnMainThread {
                     focused.tap()
                 }
-                return isKeyboardVisible(app: app)
+                return waitForKeyboardVisibility(app: app, expected: true)
             case "close":
                 if !isKeyboardVisible(app: app) {
                     return false
                 }
                 try typeKeyboardKey(.escape, app: app)
-                return isKeyboardVisible(app: app)
+                return waitForKeyboardVisibility(app: app, expected: false)
             default:
                 throw GestureError.notSupported("Keyboard action: \(action)")
             }
+        }
+
+        private func waitForKeyboardVisibility(
+            app: XCUIApplication,
+            expected: Bool,
+            timeout: TimeInterval = 1.0,
+            interval: TimeInterval = 0.05
+        ) -> Bool {
+            let deadline = Date().addingTimeInterval(timeout)
+            var visible = isKeyboardVisible(app: app)
+            while visible != expected && Date() < deadline {
+                RunLoop.current.run(until: Date().addingTimeInterval(interval))
+                visible = isKeyboardVisible(app: app)
+            }
+            return visible
         }
 
         private func isKeyboardVisible(app: XCUIApplication) -> Bool {

--- a/ios/control-proxy/Sources/CtrlProxy/Models.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/Models.swift
@@ -250,6 +250,33 @@ public struct RotateResponse: Codable {
     }
 }
 
+/// Response for keyboard commands with visibility state after the command.
+public struct KeyboardResponse: Codable {
+    public let type: String
+    public let timestamp: Int64
+    public let requestId: String?
+    public let success: Bool
+    public let open: Bool
+    public let totalTimeMs: Int64
+    public let error: String?
+
+    public init(
+        requestId: String?,
+        success: Bool,
+        open: Bool,
+        totalTimeMs: Int64,
+        error: String? = nil
+    ) {
+        self.type = ResponseType.keyboardResult.rawValue
+        self.timestamp = Int64(Date().timeIntervalSince1970 * 1000)
+        self.requestId = requestId
+        self.success = success
+        self.open = open
+        self.totalTimeMs = totalTimeMs
+        self.error = error
+    }
+}
+
 /// Performance timing data - hierarchical format matching Android/TypeScript
 public struct PerfTiming: Codable {
     public let name: String
@@ -787,6 +814,8 @@ public enum RequestType: String {
     case requestClearText = "request_clear_text"
     case requestImeAction = "request_ime_action"
     case requestSelectAll = "request_select_all"
+    case requestKeyboard = "request_keyboard"
+    case requestPressButton = "request_press_button"
     case requestPressHome = "request_press_home"
     case requestPressBack = "request_press_back"
     case requestRecentApps = "request_recent_apps"
@@ -830,6 +859,8 @@ public enum ResponseType: String {
     case clearTextResult = "clear_text_result"
     case imeActionResult = "ime_action_result"
     case selectAllResult = "select_all_result"
+    case keyboardResult = "keyboard_result"
+    case pressButtonResult = "press_button_result"
     case pressHomeResult = "press_home_result"
     case pressBackResult = "press_back_result"
     case recentAppsResult = "recent_apps_result"

--- a/ios/control-proxy/Sources/CtrlProxy/Protocols.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/Protocols.swift
@@ -112,6 +112,10 @@ public protocol GesturePerforming {
     /// Perform IME action (done, next, search, etc.)
     func performImeAction(_ action: String) throws
 
+    /// Open, close, or detect the software keyboard. Returns whether the
+    /// keyboard is visible after the requested action.
+    func keyboard(action: String) throws -> Bool
+
     // MARK: - Clipboard
 
     /// Perform clipboard operation (get, copy, clear, paste)
@@ -140,6 +144,9 @@ public protocol GesturePerforming {
 
     /// Perform app-level back navigation
     func pressBack() throws
+
+    /// Press a named hardware or keyboard-backed button.
+    func pressButton(_ button: String) throws
 
     /// Open recent apps (app switcher) via swipe-up-and-hold gesture
     func openRecentApps() throws

--- a/ios/control-proxy/Tests/CtrlProxyTests/CommandHandlerTests.swift
+++ b/ios/control-proxy/Tests/CtrlProxyTests/CommandHandlerTests.swift
@@ -335,6 +335,95 @@ final class CommandHandlerTests: XCTestCase {
         XCTAssertEqual(errorResponse.success, false)
     }
 
+    func testKeyboardDetectSuccess() {
+        fakeGesturePerformer.setKeyboardOpen(true)
+        let request = WebSocketRequest(
+            type: "request_keyboard",
+            requestId: "keyboard-detect",
+            action: "detect"
+        )
+
+        guard let response = handleRequest(request, as: KeyboardResponse.self) else { return }
+
+        XCTAssertEqual(response.success, true)
+        XCTAssertEqual(response.type, "keyboard_result")
+        XCTAssertEqual(response.open, true)
+        XCTAssertEqual(fakeGesturePerformer.getKeyboardHistory(), ["detect"])
+    }
+
+    func testKeyboardOpenSuccess() {
+        let request = WebSocketRequest(
+            type: "request_keyboard",
+            requestId: "keyboard-open",
+            action: "open"
+        )
+
+        guard let response = handleRequest(request, as: KeyboardResponse.self) else { return }
+
+        XCTAssertEqual(response.success, true)
+        XCTAssertEqual(response.open, true)
+        XCTAssertEqual(fakeGesturePerformer.getKeyboardHistory(), ["open"])
+    }
+
+    func testKeyboardOpenFailureWhenKeyboardRemainsClosed() {
+        fakeGesturePerformer.setNextKeyboardResult(false)
+        let request = WebSocketRequest(
+            type: "request_keyboard",
+            requestId: "keyboard-open-failed",
+            action: "open"
+        )
+
+        guard let response = handleRequest(request, as: KeyboardResponse.self) else { return }
+
+        XCTAssertEqual(response.success, false)
+        XCTAssertEqual(response.open, false)
+        XCTAssertEqual(response.error, "Keyboard did not open")
+        XCTAssertEqual(fakeGesturePerformer.getKeyboardHistory(), ["open"])
+    }
+
+    func testKeyboardCloseSuccess() {
+        fakeGesturePerformer.setKeyboardOpen(true)
+        let request = WebSocketRequest(
+            type: "request_keyboard",
+            requestId: "keyboard-close",
+            action: "close"
+        )
+
+        guard let response = handleRequest(request, as: KeyboardResponse.self) else { return }
+
+        XCTAssertEqual(response.success, true)
+        XCTAssertEqual(response.open, false)
+        XCTAssertEqual(fakeGesturePerformer.getKeyboardHistory(), ["close"])
+    }
+
+    func testKeyboardCloseFailureWhenKeyboardRemainsOpen() {
+        fakeGesturePerformer.setNextKeyboardResult(true)
+        let request = WebSocketRequest(
+            type: "request_keyboard",
+            requestId: "keyboard-close-failed",
+            action: "close"
+        )
+
+        guard let response = handleRequest(request, as: KeyboardResponse.self) else { return }
+
+        XCTAssertEqual(response.success, false)
+        XCTAssertEqual(response.open, true)
+        XCTAssertEqual(response.error, "Keyboard did not close")
+        XCTAssertEqual(fakeGesturePerformer.getKeyboardHistory(), ["close"])
+    }
+
+    func testKeyboardMissingAction() {
+        let request = WebSocketRequest(
+            type: "request_keyboard",
+            requestId: "keyboard-missing"
+        )
+
+        guard let errorResponse = handleRequest(request, as: WebSocketResponse.self) else { return }
+        XCTAssertEqual(errorResponse.success, false)
+        XCTAssertEqual(errorResponse.type, "keyboard_result")
+        XCTAssertTrue(errorResponse.error?.contains("action") == true)
+    }
+
     func testClearTextWithoutResourceId() {
         let request = WebSocketRequest(
             type: "request_clear_text",
@@ -484,6 +573,38 @@ final class CommandHandlerTests: XCTestCase {
         XCTAssertEqual(perfTimings[0].name, "handlePressBack")
         let childNames = perfTimings[0].children?.map { $0.name } ?? []
         XCTAssertEqual(childNames, ["pressBack"])
+    }
+
+    func testPressButtonBackSuccess() {
+        let request = WebSocketRequest(
+            type: "request_press_button",
+            requestId: "button-back",
+            action: "back"
+        )
+
+        guard let response = handleRequest(request, as: WebSocketResponse.self) else { return }
+
+        XCTAssertEqual(response.success, true)
+        XCTAssertEqual(response.type, "press_button_result")
+        XCTAssertEqual(fakeGesturePerformer.getPressButtonHistory(), ["back"])
+        XCTAssertEqual(fakeElementLocator.switchedBundleIds, [])
+        XCTAssertEqual(fakeGesturePerformer.updateApplicationHistory, [])
+    }
+
+    func testPressButtonHomeSwitchesToSpringBoard() {
+        let request = WebSocketRequest(
+            type: "request_press_button",
+            requestId: "button-home",
+            action: "home"
+        )
+
+        guard let response = handleRequest(request, as: WebSocketResponse.self) else { return }
+
+        XCTAssertEqual(response.success, true)
+        XCTAssertEqual(response.type, "press_button_result")
+        XCTAssertEqual(fakeGesturePerformer.getPressButtonHistory(), ["home"])
+        XCTAssertEqual(fakeElementLocator.switchedBundleIds, ["com.apple.springboard"])
+        XCTAssertEqual(fakeGesturePerformer.updateApplicationHistory, ["com.apple.springboard"])
     }
 
     func testLaunchAppSuccess() {

--- a/src/features/action/Keyboard.ts
+++ b/src/features/action/Keyboard.ts
@@ -10,6 +10,7 @@ import { DefaultElementFinder } from "../utility/ElementFinder";
 import { ViewHierarchy } from "../observe/ViewHierarchy";
 import { NoOpPerformanceTracker } from "../../utils/PerformanceTracker";
 import { Timer, defaultTimer } from "../../utils/SystemTimer";
+import { IOSCtrlProxyClient } from "../observe/ios";
 
 type KeyboardAction = "open" | "close" | "detect";
 
@@ -79,12 +80,7 @@ export class Keyboard {
 
   async execute(action: KeyboardAction, signal?: AbortSignal): Promise<KeyboardResult> {
     if (this.device.platform === "ios") {
-      return {
-        success: false,
-        open: false,
-        message: "iOS keyboard management is not yet supported",
-        error: "iOS keyboard management is not yet supported"
-      };
+      return this.executeIOS(action);
     }
 
     switch (action) {
@@ -105,6 +101,41 @@ export class Keyboard {
           error: `Unsupported keyboard action: ${action}`
         };
     }
+  }
+
+  private async executeIOS(action: KeyboardAction): Promise<KeyboardResult> {
+    const client = IOSCtrlProxyClient.getInstance(this.device);
+    const result = await client.requestKeyboard(action);
+    if (!result.success) {
+      const message = result.error ?? `Failed to ${action} iOS keyboard`;
+      return {
+        success: false,
+        open: result.open,
+        message,
+        error: message
+      };
+    }
+
+    const success = action === "detect"
+      || (action === "open" && result.open)
+      || (action === "close" && !result.open);
+    const message = this.keyboardMessage(action, result.open);
+    return {
+      success,
+      open: result.open,
+      message,
+      ...(success ? {} : { error: message })
+    };
+  }
+
+  private keyboardMessage(action: KeyboardAction, open: boolean): string {
+    if (action === "detect") {
+      return open ? "Keyboard is open" : "Keyboard is closed";
+    }
+    if (action === "open") {
+      return open ? "Keyboard opened" : "Keyboard did not open";
+    }
+    return open ? "Keyboard did not close" : "Keyboard closed";
   }
 
   private async detect(signal?: AbortSignal): Promise<KeyboardResult> {

--- a/src/features/action/PressButton.ts
+++ b/src/features/action/PressButton.ts
@@ -121,19 +121,18 @@ export class PressButton extends BaseVisualChange {
    */
   private async executeiOSButtonPress(button: string): Promise<PressButtonResult> {
     const normalizedButton = button.toLowerCase();
-    if (normalizedButton !== "home" && normalizedButton !== "back") {
+    const supportedButtons = new Set(["home", "back", "recent"]);
+    if (!supportedButtons.has(normalizedButton)) {
       return {
         success: false,
         button,
         keyCode: -1,
-        error: `Unsupported iOS button: ${button}`
+        error: `Unsupported iOS simulator button: ${button}`
       };
     }
 
     const client = IOSCtrlProxyClient.getInstance(this.device);
-    const result = normalizedButton === "home"
-      ? await client.requestPressHome()
-      : await client.requestPressBack();
+    const result = await this.executeiOSNavigationButton(client, normalizedButton);
 
     if (!result.success) {
       return {
@@ -149,5 +148,21 @@ export class PressButton extends BaseVisualChange {
       button,
       keyCode: -1
     };
+  }
+
+  private async executeiOSNavigationButton(
+    client: IOSCtrlProxyClient,
+    button: string
+  ): Promise<{ success: boolean; error?: string }> {
+    switch (button) {
+      case "home":
+        return client.requestPressHome();
+      case "back":
+        return client.requestPressBack();
+      case "recent":
+        return client.requestRecentApps();
+      default:
+        return { success: false, error: `Unsupported iOS button: ${button}` };
+    }
   }
 }

--- a/src/features/observe/ios/CtrlProxyKeyboard.ts
+++ b/src/features/observe/ios/CtrlProxyKeyboard.ts
@@ -1,0 +1,43 @@
+/**
+ * CtrlProxyKeyboard - iOS keyboard delegate.
+ */
+
+import type { PerformanceTracker } from "../../../utils/PerformanceTracker";
+import type { DelegateContext, CtrlProxyKeyboardResult } from "./types";
+import { sendCommand } from "../DeviceServiceUtils";
+
+export class CtrlProxyKeyboard {
+  private readonly context: DelegateContext;
+
+  constructor(context: DelegateContext) {
+    this.context = context;
+  }
+
+  async requestKeyboard(
+    action: "open" | "close" | "detect",
+    timeoutMs: number = 5000,
+    perf?: PerformanceTracker
+  ): Promise<CtrlProxyKeyboardResult> {
+    return sendCommand<CtrlProxyKeyboardResult>(this.context, {
+      idPrefix: "keyboard",
+      responseType: "keyboard",
+      messageType: "request_keyboard",
+      params: { action },
+      timeoutMs,
+      perf,
+      errorLabel: "Keyboard",
+      notConnectedError: () => ({
+        success: false,
+        open: false,
+        totalTimeMs: 0,
+        error: "Not connected",
+      }),
+      timeoutError: timeout => ({
+        success: false,
+        open: false,
+        totalTimeMs: timeout,
+        error: `Keyboard timed out after ${timeout}ms`,
+      }),
+    });
+  }
+}

--- a/src/features/observe/ios/IOSCtrlProxyClient.ts
+++ b/src/features/observe/ios/IOSCtrlProxyClient.ts
@@ -7,6 +7,7 @@
  *
  * - CtrlProxyGestures: Swipe, tap, drag, pinch operations
  * - CtrlProxyText: setText, clearText, IME actions, select all
+ * - CtrlProxyKeyboard: keyboard open, close, detect
  * - CtrlProxyHierarchy: Hierarchy retrieval, caching, conversion
  * - CtrlProxyScreenshot: Screenshot capture
  * - CtrlProxyNavigation: pressHome, pressBack, launchApp
@@ -98,6 +99,7 @@ import { CtrlProxyNavigation } from "./CtrlProxyNavigation";
 import { CtrlProxyClipboard } from "./CtrlProxyClipboard";
 import { CtrlProxyStorage } from "./CtrlProxyStorage";
 import { CtrlProxyVoiceOver } from "./CtrlProxyVoiceOver";
+import { CtrlProxyKeyboard } from "./CtrlProxyKeyboard";
 
 // Import types
 import type {
@@ -114,6 +116,7 @@ import type {
   CtrlProxySetTextResult,
   CtrlProxyImeActionResult,
   CtrlProxySelectAllResult,
+  CtrlProxyKeyboardResult,
   CtrlProxyPressHomeResult,
   CtrlProxyPressBackResult,
   CtrlProxyRecentAppsResult,
@@ -189,6 +192,11 @@ export interface IOSCtrlProxy extends CtrlProxyClient {
   requestSelectAll(
     timeoutMs?: number, perf?: PerformanceTracker
   ): Promise<CtrlProxySelectAllResult>;
+
+  requestKeyboard(
+    action: "open" | "close" | "detect",
+    timeoutMs?: number, perf?: PerformanceTracker
+  ): Promise<CtrlProxyKeyboardResult>;
 
   requestClipboard(
     action: "copy" | "paste" | "clear" | "get",
@@ -288,6 +296,7 @@ export class IOSCtrlProxyClient extends DeviceServiceClient implements IOSCtrlPr
   private _clipboard: CtrlProxyClipboard | null = null;
   private _voiceOver: CtrlProxyVoiceOver | null = null;
   private _storage: CtrlProxyStorage | null = null;
+  private _keyboard: CtrlProxyKeyboard | null = null;
 
   // Logging tag for base class
   protected readonly logTag = "IOSCtrlProxyClient";
@@ -540,6 +549,13 @@ export class IOSCtrlProxyClient extends DeviceServiceClient implements IOSCtrlPr
       this._storage = new CtrlProxyStorage(this.createDelegateContext());
     }
     return this._storage;
+  }
+
+  private get keyboard(): CtrlProxyKeyboard {
+    if (!this._keyboard) {
+      this._keyboard = new CtrlProxyKeyboard(this.createDelegateContext());
+    }
+    return this._keyboard;
   }
 
   // ===========================================================================
@@ -958,12 +974,23 @@ export class IOSCtrlProxyClient extends DeviceServiceClient implements IOSCtrlPr
         case "set_text_result":
         case "clear_text_result":
         case "select_all_result":
+        case "press_button_result":
         case "press_home_result":
         case "press_back_result":
         case "recent_apps_result":
         case "launch_app_result":
           result = {
             success: message.success ?? true,
+            totalTimeMs: message.totalTimeMs ?? 0,
+            error: message.error,
+            perfTiming: message.perfTiming
+          };
+          break;
+
+        case "keyboard_result":
+          result = {
+            success: message.success ?? true,
+            open: message.open ?? false,
             totalTimeMs: message.totalTimeMs ?? 0,
             error: message.error,
             perfTiming: message.perfTiming
@@ -1275,6 +1302,14 @@ export class IOSCtrlProxyClient extends DeviceServiceClient implements IOSCtrlPr
     timeoutMs: number = 5000, perf?: PerformanceTracker
   ): Promise<CtrlProxySelectAllResult> {
     return this.text.requestSelectAll(timeoutMs, perf);
+  }
+
+  async requestKeyboard(
+    action: "open" | "close" | "detect",
+    timeoutMs: number = 5000,
+    perf?: PerformanceTracker
+  ): Promise<CtrlProxyKeyboardResult> {
+    return this.keyboard.requestKeyboard(action, timeoutMs, perf);
   }
 
   // ===========================================================================

--- a/src/features/observe/ios/index.ts
+++ b/src/features/observe/ios/index.ts
@@ -17,6 +17,7 @@ export { CtrlProxyScreenshot } from "./CtrlProxyScreenshot";
 export { CtrlProxyNavigation } from "./CtrlProxyNavigation";
 export { CtrlProxyClipboard } from "./CtrlProxyClipboard";
 export { CtrlProxyStorage } from "./CtrlProxyStorage";
+export { CtrlProxyKeyboard } from "./CtrlProxyKeyboard";
 
 // Types
 export type {
@@ -37,6 +38,7 @@ export type {
   CtrlProxySetTextResult,
   CtrlProxyImeActionResult,
   CtrlProxySelectAllResult,
+  CtrlProxyKeyboardResult,
   CtrlProxyPressHomeResult,
   CtrlProxyPressBackResult,
   CtrlProxyRecentAppsResult,

--- a/src/features/observe/ios/types.ts
+++ b/src/features/observe/ios/types.ts
@@ -111,6 +111,7 @@ export interface WebSocketMessage {
   performanceData?: CtrlProxyPerformanceSnapshot;
   format?: string;
   success?: boolean;
+  open?: boolean;
   totalTimeMs?: number;
   error?: string;
   perfTiming?: CtrlProxyPerfTiming | CtrlProxyPerfTiming[];
@@ -151,6 +152,11 @@ export type CtrlProxyImeActionResult = ActionTimingResult;
 
 /** Select all result from CtrlProxy iOS */
 export type CtrlProxySelectAllResult = BaseResult;
+
+/** Keyboard action result from CtrlProxy iOS */
+export interface CtrlProxyKeyboardResult extends BaseResult {
+  open: boolean;
+}
 
 /** Press home result from CtrlProxy iOS */
 export type CtrlProxyPressHomeResult = BaseResult;

--- a/test/fakes/FakeIOSCtrlProxy.ts
+++ b/test/fakes/FakeIOSCtrlProxy.ts
@@ -8,7 +8,9 @@ import {
   CtrlProxySetTextResult,
   CtrlProxyImeActionResult,
   CtrlProxySelectAllResult,
+  CtrlProxyKeyboardResult,
   CtrlProxyPressHomeResult,
+  CtrlProxyPressBackResult,
   CtrlProxyRecentAppsResult,
   CtrlProxyRotateResult,
   CtrlProxyLaunchAppResult,
@@ -95,7 +97,10 @@ export class FakeIOSCtrlProxy implements IOSCtrlProxy {
 
   private screenshotRequestCount: number = 0;
   private hierarchyRequestCount: number = 0;
+  private keyboardOpen: boolean = false;
+  private keyboardHistory: Array<{ action: "open" | "close" | "detect" }> = [];
   private pressHomeRequestCount: number = 0;
+  private pressBackRequestCount: number = 0;
   private recentAppsRequestCount: number = 0;
   private rotateHistory: Array<{ orientation: string }> = [];
   private currentOrientation: string = "portrait";
@@ -286,6 +291,14 @@ export class FakeIOSCtrlProxy implements IOSCtrlProxy {
     return this.pressHomeRequestCount;
   }
 
+  getKeyboardHistory(): Array<{ action: "open" | "close" | "detect" }> {
+    return [...this.keyboardHistory];
+  }
+
+  getPressBackRequestCount(): number {
+    return this.pressBackRequestCount;
+  }
+
   getRecentAppsRequestCount(): number {
     return this.recentAppsRequestCount;
   }
@@ -412,6 +425,11 @@ export class FakeIOSCtrlProxy implements IOSCtrlProxy {
     this.imeActionHistory = [];
     this.screenshotRequestCount = 0;
     this.hierarchyRequestCount = 0;
+    this.keyboardOpen = false;
+    this.keyboardHistory = [];
+    this.pressHomeRequestCount = 0;
+    this.pressBackRequestCount = 0;
+    this.recentAppsRequestCount = 0;
     this.launchAppHistory = [];
     this.rotateHistory = [];
     this.currentOrientation = "portrait";
@@ -728,6 +746,29 @@ export class FakeIOSCtrlProxy implements IOSCtrlProxy {
     };
   }
 
+  async requestKeyboard(
+    action: "open" | "close" | "detect",
+    timeoutMs: number = 5000,
+    perf?: PerformanceTracker
+  ): Promise<CtrlProxyKeyboardResult> {
+    await this.applyDelay("keyboard");
+    this.checkFailure("keyboard");
+
+    this.keyboardHistory.push({ action });
+    if (action === "open") {
+      this.keyboardOpen = true;
+    } else if (action === "close") {
+      this.keyboardOpen = false;
+    }
+
+    return {
+      success: true,
+      open: this.keyboardOpen,
+      totalTimeMs: 100,
+      perfTiming: this.performanceTiming || undefined
+    };
+  }
+
   async requestPressHome(
     timeoutMs: number = 5000,
     perf?: PerformanceTracker
@@ -735,6 +776,21 @@ export class FakeIOSCtrlProxy implements IOSCtrlProxy {
     this.pressHomeRequestCount++;
     await this.applyDelay("pressHome");
     this.checkFailure("pressHome");
+
+    return {
+      success: true,
+      totalTimeMs: 100,
+      perfTiming: this.performanceTiming || undefined
+    };
+  }
+
+  async requestPressBack(
+    timeoutMs: number = 5000,
+    perf?: PerformanceTracker
+  ): Promise<CtrlProxyPressBackResult> {
+    this.pressBackRequestCount++;
+    await this.applyDelay("pressBack");
+    this.checkFailure("pressBack");
 
     return {
       success: true,

--- a/test/features/action/Keyboard.test.ts
+++ b/test/features/action/Keyboard.test.ts
@@ -1,5 +1,6 @@
-import { beforeEach, describe, expect, test } from "bun:test";
+import { beforeEach, describe, expect, spyOn, test } from "bun:test";
 import { Keyboard } from "../../../src/features/action/Keyboard";
+import { IOSCtrlProxyClient } from "../../../src/features/observe/ios";
 import { BootedDevice, ViewHierarchyResult } from "../../../src/models";
 import { AdbClientFactory } from "../../../src/utils/android-cmdline-tools/AdbClientFactory";
 import { FakeAdbExecutor } from "../../fakes/FakeAdbExecutor";
@@ -16,6 +17,12 @@ describe("Keyboard", () => {
     deviceId: "test-device",
     platform: "android",
     name: "Test Device"
+  };
+
+  const iosDevice: BootedDevice = {
+    deviceId: "ios-device",
+    platform: "ios",
+    name: "iPhone"
   };
 
   const baseHierarchy = (): ViewHierarchyResult => ({
@@ -121,5 +128,69 @@ describe("Keyboard", () => {
     expect(result.success).toBe(true);
     expect(result.open).toBe(false);
     expect(fakeAdb.wasCommandExecuted("shell input keyevent KEYCODE_BACK")).toBe(true);
+  });
+
+  test("ios detect delegates to CtrlProxy keyboard request", async () => {
+    const getInstanceSpy = spyOn(IOSCtrlProxyClient, "getInstance").mockReturnValue({
+      requestKeyboard: async (action: string) => ({
+        success: true,
+        open: action === "detect",
+        totalTimeMs: 5
+      })
+    } as any);
+
+    try {
+      const keyboard = new Keyboard(iosDevice, fakeAdbFactory, fakeHierarchy, fakeTimer);
+      const result = await keyboard.execute("detect");
+
+      expect(result.success).toBe(true);
+      expect(result.open).toBe(true);
+      expect(getInstanceSpy).toHaveBeenCalled();
+    } finally {
+      getInstanceSpy.mockRestore();
+    }
+  });
+
+  test("ios close returns CtrlProxy failure", async () => {
+    const getInstanceSpy = spyOn(IOSCtrlProxyClient, "getInstance").mockReturnValue({
+      requestKeyboard: async () => ({
+        success: false,
+        open: true,
+        totalTimeMs: 5,
+        error: "No keyboard focus"
+      })
+    } as any);
+
+    try {
+      const keyboard = new Keyboard(iosDevice, fakeAdbFactory, fakeHierarchy, fakeTimer);
+      const result = await keyboard.execute("close");
+
+      expect(result.success).toBe(false);
+      expect(result.open).toBe(true);
+      expect(result.error).toBe("No keyboard focus");
+    } finally {
+      getInstanceSpy.mockRestore();
+    }
+  });
+
+  test("ios open fails when keyboard remains closed", async () => {
+    const getInstanceSpy = spyOn(IOSCtrlProxyClient, "getInstance").mockReturnValue({
+      requestKeyboard: async () => ({
+        success: true,
+        open: false,
+        totalTimeMs: 5
+      })
+    } as any);
+
+    try {
+      const keyboard = new Keyboard(iosDevice, fakeAdbFactory, fakeHierarchy, fakeTimer);
+      const result = await keyboard.execute("open");
+
+      expect(result.success).toBe(false);
+      expect(result.open).toBe(false);
+      expect(result.error).toBe("Keyboard did not open");
+    } finally {
+      getInstanceSpy.mockRestore();
+    }
   });
 });

--- a/test/features/action/PressButton.test.ts
+++ b/test/features/action/PressButton.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, spyOn, test } from "bun:test";
+import { PressButton } from "../../../src/features/action/PressButton";
+import { IOSCtrlProxyClient } from "../../../src/features/observe/ios";
+import { BootedDevice } from "../../../src/models";
+
+describe("PressButton", () => {
+  const iosDevice: BootedDevice = {
+    deviceId: "ios-device",
+    platform: "ios",
+    name: "iPhone"
+  };
+
+  test("ios back delegates to CtrlProxy pressBack", async () => {
+    let backCalls = 0;
+    const getInstanceSpy = spyOn(IOSCtrlProxyClient, "getInstance").mockReturnValue({
+      requestPressBack: async () => {
+        backCalls++;
+        return { success: true, totalTimeMs: 5 };
+      },
+      requestPressHome: async () => ({ success: true, totalTimeMs: 5 }),
+      requestRecentApps: async () => ({ success: true, totalTimeMs: 5 })
+    } as any);
+
+    try {
+      const pressButton = new PressButton(iosDevice);
+      const result = await (pressButton as any).executeiOSButtonPress("back");
+
+      expect(result.success).toBe(true);
+      expect(backCalls).toBe(1);
+      expect(getInstanceSpy).toHaveBeenCalled();
+    } finally {
+      getInstanceSpy.mockRestore();
+    }
+  });
+
+  test("ios recent delegates to CtrlProxy recent apps", async () => {
+    let recentCalls = 0;
+    const getInstanceSpy = spyOn(IOSCtrlProxyClient, "getInstance").mockReturnValue({
+      requestPressBack: async () => ({ success: true, totalTimeMs: 5 }),
+      requestPressHome: async () => ({ success: true, totalTimeMs: 5 }),
+      requestRecentApps: async () => {
+        recentCalls++;
+        return { success: true, totalTimeMs: 5 };
+      }
+    } as any);
+
+    try {
+      const pressButton = new PressButton(iosDevice);
+      const result = await (pressButton as any).executeiOSButtonPress("recent");
+
+      expect(result.success).toBe(true);
+      expect(recentCalls).toBe(1);
+      expect(getInstanceSpy).toHaveBeenCalled();
+    } finally {
+      getInstanceSpy.mockRestore();
+    }
+  });
+
+  test("ios menu remains unsupported", async () => {
+    const pressButton = new PressButton(iosDevice);
+    const result = await (pressButton as any).executeiOSButtonPress("menu");
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("Unsupported iOS simulator button");
+  });
+});

--- a/test/features/observe/DeviceServiceInterface.test.ts
+++ b/test/features/observe/DeviceServiceInterface.test.ts
@@ -169,10 +169,11 @@ describe("DeviceService Interface Compliance", () => {
       );
 
       // Verify Apple-specific interface methods exist
-      // Note: AndroidCtrlProxyClient (iOS) currently implements requestLaunchApp and requestPressHome
-      // but not all AppleDeviceService methods (requestTerminateApp, requestPressButton)
       expect(typeof client.requestLaunchApp).toBe("function");
       expect(typeof client.requestPressHome).toBe("function");
+      expect(typeof client.requestPressBack).toBe("function");
+      expect(typeof client.requestRecentApps).toBe("function");
+      expect(typeof client.requestKeyboard).toBe("function");
 
       // Cleanup
       void client.close();

--- a/test/features/observe/ios/IOSCtrlProxyClient.test.ts
+++ b/test/features/observe/ios/IOSCtrlProxyClient.test.ts
@@ -420,6 +420,83 @@ describe("IOSCtrlProxyClient", function() {
     });
   });
 
+  describe("requestKeyboard", function() {
+    test("should send keyboard request and return open state", async function() {
+      const testTimer = fakeTimer;
+
+      const { factory, getSocket } = createCapturingWebSocketFactory(testTimer);
+      const testClient = IOSCtrlProxyClient.createForTesting(
+        testDevice,
+        serverPort,
+        factory,
+        testTimer
+      );
+
+      try {
+        const resultPromise = testClient.requestKeyboard("detect", 5000);
+        const socket = await waitForSocket(getSocket);
+        expect(socket).not.toBeNull();
+        await waitForSocketOpen(socket);
+        await waitForSentMessages(socket, 1);
+
+        const sentMessage = JSON.parse(socket!.sentMessages[0]);
+        expect(sentMessage.type).toBe("request_keyboard");
+        expect(sentMessage.action).toBe("detect");
+
+        socket!.simulateMessage(JSON.stringify({
+          type: "keyboard_result",
+          requestId: sentMessage.requestId,
+          success: true,
+          open: true,
+          totalTimeMs: 20
+        }));
+
+        const result = await resultPromise;
+        expect(result.success).toBe(true);
+        expect(result.open).toBe(true);
+      } finally {
+        await testClient.close();
+      }
+    });
+  });
+
+  describe("requestRecentApps", function() {
+    test("should send recent apps request and return result", async function() {
+      const testTimer = fakeTimer;
+
+      const { factory, getSocket } = createCapturingWebSocketFactory(testTimer);
+      const testClient = IOSCtrlProxyClient.createForTesting(
+        testDevice,
+        serverPort,
+        factory,
+        testTimer
+      );
+
+      try {
+        const resultPromise = testClient.requestRecentApps(5000);
+        const socket = await waitForSocket(getSocket);
+        expect(socket).not.toBeNull();
+        await waitForSocketOpen(socket);
+        await waitForSentMessages(socket, 1);
+
+        const sentMessage = JSON.parse(socket!.sentMessages[0]);
+        expect(sentMessage.type).toBe("request_recent_apps");
+
+        socket!.simulateMessage(JSON.stringify({
+          type: "recent_apps_result",
+          requestId: sentMessage.requestId,
+          success: true,
+          totalTimeMs: 15
+        }));
+
+        const result = await resultPromise;
+        expect(result.success).toBe(true);
+      } finally {
+        await testClient.close();
+      }
+    });
+  });
+
   describe("requestLaunchApp", function() {
     test("should send launch app request and return result", async function() {
       const testTimer = fakeTimer;


### PR DESCRIPTION
## Summary

- Add iOS CtrlProxy keyboard operations for detect, open, and close.
- Route existing `keyboard` and `pressButton` tool calls through the iOS CtrlProxy bridge.
- Support iOS simulator `home`, `back`, and `recent` button actions, with unsupported buttons returning explicit errors.
- Add Swift and TypeScript tests for the new bridge messages and action behavior.

## Validation

- `bun run lint`
- `bun run build`
- `bun test test/features/observe/DeviceServiceInterface.test.ts test/features/action/Keyboard.test.ts test/features/action/PressButton.test.ts test/features/observe/ios/IOSCtrlProxyClient.test.ts`
- `bash scripts/ios/swift-test.sh ios/control-proxy`
- `git diff --check`
