### PR TITLE
Replace requestSetText positional params with options object

### DIFF
--- a/src/features/action/InputText.ts
+++ b/src/features/action/InputText.ts
@@ -109,7 +109,7 @@ export class InputText extends BaseVisualChange {
     // Use accessibility service exclusively (fastest method, ~10-30ms vs ~200-300ms for ADB)
     // It also natively supports Unicode without needing virtual keyboard
     const a11yClient = AndroidCtrlProxyClient.getInstance(this.device, this.adbFactory);
-    const a11yResult = await a11yClient.requestSetText(text, undefined, undefined, undefined, dismissKeyboard);
+    const a11yResult = await a11yClient.requestSetText(text, { dismissKeyboard });
 
     if (a11yResult.success) {
       logger.info(`[InputText] Text input via accessibility service: ${a11yResult.totalTimeMs}ms`);
@@ -162,7 +162,7 @@ export class InputText extends BaseVisualChange {
 
     const a11yClient = AndroidCtrlProxyClient.getInstance(this.device, this.adbFactory);
 
-    const prefixResult = await a11yClient.requestSetText(prefix, undefined, undefined, undefined, false);
+    const prefixResult = await a11yClient.requestSetText(prefix);
     if (!prefixResult.success) {
       return this.setTextFailure(text, "eventLast prefix", "before real key event", prefixResult.error, "eventLast");
     }
@@ -170,7 +170,7 @@ export class InputText extends BaseVisualChange {
     await this.executeKeyEventPlan(keyEventPlan);
 
     if (suffix.length > 0 || dismissKeyboard) {
-      const finalResult = await a11yClient.requestSetText(text, undefined, undefined, undefined, dismissKeyboard);
+      const finalResult = await a11yClient.requestSetText(text, { dismissKeyboard });
       if (!finalResult.success) {
         return this.setTextFailure(text, "eventLast final", "after real key event", finalResult.error, "eventLast");
       }
@@ -200,7 +200,7 @@ export class InputText extends BaseVisualChange {
     }
 
     const a11yClient = AndroidCtrlProxyClient.getInstance(this.device, this.adbFactory);
-    const clearResult = await a11yClient.requestSetText("", undefined, undefined, undefined, false);
+    const clearResult = await a11yClient.requestSetText("");
     if (!clearResult.success) {
       return this.setTextFailure(text, "eventAll initial clear", "before eventAll input", clearResult.error, "eventAll");
     }
@@ -223,14 +223,14 @@ export class InputText extends BaseVisualChange {
       }
 
       targetText += unsupportedRun;
-      const setTextResult = await a11yClient.requestSetText(targetText, undefined, undefined, undefined, false);
+      const setTextResult = await a11yClient.requestSetText(targetText);
       if (!setTextResult.success) {
         return this.setTextFailure(text, "eventAll unsupported text run", "during eventAll input", setTextResult.error, "eventAll");
       }
     }
 
     if (dismissKeyboard) {
-      const finalResult = await a11yClient.requestSetText(text, undefined, undefined, undefined, true);
+      const finalResult = await a11yClient.requestSetText(text, { dismissKeyboard: true });
       if (!finalResult.success) {
         return this.setTextFailure(text, "eventAll final", "after eventAll input", finalResult.error, "eventAll");
       }

--- a/src/features/observe/DeviceService.ts
+++ b/src/features/observe/DeviceService.ts
@@ -36,6 +36,23 @@ export interface TextResult extends DeviceOperationResult {
 }
 
 /**
+ * Optional parameters for {@link DeviceService.requestSetText}.
+ */
+export interface SetTextOptions {
+  /** Optional element identifier to target. */
+  resourceId?: string;
+  /** Operation timeout in milliseconds (default 5000). */
+  timeoutMs?: number;
+  /** Optional performance tracker. */
+  perf?: PerformanceTracker;
+  /**
+   * Android-only. Suppresses the soft keyboard via SHOW_MODE_HIDDEN after
+   * setText. Ignored on iOS (no handler on the Swift side).
+   */
+  dismissKeyboard?: boolean;
+}
+
+/**
  * Result for screenshot operations.
  */
 export interface ScreenshotResult extends DeviceOperationResult {
@@ -192,16 +209,11 @@ export interface DeviceService {
   /**
    * Set text in the focused input field.
    * @param text Text to input
-   * @param resourceId Optional element identifier to target
-   * @param timeoutMs Operation timeout in milliseconds
-   * @param perf Optional performance tracker
+   * @param options Optional targeting, timeout, performance, and keyboard options
    */
   requestSetText(
     text: string,
-    resourceId?: string,
-    timeoutMs?: number,
-    perf?: PerformanceTracker,
-    dismissKeyboard?: boolean
+    options?: SetTextOptions
   ): Promise<TextResult>;
 
   /**

--- a/src/features/observe/android/AndroidCtrlProxyClient.ts
+++ b/src/features/observe/android/AndroidCtrlProxyClient.ts
@@ -72,6 +72,7 @@ import {
   WebSocketFactory,
   defaultWebSocketFactory,
 } from "../DeviceServiceClient";
+import type { SetTextOptions } from "../DeviceService";
 import type { CtrlProxyClient } from "../interfaces/CtrlProxyClient";
 import { RetryExecutor, defaultRetryExecutor } from "../../../utils/retry/RetryExecutor";
 
@@ -654,7 +655,7 @@ export interface AndroidCtrlProxy extends CtrlProxyClient {
   ): Promise<A11yPinchResult>;
 
   requestSetText(
-    text: string, resourceId?: string, timeoutMs?: number, perf?: PerformanceTracker, dismissKeyboard?: boolean
+    text: string, options?: SetTextOptions
   ): Promise<A11ySetTextResult>;
 
   requestClearText(
@@ -1223,9 +1224,9 @@ export class AndroidCtrlProxyClient extends DeviceServiceClient implements Andro
   // ===========================================================================
 
   async requestSetText(
-    text: string, resourceId?: string, timeoutMs: number = 5000, perf: PerformanceTracker = new NoOpPerformanceTracker(), dismissKeyboard: boolean = false
+    text: string, options?: SetTextOptions
   ): Promise<A11ySetTextResult> {
-    return this.text.requestSetText(text, resourceId, timeoutMs, perf, dismissKeyboard);
+    return this.text.requestSetText(text, options);
   }
 
   async requestClearText(

--- a/src/features/observe/ios/IOSCtrlProxyClient.ts
+++ b/src/features/observe/ios/IOSCtrlProxyClient.ts
@@ -44,6 +44,7 @@ import {
   WebSocketFactory,
   defaultWebSocketFactory,
 } from "../DeviceServiceClient";
+import type { SetTextOptions } from "../DeviceService";
 import type { CtrlProxyClient } from "../interfaces/CtrlProxyClient";
 import { getDeviceDataStreamServer, PerformanceStreamData } from "../../../daemon/deviceDataStreamSocketServer";
 import { getPerformanceMonitor } from "../../performance/PerformanceMonitor";
@@ -178,7 +179,7 @@ export interface IOSCtrlProxy extends CtrlProxyClient {
   ): Promise<CtrlProxyPinchResult>;
 
   requestSetText(
-    text: string, resourceId?: string, timeoutMs?: number, perf?: PerformanceTracker, dismissKeyboard?: boolean
+    text: string, options?: SetTextOptions
   ): Promise<CtrlProxySetTextResult>;
 
   requestClearText(
@@ -1283,9 +1284,9 @@ export class IOSCtrlProxyClient extends DeviceServiceClient implements IOSCtrlPr
   // ===========================================================================
 
   async requestSetText(
-    text: string, resourceId?: string, timeoutMs: number = 5000, perf?: PerformanceTracker, dismissKeyboard: boolean = false
+    text: string, options?: SetTextOptions
   ): Promise<CtrlProxySetTextResult> {
-    return this.text.requestSetText(text, resourceId, timeoutMs, perf, dismissKeyboard);
+    return this.text.requestSetText(text, options);
   }
 
   async requestClearText(

--- a/src/features/observe/shared/SharedTextDelegate.ts
+++ b/src/features/observe/shared/SharedTextDelegate.ts
@@ -6,6 +6,7 @@
 
 import type { PerformanceTracker } from "../../../utils/PerformanceTracker";
 import type { ImeAction } from "../../../models";
+import type { SetTextOptions } from "../DeviceService";
 import type { DelegateContext, BaseResult, ActionTimingResult } from "./types";
 import { sendCommand } from "../DeviceServiceUtils";
 
@@ -16,17 +17,11 @@ export class SharedTextDelegate {
     this.context = context;
   }
 
-  /**
-   * @param dismissKeyboard Android-only. Suppresses the soft keyboard via
-   *   SHOW_MODE_HIDDEN after setText. Ignored on iOS (no handler on Swift side).
-   */
   async requestSetText(
     text: string,
-    resourceId?: string,
-    timeoutMs: number = 5000,
-    perf?: PerformanceTracker,
-    dismissKeyboard: boolean = false
+    options: SetTextOptions = {}
   ): Promise<BaseResult> {
+    const { resourceId, timeoutMs = 5000, perf, dismissKeyboard = false } = options;
     const params: Record<string, unknown> = { text };
     if (resourceId) {
       params.resourceId = resourceId;
@@ -51,7 +46,7 @@ export class SharedTextDelegate {
     timeoutMs: number = 5000,
     perf?: PerformanceTracker
   ): Promise<BaseResult> {
-    return this.requestSetText("", resourceId, timeoutMs, perf);
+    return this.requestSetText("", { resourceId, timeoutMs, perf });
   }
 
   async requestImeAction(

--- a/test/fakes/FakeCtrlProxy.ts
+++ b/test/fakes/FakeCtrlProxy.ts
@@ -12,6 +12,7 @@ import {
   AndroidPerfTiming,
   AccessibilityHierarchy
 } from "../../src/features/observe/android";
+import type { SetTextOptions } from "../../src/features/observe/DeviceService";
 import { HighlightOperationResult, HighlightShape, ViewHierarchyResult } from "../../src/models";
 import { ViewHierarchyQueryOptions } from "../../src/models/ViewHierarchyQueryOptions";
 import { PerformanceTracker } from "../../src/utils/PerformanceTracker";
@@ -538,14 +539,12 @@ export class FakeCtrlProxy implements AndroidCtrlProxy {
 
   async requestSetText(
     text: string,
-    resourceId?: string,
-    timeoutMs: number = 5000,
-    perf?: PerformanceTracker
+    options?: SetTextOptions
   ): Promise<A11ySetTextResult> {
     await this.applyDelay("setText");
     this.checkFailure("setText");
 
-    this.setTextHistory.push({ text, resourceId });
+    this.setTextHistory.push({ text, resourceId: options?.resourceId });
 
     return {
       success: true,

--- a/test/fakes/FakeIOSCtrlProxy.ts
+++ b/test/fakes/FakeIOSCtrlProxy.ts
@@ -24,6 +24,7 @@ import type {
   CtrlProxyVoiceOverActionResult,
   CtrlProxyActionResult,
 } from "../../src/features/observe/ios/types";
+import type { SetTextOptions } from "../../src/features/observe/DeviceService";
 import { ViewHierarchyResult } from "../../src/models";
 import { ViewHierarchyQueryOptions } from "../../src/models/ViewHierarchyQueryOptions";
 import { PerformanceTracker } from "../../src/utils/PerformanceTracker";
@@ -671,14 +672,12 @@ export class FakeIOSCtrlProxy implements IOSCtrlProxy {
 
   async requestSetText(
     text: string,
-    resourceId?: string,
-    timeoutMs: number = 5000,
-    perf?: PerformanceTracker
+    options?: SetTextOptions
   ): Promise<CtrlProxySetTextResult> {
     await this.applyDelay("setText");
     this.checkFailure("setText");
 
-    this.setTextHistory.push({ text, resourceId });
+    this.setTextHistory.push({ text, resourceId: options?.resourceId });
 
     return {
       success: true,

--- a/test/features/action/InputText.test.ts
+++ b/test/features/action/InputText.test.ts
@@ -17,10 +17,12 @@ interface TestInputText {
 
 type RequestSetText = (
   text: string,
-  resourceId?: string,
-  timeoutMs?: number,
-  perf?: unknown,
-  dismissKeyboard?: boolean
+  options?: {
+    resourceId?: string;
+    timeoutMs?: number;
+    perf?: unknown;
+    dismissKeyboard?: boolean;
+  }
 ) => Promise<{ success: boolean; error?: string; totalTimeMs: number }>;
 
 function testInputText(inputText: InputText): TestInputText {
@@ -92,8 +94,8 @@ describe("InputText", () => {
     const inputText = new InputText(androidDevice, factory as AdbClientFactory);
     const setTextCalls: Array<{ text: string; dismissKeyboard?: boolean }> = [];
 
-    stubAndroidSetText(async (text, _resourceId, _timeoutMs, _perf, dismissKeyboard) => {
-      setTextCalls.push({ text, dismissKeyboard });
+    stubAndroidSetText(async (text, options) => {
+      setTextCalls.push({ text, dismissKeyboard: options?.dismissKeyboard });
       return { success: true, totalTimeMs: 1 };
     });
 
@@ -101,7 +103,7 @@ describe("InputText", () => {
 
     expect(result.success).toBe(true);
     expect(result.method).toBe("eventLast");
-    expect(setTextCalls).toEqual([{ text: "@Jason Pearso", dismissKeyboard: false }]);
+    expect(setTextCalls).toEqual([{ text: "@Jason Pearso", dismissKeyboard: undefined }]);
     expect(inputCommands(factory)).toEqual(["shell input keyevent KEYCODE_N"]);
   });
 
@@ -110,8 +112,8 @@ describe("InputText", () => {
     const inputText = new InputText(androidDevice, factory as AdbClientFactory);
     const setTextCalls: Array<{ text: string; dismissKeyboard?: boolean }> = [];
 
-    stubAndroidSetText(async (text, _resourceId, _timeoutMs, _perf, dismissKeyboard) => {
-      setTextCalls.push({ text, dismissKeyboard });
+    stubAndroidSetText(async (text, options) => {
+      setTextCalls.push({ text, dismissKeyboard: options?.dismissKeyboard });
       return { success: true, totalTimeMs: 1 };
     });
 
@@ -119,7 +121,7 @@ describe("InputText", () => {
 
     expect(result.success).toBe(true);
     expect(setTextCalls).toEqual([
-      { text: "abc de", dismissKeyboard: false },
+      { text: "abc de", dismissKeyboard: undefined },
       { text: "abc def  ", dismissKeyboard: false },
     ]);
     expect(inputCommands(factory)).toEqual(["shell input keyevent KEYCODE_F"]);
@@ -146,8 +148,8 @@ describe("InputText", () => {
     const setTextCalls: Array<{ text: string; dismissKeyboard?: boolean }> = [];
     factory.getFakeClient().setCommandResult("shell getprop ro.build.version.sdk", "30\n");
 
-    stubAndroidSetText(async (text, _resourceId, _timeoutMs, _perf, dismissKeyboard) => {
-      setTextCalls.push({ text, dismissKeyboard });
+    stubAndroidSetText(async (text, options) => {
+      setTextCalls.push({ text, dismissKeyboard: options?.dismissKeyboard });
       return { success: true, totalTimeMs: 1 };
     });
 

--- a/test/features/observe/ios/IOSCtrlProxyClient.test.ts
+++ b/test/features/observe/ios/IOSCtrlProxyClient.test.ts
@@ -325,7 +325,7 @@ describe("IOSCtrlProxyClient", function() {
       );
 
       try {
-        const resultPromise = testClient.requestSetText("Hello World", "text_field_1", 5000);
+        const resultPromise = testClient.requestSetText("Hello World", { resourceId: "text_field_1", timeoutMs: 5000 });
         const socket = await waitForSocket(getSocket);
         expect(socket).not.toBeNull();
         await waitForSocketOpen(socket);

--- a/test/features/observe/shared/SharedTextDelegate.test.ts
+++ b/test/features/observe/shared/SharedTextDelegate.test.ts
@@ -80,7 +80,7 @@ describe("SharedTextDelegate", () => {
       const delegate = new SharedTextDelegate(context);
 
       const { sentMsg } = await callAndResolve(sent, context.requestManager, () =>
-        delegate.requestSetText("hello", "com.app:id/input")
+        delegate.requestSetText("hello", { resourceId: "com.app:id/input" })
       );
 
       expect(sentMsg.resourceId).toBe("com.app:id/input");
@@ -164,7 +164,7 @@ describe("SharedTextDelegate", () => {
       const { context } = createFakeContext({ timer, requestManager });
       const delegate = new SharedTextDelegate(context);
 
-      const promise = delegate.requestSetText("hello", undefined, 100);
+      const promise = delegate.requestSetText("hello", { timeoutMs: 100 });
 
       await Promise.resolve();
       await Promise.resolve();


### PR DESCRIPTION
## What

`DeviceService.requestSetText` took four trailing positional optionals (`resourceId`, `timeoutMs`, `perf`, `dismissKeyboard`). Reaching the final `dismissKeyboard` boolean forced call sites like:

```ts
requestSetText(text, undefined, undefined, undefined, false)
```

— an unlabeled boolean trap behind three throwaway `undefined`s. This collapses the trailing params into a single `SetTextOptions` object so intent is visible at every call site:

```ts
requestSetText(text, { dismissKeyboard })
```

## Changes

- New `SetTextOptions` interface in `DeviceService.ts`; signature is now `requestSetText(text, options?)`
- Updated `SharedTextDelegate` impl + `requestClearText` delegation
- Updated Android/iOS client interface decls and delegating impls
- Updated 6 `InputText.ts` call sites and both test fakes
- Updated affected tests (`InputText`, `SharedTextDelegate`, `IOSCtrlProxyClient`)

Behavior is unchanged: the delegate still defaults `dismissKeyboard` to `false`. The eventLast prefix calls now omit the param rather than passing explicit `false` (same wire payload).

## Validation

- `bun build.ts` passes; eslint clean on changed source files
- All 42 directly-affected tests pass; broader observe/fakes suite green (one pre-existing, unrelated navigation-test failure confirmed identical on the unmodified tree)