### PR TITLE
Fix daemon process deduplication

### DIFF
--- a/src/daemon/manager.ts
+++ b/src/daemon/manager.ts
@@ -54,6 +54,56 @@ export interface DaemonLaunchCommand {
   args: string[];
 }
 
+export interface DaemonProcessRecord {
+  pid: number;
+  ppid: number;
+  command: string;
+}
+
+export interface DaemonProcessFinder {
+  findDaemonProcesses(): DaemonProcessRecord[];
+}
+
+function isAutoMobileDaemonCommand(command: string): boolean {
+  return command.includes("--daemon-mode") &&
+    (command.includes("auto-mobile") || command.includes("dist/src/index.js"));
+}
+
+function isShellCommandWrapper(command: string): boolean {
+  const executable = command.trim().split(/\s+/, 1)[0] ?? "";
+  return /(^|\/)(?:ba|da|z)?sh$/.test(executable) && command.includes(" -c ");
+}
+
+export function parseDaemonProcessTable(psOutput: string): DaemonProcessRecord[] {
+  const records: DaemonProcessRecord[] = [];
+
+  for (const line of psOutput.split("\n")) {
+    const match = line.match(/^\s*(\d+)\s+(\d+)\s+(.+?)\s*$/);
+    if (!match) {
+      continue;
+    }
+
+    const pid = parseInt(match[1], 10);
+    const ppid = parseInt(match[2], 10);
+    const command = match[3];
+
+    if (!Number.isFinite(pid) || !Number.isFinite(ppid) || !isAutoMobileDaemonCommand(command)) {
+      continue;
+    }
+
+    records.push({ pid, ppid, command });
+  }
+
+  return records;
+}
+
+class PsDaemonProcessFinder implements DaemonProcessFinder {
+  findDaemonProcesses(): DaemonProcessRecord[] {
+    const psOutput = execSync("ps -eo pid=,ppid=,command=", { encoding: "utf-8" });
+    return parseDaemonProcessTable(psOutput);
+  }
+}
+
 function resolvePackageSpecifier(version: string): string {
   const trimmedVersion = version.trim();
   if (trimmedVersion.length === 0 || trimmedVersion === "unknown") {
@@ -116,6 +166,7 @@ export class DaemonManager implements DaemonManagerLike {
   private readonly lockFilePath: string;
   private readonly pidFilePath: string;
   private readonly socketPath: string;
+  private readonly processFinder: DaemonProcessFinder;
 
   constructor(
     clientFactory: DaemonClientFactory | undefined = undefined,
@@ -123,13 +174,15 @@ export class DaemonManager implements DaemonManagerLike {
     timer: Timer = defaultTimer,
     lockFilePath: string = LOCK_FILE_PATH,
     pidFilePath: string = PID_FILE_PATH,
-    socketPath: string = SOCKET_PATH
+    socketPath: string = SOCKET_PATH,
+    processFinder: DaemonProcessFinder = new PsDaemonProcessFinder()
   ) {
     this.stateProvider = stateProvider;
     this.timer = timer;
     this.lockFilePath = lockFilePath;
     this.pidFilePath = pidFilePath;
     this.socketPath = socketPath;
+    this.processFinder = processFinder;
     this.clientFactory = clientFactory ?? (() => new DaemonClient(this.socketPath));
   }
 
@@ -211,31 +264,40 @@ export class DaemonManager implements DaemonManagerLike {
    */
   findAllDaemonProcesses(): number[] {
     try {
-      // Use ps to find all auto-mobile daemon processes for current user
-      const psOutput = execSync(
-        `ps aux | grep -E "auto-mobile.*--daemon-mode|dist/src/index.js --daemon-mode" | grep -v grep`,
-        { encoding: "utf-8" }
-      );
-
-      const pids: number[] = [];
-      const lines = psOutput.trim().split("\n").filter(line => line.trim());
-
-      for (const line of lines) {
-        // Parse PID from ps output (second column)
-        const parts = line.trim().split(/\s+/);
-        if (parts.length >= 2) {
-          const pid = parseInt(parts[1], 10);
-          if (!isNaN(pid) && pid !== process.pid) {
-            pids.push(pid);
-          }
-        }
-      }
-
-      return pids;
+      return this.normalizeDaemonProcessRecords(this.processFinder.findDaemonProcesses());
     } catch (error) {
       // No matching processes found or command failed
       return [];
     }
+  }
+
+  findOtherDaemonProcesses(activeDaemonPid: number | undefined): number[] {
+    return this.findAllDaemonProcesses().filter(pid => pid !== activeDaemonPid);
+  }
+
+  private normalizeDaemonProcessRecords(records: DaemonProcessRecord[]): number[] {
+    const wrapperPids = new Set<number>();
+    const childPpids = new Set(records.map(record => record.ppid));
+
+    for (const record of records) {
+      if (isShellCommandWrapper(record.command) && childPpids.has(record.pid)) {
+        wrapperPids.add(record.pid);
+      }
+    }
+
+    const pids: number[] = [];
+    const seen = new Set<number>();
+
+    for (const record of records) {
+      if (record.pid === process.pid || wrapperPids.has(record.pid) || seen.has(record.pid)) {
+        continue;
+      }
+
+      pids.push(record.pid);
+      seen.add(record.pid);
+    }
+
+    return pids;
   }
 
   /**
@@ -816,7 +878,7 @@ export async function runDaemonCommand(
           );
 
           // Check for other daemon processes (exclude current daemon)
-          const otherDaemons = manager.findAllDaemonProcesses().filter(pid => pid !== status.pid);
+          const otherDaemons = manager.findOtherDaemonProcesses(status.pid);
           if (otherDaemons.length > 0) {
             console.log(
               `\n⚠️  WARNING: Found ${otherDaemons.length} other daemon process(es) from other worktrees:`

--- a/src/daemon/manager.ts
+++ b/src/daemon/manager.ts
@@ -64,6 +64,13 @@ export interface DaemonProcessFinder {
   findDaemonProcesses(): DaemonProcessRecord[];
 }
 
+export const DAEMON_PROCESS_TABLE_MAX_BUFFER_BYTES = 16 * 1024 * 1024;
+
+type ProcessTableCommandRunner = (
+  command: string,
+  options: { encoding: "utf-8"; maxBuffer: number }
+) => string;
+
 function isAutoMobileDaemonCommand(command: string): boolean {
   return command.includes("--daemon-mode") &&
     (command.includes("auto-mobile") || command.includes("dist/src/index.js"));
@@ -97,9 +104,14 @@ export function parseDaemonProcessTable(psOutput: string): DaemonProcessRecord[]
   return records;
 }
 
-class PsDaemonProcessFinder implements DaemonProcessFinder {
+export class PsDaemonProcessFinder implements DaemonProcessFinder {
+  constructor(private readonly runCommand: ProcessTableCommandRunner = execSync) {}
+
   findDaemonProcesses(): DaemonProcessRecord[] {
-    const psOutput = execSync("ps -eo pid=,ppid=,command=", { encoding: "utf-8" });
+    const psOutput = this.runCommand("ps -eo pid=,ppid=,command=", {
+      encoding: "utf-8",
+      maxBuffer: DAEMON_PROCESS_TABLE_MAX_BUFFER_BYTES,
+    });
     return parseDaemonProcessTable(psOutput);
   }
 }

--- a/test/daemon/manager.test.ts
+++ b/test/daemon/manager.test.ts
@@ -1,5 +1,12 @@
 import { describe, expect, spyOn, test } from "bun:test";
-import { DaemonManager, parseDaemonProcessTable, resolveDaemonLaunchCommand, runDaemonCommand } from "../../src/daemon/manager";
+import {
+  DAEMON_PROCESS_TABLE_MAX_BUFFER_BYTES,
+  DaemonManager,
+  parseDaemonProcessTable,
+  PsDaemonProcessFinder,
+  resolveDaemonLaunchCommand,
+  runDaemonCommand
+} from "../../src/daemon/manager";
 import type { DaemonProcessFinder, DaemonProcessRecord } from "../../src/daemon/manager";
 import type { DaemonStateLike } from "../../src/daemon/daemonState";
 import type { DaemonClientLike } from "../../src/daemon/client";
@@ -95,6 +102,35 @@ describe("Daemon manager process detection", () => {
         command: "bunx -y @kaeawc/auto-mobile@0.0.38 --daemon-mode",
       },
     ]);
+  });
+
+  test("uses an expanded buffer when reading the full process table", () => {
+    const calls: Array<{
+      command: string;
+      options: { encoding: "utf-8"; maxBuffer: number };
+    }> = [];
+    const finder = new PsDaemonProcessFinder((command, options) => {
+      calls.push({ command, options });
+      return "20 1 bunx -y @kaeawc/auto-mobile@0.0.38 --daemon-mode";
+    });
+
+    expect(finder.findDaemonProcesses()).toEqual([
+      {
+        pid: 20,
+        ppid: 1,
+        command: "bunx -y @kaeawc/auto-mobile@0.0.38 --daemon-mode",
+      },
+    ]);
+    expect(calls).toEqual([
+      {
+        command: "ps -eo pid=,ppid=,command=",
+        options: {
+          encoding: "utf-8",
+          maxBuffer: DAEMON_PROCESS_TABLE_MAX_BUFFER_BYTES,
+        },
+      },
+    ]);
+    expect(DAEMON_PROCESS_TABLE_MAX_BUFFER_BYTES).toBeGreaterThan(1024 * 1024);
   });
 
   function managerWithProcesses(records: DaemonProcessRecord[]): DaemonManager {

--- a/test/daemon/manager.test.ts
+++ b/test/daemon/manager.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, spyOn, test } from "bun:test";
-import { resolveDaemonLaunchCommand, runDaemonCommand } from "../../src/daemon/manager";
+import { DaemonManager, parseDaemonProcessTable, resolveDaemonLaunchCommand, runDaemonCommand } from "../../src/daemon/manager";
+import type { DaemonProcessFinder, DaemonProcessRecord } from "../../src/daemon/manager";
 import type { DaemonStateLike } from "../../src/daemon/daemonState";
 import type { DaemonClientLike } from "../../src/daemon/client";
 
@@ -33,6 +34,14 @@ class FakeDaemonClient implements DaemonClientLike {
   }
 }
 
+class FakeDaemonProcessFinder implements DaemonProcessFinder {
+  constructor(private readonly records: DaemonProcessRecord[]) {}
+
+  findDaemonProcesses(): DaemonProcessRecord[] {
+    return this.records;
+  }
+}
+
 describe("resolveDaemonLaunchCommand", () => {
   test("uses the current entry script when one is available", () => {
     const launch = resolveDaemonLaunchCommand("/tmp/auto-mobile/dist/src/index.js", "bunx", "1.2.3");
@@ -56,6 +65,109 @@ describe("resolveDaemonLaunchCommand", () => {
     expect(() => resolveDaemonLaunchCommand("", "bunx", "unknown")).toThrow(
       "current package version is unknown"
     );
+  });
+});
+
+describe("Daemon manager process detection", () => {
+  test("parses daemon processes from ps pid ppid command output", () => {
+    const records = parseDaemonProcessTable(`
+      10     1 /usr/bin/unrelated --daemon-mode
+      20     1 /bin/sh -c "bun /worktree/dist/src/index.js --daemon-mode"
+      21    20 bun /worktree/dist/src/index.js --daemon-mode
+      22     1 bun /worktree/dist/src/index.js
+      30     1 bunx -y @kaeawc/auto-mobile@0.0.38 --daemon-mode
+    `);
+
+    expect(records).toEqual([
+      {
+        pid: 20,
+        ppid: 1,
+        command: `/bin/sh -c "bun /worktree/dist/src/index.js --daemon-mode"`,
+      },
+      {
+        pid: 21,
+        ppid: 20,
+        command: "bun /worktree/dist/src/index.js --daemon-mode",
+      },
+      {
+        pid: 30,
+        ppid: 1,
+        command: "bunx -y @kaeawc/auto-mobile@0.0.38 --daemon-mode",
+      },
+    ]);
+  });
+
+  function managerWithProcesses(records: DaemonProcessRecord[]): DaemonManager {
+    return new DaemonManager(
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      new FakeDaemonProcessFinder(records)
+    );
+  }
+
+  test("reports a shell-launched daemon once using the long-lived daemon child PID", () => {
+    const manager = managerWithProcesses([
+      {
+        pid: 100,
+        ppid: 1,
+        command: `/bin/sh -c "${process.execPath} /tmp/auto-mobile/dist/src/index.js --daemon-mode"`,
+      },
+      {
+        pid: 101,
+        ppid: 100,
+        command: `${process.execPath} /tmp/auto-mobile/dist/src/index.js --daemon-mode`,
+      },
+    ]);
+
+    expect(manager.findAllDaemonProcesses()).toEqual([101]);
+  });
+
+  test("does not report the current daemon's shell wrapper as another daemon", () => {
+    const manager = managerWithProcesses([
+      {
+        pid: 100,
+        ppid: 1,
+        command: `/bin/sh -c "${process.execPath} /tmp/auto-mobile/dist/src/index.js --daemon-mode"`,
+      },
+      {
+        pid: process.pid,
+        ppid: 100,
+        command: `${process.execPath} /tmp/auto-mobile/dist/src/index.js --daemon-mode`,
+      },
+    ]);
+
+    expect(manager.findAllDaemonProcesses()).toEqual([]);
+  });
+
+  test("filters the active daemon PID while preserving distinct daemons", () => {
+    const manager = managerWithProcesses([
+      {
+        pid: 200,
+        ppid: 1,
+        command: `/bin/sh -c "bun /worktree-a/dist/src/index.js --daemon-mode"`,
+      },
+      {
+        pid: 201,
+        ppid: 200,
+        command: `bun /worktree-a/dist/src/index.js --daemon-mode`,
+      },
+      {
+        pid: 300,
+        ppid: 1,
+        command: `/bin/sh -c "bun /worktree-b/dist/src/index.js --daemon-mode"`,
+      },
+      {
+        pid: 301,
+        ppid: 300,
+        command: `bun /worktree-b/dist/src/index.js --daemon-mode`,
+      },
+    ]);
+
+    expect(manager.findOtherDaemonProcesses(201)).toEqual([301]);
   });
 });
 


### PR DESCRIPTION
## Summary

- Replace daemon process discovery's `ps aux | grep` pipeline with parsed `ps -eo pid,ppid,command` records.
- Collapse shell wrapper + daemon child process pairs so a single shell-launched daemon is counted once.
- Reuse normalized daemon process detection for status-time "other daemon" warnings.

Fixes #2561

## Testing

- `bun test test/daemon/manager.test.ts`
- `bun run lint`
- `bun run build`
- `bun test`
- `bash scripts/all_fast_validate_checks.sh` (fails only `claude-plugin`: `.claude-plugin/plugin.json` hooks path `./hooks.json` is reported missing by Claude CLI validation; 8/9 checks passed)
