### PR TITLE
feat(ios): support mockNetwork rules

### DIFF
--- a/docs/design-docs/api-surface/cross-platform-parity.md
+++ b/docs/design-docs/api-surface/cross-platform-parity.md
@@ -117,9 +117,9 @@ Side-by-side comparison of every public API symbol on Android and iOS.
 | `setCaptureBodies` | -- | `setCaptureBodies(Bool)` | iOS-only config |
 | `setMaxBodyBytes` | -- | `setMaxBodyBytes(Int)` | iOS-only config |
 | `setEnabled` | -- | `setEnabled(Bool)` | iOS-only toggle |
-| `NetworkMockRuleStore` | Yes (with BroadcastReceiver) | -- | Android-only network mocking |
+| `NetworkMockRuleStore` | Yes (with BroadcastReceiver) | Yes (via CtrlProxy relay to SDK server) | iOS requires sessions to register `protocolClass()` |
 
-**Why these differ:** Network interception is inherently platform-specific. Android uses OkHttp interceptors; iOS uses URLProtocol. The mock rule store on Android uses broadcast intents which have no iOS equivalent.
+**Why these differ:** Network interception is inherently platform-specific. Android uses OkHttp interceptors; iOS uses URLProtocol. Mock-rule transport also differs: Android uses broadcast intents, while iOS relays through CtrlProxy to the SDK server.
 
 ## 10. ANR / Hang Detection
 
@@ -219,11 +219,12 @@ These APIs exist on only one platform due to inherent platform differences:
 - `CircuitAdapter`, `Navigation3Adapter` -- Android navigation framework adapters
 - `SdkConstants` (CTRL_PROXY_PACKAGE, PERMISSION_NETWORK_CONTROL) -- Android IPC
 - `ConfigurationOverrideHelper` -- Android Configuration override for testing
-- `NetworkMockRuleStore` -- Uses Android BroadcastReceiver for mock rule delivery
+- Network mock delivery -- Android uses BroadcastReceiver IPC
 - `AutoMobileNetworkInterceptor` / `AutoMobileWebSocketListener` -- OkHttp specific
 
 ### iOS-Only
 - `AutoMobileURLProtocol` -- URLSession interception
+- Network mock delivery -- iOS uses CtrlProxy relay to the SDK server
 - `BreadcrumbTrail.writeToDisk` / `loadFromDisk` / `clearDisk` -- Disk persistence for crash resilience
 - `AutoMobileCrashes.enableSignalHandlers` -- POSIX signal handler installation
 - `SwiftUINavigationAdapter` -- SwiftUI navigation tracking

--- a/docs/design-docs/plat/ios/auto-mobile-sdk.md
+++ b/docs/design-docs/plat/ios/auto-mobile-sdk.md
@@ -391,7 +391,7 @@ The SDK uses protocol + fake pattern throughout for testability:
 | Notifications | `AutoMobileNotifications` | `AutoMobileNotifications` | Platform notification APIs |
 | OS events | `AutoMobileOsEvents` | `AutoMobileOsEvents` | Lifecycle, battery, connectivity |
 | Broadcast / System events | `AutoMobileBroadcastInterceptor` | `AutoMobileNotificationObserver` | BroadcastReceiver vs NotificationCenter |
-| Network mock rules | `NetworkMockRuleStore` | -- | Android only |
+| Network mock rules | `NetworkMockRuleStore` | `NetworkMockRuleStore` | iOS requires sessions to register `AutoMobileNetwork.shared.protocolClass()` |
 
 ## See also
 

