### PR TITLE
Publish daemon stream socket paths

### DIFF
--- a/src/daemon/appearanceSocketServer.ts
+++ b/src/daemon/appearanceSocketServer.ts
@@ -158,6 +158,10 @@ export class AppearanceSocketServer extends RequestResponseSocketServer<
 
 let socketServer: AppearanceSocketServer | null = null;
 
+export function getAppearanceSocketPath(): string {
+  return socketServer?.getSocketPath() ?? getSocketPath(SOCKET_CONFIG);
+}
+
 export async function startAppearanceSocketServer(): Promise<void> {
   if (!socketServer) {
     socketServer = new AppearanceSocketServer();

--- a/src/daemon/daemon.ts
+++ b/src/daemon/daemon.ts
@@ -33,6 +33,7 @@ import { startDeviceDataStreamSocketServer, stopDeviceDataStreamSocketServer, ge
 import { startFailuresStreamSocketServer, stopFailuresStreamSocketServer } from "./failuresStreamSocketServer";
 import { startFailuresPushSocketServer, stopFailuresPushSocketServer } from "./failuresPushSocketServer";
 import { startTelemetryPushSocketServer, stopTelemetryPushSocketServer } from "./telemetryPushSocketServer";
+import { getDaemonSocketPaths } from "./socketPaths";
 import { AndroidCtrlProxyClient } from "../features/observe/android";
 import { defaultAdbClientFactory } from "../utils/android-cmdline-tools/AdbClientFactory";
 import { IOSCtrlProxyClient } from "../features/observe/ios";
@@ -576,6 +577,7 @@ export class Daemon {
     const pidData: PidFileData = {
       pid: process.pid,
       socketPath: SOCKET_PATH,
+      sockets: getDaemonSocketPaths(),
       port: this.port,
       startedAt: this.timer.now(),
       version: DAEMON_VERSION,

--- a/src/daemon/deviceDataStreamSocketServer.ts
+++ b/src/daemon/deviceDataStreamSocketServer.ts
@@ -376,6 +376,10 @@ export function getDeviceDataStreamServer(): DeviceDataStreamSocketServer | null
   return socketServer;
 }
 
+export function getDeviceDataStreamSocketPath(): string {
+  return socketServer?.getSocketPath() ?? getSocketPath(SOCKET_CONFIG);
+}
+
 export async function startDeviceDataStreamSocketServer(
   timer: Timer = defaultTimer
 ): Promise<DeviceDataStreamSocketServer> {

--- a/src/daemon/deviceSnapshotSocketServer.ts
+++ b/src/daemon/deviceSnapshotSocketServer.ts
@@ -73,6 +73,10 @@ export class DeviceSnapshotSocketServer extends RequestResponseSocketServer<
 
 let socketServer: DeviceSnapshotSocketServer | null = null;
 
+export function getDeviceSnapshotSocketPath(): string {
+  return socketServer?.getSocketPath() ?? getSocketPath(SOCKET_CONFIG);
+}
+
 export async function startDeviceSnapshotSocketServer(): Promise<void> {
   if (!socketServer) {
     socketServer = new DeviceSnapshotSocketServer();

--- a/src/daemon/failuresPushSocketServer.ts
+++ b/src/daemon/failuresPushSocketServer.ts
@@ -96,6 +96,10 @@ export function getFailuresPushServer(): FailuresPushSocketServer | null {
   return socketServer;
 }
 
+export function getFailuresPushSocketPath(): string {
+  return socketServer?.getSocketPath() ?? getSocketPath(SOCKET_CONFIG);
+}
+
 export async function startFailuresPushSocketServer(): Promise<FailuresPushSocketServer> {
   if (!socketServer) {
     socketServer = new FailuresPushSocketServer();

--- a/src/daemon/failuresStreamSocketServer.ts
+++ b/src/daemon/failuresStreamSocketServer.ts
@@ -291,6 +291,10 @@ export class FailuresStreamSocketServer extends RequestResponseSocketServer<
 
 let socketServer: FailuresStreamSocketServer | null = null;
 
+export function getFailuresStreamSocketPath(): string {
+  return socketServer?.getSocketPath() ?? getSocketPath(SOCKET_CONFIG);
+}
+
 export async function startFailuresStreamSocketServer(): Promise<void> {
   if (!socketServer) {
     socketServer = new FailuresStreamSocketServer();

--- a/src/daemon/manager.ts
+++ b/src/daemon/manager.ts
@@ -515,6 +515,7 @@ export class DaemonManager implements DaemonManagerLike {
         pid: pidData.pid,
         port: pidData.port,
         socketPath: pidData.socketPath,
+        sockets: pidData.sockets,
         startedAt: pidData.startedAt,
         version: pidData.version,
       };

--- a/src/daemon/performancePushSocketServer.ts
+++ b/src/daemon/performancePushSocketServer.ts
@@ -193,6 +193,10 @@ export function getPerformancePushServer(): PerformancePushSocketServer | null {
   return socketServer;
 }
 
+export function getPerformancePushSocketPath(): string {
+  return socketServer?.getSocketPath() ?? getSocketPath(SOCKET_CONFIG);
+}
+
 export async function startPerformancePushSocketServer(): Promise<PerformancePushSocketServer> {
   if (!socketServer) {
     socketServer = new PerformancePushSocketServer();

--- a/src/daemon/performanceStreamSocketServer.ts
+++ b/src/daemon/performanceStreamSocketServer.ts
@@ -112,6 +112,10 @@ export class PerformanceStreamSocketServer extends RequestResponseSocketServer<
 
 let socketServer: PerformanceStreamSocketServer | null = null;
 
+export function getPerformanceStreamSocketPath(): string {
+  return socketServer?.getSocketPath() ?? getSocketPath(SOCKET_CONFIG);
+}
+
 export async function startPerformanceStreamSocketServer(): Promise<void> {
   if (!socketServer) {
     socketServer = new PerformanceStreamSocketServer();

--- a/src/daemon/socketPaths.ts
+++ b/src/daemon/socketPaths.ts
@@ -1,0 +1,28 @@
+import { SOCKET_PATH } from "./constants";
+import { getAppearanceSocketPath } from "./appearanceSocketServer";
+import { getDeviceDataStreamSocketPath } from "./deviceDataStreamSocketServer";
+import { getDeviceSnapshotSocketPath } from "./deviceSnapshotSocketServer";
+import { getFailuresPushSocketPath } from "./failuresPushSocketServer";
+import { getFailuresStreamSocketPath } from "./failuresStreamSocketServer";
+import { getPerformancePushSocketPath } from "./performancePushSocketServer";
+import { getPerformanceStreamSocketPath } from "./performanceStreamSocketServer";
+import { getTelemetryPushSocketPath } from "./telemetryPushSocketServer";
+import { getTestRecordingSocketPath } from "./testRecordingSocketServer";
+import { getVideoRecordingSocketPath } from "./videoRecordingSocketServer";
+import type { DaemonSocketPaths } from "./types";
+
+export function getDaemonSocketPaths(): DaemonSocketPaths {
+  return {
+    "control": SOCKET_PATH,
+    "appearance": getAppearanceSocketPath(),
+    "device-snapshot": getDeviceSnapshotSocketPath(),
+    "failures-push": getFailuresPushSocketPath(),
+    "failures-stream": getFailuresStreamSocketPath(),
+    "observation-stream": getDeviceDataStreamSocketPath(),
+    "performance-push": getPerformancePushSocketPath(),
+    "performance-stream": getPerformanceStreamSocketPath(),
+    "telemetry-push": getTelemetryPushSocketPath(),
+    "test-recording": getTestRecordingSocketPath(),
+    "video-recording": getVideoRecordingSocketPath(),
+  };
+}

--- a/src/daemon/socketServer/BaseSocketServer.ts
+++ b/src/daemon/socketServer/BaseSocketServer.ts
@@ -88,6 +88,13 @@ export abstract class BaseSocketServer {
   }
 
   /**
+   * Return the concrete Unix socket path this server was created with.
+   */
+  getSocketPath(): string {
+    return this.socketPath;
+  }
+
+  /**
    * Handle a new connection. Sets up line-based protocol.
    */
   protected handleConnection(socket: Socket): void {

--- a/src/daemon/telemetryPushSocketServer.ts
+++ b/src/daemon/telemetryPushSocketServer.ts
@@ -244,6 +244,10 @@ export function getTelemetryPushServer(): TelemetryPushSocketServer | null {
   return socketServer;
 }
 
+export function getTelemetryPushSocketPath(): string {
+  return socketServer?.getSocketPath() ?? getSocketPath(SOCKET_CONFIG);
+}
+
 export async function startTelemetryPushSocketServer(): Promise<TelemetryPushSocketServer> {
   if (!socketServer) {
     socketServer = new TelemetryPushSocketServer();

--- a/src/daemon/testRecordingSocketServer.ts
+++ b/src/daemon/testRecordingSocketServer.ts
@@ -120,6 +120,10 @@ export class TestRecordingSocketServer extends RequestResponseSocketServer<
 
 let socketServer: TestRecordingSocketServer | null = null;
 
+export function getTestRecordingSocketPath(): string {
+  return socketServer?.getSocketPath() ?? getSocketPath(SOCKET_CONFIG);
+}
+
 export async function startTestRecordingSocketServer(): Promise<void> {
   if (!socketServer) {
     socketServer = new TestRecordingSocketServer();

--- a/src/daemon/types.ts
+++ b/src/daemon/types.ts
@@ -31,6 +31,24 @@ export interface DaemonResponse {
 }
 
 /**
+ * Known Unix-domain sockets exposed by the daemon.
+ */
+export type DaemonSocketName =
+  | "control"
+  | "appearance"
+  | "device-snapshot"
+  | "failures-push"
+  | "failures-stream"
+  | "observation-stream"
+  | "performance-push"
+  | "performance-stream"
+  | "telemetry-push"
+  | "test-recording"
+  | "video-recording";
+
+export type DaemonSocketPaths = Record<DaemonSocketName, string>;
+
+/**
  * Daemon status information
  */
 export interface DaemonStatus {
@@ -42,6 +60,8 @@ export interface DaemonStatus {
   port?: number;
   /** Unix socket path */
   socketPath?: string;
+  /** Unix socket paths exposed by the daemon, keyed by purpose */
+  sockets?: DaemonSocketPaths;
   /** Timestamp when daemon was started */
   startedAt?: number;
   /** Daemon version */
@@ -56,6 +76,8 @@ export interface PidFileData {
   pid: number;
   /** Unix socket path */
   socketPath: string;
+  /** Unix socket paths exposed by the daemon, keyed by purpose */
+  sockets?: DaemonSocketPaths;
   /** HTTP port */
   port: number;
   /** Timestamp when daemon was started */

--- a/src/daemon/videoRecordingSocketServer.ts
+++ b/src/daemon/videoRecordingSocketServer.ts
@@ -71,6 +71,10 @@ export class VideoRecordingSocketServer extends RequestResponseSocketServer<
 
 let socketServer: VideoRecordingSocketServer | null = null;
 
+export function getVideoRecordingSocketPath(): string {
+  return socketServer?.getSocketPath() ?? getSocketPath(SOCKET_CONFIG);
+}
+
 export async function startVideoRecordingSocketServer(): Promise<void> {
   if (!socketServer) {
     socketServer = new VideoRecordingSocketServer();

--- a/test/daemon/integration/versionMismatchRestart.test.ts
+++ b/test/daemon/integration/versionMismatchRestart.test.ts
@@ -167,6 +167,36 @@ describe("DaemonMcpProxy + real DaemonManager (version-mismatch integration)", (
     }
   });
 
+  test("real PID file exposes socket path map through status", async () => {
+    const sockets = {
+      "control": join(tempDir, "test.sock"),
+      "appearance": join(tempDir, "appearance.sock"),
+      "device-snapshot": join(tempDir, "device-snapshot.sock"),
+      "failures-push": join(tempDir, "failures-push.sock"),
+      "failures-stream": join(tempDir, "failures-stream.sock"),
+      "observation-stream": join(tempDir, "observation-stream.sock"),
+      "performance-push": join(tempDir, "performance-push.sock"),
+      "performance-stream": join(tempDir, "performance-stream.sock"),
+      "telemetry-push": join(tempDir, "telemetry-push.sock"),
+      "test-recording": join(tempDir, "test-recording.sock"),
+      "video-recording": join(tempDir, "video-recording.sock"),
+    };
+    const data: PidFileData = {
+      pid: process.pid,
+      socketPath: sockets.control,
+      sockets,
+      port: 0,
+      startedAt: 1,
+      version: DAEMON_VERSION,
+    };
+    writeFileSync(pidFilePath, JSON.stringify(data));
+
+    const status = await realManager.status();
+
+    expect(status.running).toBe(true);
+    expect(status.sockets).toEqual(sockets);
+  });
+
   test("PID file pointing at a dead PID is treated as not running, no restart attempted", async () => {
     // PID 999999 is virtually never alive; status() should return running:false and unlink
     const data: PidFileData = {

--- a/test/daemon/socketPaths.test.ts
+++ b/test/daemon/socketPaths.test.ts
@@ -1,0 +1,53 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import os from "node:os";
+import path from "node:path";
+import { SOCKET_PATH } from "../../src/daemon/constants";
+import { getDaemonSocketPaths } from "../../src/daemon/socketPaths";
+
+describe("daemon socket paths", () => {
+  const originalExternalMode = process.env.AUTOMOBILE_EMULATOR_EXTERNAL;
+
+  afterEach(() => {
+    if (originalExternalMode === undefined) {
+      delete process.env.AUTOMOBILE_EMULATOR_EXTERNAL;
+    } else {
+      process.env.AUTOMOBILE_EMULATOR_EXTERNAL = originalExternalMode;
+    }
+  });
+
+  test("publishes all default socket paths", () => {
+    delete process.env.AUTOMOBILE_EMULATOR_EXTERNAL;
+
+    expect(getDaemonSocketPaths()).toEqual({
+      "control": SOCKET_PATH,
+      "appearance": path.join(os.homedir(), ".auto-mobile", "appearance.sock"),
+      "device-snapshot": path.join(os.homedir(), ".auto-mobile", "device-snapshot.sock"),
+      "failures-push": path.join(os.homedir(), ".auto-mobile", "failures-push.sock"),
+      "failures-stream": path.join(os.homedir(), ".auto-mobile", "failures-stream.sock"),
+      "observation-stream": path.join(os.homedir(), ".auto-mobile", "observation-stream.sock"),
+      "performance-push": path.join(os.homedir(), ".auto-mobile", "performance-push.sock"),
+      "performance-stream": path.join(os.homedir(), ".auto-mobile", "performance-stream.sock"),
+      "telemetry-push": path.join(os.homedir(), ".auto-mobile", "telemetry-push.sock"),
+      "test-recording": path.join(os.homedir(), ".auto-mobile", "test-recording.sock"),
+      "video-recording": path.join(os.homedir(), ".auto-mobile", "video-recording.sock"),
+    });
+  });
+
+  test("publishes external-mode socket paths", () => {
+    process.env.AUTOMOBILE_EMULATOR_EXTERNAL = "true";
+
+    expect(getDaemonSocketPaths()).toEqual({
+      "control": SOCKET_PATH,
+      "appearance": "/tmp/auto-mobile-appearance.sock",
+      "device-snapshot": "/tmp/auto-mobile-device-snapshot.sock",
+      "failures-push": "/tmp/auto-mobile-failures-push.sock",
+      "failures-stream": "/tmp/auto-mobile-failures-stream.sock",
+      "observation-stream": "/tmp/auto-mobile-observation-stream.sock",
+      "performance-push": "/tmp/auto-mobile-performance-push.sock",
+      "performance-stream": "/tmp/auto-mobile-performance-stream.sock",
+      "telemetry-push": "/tmp/auto-mobile-telemetry-push.sock",
+      "test-recording": "/tmp/auto-mobile-test-recording.sock",
+      "video-recording": "/tmp/auto-mobile-video-recording.sock",
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add a typed daemon socket path map covering the control socket and all auxiliary stream/control sockets.
- Write the socket map into the PID file while preserving the legacy `socketPath` field.
- Return the socket map through `DaemonManager.status()` for programmatic discovery.

Fixes #2446

## Testing
- `bun test test/daemon/socketPaths.test.ts test/daemon/integration/versionMismatchRestart.test.ts`
- `bunx eslint --fix test/daemon/integration/versionMismatchRestart.test.ts test/daemon/socketPaths.test.ts src/daemon/socketPaths.ts src/daemon/types.ts src/daemon/daemon.ts src/daemon/manager.ts`
- `bun run build`
