### PR TITLE
Fix observation stream request command

### DIFF
--- a/src/daemon/daemon.ts
+++ b/src/daemon/daemon.ts
@@ -50,6 +50,7 @@ import { describeUnknownError } from "../utils/describeUnknownError";
 import { FeatureFlagService } from "../features/featureFlags/FeatureFlagService";
 import { serverConfig } from "../utils/ServerConfig";
 import { setDebugPerfEnabled } from "../utils/PerformanceTracker";
+import type { BootedDevice } from "../models";
 
 const DEVICE_DISCONNECT_POLL_INTERVAL_MS = 5000;
 const DEVICE_DISCONNECT_MISS_THRESHOLD = 3;
@@ -670,6 +671,40 @@ export class Daemon {
       if (allDevices.length === 0) {
         logger.info("[Daemon] No devices in pool to connect");
       }
+    });
+
+    server.setOnObservationRequested(async ({ deviceId, signal }) => {
+      const pooledDevices = deviceId
+        ? [this.devicePool.getDevice(deviceId)].filter(device => device !== null)
+        : this.devicePool.getAllDevices();
+
+      if (pooledDevices.length === 0) {
+        throw new Error(deviceId ? `Device ${deviceId} is not available` : "No devices are available");
+      }
+
+      const requestStart = this.timer.now();
+      const observations = [];
+      for (const pooledDevice of pooledDevices) {
+        if (signal.aborted) {
+          throw new Error("Observation request was aborted");
+        }
+
+        const bootedDevice: BootedDevice = {
+          deviceId: pooledDevice.id,
+          name: pooledDevice.name,
+          platform: pooledDevice.platform,
+          iosVersion: pooledDevice.iosVersion,
+        };
+        const observeScreen = new RealObserveScreen(bootedDevice);
+        const observation = await observeScreen.execute({
+          skipWaitForFresh: false,
+          minTimestamp: requestStart,
+          signal,
+        });
+        observations.push({ deviceId: pooledDevice.id, observation });
+      }
+
+      return observations;
     });
 
     logger.info("[Daemon] Observation stream callback configured");

