### PR TITLE
chore: bump versions to v0.0.38

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -14,7 +14,7 @@
       "name": "auto-mobile",
       "source": "./",
       "description": "Mobile device automation for Android and iOS - control devices with natural language",
-      "version": "0.0.37",
+      "version": "0.0.38",
       "author": {
         "name": "AutoMobile Contributors",
         "email": "jason.d.pearson@gmail.com"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "auto-mobile",
   "description": "Mobile device automation for Android and iOS - control devices with natural language",
-  "version": "0.0.37",
+  "version": "0.0.38",
   "author": {
     "name": "AutoMobile Contributors",
     "email": "jason.d.pearson@gmail.com"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,35 @@
 # Changelog
 
+## [v0.0.38] - 2026-06-25
+### Added
+- feat(android): accessibilityFocus — set/clear TalkBack cursor focus ([#2503](https://github.com/kaeawc/auto-mobile/issues/2503)) (android, a11y)
+- feat(ios): biometricAuth — Touch ID / Face ID simulation via simctl Darwin notifications ([#2497](https://github.com/kaeawc/auto-mobile/issues/2497)) (ios)
+- feat(ios): getNotificationPolicy — read per-app notification authorization on simulators via BulletinBoard ([#2496](https://github.com/kaeawc/auto-mobile/issues/2496)) (ios, research)
+- feat(ios): postNotification — deliver simulated push to target bundle via simctl push ([#2495](https://github.com/kaeawc/auto-mobile/issues/2495)) (ios)
+- feat(ios): deviceSnapshot — capture and restore simulator settings (includeSettings) ([#2494](https://github.com/kaeawc/auto-mobile/issues/2494)) (ios)
+- feat(ios): setDeviceState — Do Not Disturb mode fidelity and physical-device support ([#2493](https://github.com/kaeawc/auto-mobile/issues/2493)) (ios, research)
+- feat(ios): getDeepLinks — URL scheme & universal link discovery via Info.plist ([#2486](https://github.com/kaeawc/auto-mobile/issues/2486)) (ios)
+- feat(ios): dragAndDrop — coordinate drag via XCUITest CtrlProxy runner ([#2481](https://github.com/kaeawc/auto-mobile/issues/2481)) (ios)
+### Fixed
+- fix(ios): daemon runs the published-release CtrlProxy runner, not source — new runner commands fail "Unknown command type" against a stale binary ([#2539](https://github.com/kaeawc/auto-mobile/issues/2539)) (ios)
+- fix(ios): CtrlProxy WebSocket and AutoMobile SDK server collide on port 8766 — all iOS observe/gesture ops fail (Expected 101) ([#2538](https://github.com/kaeawc/auto-mobile/issues/2538)) (ios)
+- fix(daemon): signal/exception handlers registered inside main() after dynamic imports — startup window with no cleanup (regression from #2465) ([#2532](https://github.com/kaeawc/auto-mobile/issues/2532)) (release engineering)
+- fix(ios): observation stream double-pushes initial hierarchy frame on cold subscribe ([#2530](https://github.com/kaeawc/auto-mobile/issues/2530)) (ios)
+### Other
+- Client can silently use a daemon of a mismatched version (@latest spawn + restart cooldown) ([#2452](https://github.com/kaeawc/auto-mobile/issues/2452))
+- Crash/force-kill leaves stale PID and socket files; no exit-time cleanup ([#2451](https://github.com/kaeawc/auto-mobile/issues/2451))
+- Device disconnects are not surfaced to observation-stream subscribers ([#2450](https://github.com/kaeawc/auto-mobile/issues/2450))
+- Screenshot backoff stops after initial burst; live view freezes on static screens ([#2449](https://github.com/kaeawc/auto-mobile/issues/2449))
+- Observation stream pushes no initial frame on subscribe; idle devices show blank ([#2448](https://github.com/kaeawc/auto-mobile/issues/2448))
+- Observation-stream request_observation command is a no-op; socket clients cannot force a frame ([#2447](https://github.com/kaeawc/auto-mobile/issues/2447))
+- Daemon stream socket paths are not discoverable, causing silent connect failures on env mismatch ([#2446](https://github.com/kaeawc/auto-mobile/issues/2446))
+- Device pool never prunes shut-down devices, wedging discovery until daemon restart ([#2445](https://github.com/kaeawc/auto-mobile/issues/2445))
+- Daemon readiness inferred from PID/socket-file existence, not an actual connection ([#2444](https://github.com/kaeawc/auto-mobile/issues/2444))
+- Device held ~30s when a client dies before its first heartbeat ([#2443](https://github.com/kaeawc/auto-mobile/issues/2443))
+- iOS device pool never auto-boots an installed-but-shutdown simulator to satisfy criteria ([#2442](https://github.com/kaeawc/auto-mobile/issues/2442))
+- Daemon version skew is only reconciled one direction; stale daemon can serve newer clients ([#2441](https://github.com/kaeawc/auto-mobile/issues/2441))
+- Add a fast `--version` flag; today it hangs by falling through to the stdio server ([#2440](https://github.com/kaeawc/auto-mobile/issues/2440))
+
 ## [v0.0.37] - 2026-06-24
 ### Other
 - No changes.

--- a/android/control-proxy/build.gradle.kts
+++ b/android/control-proxy/build.gradle.kts
@@ -36,7 +36,7 @@ android {
     minSdk = libs.versions.build.android.minSdk.get().toInt()
     targetSdk = libs.versions.build.android.targetSdk.get().toInt()
     versionCode = 1
-    versionName = "0.0.37-SNAPSHOT"
+    versionName = "0.0.38-SNAPSHOT"
 
     testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
   }

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -140,7 +140,7 @@ org.jetbrains.dokka.experimental.gradle.pluginMode=V2Enabled
 # Maven Central Publishing
 
 # Library versions (single source of truth)
-VERSION_NAME=0.0.37-SNAPSHOT
+VERSION_NAME=0.0.38-SNAPSHOT
 GROUP=dev.jasonpearson.auto-mobile
 
 # POM metadata

--- a/android/playground/app/build.gradle.kts
+++ b/android/playground/app/build.gradle.kts
@@ -36,7 +36,7 @@ android {
     minSdk = libs.versions.build.android.minSdk.get().toInt()
     targetSdk = libs.versions.build.android.targetSdk.get().toInt()
     versionCode = 1
-    versionName = "0.0.37-SNAPSHOT"
+    versionName = "0.0.38-SNAPSHOT"
 
     testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kaeawc/auto-mobile",
-  "version": "0.0.37",
+  "version": "0.0.38",
   "description": "Mobile device interaction automation via MCP",
   "scripts": {
     "test": "bun test",

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "dev.jasonpearson/auto-mobile",
   "title": "AutoMobile",
   "description": "Mobile device interaction automation via MCP",
-  "version": "0.0.37",
+  "version": "0.0.38",
   "websiteUrl": "https://kaeawc.github.io/auto-mobile/",
   "repository": {
     "url": "https://github.com/kaeawc/auto-mobile",
@@ -13,7 +13,7 @@
     {
       "registryType": "npm",
       "identifier": "@kaeawc/auto-mobile",
-      "version": "0.0.37",
+      "version": "0.0.38",
       "runtimeHint": "bunx",
       "transport": {
         "type": "stdio"

--- a/src/constants/release.ts
+++ b/src/constants/release.ts
@@ -26,6 +26,11 @@ export interface ReleaseChecksumEntry {
  */
 export const RELEASE_CHECKSUM_REGISTRY: ReleaseChecksumEntry[] = [
   {
+    version: "0.0.38",
+    apkSha256: "0fb955a617654695036642662634d042c2e3d278b8e1dce20ccb37e425f059f3",
+    ipaSha256: "f5a4a485ff8ebf3bfd0d73c8b7b10769177b419ccd62e48db188bb5122a2fcde",
+  },
+  {
     version: "0.0.37",
     apkSha256: "f9b0cc92bf8f7416cdb0c458e16c7a41e4fdeefb80bb9429ab7c603388c99083",
     ipaSha256: "caccbfaa4da0015bab701a36b81ac87e3f3f3330cee77bb10ec8553724275f4f",


### PR DESCRIPTION
## Summary
- Bump versions to v0.0.38
- Update CHANGELOG.md from closed issues since the last tag
- Refresh CtrlProxy APK SHA256 checksum
- Refresh CtrlProxy iOS IPA SHA256 checksum

## Automation
- Generated by `prepare-release` workflow