### PR TITLE
[codex] Reduce default MCP context surface

### DIFF
--- a/schemas/tool-definitions.json
+++ b/schemas/tool-definitions.json
@@ -1,282 +1,7 @@
 [
   {
-    "name": "accessibilityFocus",
-    "description": "Set or clear the Android TalkBack accessibility-focus cursor on a target element (Android only). Provide one selector: resourceId, text, or contentDesc. action defaults to 'set'; pass 'clear' to clear the cursor.",
-    "inputSchema": {
-      "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "type": "object",
-      "properties": {
-        "action": {
-          "description": "Set (default) or clear the accessibility (TalkBack) focus cursor",
-          "type": "string",
-          "enum": [
-            "set",
-            "clear"
-          ]
-        },
-        "resourceId": {
-          "description": "Resource ID of the target element, e.g. com.example:id/title",
-          "type": "string"
-        },
-        "text": {
-          "description": "Text of the target element (resolved to a resource-id via the element finder)",
-          "type": "string"
-        },
-        "contentDesc": {
-          "description": "Content description of the target element (resolved to a resource-id)",
-          "type": "string"
-        },
-        "platform": {
-          "type": "string",
-          "enum": [
-            "android",
-            "ios"
-          ],
-          "description": "Target platform"
-        },
-        "sessionUuid": {
-          "description": "Session ID",
-          "type": "string"
-        },
-        "keepScreenAwake": {
-          "description": "Keep device awake",
-          "type": "boolean"
-        },
-        "device": {
-          "description": "Plan device label",
-          "type": "string"
-        },
-        "deviceId": {
-          "description": "Device ID",
-          "type": "string"
-        }
-      },
-      "additionalProperties": false
-    },
-    "outputSchema": {
-      "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "type": "object",
-      "properties": {
-        "success": {
-          "type": "boolean"
-        },
-        "error": {
-          "type": "string"
-        },
-        "warning": {
-          "type": "string"
-        },
-        "focusedElement": {
-          "type": "object",
-          "properties": {
-            "bounds": {
-              "type": "object",
-              "properties": {
-                "left": {
-                  "type": "integer",
-                  "minimum": -9007199254740991,
-                  "maximum": 9007199254740991
-                },
-                "top": {
-                  "type": "integer",
-                  "minimum": -9007199254740991,
-                  "maximum": 9007199254740991
-                },
-                "right": {
-                  "type": "integer",
-                  "minimum": -9007199254740991,
-                  "maximum": 9007199254740991
-                },
-                "bottom": {
-                  "type": "integer",
-                  "minimum": -9007199254740991,
-                  "maximum": 9007199254740991
-                },
-                "centerX": {
-                  "type": "integer",
-                  "minimum": -9007199254740991,
-                  "maximum": 9007199254740991
-                },
-                "centerY": {
-                  "type": "integer",
-                  "minimum": -9007199254740991,
-                  "maximum": 9007199254740991
-                }
-              },
-              "required": [
-                "left",
-                "top",
-                "right",
-                "bottom"
-              ],
-              "additionalProperties": false
-            },
-            "text": {
-              "type": "string"
-            },
-            "resource-id": {
-              "type": "string"
-            },
-            "content-desc": {
-              "type": "string"
-            },
-            "class": {
-              "type": "string"
-            },
-            "package": {
-              "type": "string"
-            },
-            "checkable": {
-              "anyOf": [
-                {
-                  "type": "boolean"
-                },
-                {
-                  "type": "string",
-                  "const": "true"
-                },
-                {
-                  "type": "string",
-                  "const": "false"
-                }
-              ]
-            },
-            "checked": {
-              "anyOf": [
-                {
-                  "type": "boolean"
-                },
-                {
-                  "type": "string",
-                  "const": "true"
-                },
-                {
-                  "type": "string",
-                  "const": "false"
-                }
-              ]
-            },
-            "clickable": {
-              "anyOf": [
-                {
-                  "type": "boolean"
-                },
-                {
-                  "type": "string",
-                  "const": "true"
-                },
-                {
-                  "type": "string",
-                  "const": "false"
-                }
-              ]
-            },
-            "enabled": {
-              "anyOf": [
-                {
-                  "type": "boolean"
-                },
-                {
-                  "type": "string",
-                  "const": "true"
-                },
-                {
-                  "type": "string",
-                  "const": "false"
-                }
-              ]
-            },
-            "focusable": {
-              "anyOf": [
-                {
-                  "type": "boolean"
-                },
-                {
-                  "type": "string",
-                  "const": "true"
-                },
-                {
-                  "type": "string",
-                  "const": "false"
-                }
-              ]
-            },
-            "focused": {
-              "anyOf": [
-                {
-                  "type": "boolean"
-                },
-                {
-                  "type": "string",
-                  "const": "true"
-                },
-                {
-                  "type": "string",
-                  "const": "false"
-                }
-              ]
-            },
-            "accessibility-focused": {
-              "anyOf": [
-                {
-                  "type": "boolean"
-                },
-                {
-                  "type": "string",
-                  "const": "true"
-                },
-                {
-                  "type": "string",
-                  "const": "false"
-                }
-              ]
-            },
-            "scrollable": {
-              "anyOf": [
-                {
-                  "type": "boolean"
-                },
-                {
-                  "type": "string",
-                  "const": "true"
-                },
-                {
-                  "type": "string",
-                  "const": "false"
-                }
-              ]
-            },
-            "selected": {
-              "anyOf": [
-                {
-                  "type": "boolean"
-                },
-                {
-                  "type": "string",
-                  "const": "true"
-                },
-                {
-                  "type": "string",
-                  "const": "false"
-                }
-              ]
-            }
-          },
-          "required": [
-            "bounds"
-          ],
-          "additionalProperties": {}
-        }
-      },
-      "required": [
-        "success"
-      ],
-      "additionalProperties": {}
-    }
-  },
-  {
     "name": "biometricAuth",
-    "description": "Simulate biometric authentication on Android emulators (fingerprint) and the iOS Simulator (Touch ID / Face ID via BiometricKit), or inject a deterministic result via the AutoMobile SDK on any Android device. Supports match/fail on both platforms; cancel/error require the AutoMobileBiometrics SDK (Android only). Physical iOS devices are not supported (no public biometric-injection API).",
+    "description": "Simulate biometric auth: Android emulator/SDK hook or iOS Simulator.",
     "inputSchema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "type": "object",
@@ -289,10 +14,10 @@
             "cancel",
             "error"
           ],
-          "description": "Biometric action: 'match' triggers successful authentication, 'fail' simulates a non-matching biometric, 'cancel' cancels the prompt, 'error' injects a hard error (requires AutoMobileBiometrics SDK integration in the app)."
+          "description": "match/fail/cancel/error; cancel/error require Android SDK hook"
         },
         "modality": {
-          "description": "Biometric modality (default: 'any'). Android emulators reliably support only 'fingerprint'. iOS Simulator supports both: 'fingerprint' -> Touch ID, 'face' -> Face ID, 'any' posts both (the simulator's non-enrolled biometry is a no-op).",
+          "description": "Modality: any default, fingerprint, or face",
           "type": "string",
           "enum": [
             "any",
@@ -301,15 +26,15 @@
           ]
         },
         "fingerprintId": {
-          "description": "Fingerprint ID to simulate (default: 1 for 'match'/'error', 2 for 'fail'/'cancel'). Use enrolled ID (typically 1) for match/error, non-enrolled ID (typically 2) for fail/cancel.",
+          "description": "Fingerprint ID: default 1 for match/error, 2 for fail/cancel",
           "type": "number"
         },
         "errorCode": {
-          "description": "BiometricPrompt error code to inject (e.g. 7 for ERROR_LOCKOUT, 1 for ERROR_HW_UNAVAILABLE). Only valid when action is 'error'; providing it with any other action is a validation error.",
+          "description": "BiometricPrompt error code; action=error only",
           "type": "number"
         },
         "ttlMs": {
-          "description": "How long the SDK override remains active in milliseconds (default: 5000). The override is cleared after the first authentication callback or when the TTL expires.",
+          "description": "SDK override TTL ms (default 5000)",
           "type": "number"
         },
         "platform": {
@@ -317,23 +42,20 @@
           "enum": [
             "android",
             "ios"
-          ],
-          "description": "Target platform"
+          ]
         },
         "sessionUuid": {
-          "description": "Session ID",
+          "description": "Session",
           "type": "string"
         },
         "keepScreenAwake": {
-          "description": "Keep device awake",
           "type": "boolean"
         },
         "device": {
-          "description": "Plan device label",
+          "description": "Device label",
           "type": "string"
         },
         "deviceId": {
-          "description": "Device ID",
           "type": "string"
         }
       },
@@ -355,8 +77,7 @@
           "enum": [
             "android",
             "ios"
-          ],
-          "description": "Target platform"
+          ]
         },
         "locale": {
           "description": "Locale tag (e.g., ar-SA, ja-JP)",
@@ -395,19 +116,17 @@
           "minLength": 1
         },
         "sessionUuid": {
-          "description": "Session ID",
+          "description": "Session",
           "type": "string"
         },
         "keepScreenAwake": {
-          "description": "Keep device awake",
           "type": "boolean"
         },
         "device": {
-          "description": "Plan device label",
+          "description": "Device label",
           "type": "string"
         },
         "deviceId": {
-          "description": "Device ID",
           "type": "string"
         }
       },
@@ -429,23 +148,20 @@
           "enum": [
             "android",
             "ios"
-          ],
-          "description": "Target platform"
+          ]
         },
         "sessionUuid": {
-          "description": "Session ID",
+          "description": "Session",
           "type": "string"
         },
         "keepScreenAwake": {
-          "description": "Keep device awake",
           "type": "boolean"
         },
         "device": {
-          "description": "Plan device label",
+          "description": "Device label",
           "type": "string"
         },
         "deviceId": {
-          "description": "Device ID",
           "type": "string"
         }
       },
@@ -464,7 +180,7 @@
       "properties": {
         "action": {
           "type": "string",
-          "description": "Clipboard action: copy=set clipboard, paste=paste into focused field, clear=clear clipboard, get=get clipboard content",
+          "description": "Clipboard action",
           "enum": [
             "copy",
             "paste",
@@ -482,23 +198,20 @@
           "enum": [
             "android",
             "ios"
-          ],
-          "description": "Target platform"
+          ]
         },
         "sessionUuid": {
-          "description": "Session ID",
+          "description": "Session",
           "type": "string"
         },
         "keepScreenAwake": {
-          "description": "Keep device awake",
           "type": "boolean"
         },
         "device": {
-          "description": "Plan device label",
+          "description": "Device label",
           "type": "string"
         },
         "deviceId": {
-          "description": "Device ID",
           "type": "string"
         }
       },
@@ -526,14 +239,14 @@
   },
   {
     "name": "criticalSection",
-    "description": "Coordinate multiple devices at a synchronization barrier and execute steps serially. All devices must reach the critical section before any can proceed. Steps execute one device at a time in the order they acquire the lock.",
+    "description": "Synchronize multiple devices at a barrier, then run steps serially.",
     "inputSchema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "type": "object",
       "properties": {
         "lock": {
           "type": "string",
-          "description": "Global lock identifier. All devices using the same lock name will wait for each other at this barrier."
+          "description": "Shared barrier lock name"
         },
         "steps": {
           "minItems": 1,
@@ -543,7 +256,7 @@
             "properties": {
               "tool": {
                 "type": "string",
-                "description": "Tool name to execute"
+                "description": "Tool name"
               },
               "params": {
                 "type": "object",
@@ -551,10 +264,10 @@
                   "type": "string"
                 },
                 "additionalProperties": {},
-                "description": "Tool-specific parameters. Must include a non-empty 'device'."
+                "description": "Tool params; must include device"
               },
               "label": {
-                "description": "Optional human-readable label",
+                "description": "Step label",
                 "type": "string"
               }
             },
@@ -564,16 +277,16 @@
             ],
             "additionalProperties": {}
           },
-          "description": "Steps to execute serially within the critical section. Each step should target a specific device using the 'device' parameter."
+          "description": "Serial steps; each needs params.device"
         },
         "deviceCount": {
           "type": "integer",
           "exclusiveMinimum": 0,
           "maximum": 9007199254740991,
-          "description": "Number of devices expected to reach this critical section. All devices must arrive before any can proceed."
+          "description": "Devices required at barrier"
         },
         "timeout": {
-          "description": "Timeout in milliseconds for waiting at the barrier (default: 30000ms)",
+          "description": "Barrier timeout ms (default 30000)",
           "type": "integer",
           "exclusiveMinimum": 0,
           "maximum": 9007199254740991
@@ -589,46 +302,45 @@
   },
   {
     "name": "deviceSnapshot",
-    "description": "Capture or restore a device snapshot for the active device.",
+    "description": "Capture or restore device snapshot.",
     "inputSchema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "type": "object",
       "properties": {
         "action": {
           "type": "string",
-          "description": "Action to perform",
           "enum": [
             "capture",
             "restore"
           ]
         },
         "snapshotName": {
-          "description": "Name for the snapshot",
+          "description": "Snapshot name",
           "type": "string",
           "minLength": 1
         },
         "includeAppData": {
-          "description": "Include app data directories in snapshot",
+          "description": "Include app data",
           "type": "boolean"
         },
         "includeSettings": {
-          "description": "Include system settings in snapshot",
+          "description": "Include settings",
           "type": "boolean"
         },
         "useVmSnapshot": {
-          "description": "Use emulator VM snapshot if available (faster, emulator only)",
+          "description": "Use emulator VM snapshot",
           "type": "boolean"
         },
         "strictBackupMode": {
-          "description": "If true, fail entire snapshot if app data backup fails or times out",
+          "description": "Fail if app data backup fails",
           "type": "boolean"
         },
         "backupTimeoutMs": {
-          "description": "Timeout in milliseconds for adb backup user confirmation",
+          "description": "adb backup confirmation timeout ms",
           "type": "number"
         },
         "userApps": {
-          "description": "Which apps to backup: 'current' (foreground app only) or 'all' (all user-installed apps)",
+          "description": "Apps to back up: current or all",
           "type": "string",
           "enum": [
             "current",
@@ -636,11 +348,11 @@
           ]
         },
         "vmSnapshotTimeoutMs": {
-          "description": "Timeout in milliseconds for emulator VM snapshot commands",
+          "description": "VM snapshot timeout ms",
           "type": "number"
         },
         "appBundleIds": {
-          "description": "iOS-only: bundle IDs to include in app data snapshots (omit to skip app data capture)",
+          "description": "iOS bundle IDs for app data snapshot",
           "type": "array",
           "items": {
             "type": "string"
@@ -651,23 +363,20 @@
           "enum": [
             "android",
             "ios"
-          ],
-          "description": "Target platform"
+          ]
         },
         "sessionUuid": {
-          "description": "Session ID",
+          "description": "Session",
           "type": "string"
         },
         "keepScreenAwake": {
-          "description": "Keep device awake",
           "type": "boolean"
         },
         "device": {
-          "description": "Plan device label",
+          "description": "Device label",
           "type": "string"
         },
         "deviceId": {
-          "description": "Device ID",
           "type": "string"
         }
       },
@@ -694,7 +403,7 @@
   },
   {
     "name": "doctor",
-    "description": "Run diagnostic checks to verify AutoMobile setup and environment configuration",
+    "description": "Run AutoMobile setup diagnostics",
     "inputSchema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "type": "object",
@@ -708,7 +417,7 @@
           "type": "boolean"
         },
         "installCmdlineTools": {
-          "description": "Automatically download and install Android SDK Command-line Tools to ANDROID_HOME if missing",
+          "description": "Install missing Android SDK cmdline tools",
           "type": "boolean"
         },
         "installXcodeCommandLineTools": {
@@ -811,23 +520,20 @@
           "enum": [
             "android",
             "ios"
-          ],
-          "description": "Target platform"
+          ]
         },
         "sessionUuid": {
-          "description": "Session ID",
+          "description": "Session",
           "type": "string"
         },
         "keepScreenAwake": {
-          "description": "Keep device awake",
           "type": "boolean"
         },
         "device": {
-          "description": "Plan device label",
+          "description": "Device label",
           "type": "string"
         },
         "deviceId": {
-          "description": "Device ID",
           "type": "string"
         }
       },
