### PR TITLE
Push initial observation frame on subscribe

### DIFF
--- a/src/daemon/daemon.ts
+++ b/src/daemon/daemon.ts
@@ -36,6 +36,10 @@ import { startTelemetryPushSocketServer, stopTelemetryPushSocketServer } from ".
 import { AndroidCtrlProxyClient } from "../features/observe/android";
 import { defaultAdbClientFactory } from "../utils/android-cmdline-tools/AdbClientFactory";
 import { IOSCtrlProxyClient } from "../features/observe/ios";
+import {
+  pushInitialObservationFramesForSubscriber,
+  type ObservationStreamIosClient,
+} from "./observationInitialFrame";
 import { NavigationGraphManager } from "../features/navigation/NavigationGraphManager";
 import { RealObserveScreen } from "../features/observe/ObserveScreen";
 import type { InstalledAppsStore } from "../db/installedAppsRepository";
@@ -50,6 +54,7 @@ import { describeUnknownError } from "../utils/describeUnknownError";
 import { FeatureFlagService } from "../features/featureFlags/FeatureFlagService";
 import { serverConfig } from "../utils/ServerConfig";
 import { setDebugPerfEnabled } from "../utils/PerformanceTracker";
+import type { BootedDevice } from "../models";
 
 const DEVICE_DISCONNECT_POLL_INTERVAL_MS = 5000;
 const DEVICE_DISCONNECT_MISS_THRESHOLD = 3;
