### PR TITLE
Fix pre-first-heartbeat session reclaim

### DIFF
--- a/docs/design-docs/mcp/daemon/index.md
+++ b/docs/design-docs/mcp/daemon/index.md
@@ -53,6 +53,21 @@ The daemon exposes a full [Unix Socket API](unix-socket-api.md) for IDE plugins 
 - **MCP proxy** — `tools/list`, `tools/call`, `resources/list`, `resources/read`
 - **Daemon management** — device pool queries, session lifecycle
 
+## Session Heartbeats
+
+The daemon reclaims sessions whose client heartbeat has gone stale. Sessions using the default heartbeat policy that never send their first heartbeat are reclaimed after a short grace period, while custom-heartbeat sessions, including autolock sessions, keep using their configured heartbeat timeout.
+
+Deployment overrides are read from environment variables in milliseconds:
+
+| Variable | Default | Purpose |
+| --- | ---: | --- |
+| `AUTOMOBILE_SESSION_HEARTBEAT_CHECK_INTERVAL_MS` | `10000` | How often the daemon scans for stale sessions. |
+| `AUTOMOBILE_SESSION_PRE_FIRST_HEARTBEAT_GRACE_MS` | `5000` | Grace before reclaiming a default-heartbeat session that never sent its first heartbeat. |
+| `AUTOMOBILE_SESSION_HEARTBEAT_INITIAL_GRACE_MS` | `20000` | Grace before evaluating stale custom-heartbeat sessions that never sent a heartbeat. |
+| `AUTOMOBILE_SESSION_HEARTBEAT_TIMEOUT_MS` | `10000` | Default heartbeat timeout assigned to newly created sessions. |
+
+Each variable also supports the legacy `AUTO_MOBILE_...` prefix.
+
 ## Implementation
 
 The daemon is implemented in the main AutoMobile MCP server and can run:

--- a/src/daemon/SessionHeartbeatMonitor.ts
+++ b/src/daemon/SessionHeartbeatMonitor.ts
@@ -1,6 +1,6 @@
 import { Timer, defaultTimer } from "../utils/SystemTimer";
 import { logger } from "../utils/logger";
-import { SessionManager, type Session } from "./sessionManager";
+import { getDefaultSessionHeartbeatTimeoutMs, type Session } from "./sessionManager";
 
 /**
  * Minimal view of the session store the heartbeat monitor needs.
@@ -14,17 +14,35 @@ export interface HeartbeatSessionSource {
 export interface SessionHeartbeatMonitorConfig {
   /** How often to scan for stale sessions. Default: 10s. */
   checkIntervalMs?: number;
-  /** Grace period before a session that never sent a heartbeat is eligible. Default: 20s. */
+  /** Grace period before default-heartbeat sessions that never sent a heartbeat are reaped. Default: 5s. */
+  preFirstHeartbeatGraceMs?: number;
+  /** Grace period before a custom-heartbeat session that never sent a heartbeat is eligible. Default: 20s. */
   graceMs?: number;
