### PR TITLE
Fix screenshot stream keepalive

### DIFF
--- a/src/daemon/deviceDataStreamSocketServer.ts
+++ b/src/daemon/deviceDataStreamSocketServer.ts
@@ -258,6 +258,31 @@ export class DeviceDataStreamSocketServer extends PushSubscriptionSocketServer<
   }
 
   /**
+   * Return true when at least one active subscriber would receive updates for this device.
+   */
+  hasSubscriberForDevice(deviceId: string): boolean {
+    const probe: DeviceDataPush = {
+      message: {
+        type: "screenshot_update",
+        deviceId,
+      },
+      targetDeviceId: deviceId,
+    };
+
+    for (const subscriber of this.subscribers.values()) {
+      if (subscriber.backfilling || subscriber.socket.destroyed) {
+        continue;
+      }
+
+      if (this.matchesFilter(subscriber.filter, probe)) {
+        return true;
+      }
+    }
+
+    return false;
+  }
+
+  /**
    * Override processLine to handle additional commands and the onSubscriberConnected callback.
    */
   protected async processLine(socket: Socket, line: string): Promise<void> {

--- a/src/daemon/socketServer/PushSubscriptionSocketServer.ts
+++ b/src/daemon/socketServer/PushSubscriptionSocketServer.ts
@@ -308,12 +308,16 @@ export abstract class PushSubscriptionSocketServer<TFilter, TPushData> extends B
 
       try {
         const result = subscriber.socket.write(json);
-        if (result) {
-          subscriber.lastActivity = this.timer.now();
-        } else {
+        if (!result) {
           // write()=false is not a death signal — wait for drain; truly dead peers get reaped by timeoutMs.
           this.armDrainListener(subscriber);
         }
+        // A successful write only proves our local send buffer accepted the bytes — not that the
+        // peer is alive. Liveness is tracked via inbound pongs (and drain events, which prove the
+        // peer is actually reading), so we deliberately do NOT refresh lastActivity here. Otherwise
+        // a self-sustaining write loop (e.g. screenshot keepalives) would keep refreshing liveness
+        // and mask a subscriber that has stopped responding to pings, preventing it from ever
+        // timing out.
         sentCount++;
       } catch (error) {
         logger.warn(`[${this.serverName}] Failed to send to ${subscriptionId}: ${error}`);

--- a/src/features/observe/ScreenshotBackoffScheduler.ts
+++ b/src/features/observe/ScreenshotBackoffScheduler.ts
@@ -23,12 +23,19 @@ type ScreenshotCaptureCallback = () => Promise<ScreenshotCaptureResult>;
 type ScreenshotEmitCallback = (data: string) => void;
 
 /**
+ * Callback to decide whether keepalive screenshots should continue.
+ */
+type ScreenshotKeepAlivePredicate = () => boolean;
+
+/**
  * Interface for screenshot backoff scheduling.
  *
  * On an observability event, captures screenshots at backoff intervals:
  * t=0, t=100, t=300, t=500, t=800, t=1300 ms
+ * then continues low-frequency keepalive captures while subscribers are active.
  *
- * - Skips emitting if screenshot checksum matches previous
+ * - Burst captures skip emitting if screenshot checksum matches previous
+ * - Keepalive captures emit duplicate frames to confirm stream liveness
  * - Cancels pending captures if new activity occurs
  */
 export interface ScreenshotBackoffScheduler {
@@ -63,10 +70,18 @@ interface ScreenshotBackoffConfig {
    * Default: [0, 100, 300, 500, 800, 1300]
    */
   intervals: number[];
+
+  /**
+   * Keepalive interval in milliseconds after the backoff burst completes.
+   * Set to null or undefined to disable keepalive captures.
+   * Default: 3000
+   */
+  keepAliveIntervalMs?: number | null;
 }
 
 const DEFAULT_CONFIG: ScreenshotBackoffConfig = {
   intervals: [0, 100, 300, 500, 800, 1300],
+  keepAliveIntervalMs: 3000,
 };
 
 /**
@@ -83,9 +98,11 @@ export class DefaultScreenshotBackoffScheduler implements ScreenshotBackoffSched
   private timer: Timer;
   private captureCallback: ScreenshotCaptureCallback;
   private emitCallback: ScreenshotEmitCallback;
+  private shouldKeepAlive: ScreenshotKeepAlivePredicate;
   private config: ScreenshotBackoffConfig;
 
   private pendingTimeouts: ReturnType<Timer["setTimeout"]>[] = [];
+  private keepAliveTimeout: ReturnType<Timer["setTimeout"]> | null = null;
   private lastEmittedChecksum: string | null = null;
   private sequenceId: number = 0;
 
@@ -93,20 +110,24 @@ export class DefaultScreenshotBackoffScheduler implements ScreenshotBackoffSched
     captureCallback: ScreenshotCaptureCallback,
     emitCallback: ScreenshotEmitCallback,
     config: ScreenshotBackoffConfig = DEFAULT_CONFIG,
-    timer: Timer = defaultTimer
+    timer: Timer = defaultTimer,
+    shouldKeepAlive: ScreenshotKeepAlivePredicate = () => true
   ) {
     this.captureCallback = captureCallback;
     this.emitCallback = emitCallback;
-    this.config = config;
+    this.config = {
+      ...DEFAULT_CONFIG,
+      ...config,
+    };
     this.timer = timer;
+    this.shouldKeepAlive = shouldKeepAlive;
   }
 
   startBackoffSequence(): void {
     // Cancel any existing sequence
     this.cancelPendingCaptures();
 
-    // Increment sequence ID to invalidate any in-flight captures from previous sequence
-    this.sequenceId++;
+    // cancelPendingCaptures increments sequenceId to invalidate in-flight captures.
     const currentSequenceId = this.sequenceId;
 
     logger.debug(`[ScreenshotBackoff] Starting backoff sequence ${currentSequenceId} with intervals: ${this.config.intervals.join(", ")}ms`);
@@ -121,6 +142,8 @@ export class DefaultScreenshotBackoffScheduler implements ScreenshotBackoffSched
   }
 
   cancelPendingCaptures(): void {
+    this.sequenceId++;
+
     if (this.pendingTimeouts.length > 0) {
       logger.debug(`[ScreenshotBackoff] Cancelling ${this.pendingTimeouts.length} pending captures`);
       for (const timeoutId of this.pendingTimeouts) {
@@ -128,10 +151,15 @@ export class DefaultScreenshotBackoffScheduler implements ScreenshotBackoffSched
       }
       this.pendingTimeouts = [];
     }
+    if (this.keepAliveTimeout) {
+      logger.debug("[ScreenshotBackoff] Cancelling keepalive capture");
+      this.timer.clearTimeout(this.keepAliveTimeout);
+      this.keepAliveTimeout = null;
+    }
   }
 
   isActive(): boolean {
-    return this.pendingTimeouts.length > 0;
+    return this.pendingTimeouts.length > 0 || this.keepAliveTimeout !== null;
   }
 
   getPendingCount(): number {
@@ -161,16 +189,50 @@ export class DefaultScreenshotBackoffScheduler implements ScreenshotBackoffSched
     logger.debug(`[ScreenshotBackoff] Capturing screenshot at t=${interval}ms (sequence ${sequenceId})`);
 
     try {
+      await this.captureAndEmit(sequenceId, `t=${interval}ms`, false);
+    } finally {
+      this.scheduleKeepAliveIfIdle(sequenceId);
+    }
+  }
+
+  private async captureKeepAlive(sequenceId: number): Promise<void> {
+    this.keepAliveTimeout = null;
+
+    if (sequenceId !== this.sequenceId) {
+      logger.debug(`[ScreenshotBackoff] Skipping keepalive capture - sequence ${sequenceId} was superseded by ${this.sequenceId}`);
+      return;
+    }
+
+    if (!this.shouldKeepAlive()) {
+      logger.debug("[ScreenshotBackoff] Stopping keepalive captures - no active subscribers");
+      return;
+    }
+
+    logger.debug(`[ScreenshotBackoff] Capturing keepalive screenshot (sequence ${sequenceId})`);
+
+    try {
+      await this.captureAndEmit(sequenceId, "keepalive", true);
+    } finally {
+      this.scheduleKeepAliveIfIdle(sequenceId);
+    }
+  }
+
+  private async captureAndEmit(
+    sequenceId: number,
+    captureLabel: string,
+    emitDuplicates: boolean
+  ): Promise<void> {
+    try {
       const result = await this.captureCallback();
 
       // Check again if sequence is still valid (capture might have taken time)
       if (sequenceId !== this.sequenceId) {
-        logger.debug(`[ScreenshotBackoff] Discarding capture at ${interval}ms - sequence was cancelled during capture`);
+        logger.debug(`[ScreenshotBackoff] Discarding capture ${captureLabel} - sequence was cancelled during capture`);
         return;
       }
 
       if (!result.success || !result.data) {
-        logger.debug(`[ScreenshotBackoff] Screenshot capture failed at t=${interval}ms: ${result.error}`);
+        logger.debug(`[ScreenshotBackoff] Screenshot capture failed at ${captureLabel}: ${result.error}`);
         return;
       }
 
@@ -178,19 +240,40 @@ export class DefaultScreenshotBackoffScheduler implements ScreenshotBackoffSched
       const checksum = result.checksum || computeChecksum(result.data);
 
       // Skip if same as last emitted
-      if (checksum === this.lastEmittedChecksum) {
-        logger.debug(`[ScreenshotBackoff] Skipping duplicate screenshot at t=${interval}ms (checksum: ${checksum.substring(0, 8)}...)`);
+      if (!emitDuplicates && checksum === this.lastEmittedChecksum) {
+        logger.debug(`[ScreenshotBackoff] Skipping duplicate screenshot at ${captureLabel} (checksum: ${checksum.substring(0, 8)}...)`);
         return;
       }
 
       // Emit the screenshot
-      logger.debug(`[ScreenshotBackoff] Emitting screenshot at t=${interval}ms (checksum: ${checksum.substring(0, 8)}..., size: ${result.data.length})`);
+      logger.debug(`[ScreenshotBackoff] Emitting screenshot at ${captureLabel} (checksum: ${checksum.substring(0, 8)}..., size: ${result.data.length})`);
       this.lastEmittedChecksum = checksum;
       this.emitCallback(result.data);
 
     } catch (error) {
-      logger.warn(`[ScreenshotBackoff] Error capturing screenshot at t=${interval}ms: ${error}`);
+      logger.warn(`[ScreenshotBackoff] Error capturing screenshot at ${captureLabel}: ${error}`);
     }
+  }
+
+  private scheduleKeepAliveIfIdle(sequenceId: number): void {
+    if (sequenceId !== this.sequenceId || this.pendingTimeouts.length > 0 || this.keepAliveTimeout) {
+      return;
+    }
+
+    const keepAliveIntervalMs = this.config.keepAliveIntervalMs;
+    if (keepAliveIntervalMs === null || keepAliveIntervalMs === undefined || keepAliveIntervalMs <= 0) {
+      return;
+    }
+
+    if (!this.shouldKeepAlive()) {
+      logger.debug("[ScreenshotBackoff] Not scheduling keepalive - no active subscribers");
+      return;
+    }
+
+    this.keepAliveTimeout = this.timer.setTimeout(() => {
+      this.captureKeepAlive(sequenceId);
+    }, keepAliveIntervalMs);
+    logger.debug(`[ScreenshotBackoff] Scheduled keepalive capture in ${keepAliveIntervalMs}ms (sequence ${sequenceId})`);
   }
 }
 

--- a/src/features/observe/android/AndroidCtrlProxyClient.ts
+++ b/src/features/observe/android/AndroidCtrlProxyClient.ts
@@ -2534,8 +2534,12 @@ export class AndroidCtrlProxyClient extends DeviceServiceClient implements Andro
         (data: string) => {
           this.pushScreenshotToObservationStream(data);
         },
-        { intervals: [0, 100, 300, 500, 800, 1300] },
-        this.timer
+        { intervals: [0, 100, 300, 500, 800, 1300], keepAliveIntervalMs: 3000 },
+        this.timer,
+        () => {
+          const server = getDeviceDataStreamServer();
+          return !!server && server.getSubscriberCount() > 0;
+        }
       );
     }
     return this.screenshotBackoffScheduler;

--- a/src/features/observe/android/AndroidCtrlProxyClient.ts
+++ b/src/features/observe/android/AndroidCtrlProxyClient.ts
@@ -2538,7 +2538,7 @@ export class AndroidCtrlProxyClient extends DeviceServiceClient implements Andro
         this.timer,
         () => {
           const server = getDeviceDataStreamServer();
-          return !!server && server.getSubscriberCount() > 0;
+          return !!server && server.hasSubscriberForDevice(this.device.deviceId);
         }
       );
     }
@@ -2547,7 +2547,7 @@ export class AndroidCtrlProxyClient extends DeviceServiceClient implements Andro
 
   private async captureScreenshotForBackoff(): Promise<ScreenshotCaptureResult> {
     const server = getDeviceDataStreamServer();
-    if (!server || server.getSubscriberCount() === 0) {
+    if (!server || !server.hasSubscriberForDevice(this.device.deviceId)) {
       return { success: false, error: "No subscribers" };
     }
 
@@ -2620,7 +2620,7 @@ export class AndroidCtrlProxyClient extends DeviceServiceClient implements Andro
 
   private startScreenshotBackoff(): void {
     const server = getDeviceDataStreamServer();
-    if (!server || server.getSubscriberCount() === 0) {
+    if (!server || !server.hasSubscriberForDevice(this.device.deviceId)) {
       return;
     }
 

--- a/src/features/observe/android/AndroidCtrlProxyClient.ts
+++ b/src/features/observe/android/AndroidCtrlProxyClient.ts
@@ -1077,6 +1077,7 @@ export class AndroidCtrlProxyClient extends DeviceServiceClient implements Andro
   }
 
   protected onConnectionClosed(): void {
+    this.cancelScreenshotBackoff();
     void this.markInstalledAppsStale("websocket_closed");
 
     if (this.hierarchyNavigationDetector) {

--- a/src/features/observe/ios/IOSCtrlProxyClient.ts
+++ b/src/features/observe/ios/IOSCtrlProxyClient.ts
@@ -1529,7 +1529,7 @@ export class IOSCtrlProxyClient extends DeviceServiceClient implements IOSCtrlPr
    */
   private startScreenshotBackoff(): void {
     const server = getDeviceDataStreamServer();
-    if (!server || server.getSubscriberCount() === 0) {
+    if (!server || !server.hasSubscriberForDevice(this.device.deviceId)) {
       return;
     }
 
@@ -1553,7 +1553,7 @@ export class IOSCtrlProxyClient extends DeviceServiceClient implements IOSCtrlPr
         this.timer,
         () => {
           const server = getDeviceDataStreamServer();
-          return !!server && server.getSubscriberCount() > 0;
+          return !!server && server.hasSubscriberForDevice(this.device.deviceId);
         }
       );
     }
@@ -1561,6 +1561,11 @@ export class IOSCtrlProxyClient extends DeviceServiceClient implements IOSCtrlPr
   }
 
   private async captureScreenshotForBackoff(): Promise<ScreenshotCaptureResult> {
+    const server = getDeviceDataStreamServer();
+    if (!server || !server.hasSubscriberForDevice(this.device.deviceId)) {
+      return { success: false, error: "No subscribers" };
+    }
+
     try {
       const result = await this.requestScreenshot(5000);
       if (!result.success || !result.data) {

--- a/src/features/observe/ios/IOSCtrlProxyClient.ts
+++ b/src/features/observe/ios/IOSCtrlProxyClient.ts
@@ -1550,7 +1550,11 @@ export class IOSCtrlProxyClient extends DeviceServiceClient implements IOSCtrlPr
           this.pushScreenshotToObservationStream(data, screenWidth, screenHeight);
         },
         undefined, // Use default config
-        this.timer
+        this.timer,
+        () => {
+          const server = getDeviceDataStreamServer();
+          return !!server && server.getSubscriberCount() > 0;
+        }
       );
     }
     return this.screenshotBackoffScheduler;

--- a/src/features/observe/ios/IOSCtrlProxyClient.ts
+++ b/src/features/observe/ios/IOSCtrlProxyClient.ts
@@ -589,6 +589,7 @@ export class IOSCtrlProxyClient extends DeviceServiceClient implements IOSCtrlPr
   }
 
   protected onConnectionClosed(): void {
+    this.cancelScreenshotBackoff();
     this.stopSdkEventPolling();
     this.cachedHierarchy = null;
 

--- a/test/daemon/deviceDataStreamSocketServer.test.ts
+++ b/test/daemon/deviceDataStreamSocketServer.test.ts
@@ -222,4 +222,35 @@ describe("DeviceDataStreamSocketServer", () => {
       expect(server.getSubscriberCount()).toBe(0);
     });
   });
+
+  describe("hasSubscriberForDevice", () => {
+    it("returns false when there are no subscribers", () => {
+      expect(server.hasSubscriberForDevice("device-1")).toBe(false);
+    });
+
+    it("returns true for all-device subscribers", () => {
+      server.simulateSubscription({});
+
+      expect(server.hasSubscriberForDevice("device-1")).toBe(true);
+    });
+
+    it("returns true for subscribers targeting the same device", () => {
+      server.simulateSubscription({ deviceId: "device-1" });
+
+      expect(server.hasSubscriberForDevice("device-1")).toBe(true);
+    });
+
+    it("returns false when subscribers target a different device", () => {
+      server.simulateSubscription({ deviceId: "device-2" });
+
+      expect(server.hasSubscriberForDevice("device-1")).toBe(false);
+    });
+
+    it("ignores destroyed subscriber sockets", () => {
+      const { socket } = server.simulateSubscription({ deviceId: "device-1" });
+      socket.destroy();
+
+      expect(server.hasSubscriberForDevice("device-1")).toBe(false);
+    });
+  });
 });

