### PR TITLE
fix: verify Android locale changes

### DIFF
--- a/docs/design-docs/mcp/tools.md
+++ b/docs/design-docs/mcp/tools.md
@@ -67,7 +67,7 @@ After writing, use `automobile:devices/{deviceId}/apps/{appId}/files/{container}
 - 🌐 `openLink` launches URLs or deep links.
 - 🧰 `systemTray`, `homeScreen`, and `recentApps` control system surfaces.
 - 🔔 `postNotification` posts notifications from the app-under-test when SDK hooks are installed.
-- 🌍 `changeLocalization` sets locale, time zone, text direction, and time format in one call.
+- 🌍 `changeLocalization` sets locale, time zone, text direction, and time format in one call. Android system-wide locale changes require a root-capable device and are verified against the effective system configuration before success is reported.
 
 #### Navigation & Exploration
 

--- a/src/features/utility/system-configuration/AndroidSystemConfigurationAdapter.ts
+++ b/src/features/utility/system-configuration/AndroidSystemConfigurationAdapter.ts
@@ -1,5 +1,4 @@
 import type { AdbExecutor } from "../../../utils/android-cmdline-tools/interfaces/AdbExecutor";
-import { readAndroidDeviceApiLevel } from "../../../utils/android-cmdline-tools/readAndroidDeviceApiLevel";
 import { logger } from "../../../utils/logger";
 import { AndroidCtrlProxyClient } from "../../observe/android/AndroidCtrlProxyClient";
 import type { SettingsNamespace } from "../../observe/android";
@@ -27,11 +26,6 @@ import {
 
 type TextDirectionSettingKey = "debug.force_rtl" | "force_rtl";
 
-type CommandAttempt = {
-  method: string;
-  command: string;
-};
-
 /**
  * Android implementation of {@link SystemConfigurationAdapter}. Uses
  * ADB shell commands (with an accessibility-service fast path for
@@ -49,45 +43,27 @@ export class AndroidSystemConfigurationAdapter implements SystemConfigurationAda
 
   async setLocale(languageTag: string, options: BroadcastOptions): Promise<SetLocaleResult> {
     const previousLanguageTag = await this.getCurrentLocaleTag();
-    const apiLevel = await readAndroidDeviceApiLevel(this.adb);
 
-    const commandAttempts: CommandAttempt[] = [];
-    const cmdLocaleAttempt = {
-      method: "cmd locale set-locales",
-      command: `shell cmd locale set-locales ${languageTag}`
-    };
-    const settingsAttempt = {
-      method: "settings put system user_locale",
-      command: `shell settings put system user_locale ${languageTag}`
-    };
-
-    if (apiLevel === null || apiLevel >= 31) {
-      commandAttempts.push(cmdLocaleAttempt, settingsAttempt);
-    } else {
-      commandAttempts.push(settingsAttempt, cmdLocaleAttempt);
-    }
-
-    let appliedMethod: string | null = null;
-    let lastError: string | null = null;
-
-    for (const attempt of commandAttempts) {
-      try {
-        await this.runShellCommand(attempt.command);
-        appliedMethod = attempt.method;
-        break;
-      } catch (error) {
-        const errorMessage = error instanceof Error ? error.message : String(error);
-        lastError = errorMessage;
-        logger.warn(`[SystemConfigurationManager] Failed locale command (${attempt.method}): ${errorMessage}`);
-      }
-    }
-
-    if (!appliedMethod) {
+    try {
+      await this.runShellCommand(`shell setprop persist.sys.locale ${quoteShellArg(languageTag)}`);
+      await this.runShellCommand("shell stop; start");
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : String(error);
       return {
         success: false,
         languageTag,
         previousLanguageTag,
-        error: `Failed to set locale${lastError ? `: ${lastError}` : ""}`
+        error: `Failed to set locale: ${errorMessage}`
+      };
+    }
+
+    const effectiveLanguageTag = await this.getEffectiveLocaleTag();
+    if (!this.localeTagsMatch(effectiveLanguageTag, languageTag)) {
+      return {
+        success: false,
+        languageTag,
+        previousLanguageTag,
+        error: `Read-back verification failed: expected "${languageTag}" but got "${effectiveLanguageTag ?? "null"}"`
       };
     }
 
@@ -99,7 +75,7 @@ export class AndroidSystemConfigurationAdapter implements SystemConfigurationAda
       success: true,
       languageTag,
       previousLanguageTag,
-      method: appliedMethod,
+      method: "setprop persist.sys.locale + stop/start",
       broadcasted
     };
   }
@@ -351,9 +327,9 @@ export class AndroidSystemConfigurationAdapter implements SystemConfigurationAda
       return parsedSystemLocale;
     }
 
-    const userLocale = await this.readSetting("shell settings get system user_locale");
-    if (userLocale) {
-      return userLocale;
+    const effectiveLocale = await this.getEffectiveLocaleTag();
+    if (effectiveLocale) {
+      return effectiveLocale;
     }
 
     const persistedLocale = await this.readSetting("shell getprop persist.sys.locale");
@@ -373,4 +349,45 @@ export class AndroidSystemConfigurationAdapter implements SystemConfigurationAda
 
     return language;
   }
+
+  private async getEffectiveLocaleTag(): Promise<string | null> {
+    try {
+      const result = await this.adb.executeCommand("shell am get-config", undefined, undefined, true);
+      return this.parseLocaleFromAmConfig(result.stdout);
+    } catch (error) {
+      logger.warn(`[SystemConfigurationManager] Failed to read effective Android locale: ${error}`);
+      return null;
+    }
+  }
+
+  private parseLocaleFromAmConfig(output: string): string | null {
+    const normalized = normalizeSettingValue(output);
+    if (!normalized) {
+      return null;
+    }
+
+    const bcp47Match = normalized.match(/(?:^|[-\s])b\+([a-z]{2,3})(?:\+([A-Za-z]{4}))?(?:\+([A-Z]{2}|\d{3}))?(?=[-\s]|$)/);
+    if (bcp47Match?.[1]) {
+      return [bcp47Match[1], bcp47Match[2], bcp47Match[3]].filter(Boolean).join("-");
+    }
+
+    const languageRegionMatch = normalized.match(/(?:^|[-\s])([a-z]{2,3})-r([A-Z]{2})(?=[-\s]|$)/);
+    if (languageRegionMatch?.[1] && languageRegionMatch[2]) {
+      return `${languageRegionMatch[1]}-${languageRegionMatch[2]}`;
+    }
+
+    const languageOnlyMatch = normalized.match(/(?:^|[-\s])([a-z]{2,3})(?=[-\s]|$)/);
+    return languageOnlyMatch?.[1] ?? null;
+  }
+
+  private localeTagsMatch(actual: string | null, expected: string): boolean {
+    if (!actual) {
+      return false;
+    }
+    return actual.replace(/_/g, "-").toLowerCase() === expected.replace(/_/g, "-").toLowerCase();
+  }
+}
+
+function quoteShellArg(value: string): string {
+  return `'${value.replace(/'/g, "'\\''")}'`;
 }

