### PR TITLE
fix: make openLink request timeout configurable

### DIFF
--- a/docs/design-docs/mcp/daemon/unix-socket-api.md
+++ b/docs/design-docs/mcp/daemon/unix-socket-api.md
@@ -34,7 +34,7 @@ All messages are newline-delimited JSON sent over the Unix socket. Each request 
 | `type` | `"mcp_request" \| "daemon_request"` | Yes | Request category |
 | `method` | `string` | Yes | Endpoint name (e.g. `ide/ping`, `daemon/availableDevices`) |
 | `params` | `object` | Yes | Method-specific parameters; pass `{}` when none are needed |
-| `timeoutMs` | `number` | No | Per-request timeout in milliseconds (default: 30 000) |
+| `timeoutMs` | `number` | No | Per-request timeout in milliseconds (default: 30 000). Long-running `tools/call` requests may be raised to a tool-specific minimum timeout by the daemon. `openLink` can be configured with `AUTOMOBILE_OPEN_LINK_MCP_TIMEOUT_MS` (legacy alias: `AUTO_MOBILE_OPEN_LINK_MCP_TIMEOUT_MS`), defaulting to 30 000 ms. |
 
 **Response**
 

--- a/src/daemon/mcpRequestTimeout.ts
+++ b/src/daemon/mcpRequestTimeout.ts
@@ -27,11 +27,34 @@ export const MIN_START_DEVICE_MCP_TIMEOUT_MS = 180_000;
  */
 export const MIN_LAUNCH_APP_MCP_TIMEOUT_MS = 90_000;
 
+/**
+ * Floor for `openLink` — deep links can trigger sign-in, onboarding, data sync,
+ * or other post-open navigation before the final observation settles. Keep the
+ * default at the standard request timeout, while allowing deployments with slow
+ * deeplinks to raise it without changing callers.
+ */
+export const DEFAULT_OPEN_LINK_MCP_TIMEOUT_MS = DEFAULT_MCP_REQUEST_TIMEOUT_MS;
+export const OPEN_LINK_MCP_TIMEOUT_ENV_VAR = "AUTOMOBILE_OPEN_LINK_MCP_TIMEOUT_MS";
+export const LEGACY_OPEN_LINK_MCP_TIMEOUT_ENV_VAR = "AUTO_MOBILE_OPEN_LINK_MCP_TIMEOUT_MS";
+
+function resolveOpenLinkMcpTimeoutFloorMs(): number {
+  const raw = process.env[OPEN_LINK_MCP_TIMEOUT_ENV_VAR] ??
+    process.env[LEGACY_OPEN_LINK_MCP_TIMEOUT_ENV_VAR];
+  if (!raw) {
+    return DEFAULT_OPEN_LINK_MCP_TIMEOUT_MS;
+  }
+  const parsed = Number.parseInt(raw, 10);
+  return Number.isFinite(parsed) && parsed > 0
+    ? parsed
+    : DEFAULT_OPEN_LINK_MCP_TIMEOUT_MS;
+}
+
 /** Per-tool minimum request timeouts. Tools absent here use the default. */