--- a/test/daemon/socketServer/PushSubscriptionSocketServer.test.ts
+++ b/test/daemon/socketServer/PushSubscriptionSocketServer.test.ts
@@ -354,6 +354,35 @@ describe("PushSubscriptionSocketServer", () => {
       expect(socket.destroyed).toBe(true);
     });
 
+    it("does not refresh lastActivity on a successful write", () => {
+      const { socket, subscriptionId } = server.simulateSubscription({});
+
+      timer.setCurrentTime(1_000);
+      // A successful write proves only that our send buffer accepted the bytes, not that the
+      // peer is alive — so it must not bump lastActivity.
+      server.pushData({ deviceId: "device-1", packageName: "com.app", value: 42 });
+
+      const subscriber = (server as any).subscribers.get(subscriptionId);
+      expect(socket.destroyed).toBe(false);
+      expect(subscriber.lastActivity).toBe(0);
+    });
+
+    it("times out a non-responsive subscriber despite a steady successful-write stream", () => {
+      const { socket } = server.simulateSubscription({});
+
+      // Simulate a self-sustaining keepalive stream: writes keep succeeding every few seconds,
+      // but the peer never sends a pong. Liveness must not be masked by the outbound writes.
+      for (let elapsed = 3_000; elapsed <= 33_000; elapsed += 3_000) {
+        timer.setCurrentTime(elapsed);
+        server.pushData({ deviceId: "device-1", packageName: "com.app", value: elapsed });
+      }
+
+      server.triggerKeepalive();
+
+      expect(server.getSubscriberCount()).toBe(0);
+      expect(socket.destroyed).toBe(true);
+    });
+
     it("does not stack multiple drain listeners on repeated backpressure", () => {
       const { socket, subscriptionId } = server.simulateSubscription({});
       socket.write = () => false;

--- a/test/features/observe/ScreenshotBackoffScheduler.test.ts
+++ b/test/features/observe/ScreenshotBackoffScheduler.test.ts
@@ -109,7 +109,7 @@ describe("DefaultScreenshotBackoffScheduler", () => {
 
       expect(capturedScreenshots).toHaveLength(6);
       expect(emittedScreenshots).toHaveLength(6);
-      expect(scheduler.isActive()).toBe(false);
+      expect(scheduler.isActive()).toBe(true);
       expect(scheduler.getPendingCount()).toBe(0);
     });
 
@@ -154,6 +154,83 @@ describe("DefaultScreenshotBackoffScheduler", () => {
       // Should have: 1 from first (t=0), 2 from second (t=0, t=100)
       // The t=100 and t=200 from first sequence should be cancelled
       expect(capturedScreenshots).toHaveLength(4); // 1 + 3
+    });
+  });
+
+  describe("keepalive captures", () => {
+    it("emits duplicate screenshots after burst sequence completes", async () => {
+      captureCallback = async () => {
+        capturedScreenshots.push("same-data");
+        return { success: true, data: "same-data" };
+      };
+
+      const scheduler = new DefaultScreenshotBackoffScheduler(
+        captureCallback,
+        emitCallback,
+        { intervals: [0, 100], keepAliveIntervalMs: 1000 },
+        fakeTimer
+      );
+
+      scheduler.startBackoffSequence();
+      await fakeTimer.advanceTimersByTimeAsync(0);
+      await fakeTimer.advanceTimersByTimeAsync(100);
+
+      expect(capturedScreenshots).toHaveLength(2);
+      expect(emittedScreenshots).toEqual(["same-data"]);
+      expect(scheduler.isActive()).toBe(true);
+      expect(scheduler.getPendingCount()).toBe(0);
+
+      await fakeTimer.advanceTimersByTimeAsync(1000);
+      await fakeTimer.advanceTimersByTimeAsync(1000);
+
+      expect(capturedScreenshots).toHaveLength(4);
+      expect(emittedScreenshots).toEqual(["same-data", "same-data", "same-data"]);
+    });
+
+    it("stops keepalive captures when subscribers are no longer active", async () => {
+      let hasSubscribers = true;
+      const scheduler = new DefaultScreenshotBackoffScheduler(
+        captureCallback,
+        emitCallback,
+        { intervals: [0], keepAliveIntervalMs: 1000 },
+        fakeTimer,
+        () => hasSubscribers
+      );
+
+      scheduler.startBackoffSequence();
+      await fakeTimer.advanceTimersByTimeAsync(0);
+
+      expect(capturedScreenshots).toHaveLength(1);
+      expect(scheduler.isActive()).toBe(true);
+
+      hasSubscribers = false;
+      await fakeTimer.advanceTimersByTimeAsync(1000);
+
+      expect(capturedScreenshots).toHaveLength(1);
+      expect(scheduler.isActive()).toBe(false);
+    });
+
+    it("resets pending keepalive when a new sequence starts", async () => {
+      const scheduler = new DefaultScreenshotBackoffScheduler(
+        captureCallback,
+        emitCallback,
+        { intervals: [0], keepAliveIntervalMs: 1000 },
+        fakeTimer
+      );
+
+      scheduler.startBackoffSequence();
+      await fakeTimer.advanceTimersByTimeAsync(0);
+      await fakeTimer.advanceTimersByTimeAsync(500);
+
+      scheduler.startBackoffSequence();
+      await fakeTimer.advanceTimersByTimeAsync(0);
+      await fakeTimer.advanceTimersByTimeAsync(999);
+
+      expect(capturedScreenshots).toHaveLength(2);
+
+      await fakeTimer.advanceTimersByTimeAsync(1);
+
+      expect(capturedScreenshots).toHaveLength(3);
     });
   });
 

