### PR TITLE
fix(daemon): install startup lifecycle handlers early

### DIFF
--- a/src/daemon/daemon.ts
+++ b/src/daemon/daemon.ts
@@ -19,7 +19,7 @@ import {
 import { DaemonOptions, PidFileData } from "./types";
 import { writeFile } from "node:fs/promises";
 import { PID_FILE_PATH, DAEMON_VERSION } from "./constants";
-import { cleanupDaemonFiles, cleanupDaemonFilesSync } from "./daemonFiles";
+import { cleanupDaemonFiles, cleanupDaemonFilesSync, readPidFileDataSync } from "./daemonFiles";
 import { executionTracker } from "../server/executionTracker";
 import { closeDatabase, getDatabase } from "../db";
 import { startupBenchmark } from "../utils/startupBenchmark";
@@ -55,6 +55,11 @@ import { describeUnknownError } from "../utils/describeUnknownError";
 import { FeatureFlagService } from "../features/featureFlags/FeatureFlagService";
 import { serverConfig } from "../utils/ServerConfig";
 import { setDebugPerfEnabled } from "../utils/PerformanceTracker";
+import {
+  installProcessLifecycleHandlers,
+  setFatalProcessHandler,
+  setProcessShutdownHandler,
+} from "../processLifecycle";
 import type { BootedDevice } from "../models";
 
 const DEVICE_DISCONNECT_POLL_INTERVAL_MS = 5000;
@@ -80,6 +85,7 @@ export class Daemon {
   private healthCheckTimer: NodeJS.Timeout | null = null;
   private heartbeatMonitor: SessionHeartbeatMonitor | null = null;
   private deviceDisconnectTimer: NodeJS.Timeout | null = null;
+  private pidFileWritten = false;
   private deviceDisconnectMisses: Map<string, number> = new Map();
   private stoppingRecordings: Set<string> = new Set();
   private sessionManager: SessionManager;
@@ -175,6 +181,7 @@ export class Daemon {
     logger.enableStdoutLogging();
 
     logger.info("Starting AutoMobile daemon...");
+    this.setupShutdownHandlers();
 
     await this.initializeDatabase();
 
@@ -240,9 +247,6 @@ export class Daemon {
     // Verify DaemonState is initialized
     const isInitialized = DaemonState.getInstance().isInitialized();
     logger.info(`DaemonState initialized: ${isInitialized}, device count: ${this.devicePool.getTotalDeviceCount()}`);
-
-    // Setup shutdown handlers
-    this.setupShutdownHandlers();
 
     // Start health check timer (every 30 seconds)
     this.startHealthCheckTimer();
@@ -594,6 +598,7 @@ export class Daemon {
       encoding: "utf-8",
       mode: 0o600,
     });
+    this.pidFileWritten = true;
     logger.info(`PID file written to ${PID_FILE_PATH}`);
   }
 
@@ -1079,6 +1084,7 @@ export class Daemon {
       return;
     }
     this.shutdownHandlersRegistered = true;
+    installProcessLifecycleHandlers();
 
     const shutdown = async (signal: string) => {
       if (this.shutdownInProgress) {
@@ -1087,30 +1093,25 @@ export class Daemon {
       this.shutdownInProgress = true;
       logger.info(`Received ${signal}, shutting down daemon...`);
       await this.stop();
-      process.exit(0);
     };
 
     const cleanupAndExit = (label: string, error: unknown) => {
       logger.error(`${label}: ${error instanceof Error ? error.stack ?? error.message : String(error)}`);
-      cleanupDaemonFilesSync({ expectedPid: process.pid });
+      cleanupDaemonFilesSync(this.getDaemonFileCleanupOptions());
       logger.close();
       process.exit(1);
     };
 
-    process.once("SIGINT", () => {
-      shutdown("SIGINT").catch(error => cleanupAndExit("Error during SIGINT shutdown", error));
-    });
-    process.once("SIGTERM", () => {
-      shutdown("SIGTERM").catch(error => cleanupAndExit("Error during SIGTERM shutdown", error));
-    });
+    setProcessShutdownHandler(shutdown);
     process.once("exit", () => {
-      cleanupDaemonFilesSync({ expectedPid: process.pid });
+      cleanupDaemonFilesSync(this.getDaemonFileCleanupOptions());
     });
-    process.once("uncaughtException", error => {
-      cleanupAndExit("Uncaught exception in daemon", error);
-    });
-    process.once("unhandledRejection", reason => {
-      cleanupAndExit("Unhandled rejection in daemon", reason);
+    setFatalProcessHandler(event => {
+      if (event.type === "uncaughtException") {
+        cleanupAndExit("Uncaught exception in daemon", event.error);
+        return;
+      }
+      cleanupAndExit("Unhandled rejection in daemon", event.reason);
     });
   }
 
@@ -1175,12 +1176,20 @@ export class Daemon {
       });
     }
 
-    await cleanupDaemonFiles({ expectedPid: process.pid });
+    await cleanupDaemonFiles(this.getDaemonFileCleanupOptions());
 
     await closeDatabase();
 
     logger.info("Daemon stopped");
     logger.close();
+  }
+
+  private getDaemonFileCleanupOptions(): { expectedPid?: number } {
+    if (this.pidFileWritten) {
+      return { expectedPid: process.pid };
+    }
+    const pidData = readPidFileDataSync();
+    return pidData && pidData.pid !== process.pid ? { expectedPid: process.pid } : {};
   }
 
   /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,11 @@ import type { VideoRecordingConfigInput } from "./models";
 import { getGlobalVersionOutput } from "./cli/versionFlag";
 import { startupBenchmark } from "./utils/startupBenchmark";
 import { getMcpServerVersion } from "./utils/mcpVersion";
+import {
+  installProcessLifecycleHandlers,
+  setFatalProcessHandler,
+  setProcessShutdownHandler,
+} from "./processLifecycle";
 
 interface FatalLogger {
   error(...args: unknown[]): void;
@@ -30,26 +35,21 @@ function logFatal(label: string, error: unknown): void {
   }
 }
 
-/**
- * Install process-level safety-net handlers BEFORE the dynamic imports in main()
- * run, so a failure during startup is logged rather than lost. This is the
- * proxy/client process: it logs and continues. The daemon process installs its
- * own (exit-on-fault) handlers in daemon.ts.
- */
-function registerProcessSafetyNet(): void {
-  process.on("uncaughtException", error => {
-    logFatal("Uncaught exception", error);
-  });
-  process.on("unhandledRejection", reason => {
-    logFatal("Unhandled rejection", reason);
-  });
-}
-
 const versionOutput = getGlobalVersionOutput(process.argv.slice(2), getMcpServerVersion());
 if (versionOutput !== undefined) {
   console.log(versionOutput);
   process.exit(0);
 }
+
+installProcessLifecycleHandlers();
+setFatalProcessHandler(event => {
+  if (event.type === "uncaughtException") {
+    logFatal("Uncaught exception", event.error);
+    return;
+  }
+  logFatal("Unhandled rejection", event.reason);
+});
+
 interface ParseLogger {
   warn(message: string): void;
 }
@@ -352,10 +352,6 @@ function parseArgs(log: ParseLogger): {
 }
 
 async function main() {
-  // Register before any `await import(...)` below so a crash during startup
-  // imports is logged instead of lost.
-  registerProcessSafetyNet();
-
   const { StdioServerTransport } = await import("@modelcontextprotocol/sdk/server/stdio.js");
   const { createMcpServer } = await import("./server");
   const { createProxyMcpServer } = await import("./server/proxyServer");
@@ -384,7 +380,7 @@ async function main() {
   const { startAppearanceSyncScheduler, stopAppearanceSyncScheduler } = appearanceSyncScheduler;
   const { startHostEmulatorAutoConnect, stopHostEmulatorAutoConnect } = hostEmulatorAutoConnect;
 
-  const shutdown = async (signal: "SIGINT" | "SIGTERM") => {
+  setProcessShutdownHandler(async signal => {
     logger.info(`Received ${signal} signal, shutting down`);
     await stopHostEmulatorAutoConnect();
     await stopVideoRecordingSocketServer();
@@ -394,20 +390,7 @@ async function main() {
     stopAppearanceSyncScheduler();
     await AndroidCtrlProxyManager.cleanupPrefetchedApk();
     logger.close();
-    process.exit(0);
-  };
-
-  process.on("SIGINT", () => {
-    void shutdown("SIGINT");
   });
-
-  process.on("SIGTERM", () => {
-    void shutdown("SIGTERM");
-  });
-
-  // uncaughtException/unhandledRejection are registered at startup via
-  // registerProcessSafetyNet() so failures during the dynamic imports above are
-  // also captured. fatalLogger now points at the file logger.
 
   try {
     // Parse command line arguments

--- a/src/processLifecycle.ts
+++ b/src/processLifecycle.ts
@@ -1,0 +1,110 @@
+export type ShutdownSignal = "SIGINT" | "SIGTERM";
+
+export type ProcessLifecycleEventMap = {
+  SIGINT: [];
+  SIGTERM: [];
+  uncaughtException: [Error];
+  unhandledRejection: [unknown, Promise<unknown>];
+};
+
+export interface ProcessLifecycleProcess {
+  on<K extends keyof ProcessLifecycleEventMap>(
+    event: K,
+    listener: (...args: ProcessLifecycleEventMap[K]) => void
+  ): unknown;
+  exit(code?: number): never;
+}
+
+export type ProcessShutdownHandler = (signal: ShutdownSignal) => Promise<void> | void;
+
+export type FatalProcessEvent =
+  | { type: "uncaughtException"; error: Error }
+  | { type: "unhandledRejection"; reason: unknown; promise: Promise<unknown> };
+
+export type FatalProcessHandler = (event: FatalProcessEvent) => Promise<void> | void;
+
+export class ProcessLifecycleHandlers {
+  private installed = false;
+  private shutdownInProgress = false;
+  private shutdownHandler: ProcessShutdownHandler | undefined;
+  private fatalProcessHandler: FatalProcessHandler | undefined;
+
+  constructor(private readonly lifecycleProcess: ProcessLifecycleProcess) {}
+
+  install(): void {
+    if (this.installed) {
+      return;
+    }
+    this.installed = true;
+
+    this.lifecycleProcess.on("SIGINT", () => {
+      void this.shutdown("SIGINT");
+    });
+    this.lifecycleProcess.on("SIGTERM", () => {
+      void this.shutdown("SIGTERM");
+    });
+    this.lifecycleProcess.on("uncaughtException", error => {
+      void this.handleFatalProcessEvent({ type: "uncaughtException", error });
+    });
+    this.lifecycleProcess.on("unhandledRejection", (reason, promise) => {
+      void this.handleFatalProcessEvent({ type: "unhandledRejection", reason, promise });
+    });
+  }
+
+  setShutdownHandler(handler: ProcessShutdownHandler): void {
+    this.shutdownHandler = handler;
+  }
+
+  setFatalProcessHandler(handler: FatalProcessHandler): void {
+    this.fatalProcessHandler = handler;
+  }
+
+  private async shutdown(signal: ShutdownSignal): Promise<void> {
+    if (this.shutdownInProgress) {
+      return;
+    }
+    this.shutdownInProgress = true;
+
+    try {
+      await this.shutdownHandler?.(signal);
+      this.lifecycleProcess.exit(0);
+    } catch (error) {
+      console.error(`Error during ${signal} shutdown:`, error);
+      this.lifecycleProcess.exit(1);
+    }
+  }
+
+  private async handleFatalProcessEvent(event: FatalProcessEvent): Promise<void> {
+    const handler = this.fatalProcessHandler;
+    if (!handler) {
+      if (event.type === "uncaughtException") {
+        console.error("Uncaught exception:", event.error);
+      } else {
+        console.error("Unhandled rejection at:", event.promise, "reason:", event.reason);
+      }
+      this.lifecycleProcess.exit(1);
+      return;
+    }
+
+    try {
+      await handler(event);
+    } catch (error) {
+      console.error("Error in fatal process handler:", error);
+      this.lifecycleProcess.exit(1);
+    }
+  }
+}
+
+const processLifecycleHandlers = new ProcessLifecycleHandlers(process);
+
+export function installProcessLifecycleHandlers(): void {
+  processLifecycleHandlers.install();
+}
+
+export function setProcessShutdownHandler(handler: ProcessShutdownHandler): void {
+  processLifecycleHandlers.setShutdownHandler(handler);
+}
+
+export function setFatalProcessHandler(handler: FatalProcessHandler): void {
+  processLifecycleHandlers.setFatalProcessHandler(handler);
+}

--- a/test/processLifecycle.test.ts
+++ b/test/processLifecycle.test.ts
@@ -1,0 +1,157 @@
+import { describe, expect, spyOn, test } from "bun:test";
+import {
+  ProcessLifecycleHandlers,
+  type ProcessLifecycleEventMap,
+  type ProcessLifecycleProcess,
+} from "../src/processLifecycle";
+
+class FakeProcess implements ProcessLifecycleProcess {
+  readonly listeners = new Map<keyof ProcessLifecycleEventMap, Array<(...args: any[]) => void>>();
+  readonly exitCodes: number[] = [];
+
+  on<K extends keyof ProcessLifecycleEventMap>(
+    event: K,
+    listener: (...args: ProcessLifecycleEventMap[K]) => void
+  ): unknown {
+    const eventListeners = this.listeners.get(event) ?? [];
+    eventListeners.push(listener);
+    this.listeners.set(event, eventListeners);
+    return this;
+  }
+
+  exit(code: number = 0): never {
+    this.exitCodes.push(code);
+    return undefined as never;
+  }
+
+  emit<K extends keyof ProcessLifecycleEventMap>(
+    event: K,
+    ...args: ProcessLifecycleEventMap[K]
+  ): void {
+    for (const listener of this.listeners.get(event) ?? []) {
+      listener(...args);
+    }
+  }
+
+  listenerCount(event: keyof ProcessLifecycleEventMap): number {
+    return this.listeners.get(event)?.length ?? 0;
+  }
+}
+
+async function flushMicrotasks(): Promise<void> {
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+describe("process lifecycle handlers", () => {
+  test("installs each process listener only once", () => {
+    const fakeProcess = new FakeProcess();
+    const lifecycle = new ProcessLifecycleHandlers(fakeProcess);
+
+    lifecycle.install();
+    lifecycle.install();
+
+    expect(fakeProcess.listenerCount("SIGINT")).toBe(1);
+    expect(fakeProcess.listenerCount("SIGTERM")).toBe(1);
+    expect(fakeProcess.listenerCount("uncaughtException")).toBe(1);
+    expect(fakeProcess.listenerCount("unhandledRejection")).toBe(1);
+  });
+
+  test("exits cleanly when a startup signal arrives before cleanup is bound", async () => {
+    const fakeProcess = new FakeProcess();
+    const lifecycle = new ProcessLifecycleHandlers(fakeProcess);
+
+    lifecycle.install();
+    fakeProcess.emit("SIGINT");
+    await flushMicrotasks();
+
+    expect(fakeProcess.exitCodes).toEqual([0]);
+  });
+
+  test("awaits the bound shutdown handler before exiting", async () => {
+    const fakeProcess = new FakeProcess();
+    const lifecycle = new ProcessLifecycleHandlers(fakeProcess);
+    const signals: string[] = [];
+    let finishShutdown!: () => void;
+
+    lifecycle.install();
+    lifecycle.setShutdownHandler(async signal => {
+      signals.push(signal);
+      await new Promise<void>(resolve => {
+        finishShutdown = resolve;
+      });
+    });
+
+    fakeProcess.emit("SIGTERM");
+    await flushMicrotasks();
+
+    expect(signals).toEqual(["SIGTERM"]);
+    expect(fakeProcess.exitCodes).toEqual([]);
+
+    finishShutdown();
+    await flushMicrotasks();
+
+    expect(fakeProcess.exitCodes).toEqual([0]);
+  });
+
+  test("ignores repeated signals while shutdown is already running", async () => {
+    const fakeProcess = new FakeProcess();
+    const lifecycle = new ProcessLifecycleHandlers(fakeProcess);
+    const signals: string[] = [];
+    let finishShutdown!: () => void;
+
+    lifecycle.install();
+    lifecycle.setShutdownHandler(async signal => {
+      signals.push(signal);
+      await new Promise<void>(resolve => {
+        finishShutdown = resolve;
+      });
+    });
+
+    fakeProcess.emit("SIGINT");
+    fakeProcess.emit("SIGTERM");
+    await flushMicrotasks();
+
+    expect(signals).toEqual(["SIGINT"]);
+
+    finishShutdown();
+    await flushMicrotasks();
+
+    expect(fakeProcess.exitCodes).toEqual([0]);
+  });
+
+  test("delegates fatal process events without forcing an exit", async () => {
+    const fakeProcess = new FakeProcess();
+    const lifecycle = new ProcessLifecycleHandlers(fakeProcess);
+    const events: string[] = [];
+    const promise = Promise.resolve();
+
+    lifecycle.install();
+    lifecycle.setFatalProcessHandler(event => {
+      events.push(event.type);
+    });
+
+    fakeProcess.emit("uncaughtException", new Error("boom"));
+    fakeProcess.emit("unhandledRejection", "bad", promise);
+    await flushMicrotasks();
+
+    expect(events).toEqual(["uncaughtException", "unhandledRejection"]);
+    expect(fakeProcess.exitCodes).toEqual([]);
+  });
+
+  test("exits with failure for fatal startup events before a handler is bound", async () => {
+    const fakeProcess = new FakeProcess();
+    const lifecycle = new ProcessLifecycleHandlers(fakeProcess);
+    const consoleError = spyOn(console, "error").mockImplementation(() => {});
+
+    try {
+      lifecycle.install();
+      fakeProcess.emit("uncaughtException", new Error("startup failed"));
+      await flushMicrotasks();
+
+      expect(fakeProcess.exitCodes).toEqual([1]);
+    } finally {
+      consoleError.mockRestore();
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- install process signal and fatal-error lifecycle handlers before the dynamic import startup window
- delegate early handlers to runtime cleanup once imports finish
- bind daemon cleanup at daemon startup and preserve PID ownership checks once the PID file exists
- add fast lifecycle unit tests for startup signals, fatal startup errors, duplicate signals, and delegated handlers

Closes #2532

## Testing
- `bun test test/processLifecycle.test.ts test/daemon/daemonFiles.test.ts`
- `bun run lint`
- `bun run build`
- `bun src/index.ts --version`
- `git diff --check`

## Notes
- `bun install` failed compiling optional/native `heapdump` against Node 26, but installed enough dependencies for validation to run.
- Full `bun test --bail` hit an unrelated existing `test/features/observe/CtrlProxyClient.test.ts` failure: expected `SdkHome`, received `null`, with logger rotation/write-after-end noise.
