### PR TITLE
feat(ios): biometricAuth + postNotification on iOS Simulator via simctl

### DIFF
--- a/docs/design-docs/plat/android/biometrics.md
+++ b/docs/design-docs/plat/android/biometrics.md
@@ -2,7 +2,7 @@
 
 <kbd>✅ Implemented</kbd> <kbd>🧪 Tested</kbd>
 
-> **Current state:** The `biometricAuth` MCP tool is fully implemented and tested for Android emulators via `adb emu finger touch/remove`. Physical Android devices receive an SDK broadcast override (`supported: "partial"`). Face/iris modalities are not supported. The `AutoMobileBiometrics` SDK hook is <kbd>✅ Implemented</kbd>. See the [Status Glossary](../../status-glossary.md) for chip definitions.
+> **Current state:** The `biometricAuth` MCP tool is fully implemented and tested for Android emulators via `adb emu finger touch/remove`. Physical Android devices receive an SDK broadcast override (`supported: "partial"`). Face/iris modalities are not supported. The `AutoMobileBiometrics` SDK hook is <kbd>✅ Implemented</kbd>. On iOS, `match` / `fail` (Touch ID and Face ID) are supported on the **Simulator** — see [iOS simctl integration → Biometric simulation](../ios/simctl.md#biometric-simulation). See the [Status Glossary](../../status-glossary.md) for chip definitions.
 
 ## Goal
 

--- a/docs/design-docs/plat/android/notifications.md
+++ b/docs/design-docs/plat/android/notifications.md
@@ -2,7 +2,7 @@
 
 <kbd>✅ Implemented</kbd> <kbd>🧪 Tested</kbd>
 
-> **Current state:** `postNotification` MCP tool is fully implemented. The AutoMobile SDK `AutoMobileNotifications.post()` hook is implemented in `android/auto-mobile-sdk/`. Apps without SDK integration cannot post notifications that appear as the app-under-test (third-party app limitation). See the [Status Glossary](../../status-glossary.md) for chip definitions.
+> **Current state:** `postNotification` MCP tool is fully implemented. The AutoMobile SDK `AutoMobileNotifications.post()` hook is implemented in `android/auto-mobile-sdk/`. Apps without SDK integration cannot post notifications that appear as the app-under-test (third-party app limitation). On iOS, `postNotification` delivers a simulated remote push on the **Simulator** via `simctl push` (requires `appId`) — see [iOS simctl integration → Push notifications](../ios/simctl.md#push-notifications). See the [Status Glossary](../../status-glossary.md) for chip definitions.
 
 ## Goal
 

--- a/docs/design-docs/plat/ios/simctl.md
+++ b/docs/design-docs/plat/ios/simctl.md
@@ -15,6 +15,8 @@ system-level simulator behaviors.
 - Device discovery and capability reporting.
 - Status bar configuration (demo mode) when supported.
 - Live locale and localization changes (see below).
+- Biometric (Touch ID / Face ID) simulation for `biometricAuth` (see below).
+- Simulated push delivery for `postNotification` (see below).
 
 ## Live locale changes
 
@@ -65,6 +67,70 @@ pick them up immediately.
 - Running apps cache locale at launch. Use the `restartApp` parameter or manually
   relaunch the app for it to pick up new settings.
 
+## Biometric simulation
+
+<kbd>✅ Implemented</kbd> <kbd>🧪 Tested</kbd> <kbd>📱 Simulator Only</kbd>
+
+The `biometricAuth` MCP tool simulates Touch ID / Face ID on simulators by posting
+BiometricKit Darwin notifications inside the simulator via
+`xcrun simctl spawn <udid> notifyutil`. This reaches parity with the Android emulator
+`adb emu finger` path (see [Android biometrics](../android/biometrics.md)) for
+`match` / `fail`.
+
+### How it works
+
+1. **Enroll** — `notifyutil -s com.apple.BiometricKit.enrollmentChanged 1` then
+   `-p com.apple.BiometricKit.enrollmentChanged` ensures a biometry is enrolled.
+2. **Match / non-match** — post the key the app's `LAContext` is waiting on:
+   - Touch ID: `com.apple.BiometricKit_Sim.fingerTouch.match` / `…nomatch`
+   - Face ID: `com.apple.BiometricKit_Sim.pearl.match` / `…nomatch`
+
+   `modality: "any"` posts both pairs; the simulator's non-enrolled biometry is a no-op,
+   so the action works regardless of the device's biometry type.
+
+### Action mapping
+
+| MCP `action` | iOS result |
+|--------------|------------|
+| `match` | post `*.match` |
+| `fail` | post `*.nomatch` |
+| `cancel` / `error` | `supported: "partial"` — no simctl equivalent |
+
+### Limitations
+
+- Simulator only. Physical iOS devices have no public biometric-injection API and return
+  `supported: false`.
+- `cancel` / `error` cannot be injected — the notifications carry only match vs non-match.
+  On Android these use the `AutoMobileBiometrics` SDK override, which has no iOS counterpart.
+
+## Push notifications
+
+<kbd>✅ Implemented</kbd> <kbd>🧪 Tested</kbd> <kbd>📱 Simulator Only</kbd>
+
+The `postNotification` MCP tool delivers a simulated remote push to a target app on a
+booted simulator via `xcrun simctl push <udid> <bundleId> <payload.apns>`. Unlike Android
+(a local notification posted by the in-app SDK; see
+[Android notifications](../android/notifications.md)), this is an OS-routed simulated push
+that needs no AutoMobile iOS SDK — but it does require an explicit `appId` (bundle id).
+
+### How it works
+
+1. Build an APNs payload: `title` / `body` → `aps.alert`, `channelId` → `aps.category`,
+   plus a top-level `"Simulator Target Bundle": <appId>`.
+2. Reject payloads larger than the 4096-byte `simctl push` limit.
+3. Write the payload to a temp `.apns` file and run `simctl push` (the simctl command
+   layer has no stdin, so a file is used rather than `-`).
+
+### Limitations
+
+- Simulator only. `simctl push` cannot target physical devices (no APNs token/server);
+  physical iOS devices return `supported: false`.
+- `appId` is required on iOS — there is no frontmost-bundle resolution like the Android
+  dumpsys path.
+- Rich media is limited: `bigPicture` / `imagePath` (needs a Notification Service Extension)
+  and `actions` (need a pre-registered `UNNotificationCategory`) are ignored with a
+  `warning` rather than failing.
+
 ## Usage patterns
 
 - Prefer deterministic simulator selection by device identifier.
@@ -80,3 +146,5 @@ pick them up immediately.
 
 - [CtrlProxy iOS](xctestrunner/index.md) - Touch injection and element queries.
 - [iOS overview](index.md)
+- [Android biometrics](../android/biometrics.md) - The `biometricAuth` Android counterpart.
+- [Android notifications](../android/notifications.md) - The `postNotification` Android counterpart.

--- a/schemas/tool-definitions.json
+++ b/schemas/tool-definitions.json
@@ -1,7 +1,7 @@
 [
   {
     "name": "biometricAuth",
-    "description": "Simulate biometric authentication (fingerprint) on Android emulators, or inject a deterministic result via the AutoMobile SDK on any device. Supports match/fail/cancel/error actions. The SDK broadcast path requires the app to integrate AutoMobileBiometrics.consumeOverride().",
+    "description": "Simulate biometric authentication on Android emulators (fingerprint) and the iOS Simulator (Touch ID / Face ID via BiometricKit), or inject a deterministic result via the AutoMobile SDK on any Android device. Supports match/fail on both platforms; cancel/error require the AutoMobileBiometrics SDK (Android only). Physical iOS devices are not supported (no public biometric-injection API).",
     "inputSchema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "type": "object",
@@ -17,7 +17,7 @@
           "description": "Biometric action: 'match' triggers successful authentication, 'fail' simulates a non-matching biometric, 'cancel' cancels the prompt, 'error' injects a hard error (requires AutoMobileBiometrics SDK integration in the app)."
         },
         "modality": {
-          "description": "Biometric modality (default: 'any'). Currently only 'fingerprint' is reliably supported on Android emulators. 'face' is not consistently supported.",
+          "description": "Biometric modality (default: 'any'). Android emulators reliably support only 'fingerprint'. iOS Simulator supports both: 'fingerprint' -> Touch ID, 'face' -> Face ID, 'any' posts both (the simulator's non-enrolled biometry is a no-op).",
           "type": "string",
           "enum": [
             "any",
@@ -4137,7 +4137,7 @@
   },
   {
     "name": "postNotification",
-    "description": "Post a notification from the app-under-test when AutoMobile SDK hooks are installed.",
+    "description": "Post a notification: on Android, from the app-under-test when AutoMobile SDK hooks are installed; on the iOS Simulator, deliver a simulated remote push to the given bundle id via 'simctl push' (requires appId; physical iOS devices unsupported).",
     "inputSchema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "type": "object",
@@ -4165,7 +4165,7 @@
           "type": "string"
         },
         "actions": {
-          "description": "Action buttons to include",
+          "description": "Action buttons to include (Android only)",
           "type": "array",
           "items": {
             "type": "object",
@@ -4189,7 +4189,11 @@
           }
         },
         "channelId": {
-          "description": "Notification channel ID (Android only)",
+          "description": "Notification channel ID (Android); reused as the APNs category on iOS",
+          "type": "string"
+        },
+        "appId": {
+          "description": "iOS bundle identifier to target (required on iOS; maps to APNs 'Simulator Target Bundle'). Ignored on Android.",
           "type": "string"
         },
         "platform": {

--- a/src/features/action/BiometricAuth.ts
+++ b/src/features/action/BiometricAuth.ts
@@ -1,9 +1,11 @@
 import { AdbClient } from "../../utils/android-cmdline-tools/AdbClient";
 import { BaseVisualChange, ProgressCallback } from "./BaseVisualChange";
-import { BootedDevice, BiometricAuthResult } from "../../models";
+import { BootedDevice, BiometricAuthResult, ExecResult } from "../../models";
 import { createGlobalPerformanceTracker } from "../../utils/PerformanceTracker";
 import { logger } from "../../utils/logger";
 import { Timer, defaultTimer } from "../../utils/SystemTimer";
+import { SimCtlClient } from "../../utils/ios-cmdline-tools/SimCtlClient";
+import { isIosSimulatorDevice } from "./IosSimulatorPermissions";
 
 export interface BiometricAuthOptions {
   action: "match" | "fail" | "cancel" | "error";
@@ -13,6 +15,11 @@ export interface BiometricAuthOptions {
   ttlMs?: number;
 }
 
+/** Minimal simctl surface needed by the iOS biometric path (injectable for tests). */
+export interface BiometricSimctl {
+  executeCommand(command: string, timeoutMs?: number): Promise<ExecResult>;
+}
+
 /** Broadcast action received by AutoMobileBiometrics in the app-under-test SDK. */
 const SDK_BROADCAST_ACTION = "dev.jasonpearson.automobile.sdk.BIOMETRIC_OVERRIDE";
 
@@ -20,10 +27,24 @@ const SDK_BROADCAST_ACTION = "dev.jasonpearson.automobile.sdk.BIOMETRIC_OVERRIDE
 const DEFAULT_TTL_MS = 5000;
 
 export class BiometricAuth extends BaseVisualChange {
+  /** Darwin notification keys the iOS Simulator's BiometricKit listens on. */
+  private static readonly IOS_KEYS = {
+    enrollment: "com.apple.BiometricKit.enrollmentChanged",
+    fingerTouch: {
+      match: "com.apple.BiometricKit_Sim.fingerTouch.match",
+      nomatch: "com.apple.BiometricKit_Sim.fingerTouch.nomatch"
+    },
+    pearl: {
+      match: "com.apple.BiometricKit_Sim.pearl.match",
+      nomatch: "com.apple.BiometricKit_Sim.pearl.nomatch"
+    }
+  } as const;
+
   constructor(
     device: BootedDevice,
     adb: AdbClient | null = null,
-    timer: Timer = defaultTimer
+    timer: Timer = defaultTimer,
+    private simctl: BiometricSimctl | null = null
   ) {
     super(device, adb, timer);
     this.device = device;
@@ -36,18 +57,19 @@ export class BiometricAuth extends BaseVisualChange {
     const perf = createGlobalPerformanceTracker();
     perf.serial("biometricAuth");
 
-    // Only Android is supported
+    // iOS Simulator is supported via BiometricKit Darwin notifications.
+    if (this.device.platform === "ios") {
+      perf.end();
+      return this.executeIos(options);
+    }
+
+    // Only Android is otherwise supported
     if (this.device.platform !== "android") {
       perf.end();
-      return {
-        success: false,
-        action: options.action,
-        modality: options.modality ?? "any",
-        fingerprintId: options.fingerprintId,
-        errorCode: options.errorCode,
-        supported: false,
-        error: "Biometric authentication is only supported on Android devices"
-      };
+      return this.unsupported(
+        options,
+        "Biometric authentication is only supported on Android and iOS Simulator devices"
+      );
     }
 
     // Check modality before capability check (fail fast)
@@ -128,6 +150,107 @@ export class BiometricAuth extends BaseVisualChange {
         perf
       }
     );
+  }
+
+  /**
+   * Simulate a biometric match / non-match on the iOS Simulator by posting BiometricKit
+   * Darwin notifications via `xcrun simctl spawn <udid> notifyutil`.
+   *
+   * match -> *.match, fail -> *.nomatch. For modality "any" we post both fingerTouch and
+   * pearl keys; a simulator only has one biometry enrolled so the other is a harmless no-op.
+   * cancel/error have no simulator notification and return supported:"partial".
+   * Physical iOS devices have no public injection API and return supported:false.
+   */
+  private async executeIos(options: BiometricAuthOptions): Promise<BiometricAuthResult> {
+    const modality = options.modality ?? "any";
+
+    if (!isIosSimulatorDevice(this.device)) {
+      return this.unsupported(
+        options,
+        "iOS biometric simulation is only available on the iOS Simulator. " +
+          "There is no public API to inject a biometric result on a physical iOS device."
+      );
+    }
+
+    if (options.action === "cancel" || options.action === "error") {
+      return {
+        success: false,
+        action: options.action,
+        modality,
+        fingerprintId: options.fingerprintId,
+        errorCode: options.errorCode,
+        supported: "partial",
+        error: `iOS Simulator biometrics support only 'match' and 'fail'; '${options.action}' has no simctl equivalent.`
+      };
+    }
+
+    const simctl = this.simctl ?? new SimCtlClient(this.device);
+    const udid = this.device.deviceId;
+    const wantMatch = options.action === "match";
+    const keys = BiometricAuth.IOS_KEYS;
+
+    const targets: string[] = [];
+    if (modality === "face") {
+      targets.push(wantMatch ? keys.pearl.match : keys.pearl.nomatch);
+    } else if (modality === "fingerprint") {
+      targets.push(wantMatch ? keys.fingerTouch.match : keys.fingerTouch.nomatch);
+    } else {
+      targets.push(wantMatch ? keys.fingerTouch.match : keys.fingerTouch.nomatch);
+      targets.push(wantMatch ? keys.pearl.match : keys.pearl.nomatch);
+    }
+
+    try {
+      // Ensure biometry is enrolled before attempting a match.
+      await simctl.executeCommand(`spawn ${udid} notifyutil -s ${keys.enrollment} 1`);
+      await simctl.executeCommand(`spawn ${udid} notifyutil -p ${keys.enrollment}`);
+
+      for (const target of targets) {
+        const res = await simctl.executeCommand(`spawn ${udid} notifyutil -p ${target}`);
+        if (res.stderr && res.stderr.trim().length > 0) {
+          return {
+            success: false,
+            action: options.action,
+            modality,
+            fingerprintId: options.fingerprintId,
+            errorCode: options.errorCode,
+            supported: true,
+            error: `notifyutil failed: ${res.stderr.trim()}`
+          };
+        }
+      }
+
+      return {
+        success: true,
+        action: options.action,
+        modality,
+        fingerprintId: options.fingerprintId,
+        errorCode: options.errorCode,
+        supported: true,
+        message: `Posted ${targets.join(", ")} to simulator ${udid} (${options.action})`
+      };
+    } catch (error) {
+      return {
+        success: false,
+        action: options.action,
+        modality,
+        fingerprintId: options.fingerprintId,
+        errorCode: options.errorCode,
+        supported: true,
+        error: `Failed to post iOS biometric notification: ${error instanceof Error ? error.message : String(error)}`
+      };
+    }
+  }
+
+  private unsupported(options: BiometricAuthOptions, msg: string): BiometricAuthResult {
+    return {
+      success: false,
+      action: options.action,
+      modality: options.modality ?? "any",
+      fingerprintId: options.fingerprintId,
+      errorCode: options.errorCode,
+      supported: false,
+      error: msg
+    };
   }
 
   /**

--- a/src/features/utility/PostNotification.ts
+++ b/src/features/utility/PostNotification.ts
@@ -4,6 +4,8 @@ import { BootedDevice, PostNotificationResult } from "../../models";
 import { Window } from "../observe/Window";
 import { logger } from "../../utils/logger";
 import { createGlobalPerformanceTracker } from "../../utils/PerformanceTracker";
+import { SimCtlClient } from "../../utils/ios-cmdline-tools/SimCtlClient";
+import { isIosSimulatorUdid } from "../../utils/ios-cmdline-tools/iosDeviceType";
 import { fileURLToPath } from "url";
 import fs from "fs/promises";
 import path from "path";
@@ -20,6 +22,8 @@ export interface PostNotificationOptions {
   imagePath?: string;
   actions?: PostNotificationAction[];
   channelId?: string;
+  /** iOS bundle identifier to target (required on iOS; maps to APNs "Simulator Target Bundle"). */
+  appId?: string;
 }
 
 const NOTIFICATION_ACTION = "dev.jasonpearson.automobile.sdk.NOTIFICATION_POST";
@@ -32,8 +36,14 @@ export class PostNotification {
   private adb: AdbExecutor;
   private adbFactory: AdbClientFactory;
   private window: Window;
+  private simctl: SimCtlClient;
 
-  constructor(device: BootedDevice, adbFactoryOrExecutor: AdbClientFactory | AdbExecutor | null = defaultAdbClientFactory, window: Window | null = null) {
+  constructor(
+    device: BootedDevice,
+    adbFactoryOrExecutor: AdbClientFactory | AdbExecutor | null = defaultAdbClientFactory,
+    window: Window | null = null,
+    simctl: SimCtlClient | null = null
+  ) {
     this.device = device;
     // Detect if the argument is a factory (has create method) or an executor
     if (adbFactoryOrExecutor && typeof (adbFactoryOrExecutor as AdbClientFactory).create === "function") {
@@ -49,6 +59,7 @@ export class PostNotification {
       this.adb = this.adbFactory.create(device);
     }
     this.window = window || new Window(device, this.adbFactory);
+    this.simctl = simctl || new SimCtlClient(device);
   }
 
   async execute(options: PostNotificationOptions, signal?: AbortSignal): Promise<PostNotificationResult> {
@@ -56,14 +67,102 @@ export class PostNotification {
     perf.serial("postNotification");
 
     try {
-      if (this.device.platform !== "android") {
-        return {
-          success: false,
-          supported: false,
-          error: "postNotification is only supported on Android devices."
-        };
+      switch (this.device.platform) {
+        case "android":
+          return await this.executeAndroid(options, signal);
+        case "ios":
+          return await this.executeIos(options);
+        default:
+          return {
+            success: false,
+            supported: false,
+            error: `postNotification is not supported on platform: ${this.device.platform}`
+          };
       }
+    } catch (error) {
+      return {
+        success: false,
+        supported: false,
+        error: `Failed to post notification: ${error instanceof Error ? error.message : String(error)}`
+      };
+    } finally {
+      perf.end();
+    }
+  }
 
+  /** iOS: deliver a simulated remote push via `simctl push` (simulator only). */
+  private async executeIos(options: PostNotificationOptions): Promise<PostNotificationResult> {
+    const bundleId = options.appId;
+    if (!bundleId) {
+      return {
+        success: false,
+        supported: false,
+        error: "appId (bundle identifier) is required to post a notification on iOS."
+      };
+    }
+
+    // simctl push is simulator-only. Use the repo's UDID-shape convention (NOT device.source).
+    if (!isIosSimulatorUdid(this.device.deviceId)) {
+      return {
+        success: false,
+        supported: false,
+        appId: bundleId,
+        error: "postNotification on iOS is only supported on simulators (simctl push); physical iOS devices are not supported."
+      };
+    }
+
+    const warnings: string[] = [];
+    if (options.imageType === "bigPicture" || options.imagePath) {
+      warnings.push("bigPicture/image attachments are not supported via simctl push and were ignored.");
+    }
+    if (options.actions && options.actions.length > 0) {
+      warnings.push("action buttons require a pre-registered UNNotificationCategory and were ignored.");
+    }
+    const warning = warnings.join(" ") || undefined;
+
+    const aps: Record<string, unknown> = {
+      alert: { title: options.title, body: options.body },
+      sound: "default"
+    };
+    if (options.channelId) {
+      aps.category = options.channelId; // reuse channelId as the APNs category
+    }
+    const payload = { "Simulator Target Bundle": bundleId, aps };
+    const json = JSON.stringify(payload);
+
+    if (Buffer.byteLength(json, "utf8") > 4096) {
+      return {
+        success: false,
+        supported: true,
+        appId: bundleId,
+        error: "APNs payload exceeds the 4096-byte simctl push limit.",
+        warning
+      };
+    }
+
+    const result = await this.simctl.pushNotification(this.device.deviceId, bundleId, json);
+    if (!result.success) {
+      return {
+        success: false,
+        supported: true,
+        appId: bundleId,
+        error: result.error ?? "simctl push failed.",
+        warning
+      };
+    }
+    return {
+      success: true,
+      supported: true,
+      method: "simctlPush",
+      appId: bundleId,
+      channelId: options.channelId,
+      warning
+    };
+  }
+
+  /** Android: post a local notification through the AutoMobile SDK BroadcastReceiver. */
+  private async executeAndroid(options: PostNotificationOptions, signal?: AbortSignal): Promise<PostNotificationResult> {
+    try {
       const imageType = options.imageType ?? "normal";
 
       let imagePath = options.imagePath;
@@ -104,8 +203,6 @@ export class PostNotification {
         supported: false,
         error: `Failed to post notification: ${error instanceof Error ? error.message : String(error)}`
       };
-    } finally {
-      perf.end();
     }
   }
 

--- a/src/models/PostNotificationResult.ts
+++ b/src/models/PostNotificationResult.ts
@@ -4,7 +4,7 @@
 export interface PostNotificationResult {
   success: boolean;
   supported: boolean;
-  method?: "sdk";
+  method?: "sdk" | "simctlPush";
   imageType?: "normal" | "bigPicture";
   appId?: string;
   channelId?: string;

--- a/src/server/biometricTools.ts
+++ b/src/server/biometricTools.ts
@@ -17,7 +17,8 @@ export const biometricAuthSchema = addDeviceTargetingToSchema(z.object({
     "'cancel' cancels the prompt, 'error' injects a hard error (requires AutoMobileBiometrics SDK integration in the app)."
   ),
   modality: z.enum(["any", "fingerprint", "face"]).optional().describe(
-    "Biometric modality (default: 'any'). Currently only 'fingerprint' is reliably supported on Android emulators. 'face' is not consistently supported."
+    "Biometric modality (default: 'any'). Android emulators reliably support only 'fingerprint'. iOS Simulator supports both: " +
+    "'fingerprint' -> Touch ID, 'face' -> Face ID, 'any' posts both (the simulator's non-enrolled biometry is a no-op)."
   ),
   fingerprintId: z.number().optional().describe(
     "Fingerprint ID to simulate (default: 1 for 'match'/'error', 2 for 'fail'/'cancel'). Use enrolled ID (typically 1) for match/error, non-enrolled ID (typically 2) for fail/cancel."
@@ -70,8 +71,10 @@ export function registerBiometricTools() {
   // Register the tool
   ToolRegistry.registerDeviceAware(
     "biometricAuth",
-    "Simulate biometric authentication (fingerprint) on Android emulators, or inject a deterministic result via the AutoMobile SDK on any device. " +
-    "Supports match/fail/cancel/error actions. The SDK broadcast path requires the app to integrate AutoMobileBiometrics.consumeOverride().",
+    "Simulate biometric authentication on Android emulators (fingerprint) and the iOS Simulator (Touch ID / Face ID via BiometricKit), " +
+    "or inject a deterministic result via the AutoMobile SDK on any Android device. " +
+    "Supports match/fail on both platforms; cancel/error require the AutoMobileBiometrics SDK (Android only). " +
+    "Physical iOS devices are not supported (no public biometric-injection API).",
     biometricAuthSchema,
     biometricAuthHandler,
     true // Supports progress notifications

--- a/src/server/notificationTools.ts
+++ b/src/server/notificationTools.ts
@@ -21,8 +21,9 @@ export const postNotificationSchema = addDeviceTargetingToSchema(
     body: z.string().min(1).describe("Notification body"),
     imageType: z.enum(["normal", "bigPicture"]).optional().describe("Notification image type (default: normal)"),
     imagePath: z.string().optional().describe("Host image file path to push to /sdcard/Download/automobile when imageType is bigPicture"),
-    actions: z.array(actionSchema).optional().describe("Action buttons to include"),
-    channelId: z.string().optional().describe("Notification channel ID (Android only)"),
+    actions: z.array(actionSchema).optional().describe("Action buttons to include (Android only)"),
+    channelId: z.string().optional().describe("Notification channel ID (Android); reused as the APNs category on iOS"),
+    appId: z.string().optional().describe("iOS bundle identifier to target (required on iOS; maps to APNs 'Simulator Target Bundle'). Ignored on Android."),
     platform: platformSchema
   })
 );
@@ -50,7 +51,8 @@ export function registerNotificationTools() {
         imageType: args.imageType,
         imagePath: args.imagePath,
         actions: args.actions,
-        channelId: args.channelId
+        channelId: args.channelId,
+        appId: args.appId
       });
 
       const message = result.success
@@ -94,7 +96,8 @@ export function registerNotificationTools() {
 
   ToolRegistry.registerDeviceAware(
     "postNotification",
-    "Post a notification from the app-under-test when AutoMobile SDK hooks are installed.",
+    "Post a notification: on Android, from the app-under-test when AutoMobile SDK hooks are installed; " +
+    "on the iOS Simulator, deliver a simulated remote push to the given bundle id via 'simctl push' (requires appId; physical iOS devices unsupported).",
     postNotificationSchema,
     postNotificationHandler
   );

--- a/src/utils/ios-cmdline-tools/SimCtlClient.ts
+++ b/src/utils/ios-cmdline-tools/SimCtlClient.ts
@@ -1,5 +1,8 @@
 import { ChildProcess, execFile } from "child_process";
 import { promisify } from "util";
+import { promises as fsPromises } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
 import { logger } from "../logger";
 import { createExecResult } from "../execResult";
 import { isRunningInDocker } from "../dockerEnv";
@@ -215,6 +218,14 @@ export interface SimCtl {
    * @param udid - Optional device UDID to focus
    */
   openSimulatorApp(udid?: string): Promise<void>;
+
+  /**
+   * Deliver a simulated remote push notification to a booted simulator.
+   * @param deviceId - Simulator UDID
+   * @param bundleId - Target app bundle identifier
+   * @param payloadJson - APNs payload JSON (must contain a top-level `aps` key, <=4096 bytes)
+   */
+  pushNotification(deviceId: string, bundleId: string, payloadJson: string): Promise<{ success: boolean; error?: string }>;
 }
 
 interface SimctlHostControlRunner {
@@ -1008,6 +1019,29 @@ export class SimCtlClient implements SimCtl {
   async setAppearance(mode: "light" | "dark", deviceId?: string): Promise<void> {
     const targetDevice = deviceId || this.device?.deviceId || "booted";
     await this.executeCommand(`ui ${targetDevice} appearance ${mode}`);
+  }
+
+  /**
+   * Deliver a simulated remote push to a booted simulator via `simctl push`.
+   * Writes the payload to a temp .apns file because executeCommand cannot stream stdin.
+   */
+  async pushNotification(deviceId: string, bundleId: string, payloadJson: string): Promise<{ success: boolean; error?: string }> {
+    const dir = await fsPromises.mkdtemp(join(tmpdir(), "automobile-apns-"));
+    const file = join(dir, "payload.apns");
+    try {
+      await fsPromises.writeFile(file, payloadJson, "utf-8");
+      // `xcrun simctl push <udid> <bundleId> <file>`; bundleId may be omitted when the
+      // payload carries "Simulator Target Bundle", but passing it explicitly is harmless.
+      const result = await this.executeCommand(`push ${deviceId} ${bundleId} "${file}"`);
+      if ((result.stderr || "").trim().length > 0) {
+        return { success: false, error: result.stderr.trim() };
+      }
+      return { success: true };
+    } catch (error) {
+      return { success: false, error: error instanceof Error ? error.message : String(error) };
+    } finally {
+      await fsPromises.rm(dir, { recursive: true, force: true }).catch(() => {});
+    }
   }
 
   async openSimulatorApp(udid?: string): Promise<void> {

--- a/test/fakes/FakeSimCtlClient.ts
+++ b/test/fakes/FakeSimCtlClient.ts
@@ -125,4 +125,15 @@ export class FakeSimCtlClient {
       throw this.openSimulatorAppError;
     }
   }
+
+  private pushNotificationResult: { success: boolean; error?: string } = { success: true };
+
+  setPushNotificationResult(result: { success: boolean; error?: string }): void {
+    this.pushNotificationResult = result;
+  }
+
+  async pushNotification(deviceId: string, bundleId: string, payloadJson: string): Promise<{ success: boolean; error?: string }> {
+    this.recordCall("pushNotification", { deviceId, bundleId, payloadJson });
+    return this.pushNotificationResult;
+  }
 }

--- a/test/features/action/BiometricAuth.test.ts
+++ b/test/features/action/BiometricAuth.test.ts
@@ -355,7 +355,8 @@ describe("BiometricAuth", () => {
   });
 
   describe("capability detection", () => {
-    test("should reject iOS platform", async () => {
+    test("should reject physical iOS devices (non-simulator UDID)", async () => {
+      // "test-device" is not a simulator UUID, so the iOS path treats it as a physical device.
       const iosDevice = { ...device, platform: "ios" as const };
       const iosBiometricAuth = new BiometricAuth(iosDevice, fakeAdb);
 
@@ -363,7 +364,7 @@ describe("BiometricAuth", () => {
 
       expect(result.success).toBe(false);
       expect(result.supported).toBe(false);
-      expect(result.error).toContain("only supported on Android");
+      expect(result.error).toContain("physical iOS device");
     });
 
     test("should reject emulators without emu finger support", async () => {

--- a/test/features/action/BiometricAuthIos.test.ts
+++ b/test/features/action/BiometricAuthIos.test.ts
@@ -1,0 +1,130 @@
+import { expect, describe, test, beforeEach } from "bun:test";
+import { BiometricAuth } from "../../../src/features/action/BiometricAuth";
+import { BootedDevice } from "../../../src/models";
+import { FakeSimCtlClient } from "../../fakes/FakeSimCtlClient";
+import { FakeTimer } from "../../fakes/FakeTimer";
+
+const SIM_UDID = "11111111-2222-3333-4444-555555555555";
+const PHYSICAL_UDID = "00008030001A2B3C4D5E6F7089ABCDEF01234567";
+
+const ENROLL = "com.apple.BiometricKit.enrollmentChanged";
+const TOUCH_MATCH = "com.apple.BiometricKit_Sim.fingerTouch.match";
+const TOUCH_NOMATCH = "com.apple.BiometricKit_Sim.fingerTouch.nomatch";
+const PEARL_MATCH = "com.apple.BiometricKit_Sim.pearl.match";
+const PEARL_NOMATCH = "com.apple.BiometricKit_Sim.pearl.nomatch";
+
+describe("BiometricAuth - iOS Simulator", () => {
+  let simctl: FakeSimCtlClient;
+  let timer: FakeTimer;
+
+  const makeDevice = (deviceId: string): BootedDevice =>
+    ({ deviceId, platform: "ios" } as BootedDevice);
+
+  const commands = (): string[] =>
+    simctl.getMethodCalls("executeCommand").map(c => String(c.command));
+
+  beforeEach(() => {
+    simctl = new FakeSimCtlClient();
+    timer = new FakeTimer();
+    timer.enableAutoAdvance();
+  });
+
+  test("match + fingerprint posts enrollment then fingerTouch.match", async () => {
+    const auth = new BiometricAuth(makeDevice(SIM_UDID), null, timer, simctl);
+    const result = await auth.execute({ action: "match", modality: "fingerprint" });
+
+    expect(result.success).toBe(true);
+    expect(result.supported).toBe(true);
+    expect(commands()).toEqual([
+      `spawn ${SIM_UDID} notifyutil -s ${ENROLL} 1`,
+      `spawn ${SIM_UDID} notifyutil -p ${ENROLL}`,
+      `spawn ${SIM_UDID} notifyutil -p ${TOUCH_MATCH}`,
+    ]);
+  });
+
+  test("match + face posts pearl.match", async () => {
+    const auth = new BiometricAuth(makeDevice(SIM_UDID), null, timer, simctl);
+    const result = await auth.execute({ action: "match", modality: "face" });
+
+    expect(result.success).toBe(true);
+    expect(commands()).toContain(`spawn ${SIM_UDID} notifyutil -p ${PEARL_MATCH}`);
+    expect(commands()).not.toContain(`spawn ${SIM_UDID} notifyutil -p ${TOUCH_MATCH}`);
+  });
+
+  test("match + any posts BOTH fingerTouch and pearl match (works on either biometry)", async () => {
+    const auth = new BiometricAuth(makeDevice(SIM_UDID), null, timer, simctl);
+    const result = await auth.execute({ action: "match" });
+
+    expect(result.success).toBe(true);
+    expect(result.modality).toBe("any");
+    expect(commands()).toContain(`spawn ${SIM_UDID} notifyutil -p ${TOUCH_MATCH}`);
+    expect(commands()).toContain(`spawn ${SIM_UDID} notifyutil -p ${PEARL_MATCH}`);
+  });
+
+  test("fail + fingerprint posts fingerTouch.nomatch", async () => {
+    const auth = new BiometricAuth(makeDevice(SIM_UDID), null, timer, simctl);
+    const result = await auth.execute({ action: "fail", modality: "fingerprint" });
+
+    expect(result.success).toBe(true);
+    expect(commands()).toContain(`spawn ${SIM_UDID} notifyutil -p ${TOUCH_NOMATCH}`);
+  });
+
+  test("fail + face posts pearl.nomatch", async () => {
+    const auth = new BiometricAuth(makeDevice(SIM_UDID), null, timer, simctl);
+    await auth.execute({ action: "fail", modality: "face" });
+    expect(commands()).toContain(`spawn ${SIM_UDID} notifyutil -p ${PEARL_NOMATCH}`);
+  });
+
+  test("physical iOS device is unsupported (no public injection API)", async () => {
+    const auth = new BiometricAuth(makeDevice(PHYSICAL_UDID), null, timer, simctl);
+    const result = await auth.execute({ action: "match", modality: "face" });
+
+    expect(result.success).toBe(false);
+    expect(result.supported).toBe(false);
+    expect(result.error).toContain("physical iOS device");
+    expect(commands()).toHaveLength(0);
+  });
+
+  test("cancel is partial on iOS (no simctl equivalent)", async () => {
+    const auth = new BiometricAuth(makeDevice(SIM_UDID), null, timer, simctl);
+    const result = await auth.execute({ action: "cancel" });
+
+    expect(result.success).toBe(false);
+    expect(result.supported).toBe("partial");
+    expect(commands()).toHaveLength(0);
+  });
+
+  test("error is partial on iOS (no simctl equivalent)", async () => {
+    const auth = new BiometricAuth(makeDevice(SIM_UDID), null, timer, simctl);
+    const result = await auth.execute({ action: "error", errorCode: 7 });
+
+    expect(result.success).toBe(false);
+    expect(result.supported).toBe("partial");
+  });
+
+  test("notifyutil stderr surfaces as failure", async () => {
+    simctl.setCommandResult(
+      `spawn ${SIM_UDID} notifyutil -p ${TOUCH_MATCH}`,
+      "",
+      "notifyutil: command not found"
+    );
+    const auth = new BiometricAuth(makeDevice(SIM_UDID), null, timer, simctl);
+    const result = await auth.execute({ action: "match", modality: "fingerprint" });
+
+    expect(result.success).toBe(false);
+    expect(result.supported).toBe(true);
+    expect(result.error).toContain("notifyutil failed");
+  });
+
+  test("thrown simctl error is caught and reported", async () => {
+    simctl.setCommandError(
+      `spawn ${SIM_UDID} notifyutil -s ${ENROLL} 1`,
+      new Error("simctl unavailable")
+    );
+    const auth = new BiometricAuth(makeDevice(SIM_UDID), null, timer, simctl);
+    const result = await auth.execute({ action: "match", modality: "fingerprint" });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("Failed to post iOS biometric notification");
+  });
+});

--- a/test/features/performance/PerformanceMonitor.test.ts
+++ b/test/features/performance/PerformanceMonitor.test.ts
@@ -593,6 +593,8 @@ class FakeSimCtl implements SimCtl {
   async uninstallApp(): Promise<void> {}
   async getScreenSize(): Promise<any> { return { width: 390, height: 844 }; }
   async setAppearance(): Promise<void> {}
+  async openSimulatorApp(): Promise<void> {}
+  async pushNotification(): Promise<{ success: boolean; error?: string }> { return { success: true }; }
 }
 
 /**

--- a/test/features/utility/PostNotificationIos.test.ts
+++ b/test/features/utility/PostNotificationIos.test.ts
@@ -1,0 +1,100 @@
+import { expect, describe, test, beforeEach } from "bun:test";
+import { PostNotification } from "../../../src/features/utility/PostNotification";
+import { BootedDevice } from "../../../src/models";
+import { FakeSimCtlClient } from "../../fakes/FakeSimCtlClient";
+
+const SIM_UDID = "11111111-2222-3333-4444-555555555555";
+const PHYSICAL_UDID = "00008030001A2B3C4D5E6F7089ABCDEF01234567";
+
+describe("PostNotification - iOS Simulator", () => {
+  let simctl: FakeSimCtlClient;
+
+  const makeDevice = (deviceId: string): BootedDevice =>
+    ({ deviceId, platform: "ios" } as BootedDevice);
+
+  const make = (deviceId: string) =>
+    new PostNotification(makeDevice(deviceId), null, null, simctl as any);
+
+  const pushCalls = () => simctl.getMethodCalls("pushNotification");
+
+  beforeEach(() => {
+    simctl = new FakeSimCtlClient();
+  });
+
+  test("posts via simctl push on a simulator with appId", async () => {
+    const result = await make(SIM_UDID).execute({
+      title: "Hello",
+      body: "World",
+      appId: "com.example.App",
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.supported).toBe(true);
+    expect(result.method).toBe("simctlPush");
+    expect(result.appId).toBe("com.example.App");
+
+    expect(pushCalls()).toHaveLength(1);
+    const call = pushCalls()[0];
+    expect(call.deviceId).toBe(SIM_UDID);
+    expect(call.bundleId).toBe("com.example.App");
+    const payload = JSON.parse(String(call.payloadJson));
+    expect(payload["Simulator Target Bundle"]).toBe("com.example.App");
+    expect(payload.aps.alert).toEqual({ title: "Hello", body: "World" });
+  });
+
+  test("channelId maps to APNs category", async () => {
+    await make(SIM_UDID).execute({ title: "t", body: "b", appId: "com.x", channelId: "messages" });
+    const payload = JSON.parse(String(pushCalls()[0].payloadJson));
+    expect(payload.aps.category).toBe("messages");
+  });
+
+  test("missing appId fails with no shell call", async () => {
+    const result = await make(SIM_UDID).execute({ title: "t", body: "b" });
+    expect(result.success).toBe(false);
+    expect(result.supported).toBe(false);
+    expect(result.error).toContain("appId");
+    expect(pushCalls()).toHaveLength(0);
+  });
+
+  test("physical iOS device is unsupported with no shell call", async () => {
+    const result = await make(PHYSICAL_UDID).execute({ title: "t", body: "b", appId: "com.x" });
+    expect(result.success).toBe(false);
+    expect(result.supported).toBe(false);
+    expect(result.error).toContain("physical iOS devices");
+    expect(pushCalls()).toHaveLength(0);
+  });
+
+  test("bigPicture/imagePath are ignored with a warning (still succeeds)", async () => {
+    const result = await make(SIM_UDID).execute({
+      title: "t", body: "b", appId: "com.x", imageType: "bigPicture", imagePath: "/tmp/x.png",
+    });
+    expect(result.success).toBe(true);
+    expect(result.warning).toContain("bigPicture");
+    expect(pushCalls()).toHaveLength(1);
+  });
+
+  test("action buttons are ignored with a warning", async () => {
+    const result = await make(SIM_UDID).execute({
+      title: "t", body: "b", appId: "com.x", actions: [{ label: "Open", actionId: "open" }],
+    });
+    expect(result.success).toBe(true);
+    expect(result.warning).toContain("action buttons");
+  });
+
+  test("oversized payload is rejected before invoking simctl", async () => {
+    const result = await make(SIM_UDID).execute({
+      title: "t", body: "x".repeat(5000), appId: "com.x",
+    });
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("4096");
+    expect(pushCalls()).toHaveLength(0);
+  });
+
+  test("simctl push failure surfaces as supported failure", async () => {
+    simctl.setPushNotificationResult({ success: false, error: "No such device" });
+    const result = await make(SIM_UDID).execute({ title: "t", body: "b", appId: "com.x" });
+    expect(result.success).toBe(false);
+    expect(result.supported).toBe(true);
+    expect(result.error).toContain("No such device");
+  });
+});


### PR DESCRIPTION
Implements the first batch of iOS Simulator tool parity (grouped by `simctl` mechanism).

## What

### `biometricAuth` on iOS Simulator — Closes #2497
- New iOS path posts BiometricKit Darwin notifications via `xcrun simctl spawn <udid> notifyutil`.
- `match`/`fail` → `.match`/`.nomatch`; Touch ID = `fingerTouch.*`, Face ID = `pearl.*`.
- `modality: "any"` posts **both** keys, so it works regardless of the simulator's enrolled biometry.
- Physical iOS devices → `supported: false` (no public injection API). `cancel`/`error` → `supported: "partial"` (no simctl equivalent).

### `postNotification` on iOS Simulator — Closes #2495
- New iOS path delivers a simulated remote push via `xcrun simctl push` to a target bundle (`appId`).
- `title`/`body` → `aps.alert`, `channelId` → `aps.category`; payloads > 4096 bytes rejected; `bigPicture`/`imagePath`/`actions` ignored with a `warning`.
- New `SimCtlClient.pushNotification()` (writes a temp `.apns` file, since `executeCommand` has no stdin).
- Physical iOS devices unsupported (`simctl push` is simulator-only).

Both use `isIosSimulatorUdid()` to split simulator vs physical. **Android paths are unchanged.**

## Validation
- `bun test` — 91 passing across the affected suites (new `BiometricAuthIos`/`PostNotificationIos` + existing Android suites green; updated one stale Android test that asserted "iOS rejected").
- `tsc --noEmit` — no new type errors in changed files.
- **Simulator E2E** (iPhone 16 Pro): biometric `notifyutil` commands run cleanly; `simctl push` → "Notification sent"; and the real `BiometricAuth`/`PostNotification` classes verified end-to-end against the booted sim.

Part of milestone **iOS/Android tool parity**.