### PR TITLE
fix merged review feedback

### DIFF
--- a/.lycherc.toml
+++ b/.lycherc.toml
@@ -17,7 +17,8 @@ exclude = [
     "^https://hub\\.docker\\.com/",
     # WebAIM contrast checker has unreliable uptime / timeouts in CI
     "^https://webaim\\.org/",
-    # Contributor Covenant translations page intermittently resets CI connections
+    # Contributor Covenant pages intermittently reset CI connections
+    "^https://www\\.contributor-covenant\\.org/?$",
     "^https://www\\.contributor-covenant\\.org/translations/?$",
 ]
 

--- a/ios/auto-mobile-sdk/Sources/AutoMobileSDK/ViewHierarchy/SdkHierarchyServer.swift
+++ b/ios/auto-mobile-sdk/Sources/AutoMobileSDK/ViewHierarchy/SdkHierarchyServer.swift
@@ -13,6 +13,7 @@ import Network
 final class SdkHierarchyServer: @unchecked Sendable {
 
     static let port: UInt16 = 8766
+    private static let httpHeaderDelimiter = Data("\r\n\r\n".utf8)
 
     private let lock = NSLock()
     private var listener: NWListener?
@@ -86,45 +87,54 @@ final class SdkHierarchyServer: @unchecked Sendable {
                 return
             }
 
-            guard let data, let request = String(data: data, encoding: .utf8) else {
+            guard let data = data else {
                 connection.cancel()
                 return
             }
 
-            if request.contains("GET /hierarchy/fresh") {
-                self.handleFreshHierarchy(connection)
-            } else if request.contains("GET /hierarchy") {
-                self.handleCachedHierarchy(connection)
-            } else if request.contains("GET /health") {
-                self.handleHealth(connection)
-            } else if request.contains("POST /network/mock") {
-                self.handleNetworkMock(connection, data: data)
-            } else if request.contains("POST /highlight") {
-                self.handleHighlight(connection, data: data)
-            } else if request.contains("POST /db/execute") {
-                self.sendRouteResponse(
-                    connection,
-                    self.databaseRouteHandler.handleExecuteSql(body: Self.httpBody(from: data) ?? Data())
-                )
-            } else if request.contains("POST /db/list") {
-                self.sendRouteResponse(connection, self.databaseRouteHandler.handleListDatabases())
-            } else if request.contains("POST /db/tables") {
-                self.sendRouteResponse(
-                    connection,
-                    self.databaseRouteHandler.handleListTables(body: Self.httpBody(from: data) ?? Data())
-                )
-            } else if request.contains("POST /db/table-data") {
-                self.sendRouteResponse(
-                    connection,
-                    self.databaseRouteHandler.handleTableData(body: Self.httpBody(from: data) ?? Data())
-                )
-            } else if request.contains("POST /db/table-structure") {
-                self.sendRouteResponse(
-                    connection,
-                    self.databaseRouteHandler.handleTableStructure(body: Self.httpBody(from: data) ?? Data())
-                )
-            } else {
-                self.sendResponse(connection, statusCode: 404, body: Data("{\"error\":\"not_found\"}".utf8))
+            self.readCompleteHttpHeaders(connection, initialData: data) { [weak self] requestData in
+                guard let self = self else {
+                    connection.cancel()
+                    return
+                }
+                guard let requestData = requestData,
+                      let headerData = Self.httpHeaderData(from: requestData),
+                      let request = String(data: headerData, encoding: .utf8) else {
+                    connection.cancel()
+                    return
+                }
+
+                if request.contains("GET /hierarchy/fresh") {
+                    self.handleFreshHierarchy(connection)
+                } else if request.contains("GET /hierarchy") {
+                    self.handleCachedHierarchy(connection)
+                } else if request.contains("GET /health") {
+                    self.handleHealth(connection)
+                } else if request.contains("POST /network/mock") {
+                    self.handleNetworkMock(connection, initialData: requestData)
+                } else if request.contains("POST /highlight") {
+                    self.handleHighlight(connection, initialData: requestData)
+                } else if request.contains("POST /db/execute") {
+                    self.handleBodyRoute(connection, initialData: requestData) {
+                        self.databaseRouteHandler.handleExecuteSql(body: $0)
+                    }
+                } else if request.contains("POST /db/list") {
+                    self.sendRouteResponse(connection, self.databaseRouteHandler.handleListDatabases())
+                } else if request.contains("POST /db/tables") {
+                    self.handleBodyRoute(connection, initialData: requestData) {
+                        self.databaseRouteHandler.handleListTables(body: $0)
+                    }
+                } else if request.contains("POST /db/table-data") {
+                    self.handleBodyRoute(connection, initialData: requestData) {
+                        self.databaseRouteHandler.handleTableData(body: $0)
+                    }
+                } else if request.contains("POST /db/table-structure") {
+                    self.handleBodyRoute(connection, initialData: requestData) {
+                        self.databaseRouteHandler.handleTableStructure(body: $0)
+                    }
+                } else {
+                    self.sendResponse(connection, statusCode: 404, body: Data("{\"error\":\"not_found\"}".utf8))
+                }
             }
         }
     }
@@ -164,33 +174,189 @@ final class SdkHierarchyServer: @unchecked Sendable {
         sendResponse(connection, statusCode: 200, body: data)
     }
 
-    private func handleNetworkMock(_ connection: NWConnection, data: Data) {
-        guard let body = Self.httpBody(from: data),
-              let payload = try? JSONDecoder().decode(SetMockRulesBody.self, from: body) else {
-            sendResponse(connection, statusCode: 400, body: Data("{\"error\":\"bad_request\"}".utf8))
-            return
+    private func handleNetworkMock(_ connection: NWConnection, initialData: Data) {
+        readCompleteHttpBody(connection, initialData: initialData) { [weak self] body in
+            guard let self = self else {
+                connection.cancel()
+                return
+            }
+            guard let body = body,
+                  let payload = try? JSONDecoder().decode(SetMockRulesBody.self, from: body) else {
+                self.sendResponse(connection, statusCode: 400, body: Data("{\"error\":\"bad_request\"}".utf8))
+                return
+            }
+            NetworkMockRuleStore.shared.setRules(payload.rules)
+            self.sendResponse(connection, statusCode: 200, body: Data("{\"status\":\"ok\"}".utf8))
         }
-        NetworkMockRuleStore.shared.setRules(payload.rules)
-        sendResponse(connection, statusCode: 200, body: Data("{\"status\":\"ok\"}".utf8))
     }
 
-    private func handleHighlight(_ connection: NWConnection, data: Data) {
-        guard let body = Self.httpBody(from: data),
-              let payload = try? JSONDecoder().decode(SdkAddHighlightBody.self, from: body) else {
-            sendResponse(connection, statusCode: 400, body: Data("{\"error\":\"bad_request\"}".utf8))
-            return
+    private func handleHighlight(_ connection: NWConnection, initialData: Data) {
+        readCompleteHttpBody(connection, initialData: initialData) { [weak self] body in
+            guard let self = self else {
+                connection.cancel()
+                return
+            }
+            guard let body = body,
+                  let payload = try? JSONDecoder().decode(SdkAddHighlightBody.self, from: body) else {
+                self.sendResponse(connection, statusCode: 400, body: Data("{\"error\":\"bad_request\"}".utf8))
+                return
+            }
+            guard SdkHighlightOverlayManager.shared.show(id: payload.id, shape: payload.shape) else {
+                self.sendResponse(connection, statusCode: 400, body: Data("{\"error\":\"highlight_failed\"}".utf8))
+                return
+            }
+            self.sendResponse(connection, statusCode: 200, body: Data("{\"status\":\"ok\"}".utf8))
         }
-        guard SdkHighlightOverlayManager.shared.show(id: payload.id, shape: payload.shape) else {
-            sendResponse(connection, statusCode: 400, body: Data("{\"error\":\"highlight_failed\"}".utf8))
-            return
-        }
-        sendResponse(connection, statusCode: 200, body: Data("{\"status\":\"ok\"}".utf8))
     }
 
-    private static func httpBody(from data: Data) -> Data? {
-        let delimiter = Data("\r\n\r\n".utf8)
-        guard let range = data.range(of: delimiter) else { return nil }
-        return data[range.upperBound...]
+    private func handleBodyRoute(
+        _ connection: NWConnection,
+        initialData: Data,
+        route: @escaping (Data) -> SdkRouteResponse
+    ) {
+        readCompleteHttpBody(connection, initialData: initialData) { [weak self] body in
+            guard let self = self else {
+                connection.cancel()
+                return
+            }
+            self.sendRouteResponse(connection, route(body ?? Data()))
+        }
+    }
+
+    private func readCompleteHttpHeaders(
+        _ connection: NWConnection,
+        initialData: Data,
+        completion: @escaping (Data?) -> Void
+    ) {
+        if initialData.range(of: Self.httpHeaderDelimiter) != nil {
+            completion(initialData)
+            return
+        }
+
+        connection.receive(minimumIncompleteLength: 1, maximumLength: 65536) { [weak self] data, _, isComplete, error in
+            if error != nil {
+                completion(nil)
+                return
+            }
+
+            var nextData = initialData
+            if let data = data {
+                nextData.append(data)
+            }
+
+            if nextData.range(of: Self.httpHeaderDelimiter) != nil {
+                completion(nextData)
+                return
+            }
+            if isComplete {
+                completion(nil)
+                return
+            }
+
+            guard let self = self else {
+                completion(nil)
+                return
+            }
+
+            self.readCompleteHttpHeaders(connection, initialData: nextData, completion: completion)
+        }
+    }
+
+    private func readCompleteHttpBody(
+        _ connection: NWConnection,
+        initialData: Data,
+        completion: @escaping (Data?) -> Void
+    ) {
+        guard let range = initialData.range(of: Self.httpHeaderDelimiter) else {
+            completion(nil)
+            return
+        }
+
+        let headerData = initialData[..<range.lowerBound]
+        let body = Data(initialData[range.upperBound...])
+        guard let contentLength = Self.contentLength(from: Data(headerData)) else {
+            completion(body)
+            return
+        }
+        guard contentLength >= 0 else {
+            completion(nil)
+            return
+        }
+
+        if body.count >= contentLength {
+            completion(Data(body.prefix(contentLength)))
+            return
+        }
+
+        receiveRemainingHttpBody(
+            connection,
+            accumulatedBody: body,
+            expectedLength: contentLength,
+            completion: completion
+        )
+    }
+
+    private func receiveRemainingHttpBody(
+        _ connection: NWConnection,
+        accumulatedBody: Data,
+        expectedLength: Int,
+        completion: @escaping (Data?) -> Void
+    ) {
+        let remainingLength = expectedLength - accumulatedBody.count
+        guard remainingLength > 0 else {
+            completion(Data(accumulatedBody.prefix(expectedLength)))
+            return
+        }
+
+        connection.receive(minimumIncompleteLength: 1, maximumLength: min(65536, remainingLength)) { [weak self] data, _, isComplete, error in
+            if error != nil {
+                completion(nil)
+                return
+            }
+
+            var nextBody = accumulatedBody
+            if let data = data {
+                nextBody.append(data)
+            }
+
+            if nextBody.count >= expectedLength {
+                completion(Data(nextBody.prefix(expectedLength)))
+                return
+            }
+            if isComplete {
+                completion(nil)
+                return
+            }
+
+            guard let self = self else {
+                completion(nil)
+                return
+            }
+
+            self.receiveRemainingHttpBody(
+                connection,
+                accumulatedBody: nextBody,
+                expectedLength: expectedLength,
+                completion: completion
+            )
+        }
+    }
+
+    private static func contentLength(from headerData: Data) -> Int? {
+        guard let headers = String(data: headerData, encoding: .utf8) else { return nil }
+        for line in headers.components(separatedBy: "\r\n") {
+            let parts = line.split(separator: ":", maxSplits: 1)
+            guard parts.count == 2 else { continue }
+            if parts[0].trimmingCharacters(in: .whitespaces).lowercased() == "content-length" {
+                return Int(parts[1].trimmingCharacters(in: .whitespaces))
+            }
+        }
+        return nil
+    }
+
+    private static func httpHeaderData(from data: Data) -> Data? {
+        guard let range = data.range(of: httpHeaderDelimiter) else { return nil }
+        return Data(data[..<range.lowerBound])
     }
 
     private func sendResponse(_ connection: NWConnection, statusCode: Int, body: Data?) {

--- a/ios/auto-mobile-sdk/Sources/AutoMobileSDK/ViewHierarchy/SdkHierarchyServer.swift
+++ b/ios/auto-mobile-sdk/Sources/AutoMobileSDK/ViewHierarchy/SdkHierarchyServer.swift
@@ -14,6 +14,7 @@ final class SdkHierarchyServer: @unchecked Sendable {
 
     static let port: UInt16 = 8766
     private static let httpHeaderDelimiter = Data("\r\n\r\n".utf8)
+    private static let maxHttpBodyBytes = 1024 * 1024
 
     private let lock = NSLock()
     private var listener: NWListener?
@@ -279,6 +280,10 @@ final class SdkHierarchyServer: @unchecked Sendable {
             return
         }
         guard contentLength >= 0 else {
+            completion(nil)
+            return
+        }
+        guard contentLength <= Self.maxHttpBodyBytes else {
             completion(nil)
             return
         }

--- a/src/daemon/socketServer.ts
+++ b/src/daemon/socketServer.ts
@@ -418,12 +418,23 @@ export class UnixSocketServer {
     }
 
     const record = args as Record<string, unknown>;
+    const hasSessionUuid = typeof record.sessionUuid === "string" && record.sessionUuid.length > 0;
+    const hasDeviceLabel = typeof record.device === "string" && record.device.length > 0;
+    if (hasSessionUuid && hasDeviceLabel) {
+      const sessionUuid = this.resolveDeviceLabelSession(record.sessionUuid as string, record.device);
+      const assignedDevice = this.getAssignedDeviceForSession(sessionUuid);
+      if (assignedDevice) {
+        return `device:${assignedDevice}`;
+      }
+      return `session:${sessionUuid}`;
+    }
+
     // An explicit target device must serialize by physical device even when a session is present.
     if (typeof record.deviceId === "string" && record.deviceId.length > 0) {
       return `device:${record.deviceId}`;
     }
-    if (typeof record.sessionUuid === "string" && record.sessionUuid.length > 0) {
-      const sessionUuid = this.resolveDeviceLabelSession(record.sessionUuid, record.device);
+    if (hasSessionUuid) {
+      const sessionUuid = record.sessionUuid as string;
       const assignedDevice = this.getAssignedDeviceForSession(sessionUuid);
       if (assignedDevice) {
         return `device:${assignedDevice}`;

--- a/src/server/appFileService.ts
+++ b/src/server/appFileService.ts
@@ -40,7 +40,7 @@ const defaultDependencies: AppFileServiceDependencies = {
   simctlFactory: device => new SimCtlClient(device),
 };
 
-const ANDROID_APP_FILE_READ_MAX_BUFFER = 64 * 1024 * 1024;
+const ANDROID_APP_FILE_MAX_BUFFER = 64 * 1024 * 1024;
 
 let appFileService: AppFileService | null = null;
 
@@ -194,7 +194,7 @@ class DefaultAppFileService implements AppFileService {
       ? (await adb.executeCommand(
         `shell if [ -d ${shellQuote(posix.dirname(base.absolutePath))} ]; then find ${shellQuote(posix.dirname(base.absolutePath))} -type f; fi`,
         undefined,
-        undefined,
+        ANDROID_APP_FILE_MAX_BUFFER,
         true
       )).stdout
       : (await adb.executeCommand(
@@ -202,7 +202,7 @@ class DefaultAppFileService implements AppFileService {
           `if [ -d ${shellQuote(posix.dirname(base.relativePath))} ]; then find ${shellQuote(posix.dirname(base.relativePath))} -type f; fi`
         )}`,
         undefined,
-        undefined,
+        ANDROID_APP_FILE_MAX_BUFFER,
         true
       )).stdout;
 
@@ -236,13 +236,13 @@ class DefaultAppFileService implements AppFileService {
       ? (await adb.executeCommand(
         `shell base64 ${shellQuote(target.absolutePath)}`,
         undefined,
-        ANDROID_APP_FILE_READ_MAX_BUFFER,
+        ANDROID_APP_FILE_MAX_BUFFER,
         true
       )).stdout
       : (await adb.executeCommand(
         `shell run-as ${shellQuote(appId)} base64 ${shellQuote(target.relativePath)}`,
         undefined,
-        ANDROID_APP_FILE_READ_MAX_BUFFER,
+        ANDROID_APP_FILE_MAX_BUFFER,
         true
       )).stdout;
     const blob = stdout.replace(/\s+/g, "");

--- a/test/daemon/socketServerMcpForwardSerialization.test.ts
+++ b/test/daemon/socketServerMcpForwardSerialization.test.ts
@@ -345,6 +345,53 @@ describe("UnixSocketServer MCP forward serialization", () => {
     expect(inFlight).toBe(0);
   });
 
+  test("device-label tools/call ignores a stale deviceId when choosing the forward key", async () => {
+    sessionDevices.set("session-a", "device-1");
+    sessionDevices.set("session-a:B", "device-2");
+    sessionCustomData.set("session-a", {
+      deviceLabelMap: {
+        A: "session-a",
+        B: "session-a:B",
+      },
+    });
+    let inFlight = 0;
+    let maxInFlight = 0;
+
+    (server as any).createMcpClient = async () => {
+      const fake: FakeMcpClient = {
+        listTools: async () => ({ tools: [] }),
+        callTool: async () => {
+          inFlight += 1;
+          maxInFlight = Math.max(maxInFlight, inFlight);
+          await new Promise<void>(resolve => {
+            fakeTimer.setTimeout(resolve, 40);
+          });
+          inFlight -= 1;
+          return { content: [] };
+        },
+        listResources: async () => ({ resources: [] }),
+        readResource: async () => ({ contents: [] }),
+        listResourceTemplates: async () => ({ resourceTemplates: [] }),
+        close: async () => {},
+      };
+      return fake;
+    };
+
+    const [labelResult, explicitDeviceResult] = await Promise.all([
+      sendToolsCallWithArgs(socketPath, "observe", {
+        sessionUuid: "session-a",
+        device: "B",
+        deviceId: "device-1",
+      }),
+      sendToolsCallWithArgs(socketPath, "observe", { deviceId: "device-2" }),
+    ]);
+
+    expect(labelResult.success).toBe(true);
+    expect(explicitDeviceResult.success).toBe(true);
+    expect(maxInFlight).toBe(1);
+    expect(inFlight).toBe(0);
+  });
+
   test("queued unbound session tools/call rekeys after the session binds to a device", async () => {
     let inFlightAfterBind = 0;
     let maxInFlightAfterBind = 0;

--- a/test/server/appFileService.test.ts
+++ b/test/server/appFileService.test.ts
@@ -124,4 +124,31 @@ describe("AppFileService", () => {
     expect(calls[1]?.command).toContain("shell base64 '/sdcard/Android/data/com.example.app/files/screenshots/home.png'");
     expect(calls[1]?.maxBuffer).toBe(calls[0]?.maxBuffer);
   });
+
+  test("uses an expanded ADB maxBuffer when listing Android app files", async () => {
+    const adbFactory = new FakeAdbClientFactory();
+    const service = createAppFileServiceForTesting({
+      adbFactory,
+      simctlFactory: () => {
+        throw new Error("simctl not used");
+      },
+    });
+    const device: BootedDevice = {
+      deviceId: "emulator-5554",
+      name: "Pixel",
+      platform: "android",
+    };
+
+    await (service as any).listAndroidFiles(device, "com.example.app", "documents");
+    await (service as any).listAndroidFiles(device, "com.example.app", "externalFiles");
+
+    const calls = adbFactory.getFakeClient().getCommandCalls();
+    expect(calls).toHaveLength(2);
+    expect(calls[0]?.command).toContain("shell run-as 'com.example.app' sh -c");
+    expect(calls[0]?.command).toContain("find");
+    expect(calls[0]?.maxBuffer).toBeGreaterThan(1024 * 1024);
+    expect(calls[1]?.command).toContain("shell if [ -d '/sdcard/Android/data/com.example.app/files'");
+    expect(calls[1]?.command).toContain("find");
+    expect(calls[1]?.maxBuffer).toBe(calls[0]?.maxBuffer);
+  });
 });


### PR DESCRIPTION
## Summary
- Pass the expanded Android app-file buffer to `find` listings as well as file reads.
- Align daemon MCP forward serialization with ToolRegistry precedence by honoring device labels before stale `deviceId` values.
- Accumulate `/network/mock` HTTP headers and POST bodies until `Content-Length` is satisfied before decoding mock rules.

## Notes
- The pasted feedback for migration override resolution and under-specified iOS multi-finger paths was already addressed on the current base.

## Testing
- `bun test test/server/appFileService.test.ts test/daemon/socketServerMcpForwardSerialization.test.ts`
- `bun run build`
- `swift test -Xswiftc -warnings-as-errors` from `ios/auto-mobile-sdk`
- `bun run lint`
- `bun test --bail`