--- a/test/features/utility/SystemConfigurationAdapter.test.ts
+++ b/test/features/utility/SystemConfigurationAdapter.test.ts
@@ -170,6 +170,45 @@ describe("SystemConfigurationAdapter", () => {
   }
 
   describe("AndroidSystemConfigurationAdapter behavior", () => {
+    it("sets system locale with setprop, restarts Android, and verifies am get-config", async () => {
+      const adb = new FakeAdbClient();
+      adb.setCommandResult("shell settings get system system_locales", "en-US");
+      adb.setCommandResult("shell am get-config", "config: mcc310-mnc260-ja-rJP-sw411dp\n");
+      const adapter = new AndroidSystemConfigurationAdapter(androidDevice, adb as any);
+      const result = await adapter.setLocale("ja-JP", { broadcast: false });
+
+      expect(result.success).toBe(true);
+      expect(result.method).toBe("setprop persist.sys.locale + stop/start");
+      expect(result.previousLanguageTag).toBe("en-US");
+      expect(adb.wasCommandExecuted("setprop persist.sys.locale 'ja-JP'")).toBe(true);
+      expect(adb.wasCommandExecuted("stop; start")).toBe(true);
+      expect(adb.wasCommandExecuted("cmd locale set-locales ja-JP")).toBe(false);
+      expect(adb.wasCommandExecuted("settings put system user_locale ja-JP")).toBe(false);
+    });
+
+    it("returns false when Android locale verification reads the old effective locale", async () => {
+      const adb = new FakeAdbClient();
+      adb.setCommandResult("shell settings get system system_locales", "en-US");
+      adb.setCommandResult("shell am get-config", "config: mcc310-mnc260-en-rUS-sw411dp\n");
+      const adapter = new AndroidSystemConfigurationAdapter(androidDevice, adb as any);
+      const result = await adapter.setLocale("ja-JP", {});
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBe('Read-back verification failed: expected "ja-JP" but got "en-US"');
+      expect(adb.wasCommandExecuted("am broadcast")).toBe(false);
+    });
+
+    it("ignores no-op user_locale when reading Android localization settings", async () => {
+      const adb = new FakeAdbClient();
+      adb.setCommandResult("shell settings get system user_locale", "fr-FR");
+      adb.setCommandResult("shell am get-config", "config: mcc310-mnc260-en-rUS-sw411dp\n");
+      const adapter = new AndroidSystemConfigurationAdapter(androidDevice, adb as any);
+      const result = await adapter.getLocalizationSettings();
+
+      expect(result.locale).toBe("en-US");
+      expect(adb.wasCommandExecuted("settings get system user_locale")).toBe(false);
+    });
+
     it("broadcasts the LOCALE_CHANGED intent via ADB", async () => {
       const adb = new FakeAdbClient();
       const adapter = new AndroidSystemConfigurationAdapter(androidDevice, adb as any);

--- a/test/features/utility/SystemConfigurationManager.test.ts
+++ b/test/features/utility/SystemConfigurationManager.test.ts
@@ -453,17 +453,21 @@ describe("SystemConfigurationManager", () => {
     });
   });
 
-  // --- Android: existing behavior unchanged ---
+  // --- Android: setLocale ---
 
   describe("Android setLocale still works", () => {
-    test("uses adb commands for Android", async () => {
-      fakeAdbClient.setCommandResult("shell getprop ro.build.version.sdk", "33");
+    test("uses root-backed adb commands for Android and verifies the effective locale", async () => {
+      fakeAdbClient.setCommandResult("shell settings get system system_locales", "en-US");
+      fakeAdbClient.setCommandResult("shell am get-config", "config: mcc310-mnc260-ja-rJP-sw411dp\n");
       const mgr = new SystemConfigurationManager(ANDROID_DEVICE, fakeAdbFactory, fakeExec);
-      const result = await mgr.setLocale("en-US");
+      const result = await mgr.setLocale("ja-JP");
 
       expect(result.success).toBe(true);
       expect(fakeExec.getExecutedCommands()).toHaveLength(0);
-      expect(fakeAdbClient.wasCommandExecuted("cmd locale set-locales en-US")).toBe(true);
+      expect(fakeAdbClient.wasCommandExecuted("setprop persist.sys.locale 'ja-JP'")).toBe(true);
+      expect(fakeAdbClient.wasCommandExecuted("stop; start")).toBe(true);
+      expect(fakeAdbClient.wasCommandExecuted("cmd locale set-locales ja-JP")).toBe(false);
+      expect(fakeAdbClient.wasCommandExecuted("settings put system user_locale ja-JP")).toBe(false);
     });
   });
 
@@ -712,71 +716,61 @@ describe("SystemConfigurationManager", () => {
     });
   });
 
-  // --- Android: setLocale fallback paths ---
+  // --- Android: setLocale verification paths ---
 
-  describe("Android setLocale fallback", () => {
-    test("tries cmd locale first on API 31+", async () => {
-      fakeAdbClient.setCommandResult("shell getprop ro.build.version.sdk", "33");
+  describe("Android setLocale verification", () => {
+    test("sets system locale with persist.sys.locale, restarts Android, and verifies am get-config", async () => {
+      fakeAdbClient.setCommandResult("shell settings get system system_locales", "en-US");
+      fakeAdbClient.setCommandResult("shell am get-config", "config: mcc310-mnc260-ja-rJP-sw411dp\n");
       const mgr = new SystemConfigurationManager(ANDROID_DEVICE, fakeAdbFactory, fakeExec);
       const result = await mgr.setLocale("ja-JP");
 
       expect(result.success).toBe(true);
-      expect(result.method).toBe("cmd locale set-locales");
-      expect(fakeAdbClient.wasCommandExecuted("cmd locale set-locales ja-JP")).toBe(true);
+      expect(result.method).toBe("setprop persist.sys.locale + stop/start");
+      expect(result.previousLanguageTag).toBe("en-US");
+      expect(fakeAdbClient.wasCommandExecuted("setprop persist.sys.locale 'ja-JP'")).toBe(true);
+      expect(fakeAdbClient.wasCommandExecuted("stop; start")).toBe(true);
+      expect(fakeAdbClient.wasCommandExecuted("cmd locale set-locales ja-JP")).toBe(false);
+      expect(fakeAdbClient.wasCommandExecuted("settings put system user_locale ja-JP")).toBe(false);
     });
 
-    test("falls back to settings put when cmd locale fails on API 31+", async () => {
-      fakeAdbClient.setCommandResult("shell getprop ro.build.version.sdk", "33");
-      fakeAdbClient.setCommandError("shell cmd locale set-locales ja-JP", new Error("cmd not found"));
+    test("returns false when the command succeeds but effective locale is unchanged", async () => {
+      fakeAdbClient.setCommandResult("shell settings get system system_locales", "en-US");
+      fakeAdbClient.setCommandResult("shell am get-config", "config: mcc310-mnc260-en-rUS-sw411dp\n");
       const mgr = new SystemConfigurationManager(ANDROID_DEVICE, fakeAdbFactory, fakeExec);
       const result = await mgr.setLocale("ja-JP");
 
-      expect(result.success).toBe(true);
-      expect(result.method).toBe("settings put system user_locale");
-      expect(fakeAdbClient.wasCommandExecuted("settings put system user_locale ja-JP")).toBe(true);
+      expect(result.success).toBe(false);
+      expect(result.languageTag).toBe("ja-JP");
+      expect(result.previousLanguageTag).toBe("en-US");
+      expect(result.error).toBe('Read-back verification failed: expected "ja-JP" but got "en-US"');
     });
 
-    test("tries settings put first on API < 31", async () => {
-      fakeAdbClient.setCommandResult("shell getprop ro.build.version.sdk", "28");
-      const mgr = new SystemConfigurationManager(ANDROID_DEVICE, fakeAdbFactory, fakeExec);
-      const result = await mgr.setLocale("ja-JP");
-
-      expect(result.success).toBe(true);
-      expect(result.method).toBe("settings put system user_locale");
-    });
-
-    test("falls back to cmd locale when settings put fails on API < 31", async () => {
-      fakeAdbClient.setCommandResult("shell getprop ro.build.version.sdk", "28");
-      fakeAdbClient.setCommandError("shell settings put system user_locale ja-JP", new Error("settings fail"));
-      const mgr = new SystemConfigurationManager(ANDROID_DEVICE, fakeAdbFactory, fakeExec);
-      const result = await mgr.setLocale("ja-JP");
-
-      expect(result.success).toBe(true);
-      expect(result.method).toBe("cmd locale set-locales");
-    });
-
-    test("returns error when both commands fail", async () => {
-      fakeAdbClient.setCommandResult("shell getprop ro.build.version.sdk", "33");
-      fakeAdbClient.setCommandError("shell cmd locale set-locales ja-JP", new Error("cmd fail"));
-      fakeAdbClient.setCommandError("shell settings put system user_locale ja-JP", new Error("settings fail"));
+    test("returns command error when root-backed locale write is denied", async () => {
+      fakeAdbClient.setCommandResult("shell settings get system system_locales", "en-US");
+      fakeAdbClient.setCommandError("shell setprop persist.sys.locale 'ja-JP'", new Error("permission denied"));
       const mgr = new SystemConfigurationManager(ANDROID_DEVICE, fakeAdbFactory, fakeExec);
       const result = await mgr.setLocale("ja-JP");
 
       expect(result.success).toBe(false);
       expect(result.error).toContain("Failed to set locale");
-      expect(result.error).toContain("settings fail");
+      expect(result.error).toContain("permission denied");
     });
 
-    test("reads previous locale from system_locales", async () => {
+    test("reads previous locale from system_locales without consulting user_locale", async () => {
       fakeAdbClient.setCommandResult("shell settings get system system_locales", "en-US,fr-FR");
+      fakeAdbClient.setCommandResult("shell settings get system user_locale", "ja-JP");
+      fakeAdbClient.setCommandResult("shell am get-config", "config: mcc310-mnc260-ja-rJP-sw411dp\n");
       const mgr = new SystemConfigurationManager(ANDROID_DEVICE, fakeAdbFactory, fakeExec);
       const result = await mgr.setLocale("ja-JP");
 
       expect(result.success).toBe(true);
       expect(result.previousLanguageTag).toBe("en-US");
+      expect(fakeAdbClient.wasCommandExecuted("settings get system user_locale")).toBe(false);
     });
 
     test("broadcasts locale change by default", async () => {
+      fakeAdbClient.setCommandResult("shell am get-config", "config: mcc310-mnc260-ja-rJP-sw411dp\n");
       const mgr = new SystemConfigurationManager(ANDROID_DEVICE, fakeAdbFactory, fakeExec);
       await mgr.setLocale("ja-JP");
 
@@ -784,6 +778,7 @@ describe("SystemConfigurationManager", () => {
     });
 
     test("skips broadcast when option is false", async () => {
+      fakeAdbClient.setCommandResult("shell am get-config", "config: mcc310-mnc260-ja-rJP-sw411dp\n");
       const mgr = new SystemConfigurationManager(ANDROID_DEVICE, fakeAdbFactory, fakeExec);
       const result = await mgr.setLocale("ja-JP", { broadcast: false });
 
@@ -845,12 +840,14 @@ describe("SystemConfigurationManager", () => {
       expect(result.textDirection).toBeNull();
     });
 
-    test("reads locale from user_locale when system_locales is absent", async () => {
+    test("ignores user_locale and reads effective locale from am get-config when system_locales is absent", async () => {
       fakeAdbClient.setCommandResult("shell settings get system user_locale", "fr-FR");
+      fakeAdbClient.setCommandResult("shell am get-config", "config: mcc310-mnc260-en-rUS-sw411dp\n");
       const mgr = new SystemConfigurationManager(ANDROID_DEVICE, fakeAdbFactory, fakeExec);
       const result = await mgr.getLocalizationSettings();
 
-      expect(result.locale).toBe("fr-FR");
+      expect(result.locale).toBe("en-US");
+      expect(fakeAdbClient.wasCommandExecuted("settings get system user_locale")).toBe(false);
     });
 
     test("reads locale from persist.sys.locale as last resort", async () => {


### PR DESCRIPTION
## Summary
- replace Android `changeLocalization` locale writes with root-backed `persist.sys.locale` + Android service restart
- verify Android locale changes against `am get-config` before returning success
- stop treating `settings system user_locale` as authoritative locale read-back
- document the Android root-capable device constraint for system-wide locale changes

## Testing
- `bun test test/features/utility/SystemConfigurationManager.test.ts`
- `bun test test/features/utility/SystemConfigurationAdapter.test.ts`
- `bun run lint`
- `bun run build`
- `bun test`

Fixes #2595
