### PR TITLE
fix(ios): gate getDeepLinks/getNotificationPolicy under host control; allow provisional/ephemeral notifications

### DIFF
--- a/docs/design-docs/plat/ios/simctl.md
+++ b/docs/design-docs/plat/ios/simctl.md
@@ -171,6 +171,9 @@ hosts come from two different sources.
   via `devicectl`) returns an explicit "not yet implemented" error.
 - iOS has no runtime intent resolver, so only *declared* schemes/domains are reported.
 - `supportedMimeTypes` is best-effort document-type metadata, not a routing guarantee.
+- Unsupported under host control (Docker/external-emulator mode): `get_app_container`
+  resolves to a macOS host path, but `plutil`/`codesign` run inside the container, so the
+  call returns an explicit unsupported error instead of a misleading failure.
 
 ## Notification authorization read
 
@@ -195,8 +198,10 @@ persisted plist.
    (`authorizationStatus`, `alertType`, `lockScreenSetting`, `notificationCenterSetting`,
    `pushSettings`).
 4. **Map the status** — `authorizationStatus` maps to
-   `notDetermined`/`denied`/`authorized`/`provisional`/`ephemeral`; `allowed` is true only
-   for `authorized` (2). The result uses `method: "ios_bulletinboard_plist"`.
+   `notDetermined`/`denied`/`authorized`/`provisional`/`ephemeral`; `allowed` is true for
+   any delivery-capable status — `authorized` (2), `provisional` (3, quiet delivery) and
+   `ephemeral` (4, App Clips). Callers needing strict full authorization check
+   `authorizationStatus === "authorized"`. The result uses `method: "ios_bulletinboard_plist"`.
 
 An app with no registered section returns `allowed: null` plus a warning (the app likely
 never requested authorization), not an error. A missing/unreadable plist returns a warning
@@ -212,6 +217,9 @@ rather than throwing.
   disk would not take effect without restarting the daemon.
 - This is per-app *authorization status*, a different concept from Android's DND
   *policy access* — see [Notifications](../android/notifications.md).
+- Unsupported under host control (Docker/external-emulator mode): the BulletinBoard plist
+  lives on the macOS host but `plutil` runs inside the container, so the read returns an
+  explicit `supported: false` rather than reporting every app as unknown.
 
 ## Device settings snapshot
 

--- a/src/features/utility/ios/IosNotificationAuthorizationReader.ts
+++ b/src/features/utility/ios/IosNotificationAuthorizationReader.ts
@@ -2,6 +2,8 @@ import * as os from "os";
 import * as path from "path";
 import { isIosSimulatorUdid } from "../../../utils/ios-cmdline-tools/iosDeviceType";
 import { logger } from "../../../utils/logger";
+import { shouldUseHostControl } from "../../../utils/hostControlClient";
+import { isRunningInDocker } from "../../../utils/dockerEnv";
 import type { NotificationPolicyAccessState } from "../NotificationPolicy";
 
 /**
@@ -43,6 +45,13 @@ export interface BulletinBoardReaderDeps {
   rmTemp(path: string): Promise<void>;
   /** Absolute path of a simulator device root (…/CoreSimulator/Devices/<udid>). */
   deviceDataRoot(udid: string): string;
