### PR TITLE
feat(ios): dragAndDrop via XCUITest CtrlProxy runner

### DIFF
--- a/docs/design-docs/plat/ios/ctrl-proxy-ios.md
+++ b/docs/design-docs/plat/ios/ctrl-proxy-ios.md
@@ -15,6 +15,7 @@ service and focuses on reliable observation delivery.
 - Provide element bounds for touch injection.
 - Emit view hierarchy updates when the UI changes.
 - Track first responder and focus state.
+- Perform coordinate gestures (tap, swipe, drag) via `GesturePerformer`.
 
 ## WebSocket protocol
 
@@ -52,6 +53,18 @@ Server to client response:
   }
 }
 ```
+
+## Gestures
+
+`GesturePerformer` injects coordinate gestures through `XCUICoordinate` anchored on
+SpringBoard: tap, long-press, swipe, and **drag**
+(`press(forDuration:thenDragTo:withVelocity:thenHoldForDuration:)`). The `dragAndDrop` MCP
+tool resolves source/target element centers from the shared view hierarchy and dispatches
+through `IOSCtrlProxyClient.requestDrag()` to this path, reaching parity with the Android
+accessibility-service drag.
+
+> Caveat: on the Simulator the post-drop `thenHoldForDuration:` hold may be a no-op; press
+> and drag are reliable. Verify hold-dependent flows on a physical device.
 
 ## Limitations
 

--- a/docs/design-docs/plat/ios/ctrl-proxy-ios.md
+++ b/docs/design-docs/plat/ios/ctrl-proxy-ios.md
@@ -59,9 +59,15 @@ Server to client response:
 `GesturePerformer` injects coordinate gestures through `XCUICoordinate` anchored on
 SpringBoard: tap, long-press, swipe, and **drag**
 (`press(forDuration:thenDragTo:withVelocity:thenHoldForDuration:)`). The `dragAndDrop` MCP
-tool resolves source/target element centers from the shared view hierarchy and dispatches
-through `IOSCtrlProxyClient.requestDrag()` to this path, reaching parity with the Android
-accessibility-service drag.
+tool resolves source/target element centers from a freshly-refreshed view hierarchy and
+dispatches through `IOSCtrlProxyClient.requestDrag()` to this path, reaching parity with the
+Android accessibility-service drag.
+
+The XCUICoordinate drag API takes a velocity (points/second) rather than a duration, so
+`GesturePerformer.drag` converts the caller's `dragDurationMs` into the velocity that covers
+the source→target distance in that time (`velocity = distance / dragDuration`), falling back
+to `.default` when the duration or distance is non-positive. This gives iOS the same
+drag-speed control as Android.
 
 > Caveat: on the Simulator the post-drop `thenHoldForDuration:` hold may be a no-op; press
 > and drag are reliable. Verify hold-dependent flows on a physical device.

--- a/ios/control-proxy/Sources/CtrlProxy/GesturePerformer.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/GesturePerformer.swift
@@ -337,7 +337,7 @@ public class GesturePerformer: GesturePerforming {
             startX: Double, startY: Double,
             endX: Double, endY: Double,
             pressDuration: TimeInterval,
-            dragDuration _: TimeInterval,
+            dragDuration: TimeInterval,
             holdDuration: TimeInterval
         )
             throws
@@ -352,11 +352,21 @@ public class GesturePerformer: GesturePerforming {
                 let endCoordinate = app.coordinate(withNormalizedOffset: .zero)
                     .withOffset(CGVector(dx: endX, dy: endY))
 
+                // XCUICoordinate's drag API takes a velocity (points/second), not a duration,
+                // so honor the caller's dragDuration by converting it into the velocity that
+                // covers the source→target distance in that time. This gives iOS the same
+                // drag-speed control Android has. Fall back to .default when the duration or
+                // distance is non-positive (avoids divide-by-zero / infinite velocity).
+                let distance = hypot(endX - startX, endY - startY)
+                let velocity: XCUIGestureVelocity = (dragDuration > 0 && distance > 0)
+                    ? XCUIGestureVelocity(distance / dragDuration)
+                    : .default
+
                 // Press, drag, and hold
                 startCoordinate.press(
                     forDuration: pressDuration,
                     thenDragTo: endCoordinate,
-                    withVelocity: .default,
+                    withVelocity: velocity,
                     thenHoldForDuration: holdDuration
                 )
             }

--- a/src/features/action/DragAndDrop.ts
+++ b/src/features/action/DragAndDrop.ts
@@ -272,13 +272,15 @@ export class DragAndDrop extends BaseVisualChange {
     observeResult: ObserveResult,
     signal?: AbortSignal
   ): Promise<ViewHierarchyResult | null> {
-    // Android: prefer a fresh hierarchy to avoid stale drag coordinates after navigation/scrolling.
-    // iOS has no Android accessibility-service refresh; rely on the already-observed hierarchy.
-    if (this.device.platform === "android") {
-      const refreshed = await this.refreshViewHierarchy(signal);
-      if (refreshed && !refreshed.hierarchy?.error) {
-        return refreshed;
-      }
+    // Prefer a freshly-captured hierarchy on both platforms so drag endpoints are not
+    // resolved against stale coordinates after the UI navigated/scrolled since the last
+    // observe. Android refreshes via the accessibility service; iOS via the XCUITest
+    // CtrlProxy runner's hierarchy snapshot.
+    const refreshed = this.device.platform === "ios"
+      ? await this.refreshIosViewHierarchy()
+      : await this.refreshViewHierarchy(signal);
+    if (refreshed && !refreshed.hierarchy?.error) {
+      return refreshed;
     }
 
     if (observeResult.viewHierarchy && !observeResult.viewHierarchy.hierarchy?.error) {
@@ -286,6 +288,18 @@ export class DragAndDrop extends BaseVisualChange {
     }
 
     return null;
+  }
+
+  private async refreshIosViewHierarchy(): Promise<ViewHierarchyResult | null> {
+    // skipWaitForFresh=false forces the runner to return a current snapshot when the
+    // cached hierarchy is stale, instead of resolving against the (possibly old) observe
+    // cache. Mirrors how the iOS observe path sources its hierarchy.
+    return IOSCtrlProxyClient.getInstance(this.device).getAccessibilityHierarchy(
+      undefined,
+      undefined,
+      false,
+      0
+    );
   }
 
   private async refreshViewHierarchy(signal?: AbortSignal): Promise<ViewHierarchyResult | null> {

--- a/src/features/action/DragAndDrop.ts
+++ b/src/features/action/DragAndDrop.ts
@@ -12,6 +12,7 @@ import type { ElementGeometry } from "../../utils/interfaces/ElementGeometry";
 import { DefaultElementFinder } from "../utility/ElementFinder";
 import { DefaultElementGeometry } from "../utility/ElementGeometry";
 import { AndroidCtrlProxyClient } from "../observe/android";
+import { IOSCtrlProxyClient } from "../observe/ios";
 import { createGlobalPerformanceTracker } from "../../utils/PerformanceTracker";
 import { throwIfAborted } from "../../utils/toolUtils";
 import { AndroidCtrlProxyManager } from "../../utils/CtrlProxyManager";
@@ -70,28 +71,33 @@ export class DragAndDrop extends BaseVisualChange {
     progress?: ProgressCallback,
     signal?: AbortSignal
   ): Promise<DragAndDropResult> {
-    if (this.device.platform === "ios") {
-      return {
-        success: false,
-        duration: 0,
-        distance: 0,
-        error: "dragAndDrop is not supported on iOS yet"
-      };
-    }
-
     const perf = createGlobalPerformanceTracker();
     perf.serial("dragAndDrop");
 
-    const a11yManager = AndroidCtrlProxyManager.getInstance(this.device, this.adb);
-    const isAvailable = await perf.track("a11yAvailable", () => a11yManager.isAvailable());
-    if (!isAvailable) {
+    if (this.device.platform !== "android" && this.device.platform !== "ios") {
       perf.end();
       return {
         success: false,
         duration: 0,
         distance: 0,
-        error: "dragAndDrop requires the Android accessibility service to be installed and enabled."
+        error: `dragAndDrop is not supported on ${this.device.platform}`
       };
+    }
+
+    // The Android accessibility service is only required for the Android gesture path.
+    // iOS dispatches the drag through the XCUITest CtrlProxy runner (no a11y service).
+    if (this.device.platform === "android") {
+      const a11yManager = AndroidCtrlProxyManager.getInstance(this.device, this.adb);
+      const isAvailable = await perf.track("a11yAvailable", () => a11yManager.isAvailable());
+      if (!isAvailable) {
+        perf.end();
+        return {
+          success: false,
+          duration: 0,
+          distance: 0,
+          error: "dragAndDrop requires the Android accessibility service to be installed and enabled."
+        };
+      }
     }
 
     const validationError = this.validateOptions(options);
@@ -123,7 +129,7 @@ export class DragAndDrop extends BaseVisualChange {
           const sourcePoint = this.geometry.getElementCenter(source);
           const targetPoint = this.geometry.getElementCenter(target);
 
-          const dragResult = await this.executeAndroidDrag(
+          const dragResult = await this.executeDrag(
             sourcePoint.x,
             sourcePoint.y,
             targetPoint.x,
@@ -266,10 +272,13 @@ export class DragAndDrop extends BaseVisualChange {
     observeResult: ObserveResult,
     signal?: AbortSignal
   ): Promise<ViewHierarchyResult | null> {
-    // Prefer a fresh hierarchy to avoid stale drag coordinates after navigation/scrolling.
-    const refreshed = await this.refreshViewHierarchy(signal);
-    if (refreshed && !refreshed.hierarchy?.error) {
-      return refreshed;
+    // Android: prefer a fresh hierarchy to avoid stale drag coordinates after navigation/scrolling.
+    // iOS has no Android accessibility-service refresh; rely on the already-observed hierarchy.
+    if (this.device.platform === "android") {
+      const refreshed = await this.refreshViewHierarchy(signal);
+      if (refreshed && !refreshed.hierarchy?.error) {
+        return refreshed;
+      }
     }
 
     if (observeResult.viewHierarchy && !observeResult.viewHierarchy.hierarchy?.error) {
@@ -339,7 +348,7 @@ export class DragAndDrop extends BaseVisualChange {
     return pressDurationMs + dragDurationMs + holdDurationMs + DROP_DURATION_MS + DRAG_TIMEOUT_BUFFER_MS;
   }
 
-  private async executeAndroidDrag(
+  private async executeDrag(
     startX: number,
     startY: number,
     endX: number,
@@ -356,16 +365,18 @@ export class DragAndDrop extends BaseVisualChange {
   }> {
     throwIfAborted(signal);
 
-    const result = await this.accessibilityService.requestDrag(
-      startX,
-      startY,
-      endX,
-      endY,
-      pressDurationMs,
-      dragDurationMs,
-      holdDurationMs,
-      this.getDragTimeoutMs(pressDurationMs, dragDurationMs, holdDurationMs)
-    );
+    const timeoutMs = this.getDragTimeoutMs(pressDurationMs, dragDurationMs, holdDurationMs);
+
+    // Both clients expose requestDrag with an identical signature/return shape. iOS routes
+    // through the XCUITest CtrlProxy runner (XCUICoordinate.press/thenDragTo/thenHold);
+    // Android through the accessibility service. iOS preserves exact (non-rounded) coordinates.
+    const result = this.device.platform === "ios"
+      ? await IOSCtrlProxyClient.getInstance(this.device).requestDrag(
+        startX, startY, endX, endY, pressDurationMs, dragDurationMs, holdDurationMs, timeoutMs
+      )
+      : await this.accessibilityService.requestDrag(
+        startX, startY, endX, endY, pressDurationMs, dragDurationMs, holdDurationMs, timeoutMs
+      );
 
     if (result.success) {
       return {
@@ -377,7 +388,7 @@ export class DragAndDrop extends BaseVisualChange {
 
     return {
       success: false,
-      error: result.error ?? "Drag failed via accessibility service"
+      error: result.error ?? "Drag failed via CtrlProxy"
     };
   }
 }

--- a/test/fakes/FakeCtrlProxy.ts
+++ b/test/fakes/FakeCtrlProxy.ts
@@ -111,6 +111,7 @@ export class FakeCtrlProxy implements AndroidCtrlProxy {
   private hierarchyRequestCount: number = 0;
   private dragResult: A11yDragResult | null = null;
   private pinchResult: A11yPinchResult | null = null;
+  private viewHierarchyResultOverride: ViewHierarchyResult | null = null;
 
   /**
    * Configure hierarchy data to be returned by getAccessibilityHierarchy
@@ -118,6 +119,16 @@ export class FakeCtrlProxy implements AndroidCtrlProxy {
    */
   setHierarchyData(hierarchy: AccessibilityHierarchy | null): void {
     this.hierarchyData = hierarchy;
+  }
+
+  /**
+   * Override the ViewHierarchyResult produced by convertToViewHierarchyResult
+   * (and therefore returned by getAccessibilityHierarchy / getLatestHierarchy).
+   * Lets tests assert against a realistic node tree instead of the default stub.
+   * @param result - The view hierarchy result to return, or null to restore default behavior
+   */
+  setViewHierarchyResult(result: ViewHierarchyResult | null): void {
+    this.viewHierarchyResultOverride = result;
   }
 
   /**
@@ -418,6 +429,9 @@ export class FakeCtrlProxy implements AndroidCtrlProxy {
   }
 
   convertToViewHierarchyResult(accessibilityHierarchy: AccessibilityHierarchy): ViewHierarchyResult {
+    if (this.viewHierarchyResultOverride) {
+      return this.viewHierarchyResultOverride;
+    }
     // Simple conversion - just wrap the hierarchy
     return {
       hierarchy: {

--- a/test/features/action/DragAndDropIos.test.ts
+++ b/test/features/action/DragAndDropIos.test.ts
@@ -129,4 +129,80 @@ describe("DragAndDrop - iOS", () => {
     expect(result.success).toBe(false);
     expect(result.error).toBe("Drag failed on runner");
   });
+
+  test("refreshes the iOS hierarchy before resolving drag targets", async () => {
+    fakeIosClient.setDragResult({ success: true, totalTimeMs: 1, gestureTimeMs: 1 });
+
+    await dragAndDrop.execute({
+      source: { elementId: "source-id" },
+      target: { elementId: "target-id" }
+    });
+
+    // iOS forces a fresh runner snapshot; the Android service is never asked.
+    expect(fakeIosClient.getHierarchyRequestCount()).toBeGreaterThan(0);
+    expect(fakeAndroidClient.getHierarchyRequestCount()).toBe(0);
+  });
+
+  test("drags against the freshly-refreshed hierarchy, not the stale observe cache", async () => {
+    // The cached observe places the elements at (50,50)/(250,250); the fresh runner
+    // snapshot reports new coordinates after the UI scrolled. The drag must use the fresh ones.
+    fakeIosClient.setHierarchyData({ packageName: "com.test.app", updatedAt: Date.now() });
+    fakeIosClient.setViewHierarchyResult({
+      hierarchy: {
+        node: [
+          { $: { "resource-id": "source-id", "text": "Source", "bounds": { left: 450, top: 450, right: 550, bottom: 550 }, "class": "XCUIElementTypeCell" } },
+          { $: { "resource-id": "target-id", "text": "Target", "bounds": { left: 650, top: 650, right: 750, bottom: 750 }, "class": "XCUIElementTypeCell" } }
+        ]
+      },
+      packageName: "com.test.app",
+      updatedAt: Date.now()
+    });
+    fakeIosClient.setDragResult({ success: true, totalTimeMs: 1, gestureTimeMs: 1 });
+
+    const result = await dragAndDrop.execute({
+      source: { elementId: "source-id" },
+      target: { elementId: "target-id" }
+    });
+
+    expect(result.success).toBe(true);
+    const [iosDrag] = fakeIosClient.getDragHistory();
+    expect(iosDrag.x1).toBe(500);
+    expect(iosDrag.y1).toBe(500);
+    expect(iosDrag.x2).toBe(700);
+    expect(iosDrag.y2).toBe(700);
+    expect(result.distance).toBeCloseTo(Math.hypot(200, 200));
+  });
+
+  test("falls back to the observe cache when the iOS refresh returns nothing", async () => {
+    // No hierarchyData configured → the runner snapshot is null; the cached observe
+    // (source/target at (50,50)/(250,250)) must still resolve the drag endpoints.
+    fakeIosClient.setDragResult({ success: true, totalTimeMs: 1, gestureTimeMs: 1 });
+
+    const result = await dragAndDrop.execute({
+      source: { elementId: "source-id" },
+      target: { elementId: "target-id" }
+    });
+
+    expect(result.success).toBe(true);
+    const [iosDrag] = fakeIosClient.getDragHistory();
+    expect(iosDrag.x1).toBe(50);
+    expect(iosDrag.y1).toBe(50);
+    expect(iosDrag.x2).toBe(250);
+    expect(iosDrag.y2).toBe(250);
+  });
+
+  test("forwards a caller-supplied dragDurationMs to the iOS runner", async () => {
+    fakeIosClient.setDragResult({ success: true, totalTimeMs: 1, gestureTimeMs: 1 });
+
+    const result = await dragAndDrop.execute({
+      source: { elementId: "source-id" },
+      target: { elementId: "target-id" },
+      dragDurationMs: 800
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.duration).toBe(800);
+    const [iosDrag] = fakeIosClient.getDragHistory();
+    expect(iosDrag.dragDurationMs).toBe(800);
+  });
 });

--- a/test/features/action/DragAndDropIos.test.ts
+++ b/test/features/action/DragAndDropIos.test.ts
@@ -1,0 +1,132 @@
+import { afterEach, beforeEach, describe, expect, spyOn, test } from "bun:test";
+import type { BootedDevice, ObserveResult, ViewHierarchyResult } from "../../../src/models";
+import { DragAndDrop } from "../../../src/features/action/DragAndDrop";
+import { AndroidCtrlProxyClient } from "../../../src/features/observe/android";
+import { IOSCtrlProxyClient } from "../../../src/features/observe/ios";
+import { AndroidCtrlProxyManager } from "../../../src/utils/CtrlProxyManager";
+import { FakeCtrlProxy } from "../../fakes/FakeCtrlProxy";
+import { FakeObserveScreen } from "../../fakes/FakeObserveScreen";
+import { FakeWindow } from "../../fakes/FakeWindow";
+import { FakeAwaitIdle } from "../../fakes/FakeAwaitIdle";
+import { FakeTimer } from "../../fakes/FakeTimer";
+
+// Simulator-shaped UDID so isIosSimulatorUdid would pass (not that dragAndDrop branches on it,
+// but keeps the device realistic).
+const IOS_DEVICE: BootedDevice = {
+  deviceId: "11111111-2222-3333-4444-555555555555",
+  platform: "ios",
+  name: "iPhone 16 Pro"
+};
+
+describe("DragAndDrop - iOS", () => {
+  let dragAndDrop: DragAndDrop;
+  let fakeObserveScreen: FakeObserveScreen;
+  let fakeAwaitIdle: FakeAwaitIdle;
+  let fakeWindow: FakeWindow;
+  let fakeIosClient: FakeCtrlProxy;
+  let fakeAndroidClient: FakeCtrlProxy;
+  let fakeTimer: FakeTimer;
+  let iosSpy: ReturnType<typeof spyOn> | null = null;
+  let androidSpy: ReturnType<typeof spyOn> | null = null;
+  let managerSpy: ReturnType<typeof spyOn> | null = null;
+
+  const createHierarchy = (): ViewHierarchyResult => ({
+    hierarchy: {
+      node: [
+        { $: { "resource-id": "source-id", "text": "Source", "bounds": { left: 0, top: 0, right: 100, bottom: 100 }, "class": "XCUIElementTypeCell" } },
+        { $: { "resource-id": "target-id", "text": "Target", "bounds": { left: 200, top: 200, right: 300, bottom: 300 }, "class": "XCUIElementTypeCell" } }
+      ]
+    },
+    packageName: "com.test.app",
+    updatedAt: Date.now()
+  });
+
+  const createObserveResult = (): ObserveResult => ({
+    updatedAt: Date.now(),
+    screenSize: { width: 1170, height: 2532 },
+    systemInsets: { top: 0, right: 0, bottom: 0, left: 0 },
+    viewHierarchy: createHierarchy()
+  });
+
+  beforeEach(() => {
+    fakeObserveScreen = new FakeObserveScreen();
+    fakeAwaitIdle = new FakeAwaitIdle();
+    fakeWindow = new FakeWindow();
+    fakeIosClient = new FakeCtrlProxy();
+    fakeAndroidClient = new FakeCtrlProxy();
+    fakeTimer = new FakeTimer();
+    fakeTimer.enableAutoAdvance();
+
+    fakeObserveScreen.setObserveResult(() => createObserveResult());
+    fakeWindow.configureCachedActiveWindow(null);
+    fakeWindow.configureActiveWindow({ appId: "com.test.app", activityName: "Main", layoutSeqSum: 1 });
+
+    // If the Android availability guard ran on iOS, this would force failure — it must NOT run.
+    managerSpy = spyOn(AndroidCtrlProxyManager, "getInstance").mockReturnValue({
+      isAvailable: async () => false
+    } as any);
+    androidSpy = spyOn(AndroidCtrlProxyClient, "getInstance").mockReturnValue(fakeAndroidClient as any);
+    iosSpy = spyOn(IOSCtrlProxyClient, "getInstance").mockReturnValue(fakeIosClient as any);
+
+    dragAndDrop = new DragAndDrop(IOS_DEVICE, null, fakeTimer);
+    (dragAndDrop as any).observeScreen = fakeObserveScreen;
+    (dragAndDrop as any).awaitIdle = fakeAwaitIdle;
+    (dragAndDrop as any).window = fakeWindow;
+  });
+
+  afterEach(() => {
+    iosSpy?.mockRestore();
+    androidSpy?.mockRestore();
+    managerSpy?.mockRestore();
+  });
+
+  test("routes drag through the iOS CtrlProxy client (not the Android a11y service)", async () => {
+    fakeIosClient.setDragResult({ success: true, totalTimeMs: 410, gestureTimeMs: 300 });
+
+    const result = await dragAndDrop.execute({
+      source: { elementId: "source-id" },
+      target: { elementId: "target-id" },
+      pressDurationMs: 600,
+      dragDurationMs: 500,
+      holdDurationMs: 200
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.distance).toBeCloseTo(Math.hypot(200, 200));
+    expect(result.a11yTotalTimeMs).toBe(410);
+
+    // iOS client received the drag with resolved element centers; Android client did not.
+    const [iosDrag] = fakeIosClient.getDragHistory();
+    expect(iosDrag).toBeDefined();
+    expect(iosDrag.x1).toBe(50);
+    expect(iosDrag.y1).toBe(50);
+    expect(iosDrag.x2).toBe(250);
+    expect(iosDrag.y2).toBe(250);
+    expect(fakeAndroidClient.getDragHistory()).toHaveLength(0);
+  });
+
+  test("does not require the Android accessibility service on iOS", async () => {
+    // AndroidCtrlProxyManager.isAvailable() returns false above; the iOS path must ignore it.
+    fakeIosClient.setDragResult({ success: true, totalTimeMs: 1, gestureTimeMs: 1 });
+
+    const result = await dragAndDrop.execute({
+      source: { elementId: "source-id" },
+      target: { elementId: "target-id" }
+    });
+
+    expect(result.success).toBe(true);
+    expect(fakeIosClient.getDragHistory()).toHaveLength(1);
+  });
+
+  test("surfaces iOS runner failure", async () => {
+    fakeIosClient.setDragResult({ success: false, error: "Drag failed on runner" });
+
+    const result = await dragAndDrop.execute({
+      source: { elementId: "source-id" },
+      target: { elementId: "target-id" }
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBe("Drag failed on runner");
+  });
+});


### PR DESCRIPTION
Closes #2481.

Routes `dragAndDrop` on iOS through the existing `IOSCtrlProxyClient.requestDrag()` path (`XCUICoordinate.press(forDuration:thenDragTo:withVelocity:thenHoldForDuration:)`) — the same runner stack that already ships for `swipeOn`.

## What
- Remove the `"not supported on iOS yet"` short-circuit in `DragAndDrop.execute()`.
- Gate the Android accessibility-service availability guard and the Android hierarchy refresh to `platform === "android"`.
- Branch only the final gesture dispatch (`executeDrag`): iOS → `IOSCtrlProxyClient.requestDrag`, Android → accessibility service. Identical signature/return; iOS keeps exact (non-rounded) coordinates.
- Element resolution, validation, observation, and distance math stay shared.

## Validation
- `bun test` — 6 passing (new `DragAndDropIos` routing tests assert iOS client receives resolved element centers, Android client is not called, the Android a11y guard is skipped on iOS, and runner failures surface; existing Android `DragAndDrop` tests unchanged).
- `tsc --noEmit` clean on changed files; `eslint --fix` clean.
- CtrlProxy iOS runner **builds** (`ctrl-proxy-build-for-testing.sh`, exit 0) in this environment.

## Caveat (documented)
On the Simulator the post-drop `thenHoldForDuration:` hold may be a no-op; press and drag are reliable. Hold-dependent flows should be verified on a physical device.

## Docs
`plat/ios/ctrl-proxy-ios.md` — new "Gestures" section + Responsibilities bullet.

Part of milestone **iOS/Android tool parity**.