### PR TITLE
Fix daemon proxy recovery after session loss

### DIFF
--- a/src/daemon/daemonMcpProxy.ts
+++ b/src/daemon/daemonMcpProxy.ts
@@ -298,6 +298,53 @@ export class DaemonMcpProxy {
     }
   }
 
+  private async withRecoverableReconnect<T>(
+    operation: () => Promise<T>
+  ): Promise<T> {
+    await this.ensureConnected();
+
+    try {
+      return await operation();
+    } catch (error) {
+      if (!this.isRecoverableDaemonSessionError(error)) {
+        throw error;
+      }
+
+      logger.warn(
+        `[DaemonMcpProxy] Daemon session is stale, reconnecting and retrying once: ${error instanceof Error ? error.message : String(error)}`
+      );
+      await this.resetConnection();
+      await this.ensureConnected();
+      return await operation();
+    }
+  }
+
+  private isRecoverableDaemonSessionError(error: unknown): boolean {
+    if (error instanceof DaemonUnavailableError) {
+      return true;
+    }
+
+    const message = error instanceof Error ? error.message : String(error);
+    return message.includes("Session not found");
+  }
+
+  private async resetConnection(): Promise<void> {
+    const staleClient = this.client;
+    this.connected = false;
+    this.client = null;
+    this.invalidateCache();
+
+    if (!staleClient) {
+      return;
+    }
+
+    try {
+      await staleClient.close();
+    } catch (error) {
+      logger.warn(`[DaemonMcpProxy] Failed to close stale daemon client: ${error}`);
+    }
+  }
+
   /**
    * Get list of available tools from daemon
    */
@@ -307,10 +354,10 @@ export class DaemonMcpProxy {
       return this.cachedTools;
     }
 
