### PR TITLE
fix(ios): detect stale CtrlProxy runner commands

### DIFF
--- a/ios/control-proxy/Sources/CtrlProxy/Models.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/Models.swift
@@ -766,10 +766,12 @@ public struct PerformanceUpdateResponse: Codable {
 public struct ConnectedEvent: Codable {
     public let type: String
     public let id: Int
+    public let supportedCommands: [String]
 
     public init(id: Int) {
         type = "connected"
         self.id = id
+        supportedCommands = RequestType.allCases.map(\.rawValue).sorted()
     }
 }
 
@@ -796,7 +798,7 @@ public struct VoiceOverStateResponse: Codable {
 
 // MARK: - Request Types (matching Android)
 
-public enum RequestType: String {
+public enum RequestType: String, CaseIterable {
     // View hierarchy
     case requestHierarchy = "request_hierarchy"
     case requestHierarchyIfStale = "request_hierarchy_if_stale"

--- a/ios/control-proxy/Tests/CtrlProxyTests/ModelsTests.swift
+++ b/ios/control-proxy/Tests/CtrlProxyTests/ModelsTests.swift
@@ -296,6 +296,16 @@ final class ModelsTests: XCTestCase {
         XCTAssertEqual(RequestType.requestLaunchApp.rawValue, "request_launch_app")
     }
 
+    func testConnectedEventAdvertisesSupportedCommands() {
+        let event = ConnectedEvent(id: 7)
+
+        XCTAssertEqual(event.type, "connected")
+        XCTAssertEqual(event.id, 7)
+        XCTAssertEqual(event.supportedCommands, RequestType.allCases.map(\.rawValue).sorted())
+        XCTAssertTrue(event.supportedCommands.contains("request_press_back"))
+        XCTAssertTrue(event.supportedCommands.contains("request_keyboard"))
+    }
+
     // MARK: - ResponseType Tests
 
     func testResponseTypeRawValues() {

--- a/src/features/observe/DeviceServiceUtils.ts
+++ b/src/features/observe/DeviceServiceUtils.ts
@@ -203,7 +203,19 @@ export function createMessage(
  *   cancelScreenshotBackoff → ensureConnected → register → send → await
  * flow used by WebSocket delegate methods.
  */
-export interface SendCommandOptions<T> {
+type RequiredKeys<T> = {
+  [K in keyof T]-?: object extends Pick<T, K> ? never : K
+}[keyof T];
+
+type RequiredNonBaseResultKeys<T> = Exclude<RequiredKeys<T>, keyof BaseResult>;
+
+type UnsupportedCommandErrorBuilder<T> = (messageType: string, error: string) => T;
+
+type UnsupportedCommandErrorOption<T> = [RequiredNonBaseResultKeys<T>] extends [never]
+  ? { unsupportedCommandError?: UnsupportedCommandErrorBuilder<T> }
+  : { unsupportedCommandError: UnsupportedCommandErrorBuilder<T> };
+
+interface SendCommandBaseOptions<T> {
   idPrefix: string;
   responseType: string;
   messageType: string;
@@ -216,13 +228,13 @@ export interface SendCommandOptions<T> {
   timeoutError?: (timeoutMs: number) => T;
   /** Custom not-connected-error builder for non-BaseResult shapes (e.g. carries `action` or `enabled`). */
   notConnectedError?: () => T;
-  /** Custom unsupported-command builder for non-BaseResult shapes (e.g. carries `open`). */
-  unsupportedCommandError?: (messageType: string, error: string) => T;
   /** Overrides the default "Not connected" message. Ignored when `notConnectedError` is set. */
   notConnectedMessage?: string;
   /** Human-readable label used in the default timeout error. Defaults to `responseType`. */
   errorLabel?: string;
 }
+
+export type SendCommandOptions<T> = SendCommandBaseOptions<T> & UnsupportedCommandErrorOption<T>;
 
 export async function sendCommand<T>(
   context: DelegateContext,

--- a/src/features/observe/DeviceServiceUtils.ts
+++ b/src/features/observe/DeviceServiceUtils.ts
@@ -288,12 +288,20 @@ export async function sendCommand<T>(
       totalTimeMs: timeout,
       error: `${label} timed out after ${timeout}ms`,
     } as T);
+  const responseErrorFactory = (error: string, totalTimeMs: number): T => options.unsupportedCommandError
+    ? options.unsupportedCommandError(options.messageType, error)
+    : ({
+      success: false,
+      totalTimeMs,
+      error,
+    } as T);
 
   const promise = context.requestManager.register<T>(
     requestId,
     options.responseType,
     options.timeoutMs,
     timeoutFactory,
+    responseErrorFactory,
   );
 
   const msg = createMessage(options.messageType, requestId, options.params);

--- a/src/features/observe/DeviceServiceUtils.ts
+++ b/src/features/observe/DeviceServiceUtils.ts
@@ -216,6 +216,8 @@ export interface SendCommandOptions<T> {
   timeoutError?: (timeoutMs: number) => T;
   /** Custom not-connected-error builder for non-BaseResult shapes (e.g. carries `action` or `enabled`). */
   notConnectedError?: () => T;
+  /** Custom unsupported-command builder for non-BaseResult shapes (e.g. carries `open`). */
+  unsupportedCommandError?: (messageType: string, error: string) => T;
   /** Overrides the default "Not connected" message. Ignored when `notConnectedError` is set. */
   notConnectedMessage?: string;
   /** Human-readable label used in the default timeout error. Defaults to `responseType`. */
@@ -242,6 +244,20 @@ export async function sendCommand<T>(
       success: false,
       totalTimeMs: 0,
       error: options.notConnectedMessage ?? "Not connected",
+    } as T;
+  }
+
+  if (context.isCommandSupported && !context.isCommandSupported(options.messageType)) {
+    const error = context.unsupportedCommandError
+      ? context.unsupportedCommandError(options.messageType)
+      : `${options.messageType} is not supported by the connected device service`;
+    if (options.unsupportedCommandError) {
+      return options.unsupportedCommandError(options.messageType, error);
+    }
+    return {
+      success: false,
+      totalTimeMs: 0,
+      error,
     } as T;
   }
 

--- a/src/features/observe/DeviceServiceUtils.ts
+++ b/src/features/observe/DeviceServiceUtils.ts
@@ -209,13 +209,23 @@ type RequiredKeys<T> = {
 
 type RequiredNonBaseResultKeys<T> = Exclude<RequiredKeys<T>, keyof BaseResult>;
 
+type NotConnectedErrorBuilder<T> = () => T;
+type TimeoutErrorBuilder<T> = (timeoutMs: number) => T;
 type UnsupportedCommandErrorBuilder<T> = (messageType: string, error: string) => T;
 
-type UnsupportedCommandErrorOption<T> = [RequiredNonBaseResultKeys<T>] extends [never]
-  ? { unsupportedCommandError?: UnsupportedCommandErrorBuilder<T> }
-  : { unsupportedCommandError: UnsupportedCommandErrorBuilder<T> };
+type CommandFallbackBuilders<T> = [RequiredNonBaseResultKeys<T>] extends [never]
+  ? {
+    notConnectedError?: NotConnectedErrorBuilder<T>;
+    timeoutError?: TimeoutErrorBuilder<T>;
+    unsupportedCommandError?: UnsupportedCommandErrorBuilder<T>;
+  }
+  : {
+    notConnectedError: NotConnectedErrorBuilder<T>;
+    timeoutError: TimeoutErrorBuilder<T>;
+    unsupportedCommandError: UnsupportedCommandErrorBuilder<T>;
+  };
 
-interface SendCommandBaseOptions<T> {
+interface SendCommandBaseOptions {
   idPrefix: string;
   responseType: string;
   messageType: string;
@@ -224,17 +234,13 @@ interface SendCommandBaseOptions<T> {
   perf?: PerformanceTracker;
   /** Defaults to true. Set false for endpoints that should not interrupt screenshot backoff. */
   cancelScreenshotBackoff?: boolean;
-  /** Custom timeout-error builder. Defaults to `{success:false, totalTimeMs, error: "<errorLabel> timed out after <ms>ms"}`. */
-  timeoutError?: (timeoutMs: number) => T;
-  /** Custom not-connected-error builder for non-BaseResult shapes (e.g. carries `action` or `enabled`). */
-  notConnectedError?: () => T;
   /** Overrides the default "Not connected" message. Ignored when `notConnectedError` is set. */
   notConnectedMessage?: string;
   /** Human-readable label used in the default timeout error. Defaults to `responseType`. */
   errorLabel?: string;
 }
 
-export type SendCommandOptions<T> = SendCommandBaseOptions<T> & UnsupportedCommandErrorOption<T>;
+export type SendCommandOptions<T> = SendCommandBaseOptions & CommandFallbackBuilders<T>;
 
 export async function sendCommand<T>(
   context: DelegateContext,

--- a/src/features/observe/ios/CtrlProxyClipboard.ts
+++ b/src/features/observe/ios/CtrlProxyClipboard.ts
@@ -45,6 +45,7 @@ export class CtrlProxyClipboard {
       perf,
       cancelScreenshotBackoff: false,
       notConnectedError: () => ({ success: false, action, totalTimeMs: 0, error: "Not connected" }),
+      unsupportedCommandError: (_messageType, error) => ({ success: false, action, totalTimeMs: 0, error }),
       timeoutError: timeout => ({
         success: false,
         action,

--- a/src/features/observe/ios/CtrlProxyKeyboard.ts
+++ b/src/features/observe/ios/CtrlProxyKeyboard.ts
@@ -32,6 +32,12 @@ export class CtrlProxyKeyboard {
         totalTimeMs: 0,
         error: "Not connected",
       }),
+      unsupportedCommandError: (_messageType, error) => ({
+        success: false,
+        open: false,
+        totalTimeMs: 0,
+        error,
+      }),
       timeoutError: timeout => ({
         success: false,
         open: false,

--- a/src/features/observe/ios/CtrlProxyNavigation.ts
+++ b/src/features/observe/ios/CtrlProxyNavigation.ts
@@ -89,6 +89,15 @@ export class CtrlProxyNavigation {
         value: 0,
         rotationPerformed: false,
       }),
+      unsupportedCommandError: (_messageType, error) => ({
+        success: false,
+        totalTimeMs: 0,
+        error,
+        previousOrientation: "",
+        currentOrientation: "",
+        value: 0,
+        rotationPerformed: false,
+      }),
       timeoutError: timeout => ({
         success: false,
         totalTimeMs: timeout,

--- a/src/features/observe/ios/CtrlProxyVoiceOver.ts
+++ b/src/features/observe/ios/CtrlProxyVoiceOver.ts
@@ -39,6 +39,7 @@ export class CtrlProxyVoiceOver {
       perf,
       cancelScreenshotBackoff: false,
       notConnectedError: () => ({ success: false, enabled: false, error: "Not connected to CtrlProxy" }),
+      unsupportedCommandError: (_messageType, error) => ({ success: false, enabled: false, totalTimeMs: 0, error }),
       timeoutError: () => ({ success: false, enabled: false, error: "Timeout waiting for voiceover_state_result" }),
     });
   }

--- a/src/features/observe/ios/IOSCtrlProxyClient.ts
+++ b/src/features/observe/ios/IOSCtrlProxyClient.ts
@@ -293,6 +293,7 @@ export class IOSCtrlProxyClient extends DeviceServiceClient implements IOSCtrlPr
 
   // Push update callbacks
   private onPushUpdateCallbacks: Set<(hierarchy: CtrlProxyHierarchy) => void> = new Set();
+  private supportedCommands: Set<string> | null = null;
 
   // Track last foreground bundle for performance monitoring
   private lastForegroundBundleId: string | null = null;
@@ -492,6 +493,8 @@ export class IOSCtrlProxyClient extends DeviceServiceClient implements IOSCtrlPr
       requestManager: this.requestManager,
       timer: this.timer,
       ensureConnected: perf => this.ensureConnected(perf),
+      isCommandSupported: messageType => this.isCommandSupported(messageType),
+      unsupportedCommandError: messageType => this.buildUnsupportedCommandError(messageType),
       cancelScreenshotBackoff: () => this.cancelScreenshotBackoff(),
     };
   }
@@ -613,6 +616,7 @@ export class IOSCtrlProxyClient extends DeviceServiceClient implements IOSCtrlPr
     this.cancelScreenshotBackoff();
     this.stopSdkEventPolling();
     this.cachedHierarchy = null;
+    this.supportedCommands = null;
     getDeviceDataStreamServer()?.onDeviceConnectionLost(this.device.deviceId);
 
     if (this.hierarchyNavigationDetector) {
@@ -951,6 +955,9 @@ export class IOSCtrlProxyClient extends DeviceServiceClient implements IOSCtrlPr
 
     // Handle push messages (no requestId)
     if (type === "connected") {
+      this.supportedCommands = Array.isArray(message.supportedCommands)
+        ? new Set(message.supportedCommands)
+        : null;
       logger.info(`[IOSCtrlProxyClient] Received connected message`);
       return;
     }
@@ -1138,7 +1145,7 @@ export class IOSCtrlProxyClient extends DeviceServiceClient implements IOSCtrlPr
             result = {
               success: false,
               totalTimeMs: message.totalTimeMs ?? 0,
-              error: message.error
+              error: this.rewriteUnknownCommandError(message.error)
             };
           } else {
             result = message;
@@ -1185,6 +1192,22 @@ export class IOSCtrlProxyClient extends DeviceServiceClient implements IOSCtrlPr
       }
       return;
     }
+  }
+
+  private isCommandSupported(messageType: string): boolean {
+    return this.supportedCommands === null || this.supportedCommands.has(messageType);
+  }
+
+  private buildUnsupportedCommandError(messageType: string): string {
+    return `iOS CtrlProxy runner does not support ${messageType}. The daemon and runner are out of sync; rebuild and redeploy the iOS CtrlProxy runner from this source checkout, or run the iOS hot-reload watcher with --manage-ios-runner.`;
+  }
+
+  private rewriteUnknownCommandError(error: string): string {
+    const match = /^Unknown command type: (.+)$/.exec(error);
+    if (!match) {
+      return error;
+    }
+    return `iOS CtrlProxy runner rejected ${match[1]} as unknown. The runner is likely older than this daemon; rebuild and redeploy the iOS CtrlProxy runner from this source checkout, or run the iOS hot-reload watcher with --manage-ios-runner.`;
   }
 
   /**

--- a/src/features/observe/ios/IOSCtrlProxyClient.ts
+++ b/src/features/observe/ios/IOSCtrlProxyClient.ts
@@ -1142,11 +1142,12 @@ export class IOSCtrlProxyClient extends DeviceServiceClient implements IOSCtrlPr
         default:
           // Handle error responses
           if (message.error) {
-            result = {
-              success: false,
-              totalTimeMs: message.totalTimeMs ?? 0,
-              error: this.rewriteUnknownCommandError(message.error)
-            };
+            this.requestManager.resolveError(
+              requestId,
+              this.rewriteUnknownCommandError(message.error),
+              message.totalTimeMs ?? 0
+            );
+            return;
           } else {
             result = message;
           }

--- a/src/features/observe/ios/types.ts
+++ b/src/features/observe/ios/types.ts
@@ -107,6 +107,8 @@ export interface WebSocketMessage {
   type: string;
   timestamp?: number;
   requestId?: string;
+  id?: number;
+  supportedCommands?: string[];
   data?: CtrlProxyHierarchy;
   performanceData?: CtrlProxyPerformanceSnapshot;
   format?: string;

--- a/src/features/observe/shared/SharedTextDelegate.ts
+++ b/src/features/observe/shared/SharedTextDelegate.ts
@@ -62,6 +62,7 @@ export class SharedTextDelegate {
       timeoutMs,
       perf,
       notConnectedError: () => ({ success: false, action, totalTimeMs: 0, error: "Not connected" }),
+      unsupportedCommandError: (_messageType, error) => ({ success: false, action, totalTimeMs: 0, error }),
       timeoutError: timeout => ({
         success: false,
         action,

--- a/src/features/observe/shared/types.ts
+++ b/src/features/observe/shared/types.ts
@@ -72,6 +72,10 @@ export interface DelegateContext {
   timer: Timer;
   /** Ensure the WebSocket connection is established */
   ensureConnected(perf?: PerformanceTracker): Promise<boolean>;
+  /** Return false when a connected service advertises that it cannot handle this wire command. */
+  isCommandSupported?(messageType: string): boolean;
+  /** Build a user-facing error for an advertised unsupported wire command. */
+  unsupportedCommandError?(messageType: string): string;
   /** Cancel any pending screenshot backoff captures */
   cancelScreenshotBackoff(): void;
 }

--- a/src/utils/RequestManager.ts
+++ b/src/utils/RequestManager.ts
@@ -11,12 +11,18 @@ interface PendingRequest<T> {
   reject: (error: Error) => void;
   timeoutId: ReturnType<Timer["setTimeout"]>;
   createdAt: number;
+  responseErrorFactory?: ResponseErrorFactory<T>;
 }
 
 /**
  * Default error result factory for timed-out requests.
  */
 type TimeoutErrorFactory<T> = (requestId: string, type: string, timeoutMs: number) => T;
+
+/**
+ * Error result factory for responses that fail before the expected result type is emitted.
+ */
+type ResponseErrorFactory<T> = (error: string, totalTimeMs: number) => T;
 
 /**
  * Manages pending requests with automatic timeout handling.
@@ -60,7 +66,8 @@ export class RequestManager {
     id: string,
     type: string,
     timeoutMs: number,
-    timeoutErrorFactory: TimeoutErrorFactory<T>
+    timeoutErrorFactory: TimeoutErrorFactory<T>,
+    responseErrorFactory?: ResponseErrorFactory<T>
   ): Promise<T> {
     return new Promise<T>((resolve, reject) => {
       // Set up timeout
@@ -80,7 +87,8 @@ export class RequestManager {
         resolve: resolve as (result: unknown) => void,
         reject,
         timeoutId,
-        createdAt: this.timer.now()
+        createdAt: this.timer.now(),
+        responseErrorFactory: responseErrorFactory as ResponseErrorFactory<unknown> | undefined,
       });
 
       logger.debug(`[RequestManager] Registered request: ${type} (id: ${id}, timeout: ${timeoutMs}ms)`);
@@ -109,6 +117,30 @@ export class RequestManager {
     // Resolve the promise
     const duration = this.timer.now() - request.createdAt;
     logger.debug(`[RequestManager] Resolved request: ${request.type} (id: ${id}, duration: ${duration}ms)`);
+    request.resolve(result);
+
+    return true;
+  }
+
+  /**
+   * Resolve a pending request with an error response, preserving request-specific
+   * result shape when the caller registered an error result factory.
+   */
+  resolveError(id: string, error: string, totalTimeMs: number = 0): boolean {
+    const request = this.pending.get(id);
+    if (!request) {
+      logger.debug(`[RequestManager] No pending request found for id: ${id} (may have timed out)`);
+      return false;
+    }
+
+    this.timer.clearTimeout(request.timeoutId);
+    this.pending.delete(id);
+
+    const result = request.responseErrorFactory
+      ? request.responseErrorFactory(error, totalTimeMs)
+      : { success: false, totalTimeMs, error };
+    const duration = this.timer.now() - request.createdAt;
+    logger.debug(`[RequestManager] Resolved errored request: ${request.type} (id: ${id}, duration: ${duration}ms)`);
     request.resolve(result);
 
     return true;

--- a/test/features/observe/ios/IOSCtrlProxyClient.test.ts
+++ b/test/features/observe/ios/IOSCtrlProxyClient.test.ts
@@ -715,6 +715,86 @@ describe("IOSCtrlProxyClient", function() {
         await testClient.close();
       }
     });
+
+    test("preserves required fields for old-runner unknown command errors", async function() {
+      const testTimer = fakeTimer;
+
+      const { factory, getSocket } = createCapturingWebSocketFactory(testTimer);
+      const testClient = IOSCtrlProxyClient.createForTesting(
+        testDevice,
+        serverPort,
+        factory,
+        testTimer
+      );
+
+      try {
+        await testClient.ensureConnected();
+        const socket = await waitForSocket(getSocket);
+        expect(socket).not.toBeNull();
+        await waitForSocketOpen(socket);
+
+        const keyboardPromise = testClient.requestKeyboard("detect", 5000);
+        await waitForSentMessages(socket as CapturingWebSocket, 1);
+        const keyboardMessage = JSON.parse(socket!.sentMessages[0]);
+        socket!.simulateMessage(JSON.stringify({
+          type: "error",
+          requestId: keyboardMessage.requestId,
+          error: "Unknown command type: request_keyboard",
+        }));
+        const keyboard = await keyboardPromise;
+        expect(keyboard.success).toBe(false);
+        expect(keyboard.open).toBe(false);
+        expect(keyboard.totalTimeMs).toBe(0);
+        expect(keyboard.error).toContain("runner is likely older");
+
+        const imeActionPromise = testClient.requestImeAction("done", 5000);
+        await waitForSentMessages(socket as CapturingWebSocket, 2);
+        const imeActionMessage = JSON.parse(socket!.sentMessages[1]);
+        socket!.simulateMessage(JSON.stringify({
+          type: "error",
+          requestId: imeActionMessage.requestId,
+          error: "Unknown command type: request_ime_action",
+        }));
+        const imeAction = await imeActionPromise;
+        expect(imeAction.success).toBe(false);
+        expect(imeAction.action).toBe("done");
+        expect(imeAction.totalTimeMs).toBe(0);
+        expect(imeAction.error).toContain("runner is likely older");
+
+        const rotatePromise = testClient.requestRotate("landscape", 5000);
+        await waitForSentMessages(socket as CapturingWebSocket, 3);
+        const rotateMessage = JSON.parse(socket!.sentMessages[2]);
+        socket!.simulateMessage(JSON.stringify({
+          type: "error",
+          requestId: rotateMessage.requestId,
+          error: "Unknown command type: request_rotate",
+        }));
+        const rotate = await rotatePromise;
+        expect(rotate.success).toBe(false);
+        expect(rotate.previousOrientation).toBe("");
+        expect(rotate.currentOrientation).toBe("");
+        expect(rotate.value).toBe(0);
+        expect(rotate.rotationPerformed).toBe(false);
+        expect(rotate.totalTimeMs).toBe(0);
+        expect(rotate.error).toContain("runner is likely older");
+
+        const clipboardPromise = testClient.requestClipboard("get", undefined, 5000);
+        await waitForSentMessages(socket as CapturingWebSocket, 4);
+        const clipboardMessage = JSON.parse(socket!.sentMessages[3]);
+        socket!.simulateMessage(JSON.stringify({
+          type: "error",
+          requestId: clipboardMessage.requestId,
+          error: "Unknown command type: request_clipboard",
+        }));
+        const clipboard = await clipboardPromise;
+        expect(clipboard.success).toBe(false);
+        expect(clipboard.action).toBe("get");
+        expect(clipboard.totalTimeMs).toBe(0);
+        expect(clipboard.error).toContain("runner is likely older");
+      } finally {
+        await testClient.close();
+      }
+    });
   });
 
   describe("requestRecentApps", function() {

--- a/test/features/observe/ios/IOSCtrlProxyClient.test.ts
+++ b/test/features/observe/ios/IOSCtrlProxyClient.test.ts
@@ -537,6 +537,41 @@ describe("IOSCtrlProxyClient", function() {
         await testClient.close();
       }
     });
+
+    test("returns a clear skew error when advertised runner capabilities exclude keyboard", async function() {
+      const testTimer = fakeTimer;
+
+      const { factory, getSocket } = createCapturingWebSocketFactory(testTimer);
+      const testClient = IOSCtrlProxyClient.createForTesting(
+        testDevice,
+        serverPort,
+        factory,
+        testTimer
+      );
+
+      try {
+        await testClient.ensureConnected();
+        const socket = await waitForSocket(getSocket);
+        expect(socket).not.toBeNull();
+        await waitForSocketOpen(socket);
+
+        socket!.simulateMessage(JSON.stringify({
+          type: "connected",
+          id: 1,
+          supportedCommands: ["request_recent_apps"]
+        }));
+
+        const result = await testClient.requestKeyboard("detect", 5000);
+
+        expect(result.success).toBe(false);
+        expect(result.open).toBe(false);
+        expect(result.error).toContain("does not support request_keyboard");
+        expect(result.error).toContain("out of sync");
+        expect(socket!.sentMessages).toHaveLength(0);
+      } finally {
+        await testClient.close();
+      }
+    });
   });
 
   describe("requestRecentApps", function() {
@@ -647,6 +682,44 @@ describe("IOSCtrlProxyClient", function() {
         const result = await resultPromise;
         expect(result.success).toBe(true);
         expect(result.totalTimeMs).toBe(80);
+      } finally {
+        await testClient.close();
+      }
+    });
+
+    test("rewrites old-runner unknown command responses into an actionable skew error", async function() {
+      const testTimer = fakeTimer;
+
+      const { factory, getSocket } = createCapturingWebSocketFactory(testTimer);
+      const testClient = IOSCtrlProxyClient.createForTesting(
+        testDevice,
+        serverPort,
+        factory,
+        testTimer
+      );
+
+      try {
+        const resultPromise = testClient.requestPressBack(5000);
+        const socket = await waitForSocket(getSocket);
+        expect(socket).not.toBeNull();
+        await waitForSocketOpen(socket);
+        await waitForSentMessages(socket, 1);
+
+        const sentMessage = JSON.parse(socket!.sentMessages[0]);
+        expect(sentMessage.type).toBe("request_press_back");
+
+        socket!.simulateMessage(JSON.stringify({
+          type: "error",
+          requestId: sentMessage.requestId,
+          error: "Unknown command type: request_press_back",
+          totalTimeMs: 3
+        }));
+
+        const result = await resultPromise;
+        expect(result.success).toBe(false);
+        expect(result.totalTimeMs).toBe(3);
+        expect(result.error).toContain("rejected request_press_back as unknown");
+        expect(result.error).toContain("likely older than this daemon");
       } finally {
         await testClient.close();
       }

--- a/test/features/observe/ios/IOSCtrlProxyClient.test.ts
+++ b/test/features/observe/ios/IOSCtrlProxyClient.test.ts
@@ -574,6 +574,63 @@ describe("IOSCtrlProxyClient", function() {
     });
   });
 
+  describe("unsupported command result shapes", function() {
+    test("preserves required fields for non-BaseResult command contracts", async function() {
+      const testTimer = fakeTimer;
+
+      const { factory, getSocket } = createCapturingWebSocketFactory(testTimer);
+      const testClient = IOSCtrlProxyClient.createForTesting(
+        testDevice,
+        serverPort,
+        factory,
+        testTimer
+      );
+
+      try {
+        await testClient.ensureConnected();
+        const socket = await waitForSocket(getSocket);
+        expect(socket).not.toBeNull();
+        await waitForSocketOpen(socket);
+
+        socket!.simulateMessage(JSON.stringify({
+          type: "connected",
+          id: 1,
+          supportedCommands: ["request_recent_apps"]
+        }));
+
+        const imeAction = await testClient.requestImeAction("done", 5000);
+        expect(imeAction.success).toBe(false);
+        expect(imeAction.action).toBe("done");
+        expect(imeAction.totalTimeMs).toBe(0);
+        expect(imeAction.error).toContain("does not support request_ime_action");
+
+        const rotate = await testClient.requestRotate("landscape", 5000);
+        expect(rotate.success).toBe(false);
+        expect(rotate.previousOrientation).toBe("");
+        expect(rotate.currentOrientation).toBe("");
+        expect(rotate.value).toBe(0);
+        expect(rotate.rotationPerformed).toBe(false);
+        expect(rotate.error).toContain("does not support request_rotate");
+
+        const clipboard = await testClient.requestClipboard("get", undefined, 5000);
+        expect(clipboard.success).toBe(false);
+        expect(clipboard.action).toBe("get");
+        expect(clipboard.totalTimeMs).toBe(0);
+        expect(clipboard.error).toContain("does not support request_clipboard");
+
+        const voiceOver = await testClient.requestVoiceOverState(5000);
+        expect(voiceOver.success).toBe(false);
+        expect(voiceOver.enabled).toBe(false);
+        expect(voiceOver.totalTimeMs).toBe(0);
+        expect(voiceOver.error).toContain("does not support get_voiceover_state");
+
+        expect(socket!.sentMessages).toHaveLength(0);
+      } finally {
+        await testClient.close();
+      }
+    });
+  });
+
   describe("requestRecentApps", function() {
     test("should send recent apps request and return result", async function() {
       const testTimer = fakeTimer;

--- a/test/features/observe/ios/IOSCtrlProxyClient.test.ts
+++ b/test/features/observe/ios/IOSCtrlProxyClient.test.ts
@@ -574,8 +574,8 @@ describe("IOSCtrlProxyClient", function() {
     });
   });
 
-  describe("unsupported command result shapes", function() {
-    test("preserves required fields for non-BaseResult command contracts", async function() {
+  describe("command fallback result shapes", function() {
+    test("preserves required fields for unsupported non-BaseResult command contracts", async function() {
       const testTimer = fakeTimer;
 
       const { factory, getSocket } = createCapturingWebSocketFactory(testTimer);
@@ -625,6 +625,92 @@ describe("IOSCtrlProxyClient", function() {
         expect(voiceOver.error).toContain("does not support get_voiceover_state");
 
         expect(socket!.sentMessages).toHaveLength(0);
+      } finally {
+        await testClient.close();
+      }
+    });
+
+    test("preserves required fields for timed out non-BaseResult command contracts", async function() {
+      const testTimer = new FakeTimer();
+
+      const { factory, getSocket } = createCapturingWebSocketFactory(testTimer);
+      const testClient = IOSCtrlProxyClient.createForTesting(
+        testDevice,
+        serverPort,
+        factory,
+        testTimer
+      );
+
+      try {
+        await testClient.ensureConnected();
+        const socket = await waitForSocket(getSocket);
+        expect(socket).not.toBeNull();
+        await waitForSocketOpen(socket);
+
+        const imeActionPromise = testClient.requestImeAction("done", 100);
+        await waitForSentMessages(socket as CapturingWebSocket, 1);
+        testTimer.advanceTime(100);
+        const imeAction = await imeActionPromise;
+        expect(imeAction.success).toBe(false);
+        expect(imeAction.action).toBe("done");
+        expect(imeAction.totalTimeMs).toBe(100);
+        expect(imeAction.error).toContain("IME action timed out");
+
+        const rotatePromise = testClient.requestRotate("landscape", 100);
+        await waitForSentMessages(socket as CapturingWebSocket, 2);
+        testTimer.advanceTime(100);
+        const rotate = await rotatePromise;
+        expect(rotate.success).toBe(false);
+        expect(rotate.previousOrientation).toBe("");
+        expect(rotate.currentOrientation).toBe("");
+        expect(rotate.value).toBe(0);
+        expect(rotate.rotationPerformed).toBe(false);
+        expect(rotate.totalTimeMs).toBe(100);
+        expect(rotate.error).toContain("Rotate timed out");
+
+        const clipboardPromise = testClient.requestClipboard("get", undefined, 100);
+        await waitForSentMessages(socket as CapturingWebSocket, 3);
+        testTimer.advanceTime(100);
+        const clipboard = await clipboardPromise;
+        expect(clipboard.success).toBe(false);
+        expect(clipboard.action).toBe("get");
+        expect(clipboard.totalTimeMs).toBe(100);
+        expect(clipboard.error).toContain("Clipboard operation timed out");
+      } finally {
+        await testClient.close();
+      }
+    });
+
+    test("preserves required fields for not-connected non-BaseResult command contracts", async function() {
+      const testTimer = fakeTimer;
+      const testClient = IOSCtrlProxyClient.createForTesting(
+        testDevice,
+        serverPort,
+        createInstantFailureWebSocketFactory(testTimer),
+        testTimer
+      );
+
+      try {
+        const imeAction = await testClient.requestImeAction("done", 100);
+        expect(imeAction.success).toBe(false);
+        expect(imeAction.action).toBe("done");
+        expect(imeAction.totalTimeMs).toBe(0);
+        expect(imeAction.error).toBe("Not connected");
+
+        const rotate = await testClient.requestRotate("landscape", 100);
+        expect(rotate.success).toBe(false);
+        expect(rotate.previousOrientation).toBe("");
+        expect(rotate.currentOrientation).toBe("");
+        expect(rotate.value).toBe(0);
+        expect(rotate.rotationPerformed).toBe(false);
+        expect(rotate.totalTimeMs).toBe(0);
+        expect(rotate.error).toBe("Not connected");
+
+        const clipboard = await testClient.requestClipboard("get", undefined, 100);
+        expect(clipboard.success).toBe(false);
+        expect(clipboard.action).toBe("get");
+        expect(clipboard.totalTimeMs).toBe(0);
+        expect(clipboard.error).toBe("Not connected");
       } finally {
         await testClient.close();
       }


### PR DESCRIPTION
## Summary

- fixes #2539 by having new iOS CtrlProxy runners advertise supported command types in the `connected` handshake
- checks advertised iOS runner capabilities before sending commands and returns a clear daemon/runner skew error when a command is unsupported
- rewrites old-runner `Unknown command type: ...` responses into an actionable stale-runner error
- adds TypeScript and Swift regression coverage for the handshake and stale-runner paths

## Self-review

- Reuse/simplification pass kept the enforcement in shared `sendCommand` plumbing instead of duplicating checks in each iOS delegate.
- Bug/regression pass added backward compatibility for older runners that do not send `supportedCommands`.
- Follow-up test added during self-review: `ConnectedEvent` now has direct Swift coverage for advertised command coverage.

## Validation

- `bun test test/features/observe/ios/IOSCtrlProxyClient.test.ts`
- `swift test --filter ModelsTests` from `ios/control-proxy`
- `bun run lint`
- `bun run build`
- `bash scripts/ios/swift-test.sh`

Note: `bun install --frozen-lockfile` initially hit an existing `heapdump` native build incompatibility with Node 26, but dependencies needed for the test/build commands were installed and the validation above passed.
