### PR TITLE
[codex] Cover observation disconnect client hooks

### DIFF
--- a/src/features/observe/DeviceConnectionLostNotifier.ts
+++ b/src/features/observe/DeviceConnectionLostNotifier.ts
@@ -1,0 +1,11 @@
+import { getDeviceDataStreamServer } from "../../daemon/deviceDataStreamSocketServer";
+
+export interface DeviceConnectionLostNotifier {
+  onDeviceConnectionLost(deviceId: string): void;
+}
+
+export const observationStreamDeviceConnectionLostNotifier: DeviceConnectionLostNotifier = {
+  onDeviceConnectionLost(deviceId: string): void {
+    getDeviceDataStreamServer()?.onDeviceConnectionLost(deviceId);
+  },
+};

--- a/src/features/observe/android/AndroidCtrlProxyClient.ts
+++ b/src/features/observe/android/AndroidCtrlProxyClient.ts
@@ -72,6 +72,10 @@ import {
   WebSocketFactory,
   defaultWebSocketFactory,
 } from "../DeviceServiceClient";
+import {
+  observationStreamDeviceConnectionLostNotifier,
+  type DeviceConnectionLostNotifier,
+} from "../DeviceConnectionLostNotifier";
 import type { SetTextOptions } from "../DeviceService";
 import type { CtrlProxyClient } from "../interfaces/CtrlProxyClient";
 import { RetryExecutor, defaultRetryExecutor } from "../../../utils/retry/RetryExecutor";
@@ -807,6 +811,7 @@ export class AndroidCtrlProxyClient extends DeviceServiceClient implements Andro
   private lastLayoutTelemetryTimestamp = 0;
 
   private readonly crashEventSink: CrashEventSink;
+  private readonly deviceConnectionLostNotifier: DeviceConnectionLostNotifier;
 
   // Logging tag for base class
   protected readonly logTag = "ACCESSIBILITY_SERVICE";
@@ -821,13 +826,16 @@ export class AndroidCtrlProxyClient extends DeviceServiceClient implements Andro
     timer?: Timer,
     installedAppsRepository?: InstalledAppsStore,
     retryExecutor?: RetryExecutor,
-    crashEventSink?: CrashEventSink
+    crashEventSink?: CrashEventSink,
+    deviceConnectionLostNotifier?: DeviceConnectionLostNotifier
   ) {
     super(timer ?? defaultTimer, webSocketFactory ?? defaultWebSocketFactory, {}, retryExecutor ?? defaultRetryExecutor);
     this.device = device;
     this.adb = adb;
     this.installedAppsRepository = installedAppsRepository ?? null;
     this.crashEventSink = crashEventSink ?? new FailureEventRepository();
+    this.deviceConnectionLostNotifier =
+      deviceConnectionLostNotifier ?? observationStreamDeviceConnectionLostNotifier;
     this.localPort = PortManager.allocate(device.deviceId);
     AndroidCtrlProxyManager.getInstance(device);
   }
@@ -894,9 +902,19 @@ export class AndroidCtrlProxyClient extends DeviceServiceClient implements Andro
     timer?: Timer,
     installedAppsRepository?: InstalledAppsStore,
     retryExecutor?: RetryExecutor,
-    crashEventSink?: CrashEventSink
+    crashEventSink?: CrashEventSink,
+    deviceConnectionLostNotifier?: DeviceConnectionLostNotifier
   ): AndroidCtrlProxyClient {
-    return new AndroidCtrlProxyClient(device, adb, webSocketFactory, timer, installedAppsRepository, retryExecutor, crashEventSink);
+    return new AndroidCtrlProxyClient(
+      device,
+      adb,
+      webSocketFactory,
+      timer,
+      installedAppsRepository,
+      retryExecutor,
+      crashEventSink,
+      deviceConnectionLostNotifier
+    );
   }
 
   // ===========================================================================