@@ -841,7 +547,7 @@
   },
   {
     "name": "executePlan",
-    "description": "Execute a series of tool calls from a YAML plan content. Stops execution if any step fails (success: false). Optionally can resume execution from a specific step index.",
+    "description": "Execute YAML plan steps; stops on first failed step.",
     "inputSchema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "type": "object",
@@ -852,7 +558,7 @@
         },
         "startStep": {
           "default": 0,
-          "description": "Start step index (0-based, default: 0)",
+          "description": "Start step index",
           "type": "number"
         },
         "platform": {
@@ -860,27 +566,24 @@
           "enum": [
             "android",
             "ios"
-          ],
-          "description": "Target platform"
+          ]
         },
         "sessionUuid": {
-          "description": "Session UUID for parallel execution",
+          "description": "Session",
           "type": "string"
         },
         "keepScreenAwake": {
-          "description": "Keep device awake",
           "type": "boolean"
         },
         "deviceId": {
-          "description": "Device ID",
           "type": "string"
         },
         "device": {
-          "description": "Plan device label",
+          "description": "Device label",
           "type": "string"
         },
         "devices": {
-          "description": "Device labels for multi-device plans",
+          "description": "Device labels",
           "type": "array",
           "items": {
             "type": "string"
@@ -888,12 +591,12 @@
         },
         "deviceAllocationTimeoutMs": {
           "default": 300000,
-          "description": "Timeout in milliseconds for allocating all devices (default: 300000 = 5 minutes)",
+          "description": "Allocation timeout ms",
           "type": "number"
         },
         "abortStrategy": {
           "default": "immediate",
-          "description": "Abort strategy: immediate (default) or finish-current-step",
+          "description": "Abort strategy",
           "type": "string",
           "enum": [
             "immediate",
@@ -901,7 +604,7 @@
           ]
         },
         "testMetadata": {
-          "description": "Test metadata for timing history",
+          "description": "Test metadata",
           "type": "object",
           "properties": {
             "testClass": {
@@ -941,15 +644,15 @@
           "additionalProperties": false
         },
         "cleanupAppId": {
-          "description": "App ID to terminate after execution",
+          "description": "Cleanup app ID",
           "type": "string"
         },
         "cleanupClearAppData": {
-          "description": "Clear app data on cleanup",
+          "description": "Clear app data",
           "type": "boolean"
         },
         "captureObserveSteps": {
-          "description": "Single-device plans only: attach each successful observe step snapshot to executePlan result `debug.steps[n].details.stepObservation` (`summary` = metadata + element samples; `full` = includes viewHierarchy). Ignored for multi-device plans.",
+          "description": "Attach observe snapshots",
           "type": "string",
           "enum": [
             "summary",
@@ -1017,8 +720,7 @@
           "enum": [
             "android",
             "ios"
-          ],
-          "description": "Target platform"
+          ]
         },
         "deviceId": {
           "type": "string"
@@ -1101,17 +803,17 @@
   },
   {
     "name": "exportPlan",
-    "description": "Stop the active test recording and export recorded interactions as a YAML plan. Returns the plan content.",
+    "description": "Stop active recording and export a YAML plan.",
     "inputSchema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "type": "object",
       "properties": {
         "recordingId": {
-          "description": "Recording ID to export (uses active recording if not specified)",
+          "description": "Recording ID",
           "type": "string"
         },
         "planName": {
-          "description": "Name for the exported plan (auto-generated if not specified)",
+          "description": "Plan name",
           "type": "string"
         }
       },
@@ -1161,8 +863,7 @@
       "type": "object",
       "properties": {
         "appId": {
-          "type": "string",
-          "description": "App package ID or bundle identifier"
+          "type": "string"
         },
         "permissions": {
           "description": "Optional permissions or simulator privacy services to query",
@@ -1177,23 +878,20 @@
           "enum": [
             "android",
             "ios"
-          ],
-          "description": "Target platform"
+          ]
         },
         "sessionUuid": {
-          "description": "Session ID",
+          "description": "Session",
           "type": "string"
         },
         "keepScreenAwake": {
-          "description": "Keep device awake",
           "type": "boolean"
         },
         "device": {
-          "description": "Plan device label",
+          "description": "Device label",
           "type": "string"
         },
         "deviceId": {
-          "description": "Device ID",
           "type": "string"
         }
       },
@@ -1205,37 +903,33 @@
   },
   {
     "name": "getDeepLinks",
-    "description": "Query deep links for app",
+    "description": "Query app deep links",
     "inputSchema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "type": "object",
       "properties": {
         "appId": {
-          "type": "string",
-          "description": "App package ID"
+          "type": "string"
         },
         "platform": {
           "type": "string",
           "enum": [
             "android",
             "ios"
-          ],
-          "description": "Target platform"
+          ]
         },
         "sessionUuid": {
-          "description": "Session ID",
+          "description": "Session",
           "type": "string"
         },
         "keepScreenAwake": {
-          "description": "Keep device awake",
           "type": "boolean"
         },
         "device": {
-          "description": "Plan device label",
+          "description": "Device label",
           "type": "string"
         },
         "deviceId": {
-          "description": "Device ID",
           "type": "string"
         }
       },
@@ -1253,7 +947,7 @@
       "type": "object",
       "properties": {
         "include": {
-          "description": "Optional device state fields to read. Currently supports doNotDisturb.",
+          "description": "State fields to read; supports doNotDisturb",
           "type": "array",
           "items": {
             "type": "string",
@@ -1267,23 +961,20 @@
           "enum": [
             "android",
             "ios"
-          ],
-          "description": "Target platform"
+          ]
         },
         "sessionUuid": {
-          "description": "Session ID",
+          "description": "Session",
           "type": "string"
         },
         "keepScreenAwake": {
-          "description": "Keep device awake",
           "type": "boolean"
         },
         "device": {
-          "description": "Plan device label",
+          "description": "Device label",
           "type": "string"
         },
         "deviceId": {
-          "description": "Device ID",
           "type": "string"
         }
       },
@@ -1292,38 +983,34 @@
   },
   {
     "name": "getNotificationPolicy",
-    "description": "Read app notification policy state, including Android Do Not Disturb policy access",
+    "description": "Read app notification/DND policy state",
     "inputSchema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "type": "object",
       "properties": {
         "appId": {
           "type": "string",
-          "minLength": 1,
-          "description": "App package ID or bundle identifier"
+          "minLength": 1
         },
         "platform": {
           "type": "string",
           "enum": [
             "android",
             "ios"
-          ],
-          "description": "Target platform"
+          ]
         },
         "sessionUuid": {
-          "description": "Session ID",
+          "description": "Session",
           "type": "string"
         },
         "keepScreenAwake": {
-          "description": "Keep device awake",
           "type": "boolean"
         },
         "device": {
-          "description": "Plan device label",
+          "description": "Device label",
           "type": "string"
         },
         "deviceId": {
-          "description": "Device ID",
           "type": "string"
         }
       },
@@ -1335,7 +1022,7 @@
   },
   {
     "name": "highlight",
-    "description": "Draw a visual highlight around a UI element on the device screen for debugging.",
+    "description": "Draw a visual highlight around a UI element.",
     "inputSchema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "type": "object",
@@ -1345,11 +1032,9 @@
           "enum": [
             "android",
             "ios"
-          ],
-          "description": "Target platform"
+          ]
         },
         "deviceId": {
-          "description": "Device ID",
           "type": "string"
         },
         "timeoutMs": {
@@ -1930,14 +1615,14 @@
         },
         "elementId": {
           "type": "string",
-          "description": "Element resource-id (e.g. \"com.app:id/btn_login\"). Only use for resource-id values."
+          "description": "Resource ID, e.g. com.app:id/btn_login"
         },
         "text": {
           "type": "string",
-          "description": "Element text, content-desc, or placeholder value from observe output."
+          "description": "Text, content-desc, or placeholder"
         },
         "container": {
-          "description": "Container selector object to scope search. Provide { \"elementId\": \"<id>\" } or { \"text\": \"<text>\" }.",
+          "description": "Scope search to a container",
           "anyOf": [
             {
               "type": "object",
@@ -1968,11 +1653,11 @@
           ]
         },
         "containerOf": {
-          "description": "Whether to highlight the container of the selected element",
+          "description": "Highlight selected element's container",
           "type": "boolean"
         },
         "selectionStrategy": {
-          "description": "Element selection strategy when multiple matches are found (default: first)",
+          "description": "Selection strategy when multiple match (default: first)",
           "type": "string",
           "enum": [
             "first",
@@ -1980,15 +1665,14 @@
           ]
         },
         "sessionUuid": {
-          "description": "Session ID",
+          "description": "Session",
           "type": "string"
         },
         "keepScreenAwake": {
-          "description": "Keep device awake",
           "type": "boolean"
         },
         "device": {
-          "description": "Plan device label",
+          "description": "Device label",
           "type": "string"
         }
       },
@@ -2010,23 +1694,20 @@
           "enum": [
             "android",
             "ios"
-          ],
-          "description": "Target platform"
+          ]
         },
         "sessionUuid": {
-          "description": "Session ID",
+          "description": "Session",
           "type": "string"
         },
         "keepScreenAwake": {
-          "description": "Keep device awake",
           "type": "boolean"
         },
         "device": {
-          "description": "Plan device label",
+          "description": "Device label",
           "type": "string"
         },
         "deviceId": {
-          "description": "Device ID",
           "type": "string"
         }
       },
@@ -2060,23 +1741,20 @@
           "enum": [
             "android",
             "ios"
-          ],
-          "description": "Target platform"
+          ]
         },
         "sessionUuid": {
-          "description": "Session ID",
+          "description": "Session",
           "type": "string"
         },
         "keepScreenAwake": {
-          "description": "Keep device awake",
           "type": "boolean"
         },
         "device": {
-          "description": "Plan device label",
+          "description": "Device label",
           "type": "string"
         },
         "deviceId": {
-          "description": "Device ID",
           "type": "string"
         }
       },
@@ -2096,11 +1774,10 @@
       "properties": {
         "text": {
           "type": "string",
-          "minLength": 1,
-          "description": "Text to input"
+          "minLength": 1
         },
         "mode": {
-          "description": "(Android only; ignored on iOS) Text input mode. a11y (default) sets text directly. eventLast sets text with a11y up to the last printable non-whitespace ASCII character, sends that character as a real key event, then restores any suffix with a11y. eventAll clears the field with a11y, sends key events for mappable ASCII characters, and uses a11y for Unicode/emoji runs. Search fields that use autocomplete should probably try eventLast; otherwise accept the default.",
+          "description": "Android text mode: a11y default; eventLast helps autocomplete; eventAll sends key events",
           "type": "string",
           "enum": [
             "a11y",
@@ -2121,7 +1798,7 @@
           ]
         },
         "dismissKeyboard": {
-          "description": "(Android only) Dismiss soft keyboard after input (default: false). Ignored on iOS.",
+          "description": "Android: dismiss keyboard after input",
           "type": "boolean"
         },
         "platform": {
@@ -2129,23 +1806,20 @@
           "enum": [
             "android",
             "ios"
-          ],
-          "description": "Target platform"
+          ]
         },
         "sessionUuid": {
-          "description": "Session ID",
+          "description": "Session",
           "type": "string"
         },
         "keepScreenAwake": {
-          "description": "Keep device awake",
           "type": "boolean"
         },
         "device": {
-          "description": "Plan device label",
+          "description": "Device label",
           "type": "string"
         },
         "deviceId": {
-          "description": "Device ID",
           "type": "string"
         }
       },
@@ -2158,37 +1832,34 @@
   },
   {
     "name": "installApp",
-    "description": "Install app on device (.apk for Android, .app for iOS simulator, .ipa for iOS physical device)",
+    "description": "Install app on device (.apk, .app, or .ipa)",
     "inputSchema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "type": "object",
       "properties": {
         "artifactPath": {
           "type": "string",
-          "description": "Path to app artifact (.apk for Android, .app bundle for iOS simulator, .ipa for iOS physical device)"
+          "description": "App artifact path (.apk, .app, or .ipa)"
         },
         "platform": {
           "type": "string",
           "enum": [
             "android",
             "ios"
-          ],
-          "description": "Target platform"
+          ]
         },
         "sessionUuid": {
-          "description": "Session ID",
+          "description": "Session",
           "type": "string"
         },
         "keepScreenAwake": {
-          "description": "Keep device awake",
           "type": "boolean"
         },
         "device": {
-          "description": "Plan device label",
+          "description": "Device label",
           "type": "string"
         },
         "deviceId": {
-          "description": "Device ID",
           "type": "string"
         }
       },
@@ -2219,23 +1890,20 @@
           "enum": [
             "android",
             "ios"
-          ],
-          "description": "Target platform"
+          ]
         },
         "sessionUuid": {
-          "description": "Session ID",
+          "description": "Session",
           "type": "string"
         },
         "keepScreenAwake": {
-          "description": "Keep device awake",
           "type": "boolean"
         },
         "device": {
-          "description": "Plan device label",
+          "description": "Device label",
           "type": "string"
         },
         "deviceId": {
-          "description": "Device ID",
           "type": "string"
         }
       },
@@ -2261,16 +1929,14 @@
               "description": "Device image name"
             },
             "deviceId": {
-              "type": "string",
-              "description": "Device ID"
+              "type": "string"
             },
             "platform": {
               "type": "string",
               "enum": [
                 "android",
                 "ios"
-              ],
-              "description": "Target platform"
+              ]
             }
           },
           "required": [
@@ -2295,8 +1961,7 @@
       "type": "object",
       "properties": {
         "appId": {
-          "type": "string",
-          "description": "App package ID"
+          "type": "string"
         },
         "clearAppData": {
           "description": "Clear app data before launch (default false)",
@@ -2311,23 +1976,20 @@
           "enum": [
             "android",
             "ios"
-          ],
-          "description": "Target platform"
+          ]
         },
         "sessionUuid": {
-          "description": "Session ID",
+          "description": "Session",
           "type": "string"
         },
         "keepScreenAwake": {
-          "description": "Keep device awake",
           "type": "boolean"
         },
         "device": {
-          "description": "Plan device label",
+          "description": "Device label",
           "type": "string"
         },
         "deviceId": {
-          "description": "Device ID",
           "type": "string"
         }
       },
@@ -2359,8 +2021,7 @@
           "enum": [
             "android",
             "ios"
-          ],
-          "description": "Target platform"
+          ]
         }
       },
       "required": [
@@ -2381,8 +2042,7 @@
           "enum": [
             "android",
             "ios"
-          ],
-          "description": "Target platform"
+          ]
         }
       },
       "additionalProperties": false
@@ -2400,8 +2060,7 @@
           "enum": [
             "android",
             "ios"
-          ],
-          "description": "Target platform"
+          ]
         },
         "waitFor": {
           "description": "Wait for element to appear before returning observation",
@@ -2418,7 +2077,7 @@
                   "type": "number"
                 },
                 "container": {
-                  "description": "Scope the match inside this container. Use when resource IDs repeat (e.g. id/name in a RecyclerView).",
+                  "description": "Scope match to a container",
                   "anyOf": [
                     {
                       "type": "object",
@@ -2466,7 +2125,7 @@
                   "type": "number"
                 },
                 "container": {
-                  "description": "Scope the match inside this container. Use when resource IDs repeat (e.g. id/name in a RecyclerView).",
+                  "description": "Scope match to a container",
                   "anyOf": [
                     {
                       "type": "object",
@@ -2505,27 +2164,25 @@
           ]
         },
         "raw": {
-          "description": "When true, include unprocessed view hierarchy in response alongside normal output (default: false)",
+          "description": "Include raw view hierarchy",
           "type": "boolean"
         },
         "skipBackStack": {
-          "description": "When true, skip back stack collection during waitFor polling to reduce ADB overhead (default: false)",
+          "description": "Skip back stack during waitFor polling",
           "type": "boolean"
         },
         "sessionUuid": {
-          "description": "Session ID",
+          "description": "Session",
           "type": "string"
         },
         "keepScreenAwake": {
-          "description": "Keep device awake",
           "type": "boolean"
         },
         "device": {
-          "description": "Plan device label",
+          "description": "Device label",
           "type": "string"
         },
         "deviceId": {
-          "description": "Device ID",
           "type": "string"
         }
       },
@@ -2551,23 +2208,20 @@
           "enum": [
             "android",
             "ios"
-          ],
-          "description": "Target platform"
+          ]
         },
         "sessionUuid": {
-          "description": "Session ID",
+          "description": "Session",
           "type": "string"
         },
         "keepScreenAwake": {
-          "description": "Keep device awake",
           "type": "boolean"
         },
         "device": {
-          "description": "Plan device label",
+          "description": "Device label",
           "type": "string"
         },
         "deviceId": {
-          "description": "Device ID",
           "type": "string"
         }
       },
@@ -2580,7 +2234,7 @@
   },
   {
     "name": "phoneCall",
-    "description": "Simulate an incoming phone call on an Android emulator via the emulator console (gsm call/accept/cancel/busy/hold). Emulator-only: physical devices return an unsupported error.",
+    "description": "Simulate Android emulator phone call via gsm commands.",
     "inputSchema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "type": "object",
@@ -2594,10 +2248,10 @@
             "busy",
             "hold"
           ],
-          "description": "Phone call action: 'call' simulates an incoming call; 'accept' answers a ringing or waiting call; 'cancel' ends the call from the network side; 'busy' rejects a waiting call with a busy signal; 'hold' puts the active call on hold (no phoneNumber required)."
+          "description": "call/accept/cancel/busy/hold; hold needs no phoneNumber"
         },
         "phoneNumber": {
-          "description": "Phone number for the call action. Required for all actions except 'hold'. Digits with optional leading '+', max 20 digits.",
+          "description": "Phone number; required except for hold",
           "type": "string"
         },
         "platform": {
@@ -2605,23 +2259,20 @@
           "enum": [
             "android",
             "ios"
-          ],
-          "description": "Target platform"
+          ]
         },
         "sessionUuid": {
-          "description": "Session ID",
+          "description": "Session",
           "type": "string"
         },
         "keepScreenAwake": {
-          "description": "Keep device awake",
           "type": "boolean"
         },
         "device": {
-          "description": "Plan device label",
+          "description": "Device label",
           "type": "string"
         },
         "deviceId": {
-          "description": "Device ID",
           "type": "string"
         }
       },
@@ -2671,7 +2322,7 @@
           "type": "boolean"
         },
         "container": {
-          "description": "Container selector object to scope search. Provide { \"elementId\": \"<id>\" } or { \"text\": \"<text>\" }.",
+          "description": "Scope search to a container",
           "anyOf": [
             {
               "type": "object",
@@ -2710,23 +2361,20 @@
           "enum": [
             "android",
             "ios"
-          ],
-          "description": "Target platform"
+          ]
         },
         "sessionUuid": {
-          "description": "Session ID",
+          "description": "Session",
           "type": "string"
         },
         "keepScreenAwake": {
-          "description": "Keep device awake",
           "type": "boolean"
         },
         "device": {
-          "description": "Plan device label",
+          "description": "Device label",
           "type": "string"
         },
         "deviceId": {
-          "description": "Device ID",
           "type": "string"
         }
       },
@@ -2739,7 +2387,7 @@
   },
   {
     "name": "postNotification",
-    "description": "Post a notification: on Android, from the app-under-test when AutoMobile SDK hooks are installed; on the iOS Simulator, deliver a simulated remote push to the given bundle id via 'simctl push' (requires appId; physical iOS devices unsupported).",
+    "description": "Post notification via Android SDK hooks or iOS Simulator simctl push.",
     "inputSchema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "type": "object",
@@ -2763,11 +2411,11 @@
           ]
         },
         "imagePath": {
-          "description": "Host image file path to push to /sdcard/Download/automobile when imageType is bigPicture",
+          "description": "Host image path for bigPicture",
           "type": "string"
         },
         "actions": {
-          "description": "Action buttons to include (Android only)",
+          "description": "Android action buttons",
           "type": "array",
           "items": {
             "type": "object",
@@ -2791,36 +2439,33 @@
           }
         },
         "channelId": {
-          "description": "Notification channel ID (Android); reused as the APNs category on iOS",
+          "description": "Android channel ID / iOS APNs category",
           "type": "string"
         },
         "appId": {
           "type": "string",
           "minLength": 1,
-          "description": "iOS bundle identifier to target (required on iOS; maps to APNs 'Simulator Target Bundle'). Ignored on Android."
+          "description": "iOS target bundle ID"
         },
         "platform": {
           "type": "string",
-          "description": "Target platform",
           "enum": [
             "ios",
             "android"
           ]
         },
         "sessionUuid": {
-          "description": "Session ID",
+          "description": "Session",
           "type": "string"
         },
         "keepScreenAwake": {
-          "description": "Keep device awake",
           "type": "boolean"
         },
         "device": {
-          "description": "Plan device label",
+          "description": "Device label",
           "type": "string"
         },
         "deviceId": {
-          "description": "Device ID",
           "type": "string"
         }
       },
@@ -2864,31 +2509,27 @@
             "volume_up",
             "volume_down",
             "recent"
-          ],
-          "description": "Button to press"
+          ]
         },
         "platform": {
           "type": "string",
           "enum": [
             "android",
             "ios"
-          ],
-          "description": "Target platform"
+          ]
         },
         "sessionUuid": {
-          "description": "Session ID",
+          "description": "Session",
           "type": "string"
         },
         "keepScreenAwake": {
-          "description": "Keep device awake",
           "type": "boolean"
         },
         "device": {
-          "description": "Plan device label",
+          "description": "Device label",
           "type": "string"
         },
         "deviceId": {
-          "description": "Device ID",
           "type": "string"
         }
       },
@@ -2901,15 +2542,14 @@
   },
   {
     "name": "putAppFile",
-    "description": "Write a host file, UTF-8 text, or base64 content into an app container. Prefer this over platform-specific copy commands.",
+    "description": "Write file/text/base64 content into an app container.",
     "inputSchema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "type": "object",
       "properties": {
         "appId": {
           "type": "string",
-          "minLength": 1,
-          "description": "App identifier (Android package name or iOS bundle ID)"
+          "minLength": 1
         },
         "container": {
           "type": "string",
@@ -2920,47 +2560,44 @@
             "tmp",
             "externalFiles"
           ],
-          "description": "Logical app container"
+          "description": "App container"
         },
         "sourcePath": {
-          "description": "Local host file path to copy",
+          "description": "Host file path",
           "type": "string",
           "minLength": 1
         },
         "contentText": {
-          "description": "Inline UTF-8 text content to write",
+          "description": "UTF-8 content",
           "type": "string"
         },
         "contentBase64": {
-          "description": "Inline base64-encoded binary content",
+          "description": "Base64 content",
           "type": "string"
         },
         "destinationPath": {
           "type": "string",
-          "description": "Relative destination path inside the container"
+          "description": "Container-relative destination path"
         },
         "platform": {
           "type": "string",
           "enum": [
             "android",
             "ios"
-          ],
-          "description": "Target platform"
+          ]
         },
         "sessionUuid": {
-          "description": "Session ID",
+          "description": "Session",
           "type": "string"
         },
         "keepScreenAwake": {
-          "description": "Keep device awake",
           "type": "boolean"
         },
         "device": {
-          "description": "Plan device label",
+          "description": "Device label",
           "type": "string"
         },
         "deviceId": {
-          "description": "Device ID",
           "type": "string"
         }
       },
@@ -2984,23 +2621,20 @@
           "enum": [
             "android",
             "ios"
-          ],
-          "description": "Target platform"
+          ]
         },
         "sessionUuid": {
-          "description": "Session ID",
+          "description": "Session",
           "type": "string"
         },
         "keepScreenAwake": {
-          "description": "Keep device awake",
           "type": "boolean"
         },
         "device": {
-          "description": "Plan device label",
+          "description": "Device label",
           "type": "string"
         },
         "deviceId": {
-          "description": "Device ID",
           "type": "string"
         }
       },