-const TOOL_TIMEOUT_FLOORS: Record<string, number> = {
-  executePlan: MIN_EXECUTE_PLAN_MCP_TIMEOUT_MS,
-  startDevice: MIN_START_DEVICE_MCP_TIMEOUT_MS,
-  launchApp: MIN_LAUNCH_APP_MCP_TIMEOUT_MS,
+const TOOL_TIMEOUT_FLOORS: Record<string, () => number> = {
+  executePlan: () => MIN_EXECUTE_PLAN_MCP_TIMEOUT_MS,
+  startDevice: () => MIN_START_DEVICE_MCP_TIMEOUT_MS,
+  launchApp: () => MIN_LAUNCH_APP_MCP_TIMEOUT_MS,
+  openLink: resolveOpenLinkMcpTimeoutFloorMs,
 };
 
 export function resolveMcpRequestTimeoutMs(request: DaemonRequest): number {
@@ -40,8 +63,9 @@ export function resolveMcpRequestTimeoutMs(request: DaemonRequest): number {
     typeof raw === "number" && Number.isFinite(raw) && raw > 0
       ? raw
       : DEFAULT_MCP_REQUEST_TIMEOUT_MS;
-  const floor = request.method === "tools/call"
+  const resolveFloor = request.method === "tools/call"
     ? TOOL_TIMEOUT_FLOORS[request.params?.name]
     : undefined;
+  const floor = resolveFloor?.();
   return floor ? Math.max(base, floor) : base;
 }

--- a/src/daemon/mcpRequestTimeout.ts
+++ b/src/daemon/mcpRequestTimeout.ts
@@ -49,13 +49,20 @@ function resolveOpenLinkMcpTimeoutFloorMs(): number {
     : DEFAULT_OPEN_LINK_MCP_TIMEOUT_MS;
 }
 
-/** Per-tool minimum request timeouts. Tools absent here use the default. */
-const TOOL_TIMEOUT_FLOORS: Record<string, () => number> = {
-  executePlan: () => MIN_EXECUTE_PLAN_MCP_TIMEOUT_MS,
-  startDevice: () => MIN_START_DEVICE_MCP_TIMEOUT_MS,
-  launchApp: () => MIN_LAUNCH_APP_MCP_TIMEOUT_MS,
-  openLink: resolveOpenLinkMcpTimeoutFloorMs,
-};
+function resolveToolTimeoutFloorMs(toolName: string | undefined): number | undefined {
+  switch (toolName) {
+    case "executePlan":
+      return MIN_EXECUTE_PLAN_MCP_TIMEOUT_MS;
+    case "startDevice":
+      return MIN_START_DEVICE_MCP_TIMEOUT_MS;
+    case "launchApp":
+      return MIN_LAUNCH_APP_MCP_TIMEOUT_MS;
+    case "openLink":
+      return resolveOpenLinkMcpTimeoutFloorMs();
+    default:
+      return undefined;
+  }
+}
 
 export function resolveMcpRequestTimeoutMs(request: DaemonRequest): number {
   const raw = request.timeoutMs;
@@ -63,9 +70,8 @@ export function resolveMcpRequestTimeoutMs(request: DaemonRequest): number {
     typeof raw === "number" && Number.isFinite(raw) && raw > 0
       ? raw
       : DEFAULT_MCP_REQUEST_TIMEOUT_MS;
-  const resolveFloor = request.method === "tools/call"
-    ? TOOL_TIMEOUT_FLOORS[request.params?.name]
+  const floor = request.method === "tools/call"
+    ? resolveToolTimeoutFloorMs(request.params?.name)
     : undefined;
-  const floor = resolveFloor?.();
   return floor ? Math.max(base, floor) : base;
 }

--- a/test/daemon/mcpRequestTimeout.test.ts
+++ b/test/daemon/mcpRequestTimeout.test.ts
@@ -1,13 +1,37 @@
-import { describe, expect, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import {
   DEFAULT_MCP_REQUEST_TIMEOUT_MS,
+  DEFAULT_OPEN_LINK_MCP_TIMEOUT_MS,
+  LEGACY_OPEN_LINK_MCP_TIMEOUT_ENV_VAR,
   MIN_EXECUTE_PLAN_MCP_TIMEOUT_MS,
   MIN_START_DEVICE_MCP_TIMEOUT_MS,
+  OPEN_LINK_MCP_TIMEOUT_ENV_VAR,
   resolveMcpRequestTimeoutMs
 } from "../../src/daemon/mcpRequestTimeout";
 import type { DaemonRequest } from "../../src/daemon/types";
 
 describe("resolveMcpRequestTimeoutMs", () => {
+  const originalOpenLinkTimeout = process.env[OPEN_LINK_MCP_TIMEOUT_ENV_VAR];
+  const originalLegacyOpenLinkTimeout = process.env[LEGACY_OPEN_LINK_MCP_TIMEOUT_ENV_VAR];
+
+  beforeEach(() => {
+    delete process.env[OPEN_LINK_MCP_TIMEOUT_ENV_VAR];
+    delete process.env[LEGACY_OPEN_LINK_MCP_TIMEOUT_ENV_VAR];
+  });
+
+  afterEach(() => {
+    if (originalOpenLinkTimeout === undefined) {
+      delete process.env[OPEN_LINK_MCP_TIMEOUT_ENV_VAR];
+    } else {
+      process.env[OPEN_LINK_MCP_TIMEOUT_ENV_VAR] = originalOpenLinkTimeout;
+    }
+    if (originalLegacyOpenLinkTimeout === undefined) {
+      delete process.env[LEGACY_OPEN_LINK_MCP_TIMEOUT_ENV_VAR];
+    } else {
+      process.env[LEGACY_OPEN_LINK_MCP_TIMEOUT_ENV_VAR] = originalLegacyOpenLinkTimeout;
+    }
+  });
+
   test("uses default for non-executePlan tools/call", () => {
     const request: DaemonRequest = {
       id: "1",
@@ -124,5 +148,89 @@ describe("resolveMcpRequestTimeoutMs", () => {
       timeoutMs: 300_000
     };
     expect(resolveMcpRequestTimeoutMs(request)).toBe(300_000);
+  });
+
+  test("applies default openLink floor when client omits timeoutMs", () => {
+    const request: DaemonRequest = {
+      id: "1",
+      type: "mcp_request",
+      method: "tools/call",
+      params: { name: "openLink", arguments: {} }
+    };
+    expect(resolveMcpRequestTimeoutMs(request)).toBe(DEFAULT_OPEN_LINK_MCP_TIMEOUT_MS);
+  });
+
+  test("raises short openLink timeouts to the default floor", () => {
+    const request: DaemonRequest = {
+      id: "1",
+      type: "mcp_request",
+      method: "tools/call",
+      params: { name: "openLink", arguments: {} },
+      timeoutMs: 10_000
+    };
+    expect(resolveMcpRequestTimeoutMs(request)).toBe(DEFAULT_OPEN_LINK_MCP_TIMEOUT_MS);
+  });
+
+  test("applies configured openLink floor from environment", () => {
+    process.env[OPEN_LINK_MCP_TIMEOUT_ENV_VAR] = "90000";
+
+    const request: DaemonRequest = {
+      id: "1",
+      type: "mcp_request",
+      method: "tools/call",
+      params: { name: "openLink", arguments: {} }
+    };
+    expect(resolveMcpRequestTimeoutMs(request)).toBe(90_000);
+  });
+
+  test("applies legacy configured openLink floor from environment", () => {
+    process.env[LEGACY_OPEN_LINK_MCP_TIMEOUT_ENV_VAR] = "45000";
+
+    const request: DaemonRequest = {
+      id: "1",
+      type: "mcp_request",
+      method: "tools/call",
+      params: { name: "openLink", arguments: {} }
+    };
+    expect(resolveMcpRequestTimeoutMs(request)).toBe(45_000);
+  });
+
+  test("raises short openLink timeouts to configured environment floor", () => {
+    process.env[OPEN_LINK_MCP_TIMEOUT_ENV_VAR] = "90000";
+
+    const request: DaemonRequest = {
+      id: "1",
+      type: "mcp_request",
+      method: "tools/call",
+      params: { name: "openLink", arguments: {} },
+      timeoutMs: 30_000
+    };
+    expect(resolveMcpRequestTimeoutMs(request)).toBe(90_000);
+  });
+
+  test("preserves openLink timeouts above configured environment floor", () => {
+    process.env[OPEN_LINK_MCP_TIMEOUT_ENV_VAR] = "90000";
+
+    const request: DaemonRequest = {
+      id: "1",
+      type: "mcp_request",
+      method: "tools/call",
+      params: { name: "openLink", arguments: {} },
+      timeoutMs: 120_000
+    };
+    expect(resolveMcpRequestTimeoutMs(request)).toBe(120_000);
+  });
+
+  test("falls back to default openLink floor for invalid environment values", () => {
+    process.env[OPEN_LINK_MCP_TIMEOUT_ENV_VAR] = "not-a-number";
+
+    const request: DaemonRequest = {
+      id: "1",
+      type: "mcp_request",
+      method: "tools/call",
+      params: { name: "openLink", arguments: {} },
+      timeoutMs: 10_000
+    };
+    expect(resolveMcpRequestTimeoutMs(request)).toBe(DEFAULT_OPEN_LINK_MCP_TIMEOUT_MS);
   });
 });


### PR DESCRIPTION
## Summary
- Make the `openLink` MCP request-timeout floor configurable with `AUTOMOBILE_OPEN_LINK_MCP_TIMEOUT_MS`.
- Keep the default `openLink` floor at the standard 30s request timeout and support the legacy `AUTO_MOBILE_OPEN_LINK_MCP_TIMEOUT_MS` alias.
- Cover default, configured, legacy, invalid, short, and explicit larger `openLink` timeout cases in `resolveMcpRequestTimeoutMs` tests.
- Document the `openLink` timeout environment variable in the daemon socket API docs.

Fixes #2558

## Testing
- `bun test test/daemon/mcpRequestTimeout.test.ts`
- `bun run build`
- `bun run lint`
- `bun test --bail` (first run hit an unrelated transient SQLite `database is locked` failure in `SmartNavigationHelper.test.ts`; rerun passed)
