### PR TITLE
chore: remove stale third-party tool references from source

### DIFF
--- a/src/features/observe/ListInstalledApps.ts
+++ b/src/features/observe/ListInstalledApps.ts
@@ -61,7 +61,7 @@ export class ListInstalledApps {
     try {
       switch (this.device.platform) {
         case "ios":
-          // iOS device - use idb to get installed apps
+          // iOS: list installed apps via simctl
           const apps = await this.simctl.listApps();
           return apps.map((app: any) => app.bundleId);
         case "android":

--- a/src/utils/DeviceDetection.ts
+++ b/src/utils/DeviceDetection.ts
@@ -43,7 +43,7 @@ export class DeviceDetection implements DeviceDetection {
       return "android";
     }
 
-    // iOS device patterns (UUIDs from idb/iOS Simulator)
+    // iOS device patterns (UUIDs from the iOS Simulator)
     // iOS devices typically use UUIDs like: 569C0F94-5D53-40D2-AF8F-F4AA5BAA7D5E
     // iOS simulators also use similar UUID patterns
     const iosPattern = /^[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}$/i;

--- a/src/utils/deviceUtils.ts
+++ b/src/utils/deviceUtils.ts
@@ -87,16 +87,16 @@ export class MultiPlatformDeviceManager implements PlatformDeviceManager {
   /**
    * Create a PlatformDeviceManager instance
    * @param adb - An instance of AdbExecutor for interacting with Android Debug Bridge
-   * @param idb - An instance of SimCtlClient for interacting with iOS simulator controls
+   * @param simctl - An instance of SimCtlClient for interacting with iOS simulator controls
    * @param emulator - An instance of AndroidEmulatorClient for managing Android emulators
    */
   constructor(
     adb: AdbExecutor | null = null,
-    idb: SimCtlClient | null = null,
+    simctl: SimCtlClient | null = null,
     emulator: AndroidEmulatorClient | null = null,
   ) {
     this.adb = adb || defaultAdbClientFactory.create(null);
-    this.simctl = idb || new SimCtlClient();
+    this.simctl = simctl || new SimCtlClient();
     this.emulator = emulator || new AndroidEmulatorClient();
   }
 


### PR DESCRIPTION
The code already uses `SimCtlClient` (Apple's `simctl`), but a few comments and one constructor parameter still referenced the third-party `idb` tool. This removes those references so the source is grounded only in first-party Apple tooling. **No behavior change.**

## Changes
- `src/features/observe/ListInstalledApps.ts` — comment `// iOS device - use idb to get installed apps` → `// iOS: list installed apps via simctl`.
- `src/utils/deviceUtils.ts` — `PlatformDeviceManager` constructor parameter `idb: SimCtlClient` → `simctl` (+ `@param` JSDoc + the `this.simctl = … || …` assignment). The parameter is positional with no named callers, so this is caller-transparent.
- `src/utils/DeviceDetection.ts` — comment `(UUIDs from idb/iOS Simulator)` → `(UUIDs from the iOS Simulator)`.

## Validation
- `grep -rniE '\bidb\b' src/` → no matches.
- `tsc --noEmit` — no new errors in touched files; `eslint --fix` clean.
- `bun test test/utils/deviceUtils.test.ts test/features/observe/ListInstalledApps.test.ts` → 18 pass.