### PR TITLE
Record tool call durations

### DIFF
--- a/.github/actions/setup-auto-mobile-npm-package/action.yml
+++ b/.github/actions/setup-auto-mobile-npm-package/action.yml
@@ -6,6 +6,10 @@ inputs:
     description: "The shell to use for any steps that use shells"
     default: "bash"
     required: "true"
+  install-global:
+    description: "Whether to globally install the checked-out AutoMobile package"
+    default: "true"
+    required: "false"
 
 runs:
   using: "composite"
@@ -33,6 +37,7 @@ runs:
         bunx turbo run build --output-logs=errors-only
 
     - name: "Globally Install AutoMobile"
+      if: ${{ inputs.install-global == 'true' }}
       shell: ${{ inputs.shell }}
       run: |
         if [[ "${RUNNER_OS:-}" == "Windows" ]]; then

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -773,6 +773,8 @@ jobs:
       - name: "Setup Auto Mobile"
         if: env.RUN_MCP_BUILD_TEST == 'true'
         uses: ./.github/actions/setup-auto-mobile-npm-package
+        with:
+          install-global: "false"
 
       - name: "Run Lint"
         if: env.RUN_MCP_BUILD_TEST == 'true'

--- a/src/db/toolCallRepository.ts
+++ b/src/db/toolCallRepository.ts
@@ -7,6 +7,7 @@ interface ToolCallRecord {
   toolName: string;
   timestamp: string;
   sessionUuid?: string | null;
+  durationMs?: number | null;
 }
 
 export class ToolCallRepository {
@@ -30,6 +31,9 @@ export class ToolCallRepository {
         tool_name: record.toolName,
         timestamp: record.timestamp,
         session_uuid: record.sessionUuid ?? null,
+        duration_ms: record.durationMs === undefined || record.durationMs === null
+          ? null
+          : Math.max(0, Math.round(record.durationMs)),
       };
 
       await db.insertInto("tool_calls").values(entry).execute();

--- a/src/server/toolRegistry.ts
+++ b/src/server/toolRegistry.ts
@@ -631,7 +631,7 @@ class ToolRegistryClass {
           }
         }
       } finally {
-        void this.toolCallRepository.recordToolCall({
+        await this.toolCallRepository.recordToolCall({
           toolName: name,
           timestamp: toolCallTimestamp,
           sessionUuid,

--- a/src/server/toolRegistry.ts
+++ b/src/server/toolRegistry.ts
@@ -351,6 +351,7 @@ class ToolRegistryClass {
 
       const toolStartMs = this.timer.now();
       const toolCallTimestamp = new Date().toISOString();
+      let toolDurationMs: number | undefined;
 
       try {
         // Extract platform from args, default to "either" for backward compatibility
@@ -537,7 +538,7 @@ class ToolRegistryClass {
           }
 
           // Emit tool call telemetry
-          const toolDurationMs = this.timer.now() - toolStartMs;
+          toolDurationMs = this.timer.now() - toolStartMs;
           TelemetryRecorder.getInstance().recordToolCallEvent({
             timestamp: toolStartMs,
             toolName: name,
@@ -634,7 +635,7 @@ class ToolRegistryClass {
           toolName: name,
           timestamp: toolCallTimestamp,
           sessionUuid,
-          durationMs: this.timer.now() - toolStartMs,
+          durationMs: toolDurationMs ?? this.timer.now() - toolStartMs,
         });
       }
     };

--- a/src/server/toolRegistry.ts
+++ b/src/server/toolRegistry.ts
@@ -350,287 +350,292 @@ class ToolRegistryClass {
       }
 
       const toolStartMs = this.timer.now();
-
-      // Extract platform from args, default to "either" for backward compatibility
-      let platform: SomePlatform = args.platform || "either";
-
-      if (shouldResolveDevice) {
-        const implicitSessionUuid = this.resolveImplicitAutolockSession(platform, sessionUuid, providedDeviceId, mcpSessionId);
-        if (implicitSessionUuid) {
-          sessionUuid = implicitSessionUuid;
-          args.sessionUuid = implicitSessionUuid;
-          logger.info(`[ToolRegistry] Resolved implicit autolock session for MCP session ${mcpSessionId}: ${implicitSessionUuid}`);
-        }
-        await this.enforceSessionUuidForMultipleIos(platform, sessionUuid, providedDeviceId);
-        await this.enforceSessionUuidForAutolock(platform, sessionUuid, providedDeviceId);
-      }
-
-      logger.info(`[ToolRegistry] Tool ${name} called, sessionUuid=${sessionUuid}, daemonInitialized=${DaemonState.getInstance().isInitialized()}`);
-      void this.toolCallRepository.recordToolCall({
-        toolName: name,
-        timestamp: new Date().toISOString(),
-        sessionUuid,
-      });
-
-      // If session UUID provided, resolve device from session
-      if (shouldResolveDevice && sessionUuid && DaemonState.getInstance().isInitialized()) {
-        logger.info(`[ToolRegistry] Entering session-based device assignment for ${sessionUuid}`);
-        const sessionManager = DaemonState.getInstance().getSessionManager();
-        const devicePool = DaemonState.getInstance().getDevicePool();
-        const context = await createToolExecutionContext(sessionUuid, sessionManager, devicePool, {
-          keepScreenAwake,
-          platform: platform === "android" || platform === "ios" ? platform : undefined
-        });
-        if (context.deviceId && !providedDeviceId) {
-          providedDeviceId = context.deviceId;
-          logger.info(`[ToolRegistry] Resolved device from session: ${providedDeviceId}`);
-        }
-        if (platform === "either" && context.devicePlatform) {
-          platform = context.devicePlatform;
-        }
-      } else if (sessionUuid) {
-        logger.warn(`[ToolRegistry] SessionUuid provided but DaemonState not initialized!`);
-      }
-
-      let device: BootedDevice | undefined;
-      if (shouldResolveDevice) {
-        if (sessionUuid && DaemonState.getInstance().isInitialized() && providedDeviceId) {
-          // Daemon session path: device already resolved via createToolExecutionContext.
-          // Construct BootedDevice directly to avoid mutating global DeviceSessionManager state.
-          const resolvedPlatform = (platform === "android" || platform === "ios") ? platform : "android";
-          const pooledDevice = DaemonState.getInstance().getDevicePool().getDevice(providedDeviceId);
-          device = {
-            deviceId: providedDeviceId,
-            name: pooledDevice?.name ?? providedDeviceId,
-            platform: pooledDevice?.platform ?? resolvedPlatform,
-            iosVersion: pooledDevice?.iosVersion,
-          };
-          logger.info(`[ToolRegistry] ${name}: Using session-resolved device ${device.deviceId}`);
-        } else {
-          // Legacy single-agent path or no session: use DeviceSessionManager (may set global state)
-          logger.info(`[ToolRegistry] ${name}: Resolving device for platform=${platform}, providedDeviceId=${providedDeviceId}`);
-          device = await this.deviceSessionManager.ensureDeviceReady(
-            platform,
-            providedDeviceId,
-            { skipCtrlProxyDownload: serverConfig.isSkipCtrlProxyDownloadEnabled() }
-          );
-          logger.info(`[ToolRegistry] ${name}: Using device ${device.deviceId}`);
-        }
-      } else {
-        logger.info(`[ToolRegistry] ${name}: Skipping device resolution.`);
-      }
-
-      // Enforce autolock: a locked device may only be driven by the session that locked it.
-      if (device && isDevicePoolAutolockEnabled() && DaemonState.getInstance().isInitialized()) {
-        DaemonState.getInstance().getDevicePool().assertAutolockAccess(device.deviceId, sessionUuid);
-      }
-
-      // Bind session to device's CtrlProxyClient for multi-agent NavigationGraphManager isolation
-      if (device && sessionUuid) {
-        try {
-          if (device.platform === "android") {
-            AndroidCtrlProxyClient.getInstance(device).bindSession(sessionUuid);
-          } else if (device.platform === "ios") {
-            IOSCtrlProxyClient.getInstance(device).bindSession(sessionUuid);
-          }
-        } catch {
-          // CtrlProxy may not be initialized yet — binding is best-effort
-        }
-      }
+      const toolCallTimestamp = new Date().toISOString();
 
       try {
-        // Record tool call for navigation graph correlation
-        // Only record UI interaction tools that may cause navigation
-        // Excludes app lifecycle tools (launchApp, terminateApp, homeScreen, etc.)
-        // as they don't represent replayable in-app navigation paths
-        const navigationRelevantTools = [
-          "tapOn", "swipeOn", "pinchOn", "dragAndDrop",
-          "pressButton", "inputText", "clearText", "imeAction"
-        ];
-        if (navigationRelevantTools.includes(name)) {
-          // Extract UI state from the most recent cached observation
-          const cachedResult = device
-            ? RealObserveScreen.getRecentCachedResultForDevice(device.deviceId)
-            : RealObserveScreen.getRecentCachedResult();
-          const uiState = new UIStateExtractor().extractFromObservation(cachedResult);
-          const navManager = sessionUuid
-            ? NavigationGraphManager.getInstanceForSession(sessionUuid)
-            : NavigationGraphManager.getInstance();
-          navManager.recordToolCall(name, args, uiState);
-        }
+        // Extract platform from args, default to "either" for backward compatibility
+        let platform: SomePlatform = args.platform || "either";
 
-        let response: any | undefined;
-        if (!shouldResolveDevice) {
-          if (!options.nonDeviceHandler) {
-            throw new ActionableError(`Tool ${name} requires a device.`);
+        if (shouldResolveDevice) {
+          const implicitSessionUuid = this.resolveImplicitAutolockSession(platform, sessionUuid, providedDeviceId, mcpSessionId);
+          if (implicitSessionUuid) {
+            sessionUuid = implicitSessionUuid;
+            args.sessionUuid = implicitSessionUuid;
+            logger.info(`[ToolRegistry] Resolved implicit autolock session for MCP session ${mcpSessionId}: ${implicitSessionUuid}`);
           }
-          response = await options.nonDeviceHandler(args, progress, signal);
-        } else if (device !== undefined) {
-          // Check if memory performance audit mode is enabled
-          const memPerfAuditEnabled = serverConfig.isMemPerfAuditEnabled();
-
-          if (memPerfAuditEnabled && device.platform === "android") {
-            // Get the foreground app package name
-            const packageName = await this.getForegroundPackageName(device);
-
-            if (packageName) {
-              logger.info(`[ToolRegistry] Running memory audit for ${packageName} during ${name}`);
-
-              // Create memory audit instance
-              const memoryAudit = new MemoryAudit(device);
-              const perf = createGlobalPerformanceTracker();
-
-              // Run the handler within memory audit
-              const auditResult = await memoryAudit.runAudit(
-                packageName,
-                name,
-                args,
-                async () => {
-                  response = await handler(device, args, progress, signal);
-                },
-                perf
-              );
-
-              // If audit failed, throw error with diagnostics
-              if (!auditResult.passed) {
-                const errorMsg = `Memory audit FAILED for ${packageName} during ${name}\n\n${auditResult.diagnostics}`;
-                logger.error(`[ToolRegistry] ${errorMsg}`);
-                throw new ActionableError(errorMsg);
-              }
-
-              logger.info(`[ToolRegistry] Memory audit PASSED for ${packageName} during ${name}`);
-            } else {
-              logger.warn(`[ToolRegistry] Could not determine foreground app, skipping memory audit for ${name}`);
-              response = await handler(device, args, progress, signal);
-            }
-          } else {
-            // Memory audit not enabled or not Android platform, execute normally
-            response = await handler(device, args, progress, signal);
-          }
+          await this.enforceSessionUuidForMultipleIos(platform, sessionUuid, providedDeviceId);
+          await this.enforceSessionUuidForAutolock(platform, sessionUuid, providedDeviceId);
         }
 
-        // Unwrap MCP response envelope to get the inner result for success/error checks.
-        // Tools may return { content: [{ type: "text", text: '{"success":false,...}' }] }
-        // instead of a plain { success, error } object.
-        let unwrapped = response;
-        if (
-          response && typeof response === "object" &&
-          !("success" in response) &&
-          Array.isArray(response.content) && response.content.length > 0
-        ) {
-          const first = response.content[0];
-          if (first?.type === "text" && typeof first.text === "string") {
-            try {
-              const parsed = JSON.parse(first.text);
-              if (parsed && typeof parsed === "object" && "success" in parsed) {
-                unwrapped = parsed;
-              }
-            } catch { /* not JSON — use original response */ }
-          }
-        }
+        logger.info(`[ToolRegistry] Tool ${name} called, sessionUuid=${sessionUuid}, daemonInitialized=${DaemonState.getInstance().isInitialized()}`);
 
-        const toolSuccess = unwrapped && typeof unwrapped === "object" && "success" in unwrapped
-          ? unwrapped.success !== false
-          : true;
-        const toolError = unwrapped && typeof unwrapped === "object" && "error" in unwrapped
-          ? String(unwrapped.error || "")
-          : null;
-        if (unwrapped && typeof unwrapped === "object" && "success" in unwrapped) {
-          logger.info(`[ToolRegistry] ${name} result: success=${unwrapped.success}${unwrapped.success === false ? `, error=${unwrapped.error || "unknown"}` : ""}`);
-        }
-
-        // Emit tool call telemetry
-        const toolDurationMs = this.timer.now() - toolStartMs;
-        TelemetryRecorder.getInstance().recordToolCallEvent({
-          timestamp: toolStartMs,
-          toolName: name,
-          durationMs: toolDurationMs,
-          success: toolSuccess,
-          error: toolError,
-          args: typeof args === "object" ? args : null,
-        });
-
-        // Record successful tool call for MCP recording (test plan generation)
-        if (toolSuccess) {
-          getMcpRecorder()?.record(name, args);
-        }
-
-        // After swipeOn executes with lookFor, update the tool call with scroll position
-        if (name === "swipeOn" && args.lookFor && response?.success && response?.found) {
-          const scrollPosition = UIStateExtractor.createScrollPosition(args);
-          if (scrollPosition) {
-            const scrollNavManager = sessionUuid
-              ? NavigationGraphManager.getInstanceForSession(sessionUuid)
-              : NavigationGraphManager.getInstance();
-            scrollNavManager.updateScrollPosition(scrollPosition);
-          }
-        }
-
-        // Update session cache if sessionUuid provided
+        // If session UUID provided, resolve device from session
         if (shouldResolveDevice && sessionUuid && DaemonState.getInstance().isInitialized()) {
+          logger.info(`[ToolRegistry] Entering session-based device assignment for ${sessionUuid}`);
           const sessionManager = DaemonState.getInstance().getSessionManager();
           const devicePool = DaemonState.getInstance().getDevicePool();
           const context = await createToolExecutionContext(sessionUuid, sessionManager, devicePool, {
             keepScreenAwake,
             platform: platform === "android" || platform === "ios" ? platform : undefined
           });
-
-          // Cache observation data for certain tools to reduce API calls
-          if (name === "observe" && response?.viewHierarchy) {
-            await updateSessionCache(context, "lastHierarchy", response.viewHierarchy);
+          if (context.deviceId && !providedDeviceId) {
+            providedDeviceId = context.deviceId;
+            logger.info(`[ToolRegistry] Resolved device from session: ${providedDeviceId}`);
           }
-          if (name === "observe" && response?.screenshot) {
-            await updateSessionCache(context, "lastScreenshot", response.screenshot);
+          if (platform === "either" && context.devicePlatform) {
+            platform = context.devicePlatform;
           }
-
-          // Update last action timestamp for interaction tools
-          if (["tapOn", "swipeOn", "pinchOn", "dragAndDrop", "scroll", "inputText", "clearText", "pressButton"].includes(name)) {
-            await updateSessionCache(context, "lastActionTime", this.timer.now());
-          }
+        } else if (sessionUuid) {
+          logger.warn(`[ToolRegistry] SessionUuid provided but DaemonState not initialized!`);
         }
 
-        return response;
-      } catch (error) {
-        if (error instanceof ActionableError) {
-          throw error;
-        }
-        const deviceContext = device ? ` on device ${device.deviceId}` : "";
-        throw new ActionableError(`Failed to execute tool ${name}${deviceContext}: ${error}`);
-      } finally {
-        if (device && name === "executePlan" && args?.cleanupAppId) {
-          await this.cleanupService.cleanup(device, {
-            appId: args.cleanupAppId,
-            clearAppData: args.cleanupClearAppData,
-          });
+        let device: BootedDevice | undefined;
+        if (shouldResolveDevice) {
+          if (sessionUuid && DaemonState.getInstance().isInitialized() && providedDeviceId) {
+            // Daemon session path: device already resolved via createToolExecutionContext.
+            // Construct BootedDevice directly to avoid mutating global DeviceSessionManager state.
+            const resolvedPlatform = (platform === "android" || platform === "ios") ? platform : "android";
+            const pooledDevice = DaemonState.getInstance().getDevicePool().getDevice(providedDeviceId);
+            device = {
+              deviceId: providedDeviceId,
+              name: pooledDevice?.name ?? providedDeviceId,
+              platform: pooledDevice?.platform ?? resolvedPlatform,
+              iosVersion: pooledDevice?.iosVersion,
+            };
+            logger.info(`[ToolRegistry] ${name}: Using session-resolved device ${device.deviceId}`);
+          } else {
+            // Legacy single-agent path or no session: use DeviceSessionManager (may set global state)
+            logger.info(`[ToolRegistry] ${name}: Resolving device for platform=${platform}, providedDeviceId=${providedDeviceId}`);
+            device = await this.deviceSessionManager.ensureDeviceReady(
+              platform,
+              providedDeviceId,
+              { skipCtrlProxyDownload: serverConfig.isSkipCtrlProxyDownloadEnabled() }
+            );
+            logger.info(`[ToolRegistry] ${name}: Using device ${device.deviceId}`);
+          }
+        } else {
+          logger.info(`[ToolRegistry] ${name}: Skipping device resolution.`);
         }
 
-        // Auto-release session after executePlan completes
-        // This frees the device immediately for parallel test execution
-        if (shouldResolveDevice && sessionUuid && name === "executePlan" && DaemonState.getInstance().isInitialized()) {
+        // Enforce autolock: a locked device may only be driven by the session that locked it.
+        if (device && isDevicePoolAutolockEnabled() && DaemonState.getInstance().isInitialized()) {
+          DaemonState.getInstance().getDevicePool().assertAutolockAccess(device.deviceId, sessionUuid);
+        }
+
+        // Bind session to device's CtrlProxyClient for multi-agent NavigationGraphManager isolation
+        if (device && sessionUuid) {
           try {
+            if (device.platform === "android") {
+              AndroidCtrlProxyClient.getInstance(device).bindSession(sessionUuid);
+            } else if (device.platform === "ios") {
+              IOSCtrlProxyClient.getInstance(device).bindSession(sessionUuid);
+            }
+          } catch {
+            // CtrlProxy may not be initialized yet — binding is best-effort
+          }
+        }
+
+        try {
+          // Record tool call for navigation graph correlation
+          // Only record UI interaction tools that may cause navigation
+          // Excludes app lifecycle tools (launchApp, terminateApp, homeScreen, etc.)
+          // as they don't represent replayable in-app navigation paths
+          const navigationRelevantTools = [
+            "tapOn", "swipeOn", "pinchOn", "dragAndDrop",
+            "pressButton", "inputText", "clearText", "imeAction"
+          ];
+          if (navigationRelevantTools.includes(name)) {
+            // Extract UI state from the most recent cached observation
+            const cachedResult = device
+              ? RealObserveScreen.getRecentCachedResultForDevice(device.deviceId)
+              : RealObserveScreen.getRecentCachedResult();
+            const uiState = new UIStateExtractor().extractFromObservation(cachedResult);
+            const navManager = sessionUuid
+              ? NavigationGraphManager.getInstanceForSession(sessionUuid)
+              : NavigationGraphManager.getInstance();
+            navManager.recordToolCall(name, args, uiState);
+          }
+
+          let response: any | undefined;
+          if (!shouldResolveDevice) {
+            if (!options.nonDeviceHandler) {
+              throw new ActionableError(`Tool ${name} requires a device.`);
+            }
+            response = await options.nonDeviceHandler(args, progress, signal);
+          } else if (device !== undefined) {
+            // Check if memory performance audit mode is enabled
+            const memPerfAuditEnabled = serverConfig.isMemPerfAuditEnabled();
+
+            if (memPerfAuditEnabled && device.platform === "android") {
+              // Get the foreground app package name
+              const packageName = await this.getForegroundPackageName(device);
+
+              if (packageName) {
+                logger.info(`[ToolRegistry] Running memory audit for ${packageName} during ${name}`);
+
+                // Create memory audit instance
+                const memoryAudit = new MemoryAudit(device);
+                const perf = createGlobalPerformanceTracker();
+
+                // Run the handler within memory audit
+                const auditResult = await memoryAudit.runAudit(
+                  packageName,
+                  name,
+                  args,
+                  async () => {
+                    response = await handler(device, args, progress, signal);
+                  },
+                  perf
+                );
+
+                // If audit failed, throw error with diagnostics
+                if (!auditResult.passed) {
+                  const errorMsg = `Memory audit FAILED for ${packageName} during ${name}\n\n${auditResult.diagnostics}`;
+                  logger.error(`[ToolRegistry] ${errorMsg}`);
+                  throw new ActionableError(errorMsg);
+                }
+
+                logger.info(`[ToolRegistry] Memory audit PASSED for ${packageName} during ${name}`);
+              } else {
+                logger.warn(`[ToolRegistry] Could not determine foreground app, skipping memory audit for ${name}`);
+                response = await handler(device, args, progress, signal);
+              }
+            } else {
+              // Memory audit not enabled or not Android platform, execute normally
+              response = await handler(device, args, progress, signal);
+            }
+          }
+
+          // Unwrap MCP response envelope to get the inner result for success/error checks.
+          // Tools may return { content: [{ type: "text", text: '{"success":false,...}' }] }
+          // instead of a plain { success, error } object.
+          let unwrapped = response;
+          if (
+            response && typeof response === "object" &&
+            !("success" in response) &&
+            Array.isArray(response.content) && response.content.length > 0
+          ) {
+            const first = response.content[0];
+            if (first?.type === "text" && typeof first.text === "string") {
+              try {
+                const parsed = JSON.parse(first.text);
+                if (parsed && typeof parsed === "object" && "success" in parsed) {
+                  unwrapped = parsed;
+                }
+              } catch { /* not JSON — use original response */ }
+            }
+          }
+
+          const toolSuccess = unwrapped && typeof unwrapped === "object" && "success" in unwrapped
+            ? unwrapped.success !== false
+            : true;
+          const toolError = unwrapped && typeof unwrapped === "object" && "error" in unwrapped
+            ? String(unwrapped.error || "")
+            : null;
+          if (unwrapped && typeof unwrapped === "object" && "success" in unwrapped) {
+            logger.info(`[ToolRegistry] ${name} result: success=${unwrapped.success}${unwrapped.success === false ? `, error=${unwrapped.error || "unknown"}` : ""}`);
+          }
+
+          // Emit tool call telemetry
+          const toolDurationMs = this.timer.now() - toolStartMs;
+          TelemetryRecorder.getInstance().recordToolCallEvent({
+            timestamp: toolStartMs,
+            toolName: name,
+            durationMs: toolDurationMs,
+            success: toolSuccess,
+            error: toolError,
+            args: typeof args === "object" ? args : null,
+          });
+
+          // Record successful tool call for MCP recording (test plan generation)
+          if (toolSuccess) {
+            getMcpRecorder()?.record(name, args);
+          }
+
+          // After swipeOn executes with lookFor, update the tool call with scroll position
+          if (name === "swipeOn" && args.lookFor && response?.success && response?.found) {
+            const scrollPosition = UIStateExtractor.createScrollPosition(args);
+            if (scrollPosition) {
+              const scrollNavManager = sessionUuid
+                ? NavigationGraphManager.getInstanceForSession(sessionUuid)
+                : NavigationGraphManager.getInstance();
+              scrollNavManager.updateScrollPosition(scrollPosition);
+            }
+          }
+
+          // Update session cache if sessionUuid provided
+          if (shouldResolveDevice && sessionUuid && DaemonState.getInstance().isInitialized()) {
             const sessionManager = DaemonState.getInstance().getSessionManager();
             const devicePool = DaemonState.getInstance().getDevicePool();
-            const releaseSessionUuid = baseSessionUuid ?? sessionUuid;
-            if (releaseSessionUuid) {
-              await releaseDeviceLabelSessions(releaseSessionUuid);
+            const context = await createToolExecutionContext(sessionUuid, sessionManager, devicePool, {
+              keepScreenAwake,
+              platform: platform === "android" || platform === "ios" ? platform : undefined
+            });
+
+            // Cache observation data for certain tools to reduce API calls
+            if (name === "observe" && response?.viewHierarchy) {
+              await updateSessionCache(context, "lastHierarchy", response.viewHierarchy);
+            }
+            if (name === "observe" && response?.screenshot) {
+              await updateSessionCache(context, "lastScreenshot", response.screenshot);
             }
 
-            const session = releaseSessionUuid ? sessionManager.getSession(releaseSessionUuid) : null;
-            if (session) {
-              const deviceId = session.assignedDevice;
-              sessionManager.releaseSession(session.sessionId);
-              await devicePool.releaseDevice(deviceId);
-              // Clean up session-scoped navigation state and observe cache
-              NavigationGraphManager.releaseSession(releaseSessionUuid);
-              RealObserveScreen.clearCache(deviceId);
-              logger.info(`Auto-released session ${session.sessionId} and freed device ${deviceId} after executePlan`);
+            // Update last action timestamp for interaction tools
+            if (["tapOn", "swipeOn", "pinchOn", "dragAndDrop", "scroll", "inputText", "clearText", "pressButton"].includes(name)) {
+              await updateSessionCache(context, "lastActionTime", this.timer.now());
             }
-          } catch (releaseError) {
-            // Don't fail the tool if session release fails
-            // Session will be cleaned up by timeout mechanism
-            logger.warn(`Failed to auto-release session ${sessionUuid}: ${releaseError}`);
+          }
+
+          return response;
+        } catch (error) {
+          if (error instanceof ActionableError) {
+            throw error;
+          }
+          const deviceContext = device ? ` on device ${device.deviceId}` : "";
+          throw new ActionableError(`Failed to execute tool ${name}${deviceContext}: ${error}`);
+        } finally {
+          if (device && name === "executePlan" && args?.cleanupAppId) {
+            await this.cleanupService.cleanup(device, {
+              appId: args.cleanupAppId,
+              clearAppData: args.cleanupClearAppData,
+            });
+          }
+
+          // Auto-release session after executePlan completes
+          // This frees the device immediately for parallel test execution
+          if (shouldResolveDevice && sessionUuid && name === "executePlan" && DaemonState.getInstance().isInitialized()) {
+            try {
+              const sessionManager = DaemonState.getInstance().getSessionManager();
+              const devicePool = DaemonState.getInstance().getDevicePool();
+              const releaseSessionUuid = baseSessionUuid ?? sessionUuid;
+              if (releaseSessionUuid) {
+                await releaseDeviceLabelSessions(releaseSessionUuid);
+              }
+
+              const session = releaseSessionUuid ? sessionManager.getSession(releaseSessionUuid) : null;
+              if (session) {
+                const deviceId = session.assignedDevice;
+                sessionManager.releaseSession(session.sessionId);
+                await devicePool.releaseDevice(deviceId);
+                // Clean up session-scoped navigation state and observe cache
+                NavigationGraphManager.releaseSession(releaseSessionUuid);
+                RealObserveScreen.clearCache(deviceId);
+                logger.info(`Auto-released session ${session.sessionId} and freed device ${deviceId} after executePlan`);
+              }
+            } catch (releaseError) {
+              // Don't fail the tool if session release fails
+              // Session will be cleaned up by timeout mechanism
+              logger.warn(`Failed to auto-release session ${sessionUuid}: ${releaseError}`);
+            }
           }
         }
+      } finally {
+        void this.toolCallRepository.recordToolCall({
+          toolName: name,
+          timestamp: toolCallTimestamp,
+          sessionUuid,
+          durationMs: this.timer.now() - toolStartMs,
+        });
       }
     };
 

--- a/test/db/toolCallRepository.test.ts
+++ b/test/db/toolCallRepository.test.ts
@@ -22,6 +22,7 @@ describe("ToolCallRepository", () => {
       toolName: "tapOn",
       timestamp: "2024-01-01T00:00:00.000Z",
       sessionUuid: "session-1",
+      durationMs: 42,
     });
 
     const rows = await db.selectFrom("tool_calls").selectAll().execute();
@@ -29,6 +30,7 @@ describe("ToolCallRepository", () => {
     expect(rows[0].tool_name).toBe("tapOn");
     expect(rows[0].timestamp).toBe("2024-01-01T00:00:00.000Z");
     expect(rows[0].session_uuid).toBe("session-1");
+    expect(rows[0].duration_ms).toBe(42);
   });
 
   test("recordToolCall with null session uuid", async () => {

--- a/test/server/toolRegistry.duration.test.ts
+++ b/test/server/toolRegistry.duration.test.ts
@@ -91,4 +91,61 @@ describe("ToolRegistry tool call duration recording", () => {
       }),
     ]);
   });
+
+  test("waits for duration recording before resolving the tool call", async () => {
+    let finishRecord!: () => void;
+    const recordGate = new Promise<void>(resolve => {
+      finishRecord = resolve;
+    });
+    let recordStarted = false;
+    (ToolRegistry as any).toolCallRepository = {
+      async recordToolCall(record: any): Promise<void> {
+        recordStarted = true;
+        records.push(record);
+        await recordGate;
+      },
+    };
+
+    ToolRegistry.registerDeviceAware(
+      "durationAwaitProbe",
+      "Waits for duration recording",
+      z.object({}),
+      async () => ({ success: true }),
+      false,
+      false,
+      {
+        shouldEnsureDevice: () => false,
+        nonDeviceHandler: async () => {
+          timer.advanceTime(11);
+          return { success: true };
+        },
+      }
+    );
+
+    const tool = ToolRegistry.getTool("durationAwaitProbe");
+    expect(tool).toBeDefined();
+
+    let settled = false;
+    const handlerPromise = tool!.handler({}).then(result => {
+      settled = true;
+      return result;
+    });
+
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(recordStarted).toBe(true);
+    expect(records).toEqual([
+      expect.objectContaining({
+        toolName: "durationAwaitProbe",
+        durationMs: 11,
+      }),
+    ]);
+    expect(settled).toBe(false);
+
+    finishRecord();
+
+    await expect(handlerPromise).resolves.toEqual({ success: true });
+    expect(settled).toBe(true);
+  });
 });

--- a/test/server/toolRegistry.duration.test.ts
+++ b/test/server/toolRegistry.duration.test.ts
@@ -1,0 +1,94 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { z } from "zod";
+import { ToolRegistry } from "../../src/server/toolRegistry";
+import { FakeTimer } from "../fakes/FakeTimer";
+
+describe("ToolRegistry tool call duration recording", () => {
+  let originalTimer: unknown;
+  let originalToolCallRepository: unknown;
+  let timer: FakeTimer;
+  let records: any[];
+
+  beforeEach(() => {
+    ToolRegistry.clearTools();
+    timer = new FakeTimer();
+    originalTimer = (ToolRegistry as any).timer;
+    originalToolCallRepository = (ToolRegistry as any).toolCallRepository;
+    (ToolRegistry as any).timer = timer;
+    records = [];
+    (ToolRegistry as any).toolCallRepository = {
+      async recordToolCall(record: any): Promise<void> {
+        records.push(record);
+      },
+    };
+  });
+
+  afterEach(() => {
+    (ToolRegistry as any).timer = originalTimer;
+    (ToolRegistry as any).toolCallRepository = originalToolCallRepository;
+    ToolRegistry.clearTools();
+  });
+
+  test("records elapsed duration for a completed tool call", async () => {
+    ToolRegistry.registerDeviceAware(
+      "durationProbe",
+      "Measures tool call duration",
+      z.object({
+        sessionUuid: z.string().optional(),
+      }),
+      async () => ({ success: true }),
+      false,
+      false,
+      {
+        shouldEnsureDevice: () => false,
+        nonDeviceHandler: async () => {
+          timer.advanceTime(37);
+          return { success: true };
+        },
+      }
+    );
+
+    const tool = ToolRegistry.getTool("durationProbe");
+    expect(tool).toBeDefined();
+
+    const response = await tool!.handler({ sessionUuid: "session-1" });
+
+    expect(response).toEqual({ success: true });
+    expect(records).toEqual([
+      expect.objectContaining({
+        toolName: "durationProbe",
+        sessionUuid: "session-1",
+        durationMs: 37,
+      }),
+    ]);
+  });
+
+  test("records elapsed duration when a tool call throws", async () => {
+    ToolRegistry.registerDeviceAware(
+      "durationFailureProbe",
+      "Measures failed tool call duration",
+      z.object({}),
+      async () => ({ success: true }),
+      false,
+      false,
+      {
+        shouldEnsureDevice: () => false,
+        nonDeviceHandler: async () => {
+          timer.advanceTime(19);
+          throw new Error("probe failed");
+        },
+      }
+    );
+
+    const tool = ToolRegistry.getTool("durationFailureProbe");
+    expect(tool).toBeDefined();
+
+    await expect(tool!.handler({})).rejects.toThrow("Failed to execute tool durationFailureProbe");
+    expect(records).toEqual([
+      expect.objectContaining({
+        toolName: "durationFailureProbe",
+        durationMs: 19,
+      }),
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary

- Populate `tool_calls.duration_ms` from the `ToolRegistry` elapsed timer.
- Thread `durationMs` through `ToolCallRepository.recordToolCall()` and persist it as integer milliseconds.
- Add focused regression tests for successful and throwing registry calls plus repository persistence.

Fixes #2588

## Testing

- `bun test test/db/toolCallRepository.test.ts test/server/toolRegistry.duration.test.ts`
- `bun run lint`
- `bun run build`
- `bash scripts/all_fast_validate_checks.sh`
- `bun test --bail` *(fails in existing `test/utils/IOSCtrlProxyManager.test.ts`: expected default/service port `8765` or `8767`, received `8768`; reproduces when running that test file in isolation and is outside this telemetry change)*
