### PR TITLE
feat(ios): support sqlQuery database inspection

### DIFF
--- a/docs/design-docs/api-surface/cross-platform-parity.md
+++ b/docs/design-docs/api-surface/cross-platform-parity.md
@@ -176,6 +176,7 @@ Side-by-side comparison of every public API symbol on Android and iOS.
 | `getDriver` | `getDriver()` (internal) | `getDriver()` | Aligned |
 | `closeAll` | `closeAll()` | -- | Android-only |
 | Driver interface | `DatabaseDriver` | `DatabaseDriver` | Aligned methods |
+| Host access | ContentProvider bridge | DEBUG in-app SDK HTTP server relayed by CtrlProxy | `sqlQuery` and database resources share the same JSON shape |
 
 ## 16. Compose / SwiftUI View Tracking
 

--- a/docs/design-docs/plat/ios/auto-mobile-sdk.md
+++ b/docs/design-docs/plat/ios/auto-mobile-sdk.md
@@ -298,6 +298,7 @@ SQLite database inspection using the `sqlite3` C API directly:
 - Table listing, paginated data retrieval, schema inspection via `PRAGMA table_info`
 - Raw SQL execution with read/write detection (SELECT/EXPLAIN/PRAGMA = read-only, opens with `SQLITE_OPEN_READONLY`)
 - Connection caching, 5-second busy timeout, identifier sanitization
+- MCP `sqlQuery` and database resources are available on iOS through the DEBUG-only in-app SDK HTTP server on port 8766, relayed by CtrlProxy on port 8765. Apps must call `DatabaseInspector.shared.setEnabled(true)`.
 
 ## Other Subsystems
 

--- a/ios/auto-mobile-sdk/Sources/AutoMobileSDK/Storage/SdkDatabaseRouteHandler.swift
+++ b/ios/auto-mobile-sdk/Sources/AutoMobileSDK/Storage/SdkDatabaseRouteHandler.swift
@@ -1,166 +1,182 @@
 #if DEBUG && !os(watchOS)
-import Foundation
+    import Foundation
 
