### PR TITLE
feat(ios): support hardware pressButton actions

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
   "plugins": [
     {
       "name": "auto-mobile",
-      "source": "./",
+      "source": "./.claude-plugin",
       "description": "Mobile device automation for Android and iOS - control devices with natural language",
       "version": "0.0.38",
       "author": {

--- a/docs/design-docs/plat/ios/xctestrunner/writing-tests.md
+++ b/docs/design-docs/plat/ios/xctestrunner/writing-tests.md
@@ -269,9 +269,12 @@ Presses a device or navigation button.
 ```
 
 !!! note "Supported iOS buttons"
-    The iOS runtime supports `button: home` and `button: back`. `back` performs app-level
-    navigation through CtrlProxy because iOS has no hardware back button. Other values are
-    rejected with "Unsupported iOS button" at execution time.
+    The iOS runtime supports `button: home`, `button: back`, and `button: recent`.
+    `back` performs app-level navigation through CtrlProxy because iOS has no hardware
+    back button. On physical iOS devices, `volume_up`, `volume_down`, and `power` are
+    routed through hardware-button support. On iOS simulators, those hardware buttons
+    return an explicit "unavailable on the iOS simulator" error. `menu` has no iOS
+    hardware analogue and is unsupported.
 
 ### `terminateApp`
 

--- a/ios/control-proxy/Sources/CtrlProxy/GesturePerformer.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/GesturePerformer.swift
@@ -908,12 +908,127 @@ public class GesturePerformer: GesturePerforming {
                 try openRecentApps()
             case "back":
                 try pressBack()
-            case "menu", "power", "volume_up", "volume_down":
-                throw GestureError.notSupported("iOS simulator button: \(button)")
+            case "volume_up", "volume_down":
+                #if targetEnvironment(simulator)
+                    throw GestureError.notSupported("Volume buttons are unavailable on the iOS simulator: \(button)")
+                #else
+                    try runOnMainThread {
+                        let deviceButton: XCUIDevice.Button
+                        if button.lowercased() == "volume_up" {
+                            deviceButton = .volumeUp
+                        } else {
+                            deviceButton = .volumeDown
+                        }
+                        XCUIDevice.shared.press(deviceButton)
+                    }
+                #endif
+            case "power":
+                #if targetEnvironment(simulator)
+                    throw GestureError.notSupported("Power/lock button is unavailable on the iOS simulator")
+                #else
+                    try pressPowerViaHID()
+                #endif
+            case "menu":
+                throw GestureError.notSupported("iOS has no menu hardware button")
             default:
                 throw GestureError.notSupported("Button: \(button)")
             }
         }
+
+        #if !targetEnvironment(simulator)
+            private typealias IOHIDEventRef = CFTypeRef
+            private typealias IOHIDEventSystemClientRef = CFTypeRef
+            private typealias IOHIDEventCreateKeyboardEventFn = @convention(c) (
+                CFAllocator?,
+                UInt64,
+                UInt32,
+                UInt32,
+                Bool,
+                UInt32
+            )
+                -> IOHIDEventRef?
+            private typealias IOHIDEventSystemClientCreateFn = @convention(c) (
+                CFAllocator?
+            )
+                -> IOHIDEventSystemClientRef?
+            private typealias IOHIDEventSystemClientDispatchEventFn = @convention(c) (
+                IOHIDEventSystemClientRef,
+                IOHIDEventRef
+            )
+                -> Void
+
+            private func pressPowerViaHID() throws {
+                guard let handle = openIOKitHandle() else {
+                    throw GestureError.notSupported("Power/lock button HID support unavailable")
+                }
+                defer { dlclose(handle) }
+
+                let createEventSymbol = dlsym(handle, "IOHIDEventCreateKeyboardEvent")
+                let createClientSymbol = dlsym(handle, "IOHIDEventSystemClientCreate")
+                let dispatchEventSymbol = dlsym(handle, "IOHIDEventSystemClientDispatchEvent")
+
+                guard let createEventSymbol, let createClientSymbol, let dispatchEventSymbol else {
+                    throw GestureError.notSupported("Power/lock button HID symbols unavailable")
+                }
+
+                let createKeyboardEvent = unsafeBitCast(
+                    createEventSymbol,
+                    to: IOHIDEventCreateKeyboardEventFn.self
+                )
+                let createSystemClient = unsafeBitCast(
+                    createClientSymbol,
+                    to: IOHIDEventSystemClientCreateFn.self
+                )
+                let dispatchEvent = unsafeBitCast(
+                    dispatchEventSymbol,
+                    to: IOHIDEventSystemClientDispatchEventFn.self
+                )
+
+                guard let client = createSystemClient(nil) else {
+                    throw GestureError.notSupported("Power/lock button HID client unavailable")
+                }
+                defer { CFRelease(client) }
+
+                let consumerUsagePage: UInt32 = 0x0C
+                let powerUsage: UInt32 = 0x30
+                let eventTimestamp: UInt64 = 0
+                let eventOptions: UInt32 = 0
+
+                guard let keyDown = createKeyboardEvent(
+                    nil,
+                    eventTimestamp,
+                    consumerUsagePage,
+                    powerUsage,
+                    true,
+                    eventOptions
+                ) else {
+                    throw GestureError.notSupported("Power/lock button HID key-down event unavailable")
+                }
+                defer { CFRelease(keyDown) }
+
+                guard let keyUp = createKeyboardEvent(
+                    nil,
+                    eventTimestamp,
+                    consumerUsagePage,
+                    powerUsage,
+                    false,
+                    eventOptions
+                ) else {
+                    throw GestureError.notSupported("Power/lock button HID key-up event unavailable")
+                }
+                defer { CFRelease(keyUp) }
+
+                dispatchEvent(client, keyDown)
+                dispatchEvent(client, keyUp)
+            }
+
+            private func openIOKitHandle() -> UnsafeMutableRawPointer? {
+                [
+                    "/System/Library/Frameworks/IOKit.framework/IOKit",
+                    "/System/Library/PrivateFrameworks/IOKit.framework/IOKit",
+                ].lazy.compactMap { dlopen($0, RTLD_NOW) }.first
+            }
+        #endif
 
         public func openRecentApps() throws {
             try runOnMainThread {

--- a/ios/control-proxy/Tests/CtrlProxyTests/CommandHandlerTests.swift
+++ b/ios/control-proxy/Tests/CtrlProxyTests/CommandHandlerTests.swift
@@ -897,6 +897,38 @@ final class CommandHandlerTests: XCTestCase {
         XCTAssertEqual(fakeGesturePerformer.updateApplicationHistory, ["com.apple.springboard"])
     }
 
+    func testPressButtonHardwareButtonDoesNotSwitchToSpringBoard() {
+        let request = WebSocketRequest(
+            type: "request_press_button",
+            requestId: "button-volume-up",
+            action: "volume_up"
+        )
+
+        guard let response = handleRequest(request, as: WebSocketResponse.self) else { return }
+
+        XCTAssertEqual(response.success, true)
+        XCTAssertEqual(response.type, "press_button_result")
+        XCTAssertEqual(fakeGesturePerformer.getPressButtonHistory(), ["volume_up"])
+        XCTAssertEqual(fakeElementLocator.switchedBundleIds, [])
+        XCTAssertEqual(fakeGesturePerformer.updateApplicationHistory, [])
+    }
+
+    func testPressButtonPowerDoesNotSwitchToSpringBoard() {
+        let request = WebSocketRequest(
+            type: "request_press_button",
+            requestId: "button-power",
+            action: "power"
+        )
+
+        guard let response = handleRequest(request, as: WebSocketResponse.self) else { return }
+
+        XCTAssertEqual(response.success, true)
+        XCTAssertEqual(response.type, "press_button_result")
+        XCTAssertEqual(fakeGesturePerformer.getPressButtonHistory(), ["power"])
+        XCTAssertEqual(fakeElementLocator.switchedBundleIds, [])
+        XCTAssertEqual(fakeGesturePerformer.updateApplicationHistory, [])
+    }
+
     func testLaunchAppSuccess() {
         // Default: app not running, no coldBoot → full launch
         fakeElementLocator.getAppStateResult = .notRunning

--- a/schemas/tool-definitions.json
+++ b/schemas/tool-definitions.json
@@ -52,6 +52,226 @@
         }
       },
       "additionalProperties": false
+    },
+    "outputSchema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "type": "object",
+      "properties": {
+        "success": {
+          "type": "boolean"
+        },
+        "error": {
+          "type": "string"
+        },
+        "warning": {
+          "type": "string"
+        },
+        "focusedElement": {
+          "type": "object",
+          "properties": {
+            "bounds": {
+              "type": "object",
+              "properties": {
+                "left": {
+                  "type": "integer",
+                  "minimum": -9007199254740991,
+                  "maximum": 9007199254740991
+                },
+                "top": {
+                  "type": "integer",
+                  "minimum": -9007199254740991,
+                  "maximum": 9007199254740991
+                },
+                "right": {
+                  "type": "integer",
+                  "minimum": -9007199254740991,
+                  "maximum": 9007199254740991
+                },
+                "bottom": {
+                  "type": "integer",
+                  "minimum": -9007199254740991,
+                  "maximum": 9007199254740991
+                },
+                "centerX": {
+                  "type": "integer",
+                  "minimum": -9007199254740991,
+                  "maximum": 9007199254740991
+                },
+                "centerY": {
+                  "type": "integer",
+                  "minimum": -9007199254740991,
+                  "maximum": 9007199254740991
+                }
+              },
+              "required": [
+                "left",
+                "top",
+                "right",
+                "bottom"
+              ],
+              "additionalProperties": false
+            },
+            "text": {
+              "type": "string"
+            },
+            "resource-id": {
+              "type": "string"
+            },
+            "content-desc": {
+              "type": "string"
+            },
+            "class": {
+              "type": "string"
+            },
+            "package": {
+              "type": "string"
+            },
+            "checkable": {
+              "anyOf": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "type": "string",
+                  "const": "true"
+                },
+                {
+                  "type": "string",
+                  "const": "false"
+                }
+              ]
+            },
+            "checked": {
+              "anyOf": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "type": "string",
+                  "const": "true"
+                },
+                {
+                  "type": "string",
+                  "const": "false"
+                }
+              ]
+            },
+            "clickable": {
+              "anyOf": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "type": "string",
+                  "const": "true"
+                },
+                {
+                  "type": "string",
+                  "const": "false"
+                }
+              ]
+            },
+            "enabled": {
+              "anyOf": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "type": "string",
+                  "const": "true"
+                },
+                {
+                  "type": "string",
+                  "const": "false"
+                }
+              ]
+            },
+            "focusable": {
+              "anyOf": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "type": "string",
+                  "const": "true"
+                },
+                {
+                  "type": "string",
+                  "const": "false"
+                }
+              ]
+            },
+            "focused": {
+              "anyOf": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "type": "string",
+                  "const": "true"
+                },
+                {
+                  "type": "string",
+                  "const": "false"
+                }
+              ]
+            },
+            "accessibility-focused": {
+              "anyOf": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "type": "string",
+                  "const": "true"
+                },
+                {
+                  "type": "string",
+                  "const": "false"
+                }
+              ]
+            },
+            "scrollable": {
+              "anyOf": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "type": "string",
+                  "const": "true"
+                },
+                {
+                  "type": "string",
+                  "const": "false"
+                }
+              ]
+            },
+            "selected": {
+              "anyOf": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "type": "string",
+                  "const": "true"
+                },
+                {
+                  "type": "string",
+                  "const": "false"
+                }
+              ]
+            }
+          },
+          "required": [
+            "bounds"
+          ],
+          "additionalProperties": {}
+        }
+      },
+      "required": [
+        "success"
+      ],
+      "additionalProperties": {}
     }
   },
   {
@@ -745,6 +965,138 @@
         "abortStrategy"
       ],
       "additionalProperties": false
+    },
+    "outputSchema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "type": "object",
+      "properties": {
+        "success": {
+          "type": "boolean"
+        },
+        "executedSteps": {
+          "type": "integer",
+          "minimum": -9007199254740991,
+          "maximum": 9007199254740991
+        },
+        "totalSteps": {
+          "type": "integer",
+          "minimum": -9007199254740991,
+          "maximum": 9007199254740991
+        },
+        "failedStep": {
+          "type": "object",
+          "properties": {
+            "stepIndex": {
+              "type": "integer",
+              "minimum": -9007199254740991,
+              "maximum": 9007199254740991
+            },
+            "tool": {
+              "type": "string"
+            },
+            "error": {
+              "type": "string"
+            },
+            "device": {
+              "type": "string"
+            },
+            "failureObservation": {}
+          },
+          "required": [
+            "stepIndex",
+            "tool",
+            "error"
+          ],
+          "additionalProperties": false
+        },
+        "error": {
+          "type": "string"
+        },
+        "platform": {
+          "type": "string",
+          "enum": [
+            "android",
+            "ios"
+          ],
+          "description": "Target platform"
+        },
+        "deviceId": {
+          "type": "string"
+        },
+        "deviceMapping": {
+          "type": "object",
+          "propertyNames": {
+            "type": "string"
+          },
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "debug": {
+          "type": "object",
+          "properties": {
+            "executionTimeMs": {
+              "type": "integer",
+              "minimum": -9007199254740991,
+              "maximum": 9007199254740991
+            },
+            "steps": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "step": {
+                    "type": "string"
+                  },
+                  "status": {
+                    "type": "string",
+                    "enum": [
+                      "completed",
+                      "failed",
+                      "skipped"
+                    ]
+                  },
+                  "durationMs": {
+                    "type": "integer",
+                    "minimum": -9007199254740991,
+                    "maximum": 9007199254740991
+                  },
+                  "details": {}
+                },
+                "required": [
+                  "step",
+                  "status",
+                  "durationMs"
+                ],
+                "additionalProperties": false
+              }
+            },
+            "deviceState": {
+              "type": "object",
+              "properties": {
+                "currentActivity": {
+                  "type": "string"
+                },
+                "focusedWindow": {
+                  "type": "string"
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "required": [
+            "executionTimeMs",
+            "steps"
+          ],
+          "additionalProperties": false
+        }
+      },
+      "required": [
+        "success",
+        "executedSteps",
+        "totalSteps"
+      ],
+      "additionalProperties": {}
     }
   },
   {
@@ -763,6 +1115,41 @@
           "type": "string"
         }
       },
+      "additionalProperties": false
+    },
+    "outputSchema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "type": "object",
+      "properties": {
+        "success": {
+          "type": "boolean"
+        },
+        "recordingId": {
+          "type": "string"
+        },
+        "planName": {
+          "type": "string"
+        },
+        "planContent": {
+          "type": "string"
+        },
+        "stepCount": {
+          "type": "integer",
+          "minimum": -9007199254740991,
+          "maximum": 9007199254740991
+        },
+        "durationMs": {
+          "type": "integer",
+          "minimum": -9007199254740991,
+          "maximum": 9007199254740991
+        },
+        "error": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "success"
+      ],
       "additionalProperties": false
     }
   },
@@ -2648,6 +3035,54 @@
         "action"
       ],
       "additionalProperties": false
+    },
+    "outputSchema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "type": "object",
+      "properties": {
+        "success": {
+          "type": "boolean"
+        },
+        "action": {
+          "type": "string",
+          "enum": [
+            "begin",
+            "end",
+            "status"
+          ]
+        },
+        "recording": {
+          "type": "boolean"
+        },
+        "startedAt": {
+          "type": "string"
+        },
+        "alreadyActive": {
+          "type": "boolean"
+        },
+        "currentStepCount": {
+          "type": "number"
+        },
+        "planName": {
+          "type": "string"
+        },
+        "planContent": {
+          "type": "string"
+        },
+        "stepCount": {
+          "type": "number"
+        },
+        "durationMs": {
+          "type": "number"
+        },
+        "error": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "success"
+      ],
+      "additionalProperties": false
     }
   },
   {
@@ -3124,6 +3559,34 @@
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "type": "object",
       "properties": {},
+      "additionalProperties": false
+    },
+    "outputSchema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "type": "object",
+      "properties": {
+        "success": {
+          "type": "boolean"
+        },
+        "recordingId": {
+          "type": "string"
+        },
+        "startedAt": {
+          "type": "string"
+        },
+        "deviceId": {
+          "type": "string"
+        },
+        "platform": {
+          "type": "string"
+        },
+        "error": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "success"
+      ],
       "additionalProperties": false
     }
   },
@@ -3620,6 +4083,978 @@
         "platform"
       ],
       "additionalProperties": false
+    },
+    "outputSchema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "type": "object",
+      "properties": {
+        "success": {
+          "type": "boolean"
+        },
+        "action": {
+          "type": "string"
+        },
+        "message": {
+          "type": "string"
+        },
+        "element": {
+          "type": "object",
+          "properties": {
+            "bounds": {
+              "type": "object",
+              "properties": {
+                "left": {
+                  "type": "integer",
+                  "minimum": -9007199254740991,
+                  "maximum": 9007199254740991
+                },
+                "top": {
+                  "type": "integer",
+                  "minimum": -9007199254740991,
+                  "maximum": 9007199254740991
+                },
+                "right": {
+                  "type": "integer",
+                  "minimum": -9007199254740991,
+                  "maximum": 9007199254740991
+                },
+                "bottom": {
+                  "type": "integer",
+                  "minimum": -9007199254740991,
+                  "maximum": 9007199254740991
+                },
+                "centerX": {
+                  "type": "integer",
+                  "minimum": -9007199254740991,
+                  "maximum": 9007199254740991
+                },
+                "centerY": {
+                  "type": "integer",
+                  "minimum": -9007199254740991,
+                  "maximum": 9007199254740991
+                }
+              },
+              "required": [
+                "left",
+                "top",
+                "right",
+                "bottom"
+              ],
+              "additionalProperties": false
+            },
+            "text": {
+              "type": "string"
+            },
+            "resource-id": {
+              "type": "string"
+            },
+            "content-desc": {
+              "type": "string"
+            },
+            "class": {
+              "type": "string"
+            },
+            "package": {
+              "type": "string"
+            },
+            "checkable": {
+              "anyOf": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "type": "string",
+                  "const": "true"
+                },
+                {
+                  "type": "string",
+                  "const": "false"
+                }
+              ]
+            },
+            "checked": {
+              "anyOf": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "type": "string",
+                  "const": "true"
+                },
+                {
+                  "type": "string",
+                  "const": "false"
+                }
+              ]
+            },
+            "clickable": {
+              "anyOf": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "type": "string",
+                  "const": "true"
+                },
+                {
+                  "type": "string",
+                  "const": "false"
+                }
+              ]
+            },
+            "enabled": {
+              "anyOf": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "type": "string",
+                  "const": "true"
+                },
+                {
+                  "type": "string",
+                  "const": "false"
+                }
+              ]
+            },
+            "focusable": {
+              "anyOf": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "type": "string",
+                  "const": "true"
+                },
+                {
+                  "type": "string",
+                  "const": "false"
+                }
+              ]
+            },
+            "focused": {
+              "anyOf": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "type": "string",
+                  "const": "true"
+                },
+                {
+                  "type": "string",
+                  "const": "false"
+                }
+              ]
+            },
+            "accessibility-focused": {
+              "anyOf": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "type": "string",
+                  "const": "true"
+                },
+                {
+                  "type": "string",
+                  "const": "false"
+                }
+              ]
+            },
+            "scrollable": {
+              "anyOf": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "type": "string",
+                  "const": "true"
+                },
+                {
+                  "type": "string",
+                  "const": "false"
+                }
+              ]
+            },
+            "selected": {
+              "anyOf": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "type": "string",
+                  "const": "true"
+                },
+                {
+                  "type": "string",
+                  "const": "false"
+                }
+              ]
+            }
+          },
+          "required": [
+            "bounds"
+          ],
+          "additionalProperties": {}
+        },
+        "observation": {
+          "type": "object",
+          "properties": {
+            "selectedElements": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "text": {
+                    "type": "string"
+                  },
+                  "resourceId": {
+                    "type": "string"
+                  },
+                  "contentDesc": {
+                    "type": "string"
+                  },
+                  "bounds": {
+                    "type": "object",
+                    "properties": {
+                      "left": {
+                        "type": "integer",
+                        "minimum": -9007199254740991,
+                        "maximum": 9007199254740991
+                      },
+                      "top": {
+                        "type": "integer",
+                        "minimum": -9007199254740991,
+                        "maximum": 9007199254740991
+                      },
+                      "right": {
+                        "type": "integer",
+                        "minimum": -9007199254740991,
+                        "maximum": 9007199254740991
+                      },
+                      "bottom": {
+                        "type": "integer",
+                        "minimum": -9007199254740991,
+                        "maximum": 9007199254740991
+                      },
+                      "centerX": {
+                        "type": "integer",
+                        "minimum": -9007199254740991,
+                        "maximum": 9007199254740991
+                      },
+                      "centerY": {
+                        "type": "integer",
+                        "minimum": -9007199254740991,
+                        "maximum": 9007199254740991
+                      }
+                    },
+                    "required": [
+                      "left",
+                      "top",
+                      "right",
+                      "bottom"
+                    ],
+                    "additionalProperties": false
+                  },
+                  "indexInMatches": {
+                    "type": "integer",
+                    "minimum": -9007199254740991,
+                    "maximum": 9007199254740991
+                  },
+                  "totalMatches": {
+                    "type": "integer",
+                    "minimum": -9007199254740991,
+                    "maximum": 9007199254740991
+                  },
+                  "selectionStrategy": {
+                    "type": "string"
+                  },
+                  "selectedState": {
+                    "type": "object",
+                    "properties": {
+                      "method": {
+                        "type": "string",
+                        "enum": [
+                          "accessibility",
+                          "visual"
+                        ]
+                      },
+                      "confidence": {
+                        "type": "number"
+                      },
+                      "reason": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "method",
+                      "confidence"
+                    ],
+                    "additionalProperties": false
+                  }
+                },
+                "additionalProperties": {}
+              }
+            },
+            "focusedElement": {
+              "type": "object",
+              "properties": {
+                "bounds": {
+                  "type": "object",
+                  "properties": {
+                    "left": {
+                      "type": "integer",
+                      "minimum": -9007199254740991,
+                      "maximum": 9007199254740991
+                    },
+                    "top": {
+                      "type": "integer",
+                      "minimum": -9007199254740991,
+                      "maximum": 9007199254740991
+                    },
+                    "right": {
+                      "type": "integer",
+                      "minimum": -9007199254740991,
+                      "maximum": 9007199254740991
+                    },
+                    "bottom": {
+                      "type": "integer",
+                      "minimum": -9007199254740991,
+                      "maximum": 9007199254740991
+                    },
+                    "centerX": {
+                      "type": "integer",
+                      "minimum": -9007199254740991,
+                      "maximum": 9007199254740991
+                    },
+                    "centerY": {
+                      "type": "integer",
+                      "minimum": -9007199254740991,
+                      "maximum": 9007199254740991
+                    }
+                  },
+                  "required": [
+                    "left",
+                    "top",
+                    "right",
+                    "bottom"
+                  ],
+                  "additionalProperties": false
+                },
+                "text": {
+                  "type": "string"
+                },
+                "resource-id": {
+                  "type": "string"
+                },
+                "content-desc": {
+                  "type": "string"
+                },
+                "class": {
+                  "type": "string"
+                },
+                "package": {
+                  "type": "string"
+                },
+                "checkable": {
+                  "anyOf": [
+                    {
+                      "type": "boolean"
+                    },
+                    {
+                      "type": "string",
+                      "const": "true"
+                    },
+                    {
+                      "type": "string",
+                      "const": "false"
+                    }
+                  ]
+                },
+                "checked": {
+                  "anyOf": [
+                    {
+                      "type": "boolean"
+                    },
+                    {
+                      "type": "string",
+                      "const": "true"
+                    },
+                    {
+                      "type": "string",
+                      "const": "false"
+                    }
+                  ]
+                },
+                "clickable": {
+                  "anyOf": [
+                    {
+                      "type": "boolean"
+                    },
+                    {
+                      "type": "string",
+                      "const": "true"
+                    },
+                    {
+                      "type": "string",
+                      "const": "false"
+                    }
+                  ]
+                },
+                "enabled": {
+                  "anyOf": [
+                    {
+                      "type": "boolean"
+                    },
+                    {
+                      "type": "string",
+                      "const": "true"
+                    },
+                    {
+                      "type": "string",
+                      "const": "false"
+                    }
+                  ]
+                },
+                "focusable": {
+                  "anyOf": [
+                    {
+                      "type": "boolean"
+                    },
+                    {
+                      "type": "string",
+                      "const": "true"
+                    },
+                    {
+                      "type": "string",
+                      "const": "false"
+                    }
+                  ]
+                },
+                "focused": {
+                  "anyOf": [
+                    {
+                      "type": "boolean"
+                    },
+                    {
+                      "type": "string",
+                      "const": "true"
+                    },
+                    {
+                      "type": "string",
+                      "const": "false"
+                    }
+                  ]
+                },
+                "accessibility-focused": {
+                  "anyOf": [
+                    {
+                      "type": "boolean"
+                    },
+                    {
+                      "type": "string",
+                      "const": "true"
+                    },
+                    {
+                      "type": "string",
+                      "const": "false"
+                    }
+                  ]
+                },
+                "scrollable": {
+                  "anyOf": [
+                    {
+                      "type": "boolean"
+                    },
+                    {
+                      "type": "string",
+                      "const": "true"
+                    },
+                    {
+                      "type": "string",
+                      "const": "false"
+                    }
+                  ]
+                },
+                "selected": {
+                  "anyOf": [
+                    {
+                      "type": "boolean"
+                    },
+                    {
+                      "type": "string",
+                      "const": "true"
+                    },
+                    {
+                      "type": "string",
+                      "const": "false"
+                    }
+                  ]
+                }
+              },
+              "required": [
+                "bounds"
+              ],
+              "additionalProperties": {}
+            },
+            "accessibilityFocusedElement": {
+              "type": "object",
+              "properties": {
+                "bounds": {
+                  "type": "object",
+                  "properties": {
+                    "left": {
+                      "type": "integer",
+                      "minimum": -9007199254740991,
+                      "maximum": 9007199254740991
+                    },
+                    "top": {
+                      "type": "integer",
+                      "minimum": -9007199254740991,
+                      "maximum": 9007199254740991
+                    },
+                    "right": {
+                      "type": "integer",
+                      "minimum": -9007199254740991,
+                      "maximum": 9007199254740991
+                    },
+                    "bottom": {
+                      "type": "integer",
+                      "minimum": -9007199254740991,
+                      "maximum": 9007199254740991
+                    },
+                    "centerX": {
+                      "type": "integer",
+                      "minimum": -9007199254740991,
+                      "maximum": 9007199254740991
+                    },
+                    "centerY": {
+                      "type": "integer",
+                      "minimum": -9007199254740991,
+                      "maximum": 9007199254740991
+                    }
+                  },
+                  "required": [
+                    "left",
+                    "top",
+                    "right",
+                    "bottom"
+                  ],
+                  "additionalProperties": false
+                },
+                "text": {
+                  "type": "string"
+                },
+                "resource-id": {
+                  "type": "string"
+                },
+                "content-desc": {
+                  "type": "string"
+                },
+                "class": {
+                  "type": "string"
+                },
+                "package": {
+                  "type": "string"
+                },
+                "checkable": {
+                  "anyOf": [
+                    {
+                      "type": "boolean"
+                    },
+                    {
+                      "type": "string",
+                      "const": "true"
+                    },
+                    {
+                      "type": "string",
+                      "const": "false"
+                    }
+                  ]
+                },
+                "checked": {
+                  "anyOf": [
+                    {
+                      "type": "boolean"
+                    },
+                    {
+                      "type": "string",
+                      "const": "true"
+                    },
+                    {
+                      "type": "string",
+                      "const": "false"
+                    }
+                  ]
+                },
+                "clickable": {
+                  "anyOf": [
+                    {
+                      "type": "boolean"
+                    },
+                    {
+                      "type": "string",
+                      "const": "true"
+                    },
+                    {
+                      "type": "string",
+                      "const": "false"
+                    }
+                  ]
+                },
+                "enabled": {
+                  "anyOf": [
+                    {
+                      "type": "boolean"
+                    },
+                    {
+                      "type": "string",
+                      "const": "true"
+                    },
+                    {
+                      "type": "string",
+                      "const": "false"
+                    }
+                  ]
+                },
+                "focusable": {
+                  "anyOf": [
+                    {
+                      "type": "boolean"
+                    },
+                    {
+                      "type": "string",
+                      "const": "true"
+                    },
+                    {
+                      "type": "string",
+                      "const": "false"
+                    }
+                  ]
+                },
+                "focused": {
+                  "anyOf": [
+                    {
+                      "type": "boolean"
+                    },
+                    {
+                      "type": "string",
+                      "const": "true"
+                    },
+                    {
+                      "type": "string",
+                      "const": "false"
+                    }
+                  ]
+                },
+                "accessibility-focused": {
+                  "anyOf": [
+                    {
+                      "type": "boolean"
+                    },
+                    {
+                      "type": "string",
+                      "const": "true"
+                    },
+                    {
+                      "type": "string",
+                      "const": "false"
+                    }
+                  ]
+                },
+                "scrollable": {
+                  "anyOf": [
+                    {
+                      "type": "boolean"
+                    },
+                    {
+                      "type": "string",
+                      "const": "true"
+                    },
+                    {
+                      "type": "string",
+                      "const": "false"
+                    }
+                  ]
+                },
+                "selected": {
+                  "anyOf": [
+                    {
+                      "type": "boolean"
+                    },
+                    {
+                      "type": "string",
+                      "const": "true"
+                    },
+                    {
+                      "type": "string",
+                      "const": "false"
+                    }
+                  ]
+                }
+              },
+              "required": [
+                "bounds"
+              ],
+              "additionalProperties": {}
+            },
+            "activeWindow": {
+              "type": "object",
+              "properties": {
+                "appId": {
+                  "type": "string"
+                },
+                "activityName": {
+                  "type": "string"
+                },
+                "layoutSeqSum": {
+                  "type": "integer",
+                  "minimum": -9007199254740991,
+                  "maximum": 9007199254740991
+                },
+                "type": {
+                  "type": "string"
+                }
+              },
+              "additionalProperties": {}
+            }
+          },
+          "additionalProperties": {}
+        },
+        "selectedElement": {
+          "type": "object",
+          "properties": {
+            "text": {
+              "type": "string"
+            },
+            "resourceId": {
+              "type": "string"
+            },
+            "contentDesc": {
+              "type": "string"
+            },
+            "bounds": {
+              "type": "object",
+              "properties": {
+                "left": {
+                  "type": "integer",
+                  "minimum": -9007199254740991,
+                  "maximum": 9007199254740991
+                },
+                "top": {
+                  "type": "integer",
+                  "minimum": -9007199254740991,
+                  "maximum": 9007199254740991
+                },
+                "right": {
+                  "type": "integer",
+                  "minimum": -9007199254740991,
+                  "maximum": 9007199254740991
+                },
+                "bottom": {
+                  "type": "integer",
+                  "minimum": -9007199254740991,
+                  "maximum": 9007199254740991
+                },
+                "centerX": {
+                  "type": "integer",
+                  "minimum": -9007199254740991,
+                  "maximum": 9007199254740991
+                },
+                "centerY": {
+                  "type": "integer",
+                  "minimum": -9007199254740991,
+                  "maximum": 9007199254740991
+                }
+              },
+              "required": [
+                "left",
+                "top",
+                "right",
+                "bottom"
+              ],
+              "additionalProperties": false
+            },
+            "indexInMatches": {
+              "type": "integer",
+              "minimum": -9007199254740991,
+              "maximum": 9007199254740991
+            },
+            "totalMatches": {
+              "type": "integer",
+              "minimum": -9007199254740991,
+              "maximum": 9007199254740991
+            },
+            "selectionStrategy": {
+              "type": "string"
+            },
+            "selectedState": {
+              "type": "object",
+              "properties": {
+                "method": {
+                  "type": "string",
+                  "enum": [
+                    "accessibility",
+                    "visual"
+                  ]
+                },
+                "confidence": {
+                  "type": "number"
+                },
+                "reason": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "method",
+                "confidence"
+              ],
+              "additionalProperties": false
+            }
+          },
+          "additionalProperties": {}
+        },
+        "selectedElements": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "text": {
+                "type": "string"
+              },
+              "resourceId": {
+                "type": "string"
+              },
+              "contentDesc": {
+                "type": "string"
+              },
+              "bounds": {
+                "type": "object",
+                "properties": {
+                  "left": {
+                    "type": "integer",
+                    "minimum": -9007199254740991,
+                    "maximum": 9007199254740991
+                  },
+                  "top": {
+                    "type": "integer",
+                    "minimum": -9007199254740991,
+                    "maximum": 9007199254740991
+                  },
+                  "right": {
+                    "type": "integer",
+                    "minimum": -9007199254740991,
+                    "maximum": 9007199254740991
+                  },
+                  "bottom": {
+                    "type": "integer",
+                    "minimum": -9007199254740991,
+                    "maximum": 9007199254740991
+                  },
+                  "centerX": {
+                    "type": "integer",
+                    "minimum": -9007199254740991,
+                    "maximum": 9007199254740991
+                  },
+                  "centerY": {
+                    "type": "integer",
+                    "minimum": -9007199254740991,
+                    "maximum": 9007199254740991
+                  }
+                },
+                "required": [
+                  "left",
+                  "top",
+                  "right",
+                  "bottom"
+                ],
+                "additionalProperties": false
+              },
+              "indexInMatches": {
+                "type": "integer",
+                "minimum": -9007199254740991,
+                "maximum": 9007199254740991
+              },
+              "totalMatches": {
+                "type": "integer",
+                "minimum": -9007199254740991,
+                "maximum": 9007199254740991
+              },
+              "selectionStrategy": {
+                "type": "string"
+              },
+              "selectedState": {
+                "type": "object",
+                "properties": {
+                  "method": {
+                    "type": "string",
+                    "enum": [
+                      "accessibility",
+                      "visual"
+                    ]
+                  },
+                  "confidence": {
+                    "type": "number"
+                  },
+                  "reason": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "method",
+                  "confidence"
+                ],
+                "additionalProperties": false
+              }
+            },
+            "additionalProperties": {}
+          }
+        },
+        "error": {
+          "type": "string"
+        },
+        "pressRecognized": {
+          "type": "boolean"
+        },
+        "contextMenuOpened": {
+          "type": "boolean"
+        },
+        "selectionStarted": {
+          "type": "boolean"
+        },
+        "searchUntil": {
+          "type": "object",
+          "properties": {
+            "durationMs": {
+              "type": "integer",
+              "minimum": -9007199254740991,
+              "maximum": 9007199254740991
+            },
+            "requestCount": {
+              "type": "integer",
+              "minimum": -9007199254740991,
+              "maximum": 9007199254740991
+            },
+            "changeCount": {
+              "type": "integer",
+              "minimum": -9007199254740991,
+              "maximum": 9007199254740991
+            }
+          },
+          "required": [
+            "durationMs",
+            "requestCount",
+            "changeCount"
+          ],
+          "additionalProperties": {}
+        },
+        "debug": {}
+      },
+      "required": [
+        "success"
+      ],
+      "additionalProperties": {}
     }
   },
   {

--- a/src/features/action/PressButton.ts
+++ b/src/features/action/PressButton.ts
@@ -5,6 +5,7 @@ import { createGlobalPerformanceTracker } from "../../utils/PerformanceTracker";
 import { IOSCtrlProxyClient } from "../observe/ios";
 import { AndroidCtrlProxyClient } from "../observe/android";
 import { logger } from "../../utils/logger";
+import { isIosSimulatorUdid } from "../../utils/ios-cmdline-tools/iosDeviceType";
 
 export class PressButton extends BaseVisualChange {
   constructor(device: BootedDevice, adb: AdbClient | null = null) {
@@ -67,6 +68,8 @@ export class PressButton extends BaseVisualChange {
 
   // Buttons that can be handled via accessibility service global actions
   private static readonly GLOBAL_ACTION_BUTTONS = new Set(["back", "home", "recent"]);
+  private static readonly IOS_NAVIGATION_BUTTONS = new Set(["home", "back", "recent"]);
+  private static readonly IOS_HARDWARE_BUTTONS = new Set(["volume_up", "volume_down", "power"]);
 
   /**
    * Execute Android-specific button press.
@@ -121,32 +124,65 @@ export class PressButton extends BaseVisualChange {
    */
   private async executeiOSButtonPress(button: string): Promise<PressButtonResult> {
     const normalizedButton = button.toLowerCase();
-    const supportedButtons = new Set(["home", "back", "recent"]);
-    if (!supportedButtons.has(normalizedButton)) {
+    if (PressButton.IOS_NAVIGATION_BUTTONS.has(normalizedButton)) {
+      const client = IOSCtrlProxyClient.getInstance(this.device);
+      const result = await this.executeiOSNavigationButton(client, normalizedButton);
+
+      if (!result.success) {
+        return {
+          success: false,
+          button,
+          keyCode: -1,
+          error: result.error ?? `Failed to press iOS ${normalizedButton} button`
+        };
+      }
+
       return {
-        success: false,
+        success: true,
         button,
-        keyCode: -1,
-        error: `Unsupported iOS simulator button: ${button}`
+        keyCode: -1
       };
     }
 
-    const client = IOSCtrlProxyClient.getInstance(this.device);
-    const result = await this.executeiOSNavigationButton(client, normalizedButton);
+    if (PressButton.IOS_HARDWARE_BUTTONS.has(normalizedButton)) {
+      if (isIosSimulatorUdid(this.device.deviceId)) {
+        return {
+          success: false,
+          button,
+          keyCode: -1,
+          error: `iOS button "${button}" is unavailable on the iOS simulator (physical device only)`
+        };
+      }
 
-    if (!result.success) {
+      const client = IOSCtrlProxyClient.getInstance(this.device);
+      const result = await client.requestPressButton(normalizedButton);
+
+      if (!result.success) {
+        return {
+          success: false,
+          button,
+          keyCode: -1,
+          error: result.error ?? `iOS hardware button "${button}" is not supported on this device`
+        };
+      }
+
+      return { success: true, button, keyCode: -1 };
+    }
+
+    if (normalizedButton === "menu") {
       return {
         success: false,
         button,
         keyCode: -1,
-        error: result.error ?? `Failed to press iOS ${normalizedButton} button`
+        error: "iOS has no menu hardware button"
       };
     }
 
     return {
-      success: true,
+      success: false,
       button,
-      keyCode: -1
+      keyCode: -1,
+      error: `Unsupported iOS button: ${button}`
     };
   }
 

--- a/src/features/observe/ios/CtrlProxyNavigation.ts
+++ b/src/features/observe/ios/CtrlProxyNavigation.ts
@@ -11,6 +11,7 @@ import type {
   CtrlProxyPressHomeResult,
   CtrlProxyPressBackResult,
   CtrlProxyShakeResult,
+  CtrlProxyPressButtonResult,
   CtrlProxyRecentAppsResult,
   CtrlProxyLaunchAppResult,
   CtrlProxyRotateResult,
@@ -81,6 +82,27 @@ export class CtrlProxyNavigation {
       cancelScreenshotBackoff: false,
       notConnectedMessage: "Not connected to CtrlProxy",
       errorLabel: "Shake",
+    });
+  }
+
+  /**
+   * Request to press a named iOS hardware or navigation button.
+   */
+  async requestPressButton(
+    button: string,
+    timeoutMs: number = 5000,
+    perf?: PerformanceTracker
+  ): Promise<CtrlProxyPressButtonResult> {
+    return sendCommand<CtrlProxyPressButtonResult>(this.context, {
+      idPrefix: "pressButton",
+      responseType: "press_button",
+      messageType: "request_press_button",
+      params: { action: button },
+      timeoutMs,
+      perf,
+      cancelScreenshotBackoff: false,
+      notConnectedMessage: "Not connected to CtrlProxy",
+      errorLabel: "Press button",
     });
   }
 

--- a/src/features/observe/ios/IOSCtrlProxyClient.ts
+++ b/src/features/observe/ios/IOSCtrlProxyClient.ts
@@ -126,6 +126,7 @@ import type {
   CtrlProxyPressHomeResult,
   CtrlProxyPressBackResult,
   CtrlProxyShakeResult,
+  CtrlProxyPressButtonResult,
   CtrlProxyRecentAppsResult,
   CtrlProxyRotateResult,
   CtrlProxyLaunchAppResult,
@@ -228,6 +229,10 @@ export interface IOSCtrlProxy extends CtrlProxyClient {
   requestShake(
     timeoutMs?: number, perf?: PerformanceTracker
   ): Promise<CtrlProxyShakeResult>;
+
+  requestPressButton(
+    button: string, timeoutMs?: number, perf?: PerformanceTracker
+  ): Promise<CtrlProxyPressButtonResult>;
 
   requestRecentApps(
     timeoutMs?: number, perf?: PerformanceTracker
@@ -1475,6 +1480,12 @@ export class IOSCtrlProxyClient extends DeviceServiceClient implements IOSCtrlPr
     timeoutMs: number = 5000, perf?: PerformanceTracker
   ): Promise<CtrlProxyShakeResult> {
     return this.navigation.requestShake(timeoutMs, perf);
+  }
+
+  async requestPressButton(
+    button: string, timeoutMs: number = 5000, perf?: PerformanceTracker
+  ): Promise<CtrlProxyPressButtonResult> {
+    return this.navigation.requestPressButton(button, timeoutMs, perf);
   }
 
   async requestRecentApps(

--- a/src/features/observe/ios/index.ts
+++ b/src/features/observe/ios/index.ts
@@ -42,6 +42,7 @@ export type {
   CtrlProxyPressHomeResult,
   CtrlProxyPressBackResult,
   CtrlProxyShakeResult,
+  CtrlProxyPressButtonResult,
   CtrlProxyRecentAppsResult,
   CtrlProxyRotateResult,
   CtrlProxyLaunchAppResult,

--- a/src/features/observe/ios/types.ts
+++ b/src/features/observe/ios/types.ts
@@ -169,6 +169,9 @@ export type CtrlProxyPressBackResult = BaseResult;
 /** Shake result from CtrlProxy iOS */
 export type CtrlProxyShakeResult = BaseResult;
 
+/** Generic press button result from CtrlProxy iOS */
+export type CtrlProxyPressButtonResult = BaseResult;
+
 /** Rotate result from CtrlProxy iOS */
 export interface CtrlProxyRotateResult extends BaseResult {
   previousOrientation: string;

--- a/src/server/interactionTools.ts
+++ b/src/server/interactionTools.ts
@@ -32,6 +32,7 @@ import {
   elementContainerSchema,
   elementSelectionStrategySchema,
 } from "./elementSelectorSchemas";
+import { tapOnResultSchema } from "./toolOutputSchemas";
 
 // Import from extracted modules
 import type {
@@ -995,7 +996,9 @@ export function registerInteractionTools() {
     "content-desc values from observe should be passed as text, not elementId.",
     tapOnSchema,
     tapOnHandler,
-    true
+    true,
+    false,
+    { outputSchema: tapOnResultSchema }
   );
 
   ToolRegistry.registerDeviceAware(

--- a/src/server/toolOutputSchemas.ts
+++ b/src/server/toolOutputSchemas.ts
@@ -62,6 +62,28 @@ export const observationSummarySchema = z.object({
   activeWindow: activeWindowSchema.optional()
 }).passthrough();
 
+const tapOnSearchUntilSchema = z.object({
+  durationMs: z.number().int(),
+  requestCount: z.number().int(),
+  changeCount: z.number().int()
+}).passthrough();
+
+export const tapOnResultSchema = z.object({
+  success: z.boolean(),
+  action: z.string().optional(),
+  message: z.string().optional(),
+  element: elementSchema.optional(),
+  observation: observationSummarySchema.optional(),
+  selectedElement: selectedElementSchema.optional(),
+  selectedElements: z.array(selectedElementSchema).optional(),
+  error: z.string().optional(),
+  pressRecognized: z.boolean().optional(),
+  contextMenuOpened: z.boolean().optional(),
+  selectionStarted: z.boolean().optional(),
+  searchUntil: tapOnSearchUntilSchema.optional(),
+  debug: z.any().optional()
+}).passthrough();
+
 export const screenSizeSchema = z.object({
   width: z.number().int(),
   height: z.number().int()

--- a/src/server/toolRegistry.ts
+++ b/src/server/toolRegistry.ts
@@ -821,12 +821,26 @@ class ToolRegistryClass {
   // Get tools in MCP format
   getToolDefinitions() {
     const alwaysLoad = process.env.AUTOMOBILE_ALWAYS_LOAD_TOOLS === "true";
-    return this.getAllTools().map(tool => ({
-      name: tool.name,
-      description: tool.description,
-      inputSchema: flattenTopLevelUnion(toJSONSchema(tool.schema)),
-      ...(alwaysLoad && { _meta: { "anthropic/alwaysLoad": true } })
-    }));
+    return this.getAllTools().map(tool => {
+      const definition: {
+        name: string;
+        description: string;
+        inputSchema: Record<string, unknown>;
+        outputSchema?: Record<string, unknown>;
+        _meta?: { "anthropic/alwaysLoad": true };
+      } = {
+        name: tool.name,
+        description: tool.description,
+        inputSchema: flattenTopLevelUnion(toJSONSchema(tool.schema)),
+        ...(alwaysLoad && { _meta: { "anthropic/alwaysLoad": true } })
+      };
+
+      if (tool.outputSchema) {
+        definition.outputSchema = flattenTopLevelUnion(toJSONSchema(tool.outputSchema));
+      }
+
+      return definition;
+    });
   }
 
   // Get a map of all schema

--- a/test/fakes/FakeIOSCtrlProxy.ts
+++ b/test/fakes/FakeIOSCtrlProxy.ts
@@ -12,6 +12,7 @@ import {
   CtrlProxyPressHomeResult,
   CtrlProxyPressBackResult,
   CtrlProxyShakeResult,
+  CtrlProxyPressButtonResult,
   CtrlProxyRecentAppsResult,
   CtrlProxyRotateResult,
   CtrlProxyLaunchAppResult,
@@ -817,6 +818,21 @@ export class FakeIOSCtrlProxy implements IOSCtrlProxy {
     this.shakeTimeoutHistory.push(timeoutMs);
     await this.applyDelay("shake");
     this.checkFailure("shake");
+
+    return {
+      success: true,
+      totalTimeMs: 100,
+      perfTiming: this.performanceTiming || undefined
+    };
+  }
+
+  async requestPressButton(
+    button: string,
+    timeoutMs: number = 5000,
+    perf?: PerformanceTracker
+  ): Promise<CtrlProxyPressButtonResult> {
+    await this.applyDelay("pressButton");
+    this.checkFailure("pressButton");
 
     return {
       success: true,

--- a/test/features/action/PressButton.test.ts
+++ b/test/features/action/PressButton.test.ts
@@ -10,6 +10,12 @@ describe("PressButton", () => {
     name: "iPhone"
   };
 
+  const iosSimulator: BootedDevice = {
+    deviceId: "A1B2C3D4-E5F6-7890-ABCD-EF1234567890",
+    platform: "ios",
+    name: "iPhone Simulator"
+  };
+
   test("ios back delegates to CtrlProxy pressBack", async () => {
     let backCalls = 0;
     const getInstanceSpy = spyOn(IOSCtrlProxyClient, "getInstance").mockReturnValue({
@@ -61,6 +67,79 @@ describe("PressButton", () => {
     const result = await (pressButton as any).executeiOSButtonPress("menu");
 
     expect(result.success).toBe(false);
-    expect(result.error).toContain("Unsupported iOS simulator button");
+    expect(result.error).toContain("no menu hardware button");
+  });
+
+  test("ios hardware buttons delegate to generic CtrlProxy pressButton on physical devices", async () => {
+    const pressButtonCalls: string[] = [];
+    const getInstanceSpy = spyOn(IOSCtrlProxyClient, "getInstance").mockReturnValue({
+      requestPressBack: async () => ({ success: true, totalTimeMs: 5 }),
+      requestPressHome: async () => ({ success: true, totalTimeMs: 5 }),
+      requestRecentApps: async () => ({ success: true, totalTimeMs: 5 }),
+      requestPressButton: async (button: string) => {
+        pressButtonCalls.push(button);
+        return { success: true, totalTimeMs: 5 };
+      }
+    } as any);
+
+    try {
+      const pressButton = new PressButton(iosDevice);
+
+      for (const button of ["volume_up", "volume_down", "power"]) {
+        const result = await (pressButton as any).executeiOSButtonPress(button);
+        expect(result).toEqual({ success: true, button, keyCode: -1 });
+      }
+
+      expect(pressButtonCalls).toEqual(["volume_up", "volume_down", "power"]);
+      expect(getInstanceSpy).toHaveBeenCalledTimes(3);
+    } finally {
+      getInstanceSpy.mockRestore();
+    }
+  });
+
+  test("ios simulator rejects hardware buttons without contacting CtrlProxy", async () => {
+    const getInstanceSpy = spyOn(IOSCtrlProxyClient, "getInstance").mockReturnValue({
+      requestPressButton: async () => {
+        throw new Error("should not be called");
+      }
+    } as any);
+
+    try {
+      const pressButton = new PressButton(iosSimulator);
+
+      for (const button of ["volume_up", "volume_down", "power"]) {
+        const result = await (pressButton as any).executeiOSButtonPress(button);
+        expect(result.success).toBe(false);
+        expect(result.button).toBe(button);
+        expect(result.keyCode).toBe(-1);
+        expect(result.error).toContain("unavailable on the iOS simulator");
+      }
+
+      expect(getInstanceSpy).not.toHaveBeenCalled();
+    } finally {
+      getInstanceSpy.mockRestore();
+    }
+  });
+
+  test("ios hardware button runner failures return structured errors", async () => {
+    const getInstanceSpy = spyOn(IOSCtrlProxyClient, "getInstance").mockReturnValue({
+      requestPressButton: async () => ({
+        success: false,
+        error: "Power/lock button is not supported on this device",
+        totalTimeMs: 5
+      })
+    } as any);
+
+    try {
+      const pressButton = new PressButton(iosDevice);
+      const result = await (pressButton as any).executeiOSButtonPress("power");
+
+      expect(result.success).toBe(false);
+      expect(result.button).toBe("power");
+      expect(result.keyCode).toBe(-1);
+      expect(result.error).toBe("Power/lock button is not supported on this device");
+    } finally {
+      getInstanceSpy.mockRestore();
+    }
   });
 });

--- a/test/features/observe/DeviceServiceInterface.test.ts
+++ b/test/features/observe/DeviceServiceInterface.test.ts
@@ -172,6 +172,7 @@ describe("DeviceService Interface Compliance", () => {
       expect(typeof client.requestLaunchApp).toBe("function");
       expect(typeof client.requestPressHome).toBe("function");
       expect(typeof client.requestPressBack).toBe("function");
+      expect(typeof client.requestPressButton).toBe("function");
       expect(typeof client.requestRecentApps).toBe("function");
       expect(typeof client.requestKeyboard).toBe("function");
 

--- a/test/features/observe/ios/IOSCtrlProxyClient.test.ts
+++ b/test/features/observe/ios/IOSCtrlProxyClient.test.ts
@@ -1058,6 +1058,45 @@ describe("IOSCtrlProxyClient", function() {
     });
   });
 
+  describe("requestPressButton", function() {
+    test("should send generic press button request and return result", async function() {
+      const testTimer = fakeTimer;
+
+      const { factory, getSocket } = createCapturingWebSocketFactory(testTimer);
+      const testClient = IOSCtrlProxyClient.createForTesting(
+        testDevice,
+        serverPort,
+        factory,
+        testTimer
+      );
+
+      try {
+        const resultPromise = testClient.requestPressButton("volume_up", 5000);
+        const socket = await waitForSocket(getSocket);
+        expect(socket).not.toBeNull();
+        await waitForSocketOpen(socket);
+        await waitForSentMessages(socket, 1);
+
+        const sentMessage = JSON.parse(socket!.sentMessages[0]);
+        expect(sentMessage.type).toBe("request_press_button");
+        expect(sentMessage.action).toBe("volume_up");
+
+        socket!.simulateMessage(JSON.stringify({
+          type: "press_button_result",
+          requestId: sentMessage.requestId,
+          success: true,
+          totalTimeMs: 90
+        }));
+
+        const result = await resultPromise;
+        expect(result.success).toBe(true);
+        expect(result.totalTimeMs).toBe(90);
+      } finally {
+        await testClient.close();
+      }
+    });
+  });
+
   describe("connection management", function() {
     test("isConnected should return true when WebSocket is open", async function() {
       const testTimer = fakeTimer;

--- a/test/server/tools/registry.test.ts
+++ b/test/server/tools/registry.test.ts
@@ -58,12 +58,16 @@ describe("MCP Tools Registry", () => {
     });
   });
 
-  test("should omit output schemas from generated MCP tool definitions", () => {
+  test("should expose registered output schemas in generated MCP tool definitions", () => {
     const toolDefinitions = ToolRegistry.getToolDefinitions();
 
-    expect(toolDefinitions.length).toBeGreaterThan(0);
-    for (const tool of toolDefinitions) {
-      expect(tool).not.toHaveProperty("outputSchema");
+    for (const toolName of ["executePlan", "tapOn"]) {
+      const tool = toolDefinitions.find(definition => definition.name === toolName);
+      expect(tool).toBeDefined();
+      expect(tool).toHaveProperty("outputSchema");
+      expect(tool!.outputSchema).toHaveProperty("type", "object");
+      expect(tool!.outputSchema.properties).toHaveProperty("success");
+      expect(tool!.outputSchema.required).toContain("success");
     }
   });
 


### PR DESCRIPTION
## Summary

- Adds iOS `pressButton` support for `volume_up`, `volume_down`, and `power` on physical devices.
- Returns explicit simulator-only unsupported errors for iOS hardware buttons and keeps `menu` unsupported because iOS has no menu hardware button.
- Wires the existing CtrlProxy `request_press_button` / `press_button_result` endpoint through the TypeScript client, feature layer, tests, and docs.
- Fixes the Claude plugin marketplace source path so the repo's fast validation passes.

## Why

Fixes #2485. Android already accepts hardware button values, while iOS rejected them before reaching the runner. This lets cross-platform plans degrade correctly: physical iOS devices route supported hardware buttons, simulators return clear unavailable errors, and `menu` remains a by-design unsupported value.

## Implementation Notes

- `volume_up` and `volume_down` use `XCUIDevice.shared.press(.volumeUp/.volumeDown)` on physical iOS devices.
- `power` dispatches an IOHID consumer-page power event on physical iOS devices, with both public and private IOKit framework lookup paths.
- iOS simulator detection uses the existing `isIosSimulatorUdid` helper in the TypeScript fast path, with runner-side simulator guards as a backstop.

## Validation

- `bun test test/features/action/PressButton.test.ts test/features/observe/ios/IOSCtrlProxyClient.test.ts test/features/observe/DeviceServiceInterface.test.ts`
- `bun test`
- `bun run build`
- `bun run turbo:validate`
- `bash scripts/ios/swift-test.sh`
- `bash scripts/ios/swift-build.sh`
- `bash scripts/ios/xcode-build.sh`
- `xcodebuild -project ios/control-proxy/CtrlProxy.xcodeproj -scheme CtrlProxyApp -destination 'generic/platform=iOS' -configuration Debug -quiet CODE_SIGN_IDENTITY='-' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO build`
- `bash scripts/all_fast_validate_checks.sh`

## Notes

- `ONLY_TOUCHED_FILES=true bash scripts/swiftformat/validate_swiftformat.sh` still reports existing formatting issues across the touched Swift files outside this diff. New added lines were wrapped manually and the Swift build/test validations pass.
- `bash scripts/validate-bun-test-timings.sh` was attempted and hit unrelated full-suite instability / existing slow tests; the relevant new unit tests complete well under 100ms individually.
