### PR TITLE
Fix transient iOS simctl discovery failures

### DIFF
--- a/src/utils/deviceUtils.ts
+++ b/src/utils/deviceUtils.ts
@@ -132,13 +132,17 @@ export class MultiPlatformDeviceManager implements PlatformDeviceManager {
     }
   }
 
-  private async listIosDeviceImagesIfAvailable(): Promise<DeviceInfo[]> {
+  private async listIosDeviceImagesIfAvailable(options: { swallowDiscoveryErrors: boolean }): Promise<DeviceInfo[]> {
     if (!(await this.canDiscoverIosLocallyOrViaHostControl())) {
       return [];
     }
     try {
       return await this.simctl.listSimulatorImages();
-    } catch {
+    } catch (error) {
+      logger.warn(`[DeviceManager] iOS simulator image discovery failed: ${error}`);
+      if (!options.swallowDiscoveryErrors) {
+        throw error;
+      }
       return [];
     }
   }
@@ -163,10 +167,10 @@ export class MultiPlatformDeviceManager implements PlatformDeviceManager {
       case "android":
         return this.emulator.listAvds();
       case "ios":
-        return this.listIosDeviceImagesIfAvailable();
+        return this.listIosDeviceImagesIfAvailable({ swallowDiscoveryErrors: false });
       case "either":
         const emulators = await this.emulator.listAvds();
-        const simulators = await this.listIosDeviceImagesIfAvailable();
+        const simulators = await this.listIosDeviceImagesIfAvailable({ swallowDiscoveryErrors: true });
         return [...emulators, ...simulators];
     }
   }

