### PR TITLE
Fix sqlQuery RETURNING writes

### DIFF
--- a/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/database/SQLiteDatabaseDriver.kt
+++ b/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/database/SQLiteDatabaseDriver.kt
@@ -158,84 +158,124 @@ class SQLiteDatabaseDriver(private val context: Context) : DatabaseDriver {
   override fun executeSQL(databasePath: String, query: String): SQLExecutionResult {
     synchronized(databaseLock) {
       val trimmedQuery = query.trim()
+      val (returnsRows, readOnly) = classifySQL(trimmedQuery)
 
-      // Determine if this is a query or mutation
-      val isQuery = isReadQuery(trimmedQuery)
-
-      return if (isQuery) {
-        executeQuery(databasePath, trimmedQuery)
+      return if (returnsRows) {
+        executeQuery(databasePath, trimmedQuery, readOnly = readOnly)
       } else {
         executeMutation(databasePath, trimmedQuery)
       }
     }
   }
 
-  /**
-   * Determine if a SQL statement is a read query (returns rows) vs a mutation.
-   *
-   * Handles CTE queries (WITH ... SELECT) by looking past the CTE prefix to find the actual
-   * statement type.
-   */
-  private fun isReadQuery(query: String): Boolean {
-    val upperQuery = query.uppercase()
+  private fun classifySQL(query: String): Pair<Boolean, Boolean> {
+    val statement = findTopLevelStatement(query)
+    val keyword = statement?.first ?: return Pair(false, false)
+    val statementIndex = statement.second
 
-    // Direct read queries
-    if (
-        upperQuery.startsWith("SELECT") ||
-            upperQuery.startsWith("PRAGMA") ||
-            upperQuery.startsWith("EXPLAIN")
-    ) {
-      return true
+    if (keyword == "SELECT" || keyword == "PRAGMA" || keyword == "EXPLAIN") {
+      return Pair(true, true)
     }
 
-    // CTE queries: WITH ... followed by SELECT/INSERT/UPDATE/DELETE
-    // We need to find the actual statement after the CTE definitions
-    if (upperQuery.startsWith("WITH")) {
-      // Find the final statement after all CTE definitions
-      // CTEs are: WITH name AS (...), name2 AS (...) SELECT/INSERT/UPDATE/DELETE
-      // We look for the last occurrence of a statement keyword not inside parentheses
-      val statementType = findStatementAfterCTE(upperQuery)
-      return statementType == "SELECT"
+    if (keyword == "INSERT" || keyword == "UPDATE" || keyword == "DELETE") {
+      val hasReturning =
+          findTopLevelKeyword(query, statementIndex + keyword.length, listOf("RETURNING")) != null
+      return Pair(hasReturning, false)
     }
 
-    return false
+    return Pair(false, false)
   }
 
-  /**
-   * Check if text starts with a keyword followed by a word boundary. Prevents matching CTE names
-   * like "select_cte" as statement keywords.
-   */
-  private fun startsWithKeyword(text: String, keyword: String): Boolean {
-    if (!text.startsWith(keyword)) return false
-    val nextChar = text.getOrNull(keyword.length)
-    // Word boundary: next char is null (end of string) or not a word character
-    return nextChar == null || (!nextChar.isLetterOrDigit() && nextChar != '_')
+  private fun startsWithKeyword(text: String, keyword: String): Boolean =
+      matchesKeywordAt(text, 0, keyword)
+
+  private fun matchesKeywordAt(text: String, index: Int, keyword: String): Boolean {
+    if (index > 0 && isWordChar(text[index - 1])) return false
+    if (!text.regionMatches(index, keyword, 0, keyword.length, ignoreCase = true)) return false
+    val nextChar = text.getOrNull(index + keyword.length)
+    return nextChar == null || !isWordChar(nextChar)
   }
 
-  /**
-   * Find the actual statement type after CTE definitions.
-   *
-   * Parses past WITH ... AS (...) clauses to find SELECT/INSERT/UPDATE/DELETE. Uses word boundary
-   * checks to avoid matching CTE names like "update_cte".
-   */
-  private fun findStatementAfterCTE(upperQuery: String): String? {
+  private fun isWordChar(char: Char): Boolean = char.isLetterOrDigit() || char == '_'
+
+  private fun findTopLevelStatement(query: String): Pair<String, Int>? {
+    val keywords = listOf("SELECT", "PRAGMA", "EXPLAIN", "INSERT", "UPDATE", "DELETE")
+    if (!startsWithKeyword(query, "WITH")) {
+      return keywords
+          .firstOrNull { keyword -> startsWithKeyword(query, keyword) }
+          ?.let { keyword ->
+            Pair(keyword, 0)
+          }
+    }
+
+    return findTopLevelKeyword(
+        query,
+        "WITH".length,
+        keywords,
+    )
+  }
+
+  private fun findTopLevelKeyword(
+      query: String,
+      startIndex: Int,
+      keywords: List<String>,
+  ): Pair<String, Int>? {
     var depth = 0
-    var i = 4 // Skip "WITH"
+    var i = startIndex
+    var inSingleQuote = false
+    var inDoubleQuote = false
+    var inBacktickQuote = false
+    var inBracketQuote = false
+    var inLineComment = false
+    var inBlockComment = false
 
-    while (i < upperQuery.length) {
-      val char = upperQuery[i]
+    while (i < query.length) {
+      val char = query[i]
+      val next = query.getOrNull(i + 1)
 
       when {
+        inLineComment -> if (char == '\n' || char == '\r') inLineComment = false
+        inBlockComment -> {
+          if (char == '*' && next == '/') {
+            inBlockComment = false
+            i++
+          }
+        }
+        inSingleQuote -> {
+          if (char == '\'' && next == '\'') {
+            i++
+          } else if (char == '\'') {
+            inSingleQuote = false
+          }
+        }
+        inDoubleQuote -> {
+          if (char == '"' && next == '"') {
+            i++
+          } else if (char == '"') {
+            inDoubleQuote = false
+          }
+        }
+        inBacktickQuote -> if (char == '`') inBacktickQuote = false
+        inBracketQuote -> if (char == ']') inBracketQuote = false
+        char == '-' && next == '-' -> {
+          inLineComment = true
+          i++
+        }
+        char == '/' && next == '*' -> {
+          inBlockComment = true
+          i++
+        }
+        char == '\'' -> inSingleQuote = true
+        char == '"' -> inDoubleQuote = true
+        char == '`' -> inBacktickQuote = true
+        char == '[' -> inBracketQuote = true
         char == '(' -> depth++
-        char == ')' -> depth--
+        char == ')' && depth > 0 -> depth--
         depth == 0 -> {
-          // Check for statement keywords at this position (with word boundary)
-          val remaining = upperQuery.substring(i).trimStart()
-          when {
-            startsWithKeyword(remaining, "SELECT") -> return "SELECT"
-            startsWithKeyword(remaining, "INSERT") -> return "INSERT"
-            startsWithKeyword(remaining, "UPDATE") -> return "UPDATE"
-            startsWithKeyword(remaining, "DELETE") -> return "DELETE"
+          for (keyword in keywords) {
+            if (matchesKeywordAt(query, i, keyword)) {
+              return Pair(keyword, i)
+            }
           }
         }
       }
@@ -245,8 +285,12 @@ class SQLiteDatabaseDriver(private val context: Context) : DatabaseDriver {
     return null
   }
 
-  private fun executeQuery(databasePath: String, query: String): SQLExecutionResult.Query {
-    val db = openDatabase(databasePath, readOnly = true)
+  private fun executeQuery(
+      databasePath: String,
+      query: String,
+      readOnly: Boolean,
+  ): SQLExecutionResult.Query {
+    val db = openDatabase(databasePath, readOnly = readOnly)
     val columns = mutableListOf<String>()
     val rows = mutableListOf<List<Any?>>()
 

--- a/android/auto-mobile-sdk/src/test/kotlin/dev/jasonpearson/automobile/sdk/database/SQLiteDatabaseDriverTest.kt
+++ b/android/auto-mobile-sdk/src/test/kotlin/dev/jasonpearson/automobile/sdk/database/SQLiteDatabaseDriverTest.kt
@@ -13,8 +13,8 @@ import org.junit.After
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.robolectric.RuntimeEnvironment
 import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
 
 @RunWith(RobolectricTestRunner::class)
 class SQLiteDatabaseDriverTest {
@@ -37,8 +37,7 @@ class SQLiteDatabaseDriverTest {
     val siblingPath = context.applicationInfo.dataDir + "-other/databases/outside.db"
     val driver = SQLiteDatabaseDriver(context)
 
-    val error =
-        kotlin.runCatching { driver.executeSQL(siblingPath, "SELECT 1") }.exceptionOrNull()
+    val error = kotlin.runCatching { driver.executeSQL(siblingPath, "SELECT 1") }.exceptionOrNull()
 
     assertTrue(error is DatabaseError.InvalidPath)
   }
@@ -56,7 +55,10 @@ class SQLiteDatabaseDriverTest {
         try {
           start.await(2, TimeUnit.SECONDS)
           if (index % 4 == 0) {
-            driver.executeSQL(dbFile.absolutePath, "UPDATE items SET value = value + 1 WHERE id = 1")
+            driver.executeSQL(
+                dbFile.absolutePath,
+                "UPDATE items SET value = value + 1 WHERE id = 1",
+            )
           } else {
             val data = driver.getTableData(dbFile.absolutePath, "items", 10, 0)
             assertEquals(listOf("id", "value"), data.columns)
@@ -79,6 +81,70 @@ class SQLiteDatabaseDriverTest {
     assertTrue(errors.isEmpty(), errors.joinToString("\n") { it.stackTraceToString() })
   }
 
+  @Test
+  fun `returning writes are classified as row returning and writable`() {
+    val driver = SQLiteDatabaseDriver(context)
+
+    listOf(
+            "INSERT INTO notes (body) VALUES ('delta') RETURNING id, body",
+            "UPDATE notes SET body = 'beta2' WHERE body = 'beta' RETURNING id, body",
+            "DELETE FROM notes WHERE body = 'gamma' RETURNING id, body",
+            """
+            WITH target AS (
+              SELECT id FROM notes WHERE body = 'alpha'
+            )
+            UPDATE notes SET body = 'alpha2'
+            WHERE id IN (SELECT id FROM target)
+            RETURNING id, body
+            """
+                .trimIndent(),
+        )
+        .forEach { query ->
+          assertEquals(
+              Classification(returnsRows = true, readOnly = false),
+              classifySQL(driver, query),
+              query,
+          )
+        }
+  }
+
+  @Test
+  fun `returning inside a string literal does not make a mutation return rows`() {
+    val dbFile = createNotesDatabase("returning-string-${System.nanoTime()}.db")
+    val driver = SQLiteDatabaseDriver(context)
+
+    assertEquals(
+        Classification(returnsRows = false, readOnly = false),
+        classifySQL(driver, "UPDATE notes SET body = 'not RETURNING syntax' WHERE body = 'alpha'"),
+    )
+
+    val result =
+        driver.executeSQL(
+            dbFile.absolutePath,
+            "UPDATE notes SET body = 'not RETURNING syntax' WHERE body = 'alpha'",
+        )
+
+    assertEquals(SQLExecutionResult.Mutation(rowsAffected = 1), result)
+    driver.closeAll()
+  }
+
+  @Test
+  fun `ddl statements with inner select are not classified as read only queries`() {
+    val driver = SQLiteDatabaseDriver(context)
+
+    listOf(
+            "CREATE TABLE backup AS SELECT * FROM notes",
+            "CREATE VIEW notes_view AS SELECT * FROM notes",
+        )
+        .forEach { query ->
+          assertEquals(
+              Classification(returnsRows = false, readOnly = false),
+              classifySQL(driver, query),
+              query,
+          )
+        }
+  }
+
   private fun createDatabase(name: String): File {
     val dbFile = context.getDatabasePath(name)
     dbFile.parentFile?.mkdirs()
@@ -92,4 +158,35 @@ class SQLiteDatabaseDriverTest {
 
     return dbFile
   }
+
+  private fun createNotesDatabase(name: String): File {
+    val dbFile = context.getDatabasePath(name)
+    dbFile.parentFile?.mkdirs()
+    dbFile.delete()
+    filesToDelete.add(dbFile)
+
+    SQLiteDatabase.openOrCreateDatabase(dbFile, null).use { db ->
+      db.execSQL("CREATE TABLE notes (id INTEGER PRIMARY KEY AUTOINCREMENT, body TEXT NOT NULL)")
+      db.execSQL("INSERT INTO notes (body) VALUES ('alpha'), ('beta'), ('gamma')")
+    }
+
+    return dbFile
+  }
+
+  private fun classifySQL(driver: SQLiteDatabaseDriver, query: String): Classification {
+    val classify =
+        SQLiteDatabaseDriver::class
+            .java
+            .getDeclaredMethod("classifySQL", String::class.java)
+            .apply {
+              isAccessible = true
+            }
+    val result = classify.invoke(driver, query) as Pair<*, *>
+    return Classification(
+        returnsRows = result.first as Boolean,
+        readOnly = result.second as Boolean,
+    )
+  }
+
+  private data class Classification(val returnsRows: Boolean, val readOnly: Boolean)
 }

--- a/ios/auto-mobile-sdk/Sources/AutoMobileSDK/Storage/SQLiteDatabaseDriver.swift
+++ b/ios/auto-mobile-sdk/Sources/AutoMobileSDK/Storage/SQLiteDatabaseDriver.swift
@@ -166,14 +166,13 @@ public final class SQLiteDatabaseDriver: DatabaseDriver, @unchecked Sendable {
         defer { operationLock.unlock() }
 
         let trimmed = query.trimmingCharacters(in: .whitespacesAndNewlines)
-        let isRead = isReadQuery(trimmed)
-        let readOnly = isRead
-        guard let db = openDatabase(path: databasePath, readOnly: readOnly) else {
+        let classification = classifySQL(trimmed)
+        guard let db = openDatabase(path: databasePath, readOnly: classification.readOnly) else {
             return SQLExecutionResult(columns: nil, rows: nil, rowsAffected: 0, error: "Failed to open database")
         }
 
-        if isRead {
-            return executeQuery(db: db, query: trimmed)
+        if classification.returnsRows {
+            return executeQuery(db: db, query: trimmed, includeRowsAffected: !classification.readOnly)
         } else {
             return executeMutation(db: db, query: trimmed)
         }
@@ -212,44 +211,133 @@ public final class SQLiteDatabaseDriver: DatabaseDriver, @unchecked Sendable {
         return db
     }
 
-    private func isReadQuery(_ query: String) -> Bool {
-        let upper = query.uppercased()
-        if startsWithKeyword(upper, "SELECT") || startsWithKeyword(upper, "EXPLAIN") {
-            return true
+    private func classifySQL(_ query: String) -> SQLClassification {
+        guard let statement = findTopLevelStatement(in: query) else {
+            return SQLClassification(returnsRows: false, readOnly: false)
         }
-        // PRAGMA is read-only unless it contains '=' (e.g. PRAGMA user_version = 1)
-        if startsWithKeyword(upper, "PRAGMA") {
-            return !upper.contains("=")
+
+        switch statement.keyword {
+        case "SELECT", "EXPLAIN":
+            return SQLClassification(returnsRows: true, readOnly: true)
+        case "PRAGMA":
+            // PRAGMA is read-only unless it contains '=' (e.g. PRAGMA user_version = 1).
+            return SQLClassification(returnsRows: !query.contains("="), readOnly: !query.contains("="))
+        case "INSERT", "UPDATE", "DELETE":
+            let hasReturning = findTopLevelKeyword(
+                in: query,
+                from: query.index(statement.index, offsetBy: statement.keyword.count),
+                keywords: ["RETURNING"]
+            ) != nil
+            return SQLClassification(returnsRows: hasReturning, readOnly: false)
+        default:
+            return SQLClassification(returnsRows: false, readOnly: false)
         }
-        if startsWithKeyword(upper, "WITH") {
-            // CTE: find the actual statement after the CTE definitions
-            if let range = findStatementAfterCTE(upper) {
-                return startsWithKeyword(range, "SELECT")
-            }
-        }
-        return false
     }
 
     private func startsWithKeyword(_ text: String, _ keyword: String) -> Bool {
-        guard text.hasPrefix(keyword) else { return false }
-        let idx = text.index(text.startIndex, offsetBy: keyword.count)
-        guard idx < text.endIndex else { return true }
-        let next = text[idx]
-        return !next.isLetter && next != "_" && !next.isNumber
+        matchesKeyword(in: text, at: text.startIndex, keyword: keyword)
     }
 
-    private func findStatementAfterCTE(_ query: String) -> String? {
-        // Simple heuristic: find the last unmatched SELECT/INSERT/UPDATE/DELETE after WITH
+    private func matchesKeyword(in text: String, at index: String.Index, keyword: String) -> Bool {
+        if index > text.startIndex, isWordChar(text[text.index(before: index)]) {
+            return false
+        }
+        guard text[index...].range(of: keyword, options: [.anchored, .caseInsensitive]) != nil else {
+            return false
+        }
+        guard let next = text.index(index, offsetBy: keyword.count, limitedBy: text.endIndex),
+              next < text.endIndex
+        else {
+            return true
+        }
+        return !isWordChar(text[next])
+    }
+
+    private func isWordChar(_ char: Character) -> Bool {
+        char.isLetter || char.isNumber || char == "_"
+    }
+
+    private func findTopLevelStatement(in query: String) -> SQLKeyword? {
+        let keywords = ["SELECT", "PRAGMA", "EXPLAIN", "INSERT", "UPDATE", "DELETE"]
+        if !startsWithKeyword(query, "WITH") {
+            return keywords.first(where: { startsWithKeyword(query, $0) }).map {
+                SQLKeyword(keyword: $0, index: query.startIndex)
+            }
+        }
+
+        return findTopLevelKeyword(
+            in: query,
+            from: query.index(query.startIndex, offsetBy: "WITH".count),
+            keywords: keywords
+        )
+    }
+
+    private func findTopLevelKeyword(in query: String, from start: String.Index, keywords: [String]) -> SQLKeyword? {
         var depth = 0
-        var i = query.index(query.startIndex, offsetBy: 4) // skip "WITH"
+        var i = start
+        var inSingleQuote = false
+        var inDoubleQuote = false
+        var inBacktickQuote = false
+        var inBracketQuote = false
+        var inLineComment = false
+        var inBlockComment = false
+
         while i < query.endIndex {
-            let remaining = String(query[i...]).trimmingCharacters(in: .whitespaces)
-            if remaining.hasPrefix("(") { depth += 1 }
-            else if remaining.hasPrefix(")") { depth -= 1 }
-            else if depth == 0 {
-                for keyword in ["SELECT", "INSERT", "UPDATE", "DELETE"] {
-                    if startsWithKeyword(remaining, keyword) {
-                        return remaining
+            let char = query[i]
+            let nextIndex = query.index(after: i)
+            let next = nextIndex < query.endIndex ? query[nextIndex] : nil
+
+            if inLineComment {
+                if char == "\n" || char == "\r" {
+                    inLineComment = false
+                }
+            } else if inBlockComment {
+                if char == "*", next == "/" {
+                    inBlockComment = false
+                    i = nextIndex
+                }
+            } else if inSingleQuote {
+                if char == "'", next == "'" {
+                    i = nextIndex
+                } else if char == "'" {
+                    inSingleQuote = false
+                }
+            } else if inDoubleQuote {
+                if char == "\"", next == "\"" {
+                    i = nextIndex
+                } else if char == "\"" {
+                    inDoubleQuote = false
+                }
+            } else if inBacktickQuote {
+                if char == "`" {
+                    inBacktickQuote = false
+                }
+            } else if inBracketQuote {
+                if char == "]" {
+                    inBracketQuote = false
+                }
+            } else if char == "-", next == "-" {
+                inLineComment = true
+                i = nextIndex
+            } else if char == "/", next == "*" {
+                inBlockComment = true
+                i = nextIndex
+            } else if char == "'" {
+                inSingleQuote = true
+            } else if char == "\"" {
+                inDoubleQuote = true
+            } else if char == "`" {
+                inBacktickQuote = true
+            } else if char == "[" {
+                inBracketQuote = true
+            } else if char == "(" {
+                depth += 1
+            } else if char == ")", depth > 0 {
+                depth -= 1
+            } else if depth == 0 {
+                for keyword in keywords {
+                    if matchesKeyword(in: query, at: i, keyword: keyword) {
+                        return SQLKeyword(keyword: keyword, index: i)
                     }
                 }
             }
@@ -258,7 +346,13 @@ public final class SQLiteDatabaseDriver: DatabaseDriver, @unchecked Sendable {
         return nil
     }
 
-    private func executeQuery(db: OpaquePointer, query: String) -> SQLExecutionResult {
+    private func executeQuery(
+        db: OpaquePointer,
+        query: String,
+        includeRowsAffected: Bool = false
+    )
+        -> SQLExecutionResult
+    {
         var stmt: OpaquePointer?
         guard sqlite3_prepare_v2(db, query, -1, &stmt, nil) == SQLITE_OK else {
             let error = sqlite3_errmsg(db).map { String(cString: $0) } ?? "Unknown error"
@@ -275,15 +369,23 @@ public final class SQLiteDatabaseDriver: DatabaseDriver, @unchecked Sendable {
         }
 
         var rows: [[String?]] = []
-        while sqlite3_step(stmt) == SQLITE_ROW {
+        var stepResult = sqlite3_step(stmt)
+        while stepResult == SQLITE_ROW {
             var row: [String?] = []
             for i in 0 ..< columnCount {
                 row.append(getColumnValue(stmt: stmt, index: Int32(i)))
             }
             rows.append(row)
+            stepResult = sqlite3_step(stmt)
         }
 
-        return SQLExecutionResult(columns: columns, rows: rows, rowsAffected: 0)
+        if stepResult != SQLITE_DONE {
+            let error = sqlite3_errmsg(db).map { String(cString: $0) } ?? "Unknown error"
+            return SQLExecutionResult(columns: nil, rows: nil, rowsAffected: 0, error: error)
+        }
+
+        let rowsAffected = includeRowsAffected ? Int(sqlite3_changes(db)) : 0
+        return SQLExecutionResult(columns: columns, rows: rows, rowsAffected: rowsAffected)
     }
 
     private func executeMutation(db: OpaquePointer, query: String) -> SQLExecutionResult {
@@ -371,4 +473,14 @@ public final class SQLiteDatabaseDriver: DatabaseDriver, @unchecked Sendable {
         openDatabases.removeAll()
         lock.unlock()
     }
+}
+
+private struct SQLClassification {
+    let returnsRows: Bool
+    let readOnly: Bool
+}
+
+private struct SQLKeyword {
+    let keyword: String
+    let index: String.Index
 }

--- a/ios/auto-mobile-sdk/Tests/AutoMobileSDKTests/SQLiteDatabaseDriverTests.swift
+++ b/ios/auto-mobile-sdk/Tests/AutoMobileSDKTests/SQLiteDatabaseDriverTests.swift
@@ -1,0 +1,131 @@
+@testable import AutoMobileSDK
+import SQLite3
+import XCTest
+
+final class SQLiteDatabaseDriverTests: XCTestCase {
+    private var databaseURL: URL!
+    private var driver: SQLiteDatabaseDriver!
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        databaseURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString)
+            .appendingPathExtension("db")
+        driver = SQLiteDatabaseDriver()
+
+        var db: OpaquePointer?
+        XCTAssertEqual(sqlite3_open(databaseURL.path, &db), SQLITE_OK)
+        defer { sqlite3_close(db) }
+        sqlite3_exec(db, "CREATE TABLE notes (id INTEGER PRIMARY KEY AUTOINCREMENT, body TEXT NOT NULL)", nil, nil, nil)
+        sqlite3_exec(db, "INSERT INTO notes (body) VALUES ('alpha'), ('beta'), ('gamma')", nil, nil, nil)
+    }
+
+    override func tearDownWithError() throws {
+        driver.closeAll()
+        try? FileManager.default.removeItem(at: databaseURL)
+        try super.tearDownWithError()
+    }
+
+    func testInsertReturningReturnsInsertedRow() {
+        let result = driver.executeSQL(
+            databasePath: databaseURL.path,
+            query: "INSERT INTO notes (body) VALUES ('delta') RETURNING id, body"
+        )
+
+        XCTAssertNil(result.error)
+        XCTAssertEqual(result.columns, ["id", "body"])
+        XCTAssertEqual(result.rows, [["4", "delta"]])
+        XCTAssertEqual(result.rowsAffected, 1)
+    }
+
+    func testUpdateReturningAppliesMutationAndReturnsChangedRow() {
+        let result = driver.executeSQL(
+            databasePath: databaseURL.path,
+            query: "UPDATE notes SET body = 'beta2' WHERE body = 'beta' RETURNING id, body"
+        )
+
+        XCTAssertNil(result.error)
+        XCTAssertEqual(result.columns, ["id", "body"])
+        XCTAssertEqual(result.rows, [["2", "beta2"]])
+        XCTAssertEqual(result.rowsAffected, 1)
+
+        let verification = driver.executeSQL(
+            databasePath: databaseURL.path,
+            query: "SELECT body FROM notes WHERE id = 2"
+        )
+        XCTAssertEqual(verification.rows, [["beta2"]])
+    }
+
+    func testDeleteReturningReturnsDeletedRow() {
+        let result = driver.executeSQL(
+            databasePath: databaseURL.path,
+            query: "DELETE FROM notes WHERE body = 'gamma' RETURNING id, body"
+        )
+
+        XCTAssertNil(result.error)
+        XCTAssertEqual(result.columns, ["id", "body"])
+        XCTAssertEqual(result.rows, [["3", "gamma"]])
+        XCTAssertEqual(result.rowsAffected, 1)
+    }
+
+    func testCteWrappedUpdateReturningReturnsChangedRow() {
+        let result = driver.executeSQL(
+            databasePath: databaseURL.path,
+            query: """
+            WITH target AS (
+              SELECT id FROM notes WHERE body = 'alpha'
+            )
+            UPDATE notes SET body = 'alpha2'
+            WHERE id IN (SELECT id FROM target)
+            RETURNING id, body
+            """
+        )
+
+        XCTAssertNil(result.error)
+        XCTAssertEqual(result.columns, ["id", "body"])
+        XCTAssertEqual(result.rows, [["1", "alpha2"]])
+        XCTAssertEqual(result.rowsAffected, 1)
+    }
+
+    func testReturningInsideStringLiteralDoesNotMakeMutationReturnRows() {
+        let result = driver.executeSQL(
+            databasePath: databaseURL.path,
+            query: "UPDATE notes SET body = 'not RETURNING syntax' WHERE body = 'alpha'"
+        )
+
+        XCTAssertNil(result.error)
+        XCTAssertNil(result.columns)
+        XCTAssertNil(result.rows)
+        XCTAssertEqual(result.rowsAffected, 1)
+    }
+
+    func testDdlWithInnerSelectUsesMutationPath() {
+        let createTable = driver.executeSQL(
+            databasePath: databaseURL.path,
+            query: "CREATE TABLE notes_backup AS SELECT * FROM notes"
+        )
+        let createView = driver.executeSQL(
+            databasePath: databaseURL.path,
+            query: "CREATE VIEW notes_view AS SELECT * FROM notes"
+        )
+
+        XCTAssertNil(createTable.error)
+        XCTAssertNil(createTable.columns)
+        XCTAssertNil(createTable.rows)
+        XCTAssertNil(createView.error)
+        XCTAssertNil(createView.columns)
+        XCTAssertNil(createView.rows)
+    }
+
+    func testReturningWriteSurfacesStepError() {
+        let result = driver.executeSQL(
+            databasePath: databaseURL.path,
+            query: "INSERT INTO notes (id, body) VALUES (1, 'duplicate') RETURNING id, body"
+        )
+
+        XCTAssertNotNil(result.error)
+        XCTAssertNil(result.columns)
+        XCTAssertNil(result.rows)
+        XCTAssertEqual(result.rowsAffected, 0)
+    }
+}


### PR DESCRIPTION
## Summary
- Fix `sqlQuery` classification for top-level `INSERT` / `UPDATE` / `DELETE ... RETURNING` so row-returning writes use the row collection path on writable database handles.
- Add SQL keyword scanning that skips strings, quoted identifiers, comments, and nested CTE/query bodies before matching top-level `RETURNING`.
- Add Android classifier coverage and iOS SQLite execution coverage for `INSERT`, `UPDATE`, `DELETE`, CTE-wrapped writes, false-positive strings, and iOS step errors.

Closes #2594

## Testing
- `./gradlew :auto-mobile-sdk:testDebugUnitTest --no-configuration-cache`
- `swift test --package-path ios/auto-mobile-sdk -Xswiftc -warnings-as-errors`
- `swift test --package-path ios/auto-mobile-sdk --filter SQLiteDatabaseDriverTests`
- `ktfmt --dry-run --set-exit-if-changed android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/database/SQLiteDatabaseDriver.kt android/auto-mobile-sdk/src/test/kotlin/dev/jasonpearson/automobile/sdk/database/SQLiteDatabaseDriverTest.kt`
- `swiftformat --lint ios/auto-mobile-sdk/Sources/AutoMobileSDK/Storage/SQLiteDatabaseDriver.swift ios/auto-mobile-sdk/Tests/AutoMobileSDKTests/SQLiteDatabaseDriverTests.swift`
- `git diff --check`

## Notes
- No `.github/pull_request_template*` file exists in this checkout, so this body uses the repo's standard summary/testing shape.
- Self-review found and fixed an iOS `sqlite3_step` error handling gap in the new row-returning query path.
- `:auto-mobile-sdk:apiCheck` currently reports unrelated pre-existing API baseline drift in navigation/logging/network signatures; the generated diff did not include SQLite driver signatures, and the API file was left unchanged.
