### PR TITLE
Fix SQLite busy timeout and support parallel daemon requests

### DIFF
--- a/src/daemon/daemonRequestHandlers.ts
+++ b/src/daemon/daemonRequestHandlers.ts
@@ -11,6 +11,10 @@ export interface DaemonStateAccess {
     refreshDevices(): Promise<number>;
     getStats(): DevicePoolStats;
     releaseDevice(deviceId: string): Promise<void>;
+    resolveAutolockSessionForMcpSession?(
+      mcpSessionId: string | undefined,
+      platform?: "android" | "ios"
+    ): string | undefined;
   };
 }
 

--- a/src/daemon/socketServer.ts
+++ b/src/daemon/socketServer.ts
@@ -390,6 +390,11 @@ export class UnixSocketServer {
         return scopedKey;
       }
 
+      const implicitAutolockKey = this.getImplicitAutolockScopeKey(socketSessionId, args);
+      if (implicitAutolockKey) {
+        return implicitAutolockKey;
+      }
+
       // The daemon injects __mcpSessionId before forwarding. Use the socket session as the
       // pre-forward key so separate daemon clients can autolock and run independently.
       return `socket:${socketSessionId}`;
@@ -426,9 +431,37 @@ export class UnixSocketServer {
       return `session:${sessionUuid}`;
     }
     if (typeof record.__mcpSessionId === "string" && record.__mcpSessionId.length > 0) {
-      return `mcp-session:${record.__mcpSessionId}`;
+      return this.getImplicitAutolockScopeKey(record.__mcpSessionId, args) ?? `mcp-session:${record.__mcpSessionId}`;
     }
     return undefined;
+  }
+
+  private getImplicitAutolockScopeKey(mcpSessionId: string, args: unknown): string | undefined {
+    if (!this.daemonState.isInitialized()) {
+      return undefined;
+    }
+    try {
+      const platform = this.getRequestPlatform(args);
+      const autolockSession = this.daemonState
+        .getDevicePool()
+        .resolveAutolockSessionForMcpSession?.(mcpSessionId, platform);
+      if (!autolockSession) {
+        return undefined;
+      }
+      const assignedDevice = this.getAssignedDeviceForSession(autolockSession);
+      return assignedDevice ? `device:${assignedDevice}` : `session:${autolockSession}`;
+    } catch (error) {
+      logger.debug(`Unable to resolve autolock session for MCP session ${mcpSessionId}: ${error}`);
+      return undefined;
+    }
+  }
+
+  private getRequestPlatform(args: unknown): "android" | "ios" | undefined {
+    if (!args || typeof args !== "object" || Array.isArray(args)) {
+      return undefined;
+    }
+    const platform = (args as Record<string, unknown>).platform;
+    return platform === "android" || platform === "ios" ? platform : undefined;
   }
 
   private resolveDeviceLabelSession(baseSessionUuid: string, deviceLabel: unknown): string {

--- a/src/daemon/socketServer.ts
+++ b/src/daemon/socketServer.ts
@@ -399,12 +399,28 @@ export class UnixSocketServer {
       return `device:${record.deviceId}`;
     }
     if (typeof record.sessionUuid === "string" && record.sessionUuid.length > 0) {
+      const assignedDevice = this.getAssignedDeviceForSession(record.sessionUuid);
+      if (assignedDevice) {
+        return `device:${assignedDevice}`;
+      }
       return `session:${record.sessionUuid}`;
     }
     if (typeof record.__mcpSessionId === "string" && record.__mcpSessionId.length > 0) {
       return `mcp-session:${record.__mcpSessionId}`;
     }
     return undefined;
+  }
+
+  private getAssignedDeviceForSession(sessionUuid: string): string | undefined {
+    if (!this.daemonState.isInitialized()) {
+      return undefined;
+    }
+    try {
+      return this.daemonState.getSessionManager().getSession(sessionUuid)?.assignedDevice;
+    } catch (error) {
+      logger.debug(`Unable to resolve device for session ${sessionUuid}: ${error}`);
+      return undefined;
+    }
   }
 
   /** Compact label for debug logs (method + tool name or resource URI). */

--- a/src/daemon/socketServer.ts
+++ b/src/daemon/socketServer.ts
@@ -39,6 +39,7 @@ import type { KeyValueType } from "../features/storage/storageTypes";
 /** Must exceed the longest per-request MCP timeout (executePlan = 10 min), else long tool calls get killed mid-flight. */
 const DAEMON_RPC_SOCKET_IDLE_TIMEOUT_MS = MIN_EXECUTE_PLAN_MCP_TIMEOUT_MS + 5 * 60 * 1000;
 const MCP_CLIENT_IDLE_CLOSE_MS = 5 * 60 * 1000;
