### PR TITLE
[codex] fix iOS SDK hierarchy scoping

### DIFF
--- a/ios/auto-mobile-sdk/Sources/AutoMobileSDK/ViewHierarchy/SdkHierarchyServer.swift
+++ b/ios/auto-mobile-sdk/Sources/AutoMobileSDK/ViewHierarchy/SdkHierarchyServer.swift
@@ -6,7 +6,7 @@ import Network
 /// Serves view hierarchy snapshots to control-proxy on demand.
 ///
 /// Endpoints:
-/// - `GET /health` → `{"status":"ok"}`
+/// - `GET /health` → `{"status":"ok","bundleId":"<sdk app bundle id>"}`
 /// - `GET /hierarchy` → latest cached hierarchy (fast, no main-thread work)
 /// - `GET /hierarchy/fresh` → synchronous main-thread walk (slower but guaranteed fresh)
 final class SdkHierarchyServer: @unchecked Sendable {
@@ -94,11 +94,20 @@ final class SdkHierarchyServer: @unchecked Sendable {
             } else if request.contains("GET /hierarchy") {
                 self.handleCachedHierarchy(connection)
             } else if request.contains("GET /health") {
-                self.sendResponse(connection, statusCode: 200, body: Data("{\"status\":\"ok\"}".utf8))
+                self.handleHealth(connection)
             } else {
                 self.sendResponse(connection, statusCode: 404, body: Data("{\"error\":\"not_found\"}".utf8))
             }
         }
+    }
+
+    private func handleHealth(_ connection: NWConnection) {
+        let payload = HealthPayload(status: "ok", bundleId: tracker?.bundleId)
+        guard let data = try? JSONEncoder().encode(payload) else {
+            sendResponse(connection, statusCode: 500, body: Data("{\"error\":\"encode_failed\"}".utf8))
+            return
+        }
+        sendResponse(connection, statusCode: 200, body: data)
     }
 
     private func handleCachedHierarchy(_ connection: NWConnection) {
@@ -152,5 +161,10 @@ final class SdkHierarchyServer: @unchecked Sendable {
             connection.cancel()
         })
     }
+}
+
+private struct HealthPayload: Encodable {
+    let status: String
+    let bundleId: String?
 }
 #endif

--- a/ios/auto-mobile-sdk/Sources/AutoMobileSDK/ViewHierarchy/ViewHierarchyTracker.swift
+++ b/ios/auto-mobile-sdk/Sources/AutoMobileSDK/ViewHierarchy/ViewHierarchyTracker.swift
@@ -70,6 +70,10 @@ public final class ViewHierarchyTracker: @unchecked Sendable {
         return _latestHierarchy
     }
 
