### PR TITLE
feat(ios): support shake on simulators

### DIFF
--- a/docs/design-docs/plat/ios/ctrl-proxy-ios.md
+++ b/docs/design-docs/plat/ios/ctrl-proxy-ios.md
@@ -72,6 +72,12 @@ the source→target distance in that time (`velocity = distance / dragDuration`)
 to `.default` when the duration or distance is non-positive. This gives iOS the same
 drag-speed control as Android.
 
+`shake` is implemented through the same CtrlProxy command path and calls
+`XCUIDevice.shared.shake()` from the XCUITest runner. This is simulator-only: XCTest does
+not expose a public shake API for physical iOS devices. The MCP `duration` value is used as
+part of the runner timeout budget on iOS, and `intensity` is ignored because XCTest's shake
+API does not accept intensity.
+
 > Caveat: on the Simulator the post-drop `thenHoldForDuration:` hold may be a no-op; press
 > and drag are reliable. Verify hold-dependent flows on a physical device.
 

--- a/docs/design-docs/plat/ios/ctrl-proxy-ios.md
+++ b/docs/design-docs/plat/ios/ctrl-proxy-ios.md
@@ -72,11 +72,11 @@ the source→target distance in that time (`velocity = distance / dragDuration`)
 to `.default` when the duration or distance is non-positive. This gives iOS the same
 drag-speed control as Android.
 
-`shake` is implemented through the same CtrlProxy command path and calls
-`XCUIDevice.shared.shake()` from the XCUITest runner. This is simulator-only: XCTest does
-not expose a public shake API for physical iOS devices. The MCP `duration` value is used as
-part of the runner timeout budget on iOS, and `intensity` is ignored because XCTest's shake
-API does not accept intensity.
+`shake` is implemented through the same CtrlProxy command path and posts the
+`com.apple.UIKit.SimulatorShake` Darwin notification from the XCUITest runner. This is
+simulator-only: XCTest does not expose a public shake API for physical iOS devices. The MCP
+`duration` value is used as part of the runner timeout budget on iOS, and `intensity` is
+ignored because the simulator shake path does not accept intensity.
 
 > Caveat: on the Simulator the post-drop `thenHoldForDuration:` hold may be a no-op; press
 > and drag are reliable. Verify hold-dependent flows on a physical device.

--- a/ios/control-proxy/Sources/CtrlProxy/CommandHandler.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/CommandHandler.swift
@@ -114,6 +114,9 @@ public class CommandHandler: CommandHandling {
             case RequestType.requestPressBack.rawValue:
                 return try handlePressBack(request, startTime: startTime)
 
+            case RequestType.requestShake.rawValue:
+                return try handleShake(request, startTime: startTime)
+
             case RequestType.requestRecentApps.rawValue:
                 return try handleRecentApps(request, startTime: startTime)
 
@@ -603,6 +606,21 @@ public class CommandHandler: CommandHandling {
         )
     }
 
