### PR TITLE
fix(ios): bypass hierarchy cache when resolving dragAndDrop endpoints

### DIFF
--- a/docs/design-docs/plat/ios/ctrl-proxy-ios.md
+++ b/docs/design-docs/plat/ios/ctrl-proxy-ios.md
@@ -61,7 +61,10 @@ SpringBoard: tap, long-press, swipe, and **drag**
 (`press(forDuration:thenDragTo:withVelocity:thenHoldForDuration:)`). The `dragAndDrop` MCP
 tool resolves source/target element centers from a freshly-refreshed view hierarchy and
 dispatches through `IOSCtrlProxyClient.requestDrag()` to this path, reaching parity with the
-Android accessibility-service drag.
+Android accessibility-service drag. The refresh uses `requestHierarchySync` to force a fresh
+runner round-trip rather than `getAccessibilityHierarchy`, bypassing the client's (<500ms)
+hierarchy cache so a drag started just after a navigation/scroll can't resolve against a
+stale snapshot.
 
 The XCUICoordinate drag API takes a velocity (points/second) rather than a duration, so
 `GesturePerformer.drag` converts the caller's `dragDurationMs` into the velocity that covers

--- a/src/features/action/DragAndDrop.ts
+++ b/src/features/action/DragAndDrop.ts
@@ -34,6 +34,10 @@ const HOLD_DURATION_MAX_MS = 3000;
 const DROP_DURATION_MS = 100;
 const DRAG_TIMEOUT_BUFFER_MS = 500;
 const HIERARCHY_REFRESH_TIMEOUT_MS = 5000;
