### PR TITLE
[codex] fix iOS SDK hierarchy over-merge

### DIFF
--- a/ios/control-proxy/Sources/CtrlProxy/CommandHandler.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/CommandHandler.swift
@@ -220,6 +220,22 @@ public class CommandHandler: CommandHandling {
         HierarchyMerger.merge(xcuitest: hierarchy, sdk: matchingSdkHierarchy(for: hierarchy))
     }
 
+    func enrichWithCachedSdkHierarchy(_ hierarchy: ViewHierarchy) -> ViewHierarchy {
+        HierarchyMerger.merge(xcuitest: hierarchy, sdk: matchingCachedSdkHierarchy(for: hierarchy))
+    }
+
+    private func matchingCachedSdkHierarchy(for hierarchy: ViewHierarchy) -> SdkViewHierarchy? {
+        guard let foregroundBundleId = normalizedBundleId(hierarchy.packageName),
+              let cached = sdkHierarchyCache?.latest else {
+            return nil
+        }
+        guard sdkHierarchy(cached, matches: foregroundBundleId) else {
+            sdkHierarchyCache?.clear()
+            return nil
+        }
+        return cached
+    }
+
     private func matchingSdkHierarchy(for hierarchy: ViewHierarchy) -> SdkViewHierarchy? {
         guard let foregroundBundleId = normalizedBundleId(hierarchy.packageName) else {
             return nil

--- a/ios/control-proxy/Sources/CtrlProxy/CommandHandler.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/CommandHandler.swift
@@ -204,8 +204,7 @@ public class CommandHandler: CommandHandling {
             throw CommandError.executionFailed("Failed to get view hierarchy: \(error.localizedDescription)")
         }
 
-        let sdkHierarchy = matchingSdkHierarchy(for: hierarchy)
-        let enriched = HierarchyMerger.merge(xcuitest: hierarchy, sdk: sdkHierarchy)
+        let enriched = enrichWithMatchingSdkHierarchy(hierarchy)
 
         // Get accumulated timing for this operation
         let perfTimings = perfProvider.flush()
@@ -215,6 +214,10 @@ public class CommandHandler: CommandHandling {
             data: enriched,
             perfTiming: perfTimings?.first
         )
+    }
+
+    func enrichWithMatchingSdkHierarchy(_ hierarchy: ViewHierarchy) -> ViewHierarchy {
+        HierarchyMerger.merge(xcuitest: hierarchy, sdk: matchingSdkHierarchy(for: hierarchy))
     }
 
     private func matchingSdkHierarchy(for hierarchy: ViewHierarchy) -> SdkViewHierarchy? {
@@ -227,6 +230,7 @@ public class CommandHandler: CommandHandling {
                 return cached
             }
             guard sdkServerMatchesForegroundBundleId(foregroundBundleId) else {
+                sdkHierarchyCache?.clear()
                 return nil
             }
         } else if sdkHierarchyClient != nil {
@@ -237,8 +241,10 @@ public class CommandHandler: CommandHandling {
 
         guard let fresh = sdkHierarchyClient?.fetchFreshHierarchy(),
               sdkHierarchy(fresh, matches: foregroundBundleId) else {
+            sdkHierarchyCache?.clear()
             return nil
         }
+        sdkHierarchyCache?.update(fresh)
         return fresh
     }
 

--- a/ios/control-proxy/Sources/CtrlProxy/CtrlProxy.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/CtrlProxy.swift
@@ -74,11 +74,9 @@ public class CtrlProxy {
                     print(
                         "[CtrlProxy] Hierarchy changed (hash=\(hash), extraction=\(extractionTimeMs)ms), broadcasting"
                     )
-                    let enriched = HierarchyMerger.merge(
-                        xcuitest: hierarchy,
-                        sdk: self?.sdkHierarchyCache.latest
-                    )
-                    self?.server.broadcastHierarchyUpdate(enriched)
+                    guard let self else { return }
+                    let enriched = self.commandHandler.enrichWithMatchingSdkHierarchy(hierarchy)
+                    self.server.broadcastHierarchyUpdate(enriched)
                 case .unchanged:
                     // Don't broadcast unchanged results (animation mode)
                     break

--- a/ios/control-proxy/Sources/CtrlProxy/CtrlProxy.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/CtrlProxy.swift
@@ -75,7 +75,7 @@ public class CtrlProxy {
                         "[CtrlProxy] Hierarchy changed (hash=\(hash), extraction=\(extractionTimeMs)ms), broadcasting"
                     )
                     guard let self else { return }
-                    let enriched = self.commandHandler.enrichWithMatchingSdkHierarchy(hierarchy)
+                    let enriched = self.commandHandler.enrichWithCachedSdkHierarchy(hierarchy)
                     self.server.broadcastHierarchyUpdate(enriched)
                 case .unchanged:
                     // Don't broadcast unchanged results (animation mode)

--- a/ios/control-proxy/Sources/CtrlProxy/HierarchyMerger.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/HierarchyMerger.swift
@@ -34,15 +34,24 @@ public enum HierarchyMerger {
         var matchedSdkKeyCounts: [LookupKey: Int] = [:]
         collectMatchedKeys(element: xcuitestRoot, lookup: lookup, boundsLookup: boundsLookup, identifierLookup: identifierLookup, allSdkNodes: allSdkNodes, matched: &matchedSdkKeyCounts)
 
-        // Pass 2: inject SDK-only nodes as children of matched parents
+        // Pass 2: inject SDK-only nodes as children of directly matched parents.
+        var injectedParentKeys = Set<LookupKey>()
+        let rootSdkNode = findDirectMatch(
+            className: xcuitestRoot.className,
+            resourceId: xcuitestRoot.resourceId,
+            bounds: xcuitestRoot.bounds,
+            in: lookup,
+            boundsLookup: boundsLookup,
+            identifierLookup: identifierLookup
+        )
         let injectedRoot = injectSdkOnlyNodes(
             element: enrichedRoot,
-            sdkNode: sdkRoot,
+            sdkNode: rootSdkNode,
             lookup: lookup,
             boundsLookup: boundsLookup,
             identifierLookup: identifierLookup,
-            allSdkNodes: allSdkNodes,
-            matchedSdkKeyCounts: matchedSdkKeyCounts
+            matchedSdkKeyCounts: matchedSdkKeyCounts,
+            injectedParentKeys: &injectedParentKeys
         )
 
         return ViewHierarchy(
@@ -138,6 +147,52 @@ public enum HierarchyMerger {
         identifierLookup: [String: SdkViewNode],
         allSdkNodes: [SdkViewNode]
     ) -> SdkViewNode? {
+        if let direct = findDirectMatch(
+            className: className,
+            resourceId: resourceId,
+            bounds: bounds,
+            in: lookup,
+            boundsLookup: boundsLookup,
+            identifierLookup: identifierLookup
+        ) {
+            return direct
+        }
+        // 4. Smallest enclosing SDK node: find the SDK node with smallest area
+        //    that fully contains this element's bounds.
+        if let bounds = bounds {
+            let tol = boundsTolerance
+            var bestNode: SdkViewNode?
+            var bestArea = Int.max
+            for node in allSdkNodes {
+                let nb = node.bounds
+                // Check containment with tolerance
+                if nb.left - tol <= bounds.left &&
+                   nb.top - tol <= bounds.top &&
+                   nb.right + tol >= bounds.right &&
+                   nb.bottom + tol >= bounds.bottom {
+                    let area = nb.width * nb.height
+                    if area < bestArea {
+                        bestArea = area
+                        bestNode = node
+                    }
+                }
+            }
+            return bestNode
+        }
+        return nil
+    }
+
+    /// Find a direct SDK counterpart for an XCUITest element.
+    /// Direct matches are safe to use for SDK-only injection placement; containment
+    /// matches are enrichment-only because broad containers can match many descendants.
+    private static func findDirectMatch(
+        className: String?,
+        resourceId: String?,
+        bounds: ElementBounds?,
+        in lookup: [LookupKey: SdkViewNode],
+        boundsLookup: [BoundsKey: SdkViewNode],
+        identifierLookup: [String: SdkViewNode]
+    ) -> SdkViewNode? {
         if let bounds = bounds {
             // 1. Exact match: className + bounds
             if let className = className {
@@ -162,28 +217,6 @@ public enum HierarchyMerger {
             if let idMatch = identifierLookup[resourceId] {
                 return idMatch
             }
-        }
-        // 4. Smallest enclosing SDK node: find the SDK node with smallest area
-        //    that fully contains this element's bounds
-        if let bounds = bounds {
-            let tol = boundsTolerance
-            var bestNode: SdkViewNode?
-            var bestArea = Int.max
-            for node in allSdkNodes {
-                let nb = node.bounds
-                // Check containment with tolerance
-                if nb.left - tol <= bounds.left &&
-                   nb.top - tol <= bounds.top &&
-                   nb.right + tol >= bounds.right &&
-                   nb.bottom + tol >= bounds.bottom {
-                    let area = nb.width * nb.height
-                    if area < bestArea {
-                        bestArea = area
-                        bestNode = node
-                    }
-                }
-            }
-            return bestNode
         }
         return nil
     }
@@ -303,39 +336,56 @@ public enum HierarchyMerger {
         lookup: [LookupKey: SdkViewNode],
         boundsLookup: [BoundsKey: SdkViewNode],
         identifierLookup: [String: SdkViewNode],
-        allSdkNodes: [SdkViewNode],
-        matchedSdkKeyCounts: [LookupKey: Int]
+        matchedSdkKeyCounts: [LookupKey: Int],
+        injectedParentKeys: inout Set<LookupKey>
     ) -> UIElementInfo {
         // Find the SDK node that corresponds to this XCUITest element
-        let currentSdk = sdkNode ?? findMatch(
+        let currentSdk = sdkNode ?? findDirectMatch(
             className: element.className,
             resourceId: element.resourceId,
             bounds: element.bounds,
             in: lookup,
             boundsLookup: boundsLookup,
-            identifierLookup: identifierLookup,
-            allSdkNodes: allSdkNodes
+            identifierLookup: identifierLookup
         )
 
         // Recurse into existing children, pairing each with its SDK counterpart
-        let processedChildren: [UIElementInfo]? = element.node?.map { child in
-            let childSdk = findMatch(className: child.className, resourceId: child.resourceId, bounds: child.bounds, in: lookup, boundsLookup: boundsLookup, identifierLookup: identifierLookup, allSdkNodes: allSdkNodes)
-            return injectSdkOnlyNodes(
-                element: child,
-                sdkNode: childSdk,
-                lookup: lookup,
-                boundsLookup: boundsLookup,
-                identifierLookup: identifierLookup,
-                allSdkNodes: allSdkNodes,
-                matchedSdkKeyCounts: matchedSdkKeyCounts
-            )
+        let processedChildren: [UIElementInfo]?
+        if let children = element.node {
+            var processed: [UIElementInfo] = []
+            for child in children {
+                let childSdk = findDirectMatch(
+                    className: child.className,
+                    resourceId: child.resourceId,
+                    bounds: child.bounds,
+                    in: lookup,
+                    boundsLookup: boundsLookup,
+                    identifierLookup: identifierLookup
+                )
+                processed.append(
+                    injectSdkOnlyNodes(
+                        element: child,
+                        sdkNode: childSdk,
+                        lookup: lookup,
+                        boundsLookup: boundsLookup,
+                        identifierLookup: identifierLookup,
+                        matchedSdkKeyCounts: matchedSdkKeyCounts,
+                        injectedParentKeys: &injectedParentKeys
+                    )
+                )
+            }
+            processedChildren = processed
+        } else {
+            processedChildren = nil
         }
 
         // Find SDK children of this node that have no XCUITest counterpart.
         // Use a local count to handle identical siblings: if 3 SDK children share
         // a key but only 2 were matched, the 3rd should still be injected.
         var injected: [UIElementInfo] = []
-        if let sdkChildren = currentSdk?.children {
+        if let currentSdk,
+           injectedParentKeys.insert(exactKey(for: currentSdk)).inserted,
+           let sdkChildren = currentSdk.children {
             var localKeyCounts: [LookupKey: Int] = [:]
             for sdkChild in sdkChildren {
                 let childKey = exactKey(for: sdkChild)

--- a/ios/control-proxy/Tests/CtrlProxyTests/CommandHandlerTests.swift
+++ b/ios/control-proxy/Tests/CtrlProxyTests/CommandHandlerTests.swift
@@ -239,6 +239,30 @@ final class CommandHandlerTests: XCTestCase {
         XCTAssertEqual(cache.clearCallCount, 1)
     }
 
+    func testEnrichWithCachedSdkHierarchyDoesNotProbeServerForForeignCache() {
+        let fetcher = FakeSdkHierarchyFetcher()
+        fetcher.setServerInfo(SdkHierarchyServerInfo(status: "ok", bundleId: "com.apple.Preferences"))
+        fetcher.setFreshHierarchy(makeSdkHierarchyWithTabBarNode(bundleId: "com.apple.Preferences"))
+
+        let cache = FakeSdkHierarchyCache()
+        cache.update(makeSdkHierarchyWithTabBarNode(bundleId: "dev.jasonpearson.automobile.Playground"))
+        commandHandler = CommandHandler.createForTesting(
+            elementLocator: fakeElementLocator,
+            gesturePerformer: fakeGesturePerformer,
+            perfProvider: perfProvider,
+            sdkHierarchyClient: fetcher,
+            sdkHierarchyCache: cache
+        )
+
+        let enriched = commandHandler.enrichWithCachedSdkHierarchy(makeHierarchy(packageName: "com.apple.Preferences"))
+
+        XCTAssertEqual(enriched.packageName, "com.apple.Preferences")
+        XCTAssertEqual(countClassName("UITabBarButtonLabel", in: enriched.hierarchy), 0)
+        XCTAssertEqual(fetcher.fetchServerInfoCallCount, 0)
+        XCTAssertEqual(fetcher.fetchFreshCallCount, 0)
+        XCTAssertEqual(cache.clearCallCount, 1)
+    }
+
     func testRequestHierarchyFetchesFreshSdkHierarchyOnlyWhenServerBundleMatchesForeground() {
         let fetcher = FakeSdkHierarchyFetcher()
         fetcher.setServerInfo(SdkHierarchyServerInfo(status: "ok", bundleId: "com.test.app"))

--- a/ios/control-proxy/Tests/CtrlProxyTests/CommandHandlerTests.swift
+++ b/ios/control-proxy/Tests/CtrlProxyTests/CommandHandlerTests.swift
@@ -53,7 +53,7 @@ final class CommandHandlerTests: XCTestCase {
         )
     }
 
-    private func makeSdkHierarchy(bundleId: String?) -> SdkViewHierarchy {
+    private func makeSdkHierarchy(bundleId: String?, backgroundColor: String = "#123456FF") -> SdkViewHierarchy {
         SdkViewHierarchy(
             timestamp: 1000,
             bundleId: bundleId,
@@ -63,9 +63,37 @@ final class CommandHandlerTests: XCTestCase {
             root: SdkViewNode(
                 className: "UIView",
                 bounds: SdkBounds(left: 0, top: 0, right: 375, bottom: 812),
-                backgroundColor: "#123456FF"
+                backgroundColor: backgroundColor
             )
         )
+    }
+
+    private func makeSdkHierarchyWithTabBarNode(bundleId: String?) -> SdkViewHierarchy {
+        SdkViewHierarchy(
+            timestamp: 1000,
+            bundleId: bundleId,
+            screenScale: 3.0,
+            screenWidth: 375,
+            screenHeight: 812,
+            root: SdkViewNode(
+                className: "UIView",
+                bounds: SdkBounds(left: 0, top: 0, right: 375, bottom: 812),
+                children: [
+                    SdkViewNode(
+                        className: "UITabBarButtonLabel",
+                        bounds: SdkBounds(left: 16, top: 740, right: 110, bottom: 770),
+                        accessibilityLabel: "Discover",
+                        isAccessibilityElement: true
+                    )
+                ]
+            )
+        )
+    }
+
+    private func countClassName(_ className: String, in element: UIElementInfo?) -> Int {
+        guard let element else { return 0 }
+        let current = element.className == className ? 1 : 0
+        return current + (element.node ?? []).reduce(0) { $0 + countClassName(className, in: $1) }
     }
 
     // MARK: - Hierarchy Request Tests
@@ -185,6 +213,30 @@ final class CommandHandlerTests: XCTestCase {
         XCTAssertNil(hierarchyResponse.data?.hierarchy?.extras?["sdk.backgroundColor"])
         XCTAssertEqual(fetcher.fetchServerInfoCallCount, 1)
         XCTAssertEqual(fetcher.fetchFreshCallCount, 0)
+        XCTAssertEqual(cache.clearCallCount, 1)
+    }
+
+    func testEnrichWithMatchingSdkHierarchyClearsForeignCacheWhenSdkServerIsDown() {
+        let fetcher = FakeSdkHierarchyFetcher()
+        fetcher.setServerInfo(nil)
+
+        let cache = FakeSdkHierarchyCache()
+        cache.update(makeSdkHierarchyWithTabBarNode(bundleId: "dev.jasonpearson.automobile.Playground"))
+        commandHandler = CommandHandler.createForTesting(
+            elementLocator: fakeElementLocator,
+            gesturePerformer: fakeGesturePerformer,
+            perfProvider: perfProvider,
+            sdkHierarchyClient: fetcher,
+            sdkHierarchyCache: cache
+        )
+
+        let enriched = commandHandler.enrichWithMatchingSdkHierarchy(makeHierarchy(packageName: "com.apple.Preferences"))
+
+        XCTAssertEqual(enriched.packageName, "com.apple.Preferences")
+        XCTAssertEqual(countClassName("UITabBarButtonLabel", in: enriched.hierarchy), 0)
+        XCTAssertEqual(fetcher.fetchServerInfoCallCount, 1)
+        XCTAssertEqual(fetcher.fetchFreshCallCount, 0)
+        XCTAssertEqual(cache.clearCallCount, 1)
     }
 
     func testRequestHierarchyFetchesFreshSdkHierarchyOnlyWhenServerBundleMatchesForeground() {
@@ -233,6 +285,37 @@ final class CommandHandlerTests: XCTestCase {
         XCTAssertNil(hierarchyResponse.data?.hierarchy?.extras?["sdk.backgroundColor"])
         XCTAssertEqual(fetcher.fetchServerInfoCallCount, 1)
         XCTAssertEqual(fetcher.fetchFreshCallCount, 0)
+    }
+
+    func testRequestHierarchyReplacesForeignCacheWithFreshForegroundHierarchy() {
+        let fetcher = FakeSdkHierarchyFetcher()
+        fetcher.setServerInfo(SdkHierarchyServerInfo(status: "ok", bundleId: "com.apple.Preferences"))
+        fetcher.setFreshHierarchy(makeSdkHierarchy(bundleId: "com.apple.Preferences", backgroundColor: "#ABCDEF01"))
+
+        let cache = FakeSdkHierarchyCache()
+        cache.update(makeSdkHierarchy(bundleId: "dev.sdk.app", backgroundColor: "#123456FF"))
+        commandHandler = CommandHandler.createForTesting(
+            elementLocator: fakeElementLocator,
+            gesturePerformer: fakeGesturePerformer,
+            perfProvider: perfProvider,
+            sdkHierarchyClient: fetcher,
+            sdkHierarchyCache: cache
+        )
+        fakeElementLocator.setHierarchy(makeHierarchy(packageName: "com.apple.Preferences"))
+
+        let request = WebSocketRequest(
+            type: "request_hierarchy",
+            requestId: "test-sdk-replace-cache"
+        )
+
+        guard let hierarchyResponse = handleRequest(request, as: HierarchyUpdateResponse.self) else { return }
+
+        XCTAssertEqual(hierarchyResponse.data?.hierarchy?.extras?["sdk.backgroundColor"], "#ABCDEF01")
+        XCTAssertEqual(cache.latest?.bundleId, "com.apple.Preferences")
+        XCTAssertEqual(cache.updateCallCount, 2)
+        XCTAssertEqual(cache.clearCallCount, 0)
+        XCTAssertEqual(fetcher.fetchServerInfoCallCount, 1)
+        XCTAssertEqual(fetcher.fetchFreshCallCount, 1)
     }
 
     func testRequestHierarchyError() {

--- a/ios/control-proxy/Tests/CtrlProxyTests/HierarchyMergerTests.swift
+++ b/ios/control-proxy/Tests/CtrlProxyTests/HierarchyMergerTests.swift
@@ -82,6 +82,29 @@ final class HierarchyMergerTests: XCTestCase {
         )
     }
 
+    private func countResourceId(_ resourceId: String, in element: UIElementInfo?) -> Int {
+        guard let element else { return 0 }
+        let current = element.resourceId == resourceId ? 1 : 0
+        return current + (element.node ?? []).reduce(0) { $0 + countResourceId(resourceId, in: $1) }
+    }
+
+    private func countClassName(_ className: String, in element: UIElementInfo?) -> Int {
+        guard let element else { return 0 }
+        let current = element.className == className ? 1 : 0
+        return current + (element.node ?? []).reduce(0) { $0 + countClassName(className, in: $1) }
+    }
+
+    private func countText(_ text: String, in element: UIElementInfo?) -> Int {
+        guard let element else { return 0 }
+        let current = element.text == text ? 1 : 0
+        return current + (element.node ?? []).reduce(0) { $0 + countText(text, in: $1) }
+    }
+
+    private func countNodes(in element: UIElementInfo?) -> Int {
+        guard let element else { return 0 }
+        return 1 + (element.node ?? []).reduce(0) { $0 + countNodes(in: $1) }
+    }
+
     // MARK: - No SDK Hierarchy (graceful fallback)
 
     func testMergeWithNilSdkReturnsUnchanged() {
@@ -605,6 +628,52 @@ final class HierarchyMergerTests: XCTestCase {
         XCTAssertNil(children?[0].extras?["sdk.source"])
         XCTAssertEqual(children?[1].resourceId, "sdk-only-view")
         XCTAssertEqual(children?[1].extras?["sdk.source"], "sdkWalker")
+    }
+
+    func testSdkOnlyChildrenAreNotDuplicatedUnderContainmentMatches() {
+        let xcuiChildren = (0..<3).map { index in
+            makeElement(
+                className: "ListCollectionViewCell",
+                bounds: ElementBounds(left: 0, top: 100 + index * 60, right: 390, bottom: 150 + index * 60),
+                text: "Cell \(index)"
+            )
+        }
+        let xcuiRoot = makeElement(
+            className: "UIView",
+            bounds: ElementBounds(left: 0, top: 0, right: 390, bottom: 844),
+            children: xcuiChildren
+        )
+        let tabLabels: [String] = ["Discover", "Demos", "Settings"]
+        let sdkTabLabels = tabLabels.enumerated().map { index, label in
+            makeSdkNode(
+                className: "UITabBarButtonLabel",
+                bounds: SdkBounds(left: 20 + index * 120, top: 760, right: 120 + index * 120, bottom: 790),
+                accessibilityLabel: label,
+                accessibilityIdentifier: "sdk-only-tab-label-\(label)",
+                isAccessibilityElement: true
+            )
+        }
+        let sdkRoot = makeSdkNode(
+            className: "UIView",
+            bounds: SdkBounds(left: 0, top: 0, right: 390, bottom: 844),
+            children: sdkTabLabels
+        )
+
+        let result = HierarchyMerger.merge(
+            xcuitest: makeHierarchy(root: xcuiRoot),
+            sdk: makeSdkHierarchy(root: sdkRoot)
+        )
+
+        XCTAssertEqual(
+            countResourceId("sdk-only-tab-label-Discover", in: result.hierarchy),
+            1,
+            "SDK-only children should be injected once under the direct parent, not repeated under each contained XCUITest cell"
+        )
+        XCTAssertEqual(countClassName("UITabBarButtonLabel", in: result.hierarchy), 3)
+        XCTAssertEqual(countText("Discover", in: result.hierarchy), 1)
+        XCTAssertEqual(countText("Demos", in: result.hierarchy), 1)
+        XCTAssertEqual(countText("Settings", in: result.hierarchy), 1)
+        XCTAssertEqual(countNodes(in: result.hierarchy), 7)
     }
 
     // MARK: - Hierarchy Metadata Preserved


### PR DESCRIPTION
## Summary

- Scope iOS SDK hierarchy enrichment through the same foreground-bundle guard for explicit observes and debounced broadcasts
- Clear or replace stale SDK hierarchy cache entries when the cached SDK bundle does not match the foreground app
- Prevent SDK-only subtree injection from repeating under containment-only XCUITest matches
- Add regressions for foreign cached SDK nodes, fresh cache replacement, and bounded 3-tab hierarchy duplication

## Root Cause

The explicit hierarchy request path had a foreground-bundle guard, but the debounced broadcast path still merged `sdkHierarchyCache.latest` directly. The merge injection pass also used containment matches as SDK parent placement, so broad SDK containers could cause SDK-only children, such as tab bar labels, to be attached repeatedly under unrelated XCUITest descendants.

## Validation

- `swift test -Xswiftc -warnings-as-errors` from `ios/control-proxy` passed: 214 tests
- `git diff --check` passed

## Notes

- Addresses the reopened feedback in #2540.
- Broader `bash scripts/ios/swift-test.sh` was run earlier and failed only in the live `XCTestRunner` Reminders integration because the simulator could not tap `Done`; `control-proxy` passed in that broader run.
