### PR TITLE
fix: enforce conditional tool schema requirements

### DIFF
--- a/schemas/tool-definitions.json
+++ b/schemas/tool-definitions.json
@@ -464,17 +464,18 @@
       "properties": {
         "action": {
           "type": "string",
+          "description": "Clipboard action: copy=set clipboard, paste=paste into focused field, clear=clear clipboard, get=get clipboard content",
           "enum": [
             "copy",
             "paste",
             "clear",
             "get"
-          ],
-          "description": "Clipboard action: copy=set clipboard, paste=paste into focused field, clear=clear clipboard, get=get clipboard content"
+          ]
         },
         "text": {
-          "description": "Text to copy (required for 'copy' action)",
-          "type": "string"
+          "type": "string",
+          "minLength": 1,
+          "description": "Text to copy (required for 'copy' action)"
         },
         "platform": {
           "type": "string",
@@ -580,15 +581,16 @@
       "properties": {
         "action": {
           "type": "string",
+          "description": "Action to perform",
           "enum": [
             "capture",
             "restore"
-          ],
-          "description": "Action to perform"
+          ]
         },
         "snapshotName": {
           "description": "Name for the snapshot",
-          "type": "string"
+          "type": "string",
+          "minLength": 1
         },
         "includeAppData": {
           "description": "Include app data directories in snapshot",
@@ -4468,16 +4470,17 @@
           "type": "string"
         },
         "appId": {
-          "description": "iOS bundle identifier to target (required on iOS; maps to APNs 'Simulator Target Bundle'). Ignored on Android.",
-          "type": "string"
+          "type": "string",
+          "minLength": 1,
+          "description": "iOS bundle identifier to target (required on iOS; maps to APNs 'Simulator Target Bundle'). Ignored on Android."
         },
         "platform": {
           "type": "string",
+          "description": "Target platform",
           "enum": [
-            "android",
-            "ios"
-          ],
-          "description": "Target platform"
+            "ios",
+            "android"
+          ]
         },
         "sessionUuid": {
           "description": "Session UUID",

--- a/src/server/interactionTools.ts
+++ b/src/server/interactionTools.ts
@@ -402,11 +402,36 @@ export const rotateSchema = addDeviceTargetingToSchema(z.object({
   platform: platformSchema
 }));
 
-export const clipboardSchema = addDeviceTargetingToSchema(z.object({
-  action: z.enum(["copy", "paste", "clear", "get"]).describe("Clipboard action: copy=set clipboard, paste=paste into focused field, clear=clear clipboard, get=get clipboard content"),
-  text: z.string().optional().describe("Text to copy (required for 'copy' action)"),
-  platform: platformSchema
-}));
+const clipboardTextRequiredMessage = "text is required when action is copy";
+const optionalClipboardTextSchema = z.string().min(1).optional().describe("Text to copy (required for 'copy' action)");
+const clipboardPlatformSchema = {
+  platform: platformSchema,
+};
+
+export const clipboardSchema = z.discriminatedUnion("action", [
+  addDeviceTargetingToSchema(z.object({
+    action: z.literal("copy").describe("Clipboard action: copy=set clipboard, paste=paste into focused field, clear=clear clipboard, get=get clipboard content"),
+    text: z.string({ error: clipboardTextRequiredMessage })
+      .min(1, clipboardTextRequiredMessage)
+      .describe("Text to copy (required for 'copy' action)"),
+    ...clipboardPlatformSchema,
+  })),
+  addDeviceTargetingToSchema(z.object({
+    action: z.literal("paste").describe("Clipboard action: copy=set clipboard, paste=paste into focused field, clear=clear clipboard, get=get clipboard content"),
+    text: optionalClipboardTextSchema,
+    ...clipboardPlatformSchema,
+  })),
+  addDeviceTargetingToSchema(z.object({
+    action: z.literal("clear").describe("Clipboard action: copy=set clipboard, paste=paste into focused field, clear=clear clipboard, get=get clipboard content"),
+    text: optionalClipboardTextSchema,
+    ...clipboardPlatformSchema,
+  })),
+  addDeviceTargetingToSchema(z.object({
+    action: z.literal("get").describe("Clipboard action: copy=set clipboard, paste=paste into focused field, clear=clear clipboard, get=get clipboard content"),
+    text: optionalClipboardTextSchema,
+    ...clipboardPlatformSchema,
+  }))
+]);
 
 // ============================================================================
 // Tool Registration

--- a/src/server/networkTools.ts
+++ b/src/server/networkTools.ts
@@ -22,6 +22,14 @@ const simulateErrorsSchema = z.object({
   limit: z.number().int().positive().optional().describe("Max errors to inject. Omit for unlimited"),
   durationSeconds: z.number().positive().optional().describe("How long to simulate errors. Required unless cancel is true"),
   cancel: z.boolean().optional().describe("Set to true to cancel active simulation"),
+}).superRefine((value, ctx) => {
+  if (value.cancel !== true && value.durationSeconds === undefined) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ["durationSeconds"],
+      message: "durationSeconds is required unless cancel is true",
+    });
+  }
 });
 
 const networkSchema = addDeviceTargetingToSchema(

--- a/src/server/notificationTools.ts
+++ b/src/server/notificationTools.ts
@@ -2,7 +2,7 @@ import { z } from "zod";
 import { ToolRegistry } from "./toolRegistry";
 import { ActionableError, BootedDevice, Platform } from "../models";
 import { createJSONToolResponse } from "../utils/toolUtils";
-import { addDeviceTargetingToSchema, platformSchema } from "./toolSchemaHelpers";
+import { addDeviceTargetingToSchema } from "./toolSchemaHelpers";
 import { PostNotification, PostNotificationOptions } from "../features/utility/PostNotification";
 import { NotificationPolicy } from "../features/utility/NotificationPolicy";
 
@@ -10,23 +10,36 @@ export interface PostNotificationArgs extends PostNotificationOptions {
   platform: Platform;
 }
 
+const iosAppIdRequiredMessage = "appId is required when platform is ios";
+
 const actionSchema = z.object({
   label: z.string().min(1).describe("Action label"),
   actionId: z.string().min(1).describe("Action identifier")
 });
 
-export const postNotificationSchema = addDeviceTargetingToSchema(
-  z.object({
-    title: z.string().min(1).describe("Notification title"),
-    body: z.string().min(1).describe("Notification body"),
-    imageType: z.enum(["normal", "bigPicture"]).optional().describe("Notification image type (default: normal)"),
-    imagePath: z.string().optional().describe("Host image file path to push to /sdcard/Download/automobile when imageType is bigPicture"),
-    actions: z.array(actionSchema).optional().describe("Action buttons to include (Android only)"),
-    channelId: z.string().optional().describe("Notification channel ID (Android); reused as the APNs category on iOS"),
-    appId: z.string().optional().describe("iOS bundle identifier to target (required on iOS; maps to APNs 'Simulator Target Bundle'). Ignored on Android."),
-    platform: platformSchema
-  })
-);
+const postNotificationCommonShape = {
+  title: z.string().min(1).describe("Notification title"),
+  body: z.string().min(1).describe("Notification body"),
+  imageType: z.enum(["normal", "bigPicture"]).optional().describe("Notification image type (default: normal)"),
+  imagePath: z.string().optional().describe("Host image file path to push to /sdcard/Download/automobile when imageType is bigPicture"),
+  actions: z.array(actionSchema).optional().describe("Action buttons to include (Android only)"),
+  channelId: z.string().optional().describe("Notification channel ID (Android); reused as the APNs category on iOS"),
+};
+
+export const postNotificationSchema = z.discriminatedUnion("platform", [
+  addDeviceTargetingToSchema(z.object({
+    ...postNotificationCommonShape,
+    appId: z.string({ error: iosAppIdRequiredMessage })
+      .min(1, iosAppIdRequiredMessage)
+      .describe("iOS bundle identifier to target (required on iOS; maps to APNs 'Simulator Target Bundle'). Ignored on Android."),
+    platform: z.literal("ios").describe("Target platform")
+  })),
+  addDeviceTargetingToSchema(z.object({
+    ...postNotificationCommonShape,
+    appId: z.string().min(1).optional().describe("iOS bundle identifier to target (required on iOS; maps to APNs 'Simulator Target Bundle'). Ignored on Android."),
+    platform: z.literal("android").describe("Target platform")
+  }))
+]);
 
 export const getNotificationPolicySchema = addDeviceTargetingToSchema(z.object({
   appId: z.string().min(1).describe("App package ID or bundle identifier"),

--- a/src/server/snapshotTools.ts
+++ b/src/server/snapshotTools.ts
@@ -5,9 +5,10 @@ import { ActionableError, BootedDevice } from "../models";
 import { addDeviceTargetingToSchema } from "./toolSchemaHelpers";
 import { captureDeviceSnapshot, restoreDeviceSnapshot } from "./deviceSnapshotManager";
 
-export const deviceSnapshotSchema = addDeviceTargetingToSchema(z.object({
-  action: z.enum(["capture", "restore"]).describe("Action to perform"),
-  snapshotName: z.string().optional().describe("Name for the snapshot"),
+const snapshotNameRequiredMessage = "snapshotName is required when action is restore";
+const optionalSnapshotNameSchema = z.string().min(1).optional().describe("Name for the snapshot");
+
+const deviceSnapshotCommonShape = {
   includeAppData: z.boolean().optional().describe("Include app data directories in snapshot"),
   includeSettings: z.boolean().optional().describe("Include system settings in snapshot"),
   useVmSnapshot: z.boolean().optional().describe("Use emulator VM snapshot if available (faster, emulator only)"),
@@ -18,15 +19,22 @@ export const deviceSnapshotSchema = addDeviceTargetingToSchema(z.object({
   vmSnapshotTimeoutMs: z.number().optional().describe("Timeout in milliseconds for emulator VM snapshot commands"),
   appBundleIds: z.array(z.string()).optional()
     .describe("iOS-only: bundle IDs to include in app data snapshots (omit to skip app data capture)"),
-})).superRefine((value, ctx) => {
-  if (value.action === "restore" && !value.snapshotName) {
-    ctx.addIssue({
-      code: z.ZodIssueCode.custom,
-      path: ["snapshotName"],
-      message: "snapshotName is required when action is restore",
-    });
-  }
-});
+};
+
+export const deviceSnapshotSchema = z.discriminatedUnion("action", [
+  addDeviceTargetingToSchema(z.object({
+    action: z.literal("capture").describe("Action to perform"),
+    snapshotName: optionalSnapshotNameSchema,
+    ...deviceSnapshotCommonShape,
+  })),
+  addDeviceTargetingToSchema(z.object({
+    action: z.literal("restore").describe("Action to perform"),
+    snapshotName: z.string({ error: snapshotNameRequiredMessage })
+      .min(1, snapshotNameRequiredMessage)
+      .describe("Name for the snapshot"),
+    ...deviceSnapshotCommonShape,
+  }))
+]);
 
 export type DeviceSnapshotToolArgs = z.infer<typeof deviceSnapshotSchema>;
 

--- a/src/server/toolRegistry.ts
+++ b/src/server/toolRegistry.ts
@@ -25,21 +25,15 @@ import { getMcpRecorder } from "./mcpRecordingManager";
 
 /**
  * The Anthropic API (and many MCP clients) reject tool input schemas that have
- * `anyOf` or `oneOf` at the top level. Zod's `z.union()` produces exactly that.
+ * top-level combinators such as `anyOf`, `oneOf`, or `allOf`. Zod's `z.union()`
+ * produces `anyOf`/`oneOf`.
  * This function flattens union branches into a single `type: "object"` schema
  * by merging all properties from every branch. Required fields are dropped because
  * different branches require different keys.
  *
- * Note: `allOf` is NOT handled here — it has a different semantic (intersection)
- * and would require a different merging strategy (all fields required, not any).
- *
  * Trade-off: the flattened schema loses mutual-exclusivity information, so LLMs may
- * send invalid property combinations. The server-side Zod union still validates at
- * runtime, but the error messages are less clear than a well-structured schema.
- *
- * TODO: Replace top-level z.union() usage with a discriminator field (e.g.
- * `strategy: "text" | "id" | "clickable"`) so schemas are MCP-compliant without
- * needing this lossy flattening step.
+ * send invalid property combinations or omit branch-specific required fields. The
+ * server-side Zod union still validates at runtime.
  */
 export function flattenTopLevelUnion(schema: Record<string, unknown>): Record<string, unknown> {
   const branches = (schema.anyOf ?? schema.oneOf) as Record<string, unknown>[] | undefined;
@@ -57,6 +51,8 @@ export function flattenTopLevelUnion(schema: Record<string, unknown>): Record<st
       for (const [key, value] of Object.entries(props)) {
         if (!mergedProperties[key]) {
           mergedProperties[key] = value;
+        } else {
+          mergedProperties[key] = mergeUnionProperty(mergedProperties[key], value);
         }
       }
     }
@@ -86,6 +82,36 @@ export function flattenTopLevelUnion(schema: Record<string, unknown>): Record<st
   }
 
   return result;
+}
+
+function mergeUnionProperty(existing: unknown, incoming: unknown): unknown {
+  if (!isJsonSchemaObject(existing) || !isJsonSchemaObject(incoming)) {
+    return existing;
+  }
+
+  const existingValues = constOrEnumValues(existing);
+  const incomingValues = constOrEnumValues(incoming);
+  if (existingValues.length === 0 || incomingValues.length === 0) {
+    return existing;
+  }
+
+  const baseSchema = { ...existing };
+  delete baseSchema.const;
+  return {
+    ...baseSchema,
+    enum: [...new Set([...existingValues, ...incomingValues])],
+  };
+}
+
+function constOrEnumValues(schema: Record<string, unknown>): unknown[] {
+  if ("const" in schema) {
+    return [schema.const];
+  }
+  return Array.isArray(schema.enum) ? schema.enum : [];
+}
+
+function isJsonSchemaObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
 // Progress notification interface

--- a/test/server/flattenTopLevelUnion.test.ts
+++ b/test/server/flattenTopLevelUnion.test.ts
@@ -98,4 +98,43 @@ describe("flattenTopLevelUnion", () => {
     expect(result.type).toBe("object");
     expect((result.properties as any).x).toEqual({ type: "string" });
   });
+
+  test("keeps discriminator branches flattened without top-level combinators", () => {
+    const schema = {
+      oneOf: [
+        {
+          type: "object",
+          properties: {
+            platform: { type: "string", const: "ios", description: "Target platform" },
+            title: { type: "string" },
+            appId: { type: "string" },
+          },
+          required: ["platform", "title", "appId"],
+          additionalProperties: false,
+        },
+        {
+          type: "object",
+          properties: {
+            platform: { type: "string", const: "android", description: "Target platform" },
+            title: { type: "string" },
+            appId: { type: "string" },
+          },
+          required: ["platform", "title"],
+          additionalProperties: false,
+        },
+      ],
+    };
+
+    const result = flattenTopLevelUnion(schema);
+
+    expect(result.type).toBe("object");
+    expect(result.oneOf).toBeUndefined();
+    expect(result.allOf).toBeUndefined();
+    expect((result.properties as any).platform).toEqual({
+      type: "string",
+      description: "Target platform",
+      enum: ["ios", "android"],
+    });
+    expect(result.required).toEqual(["platform", "title"]);
+  });
 });

--- a/test/server/interactionTools.clipboard.test.ts
+++ b/test/server/interactionTools.clipboard.test.ts
@@ -1,0 +1,63 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { clipboardSchema, registerInteractionTools } from "../../src/server/interactionTools";
+import { ToolRegistry } from "../../src/server/toolRegistry";
+
+describe("clipboard tool schema", () => {
+  beforeEach(() => {
+    ToolRegistry.clearTools();
+    registerInteractionTools();
+  });
+
+  afterEach(() => {
+    ToolRegistry.clearTools();
+  });
+
+  test("requires text when action is copy", () => {
+    const result = clipboardSchema.safeParse({
+      action: "copy",
+      platform: "ios",
+    });
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues[0].path).toEqual(["text"]);
+      expect(result.error.issues[0].message).toBe("text is required when action is copy");
+    }
+  });
+
+  test("keeps text optional for non-copy actions", () => {
+    for (const action of ["paste", "clear", "get"] as const) {
+      const result = clipboardSchema.safeParse({
+        action,
+        platform: "android",
+      });
+
+      expect(result.success).toBe(true);
+    }
+  });
+
+  test("rejects empty text when text is provided for any action", () => {
+    for (const action of ["copy", "paste", "clear", "get"] as const) {
+      const result = clipboardSchema.safeParse({
+        action,
+        text: "",
+        platform: "android",
+      });
+
+      expect(result.success).toBe(false);
+    }
+  });
+
+  test("keeps generated tool definition free of top-level combinators", () => {
+    const toolDefinition = ToolRegistry.getToolDefinitions()
+      .find(tool => tool.name === "clipboard");
+
+    expect(toolDefinition).toBeDefined();
+    const schema = toolDefinition!.inputSchema as any;
+    expect(schema.required).toEqual(["action", "platform"]);
+    expect(schema.properties.action.enum).toEqual(["copy", "paste", "clear", "get"]);
+    expect(schema.anyOf).toBeUndefined();
+    expect(schema.oneOf).toBeUndefined();
+    expect(schema.allOf).toBeUndefined();
+  });
+});

--- a/test/server/networkTools.test.ts
+++ b/test/server/networkTools.test.ts
@@ -1,0 +1,40 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { registerNetworkTools } from "../../src/server/networkTools";
+import { ToolRegistry } from "../../src/server/toolRegistry";
+
+describe("network tool schema", () => {
+  beforeEach(() => {
+    ToolRegistry.clearTools();
+    registerNetworkTools();
+  });
+
+  afterEach(() => {
+    ToolRegistry.clearTools();
+  });
+
+  test("requires durationSeconds when starting error simulation", () => {
+    const tool = ToolRegistry.getTool("network");
+    const result = tool!.schema.safeParse({
+      simulateErrors: {
+        errorType: "timeout",
+      },
+    });
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues[0].path).toEqual(["simulateErrors", "durationSeconds"]);
+      expect(result.error.issues[0].message).toBe("durationSeconds is required unless cancel is true");
+    }
+  });
+
+  test("allows durationSeconds to be omitted when canceling error simulation", () => {
+    const tool = ToolRegistry.getTool("network");
+    const result = tool!.schema.safeParse({
+      simulateErrors: {
+        cancel: true,
+      },
+    });
+
+    expect(result.success).toBe(true);
+  });
+});