@@ -616,56 +621,13 @@ export class Daemon {
 
       const allDevices = this.devicePool.getAllDevices();
 
-      // Android: ensure accessibility service WebSocket is connected
-      const androidDevices = allDevices.filter(d => d.platform === "android");
-      for (const pooledDevice of androidDevices) {
-        if (deviceId !== null && pooledDevice.id !== deviceId) {continue;}
-        try {
-          const bootedDevice = {
-            deviceId: pooledDevice.id,
-            name: pooledDevice.name,
-            platform: pooledDevice.platform as "android",
-          };
-          const client = AndroidCtrlProxyClient.getInstance(bootedDevice, defaultAdbClientFactory);
-          client.ensureConnected().then(connected => {
-            if (connected) {
-              logger.info(`[Daemon] WebSocket connected to ${pooledDevice.id} for observation stream`);
-            } else {
-              logger.warn(`[Daemon] Failed to connect WebSocket to ${pooledDevice.id}`);
-            }
-          }).catch(error => {
-            logger.warn(`[Daemon] Error connecting WebSocket to ${pooledDevice.id}: ${error}`);
-          });
-        } catch (error) {
-          logger.warn(`[Daemon] Error setting up WebSocket for ${pooledDevice.id}: ${error}`);
-        }
-      }
-
-      // iOS: ensure CtrlProxy is set up and connected
-      const iosDevices = allDevices.filter(d => d.platform === "ios");
-      for (const pooledDevice of iosDevices) {
-        if (deviceId !== null && pooledDevice.id !== deviceId) {continue;}
-        try {
-          const bootedDevice = {
-            deviceId: pooledDevice.id,
-            name: pooledDevice.name,
-            platform: "ios" as const,
-          };
-          logger.info(`[Daemon] Setting up CtrlProxy iOS for iOS device ${pooledDevice.id}`);
-          const client = IOSCtrlProxyClient.getInstance(bootedDevice, null);
-          client.ensureConnected().then(connected => {
-            if (connected) {
-              logger.info(`[Daemon] CtrlProxy iOS connected to ${pooledDevice.id} for observation stream`);
-            } else {
-              logger.warn(`[Daemon] Failed to connect CtrlProxy iOS to ${pooledDevice.id}`);
-            }
-          }).catch(error => {
-            logger.warn(`[Daemon] Error connecting CtrlProxy iOS to ${pooledDevice.id}: ${error}`);
-          });
-        } catch (error) {
-          logger.warn(`[Daemon] Error setting up CtrlProxy iOS for ${pooledDevice.id}: ${error}`);
-        }
-      }
+      pushInitialObservationFramesForSubscriber(deviceId, allDevices, {
+        streamServer: server,
+        androidClientFactory: device => AndroidCtrlProxyClient.getInstance(device, defaultAdbClientFactory),
+        iosClientFactory: device => this.createObservationStreamIosClient(device),
+      }).catch(error => {
+        logger.warn(`[Daemon] Error pushing initial observation frame: ${error}`);
+      });
 
       if (allDevices.length === 0) {
         logger.info("[Daemon] No devices in pool to connect");
@@ -676,6 +638,21 @@ export class Daemon {
 
     // Wire up navigation graph updates to stream to IDE plugins
     this.setupNavigationGraphStreamListener(server);
+  }
+
+  private createObservationStreamIosClient(device: BootedDevice): ObservationStreamIosClient {
+    const client = IOSCtrlProxyClient.getInstance(device);
+    return {
+      ensureConnected: () => client.ensureConnected(),
+      getLatestHierarchy: (...args) => client.getLatestHierarchy(...args),
+      requestHierarchySync: async (...args) => {
+        const result = await client.requestHierarchySync(...args);
+        return result ? { hierarchy: result.hierarchy } : null;
+      },
+      convertToViewHierarchyResult: hierarchy =>
+        client.convertToViewHierarchyResult(hierarchy as never),
+      requestScreenshot: (...args) => client.requestScreenshot(...args),
+    };
   }
 
   /**

--- a/src/daemon/observationInitialFrame.ts
+++ b/src/daemon/observationInitialFrame.ts
@@ -1,0 +1,248 @@
+import { logger } from "../utils/logger";
+import type { BootedDevice, Platform, ViewHierarchyResult } from "../models";
+import type { DeviceDataStreamSocketServer } from "./deviceDataStreamSocketServer";
+import type { PerformanceTracker } from "../utils/PerformanceTracker";
+import type {
+  AccessibilityHierarchy,
+  AccessibilityHierarchyResponse,
+  ScreenshotResult,
+} from "../features/observe/android";
+import type {
+  CtrlProxyHierarchy,
+  CtrlProxyHierarchyResponse,
+  CtrlProxyScreenshotResult,
+} from "../features/observe/ios/types";
+
+const INITIAL_FRAME_HIERARCHY_TIMEOUT_MS = 3_000;
+const INITIAL_FRAME_SCREENSHOT_TIMEOUT_MS = 3_000;
+const ANDROID_DEFAULT_SCREEN_WIDTH = 1080;
+const ANDROID_DEFAULT_SCREEN_HEIGHT = 2340;
+const IOS_DEFAULT_SCREEN_WIDTH = 1170;
+const IOS_DEFAULT_SCREEN_HEIGHT = 2532;
+
+export interface ObservationStreamDevice {
+  id: string;
+  name: string;
+  platform: Platform;
+}
+
+export interface ObservationStreamAndroidClient {
+  ensureConnected(): Promise<boolean>;
+  getLatestHierarchy(
+    waitForFresh?: boolean,
+    timeout?: number,
+    perf?: PerformanceTracker,
+    skipWaitForFresh?: boolean,
+    minTimestamp?: number
+  ): Promise<AccessibilityHierarchyResponse>;
+  requestHierarchySyncWithoutObservationStreamPush(
+    perf?: PerformanceTracker,
+    disableAllFiltering?: boolean,
+    signal?: AbortSignal,
+    timeoutMs?: number
+  ): Promise<{ hierarchy: AccessibilityHierarchy } | null>;
+  convertToViewHierarchyResult(hierarchy: AccessibilityHierarchy): ViewHierarchyResult;
+  requestScreenshotWithoutObservationStreamPush(timeoutMs?: number, perf?: PerformanceTracker): Promise<ScreenshotResult>;
+}
+
+export interface ObservationStreamIosClient {
+  ensureConnected(): Promise<boolean>;
+  getLatestHierarchy(
+    waitForFresh?: boolean,
+    timeout?: number,
+    perf?: PerformanceTracker,
+    skipWaitForFresh?: boolean,
+    minTimestamp?: number
+  ): Promise<CtrlProxyHierarchyResponse>;
+  requestHierarchySync(
+    perf?: PerformanceTracker,
+    disableAllFiltering?: boolean,
+    signal?: AbortSignal,
+    timeoutMs?: number
+  ): Promise<{ hierarchy: unknown } | null>;
+  convertToViewHierarchyResult(hierarchy: unknown): ViewHierarchyResult;
+  requestScreenshot(timeoutMs?: number, perf?: PerformanceTracker): Promise<CtrlProxyScreenshotResult>;
+}
+
+export interface ObservationInitialFrameDependencies {
+  streamServer: Pick<DeviceDataStreamSocketServer, "pushHierarchyUpdate" | "pushScreenshotUpdate">;
+  androidClientFactory: (device: BootedDevice) => ObservationStreamAndroidClient;
+  iosClientFactory: (device: BootedDevice) => ObservationStreamIosClient;
+}
+
+export async function pushInitialObservationFramesForSubscriber(
+  requestedDeviceId: string | null,
+  devices: ObservationStreamDevice[],
+  dependencies: ObservationInitialFrameDependencies
+): Promise<void> {
+  const targetDevices = devices.filter(device =>
+    requestedDeviceId === null || device.id === requestedDeviceId
+  );
+
+  await Promise.all(targetDevices.map(device =>
+    pushInitialObservationFrameForDevice(device, dependencies)
+  ));
+}
+
+async function pushInitialObservationFrameForDevice(
+  device: ObservationStreamDevice,
+  dependencies: ObservationInitialFrameDependencies
+): Promise<void> {
+  const bootedDevice: BootedDevice = {
+    deviceId: device.id,
+    name: device.name,
+    platform: device.platform,
+  };
+
+  try {
+    if (device.platform === "android") {
+      await pushAndroidInitialObservationFrame(bootedDevice, dependencies);
+      return;
+    }
+
+    if (device.platform === "ios") {
+      await pushIosInitialObservationFrame(bootedDevice, dependencies);
+    }
+  } catch (error) {
+    logger.warn(`[Daemon] Failed to push initial observation frame for ${device.id}: ${error}`);
+  }
+}
+
+async function pushAndroidInitialObservationFrame(
+  device: BootedDevice,
+  dependencies: ObservationInitialFrameDependencies
+): Promise<void> {
+  const client = dependencies.androidClientFactory(device);
+  const connected = await client.ensureConnected();
+  if (!connected) {
+    logger.warn(`[Daemon] Failed to connect WebSocket to ${device.deviceId}`);
+    return;
+  }
+
+  logger.info(`[Daemon] WebSocket connected to ${device.deviceId} for observation stream`);
+
+  const hierarchy = await getAndroidInitialHierarchy(client);
+  if (!hierarchy) {
+    logger.warn(`[Daemon] No hierarchy available for initial observation frame on ${device.deviceId}`);
+    return;
+  }
+
+  const viewHierarchy = client.convertToViewHierarchyResult(hierarchy);
+  dependencies.streamServer.pushHierarchyUpdate(device.deviceId, viewHierarchy);
+
+  await pushAndroidInitialScreenshot(device.deviceId, client, dependencies.streamServer, viewHierarchy);
+}
+
+async function pushAndroidInitialScreenshot(
+  deviceId: string,
+  client: ObservationStreamAndroidClient,
+  streamServer: Pick<DeviceDataStreamSocketServer, "pushScreenshotUpdate">,
+  viewHierarchy: ViewHierarchyResult
+): Promise<void> {
+  // Android's normal screenshot request auto-pushes to the observation stream.
+  // Suppress that side effect so this initial frame is pushed exactly once with
+  // dimensions derived from the paired hierarchy.
+  const screenshot = await client.requestScreenshotWithoutObservationStreamPush(INITIAL_FRAME_SCREENSHOT_TIMEOUT_MS);
+  if (screenshot.success && screenshot.data) {
+    const dimensions = getAndroidScreenshotDimensions(viewHierarchy);
+    streamServer.pushScreenshotUpdate(
+      deviceId,
+      screenshot.data,
+      dimensions.width,
+      dimensions.height
+    );
+  }
+}
+
+async function getAndroidInitialHierarchy(
+  client: ObservationStreamAndroidClient
+): Promise<AccessibilityHierarchy | null> {
+  const hierarchyResponse = await client.getLatestHierarchy(
+    false,
+    INITIAL_FRAME_HIERARCHY_TIMEOUT_MS,
+    undefined,
+    true
+  );
+  if (hierarchyResponse.hierarchy && hierarchyResponse.fresh) {
+    return hierarchyResponse.hierarchy;
+  }
+
+  const syncHierarchy = await client.requestHierarchySyncWithoutObservationStreamPush(
+    undefined,
+    false,
+    undefined,
+    INITIAL_FRAME_HIERARCHY_TIMEOUT_MS
+  );
+  return syncHierarchy?.hierarchy ?? null;
+}
+
+async function pushIosInitialObservationFrame(
+  device: BootedDevice,
+  dependencies: ObservationInitialFrameDependencies
+): Promise<void> {
+  const client = dependencies.iosClientFactory(device);
+  const connected = await client.ensureConnected();
+  if (!connected) {
+    logger.warn(`[Daemon] Failed to connect CtrlProxy iOS to ${device.deviceId}`);
+    return;
+  }
+
+  logger.info(`[Daemon] CtrlProxy iOS connected to ${device.deviceId} for observation stream`);
+
+  const hierarchy = await getIosInitialHierarchy(client);
+  if (!hierarchy) {
+    logger.warn(`[Daemon] No hierarchy available for initial observation frame on ${device.deviceId}`);
+    return;
+  }
+
+  const viewHierarchy = client.convertToViewHierarchyResult(hierarchy);
+  dependencies.streamServer.pushHierarchyUpdate(device.deviceId, viewHierarchy);
+
+  const screenshot = await client.requestScreenshot(INITIAL_FRAME_SCREENSHOT_TIMEOUT_MS);
+  if (screenshot.success && screenshot.data) {
+    const dimensions = getIosScreenshotDimensions(viewHierarchy);
+    dependencies.streamServer.pushScreenshotUpdate(
+      device.deviceId,
+      screenshot.data,
+      dimensions.width,
+      dimensions.height
+    );
+  }
+}
+
+async function getIosInitialHierarchy(
+  client: ObservationStreamIosClient
+): Promise<CtrlProxyHierarchy | null> {
+  const hierarchyResponse = await client.getLatestHierarchy(
+    false,
+    INITIAL_FRAME_HIERARCHY_TIMEOUT_MS,
+    undefined,
+    true
+  );
+  if (hierarchyResponse.hierarchy && hierarchyResponse.fresh) {
+    return hierarchyResponse.hierarchy;
+  }
+
+  const syncHierarchy = await client.requestHierarchySync(
+    undefined,
+    false,
+    undefined,
+    INITIAL_FRAME_HIERARCHY_TIMEOUT_MS
+  );
+  return syncHierarchy ? syncHierarchy.hierarchy as CtrlProxyHierarchy : null;
+}
+
+function getAndroidScreenshotDimensions(hierarchy: ViewHierarchyResult): { width: number; height: number } {
+  return {
+    width: hierarchy.screenWidth ?? ANDROID_DEFAULT_SCREEN_WIDTH,
+    height: hierarchy.screenHeight ?? ANDROID_DEFAULT_SCREEN_HEIGHT,
+  };
+}
+
+function getIosScreenshotDimensions(hierarchy: ViewHierarchyResult): { width: number; height: number } {
+  const scale = hierarchy.screenScale ?? 1;
+  return {
+    width: hierarchy.screenWidth ? Math.round(hierarchy.screenWidth * scale) : IOS_DEFAULT_SCREEN_WIDTH,
+    height: hierarchy.screenHeight ? Math.round(hierarchy.screenHeight * scale) : IOS_DEFAULT_SCREEN_HEIGHT,
+  };
+}

--- a/src/features/observe/android/AndroidCtrlProxyClient.ts
+++ b/src/features/observe/android/AndroidCtrlProxyClient.ts
@@ -786,7 +786,10 @@ export class AndroidCtrlProxyClient extends DeviceServiceClient implements Andro
   private screenshotBackoffScheduler: ScreenshotBackoffScheduler | null = null;
   private cachedScreenDimensions: { width: number; height: number } | null = null;
   private hierarchyObservationStreamSuppressions: Set<ObservationStreamSuppression> = new Set();
-  private suppressNextScreenshotObservationStreamPush: boolean = false;
+  // Request ids whose screenshot responses must not be auto-pushed to the
+  // observation stream. Scoped per-request so an unrelated in-flight screenshot
+  // (e.g. backoff capture or MCP screenshot) cannot consume the suppression.
+  private screenshotObservationStreamSuppressions: Set<string> = new Set();
   // Track whether the device supports accessibility service screenshots (API 30+).
   // null = unknown, true = supported, false = unsupported (fall back to ADB screencap).
   // Only marked unsupported after consecutive failures to avoid disabling on transient timeouts.
@@ -1624,8 +1627,13 @@ export class AndroidCtrlProxyClient extends DeviceServiceClient implements Andro
     }
   }
 
-  async requestScreenshot(timeoutMs: number = 5000, perf: PerformanceTracker = new NoOpPerformanceTracker()): Promise<ScreenshotResult> {
+  async requestScreenshot(
+    timeoutMs: number = 5000,
+    perf: PerformanceTracker = new NoOpPerformanceTracker(),
+    suppressObservationStreamPush: boolean = false
+  ): Promise<ScreenshotResult> {
     const startTime = this.timer.now();
+    let suppressedRequestId: string | undefined;
 
     try {
       const connected = await perf.track("ensureConnection", () => this.connectWebSocket(perf));
@@ -1635,6 +1643,10 @@ export class AndroidCtrlProxyClient extends DeviceServiceClient implements Andro
       }
 
       const requestId = this.requestManager.generateId("screenshot");
+      if (suppressObservationStreamPush) {
+        this.screenshotObservationStreamSuppressions.add(requestId);
+        suppressedRequestId = requestId;
+      }
 
       const screenshotPromise = this.requestManager.register<ScreenshotResult>(
         requestId, "screenshot", timeoutMs,
@@ -1665,6 +1677,13 @@ export class AndroidCtrlProxyClient extends DeviceServiceClient implements Andro
       const duration = this.timer.now() - startTime;
       logger.warn(`[CTRL_PROXY] Screenshot request failed after ${duration}ms: ${error}`);
       return { success: false, error: `${error}` };
+    } finally {
+      // Clean up the suppression token in case the response never arrived
+      // (timeout/error). The message handler deletes it on a normal response;
+      // this guards against leaking ids for in-flight requests that never resolve.
+      if (suppressedRequestId !== undefined) {
+        this.screenshotObservationStreamSuppressions.delete(suppressedRequestId);
+      }
     }
   }
 
@@ -1672,12 +1691,7 @@ export class AndroidCtrlProxyClient extends DeviceServiceClient implements Andro
     timeoutMs: number = 5000,
     perf: PerformanceTracker = new NoOpPerformanceTracker()
   ): Promise<ScreenshotResult> {
-    this.suppressNextScreenshotObservationStreamPush = true;
-    try {
-      return await this.requestScreenshot(timeoutMs, perf);
-    } finally {
-      this.suppressNextScreenshotObservationStreamPush = false;
-    }
+    return this.requestScreenshot(timeoutMs, perf, true);
   }
 
   async verifyServiceReady(maxAttempts: number = 5, delayMs: number = 500, timeoutMs: number = 3000): Promise<boolean> {
@@ -1876,8 +1890,7 @@ export class AndroidCtrlProxyClient extends DeviceServiceClient implements Andro
 
       // Handle screenshot response
       if (message.type === "screenshot" && message.requestId) {
-        const suppressObservationStreamPush = this.suppressNextScreenshotObservationStreamPush;
-        this.suppressNextScreenshotObservationStreamPush = false;
+        const suppressObservationStreamPush = this.screenshotObservationStreamSuppressions.delete(message.requestId);
         if (!suppressObservationStreamPush) {
           this.pushScreenshotToObservationStream(message.data);
         } else {

--- a/src/features/observe/android/AndroidCtrlProxyClient.ts
+++ b/src/features/observe/android/AndroidCtrlProxyClient.ts
@@ -190,6 +190,10 @@ interface WsConnectedMessage extends WsMessageBase {
   type: "connected";
 }
 
+interface ObservationStreamSuppression {
+  timeoutHandle: NodeJS.Timeout;
+}
+
 interface WsHierarchyUpdateMessage extends WsMessageBase {
   type: "hierarchy_update";
   data: AccessibilityHierarchy;
@@ -623,6 +627,13 @@ export interface AndroidCtrlProxy extends CtrlProxyClient {
     timeoutMs?: number
   ): Promise<{ hierarchy: AccessibilityHierarchy; perfTiming?: AndroidPerfTiming[] } | null>;
 
+  requestHierarchySyncWithoutObservationStreamPush(
+    perf?: PerformanceTracker,
+    disableAllFiltering?: boolean,
+    signal?: AbortSignal,
+    timeoutMs?: number
+  ): Promise<{ hierarchy: AccessibilityHierarchy; perfTiming?: AndroidPerfTiming[] } | null>;
+
   convertToViewHierarchyResult(accessibilityHierarchy: AccessibilityHierarchy): ViewHierarchyResult;
 
   requestSwipe(
@@ -707,6 +718,8 @@ export interface AndroidCtrlProxy extends CtrlProxyClient {
 
   requestScreenshot(timeoutMs?: number, perf?: PerformanceTracker): Promise<ScreenshotResult>;
 
+  requestScreenshotWithoutObservationStreamPush(timeoutMs?: number, perf?: PerformanceTracker): Promise<ScreenshotResult>;
+
   requestInstalledPackages(
     includeSystem?: boolean,
     userId?: number,
@@ -772,6 +785,8 @@ export class AndroidCtrlProxyClient extends DeviceServiceClient implements Andro
   // Screenshot backoff scheduler
   private screenshotBackoffScheduler: ScreenshotBackoffScheduler | null = null;
   private cachedScreenDimensions: { width: number; height: number } | null = null;
+  private hierarchyObservationStreamSuppressions: Set<ObservationStreamSuppression> = new Set();
+  private suppressNextScreenshotObservationStreamPush: boolean = false;
   // Track whether the device supports accessibility service screenshots (API 30+).
   // null = unknown, true = supported, false = unsupported (fall back to ADB screencap).
   // Only marked unsupported after consecutive failures to avoid disabling on transient timeouts.
@@ -1129,6 +1144,21 @@ export class AndroidCtrlProxyClient extends DeviceServiceClient implements Andro
     timeoutMs: number = 10000
   ): Promise<{ hierarchy: AccessibilityHierarchy; perfTiming?: AndroidPerfTiming[] } | null> {
     return this.hierarchy.requestHierarchySync(perf, disableAllFiltering, signal, timeoutMs);
+  }
+
+  async requestHierarchySyncWithoutObservationStreamPush(
+    perf: PerformanceTracker = new NoOpPerformanceTracker(),
+    disableAllFiltering: boolean = false,
+    signal?: AbortSignal,
+    timeoutMs: number = 10000
+  ): Promise<{ hierarchy: AccessibilityHierarchy; perfTiming?: AndroidPerfTiming[] } | null> {
+    const suppression: ObservationStreamSuppression = {
+      timeoutHandle: this.timer.setTimeout(() => {
+        this.hierarchyObservationStreamSuppressions.delete(suppression);
+      }, timeoutMs),
+    };
+    this.hierarchyObservationStreamSuppressions.add(suppression);
+    return this.requestHierarchySync(perf, disableAllFiltering, signal, timeoutMs);
   }
 
   convertToViewHierarchyResult(accessibilityHierarchy: AccessibilityHierarchy): ViewHierarchyResult {
@@ -1638,6 +1668,18 @@ export class AndroidCtrlProxyClient extends DeviceServiceClient implements Andro
     }
   }
 
+  async requestScreenshotWithoutObservationStreamPush(
+    timeoutMs: number = 5000,
+    perf: PerformanceTracker = new NoOpPerformanceTracker()
+  ): Promise<ScreenshotResult> {
+    this.suppressNextScreenshotObservationStreamPush = true;
+    try {
+      return await this.requestScreenshot(timeoutMs, perf);
+    } finally {
+      this.suppressNextScreenshotObservationStreamPush = false;
+    }
+  }
+
   async verifyServiceReady(maxAttempts: number = 5, delayMs: number = 500, timeoutMs: number = 3000): Promise<boolean> {
     const result = await this.retryExecutor.execute(
       async attempt => {
@@ -1834,7 +1876,13 @@ export class AndroidCtrlProxyClient extends DeviceServiceClient implements Andro
 
       // Handle screenshot response
       if (message.type === "screenshot" && message.requestId) {
-        this.pushScreenshotToObservationStream(message.data);
+        const suppressObservationStreamPush = this.suppressNextScreenshotObservationStreamPush;
+        this.suppressNextScreenshotObservationStreamPush = false;
+        if (!suppressObservationStreamPush) {
+          this.pushScreenshotToObservationStream(message.data);
+        } else {
+          logger.debug("[CTRL_PROXY] Suppressed screenshot observation stream push for explicit initial-frame request");
+        }
         this.requestManager.resolve<ScreenshotResult>(message.requestId, {
           success: true, data: message.data, format: message.format || "jpeg", timestamp: message.timestamp
         });
@@ -2404,11 +2452,21 @@ export class AndroidCtrlProxyClient extends DeviceServiceClient implements Andro
     // Update cached screen dimensions
     this.updateCachedScreenDimensions(data);
 
-    // Push to observation stream
-    this.pushHierarchyToObservationStream(data);
+    const suppression = this.hierarchyObservationStreamSuppressions.values().next().value;
+    const suppressObservationStreamPush = suppression !== undefined;
+    if (suppression) {
+      this.hierarchyObservationStreamSuppressions.delete(suppression);
+      this.timer.clearTimeout(suppression.timeoutHandle);
+    }
+    if (!suppressObservationStreamPush) {
+      // Push to observation stream
+      this.pushHierarchyToObservationStream(data);
 
-    // Start screenshot backoff
-    this.startScreenshotBackoff();
+      // Start screenshot backoff
+      this.startScreenshotBackoff();
+    } else {
+      logger.debug("[CTRL_PROXY] Suppressed hierarchy observation stream push for explicit initial-frame request");
+    }
 
     // Track foreground package for context and start performance monitoring
     if (data.packageName && data.packageName !== this.lastForegroundPackage) {

--- a/test/daemon/observationInitialFrame.test.ts
+++ b/test/daemon/observationInitialFrame.test.ts
@@ -1,0 +1,424 @@
+import { describe, expect, it } from "bun:test";
+import {
+  pushInitialObservationFramesForSubscriber,
+  type ObservationStreamAndroidClient,
+  type ObservationStreamDevice,
+  type ObservationStreamIosClient,
+} from "../../src/daemon/observationInitialFrame";
+import type { ViewHierarchyResult } from "../../src/models";
+import type {
+  AccessibilityHierarchy,
+  AccessibilityHierarchyResponse,
+  ScreenshotResult,
+} from "../../src/features/observe/android";
+import type {
+  CtrlProxyHierarchy,
+  CtrlProxyHierarchyResponse,
+  CtrlProxyScreenshotResult,
+} from "../../src/features/observe/ios/types";
+
+class FakeObservationStreamServer {
+  readonly hierarchyUpdates: Array<{ deviceId: string; hierarchy: ViewHierarchyResult }> = [];
+  readonly screenshotUpdates: Array<{
+    deviceId: string;
+    screenshotBase64: string;
+    screenWidth: number;
+    screenHeight: number;
+  }> = [];
+
+  pushHierarchyUpdate(deviceId: string, hierarchy: ViewHierarchyResult): void {
+    this.hierarchyUpdates.push({ deviceId, hierarchy });
+  }
+
+  pushScreenshotUpdate(
+    deviceId: string,
+    screenshotBase64: string,
+    screenWidth: number,
+    screenHeight: number
+  ): void {
+    this.screenshotUpdates.push({ deviceId, screenshotBase64, screenWidth, screenHeight });
+  }
+}
+
+class FakeAndroidInitialFrameClient implements ObservationStreamAndroidClient {
+  readonly latestHierarchyCalls: Array<{
+    waitForFresh?: boolean;
+    timeout?: number;
+    skipWaitForFresh?: boolean;
+  }> = [];
+  readonly suppressedSyncHierarchyCalls: Array<{ timeoutMs?: number }> = [];
+  readonly suppressedScreenshotCalls: Array<{ timeoutMs?: number }> = [];
+
+  constructor(
+    private readonly connected: boolean,
+    private readonly latestHierarchy: AccessibilityHierarchy | null,
+    private readonly syncHierarchy: AccessibilityHierarchy | null = latestHierarchy,
+    private readonly latestHierarchyFresh: boolean = true,
+    private readonly screenshot: ScreenshotResult = { success: true, data: "android-shot" }
+  ) {}
+
+  async ensureConnected(): Promise<boolean> {
+    return this.connected;
+  }
+
+  async getLatestHierarchy(
+    waitForFresh?: boolean,
+    timeout?: number,
+    _perf?: unknown,
+    skipWaitForFresh?: boolean
+  ): Promise<AccessibilityHierarchyResponse> {
+    this.latestHierarchyCalls.push({ waitForFresh, timeout, skipWaitForFresh });
+    return {
+      hierarchy: this.latestHierarchy,
+      fresh: this.latestHierarchyFresh,
+      updatedAt: this.latestHierarchy?.updatedAt,
+    };
+  }
+
+  async requestHierarchySyncWithoutObservationStreamPush(
+    _perf?: unknown,
+    _disableAllFiltering?: boolean,
+    _signal?: AbortSignal,
+    timeoutMs?: number
+  ): Promise<{ hierarchy: AccessibilityHierarchy } | null> {
+    this.suppressedSyncHierarchyCalls.push({ timeoutMs });
+    return this.syncHierarchy ? { hierarchy: this.syncHierarchy } : null;
+  }
+
+  convertToViewHierarchyResult(hierarchy: AccessibilityHierarchy): ViewHierarchyResult {
+    return {
+      hierarchy: { node: hierarchy.hierarchy },
+      packageName: hierarchy.packageName,
+      updatedAt: hierarchy.updatedAt,
+      screenWidth: hierarchy.screenWidth,
+      screenHeight: hierarchy.screenHeight,
+    };
+  }
+
+  async requestScreenshotWithoutObservationStreamPush(timeoutMs?: number): Promise<ScreenshotResult> {
+    this.suppressedScreenshotCalls.push({ timeoutMs });
+    return this.screenshot;
+  }
+}
+
+class FakeIosInitialFrameClient implements ObservationStreamIosClient {
+  readonly syncHierarchyCalls: Array<{ timeoutMs?: number }> = [];
+
+  constructor(
+    private readonly connected: boolean,
+    private readonly latestHierarchy: CtrlProxyHierarchy | null,
+    private readonly syncHierarchy: CtrlProxyHierarchy | null = latestHierarchy,
+    private readonly screenshot: CtrlProxyScreenshotResult = { success: true, data: "ios-shot" },
+    private readonly latestHierarchyFresh: boolean = true
+  ) {}
+
+  async ensureConnected(): Promise<boolean> {
+    return this.connected;
+  }
+
+  async getLatestHierarchy(): Promise<CtrlProxyHierarchyResponse> {
+    return {
+      hierarchy: this.latestHierarchy,
+      fresh: this.latestHierarchyFresh,
+      updatedAt: this.latestHierarchy?.updatedAt,
+    };
+  }
+
+  async requestHierarchySync(
+    _perf?: unknown,
+    _disableAllFiltering?: boolean,
+    _signal?: AbortSignal,
+    timeoutMs?: number
+  ): Promise<{ hierarchy: CtrlProxyHierarchy } | null> {
+    this.syncHierarchyCalls.push({ timeoutMs });
+    return this.syncHierarchy ? { hierarchy: this.syncHierarchy } : null;
+  }
+
+  convertToViewHierarchyResult(hierarchy: unknown): ViewHierarchyResult {
+    const typedHierarchy = hierarchy as CtrlProxyHierarchy;
+    return {
+      hierarchy: { node: { $: { text: typedHierarchy.hierarchy.text } } },
+      packageName: typedHierarchy.packageName,
+      updatedAt: typedHierarchy.updatedAt,
+      screenWidth: typedHierarchy.screenWidth,
+      screenHeight: typedHierarchy.screenHeight,
+      screenScale: typedHierarchy.screenScale,
+    };
+  }
+
+  async requestScreenshot(): Promise<CtrlProxyScreenshotResult> {
+    return this.screenshot;
+  }
+}
+
+describe("pushInitialObservationFramesForSubscriber", () => {
+  const androidDevice: ObservationStreamDevice = {
+    id: "emulator-5554",
+    name: "Pixel",
+    platform: "android",
+  };
+  const iosDevice: ObservationStreamDevice = {
+    id: "ios-sim-1",
+    name: "iPhone",
+    platform: "ios",
+  };
+
+  it("pushes current Android hierarchy and screenshot after subscriber connects", async () => {
+    const streamServer = new FakeObservationStreamServer();
+    const androidClient = new FakeAndroidInitialFrameClient(true, {
+      updatedAt: 123,
+      packageName: "com.example",
+      screenWidth: 1440,
+      screenHeight: 3120,
+      hierarchy: { text: "Home", bounds: { left: 0, top: 0, right: 1440, bottom: 3120 } },
+    });
+
+    await pushInitialObservationFramesForSubscriber(androidDevice.id, [androidDevice], {
+      streamServer,
+      androidClientFactory: () => androidClient,
+      iosClientFactory: () => {
+        throw new Error("unexpected iOS client");
+      },
+    });
+
+    expect(streamServer.hierarchyUpdates).toEqual([
+      {
+        deviceId: androidDevice.id,
+        hierarchy: {
+          hierarchy: { node: { text: "Home", bounds: { left: 0, top: 0, right: 1440, bottom: 3120 } } },
+          packageName: "com.example",
+          updatedAt: 123,
+          screenWidth: 1440,
+          screenHeight: 3120,
+        },
+      },
+    ]);
+    expect(streamServer.screenshotUpdates).toEqual([
+      {
+        deviceId: androidDevice.id,
+        screenshotBase64: "android-shot",
+        screenWidth: 1440,
+        screenHeight: 3120,
+      },
+    ]);
+    expect(androidClient.latestHierarchyCalls).toEqual([
+      { waitForFresh: false, timeout: 3000, skipWaitForFresh: true },
+    ]);
+    expect(androidClient.suppressedSyncHierarchyCalls).toHaveLength(0);
+    expect(androidClient.suppressedScreenshotCalls).toEqual([{ timeoutMs: 3000 }]);
+  });
+
+  it("captures Android hierarchy without an automatic stream push when the initial cache is empty", async () => {
+    const streamServer = new FakeObservationStreamServer();
+    const androidClient = new FakeAndroidInitialFrameClient(
+      true,
+      null,
+      {
+        updatedAt: 789,
+        packageName: "com.example",
+        screenWidth: 720,
+        screenHeight: 1280,
+        hierarchy: { text: "Cold start" },
+      }
+    );
+
+    await pushInitialObservationFramesForSubscriber(androidDevice.id, [androidDevice], {
+      streamServer,
+      androidClientFactory: () => androidClient,
+      iosClientFactory: () => {
+        throw new Error("unexpected iOS client");
+      },
+    });
+
+    expect(androidClient.latestHierarchyCalls).toEqual([
+      { waitForFresh: false, timeout: 3000, skipWaitForFresh: true },
+    ]);
+    expect(androidClient.suppressedSyncHierarchyCalls).toEqual([{ timeoutMs: 3000 }]);
+    expect(androidClient.suppressedScreenshotCalls).toEqual([{ timeoutMs: 3000 }]);
+    expect(streamServer.hierarchyUpdates[0].hierarchy.updatedAt).toBe(789);
+    expect(streamServer.screenshotUpdates[0]).toMatchObject({
+      deviceId: androidDevice.id,
+      screenWidth: 720,
+      screenHeight: 1280,
+    });
+  });
+
+  it("does not seed Android subscribers from stale cached hierarchy", async () => {
+    const streamServer = new FakeObservationStreamServer();
+    const androidClient = new FakeAndroidInitialFrameClient(
+      true,
+      {
+        updatedAt: 100,
+        packageName: "com.example",
+        screenWidth: 720,
+        screenHeight: 1280,
+        hierarchy: { text: "Stale" },
+      },
+      {
+        updatedAt: 200,
+        packageName: "com.example",
+        screenWidth: 720,
+        screenHeight: 1280,
+        hierarchy: { text: "Fresh sync" },
+      },
+      false
+    );
+
+    await pushInitialObservationFramesForSubscriber(androidDevice.id, [androidDevice], {
+      streamServer,
+      androidClientFactory: () => androidClient,
+      iosClientFactory: () => {
+        throw new Error("unexpected iOS client");
+      },
+    });
+
+    expect(androidClient.suppressedSyncHierarchyCalls).toEqual([{ timeoutMs: 3000 }]);
+    expect(streamServer.hierarchyUpdates[0].hierarchy.updatedAt).toBe(200);
+    expect(streamServer.hierarchyUpdates[0].hierarchy.hierarchy.node).toMatchObject({ text: "Fresh sync" });
+  });
+
+  it("pushes iOS screenshot dimensions in pixels using screen scale", async () => {
+    const streamServer = new FakeObservationStreamServer();
+    const iosClient = new FakeIosInitialFrameClient(true, {
+      updatedAt: 456,
+      packageName: "com.example.ios",
+      screenWidth: 390,
+      screenHeight: 844,
+      screenScale: 3,
+      hierarchy: { text: "Home" },
+    });
+
+    await pushInitialObservationFramesForSubscriber(iosDevice.id, [iosDevice], {
+      streamServer,
+      androidClientFactory: () => {
+        throw new Error("unexpected Android client");
+      },
+      iosClientFactory: () => iosClient,
+    });
+
+    expect(streamServer.hierarchyUpdates).toHaveLength(1);
+    expect(streamServer.hierarchyUpdates[0].deviceId).toBe(iosDevice.id);
+    expect(streamServer.hierarchyUpdates[0].hierarchy.hierarchy.node).toEqual({ $: { text: "Home" } });
+    expect(streamServer.screenshotUpdates).toEqual([
+      {
+        deviceId: iosDevice.id,
+        screenshotBase64: "ios-shot",
+        screenWidth: 1170,
+        screenHeight: 2532,
+      },
+    ]);
+  });
+
+  it("captures iOS hierarchy synchronously when the initial cache is empty", async () => {
+    const streamServer = new FakeObservationStreamServer();
+    const iosClient = new FakeIosInitialFrameClient(
+      true,
+      null,
+      {
+        updatedAt: 987,
+        packageName: "com.example.ios",
+        screenWidth: 400,
+        screenHeight: 800,
+        screenScale: 2,
+        hierarchy: { text: "Cold start" },
+      }
+    );
+
+    await pushInitialObservationFramesForSubscriber(iosDevice.id, [iosDevice], {
+      streamServer,
+      androidClientFactory: () => {
+        throw new Error("unexpected Android client");
+      },
+      iosClientFactory: () => iosClient,
+    });
+
+    expect(iosClient.syncHierarchyCalls).toEqual([{ timeoutMs: 3000 }]);
+    expect(streamServer.hierarchyUpdates[0].hierarchy.updatedAt).toBe(987);
+    expect(streamServer.hierarchyUpdates[0].hierarchy.hierarchy.node).toEqual({ $: { text: "Cold start" } });
+    expect(streamServer.screenshotUpdates[0]).toMatchObject({
+      deviceId: iosDevice.id,
+      screenWidth: 800,
+      screenHeight: 1600,
+    });
+  });
+
+  it("does not seed iOS subscribers from stale cached hierarchy", async () => {
+    const streamServer = new FakeObservationStreamServer();
+    const iosClient = new FakeIosInitialFrameClient(
+      true,
+      {
+        updatedAt: 100,
+        packageName: "com.example.ios",
+        screenWidth: 390,
+        screenHeight: 844,
+        screenScale: 3,
+        hierarchy: { text: "Stale" },
+      },
+      {
+        updatedAt: 200,
+        packageName: "com.example.ios",
+        screenWidth: 390,
+        screenHeight: 844,
+        screenScale: 3,
+        hierarchy: { text: "Fresh sync" },
+      },
+      { success: true, data: "ios-shot" },
+      false
+    );
+
+    await pushInitialObservationFramesForSubscriber(iosDevice.id, [iosDevice], {
+      streamServer,
+      androidClientFactory: () => {
+        throw new Error("unexpected Android client");
+      },
+      iosClientFactory: () => iosClient,
+    });
+
+    expect(iosClient.syncHierarchyCalls).toEqual([{ timeoutMs: 3000 }]);
+    expect(streamServer.hierarchyUpdates[0].hierarchy.updatedAt).toBe(200);
+    expect(streamServer.hierarchyUpdates[0].hierarchy.hierarchy.node).toEqual({ $: { text: "Fresh sync" } });
+  });
+
+  it("honors a device-specific subscription filter", async () => {
+    const streamServer = new FakeObservationStreamServer();
+    const androidClient = new FakeAndroidInitialFrameClient(true, {
+      updatedAt: 1,
+      packageName: "com.example",
+      screenWidth: 100,
+      screenHeight: 200,
+      hierarchy: { text: "Android" },
+    });
+
+    await pushInitialObservationFramesForSubscriber(androidDevice.id, [androidDevice, iosDevice], {
+      streamServer,
+      androidClientFactory: () => androidClient,
+      iosClientFactory: () => {
+        throw new Error("filtered iOS device should not connect");
+      },
+    });
+
+    expect(streamServer.hierarchyUpdates.map(update => update.deviceId)).toEqual([androidDevice.id]);
+    expect(streamServer.screenshotUpdates.map(update => update.deviceId)).toEqual([androidDevice.id]);
+  });
+
+  it("does not push an initial frame when connection fails", async () => {
+    const streamServer = new FakeObservationStreamServer();
+    const androidClient = new FakeAndroidInitialFrameClient(false, {
+      updatedAt: 1,
+      packageName: "com.example",
+      hierarchy: { text: "Home" },
+    });
+
+    await pushInitialObservationFramesForSubscriber(null, [androidDevice], {
+      streamServer,
+      androidClientFactory: () => androidClient,
+      iosClientFactory: () => {
+        throw new Error("unexpected iOS client");
+      },
+    });
+
+    expect(streamServer.hierarchyUpdates).toHaveLength(0);
+    expect(streamServer.screenshotUpdates).toHaveLength(0);
+    expect(androidClient.latestHierarchyCalls).toHaveLength(0);
+  });
+});

--- a/test/features/observe/CtrlProxyClient.test.ts
+++ b/test/features/observe/CtrlProxyClient.test.ts
@@ -314,6 +314,76 @@ describe("AndroidCtrlProxyClient", function() {
       }
     });
 
+    test("tracks concurrent suppressed hierarchy syncs independently", async function() {
+      const testTimer = new FakeTimer();
+      const { factory, getSocket } = createCapturingWebSocketFactory(testTimer);
+      const testClient = AndroidCtrlProxyClient.createForTesting(
+        testDevice,
+        fakeAdb,
+        factory,
+        testTimer
+      );
+      const suppressionCount = (): number =>
+        (testClient as unknown as {
+          hierarchyObservationStreamSuppressions: Set<unknown>;
+        }).hierarchyObservationStreamSuppressions.size;
+
+      try {
+        const firstRequest = testClient.requestHierarchySyncWithoutObservationStreamPush(
+          undefined,
+          false,
+          undefined,
+          3000
+        );
+        const secondRequest = testClient.requestHierarchySyncWithoutObservationStreamPush(
+          undefined,
+          false,
+          undefined,
+          3000
+        );
+
+        const socket = await waitForSocket(getSocket);
+        expect(socket).not.toBeNull();
+        await waitForSocketOpen(socket);
+        await waitForSentMessages(socket, 2);
+
+        expect(suppressionCount()).toBe(2);
+
+        socket!.simulateMessage(JSON.stringify({
+          type: "hierarchy_update",
+          timestamp: testTimer.now(),
+          data: {
+            updatedAt: 100,
+            packageName: "com.example",
+            hierarchy: { text: "First sync" },
+          },
+        }));
+
+        expect(suppressionCount()).toBe(1);
+
+        socket!.simulateMessage(JSON.stringify({
+          type: "hierarchy_update",
+          timestamp: testTimer.now(),
+          data: {
+            updatedAt: 200,
+            packageName: "com.example",
+            hierarchy: { text: "Second sync" },
+          },
+        }));
+
+        expect(suppressionCount()).toBe(0);
+
+        const [firstResult, secondResult] = await Promise.all([
+          testTimer.resolvePromise(firstRequest),
+          testTimer.resolvePromise(secondRequest),
+        ]);
+        expect(firstResult?.hierarchy).not.toBeNull();
+        expect(secondResult?.hierarchy).not.toBeNull();
+      } finally {
+        await testClient.close();
+      }
+    });
+
     test("should handle WebSocket connection failure gracefully", async function() {
       // Use FakeWebSocket with instant failure and FakeTimer for fast, reliable test execution
       // See issues #68 (timeout race condition) and #72 (cache contamination)


### PR DESCRIPTION
## Summary

- Fixes #2448
- Pushes an initial hierarchy and screenshot when an observation stream subscriber connects
- Falls back to synchronous hierarchy capture when the stream cache is empty on subscribe
- Adds fake-based coverage for Android, iOS, filtering, and connection failure paths

## Testing

- `bun test test/daemon/observationInitialFrame.test.ts`
- `bun run build`
- `bun run lint`
- `bunx tsc --noEmit --ignoreDeprecations 6.0` filtered to changed files: no diagnostics

## Notes

- Full `tsc --noEmit` still reports existing repo-wide diagnostics unrelated to this change.