+const DEVICE_LABEL_CACHE_KEY = "deviceLabelMap";
 
 /**
  * Unix Socket Server that proxies requests to the HTTP MCP server
@@ -263,9 +264,9 @@ export class UnixSocketServer {
 
         const queueEnterMs = this.timer.now();
         const totalTimeoutMs = resolveMcpRequestTimeoutMs(request);
-        const forwardKey = this.getMcpForwardKey(request, sessionId);
+        const initialForwardKey = this.getMcpForwardKey(request, sessionId);
 
-        const result = await this.runKeyedMcpForward(forwardKey, async () => {
+        const result = await this.runMcpForwardForCurrentKey(initialForwardKey, request, sessionId, async forwardKey => {
           const queueWaitMs = this.timer.now() - queueEnterMs;
           const remainingTimeoutMs = totalTimeoutMs - queueWaitMs;
           const forwardLabel = UnixSocketServer.describeMcpForwardRequest(request);
@@ -363,6 +364,24 @@ export class UnixSocketServer {
     return run;
   }
 
+  private runMcpForwardForCurrentKey<T>(
+    initialKey: string,
+    request: DaemonRequest,
+    socketSessionId: string,
+    fn: (forwardKey: string) => Promise<T>
+  ): Promise<T> {
+    return this.runKeyedMcpForward(initialKey, async () => {
+      const currentKey = this.getMcpForwardKey(request, socketSessionId);
+      if (currentKey !== initialKey) {
+        logger.debug(
+          `[McpForward] rekey requestId=${request.id} initialKey=${initialKey} currentKey=${currentKey}`
+        );
+        return await this.runMcpForwardForCurrentKey(currentKey, request, socketSessionId, fn);
+      }
+      return await fn(currentKey);
+    });
+  }
+
   private getMcpForwardKey(request: DaemonRequest, socketSessionId: string): string {
     if (request.method === "tools/call") {
       const args = request.params?.arguments;
@@ -399,16 +418,39 @@ export class UnixSocketServer {
       return `device:${record.deviceId}`;
     }
     if (typeof record.sessionUuid === "string" && record.sessionUuid.length > 0) {
-      const assignedDevice = this.getAssignedDeviceForSession(record.sessionUuid);
+      const sessionUuid = this.resolveDeviceLabelSession(record.sessionUuid, record.device);
+      const assignedDevice = this.getAssignedDeviceForSession(sessionUuid);
       if (assignedDevice) {
         return `device:${assignedDevice}`;
       }
-      return `session:${record.sessionUuid}`;
+      return `session:${sessionUuid}`;
     }
     if (typeof record.__mcpSessionId === "string" && record.__mcpSessionId.length > 0) {
       return `mcp-session:${record.__mcpSessionId}`;
     }
     return undefined;
+  }
+
+  private resolveDeviceLabelSession(baseSessionUuid: string, deviceLabel: unknown): string {
+    if (typeof deviceLabel !== "string" || deviceLabel.length === 0 || !this.daemonState.isInitialized()) {
+      return baseSessionUuid;
+    }
+    try {
+      const labelMap = this.daemonState
+        .getSessionManager()
+        .getSession(baseSessionUuid)
+        ?.cacheData.customData?.[DEVICE_LABEL_CACHE_KEY];
+      if (!labelMap || typeof labelMap !== "object" || Array.isArray(labelMap)) {
+        return baseSessionUuid;
+      }
+      const mappedSession = (labelMap as Record<string, unknown>)[deviceLabel];
+      return typeof mappedSession === "string" && mappedSession.length > 0
+        ? mappedSession
+        : baseSessionUuid;
+    } catch (error) {
+      logger.debug(`Unable to resolve device label ${deviceLabel} for session ${baseSessionUuid}: ${error}`);
+      return baseSessionUuid;
+    }
   }
 
   private getAssignedDeviceForSession(sessionUuid: string): string | undefined {

--- a/src/daemon/socketServer.ts
+++ b/src/daemon/socketServer.ts
@@ -394,11 +394,12 @@ export class UnixSocketServer {
     }
 
     const record = args as Record<string, unknown>;
-    if (typeof record.sessionUuid === "string" && record.sessionUuid.length > 0) {
-      return `session:${record.sessionUuid}`;
-    }
+    // An explicit target device must serialize by physical device even when a session is present.
     if (typeof record.deviceId === "string" && record.deviceId.length > 0) {
       return `device:${record.deviceId}`;
+    }
+    if (typeof record.sessionUuid === "string" && record.sessionUuid.length > 0) {
+      return `session:${record.sessionUuid}`;
     }
     if (typeof record.__mcpSessionId === "string" && record.__mcpSessionId.length > 0) {
       return `mcp-session:${record.__mcpSessionId}`;

--- a/src/daemon/socketServer.ts
+++ b/src/daemon/socketServer.ts
@@ -38,6 +38,7 @@ import { defaultAdbClientFactory } from "../utils/android-cmdline-tools/AdbClien
 import type { KeyValueType } from "../features/storage/storageTypes";
 /** Must exceed the longest per-request MCP timeout (executePlan = 10 min), else long tool calls get killed mid-flight. */
 const DAEMON_RPC_SOCKET_IDLE_TIMEOUT_MS = MIN_EXECUTE_PLAN_MCP_TIMEOUT_MS + 5 * 60 * 1000;
+const MCP_CLIENT_IDLE_CLOSE_MS = 5 * 60 * 1000;
 
 /**
  * Unix Socket Server that proxies requests to the HTTP MCP server
@@ -50,9 +51,9 @@ const DAEMON_RPC_SOCKET_IDLE_TIMEOUT_MS = MIN_EXECUTE_PLAN_MCP_TIMEOUT_MS + 5 * 
  * - Manage concurrent client sessions
  *
  * JUnit uses one Unix socket per thread (`DaemonSocketClientManager` ThreadLocal) for parallel
- * tests, but this server shares a single in-process MCP HTTP client (one Streamable HTTP session).
- * Concurrent `callTool` on that client corrupts the session and yields transport errors plus
- * `Operation cancelled` on in-flight `executePlan`. All MCP forwards are serialized below.
+ * tests. Each MCP HTTP client owns one Streamable HTTP session, so concurrent calls on the same
+ * client are unsafe. MCP forwards are serialized by target key below, and each key gets its own
+ * MCP client so independent devices/sessions can run concurrently.
  *
  * The SDK's Streamable HTTP client may auto-reopen a standalone GET (SSE) after a disconnect.
  * The server transport allows only one such stream per session; a second GET while the first
@@ -79,10 +80,11 @@ export class UnixSocketServer {
   private socketPath: string;
   private mcpEndpoint: string;
   private daemonState: DaemonStateAccess;
-  private mcpClient: Client | null = null;
-  private mcpClientPromise: Promise<Client> | null = null;
-  /** Tail of a promise chain that serializes MCP HTTP forwards across all socket connections. */
-  private mcpForwardTail: Promise<void> = Promise.resolve();
+  private mcpClients: Map<string, Client> = new Map();
+  private mcpClientPromises: Map<string, Promise<Client>> = new Map();
+  /** Promise tails that serialize MCP HTTP forwards only within the same target key. */
+  private mcpForwardTails: Map<string, Promise<void>> = new Map();
+  private mcpClientIdleTimers: Map<string, NodeJS.Timeout> = new Map();
   private timer: Timer;
   private featureFlagService: FeatureFlagService | null;
 
