### PR TITLE
feat(android): accessibilityFocus — set/clear TalkBack cursor focus

### DIFF
--- a/docs/design-docs/mcp/a11y/index.md
+++ b/docs/design-docs/mcp/a11y/index.md
@@ -61,6 +61,7 @@ flowchart LR
 | Document | Description |
 |----------|-------------|
 | [TalkBack/VoiceOver Adaptation](talkback-voiceover.md) | Complete design for screen reader support |
+| [accessibilityFocus tool](../../plat/android/accessibility-focus.md) | Set/clear the Android TalkBack focus cursor on an element (Android only) |
 
 ## Platform Support
 

--- a/docs/design-docs/plat/android/accessibility-focus.md
+++ b/docs/design-docs/plat/android/accessibility-focus.md
@@ -1,0 +1,93 @@
+# accessibilityFocus
+
+<kbd>✅ Implemented</kbd> · <kbd>🧪 Tested</kbd> · <kbd>🤖 Android Only</kbd>
+
+> **Current state:** The `accessibilityFocus` MCP tool sets or clears the Android
+> TalkBack accessibility-focus cursor on a chosen element. iOS VoiceOver focus has no
+> backend wired, so the tool errors clearly on iOS rather than no-op'ing. See the
+> [Status Glossary](../../status-glossary.md) for chip definitions.
+
+For the overall accessibility adaptation design see
+[TalkBack/VoiceOver Adaptation](../../mcp/a11y/talkback-voiceover.md) and the
+[Accessibility overview](../../mcp/a11y/index.md). This document covers the
+explicit focus-control tool.
+
+## Goal
+
+Deliberately place or clear the **TalkBack accessibility-focus cursor** (the green
+focus rectangle, distinct from input focus) on a chosen element. This is the *write*
+counterpart to the already-shipping `requestCurrentFocus` / `requestTraversalOrder`
+read paths and is a building block for accessibility audits and deterministic
+TalkBack navigation.
+
+## MCP tool
+
+```typescript
+accessibilityFocus({
+  action?: "set" | "clear",   // defaults to "set"
+  resourceId?: string,        // e.g. "com.example:id/title"
+  text?: string,              // resolved to a resource-id via the element finder
+  contentDesc?: string        // resolved to a resource-id via the element finder
+})
+// → { success: boolean, focusedElement?: Element, error?: string }
+```
+
+Provide exactly one selector. `text` / `contentDesc` selectors are resolved to a
+`resource-id` against the current view hierarchy before the action is sent, because
+the accessibility service resolves nodes by `resource-id`. If the matched element has
+no `resource-id`, the tool returns a structured error.
+
+## How it works
+
+The CtrlProxy `AccessibilityService` already exposes both operations as named actions
+over the WebSocket `request_action` protocol
+(`android/control-proxy/.../CtrlProxy.kt`, `performNodeAction`):
+
+- `"focus"` → `AccessibilityNodeInfo.performAction(ACTION_ACCESSIBILITY_FOCUS)`
+- `"clear_focus"` → `AccessibilityNodeInfo.performAction(ACTION_CLEAR_ACCESSIBILITY_FOCUS)`
+
+The service resolves the node by `resource-id` (`findNodeByResourceId`) and broadcasts
+an `action_result`. The TypeScript path:
+
+1. `accessibilityFocus` tool (`src/server/accessibilityFocusTools.ts`) gates iOS and
+   delegates to the `SetAccessibilityFocus` feature.
+2. `SetAccessibilityFocus` (`src/features/accessibility/SetAccessibilityFocus.ts`)
+   resolves the selector to a `resource-id`, calls
+   `AndroidCtrlProxyClient.setAccessibilityFocus` / `clearAccessibilityFocus`, then
+   confirms the cursor moved via `requestCurrentFocus` (best-effort).
+3. `CtrlProxyFocus` (`src/features/observe/android/CtrlProxyFocus.ts`) sends
+   `{ type: "request_action", action: "focus" | "clear_focus", resourceId }` and awaits
+   the `action_result`.
+
+This mirrors the already-shipping focus-set in
+`ScrollUntilVisible.setAccessibilityFocusOnElement()`, which proves the path works
+end to end.
+
+## Platform support
+
+| Platform | Screen Reader | Status |
+|----------|---------------|--------|
+| Android | TalkBack | <kbd>✅ Implemented</kbd> |
+| iOS | VoiceOver | <kbd>❌ Not Implemented</kbd> — tool errors with an Android-only message |
+
+## Manual test plan
+
+Prereqs: an Android emulator/device with the AutoMobile CtrlProxy accessibility
+service installed and enabled, TalkBack on (so the cursor is observable), and a
+foreground app with at least two elements that have resource-ids.
+
+1. Find a target resource-id:
+   `adb shell uiautomator dump /sdcard/win.xml && adb pull /sdcard/win.xml -`
+2. Set focus by resource-id:
+   `{ "action": "set", "selector": { "resourceId": "com.example:id/title" } }` —
+   expect `{ "success": true, "focusedElement": { ... } }` and the green focus
+   rectangle on that element.
+3. Confirm via `observe` / `requestCurrentFocus` — `focusedElement` matches the target.
+4. Set focus by text (resolution path): `{ "action": "set", "text": "Settings" }`.
+5. Clear focus: `{ "action": "clear", "resourceId": "com.example:id/title" }` —
+   expect `{ "success": true }`; the focus rectangle disappears.
+6. Error path — bad id:
+   `{ "action": "set", "resourceId": "com.example:id/does_not_exist" }` — expect a
+   structured error `Element not found with resource-id: ...`.
+7. iOS gating — run against a booted simulator and expect an `ActionableError` stating
+   the tool is Android-only.

--- a/docs/design-docs/plat/android/talkback.md
+++ b/docs/design-docs/plat/android/talkback.md
@@ -2,7 +2,7 @@
 
 <kbd>❌ Not Implemented</kbd> *(MCP tools)* · <kbd>✅ Implemented</kbd> *(ADB commands, validated)*
 
-> **Current state:** The ADB commands for enabling/disabling real TalkBack are validated on API 35. The three proposed MCP tools (`setTalkBackEnabled`, `setA11yFocus`, `announce`) have **not been built** — they are design proposals. The AccessibilityService infrastructure needed by simulated mode is available.
+> **Current state:** The ADB commands for enabling/disabling real TalkBack are validated on API 35. Of the three proposed MCP tools, explicit focus control now ships as [`accessibilityFocus`](accessibility-focus.md) (set/clear the TalkBack cursor); `setTalkBackEnabled` and `announce` have **not been built**. The AccessibilityService infrastructure needed by simulated mode is available.
 >
 > See the [Status Glossary](../../status-glossary.md) for chip definitions.
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -154,6 +154,7 @@ nav:
             - 'Desktop App': design-docs/plat/android/desktop-app.md
             - 'Work Profiles': design-docs/plat/android/work-profiles.md
             - 'Device Tools':
+              - 'accessibilityFocus': design-docs/plat/android/accessibility-focus.md
               - 'takeScreenshot fallback': design-docs/plat/android/take-screenshot.md
               - 'Biometrics stubbing': design-docs/plat/android/biometrics.md
               - 'Notification triggering': design-docs/plat/android/notifications.md

