### PR TITLE
Verify daemon readiness with socket probe

### DIFF
--- a/src/daemon/manager.ts
+++ b/src/daemon/manager.ts
@@ -1,6 +1,6 @@
 import { spawn, execSync } from "node:child_process";
 import { readFile, unlink } from "node:fs/promises";
-import { existsSync, openSync, closeSync, mkdtempSync, readFileSync, statSync, unlinkSync, writeFileSync } from "node:fs";
+import { existsSync, openSync, closeSync, mkdtempSync, readFileSync, unlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { logger } from "../utils/logger";
@@ -582,17 +582,18 @@ export class DaemonManager implements DaemonManagerLike {
     }
   }
 
+  /**
+   * Remove a daemon socket path that failed the readiness probe.
+   *
+   * This is only invoked after {@link verifyDaemonConnection} could not connect,
+   * which is the authoritative signal that the path is unusable. A stale socket
+   * inode left behind by a SIGKILL'd daemon is still an `isSocket()` inode, so we
+   * must remove it regardless of file type — otherwise a reused PID makes
+   * `status()` report running and the readiness loop spins until it times out.
+   * This mirrors the unconditional stale-socket cleanup in {@link start}.
+   */
   private async removeInvalidSocketPath(): Promise<void> {
     if (!existsSync(this.socketPath)) {
-      return;
-    }
-
-    try {
-      if (statSync(this.socketPath).isSocket()) {
-        return;
-      }
-    } catch (error) {
-      logger.debug(`Failed to inspect daemon socket path: ${error instanceof Error ? error.message : String(error)}`);
       return;
     }
 

--- a/src/daemon/manager.ts
+++ b/src/daemon/manager.ts
@@ -71,19 +71,22 @@ export class DaemonManager implements DaemonManagerLike {
   private readonly timer: Timer;
   private readonly lockFilePath: string;
   private readonly pidFilePath: string;
+  private readonly socketPath: string;
 
   constructor(
-    clientFactory: DaemonClientFactory = () => new DaemonClient(),
+    clientFactory: DaemonClientFactory | undefined = undefined,
     stateProvider: () => DaemonStateLike = () => DaemonState.getInstance(),
     timer: Timer = defaultTimer,
     lockFilePath: string = LOCK_FILE_PATH,
-    pidFilePath: string = PID_FILE_PATH
+    pidFilePath: string = PID_FILE_PATH,
+    socketPath: string = SOCKET_PATH
   ) {
-    this.clientFactory = clientFactory;
     this.stateProvider = stateProvider;
     this.timer = timer;
     this.lockFilePath = lockFilePath;
     this.pidFilePath = pidFilePath;
+    this.socketPath = socketPath;
+    this.clientFactory = clientFactory ?? (() => new DaemonClient(this.socketPath));
   }
 
   /**
@@ -272,10 +275,10 @@ export class DaemonManager implements DaemonManagerLike {
     }
 
     // Clean up stale socket and PID files from previous sessions
-    if (existsSync(SOCKET_PATH)) {
+    if (existsSync(this.socketPath)) {
       logger.debug("Removing stale socket file");
       try {
-        await unlink(SOCKET_PATH);
+        await unlink(this.socketPath);
       } catch (error) {
         logger.warn(`Failed to remove stale socket file: ${error instanceof Error ? error.message : String(error)}`);
       }
@@ -403,6 +406,9 @@ export class DaemonManager implements DaemonManagerLike {
     }
     if (this.lockFilePath !== LOCK_FILE_PATH) {
       childEnv.AUTOMOBILE_DAEMON_LOCK_FILE_PATH = this.lockFilePath;
+    }
+    if (this.socketPath !== SOCKET_PATH) {
+      childEnv.AUTOMOBILE_DAEMON_SOCKET_PATH = this.socketPath;
     }
 
     const daemonProcess = spawn(autoMobileCmd, args, {
@@ -543,12 +549,13 @@ export class DaemonManager implements DaemonManagerLike {
     const pollInterval = 100; // Poll every 100ms
 
     while (this.timer.now() - startTime < timeout) {
-      // Check if socket exists
-      if (existsSync(SOCKET_PATH)) {
-        // Check if daemon is responding
+      if (existsSync(this.socketPath)) {
         const status = await this.status();
         if (status.running) {
-          return true;
+          if (await this.verifyDaemonConnection()) {
+            return true;
+          }
+          await this.removeStaleSocketFile();
         }
       }
 
@@ -556,6 +563,36 @@ export class DaemonManager implements DaemonManagerLike {
     }
 
     return false;
+  }
+
+  private async verifyDaemonConnection(): Promise<boolean> {
+    const client = this.createClient();
+    try {
+      await client.connect();
+      return true;
+    } catch (error) {
+      logger.debug(`Daemon socket readiness probe failed: ${error instanceof Error ? error.message : String(error)}`);
+      return false;
+    } finally {
+      try {
+        await client.close();
+      } catch (error) {
+        logger.debug(`Failed to close daemon readiness probe client: ${error instanceof Error ? error.message : String(error)}`);
+      }
+    }
+  }
+
+  private async removeStaleSocketFile(): Promise<void> {
+    if (!existsSync(this.socketPath)) {
+      return;
+    }
+
+    try {
+      await unlink(this.socketPath);
+      logger.debug(`Removed stale daemon socket file: ${this.socketPath}`);
+    } catch (error) {
+      logger.debug(`Failed to remove stale daemon socket file: ${error instanceof Error ? error.message : String(error)}`);
+    }
   }
 
   /**

--- a/src/daemon/manager.ts
+++ b/src/daemon/manager.ts
@@ -1,6 +1,6 @@
 import { spawn, execSync } from "node:child_process";
 import { readFile, unlink } from "node:fs/promises";
-import { existsSync, openSync, closeSync, mkdtempSync, readFileSync, unlinkSync, writeFileSync } from "node:fs";
+import { existsSync, openSync, closeSync, mkdtempSync, readFileSync, statSync, unlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { logger } from "../utils/logger";
@@ -555,7 +555,7 @@ export class DaemonManager implements DaemonManagerLike {
           if (await this.verifyDaemonConnection()) {
             return true;
           }
-          await this.removeStaleSocketFile();
+          await this.removeInvalidSocketPath();
         }
       }
 
@@ -582,16 +582,25 @@ export class DaemonManager implements DaemonManagerLike {
     }
   }
 
-  private async removeStaleSocketFile(): Promise<void> {
+  private async removeInvalidSocketPath(): Promise<void> {
     if (!existsSync(this.socketPath)) {
       return;
     }
 
     try {
-      await unlink(this.socketPath);
-      logger.debug(`Removed stale daemon socket file: ${this.socketPath}`);
+      if (statSync(this.socketPath).isSocket()) {
+        return;
+      }
     } catch (error) {
-      logger.debug(`Failed to remove stale daemon socket file: ${error instanceof Error ? error.message : String(error)}`);
+      logger.debug(`Failed to inspect daemon socket path: ${error instanceof Error ? error.message : String(error)}`);
+      return;
+    }
+
+    try {
+      await unlink(this.socketPath);
+      logger.debug(`Removed invalid daemon socket path: ${this.socketPath}`);
+    } catch (error) {
+      logger.debug(`Failed to remove invalid daemon socket path: ${error instanceof Error ? error.message : String(error)}`);
     }
   }
 

--- a/test/daemon/daemonManagerReadiness.test.ts
+++ b/test/daemon/daemonManagerReadiness.test.ts
@@ -132,32 +132,49 @@ describe("DaemonManager readiness", () => {
     expect(existsSync(socketPath)).toBe(false);
   });
 
-  test("does not remove a socket path when a readiness probe fails", async () => {
-    const { lockPath, pidPath, socketPath } = createPaths();
-    const fakeTimer = new FakeTimer();
-    fakeTimer.enableAutoAdvance();
-    const clients: ProbeClient[] = [];
-    writePidFile(pidPath, socketPath);
+  // A daemon killed with SIGKILL leaves its Unix socket pathname behind as a
+  // socket inode. If the PID is later reused, status() reports running, but the
+  // readiness probe still cannot connect. The stale socket inode must be removed
+  // so the loop does not spin until timeout (and so a fresh daemon can bind it).
+  // Gated off Windows: net.Server.listen(path) there means a named pipe, not a
+  // filesystem socket inode, so a real socket inode cannot be created this way.
+  test.skipIf(process.platform === "win32")(
+    "removes a stale socket inode when the readiness probe cannot connect",
+    async () => {
+      const { lockPath, pidPath, socketPath } = createPaths();
+      const fakeTimer = new FakeTimer();
+      fakeTimer.enableAutoAdvance();
+      const clients: ProbeClient[] = [];
+      writePidFile(pidPath, socketPath);
 
-    const server = createServer();
-    servers.push(server);
-    await new Promise<void>(resolve => server.listen(socketPath, resolve));
+      // Bind a real Unix socket so the path is a genuine socket inode (the case
+      // the previous isSocket() guard wrongly preserved). The probe still fails
+      // because it cannot complete the daemon handshake, so the inode is stale
+      // from the client's perspective and must be removed. Left listening for
+      // afterEach cleanup; closing here would unlink the inode itself.
+      const server = createServer();
+      servers.push(server);
+      await new Promise<void>(resolve => server.listen(socketPath, resolve));
+      expect(existsSync(socketPath)).toBe(true);
 
-    const manager = new DaemonManager(
-      () => {
-        const client = new ProbeClient(false);
-        clients.push(client);
-        return client;
-      },
-      undefined,
-      fakeTimer,
-      lockPath,
-      pidPath,
-      socketPath
-    );
+      const manager = new DaemonManager(
+        () => {
+          const client = new ProbeClient(false);
+          clients.push(client);
+          return client;
+        },
+        undefined,
+        fakeTimer,
+        lockPath,
+        pidPath,
+        socketPath
+      );
 
-    await expect(manager.waitForReady(250)).resolves.toBe(false);
-    expect(clients).toHaveLength(3);
-    expect(existsSync(socketPath)).toBe(true);
-  });
+      await expect(manager.waitForReady(250)).resolves.toBe(false);
+      expect(clients).toHaveLength(1);
+      expect(clients[0].connectCallCount).toBe(1);
+      expect(clients[0].closeCallCount).toBe(1);
+      expect(existsSync(socketPath)).toBe(false);
+    }
+  );
 });

--- a/test/daemon/daemonManagerReadiness.test.ts
+++ b/test/daemon/daemonManagerReadiness.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, test } from "bun:test";
+import { createServer, type Server } from "node:net";
 import { existsSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -39,6 +40,7 @@ class ProbeClient implements DaemonClientLike {
 
 describe("DaemonManager readiness", () => {
   const tempDirs: string[] = [];
+  const servers: Server[] = [];
 
   function createPaths(): { dir: string; lockPath: string; pidPath: string; socketPath: string } {
     const dir = mkdtempSync(join(tmpdir(), "daemon-readiness-test-"));
@@ -62,7 +64,12 @@ describe("DaemonManager readiness", () => {
     writeFileSync(pidPath, JSON.stringify(pidData), { mode: 0o600 });
   }
 
-  afterEach(() => {
+  afterEach(async () => {
+    await Promise.all(
+      servers.map(server => new Promise<void>(resolve => server.close(() => resolve())))
+    );
+    servers.length = 0;
+
     for (const dir of tempDirs) {
       rmSync(dir, { recursive: true, force: true });
     }
@@ -97,7 +104,7 @@ describe("DaemonManager readiness", () => {
     expect(existsSync(socketPath)).toBe(true);
   });
 
-  test("removes a stale socket and keeps waiting when the PID is alive but connect fails", async () => {
+  test("removes an invalid non-socket path and keeps waiting when the PID is alive", async () => {
     const { lockPath, pidPath, socketPath } = createPaths();
     const fakeTimer = new FakeTimer();
     fakeTimer.enableAutoAdvance();
@@ -123,5 +130,34 @@ describe("DaemonManager readiness", () => {
     expect(clients[0].connectCallCount).toBe(1);
     expect(clients[0].closeCallCount).toBe(1);
     expect(existsSync(socketPath)).toBe(false);
+  });
+
+  test("does not remove a socket path when a readiness probe fails", async () => {
+    const { lockPath, pidPath, socketPath } = createPaths();
+    const fakeTimer = new FakeTimer();
+    fakeTimer.enableAutoAdvance();
+    const clients: ProbeClient[] = [];
+    writePidFile(pidPath, socketPath);
+
+    const server = createServer();
+    servers.push(server);
+    await new Promise<void>(resolve => server.listen(socketPath, resolve));
+
+    const manager = new DaemonManager(
+      () => {
+        const client = new ProbeClient(false);
+        clients.push(client);
+        return client;
+      },
+      undefined,
+      fakeTimer,
+      lockPath,
+      pidPath,
+      socketPath
+    );
+
+    await expect(manager.waitForReady(250)).resolves.toBe(false);
+    expect(clients).toHaveLength(3);
+    expect(existsSync(socketPath)).toBe(true);
   });
 });

--- a/test/daemon/daemonManagerReadiness.test.ts
+++ b/test/daemon/daemonManagerReadiness.test.ts
@@ -1,0 +1,127 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { existsSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { DaemonManager } from "../../src/daemon/manager";
+import type { DaemonClientLike } from "../../src/daemon/client";
+import type { PidFileData } from "../../src/daemon/types";
+import { FakeTimer } from "../fakes/FakeTimer";
+
+class ProbeClient implements DaemonClientLike {
+  connectCallCount = 0;
+  closeCallCount = 0;
+
+  constructor(private readonly canConnect: boolean) {}
+
+  async connect(): Promise<void> {
+    this.connectCallCount++;
+    if (!this.canConnect) {
+      throw new Error("socket not accepting connections");
+    }
+  }
+
+  async close(): Promise<void> {
+    this.closeCallCount++;
+  }
+
+  async callTool(): Promise<any> {
+    throw new Error("not used");
+  }
+
+  async readResource(): Promise<any> {
+    throw new Error("not used");
+  }
+
+  async callDaemonMethod(): Promise<any> {
+    throw new Error("not used");
+  }
+}
+
+describe("DaemonManager readiness", () => {
+  const tempDirs: string[] = [];
+
+  function createPaths(): { dir: string; lockPath: string; pidPath: string; socketPath: string } {
+    const dir = mkdtempSync(join(tmpdir(), "daemon-readiness-test-"));
+    tempDirs.push(dir);
+    return {
+      dir,
+      lockPath: join(dir, "daemon.lock"),
+      pidPath: join(dir, "daemon.pid"),
+      socketPath: join(dir, "daemon.sock"),
+    };
+  }
+
+  function writePidFile(pidPath: string, socketPath: string): void {
+    const pidData: PidFileData = {
+      pid: process.pid,
+      socketPath,
+      port: 31879,
+      startedAt: 0,
+      version: "test",
+    };
+    writeFileSync(pidPath, JSON.stringify(pidData), { mode: 0o600 });
+  }
+
+  afterEach(() => {
+    for (const dir of tempDirs) {
+      rmSync(dir, { recursive: true, force: true });
+    }
+    tempDirs.length = 0;
+  });
+
+  test("reports ready only after the daemon socket accepts a connection", async () => {
+    const { lockPath, pidPath, socketPath } = createPaths();
+    const fakeTimer = new FakeTimer();
+    fakeTimer.enableAutoAdvance();
+    const clients: ProbeClient[] = [];
+    writePidFile(pidPath, socketPath);
+    writeFileSync(socketPath, "socket placeholder");
+
+    const manager = new DaemonManager(
+      () => {
+        const client = new ProbeClient(true);
+        clients.push(client);
+        return client;
+      },
+      undefined,
+      fakeTimer,
+      lockPath,
+      pidPath,
+      socketPath
+    );
+
+    await expect(manager.waitForReady(100)).resolves.toBe(true);
+    expect(clients).toHaveLength(1);
+    expect(clients[0].connectCallCount).toBe(1);
+    expect(clients[0].closeCallCount).toBe(1);
+    expect(existsSync(socketPath)).toBe(true);
+  });
+
+  test("removes a stale socket and keeps waiting when the PID is alive but connect fails", async () => {
+    const { lockPath, pidPath, socketPath } = createPaths();
+    const fakeTimer = new FakeTimer();
+    fakeTimer.enableAutoAdvance();
+    const clients: ProbeClient[] = [];
+    writePidFile(pidPath, socketPath);
+    writeFileSync(socketPath, "stale socket placeholder");
+
+    const manager = new DaemonManager(
+      () => {
+        const client = new ProbeClient(false);
+        clients.push(client);
+        return client;
+      },
+      undefined,
+      fakeTimer,
+      lockPath,
+      pidPath,
+      socketPath
+    );
+
+    await expect(manager.waitForReady(250)).resolves.toBe(false);
+    expect(clients).toHaveLength(1);
+    expect(clients[0].connectCallCount).toBe(1);
+    expect(clients[0].closeCallCount).toBe(1);
+    expect(existsSync(socketPath)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- verify daemon readiness by opening an actual daemon socket client connection before returning ready
- remove a stale socket file when PID liveness says running but the socket probe cannot connect
- make the daemon manager socket path injectable and propagate custom socket paths to child daemon processes

## Root Cause
`DaemonManager.waitForReady` treated daemon readiness as socket-file existence plus PID liveness. A stale socket path combined with a live or reused PID could report ready even though clients could not connect.

## Validation
- `bun test test/daemon/daemonManagerReadiness.test.ts`
- `bun test test/daemon/daemonManagerReadiness.test.ts test/daemon/daemonClientAvailability.test.ts test/daemon/daemonMcpProxy.test.ts`
- `bun run build`
- `bunx eslint src/daemon/manager.ts test/daemon/daemonManagerReadiness.test.ts --fix`

Fixes #2444
