### PR TITLE
[codex] Surface device disconnects in observation stream

### DIFF
--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/ObservationStreamClient.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/ObservationStreamClient.kt
@@ -341,6 +341,7 @@ class ObservationStreamClient {
 
         _hierarchyUpdates.resetReplayCache()
         _screenshotUpdates.resetReplayCache()
+        _performanceUpdates.resetReplayCache()
         _deviceEvents.emit(
             DeviceStreamEvent.DeviceConnectionLost(
                 deviceId = deviceId,

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/ObservationStreamClient.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/ObservationStreamClient.kt
@@ -83,6 +83,10 @@ class ObservationStreamClient {
     )
     val performanceUpdates: SharedFlow<PerformanceStreamUpdate> = _performanceUpdates.asSharedFlow()
 
+    // Flow for device-level stream events such as control connection loss.
+    private val _deviceEvents = MutableSharedFlow<DeviceStreamEvent>(replay = 1)
+    val deviceEvents: SharedFlow<DeviceStreamEvent> = _deviceEvents.asSharedFlow()
+
     // Flow for connection state
     private val _connectionState = MutableStateFlow<ConnectionState>(ConnectionState.Disconnected())
     val connectionState: StateFlow<ConnectionState> = _connectionState.asStateFlow()
@@ -234,7 +238,7 @@ class ObservationStreamClient {
         log.info("Observation stream disconnected")
     }
 
-    private suspend fun handleMessage(message: String) {
+    internal suspend fun handleMessage(message: String) {
         val response = json.decodeFromString(StreamResponse.serializer(), message)
         log.info("Handling message type: ${response.type}")
 
@@ -321,11 +325,27 @@ class ObservationStreamClient {
             }
             "error" -> {
                 log.warn("Observation stream error: ${response.error}")
+                emitDeviceEvent(response)
             }
             else -> {
                 log.warn("Unknown message type: ${response.type}")
             }
         }
+    }
+
+    private suspend fun emitDeviceEvent(response: StreamResponse) {
+        val deviceId = response.deviceId ?: return
+        val error = response.error ?: return
+        if (error != DEVICE_CONNECTION_LOST_ERROR) return
+
+        _deviceEvents.emit(
+            DeviceStreamEvent.DeviceConnectionLost(
+                deviceId = deviceId,
+                timestamp = response.timestamp ?: System.currentTimeMillis(),
+                error = error,
+            )
+        )
+        log.info("Emitted device connection lost event for $deviceId")
     }
 
     /**
@@ -475,3 +495,13 @@ data class PerformanceStreamUpdate(
     val recompositionCount: Int?,
     val recompositionRate: Float?,
 )
+
+sealed class DeviceStreamEvent {
+    data class DeviceConnectionLost(
+        val deviceId: String,
+        val timestamp: Long,
+        val error: String,
+    ) : DeviceStreamEvent()
+}
+
+private const val DEVICE_CONNECTION_LOST_ERROR = "device connection lost"

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/ObservationStreamClient.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/ObservationStreamClient.kt
@@ -333,11 +333,14 @@ class ObservationStreamClient {
         }
     }
 
+    @OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
     private suspend fun emitDeviceEvent(response: StreamResponse) {
         val deviceId = response.deviceId ?: return
         val error = response.error ?: return
         if (error != DEVICE_CONNECTION_LOST_ERROR) return
 
+        _hierarchyUpdates.resetReplayCache()
+        _screenshotUpdates.resetReplayCache()
         _deviceEvents.emit(
             DeviceStreamEvent.DeviceConnectionLost(
                 deviceId = deviceId,

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/layout/LayoutInspectorDashboard.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/layout/LayoutInspectorDashboard.kt
@@ -67,6 +67,7 @@ fun LayoutInspectorDashboard(
                 }
                 if (result != null) {
                     dashboardLog.info("Parsed hierarchy: root=${result.first.root.className}, children=${result.first.root.children.size}")
+                    state.updateConnectionStatus(ConnectionStatus.Connected)
                     state.applyHierarchyUpdate(result.first, result.second)
                     dashboardLog.info("Updated state with new hierarchy")
                 } else {
@@ -87,6 +88,7 @@ fun LayoutInspectorDashboard(
                     java.util.Base64.getDecoder().decode(base64)
                 }
                 dashboardLog.info("Decoded screenshot: ${screenshotData.size} bytes")
+                state.updateConnectionStatus(ConnectionStatus.Connected)
                 state.updateScreenshot(
                     data = screenshotData,
                     width = update.screenWidth,

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/layout/LayoutInspectorDashboard.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/layout/LayoutInspectorDashboard.kt
@@ -20,6 +20,7 @@ import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.dp
 import androidx.compose.material3.MaterialTheme
 import dev.jasonpearson.automobile.desktop.core.daemon.AutoMobileClient
+import dev.jasonpearson.automobile.desktop.core.daemon.DeviceStreamEvent
 import dev.jasonpearson.automobile.desktop.core.daemon.ObservationStreamClient
 import dev.jasonpearson.automobile.desktop.core.datasource.DataSourceMode
 import dev.jasonpearson.automobile.desktop.core.di.LocalAutoMobileGraph
@@ -115,6 +116,16 @@ fun LayoutInspectorDashboard(
         LaunchedEffect(streamClient, gracePeriod) {
             streamClient.connectionState.collect { connectionState ->
                 gracePeriod.onStreamStateChange(connectionState)
+            }
+        }
+        LaunchedEffect(streamClient) {
+            streamClient.deviceEvents.collect { event ->
+                when (event) {
+                    is DeviceStreamEvent.DeviceConnectionLost -> {
+                        dashboardLog.warn("Device connection lost for ${event.deviceId}: ${event.error}")
+                        state.disconnect()
+                    }
+                }
             }
         }
     }
@@ -290,4 +301,3 @@ fun LayoutInspectorDashboard(
         }
     }
 }
-

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/ObservationStreamClientTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/ObservationStreamClientTest.kt
@@ -25,7 +25,7 @@ class ObservationStreamClientTest {
     }
 
     @Test
-    fun `clears replayed hierarchy and screenshot data when device connection is lost`() = runTest {
+    fun `clears replayed hierarchy screenshot and performance data when device connection is lost`() = runTest {
         val client = ObservationStreamClient()
 
         client.handleMessage(
@@ -50,11 +50,31 @@ class ObservationStreamClientTest {
             }
             """.trimIndent()
         )
+        client.handleMessage(
+            """
+            {
+              "type": "performance_update",
+              "deviceId": "emulator-5554",
+              "timestamp": 1002,
+              "performanceData": {
+                "fps": 60.0,
+                "frameTimeMs": 16.67,
+                "jankFrames": 0,
+                "droppedFrames": 0,
+                "memoryUsageMb": 128.0,
+                "cpuUsagePercent": 10.0
+              }
+            }
+            """.trimIndent()
+        )
 
         client.hierarchyUpdates.test {
             assertEquals("emulator-5554", awaitItem().deviceId)
         }
         client.screenshotUpdates.test {
+            assertEquals("emulator-5554", awaitItem().deviceId)
+        }
+        client.performanceUpdates.test {
             assertEquals("emulator-5554", awaitItem().deviceId)
         }
 
@@ -64,6 +84,9 @@ class ObservationStreamClientTest {
             expectNoEvents()
         }
         client.screenshotUpdates.test {
+            expectNoEvents()
+        }
+        client.performanceUpdates.test {
             expectNoEvents()
         }
     }

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/ObservationStreamClientTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/ObservationStreamClientTest.kt
@@ -11,17 +11,7 @@ class ObservationStreamClientTest {
         val client = ObservationStreamClient()
 
         client.deviceEvents.test {
-            client.handleMessage(
-                """
-                {
-                  "type": "error",
-                  "success": false,
-                  "deviceId": "emulator-5554",
-                  "timestamp": 1234,
-                  "error": "device connection lost"
-                }
-                """.trimIndent()
-            )
+            client.handleMessage(deviceConnectionLostMessage())
 
             assertEquals(
                 DeviceStreamEvent.DeviceConnectionLost(
@@ -33,4 +23,59 @@ class ObservationStreamClientTest {
             )
         }
     }
+
+    @Test
+    fun `clears replayed hierarchy and screenshot data when device connection is lost`() = runTest {
+        val client = ObservationStreamClient()
+
+        client.handleMessage(
+            """
+            {
+              "type": "hierarchy_update",
+              "deviceId": "emulator-5554",
+              "timestamp": 1000,
+              "data": { "packageName": "com.example" }
+            }
+            """.trimIndent()
+        )
+        client.handleMessage(
+            """
+            {
+              "type": "screenshot_update",
+              "deviceId": "emulator-5554",
+              "timestamp": 1001,
+              "screenshotBase64": "aW1hZ2U=",
+              "screenWidth": 100,
+              "screenHeight": 200
+            }
+            """.trimIndent()
+        )
+
+        client.hierarchyUpdates.test {
+            assertEquals("emulator-5554", awaitItem().deviceId)
+        }
+        client.screenshotUpdates.test {
+            assertEquals("emulator-5554", awaitItem().deviceId)
+        }
+
+        client.handleMessage(deviceConnectionLostMessage())
+
+        client.hierarchyUpdates.test {
+            expectNoEvents()
+        }
+        client.screenshotUpdates.test {
+            expectNoEvents()
+        }
+    }
+
+    private fun deviceConnectionLostMessage(): String =
+        """
+        {
+          "type": "error",
+          "success": false,
+          "deviceId": "emulator-5554",
+          "timestamp": 1234,
+          "error": "device connection lost"
+        }
+        """.trimIndent()
 }

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/ObservationStreamClientTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/ObservationStreamClientTest.kt
@@ -1,0 +1,36 @@
+package dev.jasonpearson.automobile.desktop.core.daemon
+
+import app.cash.turbine.test
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlinx.coroutines.test.runTest
+
+class ObservationStreamClientTest {
+    @Test
+    fun `emits device connection lost event for disconnect error message`() = runTest {
+        val client = ObservationStreamClient()
+
+        client.deviceEvents.test {
+            client.handleMessage(
+                """
+                {
+                  "type": "error",
+                  "success": false,
+                  "deviceId": "emulator-5554",
+                  "timestamp": 1234,
+                  "error": "device connection lost"
+                }
+                """.trimIndent()
+            )
+
+            assertEquals(
+                DeviceStreamEvent.DeviceConnectionLost(
+                    deviceId = "emulator-5554",
+                    timestamp = 1234,
+                    error = "device connection lost",
+                ),
+                awaitItem(),
+            )
+        }
+    }
+}

--- a/src/daemon/deviceDataStreamSocketServer.ts
+++ b/src/daemon/deviceDataStreamSocketServer.ts
@@ -138,6 +138,7 @@ export type OnNavigationGraphRequestedCallback = (appId?: string | null) => Prom
  * - Server pushes: {"type": "hierarchy_update", "deviceId": "emulator-5554", "timestamp": 123, "data": {...}}
  * - Server pushes: {"type": "screenshot_update", "deviceId": "emulator-5554", "timestamp": 123, "screenshotBase64": "..."}
  * - Server pushes: {"type": "storage_update", "deviceId": "emulator-5554", "timestamp": 123, "storageEvent": {...}}
+ * - Server pushes: {"type": "error", "deviceId": "emulator-5554", "timestamp": 123, "error": "device connection lost"}
  */
 export class DeviceDataStreamSocketServer extends PushSubscriptionSocketServer<
   DeviceDataFilter,
@@ -254,6 +255,24 @@ export class DeviceDataStreamSocketServer extends PushSubscriptionSocketServer<
     const sentCount = this.pushToSubscribers({ message, targetDeviceId: deviceId });
     if (sentCount > 0) {
       logger.debug(`[DeviceDataStream] Pushed storage_update to ${sentCount} subscribers (device: ${deviceId})`);
+    }
+  }
+
+  /**
+   * Notify subscribers that the underlying device control connection was lost.
+   */
+  onDeviceConnectionLost(deviceId: string): void {
+    const message: DeviceDataStreamMessage = {
+      type: "error",
+      success: false,
+      deviceId,
+      timestamp: this.timer.now(),
+      error: "device connection lost",
+    };
+
+    const sentCount = this.pushToSubscribers({ message, targetDeviceId: deviceId });
+    if (sentCount > 0) {
+      logger.debug(`[DeviceDataStream] Pushed device connection lost error to ${sentCount} subscribers (device: ${deviceId})`);
     }
   }
 

--- a/src/features/observe/android/AndroidCtrlProxyClient.ts
+++ b/src/features/observe/android/AndroidCtrlProxyClient.ts
@@ -1078,6 +1078,7 @@ export class AndroidCtrlProxyClient extends DeviceServiceClient implements Andro
 
   protected onConnectionClosed(): void {
     void this.markInstalledAppsStale("websocket_closed");
+    getDeviceDataStreamServer()?.onDeviceConnectionLost(this.device.deviceId);
 
     if (this.hierarchyNavigationDetector) {
       this.hierarchyNavigationDetector.dispose();

--- a/src/features/observe/ios/IOSCtrlProxyClient.ts
+++ b/src/features/observe/ios/IOSCtrlProxyClient.ts
@@ -591,6 +591,7 @@ export class IOSCtrlProxyClient extends DeviceServiceClient implements IOSCtrlPr
   protected onConnectionClosed(): void {
     this.stopSdkEventPolling();
     this.cachedHierarchy = null;
+    getDeviceDataStreamServer()?.onDeviceConnectionLost(this.device.deviceId);
 
     if (this.hierarchyNavigationDetector) {
       this.hierarchyNavigationDetector.dispose();

--- a/test/daemon/deviceDataStreamSocketServer.test.ts
+++ b/test/daemon/deviceDataStreamSocketServer.test.ts
@@ -222,4 +222,52 @@ describe("DeviceDataStreamSocketServer", () => {
       expect(server.getSubscriberCount()).toBe(0);
     });
   });
+
+  describe("onDeviceConnectionLost", () => {
+    it("pushes a device-scoped error to subscribers for that device", () => {
+      const { socket } = server.simulateSubscription({ deviceId: "emulator-5554" });
+      timer.advanceTime(1234);
+
+      server.onDeviceConnectionLost("emulator-5554");
+
+      const msgs = socket.getWrittenMessages<{
+        type: string;
+        success?: boolean;
+        deviceId?: string;
+        timestamp?: number;
+        error?: string;
+      }>();
+      expect(msgs).toEqual([
+        {
+          type: "error",
+          success: false,
+          deviceId: "emulator-5554",
+          timestamp: 1234,
+          error: "device connection lost",
+        },
+      ]);
+    });
+
+    it("pushes device connection errors to all-device subscribers", () => {
+      const { socket } = server.simulateSubscription({});
+
+      server.onDeviceConnectionLost("emulator-5554");
+
+      const msgs = socket.getWrittenMessages<{ type: string; deviceId?: string; error?: string }>();
+      expect(msgs).toHaveLength(1);
+      expect(msgs[0]).toMatchObject({
+        type: "error",
+        deviceId: "emulator-5554",
+        error: "device connection lost",
+      });
+    });
+
+    it("does not push device connection errors to other device subscribers", () => {
+      const { socket } = server.simulateSubscription({ deviceId: "emulator-5556" });
+
+      server.onDeviceConnectionLost("emulator-5554");
+
+      expect(socket.getWrittenMessages()).toHaveLength(0);
+    });
+  });
 });


### PR DESCRIPTION
## Summary

- Add a device-scoped disconnect notification path for observation-stream subscribers.
- Emit `type: "error"` messages with `success: false`, `deviceId`, `timestamp`, and `error: "device connection lost"` when Android or iOS control WebSockets close.
- Cover subscriber filtering so device-specific and all-device subscribers receive the error while unrelated device subscribers do not.

## Root Cause

Device control clients cleaned up local state when the underlying WebSocket closed, but the observation stream had no push path for that state change. Consumers kept their last hierarchy or screenshot and could not distinguish an idle device from a dead connection.

Fixes #2450.

## Validation

- `bun test test/daemon/deviceDataStreamSocketServer.test.ts`
- `bun run lint`
- `bun run build`

## Note

`bun install --frozen-lockfile` failed while compiling the native dev dependency `heapdump` under Node 26, but enough dependencies were installed afterward for lint, build, and the targeted test to pass.
