### PR TITLE
Fix iOS simulator TCC sqlite reads

### DIFF
--- a/src/features/action/IosSimulatorPermissions.ts
+++ b/src/features/action/IosSimulatorPermissions.ts
@@ -62,11 +62,22 @@ interface SqliteColumnInfo {
   name: string;
 }
 
+export interface SqliteCommandExecutor {
+  execFile(command: string, args: string[]): Promise<{ stdout: string }>;
+}
+
 export interface TccPermissionReader {
   readPermissions(deviceId: string, appId: string, permissions?: string[]): Promise<TccPermissionRow[]>;
 }
 
 const execFileAsync = promisify(execFile);
+
+class NodeSqliteCommandExecutor implements SqliteCommandExecutor {
+  async execFile(command: string, args: string[]): Promise<{ stdout: string }> {
+    const { stdout } = await execFileAsync(command, args);
+    return { stdout };
+  }
+}
 
 const TCC_SERVICE_BY_PERMISSION = new Map<string, string>([
   ["calendar", "kTCCServiceCalendar"],
@@ -134,9 +145,14 @@ function stateFromAllowed(value: number | null | undefined): IosSimulatorPermiss
 }
 
 export class SqliteTccPermissionReader implements TccPermissionReader {
+  constructor(
+    private readonly sqlite: SqliteCommandExecutor = new NodeSqliteCommandExecutor(),
+    private readonly homeDirectory: string = homedir()
+  ) {}
+
   async readPermissions(deviceId: string, appId: string, permissions?: string[]): Promise<TccPermissionRow[]> {
     const tccPath = join(
-      homedir(),
+      this.homeDirectory,
       "Library",
       "Developer",
       "CoreSimulator",
@@ -158,18 +174,17 @@ export class SqliteTccPermissionReader implements TccPermissionReader {
       .filter(column => columns.has(column));
     const selectColumns = ["service", "client", ...optionalColumns].join(", ");
     const query = [
-      ".mode json",
       `select ${selectColumns}`,
       "from access",
       `where client = '${appId.replace(/'/g, "''")}'${serviceFilter};`
     ].join("\n");
 
-    const { stdout } = await execFileAsync("sqlite3", [tccPath, query]);
+    const { stdout } = await this.sqlite.execFile("sqlite3", ["-json", tccPath, query]);
     return JSON.parse(stdout.trim() || "[]") as TccPermissionRow[];
   }
 
   private async readAccessColumns(tccPath: string): Promise<Set<string>> {
-    const { stdout } = await execFileAsync("sqlite3", [tccPath, ".mode json\npragma table_info(access);"]);
+    const { stdout } = await this.sqlite.execFile("sqlite3", ["-json", tccPath, "pragma table_info(access);"]);
     const columns = JSON.parse(stdout.trim() || "[]") as SqliteColumnInfo[];
     return new Set(columns.map(column => column.name));
   }

--- a/test/features/action/GrantIosSimulatorPermissions.test.ts
+++ b/test/features/action/GrantIosSimulatorPermissions.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, test } from "bun:test";
+import { join } from "path";
 import { GrantIosSimulatorPermissions } from "../../../src/features/action/GrantIosSimulatorPermissions";
-import { IosSimulatorPermissions, type TccPermissionReader } from "../../../src/features/action/IosSimulatorPermissions";
+import {
+  IosSimulatorPermissions,
+  SqliteTccPermissionReader,
+  type SqliteCommandExecutor,
+  type TccPermissionReader
+} from "../../../src/features/action/IosSimulatorPermissions";
 import type { BootedDevice } from "../../../src/models";
 import { FakeSimCtlClient } from "../../fakes/FakeSimCtlClient";
 
@@ -9,6 +15,37 @@ const simulatorDevice: BootedDevice = {
   platform: "ios",
   deviceId: "12345678-1234-1234-1234-123456789ABC"
 };
+
+class FakeSqliteCommandExecutor implements SqliteCommandExecutor {
+  readonly calls: Array<{ command: string; args: string[] }> = [];
+
+  async execFile(command: string, args: string[]): Promise<{ stdout: string }> {
+    this.calls.push({ command, args });
+
+    const sql = args.at(-1);
+    if (sql === "pragma table_info(access);") {
+      return {
+        stdout: JSON.stringify([
+          { name: "service" },
+          { name: "client" },
+          { name: "auth_value" },
+          { name: "prompt_count" }
+        ])
+      };
+    }
+
+    return {
+      stdout: JSON.stringify([
+        {
+          service: "kTCCServiceCamera",
+          client: "com.example.app",
+          auth_value: 2,
+          prompt_count: 1
+        }
+      ])
+    };
+  }
+}
 
 describe("GrantIosSimulatorPermissions", () => {
   test("grants each permission with simctl privacy", async () => {
@@ -157,5 +194,59 @@ describe("IosSimulatorPermissions", () => {
         }
       ]
     });
+  });
+
+  test("reads TCC rows with sqlite json mode flag and SQL-only statements", async () => {
+    const sqlite = new FakeSqliteCommandExecutor();
+    const reader = new SqliteTccPermissionReader(sqlite, "/Users/tester");
+    const expectedTccPath = join(
+      "/Users/tester",
+      "Library",
+      "Developer",
+      "CoreSimulator",
+      "Devices",
+      "12345678-1234-1234-1234-123456789ABC",
+      "data",
+      "Library",
+      "TCC",
+      "TCC.db"
+    );
+
+    const rows = await reader.readPermissions(
+      "12345678-1234-1234-1234-123456789ABC",
+      "com.example.app",
+      ["camera"]
+    );
+
+    expect(rows).toEqual([
+      {
+        service: "kTCCServiceCamera",
+        client: "com.example.app",
+        auth_value: 2,
+        prompt_count: 1
+      }
+    ]);
+    expect(sqlite.calls).toEqual([
+      {
+        command: "sqlite3",
+        args: [
+          "-json",
+          expectedTccPath,
+          "pragma table_info(access);"
+        ]
+      },
+      {
+        command: "sqlite3",
+        args: [
+          "-json",
+          expectedTccPath,
+          [
+            "select service, client, auth_value, prompt_count",
+            "from access",
+            "where client = 'com.example.app' and service in ('kTCCServiceCamera');"
+          ].join("\n")
+        ]
+      }
+    ]);
   });
 });


### PR DESCRIPTION
## Summary

- Fixes #2603
- Read iOS simulator TCC rows with `sqlite3 -json <TCC.db> <sql>` for both schema introspection and permission queries.
- Add a fake-backed sqlite reader test that asserts SQL is passed as SQL-only statements without `.mode json`.

## Plan

- Reproduce the sqlite command contract failure with a focused unit test.
- Replace the `.mode json` positional SQL arguments with the `-json` sqlite flag.
- Keep the existing `getAppPermissions` facade behavior intact for parsed iOS TCC rows.

## Evaluation Criteria

- `readAccessColumns()` invokes `sqlite3` with `["-json", tccPath, "pragma table_info(access);"]`.
- Permission row reads invoke `sqlite3` with `["-json", tccPath, selectSql]`.
- No TCC read path passes `.mode json` as part of a positional SQL argument.
- Existing iOS simulator permission mapping still reports parsed TCC rows through `getAppPermissions`.

## Testing

- `bun test test/features/action/GrantIosSimulatorPermissions.test.ts`
- `bun test test/features/action/AppPermissions.test.ts`
- `bun test test/features/action/GrantIosSimulatorPermissions.test.ts test/features/action/AppPermissions.test.ts`
- `bun test --bail`
- `bun run lint`
- `bun run build`
- `bash scripts/all_fast_validate_checks.sh`