--- a/src/utils/ios-cmdline-tools/SimCtlClient.ts
+++ b/src/utils/ios-cmdline-tools/SimCtlClient.ts
@@ -347,12 +347,13 @@ export class SimCtlClient implements SimCtl {
   execAsync: (file: string, args: string[], maxBuffer?: number) => Promise<ExecResult>;
   private hostControl: SimctlHostControlRunner;
   private timer: Timer;
+  private platform: NodeJS.Platform;
   private readonly usesInjectedExecAsync: boolean;
 
   // Static cache for device list
   private static deviceListCache: { devices: DeviceInfo[], timestamp: number } | null = null;
   private static readonly DEVICE_LIST_CACHE_TTL = 5000; // 5 seconds
-  private static localSimctlAvailability: Promise<boolean> | null = null;
+  private static localSimctlAvailability: Promise<void> | null = null;
 
   /**
    * Create an IosUtils instance
@@ -365,12 +366,14 @@ export class SimCtlClient implements SimCtl {
     device: BootedDevice | null = null,
     execAsyncFn: ((file: string, args: string[], maxBuffer?: number) => Promise<ExecResult>) | null = null,
     hostControlRunner: SimctlHostControlRunner | null = null,
-    timer: Timer = defaultTimer
+    timer: Timer = defaultTimer,
+    platform: NodeJS.Platform = process.platform
   ) {
     this.device = device;
     this.usesInjectedExecAsync = execAsyncFn !== null;
     this.execAsync = execAsyncFn || execAsync;
     this.timer = timer;
+    this.platform = platform;
     this.hostControl = hostControlRunner || {
       isAvailable: () => isHostControlAvailable(),
       isRunningInDocker,
@@ -420,9 +423,12 @@ export class SimCtlClient implements SimCtl {
 
     logger.debug(`[iOS] Executing command: ${fullCommand}`);
 
-    if (!(await this.isLocalSimctlAvailable())) {
-      const message = process.platform === "darwin"
-        ? "simctl is not available. Please install Xcode command line tools to continue."
+    try {
+      await this.ensureLocalSimctlAvailable();
+    } catch (error) {
+      const detail = error instanceof Error ? error.message : String(error);
+      const message = this.platform === "darwin"
+        ? `simctl is not available. Please install Xcode command line tools to continue. ${detail}`
         : "iOS simulator tooling is only available on macOS.";
       throw new ActionableError(message);
     }
@@ -495,30 +501,36 @@ export class SimCtlClient implements SimCtl {
     return this.hostControl.shouldUseHostControl() && this.hostControl.isRunningInDocker();
   }
 
-  private async isLocalSimctlAvailable(): Promise<boolean> {
+  private async ensureLocalSimctlAvailable(): Promise<void> {
     if (this.usesInjectedExecAsync) {
-      try {
-        await this.execAsync("xcrun", ["simctl", "--version"]);
-        return true;
-      } catch {
-        return false;
-      }
+      await this.execAsync("xcrun", ["simctl", "--version"]);
+      return;
     }
 
-    if (process.platform !== "darwin") {
-      return false;
+    if (this.platform !== "darwin") {
+      throw new ActionableError("iOS simulator tooling is only available on macOS.");
     }
 
     if (!SimCtlClient.localSimctlAvailability) {
       SimCtlClient.localSimctlAvailability = this.execAsync("xcrun", ["simctl", "--version"])
-        .then(() => true)
+        .then(() => undefined)
         .catch(err => {
+          SimCtlClient.localSimctlAvailability = null;
           logger.debug(`[iOS] simctl unavailable: ${err instanceof Error ? err.message : String(err)}`);
-          return false;
+          throw err;
         });
     }
 
-    return SimCtlClient.localSimctlAvailability;
+    await SimCtlClient.localSimctlAvailability;
+  }
+
+  private async isLocalSimctlAvailable(): Promise<boolean> {
+    try {
+      await this.ensureLocalSimctlAvailable();
+      return true;
+    } catch {
+      return false;
+    }
   }
 
   /**
@@ -680,17 +692,21 @@ export class SimCtlClient implements SimCtl {
         }
       }
 
-      // Cache the result
-      SimCtlClient.deviceListCache = {
-        devices,
-        timestamp: this.timer.now()
-      };
-
       devices.sort((a, b) => (a.deviceId || "").localeCompare(b.deviceId || ""));
+      if (devices.length > 0) {
+        SimCtlClient.deviceListCache = {
+          devices,
+          timestamp: this.timer.now()
+        };
+      } else {
+        SimCtlClient.deviceListCache = null;
+      }
       return devices;
     } catch (error) {
-      logger.debug(`Failed to get iOS devices: ${error}`);
-      return [];
+      SimCtlClient.deviceListCache = null;
+      const detail = error instanceof Error ? error.message : String(error);
+      logger.warn(`Failed to get iOS devices: ${detail}`);
+      throw new ActionableError(`Failed to list iOS simulator devices: ${detail}`);
     }
   }
 

--- a/test/utils/deviceUtils.test.ts
+++ b/test/utils/deviceUtils.test.ts
@@ -194,6 +194,27 @@ describe("MultiPlatformDeviceManager", () => {
     });
   });
 
+  test("listDeviceImages(ios) surfaces iOS image discovery failures", async () => {
+    const fakeSimctl = {
+      isAvailable: async () => true,
+      isUnsupportedDockerHostControlMode: () => false,
+      listSimulatorImages: async () => {
+        throw new Error("simctl list devices exploded");
+      }
+    } as unknown as SimCtlClient;
+    const fakeEmulator = {
+      listAvds: async () => []
+    } as unknown as AndroidEmulatorClient;
+
+    const manager = new MultiPlatformDeviceManager(
+      new FakeAdbClient() as unknown as AdbClient,
+      fakeSimctl,
+      fakeEmulator
+    );
+
+    await expect(manager.listDeviceImages("ios")).rejects.toThrow(/simctl list devices exploded/);
+  });
+
   test("listDeviceImages(either) keeps Android working and skips iOS in unsupported Docker host-control mode", async () => {
     await withProcessPlatform("linux", async () => {
       let simctlListCalls = 0;

--- a/test/utils/ios-cmdline-tools/simctl.test.ts
+++ b/test/utils/ios-cmdline-tools/simctl.test.ts
@@ -2,6 +2,31 @@ import { expect, describe, test, beforeEach } from "bun:test";
 import { Simctl } from "../../../src/utils/ios-cmdline-tools/SimCtlClient";
 import { BootedDevice, ExecResult } from "../../../src/models";
 import { createExecResult } from "../../../src/utils/execResult";
+import { FakeTimer } from "../../fakes/FakeTimer";
+
+function resetSimctlCaches(): void {
+  const simctlClass = Simctl as unknown as {
+    deviceListCache: { devices: unknown[]; timestamp: number } | null;
+    localSimctlAvailability: Promise<void> | null;
+  };
+  simctlClass.deviceListCache = null;
+  simctlClass.localSimctlAvailability = null;
+}
+
+function forceStaticAvailabilityPath(instance: Simctl): void {
+  (instance as unknown as { usesInjectedExecAsync: boolean }).usesInjectedExecAsync = false;
+}
+
+function simulatorListPayload(devices: unknown[]): string {
+  return JSON.stringify({
+    devices: {
+      "com.apple.CoreSimulator.SimRuntime.iOS-26-4": devices
+    },
+    runtimes: [],
+    devicetypes: [],
+    pairs: []
+  });
+}
 
 describe("Simctl", function() {
   let simctl: Simctl;
@@ -9,6 +34,8 @@ describe("Simctl", function() {
   let mockExecAsync: (file: string, args: string[], maxBuffer?: number) => Promise<ExecResult>;
 
   beforeEach(function() {
+    resetSimctlCaches();
+
     mockDevice = {
       deviceId: "test-ios-device-id",
       name: "Test iOS Device",
@@ -143,6 +170,96 @@ describe("Simctl", function() {
   });
 
   describe("listSimulatorImages", function() {
+    test("should retry local simctl availability after a transient failed probe", async function() {
+      let versionProbeCalls = 0;
+      const payload = simulatorListPayload([
+        {
+          udid: "iphone-17-pro-udid",
+          name: "iPhone 17 Pro",
+          state: "Booted",
+          isAvailable: true,
+          deviceTypeIdentifier: "com.apple.CoreSimulator.SimDeviceType.iPhone-17-Pro",
+          os_version: "26.4"
+        }
+      ]);
+
+      mockExecAsync = async (file: string, args: string[]): Promise<ExecResult> => {
+        if (file === "xcrun" && args.join(" ") === "simctl --version") {
+          versionProbeCalls++;
+          if (versionProbeCalls === 1) {
+            throw new Error("transient xcrun failure");
+          }
+          return createExecResult("simctl version 1051.50", "");
+        }
+        if (file === "xcrun" && args.join(" ") === "simctl list devices --json") {
+          return createExecResult(payload, "");
+        }
+        return createExecResult("", "");
+      };
+
+      simctl = new Simctl(null, mockExecAsync, null, undefined, "darwin");
+      forceStaticAvailabilityPath(simctl);
+
+      await expect(simctl.listSimulatorImages()).rejects.toThrow(/transient xcrun failure/);
+      const devices = await simctl.listSimulatorImages();
+
+      expect(versionProbeCalls).toBe(2);
+      expect(devices.map(device => device.name)).toEqual(["iPhone 17 Pro"]);
+    });
+
+    test("should not cache an empty simulator discovery result", async function() {
+      const timer = new FakeTimer();
+      let listCalls = 0;
+      const emptyPayload = simulatorListPayload([]);
+      const populatedPayload = simulatorListPayload([
+        {
+          udid: "iphone-17-pro-udid",
+          name: "iPhone 17 Pro",
+          state: "Booted",
+          isAvailable: true,
+          deviceTypeIdentifier: "com.apple.CoreSimulator.SimDeviceType.iPhone-17-Pro",
+          os_version: "26.4"
+        }
+      ]);
+
+      mockExecAsync = async (file: string, args: string[]): Promise<ExecResult> => {
+        if (file === "xcrun" && args.join(" ") === "simctl --version") {
+          return createExecResult("simctl version 1051.50", "");
+        }
+        if (file === "xcrun" && args.join(" ") === "simctl list devices --json") {
+          listCalls++;
+          return createExecResult(listCalls === 1 ? emptyPayload : populatedPayload, "");
+        }
+        return createExecResult("", "");
+      };
+
+      simctl = new Simctl(null, mockExecAsync, null, timer);
+
+      expect(await simctl.listSimulatorImages()).toEqual([]);
+      const devices = await simctl.listSimulatorImages();
+
+      expect(listCalls).toBe(2);
+      expect(devices.map(device => device.name)).toEqual(["iPhone 17 Pro"]);
+    });
+
+    test("should surface simctl discovery failures instead of returning an empty list", async function() {
+      mockExecAsync = async (file: string, args: string[]): Promise<ExecResult> => {
+        if (file === "xcrun" && args.join(" ") === "simctl --version") {
+          return createExecResult("simctl version 1051.50", "");
+        }
+        if (file === "xcrun" && args.join(" ") === "simctl list devices --json") {
+          throw new Error("simctl list devices exploded");
+        }
+        return createExecResult("", "");
+      };
+
+      simctl = new Simctl(null, mockExecAsync);
+
+      await expect(simctl.listSimulatorImages()).rejects.toThrow(
+        /Failed to list iOS simulator devices.*simctl list devices exploded/
+      );
+    });
+
     test("should include unavailable and transitional simulators", async function() {
       const simulatorPayload = {
         devices: {
@@ -212,8 +329,6 @@ describe("Simctl", function() {
       };
 
       simctl = new Simctl(null, mockExecAsync);
-      (Simctl as unknown as { deviceListCache: { devices: unknown[]; timestamp: number } | null })
-        .deviceListCache = null;
 
       const devices = await simctl.listSimulatorImages();
 


### PR DESCRIPTION
## Summary

- Fixes #2572.
- Stops permanently memoizing failed local `simctl --version` probes so a transient first failure can recover in the same process.
- Avoids caching empty iOS simulator discovery results and surfaces simulator discovery failures instead of silently returning no devices.
- Keeps mixed `either` image discovery resilient while explicit iOS image discovery reports the underlying simctl error.

## Testing

- `bun test test/utils/ios-cmdline-tools/simctl.test.ts test/utils/deviceUtils.test.ts`
- `bun run lint`
- `bun run build`
- `bun test --isolate`

## Notes

- Plain `bun test` and `bash scripts/validate-bun-test-timings.sh` fail in this local worktree because non-isolated platform-mutation tests cause `sharp` to resolve the invalid `linuxnull-arm64` runtime. The affected sharp and memory-leak tests pass individually, and the full isolated suite passes.