+// XCUITest hierarchy extraction is slow (can take 5-15s), so the iOS refresh uses the same
+// 15s budget as CtrlProxyHierarchy.getAccessibilityHierarchy rather than the 5s Android value.
+// A shorter timeout would fall back to the (possibly stale) observe cache on slow screens.
+const IOS_HIERARCHY_REFRESH_TIMEOUT_MS = 15000;
 
 interface DragAndDropDeps {
   visionConfig?: VisionFallbackConfig;
@@ -296,8 +300,10 @@ export class DragAndDrop extends BaseVisualChange {
     // TTL before issuing a fresh request, so a drag started shortly after a navigation/scroll
     // could still resolve against stale coordinates. requestHierarchySync always performs a
     // fresh runner round-trip, guaranteeing the drag endpoints come from a current snapshot.
+    // Use the 15s iOS budget: XCUITest extraction can take 5-15s, and a shorter timeout would
+    // fall back to the stale observe cache on slow screens.
     const client = IOSCtrlProxyClient.getInstance(this.device);
-    const synced = await client.requestHierarchySync(undefined, false, signal, HIERARCHY_REFRESH_TIMEOUT_MS);
+    const synced = await client.requestHierarchySync(undefined, false, signal, IOS_HIERARCHY_REFRESH_TIMEOUT_MS);
     if (!synced?.hierarchy) {
       return null;
     }

--- a/src/features/action/DragAndDrop.ts
+++ b/src/features/action/DragAndDrop.ts
@@ -277,7 +277,7 @@ export class DragAndDrop extends BaseVisualChange {
     // observe. Android refreshes via the accessibility service; iOS via the XCUITest
     // CtrlProxy runner's hierarchy snapshot.
     const refreshed = this.device.platform === "ios"
-      ? await this.refreshIosViewHierarchy()
+      ? await this.refreshIosViewHierarchy(signal)
       : await this.refreshViewHierarchy(signal);
     if (refreshed && !refreshed.hierarchy?.error) {
       return refreshed;
@@ -290,16 +290,18 @@ export class DragAndDrop extends BaseVisualChange {
     return null;
   }
 
-  private async refreshIosViewHierarchy(): Promise<ViewHierarchyResult | null> {
-    // skipWaitForFresh=false forces the runner to return a current snapshot when the
-    // cached hierarchy is stale, instead of resolving against the (possibly old) observe
-    // cache. Mirrors how the iOS observe path sources its hierarchy.
-    return IOSCtrlProxyClient.getInstance(this.device).getAccessibilityHierarchy(
-      undefined,
-      undefined,
-      false,
-      0
-    );
+  private async refreshIosViewHierarchy(signal?: AbortSignal): Promise<ViewHierarchyResult | null> {
+    // Bypass the IOSCtrlProxyClient hierarchy cache entirely. getAccessibilityHierarchy /
+    // getLatestHierarchy would return any client-cached snapshot younger than its (<500ms)
+    // TTL before issuing a fresh request, so a drag started shortly after a navigation/scroll
+    // could still resolve against stale coordinates. requestHierarchySync always performs a
+    // fresh runner round-trip, guaranteeing the drag endpoints come from a current snapshot.
+    const client = IOSCtrlProxyClient.getInstance(this.device);
+    const synced = await client.requestHierarchySync(undefined, false, signal, HIERARCHY_REFRESH_TIMEOUT_MS);
+    if (!synced?.hierarchy) {
+      return null;
+    }
+    return client.convertToViewHierarchyResult(synced.hierarchy);
   }
 
   private async refreshViewHierarchy(signal?: AbortSignal): Promise<ViewHierarchyResult | null> {

--- a/test/features/action/DragAndDropIos.test.ts
+++ b/test/features/action/DragAndDropIos.test.ts
@@ -160,6 +160,8 @@ describe("DragAndDrop - iOS", () => {
     expect(syncSpy).toHaveBeenCalled();
     expect(cachedSpy).not.toHaveBeenCalled();
     expect(latestSpy).not.toHaveBeenCalled();
+    // Uses the 15s iOS budget (XCUITest extraction can take 5-15s), not the 5s Android value.
+    expect(syncSpy).toHaveBeenCalledWith(undefined, false, undefined, 15000);
   });
 
   test("drags against the freshly-refreshed hierarchy, not the stale observe cache", async () => {

--- a/test/features/action/DragAndDropIos.test.ts
+++ b/test/features/action/DragAndDropIos.test.ts
@@ -143,6 +143,25 @@ describe("DragAndDrop - iOS", () => {
     expect(fakeAndroidClient.getHierarchyRequestCount()).toBe(0);
   });
 
+  test("bypasses the client hierarchy cache via requestHierarchySync", async () => {
+    // requestHierarchySync always does a fresh runner round-trip; the cache-aware
+    // getAccessibilityHierarchy / getLatestHierarchy fast-paths must NOT be used,
+    // otherwise a snapshot younger than the client TTL could resolve stale coordinates.
+    const syncSpy = spyOn(fakeIosClient, "requestHierarchySync");
+    const cachedSpy = spyOn(fakeIosClient, "getAccessibilityHierarchy");
+    const latestSpy = spyOn(fakeIosClient, "getLatestHierarchy");
+    fakeIosClient.setDragResult({ success: true, totalTimeMs: 1, gestureTimeMs: 1 });
+
+    await dragAndDrop.execute({
+      source: { elementId: "source-id" },
+      target: { elementId: "target-id" }
+    });
+
+    expect(syncSpy).toHaveBeenCalled();
+    expect(cachedSpy).not.toHaveBeenCalled();
+    expect(latestSpy).not.toHaveBeenCalled();
+  });
+
   test("drags against the freshly-refreshed hierarchy, not the stale observe cache", async () => {
     // The cached observe places the elements at (50,50)/(250,250); the fresh runner
     // snapshot reports new coordinates after the UI scrolled. The drag must use the fresh ones.


### PR DESCRIPTION
Follow-up to #2507 addressing the remaining Codex review comment.

## Problem
`DragAndDrop.refreshIosViewHierarchy` resolved the iOS drag endpoints via
`getAccessibilityHierarchy(skipWaitForFresh=false, minTimestamp=0)`. With `minTimestamp=0`,
`CtrlProxyHierarchy.getLatestHierarchy` still returns any client-cached snapshot younger than
its (<500 ms) TTL *before* it issues a fresh `requestHierarchySync`. So a `dragAndDrop` started
shortly after the UI navigated/scrolled could still resolve source/target against **stale
coordinates** — exactly the staleness the earlier fix was meant to close.

## Fix
Switch `refreshIosViewHierarchy` to call `requestHierarchySync` directly, which always performs
a fresh runner round-trip with no cache fast-path, then convert the result. The abort signal is
threaded through, and the existing fallback to the observe cache (when no snapshot is available)
is preserved.

```ts
const client = IOSCtrlProxyClient.getInstance(this.device);
const synced = await client.requestHierarchySync(undefined, false, signal, HIERARCHY_REFRESH_TIMEOUT_MS);
if (!synced?.hierarchy) return null;
return client.convertToViewHierarchyResult(synced.hierarchy);
```

This bypasses the client cache (the reviewer's first suggested remedy) rather than passing a
current timestamp, avoiding any TS-clock vs device-`updatedAt` skew in the `minTimestamp`
comparison.

## Tests
- New test asserts `requestHierarchySync` is used and the cache-aware
  `getAccessibilityHierarchy` / `getLatestHierarchy` paths are **not** called.
- Existing iOS routing tests (fresh-hierarchy use, fallback, duration forwarding) still pass.
- `bun test test/features/action/` — 650 pass / 1 skip / 0 fail.
- `eslint --fix` clean; `bun run build` succeeds. TS-only change (no Swift).

## Docs
`plat/ios/ctrl-proxy-ios.md` Gestures section notes the `requestHierarchySync` cache bypass.