### PR TITLE
fix(android): report restricted clipboard reads

### DIFF
--- a/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/CtrlProxy.kt
+++ b/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/CtrlProxy.kt
@@ -3131,14 +3131,20 @@ class CtrlProxy : AccessibilityService() {
             }
             "get" -> {
               try {
-                val clip = clipboardManager.primaryClip
-                val clipText = clip?.getItemAt(0)?.text?.toString()
-                if (clipText != null) {
-                  Log.d(TAG, "Clipboard get successful (${clipText.length} chars)")
+                val readResult =
+                    CtrlProxyClipboard.readResultFromPrimaryClip(clipboardManager.primaryClip)
+                if (readResult.success) {
+                  val clipText = readResult.text ?: ""
+                  if (clipText.isEmpty()) {
+                    Log.d(TAG, "Clipboard is empty")
+                  } else {
+                    Log.d(TAG, "Clipboard get successful (${clipText.length} chars)")
+                  }
                   Triple(true, clipText, null)
                 } else {
-                  Log.d(TAG, "Clipboard is empty")
-                  Triple(true, "", null)
+                  val readError = readResult.error ?: "Clipboard read failed"
+                  Log.w(TAG, readError)
+                  Triple(false, null, readError)
                 }
               } catch (e: Exception) {
                 Log.e(TAG, "Clipboard get failed", e)

--- a/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/CtrlProxyClipboard.kt
+++ b/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/CtrlProxyClipboard.kt
@@ -13,6 +13,10 @@ object CtrlProxyClipboard {
 
   fun readResultFromPrimaryClip(clip: ClipData?, sdkInt: Int = Build.VERSION.SDK_INT): ReadResult {
     if (clip == null) {
+      // Android 10+ only permits clipboard reads from the focused app, default IME, or
+      // privileged/system services. CtrlProxy runs as a background accessibility service, so a
+      // null primary clip can mean Android denied the read rather than the target app clipboard
+      // being empty. Report that restriction instead of masking it as successful empty content.
       return if (sdkInt >= Build.VERSION_CODES.Q) {
         ReadResult(success = false, text = null, error = RESTRICTED_READ_ERROR)
       } else {

--- a/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/CtrlProxyClipboard.kt
+++ b/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/CtrlProxyClipboard.kt
@@ -1,0 +1,25 @@
+package dev.jasonpearson.automobile.ctrlproxy
+
+import android.content.ClipData
+import android.os.Build
+
+object CtrlProxyClipboard {
+  private const val RESTRICTED_READ_ERROR =
+      "Clipboard read is restricted while CtrlProxy is not foreground. " +
+          "Android 10+ only allows clipboard reads from the foreground app, default IME, " +
+          "or system services."
+
+  data class ReadResult(val success: Boolean, val text: String?, val error: String?)
+
+  fun readResultFromPrimaryClip(clip: ClipData?, sdkInt: Int = Build.VERSION.SDK_INT): ReadResult {
+    if (clip == null) {
+      return if (sdkInt >= Build.VERSION_CODES.Q) {
+        ReadResult(success = false, text = null, error = RESTRICTED_READ_ERROR)
+      } else {
+        ReadResult(success = true, text = "", error = null)
+      }
+    }
+
+    return ReadResult(success = true, text = clip.getItemAt(0)?.text?.toString() ?: "", error = null)
+  }
+}

--- a/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/CtrlProxyClipboardTest.kt
+++ b/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/CtrlProxyClipboardTest.kt
@@ -1,0 +1,46 @@
+package dev.jasonpearson.automobile.ctrlproxy
+
+import android.content.ClipData
+import android.os.Build
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class CtrlProxyClipboardTest {
+
+  @Test
+  fun `classifies null clipboard read on Android 10 and newer as restricted`() {
+    val result = CtrlProxyClipboard.readResultFromPrimaryClip(null, Build.VERSION_CODES.Q)
+
+    assertFalse(result.success)
+    assertNull(result.text)
+    val error = result.error ?: error("Expected restricted read error")
+    assertTrue(error.contains("restricted"))
+    assertTrue(error.contains("foreground"))
+  }
+
+  @Test
+  fun `classifies null clipboard read before Android 10 as empty`() {
+    val result = CtrlProxyClipboard.readResultFromPrimaryClip(null, Build.VERSION_CODES.P)
+
+    assertTrue(result.success)
+    assertEquals("", result.text)
+    assertNull(result.error)
+  }
+
+  @Test
+  fun `returns clipboard text when a primary clip is readable`() {
+    val clip = ClipData.newPlainText("AutoMobile", "CLIPMARKER777")
+
+    val result = CtrlProxyClipboard.readResultFromPrimaryClip(clip, Build.VERSION_CODES.UPSIDE_DOWN_CAKE)
+
+    assertTrue(result.success)
+    assertEquals("CLIPMARKER777", result.text)
+    assertNull(result.error)
+  }
+}

--- a/docs/design-docs/plat/android/clipboard.md
+++ b/docs/design-docs/plat/android/clipboard.md
@@ -2,7 +2,7 @@
 
 <kbd>✅ Implemented</kbd> <kbd>🧪 Tested</kbd>
 
-> **Current state:** `clipboard` MCP tool is fully implemented. On API 35, `cmd clipboard` returns "No shell command implementation", so the implementation routes through the AutoMobile Accessibility Service. See the [Status Glossary](../../status-glossary.md) for chip definitions.
+> **Current state:** `clipboard` MCP tool routes Android operations through the AutoMobile Accessibility Service. On API 35, `cmd clipboard` returns "No shell command implementation", so Android `get` reports accessibility-service read restrictions directly instead of treating ADB as a recovery path. See the [Status Glossary](../../status-glossary.md) for chip definitions.
 
 ## Goal
 
@@ -20,26 +20,25 @@ clipboard({
 
 ## Android implementation
 
-Primary path (API 29/35 if supported):
+Primary path:
 
-- `adb -s <device> shell cmd clipboard set "<text>"`
-- `adb -s <device> shell cmd clipboard get`
-- `adb -s <device> shell cmd clipboard clear`
+- CtrlProxy handles `copy`, `paste`, `clear`, and `get` via the AutoMobile
+  Accessibility Service.
+- `get` returns an explicit failure when Android reports the clipboard as
+  unreadable from the background on Android 10+.
 
-Capability probe:
+Legacy ADB path:
 
-- `adb -s <device> shell cmd clipboard help`
-
-Fallback path (helper APK):
-
-- Helper app exposes a broadcast receiver or bound service to set/read
-  the clipboard via `ClipboardManager`.
-- AutoMobile reads results via file or socket for `get`.
+- `cmd clipboard` is guarded as unsupported when Android returns
+  "No shell command implementation".
+- Android `get` does not use `cmd clipboard` as a recovery path.
 
 Notes:
 
-- Newer Android versions restrict clipboard reads for background apps.
-  The helper should run in the foreground when possible.
+- Android 10+ restricts clipboard reads for background apps. CtrlProxy cannot
+  distinguish a denied background read from an empty clipboard when
+  `ClipboardManager.getPrimaryClip()` returns `null`, so it reports that state
+  as unreadable/restricted instead of successful empty content.
 
 ## ADB validation (API 35)
 
@@ -66,8 +65,9 @@ Notes:
 
 ## Plan
 
-1. Implement adb `cmd clipboard` support with capability detection.
-2. Add helper APK fallback for consistent behavior.
+1. Add a node-based read path for focused editable fields where possible.
+2. Explore foreground/IME-assisted reads for cases that require actual
+   ClipboardManager content.
 
 ## Risks
 

--- a/docs/design-docs/plat/android/clipboard.md
+++ b/docs/design-docs/plat/android/clipboard.md
@@ -24,16 +24,42 @@ Primary path:
 
 - CtrlProxy handles `copy`, `paste`, `clear`, and `get` via the AutoMobile
   Accessibility Service.
+- `copy` and `clear` are direct `ClipboardManager` writes from CtrlProxy.
+- `paste` uses accessibility paste actions against the focused editable node.
 - `get` returns an explicit failure when Android reports the clipboard as
   unreadable from the background on Android 10+.
+
+Android 10+ read model:
+
+- Direct clipboard reads work only for the focused foreground app, the default
+  IME, or privileged/system services.
+- CtrlProxy is a background accessibility service, so it cannot reliably read a
+  target app's clipboard with `ClipboardManager.getPrimaryClip()`.
+- If target-app code is available, read from the target app while its activity
+  has input focus.
+- If an automation IME is available and selected as the default keyboard, read
+  through that IME.
+- For black-box automation, focus an editable field, paste, then read the field
+  contents via accessibility. This reads what would be pasted, not the raw
+  clipboard independently.
 
 Legacy ADB path:
 
 - `cmd clipboard` is guarded as unsupported when Android returns
   "No shell command implementation".
 - Android `get` does not use `cmd clipboard` as a recovery path.
+- `dumpsys clipboard` is not a reliable content read path on current emulator
+  images.
 
-Notes:
+Do not retry these as clipboard-read fixes:
+
+- Background helper apps or foreground services without actual input focus.
+- Accessibility services calling `ClipboardManager.getPrimaryClip()` and
+  treating `null` as empty.
+- `adb shell cmd clipboard get` on modern builds that report
+  "No shell command implementation".
+
+Failure reporting:
 
 - Android 10+ restricts clipboard reads for background apps. CtrlProxy cannot
   distinguish a denied background read from an empty clipboard when
@@ -61,13 +87,14 @@ Observed results:
 Notes:
 
 - ADB-only clipboard manipulation appears unsupported on this emulator/API
-  level; a helper APK fallback is likely required.
+  level.
 
 ## Plan
 
-1. Add a node-based read path for focused editable fields where possible.
-2. Explore foreground/IME-assisted reads for cases that require actual
-   ClipboardManager content.
+1. Add a node-based paste-then-read path for focused editable fields where
+   possible.
+2. Explore foreground target-app or IME-assisted reads for cases that require
+   actual ClipboardManager content.
 
 ## Risks
 

--- a/src/features/action/Clipboard.ts
+++ b/src/features/action/Clipboard.ts
@@ -81,7 +81,8 @@ export class Clipboard {
 
   /**
    * Execute Android-specific clipboard operation
-   * Tries accessibility service first, falls back to ADB cmd clipboard
+   * Tries accessibility service first. Mutating actions can fall back to ADB cmd clipboard;
+   * get returns the accessibility result because cmd clipboard is unavailable on Android.
    * @param action - Clipboard action to perform
    * @param text - Text for copy action
    * @returns Result of the clipboard operation
@@ -114,31 +115,28 @@ export class Clipboard {
           method: "a11y"
         };
 
-        // A11y clipboard reads can be restricted; try ADB when get returns empty.
-        if (action !== "get" || (a11yResult.text?.length ?? 0) > 0) {
-          return a11yClipboardResult;
-        }
-
-        logger.warn("[Clipboard] Accessibility service returned empty clipboard; trying ADB fallback");
-        try {
-          const adbResult = await this.executeAdbClipboard(action, text);
-          if (adbResult.success && (adbResult.text?.length ?? 0) > 0) {
-            logger.info("[Clipboard] Retrieved clipboard via ADB fallback after empty a11y result");
-            return adbResult;
-          }
-          if (!adbResult.success) {
-            logger.warn(`[Clipboard] ADB fallback for clipboard get failed: ${adbResult.error}`);
-          }
-        } catch (error) {
-          logger.warn(`[Clipboard] ADB fallback error: ${error}`);
-        }
-
         return a11yClipboardResult;
       }
 
       logger.warn(`[Clipboard] Accessibility service ${action} failed: ${a11yResult.error}`);
+      if (action === "get") {
+        return {
+          success: false,
+          action,
+          error: a11yResult.error ?? "Accessibility clipboard get failed",
+          method: "a11y"
+        };
+      }
     } catch (error) {
       logger.warn(`[Clipboard] Accessibility service error: ${error}`);
+      if (action === "get") {
+        return {
+          success: false,
+          action,
+          error: `Accessibility clipboard get failed: ${error instanceof Error ? error.message : String(error)}`,
+          method: "a11y"
+        };
+      }
     }
 
     // Fall back to ADB cmd clipboard

--- a/src/features/action/Clipboard.ts
+++ b/src/features/action/Clipboard.ts
@@ -120,6 +120,10 @@ export class Clipboard {
 
       logger.warn(`[Clipboard] Accessibility service ${action} failed: ${a11yResult.error}`);
       if (action === "get") {
+        // On Android 10+, a background service cannot directly read a target app's clipboard.
+        // Working read strategies require foreground target-app code, the default IME role, or
+        // paste-then-read from a focused editable node. `cmd clipboard get` is not a recovery path
+        // on modern Android builds because the shell command is usually unimplemented.
         return {
           success: false,
           action,

--- a/src/server/interactionTools.ts
+++ b/src/server/interactionTools.ts
@@ -20,6 +20,7 @@ import { Keyboard } from "../features/action/Keyboard";
 import {
   ActionableError,
   BootedDevice,
+  ClipboardResult,
 } from "../models";
 import { ListInstalledApps } from "../features/observe/ListInstalledApps";
 import { createJSONToolResponse, createStructuredToolResponse } from "../utils/toolUtils";
@@ -382,6 +383,25 @@ export const clipboardSchema = z.discriminatedUnion("action", [
     ...clipboardPlatformSchema,
   }))
 ]);
+
+export function formatClipboardMessage(result: ClipboardResult): string {
+  if (!result.success) {
+    return `Failed to execute clipboard ${result.action}: ${result.error ?? "unknown error"}`;
+  }
+
+  switch (result.action) {
+    case "copy":
+      return "Copied text to clipboard";
+    case "paste":
+      return "Pasted clipboard content into focused field";
+    case "clear":
+      return "Cleared clipboard";
+    case "get":
+      return result.text
+        ? `Retrieved clipboard content: "${result.text.substring(0, 50)}${result.text.length > 50 ? "..." : ""}"`
+        : "Retrieved empty clipboard";
+  }
+}
 
 // ============================================================================
 // Tool Registration
@@ -907,26 +927,7 @@ export function registerInteractionTools() {
       const clipboard = new Clipboard(device);
       const result = await clipboard.execute(args.action, args.text);
 
-      // Build descriptive message based on action
-      let message = "";
-      switch (args.action) {
-        case "copy":
-          message = `Copied text to clipboard`;
-          break;
-        case "paste":
-          message = `Pasted clipboard content into focused field`;
-          break;
-        case "clear":
-          message = `Cleared clipboard`;
-          break;
-        case "get":
-          message = !result.success
-            ? `Failed to retrieve clipboard content: ${result.error ?? "unknown error"}`
-            : result.text
-              ? `Retrieved clipboard content: "${result.text.substring(0, 50)}${result.text.length > 50 ? "..." : ""}"`
-              : `Retrieved empty clipboard`;
-          break;
-      }
+      let message = formatClipboardMessage(result);
 
       if (result.method) {
         message += ` (via ${result.method})`;

--- a/src/server/interactionTools.ts
+++ b/src/server/interactionTools.ts
@@ -920,9 +920,11 @@ export function registerInteractionTools() {
           message = `Cleared clipboard`;
           break;
         case "get":
-          message = result.text
-            ? `Retrieved clipboard content: "${result.text.substring(0, 50)}${result.text.length > 50 ? "..." : ""}"`
-            : `Retrieved empty clipboard`;
+          message = !result.success
+            ? `Failed to retrieve clipboard content: ${result.error ?? "unknown error"}`
+            : result.text
+              ? `Retrieved clipboard content: "${result.text.substring(0, 50)}${result.text.length > 50 ? "..." : ""}"`
+              : `Retrieved empty clipboard`;
           break;
       }
 

--- a/test/features/action/Clipboard.test.ts
+++ b/test/features/action/Clipboard.test.ts
@@ -125,6 +125,12 @@ describe("Clipboard iOS", () => {
 });
 
 describe("Clipboard Android", () => {
+  const androidDevice: BootedDevice = {
+    name: "Test Android",
+    platform: "android",
+    deviceId: "test-android",
+  };
+
   // Regression for https://github.com/kaeawc/auto-mobile/issues/2227.
   // AndroidCtrlProxyClient.getInstance expects an AdbClientFactory and calls
   // `.create(device)` on it. Passing the resolved AdbExecutor instead
@@ -136,19 +142,85 @@ describe("Clipboard Android", () => {
       requestClipboard: async () => ({ success: true, action: "copy", totalTimeMs: 1 }),
     } as unknown as AndroidCtrlProxyClient);
 
-    const device: BootedDevice = {
-      name: "Test Android",
-      platform: "android",
-      deviceId: "test-android",
-    };
-    const clipboard = new Clipboard(device, factory);
+    const clipboard = new Clipboard(androidDevice, factory);
     await clipboard.execute("copy", "hello");
 
     expect(getInstanceSpy).toHaveBeenCalled();
     const [, passedFactory] = getInstanceSpy.mock.calls[0] as [BootedDevice, FakeAdbClientFactory];
     expect(typeof passedFactory.create).toBe("function");
     expect(passedFactory).toBe(factory);
-    expect(factory.wasCalledForDevice(device.deviceId)).toBe(true);
+    expect(factory.wasCalledForDevice(androidDevice.deviceId)).toBe(true);
+
+    getInstanceSpy.mockRestore();
+  });
+
+  test("get returns accessibility restriction error without ADB fallback when Android denies clipboard reads", async () => {
+    const factory = new FakeAdbClientFactory();
+    const fakeAdb = factory.getFakeClient();
+    const getInstanceSpy = spyOn(AndroidCtrlProxyClient, "getInstance").mockReturnValue({
+      requestClipboard: async () => ({
+        success: false,
+        action: "get",
+        totalTimeMs: 1,
+        error: "Clipboard read is restricted while CtrlProxy is not foreground",
+      }),
+    } as unknown as AndroidCtrlProxyClient);
+
+    const clipboard = new Clipboard(androidDevice, factory);
+    const result = await clipboard.execute("get");
+
+    expect(result.success).toBe(false);
+    expect(result.action).toBe("get");
+    expect(result.method).toBe("a11y");
+    expect(result.error).toContain("Clipboard read is restricted");
+    expect(fakeAdb.getAllCommands()).not.toContain("shell cmd clipboard get");
+
+    getInstanceSpy.mockRestore();
+  });
+
+  test("get returns default accessibility error when Android read fails without details", async () => {
+    const factory = new FakeAdbClientFactory();
+    const fakeAdb = factory.getFakeClient();
+    const getInstanceSpy = spyOn(AndroidCtrlProxyClient, "getInstance").mockReturnValue({
+      requestClipboard: async () => ({
+        success: false,
+        action: "get",
+        totalTimeMs: 1,
+      }),
+    } as unknown as AndroidCtrlProxyClient);
+
+    const clipboard = new Clipboard(androidDevice, factory);
+    const result = await clipboard.execute("get");
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBe("Accessibility clipboard get failed");
+    expect(result.method).toBe("a11y");
+    expect(fakeAdb.getAllCommands()).not.toContain("shell cmd clipboard get");
+
+    getInstanceSpy.mockRestore();
+  });
+
+  test("get does not use unsupported cmd clipboard fallback for an empty accessibility read", async () => {
+    const factory = new FakeAdbClientFactory();
+    const fakeAdb = factory.getFakeClient();
+    fakeAdb.setCommandResult("shell cmd clipboard get", "No shell command implementation");
+    const getInstanceSpy = spyOn(AndroidCtrlProxyClient, "getInstance").mockReturnValue({
+      requestClipboard: async () => ({
+        success: true,
+        action: "get",
+        text: "",
+        totalTimeMs: 1,
+      }),
+    } as unknown as AndroidCtrlProxyClient);
+
+    const clipboard = new Clipboard(androidDevice, factory);
+    const result = await clipboard.execute("get");
+
+    expect(result.success).toBe(true);
+    expect(result.action).toBe("get");
+    expect(result.text).toBe("");
+    expect(result.method).toBe("a11y");
+    expect(fakeAdb.getAllCommands()).not.toContain("shell cmd clipboard get");
 
     getInstanceSpy.mockRestore();
   });

--- a/test/server/interactionTools.clipboard.test.ts
+++ b/test/server/interactionTools.clipboard.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { clipboardSchema, registerInteractionTools } from "../../src/server/interactionTools";
+import { clipboardSchema, formatClipboardMessage, registerInteractionTools } from "../../src/server/interactionTools";
 import { ToolRegistry } from "../../src/server/toolRegistry";
 
 describe("clipboard tool schema", () => {
@@ -59,5 +59,35 @@ describe("clipboard tool schema", () => {
     expect(schema.anyOf).toBeUndefined();
     expect(schema.oneOf).toBeUndefined();
     expect(schema.allOf).toBeUndefined();
+  });
+
+  test("formats failed actions without success wording", () => {
+    for (const action of ["copy", "paste", "clear", "get"] as const) {
+      const message = formatClipboardMessage({
+        success: false,
+        action,
+        error: "Clipboard access denied",
+      });
+
+      expect(message).toBe(`Failed to execute clipboard ${action}: Clipboard access denied`);
+      expect(message).not.toContain("Copied");
+      expect(message).not.toContain("Pasted");
+      expect(message).not.toContain("Cleared");
+      expect(message).not.toContain("Retrieved empty");
+    }
+  });
+
+  test("formats successful get with content preview and empty clipboard message", () => {
+    expect(formatClipboardMessage({
+      success: true,
+      action: "get",
+      text: "hello",
+    })).toBe("Retrieved clipboard content: \"hello\"");
+
+    expect(formatClipboardMessage({
+      success: true,
+      action: "get",
+      text: "",
+    })).toBe("Retrieved empty clipboard");
   });
 });


### PR DESCRIPTION
## Summary
- report Android 10+ CtrlProxy clipboard `get` null reads as restricted failures instead of successful empty content
- stop Android clipboard `get` from probing unsupported `cmd clipboard get` after accessibility results
- update clipboard docs and tests for restricted reads and empty accessibility reads

Closes #2596

## Testing
- `bun test test/features/action/Clipboard.test.ts`
- `bun test`
- `bun run lint`
- `bun run build`
- `(cd android && ./gradlew :control-proxy:testDebugUnitTest)`
