### PR TITLE
Fix stale daemon file cleanup

### DIFF
--- a/src/daemon/appearanceSocketServer.ts
+++ b/src/daemon/appearanceSocketServer.ts
@@ -1,8 +1,6 @@
-import os from "node:os";
-import path from "node:path";
 import { logger } from "../utils/logger";
 import { Timer, defaultTimer } from "../utils/SystemTimer";
-import { RequestResponseSocketServer, getSocketPath, SocketServerConfig } from "./socketServer/index";
+import { RequestResponseSocketServer, getSocketPath } from "./socketServer/index";
 import {
   AppearanceSocketRequest,
   AppearanceSocketResponse,
@@ -18,11 +16,7 @@ import { applyAppearanceToDevice } from "../utils/deviceAppearance";
 import { triggerAppearanceSync } from "../utils/appearance/AppearanceSyncScheduler";
 import { DaemonState } from "./daemonState";
 import type { AppearanceMode, BootedDevice } from "../models";
-
-const SOCKET_CONFIG: SocketServerConfig = {
-  defaultPath: path.join(os.homedir(), ".auto-mobile", "appearance.sock"),
-  externalPath: "/tmp/auto-mobile-appearance.sock",
-};
+import { APPEARANCE_SOCKET_CONFIG } from "./daemonFiles";
 
 const VALID_MODES = new Set(["light", "dark", "auto"]);
 
@@ -34,7 +28,7 @@ export class AppearanceSocketServer extends RequestResponseSocketServer<
   AppearanceSocketRequest,
   AppearanceSocketResponse
 > {
-  constructor(socketPath: string = getSocketPath(SOCKET_CONFIG), timer: Timer = defaultTimer) {
+  constructor(socketPath: string = getSocketPath(APPEARANCE_SOCKET_CONFIG), timer: Timer = defaultTimer) {
     super(socketPath, timer, "Appearance");
   }
 
@@ -159,7 +153,7 @@ export class AppearanceSocketServer extends RequestResponseSocketServer<
 let socketServer: AppearanceSocketServer | null = null;
 
 export function getAppearanceSocketPath(): string {
-  return socketServer?.getSocketPath() ?? getSocketPath(SOCKET_CONFIG);
+  return socketServer?.getSocketPath() ?? getSocketPath(APPEARANCE_SOCKET_CONFIG);
 }
 
 export async function startAppearanceSocketServer(): Promise<void> {

--- a/src/daemon/client.ts
+++ b/src/daemon/client.ts
@@ -12,6 +12,11 @@ import {
 import { resolveMcpRequestTimeoutMs } from "./mcpRequestTimeout";
 import { McpTimeoutError } from "./McpTimeoutError";
 import { type Timer, defaultTimer } from "../utils/SystemTimer";
+import {
+  cleanupStaleDaemonFilesForDeadPidSync,
+  getDaemonSocketPaths,
+  type StaleDaemonFileCleanupOptions,
+} from "./daemonFiles";
 
 /**
  * Custom error thrown when daemon is unavailable
@@ -22,6 +27,8 @@ export class DaemonUnavailableError extends Error {
     this.name = "DaemonUnavailableError";
   }
 }
+
+export interface DaemonClientRecoveryOptions extends StaleDaemonFileCleanupOptions {}
 
 /**
  * CLI Client for communicating with the daemon via Unix socket
@@ -45,22 +52,28 @@ export class DaemonClient {
   }> = new Map();
   private buffer: string = "";
   private connected: boolean = false;
+  private recoveryOptions: DaemonClientRecoveryOptions;
 
   constructor(
     socketPath: string = SOCKET_PATH,
     connectionTimeout: number = CONNECTION_TIMEOUT_MS,
     timer: Timer = defaultTimer,
+    recoveryOptions: DaemonClientRecoveryOptions = {},
   ) {
     this.socketPath = socketPath;
     this.connectionTimeout = connectionTimeout;
     this.timer = timer;
+    this.recoveryOptions = recoveryOptions;
   }
 
   /**
    * Check if daemon is available (socket file exists and is connectable).
    * Uses a lightweight raw socket probe — no logging, no DaemonClient overhead.
    */
-  static async isAvailable(socketPath: string = SOCKET_PATH): Promise<boolean> {
+  static async isAvailable(
+    socketPath: string = SOCKET_PATH,
+    recoveryOptions: DaemonClientRecoveryOptions = {}
+  ): Promise<boolean> {
     // On Unix, verify the path exists and is a socket (not a stale regular file).
     // On Windows, named pipes don't have filesystem entries — skip the stat check
     // and let createConnection determine reachability.
@@ -68,6 +81,7 @@ export class DaemonClient {
       try {
         const stats = statSync(socketPath);
         if (!stats.isSocket()) {
+          DaemonClient.cleanupStaleSocketIfDaemonDead(socketPath, recoveryOptions);
           return false;
         }
       } catch {
@@ -92,10 +106,12 @@ export class DaemonClient {
       socket.on("error", () => {
         defaultTimer.clearTimeout(timeout);
         socket.destroy();
+        DaemonClient.cleanupStaleSocketIfDaemonDead(socketPath, recoveryOptions);
         settle(false);
       });
       const timeout = defaultTimer.setTimeout(() => {
         socket.destroy();
+        DaemonClient.cleanupStaleSocketIfDaemonDead(socketPath, recoveryOptions);
         settle(false);
       }, 1000);
     });
@@ -109,6 +125,23 @@ export class DaemonClient {
       return;
     }
 
+    try {
+      await this.connectOnce();
+      return;
+    } catch (error) {
+      if (DaemonClient.cleanupStaleSocketIfDaemonDead(this.socketPath, this.recoveryOptions)) {
+        await this.connectOnce();
+        return;
+      }
+      throw error;
+    }
+  }
+
+  private async connectOnce(): Promise<void> {
+    if (this.connected) {
+      return;
+    }
+
     if (!existsSync(this.socketPath)) {
       throw new DaemonUnavailableError(
         `Daemon socket not found: ${this.socketPath}`
@@ -116,11 +149,32 @@ export class DaemonClient {
     }
 
     return new Promise((resolve, reject) => {
-      const timeout = this.timer.setTimeout(() => {
+      let settled = false;
+
+      const rejectPendingRequests = (error: Error) => {
+        for (const [, { reject, timeout }] of this.pendingRequests) {
+          this.timer.clearTimeout(timeout);
+          reject(error);
+        }
+        this.pendingRequests.clear();
+      };
+
+      const fail = (error: Error) => {
+        this.timer.clearTimeout(timeout);
+        this.connected = false;
         if (this.socket) {
           this.socket.destroy();
+          this.socket = null;
         }
-        reject(
+        rejectPendingRequests(error);
+        if (!settled) {
+          settled = true;
+          reject(error);
+        }
+      };
+
+      const timeout = this.timer.setTimeout(() => {
+        fail(
           new DaemonUnavailableError(
             `Failed to connect to daemon within ${this.connectionTimeout}ms`
           )
@@ -131,7 +185,10 @@ export class DaemonClient {
         this.timer.clearTimeout(timeout);
         this.connected = true;
         logger.info(`Connected to daemon at ${this.socketPath}`);
-        resolve();
+        if (!settled) {
+          settled = true;
+          resolve();
+        }
       });
 
       this.socket.on("data", data => {
@@ -139,24 +196,28 @@ export class DaemonClient {
       });
 
       this.socket.on("error", error => {
-        this.timer.clearTimeout(timeout);
-        this.connected = false;
         logger.error(`Daemon socket error: ${error.message}`);
-
-        // Reject all pending requests
-        for (const [, { reject, timeout }] of this.pendingRequests) {
-          this.timer.clearTimeout(timeout);
-          reject(error);
-        }
-        this.pendingRequests.clear();
-
-        reject(error);
+        fail(error);
       });
 
       this.socket.on("close", () => {
         this.connected = false;
         logger.info("Daemon socket connection closed");
       });
+    });
+  }
+
+  private static cleanupStaleSocketIfDaemonDead(
+    socketPath: string,
+    recoveryOptions: DaemonClientRecoveryOptions
+  ): boolean {
+    const socketPaths = recoveryOptions.socketPaths ?? (
+      socketPath === SOCKET_PATH ? getDaemonSocketPaths() : [socketPath]
+    );
+
+    return cleanupStaleDaemonFilesForDeadPidSync({
+      ...recoveryOptions,
+      socketPaths,
     });
   }
 

--- a/src/daemon/daemon.ts
+++ b/src/daemon/daemon.ts
@@ -17,9 +17,9 @@ import {
   DAEMON_PORT_RANGE_END,
 } from "./constants";
 import { DaemonOptions, PidFileData } from "./types";
-import { writeFile, unlink } from "node:fs/promises";
-import { existsSync } from "node:fs";
+import { writeFile } from "node:fs/promises";
 import { PID_FILE_PATH, DAEMON_VERSION } from "./constants";
+import { cleanupDaemonFiles, cleanupDaemonFilesSync } from "./daemonFiles";
 import { executionTracker } from "../server/executionTracker";
 import { closeDatabase, getDatabase } from "../db";
 import { startupBenchmark } from "../utils/startupBenchmark";
@@ -84,6 +84,8 @@ export class Daemon {
   private installedAppsRepository: InstalledAppsStore;
   private deviceSessionRepository: DeviceSessionRepository;
   private timer: Timer;
+  private shutdownHandlersRegistered: boolean = false;
+  private shutdownInProgress: boolean = false;
 
   constructor(
     options: DaemonOptions = {},
@@ -592,16 +594,6 @@ export class Daemon {
   }
 
   /**
-   * Remove PID file
-   */
-  private async removePidFile(): Promise<void> {
-    if (existsSync(PID_FILE_PATH)) {
-      await unlink(PID_FILE_PATH);
-      logger.info(`PID file removed: ${PID_FILE_PATH}`);
-    }
-  }
-
-  /**
    * Set up callback for observation stream to trigger device WebSocket connections.
    * When an IDE plugin subscribes to the observation stream, we need to ensure
    * the WebSocket connections to Android devices are established so that
@@ -1089,14 +1081,43 @@ export class Daemon {
    * Setup graceful shutdown handlers
    */
   private setupShutdownHandlers(): void {
+    if (this.shutdownHandlersRegistered) {
+      return;
+    }
+    this.shutdownHandlersRegistered = true;
+
     const shutdown = async (signal: string) => {
+      if (this.shutdownInProgress) {
+        return;
+      }
+      this.shutdownInProgress = true;
       logger.info(`Received ${signal}, shutting down daemon...`);
       await this.stop();
       process.exit(0);
     };
 
-    process.on("SIGINT", () => shutdown("SIGINT"));
-    process.on("SIGTERM", () => shutdown("SIGTERM"));
+    const cleanupAndExit = (label: string, error: unknown) => {
+      logger.error(`${label}: ${error instanceof Error ? error.stack ?? error.message : String(error)}`);
+      cleanupDaemonFilesSync();
+      logger.close();
+      process.exit(1);
+    };
+
+    process.once("SIGINT", () => {
+      shutdown("SIGINT").catch(error => cleanupAndExit("Error during SIGINT shutdown", error));
+    });
+    process.once("SIGTERM", () => {
+      shutdown("SIGTERM").catch(error => cleanupAndExit("Error during SIGTERM shutdown", error));
+    });
+    process.once("exit", () => {
+      cleanupDaemonFilesSync();
+    });
+    process.once("uncaughtException", error => {
+      cleanupAndExit("Uncaught exception in daemon", error);
+    });
+    process.once("unhandledRejection", reason => {
+      cleanupAndExit("Unhandled rejection in daemon", reason);
+    });
   }
 
   /**
@@ -1160,8 +1181,7 @@ export class Daemon {
       });
     }
 
-    // Remove PID file
-    await this.removePidFile();
+    await cleanupDaemonFiles();
 
     await closeDatabase();
 

--- a/src/daemon/daemon.ts
+++ b/src/daemon/daemon.ts
@@ -1098,7 +1098,7 @@ export class Daemon {
 
     const cleanupAndExit = (label: string, error: unknown) => {
       logger.error(`${label}: ${error instanceof Error ? error.stack ?? error.message : String(error)}`);
-      cleanupDaemonFilesSync();
+      cleanupDaemonFilesSync({ expectedPid: process.pid });
       logger.close();
       process.exit(1);
     };
@@ -1110,7 +1110,7 @@ export class Daemon {
       shutdown("SIGTERM").catch(error => cleanupAndExit("Error during SIGTERM shutdown", error));
     });
     process.once("exit", () => {
-      cleanupDaemonFilesSync();
+      cleanupDaemonFilesSync({ expectedPid: process.pid });
     });
     process.once("uncaughtException", error => {
       cleanupAndExit("Uncaught exception in daemon", error);
@@ -1181,7 +1181,7 @@ export class Daemon {
       });
     }
 
-    await cleanupDaemonFiles();
+    await cleanupDaemonFiles({ expectedPid: process.pid });
 
     await closeDatabase();
 

--- a/src/daemon/daemonFiles.ts
+++ b/src/daemon/daemonFiles.ts
@@ -1,0 +1,175 @@
+import os from "node:os";
+import path from "node:path";
+import { existsSync, readFileSync, unlinkSync } from "node:fs";
+import { unlink } from "node:fs/promises";
+import { PID_FILE_PATH, SOCKET_PATH } from "./constants";
+import { getSocketPath, type SocketServerConfig } from "./socketServer/index";
+import type { PidFileData } from "./types";
+
+export const VIDEO_RECORDING_SOCKET_CONFIG: SocketServerConfig = {
+  defaultPath: path.join(os.homedir(), ".auto-mobile", "video-recording.sock"),
+  externalPath: "/tmp/auto-mobile-video-recording.sock",
+};
+
+export const TEST_RECORDING_SOCKET_CONFIG: SocketServerConfig = {
+  defaultPath: path.join(os.homedir(), ".auto-mobile", "test-recording.sock"),
+  externalPath: "/tmp/auto-mobile-test-recording.sock",
+};
+
+export const DEVICE_SNAPSHOT_SOCKET_CONFIG: SocketServerConfig = {
+  defaultPath: path.join(os.homedir(), ".auto-mobile", "device-snapshot.sock"),
+  externalPath: "/tmp/auto-mobile-device-snapshot.sock",
+};
+
+export const APPEARANCE_SOCKET_CONFIG: SocketServerConfig = {
+  defaultPath: path.join(os.homedir(), ".auto-mobile", "appearance.sock"),
+  externalPath: "/tmp/auto-mobile-appearance.sock",
+};
+
+export const PERFORMANCE_STREAM_SOCKET_CONFIG: SocketServerConfig = {
+  defaultPath: path.join(os.homedir(), ".auto-mobile", "performance-stream.sock"),
+  externalPath: "/tmp/auto-mobile-performance-stream.sock",
+};
+
+export const PERFORMANCE_PUSH_SOCKET_CONFIG: SocketServerConfig = {
+  defaultPath: path.join(os.homedir(), ".auto-mobile", "performance-push.sock"),
+  externalPath: "/tmp/auto-mobile-performance-push.sock",
+};
+
+export const DEVICE_DATA_STREAM_SOCKET_CONFIG: SocketServerConfig = {
+  defaultPath: path.join(os.homedir(), ".auto-mobile", "observation-stream.sock"),
+  externalPath: "/tmp/auto-mobile-observation-stream.sock",
+};
+
+export const FAILURES_STREAM_SOCKET_CONFIG: SocketServerConfig = {
+  defaultPath: path.join(os.homedir(), ".auto-mobile", "failures-stream.sock"),
+  externalPath: "/tmp/auto-mobile-failures-stream.sock",
+};
+
+export const FAILURES_PUSH_SOCKET_CONFIG: SocketServerConfig = {
+  defaultPath: path.join(os.homedir(), ".auto-mobile", "failures-push.sock"),
+  externalPath: "/tmp/auto-mobile-failures-push.sock",
+};
+
+export const TELEMETRY_PUSH_SOCKET_CONFIG: SocketServerConfig = {
+  defaultPath: path.join(os.homedir(), ".auto-mobile", "telemetry-push.sock"),
+  externalPath: "/tmp/auto-mobile-telemetry-push.sock",
+};
+
+const AUXILIARY_SOCKET_CONFIGS: SocketServerConfig[] = [
+  VIDEO_RECORDING_SOCKET_CONFIG,
+  TEST_RECORDING_SOCKET_CONFIG,
+  DEVICE_SNAPSHOT_SOCKET_CONFIG,
+  APPEARANCE_SOCKET_CONFIG,
+  PERFORMANCE_STREAM_SOCKET_CONFIG,
+  PERFORMANCE_PUSH_SOCKET_CONFIG,
+  DEVICE_DATA_STREAM_SOCKET_CONFIG,
+  FAILURES_STREAM_SOCKET_CONFIG,
+  FAILURES_PUSH_SOCKET_CONFIG,
+  TELEMETRY_PUSH_SOCKET_CONFIG,
+];
+
+export interface DaemonFileCleanupOptions {
+  pidFilePath?: string;
+  socketPaths?: string[];
+}
+
+export interface StaleDaemonFileCleanupOptions extends DaemonFileCleanupOptions {
+  isProcessRunning?: (pid: number) => boolean;
+}
+
+export function getDaemonSocketPaths(): string[] {
+  return [
+    SOCKET_PATH,
+    ...AUXILIARY_SOCKET_CONFIGS.map(config => getSocketPath(config)),
+  ];
+}
+
+export async function cleanupDaemonFiles(options: DaemonFileCleanupOptions = {}): Promise<void> {
+  const pidFilePath = options.pidFilePath ?? PID_FILE_PATH;
+  const socketPaths = options.socketPaths ?? getDaemonSocketPaths();
+
+  for (const socketPath of socketPaths) {
+    if (!existsSync(socketPath)) {
+      continue;
+    }
+    try {
+      await unlink(socketPath);
+    } catch {
+      // Best-effort cleanup; callers should not fail shutdown/startup on stale files.
+    }
+  }
+
+  if (existsSync(pidFilePath)) {
+    try {
+      await unlink(pidFilePath);
+    } catch {
+      // Best-effort cleanup.
+    }
+  }
+}
+
+export function cleanupDaemonFilesSync(options: DaemonFileCleanupOptions = {}): void {
+  const pidFilePath = options.pidFilePath ?? PID_FILE_PATH;
+  const socketPaths = options.socketPaths ?? getDaemonSocketPaths();
+
+  for (const socketPath of socketPaths) {
+    if (!existsSync(socketPath)) {
+      continue;
+    }
+    try {
+      unlinkSync(socketPath);
+    } catch {
+      // Best-effort cleanup.
+    }
+  }
+
+  if (existsSync(pidFilePath)) {
+    try {
+      unlinkSync(pidFilePath);
+    } catch {
+      // Best-effort cleanup.
+    }
+  }
+}
+
+export function readPidFileDataSync(pidFilePath: string = PID_FILE_PATH): PidFileData | null {
+  if (!existsSync(pidFilePath)) {
+    return null;
+  }
+  try {
+    return JSON.parse(readFileSync(pidFilePath, "utf-8")) as PidFileData;
+  } catch {
+    return null;
+  }
+}
+
+export function isProcessRunning(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function cleanupStaleDaemonFilesForDeadPidSync(
+  options: StaleDaemonFileCleanupOptions = {}
+): boolean {
+  const pidFilePath = options.pidFilePath ?? PID_FILE_PATH;
+  const pidData = readPidFileDataSync(pidFilePath);
+  if (!pidData || typeof pidData.pid !== "number") {
+    return false;
+  }
+
+  const processRunning = options.isProcessRunning ?? isProcessRunning;
+  if (processRunning(pidData.pid)) {
+    return false;
+  }
+
+  cleanupDaemonFilesSync({
+    pidFilePath,
+    socketPaths: options.socketPaths,
+  });
+  return true;
+}

--- a/src/daemon/daemonFiles.ts
+++ b/src/daemon/daemonFiles.ts
@@ -86,12 +86,12 @@ export function getDaemonSocketPaths(): string[] {
   ];
 }
 
-export async function cleanupDaemonFiles(options: DaemonFileCleanupOptions = {}): Promise<void> {
+export async function cleanupDaemonFiles(options: DaemonFileCleanupOptions = {}): Promise<boolean> {
   const pidFilePath = options.pidFilePath ?? PID_FILE_PATH;
   const socketPaths = options.socketPaths ?? getDaemonSocketPaths();
 
   if (!shouldCleanupForExpectedPid(pidFilePath, options.expectedPid)) {
-    return;
+    return false;
   }
 
   for (const socketPath of socketPaths) {
@@ -112,14 +112,15 @@ export async function cleanupDaemonFiles(options: DaemonFileCleanupOptions = {})
       // Best-effort cleanup.
     }
   }
+  return true;
 }
 
-export function cleanupDaemonFilesSync(options: DaemonFileCleanupOptions = {}): void {
+export function cleanupDaemonFilesSync(options: DaemonFileCleanupOptions = {}): boolean {
   const pidFilePath = options.pidFilePath ?? PID_FILE_PATH;
   const socketPaths = options.socketPaths ?? getDaemonSocketPaths();
 
   if (!shouldCleanupForExpectedPid(pidFilePath, options.expectedPid)) {
-    return;
+    return false;
   }
 
   for (const socketPath of socketPaths) {
@@ -140,6 +141,7 @@ export function cleanupDaemonFilesSync(options: DaemonFileCleanupOptions = {}): 
       // Best-effort cleanup.
     }
   }
+  return true;
 }
 
 export function readPidFileDataSync(pidFilePath: string = PID_FILE_PATH): PidFileData | null {
@@ -184,9 +186,9 @@ export function cleanupStaleDaemonFilesForDeadPidSync(
     return false;
   }
 
-  cleanupDaemonFilesSync({
+  return cleanupDaemonFilesSync({
     pidFilePath,
     socketPaths: options.socketPaths,
+    expectedPid: pidData.pid,
   });
-  return true;
 }

--- a/src/daemon/daemonFiles.ts
+++ b/src/daemon/daemonFiles.ts
@@ -72,6 +72,7 @@ const AUXILIARY_SOCKET_CONFIGS: SocketServerConfig[] = [
 export interface DaemonFileCleanupOptions {
   pidFilePath?: string;
   socketPaths?: string[];
+  expectedPid?: number;
 }
 
 export interface StaleDaemonFileCleanupOptions extends DaemonFileCleanupOptions {
@@ -88,6 +89,10 @@ export function getDaemonSocketPaths(): string[] {
 export async function cleanupDaemonFiles(options: DaemonFileCleanupOptions = {}): Promise<void> {
   const pidFilePath = options.pidFilePath ?? PID_FILE_PATH;
   const socketPaths = options.socketPaths ?? getDaemonSocketPaths();
+
+  if (!shouldCleanupForExpectedPid(pidFilePath, options.expectedPid)) {
+    return;
+  }
 
   for (const socketPath of socketPaths) {
     if (!existsSync(socketPath)) {
@@ -112,6 +117,10 @@ export async function cleanupDaemonFiles(options: DaemonFileCleanupOptions = {})
 export function cleanupDaemonFilesSync(options: DaemonFileCleanupOptions = {}): void {
   const pidFilePath = options.pidFilePath ?? PID_FILE_PATH;
   const socketPaths = options.socketPaths ?? getDaemonSocketPaths();
+
+  if (!shouldCleanupForExpectedPid(pidFilePath, options.expectedPid)) {
+    return;
+  }
 
   for (const socketPath of socketPaths) {
     if (!existsSync(socketPath)) {
@@ -151,6 +160,14 @@ export function isProcessRunning(pid: number): boolean {
   } catch {
     return false;
   }
+}
+
+function shouldCleanupForExpectedPid(pidFilePath: string, expectedPid: number | undefined): boolean {
+  if (expectedPid === undefined) {
+    return true;
+  }
+  const pidData = readPidFileDataSync(pidFilePath);
+  return pidData?.pid === expectedPid;
 }
 
 export function cleanupStaleDaemonFilesForDeadPidSync(

--- a/src/daemon/deviceDataStreamSocketServer.ts
+++ b/src/daemon/deviceDataStreamSocketServer.ts
@@ -1,23 +1,14 @@
-import os from "node:os";
-import path from "node:path";
 import { Socket } from "node:net";
 import { logger } from "../utils/logger";
 import { Timer, defaultTimer } from "../utils/SystemTimer";
 import {
   PushSubscriptionSocketServer,
   getSocketPath,
-  SocketServerConfig,
   SubscriptionResponse,
 } from "./socketServer/index";
 import type { ObserveResult, ViewHierarchyResult } from "../models";
 import type { StorageChangedEvent } from "../features/storage/storageTypes";
-
-// NOTE: Keep legacy socket path for backward compatibility with IDE plugin
-// (android/ide-plugin/.../ObservationStreamClient.kt hardcodes this path)
-const SOCKET_CONFIG: SocketServerConfig = {
-  defaultPath: path.join(os.homedir(), ".auto-mobile", "observation-stream.sock"),
-  externalPath: "/tmp/auto-mobile-observation-stream.sock",
-};
+import { DEVICE_DATA_STREAM_SOCKET_CONFIG } from "./daemonFiles";
 
 /**
  * Navigation graph summary for streaming to IDE plugins.
@@ -172,7 +163,7 @@ export class DeviceDataStreamSocketServer extends PushSubscriptionSocketServer<
   private onNavigationGraphRequested: OnNavigationGraphRequestedCallback | null = null;
   private observationRequestTimeoutMs = DEFAULT_OBSERVATION_REQUEST_TIMEOUT_MS;
 
-  constructor(socketPath: string = getSocketPath(SOCKET_CONFIG), timer: Timer = defaultTimer) {
+  constructor(socketPath: string = getSocketPath(DEVICE_DATA_STREAM_SOCKET_CONFIG), timer: Timer = defaultTimer) {
     super(socketPath, timer, "DeviceDataStream");
   }
 
@@ -531,14 +522,14 @@ export function getDeviceDataStreamServer(): DeviceDataStreamSocketServer | null
 }
 
 export function getDeviceDataStreamSocketPath(): string {
-  return socketServer?.getSocketPath() ?? getSocketPath(SOCKET_CONFIG);
+  return socketServer?.getSocketPath() ?? getSocketPath(DEVICE_DATA_STREAM_SOCKET_CONFIG);
 }
 
 export async function startDeviceDataStreamSocketServer(
   timer: Timer = defaultTimer
 ): Promise<DeviceDataStreamSocketServer> {
   if (!socketServer) {
-    socketServer = new DeviceDataStreamSocketServer(getSocketPath(SOCKET_CONFIG), timer);
+    socketServer = new DeviceDataStreamSocketServer(getSocketPath(DEVICE_DATA_STREAM_SOCKET_CONFIG), timer);
   }
   if (!socketServer.isListening()) {
     await socketServer.start();

--- a/src/daemon/deviceSnapshotSocketServer.ts
+++ b/src/daemon/deviceSnapshotSocketServer.ts
@@ -1,17 +1,11 @@
-import os from "node:os";
-import path from "node:path";
 import { Timer, defaultTimer } from "../utils/SystemTimer";
-import { RequestResponseSocketServer, getSocketPath, SocketServerConfig } from "./socketServer/index";
+import { RequestResponseSocketServer, getSocketPath } from "./socketServer/index";
 import {
   DeviceSnapshotSocketRequest,
   DeviceSnapshotSocketResponse,
 } from "./deviceSnapshotSocketTypes";
 import { getDeviceSnapshotConfig, updateDeviceSnapshotConfig } from "../server/deviceSnapshotManager";
-
-const SOCKET_CONFIG: SocketServerConfig = {
-  defaultPath: path.join(os.homedir(), ".auto-mobile", "device-snapshot.sock"),
-  externalPath: "/tmp/auto-mobile-device-snapshot.sock",
-};
+import { DEVICE_SNAPSHOT_SOCKET_CONFIG } from "./daemonFiles";
 
 /**
  * Socket server for device snapshot configuration.
@@ -21,7 +15,7 @@ export class DeviceSnapshotSocketServer extends RequestResponseSocketServer<
   DeviceSnapshotSocketRequest,
   DeviceSnapshotSocketResponse
 > {
-  constructor(socketPath: string = getSocketPath(SOCKET_CONFIG), timer: Timer = defaultTimer) {
+  constructor(socketPath: string = getSocketPath(DEVICE_SNAPSHOT_SOCKET_CONFIG), timer: Timer = defaultTimer) {
     super(socketPath, timer, "DeviceSnapshot");
   }
 
@@ -74,7 +68,7 @@ export class DeviceSnapshotSocketServer extends RequestResponseSocketServer<
 let socketServer: DeviceSnapshotSocketServer | null = null;
 
 export function getDeviceSnapshotSocketPath(): string {
-  return socketServer?.getSocketPath() ?? getSocketPath(SOCKET_CONFIG);
+  return socketServer?.getSocketPath() ?? getSocketPath(DEVICE_SNAPSHOT_SOCKET_CONFIG);
 }
 
 export async function startDeviceSnapshotSocketServer(): Promise<void> {

--- a/src/daemon/failuresPushSocketServer.ts
+++ b/src/daemon/failuresPushSocketServer.ts
@@ -1,14 +1,8 @@
-import os from "node:os";
-import path from "node:path";
 import { logger } from "../utils/logger";
 import { Timer, defaultTimer } from "../utils/SystemTimer";
-import { PushSubscriptionSocketServer, getSocketPath, SocketServerConfig } from "./socketServer/index";
+import { PushSubscriptionSocketServer, getSocketPath } from "./socketServer/index";
 import type { FailureType, FailureSeverity } from "../server/failuresResources";
-
-const SOCKET_CONFIG: SocketServerConfig = {
-  defaultPath: path.join(os.homedir(), ".auto-mobile", "failures-push.sock"),
-  externalPath: "/tmp/auto-mobile-failures-push.sock",
-};
+import { FAILURES_PUSH_SOCKET_CONFIG } from "./daemonFiles";
 
 /**
  * Failure notification data pushed to clients
@@ -54,7 +48,7 @@ export class FailuresPushSocketServer extends PushSubscriptionSocketServer<
   FailureFilter,
   FailureNotificationPush
 > {
-  constructor(socketPath: string = getSocketPath(SOCKET_CONFIG), timer: Timer = defaultTimer) {
+  constructor(socketPath: string = getSocketPath(FAILURES_PUSH_SOCKET_CONFIG), timer: Timer = defaultTimer) {
     super(socketPath, timer, "FailuresPush");
   }
 
@@ -97,7 +91,7 @@ export function getFailuresPushServer(): FailuresPushSocketServer | null {
 }
 
 export function getFailuresPushSocketPath(): string {
-  return socketServer?.getSocketPath() ?? getSocketPath(SOCKET_CONFIG);
+  return socketServer?.getSocketPath() ?? getSocketPath(FAILURES_PUSH_SOCKET_CONFIG);
 }
 
 export async function startFailuresPushSocketServer(): Promise<FailuresPushSocketServer> {

--- a/src/daemon/failuresStreamSocketServer.ts
+++ b/src/daemon/failuresStreamSocketServer.ts
@@ -1,7 +1,5 @@
-import os from "node:os";
-import path from "node:path";
 import { Timer, defaultTimer } from "../utils/SystemTimer";
-import { RequestResponseSocketServer, getSocketPath, SocketServerConfig } from "./socketServer/index";
+import { RequestResponseSocketServer, getSocketPath } from "./socketServer/index";
 import { FailureAnalyticsRepository } from "../db/failureAnalyticsRepository";
 import type {
   FailuresStreamSocketRequest,
@@ -9,11 +7,7 @@ import type {
   DateRangePreset,
   TimeAggregation,
 } from "./failuresStreamSocketTypes";
-
-const SOCKET_CONFIG: SocketServerConfig = {
-  defaultPath: path.join(os.homedir(), ".auto-mobile", "failures-stream.sock"),
-  externalPath: "/tmp/auto-mobile-failures-stream.sock",
-};
+import { FAILURES_STREAM_SOCKET_CONFIG } from "./daemonFiles";
 
 const DEFAULT_LIMIT = 100;
 const STREAM_LIMIT_MAX = 500;
@@ -139,7 +133,7 @@ export class FailuresStreamSocketServer extends RequestResponseSocketServer<
   FailuresStreamSocketRequest,
   FailuresStreamSocketResponse
 > {
-  constructor(socketPath: string = getSocketPath(SOCKET_CONFIG), timer: Timer = defaultTimer) {
+  constructor(socketPath: string = getSocketPath(FAILURES_STREAM_SOCKET_CONFIG), timer: Timer = defaultTimer) {
     super(socketPath, timer, "FailuresStream");
   }
 
@@ -292,7 +286,7 @@ export class FailuresStreamSocketServer extends RequestResponseSocketServer<
 let socketServer: FailuresStreamSocketServer | null = null;
 
 export function getFailuresStreamSocketPath(): string {
-  return socketServer?.getSocketPath() ?? getSocketPath(SOCKET_CONFIG);
+  return socketServer?.getSocketPath() ?? getSocketPath(FAILURES_STREAM_SOCKET_CONFIG);
 }
 
 export async function startFailuresStreamSocketServer(): Promise<void> {

--- a/src/daemon/manager.ts
+++ b/src/daemon/manager.ts
@@ -1,5 +1,5 @@
 import { spawn, execSync } from "node:child_process";
-import { readFile, unlink } from "node:fs/promises";
+import { readFile } from "node:fs/promises";
 import { existsSync, openSync, closeSync, mkdtempSync, readFileSync, unlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -23,6 +23,7 @@ import {
 import { DaemonClient, type DaemonClientFactory, type DaemonClientLike } from "./client";
 import { DaemonState, type DaemonStateLike } from "./daemonState";
 import { Timer, defaultTimer } from "../utils/SystemTimer";
+import { cleanupDaemonFiles } from "./daemonFiles";
 
 /**
  * Check that bunx is available on PATH.
@@ -195,6 +196,14 @@ export class DaemonManager implements DaemonManagerLike {
   getDaemonState(): DaemonStateLike {
     return this.stateProvider();
   }
+
+  private cleanupSocketPaths(primarySocketPath?: string): string[] | undefined {
+    if (this.pidFilePath === PID_FILE_PATH) {
+      return undefined;
+    }
+    return primarySocketPath ? [primarySocketPath] : [];
+  }
+
   /**
    * Find all running auto-mobile daemon processes (including those from other worktrees)
    */
@@ -316,22 +325,7 @@ export class DaemonManager implements DaemonManagerLike {
     }
 
     // Clean up stale socket and PID files from previous sessions
-    if (existsSync(this.socketPath)) {
-      logger.debug("Removing stale socket file");
-      try {
-        await unlink(this.socketPath);
-      } catch (error) {
-        logger.warn(`Failed to remove stale socket file: ${error instanceof Error ? error.message : String(error)}`);
-      }
-    }
-    if (existsSync(this.pidFilePath)) {
-      logger.debug("Removing stale PID file");
-      try {
-        await unlink(this.pidFilePath);
-      } catch (error) {
-        logger.warn(`Failed to remove stale PID file: ${error instanceof Error ? error.message : String(error)}`);
-      }
-    }
+    await cleanupDaemonFiles({ pidFilePath: this.pidFilePath });
 
     stderrLog("Starting AutoMobile daemon...");
 
@@ -496,10 +490,10 @@ export class DaemonManager implements DaemonManagerLike {
         await this.timer.sleep(1000);
       }
 
-      // Clean up stale PID file if it exists
-      if (existsSync(this.pidFilePath)) {
-        await unlink(this.pidFilePath);
-      }
+      await cleanupDaemonFiles({
+        pidFilePath: this.pidFilePath,
+        socketPaths: this.cleanupSocketPaths(status.socketPath),
+      });
 
       stderrLog("Daemon stopped");
     } catch (error) {
@@ -508,10 +502,10 @@ export class DaemonManager implements DaemonManagerLike {
         error instanceof Error &&
         (error.message.includes("ESRCH") || error.message.includes("EPERM"))
       ) {
-        // Clean up stale PID file
-        if (existsSync(this.pidFilePath)) {
-          await unlink(this.pidFilePath);
-        }
+        await cleanupDaemonFiles({
+          pidFilePath: this.pidFilePath,
+          socketPaths: this.cleanupSocketPaths(status.socketPath),
+        });
         stderrLog("Daemon was not running (cleaned up stale PID file)");
       } else {
         throw error;
@@ -537,8 +531,10 @@ export class DaemonManager implements DaemonManagerLike {
       const running = this.isProcessRunning(pidData.pid);
 
       if (!running) {
-        // Clean up stale PID file
-        await unlink(this.pidFilePath);
+        await cleanupDaemonFiles({
+          pidFilePath: this.pidFilePath,
+          socketPaths: this.cleanupSocketPaths(pidData.socketPath),
+        });
         return { running: false };
       }
 

--- a/src/daemon/manager.ts
+++ b/src/daemon/manager.ts
@@ -1,5 +1,5 @@
 import { spawn, execSync } from "node:child_process";
-import { readFile } from "node:fs/promises";
+import { readFile, unlink } from "node:fs/promises";
 import { existsSync, openSync, closeSync, mkdtempSync, readFileSync, unlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -493,6 +493,7 @@ export class DaemonManager implements DaemonManagerLike {
       await cleanupDaemonFiles({
         pidFilePath: this.pidFilePath,
         socketPaths: this.cleanupSocketPaths(status.socketPath),
+        expectedPid: pid,
       });
 
       stderrLog("Daemon stopped");
@@ -505,6 +506,7 @@ export class DaemonManager implements DaemonManagerLike {
         await cleanupDaemonFiles({
           pidFilePath: this.pidFilePath,
           socketPaths: this.cleanupSocketPaths(status.socketPath),
+          expectedPid: pid,
         });
         stderrLog("Daemon was not running (cleaned up stale PID file)");
       } else {
@@ -534,6 +536,7 @@ export class DaemonManager implements DaemonManagerLike {
         await cleanupDaemonFiles({
           pidFilePath: this.pidFilePath,
           socketPaths: this.cleanupSocketPaths(pidData.socketPath),
+          expectedPid: pidData.pid,
         });
         return { running: false };
       }

--- a/src/daemon/performancePushSocketServer.ts
+++ b/src/daemon/performancePushSocketServer.ts
@@ -1,13 +1,7 @@
-import os from "node:os";
-import path from "node:path";
 import { logger } from "../utils/logger";
 import { Timer, defaultTimer } from "../utils/SystemTimer";
-import { PushSubscriptionSocketServer, getSocketPath, SocketServerConfig } from "./socketServer/index";
-
-const SOCKET_CONFIG: SocketServerConfig = {
-  defaultPath: path.join(os.homedir(), ".auto-mobile", "performance-push.sock"),
-  externalPath: "/tmp/auto-mobile-performance-push.sock",
-};
+import { PushSubscriptionSocketServer, getSocketPath } from "./socketServer/index";
+import { PERFORMANCE_PUSH_SOCKET_CONFIG } from "./daemonFiles";
 
 /**
  * Performance thresholds for health status calculation
@@ -104,7 +98,7 @@ export class PerformancePushSocketServer extends PushSubscriptionSocketServer<
   PerformanceFilter,
   LivePerformanceData
 > {
-  constructor(socketPath: string = getSocketPath(SOCKET_CONFIG), timer: Timer = defaultTimer) {
+  constructor(socketPath: string = getSocketPath(PERFORMANCE_PUSH_SOCKET_CONFIG), timer: Timer = defaultTimer) {
     super(socketPath, timer, "PerformancePush");
   }
 
@@ -194,7 +188,7 @@ export function getPerformancePushServer(): PerformancePushSocketServer | null {
 }
 
 export function getPerformancePushSocketPath(): string {
-  return socketServer?.getSocketPath() ?? getSocketPath(SOCKET_CONFIG);
+  return socketServer?.getSocketPath() ?? getSocketPath(PERFORMANCE_PUSH_SOCKET_CONFIG);
 }
 
 export async function startPerformancePushSocketServer(): Promise<PerformancePushSocketServer> {

--- a/src/daemon/performanceStreamSocketServer.ts
+++ b/src/daemon/performanceStreamSocketServer.ts
@@ -1,17 +1,11 @@
-import os from "node:os";
-import path from "node:path";
 import { Timer, defaultTimer } from "../utils/SystemTimer";
-import { RequestResponseSocketServer, getSocketPath, SocketServerConfig } from "./socketServer/index";
+import { RequestResponseSocketServer, getSocketPath } from "./socketServer/index";
 import { PerformanceAuditRepository } from "../db/performanceAuditRepository";
 import {
   PerformanceStreamSocketRequest,
   PerformanceStreamSocketResponse,
 } from "./performanceStreamSocketTypes";
-
-const SOCKET_CONFIG: SocketServerConfig = {
-  defaultPath: path.join(os.homedir(), ".auto-mobile", "performance-stream.sock"),
-  externalPath: "/tmp/auto-mobile-performance-stream.sock",
-};
+import { PERFORMANCE_STREAM_SOCKET_CONFIG } from "./daemonFiles";
 
 const DEFAULT_LIMIT = 200;
 const auditRepository = new PerformanceAuditRepository();
@@ -64,7 +58,7 @@ export class PerformanceStreamSocketServer extends RequestResponseSocketServer<
   PerformanceStreamSocketRequest,
   PerformanceStreamSocketResponse
 > {
-  constructor(socketPath: string = getSocketPath(SOCKET_CONFIG), timer: Timer = defaultTimer) {
+  constructor(socketPath: string = getSocketPath(PERFORMANCE_STREAM_SOCKET_CONFIG), timer: Timer = defaultTimer) {
     super(socketPath, timer, "PerformanceStream");
   }
 
@@ -113,7 +107,7 @@ export class PerformanceStreamSocketServer extends RequestResponseSocketServer<
 let socketServer: PerformanceStreamSocketServer | null = null;
 
 export function getPerformanceStreamSocketPath(): string {
-  return socketServer?.getSocketPath() ?? getSocketPath(SOCKET_CONFIG);
+  return socketServer?.getSocketPath() ?? getSocketPath(PERFORMANCE_STREAM_SOCKET_CONFIG);
 }
 
 export async function startPerformanceStreamSocketServer(): Promise<void> {

--- a/src/daemon/socketServer.ts
+++ b/src/daemon/socketServer.ts
@@ -700,14 +700,14 @@ export class UnixSocketServer {
     // Clear sessions
     this.sessions.clear();
 
-    // Close server
     if (this.server) {
-      return new Promise(resolve => {
+      await new Promise<void>(resolve => {
         this.server!.close(() => {
           logger.info("Unix socket server closed");
           resolve();
         });
       });
+      this.server = null;
     }
 
     // Remove socket file

--- a/src/daemon/socketServer.ts
+++ b/src/daemon/socketServer.ts
@@ -1,7 +1,7 @@
 import { createServer, Server as NetServer, Socket } from "node:net";
 import { randomUUID } from "node:crypto";
 import { unlink } from "node:fs/promises";
-import { existsSync } from "node:fs";
+import { existsSync, statSync } from "node:fs";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import {
   StreamableHTTPClientTransport,
@@ -67,8 +67,14 @@ const DAEMON_LOOPBACK_STREAMABLE_HTTP_RECONNECTION: StreamableHTTPReconnectionOp
   maxRetries: 0,
 };
 
+interface SocketFileIdentity {
+  dev: number;
+  ino: number;
+}
+
 export class UnixSocketServer {
   private server: NetServer | null = null;
+  private socketFileIdentity: SocketFileIdentity | null = null;
   private sessions: Map<string, SessionContext> = new Map();
   private socketPath: string;
   private mcpEndpoint: string;
@@ -113,6 +119,7 @@ export class UnixSocketServer {
 
     return new Promise((resolve, reject) => {
       this.server!.listen(this.socketPath, () => {
+        this.socketFileIdentity = this.readSocketFileIdentity();
         logger.info(`Unix socket server listening on ${this.socketPath}`);
         resolve();
       });
@@ -700,7 +707,9 @@ export class UnixSocketServer {
     // Clear sessions
     this.sessions.clear();
 
-    if (this.server) {
+    const ownsSocketPath = this.isOwnedSocketFile();
+
+    if (this.server && (ownsSocketPath || !existsSync(this.socketPath))) {
       await new Promise<void>(resolve => {
         this.server!.close(() => {
           logger.info("Unix socket server closed");
@@ -708,11 +717,35 @@ export class UnixSocketServer {
         });
       });
       this.server = null;
+    } else if (this.server) {
+      logger.warn(
+        `Unix socket path ${this.socketPath} no longer belongs to this server; leaving listener for process teardown`
+      );
+      this.server.unref();
+      this.server = null;
     }
 
-    // Remove socket file
-    if (existsSync(this.socketPath)) {
+    if (ownsSocketPath && existsSync(this.socketPath)) {
       await unlink(this.socketPath);
     }
+    this.socketFileIdentity = null;
+  }
+
+  private readSocketFileIdentity(): SocketFileIdentity | null {
+    try {
+      const stats = statSync(this.socketPath);
+      return { dev: stats.dev, ino: stats.ino };
+    } catch {
+      return null;
+    }
+  }
+
+  private isOwnedSocketFile(): boolean {
+    if (!this.socketFileIdentity || !existsSync(this.socketPath)) {
+      return false;
+    }
+    const currentIdentity = this.readSocketFileIdentity();
+    return currentIdentity?.dev === this.socketFileIdentity.dev &&
+      currentIdentity.ino === this.socketFileIdentity.ino;
   }
 }

--- a/src/daemon/telemetryPushSocketServer.ts
+++ b/src/daemon/telemetryPushSocketServer.ts
@@ -1,9 +1,7 @@
-import os from "node:os";
-import path from "node:path";
 import type { Socket } from "node:net";
 import { logger } from "../utils/logger";
 import { Timer, defaultTimer } from "../utils/SystemTimer";
-import { PushSubscriptionSocketServer, getSocketPath, SocketServerConfig } from "./socketServer/index";
+import { PushSubscriptionSocketServer, getSocketPath } from "./socketServer/index";
 import type { TelemetryEvent } from "../features/telemetry/TelemetryRecorder";
 import { getNetworkEvents } from "../db/networkEventRepository";
 import { getLogEvents } from "../db/logEventRepository";
@@ -14,11 +12,7 @@ import { getLayoutEvents } from "../db/layoutEventRepository";
 import { getDatabase } from "../db/database";
 import type { Database } from "../db/types";
 import type { Kysely } from "kysely";
-
-const SOCKET_CONFIG: SocketServerConfig = {
-  defaultPath: path.join(os.homedir(), ".auto-mobile", "telemetry-push.sock"),
-  externalPath: "/tmp/auto-mobile-telemetry-push.sock",
-};
+import { TELEMETRY_PUSH_SOCKET_CONFIG } from "./daemonFiles";
 
 interface TelemetryFilter {
   category: string | null; // "network", "log", "os", "navigation", "crash", "anr", "nonfatal", "storage", "layout", or null for all
@@ -36,7 +30,7 @@ export class TelemetryPushSocketServer extends PushSubscriptionSocketServer<
   TelemetryFilter,
   TelemetryEvent
 > {
-  constructor(socketPath: string = getSocketPath(SOCKET_CONFIG), timer: Timer = defaultTimer) {
+  constructor(socketPath: string = getSocketPath(TELEMETRY_PUSH_SOCKET_CONFIG), timer: Timer = defaultTimer) {
     super(socketPath, timer, "TelemetryPush");
   }
 
@@ -245,7 +239,7 @@ export function getTelemetryPushServer(): TelemetryPushSocketServer | null {
 }
 
 export function getTelemetryPushSocketPath(): string {
-  return socketServer?.getSocketPath() ?? getSocketPath(SOCKET_CONFIG);
+  return socketServer?.getSocketPath() ?? getSocketPath(TELEMETRY_PUSH_SOCKET_CONFIG);
 }
 
 export async function startTelemetryPushSocketServer(): Promise<TelemetryPushSocketServer> {

--- a/src/daemon/testRecordingSocketServer.ts
+++ b/src/daemon/testRecordingSocketServer.ts
@@ -1,7 +1,5 @@
-import os from "node:os";
-import path from "node:path";
 import { Timer, defaultTimer } from "../utils/SystemTimer";
-import { RequestResponseSocketServer, getSocketPath, SocketServerConfig } from "./socketServer/index";
+import { RequestResponseSocketServer, getSocketPath } from "./socketServer/index";
 import { DeviceSessionManager } from "../utils/DeviceSessionManager";
 import type { BootedDevice, Platform, SomePlatform } from "../models";
 import {
@@ -13,11 +11,7 @@ import {
   TestRecordingCommand,
   TestRecordingResponse,
 } from "./testRecordingSocketTypes";
-
-const SOCKET_CONFIG: SocketServerConfig = {
-  defaultPath: path.join(os.homedir(), ".auto-mobile", "test-recording.sock"),
-  externalPath: "/tmp/auto-mobile-test-recording.sock",
-};
+import { TEST_RECORDING_SOCKET_CONFIG } from "./daemonFiles";
 
 const resolveDevice = async (
   deviceId?: string,
@@ -58,7 +52,7 @@ export class TestRecordingSocketServer extends RequestResponseSocketServer<
   TestRecordingCommand,
   TestRecordingResponse
 > {
-  constructor(socketPath: string = getSocketPath(SOCKET_CONFIG), timer: Timer = defaultTimer) {
+  constructor(socketPath: string = getSocketPath(TEST_RECORDING_SOCKET_CONFIG), timer: Timer = defaultTimer) {
     super(socketPath, timer, "TestRecording");
   }
 
@@ -121,7 +115,7 @@ export class TestRecordingSocketServer extends RequestResponseSocketServer<
 let socketServer: TestRecordingSocketServer | null = null;
 
 export function getTestRecordingSocketPath(): string {
-  return socketServer?.getSocketPath() ?? getSocketPath(SOCKET_CONFIG);
+  return socketServer?.getSocketPath() ?? getSocketPath(TEST_RECORDING_SOCKET_CONFIG);
 }
 
 export async function startTestRecordingSocketServer(): Promise<void> {

--- a/src/daemon/videoRecordingSocketServer.ts
+++ b/src/daemon/videoRecordingSocketServer.ts
@@ -1,17 +1,11 @@
-import os from "node:os";
-import path from "node:path";
 import { Timer, defaultTimer } from "../utils/SystemTimer";
-import { RequestResponseSocketServer, getSocketPath, SocketServerConfig } from "./socketServer/index";
+import { RequestResponseSocketServer, getSocketPath } from "./socketServer/index";
 import {
   VideoRecordingSocketRequest,
   VideoRecordingSocketResponse,
 } from "./videoRecordingSocketTypes";
 import { getVideoRecordingConfig, updateVideoRecordingConfig } from "../server/videoRecordingManager";
-
-const SOCKET_CONFIG: SocketServerConfig = {
-  defaultPath: path.join(os.homedir(), ".auto-mobile", "video-recording.sock"),
-  externalPath: "/tmp/auto-mobile-video-recording.sock",
-};
+import { VIDEO_RECORDING_SOCKET_CONFIG } from "./daemonFiles";
 
 /**
  * Socket server for video recording configuration.
@@ -21,7 +15,7 @@ export class VideoRecordingSocketServer extends RequestResponseSocketServer<
   VideoRecordingSocketRequest,
   VideoRecordingSocketResponse
 > {
-  constructor(socketPath: string = getSocketPath(SOCKET_CONFIG), timer: Timer = defaultTimer) {
+  constructor(socketPath: string = getSocketPath(VIDEO_RECORDING_SOCKET_CONFIG), timer: Timer = defaultTimer) {
     super(socketPath, timer, "VideoRecording");
   }
 
@@ -72,7 +66,7 @@ export class VideoRecordingSocketServer extends RequestResponseSocketServer<
 let socketServer: VideoRecordingSocketServer | null = null;
 
 export function getVideoRecordingSocketPath(): string {
-  return socketServer?.getSocketPath() ?? getSocketPath(SOCKET_CONFIG);
+  return socketServer?.getSocketPath() ?? getSocketPath(VIDEO_RECORDING_SOCKET_CONFIG);
 }
 
 export async function startVideoRecordingSocketServer(): Promise<void> {

--- a/test/daemon/daemonClientStaleSocketRecovery.test.ts
+++ b/test/daemon/daemonClientStaleSocketRecovery.test.ts
@@ -1,0 +1,101 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { createServer, type Server } from "node:net";
+import { existsSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir, platform } from "node:os";
+import { DaemonClient } from "../../src/daemon/client";
+import type { PidFileData } from "../../src/daemon/types";
+
+const isWindows = platform() === "win32";
+
+describe("DaemonClient stale socket recovery", () => {
+  const tempDirs: string[] = [];
+  let server: Server | null = null;
+
+  function createTempPaths(): { dir: string; socketPath: string; pidFilePath: string } {
+    const dir = mkdtempSync(join(tmpdir(), "daemon-stale-socket-test-"));
+    tempDirs.push(dir);
+    return {
+      dir,
+      socketPath: join(dir, "daemon.sock"),
+      pidFilePath: join(dir, "daemon.pid"),
+    };
+  }
+
+  async function createClosedSocketFile(socketPath: string): Promise<void> {
+    server = createServer();
+    await new Promise<void>(resolve => server!.listen(socketPath, resolve));
+    await new Promise<void>(resolve => server!.close(() => resolve()));
+    server = null;
+  }
+
+  function writePidFile(pidFilePath: string, socketPath: string): void {
+    const pidData: PidFileData = {
+      pid: 12345,
+      socketPath,
+      port: 3000,
+      startedAt: 0,
+      version: "test",
+    };
+    writeFileSync(pidFilePath, JSON.stringify(pidData));
+  }
+
+  afterEach(async () => {
+    if (server) {
+      await new Promise<void>(resolve => server!.close(() => resolve()));
+      server = null;
+    }
+    for (const dir of tempDirs) {
+      rmSync(dir, { recursive: true, force: true });
+    }
+    tempDirs.length = 0;
+  });
+
+  (isWindows ? test.skip : test)("isAvailable removes socket and PID files when the recorded daemon PID is dead", async () => {
+    const { socketPath, pidFilePath } = createTempPaths();
+    writeFileSync(socketPath, "stale socket placeholder");
+    writePidFile(pidFilePath, socketPath);
+
+    const available = await DaemonClient.isAvailable(socketPath, {
+      pidFilePath,
+      socketPaths: [socketPath],
+      isProcessRunning: () => false,
+    });
+
+    expect(available).toBe(false);
+    expect(existsSync(socketPath)).toBe(false);
+    expect(existsSync(pidFilePath)).toBe(false);
+  });
+
+  (isWindows ? test.skip : test)("isAvailable leaves files intact when the recorded daemon PID is alive", async () => {
+    const { socketPath, pidFilePath } = createTempPaths();
+    writeFileSync(socketPath, "stale socket placeholder");
+    writePidFile(pidFilePath, socketPath);
+
+    const available = await DaemonClient.isAvailable(socketPath, {
+      pidFilePath,
+      socketPaths: [socketPath],
+      isProcessRunning: () => true,
+    });
+
+    expect(available).toBe(false);
+    expect(existsSync(socketPath)).toBe(true);
+    expect(existsSync(pidFilePath)).toBe(true);
+  });
+
+  (isWindows ? test.skip : test)("connect cleans stale files and retries after a failed socket connection", async () => {
+    const { socketPath, pidFilePath } = createTempPaths();
+    await createClosedSocketFile(socketPath);
+    writePidFile(pidFilePath, socketPath);
+
+    const client = new DaemonClient(socketPath, 50, undefined, {
+      pidFilePath,
+      socketPaths: [socketPath],
+      isProcessRunning: () => false,
+    });
+
+    await expect(client.connect()).rejects.toThrow("Daemon socket not found");
+    expect(existsSync(socketPath)).toBe(false);
+    expect(existsSync(pidFilePath)).toBe(false);
+  });
+});

--- a/test/daemon/daemonFiles.test.ts
+++ b/test/daemon/daemonFiles.test.ts
@@ -81,6 +81,29 @@ describe("daemon file cleanup", () => {
     expect(existsSync(pidFilePath)).toBe(true);
   });
 
+  test("cleanupStaleDaemonFilesForDeadPidSync rechecks PID ownership before cleanup", () => {
+    const { socketPath, pidFilePath } = createTempFiles();
+
+    const cleaned = cleanupStaleDaemonFilesForDeadPidSync({
+      pidFilePath,
+      socketPaths: [socketPath],
+      isProcessRunning: () => {
+        writeFileSync(pidFilePath, JSON.stringify({
+          pid: 67890,
+          socketPath,
+          port: 3000,
+          startedAt: 0,
+          version: "test",
+        } satisfies PidFileData));
+        return false;
+      },
+    });
+
+    expect(cleaned).toBe(false);
+    expect(existsSync(socketPath)).toBe(true);
+    expect(existsSync(pidFilePath)).toBe(true);
+  });
+
   test("cleanupDaemonFilesSync skips cleanup when PID file belongs to another process", () => {
     const { socketPath, pidFilePath } = createTempFiles();
 

--- a/test/daemon/daemonFiles.test.ts
+++ b/test/daemon/daemonFiles.test.ts
@@ -80,4 +80,13 @@ describe("daemon file cleanup", () => {
     expect(existsSync(socketPath)).toBe(true);
     expect(existsSync(pidFilePath)).toBe(true);
   });
+
+  test("cleanupDaemonFilesSync skips cleanup when PID file belongs to another process", () => {
+    const { socketPath, pidFilePath } = createTempFiles();
+
+    cleanupDaemonFilesSync({ pidFilePath, socketPaths: [socketPath], expectedPid: 67890 });
+
+    expect(existsSync(socketPath)).toBe(true);
+    expect(existsSync(pidFilePath)).toBe(true);
+  });
 });

--- a/test/daemon/daemonFiles.test.ts
+++ b/test/daemon/daemonFiles.test.ts
@@ -1,0 +1,83 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { existsSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import {
+  cleanupDaemonFiles,
+  cleanupDaemonFilesSync,
+  cleanupStaleDaemonFilesForDeadPidSync,
+} from "../../src/daemon/daemonFiles";
+import type { PidFileData } from "../../src/daemon/types";
+
+describe("daemon file cleanup", () => {
+  const tempDirs: string[] = [];
+
+  function createTempFiles(): { dir: string; socketPath: string; pidFilePath: string } {
+    const dir = mkdtempSync(join(tmpdir(), "daemon-file-cleanup-test-"));
+    tempDirs.push(dir);
+    const socketPath = join(dir, "daemon.sock");
+    const pidFilePath = join(dir, "daemon.pid");
+    writeFileSync(socketPath, "");
+    writeFileSync(pidFilePath, JSON.stringify({
+      pid: 12345,
+      socketPath,
+      port: 3000,
+      startedAt: 0,
+      version: "test",
+    } satisfies PidFileData));
+    return { dir, socketPath, pidFilePath };
+  }
+
+  afterEach(() => {
+    for (const dir of tempDirs) {
+      rmSync(dir, { recursive: true, force: true });
+    }
+    tempDirs.length = 0;
+  });
+
+  test("cleanupDaemonFiles removes configured socket and PID paths", async () => {
+    const { socketPath, pidFilePath } = createTempFiles();
+
+    await cleanupDaemonFiles({ pidFilePath, socketPaths: [socketPath] });
+
+    expect(existsSync(socketPath)).toBe(false);
+    expect(existsSync(pidFilePath)).toBe(false);
+  });
+
+  test("cleanupDaemonFilesSync removes configured socket and PID paths", () => {
+    const { socketPath, pidFilePath } = createTempFiles();
+
+    cleanupDaemonFilesSync({ pidFilePath, socketPaths: [socketPath] });
+
+    expect(existsSync(socketPath)).toBe(false);
+    expect(existsSync(pidFilePath)).toBe(false);
+  });
+
+  test("cleanupStaleDaemonFilesForDeadPidSync only removes files for dead recorded PIDs", () => {
+    const { socketPath, pidFilePath } = createTempFiles();
+
+    const cleaned = cleanupStaleDaemonFilesForDeadPidSync({
+      pidFilePath,
+      socketPaths: [socketPath],
+      isProcessRunning: () => false,
+    });
+
+    expect(cleaned).toBe(true);
+    expect(existsSync(socketPath)).toBe(false);
+    expect(existsSync(pidFilePath)).toBe(false);
+  });
+
+  test("cleanupStaleDaemonFilesForDeadPidSync leaves files for live recorded PIDs", () => {
+    const { socketPath, pidFilePath } = createTempFiles();
+
+    const cleaned = cleanupStaleDaemonFilesForDeadPidSync({
+      pidFilePath,
+      socketPaths: [socketPath],
+      isProcessRunning: () => true,
+    });
+
+    expect(cleaned).toBe(false);
+    expect(existsSync(socketPath)).toBe(true);
+    expect(existsSync(pidFilePath)).toBe(true);
+  });
+});

--- a/test/daemon/socketServerClose.test.ts
+++ b/test/daemon/socketServerClose.test.ts
@@ -3,10 +3,12 @@ import { randomUUID } from "node:crypto";
 import { createServer, type Server as NetServer } from "node:net";
 import { existsSync } from "node:fs";
 import { unlink } from "node:fs/promises";
-import { tmpdir } from "node:os";
+import { platform, tmpdir } from "node:os";
 import { join } from "node:path";
 import { UnixSocketServer } from "../../src/daemon/socketServer";
 import { FakeTimer } from "../fakes/FakeTimer";
+
+const isWindows = platform() === "win32";
 
 function createFakeDaemonState() {
   return {
@@ -42,13 +44,13 @@ describe("UnixSocketServer close", () => {
     }
   });
 
-  test("removes its own socket file on close", async () => {
+  (isWindows ? test.skip : test)("removes its own socket file on close", async () => {
     await server.close();
 
     expect(existsSync(socketPath)).toBe(false);
   });
 
-  test("does not remove a replacement socket at the socket path", async () => {
+  (isWindows ? test.skip : test)("does not remove a replacement socket at the socket path", async () => {
     await unlink(socketPath);
     const replacementServer = await listenOnSocket(socketPath);
 

--- a/test/daemon/socketServerClose.test.ts
+++ b/test/daemon/socketServerClose.test.ts
@@ -1,0 +1,80 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { randomUUID } from "node:crypto";
+import { createServer, type Server as NetServer } from "node:net";
+import { existsSync } from "node:fs";
+import { unlink } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { UnixSocketServer } from "../../src/daemon/socketServer";
+import { FakeTimer } from "../fakes/FakeTimer";
+
+function createFakeDaemonState() {
+  return {
+    isInitialized: () => true,
+    getSessionManager: () => ({ getSession: () => null, releaseSession: async () => null }),
+    getDevicePool: () => ({
+      refreshDevices: async () => 0,
+      getStats: () => ({ total: 0, idle: 0, assigned: 0, error: 0 }),
+      releaseDevice: async () => {},
+    }),
+  };
+}
+
+describe("UnixSocketServer close", () => {
+  let socketPath: string;
+  let server: UnixSocketServer;
+
+  beforeEach(async () => {
+    socketPath = join(tmpdir(), `socket-close-${randomUUID()}.sock`);
+    server = new UnixSocketServer(
+      socketPath,
+      "http://localhost:0/mcp",
+      createFakeDaemonState(),
+      new FakeTimer(),
+    );
+    await server.start();
+  });
+
+  afterEach(async () => {
+    await server.close();
+    if (existsSync(socketPath)) {
+      await unlink(socketPath);
+    }
+  });
+
+  test("removes its own socket file on close", async () => {
+    await server.close();
+
+    expect(existsSync(socketPath)).toBe(false);
+  });
+
+  test("does not remove a replacement socket at the socket path", async () => {
+    await unlink(socketPath);
+    const replacementServer = await listenOnSocket(socketPath);
+
+    try {
+      await server.close();
+
+      expect(existsSync(socketPath)).toBe(true);
+    } finally {
+      await closeServer(replacementServer);
+    }
+  });
+});
+
+function listenOnSocket(socketPath: string): Promise<NetServer> {
+  const replacementServer = createServer();
+  return new Promise((resolve, reject) => {
+    replacementServer.once("error", reject);
+    replacementServer.listen(socketPath, () => {
+      replacementServer.off("error", reject);
+      resolve(replacementServer);
+    });
+  });
+}
+
+function closeServer(server: NetServer): Promise<void> {
+  return new Promise(resolve => {
+    server.close(() => resolve());
+  });
+}


### PR DESCRIPTION
## Summary

- add shared daemon PID/socket cleanup helpers covering the main daemon socket and auxiliary daemon sockets
- clean up daemon files on process exit, uncaught exceptions, unhandled rejections, manager stale-PID paths, and client stale-socket connection failures
- reuse shared socket path config across daemon socket servers and ensure `UnixSocketServer.close()` unlinks its socket after closing
- add focused tests for stale socket recovery and daemon file cleanup

Closes #2451

## Testing

- `bun run build`
- `bun test test/daemon`
- `bun run lint`

## Notes

- `bun install --frozen-lockfile` initially failed compiling the optional/dev `heapdump` native module against local Node 26, but the required dependencies were installed sufficiently for build, daemon tests, and lint to pass.