--- a/test/server/notificationTools.test.ts
+++ b/test/server/notificationTools.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { registerNotificationTools } from "../../src/server/notificationTools";
+import { postNotificationSchema, registerNotificationTools } from "../../src/server/notificationTools";
 import { ToolRegistry } from "../../src/server/toolRegistry";
 
 describe("notification tools", () => {
@@ -32,5 +32,42 @@ describe("notification tools", () => {
     expect(() => setTool!.schema.parse({
       appId: "com.example.app",
     })).toThrow();
+  });
+
+  test("requires appId when posting notifications on iOS", () => {
+    const result = postNotificationSchema.safeParse({
+      platform: "ios",
+      title: "T",
+      body: "B",
+    });
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues[0].path).toEqual(["appId"]);
+      expect(result.error.issues[0].message).toBe("appId is required when platform is ios");
+    }
+  });
+
+  test("keeps appId optional when posting notifications on Android", () => {
+    const result = postNotificationSchema.safeParse({
+      platform: "android",
+      title: "T",
+      body: "B",
+    });
+
+    expect(result.success).toBe(true);
+  });
+
+  test("keeps generated tool definition free of top-level combinators", () => {
+    const toolDefinition = ToolRegistry.getToolDefinitions()
+      .find(tool => tool.name === "postNotification");
+
+    expect(toolDefinition).toBeDefined();
+    const schema = toolDefinition!.inputSchema as any;
+    expect(schema.required).toEqual(["title", "body", "platform"]);
+    expect(schema.properties.platform.enum).toEqual(["ios", "android"]);
+    expect(schema.anyOf).toBeUndefined();
+    expect(schema.oneOf).toBeUndefined();
+    expect(schema.allOf).toBeUndefined();
   });
 });