-struct SdkRouteResponse {
-    let statusCode: Int
-    let body: Data
-}
-
-struct SdkExecuteSqlRequest: Codable {
-    let databasePath: String
-    let query: String
-}
-
-struct SdkDatabasePathRequest: Codable {
-    let databasePath: String
-}
-
-struct SdkTableDataRequest: Codable {
-    let databasePath: String
-    let table: String
-    let limit: Int
-    let offset: Int
-}
-
-struct SdkTableStructureRequest: Codable {
-    let databasePath: String
-    let table: String
-}
-
-struct SdkExecuteSqlPayload: Codable {
-    let queryType: String
-    let columns: [String]?
-    let rows: [[String?]]?
-    let rowsAffected: Int
-    let error: String?
-}
-
-struct SdkDatabaseListPayload: Codable {
-    let databases: [SdkDatabaseDescriptorPayload]
-}
-
-struct SdkDatabaseDescriptorPayload: Codable {
-    let name: String
-    let path: String
-    let sizeBytes: Int64
-}
-
-struct SdkTablesPayload: Codable {
-    let tables: [String]
-}
-
-struct SdkTableDataPayload: Codable {
-    let columns: [String]
-    let rows: [[String?]]
-    let total: Int
-}
-
-struct SdkTableStructurePayload: Codable {
-    let columns: [SdkColumnInfoPayload]
-}
-
-struct SdkColumnInfoPayload: Codable {
-    let name: String
-    let type: String
-    let nullable: Bool
-    let primaryKey: Bool
-    let defaultValue: String?
-}
-
-struct SdkDatabaseErrorPayload: Codable {
-    let error: String
-}
-
-final class SdkDatabaseRouteHandler {
-    func handleListDatabases() -> SdkRouteResponse {
-        guard let driver = DatabaseInspector.shared.getDriver() else {
-            return error(statusCode: 503, code: "db_inspection_disabled")
-        }
-
-        let databases = driver.getDatabases().map {
-            SdkDatabaseDescriptorPayload(name: $0.name, path: $0.path, sizeBytes: $0.sizeBytes)
-        }
-        return encode(SdkDatabaseListPayload(databases: databases))
+    struct SdkRouteResponse {
+        let statusCode: Int
+        let body: Data
     }
 
-    func handleListTables(body: Data) -> SdkRouteResponse {
-        guard let driver = DatabaseInspector.shared.getDriver() else {
-            return error(statusCode: 503, code: "db_inspection_disabled")
-        }
-        guard let request = try? JSONDecoder().decode(SdkDatabasePathRequest.self, from: body) else {
-            return error(statusCode: 400, code: "bad_request")
-        }
-
-        return encode(SdkTablesPayload(tables: driver.getTables(databasePath: request.databasePath)))
+    struct SdkExecuteSqlRequest: Codable {
+        let databasePath: String
+        let query: String
     }
 
-    func handleTableData(body: Data) -> SdkRouteResponse {
-        guard let driver = DatabaseInspector.shared.getDriver() else {
-            return error(statusCode: 503, code: "db_inspection_disabled")
-        }
-        guard let request = try? JSONDecoder().decode(SdkTableDataRequest.self, from: body) else {
-            return error(statusCode: 400, code: "bad_request")
-        }
-
-        let result = driver.getTableData(
-            databasePath: request.databasePath,
-            table: request.table,
-            limit: request.limit,
-            offset: request.offset
-        )
-        return encode(SdkTableDataPayload(columns: result.columns, rows: result.rows, total: result.totalRows))
+    struct SdkDatabasePathRequest: Codable {
+        let databasePath: String
     }
 
-    func handleTableStructure(body: Data) -> SdkRouteResponse {
-        guard let driver = DatabaseInspector.shared.getDriver() else {
-            return error(statusCode: 503, code: "db_inspection_disabled")
-        }
-        guard let request = try? JSONDecoder().decode(SdkTableStructureRequest.self, from: body) else {
-            return error(statusCode: 400, code: "bad_request")
+    struct SdkTableDataRequest: Codable {
+        let databasePath: String
+        let table: String
+        let limit: Int
+        let offset: Int
+    }
+
+    struct SdkTableStructureRequest: Codable {
+        let databasePath: String
+        let table: String
+    }
+
+    struct SdkExecuteSqlPayload: Codable {
+        let queryType: String
+        let columns: [String]?
+        let rows: [[String?]]?
+        let rowsAffected: Int
+        let error: String?
+    }
+
+    struct SdkDatabaseListPayload: Codable {
+        let databases: [SdkDatabaseDescriptorPayload]
+    }
+
+    struct SdkDatabaseDescriptorPayload: Codable {
+        let name: String
+        let path: String
+        let sizeBytes: Int64
+    }
+
+    struct SdkTablesPayload: Codable {
+        let tables: [String]
+    }
+
+    struct SdkTableDataPayload: Codable {
+        let columns: [String]
+        let rows: [[String?]]
+        let total: Int
+    }
+
+    struct SdkTableStructurePayload: Codable {
+        let columns: [SdkColumnInfoPayload]
+    }
+
+    struct SdkColumnInfoPayload: Codable {
+        let name: String
+        let type: String
+        let nullable: Bool
+        let primaryKey: Bool
+        let defaultValue: String?
+    }
+
+    struct SdkDatabaseErrorPayload: Codable {
+        let error: String
+    }
+
+    final class SdkDatabaseRouteHandler {
+        func handleListDatabases() -> SdkRouteResponse {
+            guard let driver = DatabaseInspector.shared.getDriver() else {
+                return error(statusCode: 503, code: "db_inspection_disabled")
+            }
+
+            let databases = driver.getDatabases().map {
+                SdkDatabaseDescriptorPayload(name: $0.name, path: $0.path, sizeBytes: $0.sizeBytes)
+            }
+            return encode(SdkDatabaseListPayload(databases: databases))
         }
 
-        let result = driver.getTableStructure(databasePath: request.databasePath, table: request.table)
-        return encode(SdkTableStructurePayload(columns: result.columns.map {
-            SdkColumnInfoPayload(
-                name: $0.name,
-                type: $0.type,
-                nullable: $0.isNullable,
-                primaryKey: $0.isPrimaryKey,
-                defaultValue: $0.defaultValue
+        func handleListTables(body: Data) -> SdkRouteResponse {
+            guard let driver = DatabaseInspector.shared.getDriver() else {
+                return error(statusCode: 503, code: "db_inspection_disabled")
+            }
+            guard let request = try? JSONDecoder().decode(SdkDatabasePathRequest.self, from: body) else {
+                return error(statusCode: 400, code: "bad_request")
+            }
+            guard isKnownDatabasePath(request.databasePath, driver: driver) else {
+                return error(statusCode: 404, code: "unknown_database_path")
+            }
+
+            return encode(SdkTablesPayload(tables: driver.getTables(databasePath: request.databasePath)))
+        }
+
+        func handleTableData(body: Data) -> SdkRouteResponse {
+            guard let driver = DatabaseInspector.shared.getDriver() else {
+                return error(statusCode: 503, code: "db_inspection_disabled")
+            }
+            guard let request = try? JSONDecoder().decode(SdkTableDataRequest.self, from: body) else {
+                return error(statusCode: 400, code: "bad_request")
+            }
+            guard isKnownDatabasePath(request.databasePath, driver: driver) else {
+                return error(statusCode: 404, code: "unknown_database_path")
+            }
+
+            let result = driver.getTableData(
+                databasePath: request.databasePath,
+                table: request.table,
+                limit: request.limit,
+                offset: request.offset
             )
-        }))
-    }
-
-    func handleExecuteSql(body: Data) -> SdkRouteResponse {
-        guard let driver = DatabaseInspector.shared.getDriver() else {
-            return error(statusCode: 503, code: "db_inspection_disabled")
-        }
-        guard let request = try? JSONDecoder().decode(SdkExecuteSqlRequest.self, from: body) else {
-            return error(statusCode: 400, code: "bad_request")
+            return encode(SdkTableDataPayload(columns: result.columns, rows: result.rows, total: result.totalRows))
         }
 
-        let result = driver.executeSQL(databasePath: request.databasePath, query: request.query)
-        let payload = SdkExecuteSqlPayload(
-            queryType: result.columns == nil ? "mutation" : "query",
-            columns: result.columns,
-            rows: result.rows,
-            rowsAffected: result.rowsAffected,
-            error: result.error
-        )
-        return encode(payload)
-    }
+        func handleTableStructure(body: Data) -> SdkRouteResponse {
+            guard let driver = DatabaseInspector.shared.getDriver() else {
+                return error(statusCode: 503, code: "db_inspection_disabled")
+            }
+            guard let request = try? JSONDecoder().decode(SdkTableStructureRequest.self, from: body) else {
+                return error(statusCode: 400, code: "bad_request")
+            }
+            guard isKnownDatabasePath(request.databasePath, driver: driver) else {
+                return error(statusCode: 404, code: "unknown_database_path")
+            }
 
-    private func encode<T: Encodable>(_ payload: T) -> SdkRouteResponse {
-        guard let data = try? JSONEncoder().encode(payload) else {
-            return error(statusCode: 500, code: "encode_failed")
+            let result = driver.getTableStructure(databasePath: request.databasePath, table: request.table)
+            return encode(SdkTableStructurePayload(columns: result.columns.map {
+                SdkColumnInfoPayload(
+                    name: $0.name,
+                    type: $0.type,
+                    nullable: $0.isNullable,
+                    primaryKey: $0.isPrimaryKey,
+                    defaultValue: $0.defaultValue
+                )
+            }))
         }
-        return SdkRouteResponse(statusCode: 200, body: data)
-    }
 
-    private func error(statusCode: Int, code: String) -> SdkRouteResponse {
-        let payload = SdkDatabaseErrorPayload(error: code)
-        let body = (try? JSONEncoder().encode(payload)) ?? Data("{\"error\":\"\(code)\"}".utf8)
-        return SdkRouteResponse(statusCode: statusCode, body: body)
+        func handleExecuteSql(body: Data) -> SdkRouteResponse {
+            guard let driver = DatabaseInspector.shared.getDriver() else {
+                return error(statusCode: 503, code: "db_inspection_disabled")
+            }
+            guard let request = try? JSONDecoder().decode(SdkExecuteSqlRequest.self, from: body) else {
+                return error(statusCode: 400, code: "bad_request")
+            }
+            guard isKnownDatabasePath(request.databasePath, driver: driver) else {
+                return error(statusCode: 404, code: "unknown_database_path")
+            }
+
+            let result = driver.executeSQL(databasePath: request.databasePath, query: request.query)
+            let payload = SdkExecuteSqlPayload(
+                queryType: result.columns == nil ? "mutation" : "query",
+                columns: result.columns,
+                rows: result.rows,
+                rowsAffected: result.rowsAffected,
+                error: result.error
+            )
+            return encode(payload)
+        }
+
+        private func isKnownDatabasePath(_ databasePath: String, driver: DatabaseDriver) -> Bool {
+            driver.getDatabases().contains { $0.path == databasePath }
+        }
+
+        private func encode<T: Encodable>(_ payload: T) -> SdkRouteResponse {
+            guard let data = try? JSONEncoder().encode(payload) else {
+                return error(statusCode: 500, code: "encode_failed")
+            }
+            return SdkRouteResponse(statusCode: 200, body: data)
+        }
+
+        private func error(statusCode: Int, code: String) -> SdkRouteResponse {
+            let payload = SdkDatabaseErrorPayload(error: code)
+            let body = (try? JSONEncoder().encode(payload)) ?? Data("{\"error\":\"\(code)\"}".utf8)
+            return SdkRouteResponse(statusCode: statusCode, body: body)
+        }
     }
-}
 #endif

--- a/ios/auto-mobile-sdk/Sources/AutoMobileSDK/Storage/SdkDatabaseRouteHandler.swift
+++ b/ios/auto-mobile-sdk/Sources/AutoMobileSDK/Storage/SdkDatabaseRouteHandler.swift
@@ -1,0 +1,166 @@
+#if DEBUG && !os(watchOS)
+import Foundation
+
+struct SdkRouteResponse {
+    let statusCode: Int
+    let body: Data
+}
+
+struct SdkExecuteSqlRequest: Codable {
+    let databasePath: String
+    let query: String
+}
+
+struct SdkDatabasePathRequest: Codable {
+    let databasePath: String
+}
+
+struct SdkTableDataRequest: Codable {
+    let databasePath: String
+    let table: String
+    let limit: Int
+    let offset: Int
+}
+
+struct SdkTableStructureRequest: Codable {
+    let databasePath: String
+    let table: String
+}
+
+struct SdkExecuteSqlPayload: Codable {
+    let queryType: String
+    let columns: [String]?
+    let rows: [[String?]]?
+    let rowsAffected: Int
+    let error: String?
+}
+
+struct SdkDatabaseListPayload: Codable {
+    let databases: [SdkDatabaseDescriptorPayload]
+}
+
+struct SdkDatabaseDescriptorPayload: Codable {
+    let name: String
+    let path: String
+    let sizeBytes: Int64
+}
+
+struct SdkTablesPayload: Codable {
+    let tables: [String]
+}
+
+struct SdkTableDataPayload: Codable {
+    let columns: [String]
+    let rows: [[String?]]
+    let total: Int
+}
+
+struct SdkTableStructurePayload: Codable {
+    let columns: [SdkColumnInfoPayload]
+}
+
+struct SdkColumnInfoPayload: Codable {
+    let name: String
+    let type: String
+    let nullable: Bool
+    let primaryKey: Bool
+    let defaultValue: String?
+}
+
+struct SdkDatabaseErrorPayload: Codable {
+    let error: String
+}
+
+final class SdkDatabaseRouteHandler {
+    func handleListDatabases() -> SdkRouteResponse {
+        guard let driver = DatabaseInspector.shared.getDriver() else {
+            return error(statusCode: 503, code: "db_inspection_disabled")
+        }
+
+        let databases = driver.getDatabases().map {
+            SdkDatabaseDescriptorPayload(name: $0.name, path: $0.path, sizeBytes: $0.sizeBytes)
+        }
+        return encode(SdkDatabaseListPayload(databases: databases))
+    }
+
+    func handleListTables(body: Data) -> SdkRouteResponse {
+        guard let driver = DatabaseInspector.shared.getDriver() else {
+            return error(statusCode: 503, code: "db_inspection_disabled")
+        }
+        guard let request = try? JSONDecoder().decode(SdkDatabasePathRequest.self, from: body) else {
+            return error(statusCode: 400, code: "bad_request")
+        }
+
+        return encode(SdkTablesPayload(tables: driver.getTables(databasePath: request.databasePath)))
+    }
+
+    func handleTableData(body: Data) -> SdkRouteResponse {
+        guard let driver = DatabaseInspector.shared.getDriver() else {
+            return error(statusCode: 503, code: "db_inspection_disabled")
+        }
+        guard let request = try? JSONDecoder().decode(SdkTableDataRequest.self, from: body) else {
+            return error(statusCode: 400, code: "bad_request")
+        }
+
+        let result = driver.getTableData(
+            databasePath: request.databasePath,
+            table: request.table,
+            limit: request.limit,
+            offset: request.offset
+        )
+        return encode(SdkTableDataPayload(columns: result.columns, rows: result.rows, total: result.totalRows))
+    }
+
+    func handleTableStructure(body: Data) -> SdkRouteResponse {
+        guard let driver = DatabaseInspector.shared.getDriver() else {
+            return error(statusCode: 503, code: "db_inspection_disabled")
+        }
+        guard let request = try? JSONDecoder().decode(SdkTableStructureRequest.self, from: body) else {
+            return error(statusCode: 400, code: "bad_request")
+        }
+
+        let result = driver.getTableStructure(databasePath: request.databasePath, table: request.table)
+        return encode(SdkTableStructurePayload(columns: result.columns.map {
+            SdkColumnInfoPayload(
+                name: $0.name,
+                type: $0.type,
+                nullable: $0.isNullable,
+                primaryKey: $0.isPrimaryKey,
+                defaultValue: $0.defaultValue
+            )
+        }))
+    }
+
+    func handleExecuteSql(body: Data) -> SdkRouteResponse {
+        guard let driver = DatabaseInspector.shared.getDriver() else {
+            return error(statusCode: 503, code: "db_inspection_disabled")
+        }
+        guard let request = try? JSONDecoder().decode(SdkExecuteSqlRequest.self, from: body) else {
+            return error(statusCode: 400, code: "bad_request")
+        }
+
+        let result = driver.executeSQL(databasePath: request.databasePath, query: request.query)
+        let payload = SdkExecuteSqlPayload(
+            queryType: result.columns == nil ? "mutation" : "query",
+            columns: result.columns,
+            rows: result.rows,
+            rowsAffected: result.rowsAffected,
+            error: result.error
+        )
+        return encode(payload)
+    }
+
+    private func encode<T: Encodable>(_ payload: T) -> SdkRouteResponse {
+        guard let data = try? JSONEncoder().encode(payload) else {
+            return error(statusCode: 500, code: "encode_failed")
+        }
+        return SdkRouteResponse(statusCode: 200, body: data)
+    }
+
+    private func error(statusCode: Int, code: String) -> SdkRouteResponse {
+        let payload = SdkDatabaseErrorPayload(error: code)
+        let body = (try? JSONEncoder().encode(payload)) ?? Data("{\"error\":\"\(code)\"}".utf8)
+        return SdkRouteResponse(statusCode: statusCode, body: body)
+    }
+}
+#endif

--- a/ios/auto-mobile-sdk/Sources/AutoMobileSDK/Storage/SdkDatabaseRouteHandler.swift
+++ b/ios/auto-mobile-sdk/Sources/AutoMobileSDK/Storage/SdkDatabaseRouteHandler.swift
@@ -107,6 +107,9 @@
             guard isKnownDatabasePath(request.databasePath, driver: driver) else {
                 return error(statusCode: 404, code: "unknown_database_path")
             }
+            guard isKnownTable(request.table, databasePath: request.databasePath, driver: driver) else {
+                return error(statusCode: 404, code: "unknown_table")
+            }
 
             let result = driver.getTableData(
                 databasePath: request.databasePath,
@@ -126,6 +129,9 @@
             }
             guard isKnownDatabasePath(request.databasePath, driver: driver) else {
                 return error(statusCode: 404, code: "unknown_database_path")
+            }
+            guard isKnownTable(request.table, databasePath: request.databasePath, driver: driver) else {
+                return error(statusCode: 404, code: "unknown_table")
             }
 
             let result = driver.getTableStructure(databasePath: request.databasePath, table: request.table)
@@ -164,6 +170,10 @@
 
         private func isKnownDatabasePath(_ databasePath: String, driver: DatabaseDriver) -> Bool {
             driver.getDatabases().contains { $0.path == databasePath }
+        }
+
+        private func isKnownTable(_ table: String, databasePath: String, driver: DatabaseDriver) -> Bool {
+            driver.getTables(databasePath: databasePath).contains(table)
         }
 
         private func encode<T: Encodable>(_ payload: T) -> SdkRouteResponse {

--- a/ios/auto-mobile-sdk/Sources/AutoMobileSDK/ViewHierarchy/SdkHierarchyServer.swift
+++ b/ios/auto-mobile-sdk/Sources/AutoMobileSDK/ViewHierarchy/SdkHierarchyServer.swift
@@ -6,10 +6,10 @@ import Network
 /// Serves view hierarchy snapshots to control-proxy on demand.
 ///
 /// Endpoints:
-/// - `GET /health` → `{"status":"ok","bundleId":"<sdk app bundle id>"}`
-/// - `GET /hierarchy` → latest cached hierarchy (fast, no main-thread work)
-/// - `GET /hierarchy/fresh` → synchronous main-thread walk (slower but guaranteed fresh)
-/// - `POST /highlight` → render a debug highlight in the app-under-test process
+/// - `GET /health` -> `{"status":"ok","bundleId":"<sdk app bundle id>"}`
+/// - `GET /hierarchy` -> latest cached hierarchy (fast, no main-thread work)
+/// - `GET /hierarchy/fresh` -> synchronous main-thread walk (slower but guaranteed fresh)
+/// - `POST /highlight` -> render a debug highlight in the app-under-test process
 final class SdkHierarchyServer: @unchecked Sendable {
 
     static let port: UInt16 = 8766
@@ -18,6 +18,7 @@ final class SdkHierarchyServer: @unchecked Sendable {
     private var listener: NWListener?
     private let queue = DispatchQueue(label: "dev.jasonpearson.automobile.sdk.hierarchy-server")
     private weak var tracker: ViewHierarchyTracker?
+    private let databaseRouteHandler = SdkDatabaseRouteHandler()
 
     init(tracker: ViewHierarchyTracker) {
         self.tracker = tracker
@@ -37,7 +38,7 @@ final class SdkHierarchyServer: @unchecked Sendable {
 
         do {
             let nwListener = try NWListener(using: parameters, on: NWEndpoint.Port(integerLiteral: Self.port))
-            self.listener = nwListener
+            listener = nwListener
             lock.unlock()
 
             nwListener.stateUpdateHandler = { state in
@@ -85,7 +86,7 @@ final class SdkHierarchyServer: @unchecked Sendable {
                 return
             }
 
-            guard let data = data, let request = String(data: data, encoding: .utf8) else {
+            guard let data, let request = String(data: data, encoding: .utf8) else {
                 connection.cancel()
                 return
             }
@@ -100,6 +101,28 @@ final class SdkHierarchyServer: @unchecked Sendable {
                 self.handleNetworkMock(connection, data: data)
             } else if request.contains("POST /highlight") {
                 self.handleHighlight(connection, data: data)
+            } else if request.contains("POST /db/execute") {
+                self.sendRouteResponse(
+                    connection,
+                    self.databaseRouteHandler.handleExecuteSql(body: Self.httpBody(from: data) ?? Data())
+                )
+            } else if request.contains("POST /db/list") {
+                self.sendRouteResponse(connection, self.databaseRouteHandler.handleListDatabases())
+            } else if request.contains("POST /db/tables") {
+                self.sendRouteResponse(
+                    connection,
+                    self.databaseRouteHandler.handleListTables(body: Self.httpBody(from: data) ?? Data())
+                )
+            } else if request.contains("POST /db/table-data") {
+                self.sendRouteResponse(
+                    connection,
+                    self.databaseRouteHandler.handleTableData(body: Self.httpBody(from: data) ?? Data())
+                )
+            } else if request.contains("POST /db/table-structure") {
+                self.sendRouteResponse(
+                    connection,
+                    self.databaseRouteHandler.handleTableStructure(body: Self.httpBody(from: data) ?? Data())
+                )
             } else {
                 self.sendResponse(connection, statusCode: 404, body: Data("{\"error\":\"not_found\"}".utf8))
             }
@@ -128,7 +151,7 @@ final class SdkHierarchyServer: @unchecked Sendable {
     }
 
     private func handleFreshHierarchy(_ connection: NWConnection) {
-        guard let tracker = tracker else {
+        guard let tracker else {
             sendResponse(connection, statusCode: 503, body: Data("{\"error\":\"tracker_unavailable\"}".utf8))
             return
         }
@@ -195,6 +218,10 @@ final class SdkHierarchyServer: @unchecked Sendable {
         connection.send(content: responseData, completion: .contentProcessed { _ in
             connection.cancel()
         })
+    }
+
+    private func sendRouteResponse(_ connection: NWConnection, _ response: SdkRouteResponse) {
+        sendResponse(connection, statusCode: response.statusCode, body: response.body)
     }
 }
 

--- a/ios/auto-mobile-sdk/Tests/AutoMobileSDKTests/StorageTests.swift
+++ b/ios/auto-mobile-sdk/Tests/AutoMobileSDKTests/StorageTests.swift
@@ -92,6 +92,9 @@ final class SdkDatabaseRouteHandlerTests: XCTestCase {
 
     func testExecuteSqlEncodesQueryResult() throws {
         let fakeDriver = RouteFakeDatabaseDriver()
+        fakeDriver.databases = [
+            DatabaseDescriptor(name: "app.db", path: "/app/Documents/app.db", sizeBytes: 1024),
+        ]
         fakeDriver.sqlResult = SQLExecutionResult(
             columns: ["id", "payload"],
             rows: [["1", "0xCAFE"]],
@@ -119,6 +122,29 @@ final class SdkDatabaseRouteHandlerTests: XCTestCase {
         XCTAssertEqual(fakeDriver.executeSqlCalls[0].query, "SELECT id, payload FROM notes")
     }
 
+    func testExecuteSqlRejectsUnknownDatabasePathBeforeOpeningSqlite() throws {
+        let fakeDriver = RouteFakeDatabaseDriver()
+        fakeDriver.databases = [
+            DatabaseDescriptor(name: "app.db", path: "/app/Documents/app.db", sizeBytes: 1024),
+        ]
+        DatabaseInspector.shared.initialize()
+        DatabaseInspector.shared.setDriver(fakeDriver)
+        DatabaseInspector.shared.setEnabled(true)
+
+        let request = SdkExecuteSqlRequest(
+            databasePath: "/app/Documents/misspelled.db",
+            query: "INSERT INTO notes (title) VALUES ('new')"
+        )
+        let body = try JSONEncoder().encode(request)
+
+        let response = SdkDatabaseRouteHandler().handleExecuteSql(body: body)
+
+        XCTAssertEqual(response.statusCode, 404)
+        let payload = try JSONDecoder().decode(SdkDatabaseErrorPayload.self, from: response.body)
+        XCTAssertEqual(payload.error, "unknown_database_path")
+        XCTAssertEqual(fakeDriver.executeSqlCalls.count, 0)
+    }
+
     func testExecuteSqlReturnsDisabledWhenInspectorNotEnabled() throws {
         DatabaseInspector.shared.initialize()
         DatabaseInspector.shared.setEnabled(false)
@@ -133,11 +159,12 @@ final class SdkDatabaseRouteHandlerTests: XCTestCase {
 }
 
 private final class RouteFakeDatabaseDriver: DatabaseDriver, @unchecked Sendable {
+    var databases: [DatabaseDescriptor] = []
     var sqlResult = SQLExecutionResult(columns: nil, rows: nil, rowsAffected: 0)
     var executeSqlCalls: [(databasePath: String, query: String)] = []
 
     func getDatabases() -> [DatabaseDescriptor] {
-        []
+        databases
     }
 
     func getTables(databasePath _: String) -> [String] {

--- a/ios/auto-mobile-sdk/Tests/AutoMobileSDKTests/StorageTests.swift
+++ b/ios/auto-mobile-sdk/Tests/AutoMobileSDKTests/StorageTests.swift
@@ -145,6 +145,56 @@ final class SdkDatabaseRouteHandlerTests: XCTestCase {
         XCTAssertEqual(fakeDriver.executeSqlCalls.count, 0)
     }
 
+    func testTableDataRejectsUnknownTableBeforeOpeningSqlite() throws {
+        let fakeDriver = RouteFakeDatabaseDriver()
+        fakeDriver.databases = [
+            DatabaseDescriptor(name: "app.db", path: "/app/Documents/app.db", sizeBytes: 1024),
+        ]
+        fakeDriver.tablesByDatabase = ["/app/Documents/app.db": ["notes"]]
+        DatabaseInspector.shared.initialize()
+        DatabaseInspector.shared.setDriver(fakeDriver)
+        DatabaseInspector.shared.setEnabled(true)
+
+        let request = SdkTableDataRequest(
+            databasePath: "/app/Documents/app.db",
+            table: "notess",
+            limit: 50,
+            offset: 0
+        )
+        let body = try JSONEncoder().encode(request)
+
+        let response = SdkDatabaseRouteHandler().handleTableData(body: body)
+
+        XCTAssertEqual(response.statusCode, 404)
+        let payload = try JSONDecoder().decode(SdkDatabaseErrorPayload.self, from: response.body)
+        XCTAssertEqual(payload.error, "unknown_table")
+        XCTAssertEqual(fakeDriver.tableDataCalls.count, 0)
+    }
+
+    func testTableStructureRejectsUnknownTableBeforeOpeningSqlite() throws {
+        let fakeDriver = RouteFakeDatabaseDriver()
+        fakeDriver.databases = [
+            DatabaseDescriptor(name: "app.db", path: "/app/Documents/app.db", sizeBytes: 1024),
+        ]
+        fakeDriver.tablesByDatabase = ["/app/Documents/app.db": ["notes"]]
+        DatabaseInspector.shared.initialize()
+        DatabaseInspector.shared.setDriver(fakeDriver)
+        DatabaseInspector.shared.setEnabled(true)
+
+        let request = SdkTableStructureRequest(
+            databasePath: "/app/Documents/app.db",
+            table: "notess"
+        )
+        let body = try JSONEncoder().encode(request)
+
+        let response = SdkDatabaseRouteHandler().handleTableStructure(body: body)
+
+        XCTAssertEqual(response.statusCode, 404)
+        let payload = try JSONDecoder().decode(SdkDatabaseErrorPayload.self, from: response.body)
+        XCTAssertEqual(payload.error, "unknown_table")
+        XCTAssertEqual(fakeDriver.tableStructureCalls.count, 0)
+    }
+
     func testExecuteSqlReturnsDisabledWhenInspectorNotEnabled() throws {
         DatabaseInspector.shared.initialize()
         DatabaseInspector.shared.setEnabled(false)
@@ -160,23 +210,33 @@ final class SdkDatabaseRouteHandlerTests: XCTestCase {
 
 private final class RouteFakeDatabaseDriver: DatabaseDriver, @unchecked Sendable {
     var databases: [DatabaseDescriptor] = []
+    var tablesByDatabase: [String: [String]] = [:]
     var sqlResult = SQLExecutionResult(columns: nil, rows: nil, rowsAffected: 0)
     var executeSqlCalls: [(databasePath: String, query: String)] = []
+    var tableDataCalls: [SdkTableDataRequest] = []
+    var tableStructureCalls: [(databasePath: String, table: String)] = []
 
     func getDatabases() -> [DatabaseDescriptor] {
         databases
     }
 
-    func getTables(databasePath _: String) -> [String] {
-        []
+    func getTables(databasePath: String) -> [String] {
+        tablesByDatabase[databasePath] ?? []
     }
 
-    func getTableData(databasePath _: String, table _: String, limit _: Int, offset _: Int) -> TableDataResult {
-        TableDataResult(columns: [], rows: [], totalRows: 0)
+    func getTableData(databasePath: String, table: String, limit: Int, offset: Int) -> TableDataResult {
+        tableDataCalls.append(SdkTableDataRequest(
+            databasePath: databasePath,
+            table: table,
+            limit: limit,
+            offset: offset
+        ))
+        return TableDataResult(columns: [], rows: [], totalRows: 0)
     }
 
-    func getTableStructure(databasePath _: String, table _: String) -> TableStructureResult {
-        TableStructureResult(columns: [])
+    func getTableStructure(databasePath: String, table: String) -> TableStructureResult {
+        tableStructureCalls.append((databasePath: databasePath, table: table))
+        return TableStructureResult(columns: [])
     }
 
     func executeSQL(databasePath: String, query: String) -> SQLExecutionResult {

--- a/ios/auto-mobile-sdk/Tests/AutoMobileSDKTests/StorageTests.swift
+++ b/ios/auto-mobile-sdk/Tests/AutoMobileSDKTests/StorageTests.swift
@@ -1,5 +1,5 @@
-import XCTest
 @testable import AutoMobileSDK
+import XCTest
 
 final class UserDefaultsInspectorTests: XCTestCase {
     override func tearDown() {
@@ -81,5 +81,79 @@ final class DatabaseInspectorTests: XCTestCase {
         let driver = DatabaseInspector.shared.getDriver()
         XCTAssertEqual(driver?.getDatabases().count, 1)
         XCTAssertEqual(driver?.getTables(databasePath: "/path/test.db"), ["users", "posts"])
+    }
+}
+
+final class SdkDatabaseRouteHandlerTests: XCTestCase {
+    override func tearDown() {
+        DatabaseInspector.shared.reset()
+        super.tearDown()
+    }
+
+    func testExecuteSqlEncodesQueryResult() throws {
+        let fakeDriver = RouteFakeDatabaseDriver()
+        fakeDriver.sqlResult = SQLExecutionResult(
+            columns: ["id", "payload"],
+            rows: [["1", "0xCAFE"]],
+            rowsAffected: 0
+        )
+        DatabaseInspector.shared.initialize()
+        DatabaseInspector.shared.setDriver(fakeDriver)
+        DatabaseInspector.shared.setEnabled(true)
+
+        let request = SdkExecuteSqlRequest(
+            databasePath: "/app/Documents/app.db",
+            query: "SELECT id, payload FROM notes"
+        )
+        let body = try JSONEncoder().encode(request)
+
+        let response = SdkDatabaseRouteHandler().handleExecuteSql(body: body)
+
+        XCTAssertEqual(response.statusCode, 200)
+        let payload = try JSONDecoder().decode(SdkExecuteSqlPayload.self, from: response.body)
+        XCTAssertEqual(payload.queryType, "query")
+        XCTAssertEqual(payload.columns, ["id", "payload"])
+        XCTAssertEqual(payload.rows, [["1", "0xCAFE"]])
+        XCTAssertEqual(fakeDriver.executeSqlCalls.count, 1)
+        XCTAssertEqual(fakeDriver.executeSqlCalls[0].databasePath, "/app/Documents/app.db")
+        XCTAssertEqual(fakeDriver.executeSqlCalls[0].query, "SELECT id, payload FROM notes")
+    }
+
+    func testExecuteSqlReturnsDisabledWhenInspectorNotEnabled() throws {
+        DatabaseInspector.shared.initialize()
+        DatabaseInspector.shared.setEnabled(false)
+        let body = try JSONEncoder().encode(SdkExecuteSqlRequest(databasePath: "/db.sqlite", query: "SELECT 1"))
+
+        let response = SdkDatabaseRouteHandler().handleExecuteSql(body: body)
+
+        XCTAssertEqual(response.statusCode, 503)
+        let payload = try JSONDecoder().decode(SdkDatabaseErrorPayload.self, from: response.body)
+        XCTAssertEqual(payload.error, "db_inspection_disabled")
+    }
+}
+
+private final class RouteFakeDatabaseDriver: DatabaseDriver, @unchecked Sendable {
+    var sqlResult = SQLExecutionResult(columns: nil, rows: nil, rowsAffected: 0)
+    var executeSqlCalls: [(databasePath: String, query: String)] = []
+
+    func getDatabases() -> [DatabaseDescriptor] {
+        []
+    }
+
+    func getTables(databasePath _: String) -> [String] {
+        []
+    }
+
+    func getTableData(databasePath _: String, table _: String, limit _: Int, offset _: Int) -> TableDataResult {
+        TableDataResult(columns: [], rows: [], totalRows: 0)
+    }
+
+    func getTableStructure(databasePath _: String, table _: String) -> TableStructureResult {
+        TableStructureResult(columns: [])
+    }
+
+    func executeSQL(databasePath: String, query: String) -> SQLExecutionResult {
+        executeSqlCalls.append((databasePath: databasePath, query: query))
+        return sqlResult
     }
 }

--- a/ios/control-proxy/CtrlProxy.xcodeproj/project.pbxproj
+++ b/ios/control-proxy/CtrlProxy.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		0A4F48C4211E43B829855704 /* SdkHierarchyClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7C65BE687554E71E587B731 /* SdkHierarchyClient.swift */; };
 		0DCD8748EF0E74AD806385A5 /* SdkHierarchyCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 043D2CA5107B76077BA6301C /* SdkHierarchyCache.swift */; };
 		0E8A9A62BEF9C4E672D09764 /* PerfProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEF454F64F7AF11BD79DB97D /* PerfProviderTests.swift */; };
+		102B43801F02F0409F0A2497 /* SdkDatabaseClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45F68BA7AC670D5C3D07725B /* SdkDatabaseClient.swift */; };
 		12D60B8E4D067E91189066AD /* CommandHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25C10BFA5B6504892F8459D7 /* CommandHandlerTests.swift */; };
 		141E5CD4FAF4509F538E736C /* OSLogReader.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBA97A6C3A1240A055D9876C /* OSLogReader.swift */; };
 		158C6F3B528C02BE92AA6132 /* HierarchyMerger.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAAF8CEA9B9A28B052E57E0A /* HierarchyMerger.swift */; };
@@ -18,6 +19,7 @@
 		1F968B5EDB744057F51321EF /* ElementLocator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95565999DC108319DEED894A /* ElementLocator.swift */; };
 		22D7BF7E548A966178B6A5A3 /* HighlightOverlayManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D07D98176593529FE7FC93F /* HighlightOverlayManager.swift */; };
 		261F76AE6277D92BD87CFB1C /* SdkHierarchyClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7C65BE687554E71E587B731 /* SdkHierarchyClient.swift */; };
+		28335B9012A77482EF8F7B71 /* SdkDatabaseClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45F68BA7AC670D5C3D07725B /* SdkDatabaseClient.swift */; };
 		2ABF683DE1AD6578F8EAF168 /* SdkHierarchyCacheTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5408FE8438060177DDAE7177 /* SdkHierarchyCacheTests.swift */; };
 		2BC78956D2B04A95DA43E6FB /* Protocols.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0F9D7B74C318EE243B225B95 /* Protocols.swift */; };
 		2CFEE57D3D518C352BAB2937 /* SdkHierarchyModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83E0B84D4CA225ECB1E09064 /* SdkHierarchyModels.swift */; };
@@ -162,6 +164,7 @@
 		3BF23F10C24C9F40E5CEC303 /* Logging.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Logging.swift; sourceTree = "<group>"; };
 		3E5AAA4E2861D92C17F39B14 /* HierarchyDebouncerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HierarchyDebouncerTests.swift; sourceTree = "<group>"; };
 		42C53A4D56EE97B5BD11EC63 /* Debug.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Debug.xcconfig; sourceTree = "<group>"; };
+		45F68BA7AC670D5C3D07725B /* SdkDatabaseClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SdkDatabaseClient.swift; sourceTree = "<group>"; };
 		5408FE8438060177DDAE7177 /* SdkHierarchyCacheTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SdkHierarchyCacheTests.swift; sourceTree = "<group>"; };
 		637A2A05C90AA6E64D224651 /* CtrlProxyTests.xctest */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.cfbundle; path = CtrlProxyTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		649A3185201F07E4D152CED6 /* ObjCExceptionBridgeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ObjCExceptionBridgeTests.swift; sourceTree = "<group>"; };
@@ -327,6 +330,7 @@
 				B136EAD78CC0B932F258C265 /* PerformanceMetrics.swift */,
 				A284B6FFBE969931BB03A2FF /* PerfProvider.swift */,
 				0F9D7B74C318EE243B225B95 /* Protocols.swift */,
+				45F68BA7AC670D5C3D07725B /* SdkDatabaseClient.swift */,
 				043D2CA5107B76077BA6301C /* SdkHierarchyCache.swift */,
 				E7C65BE687554E71E587B731 /* SdkHierarchyClient.swift */,
 				83E0B84D4CA225ECB1E09064 /* SdkHierarchyModels.swift */,
@@ -545,6 +549,7 @@
 				D0C171171348407EBFF5BAB7 /* PerfProvider.swift in Sources */,
 				E8327D679D58C8F804C064B1 /* PerformanceMetrics.swift in Sources */,
 				47A050F2D8153251E395B7B9 /* Protocols.swift in Sources */,
+				102B43801F02F0409F0A2497 /* SdkDatabaseClient.swift in Sources */,
 				0DCD8748EF0E74AD806385A5 /* SdkHierarchyCache.swift in Sources */,
 				0A4F48C4211E43B829855704 /* SdkHierarchyClient.swift in Sources */,
 				2CFEE57D3D518C352BAB2937 /* SdkHierarchyModels.swift in Sources */,
@@ -598,6 +603,7 @@
 				4A0FBEF6FAEF437AA17B20EA /* PerfProvider.swift in Sources */,
 				B55A16F80CE62B998CEBC6E0 /* PerformanceMetrics.swift in Sources */,
 				2BC78956D2B04A95DA43E6FB /* Protocols.swift in Sources */,
+				28335B9012A77482EF8F7B71 /* SdkDatabaseClient.swift in Sources */,
 				EE7765F6DA0807474D52C3DD /* SdkHierarchyCache.swift in Sources */,
 				261F76AE6277D92BD87CFB1C /* SdkHierarchyClient.swift in Sources */,
 				CB577FE46E063BB09F5D4010 /* SdkHierarchyModels.swift in Sources */,

--- a/ios/control-proxy/Sources/CtrlProxy/CommandHandler.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/CommandHandler.swift
@@ -1,6 +1,6 @@
 import Foundation
 #if canImport(os)
-import os
+    import os
 #endif
 #if canImport(XCTest) && os(iOS)
     import XCTest
@@ -22,6 +22,7 @@ public class CommandHandler: CommandHandling {
     private let sdkHierarchyClient: (any SdkHierarchyFetching)?
     private let sdkHierarchyCache: (any SdkHierarchyCaching)?
     private let highlightOverlayManager: HighlightOverlayManaging
+    private let sdkDatabaseClient: (any SdkDatabaseFetching)?
 
     public init(
         elementLocator: ElementLocating,
@@ -30,7 +31,8 @@ public class CommandHandler: CommandHandling {
         storageInspector: StorageInspecting? = nil,
         sdkHierarchyClient: (any SdkHierarchyFetching)? = nil,
         sdkHierarchyCache: (any SdkHierarchyCaching)? = nil,
-        highlightOverlayManager: HighlightOverlayManaging = HighlightOverlayManager()
+        highlightOverlayManager: HighlightOverlayManaging = HighlightOverlayManager(),
+        sdkDatabaseClient: (any SdkDatabaseFetching)? = nil
     ) {
         self.elementLocator = elementLocator
         self.gesturePerformer = gesturePerformer
@@ -39,6 +41,7 @@ public class CommandHandler: CommandHandling {
         self.sdkHierarchyClient = sdkHierarchyClient
         self.sdkHierarchyCache = sdkHierarchyCache
         self.highlightOverlayManager = highlightOverlayManager
+        self.sdkDatabaseClient = sdkDatabaseClient
     }
 
     /// Factory for testing - allows injecting fakes
@@ -49,7 +52,8 @@ public class CommandHandler: CommandHandling {
         storageInspector: StorageInspecting? = nil,
         sdkHierarchyClient: (any SdkHierarchyFetching)? = nil,
         sdkHierarchyCache: (any SdkHierarchyCaching)? = nil,
-        highlightOverlayManager: HighlightOverlayManaging = HighlightOverlayManager()
+        highlightOverlayManager: HighlightOverlayManaging = HighlightOverlayManager(),
+        sdkDatabaseClient: (any SdkDatabaseFetching)? = nil
     )
         -> CommandHandler
     {
@@ -60,7 +64,8 @@ public class CommandHandler: CommandHandling {
             storageInspector: storageInspector,
             sdkHierarchyClient: sdkHierarchyClient,
             sdkHierarchyCache: sdkHierarchyCache,
-            highlightOverlayManager: highlightOverlayManager
+            highlightOverlayManager: highlightOverlayManager,
+            sdkDatabaseClient: sdkDatabaseClient
         )
     }
 
@@ -179,6 +184,22 @@ public class CommandHandler: CommandHandling {
             case RequestType.setNetworkMockRules.rawValue:
                 return try handleSetNetworkMockRules(request, startTime: startTime)
 
+            // Database commands
+            case RequestType.executeSql.rawValue:
+                return handleExecuteSql(request, startTime: startTime)
+
+            case RequestType.listDatabases.rawValue:
+                return handleListDatabases(request, startTime: startTime)
+
+            case RequestType.listTables.rawValue:
+                return handleListTables(request, startTime: startTime)
+
+            case RequestType.getTableData.rawValue:
+                return handleGetTableData(request, startTime: startTime)
+
+            case RequestType.getTableStructure.rawValue:
+                return handleGetTableStructure(request, startTime: startTime)
+
             default:
                 return WebSocketResponse.error(
                     type: "error",
@@ -260,7 +281,8 @@ public class CommandHandler: CommandHandling {
 
     private func matchingCachedSdkHierarchy(for hierarchy: ViewHierarchy) -> SdkViewHierarchy? {
         guard let foregroundBundleId = normalizedBundleId(hierarchy.packageName),
-              let cached = sdkHierarchyCache?.latest else {
+              let cached = sdkHierarchyCache?.latest
+        else {
             return nil
         }
         guard sdkHierarchy(cached, matches: foregroundBundleId) else {
@@ -290,7 +312,8 @@ public class CommandHandler: CommandHandling {
         }
 
         guard let fresh = sdkHierarchyClient?.fetchFreshHierarchy(),
-              sdkHierarchy(fresh, matches: foregroundBundleId) else {
+              sdkHierarchy(fresh, matches: foregroundBundleId)
+        else {
             sdkHierarchyCache?.clear()
             return nil
         }
@@ -318,7 +341,8 @@ public class CommandHandler: CommandHandling {
 
     private func normalizedBundleId(_ bundleId: String?) -> String? {
         guard let normalized = bundleId?.trimmingCharacters(in: .whitespacesAndNewlines),
-              !normalized.isEmpty else {
+              !normalized.isEmpty
+        else {
             return nil
         }
         return normalized
@@ -470,7 +494,10 @@ public class CommandHandler: CommandHandling {
         defer { perfProvider.end() }
 
         let resourceId = request.resourceId
-        textInputLog.debug("handleSetText begin resourceId=\(resourceId ?? "nil", privacy: .public) textLength=\(text.count, privacy: .public) requestId=\(request.requestId ?? "nil", privacy: .public)")
+        textInputLog
+            .debug(
+                "handleSetText begin resourceId=\(resourceId ?? "nil", privacy: .public) textLength=\(text.count, privacy: .public) requestId=\(request.requestId ?? "nil", privacy: .public)"
+            )
 
         do {
             if let resourceId = resourceId {
@@ -483,15 +510,23 @@ public class CommandHandler: CommandHandling {
                 }
             }
         } catch {
-            textInputLog.error("handleSetText FAILED resourceId=\(resourceId ?? "nil", privacy: .public) error=\(String(describing: error), privacy: .public) elapsedMs=\(self.totalTimeMs(from: startTime), privacy: .public)")
+            let elapsedMs = totalTimeMs(from: startTime)
+            textInputLog
+                .error(
+                    "handleSetText FAILED resourceId=\(resourceId ?? "nil", privacy: .public) error=\(String(describing: error), privacy: .public) elapsedMs=\(elapsedMs, privacy: .public)"
+                )
             throw error
         }
 
-        textInputLog.debug("handleSetText OK resourceId=\(resourceId ?? "nil", privacy: .public) elapsedMs=\(self.totalTimeMs(from: startTime), privacy: .public)")
+        let elapsedMs = totalTimeMs(from: startTime)
+        textInputLog
+            .debug(
+                "handleSetText OK resourceId=\(resourceId ?? "nil", privacy: .public) elapsedMs=\(elapsedMs, privacy: .public)"
+            )
         return WebSocketResponse.success(
             type: ResponseType.setTextResult.rawValue,
             requestId: request.requestId,
-            totalTimeMs: totalTimeMs(from: startTime)
+            totalTimeMs: elapsedMs
         )
     }
 
@@ -500,22 +535,33 @@ public class CommandHandler: CommandHandling {
         defer { perfProvider.end() }
 
         let resourceId = request.resourceId
-        textInputLog.debug("handleClearText begin resourceId=\(resourceId ?? "nil", privacy: .public) requestId=\(request.requestId ?? "nil", privacy: .public)")
+        textInputLog
+            .debug(
+                "handleClearText begin resourceId=\(resourceId ?? "nil", privacy: .public) requestId=\(request.requestId ?? "nil", privacy: .public)"
+            )
 
         do {
             try perfProvider.track("clearText") {
                 try gesturePerformer.clearText(resourceId: resourceId)
             }
         } catch {
-            textInputLog.error("handleClearText FAILED resourceId=\(resourceId ?? "nil", privacy: .public) error=\(String(describing: error), privacy: .public) elapsedMs=\(self.totalTimeMs(from: startTime), privacy: .public)")
+            let elapsedMs = totalTimeMs(from: startTime)
+            textInputLog
+                .error(
+                    "handleClearText FAILED resourceId=\(resourceId ?? "nil", privacy: .public) error=\(String(describing: error), privacy: .public) elapsedMs=\(elapsedMs, privacy: .public)"
+                )
             throw error
         }
 
-        textInputLog.debug("handleClearText OK resourceId=\(resourceId ?? "nil", privacy: .public) elapsedMs=\(self.totalTimeMs(from: startTime), privacy: .public)")
+        let elapsedMs = totalTimeMs(from: startTime)
+        textInputLog
+            .debug(
+                "handleClearText OK resourceId=\(resourceId ?? "nil", privacy: .public) elapsedMs=\(elapsedMs, privacy: .public)"
+            )
         return WebSocketResponse.success(
             type: ResponseType.clearTextResult.rawValue,
             requestId: request.requestId,
-            totalTimeMs: totalTimeMs(from: startTime)
+            totalTimeMs: elapsedMs
         )
     }
 
@@ -527,22 +573,33 @@ public class CommandHandler: CommandHandling {
         perfProvider.serial("handleImeAction")
         defer { perfProvider.end() }
 
-        textInputLog.debug("handleImeAction begin action=\(action, privacy: .public) requestId=\(request.requestId ?? "nil", privacy: .public)")
+        textInputLog
+            .debug(
+                "handleImeAction begin action=\(action, privacy: .public) requestId=\(request.requestId ?? "nil", privacy: .public)"
+            )
 
         do {
             try perfProvider.track("imeAction") {
                 try gesturePerformer.performImeAction(action)
             }
         } catch {
-            textInputLog.error("handleImeAction FAILED action=\(action, privacy: .public) error=\(String(describing: error), privacy: .public) elapsedMs=\(self.totalTimeMs(from: startTime), privacy: .public)")
+            let elapsedMs = totalTimeMs(from: startTime)
+            textInputLog
+                .error(
+                    "handleImeAction FAILED action=\(action, privacy: .public) error=\(String(describing: error), privacy: .public) elapsedMs=\(elapsedMs, privacy: .public)"
+                )
             throw error
         }
 
-        textInputLog.debug("handleImeAction OK action=\(action, privacy: .public) elapsedMs=\(self.totalTimeMs(from: startTime), privacy: .public)")
+        let elapsedMs = totalTimeMs(from: startTime)
+        textInputLog
+            .debug(
+                "handleImeAction OK action=\(action, privacy: .public) elapsedMs=\(elapsedMs, privacy: .public)"
+            )
         return WebSocketResponse.success(
             type: ResponseType.imeActionResult.rawValue,
             requestId: request.requestId,
-            totalTimeMs: totalTimeMs(from: startTime)
+            totalTimeMs: elapsedMs
         )
     }
 
@@ -557,15 +614,20 @@ public class CommandHandler: CommandHandling {
                 try gesturePerformer.selectAll()
             }
         } catch {
-            textInputLog.error("handleSelectAll FAILED error=\(String(describing: error), privacy: .public) elapsedMs=\(self.totalTimeMs(from: startTime), privacy: .public)")
+            let elapsedMs = totalTimeMs(from: startTime)
+            textInputLog
+                .error(
+                    "handleSelectAll FAILED error=\(String(describing: error), privacy: .public) elapsedMs=\(elapsedMs, privacy: .public)"
+                )
             throw error
         }
 
-        textInputLog.debug("handleSelectAll OK elapsedMs=\(self.totalTimeMs(from: startTime), privacy: .public)")
+        let elapsedMs = totalTimeMs(from: startTime)
+        textInputLog.debug("handleSelectAll OK elapsedMs=\(elapsedMs, privacy: .public)")
         return WebSocketResponse.success(
             type: ResponseType.selectAllResult.rawValue,
             requestId: request.requestId,
-            totalTimeMs: totalTimeMs(from: startTime)
+            totalTimeMs: elapsedMs
         )
     }
 
@@ -754,7 +816,9 @@ public class CommandHandler: CommandHandling {
 
         if coldBoot {
             // Cold boot: always terminate then launch fresh
-            if appState == .runningForeground || appState == .runningBackground || appState == .runningBackgroundSuspended {
+            if appState == .runningForeground || appState == .runningBackground || appState ==
+                .runningBackgroundSuspended
+            {
                 try perfProvider.track("terminateApp") {
                     try gesturePerformer.terminateApp(bundleId: bundleId)
                 }
@@ -791,7 +855,7 @@ public class CommandHandler: CommandHandling {
         // activate() is synchronous and the app is guaranteed to remain foreground.
         if !alreadyForeground || coldBoot {
             perfProvider.track("awaitForeground") {
-                let _ = elementLocator.awaitAppState(bundleId: bundleId, expectedState: .foreground)
+                _ = elementLocator.awaitAppState(bundleId: bundleId, expectedState: .foreground)
             }
         }
 
@@ -1111,7 +1175,225 @@ public class CommandHandler: CommandHandling {
         )
     }
 
+    // MARK: - Database
+
+    private func handleExecuteSql(_ request: WebSocketRequest, startTime: Date) -> ExecuteSqlResponse {
+        guard let client = sdkDatabaseClient else {
+            return ExecuteSqlResponse(
+                requestId: request.requestId,
+                success: false,
+                error: databaseUnavailableMessage,
+                totalTimeMs: totalTimeMs(from: startTime)
+            )
+        }
+        guard let databasePath = request.databasePath else {
+            return ExecuteSqlResponse(
+                requestId: request.requestId,
+                success: false,
+                error: CommandError.missingParameter("databasePath").localizedDescription,
+                totalTimeMs: totalTimeMs(from: startTime)
+            )
+        }
+        guard let query = request.query else {
+            return ExecuteSqlResponse(
+                requestId: request.requestId,
+                success: false,
+                error: CommandError.missingParameter("query").localizedDescription,
+                totalTimeMs: totalTimeMs(from: startTime)
+            )
+        }
+
+        do {
+            let result = try client.executeSQL(databasePath: databasePath, query: query)
+            if let error = result.error {
+                return ExecuteSqlResponse(
+                    requestId: request.requestId,
+                    success: false,
+                    error: error,
+                    totalTimeMs: totalTimeMs(from: startTime)
+                )
+            }
+            return ExecuteSqlResponse(
+                requestId: request.requestId,
+                success: true,
+                queryType: result.queryType,
+                columns: result.columns,
+                rows: result.rows,
+                rowsAffected: result.rowsAffected,
+                totalTimeMs: totalTimeMs(from: startTime)
+            )
+        } catch {
+            return ExecuteSqlResponse(
+                requestId: request.requestId,
+                success: false,
+                error: error.localizedDescription,
+                totalTimeMs: totalTimeMs(from: startTime)
+            )
+        }
+    }
+
+    private func handleListDatabases(_ request: WebSocketRequest, startTime: Date) -> ListDatabasesResponse {
+        guard let client = sdkDatabaseClient else {
+            return ListDatabasesResponse(
+                requestId: request.requestId,
+                success: false,
+                error: databaseUnavailableMessage,
+                totalTimeMs: totalTimeMs(from: startTime)
+            )
+        }
+
+        do {
+            return try ListDatabasesResponse(
+                requestId: request.requestId,
+                success: true,
+                databases: client.listDatabases(),
+                totalTimeMs: totalTimeMs(from: startTime)
+            )
+        } catch {
+            return ListDatabasesResponse(
+                requestId: request.requestId,
+                success: false,
+                error: error.localizedDescription,
+                totalTimeMs: totalTimeMs(from: startTime)
+            )
+        }
+    }
+
+    private func handleListTables(_ request: WebSocketRequest, startTime: Date) -> ListTablesResponse {
+        guard let client = sdkDatabaseClient else {
+            return ListTablesResponse(
+                requestId: request.requestId,
+                success: false,
+                error: databaseUnavailableMessage,
+                totalTimeMs: totalTimeMs(from: startTime)
+            )
+        }
+        guard let databasePath = request.databasePath else {
+            return ListTablesResponse(
+                requestId: request.requestId,
+                success: false,
+                error: CommandError.missingParameter("databasePath").localizedDescription,
+                totalTimeMs: totalTimeMs(from: startTime)
+            )
+        }
+
+        do {
+            return try ListTablesResponse(
+                requestId: request.requestId,
+                success: true,
+                tables: client.listTables(databasePath: databasePath),
+                totalTimeMs: totalTimeMs(from: startTime)
+            )
+        } catch {
+            return ListTablesResponse(
+                requestId: request.requestId,
+                success: false,
+                error: error.localizedDescription,
+                totalTimeMs: totalTimeMs(from: startTime)
+            )
+        }
+    }
+
+    private func handleGetTableData(_ request: WebSocketRequest, startTime: Date) -> TableDataResponse {
+        guard let client = sdkDatabaseClient else {
+            return TableDataResponse(
+                requestId: request.requestId,
+                success: false,
+                error: databaseUnavailableMessage,
+                totalTimeMs: totalTimeMs(from: startTime)
+            )
+        }
+        guard let databasePath = request.databasePath else {
+            return TableDataResponse(
+                requestId: request.requestId,
+                success: false,
+                error: CommandError.missingParameter("databasePath").localizedDescription,
+                totalTimeMs: totalTimeMs(from: startTime)
+            )
+        }
+        guard let table = request.table else {
+            return TableDataResponse(
+                requestId: request.requestId,
+                success: false,
+                error: CommandError.missingParameter("table").localizedDescription,
+                totalTimeMs: totalTimeMs(from: startTime)
+            )
+        }
+
+        do {
+            let data = try client.getTableData(
+                databasePath: databasePath,
+                table: table,
+                limit: request.limit ?? 50,
+                offset: request.offset ?? 0
+            )
+            return TableDataResponse(
+                requestId: request.requestId,
+                success: true,
+                columns: data.columns,
+                rows: data.rows,
+                total: data.total,
+                totalTimeMs: totalTimeMs(from: startTime)
+            )
+        } catch {
+            return TableDataResponse(
+                requestId: request.requestId,
+                success: false,
+                error: error.localizedDescription,
+                totalTimeMs: totalTimeMs(from: startTime)
+            )
+        }
+    }
+
+    private func handleGetTableStructure(_ request: WebSocketRequest, startTime: Date) -> TableStructureResponse {
+        guard let client = sdkDatabaseClient else {
+            return TableStructureResponse(
+                requestId: request.requestId,
+                success: false,
+                error: databaseUnavailableMessage,
+                totalTimeMs: totalTimeMs(from: startTime)
+            )
+        }
+        guard let databasePath = request.databasePath else {
+            return TableStructureResponse(
+                requestId: request.requestId,
+                success: false,
+                error: CommandError.missingParameter("databasePath").localizedDescription,
+                totalTimeMs: totalTimeMs(from: startTime)
+            )
+        }
+        guard let table = request.table else {
+            return TableStructureResponse(
+                requestId: request.requestId,
+                success: false,
+                error: CommandError.missingParameter("table").localizedDescription,
+                totalTimeMs: totalTimeMs(from: startTime)
+            )
+        }
+
+        do {
+            let structure = try client.getTableStructure(databasePath: databasePath, table: table)
+            return TableStructureResponse(
+                requestId: request.requestId,
+                success: true,
+                columns: structure.columns,
+                totalTimeMs: totalTimeMs(from: startTime)
+            )
+        } catch {
+            return TableStructureResponse(
+                requestId: request.requestId,
+                success: false,
+                error: error.localizedDescription,
+                totalTimeMs: totalTimeMs(from: startTime)
+            )
+        }
+    }
+
     // MARK: - Helpers
+
+    private var databaseUnavailableMessage: String {
+        "database inspection unavailable - embed the AutoMobile SDK and call DatabaseInspector.shared.setEnabled(true)"
+    }
 
     private func totalTimeMs(from startTime: Date) -> Int64 {
         return Int64(Date().timeIntervalSince(startTime) * 1000)
@@ -1179,6 +1461,16 @@ public class CommandHandler: CommandHandling {
             return ResponseType.clearPreferencesResult.rawValue
         case RequestType.setNetworkMockRules.rawValue:
             return ResponseType.setNetworkMockRulesResult.rawValue
+        case RequestType.executeSql.rawValue:
+            return ResponseType.executeSqlResult.rawValue
+        case RequestType.listDatabases.rawValue:
+            return ResponseType.listDatabasesResult.rawValue
+        case RequestType.listTables.rawValue:
+            return ResponseType.listTablesResult.rawValue
+        case RequestType.getTableData.rawValue:
+            return ResponseType.tableDataResult.rawValue
+        case RequestType.getTableStructure.rawValue:
+            return ResponseType.tableStructureResult.rawValue
         default:
             return "error"
         }

--- a/ios/control-proxy/Sources/CtrlProxy/CommandHandler.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/CommandHandler.swift
@@ -1204,6 +1204,7 @@ public class CommandHandler: CommandHandling {
         }
 
         do {
+            try validateDatabaseAppId(request)
             let result = try client.executeSQL(databasePath: databasePath, query: query)
             if let error = result.error {
                 return ExecuteSqlResponse(
@@ -1243,6 +1244,7 @@ public class CommandHandler: CommandHandling {
         }
 
         do {
+            try validateDatabaseAppId(request)
             return try ListDatabasesResponse(
                 requestId: request.requestId,
                 success: true,
@@ -1278,6 +1280,7 @@ public class CommandHandler: CommandHandling {
         }
 
         do {
+            try validateDatabaseAppId(request)
             return try ListTablesResponse(
                 requestId: request.requestId,
                 success: true,
@@ -1321,6 +1324,7 @@ public class CommandHandler: CommandHandling {
         }
 
         do {
+            try validateDatabaseAppId(request)
             let data = try client.getTableData(
                 databasePath: databasePath,
                 table: table,
@@ -1372,6 +1376,7 @@ public class CommandHandler: CommandHandling {
         }
 
         do {
+            try validateDatabaseAppId(request)
             let structure = try client.getTableStructure(databasePath: databasePath, table: table)
             return TableStructureResponse(
                 requestId: request.requestId,
@@ -1393,6 +1398,24 @@ public class CommandHandler: CommandHandling {
 
     private var databaseUnavailableMessage: String {
         "database inspection unavailable - embed the AutoMobile SDK and call DatabaseInspector.shared.setEnabled(true)"
+    }
+
+    private func validateDatabaseAppId(_ request: WebSocketRequest) throws {
+        guard let requestedAppId = normalizedBundleId(request.appId) else {
+            throw CommandError.missingParameter("appId")
+        }
+
+        guard let serverAppId = normalizedBundleId(sdkHierarchyClient?.fetchServerInfo()?.bundleId) else {
+            throw CommandError.executionFailed(
+                "\(databaseUnavailableMessage); unable to verify SDK server bundle for requested appId \(requestedAppId)"
+            )
+        }
+
+        guard serverAppId == requestedAppId else {
+            throw CommandError.executionFailed(
+                "SDK server bundle \(serverAppId) does not match requested appId \(requestedAppId)"
+            )
+        }
     }
 
     private func totalTimeMs(from startTime: Date) -> Int64 {

--- a/ios/control-proxy/Sources/CtrlProxy/CommandHandler.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/CommandHandler.swift
@@ -229,10 +229,10 @@ public class CommandHandler: CommandHandling {
         guard let rules = request.rules else {
             throw CommandError.missingParameter("rules")
         }
-        let ok = sdkHierarchyClient?.setMockRules(rules) ?? false
+        let succeeded = sdkHierarchyClient?.setMockRules(rules) ?? false
         return SetNetworkMockRulesResponse(
             requestId: request.requestId,
-            ok: ok,
+            ok: succeeded,
             totalTimeMs: totalTimeMs(from: startTime)
         )
     }
@@ -405,7 +405,9 @@ public class CommandHandler: CommandHandling {
         _ request: WebSocketRequest,
         startTime: Date,
         defaultFingers: Int = 2
-    ) throws -> WebSocketResponse {
+    )
+        throws -> WebSocketResponse
+    {
         guard let x1 = request.x1, let y1 = request.y1,
               let x2 = request.x2, let y2 = request.y2
         else {
@@ -1329,7 +1331,7 @@ public class CommandHandler: CommandHandling {
                 databasePath: databasePath,
                 table: table,
                 limit: request.limit ?? 50,
-                offset: request.offset ?? 0
+                offset: Int(request.offset ?? 0)
             )
             return TableDataResponse(
                 requestId: request.requestId,

--- a/ios/control-proxy/Sources/CtrlProxy/CtrlProxy.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/CtrlProxy.swift
@@ -16,23 +16,30 @@ public class CtrlProxy {
     private let fpsMonitor: DisplayLinkFPSMonitor
     private let sdkHierarchyCache: SdkHierarchyCache
     private let sdkHierarchyClient: SdkHierarchyClient
+    private let sdkDatabaseClient: SdkDatabaseClient
 
     #if canImport(XCTest) && os(iOS)
         private var application: XCUIApplication?
     #endif
 
     /// Creates the service with specified port
-    public init(port: UInt16 = defaultPort, timer: Timer = SystemTimer(), storageInspector: StorageInspecting? = DefaultStorageInspecting()) {
+    public init(
+        port: UInt16 = defaultPort,
+        timer: Timer = SystemTimer(),
+        storageInspector: StorageInspecting? = DefaultStorageInspecting()
+    ) {
         elementLocator = ElementLocator()
         gesturePerformer = GesturePerformer(elementLocator: elementLocator)
         sdkHierarchyCache = SdkHierarchyCache()
         sdkHierarchyClient = SdkHierarchyClient()
+        sdkDatabaseClient = SdkDatabaseClient()
         commandHandler = CommandHandler(
             elementLocator: elementLocator,
             gesturePerformer: gesturePerformer,
             storageInspector: storageInspector,
             sdkHierarchyClient: sdkHierarchyClient,
-            sdkHierarchyCache: sdkHierarchyCache
+            sdkHierarchyCache: sdkHierarchyCache,
+            sdkDatabaseClient: sdkDatabaseClient
         )
         server = WebSocketServer(port: port, commandHandler: commandHandler, sdkHierarchyCache: sdkHierarchyCache)
         hierarchyDebouncer = HierarchyDebouncer(elementLocator: elementLocator, timer: timer)

--- a/ios/control-proxy/Sources/CtrlProxy/Fakes.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/Fakes.swift
@@ -100,7 +100,7 @@ public class FakeElementLocator: ElementLocating {
 
     public private(set) var switchedBundleIds: [String] = []
     public private(set) var awaitStateCalls: [(bundleId: String, expectedState: AppStateExpectation)] = []
-    public var awaitAppStateResult: Bool = true
+    public var awaitAppStateResult = true
     public private(set) var getAppStateCalls: [String] = []
     public var getAppStateResult: ObservedAppState = .notRunning
 
@@ -194,7 +194,7 @@ public class FakeGesturePerformer: GesturePerforming {
     private var typeTextHistory: [String] = []
     private var setTextHistory: [TextCall] = []
     private var clearTextHistory: [String?] = []
-    private var selectAllCallCount: Int = 0
+    private var selectAllCallCount = 0
     private var imeActionHistory: [String] = []
     private var keyboardHistory: [String] = []
     private var keyboardOpen = false
@@ -209,7 +209,7 @@ public class FakeGesturePerformer: GesturePerforming {
     private var appLaunchHistory: [String] = []
     private var appTerminateHistory: [String] = []
     private var clipboardHistory: [(action: String, text: String?)] = []
-    private var clipboardContents: String? = nil
+    private var clipboardContents: String?
 
     public init() {}
 
@@ -571,7 +571,7 @@ public class FakeStorageInspecting: StorageInspecting {
     // MARK: - Configurable State
 
     private var suites: [StorageSuiteInfo] = []
-    private var entries: [String?: [StorageEntry]] = [:]  // keyed by suiteName
+    private var entries: [String?: [StorageEntry]] = [:] // keyed by suiteName
     private var shouldThrow: Error?
 
     // MARK: - Call History
@@ -736,7 +736,7 @@ public class FakeSdkHierarchyFetcher: SdkHierarchyFetching {
     private var _cachedHierarchy: SdkViewHierarchy?
     private var _freshHierarchy: SdkViewHierarchy?
     private var _serverInfo: SdkHierarchyServerInfo?
-    private var _isAvailable: Bool = false
+    private var _isAvailable = false
     private var _fetchCallCount = 0
     private var _fetchFreshCallCount = 0
     private var _fetchServerInfoCallCount = 0
@@ -937,6 +937,70 @@ public class FakeSdkHierarchyCache: SdkHierarchyCaching {
         _latest = nil
         _clearCallCount += 1
         lock.unlock()
+    }
+}
+
+// MARK: - FakeSdkDatabaseFetcher
+
+/// Fake implementation of SdkDatabaseFetching for testing
+public class FakeSdkDatabaseFetcher: SdkDatabaseFetching {
+    public struct TableDataCall {
+        public let databasePath: String
+        public let table: String
+        public let limit: Int
+        public let offset: Int
+    }
+
+    public private(set) var executeSqlCalls: [(databasePath: String, query: String)] = []
+    public private(set) var listDatabasesCallCount = 0
+    public private(set) var listTablesCalls: [String] = []
+    public private(set) var tableDataCalls: [TableDataCall] = []
+    public private(set) var tableStructureCalls: [(databasePath: String, table: String)] = []
+
+    public var executeSqlResult = SdkExecuteSqlResult(queryType: "query", columns: [], rows: [], rowsAffected: 0)
+    public var executeSqlError: Error?
+    public var databases: [SdkDatabaseInfo] = []
+    public var tables: [String] = []
+    public var tableData = SdkTableDataResult(columns: [], rows: [], total: 0)
+    public var tableStructure = SdkTableStructureResult(columns: [])
+
+    public init() {}
+
+    public func executeSQL(databasePath: String, query: String) throws -> SdkExecuteSqlResult {
+        executeSqlCalls.append((databasePath: databasePath, query: query))
+        if let executeSqlError {
+            throw executeSqlError
+        }
+        return executeSqlResult
+    }
+
+    public func listDatabases() throws -> [SdkDatabaseInfo] {
+        listDatabasesCallCount += 1
+        return databases
+    }
+
+    public func listTables(databasePath: String) throws -> [String] {
+        listTablesCalls.append(databasePath)
+        return tables
+    }
+
+    public func getTableData(
+        databasePath: String,
+        table: String,
+        limit: Int,
+        offset: Int
+    )
+        throws -> SdkTableDataResult
+    {
+        tableDataCalls.append(
+            TableDataCall(databasePath: databasePath, table: table, limit: limit, offset: offset)
+        )
+        return tableData
+    }
+
+    public func getTableStructure(databasePath: String, table: String) throws -> SdkTableStructureResult {
+        tableStructureCalls.append((databasePath: databasePath, table: table))
+        return tableStructure
     }
 }
 

--- a/ios/control-proxy/Sources/CtrlProxy/Models.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/Models.swift
@@ -57,10 +57,16 @@ public struct WebSocketRequest: Codable {
     public let value: String?
     public let valueType: String?
 
-    // App launch parameters
+    // Database parameters
+    public let databasePath: String?
+    public let query: String?
+    public let table: String?
+    public let limit: Int?
+
+    /// App launch parameters
     public let coldBoot: Bool?
 
-    // Rotation parameters
+    /// Rotation parameters
     public let orientation: String?
 
     // Permission/settings
@@ -105,6 +111,10 @@ public struct WebSocketRequest: Codable {
         key: String? = nil,
         value: String? = nil,
         valueType: String? = nil,
+        databasePath: String? = nil,
+        query: String? = nil,
+        table: String? = nil,
+        limit: Int? = nil,
         coldBoot: Bool? = nil,
         orientation: String? = nil,
         permission: String? = nil,
@@ -145,6 +155,10 @@ public struct WebSocketRequest: Codable {
         self.key = key
         self.value = value
         self.valueType = valueType
+        self.databasePath = databasePath
+        self.query = query
+        self.table = table
+        self.limit = limit
         self.coldBoot = coldBoot
         self.orientation = orientation
         self.permission = permission
@@ -298,8 +312,8 @@ public struct RotateResponse: Codable {
         rotationPerformed: Bool,
         error: String? = nil
     ) {
-        self.type = ResponseType.rotateResult.rawValue
-        self.timestamp = Int64(Date().timeIntervalSince1970 * 1000)
+        type = ResponseType.rotateResult.rawValue
+        timestamp = Int64(Date().timeIntervalSince1970 * 1000)
         self.requestId = requestId
         self.success = success
         self.totalTimeMs = totalTimeMs
@@ -328,8 +342,8 @@ public struct KeyboardResponse: Codable {
         totalTimeMs: Int64,
         error: String? = nil
     ) {
-        self.type = ResponseType.keyboardResult.rawValue
-        self.timestamp = Int64(Date().timeIntervalSince1970 * 1000)
+        type = ResponseType.keyboardResult.rawValue
+        timestamp = Int64(Date().timeIntervalSince1970 * 1000)
         self.requestId = requestId
         self.success = success
         self.open = open
@@ -734,8 +748,8 @@ public struct StorageFilesResponse: Codable {
         error: String? = nil,
         totalTimeMs: Int64? = nil
     ) {
-        self.type = ResponseType.preferenceFiles.rawValue
-        self.timestamp = Int64(Date().timeIntervalSince1970 * 1000)
+        type = ResponseType.preferenceFiles.rawValue
+        timestamp = Int64(Date().timeIntervalSince1970 * 1000)
         self.requestId = requestId
         self.success = success
         self.files = files
@@ -761,8 +775,8 @@ public struct StorageEntriesResponse: Codable {
         error: String? = nil,
         totalTimeMs: Int64? = nil
     ) {
-        self.type = ResponseType.preferences.rawValue
-        self.timestamp = Int64(Date().timeIntervalSince1970 * 1000)
+        type = ResponseType.preferences.rawValue
+        timestamp = Int64(Date().timeIntervalSince1970 * 1000)
         self.requestId = requestId
         self.success = success
         self.entries = entries
@@ -794,14 +808,161 @@ public struct StorageEntryResponse: Codable {
         error: String? = nil,
         totalTimeMs: Int64? = nil
     ) {
-        self.type = ResponseType.getPreferenceResult.rawValue
-        self.timestamp = Int64(Date().timeIntervalSince1970 * 1000)
+        type = ResponseType.getPreferenceResult.rawValue
+        timestamp = Int64(Date().timeIntervalSince1970 * 1000)
         self.requestId = requestId
         self.success = success
         self.found = found
         self.key = key
         self.value = value
         self.valueType = valueType
+        self.error = error
+        self.totalTimeMs = totalTimeMs
+    }
+}
+
+// MARK: - Database Response Models
+
+public struct ExecuteSqlResponse: Codable {
+    public let type: String
+    public let timestamp: Int64
+    public let requestId: String?
+    public let success: Bool
+    public let queryType: String?
+    public let columns: [String]?
+    public let rows: [[String?]]?
+    public let rowsAffected: Int?
+    public let error: String?
+    public let totalTimeMs: Int64?
+
+    public init(
+        requestId: String?,
+        success: Bool,
+        queryType: String? = nil,
+        columns: [String]? = nil,
+        rows: [[String?]]? = nil,
+        rowsAffected: Int? = nil,
+        error: String? = nil,
+        totalTimeMs: Int64? = nil
+    ) {
+        type = ResponseType.executeSqlResult.rawValue
+        timestamp = Int64(Date().timeIntervalSince1970 * 1000)
+        self.requestId = requestId
+        self.success = success
+        self.queryType = queryType
+        self.columns = columns
+        self.rows = rows
+        self.rowsAffected = rowsAffected
+        self.error = error
+        self.totalTimeMs = totalTimeMs
+    }
+}
+
+public struct ListDatabasesResponse: Codable {
+    public let type: String
+    public let timestamp: Int64
+    public let requestId: String?
+    public let success: Bool
+    public let databases: [SdkDatabaseInfo]?
+    public let error: String?
+    public let totalTimeMs: Int64?
+
+    public init(
+        requestId: String?,
+        success: Bool,
+        databases: [SdkDatabaseInfo]? = nil,
+        error: String? = nil,
+        totalTimeMs: Int64? = nil
+    ) {
+        type = ResponseType.listDatabasesResult.rawValue
+        timestamp = Int64(Date().timeIntervalSince1970 * 1000)
+        self.requestId = requestId
+        self.success = success
+        self.databases = databases
+        self.error = error
+        self.totalTimeMs = totalTimeMs
+    }
+}
+
+public struct ListTablesResponse: Codable {
+    public let type: String
+    public let timestamp: Int64
+    public let requestId: String?
+    public let success: Bool
+    public let tables: [String]?
+    public let error: String?
+    public let totalTimeMs: Int64?
+
+    public init(
+        requestId: String?,
+        success: Bool,
+        tables: [String]? = nil,
+        error: String? = nil,
+        totalTimeMs: Int64? = nil
+    ) {
+        type = ResponseType.listTablesResult.rawValue
+        timestamp = Int64(Date().timeIntervalSince1970 * 1000)
+        self.requestId = requestId
+        self.success = success
+        self.tables = tables
+        self.error = error
+        self.totalTimeMs = totalTimeMs
+    }
+}
+
+public struct TableDataResponse: Codable {
+    public let type: String
+    public let timestamp: Int64
+    public let requestId: String?
+    public let success: Bool
+    public let columns: [String]?
+    public let rows: [[String?]]?
+    public let total: Int?
+    public let error: String?
+    public let totalTimeMs: Int64?
+
+    public init(
+        requestId: String?,
+        success: Bool,
+        columns: [String]? = nil,
+        rows: [[String?]]? = nil,
+        total: Int? = nil,
+        error: String? = nil,
+        totalTimeMs: Int64? = nil
+    ) {
+        type = ResponseType.tableDataResult.rawValue
+        timestamp = Int64(Date().timeIntervalSince1970 * 1000)
+        self.requestId = requestId
+        self.success = success
+        self.columns = columns
+        self.rows = rows
+        self.total = total
+        self.error = error
+        self.totalTimeMs = totalTimeMs
+    }
+}
+
+public struct TableStructureResponse: Codable {
+    public let type: String
+    public let timestamp: Int64
+    public let requestId: String?
+    public let success: Bool
+    public let columns: [SdkColumnInfo]?
+    public let error: String?
+    public let totalTimeMs: Int64?
+
+    public init(
+        requestId: String?,
+        success: Bool,
+        columns: [SdkColumnInfo]? = nil,
+        error: String? = nil,
+        totalTimeMs: Int64? = nil
+    ) {
+        type = ResponseType.tableStructureResult.rawValue
+        timestamp = Int64(Date().timeIntervalSince1970 * 1000)
+        self.requestId = requestId
+        self.success = success
+        self.columns = columns
         self.error = error
         self.totalTimeMs = totalTimeMs
     }
@@ -889,7 +1050,7 @@ public enum RequestType: String, CaseIterable {
     case requestAction = "request_action"
     case requestLaunchApp = "request_launch_app"
 
-    // Device control
+    /// Device control
     case requestRotate = "request_rotate"
 
     /// Clipboard
@@ -911,6 +1072,13 @@ public enum RequestType: String, CaseIterable {
 
     // Network mocking
     case setNetworkMockRules = "set_network_mock_rules"
+
+    // Database inspection
+    case executeSql = "execute_sql"
+    case listDatabases = "list_databases"
+    case listTables = "list_tables"
+    case getTableData = "get_table_data"
+    case getTableStructure = "get_table_structure"
 }
 
 // MARK: - Response Types (matching Android)
@@ -952,4 +1120,11 @@ public enum ResponseType: String {
     case removePreferenceResult = "remove_preference_result"
     case clearPreferencesResult = "clear_preferences_result"
     case setNetworkMockRulesResult = "set_network_mock_rules_result"
+
+    // Database inspection
+    case executeSqlResult = "execute_sql_result"
+    case listDatabasesResult = "list_databases_result"
+    case listTablesResult = "list_tables_result"
+    case tableDataResult = "table_data_result"
+    case tableStructureResult = "table_structure_result"
 }

--- a/ios/control-proxy/Sources/CtrlProxy/Models.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/Models.swift
@@ -58,6 +58,7 @@ public struct WebSocketRequest: Codable {
     public let valueType: String?
 
     // Database parameters
+    public let appId: String?
     public let databasePath: String?
     public let query: String?
     public let table: String?
@@ -74,7 +75,7 @@ public struct WebSocketRequest: Codable {
     public let requestPermission: Bool?
     public let enabled: Bool?
 
-    // Network mocking
+    /// Network mocking
     public let rules: [NetworkMockRuleDTO]?
 
     public init(
@@ -111,6 +112,7 @@ public struct WebSocketRequest: Codable {
         key: String? = nil,
         value: String? = nil,
         valueType: String? = nil,
+        appId: String? = nil,
         databasePath: String? = nil,
         query: String? = nil,
         table: String? = nil,
@@ -155,6 +157,7 @@ public struct WebSocketRequest: Codable {
         self.key = key
         self.value = value
         self.valueType = valueType
+        self.appId = appId
         self.databasePath = databasePath
         self.query = query
         self.table = table
@@ -164,7 +167,7 @@ public struct WebSocketRequest: Codable {
         self.permission = permission
         self.requestPermission = requestPermission
         self.enabled = enabled
-        self.rules = networkMockRules
+        rules = networkMockRules
     }
 }
 
@@ -1070,7 +1073,7 @@ public enum RequestType: String, CaseIterable {
     case removePreference = "remove_preference"
     case clearPreferences = "clear_preferences"
 
-    // Network mocking
+    /// Network mocking
     case setNetworkMockRules = "set_network_mock_rules"
 
     // Database inspection

--- a/ios/control-proxy/Sources/CtrlProxy/Protocols.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/Protocols.swift
@@ -256,3 +256,14 @@ public protocol SdkHierarchyCaching {
     /// Clear the cached hierarchy.
     func clear()
 }
+
+// MARK: - SDK Database Protocols
+
+/// Protocol for relaying SQLite database inspection requests to the target app SDK.
+public protocol SdkDatabaseFetching {
+    func executeSQL(databasePath: String, query: String) throws -> SdkExecuteSqlResult
+    func listDatabases() throws -> [SdkDatabaseInfo]
+    func listTables(databasePath: String) throws -> [String]
+    func getTableData(databasePath: String, table: String, limit: Int, offset: Int) throws -> SdkTableDataResult
+    func getTableStructure(databasePath: String, table: String) throws -> SdkTableStructureResult
+}

--- a/ios/control-proxy/Sources/CtrlProxy/SdkDatabaseClient.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/SdkDatabaseClient.swift
@@ -1,0 +1,205 @@
+import Foundation
+
+public enum SdkDatabaseError: Error, LocalizedError {
+    case unavailable(String)
+    case badResponse(String)
+
+    public var errorDescription: String? {
+        switch self {
+        case let .unavailable(message):
+            return message
+        case let .badResponse(message):
+            return message
+        }
+    }
+}
+
+public struct SdkDatabaseInfo: Codable, Equatable {
+    public let name: String
+    public let path: String
+    public let sizeBytes: Int64?
+
+    public init(name: String, path: String, sizeBytes: Int64? = nil) {
+        self.name = name
+        self.path = path
+        self.sizeBytes = sizeBytes
+    }
+}
+
+public struct SdkColumnInfo: Codable, Equatable {
+    public let name: String
+    public let type: String
+    public let nullable: Bool
+    public let primaryKey: Bool
+    public let defaultValue: String?
+
+    public init(name: String, type: String, nullable: Bool, primaryKey: Bool, defaultValue: String?) {
+        self.name = name
+        self.type = type
+        self.nullable = nullable
+        self.primaryKey = primaryKey
+        self.defaultValue = defaultValue
+    }
+}
+
+public struct SdkExecuteSqlResult: Codable, Equatable {
+    public let queryType: String
+    public let columns: [String]?
+    public let rows: [[String?]]?
+    public let rowsAffected: Int
+    public let error: String?
+
+    public init(
+        queryType: String,
+        columns: [String]? = nil,
+        rows: [[String?]]? = nil,
+        rowsAffected: Int,
+        error: String? = nil
+    ) {
+        self.queryType = queryType
+        self.columns = columns
+        self.rows = rows
+        self.rowsAffected = rowsAffected
+        self.error = error
+    }
+}
+
+public struct SdkTableDataResult: Codable, Equatable {
+    public let columns: [String]
+    public let rows: [[String?]]
+    public let total: Int
+
+    public init(columns: [String], rows: [[String?]], total: Int) {
+        self.columns = columns
+        self.rows = rows
+        self.total = total
+    }
+}
+
+public struct SdkTableStructureResult: Codable, Equatable {
+    public let columns: [SdkColumnInfo]
+
+    public init(columns: [SdkColumnInfo]) {
+        self.columns = columns
+    }
+}
+
+private struct SdkDatabaseErrorPayload: Codable {
+    let error: String
+}
+
+private struct ExecuteSqlRequest: Codable {
+    let databasePath: String
+    let query: String
+}
+
+private struct DatabasePathRequest: Codable {
+    let databasePath: String
+}
+
+private struct TableDataRequest: Codable {
+    let databasePath: String
+    let table: String
+    let limit: Int
+    let offset: Int
+}
+
+private struct TableStructureRequest: Codable {
+    let databasePath: String
+    let table: String
+}
+
+private struct ListDatabasesPayload: Codable {
+    let databases: [SdkDatabaseInfo]
+}
+
+private struct ListTablesPayload: Codable {
+    let tables: [String]
+}
+
+public final class SdkDatabaseClient: SdkDatabaseFetching, @unchecked Sendable {
+    private let baseURL: URL
+    private let urlSession: URLSession
+
+    public init(port: UInt16 = 8766) {
+        self.baseURL = URL(string: "http://localhost:\(port)")!
+        let config = URLSessionConfiguration.default
+        config.timeoutIntervalForRequest = 2
+        config.timeoutIntervalForResource = 5
+        config.waitsForConnectivity = false
+        self.urlSession = URLSession(configuration: config)
+    }
+
+    public func executeSQL(databasePath: String, query: String) throws -> SdkExecuteSqlResult {
+        try post(path: "/db/execute", body: ExecuteSqlRequest(databasePath: databasePath, query: query))
+    }
+
+    public func listDatabases() throws -> [SdkDatabaseInfo] {
+        let payload: ListDatabasesPayload = try post(path: "/db/list", body: EmptyRequest())
+        return payload.databases
+    }
+
+    public func listTables(databasePath: String) throws -> [String] {
+        let payload: ListTablesPayload = try post(path: "/db/tables", body: DatabasePathRequest(databasePath: databasePath))
+        return payload.tables
+    }
+
+    public func getTableData(databasePath: String, table: String, limit: Int, offset: Int) throws -> SdkTableDataResult {
+        try post(
+            path: "/db/table-data",
+            body: TableDataRequest(databasePath: databasePath, table: table, limit: limit, offset: offset)
+        )
+    }
+
+    public func getTableStructure(databasePath: String, table: String) throws -> SdkTableStructureResult {
+        try post(path: "/db/table-structure", body: TableStructureRequest(databasePath: databasePath, table: table))
+    }
+
+    private func post<RequestBody: Encodable, ResponseBody: Decodable>(
+        path: String,
+        body: RequestBody
+    ) throws -> ResponseBody {
+        let data = try requestSync(path: path, body: JSONEncoder().encode(body))
+        return try JSONDecoder().decode(ResponseBody.self, from: data)
+    }
+
+    private func requestSync(path: String, body: Data) throws -> Data {
+        let url = baseURL.appendingPathComponent(path)
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.httpBody = body
+
+        let semaphore = DispatchSemaphore(value: 0)
+        var result: Result<Data, Error> = .failure(SdkDatabaseError.unavailable(Self.unavailableMessage))
+
+        urlSession.dataTask(with: request) { data, response, error in
+            defer { semaphore.signal() }
+            if let error {
+                result = .failure(SdkDatabaseError.unavailable("\(Self.unavailableMessage): \(error.localizedDescription)"))
+                return
+            }
+
+            guard let http = response as? HTTPURLResponse else {
+                result = .failure(SdkDatabaseError.badResponse("database inspection returned a non-HTTP response"))
+                return
+            }
+
+            guard (200..<300).contains(http.statusCode), let data else {
+                let message = data.flatMap { try? JSONDecoder().decode(SdkDatabaseErrorPayload.self, from: $0).error }
+                    ?? "HTTP \(http.statusCode)"
+                result = .failure(SdkDatabaseError.unavailable("\(Self.unavailableMessage): \(message)"))
+                return
+            }
+
+            result = .success(data)
+        }.resume()
+
+        semaphore.wait()
+        return try result.get()
+    }
+
+    private static let unavailableMessage = "database inspection unavailable - embed the AutoMobile SDK and call DatabaseInspector.shared.setEnabled(true)"
+}
+
+private struct EmptyRequest: Codable {}

--- a/ios/control-proxy/Tests/CtrlProxyTests/CommandHandlerTests.swift
+++ b/ios/control-proxy/Tests/CtrlProxyTests/CommandHandlerTests.swift
@@ -1953,6 +1953,7 @@ final class DatabaseCommandHandlerTests: XCTestCase {
     var perfProvider: PerfProvider!
     var fakeElementLocator: FakeElementLocator!
     var fakeGesturePerformer: FakeGesturePerformer!
+    var fakeSdkHierarchy: FakeSdkHierarchyFetcher!
     var fakeDatabase: FakeSdkDatabaseFetcher!
     var commandHandler: CommandHandler!
 
@@ -1962,11 +1963,14 @@ final class DatabaseCommandHandlerTests: XCTestCase {
         perfProvider = PerfProvider.createForTesting(timeProvider: fakeTimeProvider)
         fakeElementLocator = FakeElementLocator()
         fakeGesturePerformer = FakeGesturePerformer()
+        fakeSdkHierarchy = FakeSdkHierarchyFetcher()
+        fakeSdkHierarchy.setServerInfo(SdkHierarchyServerInfo(status: "ok", bundleId: "com.example.app"))
         fakeDatabase = FakeSdkDatabaseFetcher()
         commandHandler = CommandHandler.createForTesting(
             elementLocator: fakeElementLocator,
             gesturePerformer: fakeGesturePerformer,
             perfProvider: perfProvider,
+            sdkHierarchyClient: fakeSdkHierarchy,
             sdkDatabaseClient: fakeDatabase
         )
     }
@@ -2004,6 +2008,7 @@ final class DatabaseCommandHandlerTests: XCTestCase {
         let request = WebSocketRequest(
             type: "execute_sql",
             requestId: "sql-1",
+            appId: "com.example.app",
             databasePath: "/app/Documents/app.db",
             query: "SELECT id, payload FROM notes"
         )
@@ -2030,6 +2035,7 @@ final class DatabaseCommandHandlerTests: XCTestCase {
         let request = WebSocketRequest(
             type: "execute_sql",
             requestId: "sql-disabled",
+            appId: "com.example.app",
             databasePath: "/app/Documents/app.db",
             query: "SELECT 1"
         )
@@ -2038,5 +2044,23 @@ final class DatabaseCommandHandlerTests: XCTestCase {
 
         XCTAssertFalse(response.success)
         XCTAssertTrue(response.error?.contains("setEnabled(true)") ?? false)
+    }
+
+    func testExecuteSqlRejectsSdkServerBundleMismatchBeforeDatabaseCall() {
+        fakeSdkHierarchy.setServerInfo(SdkHierarchyServerInfo(status: "ok", bundleId: "com.other.app"))
+
+        let request = WebSocketRequest(
+            type: "execute_sql",
+            requestId: "sql-mismatch",
+            appId: "com.example.app",
+            databasePath: "/app/Documents/app.db",
+            query: "SELECT 1"
+        )
+
+        guard let response = handleRequest(request, as: ExecuteSqlResponse.self) else { return }
+
+        XCTAssertFalse(response.success)
+        XCTAssertTrue(response.error?.contains("does not match requested appId") ?? false)
+        XCTAssertEqual(fakeDatabase.executeSqlCalls.count, 0)
     }
 }

--- a/ios/control-proxy/Tests/CtrlProxyTests/CommandHandlerTests.swift
+++ b/ios/control-proxy/Tests/CtrlProxyTests/CommandHandlerTests.swift
@@ -32,7 +32,9 @@ final class CommandHandlerTests: XCTestCase {
         as _: T.Type = T.self,
         file: StaticString = #file,
         line: UInt = #line
-    ) -> T? {
+    )
+        -> T?
+    {
         let response = commandHandler.handle(request)
         guard let typed = response as? T else {
             XCTFail("Expected \(T.self), got \(Swift.type(of: response))", file: file, line: line)
@@ -84,7 +86,7 @@ final class CommandHandlerTests: XCTestCase {
                         bounds: SdkBounds(left: 16, top: 740, right: 110, bottom: 770),
                         accessibilityLabel: "Discover",
                         isAccessibilityElement: true
-                    )
+                    ),
                 ]
             )
         )
@@ -288,7 +290,8 @@ final class CommandHandlerTests: XCTestCase {
             sdkHierarchyCache: cache
         )
 
-        let enriched = commandHandler.enrichWithMatchingSdkHierarchy(makeHierarchy(packageName: "com.apple.Preferences"))
+        let enriched = commandHandler
+            .enrichWithMatchingSdkHierarchy(makeHierarchy(packageName: "com.apple.Preferences"))
 
         XCTAssertEqual(enriched.packageName, "com.apple.Preferences")
         XCTAssertEqual(countClassName("UITabBarButtonLabel", in: enriched.hierarchy), 0)
@@ -1051,7 +1054,10 @@ final class CommandHandlerTests: XCTestCase {
         XCTAssertEqual(perfTimings.count, 1)
         XCTAssertEqual(perfTimings[0].name, "handleLaunchApp")
         let childNames = perfTimings[0].children?.map { $0.name } ?? []
-        XCTAssertEqual(childNames, ["checkAppState", "launchApp", "switchForegroundApp", "updateApplication", "awaitForeground"])
+        XCTAssertEqual(
+            childNames,
+            ["checkAppState", "launchApp", "switchForegroundApp", "updateApplication", "awaitForeground"]
+        )
     }
 
     func testLaunchAppUsesActivateWhenRunningBackground() {
@@ -1074,7 +1080,10 @@ final class CommandHandlerTests: XCTestCase {
             return
         }
         let childNames = perfTimings[0].children?.map { $0.name } ?? []
-        XCTAssertEqual(childNames, ["checkAppState", "activateApp", "switchForegroundApp", "updateApplication", "awaitForeground"])
+        XCTAssertEqual(
+            childNames,
+            ["checkAppState", "activateApp", "switchForegroundApp", "updateApplication", "awaitForeground"]
+        )
     }
 
     func testLaunchAppUsesActivateWhenRunningForeground() {
@@ -1122,7 +1131,17 @@ final class CommandHandlerTests: XCTestCase {
             return
         }
         let childNames = perfTimings[0].children?.map { $0.name } ?? []
-        XCTAssertEqual(childNames, ["checkAppState", "terminateApp", "launchApp", "switchForegroundApp", "updateApplication", "awaitForeground"])
+        XCTAssertEqual(
+            childNames,
+            [
+                "checkAppState",
+                "terminateApp",
+                "launchApp",
+                "switchForegroundApp",
+                "updateApplication",
+                "awaitForeground",
+            ]
+        )
     }
 
     func testLaunchAppColdBootNotRunningSkipsTerminate() {
@@ -1690,7 +1709,9 @@ final class StorageCommandHandlerTests: XCTestCase {
         as _: T.Type = T.self,
         file: StaticString = #file,
         line: UInt = #line
-    ) -> T? {
+    )
+        -> T?
+    {
         handleRequest(commandHandler, request, as: T.self, file: file, line: line)
     }
 
@@ -1700,7 +1721,9 @@ final class StorageCommandHandlerTests: XCTestCase {
         as _: T.Type = T.self,
         file: StaticString = #file,
         line: UInt = #line
-    ) -> T? {
+    )
+        -> T?
+    {
         let response = handler.handle(request)
         guard let typed = response as? T else {
             XCTFail("Expected \(T.self), got \(Swift.type(of: response))", file: file, line: line)
@@ -1711,7 +1734,7 @@ final class StorageCommandHandlerTests: XCTestCase {
 
     // MARK: - List Preference Files
 
-    func testListPreferenceFilesReturnsSuites() throws {
+    func testListPreferenceFilesReturnsSuites() {
         fakeStorage.setSuites([
             StorageSuiteInfo(name: "Standard", displayName: "Standard", entryCount: 5),
             StorageSuiteInfo(name: "group.com.example", displayName: "group.com.example", entryCount: 3),
@@ -1772,7 +1795,7 @@ final class StorageCommandHandlerTests: XCTestCase {
             requestId: "get-std",
             fileName: "Standard"
         )
-        let _ = commandHandler.handle(request)
+        _ = commandHandler.handle(request)
         XCTAssertEqual(fakeStorage.getEntriesHistory, [nil])
     }
 
@@ -1897,7 +1920,8 @@ final class StorageCommandHandlerTests: XCTestCase {
         )
 
         let request = WebSocketRequest(type: "list_preference_files", requestId: "nil-1")
-        guard let filesResponse = handleRequest(handlerNoStorage, request, as: StorageFilesResponse.self) else { return }
+        guard let filesResponse = handleRequest(handlerNoStorage, request, as: StorageFilesResponse.self)
+        else { return }
 
         XCTAssertFalse(filesResponse.success)
         XCTAssertTrue(filesResponse.error?.contains("not available") ?? false)
@@ -1919,5 +1943,100 @@ final class StorageCommandHandlerTests: XCTestCase {
 
         XCTAssertFalse(wsResponse.success ?? true)
         XCTAssertTrue(wsResponse.error?.contains("parse") ?? false)
+    }
+}
+
+// MARK: - Database Command Tests
+
+final class DatabaseCommandHandlerTests: XCTestCase {
+    var fakeTimeProvider: FakeTimeProvider!
+    var perfProvider: PerfProvider!
+    var fakeElementLocator: FakeElementLocator!
+    var fakeGesturePerformer: FakeGesturePerformer!
+    var fakeDatabase: FakeSdkDatabaseFetcher!
+    var commandHandler: CommandHandler!
+
+    override func setUp() {
+        super.setUp()
+        fakeTimeProvider = FakeTimeProvider(initialTime: 1000)
+        perfProvider = PerfProvider.createForTesting(timeProvider: fakeTimeProvider)
+        fakeElementLocator = FakeElementLocator()
+        fakeGesturePerformer = FakeGesturePerformer()
+        fakeDatabase = FakeSdkDatabaseFetcher()
+        commandHandler = CommandHandler.createForTesting(
+            elementLocator: fakeElementLocator,
+            gesturePerformer: fakeGesturePerformer,
+            perfProvider: perfProvider,
+            sdkDatabaseClient: fakeDatabase
+        )
+    }
+
+    override func tearDown() {
+        perfProvider.clear()
+        PerfProvider.resetInstance()
+        super.tearDown()
+    }
+
+    private func handleRequest<T>(
+        _ request: WebSocketRequest,
+        as _: T.Type = T.self,
+        file: StaticString = #file,
+        line: UInt = #line
+    )
+        -> T?
+    {
+        let response = commandHandler.handle(request)
+        guard let typed = response as? T else {
+            XCTFail("Expected \(T.self), got \(Swift.type(of: response))", file: file, line: line)
+            return nil
+        }
+        return typed
+    }
+
+    func testExecuteSqlRelaysQueryToSdkDatabaseClient() {
+        fakeDatabase.executeSqlResult = SdkExecuteSqlResult(
+            queryType: "query",
+            columns: ["id", "payload"],
+            rows: [["1", "0xCAFE"]],
+            rowsAffected: 0
+        )
+
+        let request = WebSocketRequest(
+            type: "execute_sql",
+            requestId: "sql-1",
+            databasePath: "/app/Documents/app.db",
+            query: "SELECT id, payload FROM notes"
+        )
+
+        guard let response = handleRequest(request, as: ExecuteSqlResponse.self) else { return }
+
+        XCTAssertTrue(response.success)
+        XCTAssertEqual(response.type, "execute_sql_result")
+        XCTAssertEqual(response.requestId, "sql-1")
+        XCTAssertEqual(response.queryType, "query")
+        XCTAssertEqual(response.columns, ["id", "payload"])
+        XCTAssertEqual(response.rows, [["1", "0xCAFE"]])
+        XCTAssertEqual(fakeDatabase.executeSqlCalls.count, 1)
+        XCTAssertEqual(fakeDatabase.executeSqlCalls[0].databasePath, "/app/Documents/app.db")
+        XCTAssertEqual(fakeDatabase.executeSqlCalls[0].query, "SELECT id, payload FROM notes")
+    }
+
+    func testExecuteSqlReturnsActionableErrorWhenSdkDatabaseUnavailable() {
+        fakeDatabase.executeSqlError = SdkDatabaseError
+            .unavailable(
+                "database inspection unavailable - embed the AutoMobile SDK and call DatabaseInspector.shared.setEnabled(true)"
+            )
+
+        let request = WebSocketRequest(
+            type: "execute_sql",
+            requestId: "sql-disabled",
+            databasePath: "/app/Documents/app.db",
+            query: "SELECT 1"
+        )
+
+        guard let response = handleRequest(request, as: ExecuteSqlResponse.self) else { return }
+
+        XCTAssertFalse(response.success)
+        XCTAssertTrue(response.error?.contains("setEnabled(true)") ?? false)
     }
 }

--- a/src/features/observe/ios/CtrlProxyDatabase.ts
+++ b/src/features/observe/ios/CtrlProxyDatabase.ts
@@ -48,11 +48,11 @@ interface TableStructureResponseResult extends DatabaseResultBase {
 export class CtrlProxyDatabase {
   constructor(private readonly context: DelegateContext) {}
 
-  async executeSQL(databasePath: string, query: string, timeoutMs: number = 5000): Promise<SQLResult> {
+  async executeSQL(appId: string, databasePath: string, query: string, timeoutMs: number = 5000): Promise<SQLResult> {
     const result = await this.request<ExecuteSqlResult>(
       "execute_sql",
       "execute_sql_result",
-      { databasePath, query },
+      { appId, databasePath, query },
       timeoutMs,
       "Execute SQL"
     );
@@ -66,22 +66,22 @@ export class CtrlProxyDatabase {
       };
   }
 
-  async listDatabases(timeoutMs: number = 5000): Promise<DatabaseInfo[]> {
+  async listDatabases(appId: string, timeoutMs: number = 5000): Promise<DatabaseInfo[]> {
     const result = await this.request<ListDatabasesResult>(
       "list_databases",
       "list_databases_result",
-      {},
+      { appId },
       timeoutMs,
       "List databases"
     );
     return result.databases ?? [];
   }
 
-  async listTables(databasePath: string, timeoutMs: number = 5000): Promise<string[]> {
+  async listTables(appId: string, databasePath: string, timeoutMs: number = 5000): Promise<string[]> {
     const result = await this.request<ListTablesResult>(
       "list_tables",
       "list_tables_result",
-      { databasePath },
+      { appId, databasePath },
       timeoutMs,
       "List tables"
     );
@@ -89,6 +89,7 @@ export class CtrlProxyDatabase {
   }
 
   async getTableData(
+    appId: string,
     databasePath: string,
     table: string,
     limit: number = 50,
@@ -98,7 +99,7 @@ export class CtrlProxyDatabase {
     const result = await this.request<TableDataResponseResult>(
       "get_table_data",
       "table_data_result",
-      { databasePath, table, limit, offset },
+      { appId, databasePath, table, limit, offset },
       timeoutMs,
       "Get table data"
     );
@@ -110,6 +111,7 @@ export class CtrlProxyDatabase {
   }
 
   async getTableStructure(
+    appId: string,
     databasePath: string,
     table: string,
     timeoutMs: number = 5000
@@ -117,7 +119,7 @@ export class CtrlProxyDatabase {
     const result = await this.request<TableStructureResponseResult>(
       "get_table_structure",
       "table_structure_result",
-      { databasePath, table },
+      { appId, databasePath, table },
       timeoutMs,
       "Get table structure"
     );

--- a/src/features/observe/ios/CtrlProxyDatabase.ts
+++ b/src/features/observe/ios/CtrlProxyDatabase.ts
@@ -1,0 +1,165 @@
+/**
+ * CtrlProxy iOS Database - Delegate for SQLite database inspection operations.
+ *
+ * Requests are relayed through CtrlProxy to the target app's in-app SDK server,
+ * so SQLite access happens inside the app process.
+ */
+
+import { logger } from "../../../utils/logger";
+import type {
+  DatabaseInfo,
+  SQLResult,
+  TableDataResult,
+  TableStructureResult,
+} from "../../database/DatabaseInspector";
+import type { DelegateContext } from "./types";
+
+interface DatabaseResultBase {
+  success: boolean;
+  totalTimeMs: number;
+  error?: string;
+}
+
+interface ExecuteSqlResult extends DatabaseResultBase {
+  queryType?: "query" | "mutation";
+  columns?: string[];
+  rows?: unknown[][];
+  rowsAffected?: number;
+}
+
+interface ListDatabasesResult extends DatabaseResultBase {
+  databases?: DatabaseInfo[];
+}
+
+interface ListTablesResult extends DatabaseResultBase {
+  tables?: string[];
+}
+
+interface TableDataResponseResult extends DatabaseResultBase {
+  columns?: string[];
+  rows?: unknown[][];
+  total?: number;
+}
+
+interface TableStructureResponseResult extends DatabaseResultBase {
+  columns?: TableStructureResult["columns"];
+}
+
+export class CtrlProxyDatabase {
+  constructor(private readonly context: DelegateContext) {}
+
+  async executeSQL(databasePath: string, query: string, timeoutMs: number = 5000): Promise<SQLResult> {
+    const result = await this.request<ExecuteSqlResult>(
+      "execute_sql",
+      "execute_sql_result",
+      { databasePath, query },
+      timeoutMs,
+      "Execute SQL"
+    );
+
+    return result.queryType === "mutation"
+      ? { type: "mutation", rowsAffected: result.rowsAffected ?? 0 }
+      : {
+        type: "query",
+        columns: result.columns ?? [],
+        rows: result.rows ?? [],
+      };
+  }
+
+  async listDatabases(timeoutMs: number = 5000): Promise<DatabaseInfo[]> {
+    const result = await this.request<ListDatabasesResult>(
+      "list_databases",
+      "list_databases_result",
+      {},
+      timeoutMs,
+      "List databases"
+    );
+    return result.databases ?? [];
+  }
+
+  async listTables(databasePath: string, timeoutMs: number = 5000): Promise<string[]> {
+    const result = await this.request<ListTablesResult>(
+      "list_tables",
+      "list_tables_result",
+      { databasePath },
+      timeoutMs,
+      "List tables"
+    );
+    return result.tables ?? [];
+  }
+
+  async getTableData(
+    databasePath: string,
+    table: string,
+    limit: number = 50,
+    offset: number = 0,
+    timeoutMs: number = 5000
+  ): Promise<TableDataResult> {
+    const result = await this.request<TableDataResponseResult>(
+      "get_table_data",
+      "table_data_result",
+      { databasePath, table, limit, offset },
+      timeoutMs,
+      "Get table data"
+    );
+    return {
+      columns: result.columns ?? [],
+      rows: result.rows ?? [],
+      total: result.total ?? 0,
+    };
+  }
+
+  async getTableStructure(
+    databasePath: string,
+    table: string,
+    timeoutMs: number = 5000
+  ): Promise<TableStructureResult> {
+    const result = await this.request<TableStructureResponseResult>(
+      "get_table_structure",
+      "table_structure_result",
+      { databasePath, table },
+      timeoutMs,
+      "Get table structure"
+    );
+    return { columns: result.columns ?? [] };
+  }
+
+  private async request<T extends DatabaseResultBase>(
+    type: string,
+    responseType: string,
+    payload: Record<string, unknown>,
+    timeoutMs: number,
+    operationName: string
+  ): Promise<T> {
+    const startTime = this.context.timer.now();
+
+    if (!await this.context.ensureConnected()) {
+      throw new Error("Failed to connect to CtrlProxy");
+    }
+
+    const requestId = this.context.requestManager.generateId(type);
+    const promise = this.context.requestManager.register<T>(
+      requestId,
+      responseType,
+      timeoutMs,
+      (_id, _type, _timeout) => ({
+        success: false,
+        totalTimeMs: this.context.timer.now() - startTime,
+        error: `${operationName} timeout after ${timeoutMs}ms`,
+      } as T)
+    );
+
+    this.context.getWebSocket()?.send(JSON.stringify({
+      type,
+      requestId,
+      ...payload,
+    }));
+    logger.debug(`[CTRL_PROXY_IOS] Sent ${type} request (requestId: ${requestId})`);
+
+    const result = await promise;
+    if (!result.success) {
+      throw new Error(result.error || `${operationName} failed`);
+    }
+    return result;
+  }
+}

--- a/src/features/observe/ios/IOSCtrlProxyClient.ts
+++ b/src/features/observe/ios/IOSCtrlProxyClient.ts
@@ -108,6 +108,7 @@ import { CtrlProxyStorage } from "./CtrlProxyStorage";
 import { CtrlProxyVoiceOver } from "./CtrlProxyVoiceOver";
 import { CtrlProxyKeyboard } from "./CtrlProxyKeyboard";
 import { CtrlProxyHighlights } from "./CtrlProxyHighlights";
+import { CtrlProxyDatabase } from "./CtrlProxyDatabase";
 
 // Import types
 import type {
@@ -336,6 +337,7 @@ export class IOSCtrlProxyClient extends DeviceServiceClient implements IOSCtrlPr
   private _storage: CtrlProxyStorage | null = null;
   private _keyboard: CtrlProxyKeyboard | null = null;
   private _highlights: CtrlProxyHighlights | null = null;
+  private _database: CtrlProxyDatabase | null = null;
 
   // Logging tag for base class
   protected readonly logTag = "IOSCtrlProxyClient";
@@ -648,6 +650,13 @@ export class IOSCtrlProxyClient extends DeviceServiceClient implements IOSCtrlPr
       this._highlights = new CtrlProxyHighlights(this.createDelegateContext());
     }
     return this._highlights;
+  }
+
+  private get database(): CtrlProxyDatabase {
+    if (!this._database) {
+      this._database = new CtrlProxyDatabase(this.createDelegateContext());
+    }
+    return this._database;
   }
 
   // ===========================================================================
@@ -1253,6 +1262,56 @@ export class IOSCtrlProxyClient extends DeviceServiceClient implements IOSCtrlPr
           };
           break;
 
+        case "execute_sql_result":
+          result = {
+            success: message.success ?? false,
+            queryType: (message as { queryType?: string }).queryType,
+            columns: (message as { columns?: string[] }).columns,
+            rows: (message as { rows?: unknown[][] }).rows,
+            rowsAffected: (message as { rowsAffected?: number }).rowsAffected,
+            totalTimeMs: message.totalTimeMs ?? 0,
+            error: message.error,
+          };
+          break;
+
+        case "list_databases_result":
+          result = {
+            success: message.success ?? false,
+            databases: (message as { databases?: unknown[] }).databases ?? [],
+            totalTimeMs: message.totalTimeMs ?? 0,
+            error: message.error,
+          };
+          break;
+
+        case "list_tables_result":
+          result = {
+            success: message.success ?? false,
+            tables: (message as { tables?: string[] }).tables ?? [],
+            totalTimeMs: message.totalTimeMs ?? 0,
+            error: message.error,
+          };
+          break;
+
+        case "table_data_result":
+          result = {
+            success: message.success ?? false,
+            columns: (message as { columns?: string[] }).columns ?? [],
+            rows: (message as { rows?: unknown[][] }).rows ?? [],
+            total: (message as { total?: number }).total ?? 0,
+            totalTimeMs: message.totalTimeMs ?? 0,
+            error: message.error,
+          };
+          break;
+
+        case "table_structure_result":
+          result = {
+            success: message.success ?? false,
+            columns: (message as { columns?: unknown[] }).columns ?? [],
+            totalTimeMs: message.totalTimeMs ?? 0,
+            error: message.error,
+          };
+          break;
+
         default:
           // Handle error responses
           if (message.error) {
@@ -1641,6 +1700,44 @@ export class IOSCtrlProxyClient extends DeviceServiceClient implements IOSCtrlPr
 
   async clearPreferenceStore(packageName: string, fileName: string, timeoutMs: number = 5000): Promise<void> {
     return this.storage.clearPreferenceStore(packageName, fileName, timeoutMs);
+  }
+
+  // ===========================================================================
+  // Delegated Public Methods - Database (SQLite)
+  // ===========================================================================
+
+  async executeSQLForIos(
+    databasePath: string,
+    query: string,
+    timeoutMs: number = 5000
+  ): Promise<import("../../database/DatabaseInspector").SQLResult> {
+    return this.database.executeSQL(databasePath, query, timeoutMs);
+  }
+
+  async listDatabasesForIos(timeoutMs: number = 5000): Promise<import("../../database/DatabaseInspector").DatabaseInfo[]> {
+    return this.database.listDatabases(timeoutMs);
+  }
+
+  async listTablesForIos(databasePath: string, timeoutMs: number = 5000): Promise<string[]> {
+    return this.database.listTables(databasePath, timeoutMs);
+  }
+
+  async getTableDataForIos(
+    databasePath: string,
+    table: string,
+    limit: number = 50,
+    offset: number = 0,
+    timeoutMs: number = 5000
+  ): Promise<import("../../database/DatabaseInspector").TableDataResult> {
+    return this.database.getTableData(databasePath, table, limit, offset, timeoutMs);
+  }
+
+  async getTableStructureForIos(
+    databasePath: string,
+    table: string,
+    timeoutMs: number = 5000
+  ): Promise<import("../../database/DatabaseInspector").TableStructureResult> {
+    return this.database.getTableStructure(databasePath, table, timeoutMs);
   }
 
   // ===========================================================================

--- a/src/features/observe/ios/IOSCtrlProxyClient.ts
+++ b/src/features/observe/ios/IOSCtrlProxyClient.ts
@@ -1707,37 +1707,43 @@ export class IOSCtrlProxyClient extends DeviceServiceClient implements IOSCtrlPr
   // ===========================================================================
 
   async executeSQLForIos(
+    appId: string,
     databasePath: string,
     query: string,
     timeoutMs: number = 5000
   ): Promise<import("../../database/DatabaseInspector").SQLResult> {
-    return this.database.executeSQL(databasePath, query, timeoutMs);
+    return this.database.executeSQL(appId, databasePath, query, timeoutMs);
   }
 
-  async listDatabasesForIos(timeoutMs: number = 5000): Promise<import("../../database/DatabaseInspector").DatabaseInfo[]> {
-    return this.database.listDatabases(timeoutMs);
+  async listDatabasesForIos(
+    appId: string,
+    timeoutMs: number = 5000
+  ): Promise<import("../../database/DatabaseInspector").DatabaseInfo[]> {
+    return this.database.listDatabases(appId, timeoutMs);
   }
 
-  async listTablesForIos(databasePath: string, timeoutMs: number = 5000): Promise<string[]> {
-    return this.database.listTables(databasePath, timeoutMs);
+  async listTablesForIos(appId: string, databasePath: string, timeoutMs: number = 5000): Promise<string[]> {
+    return this.database.listTables(appId, databasePath, timeoutMs);
   }
 
   async getTableDataForIos(
+    appId: string,
     databasePath: string,
     table: string,
     limit: number = 50,
     offset: number = 0,
     timeoutMs: number = 5000
   ): Promise<import("../../database/DatabaseInspector").TableDataResult> {
-    return this.database.getTableData(databasePath, table, limit, offset, timeoutMs);
+    return this.database.getTableData(appId, databasePath, table, limit, offset, timeoutMs);
   }
 
   async getTableStructureForIos(
+    appId: string,
     databasePath: string,
     table: string,
     timeoutMs: number = 5000
   ): Promise<import("../../database/DatabaseInspector").TableStructureResult> {
-    return this.database.getTableStructure(databasePath, table, timeoutMs);
+    return this.database.getTableStructure(appId, databasePath, table, timeoutMs);
   }
 
   // ===========================================================================

--- a/src/features/observe/ios/index.ts
+++ b/src/features/observe/ios/index.ts
@@ -19,6 +19,7 @@ export { CtrlProxyClipboard } from "./CtrlProxyClipboard";
 export { CtrlProxyStorage } from "./CtrlProxyStorage";
 export { CtrlProxyKeyboard } from "./CtrlProxyKeyboard";
 export { CtrlProxyHighlights } from "./CtrlProxyHighlights";
+export { CtrlProxyDatabase } from "./CtrlProxyDatabase";
 
 // Types
 export type {

--- a/src/server/databaseResources.ts
+++ b/src/server/databaseResources.ts
@@ -4,6 +4,8 @@ import { DatabaseInspector, DatabaseInfo, TableStructureResult } from "../featur
 import { defaultAdbClientFactory } from "../utils/android-cmdline-tools/AdbClientFactory";
 import { BootedDevice } from "../models";
 import { logger } from "../utils/logger";
+import { IOSCtrlProxyClient } from "../features/observe/ios";
+import type { TableDataResult } from "../features/database/DatabaseInspector";
 
 // Resource URI templates
 const DATABASE_RESOURCE_TEMPLATES = {
@@ -51,16 +53,59 @@ function generateHash(data: unknown): string {
 }
 
 /**
- * Find a booted Android device by ID
+ * Cross-platform interface for database inspection.
  */
-async function findBootedAndroidDevice(deviceId: string): Promise<BootedDevice | null> {
+interface AppDatabaseClient {
+  listDatabases(appId: string): Promise<DatabaseInfo[]>;
+  listTables(appId: string, databasePath: string): Promise<string[]>;
+  getTableData(appId: string, databasePath: string, table: string, limit: number, offset: number): Promise<TableDataResult>;
+  getTableStructure(appId: string, databasePath: string, table: string): Promise<TableStructureResult>;
+}
+
+/**
+ * Find a booted Android or iOS device by ID.
+ */
+async function findBootedDevice(deviceId: string): Promise<BootedDevice | null> {
+  const manager = PlatformDeviceManagerFactory.getInstance();
+  const [androidDevices, iosDevices] = await Promise.all([
+    getBootedDevicesSafely("android", () => manager.getBootedDevices("android")),
+    getBootedDevicesSafely("ios", () => manager.getBootedDevices("ios")),
+  ]);
+  const devices = [...androidDevices, ...iosDevices];
+  return devices.find(d => d.deviceId === deviceId) ?? null;
+}
+
+async function getBootedDevicesSafely(
+  platform: "android" | "ios",
+  listDevices: () => Promise<BootedDevice[]>
+): Promise<BootedDevice[]> {
   try {
-    const devices = await PlatformDeviceManagerFactory.getInstance().getBootedDevices("android");
-    return devices.find(d => d.deviceId === deviceId) ?? null;
+    return await listDevices();
   } catch (error) {
-    logger.warn(`[DatabaseResources] Failed to find device ${deviceId}: ${error}`);
-    return null;
+    logger.warn(`[DatabaseResources] Failed to list ${platform} devices: ${error}`);
+    return [];
   }
+}
+
+function createDatabaseClient(device: BootedDevice): AppDatabaseClient {
+  if (device.platform === "android") {
+    const adb = defaultAdbClientFactory.create(device);
+    return new DatabaseInspector(device, adb);
+  }
+
+  if (device.platform === "ios") {
+    const client = IOSCtrlProxyClient.getInstance(device);
+    return {
+      listDatabases: async () => client.listDatabasesForIos(),
+      listTables: async (_appId, databasePath) => client.listTablesForIos(databasePath),
+      getTableData: async (_appId, databasePath, table, limit, offset) =>
+        client.getTableDataForIos(databasePath, table, limit, offset),
+      getTableStructure: async (_appId, databasePath, table) =>
+        client.getTableStructureForIos(databasePath, table),
+    };
+  }
+
+  throw new Error(`Database inspection is not supported on ${device.platform} devices.`);
 }
 
 /**
@@ -113,7 +158,7 @@ async function getDatabasesResource(params: Record<string, string>): Promise<Res
   const uri = buildDatabasesUri(deviceId, appId);
 
   try {
-    const device = await findBootedAndroidDevice(deviceId);
+    const device = await findBootedDevice(deviceId);
     if (!device) {
       return {
         uri,
@@ -122,8 +167,7 @@ async function getDatabasesResource(params: Record<string, string>): Promise<Res
       };
     }
 
-    const adb = defaultAdbClientFactory.create(device);
-    const inspector = new DatabaseInspector(device, adb);
+    const inspector = createDatabaseClient(device);
     const databases = await inspector.listDatabases(appId);
     const lastUpdated = new Date().toISOString();
     const hash = generateHash(databases);
@@ -169,7 +213,7 @@ async function getTablesResource(params: Record<string, string>): Promise<Resour
   const uri = buildTablesUri(deviceId, decodedPath, appId);
 
   try {
-    const device = await findBootedAndroidDevice(deviceId);
+    const device = await findBootedDevice(deviceId);
     if (!device) {
       return {
         uri,
@@ -178,8 +222,7 @@ async function getTablesResource(params: Record<string, string>): Promise<Resour
       };
     }
 
-    const adb = defaultAdbClientFactory.create(device);
-    const inspector = new DatabaseInspector(device, adb);
+    const inspector = createDatabaseClient(device);
     const tables = await inspector.listTables(appId, decodedPath);
     const lastUpdated = new Date().toISOString();
 
@@ -219,7 +262,7 @@ async function getTableDataResource(params: Record<string, string>): Promise<Res
   const offset = params.offset ? parseInt(params.offset, 10) : 0;
 
   try {
-    const device = await findBootedAndroidDevice(deviceId);
+    const device = await findBootedDevice(deviceId);
     if (!device) {
       return {
         uri,
@@ -228,8 +271,7 @@ async function getTableDataResource(params: Record<string, string>): Promise<Res
       };
     }
 
-    const adb = defaultAdbClientFactory.create(device);
-    const inspector = new DatabaseInspector(device, adb);
+    const inspector = createDatabaseClient(device);
     const data = await inspector.getTableData(appId, decodedPath, decodedTable, limit, offset);
     const lastUpdated = new Date().toISOString();
 
@@ -269,7 +311,7 @@ async function getTableStructureResource(params: Record<string, string>): Promis
   const uri = buildTableStructureUri(deviceId, decodedPath, decodedTable, appId);
 
   try {
-    const device = await findBootedAndroidDevice(deviceId);
+    const device = await findBootedDevice(deviceId);
     if (!device) {
       return {
         uri,
@@ -278,8 +320,7 @@ async function getTableStructureResource(params: Record<string, string>): Promis
       };
     }
 
-    const adb = defaultAdbClientFactory.create(device);
-    const inspector = new DatabaseInspector(device, adb);
+    const inspector = createDatabaseClient(device);
     const structure = await inspector.getTableStructure(appId, decodedPath, decodedTable);
     const lastUpdated = new Date().toISOString();
     const hash = generateHash(structure);
@@ -366,7 +407,7 @@ export function registerDatabaseResources(): void {
   ResourceRegistry.registerTemplate(
     DATABASE_RESOURCE_TEMPLATES.DATABASES,
     "App Databases",
-    "List all SQLite databases in an Android app. Requires app to have AutoMobile SDK with database inspection enabled.",
+    "List all SQLite databases in an Android or iOS app. Requires app to have AutoMobile SDK with database inspection enabled; iOS support requires a DEBUG SDK server.",
     "application/json",
     getDatabasesResource
   );

--- a/src/server/databaseResources.ts
+++ b/src/server/databaseResources.ts
@@ -96,12 +96,12 @@ function createDatabaseClient(device: BootedDevice): AppDatabaseClient {
   if (device.platform === "ios") {
     const client = IOSCtrlProxyClient.getInstance(device);
     return {
-      listDatabases: async () => client.listDatabasesForIos(),
-      listTables: async (_appId, databasePath) => client.listTablesForIos(databasePath),
+      listDatabases: async appId => client.listDatabasesForIos(appId),
+      listTables: async (appId, databasePath) => client.listTablesForIos(appId, databasePath),
       getTableData: async (_appId, databasePath, table, limit, offset) =>
-        client.getTableDataForIos(databasePath, table, limit, offset),
-      getTableStructure: async (_appId, databasePath, table) =>
-        client.getTableStructureForIos(databasePath, table),
+        client.getTableDataForIos(_appId, databasePath, table, limit, offset),
+      getTableStructure: async (appId, databasePath, table) =>
+        client.getTableStructureForIos(appId, databasePath, table),
     };
   }
 

--- a/src/server/databaseTools.ts
+++ b/src/server/databaseTools.ts
@@ -201,7 +201,7 @@ async function executeSqlForDevice(device: BootedDevice, args: SqlQueryArgs): Pr
 
   if (device.platform === "ios") {
     try {
-      return await IOSCtrlProxyClient.getInstance(device).executeSQLForIos(args.databasePath, args.query);
+      return await IOSCtrlProxyClient.getInstance(device).executeSQLForIos(args.appId, args.databasePath, args.query);
     } catch (error) {
       throw new ActionableError(
         "Failed to execute SQL on iOS. Ensure the app embeds the AutoMobile SDK in a DEBUG build " +

--- a/src/server/databaseTools.ts
+++ b/src/server/databaseTools.ts
@@ -6,6 +6,8 @@ import { createJSONToolResponse } from "../utils/toolUtils";
 import { DatabaseInspector } from "../features/database/DatabaseInspector";
 import { defaultAdbClientFactory } from "../utils/android-cmdline-tools/AdbClientFactory";
 import { notifyDatabaseChanged } from "./databaseResources";
+import { IOSCtrlProxyClient } from "../features/observe/ios";
+import type { SQLResult } from "../features/database/DatabaseInspector";
 
 // Schema for sqlQuery tool
 const sqlQuerySchema = addDeviceTargetingToSchema(
@@ -141,16 +143,8 @@ function findStatementAfterCTE(upperQuery: string): string | null {
 export function registerDatabaseTools() {
   // SQL Query handler
   const sqlQueryHandler = async (device: BootedDevice, args: SqlQueryArgs) => {
-    validateAndroidDevice(device);
-
     try {
-      const adb = defaultAdbClientFactory.create(device);
-      const inspector = new DatabaseInspector(device, adb);
-      const result = await inspector.executeSQL(
-        args.appId,
-        args.databasePath,
-        args.query
-      );
+      const result = await executeSqlForDevice(device, args);
 
       // If this was a mutation, notify resource subscribers of the change
       if (isMutationQuery(args.query)) {
@@ -183,7 +177,8 @@ export function registerDatabaseTools() {
   // Register the sqlQuery tool
   ToolRegistry.registerDeviceAware(
     "sqlQuery",
-    "Execute a SQL query on an Android app's database. Supports SELECT, INSERT, UPDATE, DELETE. " +
+    "Execute a SQL query on an Android or iOS app's SQLite database. Supports SELECT, INSERT, UPDATE, DELETE. " +
+    "On iOS this requires a DEBUG app build with the AutoMobile SDK integrated and DatabaseInspector.shared.setEnabled(true). " +
     "For read-only operations (listing databases, tables, viewing data/schema), use the database resources instead.",
     sqlQuerySchema,
     sqlQueryHandler
@@ -191,13 +186,29 @@ export function registerDatabaseTools() {
 }
 
 /**
- * Validate that the device is an Android device
+ * Execute SQL using the platform-specific database bridge.
  */
-function validateAndroidDevice(device: BootedDevice): void {
-  if (device.platform !== "android") {
-    throw new ActionableError(
-      "Database inspection is only supported on Android devices. " +
-      "The app must have AutoMobile SDK integrated with database inspection enabled."
+async function executeSqlForDevice(device: BootedDevice, args: SqlQueryArgs): Promise<SQLResult> {
+  if (device.platform === "android") {
+    const adb = defaultAdbClientFactory.create(device);
+    const inspector = new DatabaseInspector(device, adb);
+    return inspector.executeSQL(
+      args.appId,
+      args.databasePath,
+      args.query
     );
   }
+
+  if (device.platform === "ios") {
+    try {
+      return await IOSCtrlProxyClient.getInstance(device).executeSQLForIos(args.databasePath, args.query);
+    } catch (error) {
+      throw new ActionableError(
+        "Failed to execute SQL on iOS. Ensure the app embeds the AutoMobile SDK in a DEBUG build " +
+        `and calls DatabaseInspector.shared.setEnabled(true): ${error}`
+      );
+    }
+  }
+
+  throw new ActionableError(`Database inspection is not supported on ${device.platform} devices.`);
 }

--- a/test/features/observe/ios/CtrlProxyDatabase.test.ts
+++ b/test/features/observe/ios/CtrlProxyDatabase.test.ts
@@ -1,0 +1,159 @@
+import { beforeEach, describe, expect, test } from "bun:test";
+import { IOSCtrlProxyClient } from "../../../../src/features/observe/ios";
+import type { BootedDevice } from "../../../../src/models";
+import { FakeWebSocket, WebSocketState } from "../../../fakes/FakeWebSocket";
+import { FakeTimer } from "../../../fakes/FakeTimer";
+
+describe("CtrlProxyDatabase (iOS)", function() {
+  let testDevice: BootedDevice;
+  let fakeTimer: FakeTimer;
+  const serverPort = 8765;
+
+  beforeEach(function() {
+    fakeTimer = new FakeTimer();
+    fakeTimer.enableAutoAdvance();
+    testDevice = {
+      deviceId: "A1B2C3D4-E5F6-7890-ABCD-EF1234567890",
+      platform: "ios",
+      name: "iPhone 16 Simulator",
+    };
+    IOSCtrlProxyClient.resetInstances();
+  });
+
+  class CapturingWebSocket extends FakeWebSocket {
+    sentMessages: string[] = [];
+
+    send(data: unknown): void {
+      this.sentMessages.push(String(data));
+      super.send(data);
+    }
+  }
+
+  const createCapturingFactory = (): {
+    factory: (url: string) => CapturingWebSocket;
+    getSocket: () => CapturingWebSocket | null;
+  } => {
+    let socket: CapturingWebSocket | null = null;
+    return {
+      factory: (url: string) => {
+        socket = new CapturingWebSocket(url, "none", 0, fakeTimer);
+        return socket;
+      },
+      getSocket: () => socket,
+    };
+  };
+
+  const waitForSocketOpen = async (socket: FakeWebSocket | null): Promise<void> => {
+    if (!socket || socket.readyState === WebSocketState.OPEN) { return; }
+    await new Promise<void>(resolve => socket.once("open", () => resolve()));
+  };
+
+  const waitForSocket = async (
+    getSocket: () => CapturingWebSocket | null
+  ): Promise<CapturingWebSocket | null> => {
+    for (let i = 0; i < 5; i += 1) {
+      const socket = getSocket();
+      if (socket) { return socket; }
+      await new Promise(resolve => setImmediate(resolve));
+    }
+    return getSocket();
+  };
+
+  const waitForSentMessages = async (socket: CapturingWebSocket | null, minCount = 1): Promise<void> => {
+    if (!socket) { return; }
+    for (let i = 0; i < 10; i += 1) {
+      if (socket.sentMessages.length >= minCount) { return; }
+      await new Promise(resolve => setImmediate(resolve));
+    }
+  };
+
+  test("executeSQLForIos sends execute_sql and returns query rows including blob strings", async function() {
+    const { factory, getSocket } = createCapturingFactory();
+    const client = IOSCtrlProxyClient.createForTesting(testDevice, serverPort, factory, fakeTimer);
+
+    try {
+      const resultPromise = client.executeSQLForIos("/app/Documents/app.db", "SELECT id, payload FROM notes");
+      const socket = await waitForSocket(getSocket);
+      await waitForSocketOpen(socket);
+      await waitForSentMessages(socket);
+
+      const sentMessage = JSON.parse(socket!.sentMessages[0]);
+      expect(sentMessage.type).toBe("execute_sql");
+      expect(sentMessage.databasePath).toBe("/app/Documents/app.db");
+      expect(sentMessage.query).toBe("SELECT id, payload FROM notes");
+
+      socket!.simulateMessage(JSON.stringify({
+        type: "execute_sql_result",
+        requestId: sentMessage.requestId,
+        success: true,
+        queryType: "query",
+        columns: ["id", "payload"],
+        rows: [["1", "0xCAFE"]],
+        rowsAffected: 0,
+        totalTimeMs: 4,
+      }));
+
+      await expect(resultPromise).resolves.toEqual({
+        type: "query",
+        columns: ["id", "payload"],
+        rows: [["1", "0xCAFE"]],
+      });
+    } finally {
+      await client.close();
+    }
+  });
+
+  test("executeSQLForIos returns mutation rowsAffected", async function() {
+    const { factory, getSocket } = createCapturingFactory();
+    const client = IOSCtrlProxyClient.createForTesting(testDevice, serverPort, factory, fakeTimer);
+
+    try {
+      const resultPromise = client.executeSQLForIos("/app/Documents/app.db", "UPDATE notes SET title = 'x'");
+      const socket = await waitForSocket(getSocket);
+      await waitForSocketOpen(socket);
+      await waitForSentMessages(socket);
+      const sentMessage = JSON.parse(socket!.sentMessages[0]);
+
+      socket!.simulateMessage(JSON.stringify({
+        type: "execute_sql_result",
+        requestId: sentMessage.requestId,
+        success: true,
+        queryType: "mutation",
+        rowsAffected: 2,
+        totalTimeMs: 5,
+      }));
+
+      await expect(resultPromise).resolves.toEqual({
+        type: "mutation",
+        rowsAffected: 2,
+      });
+    } finally {
+      await client.close();
+    }
+  });
+
+  test("executeSQLForIos surfaces disabled SDK errors without timing out", async function() {
+    const { factory, getSocket } = createCapturingFactory();
+    const client = IOSCtrlProxyClient.createForTesting(testDevice, serverPort, factory, fakeTimer);
+
+    try {
+      const resultPromise = client.executeSQLForIos("/app/Documents/app.db", "SELECT 1");
+      const socket = await waitForSocket(getSocket);
+      await waitForSocketOpen(socket);
+      await waitForSentMessages(socket);
+      const sentMessage = JSON.parse(socket!.sentMessages[0]);
+
+      socket!.simulateMessage(JSON.stringify({
+        type: "execute_sql_result",
+        requestId: sentMessage.requestId,
+        success: false,
+        error: "database inspection unavailable - embed the AutoMobile SDK and call DatabaseInspector.shared.setEnabled(true)",
+        totalTimeMs: 3,
+      }));
+
+      await expect(resultPromise).rejects.toThrow("setEnabled(true)");
+    } finally {
+      await client.close();
+    }
+  });
+});

--- a/test/features/observe/ios/CtrlProxyDatabase.test.ts
+++ b/test/features/observe/ios/CtrlProxyDatabase.test.ts
@@ -72,13 +72,14 @@ describe("CtrlProxyDatabase (iOS)", function() {
     const client = IOSCtrlProxyClient.createForTesting(testDevice, serverPort, factory, fakeTimer);
 
     try {
-      const resultPromise = client.executeSQLForIos("/app/Documents/app.db", "SELECT id, payload FROM notes");
+      const resultPromise = client.executeSQLForIos("com.example.app", "/app/Documents/app.db", "SELECT id, payload FROM notes");
       const socket = await waitForSocket(getSocket);
       await waitForSocketOpen(socket);
       await waitForSentMessages(socket);
 
       const sentMessage = JSON.parse(socket!.sentMessages[0]);
       expect(sentMessage.type).toBe("execute_sql");
+      expect(sentMessage.appId).toBe("com.example.app");
       expect(sentMessage.databasePath).toBe("/app/Documents/app.db");
       expect(sentMessage.query).toBe("SELECT id, payload FROM notes");
 
@@ -108,7 +109,7 @@ describe("CtrlProxyDatabase (iOS)", function() {
     const client = IOSCtrlProxyClient.createForTesting(testDevice, serverPort, factory, fakeTimer);
 
     try {
-      const resultPromise = client.executeSQLForIos("/app/Documents/app.db", "UPDATE notes SET title = 'x'");
+      const resultPromise = client.executeSQLForIos("com.example.app", "/app/Documents/app.db", "UPDATE notes SET title = 'x'");
       const socket = await waitForSocket(getSocket);
       await waitForSocketOpen(socket);
       await waitForSentMessages(socket);
@@ -137,7 +138,7 @@ describe("CtrlProxyDatabase (iOS)", function() {
     const client = IOSCtrlProxyClient.createForTesting(testDevice, serverPort, factory, fakeTimer);
 
     try {
-      const resultPromise = client.executeSQLForIos("/app/Documents/app.db", "SELECT 1");
+      const resultPromise = client.executeSQLForIos("com.example.app", "/app/Documents/app.db", "SELECT 1");
       const socket = await waitForSocket(getSocket);
       await waitForSocketOpen(socket);
       await waitForSentMessages(socket);

--- a/test/server/databaseIos.test.ts
+++ b/test/server/databaseIos.test.ts
@@ -1,0 +1,155 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { registerDatabaseResources } from "../../src/server/databaseResources";
+import { registerDatabaseTools } from "../../src/server/databaseTools";
+import { ResourceRegistry } from "../../src/server/resourceRegistry";
+import { ToolRegistry } from "../../src/server/toolRegistry";
+import { IOSCtrlProxyClient } from "../../src/features/observe/ios";
+import { PlatformDeviceManagerFactory } from "../../src/utils/factories/PlatformDeviceManagerFactory";
+import type { BootedDevice } from "../../src/models";
+
+describe("iOS database inspection server integration", function() {
+  const iosDevice: BootedDevice = {
+    deviceId: "ios-1",
+    platform: "ios",
+    name: "iPhone 16 Simulator",
+  };
+
+  let originalGetInstance: typeof IOSCtrlProxyClient.getInstance;
+
+  beforeEach(function() {
+    ToolRegistry.clearTools();
+    ResourceRegistry.clearResources();
+    PlatformDeviceManagerFactory.reset();
+    IOSCtrlProxyClient.resetInstances();
+    originalGetInstance = IOSCtrlProxyClient.getInstance;
+  });
+
+  afterEach(function() {
+    IOSCtrlProxyClient.getInstance = originalGetInstance;
+    ToolRegistry.clearTools();
+    ResourceRegistry.clearResources();
+    PlatformDeviceManagerFactory.reset();
+    IOSCtrlProxyClient.resetInstances();
+  });
+
+  test("sqlQuery executes SELECT on iOS through CtrlProxy and keeps Android response shape", async function() {
+    const executeSQLForIos = mock(async () => ({
+      type: "query" as const,
+      columns: ["id", "payload"],
+      rows: [["1", "0xCAFE"]],
+    }));
+    IOSCtrlProxyClient.getInstance = mock(() => ({
+      executeSQLForIos,
+    })) as unknown as typeof IOSCtrlProxyClient.getInstance;
+
+    registerDatabaseTools();
+    const tool = ToolRegistry.getTool("sqlQuery");
+    expect(tool?.deviceAwareHandler).toBeDefined();
+
+    const response = await tool!.deviceAwareHandler!(iosDevice, {
+      appId: "com.example.app",
+      databasePath: "/app/Documents/app.db",
+      query: "SELECT id, payload FROM notes",
+    });
+
+    expect(executeSQLForIos).toHaveBeenCalledWith(
+      "/app/Documents/app.db",
+      "SELECT id, payload FROM notes"
+    );
+    const payload = JSON.parse(response.content[0].text);
+    expect(payload).toEqual({
+      message: "Query returned 1 row(s)",
+      type: "query",
+      columns: ["id", "payload"],
+      rows: [["1", "0xCAFE"]],
+    });
+  });
+
+  test("sqlQuery notifies database resources for iOS mutations", async function() {
+    const executeSQLForIos = mock(async () => ({
+      type: "mutation" as const,
+      rowsAffected: 1,
+    }));
+    IOSCtrlProxyClient.getInstance = mock(() => ({
+      executeSQLForIos,
+    })) as unknown as typeof IOSCtrlProxyClient.getInstance;
+    const notifyResourceUpdated = mock(async (_uri: string) => {});
+    const originalNotify = ResourceRegistry.notifyResourceUpdated;
+    ResourceRegistry.notifyResourceUpdated = notifyResourceUpdated;
+
+    try {
+      registerDatabaseTools();
+      const tool = ToolRegistry.getTool("sqlQuery");
+      const response = await tool!.deviceAwareHandler!(iosDevice, {
+        appId: "com.example.app",
+        databasePath: "/app/Documents/app.db",
+        query: "INSERT INTO notes (title) VALUES ('new')",
+      });
+
+      const payload = JSON.parse(response.content[0].text);
+      expect(payload.type).toBe("mutation");
+      expect(payload.rowsAffected).toBe(1);
+      expect(notifyResourceUpdated).toHaveBeenCalledWith(
+        "automobile:devices/ios-1/databases?appId=com.example.app"
+      );
+      expect(notifyResourceUpdated).toHaveBeenCalledWith(
+        "automobile:devices/ios-1/databases/%2Fapp%2FDocuments%2Fapp.db/tables/notes/data?appId=com.example.app"
+      );
+    } finally {
+      ResourceRegistry.notifyResourceUpdated = originalNotify;
+    }
+  });
+
+  test("database resources resolve iOS devices through CtrlProxy", async function() {
+    const listDatabases = mock(async () => [
+      { name: "app.db", path: "/app/Documents/app.db" },
+    ]);
+    IOSCtrlProxyClient.getInstance = mock(() => ({
+      listDatabasesForIos: listDatabases,
+    })) as unknown as typeof IOSCtrlProxyClient.getInstance;
+    PlatformDeviceManagerFactory.setInstance({
+      getBootedDevices: mock(async () => [iosDevice]),
+    } as unknown as ReturnType<typeof PlatformDeviceManagerFactory.getInstance>);
+
+    registerDatabaseResources();
+    const uri = "automobile:devices/ios-1/databases?appId=com.example.app";
+    const match = ResourceRegistry.matchTemplate(uri);
+    expect(match).toBeDefined();
+
+    const content = await match!.template.handler(match!.params);
+    const payload = JSON.parse(content.text!);
+
+    expect(listDatabases).toHaveBeenCalled();
+    expect(payload.databases).toEqual([
+      { name: "app.db", path: "/app/Documents/app.db" },
+    ]);
+    expect(payload.totalCount).toBe(1);
+  });
+
+  test("database resources still resolve iOS when Android discovery fails", async function() {
+    const listDatabases = mock(async () => [
+      { name: "app.db", path: "/app/Documents/app.db" },
+    ]);
+    IOSCtrlProxyClient.getInstance = mock(() => ({
+      listDatabasesForIos: listDatabases,
+    })) as unknown as typeof IOSCtrlProxyClient.getInstance;
+    PlatformDeviceManagerFactory.setInstance({
+      getBootedDevices: mock(async platform => {
+        if (platform === "android") {
+          throw new Error("adb unavailable");
+        }
+        return [iosDevice];
+      }),
+    } as unknown as ReturnType<typeof PlatformDeviceManagerFactory.getInstance>);
+
+    registerDatabaseResources();
+    const uri = "automobile:devices/ios-1/databases?appId=com.example.app";
+    const match = ResourceRegistry.matchTemplate(uri);
+    const content = await match!.template.handler(match!.params);
+    const payload = JSON.parse(content.text!);
+
+    expect(payload.databases).toEqual([
+      { name: "app.db", path: "/app/Documents/app.db" },
+    ]);
+  });
+});

--- a/test/server/databaseIos.test.ts
+++ b/test/server/databaseIos.test.ts
@@ -53,6 +53,7 @@ describe("iOS database inspection server integration", function() {
     });
 
     expect(executeSQLForIos).toHaveBeenCalledWith(
+      "com.example.app",
       "/app/Documents/app.db",
       "SELECT id, payload FROM notes"
     );
@@ -119,7 +120,7 @@ describe("iOS database inspection server integration", function() {
     const content = await match!.template.handler(match!.params);
     const payload = JSON.parse(content.text!);
 
-    expect(listDatabases).toHaveBeenCalled();
+    expect(listDatabases).toHaveBeenCalledWith("com.example.app");
     expect(payload.databases).toEqual([
       { name: "app.db", path: "/app/Documents/app.db" },
     ]);
@@ -148,6 +149,7 @@ describe("iOS database inspection server integration", function() {
     const content = await match!.template.handler(match!.params);
     const payload = JSON.parse(content.text!);
 
+    expect(listDatabases).toHaveBeenCalledWith("com.example.app");
     expect(payload.databases).toEqual([
       { name: "app.db", path: "/app/Documents/app.db" },
     ]);


### PR DESCRIPTION
## Summary

- Add iOS `sqlQuery` support by relaying TS host requests through CtrlProxy to the in-app AutoMobile SDK database HTTP routes.
- Add read-only iOS database resources for listing databases, tables, table data, and table structure.
- Cover the new bridge with TS and Swift tests, plus docs for the iOS DEBUG SDK requirement.

Closes #2498

## Testing

- `bun test test/features/observe/ios/CtrlProxyDatabase.test.ts test/server/databaseIos.test.ts`
- `bun run build`
- `bun run lint`
- `bun test --bail`
- `bash scripts/ios/swift-test.sh`
- `ONLY_TOUCHED_FILES=true bash scripts/swiftformat/validate_swiftformat.sh`
- `ONLY_TOUCHED_FILES=true bash scripts/swiftlint/validate_swiftlint.sh`
- `git diff --check`
- `bun run turbo:validate`

## Notes

- `bash scripts/validate-bun-test-timings.sh` ran the full Bun suite successfully, but the timing gate still failed on existing >100ms tests outside this change.
