### PR TITLE
fix(ios): register notifyutil state writes

### DIFF
--- a/docs/design-docs/plat/ios/simctl.md
+++ b/docs/design-docs/plat/ios/simctl.md
@@ -82,8 +82,10 @@ BiometricKit Darwin notifications inside the simulator via
 
 ### How it works
 
-1. **Enroll** — `notifyutil -s com.apple.BiometricKit.enrollmentChanged 1` then
-   `-p com.apple.BiometricKit.enrollmentChanged` ensures a biometry is enrolled.
+1. **Enroll** — a registered `notifyutil` set/read/post on
+   `com.apple.BiometricKit.enrollmentChanged` ensures a biometry is enrolled.
+   The registration is required because `notifyutil -s` has no effect when no
+   process has registered the key.
 2. **Match / non-match** — post the key the app's `LAContext` is waiting on:
    - Touch ID: `com.apple.BiometricKit_Sim.fingerTouch.match` / `…nomatch`
    - Face ID: `com.apple.BiometricKit_Sim.pearl.match` / `…nomatch`
@@ -271,9 +273,14 @@ limitation, not a missing wiring detail.
 1. **Binary toggle** — the only lever the simulator exposes is the
    `com.apple.donotdisturb.enabled` Darwin notification, driven via
    `xcrun simctl spawn <udid> notifyutil`:
-   - `notifyutil -s com.apple.donotdisturb.enabled <0|1>` sets the value.
+   - `notifyutil -1 com.apple.donotdisturb.enabled ...` creates a temporary
+     registration. This is required because `notifyutil -s` has no effect when
+     no process has registered the key.
+   - `notifyutil -s com.apple.donotdisturb.enabled <0|1>` sets the value while
+     the registration is alive.
+   - `notifyutil -g com.apple.donotdisturb.enabled` verifies the registered
+     state in the same invocation.
    - `notifyutil -p com.apple.donotdisturb.enabled` posts it so observers react.
-   - `notifyutil -g com.apple.donotdisturb.enabled` reads it back.
 2. **Honest capability reporting** — every result carries a machine-readable
    `capability` field so callers can branch instead of string-matching warnings:
    - `binary` — simulator: on/off only.
@@ -285,8 +292,9 @@ limitation, not a missing wiring detail.
    `appliedMode: "none"`, a structured `warning`, and `verified: false` (so
    `success` is `false`). The tool never claims a tier it cannot deliver.
 4. **Best effort** — results are `bestEffort: true`. `notifyutil` values are
-   session-scoped, so a separate `-g` read may not reflect a prior `-s`; the
-   readback is advisory, not authoritative.
+   registration-scoped, so the setter verifies inside the registered invocation.
+   A later standalone `-g` read may not reflect a prior `-s`; the readback is
+   advisory, not authoritative.
 
 ### Limitations
 

