### PR TITLE
fix(ios): avoid duplicate initial observation frame

### DIFF
--- a/src/daemon/daemon.ts
+++ b/src/daemon/daemon.ts
@@ -673,13 +673,14 @@ export class Daemon {
     return {
       ensureConnected: () => client.ensureConnected(),
       getLatestHierarchy: (...args) => client.getLatestHierarchy(...args),
-      requestHierarchySync: async (...args) => {
-        const result = await client.requestHierarchySync(...args);
+      requestHierarchySyncWithoutObservationStreamPush: async (...args) => {
+        const result = await client.requestHierarchySyncWithoutObservationStreamPush(...args);
         return result ? { hierarchy: result.hierarchy } : null;
       },
       convertToViewHierarchyResult: hierarchy =>
         client.convertToViewHierarchyResult(hierarchy as never),
-      requestScreenshot: (...args) => client.requestScreenshot(...args),
+      requestScreenshotWithoutObservationStreamPush: (...args) =>
+        client.requestScreenshotWithoutObservationStreamPush(...args),
     };
   }
 

--- a/src/daemon/observationInitialFrame.ts
+++ b/src/daemon/observationInitialFrame.ts
@@ -54,14 +54,14 @@ export interface ObservationStreamIosClient {
     skipWaitForFresh?: boolean,
     minTimestamp?: number
   ): Promise<CtrlProxyHierarchyResponse>;
-  requestHierarchySync(
+  requestHierarchySyncWithoutObservationStreamPush(
     perf?: PerformanceTracker,
     disableAllFiltering?: boolean,
     signal?: AbortSignal,
     timeoutMs?: number
   ): Promise<{ hierarchy: unknown } | null>;
   convertToViewHierarchyResult(hierarchy: unknown): ViewHierarchyResult;
-  requestScreenshot(timeoutMs?: number, perf?: PerformanceTracker): Promise<CtrlProxyScreenshotResult>;
+  requestScreenshotWithoutObservationStreamPush(timeoutMs?: number, perf?: PerformanceTracker): Promise<CtrlProxyScreenshotResult>;
 }
 
 export interface ObservationInitialFrameDependencies {
@@ -198,7 +198,7 @@ async function pushIosInitialObservationFrame(
   const viewHierarchy = client.convertToViewHierarchyResult(hierarchy);
   dependencies.streamServer.pushHierarchyUpdate(device.deviceId, viewHierarchy);
 
-  const screenshot = await client.requestScreenshot(INITIAL_FRAME_SCREENSHOT_TIMEOUT_MS);
+  const screenshot = await client.requestScreenshotWithoutObservationStreamPush(INITIAL_FRAME_SCREENSHOT_TIMEOUT_MS);
   if (screenshot.success && screenshot.data) {
     const dimensions = getIosScreenshotDimensions(viewHierarchy);
     dependencies.streamServer.pushScreenshotUpdate(
@@ -223,7 +223,7 @@ async function getIosInitialHierarchy(
     return hierarchyResponse.hierarchy;
   }
 
-  const syncHierarchy = await client.requestHierarchySync(
+  const syncHierarchy = await client.requestHierarchySyncWithoutObservationStreamPush(
     undefined,
     false,
     undefined,

--- a/src/features/observe/ios/CtrlProxyHierarchy.ts
+++ b/src/features/observe/ios/CtrlProxyHierarchy.ts
@@ -153,13 +153,17 @@ export class CtrlProxyHierarchy {
     perf?: PerformanceTracker,
     disableAllFiltering?: boolean,
     signal?: AbortSignal,
-    timeoutMs: number = 5000
+    timeoutMs: number = 5000,
+    suppressObservationStreamPush: boolean = false
   ): Promise<{ hierarchy: XCTestHierarchy; perfTiming?: CtrlProxyPerfTiming } | null> {
     if (!await this.context.ensureConnected(perf)) {
       return null;
     }
 
     const requestId = this.context.requestManager.generateId("hierarchy");
+    if (suppressObservationStreamPush) {
+      this.context.suppressHierarchyObservationStreamPush?.(requestId, timeoutMs);
+    }
     const promise = this.context.requestManager.register<{ hierarchy?: XCTestHierarchy; perfTiming?: CtrlProxyPerfTiming }>(
       requestId,
       "hierarchy",

--- a/src/features/observe/ios/IOSCtrlProxyClient.ts
+++ b/src/features/observe/ios/IOSCtrlProxyClient.ts
@@ -156,6 +156,13 @@ export interface IOSCtrlProxy extends CtrlProxyClient {
     timeoutMs?: number
   ): Promise<{ hierarchy: CtrlProxyHierarchy; perfTiming?: CtrlProxyPerfTiming } | null>;
 
+  requestHierarchySyncWithoutObservationStreamPush(
+    perf?: PerformanceTracker,
+    disableAllFiltering?: boolean,
+    signal?: AbortSignal,
+    timeoutMs?: number
+  ): Promise<{ hierarchy: CtrlProxyHierarchy; perfTiming?: CtrlProxyPerfTiming } | null>;
+
   convertToViewHierarchyResult(hierarchy: CtrlProxyHierarchy): ViewHierarchyResult;
 
   requestSwipe(
@@ -229,6 +236,10 @@ export interface IOSCtrlProxy extends CtrlProxyClient {
     timeoutMs?: number, perf?: PerformanceTracker
   ): Promise<CtrlProxyScreenshotResult>;
 
+  requestScreenshotWithoutObservationStreamPush(
+    timeoutMs?: number, perf?: PerformanceTracker
+  ): Promise<CtrlProxyScreenshotResult>;
+
   requestVoiceOverState(
     timeoutMs?: number, perf?: PerformanceTracker
   ): Promise<CtrlProxyVoiceOverResult>;
@@ -278,6 +289,7 @@ export class IOSCtrlProxyClient extends DeviceServiceClient implements IOSCtrlPr
   private cachedHierarchy: CtrlProxyCachedHierarchy | null = null;
   private static readonly CACHE_FRESH_TTL_MS = 500;
   private hierarchyNavigationDetector: HierarchyNavigationDetector | null = null;
+  private readonly hierarchyObservationStreamSuppressions: Map<string, NodeJS.Timeout> = new Map();
 
   // Push update callbacks
   private onPushUpdateCallbacks: Set<(hierarchy: CtrlProxyHierarchy) => void> = new Set();
@@ -490,6 +502,8 @@ export class IOSCtrlProxyClient extends DeviceServiceClient implements IOSCtrlPr
       cacheFreshTtlMs: IOSCtrlProxyClient.CACHE_FRESH_TTL_MS,
       getCachedHierarchy: () => this.cachedHierarchy,
       setCachedHierarchy: h => { this.cachedHierarchy = h; },
+      suppressHierarchyObservationStreamPush: (requestId, timeoutMs) =>
+        this.suppressHierarchyObservationStreamPush(requestId, timeoutMs),
     };
   }
 
@@ -945,7 +959,12 @@ export class IOSCtrlProxyClient extends DeviceServiceClient implements IOSCtrlPr
       // Push messages (no requestId) are handled in the dedicated push-message branch below
       // to avoid duplicate hierarchy events.
       if (requestId) {
-        this.pushHierarchyToObservationStream(converted);
+        const suppressObservationStreamPush = this.consumeHierarchyObservationStreamSuppression(requestId);
+        if (!suppressObservationStreamPush) {
+          this.pushHierarchyToObservationStream(converted);
+        } else {
+          logger.debug("[IOSCtrlProxyClient] Suppressed hierarchy observation stream push for explicit initial-frame request");
+        }
       }
     }
 
@@ -1231,6 +1250,15 @@ export class IOSCtrlProxyClient extends DeviceServiceClient implements IOSCtrlPr
     return this.hierarchy.requestHierarchySync(perf, disableAllFiltering, signal, timeoutMs);
   }
 
+  async requestHierarchySyncWithoutObservationStreamPush(
+    perf?: PerformanceTracker,
+    disableAllFiltering?: boolean,
+    signal?: AbortSignal,
+    timeoutMs: number = 5000
+  ): Promise<{ hierarchy: CtrlProxyHierarchy; perfTiming?: CtrlProxyPerfTiming } | null> {
+    return this.hierarchy.requestHierarchySync(perf, disableAllFiltering, signal, timeoutMs, true);
+  }
+
   convertToViewHierarchyResult(hierarchy: CtrlProxyHierarchy): ViewHierarchyResult {
     return this.hierarchy.convertToViewHierarchyResult(hierarchy);
   }
@@ -1373,6 +1401,12 @@ export class IOSCtrlProxyClient extends DeviceServiceClient implements IOSCtrlPr
     return this.screenshot.requestScreenshot(timeoutMs, perf);
   }
 
+  async requestScreenshotWithoutObservationStreamPush(
+    timeoutMs: number = 5000, perf?: PerformanceTracker
+  ): Promise<CtrlProxyScreenshotResult> {
+    return this.requestScreenshot(timeoutMs, perf);
+  }
+
   // ===========================================================================
   // Delegated Public Methods - VoiceOver
   // ===========================================================================
@@ -1489,6 +1523,29 @@ export class IOSCtrlProxyClient extends DeviceServiceClient implements IOSCtrlPr
         logger.warn(`[IOSCtrlProxyClient] Push update callback error: ${error}`);
       }
     }
+  }
+
+  private suppressHierarchyObservationStreamPush(requestId: string, timeoutMs: number): void {
+    const existingTimeout = this.hierarchyObservationStreamSuppressions.get(requestId);
+    if (existingTimeout) {
+      this.timer.clearTimeout(existingTimeout);
+    }
+
+    const timeoutHandle = this.timer.setTimeout(() => {
+      this.hierarchyObservationStreamSuppressions.delete(requestId);
+    }, timeoutMs);
+    this.hierarchyObservationStreamSuppressions.set(requestId, timeoutHandle);
+  }
+
+  private consumeHierarchyObservationStreamSuppression(requestId: string): boolean {
+    const timeoutHandle = this.hierarchyObservationStreamSuppressions.get(requestId);
+    if (!timeoutHandle) {
+      return false;
+    }
+
+    this.hierarchyObservationStreamSuppressions.delete(requestId);
+    this.timer.clearTimeout(timeoutHandle);
+    return true;
   }
 
   /**

--- a/src/features/observe/ios/types.ts
+++ b/src/features/observe/ios/types.ts
@@ -241,4 +241,6 @@ export interface HierarchyDelegateContext extends DelegateContext {
   getCachedHierarchy(): CtrlProxyCachedHierarchy | null;
   /** Set the cached hierarchy data */
   setCachedHierarchy(h: CtrlProxyCachedHierarchy | null): void;
+  /** Prevent the response for this request from being forwarded to the observation stream. */
+  suppressHierarchyObservationStreamPush?(requestId: string, timeoutMs: number): void;
 }

--- a/test/daemon/observationInitialFrame.test.ts
+++ b/test/daemon/observationInitialFrame.test.ts
@@ -103,6 +103,8 @@ class FakeAndroidInitialFrameClient implements ObservationStreamAndroidClient {
 
 class FakeIosInitialFrameClient implements ObservationStreamIosClient {
   readonly syncHierarchyCalls: Array<{ timeoutMs?: number }> = [];
+  readonly suppressedSyncHierarchyCalls: Array<{ timeoutMs?: number }> = [];
+  readonly suppressedScreenshotCalls: Array<{ timeoutMs?: number }> = [];
 
   constructor(
     private readonly connected: boolean,
@@ -134,6 +136,16 @@ class FakeIosInitialFrameClient implements ObservationStreamIosClient {
     return this.syncHierarchy ? { hierarchy: this.syncHierarchy } : null;
   }
 
+  async requestHierarchySyncWithoutObservationStreamPush(
+    _perf?: unknown,
+    _disableAllFiltering?: boolean,
+    _signal?: AbortSignal,
+    timeoutMs?: number
+  ): Promise<{ hierarchy: CtrlProxyHierarchy } | null> {
+    this.suppressedSyncHierarchyCalls.push({ timeoutMs });
+    return this.syncHierarchy ? { hierarchy: this.syncHierarchy } : null;
+  }
+
   convertToViewHierarchyResult(hierarchy: unknown): ViewHierarchyResult {
     const typedHierarchy = hierarchy as CtrlProxyHierarchy;
     return {
@@ -147,6 +159,11 @@ class FakeIosInitialFrameClient implements ObservationStreamIosClient {
   }
 
   async requestScreenshot(): Promise<CtrlProxyScreenshotResult> {
+    return this.screenshot;
+  }
+
+  async requestScreenshotWithoutObservationStreamPush(timeoutMs?: number): Promise<CtrlProxyScreenshotResult> {
+    this.suppressedScreenshotCalls.push({ timeoutMs });
     return this.screenshot;
   }
 }
@@ -307,6 +324,9 @@ describe("pushInitialObservationFramesForSubscriber", () => {
         screenHeight: 2532,
       },
     ]);
+    expect(iosClient.syncHierarchyCalls).toHaveLength(0);
+    expect(iosClient.suppressedSyncHierarchyCalls).toHaveLength(0);
+    expect(iosClient.suppressedScreenshotCalls).toEqual([{ timeoutMs: 3000 }]);
   });
 
   it("captures iOS hierarchy synchronously when the initial cache is empty", async () => {
@@ -332,7 +352,8 @@ describe("pushInitialObservationFramesForSubscriber", () => {
       iosClientFactory: () => iosClient,
     });
 
-    expect(iosClient.syncHierarchyCalls).toEqual([{ timeoutMs: 3000 }]);
+    expect(iosClient.syncHierarchyCalls).toHaveLength(0);
+    expect(iosClient.suppressedSyncHierarchyCalls).toEqual([{ timeoutMs: 3000 }]);
     expect(streamServer.hierarchyUpdates[0].hierarchy.updatedAt).toBe(987);
     expect(streamServer.hierarchyUpdates[0].hierarchy.hierarchy.node).toEqual({ $: { text: "Cold start" } });
     expect(streamServer.screenshotUpdates[0]).toMatchObject({
@@ -374,7 +395,8 @@ describe("pushInitialObservationFramesForSubscriber", () => {
       iosClientFactory: () => iosClient,
     });
 
-    expect(iosClient.syncHierarchyCalls).toEqual([{ timeoutMs: 3000 }]);
+    expect(iosClient.syncHierarchyCalls).toHaveLength(0);
+    expect(iosClient.suppressedSyncHierarchyCalls).toEqual([{ timeoutMs: 3000 }]);
     expect(streamServer.hierarchyUpdates[0].hierarchy.updatedAt).toBe(200);
     expect(streamServer.hierarchyUpdates[0].hierarchy.hierarchy.node).toEqual({ $: { text: "Fresh sync" } });
   });

--- a/test/features/observe/ios/IOSCtrlProxyClient.test.ts
+++ b/test/features/observe/ios/IOSCtrlProxyClient.test.ts
@@ -186,6 +186,59 @@ describe("IOSCtrlProxyClient", function() {
       }
     });
 
+    test("suppresses observation stream push for explicit hierarchy sync request", async function() {
+      const mockHierarchyData: CtrlProxyHierarchy = {
+        updatedAt: 1750934584218,
+        packageName: "com.example.ios",
+        hierarchy: {
+          text: "Initial frame",
+        },
+      };
+      const testTimer = fakeTimer;
+      const { factory, getSocket } = createCapturingWebSocketFactory(testTimer);
+      const testClient = IOSCtrlProxyClient.createForTesting(
+        testDevice,
+        serverPort,
+        factory,
+        testTimer
+      );
+      const suppressionIds = (): string[] =>
+        Array.from((testClient as unknown as {
+          hierarchyObservationStreamSuppressions: Map<string, unknown>;
+        }).hierarchyObservationStreamSuppressions.keys());
+
+      try {
+        const resultPromise = testClient.requestHierarchySyncWithoutObservationStreamPush(
+          undefined,
+          false,
+          undefined,
+          3000
+        );
+        const socket = await waitForSocket(getSocket);
+        expect(socket).not.toBeNull();
+        await waitForSocketOpen(socket);
+        await waitForSentMessages(socket, 1);
+
+        const sentMessage = JSON.parse(socket!.sentMessages[0]);
+        expect(sentMessage.type).toBe("request_hierarchy_if_stale");
+        expect(suppressionIds()).toEqual([sentMessage.requestId]);
+
+        socket!.simulateMessage(JSON.stringify({
+          type: "hierarchy_update",
+          requestId: sentMessage.requestId,
+          timestamp: Date.now(),
+          data: mockHierarchyData,
+        }));
+
+        const result = await resultPromise;
+
+        expect(result?.hierarchy.updatedAt).toBe(1750934584218);
+        expect(suppressionIds()).toHaveLength(0);
+      } finally {
+        await testClient.close();
+      }
+    });
+
     test("should return null hierarchy when not connected", async function() {
       const testTimer = fakeTimer;
 


### PR DESCRIPTION
## Summary
- Fix iOS cold observation-stream initial hierarchy pushes by adding an exact-request suppression path to `IOSCtrlProxyClient`
- Route the iOS initial-frame hierarchy and screenshot capture through suppressed variants to mirror the Android initial-frame contract
- Add daemon-level and iOS client-level regression coverage for the suppressed initial-frame path

Fixes #2530.

## Self-review
- Removed unused plain iOS request methods from the initial-frame dependency interface after switching that path to suppressed variants
- Checked for contract drift between daemon adapter, initial-frame dependency interfaces, and iOS client public methods

## Testing
- `bun test test/daemon/observationInitialFrame.test.ts test/features/observe/ios/IOSCtrlProxyClient.test.ts`
- `bun run lint`
- `bun run build`
- `bun test --bail`

Note: `bun install` was attempted to restore a missing local `xml2js` package. It failed compiling the existing dev dependency `heapdump` against Node 26, but the needed pure JS packages were installed before that failure and all validation above passed.