--- a/ios/auto-mobile-sdk/Sources/AutoMobileSDK/Network/AutoMobileNetwork.swift
+++ b/ios/auto-mobile-sdk/Sources/AutoMobileSDK/Network/AutoMobileNetwork.swift
@@ -436,6 +436,49 @@ public class AutoMobileURLProtocol: URLProtocol {
         receivedData = Data()
         totalBytesReceived = 0
 
+        if AutoMobileSDK.shared.isEnabled,
+           let url = request.url,
+           let match = NetworkMockRuleStore.shared.findMatchingRule(
+               host: url.host ?? "",
+               path: url.path,
+               method: request.httpMethod ?? "GET"
+           )
+        {
+            let body = Data(match.responseBody.utf8)
+            var headers = match.responseHeaders
+            headers["Content-Type"] = match.contentType
+            let response = HTTPURLResponse(
+                url: url,
+                statusCode: match.statusCode,
+                httpVersion: "HTTP/1.1",
+                headerFields: headers
+            )!
+            client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+            if !body.isEmpty {
+                client?.urlProtocol(self, didLoad: body)
+            }
+            client?.urlProtocolDidFinishLoading(self)
+            AutoMobileNetwork.shared.recordRequest(NetworkRequestRecord(
+                url: url.absoluteString,
+                method: request.httpMethod ?? "GET",
+                requestHeaders: request.allHTTPHeaderFields,
+                requestBodySize: request.httpBody?.count,
+                statusCode: match.statusCode,
+                responseHeaders: headers,
+                responseBodySize: body.count,
+                durationMs: startTime.map { Date().timeIntervalSince($0) * 1000 },
+                error: "mocked:\(match.mockId)",
+                requestBody: request.httpBody.flatMap { data in
+                    AutoMobileNetwork.isTextContentType(request.value(forHTTPHeaderField: "Content-Type"))
+                        ? AutoMobileNetwork.utf8String(from: data.prefix(AutoMobileNetwork.shared.maxBodyBytes))
+                        : nil
+                },
+                responseBody: match.responseBody,
+                contentType: match.contentType
+            ))
+            return
+        }
+
         guard let mutableRequest = (request as NSURLRequest).mutableCopy() as? NSMutableURLRequest else {
             client?.urlProtocol(self, didFailWithError: URLError(.badURL))
             return

--- a/ios/auto-mobile-sdk/Sources/AutoMobileSDK/Network/NetworkMockRuleStore.swift
+++ b/ios/auto-mobile-sdk/Sources/AutoMobileSDK/Network/NetworkMockRuleStore.swift
@@ -1,0 +1,103 @@
+import Foundation
+
+struct NetworkMockRuleDTO: Codable, Equatable {
+    let mockId: String
+    let host: String
+    let path: String
+    let method: String
+    let limit: Int?
+    let remaining: Int?
+    let statusCode: Int
+    let responseHeaders: [String: String]
+    let responseBody: String
+    let contentType: String
+}
+
+final class NetworkMockRuleStore: @unchecked Sendable {
+    static let shared = NetworkMockRuleStore()
+
+    struct MatchedRule: Equatable {
+        let mockId: String
+        let statusCode: Int
+        let responseHeaders: [String: String]
+        let responseBody: String
+        let contentType: String
+    }
+
+    private struct CompiledRule {
+        let mockId: String
+        let host: NSRegularExpression
+        let path: NSRegularExpression
+        let method: String
+        var remaining: Int?
+        let statusCode: Int
+        let responseHeaders: [String: String]
+        let responseBody: String
+        let contentType: String
+    }
+
+    private let lock = NSLock()
+    private var rules: [CompiledRule] = []
+
+    func setRules(_ dtos: [NetworkMockRuleDTO]) {
+        let compiled = dtos.compactMap { dto -> CompiledRule? in
+            do {
+                let host = try NSRegularExpression(pattern: dto.host)
+                let path = try NSRegularExpression(pattern: dto.path)
+                return CompiledRule(
+                    mockId: dto.mockId,
+                    host: host,
+                    path: path,
+                    method: dto.method,
+                    remaining: dto.remaining ?? dto.limit,
+                    statusCode: dto.statusCode,
+                    responseHeaders: dto.responseHeaders,
+                    responseBody: dto.responseBody,
+                    contentType: dto.contentType
+                )
+            } catch {
+                InternalLogger.debug("[NetworkMockRuleStore] Skipping invalid regex for \(dto.mockId): \(error)")
+                return nil
+            }
+        }
+
+        lock.lock()
+        rules = compiled
+        lock.unlock()
+    }
+
+    func findMatchingRule(host: String, path: String, method: String) -> MatchedRule? {
+        lock.lock()
+        defer { lock.unlock() }
+
+        for index in rules.indices {
+            let rule = rules[index]
+            if rule.method != "*", rule.method.caseInsensitiveCompare(method) != .orderedSame {
+                continue
+            }
+            guard Self.matches(rule.host, host), Self.matches(rule.path, path) else {
+                continue
+            }
+            if var remaining = rule.remaining {
+                remaining -= 1
+                rules[index].remaining = remaining
+                if remaining < 0 {
+                    continue
+                }
+            }
+            return MatchedRule(
+                mockId: rule.mockId,
+                statusCode: rule.statusCode,
+                responseHeaders: rule.responseHeaders,
+                responseBody: rule.responseBody,
+                contentType: rule.contentType
+            )
+        }
+        return nil
+    }
+
+    private static func matches(_ regex: NSRegularExpression, _ value: String) -> Bool {
+        let range = NSRange(value.startIndex ..< value.endIndex, in: value)
+        return regex.firstMatch(in: value, range: range) != nil
+    }
+}

--- a/ios/auto-mobile-sdk/Sources/AutoMobileSDK/ViewHierarchy/SdkHierarchyServer.swift
+++ b/ios/auto-mobile-sdk/Sources/AutoMobileSDK/ViewHierarchy/SdkHierarchyServer.swift
@@ -95,6 +95,8 @@ final class SdkHierarchyServer: @unchecked Sendable {
                 self.handleCachedHierarchy(connection)
             } else if request.contains("GET /health") {
                 self.handleHealth(connection)
+            } else if request.contains("POST /network/mock") {
+                self.handleNetworkMock(connection, data: data)
             } else {
                 self.sendResponse(connection, statusCode: 404, body: Data("{\"error\":\"not_found\"}".utf8))
             }
@@ -136,11 +138,28 @@ final class SdkHierarchyServer: @unchecked Sendable {
         sendResponse(connection, statusCode: 200, body: data)
     }
 
+    private func handleNetworkMock(_ connection: NWConnection, data: Data) {
+        guard let body = Self.httpBody(from: data),
+              let payload = try? JSONDecoder().decode(SetMockRulesBody.self, from: body) else {
+            sendResponse(connection, statusCode: 400, body: Data("{\"error\":\"bad_request\"}".utf8))
+            return
+        }
+        NetworkMockRuleStore.shared.setRules(payload.rules)
+        sendResponse(connection, statusCode: 200, body: Data("{\"status\":\"ok\"}".utf8))
+    }
+
+    private static func httpBody(from data: Data) -> Data? {
+        let delimiter = Data("\r\n\r\n".utf8)
+        guard let range = data.range(of: delimiter) else { return nil }
+        return data[range.upperBound...]
+    }
+
     private func sendResponse(_ connection: NWConnection, statusCode: Int, body: Data?) {
         let statusText: String
         switch statusCode {
         case 200: statusText = "OK"
         case 204: statusText = "No Content"
+        case 400: statusText = "Bad Request"
         case 404: statusText = "Not Found"
         case 500: statusText = "Internal Server Error"
         case 503: statusText = "Service Unavailable"
@@ -166,5 +185,9 @@ final class SdkHierarchyServer: @unchecked Sendable {
 private struct HealthPayload: Encodable {
     let status: String
     let bundleId: String?
+}
+
+private struct SetMockRulesBody: Decodable {
+    let rules: [NetworkMockRuleDTO]
 }
 #endif

--- a/ios/auto-mobile-sdk/Tests/AutoMobileSDKTests/NetworkTests.swift
+++ b/ios/auto-mobile-sdk/Tests/AutoMobileSDKTests/NetworkTests.swift
@@ -11,6 +11,7 @@ private final class EventCollector: @unchecked Sendable {
 final class AutoMobileNetworkTests: XCTestCase {
     override func tearDown() {
         AutoMobileNetwork.shared.reset()
+        NetworkMockRuleStore.shared.setRules([])
         super.tearDown()
     }
 
@@ -241,5 +242,151 @@ final class AutoMobileNetworkTests: XCTestCase {
 
         buffer.flush()
         XCTAssertEqual(collector.events.count, 0)
+    }
+
+    // MARK: - Network Mock Rules
+
+    func testNetworkMockRuleStoreMatchesWildcardMethodAndRegex() {
+        let store = NetworkMockRuleStore()
+        store.setRules([
+            NetworkMockRuleDTO(
+                mockId: "mock-1",
+                host: "api\\.example\\.com",
+                path: "^/v1/items",
+                method: "*",
+                limit: nil,
+                remaining: nil,
+                statusCode: 503,
+                responseHeaders: ["x-source": "test"],
+                responseBody: "{\"offline\":true}",
+                contentType: "application/json"
+            ),
+        ])
+
+        let match = store.findMatchingRule(host: "api.example.com", path: "/v1/items/42", method: "POST")
+
+        XCTAssertEqual(match?.mockId, "mock-1")
+        XCTAssertEqual(match?.statusCode, 503)
+        XCTAssertEqual(match?.responseHeaders["x-source"], "test")
+        XCTAssertEqual(match?.responseBody, "{\"offline\":true}")
+        XCTAssertEqual(match?.contentType, "application/json")
+    }
+
+    func testNetworkMockRuleStoreMatchesExplicitMethodCaseInsensitively() {
+        let store = NetworkMockRuleStore()
+        store.setRules([
+            NetworkMockRuleDTO(
+                mockId: "mock-1",
+                host: "api\\.example\\.com",
+                path: "/users",
+                method: "post",
+                limit: nil,
+                remaining: nil,
+                statusCode: 201,
+                responseHeaders: [:],
+                responseBody: "",
+                contentType: "application/json"
+            ),
+        ])
+
+        XCTAssertNotNil(store.findMatchingRule(host: "api.example.com", path: "/users", method: "POST"))
+        XCTAssertNil(store.findMatchingRule(host: "api.example.com", path: "/users", method: "GET"))
+    }
+
+    func testNetworkMockRuleStoreHonorsLimit() {
+        let store = NetworkMockRuleStore()
+        store.setRules([
+            NetworkMockRuleDTO(
+                mockId: "mock-1",
+                host: ".*",
+                path: ".*",
+                method: "*",
+                limit: 1,
+                remaining: 1,
+                statusCode: 204,
+                responseHeaders: [:],
+                responseBody: "",
+                contentType: "application/json"
+            ),
+        ])
+
+        XCTAssertNotNil(store.findMatchingRule(host: "api.example.com", path: "/one", method: "GET"))
+        XCTAssertNil(store.findMatchingRule(host: "api.example.com", path: "/one", method: "GET"))
+    }
+
+    func testNetworkMockRuleStoreSkipsInvalidRegexRules() {
+        let store = NetworkMockRuleStore()
+        store.setRules([
+            NetworkMockRuleDTO(
+                mockId: "bad",
+                host: "[",
+                path: ".*",
+                method: "*",
+                limit: nil,
+                remaining: nil,
+                statusCode: 500,
+                responseHeaders: [:],
+                responseBody: "bad",
+                contentType: "application/json"
+            ),
+            NetworkMockRuleDTO(
+                mockId: "good",
+                host: "api\\.example\\.com",
+                path: "/ok",
+                method: "GET",
+                limit: nil,
+                remaining: nil,
+                statusCode: 200,
+                responseHeaders: [:],
+                responseBody: "ok",
+                contentType: "text/plain"
+            ),
+        ])
+
+        let match = store.findMatchingRule(host: "api.example.com", path: "/ok", method: "GET")
+
+        XCTAssertEqual(match?.mockId, "good")
+        XCTAssertEqual(match?.responseBody, "ok")
+    }
+
+    func testURLProtocolServesMatchingMockResponseAndRecordsRequest() async throws {
+        let collector = EventCollector()
+        let buffer = SdkEventBuffer(maxBufferSize: 100, flushIntervalMs: 60000) { events in
+            collector.collect(events)
+        }
+        AutoMobileNetwork.shared.initialize(bundleId: "test", buffer: buffer)
+        AutoMobileNetwork.shared.setCaptureHeaders(true)
+        AutoMobileNetwork.shared.setCaptureBodies(true)
+        NetworkMockRuleStore.shared.setRules([
+            NetworkMockRuleDTO(
+                mockId: "mock-1",
+                host: "api\\.example\\.com",
+                path: "^/v1/items$",
+                method: "GET",
+                limit: nil,
+                remaining: nil,
+                statusCode: 500,
+                responseHeaders: ["x-mocked": "true"],
+                responseBody: "{\"error\":\"mocked\"}",
+                contentType: "application/json"
+            ),
+        ])
+        let config = URLSessionConfiguration.ephemeral
+        config.protocolClasses = [AutoMobileNetwork.shared.protocolClass()]
+        let session = URLSession(configuration: config)
+
+        let (data, response) = try await session.data(from: URL(string: "https://api.example.com/v1/items")!)
+
+        XCTAssertEqual((response as? HTTPURLResponse)?.statusCode, 500)
+        XCTAssertEqual(String(data: data, encoding: .utf8), "{\"error\":\"mocked\"}")
+        XCTAssertEqual((response as? HTTPURLResponse)?.value(forHTTPHeaderField: "x-mocked"), "true")
+        buffer.flush()
+        let event = collector.events.first as? SdkNetworkRequestEvent
+        XCTAssertEqual(event?.url, "https://api.example.com/v1/items")
+        XCTAssertEqual(event?.method, "GET")
+        XCTAssertEqual(event?.statusCode, 500)
+        XCTAssertEqual(event?.responseBody, "{\"error\":\"mocked\"}")
+        XCTAssertEqual(event?.contentType, "application/json")
+        XCTAssertEqual(event?.error, "mocked:mock-1")
     }
 }

--- a/ios/control-proxy/Sources/CtrlProxy/CommandHandler.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/CommandHandler.swift
@@ -164,6 +164,10 @@ public class CommandHandler: CommandHandling {
             case RequestType.clearPreferences.rawValue:
                 return try handleClearPreferences(request, startTime: startTime)
 
+            // Network mocking
+            case RequestType.setNetworkMockRules.rawValue:
+                return try handleSetNetworkMockRules(request, startTime: startTime)
+
             default:
                 return WebSocketResponse.error(
                     type: "error",
@@ -180,6 +184,25 @@ public class CommandHandler: CommandHandling {
                 totalTimeMs: totalTimeMs(from: startTime)
             )
         }
+    }
+
+    // MARK: - Network Mocking
+
+    private func handleSetNetworkMockRules(
+        _ request: WebSocketRequest,
+        startTime: Date
+    )
+        throws -> SetNetworkMockRulesResponse
+    {
+        guard let rules = request.rules else {
+            throw CommandError.missingParameter("rules")
+        }
+        let ok = sdkHierarchyClient?.setMockRules(rules) ?? false
+        return SetNetworkMockRulesResponse(
+            requestId: request.requestId,
+            ok: ok,
+            totalTimeMs: totalTimeMs(from: startTime)
+        )
     }
 
     // MARK: - View Hierarchy
@@ -1067,6 +1090,8 @@ public class CommandHandler: CommandHandling {
             return ResponseType.removePreferenceResult.rawValue
         case RequestType.clearPreferences.rawValue:
             return ResponseType.clearPreferencesResult.rawValue
+        case RequestType.setNetworkMockRules.rawValue:
+            return ResponseType.setNetworkMockRulesResult.rawValue
         default:
             return "error"
         }

--- a/ios/control-proxy/Sources/CtrlProxy/Fakes.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/Fakes.swift
@@ -693,6 +693,9 @@ public class FakeSdkHierarchyFetcher: SdkHierarchyFetching {
     private var _fetchFreshCallCount = 0
     private var _fetchServerInfoCallCount = 0
     private var _isAvailableCallCount = 0
+    private var _setMockRulesCallCount = 0
+    private var _lastMockRules: [NetworkMockRuleDTO]?
+    public var setMockRulesResult = true
 
     public init() {}
 
@@ -748,12 +751,26 @@ public class FakeSdkHierarchyFetcher: SdkHierarchyFetching {
         return _isAvailableCallCount
     }
 
+    public var setMockRulesCallCount: Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return _setMockRulesCallCount
+    }
+
+    public var lastMockRules: [NetworkMockRuleDTO]? {
+        lock.lock()
+        defer { lock.unlock() }
+        return _lastMockRules
+    }
+
     public func clearHistory() {
         lock.lock()
         _fetchCallCount = 0
         _fetchFreshCallCount = 0
         _fetchServerInfoCallCount = 0
         _isAvailableCallCount = 0
+        _setMockRulesCallCount = 0
+        _lastMockRules = nil
         lock.unlock()
     }
 
@@ -787,6 +804,15 @@ public class FakeSdkHierarchyFetcher: SdkHierarchyFetching {
         lock.lock()
         _isAvailableCallCount += 1
         let result = _serverInfo != nil || _isAvailable
+        lock.unlock()
+        return result
+    }
+
+    public func setMockRules(_ rules: [NetworkMockRuleDTO]) -> Bool {
+        lock.lock()
+        _setMockRulesCallCount += 1
+        _lastMockRules = rules
+        let result = setMockRulesResult
         lock.unlock()
         return result
     }

--- a/ios/control-proxy/Sources/CtrlProxy/Models.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/Models.swift
@@ -67,6 +67,9 @@ public struct WebSocketRequest: Codable {
     public let requestPermission: Bool?
     public let enabled: Bool?
 
+    // Network mocking
+    public let rules: [NetworkMockRuleDTO]?
+
     public init(
         type: String,
         requestId: String? = nil,
@@ -104,7 +107,8 @@ public struct WebSocketRequest: Codable {
         orientation: String? = nil,
         permission: String? = nil,
         requestPermission: Bool? = nil,
-        enabled: Bool? = nil
+        enabled: Bool? = nil,
+        networkMockRules: [NetworkMockRuleDTO]? = nil
     ) {
         self.type = type
         self.requestId = requestId
@@ -143,6 +147,44 @@ public struct WebSocketRequest: Codable {
         self.permission = permission
         self.requestPermission = requestPermission
         self.enabled = enabled
+        self.rules = networkMockRules
+    }
+}
+
+public struct NetworkMockRuleDTO: Codable, Sendable, Equatable {
+    public let mockId: String
+    public let host: String
+    public let path: String
+    public let method: String
+    public let limit: Int?
+    public let remaining: Int?
+    public let statusCode: Int
+    public let responseHeaders: [String: String]
+    public let responseBody: String
+    public let contentType: String
+
+    public init(
+        mockId: String,
+        host: String,
+        path: String,
+        method: String,
+        limit: Int?,
+        remaining: Int?,
+        statusCode: Int,
+        responseHeaders: [String: String],
+        responseBody: String,
+        contentType: String
+    ) {
+        self.mockId = mockId
+        self.host = host
+        self.path = path
+        self.method = method
+        self.limit = limit
+        self.remaining = remaining
+        self.statusCode = statusCode
+        self.responseHeaders = responseHeaders
+        self.responseBody = responseBody
+        self.contentType = contentType
     }
 }
 
@@ -211,6 +253,22 @@ public struct WebSocketResponse: Codable {
             totalTimeMs: totalTimeMs,
             error: error
         )
+    }
+}
+
+public struct SetNetworkMockRulesResponse: Codable {
+    public let type: String
+    public let timestamp: Int64
+    public let requestId: String?
+    public let ok: Bool
+    public let totalTimeMs: Int64?
+
+    public init(requestId: String?, ok: Bool, totalTimeMs: Int64?) {
+        type = ResponseType.setNetworkMockRulesResult.rawValue
+        timestamp = Int64(Date().timeIntervalSince1970 * 1000)
+        self.requestId = requestId
+        self.ok = ok
+        self.totalTimeMs = totalTimeMs
     }
 }
 
@@ -845,6 +903,9 @@ public enum RequestType: String, CaseIterable {
     case setPreference = "set_preference"
     case removePreference = "remove_preference"
     case clearPreferences = "clear_preferences"
+
+    // Network mocking
+    case setNetworkMockRules = "set_network_mock_rules"
 }
 
 // MARK: - Response Types (matching Android)
@@ -883,4 +944,5 @@ public enum ResponseType: String {
     case setPreferenceResult = "set_preference_result"
     case removePreferenceResult = "remove_preference_result"
     case clearPreferencesResult = "clear_preferences_result"
+    case setNetworkMockRulesResult = "set_network_mock_rules_result"
 }

--- a/ios/control-proxy/Sources/CtrlProxy/Protocols.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/Protocols.swift
@@ -226,6 +226,8 @@ public protocol SdkHierarchyFetching {
     func fetchServerInfo() -> SdkHierarchyServerInfo?
     /// Whether the SDK hierarchy server is reachable.
     func isAvailable() -> Bool
+    /// Replace network mock rules in the in-app SDK.
+    func setMockRules(_ rules: [NetworkMockRuleDTO]) -> Bool
 }
 
 /// Protocol for accessing the cached SDK hierarchy.

--- a/ios/control-proxy/Sources/CtrlProxy/SdkHierarchyClient.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/SdkHierarchyClient.swift
@@ -36,6 +36,14 @@ public final class SdkHierarchyClient: SdkHierarchyFetching, @unchecked Sendable
         return fetchServerInfo() != nil
     }
 
+    /// Replace network mock rules in the SDK's in-app server.
+    public func setMockRules(_ rules: [NetworkMockRuleDTO]) -> Bool {
+        guard let body = try? JSONEncoder().encode(SetMockRulesBody(rules: rules)) else {
+            return false
+        }
+        return postSync(path: "/network/mock", body: body, session: urlSession)
+    }
+
     // MARK: - Private
 
     private lazy var healthSession: URLSession = {
@@ -66,4 +74,28 @@ public final class SdkHierarchyClient: SdkHierarchyFetching, @unchecked Sendable
         semaphore.wait()
         return result
     }
+
+    private func postSync(path: String, body: Data, session: URLSession) -> Bool {
+        let url = baseURL.appendingPathComponent(path)
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.httpBody = body
+
+        let semaphore = DispatchSemaphore(value: 0)
+        var ok = false
+
+        session.dataTask(with: request) { _, response, _ in
+            defer { semaphore.signal() }
+            guard let http = response as? HTTPURLResponse else { return }
+            ok = http.statusCode == 200
+        }.resume()
+
+        semaphore.wait()
+        return ok
+    }
+}
+
+private struct SetMockRulesBody: Encodable {
+    let rules: [NetworkMockRuleDTO]
 }

--- a/ios/control-proxy/Tests/CtrlProxyTests/CommandHandlerTests.swift
+++ b/ios/control-proxy/Tests/CtrlProxyTests/CommandHandlerTests.swift
@@ -96,6 +96,64 @@ final class CommandHandlerTests: XCTestCase {
         return current + (element.node ?? []).reduce(0) { $0 + countClassName(className, in: $1) }
     }
 
+    // MARK: - Network Mock Relay
+
+    func testSetNetworkMockRulesRelaysRulesToSdkClient() {
+        let fetcher = FakeSdkHierarchyFetcher()
+        commandHandler = CommandHandler.createForTesting(
+            elementLocator: fakeElementLocator,
+            gesturePerformer: fakeGesturePerformer,
+            perfProvider: perfProvider,
+            sdkHierarchyClient: fetcher
+        )
+        let rules = [
+            NetworkMockRuleDTO(
+                mockId: "mock-1",
+                host: "api\\.example\\.com",
+                path: "^/v1/items",
+                method: "GET",
+                limit: 2,
+                remaining: 2,
+                statusCode: 500,
+                responseHeaders: ["x-test": "yes"],
+                responseBody: "{\"error\":\"mocked\"}",
+                contentType: "application/json"
+            ),
+        ]
+
+        let response = commandHandler.handle(WebSocketRequest(
+            type: RequestType.setNetworkMockRules.rawValue,
+            requestId: "mock-sync-1",
+            networkMockRules: rules
+        ))
+
+        guard let typed = response as? SetNetworkMockRulesResponse else {
+            XCTFail("Expected SetNetworkMockRulesResponse, got \(Swift.type(of: response))")
+            return
+        }
+        XCTAssertEqual(typed.type, ResponseType.setNetworkMockRulesResult.rawValue)
+        XCTAssertEqual(typed.requestId, "mock-sync-1")
+        XCTAssertTrue(typed.ok)
+        XCTAssertEqual(fetcher.setMockRulesCallCount, 1)
+        XCTAssertEqual(fetcher.lastMockRules?.first?.mockId, "mock-1")
+    }
+
+    func testSetNetworkMockRulesReturnsMissingParameterErrorWhenRulesAbsent() {
+        let response = commandHandler.handle(WebSocketRequest(
+            type: RequestType.setNetworkMockRules.rawValue,
+            requestId: "mock-sync-missing"
+        ))
+
+        guard let typed = response as? WebSocketResponse else {
+            XCTFail("Expected WebSocketResponse, got \(Swift.type(of: response))")
+            return
+        }
+        XCTAssertEqual(typed.type, ResponseType.setNetworkMockRulesResult.rawValue)
+        XCTAssertEqual(typed.requestId, "mock-sync-missing")
+        XCTAssertEqual(typed.success, false)
+        XCTAssertEqual(typed.error, "Missing required parameter: rules")
+    }
+
     // MARK: - Hierarchy Request Tests
 
     func testRequestHierarchyIncludesPerfTiming() {

--- a/src/features/observe/ios/IOSCtrlProxyClient.ts
+++ b/src/features/observe/ios/IOSCtrlProxyClient.ts
@@ -633,6 +633,8 @@ export class IOSCtrlProxyClient extends DeviceServiceClient implements IOSCtrlPr
     this.isRequestingServiceRestart = false;
     logger.info(`[IOSCtrlProxyClient] Connection established, reset failure counter`);
 
+    this.syncNetworkMockRulesToDevice();
+
     // Start polling for SDK events from the CtrlProxy HTTP endpoint
     this.startSdkEventPolling();
 
@@ -640,6 +642,35 @@ export class IOSCtrlProxyClient extends DeviceServiceClient implements IOSCtrlPr
     // cancels it; without restarting here, a transient drop on a STATIC screen
     // leaves the live view frozen forever. Subscriber-gated and idempotent.
     this.startScreenshotBackoff();
+  }
+
+  private syncNetworkMockRulesToDevice(): void {
+    if (!serverConfig.isNetworkMockableEnabled()) {
+      return;
+    }
+
+    try {
+      const { NetworkState } = require("../../../server/NetworkState");
+      const state = NetworkState.getInstance();
+
+      // Always sync mock rules on reconnect. Sending an empty list clears
+      // stale rules that may linger in the iOS SDK after a CtrlProxy restart.
+      const rules = Array.from(state.getMocks().values()).map((r: any) => ({
+        mockId: r.mockId,
+        host: r.host,
+        path: r.path,
+        method: r.method,
+        limit: r.limit,
+        remaining: r.limit,
+        statusCode: r.statusCode,
+        responseHeaders: r.responseHeaders,
+        responseBody: r.responseBody,
+        contentType: r.contentType,
+      }));
+      this.sendMessage(JSON.stringify({ type: "set_network_mock_rules", rules }));
+    } catch (e) {
+      logger.debug(`[IOSCtrlProxyClient] Failed to sync network mock rules on reconnect: ${e}`);
+    }
   }
 
   protected onConnectionClosed(): void {

--- a/src/server/networkTools.ts
+++ b/src/server/networkTools.ts
@@ -9,6 +9,7 @@ import { serverConfig } from "../utils/ServerConfig";
 import { ActionableError } from "../models";
 import { defaultTimer } from "../utils/SystemTimer";
 import { AndroidCtrlProxyClient } from "../features/observe/android";
+import { IOSCtrlProxyClient } from "../features/observe/ios";
 import type { BootedDevice } from "../utils/deviceUtils";
 import { logger } from "../utils/logger";
 
@@ -116,9 +117,11 @@ const getNetworkGraphSchema = addDeviceTargetingToSchema(
 type GetNetworkGraphArgs = z.infer<typeof getNetworkGraphSchema>;
 
 function syncMockRulesToDevice(device: BootedDevice, state: NetworkState): void {
-  if (device.platform !== "android") {return;}
+  if (device.platform !== "android" && device.platform !== "ios") {return;}
   try {
-    const client = AndroidCtrlProxyClient.getInstance(device);
+    const client = device.platform === "android"
+      ? AndroidCtrlProxyClient.getInstance(device)
+      : IOSCtrlProxyClient.getInstance(device);
     // Use limit (not remaining) since the server never tracks consumption —
     // the device-side NetworkMockRuleStore manages its own remaining count
     const rules = Array.from(state.getMocks().values()).map(r => ({
@@ -135,7 +138,7 @@ function syncMockRulesToDevice(device: BootedDevice, state: NetworkState): void 
     }));
     const msg = JSON.stringify({ type: "set_network_mock_rules", rules });
     const sent = client.sendMessage(msg);
-    logger.info(`[networkTools] syncMockRules: ${rules.length} rules, sent=${sent}`);
+    logger.info(`[networkTools] syncMockRules(${device.platform}): ${rules.length} rules, sent=${sent}`);
   } catch (e) {
     logger.info(`[networkTools] Failed to sync mock rules to device: ${e}`);
   }
@@ -211,7 +214,7 @@ export function registerNetworkTools(): void {
   // --- mockNetwork ---
   ToolRegistry.registerDeviceAware(
     "mockNetwork",
-    "Add a mock response rule for matching network requests. Requires --network-mockable flag.",
+    "Add a mock response rule for matching Android or iOS SDK-integrated network requests. Requires --network-mockable flag.",
     mockNetworkSchema,
     async (device, args: MockNetworkArgs) => {
       if (!serverConfig.isNetworkMockableEnabled()) {
@@ -219,9 +222,9 @@ export function registerNetworkTools(): void {
           "Network mocking is disabled. Start the server with --network-mockable to enable."
         );
       }
-      if (device.platform !== "android") {
+      if (device.platform !== "android" && device.platform !== "ios") {
         throw new ActionableError(
-          "Network mocking is only supported on Android devices."
+          "Network mocking is only supported on Android and iOS devices."
         );
       }
 
@@ -261,7 +264,7 @@ export function registerNetworkTools(): void {
   // --- clearMockNetwork ---
   ToolRegistry.registerDeviceAware(
     "clearMockNetwork",
-    "Clear mock network response rules. Optionally target a specific mock by ID. Requires --network-mockable flag.",
+    "Clear Android or iOS mock network response rules. Optionally target a specific mock by ID. Requires --network-mockable flag.",
     clearMockNetworkSchema,
     async (device, args: ClearMockNetworkArgs) => {
       if (!serverConfig.isNetworkMockableEnabled()) {
@@ -269,9 +272,9 @@ export function registerNetworkTools(): void {
           "Network mocking is disabled. Start the server with --network-mockable to enable."
         );
       }
-      if (device.platform !== "android") {
+      if (device.platform !== "android" && device.platform !== "ios") {
         throw new ActionableError(
-          "Network mocking is only supported on Android devices."
+          "Network mocking is only supported on Android and iOS devices."
         );
       }
 

--- a/test/features/observe/ios/IOSCtrlProxyClient.test.ts
+++ b/test/features/observe/ios/IOSCtrlProxyClient.test.ts
@@ -1,6 +1,8 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { IOSCtrlProxyClient, CtrlProxyHierarchy } from "../../../../src/features/observe/ios";
 import { BootedDevice } from "../../../../src/models";
+import { NetworkState } from "../../../../src/server/NetworkState";
+import { serverConfig } from "../../../../src/utils/ServerConfig";
 import {
   FakeWebSocket,
   createInstantFailureWebSocketFactory,
@@ -30,6 +32,8 @@ describe("IOSCtrlProxyClient", function() {
 
     // Reset singleton instances for clean test state
     IOSCtrlProxyClient.resetInstances();
+    NetworkState.resetInstance();
+    serverConfig.setNetworkMockableEnabled(false);
 
     ctrlProxyClient = IOSCtrlProxyClient.createForTesting(
       testDevice,
@@ -44,6 +48,8 @@ describe("IOSCtrlProxyClient", function() {
     if (ctrlProxyClient) {
       await ctrlProxyClient.close();
     }
+    NetworkState.resetInstance();
+    serverConfig.setNetworkMockableEnabled(false);
   });
 
   class CapturingWebSocket extends FakeWebSocket {
@@ -133,6 +139,49 @@ describe("IOSCtrlProxyClient", function() {
       (ctrlProxyClient as any).onConnectionEstablished();
 
       expect(backoffStarts).toBe(1);
+    });
+
+    test("syncs network mock rules when the connection (re)establishes", function() {
+      serverConfig.setNetworkMockableEnabled(true);
+      const state = NetworkState.getInstance();
+      const mock = state.addMock({
+        host: "api\\.example\\.com",
+        path: "/v1/items",
+        method: "GET",
+        limit: 3,
+        remaining: 3,
+        statusCode: 201,
+        responseHeaders: { "X-Test": "yes" },
+        responseBody: "{\"ok\":true}",
+        contentType: "application/json",
+      });
+      const sentMessages: string[] = [];
+
+      (ctrlProxyClient as any).sendMessage = (message: string) => {
+        sentMessages.push(message);
+        return true;
+      };
+      (ctrlProxyClient as any).startSdkEventPolling = () => { /* no-op */ };
+      (ctrlProxyClient as any).startScreenshotBackoff = () => { /* no-op */ };
+
+      (ctrlProxyClient as any).onConnectionEstablished();
+
+      expect(sentMessages).toHaveLength(1);
+      expect(JSON.parse(sentMessages[0])).toEqual({
+        type: "set_network_mock_rules",
+        rules: [{
+          mockId: mock.mockId,
+          host: "api\\.example\\.com",
+          path: "/v1/items",
+          method: "GET",
+          limit: 3,
+          remaining: 3,
+          statusCode: 201,
+          responseHeaders: { "X-Test": "yes" },
+          responseBody: "{\"ok\":true}",
+          contentType: "application/json",
+        }],
+      });
     });
   });
 

--- a/test/server/networkTools.test.ts
+++ b/test/server/networkTools.test.ts
@@ -1,15 +1,61 @@
-import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, spyOn, test } from "bun:test";
+import { AndroidCtrlProxyClient } from "../../src/features/observe/android";
+import { IOSCtrlProxyClient } from "../../src/features/observe/ios";
+import type { BootedDevice } from "../../src/models";
+import { NetworkState } from "../../src/server/NetworkState";
 import { registerNetworkTools } from "../../src/server/networkTools";
 import { ToolRegistry } from "../../src/server/toolRegistry";
+import { serverConfig } from "../../src/utils/ServerConfig";
+
+function parseToolJson(response: any): any {
+  return JSON.parse(response.content[0].text);
+}
 
 describe("network tool schema", () => {
+  let iosMessages: string[];
+  let androidMessages: string[];
+  let iosGetInstanceSpy: ReturnType<typeof spyOn>;
+  let androidGetInstanceSpy: ReturnType<typeof spyOn>;
+
+  const iosDevice: BootedDevice = {
+    deviceId: "ios-sim-1",
+    name: "iPhone 15",
+    platform: "ios",
+  };
+
+  const androidDevice: BootedDevice = {
+    deviceId: "emulator-5554",
+    name: "Pixel",
+    platform: "android",
+  };
+
   beforeEach(() => {
     ToolRegistry.clearTools();
+    NetworkState.resetInstance();
+    serverConfig.setNetworkMockableEnabled(true);
+    iosMessages = [];
+    androidMessages = [];
+    iosGetInstanceSpy = spyOn(IOSCtrlProxyClient, "getInstance").mockReturnValue({
+      sendMessage: (message: string) => {
+        iosMessages.push(message);
+        return true;
+      },
+    } as IOSCtrlProxyClient);
+    androidGetInstanceSpy = spyOn(AndroidCtrlProxyClient, "getInstance").mockReturnValue({
+      sendMessage: (message: string) => {
+        androidMessages.push(message);
+        return true;
+      },
+    } as AndroidCtrlProxyClient);
     registerNetworkTools();
   });
 
   afterEach(() => {
     ToolRegistry.clearTools();
+    NetworkState.resetInstance();
+    serverConfig.setNetworkMockableEnabled(false);
+    iosGetInstanceSpy.mockRestore();
+    androidGetInstanceSpy.mockRestore();
   });
 
   test("requires durationSeconds when starting error simulation", () => {
@@ -36,5 +82,99 @@ describe("network tool schema", () => {
     });
 
     expect(result.success).toBe(true);
+  });
+
+  test("mockNetwork creates an iOS rule and syncs through IOSCtrlProxyClient", async () => {
+    const tool = ToolRegistry.getTool("mockNetwork");
+
+    const response = await tool!.deviceAwareHandler!(iosDevice, {
+      host: "api\\.example\\.com",
+      path: "^/v1/items",
+      method: "GET",
+      limit: 2,
+      statusCode: 500,
+      responseHeaders: { "x-test": "yes" },
+      responseBody: "{\"error\":\"mocked\"}",
+      contentType: "application/json",
+    });
+
+    expect(parseToolJson(response)).toEqual({
+      mockId: "mock-1",
+      mocked: {
+        "GET api\\.example\\.com^/v1/items": 2,
+      },
+    });
+    expect(iosGetInstanceSpy).toHaveBeenCalledWith(iosDevice);
+    expect(androidGetInstanceSpy).not.toHaveBeenCalled();
+    expect(iosMessages).toHaveLength(1);
+    expect(JSON.parse(iosMessages[0])).toEqual({
+      type: "set_network_mock_rules",
+      rules: [{
+        mockId: "mock-1",
+        host: "api\\.example\\.com",
+        path: "^/v1/items",
+        method: "GET",
+        limit: 2,
+        remaining: 2,
+        statusCode: 500,
+        responseHeaders: { "x-test": "yes" },
+        responseBody: "{\"error\":\"mocked\"}",
+        contentType: "application/json",
+      }],
+    });
+  });
+
+  test("mockNetwork keeps the network-mockable gate for iOS", async () => {
+    serverConfig.setNetworkMockableEnabled(false);
+    const tool = ToolRegistry.getTool("mockNetwork");
+
+    await expect(tool!.deviceAwareHandler!(iosDevice, {
+      host: ".*",
+      path: ".*",
+    })).rejects.toThrow("Network mocking is disabled. Start the server with --network-mockable to enable.");
+    expect(iosMessages).toHaveLength(0);
+  });
+
+  test("mockNetwork still syncs Android rules through AndroidCtrlProxyClient", async () => {
+    const tool = ToolRegistry.getTool("mockNetwork");
+
+    await tool!.deviceAwareHandler!(androidDevice, {
+      host: "api\\.example\\.com",
+      path: "/ok",
+    });
+
+    expect(androidGetInstanceSpy).toHaveBeenCalledWith(androidDevice);
+    expect(iosGetInstanceSpy).not.toHaveBeenCalled();
+    expect(androidMessages).toHaveLength(1);
+    expect(JSON.parse(androidMessages[0]).type).toBe("set_network_mock_rules");
+  });
+
+  test("clearMockNetwork supports iOS and re-syncs remaining rules", async () => {
+    const mockTool = ToolRegistry.getTool("mockNetwork");
+    const clearTool = ToolRegistry.getTool("clearMockNetwork");
+
+    await mockTool!.deviceAwareHandler!(iosDevice, {
+      host: "api\\.example\\.com",
+      path: "/one",
+    });
+    await mockTool!.deviceAwareHandler!(iosDevice, {
+      host: "api\\.example\\.com",
+      path: "/two",
+      method: "POST",
+    });
+    iosMessages = [];
+
+    const response = await clearTool!.deviceAwareHandler!(iosDevice, {
+      mockId: "mock-1",
+    });
+
+    expect(parseToolJson(response)).toEqual({
+      cleared: 1,
+      remaining: {
+        "POST api\\.example\\.com/two": -1,
+      },
+    });
+    expect(iosMessages).toHaveLength(1);
+    expect(JSON.parse(iosMessages[0]).rules.map((rule: { mockId: string }) => rule.mockId)).toEqual(["mock-2"]);
   });
 });


### PR DESCRIPTION
## Summary

- Closes #2500.
- Enables `mockNetwork` and `clearMockNetwork` for iOS by syncing rules over the existing host -> iOS CtrlProxy WebSocket path.
- Adds an iOS CtrlProxy relay for `set_network_mock_rules` to the in-app SDK server at `POST /network/mock`.
- Adds iOS SDK rule storage and `URLProtocol` mock enforcement with limit handling, wildcard/case-insensitive methods, invalid-regex skipping, and captured mocked request records.
- Updates iOS/parity docs to describe the SDK `protocolClass()` registration requirement.

## Evaluation Criteria Covered

- iOS `mockNetwork` creates state and sends `set_network_mock_rules` through a faked `IOSCtrlProxyClient`.
- iOS `clearMockNetwork` re-syncs remaining rules.
- Android routing remains on `AndroidCtrlProxyClient`.
- Reconnect sync restores mock rules to iOS when `--network-mockable` is enabled.
- CtrlProxy relays rules to the SDK client and reports missing `rules` as a command error.
- SDK matching covers wildcard method, explicit case-insensitive method, invalid regex skip, limit exhaustion, and mocked `URLSession` response recording.

## Testing

- `bun run lint`
- `bun run build`
- `bun test test/features/observe/ios/IOSCtrlProxyClient.test.ts test/server/networkTools.test.ts`
- `bun test --bail`
- `swift test --package-path ios/auto-mobile-sdk --filter AutoMobileNetworkTests`
- `swift test --package-path ios/control-proxy --filter CommandHandlerTests`
- `swift build --package-path ios/auto-mobile-sdk`
- `swift build --package-path ios/control-proxy`
- `bash scripts/ios/swift-build.sh`
- `bash scripts/ios/swift-test.sh`

## Notes

- No `.github/pull_request_template.md` exists in this repo, so this uses the repo's standard Summary/Testing format.
- `bun install` was attempted but failed while compiling the optional/native `heapdump` dependency under the local Node runtime; the existing dependency install was sufficient for all validation commands above.
- Full Swift format/lint wrapper scripts still report pre-existing repo-wide issues, but the new `NetworkMockRuleStore.swift` passes direct SwiftFormat lint and all Swift build/test validation is green.