+  /** Default timeout for sessions that do not carry their own heartbeat timeout. Default: 10s. */
+  heartbeatTimeoutMs?: number;
+}
+
+const DEFAULT_CHECK_INTERVAL_MS = 10_000;
+const DEFAULT_PRE_FIRST_HEARTBEAT_GRACE_MS = 5_000;
+const DEFAULT_INITIAL_GRACE_MS = 20_000;
+
+function readPositiveMsEnv(primaryName: string, legacyName: string): number | undefined {
+  const rawValue = process.env[primaryName] ?? process.env[legacyName];
+  if (!rawValue) {
+    return undefined;
+  }
+  const parsed = Number.parseInt(rawValue, 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : undefined;
 }
 
 /**
  * Session Heartbeat Monitor
  *
  * Periodically cancels sessions whose heartbeat has gone stale, freeing their
- * devices. A session is reaped when, after the initial grace period and with no
- * active executions, `now - lastHeartbeat` exceeds the session's heartbeat
- * timeout.
+ * devices. Sessions using the default heartbeat policy that never send their
+ * first heartbeat are reaped after a short pre-first-heartbeat grace. Other
+ * sessions are reaped when, after the initial grace period and with no active
+ * executions, `now - lastHeartbeat` exceeds the session's heartbeat timeout.
  *
  * Extracted from the daemon so the reaping logic can be driven deterministically
  * with an injected timer in tests. Behaviour is unchanged in production, where
@@ -34,6 +52,8 @@ export class SessionHeartbeatMonitor {
   private timerHandle: NodeJS.Timeout | null = null;
   private readonly checkIntervalMs: number;
   private readonly graceMs: number;
+  private readonly preFirstHeartbeatGraceMs: number;
+  private readonly defaultHeartbeatTimeoutMs: number;
 
   constructor(
     private readonly sessions: HeartbeatSessionSource,
@@ -42,8 +62,18 @@ export class SessionHeartbeatMonitor {
     private readonly timer: Timer = defaultTimer,
     config: SessionHeartbeatMonitorConfig = {},
   ) {
-    this.checkIntervalMs = config.checkIntervalMs ?? 10_000;
-    this.graceMs = config.graceMs ?? 20_000;
+    this.checkIntervalMs = config.checkIntervalMs
+      ?? readPositiveMsEnv("AUTOMOBILE_SESSION_HEARTBEAT_CHECK_INTERVAL_MS", "AUTO_MOBILE_SESSION_HEARTBEAT_CHECK_INTERVAL_MS")
+      ?? DEFAULT_CHECK_INTERVAL_MS;
+    this.graceMs = config.graceMs
+      ?? readPositiveMsEnv("AUTOMOBILE_SESSION_HEARTBEAT_INITIAL_GRACE_MS", "AUTO_MOBILE_SESSION_HEARTBEAT_INITIAL_GRACE_MS")
+      ?? DEFAULT_INITIAL_GRACE_MS;
+    this.preFirstHeartbeatGraceMs = config.preFirstHeartbeatGraceMs
+      ?? readPositiveMsEnv("AUTOMOBILE_SESSION_PRE_FIRST_HEARTBEAT_GRACE_MS", "AUTO_MOBILE_SESSION_PRE_FIRST_HEARTBEAT_GRACE_MS")
+      ?? DEFAULT_PRE_FIRST_HEARTBEAT_GRACE_MS;
+    this.defaultHeartbeatTimeoutMs = config.heartbeatTimeoutMs
+      ?? readPositiveMsEnv("AUTOMOBILE_SESSION_HEARTBEAT_TIMEOUT_MS", "AUTO_MOBILE_SESSION_HEARTBEAT_TIMEOUT_MS")
+      ?? getDefaultSessionHeartbeatTimeoutMs();
   }
 
   start(): void {
@@ -83,13 +113,23 @@ export class SessionHeartbeatMonitor {
     this.sessions.cleanupExpiredSessions();
 
     for (const session of this.sessions.getAllSessions()) {
-      if (!session.hasReceivedHeartbeat && now - session.createdAt < this.graceMs) {
-        continue;
-      }
       if (this.hasActiveExecutions(session.sessionId)) {
         continue;
       }
-      const timeoutMs = session.heartbeatTimeoutMs ?? SessionManager.DEFAULT_HEARTBEAT_TIMEOUT_MS;
+      const timeoutMs = session.heartbeatTimeoutMs ?? this.defaultHeartbeatTimeoutMs;
+      const ageMs = now - session.createdAt;
+      if (!session.hasReceivedHeartbeat) {
+        if (timeoutMs === this.defaultHeartbeatTimeoutMs) {
+          if (ageMs > this.preFirstHeartbeatGraceMs) {
+            logger.warn(`Session ${session.sessionId} never received first heartbeat, cancelling`);
+            await this.reap(session.sessionId);
+          }
+          continue;
+        }
+        if (ageMs < this.graceMs) {
+          continue;
+        }
+      }
       const lastHeartbeat = session.lastHeartbeat ?? session.lastUsedAt;
       if (now - lastHeartbeat > timeoutMs) {
         logger.warn(`Session ${session.sessionId} heartbeat timeout, cancelling`);

--- a/src/daemon/SessionHeartbeatMonitor.ts
+++ b/src/daemon/SessionHeartbeatMonitor.ts
@@ -117,15 +117,16 @@ export class SessionHeartbeatMonitor {
         continue;
       }
       const timeoutMs = session.heartbeatTimeoutMs ?? this.defaultHeartbeatTimeoutMs;
-      const ageMs = now - session.createdAt;
       if (!session.hasReceivedHeartbeat) {
+        const lastHeartbeat = session.lastHeartbeat ?? session.lastUsedAt;
         if (session.heartbeatTimeoutSource === "default") {
-          if (ageMs > this.preFirstHeartbeatGraceMs) {
+          if (now - lastHeartbeat > this.preFirstHeartbeatGraceMs) {
             logger.warn(`Session ${session.sessionId} never received first heartbeat, cancelling`);
             await this.reap(session.sessionId);
           }
           continue;
         }
+        const ageMs = now - session.createdAt;
         if (ageMs < this.graceMs) {
           continue;
         }

--- a/src/daemon/SessionHeartbeatMonitor.ts
+++ b/src/daemon/SessionHeartbeatMonitor.ts
@@ -119,7 +119,7 @@ export class SessionHeartbeatMonitor {
       const timeoutMs = session.heartbeatTimeoutMs ?? this.defaultHeartbeatTimeoutMs;
       const ageMs = now - session.createdAt;
       if (!session.hasReceivedHeartbeat) {
-        if (timeoutMs === this.defaultHeartbeatTimeoutMs) {
+        if (session.heartbeatTimeoutSource === "default") {
           if (ageMs > this.preFirstHeartbeatGraceMs) {
             logger.warn(`Session ${session.sessionId} never received first heartbeat, cancelling`);
             await this.reap(session.sessionId);

--- a/src/daemon/sessionManager.ts
+++ b/src/daemon/sessionManager.ts
@@ -51,6 +51,15 @@ export interface Session {
  */
 export type SessionReleaseCallback = (sessionId: string, deviceId: string) => void;
 
+export function getDefaultSessionHeartbeatTimeoutMs(): number {
+  const rawValue = process.env.AUTOMOBILE_SESSION_HEARTBEAT_TIMEOUT_MS
+    ?? process.env.AUTO_MOBILE_SESSION_HEARTBEAT_TIMEOUT_MS;
+  const parsed = rawValue ? Number.parseInt(rawValue, 10) : NaN;
+  return Number.isFinite(parsed) && parsed > 0
+    ? parsed
+    : SessionManager.DEFAULT_HEARTBEAT_TIMEOUT_MS;
+}
+
 export class SessionManager {
   private sessions: Map<string, Session> = new Map();
   private sessionDeviceMap: Map<string, string> = new Map(); // sessionId -> deviceId
@@ -113,7 +122,7 @@ export class SessionManager {
       cacheData: {},
       lastHeartbeat: now,
       sessionTimeoutMs,
-      heartbeatTimeoutMs: heartbeatTimeoutMs ?? SessionManager.DEFAULT_HEARTBEAT_TIMEOUT_MS,
+      heartbeatTimeoutMs: heartbeatTimeoutMs ?? getDefaultSessionHeartbeatTimeoutMs(),
       hasReceivedHeartbeat: false,
     };
 

--- a/src/daemon/sessionManager.ts
+++ b/src/daemon/sessionManager.ts
@@ -34,6 +34,7 @@ export interface Session {
   lastHeartbeat: number;       // Timestamp of last heartbeat
   sessionTimeoutMs: number;    // Idle timeout used when extending this session
   heartbeatTimeoutMs: number;  // Heartbeat timeout for this session
+  heartbeatTimeoutSource: "default" | "custom"; // Whether the heartbeat timeout was defaulted or explicitly provided
   hasReceivedHeartbeat: boolean; // Whether any heartbeat has been received
 }
 
@@ -112,6 +113,7 @@ export class SessionManager {
 
     const now = this.timer.now();
     const sessionTimeoutMs = timeoutMs ?? this.SESSION_TIMEOUT_MS;
+    const heartbeatTimeoutSource = heartbeatTimeoutMs === undefined ? "default" : "custom";
     const session: Session = {
       sessionId,
       assignedDevice,
@@ -123,6 +125,7 @@ export class SessionManager {
       lastHeartbeat: now,
       sessionTimeoutMs,
       heartbeatTimeoutMs: heartbeatTimeoutMs ?? getDefaultSessionHeartbeatTimeoutMs(),
+      heartbeatTimeoutSource,
       hasReceivedHeartbeat: false,
     };
 

--- a/test/daemon/SessionHeartbeatMonitor.test.ts
+++ b/test/daemon/SessionHeartbeatMonitor.test.ts
@@ -10,6 +10,14 @@ const AUTOLOCK_ENV_KEYS = [
   "AUTO_MOBILE_DEVICE_POOL_AUTOLOCK",
   "AUTOMOBILE_DEVICE_POOL_TIMEOUT",
   "AUTO_MOBILE_DEVICE_POOL_TIMEOUT",
+  "AUTOMOBILE_SESSION_HEARTBEAT_CHECK_INTERVAL_MS",
+  "AUTO_MOBILE_SESSION_HEARTBEAT_CHECK_INTERVAL_MS",
+  "AUTOMOBILE_SESSION_HEARTBEAT_INITIAL_GRACE_MS",
+  "AUTO_MOBILE_SESSION_HEARTBEAT_INITIAL_GRACE_MS",
+  "AUTOMOBILE_SESSION_PRE_FIRST_HEARTBEAT_GRACE_MS",
+  "AUTO_MOBILE_SESSION_PRE_FIRST_HEARTBEAT_GRACE_MS",
+  "AUTOMOBILE_SESSION_HEARTBEAT_TIMEOUT_MS",
+  "AUTO_MOBILE_SESSION_HEARTBEAT_TIMEOUT_MS",
 ] as const;
 
 function clearAutolockEnv(): void {
@@ -60,12 +68,8 @@ describe("SessionHeartbeatMonitor", () => {
       );
       monitor.start();
 
-      // Within grace: interval fires but nothing is reaped.
+      // Past the pre-first-heartbeat grace on the first scan: reaped.
       timer.advanceTime(10_000);
-      expect(reaped).toEqual([]);
-
-      // Past grace (20s) and past the 10s heartbeat window with no activity: reaped.
-      timer.advanceTime(20_000);
       await Promise.resolve();
       expect(reaped).toEqual(["s1"]);
 
@@ -74,23 +78,23 @@ describe("SessionHeartbeatMonitor", () => {
   });
 
   describe("tick reaping decision", () => {
-    it("does not reap a session still within the initial grace period", async () => {
+    it("does not reap a default-heartbeat session still within the pre-first-heartbeat grace period", async () => {
       await sessionManager.createSession("s1", "emulator-5554", "android", 60_000, 10_000);
       const reaped: string[] = [];
       const monitor = new SessionHeartbeatMonitor(sessionManager, () => false, async sid => { reaped.push(sid); }, timer);
 
-      timer.advanceTime(15_000); // < 20s grace, no heartbeat yet
+      timer.advanceTime(5_000);
       await monitor.tick();
 
       expect(reaped).toEqual([]);
     });
 
-    it("reaps a stale session after the grace period", async () => {
+    it("reaps a default-heartbeat session shortly after it misses the first heartbeat", async () => {
       await sessionManager.createSession("s1", "emulator-5554", "android", 60_000, 10_000);
       const reaped: string[] = [];
       const monitor = new SessionHeartbeatMonitor(sessionManager, () => false, async sid => { reaped.push(sid); }, timer);
 
-      timer.advanceTime(31_000); // past grace and past the 10s heartbeat window
+      timer.advanceTime(5_001);
       await monitor.tick();
 
       expect(reaped).toEqual(["s1"]);
@@ -101,7 +105,7 @@ describe("SessionHeartbeatMonitor", () => {
       const reaped: string[] = [];
       const monitor = new SessionHeartbeatMonitor(sessionManager, () => true, async sid => { reaped.push(sid); }, timer);
 
-      timer.advanceTime(31_000);
+      timer.advanceTime(5_001);
       await monitor.tick();
 
       expect(reaped).toEqual([]);
@@ -116,6 +120,46 @@ describe("SessionHeartbeatMonitor", () => {
       timer.advanceTime(31_000);
       await monitor.tick();
       expect(reaped).toEqual([]);
+    });
+
+    it("uses the configured pre-first-heartbeat grace for default-heartbeat sessions", async () => {
+      await sessionManager.createSession("s1", "emulator-5554", "android", 60_000, 10_000);
+      const reaped: string[] = [];
+      const monitor = new SessionHeartbeatMonitor(
+        sessionManager,
+        () => false,
+        async sid => { reaped.push(sid); },
+        timer,
+        { preFirstHeartbeatGraceMs: 1_000 },
+      );
+
+      timer.advanceTime(1_001);
+      await monitor.tick();
+
+      expect(reaped).toEqual(["s1"]);
+    });
+
+    it("honors environment overrides for the heartbeat monitor timings", async () => {
+      process.env.AUTOMOBILE_SESSION_HEARTBEAT_CHECK_INTERVAL_MS = "1";
+      process.env.AUTOMOBILE_SESSION_PRE_FIRST_HEARTBEAT_GRACE_MS = "2";
+      await sessionManager.createSession("s1", "emulator-5554", "android", 60_000, 10_000);
+      const reaped: string[] = [];
+      const monitor = new SessionHeartbeatMonitor(
+        sessionManager,
+        () => false,
+        async sid => { reaped.push(sid); },
+        timer,
+      );
+
+      monitor.start();
+      timer.advanceTime(1);
+      await Promise.resolve();
+      expect(reaped).toEqual([]);
+
+      timer.advanceTime(2);
+      await Promise.resolve();
+      expect(reaped).toEqual(["s1"]);
+      monitor.stop();
     });
   });
 

--- a/test/daemon/SessionHeartbeatMonitor.test.ts
+++ b/test/daemon/SessionHeartbeatMonitor.test.ts
@@ -58,7 +58,7 @@ describe("SessionHeartbeatMonitor", () => {
     });
 
     it("reaps on each interval tick", async () => {
-      await sessionManager.createSession("s1", "emulator-5554", "android", 60_000, 10_000);
+      await sessionManager.createSession("s1", "emulator-5554", "android", 60_000);
       const reaped: string[] = [];
       const monitor = new SessionHeartbeatMonitor(
         sessionManager,
@@ -79,7 +79,7 @@ describe("SessionHeartbeatMonitor", () => {
 
   describe("tick reaping decision", () => {
     it("does not reap a default-heartbeat session still within the pre-first-heartbeat grace period", async () => {
-      await sessionManager.createSession("s1", "emulator-5554", "android", 60_000, 10_000);
+      await sessionManager.createSession("s1", "emulator-5554", "android", 60_000);
       const reaped: string[] = [];
       const monitor = new SessionHeartbeatMonitor(sessionManager, () => false, async sid => { reaped.push(sid); }, timer);
 
@@ -90,7 +90,7 @@ describe("SessionHeartbeatMonitor", () => {
     });
 
     it("reaps a default-heartbeat session shortly after it misses the first heartbeat", async () => {
-      await sessionManager.createSession("s1", "emulator-5554", "android", 60_000, 10_000);
+      await sessionManager.createSession("s1", "emulator-5554", "android", 60_000);
       const reaped: string[] = [];
       const monitor = new SessionHeartbeatMonitor(sessionManager, () => false, async sid => { reaped.push(sid); }, timer);
 
@@ -101,7 +101,7 @@ describe("SessionHeartbeatMonitor", () => {
     });
 
     it("skips a session with active executions", async () => {
-      await sessionManager.createSession("s1", "emulator-5554", "android", 60_000, 10_000);
+      await sessionManager.createSession("s1", "emulator-5554", "android", 60_000);
       const reaped: string[] = [];
       const monitor = new SessionHeartbeatMonitor(sessionManager, () => true, async sid => { reaped.push(sid); }, timer);
 
@@ -122,8 +122,24 @@ describe("SessionHeartbeatMonitor", () => {
       expect(reaped).toEqual([]);
     });
 
+    it("treats explicit heartbeat timeout as custom even when it equals the configured default", async () => {
+      process.env.AUTOMOBILE_SESSION_HEARTBEAT_TIMEOUT_MS = "60000";
+      await sessionManager.createSession("default-session", "emulator-5554", "android", 60_000);
+      await sessionManager.createSession("custom-session", "emulator-5556", "android", 60_000, 60_000);
+      const reaped: string[] = [];
+      const monitor = new SessionHeartbeatMonitor(sessionManager, () => false, async sid => { reaped.push(sid); }, timer);
+
+      timer.advanceTime(5_001);
+      await monitor.tick();
+      expect(reaped).toEqual(["default-session"]);
+
+      timer.advanceTime(25_999);
+      await monitor.tick();
+      expect(reaped).not.toContain("custom-session");
+    });
+
     it("uses the configured pre-first-heartbeat grace for default-heartbeat sessions", async () => {
-      await sessionManager.createSession("s1", "emulator-5554", "android", 60_000, 10_000);
+      await sessionManager.createSession("s1", "emulator-5554", "android", 60_000);
       const reaped: string[] = [];
       const monitor = new SessionHeartbeatMonitor(
         sessionManager,
@@ -142,7 +158,7 @@ describe("SessionHeartbeatMonitor", () => {
     it("honors environment overrides for the heartbeat monitor timings", async () => {
       process.env.AUTOMOBILE_SESSION_HEARTBEAT_CHECK_INTERVAL_MS = "1";
       process.env.AUTOMOBILE_SESSION_PRE_FIRST_HEARTBEAT_GRACE_MS = "2";
-      await sessionManager.createSession("s1", "emulator-5554", "android", 60_000, 10_000);
+      await sessionManager.createSession("s1", "emulator-5554", "android", 60_000);
       const reaped: string[] = [];
       const monitor = new SessionHeartbeatMonitor(
         sessionManager,

--- a/test/daemon/SessionHeartbeatMonitor.test.ts
+++ b/test/daemon/SessionHeartbeatMonitor.test.ts
@@ -100,6 +100,22 @@ describe("SessionHeartbeatMonitor", () => {
       expect(reaped).toEqual(["s1"]);
     });
 
+    it("does not reap a default-heartbeat session with recent activity before its first heartbeat", async () => {
+      await sessionManager.createSession("s1", "emulator-5554", "android", 60_000);
+      const reaped: string[] = [];
+      const monitor = new SessionHeartbeatMonitor(sessionManager, () => false, async sid => { reaped.push(sid); }, timer);
+
+      timer.advanceTime(4_000);
+      await sessionManager.getOrCreateSession("s1");
+      timer.advanceTime(2_000);
+      await monitor.tick();
+      expect(reaped).toEqual([]);
+
+      timer.advanceTime(3_001);
+      await monitor.tick();
+      expect(reaped).toEqual(["s1"]);
+    });
+
     it("skips a session with active executions", async () => {
       await sessionManager.createSession("s1", "emulator-5554", "android", 60_000);
       const reaped: string[] = [];

--- a/test/daemon/devicePool.autolock.test.ts
+++ b/test/daemon/devicePool.autolock.test.ts
@@ -203,13 +203,19 @@ describe("DevicePool autolock", () => {
     });
 
     it("survives the daemon heartbeat watchdog until the idle timeout", async () => {
-      // Mirrors the reaping predicate in daemon.ts startHeartbeatMonitor():
-      //   after the initial grace, a session is cancelled when
-      //   now - lastHeartbeat > heartbeatTimeoutMs (and it has no active executions).
-      const INITIAL_HEARTBEAT_GRACE_MS = 20_000;
+      // Mirrors SessionHeartbeatMonitor: default-heartbeat sessions that never
+      // heartbeat are reaped quickly, while custom-heartbeat sessions use the
+      // normal heartbeat timeout after the initial grace.
+      const PRE_FIRST_HEARTBEAT_GRACE_MS = 5_000;
+      const CUSTOM_HEARTBEAT_INITIAL_GRACE_MS = 20_000;
       const wouldReap = (createdAt: number, lastHeartbeat: number, heartbeatTimeoutMs: number, now: number, hasReceivedHeartbeat: boolean): boolean => {
-        if (!hasReceivedHeartbeat && now - createdAt < INITIAL_HEARTBEAT_GRACE_MS) {
-          return false;
+        if (!hasReceivedHeartbeat) {
+          if (heartbeatTimeoutMs === SessionManager.DEFAULT_HEARTBEAT_TIMEOUT_MS) {
+            return now - createdAt > PRE_FIRST_HEARTBEAT_GRACE_MS;
+          }
+          if (now - createdAt < CUSTOM_HEARTBEAT_INITIAL_GRACE_MS) {
+            return false;
+          }
         }
         return now - lastHeartbeat > heartbeatTimeoutMs;
       };
@@ -239,12 +245,13 @@ describe("DevicePool autolock", () => {
 
     it("ongoing interaction keeps an autolocked device alive past the heartbeat window", async () => {
       // Integration: a locked device driven through repeated session resolutions
-      // (createToolExecutionContext -> getOrCreateSession on every tool call) must
-      // not be reaped by the heartbeat watchdog, because each interaction bumps
-      // lastHeartbeat. Mirrors the daemon.ts startHeartbeatMonitor() predicate.
-      const INITIAL_HEARTBEAT_GRACE_MS = 20_000;
+      // (createToolExecutionContext -> getOrCreateSession on every tool call)
+      // must not be reaped by the heartbeat watchdog, because each interaction
+      // bumps lastHeartbeat. Mirrors SessionHeartbeatMonitor for a custom
+      // heartbeat timeout.
+      const CUSTOM_HEARTBEAT_INITIAL_GRACE_MS = 20_000;
       const reapableAt = (session: { createdAt: number; lastHeartbeat: number; heartbeatTimeoutMs: number; hasReceivedHeartbeat: boolean }, now: number): boolean => {
-        if (!session.hasReceivedHeartbeat && now - session.createdAt < INITIAL_HEARTBEAT_GRACE_MS) {
+        if (!session.hasReceivedHeartbeat && now - session.createdAt < CUSTOM_HEARTBEAT_INITIAL_GRACE_MS) {
           return false;
         }
         return now - session.lastHeartbeat > session.heartbeatTimeoutMs;

--- a/test/daemon/devicePool.autolock.test.ts
+++ b/test/daemon/devicePool.autolock.test.ts
@@ -208,9 +208,16 @@ describe("DevicePool autolock", () => {
       // normal heartbeat timeout after the initial grace.
       const PRE_FIRST_HEARTBEAT_GRACE_MS = 5_000;
       const CUSTOM_HEARTBEAT_INITIAL_GRACE_MS = 20_000;
-      const wouldReap = (createdAt: number, lastHeartbeat: number, heartbeatTimeoutMs: number, now: number, hasReceivedHeartbeat: boolean): boolean => {
+      const wouldReap = (
+        createdAt: number,
+        lastHeartbeat: number,
+        heartbeatTimeoutMs: number,
+        heartbeatTimeoutSource: "default" | "custom",
+        now: number,
+        hasReceivedHeartbeat: boolean
+      ): boolean => {
         if (!hasReceivedHeartbeat) {
-          if (heartbeatTimeoutMs === SessionManager.DEFAULT_HEARTBEAT_TIMEOUT_MS) {
+          if (heartbeatTimeoutSource === "default") {
             return now - createdAt > PRE_FIRST_HEARTBEAT_GRACE_MS;
           }
           if (now - createdAt < CUSTOM_HEARTBEAT_INITIAL_GRACE_MS) {
@@ -229,17 +236,17 @@ describe("DevicePool autolock", () => {
 
       // With the OLD 10s heartbeat timeout the watchdog would have reaped this at ~20s.
       expect(
-        wouldReap(session.createdAt, session.lastHeartbeat, SessionManager.DEFAULT_HEARTBEAT_TIMEOUT_MS, 20_000, false)
+        wouldReap(session.createdAt, session.lastHeartbeat, SessionManager.DEFAULT_HEARTBEAT_TIMEOUT_MS, "default", 20_000, false)
       ).toBe(true);
 
       // With the aligned timeout it survives the grace + well past the old window...
       expect(
-        wouldReap(session.createdAt, session.lastHeartbeat, session.heartbeatTimeoutMs, 30_000, false)
+        wouldReap(session.createdAt, session.lastHeartbeat, session.heartbeatTimeoutMs, session.heartbeatTimeoutSource, 30_000, false)
       ).toBe(false);
 
       // ...and is only reaped once the idle timeout elapses with no activity.
       expect(
-        wouldReap(session.createdAt, session.lastHeartbeat, session.heartbeatTimeoutMs, 60_001, false)
+        wouldReap(session.createdAt, session.lastHeartbeat, session.heartbeatTimeoutMs, session.heartbeatTimeoutSource, 60_001, false)
       ).toBe(true);
     });
 

--- a/test/daemon/sessionManager.test.ts
+++ b/test/daemon/sessionManager.test.ts
@@ -65,6 +65,15 @@ describe("SessionManager", () => {
       const session = await sessionManager.createSession("session-1", "emulator-5554", "android");
 
       expect(session.heartbeatTimeoutMs).toBe(15_000);
+      expect(session.heartbeatTimeoutSource).toBe("default");
+    });
+
+    test("should mark explicitly provided heartbeat timeout as custom", async () => {
+      process.env.AUTOMOBILE_SESSION_HEARTBEAT_TIMEOUT_MS = "15000";
+      const session = await sessionManager.createSession("session-1", "emulator-5554", "android", 30_000, 15_000);
+
+      expect(session.heartbeatTimeoutMs).toBe(15_000);
+      expect(session.heartbeatTimeoutSource).toBe("custom");
     });
   });
 

--- a/test/daemon/sessionManager.test.ts
+++ b/test/daemon/sessionManager.test.ts
@@ -2,17 +2,30 @@ import { describe, expect, test, beforeEach, afterEach } from "bun:test";
 import { SessionManager } from "../../src/daemon/sessionManager";
 import { FakeTimer } from "../fakes/FakeTimer";
 
+const HEARTBEAT_ENV_KEYS = [
+  "AUTOMOBILE_SESSION_HEARTBEAT_TIMEOUT_MS",
+  "AUTO_MOBILE_SESSION_HEARTBEAT_TIMEOUT_MS",
+] as const;
+
+function clearHeartbeatEnv(): void {
+  for (const key of HEARTBEAT_ENV_KEYS) {
+    delete process.env[key];
+  }
+}
+
 describe("SessionManager", () => {
   let sessionManager: SessionManager;
   let fakeTimer: FakeTimer;
 
   beforeEach(() => {
+    clearHeartbeatEnv();
     fakeTimer = new FakeTimer();
     sessionManager = new SessionManager(fakeTimer);
   });
 
   afterEach(() => {
     sessionManager.stopCleanupTimer();
+    clearHeartbeatEnv();
   });
 
   describe("createSession", () => {
@@ -45,6 +58,13 @@ describe("SessionManager", () => {
       const session = await sessionManager.createSession("session-1", "emulator-5554", "android", 5000);
       expect(session.sessionTimeoutMs).toBe(5000);
       expect(session.expiresAt).toBe(fakeTimer.now() + 5000);
+    });
+
+    test("should use configured default heartbeat timeout", async () => {
+      process.env.AUTOMOBILE_SESSION_HEARTBEAT_TIMEOUT_MS = "15000";
+      const session = await sessionManager.createSession("session-1", "emulator-5554", "android");
+
+      expect(session.heartbeatTimeoutMs).toBe(15_000);
     });
   });
 


### PR DESCRIPTION
## Summary
- reclaim default-heartbeat sessions shortly after they miss their first heartbeat
- keep custom-heartbeat and autolock sessions on their configured timeout path
- add heartbeat timing environment overrides and daemon docs

Fixes #2443

## Testing
- `bun test test/daemon/SessionHeartbeatMonitor.test.ts`
- `bun test test/daemon/sessionManager.test.ts`
- `bun test test/daemon/devicePool.autolock.test.ts`
- `bun run lint`
- `bun run build`
- `git diff --check`
