### PR TITLE
Add app file service provider layer

### DIFF
--- a/docs/design-docs/mcp/app-file-service.md
+++ b/docs/design-docs/mcp/app-file-service.md
@@ -1,0 +1,51 @@
+# App File Service
+
+<kbd>✅ Implemented</kbd> <kbd>🧪 Tested</kbd>
+
+`putAppFile` and the app-file resources share one internal service so tools and
+resources do not call `adb`, `run-as`, `simctl`, or the host filesystem directly.
+
+## Service Boundary
+
+- Public MCP handlers call `AppFileService` in `src/server/appFileService.ts`.
+- `DefaultAppFileService` owns shared validation, source preparation, device
+  resolution for resources, provider selection, and typed result metadata.
+- Platform-specific behavior lives behind `AppFileProvider` implementations:
+  `AndroidAppFileProvider` and `IosSimulatorAppFileProvider`.
+- Providers receive normalized app IDs, logical containers, safe relative paths,
+  and prepared source file paths. They should not accept raw MCP arguments.
+
+## Shared Validation
+
+Keep validation that is common to all platforms in the service or contract layer:
+
+- `src/server/appFileContract.ts` validates MCP schema shape and resource URI
+  parsing.
+- `normalizeAppFileRelativePath` rejects absolute paths, empty paths, repeated
+  separators, `.`, and `..` traversal.
+- `AppFileService` validates app IDs before provider selection so unsafe app IDs
+  cannot reach platform path construction.
+
+Provider-specific checks should only cover platform capability differences. For
+example, Android rejects `library`, and iOS rejects `externalFiles`.
+
+## Adding Containers
+
+1. Add the logical name to `APP_FILE_CONTAINERS` in
+   `src/server/appFileContract.ts`.
+2. Map the container in each provider in `src/server/appFileService.ts`.
+3. If a platform cannot support the container, throw an explicit
+   `ActionableError` through the unsupported-operation helper. Include the
+   operation, app ID, container, and platform in the message.
+4. Add tests in `test/server/appFileService.test.ts` for shared validation,
+   provider routing, and the platform-specific capability behavior.
+
+## Adding Providers
+
+1. Implement `AppFileProvider` in `src/server/appFileService.ts` or a nearby
+   module if the provider grows large.
+2. Register the provider in `createDefaultProviders`.
+3. Keep command-line details inside the provider. Return `AppFileListResult`,
+   `AppFileReadResult`, and `PutAppFileResult` metadata through the service
+   contract rather than leaking raw command output into MCP responses.
+4. Unit-test with fakes; do not require real Android devices or iOS simulators.

--- a/docs/design-docs/mcp/index.md
+++ b/docs/design-docs/mcp/index.md
@@ -18,6 +18,7 @@ The MCP server exposes AutoMobile's capabilities as tool calls, resources, and r
 - 📹 **[Video recording](observe/video-recording.md)** Low-overhead capture for CI artifacts
 - 💄 **[Visual Highlighting](observe/visual-highlighting.md)** Overlays for calling out important elements or regressions
 - 📱 **[Device Snapshots](storage/snapshots.md)** Emulator Snapshots & Simulator App Containers
+- 📄 **[App file service](app-file-service.md)** Shared app-container file operations behind platform providers
 - 🗺️ **[Navigation graph](nav/index.md)** Automatic screen flow mapping
 - ⚙️ **[Feature flags](feature-flags.md)** to gate debug or advanced features to be toggled at runtime in IDE integrations.
 - 🦆 **[Migrations](storage/migrations.md)** Database & test plan schema management

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -97,6 +97,7 @@ nav:
       - 'MCP':
           - 'Overview': design-docs/mcp/index.md
           - 'Tools': design-docs/mcp/tools.md
+          - 'App File Service': design-docs/mcp/app-file-service.md
           - 'Observe':
              - 'Overview': design-docs/mcp/observe/index.md
              - 'Appearance Sync': design-docs/mcp/observe/appearance.md

--- a/scripts/validate_mkdocs_nav.sh
+++ b/scripts/validate_mkdocs_nav.sh
@@ -73,8 +73,11 @@ extract_nav_files() {
 
 # List all .md files in docs/ directory relative to docs/
 list_actual_files() {
-    find "$DOCS_DIR" -type f -name "*.md" -not -path "*/\.*" | \
-        sed "s|^$DOCS_DIR/||" | \
+    (
+        cd "$DOCS_DIR"
+        find . -type f -name "*.md" -not -path "./.*" | \
+            sed 's|^\./||'
+    ) | \
         sort
 }
 

--- a/src/server/appFileService.ts
+++ b/src/server/appFileService.ts
@@ -1,7 +1,7 @@
+import { randomUUID } from "node:crypto";
 import { promises as nodeFs } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join, posix, relative } from "node:path";
