### PR TITLE
fix: surface subprocess failure context

### DIFF
--- a/src/daemon/manager.ts
+++ b/src/daemon/manager.ts
@@ -1,5 +1,5 @@
-import { spawn, execSync } from "node:child_process";
-import { readFile, unlink } from "node:fs/promises";
+import { spawn as nodeSpawn, execSync, type ChildProcess, type SpawnOptions } from "node:child_process";
+import { open, readFile, unlink } from "node:fs/promises";
 import { existsSync, openSync, closeSync, mkdtempSync, readFileSync, unlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -116,6 +116,16 @@ export class PsDaemonProcessFinder implements DaemonProcessFinder {
   }
 }
 
+export interface DaemonProcessSpawner {
+  spawn(command: string, args: string[], options: SpawnOptions): ChildProcess;
+}
+
+const nodeDaemonProcessSpawner: DaemonProcessSpawner = {
+  spawn: nodeSpawn,
+};
+
+const MAX_DAEMON_STARTUP_LOG_BYTES = 4000;
+
 function resolvePackageSpecifier(version: string): string {
   const trimmedVersion = version.trim();
   if (trimmedVersion.length === 0 || trimmedVersion === "unknown") {
@@ -159,7 +169,7 @@ export interface DaemonManagerLike {
   status(): Promise<DaemonStatus>;
   start(options?: DaemonOptions): Promise<void>;
   restart(options?: DaemonOptions): Promise<void>;
-  waitForReady(timeout: number): Promise<boolean>;
+  waitForReady(timeout: number, signal?: AbortSignal): Promise<boolean>;
 }
 
 /**
@@ -179,6 +189,7 @@ export class DaemonManager implements DaemonManagerLike {
   private readonly pidFilePath: string;
   private readonly socketPath: string;
   private readonly processFinder: DaemonProcessFinder;
+  private readonly processSpawner: DaemonProcessSpawner;
 
   constructor(
     clientFactory: DaemonClientFactory | undefined = undefined,
@@ -187,14 +198,21 @@ export class DaemonManager implements DaemonManagerLike {
     lockFilePath: string = LOCK_FILE_PATH,
     pidFilePath: string = PID_FILE_PATH,
     socketPath: string = SOCKET_PATH,
-    processFinder: DaemonProcessFinder = new PsDaemonProcessFinder()
+    processFinderOrSpawner: DaemonProcessFinder | DaemonProcessSpawner = new PsDaemonProcessFinder(),
+    processSpawner: DaemonProcessSpawner = nodeDaemonProcessSpawner
   ) {
     this.stateProvider = stateProvider;
     this.timer = timer;
     this.lockFilePath = lockFilePath;
     this.pidFilePath = pidFilePath;
     this.socketPath = socketPath;
-    this.processFinder = processFinder;
+    if ("findDaemonProcesses" in processFinderOrSpawner) {
+      this.processFinder = processFinderOrSpawner;
+      this.processSpawner = processSpawner;
+    } else {
+      this.processFinder = new PsDaemonProcessFinder();
+      this.processSpawner = processFinderOrSpawner;
+    }
     this.clientFactory = clientFactory ?? (() => new DaemonClient(this.socketPath));
   }
 
@@ -507,7 +525,7 @@ export class DaemonManager implements DaemonManagerLike {
       childEnv.AUTOMOBILE_DAEMON_SOCKET_PATH = this.socketPath;
     }
 
-    const daemonProcess = spawn(autoMobileCmd, args, {
+    const daemonProcess = this.processSpawner.spawn(autoMobileCmd, args, {
       detached: true,
       stdio: ["ignore", logFd, logFd], // Write stdout/stderr to log file
       shell: true, // Use shell to resolve command from PATH
@@ -520,13 +538,7 @@ export class DaemonManager implements DaemonManagerLike {
     // Unref so parent process can exit
     daemonProcess.unref();
 
-    // Wait for daemon to be ready
-    const ready = await this.waitForReady(DAEMON_STARTUP_TIMEOUT_MS);
-    if (!ready) {
-      throw new ActionableError(
-        `Daemon failed to start within ${DAEMON_STARTUP_TIMEOUT_MS}ms`
-      );
-    }
+    await this.waitForDaemonStartup(daemonProcess, logPath, DAEMON_STARTUP_TIMEOUT_MS);
 
     const newStatus = await this.status();
     stderrLog(
@@ -534,6 +546,105 @@ export class DaemonManager implements DaemonManagerLike {
     );
     stderrLog(`Socket: ${newStatus.socketPath}`);
     stderrLog(`Logs: ${logPath}`);
+  }
+
+  private async waitForDaemonStartup(
+    daemonProcess: ChildProcess,
+    logPath: string,
+    timeoutMs: number
+  ): Promise<void> {
+    let cleanupProcessListeners = () => {};
+
+    const readinessAbort = new AbortController();
+    const processFailure = new Promise<never>((_, reject) => {
+      const rejectWithContext = (summary: string) => {
+        void this.formatDaemonStartupFailure(summary, logPath).then(
+          message => {
+            reject(new ActionableError(message));
+            readinessAbort.abort();
+          },
+          () => {
+            reject(new ActionableError(summary));
+            readinessAbort.abort();
+          }
+        );
+      };
+
+      const onError = (error: Error) => {
+        rejectWithContext(`Daemon subprocess failed to spawn: ${this.formatRawSpawnError(error)}`);
+      };
+      const onExit = (code: number | null, signal: NodeJS.Signals | null) => {
+        const exitCode = code === null ? "unknown" : code.toString();
+        const signalDetail = signal ? `, signal ${signal}` : "";
+        rejectWithContext(`Daemon subprocess exited before becoming ready (exit code ${exitCode}${signalDetail})`);
+      };
+
+      daemonProcess.once("error", onError);
+      daemonProcess.once("exit", onExit);
+      cleanupProcessListeners = () => {
+        daemonProcess.off("error", onError);
+        daemonProcess.off("exit", onExit);
+      };
+    });
+
+    try {
+      const ready = await Promise.race([
+        this.waitForReady(timeoutMs, readinessAbort.signal),
+        processFailure,
+      ]);
+      if (!ready) {
+        throw new ActionableError(
+          await this.formatDaemonStartupFailure(
+            `Daemon failed to start within ${timeoutMs}ms`,
+            logPath
+          )
+        );
+      }
+    } finally {
+      readinessAbort.abort();
+      cleanupProcessListeners();
+    }
+  }
+
+  private formatRawSpawnError(error: Error): string {
+    const details = error as NodeJS.ErrnoException;
+    const additions = [
+      details.code && !error.message.includes(details.code) ? `code ${details.code}` : undefined,
+      details.syscall && !error.message.includes(details.syscall) ? `syscall ${details.syscall}` : undefined,
+      details.path && !error.message.includes(details.path) ? `path ${details.path}` : undefined,
+    ].filter((value): value is string => value !== undefined);
+    return additions.length > 0 ? `${error.message} (${additions.join(", ")})` : error.message;
+  }
+
+  private async formatDaemonStartupFailure(summary: string, logPath: string): Promise<string> {
+    const logExcerpt = await this.readDaemonStartupLogExcerpt(logPath);
+    if (logExcerpt.length === 0) {
+      return `${summary}\nLogs: ${logPath} (empty)`;
+    }
+    return [
+      summary,
+      `Logs: ${logPath}`,
+      `Daemon stdout/stderr log excerpt (last ${MAX_DAEMON_STARTUP_LOG_BYTES} bytes):`,
+      logExcerpt,
+    ].join("\n");
+  }
+
+  private async readDaemonStartupLogExcerpt(logPath: string): Promise<string> {
+    let file: Awaited<ReturnType<typeof open>> | undefined;
+    try {
+      file = await open(logPath, "r");
+      const { size } = await file.stat();
+      const start = Math.max(0, size - MAX_DAEMON_STARTUP_LOG_BYTES);
+      const length = size - start;
+      const buffer = Buffer.alloc(length);
+      const { bytesRead } = await file.read(buffer, 0, length, start);
+      const log = buffer.subarray(0, bytesRead).toString("utf-8").trim();
+      return start > 0 ? `...${log}` : log;
+    } catch (error) {
+      return `Unable to read daemon stdout/stderr log: ${error instanceof Error ? error.message : String(error)}`;
+    } finally {
+      await file?.close();
+    }
   }
 
   /**
@@ -646,25 +757,54 @@ export class DaemonManager implements DaemonManagerLike {
   /**
    * Wait for daemon to be ready (socket listening)
    */
-  async waitForReady(timeout: number): Promise<boolean> {
+  async waitForReady(timeout: number, signal?: AbortSignal): Promise<boolean> {
     const startTime = this.timer.now();
     const pollInterval = 100; // Poll every 100ms
 
     while (this.timer.now() - startTime < timeout) {
+      if (signal?.aborted) {
+        return false;
+      }
       if (existsSync(this.socketPath)) {
         const status = await this.status();
         if (status.running) {
           if (await this.verifyDaemonConnection()) {
             return true;
           }
+          if (signal?.aborted) {
+            return false;
+          }
           await this.removeInvalidSocketPath();
         }
       }
 
-      await this.timer.sleep(pollInterval);
+      await this.sleepUnlessAborted(pollInterval, signal);
     }
 
     return false;
+  }
+
+  private sleepUnlessAborted(ms: number, signal?: AbortSignal): Promise<void> {
+    if (!signal) {
+      return this.timer.sleep(ms);
+    }
+    if (signal.aborted) {
+      return Promise.resolve();
+    }
+
+    return new Promise(resolve => {
+      function done() {
+        signal.removeEventListener("abort", onAbort);
+        resolve();
+      }
+      const onAbort = () => {
+        this.timer.clearTimeout(timeout);
+        done();
+      };
+
+      const timeout = this.timer.setTimeout(done, ms);
+      signal.addEventListener("abort", onAbort, { once: true });
+    });
   }
 
   private async verifyDaemonConnection(): Promise<boolean> {

--- a/src/features/observe/cache/FileSystemObserveCacheStore.ts
+++ b/src/features/observe/cache/FileSystemObserveCacheStore.ts
@@ -36,6 +36,7 @@ export class FileSystemObserveCacheStore implements ObserveResultCacheStore {
   private readonly cache: Map<string, ObserveResultCacheEntry> = new Map();
   private readonly cacheDir: string;
   private readonly timer: Timer;
+  private pendingDiskCleanup: Promise<void> = Promise.resolve();
 
   constructor(timer: Timer = defaultTimer, cacheDir?: string) {
     this.timer = timer;
@@ -52,6 +53,7 @@ export class FileSystemObserveCacheStore implements ObserveResultCacheStore {
     const cacheKey = `${deviceId}:${timestamp}`;
     try {
       logger.debug(`[OBSERVE_CACHE] Caching observe result for device ${deviceId} with timestamp ${timestamp}`);
+      await this.pendingDiskCleanup;
       this.cache.set(cacheKey, { timestamp, deviceId, observeResult: result });
       await this.saveObserveResultToDisk(cacheKey, result);
       logger.debug(`[OBSERVE_CACHE] Successfully cached observe result, in-memory cache size: ${this.cache.size}`);
@@ -248,7 +250,7 @@ export class FileSystemObserveCacheStore implements ObserveResultCacheStore {
       return;
     }
 
-    void Promise.all(
+    const cleanup = Promise.all(
       matches.map(async file => {
         try {
           await unlinkAsync(path.join(this.cacheDir, file));
@@ -256,6 +258,7 @@ export class FileSystemObserveCacheStore implements ObserveResultCacheStore {
           logger.warn(`[OBSERVE_CACHE] Failed to delete cache file ${file}: ${error}`);
         }
       })
-    );
+    ).then(() => {});
+    this.pendingDiskCleanup = this.pendingDiskCleanup.then(() => cleanup);
   }
 }

--- a/src/utils/CommandError.ts
+++ b/src/utils/CommandError.ts
@@ -52,7 +52,7 @@ export function formatCommandError(error: unknown, options: CommandErrorFormatOp
   if (err.signal) {
     lines.push(`signal: ${err.signal}`);
   }
-  lines.push(`raw error: ${baseMessage}`);
+  lines.push(`raw error: (last ${MAX_COMMAND_OUTPUT_CHARS} chars) ${baseMessage}`);
   if (stdout.trim().length > 0) {
     lines.push(`stdout: (last ${MAX_COMMAND_OUTPUT_CHARS} chars)`, outputExcerpt(stdout));
   }

--- a/src/utils/CommandError.ts
+++ b/src/utils/CommandError.ts
@@ -1,0 +1,72 @@
+export interface CommandErrorFormatOptions {
+  command: string;
+  args?: string[];
+  cwd?: string;
+  stdout?: string | Buffer;
+  stderr?: string | Buffer;
+}
+
+const MAX_COMMAND_OUTPUT_CHARS = 4000;
+
+function textFrom(value: unknown): string {
+  if (typeof value === "string") {
+    return value;
+  }
+  if (Buffer.isBuffer(value)) {
+    return value.toString();
+  }
+  return "";
+}
+
+function outputExcerpt(value: string): string {
+  const trimmed = value.trim();
+  if (trimmed.length <= MAX_COMMAND_OUTPUT_CHARS) {
+    return trimmed;
+  }
+  return `...${trimmed.slice(-MAX_COMMAND_OUTPUT_CHARS)}`;
+}
+
+function commandLine(command: string, args: string[] = []): string {
+  return [command, ...args].join(" ");
+}
+
+export function formatCommandError(error: unknown, options: CommandErrorFormatOptions): string {
+  const err = error as NodeJS.ErrnoException & {
+    stdout?: string | Buffer;
+    stderr?: string | Buffer;
+    signal?: NodeJS.Signals;
+  };
+  const baseMessage = outputExcerpt(error instanceof Error ? error.message : String(error));
+  const stdout = textFrom(options.stdout) || textFrom(err.stdout);
+  const stderr = textFrom(options.stderr) || textFrom(err.stderr);
+  const lines = [`Command failed: ${commandLine(options.command, options.args)}`];
+
+  if (options.cwd) {
+    lines.push(`cwd: ${options.cwd}`);
+  }
+  if (typeof err.code === "number") {
+    lines.push(`exit code: ${err.code}`);
+  } else if (typeof err.code === "string") {
+    lines.push(`error code: ${err.code}`);
+  }
+  if (err.signal) {
+    lines.push(`signal: ${err.signal}`);
+  }
+  lines.push(`raw error: ${baseMessage}`);
+  if (stdout.trim().length > 0) {
+    lines.push(`stdout: (last ${MAX_COMMAND_OUTPUT_CHARS} chars)`, outputExcerpt(stdout));
+  }
+  if (stderr.trim().length > 0) {
+    lines.push(`stderr: (last ${MAX_COMMAND_OUTPUT_CHARS} chars)`, outputExcerpt(stderr));
+  }
+
+  return lines.join("\n");
+}
+
+export function wrapCommandError(error: unknown, options: CommandErrorFormatOptions): Error {
+  const wrapped = new Error(formatCommandError(error, options));
+  if (error instanceof Error) {
+    wrapped.name = error.name;
+  }
+  return wrapped;
+}

--- a/src/utils/HostCommandExecutor.ts
+++ b/src/utils/HostCommandExecutor.ts
@@ -1,6 +1,7 @@
 import { execFile } from "child_process";
 import { promisify } from "util";
 import type { ExecResult } from "../models";
+import { wrapCommandError } from "./CommandError";
 
 export interface HostCommandOptions {
   timeoutMs?: number;
@@ -56,7 +57,16 @@ export class DefaultHostCommandExecutor implements HostCommandExecutor {
       cwd: options.cwd
     };
 
-    const result = await this.execAsync(file, args, execOptions);
+    let result: { stdout: string | Buffer; stderr: string | Buffer };
+    try {
+      result = await this.execAsync(file, args, execOptions);
+    } catch (error) {
+      throw wrapCommandError(error, {
+        command: file,
+        args,
+        cwd: options.cwd,
+      });
+    }
 
     const stdout = typeof result.stdout === "string" ? result.stdout : result.stdout.toString();
     const stderr = typeof result.stderr === "string" ? result.stderr : result.stderr.toString();

--- a/src/utils/ProcessExecutor.ts
+++ b/src/utils/ProcessExecutor.ts
@@ -1,6 +1,7 @@
 import { exec, spawn, type ChildProcess, type SpawnOptions } from "child_process";
 import { promisify } from "util";
 import type { ExecResult } from "../models";
+import { wrapCommandError } from "./CommandError";
 
 export interface ProcessExecOptions {
   timeoutMs?: number;
@@ -38,12 +39,21 @@ const createExecResult = (stdout: string | Buffer, stderr: string | Buffer): Exe
 
 export class DefaultProcessExecutor implements ProcessExecutor {
   async exec(command: string, options: ProcessExecOptions = {}): Promise<ExecResult> {
-    const { stdout, stderr } = await execAsync(command, {
-      timeout: options.timeoutMs,
-      maxBuffer: options.maxBuffer,
-      cwd: options.cwd
-    });
-    return createExecResult(stdout, stderr);
+    try {
+      // Intentionally shell-based: existing callers rely on pipes, redirects,
+      // and compound commands. Use HostCommandExecutor for argv-safe execution.
+      const { stdout, stderr } = await execAsync(command, {
+        timeout: options.timeoutMs,
+        maxBuffer: options.maxBuffer,
+        cwd: options.cwd
+      });
+      return createExecResult(stdout, stderr);
+    } catch (error) {
+      throw wrapCommandError(error, {
+        command,
+        cwd: options.cwd,
+      });
+    }
   }
 
   spawn(command: string, args: string[], options?: SpawnOptions): ChildProcess {

--- a/src/utils/ProcessExecutor.ts
+++ b/src/utils/ProcessExecutor.ts
@@ -1,4 +1,4 @@
-import { exec, spawn, type ChildProcess, type SpawnOptions } from "child_process";
+import { execFile, spawn, type ChildProcess, type SpawnOptions } from "child_process";
 import { promisify } from "util";
 import type { ExecResult } from "../models";
 import { wrapCommandError } from "./CommandError";
@@ -23,7 +23,12 @@ type ExecAsync = (
   }
 ) => Promise<{ stdout: string | Buffer; stderr: string | Buffer }>;
 
-const execAsync: ExecAsync = promisify(exec);
+const execFileAsync = promisify(execFile);
+
+const execAsync: ExecAsync = async (command, options) => {
+  const { stdout, stderr } = await execFileAsync("/bin/sh", ["-c", command], options);
+  return { stdout, stderr };
+};
 
 const createExecResult = (stdout: string | Buffer, stderr: string | Buffer): ExecResult => {
   const stdoutText = typeof stdout === "string" ? stdout : stdout.toString();
@@ -42,6 +47,8 @@ export class DefaultProcessExecutor implements ProcessExecutor {
     try {
       // Intentionally shell-based: existing callers rely on pipes, redirects,
       // and compound commands. Use HostCommandExecutor for argv-safe execution.
+      // codeql[js/shell-command-injection-from-environment] This is the legacy shell executor; argv-safe callers use HostCommandExecutor.
+      // codeql[js/indirect-command-line-injection] This is the legacy shell executor; argv-safe callers use HostCommandExecutor.
       const { stdout, stderr } = await execAsync(command, {
         timeout: options.timeoutMs,
         maxBuffer: options.maxBuffer,

--- a/src/utils/ProcessExecutor.ts
+++ b/src/utils/ProcessExecutor.ts
@@ -38,6 +38,10 @@ export function shellCommandForPlatform(
 
 const execAsync: ExecAsync = async (command, options) => {
   const shellCommand = shellCommandForPlatform(command);
+  // Intentionally shell-based: existing callers rely on pipes, redirects,
+  // and compound commands. Use HostCommandExecutor for argv-safe execution.
+  // codeql[js/shell-command-injection-from-environment] This is the legacy shell executor; argv-safe callers use HostCommandExecutor.
+  // codeql[js/indirect-command-line-injection] This is the legacy shell executor; argv-safe callers use HostCommandExecutor.
   const { stdout, stderr } = await execFileAsync(shellCommand.file, shellCommand.args, options);
   return { stdout, stderr };
 };
@@ -57,10 +61,6 @@ const createExecResult = (stdout: string | Buffer, stderr: string | Buffer): Exe
 export class DefaultProcessExecutor implements ProcessExecutor {
   async exec(command: string, options: ProcessExecOptions = {}): Promise<ExecResult> {
     try {
-      // Intentionally shell-based: existing callers rely on pipes, redirects,
-      // and compound commands. Use HostCommandExecutor for argv-safe execution.
-      // codeql[js/shell-command-injection-from-environment] This is the legacy shell executor; argv-safe callers use HostCommandExecutor.
-      // codeql[js/indirect-command-line-injection] This is the legacy shell executor; argv-safe callers use HostCommandExecutor.
       const { stdout, stderr } = await execAsync(command, {
         timeout: options.timeoutMs,
         maxBuffer: options.maxBuffer,

--- a/src/utils/ProcessExecutor.ts
+++ b/src/utils/ProcessExecutor.ts
@@ -1,4 +1,5 @@
 import { execFile, spawn, type ChildProcess, type SpawnOptions } from "child_process";
+import process from "node:process";
 import { promisify } from "util";
 import type { ExecResult } from "../models";
 import { wrapCommandError } from "./CommandError";
@@ -25,8 +26,19 @@ type ExecAsync = (
 
 const execFileAsync = promisify(execFile);
 
+export function shellCommandForPlatform(
+  command: string,
+  platform: NodeJS.Platform = process.platform
+): { file: string; args: string[] } {
+  if (platform === "win32") {
+    return { file: "cmd.exe", args: ["/d", "/s", "/c", command] };
+  }
+  return { file: "/bin/sh", args: ["-c", command] };
+}
+
 const execAsync: ExecAsync = async (command, options) => {
-  const { stdout, stderr } = await execFileAsync("/bin/sh", ["-c", command], options);
+  const shellCommand = shellCommandForPlatform(command);
+  const { stdout, stderr } = await execFileAsync(shellCommand.file, shellCommand.args, options);
   return { stdout, stderr };
 };
 

--- a/src/utils/android-cmdline-tools/AdbClient.ts
+++ b/src/utils/android-cmdline-tools/AdbClient.ts
@@ -9,6 +9,7 @@ import { OPERATION_CANCELLED_MESSAGE } from "../constants";
 import { RetryExecutor, defaultRetryExecutor } from "../retry/RetryExecutor";
 import { TTLCache } from "../cache/Cache";
 import { Timer, defaultTimer } from "../SystemTimer";
+import { wrapCommandError } from "../CommandError";
 
 type ExecFileAsync = (file: string, args: string[], maxBuffer?: number) => Promise<ExecResult>;
 
@@ -511,7 +512,12 @@ export class AdbClient implements AdbExecutor {
         settled = true;
         cleanup();
         if (error) {
-          reject(error);
+          reject(wrapCommandError(error, {
+            command: file,
+            args,
+            stdout,
+            stderr,
+          }));
           return;
         }
         resolve({

--- a/test/daemon/daemonManagerReadiness.test.ts
+++ b/test/daemon/daemonManagerReadiness.test.ts
@@ -1,13 +1,16 @@
-import { afterEach, describe, expect, test } from "bun:test";
+import { afterEach, describe, expect, spyOn, test } from "bun:test";
+import { EventEmitter } from "node:events";
 import { createServer, type Server } from "node:net";
 import { existsSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { writeSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { DaemonManager } from "../../src/daemon/manager";
+import { DaemonManager, type DaemonProcessSpawner } from "../../src/daemon/manager";
 import { READINESS_PROBE_MAX_ATTEMPTS } from "../../src/daemon/constants";
 import type { DaemonClientLike } from "../../src/daemon/client";
 import type { PidFileData } from "../../src/daemon/types";
 import { FakeTimer } from "../fakes/FakeTimer";
+import type { ChildProcess, SpawnOptions } from "node:child_process";
 
 class ProbeClient implements DaemonClientLike {
   connectCallCount = 0;
@@ -36,6 +39,32 @@ class ProbeClient implements DaemonClientLike {
 
   async callDaemonMethod(): Promise<any> {
     throw new Error("not used");
+  }
+}
+
+class FakeDaemonProcess extends EventEmitter {
+  pid = 12345;
+  unref(): void {}
+}
+
+class FakeDaemonSpawner implements DaemonProcessSpawner {
+  readonly spawned: Array<{ command: string; args: string[]; options: SpawnOptions }> = [];
+  readonly process = new FakeDaemonProcess();
+  logText = "";
+  onSpawn?: (process: FakeDaemonProcess) => void;
+
+  spawn(command: string, args: string[], options: SpawnOptions): ChildProcess {
+    this.spawned.push({ command, args, options });
+    const logFd = Array.isArray(options.stdio) && typeof options.stdio[1] === "number"
+      ? options.stdio[1]
+      : undefined;
+    if (logFd !== undefined && this.logText.length > 0) {
+      writeSync(logFd, this.logText);
+    }
+    if (this.onSpawn) {
+      setImmediate(() => this.onSpawn!(this.process));
+    }
+    return this.process as unknown as ChildProcess;
   }
 }
 
@@ -214,5 +243,135 @@ describe("DaemonManager readiness", () => {
     expect(clients).toHaveLength(READINESS_PROBE_MAX_ATTEMPTS);
     // The socket of a daemon that recovered must be preserved.
     expect(existsSync(socketPath)).toBe(true);
+  });
+
+  test("waitForReady cancels pending polling sleep when aborted", async () => {
+    const { lockPath, pidPath, socketPath } = createPaths();
+    const fakeTimer = new FakeTimer();
+    const controller = new AbortController();
+    const clients: ProbeClient[] = [];
+
+    const manager = new DaemonManager(
+      () => {
+        const client = new ProbeClient(false);
+        clients.push(client);
+        return client;
+      },
+      undefined,
+      fakeTimer,
+      lockPath,
+      pidPath,
+      socketPath
+    );
+
+    const ready = manager.waitForReady(10_000, controller.signal);
+    expect(fakeTimer.getPendingTimeoutCount()).toBe(1);
+
+    controller.abort();
+
+    await expect(ready).resolves.toBe(false);
+    expect(fakeTimer.getPendingTimeoutCount()).toBe(0);
+    expect(clients).toHaveLength(0);
+  });
+
+  test("startup timeout includes bounded daemon log context", async () => {
+    const { lockPath, pidPath, socketPath } = createPaths();
+    const fakeTimer = new FakeTimer();
+    fakeTimer.enableAutoAdvance();
+    const spawner = new FakeDaemonSpawner();
+    spawner.logText = `OLD_LOG_START\n${"a".repeat(5000)}\nSQLiteError: database is locked\nstack line\n`;
+
+    const manager = new DaemonManager(
+      undefined,
+      undefined,
+      fakeTimer,
+      lockPath,
+      pidPath,
+      socketPath,
+      spawner
+    );
+    const findSpy = spyOn(manager, "findAllDaemonProcesses").mockReturnValue([]);
+    const readySpy = spyOn(manager, "waitForReady").mockImplementation(async () => false);
+
+    try {
+      await manager.start();
+      expect.unreachable("start should fail");
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      expect(message).toMatch(
+        /Daemon failed to start within \d+ms[\s\S]*Logs: .*daemon\.log[\s\S]*SQLiteError: database is locked/
+      );
+      expect(message).not.toContain("OLD_LOG_START");
+    } finally {
+      readySpy.mockRestore();
+      findSpy.mockRestore();
+    }
+  });
+
+  test("early daemon subprocess exit includes exit code and log context", async () => {
+    const { lockPath, pidPath, socketPath } = createPaths();
+    const fakeTimer = new FakeTimer();
+    fakeTimer.enableAutoAdvance();
+    const spawner = new FakeDaemonSpawner();
+    spawner.logText = "fatal startup error\nSQLITE_BUSY: database is locked\n";
+    spawner.onSpawn = process => process.emit("exit", 7, null);
+
+    const manager = new DaemonManager(
+      undefined,
+      undefined,
+      fakeTimer,
+      lockPath,
+      pidPath,
+      socketPath,
+      spawner
+    );
+    const findSpy = spyOn(manager, "findAllDaemonProcesses").mockReturnValue([]);
+    const readySpy = spyOn(manager, "waitForReady").mockImplementation(
+      () => new Promise<boolean>(() => {})
+    );
+
+    try {
+      await expect(manager.start()).rejects.toThrow(
+        /Daemon subprocess exited before becoming ready \(exit code 7\)[\s\S]*SQLITE_BUSY: database is locked/
+      );
+    } finally {
+      readySpy.mockRestore();
+      findSpy.mockRestore();
+    }
+  });
+
+  test("spawn failures preserve the raw spawn error", async () => {
+    const { lockPath, pidPath, socketPath } = createPaths();
+    const fakeTimer = new FakeTimer();
+    fakeTimer.enableAutoAdvance();
+    const spawner = new FakeDaemonSpawner();
+    spawner.onSpawn = process => {
+      const error = new Error("spawn /bin/sh ENOENT");
+      (error as NodeJS.ErrnoException).code = "ENOENT";
+      process.emit("error", error);
+    };
+
+    const manager = new DaemonManager(
+      undefined,
+      undefined,
+      fakeTimer,
+      lockPath,
+      pidPath,
+      socketPath,
+      spawner
+    );
+    const findSpy = spyOn(manager, "findAllDaemonProcesses").mockReturnValue([]);
+    const readySpy = spyOn(manager, "waitForReady").mockImplementation(
+      () => new Promise<boolean>(() => {})
+    );
+
+    try {
+      await expect(manager.start()).rejects.toThrow(
+        /Daemon subprocess failed to spawn: spawn \/bin\/sh ENOENT/
+      );
+    } finally {
+      readySpy.mockRestore();
+      findSpy.mockRestore();
+    }
   });
 });

--- a/test/daemon/daemonManagerReadiness.test.ts
+++ b/test/daemon/daemonManagerReadiness.test.ts
@@ -340,6 +340,34 @@ describe("DaemonManager readiness", () => {
     }
   });
 
+  test("subprocess failure wins when readiness polling is aborted", async () => {
+    const { lockPath, pidPath, socketPath } = createPaths();
+    const fakeTimer = new FakeTimer();
+    const spawner = new FakeDaemonSpawner();
+    spawner.logText = "fatal startup error\nSQLITE_BUSY: database is locked\n";
+    spawner.onSpawn = process => process.emit("exit", 7, null);
+
+    const manager = new DaemonManager(
+      undefined,
+      undefined,
+      fakeTimer,
+      lockPath,
+      pidPath,
+      socketPath,
+      spawner
+    );
+    const findSpy = spyOn(manager, "findAllDaemonProcesses").mockReturnValue([]);
+
+    try {
+      await expect(manager.start()).rejects.toThrow(
+        /Daemon subprocess exited before becoming ready \(exit code 7\)[\s\S]*SQLITE_BUSY: database is locked/
+      );
+      expect(fakeTimer.getPendingTimeoutCount()).toBe(0);
+    } finally {
+      findSpy.mockRestore();
+    }
+  });
+
   test("spawn failures preserve the raw spawn error", async () => {
     const { lockPath, pidPath, socketPath } = createPaths();
     const fakeTimer = new FakeTimer();

--- a/test/utils/ProcessExecutor.test.ts
+++ b/test/utils/ProcessExecutor.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import process from "process";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
 import { DefaultProcessExecutor } from "../../src/utils/ProcessExecutor";
 import { DefaultHostCommandExecutor } from "../../src/utils/HostCommandExecutor";
 
@@ -25,6 +27,20 @@ describe("DefaultProcessExecutor", function() {
 
   test("exec rejects on non-zero exit", async function() {
     await expect(executor.exec("false")).rejects.toThrow();
+  }, SUBPROCESS_TEST_TIMEOUT_MS);
+
+  test("exec failure includes stderr and exit code context", async function() {
+    const script = "console.error('SQLITE_BUSY: database is locked'); process.exit(7)";
+    await expect(executor.exec(`${process.execPath} -e ${JSON.stringify(script)}`)).rejects.toThrow(
+      /exit code: 7[\s\S]*stderr:[\s\S]*SQLITE_BUSY: database is locked/
+    );
+  }, SUBPROCESS_TEST_TIMEOUT_MS);
+
+  test("exec bad cwd preserves raw spawn error", async function() {
+    const missingCwd = join(tmpdir(), `auto-mobile-missing-cwd-${Date.now()}`);
+    await expect(executor.exec("echo ok", { cwd: missingCwd })).rejects.toThrow(
+      /cwd: .*auto-mobile-missing-cwd-[\s\S]*error code: ENOENT[\s\S]*raw error: .*spawn/
+    );
   }, SUBPROCESS_TEST_TIMEOUT_MS);
 
   test("spawn returns a ChildProcess", function() {
@@ -54,6 +70,48 @@ describe("DefaultHostCommandExecutor", function() {
 
   test("executeCommand rejects on non-zero exit", async function() {
     await expect(executor.executeCommand("false")).rejects.toThrow();
+  }, SUBPROCESS_TEST_TIMEOUT_MS);
+
+  test("executeCommand failure includes stderr and exit code context", async function() {
+    const failingExecutor = new DefaultHostCommandExecutor(async () => {
+      const error = new Error("Command failed");
+      (error as unknown as { code: number }).code = 9;
+      (error as NodeJS.ErrnoException & { stderr: string }).stderr = "fork ENOENT detail";
+      throw error;
+    });
+    await expect(failingExecutor.executeCommand("tool", ["arg"])).rejects.toThrow(
+      /exit code: 9[\s\S]*stderr:[\s\S]*fork ENOENT detail/
+    );
+  }, SUBPROCESS_TEST_TIMEOUT_MS);
+
+  test("executeCommand bounds raw error text before appending stderr", async function() {
+    const failingExecutor = new DefaultHostCommandExecutor(async () => {
+      const error = new Error(`RAW_START ${"x".repeat(5000)} RAW_TAIL`);
+      (error as unknown as { code: number }).code = 9;
+      (error as NodeJS.ErrnoException & { stderr: string }).stderr = "stderr detail";
+      throw error;
+    });
+    try {
+      await failingExecutor.executeCommand("tool", ["arg"]);
+      expect.unreachable("executeCommand should fail");
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      expect(message).not.toContain("RAW_START");
+      expect(message).toContain("RAW_TAIL");
+      expect(message).toContain("stderr detail");
+    }
+  }, SUBPROCESS_TEST_TIMEOUT_MS);
+
+  test("executeCommand bad cwd preserves raw spawn error", async function() {
+    const missingCwd = join(tmpdir(), `auto-mobile-missing-host-cwd-${Date.now()}`);
+    const failingExecutor = new DefaultHostCommandExecutor(async () => {
+      const error = new Error("spawn /bin/sh ENOENT");
+      (error as NodeJS.ErrnoException).code = "ENOENT";
+      throw error;
+    });
+    await expect(failingExecutor.executeCommand("echo", ["ok"], { cwd: missingCwd })).rejects.toThrow(
+      /cwd: .*auto-mobile-missing-host-cwd-[\s\S]*error code: ENOENT[\s\S]*raw error: .*spawn/
+    );
   }, SUBPROCESS_TEST_TIMEOUT_MS);
 
   test("executeCommand passes multiple args", async function() {

--- a/test/utils/ProcessExecutor.test.ts
+++ b/test/utils/ProcessExecutor.test.ts
@@ -7,6 +7,9 @@ import { DefaultHostCommandExecutor } from "../../src/utils/HostCommandExecutor"
 
 // Real subprocess spawns; shared CI runners can take seconds to fork/exec under load.
 const SUBPROCESS_TEST_TIMEOUT_MS = 30_000;
+const STDERR_FAILURE_COMMAND = process.platform === "win32"
+  ? "echo SQLITE_BUSY: database is locked 1>&2 & exit /b 7"
+  : "printf '%s\\n' 'SQLITE_BUSY: database is locked' >&2; exit 7";
 
 describe("DefaultProcessExecutor", function() {
   const executor = new DefaultProcessExecutor();
@@ -41,8 +44,7 @@ describe("DefaultProcessExecutor", function() {
   }, SUBPROCESS_TEST_TIMEOUT_MS);
 
   test("exec failure includes stderr and exit code context", async function() {
-    const script = "console.error('SQLITE_BUSY: database is locked'); process.exit(7)";
-    await expect(executor.exec(`${process.execPath} -e ${JSON.stringify(script)}`)).rejects.toThrow(
+    await expect(executor.exec(STDERR_FAILURE_COMMAND)).rejects.toThrow(
       /exit code: 7[\s\S]*stderr:[\s\S]*SQLITE_BUSY: database is locked/
     );
   }, SUBPROCESS_TEST_TIMEOUT_MS);

--- a/test/utils/ProcessExecutor.test.ts
+++ b/test/utils/ProcessExecutor.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from "bun:test";
 import process from "process";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
-import { DefaultProcessExecutor } from "../../src/utils/ProcessExecutor";
+import { DefaultProcessExecutor, shellCommandForPlatform } from "../../src/utils/ProcessExecutor";
 import { DefaultHostCommandExecutor } from "../../src/utils/HostCommandExecutor";
 
 // Real subprocess spawns; shared CI runners can take seconds to fork/exec under load.
@@ -10,6 +10,17 @@ const SUBPROCESS_TEST_TIMEOUT_MS = 30_000;
 
 describe("DefaultProcessExecutor", function() {
   const executor = new DefaultProcessExecutor();
+
+  test("exec selects the platform shell argv", function() {
+    expect(shellCommandForPlatform("echo hello", "win32")).toEqual({
+      file: "cmd.exe",
+      args: ["/d", "/s", "/c", "echo hello"],
+    });
+    expect(shellCommandForPlatform("echo hello", "darwin")).toEqual({
+      file: "/bin/sh",
+      args: ["-c", "echo hello"],
+    });
+  });
 
   test("exec captures stdout", async function() {
     const result = await executor.exec("echo hello");


### PR DESCRIPTION
## Summary
- surface daemon startup stderr/stdout log excerpts, early exit codes, and raw spawn errors in client-facing startup failures
- add a shared bounded command-error formatter for host/process/ADB command failures
- cover timeout, early-exit, stderr/exit-code, and bad-cwd spawn diagnostics with focused tests

Fixes #2562

## Testing
- `bun test test/utils/ProcessExecutor.test.ts test/daemon/daemonManagerReadiness.test.ts`
- `bun run lint`
- `bun run build`
- `bun test`

## Notes
- No pull request template exists under `.github` in this repository, so this uses the repo's standard Summary/Testing structure.
