### PR TITLE
Avoid blocking CtrlProxy readiness on APK refresh

### DIFF
--- a/docs/design-docs/plat/android/control-proxy.md
+++ b/docs/design-docs/plat/android/control-proxy.md
@@ -203,10 +203,16 @@ AutoMobile manages accessibility service versions automatically:
 - Accepts an already-installed CtrlProxy during normal readiness checks even when
   the checksum differs, so local/offline tool calls do not block on a release APK download
 - Queues a background release APK prefetch when a mismatch is detected with the default downloader
+- Installs an already-completed background prefetch on a later readiness check without
+  waiting on network, so genuinely stale services can self-heal after the download finishes
 - Upgrades when version mismatch is detected through an explicit service update request
 - Falls back to reinstallation if upgrade fails
 - Validates downloaded APKs via SHA256 checksum
 - Supports local APK overrides for development
+
+A cold device with no CtrlProxy installed still needs an APK source for the first install.
+If the network is unavailable and no local `AUTOMOBILE_CTRL_PROXY_APK_PATH` is configured,
+the first install attempt fails fast and is cached briefly to avoid repeated download attempts.
 
 When device setup uses `skipAccessibilityDownload`, AutoMobile still validates the installed service checksum.
 If the version is incompatible, it surfaces a warning/error advising you to rerun without

--- a/docs/design-docs/plat/android/control-proxy.md
+++ b/docs/design-docs/plat/android/control-proxy.md
@@ -200,7 +200,10 @@ The accessibility service runs as a standard Android accessibility service that:
 AutoMobile manages accessibility service versions automatically:
 
 - Compares installed APK checksum against expected release version
-- Upgrades when version mismatch detected
+- Accepts an already-installed CtrlProxy during normal readiness checks even when
+  the checksum differs, so local/offline tool calls do not block on a release APK download
+- Queues a background release APK prefetch when a mismatch is detected with the default downloader
+- Upgrades when version mismatch is detected through an explicit service update request
 - Falls back to reinstallation if upgrade fails
 - Validates downloaded APKs via SHA256 checksum
 - Supports local APK overrides for development
@@ -218,10 +221,10 @@ If the version is incompatible, it surfaces a warning/error advising you to reru
 
 ## Environment Variables
 
-- `AUTOMOBILE_ACCESSIBILITY_APK_PATH`: Override APK source with a local file path.
+- `AUTOMOBILE_CTRL_PROXY_APK_PATH`: Override APK source with a local file path.
 - `AUTOMOBILE_SKIP_ACCESSIBILITY_CHECKSUM`: Skip checksum validation (development mode).
 - `AUTO_MOBILE_ACCESSIBILITY_SERVICE_SHA_SKIP_CHECK` (deprecated): Legacy alias for skipping checksum validation.
-- `AUTOMOBILE_SKIP_ACCESSIBILITY_DOWNLOAD_IF_INSTALLED`: Skip version check if the service is already installed.
+- `AUTOMOBILE_SKIP_ACCESSIBILITY_DOWNLOAD_IF_INSTALLED`: Explicitly skip version check if the service is already installed.
 - `AUTOMOBILE_ACCESSIBILITY_TOGGLE_METHOD`: Not supported; settings-based toggling is the only automated path.
 
 See [GitHub Issue #483](https://github.com/kaeawc/auto-mobile/issues/483) for ongoing work to standardize environment variable naming.

--- a/src/daemon/socketServer.ts
+++ b/src/daemon/socketServer.ts
@@ -596,7 +596,7 @@ export class UnixSocketServer {
             allowDownloadWhenInstalled: true,
             bypassVersionCheckCache: true
           });