-    await this.ensureConnected();
-
     try {
-      const result = await this.client!.callDaemonMethod("tools/list", {});
+      const result = await this.withRecoverableReconnect(() =>
+        this.client!.callDaemonMethod("tools/list", {})
+      );
       const tools = result?.tools ?? [];
       this.cachedTools = tools;
       return tools;
@@ -327,22 +374,7 @@ export class DaemonMcpProxy {
     name: string,
     args: Record<string, unknown>
   ): Promise<any> {
-    await this.ensureConnected();
-
-    try {
-      const result = await this.client!.callTool(name, args);
-      return result;
-    } catch (error) {
-      // Handle connection errors by reconnecting
-      if (error instanceof DaemonUnavailableError) {
-        this.connected = false;
-        this.client = null;
-        // Retry once after reconnecting
-        await this.ensureConnected();
-        return await this.client!.callTool(name, args);
-      }
-      throw error;
-    }
+    return await this.withRecoverableReconnect(() => this.client!.callTool(name, args));
   }
 
   /**
@@ -354,10 +386,10 @@ export class DaemonMcpProxy {
       return this.cachedResources;
     }
 
-    await this.ensureConnected();
-
     try {
-      const result = await this.client!.callDaemonMethod("resources/list", {});
+      const result = await this.withRecoverableReconnect(() =>
+        this.client!.callDaemonMethod("resources/list", {})
+      );
       const resources = result?.resources ?? [];
       this.cachedResources = resources;
       return resources;
@@ -376,10 +408,10 @@ export class DaemonMcpProxy {
       return this.cachedResourceTemplates;
     }
 
-    await this.ensureConnected();
-
     try {
-      const result = await this.client!.callDaemonMethod("resources/list-templates", {});
+      const result = await this.withRecoverableReconnect(() =>
+        this.client!.callDaemonMethod("resources/list-templates", {})
+      );
       const templates = result?.resourceTemplates ?? [];
       this.cachedResourceTemplates = templates;
       return templates;
@@ -393,22 +425,7 @@ export class DaemonMcpProxy {
    * Read a resource from the daemon
    */
   async readResource(uri: string): Promise<any> {
-    await this.ensureConnected();
-
-    try {
-      const result = await this.client!.readResource(uri);
-      return result;
-    } catch (error) {
-      // Handle connection errors by reconnecting
-      if (error instanceof DaemonUnavailableError) {
-        this.connected = false;
-        this.client = null;
-        // Retry once after reconnecting
-        await this.ensureConnected();
-        return await this.client!.readResource(uri);
-      }
-      throw error;
-    }
+    return await this.withRecoverableReconnect(() => this.client!.readResource(uri));
   }
 
   /**

--- a/test/daemon/daemonMcpProxy.test.ts
+++ b/test/daemon/daemonMcpProxy.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test, spyOn } from "bun:test";
 import { DaemonMcpProxy, DaemonVersionMismatchError } from "../../src/daemon/daemonMcpProxy";
-import { DaemonClient, DaemonUnavailableError } from "../../src/daemon/client";
+import { DaemonClient, DaemonUnavailableError, type DaemonClientLike } from "../../src/daemon/client";
 import { DAEMON_VERSION, DAEMON_VERSION_RESTART_COOLDOWN_MS } from "../../src/daemon/constants";
 import { logger } from "../../src/utils/logger";
 import { FakeDaemonManager } from "../fakes/FakeDaemonManager";
@@ -10,6 +10,57 @@ import { FakeTimer } from "../fakes/FakeTimer";
 const OLDER_VERSION = "0.0.1";
 const NEWER_VERSION = "9999.0.0";
 const ANCIENT_TIMESTAMP = 1;
+
+class ScriptedDaemonClient implements DaemonClientLike {
+  readonly callToolCalls: Array<{ toolName: string; params: Record<string, any> }> = [];
+  readonly readResourceCalls: string[] = [];
+  readonly callDaemonMethodCalls: Array<{ method: string; params: Record<string, any> }> = [];
+  connectCallCount = 0;
+  closeCallCount = 0;
+
+  constructor(
+    private readonly behavior: {
+      toolResult?: any;
+      toolError?: Error;
+      resourceResult?: any;
+      resourceError?: Error;
+      daemonMethodResults?: Map<string, any>;
+      daemonMethodError?: Error;
+    }
+  ) {}
+
+  async connect(): Promise<void> {
+    this.connectCallCount++;
+  }
+
+  async close(): Promise<void> {
+    this.closeCallCount++;
+  }
+
+  async callTool(toolName: string, params: Record<string, any>): Promise<any> {
+    this.callToolCalls.push({ toolName, params });
+    if (this.behavior.toolError) {
+      throw this.behavior.toolError;
+    }
+    return this.behavior.toolResult ?? { content: [{ type: "text", text: "success" }] };
+  }
+
+  async readResource(uri: string): Promise<any> {
+    this.readResourceCalls.push(uri);
+    if (this.behavior.resourceError) {
+      throw this.behavior.resourceError;
+    }
+    return this.behavior.resourceResult ?? { contents: [{ uri, text: "success" }] };
+  }
+
+  async callDaemonMethod(method: string, params: Record<string, any>): Promise<any> {
+    this.callDaemonMethodCalls.push({ method, params });
+    if (this.behavior.daemonMethodError) {
+      throw this.behavior.daemonMethodError;
+    }
+    return this.behavior.daemonMethodResults?.get(method) ?? {};
+  }
+}
 
 describe("DaemonMcpProxy", () => {
   describe("connection management", () => {
@@ -416,6 +467,126 @@ describe("DaemonMcpProxy", () => {
         await proxy.close();
       }
     });
+
+    test("callTool reconnects and retries once when daemon session is stale", async () => {
+      const recoveredResult = { content: [{ type: "text", text: "observed after reconnect" }] };
+      const staleClient = new ScriptedDaemonClient({
+        toolError: new Error("Session not found"),
+      });
+      const freshClient = new ScriptedDaemonClient({
+        toolResult: recoveredResult,
+      });
+      const clients = [staleClient, freshClient];
+      const isAvailableSpy = spyOn(DaemonClient, "isAvailable").mockResolvedValue(true);
+
+      const proxy = new DaemonMcpProxy({
+        clientFactory: () => clients.shift()!,
+        autoStartDaemon: false
+      });
+
+      try {
+        const result = await proxy.callTool("observe", { deviceId: "device-1" });
+
+        expect(result).toEqual(recoveredResult);
+        expect(staleClient.connectCallCount).toBe(1);
+        expect(staleClient.closeCallCount).toBe(1);
+        expect(staleClient.callToolCalls).toEqual([
+          { toolName: "observe", params: { deviceId: "device-1" } }
+        ]);
+        expect(freshClient.connectCallCount).toBe(1);
+        expect(freshClient.callToolCalls).toEqual([
+          { toolName: "observe", params: { deviceId: "device-1" } }
+        ]);
+      } finally {
+        isAvailableSpy.mockRestore();
+        await proxy.close();
+      }
+    });
+
+    test("callTool surfaces second session failure after one reconnect retry", async () => {
+      const firstClient = new ScriptedDaemonClient({
+        toolError: new Error("Session not found"),
+      });
+      const secondClient = new ScriptedDaemonClient({
+        toolError: new Error("Session not found"),
+      });
+      const clients = [firstClient, secondClient];
+      const isAvailableSpy = spyOn(DaemonClient, "isAvailable").mockResolvedValue(true);
+
+      const proxy = new DaemonMcpProxy({
+        clientFactory: () => clients.shift()!,
+        autoStartDaemon: false
+      });
+
+      try {
+        await expect(proxy.callTool("observe", {})).rejects.toThrow("Session not found");
+        expect(firstClient.closeCallCount).toBe(1);
+        expect(firstClient.callToolCalls).toHaveLength(1);
+        expect(secondClient.callToolCalls).toHaveLength(1);
+        expect(clients).toHaveLength(0);
+      } finally {
+        isAvailableSpy.mockRestore();
+        await proxy.close();
+      }
+    });
+
+    test("callTool does not reconnect for non-session daemon errors", async () => {
+      const client = new ScriptedDaemonClient({
+        toolError: new Error("Permission denied"),
+      });
+      const isAvailableSpy = spyOn(DaemonClient, "isAvailable").mockResolvedValue(true);
+
+      const proxy = new DaemonMcpProxy({
+        clientFactory: () => client,
+        autoStartDaemon: false
+      });
+
+      try {
+        await expect(proxy.callTool("observe", {})).rejects.toThrow("Permission denied");
+        expect(client.callToolCalls).toHaveLength(1);
+        expect(client.closeCallCount).toBe(0);
+      } finally {
+        isAvailableSpy.mockRestore();
+        await proxy.close();
+      }
+    });
+
+    test("callTool recovery invalidates cached daemon definitions", async () => {
+      const staleClient = new ScriptedDaemonClient({
+        daemonMethodResults: new Map([
+          ["tools/list", { tools: [{ name: "oldTool", inputSchema: {} }] }]
+        ]),
+        toolError: new Error("Session not found"),
+      });
+      const freshClient = new ScriptedDaemonClient({
+        daemonMethodResults: new Map([
+          ["tools/list", { tools: [{ name: "newTool", inputSchema: {} }] }]
+        ]),
+      });
+      const clients = [staleClient, freshClient];
+      const isAvailableSpy = spyOn(DaemonClient, "isAvailable").mockResolvedValue(true);
+
+      const proxy = new DaemonMcpProxy({
+        clientFactory: () => clients.shift()!,
+        autoStartDaemon: false
+      });
+
+      try {
+        await expect(proxy.listTools()).resolves.toEqual([{ name: "oldTool", inputSchema: {} }]);
+        await proxy.callTool("observe", {});
+        await expect(proxy.listTools()).resolves.toEqual([{ name: "newTool", inputSchema: {} }]);
+
+        expect(staleClient.closeCallCount).toBe(1);
+        expect(staleClient.callDaemonMethodCalls).toHaveLength(1);
+        expect(freshClient.callToolCalls).toHaveLength(1);
+        expect(freshClient.callDaemonMethodCalls).toEqual([
+          { method: "tools/list", params: {} }
+        ]);
+      } finally {
+        isAvailableSpy.mockRestore();
+        await proxy.close();
+      }
+    });
   });
 
   describe("resource operations", () => {
@@ -460,6 +631,37 @@ describe("DaemonMcpProxy", () => {
 
         expect(result).toEqual(expectedResult);
         expect(fakeClient.readResourceCalls).toContain("automobile:devices/booted");
+      } finally {
+        isAvailableSpy.mockRestore();
+        await proxy.close();
+      }
+    });
+
+    test("readResource reconnects and retries once when daemon session is stale", async () => {
+      const recoveredResult = { contents: [{ uri: "automobile:devices/booted", text: "[]" }] };
+      const staleClient = new ScriptedDaemonClient({
+        resourceError: new Error("MCP error -32603: Failed to read resource from daemon: Session not found"),
+      });
+      const freshClient = new ScriptedDaemonClient({
+        resourceResult: recoveredResult,
+      });
+      const clients = [staleClient, freshClient];
+      const isAvailableSpy = spyOn(DaemonClient, "isAvailable").mockResolvedValue(true);
+
+      const proxy = new DaemonMcpProxy({
+        clientFactory: () => clients.shift()!,
+        autoStartDaemon: false
+      });
+
+      try {
+        const result = await proxy.readResource("automobile:devices/booted");
+
+        expect(result).toEqual(recoveredResult);
+        expect(staleClient.connectCallCount).toBe(1);
+        expect(staleClient.closeCallCount).toBe(1);
+        expect(staleClient.readResourceCalls).toEqual(["automobile:devices/booted"]);
+        expect(freshClient.connectCallCount).toBe(1);
+        expect(freshClient.readResourceCalls).toEqual(["automobile:devices/booted"]);
       } finally {
         isAvailableSpy.mockRestore();
         await proxy.close();


### PR DESCRIPTION
## Summary
- Recover daemon proxy requests when a stale daemon session returns `Session not found`.
- Close the stale daemon client, invalidate cached tool/resource definitions, reconnect, and retry the request once.
- Cover tool calls, resource reads, retry limit behavior, non-session errors, and cache invalidation with focused unit tests.

Fixes #2599

## Testing
- `bun test test/daemon/daemonMcpProxy.test.ts`
- `bun test test/daemon/daemonMcpProxy.test.ts test/daemon/socketServerMcpReconnect.test.ts`
- `bun run lint`
- `bun run build`
- `bash scripts/all_fast_validate_checks.sh`
- `bun test`
