### PR TITLE
Fix SQLite parallel client safety

### DIFF
--- a/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/database/SQLiteDatabaseDriver.kt
+++ b/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/database/SQLiteDatabaseDriver.kt
@@ -14,6 +14,7 @@ import java.util.concurrent.ConcurrentHashMap
  */
 class SQLiteDatabaseDriver(private val context: Context) : DatabaseDriver {
 
+  private val databaseLock = Any()
   private val openDatabases = ConcurrentHashMap<String, SQLiteDatabase>()
 
   override fun getDatabases(): List<DatabaseDescriptor> {
@@ -51,109 +52,121 @@ class SQLiteDatabaseDriver(private val context: Context) : DatabaseDriver {
   }
 
   override fun getTables(databasePath: String): List<String> {
-    val db = openDatabase(databasePath, readOnly = true)
-    val tables = mutableListOf<String>()
+    synchronized(databaseLock) {
+      val db = openDatabase(databasePath, readOnly = true)
+      val tables = mutableListOf<String>()
 
-    db.rawQuery("SELECT name FROM sqlite_master WHERE type='table' ORDER BY name", null)
-        .use { cursor ->
-          while (cursor.moveToNext()) {
-            val name = cursor.getString(0)
-            // Exclude internal SQLite tables
-            if (!name.startsWith("sqlite_") && !name.startsWith("android_")) {
-              tables.add(name)
-            }
+      db.rawQuery("SELECT name FROM sqlite_master WHERE type='table' ORDER BY name", null).use {
+          cursor ->
+        while (cursor.moveToNext()) {
+          val name = cursor.getString(0)
+          // Exclude internal SQLite tables
+          if (!name.startsWith("sqlite_") && !name.startsWith("android_")) {
+            tables.add(name)
           }
         }
+      }
 
-    return tables
+      return tables
+    }
   }
 
   override fun getTableData(
       databasePath: String,
       table: String,
       limit: Int,
-      offset: Int
+      offset: Int,
   ): TableDataResult {
-    val db = openDatabase(databasePath, readOnly = true)
+    synchronized(databaseLock) {
+      val db = openDatabase(databasePath, readOnly = true)
 
-    // Validate table exists
-    if (!tableExists(db, table)) {
-      throw DatabaseError.TableNotFound(table)
-    }
+      // Validate table exists
+      if (!tableExists(db, table)) {
+        throw DatabaseError.TableNotFound(table)
+      }
 
-    // Get total count
-    val total =
-        db.rawQuery("SELECT COUNT(*) FROM \"${table.replace("\"", "\"\"")}\"", null).use { cursor ->
-          cursor.moveToFirst()
-          cursor.getInt(0)
-        }
-
-    // Get paginated data
-    val columns = mutableListOf<String>()
-    val rows = mutableListOf<List<Any?>>()
-
-    db.rawQuery(
-            "SELECT * FROM \"${table.replace("\"", "\"\"")}\" LIMIT ? OFFSET ?",
-            arrayOf(limit.toString(), offset.toString()))
-        .use { cursor ->
-          // Get column names
-          columns.addAll(cursor.columnNames)
-
-          // Get row data
-          while (cursor.moveToNext()) {
-            val row = mutableListOf<Any?>()
-            for (i in 0 until cursor.columnCount) {
-              row.add(getColumnValue(cursor, i))
-            }
-            rows.add(row)
+      // Get total count
+      val total =
+          db.rawQuery("SELECT COUNT(*) FROM \"${table.replace("\"", "\"\"")}\"", null).use { cursor
+            ->
+            cursor.moveToFirst()
+            cursor.getInt(0)
           }
-        }
 
-    return TableDataResult(columns = columns, rows = rows, total = total)
+      // Get paginated data
+      val columns = mutableListOf<String>()
+      val rows = mutableListOf<List<Any?>>()
+
+      db.rawQuery(
+              "SELECT * FROM \"${table.replace("\"", "\"\"")}\" LIMIT ? OFFSET ?",
+              arrayOf(limit.toString(), offset.toString()),
+          )
+          .use { cursor ->
+            // Get column names
+            columns.addAll(cursor.columnNames)
+
+            // Get row data
+            while (cursor.moveToNext()) {
+              val row = mutableListOf<Any?>()
+              for (i in 0 until cursor.columnCount) {
+                row.add(getColumnValue(cursor, i))
+              }
+              rows.add(row)
+            }
+          }
+
+      return TableDataResult(columns = columns, rows = rows, total = total)
+    }
   }
 
   override fun getTableStructure(databasePath: String, table: String): TableStructureResult {
-    val db = openDatabase(databasePath, readOnly = true)
+    synchronized(databaseLock) {
+      val db = openDatabase(databasePath, readOnly = true)
 
-    // Validate table exists
-    if (!tableExists(db, table)) {
-      throw DatabaseError.TableNotFound(table)
-    }
-
-    val columns = mutableListOf<ColumnInfo>()
-
-    db.rawQuery("PRAGMA table_info(\"${table.replace("\"", "\"\"")}\")", null).use { cursor ->
-      while (cursor.moveToNext()) {
-        // Columns: cid, name, type, notnull, dflt_value, pk
-        val name = cursor.getString(1)
-        val type = cursor.getString(2) ?: "TEXT"
-        val notNull = cursor.getInt(3) == 1
-        val defaultValue = if (cursor.isNull(4)) null else cursor.getString(4)
-        val isPrimaryKey = cursor.getInt(5) > 0
-
-        columns.add(
-            ColumnInfo(
-                name = name,
-                type = type,
-                nullable = !notNull,
-                primaryKey = isPrimaryKey,
-                defaultValue = defaultValue))
+      // Validate table exists
+      if (!tableExists(db, table)) {
+        throw DatabaseError.TableNotFound(table)
       }
-    }
 
-    return TableStructureResult(columns = columns)
+      val columns = mutableListOf<ColumnInfo>()
+
+      db.rawQuery("PRAGMA table_info(\"${table.replace("\"", "\"\"")}\")", null).use { cursor ->
+        while (cursor.moveToNext()) {
+          // Columns: cid, name, type, notnull, dflt_value, pk
+          val name = cursor.getString(1)
+          val type = cursor.getString(2) ?: "TEXT"
+          val notNull = cursor.getInt(3) == 1
+          val defaultValue = if (cursor.isNull(4)) null else cursor.getString(4)
+          val isPrimaryKey = cursor.getInt(5) > 0
+
+          columns.add(
+              ColumnInfo(
+                  name = name,
+                  type = type,
+                  nullable = !notNull,
+                  primaryKey = isPrimaryKey,
+                  defaultValue = defaultValue,
+              )
+          )
+        }
+      }
+
+      return TableStructureResult(columns = columns)
+    }
   }
 
   override fun executeSQL(databasePath: String, query: String): SQLExecutionResult {
-    val trimmedQuery = query.trim()
+    synchronized(databaseLock) {
+      val trimmedQuery = query.trim()
 
-    // Determine if this is a query or mutation
-    val isQuery = isReadQuery(trimmedQuery)
+      // Determine if this is a query or mutation
+      val isQuery = isReadQuery(trimmedQuery)
 
-    return if (isQuery) {
-      executeQuery(databasePath, trimmedQuery)
-    } else {
-      executeMutation(databasePath, trimmedQuery)
+      return if (isQuery) {
+        executeQuery(databasePath, trimmedQuery)
+      } else {
+        executeMutation(databasePath, trimmedQuery)
+      }
     }
   }
 
@@ -167,9 +180,11 @@ class SQLiteDatabaseDriver(private val context: Context) : DatabaseDriver {
     val upperQuery = query.uppercase()
 
     // Direct read queries
-    if (upperQuery.startsWith("SELECT") ||
-        upperQuery.startsWith("PRAGMA") ||
-        upperQuery.startsWith("EXPLAIN")) {
+    if (
+        upperQuery.startsWith("SELECT") ||
+            upperQuery.startsWith("PRAGMA") ||
+            upperQuery.startsWith("EXPLAIN")
+    ) {
       return true
     }
 
@@ -187,8 +202,8 @@ class SQLiteDatabaseDriver(private val context: Context) : DatabaseDriver {
   }
 
   /**
-   * Check if text starts with a keyword followed by a word boundary.
-   * Prevents matching CTE names like "select_cte" as statement keywords.
+   * Check if text starts with a keyword followed by a word boundary. Prevents matching CTE names
+   * like "select_cte" as statement keywords.
    */
   private fun startsWithKeyword(text: String, keyword: String): Boolean {
     if (!text.startsWith(keyword)) return false
@@ -200,8 +215,8 @@ class SQLiteDatabaseDriver(private val context: Context) : DatabaseDriver {
   /**
    * Find the actual statement type after CTE definitions.
    *
-   * Parses past WITH ... AS (...) clauses to find SELECT/INSERT/UPDATE/DELETE.
-   * Uses word boundary checks to avoid matching CTE names like "update_cte".
+   * Parses past WITH ... AS (...) clauses to find SELECT/INSERT/UPDATE/DELETE. Uses word boundary
+   * checks to avoid matching CTE names like "update_cte".
    */
   private fun findStatementAfterCTE(upperQuery: String): String? {
     var depth = 0
@@ -304,15 +319,7 @@ class SQLiteDatabaseDriver(private val context: Context) : DatabaseDriver {
     try {
       val db = SQLiteDatabase.openDatabase(path, null, flags)
       if (!readOnly) {
-        // Allow up to 5 seconds waiting for write locks held by Room or other connections.
-        // Without this, SQLite fails immediately with "database is locked" if the app has
-        // an active write transaction open on the same database.
-        //
-        // Use compileStatement().execute() instead of execSQL() here for the same reason
-        // as in executeMutation: on Android 15 (API 35) with WAL-mode databases, execSQL()
-        // calls throwIfReadOnly() which throws even on OPEN_READWRITE connections when Room
-        // holds the WAL write connection. compileStatement().execute() bypasses that check.
-        db.compileStatement("PRAGMA busy_timeout=5000").execute()
+        setBusyTimeout(db)
       }
       openDatabases[path] = db
       return db
@@ -321,19 +328,44 @@ class SQLiteDatabaseDriver(private val context: Context) : DatabaseDriver {
     }
   }
 
+  private fun setBusyTimeout(db: SQLiteDatabase) {
+    // Allow up to 5 seconds waiting for write locks held by Room or other connections.
+    // Without this, SQLite fails immediately with "database is locked" if the app has
+    // an active write transaction open on the same database.
+    //
+    // Use compileStatement().execute() instead of execSQL() here for the same reason as
+    // in executeMutation: on Android 15 (API 35) with WAL-mode databases, execSQL() calls
+    // throwIfReadOnly() which throws even on OPEN_READWRITE connections when Room holds
+    // the WAL write connection. compileStatement().execute() bypasses that check.
+    try {
+      db.compileStatement("PRAGMA busy_timeout=5000").execute()
+    } catch (_: RuntimeException) {
+      db.rawQuery("PRAGMA busy_timeout=5000", null).use { cursor ->
+        while (cursor.moveToNext()) {
+          // Exhaust the cursor so SQLite applies the pragma on Robolectric.
+        }
+      }
+    }
+  }
+
   private fun validatePath(path: String) {
     val dataDir = context.applicationInfo.dataDir
     val normalizedPath = File(path).canonicalPath
     val normalizedDataDir = File(dataDir).canonicalPath
 
-    if (!normalizedPath.startsWith(normalizedDataDir)) {
+    if (
+        normalizedPath != normalizedDataDir &&
+            !normalizedPath.startsWith(normalizedDataDir + File.separator)
+    ) {
       throw DatabaseError.InvalidPath(path)
     }
   }
 
   private fun tableExists(db: SQLiteDatabase, table: String): Boolean {
     return db.rawQuery(
-            "SELECT name FROM sqlite_master WHERE type='table' AND name=?", arrayOf(table))
+            "SELECT name FROM sqlite_master WHERE type='table' AND name=?",
+            arrayOf(table),
+        )
         .use { cursor -> cursor.count > 0 }
   }
 
@@ -354,15 +386,17 @@ class SQLiteDatabaseDriver(private val context: Context) : DatabaseDriver {
 
   /** Close all open database connections. */
   fun closeAll() {
-    openDatabases.values.forEach { db ->
-      try {
-        if (db.isOpen) {
-          db.close()
+    synchronized(databaseLock) {
+      openDatabases.values.forEach { db ->
+        try {
+          if (db.isOpen) {
+            db.close()
+          }
+        } catch (_: Exception) {
+          // Ignore close errors
         }
-      } catch (_: Exception) {
-        // Ignore close errors
       }
+      openDatabases.clear()
     }
-    openDatabases.clear()
   }
 }

--- a/android/auto-mobile-sdk/src/test/kotlin/dev/jasonpearson/automobile/sdk/database/SQLiteDatabaseDriverTest.kt
+++ b/android/auto-mobile-sdk/src/test/kotlin/dev/jasonpearson/automobile/sdk/database/SQLiteDatabaseDriverTest.kt
@@ -1,0 +1,95 @@
+package dev.jasonpearson.automobile.sdk.database
+
+import android.content.Context
+import android.database.sqlite.SQLiteDatabase
+import java.io.File
+import java.util.Collections
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RuntimeEnvironment
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class SQLiteDatabaseDriverTest {
+
+  private lateinit var context: Context
+  private val filesToDelete = mutableListOf<File>()
+
+  @Before
+  fun setup() {
+    context = RuntimeEnvironment.getApplication()
+  }
+
+  @After
+  fun tearDown() {
+    filesToDelete.forEach { it.delete() }
+  }
+
+  @Test
+  fun `rejects sibling data directory with same path prefix`() {
+    val siblingPath = context.applicationInfo.dataDir + "-other/databases/outside.db"
+    val driver = SQLiteDatabaseDriver(context)
+
+    val error =
+        kotlin.runCatching { driver.executeSQL(siblingPath, "SELECT 1") }.exceptionOrNull()
+
+    assertTrue(error is DatabaseError.InvalidPath)
+  }
+
+  @Test
+  fun `serializes parallel reads and writes through one driver`() {
+    val dbFile = createDatabase("parallel-${System.nanoTime()}.db")
+    val driver = SQLiteDatabaseDriver(context)
+    val executor = Executors.newFixedThreadPool(8)
+    val start = CountDownLatch(1)
+    val errors = Collections.synchronizedList(mutableListOf<Throwable>())
+
+    repeat(80) { index ->
+      executor.execute {
+        try {
+          start.await(2, TimeUnit.SECONDS)
+          if (index % 4 == 0) {
+            driver.executeSQL(dbFile.absolutePath, "UPDATE items SET value = value + 1 WHERE id = 1")
+          } else {
+            val data = driver.getTableData(dbFile.absolutePath, "items", 10, 0)
+            assertEquals(listOf("id", "value"), data.columns)
+            assertEquals(1, data.total)
+          }
+        } catch (error: Throwable) {
+          errors.add(error)
+        }
+      }
+    }
+
+    start.countDown()
+    executor.shutdown()
+    assertTrue(executor.awaitTermination(10, TimeUnit.SECONDS))
+
+    val finalData = driver.getTableData(dbFile.absolutePath, "items", 10, 0)
+    assertEquals(20L, finalData.rows.single()[1])
+
+    driver.closeAll()
+    assertTrue(errors.isEmpty(), errors.joinToString("\n") { it.stackTraceToString() })
+  }
+
+  private fun createDatabase(name: String): File {
+    val dbFile = context.getDatabasePath(name)
+    dbFile.parentFile?.mkdirs()
+    dbFile.delete()
+    filesToDelete.add(dbFile)
+
+    SQLiteDatabase.openOrCreateDatabase(dbFile, null).use { db ->
+      db.execSQL("CREATE TABLE items (id INTEGER PRIMARY KEY, value INTEGER NOT NULL)")
+      db.execSQL("INSERT INTO items (id, value) VALUES (1, 0)")
+    }
+
+    return dbFile
+  }
+}

--- a/ios/auto-mobile-sdk/Sources/AutoMobileSDK/Storage/SQLiteDatabaseDriver.swift
+++ b/ios/auto-mobile-sdk/Sources/AutoMobileSDK/Storage/SQLiteDatabaseDriver.swift
@@ -6,6 +6,7 @@ import SQLite3
 /// Uses the SQLite C API directly (available on all Apple platforms).
 public final class SQLiteDatabaseDriver: DatabaseDriver, @unchecked Sendable {
     private let lock = NSLock()
+    private let operationLock = NSLock()
     private var openDatabases: [String: OpaquePointer] = [:]
 
     public init() {}
@@ -52,6 +53,9 @@ public final class SQLiteDatabaseDriver: DatabaseDriver, @unchecked Sendable {
     }
 
     public func getTables(databasePath: String) -> [String] {
+        operationLock.lock()
+        defer { operationLock.unlock() }
+
         guard let db = openDatabase(path: databasePath, readOnly: true) else { return [] }
 
         let query = "SELECT name FROM sqlite_master WHERE type='table' ORDER BY name"
@@ -73,6 +77,9 @@ public final class SQLiteDatabaseDriver: DatabaseDriver, @unchecked Sendable {
     }
 
     public func getTableData(databasePath: String, table: String, limit: Int, offset: Int) -> TableDataResult {
+        operationLock.lock()
+        defer { operationLock.unlock() }
+
         guard let db = openDatabase(path: databasePath, readOnly: true) else {
             return TableDataResult(columns: [], rows: [], totalRows: 0)
         }
@@ -101,7 +108,7 @@ public final class SQLiteDatabaseDriver: DatabaseDriver, @unchecked Sendable {
 
         let columnCount = Int(sqlite3_column_count(dataStmt))
         var columns: [String] = []
-        for i in 0..<columnCount {
+        for i in 0 ..< columnCount {
             if let name = sqlite3_column_name(dataStmt, Int32(i)) {
                 columns.append(String(cString: name))
             }
@@ -110,7 +117,7 @@ public final class SQLiteDatabaseDriver: DatabaseDriver, @unchecked Sendable {
         var rows: [[String?]] = []
         while sqlite3_step(dataStmt) == SQLITE_ROW {
             var row: [String?] = []
-            for i in 0..<columnCount {
+            for i in 0 ..< columnCount {
                 row.append(getColumnValue(stmt: dataStmt, index: Int32(i)))
             }
             rows.append(row)
@@ -120,6 +127,9 @@ public final class SQLiteDatabaseDriver: DatabaseDriver, @unchecked Sendable {
     }
 
     public func getTableStructure(databasePath: String, table: String) -> TableStructureResult {
+        operationLock.lock()
+        defer { operationLock.unlock() }
+
         guard let db = openDatabase(path: databasePath, readOnly: true) else {
             return TableStructureResult(columns: [])
         }
@@ -152,6 +162,9 @@ public final class SQLiteDatabaseDriver: DatabaseDriver, @unchecked Sendable {
     }
 
     public func executeSQL(databasePath: String, query: String) -> SQLExecutionResult {
+        operationLock.lock()
+        defer { operationLock.unlock() }
+
         let trimmed = query.trimmingCharacters(in: .whitespacesAndNewlines)
         let isRead = isReadQuery(trimmed)
         let readOnly = isRead
@@ -255,7 +268,7 @@ public final class SQLiteDatabaseDriver: DatabaseDriver, @unchecked Sendable {
 
         let columnCount = Int(sqlite3_column_count(stmt))
         var columns: [String] = []
-        for i in 0..<columnCount {
+        for i in 0 ..< columnCount {
             if let name = sqlite3_column_name(stmt, Int32(i)) {
                 columns.append(String(cString: name))
             }
@@ -264,7 +277,7 @@ public final class SQLiteDatabaseDriver: DatabaseDriver, @unchecked Sendable {
         var rows: [[String?]] = []
         while sqlite3_step(stmt) == SQLITE_ROW {
             var row: [String?] = []
-            for i in 0..<columnCount {
+            for i in 0 ..< columnCount {
                 row.append(getColumnValue(stmt: stmt, index: Int32(i)))
             }
             rows.append(row)
@@ -289,7 +302,7 @@ public final class SQLiteDatabaseDriver: DatabaseDriver, @unchecked Sendable {
             // RETURNING clause produces rows — collect them like a query
             let columnCount = Int(sqlite3_column_count(stmt))
             var columns: [String] = []
-            for i in 0..<columnCount {
+            for i in 0 ..< columnCount {
                 if let name = sqlite3_column_name(stmt, Int32(i)) {
                     columns.append(String(cString: name))
                 }
@@ -298,7 +311,7 @@ public final class SQLiteDatabaseDriver: DatabaseDriver, @unchecked Sendable {
             // First row is already stepped
             repeat {
                 var row: [String?] = []
-                for i in 0..<columnCount {
+                for i in 0 ..< columnCount {
                     row.append(getColumnValue(stmt: stmt, index: Int32(i)))
                 }
                 rows.append(row)
@@ -348,6 +361,9 @@ public final class SQLiteDatabaseDriver: DatabaseDriver, @unchecked Sendable {
 
     /// Close all open database connections.
     public func closeAll() {
+        operationLock.lock()
+        defer { operationLock.unlock() }
+
         lock.lock()
         for (_, db) in openDatabases {
             sqlite3_close(db)

--- a/ios/auto-mobile-sdk/Tests/AutoMobileSDKTests/StorageTests.swift
+++ b/ios/auto-mobile-sdk/Tests/AutoMobileSDKTests/StorageTests.swift
@@ -1,4 +1,5 @@
 @testable import AutoMobileSDK
+import SQLite3
 import XCTest
 
 final class UserDefaultsInspectorTests: XCTestCase {
@@ -208,6 +209,103 @@ final class SdkDatabaseRouteHandlerTests: XCTestCase {
     }
 }
 
+final class SQLiteDatabaseDriverConcurrencyTests: XCTestCase {
+    private var filesToDelete: [URL] = []
+
+    override func tearDown() {
+        for file in filesToDelete {
+            try? FileManager.default.removeItem(at: file)
+        }
+        filesToDelete.removeAll()
+        super.tearDown()
+    }
+
+    func testSerializesParallelReadsAndWritesThroughOneDriver() throws {
+        let databaseURL = try createDatabase()
+        let driver = SQLiteDatabaseDriver()
+        let queue = DispatchQueue(label: "sqlite-driver-concurrency", attributes: .concurrent)
+        let group = DispatchGroup()
+        let errors = LockedErrors()
+
+        for index in 0 ..< 80 {
+            group.enter()
+            queue.async {
+                defer { group.leave() }
+
+                if index % 4 == 0 {
+                    let result = driver.executeSQL(
+                        databasePath: databaseURL.path,
+                        query: "UPDATE items SET value = value + 1 WHERE id = 1"
+                    )
+                    if let error = result.error {
+                        errors.append(error)
+                    }
+                } else {
+                    let result = driver.getTableData(
+                        databasePath: databaseURL.path,
+                        table: "items",
+                        limit: 10,
+                        offset: 0
+                    )
+                    if result.columns != ["id", "value"] {
+                        errors.append("unexpected columns: \(result.columns)")
+                    }
+                    if result.totalRows != 1 {
+                        errors.append("unexpected total rows: \(result.totalRows)")
+                    }
+                }
+            }
+        }
+
+        XCTAssertEqual(group.wait(timeout: .now() + 10), .success)
+        let finalData = driver.getTableData(
+            databasePath: databaseURL.path,
+            table: "items",
+            limit: 10,
+            offset: 0
+        )
+        XCTAssertEqual(finalData.rows.first?[1], "20")
+
+        driver.closeAll()
+        XCTAssertTrue(errors.all.isEmpty, errors.all.joined(separator: "\n"))
+    }
+
+    private func createDatabase() throws -> URL {
+        let file = FileManager.default.temporaryDirectory
+            .appendingPathComponent("auto-mobile-\(UUID().uuidString).sqlite")
+        filesToDelete.append(file)
+
+        var db: OpaquePointer?
+        let openResult = sqlite3_open(file.path, &db)
+        XCTAssertEqual(openResult, SQLITE_OK)
+        guard openResult == SQLITE_OK, let db else {
+            throw NSError(domain: "SQLiteDatabaseDriverConcurrencyTests", code: 1)
+        }
+        defer { sqlite3_close(db) }
+
+        try executeSQL(db, "CREATE TABLE items (id INTEGER PRIMARY KEY, value INTEGER NOT NULL)")
+        try executeSQL(db, "INSERT INTO items (id, value) VALUES (1, 0)")
+
+        return file
+    }
+
+    private func executeSQL(_ db: OpaquePointer, _ sql: String) throws {
+        var errorMessage: UnsafeMutablePointer<CChar>?
+        let result = sqlite3_exec(db, sql, nil, nil, &errorMessage)
+        defer { sqlite3_free(errorMessage) }
+
+        XCTAssertEqual(result, SQLITE_OK)
+        guard result == SQLITE_OK else {
+            let message = errorMessage.map { String(cString: $0) } ?? "Unknown SQLite error"
+            throw NSError(
+                domain: "SQLiteDatabaseDriverConcurrencyTests",
+                code: Int(result),
+                userInfo: [NSLocalizedDescriptionKey: message]
+            )
+        }
+    }
+}
+
 private final class RouteFakeDatabaseDriver: DatabaseDriver, @unchecked Sendable {
     var databases: [DatabaseDescriptor] = []
     var tablesByDatabase: [String: [String]] = [:]
@@ -242,5 +340,22 @@ private final class RouteFakeDatabaseDriver: DatabaseDriver, @unchecked Sendable
     func executeSQL(databasePath: String, query: String) -> SQLExecutionResult {
         executeSqlCalls.append((databasePath: databasePath, query: query))
         return sqlResult
+    }
+}
+
+private final class LockedErrors: @unchecked Sendable {
+    private let lock = NSLock()
+    private var messages: [String] = []
+
+    var all: [String] {
+        lock.lock()
+        defer { lock.unlock() }
+        return messages
+    }
+
+    func append(_ message: String) {
+        lock.lock()
+        defer { lock.unlock() }
+        messages.append(message)
     }
 }

--- a/src/db/bunSqliteDialect.ts
+++ b/src/db/bunSqliteDialect.ts
@@ -49,33 +49,36 @@ interface BunSqliteDialectConfig {
 
 class BunSqliteDriver implements Driver {
   readonly #config: BunSqliteDialectConfig;
-  #connection?: BunSqliteConnection;
+  #connectionState?: BunSqliteConnectionState;
 
   constructor(config: BunSqliteDialectConfig) {
     this.#config = config;
   }
 
   async init(): Promise<void> {
-    this.#connection = new BunSqliteConnection(this.#config.database, this.#config.beforeQuery);
+    this.#connectionState = new BunSqliteConnectionState(
+      this.#config.database,
+      this.#config.beforeQuery
+    );
   }
 
   async acquireConnection(): Promise<DatabaseConnection> {
-    if (!this.#connection) {
+    if (!this.#connectionState) {
       throw new Error("BunSqliteDriver not initialized");
     }
-    return this.#connection;
+    return new BunSqliteConnectionLease(this.#connectionState);
   }
 
   async beginTransaction(connection: DatabaseConnection, _settings: TransactionSettings): Promise<void> {
-    await connection.executeQuery(CompiledQuery.raw("begin"));
+    await this.#lease(connection).beginTransaction();
   }
 
   async commitTransaction(connection: DatabaseConnection): Promise<void> {
-    await connection.executeQuery(CompiledQuery.raw("commit"));
+    await this.#lease(connection).commitTransaction();
   }
 
   async rollbackTransaction(connection: DatabaseConnection): Promise<void> {
-    await connection.executeQuery(CompiledQuery.raw("rollback"));
+    await this.#lease(connection).rollbackTransaction();
   }
 
   async releaseConnection(): Promise<void> {
@@ -83,22 +86,63 @@ class BunSqliteDriver implements Driver {
   }
 
   async destroy(): Promise<void> {
-    if (this.#connection) {
+    if (this.#connectionState) {
       this.#config.database.close();
+      this.#connectionState = undefined;
     }
+  }
+
+  #lease(connection: DatabaseConnection): BunSqliteConnectionLease {
+    if (!(connection instanceof BunSqliteConnectionLease)) {
+      throw new Error("Invalid Bun SQLite connection");
+    }
+    return connection;
   }
 }
 
-class BunSqliteConnection implements DatabaseConnection {
+class BunSqliteConnectionState {
   readonly #db: BunDatabase;
   readonly #beforeQuery?: () => Promise<void>;
+  #transactionOwner: symbol | null = null;
+  #activeQueries = 0;
+  #waiters: Array<() => void> = [];
 
   constructor(db: BunDatabase, beforeQuery?: () => Promise<void>) {
     this.#db = db;
     this.#beforeQuery = beforeQuery;
   }
 
-  async executeQuery<R>(compiledQuery: CompiledQuery): Promise<QueryResult<R>> {
+  async beginTransaction(owner: symbol): Promise<void> {
+    await this.#reserveTransaction(owner);
+
+    try {
+      await this.executeQuery(CompiledQuery.raw("begin"), owner);
+    } catch (error) {
+      this.#transactionOwner = null;
+      this.#notifyWaiters();
+      throw error;
+    }
+  }
+
+  async commitTransaction(owner: symbol): Promise<void> {
+    try {
+      await this.executeQuery(CompiledQuery.raw("commit"), owner);
+    } finally {
+      this.#clearTransactionOwner(owner);
+    }
+  }
+
+  async rollbackTransaction(owner: symbol): Promise<void> {
+    try {
+      await this.executeQuery(CompiledQuery.raw("rollback"), owner);
+    } finally {
+      this.#clearTransactionOwner(owner);
+    }
+  }
+
+  async executeQuery<R>(compiledQuery: CompiledQuery, owner: symbol): Promise<QueryResult<R>> {
+    await this.#enterQuery(owner);
+
     const { sql, parameters } = compiledQuery;
 
     try {
@@ -135,7 +179,70 @@ class BunSqliteConnection implements DatabaseConnection {
       throw new Error(
         `Query failed: ${error}\nSQL: ${sql}\nParameters: ${JSON.stringify(parameters)}`
       );
+    } finally {
+      this.#activeQueries -= 1;
+      this.#notifyWaiters();
     }
+  }
+
+  async #reserveTransaction(owner: symbol): Promise<void> {
+    while (this.#transactionOwner !== null || this.#activeQueries > 0) {
+      await this.#waitForStateChange();
+    }
+    this.#transactionOwner = owner;
+  }
+
+  async #enterQuery(owner: symbol): Promise<void> {
+    while (this.#transactionOwner !== null && this.#transactionOwner !== owner) {
+      await this.#waitForStateChange();
+    }
+    this.#activeQueries += 1;
+  }
+
+  #clearTransactionOwner(owner: symbol): void {
+    if (this.#transactionOwner === owner) {
+      this.#transactionOwner = null;
+      this.#notifyWaiters();
+    }
+  }
+
+  async #waitForStateChange(): Promise<void> {
+    await new Promise<void>(resolve => {
+      this.#waiters.push(resolve);
+    });
+  }
+
+  #notifyWaiters(): void {
+    const waiters = this.#waiters;
+    this.#waiters = [];
+    for (const waiter of waiters) {
+      waiter();
+    }
+  }
+}
+
+class BunSqliteConnectionLease implements DatabaseConnection {
+  readonly #state: BunSqliteConnectionState;
+  readonly #owner = Symbol("BunSqliteConnectionLease");
+
+  constructor(state: BunSqliteConnectionState) {
+    this.#state = state;
+  }
+
+  async beginTransaction(): Promise<void> {
+    await this.#state.beginTransaction(this.#owner);
+  }
+
+  async commitTransaction(): Promise<void> {
+    await this.#state.commitTransaction(this.#owner);
+  }
+
+  async rollbackTransaction(): Promise<void> {
+    await this.#state.rollbackTransaction(this.#owner);
+  }
+
+  async executeQuery<R>(compiledQuery: CompiledQuery): Promise<QueryResult<R>> {
+    return this.#state.executeQuery<R>(compiledQuery, this.#owner);
   }
 
   // eslint-disable-next-line require-yield

--- a/src/db/bunSqliteDialect.ts
+++ b/src/db/bunSqliteDialect.ts
@@ -10,6 +10,7 @@ import {
   SqliteAdapter,
   SqliteIntrospector,
   SqliteQueryCompiler,
+  TransactionSettings,
 } from "kysely";
 import { CompiledQuery } from "kysely";
 
@@ -43,6 +44,7 @@ export class BunSqliteDialect implements Dialect {
 
 interface BunSqliteDialectConfig {
   database: BunDatabase;
+  beforeQuery?: () => Promise<void>;
 }
 
 class BunSqliteDriver implements Driver {
@@ -54,7 +56,7 @@ class BunSqliteDriver implements Driver {
   }
 
   async init(): Promise<void> {
-    this.#connection = new BunSqliteConnection(this.#config.database);
+    this.#connection = new BunSqliteConnection(this.#config.database, this.#config.beforeQuery);
   }
 
   async acquireConnection(): Promise<DatabaseConnection> {
@@ -64,16 +66,16 @@ class BunSqliteDriver implements Driver {
     return this.#connection;
   }
 
-  async beginTransaction(): Promise<void> {
-    // No-op for Bun SQLite as it handles transactions internally
+  async beginTransaction(connection: DatabaseConnection, _settings: TransactionSettings): Promise<void> {
+    await connection.executeQuery(CompiledQuery.raw("begin"));
   }
 
-  async commitTransaction(): Promise<void> {
-    // No-op for Bun SQLite as it handles transactions internally
+  async commitTransaction(connection: DatabaseConnection): Promise<void> {
+    await connection.executeQuery(CompiledQuery.raw("commit"));
   }
 
-  async rollbackTransaction(): Promise<void> {
-    // No-op for Bun SQLite as it handles transactions internally
+  async rollbackTransaction(connection: DatabaseConnection): Promise<void> {
+    await connection.executeQuery(CompiledQuery.raw("rollback"));
   }
 
   async releaseConnection(): Promise<void> {
@@ -89,15 +91,19 @@ class BunSqliteDriver implements Driver {
 
 class BunSqliteConnection implements DatabaseConnection {
   readonly #db: BunDatabase;
+  readonly #beforeQuery?: () => Promise<void>;
 
-  constructor(db: BunDatabase) {
+  constructor(db: BunDatabase, beforeQuery?: () => Promise<void>) {
     this.#db = db;
+    this.#beforeQuery = beforeQuery;
   }
 
   async executeQuery<R>(compiledQuery: CompiledQuery): Promise<QueryResult<R>> {
     const { sql, parameters } = compiledQuery;
 
     try {
+      await this.#beforeQuery?.();
+
       // Prepare statement
       const stmt = this.#db.prepare(sql);
 

--- a/src/db/bunSqliteDialect.ts
+++ b/src/db/bunSqliteDialect.ts
@@ -104,6 +104,7 @@ class BunSqliteConnectionState {
   readonly #db: BunDatabase;
   readonly #beforeQuery?: () => Promise<void>;
   #transactionOwner: symbol | null = null;
+  #pendingTransactions = 0;
   #activeQueries = 0;
   #waiters: Array<() => void> = [];
 
@@ -113,7 +114,13 @@ class BunSqliteConnectionState {
   }
 
   async beginTransaction(owner: symbol): Promise<void> {
-    await this.#reserveTransaction(owner);
+    this.#pendingTransactions += 1;
+    try {
+      await this.#reserveTransaction(owner);
+    } finally {
+      this.#pendingTransactions -= 1;
+      this.#notifyWaiters();
+    }
 
     try {
       await this.executeQuery(CompiledQuery.raw("begin"), owner);
@@ -193,7 +200,10 @@ class BunSqliteConnectionState {
   }
 
   async #enterQuery(owner: symbol): Promise<void> {
-    while (this.#transactionOwner !== null && this.#transactionOwner !== owner) {
+    while (
+      (this.#transactionOwner !== null && this.#transactionOwner !== owner) ||
+      (this.#transactionOwner === null && this.#pendingTransactions > 0)
+    ) {
       await this.#waitForStateChange();
     }
     this.#activeQueries += 1;

--- a/src/db/database.ts
+++ b/src/db/database.ts
@@ -92,6 +92,14 @@ let dbInstance: Kysely<DatabaseSchema> | null = null;
 let migrationsRun = false;
 let migrationsPromise: Promise<void> | null = null;
 
+const DATABASE_STARTUP_MIGRATION_FAILURE =
+  "Database startup migrations failed; refusing to run queries until the daemon restarts.";
+
+function createStartupMigrationError(cause: unknown): Error {
+  const causeMessage = cause instanceof Error ? cause.message : String(cause);
+  return new Error(`${DATABASE_STARTUP_MIGRATION_FAILURE} Cause: ${causeMessage}`, { cause });
+}
+
 async function waitForMigrationsBeforeQuery(): Promise<void> {
   if (migrationsRun || !migrationsPromise) {
     return;
@@ -132,7 +140,9 @@ async function startMigrations(dbPath: string): Promise<void> {
 
 function ensureMigrationsStarted(dbPath: string): void {
   if (!migrationsRun && !migrationsPromise) {
-    migrationsPromise = startMigrations(dbPath);
+    migrationsPromise = startMigrations(dbPath).catch(error => {
+      throw createStartupMigrationError(error);
+    });
   }
 }
 

--- a/src/db/database.ts
+++ b/src/db/database.ts
@@ -92,6 +92,62 @@ let dbInstance: Kysely<DatabaseSchema> | null = null;
 let migrationsRun = false;
 let migrationsPromise: Promise<void> | null = null;
 
+async function waitForMigrationsBeforeQuery(): Promise<void> {
+  if (migrationsRun || !migrationsPromise) {
+    return;
+  }
+
+  await migrationsPromise;
+}
+
+function createSqliteKysely<T>(
+  dbPath: string,
+  beforeQuery?: () => Promise<void>
+): Kysely<T> {
+  const BunDatabaseConstructor = resolveBunDatabaseConstructor();
+  const sqliteDb = new BunDatabaseConstructor(dbPath);
+  configureSqliteDatabase(sqliteDb);
+
+  return new Kysely<T>({
+    dialect: new BunSqliteDialect({
+      database: sqliteDb,
+      beforeQuery,
+    }),
+  });
+}
+
+async function startMigrations(dbPath: string): Promise<void> {
+  const migrationDb = createSqliteKysely<unknown>(dbPath);
+
+  try {
+    await runMigrations(migrationDb);
+    migrationsRun = true;
+  } catch (error) {
+    logger.error("Failed to run migrations on database initialization:", error);
+    throw error;
+  } finally {
+    await migrationDb.destroy();
+  }
+}
+
+function ensureMigrationsStarted(dbPath: string): void {
+  if (!migrationsRun && !migrationsPromise) {
+    migrationsPromise = startMigrations(dbPath);
+  }
+}
+
+function ensureDatabaseDirectory(dbPath: string): void {
+  const dbDir = path.dirname(dbPath);
+
+  if (!fs.existsSync(dbDir)) {
+    fs.mkdirSync(dbDir, { recursive: true });
+  }
+}
+
+function createApplicationDatabase(dbPath: string): Kysely<DatabaseSchema> {
+  return createSqliteKysely<DatabaseSchema>(dbPath, waitForMigrationsBeforeQuery);
+}
+
 /**
  * Get the singleton database instance.
  * Creates the database file and directory if they don't exist.
@@ -99,35 +155,10 @@ let migrationsPromise: Promise<void> | null = null;
 export function getDatabase(): Kysely<DatabaseSchema> {
   if (!dbInstance) {
     const dbPath = resolveDbPath();
-    const dbDir = path.dirname(dbPath);
+    ensureDatabaseDirectory(dbPath);
 
-    // Ensure directory exists
-    if (!fs.existsSync(dbDir)) {
-      fs.mkdirSync(dbDir, { recursive: true });
-    }
-
-    // Use Bun's built-in SQLite
-    const BunDatabaseConstructor = resolveBunDatabaseConstructor();
-    const sqliteDb = new BunDatabaseConstructor(dbPath);
-    configureSqliteDatabase(sqliteDb);
-
-    dbInstance = new Kysely<DatabaseSchema>({
-      dialect: new BunSqliteDialect({
-        database: sqliteDb,
-      }),
-    });
-
-    // Run migrations if not already run
-    if (!migrationsRun && !migrationsPromise) {
-      migrationsPromise = runMigrations(dbInstance as Kysely<unknown>)
-        .then(() => {
-          migrationsRun = true;
-        })
-        .catch(error => {
-          logger.error("Failed to run migrations on database initialization:", error);
-          throw error;
-        });
-    }
+    dbInstance = createApplicationDatabase(dbPath);
+    ensureMigrationsStarted(dbPath);
   }
 
   return dbInstance;
@@ -142,16 +173,7 @@ export async function ensureMigrations(): Promise<void> {
     getDatabase();
   }
 
-  if (!migrationsPromise) {
-    migrationsPromise = runMigrations(dbInstance as Kysely<unknown>)
-      .then(() => {
-        migrationsRun = true;
-      })
-      .catch(error => {
-        logger.error("Failed to run migrations on database initialization:", error);
-        throw error;
-      });
-  }
+  ensureMigrationsStarted(resolveDbPath());
 
   await migrationsPromise;
 }

--- a/test/db/database.test.ts
+++ b/test/db/database.test.ts
@@ -15,6 +15,20 @@ class FakeSqliteDatabase {
   }
 }
 
+interface Deferred<T> {
+  promise: Promise<T>;
+  resolve: (value: T | PromiseLike<T>) => void;
+}
+
+function createDeferred<T = void>(): Deferred<T> {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  const promise = new Promise<T>(res => {
+    resolve = res;
+  });
+
+  return { promise, resolve };
+}
+
 describe("configureSqliteDatabase", () => {
   test("enables WAL, busy timeout, and foreign keys for new connections", () => {
     const db = new FakeSqliteDatabase();
@@ -93,6 +107,55 @@ describe("BunSqliteDialect transactions", () => {
 
       const rows = await db.selectFrom("items").selectAll().execute();
       expect(rows).toEqual([{ id: 1, name: "committed" }]);
+    } finally {
+      await db.destroy();
+    }
+  });
+
+  test("waits to run non-transaction queries while a transaction is open", async () => {
+    const db = new Kysely<{ items: { id: number; name: string } }>({
+      dialect: new BunSqliteDialect({
+        database: new BunDatabase(":memory:"),
+      }),
+    });
+
+    try {
+      await db.schema
+        .createTable("items")
+        .addColumn("id", "integer", col => col.primaryKey())
+        .addColumn("name", "text", col => col.notNull())
+        .execute();
+
+      const transactionStarted = createDeferred();
+      const failTransaction = createDeferred();
+
+      const transaction = db.transaction().execute(async trx => {
+        await trx.insertInto("items").values({ id: 1, name: "rolled-back" }).execute();
+        transactionStarted.resolve();
+        await failTransaction.promise;
+        throw new Error("force rollback");
+      });
+
+      await transactionStarted.promise;
+
+      let outsideInsertFinished = false;
+      const outsideInsert = db
+        .insertInto("items")
+        .values({ id: 2, name: "outside" })
+        .execute()
+        .then(() => {
+          outsideInsertFinished = true;
+        });
+
+      await Promise.resolve();
+      expect(outsideInsertFinished).toBe(false);
+
+      failTransaction.resolve();
+      await expect(transaction).rejects.toThrow("force rollback");
+      await outsideInsert;
+
+      const rows = await db.selectFrom("items").selectAll().orderBy("id").execute();
+      expect(rows).toEqual([{ id: 2, name: "outside" }]);
     } finally {
       await db.destroy();
     }

--- a/test/db/database.test.ts
+++ b/test/db/database.test.ts
@@ -1,8 +1,5 @@
-import { afterEach, describe, expect, test } from "bun:test";
+import { describe, expect, test } from "bun:test";
 import { Database as BunDatabase } from "bun:sqlite";
-import { mkdtemp, rm } from "node:fs/promises";
-import { join } from "node:path";
-import { tmpdir } from "node:os";
 import { Kysely } from "kysely";
 import { BunSqliteDialect } from "../../src/db/bunSqliteDialect";
 import {
@@ -19,13 +16,6 @@ class FakeSqliteDatabase {
 }
 
 describe("configureSqliteDatabase", () => {
-  let tempDirs: string[] = [];
-
-  afterEach(async () => {
-    await Promise.all(tempDirs.map(dir => rm(dir, { recursive: true, force: true })));
-    tempDirs = [];
-  });
-
   test("enables WAL, busy timeout, and foreign keys for new connections", () => {
     const db = new FakeSqliteDatabase();
 
@@ -38,10 +28,8 @@ describe("configureSqliteDatabase", () => {
     ]);
   });
 
-  test("sets a 5 second busy timeout on Bun SQLite file databases", async () => {
-    const tempDir = await mkdtemp(join(tmpdir(), "auto-mobile-sqlite-"));
-    tempDirs.push(tempDir);
-    const sqliteDb = new BunDatabase(join(tempDir, "auto-mobile.db"));
+  test("sets a 5 second busy timeout on Bun SQLite databases", async () => {
+    const sqliteDb = new BunDatabase(":memory:");
 
     try {
       configureSqliteDatabase(sqliteDb);

--- a/test/db/database.test.ts
+++ b/test/db/database.test.ts
@@ -160,4 +160,76 @@ describe("BunSqliteDialect transactions", () => {
       await db.destroy();
     }
   });
+
+  test("prioritizes a pending transaction before later non-transaction queries", async () => {
+    const heldQueryStarted = createDeferred();
+    const releaseHeldQuery = createDeferred();
+    const transactionStarted = createDeferred();
+    const releaseTransaction = createDeferred();
+    let holdNextQuery = false;
+
+    const db = new Kysely<{ items: { id: number; name: string } }>({
+      dialect: new BunSqliteDialect({
+        database: new BunDatabase(":memory:"),
+        beforeQuery: async () => {
+          if (!holdNextQuery) {
+            return;
+          }
+
+          holdNextQuery = false;
+          heldQueryStarted.resolve();
+          await releaseHeldQuery.promise;
+        },
+      }),
+    });
+
+    try {
+      await db.schema
+        .createTable("items")
+        .addColumn("id", "integer", col => col.primaryKey())
+        .addColumn("name", "text", col => col.notNull())
+        .execute();
+
+      holdNextQuery = true;
+      const heldRead = db.selectFrom("items").selectAll().execute();
+      await heldQueryStarted.promise;
+
+      const transaction = db.transaction().execute(async trx => {
+        await trx.insertInto("items").values({ id: 1, name: "transaction" }).execute();
+        transactionStarted.resolve();
+        await releaseTransaction.promise;
+      });
+
+      await Promise.resolve();
+
+      let outsideInsertFinished = false;
+      const outsideInsert = db
+        .insertInto("items")
+        .values({ id: 2, name: "outside" })
+        .execute()
+        .then(() => {
+          outsideInsertFinished = true;
+        });
+
+      await Promise.resolve();
+      expect(outsideInsertFinished).toBe(false);
+
+      releaseHeldQuery.resolve();
+      await heldRead;
+      await transactionStarted.promise;
+      expect(outsideInsertFinished).toBe(false);
+
+      releaseTransaction.resolve();
+      await transaction;
+      await outsideInsert;
+
+      const rows = await db.selectFrom("items").selectAll().orderBy("id").execute();
+      expect(rows).toEqual([
+        { id: 1, name: "transaction" },
+        { id: 2, name: "outside" },
+      ]);
+    } finally {
+      await db.destroy();
+    }
+  });
 });

--- a/test/db/database.test.ts
+++ b/test/db/database.test.ts
@@ -3,6 +3,8 @@ import { Database as BunDatabase } from "bun:sqlite";
 import { mkdtemp, rm } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
+import { Kysely } from "kysely";
+import { BunSqliteDialect } from "../../src/db/bunSqliteDialect";
 import {
   configureSqliteDatabase,
   SQLITE_BUSY_TIMEOUT_MS,
@@ -50,6 +52,61 @@ describe("configureSqliteDatabase", () => {
       expect(result?.timeout).toBe(5_000);
     } finally {
       sqliteDb.close();
+    }
+  });
+});
+
+describe("BunSqliteDialect transactions", () => {
+  test("rolls back all statements when a transaction throws", async () => {
+    const db = new Kysely<{ items: { id: number; name: string } }>({
+      dialect: new BunSqliteDialect({
+        database: new BunDatabase(":memory:"),
+      }),
+    });
+
+    try {
+      await db.schema
+        .createTable("items")
+        .addColumn("id", "integer", col => col.primaryKey())
+        .addColumn("name", "text", col => col.notNull())
+        .execute();
+
+      await expect(
+        db.transaction().execute(async trx => {
+          await trx.insertInto("items").values({ id: 1, name: "rolled-back" }).execute();
+          throw new Error("force rollback");
+        })
+      ).rejects.toThrow("force rollback");
+
+      const rows = await db.selectFrom("items").selectAll().execute();
+      expect(rows).toEqual([]);
+    } finally {
+      await db.destroy();
+    }
+  });
+
+  test("commits all statements when a transaction completes", async () => {
+    const db = new Kysely<{ items: { id: number; name: string } }>({
+      dialect: new BunSqliteDialect({
+        database: new BunDatabase(":memory:"),
+      }),
+    });
+
+    try {
+      await db.schema
+        .createTable("items")
+        .addColumn("id", "integer", col => col.primaryKey())
+        .addColumn("name", "text", col => col.notNull())
+        .execute();
+
+      await db.transaction().execute(async trx => {
+        await trx.insertInto("items").values({ id: 1, name: "committed" }).execute();
+      });
+
+      const rows = await db.selectFrom("items").selectAll().execute();
+      expect(rows).toEqual([{ id: 1, name: "committed" }]);
+    } finally {
+      await db.destroy();
     }
   });
 });

--- a/test/db/databaseLazyPath.test.ts
+++ b/test/db/databaseLazyPath.test.ts
@@ -3,6 +3,7 @@ import path from "path";
 import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { DAEMON_LAUNCH_CWD_ENV } from "../../src/utils/workingDirectory";
+import { defaultTimer } from "../../src/utils/SystemTimer";
 
 /**
  * Regression test for the module-load-time-vs-runtime path hazard.
@@ -34,6 +35,23 @@ describe("database path lazy resolution", () => {
   async function importFreshDatabaseModule() {
     // Fresh module instance so its lazy cache is not shared with other tests.
     return import(`../../src/db/database.ts?lazy-db-path-test=${Date.now()}-${Math.random()}`);
+  }
+
+  async function removeTempDirWithRetry(dir: string): Promise<void> {
+    for (let attempt = 0; attempt < 10; attempt += 1) {
+      try {
+        await rm(dir, { recursive: true, force: true });
+        return;
+      } catch (error) {
+        const code = (error as NodeJS.ErrnoException).code;
+        if (code !== "EBUSY" && code !== "EPERM") {
+          throw error;
+        }
+        await defaultTimer.sleep(50);
+      }
+    }
+
+    await rm(dir, { recursive: true, force: true });
   }
 
   test("resolves relative AUTOMOBILE_DB_DIR against the launch cwd set AFTER import", async () => {
@@ -90,7 +108,7 @@ describe("database path lazy resolution", () => {
       expect(rows).toEqual([]);
     } finally {
       await databaseModule.closeDatabase();
-      await rm(dbDir, { recursive: true, force: true });
+      await removeTempDirWithRetry(dbDir);
     }
   });
 });

--- a/test/db/databaseLazyPath.test.ts
+++ b/test/db/databaseLazyPath.test.ts
@@ -42,13 +42,13 @@ describe("database path lazy resolution", () => {
   }
 
   async function removeTempDirWithRetry(dir: string): Promise<void> {
-    for (let attempt = 0; attempt < 10; attempt += 1) {
+    for (let attempt = 0; attempt < 100; attempt += 1) {
       try {
         await rm(dir, { recursive: true, force: true });
         return;
       } catch (error) {
         const code = (error as NodeJS.ErrnoException).code;
-        if (code !== "EBUSY" && code !== "EPERM") {
+        if (code !== "EBUSY" && code !== "EPERM" && code !== "ENOTEMPTY") {
           throw error;
         }
         await defaultTimer.sleep(50);

--- a/test/db/databaseLazyPath.test.ts
+++ b/test/db/databaseLazyPath.test.ts
@@ -1,5 +1,7 @@
 import { afterEach, describe, expect, test } from "bun:test";
 import path from "path";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
 import { DAEMON_LAUNCH_CWD_ENV } from "../../src/utils/workingDirectory";
 
 /**
@@ -69,5 +71,26 @@ describe("database path lazy resolution", () => {
     const second = databaseModule.getDatabasePath();
 
     expect(second).toBe(first);
+  });
+
+  test("queries issued immediately after getDatabase wait for startup migrations", async () => {
+    const dbDir = await mkdtemp(path.join(tmpdir(), "auto-mobile-db-startup-"));
+    process.env.AUTOMOBILE_DB_DIR = dbDir;
+    delete process.env[DAEMON_LAUNCH_CWD_ENV];
+
+    const databaseModule = await importFreshDatabaseModule();
+    const db = databaseModule.getDatabase();
+
+    try {
+      const rows = await db
+        .selectFrom("tool_calls" as any)
+        .selectAll()
+        .execute();
+
+      expect(rows).toEqual([]);
+    } finally {
+      await databaseModule.closeDatabase();
+      await rm(dbDir, { recursive: true, force: true });
+    }
   });
 });

--- a/test/db/databaseLazyPath.test.ts
+++ b/test/db/databaseLazyPath.test.ts
@@ -18,6 +18,8 @@ import { defaultTimer } from "../../src/utils/SystemTimer";
 describe("database path lazy resolution", () => {
   const originalLaunchCwd = process.env[DAEMON_LAUNCH_CWD_ENV];
   const originalDbDir = process.env.AUTOMOBILE_DB_DIR;
+  const originalMigrationsDir = process.env.AUTOMOBILE_MIGRATIONS_DIR;
+  const originalLegacyMigrationsDir = process.env.AUTO_MOBILE_MIGRATIONS_DIR;
 
   function restore(key: string, value: string | undefined): void {
     if (value === undefined) {
@@ -30,6 +32,8 @@ describe("database path lazy resolution", () => {
   afterEach(() => {
     restore(DAEMON_LAUNCH_CWD_ENV, originalLaunchCwd);
     restore("AUTOMOBILE_DB_DIR", originalDbDir);
+    restore("AUTOMOBILE_MIGRATIONS_DIR", originalMigrationsDir);
+    restore("AUTO_MOBILE_MIGRATIONS_DIR", originalLegacyMigrationsDir);
   });
 
   async function importFreshDatabaseModule() {
@@ -106,6 +110,34 @@ describe("database path lazy resolution", () => {
         .execute();
 
       expect(rows).toEqual([]);
+    } finally {
+      await databaseModule.closeDatabase();
+      await removeTempDirWithRetry(dbDir);
+    }
+  });
+
+  test("queries fail clearly and consistently when startup migrations fail", async () => {
+    const dbDir = await mkdtemp(path.join(tmpdir(), "auto-mobile-db-startup-fail-"));
+    process.env.AUTOMOBILE_DB_DIR = dbDir;
+    process.env.AUTOMOBILE_MIGRATIONS_DIR = path.join(dbDir, "missing-migrations");
+    delete process.env.AUTO_MOBILE_MIGRATIONS_DIR;
+    delete process.env[DAEMON_LAUNCH_CWD_ENV];
+
+    const databaseModule = await importFreshDatabaseModule();
+    const db = databaseModule.getDatabase();
+    const query = () =>
+      db
+        .selectFrom("tool_calls" as any)
+        .selectAll()
+        .execute();
+
+    try {
+      await expect(query()).rejects.toThrow(
+        "Database startup migrations failed; refusing to run queries until the daemon restarts."
+      );
+      await expect(query()).rejects.toThrow(
+        "Database startup migrations failed; refusing to run queries until the daemon restarts."
+      );
     } finally {
       await databaseModule.closeDatabase();
       await removeTempDirWithRetry(dbDir);


### PR DESCRIPTION
## Summary

- implement real Bun SQLite transaction begin/commit/rollback and gate early app queries until startup migrations finish
- serialize shared SQLite driver operations on Android and iOS so parallel inspector clients cannot close or reuse handles concurrently
- fix Android database path prefix validation and make busy-timeout setup compatible with Robolectric
- add parallel read/write coverage for TypeScript, Android, and iOS SQLite paths
- isolate IOSCtrlProxyManager port allocation tests from local adb-owned ports

## Validation

- `bun run lint`
- `bun run build`
- `bun test`
- `bun test test/db/database.test.ts test/db/databaseLazyPath.test.ts`
- `swift test --filter SQLiteDatabaseDriverConcurrencyTests`
- `swift test` in `ios/auto-mobile-sdk`
- `bash scripts/ios/swift-build.sh`
- `./gradlew :auto-mobile-sdk:testDebugUnitTest`
- `ONLY_TOUCHED_FILES=true bash scripts/ktfmt/validate_ktfmt.sh`
- `ONLY_TOUCHED_FILES=true bash scripts/swiftformat/validate_swiftformat.sh`
- `ONLY_TOUCHED_FILES=true bash scripts/swiftlint/validate_swiftlint.sh`
- `bash scripts/all_fast_validate_checks.sh`

## Notes

- `bash scripts/validate-bun-test-timings.sh` still reports pre-existing slow Bun tests outside this SQLite change.