+    var bundleId: String? {
+        AutoMobileSDK.shared.bundleId
+    }
+
     /// Performs a synchronous main-thread walk and returns the result.
     /// Must NOT be called from the main thread (will deadlock).
     public func walkNow() -> SdkViewHierarchy {

--- a/ios/control-proxy/Sources/CtrlProxy/CommandHandler.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/CommandHandler.swift
@@ -204,9 +204,7 @@ public class CommandHandler: CommandHandling {
             throw CommandError.executionFailed("Failed to get view hierarchy: \(error.localizedDescription)")
         }
 
-        // Merge with SDK hierarchy: prefer cached (fast), fall back to fresh pull if no cache
-        let sdkHierarchy: SdkViewHierarchy? = sdkHierarchyCache?.latest
-            ?? sdkHierarchyClient?.fetchFreshHierarchy()
+        let sdkHierarchy = matchingSdkHierarchy(for: hierarchy)
         let enriched = HierarchyMerger.merge(xcuitest: hierarchy, sdk: sdkHierarchy)
 
         // Get accumulated timing for this operation
@@ -217,6 +215,50 @@ public class CommandHandler: CommandHandling {
             data: enriched,
             perfTiming: perfTimings?.first
         )
+    }
+
+    private func matchingSdkHierarchy(for hierarchy: ViewHierarchy) -> SdkViewHierarchy? {
+        guard let foregroundBundleId = normalizedBundleId(hierarchy.packageName) else {
+            return nil
+        }
+
+        if let cached = sdkHierarchyCache?.latest {
+            if sdkHierarchy(cached, matches: foregroundBundleId) {
+                return cached
+            }
+            guard sdkServerMatchesForegroundBundleId(foregroundBundleId) else {
+                return nil
+            }
+        } else if sdkHierarchyClient != nil {
+            guard sdkServerMatchesForegroundBundleId(foregroundBundleId) else {
+                return nil
+            }
+        }
+
+        guard let fresh = sdkHierarchyClient?.fetchFreshHierarchy(),
+              sdkHierarchy(fresh, matches: foregroundBundleId) else {
+            return nil
+        }
+        return fresh
+    }
+
+    private func sdkServerMatchesForegroundBundleId(_ foregroundBundleId: String) -> Bool {
+        guard let serverBundleId = normalizedBundleId(sdkHierarchyClient?.fetchServerInfo()?.bundleId) else {
+            return false
+        }
+        return serverBundleId == foregroundBundleId
+    }
+
+    private func sdkHierarchy(_ sdkHierarchy: SdkViewHierarchy, matches foregroundBundleId: String) -> Bool {
+        normalizedBundleId(sdkHierarchy.bundleId) == foregroundBundleId
+    }
+
+    private func normalizedBundleId(_ bundleId: String?) -> String? {
+        guard let normalized = bundleId?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !normalized.isEmpty else {
+            return nil
+        }
+        return normalized
     }
 
     private func handleRequestScreenshot(_ request: WebSocketRequest, startTime _: Date) throws -> ScreenshotResponse {

--- a/ios/control-proxy/Sources/CtrlProxy/Fakes.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/Fakes.swift
@@ -687,9 +687,11 @@ public class FakeSdkHierarchyFetcher: SdkHierarchyFetching {
     private let lock = NSLock()
     private var _cachedHierarchy: SdkViewHierarchy?
     private var _freshHierarchy: SdkViewHierarchy?
+    private var _serverInfo: SdkHierarchyServerInfo?
     private var _isAvailable: Bool = false
     private var _fetchCallCount = 0
     private var _fetchFreshCallCount = 0
+    private var _fetchServerInfoCallCount = 0
     private var _isAvailableCallCount = 0
 
     public init() {}
@@ -714,6 +716,12 @@ public class FakeSdkHierarchyFetcher: SdkHierarchyFetching {
         lock.unlock()
     }
 
+    public func setServerInfo(_ serverInfo: SdkHierarchyServerInfo?) {
+        lock.lock()
+        _serverInfo = serverInfo
+        lock.unlock()
+    }
+
     // MARK: - Assertions
 
     public var fetchCallCount: Int {
@@ -728,6 +736,12 @@ public class FakeSdkHierarchyFetcher: SdkHierarchyFetching {
         return _fetchFreshCallCount
     }
 
+    public var fetchServerInfoCallCount: Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return _fetchServerInfoCallCount
+    }
+
     public var isAvailableCallCount: Int {
         lock.lock()
         defer { lock.unlock() }
@@ -738,6 +752,7 @@ public class FakeSdkHierarchyFetcher: SdkHierarchyFetching {
         lock.lock()
         _fetchCallCount = 0
         _fetchFreshCallCount = 0
+        _fetchServerInfoCallCount = 0
         _isAvailableCallCount = 0
         lock.unlock()
     }
@@ -760,10 +775,18 @@ public class FakeSdkHierarchyFetcher: SdkHierarchyFetching {
         return result
     }
 
+    public func fetchServerInfo() -> SdkHierarchyServerInfo? {
+        lock.lock()
+        _fetchServerInfoCallCount += 1
+        let result = _serverInfo
+        lock.unlock()
+        return result
+    }
+
     public func isAvailable() -> Bool {
         lock.lock()
         _isAvailableCallCount += 1
-        let result = _isAvailable
+        let result = _serverInfo != nil || _isAvailable
         lock.unlock()
         return result
     }

--- a/ios/control-proxy/Sources/CtrlProxy/Protocols.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/Protocols.swift
@@ -222,6 +222,8 @@ public protocol SdkHierarchyFetching {
     func fetchHierarchy() -> SdkViewHierarchy?
     /// Request a fresh hierarchy walk (slower).
     func fetchFreshHierarchy() -> SdkViewHierarchy?
+    /// Fetch lightweight server metadata, including the owning app bundle ID.
+    func fetchServerInfo() -> SdkHierarchyServerInfo?
     /// Whether the SDK hierarchy server is reachable.
     func isAvailable() -> Bool
 }

--- a/ios/control-proxy/Sources/CtrlProxy/SdkHierarchyClient.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/SdkHierarchyClient.swift
@@ -25,9 +25,15 @@ public final class SdkHierarchyClient: SdkHierarchyFetching, @unchecked Sendable
         return fetchSync(path: "/hierarchy/fresh")
     }
 
+    /// Fetch lightweight SDK server metadata without walking or serializing the view tree.
+    public func fetchServerInfo() -> SdkHierarchyServerInfo? {
+        guard let data = requestSync(path: "/health", session: healthSession) else { return nil }
+        return try? JSONDecoder().decode(SdkHierarchyServerInfo.self, from: data)
+    }
+
     /// Whether the SDK hierarchy server is reachable.
     public func isAvailable() -> Bool {
-        return requestSync(path: "/health", session: healthSession) != nil
+        return fetchServerInfo() != nil
     }
 
     // MARK: - Private

--- a/ios/control-proxy/Sources/CtrlProxy/SdkHierarchyModels.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/SdkHierarchyModels.swift
@@ -13,6 +13,17 @@ public struct SdkViewHierarchy: Codable, Sendable {
     public let root: SdkViewNode?
 }
 
+/// Lightweight metadata exposed by the SDK hierarchy server.
+public struct SdkHierarchyServerInfo: Codable, Sendable {
+    public let status: String
+    public let bundleId: String?
+
+    public init(status: String, bundleId: String?) {
+        self.status = status
+        self.bundleId = bundleId
+    }
+}
+
 /// A single node in the SDK's UIView hierarchy tree.
 public struct SdkViewNode: Codable, Sendable {
     public let className: String

--- a/ios/control-proxy/Tests/CtrlProxyTests/CommandHandlerTests.swift
+++ b/ios/control-proxy/Tests/CtrlProxyTests/CommandHandlerTests.swift
@@ -41,6 +41,33 @@ final class CommandHandlerTests: XCTestCase {
         return typed
     }
 
+    private func makeHierarchy(packageName: String?) -> ViewHierarchy {
+        ViewHierarchy(
+            packageName: packageName,
+            hierarchy: UIElementInfo(
+                text: "Root",
+                className: "UIView",
+                bounds: ElementBounds(left: 0, top: 0, right: 375, bottom: 812)
+            ),
+            windowInfo: WindowInfo(id: 0, type: 1, isActive: true, isFocused: true)
+        )
+    }
+
+    private func makeSdkHierarchy(bundleId: String?) -> SdkViewHierarchy {
+        SdkViewHierarchy(
+            timestamp: 1000,
+            bundleId: bundleId,
+            screenScale: 3.0,
+            screenWidth: 375,
+            screenHeight: 812,
+            root: SdkViewNode(
+                className: "UIView",
+                bounds: SdkBounds(left: 0, top: 0, right: 375, bottom: 812),
+                backgroundColor: "#123456FF"
+            )
+        )
+    }
+
     // MARK: - Hierarchy Request Tests
 
     func testRequestHierarchyIncludesPerfTiming() {
@@ -108,6 +135,104 @@ final class CommandHandlerTests: XCTestCase {
         // Should have extraction as a child
         let extractionChild = perfTiming?.children?.first { $0.name == "extraction" }
         XCTAssertNotNil(extractionChild, "Expected 'extraction' child in perf timing")
+    }
+
+    func testRequestHierarchyMergesCachedSdkHierarchyForForegroundBundle() {
+        let cache = FakeSdkHierarchyCache()
+        cache.update(makeSdkHierarchy(bundleId: "com.test.app"))
+        commandHandler = CommandHandler.createForTesting(
+            elementLocator: fakeElementLocator,
+            gesturePerformer: fakeGesturePerformer,
+            perfProvider: perfProvider,
+            sdkHierarchyCache: cache
+        )
+        fakeElementLocator.setHierarchy(makeHierarchy(packageName: "com.test.app"))
+
+        let request = WebSocketRequest(
+            type: "request_hierarchy",
+            requestId: "test-sdk-match"
+        )
+
+        guard let hierarchyResponse = handleRequest(request, as: HierarchyUpdateResponse.self) else { return }
+
+        XCTAssertEqual(hierarchyResponse.data?.packageName, "com.test.app")
+        XCTAssertEqual(hierarchyResponse.data?.hierarchy?.extras?["sdk.backgroundColor"], "#123456FF")
+    }
+
+    func testRequestHierarchySkipsCachedSdkHierarchyForDifferentForegroundBundle() {
+        let fetcher = FakeSdkHierarchyFetcher()
+        fetcher.setServerInfo(SdkHierarchyServerInfo(status: "ok", bundleId: "dev.sdk.app"))
+
+        let cache = FakeSdkHierarchyCache()
+        cache.update(makeSdkHierarchy(bundleId: "dev.sdk.app"))
+        commandHandler = CommandHandler.createForTesting(
+            elementLocator: fakeElementLocator,
+            gesturePerformer: fakeGesturePerformer,
+            perfProvider: perfProvider,
+            sdkHierarchyClient: fetcher,
+            sdkHierarchyCache: cache
+        )
+        fakeElementLocator.setHierarchy(makeHierarchy(packageName: "com.apple.Preferences"))
+
+        let request = WebSocketRequest(
+            type: "request_hierarchy",
+            requestId: "test-sdk-mismatch"
+        )
+
+        guard let hierarchyResponse = handleRequest(request, as: HierarchyUpdateResponse.self) else { return }
+
+        XCTAssertEqual(hierarchyResponse.data?.packageName, "com.apple.Preferences")
+        XCTAssertNil(hierarchyResponse.data?.hierarchy?.extras?["sdk.backgroundColor"])
+        XCTAssertEqual(fetcher.fetchServerInfoCallCount, 1)
+        XCTAssertEqual(fetcher.fetchFreshCallCount, 0)
+    }
+
+    func testRequestHierarchyFetchesFreshSdkHierarchyOnlyWhenServerBundleMatchesForeground() {
+        let fetcher = FakeSdkHierarchyFetcher()
+        fetcher.setServerInfo(SdkHierarchyServerInfo(status: "ok", bundleId: "com.test.app"))
+        fetcher.setFreshHierarchy(makeSdkHierarchy(bundleId: "com.test.app"))
+        commandHandler = CommandHandler.createForTesting(
+            elementLocator: fakeElementLocator,
+            gesturePerformer: fakeGesturePerformer,
+            perfProvider: perfProvider,
+            sdkHierarchyClient: fetcher
+        )
+        fakeElementLocator.setHierarchy(makeHierarchy(packageName: "com.test.app"))
+
+        let request = WebSocketRequest(
+            type: "request_hierarchy",
+            requestId: "test-sdk-fresh"
+        )
+
+        guard let hierarchyResponse = handleRequest(request, as: HierarchyUpdateResponse.self) else { return }
+
+        XCTAssertEqual(hierarchyResponse.data?.hierarchy?.extras?["sdk.backgroundColor"], "#123456FF")
+        XCTAssertEqual(fetcher.fetchServerInfoCallCount, 1)
+        XCTAssertEqual(fetcher.fetchFreshCallCount, 1)
+    }
+
+    func testRequestHierarchyDoesNotFetchFreshSdkHierarchyWhenServerBundleDiffers() {
+        let fetcher = FakeSdkHierarchyFetcher()
+        fetcher.setServerInfo(SdkHierarchyServerInfo(status: "ok", bundleId: "dev.sdk.app"))
+        fetcher.setFreshHierarchy(makeSdkHierarchy(bundleId: "dev.sdk.app"))
+        commandHandler = CommandHandler.createForTesting(
+            elementLocator: fakeElementLocator,
+            gesturePerformer: fakeGesturePerformer,
+            perfProvider: perfProvider,
+            sdkHierarchyClient: fetcher
+        )
+        fakeElementLocator.setHierarchy(makeHierarchy(packageName: "com.apple.Preferences"))
+
+        let request = WebSocketRequest(
+            type: "request_hierarchy",
+            requestId: "test-sdk-no-fresh"
+        )
+
+        guard let hierarchyResponse = handleRequest(request, as: HierarchyUpdateResponse.self) else { return }
+
+        XCTAssertNil(hierarchyResponse.data?.hierarchy?.extras?["sdk.backgroundColor"])
+        XCTAssertEqual(fetcher.fetchServerInfoCallCount, 1)
+        XCTAssertEqual(fetcher.fetchFreshCallCount, 0)
     }
 
     func testRequestHierarchyError() {


### PR DESCRIPTION
## Summary

- Fixes #2540 by scoping iOS SDK hierarchy enrichment to the foreground app.
- Adds lightweight SDK hierarchy server ownership metadata through `/health`.
- Prevents observes of unrelated foreground apps from merging or fresh-fetching a background SDK app hierarchy.
- Adds focused CtrlProxy unit tests for matching cached SDK data, mismatched cached data, matching fresh data, and skipped fresh fetches.

## Root Cause

CtrlProxy previously merged `sdkHierarchyCache.latest ?? sdkHierarchyClient.fetchFreshHierarchy()` into every XCUITest hierarchy without checking whether the SDK server on port 8766 belonged to the foreground app. If an SDK app stayed running in the background, observes of Settings or another non-SDK app could include the stale SDK tree.

## Validation

- `swift test --package-path ios/control-proxy --filter CommandHandlerTests`
- `swift test --package-path ios/auto-mobile-sdk`
- `swift test --package-path ios/control-proxy -Xswiftc -warnings-as-errors --filter CommandHandlerTests`
- `bash scripts/ios/swift-build.sh`

## Notes

- `bash scripts/ios/api-check.sh` currently fails due pre-existing SDK API dump drift unrelated to this change.
- `bash scripts/ios/swift-test.sh` passed the touched packages, but failed in `XCTestRunner` live Reminders integration because the simulator flow could not find text `Done`.
