### PR TITLE
fix: confirm daemon process candidates

### DIFF
--- a/src/daemon/manager.ts
+++ b/src/daemon/manager.ts
@@ -25,7 +25,10 @@ import {
 import { DaemonClient, type DaemonClientFactory, type DaemonClientLike } from "./client";
 import { DaemonState, type DaemonStateLike } from "./daemonState";
 import { Timer, defaultTimer } from "../utils/SystemTimer";
-import { cleanupDaemonFiles } from "./daemonFiles";
+import {
+  cleanupDaemonFiles,
+  isProcessRunning as isDaemonProcessRunning,
+} from "./daemonFiles";
 import {
   DAEMON_LAUNCH_CWD_ENV,
   resolveDaemonLaunchWorkingDirectory,
@@ -110,7 +113,11 @@ export function parseDaemonProcessTable(psOutput: string): DaemonProcessRecord[]
   return records;
 }
 
-export class PsDaemonProcessFinder implements DaemonProcessFinder {
+export interface DaemonProcessLivenessChecker {
+  isProcessRunning(pid: number): boolean;
+}
+
+export class PsDaemonProcessFinder implements DaemonProcessFinder, DaemonProcessLivenessChecker {
   constructor(private readonly runCommand: ProcessTableCommandRunner = execSync) {}
 
   findDaemonProcesses(): DaemonProcessRecord[] {
@@ -119,6 +126,10 @@ export class PsDaemonProcessFinder implements DaemonProcessFinder {
       maxBuffer: DAEMON_PROCESS_TABLE_MAX_BUFFER_BYTES,
     });
     return parseDaemonProcessTable(psOutput);
+  }
+
+  isProcessRunning(pid: number): boolean {
+    return isDaemonProcessRunning(pid);
   }
 }
 
@@ -129,6 +140,10 @@ export interface DaemonProcessSpawner {
 const nodeDaemonProcessSpawner: DaemonProcessSpawner = {
   spawn: nodeSpawn,
 };
+
+function hasProcessLivenessChecker(value: unknown): value is DaemonProcessLivenessChecker {
+  return typeof (value as Partial<DaemonProcessLivenessChecker> | undefined)?.isProcessRunning === "function";
+}
 
 const MAX_DAEMON_STARTUP_LOG_BYTES = 4000;
 
@@ -196,6 +211,7 @@ export class DaemonManager implements DaemonManagerLike {
   private readonly socketPath: string;
   private readonly processFinder: DaemonProcessFinder;
   private readonly processSpawner: DaemonProcessSpawner;
+  private readonly processLivenessChecker: DaemonProcessLivenessChecker;
 
   constructor(
     clientFactory: DaemonClientFactory | undefined = undefined,
@@ -215,9 +231,14 @@ export class DaemonManager implements DaemonManagerLike {
     if ("findDaemonProcesses" in processFinderOrSpawner) {
       this.processFinder = processFinderOrSpawner;
       this.processSpawner = processSpawner;
+      this.processLivenessChecker = hasProcessLivenessChecker(processFinderOrSpawner)
+        ? processFinderOrSpawner
+        : new PsDaemonProcessFinder();
     } else {
-      this.processFinder = new PsDaemonProcessFinder();
+      const processFinder = new PsDaemonProcessFinder();
+      this.processFinder = processFinder;
       this.processSpawner = processFinderOrSpawner;
+      this.processLivenessChecker = processFinder;
     }
     this.clientFactory = clientFactory ?? (() => new DaemonClient(this.socketPath));
   }
@@ -303,13 +324,18 @@ export class DaemonManager implements DaemonManagerLike {
     try {
       return this.normalizeDaemonProcessRecords(this.processFinder.findDaemonProcesses());
     } catch (error) {
-      // No matching processes found or command failed
-      return [];
+      throw new ActionableError(
+        `Failed to inspect daemon process table: ${error instanceof Error ? error.message : String(error)}`
+      );
     }
   }
 
   findOtherDaemonProcesses(activeDaemonPid: number | undefined): number[] {
-    return this.findAllDaemonProcesses().filter(pid => pid !== activeDaemonPid);
+    return this.findLiveDaemonProcesses().filter(pid => pid !== activeDaemonPid);
+  }
+
+  findLiveDaemonProcesses(): number[] {
+    return this.findAllDaemonProcesses().filter(pid => this.isProcessRunning(pid));
   }
 
   private normalizeDaemonProcessRecords(records: DaemonProcessRecord[]): number[] {
@@ -387,7 +413,7 @@ export class DaemonManager implements DaemonManagerLike {
    */
   private async startUnlocked(options: DaemonOptions): Promise<void> {
     // Check for any running daemon processes from ANY worktree
-    const otherDaemons = this.findAllDaemonProcesses();
+    const otherDaemons = this.findLiveDaemonProcesses();
     if (otherDaemons.length > 0) {
       stderrLog(
         `\nWARNING: Found ${otherDaemons.length} other auto-mobile daemon process(es) running:`
@@ -403,7 +429,7 @@ export class DaemonManager implements DaemonManagerLike {
       for (const pid of otherDaemons) {
         try {
           process.kill(pid, "SIGTERM");
-          stderrLog(`  Stopped PID ${pid}`);
+          stderrLog(`  Sent SIGTERM to PID ${pid}`);
         } catch (error) {
           stderrLog(`  Failed to stop PID ${pid}: ${error instanceof Error ? error.message : String(error)}`);
         }
@@ -411,6 +437,19 @@ export class DaemonManager implements DaemonManagerLike {
 
       // Wait for processes to terminate
       await this.timer.sleep(1000);
+
+      const remainingDaemonPids = new Set(this.findLiveDaemonProcesses());
+      for (const pid of otherDaemons) {
+        if (!remainingDaemonPids.has(pid)) {
+          continue;
+        }
+        try {
+          process.kill(pid, "SIGKILL");
+          stderrLog(`  Sent SIGKILL to PID ${pid}`);
+        } catch (error) {
+          stderrLog(`  Failed to kill PID ${pid}: ${error instanceof Error ? error.message : String(error)}`);
+        }
+      }
     }
 
     // Enforce single daemon policy: stop any existing daemon before starting
@@ -892,13 +931,7 @@ export class DaemonManager implements DaemonManagerLike {
    * Check if a process is running
    */
   private isProcessRunning(pid: number): boolean {
-    try {
-      // Sending signal 0 checks if process exists without actually sending a signal
-      process.kill(pid, 0);
-      return true;
-    } catch (error) {
-      return false;
-    }
+    return this.processLivenessChecker.isProcessRunning(pid);
   }
 
   /**

--- a/test/daemon/manager.test.ts
+++ b/test/daemon/manager.test.ts
@@ -1,4 +1,8 @@
 import { describe, expect, spyOn, test } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import type { ChildProcess, SpawnOptions } from "node:child_process";
 import {
   DAEMON_PROCESS_TABLE_MAX_BUFFER_BYTES,
   DaemonManager,
@@ -7,9 +11,15 @@ import {
   resolveDaemonLaunchCommand,
   runDaemonCommand
 } from "../../src/daemon/manager";
-import type { DaemonProcessFinder, DaemonProcessRecord } from "../../src/daemon/manager";
+import type {
+  DaemonProcessFinder,
+  DaemonProcessLivenessChecker,
+  DaemonProcessSpawner,
+  DaemonProcessRecord,
+} from "../../src/daemon/manager";
 import type { DaemonStateLike } from "../../src/daemon/daemonState";
 import type { DaemonClientLike } from "../../src/daemon/client";
+import { FakeTimer } from "../fakes/FakeTimer";
 
 class FakeDaemonClient implements DaemonClientLike {
   readonly readResourceCalls: string[] = [];
@@ -41,11 +51,18 @@ class FakeDaemonClient implements DaemonClientLike {
   }
 }
 
-class FakeDaemonProcessFinder implements DaemonProcessFinder {
-  constructor(private readonly records: DaemonProcessRecord[]) {}
+class FakeDaemonProcessFinder implements DaemonProcessFinder, DaemonProcessLivenessChecker {
+  constructor(
+    private readonly records: DaemonProcessRecord[],
+    private readonly livePids: Set<number> = new Set(records.map(record => record.pid))
+  ) {}
 
   findDaemonProcesses(): DaemonProcessRecord[] {
     return this.records;
+  }
+
+  isProcessRunning(pid: number): boolean {
+    return this.livePids.has(pid);
   }
 }
 
@@ -133,7 +150,10 @@ describe("Daemon manager process detection", () => {
     expect(DAEMON_PROCESS_TABLE_MAX_BUFFER_BYTES).toBeGreaterThan(1024 * 1024);
   });
 
-  function managerWithProcesses(records: DaemonProcessRecord[]): DaemonManager {
+  function managerWithProcesses(
+    records: DaemonProcessRecord[],
+    options: { livePids?: Set<number> } = {}
+  ): DaemonManager {
     return new DaemonManager(
       undefined,
       undefined,
@@ -141,7 +161,8 @@ describe("Daemon manager process detection", () => {
       undefined,
       undefined,
       undefined,
-      new FakeDaemonProcessFinder(records)
+      new FakeDaemonProcessFinder(records, options.livePids),
+      undefined
     );
   }
 
@@ -201,9 +222,190 @@ describe("Daemon manager process detection", () => {
         ppid: 300,
         command: `bun /worktree-b/dist/src/index.js --daemon-mode`,
       },
-    ]);
+    ], { livePids: new Set([201, 301]) });
 
     expect(manager.findOtherDaemonProcesses(201)).toEqual([301]);
+  });
+
+  test("preserves live daemon-mode candidates that are not backed by the PID file", () => {
+    const manager = managerWithProcesses([
+      {
+        pid: 201,
+        ppid: 200,
+        command: `bun /worktree-a/dist/src/index.js --daemon-mode`,
+      },
+      {
+        pid: 401,
+        ppid: 1,
+        command: `bun /worktree-b/dist/src/index.js --daemon-mode`,
+      },
+    ], { livePids: new Set([201, 401]) });
+
+    expect(manager.findOtherDaemonProcesses(201)).toEqual([401]);
+  });
+
+  test("ignores daemon-mode candidates that are gone by liveness re-check", () => {
+    const manager = managerWithProcesses([
+      {
+        pid: 201,
+        ppid: 200,
+        command: `bun /worktree-a/dist/src/index.js --daemon-mode`,
+      },
+      {
+        pid: 401,
+        ppid: 1,
+        command: `bun /worktree-a/dist/src/index.js --daemon-mode`,
+      },
+    ], { livePids: new Set([201]) });
+
+    expect(manager.findOtherDaemonProcesses(201)).toEqual([]);
+  });
+
+  test("fails closed when the process table cannot be inspected", () => {
+    const manager = new DaemonManager(
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      {
+        findDaemonProcesses() {
+          throw new Error("spawn ENOBUFS");
+        },
+      }
+    );
+
+    expect(() => manager.findAllDaemonProcesses()).toThrow("Failed to inspect daemon process table: spawn ENOBUFS");
+  });
+
+  test("start takeover escalates to SIGKILL when another daemon survives SIGTERM", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "daemon-manager-takeover-test-"));
+    const fakeTimer = new FakeTimer();
+    fakeTimer.enableAutoAdvance();
+    const killCalls: Array<{ pid: number; signal: NodeJS.Signals | number | undefined }> = [];
+    const processFinder = new FakeDaemonProcessFinder([
+      {
+        pid: 301,
+        ppid: 1,
+        command: `bun /worktree-b/dist/src/index.js --daemon-mode`,
+      },
+    ], new Set([301]));
+    const processSpawner: DaemonProcessSpawner = {
+      spawn: (_command: string, _args: string[], _options: SpawnOptions) => ({
+        unref() {},
+        once() { return this; },
+        off() { return this; },
+      }) as ChildProcess,
+    };
+    const killSpy = spyOn(process, "kill").mockImplementation(((pid: number, signal?: NodeJS.Signals | number) => {
+      if (pid === 301) {
+        killCalls.push({ pid, signal });
+      }
+      return true;
+    }) as typeof process.kill);
+
+    class TestDaemonManager extends DaemonManager {
+      override async status(): Promise<any> {
+        return { running: false };
+      }
+
+      override async waitForReady(_timeout: number): Promise<boolean> {
+        return true;
+      }
+    }
+
+    try {
+      const manager = new TestDaemonManager(
+        undefined,
+        undefined,
+        fakeTimer,
+        join(dir, "daemon.lock"),
+        join(dir, "daemon.pid"),
+        join(dir, "daemon.sock"),
+        processFinder,
+        processSpawner
+      );
+
+      await manager.start();
+
+      expect(killCalls).toEqual([
+        { pid: 301, signal: "SIGTERM" },
+        { pid: 301, signal: "SIGKILL" },
+      ]);
+    } finally {
+      killSpy.mockRestore();
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("start takeover does not SIGKILL when daemon identity is no longer confirmed", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "daemon-manager-takeover-revalidate-test-"));
+    const fakeTimer = new FakeTimer();
+    fakeTimer.enableAutoAdvance();
+    const killCalls: Array<{ pid: number; signal: NodeJS.Signals | number | undefined }> = [];
+    let findCalls = 0;
+    const processFinder: DaemonProcessFinder & DaemonProcessLivenessChecker = {
+      findDaemonProcesses() {
+        findCalls++;
+        return findCalls === 1 ? [
+          {
+            pid: 301,
+            ppid: 1,
+            command: `bun /worktree-b/dist/src/index.js --daemon-mode`,
+          },
+        ] : [];
+      },
+      isProcessRunning(pid: number) {
+        return pid === 301;
+      },
+    };
+    const processSpawner: DaemonProcessSpawner = {
+      spawn: (_command: string, _args: string[], _options: SpawnOptions) => ({
+        unref() {},
+        once() { return this; },
+        off() { return this; },
+      }) as ChildProcess,
+    };
+    const killSpy = spyOn(process, "kill").mockImplementation(((pid: number, signal?: NodeJS.Signals | number) => {
+      if (pid === 301) {
+        killCalls.push({ pid, signal });
+      }
+      return true;
+    }) as typeof process.kill);
+
+    class TestDaemonManager extends DaemonManager {
+      override async status(): Promise<any> {
+        return { running: false };
+      }
+
+      override async waitForReady(_timeout: number): Promise<boolean> {
+        return true;
+      }
+    }
+
+    try {
+      const manager = new TestDaemonManager(
+        undefined,
+        undefined,
+        fakeTimer,
+        join(dir, "daemon.lock"),
+        join(dir, "daemon.pid"),
+        join(dir, "daemon.sock"),
+        processFinder,
+        processSpawner
+      );
+
+      await manager.start();
+
+      expect(killCalls).toEqual([
+        { pid: 301, signal: "SIGTERM" },
+      ]);
+      expect(findCalls).toBe(2);
+    } finally {
+      killSpy.mockRestore();
+      rmSync(dir, { recursive: true, force: true });
+    }
   });
 });
 


### PR DESCRIPTION
## Summary

- Re-check all daemon process-table candidates for liveness before status warnings or startup takeover signaling.
- Preserve live non-PID-file daemon candidates so genuine cross-worktree conflicts still surface.
- Escalate startup takeover from `SIGTERM` to `SIGKILL` for daemon candidates that survive the grace period.
- Fail closed when process-table inspection fails instead of treating the failure as "no daemons."

## Root Cause

`--daemon status` scanned the full process table and treated every normalized `--daemon-mode` match except the active daemon PID as another daemon. Short-lived startup or health-probe processes could appear in that snapshot and then exit before inspection, producing false multi-daemon warnings.

## User Impact

Single-daemon setups should no longer warn about probe PIDs that are gone by report time, while live rogue daemons from other worktrees remain visible and are still stopped during startup takeover.

## Testing

- `./node_modules/.bin/eslint src/daemon/manager.ts test/daemon/manager.test.ts --fix`
- `bun test test/daemon/manager.test.ts test/daemon/daemonManagerLaunch.test.ts test/daemon/daemonManagerReadiness.test.ts test/daemon/daemonManagerLock.test.ts`
- `bun run build`