-import { randomUUID } from "node:crypto";
 import {
   AppFileContainer,
   AppFileListRequest,
@@ -13,13 +13,44 @@ import {
   buildAppFileResourceUri,
   normalizeAppFileRelativePath,
 } from "./appFileContract";
-import { ActionableError, BootedDevice } from "../models";
+import { ActionableError, BootedDevice, Platform } from "../models";
 import { defaultAdbClientFactory, type AdbClientFactory } from "../utils/android-cmdline-tools/AdbClientFactory";
 import { SimCtlClient } from "../utils/ios-cmdline-tools/SimCtlClient";
 import { PlatformDeviceManagerFactory } from "../utils/factories/PlatformDeviceManagerFactory";
 
+export interface PutAppFileRequest extends PutAppFileArgs {
+  device: BootedDevice;
+  signal?: AbortSignal;
+}
+
+export interface PutAppFileProviderRequest {
+  device: BootedDevice;
+  appId: string;
+  container: AppFileContainer;
+  destinationPath: string;
+  sourcePath: string;
+  byteCount: number;
+  signal?: AbortSignal;
+}
+
+export interface AppFileProviderListRequest extends AppFileListRequest {
+  device: BootedDevice;
+}
+
+export interface AppFileProviderReadRequest extends AppFileReadRequest {
+  device: BootedDevice;
+  path: string;
+}
+
+export interface AppFileProvider {
+  readonly platform: Platform;
+  putFile(request: PutAppFileProviderRequest): Promise<void>;
+  listFiles(request: AppFileProviderListRequest): Promise<AppFileListResult>;
+  readFile(request: AppFileProviderReadRequest): Promise<AppFileReadResult>;
+}
+
 export interface AppFileService {
-  putFile(device: BootedDevice, args: PutAppFileArgs, signal?: AbortSignal): Promise<PutAppFileResult>;
+  putFile(request: PutAppFileRequest): Promise<PutAppFileResult>;
   listFiles(request: AppFileListRequest): Promise<AppFileListResult>;
   readFile(request: AppFileReadRequest): Promise<AppFileReadResult>;
 }
@@ -31,13 +62,16 @@ interface FileSource {
 }
 
 export interface AppFileServiceDependencies {
-  adbFactory: AdbClientFactory;
-  simctlFactory: (device: BootedDevice) => SimCtlClient;
+  adbFactory?: AdbClientFactory;
+  simctlFactory?: (device: BootedDevice) => SimCtlClient;
+  providers?: AppFileProvider[];
+  deviceResolver?: (deviceId: string) => Promise<BootedDevice>;
 }
 
-const defaultDependencies: AppFileServiceDependencies = {
+const defaultDependencies: Required<Pick<AppFileServiceDependencies, "adbFactory" | "simctlFactory" | "deviceResolver">> = {
   adbFactory: defaultAdbClientFactory,
   simctlFactory: device => new SimCtlClient(device),
+  deviceResolver: findBootedDevice,
 };
 
 const ANDROID_APP_FILE_MAX_BUFFER = 64 * 1024 * 1024;
@@ -46,7 +80,7 @@ let appFileService: AppFileService | null = null;
 
 export function getAppFileService(): AppFileService {
   if (!appFileService) {
-    appFileService = new DefaultAppFileService(defaultDependencies);
+    appFileService = new DefaultAppFileService(createDefaultProviders(defaultDependencies), defaultDependencies.deviceResolver);
   }
   return appFileService;
 }
@@ -59,37 +93,67 @@ export function resetAppFileServiceForTesting(): void {
   appFileService = null;
 }
 
-export function createAppFileServiceForTesting(deps: AppFileServiceDependencies): AppFileService {
-  return new DefaultAppFileService(deps);
+export function createAppFileServiceForTesting(deps: AppFileServiceDependencies = {}): AppFileService {
+  const resolvedDeps = {
+    adbFactory: deps.adbFactory ?? defaultDependencies.adbFactory,
+    simctlFactory: deps.simctlFactory ?? defaultDependencies.simctlFactory,
+    deviceResolver: deps.deviceResolver ?? defaultDependencies.deviceResolver,
+  };
+  return new DefaultAppFileService(
+    deps.providers ?? createDefaultProviders(resolvedDeps),
+    resolvedDeps.deviceResolver
+  );
+}
+
+function createDefaultProviders(
+  deps: Required<Pick<AppFileServiceDependencies, "adbFactory" | "simctlFactory">>
+): AppFileProvider[] {
+  return [
+    new AndroidAppFileProvider(deps.adbFactory),
+    new IosSimulatorAppFileProvider(deps.simctlFactory),
+  ];
 }
 
 class DefaultAppFileService implements AppFileService {
-  constructor(private readonly deps: AppFileServiceDependencies) {}
+  private readonly providersByPlatform = new Map<Platform, AppFileProvider>();
 
-  async putFile(device: BootedDevice, args: PutAppFileArgs, signal?: AbortSignal): Promise<PutAppFileResult> {
-    const destinationPath = normalizeAppFileRelativePath(args.destinationPath);
-    const source = await this.prepareSource(args);
+  constructor(
+    providers: AppFileProvider[],
+    private readonly deviceResolver: (deviceId: string) => Promise<BootedDevice>
+  ) {
+    for (const provider of providers) {
+      this.providersByPlatform.set(provider.platform, provider);
+    }
+  }
+
+  async putFile(request: PutAppFileRequest): Promise<PutAppFileResult> {
+    const appId = normalizeAppId(request.appId);
+    const destinationPath = normalizeAppFileRelativePath(request.destinationPath);
+    const provider = this.getProvider(request.device.platform, "putFile", appId, request.container);
+    const source = await this.prepareSource(request);
     try {
-      if (device.platform === "android") {
-        await this.putAndroidFile(device, args.appId, args.container, source.path, destinationPath, signal);
-      } else if (device.platform === "ios") {
-        await this.putIosFile(device, args.appId, args.container, source.path, destinationPath);
-      } else {
-        throw new ActionableError(`Unsupported platform: ${device.platform}`);
-      }
+      await provider.putFile({
+        device: request.device,
+        appId,
+        container: request.container,
+        destinationPath,
+        sourcePath: source.path,
+        byteCount: source.byteCount,
+        signal: request.signal,
+      });
 
       return {
         success: true,
-        deviceId: device.deviceId,
-        platform: device.platform,
-        appId: args.appId,
-        container: args.container,
+        deviceId: request.device.deviceId,
+        platform: request.device.platform,
+        appId,
+        container: request.container,
         destinationPath,
         byteCount: source.byteCount,
         resourceUri: buildAppFileResourceUri({
-          deviceId: device.deviceId,
-          appId: args.appId,
-          container: args.container,
+          deviceId: request.device.deviceId,
+          appId,
+          container: request.container,
           path: destinationPath,
         }),
       };
@@ -99,26 +163,37 @@ class DefaultAppFileService implements AppFileService {
   }
 
   async listFiles(request: AppFileListRequest): Promise<AppFileListResult> {
-    const device = await findBootedDevice(request.deviceId);
-    if (device.platform === "android") {
-      return this.listAndroidFiles(device, request.appId, request.container);
-    }
-    if (device.platform === "ios") {
-      return this.listIosFiles(device, request.appId, request.container);
-    }
-    throw new ActionableError(`Unsupported platform: ${device.platform}`);
+    const appId = normalizeAppId(request.appId);
+    const device = await this.deviceResolver(request.deviceId);
+    const provider = this.getProvider(device.platform, "listFiles", appId, request.container);
+    return provider.listFiles({
+      device,
+      deviceId: device.deviceId,
+      appId,
+      container: request.container,
+    });
   }
 
   async readFile(request: AppFileReadRequest): Promise<AppFileReadResult> {
+    const appId = normalizeAppId(request.appId);
     const path = normalizeAppFileRelativePath(request.path);
-    const device = await findBootedDevice(request.deviceId);
-    if (device.platform === "android") {
-      return this.readAndroidFile(device, request.appId, request.container, path);
+    const device = await this.deviceResolver(request.deviceId);
+    const provider = this.getProvider(device.platform, "readFile", appId, request.container);
+    return provider.readFile({
+      device,
+      deviceId: device.deviceId,
+      appId,
+      container: request.container,
+      path,
+    });
+  }
+
+  private getProvider(platform: Platform, operation: string, appId: string, container: AppFileContainer): AppFileProvider {
+    const provider = this.providersByPlatform.get(platform);
+    if (!provider) {
+      throw unsupportedAppFileOperation(operation, platform, appId, container, "no app file provider is registered");
     }
-    if (device.platform === "ios") {
-      return this.readIosFile(device, request.appId, request.container, path);
-    }
-    throw new ActionableError(`Unsupported platform: ${device.platform}`);
+    return provider;
   }
 
   private async prepareSource(args: PutAppFileArgs): Promise<FileSource> {
@@ -144,50 +219,49 @@ class DefaultAppFileService implements AppFileService {
       },
     };
   }
+}
 
-  private async putAndroidFile(
-    device: BootedDevice,
-    appId: string,
-    container: AppFileContainer,
-    sourcePath: string,
-    destinationPath: string,
-    signal?: AbortSignal
-  ): Promise<void> {
-    const adb = this.deps.adbFactory.create(device);
-    const target = resolveAndroidTarget(appId, container, destinationPath);
+class AndroidAppFileProvider implements AppFileProvider {
+  readonly platform = "android" as const;
+
+  constructor(private readonly adbFactory: AdbClientFactory) {}
+
+  async putFile(request: PutAppFileProviderRequest): Promise<void> {
+    const adb = this.adbFactory.create(request.device);
+    const target = resolveAndroidTarget(request.appId, request.container, request.destinationPath);
     if (target.kind === "unsupported") {
-      throw new ActionableError(target.message);
+      throw unsupportedAppFileOperation("putFile", request.device.platform, request.appId, request.container, target.message);
     }
 
     if (target.kind === "external") {
-      await adb.executeCommand(`shell mkdir -p ${shellQuote(posix.dirname(target.absolutePath))}`, undefined, undefined, true, signal);
-      await adb.executeCommand(`push ${shellQuote(sourcePath)} ${shellQuote(target.absolutePath)}`, undefined, undefined, true, signal);
+      await adb.executeCommand(`shell mkdir -p ${shellQuote(posix.dirname(target.absolutePath))}`, undefined, undefined, true, request.signal);
+      await adb.executeCommand(`push ${shellQuote(request.sourcePath)} ${shellQuote(target.absolutePath)}`, undefined, undefined, true, request.signal);
       return;
     }
 
-    const tempDevicePath = `/data/local/tmp/automobile-${randomUUID()}-${posix.basename(destinationPath)}`;
-    await adb.executeCommand(`push ${shellQuote(sourcePath)} ${shellQuote(tempDevicePath)}`, undefined, undefined, true, signal);
+    const tempDevicePath = `/data/local/tmp/automobile-${randomUUID()}-${posix.basename(request.destinationPath)}`;
+    await adb.executeCommand(`push ${shellQuote(request.sourcePath)} ${shellQuote(tempDevicePath)}`, undefined, undefined, true, request.signal);
     try {
       const command = `mkdir -p ${shellQuote(posix.dirname(target.relativePath))} && ` +
         `cp ${shellQuote(tempDevicePath)} ${shellQuote(target.relativePath)} && ` +
         `chmod 600 ${shellQuote(target.relativePath)}`;
       await adb.executeCommand(
-        `shell run-as ${shellQuote(appId)} sh -c ${shellQuote(command)}`,
+        `shell run-as ${shellQuote(request.appId)} sh -c ${shellQuote(command)}`,
         undefined,
         undefined,
         true,
-        signal
+        request.signal
       );
     } finally {
-      await adb.executeCommand(`shell rm -f ${shellQuote(tempDevicePath)}`, undefined, undefined, true, signal).catch(() => {});
+      await adb.executeCommand(`shell rm -f ${shellQuote(tempDevicePath)}`, undefined, undefined, true, request.signal).catch(() => {});
     }
   }
 
-  private async listAndroidFiles(device: BootedDevice, appId: string, container: AppFileContainer): Promise<AppFileListResult> {
-    const adb = this.deps.adbFactory.create(device);
-    const base = resolveAndroidTarget(appId, container, "placeholder");
+  async listFiles(request: AppFileProviderListRequest): Promise<AppFileListResult> {
+    const adb = this.adbFactory.create(request.device);
+    const base = resolveAndroidTarget(request.appId, request.container, "placeholder");
     if (base.kind === "unsupported") {
-      throw new ActionableError(base.message);
+      throw unsupportedAppFileOperation("listFiles", request.device.platform, request.appId, request.container, base.message);
     }
 
     const stdout = base.kind === "external"
@@ -198,7 +272,7 @@ class DefaultAppFileService implements AppFileService {
         true
       )).stdout
       : (await adb.executeCommand(
-        `shell run-as ${shellQuote(appId)} sh -c ${shellQuote(
+        `shell run-as ${shellQuote(request.appId)} sh -c ${shellQuote(
           `if [ -d ${shellQuote(posix.dirname(base.relativePath))} ]; then find ${shellQuote(posix.dirname(base.relativePath))} -type f; fi`
         )}`,
         undefined,
@@ -214,22 +288,28 @@ class DefaultAppFileService implements AppFileService {
       .map(filePath => filePath.startsWith(`${root}/`) ? filePath.slice(root.length + 1) : filePath)
       .map(path => ({
         path,
-        resourceUri: buildAppFileResourceUri({ deviceId: device.deviceId, appId, container, path }),
+        resourceUri: buildAppFileResourceUri({
+          deviceId: request.device.deviceId,
+          appId: request.appId,
+          container: request.container,
+          path,
+        }),
       }));
 
-    return { deviceId: device.deviceId, platform: device.platform, appId, container, files };
+    return {
+      deviceId: request.device.deviceId,
+      platform: request.device.platform,
+      appId: request.appId,
+      container: request.container,
+      files,
+    };
   }
 
-  private async readAndroidFile(
-    device: BootedDevice,
-    appId: string,
-    container: AppFileContainer,
-    path: string
-  ): Promise<AppFileReadResult> {
-    const adb = this.deps.adbFactory.create(device);
-    const target = resolveAndroidTarget(appId, container, path);
+  async readFile(request: AppFileProviderReadRequest): Promise<AppFileReadResult> {
+    const adb = this.adbFactory.create(request.device);
+    const target = resolveAndroidTarget(request.appId, request.container, request.path);
     if (target.kind === "unsupported") {
-      throw new ActionableError(target.message);
+      throw unsupportedAppFileOperation("readFile", request.device.platform, request.appId, request.container, target.message);
     }
 
     const stdout = target.kind === "external"
@@ -240,90 +320,91 @@ class DefaultAppFileService implements AppFileService {
         true
       )).stdout
       : (await adb.executeCommand(
-        `shell run-as ${shellQuote(appId)} base64 ${shellQuote(target.relativePath)}`,
+        `shell run-as ${shellQuote(request.appId)} base64 ${shellQuote(target.relativePath)}`,
         undefined,
         ANDROID_APP_FILE_MAX_BUFFER,
         true
       )).stdout;
     const blob = stdout.replace(/\s+/g, "");
     return {
-      deviceId: device.deviceId,
-      platform: device.platform,
-      appId,
-      container,
-      path,
+      deviceId: request.device.deviceId,
+      platform: request.device.platform,
+      appId: request.appId,
+      container: request.container,
+      path: request.path,
       byteCount: Buffer.from(blob, "base64").byteLength,
       mimeType: "application/octet-stream",
       blob,
     };
   }
+}
 
-  private async putIosFile(
-    device: BootedDevice,
-    appId: string,
-    container: AppFileContainer,
-    sourcePath: string,
-    destinationPath: string
-  ): Promise<void> {
-    const target = await this.resolveIosPath(device, appId, container, destinationPath);
+class IosSimulatorAppFileProvider implements AppFileProvider {
+  readonly platform = "ios" as const;
+
+  constructor(private readonly simctlFactory: (device: BootedDevice) => SimCtlClient) {}
+
+  async putFile(request: PutAppFileProviderRequest): Promise<void> {
+    const target = await this.resolvePath(request.device, request.appId, request.container, request.destinationPath, "putFile");
     await nodeFs.mkdir(dirname(target), { recursive: true });
-    await nodeFs.copyFile(sourcePath, target);
+    await nodeFs.copyFile(request.sourcePath, target);
   }
 
-  private async listIosFiles(device: BootedDevice, appId: string, container: AppFileContainer): Promise<AppFileListResult> {
-    const root = await this.resolveIosPath(device, appId, container);
+  async listFiles(request: AppFileProviderListRequest): Promise<AppFileListResult> {
+    const root = await this.resolvePath(request.device, request.appId, request.container, undefined, "listFiles");
     const files = await listLocalFiles(root);
     return {
-      deviceId: device.deviceId,
-      platform: device.platform,
-      appId,
-      container,
+      deviceId: request.device.deviceId,
+      platform: request.device.platform,
+      appId: request.appId,
+      container: request.container,
       files: files.map(file => ({
         path: file.path,
         byteCount: file.byteCount,
-        resourceUri: buildAppFileResourceUri({ deviceId: device.deviceId, appId, container, path: file.path }),
+        resourceUri: buildAppFileResourceUri({
+          deviceId: request.device.deviceId,
+          appId: request.appId,
+          container: request.container,
+          path: file.path,
+        }),
       })),
     };
   }
 
-  private async readIosFile(
-    device: BootedDevice,
-    appId: string,
-    container: AppFileContainer,
-    path: string
-  ): Promise<AppFileReadResult> {
-    const target = await this.resolveIosPath(device, appId, container, path);
+  async readFile(request: AppFileProviderReadRequest): Promise<AppFileReadResult> {
+    const target = await this.resolvePath(request.device, request.appId, request.container, request.path, "readFile");
     const buffer = await nodeFs.readFile(target);
     return {
-      deviceId: device.deviceId,
-      platform: device.platform,
-      appId,
-      container,
-      path,
+      deviceId: request.device.deviceId,
+      platform: request.device.platform,
+      appId: request.appId,
+      container: request.container,
+      path: request.path,
       byteCount: buffer.byteLength,
       mimeType: "application/octet-stream",
       blob: buffer.toString("base64"),
     };
   }
 
-  private async resolveIosPath(
+  private async resolvePath(
     device: BootedDevice,
     appId: string,
     container: AppFileContainer,
-    path?: string
+    path: string | undefined,
+    operation: string
   ): Promise<string> {
     if (container === "externalFiles") {
-      throw new ActionableError("externalFiles is not supported for iOS app containers.");
+      throw unsupportedAppFileOperation(operation, device.platform, appId, container, "externalFiles is not available for iOS app containers");
     }
 
-    const simctl = this.deps.simctlFactory(device);
+    const simctl = this.simctlFactory(device);
     const result = await simctl.executeCommand(`get_app_container ${shellQuote(device.deviceId)} ${shellQuote(appId)} data`);
     const dataRoot = result.stdout.trim();
     if (!dataRoot) {
       throw new ActionableError(`Unable to resolve iOS app data container for ${appId} on ${device.deviceId}.`);
     }
 
-    const containerRoot = join(dataRoot, iosContainerRelativePath(container));
+    const containerRoot = join(dataRoot, iosContainerRelativePath(container, operation, appId, device.platform));
     return path === undefined ? containerRoot : join(containerRoot, normalizeAppFileRelativePath(path));
   }
 }
@@ -341,6 +422,32 @@ async function findBootedDevice(deviceId: string): Promise<BootedDevice> {
   return device;
 }
 
+function normalizeAppId(appId: string): string {
+  const normalized = appId.trim();
+  const segments = normalized.split(".");
+  if (
+    normalized.length === 0 ||
+    normalized.includes("/") ||
+    normalized.includes("\\") ||
+    segments.some(segment => segment.length === 0 || segment === "." || segment === "..")
+  ) {
+    throw new ActionableError("appId must be a non-empty app identifier without path separators or traversal segments.");
+  }
+  return normalized;
+}
+
+function unsupportedAppFileOperation(
+  operation: string,
+  platform: Platform,
+  appId: string,
+  container: AppFileContainer,
+  reason: string
+): ActionableError {
+  return new ActionableError(
+    `${operation} is not supported for appId ${appId} in ${container} on ${platform}: ${reason}`
+  );
+}
+
 function shellQuote(value: string): string {
   return `'${value.replace(/'/g, "'\\''")}'`;
 }
@@ -352,7 +459,6 @@ type AndroidTarget =
 
 function resolveAndroidTarget(appId: string, container: AppFileContainer, path: string): AndroidTarget {
   const safePath = normalizeAppFileRelativePath(path);
-  validateAndroidAppIdForPath(appId);
   switch (container) {
     case "documents":
       return { kind: "runAs", relativePath: posix.join("files", safePath) };
@@ -363,23 +469,16 @@ function resolveAndroidTarget(appId: string, container: AppFileContainer, path: 
     case "externalFiles":
       return { kind: "external", absolutePath: `/sdcard/Android/data/${appId}/files/${safePath}` };
     case "library":
-      return { kind: "unsupported", message: "library is not supported for Android app containers. Use documents, cache, tmp, or externalFiles." };
+      return { kind: "unsupported", message: "library is not available for Android app containers. Use documents, cache, tmp, or externalFiles." };
   }
 }
 
-function validateAndroidAppIdForPath(appId: string): void {
-  const segments = appId.split(".");
-  if (
-    appId.length === 0 ||
-    appId.includes("/") ||
-    appId.includes("\\") ||
-    segments.some(segment => segment.length === 0 || segment === "." || segment === "..")
-  ) {
-    throw new ActionableError("appId must not contain path separators or traversal segments.");
-  }
-}
-
-function iosContainerRelativePath(container: AppFileContainer): string {
+function iosContainerRelativePath(
+  container: AppFileContainer,
+  operation: string,
+  appId: string,
+  platform: Platform
+): string {
   switch (container) {
     case "documents":
       return "Documents";
@@ -390,7 +489,7 @@ function iosContainerRelativePath(container: AppFileContainer): string {
     case "tmp":
       return "tmp";
     case "externalFiles":
-      throw new ActionableError("externalFiles is not supported for iOS app containers.");
+      throw unsupportedAppFileOperation(operation, platform, appId, container, "externalFiles is not available for iOS app containers");
   }
 }
 

--- a/src/server/appFileTools.ts
+++ b/src/server/appFileTools.ts
@@ -10,7 +10,7 @@ export function registerAppFileTools(): void {
     "Write a host file, UTF-8 text, or base64 content into an app container. Prefer this over platform-specific copy commands.",
     putAppFileSchema,
     async (device: BootedDevice, args: PutAppFileArgs, _progress, signal) => {
-      const result = await getAppFileService().putFile(device, args, signal);
+      const result = await getAppFileService().putFile({ ...args, device, signal });
       return createJSONToolResponse(result);
     }
   );

--- a/test/server/appFileService.test.ts
+++ b/test/server/appFileService.test.ts
@@ -1,8 +1,15 @@
-import { rm } from "node:fs/promises";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { afterEach, describe, expect, test } from "bun:test";
-import { createAppFileServiceForTesting } from "../../src/server/appFileService";
+import {
+  createAppFileServiceForTesting,
+  type AppFileProvider,
+  type PutAppFileProviderRequest,
+} from "../../src/server/appFileService";
 import type { BootedDevice } from "../../src/models";
 import { FakeAdbClientFactory } from "../fakes/FakeAdbClientFactory";
+import { FakeSimCtlClient } from "../fakes/FakeSimCtlClient";
 
 describe("AppFileService", () => {
   const tempDirs: string[] = [];
@@ -10,6 +17,96 @@ describe("AppFileService", () => {
   afterEach(async () => {
     await Promise.all(tempDirs.map(dir => rm(dir, { recursive: true, force: true })));
     tempDirs.length = 0;
+  });
+
+  test("selects the matching provider and passes normalized put requests", async () => {
+    const androidDevice: BootedDevice = {
+      deviceId: "emulator-5554",
+      name: "Pixel",
+      platform: "android",
+    };
+    const androidProvider = new RecordingAppFileProvider("android");
+    const iosProvider = new RecordingAppFileProvider("ios");
+    const service = createAppFileServiceForTesting({
+      providers: [androidProvider, iosProvider],
+      deviceResolver: async () => {
+        throw new Error("putFile already has a device");
+      },
+    });
+
+    const result = await service.putFile({
+      device: androidDevice,
+      appId: "com.example.app",
+      container: "documents",
+      contentText: "hello",
+      destinationPath: "./fixtures/welcome.txt",
+    });
+
+    expect(result).toMatchObject({
+      success: true,
+      deviceId: "emulator-5554",
+      platform: "android",
+      appId: "com.example.app",
+      container: "documents",
+      destinationPath: "fixtures/welcome.txt",
+      byteCount: 5,
+    });
+    expect(androidProvider.putRequests).toHaveLength(1);
+    expect(androidProvider.putRequests[0]?.destinationPath).toBe("fixtures/welcome.txt");
+    expect(androidProvider.putRequests[0]?.sourcePath).toContain("automobile-app-file-");
+    expect(iosProvider.putRequests).toHaveLength(0);
+  });
+
+  test("rejects unsafe service input before provider selection", async () => {
+    const provider = new RecordingAppFileProvider("android");
+    const service = createAppFileServiceForTesting({
+      providers: [provider],
+      deviceResolver: async () => {
+        throw new Error("device resolver should not be called");
+      },
+    });
+    const device: BootedDevice = {
+      deviceId: "emulator-5554",
+      name: "Pixel",
+      platform: "android",
+    };
+
+    await expect(service.putFile({
+      device,
+      appId: "../com.example.app",
+      container: "documents",
+      contentText: "hello",
+      destinationPath: "fixtures/welcome.txt",
+    })).rejects.toThrow("appId must be a non-empty app identifier without path separators or traversal segments");
+
+    await expect(service.putFile({
+      device,
+      appId: "com.example.app",
+      container: "documents",
+      contentText: "hello",
+      destinationPath: "/absolute.txt",
+    })).rejects.toThrow("destinationPath must be a non-empty relative path without '.' or '..' segments");
+
+    expect(provider.putRequests).toHaveLength(0);
+  });
+
+  test("maps unsupported platform capabilities to explicit operation errors", async () => {
+    const service = createAppFileServiceForTesting({
+      providers: [new RecordingAppFileProvider("android")],
+      deviceResolver: async deviceId => ({
+        deviceId,
+        name: "iPhone",
+        platform: "ios",
+      }),
+    });
+
+    await expect(service.listFiles({
+      deviceId: "sim-1",
+      appId: "com.example.app",
+      container: "documents",
+    })).rejects.toThrow(
+      "listFiles is not supported for appId com.example.app in documents on ios"
+    );
   });
 
   test("writes Android inline content through run-as and returns stable response metadata", async () => {
@@ -26,7 +123,8 @@ describe("AppFileService", () => {
       platform: "android",
     };
 
-    const result = await service.putFile(device, {
+    const result = await service.putFile({
+      device,
       appId: "com.example.app",
       container: "documents",
       contentText: "hello",
@@ -62,13 +160,14 @@ describe("AppFileService", () => {
       simctlFactory: () => {
         throw new Error("simctl not used");
       },
+      deviceResolver: async () => ({ deviceId: "emulator-5554", name: "Pixel", platform: "android" }),
     });
 
-    const result = await (service as any).listAndroidFiles(
-      { deviceId: "emulator-5554", name: "Pixel", platform: "android" },
-      "com.example.app",
-      "documents"
-    );
+    const result = await service.listFiles({
+      deviceId: "emulator-5554",
+      appId: "com.example.app",
+      container: "documents",
+    });
 
     expect(result.files).toEqual([]);
     expect(adbFactory.getFakeClient().getLastCommand()).toContain("if [ -d");
@@ -90,14 +189,78 @@ describe("AppFileService", () => {
       platform: "android",
     };
 
-    await expect(service.putFile(device, {
+    await expect(service.putFile({
+      device,
       appId: "../other.app",
       container: "externalFiles",
       contentText: "hello",
       destinationPath: "fixtures/welcome.txt",
-    })).rejects.toThrow("appId must not contain path separators or traversal segments");
+    })).rejects.toThrow("appId must be a non-empty app identifier without path separators or traversal segments");
 
     expect(adbFactory.getFakeClient().getAllCommands()).toEqual([]);
+  });
+
+  test("writes iOS files through the provider resolved app data container", async () => {
+    const dataRoot = await mkdtemp(join(tmpdir(), "automobile-ios-app-file-"));
+    tempDirs.push(dataRoot);
+    const simctl = new FakeSimCtlClient();
+    simctl.setCommandResult("get_app_container 'SIM-1' 'com.example.app' data", dataRoot);
+    const service = createAppFileServiceForTesting({
+      simctlFactory: () => simctl as any,
+    });
+    const device: BootedDevice = {
+      deviceId: "SIM-1",
+      name: "iPhone",
+      platform: "ios",
+    };
+
+    const result = await service.putFile({
+      device,
+      appId: "com.example.app",
+      container: "library",
+      contentText: "hello ios",
+      destinationPath: "Support/config.txt",
+    });
+
+    expect(result).toMatchObject({
+      success: true,
+      deviceId: "SIM-1",
+      platform: "ios",
+      appId: "com.example.app",
+      container: "library",
+      destinationPath: "Support/config.txt",
+      byteCount: 9,
+    });
+    await expect(readFile(join(dataRoot, "Library", "Support", "config.txt"), "utf8")).resolves.toBe("hello ios");
+  });
+
+  test("maps iOS externalFiles to explicit unsupported capability errors", async () => {
+    const simctl = new FakeSimCtlClient();
+    const service = createAppFileServiceForTesting({
+      simctlFactory: () => simctl as any,
+      deviceResolver: async deviceId => ({ deviceId, name: "iPhone", platform: "ios" }),
+    });
+    const device: BootedDevice = {
+      deviceId: "SIM-1",
+      name: "iPhone",
+      platform: "ios",
+    };
+
+    await expect(service.putFile({
+      device,
+      appId: "com.example.app",
+      container: "externalFiles",
+      contentText: "hello",
+      destinationPath: "config.txt",
+    })).rejects.toThrow("putFile is not supported for appId com.example.app in externalFiles on ios");
+
+    await expect(service.listFiles({
+      deviceId: "SIM-1",
+      appId: "com.example.app",
+      container: "externalFiles",
+    })).rejects.toThrow("listFiles is not supported for appId com.example.app in externalFiles on ios");
+
+    expect(simctl.getMethodCalls("executeCommand")).toHaveLength(0);
   });
 
   test("uses an expanded ADB maxBuffer when reading Android app files as base64", async () => {
@@ -107,15 +270,21 @@ describe("AppFileService", () => {
       simctlFactory: () => {
         throw new Error("simctl not used");
       },
+      deviceResolver: async () => ({ deviceId: "emulator-5554", name: "Pixel", platform: "android" }),
     });
-    const device: BootedDevice = {
-      deviceId: "emulator-5554",
-      name: "Pixel",
-      platform: "android",
-    };
 
-    await (service as any).readAndroidFile(device, "com.example.app", "documents", "screenshots/home.png");
-    await (service as any).readAndroidFile(device, "com.example.app", "externalFiles", "screenshots/home.png");
+    await service.readFile({
+      deviceId: "emulator-5554",
+      appId: "com.example.app",
+      container: "documents",
+      path: "screenshots/home.png",
+    });
+    await service.readFile({
+      deviceId: "emulator-5554",
+      appId: "com.example.app",
+      container: "externalFiles",
+      path: "screenshots/home.png",
+    });
 
     const calls = adbFactory.getFakeClient().getCommandCalls();
     expect(calls).toHaveLength(2);
@@ -132,15 +301,19 @@ describe("AppFileService", () => {
       simctlFactory: () => {
         throw new Error("simctl not used");
       },
+      deviceResolver: async () => ({ deviceId: "emulator-5554", name: "Pixel", platform: "android" }),
     });
-    const device: BootedDevice = {
-      deviceId: "emulator-5554",
-      name: "Pixel",
-      platform: "android",
-    };
 
-    await (service as any).listAndroidFiles(device, "com.example.app", "documents");
-    await (service as any).listAndroidFiles(device, "com.example.app", "externalFiles");
+    await service.listFiles({
+      deviceId: "emulator-5554",
+      appId: "com.example.app",
+      container: "documents",
+    });
+    await service.listFiles({
+      deviceId: "emulator-5554",
+      appId: "com.example.app",
+      container: "externalFiles",
+    });
 
     const calls = adbFactory.getFakeClient().getCommandCalls();
     expect(calls).toHaveLength(2);
@@ -152,3 +325,21 @@ describe("AppFileService", () => {
     expect(calls[1]?.maxBuffer).toBe(calls[0]?.maxBuffer);
   });
 });
+
+class RecordingAppFileProvider implements AppFileProvider {
+  readonly putRequests: PutAppFileProviderRequest[] = [];
+
+  constructor(readonly platform: "android" | "ios") {}
+
+  async putFile(request: PutAppFileProviderRequest): Promise<void> {
+    this.putRequests.push(request);
+  }
+
+  async listFiles(): Promise<never> {
+    throw new Error(`${this.platform} listFiles not supported in fake`);
+  }
+
+  async readFile(): Promise<never> {
+    throw new Error(`${this.platform} readFile not supported in fake`);
+  }
+}

--- a/test/utils/IOSCtrlProxyManager.test.ts
+++ b/test/utils/IOSCtrlProxyManager.test.ts
@@ -134,6 +134,8 @@ describe("IOSCtrlProxyManager", function() {
   });
 
   afterEach(function() {
+    IOSCtrlProxyManager.resetInstances();
+    PortManager.reset();
     PortManager.setPortAvailabilityCheckerForTesting(null);
   });
 


### PR DESCRIPTION
## Summary

- Refactor app-file handling into an `AppFileService` coordinator with Android and iOS `AppFileProvider` implementations.
- Normalize app IDs and relative paths before provider calls, and return explicit unsupported-operation errors with operation, app ID, container, and platform context.
- Add fast provider/validation tests, real iOS-provider fake tests, deterministic iOS CtrlProxy port tests, and developer docs for containers/providers.

## Testing

- `bun test test/server/appFileService.test.ts test/server/appFileTools.test.ts test/server/appFileResources.test.ts test/server/appFileContract.test.ts`
- `bun test test/utils/IOSCtrlProxyManager.test.ts`
- `bun test`
- `bun run lint`
- `bun run build`

Closes #2569
