### PR TITLE
fix: publish conditional postNotification schema

### DIFF
--- a/schemas/tool-definitions.json
+++ b/schemas/tool-definitions.json
@@ -506,7 +506,22 @@
         "action",
         "platform"
       ],
-      "additionalProperties": false
+      "additionalProperties": false,
+      "if": {
+        "properties": {
+          "action": {
+            "const": "copy"
+          }
+        },
+        "required": [
+          "action"
+        ]
+      },
+      "then": {
+        "required": [
+          "text"
+        ]
+      }
     }
   },
   {
@@ -659,7 +674,22 @@
       "required": [
         "action"
       ],
-      "additionalProperties": false
+      "additionalProperties": false,
+      "if": {
+        "properties": {
+          "action": {
+            "const": "restore"
+          }
+        },
+        "required": [
+          "action"
+        ]
+      },
+      "then": {
+        "required": [
+          "snapshotName"
+        ]
+      }
     }
   },
   {
@@ -4504,7 +4534,22 @@
         "body",
         "platform"
       ],
-      "additionalProperties": false
+      "additionalProperties": false,
+      "if": {
+        "properties": {
+          "platform": {
+            "const": "ios"
+          }
+        },
+        "required": [
+          "platform"
+        ]
+      },
+      "then": {
+        "required": [
+          "appId"
+        ]
+      }
     }
   },
   {

--- a/src/server/toolRegistry.ts
+++ b/src/server/toolRegistry.ts
@@ -81,7 +81,92 @@ export function flattenTopLevelUnion(schema: Record<string, unknown>): Record<st
     result.additionalProperties = [...seenAdditionalProperties][0];
   }
 
+  const conditionalRequired = buildConditionalRequired(branches, commonRequired);
+  if (conditionalRequired) {
+    Object.assign(result, conditionalRequired);
+  }
+
   return result;
+}
+
+interface ConditionalRequirement {
+  if: {
+    properties: Record<string, { const: unknown }>;
+    required: string[];
+  };
+  then: {
+    required: string[];
+  };
+  else?: ConditionalRequirement;
+}
+
+function buildConditionalRequired(
+  branches: Record<string, unknown>[],
+  commonRequired: string[]
+): ConditionalRequirement | undefined {
+  const commonRequiredSet = new Set(commonRequired);
+  const requirements: ConditionalRequirement[] = [];
+
+  for (const branch of branches) {
+    const required = Array.isArray(branch.required)
+      ? branch.required.filter((key): key is string => typeof key === "string")
+      : [];
+    const branchOnlyRequired = required.filter(key => !commonRequiredSet.has(key));
+    if (branchOnlyRequired.length === 0) {
+      continue;
+    }
+
+    const condition = buildDiscriminatorCondition(branch);
+    if (!condition) {
+      continue;
+    }
+
+    requirements.push({
+      if: condition,
+      then: {
+        required: branchOnlyRequired,
+      },
+    });
+  }
+
+  return chainConditionalRequirements(requirements);
+}
+
+function buildDiscriminatorCondition(
+  branch: Record<string, unknown>
+): ConditionalRequirement["if"] | undefined {
+  const properties = isJsonSchemaObject(branch.properties) ? branch.properties : {};
+  for (const [key, value] of Object.entries(properties)) {
+    if (!isJsonSchemaObject(value)) {
+      continue;
+    }
+    const values = constOrEnumValues(value);
+    if (values.length !== 1) {
+      continue;
+    }
+    return {
+      properties: {
+        [key]: { const: values[0] },
+      },
+      required: [key],
+    };
+  }
+  return undefined;
+}
+
+function chainConditionalRequirements(
+  requirements: ConditionalRequirement[]
+): ConditionalRequirement | undefined {
+  let chain: ConditionalRequirement | undefined;
+
+  for (const requirement of requirements.toReversed()) {
+    chain = {
+      ...requirement,
+      ...(chain ? { else: chain } : {}),
+    };
+  }
+
+  return chain;
 }
 
 function mergeUnionProperty(existing: unknown, incoming: unknown): unknown {

--- a/test/server/flattenTopLevelUnion.test.ts
+++ b/test/server/flattenTopLevelUnion.test.ts
@@ -137,4 +137,44 @@ describe("flattenTopLevelUnion", () => {
     });
     expect(result.required).toEqual(["platform", "title"]);
   });
+
+  test("preserves a branch-only required field as a conditional requirement", () => {
+    const schema = {
+      oneOf: [
+        {
+          type: "object",
+          properties: {
+            platform: { type: "string", const: "ios", description: "Target platform" },
+            title: { type: "string" },
+            appId: { type: "string" },
+          },
+          required: ["platform", "title", "appId"],
+          additionalProperties: false,
+        },
+        {
+          type: "object",
+          properties: {
+            platform: { type: "string", const: "android", description: "Target platform" },
+            title: { type: "string" },
+            appId: { type: "string" },
+          },
+          required: ["platform", "title"],
+          additionalProperties: false,
+        },
+      ],
+    };
+
+    const result = flattenTopLevelUnion(schema);
+
+    expect(result.required).toEqual(["platform", "title"]);
+    expect(result.if).toEqual({
+      properties: {
+        platform: { const: "ios" },
+      },
+      required: ["platform"],
+    });
+    expect(result.then).toEqual({
+      required: ["appId"],
+    });
+  });
 });

--- a/test/server/notificationTools.test.ts
+++ b/test/server/notificationTools.test.ts
@@ -70,4 +70,23 @@ describe("notification tools", () => {
     expect(schema.oneOf).toBeUndefined();
     expect(schema.allOf).toBeUndefined();
   });
+
+  test("generated tool definition conditionally requires appId on iOS", () => {
+    const toolDefinition = ToolRegistry.getToolDefinitions()
+      .find(tool => tool.name === "postNotification");
+
+    expect(toolDefinition).toBeDefined();
+    const schema = toolDefinition!.inputSchema as any;
+    expect(schema.required).toEqual(["title", "body", "platform"]);
+    expect(schema.if).toEqual({
+      properties: {
+        platform: { const: "ios" },
+      },
+      required: ["platform"],
+    });
+    expect(schema.then).toEqual({
+      required: ["appId"],
+    });
+    expect(schema.required).not.toContain("appId");
+  });
 });


### PR DESCRIPTION
## Summary
- Preserve branch-specific required fields when flattening top-level Zod unions for published tool definitions.
- Advertise `postNotification` as conditionally requiring `appId` when `platform` is `ios`, while keeping Android calls valid without `appId`.
- Regenerate `schemas/tool-definitions.json`, which also carries existing conditional requirements for `clipboard` and `deviceSnapshot`.

Closes #2544.

## Evaluation criteria
- `postNotificationSchema` rejects `{ platform: "ios", title, body }` with an `appId` schema error.
- `postNotificationSchema` accepts `{ platform: "android", title, body }` without `appId`.
- Generated `postNotification` input schema has no top-level `anyOf`, `oneOf`, or `allOf`.
- Generated `postNotification` input schema includes `if platform == ios then required appId`.
- Generated schemas remain in sync with source.

## Testing
- `bun test test/server/flattenTopLevelUnion.test.ts test/server/notificationTools.test.ts test/server/interactionTools.clipboard.test.ts test/server/snapshotTools.test.ts test/server/tools/schema.test.ts`
- `bun run lint`
- `bun run build`
- `bun test`