--- a/test/features/observe/android/CtrlProxyPackages.test.ts
+++ b/test/features/observe/android/CtrlProxyPackages.test.ts
@@ -10,6 +10,7 @@ import {
   WebSocketState
 } from "../../../fakes/FakeWebSocket";
 import { FakeTimer } from "../../../fakes/FakeTimer";
+import { FakeScreenshotBackoffScheduler } from "../../../../src/features/observe/ScreenshotBackoffScheduler";
 
 describe("CtrlProxyPackages (Android)", function() {
   let fakeAdb: FakeAdbExecutor;
@@ -100,6 +101,19 @@ describe("CtrlProxyPackages (Android)", function() {
     }
     throw new Error(`No message of type ${type} in: ${socket.sentMessages.join(", ")}`);
   };
+
+  describe("connection lifecycle", function() {
+    test("cancels screenshot backoff when the connection closes", function() {
+      const { factory } = createCapturingFactory(fakeTimer);
+      const client = AndroidCtrlProxyClient.createForTesting(testDevice, fakeAdb, factory, fakeTimer);
+      const scheduler = new FakeScreenshotBackoffScheduler();
+
+      (client as any).screenshotBackoffScheduler = scheduler;
+      (client as any).onConnectionClosed();
+
+      expect(scheduler.cancelPendingCapturesCalls).toBe(1);
+    });
+  });
 
   describe("requestInstalledPackages", function() {
     test("sends request_installed_packages and resolves on result", async function() {

--- a/test/features/observe/ios/IOSCtrlProxyClient.test.ts
+++ b/test/features/observe/ios/IOSCtrlProxyClient.test.ts
@@ -8,6 +8,7 @@ import {
   WebSocketState
 } from "../../../fakes/FakeWebSocket";
 import { FakeTimer } from "../../../fakes/FakeTimer";
+import { FakeScreenshotBackoffScheduler } from "../../../../src/features/observe/ScreenshotBackoffScheduler";
 
 describe("IOSCtrlProxyClient", function() {
   let ctrlProxyClient: IOSCtrlProxyClient;
@@ -109,6 +110,17 @@ describe("IOSCtrlProxyClient", function() {
       await new Promise(resolve => setImmediate(resolve));
     }
   };
+
+  describe("connection lifecycle", function() {
+    test("cancels screenshot backoff when the connection closes", function() {
+      const scheduler = new FakeScreenshotBackoffScheduler();
+
+      (ctrlProxyClient as any).screenshotBackoffScheduler = scheduler;
+      (ctrlProxyClient as any).onConnectionClosed();
+
+      expect(scheduler.cancelPendingCapturesCalls).toBe(1);
+    });
+  });
 
   describe("getLatestHierarchy", function() {
     test("should return hierarchy data when WebSocket receives fresh data", async function() {


### PR DESCRIPTION
## Summary

- add low-frequency screenshot keepalive captures after the initial backoff burst
- keep burst duplicate suppression while allowing keepalive frames to emit unchanged screenshots for liveness
- wire Android and iOS screenshot streaming to stop keepalives when no observation subscribers remain

## Root Cause

The screenshot backoff scheduler only scheduled a fixed burst of captures after hierarchy changes. Once the final burst capture fired, static screens produced no further screenshot stream updates, so live-view consumers could not distinguish an idle device from a stale stream.

## Validation

- `bun test test/features/observe/ScreenshotBackoffScheduler.test.ts`
- `bunx eslint src/features/observe/ScreenshotBackoffScheduler.ts src/features/observe/android/AndroidCtrlProxyClient.ts src/features/observe/ios/IOSCtrlProxyClient.ts test/features/observe/ScreenshotBackoffScheduler.test.ts`
- `bun run build`
- `bun test --bail`

Closes #2449
