### PR TITLE
Implement Android app file management

### DIFF
--- a/docs/design-docs/mcp/resources.md
+++ b/docs/design-docs/mcp/resources.md
@@ -73,6 +73,8 @@ Lists files in a logical app container without requiring callers to know Android
 - `tmp`
 - `externalFiles` where the platform supports it
 
+List responses include each entry's relative `path`, `name`, `resourceUri`, `isDirectory` marker, byte size for files when available, and `lastModified` timestamp when the platform can report one.
+
 Example list request:
 
 ```json
@@ -87,6 +89,7 @@ Example list request:
 **URI Template**: `automobile:devices/{deviceId}/apps/{appId}/files/{container}/{path}`
 
 Reads a single file from an app container. Nested paths and filenames containing spaces are encoded as URI path segments. Binary content is returned as an MCP `blob` so it can be round-tripped losslessly.
+UTF-8 text files are returned as text with `text/plain; charset=utf-8` so clients do not need Android or iOS specific decoding logic.
 
 Example read request:
 

--- a/docs/design-docs/mcp/tools.md
+++ b/docs/design-docs/mcp/tools.md
@@ -55,6 +55,32 @@ Write inline configuration without a temporary file:
 
 After writing, use `automobile:devices/{deviceId}/apps/{appId}/files/{container}` to list files or `automobile:devices/{deviceId}/apps/{appId}/files/{container}/{path}` to read one back. Prefer this API over direct `adb push`, `run-as`, or `simctl get_app_container` copy commands.
 
+Android app files support `externalFiles` through `/sdcard/Android/data/{appId}/files`. Use this for app-readable fixture files that do not require private app storage:
+
+```json
+{
+  "tool": "putAppFile",
+  "params": {
+    "appId": "com.example.app",
+    "container": "externalFiles",
+    "sourcePath": "/Users/me/fixtures/document.pdf",
+    "destinationPath": "fixtures/document.pdf",
+    "platform": "android"
+  }
+}
+```
+
+Android private containers (`documents`, `cache`, and `tmp`) use `run-as {appId}` and require a debuggable app build. Non-debuggable apps fail with an actionable error instead of reporting a successful write. `library` is not an Android container; use `documents`, `cache`, `tmp`, or `externalFiles`.
+
+Manual emulator validation for Android:
+
+```sh
+printf '{"enabled":true}\n' > /tmp/automobile-settings.json
+# Call putAppFile with appId=com.example.app, container=externalFiles,
+# sourcePath=/tmp/automobile-settings.json, destinationPath=config/settings.json.
+adb shell cat /sdcard/Android/data/com.example.app/files/config/settings.json
+```
+
 #### Input Methods
 
 - ⌨️ `inputText` and `imeAction` for typing and IME actions.

--- a/src/server/appFileContract.ts
+++ b/src/server/appFileContract.ts
@@ -57,7 +57,10 @@ export interface AppFileListRequest {
 
 export interface AppFileListEntry {
   path: string;
+  name?: string;
   byteCount?: number;
+  isDirectory?: boolean;
+  lastModified?: string;
   resourceUri: string;
 }
 

--- a/src/server/appFileResources.ts
+++ b/src/server/appFileResources.ts
@@ -52,7 +52,7 @@ export function registerAppFileResources(): void {
   ResourceRegistry.registerTemplate(
     APP_FILE_RESOURCE_TEMPLATES.FILE,
     "App Container File",
-    "Read a file from a logical app container. Binary content is returned as a base64 MCP blob.",
+    "Read a file from a logical app container. UTF-8 content is returned as text; binary content is returned as a base64 MCP blob.",
     "application/octet-stream",
     readAppFileResource
   );

--- a/src/server/appFileService.ts
+++ b/src/server/appFileService.ts
@@ -1,9 +1,12 @@
 import { randomUUID } from "node:crypto";
 import { promises as nodeFs } from "node:fs";
+import type { Stats } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join, posix, relative } from "node:path";
+import { TextDecoder } from "node:util";
 import {
   AppFileContainer,
+  AppFileListEntry,
   AppFileListRequest,
   AppFileListResult,
   AppFileReadRequest,
@@ -13,8 +16,9 @@ import {
   buildAppFileResourceUri,
   normalizeAppFileRelativePath,
 } from "./appFileContract";
-import { ActionableError, BootedDevice, Platform } from "../models";
+import { ActionableError, BootedDevice, Platform, type ExecResult } from "../models";
 import { defaultAdbClientFactory, type AdbClientFactory } from "../utils/android-cmdline-tools/AdbClientFactory";
+import type { AdbExecutor } from "../utils/android-cmdline-tools/interfaces/AdbExecutor";
 import { SimCtlClient } from "../utils/ios-cmdline-tools/SimCtlClient";
 import { PlatformDeviceManagerFactory } from "../utils/factories/PlatformDeviceManagerFactory";
 
@@ -234,19 +238,45 @@ class AndroidAppFileProvider implements AppFileProvider {
     }
 
     if (target.kind === "external") {
-      await adb.executeCommand(`shell mkdir -p ${shellQuote(posix.dirname(target.absolutePath))}`, undefined, undefined, true, request.signal);
-      await adb.executeCommand(`push ${shellQuote(request.sourcePath)} ${shellQuote(target.absolutePath)}`, undefined, undefined, true, request.signal);
+      await executeAndroidAppFileCommand(
+        adb,
+        `shell mkdir -p ${shellQuote(posix.dirname(target.absolutePath))}`,
+        { device: request.device, appId: request.appId, container: request.container, operation: "write", access: "externalFiles" },
+        undefined,
+        undefined,
+        true,
+        request.signal
+      );
+      await executeAndroidAppFileCommand(
+        adb,
+        `push ${shellQuote(request.sourcePath)} ${shellQuote(target.absolutePath)}`,
+        { device: request.device, appId: request.appId, container: request.container, operation: "write", access: "externalFiles" },
+        undefined,
+        undefined,
+        true,
+        request.signal
+      );
       return;
     }
 
     const tempDevicePath = `/data/local/tmp/automobile-${randomUUID()}-${posix.basename(request.destinationPath)}`;
-    await adb.executeCommand(`push ${shellQuote(request.sourcePath)} ${shellQuote(tempDevicePath)}`, undefined, undefined, true, request.signal);
+    await executeAndroidAppFileCommand(
+      adb,
+      `push ${shellQuote(request.sourcePath)} ${shellQuote(tempDevicePath)}`,
+      { device: request.device, appId: request.appId, container: request.container, operation: "write", access: "run-as" },
+      undefined,
+      undefined,
+      true,
+      request.signal
+    );
     try {
       const command = `mkdir -p ${shellQuote(posix.dirname(target.relativePath))} && ` +
         `cp ${shellQuote(tempDevicePath)} ${shellQuote(target.relativePath)} && ` +
         `chmod 600 ${shellQuote(target.relativePath)}`;
-      await adb.executeCommand(
+      await executeAndroidAppFileCommand(
+        adb,
         `shell run-as ${shellQuote(request.appId)} sh -c ${shellQuote(command)}`,
+        { device: request.device, appId: request.appId, container: request.container, operation: "write", access: "run-as" },
         undefined,
         undefined,
         true,
@@ -264,37 +294,27 @@ class AndroidAppFileProvider implements AppFileProvider {
       throw unsupportedAppFileOperation("listFiles", request.device.platform, request.appId, request.container, base.message);
     }
 
+    const root = base.kind === "external" ? posix.dirname(base.absolutePath) : posix.dirname(base.relativePath);
+    const script = `if [ -d ${shellQuote(root)} ]; then find ${shellQuote(root)} -exec stat -c '%F|%s|%Y|%n' {} \\; ; fi`;
     const stdout = base.kind === "external"
-      ? (await adb.executeCommand(
-        `shell if [ -d ${shellQuote(posix.dirname(base.absolutePath))} ]; then find ${shellQuote(posix.dirname(base.absolutePath))} -type f; fi`,
+      ? (await executeAndroidAppFileCommand(
+        adb,
+        `shell ${script}`,
+        { device: request.device, appId: request.appId, container: request.container, operation: "list", access: "externalFiles" },
         undefined,
         ANDROID_APP_FILE_MAX_BUFFER,
         true
       )).stdout
-      : (await adb.executeCommand(
-        `shell run-as ${shellQuote(request.appId)} sh -c ${shellQuote(
-          `if [ -d ${shellQuote(posix.dirname(base.relativePath))} ]; then find ${shellQuote(posix.dirname(base.relativePath))} -type f; fi`
-        )}`,
+      : (await executeAndroidAppFileCommand(
+        adb,
+        `shell run-as ${shellQuote(request.appId)} sh -c ${shellQuote(script)}`,
+        { device: request.device, appId: request.appId, container: request.container, operation: "list", access: "run-as" },
         undefined,
         ANDROID_APP_FILE_MAX_BUFFER,
         true
       )).stdout;
 
-    const root = base.kind === "external" ? posix.dirname(base.absolutePath) : posix.dirname(base.relativePath);
-    const files = stdout
-      .split(/\r?\n/)
-      .map(line => line.trim())
-      .filter(Boolean)
-      .map(filePath => filePath.startsWith(`${root}/`) ? filePath.slice(root.length + 1) : filePath)
-      .map(path => ({
-        path,
-        resourceUri: buildAppFileResourceUri({
-          deviceId: request.device.deviceId,
-          appId: request.appId,
-          container: request.container,
-          path,
-        }),
-      }));
+    const files = parseAndroidStatListing(stdout, root, request.device, request.appId, request.container);
 
     return {
       deviceId: request.device.deviceId,
@@ -313,28 +333,35 @@ class AndroidAppFileProvider implements AppFileProvider {
     }
 
     const stdout = target.kind === "external"
-      ? (await adb.executeCommand(
+      ? (await executeAndroidAppFileCommand(
+        adb,
         `shell base64 ${shellQuote(target.absolutePath)}`,
+        { device: request.device, appId: request.appId, container: request.container, operation: "read", access: "externalFiles" },
         undefined,
         ANDROID_APP_FILE_MAX_BUFFER,
         true
       )).stdout
-      : (await adb.executeCommand(
+      : (await executeAndroidAppFileCommand(
+        adb,
         `shell run-as ${shellQuote(request.appId)} base64 ${shellQuote(target.relativePath)}`,
+        { device: request.device, appId: request.appId, container: request.container, operation: "read", access: "run-as" },
         undefined,
         ANDROID_APP_FILE_MAX_BUFFER,
         true
       )).stdout;
     const blob = stdout.replace(/\s+/g, "");
+    const buffer = Buffer.from(blob, "base64");
+    const text = decodeUtf8Text(buffer);
     return {
       deviceId: request.device.deviceId,
       platform: request.device.platform,
       appId: request.appId,
       container: request.container,
       path: request.path,
-      byteCount: Buffer.from(blob, "base64").byteLength,
-      mimeType: "application/octet-stream",
-      blob,
+      byteCount: buffer.byteLength,
+      ...(text === undefined
+        ? { mimeType: "application/octet-stream", blob }
+        : { mimeType: "text/plain; charset=utf-8", text }),
     };
   }
 }
@@ -359,8 +386,7 @@ class IosSimulatorAppFileProvider implements AppFileProvider {
       appId: request.appId,
       container: request.container,
       files: files.map(file => ({
-        path: file.path,
-        byteCount: file.byteCount,
+        ...file,
         resourceUri: buildAppFileResourceUri({
           deviceId: request.device.deviceId,
           appId: request.appId,
@@ -374,6 +400,7 @@ class IosSimulatorAppFileProvider implements AppFileProvider {
   async readFile(request: AppFileProviderReadRequest): Promise<AppFileReadResult> {
     const target = await this.resolvePath(request.device, request.appId, request.container, request.path, "readFile");
     const buffer = await nodeFs.readFile(target);
+    const text = decodeUtf8Text(buffer);
     return {
       deviceId: request.device.deviceId,
       platform: request.device.platform,
@@ -381,8 +408,9 @@ class IosSimulatorAppFileProvider implements AppFileProvider {
       container: request.container,
       path: request.path,
       byteCount: buffer.byteLength,
-      mimeType: "application/octet-stream",
-      blob: buffer.toString("base64"),
+      ...(text === undefined
+        ? { mimeType: "application/octet-stream", blob: buffer.toString("base64") }
+        : { mimeType: "text/plain; charset=utf-8", text }),
     };
   }
 
@@ -493,21 +521,22 @@ function iosContainerRelativePath(
   }
 }
 
-async function listLocalFiles(root: string): Promise<Array<{ path: string; byteCount: number }>> {
-  const entries: Array<{ path: string; byteCount: number }> = [];
+type LocalFileListEntry = Omit<AppFileListEntry, "resourceUri">;
+
+async function listLocalFiles(root: string): Promise<LocalFileListEntry[]> {
+  const entries: LocalFileListEntry[] = [];
 
   async function visit(dir: string): Promise<void> {
     const children = await nodeFs.readdir(dir, { withFileTypes: true });
     for (const child of children) {
       const childPath = join(dir, child.name);
       if (child.isDirectory()) {
+        const stat = await nodeFs.stat(childPath);
+        entries.push(buildLocalListEntry(root, childPath, stat, true));
         await visit(childPath);
       } else if (child.isFile()) {
         const stat = await nodeFs.stat(childPath);
-        entries.push({
-          path: relative(root, childPath).replace(/\\/g, "/"),
-          byteCount: stat.size,
-        });
+        entries.push(buildLocalListEntry(root, childPath, stat, false));
       }
     }
   }
@@ -521,4 +550,129 @@ async function listLocalFiles(root: string): Promise<Array<{ path: string; byteC
   }
 
   return entries;
+}
+
+function buildLocalListEntry(root: string, childPath: string, stat: Stats, isDirectory: boolean): LocalFileListEntry {
+  const filePath = relative(root, childPath).replace(/\\/g, "/");
+  return {
+    path: filePath,
+    name: posix.basename(filePath),
+    ...(isDirectory ? {} : { byteCount: stat.size }),
+    isDirectory,
+    lastModified: stat.mtime.toISOString(),
+  };
+}
+
+function parseAndroidStatListing(
+  stdout: string,
+  root: string,
+  device: BootedDevice,
+  appId: string,
+  container: AppFileContainer
+): AppFileListEntry[] {
+  return stdout
+    .split(/\n/)
+    .map(line => line.replace(/\r$/, ""))
+    .filter(line => line.length > 0)
+    .map(line => parseAndroidStatLine(line, root, device, appId, container))
+    .filter((entry): entry is AppFileListEntry => entry !== null);
+}
+
+function parseAndroidStatLine(
+  line: string,
+  root: string,
+  device: BootedDevice,
+  appId: string,
+  container: AppFileContainer
+): AppFileListEntry | null {
+  const parts = line.split("|");
+  if (parts.length < 4) {
+    return null;
+  }
+
+  const [fileType, sizeText, modifiedSecondsText, ...pathParts] = parts;
+  const absolutePath = pathParts.join("|");
+  if (absolutePath === root) {
+    return null;
+  }
+
+  const relativePath = absolutePath.startsWith(`${root}/`)
+    ? absolutePath.slice(root.length + 1)
+    : absolutePath;
+  const path = normalizeAppFileRelativePath(relativePath);
+  const isDirectory = fileType.toLowerCase().includes("directory");
+  const byteCount = Number(sizeText);
+  const modifiedSeconds = Number(modifiedSecondsText);
+
+  return {
+    path,
+    name: posix.basename(path),
+    ...(isDirectory || !Number.isFinite(byteCount) ? {} : { byteCount }),
+    isDirectory,
+    ...(Number.isFinite(modifiedSeconds) ? { lastModified: new Date(modifiedSeconds * 1000).toISOString() } : {}),
+    resourceUri: buildAppFileResourceUri({ deviceId: device.deviceId, appId, container, path }),
+  };
+}
+
+interface AndroidAppFileCommandContext {
+  device: BootedDevice;
+  appId: string;
+  container: AppFileContainer;
+  operation: "write" | "list" | "read";
+  access: "externalFiles" | "run-as";
+}
+
+async function executeAndroidAppFileCommand(
+  adb: AdbExecutor,
+  command: string,
+  context: AndroidAppFileCommandContext,
+  timeoutMs?: number,
+  maxBuffer?: number,
+  noRetry?: boolean,
+  signal?: AbortSignal
+): Promise<ExecResult> {
+  try {
+    return await adb.executeCommand(command, timeoutMs, maxBuffer, noRetry, signal);
+  } catch (error) {
+    throw mapAndroidAppFileError(error, context);
+  }
+}
+
+function mapAndroidAppFileError(error: unknown, context: AndroidAppFileCommandContext): ActionableError {
+  const message = error instanceof Error ? error.message : String(error);
+  if (/not debuggable/i.test(message)) {
+    return new ActionableError(
+      `Android ${context.container} app file ${context.operation} for ${context.appId} on ${context.device.deviceId} ` +
+      "requires a debuggable app build because it uses run-as. Install a debuggable build or use externalFiles. " +
+      `Original error: ${message}`
+    );
+  }
+
+  if (/package .* (unknown|not found)|unknown package|not installed|does not exist/i.test(message)) {
+    return new ActionableError(
+      `Android app ${context.appId} is not installed on ${context.device.deviceId}; ` +
+      `cannot ${context.operation} ${context.container} app files. Original error: ${message}`
+    );
+  }
+
+  if (/permission denied|operation not permitted/i.test(message)) {
+    return new ActionableError(
+      `Android ${context.container} app file ${context.operation} for ${context.appId} on ${context.device.deviceId} ` +
+      `was denied by the device. ${context.access === "run-as" ? "Use a debuggable build for private storage or choose externalFiles." : "Check app install state and external storage access."} ` +
+      `Original error: ${message}`
+    );
+  }
+
+  return new ActionableError(
+    `Failed to ${context.operation} Android ${context.container} app files for ${context.appId} on ${context.device.deviceId}: ${message}`
+  );
+}
+
+function decodeUtf8Text(buffer: Buffer): string | undefined {
+  try {
+    const text = new TextDecoder("utf-8", { fatal: true, ignoreBOM: true }).decode(buffer);
+    return text.includes("\u0000") ? undefined : text;
+  } catch {
+    return undefined;
+  }
 }

--- a/test/server/appFileResources.test.ts
+++ b/test/server/appFileResources.test.ts
@@ -99,4 +99,34 @@ describe("App file resources", () => {
     expect(content.blob).toBe("AAEC/w==");
     expect(content.text).toBeUndefined();
   });
+
+  test("reads UTF-8 app files as MCP text content", async () => {
+    setAppFileServiceForTesting({
+      ...fakeService,
+      readFile: async request => ({
+        deviceId: request.deviceId,
+        platform: "android",
+        appId: request.appId,
+        container: request.container,
+        path: request.path,
+        byteCount: 17,
+        mimeType: "text/plain; charset=utf-8",
+        text: "{\"enabled\":true}\n",
+      }),
+    });
+    registerAppFileResources();
+
+    const match = ResourceRegistry.matchTemplate(
+      "automobile:devices/emulator-5554/apps/com.example.app/files/externalFiles/config/settings.json"
+    );
+    expect(match).toBeDefined();
+
+    const content = await match!.template.handler(match!.params);
+    expect(content.uri).toBe(
+      "automobile:devices/emulator-5554/apps/com.example.app/files/externalFiles/config/settings.json"
+    );
+    expect(content.mimeType).toBe("text/plain; charset=utf-8");
+    expect(content.text).toBe("{\"enabled\":true}\n");
+    expect(content.blob).toBeUndefined();
+  });
 });

--- a/test/server/appFileService.test.ts
+++ b/test/server/appFileService.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, rm, symlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, test } from "bun:test";
@@ -8,8 +8,26 @@ import {
   type PutAppFileProviderRequest,
 } from "../../src/server/appFileService";
 import type { BootedDevice } from "../../src/models";
+import type { AdbClientFactory } from "../../src/utils/android-cmdline-tools/AdbClientFactory";
 import { FakeAdbClientFactory } from "../fakes/FakeAdbClientFactory";
+import { FakeAdbExecutor } from "../fakes/FakeAdbExecutor";
 import { FakeSimCtlClient } from "../fakes/FakeSimCtlClient";
+
+function execResult(stdout: string, stderr = "") {
+  return {
+    stdout,
+    stderr,
+    toString: () => stdout,
+    trim: () => stdout.trim(),
+    includes: (search: string) => stdout.includes(search),
+  };
+}
+
+function adbFactoryFor(executor: FakeAdbExecutor): AdbClientFactory {
+  return {
+    create: () => executor,
+  };
+}
 
 describe("AppFileService", () => {
   const tempDirs: string[] = [];
@@ -323,6 +341,178 @@ describe("AppFileService", () => {
     expect(calls[1]?.command).toContain("shell if [ -d '/sdcard/Android/data/com.example.app/files'");
     expect(calls[1]?.command).toContain("find");
     expect(calls[1]?.maxBuffer).toBe(calls[0]?.maxBuffer);
+  });
+
+  test("lists Android externalFiles with file names, directory markers, byte sizes, and last-modified metadata", async () => {
+    const adb = new FakeAdbExecutor();
+    adb.setCommandResponse("find '/sdcard/Android/data/com.example.app/files'", execResult([
+      "directory|4096|1710000000|/sdcard/Android/data/com.example.app/files",
+      "directory|4096|1710000060|/sdcard/Android/data/com.example.app/files/fixtures",
+      "regular file|4|1710000123|/sdcard/Android/data/com.example.app/files/fixtures/welcome file.txt",
+    ].join("\n")));
+    const service = createAppFileServiceForTesting({
+      adbFactory: adbFactoryFor(adb),
+      simctlFactory: () => {
+        throw new Error("simctl not used");
+      },
+      deviceResolver: async () => ({ deviceId: "emulator-5554", name: "Pixel", platform: "android" }),
+    });
+
+    const result = await service.listFiles({
+      deviceId: "emulator-5554",
+      appId: "com.example.app",
+      container: "externalFiles",
+    });
+
+    expect(result.files).toEqual([
+      {
+        path: "fixtures",
+        name: "fixtures",
+        isDirectory: true,
+        lastModified: "2024-03-09T16:01:00.000Z",
+        resourceUri: "automobile:devices/emulator-5554/apps/com.example.app/files/externalFiles/fixtures",
+      },
+      {
+        path: "fixtures/welcome file.txt",
+        name: "welcome file.txt",
+        byteCount: 4,
+        isDirectory: false,
+        lastModified: "2024-03-09T16:02:03.000Z",
+        resourceUri: "automobile:devices/emulator-5554/apps/com.example.app/files/externalFiles/fixtures/welcome%20file.txt",
+      },
+    ]);
+  });
+
+  test("reads Android UTF-8 files as text without platform-specific decoding", async () => {
+    const adb = new FakeAdbExecutor();
+    adb.setCommandResponse("base64 '/sdcard/Android/data/com.example.app/files/config/settings.json'", execResult(
+      Buffer.from("{\"enabled\":true}\n", "utf8").toString("base64")
+    ));
+    const service = createAppFileServiceForTesting({
+      adbFactory: adbFactoryFor(adb),
+      simctlFactory: () => {
+        throw new Error("simctl not used");
+      },
+      deviceResolver: async () => ({ deviceId: "emulator-5554", name: "Pixel", platform: "android" }),
+    });
+
+    const result = await service.readFile({
+      deviceId: "emulator-5554",
+      appId: "com.example.app",
+      container: "externalFiles",
+      path: "config/settings.json",
+    });
+
+    expect(result).toMatchObject({
+      byteCount: 17,
+      mimeType: "text/plain; charset=utf-8",
+      text: "{\"enabled\":true}\n",
+    });
+    expect(result.blob).toBeUndefined();
+  });
+
+  test("preserves UTF-8 BOM bytes when reading text app files", async () => {
+    const bytes = Buffer.from([0xef, 0xbb, 0xbf, 0x7b, 0x7d]);
+    const adb = new FakeAdbExecutor();
+    adb.setCommandResponse("base64 '/sdcard/Android/data/com.example.app/files/config/bom.json'", execResult(
+      bytes.toString("base64")
+    ));
+    const service = createAppFileServiceForTesting({
+      adbFactory: adbFactoryFor(adb),
+      simctlFactory: () => {
+        throw new Error("simctl not used");
+      },
+      deviceResolver: async () => ({ deviceId: "emulator-5554", name: "Pixel", platform: "android" }),
+    });
+
+    const result = await service.readFile({
+      deviceId: "emulator-5554",
+      appId: "com.example.app",
+      container: "externalFiles",
+      path: "config/bom.json",
+    });
+
+    expect(result).toMatchObject({
+      byteCount: bytes.byteLength,
+      mimeType: "text/plain; charset=utf-8",
+      text: "\uFEFF{}",
+    });
+    expect(Buffer.from(result.text!, "utf8")).toEqual(bytes);
+    expect(result.blob).toBeUndefined();
+  });
+
+  test("keeps Android binary reads as lossless MCP blobs", async () => {
+    const bytes = Buffer.from([0, 159, 146, 150, 255]);
+    const adb = new FakeAdbExecutor();
+    adb.setCommandResponse("base64 '/sdcard/Android/data/com.example.app/files/fixtures/pixel.bin'", execResult(
+      bytes.toString("base64")
+    ));
+    const service = createAppFileServiceForTesting({
+      adbFactory: adbFactoryFor(adb),
+      simctlFactory: () => {
+        throw new Error("simctl not used");
+      },
+      deviceResolver: async () => ({ deviceId: "emulator-5554", name: "Pixel", platform: "android" }),
+    });
+
+    const result = await service.readFile({
+      deviceId: "emulator-5554",
+      appId: "com.example.app",
+      container: "externalFiles",
+      path: "fixtures/pixel.bin",
+    });
+
+    expect(result).toMatchObject({
+      byteCount: bytes.byteLength,
+      mimeType: "application/octet-stream",
+      blob: bytes.toString("base64"),
+    });
+    expect(result.text).toBeUndefined();
+  });
+
+  test("maps Android run-as failures to actionable private-storage guidance", async () => {
+    const adb = new FakeAdbExecutor();
+    adb.setCommandError("shell run-as 'com.example.app'", new Error("run-as: Package 'com.example.app' is not debuggable"));
+    const service = createAppFileServiceForTesting({
+      adbFactory: adbFactoryFor(adb),
+      simctlFactory: () => {
+        throw new Error("simctl not used");
+      },
+      deviceResolver: async () => ({ deviceId: "emulator-5554", name: "Pixel", platform: "android" }),
+    });
+
+    await expect(service.readFile({
+      deviceId: "emulator-5554",
+      appId: "com.example.app",
+      container: "documents",
+      path: "fixtures/private.txt",
+    })).rejects.toThrow(
+      "Android documents app file read for com.example.app on emulator-5554 requires a debuggable app build because it uses run-as"
+    );
+  });
+
+  test("skips broken symlinks when listing iOS app container files", async () => {
+    const root = await mkdtemp(join(tmpdir(), "automobile-app-files-"));
+    tempDirs.push(root);
+    const dataRoot = join(root, "data");
+    const documentsRoot = join(dataRoot, "Documents");
+    await mkdir(documentsRoot, { recursive: true });
+    await writeFile(join(documentsRoot, "welcome.txt"), "hello");
+    await symlink(join(documentsRoot, "missing.txt"), join(documentsRoot, "broken-link"));
+    const simctl = new FakeSimCtlClient();
+    simctl.setCommandResult("get_app_container 'ios-sim-1' 'com.example.app' data", dataRoot);
+    const service = createAppFileServiceForTesting({
+      simctlFactory: () => simctl as any,
+      deviceResolver: async () => ({ deviceId: "ios-sim-1", name: "iPhone", platform: "ios" }),
+    });
+
+    const result = await service.listFiles({
+      deviceId: "ios-sim-1",
+      appId: "com.example.app",
+      container: "documents",
+    });
+
+    expect(result.files.map(file => file.path)).toEqual(["welcome.txt"]);
   });
 });
 


### PR DESCRIPTION
## Summary
- Implement Android app-container file listing/read behavior for `externalFiles` and `run-as` private containers.
- Return list metadata including names, directory markers, file sizes, last-modified timestamps, and resource URIs.
- Decode UTF-8 app-file reads as MCP text while preserving binary reads as base64 blobs.
- Map Android app-file ADB failures into actionable app/container/device errors.
- Document Android `externalFiles`, debuggable private storage behavior, and manual emulator validation.

Closes #2570

## Testing
- `bun test test/server/appFileContract.test.ts test/server/appFileResources.test.ts test/server/appFileTools.test.ts test/server/appFileService.test.ts`
- `bun run lint && bun run build && bun test --bail`
