### PR TITLE
fix(db): resolve daemon DB/state paths against the real launch cwd

### DIFF
--- a/src/db/database.ts
+++ b/src/db/database.ts
@@ -66,8 +66,27 @@ export function resolveDatabasePathFromEnvironment(
   return path.join(dbDir, "auto-mobile.db");
 }
 
-const DB_PATH = resolveDatabasePathFromEnvironment();
-const DB_DIR = path.dirname(DB_PATH);
+let resolvedDbPath: string | null = null;
+
+/**
+ * Resolve the database file path lazily, on first use rather than at module load.
+ *
+ * A directly launched daemon (`--daemon-mode`, started by an IDE/user rather than
+ * spawned by DaemonManager) sets AUTOMOBILE_DAEMON_LAUNCH_CWD and chdirs to a
+ * stable working directory inside Daemon.start() — AFTER this module is imported.
+ * Resolving at module load would bind a relative AUTOMOBILE_DB_DIR /
+ * AUTOMOBILE_DB_PATH to the pre-chdir cwd with that env unset, diverging from
+ * migrator.ts (which resolves AUTOMOBILE_MIGRATIONS_DIR at runtime) or landing the
+ * database in the wrong place once the daemon chdirs. Deferring to first use makes
+ * resolution happen post-chdir/post-env, consistent with the migrator. The result
+ * is cached so getDatabasePath() always matches the path the database was opened at.
+ */
+function resolveDbPath(): string {
+  if (resolvedDbPath === null) {
+    resolvedDbPath = resolveDatabasePathFromEnvironment();
+  }
+  return resolvedDbPath;
+}
 
 let dbInstance: Kysely<DatabaseSchema> | null = null;
 let migrationsRun = false;