+  /**
+   * True when running in Docker/external-emulator host-control mode. There the
+   * CoreSimulator BulletinBoard plist lives on the macOS host and host `plutil`
+   * is not reachable from inside the container, so the read must be gated as
+   * unsupported rather than silently reporting every app as unknown.
+   */
+  isHostControlMode(): boolean;
 }
 
 /**
@@ -96,6 +105,16 @@ export class BulletinBoardAuthorizationReader implements IosNotificationAuthoriz
       };
     }
 
+    if (this.deps.isHostControlMode()) {
+      return {
+        supported: false,
+        method: "unsupported",
+        error:
+          "iOS notification authorization cannot be read under host control (Docker/external-emulator mode): " +
+          "the CoreSimulator BulletinBoard plist is on the macOS host and host plutil is unreachable from the container",
+      };
+    }
+
     const path = `${this.deps.deviceDataRoot(deviceId)}/data/Library/BulletinBoard/VersionedSectionInfo.plist`;
 
     let outerXml: string;
@@ -128,10 +147,19 @@ export class BulletinBoardAuthorizationReader implements IosNotificationAuthoriz
         ? UN_AUTH[settings.authorizationStatus]
         : undefined;
 
+    // iOS still delivers notifications for authorized (2), provisional (3, quiet
+    // delivery) and ephemeral (4, App Clips), so all three count as "allowed".
+    // Callers needing strict full authorization can check
+    // `authorizationStatus === "authorized"`.
+    const allowed =
+      settings.authorizationStatus !== undefined &&
+      settings.authorizationStatus >= 2 &&
+      settings.authorizationStatus <= 4;
+
     return {
       supported: true,
       method: "ios_bulletinboard_plist",
-      allowed: settings.authorizationStatus === 2,
+      allowed,
       authorizationStatus: status,
       lockScreen: settings.lockScreenSetting === 2,
       notificationCenter: settings.notificationCenterSetting === 2,
@@ -183,5 +211,6 @@ export function defaultBulletinBoardReader(): IosNotificationAuthorizationReader
     },
     deviceDataRoot: udid =>
       path.join(os.homedir(), "Library/Developer/CoreSimulator/Devices", udid),
+    isHostControlMode: () => shouldUseHostControl() && isRunningInDocker(),
   });
 }

--- a/src/utils/DeepLinkManager.ts
+++ b/src/utils/DeepLinkManager.ts
@@ -18,6 +18,8 @@ import { DefaultElementGeometry } from "../features/utility/ElementGeometry";
 import { SimCtlClient } from "./ios-cmdline-tools/SimCtlClient";
 import { quoteSimctlArg } from "./ios-cmdline-tools/iosAppContainer";
 import { isIosSimulatorUdid } from "./ios-cmdline-tools/iosDeviceType";
+import { shouldUseHostControl } from "./hostControlClient";
+import { isRunningInDocker } from "./dockerEnv";
 
 /**
  * Runs a host program (NOT `xcrun simctl`) **by argv, never via a shell**. Used
@@ -110,12 +112,14 @@ export class DeepLinkManager implements DeepLinkManager {
   private geometry: ElementGeometry;
   private simctl: SimCtlClient;
   private hostExec: HostExec;
+  private isHostControlMode: () => boolean;
 
   constructor(
     device: BootedDevice | null = null,
     adbFactoryOrExecutor: AdbClientFactory | AdbExecutor | null = defaultAdbClientFactory,
     simctl: SimCtlClient | null = null,
-    hostExec: HostExec | null = null
+    hostExec: HostExec | null = null,
+    hostControlGate: (() => boolean) | null = null
   ) {
     // Detect if the argument is a factory (has create method) or an executor
     if (adbFactoryOrExecutor && typeof (adbFactoryOrExecutor as AdbClientFactory).create === "function") {
@@ -133,6 +137,7 @@ export class DeepLinkManager implements DeepLinkManager {
     this.device = device;
     this.simctl = simctl ?? new SimCtlClient(device);
     this.hostExec = hostExec ?? defaultHostExec;
+    this.isHostControlMode = hostControlGate ?? (() => shouldUseHostControl() && isRunningInDocker());
     this.parser = new DefaultElementParser();
     this.geometry = new DefaultElementGeometry();
   }
@@ -236,6 +241,19 @@ export class DeepLinkManager implements DeepLinkManager {
         return this.emptyIosResult(
           bundleId,
           `Physical-device deep-link discovery for ${bundleId} is not yet implemented`
+        );
+      }
+
+      // Under host control (Docker/external-emulator mode), `get_app_container`
+      // resolves to a macOS host path while `plutil`/`codesign` run inside the
+      // container — the host path is not mounted and the tools may be absent.
+      // Gate as explicitly unsupported instead of reporting a misleading failure.
+      if (this.isHostControlMode()) {
+        return this.emptyIosResult(
+          bundleId,
+          `Deep-link discovery for ${bundleId} is not supported under host control ` +
+          `(Docker/external-emulator mode): the installed .app path resolves to the ` +
+          `macOS host, but plutil/codesign run inside the container`
         );
       }
 

--- a/test/features/utility/IosNotificationAuthorizationReader.test.ts
+++ b/test/features/utility/IosNotificationAuthorizationReader.test.ts
@@ -63,7 +63,7 @@ ${lines.join("\n")}
 }
 
 /** Fake deps: maps the outer path to canned plutil-xml; nested blobs matched by temp path. */
-function fakeDeps(opts: { outer?: string | Error; nested?: string }): {
+function fakeDeps(opts: { outer?: string | Error; nested?: string; hostControl?: boolean }): {
   deps: BulletinBoardReaderDeps;
   plutilPaths: string[];
 } {
@@ -86,6 +86,7 @@ function fakeDeps(opts: { outer?: string | Error; nested?: string }): {
     },
     rmTemp: async () => {},
     deviceDataRoot: (udid: string) => `/fake/CoreSimulator/Devices/${udid}`,
+    isHostControlMode: () => opts.hostControl ?? false,
   };
   return { deps, plutilPaths };
 }
@@ -148,7 +149,7 @@ describe("BulletinBoardAuthorizationReader", () => {
     });
   });
 
