### PR TITLE
fix(ios): avoid CtrlProxy port collision

### DIFF
--- a/ios/control-proxy/Sources/CtrlProxy/WebSocketServer.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/WebSocketServer.swift
@@ -413,10 +413,24 @@ class WebSocketConnection {
     }
 
     private func handleHealthCheck() {
-        let response = "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: 15\r\n\r\n{\"status\":\"ok\"}"
-        connection.send(content: response.data(using: .utf8), completion: .contentProcessed { [weak self] _ in
+        var payload: [String: String] = ["status": "ok"]
+        if let deviceId = Self.currentDeviceId() {
+            payload["deviceId"] = deviceId
+        }
+
+        let body = (try? JSONSerialization.data(withJSONObject: payload, options: [.sortedKeys]))
+            ?? Data(#"{"status":"ok"}"#.utf8)
+        let header = "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: \(body.count)\r\n\r\n"
+        var response = Data(header.utf8)
+        response.append(body)
+        connection.send(content: response, completion: .contentProcessed { [weak self] _ in
             self?.connection.cancel()
         })
+    }
+
+    private static func currentDeviceId() -> String? {
+        let environment = ProcessInfo.processInfo.environment
+        return environment["AUTOMOBILE_DEVICE_ID"] ?? environment["SIMULATOR_UDID"]
     }
 
     private func handleSdkEventsPost(_ request: String) {

--- a/scripts/ios/ctrl-proxy-run.sh
+++ b/scripts/ios/ctrl-proxy-run.sh
@@ -86,5 +86,6 @@ echo ""
 # simctl spawn requires SIMCTL_CHILD_ prefixed env vars (--setenv is not supported)
 SIMCTL_CHILD_CTRL_PROXY_IOS_PORT="${PORT}" \
 SIMCTL_CHILD_CTRL_PROXY_IOS_TIMEOUT="${TIMEOUT}" \
+SIMCTL_CHILD_AUTOMOBILE_DEVICE_ID="${SIMULATOR_ID}" \
 xcrun simctl spawn "${SIMULATOR_ID}" \
     "${RUNNER_BINARY}"

--- a/scripts/local-dev/lib/ctrl-proxy-ios.sh
+++ b/scripts/local-dev/lib/ctrl-proxy-ios.sh
@@ -193,6 +193,7 @@ start_ctrl_proxy_ios() {
       -destination "id=${simulator_id}"
       -only-testing:CtrlProxyUITests/CtrlProxyUITests/testRunService
       "CTRL_PROXY_IOS_PORT=${port}"
+      "AUTOMOBILE_DEVICE_ID=${simulator_id}"
     )
   else
     log_info "Starting CtrlProxy iOS (xcodebuild test)..."
@@ -203,6 +204,7 @@ start_ctrl_proxy_ios() {
       -destination "id=${simulator_id}"
       -only-testing:CtrlProxyUITests/CtrlProxyUITests/testRunService
       "CTRL_PROXY_IOS_PORT=${port}"
+      "AUTOMOBILE_DEVICE_ID=${simulator_id}"
     )
   fi
 

--- a/src/features/observe/ios/IOSCtrlProxyClient.ts
+++ b/src/features/observe/ios/IOSCtrlProxyClient.ts
@@ -25,7 +25,7 @@ import {
 import { ViewHierarchyQueryOptions } from "../../../models/ViewHierarchyQueryOptions";
 import { PerformanceTracker, NoOpPerformanceTracker } from "../../../utils/PerformanceTracker";
 import { Timer, defaultTimer } from "../../../utils/SystemTimer";
-import { PortManager } from "../../../utils/PortManager";
+import { IOS_CTRL_PROXY_RESERVED_PORTS, PortManager } from "../../../utils/PortManager";
 import { requireBootedDevice } from "../../../utils/requireBootedDevice";
 import { shouldUseHostControl, getHostControlHost } from "../../../utils/hostControlClient";
 import { isRunningInDocker } from "../../../utils/dockerEnv";
@@ -299,7 +299,7 @@ export class IOSCtrlProxyClient extends DeviceServiceClient implements IOSCtrlPr
 
   // Platform-specific dependencies
   private readonly device: BootedDevice;
-  private readonly port: number;
+  private port: number;
 
   // Delegate instances (lazy initialized)
   private _gestures: CtrlProxyGestures | null = null;
@@ -353,13 +353,20 @@ export class IOSCtrlProxyClient extends DeviceServiceClient implements IOSCtrlPr
   ): IOSCtrlProxyClient {
     requireBootedDevice(device, "IOSCtrlProxyClient.getInstance");
     const resolvedPort = port ?? (
-      device.platform === "ios" ? PortManager.allocate(device.deviceId) : IOSCtrlProxyClient.DEFAULT_PORT
+      device.platform === "ios"
+        ? PortManager.allocate(device.deviceId, { reservedPorts: IOS_CTRL_PROXY_RESERVED_PORTS })
+        : IOSCtrlProxyClient.DEFAULT_PORT
     );
-    const key = `${device.deviceId}:${resolvedPort}`;
-    if (!IOSCtrlProxyClient.instances.has(key)) {
-      IOSCtrlProxyClient.instances.set(key, new IOSCtrlProxyClient(device, resolvedPort));
+    const key = device.deviceId;
+    const existing = IOSCtrlProxyClient.instances.get(key);
+    if (existing) {
+      existing.updatePort(resolvedPort);
+      return existing;
     }
-    return IOSCtrlProxyClient.instances.get(key)!;
+
+    const client = new IOSCtrlProxyClient(device, resolvedPort);
+    IOSCtrlProxyClient.instances.set(key, client);
+    return client;
   }
 
   /**
@@ -443,6 +450,7 @@ export class IOSCtrlProxyClient extends DeviceServiceClient implements IOSCtrlPr
       const alreadyRunning = await manager.isRunning();
       if (alreadyRunning) {
         logger.info(`[IOSCtrlProxyClient] Service is running but WebSocket failed — transient issue, retrying connection`);
+        this.syncPortFromManager(manager);
         this.connectionAttempts = 0;
         return await super.ensureConnected(perf);
       }
@@ -470,6 +478,8 @@ export class IOSCtrlProxyClient extends DeviceServiceClient implements IOSCtrlPr
         return false;
       }
 
+      this.syncPortFromManager(manager);
+
       logger.info(`[IOSCtrlProxyClient] Auto-setup succeeded, retrying WebSocket connection`);
       // Reset connection attempts to allow fresh connection attempts
       this.connectionAttempts = 0;
@@ -479,6 +489,26 @@ export class IOSCtrlProxyClient extends DeviceServiceClient implements IOSCtrlPr
       return false;
     } finally {
       this.isAttemptingAutoSetup = false;
+    }
+  }
+
+  private syncPortFromManager(manager: CtrlProxyIosManager): void {
+    this.updatePort(manager.getServicePort());
+  }
+
+  private updatePort(port: number): void {
+    if (port !== this.port) {
+      logger.info(`[IOSCtrlProxyClient] CtrlProxy service port changed from ${this.port} to ${port}`);
+      this.port = port;
+      if (this.ws) {
+        logger.info("[IOSCtrlProxyClient] Closing stale WebSocket after CtrlProxy service port change");
+        const staleSocket = this.ws;
+        this.ws = null;
+        this.stopHealthCheck();
+        this.requestManager.cancelAll(new Error("CtrlProxy service port changed"));
+        staleSocket.removeAllListeners();
+        staleSocket.close();
+      }
     }
   }
 

--- a/src/utils/IOSCtrlProxyManager.ts
+++ b/src/utils/IOSCtrlProxyManager.ts
@@ -560,12 +560,15 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
       if (this.isSimulator()) {
         perf.startOperation("externalProcessCheck");
         const externalProcess = await this.findExternalCtrlProxyProcess();
-        const defaultPortIsHealthy = externalProcess === null &&
+        const defaultPortIsHealthyForDevice = externalProcess === null &&
           !this.useHostControl() &&
           this.servicePort !== IOSCtrlProxyManager.DEFAULT_PORT &&
-          await this.checkHealthEndpointOnPort(IOSCtrlProxyManager.DEFAULT_PORT);
+          await this.checkHealthEndpointOnPortForDevice(
+            IOSCtrlProxyManager.DEFAULT_PORT,
+            this.device.deviceId
+          );
         perf.endOperation("externalProcessCheck");
-        if (externalProcess || defaultPortIsHealthy) {
+        if (externalProcess || defaultPortIsHealthyForDevice) {
           const externalPort = externalProcess?.port ?? IOSCtrlProxyManager.DEFAULT_PORT;
           logger.info(
             `[IOSCtrlProxy] External CtrlProxy process detected on port ${externalPort}, skipping spawn`
@@ -644,7 +647,7 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
       }
 
       if (!this.isSimulator()) {
-        await this.stopIproxyTunnel();
+        await this.stopIproxyTunnel({ clearDevicePort: true });
       }
 
       this.xcTestProcessId = null;
@@ -661,7 +664,7 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
     this.stopProcessMonitoring();
 
     // Stop iproxy tunnel if running
-    await this.stopIproxyTunnel();
+    await this.stopIproxyTunnel({ clearDevicePort: true });
 
     if (this.xcTestProcessId) {
       try {
@@ -955,8 +958,10 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
     const childEnv: Record<string, string> = {
       CTRL_PROXY_IOS_PORT: String(this.servicePort),
       CTRL_PROXY_IOS_TIMEOUT: timeout,
+      AUTOMOBILE_DEVICE_ID: this.device.deviceId,
       SIMCTL_CHILD_CTRL_PROXY_IOS_PORT: String(this.servicePort),
       SIMCTL_CHILD_CTRL_PROXY_IOS_TIMEOUT: timeout,
+      SIMCTL_CHILD_AUTOMOBILE_DEVICE_ID: this.device.deviceId,
     };
     if (bundleId) {
       childEnv.CTRL_PROXY_IOS_BUNDLE_ID = bundleId;
@@ -1250,6 +1255,9 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
             `ps -p ${pid} -o args= 2>/dev/null`
           );
           if (argsOut.includes("CtrlProxy")) {
+            if (!argsOut.includes(`id=${this.device.deviceId}`)) {
+              continue;
+            }
             const port = this.parseCtrlProxyPortFromProcessArgs(argsOut) ?? IOSCtrlProxyManager.DEFAULT_PORT;
             logger.info(`[IOSCtrlProxy] Found external xcodebuild CtrlProxy process: ${pid}`);
             return { pid, port };
@@ -1456,6 +1464,25 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
   }
 
   private async checkHealthEndpointOnPort(port: number): Promise<boolean> {
+    const body = await this.readHealthEndpointBodyOnPort(port);
+    return body !== null && (body.includes("ok") || body.includes("healthy"));
+  }
+
+  private async checkHealthEndpointOnPortForDevice(port: number, deviceId: string): Promise<boolean> {
+    const body = await this.readHealthEndpointBodyOnPort(port);
+    if (body === null) {
+      return false;
+    }
+
+    try {
+      const health = JSON.parse(body) as { status?: unknown; deviceId?: unknown };
+      return health.status === "ok" && health.deviceId === deviceId;
+    } catch {
+      return false;
+    }
+  }
+
+  private async readHealthEndpointBodyOnPort(port: number): Promise<string | null> {
     try {
       const host = this.useHostControl() ? this.hostControl.getHost() : "localhost";
       if (this.useHostControl()) {
@@ -1465,8 +1492,7 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
           const response = await fetch(`http://${host}:${port}/health`, {
             signal: controller.signal
           });
-          const body = await response.text();
-          return body.includes("ok") || body.includes("healthy");
+          return await response.text();
         } finally {
           this.timer.clearTimeout(timeoutId);
         }
@@ -1476,9 +1502,9 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
       const { stdout } = await this.processExecutor.exec(
         `curl -s --max-time 2 http://${host}:${port}/health`
       );
-      return stdout.includes("ok") || stdout.includes("healthy");
+      return stdout;
     } catch {
-      return false;
+      return null;
     }
   }
 
@@ -1577,7 +1603,7 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
     await this.waitForIproxyStartup();
   }
 
-  private async stopIproxyTunnel(): Promise<void> {
+  private async stopIproxyTunnel(options: { clearDevicePort?: boolean } = {}): Promise<void> {
     this.stopIproxyMonitoring();
 
     if (this.iproxyRestartTimeout) {
@@ -1608,7 +1634,9 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
 
     this.iproxyProcessId = null;
     this.iproxyProcess = null;
-    this.iproxyDevicePort = null;
+    if (options.clearDevicePort) {
+      this.iproxyDevicePort = null;
+    }
     this.iproxyRestartAttempts = 0;
   }
 

--- a/src/utils/IOSCtrlProxyManager.ts
+++ b/src/utils/IOSCtrlProxyManager.ts
@@ -82,13 +82,13 @@ interface HostControlCtrlProxyIOSRunner {
     xctestrunPath?: string;
     bundleId?: string;
     timeoutSeconds?: number;
-  }): Promise<{ success: boolean; error?: string; data?: { pid: number; message: string } }>;
+  }): Promise<{ success: boolean; error?: string; data?: { pid: number; message: string; port?: number } }>;
   stop(params: { deviceId?: string; pid?: number }): Promise<{ success: boolean; error?: string }>;
   status(params: {
     deviceId?: string;
     pid?: number;
     port?: number;
-  }): Promise<{ success: boolean; error?: string; data?: { running: boolean; pid?: number } }>;
+  }): Promise<{ success: boolean; error?: string; data?: { running: boolean; pid?: number; port?: number } }>;
 }
 
 export interface HostPortAvailabilityChecker {
@@ -155,7 +155,6 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
   private readonly hostControl: HostControlCtrlProxyIOSRunner;
   private readonly hostPortAvailabilityChecker: HostPortAvailabilityChecker;
   private hostControlAvailability: Promise<boolean> | null = null;
-  private readonly hostControlUnavailablePorts: Set<number> = new Set();
 
   // Singleton instances per device
   private static instances: Map<string, IOSCtrlProxyManager> = new Map();
@@ -833,21 +832,23 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
   private async ensureHostControlServicePortAvailable(options: { allowReallocation?: boolean } = {}): Promise<void> {
     const allowReallocation = options.allowReallocation ?? true;
     const host = this.hostControl.getHost();
+    const unavailablePorts = new Set<number>();
 
     for (let attempt = 0; attempt < PortManager.getMaxDevices(); attempt++) {
       if (await this.hostPortAvailabilityChecker.isAvailable(host, this.servicePort)) {
         return;
       }
 
+      const unavailablePort = this.servicePort;
       logger.warn(
-        `[IOSCtrlProxy] Host control port ${this.servicePort} is already in use on ${host}; reallocating`
+        `[IOSCtrlProxy] Host control port ${unavailablePort} is already in use on ${host}; reallocating`
       );
-      this.hostControlUnavailablePorts.add(this.servicePort);
       if (!allowReallocation) {
-        throw new HostControlServicePortUnavailableError(host, this.servicePort);
+        throw new HostControlServicePortUnavailableError(host, unavailablePort);
       }
+      unavailablePorts.add(unavailablePort);
       PortManager.release(this.device.deviceId);
-      this.servicePort = this.allocateServicePort(this.hostControlUnavailablePorts);
+      this.servicePort = this.allocateServicePort(unavailablePorts);
     }
 
     throw new Error(
@@ -876,6 +877,19 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
         throw new Error("Host control daemon not available for CtrlProxy startup");
       }
 
+      const existingProcess = await this.hostControl.status({ deviceId: this.device.deviceId });
+      const existingServicePort = existingProcess.data?.port;
+      if (existingProcess.success && existingProcess.data?.running && typeof existingServicePort === "number") {
+        logger.info(
+          `[IOSCtrlProxy] Reusing host-control CtrlProxy process on service port ${existingServicePort}`
+        );
+        PortManager.reserve(this.device.deviceId, existingServicePort);
+        this.servicePort = existingServicePort;
+        this.xcTestProcessId = existingProcess.data.pid ?? null;
+        this.xcTestProcess = null;
+        return;
+      }
+
       await this.ensureHostControlServicePortAvailable();
 
       const xctestrunPath = await this.builder.getXctestrunPath("simulator");
@@ -891,6 +905,10 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
         throw new Error(result.error || "Host control failed to start CtrlProxy");
       }
 
+      if (typeof result.data.port === "number") {
+        PortManager.reserve(this.device.deviceId, result.data.port);
+        this.servicePort = result.data.port;
+      }
       this.xcTestProcessId = result.data.pid;
       this.xcTestProcess = null;
       return;
@@ -1250,6 +1268,18 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
         throw new Error("Host control daemon not available for CtrlProxy startup");
       }
 
+      const existingProcess = await this.hostControl.status({ deviceId: this.device.deviceId });
+      const existingDevicePort = existingProcess.data?.port;
+      if (existingProcess.success && existingProcess.data?.running && typeof existingDevicePort === "number") {
+        logger.info(
+          `[IOSCtrlProxy] Reusing host-control CtrlProxy process on device port ${existingDevicePort}`
+        );
+        this.xcTestProcessId = existingProcess.data.pid ?? null;
+        this.xcTestProcess = null;
+        await this.startIproxyTunnel({ devicePort: existingDevicePort });
+        return;
+      }
+
       const xctestrunPath = await this.builder.getXctestrunPath("device");
       await this.startIproxyTunnel();
       await this.verifyInstalledAppBundle();
@@ -1266,6 +1296,14 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
         throw new Error(result.error || "Host control failed to start CtrlProxy");
       }
 
+      const resultDevicePort = result.data.port;
+      if (typeof resultDevicePort === "number" && resultDevicePort !== this.servicePort) {
+        logger.info(
+          `[IOSCtrlProxy] Host-control CtrlProxy process is listening on device port ${resultDevicePort}; restarting tunnel`
+        );
+        await this.stopIproxyTunnel();
+        await this.startIproxyTunnel({ devicePort: resultDevicePort });
+      }
       this.xcTestProcessId = result.data.pid;
       this.xcTestProcess = null;
       return;
@@ -1419,7 +1457,10 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
     return parsed;
   }
 
-  private async startIproxyTunnel(options: { allowServicePortReallocation?: boolean } = {}): Promise<void> {
+  private async startIproxyTunnel(options: {
+    allowServicePortReallocation?: boolean;
+    devicePort?: number;
+  } = {}): Promise<void> {
     if (this.isSimulator()) {
       return;
     }
@@ -1440,7 +1481,7 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
       const result = await this.hostControl.startIproxy({
         deviceId: this.device.deviceId,
         localPort: this.servicePort,
-        devicePort: this.servicePort
+        devicePort: options.devicePort ?? this.servicePort
       });
       if (!result.success || !result.data) {
         throw new Error(result.error || "Failed to start iproxy tunnel via host control");

--- a/src/utils/IOSCtrlProxyManager.ts
+++ b/src/utils/IOSCtrlProxyManager.ts
@@ -5,12 +5,13 @@ import { NoOpPerformanceTracker, createGlobalPerformanceTracker, type Performanc
 import { Timer, defaultTimer } from "./SystemTimer";
 import { IOSCtrlProxyBuilder, type CtrlProxyIosBuildResult } from "./IOSCtrlProxyBuilder";
 import { type ChildProcess } from "child_process";
-import { PortManager } from "./PortManager";
+import { IOS_CTRL_PROXY_RESERVED_PORTS, PortManager } from "./PortManager";
 import { DefaultProcessExecutor, type ProcessExecutor } from "./ProcessExecutor";
 import { XcodeSigningManager } from "./ios-cmdline-tools/XcodeSigning";
 import { DeviceAppInspector } from "./ios-cmdline-tools/DeviceAppInspector";
 import { isIosSimulatorUdid } from "./ios-cmdline-tools/iosDeviceType";
 import { isRunningInDocker } from "./dockerEnv";
+import { createConnection } from "node:net";
 import {
   getHostControlHost,
   getCtrlProxyIOSStatus,
@@ -90,6 +91,45 @@ interface HostControlCtrlProxyIOSRunner {
   }): Promise<{ success: boolean; error?: string; data?: { running: boolean; pid?: number } }>;
 }
 
+export interface HostPortAvailabilityChecker {
+  isAvailable(host: string, port: number): Promise<boolean>;
+}
+
+class TcpHostPortAvailabilityChecker implements HostPortAvailabilityChecker {
+  private static readonly CONNECT_TIMEOUT_MS = 1000;
+
+  public isAvailable(host: string, port: number): Promise<boolean> {
+    return new Promise(resolve => {
+      const socket = createConnection({ host, port });
+      let settled = false;
+
+      const finish = (available: boolean) => {
+        if (settled) {
+          return;
+        }
+        settled = true;
+        socket.destroy();
+        resolve(available);
+      };
+
+      socket.setTimeout(TcpHostPortAvailabilityChecker.CONNECT_TIMEOUT_MS);
+      socket.once("connect", () => finish(false));
+      socket.once("timeout", () => finish(false));
+      socket.once("error", error => {
+        const code = (error as NodeJS.ErrnoException).code;
+        finish(code === "ECONNREFUSED");
+      });
+    });
+  }
+}
+
+class HostControlServicePortUnavailableError extends Error {
+  constructor(host: string, port: number) {
+    super(`Host control port ${port} is already in use on ${host}`);
+    this.name = "HostControlServicePortUnavailableError";
+  }
+}
+
 /**
  * Capabilities of the iOS device for CtrlProxy
  */
@@ -113,7 +153,9 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
   private readonly signingManager: XcodeSigningManager;
   private readonly appInspector: DeviceAppInspector;
   private readonly hostControl: HostControlCtrlProxyIOSRunner;
+  private readonly hostPortAvailabilityChecker: HostPortAvailabilityChecker;
   private hostControlAvailability: Promise<boolean> | null = null;
+  private readonly hostControlUnavailablePorts: Set<number> = new Set();
 
   // Singleton instances per device
   private static instances: Map<string, IOSCtrlProxyManager> = new Map();
@@ -189,15 +231,17 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
     processExecutor: ProcessExecutor = new DefaultProcessExecutor(),
     signingManager: XcodeSigningManager = new XcodeSigningManager(),
     appInspector: DeviceAppInspector = new DeviceAppInspector(),
-    hostControlRunner?: HostControlCtrlProxyIOSRunner
+    hostControlRunner?: HostControlCtrlProxyIOSRunner,
+    hostPortAvailabilityChecker: HostPortAvailabilityChecker = new TcpHostPortAvailabilityChecker()
   ) {
     this.device = device;
     this.timer = timer;
-    this.servicePort = PortManager.allocate(device.deviceId);
+    this.servicePort = this.allocateServicePort();
     this.builder = builder || IOSCtrlProxyBuilder.getInstance();
     this.processExecutor = processExecutor;
     this.signingManager = signingManager;
     this.appInspector = appInspector;
+    this.hostPortAvailabilityChecker = hostPortAvailabilityChecker;
     this.hostControl = hostControlRunner || {
       shouldUseHostControl,
       isRunningInDocker,
@@ -246,7 +290,8 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
     processExecutor: ProcessExecutor,
     signingManager?: XcodeSigningManager,
     appInspector?: DeviceAppInspector,
-    hostControlRunner?: HostControlCtrlProxyIOSRunner
+    hostControlRunner?: HostControlCtrlProxyIOSRunner,
+    hostPortAvailabilityChecker?: HostPortAvailabilityChecker
   ): IOSCtrlProxyManager {
     return new IOSCtrlProxyManager(
       device,
@@ -255,7 +300,8 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
       processExecutor,
       signingManager,
       appInspector,
-      hostControlRunner
+      hostControlRunner,
+      hostPortAvailabilityChecker
     );
   }
 
@@ -461,6 +507,7 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
     perf.startOperation("processAliveCheck");
     const isAlive = await this.isCtrlProxyProcessAlive();
     perf.endOperation("processAliveCheck");
+    let restartedAliveProcess = false;
     if (isAlive) {
       logger.info("[IOSCtrlProxy] CtrlProxy process is alive, skipping start");
       // On physical devices the iproxy tunnel may have been stopped independently
@@ -469,39 +516,59 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
       // self-heals the connection when it is not.
       if (!this.isSimulator()) {
         perf.startOperation("iproxyTunnel");
-        await this.startIproxyTunnel();
-        perf.endOperation("iproxyTunnel");
-        this.startIproxyMonitoring();
+        try {
+          await this.startIproxyTunnel({ allowServicePortReallocation: false });
+        } catch (error) {
+          perf.endOperation("iproxyTunnel");
+          if (!(error instanceof HostControlServicePortUnavailableError)) {
+            throw error;
+          }
+          logger.warn(
+            "[IOSCtrlProxy] Existing CtrlProxy process uses a host port that is no longer available; restarting"
+          );
+          perf.startOperation("spawnRunner");
+          await this.restartDeviceProcessAfterHostPortCollision();
+          perf.endOperation("spawnRunner");
+          restartedAliveProcess = true;
+        }
+        if (!restartedAliveProcess) {
+          perf.endOperation("iproxyTunnel");
+          this.startIproxyMonitoring();
+        }
       }
-      return;
+      if (!restartedAliveProcess) {
+        return;
+      }
     }
 
-    perf.startOperation("runningCheck");
-    const alreadyRunning = await this.isRunning();
-    perf.endOperation("runningCheck");
-    if (alreadyRunning) {
-      logger.info("[IOSCtrlProxy] Service is already running");
-      return;
-    }
+    if (!restartedAliveProcess) {
+      perf.startOperation("runningCheck");
+      const alreadyRunning = await this.isRunning();
+      perf.endOperation("runningCheck");
+      if (alreadyRunning) {
+        logger.info("[IOSCtrlProxy] Service is already running");
+        return;
+      }
 
-    // Check for externally-managed xcodebuild processes (e.g. hot-reload script)
-    // before spawning our own to avoid conflicting xcodebuild instances.
-    if (this.isSimulator()) {
-      perf.startOperation("externalProcessCheck");
-      const hasExternal = await this.isExternalCtrlProxyProcessRunning();
-      perf.endOperation("externalProcessCheck");
-      if (hasExternal) {
-        logger.info("[IOSCtrlProxy] External xcodebuild CtrlProxy process detected, skipping spawn — will wait for health endpoint");
-        // Fall through to health polling below instead of spawning
+      // Check for externally-managed xcodebuild processes (e.g. hot-reload script)
+      // before spawning our own to avoid conflicting xcodebuild instances.
+      if (this.isSimulator()) {
+        perf.startOperation("externalProcessCheck");
+        const hasExternal = await this.isExternalCtrlProxyProcessRunning();
+        perf.endOperation("externalProcessCheck");
+        if (hasExternal) {
+          logger.info("[IOSCtrlProxy] External xcodebuild CtrlProxy process detected, skipping spawn — will wait for health endpoint");
+          // Fall through to health polling below instead of spawning
+        } else {
+          perf.startOperation("spawnRunner");
+          await this.startOnSimulator();
+          perf.endOperation("spawnRunner");
+        }
       } else {
         perf.startOperation("spawnRunner");
-        await this.startOnSimulator();
+        await this.startOnDevice();
         perf.endOperation("spawnRunner");
       }
-    } else {
-      perf.startOperation("spawnRunner");
-      await this.startOnDevice();
-      perf.endOperation("spawnRunner");
     }
 
     // Wait for HTTP health endpoint to be ready
@@ -754,11 +821,51 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
     return this.hostControl.shouldUseHostControl() && this.hostControl.isRunningInDocker();
   }
 
+  private allocateServicePort(additionalReservedPorts: Iterable<number> = []): number {
+    return PortManager.allocate(this.device.deviceId, {
+      reservedPorts: [
+        ...IOS_CTRL_PROXY_RESERVED_PORTS,
+        ...additionalReservedPorts,
+      ],
+    });
+  }
+
+  private async ensureHostControlServicePortAvailable(options: { allowReallocation?: boolean } = {}): Promise<void> {
+    const allowReallocation = options.allowReallocation ?? true;
+    const host = this.hostControl.getHost();
+
+    for (let attempt = 0; attempt < PortManager.getMaxDevices(); attempt++) {
+      if (await this.hostPortAvailabilityChecker.isAvailable(host, this.servicePort)) {
+        return;
+      }
+
+      logger.warn(
+        `[IOSCtrlProxy] Host control port ${this.servicePort} is already in use on ${host}; reallocating`
+      );
+      this.hostControlUnavailablePorts.add(this.servicePort);
+      if (!allowReallocation) {
+        throw new HostControlServicePortUnavailableError(host, this.servicePort);
+      }
+      PortManager.release(this.device.deviceId);
+      this.servicePort = this.allocateServicePort(this.hostControlUnavailablePorts);
+    }
+
+    throw new Error(
+      `No host-control iOS CtrlProxy ports are available for device ${this.device.deviceId}.`
+    );
+  }
+
   private async isHostControlAvailable(): Promise<boolean> {
     if (!this.hostControlAvailability) {
       this.hostControlAvailability = this.hostControl.isAvailable();
     }
     return this.hostControlAvailability;
+  }
+
+  private async restartDeviceProcessAfterHostPortCollision(): Promise<void> {
+    await this.stop();
+    this.isStopping = false;
+    await this.startOnDevice();
   }
 
   private async startOnSimulator(): Promise<void> {
@@ -768,6 +875,8 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
       if (!await this.isHostControlAvailable()) {
         throw new Error("Host control daemon not available for CtrlProxy startup");
       }
+
+      await this.ensureHostControlServicePortAvailable();
 
       const xctestrunPath = await this.builder.getXctestrunPath("simulator");
       const bundleId = this.resolveTargetBundleId();
@@ -1310,7 +1419,7 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
     return parsed;
   }
 
-  private async startIproxyTunnel(): Promise<void> {
+  private async startIproxyTunnel(options: { allowServicePortReallocation?: boolean } = {}): Promise<void> {
     if (this.isSimulator()) {
       return;
     }
@@ -1324,6 +1433,9 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
       }
 
       await this.stopIproxyTunnel();
+      await this.ensureHostControlServicePortAvailable({
+        allowReallocation: options.allowServicePortReallocation ?? true,
+      });
 
       const result = await this.hostControl.startIproxy({
         deviceId: this.device.deviceId,
@@ -1450,9 +1562,20 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
 
     this.iproxyRestartTimeout = this.timer.setTimeout(() => {
       this.iproxyRestartTimeout = null;
-      void this.startIproxyTunnel().then(() => {
+      void this.startIproxyTunnel({ allowServicePortReallocation: false }).then(() => {
         this.startIproxyMonitoring();
       }).catch(error => {
+        if (error instanceof HostControlServicePortUnavailableError) {
+          logger.warn(
+            "[IOSCtrlProxy] Existing CtrlProxy process uses a host port that is no longer available during iproxy restart; restarting"
+          );
+          void this.restartDeviceProcessAfterHostPortCollision().then(() => {
+            this.startIproxyMonitoring();
+          }).catch(restartError => {
+            logger.warn(`[IOSCtrlProxy] Failed to restart CtrlProxy after iproxy port collision: ${restartError instanceof Error ? restartError.message : String(restartError)}`);
+          });
+          return;
+        }
         logger.warn(`[IOSCtrlProxy] Failed to restart iproxy: ${error instanceof Error ? error.message : String(error)}`);
       });
     }, delay);

--- a/src/utils/IOSCtrlProxyManager.ts
+++ b/src/utils/IOSCtrlProxyManager.ts
@@ -207,6 +207,7 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
   // iproxy tunnel state (physical devices)
   private iproxyProcessId: number | null = null;
   private iproxyProcess: ChildProcess | null = null;
+  private iproxyDevicePort: number | null = null;
   private iproxyMonitorInterval: ReturnType<typeof setInterval> | null = null;
   private iproxyRestartTimeout: ReturnType<Timer["setTimeout"]> | null = null;
   private iproxyRestartAttempts: number = 0;
@@ -1511,15 +1512,17 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
         }
       }
 
+      const fixedDevicePort = options.devicePort ?? this.iproxyDevicePort;
       await this.stopIproxyTunnel();
       await this.ensureHostControlServicePortAvailable({
         allowReallocation: options.allowServicePortReallocation ?? true,
       });
+      const devicePort = fixedDevicePort ?? this.servicePort;
 
       const result = await this.hostControl.startIproxy({
         deviceId: this.device.deviceId,
         localPort: this.servicePort,
-        devicePort: options.devicePort ?? this.servicePort
+        devicePort
       });
       if (!result.success || !result.data) {
         throw new Error(result.error || "Failed to start iproxy tunnel via host control");
@@ -1527,6 +1530,7 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
 
       this.iproxyProcessId = result.data.pid;
       this.iproxyProcess = null;
+      this.iproxyDevicePort = devicePort;
       await this.waitForIproxyStartup();
       return;
     }
@@ -1604,6 +1608,7 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
 
     this.iproxyProcessId = null;
     this.iproxyProcess = null;
+    this.iproxyDevicePort = null;
     this.iproxyRestartAttempts = 0;
   }
 
@@ -1641,7 +1646,10 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
 
     this.iproxyRestartTimeout = this.timer.setTimeout(() => {
       this.iproxyRestartTimeout = null;
-      void this.startIproxyTunnel({ allowServicePortReallocation: false }).then(() => {
+      void this.startIproxyTunnel({
+        allowServicePortReallocation: false,
+        devicePort: this.iproxyDevicePort ?? undefined,
+      }).then(() => {
         this.startIproxyMonitoring();
       }).catch(error => {
         if (error instanceof HostControlServicePortUnavailableError) {

--- a/src/utils/IOSCtrlProxyManager.ts
+++ b/src/utils/IOSCtrlProxyManager.ts
@@ -559,13 +559,18 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
       if (this.isSimulator()) {
         perf.startOperation("externalProcessCheck");
         const externalProcess = await this.findExternalCtrlProxyProcess();
+        const defaultPortIsHealthy = externalProcess === null &&
+          !this.useHostControl() &&
+          this.servicePort !== IOSCtrlProxyManager.DEFAULT_PORT &&
+          await this.checkHealthEndpointOnPort(IOSCtrlProxyManager.DEFAULT_PORT);
         perf.endOperation("externalProcessCheck");
-        if (externalProcess) {
+        if (externalProcess || defaultPortIsHealthy) {
+          const externalPort = externalProcess?.port ?? IOSCtrlProxyManager.DEFAULT_PORT;
           logger.info(
-            `[IOSCtrlProxy] External xcodebuild CtrlProxy process detected on port ${externalProcess.port}, skipping spawn`
+            `[IOSCtrlProxy] External CtrlProxy process detected on port ${externalPort}, skipping spawn`
           );
-          if (externalProcess.port !== this.servicePort) {
-            this.adoptServicePort(externalProcess.port);
+          if (externalPort !== this.servicePort) {
+            this.adoptServicePort(externalPort);
           }
           // Fall through to health polling below instead of spawning
         } else {
@@ -1446,13 +1451,17 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
   }
 
   private async checkHealthEndpoint(): Promise<boolean> {
+    return this.checkHealthEndpointOnPort(this.servicePort);
+  }
+
+  private async checkHealthEndpointOnPort(port: number): Promise<boolean> {
     try {
       const host = this.useHostControl() ? this.hostControl.getHost() : "localhost";
       if (this.useHostControl()) {
         const controller = new AbortController();
         const timeoutId = this.timer.setTimeout(() => controller.abort(), 2000);
         try {
-          const response = await fetch(`http://${host}:${this.servicePort}/health`, {
+          const response = await fetch(`http://${host}:${port}/health`, {
             signal: controller.signal
           });
           const body = await response.text();
@@ -1464,7 +1473,7 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
 
       // Use curl to check the health endpoint locally
       const { stdout } = await this.processExecutor.exec(
-        `curl -s --max-time 2 http://${host}:${this.servicePort}/health`
+        `curl -s --max-time 2 http://${host}:${port}/health`
       );
       return stdout.includes("ok") || stdout.includes("healthy");
     } catch {

--- a/src/utils/IOSCtrlProxyManager.ts
+++ b/src/utils/IOSCtrlProxyManager.ts
@@ -91,6 +91,11 @@ interface HostControlCtrlProxyIOSRunner {
   }): Promise<{ success: boolean; error?: string; data?: { running: boolean; pid?: number; port?: number } }>;
 }
 
+interface ExternalCtrlProxyProcess {
+  pid: number;
+  port: number;
+}
+
 export interface HostPortAvailabilityChecker {
   isAvailable(host: string, port: number): Promise<boolean>;
 }
@@ -553,10 +558,15 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
       // before spawning our own to avoid conflicting xcodebuild instances.
       if (this.isSimulator()) {
         perf.startOperation("externalProcessCheck");
-        const hasExternal = await this.isExternalCtrlProxyProcessRunning();
+        const externalProcess = await this.findExternalCtrlProxyProcess();
         perf.endOperation("externalProcessCheck");
-        if (hasExternal) {
-          logger.info("[IOSCtrlProxy] External xcodebuild CtrlProxy process detected, skipping spawn — will wait for health endpoint");
+        if (externalProcess) {
+          logger.info(
+            `[IOSCtrlProxy] External xcodebuild CtrlProxy process detected on port ${externalProcess.port}, skipping spawn`
+          );
+          if (externalProcess.port !== this.servicePort) {
+            this.adoptServicePort(externalProcess.port);
+          }
           // Fall through to health polling below instead of spawning
         } else {
           perf.startOperation("spawnRunner");
@@ -829,6 +839,16 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
     });
   }
 
+  private adoptServicePort(port: number): void {
+    if (PortManager.getPort(this.device.deviceId) !== port) {
+      PortManager.reserve(this.device.deviceId, port);
+    }
+    if (this.servicePort !== port) {
+      this.servicePort = port;
+      this.clearCaches();
+    }
+  }
+
   private async ensureHostControlServicePortAvailable(options: { allowReallocation?: boolean } = {}): Promise<void> {
     const allowReallocation = options.allowReallocation ?? true;
     const host = this.hostControl.getHost();
@@ -883,8 +903,7 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
         logger.info(
           `[IOSCtrlProxy] Reusing host-control CtrlProxy process on service port ${existingServicePort}`
         );
-        PortManager.reserve(this.device.deviceId, existingServicePort);
-        this.servicePort = existingServicePort;
+        this.adoptServicePort(existingServicePort);
         this.xcTestProcessId = existingProcess.data.pid ?? null;
         this.xcTestProcess = null;
         return;
@@ -906,8 +925,7 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
       }
 
       if (typeof result.data.port === "number") {
-        PortManager.reserve(this.device.deviceId, result.data.port);
-        this.servicePort = result.data.port;
+        this.adoptServicePort(result.data.port);
       }
       this.xcTestProcessId = result.data.pid;
       this.xcTestProcess = null;
@@ -1201,9 +1219,9 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
    * binary name match to avoid self-matching shell wrappers) then verifies
    * CtrlProxy appears in the process args.
    */
-  private async isExternalCtrlProxyProcessRunning(): Promise<boolean> {
+  private async findExternalCtrlProxyProcess(): Promise<ExternalCtrlProxyProcess | null> {
     if (this.useHostControl()) {
-      return false; // Host-control environments don't have external xcodebuild
+      return null; // Host-control environments don't have external xcodebuild
     }
     try {
       // pgrep -x matches only processes whose binary name is exactly "xcodebuild"
@@ -1212,7 +1230,7 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
       );
       const pids = pgrepOut.trim().split("\n").filter(line => line.length > 0);
       if (pids.length === 0) {
-        return false;
+        return null;
       }
 
       // Filter to PIDs whose args contain CtrlProxy, excluding our tracked PID
@@ -1226,18 +1244,29 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
             `ps -p ${pid} -o args= 2>/dev/null`
           );
           if (argsOut.includes("CtrlProxy")) {
+            const port = this.parseCtrlProxyPortFromProcessArgs(argsOut) ?? IOSCtrlProxyManager.DEFAULT_PORT;
             logger.info(`[IOSCtrlProxy] Found external xcodebuild CtrlProxy process: ${pid}`);
-            return true;
+            return { pid, port };
           }
         } catch {
           // Process may have exited between pgrep and ps
         }
       }
-      return false;
+      return null;
     } catch {
       // pgrep exits 1 when no process matches
-      return false;
+      return null;
     }
+  }
+
+  private parseCtrlProxyPortFromProcessArgs(args: string): number | null {
+    const match = args.match(/(?:^|\s)(?:SIMCTL_CHILD_)?CTRL_PROXY_IOS_PORT=(\d+)(?:\s|$)/);
+    if (!match) {
+      return null;
+    }
+
+    const port = Number.parseInt(match[1], 10);
+    return Number.isNaN(port) || port <= 0 || port > 65535 ? null : port;
   }
 
   /**

--- a/src/utils/PortManager.ts
+++ b/src/utils/PortManager.ts
@@ -1,5 +1,74 @@
 import { logger } from "./logger";
 
+export const IOS_SDK_HIERARCHY_SERVER_PORT = 8766;
+export const IOS_CTRL_PROXY_RESERVED_PORTS = new Set<number>([
+  // The in-app AutoMobile iOS SDK hierarchy server is fixed on 8766.
+  IOS_SDK_HIERARCHY_SERVER_PORT,
+]);
+
+export interface PortAvailabilityChecker {
+  isPortAvailable(port: number): boolean;
+}
+
+export interface PortAllocationOptions {
+  reservedPorts?: Iterable<number>;
+  availabilityChecker?: PortAvailabilityChecker;
+}
+
+type BunTcpServer = {
+  stop(force?: boolean): void;
+};
+
+type BunRuntime = {
+  listen(options: {
+    hostname: string;
+    port: number;
+    socket: {
+      open(socket: unknown): void;
+      data(socket: unknown, data: unknown): void;
+      drain(socket: unknown): void;
+      close(socket: unknown): void;
+      error(socket: unknown, error: Error): void;
+    };
+  }): BunTcpServer;
+};
+
+const noopSocketHandler = {
+  open(): void {},
+  data(): void {},
+  drain(): void {},
+  close(): void {},
+  error(): void {},
+};
+
+class BunPortAvailabilityChecker implements PortAvailabilityChecker {
+  public isPortAvailable(port: number): boolean {
+    const bun = (globalThis as { Bun?: BunRuntime }).Bun;
+    if (!bun) {
+      return true;
+    }
+
+    const servers: BunTcpServer[] = [];
+    try {
+      for (const hostname of ["127.0.0.1", "::1"]) {
+        servers.push(bun.listen({
+          hostname,
+          port,
+          socket: noopSocketHandler,
+        }));
+      }
+      return true;
+    } catch (error) {
+      logger.debug(`[PortManager] Port ${port} is not available: ${error}`);
+      return false;
+    } finally {
+      for (const server of servers) {
+        server.stop(true);
+      }
+    }
+  }
+}
+
 /**
  * Manages port allocation for multi-device support.
  * Each device gets a unique local port for WebSocket forwarding to avoid conflicts
@@ -11,6 +80,7 @@ export class PortManager {
   private static readonly DEFAULT_MAX_DEVICES = 100;
   private static readonly basePort = PortManager.resolveBasePort();
   private static readonly maxDevices = PortManager.resolveMaxDevices();
+  private static portAvailabilityChecker: PortAvailabilityChecker = new BunPortAvailabilityChecker();
 
   /**
    * Allocate a unique local port for a device.
@@ -19,7 +89,7 @@ export class PortManager {
    * @returns The allocated local port number
    * @throws Error if no ports are available
    */
-  public static allocate(deviceId: string): number {
+  public static allocate(deviceId: string, options: PortAllocationOptions = {}): number {
     // Return existing allocation
     if (this.allocatedPorts.has(deviceId)) {
       return this.allocatedPorts.get(deviceId)!;
@@ -27,18 +97,24 @@ export class PortManager {
 
     // Find next available port
     const usedPorts = new Set(this.allocatedPorts.values());
+    const reservedPorts = new Set(options.reservedPorts ?? []);
+    const availabilityChecker = options.availabilityChecker ?? this.portAvailabilityChecker;
     for (let i = 0; i < this.maxDevices; i++) {
       const port = this.basePort + i;
-      if (!usedPorts.has(port)) {
-        this.allocatedPorts.set(deviceId, port);
-        logger.info(`[PortManager] Allocated port ${port} for device ${deviceId}`);
-        return port;
+      if (usedPorts.has(port) || reservedPorts.has(port)) {
+        continue;
       }
+      if (!availabilityChecker.isPortAvailable(port)) {
+        continue;
+      }
+      this.allocatedPorts.set(deviceId, port);
+      logger.info(`[PortManager] Allocated port ${port} for device ${deviceId}`);
+      return port;
     }
 
     throw new Error(
       `No available ports for device ${deviceId}. ` +
-      `All ${this.maxDevices} ports (${this.basePort}-${this.basePort + this.maxDevices - 1}) are in use.`
+      `All ${this.maxDevices} ports (${this.basePort}-${this.basePort + this.maxDevices - 1}) are in use or reserved.`
     );
   }
 
@@ -100,10 +176,25 @@ export class PortManager {
   }
 
   /**
+   * Override the host-port availability checker.
+   * Should only be used in testing.
+   */
+  public static setPortAvailabilityCheckerForTesting(checker: PortAvailabilityChecker | null): void {
+    this.portAvailabilityChecker = checker ?? new BunPortAvailabilityChecker();
+  }
+
+  /**
    * The base port number (for reference/testing)
    */
   public static getBasePort(): number {
     return this.basePort;
+  }
+
+  /**
+   * The configured port range size (for testing and bounded retry loops).
+   */
+  public static getMaxDevices(): number {
+    return this.maxDevices;
   }
 
   /**

--- a/src/utils/PortManager.ts
+++ b/src/utils/PortManager.ts
@@ -131,6 +131,26 @@ export class PortManager {
   }
 
   /**
+   * Reserve a known port for a device, such as a port owned by an existing
+   * host-control process discovered after this process starts.
+   */
+  public static reserve(deviceId: string, port: number): void {
+    for (const [allocatedDeviceId, allocatedPort] of this.allocatedPorts) {
+      if (allocatedDeviceId !== deviceId && allocatedPort === port) {
+        throw new Error(`Port ${port} is already allocated to device ${allocatedDeviceId}`);
+      }
+    }
+
+    const existingPort = this.allocatedPorts.get(deviceId);
+    if (existingPort === port) {
+      return;
+    }
+
+    this.allocatedPorts.set(deviceId, port);
+    logger.info(`[PortManager] Reserved port ${port} for device ${deviceId}`);
+  }
+
+  /**
    * Get the port allocated to a device, if any.
    * @param deviceId - The device identifier
    * @returns The allocated port or undefined

--- a/src/utils/hostControlClient.ts
+++ b/src/utils/hostControlClient.ts
@@ -504,7 +504,7 @@ export async function startCtrlProxyIOS(params: {
   xctestrunPath?: string;
   bundleId?: string;
   timeoutSeconds?: number;
-}): Promise<HostControlResult<{ pid: number; message: string }>> {
+}): Promise<HostControlResult<{ pid: number; message: string; port?: number }>> {
   return sendCommand("xctest-start", params);
 }
 

--- a/test/features/observe/ios/CtrlProxyClientAutoSetup.test.ts
+++ b/test/features/observe/ios/CtrlProxyClientAutoSetup.test.ts
@@ -82,6 +82,79 @@ describe("IOSCtrlProxyClient auto-setup", function() {
     await client.close();
   });
 
+  test("retries on manager port when already-running service moved ports", async function() {
+    fakeManager.setRunning(true);
+    fakeManager.setServicePort(8767);
+    const urls: string[] = [];
+    let callCount = 0;
+    const wsFactory = (url: string) => {
+      urls.push(url);
+      callCount++;
+      if (callCount === 1) {
+        return createInstantFailureWebSocketFactory(fakeTimer)(url);
+      }
+      return createSuccessWebSocketFactory(fakeTimer)(url);
+    };
+
+    const client = IOSCtrlProxyClient.createForTesting(
+      testDevice,
+      serverPort,
+      wsFactory,
+      fakeTimer,
+      createManagerFactory()
+    );
+
+    const result = await client.ensureConnected();
+
+    expect(result).toBe(true);
+    expect(fakeManager.wasMethodCalled("setup:force=true")).toBe(false);
+    expect(urls).toEqual([
+      "ws://localhost:8765/ws",
+      "ws://localhost:8767/ws",
+    ]);
+
+    await client.close();
+  });
+
+  test("getInstance reuses the device singleton when the service port changes", async function() {
+    const client = IOSCtrlProxyClient.getInstance(testDevice, 8765);
+    const sameClient = IOSCtrlProxyClient.getInstance(testDevice, 8767);
+
+    expect(sameClient).toBe(client);
+    expect((sameClient as unknown as { getWebSocketUrl: () => string }).getWebSocketUrl()).toBe(
+      "ws://localhost:8767/ws"
+    );
+
+    await client.close();
+  });
+
+  test("port changes force the next connection to use the new WebSocket URL", async function() {
+    const urls: string[] = [];
+    const wsFactory = (url: string) => {
+      urls.push(url);
+      return createSuccessWebSocketFactory(fakeTimer)(url);
+    };
+    const client = IOSCtrlProxyClient.createForTesting(
+      testDevice,
+      serverPort,
+      wsFactory,
+      fakeTimer,
+      createManagerFactory()
+    );
+
+    expect(await client.ensureConnected()).toBe(true);
+
+    (client as unknown as { updatePort: (port: number) => void }).updatePort(8767);
+
+    expect(await client.ensureConnected()).toBe(true);
+    expect(urls).toEqual([
+      "ws://localhost:8765/ws",
+      "ws://localhost:8767/ws",
+    ]);
+
+    await client.close();
+  });
+
   test("no auto-setup when already connected", async function() {
     const client = IOSCtrlProxyClient.createForTesting(
       testDevice,

--- a/test/utils/IOSCtrlProxyManager.test.ts
+++ b/test/utils/IOSCtrlProxyManager.test.ts
@@ -19,11 +19,20 @@ class FakeHostPortAvailabilityChecker implements HostPortAvailabilityChecker {
   }
 }
 
-function createHostControlRunner(options: { runningCtrlProxyPids?: number[] } = {}) {
+function createHostControlRunner(options: {
+  runningCtrlProxyPids?: number[];
+  runningCtrlProxyProcesses?: { pid: number; port: number; deviceId?: string }[];
+} = {}) {
   const starts: { deviceId: string; port: number; xctestrunPath?: string }[] = [];
   const stops: { deviceId?: string; pid?: number }[] = [];
   const iproxyStarts: { deviceId: string; localPort: number; devicePort?: number }[] = [];
-  const runningCtrlProxyPids = new Set(options.runningCtrlProxyPids ?? []);
+  const runningCtrlProxyProcesses = new Map<number, { pid: number; port: number; deviceId?: string }>();
+  for (const pid of options.runningCtrlProxyPids ?? []) {
+    runningCtrlProxyProcesses.set(pid, { pid, port: 8765 });
+  }
+  for (const process of options.runningCtrlProxyProcesses ?? []) {
+    runningCtrlProxyProcesses.set(process.pid, process);
+  }
   const runningIproxyPids = new Set<number>();
   let nextCtrlProxyPid = 1234;
   let nextIproxyPid = 4321;
@@ -57,22 +66,49 @@ function createHostControlRunner(options: { runningCtrlProxyPids?: number[] } = 
         data: { running: params.pid !== undefined && runningIproxyPids.has(params.pid), pid: params.pid },
       }),
       start: async (params: { deviceId: string; port: number; xctestrunPath?: string }) => {
+        const existingProcess = Array.from(runningCtrlProxyProcesses.values())
+          .find(process => process.deviceId === params.deviceId);
+        if (existingProcess) {
+          return {
+            success: true,
+            data: { pid: existingProcess.pid, message: "already running", port: existingProcess.port },
+          };
+        }
         starts.push(params);
         const pid = nextCtrlProxyPid++;
-        runningCtrlProxyPids.add(pid);
-        return { success: true, data: { pid, message: "started" } };
+        runningCtrlProxyProcesses.set(pid, { pid, port: params.port, deviceId: params.deviceId });
+        return { success: true, data: { pid, message: "started", port: params.port } };
       },
       stop: async (params: { deviceId?: string; pid?: number }) => {
         stops.push(params);
         if (params.pid) {
-          runningCtrlProxyPids.delete(params.pid);
+          runningCtrlProxyProcesses.delete(params.pid);
+        }
+        if (params.deviceId) {
+          for (const [pid, process] of runningCtrlProxyProcesses) {
+            if (process.deviceId === params.deviceId) {
+              runningCtrlProxyProcesses.delete(pid);
+            }
+          }
         }
         return { success: true };
       },
-      status: async (params: { pid?: number }) => ({
-        success: true,
-        data: { running: params.pid !== undefined && runningCtrlProxyPids.has(params.pid), pid: params.pid },
-      }),
+      status: async (params: { deviceId?: string; pid?: number; port?: number }) => {
+        const runningProcess = params.pid !== undefined
+          ? runningCtrlProxyProcesses.get(params.pid)
+          : Array.from(runningCtrlProxyProcesses.values()).find(process =>
+            (params.deviceId !== undefined && process.deviceId === params.deviceId) ||
+            (params.port !== undefined && process.port === params.port)
+          );
+        return {
+          success: true,
+          data: {
+            running: runningProcess !== undefined,
+            pid: runningProcess?.pid ?? params.pid,
+            port: runningProcess?.port ?? params.port,
+          },
+        };
+      },
     },
   };
 }
@@ -247,6 +283,45 @@ describe("IOSCtrlProxyManager", function() {
       expect(iproxyStarts[0]).toMatchObject({ localPort: 8767, devicePort: 8767 });
     });
 
+    test("host-control iproxy only skips busy host ports for the current allocation attempt", async function() {
+      const unavailablePorts = new Set([8765]);
+      const { runner, iproxyStarts } = createHostControlRunner();
+      const checker = new FakeHostPortAvailabilityChecker(unavailablePorts);
+      const manager = IOSCtrlProxyManager.createForTestingWithDeps(
+        physicalDevice,
+        fakeTimer,
+        undefined,
+        fakeExecutor,
+        undefined,
+        undefined,
+        runner,
+        checker
+      );
+
+      await (manager as unknown as { startIproxyTunnel: () => Promise<void> }).startIproxyTunnel();
+
+      (manager as unknown as { iproxyProcessId: null }).iproxyProcessId = null;
+      unavailablePorts.clear();
+      unavailablePorts.add(8767);
+
+      await (manager as unknown as { startIproxyTunnel: () => Promise<void> }).startIproxyTunnel();
+
+      expect(checker.calls).toEqual([
+        { host: "host.test", port: 8765 },
+        { host: "host.test", port: 8767 },
+        { host: "host.test", port: 8767 },
+        { host: "host.test", port: 8765 },
+      ]);
+      expect(manager.getServicePort()).toBe(8765);
+      expect(iproxyStarts.map(start => ({
+        localPort: start.localPort,
+        devicePort: start.devicePort,
+      }))).toEqual([
+        { localPort: 8767, devicePort: 8767 },
+        { localPort: 8765, devicePort: 8765 },
+      ]);
+    });
+
     test("host-control iproxy keeps the service port when reallocation is disabled", async function() {
       const { runner, iproxyStarts } = createHostControlRunner();
       const checker = new FakeHostPortAvailabilityChecker(new Set([8765]));
@@ -270,6 +345,43 @@ describe("IOSCtrlProxyManager", function() {
       expect(checker.calls).toEqual([{ host: "host.test", port: 8765 }]);
       expect(manager.getServicePort()).toBe(8765);
       expect(iproxyStarts).toEqual([]);
+    });
+
+    test("host-control device startup preserves the device port for daemon-owned live processes", async function() {
+      const fakeBuilder = {
+        getXctestrunPath: async () => {
+          throw new Error("should not build when an existing host-control process is reused");
+        },
+        getRunnerBinaryPath: async () => null,
+        getExpectedAppHash: () => null,
+      } as unknown as import("../../src/utils/IOSCtrlProxyBuilder").IOSCtrlProxyBuilder;
+      const { runner, starts, iproxyStarts } = createHostControlRunner({
+        runningCtrlProxyProcesses: [{
+          pid: 1234,
+          port: 8765,
+          deviceId: physicalDevice.deviceId,
+        }],
+      });
+      const checker = new FakeHostPortAvailabilityChecker(new Set([8765]));
+      const manager = IOSCtrlProxyManager.createForTestingWithDeps(
+        physicalDevice,
+        fakeTimer,
+        fakeBuilder,
+        fakeExecutor,
+        undefined,
+        undefined,
+        runner,
+        checker
+      );
+
+      await (manager as unknown as { startOnDevice: () => Promise<void> }).startOnDevice();
+
+      expect(starts).toEqual([]);
+      expect(manager.getServicePort()).toBe(8767);
+      expect(iproxyStarts).toEqual([
+        { deviceId: physicalDevice.deviceId, localPort: 8767, devicePort: 8765 },
+      ]);
+      expect((manager as unknown as { xcTestProcessId: number }).xcTestProcessId).toBe(1234);
     });
   });
 
@@ -602,6 +714,41 @@ describe("IOSCtrlProxyManager", function() {
       ]);
       expect(manager.getServicePort()).toBe(8767);
       expect(starts[0]).toMatchObject({ port: 8767, xctestrunPath: "/tmp/test.xctestrun" });
+    });
+
+    test("host-control simulator start reuses daemon-owned live process ports", async function() {
+      const fakeBuilder = {
+        getXctestrunPath: async () => {
+          throw new Error("should not build when an existing host-control process is reused");
+        },
+        getRunnerBinaryPath: async () => null,
+      } as unknown as import("../../src/utils/IOSCtrlProxyBuilder").IOSCtrlProxyBuilder;
+      const { runner, starts } = createHostControlRunner({
+        runningCtrlProxyProcesses: [{
+          pid: 2233,
+          port: 8767,
+          deviceId: testDevice.deviceId,
+        }],
+      });
+      const checker = new FakeHostPortAvailabilityChecker(new Set([8765]));
+      const manager = IOSCtrlProxyManager.createForTestingWithDeps(
+        testDevice,
+        fakeTimer,
+        fakeBuilder,
+        fakeExecutor,
+        undefined,
+        undefined,
+        runner,
+        checker
+      );
+
+      await (manager as unknown as { startOnSimulator: () => Promise<void> }).startOnSimulator();
+
+      expect(checker.calls).toEqual([]);
+      expect(starts).toEqual([]);
+      expect(manager.getServicePort()).toBe(8767);
+      expect(PortManager.getPort(testDevice.deviceId)).toBe(8767);
+      expect((manager as unknown as { xcTestProcessId: number }).xcTestProcessId).toBe(2233);
     });
   });
 });

--- a/test/utils/IOSCtrlProxyManager.test.ts
+++ b/test/utils/IOSCtrlProxyManager.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, test } from "bun:test";
-import { IOSCtrlProxyManager } from "../../src/utils/IOSCtrlProxyManager";
+import { IOSCtrlProxyManager, type HostPortAvailabilityChecker } from "../../src/utils/IOSCtrlProxyManager";
 import { BootedDevice } from "../../src/models";
 import { FakeTimer } from "../fakes/FakeTimer";
 import { FakeIOSCtrlProxyManager } from "../fakes/FakeIOSCtrlProxyManager";
@@ -7,6 +7,75 @@ import { FakeProcessExecutor } from "../fakes/FakeProcessExecutor";
 import { FakeChildProcess } from "../fakes/FakeChildProcess";
 import type { ExecResult } from "../../src/models";
 import { PortManager } from "../../src/utils/PortManager";
+
+class FakeHostPortAvailabilityChecker implements HostPortAvailabilityChecker {
+  public readonly calls: { host: string; port: number }[] = [];
+
+  public constructor(private readonly unavailablePorts: Set<number> = new Set()) {}
+
+  public async isAvailable(host: string, port: number): Promise<boolean> {
+    this.calls.push({ host, port });
+    return !this.unavailablePorts.has(port);
+  }
+}
+
+function createHostControlRunner(options: { runningCtrlProxyPids?: number[] } = {}) {
+  const starts: { deviceId: string; port: number; xctestrunPath?: string }[] = [];
+  const stops: { deviceId?: string; pid?: number }[] = [];
+  const iproxyStarts: { deviceId: string; localPort: number; devicePort?: number }[] = [];
+  const runningCtrlProxyPids = new Set(options.runningCtrlProxyPids ?? []);
+  const runningIproxyPids = new Set<number>();
+  let nextCtrlProxyPid = 1234;
+  let nextIproxyPid = 4321;
+
+  return {
+    starts,
+    stops,
+    iproxyStarts,
+    runner: {
+      shouldUseHostControl: () => true,
+      isRunningInDocker: () => true,
+      isAvailable: async () => true,
+      getHost: () => "host.test",
+      runIdeviceId: async () => ({ success: true, data: { stdout: "" } }),
+      runIdeviceInstaller: async () => ({ success: true, data: { stdout: "" } }),
+      runSimctl: async () => ({ success: true, data: { stdout: "" } }),
+      startIproxy: async (params: { deviceId: string; localPort: number; devicePort?: number }) => {
+        iproxyStarts.push(params);
+        const pid = nextIproxyPid++;
+        runningIproxyPids.add(pid);
+        return { success: true, data: { pid } };
+      },
+      stopIproxy: async (params: { pid?: number }) => {
+        if (params.pid) {
+          runningIproxyPids.delete(params.pid);
+        }
+        return { success: true };
+      },
+      getIproxyStatus: async (params: { pid?: number }) => ({
+        success: true,
+        data: { running: params.pid !== undefined && runningIproxyPids.has(params.pid), pid: params.pid },
+      }),
+      start: async (params: { deviceId: string; port: number; xctestrunPath?: string }) => {
+        starts.push(params);
+        const pid = nextCtrlProxyPid++;
+        runningCtrlProxyPids.add(pid);
+        return { success: true, data: { pid, message: "started" } };
+      },
+      stop: async (params: { deviceId?: string; pid?: number }) => {
+        stops.push(params);
+        if (params.pid) {
+          runningCtrlProxyPids.delete(params.pid);
+        }
+        return { success: true };
+      },
+      status: async (params: { pid?: number }) => ({
+        success: true,
+        data: { running: params.pid !== undefined && runningCtrlProxyPids.has(params.pid), pid: params.pid },
+      }),
+    },
+  };
+}
 
 describe("IOSCtrlProxyManager", function() {
   let testDevice: BootedDevice;
@@ -153,6 +222,55 @@ describe("IOSCtrlProxyManager", function() {
 
       expect(fakeExecutor.getSpawnedProcesses().length).toBe(2);
     });
+
+    test("host-control iproxy skips ports that are busy on the host", async function() {
+      const { runner, iproxyStarts } = createHostControlRunner();
+      const checker = new FakeHostPortAvailabilityChecker(new Set([8765]));
+      const manager = IOSCtrlProxyManager.createForTestingWithDeps(
+        physicalDevice,
+        fakeTimer,
+        undefined,
+        fakeExecutor,
+        undefined,
+        undefined,
+        runner,
+        checker
+      );
+
+      await (manager as unknown as { startIproxyTunnel: () => Promise<void> }).startIproxyTunnel();
+
+      expect(checker.calls).toEqual([
+        { host: "host.test", port: 8765 },
+        { host: "host.test", port: 8767 },
+      ]);
+      expect(manager.getServicePort()).toBe(8767);
+      expect(iproxyStarts[0]).toMatchObject({ localPort: 8767, devicePort: 8767 });
+    });
+
+    test("host-control iproxy keeps the service port when reallocation is disabled", async function() {
+      const { runner, iproxyStarts } = createHostControlRunner();
+      const checker = new FakeHostPortAvailabilityChecker(new Set([8765]));
+      const manager = IOSCtrlProxyManager.createForTestingWithDeps(
+        physicalDevice,
+        fakeTimer,
+        undefined,
+        fakeExecutor,
+        undefined,
+        undefined,
+        runner,
+        checker
+      );
+
+      await expect(
+        (manager as unknown as {
+          startIproxyTunnel: (options: { allowServicePortReallocation: boolean }) => Promise<void>;
+        }).startIproxyTunnel({ allowServicePortReallocation: false })
+      ).rejects.toThrow("Host control port 8765 is already in use on host.test");
+
+      expect(checker.calls).toEqual([{ host: "host.test", port: 8765 }]);
+      expect(manager.getServicePort()).toBe(8765);
+      expect(iproxyStarts).toEqual([]);
+    });
   });
 
   describe("restart prevention", function() {
@@ -216,6 +334,95 @@ describe("IOSCtrlProxyManager", function() {
       // iproxy should have been (re-)spawned even though CtrlProxy was alive
       expect(fakeExecutor.getSpawnedProcesses().length).toBe(1);
       expect(fakeExecutor.getSpawnedProcesses()[0].command).toBe("iproxy");
+    });
+
+    test("start() restarts live host-control device process before reallocating its busy service port", async function() {
+      const fakeBuilder = {
+        getXctestrunPath: async () => "/tmp/test.xctestrun",
+        getRunnerBinaryPath: async () => null,
+        getExpectedAppHash: () => null,
+      } as unknown as import("../../src/utils/IOSCtrlProxyBuilder").IOSCtrlProxyBuilder;
+      const { runner, starts, stops, iproxyStarts } = createHostControlRunner({
+        runningCtrlProxyPids: [1234],
+      });
+      const checker = new FakeHostPortAvailabilityChecker(new Set([8765]));
+      const manager = IOSCtrlProxyManager.createForTestingWithDeps(
+        physicalDevice,
+        fakeTimer,
+        fakeBuilder,
+        fakeExecutor,
+        undefined,
+        undefined,
+        runner,
+        checker
+      );
+      (manager as unknown as { xcTestProcessId: number }).xcTestProcessId = 1234;
+
+      const originalFetch = globalThis.fetch;
+      globalThis.fetch = async () => new Response("ok");
+      try {
+        fakeTimer.enableAutoAdvance();
+        await manager.start();
+      } finally {
+        globalThis.fetch = originalFetch;
+      }
+
+      expect(stops).toEqual([{ deviceId: physicalDevice.deviceId, pid: 1234 }]);
+      expect(checker.calls).toEqual([
+        { host: "host.test", port: 8765 },
+        { host: "host.test", port: 8765 },
+        { host: "host.test", port: 8767 },
+      ]);
+      expect(manager.getServicePort()).toBe(8767);
+      expect(iproxyStarts).toEqual([
+        { deviceId: physicalDevice.deviceId, localPort: 8767, devicePort: 8767 },
+      ]);
+      expect(starts).toEqual([
+        { deviceId: physicalDevice.deviceId, port: 8767, xctestrunPath: "/tmp/test.xctestrun" },
+      ]);
+    });
+
+    test("scheduled host-control iproxy restart restarts live device process before reallocating busy service port", async function() {
+      const fakeBuilder = {
+        getXctestrunPath: async () => "/tmp/test.xctestrun",
+        getRunnerBinaryPath: async () => null,
+        getExpectedAppHash: () => null,
+      } as unknown as import("../../src/utils/IOSCtrlProxyBuilder").IOSCtrlProxyBuilder;
+      const { runner, starts, stops, iproxyStarts } = createHostControlRunner({
+        runningCtrlProxyPids: [1234],
+      });
+      const checker = new FakeHostPortAvailabilityChecker(new Set([8765]));
+      const manager = IOSCtrlProxyManager.createForTestingWithDeps(
+        physicalDevice,
+        fakeTimer,
+        fakeBuilder,
+        fakeExecutor,
+        undefined,
+        undefined,
+        runner,
+        checker
+      );
+      (manager as unknown as { xcTestProcessId: number }).xcTestProcessId = 1234;
+
+      fakeTimer.enableAutoAdvance();
+      (manager as unknown as { scheduleIproxyRestart: () => void }).scheduleIproxyRestart();
+      for (let i = 0; i < 10; i++) {
+        await new Promise(resolve => setImmediate(resolve));
+      }
+
+      expect(stops).toEqual([{ deviceId: physicalDevice.deviceId, pid: 1234 }]);
+      expect(checker.calls).toEqual([
+        { host: "host.test", port: 8765 },
+        { host: "host.test", port: 8765 },
+        { host: "host.test", port: 8767 },
+      ]);
+      expect(manager.getServicePort()).toBe(8767);
+      expect(iproxyStarts).toEqual([
+        { deviceId: physicalDevice.deviceId, localPort: 8767, devicePort: 8767 },
+      ]);
+      expect(starts).toEqual([
+        { deviceId: physicalDevice.deviceId, port: 8767, xctestrunPath: "/tmp/test.xctestrun" },
+      ]);
     });
 
     test("startProcessMonitoring uses the injected timer so tests can control it", function() {
@@ -367,6 +574,34 @@ describe("IOSCtrlProxyManager", function() {
 
       // simctl spawn should never be invoked via processExecutor
       expect(fakeExecutor.wasCommandExecuted("simctl spawn")).toBe(false);
+    });
+
+    test("host-control simulator start skips ports that are busy on the host", async function() {
+      const fakeBuilder = {
+        getXctestrunPath: async () => "/tmp/test.xctestrun",
+        getRunnerBinaryPath: async () => null,
+      } as unknown as import("../../src/utils/IOSCtrlProxyBuilder").IOSCtrlProxyBuilder;
+      const { runner, starts } = createHostControlRunner();
+      const checker = new FakeHostPortAvailabilityChecker(new Set([8765]));
+      const manager = IOSCtrlProxyManager.createForTestingWithDeps(
+        testDevice,
+        fakeTimer,
+        fakeBuilder,
+        fakeExecutor,
+        undefined,
+        undefined,
+        runner,
+        checker
+      );
+
+      await (manager as unknown as { startOnSimulator: () => Promise<void> }).startOnSimulator();
+
+      expect(checker.calls).toEqual([
+        { host: "host.test", port: 8765 },
+        { host: "host.test", port: 8767 },
+      ]);
+      expect(manager.getServicePort()).toBe(8767);
+      expect(starts[0]).toMatchObject({ port: 8767, xctestrunPath: "/tmp/test.xctestrun" });
     });
   });
 });

--- a/test/utils/IOSCtrlProxyManager.test.ts
+++ b/test/utils/IOSCtrlProxyManager.test.ts
@@ -688,6 +688,103 @@ describe("IOSCtrlProxyManager", function() {
       expect(fakeExecutor.wasCommandExecuted("simctl spawn")).toBe(false);
     });
 
+    test("start() adopts the default hot-reload CtrlProxy port before health polling", async function() {
+      PortManager.setPortAvailabilityCheckerForTesting({
+        isPortAvailable: (port: number) => port !== 8765,
+      });
+      try {
+        const fakeBuilder = {
+          getXctestrunPath: async () => {
+            throw new Error("should not build when an external CtrlProxy process is reused");
+          },
+          getRunnerBinaryPath: async () => null,
+        } as unknown as import("../../src/utils/IOSCtrlProxyBuilder").IOSCtrlProxyBuilder;
+        const manager = IOSCtrlProxyManager.createForTestingWithDeps(
+          testDevice,
+          fakeTimer,
+          fakeBuilder,
+          fakeExecutor
+        );
+        expect(manager.getServicePort()).toBe(8767);
+
+        fakeExecutor.setCommandResponse("http://localhost:8767/health", createExecResult("", ""));
+        fakeExecutor.setCommandResponse("pgrep -x xcodebuild", createExecResult("2468\n", ""));
+        fakeExecutor.setCommandResponse(
+          "ps -p 2468",
+          createExecResult("xcodebuild test CtrlProxyUITests/CtrlProxyUITests/testRunService", "")
+        );
+        fakeExecutor.setCommandResponse("http://localhost:8765/health", createExecResult("ok", ""));
+        fakeTimer.enableAutoAdvance();
+
+        await manager.start();
+
+        expect(manager.getServicePort()).toBe(8765);
+        expect(PortManager.getPort(testDevice.deviceId)).toBe(8765);
+        expect(fakeExecutor.getSpawnedProcesses()).toEqual([]);
+      } finally {
+        PortManager.setPortAvailabilityCheckerForTesting(null);
+      }
+    });
+
+    test("start() adopts a custom hot-reload CtrlProxy port from process args", async function() {
+      const fakeBuilder = {
+        getXctestrunPath: async () => {
+          throw new Error("should not build when an external CtrlProxy process is reused");
+        },
+        getRunnerBinaryPath: async () => null,
+      } as unknown as import("../../src/utils/IOSCtrlProxyBuilder").IOSCtrlProxyBuilder;
+      const manager = IOSCtrlProxyManager.createForTestingWithDeps(
+        testDevice,
+        fakeTimer,
+        fakeBuilder,
+        fakeExecutor
+      );
+
+      fakeExecutor.setCommandResponse("http://localhost:8765/health", createExecResult("", ""));
+      fakeExecutor.setCommandResponse("pgrep -x xcodebuild", createExecResult("2469\n", ""));
+      fakeExecutor.setCommandResponse(
+        "ps -p 2469",
+        createExecResult("xcodebuild test CtrlProxyUITests CTRL_PROXY_IOS_PORT=8790", "")
+      );
+      fakeExecutor.setCommandResponse("http://localhost:8790/health", createExecResult("ok", ""));
+      fakeTimer.enableAutoAdvance();
+
+      await manager.start();
+
+      expect(manager.getServicePort()).toBe(8790);
+      expect(PortManager.getPort(testDevice.deviceId)).toBe(8790);
+      expect(fakeExecutor.getSpawnedProcesses()).toEqual([]);
+    });
+
+    test("startOnSimulator() keeps the reallocated simulator port when spawning", async function() {
+      PortManager.setPortAvailabilityCheckerForTesting({
+        isPortAvailable: (port: number) => port !== 8765,
+      });
+      try {
+        const fakeBuilder = {
+          getXctestrunPath: async () => "/tmp/test.xctestrun",
+          getRunnerBinaryPath: async () => null,
+        } as unknown as import("../../src/utils/IOSCtrlProxyBuilder").IOSCtrlProxyBuilder;
+        const manager = IOSCtrlProxyManager.createForTestingWithDeps(
+          testDevice,
+          fakeTimer,
+          fakeBuilder,
+          fakeExecutor
+        );
+
+        await (manager as unknown as { startOnSimulator: () => Promise<void> }).startOnSimulator();
+
+        const spawn = fakeExecutor.getSpawnedProcesses()[0];
+        expect(manager.getServicePort()).toBe(8767);
+        expect(spawn.options?.env).toMatchObject({
+          CTRL_PROXY_IOS_PORT: "8767",
+          SIMCTL_CHILD_CTRL_PROXY_IOS_PORT: "8767",
+        });
+      } finally {
+        PortManager.setPortAvailabilityCheckerForTesting(null);
+      }
+    });
+
     test("host-control simulator start skips ports that are busy on the host", async function() {
       const fakeBuilder = {
         getXctestrunPath: async () => "/tmp/test.xctestrun",

--- a/test/utils/IOSCtrlProxyManager.test.ts
+++ b/test/utils/IOSCtrlProxyManager.test.ts
@@ -399,6 +399,10 @@ describe("IOSCtrlProxyManager", function() {
           deviceId: physicalDevice.deviceId,
         }],
       });
+      runner.runIdeviceId = async () => ({
+        success: true,
+        data: { stdout: `${physicalDevice.deviceId}\n` },
+      });
       const checker = new FakeHostPortAvailabilityChecker(new Set([8765]));
       const manager = IOSCtrlProxyManager.createForTestingWithDeps(
         physicalDevice,
@@ -414,8 +418,12 @@ describe("IOSCtrlProxyManager", function() {
       await (manager as unknown as { startOnDevice: () => Promise<void> }).startOnDevice();
       (manager as unknown as { iproxyProcessId: null }).iproxyProcessId = null;
 
-      fakeTimer.enableAutoAdvance();
-      (manager as unknown as { scheduleIproxyRestart: () => void }).scheduleIproxyRestart();
+      (manager as unknown as { startIproxyMonitoring: () => void }).startIproxyMonitoring();
+      fakeTimer.advanceTime(5000);
+      for (let i = 0; i < 10; i++) {
+        await Promise.resolve();
+      }
+      fakeTimer.advanceTime(1000);
       for (let i = 0; i < 10; i++) {
         await new Promise(resolve => setImmediate(resolve));
       }
@@ -752,7 +760,10 @@ describe("IOSCtrlProxyManager", function() {
 
         fakeExecutor.setCommandResponse("http://localhost:8767/health", createExecResult("", ""));
         fakeExecutor.setCommandResponse("pgrep -x xcodebuild", createExecResult("", ""));
-        fakeExecutor.setCommandResponse("http://localhost:8765/health", createExecResult("ok", ""));
+        fakeExecutor.setCommandResponse(
+          "http://localhost:8765/health",
+          createExecResult(JSON.stringify({ status: "ok", deviceId: testDevice.deviceId }), "")
+        );
         fakeTimer.enableAutoAdvance();
 
         await manager.start();
@@ -760,6 +771,41 @@ describe("IOSCtrlProxyManager", function() {
         expect(manager.getServicePort()).toBe(8765);
         expect(PortManager.getPort(testDevice.deviceId)).toBe(8765);
         expect(fakeExecutor.getSpawnedProcesses()).toEqual([]);
+      } finally {
+        PortManager.setPortAvailabilityCheckerForTesting(null);
+      }
+    });
+
+    test("start() does not adopt the default CtrlProxy port for another simulator", async function() {
+      PortManager.setPortAvailabilityCheckerForTesting({
+        isPortAvailable: (port: number) => port !== 8765,
+      });
+      try {
+        const fakeBuilder = {
+          getXctestrunPath: async () => "/tmp/test.xctestrun",
+          getRunnerBinaryPath: async () => null,
+        } as unknown as import("../../src/utils/IOSCtrlProxyBuilder").IOSCtrlProxyBuilder;
+        const manager = IOSCtrlProxyManager.createForTestingWithDeps(
+          testDevice,
+          fakeTimer,
+          fakeBuilder,
+          fakeExecutor
+        );
+        expect(manager.getServicePort()).toBe(8767);
+
+        fakeExecutor.setCommandResponse("http://localhost:8767/health", createExecResult("", ""));
+        fakeExecutor.setCommandResponse("pgrep -x xcodebuild", createExecResult("", ""));
+        fakeExecutor.setCommandResponse(
+          "http://localhost:8765/health",
+          createExecResult(JSON.stringify({ status: "ok", deviceId: "OTHER-SIMULATOR" }), "")
+        );
+        fakeTimer.enableAutoAdvance();
+
+        await expect(manager.start()).rejects.toThrow("CtrlProxy failed to start within timeout");
+
+        expect(manager.getServicePort()).toBe(8767);
+        expect(PortManager.getPort(testDevice.deviceId)).toBe(8767);
+        expect(fakeExecutor.getSpawnedProcesses()).toHaveLength(1);
       } finally {
         PortManager.setPortAvailabilityCheckerForTesting(null);
       }
@@ -813,7 +859,7 @@ describe("IOSCtrlProxyManager", function() {
       fakeExecutor.setCommandResponse("pgrep -x xcodebuild", createExecResult("2469\n", ""));
       fakeExecutor.setCommandResponse(
         "ps -p 2469",
-        createExecResult("xcodebuild test CtrlProxyUITests CTRL_PROXY_IOS_PORT=8790", "")
+        createExecResult(`xcodebuild test CtrlProxyUITests -destination id=${testDevice.deviceId} CTRL_PROXY_IOS_PORT=8790`, "")
       );
       fakeExecutor.setCommandResponse("http://localhost:8790/health", createExecResult("ok", ""));
       fakeTimer.enableAutoAdvance();
@@ -823,6 +869,32 @@ describe("IOSCtrlProxyManager", function() {
       expect(manager.getServicePort()).toBe(8790);
       expect(PortManager.getPort(testDevice.deviceId)).toBe(8790);
       expect(fakeExecutor.getSpawnedProcesses()).toEqual([]);
+    });
+
+    test("start() ignores xcodebuild CtrlProxy processes for other simulators", async function() {
+      const fakeBuilder = {
+        getXctestrunPath: async () => "/tmp/test.xctestrun",
+        getRunnerBinaryPath: async () => null,
+      } as unknown as import("../../src/utils/IOSCtrlProxyBuilder").IOSCtrlProxyBuilder;
+      const manager = IOSCtrlProxyManager.createForTestingWithDeps(
+        testDevice,
+        fakeTimer,
+        fakeBuilder,
+        fakeExecutor
+      );
+
+      fakeExecutor.setCommandResponse("http://localhost:8765/health", createExecResult("", ""));
+      fakeExecutor.setCommandResponse("pgrep -x xcodebuild", createExecResult("2469\n", ""));
+      fakeExecutor.setCommandResponse(
+        "ps -p 2469",
+        createExecResult("xcodebuild test CtrlProxyUITests -destination id=OTHER-SIMULATOR CTRL_PROXY_IOS_PORT=8790", "")
+      );
+      fakeTimer.enableAutoAdvance();
+
+      await expect(manager.start()).rejects.toThrow("CtrlProxy failed to start within timeout");
+
+      expect(manager.getServicePort()).toBe(8765);
+      expect(fakeExecutor.getSpawnedProcesses()).toHaveLength(1);
     });
 
     test("startOnSimulator() keeps the reallocated simulator port when spawning", async function() {

--- a/test/utils/IOSCtrlProxyManager.test.ts
+++ b/test/utils/IOSCtrlProxyManager.test.ts
@@ -318,7 +318,7 @@ describe("IOSCtrlProxyManager", function() {
         devicePort: start.devicePort,
       }))).toEqual([
         { localPort: 8767, devicePort: 8767 },
-        { localPort: 8765, devicePort: 8765 },
+        { localPort: 8765, devicePort: 8767 },
       ]);
     });
 
@@ -382,6 +382,49 @@ describe("IOSCtrlProxyManager", function() {
         { deviceId: physicalDevice.deviceId, localPort: 8767, devicePort: 8765 },
       ]);
       expect((manager as unknown as { xcTestProcessId: number }).xcTestProcessId).toBe(1234);
+    });
+
+    test("scheduled host-control iproxy restart preserves the device port for daemon-owned live processes", async function() {
+      const fakeBuilder = {
+        getXctestrunPath: async () => {
+          throw new Error("should not build when an existing host-control process is reused");
+        },
+        getRunnerBinaryPath: async () => null,
+        getExpectedAppHash: () => null,
+      } as unknown as import("../../src/utils/IOSCtrlProxyBuilder").IOSCtrlProxyBuilder;
+      const { runner, iproxyStarts } = createHostControlRunner({
+        runningCtrlProxyProcesses: [{
+          pid: 1234,
+          port: 8765,
+          deviceId: physicalDevice.deviceId,
+        }],
+      });
+      const checker = new FakeHostPortAvailabilityChecker(new Set([8765]));
+      const manager = IOSCtrlProxyManager.createForTestingWithDeps(
+        physicalDevice,
+        fakeTimer,
+        fakeBuilder,
+        fakeExecutor,
+        undefined,
+        undefined,
+        runner,
+        checker
+      );
+
+      await (manager as unknown as { startOnDevice: () => Promise<void> }).startOnDevice();
+      (manager as unknown as { iproxyProcessId: null }).iproxyProcessId = null;
+
+      fakeTimer.enableAutoAdvance();
+      (manager as unknown as { scheduleIproxyRestart: () => void }).scheduleIproxyRestart();
+      for (let i = 0; i < 10; i++) {
+        await new Promise(resolve => setImmediate(resolve));
+      }
+
+      expect(manager.getServicePort()).toBe(8767);
+      expect(iproxyStarts).toEqual([
+        { deviceId: physicalDevice.deviceId, localPort: 8767, devicePort: 8765 },
+        { deviceId: physicalDevice.deviceId, localPort: 8767, devicePort: 8765 },
+      ]);
     });
   });
 

--- a/test/utils/IOSCtrlProxyManager.test.ts
+++ b/test/utils/IOSCtrlProxyManager.test.ts
@@ -688,7 +688,7 @@ describe("IOSCtrlProxyManager", function() {
       expect(fakeExecutor.wasCommandExecuted("simctl spawn")).toBe(false);
     });
 
-    test("start() adopts the default hot-reload CtrlProxy port before health polling", async function() {
+    test("start() adopts a healthy default hot-reload CtrlProxy port before health polling", async function() {
       PortManager.setPortAvailabilityCheckerForTesting({
         isPortAvailable: (port: number) => port !== 8765,
       });
@@ -708,11 +708,7 @@ describe("IOSCtrlProxyManager", function() {
         expect(manager.getServicePort()).toBe(8767);
 
         fakeExecutor.setCommandResponse("http://localhost:8767/health", createExecResult("", ""));
-        fakeExecutor.setCommandResponse("pgrep -x xcodebuild", createExecResult("2468\n", ""));
-        fakeExecutor.setCommandResponse(
-          "ps -p 2468",
-          createExecResult("xcodebuild test CtrlProxyUITests/CtrlProxyUITests/testRunService", "")
-        );
+        fakeExecutor.setCommandResponse("pgrep -x xcodebuild", createExecResult("", ""));
         fakeExecutor.setCommandResponse("http://localhost:8765/health", createExecResult("ok", ""));
         fakeTimer.enableAutoAdvance();
 
@@ -721,6 +717,36 @@ describe("IOSCtrlProxyManager", function() {
         expect(manager.getServicePort()).toBe(8765);
         expect(PortManager.getPort(testDevice.deviceId)).toBe(8765);
         expect(fakeExecutor.getSpawnedProcesses()).toEqual([]);
+      } finally {
+        PortManager.setPortAvailabilityCheckerForTesting(null);
+      }
+    });
+
+    test("start() spawns when default hot-reload port is not healthy", async function() {
+      PortManager.setPortAvailabilityCheckerForTesting({
+        isPortAvailable: (port: number) => port !== 8765,
+      });
+      try {
+        const fakeBuilder = {
+          getXctestrunPath: async () => "/tmp/test.xctestrun",
+          getRunnerBinaryPath: async () => null,
+        } as unknown as import("../../src/utils/IOSCtrlProxyBuilder").IOSCtrlProxyBuilder;
+        const manager = IOSCtrlProxyManager.createForTestingWithDeps(
+          testDevice,
+          fakeTimer,
+          fakeBuilder,
+          fakeExecutor
+        );
+
+        fakeExecutor.setCommandResponse("http://localhost:8767/health", createExecResult("", ""));
+        fakeExecutor.setCommandResponse("pgrep -x xcodebuild", createExecResult("", ""));
+        fakeExecutor.setCommandResponse("http://localhost:8765/health", createExecResult("", ""));
+        fakeTimer.enableAutoAdvance();
+
+        await expect(manager.start()).rejects.toThrow("CtrlProxy failed to start within timeout");
+
+        expect(manager.getServicePort()).toBe(8767);
+        expect(fakeExecutor.getSpawnedProcesses()).toHaveLength(1);
       } finally {
         PortManager.setPortAvailabilityCheckerForTesting(null);
       }

--- a/test/utils/PortManager.test.ts
+++ b/test/utils/PortManager.test.ts
@@ -93,6 +93,23 @@ describe("PortManager", () => {
     expect(port2).toBe(8765);
   });
 
+  test("should reserve a known port for a device", () => {
+    PortManager.allocate("device-1");
+
+    PortManager.reserve("device-1", 8767);
+
+    expect(PortManager.getPort("device-1")).toBe(8767);
+    expect(PortManager.allocate("device-2")).toBe(8765);
+  });
+
+  test("should reject reserving a port allocated to another device", () => {
+    PortManager.allocate("device-1");
+
+    expect(() => PortManager.reserve("device-2", 8765)).toThrow(
+      "Port 8765 is already allocated to device device-1"
+    );
+  });
+
   test("should reuse released ports in order", () => {
     PortManager.allocate("device-1"); // 8765
     PortManager.allocate("device-2"); // 8766

--- a/test/utils/PortManager.test.ts
+++ b/test/utils/PortManager.test.ts
@@ -1,14 +1,36 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { PortManager } from "../../src/utils/PortManager";
+import { IOS_CTRL_PROXY_RESERVED_PORTS, PortManager, type PortAvailabilityChecker } from "../../src/utils/PortManager";
+
+class FakePortAvailabilityChecker implements PortAvailabilityChecker {
+  public readonly checkedPorts: number[] = [];
+
+  public constructor(private readonly unavailablePorts: Set<number> = new Set()) {}
+
+  public isPortAvailable(port: number): boolean {
+    this.checkedPorts.push(port);
+    return !this.unavailablePorts.has(port);
+  }
+}
+
+function expectedAllocatedPort(index: number): number {
+  return 8765 + index;
+}
+
+function expectedIosAllocatedPort(index: number): number {
+  const port = expectedAllocatedPort(index);
+  return port >= 8766 ? port + 1 : port;
+}
 
 describe("PortManager", () => {
   beforeEach(() => {
+    PortManager.setPortAvailabilityCheckerForTesting(new FakePortAvailabilityChecker());
     // Reset before each test to ensure clean state (other tests may allocate ports)
     PortManager.reset();
   });
 
   afterEach(() => {
     PortManager.reset();
+    PortManager.setPortAvailabilityCheckerForTesting(null);
   });
 
   test("should allocate unique ports for different devices", () => {
@@ -19,6 +41,35 @@ describe("PortManager", () => {
     expect(port1).toBe(8765);
     expect(port2).toBe(8766);
     expect(port3).toBe(8767);
+  });
+
+  test("should reserve the iOS SDK hierarchy server port when requested", () => {
+    const port1 = PortManager.allocate("device-1", { reservedPorts: IOS_CTRL_PROXY_RESERVED_PORTS });
+    const port2 = PortManager.allocate("device-2", { reservedPorts: IOS_CTRL_PROXY_RESERVED_PORTS });
+
+    expect(port1).toBe(8765);
+    expect(port2).toBe(8767);
+    expect([...PortManager.getAllocations().values()]).not.toContain(8766);
+  });
+
+  test("should skip ports unavailable on the host OS", () => {
+    const checker = new FakePortAvailabilityChecker(new Set([8765, 8766]));
+    PortManager.setPortAvailabilityCheckerForTesting(checker);
+
+    const port = PortManager.allocate("device-1");
+
+    expect(port).toBe(8767);
+    expect(checker.checkedPorts).toEqual([8765, 8766, 8767]);
+  });
+
+  test("should combine scoped reserved ports with unavailable host ports", () => {
+    const checker = new FakePortAvailabilityChecker(new Set([8765, 8767]));
+    PortManager.setPortAvailabilityCheckerForTesting(checker);
+
+    const port = PortManager.allocate("device-1", { reservedPorts: IOS_CTRL_PROXY_RESERVED_PORTS });
+
+    expect(port).toBe(8768);
+    expect(checker.checkedPorts).toEqual([8765, 8767, 8768]);
   });
 
   test("should return same port for same device", () => {
@@ -101,6 +152,7 @@ describe("PortManager", () => {
 
   test("should expose base port and device port constants", () => {
     expect(PortManager.getBasePort()).toBe(8765);
+    expect(PortManager.getMaxDevices()).toBe(100);
     expect(PortManager.DEVICE_PORT).toBe(8765);
   });
 
@@ -114,7 +166,16 @@ describe("PortManager", () => {
     // Allocate 50 devices (well under 100 limit)
     for (let i = 0; i < 50; i++) {
       const port = PortManager.allocate(`device-${i}`);
-      expect(port).toBe(8765 + i);
+      expect(port).toBe(expectedAllocatedPort(i));
+    }
+
+    expect(PortManager.getAllocatedCount()).toBe(50);
+  });
+
+  test("should support many iOS devices while skipping reserved ports", () => {
+    for (let i = 0; i < 50; i++) {
+      const port = PortManager.allocate(`ios-device-${i}`, { reservedPorts: IOS_CTRL_PROXY_RESERVED_PORTS });
+      expect(port).toBe(expectedIosAllocatedPort(i));
     }
 
     expect(PortManager.getAllocatedCount()).toBe(50);


### PR DESCRIPTION
## Summary
- reserve the fixed iOS SDK hierarchy server port (`8766`) so CtrlProxy local port allocation skips it
- add a Bun-backed host port availability probe so PortManager avoids ports already bound by other processes
- update PortManager tests with a fake availability checker for deterministic, fast coverage

Fixes #2538

## Testing
- `bun test test/utils/PortManager.test.ts test/utils/IOSCtrlProxyManager.test.ts test/features/observe/ios/IOSCtrlProxyClient.test.ts`
- `bun run lint`
- `bun run build`
- real runtime probe: bind `127.0.0.1:8765`, then verify `PortManager.allocate("probe-device")` returns `8767`

## Notes
- `bun install --frozen-lockfile` failed on `heapdump` native build under Node 26; `bun install --frozen-lockfile --ignore-scripts` succeeded for validation dependencies.
- `bun test test/features/observe/CtrlProxyClient.test.ts` has an unrelated order-dependent Android navigation test failure; the failing test passes when run in isolation.