-          const successStatuses = new Set(["compatible", "upgraded", "installed", "reinstalled", "skipped"]);
+          const successStatuses = new Set(["compatible", "upgraded", "installed", "reinstalled"]);
           return {
             success: successStatuses.has(result.status),
             message: `Accessibility service ${result.status}${result.error ? `: ${result.error}` : ""}`,

--- a/src/daemon/socketServer.ts
+++ b/src/daemon/socketServer.ts
@@ -592,8 +592,11 @@ export class UnixSocketServer {
 
         if (args.platform === "android") {
           const manager = AndroidCtrlProxyManager.getInstance(targetDevice);
-          const result = await manager.ensureCompatibleVersion();
-          const successStatuses = new Set(["compatible", "upgraded", "installed", "reinstalled"]);
+          const result = await manager.ensureCompatibleVersion({
+            allowDownloadWhenInstalled: true,
+            bypassVersionCheckCache: true
+          });
+          const successStatuses = new Set(["compatible", "upgraded", "installed", "reinstalled", "skipped"]);
           return {
             success: successStatuses.has(result.status),
             message: `Accessibility service ${result.status}${result.error ? `: ${result.error}` : ""}`,

--- a/src/doctor/checks/automobile.ts
+++ b/src/doctor/checks/automobile.ts
@@ -137,7 +137,7 @@ export async function checkCtrlProxy(
     // Reset cached instances to ensure fresh ADB reads for doctor diagnostics
     // (getInstance memoizes isInstalled/isEnabled for 30 minutes which can report stale state)
     AndroidCtrlProxyManager.resetInstances();
-    const serviceManager = AndroidCtrlProxyManager.getInstance(device);
+    const serviceManager = AndroidCtrlProxyManager.getInstance(device, adbFactory);
 
     const versionResult = await serviceManager.ensureCompatibleVersion();
     const isInstalled = await serviceManager.isInstalled();
@@ -172,12 +172,25 @@ export async function checkCtrlProxy(
       diagnostics.push("downloadUnavailable=offline");
     }
 
+    if (versionResult.acceptedPreinstalled) {
+      diagnostics.push("acceptedPreinstalled=true");
+    }
+
     if (downloadUnavailable) {
       return {
         name: "CtrlProxy",
         status: "warn",
         message: diagnostics.join("; "),
         recommendation: "Newer CtrlProxy APK unavailable while offline. Connect to the internet and re-run doctor."
+      };
+    }
+
+    if (versionResult.acceptedPreinstalled && isInstalled && isEnabled) {
+      return {
+        name: "CtrlProxy",
+        status: "warn",
+        message: diagnostics.join("; "),
+        recommendation: "CtrlProxy is installed and enabled, but its APK SHA differs from the expected release. Re-run doctor after the background APK refresh completes or update CtrlProxy from the latest release."
       };
     }
 

--- a/src/utils/CtrlProxyManager.ts
+++ b/src/utils/CtrlProxyManager.ts
@@ -719,7 +719,16 @@ export class AndroidCtrlProxyManager implements CtrlProxyManager {
         return upgradeResult;
       }
 
-      logger.warn("[CTRL_PROXY] Completed prefetched APK install failed; accepting existing CtrlProxy for readiness", {
+      this.clearServiceAvailabilityCache();
+      const stillInstalled = await this.isInstalled();
+      if (!stillInstalled) {
+        logger.warn("[CTRL_PROXY] Completed prefetched APK install failed and existing CtrlProxy is no longer installed", {
+          error: upgradeResult.error || upgradeResult.upgradeError || upgradeResult.reinstallError
+        });
+        return upgradeResult;
+      }
+
+      logger.warn("[CTRL_PROXY] Completed prefetched APK install failed; verified existing CtrlProxy remains installed for readiness", {
         error: upgradeResult.error || upgradeResult.upgradeError || upgradeResult.reinstallError
       });
       return {
@@ -776,6 +785,7 @@ export class AndroidCtrlProxyManager implements CtrlProxyManager {
       };
     } catch (reinstallError) {
       const reinstallMessage = reinstallError instanceof Error ? reinstallError.message : String(reinstallError);
+      this.clearServiceAvailabilityCache();
       return {
         ...result,
         status: "failed",

--- a/src/utils/CtrlProxyManager.ts
+++ b/src/utils/CtrlProxyManager.ts
@@ -205,6 +205,7 @@ export class AndroidCtrlProxyManager implements CtrlProxyManager {
 
     logger.info("[CTRL_PROXY] Starting APK prefetch");
     const startTime = defaultTimer.now();
+    AndroidCtrlProxyManager.prefetchError = null;
 
     AndroidCtrlProxyManager.prefetchPromise = AndroidCtrlProxyManager.doPrefetch()
       .then(apkPath => {
@@ -221,6 +222,7 @@ export class AndroidCtrlProxyManager implements CtrlProxyManager {
         logger.warn(`[CTRL_PROXY] APK prefetch failed after ${duration}ms`, {
           error: AndroidCtrlProxyManager.prefetchError.message
         });
+        AndroidCtrlProxyManager.prefetchPromise = null;
         return null;
       });
   }
@@ -232,33 +234,36 @@ export class AndroidCtrlProxyManager implements CtrlProxyManager {
     const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "auto-mobile-prefetch-"));
     const apkPath = path.join(tempDir, "control-proxy.apk");
 
-    // Download the APK
-    logger.info("[CTRL_PROXY] Prefetch: downloading APK", { url: APK_URL, destination: apkPath });
-    await AndroidCtrlProxyManager.defaultFileDownloader.download(APK_URL, apkPath);
+    try {
+      // Download the APK
+      logger.info("[CTRL_PROXY] Prefetch: downloading APK", { url: APK_URL, destination: apkPath });
+      await AndroidCtrlProxyManager.defaultFileDownloader.download(APK_URL, apkPath);
 
-    // Verify the file exists and has reasonable size
-    const stats = await fs.stat(apkPath);
-    if (stats.size < 10000) {
-      throw new Error(`Prefetched APK is too small (${stats.size} bytes), likely invalid`);
-    }
-
-    // Verify APK integrity
-    AndroidCtrlProxyManager.verifyApkIntegrityStatic(apkPath);
-
-    // Verify checksum if provided
-    const expectedChecksum = AndroidCtrlProxyManager.expectedChecksumOverride ?? APK_SHA256_CHECKSUM;
-    if (expectedChecksum.length > 0) {
-      const { checksum: actualChecksum } = await AndroidCtrlProxyManager.defaultChecksumCalculator.computeFileSha256(apkPath);
-      if (actualChecksum.toLowerCase() !== expectedChecksum.toLowerCase()) {
-        // Clean up invalid file
-        await fs.rm(tempDir, { recursive: true, force: true }).catch(() => {});
-        throw new Error(`APK checksum verification failed. Expected: ${expectedChecksum}, Got: ${actualChecksum}`);
+      // Verify the file exists and has reasonable size
+      const stats = await fs.stat(apkPath);
+      if (stats.size < 10000) {
+        throw new Error(`Prefetched APK is too small (${stats.size} bytes), likely invalid`);
       }
-      logger.info("[CTRL_PROXY] Prefetch: checksum verified", { checksum: actualChecksum });
-    }
 
-    logger.info("[CTRL_PROXY] Prefetch: APK ready", { path: apkPath, size: stats.size });
-    return apkPath;
+      // Verify APK integrity
+      AndroidCtrlProxyManager.verifyApkIntegrityStatic(apkPath);
+
+      // Verify checksum if provided
+      const expectedChecksum = AndroidCtrlProxyManager.expectedChecksumOverride ?? APK_SHA256_CHECKSUM;
+      if (expectedChecksum.length > 0) {
+        const { checksum: actualChecksum } = await AndroidCtrlProxyManager.defaultChecksumCalculator.computeFileSha256(apkPath);
+        if (actualChecksum.toLowerCase() !== expectedChecksum.toLowerCase()) {
+          throw new Error(`APK checksum verification failed. Expected: ${expectedChecksum}, Got: ${actualChecksum}`);
+        }
+        logger.info("[CTRL_PROXY] Prefetch: checksum verified", { checksum: actualChecksum });
+      }
+
+      logger.info("[CTRL_PROXY] Prefetch: APK ready", { path: apkPath, size: stats.size });
+      return apkPath;
+    } catch (error) {
+      await fs.rm(tempDir, { recursive: true, force: true }).catch(() => {});
+      throw error;
+    }
   }
 
   /**

--- a/src/utils/CtrlProxyManager.ts
+++ b/src/utils/CtrlProxyManager.ts
@@ -33,7 +33,7 @@ export interface CtrlProxyManager extends ProxyManager {
   isEnabledForUser(userId: number): Promise<boolean>;
   getInstalledApkSha256(): Promise<string | null>;
   isVersionCompatible(): Promise<boolean>;
-  ensureCompatibleVersion(): Promise<AccessibilityVersionCheckResult>;
+  ensureCompatibleVersion(options?: AccessibilityVersionCheckOptions): Promise<AccessibilityVersionCheckResult>;
   downloadApk(): Promise<string>;
   install(apkPath: string): Promise<void>;
   enable(): Promise<void>;
@@ -54,6 +54,11 @@ interface AccessibilityVersionCheckResult {
   error?: string;
   upgradeError?: string;
   reinstallError?: string;
+}
+
+interface AccessibilityVersionCheckOptions {
+  allowDownloadWhenInstalled?: boolean;
+  bypassVersionCheckCache?: boolean;
 }
 
 interface ToggleCapabilities {
@@ -82,6 +87,8 @@ export class AndroidCtrlProxyManager implements CtrlProxyManager {
   // Static cache for service availability
   private cachedAvailability: { isAvailable: boolean; timestamp: number } | null = null;
   private static readonly AVAILABILITY_CACHE_TTL = 60 * 60 * 1000; // 1 hour
+  private cachedVersionCheck: { result: AccessibilityVersionCheckResult; timestamp: number } | null = null;
+  private static readonly VERSION_CHECK_CACHE_TTL = 60 * 1000; // 1 minute
 
   // Static caches for individual status checks
   private cachedInstallation: { isInstalled: boolean; timestamp: number } | null = null;
@@ -156,6 +163,17 @@ export class AndroidCtrlProxyManager implements CtrlProxyManager {
       ));
     }
     return AndroidCtrlProxyManager.instances.get(device.deviceId)!;
+  }
+
+  public static createForTestingWithDeps(
+    device: BootedDevice,
+    adb: AdbExecutor,
+    timer: Timer = defaultTimer,
+    fileDownloader: FileDownloader = AndroidCtrlProxyManager.defaultFileDownloader,
+    checksumCalculator: ChecksumCalculator = AndroidCtrlProxyManager.defaultChecksumCalculator
+  ): AndroidCtrlProxyManager {
+    requireBootedDevice(device, "AndroidCtrlProxyManager.createForTestingWithDeps");
+    return new AndroidCtrlProxyManager(device, adb, timer, fileDownloader, checksumCalculator);
   }
 
   /**
@@ -343,6 +361,7 @@ export class AndroidCtrlProxyManager implements CtrlProxyManager {
     this.cachedInstallation = null;
     this.cachedEnabled = null;
     this.cachedToggleCapabilities = null;
+    this.cachedVersionCheck = null;
     logger.info("[CTRL_PROXY] Cleared all availability caches");
   }
 
@@ -520,19 +539,27 @@ export class AndroidCtrlProxyManager implements CtrlProxyManager {
   /**
    * Ensure installed accessibility service version matches expected checksum.
    */
-  async ensureCompatibleVersion(): Promise<AccessibilityVersionCheckResult> {
+  async ensureCompatibleVersion(options: AccessibilityVersionCheckOptions = {}): Promise<AccessibilityVersionCheckResult> {
     const perf = createGlobalPerformanceTracker();
-    this.clearAvailabilityCache();
+
+    if (!options.bypassVersionCheckCache && !options.allowDownloadWhenInstalled) {
+      const cachedResult = this.getCachedVersionCheckResult();
+      if (cachedResult) {
+        return cachedResult;
+      }
+    }
+
+    this.clearServiceAvailabilityCache();
     perf.startOperation("uninstallLegacy");
     await this.uninstallLegacyPackageIfPresent();
     perf.endOperation("uninstallLegacy");
 
     const expectedSha = this.getExpectedChecksum();
     if (expectedSha.length === 0) {
-      return {
+      return this.cacheVersionCheckResult({
         status: "skipped",
         expectedSha256: expectedSha
-      };
+      });
     }
 
     perf.startOperation("checkInstalled");
@@ -541,10 +568,10 @@ export class AndroidCtrlProxyManager implements CtrlProxyManager {
 
     if (isInstalled && this.shouldSkipDownloadIfInstalled()) {
       logger.warn("[CTRL_PROXY] Skipping APK download/version check (preinstalled APK allowed)");
-      return {
+      return this.cacheVersionCheckResult({
         status: "skipped",
         expectedSha256: expectedSha
-      };
+      });
     }
 
     const result: AccessibilityVersionCheckResult = {
@@ -572,7 +599,20 @@ export class AndroidCtrlProxyManager implements CtrlProxyManager {
       }
 
       if (installedSha && installedSha.toLowerCase() === expectedSha.toLowerCase()) {
-        return result;
+        return this.cacheVersionCheckResult(result);
+      }
+
+      if (!options.allowDownloadWhenInstalled && !this.getApkPathOverride()) {
+        logger.warn("[CTRL_PROXY] Installed APK SHA differs from expected release; accepting preinstalled CtrlProxy for nonblocking readiness", {
+          expected: expectedSha,
+          actual: installedSha
+        });
+        this.queueBackgroundApkRefresh();
+        return this.cacheVersionCheckResult({
+          ...result,
+          status: "skipped",
+          attemptedDownload: false
+        });
       }
 
       if (needsReinstallDueToUnknownSha) {
@@ -640,7 +680,7 @@ export class AndroidCtrlProxyManager implements CtrlProxyManager {
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
       const downloadUnavailable = this.isNetworkError(message);
-      return {
+      const failedResult: AccessibilityVersionCheckResult = {
         ...result,
         status: "failed",
         downloadUnavailable,
@@ -648,6 +688,9 @@ export class AndroidCtrlProxyManager implements CtrlProxyManager {
           ? "Unable to download the latest accessibility service APK while offline. Connect to the internet and retry."
           : message
       };
+      return options.allowDownloadWhenInstalled
+        ? failedResult
+        : this.cacheVersionCheckResult(failedResult);
     } finally {
       if (apkPath) {
         await this.cleanupApk(apkPath);
@@ -1352,6 +1395,42 @@ export class AndroidCtrlProxyManager implements CtrlProxyManager {
       return "";
     }
     return AndroidCtrlProxyManager.expectedChecksumOverride ?? resolveChecksum(RELEASE_VERSION, "android");
+  }
+
+  private getCachedVersionCheckResult(): AccessibilityVersionCheckResult | null {
+    if (!this.cachedVersionCheck) {
+      return null;
+    }
+
+    const cacheAge = this.timer.now() - this.cachedVersionCheck.timestamp;
+    if (cacheAge >= AndroidCtrlProxyManager.VERSION_CHECK_CACHE_TTL) {
+      this.cachedVersionCheck = null;
+      return null;
+    }
+
+    logger.debug(`[CTRL_PROXY] Using cached version check result (age: ${cacheAge}ms): ${this.cachedVersionCheck.result.status}`);
+    return { ...this.cachedVersionCheck.result };
+  }
+
+  private cacheVersionCheckResult(result: AccessibilityVersionCheckResult): AccessibilityVersionCheckResult {
+    this.cachedVersionCheck = {
+      result: { ...result },
+      timestamp: this.timer.now()
+    };
+    return result;
+  }
+
+  private clearServiceAvailabilityCache(): void {
+    this.cachedAvailability = null;
+    this.cachedInstallation = null;
+    this.cachedEnabled = null;
+  }
+
+  private queueBackgroundApkRefresh(): void {
+    if (this.fileDownloader !== AndroidCtrlProxyManager.defaultFileDownloader) {
+      return;
+    }
+    AndroidCtrlProxyManager.prefetchApk();
   }
 
   private isNetworkError(message: string): boolean {

--- a/src/utils/CtrlProxyManager.ts
+++ b/src/utils/CtrlProxyManager.ts
@@ -51,6 +51,7 @@ interface AccessibilityVersionCheckResult {
   attemptedInstall?: boolean;
   attemptedReinstall?: boolean;
   downloadUnavailable?: boolean;
+  acceptedPreinstalled?: boolean;
   error?: string;
   upgradeError?: string;
   reinstallError?: string;
@@ -299,6 +300,31 @@ export class AndroidCtrlProxyManager implements CtrlProxyManager {
       return true;
     } catch (error) {
       logger.warn("[CTRL_PROXY] Failed to copy prefetched APK", {
+        error: error instanceof Error ? error.message : String(error)
+      });
+      return false;
+    }
+  }
+
+  /**
+   * Consume only an already-completed prefetch. Unlike consumePrefetchedApk(),
+   * this never waits for an in-progress network download.
+   */
+  private static async consumeCompletedPrefetchedApk(destinationPath: string): Promise<boolean> {
+    if (!AndroidCtrlProxyManager.prefetchedApkPath) {
+      return false;
+    }
+
+    try {
+      await fs.mkdir(path.dirname(destinationPath), { recursive: true });
+      await fs.copyFile(AndroidCtrlProxyManager.prefetchedApkPath, destinationPath);
+      logger.info("[CTRL_PROXY] Copied completed prefetched APK", {
+        source: AndroidCtrlProxyManager.prefetchedApkPath,
+        destination: destinationPath
+      });
+      return true;
+    } catch (error) {
+      logger.warn("[CTRL_PROXY] Failed to copy completed prefetched APK", {
         error: error instanceof Error ? error.message : String(error)
       });
       return false;
@@ -556,21 +582,26 @@ export class AndroidCtrlProxyManager implements CtrlProxyManager {
 
     const expectedSha = this.getExpectedChecksum();
     if (expectedSha.length === 0) {
-      return this.cacheVersionCheckResult({
-        status: "skipped",
-        expectedSha256: expectedSha
-      });
+      if (options.allowDownloadWhenInstalled) {
+        logger.warn("[CTRL_PROXY] Version checksum unavailable; explicit update will install APK without checksum comparison");
+      } else {
+        return this.cacheVersionCheckResult({
+          status: "skipped",
+          expectedSha256: expectedSha
+        });
+      }
     }
 
     perf.startOperation("checkInstalled");
     const isInstalled = await this.isInstalled();
     perf.endOperation("checkInstalled");
 
-    if (isInstalled && this.shouldSkipDownloadIfInstalled()) {
+    if (isInstalled && this.shouldSkipDownloadIfInstalled() && !options.allowDownloadWhenInstalled) {
       logger.warn("[CTRL_PROXY] Skipping APK download/version check (preinstalled APK allowed)");
       return this.cacheVersionCheckResult({
         status: "skipped",
-        expectedSha256: expectedSha
+        expectedSha256: expectedSha,
+        acceptedPreinstalled: true
       });
     }
 
@@ -590,19 +621,24 @@ export class AndroidCtrlProxyManager implements CtrlProxyManager {
       result.installedApkPath = installedShaResult.apkPath;
 
       const installedSha = installedShaResult.sha256;
-      needsReinstallDueToUnknownSha = !installedSha;
+      needsReinstallDueToUnknownSha = expectedSha.length > 0 && !installedSha;
 
-      if (!installedSha && installedShaResult.error) {
+      if (expectedSha.length > 0 && !installedSha && installedShaResult.error) {
         logger.warn("[CTRL_PROXY] Unable to determine installed APK checksum, forcing reinstall", {
           error: installedShaResult.error
         });
       }
 
-      if (installedSha && installedSha.toLowerCase() === expectedSha.toLowerCase()) {
+      if (expectedSha.length > 0 && installedSha && installedSha.toLowerCase() === expectedSha.toLowerCase()) {
         return this.cacheVersionCheckResult(result);
       }
 
-      if (!options.allowDownloadWhenInstalled && !this.getApkPathOverride()) {
+      if (expectedSha.length > 0 && !options.allowDownloadWhenInstalled && !this.getApkPathOverride()) {
+        const prefetchedUpgradeResult = await this.tryUpgradeFromCompletedPrefetch(result, perf);
+        if (prefetchedUpgradeResult) {
+          return this.cacheVersionCheckResult(prefetchedUpgradeResult);
+        }
+
         logger.warn("[CTRL_PROXY] Installed APK SHA differs from expected release; accepting preinstalled CtrlProxy for nonblocking readiness", {
           expected: expectedSha,
           actual: installedSha
@@ -611,7 +647,8 @@ export class AndroidCtrlProxyManager implements CtrlProxyManager {
         return this.cacheVersionCheckResult({
           ...result,
           status: "skipped",
-          attemptedDownload: false
+          attemptedDownload: false,
+          acceptedPreinstalled: true
         });
       }
 
@@ -634,49 +671,7 @@ export class AndroidCtrlProxyManager implements CtrlProxyManager {
       apkPath = await this.downloadApk();
       perf.endOperation("downloadApk");
 
-      if (isInstalled && !needsReinstallDueToUnknownSha) {
-        try {
-          result.attemptedInstall = true;
-          perf.startOperation("installApk");
-          await this.adb.executeCommand(`install -r -d "${apkPath}"`);
-          perf.endOperation("installApk");
-          logger.info("[CTRL_PROXY] APK upgraded successfully");
-          this.clearAvailabilityCache();
-          return {
-            ...result,
-            status: "upgraded"
-          };
-        } catch (upgradeError) {
-          perf.endOperation("installApk");
-          const upgradeMessage = upgradeError instanceof Error ? upgradeError.message : String(upgradeError);
-          logger.warn("[CTRL_PROXY] Upgrade failed, attempting reinstall", { error: upgradeMessage });
-          result.upgradeError = upgradeMessage;
-        }
-      }
-
-      try {
-        result.attemptedReinstall = true;
-        if (isInstalled) {
-          await this.adb.executeCommand(`shell pm uninstall ${AndroidCtrlProxyManager.PACKAGE}`);
-        }
-        perf.startOperation("installApk");
-        await this.install(apkPath);
-        perf.endOperation("installApk");
-        await this.enable();
-        logger.info(`[CTRL_PROXY] APK ${isInstalled ? "reinstalled" : "installed"} and service enabled`);
-        this.clearAvailabilityCache();
-        return {
-          ...result,
-          status: isInstalled ? "reinstalled" : "installed"
-        };
-      } catch (reinstallError) {
-        const reinstallMessage = reinstallError instanceof Error ? reinstallError.message : String(reinstallError);
-        return {
-          ...result,
-          status: "failed",
-          reinstallError: reinstallMessage
-        };
-      }
+      return await this.installDownloadedApk(apkPath, result, isInstalled, needsReinstallDueToUnknownSha, perf);
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
       const downloadUnavailable = this.isNetworkError(message);
@@ -695,6 +690,97 @@ export class AndroidCtrlProxyManager implements CtrlProxyManager {
       if (apkPath) {
         await this.cleanupApk(apkPath);
       }
+    }
+  }
+
+  private async tryUpgradeFromCompletedPrefetch(
+    result: AccessibilityVersionCheckResult,
+    perf: PerformanceTracker
+  ): Promise<AccessibilityVersionCheckResult | null> {
+    if (!AndroidCtrlProxyManager.prefetchedApkPath) {
+      return null;
+    }
+
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "auto-mobile-prefetch-upgrade-"));
+    const apkPath = path.join(tempDir, "control-proxy.apk");
+
+    try {
+      const usedPrefetch = await AndroidCtrlProxyManager.consumeCompletedPrefetchedApk(apkPath);
+      if (!usedPrefetch) {
+        return null;
+      }
+
+      const upgradeResult = await this.installDownloadedApk(apkPath, {
+        ...result,
+        attemptedDownload: false
+      }, true, false, perf);
+
+      if (upgradeResult.status !== "failed") {
+        return upgradeResult;
+      }
+
+      logger.warn("[CTRL_PROXY] Completed prefetched APK install failed; accepting existing CtrlProxy for readiness", {
+        error: upgradeResult.error || upgradeResult.upgradeError || upgradeResult.reinstallError
+      });
+      return {
+        ...upgradeResult,
+        status: "skipped",
+        acceptedPreinstalled: true
+      };
+    } finally {
+      await this.cleanupApk(apkPath);
+    }
+  }
+
+  private async installDownloadedApk(
+    apkPath: string,
+    result: AccessibilityVersionCheckResult,
+    isInstalled: boolean,
+    needsReinstallDueToUnknownSha: boolean,
+    perf: PerformanceTracker
+  ): Promise<AccessibilityVersionCheckResult> {
+    if (isInstalled && !needsReinstallDueToUnknownSha) {
+      try {
+        result.attemptedInstall = true;
+        perf.startOperation("installApk");
+        await this.adb.executeCommand(`install -r -d "${apkPath}"`);
+        perf.endOperation("installApk");
+        logger.info("[CTRL_PROXY] APK upgraded successfully");
+        this.clearAvailabilityCache();
+        return {
+          ...result,
+          status: "upgraded"
+        };
+      } catch (upgradeError) {
+        perf.endOperation("installApk");
+        const upgradeMessage = upgradeError instanceof Error ? upgradeError.message : String(upgradeError);
+        logger.warn("[CTRL_PROXY] Upgrade failed, attempting reinstall", { error: upgradeMessage });
+        result.upgradeError = upgradeMessage;
+      }
+    }
+
+    try {
+      result.attemptedReinstall = true;
+      if (isInstalled) {
+        await this.adb.executeCommand(`shell pm uninstall ${AndroidCtrlProxyManager.PACKAGE}`);
+      }
+      perf.startOperation("installApk");
+      await this.install(apkPath);
+      perf.endOperation("installApk");
+      await this.enable();
+      logger.info(`[CTRL_PROXY] APK ${isInstalled ? "reinstalled" : "installed"} and service enabled`);
+      this.clearAvailabilityCache();
+      return {
+        ...result,
+        status: isInstalled ? "reinstalled" : "installed"
+      };
+    } catch (reinstallError) {
+      const reinstallMessage = reinstallError instanceof Error ? reinstallError.message : String(reinstallError);
+      return {
+        ...result,
+        status: "failed",
+        reinstallError: reinstallMessage
+      };
     }
   }
 

--- a/test/daemon/socketServerIdeStatus.test.ts
+++ b/test/daemon/socketServerIdeStatus.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, spyOn, test } from "bun:test";
 import { Socket } from "node:net";
 import { randomUUID } from "node:crypto";
 import { existsSync } from "node:fs";
@@ -8,6 +8,9 @@ import { join } from "node:path";
 import { UnixSocketServer } from "../../src/daemon/socketServer";
 import { FakeTimer } from "../fakes/FakeTimer";
 import type { DaemonResponse } from "../../src/daemon/types";
+import { AndroidCtrlProxyManager } from "../../src/utils/CtrlProxyManager";
+import { PlatformDeviceManagerFactory } from "../../src/utils/factories/PlatformDeviceManagerFactory";
+import type { BootedDevice } from "../../src/models";
 
 function createFakeDaemonState() {
   return {
@@ -133,5 +136,40 @@ describe("UnixSocketServer ide/status and ide/updateService handlers", () => {
 
     expect(response.success).toBe(false);
     expect(response.error).toContain("Invalid platform");
+  });
+
+  test("ide/updateService does not report skipped Android update as success", async () => {
+    const device: BootedDevice = {
+      deviceId: "emulator-5554",
+      platform: "android",
+      isEmulator: true,
+      name: "Pixel"
+    };
+    const platformSpy = spyOn(PlatformDeviceManagerFactory, "getInstance").mockReturnValue({
+      getBootedDevices: async () => [device]
+    } as any);
+    const ctrlProxySpy = spyOn(AndroidCtrlProxyManager, "getInstance").mockReturnValue({
+      ensureCompatibleVersion: async () => ({
+        status: "skipped",
+        expectedSha256: "",
+        acceptedPreinstalled: true
+      })
+    } as any);
+
+    try {
+      const response = await sendRequest(socketPath, "ide/updateService", {
+        deviceId: "emulator-5554",
+        platform: "android",
+      });
+
+      expect(response.success).toBe(true);
+      const result = response.result as { success: boolean; message: string; status: { status: string } };
+      expect(result.success).toBe(false);
+      expect(result.message).toContain("Accessibility service skipped");
+      expect(result.status.status).toBe("skipped");
+    } finally {
+      ctrlProxySpy.mockRestore();
+      platformSpy.mockRestore();
+    }
   });
 });

--- a/test/doctor/automobile.test.ts
+++ b/test/doctor/automobile.test.ts
@@ -1,4 +1,4 @@
-import { describe, test, expect, beforeEach } from "bun:test";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import {
   checkCtrlProxy,
   checkCtrlProxyVersion,
@@ -12,6 +12,7 @@ import {
 import { getMcpServerVersion } from "../../src/utils/mcpVersion";
 import { FakeAdbExecutor } from "../fakes/FakeAdbExecutor";
 import type { AdbClientFactory } from "../../src/utils/android-cmdline-tools/AdbClientFactory";
+import { AndroidCtrlProxyManager } from "../../src/utils/CtrlProxyManager";
 
 describe("checkDaemonVersion", () => {
   test("returns pass status", () => {
@@ -49,10 +50,17 @@ describe("checkCtrlProxy", () => {
   let fakeFactory: AdbClientFactory;
 
   beforeEach(() => {
+    AndroidCtrlProxyManager.resetInstances();
+    AndroidCtrlProxyManager.setExpectedChecksumForTesting(null);
     fakeAdb = new FakeAdbExecutor();
     fakeFactory = {
       create: () => fakeAdb,
     };
+  });
+
+  afterEach(async () => {
+    AndroidCtrlProxyManager.setExpectedChecksumForTesting(null);
+    await AndroidCtrlProxyManager.cleanupPrefetchedApk();
   });
 
   test("returns skip when no devices connected", async () => {
@@ -63,5 +71,49 @@ describe("checkCtrlProxy", () => {
     expect(result.name).toBe("CtrlProxy");
     expect(result.status).toBe("skip");
     expect(result.message).toBe("No Android devices connected");
+  });
+
+  test("warns when installed and enabled CtrlProxy is stale but accepted for readiness", async () => {
+    AndroidCtrlProxyManager.setExpectedChecksumForTesting("expected-sha");
+    const originalDefaultDownloader = (AndroidCtrlProxyManager as any).defaultFileDownloader;
+    (AndroidCtrlProxyManager as any).defaultFileDownloader = {
+      download: async () => {
+        throw new Error("network is unreachable");
+      }
+    };
+
+    try {
+      fakeAdb.setDevices([{
+        deviceId: "emulator-5554",
+        platform: "android",
+        isEmulator: true,
+        name: "Pixel"
+      }]);
+      fakeAdb.setCommandResponse(`shell pm list packages | grep ${AndroidCtrlProxyManager.PACKAGE}`, {
+        stdout: `package:${AndroidCtrlProxyManager.PACKAGE}\n`,
+        stderr: ""
+      });
+      fakeAdb.setCommandResponse(`shell pm path ${AndroidCtrlProxyManager.PACKAGE}`, {
+        stdout: "package:/data/app/dev.jasonpearson.automobile.ctrlproxy/base.apk\n",
+        stderr: ""
+      });
+      fakeAdb.setCommandResponse("shell sha256sum", {
+        stdout: "different-sha /data/app/dev.jasonpearson.automobile.ctrlproxy/base.apk\n",
+        stderr: ""
+      });
+      fakeAdb.setCommandResponse("settings get secure", {
+        stdout: `${AndroidCtrlProxyManager.PACKAGE}/${AndroidCtrlProxyManager.PACKAGE}.CtrlProxy`,
+        stderr: ""
+      });
+
+      const result = await checkCtrlProxy(fakeFactory);
+
+      expect(result.status).toBe("warn");
+      expect(result.message).toContain("versionStatus=skipped");
+      expect(result.message).toContain("acceptedPreinstalled=true");
+      expect(result.recommendation).toBe("CtrlProxy is installed and enabled, but its APK SHA differs from the expected release. Re-run doctor after the background APK refresh completes or update CtrlProxy from the latest release.");
+    } finally {
+      (AndroidCtrlProxyManager as any).defaultFileDownloader = originalDefaultDownloader;
+    }
   });
 });

--- a/test/fakes/FakeCtrlProxyManager.ts
+++ b/test/fakes/FakeCtrlProxyManager.ts
@@ -182,7 +182,10 @@ export class FakeCtrlProxyManager implements CtrlProxyManager {
     return this.versionCompatible;
   }
 
-  async ensureCompatibleVersion(): Promise<{
+  async ensureCompatibleVersion(_options?: {
+    allowDownloadWhenInstalled?: boolean;
+    bypassVersionCheckCache?: boolean;
+  }): Promise<{
     status: "skipped" | "not_installed" | "compatible" | "upgraded" | "installed" | "reinstalled" | "failed";
     expectedSha256?: string;
     installedSha256?: string | null;

--- a/test/utils/CtrlProxyManager.test.ts
+++ b/test/utils/CtrlProxyManager.test.ts
@@ -477,6 +477,44 @@ describe("CtrlProxyManager", function() {
       expect(localFakeAdb.wasCommandExecuted(`shell pm uninstall ${AndroidCtrlProxyManager.PACKAGE}`)).toBe(true);
     });
 
+    test("should allow background refresh to retry failed prefetches", async function() {
+      AndroidCtrlProxyManager.setExpectedChecksumForTesting("");
+      const zip = new AdmZip();
+      zip.addFile("AndroidManifest.xml", Buffer.from('<?xml version="1.0" encoding="utf-8"?><manifest></manifest>', "utf8"));
+      zip.addFile("classes.dex", crypto.randomBytes(15000));
+      const payload = zip.toBuffer();
+      const originalDefaultDownloader = (AndroidCtrlProxyManager as any).defaultFileDownloader;
+      let downloadCalls = 0;
+      let failedDestination: string | null = null;
+
+      try {
+        (AndroidCtrlProxyManager as any).defaultFileDownloader = {
+          download: async (_url: string, destination: string) => {
+            downloadCalls++;
+            if (downloadCalls === 1) {
+              failedDestination = destination;
+              throw new Error("network is unreachable");
+            }
+            await fs.mkdir(path.dirname(destination), { recursive: true });
+            await fs.writeFile(destination, payload);
+          }
+        };
+
+        AndroidCtrlProxyManager.prefetchApk();
+        expect(await AndroidCtrlProxyManager.getPrefetchedApkPath()).toBeNull();
+        expect(failedDestination).not.toBeNull();
+        await expect(fs.stat(path.dirname(failedDestination!))).rejects.toThrow();
+
+        AndroidCtrlProxyManager.prefetchApk();
+        const retriedPath = await AndroidCtrlProxyManager.getPrefetchedApkPath();
+
+        expect(downloadCalls).toBe(2);
+        expect(retriedPath).not.toBeNull();
+      } finally {
+        (AndroidCtrlProxyManager as any).defaultFileDownloader = originalDefaultDownloader;
+      }
+    });
+
     test("should cache failed download result briefly instead of retrying every call", async function() {
       AndroidCtrlProxyManager.setExpectedChecksumForTesting("expected-sha");
       const fakeTimer = new FakeTimer();

--- a/test/utils/CtrlProxyManager.test.ts
+++ b/test/utils/CtrlProxyManager.test.ts
@@ -429,6 +429,54 @@ describe("CtrlProxyManager", function() {
       expect(localFakeAdb.wasCommandExecuted("install -r -d")).toBe(true);
     });
 
+    test("should keep completed prefetch install failure failed after fallback uninstall removes service", async function() {
+      AndroidCtrlProxyManager.setExpectedChecksumForTesting("expected-sha");
+      const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "auto-mobile-prefetch-source-"));
+      const prefetchedApkPath = path.join(tempDir, "control-proxy.apk");
+      await fs.writeFile(prefetchedApkPath, Buffer.from("prefetched-apk"));
+      (AndroidCtrlProxyManager as any).prefetchedApkPath = prefetchedApkPath;
+
+      const packageCheckCommand = `shell pm list packages | grep ${AndroidCtrlProxyManager.PACKAGE}`;
+      const localFakeAdb = new FakeAdbExecutor();
+      localFakeAdb.setCommandResponseSequence(packageCheckCommand, [
+        createExecResult(`package:${AndroidCtrlProxyManager.PACKAGE}\n`, ""),
+        createExecResult("", "")
+      ]);
+      localFakeAdb.setCommandResponse(`shell pm path ${AndroidCtrlProxyManager.PACKAGE}`, {
+        stdout: "package:/data/app/dev.jasonpearson.automobile.ctrlproxy/base.apk\n",
+        stderr: ""
+      });
+      localFakeAdb.setCommandResponse("shell sha256sum", {
+        stdout: "different-sha /data/app/dev.jasonpearson.automobile.ctrlproxy/base.apk\n",
+        stderr: ""
+      });
+      localFakeAdb.setCommandError("install -r -d", new Error("INSTALL_FAILED_UPDATE_INCOMPATIBLE"));
+      localFakeAdb.setCommandResponse(`shell pm uninstall ${AndroidCtrlProxyManager.PACKAGE}`, createExecResult("Success", ""));
+      localFakeAdb.setCommandError("install \"", new Error("INSTALL_FAILED_ABORTED"));
+
+      const manager = AndroidCtrlProxyManager.createForTestingWithDeps(
+        testDevice,
+        localFakeAdb,
+        new FakeTimer(),
+        {
+          download: async () => {
+            throw new Error("download should not be called for completed prefetch");
+          }
+        }
+      );
+
+      const result = await manager.ensureCompatibleVersion();
+      const packageCheckCalls = localFakeAdb.getExecutedCommands()
+        .filter(command => command.includes(packageCheckCommand));
+
+      expect(result.status).toBe("failed");
+      expect(result.acceptedPreinstalled).toBeUndefined();
+      expect(result.attemptedInstall).toBe(true);
+      expect(result.attemptedReinstall).toBe(true);
+      expect(packageCheckCalls.length).toBe(2);
+      expect(localFakeAdb.wasCommandExecuted(`shell pm uninstall ${AndroidCtrlProxyManager.PACKAGE}`)).toBe(true);
+    });
+
     test("should cache failed download result briefly instead of retrying every call", async function() {
       AndroidCtrlProxyManager.setExpectedChecksumForTesting("expected-sha");
       const fakeTimer = new FakeTimer();

--- a/test/utils/CtrlProxyManager.test.ts
+++ b/test/utils/CtrlProxyManager.test.ts
@@ -50,9 +50,10 @@ describe("CtrlProxyManager", function() {
     accessibilityServiceClient.clearAvailabilityCache();
   });
 
-  afterEach(function() {
+  afterEach(async function() {
     AndroidCtrlProxyManager.setExpectedChecksumForTesting(null);
     AndroidCtrlProxyManager.setAccessibilityDetectorForTesting(null);
+    await AndroidCtrlProxyManager.cleanupPrefetchedApk();
     if (originalApkPathEnv === undefined) {
       delete process.env.AUTOMOBILE_CTRL_PROXY_APK_PATH;
     } else {
@@ -346,6 +347,85 @@ describe("CtrlProxyManager", function() {
 
       const result = await manager.ensureCompatibleVersion({ allowDownloadWhenInstalled: true });
       expect(result.status).toBe("upgraded");
+      expect(localFakeAdb.wasCommandExecuted("install -r -d")).toBe(true);
+    });
+
+    test("should install local APK override when explicit update is requested", async function() {
+      const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "auto-mobile-local-update-"));
+      const localApkPath = path.join(tempDir, "control-proxy-debug.apk");
+      const zip = new AdmZip();
+      zip.addFile("AndroidManifest.xml", Buffer.from('<?xml version="1.0" encoding="utf-8"?><manifest></manifest>', "utf8"));
+      zip.addFile("classes.dex", crypto.randomBytes(15000));
+      zip.writeZip(localApkPath);
+
+      process.env.AUTOMOBILE_CTRL_PROXY_APK_PATH = localApkPath;
+      process.env.AUTOMOBILE_SKIP_ACCESSIBILITY_CHECKSUM = "true";
+
+      const localFakeAdb = new FakeAdbExecutor();
+      localFakeAdb.setCommandResponse(`shell pm list packages | grep ${AndroidCtrlProxyManager.PACKAGE}`, {
+        stdout: `package:${AndroidCtrlProxyManager.PACKAGE}\n`,
+        stderr: ""
+      });
+      localFakeAdb.setCommandResponse(`shell pm path ${AndroidCtrlProxyManager.PACKAGE}`, {
+        stdout: "package:/data/app/dev.jasonpearson.automobile.ctrlproxy/base.apk\n",
+        stderr: ""
+      });
+      localFakeAdb.setCommandResponse("shell sha256sum", {
+        stdout: "local-dev-sha /data/app/dev.jasonpearson.automobile.ctrlproxy/base.apk\n",
+        stderr: ""
+      });
+      localFakeAdb.setCommandResponse("install -r -d", createExecResult("Success", ""));
+
+      AndroidCtrlProxyManager.resetInstances();
+      const manager = AndroidCtrlProxyManager.getInstance(testDevice, { create: () => localFakeAdb });
+
+      const result = await manager.ensureCompatibleVersion({ allowDownloadWhenInstalled: true });
+      expect(result.status).toBe("upgraded");
+      expect(localFakeAdb.wasCommandExecuted("install -r -d")).toBe(true);
+
+      await fs.rm(tempDir, { recursive: true, force: true });
+    });
+
+    test("should install completed background prefetch on later readiness check without downloading", async function() {
+      AndroidCtrlProxyManager.setExpectedChecksumForTesting("expected-sha");
+      const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "auto-mobile-prefetch-source-"));
+      const prefetchedApkPath = path.join(tempDir, "control-proxy.apk");
+      await fs.writeFile(prefetchedApkPath, Buffer.from("prefetched-apk"));
+      (AndroidCtrlProxyManager as any).prefetchedApkPath = prefetchedApkPath;
+
+      const localFakeAdb = new FakeAdbExecutor();
+      localFakeAdb.setCommandResponse(`shell pm list packages | grep ${AndroidCtrlProxyManager.PACKAGE}`, {
+        stdout: `package:${AndroidCtrlProxyManager.PACKAGE}\n`,
+        stderr: ""
+      });
+      localFakeAdb.setCommandResponse(`shell pm path ${AndroidCtrlProxyManager.PACKAGE}`, {
+        stdout: "package:/data/app/dev.jasonpearson.automobile.ctrlproxy/base.apk\n",
+        stderr: ""
+      });
+      localFakeAdb.setCommandResponse("shell sha256sum", {
+        stdout: "different-sha /data/app/dev.jasonpearson.automobile.ctrlproxy/base.apk\n",
+        stderr: ""
+      });
+      localFakeAdb.setCommandResponse("install -r -d", createExecResult("Success", ""));
+
+      let downloadCalls = 0;
+      const manager = AndroidCtrlProxyManager.createForTestingWithDeps(
+        testDevice,
+        localFakeAdb,
+        new FakeTimer(),
+        {
+          download: async () => {
+            downloadCalls++;
+            throw new Error("download should not be called for completed prefetch");
+          }
+        }
+      );
+
+      const result = await manager.ensureCompatibleVersion();
+      expect(result.status).toBe("upgraded");
+      expect(result.attemptedDownload).toBe(false);
+      expect(result.attemptedInstall).toBe(true);
+      expect(downloadCalls).toBe(0);
       expect(localFakeAdb.wasCommandExecuted("install -r -d")).toBe(true);
     });
 

--- a/test/utils/CtrlProxyManager.test.ts
+++ b/test/utils/CtrlProxyManager.test.ts
@@ -11,6 +11,7 @@ import os from "os";
 import AdmZip from "adm-zip";
 
 import { FakeAccessibilityDetector } from "../fakes/FakeAccessibilityDetector";
+import { FakeTimer } from "../fakes/FakeTimer";
 import { DAEMON_LAUNCH_CWD_ENV } from "../../src/utils/workingDirectory";
 
 describe("CtrlProxyManager", function() {
@@ -283,7 +284,45 @@ describe("CtrlProxyManager", function() {
       expect(localFakeAdb.wasCommandExecuted("install -r -d")).toBe(false);
     });
 
-    test("should upgrade when installed SHA mismatches expected", async function() {
+    test("should accept preinstalled APK when installed SHA mismatches expected by default", async function() {
+      AndroidCtrlProxyManager.setExpectedChecksumForTesting("expected-sha");
+      const localFakeAdb = new FakeAdbExecutor();
+      localFakeAdb.setCommandResponse(`shell pm list packages | grep ${AndroidCtrlProxyManager.PACKAGE}`, {
+        stdout: `package:${AndroidCtrlProxyManager.PACKAGE}\n`,
+        stderr: ""
+      });
+      localFakeAdb.setCommandResponse(`shell pm path ${AndroidCtrlProxyManager.PACKAGE}`, {
+        stdout: "package:/data/app/dev.jasonpearson.automobile.ctrlproxy/base.apk\n",
+        stderr: ""
+      });
+      localFakeAdb.setCommandResponse("shell sha256sum", {
+        stdout: "different-sha /data/app/dev.jasonpearson.automobile.ctrlproxy/base.apk\n",
+        stderr: ""
+      });
+
+      let downloadCalls = 0;
+      AndroidCtrlProxyManager.resetInstances();
+      const manager = AndroidCtrlProxyManager.createForTestingWithDeps(
+        testDevice,
+        localFakeAdb,
+        new FakeTimer(),
+        {
+          download: async () => {
+            downloadCalls++;
+            throw new Error("download should not be called for readiness");
+          }
+        }
+      );
+
+      const result = await manager.ensureCompatibleVersion();
+      expect(result.status).toBe("skipped");
+      expect(result.installedSha256).toBe("different-sha");
+      expect(result.attemptedDownload).toBe(false);
+      expect(downloadCalls).toBe(0);
+      expect(localFakeAdb.wasCommandExecuted("install -r -d")).toBe(false);
+    });
+
+    test("should upgrade when installed SHA mismatches expected and installed download is explicitly allowed", async function() {
       AndroidCtrlProxyManager.setExpectedChecksumForTesting("expected-sha");
       const localFakeAdb = new FakeAdbExecutor();
       localFakeAdb.setCommandResponse(`shell pm list packages | grep ${AndroidCtrlProxyManager.PACKAGE}`, {
@@ -305,9 +344,44 @@ describe("CtrlProxyManager", function() {
       (manager as any).downloadApk = async () => "/tmp/fake-accessibility.apk";
       (manager as any).cleanupApk = async () => undefined;
 
-      const result = await manager.ensureCompatibleVersion();
+      const result = await manager.ensureCompatibleVersion({ allowDownloadWhenInstalled: true });
       expect(result.status).toBe("upgraded");
       expect(localFakeAdb.wasCommandExecuted("install -r -d")).toBe(true);
+    });
+
+    test("should cache failed download result briefly instead of retrying every call", async function() {
+      AndroidCtrlProxyManager.setExpectedChecksumForTesting("expected-sha");
+      const fakeTimer = new FakeTimer();
+      const localFakeAdb = new FakeAdbExecutor();
+      localFakeAdb.setCommandResponse(`shell pm list packages | grep ${AndroidCtrlProxyManager.PACKAGE}`, {
+        stdout: "",
+        stderr: ""
+      });
+
+      let downloadCalls = 0;
+      AndroidCtrlProxyManager.resetInstances();
+      const manager = AndroidCtrlProxyManager.createForTestingWithDeps(
+        testDevice,
+        localFakeAdb,
+        fakeTimer,
+        {
+          download: async () => {
+            downloadCalls++;
+            throw new Error("Could not resolve host");
+          }
+        }
+      );
+
+      const firstResult = await manager.ensureCompatibleVersion();
+      const secondResult = await manager.ensureCompatibleVersion();
+      expect(firstResult.status).toBe("failed");
+      expect(firstResult.downloadUnavailable).toBe(true);
+      expect(secondResult.status).toBe("failed");
+      expect(downloadCalls).toBe(1);
+
+      fakeTimer.advanceTime(61_000);
+      await manager.ensureCompatibleVersion();
+      expect(downloadCalls).toBe(2);
     });
 
     test("should reinstall when upgrade install fails", async function() {
@@ -347,7 +421,7 @@ describe("CtrlProxyManager", function() {
       (manager as any).install = async () => undefined;
       (manager as any).enable = async () => undefined;
 
-      const result = await manager.ensureCompatibleVersion();
+      const result = await manager.ensureCompatibleVersion({ allowDownloadWhenInstalled: true });
       expect(result.status).toBe("reinstalled");
       expect(localFakeAdb.wasCommandExecuted("shell pm uninstall")).toBe(true);
     });
@@ -434,7 +508,7 @@ describe("CtrlProxyManager", function() {
       (manager as any).install = async () => undefined;
       (manager as any).enable = async () => undefined;
 
-      const result = await manager.ensureCompatibleVersion();
+      const result = await manager.ensureCompatibleVersion({ allowDownloadWhenInstalled: true });
       expect(result.status).toBe("reinstalled");
       expect(executedCommands.some(command => command.includes("install -r -d"))).toBe(false);
       expect(executedCommands.some(command => command.includes("shell pm uninstall"))).toBe(true);
@@ -457,15 +531,57 @@ describe("CtrlProxyManager", function() {
       });
 
       AndroidCtrlProxyManager.resetInstances();
-      const manager = AndroidCtrlProxyManager.getInstance(testDevice, { create: () => localFakeAdb });
-      (manager as any).downloadApk = async () => {
-        throw new Error("Could not resolve host");
-      };
+      const manager = AndroidCtrlProxyManager.createForTestingWithDeps(
+        testDevice,
+        localFakeAdb,
+        new FakeTimer(),
+        {
+          download: async () => {
+            throw new Error("Could not resolve host");
+          }
+        }
+      );
 
-      const result = await manager.ensureCompatibleVersion();
+      const result = await manager.ensureCompatibleVersion({ allowDownloadWhenInstalled: true });
       expect(result.status).toBe("failed");
       expect(result.downloadUnavailable).toBe(true);
       expect(result.error).toContain("offline");
+    });
+
+    test("should not let forced update failures poison nonblocking readiness cache", async function() {
+      AndroidCtrlProxyManager.setExpectedChecksumForTesting("expected-sha");
+      const localFakeAdb = new FakeAdbExecutor();
+      localFakeAdb.setCommandResponse(`shell pm list packages | grep ${AndroidCtrlProxyManager.PACKAGE}`, {
+        stdout: `package:${AndroidCtrlProxyManager.PACKAGE}\n`,
+        stderr: ""
+      });
+      localFakeAdb.setCommandResponse(`shell pm path ${AndroidCtrlProxyManager.PACKAGE}`, {
+        stdout: "package:/data/app/dev.jasonpearson.automobile.ctrlproxy/base.apk\n",
+        stderr: ""
+      });
+      localFakeAdb.setCommandResponse("shell sha256sum", {
+        stdout: "different-sha /data/app/dev.jasonpearson.automobile.ctrlproxy/base.apk\n",
+        stderr: ""
+      });
+
+      AndroidCtrlProxyManager.resetInstances();
+      const manager = AndroidCtrlProxyManager.createForTestingWithDeps(
+        testDevice,
+        localFakeAdb,
+        new FakeTimer(),
+        {
+          download: async () => {
+            throw new Error("Could not resolve host");
+          }
+        }
+      );
+
+      const forcedResult = await manager.ensureCompatibleVersion({ allowDownloadWhenInstalled: true });
+      const readinessResult = await manager.ensureCompatibleVersion();
+
+      expect(forcedResult.status).toBe("failed");
+      expect(readinessResult.status).toBe("skipped");
+      expect(readinessResult.downloadUnavailable).toBeUndefined();
     });
   });
 


### PR DESCRIPTION
## Summary
- Keep normal Android CtrlProxy readiness nonblocking when an installed APK checksum differs from the release checksum, accepting the preinstalled service and queuing a background APK prefetch instead of synchronously downloading.
- Add a short version-check cache so failed/offline download checks are not retried on every tool call.
- Preserve explicit service update behavior by forcing installed-service downloads through `ide/updateService`, and document the updated CtrlProxy version-management behavior.
- Make iOS CtrlProxy manager tests deterministic by faking default port availability instead of depending on local machine ports.

## Tests
- `bun test test/utils/CtrlProxyManager.test.ts`
- `bun test test/utils/IOSCtrlProxyManager.test.ts`
- `bun run lint`
- `bun run build`
- `bun test` (4,841 pass, 1 skip)

Closes #2590