@@ -261,13 +263,14 @@ export class UnixSocketServer {
 
         const queueEnterMs = this.timer.now();
         const totalTimeoutMs = resolveMcpRequestTimeoutMs(request);
+        const forwardKey = this.getMcpForwardKey(request, sessionId);
 
-        const result = await this.runExclusiveMcpForward(async () => {
+        const result = await this.runKeyedMcpForward(forwardKey, async () => {
           const queueWaitMs = this.timer.now() - queueEnterMs;
           const remainingTimeoutMs = totalTimeoutMs - queueWaitMs;
           const forwardLabel = UnixSocketServer.describeMcpForwardRequest(request);
           logger.debug(
-            `[McpForward] start socketSession=${sessionId} requestId=${request.id} ${forwardLabel} queueWaitMs=${queueWaitMs} remainingTimeoutMs=${remainingTimeoutMs}`
+            `[McpForward] start key=${forwardKey} socketSession=${sessionId} requestId=${request.id} ${forwardLabel} queueWaitMs=${queueWaitMs} remainingTimeoutMs=${remainingTimeoutMs}`
           );
 
           if (remainingTimeoutMs <= 0) {
@@ -282,7 +285,7 @@ export class UnixSocketServer {
 
           const forwardStartMs = this.timer.now();
           try {
-            const mcpClient = await this.getMcpClient();
+            const mcpClient = await this.getMcpClient(forwardKey);
 
             try {
               return await this.handleIdeRequest(mcpClient, request, remainingTimeoutMs, sessionId);
@@ -290,9 +293,8 @@ export class UnixSocketServer {
               const ideErrorMessage = ideError instanceof Error ? ideError.message : String(ideError);
               if (ideErrorMessage.includes("Session not found")) {
                 logger.warn("MCP client session expired, reconnecting and retrying...");
-                this.mcpClient = null;
-                this.mcpClientPromise = null;
-                const freshClient = await this.getMcpClient();
+                await this.resetMcpClient(forwardKey);
+                const freshClient = await this.getMcpClient(forwardKey);
                 const retryRemainingMs = remainingTimeoutMs - (this.timer.now() - forwardStartMs);
                 if (retryRemainingMs <= 0) {
                   const toolName = request.method === "tools/call" ? request.params?.name ?? request.method : request.method;
@@ -309,7 +311,7 @@ export class UnixSocketServer {
             }
           } finally {
             logger.debug(
-              `[McpForward] end socketSession=${sessionId} requestId=${request.id} ${forwardLabel} forwardMs=${this.timer.now() - forwardStartMs}`
+              `[McpForward] end key=${forwardKey} socketSession=${sessionId} requestId=${request.id} ${forwardLabel} forwardMs=${this.timer.now() - forwardStartMs}`
             );
           }
         });
@@ -337,16 +339,71 @@ export class UnixSocketServer {
   }
 
   /**
-   * Run one MCP forward at a time. The shared `mcpClient` is not safe under concurrent
-   * `tools/call` (long SSE responses from `executePlan` interleaved with other RPCs).
+   * Run one MCP forward at a time for a single target key. Each key owns a separate MCP client,
+   * so calls for different devices or sessions can proceed concurrently without sharing one
+   * Streamable HTTP session.
    */
-  private runExclusiveMcpForward<T>(fn: () => Promise<T>): Promise<T> {
-    const run = this.mcpForwardTail.then(() => fn());
-    this.mcpForwardTail = run.then(
+  private runKeyedMcpForward<T>(key: string, fn: () => Promise<T>): Promise<T> {
+    const previous = this.mcpForwardTails.get(key) ?? Promise.resolve();
+    const run = previous.then(() => {
+      this.clearMcpClientIdleTimer(key);
+      return fn();
+    });
+    const tail = run.then(
       () => undefined,
       () => undefined
     );
+    this.mcpForwardTails.set(key, tail);
+    void tail.finally(() => {
+      if (this.mcpForwardTails.get(key) === tail) {
+        this.mcpForwardTails.delete(key);
+        this.scheduleMcpClientIdleClose(key);
+      }
+    });
     return run;
+  }
+
+  private getMcpForwardKey(request: DaemonRequest, socketSessionId: string): string {
+    if (request.method === "tools/call") {
+      const args = request.params?.arguments;
+      const scopedKey = this.getRequestArgumentScopeKey(args);
+      if (scopedKey) {
+        return scopedKey;
+      }
+
+      // The daemon injects __mcpSessionId before forwarding. Use the socket session as the
+      // pre-forward key so separate daemon clients can autolock and run independently.
+      return `socket:${socketSessionId}`;
+    }
+
+    if (request.method === "ide/getNavigationGraph") {
+      return this.getRequestArgumentScopeKey(request.params) ?? `method:${request.method}`;
+    }
+
+    if (request.method === "resources/read") {
+      const uri = request.params?.uri;
+      return typeof uri === "string" ? `resource:${uri}` : "resource:unknown";
+    }
+
+    return `method:${request.method}`;
+  }
+
+  private getRequestArgumentScopeKey(args: unknown): string | undefined {
+    if (!args || typeof args !== "object" || Array.isArray(args)) {
+      return undefined;
+    }
+
+    const record = args as Record<string, unknown>;
+    if (typeof record.sessionUuid === "string" && record.sessionUuid.length > 0) {
+      return `session:${record.sessionUuid}`;
+    }
+    if (typeof record.deviceId === "string" && record.deviceId.length > 0) {
+      return `device:${record.deviceId}`;
+    }
+    if (typeof record.__mcpSessionId === "string" && record.__mcpSessionId.length > 0) {
+      return `mcp-session:${record.__mcpSessionId}`;
+    }
+    return undefined;
   }
 
   /** Compact label for debug logs (method + tool name or resource URI). */
@@ -610,28 +667,74 @@ export class UnixSocketServer {
   }
 
   /**
-   * Get or create a shared MCP client (single session for state persistence)
+   * Get or create the MCP client for a target key.
    */
-  private async getMcpClient(): Promise<Client> {
-    if (this.mcpClient) {
-      return this.mcpClient;
+  private async getMcpClient(key: string): Promise<Client> {
+    this.clearMcpClientIdleTimer(key);
+
+    const existingClient = this.mcpClients.get(key);
+    if (existingClient) {
+      return existingClient;
     }
 
-    if (this.mcpClientPromise) {
-      return this.mcpClientPromise;
+    const existingPromise = this.mcpClientPromises.get(key);
+    if (existingPromise) {
+      return existingPromise;
     }
 
-    this.mcpClientPromise = this.createMcpClient()
+    const clientPromise = this.createMcpClient()
       .then(client => {
-        this.mcpClient = client;
+        this.mcpClients.set(key, client);
+        this.mcpClientPromises.delete(key);
         return client;
       })
       .catch(error => {
-        this.mcpClientPromise = null;
+        this.mcpClientPromises.delete(key);
         throw error;
       });
 
-    return this.mcpClientPromise;
+    this.mcpClientPromises.set(key, clientPromise);
+    return clientPromise;
+  }
+
+  private async resetMcpClient(key: string): Promise<void> {
+    this.clearMcpClientIdleTimer(key);
+    const existingClient = this.mcpClients.get(key);
+    this.mcpClients.delete(key);
+    this.mcpClientPromises.delete(key);
+    if (!existingClient) {
+      return;
+    }
+    try {
+      await existingClient.close();
+    } catch (error) {
+      logger.warn(`Error closing MCP client for key ${key}:`, error);
+    }
+  }
+
+  private scheduleMcpClientIdleClose(key: string): void {
+    this.clearMcpClientIdleTimer(key);
+    const timer = this.timer.setTimeout(() => {
+      void this.closeIdleMcpClient(key);
+    }, MCP_CLIENT_IDLE_CLOSE_MS);
+    this.mcpClientIdleTimers.set(key, timer);
+  }
+
+  private clearMcpClientIdleTimer(key: string): void {
+    const timer = this.mcpClientIdleTimers.get(key);
+    if (!timer) {
+      return;
+    }
+    this.timer.clearTimeout(timer);
+    this.mcpClientIdleTimers.delete(key);
+  }
+
+  private async closeIdleMcpClient(key: string): Promise<void> {
+    this.mcpClientIdleTimers.delete(key);
+    if (this.mcpForwardTails.has(key)) {
+      return;
+    }
+    await this.resetMcpClient(key);
   }
 
   /**
@@ -693,16 +796,22 @@ export class UnixSocketServer {
   async close(): Promise<void> {
     logger.info("Closing Unix socket server...");
 
-    // Close shared MCP client
-    if (this.mcpClient) {
-      try {
-        await this.mcpClient.close();
-      } catch (error) {
-        logger.warn(`Error closing MCP client:`, error);
-      }
-      this.mcpClient = null;
+    // Close MCP clients
+    const clients = Array.from(this.mcpClients.entries());
+    this.mcpClients.clear();
+    this.mcpClientPromises.clear();
+    for (const timer of this.mcpClientIdleTimers.values()) {
+      this.timer.clearTimeout(timer);
     }
-    this.mcpClientPromise = null;
+    this.mcpClientIdleTimers.clear();
+    for (const [key, client] of clients) {
+      try {
+        await client.close();
+      } catch (error) {
+        logger.warn(`Error closing MCP client for key ${key}:`, error);
+      }
+    }
+    this.mcpForwardTails.clear();
 
     // Clear sessions
     this.sessions.clear();

--- a/src/db/database.ts
+++ b/src/db/database.ts
@@ -11,6 +11,12 @@ type BunDatabaseConstructor = typeof import("bun:sqlite").Database;
 
 let bunDatabaseConstructor: BunDatabaseConstructor | null = null;
 
+export const SQLITE_BUSY_TIMEOUT_MS = 5_000;
+
+interface SqlitePragmaDatabase {
+  exec(sql: string): unknown;
+}
+
 function isBunRuntime(): boolean {
   return typeof (process.versions as Record<string, string> | undefined)?.bun === "string";
 }
@@ -26,6 +32,17 @@ function resolveBunDatabaseConstructor(): BunDatabaseConstructor {
   }
 
   return bunDatabaseConstructor;
+}
+
+export function configureSqliteDatabase(sqliteDb: SqlitePragmaDatabase): void {
+  // Wait for transient writer locks instead of failing immediately with SQLITE_BUSY
+  sqliteDb.exec(`PRAGMA busy_timeout = ${SQLITE_BUSY_TIMEOUT_MS};`);
+
+  // Enable WAL mode for better concurrent read performance
+  sqliteDb.exec("PRAGMA journal_mode = WAL;");
+
+  // Enable foreign key enforcement for cascade deletes
+  sqliteDb.exec("PRAGMA foreign_keys = ON;");
 }
 
 // Database file location (defaults to ~/.auto-mobile/auto-mobile.db)
@@ -57,12 +74,7 @@ export function getDatabase(): Kysely<DatabaseSchema> {
     // Use Bun's built-in SQLite
     const BunDatabaseConstructor = resolveBunDatabaseConstructor();
     const sqliteDb = new BunDatabaseConstructor(DB_PATH);
-
-    // Enable WAL mode for better concurrent read performance
-    sqliteDb.exec("PRAGMA journal_mode = WAL;");
-
-    // Enable foreign key enforcement for cascade deletes
-    sqliteDb.exec("PRAGMA foreign_keys = ON;");
+    configureSqliteDatabase(sqliteDb);
 
     dbInstance = new Kysely<DatabaseSchema>({
       dialect: new BunSqliteDialect({

--- a/test/daemon/socketServerMcpForwardSerialization.test.ts
+++ b/test/daemon/socketServerMcpForwardSerialization.test.ts
@@ -42,7 +42,8 @@ function createFakeSession(
 
 function createFakeDaemonState(
   sessionDevices: Map<string, string>,
-  sessionCustomData: Map<string, Record<string, unknown>>
+  sessionCustomData: Map<string, Record<string, unknown>>,
+  mcpAutolockSessions: Map<string, string>
 ) {
   return {
     isInitialized: () => true,
@@ -57,6 +58,9 @@ function createFakeDaemonState(
       refreshDevices: async () => 0,
       getStats: () => ({ total: 0, idle: 0, assigned: 0, error: 0 }),
       releaseDevice: async () => {},
+      resolveAutolockSessionForMcpSession: (mcpSessionId: string | undefined) => {
+        return mcpSessionId ? mcpAutolockSessions.get(mcpSessionId) : undefined;
+      },
     }),
   };
 }
@@ -167,6 +171,7 @@ describe("UnixSocketServer MCP forward serialization", () => {
   let fakeTimer: FakeTimer;
   let sessionDevices: Map<string, string>;
   let sessionCustomData: Map<string, Record<string, unknown>>;
+  let mcpAutolockSessions: Map<string, string>;
 
   beforeEach(async () => {
     socketPath = join(tmpdir(), `mcp-ser-${randomUUID()}.sock`);
@@ -174,10 +179,11 @@ describe("UnixSocketServer MCP forward serialization", () => {
     fakeTimer.enableAutoAdvance();
     sessionDevices = new Map();
     sessionCustomData = new Map();
+    mcpAutolockSessions = new Map();
     server = new UnixSocketServer(
       socketPath,
       "http://localhost:0/mcp",
-      createFakeDaemonState(sessionDevices, sessionCustomData),
+      createFakeDaemonState(sessionDevices, sessionCustomData, mcpAutolockSessions),
       fakeTimer,
     );
     await server.start();
@@ -400,6 +406,65 @@ describe("UnixSocketServer MCP forward serialization", () => {
     expect(explicitDeviceResult.success).toBe(true);
     expect(maxInFlightAfterBind).toBe(1);
     expect(inFlightAfterBind).toBe(0);
+  });
+
+  test("implicit autolock tools/call serializes with explicit session calls for the same device", async () => {
+    let inFlightAfterAutolock = 0;
+    let maxInFlightAfterAutolock = 0;
+    let releaseFirstImplicitCall: () => void = () => {};
+    let resolveAutolockReady: () => void = () => {};
+    const firstImplicitCallReleased = new Promise<void>(resolve => { releaseFirstImplicitCall = resolve; });
+    const autolockReady = new Promise<void>(resolve => { resolveAutolockReady = resolve; });
+
+    (server as any).createMcpClient = async () => {
+      const fake: FakeMcpClient = {
+        listTools: async () => ({ tools: [] }),
+        callTool: async request => {
+          const args = (request as { arguments: Record<string, unknown> }).arguments;
+          const mcpSessionId = String(args.__mcpSessionId);
+          if (!mcpAutolockSessions.has(mcpSessionId) && !args.sessionUuid) {
+            mcpAutolockSessions.set(mcpSessionId, "session-a");
+            sessionDevices.set("session-a", "device-1");
+            resolveAutolockReady();
+            await firstImplicitCallReleased;
+            return { content: [] };
+          }
+
+          if (args.sessionUuid === "session-a") {
+            await firstImplicitCallReleased;
+          }
+
+          inFlightAfterAutolock += 1;
+          maxInFlightAfterAutolock = Math.max(maxInFlightAfterAutolock, inFlightAfterAutolock);
+          await new Promise<void>(resolve => {
+            fakeTimer.setTimeout(resolve, 40);
+          });
+          inFlightAfterAutolock -= 1;
+          return { content: [] };
+        },
+        listResources: async () => ({ resources: [] }),
+        readResource: async () => ({ contents: [] }),
+        listResourceTemplates: async () => ({ resourceTemplates: [] }),
+        close: async () => {},
+      };
+      return fake;
+    };
+
+    const implicitSocketCalls = sendTwoToolsCallsOnOneSocket(socketPath, "observe");
+    await autolockReady;
+    const explicitSessionCall = sendToolsCallWithArgs(socketPath, "observe", { sessionUuid: "session-a" });
+
+    releaseFirstImplicitCall();
+
+    const [implicitResults, explicitSessionResult] = await Promise.all([
+      implicitSocketCalls,
+      explicitSessionCall,
+    ]);
+
+    expect(implicitResults.every(response => response.success)).toBe(true);
+    expect(explicitSessionResult.success).toBe(true);
+    expect(maxInFlightAfterAutolock).toBe(1);
+    expect(inFlightAfterAutolock).toBe(0);
   });
 
   test("concurrent tools/call for different devices can overlap inside callTool", async () => {

--- a/test/daemon/socketServerMcpForwardSerialization.test.ts
+++ b/test/daemon/socketServerMcpForwardSerialization.test.ts
@@ -8,6 +8,7 @@ import { join } from "node:path";
 import { UnixSocketServer } from "../../src/daemon/socketServer";
 import { FakeTimer } from "../fakes/FakeTimer";
 import type { DaemonRequest, DaemonResponse } from "../../src/daemon/types";
+import type { Session } from "../../src/daemon/sessionManager";
 
 interface FakeMcpClient {
   callTool: (...args: unknown[]) => Promise<unknown>;
@@ -18,10 +19,33 @@ interface FakeMcpClient {
   close: () => Promise<void>;
 }
 
-function createFakeDaemonState() {
+function createFakeSession(sessionId: string, assignedDevice: string): Session {
+  return {
+    sessionId,
+    assignedDevice,
+    platform: "android",
+    createdAt: 0,
+    lastUsedAt: 0,
+    expiresAt: 60_000,
+    cacheData: {},
+    lastHeartbeat: 0,
+    sessionTimeoutMs: 60_000,
+    heartbeatTimeoutMs: 10_000,
+    heartbeatTimeoutSource: "default",
+    hasReceivedHeartbeat: false,
+  };
+}
+
+function createFakeDaemonState(sessionDevices: Map<string, string>) {
   return {
     isInitialized: () => true,
-    getSessionManager: () => ({ getSession: () => null, releaseSession: async () => null }),
+    getSessionManager: () => ({
+      getSession: (sessionId: string) => {
+        const assignedDevice = sessionDevices.get(sessionId);
+        return assignedDevice ? createFakeSession(sessionId, assignedDevice) : null;
+      },
+      releaseSession: async () => null,
+    }),
     getDevicePool: () => ({
       refreshDevices: async () => 0,
       getStats: () => ({ total: 0, idle: 0, assigned: 0, error: 0 }),
@@ -134,15 +158,17 @@ describe("UnixSocketServer MCP forward serialization", () => {
   let socketPath: string;
   let server: UnixSocketServer;
   let fakeTimer: FakeTimer;
+  let sessionDevices: Map<string, string>;
 
   beforeEach(async () => {
     socketPath = join(tmpdir(), `mcp-ser-${randomUUID()}.sock`);
     fakeTimer = new FakeTimer();
     fakeTimer.enableAutoAdvance();
+    sessionDevices = new Map();
     server = new UnixSocketServer(
       socketPath,
       "http://localhost:0/mcp",
-      createFakeDaemonState(),
+      createFakeDaemonState(sessionDevices),
       fakeTimer,
     );
     await server.start();
@@ -217,6 +243,42 @@ describe("UnixSocketServer MCP forward serialization", () => {
     const [a, b] = await Promise.all([
       sendToolsCallWithArgs(socketPath, "observe", { deviceId: "device-1", sessionUuid: "session-a" }),
       sendToolsCallWithArgs(socketPath, "observe", { deviceId: "device-1", sessionUuid: "session-b" }),
+    ]);
+
+    expect(a.success).toBe(true);
+    expect(b.success).toBe(true);
+    expect(maxInFlight).toBe(1);
+    expect(inFlight).toBe(0);
+  });
+
+  test("session-bound tools/call serializes with explicit calls for the same device", async () => {
+    sessionDevices.set("session-a", "device-1");
+    let inFlight = 0;
+    let maxInFlight = 0;
+
+    (server as any).createMcpClient = async () => {
+      const fake: FakeMcpClient = {
+        listTools: async () => ({ tools: [] }),
+        callTool: async () => {
+          inFlight += 1;
+          maxInFlight = Math.max(maxInFlight, inFlight);
+          await new Promise<void>(resolve => {
+            fakeTimer.setTimeout(resolve, 40);
+          });
+          inFlight -= 1;
+          return { content: [] };
+        },
+        listResources: async () => ({ resources: [] }),
+        readResource: async () => ({ contents: [] }),
+        listResourceTemplates: async () => ({ resourceTemplates: [] }),
+        close: async () => {},
+      };
+      return fake;
+    };
+
+    const [a, b] = await Promise.all([
+      sendToolsCallWithArgs(socketPath, "observe", { sessionUuid: "session-a" }),
+      sendToolsCallWithArgs(socketPath, "observe", { deviceId: "device-1" }),
     ]);
 
     expect(a.success).toBe(true);

--- a/test/daemon/socketServerMcpForwardSerialization.test.ts
+++ b/test/daemon/socketServerMcpForwardSerialization.test.ts
@@ -190,6 +190,41 @@ describe("UnixSocketServer MCP forward serialization", () => {
     expect(inFlight).toBe(0);
   });
 
+  test("explicit device targets serialize even when session UUIDs differ", async () => {
+    let inFlight = 0;
+    let maxInFlight = 0;
+
+    (server as any).createMcpClient = async () => {
+      const fake: FakeMcpClient = {
+        listTools: async () => ({ tools: [] }),
+        callTool: async () => {
+          inFlight += 1;
+          maxInFlight = Math.max(maxInFlight, inFlight);
+          await new Promise<void>(resolve => {
+            fakeTimer.setTimeout(resolve, 40);
+          });
+          inFlight -= 1;
+          return { content: [] };
+        },
+        listResources: async () => ({ resources: [] }),
+        readResource: async () => ({ contents: [] }),
+        listResourceTemplates: async () => ({ resourceTemplates: [] }),
+        close: async () => {},
+      };
+      return fake;
+    };
+
+    const [a, b] = await Promise.all([
+      sendToolsCallWithArgs(socketPath, "observe", { deviceId: "device-1", sessionUuid: "session-a" }),
+      sendToolsCallWithArgs(socketPath, "observe", { deviceId: "device-1", sessionUuid: "session-b" }),
+    ]);
+
+    expect(a.success).toBe(true);
+    expect(b.success).toBe(true);
+    expect(maxInFlight).toBe(1);
+    expect(inFlight).toBe(0);
+  });
+
   test("concurrent tools/call for different devices can overlap inside callTool", async () => {
     let inFlight = 0;
     let maxInFlight = 0;

--- a/test/daemon/socketServerMcpForwardSerialization.test.ts
+++ b/test/daemon/socketServerMcpForwardSerialization.test.ts
@@ -19,7 +19,11 @@ interface FakeMcpClient {
   close: () => Promise<void>;
 }
 
-function createFakeSession(sessionId: string, assignedDevice: string): Session {
+function createFakeSession(
+  sessionId: string,
+  assignedDevice: string,
+  customData: Record<string, unknown> = {}
+): Session {
   return {
     sessionId,
     assignedDevice,
@@ -27,7 +31,7 @@ function createFakeSession(sessionId: string, assignedDevice: string): Session {
     createdAt: 0,
     lastUsedAt: 0,
     expiresAt: 60_000,
-    cacheData: {},
+    cacheData: { customData },
     lastHeartbeat: 0,
     sessionTimeoutMs: 60_000,
     heartbeatTimeoutMs: 10_000,
@@ -36,13 +40,16 @@ function createFakeSession(sessionId: string, assignedDevice: string): Session {
   };
 }
 
-function createFakeDaemonState(sessionDevices: Map<string, string>) {
+function createFakeDaemonState(
+  sessionDevices: Map<string, string>,
+  sessionCustomData: Map<string, Record<string, unknown>>
+) {
   return {
     isInitialized: () => true,
     getSessionManager: () => ({
       getSession: (sessionId: string) => {
         const assignedDevice = sessionDevices.get(sessionId);
-        return assignedDevice ? createFakeSession(sessionId, assignedDevice) : null;
+        return assignedDevice ? createFakeSession(sessionId, assignedDevice, sessionCustomData.get(sessionId) ?? {}) : null;
       },
       releaseSession: async () => null,
     }),
@@ -159,16 +166,18 @@ describe("UnixSocketServer MCP forward serialization", () => {
   let server: UnixSocketServer;
   let fakeTimer: FakeTimer;
   let sessionDevices: Map<string, string>;
+  let sessionCustomData: Map<string, Record<string, unknown>>;
 
   beforeEach(async () => {
     socketPath = join(tmpdir(), `mcp-ser-${randomUUID()}.sock`);
     fakeTimer = new FakeTimer();
     fakeTimer.enableAutoAdvance();
     sessionDevices = new Map();
+    sessionCustomData = new Map();
     server = new UnixSocketServer(
       socketPath,
       "http://localhost:0/mcp",
-      createFakeDaemonState(sessionDevices),
+      createFakeDaemonState(sessionDevices, sessionCustomData),
       fakeTimer,
     );
     await server.start();
@@ -285,6 +294,112 @@ describe("UnixSocketServer MCP forward serialization", () => {
     expect(b.success).toBe(true);
     expect(maxInFlight).toBe(1);
     expect(inFlight).toBe(0);
+  });
+
+  test("device-label tools/call serializes with explicit calls for the mapped device", async () => {
+    sessionDevices.set("session-a", "device-1");
+    sessionDevices.set("session-a:B", "device-2");
+    sessionCustomData.set("session-a", {
+      deviceLabelMap: {
+        A: "session-a",
+        B: "session-a:B",
+      },
+    });
+    let inFlight = 0;
+    let maxInFlight = 0;
+
+    (server as any).createMcpClient = async () => {
+      const fake: FakeMcpClient = {
+        listTools: async () => ({ tools: [] }),
+        callTool: async () => {
+          inFlight += 1;
+          maxInFlight = Math.max(maxInFlight, inFlight);
+          await new Promise<void>(resolve => {
+            fakeTimer.setTimeout(resolve, 40);
+          });
+          inFlight -= 1;
+          return { content: [] };
+        },
+        listResources: async () => ({ resources: [] }),
+        readResource: async () => ({ contents: [] }),
+        listResourceTemplates: async () => ({ resourceTemplates: [] }),
+        close: async () => {},
+      };
+      return fake;
+    };
+
+    const [a, b] = await Promise.all([
+      sendToolsCallWithArgs(socketPath, "observe", { sessionUuid: "session-a", device: "B" }),
+      sendToolsCallWithArgs(socketPath, "observe", { deviceId: "device-2" }),
+    ]);
+
+    expect(a.success).toBe(true);
+    expect(b.success).toBe(true);
+    expect(maxInFlight).toBe(1);
+    expect(inFlight).toBe(0);
+  });
+
+  test("queued unbound session tools/call rekeys after the session binds to a device", async () => {
+    let inFlightAfterBind = 0;
+    let maxInFlightAfterBind = 0;
+    let releaseFirstSessionCall: () => void = () => {};
+    let resolveFirstSessionCallStarted: () => void = () => {};
+    let resolveSessionBound: () => void = () => {};
+    const firstSessionCallStarted = new Promise<void>(resolve => { resolveFirstSessionCallStarted = resolve; });
+    const firstSessionCallReleased = new Promise<void>(resolve => { releaseFirstSessionCall = resolve; });
+    const sessionBound = new Promise<void>(resolve => { resolveSessionBound = resolve; });
+
+    (server as any).createMcpClient = async () => {
+      const fake: FakeMcpClient = {
+        listTools: async () => ({ tools: [] }),
+        callTool: async request => {
+          const args = (request as { arguments: Record<string, unknown> }).arguments;
+          if (args.sessionUuid === "session-a" && !sessionDevices.has("session-a")) {
+            resolveFirstSessionCallStarted();
+            await firstSessionCallReleased;
+            sessionDevices.set("session-a", "device-1");
+            resolveSessionBound();
+            return { content: [] };
+          }
+
+          if (args.deviceId === "device-1") {
+            await sessionBound;
+          }
+
+          inFlightAfterBind += 1;
+          maxInFlightAfterBind = Math.max(maxInFlightAfterBind, inFlightAfterBind);
+          await new Promise<void>(resolve => {
+            fakeTimer.setTimeout(resolve, 40);
+          });
+          inFlightAfterBind -= 1;
+          return { content: [] };
+        },
+        listResources: async () => ({ resources: [] }),
+        readResource: async () => ({ contents: [] }),
+        listResourceTemplates: async () => ({ resourceTemplates: [] }),
+        close: async () => {},
+      };
+      return fake;
+    };
+
+    const first = sendToolsCallWithArgs(socketPath, "observe", { sessionUuid: "session-a" });
+    await firstSessionCallStarted;
+    const queuedSameSession = sendToolsCallWithArgs(socketPath, "observe", { sessionUuid: "session-a" });
+    const explicitDevice = sendToolsCallWithArgs(socketPath, "observe", { deviceId: "device-1" });
+
+    releaseFirstSessionCall();
+
+    const [firstResult, sameSessionResult, explicitDeviceResult] = await Promise.all([
+      first,
+      queuedSameSession,
+      explicitDevice,
+    ]);
+
+    expect(firstResult.success).toBe(true);
+    expect(sameSessionResult.success).toBe(true);
+    expect(explicitDeviceResult.success).toBe(true);
+    expect(maxInFlightAfterBind).toBe(1);
+    expect(inFlightAfterBind).toBe(0);
   });
 
   test("concurrent tools/call for different devices can overlap inside callTool", async () => {

--- a/test/daemon/socketServerMcpForwardSerialization.test.ts
+++ b/test/daemon/socketServerMcpForwardSerialization.test.ts
@@ -65,15 +65,6 @@ function sendRequest(socketPath: string, request: DaemonRequest): Promise<Daemon
   });
 }
 
-function sendToolsCall(socketPath: string, toolName: string): Promise<DaemonResponse> {
-  return sendRequest(socketPath, {
-    id: randomUUID(),
-    type: "mcp_request",
-    method: "tools/call",
-    params: { name: toolName, arguments: {} },
-  });
-}
-
 function sendToolsCallWithArgs(
   socketPath: string,
   toolName: string,
@@ -164,7 +155,7 @@ describe("UnixSocketServer MCP forward serialization", () => {
     }
   });
 
-  test("concurrent tools/call from two sockets never overlaps inside callTool", async () => {
+  test("concurrent tools/call for the same device never overlaps inside callTool", async () => {
     let inFlight = 0;
     let maxInFlight = 0;
 
@@ -189,14 +180,88 @@ describe("UnixSocketServer MCP forward serialization", () => {
     };
 
     const [a, b] = await Promise.all([
-      sendToolsCall(socketPath, "observe"),
-      sendToolsCall(socketPath, "observe"),
+      sendToolsCallWithArgs(socketPath, "observe", { deviceId: "device-1" }),
+      sendToolsCallWithArgs(socketPath, "observe", { deviceId: "device-1" }),
     ]);
 
     expect(a.success).toBe(true);
     expect(b.success).toBe(true);
     expect(maxInFlight).toBe(1);
     expect(inFlight).toBe(0);
+  });
+
+  test("concurrent tools/call for different devices can overlap inside callTool", async () => {
+    let inFlight = 0;
+    let maxInFlight = 0;
+
+    (server as any).createMcpClient = async () => {
+      const fake: FakeMcpClient = {
+        listTools: async () => ({ tools: [] }),
+        callTool: async () => {
+          inFlight += 1;
+          maxInFlight = Math.max(maxInFlight, inFlight);
+          await new Promise<void>(resolve => {
+            fakeTimer.setTimeout(resolve, 40);
+          });
+          inFlight -= 1;
+          return { content: [] };
+        },
+        listResources: async () => ({ resources: [] }),
+        readResource: async () => ({ contents: [] }),
+        listResourceTemplates: async () => ({ resourceTemplates: [] }),
+        close: async () => {},
+      };
+      return fake;
+    };
+
+    const [a, b] = await Promise.all([
+      sendToolsCallWithArgs(socketPath, "observe", { deviceId: "device-1" }),
+      sendToolsCallWithArgs(socketPath, "observe", { deviceId: "device-2" }),
+    ]);
+
+    expect(a.success).toBe(true);
+    expect(b.success).toBe(true);
+    expect(maxInFlight).toBe(2);
+    expect(inFlight).toBe(0);
+  });
+
+  test("concurrent implicit autolock tools/call from different sockets can overlap", async () => {
+    let inFlight = 0;
+    let maxInFlight = 0;
+    const forwardedSessionIds: string[] = [];
+
+    (server as any).createMcpClient = async () => {
+      const fake: FakeMcpClient = {
+        listTools: async () => ({ tools: [] }),
+        callTool: async request => {
+          const args = (request as { arguments: Record<string, unknown> }).arguments;
+          forwardedSessionIds.push(String(args.__mcpSessionId));
+          inFlight += 1;
+          maxInFlight = Math.max(maxInFlight, inFlight);
+          await new Promise<void>(resolve => {
+            fakeTimer.setTimeout(resolve, 40);
+          });
+          inFlight -= 1;
+          return { content: [] };
+        },
+        listResources: async () => ({ resources: [] }),
+        readResource: async () => ({ contents: [] }),
+        listResourceTemplates: async () => ({ resourceTemplates: [] }),
+        close: async () => {},
+      };
+      return fake;
+    };
+
+    const [a, b] = await Promise.all([
+      sendToolsCallWithArgs(socketPath, "observe", {}),
+      sendToolsCallWithArgs(socketPath, "observe", {}),
+    ]);
+
+    expect(a.success).toBe(true);
+    expect(b.success).toBe(true);
+    expect(maxInFlight).toBe(2);
+    expect(forwardedSessionIds).toHaveLength(2);
+    expect(forwardedSessionIds[0]).not.toBe(forwardedSessionIds[1]);
   });
 
   test("forwards the Unix socket session as the implicit autolock key", async () => {
@@ -314,7 +379,7 @@ describe("UnixSocketServer MCP forward serialization", () => {
     };
 
     // First request: blocks in callTool until we release it
-    const first = sendToolsCall(socketPath, "observe");
+    const first = sendToolsCallWithArgs(socketPath, "observe", { deviceId: "device-1" });
 
     // Yield to the real event loop so the first request enters callTool
     for (let i = 0; i < 10; i++) {
@@ -326,7 +391,7 @@ describe("UnixSocketServer MCP forward serialization", () => {
       id: randomUUID(),
       type: "mcp_request",
       method: "tools/call",
-      params: { name: "observe", arguments: {} },
+      params: { name: "observe", arguments: { deviceId: "device-1" } },
       timeoutMs: 500,
     });
 

--- a/test/daemon/socketServerMcpReconnect.test.ts
+++ b/test/daemon/socketServerMcpReconnect.test.ts
@@ -152,8 +152,8 @@ describe("UnixSocketServer MCP session reconnect", () => {
 
     await sendRequest(socketPath, "tools/list");
 
-    // After reconnect, mcpClient should hold the fresh client
-    expect((server as any).mcpClient).not.toBeNull();
+    // After reconnect, the per-key client cache should hold the fresh client.
+    expect((server as any).mcpClients.size).toBe(1);
     expect(clientsCreated).toBe(2);
   });
 
@@ -200,5 +200,27 @@ describe("UnixSocketServer MCP session reconnect", () => {
     const second = await sendRequest(socketPath, "tools/list");
     expect(second.success).toBe(true);
     expect(clientsCreated).toBe(2);
+  });
+
+  test("closes idle per-key MCP clients after the idle timeout", async () => {
+    let closeCalls = 0;
+
+    (server as any).createMcpClient = async () => createFakeMcpClient({
+      listTools: async () => ({ tools: [] }),
+      close: async () => {
+        closeCalls++;
+      },
+    });
+
+    const response = await sendRequest(socketPath, "tools/list");
+
+    expect(response.success).toBe(true);
+    expect((server as any).mcpClients.size).toBe(1);
+
+    fakeTimer.advanceTime(5 * 60 * 1000);
+    await Promise.resolve();
+
+    expect(closeCalls).toBe(1);
+    expect((server as any).mcpClients.size).toBe(0);
   });
 });

--- a/test/db/database.test.ts
+++ b/test/db/database.test.ts
@@ -1,0 +1,55 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { Database as BunDatabase } from "bun:sqlite";
+import { mkdtemp, rm } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import {
+  configureSqliteDatabase,
+  SQLITE_BUSY_TIMEOUT_MS,
+} from "../../src/db/database";
+
+class FakeSqliteDatabase {
+  readonly statements: string[] = [];
+
+  exec(sql: string): void {
+    this.statements.push(sql);
+  }
+}
+
+describe("configureSqliteDatabase", () => {
+  let tempDirs: string[] = [];
+
+  afterEach(async () => {
+    await Promise.all(tempDirs.map(dir => rm(dir, { recursive: true, force: true })));
+    tempDirs = [];
+  });
+
+  test("enables WAL, busy timeout, and foreign keys for new connections", () => {
+    const db = new FakeSqliteDatabase();
+
+    configureSqliteDatabase(db);
+
+    expect(db.statements).toEqual([
+      `PRAGMA busy_timeout = ${SQLITE_BUSY_TIMEOUT_MS};`,
+      "PRAGMA journal_mode = WAL;",
+      "PRAGMA foreign_keys = ON;",
+    ]);
+  });
+
+  test("sets a 5 second busy timeout on Bun SQLite file databases", async () => {
+    const tempDir = await mkdtemp(join(tmpdir(), "auto-mobile-sqlite-"));
+    tempDirs.push(tempDir);
+    const sqliteDb = new BunDatabase(join(tempDir, "auto-mobile.db"));
+
+    try {
+      configureSqliteDatabase(sqliteDb);
+
+      const result = sqliteDb
+        .query<{ timeout: number }, []>("PRAGMA busy_timeout;")
+        .get();
+      expect(result?.timeout).toBe(5_000);
+    } finally {
+      sqliteDb.close();
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- Fixes #2559
- Configures SQLite connections with a 5 second `busy_timeout` before other PRAGMAs run.
- Replaces the daemon's single global MCP forward queue with keyed forwarding lanes.
- Serializes requests for the same `sessionUuid`, `deviceId`, or implicit daemon socket session while allowing independent devices/agents to run concurrently through separate MCP clients.
- Closes idle per-key MCP clients after 5 minutes so concurrent agent lanes do not accumulate indefinitely.

## Testing

- `bun test test/db/database.test.ts`
- `bun test test/db`
- `bun test test/daemon`
- `bun run lint`
- `bun run build`
- `bun test`
- `bash scripts/all_fast_validate_checks.sh`

## Validation Notes

- `bun test` passed on the final run: 4712 pass, 1 skip, 0 fail.
- `bash scripts/all_fast_validate_checks.sh` passed 8 of 9 checks but failed the existing `claude-plugin` check because current Claude CLI validation reports `.claude-plugin/plugin.json` hook path `./hooks.json` as missing. This is unrelated to the SQLite and daemon request changes.
