### PR TITLE
Fix stale device pool pruning

### DIFF
--- a/src/daemon/daemon.ts
+++ b/src/daemon/daemon.ts
@@ -792,9 +792,10 @@ export class Daemon {
           return;
         }
 
-        const bootedDevices = await deviceManager.getBootedDevices("either");
+        const discovery = await deviceManager.getBootedDevicesDetailed("either");
+        const bootedDevices = discovery.devices;
+        const succeededPlatforms = discovery.succeededPlatforms;
         const bootedDeviceIds = new Set(bootedDevices.map(device => device.deviceId));
-        const bootedPlatforms = new Set(bootedDevices.map(device => device.platform));
         const activeRecordings = await listActiveVideoRecordings();
 
         const missingByDevice = new Map<string, string[]>();
@@ -803,10 +804,14 @@ export class Daemon {
           candidateDeviceIds.add(recording.deviceId);
         }
         for (const device of this.devicePool.getAllDevices()) {
-          if (device.status === "idle" && bootedDeviceIds.size > 0 && !bootedPlatforms.has(device.platform)) {
+          // Skip idle devices on platforms whose discovery failed or was
+          // unavailable this poll — a partial discovery cannot confirm they
+          // disconnected, so counting misses would risk dropping a healthy
+          // idle device.
+          if (device.status === "idle" && !succeededPlatforms.has(device.platform)) {
             logger.warn(
               `[DisconnectMonitor] Skipping idle ${device.platform} device ${device.id}: ` +
-              "no devices for that platform appeared in a partial discovery result"
+              `${device.platform} discovery did not succeed this poll`
             );
             this.deviceDisconnectMisses.delete(device.id);
             continue;

--- a/src/daemon/daemon.ts
+++ b/src/daemon/daemon.ts
@@ -794,6 +794,7 @@ export class Daemon {
 
         const bootedDevices = await deviceManager.getBootedDevices("either");
         const bootedDeviceIds = new Set(bootedDevices.map(device => device.deviceId));
+        const bootedPlatforms = new Set(bootedDevices.map(device => device.platform));
         const activeRecordings = await listActiveVideoRecordings();
 
         const missingByDevice = new Map<string, string[]>();
@@ -802,6 +803,14 @@ export class Daemon {
           candidateDeviceIds.add(recording.deviceId);
         }
         for (const device of this.devicePool.getAllDevices()) {
+          if (device.status === "idle" && bootedDeviceIds.size > 0 && !bootedPlatforms.has(device.platform)) {
+            logger.warn(
+              `[DisconnectMonitor] Skipping idle ${device.platform} device ${device.id}: ` +
+              "no devices for that platform appeared in a partial discovery result"
+            );
+            this.deviceDisconnectMisses.delete(device.id);
+            continue;
+          }
           candidateDeviceIds.add(device.id);
         }
         for (const deviceId of this.sessionManager.getAssignedDevices()) {

--- a/src/daemon/daemon.ts
+++ b/src/daemon/daemon.ts
@@ -801,6 +801,9 @@ export class Daemon {
         for (const recording of activeRecordings) {
           candidateDeviceIds.add(recording.deviceId);
         }
+        for (const device of this.devicePool.getAllDevices()) {
+          candidateDeviceIds.add(device.id);
+        }
         for (const deviceId of this.sessionManager.getAssignedDevices()) {
           candidateDeviceIds.add(deviceId);
         }
@@ -871,6 +874,7 @@ export class Daemon {
             await this.cancelAndReleaseSession(sessionId);
           }
 
+          await this.devicePool.removeDevice(deviceId);
           this.deviceDisconnectMisses.delete(deviceId);
         }
       } catch (error) {

--- a/src/daemon/devicePool.ts
+++ b/src/daemon/devicePool.ts
@@ -183,9 +183,10 @@ export class DevicePool {
       let addedCount = 0;
       let removedCount = 0;
       const bootedDeviceIds = new Set(bootedDevices.map(device => device.deviceId));
+      const bootedPlatforms = new Set(bootedDevices.map(device => device.platform));
 
       perf.startOperation("poolUpdate");
-      removedCount = await this.removeDevicesMissingFrom(bootedDeviceIds);
+      removedCount = await this.removeDevicesMissingFrom(bootedDeviceIds, bootedPlatforms);
 
       for (const device of bootedDevices) {
         const pooledDevice = this.devices.get(device.deviceId);
@@ -259,6 +260,7 @@ export class DevicePool {
       iosVersion: device.iosVersion,
     });
     this.deviceSessionStarts.set(device.deviceId, now);
+    this.refreshMissingDeviceMisses.delete(device.deviceId);
     await this.setDeviceSessionTracking(device.deviceId, now);
 
     logger.info(`Added device ${device.deviceId} to pool`);
@@ -288,7 +290,10 @@ export class DevicePool {
     logger.info(`Removed device ${deviceId} from pool and cleared cached data`);
   }
 
-  private async removeDevicesMissingFrom(bootedDeviceIds: Set<string>): Promise<number> {
+  private async removeDevicesMissingFrom(
+    bootedDeviceIds: Set<string>,
+    bootedPlatforms: Set<Platform>
+  ): Promise<number> {
     let removedCount = 0;
 
     for (const device of Array.from(this.devices.values())) {
@@ -302,11 +307,11 @@ export class DevicePool {
         );
         continue;
       }
-      if (bootedDeviceIds.size === 0) {
+      if (!bootedPlatforms.has(device.platform)) {
         const misses = (this.refreshMissingDeviceMisses.get(device.id) ?? 0) + 1;
         this.refreshMissingDeviceMisses.set(device.id, misses);
         logger.warn(
-          `Device ${device.id} missing from empty refresh discovery ` +
+          `Device ${device.id} missing from ${device.platform} refresh discovery ` +
           `(miss ${misses}/${this.REFRESH_MISSING_DEVICE_MISS_THRESHOLD}); retaining until confirmed`
         );
         if (misses < this.REFRESH_MISSING_DEVICE_MISS_THRESHOLD) {

--- a/src/daemon/devicePool.ts
+++ b/src/daemon/devicePool.ts
@@ -174,8 +174,9 @@ export class DevicePool {
       logger.info(`Environment: ANDROID_HOME=${androidHome}, ANDROID_SDK_ROOT=${androidSdkRoot}`);
 
       perf.startOperation("deviceDiscovery");
-      const bootedDevices = await this.deviceManager.getBootedDevices("either");
+      const discovery = await this.deviceManager.getBootedDevicesDetailed("either");
       perf.endOperation("deviceDiscovery");
+      const bootedDevices = discovery.devices;
       const discoveryTime = this.timer.now() - startTime;
       logger.info(`Device discovery completed in ${discoveryTime}ms, found ${bootedDevices.length} devices`);
 
@@ -186,7 +187,11 @@ export class DevicePool {
       const bootedPlatforms = new Set(bootedDevices.map(device => device.platform));
 
       perf.startOperation("poolUpdate");
-      removedCount = await this.removeDevicesMissingFrom(bootedDeviceIds, bootedPlatforms);
+      removedCount = await this.removeDevicesMissingFrom(
+        bootedDeviceIds,
+        bootedPlatforms,
+        discovery.succeededPlatforms
+      );
 
       for (const device of bootedDevices) {
         const pooledDevice = this.devices.get(device.deviceId);
@@ -292,7 +297,8 @@ export class DevicePool {
 
   private async removeDevicesMissingFrom(
     bootedDeviceIds: Set<string>,
-    bootedPlatforms: Set<Platform>
+    bootedPlatforms: Set<Platform>,
+    succeededPlatforms: Set<Platform>
   ): Promise<number> {
     let removedCount = 0;
 
@@ -307,6 +313,20 @@ export class DevicePool {
         );
         continue;
       }
+      // Discovery for this platform failed or was unavailable this refresh, so
+      // we cannot confirm the device is gone. Retain it rather than pruning a
+      // device that may still be running (e.g. iOS simctl failed while Android
+      // discovery succeeded, or all tooling was transiently unreachable).
+      if (!succeededPlatforms.has(device.platform)) {
+        this.refreshMissingDeviceMisses.delete(device.id);
+        logger.warn(
+          `Device ${device.id} retained: ${device.platform} discovery did not succeed this refresh`
+        );
+        continue;
+      }
+      // Discovery succeeded but returned no devices for this platform at all.
+      // Tolerate brief reboot/boot races with a small consecutive-miss threshold
+      // before removing.
       if (!bootedPlatforms.has(device.platform)) {
         const misses = (this.refreshMissingDeviceMisses.get(device.id) ?? 0) + 1;
         this.refreshMissingDeviceMisses.set(device.id, misses);

--- a/src/daemon/devicePool.ts
+++ b/src/daemon/devicePool.ts
@@ -156,7 +156,9 @@ export class DevicePool {
    * This handles race conditions during daemon startup where device discovery
    * may not have completed before tests begin.
    *
-   * Only adds new devices - does not remove existing devices that may be assigned.
+   * Adds newly booted devices and prunes unassigned devices that are no longer
+   * booted. Assigned devices are kept so active sessions can be cancelled and
+   * released by the disconnect monitor.
    */
   async refreshDevices(): Promise<number> {
     const startTime = this.timer.now();
@@ -177,10 +179,15 @@ export class DevicePool {
 
       const now = this.seedLastUsedAt(this.timer.now());
       let addedCount = 0;
+      let removedCount = 0;
+      const bootedDeviceIds = new Set(bootedDevices.map(device => device.deviceId));
 
       perf.startOperation("poolUpdate");
+      removedCount = await this.removeDevicesMissingFrom(bootedDeviceIds);
+
       for (const device of bootedDevices) {
-        if (!this.devices.has(device.deviceId)) {
+        const pooledDevice = this.devices.get(device.deviceId);
+        if (!pooledDevice) {
           this.devices.set(device.deviceId, {
             id: device.deviceId,
             name: device.name,
@@ -196,12 +203,19 @@ export class DevicePool {
           await this.setDeviceSessionTracking(device.deviceId, now);
           addedCount++;
           logger.info(`Added device ${device.deviceId} to pool during refresh`);
+        } else {
+          pooledDevice.name = device.name;
+          pooledDevice.platform = device.platform;
+          pooledDevice.iosVersion = device.iosVersion;
         }
       }
       perf.endOperation("poolUpdate");
 
-      if (addedCount > 0) {
-        logger.info(`Device pool refreshed: added ${addedCount} new devices (total: ${this.devices.size})`);
+      if (addedCount > 0 || removedCount > 0) {
+        logger.info(
+          `Device pool refreshed: added ${addedCount}, removed ${removedCount} ` +
+          `(total: ${this.devices.size})`
+        );
       } else if (bootedDevices.length === 0) {
         logger.warn("No devices found during pool refresh. Is an emulator running?");
         logger.warn("Ensure 'adb devices' returns connected devices in the daemon process environment.");
@@ -263,8 +277,32 @@ export class DevicePool {
 
     this.devices.delete(deviceId);
     this.deviceSessionStarts.delete(deviceId);
+    if (this.lastReleasedDeviceId === deviceId) {
+      this.lastReleasedDeviceId = null;
+    }
     await this.clearDeviceSessionCache(deviceId);
     logger.info(`Removed device ${deviceId} from pool and cleared cached data`);
+  }
+
+  private async removeDevicesMissingFrom(bootedDeviceIds: Set<string>): Promise<number> {
+    let removedCount = 0;
+
+    for (const device of Array.from(this.devices.values())) {
+      if (bootedDeviceIds.has(device.id)) {
+        continue;
+      }
+      if (device.sessionId) {
+        logger.warn(
+          `Device ${device.id} is no longer booted but is assigned to session ${device.sessionId}; keeping until session cleanup`
+        );
+        continue;
+      }
+
+      await this.removeDevice(device.id);
+      removedCount++;
+    }
+
+    return removedCount;
   }
 
   /**
@@ -759,18 +797,20 @@ export class DevicePool {
 
       // If no devices available and pool is empty, try to refresh
       // This handles race conditions during daemon startup
-      if (!device && (this.devices.size === 0 || totalDevices === 0)) {
-        const refreshReason = this.devices.size === 0 ? "empty pool" : "platform pool empty";
+      const busyDevicesBeforeRefresh = candidates.filter(d => d.status === "busy").length;
+      if (!device && (this.devices.size === 0 || totalDevices === 0 || busyDevicesBeforeRefresh === 0)) {
+        const refreshReason = this.devices.size === 0
+          ? "empty pool"
+          : totalDevices === 0
+            ? "platform pool empty"
+            : "no idle usable devices";
         logger.info(`[DevicePool] Auto-refreshing devices due to ${refreshReason}...`);
         const addedCount = await this.refreshDevices();
         logger.info(`[DEVICE-POOL-DEBUG] Auto-refresh added ${addedCount} devices`);
-        if (addedCount > 0) {
-          // Try again after refresh
-          candidates = this.getDevicesByPlatform(platform);
-          totalDevices = candidates.length;
-          device = candidates.find(d => d.status === "idle");
-          logger.info(`[DEVICE-POOL-DEBUG] After refresh, found idle device = ${device?.id || "none"}`);
-        }
+        candidates = this.getDevicesByPlatform(platform);
+        totalDevices = candidates.length;
+        device = candidates.find(d => d.status === "idle");
+        logger.info(`[DEVICE-POOL-DEBUG] After refresh, found idle device = ${device?.id || "none"}`);
       }
 
       logger.info(`[DEVICE-POOL-DEBUG] tryAssignDevice: totalDevices = ${totalDevices}`);
@@ -834,16 +874,19 @@ export class DevicePool {
         }
       }
 
-      if (!device && (this.devices.size === 0 || totalDevices === 0)) {
-        const refreshReason = this.devices.size === 0 ? "empty pool" : "criteria pool empty";
+      const busyDevicesBeforeRefresh = candidates.filter(d => d.status === "busy").length;
+      if (!device && (this.devices.size === 0 || totalDevices === 0 || busyDevicesBeforeRefresh === 0)) {
+        const refreshReason = this.devices.size === 0
+          ? "empty pool"
+          : totalDevices === 0
+            ? "criteria pool empty"
+            : "no idle usable devices";
         logger.info(`[DevicePool] Auto-refreshing devices due to ${refreshReason}...`);
         const addedCount = await this.refreshDevices();
         logger.info(`[DevicePool] Auto-refresh added ${addedCount} devices`);
-        if (addedCount > 0) {
-          candidates = this.getDevicesMatchingCriteria(criteria);
-          totalDevices = candidates.length;
-          device = candidates.find(d => d.status === "idle");
-        }
+        candidates = this.getDevicesMatchingCriteria(criteria);
+        totalDevices = candidates.length;
+        device = candidates.find(d => d.status === "idle");
       }
 
       if (!device) {

--- a/src/daemon/devicePool.ts
+++ b/src/daemon/devicePool.ts
@@ -80,6 +80,7 @@ export class DevicePool {
   private lastUsedAtMarker = 0;
   private lastReleasedDeviceId: string | null = null;
   private readonly mcpSessionAutolockMap: Map<string, string> = new Map();
+  private readonly refreshMissingDeviceMisses: Map<string, number> = new Map();
   private daemonSessionId: string;
   private installedAppsRepository: InstalledAppsStore;
   private deviceManager: PlatformDeviceManager;
@@ -88,6 +89,7 @@ export class DevicePool {
 
   // Max consecutive errors before marking device as failed
   private readonly MAX_DEVICE_ERRORS = 5;
+  private readonly REFRESH_MISSING_DEVICE_MISS_THRESHOLD = 2;
 
   // Device wait configuration for parallel test execution
   private readonly DEVICE_WAIT_TIMEOUT_MS = 60000; // 60 seconds max wait
@@ -200,6 +202,7 @@ export class DevicePool {
             iosVersion: device.iosVersion,
           });
           this.deviceSessionStarts.set(device.deviceId, now);
+          this.refreshMissingDeviceMisses.delete(device.deviceId);
           await this.setDeviceSessionTracking(device.deviceId, now);
           addedCount++;
           logger.info(`Added device ${device.deviceId} to pool during refresh`);
@@ -277,6 +280,7 @@ export class DevicePool {
 
     this.devices.delete(deviceId);
     this.deviceSessionStarts.delete(deviceId);
+    this.refreshMissingDeviceMisses.delete(deviceId);
     if (this.lastReleasedDeviceId === deviceId) {
       this.lastReleasedDeviceId = null;
     }
@@ -289,6 +293,7 @@ export class DevicePool {
 
     for (const device of Array.from(this.devices.values())) {
       if (bootedDeviceIds.has(device.id)) {
+        this.refreshMissingDeviceMisses.delete(device.id);
         continue;
       }
       if (device.sessionId) {
@@ -296,6 +301,17 @@ export class DevicePool {
           `Device ${device.id} is no longer booted but is assigned to session ${device.sessionId}; keeping until session cleanup`
         );
         continue;
+      }
+      if (bootedDeviceIds.size === 0) {
+        const misses = (this.refreshMissingDeviceMisses.get(device.id) ?? 0) + 1;
+        this.refreshMissingDeviceMisses.set(device.id, misses);
+        logger.warn(
+          `Device ${device.id} missing from empty refresh discovery ` +
+          `(miss ${misses}/${this.REFRESH_MISSING_DEVICE_MISS_THRESHOLD}); retaining until confirmed`
+        );
+        if (misses < this.REFRESH_MISSING_DEVICE_MISS_THRESHOLD) {
+          continue;
+        }
       }
 
       await this.removeDevice(device.id);

--- a/src/server/bootedDeviceResources.ts
+++ b/src/server/bootedDeviceResources.ts
@@ -155,18 +155,38 @@ function getPoolDeviceInfo(devicePool: DevicePool | null, deviceId: string): Poo
   };
 }
 
-function summarizeLivePoolStatus(devices: BootedDeviceInfo[]): PoolStatusSummary {
+function summarizePoolStatus(
+  devicePool: DevicePool,
+  discoveredDevices: BootedDeviceInfo[],
+  succeededPlatforms: Set<Platform>
+): PoolStatusSummary {
   let idle = 0;
   let assigned = 0;
   let error = 0;
 
-  for (const device of devices) {
-    if (device.poolStatus === "idle") {
+  const tally = (status: PoolDeviceStatus | undefined): void => {
+    if (status === "idle") {
       idle++;
-    } else if (device.poolStatus === "assigned") {
+    } else if (status === "assigned") {
       assigned++;
-    } else if (device.poolStatus === "error") {
+    } else if (status === "error") {
       error++;
+    }
+  };
+
+  // For successfully-discovered platforms, count from the live booted list so
+  // phantom (shut-down) pool entries are excluded.
+  for (const device of discoveredDevices) {
+    if (succeededPlatforms.has(device.platform)) {
+      tally(device.poolStatus);
+    }
+  }
+
+  // For platforms whose discovery failed/was unavailable, keep the pool's own
+  // tracked counts — we cannot confirm which of those entries are phantom.
+  for (const pooled of devicePool.getAllDevices()) {
+    if (!succeededPlatforms.has(pooled.platform)) {
+      tally(pooled.status === "busy" ? "assigned" : pooled.status);
     }
   }
 
@@ -261,12 +281,17 @@ async function getBootedDevicesForPlatforms(platforms: Platform[]): Promise<Boot
     }
   }
 
+  const succeededPlatforms = new Set<Platform>();
+
   try {
     // Fetch Android booted devices if requested
     if (platforms.includes("android")) {
       try {
-        const androidDevices = await PlatformDeviceManagerFactory.getInstance().getBootedDevices("android");
-        for (const device of androidDevices) {
+        const androidDiscovery = await PlatformDeviceManagerFactory.getInstance().getBootedDevicesDetailed("android");
+        for (const discoveredPlatform of androidDiscovery.succeededPlatforms) {
+          succeededPlatforms.add(discoveredPlatform);
+        }
+        for (const device of androidDiscovery.devices) {
           devices.push(
             toBootedDeviceInfo(
               device,
@@ -284,8 +309,11 @@ async function getBootedDevicesForPlatforms(platforms: Platform[]): Promise<Boot
     // Fetch iOS booted simulators if requested
     if (platforms.includes("ios")) {
       try {
-        const iosDevices = await PlatformDeviceManagerFactory.getInstance().getBootedDevices("ios");
-        for (const device of iosDevices) {
+        const iosDiscovery = await PlatformDeviceManagerFactory.getInstance().getBootedDevicesDetailed("ios");
+        for (const discoveredPlatform of iosDiscovery.succeededPlatforms) {
+          succeededPlatforms.add(discoveredPlatform);
+        }
+        for (const device of iosDiscovery.devices) {
           devices.push(
             toBootedDeviceInfo(
               device,
@@ -335,8 +363,8 @@ async function getBootedDevicesForPlatforms(platforms: Platform[]): Promise<Boot
 
   const virtualCount = devices.filter(device => device.isVirtual).length;
   const physicalCount = devices.length - virtualCount;
-  if (poolStatus) {
-    poolStatus = summarizeLivePoolStatus(devices);
+  if (poolStatus && devicePool) {
+    poolStatus = summarizePoolStatus(devicePool, devices, succeededPlatforms);
   }
 
   return {

--- a/src/server/bootedDeviceResources.ts
+++ b/src/server/bootedDeviceResources.ts
@@ -155,6 +155,30 @@ function getPoolDeviceInfo(devicePool: DevicePool | null, deviceId: string): Poo
   };
 }
 
+function summarizeLivePoolStatus(devices: BootedDeviceInfo[]): PoolStatusSummary {
+  let idle = 0;
+  let assigned = 0;
+  let error = 0;
+
+  for (const device of devices) {
+    if (device.poolStatus === "idle") {
+      idle++;
+    } else if (device.poolStatus === "assigned") {
+      assigned++;
+    } else if (device.poolStatus === "error") {
+      error++;
+    }
+  }
+
+  return {
+    enabled: true,
+    idle,
+    assigned,
+    error,
+    total: idle + assigned + error
+  };
+}
+
 function toDeviceSessionInfo(session: Session): DeviceSessionInfo {
   return {
     sessionId: session.sessionId,
@@ -213,13 +237,12 @@ async function getBootedDevicesForPlatforms(platforms: Platform[]): Promise<Boot
   if (daemonState.isInitialized()) {
     try {
       devicePool = daemonState.getDevicePool();
-      const stats = devicePool.getStats();
       poolStatus = {
         enabled: true,
-        idle: stats.idle,
-        assigned: stats.assigned,
-        error: stats.error,
-        total: stats.total
+        idle: 0,
+        assigned: 0,
+        error: 0,
+        total: 0
       };
     } catch (error) {
       logger.warn(`[BootedDeviceResources] Failed to read device pool status: ${error}`);
@@ -312,6 +335,9 @@ async function getBootedDevicesForPlatforms(platforms: Platform[]): Promise<Boot
 
   const virtualCount = devices.filter(device => device.isVirtual).length;
   const physicalCount = devices.length - virtualCount;
+  if (poolStatus) {
+    poolStatus = summarizeLivePoolStatus(devices);
+  }
 
   return {
     totalCount: devices.length,

--- a/src/server/utilityTools.ts
+++ b/src/server/utilityTools.ts
@@ -90,6 +90,14 @@ export function registerUtilityTools() {
         if (!pooledDevice) {
           throw new ActionableError(`Device '${args.deviceId}' not found in device pool`);
         }
+        if (pooledDevice.sessionId && pooledDevice.sessionId !== args.sessionUuid) {
+          const owningSession = sessionManager.getSession(pooledDevice.sessionId);
+          if (owningSession) {
+            throw new ActionableError(
+              `Device '${args.deviceId}' is already assigned to session ${pooledDevice.sessionId}`
+            );
+          }
+        }
         // Release any existing session for this sessionUuid before rebinding
         const existing = sessionManager.getSession(args.sessionUuid);
         if (existing && existing.assignedDevice !== args.deviceId) {
@@ -97,7 +105,12 @@ export function registerUtilityTools() {
           await devicePool.releaseDevice(existing.assignedDevice);
         }
         if (!existing || existing.assignedDevice !== args.deviceId) {
-          await devicePool.bindOrReuseDeviceSession(args.sessionUuid, args.deviceId, args.platform);
+          const boundSession = await devicePool.bindOrReuseDeviceSession(args.sessionUuid, args.deviceId, args.platform);
+          if (boundSession !== args.sessionUuid) {
+            throw new ActionableError(
+              `Device '${args.deviceId}' is already assigned to session ${boundSession}`
+            );
+          }
         }
         logger.info(`[setActiveDevice] Bound device ${args.deviceId} to session ${args.sessionUuid}`);
       } else {

--- a/src/server/utilityTools.ts
+++ b/src/server/utilityTools.ts
@@ -82,7 +82,11 @@ export function registerUtilityTools() {
         // Session-scoped: bind the specific requested device to this session
         const sessionManager = DaemonState.getInstance().getSessionManager();
         const devicePool = DaemonState.getInstance().getDevicePool();
-        const pooledDevice = devicePool.getDevice(args.deviceId);
+        let pooledDevice = devicePool.getDevice(args.deviceId);
+        if (!pooledDevice) {
+          await devicePool.refreshDevices();
+          pooledDevice = devicePool.getDevice(args.deviceId);
+        }
         if (!pooledDevice) {
           throw new ActionableError(`Device '${args.deviceId}' not found in device pool`);
         }

--- a/src/server/utilityTools.ts
+++ b/src/server/utilityTools.ts
@@ -97,7 +97,7 @@ export function registerUtilityTools() {
           await devicePool.releaseDevice(existing.assignedDevice);
         }
         if (!existing || existing.assignedDevice !== args.deviceId) {
-          await sessionManager.createSession(args.sessionUuid, args.deviceId, args.platform);
+          await devicePool.bindOrReuseDeviceSession(args.sessionUuid, args.deviceId, args.platform);
         }
         logger.info(`[setActiveDevice] Bound device ${args.deviceId} to session ${args.sessionUuid}`);
       } else {

--- a/src/utils/android-cmdline-tools/AndroidEmulatorClient.ts
+++ b/src/utils/android-cmdline-tools/AndroidEmulatorClient.ts
@@ -618,8 +618,23 @@ export class AndroidEmulatorClient implements AndroidEmulator {
    * @returns Promise with array of running emulator info
    */
   async getBootedDevices(onlyEmulators: boolean = false): Promise<BootedDevice[]> {
-    const perf = createGlobalPerformanceTracker();
     try {
+      return await this.getBootedDevicesChecked(onlyEmulators);
+    } catch (error) {
+      logger.debug(`[DeviceListTimeout] Failed to get running emulators: ${error}`);
+      return [];
+    }
+  }
+
+  /**
+   * Like {@link getBootedDevices} but rethrows discovery failures (e.g. adb
+   * unreachable) instead of swallowing them into an empty list. Callers that
+   * must distinguish "no emulators are booted" from "adb discovery failed"
+   * should use this.
+   */
+  async getBootedDevicesChecked(onlyEmulators: boolean = false): Promise<BootedDevice[]> {
+    const perf = createGlobalPerformanceTracker();
+    {
       const adb = this.adbFactory.create(null);
       perf.startOperation("adbDeviceScan");
       const devices = await adb.getBootedAndroidDevices();
@@ -722,9 +737,6 @@ export class AndroidEmulatorClient implements AndroidEmulator {
       perf.endOperation("avdNameResolution");
 
       return runningDevices;
-    } catch (error) {
-      logger.debug(`[DeviceListTimeout] Failed to get running emulators: ${error}`);
-      return [];
     }
   }
 

--- a/src/utils/deviceUtils.ts
+++ b/src/utils/deviceUtils.ts
@@ -1,9 +1,23 @@
 import { ChildProcess } from "child_process";
-import { DeviceInfo, ActionableError, SomePlatform, BootedDevice } from "../models";
+import { DeviceInfo, ActionableError, SomePlatform, BootedDevice, Platform } from "../models";
 import { defaultAdbClientFactory } from "./android-cmdline-tools/AdbClientFactory";
 import type { AdbExecutor } from "./android-cmdline-tools/interfaces/AdbExecutor";
 import { SimCtlClient } from "./ios-cmdline-tools/SimCtlClient";
 import { AndroidEmulatorClient } from "./android-cmdline-tools/AndroidEmulatorClient";
+import { logger } from "./logger";
+
+/**
+ * Result of a discovery sweep that distinguishes per-platform success.
+ *
+ * `succeededPlatforms` only contains platforms whose discovery tooling was
+ * reachable and completed (even if it found zero devices). A platform absent
+ * from the set had a failed or unavailable discovery this sweep, so its tracked
+ * devices must not be treated as gone (no pruning / disconnect detection).
+ */
+export interface BootedDeviceDiscovery {
+  devices: BootedDevice[];
+  succeededPlatforms: Set<Platform>;
+}
 
 /**
  * Interface for device utility operations
@@ -30,6 +44,16 @@ export interface PlatformDeviceManager {
    * @returns Promise with array of booted device information
    */
   getBootedDevices(platform: SomePlatform): Promise<BootedDevice[]>;
+
+  /**
+   * Get all currently booted devices along with which platforms were
+   * successfully discovered. Unlike {@link getBootedDevices}, a platform whose
+   * discovery tooling failed or was unavailable is reported as un-discovered
+   * rather than collapsing into an empty device list, so callers can avoid
+   * pruning devices on a transient/partial discovery failure.
+   * @param platform - Target platform ("android", "ios", or "either" for both)
+   */
+  getBootedDevicesDetailed(platform: SomePlatform): Promise<BootedDeviceDiscovery>;
 
   /**
    * Start a device (emulator or simulator)
@@ -162,6 +186,50 @@ export class MultiPlatformDeviceManager implements PlatformDeviceManager {
         const emulators = await this.emulator.getBootedDevices();
         const simulators = await this.getBootedIosDevicesIfAvailable();
         return [...emulators, ...simulators];
+    }
+  }
+
+  async getBootedDevicesDetailed(platform: SomePlatform): Promise<BootedDeviceDiscovery> {
+    const devices: BootedDevice[] = [];
+    const succeededPlatforms = new Set<Platform>();
+
+    if (platform === "android" || platform === "either") {
+      try {
+        const emulators = await this.emulator.getBootedDevicesChecked();
+        devices.push(...emulators);
+        succeededPlatforms.add("android");
+      } catch (error) {
+        logger.warn(
+          `[DeviceManager] Android booted-device discovery failed; retaining tracked Android devices: ${error}`
+        );
+      }
+    }
+
+    if (platform === "ios" || platform === "either") {
+      const ios = await this.discoverBootedIosDevices();
+      if (ios.succeeded) {
+        devices.push(...ios.devices);
+        succeededPlatforms.add("ios");
+      }
+    }
+
+    return { devices, succeededPlatforms };
+  }
+
+  private async discoverBootedIosDevices(): Promise<{ devices: BootedDevice[]; succeeded: boolean }> {
+    // iOS tooling that is genuinely unavailable on this host cannot confirm a
+    // device is gone, so report it as un-discovered rather than empty.
+    if (!(await this.canDiscoverIosLocallyOrViaHostControl())) {
+      return { devices: [], succeeded: false };
+    }
+    try {
+      const devices = await this.simctl.getBootedSimulatorsChecked();
+      return { devices, succeeded: true };
+    } catch (error) {
+      logger.warn(
+        `[DeviceManager] iOS booted-device discovery failed; retaining tracked iOS devices: ${error}`
+      );
+      return { devices: [], succeeded: false };
     }
   }
 

--- a/src/utils/ios-cmdline-tools/SimCtlClient.ts
+++ b/src/utils/ios-cmdline-tools/SimCtlClient.ts
@@ -674,33 +674,42 @@ export class SimCtlClient implements SimCtl {
    */
   async getBootedSimulators(): Promise<BootedDevice[]> {
     try {
-      const simulatorList = await this.listSimulators();
-      logger.debug(`Found simulator list: ${simulatorList}`);
-      const bootedDevices: BootedDevice[] = [];
-
-      // Extract booted devices from all runtime versions
-      for (const [runtimeId, runtimeDevices] of Object.entries(simulatorList.devices)) {
-        for (const device of runtimeDevices) {
-          if (device.isAvailable && device.state === "Booted") {
-            const iosVersion = normalizeIosVersion(runtimeId, device.os_version);
-            bootedDevices.push({
-              name: device.name,
-              platform: "ios",
-              deviceId: device.udid,
-              iosVersion,
-              osVersion: iosVersion,
-              formFactor: inferIosFormFactor(device.deviceTypeIdentifier),
-            } as BootedDevice);
-          }
-        }
-      }
-
-      bootedDevices.sort((a, b) => a.deviceId.localeCompare(b.deviceId));
-      return bootedDevices;
+      return await this.getBootedSimulatorsChecked();
     } catch (error) {
       logger.debug(`Failed to get booted iOS devices: ${error}`);
       return [];
     }
+  }
+
+  /**
+   * Like {@link getBootedSimulators} but rethrows discovery failures instead of
+   * swallowing them into an empty list. Callers that must distinguish "no
+   * simulators are booted" from "simctl discovery failed" should use this.
+   */
+  async getBootedSimulatorsChecked(): Promise<BootedDevice[]> {
+    const simulatorList = await this.listSimulators();
+    logger.debug(`Found simulator list: ${simulatorList}`);
+    const bootedDevices: BootedDevice[] = [];
+
+    // Extract booted devices from all runtime versions
+    for (const [runtimeId, runtimeDevices] of Object.entries(simulatorList.devices)) {
+      for (const device of runtimeDevices) {
+        if (device.isAvailable && device.state === "Booted") {
+          const iosVersion = normalizeIosVersion(runtimeId, device.os_version);
+          bootedDevices.push({
+            name: device.name,
+            platform: "ios",
+            deviceId: device.udid,
+            iosVersion,
+            osVersion: iosVersion,
+            formFactor: inferIosFormFactor(device.deviceTypeIdentifier),
+          } as BootedDevice);
+        }
+      }
+    }
+
+    bootedDevices.sort((a, b) => a.deviceId.localeCompare(b.deviceId));
+    return bootedDevices;
   }
 
   /**

--- a/test/daemon/devicePool.test.ts
+++ b/test/daemon/devicePool.test.ts
@@ -103,10 +103,15 @@ describe("DevicePool", () => {
           getBootedSimulators: async () => {
             simctlBootedCalls++;
             throw new Error("simctl should not be queried");
+          },
+          getBootedSimulatorsChecked: async () => {
+            simctlBootedCalls++;
+            throw new Error("simctl should not be queried");
           }
         } as unknown as SimCtlClient;
         const fakeEmulator = {
-          getBootedDevices: async () => [androidDevice]
+          getBootedDevices: async () => [androidDevice],
+          getBootedDevicesChecked: async () => [androidDevice]
         } as unknown as AndroidEmulatorClient;
         const manager = new MultiPlatformDeviceManager(
           new FakeAdbClient() as unknown as AdbClient,
@@ -137,10 +142,14 @@ describe("DevicePool", () => {
           isAvailable: async () => true,
           getBootedSimulators: async () => {
             throw new Error("host-control simctl unavailable");
+          },
+          getBootedSimulatorsChecked: async () => {
+            throw new Error("host-control simctl unavailable");
           }
         } as unknown as SimCtlClient;
         const fakeEmulator = {
-          getBootedDevices: async () => [androidDevice]
+          getBootedDevices: async () => [androidDevice],
+          getBootedDevicesChecked: async () => [androidDevice]
         } as unknown as AndroidEmulatorClient;
         const manager = new MultiPlatformDeviceManager(
           new FakeAdbClient() as unknown as AdbClient,
@@ -222,6 +231,55 @@ describe("DevicePool", () => {
       expect(devicePool.getDevice("sim-old")?.status).toBe("idle");
       expect(devicePool.getDevice("emulator-5554")).not.toBeNull();
       expect(devicePool.getTotalDeviceCount()).toBe(2);
+    });
+
+    test("retains iOS devices across repeated refreshes when iOS discovery keeps failing", async () => {
+      await devicePool.initializeWithDevices([createBootedDevice("sim-old", "ios", "iPhone 15")]);
+      // Android discovery succeeds, but iOS discovery fails this and every refresh.
+      fakeDeviceManager.bootedDevices = [createBootedDevice("emulator-5554", "android", "Pixel 8")];
+      fakeDeviceManager.failedPlatforms = new Set<Platform>(["ios"]);
+
+      // Even past the miss threshold, a device on a platform whose discovery
+      // failed must never be pruned (it may still be running).
+      await devicePool.refreshDevices();
+      await devicePool.refreshDevices();
+      await devicePool.refreshDevices();
+
+      expect(devicePool.getDevice("sim-old")?.status).toBe("idle");
+      expect(devicePool.getDevice("emulator-5554")).not.toBeNull();
+      expect(devicePool.getTotalDeviceCount()).toBe(2);
+    });
+
+    test("retains all devices when discovery fails for every platform", async () => {
+      await devicePool.initializeWithDevices([
+        createBootedDevice("emulator-5554", "android", "Pixel 8"),
+        createBootedDevice("sim-old", "ios", "iPhone 15")
+      ]);
+      fakeDeviceManager.bootedDevices = [];
+      fakeDeviceManager.failedPlatforms = new Set<Platform>(["android", "ios"]);
+
+      await devicePool.refreshDevices();
+      await devicePool.refreshDevices();
+
+      expect(devicePool.getDevice("emulator-5554")).not.toBeNull();
+      expect(devicePool.getDevice("sim-old")).not.toBeNull();
+      expect(devicePool.getTotalDeviceCount()).toBe(2);
+    });
+
+    test("prunes iOS devices once iOS discovery succeeds and confirms them gone", async () => {
+      await devicePool.initializeWithDevices([createBootedDevice("sim-old", "ios", "iPhone 15")]);
+      // iOS discovery now succeeds but reports zero booted simulators.
+      fakeDeviceManager.bootedDevices = [createBootedDevice("emulator-5554", "android", "Pixel 8")];
+      fakeDeviceManager.failedPlatforms = new Set<Platform>();
+
+      // Genuine empties are tolerated for one refresh, then removed.
+      await devicePool.refreshDevices();
+      expect(devicePool.getDevice("sim-old")?.status).toBe("idle");
+      await devicePool.refreshDevices();
+
+      expect(devicePool.getDevice("sim-old")).toBeNull();
+      expect(devicePool.getDevice("emulator-5554")).not.toBeNull();
+      expect(devicePool.getTotalDeviceCount()).toBe(1);
     });
 
     test("recomputes candidates after refresh prunes all unavailable error devices", async () => {

--- a/test/daemon/devicePool.test.ts
+++ b/test/daemon/devicePool.test.ts
@@ -212,6 +212,18 @@ describe("DevicePool", () => {
       expect(devicePool.getTotalDeviceCount()).toBe(0);
     });
 
+    test("retains devices on first partial platform discovery miss", async () => {
+      await devicePool.initializeWithDevices([createBootedDevice("sim-old", "ios", "iPhone 15")]);
+      fakeDeviceManager.bootedDevices = [createBootedDevice("emulator-5554", "android", "Pixel 8")];
+
+      const added = await devicePool.refreshDevices();
+
+      expect(added).toBe(1);
+      expect(devicePool.getDevice("sim-old")?.status).toBe("idle");
+      expect(devicePool.getDevice("emulator-5554")).not.toBeNull();
+      expect(devicePool.getTotalDeviceCount()).toBe(2);
+    });
+
     test("recomputes candidates after refresh prunes all unavailable error devices", async () => {
       await devicePool.initializeWithDevices([createBootedDevice("sim-old", "ios", "iPhone 15")]);
       for (let i = 0; i < 5; i++) {
@@ -219,6 +231,7 @@ describe("DevicePool", () => {
       }
       fakeDeviceManager.bootedDevices = [createBootedDevice("emulator-5554", "android", "Pixel 8")];
 
+      await devicePool.refreshDevices();
       await expect(devicePool.assignDeviceToSession("session-1", "ios"))
         .rejects.toThrow(/No devices in pool/);
       expect(devicePool.getDevice("sim-old")).toBeNull();

--- a/test/daemon/devicePool.test.ts
+++ b/test/daemon/devicePool.test.ts
@@ -162,6 +162,45 @@ describe("DevicePool", () => {
         expect(pool.getDevice("emulator-5554")).not.toBeNull();
       });
     });
+
+    test("removes unassigned devices that are no longer booted", async () => {
+      await devicePool.initializeWithDevices([createBootedDevice("sim-old", "ios", "iPhone 15")]);
+      await fakeAppsRepo.upsertInstalledApp("sim-old", 0, "com.test.app", false, Date.now());
+      fakeDeviceManager.bootedDevices = [createBootedDevice("sim-new", "ios", "iPhone 16")];
+
+      const added = await devicePool.refreshDevices();
+
+      expect(added).toBe(1);
+      expect(devicePool.getDevice("sim-old")).toBeNull();
+      expect(devicePool.getDevice("sim-new")).not.toBeNull();
+      expect(devicePool.getTotalDeviceCount()).toBe(1);
+      expect(await fakeAppsRepo.listInstalledApps("sim-old")).toEqual([]);
+    });
+
+    test("keeps missing assigned devices until session cleanup releases them", async () => {
+      await devicePool.initializeWithDevices([createBootedDevice("sim-old", "ios", "iPhone 15")]);
+      await devicePool.assignDeviceToSession("session-1", "ios");
+      fakeDeviceManager.bootedDevices = [createBootedDevice("sim-new", "ios", "iPhone 16")];
+
+      const added = await devicePool.refreshDevices();
+
+      expect(added).toBe(1);
+      expect(devicePool.getDevice("sim-old")?.sessionId).toBe("session-1");
+      expect(devicePool.getDevice("sim-new")?.status).toBe("idle");
+      expect(devicePool.getTotalDeviceCount()).toBe(2);
+    });
+
+    test("recomputes candidates after refresh prunes all unavailable error devices", async () => {
+      await devicePool.initializeWithDevices([createBootedDevice("sim-old", "ios", "iPhone 15")]);
+      for (let i = 0; i < 5; i++) {
+        devicePool.recordDeviceError("sim-old");
+      }
+      fakeDeviceManager.bootedDevices = [];
+
+      await expect(devicePool.assignDeviceToSession("session-1", "ios"))
+        .rejects.toThrow(/No devices in pool/);
+      expect(devicePool.getTotalDeviceCount()).toBe(0);
+    });
   });
 
   describe("assignDeviceToSession", () => {

--- a/test/daemon/devicePool.test.ts
+++ b/test/daemon/devicePool.test.ts
@@ -190,16 +190,39 @@ describe("DevicePool", () => {
       expect(devicePool.getTotalDeviceCount()).toBe(2);
     });
 
+    test("retains unassigned devices on first empty discovery", async () => {
+      await devicePool.initializeWithDevices([createBootedDevice("sim-old", "ios", "iPhone 15")]);
+      fakeDeviceManager.bootedDevices = [];
+
+      const added = await devicePool.refreshDevices();
+
+      expect(added).toBe(0);
+      expect(devicePool.getDevice("sim-old")?.status).toBe("idle");
+      expect(devicePool.getTotalDeviceCount()).toBe(1);
+    });
+
+    test("removes unassigned devices after repeated empty discovery misses", async () => {
+      await devicePool.initializeWithDevices([createBootedDevice("sim-old", "ios", "iPhone 15")]);
+      fakeDeviceManager.bootedDevices = [];
+
+      await devicePool.refreshDevices();
+      await devicePool.refreshDevices();
+
+      expect(devicePool.getDevice("sim-old")).toBeNull();
+      expect(devicePool.getTotalDeviceCount()).toBe(0);
+    });
+
     test("recomputes candidates after refresh prunes all unavailable error devices", async () => {
       await devicePool.initializeWithDevices([createBootedDevice("sim-old", "ios", "iPhone 15")]);
       for (let i = 0; i < 5; i++) {
         devicePool.recordDeviceError("sim-old");
       }
-      fakeDeviceManager.bootedDevices = [];
+      fakeDeviceManager.bootedDevices = [createBootedDevice("emulator-5554", "android", "Pixel 8")];
 
       await expect(devicePool.assignDeviceToSession("session-1", "ios"))
         .rejects.toThrow(/No devices in pool/);
-      expect(devicePool.getTotalDeviceCount()).toBe(0);
+      expect(devicePool.getDevice("sim-old")).toBeNull();
+      expect(devicePool.getTotalDeviceCount()).toBe(1);
     });
   });
 

--- a/test/daemon/sseKeepaliveAndDisconnect.test.ts
+++ b/test/daemon/sseKeepaliveAndDisconnect.test.ts
@@ -132,6 +132,9 @@ describe("disconnect monitor miss counting", () => {
     deviceDisconnectMisses: Map<string, number>,
     bootedDeviceIds: Set<string>,
     candidateDeviceIds: Set<string>,
+    bootedPlatforms: Set<string> = new Set(),
+    candidatePlatforms: Map<string, string> = new Map(),
+    idleCandidateIds: Set<string> = new Set(),
   ): { disconnected: string[]; skippedAdbUnreachable: boolean } => {
     const disconnected: string[] = [];
 
@@ -141,6 +144,16 @@ describe("disconnect monitor miss counting", () => {
 
     for (const deviceId of candidateDeviceIds) {
       if (bootedDeviceIds.has(deviceId)) {
+        deviceDisconnectMisses.delete(deviceId);
+        continue;
+      }
+      const platform = candidatePlatforms.get(deviceId);
+      if (
+        platform &&
+        idleCandidateIds.has(deviceId) &&
+        bootedDeviceIds.size > 0 &&
+        !bootedPlatforms.has(platform)
+      ) {
         deviceDisconnectMisses.delete(deviceId);
         continue;
       }
@@ -201,6 +214,24 @@ describe("disconnect monitor miss counting", () => {
     expect(result.skippedAdbUnreachable).toBe(true);
     expect(result.disconnected).toEqual([]);
     expect(misses.size).toBe(0);
+  });
+
+  test("skips idle candidates from platforms absent in partial discovery", () => {
+    const misses = new Map<string, number>();
+    misses.set("sim-1", 2);
+
+    const result = runDisconnectPoll(
+      misses,
+      new Set(["emulator-5554"]),
+      new Set(["sim-1"]),
+      new Set(["android"]),
+      new Map([["sim-1", "ios"]]),
+      new Set(["sim-1"]),
+    );
+
+    expect(result.skippedAdbUnreachable).toBe(false);
+    expect(result.disconnected).toEqual([]);
+    expect(misses.has("sim-1")).toBe(false);
   });
 
   test("miss count resets after device reappears then starts over", () => {

--- a/test/daemon/sseKeepaliveAndDisconnect.test.ts
+++ b/test/daemon/sseKeepaliveAndDisconnect.test.ts
@@ -132,7 +132,7 @@ describe("disconnect monitor miss counting", () => {
     deviceDisconnectMisses: Map<string, number>,
     bootedDeviceIds: Set<string>,
     candidateDeviceIds: Set<string>,
-    bootedPlatforms: Set<string> = new Set(),
+    succeededPlatforms: Set<string> = new Set(),
     candidatePlatforms: Map<string, string> = new Map(),
     idleCandidateIds: Set<string> = new Set(),
   ): { disconnected: string[]; skippedAdbUnreachable: boolean } => {
@@ -148,11 +148,12 @@ describe("disconnect monitor miss counting", () => {
         continue;
       }
       const platform = candidatePlatforms.get(deviceId);
+      // Idle devices on platforms whose discovery did not succeed this poll are
+      // skipped — a partial/failed discovery cannot confirm they disconnected.
       if (
         platform &&
         idleCandidateIds.has(deviceId) &&
-        bootedDeviceIds.size > 0 &&
-        !bootedPlatforms.has(platform)
+        !succeededPlatforms.has(platform)
       ) {
         deviceDisconnectMisses.delete(deviceId);
         continue;
@@ -216,10 +217,12 @@ describe("disconnect monitor miss counting", () => {
     expect(misses.size).toBe(0);
   });
 
-  test("skips idle candidates from platforms absent in partial discovery", () => {
+  test("skips idle candidates from platforms whose discovery did not succeed", () => {
     const misses = new Map<string, number>();
     misses.set("sim-1", 2);
 
+    // Android discovery succeeded; iOS discovery did not, so the idle iOS
+    // simulator must not be miss-counted toward disconnect.
     const result = runDisconnectPoll(
       misses,
       new Set(["emulator-5554"]),
@@ -232,6 +235,24 @@ describe("disconnect monitor miss counting", () => {
     expect(result.skippedAdbUnreachable).toBe(false);
     expect(result.disconnected).toEqual([]);
     expect(misses.has("sim-1")).toBe(false);
+  });
+
+  test("miss-counts an idle device once its platform discovery succeeds", () => {
+    const misses = new Map<string, number>();
+
+    // iOS discovery succeeded but reported zero simulators, so an idle iOS
+    // device that is genuinely gone should now be miss-counted.
+    const result = runDisconnectPoll(
+      misses,
+      new Set(["emulator-5554"]),
+      new Set(["sim-1"]),
+      new Set(["android", "ios"]),
+      new Map([["sim-1", "ios"]]),
+      new Set(["sim-1"]),
+    );
+
+    expect(result.skippedAdbUnreachable).toBe(false);
+    expect(misses.get("sim-1")).toBe(1);
   });
 
   test("miss count resets after device reappears then starts over", () => {

--- a/test/fakes/FakeDeviceManager.ts
+++ b/test/fakes/FakeDeviceManager.ts
@@ -1,11 +1,14 @@
 import { ChildProcess } from "child_process";
-import { BootedDevice, DeviceInfo, SomePlatform } from "../../src/models";
-import { PlatformDeviceManager } from "../../src/utils/deviceUtils";
+import { BootedDevice, DeviceInfo, Platform, SomePlatform } from "../../src/models";
+import { BootedDeviceDiscovery, PlatformDeviceManager } from "../../src/utils/deviceUtils";
 
 export class FakeDeviceManager implements PlatformDeviceManager {
   deviceImages: DeviceInfo[] = [];
   bootedDevices: BootedDevice[] = [];
   startedDevices: DeviceInfo[] = [];
+  // Platforms whose discovery should report as failed/unavailable (used to
+  // exercise partial-discovery handling). Defaults to all platforms succeeding.
+  failedPlatforms: Set<Platform> = new Set();
 
   constructor(images: DeviceInfo[] = [], booted: BootedDevice[] = []) {
     this.deviceImages = images;
@@ -32,6 +35,20 @@ export class FakeDeviceManager implements PlatformDeviceManager {
       return this.bootedDevices;
     }
     return this.bootedDevices.filter(device => device.platform === platform);
+  }
+
+  async getBootedDevicesDetailed(platform: SomePlatform): Promise<BootedDeviceDiscovery> {
+    const requested: Platform[] = platform === "either" ? ["android", "ios"] : [platform];
+    const devices: BootedDevice[] = [];
+    const succeededPlatforms = new Set<Platform>();
+    for (const p of requested) {
+      if (this.failedPlatforms.has(p)) {
+        continue;
+      }
+      succeededPlatforms.add(p);
+      devices.push(...this.bootedDevices.filter(device => device.platform === p));
+    }
+    return { devices, succeededPlatforms };
   }
 
   async startDevice(device: DeviceInfo): Promise<ChildProcess> {

--- a/test/fakes/FakeDeviceUtils.ts
+++ b/test/fakes/FakeDeviceUtils.ts
@@ -5,7 +5,7 @@ import {
   SomePlatform,
   Platform,
 } from "../../src/models";
-import { PlatformDeviceManager } from "../../src/utils/deviceUtils";
+import { BootedDeviceDiscovery, PlatformDeviceManager } from "../../src/utils/deviceUtils";
 
 /**
  * Fake implementation of PlatformDeviceManager for testing
@@ -142,6 +142,27 @@ export class FakeDeviceUtils implements PlatformDeviceManager {
     }
 
     return this.bootedDevices.get(platform) || [];
+  }
+
+  /**
+   * Platforms whose discovery should report as failed/unavailable. Defaults to
+   * all platforms succeeding.
+   */
+  failedPlatforms: Set<Platform> = new Set();
+
+  async getBootedDevicesDetailed(platform: SomePlatform): Promise<BootedDeviceDiscovery> {
+    const requested: Platform[] = platform === "either" ? ["android", "ios"] : [platform];
+    const devices: BootedDevice[] = [];
+    const succeededPlatforms = new Set<Platform>();
+    for (const p of requested) {
+      if (this.failedPlatforms.has(p)) {
+        continue;
+      }
+      // Delegate to getBootedDevices so operation tracking stays consistent.
+      devices.push(...(await this.getBootedDevices(p)));
+      succeededPlatforms.add(p);
+    }
+    return { devices, succeededPlatforms };
   }
 
   async startDevice(device: DeviceInfo): Promise<ChildProcess> {

--- a/test/server/resources/bootedDevices.test.ts
+++ b/test/server/resources/bootedDevices.test.ts
@@ -4,7 +4,7 @@ import { ResourceRegistry } from "../../../src/server/resourceRegistry";
 import { FakeDeviceUtils } from "../../fakes/FakeDeviceUtils";
 import { FakeTimer } from "../../fakes/FakeTimer";
 import { setDeviceManager, BootedDevicesResourceContent } from "../../../src/server/bootedDeviceResources";
-import { BootedDevice } from "../../../src/models";
+import { BootedDevice, Platform } from "../../../src/models";
 import { DaemonState } from "../../../src/daemon/daemonState";
 import { DevicePool } from "../../../src/daemon/devicePool";
 import { SessionManager } from "../../../src/daemon/sessionManager";
@@ -414,6 +414,54 @@ describe("MCP Booted Device Resources", () => {
         assigned: 0,
         error: 0,
         total: 0
+      });
+
+      sessionManager.stopCleanupTimer();
+    });
+
+    test("preserves pool stats for a platform whose discovery fails", async function() {
+      // Android discovery succeeds with zero booted devices; iOS discovery fails.
+      fakeDeviceUtils.setBootedDevices("android", []);
+      fakeDeviceUtils.failedPlatforms = new Set<Platform>(["ios"]);
+
+      const fakeTimer = new FakeTimer();
+      fakeTimer.enableAutoAdvance();
+      const sessionManager = new SessionManager(fakeTimer);
+      const { FakeInstalledAppsRepository } = await import("../../fakes/FakeInstalledAppsRepository");
+      const fakeAppsRepo = new FakeInstalledAppsRepository();
+      const devicePool = new DevicePool(sessionManager, "test-daemon-session-id", fakeTimer, fakeAppsRepo);
+      // An idle Android phantom (no longer booted) plus an assigned iOS device.
+      await devicePool.initializeWithDevices([mockAndroidDevice1, mockIosDevice1]);
+      await devicePool.assignDeviceToSession("session-ios", "ios");
+      DaemonState.getInstance().initialize(sessionManager, devicePool);
+
+      const { client } = fixture.getContext();
+
+      const readResourceResponseSchema = z.object({
+        contents: z.array(z.object({
+          uri: z.string(),
+          mimeType: z.string().optional(),
+          text: z.string().optional(),
+          blob: z.string().optional()
+        }))
+      });
+
+      const result = await client.request({
+        method: "resources/read",
+        params: {
+          uri: "automobile:devices/booted"
+        }
+      }, readResourceResponseSchema);
+
+      const data: BootedDevicesResourceContent = JSON.parse(result.contents[0].text!);
+      // The Android phantom is dropped (android discovery succeeded, empty), but
+      // the still-tracked iOS device is preserved because iOS discovery failed.
+      expect(data.poolStatus).toEqual({
+        enabled: true,
+        idle: 0,
+        assigned: 1,
+        error: 0,
+        total: 1
       });
 
       sessionManager.stopCleanupTimer();

--- a/test/server/resources/bootedDevices.test.ts
+++ b/test/server/resources/bootedDevices.test.ts
@@ -376,6 +376,49 @@ describe("MCP Booted Device Resources", () => {
       sessionManager.stopCleanupTimer();
     });
 
+    test("should not include phantom pool devices in pool status", async function() {
+      fakeDeviceUtils.setBootedDevices("android", []);
+
+      const fakeTimer = new FakeTimer();
+      fakeTimer.enableAutoAdvance();
+      const sessionManager = new SessionManager(fakeTimer);
+      const { FakeInstalledAppsRepository } = await import("../../fakes/FakeInstalledAppsRepository");
+      const fakeAppsRepo = new FakeInstalledAppsRepository();
+      const devicePool = new DevicePool(sessionManager, "test-daemon-session-id", fakeTimer, fakeAppsRepo);
+      await devicePool.initializeWithDevices([mockAndroidDevice1]);
+      DaemonState.getInstance().initialize(sessionManager, devicePool);
+
+      const { client } = fixture.getContext();
+
+      const readResourceResponseSchema = z.object({
+        contents: z.array(z.object({
+          uri: z.string(),
+          mimeType: z.string().optional(),
+          text: z.string().optional(),
+          blob: z.string().optional()
+        }))
+      });
+
+      const result = await client.request({
+        method: "resources/read",
+        params: {
+          uri: "automobile:devices/booted"
+        }
+      }, readResourceResponseSchema);
+
+      const data: BootedDevicesResourceContent = JSON.parse(result.contents[0].text!);
+      expect(data.devices).toHaveLength(0);
+      expect(data.poolStatus).toEqual({
+        enabled: true,
+        idle: 0,
+        assigned: 0,
+        error: 0,
+        total: 0
+      });
+
+      sessionManager.stopCleanupTimer();
+    });
+
     test("should return error for invalid platform", async function() {
       const { client } = fixture.getContext();
 

--- a/test/server/utilityTools.deviceState.test.ts
+++ b/test/server/utilityTools.deviceState.test.ts
@@ -80,4 +80,37 @@ describe("device state tools", () => {
 
     sessionManager.stopCleanupTimer();
   });
+
+  test("setActiveDevice rejects devices owned by another live session", async () => {
+    const fakeTimer = new FakeTimer();
+    const sessionManager = new SessionManager(fakeTimer);
+    const devicePool = new DevicePool(
+      sessionManager,
+      "test-daemon-session-id",
+      fakeTimer,
+      new FakeInstalledAppsRepository(),
+      new FakeDeviceManager(),
+      new DefaultRetryExecutor(fakeTimer)
+    );
+    await devicePool.initializeWithDevices([
+      createBootedDevice("sim-a", "ios", "iPhone 15"),
+      createBootedDevice("sim-b", "ios", "iPhone 16"),
+    ]);
+    await devicePool.bindOrReuseDeviceSession("session-a", "sim-a", "ios");
+    await devicePool.bindOrReuseDeviceSession("session-b", "sim-b", "ios");
+    DaemonState.getInstance().initialize(sessionManager, devicePool);
+
+    const setActiveDevice = ToolRegistry.getTool("setActiveDevice");
+    await expect(setActiveDevice!.handler({
+      deviceId: "sim-b",
+      platform: "ios",
+      sessionUuid: "session-a",
+    })).rejects.toThrow(/already assigned to session session-b/);
+
+    expect(sessionManager.getSession("session-a")?.assignedDevice).toBe("sim-a");
+    expect(devicePool.getDevice("sim-a")?.sessionId).toBe("session-a");
+    expect(devicePool.getDevice("sim-b")?.sessionId).toBe("session-b");
+
+    sessionManager.stopCleanupTimer();
+  });
 });

--- a/test/server/utilityTools.deviceState.test.ts
+++ b/test/server/utilityTools.deviceState.test.ts
@@ -1,6 +1,24 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { registerUtilityTools } from "../../src/server/utilityTools";
 import { ToolRegistry } from "../../src/server/toolRegistry";
+import { DaemonState } from "../../src/daemon/daemonState";
+import { DevicePool } from "../../src/daemon/devicePool";
+import { SessionManager } from "../../src/daemon/sessionManager";
+import { BootedDevice, Platform } from "../../src/models";
+import { DefaultRetryExecutor } from "../../src/utils/retry/RetryExecutor";
+import { FakeDeviceManager } from "../fakes/FakeDeviceManager";
+import { FakeInstalledAppsRepository } from "../fakes/FakeInstalledAppsRepository";
+import { FakeTimer } from "../fakes/FakeTimer";
+
+const createBootedDevice = (
+  deviceId: string,
+  platform: Platform = "android",
+  name?: string,
+): BootedDevice => ({
+  name: name ?? deviceId,
+  platform,
+  deviceId,
+});
 
 describe("device state tools", () => {
   beforeEach(() => {
@@ -10,6 +28,7 @@ describe("device state tools", () => {
 
   afterEach(() => {
     ToolRegistry.clearTools();
+    DaemonState.getInstance().reset();
   });
 
   test("registers getDeviceState and setDeviceState schemas", () => {
@@ -29,5 +48,36 @@ describe("device state tools", () => {
       doNotDisturb: { mode: "priority" },
     })).not.toThrow();
     expect(() => setTool!.schema.parse({})).toThrow();
+  });
+
+  test("setActiveDevice binds a refreshed session device in the pool", async () => {
+    const fakeTimer = new FakeTimer();
+    const sessionManager = new SessionManager(fakeTimer);
+    const fakeDeviceManager = new FakeDeviceManager(
+      [],
+      [createBootedDevice("sim-new", "ios", "iPhone 16")]
+    );
+    const devicePool = new DevicePool(
+      sessionManager,
+      "test-daemon-session-id",
+      fakeTimer,
+      new FakeInstalledAppsRepository(),
+      fakeDeviceManager,
+      new DefaultRetryExecutor(fakeTimer)
+    );
+    DaemonState.getInstance().initialize(sessionManager, devicePool);
+
+    const setActiveDevice = ToolRegistry.getTool("setActiveDevice");
+    await setActiveDevice!.handler({
+      deviceId: "sim-new",
+      platform: "ios",
+      sessionUuid: "session-1",
+    });
+
+    expect(sessionManager.getSession("session-1")?.assignedDevice).toBe("sim-new");
+    expect(devicePool.getDevice("sim-new")?.sessionId).toBe("session-1");
+    expect(devicePool.getDevice("sim-new")?.status).toBe("busy");
+
+    sessionManager.stopCleanupTimer();
   });
 });


### PR DESCRIPTION
## Summary

- Reconcile the daemon device pool during refresh by pruning unassigned devices that are no longer booted while preserving assigned devices for session cleanup.
- Include idle pool entries in the disconnect monitor so confirmed-missing devices are removed proactively.
- Derive booted-device resource pool counts from the live booted device list and refresh session-scoped setActiveDevice before failing a missing pool lookup.

Fixes #2445

## Root cause

The pool refresh path only added newly discovered booted devices. Devices shut down outside the daemon could remain as idle phantom entries, so discovery and resource reporting could disagree until the daemon restarted.

## Validation

- bun test test/daemon/devicePool.test.ts
- bun test test/server/resources/bootedDevices.test.ts
- bun test test/daemon/daemonRequestHandlers.test.ts
- bun run build
- bun run lint

Note: bun install hit the existing heapdump native build incompatibility with Node 26 after installing the dependencies needed for validation.