@@ -79,14 +98,17 @@ let migrationsPromise: Promise<void> | null = null;
  */
 export function getDatabase(): Kysely<DatabaseSchema> {
   if (!dbInstance) {
+    const dbPath = resolveDbPath();
+    const dbDir = path.dirname(dbPath);
+
     // Ensure directory exists
-    if (!fs.existsSync(DB_DIR)) {
-      fs.mkdirSync(DB_DIR, { recursive: true });
+    if (!fs.existsSync(dbDir)) {
+      fs.mkdirSync(dbDir, { recursive: true });
     }
 
     // Use Bun's built-in SQLite
     const BunDatabaseConstructor = resolveBunDatabaseConstructor();
-    const sqliteDb = new BunDatabaseConstructor(DB_PATH);
+    const sqliteDb = new BunDatabaseConstructor(dbPath);
     configureSqliteDatabase(sqliteDb);
 
     dbInstance = new Kysely<DatabaseSchema>({
@@ -149,5 +171,5 @@ export async function closeDatabase(): Promise<void> {
  * Get the database file path.
  */
 export function getDatabasePath(): string {
-  return DB_PATH;
+  return resolveDbPath();
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,19 @@
 #!/usr/bin/env bun
 import { bootstrapEnvironment } from "./utils/envBootstrap";
+import { DAEMON_LAUNCH_CWD_ENV, safeProcessCwd } from "./utils/workingDirectory";
 
 // Run before any other imports that may resolve tool paths at module load time.
 bootstrapEnvironment();
+
+// Record the launch working directory before db/constants are imported. Those
+// modules resolve relative env-overridden paths (AUTOMOBILE_DB_DIR/DB_PATH and the
+// daemon socket/pid/lock paths) against AUTOMOBILE_DAEMON_LAUNCH_CWD. A directly
+// launched daemon (--daemon-mode, not spawned by DaemonManager) otherwise only sets
+// this inside Daemon.start(), which runs after it has chdir'd to a stable dir — too
+// late, so paths would resolve against the wrong cwd. db/constants are pulled in via
+// the dynamic import("./daemon/daemon") inside main(), so this body-level assignment
+// runs first. ??= preserves a value inherited from DaemonManager-spawned daemons.
+process.env[DAEMON_LAUNCH_CWD_ENV] ??= safeProcessCwd();
 
 import type { DaemonOptions } from "./daemon/types";
 import type { FeatureFlagKey } from "./features/featureFlags/FeatureFlagDefinitions";

--- a/test/db/databaseLazyPath.test.ts
+++ b/test/db/databaseLazyPath.test.ts
@@ -1,0 +1,73 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import path from "path";
+import { DAEMON_LAUNCH_CWD_ENV } from "../../src/utils/workingDirectory";
+
+/**
+ * Regression test for the module-load-time-vs-runtime path hazard.
+ *
+ * A directly launched daemon (--daemon-mode, not spawned by DaemonManager) only sets
+ * AUTOMOBILE_DAEMON_LAUNCH_CWD and chdirs inside Daemon.start(), AFTER src/db/database.ts
+ * has been imported. If DB_PATH were resolved at module load it would bind a relative
+ * AUTOMOBILE_DB_DIR to the import-time cwd with the env unset. The fix resolves the path
+ * lazily (on first getDatabasePath()/getDatabase() call), so it sees the launch cwd that
+ * Daemon.start() records after import — matching migrator.ts's runtime resolution.
+ */
+describe("database path lazy resolution", () => {
+  const originalLaunchCwd = process.env[DAEMON_LAUNCH_CWD_ENV];
+  const originalDbDir = process.env.AUTOMOBILE_DB_DIR;
+
+  function restore(key: string, value: string | undefined): void {
+    if (value === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = value;
+    }
+  }
+
+  afterEach(() => {
+    restore(DAEMON_LAUNCH_CWD_ENV, originalLaunchCwd);
+    restore("AUTOMOBILE_DB_DIR", originalDbDir);
+  });
+
+  async function importFreshDatabaseModule() {
+    // Fresh module instance so its lazy cache is not shared with other tests.
+    return import(`../../src/db/database.ts?lazy-db-path-test=${Date.now()}-${Math.random()}`);
+  }
+
+  test("resolves relative AUTOMOBILE_DB_DIR against the launch cwd set AFTER import", async () => {
+    const importTimeCwd = process.cwd();
+    const launchCwd = path.resolve("/project/auto-mobile");
+
+    // Simulate the direct-launch ordering: a relative DB dir is configured, but the
+    // launch cwd env is NOT yet set when the module is imported.
+    process.env.AUTOMOBILE_DB_DIR = ".automobile-db";
+    delete process.env[DAEMON_LAUNCH_CWD_ENV];
+
+    const databaseModule = await importFreshDatabaseModule();
+
+    // Daemon.start() records the launch cwd only after import / before first use.
+    process.env[DAEMON_LAUNCH_CWD_ENV] = launchCwd;
+
+    const resolved = databaseModule.getDatabasePath();
+
+    // Must follow the launch cwd, NOT the cwd that was current when the module loaded.
+    expect(resolved).toBe(path.join(launchCwd, ".automobile-db", "auto-mobile.db"));
+    expect(resolved.startsWith(importTimeCwd)).toBe(false);
+  });
+
+  test("caches the resolved path so it stays stable for the process lifetime", async () => {
+    process.env.AUTOMOBILE_DB_DIR = ".automobile-db";
+    delete process.env[DAEMON_LAUNCH_CWD_ENV];
+
+    const databaseModule = await importFreshDatabaseModule();
+
+    process.env[DAEMON_LAUNCH_CWD_ENV] = path.resolve("/project/auto-mobile");
+    const first = databaseModule.getDatabasePath();
+
+    // A later env change must not move the database the daemon already opened against.
+    process.env[DAEMON_LAUNCH_CWD_ENV] = path.resolve("/elsewhere/launch-cwd");
+    const second = databaseModule.getDatabasePath();
+
+    expect(second).toBe(first);
+  });
+});


### PR DESCRIPTION
## Problem

`src/db/database.ts` resolved `DB_PATH` in a **module-level const at import time**. In a **direct daemon launch** (`--daemon-mode`, started by an IDE/user rather than spawned by `DaemonManager`), `AUTOMOBILE_DAEMON_LAUNCH_CWD` is only set — and `process.chdir()` only runs — inside `Daemon.start()` ([daemon.ts:189-190](https://github.com/kaeawc/auto-mobile/blob/main/src/daemon/daemon.ts#L189-L190)), which happens **after** `daemon.ts`'s static `import "../db"` has already evaluated `database.ts`.

As a result:
- A relative `AUTOMOBILE_DB_DIR` / `AUTOMOBILE_DB_PATH` resolved against the **pre-chdir, env-unset** cwd.
- Meanwhile `src/db/migrator.ts` `resolveMigrationFolder()` resolves `AUTOMOBILE_MIGRATIONS_DIR` at **runtime** (post-chdir, env set).

So the database file and the migrations folder could resolve against **two different base directories**, or the DB could land in the wrong place entirely once the daemon chdirs to homedir.

The same module-load-vs-runtime hazard applied to `SOCKET_PATH` / `PID_FILE_PATH` / `LOCK_FILE_PATH` in `src/daemon/constants.ts` (also module-level consts using `resolvePathFromDaemonLaunchWorkingDirectory` on relative overrides).

This was introduced by the interaction of #2564 (daemon cwd for detached launches) and #2565 (busy timeout).

## Fix

Two complementary layers:

1. **Lazy DB path resolution** (`src/db/database.ts`) — replaced the module-level `DB_PATH`/`DB_DIR` consts with a cached `resolveDbPath()` that resolves on first `getDatabase()`/`getDatabasePath()` use. This runs post-chdir/post-env, consistent with `migrator.ts`, and is robust to import ordering. The result is cached so `getDatabasePath()` always matches the path the DB was opened at.

2. **Entrypoint env guard** (`src/index.ts`) — set `process.env[DAEMON_LAUNCH_CWD_ENV] ??= safeProcessCwd()` at the top of the module body. `index.ts`'s static imports only reach node builtins, so `constants.ts`/`db` are pulled in solely via the dynamic `import("./daemon/daemon")` inside `main()` — meaning this assignment runs first. This fixes the same hazard for the `constants.ts` socket/pid/lock consts, which are imported as values across many call sites and can't be made lazy without a large ripple. `??=` preserves the value `DaemonManager` already injects for spawned daemons ([manager.ts:525](https://github.com/kaeawc/auto-mobile/blob/main/src/daemon/manager.ts#L525)).

## Test

`test/db/databaseLazyPath.test.ts` imports a fresh db module with the launch-cwd env **unset** at import time and a relative `AUTOMOBILE_DB_DIR` configured, then sets `AUTOMOBILE_DAEMON_LAUNCH_CWD` **after** import (simulating `Daemon.start()`), and asserts `getDatabasePath()` follows the launch cwd, not the import-time cwd. A second case asserts the cached path stays stable against later env changes. This fails against the old eager-const code and passes now.

## Validation

- `bun test` (db path + daemon constant path suites): ✅ 9 pass
- `bun run lint`: ✅
- `bun run build`: ✅