@@ -3012,7 +2646,7 @@
   },
   {
     "name": "recordSteps",
-    "description": "Record MCP tool calls as a replayable YAML test plan. Actions: 'begin' starts capturing plan-relevant tool calls, 'end' stops and exports the plan as YAML (both require the 'mcp-recording' feature flag), 'status' checks if a recording session is active (always available, even when the flag is off).",
+    "description": "Record MCP tool calls to YAML. begin/end require mcp-recording; status always works.",
     "inputSchema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "type": "object",
@@ -3023,11 +2657,10 @@
             "begin",
             "end",
             "status"
-          ],
-          "description": "begin: start capturing tool calls. end: stop and export the recorded plan as YAML. status: check if a recording session is active."
+          ]
         },
         "planName": {
-          "description": "Name for the exported plan (kebab-case recommended, auto-generated if not specified). Only used with action 'end'.",
+          "description": "Plan name for action=end",
           "type": "string"
         }
       },
@@ -3097,31 +2730,27 @@
           "enum": [
             "portrait",
             "landscape"
-          ],
-          "description": "Orientation"
+          ]
         },
         "platform": {
           "type": "string",
           "enum": [
             "android",
             "ios"
-          ],
-          "description": "Target platform"
+          ]
         },
         "sessionUuid": {
-          "description": "Session ID",
+          "description": "Session",
           "type": "string"
         },
         "keepScreenAwake": {
-          "description": "Keep device awake",
           "type": "boolean"
         },
         "device": {
-          "description": "Plan device label",
+          "description": "Device label",
           "type": "string"
         },
         "deviceId": {
-          "description": "Device ID",
           "type": "string"
         }
       },
@@ -3144,23 +2773,20 @@
           "enum": [
             "android",
             "ios"
-          ],
-          "description": "Target platform"
+          ]
         },
         "sessionUuid": {
-          "description": "Session ID",
+          "description": "Session",
           "type": "string"
         },
         "keepScreenAwake": {
-          "description": "Keep device awake",
           "type": "boolean"
         },
         "device": {
-          "description": "Plan device label",
+          "description": "Device label",
           "type": "string"
         },
         "deviceId": {
-          "description": "Device ID",
           "type": "string"
         }
       },
@@ -3172,41 +2798,38 @@
   },
   {
     "name": "sendSms",
-    "description": "Send a simulated incoming SMS to an Android emulator via the emulator console (sms send). Emulator-only: physical devices return an unsupported error.",
+    "description": "Send simulated incoming SMS on Android emulator.",
     "inputSchema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "type": "object",
       "properties": {
         "phoneNumber": {
           "type": "string",
-          "description": "Sender phone number for the simulated incoming SMS. Digits with optional leading '+', max 20 digits."
+          "description": "Sender phone number"
         },
         "message": {
           "type": "string",
-          "description": "SMS message body. Max 1024 characters. Must not contain newlines, carriage returns, or NUL bytes."
+          "description": "SMS body; max 1024 chars, no newlines/NUL"
         },
         "platform": {
           "type": "string",
           "enum": [
             "android",
             "ios"
-          ],
-          "description": "Target platform"
+          ]
         },
         "sessionUuid": {
-          "description": "Session ID",
+          "description": "Session",
           "type": "string"
         },
         "keepScreenAwake": {
-          "description": "Keep device awake",
           "type": "boolean"
         },
         "device": {
-          "description": "Plan device label",
+          "description": "Device label",
           "type": "string"
         },
         "deviceId": {
-          "description": "Device ID",
           "type": "string"
         }
       },
@@ -3225,23 +2848,20 @@
       "type": "object",
       "properties": {
         "deviceId": {
-          "type": "string",
-          "description": "Device ID"
+          "type": "string"
         },
         "platform": {
           "type": "string",
           "enum": [
             "android",
             "ios"
-          ],
-          "description": "Target platform"
+          ]
         },
         "sessionUuid": {
-          "description": "Session ID",
+          "description": "Session",
           "type": "string"
         },
         "keepScreenAwake": {
-          "description": "Keep device awake",
           "type": "boolean"
         }
       },
@@ -3260,8 +2880,7 @@
       "type": "object",
       "properties": {
         "appId": {
-          "type": "string",
-          "description": "App package ID or bundle identifier"
+          "type": "string"
         },
         "action": {
           "description": "Permission action; defaults to grant",
@@ -3281,17 +2900,17 @@
           }
         },
         "userId": {
-          "description": "Android user id for runtime permission grants",
+          "description": "Android user id",
           "type": "integer",
           "minimum": 0,
           "maximum": 9007199254740991
         },
         "notificationPolicyAccess": {
-          "description": "Android only: set notification policy / DND access",
+          "description": "Android: set DND policy access",
           "type": "boolean"
         },
         "scheduleExactAlarm": {
-          "description": "Android only: set UID-level SCHEDULE_EXACT_ALARM appop",
+          "description": "Android: set SCHEDULE_EXACT_ALARM appop",
           "type": "string",
           "enum": [
             "allow",
@@ -3303,23 +2922,20 @@
           "enum": [
             "android",
             "ios"
-          ],
-          "description": "Target platform"
+          ]
         },
         "sessionUuid": {
-          "description": "Session ID",
+          "description": "Session",
           "type": "string"
         },
         "keepScreenAwake": {
-          "description": "Keep device awake",
           "type": "boolean"
         },
         "device": {
-          "description": "Plan device label",
+          "description": "Device label",
           "type": "string"
         },
         "deviceId": {
-          "description": "Device ID",
           "type": "string"
         }
       },
@@ -3331,7 +2947,7 @@
   },
   {
     "name": "setDeviceState",
-    "description": "Set device-level state such as Do Not Disturb. Android supports off/none/priority/alarms; iOS simulators support binary DND only.",
+    "description": "Set device state such as Do Not Disturb.",
     "inputSchema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "type": "object",
@@ -3362,23 +2978,20 @@
           "enum": [
             "android",
             "ios"
-          ],
-          "description": "Target platform"
+          ]
         },
         "sessionUuid": {
-          "description": "Session ID",
+          "description": "Session",
           "type": "string"
         },
         "keepScreenAwake": {
-          "description": "Keep device awake",
           "type": "boolean"
         },
         "device": {
-          "description": "Plan device label",
+          "description": "Device label",
           "type": "string"
         },
         "deviceId": {
-          "description": "Device ID",
           "type": "string"
         }
       },
@@ -3387,42 +3000,38 @@
   },
   {
     "name": "setNotificationPolicy",
-    "description": "Set app notification policy state, including Android Do Not Disturb policy access",
+    "description": "Set app notification/DND policy state",
     "inputSchema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "type": "object",
       "properties": {
         "appId": {
           "type": "string",
-          "minLength": 1,
-          "description": "App package ID or bundle identifier"
+          "minLength": 1
         },
         "policyAccess": {
           "type": "boolean",
-          "description": "Android only: allow or revoke app notification policy / DND access"
+          "description": "Android: allow DND policy access"
         },
         "platform": {
           "type": "string",
           "enum": [
             "android",
             "ios"
-          ],
-          "description": "Target platform"
+          ]
         },
         "sessionUuid": {
-          "description": "Session ID",
+          "description": "Session",
           "type": "string"
         },
         "keepScreenAwake": {
-          "description": "Keep device awake",
           "type": "boolean"
         },
         "device": {
-          "description": "Plan device label",
+          "description": "Device label",
           "type": "string"
         },
         "deviceId": {
-          "description": "Device ID",
           "type": "string"
         }
       },
@@ -3435,17 +3044,17 @@
   },
   {
     "name": "shake",
-    "description": "Shake device. iOS support is Simulator-only; physical iOS devices are not supported by XCTest.",
+    "description": "Shake device; iOS Simulator only.",
     "inputSchema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "type": "object",
       "properties": {
         "duration": {
-          "description": "Shake duration in ms (default: 1000). On iOS Simulator this contributes to the runner timeout budget.",
+          "description": "Shake duration ms (default 1000)",
           "type": "number"
         },
         "intensity": {
-          "description": "Shake acceleration intensity (default: 100). Ignored on iOS Simulator because XCTest shake has no intensity parameter.",
+          "description": "Shake intensity (Android; default 100)",
           "type": "number"
         },
         "platform": {
@@ -3453,23 +3062,20 @@
           "enum": [
             "android",
             "ios"
-          ],
-          "description": "Target platform"
+          ]
         },
         "sessionUuid": {
-          "description": "Session ID",
+          "description": "Session",
           "type": "string"
         },
         "keepScreenAwake": {
-          "description": "Keep device awake",
           "type": "boolean"
         },
         "device": {
-          "description": "Plan device label",
+          "description": "Device label",
           "type": "string"
         },
         "deviceId": {
-          "description": "Device ID",
           "type": "string"
         }
       },
@@ -3491,8 +3097,7 @@
           "enum": [
             "android",
             "ios"
-          ],
-          "description": "Target platform"
+          ]
         },
         "minOsVersion": {
           "description": "Minimum OS version, inclusive (e.g., '14', '17.2')",
@@ -3534,7 +3139,6 @@
           "additionalProperties": false
         },
         "deviceId": {
-          "description": "Specific device ID (bypasses matching)",
           "type": "string"
         },
         "preferRunning": {
@@ -3554,7 +3158,7 @@
   },
   {
     "name": "startTestRecording",
-    "description": "Start test recording mode on the active device. Records user interactions for later export as a test plan. Returns the session ID which can be used with exportPlan.",
+    "description": "Start recording user interactions for exportPlan.",
     "inputSchema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "type": "object",
@@ -3602,7 +3206,7 @@
           "type": "boolean"
         },
         "container": {
-          "description": "Container selector object to scope search. Provide { \"elementId\": \"<id>\" } or { \"text\": \"<text>\" }.",
+          "description": "Scope search to a container",
           "anyOf": [
             {
               "type": "object",
@@ -3647,7 +3251,7 @@
           "description": "Swipe/scroll direction"
         },
         "gestureType": {
-          "description": "swipeFingerTowardsDirection: finger moves in direction (e.g., 'up' = finger up = content scrolls down). scrollTowardsDirection: content moves in direction (e.g., 'up' = content up = see content below). Default: scrollTowardsDirection.",
+          "description": "Finger direction or content scroll direction; default: scrollTowardsDirection",
           "type": "string",
           "enum": [
             "swipeFingerTowardsDirection",
@@ -3715,23 +3319,20 @@
           "enum": [
             "android",
             "ios"
-          ],
-          "description": "Target platform"
+          ]
         },
         "sessionUuid": {
-          "description": "Session ID",
+          "description": "Session",
           "type": "string"
         },
         "keepScreenAwake": {
-          "description": "Keep device awake",
           "type": "boolean"
         },
         "device": {
-          "description": "Plan device label",
+          "description": "Device label",
           "type": "string"
         },
         "deviceId": {
-          "description": "Device ID",
           "type": "string"
         }
       },
@@ -3759,7 +3360,7 @@
             "dismiss",
             "clearAll"
           ],
-          "description": "Action: open=expand tray, close=collapse tray/shade, find=search for notification, tap=tap notification, dismiss=swipe away, clearAll=dismiss all for app"
+          "description": "open/close/find/tap/dismiss/clearAll notification"
         },
         "notification": {
           "description": "Notification criteria to match",
@@ -3793,23 +3394,20 @@
           "enum": [
             "android",
             "ios"
-          ],
-          "description": "Target platform"
+          ]
         },
         "sessionUuid": {
-          "description": "Session ID",
+          "description": "Session",
           "type": "string"
         },
         "keepScreenAwake": {
-          "description": "Keep device awake",
           "type": "boolean"
         },
         "device": {
-          "description": "Plan device label",
+          "description": "Device label",
           "type": "string"
         },
         "deviceId": {
-          "description": "Device ID",
           "type": "string"
         }
       },
@@ -3822,13 +3420,13 @@
   },
   {
     "name": "tapAny",
-    "description": "Tap any clickable element without knowing its text or ID. Good for tapping the first list item. Use container to scope, selectionStrategy to pick 'first' (default) or 'random', and scrollableContainer: true to limit to list/RecyclerView items.",
+    "description": "Tap any clickable element; scope with container or scrollableContainer.",
     "inputSchema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "type": "object",
       "properties": {
         "container": {
-          "description": "Container selector object to scope search. Provide { \"elementId\": \"<id>\" } or { \"text\": \"<text>\" }.",
+          "description": "Scope search to a container",
           "anyOf": [
             {
               "type": "object",
@@ -3867,7 +3465,7 @@
           ]
         },
         "scrollableContainer": {
-          "description": "Only search within scrollable containers (lists/RecyclerViews). Use this to avoid tapping search bars or other clickable UI elements when you want the first list item.",
+          "description": "Search only scrollable containers/lists",
           "type": "boolean"
         },
         "action": {
@@ -3902,23 +3500,20 @@
           "enum": [
             "android",
             "ios"
-          ],
-          "description": "Target platform"
+          ]
         },
         "sessionUuid": {
-          "description": "Session ID",
+          "description": "Session",
           "type": "string"
         },
         "keepScreenAwake": {
-          "description": "Keep device awake",
           "type": "boolean"
         },
         "device": {
-          "description": "Plan device label",
+          "description": "Device label",
           "type": "string"
         },
         "deviceId": {
-          "description": "Device ID",
           "type": "string"
         }
       },
@@ -3931,7 +3526,7 @@
   },
   {
     "name": "tapOn",
-    "description": "Tap a specific UI element identified by text or resource-id.\nProvide a selector: { \"text\": \"Login\" } or { \"elementId\": \"com.app:id/btn\" }.\nSet sibling: true to tap a clickable sibling adjacent to the matched element (e.g., a checkbox next to a label).\ncontent-desc values from observe should be passed as text, not elementId.",
+    "description": "Tap an element by text/content-desc or resource-id; use sibling for adjacent controls.",
     "inputSchema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "type": "object",
@@ -3944,7 +3539,7 @@
                 "elementId": {
                   "type": "string",
                   "minLength": 1,
-                  "description": "Element resource-id (e.g. \"com.app:id/btn_login\"). Only use for resource-id values."
+                  "description": "Resource ID, e.g. com.app:id/btn_login"
                 }
               },
               "required": [
@@ -3958,7 +3553,7 @@
                 "text": {
                   "type": "string",
                   "minLength": 1,
-                  "description": "Element text, content-desc, or placeholder value from observe output."
+                  "description": "Text, content-desc, or placeholder"
                 }
               },
               "required": [
@@ -3967,14 +3562,14 @@
               "additionalProperties": false
             }
           ],
-          "description": "Element to tap. Provide exactly one of elementId or text."
+          "description": "Element to tap: elementId or text"
         },
         "sibling": {
-          "description": "When true, tap a clickable sibling of the matched element instead of the element itself. Useful for tapping checkboxes, icons, or buttons adjacent to a text label.",
+          "description": "Tap a clickable sibling of the match, e.g. checkbox beside label",
           "type": "boolean"
         },
         "container": {
-          "description": "Container selector object to scope search. Provide { \"elementId\": \"<id>\" } or { \"text\": \"<text>\" }.",
+          "description": "Scope search to a container",
           "anyOf": [
             {
               "type": "object",
@@ -4016,7 +3611,7 @@
           ]
         },
         "selectionStrategy": {
-          "description": "Element selection strategy when multiple matches are found (default: first)",
+          "description": "Selection strategy when multiple match (default: first)",
           "type": "string",
           "enum": [
             "first",
@@ -4041,15 +3636,15 @@
           "additionalProperties": false
         },
         "preTapStability": {
-          "description": "When true, refresh the accessibility hierarchy before tapping and require consecutive re-finds with stable bounds before dispatching the gesture. Prevents tapping stale coordinates when the UI is still settling (loading overlays, list refreshes, keyboard). Recommended for search result lists and dynamic content.",
+          "description": "Require stable bounds before tapping; use for dynamic UI",
           "type": "boolean"
         },
         "retryIfNoChange": {
-          "description": "When true, compare the view hierarchy before and after the tap. If unchanged (ghost tap detected), retry the tap once after a short delay. Recommended for taps that should cause obvious UI changes like navigation or screen transitions.",
+          "description": "Retry once if the view hierarchy is unchanged after tap",
           "type": "boolean"
         },
         "ensureTap": {
-          "description": "Convenience flag that enables both preTapStability and retryIfNoChange. Use on taps in dynamic UI where you want both stable bounds before tapping and ghost-tap detection after.",
+          "description": "Enable preTapStability and retryIfNoChange",
           "type": "boolean"
         },
         "platform": {
@@ -4057,23 +3652,20 @@
           "enum": [
             "android",
             "ios"
-          ],
-          "description": "Target platform"
+          ]
         },
         "sessionUuid": {
-          "description": "Session ID",
+          "description": "Session",
           "type": "string"
         },
         "keepScreenAwake": {
-          "description": "Keep device awake",
           "type": "boolean"
         },
         "device": {
-          "description": "Plan device label",
+          "description": "Device label",
           "type": "string"
         },
         "deviceId": {
-          "description": "Device ID",
           "type": "string"
         }
       },
@@ -5065,31 +4657,27 @@
       "type": "object",
       "properties": {
         "appId": {
-          "type": "string",
-          "description": "App package ID"
+          "type": "string"
         },
         "platform": {
           "type": "string",
           "enum": [
             "android",
             "ios"
-          ],
-          "description": "Target platform"
+          ]
         },
         "sessionUuid": {
-          "description": "Session ID",
+          "description": "Session",
           "type": "string"
         },
         "keepScreenAwake": {
-          "description": "Keep device awake",
           "type": "boolean"
         },
         "device": {
-          "description": "Plan device label",
+          "description": "Device label",
           "type": "string"
         },
         "deviceId": {
-          "description": "Device ID",
           "type": "string"
         }
       },
@@ -5107,8 +4695,7 @@
       "type": "object",
       "properties": {
         "appId": {
-          "type": "string",
-          "description": "App package ID or bundle identifier to uninstall"
+          "type": "string"
         },
         "keepData": {
           "description": "Keep app data after uninstall (Android only, default false)",
@@ -5119,23 +4706,20 @@
           "enum": [
             "android",
             "ios"
-          ],
-          "description": "Target platform"
+          ]
         },
         "sessionUuid": {
-          "description": "Session ID",
+          "description": "Session",
           "type": "string"
         },
         "keepScreenAwake": {
-          "description": "Keep device awake",
           "type": "boolean"
         },
         "device": {
-          "description": "Plan device label",
+          "description": "Device label",
           "type": "string"
         },
         "deviceId": {
-          "description": "Device ID",
           "type": "string"
         }
       },
