### PR TITLE
feat(ios): getDeepLinks, getNotificationPolicy & deviceSnapshot settings on iOS Simulator

### DIFF
--- a/docs/design-docs/plat/android/notifications.md
+++ b/docs/design-docs/plat/android/notifications.md
@@ -82,3 +82,16 @@ Observed results:
 
 - Requires app-under-test integration (not possible for third-party apps).
 - Big picture style has size constraints and may fail with large images.
+
+## Notification policy (cross-platform)
+
+`getNotificationPolicy` reads notification *policy state*, but the underlying concept
+differs by platform:
+
+- **Android** — Do Not Disturb *policy access* (which apps may control DND), read from
+  `dumpsys notification`'s `mPolicyAccess` section. `setNotificationPolicy` can grant/revoke
+  it via `cmd notification`.
+- **iOS simulators** — per-app *notification authorization* (`UNAuthorizationStatus`:
+  notDetermined/denied/authorized/provisional/ephemeral), decoded from the BulletinBoard
+  `VersionedSectionInfo.plist`. Read-only; physical devices are unsupported. See
+  [simctl Integration → Notification authorization read](../ios/simctl.md#notification-authorization-read).

--- a/docs/design-docs/plat/ios/simctl.md
+++ b/docs/design-docs/plat/ios/simctl.md
@@ -207,8 +207,9 @@ rather than throwing.
 - Simulator only. Physical devices return `supported: false` (no host-side read API;
   notification settings are only available to the owning app at runtime via
   `UNUserNotificationCenter`).
-- Read-only. `setNotificationPolicy` stays unsupported on iOS (writing would require
-  reloading the BulletinBoard daemon caches or `applesimutils --setPermissions`).
+- Read-only. `setNotificationPolicy` stays unsupported on iOS: there is no public API
+  to write per-app notification authorization, and editing the BulletinBoard plist on
+  disk would not take effect without restarting the daemon.
 - This is per-app *authorization status*, a different concept from Android's DND
   *policy access* — see [Notifications](../android/notifications.md).
 

--- a/docs/design-docs/plat/ios/simctl.md
+++ b/docs/design-docs/plat/ios/simctl.md
@@ -17,6 +17,9 @@ system-level simulator behaviors.
 - Live locale and localization changes (see below).
 - Biometric (Touch ID / Face ID) simulation for `biometricAuth` (see below).
 - Simulated push delivery for `postNotification` (see below).
+- Deep-link / URL-scheme discovery from the installed `.app` bundle (see below).
+- Per-app notification authorization read via BulletinBoard (see below).
+- Device settings capture/restore for `deviceSnapshot` (see below).
 
 ## Live locale changes
 
@@ -131,6 +134,121 @@ that needs no AutoMobile iOS SDK — but it does require an explicit `appId` (bu
   and `actions` (need a pre-registered `UNNotificationCategory`) are ignored with a
   `warning` rather than failing.
 
+## Deep-link discovery
+
+<kbd>✅ Implemented</kbd> <kbd>🧪 Tested</kbd> <kbd>📱 Simulator Only</kbd>
+
+The `getDeepLinks` MCP tool returns an iOS app's declared deep links. iOS apps declare
+deep links statically in bundle metadata rather than via a runtime resolver, so AutoMobile
+reads them off the installed `.app` bundle on disk. Custom URL schemes and universal-link
+hosts come from two different sources.
+
+### How it works
+
+1. **Resolve the bundle path** — `xcrun simctl get_app_container <udid> <bundleId> app`
+   returns the `.app`'s host filesystem path. A missing app exits non-zero and is reported
+   as a clean "not installed" result.
+2. **URL schemes** — read `<app>/Info.plist` with host `plutil -convert json` and collect
+   `CFBundleURLTypes[].CFBundleURLSchemes[]` (deduplicated). These become the `schemes`
+   field.
+3. **Universal-link hosts** — `codesign -d --entitlements :- <app> | plutil -convert json`
+   surfaces the code-signing entitlements; AutoMobile keeps
+   `com.apple.developer.associated-domains` entries prefixed with `applinks:` and strips the
+   prefix. These become the `hosts` field. Unsigned bundles or bundles without associated
+   domains yield `[]`, not an error.
+4. **Document types** — best-effort `supportedMimeTypes` from
+   `CFBundleDocumentTypes[].LSItemContentTypes[]`.
+5. **Cross-platform shape** — synthesized `intentFilters` (one VIEW filter listing each
+   scheme/host) keep the `DeepLinkResult` shape identical to Android so platform-agnostic
+   callers work unchanged.
+
+`get_app_container` routes through `simctl`; `plutil`/`codesign` are host tools (not
+`simctl` subcommands) and run directly on the host filesystem.
+
+### Limitations
+
+- Simulator only. Physical-device discovery (copying the device-signed bundle off-device
+  via `devicectl`) returns an explicit "not yet implemented" error.
+- iOS has no runtime intent resolver, so only *declared* schemes/domains are reported.
+- `supportedMimeTypes` is best-effort document-type metadata, not a routing guarantee.
+
+## Notification authorization read
+
+<kbd>✅ Implemented</kbd> <kbd>🧪 Tested</kbd> <kbd>📱 Simulator Only</kbd>
+
+The `getNotificationPolicy` MCP tool reports per-app notification authorization
+(`UNAuthorizationStatus`) on iOS simulators by reading the BulletinBoard daemon's on-disk
+section info. There is no host-side runtime API for this, so AutoMobile decodes the
+persisted plist.
+
+### How it works
+
+1. **Locate the plist** —
+   `~/Library/Developer/CoreSimulator/Devices/<udid>/data/Library/BulletinBoard/VersionedSectionInfo.plist`.
+2. **Decode the outer plist** — convert it with `plutil -convert xml1` (not `json`: the
+   file embeds `<data>` blobs JSON cannot represent) and extract the base64 `<data>` blob
+   registered under `sectionInfo[<bundleId>]`.
+3. **Decode the nested blob** — each section value is a separate `bplist00`
+   NSKeyedArchiver archive. Because it contains `CFKeyedArchiverUID` refs that
+   `plutil -convert json` rejects, AutoMobile writes the blob to a temp file and converts
+   it with `plutil -convert xml1`, then reads the settings dict scalars
+   (`authorizationStatus`, `alertType`, `lockScreenSetting`, `notificationCenterSetting`,
+   `pushSettings`).
+4. **Map the status** — `authorizationStatus` maps to
+   `notDetermined`/`denied`/`authorized`/`provisional`/`ephemeral`; `allowed` is true only
+   for `authorized` (2). The result uses `method: "ios_bulletinboard_plist"`.
+
+An app with no registered section returns `allowed: null` plus a warning (the app likely
+never requested authorization), not an error. A missing/unreadable plist returns a warning
+rather than throwing.
+
+### Limitations
+
+- Simulator only. Physical devices return `supported: false` (no host-side read API;
+  notification settings are only available to the owning app at runtime via
+  `UNUserNotificationCenter`).
+- Read-only. `setNotificationPolicy` stays unsupported on iOS (writing would require
+  reloading the BulletinBoard daemon caches or `applesimutils --setPermissions`).
+- This is per-app *authorization status*, a different concept from Android's DND
+  *policy access* — see [Notifications](../android/notifications.md).
+
+## Device settings snapshot
+
+<kbd>✅ Implemented</kbd> <kbd>🧪 Tested</kbd> <kbd>📱 Simulator Only</kbd>
+
+When `deviceSnapshot` is invoked with `includeSettings: true` on an iOS simulator,
+AutoMobile captures and restores a curated allowlist of simulator settings alongside app
+data. (Previously iOS silently dropped settings and hard-coded the manifest to
+`includeSettings: false`.)
+
+### How it works
+
+1. **Capture per-key defaults** — for each `(domain, key)` in the allowlist, run
+   `xcrun simctl spawn <udid> defaults read <domain> <key>` and record the value. The
+   allowlist is scalar-only for now (`{.GlobalPreferences, AppleLocale}`); array-typed keys
+   such as `AppleLanguages` are a follow-up because a plain per-key `defaults write` cannot
+   round-trip them.
+2. **Capture UI state** — `xcrun simctl ui <udid> appearance` and `... content_size` read
+   the device-level light/dark appearance and Dynamic Type size.
+3. **Persist to the manifest** — captured values go into a distinct optional
+   `iosSettings` manifest field (separate from Android's `global/secure/system` triplet,
+   which does not fit `(domain, key)` exports).
+4. **Restore surgically** — on restore (gated on `manifest.includeSettings &&
+   manifest.iosSettings`, identical to Android), each value is re-applied with a per-key
+   `defaults write` (never a whole-domain `defaults import`, so system-managed keys are not
+   clobbered), then `simctl ui appearance`/`content_size` re-apply UI state so it takes
+   effect without a respawn.
+
+Individual key read/write failures are logged and skipped (non-fatal), matching the
+per-package resilience of iOS app-data restore.
+
+### Limitations
+
+- Simulator only; physical-device settings are not reachable via `simctl`.
+- Scalar keys only in the first cut; array-typed and per-app domains are future work.
+- `simctl spawn ... defaults` has no stdin, so whole-domain `defaults export/import` is not
+  used — the per-key allowlist is the deliberate, auditable design.
+
 ## Usage patterns
 
 - Prefer deterministic simulator selection by device identifier.
@@ -147,4 +265,6 @@ that needs no AutoMobile iOS SDK — but it does require an explicit `appId` (bu
 - [CtrlProxy iOS](xctestrunner/index.md) - Touch injection and element queries.
 - [iOS overview](index.md)
 - [Android biometrics](../android/biometrics.md) - The `biometricAuth` Android counterpart.
-- [Android notifications](../android/notifications.md) - The `postNotification` Android counterpart.
+- [Android notifications](../android/notifications.md) - The `postNotification` Android counterpart,
+  and the cross-platform notification policy concept (Android DND policy access vs iOS
+  per-app authorization).

--- a/src/features/action/CaptureSnapshotIos.ts
+++ b/src/features/action/CaptureSnapshotIos.ts
@@ -4,6 +4,7 @@ import type { CaptureSnapshotArgs, CaptureSnapshotResult } from "./CaptureSnapsh
 import { DeviceSnapshotStore, SnapshotPathOptions } from "../../utils/DeviceSnapshotStore";
 import { SimCtlClient } from "../../utils/ios-cmdline-tools/SimCtlClient";
 import { getAppDataContainerPath, IOS_APP_DATA_FOLDERS } from "../../utils/ios-cmdline-tools/iosAppContainer";
+import { captureIosSettings, type IosSettingsSnapshot } from "../../utils/ios-cmdline-tools/iosSettings";
 import { pathExists } from "../../utils/filesystem/DefaultFileSystem";
 import { logger } from "../../utils/logger";
 import { promises as fs } from "fs";
@@ -55,8 +56,9 @@ export class CaptureSnapshotIos implements SnapshotCaptureProvider {
     const metadata = await this.getDeviceMetadata();
     const pathOptions = this.getPathOptions();
 
+    let iosSettings: IosSettingsSnapshot | undefined;
     if (includeSettings) {
-      logger.warn("[iOS] includeSettings requested, but settings capture is not supported for iOS app data snapshots");
+      iosSettings = await captureIosSettings(this.simctl, this.device.deviceId);
     }
 
     const appDataBackup = includeAppData
@@ -73,7 +75,8 @@ export class CaptureSnapshotIos implements SnapshotCaptureProvider {
       osVersion: metadata.osVersion,
       snapshotType: "app_data",
       includeAppData,
-      includeSettings: false,
+      includeSettings,
+      ...(iosSettings ? { iosSettings } : {}),
       appDataBackup,
     };
 

--- a/src/features/action/RestoreSnapshotIos.ts
+++ b/src/features/action/RestoreSnapshotIos.ts
@@ -4,6 +4,7 @@ import type { RestoreSnapshotArgs, RestoreSnapshotResult } from "./RestoreSnapsh
 import { DeviceSnapshotStore, SnapshotPathOptions } from "../../utils/DeviceSnapshotStore";
 import { SimCtlClient } from "../../utils/ios-cmdline-tools/SimCtlClient";
 import { getAppDataContainerPath, IOS_APP_DATA_FOLDERS, terminateAppIfRunning } from "../../utils/ios-cmdline-tools/iosAppContainer";
+import { restoreIosSettings } from "../../utils/ios-cmdline-tools/iosSettings";
 import { pathExists } from "../../utils/filesystem/DefaultFileSystem";
 import { logger } from "../../utils/logger";
 import { promises as fs } from "fs";
@@ -54,6 +55,11 @@ export class RestoreSnapshotIos implements SnapshotRestoreProvider {
     }
 
     await this.validateSnapshotCompatibility(manifest);
+
+    if (manifest.includeSettings && manifest.iosSettings) {
+      await restoreIosSettings(this.simctl, this.device.deviceId, manifest.iosSettings);
+    }
+
     await this.restoreAppData(snapshotName, manifest);
 
     logger.info(`[iOS] Snapshot '${snapshotName}' restored successfully`);

--- a/src/features/utility/NotificationPolicy.ts
+++ b/src/features/utility/NotificationPolicy.ts
@@ -2,14 +2,27 @@ import { defaultAdbClientFactory, type AdbClientFactory } from "../../utils/andr
 import type { AdbExecutor } from "../../utils/android-cmdline-tools/interfaces/AdbExecutor";
 import type { BootedDevice } from "../../models";
 import { SetAndroidNotificationPolicyAccess } from "../action/SetAndroidNotificationPolicyAccess";
+import {
+  defaultBulletinBoardReader,
+  type IosNotificationAuthorizationReader,
+} from "./ios/IosNotificationAuthorizationReader";
 
 export interface NotificationPolicyAccessState {
   supported: boolean;
   allowed?: boolean | null;
-  method?: "android_cmd_notification" | "android_dumpsys_notification" | "unsupported";
+  method?:
+    | "android_cmd_notification"
+    | "android_dumpsys_notification"
+    | "ios_bulletinboard_plist"
+    | "unsupported";
   rawValue?: string;
   warning?: string;
   error?: string;
+  // iOS-only enrichment (all optional so the Android shape is unchanged):
+  authorizationStatus?: "notDetermined" | "denied" | "authorized" | "provisional" | "ephemeral";
+  lockScreen?: boolean;
+  notificationCenter?: boolean;
+  alerts?: boolean;
 }
 
 export interface NotificationPolicyResult {
@@ -27,6 +40,7 @@ export interface SetNotificationPolicyInput {
 
 export interface NotificationPolicyDependencies {
   adbFactory?: AdbClientFactory;
+  iosReader?: IosNotificationAuthorizationReader;
 }
 
 function escapeRegExp(value: string): string {
@@ -87,12 +101,28 @@ export class NotificationPolicy {
 
   private adbFactory: AdbClientFactory;
 
+  private iosReader?: IosNotificationAuthorizationReader;
+
   constructor(device: BootedDevice, dependencies: NotificationPolicyDependencies = {}) {
     this.device = device;
     this.adbFactory = dependencies.adbFactory ?? defaultAdbClientFactory;
+    this.iosReader = dependencies.iosReader;
   }
 
   async getPolicy(appId: string): Promise<NotificationPolicyResult> {
+    if (this.device.platform === "ios") {
+      const reader = this.iosReader ?? defaultBulletinBoardReader();
+      const policyAccess = await reader.read(this.device.deviceId, appId);
+      return {
+        success: !policyAccess.error,
+        appId,
+        deviceId: this.device.deviceId,
+        platform: "ios",
+        policyAccess,
+        ...(policyAccess.error ? { error: policyAccess.error } : {}),
+      };
+    }
+
     if (this.device.platform !== "android") {
       const error = "iOS does not expose app notification policy access for simulators or physical devices";
       return {

--- a/src/features/utility/ios/IosNotificationAuthorizationReader.ts
+++ b/src/features/utility/ios/IosNotificationAuthorizationReader.ts
@@ -1,0 +1,187 @@
+import * as os from "os";
+import * as path from "path";
+import { isIosSimulatorUdid } from "../../../utils/ios-cmdline-tools/iosDeviceType";
+import { logger } from "../../../utils/logger";
+import type { NotificationPolicyAccessState } from "../NotificationPolicy";
+
+/**
+ * `UNAuthorizationStatus` ordering — the on-disk `authorizationStatus` integer
+ * maps directly onto this enum.
+ */
+const UN_AUTH = ["notDetermined", "denied", "authorized", "provisional", "ephemeral"] as const;
+
+/** Settings keys decoded from the per-bundle BulletinBoard NSKeyedArchiver blob. */
+export interface BulletinBoardSettings {
+  authorizationStatus?: number;
+  pushSettings?: number;
+  alertType?: number;
+  lockScreenSetting?: number;
+  notificationCenterSetting?: number;
+}
+
+export interface IosNotificationAuthorizationReader {
+  read(deviceId: string, bundleId: string): Promise<NotificationPolicyAccessState>;
+}
+
+/**
+ * Dependencies injected so the reader is fully fakeable (<100ms, no real device,
+ * no real `plutil`).
+ *
+ * `plutilToXml` is the ONLY thing that shells out. We convert to **xml1** rather
+ * than json because BulletinBoard blobs are NSKeyedArchiver archives containing
+ * `CFKeyedArchiverUID` refs, which `plutil -convert json` rejects ("invalid
+ * object in plist for destination format"). xml1 round-trips them losslessly,
+ * and the scalar settings we need (`authorizationStatus`, etc.) appear as plain
+ * `<integer>` values we can extract without a full plist parser.
+ */
+export interface BulletinBoardReaderDeps {
+  /** Run `plutil -convert xml1 -o - -- <path>` and return the XML string. */
+  plutilToXml(path: string): Promise<string>;
+  /** Persist a decoded nested blob to a temp file; returns its path. */
+  writeTemp(buf: Buffer): Promise<string>;
+  /** Remove a temp file written by {@link writeTemp}. */
+  rmTemp(path: string): Promise<void>;
+  /** Absolute path of a simulator device root (…/CoreSimulator/Devices/<udid>). */
+  deviceDataRoot(udid: string): string;
+}
+
+/**
+ * Extract the base64 `<data>` blob registered under `sectionInfo[bundleId]` in
+ * the outer `VersionedSectionInfo.plist` XML. Returns null if the bundle has no
+ * section registered.
+ */
+export function extractSectionDataBase64(outerXml: string, bundleId: string): string | null {
+  // Match `<key>bundleId</key>` followed (ignoring whitespace) by `<data>…</data>`.
+  // Bundle IDs are dotted identifiers, so escape regex metacharacters.
+  const escaped = bundleId.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const re = new RegExp(`<key>${escaped}</key>\\s*<data>([\\s\\S]*?)</data>`);
+  const match = outerXml.match(re);
+  if (!match) {
+    return null;
+  }
+  // Strip all whitespace from the base64 payload (plutil wraps it across lines).
+  return match[1].replace(/\s+/g, "");
+}
+
+/**
+ * Extract the BulletinBoard settings scalars from the decoded nested-blob XML.
+ * The settings dict is the `<dict>` carrying `<key>authorizationStatus</key>`;
+ * we pull each integer key globally (the archive has exactly one settings dict).
+ */
+export function parseSettingsFromNestedXml(nestedXml: string): BulletinBoardSettings {
+  const intKey = (key: string): number | undefined => {
+    const re = new RegExp(`<key>${key}</key>\\s*<integer>(-?\\d+)</integer>`);
+    const match = nestedXml.match(re);
+    return match ? Number(match[1]) : undefined;
+  };
+  return {
+    authorizationStatus: intKey("authorizationStatus"),
+    pushSettings: intKey("pushSettings"),
+    alertType: intKey("alertType"),
+    lockScreenSetting: intKey("lockScreenSetting"),
+    notificationCenterSetting: intKey("notificationCenterSetting"),
+  };
+}
+
+export class BulletinBoardAuthorizationReader implements IosNotificationAuthorizationReader {
+  constructor(private readonly deps: BulletinBoardReaderDeps) {}
+
+  async read(deviceId: string, bundleId: string): Promise<NotificationPolicyAccessState> {
+    if (!isIosSimulatorUdid(deviceId)) {
+      return {
+        supported: false,
+        method: "unsupported",
+        error:
+          "iOS notification authorization can only be read on simulators (no host-side API on physical devices)",
+      };
+    }
+
+    const path = `${this.deps.deviceDataRoot(deviceId)}/data/Library/BulletinBoard/VersionedSectionInfo.plist`;
+
+    let outerXml: string;
+    try {
+      outerXml = await this.deps.plutilToXml(path);
+    } catch (error) {
+      logger.debug(`[iOS] No BulletinBoard section info (${path}): ${error}`);
+      return {
+        supported: true,
+        allowed: null,
+        method: "ios_bulletinboard_plist",
+        warning: `No BulletinBoard section info for device (${path} not found or unreadable)`,
+      };
+    }
+
+    const base64Blob = extractSectionDataBase64(outerXml, bundleId);
+    if (!base64Blob) {
+      return {
+        supported: true,
+        allowed: null,
+        method: "ios_bulletinboard_plist",
+        warning: `No notification section registered for ${bundleId} (app may never have requested authorization)`,
+      };
+    }
+
+    const settings = await this.decodeNestedBlob(Buffer.from(base64Blob, "base64"));
+
+    const status =
+      settings.authorizationStatus !== undefined && settings.authorizationStatus < UN_AUTH.length
+        ? UN_AUTH[settings.authorizationStatus]
+        : undefined;
+
+    return {
+      supported: true,
+      method: "ios_bulletinboard_plist",
+      allowed: settings.authorizationStatus === 2,
+      authorizationStatus: status,
+      lockScreen: settings.lockScreenSetting === 2,
+      notificationCenter: settings.notificationCenterSetting === 2,
+      alerts: settings.alertType !== undefined && settings.alertType !== 0,
+      rawValue:
+        `authorizationStatus=${settings.authorizationStatus} ` +
+        `pushSettings=${settings.pushSettings} alertType=${settings.alertType}`,
+    };
+  }
+
+  private async decodeNestedBlob(blob: Buffer): Promise<BulletinBoardSettings> {
+    const tmp = await this.deps.writeTemp(blob);
+    try {
+      const nestedXml = await this.deps.plutilToXml(tmp);
+      return parseSettingsFromNestedXml(nestedXml);
+    } finally {
+      try {
+        await this.deps.rmTemp(tmp);
+      } catch {
+        // best-effort temp cleanup
+      }
+    }
+  }
+}
+
+/** Wire the real deps: host `plutil`, `fs` temp files, CoreSimulator device root. */
+export function defaultBulletinBoardReader(): IosNotificationAuthorizationReader {
+  return new BulletinBoardAuthorizationReader({
+    plutilToXml: async path => {
+      const { execFile } = await import("child_process");
+      const { promisify } = await import("util");
+      const result = await promisify(execFile)(
+        "plutil",
+        ["-convert", "xml1", "-o", "-", "--", path],
+        { maxBuffer: 16 * 1024 * 1024 }
+      );
+      return typeof result.stdout === "string" ? result.stdout : result.stdout.toString();
+    },
+    writeTemp: async buf => {
+      const { promises: fs } = await import("fs");
+      const dir = await fs.mkdtemp(path.join(os.tmpdir(), "automobile-bb-"));
+      const file = path.join(dir, "blob.bplist");
+      await fs.writeFile(file, buf);
+      return file;
+    },
+    rmTemp: async file => {
+      const { promises: fs } = await import("fs");
+      await fs.rm(path.dirname(file), { recursive: true, force: true });
+    },
+    deviceDataRoot: udid =>
+      path.join(os.homedir(), "Library/Developer/CoreSimulator/Devices", udid),
+  });
+}

--- a/src/models/DeepLinkResult.ts
+++ b/src/models/DeepLinkResult.ts
@@ -26,3 +26,15 @@ export interface DeepLinkResult {
     rawOutput?: string;
     error?: string;
 }
+
+/**
+ * Minimal shape of an iOS app's `Info.plist` relevant to deep-link discovery.
+ * Custom URL schemes are declared under `CFBundleURLTypes`; document/MIME types
+ * under `CFBundleDocumentTypes`. Universal-link hosts are NOT here — they live in
+ * the code-signing entitlements (`com.apple.developer.associated-domains`).
+ */
+export interface IosInfoPlist {
+    CFBundleURLTypes?: { CFBundleURLName?: string; CFBundleURLSchemes?: string[] }[];
+    CFBundleDocumentTypes?: { LSItemContentTypes?: string[] }[];
+    LSApplicationQueriesSchemes?: string[];
+}

--- a/src/models/DeviceSnapshot.ts
+++ b/src/models/DeviceSnapshot.ts
@@ -18,6 +18,15 @@ export interface DeviceSnapshotManifest {
     secure?: Record<string, string>;
     system?: Record<string, string>;
   };
+  /**
+   * iOS simulator settings captured via `defaults`/`simctl ui`. Distinct from the
+   * Android `settings` triplet because iOS `(domain, key)` exports do not fit that
+   * shape. Present only when an iOS snapshot was captured with `includeSettings`.
+   */
+  iosSettings?: {
+    values: Record<string, string>;
+    ui?: { appearance?: "light" | "dark"; contentSize?: string };
+  };
   appDataBackup?: {
     backupFile?: string;
     backedUpPackages?: string[];

--- a/src/utils/DeepLinkManager.ts
+++ b/src/utils/DeepLinkManager.ts
@@ -20,26 +20,47 @@ import { quoteSimctlArg } from "./ios-cmdline-tools/iosAppContainer";
 import { isIosSimulatorUdid } from "./ios-cmdline-tools/iosDeviceType";
 
 /**
- * Runs a host shell command (NOT `xcrun simctl`). Used for `plutil`/`codesign`,
- * which read the `.app` bundle's metadata directly on the host filesystem.
- * Modeled on {@link DeviceAppInspector}'s injected `exec` so the iOS path is
- * fully fakeable in unit tests.
+ * Runs a host program (NOT `xcrun simctl`) **by argv, never via a shell**. Used
+ * for `plutil`/`codesign`, which read the `.app` bundle's metadata directly on
+ * the host filesystem. Passing an argv array (rather than a command string)
+ * means a malicious `.app` path containing shell metacharacters — `$(…)`,
+ * backticks, `;`, … — is handed to the program as a single literal argument and
+ * can never be expanded into host command execution. The optional `stdin` feeds
+ * one program's output into the next without a shell pipe. Modeled on
+ * {@link DeviceAppInspector}'s injected `exec` so the iOS path is fully fakeable
+ * in unit tests.
  */
-export type HostExec = (command: string) => Promise<ExecResult>;
+export type HostExec = (file: string, args: string[], stdin?: string) => Promise<ExecResult>;
 
-const defaultHostExec: HostExec = async command => {
-  const { exec } = await import("child_process");
-  const { promisify } = await import("util");
-  const result = await promisify(exec)(command, { maxBuffer: 16 * 1024 * 1024 });
-  const stdout = typeof result.stdout === "string" ? result.stdout : result.stdout.toString();
-  const stderr = typeof result.stderr === "string" ? result.stderr : result.stderr.toString();
-  return {
-    stdout,
-    stderr,
-    toString() { return stdout; },
-    trim() { return stdout.trim(); },
-    includes(searchString: string) { return stdout.includes(searchString); },
-  };
+const makeExecResult = (stdout: string, stderr: string): ExecResult => ({
+  stdout,
+  stderr,
+  toString() { return stdout; },
+  trim() { return stdout.trim(); },
+  includes(searchString: string) { return stdout.includes(searchString); },
+});
+
+const defaultHostExec: HostExec = async (file, args, stdin) => {
+  const { execFile } = await import("child_process");
+  return new Promise<ExecResult>((resolve, reject) => {
+    const child = execFile(
+      file,
+      args,
+      { maxBuffer: 16 * 1024 * 1024 },
+      (error, stdout, stderr) => {
+        if (error) {
+          reject(error);
+          return;
+        }
+        const out = typeof stdout === "string" ? stdout : stdout.toString();
+        const err = typeof stderr === "string" ? stderr : stderr.toString();
+        resolve(makeExecResult(out, err));
+      }
+    );
+    if (stdin !== undefined) {
+      child.stdin?.end(stdin);
+    }
+  });
 };
 
 /**
@@ -234,9 +255,12 @@ export class DeepLinkManager implements DeepLinkManager {
         return this.emptyIosResult(bundleId, `App ${bundleId} is not installed on ${udid}`);
       }
 
-      // 2. Info.plist -> JSON via host plutil.
+      // 2. Info.plist -> JSON via host plutil. argv form (no shell): the
+      //    bundle path is a literal argument, so a crafted `.app` name cannot
+      //    inject host commands.
       const plistJson = await this.hostExec(
-        `plutil -convert json -o - -- ${quoteSimctlArg(`${appPath}/Info.plist`)}`
+        "plutil",
+        ["-convert", "json", "-o", "-", "--", `${appPath}/Info.plist`]
       );
       const info = JSON.parse(plistJson.stdout) as IosInfoPlist;
 
@@ -301,8 +325,17 @@ export class DeepLinkManager implements DeepLinkManager {
    */
   private async parseAssociatedDomains(appPath: string): Promise<string[]> {
     try {
+      // Two argv calls (no shell pipe): `codesign` dumps the entitlements plist
+      // to stdout, which is fed to `plutil` via stdin. The bundle path is a
+      // literal argv element, so a crafted `.app` name cannot inject commands.
+      const entsXml = await this.hostExec(
+        "codesign",
+        ["-d", "--entitlements", ":-", appPath]
+      );
       const ents = await this.hostExec(
-        `codesign -d --entitlements :- ${quoteSimctlArg(appPath)} | plutil -convert json -o - -- -`
+        "plutil",
+        ["-convert", "json", "-o", "-", "--", "-"],
+        entsXml.stdout
       );
       const parsed = JSON.parse(ents.stdout) as Record<string, unknown>;
       const domains = parsed["com.apple.developer.associated-domains"];

--- a/src/utils/DeepLinkManager.ts
+++ b/src/utils/DeepLinkManager.ts
@@ -7,12 +7,40 @@ import {
   DeepLinkInfo,
   IntentChooserResult,
   ViewHierarchyResult,
-  BootedDevice
+  BootedDevice,
+  IosInfoPlist,
+  ExecResult
 } from "../models";
 import type { ElementParser } from "./interfaces/ElementParser";
 import type { ElementGeometry } from "./interfaces/ElementGeometry";
 import { DefaultElementParser } from "../features/utility/ElementParser";
 import { DefaultElementGeometry } from "../features/utility/ElementGeometry";
+import { SimCtlClient } from "./ios-cmdline-tools/SimCtlClient";
+import { quoteSimctlArg } from "./ios-cmdline-tools/iosAppContainer";
+import { isIosSimulatorUdid } from "./ios-cmdline-tools/iosDeviceType";
+
+/**
+ * Runs a host shell command (NOT `xcrun simctl`). Used for `plutil`/`codesign`,
+ * which read the `.app` bundle's metadata directly on the host filesystem.
+ * Modeled on {@link DeviceAppInspector}'s injected `exec` so the iOS path is
+ * fully fakeable in unit tests.
+ */
+export type HostExec = (command: string) => Promise<ExecResult>;
+
+const defaultHostExec: HostExec = async command => {
+  const { exec } = await import("child_process");
+  const { promisify } = await import("util");
+  const result = await promisify(exec)(command, { maxBuffer: 16 * 1024 * 1024 });
+  const stdout = typeof result.stdout === "string" ? result.stdout : result.stdout.toString();
+  const stderr = typeof result.stderr === "string" ? result.stderr : result.stderr.toString();
+  return {
+    stdout,
+    stderr,
+    toString() { return stdout; },
+    trim() { return stdout.trim(); },
+    includes(searchString: string) { return stdout.includes(searchString); },
+  };
+};
 
 /**
  * Interface for deep link management and intent chooser handling
@@ -54,12 +82,20 @@ export interface DeepLinkManager {
 }
 
 export class DeepLinkManager implements DeepLinkManager {
+  private device: BootedDevice | null;
   private adbUtils: AdbExecutor;
   private adbFactory: AdbClientFactory;
   private parser: ElementParser;
   private geometry: ElementGeometry;
+  private simctl: SimCtlClient;
+  private hostExec: HostExec;
 
-  constructor(device: BootedDevice | null = null, adbFactoryOrExecutor: AdbClientFactory | AdbExecutor | null = defaultAdbClientFactory) {
+  constructor(
+    device: BootedDevice | null = null,
+    adbFactoryOrExecutor: AdbClientFactory | AdbExecutor | null = defaultAdbClientFactory,
+    simctl: SimCtlClient | null = null,
+    hostExec: HostExec | null = null
+  ) {
     // Detect if the argument is a factory (has create method) or an executor
     if (adbFactoryOrExecutor && typeof (adbFactoryOrExecutor as AdbClientFactory).create === "function") {
       this.adbFactory = adbFactoryOrExecutor as AdbClientFactory;
@@ -73,6 +109,9 @@ export class DeepLinkManager implements DeepLinkManager {
       this.adbFactory = defaultAdbClientFactory;
       this.adbUtils = this.adbFactory.create(device);
     }
+    this.device = device;
+    this.simctl = simctl ?? new SimCtlClient(device);
+    this.hostExec = hostExec ?? defaultHostExec;
     this.parser = new DefaultElementParser();
     this.geometry = new DefaultElementGeometry();
   }
@@ -82,6 +121,7 @@ export class DeepLinkManager implements DeepLinkManager {
      * @param deviceId - Device identifier
      */
   setDeviceId(device: BootedDevice): void {
+    this.device = device;
     this.adbUtils = this.adbFactory.create(device);
   }
 
@@ -91,6 +131,21 @@ export class DeepLinkManager implements DeepLinkManager {
      * @returns Promise with deep link information
      */
   async getDeepLinks(appId: string): Promise<DeepLinkResult> {
+    switch (this.device?.platform) {
+      case "ios":
+        return this.getDeepLinksIos(appId);
+      case "android":
+      default:
+        return this.getDeepLinksAndroid(appId);
+    }
+  }
+
+  /**
+     * Android deep-link discovery via `dumpsys package`.
+     * @param appId - The application package ID
+     * @returns Promise with deep link information
+     */
+  private async getDeepLinksAndroid(appId: string): Promise<DeepLinkResult> {
     try {
       logger.info(`[DeepLinkManager] Querying deep links for app: ${appId}`);
 
@@ -138,6 +193,147 @@ export class DeepLinkManager implements DeepLinkManager {
         error: error instanceof Error ? error.message : String(error)
       };
     }
+  }
+
+  /**
+   * iOS deep-link discovery from static bundle metadata. Custom URL schemes come
+   * from the installed `.app`'s `Info.plist` (`CFBundleURLTypes`); universal-link
+   * hosts from the code-signing entitlements (`com.apple.developer.associated-domains`).
+   *
+   * Simulators only — the `.app` bundle is a host filesystem path
+   * (`get_app_container ... app`), so `plutil`/`codesign` read it directly on the
+   * host. Physical devices return an explicit "not yet implemented" failure.
+   * @param bundleId - The iOS bundle identifier
+   * @returns Promise with deep link information
+   */
+  private async getDeepLinksIos(bundleId: string): Promise<DeepLinkResult> {
+    try {
+      const udid = this.device!.deviceId;
+      logger.info(`[DeepLinkManager] Querying iOS deep links for bundle: ${bundleId}`);
+
+      if (!isIosSimulatorUdid(udid)) {
+        return this.emptyIosResult(
+          bundleId,
+          `Physical-device deep-link discovery for ${bundleId} is not yet implemented`
+        );
+      }
+
+      // 1. Resolve the installed .app bundle path (HOST path on the simulator).
+      //    A missing app makes simctl exit non-zero ("No such file or directory");
+      //    treat that as a clean not-installed result, not a raw thrown error.
+      let appPath = "";
+      try {
+        const container = await this.simctl.executeCommand(
+          `get_app_container ${quoteSimctlArg(udid)} ${quoteSimctlArg(bundleId)} app`
+        );
+        appPath = container.stdout.trim();
+      } catch (error) {
+        logger.debug(`[DeepLinkManager] get_app_container failed for ${bundleId}: ${error}`);
+      }
+      if (!appPath) {
+        return this.emptyIosResult(bundleId, `App ${bundleId} is not installed on ${udid}`);
+      }
+
+      // 2. Info.plist -> JSON via host plutil.
+      const plistJson = await this.hostExec(
+        `plutil -convert json -o - -- ${quoteSimctlArg(`${appPath}/Info.plist`)}`
+      );
+      const info = JSON.parse(plistJson.stdout) as IosInfoPlist;
+
+      const schemes = this.parseCFBundleURLSchemes(info);
+      const hosts = await this.parseAssociatedDomains(appPath);
+      const supportedMimeTypes = this.parseDocumentTypes(info);
+
+      return {
+        success: true,
+        appId: bundleId,
+        deepLinks: {
+          schemes,
+          hosts,
+          supportedMimeTypes,
+          intentFilters: this.synthesizeIosIntentFilters(schemes, hosts)
+        },
+        rawOutput: plistJson.stdout
+      };
+    } catch (error) {
+      logger.error(`[DeepLinkManager] Failed to get iOS deep links for ${bundleId}: ${error}`);
+      return this.emptyIosResult(bundleId, error instanceof Error ? error.message : String(error));
+    }
+  }
+
+  private emptyIosResult(appId: string, error: string): DeepLinkResult {
+    return {
+      success: false,
+      appId,
+      deepLinks: { schemes: [], hosts: [], intentFilters: [], supportedMimeTypes: [] },
+      error
+    };
+  }
+
+  private parseCFBundleURLSchemes(info: IosInfoPlist): string[] {
+    const out = new Set<string>();
+    for (const urlType of info.CFBundleURLTypes ?? []) {
+      for (const scheme of urlType.CFBundleURLSchemes ?? []) {
+        if (scheme) {
+          out.add(scheme);
+        }
+      }
+    }
+    return Array.from(out);
+  }
+
+  private parseDocumentTypes(info: IosInfoPlist): string[] {
+    const out = new Set<string>();
+    for (const docType of info.CFBundleDocumentTypes ?? []) {
+      for (const contentType of docType.LSItemContentTypes ?? []) {
+        if (contentType) {
+          out.add(contentType);
+        }
+      }
+    }
+    return Array.from(out);
+  }
+
+  /**
+   * Universal-link hosts from the bundle's entitlements (host `codesign` +
+   * `plutil`). Unsigned bundles or bundles without associated domains yield `[]`,
+   * not an error.
+   */
+  private async parseAssociatedDomains(appPath: string): Promise<string[]> {
+    try {
+      const ents = await this.hostExec(
+        `codesign -d --entitlements :- ${quoteSimctlArg(appPath)} | plutil -convert json -o - -- -`
+      );
+      const parsed = JSON.parse(ents.stdout) as Record<string, unknown>;
+      const domains = parsed["com.apple.developer.associated-domains"];
+      if (!Array.isArray(domains)) {
+        return [];
+      }
+      return domains
+        .filter((d): d is string => typeof d === "string" && d.startsWith("applinks:"))
+        .map(d => d.slice("applinks:".length));
+    } catch {
+      return [];
+    }
+  }
+
+  /**
+   * Synthesize cross-platform `IntentFilter` entries from iOS schemes/hosts so the
+   * `DeepLinkResult` shape stays populated for platform-agnostic consumers.
+   */
+  private synthesizeIosIntentFilters(schemes: string[], hosts: string[]): IntentFilter[] {
+    const data = [
+      ...schemes.map(scheme => ({ scheme })),
+      ...hosts.map(host => ({ host }))
+    ];
+    if (data.length === 0) {
+      return [];
+    }
+    return [{
+      action: "android.intent.action.VIEW",
+      category: [],
+      data
+    }];
   }
 
   /**

--- a/src/utils/ios-cmdline-tools/iosSettings.ts
+++ b/src/utils/ios-cmdline-tools/iosSettings.ts
@@ -1,0 +1,129 @@
+import type { SimCtlClient } from "./SimCtlClient";
+import { quoteSimctlArg } from "./iosAppContainer";
+import { logger } from "../logger";
+
+/**
+ * Curated (domain, key) allowlist captured/restored for iOS simulator snapshots.
+ *
+ * Deliberately NOT a full plist clone — a curated allowlist keeps restore robust
+ * across OS versions and surgical (per-key `defaults write`, never whole-domain
+ * `defaults import`, so system-managed keys are never clobbered).
+ *
+ * Restricted to **scalar string** keys for this cut: `defaults read AppleLanguages`
+ * returns array-shaped output that a plain per-key `defaults write` cannot
+ * round-trip without an array type flag, so array-typed keys are a follow-up.
+ */
+export const IOS_SETTINGS_KEYS: ReadonlyArray<{ domain: string; key: string }> = [
+  { domain: ".GlobalPreferences", key: "AppleLocale" },
+] as const;
+
+export interface IosSettingsSnapshot {
+  /** "domain/key" -> raw `defaults read` stdout value (scalar). */
+  values: Record<string, string>;
+  /** device-level UI state restorable via `simctl ui`. */
+  ui?: { appearance?: "light" | "dark"; contentSize?: string };
+}
+
+/**
+ * Read current device-level UI state. `simctl ui <udid> appearance` with no value
+ * prints the current setting; `content_size` is read the same way.
+ */
+async function captureUiState(
+  simctl: Pick<SimCtlClient, "executeCommand">,
+  deviceId: string
+): Promise<IosSettingsSnapshot["ui"]> {
+  const ui: NonNullable<IosSettingsSnapshot["ui"]> = {};
+  try {
+    const appearance = (
+      await simctl.executeCommand(`ui ${quoteSimctlArg(deviceId)} appearance`)
+    ).stdout.trim();
+    if (appearance === "light" || appearance === "dark") {
+      ui.appearance = appearance;
+    }
+  } catch (error) {
+    logger.warn(`[iOS] Failed to read appearance: ${error}`);
+  }
+  try {
+    const contentSize = (
+      await simctl.executeCommand(`ui ${quoteSimctlArg(deviceId)} content_size`)
+    ).stdout.trim();
+    if (contentSize) {
+      ui.contentSize = contentSize;
+    }
+  } catch (error) {
+    logger.warn(`[iOS] Failed to read content_size: ${error}`);
+  }
+  return Object.keys(ui).length > 0 ? ui : undefined;
+}
+
+/** Capture the curated iOS settings allowlist + device-level UI state. */
+export async function captureIosSettings(
+  simctl: Pick<SimCtlClient, "executeCommand">,
+  deviceId: string
+): Promise<IosSettingsSnapshot> {
+  const values: Record<string, string> = {};
+  for (const { domain, key } of IOS_SETTINGS_KEYS) {
+    try {
+      const cmd =
+        `spawn ${quoteSimctlArg(deviceId)} defaults read ` +
+        `${quoteSimctlArg(domain)} ${quoteSimctlArg(key)}`;
+      const result = await simctl.executeCommand(cmd);
+      const value = result.stdout.trim();
+      if (value) {
+        values[`${domain}/${key}`] = value;
+      }
+    } catch (error) {
+      // An unset key makes `defaults read` exit non-zero — expected, non-fatal.
+      logger.debug(`[iOS] No value for ${domain}/${key}: ${error}`);
+    }
+  }
+  return { values, ui: await captureUiState(simctl, deviceId) };
+}
+
+/**
+ * Restore captured iOS settings. Per-key `defaults write` (surgical, idempotent,
+ * does NOT replace the whole domain) followed by device-level `simctl ui` so
+ * appearance/content size take effect without a respawn. Individual key failures
+ * are logged and skipped (non-fatal).
+ */
+export async function restoreIosSettings(
+  simctl: Pick<SimCtlClient, "executeCommand">,
+  deviceId: string,
+  settings: IosSettingsSnapshot
+): Promise<void> {
+  for (const [compoundKey, value] of Object.entries(settings.values)) {
+    const slash = compoundKey.indexOf("/");
+    if (slash < 0) {
+      continue;
+    }
+    const domain = compoundKey.slice(0, slash);
+    const key = compoundKey.slice(slash + 1);
+    try {
+      const cmd =
+        `spawn ${quoteSimctlArg(deviceId)} defaults write ` +
+        `${quoteSimctlArg(domain)} ${quoteSimctlArg(key)} ${quoteSimctlArg(value)}`;
+      await simctl.executeCommand(cmd);
+    } catch (error) {
+      logger.warn(`[iOS] Failed to write ${domain}/${key}: ${error}`);
+    }
+  }
+
+  if (settings.ui?.appearance) {
+    try {
+      await simctl.executeCommand(
+        `ui ${quoteSimctlArg(deviceId)} appearance ${settings.ui.appearance}`
+      );
+    } catch (error) {
+      logger.warn(`[iOS] Failed to restore appearance: ${error}`);
+    }
+  }
+  if (settings.ui?.contentSize) {
+    try {
+      await simctl.executeCommand(
+        `ui ${quoteSimctlArg(deviceId)} content_size ${quoteSimctlArg(settings.ui.contentSize)}`
+      );
+    } catch (error) {
+      logger.warn(`[iOS] Failed to restore content_size: ${error}`);
+    }
+  }
+}

--- a/test/features/action/CaptureSnapshotIos.test.ts
+++ b/test/features/action/CaptureSnapshotIos.test.ts
@@ -69,7 +69,7 @@ describe("CaptureSnapshotIos", () => {
     const metadataJson = await fs.readFile(metadataPath, "utf-8");
     const parsed = JSON.parse(metadataJson) as typeof result.manifest;
 
-    expect(result.manifest.includeSettings).toBe(false);
+    expect(result.manifest.includeSettings).toBe(true);
     expect(result.manifest.deviceType).toBe("com.apple.CoreSimulator.SimDeviceType.iPhone-15");
     expect(result.manifest.osVersion).toBe("17.2");
     expect(parsed.snapshotName).toBe(snapshotName);
@@ -116,5 +116,49 @@ describe("CaptureSnapshotIos", () => {
 
     expect(result.manifest.appDataBackup?.backupMethod).toBe("none");
     expect(result.manifest.appDataBackup?.totalPackages).toBe(0);
+  });
+
+  it("captures iOS settings (locale + UI) into the manifest when includeSettings", async () => {
+    simctl.setCommandResult(
+      `spawn "${device.deviceId}" defaults read ".GlobalPreferences" "AppleLocale"`,
+      "nl_BE\n"
+    );
+    simctl.setCommandResult(`ui "${device.deviceId}" appearance`, "dark\n");
+    simctl.setCommandResult(`ui "${device.deviceId}" content_size`, "large\n");
+
+    const captureSnapshot = new CaptureSnapshotIos(device, simctl as any, store);
+    const result = await captureSnapshot.execute({
+      snapshotName: "with-settings",
+      includeAppData: false,
+      includeSettings: true,
+    });
+
+    expect(result.manifest.includeSettings).toBe(true);
+    expect(result.manifest.iosSettings?.values[".GlobalPreferences/AppleLocale"]).toBe("nl_BE");
+    expect(result.manifest.iosSettings?.ui).toEqual({ appearance: "dark", contentSize: "large" });
+
+    // Manifest survives the round-trip to disk.
+    const pathOptions = { platform: "ios", deviceId: device.deviceId } as const;
+    const metadataJson = await fs.readFile(store.getMetadataPath("with-settings", pathOptions), "utf-8");
+    const parsed = JSON.parse(metadataJson) as typeof result.manifest;
+    expect(parsed.iosSettings?.values[".GlobalPreferences/AppleLocale"]).toBe("nl_BE");
+  });
+
+  it("omits iosSettings and issues no settings commands when includeSettings is false", async () => {
+    const captureSnapshot = new CaptureSnapshotIos(device, simctl as any, store);
+    const result = await captureSnapshot.execute({
+      snapshotName: "no-settings",
+      includeAppData: false,
+      includeSettings: false,
+    });
+
+    expect(result.manifest.includeSettings).toBe(false);
+    expect(result.manifest.iosSettings).toBeUndefined();
+
+    const settingsCommands = simctl
+      .getMethodCalls("executeCommand")
+      .map(call => String(call.command))
+      .filter(cmd => cmd.includes("defaults") || cmd.startsWith("ui "));
+    expect(settingsCommands).toEqual([]);
   });
 });

--- a/test/features/action/RestoreSnapshotIos.test.ts
+++ b/test/features/action/RestoreSnapshotIos.test.ts
@@ -206,4 +206,85 @@ describe("RestoreSnapshotIos", () => {
     expect(simctl.getMethodCalls("executeCommand")).toHaveLength(0);
     expect(simctl.getMethodCalls("terminateApp")).toHaveLength(0);
   });
+
+  it("restores iOS settings via per-key defaults write and simctl ui", async () => {
+    const snapshotName = "settings-restore";
+    const manifest: DeviceSnapshotManifest = {
+      snapshotName,
+      timestamp: new Date().toISOString(),
+      deviceId: device.deviceId,
+      deviceName: device.name,
+      platform: "ios",
+      snapshotType: "app_data",
+      includeAppData: false,
+      includeSettings: true,
+      iosSettings: {
+        values: { ".GlobalPreferences/AppleLocale": "nl_BE" },
+        ui: { appearance: "dark", contentSize: "large" },
+      },
+    };
+
+    const restoreSnapshot = new RestoreSnapshotIos(device, simctl as any, store);
+    await restoreSnapshot.execute({ snapshotName, manifest, useVmSnapshot: false });
+
+    const commands = simctl.getMethodCalls("executeCommand").map(c => String(c.command));
+    expect(commands).toContain(
+      `spawn "${device.deviceId}" defaults write ".GlobalPreferences" "AppleLocale" "nl_BE"`
+    );
+    expect(commands).toContain(`ui "${device.deviceId}" appearance dark`);
+    expect(commands).toContain(`ui "${device.deviceId}" content_size "large"`);
+  });
+
+  it("skips settings restore when includeSettings is false", async () => {
+    const snapshotName = "settings-skip";
+    const manifest: DeviceSnapshotManifest = {
+      snapshotName,
+      timestamp: new Date().toISOString(),
+      deviceId: device.deviceId,
+      deviceName: device.name,
+      platform: "ios",
+      snapshotType: "app_data",
+      includeAppData: false,
+      includeSettings: false,
+      iosSettings: {
+        values: { ".GlobalPreferences/AppleLocale": "nl_BE" },
+      },
+    };
+
+    const restoreSnapshot = new RestoreSnapshotIos(device, simctl as any, store);
+    await restoreSnapshot.execute({ snapshotName, manifest, useVmSnapshot: false });
+
+    const commands = simctl.getMethodCalls("executeCommand").map(c => String(c.command));
+    expect(commands.some(c => c.includes("defaults write"))).toBe(false);
+  });
+
+  it("continues restoring remaining settings when one key write fails (non-fatal)", async () => {
+    const snapshotName = "settings-partial";
+    simctl.setCommandError(
+      `spawn "${device.deviceId}" defaults write ".GlobalPreferences" "AppleLocale" "nl_BE"`,
+      new Error("write failed")
+    );
+    const manifest: DeviceSnapshotManifest = {
+      snapshotName,
+      timestamp: new Date().toISOString(),
+      deviceId: device.deviceId,
+      deviceName: device.name,
+      platform: "ios",
+      snapshotType: "app_data",
+      includeAppData: false,
+      includeSettings: true,
+      iosSettings: {
+        values: { ".GlobalPreferences/AppleLocale": "nl_BE" },
+        ui: { appearance: "light" },
+      },
+    };
+
+    const restoreSnapshot = new RestoreSnapshotIos(device, simctl as any, store);
+    // Should not throw despite the failed key write.
+    await restoreSnapshot.execute({ snapshotName, manifest, useVmSnapshot: false });
+
+    const commands = simctl.getMethodCalls("executeCommand").map(c => String(c.command));
+    // UI restore still runs after the failed defaults write.
+    expect(commands).toContain(`ui "${device.deviceId}" appearance light`);
+  });
 });

--- a/test/features/utility/IosNotificationAuthorizationReader.test.ts
+++ b/test/features/utility/IosNotificationAuthorizationReader.test.ts
@@ -1,0 +1,230 @@
+import { describe, expect, test } from "bun:test";
+import {
+  BulletinBoardAuthorizationReader,
+  extractSectionDataBase64,
+  parseSettingsFromNestedXml,
+  type BulletinBoardReaderDeps,
+} from "../../../src/features/utility/ios/IosNotificationAuthorizationReader";
+
+const SIM_UDID = "7B3A3792-DB53-4654-BA94-27A1D305C3B7";
+const PHYSICAL_UDID = "00008110-000A1234567890AB";
+
+/** Build an outer VersionedSectionInfo XML with one `<data>` blob per bundle. */
+function outerXml(sections: Record<string, string>): string {
+  const entries = Object.entries(sections)
+    .map(([bundle, b64]) => `\t\t<key>${bundle}</key>\n\t\t<data>\n\t\t${b64}\n\t\t</data>`)
+    .join("\n");
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<plist version="1.0">
+<dict>
+\t<key>sectionInfo</key>
+\t<dict>
+${entries}
+\t</dict>
+\t<key>sectionInfoVersionNumber</key>
+\t<integer>2</integer>
+</dict>
+</plist>`;
+}
+
+/** Build the decoded nested-blob XML (a settings dict) for given scalars. */
+function nestedXml(s: {
+  authorizationStatus?: number;
+  alertType?: number;
+  lockScreenSetting?: number;
+  notificationCenterSetting?: number;
+  pushSettings?: number;
+}): string {
+  const lines: string[] = [];
+  const add = (k: string, v?: number) => {
+    if (v !== undefined) {
+      lines.push(`\t\t\t<key>${k}</key>\n\t\t\t<integer>${v}</integer>`);
+    }
+  };
+  add("alertType", s.alertType);
+  add("authorizationStatus", s.authorizationStatus);
+  add("lockScreenSetting", s.lockScreenSetting);
+  add("notificationCenterSetting", s.notificationCenterSetting);
+  add("pushSettings", s.pushSettings);
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<plist version="1.0">
+<dict>
+\t<key>$archiver</key>
+\t<string>NSKeyedArchiver</string>
+\t<key>$objects</key>
+\t<array>
+\t\t<string>$null</string>
+\t\t<dict>
+${lines.join("\n")}
+\t\t</dict>
+\t</array>
+</dict>
+</plist>`;
+}
+
+/** Fake deps: maps the outer path to canned plutil-xml; nested blobs matched by temp path. */
+function fakeDeps(opts: { outer?: string | Error; nested?: string }): {
+  deps: BulletinBoardReaderDeps;
+  plutilPaths: string[];
+} {
+  const plutilPaths: string[] = [];
+  let lastTemp = "";
+  const deps: BulletinBoardReaderDeps = {
+    plutilToXml: async (p: string) => {
+      plutilPaths.push(p);
+      if (p === lastTemp) {
+        return opts.nested ?? "";
+      }
+      if (opts.outer instanceof Error) {
+        throw opts.outer;
+      }
+      return opts.outer ?? "";
+    },
+    writeTemp: async () => {
+      lastTemp = `/tmp/fake-blob-${plutilPaths.length}.bplist`;
+      return lastTemp;
+    },
+    rmTemp: async () => {},
+    deviceDataRoot: (udid: string) => `/fake/CoreSimulator/Devices/${udid}`,
+  };
+  return { deps, plutilPaths };
+}
+
+describe("extractSectionDataBase64", () => {
+  test("extracts and strips whitespace from the base64 blob", () => {
+    const xml = outerXml({ "com.apple.MobileSMS": "QUJD\n\t\tREVG" });
+    expect(extractSectionDataBase64(xml, "com.apple.MobileSMS")).toBe("QUJDREVG");
+  });
+
+  test("returns null for a bundle with no section", () => {
+    const xml = outerXml({ "com.apple.MobileSMS": "QUJD" });
+    expect(extractSectionDataBase64(xml, "com.example.absent")).toBeNull();
+  });
+});
+
+describe("parseSettingsFromNestedXml", () => {
+  test("pulls integer settings keys", () => {
+    const xml = nestedXml({
+      authorizationStatus: 2,
+      alertType: 1,
+      lockScreenSetting: 2,
+      notificationCenterSetting: 2,
+      pushSettings: 63,
+    });
+    expect(parseSettingsFromNestedXml(xml)).toEqual({
+      authorizationStatus: 2,
+      alertType: 1,
+      lockScreenSetting: 2,
+      notificationCenterSetting: 2,
+      pushSettings: 63,
+    });
+  });
+});
+
+describe("BulletinBoardAuthorizationReader", () => {
+  test("authorized app (MobileSMS-like) maps to authorized + allowed", async () => {
+    const b64 = Buffer.from("bplist00-placeholder").toString("base64");
+    const { deps } = fakeDeps({
+      outer: outerXml({ "com.apple.MobileSMS": b64 }),
+      nested: nestedXml({
+        authorizationStatus: 2,
+        alertType: 1,
+        lockScreenSetting: 2,
+        notificationCenterSetting: 2,
+        pushSettings: 63,
+      }),
+    });
+    const reader = new BulletinBoardAuthorizationReader(deps);
+    const result = await reader.read(SIM_UDID, "com.apple.MobileSMS");
+
+    expect(result).toMatchObject({
+      supported: true,
+      method: "ios_bulletinboard_plist",
+      allowed: true,
+      authorizationStatus: "authorized",
+      lockScreen: true,
+      notificationCenter: true,
+      alerts: true,
+    });
+  });
+
+  test("provisional app (Home-like) maps to provisional, not allowed", async () => {
+    const b64 = Buffer.from("bplist00").toString("base64");
+    const { deps } = fakeDeps({
+      outer: outerXml({ "com.apple.Home": b64 }),
+      nested: nestedXml({
+        authorizationStatus: 3,
+        alertType: 0,
+        lockScreenSetting: 1,
+        notificationCenterSetting: 2,
+        pushSettings: 7,
+      }),
+    });
+    const reader = new BulletinBoardAuthorizationReader(deps);
+    const result = await reader.read(SIM_UDID, "com.apple.Home");
+
+    expect(result.authorizationStatus).toBe("provisional");
+    expect(result.allowed).toBe(false);
+    expect(result.alerts).toBe(false);
+    expect(result.lockScreen).toBe(false);
+    expect(result.notificationCenter).toBe(true);
+  });
+
+  test("denied app maps to denied + allowed false", async () => {
+    const b64 = Buffer.from("bplist00").toString("base64");
+    const { deps } = fakeDeps({
+      outer: outerXml({ "com.example.app": b64 }),
+      nested: nestedXml({ authorizationStatus: 1 }),
+    });
+    const reader = new BulletinBoardAuthorizationReader(deps);
+    const result = await reader.read(SIM_UDID, "com.example.app");
+    expect(result.authorizationStatus).toBe("denied");
+    expect(result.allowed).toBe(false);
+  });
+
+  test("notDetermined app maps to notDetermined", async () => {
+    const b64 = Buffer.from("bplist00").toString("base64");
+    const { deps } = fakeDeps({
+      outer: outerXml({ "com.example.app": b64 }),
+      nested: nestedXml({ authorizationStatus: 0 }),
+    });
+    const reader = new BulletinBoardAuthorizationReader(deps);
+    const result = await reader.read(SIM_UDID, "com.example.app");
+    expect(result.authorizationStatus).toBe("notDetermined");
+    expect(result.allowed).toBe(false);
+  });
+
+  test("app with no section registered returns warning, allowed null, not error", async () => {
+    const { deps } = fakeDeps({
+      outer: outerXml({ "com.apple.MobileSMS": "QUJD" }),
+    });
+    const reader = new BulletinBoardAuthorizationReader(deps);
+    const result = await reader.read(SIM_UDID, "com.example.neverlaunched");
+
+    expect(result.supported).toBe(true);
+    expect(result.allowed).toBeNull();
+    expect(result.warning).toContain("No notification section registered");
+    expect(result.error).toBeUndefined();
+  });
+
+  test("missing/unreadable plist returns warning, never throws", async () => {
+    const { deps } = fakeDeps({ outer: new Error("ENOENT") });
+    const reader = new BulletinBoardAuthorizationReader(deps);
+    const result = await reader.read(SIM_UDID, "com.apple.MobileSMS");
+
+    expect(result.supported).toBe(true);
+    expect(result.allowed).toBeNull();
+    expect(result.warning).toContain("not found or unreadable");
+    expect(result.error).toBeUndefined();
+  });
+
+  test("physical device returns unsupported with simulator-only error", async () => {
+    const { deps } = fakeDeps({ outer: outerXml({}) });
+    const reader = new BulletinBoardAuthorizationReader(deps);
+    const result = await reader.read(PHYSICAL_UDID, "com.apple.MobileSMS");
+
+    expect(result.supported).toBe(false);
+    expect(result.method).toBe("unsupported");
+    expect(result.error).toContain("simulators");
+  });
+});

--- a/test/features/utility/NotificationPolicy.test.ts
+++ b/test/features/utility/NotificationPolicy.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import type { BootedDevice } from "../../../src/models";
-import { NotificationPolicy } from "../../../src/features/utility/NotificationPolicy";
+import { NotificationPolicy, type NotificationPolicyAccessState } from "../../../src/features/utility/NotificationPolicy";
+import type { IosNotificationAuthorizationReader } from "../../../src/features/utility/ios/IosNotificationAuthorizationReader";
 import { FakeAdbClientFactory } from "../../fakes/FakeAdbClientFactory";
 
 const androidDevice: BootedDevice = {
@@ -78,5 +79,61 @@ describe("NotificationPolicy", () => {
     expect(result.success).toBe(false);
     expect(result.policyAccess.supported).toBe(false);
     expect(result.error).toContain("iOS does not expose");
+  });
+
+  test("getPolicy on iOS simulator routes to the injected BulletinBoard reader", async () => {
+    const ios: BootedDevice = {
+      name: "iPhone 16",
+      platform: "ios",
+      deviceId: "12345678-1234-1234-1234-123456789ABC",
+    };
+
+    const calls: Array<{ deviceId: string; bundleId: string }> = [];
+    const fakeReader: IosNotificationAuthorizationReader = {
+      read: async (deviceId, bundleId) => {
+        calls.push({ deviceId, bundleId });
+        return {
+          supported: true,
+          method: "ios_bulletinboard_plist",
+          allowed: true,
+          authorizationStatus: "authorized",
+        } as NotificationPolicyAccessState;
+      },
+    };
+
+    const notificationPolicy = new NotificationPolicy(ios, { iosReader: fakeReader });
+    const result = await notificationPolicy.getPolicy("com.apple.MobileSMS");
+
+    expect(result.success).toBe(true);
+    expect(result.platform).toBe("ios");
+    expect(result.policyAccess).toMatchObject({
+      supported: true,
+      method: "ios_bulletinboard_plist",
+      allowed: true,
+      authorizationStatus: "authorized",
+    });
+    expect(calls).toEqual([{ deviceId: ios.deviceId, bundleId: "com.apple.MobileSMS" }]);
+  });
+
+  test("getPolicy on iOS surfaces reader errors as success:false", async () => {
+    const ios: BootedDevice = {
+      name: "iPhone (physical)",
+      platform: "ios",
+      deviceId: "00008110-000A1234567890AB",
+    };
+    const fakeReader: IosNotificationAuthorizationReader = {
+      read: async () => ({
+        supported: false,
+        method: "unsupported",
+        error: "iOS notification authorization can only be read on simulators",
+      }),
+    };
+
+    const notificationPolicy = new NotificationPolicy(ios, { iosReader: fakeReader });
+    const result = await notificationPolicy.getPolicy("com.apple.MobileSMS");
+
+    expect(result.success).toBe(false);
+    expect(result.policyAccess.supported).toBe(false);
+    expect(result.error).toContain("simulators");
   });
 });

--- a/test/server/deviceSnapshotManager.test.ts
+++ b/test/server/deviceSnapshotManager.test.ts
@@ -182,6 +182,49 @@ describe("deviceSnapshotManager", () => {
     expect(updated?.lastAccessedAt).toBe(nowIso);
   });
 
+  test("restoreDeviceSnapshot round-trips an iOS manifest carrying iosSettings", async () => {
+    const createdAt = new Date(0).toISOString();
+    const manifest: DeviceSnapshotManifest = {
+      snapshotName: "ios-settings-snapshot",
+      timestamp: createdAt,
+      deviceId: TEST_DEVICE.deviceId,
+      deviceName: TEST_DEVICE.name,
+      platform: "ios",
+      snapshotType: "app_data",
+      includeAppData: false,
+      includeSettings: true,
+      iosSettings: {
+        values: { ".GlobalPreferences/AppleLocale": "nl_BE" },
+        ui: { appearance: "dark", contentSize: "large" },
+      },
+    };
+
+    await repository.insertSnapshot({
+      snapshotName: "ios-settings-snapshot",
+      deviceId: TEST_DEVICE.deviceId,
+      deviceName: TEST_DEVICE.name,
+      platform: "ios",
+      snapshotType: "app_data",
+      includeAppData: false,
+      includeSettings: true,
+      createdAt,
+      lastAccessedAt: createdAt,
+      sizeBytes: 0,
+      manifest,
+    });
+
+    // The stored record preserves the optional iosSettings field.
+    const stored = await repository.getSnapshot("ios-settings-snapshot");
+    expect(stored?.manifest.iosSettings).toEqual(manifest.iosSettings);
+
+    const { manifest: returnedManifest } = await restoreDeviceSnapshot(TEST_DEVICE, {
+      snapshotName: "ios-settings-snapshot",
+    });
+
+    expect(returnedManifest.iosSettings).toEqual(manifest.iosSettings);
+    expect(restoreCalls[restoreCalls.length - 1]?.manifest.iosSettings).toEqual(manifest.iosSettings);
+  });
+
   test("restoreDeviceSnapshot migrates legacy manifest when missing from repository", async () => {
     const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "snapshot-manager-legacy-"));
     try {

--- a/test/utils/DeepLinkManagerIos.test.ts
+++ b/test/utils/DeepLinkManagerIos.test.ts
@@ -1,0 +1,193 @@
+import { describe, expect, test } from "bun:test";
+import { DeepLinkManager, type HostExec } from "../../src/utils/DeepLinkManager";
+import type { BootedDevice, ExecResult } from "../../src/models";
+import { FakeSimCtlClient } from "../fakes/FakeSimCtlClient";
+
+const SIM_UDID = "7B3A3792-DB53-4654-BA94-27A1D305C3B7";
+const PHYSICAL_UDID = "00008110-000A1234567890AB";
+
+const iosDevice: BootedDevice = {
+  name: "iPhone 16 Pro",
+  platform: "ios",
+  deviceId: SIM_UDID,
+};
+
+function execResult(stdout: string): ExecResult {
+  return {
+    stdout,
+    stderr: "",
+    toString: () => stdout,
+    trim: () => stdout.trim(),
+    includes: (value: string) => stdout.includes(value),
+  };
+}
+
+/** A fake host exec that maps command-substring matches to canned stdout. */
+function fakeHostExec(
+  routes: Array<{ match: string; stdout?: string; throws?: Error }>
+): { exec: HostExec; calls: string[] } {
+  const calls: string[] = [];
+  const exec: HostExec = async (command: string) => {
+    calls.push(command);
+    for (const route of routes) {
+      if (command.includes(route.match)) {
+        if (route.throws) {
+          throw route.throws;
+        }
+        return execResult(route.stdout ?? "");
+      }
+    }
+    return execResult("");
+  };
+  return { exec, calls };
+}
+
+describe("DeepLinkManager iOS", () => {
+  test("returns schemes from CFBundleURLTypes for a schemes-only app", async () => {
+    const simctl = new FakeSimCtlClient();
+    const appPath = "/sim/Containers/Bundle/Application/ABC/MyApp.app";
+    simctl.setCommandResult(
+      `get_app_container "${SIM_UDID}" "com.example.myapp" app`,
+      appPath
+    );
+
+    const infoPlist = JSON.stringify({
+      CFBundleURLTypes: [
+        { CFBundleURLName: "Main", CFBundleURLSchemes: ["myapp", "myapp-alt"] },
+        { CFBundleURLSchemes: ["myapp"] }, // duplicate scheme deduped
+      ],
+    });
+    const { exec, calls } = fakeHostExec([
+      { match: "plutil -convert json", stdout: infoPlist },
+      { match: "codesign", stdout: "{}" }, // no associated domains
+    ]);
+
+    const manager = new DeepLinkManager(iosDevice, null, simctl as any, exec);
+    const result = await manager.getDeepLinks("com.example.myapp");
+
+    expect(result.success).toBe(true);
+    expect(result.appId).toBe("com.example.myapp");
+    expect(result.deepLinks.schemes).toEqual(["myapp", "myapp-alt"]);
+    expect(result.deepLinks.hosts).toEqual([]);
+    expect(result.deepLinks.intentFilters).toHaveLength(1);
+    expect(result.deepLinks.intentFilters[0].data).toEqual([
+      { scheme: "myapp" },
+      { scheme: "myapp-alt" },
+    ]);
+
+    // get_app_container routes through simctl (xcrun simctl), not host exec.
+    const simctlCalls = simctl.getMethodCalls("executeCommand");
+    expect(simctlCalls.some(c => String(c.command).includes("get_app_container") && String(c.command).includes(" app"))).toBe(true);
+    // plutil/codesign route through host exec, never simctl.
+    expect(calls.some(c => c.includes("plutil -convert json"))).toBe(true);
+    expect(simctlCalls.every(c => !String(c.command).includes("plutil"))).toBe(true);
+  });
+
+  test("returns universal-link hosts from associated-domains entitlement", async () => {
+    const simctl = new FakeSimCtlClient();
+    const appPath = "/sim/MyApp.app";
+    simctl.setCommandResult(
+      `get_app_container "${SIM_UDID}" "com.example.myapp" app`,
+      appPath
+    );
+
+    const infoPlist = JSON.stringify({
+      CFBundleURLTypes: [{ CFBundleURLSchemes: ["myapp"] }],
+      CFBundleDocumentTypes: [{ LSItemContentTypes: ["public.image"] }],
+    });
+    const entitlements = JSON.stringify({
+      "com.apple.developer.associated-domains": [
+        "applinks:example.com",
+        "applinks:www.example.com",
+        "webcredentials:example.com", // non-applinks ignored
+      ],
+    });
+    const { exec } = fakeHostExec([
+      { match: "plutil -convert json -o - -- \"/sim/MyApp.app/Info.plist\"", stdout: infoPlist },
+      { match: "codesign", stdout: entitlements },
+    ]);
+
+    const manager = new DeepLinkManager(iosDevice, null, simctl as any, exec);
+    const result = await manager.getDeepLinks("com.example.myapp");
+
+    expect(result.success).toBe(true);
+    expect(result.deepLinks.schemes).toEqual(["myapp"]);
+    expect(result.deepLinks.hosts).toEqual(["example.com", "www.example.com"]);
+    expect(result.deepLinks.supportedMimeTypes).toEqual(["public.image"]);
+    expect(result.deepLinks.intentFilters[0].data).toEqual([
+      { scheme: "myapp" },
+      { host: "example.com" },
+      { host: "www.example.com" },
+    ]);
+  });
+
+  test("unsigned bundle with no entitlements yields empty hosts (not an error)", async () => {
+    const simctl = new FakeSimCtlClient();
+    simctl.setCommandResult(
+      `get_app_container "${SIM_UDID}" "com.example.myapp" app`,
+      "/sim/MyApp.app"
+    );
+    const infoPlist = JSON.stringify({ CFBundleURLTypes: [{ CFBundleURLSchemes: ["myapp"] }] });
+    const { exec } = fakeHostExec([
+      { match: "plutil -convert json", stdout: infoPlist },
+      { match: "codesign", throws: new Error("code object is not signed at all") },
+    ]);
+
+    const manager = new DeepLinkManager(iosDevice, null, simctl as any, exec);
+    const result = await manager.getDeepLinks("com.example.myapp");
+
+    expect(result.success).toBe(true);
+    expect(result.deepLinks.schemes).toEqual(["myapp"]);
+    expect(result.deepLinks.hosts).toEqual([]);
+  });
+
+  test("app not installed returns success:false with descriptive error", async () => {
+    const simctl = new FakeSimCtlClient();
+    // get_app_container ... app returns empty (FakeSimCtlClient default for app variant)
+    const { exec } = fakeHostExec([]);
+
+    const manager = new DeepLinkManager(iosDevice, null, simctl as any, exec);
+    const result = await manager.getDeepLinks("com.example.notinstalled");
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("not installed");
+    expect(result.deepLinks.schemes).toEqual([]);
+  });
+
+  test("malformed plist JSON returns success:false without throwing", async () => {
+    const simctl = new FakeSimCtlClient();
+    simctl.setCommandResult(
+      `get_app_container "${SIM_UDID}" "com.example.myapp" app`,
+      "/sim/MyApp.app"
+    );
+    const { exec } = fakeHostExec([
+      { match: "plutil -convert json", stdout: "<<<not json>>>" },
+    ]);
+
+    const manager = new DeepLinkManager(iosDevice, null, simctl as any, exec);
+    const result = await manager.getDeepLinks("com.example.myapp");
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBeDefined();
+    expect(result.deepLinks.schemes).toEqual([]);
+  });
+
+  test("physical-device UDID returns explicit not-yet-implemented error", async () => {
+    const simctl = new FakeSimCtlClient();
+    const { exec, calls } = fakeHostExec([]);
+    const physicalDevice: BootedDevice = {
+      name: "iPhone (physical)",
+      platform: "ios",
+      deviceId: PHYSICAL_UDID,
+    };
+
+    const manager = new DeepLinkManager(physicalDevice, null, simctl as any, exec);
+    const result = await manager.getDeepLinks("com.example.myapp");
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("not yet implemented");
+    // No simctl or host exec invoked for physical devices.
+    expect(simctl.getMethodCalls("executeCommand")).toHaveLength(0);
+    expect(calls).toHaveLength(0);
+  });
+});

--- a/test/utils/DeepLinkManagerIos.test.ts
+++ b/test/utils/DeepLinkManagerIos.test.ts
@@ -22,13 +22,25 @@ function execResult(stdout: string): ExecResult {
   };
 }
 
-/** A fake host exec that maps command-substring matches to canned stdout. */
+/**
+ * A fake host exec that maps command-substring matches to canned stdout. Calls
+ * are recorded as the reconstructed `file arg arg …` line so substring routing
+ * still works against the argv-based {@link HostExec} signature.
+ *
+ * `plutil` reading from stdin (`… -- -`) echoes the piped content, mirroring the
+ * real `codesign | plutil` conversion where `codesign`'s output is what plutil
+ * re-serializes — so the codesign route can return the canned entitlements JSON.
+ */
 function fakeHostExec(
   routes: Array<{ match: string; stdout?: string; throws?: Error }>
 ): { exec: HostExec; calls: string[] } {
   const calls: string[] = [];
-  const exec: HostExec = async (command: string) => {
+  const exec: HostExec = async (file: string, args: string[], stdin?: string) => {
+    const command = [file, ...args].join(" ");
     calls.push(command);
+    if (file === "plutil" && args[args.length - 1] === "-" && stdin !== undefined) {
+      return execResult(stdin);
+    }
     for (const route of routes) {
       if (command.includes(route.match)) {
         if (route.throws) {
@@ -103,7 +115,7 @@ describe("DeepLinkManager iOS", () => {
       ],
     });
     const { exec } = fakeHostExec([
-      { match: "plutil -convert json -o - -- \"/sim/MyApp.app/Info.plist\"", stdout: infoPlist },
+      { match: "plutil -convert json -o - -- /sim/MyApp.app/Info.plist", stdout: infoPlist },
       { match: "codesign", stdout: entitlements },
     ]);
 

--- a/test/utils/ios-cmdline-tools/iosSettings.test.ts
+++ b/test/utils/ios-cmdline-tools/iosSettings.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, test } from "bun:test";
+import {
+  captureIosSettings,
+  restoreIosSettings,
+  IOS_SETTINGS_KEYS,
+} from "../../../src/utils/ios-cmdline-tools/iosSettings";
+import { FakeSimCtlClient } from "../../fakes/FakeSimCtlClient";
+
+const UDID = "7B3A3792-DB53-4654-BA94-27A1D305C3B7";
+
+describe("iosSettings", () => {
+  test("allowlist is scalar-only for the first cut (no array-typed keys)", () => {
+    expect(IOS_SETTINGS_KEYS.map(k => k.key)).toEqual(["AppleLocale"]);
+  });
+
+  test("captureIosSettings reads allowlisted keys + UI state", async () => {
+    const simctl = new FakeSimCtlClient();
+    simctl.setCommandResult(
+      `spawn "${UDID}" defaults read ".GlobalPreferences" "AppleLocale"`,
+      "nl_BE\n"
+    );
+    simctl.setCommandResult(`ui "${UDID}" appearance`, "dark\n");
+    simctl.setCommandResult(`ui "${UDID}" content_size`, "large\n");
+
+    const snapshot = await captureIosSettings(simctl as any, UDID);
+
+    expect(snapshot.values).toEqual({ ".GlobalPreferences/AppleLocale": "nl_BE" });
+    expect(snapshot.ui).toEqual({ appearance: "dark", contentSize: "large" });
+  });
+
+  test("captureIosSettings skips unset keys (defaults read non-zero) without throwing", async () => {
+    const simctl = new FakeSimCtlClient();
+    simctl.setCommandError(
+      `spawn "${UDID}" defaults read ".GlobalPreferences" "AppleLocale"`,
+      new Error("does not exist")
+    );
+    // appearance/content_size return "" by default → ui undefined
+
+    const snapshot = await captureIosSettings(simctl as any, UDID);
+    expect(snapshot.values).toEqual({});
+    expect(snapshot.ui).toBeUndefined();
+  });
+
+  test("restoreIosSettings replays per-key defaults write + ui commands", async () => {
+    const simctl = new FakeSimCtlClient();
+    await restoreIosSettings(simctl as any, UDID, {
+      values: { ".GlobalPreferences/AppleLocale": "nl_BE" },
+      ui: { appearance: "dark", contentSize: "large" },
+    });
+
+    const commands = simctl.getMethodCalls("executeCommand").map(c => String(c.command));
+    expect(commands).toEqual([
+      `spawn "${UDID}" defaults write ".GlobalPreferences" "AppleLocale" "nl_BE"`,
+      `ui "${UDID}" appearance dark`,
+      `ui "${UDID}" content_size "large"`,
+    ]);
+  });
+
+  test("capture -> restore round-trips the locale value", async () => {
+    const capSim = new FakeSimCtlClient();
+    capSim.setCommandResult(
+      `spawn "${UDID}" defaults read ".GlobalPreferences" "AppleLocale"`,
+      "en_US"
+    );
+    const snapshot = await captureIosSettings(capSim as any, UDID);
+
+    const restoreSim = new FakeSimCtlClient();
+    await restoreIosSettings(restoreSim as any, UDID, snapshot);
+
+    const commands = restoreSim.getMethodCalls("executeCommand").map(c => String(c.command));
+    expect(commands).toContain(
+      `spawn "${UDID}" defaults write ".GlobalPreferences" "AppleLocale" "en_US"`
+    );
+  });
+
+  test("restoreIosSettings is non-fatal when a single key write fails", async () => {
+    const simctl = new FakeSimCtlClient();
+    simctl.setCommandError(
+      `spawn "${UDID}" defaults write ".GlobalPreferences" "AppleLocale" "nl_BE"`,
+      new Error("boom")
+    );
+
+    await restoreIosSettings(simctl as any, UDID, {
+      values: { ".GlobalPreferences/AppleLocale": "nl_BE" },
+      ui: { appearance: "light" },
+    });
+
+    const commands = simctl.getMethodCalls("executeCommand").map(c => String(c.command));
+    // UI restore still ran after the failed write.
+    expect(commands).toContain(`ui "${UDID}" appearance light`);
+  });
+});


### PR DESCRIPTION
Adds iOS Simulator support for three metadata/settings tools. All simulator-only; Android paths unchanged; physical iOS returns clear unsupported errors (`isIosSimulatorUdid` gating).

## What

### `getDeepLinks` — Closes #2486
Reads the installed app's `Info.plist` (`CFBundleURLTypes.CFBundleURLSchemes` → schemes, `CFBundleDocumentTypes.LSItemContentTypes` → mime types) and `associated-domains` (`applinks:`) from the code-signing entitlements, via `simctl get_app_container` + host `plutil`/`codesign`. Synthesizes `intentFilters` so the result shape matches Android.

### `getNotificationPolicy` — Closes #2496
New `IosNotificationAuthorizationReader` reads the simulator's `BulletinBoard/VersionedSectionInfo.plist`, extracts the per-bundle nested `bplist00` archive, and maps `authorizationStatus` → `UNAuthorizationStatus` (authorized / denied / provisional / not-determined). `setNotificationPolicy` stays read-only/unsupported on iOS (no public write API).

### `deviceSnapshot` settings — Closes #2494
`CaptureSnapshotIos`/`RestoreSnapshotIos` now capture/restore a curated settings allowlist plus `simctl ui appearance`/`content_size` via per-key `defaults`. Removes the warn-and-drop and the hard-coded `includeSettings:false`; adds an optional `iosSettings` manifest field. Per-key failures are non-fatal.

## Notable adaptation
`plutil -convert json` fails on the BulletinBoard plists on Xcode/iOS 18.6 (`<data>` blobs + `CFKeyedArchiverUID` refs → "invalid object for destination format"). Switched to `plutil -convert xml1` + base64 extraction for both the outer plist and each nested archive — dependency-free (no `plist` npm package). The settings allowlist is scalar-only (`AppleLocale`) for the first cut; array-typed keys (`AppleLanguages`) are a flagged follow-up.

## Validation
- `bun test` — new iOS suites (deep links 6, notification reader 10, settings 6) + updated suites; broader `test/utils test/features/utility test/features/action test/server` run: **2247 pass, 0 fail**.
- `tsc --noEmit` clean on changed files; `eslint --fix` + `bun run lint` clean; `bun run build` succeeds; `validate_mkdocs_nav.sh` passes.
- **Simulator E2E** (UDID 7B3A3792…, via the real TS classes): `getDeepLinks` for `com.apple.MobileSMS` returned its real schemes; `getNotificationPolicy` matched on-disk `authorizationStatus` (MobileSMS→authorized, Home→provisional); settings capture→mutate→restore round-tripped `AppleLocale`/appearance/content_size.

## Docs
`plat/ios/simctl.md` — three new feature sections (chips → How it works → Limitations); `plat/android/notifications.md` cross-linked.

Part of milestone **iOS/Android tool parity**.