--- a/test/server/snapshotTools.test.ts
+++ b/test/server/snapshotTools.test.ts
@@ -1,6 +1,6 @@
 import { afterAll, beforeAll, beforeEach, describe, expect, test } from "bun:test";
 import type { BootedDevice, DeviceSnapshotManifest } from "../../src/models";
-import { registerSnapshotTools } from "../../src/server/snapshotTools";
+import { deviceSnapshotSchema, registerSnapshotTools } from "../../src/server/snapshotTools";
 import { ToolRegistry } from "../../src/server/toolRegistry";
 import {
   resetDeviceSnapshotManagerDependencies,
@@ -85,6 +85,42 @@ describe("snapshot tool", () => {
 
   afterAll(() => {
     resetDeviceSnapshotManagerDependencies();
+  });
+
+  test("requires snapshotName when action is restore", () => {
+    const result = deviceSnapshotSchema.safeParse({
+      action: "restore",
+    });
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues[0].path).toEqual(["snapshotName"]);
+      expect(result.error.issues[0].message).toBe("snapshotName is required when action is restore");
+    }
+  });
+
+  test("rejects empty snapshotName when provided", () => {
+    for (const action of ["capture", "restore"] as const) {
+      const result = deviceSnapshotSchema.safeParse({
+        action,
+        snapshotName: "",
+      });
+
+      expect(result.success).toBe(false);
+    }
+  });
+
+  test("keeps generated tool definition free of top-level combinators", () => {
+    const toolDefinition = ToolRegistry.getToolDefinitions()
+      .find(tool => tool.name === "deviceSnapshot");
+
+    expect(toolDefinition).toBeDefined();
+    const schema = toolDefinition!.inputSchema as any;
+    expect(schema.required).toEqual(["action"]);
+    expect(schema.properties.action.enum).toEqual(["capture", "restore"]);
+    expect(schema.anyOf).toBeUndefined();
+    expect(schema.oneOf).toBeUndefined();
+    expect(schema.allOf).toBeUndefined();
   });
 
   test("captures snapshot and returns payload", async () => {

--- a/test/server/toolSchemaHelpers.test.ts
+++ b/test/server/toolSchemaHelpers.test.ts
@@ -129,7 +129,7 @@ describe("platform field accepted by all device-targeting tool schemas", () => {
     ["navigateToSchema", navigateToSchema, { targetScreen: "Home" }],
     ["getNavigationGraphSchema", getNavigationGraphSchema, {}],
     ["exploreSchema", exploreSchema, {}],
-    ["postNotificationSchema", postNotificationSchema, { title: "Hi", body: "Test", platform: "ios" }],
+    ["postNotificationSchema", postNotificationSchema, { title: "Hi", body: "Test", appId: "com.example", platform: "ios" }],
     ["getNotificationPolicySchema", getNotificationPolicySchema, { appId: "com.example" }],
     ["setNotificationPolicySchema", setNotificationPolicySchema, { appId: "com.example", policyAccess: true }],
     ["observeSchema", observeSchema, { platform: "ios" }],

--- a/test/server/tools/schema.test.ts
+++ b/test/server/tools/schema.test.ts
@@ -63,6 +63,17 @@ describe("MCP Tools Schema", () => {
     });
   });
 
+  test("should not publish top-level schema combinators", () => {
+    const toolDefinitions = ToolRegistry.getToolDefinitions();
+
+    for (const tool of toolDefinitions) {
+      const schema = tool.inputSchema as any;
+      expect(schema.anyOf, `${tool.name} should not publish top-level anyOf`).toBeUndefined();
+      expect(schema.oneOf, `${tool.name} should not publish top-level oneOf`).toBeUndefined();
+      expect(schema.allOf, `${tool.name} should not publish top-level allOf`).toBeUndefined();
+    }
+  });
+
   test("given a request that matches valid schema, should return a valid response", async function() {
 
     const { client } = fixture.getContext();


### PR DESCRIPTION
## Summary

- Enforce conditional tool schema requirements for `postNotification`, `clipboard`, `deviceSnapshot`, and `network`.
- Preserve discriminator-specific required fields when flattening top-level Zod unions into MCP-compatible JSON schemas.
- Regenerate `schemas/tool-definitions.json` and add regression coverage for runtime and generated schema behavior.

## Testing

- `bun test test/server/networkTools.test.ts test/server/snapshotTools.test.ts test/server/interactionTools.clipboard.test.ts test/server/toolSchemaHelpers.test.ts test/server/flattenTopLevelUnion.test.ts test/server/notificationTools.test.ts`
- `bun run lint`
- `bun run build`
- `bun test`
- `git diff --check`