@@ -5147,7 +4731,7 @@
   },
   {
     "name": "videoRecording",
-    "description": "Start or stop a low-overhead video recording for the active device.",
+    "description": "Start or stop device video recording.",
     "inputSchema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "type": "object",
@@ -5157,27 +4741,23 @@
           "enum": [
             "start",
             "stop"
-          ],
-          "description": "Action to perform"
+          ]
         },
         "platform": {
           "type": "string",
           "enum": [
             "android",
             "ios"
-          ],
-          "description": "Target platform"
+          ]
         },
         "deviceId": {
-          "description": "Device ID",
           "type": "string"
         },
         "recordingId": {
-          "description": "Recording ID to stop",
+          "description": "Recording ID",
           "type": "string"
         },
         "qualityPreset": {
-          "description": "Recording quality preset",
           "type": "string",
           "enum": [
             "low",
@@ -5186,37 +4766,35 @@
           ]
         },
         "targetBitrateKbps": {
-          "description": "Target bitrate in Kbps",
+          "description": "Bitrate Kbps",
           "type": "integer",
           "exclusiveMinimum": 0,
           "maximum": 9007199254740991
         },
         "maxThroughputMbps": {
-          "description": "Max throughput in Mbps",
+          "description": "Max throughput Mbps",
           "type": "number",
           "exclusiveMinimum": 0
         },
         "fps": {
-          "description": "Frames per second",
+          "description": "FPS",
           "type": "integer",
           "exclusiveMinimum": 0,
           "maximum": 9007199254740991
         },
         "resolution": {
-          "description": "Override capture resolution",
+          "description": "Resolution",
           "type": "object",
           "properties": {
             "width": {
               "type": "integer",
               "exclusiveMinimum": 0,
-              "maximum": 9007199254740991,
-              "description": "Override resolution width in pixels"
+              "maximum": 9007199254740991
             },
             "height": {
               "type": "integer",
               "exclusiveMinimum": 0,
-              "maximum": 9007199254740991,
-              "description": "Override resolution height in pixels"
+              "maximum": 9007199254740991
             }
           },
           "required": [
@@ -5226,30 +4804,29 @@
           "additionalProperties": false
         },
         "format": {
-          "description": "Video format",
           "type": "string",
           "enum": [
             "mp4"
           ]
         },
         "maxDuration": {
-          "description": "Max seconds to record video for (default 30, max 300)",
+          "description": "Max duration seconds",
           "type": "integer",
           "exclusiveMinimum": 0,
           "maximum": 300
         },
         "outputName": {
-          "description": "Optional label to identify the recording",
+          "description": "Recording label",
           "type": "string"
         },
         "highlights": {
-          "description": "Optional highlights to show during recording",
+          "description": "Recording highlights",
           "type": "array",
           "items": {
             "type": "object",
             "properties": {
               "description": {
-                "description": "Description of the highlight",
+                "description": "Highlight description",
                 "type": "string"
               },
               "shape": {
@@ -5816,10 +5393,10 @@
                     "additionalProperties": false
                   }
                 ],
-                "description": "Highlight shape definition"
+                "description": "Highlight shape"
               },
               "timing": {
-                "description": "Optional highlight timing",
+                "description": "Highlight timing",
                 "type": "object",
                 "properties": {
                   "startTimeMs": {
@@ -5839,15 +5416,14 @@
           }
         },
         "sessionUuid": {
-          "description": "Session ID",
+          "description": "Session",
           "type": "string"
         },
         "keepScreenAwake": {
-          "description": "Keep device awake",
           "type": "boolean"
         },
         "device": {
-          "description": "Plan device label",
+          "description": "Device label",
           "type": "string"
         }
       },

--- a/src/daemon/daemon.ts
+++ b/src/daemon/daemon.ts
@@ -100,6 +100,7 @@ export class Daemon {
   private installedAppsRepository: InstalledAppsStore;
   private deviceSessionRepository: DeviceSessionRepository;
   private timer: Timer;
+  private options: DaemonOptions;
   private shutdownHandlersRegistered: boolean = false;
   private shutdownInProgress: boolean = false;
 
@@ -109,6 +110,7 @@ export class Daemon {
     timer: Timer = defaultTimer,
     deviceSessionRepository: DeviceSessionRepository = new DeviceSessionRepository()
   ) {
+    this.options = { ...options };
     this.port = options.port || DEFAULT_DAEMON_PORT;
     // Prefer IPv4 loopback: Bun's fetch and Node's listen can disagree on "localhost" (::1 vs 127.0.0.1),
     // which surfaces as ConnectionRefused on the Unix-socket → Streamable HTTP MCP hop (common in Linux CI).
@@ -601,6 +603,7 @@ export class Daemon {
       port: this.port,
       startedAt: this.timer.now(),
       version: DAEMON_VERSION,
+      options: this.options,
     };
 
     await mkdir(dirname(PID_FILE_PATH), { recursive: true });

--- a/src/daemon/daemonMcpProxy.ts
+++ b/src/daemon/daemonMcpProxy.ts
@@ -172,8 +172,10 @@ export class DaemonMcpProxy {
       logger.info("[DaemonMcpProxy] Daemon not available, starting daemon...");
       await this.startDaemon();
       await this.ensureVersionMatches();
+      await this.ensureStartupOptionsMatch();
     } else {
       await this.ensureVersionMatches();
+      await this.ensureStartupOptionsMatch();
     }
 
     // Create and connect client
@@ -274,6 +276,44 @@ export class DaemonMcpProxy {
       detail,
       retryAfterMs,
     });
+  }
+
+  private async ensureStartupOptionsMatch(): Promise<void> {
+    const status = await this.daemonManager.status();
+    if (!status.running) {
+      return;
+    }
+
+    const requestedEmbeddedSdk = this.config.daemonOptions?.embeddedSdk === true;
+    const runningEmbeddedSdk = status.options?.embeddedSdk === true;
+    if (requestedEmbeddedSdk === runningEmbeddedSdk) {
+      return;
+    }
+
+    if (!this.config.autoStartDaemon) {
+      throw new DaemonUnavailableError(
+        "Daemon startup options differ from MCP server options and auto-start is disabled"
+      );
+    }
+
+    logger.info(
+      `[DaemonMcpProxy] Daemon embeddedSdk=${runningEmbeddedSdk} differs from MCP server embeddedSdk=${requestedEmbeddedSdk}, restarting daemon`
+    );
+    await this.daemonManager.restart(this.config.daemonOptions ?? {});
+    const ready = await this.daemonManager.waitForReady(DAEMON_STARTUP_TIMEOUT_MS);
+    if (!ready) {
+      throw new DaemonUnavailableError(
+        `Daemon failed to restart within ${DAEMON_STARTUP_TIMEOUT_MS}ms`
+      );
+    }
+
+    const restartedStatus = await this.daemonManager.status();
+    const restartedEmbeddedSdk = restartedStatus.options?.embeddedSdk === true;
+    if (!restartedStatus.running || restartedEmbeddedSdk !== requestedEmbeddedSdk) {
+      throw new DaemonUnavailableError(
+        "Daemon restart completed but startup options still differ"
+      );
+    }
   }
 
   /**

--- a/src/daemon/manager.ts
+++ b/src/daemon/manager.ts
@@ -470,6 +470,9 @@ export class DaemonManager implements DaemonManagerLike {
     if (options.networkMockable) {
       args.push("--network-mockable");
     }
+    if (options.embeddedSdk) {
+      args.push("--embedded-sdk");
+    }
     if (options.dismissKeyboardAfterInput) {
       args.push("--dismiss-keyboard-after-input");
     }
@@ -964,6 +967,8 @@ function parseDaemonArgs(args: string[]): DaemonOptions {
       i++;
     } else if (args[i] === "--network-mockable") {
       options.networkMockable = true;
+    } else if (args[i] === "--embedded-sdk") {
+      options.embeddedSdk = true;
     } else if (args[i] === "--dismiss-keyboard-after-input") {
       options.dismissKeyboardAfterInput = true;
     } else if (args[i] === "--no-ui-perf-mode") {

--- a/src/daemon/manager.ts
+++ b/src/daemon/manager.ts
@@ -748,6 +748,7 @@ export class DaemonManager implements DaemonManagerLike {
         sockets: pidData.sockets,
         startedAt: pidData.startedAt,
         version: pidData.version,
+        options: pidData.options,
       };
     } catch (error) {
       logger.warn(`Error reading PID file: ${error instanceof Error ? error.message : String(error)}`);

--- a/src/daemon/types.ts
+++ b/src/daemon/types.ts
@@ -114,6 +114,8 @@ export interface DaemonOptions {
   videoMaxArchiveSizeMb?: number;
   /** Enable network mocking */
   networkMockable?: boolean;
+  /** Expose tools that require the target app to embed the AutoMobile SDK */
+  embeddedSdk?: boolean;
   /** Dismiss keyboard after text input (Android only) */
   dismissKeyboardAfterInput?: boolean;
   /** Disable UI performance mode */

--- a/src/daemon/types.ts
+++ b/src/daemon/types.ts
@@ -66,6 +66,8 @@ export interface DaemonStatus {
   startedAt?: number;
   /** Daemon version */
   version?: string;
+  /** Options used to start the daemon */
+  options?: DaemonOptions;
 }
 
 /**
@@ -84,6 +86,8 @@ export interface PidFileData {
   startedAt: number;
   /** Daemon version */
   version: string;
+  /** Options used to start the daemon */
+  options?: DaemonOptions;
 }
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -89,6 +89,7 @@ function parseArgs(log: ParseLogger): {
   daemonCommand?: string;
   daemonArgs: string[];
   skipCtrlProxyDownload: boolean;
+  embeddedSdk: boolean;
   dismissKeyboardAfterInput: boolean;
   mcpRecording: boolean;
   navigationScreenshots: boolean;
@@ -151,6 +152,7 @@ function parseArgs(log: ParseLogger): {
   const predictiveUi = args.includes("--predictive") || args.includes("--predictive-ui");
   const rawElementSearch = args.includes("--raw-element-search");
   const skipCtrlProxyDownload = args.includes("--skip-ctrl-proxy-download") || args.includes("--skip-accessibility-download");
+  const embeddedSdk = args.includes("--embedded-sdk");
   const networkMockable = args.includes("--network-mockable");
   const dismissKeyboardAfterInput = args.includes("--dismiss-keyboard-after-input");
   const mcpRecording = args.includes("--mcp-recording");
@@ -349,6 +351,7 @@ function parseArgs(log: ParseLogger): {
     daemonCommand,
     daemonArgs,
     skipCtrlProxyDownload,
+    embeddedSdk,
     networkMockable,
     dismissKeyboardAfterInput,
     mcpRecording,
@@ -427,6 +430,7 @@ async function main() {
       daemonCommand,
       daemonArgs,
       skipCtrlProxyDownload,
+      embeddedSdk,
       networkMockable,
       dismissKeyboardAfterInput,
       mcpRecording,
@@ -442,6 +446,7 @@ async function main() {
     serverConfig.setPlanExecutionLockScope(planExecutionLockScope);
     serverConfig.setVideoRecordingDefaults(videoRecordingDefaults);
     serverConfig.setSkipCtrlProxyDownload(skipCtrlProxyDownload);
+    serverConfig.setEmbeddedSdkEnabled(embeddedSdk);
     serverConfig.setNetworkMockableEnabled(networkMockable);
     serverConfig.setDismissKeyboardAfterInputEnabled(dismissKeyboardAfterInput);
     if (skipCtrlProxyDownload) {
@@ -505,6 +510,7 @@ async function main() {
     // grep-verifiable so a missing flag is visible without re-running.
     const silentDaemonFlags: Array<[boolean, string]> = [
       [!uiPerfMode, "UI perf mode disabled (--no-ui-perf-mode): skipping selection-state visual capture on taps and UI perf auditing"],
+      [embeddedSdk, "Embedded SDK tools enabled (--embedded-sdk)"],
       [dismissKeyboardAfterInput, "Dismiss keyboard after inputText enabled (--dismiss-keyboard-after-input)"],
       [noA11yIncludeNotImportantViews, "Accessibility includeNotImportantViews disabled (--no-include-not-important-views)"],
       [noA11yReportViewIds, "Accessibility reportViewIds disabled (--no-report-view-ids)"],
@@ -530,6 +536,7 @@ async function main() {
         videoFormat: videoRecordingDefaults.format,
         videoMaxArchiveSizeMb: videoRecordingDefaults.maxArchiveSizeMb,
         networkMockable,
+        embeddedSdk,
         dismissKeyboardAfterInput,
         noUiPerfMode: !uiPerfMode,
         memPerfAudit: memPerfAuditMode,
@@ -588,6 +595,7 @@ async function main() {
         videoFormat: videoRecordingDefaults.format,
         videoMaxArchiveSizeMb: videoRecordingDefaults.maxArchiveSizeMb,
         networkMockable,
+        embeddedSdk,
         dismissKeyboardAfterInput,
         noUiPerfMode: !uiPerfMode,
         memPerfAudit: memPerfAuditMode,

--- a/src/server/accessibilityFocusTools.ts
+++ b/src/server/accessibilityFocusTools.ts
@@ -12,19 +12,19 @@ export const accessibilityFocusSchema = addDeviceTargetingToSchema(
     action: z
       .enum(["set", "clear"])
       .optional()
-      .describe("Set (default) or clear the accessibility (TalkBack) focus cursor"),
+      .describe("set default or clear TalkBack focus"),
     resourceId: z
       .string()
       .optional()
-      .describe("Resource ID of the target element, e.g. com.example:id/title"),
+      .describe("Target resource ID"),
     text: z
       .string()
       .optional()
-      .describe("Text of the target element (resolved to a resource-id via the element finder)"),
+      .describe("Target text"),
     contentDesc: z
       .string()
       .optional()
-      .describe("Content description of the target element (resolved to a resource-id)")
+      .describe("Target content-desc")
   })
 );
 
@@ -66,14 +66,18 @@ export function registerAccessibilityFocusTools() {
     });
   };
 
+  // Debug-only pending audit: this explicit cursor setter is not a typical UI
+  // navigation/interaction tool because a human cannot directly command TalkBack
+  // to focus an arbitrary node. Re-evaluate whether it should be removed, kept as
+  // an internal debug primitive, or implemented through human-representative
+  // TalkBack navigation gestures instead.
   ToolRegistry.registerDeviceAware(
     "accessibilityFocus",
-    "Set or clear the Android TalkBack accessibility-focus cursor on a target element (Android only). " +
-      "Provide one selector: resourceId, text, or contentDesc. action defaults to 'set'; pass 'clear' to clear the cursor.",
+    "Set or clear Android TalkBack focus by resourceId, text, or contentDesc.",
     accessibilityFocusSchema,
     handler,
     false,
-    false,
+    true,
     { outputSchema: accessibilityFocusResultSchema }
   );
 }

--- a/src/server/appFileContract.ts
+++ b/src/server/appFileContract.ts
@@ -105,12 +105,12 @@ export function normalizeAppFileRelativePath(path: string): string {
 }
 
 export const putAppFileSchema = addDeviceTargetingToSchema(z.object({
-  appId: z.string().min(1).describe("App identifier (Android package name or iOS bundle ID)"),
-  container: appFileContainerSchema.describe("Logical app container"),
-  sourcePath: z.string().min(1).optional().describe("Local host file path to copy"),
-  contentText: z.string().optional().describe("Inline UTF-8 text content to write"),
-  contentBase64: z.string().optional().describe("Inline base64-encoded binary content"),
-  destinationPath: z.string().describe("Relative destination path inside the container"),
+  appId: z.string().min(1),
+  container: appFileContainerSchema.describe("App container"),
+  sourcePath: z.string().min(1).optional().describe("Host file path"),
+  contentText: z.string().optional().describe("UTF-8 content"),
+  contentBase64: z.string().optional().describe("Base64 content"),
+  destinationPath: z.string().describe("Container-relative destination path"),
 }).superRefine((args, ctx) => {
   if (countDefined([args.sourcePath, args.contentText, args.contentBase64]) !== 1) {
     ctx.addIssue({

--- a/src/server/appFileTools.ts
+++ b/src/server/appFileTools.ts
@@ -7,7 +7,7 @@ import type { BootedDevice } from "../models";
 export function registerAppFileTools(): void {
   ToolRegistry.registerDeviceAware(
     "putAppFile",
-    "Write a host file, UTF-8 text, or base64 content into an app container. Prefer this over platform-specific copy commands.",
+    "Write file/text/base64 content into an app container.",
     putAppFileSchema,
     async (device: BootedDevice, args: PutAppFileArgs, _progress, signal) => {
       const result = await getAppFileService().putFile(device, args, signal);

--- a/src/server/appTools.ts
+++ b/src/server/appTools.ts
@@ -44,21 +44,21 @@ export function resetListAppsToolDependencies(): void {
 
 // Schema definitions
 export const packageNameSchema = addDeviceTargetingToSchema(z.object({
-  appId: z.string().describe("App package ID"),
+  appId: z.string(),
 }));
 
 export const launchAppSchema = addDeviceTargetingToSchema(z.object({
-  appId: z.string().describe("App package ID"),
+  appId: z.string(),
   clearAppData: z.boolean().optional().describe("Clear app data before launch (default false)"),
   coldBoot: z.boolean().optional().describe("Cold boot app (default false)"),
 }));
 
 export const installAppSchema = addDeviceTargetingToSchema(z.object({
-  artifactPath: z.string().describe("Path to app artifact (.apk for Android, .app bundle for iOS simulator, .ipa for iOS physical device)"),
+  artifactPath: z.string().describe("App artifact path (.apk, .app, or .ipa)"),
 }));
 
 export const uninstallAppSchema = addDeviceTargetingToSchema(z.object({
-  appId: z.string().describe("App package ID or bundle identifier to uninstall"),
+  appId: z.string(),
   keepData: z.boolean().optional().describe("Keep app data after uninstall (Android only, default false)"),
 }));
 
@@ -66,7 +66,7 @@ const appPermissionActionSchema = z.enum(["grant", "revoke", "reset"]);
 
 export const setAppPermissionsSchema = addDeviceTargetingToSchema(
   z.object({
-    appId: z.string().describe("App package ID or bundle identifier"),
+    appId: z.string(),
     action: appPermissionActionSchema
       .optional()
       .describe("Permission action; defaults to grant"),
@@ -79,15 +79,15 @@ export const setAppPermissionsSchema = addDeviceTargetingToSchema(
       .int()
       .nonnegative()
       .optional()
-      .describe("Android user id for runtime permission grants"),
+      .describe("Android user id"),
     notificationPolicyAccess: z
       .boolean()
       .optional()
-      .describe("Android only: set notification policy / DND access"),
+      .describe("Android: set DND policy access"),
     scheduleExactAlarm: z
       .enum(["allow", "deny"])
       .optional()
-      .describe("Android only: set UID-level SCHEDULE_EXACT_ALARM appop"),
+      .describe("Android: set SCHEDULE_EXACT_ALARM appop"),
   })
 ).refine(
   args =>
@@ -99,7 +99,7 @@ export const setAppPermissionsSchema = addDeviceTargetingToSchema(
 
 export const getAppPermissionsSchema = addDeviceTargetingToSchema(
   z.object({
-    appId: z.string().describe("App package ID or bundle identifier"),
+    appId: z.string(),
     permissions: z
       .array(z.string().min(1))
       .optional()
@@ -316,7 +316,7 @@ export function registerAppTools(
 
   ToolRegistry.registerDeviceAware(
     "installApp",
-    "Install app on device (.apk for Android, .app for iOS simulator, .ipa for iOS physical device)",
+    "Install app on device (.apk, .app, or .ipa)",
     installAppSchema,
     installAppHandler
   );

--- a/src/server/biometricTools.ts
+++ b/src/server/biometricTools.ts
@@ -13,21 +13,19 @@ export interface BiometricAuthArgs extends BiometricAuthOptions {
 // Schema definition
 export const biometricAuthSchema = addDeviceTargetingToSchema(z.object({
   action: z.enum(["match", "fail", "cancel", "error"]).describe(
-    "Biometric action: 'match' triggers successful authentication, 'fail' simulates a non-matching biometric, " +
-    "'cancel' cancels the prompt, 'error' injects a hard error (requires AutoMobileBiometrics SDK integration in the app)."
+    "match/fail/cancel/error; cancel/error require Android SDK hook"
   ),
   modality: z.enum(["any", "fingerprint", "face"]).optional().describe(
-    "Biometric modality (default: 'any'). Android emulators reliably support only 'fingerprint'. iOS Simulator supports both: " +
-    "'fingerprint' -> Touch ID, 'face' -> Face ID, 'any' posts both (the simulator's non-enrolled biometry is a no-op)."
+    "Modality: any default, fingerprint, or face"
   ),
   fingerprintId: z.number().optional().describe(
-    "Fingerprint ID to simulate (default: 1 for 'match'/'error', 2 for 'fail'/'cancel'). Use enrolled ID (typically 1) for match/error, non-enrolled ID (typically 2) for fail/cancel."
+    "Fingerprint ID: default 1 for match/error, 2 for fail/cancel"
   ),
   errorCode: z.number().optional().describe(
-    "BiometricPrompt error code to inject (e.g. 7 for ERROR_LOCKOUT, 1 for ERROR_HW_UNAVAILABLE). Only valid when action is 'error'; providing it with any other action is a validation error."
+    "BiometricPrompt error code; action=error only"
   ),
   ttlMs: z.number().optional().describe(
-    "How long the SDK override remains active in milliseconds (default: 5000). The override is cleared after the first authentication callback or when the TTL expires."
+    "SDK override TTL ms (default 5000)"
   )
 }).refine(
   data => data.errorCode === undefined || data.action === "error",
@@ -71,10 +69,7 @@ export function registerBiometricTools() {
   // Register the tool
   ToolRegistry.registerDeviceAware(
     "biometricAuth",
-    "Simulate biometric authentication on Android emulators (fingerprint) and the iOS Simulator (Touch ID / Face ID via BiometricKit), " +
-    "or inject a deterministic result via the AutoMobile SDK on any Android device. " +
-    "Supports match/fail on both platforms; cancel/error require the AutoMobileBiometrics SDK (Android only). " +
-    "Physical iOS devices are not supported (no public biometric-injection API).",
+    "Simulate biometric auth: Android emulator/SDK hook or iOS Simulator.",
     biometricAuthSchema,
     biometricAuthHandler,
     true // Supports progress notifications

--- a/src/server/criticalSectionTools.ts
+++ b/src/server/criticalSectionTools.ts
@@ -12,11 +12,11 @@ import { PlanNormalizer } from "../utils/plan/PlanNormalizer";
 // run on whichever device acquired the lock first.
 const criticalSectionStepSchema = z
   .object({
-    tool: z.string().describe("Tool name to execute"),
+    tool: z.string().describe("Tool name"),
     params: z
       .record(z.string(), z.any())
-      .describe("Tool-specific parameters. Must include a non-empty 'device'."),
-    label: z.string().optional().describe("Optional human-readable label"),
+      .describe("Tool params; must include device"),
+    label: z.string().optional().describe("Step label"),
   })
   .passthrough()
   .superRefine((step, ctx) => {
@@ -38,20 +38,20 @@ const criticalSectionSchema = z.object({
   lock: z
     .string()
     .describe(
-      "Global lock identifier. All devices using the same lock name will wait for each other at this barrier."
+      "Shared barrier lock name"
     ),
   steps: z
     .array(criticalSectionStepSchema)
     .min(1)
     .describe(
-      "Steps to execute serially within the critical section. Each step should target a specific device using the 'device' parameter."
+      "Serial steps; each needs params.device"
     ),
   deviceCount: z
     .number()
     .int()
     .positive()
     .describe(
-      "Number of devices expected to reach this critical section. All devices must arrive before any can proceed."
+      "Devices required at barrier"
     ),
   timeout: z
     .number()
@@ -59,7 +59,7 @@ const criticalSectionSchema = z.object({
     .positive()
     .optional()
     .describe(
-      "Timeout in milliseconds for waiting at the barrier (default: 30000ms)"
+      "Barrier timeout ms (default 30000)"
     ),
 });
 
@@ -217,9 +217,7 @@ const criticalSectionHandler = async (
 export function registerCriticalSectionTools(): void {
   ToolRegistry.registerDeviceAware(
     "criticalSection",
-    "Coordinate multiple devices at a synchronization barrier and execute steps serially. " +
-			"All devices must reach the critical section before any can proceed. " +
-			"Steps execute one device at a time in the order they acquire the lock.",
+    "Synchronize multiple devices at a barrier, then run steps serially.",
     criticalSectionSchema,
     criticalSectionHandler,
     false // Does not support progress notifications

--- a/src/server/databaseTools.ts
+++ b/src/server/databaseTools.ts
@@ -12,9 +12,9 @@ import type { SQLResult } from "../features/database/DatabaseInspector";
 // Schema for sqlQuery tool
 const sqlQuerySchema = addDeviceTargetingToSchema(
   z.object({
-    appId: z.string().describe("App package ID"),
-    databasePath: z.string().describe("Absolute path to the database file"),
-    query: z.string().describe("SQL query to execute (SELECT, INSERT, UPDATE, DELETE)")
+    appId: z.string(),
+    databasePath: z.string().describe("Database path"),
+    query: z.string().describe("SQL query")
   })
 );
 
@@ -177,11 +177,12 @@ export function registerDatabaseTools() {
   // Register the sqlQuery tool
   ToolRegistry.registerDeviceAware(
     "sqlQuery",
-    "Execute a SQL query on an Android or iOS app's SQLite database. Supports SELECT, INSERT, UPDATE, DELETE. " +
-    "On iOS this requires a DEBUG app build with the AutoMobile SDK integrated and DatabaseInspector.shared.setEnabled(true). " +
-    "For read-only operations (listing databases, tables, viewing data/schema), use the database resources instead.",
+    "Execute SQL on app SQLite database.",
     sqlQuerySchema,
-    sqlQueryHandler
+    sqlQueryHandler,
+    false,
+    false,
+    { embeddedSdkOnly: true }
   );
 }
 

--- a/src/server/deepLinkTools.ts
+++ b/src/server/deepLinkTools.ts
@@ -8,7 +8,7 @@ import { addDeviceTargetingToSchema } from "./toolSchemaHelpers";
 
 // Schema definitions for tool arguments
 export const getDeepLinksSchema = addDeviceTargetingToSchema(z.object({
-  appId: z.string().describe("App package ID"),
+  appId: z.string(),
 }));
 
 // Type definitions for better TypeScript support
@@ -45,7 +45,7 @@ export function registerDeepLinkTools() {
   // Register with the tool registry
   ToolRegistry.registerDeviceAware(
     "getDeepLinks",
-    "Query deep links for app",
+    "Query app deep links",
     getDeepLinksSchema,
     getDeepLinksHandler,
     false // Does not support progress notifications

--- a/src/server/deviceTools.ts
+++ b/src/server/deviceTools.ts
@@ -37,7 +37,7 @@ const startDeviceParametersSchema = z.object({
     width: z.number().describe("Screen width in pixels"),
     height: z.number().describe("Screen height in pixels"),
   }).optional().describe("Desired screen dimensions"),
-  deviceId: z.string().optional().describe("Specific device ID (bypasses matching)"),
+  deviceId: z.string().optional(),
   preferRunning: z.boolean().optional().describe("Prefer already-booted device (default true)"),
   timeoutMs: z.number().optional().describe("Boot timeout in ms"),
 });
@@ -64,7 +64,7 @@ export const startDeviceSchema = z.preprocess(input => {
 export const killDeviceSchema = z.object({
   device: z.object({
     name: z.string().describe("Device image name"),
-    deviceId: z.string().describe("Device ID"),
+    deviceId: z.string(),
     platform: platformSchema
   })
 });

--- a/src/server/doctorTools.ts
+++ b/src/server/doctorTools.ts
@@ -15,7 +15,7 @@ export const doctorSchema = z.object({
   android: z.boolean().optional().describe("Run Android-specific checks only"),
   ios: z.boolean().optional().describe("Run iOS-specific checks only"),
   installCmdlineTools: z.boolean().optional().describe(
-    "Automatically download and install Android SDK Command-line Tools to ANDROID_HOME if missing"
+    "Install missing Android SDK cmdline tools"
   ),
   installXcodeCommandLineTools: z.boolean().optional().describe(
     "Install Xcode Command Line Tools if missing"
@@ -38,7 +38,7 @@ export interface DoctorArgs {
 export function registerDoctorTools(): void {
   ToolRegistry.register(
     "doctor",
-    "Run diagnostic checks to verify AutoMobile setup and environment configuration",
+    "Run AutoMobile setup diagnostics",
     doctorSchema,
     async (args: DoctorArgs) => {
       const report = await runDoctor({

--- a/src/server/elementSelectorSchemas.ts
+++ b/src/server/elementSelectorSchemas.ts
@@ -23,8 +23,8 @@ export const elementContainerSchema = createElementIdTextSelectorSchema({
 
 
 export const elementIdTextFieldsSchema = z.object({
-  elementId: z.string().describe("Element resource-id (e.g. \"com.app:id/btn_login\"). Only use for resource-id values.").optional(),
-  text: z.string().describe("Element text, content-desc, or placeholder value from observe output.").optional()
+  elementId: z.string().describe("Resource ID, e.g. com.app:id/btn_login").optional(),
+  text: z.string().describe("Text, content-desc, or placeholder").optional()
 }).strict();
 
 export const elementSelectionStrategySchema = z.enum(["first", "random"]);

--- a/src/server/formTools.ts
+++ b/src/server/formTools.ts
@@ -16,9 +16,9 @@ import {
 const fieldSpecSchema = z.object({
   selector: elementIdTextFieldsSchema.superRefine((value, ctx) => {
     validateElementIdTextSelector(value, ctx, "Provide exactly one of elementId or text in selector");
-  }).describe("Selector to find the field element"),
-  value: z.string().optional().describe("Value to set (for text inputs and dropdowns)"),
-  selected: z.boolean().optional().describe("Target selection state (for checkboxes and toggles)")
+  }).describe("Field selector"),
+  value: z.string().optional().describe("Text/dropdown value"),
+  selected: z.boolean().optional().describe("Checkbox/toggle state")
 }).refine(
   data => data.value !== undefined || data.selected !== undefined,
   { message: "Provide either value (for text/dropdown) or selected (for checkbox/toggle)" }
@@ -30,9 +30,9 @@ const fieldSpecSchema = z.object({
 const setUIStateSchema = z.object({
   fields: z.array(fieldSpecSchema)
     .min(1, "At least one field is required")
-    .describe("List of fields to set"),
+    .describe("Fields to set"),
   scrollDirection: z.enum(["up", "down"]).optional()
-    .describe("Initial scroll direction when searching (default: down)")
+    .describe("Initial search scroll direction")
 });
 
 /**
@@ -55,10 +55,10 @@ const fieldResultSchema = z.object({
  * Output schema for setUIState result
  */
 const setUIStateResultSchema = z.object({
-  success: z.boolean().describe("Whether all fields were set successfully"),
-  fields: z.array(fieldResultSchema).describe("Results for each field"),
-  totalAttempts: z.number().describe("Total attempts across all fields"),
-  error: z.string().optional().describe("Error message if the operation failed")
+  success: z.boolean().describe("All fields set"),
+  fields: z.array(fieldResultSchema).describe("Field results"),
+  totalAttempts: z.number().describe("Total attempts"),
+  error: z.string().optional().describe("Error message")
 });
 
 /**
@@ -68,27 +68,7 @@ export function registerFormTools(): void {
   // setUIState tool
   ToolRegistry.registerDeviceAware(
     "setUIState",
-    `Declaratively set UI form fields to desired values.
-
-Instead of procedural steps (tap, clear, type), specify the desired end-state for each field.
-Automatically handles:
-- Field type detection (text input, checkbox, toggle, dropdown)
-- Clearing existing text before typing
-- Toggling checkboxes only when needed
-- Scrolling to find hidden fields
-- Retry on failure
-- Value verification
-
-Example usage:
-\`\`\`json
-{
-  "fields": [
-    { "selector": { "elementId": "username" }, "value": "john@example.com" },
-    { "selector": { "text": "Password" }, "value": "secret123" },
-    { "selector": { "elementId": "remember_me" }, "selected": true }
-  ]
-}
-\`\`\``,
+    "Set multiple form fields by desired state.",
     addDeviceTargetingToSchema(setUIStateSchema),
     async (
       device: BootedDevice,
@@ -131,7 +111,7 @@ Example usage:
       });
     },
     true, // supportsProgress
-    false, // debugOnly
+    true, // debugOnly
     { outputSchema: setUIStateResultSchema }
   );
 }

--- a/src/server/formTools.ts
+++ b/src/server/formTools.ts
@@ -112,6 +112,6 @@ export function registerFormTools(): void {
     },
     true, // supportsProgress
     true, // debugOnly
-    { outputSchema: setUIStateResultSchema }
+    { outputSchema: setUIStateResultSchema, planExecutable: true }
   );
 }

--- a/src/server/highlightTools.ts
+++ b/src/server/highlightTools.ts
@@ -38,20 +38,20 @@ const generateHighlightId = (timer: Timer = defaultTimer): string => {
 
 const highlightBaseSchema = z.object({
   platform: platformSchema,
-  deviceId: z.string().optional().describe("Optional device ID override"),
+  deviceId: z.string().optional(),
   timeoutMs: z.number().int().positive().optional().describe("Highlight request timeout ms (default: 5000)"),
   description: z.string().optional().describe("Optional description of the highlight"),
   shape: highlightShapeSchema.optional().describe("Optional highlight shape definition"),
   elementId: elementIdTextFieldsSchema.shape.elementId,
   text: elementIdTextFieldsSchema.shape.text,
   container: elementContainerSchema.optional().describe(
-    "Container selector object to scope search. Provide { \"elementId\": \"<id>\" } or { \"text\": \"<text>\" }."
+    "Scope search to a container"
   ),
   containerOf: z.boolean().optional().describe(
-    "Whether to highlight the container of the selected element"
+    "Highlight selected element's container"
   ),
   selectionStrategy: elementSelectionStrategySchema.optional().describe(
-    "Element selection strategy when multiple matches are found (default: first)"
+    "Selection strategy when multiple match (default: first)"
   )
 }).strict();
 
@@ -329,7 +329,7 @@ export function registerHighlightTools(dependencies: HighlightToolDependencies =
 
   ToolRegistry.registerDeviceAware(
     "highlight",
-    "Draw a visual highlight around a UI element on the device screen for debugging.",
+    "Draw a visual highlight around a UI element.",
     highlightSchema,
     highlightHandler,
     false,

--- a/src/server/interactionTools.ts
+++ b/src/server/interactionTools.ts
@@ -119,8 +119,8 @@ export {
 // ============================================================================
 
 export const shakeSchema = addDeviceTargetingToSchema(z.object({
-  duration: z.number().optional().describe("Shake duration in ms (default: 1000). On iOS Simulator this contributes to the runner timeout budget."),
-  intensity: z.number().optional().describe("Shake acceleration intensity (default: 100). Ignored on iOS Simulator because XCTest shake has no intensity parameter."),
+  duration: z.number().optional().describe("Shake duration ms (default 1000)"),
+  intensity: z.number().optional().describe("Shake intensity (Android; default 100)"),
   platform: platformSchema
 }));
 
@@ -130,56 +130,47 @@ export const keyboardSchema = addDeviceTargetingToSchema(z.object({
 }));
 
 const tapOnSelectorSchema = z.union([
-  z.object({ elementId: z.string().min(1).describe("Element resource-id (e.g. \"com.app:id/btn_login\"). Only use for resource-id values.") }).strict(),
-  z.object({ text: z.string().min(1).describe("Element text, content-desc, or placeholder value from observe output.") }).strict()
-]).describe("Element to tap. Provide exactly one of elementId or text.");
+  z.object({ elementId: z.string().min(1).describe("Resource ID, e.g. com.app:id/btn_login") }).strict(),
+  z.object({ text: z.string().min(1).describe("Text, content-desc, or placeholder") }).strict()
+]).describe("Element to tap: elementId or text");
 
 export const tapOnSchema = addDeviceTargetingToSchema(z.object({
   selector: tapOnSelectorSchema,
   sibling: z.boolean().optional().describe(
-    "When true, tap a clickable sibling of the matched element instead of the element itself. " +
-    "Useful for tapping checkboxes, icons, or buttons adjacent to a text label."
+    "Tap a clickable sibling of the match, e.g. checkbox beside label"
   ),
   container: elementContainerSchema.optional().describe(
-    "Container selector object to scope search. Provide { \"elementId\": \"<id>\" } or { \"text\": \"<text>\" }."
+    "Scope search to a container"
   ),
   action: z.enum(["tap", "doubleTap", "longPress", "focus"]).default("tap").describe("Action type (default: tap)"),
   selectionStrategy: elementSelectionStrategySchema.optional().describe(
-    "Element selection strategy when multiple matches are found (default: first)"
+    "Selection strategy when multiple match (default: first)"
   ),
   duration: z.number().optional().describe("Long press duration (ms)"),
   searchUntil: z.object({
     duration: z.number().min(100).max(12000).optional().describe("Polling duration (ms, default: 500)"),
   }).optional().describe("Poll for element before tapping"),
   preTapStability: z.boolean().optional().describe(
-    "When true, refresh the accessibility hierarchy before tapping and require consecutive re-finds with " +
-    "stable bounds before dispatching the gesture. Prevents tapping stale coordinates when the UI is still " +
-    "settling (loading overlays, list refreshes, keyboard). Recommended for search result lists and dynamic content."
+    "Require stable bounds before tapping; use for dynamic UI"
   ),
   retryIfNoChange: z.boolean().optional().describe(
-    "When true, compare the view hierarchy before and after the tap. If unchanged (ghost tap detected), " +
-    "retry the tap once after a short delay. Recommended for taps that should cause obvious UI changes " +
-    "like navigation or screen transitions."
+    "Retry once if the view hierarchy is unchanged after tap"
   ),
   ensureTap: z.boolean().optional().describe(
-    "Convenience flag that enables both preTapStability and retryIfNoChange. " +
-    "Use on taps in dynamic UI where you want both stable bounds before tapping " +
-    "and ghost-tap detection after."
+    "Enable preTapStability and retryIfNoChange"
   ),
   platform: platformSchema
 }).strict());
 
 export const tapAnySchema = addDeviceTargetingToSchema(z.object({
   container: elementContainerSchema.optional().describe(
-    "Container selector object to scope search. Provide { \"elementId\": \"<id>\" } or { \"text\": \"<text>\" }."
+    "Scope search to a container"
   ),
   selectionStrategy: elementSelectionStrategySchema.optional().describe(
     "Element selection strategy: 'first' (default) or 'random'"
   ),
   scrollableContainer: z.boolean().optional().describe(
-    "Only search within scrollable containers (lists/RecyclerViews). " +
-    "Use this to avoid tapping search bars or other clickable UI elements " +
-    "when you want the first list item."
+    "Search only scrollable containers/lists"
   ),
   action: z.enum(["tap", "doubleTap", "longPress"]).default("tap").describe("Action type (default: tap)"),
   duration: z.number().optional().describe("Long press duration (ms)"),
@@ -218,12 +209,12 @@ export const dragAndDropSchema = addDeviceTargetingToSchema(z.object({
 export const swipeOnSchema = addDeviceTargetingToSchema(z.object({
   includeSystemInsets: z.boolean().optional().describe("Use full screen including status/nav bars"),
   container: elementContainerSchema.optional().describe(
-    "Container selector object to scope search. Provide { \"elementId\": \"<id>\" } or { \"text\": \"<text>\" }."
+    "Scope search to a container"
   ),
   autoTarget: z.boolean().optional().describe("Auto-target scrollable containers (default: true)"),
   direction: z.enum(["up", "down", "left", "right"]).describe("Swipe/scroll direction"),
   gestureType: z.enum(["swipeFingerTowardsDirection", "scrollTowardsDirection"]).optional()
-    .describe("swipeFingerTowardsDirection: finger moves in direction (e.g., 'up' = finger up = content scrolls down). scrollTowardsDirection: content moves in direction (e.g., 'up' = content up = see content below). Default: scrollTowardsDirection."),
+    .describe("Finger direction or content scroll direction; default: scrollTowardsDirection"),
   lookFor: swipeOnLookForSchema.optional().describe("Element to look for during swipe"),
   boomerang: z.boolean().optional().describe("Return to start position after swipe apex"),
   apexPause: z.number().min(0).max(3000).optional().describe("Pause duration at swipe apex in ms (0-3000)"),
@@ -241,7 +232,7 @@ export const pinchOnSchema = addDeviceTargetingToSchema(z.object({
   rotationDegrees: z.number().optional().describe("Rotation during pinch (degrees)"),
   includeSystemInsets: z.boolean().optional().describe("Use full screen including status/nav bars"),
   container: elementContainerSchema.optional().describe(
-    "Container selector object to scope search. Provide { \"elementId\": \"<id>\" } or { \"text\": \"<text>\" }."
+    "Scope search to a container"
   ),
   autoTarget: z.boolean().optional().describe("Auto-target pinchable containers"),
   platform: platformSchema
@@ -256,8 +247,7 @@ export const selectAllTextSchema = addDeviceTargetingToSchema(z.object({
 }));
 
 export const pressButtonSchema = addDeviceTargetingToSchema(z.object({
-  button: z.enum(["home", "back", "menu", "power", "volume_up", "volume_down", "recent"])
-    .describe("Button to press"),
+  button: z.enum(["home", "back", "menu", "power", "volume_up", "volume_down", "recent"]),
   platform: platformSchema
 }));
 
@@ -270,7 +260,7 @@ const systemTrayNotificationSchema = z.object({
 
 const systemTraySchemaBase = z.object({
   action: z.enum(["open", "close", "find", "tap", "dismiss", "clearAll"]).describe(
-    "Action: open=expand tray, close=collapse tray/shade, find=search for notification, tap=tap notification, dismiss=swipe away, clearAll=dismiss all for app"
+    "open/close/find/tap/dismiss/clearAll notification"
   ),
   notification: systemTrayNotificationSchema.optional().describe("Notification criteria to match"),
   awaitTimeout: z.number().optional().describe("Timeout in ms to wait for notification (default: 5000)"),
@@ -308,24 +298,24 @@ export const systemTraySchema = addDeviceTargetingToSchema(systemTraySchemaBase)
 });
 
 export const stopAppSchema = addDeviceTargetingToSchema(z.object({
-  appId: z.string().describe("App package ID"),
+  appId: z.string(),
   platform: platformSchema
 }));
 
 export const clearStateSchema = addDeviceTargetingToSchema(z.object({
-  appId: z.string().describe("App package ID"),
+  appId: z.string(),
   clearKeychain: z.boolean().optional().describe("Clear iOS keychain"),
   platform: platformSchema
 }));
 
 export const inputTextSchema = addDeviceTargetingToSchema(z.object({
-  text: z.string().min(1).describe("Text to input"),
+  text: z.string().min(1),
   mode: z.enum(["a11y", "eventLast", "eventAll"]).optional()
-    .describe("(Android only; ignored on iOS) Text input mode. a11y (default) sets text directly. eventLast sets text with a11y up to the last printable non-whitespace ASCII character, sends that character as a real key event, then restores any suffix with a11y. eventAll clears the field with a11y, sends key events for mappable ASCII characters, and uses a11y for Unicode/emoji runs. Search fields that use autocomplete should probably try eventLast; otherwise accept the default."),
+    .describe("Android text mode: a11y default; eventLast helps autocomplete; eventAll sends key events"),
   imeAction: z.enum(["done", "next", "search", "send", "go", "previous"]).optional()
     .describe("IME action after input"),
   dismissKeyboard: z.boolean().optional()
-    .describe("(Android only) Dismiss soft keyboard after input (default: false). Ignored on iOS."),
+    .describe("Android: dismiss keyboard after input"),
   platform: platformSchema
 }));
 
@@ -348,7 +338,7 @@ export const homeScreenSchema = addDeviceTargetingToSchema(z.object({
 }));
 
 export const rotateSchema = addDeviceTargetingToSchema(z.object({
-  orientation: z.enum(["portrait", "landscape"]).describe("Orientation"),
+  orientation: z.enum(["portrait", "landscape"]),
   platform: platformSchema
 }));
 
@@ -360,24 +350,24 @@ const clipboardPlatformSchema = {
 
 export const clipboardSchema = z.discriminatedUnion("action", [
   addDeviceTargetingToSchema(z.object({
-    action: z.literal("copy").describe("Clipboard action: copy=set clipboard, paste=paste into focused field, clear=clear clipboard, get=get clipboard content"),
+    action: z.literal("copy").describe("Clipboard action"),
     text: z.string({ error: clipboardTextRequiredMessage })
       .min(1, clipboardTextRequiredMessage)
       .describe("Text to copy (required for 'copy' action)"),
     ...clipboardPlatformSchema,
   })),
   addDeviceTargetingToSchema(z.object({
-    action: z.literal("paste").describe("Clipboard action: copy=set clipboard, paste=paste into focused field, clear=clear clipboard, get=get clipboard content"),
+    action: z.literal("paste").describe("Clipboard action"),
     text: optionalClipboardTextSchema,
     ...clipboardPlatformSchema,
   })),
   addDeviceTargetingToSchema(z.object({
-    action: z.literal("clear").describe("Clipboard action: copy=set clipboard, paste=paste into focused field, clear=clear clipboard, get=get clipboard content"),
+    action: z.literal("clear").describe("Clipboard action"),
     text: optionalClipboardTextSchema,
     ...clipboardPlatformSchema,
   })),
   addDeviceTargetingToSchema(z.object({
-    action: z.literal("get").describe("Clipboard action: copy=set clipboard, paste=paste into focused field, clear=clear clipboard, get=get clipboard content"),
+    action: z.literal("get").describe("Clipboard action"),
     text: optionalClipboardTextSchema,
     ...clipboardPlatformSchema,
   }))
@@ -990,10 +980,7 @@ export function registerInteractionTools() {
 
   ToolRegistry.registerDeviceAware(
     "tapOn",
-    "Tap a specific UI element identified by text or resource-id.\n" +
-    "Provide a selector: { \"text\": \"Login\" } or { \"elementId\": \"com.app:id/btn\" }.\n" +
-    "Set sibling: true to tap a clickable sibling adjacent to the matched element (e.g., a checkbox next to a label).\n" +
-    "content-desc values from observe should be passed as text, not elementId.",
+    "Tap an element by text/content-desc or resource-id; use sibling for adjacent controls.",
     tapOnSchema,
     tapOnHandler,
     true,
@@ -1003,10 +990,7 @@ export function registerInteractionTools() {
 
   ToolRegistry.registerDeviceAware(
     "tapAny",
-    "Tap any clickable element without knowing its text or ID. " +
-    "Good for tapping the first list item. Use container to scope, " +
-    "selectionStrategy to pick 'first' (default) or 'random', and " +
-    "scrollableContainer: true to limit to list/RecyclerView items.",
+    "Tap any clickable element; scope with container or scrollableContainer.",
     tapAnySchema,
     tapAnyHandler,
     true
@@ -1038,7 +1022,7 @@ export function registerInteractionTools() {
 
   ToolRegistry.registerDeviceAware(
     "shake",
-    "Shake device. iOS support is Simulator-only; physical iOS devices are not supported by XCTest.",
+    "Shake device; iOS Simulator only.",
     shakeSchema,
     shakeHandler,
     true // Supports progress notifications

--- a/src/server/networkTools.ts
+++ b/src/server/networkTools.ts
@@ -19,10 +19,10 @@ const simulateErrorsSchema = z.object({
   errorType: z
     .enum(["http500", "timeout", "connectionRefused", "dnsFailure", "tlsFailure"])
     .optional()
-    .describe("Type of error to simulate. Default: http500"),
-  limit: z.number().int().positive().optional().describe("Max errors to inject. Omit for unlimited"),
-  durationSeconds: z.number().positive().optional().describe("How long to simulate errors. Required unless cancel is true"),
-  cancel: z.boolean().optional().describe("Set to true to cancel active simulation"),
+    .describe("Error type; default http500"),
+  limit: z.number().int().positive().optional().describe("Max errors"),
+  durationSeconds: z.number().positive().optional().describe("Simulation duration seconds"),
+  cancel: z.boolean().optional().describe("Cancel active simulation"),
 }).superRefine((value, ctx) => {
   if (value.cancel !== true && value.durationSeconds === undefined) {
     ctx.addIssue({
@@ -35,26 +35,26 @@ const simulateErrorsSchema = z.object({
 
 const networkSchema = addDeviceTargetingToSchema(
   z.object({
-    capture: z.boolean().optional().describe("Toggle network capture on/off"),
+    capture: z.boolean().optional().describe("Toggle capture"),
     simulateErrors: simulateErrorsSchema
       .optional()
-      .describe("Start error simulation, or set cancel:true to stop"),
+      .describe("Error simulation settings"),
     notifFilter: z
       .enum(["all", "errors", "slow"])
       .optional()
-      .describe("Filter which events trigger resource notifications"),
+      .describe("Notification filter"),
     notifDebounceMs: z
       .number()
       .int()
       .min(0)
       .optional()
-      .describe("Debounce interval for notifications in ms. Default: 100"),
+      .describe("Notification debounce ms"),
     slowThresholdMs: z
       .number()
       .int()
       .positive()
       .optional()
-      .describe("Duration threshold in ms for 'slow' filter. Default: 2000"),
+      .describe("Slow threshold ms"),
   })
 );
 
@@ -66,20 +66,20 @@ const mockNetworkSchema = addDeviceTargetingToSchema(
   z.object({
     host: z.string().describe("Host pattern (regex)"),
     path: z.string().describe("Path pattern (regex)"),
-    method: z.string().optional().describe("HTTP method to match. Default: * (any)"),
+    method: z.string().optional().describe("HTTP method; default *"),
     limit: z
       .number()
       .int()
       .positive()
       .optional()
-      .describe("Number of times to serve mock before reverting. Omit for unlimited"),
-    statusCode: z.number().int().min(100).max(599).optional().describe("Response status code. Default: 200"),
+      .describe("Mock response limit"),
+    statusCode: z.number().int().min(100).max(599).optional().describe("Response status; default 200"),
     responseHeaders: z
       .record(z.string(), z.string())
       .optional()
       .describe("Response headers"),
     responseBody: z.string().optional().describe("Response body (max 10KB)"),
-    contentType: z.string().optional().describe("Content-Type header. Default: application/json"),
+    contentType: z.string().optional().describe("Content-Type; default application/json"),
   })
 );
 
@@ -89,7 +89,7 @@ type MockNetworkArgs = z.infer<typeof mockNetworkSchema>;
 
 const clearMockNetworkSchema = addDeviceTargetingToSchema(
   z.object({
-    mockId: z.string().optional().describe("ID of specific mock to clear. Omit to clear all"),
+    mockId: z.string().optional().describe("Mock ID; omit to clear all"),
   })
 );
 
@@ -103,14 +103,14 @@ const getNetworkGraphSchema = addDeviceTargetingToSchema(
       .number()
       .positive()
       .optional()
-      .describe("Only include traffic from the last N seconds"),
+      .describe("Lookback seconds"),
     method: z.string().optional().describe("Filter by HTTP method"),
     minRequests: z
       .number()
       .int()
       .min(1)
       .optional()
-      .describe("Exclude endpoints with fewer requests. Default: 1"),
+      .describe("Minimum request count"),
   })
 );
 
@@ -167,7 +167,7 @@ export function registerNetworkTools(): void {
   // --- network ---
   ToolRegistry.registerDeviceAware(
     "network",
-    "Control network capture, error simulation, and notification settings. Call with no args to read current state.",
+    "Control network capture and error simulation.",
     networkSchema,
     async (device, args: NetworkArgs) => {
       if (args.capture !== undefined) {
@@ -208,13 +208,16 @@ export function registerNetworkTools(): void {
       }
 
       return createJSONToolResponse(state.getSnapshot());
-    }
+    },
+    false,
+    false,
+    { embeddedSdkOnly: true }
   );
 
   // --- mockNetwork ---
   ToolRegistry.registerDeviceAware(
     "mockNetwork",
-    "Add a mock response rule for matching Android or iOS SDK-integrated network requests. Requires --network-mockable flag.",
+    "Add mock network response rule.",
     mockNetworkSchema,
     async (device, args: MockNetworkArgs) => {
       if (!serverConfig.isNetworkMockableEnabled()) {
@@ -258,13 +261,16 @@ export function registerNetworkTools(): void {
         mockId: mock.mockId,
         mocked: state.getMockSummary(),
       });
-    }
+    },
+    false,
+    false,
+    { embeddedSdkOnly: true }
   );
 
   // --- clearMockNetwork ---
   ToolRegistry.registerDeviceAware(
     "clearMockNetwork",
-    "Clear Android or iOS mock network response rules. Optionally target a specific mock by ID. Requires --network-mockable flag.",
+    "Clear mock network response rules.",
     clearMockNetworkSchema,
     async (device, args: ClearMockNetworkArgs) => {
       if (!serverConfig.isNetworkMockableEnabled()) {
@@ -294,13 +300,16 @@ export function registerNetworkTools(): void {
         cleared,
         remaining: state.getMockSummary(),
       });
-    }
+    },
+    false,
+    false,
+    { embeddedSdkOnly: true }
   );
 
   // --- getNetworkGraph ---
   ToolRegistry.registerDeviceAware(
     "getNetworkGraph",
-    "Get an aggregate URL tree of captured network traffic with stats (success/error counts, p50/p95 latency).",
+    "Get aggregate captured network graph.",
     getNetworkGraphSchema,
     async (device, args: GetNetworkGraphArgs) => {
       const sinceTimestamp = args.sinceSeconds
@@ -319,6 +328,9 @@ export function registerNetworkTools(): void {
       });
 
       return createJSONToolResponse(graph);
-    }
+    },
+    false,
+    false,
+    { embeddedSdkOnly: true }
   );
 }

--- a/src/server/notificationTools.ts
+++ b/src/server/notificationTools.ts
@@ -21,9 +21,9 @@ const postNotificationCommonShape = {
   title: z.string().min(1).describe("Notification title"),
   body: z.string().min(1).describe("Notification body"),
   imageType: z.enum(["normal", "bigPicture"]).optional().describe("Notification image type (default: normal)"),
-  imagePath: z.string().optional().describe("Host image file path to push to /sdcard/Download/automobile when imageType is bigPicture"),
-  actions: z.array(actionSchema).optional().describe("Action buttons to include (Android only)"),
-  channelId: z.string().optional().describe("Notification channel ID (Android); reused as the APNs category on iOS"),
+  imagePath: z.string().optional().describe("Host image path for bigPicture"),
+  actions: z.array(actionSchema).optional().describe("Android action buttons"),
+  channelId: z.string().optional().describe("Android channel ID / iOS APNs category"),
 };
 
 export const postNotificationSchema = z.discriminatedUnion("platform", [
@@ -31,23 +31,23 @@ export const postNotificationSchema = z.discriminatedUnion("platform", [
     ...postNotificationCommonShape,
     appId: z.string({ error: iosAppIdRequiredMessage })
       .min(1, iosAppIdRequiredMessage)
-      .describe("iOS bundle identifier to target (required on iOS; maps to APNs 'Simulator Target Bundle'). Ignored on Android."),
-    platform: z.literal("ios").describe("Target platform")
+      .describe("iOS target bundle ID"),
+    platform: z.literal("ios")
   })),
   addDeviceTargetingToSchema(z.object({
     ...postNotificationCommonShape,
-    appId: z.string().min(1).optional().describe("iOS bundle identifier to target (required on iOS; maps to APNs 'Simulator Target Bundle'). Ignored on Android."),
-    platform: z.literal("android").describe("Target platform")
+    appId: z.string().min(1).optional().describe("iOS target bundle ID"),
+    platform: z.literal("android")
   }))
 ]);
 
 export const getNotificationPolicySchema = addDeviceTargetingToSchema(z.object({
-  appId: z.string().min(1).describe("App package ID or bundle identifier"),
+  appId: z.string().min(1),
 }));
 
 export const setNotificationPolicySchema = addDeviceTargetingToSchema(z.object({
-  appId: z.string().min(1).describe("App package ID or bundle identifier"),
-  policyAccess: z.boolean().describe("Android only: allow or revoke app notification policy / DND access"),
+  appId: z.string().min(1),
+  policyAccess: z.boolean().describe("Android: allow DND policy access"),
 }));
 
 export type GetNotificationPolicyArgs = z.infer<typeof getNotificationPolicySchema>;
@@ -109,22 +109,21 @@ export function registerNotificationTools() {
 
   ToolRegistry.registerDeviceAware(
     "postNotification",
-    "Post a notification: on Android, from the app-under-test when AutoMobile SDK hooks are installed; " +
-    "on the iOS Simulator, deliver a simulated remote push to the given bundle id via 'simctl push' (requires appId; physical iOS devices unsupported).",
+    "Post notification via Android SDK hooks or iOS Simulator simctl push.",
     postNotificationSchema,
     postNotificationHandler
   );
 
   ToolRegistry.registerDeviceAware(
     "getNotificationPolicy",
-    "Read app notification policy state, including Android Do Not Disturb policy access",
+    "Read app notification/DND policy state",
     getNotificationPolicySchema,
     getNotificationPolicyHandler
   );
 
   ToolRegistry.registerDeviceAware(
     "setNotificationPolicy",
-    "Set app notification policy state, including Android Do Not Disturb policy access",
+    "Set app notification/DND policy state",
     setNotificationPolicySchema,
     setNotificationPolicyHandler
   );

--- a/src/server/observeTools.ts
+++ b/src/server/observeTools.ts
@@ -24,7 +24,7 @@ import { serverConfig } from "../utils/ServerConfig";
 const waitForContainerField = elementContainerSchema
   .optional()
   .describe(
-    "Scope the match inside this container. Use when resource IDs repeat (e.g. id/name in a RecyclerView)."
+    "Scope match to a container"
   );
 
 const waitForSchema = z.union([
@@ -43,8 +43,8 @@ const waitForSchema = z.union([
 export const observeSchema = addDeviceTargetingToSchema(z.object({
   platform: platformSchema,
   waitFor: waitForSchema.optional().describe("Wait for element to appear before returning observation"),
-  raw: z.boolean().optional().describe("When true, include unprocessed view hierarchy in response alongside normal output (default: false)"),
-  skipBackStack: z.boolean().optional().describe("When true, skip back stack collection during waitFor polling to reduce ADB overhead (default: false)")
+  raw: z.boolean().optional().describe("Include raw view hierarchy"),
+  skipBackStack: z.boolean().optional().describe("Skip back stack during waitFor polling")
 }));
 
 export const identifyInteractionsSchema = addDeviceTargetingToSchema(z.object({

--- a/src/server/planTools.ts
+++ b/src/server/planTools.ts
@@ -25,24 +25,23 @@ const testMetadataSchema = z.object({
 // Execute plan tool schema
 const executePlanSchema = z.object({
   planContent: z.string().describe("YAML plan content"),
-  startStep: z.number().default(0).describe("Start step index (0-based, default: 0)"),
-  platform: z.enum(["android", "ios"]).describe("Target platform"),
-  sessionUuid: z.string().optional().describe("Session UUID for parallel execution"),
-  keepScreenAwake: z.boolean().optional().describe("Keep device awake"),
-  deviceId: z.string().optional().describe("Device ID"),
+  startStep: z.number().default(0).describe("Start step index"),
+  platform: z.enum(["android", "ios"]),
+  sessionUuid: z.string().optional().describe("Session"),
+  keepScreenAwake: z.boolean().optional(),
+  deviceId: z.string().optional(),
   device: z.string().optional().describe(DEVICE_LABEL_DESCRIPTION),
-  devices: z.array(z.string()).optional().describe("Device labels for multi-device plans"),
-  deviceAllocationTimeoutMs: z.number().default(300000).describe("Timeout in milliseconds for allocating all devices (default: 300000 = 5 minutes)"),
-  abortStrategy: z.enum(["immediate", "finish-current-step"]).default("immediate").describe("Abort strategy: immediate (default) or finish-current-step"),
-  testMetadata: testMetadataSchema.optional().describe("Test metadata for timing history"),
-  cleanupAppId: z.string().optional().describe("App ID to terminate after execution"),
-  cleanupClearAppData: z.boolean().optional().describe("Clear app data on cleanup"),
+  devices: z.array(z.string()).optional().describe("Device labels"),
+  deviceAllocationTimeoutMs: z.number().default(300000).describe("Allocation timeout ms"),
+  abortStrategy: z.enum(["immediate", "finish-current-step"]).default("immediate").describe("Abort strategy"),
+  testMetadata: testMetadataSchema.optional().describe("Test metadata"),
+  cleanupAppId: z.string().optional().describe("Cleanup app ID"),
+  cleanupClearAppData: z.boolean().optional().describe("Clear app data"),
   captureObserveSteps: z
     .enum(["summary", "full"])
     .optional()
     .describe(
-      "Single-device plans only: attach each successful observe step snapshot to executePlan result `debug.steps[n].details.stepObservation` " +
-        "(`summary` = metadata + element samples; `full` = includes viewHierarchy). Ignored for multi-device plans."
+      "Attach observe snapshots"
     )
 });
 
@@ -74,7 +73,7 @@ const executePlanResultSchema = z.object({
     failureObservation: z.any().optional()
   }).optional(),
   error: z.string().optional(),
-  platform: z.enum(["android", "ios"]).describe("Target platform").optional(),
+  platform: z.enum(["android", "ios"]).optional(),
   deviceId: z.string().optional(),
   deviceMapping: z.record(z.string(), z.string()).optional(),
   debug: executePlanDebugSchema.optional()
@@ -148,8 +147,8 @@ const startTestRecordingTool = async (device: BootedDevice): Promise<any> => {
 
 // Export plan tool schema
 const exportPlanSchema = z.object({
-  recordingId: z.string().optional().describe("Recording ID to export (uses active recording if not specified)"),
-  planName: z.string().optional().describe("Name for the exported plan (auto-generated if not specified)"),
+  recordingId: z.string().optional().describe("Recording ID"),
+  planName: z.string().optional().describe("Plan name"),
 });
 
 const exportPlanResultSchema = z.object({
@@ -213,8 +212,8 @@ const exportPlanTool = async (params: {
 // ============================================================================
 
 const recordStepsSchema = z.object({
-  action: z.enum(["begin", "end", "status"]).describe("begin: start capturing tool calls. end: stop and export the recorded plan as YAML. status: check if a recording session is active."),
-  planName: z.string().optional().describe("Name for the exported plan (kebab-case recommended, auto-generated if not specified). Only used with action 'end'."),
+  action: z.enum(["begin", "end", "status"]),
+  planName: z.string().optional().describe("Plan name for action=end"),
 });
 
 const recordStepsResultSchema = z.object({
@@ -292,7 +291,7 @@ const recordStepsTool = async (params: { action: "begin" | "end" | "status"; pla
 export const registerPlanTools = () => {
   ToolRegistry.registerDeviceAware(
     "executePlan",
-    "Execute a series of tool calls from a YAML plan content. Stops execution if any step fails (success: false). Optionally can resume execution from a specific step index.",
+    "Execute YAML plan steps; stops on first failed step.",
     executePlanSchema,
     executePlanTool,
     true,
@@ -302,7 +301,7 @@ export const registerPlanTools = () => {
 
   ToolRegistry.registerDeviceAware(
     "startTestRecording",
-    "Start test recording mode on the active device. Records user interactions for later export as a test plan. Returns the session ID which can be used with exportPlan.",
+    "Start recording user interactions for exportPlan.",
     startTestRecordingSchema,
     startTestRecordingTool,
     false,
@@ -312,7 +311,7 @@ export const registerPlanTools = () => {
 
   ToolRegistry.register(
     "exportPlan",
-    "Stop the active test recording and export recorded interactions as a YAML plan. Returns the plan content.",
+    "Stop active recording and export a YAML plan.",
     exportPlanSchema,
     exportPlanTool,
     false,
@@ -323,7 +322,7 @@ export const registerPlanTools = () => {
   // MCP call recording — begin/end gated by "mcp-recording" feature flag; status always available.
   ToolRegistry.register(
     "recordSteps",
-    "Record MCP tool calls as a replayable YAML test plan. Actions: 'begin' starts capturing plan-relevant tool calls, 'end' stops and exports the plan as YAML (both require the 'mcp-recording' feature flag), 'status' checks if a recording session is active (always available, even when the flag is off).",
+    "Record MCP tool calls to YAML. begin/end require mcp-recording; status always works.",
     recordStepsSchema,
     recordStepsTool,
     false,

--- a/src/server/snapshotTools.ts
+++ b/src/server/snapshotTools.ts
@@ -6,32 +6,32 @@ import { addDeviceTargetingToSchema } from "./toolSchemaHelpers";
 import { captureDeviceSnapshot, restoreDeviceSnapshot } from "./deviceSnapshotManager";
 
 const snapshotNameRequiredMessage = "snapshotName is required when action is restore";
-const optionalSnapshotNameSchema = z.string().min(1).optional().describe("Name for the snapshot");
+const optionalSnapshotNameSchema = z.string().min(1).optional().describe("Snapshot name");
 
 const deviceSnapshotCommonShape = {
-  includeAppData: z.boolean().optional().describe("Include app data directories in snapshot"),
-  includeSettings: z.boolean().optional().describe("Include system settings in snapshot"),
-  useVmSnapshot: z.boolean().optional().describe("Use emulator VM snapshot if available (faster, emulator only)"),
-  strictBackupMode: z.boolean().optional().describe("If true, fail entire snapshot if app data backup fails or times out"),
-  backupTimeoutMs: z.number().optional().describe("Timeout in milliseconds for adb backup user confirmation"),
+  includeAppData: z.boolean().optional().describe("Include app data"),
+  includeSettings: z.boolean().optional().describe("Include settings"),
+  useVmSnapshot: z.boolean().optional().describe("Use emulator VM snapshot"),
+  strictBackupMode: z.boolean().optional().describe("Fail if app data backup fails"),
+  backupTimeoutMs: z.number().optional().describe("adb backup confirmation timeout ms"),
   userApps: z.enum(["current", "all"]).optional()
-    .describe("Which apps to backup: 'current' (foreground app only) or 'all' (all user-installed apps)"),
-  vmSnapshotTimeoutMs: z.number().optional().describe("Timeout in milliseconds for emulator VM snapshot commands"),
+    .describe("Apps to back up: current or all"),
+  vmSnapshotTimeoutMs: z.number().optional().describe("VM snapshot timeout ms"),
   appBundleIds: z.array(z.string()).optional()
-    .describe("iOS-only: bundle IDs to include in app data snapshots (omit to skip app data capture)"),
+    .describe("iOS bundle IDs for app data snapshot"),
 };
 
 export const deviceSnapshotSchema = z.discriminatedUnion("action", [
   addDeviceTargetingToSchema(z.object({
-    action: z.literal("capture").describe("Action to perform"),
+    action: z.literal("capture"),
     snapshotName: optionalSnapshotNameSchema,
     ...deviceSnapshotCommonShape,
   })),
   addDeviceTargetingToSchema(z.object({
-    action: z.literal("restore").describe("Action to perform"),
+    action: z.literal("restore"),
     snapshotName: z.string({ error: snapshotNameRequiredMessage })
       .min(1, snapshotNameRequiredMessage)
-      .describe("Name for the snapshot"),
+      .describe("Snapshot name"),
     ...deviceSnapshotCommonShape,
   }))
 ]);
@@ -84,7 +84,7 @@ export function registerSnapshotTools() {
 
   ToolRegistry.registerDeviceAware(
     "deviceSnapshot",
-    "Capture or restore a device snapshot for the active device.",
+    "Capture or restore device snapshot.",
     deviceSnapshotSchema,
     deviceSnapshotHandler
   );

--- a/src/server/storageTools.ts
+++ b/src/server/storageTools.ts
@@ -35,11 +35,10 @@ const TYPE_GUIDANCE: Record<string, string> = {
 };
 
 const STORAGE_NAME_DESCRIPTION =
-  "Storage name: SharedPreferences file name (without .xml) on Android, " +
-  "UserDefaults suite name on iOS. Use 'Standard' for the default iOS suite.";
+  "Storage name";
 
 const legacyFileNameDescription =
-  "Deprecated alias for `name`. Accepted for backward compatibility.";
+  "Deprecated alias for name";
 
 function resolveStorageName(args: { name?: string; fileName?: string }): string {
   return args.name ?? args.fileName!;
@@ -48,25 +47,23 @@ function resolveStorageName(args: { name?: string; fileName?: string }): string 
 // Schema for setKeyValue tool
 const setKeyValueSchema = z.union([
   addDeviceTargetingToSchema(z.object({
-    appId: z.string().describe("App identifier (package name on Android, bundle ID on iOS)"),
+    appId: z.string(),
     name: z.string().describe(STORAGE_NAME_DESCRIPTION),
     fileName: z.string().optional().describe(legacyFileNameDescription),
-    key: z.string().describe("The key to set"),
-    value: z.string().nullable().describe("The value to set, serialized as a string (null to clear)"),
+    key: z.string().describe("Key"),
+    value: z.string().nullable().describe("Value string; null clears"),
     type: z.enum(KEY_VALUE_TYPES).describe(
-      "Value type. Android: STRING, INT, LONG, FLOAT, BOOLEAN, STRING_SET. " +
-      "iOS: STRING, INT, DOUBLE, BOOLEAN, DATA, DATE, ARRAY, DICTIONARY."
+      "Value type"
     ),
   })),
   addDeviceTargetingToSchema(z.object({
-    appId: z.string().describe("App identifier (package name on Android, bundle ID on iOS)"),
+    appId: z.string(),
     name: z.string().optional().describe(STORAGE_NAME_DESCRIPTION),
     fileName: z.string().describe(legacyFileNameDescription),
-    key: z.string().describe("The key to set"),
-    value: z.string().nullable().describe("The value to set, serialized as a string (null to clear)"),
+    key: z.string().describe("Key"),
+    value: z.string().nullable().describe("Value string; null clears"),
     type: z.enum(KEY_VALUE_TYPES).describe(
-      "Value type. Android: STRING, INT, LONG, FLOAT, BOOLEAN, STRING_SET. " +
-      "iOS: STRING, INT, DOUBLE, BOOLEAN, DATA, DATE, ARRAY, DICTIONARY."
+      "Value type"
     ),
   })),
 ]);
@@ -74,28 +71,28 @@ const setKeyValueSchema = z.union([
 // Schema for removeKeyValue tool
 const removeKeyValueSchema = z.union([
   addDeviceTargetingToSchema(z.object({
-    appId: z.string().describe("App identifier (package name on Android, bundle ID on iOS)"),
+    appId: z.string(),
     name: z.string().describe(STORAGE_NAME_DESCRIPTION),
     fileName: z.string().optional().describe(legacyFileNameDescription),
-    key: z.string().describe("The key to remove"),
+    key: z.string().describe("Key"),
   })),
   addDeviceTargetingToSchema(z.object({
-    appId: z.string().describe("App identifier (package name on Android, bundle ID on iOS)"),
+    appId: z.string(),
     name: z.string().optional().describe(STORAGE_NAME_DESCRIPTION),
     fileName: z.string().describe(legacyFileNameDescription),
-    key: z.string().describe("The key to remove"),
+    key: z.string().describe("Key"),
   })),
 ]);
 
 // Schema for clearKeyValueFile tool
 const clearKeyValueFileSchema = z.union([
   addDeviceTargetingToSchema(z.object({
-    appId: z.string().describe("App identifier (package name on Android, bundle ID on iOS)"),
+    appId: z.string(),
     name: z.string().describe(STORAGE_NAME_DESCRIPTION),
     fileName: z.string().optional().describe(legacyFileNameDescription),
   })),
   addDeviceTargetingToSchema(z.object({
-    appId: z.string().describe("App identifier (package name on Android, bundle ID on iOS)"),
+    appId: z.string(),
     name: z.string().optional().describe(STORAGE_NAME_DESCRIPTION),
     fileName: z.string().describe(legacyFileNameDescription),
   })),
@@ -270,25 +267,31 @@ export function registerStorageTools(): void {
 
   ToolRegistry.registerDeviceAware(
     "setKeyValue",
-    "Set a key-value entry in an app's storage (Android SharedPreferences or iOS UserDefaults). " +
-    "Requires the app to have AutoMobile SDK integrated with storage inspection enabled.",
+    "Set app key-value storage entry.",
     setKeyValueSchema,
-    setKeyValueHandler
+    setKeyValueHandler,
+    false,
+    false,
+    { embeddedSdkOnly: true }
   );
 
   ToolRegistry.registerDeviceAware(
     "removeKeyValue",
-    "Remove a key-value entry from an app's storage (Android SharedPreferences or iOS UserDefaults). " +
-    "Requires the app to have AutoMobile SDK integrated with storage inspection enabled.",
+    "Remove app key-value storage entry.",
     removeKeyValueSchema,
-    removeKeyValueHandler
+    removeKeyValueHandler,
+    false,
+    false,
+    { embeddedSdkOnly: true }
   );
 
   ToolRegistry.registerDeviceAware(
     "clearKeyValueFile",
-    "Clear all key-value entries from an app's storage file (Android SharedPreferences or iOS UserDefaults suite). " +
-    "Requires the app to have AutoMobile SDK integrated with storage inspection enabled.",
+    "Clear app key-value storage file.",
     clearKeyValueFileSchema,
-    clearKeyValueFileHandler
+    clearKeyValueFileHandler,
+    false,
+    false,
+    { embeddedSdkOnly: true }
   );
 }

--- a/src/server/telephonyTools.ts
+++ b/src/server/telephonyTools.ts
@@ -7,22 +7,19 @@ import { addDeviceTargetingToSchema } from "./toolSchemaHelpers";
 
 export const phoneCallSchema = addDeviceTargetingToSchema(z.object({
   action: z.enum(["call", "accept", "cancel", "busy", "hold"]).describe(
-    "Phone call action: 'call' simulates an incoming call; 'accept' answers a ringing or waiting call; " +
-    "'cancel' ends the call from the network side; 'busy' rejects a waiting call with a busy signal; " +
-    "'hold' puts the active call on hold (no phoneNumber required)."
+    "call/accept/cancel/busy/hold; hold needs no phoneNumber"
   ),
   phoneNumber: z.string().optional().describe(
-    "Phone number for the call action. Required for all actions except 'hold'. " +
-    "Digits with optional leading '+', max 20 digits."
+    "Phone number; required except for hold"
   )
 }));
 
 export const sendSmsSchema = addDeviceTargetingToSchema(z.object({
   phoneNumber: z.string().describe(
-    "Sender phone number for the simulated incoming SMS. Digits with optional leading '+', max 20 digits."
+    "Sender phone number"
   ),
   message: z.string().describe(
-    "SMS message body. Max 1024 characters. Must not contain newlines, carriage returns, or NUL bytes."
+    "SMS body; max 1024 chars, no newlines/NUL"
   )
 }));
 
@@ -70,16 +67,14 @@ export function registerTelephonyTools() {
 
   ToolRegistry.registerDeviceAware(
     "phoneCall",
-    "Simulate an incoming phone call on an Android emulator via the emulator console (gsm call/accept/cancel/busy/hold). " +
-    "Emulator-only: physical devices return an unsupported error.",
+    "Simulate Android emulator phone call via gsm commands.",
     phoneCallSchema,
     phoneCallHandler
   );
 
   ToolRegistry.registerDeviceAware(
     "sendSms",
-    "Send a simulated incoming SMS to an Android emulator via the emulator console (sms send). " +
-    "Emulator-only: physical devices return an unsupported error.",
+    "Send simulated incoming SMS on Android emulator.",
     sendSmsSchema,
     sendSmsHandler
   );

--- a/src/server/toolRegistry.ts
+++ b/src/server/toolRegistry.ts
@@ -218,6 +218,7 @@ interface DeviceAwareToolOptions<T = any> {
   shouldEnsureDevice?: (args: T) => boolean;
   nonDeviceHandler?: ToolHandler<T>;
   outputSchema?: any;
+  embeddedSdkOnly?: boolean;
 }
 
 // Interface for a registered tool
@@ -230,6 +231,7 @@ export interface RegisteredTool {
   requiresDevice?: boolean;
   deviceAwareHandler?: DeviceAwareToolHandler;
   debugOnly?: boolean;
+  embeddedSdkOnly?: boolean;
   outputSchema?: any;
 }
 
@@ -249,7 +251,13 @@ class ToolRegistryClass {
   }
 
   private isToolAvailable(tool: RegisteredTool): boolean {
-    return !tool.debugOnly || isDebugModeEnabled();
+    if (tool.debugOnly && !isDebugModeEnabled()) {
+      return false;
+    }
+    if (tool.embeddedSdkOnly && !serverConfig.isEmbeddedSdkEnabled()) {
+      return false;
+    }
+    return true;
   }
 
   // Register a new tool
@@ -270,6 +278,7 @@ class ToolRegistryClass {
       supportsProgress,
       requiresDevice: false,
       debugOnly,
+      embeddedSdkOnly: false,
       outputSchema
     });
   }
@@ -643,6 +652,7 @@ class ToolRegistryClass {
       requiresDevice: true,
       deviceAwareHandler: handler,
       debugOnly,
+      embeddedSdkOnly: options.embeddedSdkOnly ?? false,
       outputSchema: options.outputSchema
     });
   }

--- a/src/server/toolRegistry.ts
+++ b/src/server/toolRegistry.ts
@@ -219,6 +219,7 @@ interface DeviceAwareToolOptions<T = any> {
   nonDeviceHandler?: ToolHandler<T>;
   outputSchema?: any;
   embeddedSdkOnly?: boolean;
+  planExecutable?: boolean;
 }
 
 // Interface for a registered tool
@@ -232,6 +233,7 @@ export interface RegisteredTool {
   deviceAwareHandler?: DeviceAwareToolHandler;
   debugOnly?: boolean;
   embeddedSdkOnly?: boolean;
+  planExecutable?: boolean;
   outputSchema?: any;
 }
 
@@ -653,6 +655,7 @@ class ToolRegistryClass {
       deviceAwareHandler: handler,
       debugOnly,
       embeddedSdkOnly: options.embeddedSdkOnly ?? false,
+      planExecutable: options.planExecutable ?? false,
       outputSchema: options.outputSchema
     });
   }
@@ -779,6 +782,22 @@ class ToolRegistryClass {
   getTool(name: string): RegisteredTool | undefined {
     const tool = this.tools.get(name);
     if (!tool || !this.isToolAvailable(tool)) {
+      return undefined;
+    }
+    return tool;
+  }
+
+  // Get a tool for internal plan execution. Some tools are intentionally hidden
+  // from MCP navigation surfaces but remain valid in recorded/replayed plans.
+  getToolForPlan(name: string): RegisteredTool | undefined {
+    const tool = this.tools.get(name);
+    if (!tool) {
+      return undefined;
+    }
+    if (tool.embeddedSdkOnly && !serverConfig.isEmbeddedSdkEnabled()) {
+      return undefined;
+    }
+    if (tool.debugOnly && !isDebugModeEnabled() && !tool.planExecutable) {
       return undefined;
     }
     return tool;

--- a/src/server/toolSchemaHelpers.ts
+++ b/src/server/toolSchemaHelpers.ts
@@ -1,10 +1,10 @@
 import { z } from "zod";
 
 /** Shared platform schema — single source of truth for all tool schemas. */
-export const platformSchema = z.enum(["android", "ios"]).describe("Target platform");
+export const platformSchema = z.enum(["android", "ios"]);
 
 export const DEVICE_LABEL_DESCRIPTION =
-  "Plan device label";
+  "Device label";
 
 /**
  * Helper to add sessionUuid field to tool schemas
@@ -15,8 +15,8 @@ export const DEVICE_LABEL_DESCRIPTION =
  */
 export function addSessionUuidToSchema<T extends z.ZodObject<any>>(schema: T): z.ZodObject<any> {
   return schema.extend({
-    sessionUuid: z.string().optional().describe("Session ID"),
-    keepScreenAwake: z.boolean().optional().describe("Keep device awake"),
+    sessionUuid: z.string().optional().describe("Session"),
+    keepScreenAwake: z.boolean().optional(),
   }) as z.ZodObject<any>;
 }
 
@@ -41,7 +41,7 @@ function addDeviceLabelToSchema<T extends z.ZodObject<any>>(schema: T): z.ZodObj
  */
 function addDeviceIdToSchema<T extends z.ZodObject<any>>(schema: T): z.ZodObject<any> {
   return schema.extend({
-    deviceId: z.string().optional().describe("Device ID"),
+    deviceId: z.string().optional(),
   }) as z.ZodObject<any>;
 }
 

--- a/src/server/utilityTools.ts
+++ b/src/server/utilityTools.ts
@@ -13,7 +13,7 @@ import { DaemonState } from "../daemon/daemonState";
 
 // Schema definitions
 export const setActiveDeviceSchema = addSessionUuidToSchema(z.object({
-  deviceId: z.string().describe("Device ID"),
+  deviceId: z.string(),
   platform: platformSchema
 }));
 
@@ -42,7 +42,7 @@ const doNotDisturbStateInputSchema = z.object({
 export const getDeviceStateSchema = addDeviceTargetingToSchema(z.object({
   include: z.array(z.enum(["doNotDisturb"]))
     .optional()
-    .describe("Optional device state fields to read. Currently supports doNotDisturb.")
+    .describe("State fields to read; supports doNotDisturb")
 }));
 
 export const setDeviceStateSchema = addDeviceTargetingToSchema(z.object({
@@ -271,7 +271,7 @@ export function registerUtilityTools() {
 
   ToolRegistry.registerDeviceAware(
     "setDeviceState",
-    "Set device-level state such as Do Not Disturb. Android supports off/none/priority/alarms; iOS simulators support binary DND only.",
+    "Set device state such as Do Not Disturb.",
     setDeviceStateSchema,
     setDeviceStateHandler
   );

--- a/src/server/videoRecordingTools.ts
+++ b/src/server/videoRecordingTools.ts
@@ -43,8 +43,8 @@ export interface VideoRecordingArgs {
 }
 
 const resolutionSchema = z.object({
-  width: z.number().int().positive().describe("Override resolution width in pixels"),
-  height: z.number().int().positive().describe("Override resolution height in pixels"),
+  width: z.number().int().positive(),
+  height: z.number().int().positive(),
 });
 
 const highlightTimingSchema = z.object({
@@ -52,31 +52,31 @@ const highlightTimingSchema = z.object({
 });
 
 const highlightSchema = z.object({
-  description: z.string().optional().describe("Description of the highlight"),
-  shape: highlightShapeSchema.describe("Highlight shape definition"),
-  timing: highlightTimingSchema.optional().describe("Optional highlight timing"),
+  description: z.string().optional().describe("Highlight description"),
+  shape: highlightShapeSchema.describe("Highlight shape"),
+  timing: highlightTimingSchema.optional().describe("Highlight timing"),
 });
 
 const videoRecordingSchema = addDeviceTargetingToSchema(z.object({
-  action: z.enum(["start", "stop"]).describe("Action to perform"),
+  action: z.enum(["start", "stop"]),
   platform: platformSchema,
-  deviceId: z.string().optional().describe("Optional device ID override"),
-  recordingId: z.string().optional().describe("Recording ID to stop"),
-  qualityPreset: z.enum(["low", "medium", "high"]).optional().describe("Recording quality preset"),
-  targetBitrateKbps: z.number().int().positive().optional().describe("Target bitrate in Kbps"),
-  maxThroughputMbps: z.number().positive().optional().describe("Max throughput in Mbps"),
-  fps: z.number().int().positive().optional().describe("Frames per second"),
-  resolution: resolutionSchema.optional().describe("Override capture resolution"),
-  format: z.enum(["mp4"]).optional().describe("Video format"),
+  deviceId: z.string().optional(),
+  recordingId: z.string().optional().describe("Recording ID"),
+  qualityPreset: z.enum(["low", "medium", "high"]).optional(),
+  targetBitrateKbps: z.number().int().positive().optional().describe("Bitrate Kbps"),
+  maxThroughputMbps: z.number().positive().optional().describe("Max throughput Mbps"),
+  fps: z.number().int().positive().optional().describe("FPS"),
+  resolution: resolutionSchema.optional().describe("Resolution"),
+  format: z.enum(["mp4"]).optional(),
   maxDuration: z
     .number()
     .int()
     .positive()
     .max(300)
     .optional()
-    .describe("Max seconds to record video for (default 30, max 300)"),
-  outputName: z.string().optional().describe("Optional label to identify the recording"),
-  highlights: z.array(highlightSchema).optional().describe("Optional highlights to show during recording"),
+    .describe("Max duration seconds"),
+  outputName: z.string().optional().describe("Recording label"),
+  highlights: z.array(highlightSchema).optional().describe("Recording highlights"),
 }));
 
 function buildConfigOverrides(args: VideoRecordingArgs): VideoRecordingConfigInput {
@@ -319,7 +319,7 @@ export function registerVideoRecordingTools(): void {
 
   ToolRegistry.registerDeviceAware(
     "videoRecording",
-    "Start or stop a low-overhead video recording for the active device.",
+    "Start or stop device video recording.",
     videoRecordingSchema,
     videoRecordingHandler,
     false,

--- a/src/utils/ServerConfig.ts
+++ b/src/utils/ServerConfig.ts
@@ -25,6 +25,7 @@ class ServerConfig {
   private _deviceSnapshotDefaults: DeviceSnapshotConfigInput = {};
   private _appearanceDefaults: AppearanceConfigInput = {};
   private _skipCtrlProxyDownload: boolean = false;
+  private _embeddedSdkEnabled: boolean = false;
   private _networkMockableEnabled: boolean = false;
   private _mcpRecordingEnabled: boolean = false;
   private _dismissKeyboardAfterInputEnabled: boolean = false;
@@ -126,6 +127,14 @@ class ServerConfig {
 
   isSkipCtrlProxyDownloadEnabled(): boolean {
     return this._skipCtrlProxyDownload;
+  }
+
+  setEmbeddedSdkEnabled(enabled: boolean): void {
+    this._embeddedSdkEnabled = enabled;
+  }
+
+  isEmbeddedSdkEnabled(): boolean {
+    return this._embeddedSdkEnabled;
   }
 
   setNetworkMockableEnabled(enabled: boolean): void {

--- a/src/utils/plan/PlanExecutor.ts
+++ b/src/utils/plan/PlanExecutor.ts
@@ -364,7 +364,7 @@ export class DefaultPlanExecutor implements PlanExecutor {
         logger.info(`[PLAN_STEP_${i + 1}/${plan.steps.length}] Tool: ${step.tool}, Label: ${stepLabel}`);
 
         // Get the registered tool
-        const tool = ToolRegistry.getTool(step.tool);
+        const tool = ToolRegistry.getToolForPlan(step.tool);
         if (!tool) {
           logger.info(`Could not find tool: ${step.tool}`);
 
@@ -860,7 +860,7 @@ export class DefaultPlanExecutor implements PlanExecutor {
         );
 
         // Get the registered tool
-        const tool = ToolRegistry.getTool(step.tool);
+        const tool = ToolRegistry.getToolForPlan(step.tool);
         if (!tool) {
           logger.error(`[PARALLEL_EXEC][${device}] Unknown tool: ${step.tool}`);
           return {

--- a/test/daemon/daemonMcpProxy.test.ts
+++ b/test/daemon/daemonMcpProxy.test.ts
@@ -313,6 +313,99 @@ describe("DaemonMcpProxy", () => {
       });
     });
 
+    describe("startup option mismatch handling", () => {
+      function runningStatus(options: { embeddedSdk?: boolean }) {
+        return {
+          running: true,
+          pid: 1234,
+          port: 3000,
+          socketPath: "/tmp/test.sock",
+          version: DAEMON_VERSION,
+          startedAt: ANCIENT_TIMESTAMP,
+          options,
+        };
+      }
+
+      test("restarts daemon when embedded SDK mode differs", async () => {
+        const fakeClient = new FakeDaemonClient({
+          daemonMethodResults: new Map([["tools/list", { tools: [] }]]),
+        });
+        const fakeManager = new FakeDaemonManager();
+        fakeManager.statusResults = [
+          runningStatus({ embeddedSdk: false }),
+          runningStatus({ embeddedSdk: false }),
+          runningStatus({ embeddedSdk: true }),
+        ];
+        const isAvailableSpy = spyOn(DaemonClient, "isAvailable").mockResolvedValue(true);
+        const proxy = new DaemonMcpProxy({
+          clientFactory: () => fakeClient,
+          daemonManager: fakeManager,
+          daemonOptions: { embeddedSdk: true },
+        });
+
+        try {
+          await proxy.listTools();
+          expect(fakeManager.restartCalled).toBe(true);
+          expect(fakeManager.restartOptions).toEqual({ embeddedSdk: true });
+        } finally {
+          isAvailableSpy.mockRestore();
+          await proxy.close();
+        }
+      });
+
+      test("does not restart daemon when embedded SDK mode matches", async () => {
+        const fakeClient = new FakeDaemonClient({
+          daemonMethodResults: new Map([["tools/list", { tools: [] }]]),
+        });
+        const fakeManager = new FakeDaemonManager();
+        fakeManager.statusResults = [
+          runningStatus({ embeddedSdk: true }),
+          runningStatus({ embeddedSdk: true }),
+        ];
+        const isAvailableSpy = spyOn(DaemonClient, "isAvailable").mockResolvedValue(true);
+        const proxy = new DaemonMcpProxy({
+          clientFactory: () => fakeClient,
+          daemonManager: fakeManager,
+          daemonOptions: { embeddedSdk: true },
+        });
+
+        try {
+          await proxy.listTools();
+          expect(fakeManager.restartCalled).toBe(false);
+        } finally {
+          isAvailableSpy.mockRestore();
+          await proxy.close();
+        }
+      });
+
+      test("throws on embedded SDK mode mismatch when auto-start is disabled", async () => {
+        const fakeClient = new FakeDaemonClient({
+          daemonMethodResults: new Map([["tools/list", { tools: [] }]]),
+        });
+        const fakeManager = new FakeDaemonManager();
+        fakeManager.statusResults = [
+          runningStatus({ embeddedSdk: false }),
+          runningStatus({ embeddedSdk: false }),
+        ];
+        const isAvailableSpy = spyOn(DaemonClient, "isAvailable").mockResolvedValue(true);
+        const proxy = new DaemonMcpProxy({
+          clientFactory: () => fakeClient,
+          daemonManager: fakeManager,
+          autoStartDaemon: false,
+          daemonOptions: { embeddedSdk: true },
+        });
+
+        try {
+          await expect(proxy.listTools()).rejects.toThrow("startup options differ");
+          expect(fakeManager.restartCalled).toBe(false);
+          expect(fakeClient.isConnected()).toBe(false);
+        } finally {
+          isAvailableSpy.mockRestore();
+          await proxy.close();
+        }
+      });
+    });
+
     test("throws error when auto-start is disabled and daemon not running", async () => {
       const fakeClient = new FakeDaemonClient();
       const fakeManager = new FakeDaemonManager();

--- a/test/server/criticalSectionTools.test.ts
+++ b/test/server/criticalSectionTools.test.ts
@@ -23,7 +23,7 @@ describe("criticalSection tool", () => {
 
     expect(tool).toBeDefined();
     expect(tool?.name).toBe("criticalSection");
-    expect(tool?.description).toContain("Coordinate multiple devices");
+    expect(tool?.description).toContain("Synchronize multiple devices");
     expect(tool?.deviceAwareHandler).toBeDefined();
   });
 

--- a/test/server/databaseIos.test.ts
+++ b/test/server/databaseIos.test.ts
@@ -5,6 +5,7 @@ import { ResourceRegistry } from "../../src/server/resourceRegistry";
 import { ToolRegistry } from "../../src/server/toolRegistry";
 import { IOSCtrlProxyClient } from "../../src/features/observe/ios";
 import { PlatformDeviceManagerFactory } from "../../src/utils/factories/PlatformDeviceManagerFactory";
+import { serverConfig } from "../../src/utils/ServerConfig";
 import type { BootedDevice } from "../../src/models";
 
 describe("iOS database inspection server integration", function() {
@@ -21,6 +22,7 @@ describe("iOS database inspection server integration", function() {
     ResourceRegistry.clearResources();
     PlatformDeviceManagerFactory.reset();
     IOSCtrlProxyClient.resetInstances();
+    serverConfig.setEmbeddedSdkEnabled(true);
     originalGetInstance = IOSCtrlProxyClient.getInstance;
   });
 
@@ -30,6 +32,7 @@ describe("iOS database inspection server integration", function() {
     ResourceRegistry.clearResources();
     PlatformDeviceManagerFactory.reset();
     IOSCtrlProxyClient.resetInstances();
+    serverConfig.setEmbeddedSdkEnabled(false);
   });
 
   test("sqlQuery executes SELECT on iOS through CtrlProxy and keeps Android response shape", async function() {

--- a/test/server/deepLinkTools.test.ts
+++ b/test/server/deepLinkTools.test.ts
@@ -28,7 +28,7 @@ describe("Deep Link Tools Registration", function() {
 
       const tool = ToolRegistry.getTool("getDeepLinks");
       expect(tool).toBeDefined();
-      expect(tool!.description).toContain("Query deep links");
+      expect(tool!.description).toContain("Query app deep links");
       expect(tool!.supportsProgress).toBe(false);
 
       // Test schema validation

--- a/test/server/networkTools.test.ts
+++ b/test/server/networkTools.test.ts
@@ -32,6 +32,7 @@ describe("network tool schema", () => {
   beforeEach(() => {
     ToolRegistry.clearTools();
     NetworkState.resetInstance();
+    serverConfig.setEmbeddedSdkEnabled(true);
     serverConfig.setNetworkMockableEnabled(true);
     iosMessages = [];
     androidMessages = [];
@@ -53,6 +54,7 @@ describe("network tool schema", () => {
   afterEach(() => {
     ToolRegistry.clearTools();
     NetworkState.resetInstance();
+    serverConfig.setEmbeddedSdkEnabled(false);
     serverConfig.setNetworkMockableEnabled(false);
     iosGetInstanceSpy.mockRestore();
     androidGetInstanceSpy.mockRestore();

--- a/test/server/storageTools.test.ts
+++ b/test/server/storageTools.test.ts
@@ -1,14 +1,17 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { registerStorageTools } from "../../src/server/storageTools";
 import { ToolRegistry } from "../../src/server/toolRegistry";
+import { serverConfig } from "../../src/utils/ServerConfig";
 
 describe("Storage Tools Registration", () => {
   beforeEach(() => {
     (ToolRegistry as any).tools.clear();
+    serverConfig.setEmbeddedSdkEnabled(true);
   });
 
   afterEach(() => {
     (ToolRegistry as any).tools.clear();
+    serverConfig.setEmbeddedSdkEnabled(false);
   });
 
   test("registers all three storage write tools", () => {

--- a/test/server/toolRegistration.test.ts
+++ b/test/server/toolRegistration.test.ts
@@ -102,7 +102,17 @@ class ToolRegistrationValidator {
     // Debug-only tools (registered when isDebugModeEnabled() returns true)
     "bugReport",
     "debugSearch",
+    "accessibilityFocus",
+    "setUIState",
     "identifyInteractions",
+    "sqlQuery",
+    "setKeyValue",
+    "removeKeyValue",
+    "clearKeyValueFile",
+    "network",
+    "mockNetwork",
+    "clearMockNetwork",
+    "getNetworkGraph",
 
     // Feature-flag controlled tools
     "criticalSection",
@@ -433,7 +443,7 @@ describe("Tool Registration Validation (Unit Tests)", () => {
         });
       }
 
-      // Schema file has 38 tools (2 conditionally registered)
+      // Schema file may differ by the number of conditionally exposed tools.
       expect(() => {
         validator.validateToolCount(38);
       }).not.toThrow();
@@ -450,9 +460,11 @@ describe("Tool Registration Validation (Unit Tests)", () => {
         });
       }
 
-      // Schema file has 40 tools (difference of 10 > limit of 2)
+      const conditionalLimit = (validator as any).CONDITIONALLY_REGISTERED_TOOLS.size;
+      const schemaCountBeyondLimit = 30 + conditionalLimit + 1;
+
       expect(() => {
-        validator.validateToolCount(40);
+        validator.validateToolCount(schemaCountBeyondLimit);
       }).toThrow();
     });
   });

--- a/test/server/tools/daemonModeTools.test.ts
+++ b/test/server/tools/daemonModeTools.test.ts
@@ -36,6 +36,8 @@ describe("Daemon-only MCP tools", () => {
 
     expect(ToolRegistry.getTool("accessibilityFocus")).toBeUndefined();
     expect(ToolRegistry.getTool("setUIState")).toBeUndefined();
+    expect(ToolRegistry.getToolForPlan("accessibilityFocus")).toBeUndefined();
+    expect(ToolRegistry.getToolForPlan("setUIState")).toBeDefined();
     expect(ToolRegistry.getToolDefinitions().map(tool => tool.name)).not.toContain("accessibilityFocus");
     expect(ToolRegistry.getToolDefinitions().map(tool => tool.name)).not.toContain("setUIState");
 
@@ -45,6 +47,8 @@ describe("Daemon-only MCP tools", () => {
 
     expect(ToolRegistry.getTool("accessibilityFocus")).toBeDefined();
     expect(ToolRegistry.getTool("setUIState")).toBeDefined();
+    expect(ToolRegistry.getToolForPlan("accessibilityFocus")).toBeDefined();
+    expect(ToolRegistry.getToolForPlan("setUIState")).toBeDefined();
     expect(ToolRegistry.getToolDefinitions().map(tool => tool.name)).toContain("accessibilityFocus");
     expect(ToolRegistry.getToolDefinitions().map(tool => tool.name)).toContain("setUIState");
   });

--- a/test/server/tools/daemonModeTools.test.ts
+++ b/test/server/tools/daemonModeTools.test.ts
@@ -1,6 +1,8 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { createMcpServer } from "../../../src/server/index";
 import { ToolRegistry } from "../../../src/server/toolRegistry";
+import { serverConfig } from "../../../src/utils/ServerConfig";
+import { setDebugModeEnabled } from "../../../src/utils/debug";
 
 describe("Daemon-only MCP tools", () => {
   beforeEach(() => {
@@ -8,6 +10,8 @@ describe("Daemon-only MCP tools", () => {
   });
 
   afterEach(() => {
+    setDebugModeEnabled(false);
+    serverConfig.setEmbeddedSdkEnabled(false);
     (ToolRegistry as any).tools.clear();
   });
 
@@ -25,5 +29,54 @@ describe("Daemon-only MCP tools", () => {
     const toolNames = ToolRegistry.getToolDefinitions().map(tool => tool.name);
     expect(toolNames).toContain("executePlan");
     expect(toolNames).toContain("criticalSection");
+  });
+
+  test("hides debug-only tools unless debug mode is enabled", () => {
+    createMcpServer();
+
+    expect(ToolRegistry.getTool("accessibilityFocus")).toBeUndefined();
+    expect(ToolRegistry.getTool("setUIState")).toBeUndefined();
+    expect(ToolRegistry.getToolDefinitions().map(tool => tool.name)).not.toContain("accessibilityFocus");
+    expect(ToolRegistry.getToolDefinitions().map(tool => tool.name)).not.toContain("setUIState");
+
+    (ToolRegistry as any).tools.clear();
+    setDebugModeEnabled(true);
+    createMcpServer({ debug: true });
+
+    expect(ToolRegistry.getTool("accessibilityFocus")).toBeDefined();
+    expect(ToolRegistry.getTool("setUIState")).toBeDefined();
+    expect(ToolRegistry.getToolDefinitions().map(tool => tool.name)).toContain("accessibilityFocus");
+    expect(ToolRegistry.getToolDefinitions().map(tool => tool.name)).toContain("setUIState");
+  });
+
+  test("hides embedded-SDK tools unless embedded SDK mode is enabled", () => {
+    const embeddedSdkTools = [
+      "sqlQuery",
+      "setKeyValue",
+      "removeKeyValue",
+      "clearKeyValueFile",
+      "network",
+      "mockNetwork",
+      "clearMockNetwork",
+      "getNetworkGraph",
+    ];
+
+    createMcpServer();
+
+    const defaultNames = ToolRegistry.getToolDefinitions().map(tool => tool.name);
+    for (const toolName of embeddedSdkTools) {
+      expect(ToolRegistry.getTool(toolName)).toBeUndefined();
+      expect(defaultNames).not.toContain(toolName);
+    }
+
+    (ToolRegistry as any).tools.clear();
+    serverConfig.setEmbeddedSdkEnabled(true);
+    createMcpServer();
+
+    const embeddedSdkNames = ToolRegistry.getToolDefinitions().map(tool => tool.name);
+    for (const toolName of embeddedSdkTools) {
+      expect(ToolRegistry.getTool(toolName)).toBeDefined();
+      expect(embeddedSdkNames).toContain(toolName);
+    }
   });
 });


### PR DESCRIPTION
## Summary
- gate debug-only and embedded-SDK-only MCP tools out of the default tool surface
- add the --embedded-sdk flag and propagate it through daemon startup
- shorten or remove low-value tool and field descriptions, then regenerate tool definitions

## Validation
- bun scripts/generate-tool-definitions.ts && bun scripts/benchmark-context-thresholds.ts
- bun test test/server/tools/schema.test.ts test/server/toolRegistration.test.ts test/server/tools/daemonModeTools.test.ts test/server/storageTools.test.ts test/server/databaseIos.test.ts
- bun test test/server/tools/daemonModeTools.test.ts test/server/toolRegistration.test.ts test/server/networkTools.test.ts test/server/storageTools.test.ts test/server/databaseIos.test.ts
- bun test test/daemon/daemonManagerLaunch.test.ts test/daemon/manager.test.ts
- bun run build
- bunx eslint src/server/appTools.ts src/server/deepLinkTools.ts src/server/appFileContract.ts src/server/notificationTools.ts src/server/interactionTools.ts src/server/planTools.ts src/server/videoRecordingTools.ts src/server/snapshotTools.ts src/server/databaseTools.ts src/server/storageTools.ts