@@ -1105,7 +1123,7 @@ export class AndroidCtrlProxyClient extends DeviceServiceClient implements Andro
   protected onConnectionClosed(): void {
     this.cancelScreenshotBackoff();
     void this.markInstalledAppsStale("websocket_closed");
-    getDeviceDataStreamServer()?.onDeviceConnectionLost(this.device.deviceId);
+    this.deviceConnectionLostNotifier.onDeviceConnectionLost(this.device.deviceId);
 
     if (this.hierarchyNavigationDetector) {
       this.hierarchyNavigationDetector.dispose();

--- a/src/features/observe/ios/IOSCtrlProxyClient.ts
+++ b/src/features/observe/ios/IOSCtrlProxyClient.ts
@@ -44,6 +44,10 @@ import {
   WebSocketFactory,
   defaultWebSocketFactory,
 } from "../DeviceServiceClient";
+import {
+  observationStreamDeviceConnectionLostNotifier,
+  type DeviceConnectionLostNotifier,
+} from "../DeviceConnectionLostNotifier";
 import type { SetTextOptions } from "../DeviceService";
 import type { CtrlProxyClient } from "../interfaces/CtrlProxyClient";
 import { getDeviceDataStreamServer, PerformanceStreamData } from "../../../daemon/deviceDataStreamSocketServer";
@@ -328,6 +332,7 @@ export class IOSCtrlProxyClient extends DeviceServiceClient implements IOSCtrlPr
   // Auto-setup on connection failure
   private readonly serviceManagerFactory: ServiceManagerFactory;
   private readonly bootedDeviceLister: BootedDeviceLister;
+  private readonly deviceConnectionLostNotifier: DeviceConnectionLostNotifier;
   private isAttemptingAutoSetup: boolean = false;
 
   private constructor(
@@ -336,13 +341,15 @@ export class IOSCtrlProxyClient extends DeviceServiceClient implements IOSCtrlPr
     wsFactory: WebSocketFactory = defaultWebSocketFactory,
     timer: Timer = defaultTimer,
     serviceManagerFactory: ServiceManagerFactory = defaultServiceManagerFactory,
-    bootedDeviceLister: BootedDeviceLister = defaultBootedDeviceLister
+    bootedDeviceLister: BootedDeviceLister = defaultBootedDeviceLister,
+    deviceConnectionLostNotifier: DeviceConnectionLostNotifier = observationStreamDeviceConnectionLostNotifier
   ) {
     super(timer, wsFactory);
     this.device = device;
     this.port = port;
     this.serviceManagerFactory = serviceManagerFactory;
     this.bootedDeviceLister = bootedDeviceLister;
+    this.deviceConnectionLostNotifier = deviceConnectionLostNotifier;
   }
 
   /**
@@ -402,12 +409,21 @@ export class IOSCtrlProxyClient extends DeviceServiceClient implements IOSCtrlPr
     wsFactory: WebSocketFactory,
     timer: Timer,
     serviceManagerFactory: ServiceManagerFactory = noOpServiceManagerFactory,
-    bootedDeviceLister?: BootedDeviceLister
+    bootedDeviceLister?: BootedDeviceLister,
+    deviceConnectionLostNotifier?: DeviceConnectionLostNotifier
   ): IOSCtrlProxyClient {
     // Default test lister always reports the device as booted so existing tests
     // are unaffected. Tests that verify boot-check behavior supply their own lister.
     const lister = bootedDeviceLister ?? (async () => [device]);
-    return new IOSCtrlProxyClient(device, port, wsFactory, timer, serviceManagerFactory, lister);
+    return new IOSCtrlProxyClient(
+      device,
+      port,
+      wsFactory,
+      timer,
+      serviceManagerFactory,
+      lister,
+      deviceConnectionLostNotifier
+    );
   }
 
   /**
@@ -647,7 +663,7 @@ export class IOSCtrlProxyClient extends DeviceServiceClient implements IOSCtrlPr
     this.stopSdkEventPolling();
     this.cachedHierarchy = null;
     this.supportedCommands = null;
-    getDeviceDataStreamServer()?.onDeviceConnectionLost(this.device.deviceId);
+    this.deviceConnectionLostNotifier.onDeviceConnectionLost(this.device.deviceId);
 
     if (this.hierarchyNavigationDetector) {
       this.hierarchyNavigationDetector.dispose();

--- a/test/features/observe/CtrlProxyClient.test.ts
+++ b/test/features/observe/CtrlProxyClient.test.ts
@@ -13,6 +13,7 @@ import {
 } from "../../fakes/FakeWebSocket";
 import { FakeInstalledAppsRepository } from "../../fakes/FakeInstalledAppsRepository";
 import { FakeTimer } from "../../fakes/FakeTimer";
+import type { DeviceConnectionLostNotifier } from "../../../src/features/observe/DeviceConnectionLostNotifier";
 
 describe("AndroidCtrlProxyClient", function() {
   let accessibilityServiceClient: AndroidCtrlProxyClient;
@@ -131,6 +132,31 @@ describe("AndroidCtrlProxyClient", function() {
       await new Promise(resolve => setImmediate(resolve));
     }
   };
+
+  describe("connection lifecycle", function() {
+    test("notifies the observation stream when the WebSocket connection closes", function() {
+      const lostDeviceIds: string[] = [];
+      const notifier: DeviceConnectionLostNotifier = {
+        onDeviceConnectionLost: deviceId => {
+          lostDeviceIds.push(deviceId);
+        },
+      };
+      const testClient = AndroidCtrlProxyClient.createForTesting(
+        testDevice,
+        fakeAdb,
+        createSuccessWebSocketFactory(fakeTimer),
+        fakeTimer,
+        undefined,
+        undefined,
+        undefined,
+        notifier
+      );
+
+      (testClient as any).onConnectionClosed();
+
+      expect(lostDeviceIds).toEqual(["test-device"]);
+    });
+  });
 
   describe("getLatestHierarchy", function() {
     test("should return hierarchy data when WebSocket receives fresh data", async function() {

--- a/test/features/observe/ios/IOSCtrlProxyClient.test.ts
+++ b/test/features/observe/ios/IOSCtrlProxyClient.test.ts
@@ -9,6 +9,7 @@ import {
 } from "../../../fakes/FakeWebSocket";
 import { FakeTimer } from "../../../fakes/FakeTimer";
 import { FakeScreenshotBackoffScheduler } from "../../../../src/features/observe/ScreenshotBackoffScheduler";
+import type { DeviceConnectionLostNotifier } from "../../../../src/features/observe/DeviceConnectionLostNotifier";
 
 describe("IOSCtrlProxyClient", function() {
   let ctrlProxyClient: IOSCtrlProxyClient;
@@ -119,6 +120,28 @@ describe("IOSCtrlProxyClient", function() {
       (ctrlProxyClient as any).onConnectionClosed();
 
       expect(scheduler.cancelPendingCapturesCalls).toBe(1);
+    });
+
+    test("notifies the observation stream when the WebSocket connection closes", function() {
+      const lostDeviceIds: string[] = [];
+      const notifier: DeviceConnectionLostNotifier = {
+        onDeviceConnectionLost: deviceId => {
+          lostDeviceIds.push(deviceId);
+        },
+      };
+      const testClient = IOSCtrlProxyClient.createForTesting(
+        testDevice,
+        serverPort,
+        createSuccessWebSocketFactory(fakeTimer),
+        fakeTimer,
+        undefined,
+        undefined,
+        notifier
+      );
+
+      (testClient as any).onConnectionClosed();
+
+      expect(lostDeviceIds).toEqual(["A1B2C3D4-E5F6-7890-ABCD-EF1234567890"]);
     });
 
     test("restarts screenshot backoff when the connection (re)establishes", function() {


### PR DESCRIPTION
## Summary

- Add an injectable `DeviceConnectionLostNotifier` for CtrlProxy clients, with the default implementation still routing connection-loss events to the observation stream server.
- Wire Android and iOS `onConnectionClosed()` through that notifier so the device-scoped disconnect path is directly testable.
- Add fake-backed Android and iOS lifecycle tests covering the issue criteria that WebSocket close paths notify with the exact device id; existing stream-server tests continue to cover `type: "error"`, `success: false`, all-device subscribers, matching device subscribers, and unrelated device filtering.

## Validation

- `bun test test/features/observe/CtrlProxyClient.test.ts -t "notifies the observation stream"`
- `bun test test/features/observe/ios/IOSCtrlProxyClient.test.ts -t "notifies the observation stream"`
- `bun test test/daemon/deviceDataStreamSocketServer.test.ts`
- `bun run lint`
- `bun run build`

## Notes

- No `PULL_REQUEST_TEMPLATE` exists in this checkout or via the GitHub contents API, so this body uses the repository's usual Summary/Validation format.
- Broader check `bun test test/features/observe/CtrlProxyClient.test.ts` still has an unrelated pre-existing order-sensitive failure: `should preserve SDK screen names when hierarchy updates follow navigation events` expects `SdkHome` but receives `null` after 19 passing tests. The new targeted Android lifecycle test in that file passes.
