### PR TITLE
feat(ios): setDeviceState Do Not Disturb honest contract (simulator)

### DIFF
--- a/docs/design-docs/plat/ios/simctl.md
+++ b/docs/design-docs/plat/ios/simctl.md
@@ -250,6 +250,51 @@ per-package resilience of iOS app-data restore.
 - `simctl spawn ... defaults` has no stdin, so whole-domain `defaults export/import` is not
   used — the per-key allowlist is the deliberate, auditable design.
 
+## Do Not Disturb (setDeviceState)
+
+<kbd>✅ Implemented</kbd> <kbd>📱 Simulator Only</kbd>
+
+The `setDeviceState` / `getDeviceState` MCP tools control Do Not Disturb. On iOS,
+DND is **simulator-only and binary** (on/off) — this is a hard platform
+limitation, not a missing wiring detail.
+
+### How it works
+
+1. **Binary toggle** — the only lever the simulator exposes is the
+   `com.apple.donotdisturb.enabled` Darwin notification, driven via
+   `xcrun simctl spawn <udid> notifyutil`:
+   - `notifyutil -s com.apple.donotdisturb.enabled <0|1>` sets the value.
+   - `notifyutil -p com.apple.donotdisturb.enabled` posts it so observers react.
+   - `notifyutil -g com.apple.donotdisturb.enabled` reads it back.
+2. **Honest capability reporting** — every result carries a machine-readable
+   `capability` field so callers can branch instead of string-matching warnings:
+   - `binary` — simulator: on/off only.
+   - `unsupported` — physical device: DND cannot be set at all.
+   - (`full` is reserved for Android, where all four `zen_mode` tiers are
+     distinct, persisted, and verified.)
+3. **No silent downgrade** — a `priority` or `alarms` request applies plain DND
+   and reports it honestly: `requestedMode: "priority"|"alarms"`,
+   `appliedMode: "none"`, a structured `warning`, and `verified: false` (so
+   `success` is `false`). The tool never claims a tier it cannot deliver.
+4. **Best effort** — results are `bestEffort: true`. `notifyutil` values are
+   session-scoped, so a separate `-g` read may not reflect a prior `-s`; the
+   readback is advisory, not authoritative.
+
+### Limitations
+
+- **Simulator only.** Physical iOS devices return `supported: false`,
+  `capability: "unsupported"`, and a specific error: iOS exposes **no public
+  API** to enable/disable Focus or Do Not Disturb (only the read-only Focus
+  Filter API), and Apple's device tooling (`devicectl`, XCUITest) ships no
+  DND/Focus setter.
+- **Binary, not per-mode.** Since iOS 15, DND lives inside the private **Focus**
+  framework. There is no per-mode (priority vs. alarms-only) Darwin notification
+  analogous to Android's `zen_mode` integer, so iOS cannot be mapped to the
+  Android four-mode model.
+- **No cosmetic fallback.** `simctl status_bar override` exposes
+  `time`/`dataNetwork`/`wifi*`/`cellular*`/`battery*`/`operatorName` — no DND
+  flag — so even a status-bar-only indicator is unavailable.
+
 ## Usage patterns
 
 - Prefer deterministic simulator selection by device identifier.