-  test("provisional app (Home-like) maps to provisional, not allowed", async () => {
+  test("provisional app (Home-like) maps to provisional and is allowed", async () => {
     const b64 = Buffer.from("bplist00").toString("base64");
     const { deps } = fakeDeps({
       outer: outerXml({ "com.apple.Home": b64 }),
@@ -163,11 +164,41 @@ describe("BulletinBoardAuthorizationReader", () => {
     const reader = new BulletinBoardAuthorizationReader(deps);
     const result = await reader.read(SIM_UDID, "com.apple.Home");
 
+    // Provisional (quiet) authorization still delivers notifications, so `allowed`
+    // is true; callers wanting full authorization check `authorizationStatus`.
     expect(result.authorizationStatus).toBe("provisional");
-    expect(result.allowed).toBe(false);
+    expect(result.allowed).toBe(true);
     expect(result.alerts).toBe(false);
     expect(result.lockScreen).toBe(false);
     expect(result.notificationCenter).toBe(true);
+  });
+
+  test("ephemeral app (App Clip) maps to ephemeral and is allowed", async () => {
+    const b64 = Buffer.from("bplist00").toString("base64");
+    const { deps } = fakeDeps({
+      outer: outerXml({ "com.example.clip": b64 }),
+      nested: nestedXml({ authorizationStatus: 4 }),
+    });
+    const reader = new BulletinBoardAuthorizationReader(deps);
+    const result = await reader.read(SIM_UDID, "com.example.clip");
+
+    expect(result.authorizationStatus).toBe("ephemeral");
+    expect(result.allowed).toBe(true);
+  });
+
+  test("host-control mode returns explicit unsupported, not a misleading unknown", async () => {
+    const { deps, plutilPaths } = fakeDeps({
+      outer: outerXml({ "com.apple.MobileSMS": "QUJD" }),
+      hostControl: true,
+    });
+    const reader = new BulletinBoardAuthorizationReader(deps);
+    const result = await reader.read(SIM_UDID, "com.apple.MobileSMS");
+
+    expect(result.supported).toBe(false);
+    expect(result.method).toBe("unsupported");
+    expect(result.error).toContain("host control");
+    // No host plutil read attempted in this environment.
+    expect(plutilPaths).toHaveLength(0);
   });
 
   test("denied app maps to denied + allowed false", async () => {

--- a/test/utils/DeepLinkManagerIos.test.ts
+++ b/test/utils/DeepLinkManagerIos.test.ts
@@ -184,6 +184,21 @@ describe("DeepLinkManager iOS", () => {
     expect(result.deepLinks.schemes).toEqual([]);
   });
 
+  test("host-control mode returns explicit unsupported without shelling out", async () => {
+    const simctl = new FakeSimCtlClient();
+    const { exec, calls } = fakeHostExec([]);
+
+    // hostControlGate = () => true simulates Docker/external-emulator mode.
+    const manager = new DeepLinkManager(iosDevice, null, simctl as any, exec, () => true);
+    const result = await manager.getDeepLinks("com.example.myapp");
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("host control");
+    // No get_app_container or host plutil/codesign attempted in this environment.
+    expect(simctl.getMethodCalls("executeCommand")).toHaveLength(0);
+    expect(calls).toHaveLength(0);
+  });
+
   test("physical-device UDID returns explicit not-yet-implemented error", async () => {
     const simctl = new FakeSimCtlClient();
     const { exec, calls } = fakeHostExec([]);


### PR DESCRIPTION
Follow-up to #2511, which merged before these review fixes could land on its branch. The P1 shell-injection fix (argv `execFile` instead of `exec`) made it into #2511 (commit `98aabed9`, squashed to `ccad778c`). This PR addresses the three remaining P2 review comments.

## Changes

### Host-control (Docker / external-emulator) gating — P2
In external-emulator mode, `SimCtlClient` routes `get_app_container` (and the BulletinBoard data root) to the **macOS host**, but `plutil`/`codesign` run **inside the container**, where the host path is not mounted and the tools may be absent. Previously this surfaced as a misleading failure (`getDeepLinks`) or made every app look unknown (`getNotificationPolicy`).

Both now return an explicit *"unsupported in this environment"* result, matching the existing `DeviceAppInspector` host-control gating pattern. Host-control exposes a fixed command allowlist (`simctl`/`xcodebuild`/`xcrun`/…) with no `plutil`/`codesign`, so routing the reads through the daemon isn't possible without new daemon commands — gating is the correct scope here.

### Provisional / ephemeral notification authorization — P2
iOS still delivers notifications for `provisional` (3, quiet) and `ephemeral` (4, App Clips), not just `authorized` (2). `allowed` is now true for all three delivery-capable statuses; callers needing strict full authorization check `authorizationStatus === "authorized"`.

## Tests
- New coverage: host-control gating for `getDeepLinks` and the BulletinBoard reader (no shell-out / no host read attempted), plus ephemeral-allowed and provisional-allowed cases.
- Updated the prior "provisional → not allowed" expectation to the corrected behavior.
- Full affected suite green; `turbo run lint build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)