### PR TITLE
[codex] Fix daemon version mismatch handling

### DIFF
--- a/src/daemon/daemonMcpProxy.ts
+++ b/src/daemon/daemonMcpProxy.ts
@@ -4,6 +4,7 @@ import { logger } from "../utils/logger";
 import { SOCKET_PATH, DAEMON_STARTUP_TIMEOUT_MS, CONNECTION_TIMEOUT_MS, DAEMON_VERSION, DAEMON_VERSION_RESTART_COOLDOWN_MS } from "./constants";
 import type { DaemonOptions } from "./types";
 import { compareVersions } from "../server/deviceMatcher";
+import { defaultTimer, type Timer } from "../utils/SystemTimer";
 
 /**
  * Configuration for the DaemonMcpProxy
@@ -21,6 +22,8 @@ export interface DaemonMcpProxyConfig {
   daemonManager?: DaemonManagerLike;
   /** Options to pass when auto-starting the daemon */
   daemonOptions?: DaemonOptions;
+  /** Timer for version restart cooldown checks */
+  timer?: Pick<Timer, "now">;
 }
 
 /**
@@ -67,6 +70,7 @@ export class DaemonMcpProxy {
   private config: DaemonMcpProxyConfig;
   private daemonManager: DaemonManagerLike;
   private clientFactory: DaemonClientFactory;
+  private readonly timer: Pick<Timer, "now">;
   private connecting: Promise<void> | null = null;
   private connected: boolean = false;
 
@@ -87,6 +91,7 @@ export class DaemonMcpProxy {
       this.config.socketPath,
       this.config.connectionTimeoutMs
     ));
+    this.timer = config.timer ?? defaultTimer;
   }
 
   /**
@@ -124,7 +129,8 @@ export class DaemonMcpProxy {
       }
       logger.info("[DaemonMcpProxy] Daemon not available, starting daemon...");
       await this.startDaemon();
-    } else if (this.config.autoStartDaemon) {
+      await this.ensureVersionMatches();
+    } else {
       await this.ensureVersionMatches();
     }
 
@@ -136,33 +142,57 @@ export class DaemonMcpProxy {
   }
 
   /**
-   * Restart the daemon when this MCP server is strictly newer than the running daemon,
-   * so a newly-pinned or freshly-resolved-@latest client upgrades the shared daemon in place.
-   *
-   * "Newer wins, older connects anyway" — older clients attach to whatever's running,
-   * which prevents ping-pong restarts when concurrent agents are pinned to different versions.
-   *
-   * A cooldown (DAEMON_VERSION_RESTART_COOLDOWN_MS) on `startedAt` further suppresses
-   * thrash from racing restarts during a coordinated upgrade.
+   * Ensure the client never attaches to a daemon running a different package version.
+   * Newer clients may restart older daemons, but every mismatch remains a hard gate.
    */
   private async ensureVersionMatches(): Promise<void> {
     const status = await this.daemonManager.status();
-    if (!status.running || !status.version) {
+    if (!status.running) {
       return;
     }
-    const cmp = compareVersions(DAEMON_VERSION, status.version);
-    // NaN means non-numeric version (prerelease tag, "unknown", etc.) — be conservative and skip.
-    if (!Number.isFinite(cmp) || cmp <= 0) {
+
+    const runningVersion = status.version?.trim() ?? "";
+    if (runningVersion === DAEMON_VERSION) {
       return;
     }
-    if (status.startedAt && Date.now() - status.startedAt < DAEMON_VERSION_RESTART_COOLDOWN_MS) {
-      logger.info(
-        `[DaemonMcpProxy] Daemon ${status.version} is older than ${DAEMON_VERSION} but was started ${Date.now() - status.startedAt}ms ago, skipping restart (cooldown)`
+
+    const cmp = runningVersion.length > 0
+      ? compareVersions(DAEMON_VERSION, runningVersion)
+      : Number.POSITIVE_INFINITY;
+
+    if (!this.config.autoStartDaemon) {
+      throw this.versionMismatchError(runningVersion, "auto-start is disabled");
+    }
+
+    if (runningVersion.length > 0 && !Number.isFinite(cmp)) {
+      throw this.versionMismatchError(
+        runningVersion,
+        "version comparison is not numeric"
       );
-      return;
     }
+
+    if (cmp <= 0) {
+      throw this.versionMismatchError(
+        runningVersion,
+        "the running daemon is newer than this client"
+      );
+    }
+
+    if (status.startedAt) {
+      const daemonAgeMs = this.timer.now() - status.startedAt;
+      if (daemonAgeMs < DAEMON_VERSION_RESTART_COOLDOWN_MS) {
+        logger.warn(
+          `[DaemonMcpProxy] Skipping version-mismatch restart due to cooldown: daemon ${runningVersion || "unknown"} is ${daemonAgeMs}ms old, client version is ${DAEMON_VERSION}`
+        );
+        throw this.versionMismatchError(
+          runningVersion,
+          "restart is in cooldown"
+        );
+      }
+    }
+
     logger.info(
-      `[DaemonMcpProxy] Daemon version ${status.version} is older than MCP server ${DAEMON_VERSION}, restarting daemon`
+      `[DaemonMcpProxy] Daemon version ${runningVersion || "unknown"} differs from MCP server ${DAEMON_VERSION}, restarting daemon`
     );
     await this.daemonManager.restart(this.config.daemonOptions ?? {});
     const ready = await this.daemonManager.waitForReady(DAEMON_STARTUP_TIMEOUT_MS);
@@ -171,6 +201,26 @@ export class DaemonMcpProxy {
         `Daemon failed to restart within ${DAEMON_STARTUP_TIMEOUT_MS}ms`
       );
     }
+
+    const restartedStatus = await this.daemonManager.status();
+    const restartedVersion = restartedStatus.version?.trim() ?? "";
+    if (!restartedStatus.running || restartedVersion !== DAEMON_VERSION) {
+      throw this.versionMismatchError(
+        restartedVersion,
+        "daemon restart completed but version still differs"
+      );
+    }
+  }
+
+  private versionMismatchError(runningVersion: string, reason: string): DaemonUnavailableError {
+    const daemonVersion = runningVersion.length > 0 ? runningVersion : "unknown";
+    const clientVersion = DAEMON_VERSION.trim();
+    const restartCommand = clientVersion.length > 0 && clientVersion !== "unknown"
+      ? `bunx @kaeawc/auto-mobile@${clientVersion} --daemon restart`
+      : "the same installed auto-mobile package";
+    return new DaemonUnavailableError(
+      `AutoMobile daemon version mismatch: daemon=${daemonVersion}, client=${DAEMON_VERSION} (${reason}). Restart the daemon with: ${restartCommand}`
+    );
   }
 
   /**

--- a/src/daemon/manager.ts
+++ b/src/daemon/manager.ts
@@ -11,6 +11,7 @@ import {
   LOCK_FILE_PATH,
   DAEMON_STARTUP_TIMEOUT_MS,
   DAEMON_SHUTDOWN_TIMEOUT_MS,
+  DAEMON_VERSION,
 } from "./constants";
 import { DaemonStatus, PidFileData, DaemonOptions } from "./types";
 import {
@@ -43,6 +44,46 @@ function resolvePackageRunner(): string | null {
  */
 function stderrLog(message: string): void {
   process.stderr.write(message + "\n");
+}
+
+export interface DaemonLaunchCommand {
+  command: string;
+  args: string[];
+}
+
+function resolvePackageSpecifier(version: string): string {
+  const trimmedVersion = version.trim();
+  if (trimmedVersion.length === 0 || trimmedVersion === "unknown") {
+    throw new ActionableError(
+      "Cannot spawn AutoMobile daemon via bunx because the current package version is unknown. Run from an installed auto-mobile binary or set MCP_SERVER_VERSION."
+    );
+  }
+  return `@kaeawc/auto-mobile@${trimmedVersion}`;
+}
+
+export function resolveDaemonLaunchCommand(
+  entryScript: string | undefined = process.argv[1],
+  packageRunner: string | null = resolvePackageRunner(),
+  version: string = DAEMON_VERSION
+): DaemonLaunchCommand {
+  if (entryScript) {
+    return {
+      command: process.execPath,
+      args: [entryScript, "--daemon-mode"],
+    };
+  }
+
+  if (packageRunner) {
+    return {
+      command: packageRunner,
+      args: ["-y", resolvePackageSpecifier(version), "--daemon-mode"],
+    };
+  }
+
+  return {
+    command: "auto-mobile",
+    args: ["--daemon-mode"],
+  };
 }
 
 /**
@@ -294,22 +335,7 @@ export class DaemonManager implements DaemonManagerLike {
     // Resolve the current binary so the daemon uses the same version.
     // process.argv[1] is the entry script (e.g. dist/src/index.js).
     // Falls back to bunx to avoid requiring a global install.
-    const entryScript = process.argv[1];
-    let autoMobileCmd: string;
-    let args: string[];
-    if (entryScript) {
-      autoMobileCmd = process.execPath;
-      args = [entryScript, "--daemon-mode"];
-    } else {
-      const runner = resolvePackageRunner();
-      if (runner) {
-        autoMobileCmd = runner;
-        args = ["-y", "@kaeawc/auto-mobile@latest", "--daemon-mode"];
-      } else {
-        autoMobileCmd = "auto-mobile";
-        args = ["--daemon-mode"];
-      }
-    }
+    const { command: autoMobileCmd, args } = resolveDaemonLaunchCommand();
     if (options.port) {
       args.push("--port", options.port.toString());
     }

--- a/test/daemon/daemonMcpProxy.test.ts
+++ b/test/daemon/daemonMcpProxy.test.ts
@@ -2,8 +2,10 @@ import { describe, expect, test, spyOn } from "bun:test";
 import { DaemonMcpProxy } from "../../src/daemon/daemonMcpProxy";
 import { DaemonClient, DaemonUnavailableError } from "../../src/daemon/client";
 import { DAEMON_VERSION, DAEMON_VERSION_RESTART_COOLDOWN_MS } from "../../src/daemon/constants";
+import { logger } from "../../src/utils/logger";
 import { FakeDaemonManager } from "../fakes/FakeDaemonManager";
 import { FakeDaemonClient } from "../fakes/FakeDaemonClient";
+import { FakeTimer } from "../fakes/FakeTimer";
 
 const OLDER_VERSION = "0.0.1";
 const NEWER_VERSION = "9999.0.0";
@@ -18,6 +20,13 @@ describe("DaemonMcpProxy", () => {
         ])
       });
       const fakeManager = new FakeDaemonManager();
+      fakeManager.statusResult = {
+        running: true,
+        pid: 1234,
+        port: 3000,
+        socketPath: "/tmp/test.sock",
+        version: DAEMON_VERSION,
+      };
 
       // Mock DaemonClient.isAvailable to return true
       const isAvailableSpy = spyOn(DaemonClient, "isAvailable").mockResolvedValue(true);
@@ -79,12 +88,15 @@ describe("DaemonMcpProxy", () => {
         autoStartDaemon?: boolean;
         waitForReadyResult?: boolean;
         daemonOptions?: { debug?: boolean; port?: number };
+        statusAfterRestartVersion?: string;
       } = {}) {
+        const timer = new FakeTimer();
+        timer.advanceTime(100_000);
         const fakeClient = new FakeDaemonClient({
           daemonMethodResults: new Map([["tools/list", { tools: [] }]]),
         });
         const fakeManager = new FakeDaemonManager();
-        fakeManager.statusResult = {
+        const initialStatus = {
           running: true,
           pid: 1234,
           port: 3000,
@@ -92,6 +104,15 @@ describe("DaemonMcpProxy", () => {
           ...(opts.runningVersion !== undefined ? { version: opts.runningVersion } : {}),
           ...(opts.startedAt !== undefined ? { startedAt: opts.startedAt } : {}),
         };
+        fakeManager.statusResult = initialStatus;
+        fakeManager.statusResults = [
+          initialStatus,
+          {
+            ...initialStatus,
+            version: opts.statusAfterRestartVersion ?? DAEMON_VERSION,
+            startedAt: timer.now(),
+          },
+        ];
         if (opts.waitForReadyResult !== undefined) {
           fakeManager.waitForReadyResult = opts.waitForReadyResult;
         }
@@ -101,6 +122,7 @@ describe("DaemonMcpProxy", () => {
           daemonManager: fakeManager,
           autoStartDaemon: opts.autoStartDaemon ?? true,
           daemonOptions: opts.daemonOptions,
+          timer,
         });
         return { fakeClient, fakeManager, isAvailableSpy, proxy };
       }
@@ -119,15 +141,15 @@ describe("DaemonMcpProxy", () => {
         }
       });
 
-      test("does not restart when daemon version is newer (older client connects anyway)", async () => {
+      test("throws when daemon version is newer", async () => {
         const { fakeClient, fakeManager, isAvailableSpy, proxy } = makeProxy({
           runningVersion: NEWER_VERSION,
           startedAt: ANCIENT_TIMESTAMP,
         });
         try {
-          await proxy.listTools();
+          await expect(proxy.listTools()).rejects.toThrow("AutoMobile daemon version mismatch");
           expect(fakeManager.restartCalled).toBe(false);
-          expect(fakeClient.isConnected()).toBe(true);
+          expect(fakeClient.isConnected()).toBe(false);
         } finally {
           isAvailableSpy.mockRestore();
           await proxy.close();
@@ -148,16 +170,19 @@ describe("DaemonMcpProxy", () => {
         }
       });
 
-      test("does not restart when daemon is older but within cooldown window", async () => {
+      test("throws when daemon is older but within cooldown window", async () => {
+        const warnSpy = spyOn(logger, "warn").mockImplementation(() => {});
         const { fakeClient, fakeManager, isAvailableSpy, proxy } = makeProxy({
           runningVersion: OLDER_VERSION,
-          startedAt: Date.now() - Math.floor(DAEMON_VERSION_RESTART_COOLDOWN_MS / 2),
+          startedAt: 100_000 - Math.floor(DAEMON_VERSION_RESTART_COOLDOWN_MS / 2),
         });
         try {
-          await proxy.listTools();
+          await expect(proxy.listTools()).rejects.toThrow("restart is in cooldown");
           expect(fakeManager.restartCalled).toBe(false);
-          expect(fakeClient.isConnected()).toBe(true);
+          expect(fakeClient.isConnected()).toBe(false);
+          expect(warnSpy).toHaveBeenCalled();
         } finally {
+          warnSpy.mockRestore();
           isAvailableSpy.mockRestore();
           await proxy.close();
         }
@@ -166,7 +191,7 @@ describe("DaemonMcpProxy", () => {
       test("restarts older daemon once cooldown has elapsed", async () => {
         const { fakeManager, isAvailableSpy, proxy } = makeProxy({
           runningVersion: OLDER_VERSION,
-          startedAt: Date.now() - DAEMON_VERSION_RESTART_COOLDOWN_MS - 1000,
+          startedAt: 100_000 - DAEMON_VERSION_RESTART_COOLDOWN_MS - 1000,
         });
         try {
           await proxy.listTools();
@@ -177,16 +202,16 @@ describe("DaemonMcpProxy", () => {
         }
       });
 
-      test("does not restart when autoStartDaemon is disabled, even when newer", async () => {
+      test("throws without restarting when autoStartDaemon is disabled", async () => {
         const { fakeClient, fakeManager, isAvailableSpy, proxy } = makeProxy({
           runningVersion: OLDER_VERSION,
           startedAt: ANCIENT_TIMESTAMP,
           autoStartDaemon: false,
         });
         try {
-          await proxy.listTools();
+          await expect(proxy.listTools()).rejects.toThrow("auto-start is disabled");
           expect(fakeManager.restartCalled).toBe(false);
-          expect(fakeClient.isConnected()).toBe(true);
+          expect(fakeClient.isConnected()).toBe(false);
         } finally {
           isAvailableSpy.mockRestore();
           await proxy.close();
@@ -225,13 +250,28 @@ describe("DaemonMcpProxy", () => {
         }
       });
 
-      test("does not restart when running daemon does not expose a version", async () => {
+      test("restarts when running daemon does not expose a version", async () => {
         const { fakeManager, isAvailableSpy, proxy } = makeProxy({
           startedAt: ANCIENT_TIMESTAMP,
         });
         try {
           await proxy.listTools();
-          expect(fakeManager.restartCalled).toBe(false);
+          expect(fakeManager.restartCalled).toBe(true);
+        } finally {
+          isAvailableSpy.mockRestore();
+          await proxy.close();
+        }
+      });
+
+      test("throws when restarted daemon version still differs", async () => {
+        const { fakeManager, isAvailableSpy, proxy } = makeProxy({
+          runningVersion: OLDER_VERSION,
+          startedAt: ANCIENT_TIMESTAMP,
+          statusAfterRestartVersion: OLDER_VERSION,
+        });
+        try {
+          await expect(proxy.listTools()).rejects.toThrow("daemon restart completed but version still differs");
+          expect(fakeManager.restartCalled).toBe(true);
         } finally {
           isAvailableSpy.mockRestore();
           await proxy.close();
@@ -242,13 +282,13 @@ describe("DaemonMcpProxy", () => {
         ["prerelease tag", "0.0.21-beta.1"],
         ["unknown fallback", "unknown"],
         ["empty-after-prefix", "v"],
-      ])("does not restart when version comparison is non-numeric (%s)", async (_label, runningVersion) => {
+      ])("throws when version comparison is non-numeric (%s)", async (_label, runningVersion) => {
         const { fakeManager, isAvailableSpy, proxy } = makeProxy({
           runningVersion,
           startedAt: ANCIENT_TIMESTAMP,
         });
         try {
-          await proxy.listTools();
+          await expect(proxy.listTools()).rejects.toThrow("version comparison is not numeric");
           expect(fakeManager.restartCalled).toBe(false);
         } finally {
           isAvailableSpy.mockRestore();

--- a/test/daemon/integration/versionMismatchRestart.test.ts
+++ b/test/daemon/integration/versionMismatchRestart.test.ts
@@ -8,6 +8,7 @@ import { DaemonManager, type DaemonManagerLike } from "../../../src/daemon/manag
 import { DAEMON_VERSION, DAEMON_VERSION_RESTART_COOLDOWN_MS } from "../../../src/daemon/constants";
 import type { DaemonOptions, DaemonStatus, PidFileData } from "../../../src/daemon/types";
 import { FakeDaemonClient } from "../../fakes/FakeDaemonClient";
+import { FakeTimer } from "../../fakes/FakeTimer";
 
 /**
  * Integration test: real DaemonManager.status() reading a real PID file written
@@ -22,6 +23,7 @@ describe("DaemonMcpProxy + real DaemonManager (version-mismatch integration)", (
   let pidFilePath: string;
   let realManager: DaemonManager;
   let isAvailableSpy: ReturnType<typeof spyOn>;
+  let fakeTimer: FakeTimer;
 
   function writePidFile(fields: { version?: string; startedAt?: number }): void {
     const data: PidFileData = {
@@ -39,6 +41,8 @@ describe("DaemonMcpProxy + real DaemonManager (version-mismatch integration)", (
     pidFilePath = join(tempDir, "test.pid");
     realManager = new DaemonManager(undefined, undefined, undefined, undefined, pidFilePath);
     isAvailableSpy = spyOn(DaemonClient, "isAvailable").mockResolvedValue(true);
+    fakeTimer = new FakeTimer();
+    fakeTimer.advanceTime(100_000);
   });
 
   afterEach(() => {
@@ -70,6 +74,7 @@ describe("DaemonMcpProxy + real DaemonManager (version-mismatch integration)", (
       async restart(options?: DaemonOptions) {
         restartCalled = true;
         restartOptions = options;
+        writePidFile({ version: DAEMON_VERSION, startedAt: fakeTimer.now() });
       },
       async waitForReady() {
         return tracker.waitForReadyResult;
@@ -85,6 +90,7 @@ describe("DaemonMcpProxy + real DaemonManager (version-mismatch integration)", (
       clientFactory: () => new FakeDaemonClient(),
       daemonManager: tracked,
       autoStartDaemon: true,
+      timer: fakeTimer,
     });
     try {
       await proxy.listTools();
@@ -94,17 +100,20 @@ describe("DaemonMcpProxy + real DaemonManager (version-mismatch integration)", (
     }
   });
 
-  test("real PID file with newer version does not trigger restart", async () => {
+  test("real PID file with newer version fails without attaching", async () => {
     writePidFile({ version: "9999.0.0", startedAt: 1 });
     const tracked = makeTracked();
+    const fakeClient = new FakeDaemonClient();
     const proxy = new DaemonMcpProxy({
-      clientFactory: () => new FakeDaemonClient(),
+      clientFactory: () => fakeClient,
       daemonManager: tracked,
       autoStartDaemon: true,
+      timer: fakeTimer,
     });
     try {
-      await proxy.listTools();
+      await expect(proxy.listTools()).rejects.toThrow("AutoMobile daemon version mismatch");
       expect(tracked.restartCalled).toBe(false);
+      expect(fakeClient.isConnected()).toBe(false);
     } finally {
       await proxy.close();
     }
@@ -117,6 +126,7 @@ describe("DaemonMcpProxy + real DaemonManager (version-mismatch integration)", (
       clientFactory: () => new FakeDaemonClient(),
       daemonManager: tracked,
       autoStartDaemon: true,
+      timer: fakeTimer,
     });
     try {
       await proxy.listTools();
@@ -126,26 +136,29 @@ describe("DaemonMcpProxy + real DaemonManager (version-mismatch integration)", (
     }
   });
 
-  test("real PID file with older version inside cooldown window does not trigger restart", async () => {
+  test("real PID file with older version inside cooldown window fails without attaching", async () => {
     writePidFile({
       version: "0.0.1",
-      startedAt: Date.now() - Math.floor(DAEMON_VERSION_RESTART_COOLDOWN_MS / 2),
+      startedAt: fakeTimer.now() - Math.floor(DAEMON_VERSION_RESTART_COOLDOWN_MS / 2),
     });
     const tracked = makeTracked();
+    const fakeClient = new FakeDaemonClient();
     const proxy = new DaemonMcpProxy({
-      clientFactory: () => new FakeDaemonClient(),
+      clientFactory: () => fakeClient,
       daemonManager: tracked,
       autoStartDaemon: true,
+      timer: fakeTimer,
     });
     try {
-      await proxy.listTools();
+      await expect(proxy.listTools()).rejects.toThrow("restart is in cooldown");
       expect(tracked.restartCalled).toBe(false);
+      expect(fakeClient.isConnected()).toBe(false);
     } finally {
       await proxy.close();
     }
   });
 
-  test("real PID file missing version field does not trigger restart", async () => {
+  test("real PID file missing version field triggers restart", async () => {
     const data = {
       pid: process.pid,
       socketPath: join(tempDir, "test.sock"),
@@ -158,10 +171,11 @@ describe("DaemonMcpProxy + real DaemonManager (version-mismatch integration)", (
       clientFactory: () => new FakeDaemonClient(),
       daemonManager: tracked,
       autoStartDaemon: true,
+      timer: fakeTimer,
     });
     try {
       await proxy.listTools();
-      expect(tracked.restartCalled).toBe(false);
+      expect(tracked.restartCalled).toBe(true);
     } finally {
       await proxy.close();
     }
@@ -182,6 +196,7 @@ describe("DaemonMcpProxy + real DaemonManager (version-mismatch integration)", (
       clientFactory: () => new FakeDaemonClient(),
       daemonManager: tracked,
       autoStartDaemon: true,
+      timer: fakeTimer,
     });
     try {
       await proxy.listTools();

--- a/test/daemon/manager.test.ts
+++ b/test/daemon/manager.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, spyOn, test } from "bun:test";
-import { runDaemonCommand } from "../../src/daemon/manager";
+import { resolveDaemonLaunchCommand, runDaemonCommand } from "../../src/daemon/manager";
 import type { DaemonStateLike } from "../../src/daemon/daemonState";
 import type { DaemonClientLike } from "../../src/daemon/client";
 
@@ -32,6 +32,32 @@ class FakeDaemonClient implements DaemonClientLike {
     return {};
   }
 }
+
+describe("resolveDaemonLaunchCommand", () => {
+  test("uses the current entry script when one is available", () => {
+    const launch = resolveDaemonLaunchCommand("/tmp/auto-mobile/dist/src/index.js", "bunx", "1.2.3");
+
+    expect(launch).toEqual({
+      command: process.execPath,
+      args: ["/tmp/auto-mobile/dist/src/index.js", "--daemon-mode"],
+    });
+  });
+
+  test("pins bunx fallback to the initiating package version", () => {
+    const launch = resolveDaemonLaunchCommand("", "bunx", "1.2.3");
+
+    expect(launch).toEqual({
+      command: "bunx",
+      args: ["-y", "@kaeawc/auto-mobile@1.2.3", "--daemon-mode"],
+    });
+  });
+
+  test("rejects unknown versions instead of falling back to latest", () => {
+    expect(() => resolveDaemonLaunchCommand("", "bunx", "unknown")).toThrow(
+      "current package version is unknown"
+    );
+  });
+});
 
 describe("Daemon manager available-devices", () => {
   test("queries the booted devices resource when daemon is not initialized", async () => {

--- a/test/fakes/FakeDaemonManager.ts
+++ b/test/fakes/FakeDaemonManager.ts
@@ -12,6 +12,7 @@ export class FakeDaemonManager implements DaemonManagerLike {
     port: 3000,
     socketPath: "/tmp/test.sock",
   };
+  statusResults: DaemonStatus[] = [];
   startCalled = false;
   startCallCount = 0;
   startOptions: DaemonOptions | undefined;
@@ -22,6 +23,10 @@ export class FakeDaemonManager implements DaemonManagerLike {
   waitForReadyCallCount = 0;
 
   async status(): Promise<DaemonStatus> {
+    const nextStatus = this.statusResults.shift();
+    if (nextStatus) {
+      return nextStatus;
+    }
     return this.statusResult;
   }
 


### PR DESCRIPTION
## Summary

- pin daemon bunx fallback spawns to the initiating package version instead of `@latest`
- make daemon/client version mismatch a hard connection gate with actionable errors
- verify the daemon version again after auto-start/restart before connecting
- log cooldown-skipped version restarts and refuse to silently attach during cooldown

Fixes #2452

## Validation

- `bunx eslint src/daemon/daemonMcpProxy.ts src/daemon/manager.ts test/daemon/daemonMcpProxy.test.ts test/daemon/integration/versionMismatchRestart.test.ts test/daemon/manager.test.ts test/fakes/FakeDaemonManager.ts --fix`
- `bun test test/daemon/daemonMcpProxy.test.ts test/daemon/integration/versionMismatchRestart.test.ts test/daemon/manager.test.ts`
- `bun run build`
