### PR TITLE
[codex] fix live layout inactive frame replay

### DIFF
--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/AutoMobileContent.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/AutoMobileContent.kt
@@ -673,6 +673,7 @@ fun AutoMobileContent(
   LaunchedEffect(liveStreamClient, isLiveLayoutMode, activeDeviceId) {
     if (!isLiveLayoutMode || liveStreamClient == null) return@LaunchedEffect
     liveStreamClient.hierarchyUpdates.collect { update ->
+      if (!isActiveDeviceStreamFrame(update.deviceId, activeDeviceId)) return@collect
       update.data?.let { hierarchyJson ->
         val result =
             kotlinx.coroutines.withContext(kotlinx.coroutines.Dispatchers.Default) {
@@ -685,9 +686,7 @@ fun AutoMobileContent(
               parsed to changedIds
             }
         result?.let {
-          if (isActiveDeviceStreamFrame(update.deviceId, activeDeviceId)) {
-            layoutInspectorState.updateConnectionStatus(ConnectionStatus.Connected)
-          }
+          layoutInspectorState.updateConnectionStatus(ConnectionStatus.Connected)
           layoutInspectorState.applyHierarchyUpdate(it.first, it.second)
         }
       }
@@ -696,14 +695,13 @@ fun AutoMobileContent(
   LaunchedEffect(liveStreamClient, isLiveLayoutMode, activeDeviceId) {
     if (!isLiveLayoutMode || liveStreamClient == null) return@LaunchedEffect
     liveStreamClient.screenshotUpdates.collect { update ->
+      if (!isActiveDeviceStreamFrame(update.deviceId, activeDeviceId)) return@collect
       update.screenshotBase64?.let { base64 ->
         val screenshotData =
             kotlinx.coroutines.withContext(kotlinx.coroutines.Dispatchers.Default) {
               java.util.Base64.getDecoder().decode(base64)
             }
-        if (isActiveDeviceStreamFrame(update.deviceId, activeDeviceId)) {
-          layoutInspectorState.updateConnectionStatus(ConnectionStatus.Connected)
-        }
+        layoutInspectorState.updateConnectionStatus(ConnectionStatus.Connected)
         layoutInspectorState.updateScreenshot(
             data = screenshotData,
             width = update.screenWidth,


### PR DESCRIPTION
## Summary

- Drop inactive-device replayed hierarchy frames before parsing or applying them
- Drop inactive-device replayed screenshot frames before decoding or applying them
- Keep active-device frames restoring the live layout connection status

## Why

Follow-up to #2535 review feedback. The production live layout collectors were guarding `ConnectionStatus.Connected` restoration by active device, but still applied inactive replayed frames from the previous `ObservationStreamClient` while the active device was changing. This prevents the live view from briefly showing the prior device until the new device emits a frame.

## Validation

- `./gradlew :desktop-core:test --tests dev.jasonpearson.automobile.desktop.core.AutoMobileContentDeviceEventTest --tests dev.jasonpearson.automobile.desktop.core.daemon.ObservationStreamClientTest`
- `./gradlew :desktop-core:test`
- `git diff --check`