--- a/schemas/tool-definitions.json
+++ b/schemas/tool-definitions.json
@@ -4915,7 +4915,7 @@
   },
   {
     "name": "setDeviceState",
-    "description": "Set device-level state such as Do Not Disturb. Android supports all four DND modes (off/none/priority/alarms) with read-back verification. iOS DND is simulator-only and binary (on/off) via the com.apple.donotdisturb.enabled notifyutil toggle; priority/alarms are applied as plain DND and reported honestly (capability:\"binary\", appliedMode:\"none\", verified:false, warning). Physical iOS devices are unsupported (capability:\"unsupported\") because iOS exposes no public API to set Focus/Do Not Disturb.",
+    "description": "Set device-level state such as Do Not Disturb. Android supports all four DND modes (off/none/priority/alarms) with read-back verification. iOS DND is simulator-only and binary (on/off) via a registered com.apple.donotdisturb.enabled notifyutil toggle; priority/alarms are applied as plain DND and reported honestly (capability:\"binary\", appliedMode:\"none\", verified:false, warning). Physical iOS devices are unsupported (capability:\"unsupported\") because iOS exposes no public API to set Focus/Do Not Disturb.",
     "inputSchema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "type": "object",

--- a/src/features/action/BiometricAuth.ts
+++ b/src/features/action/BiometricAuth.ts
@@ -6,6 +6,11 @@ import { logger } from "../../utils/logger";
 import { Timer, defaultTimer } from "../../utils/SystemTimer";
 import { SimCtlClient } from "../../utils/ios-cmdline-tools/SimCtlClient";
 import { isIosSimulatorDevice } from "./IosSimulatorPermissions";
+import {
+  IOS_NOTIFYUTIL_REGISTERED_SET_TIMEOUT_MS,
+  iosNotifyutilRegisteredSetCommand,
+  parseNotifyutilState
+} from "../../utils/ios-cmdline-tools/notifyutil";
 
 export interface BiometricAuthOptions {
   action: "match" | "fail" | "cancel" | "error";
@@ -201,8 +206,32 @@ export class BiometricAuth extends BaseVisualChange {
 
     try {
       // Ensure biometry is enrolled before attempting a match.
-      await simctl.executeCommand(`spawn ${udid} notifyutil -s ${keys.enrollment} 1`);
-      await simctl.executeCommand(`spawn ${udid} notifyutil -p ${keys.enrollment}`);
+      const enrollmentResult = await simctl.executeCommand(
+        iosNotifyutilRegisteredSetCommand(udid, keys.enrollment, "1"),
+        IOS_NOTIFYUTIL_REGISTERED_SET_TIMEOUT_MS
+      );
+      if (enrollmentResult.stderr && enrollmentResult.stderr.trim().length > 0) {
+        return {
+          success: false,
+          action: options.action,
+          modality,
+          fingerprintId: options.fingerprintId,
+          errorCode: options.errorCode,
+          supported: true,
+          error: `notifyutil failed: ${enrollmentResult.stderr.trim()}`
+        };
+      }
+      if (parseNotifyutilState(enrollmentResult.stdout ?? "") !== true) {
+        return {
+          success: false,
+          action: options.action,
+          modality,
+          fingerprintId: options.fingerprintId,
+          errorCode: options.errorCode,
+          supported: true,
+          error: "iOS biometric enrollment did not verify: notifyutil did not read back enrolled state."
+        };
+      }
 
       for (const target of targets) {
         const res = await simctl.executeCommand(`spawn ${udid} notifyutil -p ${target}`);

--- a/src/features/utility/DeviceState.ts
+++ b/src/features/utility/DeviceState.ts
@@ -5,6 +5,12 @@ import { isIosSimulatorDevice } from "../action/IosSimulatorPermissions";
 import { outputLooksLikeShellFailure } from "../../utils/android-cmdline-tools/shellOutputHeuristics";
 import { AndroidCtrlProxyClient } from "../observe/android/AndroidCtrlProxyClient";
 import { logger } from "../../utils/logger";
+import {
+  IOS_NOTIFYUTIL_REGISTERED_SET_TIMEOUT_MS,
+  iosNotifyutilGetCommand,
+  iosNotifyutilRegisteredSetCommand,
+  parseNotifyutilState
+} from "../../utils/ios-cmdline-tools/notifyutil";
 
 export type DoNotDisturbMode = "off" | "none" | "priority" | "alarms";
 
@@ -127,13 +133,28 @@ function parseAndroidZenMode(raw: string): DoNotDisturbState {
   }
 }
 
-function parseNotifyutilState(raw: string): boolean | null {
-  const trimmed = raw.trim();
-  const match = trimmed.match(/([01])\s*$/);
-  if (!match) {
-    return null;
+function iosDndStateFromNotifyutilOutput(raw: string): DoNotDisturbState {
+  const enabled = parseNotifyutilState(raw);
+  if (enabled === null) {
+    return {
+      supported: true,
+      capability: "binary",
+      method: "ios_simulator_notifyutil",
+      bestEffort: true,
+      rawValue: raw,
+      warning: "Could not parse iOS simulator Do Not Disturb notifyutil state",
+    };
   }
-  return match[1] === "1";
+
+  return {
+    supported: true,
+    capability: "binary",
+    enabled,
+    mode: enabled ? "none" : "off",
+    rawValue: enabled ? "1" : "0",
+    method: "ios_simulator_notifyutil",
+    bestEffort: true,
+  };
 }
 
 /**
@@ -305,28 +326,10 @@ export class DeviceState {
 
     try {
       const simctl = this.simctl ?? new SimCtlClient(this.device);
-      const result = await simctl.executeCommand(`spawn ${this.device.deviceId} notifyutil -g ${IOS_DND_NOTIFICATION}`);
-      const enabled = parseNotifyutilState(result.stdout ?? "");
-      if (enabled === null) {
-        return {
-          supported: true,
-          capability: "binary",
-          method: "ios_simulator_notifyutil",
-          bestEffort: true,
-          rawValue: result.stdout,
-          warning: "Could not parse iOS simulator Do Not Disturb notifyutil state",
-        };
-      }
-
-      return {
-        supported: true,
-        capability: "binary",
-        enabled,
-        mode: enabled ? "none" : "off",
-        rawValue: enabled ? "1" : "0",
-        method: "ios_simulator_notifyutil",
-        bestEffort: true,
-      };
+      const result = await simctl.executeCommand(
+        iosNotifyutilGetCommand(this.device.deviceId, IOS_DND_NOTIFICATION)
+      );
+      return iosDndStateFromNotifyutilOutput(result.stdout ?? "");
     } catch (error) {
       return {
         supported: true,
@@ -353,10 +356,12 @@ export class DeviceState {
     }
 
     // Simulator: the only lever is the binary `com.apple.donotdisturb.enabled`
-    // Darwin notification. There is no per-mode (priority/alarms) Darwin
-    // notification analogous to Android's `zen_mode` integer, so `priority`/
-    // `alarms` requests are applied as plain DND ("none") and reported honestly
-    // rather than silently claiming the tier was honored.
+    // Darwin notification. `notifyutil -s` is a no-op unless the key has a
+    // registration, so set/read/post must happen in one registered invocation.
+    // There is no per-mode (priority/alarms) Darwin notification analogous to
+    // Android's `zen_mode` integer, so `priority`/`alarms` requests are applied
+    // as plain DND ("none") and reported honestly rather than silently claiming
+    // the tier was honored.
     const requestedEnabled = requestedMode !== "off";
     const appliedMode: DoNotDisturbMode = requestedEnabled ? "none" : "off";
     const downgraded = requestedMode === "priority" || requestedMode === "alarms";
@@ -364,10 +369,11 @@ export class DeviceState {
     try {
       const simctl = this.simctl ?? new SimCtlClient(this.device);
       const value = requestedEnabled ? "1" : "0";
-      await simctl.executeCommand(`spawn ${this.device.deviceId} notifyutil -s ${IOS_DND_NOTIFICATION} ${value}`);
-      await simctl.executeCommand(`spawn ${this.device.deviceId} notifyutil -p ${IOS_DND_NOTIFICATION}`);
-
-      const state = await this.getIosDoNotDisturb();
+      const writeResult = await simctl.executeCommand(
+        iosNotifyutilRegisteredSetCommand(this.device.deviceId, IOS_DND_NOTIFICATION, value),
+        IOS_NOTIFYUTIL_REGISTERED_SET_TIMEOUT_MS
+      );
+      const state = iosDndStateFromNotifyutilOutput(writeResult.stdout ?? "");
       const stateMatches = state.enabled === requestedEnabled;
       // For priority/alarms we applied *a* DND state but NOT the requested tier,
       // so verified is intentionally false: setState() will then report

--- a/src/server/utilityTools.ts
+++ b/src/server/utilityTools.ts
@@ -273,8 +273,8 @@ export function registerUtilityTools() {
     "setDeviceState",
     "Set device-level state such as Do Not Disturb. Android supports all four DND modes "
       + "(off/none/priority/alarms) with read-back verification. iOS DND is simulator-only and "
-      + "binary (on/off) via the com.apple.donotdisturb.enabled notifyutil toggle; priority/alarms "
-      + "are applied as plain DND and reported honestly (capability:\"binary\", appliedMode:\"none\", "
+      + "binary (on/off) via a registered com.apple.donotdisturb.enabled notifyutil toggle; "
+      + "priority/alarms are applied as plain DND and reported honestly (capability:\"binary\", appliedMode:\"none\", "
       + "verified:false, warning). Physical iOS devices are unsupported (capability:\"unsupported\") "
       + "because iOS exposes no public API to set Focus/Do Not Disturb.",
     setDeviceStateSchema,

--- a/src/utils/ios-cmdline-tools/notifyutil.ts
+++ b/src/utils/ios-cmdline-tools/notifyutil.ts
@@ -1,0 +1,27 @@
+export const IOS_NOTIFYUTIL_REGISTERED_SET_TIMEOUT_MS = 5000;
+
+export function parseNotifyutilState(raw: string): boolean | null {
+  const lines = raw.trim().split(/\r?\n/).reverse();
+  for (const line of lines) {
+    const match = line.trim().match(/(?:^|\s)([01])$/);
+    if (match) {
+      return match[1] === "1";
+    }
+  }
+  return null;
+}
+
+export function iosNotifyutilGetCommand(deviceId: string, key: string): string {
+  return `spawn ${deviceId} notifyutil -g ${key}`;
+}
+
+export function iosNotifyutilRegisteredSetCommand(
+  deviceId: string,
+  key: string,
+  value: "0" | "1"
+): string {
+  return `spawn ${deviceId} notifyutil -1 ${key} `
+    + `-s ${key} ${value} `
+    + `-g ${key} `
+    + `-p ${key}`;
+}

--- a/test/features/action/BiometricAuthIos.test.ts
+++ b/test/features/action/BiometricAuthIos.test.ts
@@ -12,6 +12,7 @@ const TOUCH_MATCH = "com.apple.BiometricKit_Sim.fingerTouch.match";
 const TOUCH_NOMATCH = "com.apple.BiometricKit_Sim.fingerTouch.nomatch";
 const PEARL_MATCH = "com.apple.BiometricKit_Sim.pearl.match";
 const PEARL_NOMATCH = "com.apple.BiometricKit_Sim.pearl.nomatch";
+const ENROLL_COMMAND = `spawn ${SIM_UDID} notifyutil -1 ${ENROLL} -s ${ENROLL} 1 -g ${ENROLL} -p ${ENROLL}`;
 
 describe("BiometricAuth - iOS Simulator", () => {
   let simctl: FakeSimCtlClient;
@@ -25,6 +26,7 @@ describe("BiometricAuth - iOS Simulator", () => {
 
   beforeEach(() => {
     simctl = new FakeSimCtlClient();
+    simctl.setCommandResult(ENROLL_COMMAND, `${ENROLL} 1\n${ENROLL}\n`);
     timer = new FakeTimer();
     timer.enableAutoAdvance();
   });
@@ -36,10 +38,10 @@ describe("BiometricAuth - iOS Simulator", () => {
     expect(result.success).toBe(true);
     expect(result.supported).toBe(true);
     expect(commands()).toEqual([
-      `spawn ${SIM_UDID} notifyutil -s ${ENROLL} 1`,
-      `spawn ${SIM_UDID} notifyutil -p ${ENROLL}`,
+      ENROLL_COMMAND,
       `spawn ${SIM_UDID} notifyutil -p ${TOUCH_MATCH}`,
     ]);
+    expect(simctl.getMethodCalls("executeCommand")[0]?.timeoutMs).toBe(5000);
   });
 
   test("match + face posts pearl.match", async () => {
@@ -116,9 +118,35 @@ describe("BiometricAuth - iOS Simulator", () => {
     expect(result.error).toContain("notifyutil failed");
   });
 
+  test("enrollment notifyutil stderr surfaces as failure", async () => {
+    simctl.setCommandResult(
+      ENROLL_COMMAND,
+      "",
+      "notifyutil: enrollment unavailable"
+    );
+    const auth = new BiometricAuth(makeDevice(SIM_UDID), null, timer, simctl);
+    const result = await auth.execute({ action: "match", modality: "fingerprint" });
+
+    expect(result.success).toBe(false);
+    expect(result.supported).toBe(true);
+    expect(result.error).toContain("notifyutil failed");
+    expect(commands()).toEqual([ENROLL_COMMAND]);
+  });
+
+  test("enrollment readback must verify before posting biometric event", async () => {
+    simctl.setCommandResult(ENROLL_COMMAND, `${ENROLL} 0\n${ENROLL}\n`);
+    const auth = new BiometricAuth(makeDevice(SIM_UDID), null, timer, simctl);
+    const result = await auth.execute({ action: "match", modality: "fingerprint" });
+
+    expect(result.success).toBe(false);
+    expect(result.supported).toBe(true);
+    expect(result.error).toContain("enrollment did not verify");
+    expect(commands()).toEqual([ENROLL_COMMAND]);
+  });
+
   test("thrown simctl error is caught and reported", async () => {
     simctl.setCommandError(
-      `spawn ${SIM_UDID} notifyutil -s ${ENROLL} 1`,
+      ENROLL_COMMAND,
       new Error("simctl unavailable")
     );
     const auth = new BiometricAuth(makeDevice(SIM_UDID), null, timer, simctl);

--- a/test/features/utility/DeviceState.test.ts
+++ b/test/features/utility/DeviceState.test.ts
@@ -58,7 +58,7 @@ describe("DeviceState", () => {
   test("sets iOS simulator Do Not Disturb on with notifyutil best-effort commands", async () => {
     const simctl = new FakeSimCtlClient();
     simctl.setCommandResult(
-      "spawn 12345678-1234-1234-1234-123456789ABC notifyutil -g com.apple.donotdisturb.enabled",
+      "spawn 12345678-1234-1234-1234-123456789ABC notifyutil -1 com.apple.donotdisturb.enabled -s com.apple.donotdisturb.enabled 1 -g com.apple.donotdisturb.enabled -p com.apple.donotdisturb.enabled",
       "com.apple.donotdisturb.enabled 1\n"
     );
 
@@ -81,16 +81,8 @@ describe("DeviceState", () => {
     expect(result.doNotDisturb?.warning).toBeUndefined();
     expect(simctl.getMethodCalls("executeCommand")).toEqual([
       {
-        command: "spawn 12345678-1234-1234-1234-123456789ABC notifyutil -s com.apple.donotdisturb.enabled 1",
-        timeoutMs: undefined,
-      },
-      {
-        command: "spawn 12345678-1234-1234-1234-123456789ABC notifyutil -p com.apple.donotdisturb.enabled",
-        timeoutMs: undefined,
-      },
-      {
-        command: "spawn 12345678-1234-1234-1234-123456789ABC notifyutil -g com.apple.donotdisturb.enabled",
-        timeoutMs: undefined,
+        command: "spawn 12345678-1234-1234-1234-123456789ABC notifyutil -1 com.apple.donotdisturb.enabled -s com.apple.donotdisturb.enabled 1 -g com.apple.donotdisturb.enabled -p com.apple.donotdisturb.enabled",
+        timeoutMs: 5000,
       },
     ]);
   });
@@ -98,7 +90,7 @@ describe("DeviceState", () => {
   test("sets iOS simulator Do Not Disturb off with notifyutil best-effort commands", async () => {
     const simctl = new FakeSimCtlClient();
     simctl.setCommandResult(
-      "spawn 12345678-1234-1234-1234-123456789ABC notifyutil -g com.apple.donotdisturb.enabled",
+      "spawn 12345678-1234-1234-1234-123456789ABC notifyutil -1 com.apple.donotdisturb.enabled -s com.apple.donotdisturb.enabled 0 -g com.apple.donotdisturb.enabled -p com.apple.donotdisturb.enabled",
       "com.apple.donotdisturb.enabled 0\n"
     );
 
@@ -121,25 +113,39 @@ describe("DeviceState", () => {
     expect(result.doNotDisturb?.warning).toBeUndefined();
     expect(simctl.getMethodCalls("executeCommand")).toEqual([
       {
-        command: "spawn 12345678-1234-1234-1234-123456789ABC notifyutil -s com.apple.donotdisturb.enabled 0",
-        timeoutMs: undefined,
-      },
-      {
-        command: "spawn 12345678-1234-1234-1234-123456789ABC notifyutil -p com.apple.donotdisturb.enabled",
-        timeoutMs: undefined,
-      },
-      {
-        command: "spawn 12345678-1234-1234-1234-123456789ABC notifyutil -g com.apple.donotdisturb.enabled",
-        timeoutMs: undefined,
+        command: "spawn 12345678-1234-1234-1234-123456789ABC notifyutil -1 com.apple.donotdisturb.enabled -s com.apple.donotdisturb.enabled 0 -g com.apple.donotdisturb.enabled -p com.apple.donotdisturb.enabled",
+        timeoutMs: 5000,
       },
     ]);
+  });
+
+  test("sets iOS simulator Do Not Disturb with a temporary notifyutil registration", async () => {
+    const simctl = new FakeSimCtlClient();
+    simctl.setCommandResult(
+      "spawn 12345678-1234-1234-1234-123456789ABC notifyutil -1 com.apple.donotdisturb.enabled -s com.apple.donotdisturb.enabled 1 -g com.apple.donotdisturb.enabled -p com.apple.donotdisturb.enabled",
+      "com.apple.donotdisturb.enabled 1\ncom.apple.donotdisturb.enabled\n"
+    );
+
+    const deviceState = new DeviceState(iosSimulator, { simctl });
+    const result = await deviceState.setState({
+      doNotDisturb: { enabled: true },
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.doNotDisturb).toMatchObject({
+      supported: true,
+      enabled: true,
+      requestedMode: "none",
+      appliedMode: "none",
+      verified: true,
+    });
   });
 
   test("reports honest downgrade for iOS simulator priority/alarms (no silent tier claim)", async () => {
     const simctl = new FakeSimCtlClient();
     // notifyutil reads back enabled, but the requested *tier* cannot be applied.
     simctl.setCommandResult(
-      "spawn 12345678-1234-1234-1234-123456789ABC notifyutil -g com.apple.donotdisturb.enabled",
+      "spawn 12345678-1234-1234-1234-123456789ABC notifyutil -1 com.apple.donotdisturb.enabled -s com.apple.donotdisturb.enabled 1 -g com.apple.donotdisturb.enabled -p com.apple.donotdisturb.enabled",
       "com.apple.donotdisturb.enabled 1\n"
     );
 
@@ -165,16 +171,8 @@ describe("DeviceState", () => {
     // We still posted the binary toggle (a DND state was applied, just not the tier).
     expect(simctl.getMethodCalls("executeCommand")).toEqual([
       {
-        command: "spawn 12345678-1234-1234-1234-123456789ABC notifyutil -s com.apple.donotdisturb.enabled 1",
-        timeoutMs: undefined,
-      },
-      {
-        command: "spawn 12345678-1234-1234-1234-123456789ABC notifyutil -p com.apple.donotdisturb.enabled",
-        timeoutMs: undefined,
-      },
-      {
-        command: "spawn 12345678-1234-1234-1234-123456789ABC notifyutil -g com.apple.donotdisturb.enabled",
-        timeoutMs: undefined,
+        command: "spawn 12345678-1234-1234-1234-123456789ABC notifyutil -1 com.apple.donotdisturb.enabled -s com.apple.donotdisturb.enabled 1 -g com.apple.donotdisturb.enabled -p com.apple.donotdisturb.enabled",
+        timeoutMs: 5000,
       },
     ]);
   });
@@ -184,7 +182,7 @@ describe("DeviceState", () => {
     // notifyutil reads back DISABLED even though we requested an enabled tier:
     // the binary toggle itself did not verify, on top of the tier downgrade.
     simctl.setCommandResult(
-      "spawn 12345678-1234-1234-1234-123456789ABC notifyutil -g com.apple.donotdisturb.enabled",
+      "spawn 12345678-1234-1234-1234-123456789ABC notifyutil -1 com.apple.donotdisturb.enabled -s com.apple.donotdisturb.enabled 1 -g com.apple.donotdisturb.enabled -p com.apple.donotdisturb.enabled",
       "com.apple.donotdisturb.enabled 0\n"
     );
 
@@ -214,7 +212,7 @@ describe("DeviceState", () => {
   test("surfaces simctl errors without throwing out of setState", async () => {
     const simctl = new FakeSimCtlClient();
     simctl.setCommandError(
-      "spawn 12345678-1234-1234-1234-123456789ABC notifyutil -s com.apple.donotdisturb.enabled 1",
+      "spawn 12345678-1234-1234-1234-123456789ABC notifyutil -1 com.apple.donotdisturb.enabled -s com.apple.donotdisturb.enabled 1 -g com.apple.donotdisturb.enabled -p com.apple.donotdisturb.enabled",
       new Error("simctl spawn failed")
     );
 


### PR DESCRIPTION
## Summary

- Fix iOS simulator DND writes by using a registered `notifyutil` set/read/post invocation.
- Reuse the same registered notifyutil helper for iOS biometric enrollment.
- Verify biometric enrollment readback before posting match/fail events, and bound registered notifyutil writes with a timeout.
- Update tests, generated tool docs, and iOS simctl documentation.

## Root Cause

`notifyutil -s` has no effect when no process has registered the key. The old DND and biometric enrollment paths set state in one command and posted/read in later commands, so newer simulators could report unchanged state or proceed after a no-op enrollment write.

## Validation

- `bun test test/features/action/BiometricAuthIos.test.ts test/features/utility/DeviceState.test.ts`
- `bun run lint`
- `bun run build`
- `bun test` (4662 pass, 1 skip, 0 fail)