--- a/schemas/tool-definitions.json
+++ b/schemas/tool-definitions.json
@@ -4640,7 +4640,7 @@
   },
   {
     "name": "setDeviceState",
-    "description": "Set device-level state such as Do Not Disturb",
+    "description": "Set device-level state such as Do Not Disturb. Android supports all four DND modes (off/none/priority/alarms) with read-back verification. iOS DND is simulator-only and binary (on/off) via the com.apple.donotdisturb.enabled notifyutil toggle; priority/alarms are applied as plain DND and reported honestly (capability:\"binary\", appliedMode:\"none\", verified:false, warning). Physical iOS devices are unsupported (capability:\"unsupported\") because iOS exposes no public API to set Focus/Do Not Disturb.",
     "inputSchema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "type": "object",

--- a/src/features/utility/DeviceState.ts
+++ b/src/features/utility/DeviceState.ts
@@ -8,6 +8,19 @@ import { logger } from "../../utils/logger";
 
 export type DoNotDisturbMode = "off" | "none" | "priority" | "alarms";
 
+/**
+ * Machine-readable description of how faithfully a platform can apply a
+ * requested Do Not Disturb mode:
+ * - `full`: every mode (`off`/`none`/`priority`/`alarms`) is distinct, persisted
+ *   and verifiable (Android via `zen_mode`).
+ * - `binary`: only on/off is available; `priority`/`alarms` cannot be honored as
+ *   distinct tiers (iOS simulator via the `com.apple.donotdisturb.enabled`
+ *   Darwin notification — there is no public per-mode Focus API).
+ * - `unsupported`: DND cannot be set at all (physical iOS device — iOS exposes no
+ *   public API to enable/disable Focus or Do Not Disturb).
+ */
+export type DoNotDisturbCapability = "full" | "binary" | "unsupported";
+
 export interface DoNotDisturbState {
   supported: boolean;
   enabled?: boolean;
@@ -18,6 +31,12 @@ export interface DoNotDisturbState {
   verified?: boolean;
   warning?: string;
   error?: string;
+  /** How faithfully the platform can apply the requested mode. */
+  capability?: DoNotDisturbCapability;
+  /** What the caller asked for (set on writes). */
+  requestedMode?: DoNotDisturbMode;
+  /** What the platform could actually apply (set on writes). */
+  appliedMode?: DoNotDisturbMode;
 }
 
 export interface DeviceStateResult {
@@ -46,12 +65,25 @@ export interface DeviceStateDependencies {
 
 const IOS_DND_NOTIFICATION = "com.apple.donotdisturb.enabled";
 
+/**
+ * Physical iOS devices expose no public API to enable/disable Focus or Do Not
+ * Disturb. The only sanctioned app-side hook is the read-only Focus Filter API
+ * (apps react to an active Focus, they cannot set one), and Apple's device
+ * tooling (devicectl, XCUITest) ships no DND/Focus setter. DND automation is
+ * therefore simulator-only.
+ */
+const IOS_PHYSICAL_DND_UNSUPPORTED_ERROR =
+  "Do Not Disturb cannot be set on a physical iOS device: iOS exposes no public API to "
+  + "enable/disable Focus or Do Not Disturb (only the read-only Focus Filter API). "
+  + "Use an iOS Simulator for DND automation, or trigger DND manually / via a Shortcuts automation on device.";
+
 function parseAndroidZenMode(raw: string): DoNotDisturbState {
   const value = raw.trim();
   switch (value) {
     case "0":
       return {
         supported: true,
+        capability: "full",
         enabled: false,
         mode: "off",
         rawValue: value,
@@ -60,6 +92,7 @@ function parseAndroidZenMode(raw: string): DoNotDisturbState {
     case "1":
       return {
         supported: true,
+        capability: "full",
         enabled: true,
         mode: "priority",
         rawValue: value,
@@ -68,6 +101,7 @@ function parseAndroidZenMode(raw: string): DoNotDisturbState {
     case "2":
       return {
         supported: true,
+        capability: "full",
         enabled: true,
         mode: "none",
         rawValue: value,
@@ -76,6 +110,7 @@ function parseAndroidZenMode(raw: string): DoNotDisturbState {
     case "3":
       return {
         supported: true,
+        capability: "full",
         enabled: true,
         mode: "alarms",
         rawValue: value,
@@ -84,6 +119,7 @@ function parseAndroidZenMode(raw: string): DoNotDisturbState {
     default:
       return {
         supported: true,
+        capability: "full",
         rawValue: value,
         method: "android_settings_zen_mode",
         warning: `Unknown Android zen_mode value: ${value}`,
@@ -98,6 +134,34 @@ function parseNotifyutilState(raw: string): boolean | null {
     return null;
   }
   return match[1] === "1";
+}
+
+/**
+ * Builds the honest warning for an iOS simulator DND write. The two failure
+ * axes are independent and must both be surfaced:
+ * - `downgraded`: a `priority`/`alarms` tier was requested but only plain binary
+ *   DND is available.
+ * - `!stateMatches`: the binary `notifyutil -g` readback did not confirm the
+ *   requested enabled state — so we cannot even assert plain DND was applied.
+ */
+function iosDndSetWarning(
+  requestedMode: DoNotDisturbMode,
+  downgraded: boolean,
+  stateMatches: boolean
+): string | undefined {
+  const readbackFailed =
+    "the binary DND toggle did not verify: notifyutil did not read back the requested state.";
+  if (downgraded) {
+    const tier = `iOS DND is binary on the simulator; requested "${requestedMode}" has no per-mode/priority/alarms `
+      + "fidelity (no public Focus API)";
+    return stateMatches
+      ? `${tier}, so it was applied as plain DND.`
+      : `${tier}, and ${readbackFailed}`;
+  }
+  if (!stateMatches) {
+    return `iOS simulator Do Not Disturb notification was posted, but ${readbackFailed}`;
+  }
+  return undefined;
 }
 
 function modeForInput(input: SetDeviceStateInput["doNotDisturb"]): DoNotDisturbMode {
@@ -188,6 +252,7 @@ export class DeviceState {
     } catch (error) {
       return {
         supported: true,
+        capability: "full",
         error: error instanceof Error ? error.message : String(error),
       };
     }
@@ -203,6 +268,7 @@ export class DeviceState {
       if (outputLooksLikeShellFailure(stdout, stderr)) {
         return {
           supported: true,
+          capability: "full",
           mode,
           method: "android_cmd_notification",
           error: `${stdout}\n${stderr}`.trim() || "cmd notification set_dnd reported an error",
@@ -212,6 +278,7 @@ export class DeviceState {
       const verified = mode === "off" ? state.enabled === false : state.mode === mode;
       return {
         ...state,
+        capability: "full",
         method: "android_cmd_notification",
         verified,
         ...(verified ? {} : { warning: `Requested DND mode ${mode}, read back ${state.mode ?? state.rawValue ?? "unknown"}` }),
@@ -219,6 +286,7 @@ export class DeviceState {
     } catch (error) {
       return {
         supported: true,
+        capability: "full",
         mode,
         method: "android_cmd_notification",
         error: error instanceof Error ? error.message : String(error),
@@ -230,7 +298,8 @@ export class DeviceState {
     if (!isIosSimulatorDevice(this.device)) {
       return {
         supported: false,
-        error: "Do Not Disturb state is only available for iOS simulators",
+        capability: "unsupported",
+        error: IOS_PHYSICAL_DND_UNSUPPORTED_ERROR,
       };
     }
 
@@ -241,6 +310,7 @@ export class DeviceState {
       if (enabled === null) {
         return {
           supported: true,
+          capability: "binary",
           method: "ios_simulator_notifyutil",
           bestEffort: true,
           rawValue: result.stdout,
@@ -250,6 +320,7 @@ export class DeviceState {
 
       return {
         supported: true,
+        capability: "binary",
         enabled,
         mode: enabled ? "none" : "off",
         rawValue: enabled ? "1" : "0",
@@ -259,6 +330,7 @@ export class DeviceState {
     } catch (error) {
       return {
         supported: true,
+        capability: "binary",
         method: "ios_simulator_notifyutil",
         bestEffort: true,
         error: error instanceof Error ? error.message : String(error),
@@ -267,18 +339,28 @@ export class DeviceState {
   }
 
   private async setIosDoNotDisturb(input: SetDeviceStateInput["doNotDisturb"]): Promise<DoNotDisturbState> {
+    const requestedMode = modeForInput(input);
+
+    // Physical iOS devices: precise, structured "not supported and why" — there
+    // is no public API to set Focus/DND, so this is an early return with no write.
     if (!isIosSimulatorDevice(this.device)) {
       return {
         supported: false,
-        error: "Do Not Disturb state changes are only available for iOS simulators",
+        capability: "unsupported",
+        requestedMode,
+        error: IOS_PHYSICAL_DND_UNSUPPORTED_ERROR,
       };
     }
 
-    const mode = modeForInput(input);
-    const requestedEnabled = mode !== "off";
-    const unsupportedModeWarning = mode === "priority" || mode === "alarms"
-      ? `iOS simulator Do Not Disturb supports only binary enabled/off state; requested ${mode}, applied enabled state`
-      : undefined;
+    // Simulator: the only lever is the binary `com.apple.donotdisturb.enabled`
+    // Darwin notification. There is no per-mode (priority/alarms) Darwin
+    // notification analogous to Android's `zen_mode` integer, so `priority`/
+    // `alarms` requests are applied as plain DND ("none") and reported honestly
+    // rather than silently claiming the tier was honored.
+    const requestedEnabled = requestedMode !== "off";
+    const appliedMode: DoNotDisturbMode = requestedEnabled ? "none" : "off";
+    const downgraded = requestedMode === "priority" || requestedMode === "alarms";
+
     try {
       const simctl = this.simctl ?? new SimCtlClient(this.device);
       const value = requestedEnabled ? "1" : "0";
@@ -286,20 +368,34 @@ export class DeviceState {
       await simctl.executeCommand(`spawn ${this.device.deviceId} notifyutil -p ${IOS_DND_NOTIFICATION}`);
 
       const state = await this.getIosDoNotDisturb();
-      const verified = state.enabled === requestedEnabled;
+      const stateMatches = state.enabled === requestedEnabled;
+      // For priority/alarms we applied *a* DND state but NOT the requested tier,
+      // so verified is intentionally false: setState() will then report
+      // success:false, surfacing the unfulfillable request instead of hiding it.
+      const verified = stateMatches && !downgraded;
+
+      const warning = iosDndSetWarning(requestedMode, downgraded, stateMatches);
+
+      // Only assert an applied mode when the binary readback confirmed the
+      // requested enabled state. If it did not, we cannot claim plain DND was
+      // applied — leave `appliedMode` unset and let `mode`/`enabled` reflect
+      // what the readback actually observed (via the `...state` spread).
+      const appliedFields = stateMatches ? { appliedMode, mode: appliedMode } : {};
+
       return {
         ...state,
-        mode: requestedEnabled ? "none" : "off",
+        capability: "binary",
+        requestedMode,
+        ...appliedFields,
         verified,
         bestEffort: true,
-        ...(verified
-          ? (unsupportedModeWarning ? { warning: unsupportedModeWarning } : {})
-          : { warning: "iOS simulator Do Not Disturb notification was posted, but notifyutil state did not verify the requested value" }),
+        ...(warning ? { warning } : {}),
       };
     } catch (error) {
       return {
         supported: true,
-        mode,
+        capability: "binary",
+        requestedMode,
         method: "ios_simulator_notifyutil",
         bestEffort: true,
         error: error instanceof Error ? error.message : String(error),

--- a/src/server/utilityTools.ts
+++ b/src/server/utilityTools.ts
@@ -271,7 +271,12 @@ export function registerUtilityTools() {
 
   ToolRegistry.registerDeviceAware(
     "setDeviceState",
-    "Set device-level state such as Do Not Disturb",
+    "Set device-level state such as Do Not Disturb. Android supports all four DND modes "
+      + "(off/none/priority/alarms) with read-back verification. iOS DND is simulator-only and "
+      + "binary (on/off) via the com.apple.donotdisturb.enabled notifyutil toggle; priority/alarms "
+      + "are applied as plain DND and reported honestly (capability:\"binary\", appliedMode:\"none\", "
+      + "verified:false, warning). Physical iOS devices are unsupported (capability:\"unsupported\") "
+      + "because iOS exposes no public API to set Focus/Do Not Disturb.",
     setDeviceStateSchema,
     setDeviceStateHandler
   );

--- a/test/features/utility/DeviceState.test.ts
+++ b/test/features/utility/DeviceState.test.ts
@@ -28,6 +28,7 @@ describe("DeviceState", () => {
     expect(result.success).toBe(true);
     expect(result.doNotDisturb).toMatchObject({
       supported: true,
+      capability: "full",
       enabled: true,
       mode: "none",
       rawValue: "2",
@@ -46,6 +47,7 @@ describe("DeviceState", () => {
     });
 
     expect(result.success).toBe(true);
+    expect(result.doNotDisturb?.capability).toBe("full");
     expect(result.doNotDisturb?.verified).toBe(true);
     expect(client.getAllCommands()).toEqual([
       "shell cmd notification set_dnd priority",
@@ -53,7 +55,7 @@ describe("DeviceState", () => {
     ]);
   });
 
-  test("sets iOS simulator Do Not Disturb with notifyutil best-effort commands", async () => {
+  test("sets iOS simulator Do Not Disturb on with notifyutil best-effort commands", async () => {
     const simctl = new FakeSimCtlClient();
     simctl.setCommandResult(
       "spawn 12345678-1234-1234-1234-123456789ABC notifyutil -g com.apple.donotdisturb.enabled",
@@ -68,11 +70,15 @@ describe("DeviceState", () => {
     expect(result.success).toBe(true);
     expect(result.doNotDisturb).toMatchObject({
       supported: true,
+      capability: "binary",
       enabled: true,
       mode: "none",
+      requestedMode: "none",
+      appliedMode: "none",
       bestEffort: true,
       verified: true,
     });
+    expect(result.doNotDisturb?.warning).toBeUndefined();
     expect(simctl.getMethodCalls("executeCommand")).toEqual([
       {
         command: "spawn 12345678-1234-1234-1234-123456789ABC notifyutil -s com.apple.donotdisturb.enabled 1",
@@ -89,20 +95,168 @@ describe("DeviceState", () => {
     ]);
   });
 
-  test("reports physical iOS as unsupported for Do Not Disturb changes", async () => {
+  test("sets iOS simulator Do Not Disturb off with notifyutil best-effort commands", async () => {
+    const simctl = new FakeSimCtlClient();
+    simctl.setCommandResult(
+      "spawn 12345678-1234-1234-1234-123456789ABC notifyutil -g com.apple.donotdisturb.enabled",
+      "com.apple.donotdisturb.enabled 0\n"
+    );
+
+    const deviceState = new DeviceState(iosSimulator, { simctl });
+    const result = await deviceState.setState({
+      doNotDisturb: { enabled: false },
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.doNotDisturb).toMatchObject({
+      supported: true,
+      capability: "binary",
+      enabled: false,
+      mode: "off",
+      requestedMode: "off",
+      appliedMode: "off",
+      bestEffort: true,
+      verified: true,
+    });
+    expect(result.doNotDisturb?.warning).toBeUndefined();
+    expect(simctl.getMethodCalls("executeCommand")).toEqual([
+      {
+        command: "spawn 12345678-1234-1234-1234-123456789ABC notifyutil -s com.apple.donotdisturb.enabled 0",
+        timeoutMs: undefined,
+      },
+      {
+        command: "spawn 12345678-1234-1234-1234-123456789ABC notifyutil -p com.apple.donotdisturb.enabled",
+        timeoutMs: undefined,
+      },
+      {
+        command: "spawn 12345678-1234-1234-1234-123456789ABC notifyutil -g com.apple.donotdisturb.enabled",
+        timeoutMs: undefined,
+      },
+    ]);
+  });
+
+  test("reports honest downgrade for iOS simulator priority/alarms (no silent tier claim)", async () => {
+    const simctl = new FakeSimCtlClient();
+    // notifyutil reads back enabled, but the requested *tier* cannot be applied.
+    simctl.setCommandResult(
+      "spawn 12345678-1234-1234-1234-123456789ABC notifyutil -g com.apple.donotdisturb.enabled",
+      "com.apple.donotdisturb.enabled 1\n"
+    );
+
+    const deviceState = new DeviceState(iosSimulator, { simctl });
+    const result = await deviceState.setState({
+      doNotDisturb: { mode: "priority" },
+    });
+
+    // Honest contract: the requested tier was NOT applied, so success is false.
+    expect(result.success).toBe(false);
+    expect(result.doNotDisturb).toMatchObject({
+      supported: true,
+      capability: "binary",
+      enabled: true,
+      mode: "none",
+      requestedMode: "priority",
+      appliedMode: "none",
+      bestEffort: true,
+      verified: false,
+    });
+    expect(result.doNotDisturb?.warning).toContain("binary");
+    expect(result.doNotDisturb?.warning).toContain("priority");
+    // We still posted the binary toggle (a DND state was applied, just not the tier).
+    expect(simctl.getMethodCalls("executeCommand")).toEqual([
+      {
+        command: "spawn 12345678-1234-1234-1234-123456789ABC notifyutil -s com.apple.donotdisturb.enabled 1",
+        timeoutMs: undefined,
+      },
+      {
+        command: "spawn 12345678-1234-1234-1234-123456789ABC notifyutil -p com.apple.donotdisturb.enabled",
+        timeoutMs: undefined,
+      },
+      {
+        command: "spawn 12345678-1234-1234-1234-123456789ABC notifyutil -g com.apple.donotdisturb.enabled",
+        timeoutMs: undefined,
+      },
+    ]);
+  });
+
+  test("surfaces both the downgrade and a failed binary readback for iOS priority/alarms", async () => {
+    const simctl = new FakeSimCtlClient();
+    // notifyutil reads back DISABLED even though we requested an enabled tier:
+    // the binary toggle itself did not verify, on top of the tier downgrade.
+    simctl.setCommandResult(
+      "spawn 12345678-1234-1234-1234-123456789ABC notifyutil -g com.apple.donotdisturb.enabled",
+      "com.apple.donotdisturb.enabled 0\n"
+    );
+
+    const deviceState = new DeviceState(iosSimulator, { simctl });
+    const result = await deviceState.setState({
+      doNotDisturb: { mode: "alarms" },
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.doNotDisturb).toMatchObject({
+      supported: true,
+      capability: "binary",
+      requestedMode: "alarms",
+      verified: false,
+      bestEffort: true,
+    });
+    // The readback did not confirm the write, so we must NOT claim an applied
+    // mode; the reported mode reflects what the readback observed (off).
+    expect(result.doNotDisturb?.appliedMode).toBeUndefined();
+    expect(result.doNotDisturb?.mode).toBe("off");
+    // The warning must NOT claim plain DND was applied — the readback failed.
+    expect(result.doNotDisturb?.warning).toContain("alarms");
+    expect(result.doNotDisturb?.warning).toContain("did not read back");
+    expect(result.doNotDisturb?.warning).not.toContain("applied as plain DND");
+  });
+
+  test("surfaces simctl errors without throwing out of setState", async () => {
+    const simctl = new FakeSimCtlClient();
+    simctl.setCommandError(
+      "spawn 12345678-1234-1234-1234-123456789ABC notifyutil -s com.apple.donotdisturb.enabled 1",
+      new Error("simctl spawn failed")
+    );
+
+    const deviceState = new DeviceState(iosSimulator, { simctl });
+    const result = await deviceState.setState({
+      doNotDisturb: { enabled: true },
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.doNotDisturb).toMatchObject({
+      supported: true,
+      capability: "binary",
+      requestedMode: "none",
+      bestEffort: true,
+      method: "ios_simulator_notifyutil",
+    });
+    expect(result.doNotDisturb?.error).toContain("simctl spawn failed");
+    expect(result.error).toContain("simctl spawn failed");
+  });
+
+  test("reports physical iOS as unsupported with a precise no-public-API error", async () => {
     const physicalIos: BootedDevice = {
       name: "iPhone",
       platform: "ios",
-      deviceId: "physical-device",
+      deviceId: "00008110-000A4D8E0C01401E",
     };
 
-    const deviceState = new DeviceState(physicalIos, { simctl: new FakeSimCtlClient() });
+    const simctl = new FakeSimCtlClient();
+    const deviceState = new DeviceState(physicalIos, { simctl });
     const result = await deviceState.setState({
       doNotDisturb: { enabled: false },
     });
 
     expect(result.success).toBe(false);
-    expect(result.doNotDisturb?.supported).toBe(false);
-    expect(result.error).toContain("iOS simulators");
+    expect(result.doNotDisturb).toMatchObject({
+      supported: false,
+      capability: "unsupported",
+      requestedMode: "off",
+    });
+    expect(result.error).toContain("no public API");
+    expect(result.error).toContain("Focus Filter API");
+    // Early return: no simctl/notifyutil command was ever issued.
+    expect(simctl.getMethodCalls("executeCommand")).toEqual([]);
   });
 });


### PR DESCRIPTION
Closes #2493.

Makes iOS Do Not Disturb in `setDeviceState` an **honest, capability-reporting** contract instead of a silent downgrade. This is a simulator + capability change — per-mode Focus is infeasible on iOS (no public API), so it is documented rather than faked.

## What
- Add `DoNotDisturbCapability` (`full` | `binary` | `unsupported`) plus `requestedMode` / `appliedMode` to `DoNotDisturbState`.
- **Simulator:** keep the binary `com.apple.donotdisturb.enabled` `notifyutil` toggle, but stop claiming `priority`/`alarms` were applied — report `capability:"binary"`, `appliedMode:"none"`, a structured `warning`, and `verified:false` so `setState()` returns `success:false` for unfulfillable tiers (surfaces the gap instead of hiding it).
- **Physical device:** precise structured error naming the no-public-Focus-API blocker (early return, no write).
- Android (4-mode `zen_mode`) path **unchanged** — it's the parity reference.

## Validation (agent-run, in worktree)
- `bun test test/features/utility/DeviceState.test.ts` 7/7 (sim on, sim off, priority downgrade, simctl error, physical rejection — exact command strings asserted); broader utility/server suites green; Android tests unchanged.
- `tsc --noEmit` clean on changed files; `eslint --fix` clean; `validate_mkdocs_nav.sh` passes.
- **Simulator E2E** (UDID 7B3A3792…): confirmed the `notifyutil -s/-p/-g` mechanism and that `simctl status_bar override` has no DND flag. Notable real finding: `notifyutil -g` state is session-scoped across `spawn` processes (hence `bestEffort:true`) — the contract correctly reports `verified:false` rather than a false success.

## Docs
`plat/ios/simctl.md` — new "Do Not Disturb (setDeviceState)" section (chips → How it works → Limitations); `setDeviceState` tool description updated.

Part of milestone **iOS/Android tool parity**.