--- a/schemas/tool-definitions.json
+++ b/schemas/tool-definitions.json
@@ -1,5 +1,280 @@
 [
   {
+    "name": "accessibilityFocus",
+    "description": "Set or clear the Android TalkBack accessibility-focus cursor on a target element (Android only). Provide one selector: resourceId, text, or contentDesc. action defaults to 'set'; pass 'clear' to clear the cursor.",
+    "inputSchema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "type": "object",
+      "properties": {
+        "action": {
+          "description": "Set (default) or clear the accessibility (TalkBack) focus cursor",
+          "type": "string",
+          "enum": [
+            "set",
+            "clear"
+          ]
+        },
+        "resourceId": {
+          "description": "Resource ID of the target element, e.g. com.example:id/title",
+          "type": "string"
+        },
+        "text": {
+          "description": "Text of the target element (resolved to a resource-id via the element finder)",
+          "type": "string"
+        },
+        "contentDesc": {
+          "description": "Content description of the target element (resolved to a resource-id)",
+          "type": "string"
+        },
+        "platform": {
+          "type": "string",
+          "enum": [
+            "android",
+            "ios"
+          ],
+          "description": "Target platform"
+        },
+        "sessionUuid": {
+          "description": "Session UUID",
+          "type": "string"
+        },
+        "keepScreenAwake": {
+          "description": "Keep device awake",
+          "type": "boolean"
+        },
+        "device": {
+          "description": "Device label for multi-device plans (e.g., \"A\", \"B\")",
+          "type": "string"
+        },
+        "deviceId": {
+          "description": "Device ID",
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
+    },
+    "outputSchema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "type": "object",
+      "properties": {
+        "success": {
+          "type": "boolean"
+        },
+        "error": {
+          "type": "string"
+        },
+        "warning": {
+          "type": "string"
+        },
+        "focusedElement": {
+          "type": "object",
+          "properties": {
+            "bounds": {
+              "type": "object",
+              "properties": {
+                "left": {
+                  "type": "integer",
+                  "minimum": -9007199254740991,
+                  "maximum": 9007199254740991
+                },
+                "top": {
+                  "type": "integer",
+                  "minimum": -9007199254740991,
+                  "maximum": 9007199254740991
+                },
+                "right": {
+                  "type": "integer",
+                  "minimum": -9007199254740991,
+                  "maximum": 9007199254740991
+                },
+                "bottom": {
+                  "type": "integer",
+                  "minimum": -9007199254740991,
+                  "maximum": 9007199254740991
+                },
+                "centerX": {
+                  "type": "integer",
+                  "minimum": -9007199254740991,
+                  "maximum": 9007199254740991
+                },
+                "centerY": {
+                  "type": "integer",
+                  "minimum": -9007199254740991,
+                  "maximum": 9007199254740991
+                }
+              },
+              "required": [
+                "left",
+                "top",
+                "right",
+                "bottom"
+              ],
+              "additionalProperties": false
+            },
+            "text": {
+              "type": "string"
+            },
+            "resource-id": {
+              "type": "string"
+            },
+            "content-desc": {
+              "type": "string"
+            },
+            "class": {
+              "type": "string"
+            },
+            "package": {
+              "type": "string"
+            },
+            "checkable": {
+              "anyOf": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "type": "string",
+                  "const": "true"
+                },
+                {
+                  "type": "string",
+                  "const": "false"
+                }
+              ]
+            },
+            "checked": {
+              "anyOf": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "type": "string",
+                  "const": "true"
+                },
+                {
+                  "type": "string",
+                  "const": "false"
+                }
+              ]
+            },
+            "clickable": {
+              "anyOf": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "type": "string",
+                  "const": "true"
+                },
+                {
+                  "type": "string",
+                  "const": "false"
+                }
+              ]
+            },
+            "enabled": {
+              "anyOf": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "type": "string",
+                  "const": "true"
+                },
+                {
+                  "type": "string",
+                  "const": "false"
+                }
+              ]
+            },
+            "focusable": {
+              "anyOf": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "type": "string",
+                  "const": "true"
+                },
+                {
+                  "type": "string",
+                  "const": "false"
+                }
+              ]
+            },
+            "focused": {
+              "anyOf": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "type": "string",
+                  "const": "true"
+                },
+                {
+                  "type": "string",
+                  "const": "false"
+                }
+              ]
+            },
+            "accessibility-focused": {
+              "anyOf": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "type": "string",
+                  "const": "true"
+                },
+                {
+                  "type": "string",
+                  "const": "false"
+                }
+              ]
+            },
+            "scrollable": {
+              "anyOf": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "type": "string",
+                  "const": "true"
+                },
+                {
+                  "type": "string",
+                  "const": "false"
+                }
+              ]
+            },
+            "selected": {
+              "anyOf": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "type": "string",
+                  "const": "true"
+                },
+                {
+                  "type": "string",
+                  "const": "false"
+                }
+              ]
+            }
+          },
+          "required": [
+            "bounds"
+          ],
+          "additionalProperties": {}
+        }
+      },
+      "required": [
+        "success"
+      ],
+      "additionalProperties": {}
+    }
+  },
+  {
     "name": "biometricAuth",
     "description": "Simulate biometric authentication (fingerprint) on Android emulators, or inject a deterministic result via the AutoMobile SDK on any device. Supports match/fail/cancel/error actions. The SDK broadcast path requires the app to integrate AutoMobileBiometrics.consumeOverride().",
     "inputSchema": {

--- a/scripts/generate-tool-definitions.ts
+++ b/scripts/generate-tool-definitions.ts
@@ -25,6 +25,7 @@ import { registerSnapshotTools } from "../src/server/snapshotTools";
 import { registerBiometricTools } from "../src/server/biometricTools";
 import { registerTelephonyTools } from "../src/server/telephonyTools";
 import { registerHighlightTools } from "../src/server/highlightTools";
+import { registerAccessibilityFocusTools } from "../src/server/accessibilityFocusTools";
 import { registerDebugTools } from "../src/server/debugTools";
 
 const OUTPUT_PATH = "schemas/tool-definitions.json";
@@ -46,6 +47,7 @@ function registerAllTools(): void {
   registerBiometricTools();
   registerTelephonyTools();
   registerHighlightTools();
+  registerAccessibilityFocusTools();
   registerDebugTools();
 }
 

--- a/src/features/accessibility/SetAccessibilityFocus.ts
+++ b/src/features/accessibility/SetAccessibilityFocus.ts
@@ -106,6 +106,21 @@ export class SetAccessibilityFocus {
    */
   private async resolveResourceId(options: SetAccessibilityFocusOptions): Promise<string> {
     if (options.resourceId) {
+      // A caller-supplied id is just as exposed to the duplicate-id hazard below: CtrlProxy
+      // focuses the FIRST node carrying it. Guard it too, but best-effort — a resource-id
+      // selector did not previously require an observable hierarchy, so if we can't read
+      // one we fall through and let CtrlProxy resolve the id as before.
+      try {
+        const viewHierarchy = await this.getViewHierarchy();
+        this.assertUniqueResourceId(viewHierarchy, options.resourceId, `resourceId "${options.resourceId}"`);
+      } catch (error) {
+        if (error instanceof ActionableError) {
+          throw error;
+        }
+        logger.warn(
+          `[accessibilityFocus] Could not observe to check resourceId uniqueness; proceeding: ${error}`
+        );
+      }
       return options.resourceId;
     }
 
@@ -125,21 +140,43 @@ export class SetAccessibilityFocus {
       );
     }
 
-    // The CtrlProxy service can only target a node by resource-id, and it focuses the
-    // FIRST node carrying that id. When the resolved id is shared by repeated rows
-    // (e.g. a RecyclerView item id reused per row), focusing it would silently move the
-    // cursor to the wrong row while reporting success. Reject the ambiguity instead.
-    const sharing = this.finder.findElementsByResourceId(viewHierarchy, resourceId);
-    if (sharing.length > 1) {
+    this.assertUniqueResourceId(viewHierarchy, resourceId, `Selector ${selector}`);
+    return resourceId;
+  }
+
+  /**
+   * The CtrlProxy service can only target a node by resource-id, and it focuses the FIRST
+   * node carrying that id. When the id is shared by repeated rows (e.g. a RecyclerView item
+   * id reused per row), focusing it would silently move the cursor to the wrong row while
+   * reporting success. Reject the ambiguity instead.
+   */
+  private assertUniqueResourceId(
+    viewHierarchy: ViewHierarchyResult,
+    resourceId: string,
+    selectorLabel: string
+  ): void {
+    const sharing = this.countMatchingResourceIds(viewHierarchy, resourceId);
+    if (sharing > 1) {
       throw new ActionableError(
-        `Selector ${selector} resolved to resource-id "${resourceId}", which is shared by ` +
-          `${sharing.length} elements (e.g. repeated list rows). Accessibility focus targets a ` +
-          `node by resource-id and would focus the first match, not necessarily the one you ` +
-          `selected. Provide a more specific selector or a unique resourceId.`
+        `${selectorLabel} resolves to resource-id "${resourceId}", which is shared by ` +
+          `${sharing} elements (e.g. repeated list rows). Accessibility focus targets a node ` +
+          `by resource-id and would focus the first match, not necessarily the one you ` +
+          `selected. Provide a more specific selector or a unique target.`
       );
     }
+  }
 
-    return resourceId;
+  /**
+   * Count nodes whose resource-id matches, mirroring CtrlProxy.findNodeByResourceId:
+   * full equality OR a ":id/<id>" suffix, so both short and fully-qualified ids are
+   * counted the same way the service would resolve them.
+   */
+  private countMatchingResourceIds(viewHierarchy: ViewHierarchyResult, resourceId: string): number {
+    const candidates = this.finder.findElementsByResourceId(viewHierarchy, resourceId, undefined, true);
+    return candidates.filter(el => {
+      const rid = el["resource-id"];
+      return typeof rid === "string" && (rid === resourceId || rid.endsWith(`:id/${resourceId}`));
+    }).length;
   }
 
   private async getViewHierarchy(): Promise<ViewHierarchyResult> {

--- a/src/features/accessibility/SetAccessibilityFocus.ts
+++ b/src/features/accessibility/SetAccessibilityFocus.ts
@@ -110,10 +110,10 @@ export class SetAccessibilityFocus {
 
     const viewHierarchy = await this.getViewHierarchy();
     const matched = this.findElement(viewHierarchy, options);
+    const selector = options.text
+      ? `text "${options.text}"`
+      : `content-desc "${options.contentDesc}"`;
     if (!matched) {
-      const selector = options.text
-        ? `text "${options.text}"`
-        : `content-desc "${options.contentDesc}"`;
       throw new ActionableError(`Element not found for selector: ${selector}`);
     }
 
@@ -123,6 +123,21 @@ export class SetAccessibilityFocus {
         "Matched element has no resource-id; accessibility focus requires one."
       );
     }
+
+    // The CtrlProxy service can only target a node by resource-id, and it focuses the
+    // FIRST node carrying that id. When the resolved id is shared by repeated rows
+    // (e.g. a RecyclerView item id reused per row), focusing it would silently move the
+    // cursor to the wrong row while reporting success. Reject the ambiguity instead.
+    const sharing = this.finder.findElementsByResourceId(viewHierarchy, resourceId);
+    if (sharing.length > 1) {
+      throw new ActionableError(
+        `Selector ${selector} resolved to resource-id "${resourceId}", which is shared by ` +
+          `${sharing.length} elements (e.g. repeated list rows). Accessibility focus targets a ` +
+          `node by resource-id and would focus the first match, not necessarily the one you ` +
+          `selected. Provide a more specific selector or a unique resourceId.`
+      );
+    }
+
     return resourceId;
   }
 

--- a/src/features/accessibility/SetAccessibilityFocus.ts
+++ b/src/features/accessibility/SetAccessibilityFocus.ts
@@ -1,0 +1,153 @@
+/**
+ * SetAccessibilityFocus - sets or clears the Android TalkBack accessibility-focus cursor.
+ *
+ * Resolves a text / contentDesc / resourceId selector to a resource-id, then asks the
+ * CtrlProxy AccessibilityService to perform ACTION_ACCESSIBILITY_FOCUS ("focus") or
+ * ACTION_CLEAR_ACCESSIBILITY_FOCUS ("clear_focus") on the matched node.
+ *
+ * Android only: iOS has no VoiceOver-focus backend wired, so the tool errors clearly
+ * rather than silently no-op'ing.
+ */
+
+import {
+  ActionableError,
+  BootedDevice,
+  CurrentFocusResult,
+  Element,
+  SetAccessibilityFocusOptions,
+  SetAccessibilityFocusResult,
+  ViewHierarchyResult
+} from "../../models";
+import type { ElementFinder } from "../../utils/interfaces/ElementFinder";
+import type { ObserveScreen } from "../observe/interfaces/ObserveScreen";
+import { DefaultElementFinder } from "../utility/ElementFinder";
+import { RealObserveScreen } from "../observe/ObserveScreen";
+import { AndroidCtrlProxyClient } from "../observe/android";
+import { defaultAdbClientFactory } from "../../utils/android-cmdline-tools/AdbClientFactory";
+import { logger } from "../../utils/logger";
+
+/**
+ * Minimal accessibility-focus capability surface, so this feature can be unit-tested
+ * with a fake instead of a real device/WebSocket.
+ */
+export interface AccessibilityFocusService {
+  setAccessibilityFocus(resourceId: string): Promise<void>;
+  clearAccessibilityFocus(resourceId: string): Promise<void>;
+  requestCurrentFocus(): Promise<CurrentFocusResult>;
+}
+
+export interface SetAccessibilityFocusDependencies {
+  finder?: ElementFinder;
+  observeScreen?: ObserveScreen;
+  /** Factory so production resolves the live CtrlProxy client lazily; fakes inject directly. */
+  serviceFactory?: (device: BootedDevice) => AccessibilityFocusService;
+}
+
+export class SetAccessibilityFocus {
+  private readonly device: BootedDevice;
+  private readonly finder: ElementFinder;
+  private readonly observeScreen: ObserveScreen;
+  private readonly serviceFactory: (device: BootedDevice) => AccessibilityFocusService;
+
+  constructor(device: BootedDevice, deps: SetAccessibilityFocusDependencies = {}) {
+    this.device = device;
+    this.finder = deps.finder ?? new DefaultElementFinder();
+    this.observeScreen = deps.observeScreen ?? new RealObserveScreen(device, defaultAdbClientFactory);
+    this.serviceFactory =
+      deps.serviceFactory ?? ((d: BootedDevice) => AndroidCtrlProxyClient.getInstance(d, defaultAdbClientFactory));
+  }
+
+  async execute(options: SetAccessibilityFocusOptions): Promise<SetAccessibilityFocusResult> {
+    if (this.device.platform !== "android") {
+      throw new ActionableError(
+        "accessibilityFocus is only supported on Android (TalkBack). iOS VoiceOver focus is not yet implemented."
+      );
+    }
+
+    const action = options.action ?? "set";
+
+    if (!options.resourceId && !options.text && !options.contentDesc) {
+      throw new ActionableError(
+        "accessibilityFocus requires a selector: provide one of resourceId, text, or contentDesc."
+      );
+    }
+
+    const service = this.serviceFactory(this.device);
+    const resourceId = await this.resolveResourceId(options);
+
+    try {
+      if (action === "clear") {
+        await service.clearAccessibilityFocus(resourceId);
+      } else {
+        await service.setAccessibilityFocus(resourceId);
+      }
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      return { success: false, error: message };
+    }
+
+    // Confirm the cursor moved (best-effort; never fail the operation on a read error).
+    let focusedElement: Element | undefined;
+    try {
+      const focus = await service.requestCurrentFocus();
+      focusedElement = focus.focusedElement ?? undefined;
+    } catch (error) {
+      logger.warn(`[accessibilityFocus] Failed to read current focus after ${action}: ${error}`);
+    }
+
+    return { success: true, focusedElement };
+  }
+
+  /**
+   * Resolve the target to a resource-id. A resource-id selector is used directly; a
+   * text/contentDesc selector is resolved against the current view hierarchy via the
+   * element finder. The matched element must itself have a resource-id.
+   */
+  private async resolveResourceId(options: SetAccessibilityFocusOptions): Promise<string> {
+    if (options.resourceId) {
+      return options.resourceId;
+    }
+
+    const viewHierarchy = await this.getViewHierarchy();
+    const matched = this.findElement(viewHierarchy, options);
+    if (!matched) {
+      const selector = options.text
+        ? `text "${options.text}"`
+        : `content-desc "${options.contentDesc}"`;
+      throw new ActionableError(`Element not found for selector: ${selector}`);
+    }
+
+    const resourceId = matched["resource-id"];
+    if (!resourceId) {
+      throw new ActionableError(
+        "Matched element has no resource-id; accessibility focus requires one."
+      );
+    }
+    return resourceId;
+  }
+
+  private async getViewHierarchy(): Promise<ViewHierarchyResult> {
+    let observeResult = await this.observeScreen.getMostRecentCachedObserveResult();
+    if (!observeResult.viewHierarchy || observeResult.viewHierarchy.hierarchy?.error) {
+      observeResult = await this.observeScreen.execute();
+    }
+    if (!observeResult.viewHierarchy) {
+      throw new ActionableError("Unable to observe screen to resolve accessibility focus target.");
+    }
+    return observeResult.viewHierarchy;
+  }
+
+  private findElement(
+    viewHierarchy: ViewHierarchyResult,
+    options: SetAccessibilityFocusOptions
+  ): Element | null {
+    if (options.text) {
+      return this.finder.findElementByText(viewHierarchy, options.text, undefined, false, false);
+    }
+    if (options.contentDesc) {
+      // content-desc is matched through the text finder (it inspects content-desc too).
+      return this.finder.findElementByText(viewHierarchy, options.contentDesc, undefined, false, false);
+    }
+    return null;
+  }
+}

--- a/src/features/accessibility/SetAccessibilityFocus.ts
+++ b/src/features/accessibility/SetAccessibilityFocus.ts
@@ -21,6 +21,7 @@ import {
 import type { ElementFinder } from "../../utils/interfaces/ElementFinder";
 import type { ObserveScreen } from "../observe/interfaces/ObserveScreen";
 import { DefaultElementFinder } from "../utility/ElementFinder";
+import { normalizeQuotes } from "../utility/TextMatcher";
 import { RealObserveScreen } from "../observe/ObserveScreen";
 import { AndroidCtrlProxyClient } from "../observe/android";
 import { defaultAdbClientFactory } from "../../utils/android-cmdline-tools/AdbClientFactory";
@@ -160,8 +161,23 @@ export class SetAccessibilityFocus {
       return this.finder.findElementByText(viewHierarchy, options.text, undefined, false, false);
     }
     if (options.contentDesc) {
-      // content-desc is matched through the text finder (it inspects content-desc too).
-      return this.finder.findElementByText(viewHierarchy, options.contentDesc, undefined, false, false);
+      // The text finder matches BOTH visible text and content-desc, so a text label that
+      // happens to equal the content-desc (e.g. a "Close" label next to a "Close" icon)
+      // could win. Restrict to nodes whose content-desc actually matches the selector.
+      const target = normalizeQuotes(options.contentDesc).toLowerCase();
+      const candidates = this.finder.findElementsByText(
+        viewHierarchy,
+        options.contentDesc,
+        undefined,
+        false,
+        false
+      );
+      return (
+        candidates.find(el => {
+          const desc = el["content-desc"];
+          return typeof desc === "string" && normalizeQuotes(desc).toLowerCase() === target;
+        }) ?? null
+      );
     }
     return null;
   }

--- a/src/features/observe/android/AndroidCtrlProxyClient.ts
+++ b/src/features/observe/android/AndroidCtrlProxyClient.ts
@@ -1326,12 +1326,16 @@ export class AndroidCtrlProxyClient extends DeviceServiceClient implements Andro
   // Delegated Public Methods - Focus
   // ===========================================================================
 
-  async clearAccessibilityFocus(): Promise<void> {
-    return this.focus.clearAccessibilityFocus();
+  async clearAccessibilityFocus(
+    resourceId: string, timeoutMs: number = 5000, perf: PerformanceTracker = new NoOpPerformanceTracker()
+  ): Promise<void> {
+    return this.focus.clearAccessibilityFocus(resourceId, timeoutMs, perf);
   }
 
-  async setAccessibilityFocus(resourceId: string): Promise<void> {
-    return this.focus.setAccessibilityFocus(resourceId);
+  async setAccessibilityFocus(
+    resourceId: string, timeoutMs: number = 5000, perf: PerformanceTracker = new NoOpPerformanceTracker()
+  ): Promise<void> {
+    return this.focus.setAccessibilityFocus(resourceId, timeoutMs, perf);
   }
 
   async requestCurrentFocus(

--- a/src/features/observe/android/CtrlProxyFocus.ts
+++ b/src/features/observe/android/CtrlProxyFocus.ts
@@ -10,7 +10,7 @@ import { logger } from "../../../utils/logger";
 import type { PerformanceTracker } from "../../../utils/PerformanceTracker";
 import { NoOpPerformanceTracker } from "../../../utils/PerformanceTracker";
 import type { CurrentFocusResult, TraversalOrderResult, Element } from "../../../models";
-import type { DelegateContext, AccessibilityNode } from "./types";
+import type { DelegateContext, AccessibilityNode, A11yActionResult } from "./types";
 import { DefaultElementParser } from "../../utility/ElementParser";
 
 /**
@@ -24,35 +24,128 @@ export class CtrlProxyFocus {
   }
 
   /**
-   * Clear accessibility focus (TalkBack cursor) on the current element.
+   * Clear accessibility focus (TalkBack cursor) on a specific element.
    *
-   * NOT IMPLEMENTED: throws rather than silently no-op'ing so callers fail loudly.
-   * Full implementation (sending a clear-focus command to the Android accessibility
-   * service) is tracked at https://github.com/kaeawc/auto-mobile/issues
+   * Sends the "clear_focus" action over the request_action protocol; the
+   * CtrlProxy AccessibilityService resolves the node by resource-id and performs
+   * ACTION_CLEAR_ACCESSIBILITY_FOCUS on it.
+   *
+   * @param resourceId - Resource ID of the element whose focus should be cleared
+   * @param timeoutMs - Maximum time to wait for the action result in milliseconds
+   * @param perf - Performance tracker for timing
+   * @throws Error if resourceId is empty, the node is not found, or the action fails
    */
-  async clearAccessibilityFocus(): Promise<void> {
-    logger.warn("[CTRL_PROXY] clearAccessibilityFocus() called but is not implemented");
-    throw new Error(
-      "clearAccessibilityFocus() is not implemented. " +
-        "Track progress at https://github.com/kaeawc/auto-mobile/issues"
-    );
+  async clearAccessibilityFocus(
+    resourceId: string,
+    timeoutMs: number = 5000,
+    perf: PerformanceTracker = new NoOpPerformanceTracker()
+  ): Promise<void> {
+    if (!resourceId) {
+      throw new Error("clearAccessibilityFocus requires a resource-id");
+    }
+    const result = await this.sendAction("clear_focus", resourceId, timeoutMs, perf);
+    if (!result.success) {
+      throw new Error(result.error ?? `Failed to clear accessibility focus on ${resourceId}`);
+    }
   }
 
   /**
    * Set accessibility focus (TalkBack cursor) on a specific element.
    *
-   * NOT IMPLEMENTED: throws rather than silently no-op'ing so callers fail loudly.
-   * Full implementation (sending a set-focus command to the Android accessibility
-   * service) is tracked at https://github.com/kaeawc/auto-mobile/issues
+   * Sends the "focus" action over the request_action protocol; the CtrlProxy
+   * AccessibilityService resolves the node by resource-id and performs
+   * ACTION_ACCESSIBILITY_FOCUS on it.
    *
    * @param resourceId - Resource ID of the element to focus
+   * @param timeoutMs - Maximum time to wait for the action result in milliseconds
+   * @param perf - Performance tracker for timing
+   * @throws Error if resourceId is empty, the node is not found, or the action fails
    */
-  async setAccessibilityFocus(resourceId: string): Promise<void> {
-    logger.warn(`[CTRL_PROXY] setAccessibilityFocus(${resourceId}) called but is not implemented`);
-    throw new Error(
-      `setAccessibilityFocus(${resourceId}) is not implemented. ` +
-        "Track progress at https://github.com/kaeawc/auto-mobile/issues"
-    );
+  async setAccessibilityFocus(
+    resourceId: string,
+    timeoutMs: number = 5000,
+    perf: PerformanceTracker = new NoOpPerformanceTracker()
+  ): Promise<void> {
+    if (!resourceId) {
+      throw new Error("setAccessibilityFocus requires a resource-id");
+    }
+    const result = await this.sendAction("focus", resourceId, timeoutMs, perf);
+    if (!result.success) {
+      throw new Error(result.error ?? `Failed to set accessibility focus on ${resourceId}`);
+    }
+  }
+
+  /**
+   * Send a node action ("focus" / "clear_focus") to the accessibility service over
+   * the request_action WebSocket protocol and await the action result.
+   *
+   * Mirrors the request/response plumbing used by requestCurrentFocus so the focus
+   * delegate stays self-contained (no dependency on the host client's requestAction).
+   */
+  private async sendAction(
+    action: string,
+    resourceId: string,
+    timeoutMs: number,
+    perf: PerformanceTracker
+  ): Promise<A11yActionResult> {
+    const startTime = this.context.timer.now();
+
+    try {
+      const connected = await perf.track("ensureConnection", () => this.context.ensureConnected(perf));
+      if (!connected) {
+        logger.warn(`[CTRL_PROXY] Failed to establish WebSocket connection for action '${action}'`);
+        return {
+          success: false,
+          action,
+          totalTimeMs: this.context.timer.now() - startTime,
+          error: "Failed to connect to accessibility service"
+        };
+      }
+
+      const requestId = this.context.requestManager.generateId("action");
+
+      const actionPromise = this.context.requestManager.register<A11yActionResult>(
+        requestId,
+        "action",
+        timeoutMs,
+        (_id, _type, timeout) => ({
+          success: false,
+          action,
+          totalTimeMs: this.context.timer.now() - startTime,
+          error: `Action timeout after ${timeout}ms`
+        })
+      );
+
+      await perf.track("sendRequest", async () => {
+        const ws = this.context.getWebSocket();
+        if (!ws || ws.readyState !== WebSocket.OPEN) {
+          throw new Error("WebSocket not connected");
+        }
+        const message = JSON.stringify({ type: "request_action", requestId, action, resourceId });
+        ws.send(message);
+        logger.debug(`[CTRL_PROXY] Sent action request (requestId: ${requestId}, action: ${action}, resourceId: ${resourceId})`);
+      });
+
+      const result = await perf.track("waitForAction", () => actionPromise);
+
+      const duration = this.context.timer.now() - startTime;
+      if (result.success) {
+        logger.debug(`[CTRL_PROXY] Action '${action}' completed in ${duration}ms`);
+      } else {
+        logger.warn(`[CTRL_PROXY] Action '${action}' failed after ${duration}ms: ${result.error}`);
+      }
+
+      return result;
+    } catch (error) {
+      const duration = this.context.timer.now() - startTime;
+      logger.warn(`[CTRL_PROXY] Action '${action}' request failed after ${duration}ms: ${error}`);
+      return {
+        success: false,
+        action,
+        totalTimeMs: duration,
+        error: `${error}`
+      };
+    }
   }
 
   /**

--- a/src/models/SetAccessibilityFocusOptions.ts
+++ b/src/models/SetAccessibilityFocusOptions.ts
@@ -1,13 +1,19 @@
 /**
- * Options for setting accessibility focus (TalkBack/VoiceOver cursor) on a specific element.
- * This interface defines the parameters for the future setAccessibilityFocus tool.
- *
- * Note: Implementation is deferred to a future PR. This interface serves as a scaffold
- * for the tool's contract.
+ * Options for setting/clearing accessibility focus (TalkBack cursor) on a specific element.
+ * Backs the `accessibilityFocus` MCP tool. Android only (TalkBack); iOS VoiceOver-focus
+ * is not yet supported.
  */
 export interface SetAccessibilityFocusOptions {
   /**
-   * Target element selectors (at least one must be specified)
+   * Whether to set or clear the accessibility (TalkBack) focus cursor.
+   * Defaults to "set".
+   */
+  action?: "set" | "clear";
+
+  /**
+   * Target element selectors (at least one must be specified).
+   * Non-id selectors are resolved to a resource-id via the element finder before
+   * the action is sent to the accessibility service.
    */
   text?: string; // Text content of the element
   resourceId?: string; // Resource ID of the element (e.g., "com.app:id/button")

--- a/src/models/SetAccessibilityFocusResult.ts
+++ b/src/models/SetAccessibilityFocusResult.ts
@@ -1,11 +1,8 @@
 import { Element } from "./Element";
 
 /**
- * Result of a setAccessibilityFocus operation.
- * This interface defines the return value for the future setAccessibilityFocus tool.
- *
- * Note: Implementation is deferred to a future PR. This interface serves as a scaffold
- * for the tool's contract.
+ * Result of an accessibilityFocus (set/clear TalkBack cursor) operation.
+ * Returned by the `accessibilityFocus` MCP tool.
  */
 export interface SetAccessibilityFocusResult {
   /**

--- a/src/server/accessibilityFocusTools.ts
+++ b/src/server/accessibilityFocusTools.ts
@@ -1,0 +1,79 @@
+import { z } from "zod";
+import { ToolRegistry } from "./toolRegistry";
+import type { ProgressCallback } from "./toolRegistry";
+import { ActionableError, BootedDevice } from "../models";
+import { createStructuredToolResponse } from "../utils/toolUtils";
+import { addDeviceTargetingToSchema } from "./toolSchemaHelpers";
+import { SetAccessibilityFocus } from "../features/accessibility/SetAccessibilityFocus";
+import { accessibilityFocusResultSchema } from "./toolOutputSchemas";
+
+export const accessibilityFocusSchema = addDeviceTargetingToSchema(
+  z.object({
+    action: z
+      .enum(["set", "clear"])
+      .optional()
+      .describe("Set (default) or clear the accessibility (TalkBack) focus cursor"),
+    resourceId: z
+      .string()
+      .optional()
+      .describe("Resource ID of the target element, e.g. com.example:id/title"),
+    text: z
+      .string()
+      .optional()
+      .describe("Text of the target element (resolved to a resource-id via the element finder)"),
+    contentDesc: z
+      .string()
+      .optional()
+      .describe("Content description of the target element (resolved to a resource-id)")
+  })
+);
+
+interface AccessibilityFocusArgs {
+  action?: "set" | "clear";
+  resourceId?: string;
+  text?: string;
+  contentDesc?: string;
+}
+
+export function registerAccessibilityFocusTools() {
+  const handler = async (
+    device: BootedDevice,
+    args: AccessibilityFocusArgs,
+    _progress?: ProgressCallback
+  ) => {
+    if (device.platform !== "android") {
+      throw new ActionableError(
+        "accessibilityFocus is only supported on Android (TalkBack). iOS VoiceOver focus is not yet implemented."
+      );
+    }
+
+    const feature = new SetAccessibilityFocus(device);
+    const result = await feature.execute({
+      action: args.action,
+      resourceId: args.resourceId,
+      text: args.text,
+      contentDesc: args.contentDesc
+    });
+
+    if (!result.success) {
+      throw new ActionableError(result.error ?? "Failed to update accessibility focus");
+    }
+
+    return createStructuredToolResponse({
+      success: true,
+      focusedElement: result.focusedElement,
+      warning: result.warning
+    });
+  };
+
+  ToolRegistry.registerDeviceAware(
+    "accessibilityFocus",
+    "Set or clear the Android TalkBack accessibility-focus cursor on a target element (Android only). " +
+      "Provide one selector: resourceId, text, or contentDesc. action defaults to 'set'; pass 'clear' to clear the cursor.",
+    accessibilityFocusSchema,
+    handler,
+    false,
+    false,
+    { outputSchema: accessibilityFocusResultSchema }
+  );
+}

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -39,6 +39,7 @@ import { registerDatabaseTools } from "./databaseTools";
 import { registerStorageTools } from "./storageTools";
 import { registerFormTools } from "./formTools";
 import { registerAccessibilityTools } from "./accessibilityTools";
+import { registerAccessibilityFocusTools } from "./accessibilityFocusTools";
 import { registerNetworkTools } from "./networkTools";
 import { getMcpServerVersion } from "../utils/mcpVersion";
 
@@ -184,6 +185,7 @@ export const createMcpServer = (options: McpServerOptions = {}): McpServer => {
   registerStorageTools();
   registerFormTools();
   registerAccessibilityTools();
+  registerAccessibilityFocusTools();
   registerNetworkTools();
   registerDebugTools();
   startupBenchmark.endPhase("toolRegistration");

--- a/src/server/toolOutputSchemas.ts
+++ b/src/server/toolOutputSchemas.ts
@@ -132,3 +132,10 @@ export const accessibilityStateSchema = z.object({
   enabled: z.boolean(),
   service: z.enum(["talkback", "voiceover", "unknown"])
 }).passthrough();
+
+export const accessibilityFocusResultSchema = z.object({
+  success: z.boolean(),
+  error: z.string().optional(),
+  warning: z.string().optional(),
+  focusedElement: elementSchema.optional()
+}).passthrough();

--- a/test/fakes/FakeAccessibilityFocusService.ts
+++ b/test/fakes/FakeAccessibilityFocusService.ts
@@ -1,0 +1,49 @@
+import type { CurrentFocusResult, Element } from "../../src/models";
+import type { AccessibilityFocusService } from "../../src/features/accessibility/SetAccessibilityFocus";
+
+type FocusCall = { method: "set" | "clear"; resourceId: string };
+
+/**
+ * Fake AccessibilityFocusService for unit tests. Records set/clear calls, can be
+ * configured to throw, and returns a configurable current-focus result.
+ */
+export class FakeAccessibilityFocusService implements AccessibilityFocusService {
+  calls: FocusCall[] = [];
+  currentFocusElement: Element | null = null;
+  private setThrows: Error | null = null;
+  private clearThrows: Error | null = null;
+  private currentFocusThrows: Error | null = null;
+
+  setSetThrows(err: Error): void {
+    this.setThrows = err;
+  }
+
+  setClearThrows(err: Error): void {
+    this.clearThrows = err;
+  }
+
+  setCurrentFocusThrows(err: Error): void {
+    this.currentFocusThrows = err;
+  }
+
+  async setAccessibilityFocus(resourceId: string): Promise<void> {
+    this.calls.push({ method: "set", resourceId });
+    if (this.setThrows) {
+      throw this.setThrows;
+    }
+  }
+
+  async clearAccessibilityFocus(resourceId: string): Promise<void> {
+    this.calls.push({ method: "clear", resourceId });
+    if (this.clearThrows) {
+      throw this.clearThrows;
+    }
+  }
+
+  async requestCurrentFocus(): Promise<CurrentFocusResult> {
+    if (this.currentFocusThrows) {
+      throw this.currentFocusThrows;
+    }
+    return { focusedElement: this.currentFocusElement, totalTimeMs: 1 };
+  }
+}

--- a/test/features/accessibility/SetAccessibilityFocus.test.ts
+++ b/test/features/accessibility/SetAccessibilityFocus.test.ts
@@ -1,0 +1,196 @@
+import { describe, expect, test, beforeEach } from "bun:test";
+import { SetAccessibilityFocus } from "../../../src/features/accessibility/SetAccessibilityFocus";
+import { ActionableError, BootedDevice, ObserveResult, ViewHierarchyResult } from "../../../src/models";
+import { FakeObserveScreen } from "../../fakes/FakeObserveScreen";
+import { FakeAccessibilityFocusService } from "../../fakes/FakeAccessibilityFocusService";
+import { DefaultElementFinder } from "../../../src/features/utility/ElementFinder";
+
+const androidDevice: BootedDevice = {
+  deviceId: "test-a11y-focus",
+  platform: "android",
+  isEmulator: true,
+  name: "Test Device"
+};
+
+const iosDevice: BootedDevice = {
+  deviceId: "test-a11y-focus-ios",
+  platform: "ios",
+  isEmulator: true,
+  name: "Test Simulator"
+};
+
+const bounds = (left: number, top: number, right: number, bottom: number) => ({ left, top, right, bottom });
+
+function makeViewHierarchy(nodes: any[]): ViewHierarchyResult {
+  return {
+    hierarchy: {
+      node: {
+        $: { bounds: bounds(0, 0, 1080, 1920) },
+        node: nodes
+      }
+    }
+  } as ViewHierarchyResult;
+}
+
+function makeObserveResult(viewHierarchy: ViewHierarchyResult): ObserveResult {
+  return {
+    updatedAt: 1,
+    screenSize: { width: 1080, height: 1920 },
+    systemInsets: { top: 0, bottom: 0, left: 0, right: 0 },
+    viewHierarchy
+  } as ObserveResult;
+}
+
+describe("SetAccessibilityFocus", () => {
+  let service: FakeAccessibilityFocusService;
+  let observeScreen: FakeObserveScreen;
+
+  const makeFeature = (device: BootedDevice = androidDevice) =>
+    new SetAccessibilityFocus(device, {
+      finder: new DefaultElementFinder(),
+      observeScreen,
+      serviceFactory: () => service
+    });
+
+  beforeEach(() => {
+    service = new FakeAccessibilityFocusService();
+    observeScreen = new FakeObserveScreen();
+  });
+
+  test("set focus by resource-id sends the 'focus' command", async () => {
+    const feature = makeFeature();
+    const result = await feature.execute({ action: "set", resourceId: "com.example:id/title" });
+
+    expect(result.success).toBe(true);
+    expect(service.calls).toEqual([{ method: "set", resourceId: "com.example:id/title" }]);
+  });
+
+  test("action defaults to 'set' when omitted", async () => {
+    const feature = makeFeature();
+    await feature.execute({ resourceId: "com.example:id/title" });
+
+    expect(service.calls).toEqual([{ method: "set", resourceId: "com.example:id/title" }]);
+  });
+
+  test("clear focus by resource-id sends the 'clear' command", async () => {
+    const feature = makeFeature();
+    const result = await feature.execute({ action: "clear", resourceId: "com.example:id/title" });
+
+    expect(result.success).toBe(true);
+    expect(service.calls).toEqual([{ method: "clear", resourceId: "com.example:id/title" }]);
+  });
+
+  test("returns focusedElement from requestCurrentFocus on success", async () => {
+    service.currentFocusElement = {
+      "bounds": bounds(0, 0, 100, 50),
+      "resource-id": "com.example:id/title"
+    } as any;
+    const feature = makeFeature();
+
+    const result = await feature.execute({ resourceId: "com.example:id/title" });
+
+    expect(result.success).toBe(true);
+    expect(result.focusedElement?.["resource-id"]).toBe("com.example:id/title");
+  });
+
+  test("resolves text selector to a resource-id via the element finder", async () => {
+    observeScreen.setObserveResult(
+      makeObserveResult(
+        makeViewHierarchy([
+          { $: { "text": "Settings", "resource-id": "com.example:id/settings", "bounds": bounds(10, 20, 200, 60) } }
+        ])
+      )
+    );
+    const feature = makeFeature();
+
+    const result = await feature.execute({ action: "set", text: "Settings" });
+
+    expect(result.success).toBe(true);
+    expect(service.calls).toEqual([{ method: "set", resourceId: "com.example:id/settings" }]);
+  });
+
+  test("resolves contentDesc selector to a resource-id", async () => {
+    observeScreen.setObserveResult(
+      makeObserveResult(
+        makeViewHierarchy([
+          { $: { "content-desc": "Close", "resource-id": "com.example:id/close", "bounds": bounds(0, 0, 50, 50) } }
+        ])
+      )
+    );
+    const feature = makeFeature();
+
+    await feature.execute({ action: "set", contentDesc: "Close" });
+
+    expect(service.calls).toEqual([{ method: "set", resourceId: "com.example:id/close" }]);
+  });
+
+  test("throws when matched element has no resource-id", async () => {
+    observeScreen.setObserveResult(
+      makeObserveResult(
+        makeViewHierarchy([
+          { $: { "text": "Settings", "bounds": bounds(10, 20, 200, 60) } }
+        ])
+      )
+    );
+    const feature = makeFeature();
+
+    await expect(feature.execute({ action: "set", text: "Settings" })).rejects.toThrow(
+      /no resource-id/
+    );
+    expect(service.calls).toHaveLength(0);
+  });
+
+  test("throws ActionableError when text selector matches nothing (node not found)", async () => {
+    observeScreen.setObserveResult(makeObserveResult(makeViewHierarchy([])));
+    const feature = makeFeature();
+
+    await expect(feature.execute({ action: "set", text: "DoesNotExist" })).rejects.toThrow(
+      /Element not found/
+    );
+    expect(service.calls).toHaveLength(0);
+  });
+
+  test("throws ActionableError when no selector is provided", async () => {
+    const feature = makeFeature();
+    await expect(feature.execute({ action: "set" })).rejects.toBeInstanceOf(ActionableError);
+    expect(service.calls).toHaveLength(0);
+  });
+
+  test("returns success:false with the service error when set fails", async () => {
+    service.setSetThrows(new Error("Element not found with resource-id: com.example:id/missing"));
+    const feature = makeFeature();
+
+    const result = await feature.execute({ action: "set", resourceId: "com.example:id/missing" });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("Element not found with resource-id");
+  });
+
+  test("returns success:false with the service error when clear fails", async () => {
+    service.setClearThrows(new Error("Action timeout after 5000ms"));
+    const feature = makeFeature();
+
+    const result = await feature.execute({ action: "clear", resourceId: "com.example:id/title" });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("timeout");
+  });
+
+  test("still succeeds when requestCurrentFocus throws (best-effort confirmation)", async () => {
+    service.setCurrentFocusThrows(new Error("focus read failed"));
+    const feature = makeFeature();
+
+    const result = await feature.execute({ resourceId: "com.example:id/title" });
+
+    expect(result.success).toBe(true);
+    expect(result.focusedElement).toBeUndefined();
+  });
+
+  test("throws ActionableError on iOS (Android-only gating)", async () => {
+    const feature = makeFeature(iosDevice);
+    await expect(feature.execute({ action: "set", resourceId: "x" })).rejects.toThrow(
+      /only supported on Android/
+    );
+    expect(service.calls).toHaveLength(0);
+  });
+});

--- a/test/features/accessibility/SetAccessibilityFocus.test.ts
+++ b/test/features/accessibility/SetAccessibilityFocus.test.ts
@@ -124,6 +124,24 @@ describe("SetAccessibilityFocus", () => {
     expect(service.calls).toEqual([{ method: "set", resourceId: "com.example:id/close" }]);
   });
 
+  test("contentDesc selector only matches content-desc, not a same-text label", async () => {
+    observeScreen.setObserveResult(
+      makeObserveResult(
+        makeViewHierarchy([
+          // A visible text label "Close" — must NOT win for a contentDesc selector.
+          { $: { "text": "Close", "resource-id": "com.example:id/close_label", "bounds": bounds(0, 0, 80, 40) } },
+          // The icon whose content-desc is "Close" — the intended target.
+          { $: { "content-desc": "Close", "resource-id": "com.example:id/close_icon", "bounds": bounds(90, 0, 130, 40) } }
+        ])
+      )
+    );
+    const feature = makeFeature();
+
+    await feature.execute({ action: "set", contentDesc: "Close" });
+
+    expect(service.calls).toEqual([{ method: "set", resourceId: "com.example:id/close_icon" }]);
+  });
+
   test("throws when text selector resolves to a resource-id shared by repeated rows", async () => {
     observeScreen.setObserveResult(
       makeObserveResult(

--- a/test/features/accessibility/SetAccessibilityFocus.test.ts
+++ b/test/features/accessibility/SetAccessibilityFocus.test.ts
@@ -142,6 +142,50 @@ describe("SetAccessibilityFocus", () => {
     expect(service.calls).toEqual([{ method: "set", resourceId: "com.example:id/close_icon" }]);
   });
 
+  test("throws when a resourceId selector is shared by repeated rows", async () => {
+    observeScreen.setObserveResult(
+      makeObserveResult(
+        makeViewHierarchy([
+          { $: { "text": "Alice", "resource-id": "com.example:id/title", "bounds": bounds(0, 0, 200, 60) } },
+          { $: { "text": "Bob", "resource-id": "com.example:id/title", "bounds": bounds(0, 60, 200, 120) } }
+        ])
+      )
+    );
+    const feature = makeFeature();
+
+    await expect(feature.execute({ action: "set", resourceId: "com.example:id/title" })).rejects.toThrow(
+      /shared by 2 elements/
+    );
+    expect(service.calls).toHaveLength(0);
+  });
+
+  test("resourceId selector proceeds when the hierarchy cannot be observed", async () => {
+    // No observe result configured -> getViewHierarchy throws; the resourceId guard is
+    // best-effort, so the focus command is still sent.
+    const feature = makeFeature();
+
+    const result = await feature.execute({ action: "set", resourceId: "com.example:id/title" });
+
+    expect(result.success).toBe(true);
+    expect(service.calls).toEqual([{ method: "set", resourceId: "com.example:id/title" }]);
+  });
+
+  test("resourceId selector proceeds when it is unique in the hierarchy", async () => {
+    observeScreen.setObserveResult(
+      makeObserveResult(
+        makeViewHierarchy([
+          { $: { "text": "Alice", "resource-id": "com.example:id/title", "bounds": bounds(0, 0, 200, 60) } }
+        ])
+      )
+    );
+    const feature = makeFeature();
+
+    const result = await feature.execute({ action: "set", resourceId: "com.example:id/title" });
+
+    expect(result.success).toBe(true);
+    expect(service.calls).toEqual([{ method: "set", resourceId: "com.example:id/title" }]);
+  });
+
   test("throws when text selector resolves to a resource-id shared by repeated rows", async () => {
     observeScreen.setObserveResult(
       makeObserveResult(

--- a/test/features/accessibility/SetAccessibilityFocus.test.ts
+++ b/test/features/accessibility/SetAccessibilityFocus.test.ts
@@ -124,6 +124,23 @@ describe("SetAccessibilityFocus", () => {
     expect(service.calls).toEqual([{ method: "set", resourceId: "com.example:id/close" }]);
   });
 
+  test("throws when text selector resolves to a resource-id shared by repeated rows", async () => {
+    observeScreen.setObserveResult(
+      makeObserveResult(
+        makeViewHierarchy([
+          { $: { "text": "Alice", "resource-id": "com.example:id/title", "bounds": bounds(0, 0, 200, 60) } },
+          { $: { "text": "Bob", "resource-id": "com.example:id/title", "bounds": bounds(0, 60, 200, 120) } }
+        ])
+      )
+    );
+    const feature = makeFeature();
+
+    await expect(feature.execute({ action: "set", text: "Bob" })).rejects.toThrow(
+      /shared by 2 elements/
+    );
+    expect(service.calls).toHaveLength(0);
+  });
+
   test("throws when matched element has no resource-id", async () => {
     observeScreen.setObserveResult(
       makeObserveResult(

--- a/test/features/observe/android/CtrlProxyFocus.test.ts
+++ b/test/features/observe/android/CtrlProxyFocus.test.ts
@@ -1,0 +1,222 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { AndroidCtrlProxyClient } from "../../../../src/features/observe/android";
+import { NavigationGraphManager } from "../../../../src/features/navigation/NavigationGraphManager";
+import { FakeAdbExecutor } from "../../../fakes/FakeAdbExecutor";
+import { AndroidCtrlProxyManager } from "../../../../src/utils/CtrlProxyManager";
+import { FakeAdbClientFactory } from "../../../fakes/FakeAdbClientFactory";
+import { BootedDevice } from "../../../../src/models";
+import { FakeWebSocket, WebSocketState } from "../../../fakes/FakeWebSocket";
+import { FakeTimer } from "../../../fakes/FakeTimer";
+
+describe("CtrlProxyFocus (Android) - set/clear accessibility focus", function() {
+  let fakeAdb: FakeAdbExecutor;
+  let testDevice: BootedDevice;
+  let fakeTimer: FakeTimer;
+  const serverPort: number = 8765;
+
+  beforeEach(function() {
+    fakeTimer = new FakeTimer();
+    fakeTimer.enableAutoAdvance();
+
+    fakeAdb = new FakeAdbExecutor();
+    fakeAdb.setCommandResponse("forward", { stdout: `${serverPort}`, stderr: "" });
+    fakeAdb.setScreenState(true);
+
+    testDevice = {
+      deviceId: "test-device-focus",
+      platform: "android",
+      isEmulator: true,
+      name: "Test Device"
+    };
+
+    AndroidCtrlProxyManager.resetInstances();
+    AndroidCtrlProxyClient.resetInstances();
+    AndroidCtrlProxyManager.getInstance(testDevice, new FakeAdbClientFactory()).clearAvailabilityCache();
+  });
+
+  afterEach(function() {
+    NavigationGraphManager.getInstance();
+  });
+
+  class CapturingWebSocket extends FakeWebSocket {
+    sentMessages: string[] = [];
+    send(data: any): void {
+      this.sentMessages.push(data.toString());
+      super.send(data);
+    }
+  }
+
+  const createCapturingFactory = (timer?: FakeTimer): {
+    factory: (url: string) => CapturingWebSocket;
+    getSocket: () => CapturingWebSocket | null;
+  } => {
+    let socket: CapturingWebSocket | null = null;
+    return {
+      factory: (url: string) => {
+        socket = new CapturingWebSocket(url, "none", 0, timer);
+        return socket;
+      },
+      getSocket: () => socket
+    };
+  };
+
+  const waitForSocketOpen = async (socket: FakeWebSocket | null): Promise<void> => {
+    if (!socket || socket.readyState === WebSocketState.OPEN) {return;}
+    await new Promise<void>(resolve => socket.once("open", () => resolve()));
+  };
+
+  const waitForSocket = async (getSocket: () => CapturingWebSocket | null): Promise<CapturingWebSocket | null> => {
+    for (let i = 0; i < 5; i++) {
+      const s = getSocket();
+      if (s) {return s;}
+      await new Promise(r => setImmediate(r));
+    }
+    return getSocket();
+  };
+
+  const waitForSentMessages = async (socket: CapturingWebSocket | null, minCount = 1): Promise<void> => {
+    if (!socket) {return;}
+    for (let i = 0; i < 10; i++) {
+      if (socket.sentMessages.length >= minCount) {return;}
+      await new Promise(r => setImmediate(r));
+    }
+  };
+
+  const findSentMessage = (socket: CapturingWebSocket, type: string): any => {
+    for (let i = socket.sentMessages.length - 1; i >= 0; i--) {
+      try {
+        const parsed = JSON.parse(socket.sentMessages[i]);
+        if (parsed.type === type) {return parsed;}
+      } catch {
+        // skip
+      }
+    }
+    throw new Error(`No message of type ${type} in: ${socket.sentMessages.join(", ")}`);
+  };
+
+  test("setAccessibilityFocus sends request_action with action='focus' and resolves on success", async function() {
+    const { factory, getSocket } = createCapturingFactory(fakeTimer);
+    const client = AndroidCtrlProxyClient.createForTesting(testDevice, fakeAdb, factory, fakeTimer);
+    try {
+      await client.ensureConnected();
+      const socket = await waitForSocket(getSocket);
+      await waitForSocketOpen(socket);
+
+      const baseCount = socket!.sentMessages.length;
+      const resultPromise = client.setAccessibilityFocus("com.example:id/title");
+      await waitForSentMessages(socket, baseCount + 1);
+
+      const sent = findSentMessage(socket!, "request_action");
+      expect(sent.action).toBe("focus");
+      expect(sent.resourceId).toBe("com.example:id/title");
+
+      socket!.simulateMessage(JSON.stringify({
+        type: "action_result",
+        requestId: sent.requestId,
+        action: "focus",
+        success: true,
+        totalTimeMs: 5
+      }));
+
+      await expect(resultPromise).resolves.toBeUndefined();
+    } finally {
+      await client.close();
+    }
+  });
+
+  test("clearAccessibilityFocus sends request_action with action='clear_focus'", async function() {
+    const { factory, getSocket } = createCapturingFactory(fakeTimer);
+    const client = AndroidCtrlProxyClient.createForTesting(testDevice, fakeAdb, factory, fakeTimer);
+    try {
+      await client.ensureConnected();
+      const socket = await waitForSocket(getSocket);
+      await waitForSocketOpen(socket);
+
+      const baseCount = socket!.sentMessages.length;
+      const resultPromise = client.clearAccessibilityFocus("com.example:id/title");
+      await waitForSentMessages(socket, baseCount + 1);
+
+      const sent = findSentMessage(socket!, "request_action");
+      expect(sent.action).toBe("clear_focus");
+      expect(sent.resourceId).toBe("com.example:id/title");
+
+      socket!.simulateMessage(JSON.stringify({
+        type: "action_result",
+        requestId: sent.requestId,
+        action: "clear_focus",
+        success: true,
+        totalTimeMs: 3
+      }));
+
+      await expect(resultPromise).resolves.toBeUndefined();
+    } finally {
+      await client.close();
+    }
+  });
+
+  test("setAccessibilityFocus throws with the service error on node-not-found", async function() {
+    const { factory, getSocket } = createCapturingFactory(fakeTimer);
+    const client = AndroidCtrlProxyClient.createForTesting(testDevice, fakeAdb, factory, fakeTimer);
+    try {
+      await client.ensureConnected();
+      const socket = await waitForSocket(getSocket);
+      await waitForSocketOpen(socket);
+
+      const baseCount = socket!.sentMessages.length;
+      const resultPromise = client.setAccessibilityFocus("com.example:id/missing");
+      await waitForSentMessages(socket, baseCount + 1);
+
+      const sent = findSentMessage(socket!, "request_action");
+      socket!.simulateMessage(JSON.stringify({
+        type: "action_result",
+        requestId: sent.requestId,
+        action: "focus",
+        success: false,
+        error: "Element not found with resource-id: com.example:id/missing",
+        totalTimeMs: 1
+      }));
+
+      await expect(resultPromise).rejects.toThrow(/Element not found with resource-id/);
+    } finally {
+      await client.close();
+    }
+  });
+
+  test("setAccessibilityFocus rejects empty resource-id without sending a request", async function() {
+    const { factory } = createCapturingFactory(fakeTimer);
+    const client = AndroidCtrlProxyClient.createForTesting(testDevice, fakeAdb, factory, fakeTimer);
+    try {
+      await expect(client.setAccessibilityFocus("")).rejects.toThrow(/requires a resource-id/);
+    } finally {
+      await client.close();
+    }
+  });
+
+  test("setAccessibilityFocus surfaces the timeout error when no result arrives", async function() {
+    const { factory, getSocket } = createCapturingFactory(fakeTimer);
+    const client = AndroidCtrlProxyClient.createForTesting(testDevice, fakeAdb, factory, fakeTimer);
+    try {
+      await client.ensureConnected();
+      const socket = await waitForSocket(getSocket);
+      await waitForSocketOpen(socket);
+
+      // Use a short timeout; never simulate a result so the RequestManager times out.
+      await expect(client.setAccessibilityFocus("com.example:id/title", 50)).rejects.toThrow(/timeout/i);
+    } finally {
+      await client.close();
+    }
+  });
+
+  test("returns error (throws) when WebSocket is not connected", async function() {
+    const { factory } = createCapturingFactory(fakeTimer);
+    const client = AndroidCtrlProxyClient.createForTesting(testDevice, fakeAdb, factory, fakeTimer);
+    try {
+      // No ensureConnected; fakeAdb forward is set but we never open the socket via the client.
+      // sendAction will attempt to connect; if it cannot it returns a connection error.
+      const result = client.setAccessibilityFocus("com.example:id/title", 50);
+      await expect(result).rejects.toThrow();
+    } finally {
+      await client.close();
+    }
+  });
+});


### PR DESCRIPTION
Closes #2503.

Implements the previously-`NOT IMPLEMENTED` accessibility-focus capability. The Kotlin CtrlProxy `AccessibilityService` already performs `ACTION_ACCESSIBILITY_FOCUS` / `ACTION_CLEAR_ACCESSIBILITY_FOCUS` (`performNodeAction`), so this was a **TypeScript wiring gap** — no Kotlin change was required.

## What
- `CtrlProxyFocus.setAccessibilityFocus(resourceId)` / `clearAccessibilityFocus(resourceId)` now send a `request_action` (`focus` / `clear_focus`) over the existing WebSocket protocol and await the result, instead of throwing.
- New `SetAccessibilityFocus` feature class: iOS gating (Android-only — TalkBack), selector (`resourceId` / `text` / `contentDesc`) → resource-id resolution via the element finder, best-effort focused-element confirmation.
- New `accessibilityFocus` MCP tool (`action: set|clear`) with a structured output schema.

## Validation
- `bun test` — 19 new tests pass (`SetAccessibilityFocus` 13, `CtrlProxyFocus` 6); broader observe/android + accessibility + server suites green (no existing tests broken).
- `tsc --noEmit` clean on changed files; `eslint --fix` clean; `bun build.ts` succeeds.
- **Kotlin**: `./gradlew :control-proxy:compileDebugKotlin` BUILD SUCCESSFUL (confirms the existing service handlers compile; no Kotlin change).
- `validate_mkdocs_nav.sh` passes.
- ⚠️ No on-device E2E — no Android emulator/device with the CtrlProxy a11y service was available in this environment. Manual E2E steps are documented in the design doc and issue #2503 for verification.

## Docs
New `plat/android/accessibility-focus.md`; cross-linked from `a11y/index.md` and `talkback.md`.

Part of milestone **iOS/Android tool parity**.