--- a/src/daemon/deviceDataStreamSocketServer.ts
+++ b/src/daemon/deviceDataStreamSocketServer.ts
@@ -143,7 +143,11 @@ export type OnObservationRequestedCallback = (request: {
  */
 export type OnNavigationGraphRequestedCallback = (appId?: string | null) => Promise<NavigationGraphStreamData | null>;
 
-const DEFAULT_OBSERVATION_REQUEST_TIMEOUT_MS = 10_000;
+// iOS observe (ViewHierarchy.getiOSViewHierarchy -> getLatestHierarchy) can
+// legitimately wait up to 15s for a fresh hierarchy. Keep this wrapper timeout
+// above that so slow-but-valid iOS captures are not reported as stream errors
+// before the platform observe path has its allotted time to complete.
+const DEFAULT_OBSERVATION_REQUEST_TIMEOUT_MS = 20_000;
 
 /**
  * Socket server that streams device data updates (hierarchy, screenshot, storage) to connected IDE plugins.
@@ -416,18 +420,32 @@ export class DeviceDataStreamSocketServer extends PushSubscriptionSocketServer<
       if (observations.length === 0) {
         throw new Error("Observation request did not capture any devices");
       }
-      const hierarchyUpdates: Array<{ deviceId: string; hierarchy: ViewHierarchyResult }> = [];
 
+      // Push valid hierarchies independently so that, for all-device requests,
+      // healthy devices still receive a refresh even when another device has no
+      // hierarchy (e.g. accessibility/CtrlProxy unavailable). Failures are
+      // collected and surfaced in the response rather than aborting the batch.
+      const failures: string[] = [];
       for (const { deviceId, observation } of observations) {
         const hierarchy = observation.viewHierarchy;
         if (!hierarchy) {
-          throw new Error(this.describeMissingHierarchy(deviceId, observation));
+          failures.push(this.describeMissingHierarchy(deviceId, observation));
+          continue;
         }
-        hierarchyUpdates.push({ deviceId, hierarchy });
+        this.pushHierarchyUpdate(deviceId, hierarchy);
       }
 
-      for (const { deviceId, hierarchy } of hierarchyUpdates) {
-        this.pushHierarchyUpdate(deviceId, hierarchy);
+      if (failures.length > 0) {
+        // Healthy devices already received their hierarchy_update pushes above;
+        // report the per-device failures so the client can display/retry them.
+        const errorResponse: SubscriptionResponse = {
+          id: request.id,
+          type: "error",
+          success: false,
+          error: failures.join("; "),
+        };
+        this.sendJson(socket, errorResponse);
+        return;
       }
 
       const response: SubscriptionResponse = {

--- a/src/daemon/deviceDataStreamSocketServer.ts
+++ b/src/daemon/deviceDataStreamSocketServer.ts
@@ -413,6 +413,9 @@ export class DeviceDataStreamSocketServer extends PushSubscriptionSocketServer<
         deviceId: request.deviceId ?? null,
         requestId: request.id,
       });
+      if (observations.length === 0) {
+        throw new Error("Observation request did not capture any devices");
+      }
       const hierarchyUpdates: Array<{ deviceId: string; hierarchy: ViewHierarchyResult }> = [];
 
       for (const { deviceId, observation } of observations) {

--- a/src/daemon/deviceDataStreamSocketServer.ts
+++ b/src/daemon/deviceDataStreamSocketServer.ts
@@ -9,7 +9,7 @@ import {
   SocketServerConfig,
   SubscriptionResponse,
 } from "./socketServer/index";
-import type { ViewHierarchyResult } from "../models";
+import type { ObserveResult, ViewHierarchyResult } from "../models";
 import type { StorageChangedEvent } from "../features/storage/storageTypes";
 
 // NOTE: Keep legacy socket path for backward compatibility with IDE plugin
@@ -121,10 +121,29 @@ interface DeviceDataPush {
 export type OnSubscriberConnectedCallback = (deviceId: string | null) => void;
 
 /**
+ * Observation captured on demand for a stream client.
+ */
+export interface RequestedObservation {
+  deviceId: string;
+  observation: ObserveResult;
+}
+
+/**
+ * Callback invoked when a client requests an immediate observation.
+ */
+export type OnObservationRequestedCallback = (request: {
+  deviceId: string | null;
+  requestId?: string;
+  signal: AbortSignal;
+}) => Promise<RequestedObservation[]>;
+
+/**
  * Callback invoked when a client requests the current navigation graph.
  * Returns the current graph data, or null if no graph is available.
  */
 export type OnNavigationGraphRequestedCallback = (appId?: string | null) => Promise<NavigationGraphStreamData | null>;
+
+const DEFAULT_OBSERVATION_REQUEST_TIMEOUT_MS = 10_000;
 
 /**
  * Socket server that streams device data updates (hierarchy, screenshot, storage) to connected IDE plugins.
@@ -144,7 +163,9 @@ export class DeviceDataStreamSocketServer extends PushSubscriptionSocketServer<
   DeviceDataPush
 > {
   private onSubscriberConnected: OnSubscriberConnectedCallback | null = null;
+  private onObservationRequested: OnObservationRequestedCallback | null = null;
   private onNavigationGraphRequested: OnNavigationGraphRequestedCallback | null = null;
+  private observationRequestTimeoutMs = DEFAULT_OBSERVATION_REQUEST_TIMEOUT_MS;
 
   constructor(socketPath: string = getSocketPath(SOCKET_CONFIG), timer: Timer = defaultTimer) {
     super(socketPath, timer, "DeviceDataStream");
@@ -156,6 +177,17 @@ export class DeviceDataStreamSocketServer extends PushSubscriptionSocketServer<
    */
   setOnSubscriberConnected(callback: OnSubscriberConnectedCallback): void {
     this.onSubscriberConnected = callback;
+  }
+
+  /**
+   * Set a callback to handle on-demand observation requests.
+   */
+  setOnObservationRequested(
+    callback: OnObservationRequestedCallback,
+    timeoutMs: number = DEFAULT_OBSERVATION_REQUEST_TIMEOUT_MS
+  ): void {
+    this.onObservationRequested = callback;
+    this.observationRequestTimeoutMs = timeoutMs;
   }
 
   /**
@@ -275,14 +307,7 @@ export class DeviceDataStreamSocketServer extends PushSubscriptionSocketServer<
 
     // Handle request_observation command (not in base class)
     if (request.command === "request_observation") {
-      // This could trigger an immediate observation request
-      // For now, just acknowledge - the caller should use MCP observe tool
-      const response: SubscriptionResponse = {
-        id: request.id,
-        type: "subscription_response",
-        success: true,
-      };
-      this.sendJson(socket, response);
+      await this.handleObservationRequest(socket, request);
       return;
     }
 
@@ -366,6 +391,81 @@ export class DeviceDataStreamSocketServer extends PushSubscriptionSocketServer<
 
   protected createPushMessage(data: DeviceDataPush): DeviceDataStreamMessage {
     return data.message;
+  }
+
+  private async handleObservationRequest(
+    socket: Socket,
+    request: { id?: string; deviceId?: string }
+  ): Promise<void> {
+    if (!this.onObservationRequested) {
+      const response: SubscriptionResponse = {
+        id: request.id,
+        type: "error",
+        success: false,
+        error: "Observation requests are not available",
+      };
+      this.sendJson(socket, response);
+      return;
+    }
+
+    try {
+      const observations = await this.requestObservationWithTimeout({
+        deviceId: request.deviceId ?? null,
+        requestId: request.id,
+      });
+
+      for (const { deviceId, observation } of observations) {
+        if (observation.viewHierarchy) {
+          this.pushHierarchyUpdate(deviceId, observation.viewHierarchy);
+        }
+      }
+
+      const response: SubscriptionResponse = {
+        id: request.id,
+        type: "subscription_response",
+        success: true,
+      };
+      this.sendJson(socket, response);
+    } catch (error) {
+      logger.warn(`[DeviceDataStream] Error handling request_observation: ${error}`);
+      const errorResponse: SubscriptionResponse = {
+        id: request.id,
+        type: "error",
+        success: false,
+        error: error instanceof Error ? error.message : String(error),
+      };
+      this.sendJson(socket, errorResponse);
+    }
+  }
+
+  private async requestObservationWithTimeout(request: {
+    deviceId: string | null;
+    requestId?: string;
+  }): Promise<RequestedObservation[]> {
+    const controller = new AbortController();
+    let timeoutHandle: NodeJS.Timeout | null = null;
+
+    const timeoutPromise = new Promise<never>((_, reject) => {
+      timeoutHandle = this.timer.setTimeout(() => {
+        controller.abort();
+        reject(new Error(`Observation request timed out after ${this.observationRequestTimeoutMs}ms`));
+      }, this.observationRequestTimeoutMs);
+    });
+
+    try {
+      return await Promise.race([
+        this.onObservationRequested!({
+          deviceId: request.deviceId,
+          requestId: request.requestId,
+          signal: controller.signal,
+        }),
+        timeoutPromise,
+      ]);
+    } finally {
+      if (timeoutHandle) {
+        this.timer.clearTimeout(timeoutHandle);
+      }
+    }
   }
 }
 

--- a/src/daemon/deviceDataStreamSocketServer.ts
+++ b/src/daemon/deviceDataStreamSocketServer.ts
@@ -413,11 +413,18 @@ export class DeviceDataStreamSocketServer extends PushSubscriptionSocketServer<
         deviceId: request.deviceId ?? null,
         requestId: request.id,
       });
+      const hierarchyUpdates: Array<{ deviceId: string; hierarchy: ViewHierarchyResult }> = [];
 
       for (const { deviceId, observation } of observations) {
-        if (observation.viewHierarchy) {
-          this.pushHierarchyUpdate(deviceId, observation.viewHierarchy);
+        const hierarchy = observation.viewHierarchy;
+        if (!hierarchy) {
+          throw new Error(this.describeMissingHierarchy(deviceId, observation));
         }
+        hierarchyUpdates.push({ deviceId, hierarchy });
+      }
+
+      for (const { deviceId, hierarchy } of hierarchyUpdates) {
+        this.pushHierarchyUpdate(deviceId, hierarchy);
       }
 
       const response: SubscriptionResponse = {
@@ -436,6 +443,13 @@ export class DeviceDataStreamSocketServer extends PushSubscriptionSocketServer<
       };
       this.sendJson(socket, errorResponse);
     }
+  }
+
+  private describeMissingHierarchy(deviceId: string, observation: ObserveResult): string {
+    const observationError = observation.error
+      ?? observation.errors?.map(error => error.message).join("; ")
+      ?? "Observation did not include view hierarchy";
+    return `Observation request failed for ${deviceId}: ${observationError}`;
   }
 
   private async requestObservationWithTimeout(request: {

--- a/test/daemon/deviceDataStreamSocketServer.test.ts
+++ b/test/daemon/deviceDataStreamSocketServer.test.ts
@@ -165,6 +165,47 @@ describe("DeviceDataStreamSocketServer", () => {
       );
     });
 
+    it("pushes healthy hierarchies and reports failures on partial all-device refresh", async () => {
+      server.setOnObservationRequested(async () => [
+        requestedObservation("emulator-5554"),
+        {
+          deviceId: "emulator-5556",
+          observation: {
+            updatedAt: "2026-06-24T00:00:00.000Z",
+            screenSize: { width: 0, height: 0 },
+            systemInsets: { top: 0, right: 0, bottom: 0, left: 0 },
+            errors: [{ phase: "viewHierarchy", message: "CtrlProxy unavailable" }],
+            error: "CtrlProxy unavailable",
+          },
+        },
+      ]);
+      const { socket } = server.simulateSubscription({});
+
+      await server.processLineForTest(socket, JSON.stringify({
+        id: "obs-partial",
+        command: "request_observation",
+      }));
+
+      const msgs = socket.getWrittenMessages<{
+        id?: string;
+        type: string;
+        success?: boolean;
+        deviceId?: string;
+        error?: string;
+      }>();
+      // Healthy device still receives its hierarchy_update...
+      expect(msgs).toHaveLength(2);
+      expect(msgs[0].type).toBe("hierarchy_update");
+      expect(msgs[0].deviceId).toBe("emulator-5554");
+      // ...and the failed device is surfaced in the response error.
+      expect(msgs[1].type).toBe("error");
+      expect(msgs[1].id).toBe("obs-partial");
+      expect(msgs[1].success).toBe(false);
+      expect(msgs[1].error).toBe(
+        "Observation request failed for emulator-5556: CtrlProxy unavailable"
+      );
+    });
+
     it("returns error when observation callback returns no devices", async () => {
       server.setOnObservationRequested(async () => []);
       const socket = new FakeSocket();

--- a/test/daemon/deviceDataStreamSocketServer.test.ts
+++ b/test/daemon/deviceDataStreamSocketServer.test.ts
@@ -165,6 +165,28 @@ describe("DeviceDataStreamSocketServer", () => {
       );
     });
 
+    it("returns error when observation callback returns no devices", async () => {
+      server.setOnObservationRequested(async () => []);
+      const socket = new FakeSocket();
+
+      await server.processLineForTest(socket, JSON.stringify({
+        id: "obs-empty",
+        command: "request_observation",
+      }));
+
+      const msgs = socket.getWrittenMessages<{
+        id?: string;
+        type: string;
+        success?: boolean;
+        error?: string;
+      }>();
+      expect(msgs).toHaveLength(1);
+      expect(msgs[0].type).toBe("error");
+      expect(msgs[0].id).toBe("obs-empty");
+      expect(msgs[0].success).toBe(false);
+      expect(msgs[0].error).toBe("Observation request did not capture any devices");
+    });
+
     it("returns error when observation callback throws", async () => {
       server.setOnObservationRequested(async () => {
         throw new Error("Observe failed");

--- a/test/daemon/deviceDataStreamSocketServer.test.ts
+++ b/test/daemon/deviceDataStreamSocketServer.test.ts
@@ -131,6 +131,40 @@ describe("DeviceDataStreamSocketServer", () => {
       expect(msgs[0].error).toBe("Observation requests are not available");
     });
 
+    it("returns error when observation has no hierarchy", async () => {
+      server.setOnObservationRequested(async () => [{
+        deviceId: "emulator-5554",
+        observation: {
+          updatedAt: "2026-06-24T00:00:00.000Z",
+          screenSize: { width: 0, height: 0 },
+          systemInsets: { top: 0, right: 0, bottom: 0, left: 0 },
+          errors: [{ phase: "viewHierarchy", message: "Accessibility service unavailable" }],
+          error: "Accessibility service unavailable",
+        },
+      }]);
+      const { socket } = server.simulateSubscription({ deviceId: "emulator-5554" });
+
+      await server.processLineForTest(socket, JSON.stringify({
+        id: "obs-no-hierarchy",
+        command: "request_observation",
+        deviceId: "emulator-5554",
+      }));
+
+      const msgs = socket.getWrittenMessages<{
+        id?: string;
+        type: string;
+        success?: boolean;
+        error?: string;
+      }>();
+      expect(msgs).toHaveLength(1);
+      expect(msgs[0].type).toBe("error");
+      expect(msgs[0].id).toBe("obs-no-hierarchy");
+      expect(msgs[0].success).toBe(false);
+      expect(msgs[0].error).toBe(
+        "Observation request failed for emulator-5554: Accessibility service unavailable"
+      );
+    });
+
     it("returns error when observation callback throws", async () => {
       server.setOnObservationRequested(async () => {
         throw new Error("Observe failed");

--- a/test/daemon/deviceDataStreamSocketServer.test.ts
+++ b/test/daemon/deviceDataStreamSocketServer.test.ts
@@ -3,6 +3,7 @@ import { Socket } from "node:net";
 import {
   DeviceDataStreamSocketServer,
   type NavigationGraphStreamData,
+  type RequestedObservation,
 } from "../../src/daemon/deviceDataStreamSocketServer";
 import { FakeTimer } from "../fakes/FakeTimer";
 import { FakeSocket } from "../fakes/FakeNetServer";
@@ -58,6 +59,131 @@ describe("DeviceDataStreamSocketServer", () => {
     timer = new FakeTimer();
     server = new TestableDeviceDataStreamSocketServer(timer);
     await server.startFake();
+  });
+
+  describe("request_observation", () => {
+    const requestedObservation = (deviceId: string): RequestedObservation => ({
+      deviceId,
+      observation: {
+        updatedAt: "2026-06-24T00:00:00.000Z",
+        screenSize: { width: 1080, height: 1920 },
+        systemInsets: { top: 0, right: 0, bottom: 0, left: 0 },
+        viewHierarchy: {
+          updatedAt: 123,
+          packageName: "com.example.app",
+          hierarchy: { text: "Home" },
+        } as any,
+      },
+    });
+
+    it("triggers callback, pushes hierarchy update, and acknowledges success", async () => {
+      let requestedDeviceId: string | null | undefined;
+      let requestSignal: AbortSignal | undefined;
+      server.setOnObservationRequested(async request => {
+        requestedDeviceId = request.deviceId;
+        requestSignal = request.signal;
+        return [requestedObservation("emulator-5554")];
+      });
+      const { socket } = server.simulateSubscription({ deviceId: "emulator-5554" });
+
+      await server.processLineForTest(socket, JSON.stringify({
+        id: "obs-1",
+        command: "request_observation",
+        deviceId: "emulator-5554",
+      }));
+
+      expect(requestedDeviceId).toBe("emulator-5554");
+      expect(requestSignal?.aborted).toBe(false);
+      const msgs = socket.getWrittenMessages<{
+        id?: string;
+        type: string;
+        success?: boolean;
+        deviceId?: string;
+        data?: { packageName?: string };
+      }>();
+      expect(msgs).toHaveLength(2);
+      expect(msgs[0].type).toBe("hierarchy_update");
+      expect(msgs[0].deviceId).toBe("emulator-5554");
+      expect(msgs[0].data?.packageName).toBe("com.example.app");
+      expect(msgs[1].type).toBe("subscription_response");
+      expect(msgs[1].id).toBe("obs-1");
+      expect(msgs[1].success).toBe(true);
+    });
+
+    it("returns error when no observation callback is configured", async () => {
+      const socket = new FakeSocket();
+
+      await server.processLineForTest(socket, JSON.stringify({
+        id: "obs-2",
+        command: "request_observation",
+      }));
+
+      const msgs = socket.getWrittenMessages<{
+        id?: string;
+        type: string;
+        success?: boolean;
+        error?: string;
+      }>();
+      expect(msgs).toHaveLength(1);
+      expect(msgs[0].type).toBe("error");
+      expect(msgs[0].id).toBe("obs-2");
+      expect(msgs[0].success).toBe(false);
+      expect(msgs[0].error).toBe("Observation requests are not available");
+    });
+
+    it("returns error when observation callback throws", async () => {
+      server.setOnObservationRequested(async () => {
+        throw new Error("Observe failed");
+      });
+      const socket = new FakeSocket();
+
+      await server.processLineForTest(socket, JSON.stringify({
+        id: "obs-3",
+        command: "request_observation",
+      }));
+
+      const msgs = socket.getWrittenMessages<{
+        id?: string;
+        type: string;
+        success?: boolean;
+        error?: string;
+      }>();
+      expect(msgs).toHaveLength(1);
+      expect(msgs[0].type).toBe("error");
+      expect(msgs[0].id).toBe("obs-3");
+      expect(msgs[0].success).toBe(false);
+      expect(msgs[0].error).toBe("Observe failed");
+    });
+
+    it("returns error and aborts request when observation times out", async () => {
+      let requestSignal: AbortSignal | undefined;
+      server.setOnObservationRequested(request => {
+        requestSignal = request.signal;
+        return new Promise<RequestedObservation[]>(() => {});
+      }, 100);
+      const socket = new FakeSocket();
+
+      const requestPromise = server.processLineForTest(socket, JSON.stringify({
+        id: "obs-4",
+        command: "request_observation",
+      }));
+      await Promise.resolve();
+      timer.advanceTime(100);
+      await requestPromise;
+
+      expect(requestSignal?.aborted).toBe(true);
+      const msgs = socket.getWrittenMessages<{
+        id?: string;
+        type: string;
+        success?: boolean;
+        error?: string;
+      }>();
+      expect(msgs).toHaveLength(1);
+      expect(msgs[0].type).toBe("error");
+      expect(msgs[0].id).toBe("obs-4");
+      expect(msgs[0].success).toBe(false);
+      expect(msgs[0].error).toBe("Observation request timed out after 100ms");
+    });
   });
 
   describe("request_navigation_graph", () => {


### PR DESCRIPTION
## Summary

- Implement `request_observation` for the observation stream socket protocol
- Add a daemon callback that runs `RealObserveScreen` for requested pooled devices
- Add timeout/error handling and focused socket protocol tests

Fixes #2447

## Testing

- `bun test test/daemon/deviceDataStreamSocketServer.test.ts`
- `bun run lint`
- `bun run build`
