### PR TITLE
Extract ImeAction union into named type

### DIFF
--- a/src/features/action/ImeAction.ts
+++ b/src/features/action/ImeAction.ts
@@ -1,6 +1,6 @@
 import { AdbClient } from "../../utils/android-cmdline-tools/AdbClient";
 import { BaseVisualChange, ProgressCallback } from "./BaseVisualChange";
-import { BootedDevice, ImeActionResult, ObserveResult } from "../../models";
+import { BootedDevice, ImeAction as ImeActionType, ImeActionResult, ObserveResult } from "../../models";
 import { logger } from "../../utils/logger";
 import { createGlobalPerformanceTracker } from "../../utils/PerformanceTracker";
 import { AndroidCtrlProxy, AndroidCtrlProxyClient } from "../observe/android";
@@ -24,7 +24,7 @@ export class ImeAction extends BaseVisualChange {
   }
 
   async execute(
-    action: "done" | "next" | "search" | "send" | "go" | "previous",
+    action: ImeActionType,
     progress?: ProgressCallback
   ): Promise<ImeActionResult> {
     const perf = createGlobalPerformanceTracker();
@@ -83,7 +83,7 @@ export class ImeAction extends BaseVisualChange {
    * Falls back to ADB key events if a11y service is unavailable.
    */
   private async executeAndroidImeAction(
-    action: "done" | "next" | "search" | "send" | "go" | "previous",
+    action: ImeActionType,
     _observeResult: ObserveResult
   ): Promise<ImeActionResult> {
     // Use provided a11y service or get default instance
@@ -107,7 +107,7 @@ export class ImeAction extends BaseVisualChange {
    * instead of moving focus between fields.
    */
   private async executeAdbImeAction(
-    action: "done" | "next" | "search" | "send" | "go" | "previous"
+    action: ImeActionType
   ): Promise<ImeActionResult> {
     logger.info("Executing IME action via ADB", { action });
 
@@ -162,7 +162,7 @@ export class ImeAction extends BaseVisualChange {
    * Execute iOS-specific IME action using CtrlProxy iOS.
    */
   private async executeiOSImeAction(
-    action: "done" | "next" | "search" | "send" | "go" | "previous",
+    action: ImeActionType,
     _observeResult: ObserveResult
   ): Promise<ImeActionResult> {
     try {

--- a/src/features/action/InputText.ts
+++ b/src/features/action/InputText.ts
@@ -1,5 +1,5 @@
 import { BaseVisualChange } from "./BaseVisualChange";
-import { BootedDevice, SendTextResult } from "../../models";
+import { BootedDevice, ImeAction, SendTextResult } from "../../models";
 import { logger } from "../../utils/logger";
 import { createGlobalPerformanceTracker } from "../../utils/PerformanceTracker";
 import { AndroidCtrlProxyClient } from "../observe/android";
@@ -27,7 +27,7 @@ export class InputText extends BaseVisualChange {
 
   async execute(
     text: string,
-    imeAction?: "done" | "next" | "search" | "send" | "go" | "previous",
+    imeAction?: ImeAction,
     dismissKeyboard: boolean = false,
     mode: InputTextMode = "a11y"
   ): Promise<SendTextResult & { method?: InputTextMode }> {
@@ -94,7 +94,7 @@ export class InputText extends BaseVisualChange {
    */
   private async executeAndroidTextInput(
     text: string,
-    imeAction?: "done" | "next" | "search" | "send" | "go" | "previous",
+    imeAction?: ImeAction,
     dismissKeyboard: boolean = false,
     mode: InputTextMode = "a11y"
   ): Promise<SendTextResult & { method?: InputTextMode }> {
@@ -139,7 +139,7 @@ export class InputText extends BaseVisualChange {
 
   private async executeAndroidEventLastTextInput(
     text: string,
-    imeAction?: "done" | "next" | "search" | "send" | "go" | "previous",
+    imeAction?: ImeAction,
     dismissKeyboard: boolean = false
   ): Promise<SendTextResult & { method?: InputTextMode }> {
     const split = this.findLastPrintableAsciiNonWhitespace(text);
@@ -202,7 +202,7 @@ export class InputText extends BaseVisualChange {
 
   private async executeAndroidEventAllTextInput(
     text: string,
-    imeAction?: "done" | "next" | "search" | "send" | "go" | "previous",
+    imeAction?: ImeAction,
     dismissKeyboard: boolean = false
   ): Promise<SendTextResult & { method?: InputTextMode }> {
     const chars = Array.from(text);
@@ -410,7 +410,7 @@ export class InputText extends BaseVisualChange {
    */
   private async executeiOSTextInput(
     text: string,
-    imeAction?: "done" | "next" | "search" | "send" | "go" | "previous"
+    imeAction?: ImeAction
   ): Promise<SendTextResult & { method?: "a11y" }> {
     const startMs = Date.now();
     logger.debug(`[InputText] iOS begin textLength=${text.length} imeAction=${imeAction ?? "none"}`);

--- a/src/features/observe/android/AndroidCtrlProxyClient.ts
+++ b/src/features/observe/android/AndroidCtrlProxyClient.ts
@@ -21,6 +21,7 @@ import type { AdbClient } from "../../../utils/android-cmdline-tools/AdbClient";
 import { logger } from "../../../utils/logger";
 import {
   BootedDevice,
+  ImeAction,
   ViewHierarchyResult,
   CurrentFocusResult,
   TraversalOrderResult,
@@ -650,7 +651,7 @@ export interface AndroidCtrlProxy extends CtrlProxyClient {
   ): Promise<A11ySetTextResult>;
 
   requestImeAction(
-    action: "done" | "next" | "search" | "send" | "go" | "previous",
+    action: ImeAction,
     timeoutMs?: number, perf?: PerformanceTracker
   ): Promise<A11yImeActionResult>;
 
@@ -1201,7 +1202,7 @@ export class AndroidCtrlProxyClient extends DeviceServiceClient implements Andro
   }
 
   async requestImeAction(
-    action: "done" | "next" | "search" | "send" | "go" | "previous",
+    action: ImeAction,
     timeoutMs: number = 5000, perf: PerformanceTracker = new NoOpPerformanceTracker()
   ): Promise<A11yImeActionResult> {
     return this.text.requestImeAction(action, timeoutMs, perf);

--- a/src/features/observe/ios/IOSCtrlProxyClient.ts
+++ b/src/features/observe/ios/IOSCtrlProxyClient.ts
@@ -19,6 +19,7 @@ import { getFailureRecorder } from "../../failures/FailureRecorder";
 import { logger } from "../../../utils/logger";
 import {
   BootedDevice,
+  ImeAction,
   ViewHierarchyResult,
 } from "../../../models";
 import { ViewHierarchyQueryOptions } from "../../../models/ViewHierarchyQueryOptions";
@@ -185,7 +186,7 @@ export interface IOSCtrlProxy extends CtrlProxyClient {
   ): Promise<CtrlProxySetTextResult>;
 
   requestImeAction(
-    action: "done" | "next" | "search" | "send" | "go" | "previous",
+    action: ImeAction,
     timeoutMs?: number, perf?: PerformanceTracker
   ): Promise<CtrlProxyImeActionResult>;
 
@@ -1294,7 +1295,7 @@ export class IOSCtrlProxyClient extends DeviceServiceClient implements IOSCtrlPr
   }
 
   async requestImeAction(
-    action: "done" | "next" | "search" | "send" | "go" | "previous",
+    action: ImeAction,
     timeoutMs: number = 5000, perf?: PerformanceTracker
   ): Promise<CtrlProxyImeActionResult> {
     return this.text.requestImeAction(action, timeoutMs, perf);

--- a/src/features/observe/shared/SharedTextDelegate.ts
+++ b/src/features/observe/shared/SharedTextDelegate.ts
@@ -5,6 +5,7 @@
  */
 
 import type { PerformanceTracker } from "../../../utils/PerformanceTracker";
+import type { ImeAction } from "../../../models";
 import type { DelegateContext, BaseResult, ActionTimingResult } from "./types";
 import { sendCommand } from "../DeviceServiceUtils";
 
@@ -54,7 +55,7 @@ export class SharedTextDelegate {
   }
 
   async requestImeAction(
-    action: "done" | "next" | "search" | "send" | "go" | "previous",
+    action: ImeAction,
     timeoutMs: number = 5000,
     perf?: PerformanceTracker
   ): Promise<ActionTimingResult> {

--- a/src/models/ImeActionResult.ts
+++ b/src/models/ImeActionResult.ts
@@ -1,3 +1,5 @@
+export type ImeAction = "done" | "next" | "search" | "send" | "go" | "previous";
+
 export interface ImeActionResult {
     success: boolean;
     action: string;

--- a/src/server/interactionToolTypes.ts
+++ b/src/server/interactionToolTypes.ts
@@ -2,7 +2,7 @@
  * Type definitions for interaction tools.
  * Extracted from interactionTools.ts for maintainability.
  */
-import type { Platform, ElementSelectionStrategy } from "../models";
+import type { Platform, ElementSelectionStrategy, ImeAction } from "../models";
 
 // ============================================================================
 // Tool Argument Types
@@ -38,7 +38,7 @@ export interface SystemTrayArgs {
 export interface InputTextArgs {
   text: string;
   mode?: "a11y" | "eventLast" | "eventAll";
-  imeAction?: "done" | "next" | "search" | "send" | "go" | "previous";
+  imeAction?: ImeAction;
   dismissKeyboard?: boolean;
   platform: Platform;
 }
@@ -143,7 +143,7 @@ export interface ShakeArgs {
 }
 
 export interface ImeActionArgs {
-  action: "done" | "next" | "search" | "send" | "go" | "previous";
+  action: ImeAction;
   platform: Platform;
 }
 


### PR DESCRIPTION
## Summary
The 6-member IME action union `"done" | "next" | "search" | "send" | "go" | "previous"` was duplicated 16× across `src/` (5× in `InputText.ts` alone, plus `ImeAction.ts`, `AndroidCtrlProxyClient.ts`, `IOSCtrlProxyClient.ts`, `interactionToolTypes.ts`, `SharedTextDelegate.ts`). Re-typing the union by hand at every call site meant adding a 7th action required a 16-site find-and-replace, where a typo in any copy would compile silently as a narrower type.

This extracts `export type ImeAction` into `src/models` and replaces every inline copy with the shared type.

## Changes
- Add `ImeAction` type to `src/models/ImeActionResult.ts` (re-exported via the `src/models` barrel)
- Replace all 16 inline unions with `ImeAction` + matching imports
- In `src/features/action/ImeAction.ts` the existing `ImeAction` **class** collides with the type, so the type is imported aliased as `ImeActionType` there

## Validation
- `tsc --noEmit` clean for touched files
- `bun build.ts` succeeds
- ImeAction (27) + InputText (12) test suites pass