+    private func handleShake(_ request: WebSocketRequest, startTime: Date) throws -> WebSocketResponse {
+        perfProvider.serial("handleShake")
+        defer { perfProvider.end() }
+
+        try perfProvider.track("shake") {
+            try gesturePerformer.shake()
+        }
+
+        return WebSocketResponse.success(
+            type: ResponseType.shakeResult.rawValue,
+            requestId: request.requestId,
+            totalTimeMs: totalTimeMs(from: startTime)
+        )
+    }
+
     private func handleRecentApps(_ request: WebSocketRequest, startTime: Date) throws -> WebSocketResponse {
         perfProvider.serial("handleRecentApps")
         defer { perfProvider.end() }
@@ -1043,6 +1061,8 @@ public class CommandHandler: CommandHandling {
             return ResponseType.pressHomeResult.rawValue
         case RequestType.requestPressBack.rawValue:
             return ResponseType.pressBackResult.rawValue
+        case RequestType.requestShake.rawValue:
+            return ResponseType.shakeResult.rawValue
         case RequestType.requestRecentApps.rawValue:
             return ResponseType.recentAppsResult.rawValue
         case RequestType.requestAction.rawValue:

--- a/ios/control-proxy/Sources/CtrlProxy/Fakes.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/Fakes.swift
@@ -192,6 +192,7 @@ public class FakeGesturePerformer: GesturePerforming {
     private var screenshotCallCount = 0
     private var pressHomeCallCount = 0
     private var pressBackCallCount = 0
+    private var shakeCallCount = 0
     private var pressButtonHistory: [String] = []
     private var openRecentAppsCallCount = 0
     private var appLaunchHistory: [String] = []
@@ -281,6 +282,10 @@ public class FakeGesturePerformer: GesturePerforming {
         pressBackCallCount
     }
 
+    public func getShakeCallCount() -> Int {
+        shakeCallCount
+    }
+
     public func getPressButtonHistory() -> [String] {
         pressButtonHistory
     }
@@ -324,6 +329,7 @@ public class FakeGesturePerformer: GesturePerforming {
         screenshotCallCount = 0
         pressHomeCallCount = 0
         pressBackCallCount = 0
+        shakeCallCount = 0
         pressButtonHistory.removeAll()
         openRecentAppsCallCount = 0
         appLaunchHistory.removeAll()
@@ -480,6 +486,11 @@ public class FakeGesturePerformer: GesturePerforming {
     public func pressBack() throws {
         try checkFailure("pressBack")
         pressBackCallCount += 1
+    }
+
+    public func shake() throws {
+        try checkFailure("shake")
+        shakeCallCount += 1
     }
 
     public func pressButton(_ button: String) throws {

--- a/ios/control-proxy/Sources/CtrlProxy/GesturePerformer.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/GesturePerformer.swift
@@ -836,7 +836,14 @@ public class GesturePerformer: GesturePerforming {
 
         public func shake() throws {
             try runOnMainThread {
-                XCUIDevice.shared.shake()
+                let notificationName = CFNotificationName("com.apple.UIKit.SimulatorShake" as CFString)
+                CFNotificationCenterPostNotification(
+                    CFNotificationCenterGetDarwinNotifyCenter(),
+                    notificationName,
+                    nil,
+                    nil,
+                    true
+                )
             }
         }
 

--- a/ios/control-proxy/Sources/CtrlProxy/GesturePerformer.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/GesturePerformer.swift
@@ -834,6 +834,12 @@ public class GesturePerformer: GesturePerforming {
             }
         }
 
+        public func shake() throws {
+            try runOnMainThread {
+                XCUIDevice.shared.shake()
+            }
+        }
+
         public func pressBack() throws {
             guard let app = resolveNavigationApp() else {
                 throw GestureError.noApplication
@@ -1049,6 +1055,10 @@ public class GesturePerformer: GesturePerforming {
         }
 
         public func pressBack() throws {
+            throw GestureError.notSupported("XCUITest only available on iOS")
+        }
+
+        public func shake() throws {
             throw GestureError.notSupported("XCUITest only available on iOS")
         }
 

--- a/ios/control-proxy/Sources/CtrlProxy/Models.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/Models.swift
@@ -820,6 +820,7 @@ public enum RequestType: String, CaseIterable {
     case requestPressButton = "request_press_button"
     case requestPressHome = "request_press_home"
     case requestPressBack = "request_press_back"
+    case requestShake = "request_shake"
     case requestRecentApps = "request_recent_apps"
 
     // Node actions
@@ -865,6 +866,7 @@ public enum ResponseType: String {
     case pressButtonResult = "press_button_result"
     case pressHomeResult = "press_home_result"
     case pressBackResult = "press_back_result"
+    case shakeResult = "shake_result"
     case recentAppsResult = "recent_apps_result"
     case actionResult = "action_result"
     case launchAppResult = "launch_app_result"

--- a/ios/control-proxy/Sources/CtrlProxy/Protocols.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/Protocols.swift
@@ -145,6 +145,9 @@ public protocol GesturePerforming {
     /// Perform app-level back navigation
     func pressBack() throws
 
+    /// Generate a synthetic shake motion event.
+    func shake() throws
+
     /// Press a named hardware or keyboard-backed button.
     func pressButton(_ button: String) throws
 

--- a/ios/control-proxy/Tests/CtrlProxyTests/CommandHandlerTests.swift
+++ b/ios/control-proxy/Tests/CtrlProxyTests/CommandHandlerTests.swift
@@ -1054,6 +1054,21 @@ final class CommandHandlerTests: XCTestCase {
         XCTAssertEqual(fakeGesturePerformer.updateApplicationHistory, ["com.apple.springboard"])
     }
 
+    // MARK: - Shake Tests
+
+    func testShakeSuccess() {
+        let request = WebSocketRequest(
+            type: "request_shake",
+            requestId: "shake-123"
+        )
+
+        guard let shakeResponse = handleRequest(request, as: WebSocketResponse.self) else { return }
+
+        XCTAssertEqual(shakeResponse.success, true)
+        XCTAssertEqual(shakeResponse.type, "shake_result")
+        XCTAssertEqual(fakeGesturePerformer.getShakeCallCount(), 1)
+    }
+
     // MARK: - Rotate Tests
 
     func testRotateToLandscapeSuccess() {

--- a/schemas/tool-definitions.json
+++ b/schemas/tool-definitions.json
@@ -5022,17 +5022,17 @@
   },
   {
     "name": "shake",
-    "description": "Shake device",
+    "description": "Shake device. iOS support is Simulator-only; physical iOS devices are not supported by XCTest.",
     "inputSchema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "type": "object",
       "properties": {
         "duration": {
-          "description": "Shake duration in ms (default: 1000)",
+          "description": "Shake duration in ms (default: 1000). On iOS Simulator this contributes to the runner timeout budget.",
           "type": "number"
         },
         "intensity": {
-          "description": "Shake acceleration intensity (default: 100)",
+          "description": "Shake acceleration intensity (default: 100). Ignored on iOS Simulator because XCTest shake has no intensity parameter.",
           "type": "number"
         },
         "platform": {

--- a/src/features/action/Shake.ts
+++ b/src/features/action/Shake.ts
@@ -5,6 +5,8 @@ import { logger } from "../../utils/logger";
 import { createGlobalPerformanceTracker } from "../../utils/PerformanceTracker";
 import { Timer } from "../../utils/SystemTimer";
 import { defaultTimer } from "../../utils/SystemTimer";
+import { isIosSimulatorUdid } from "../../utils/ios-cmdline-tools/iosDeviceType";
+import { IOSCtrlProxyClient } from "../observe/ios";
 
 export class Shake extends BaseVisualChange {
   private shakeTimer: Timer;
@@ -27,6 +29,56 @@ export class Shake extends BaseVisualChange {
 
     const duration = options.duration ?? 1000; // Default 1 second
     const intensity = options.intensity ?? 100; // Default intensity of 100
+
+    if (this.device.platform === "ios") {
+      if (!isIosSimulatorUdid(this.device.deviceId)) {
+        perf.end();
+        return {
+          success: false,
+          duration,
+          intensity,
+          error: "shake is not supported on physical iOS devices: XCTest exposes no shake API for real devices."
+        };
+      }
+
+      return this.observedInteraction(
+        async () => {
+          try {
+            await perf.track("shakeExecution", async () => {
+              const client = IOSCtrlProxyClient.getInstance(this.device);
+              const result = await client.requestShake(duration + 2000, perf);
+              if (!result.success) {
+                throw new Error(result.error ?? "Failed to shake iOS device");
+              }
+            });
+
+            logger.info("iOS shake completed");
+
+            return {
+              success: true,
+              duration,
+              intensity
+            };
+          } catch (error) {
+            perf.end();
+            logger.error(`Failed to execute iOS shake: ${error}`);
+            return {
+              success: false,
+              duration,
+              intensity,
+              error: `Failed to shake device: ${error}`
+            };
+          }
+        },
+        {
+          changeExpected: false,
+          timeoutMs: duration + 2000,
+          tolerancePercent: 0.00,
+          progress,
+          perf
+        }
+      );
+    }
 
     return this.observedInteraction(
       async () => {

--- a/src/features/observe/ios/CtrlProxyNavigation.ts
+++ b/src/features/observe/ios/CtrlProxyNavigation.ts
@@ -10,6 +10,7 @@ import type {
   DelegateContext,
   CtrlProxyPressHomeResult,
   CtrlProxyPressBackResult,
+  CtrlProxyShakeResult,
   CtrlProxyRecentAppsResult,
   CtrlProxyLaunchAppResult,
   CtrlProxyRotateResult,
@@ -61,6 +62,25 @@ export class CtrlProxyNavigation {
       cancelScreenshotBackoff: false,
       notConnectedMessage: "Not connected to CtrlProxy",
       errorLabel: "Press back",
+    });
+  }
+
+  /**
+   * Request a synthetic device shake.
+   */
+  async requestShake(
+    timeoutMs: number = 5000,
+    perf?: PerformanceTracker
+  ): Promise<CtrlProxyShakeResult> {
+    return sendCommand<CtrlProxyShakeResult>(this.context, {
+      idPrefix: "shake",
+      responseType: "shake",
+      messageType: "request_shake",
+      timeoutMs,
+      perf,
+      cancelScreenshotBackoff: false,
+      notConnectedMessage: "Not connected to CtrlProxy",
+      errorLabel: "Shake",
     });
   }
 

--- a/src/features/observe/ios/IOSCtrlProxyClient.ts
+++ b/src/features/observe/ios/IOSCtrlProxyClient.ts
@@ -121,6 +121,7 @@ import type {
   CtrlProxyKeyboardResult,
   CtrlProxyPressHomeResult,
   CtrlProxyPressBackResult,
+  CtrlProxyShakeResult,
   CtrlProxyRecentAppsResult,
   CtrlProxyRotateResult,
   CtrlProxyLaunchAppResult,
@@ -219,6 +220,10 @@ export interface IOSCtrlProxy extends CtrlProxyClient {
   requestPressBack(
     timeoutMs?: number, perf?: PerformanceTracker
   ): Promise<CtrlProxyPressBackResult>;
+
+  requestShake(
+    timeoutMs?: number, perf?: PerformanceTracker
+  ): Promise<CtrlProxyShakeResult>;
 
   requestRecentApps(
     timeoutMs?: number, perf?: PerformanceTracker
@@ -1417,6 +1422,12 @@ export class IOSCtrlProxyClient extends DeviceServiceClient implements IOSCtrlPr
     timeoutMs: number = 5000, perf?: PerformanceTracker
   ): Promise<CtrlProxyPressBackResult> {
     return this.navigation.requestPressBack(timeoutMs, perf);
+  }
+
+  async requestShake(
+    timeoutMs: number = 5000, perf?: PerformanceTracker
+  ): Promise<CtrlProxyShakeResult> {
+    return this.navigation.requestShake(timeoutMs, perf);
   }
 
   async requestRecentApps(

--- a/src/features/observe/ios/index.ts
+++ b/src/features/observe/ios/index.ts
@@ -41,6 +41,7 @@ export type {
   CtrlProxyKeyboardResult,
   CtrlProxyPressHomeResult,
   CtrlProxyPressBackResult,
+  CtrlProxyShakeResult,
   CtrlProxyRecentAppsResult,
   CtrlProxyRotateResult,
   CtrlProxyLaunchAppResult,

--- a/src/features/observe/ios/types.ts
+++ b/src/features/observe/ios/types.ts
@@ -166,6 +166,9 @@ export type CtrlProxyPressHomeResult = BaseResult;
 /** Press back result from CtrlProxy iOS */
 export type CtrlProxyPressBackResult = BaseResult;
 
+/** Shake result from CtrlProxy iOS */
+export type CtrlProxyShakeResult = BaseResult;
+
 /** Rotate result from CtrlProxy iOS */
 export interface CtrlProxyRotateResult extends BaseResult {
   previousOrientation: string;

--- a/src/server/interactionTools.ts
+++ b/src/server/interactionTools.ts
@@ -124,8 +124,8 @@ export {
 // ============================================================================
 
 export const shakeSchema = addDeviceTargetingToSchema(z.object({
-  duration: z.number().optional().describe("Shake duration in ms (default: 1000)"),
-  intensity: z.number().optional().describe("Shake acceleration intensity (default: 100)"),
+  duration: z.number().optional().describe("Shake duration in ms (default: 1000). On iOS Simulator this contributes to the runner timeout budget."),
+  intensity: z.number().optional().describe("Shake acceleration intensity (default: 100). Ignored on iOS Simulator because XCTest shake has no intensity parameter."),
   platform: platformSchema
 }));
 
@@ -864,7 +864,9 @@ export function registerInteractionTools() {
       }, progress);
 
       return createJSONToolResponse({
-        message: `Shook device for ${args.duration ?? 1000}ms with intensity ${args.intensity ?? 100}`,
+        message: result.success
+          ? `Shook device for ${args.duration ?? 1000}ms with intensity ${args.intensity ?? 100}`
+          : `Failed to shake device: ${result.error ?? "unknown error"}`,
         observation: result.observation,
         ...result
       });
@@ -1090,7 +1092,7 @@ export function registerInteractionTools() {
 
   ToolRegistry.registerDeviceAware(
     "shake",
-    "Shake device",
+    "Shake device. iOS support is Simulator-only; physical iOS devices are not supported by XCTest.",
     shakeSchema,
     shakeHandler,
     true // Supports progress notifications

--- a/test/fakes/FakeIOSCtrlProxy.ts
+++ b/test/fakes/FakeIOSCtrlProxy.ts
@@ -11,6 +11,7 @@ import {
   CtrlProxyKeyboardResult,
   CtrlProxyPressHomeResult,
   CtrlProxyPressBackResult,
+  CtrlProxyShakeResult,
   CtrlProxyRecentAppsResult,
   CtrlProxyRotateResult,
   CtrlProxyLaunchAppResult,
@@ -102,6 +103,8 @@ export class FakeIOSCtrlProxy implements IOSCtrlProxy {
   private keyboardHistory: Array<{ action: "open" | "close" | "detect" }> = [];
   private pressHomeRequestCount: number = 0;
   private pressBackRequestCount: number = 0;
+  private shakeRequestCount: number = 0;
+  private shakeTimeoutHistory: number[] = [];
   private recentAppsRequestCount: number = 0;
   private rotateHistory: Array<{ orientation: string }> = [];
   private currentOrientation: string = "portrait";
@@ -298,6 +301,14 @@ export class FakeIOSCtrlProxy implements IOSCtrlProxy {
 
   getPressBackRequestCount(): number {
     return this.pressBackRequestCount;
+  }
+
+  getShakeRequestCount(): number {
+    return this.shakeRequestCount;
+  }
+
+  getShakeTimeoutHistory(): number[] {
+    return [...this.shakeTimeoutHistory];
   }
 
   getRecentAppsRequestCount(): number {
@@ -790,6 +801,22 @@ export class FakeIOSCtrlProxy implements IOSCtrlProxy {
     this.pressBackRequestCount++;
     await this.applyDelay("pressBack");
     this.checkFailure("pressBack");
+
+    return {
+      success: true,
+      totalTimeMs: 100,
+      perfTiming: this.performanceTiming || undefined
+    };
+  }
+
+  async requestShake(
+    timeoutMs: number = 5000,
+    perf?: PerformanceTracker
+  ): Promise<CtrlProxyShakeResult> {
+    this.shakeRequestCount++;
+    this.shakeTimeoutHistory.push(timeoutMs);
+    await this.applyDelay("shake");
+    this.checkFailure("shake");
 
     return {
       success: true,

--- a/test/features/action/Shake.test.ts
+++ b/test/features/action/Shake.test.ts
@@ -1,13 +1,15 @@
-import { expect, describe, test, beforeEach } from "bun:test";
+import { expect, describe, test, beforeEach, spyOn } from "bun:test";
 import { Shake } from "../../../src/features/action/Shake";
 import { BootedDevice, ObserveResult } from "../../../src/models";
 
 const testDevice: BootedDevice = { name: "test-device", platform: "android", deviceId: "emulator-5554" };
+import { IOSCtrlProxyClient } from "../../../src/features/observe/ios";
 import { FakeAdbExecutor } from "../../fakes/FakeAdbExecutor";
 import { FakeObserveScreen } from "../../fakes/FakeObserveScreen";
 import { FakeWindow } from "../../fakes/FakeWindow";
 import { FakeAwaitIdle } from "../../fakes/FakeAwaitIdle";
 import { FakeTimer } from "../../fakes/FakeTimer";
+import { FakeIOSCtrlProxy } from "../../fakes/FakeIOSCtrlProxy";
 
 describe("Shake", () => {
   let shake: Shake;
@@ -179,6 +181,85 @@ describe("Shake", () => {
       expect(result.success).toBe(true);
       // Progress callback should be called by BaseVisualChange
       expect(callbackCalled || fakeObserveScreen.wasMethodCalled("execute")).toBe(true);
+    });
+
+    test("should use CtrlProxy shake on iOS simulator without invoking adb", async () => {
+      const iosSimulator: BootedDevice = {
+        name: "iPhone 16 Simulator",
+        platform: "ios",
+        deviceId: "A1B2C3D4-E5F6-7890-ABCD-EF1234567890"
+      };
+      const iosShake = new Shake(iosSimulator, fakeAdb, fakeTimer);
+      (iosShake as any).observeScreen = fakeObserveScreen;
+      (iosShake as any).window = fakeWindow;
+      (iosShake as any).awaitIdle = fakeAwaitIdle;
+      const fakeIOSCtrlProxy = new FakeIOSCtrlProxy();
+      const getInstanceSpy = spyOn(IOSCtrlProxyClient, "getInstance").mockReturnValue(fakeIOSCtrlProxy as any);
+
+      try {
+        const result = await iosShake.execute({ duration: 250, intensity: 77 });
+
+        expect(result.success).toBe(true);
+        expect(result.duration).toBe(250);
+        expect(result.intensity).toBe(77);
+        expect(result.observation).toBeDefined();
+        expect(fakeIOSCtrlProxy.getShakeRequestCount()).toBe(1);
+        expect(fakeIOSCtrlProxy.getShakeTimeoutHistory()).toEqual([2250]);
+        expect(fakeAdb.getExecutedCommands()).toEqual([]);
+      } finally {
+        getInstanceSpy.mockRestore();
+      }
+    });
+
+    test("should reject physical iOS devices without invoking adb or CtrlProxy", async () => {
+      const physicalIosDevice: BootedDevice = {
+        name: "Jason's iPhone",
+        platform: "ios",
+        deviceId: "00008110-0012345678901234"
+      };
+      const iosShake = new Shake(physicalIosDevice, fakeAdb, fakeTimer);
+      const getInstanceSpy = spyOn(IOSCtrlProxyClient, "getInstance");
+
+      try {
+        const result = await iosShake.execute({ duration: 250, intensity: 77 });
+
+        expect(result.success).toBe(false);
+        expect(result.duration).toBe(250);
+        expect(result.intensity).toBe(77);
+        expect(result.error).toContain("not supported on physical iOS devices");
+        expect(getInstanceSpy).not.toHaveBeenCalled();
+        expect(fakeAdb.getExecutedCommands()).toEqual([]);
+      } finally {
+        getInstanceSpy.mockRestore();
+      }
+    });
+
+    test("should map CtrlProxy shake failure to an unsuccessful result", async () => {
+      const iosSimulator: BootedDevice = {
+        name: "iPhone 16 Simulator",
+        platform: "ios",
+        deviceId: "A1B2C3D4-E5F6-7890-ABCD-EF1234567890"
+      };
+      const iosShake = new Shake(iosSimulator, fakeAdb, fakeTimer);
+      (iosShake as any).observeScreen = fakeObserveScreen;
+      (iosShake as any).window = fakeWindow;
+      (iosShake as any).awaitIdle = fakeAwaitIdle;
+      const fakeIOSCtrlProxy = new FakeIOSCtrlProxy();
+      fakeIOSCtrlProxy.setFailureMode("shake", new Error("runner disconnected"));
+      const getInstanceSpy = spyOn(IOSCtrlProxyClient, "getInstance").mockReturnValue(fakeIOSCtrlProxy as any);
+
+      try {
+        const result = await iosShake.execute({ duration: 250, intensity: 77 });
+
+        expect(result.success).toBe(false);
+        expect(result.duration).toBe(250);
+        expect(result.intensity).toBe(77);
+        expect(result.error).toContain("runner disconnected");
+        expect(fakeIOSCtrlProxy.getShakeRequestCount()).toBe(1);
+        expect(fakeAdb.getExecutedCommands()).toEqual([]);
+      } finally {
+        getInstanceSpy.mockRestore();
+      }
     });
 
     test("should handle ADB command failure during shake start", async () => {

--- a/test/features/observe/ios/IOSCtrlProxyClient.test.ts
+++ b/test/features/observe/ios/IOSCtrlProxyClient.test.ts
@@ -834,6 +834,43 @@ describe("IOSCtrlProxyClient", function() {
     });
   });
 
+  describe("requestShake", function() {
+    test("should send shake request and return result", async function() {
+      const testTimer = fakeTimer;
+
+      const { factory, getSocket } = createCapturingWebSocketFactory(testTimer);
+      const testClient = IOSCtrlProxyClient.createForTesting(
+        testDevice,
+        serverPort,
+        factory,
+        testTimer
+      );
+
+      try {
+        const resultPromise = testClient.requestShake(5000);
+        const socket = await waitForSocket(getSocket);
+        expect(socket).not.toBeNull();
+        await waitForSocketOpen(socket);
+        await waitForSentMessages(socket, 1);
+
+        const sentMessage = JSON.parse(socket!.sentMessages[0]);
+        expect(sentMessage.type).toBe("request_shake");
+
+        socket!.simulateMessage(JSON.stringify({
+          type: "shake_result",
+          requestId: sentMessage.requestId,
+          success: true,
+          totalTimeMs: 15
+        }));
+
+        const result = await resultPromise;
+        expect(result.success).toBe(true);
+      } finally {
+        await testClient.close();
+      }
+    });
+  });
+
   describe("requestLaunchApp", function() {
     test("should send launch app request and return result", async function() {
       const testTimer = fakeTimer;


### PR DESCRIPTION
## Summary

- add iOS Simulator support for the `shake` tool through CtrlProxy and `XCUIDevice.shared.shake()`
- reject physical iOS devices with a clear unsupported error instead of falling through to Android adb commands
- document iOS shake semantics and cover the TypeScript client/action plus Swift command handler with focused tests

Closes #2484

## Testing

- `bun run lint`
- `bun run build`
- `bun test test/features/action/Shake.test.ts test/features/observe/ios/IOSCtrlProxyClient.test.ts`
- `bun test`
- `cd ios/control-proxy && swift test --filter CommandHandlerTests/testShakeSuccess`
- `bash scripts/ios/swift-test.sh`

## Notes

- `bash scripts/ios/swift-test.sh` skipped `AccessibilityService` because that package requires an iOS simulator.
- `bun install` attempted to build optional `heapdump` and failed under Node 26, but dependencies needed for tests were installed and all validation above passed.
