### PR TITLE
Keep CtrlProxy skip-env checks distinct

### DIFF
--- a/src/utils/CtrlProxyManager.ts
+++ b/src/utils/CtrlProxyManager.ts
@@ -605,8 +605,7 @@ export class AndroidCtrlProxyManager implements CtrlProxyManager {
       logger.warn("[CTRL_PROXY] Skipping APK download/version check (preinstalled APK allowed)");
       return this.cacheVersionCheckResult({
         status: "skipped",
-        expectedSha256: expectedSha,
-        acceptedPreinstalled: true
+        expectedSha256: expectedSha
       });
     }
 

--- a/test/doctor/automobile.test.ts
+++ b/test/doctor/automobile.test.ts
@@ -116,4 +116,40 @@ describe("checkCtrlProxy", () => {
       (AndroidCtrlProxyManager as any).defaultFileDownloader = originalDefaultDownloader;
     }
   });
+
+  test("passes skip-env checks without reporting a stale CtrlProxy warning", async () => {
+    AndroidCtrlProxyManager.setExpectedChecksumForTesting("expected-sha");
+    const originalSkipDownload = process.env.AUTOMOBILE_SKIP_ACCESSIBILITY_DOWNLOAD_IF_INSTALLED;
+    process.env.AUTOMOBILE_SKIP_ACCESSIBILITY_DOWNLOAD_IF_INSTALLED = "true";
+
+    try {
+      fakeAdb.setDevices([{
+        deviceId: "emulator-5554",
+        platform: "android",
+        isEmulator: true,
+        name: "Pixel"
+      }]);
+      fakeAdb.setCommandResponse(`shell pm list packages | grep ${AndroidCtrlProxyManager.PACKAGE}`, {
+        stdout: `package:${AndroidCtrlProxyManager.PACKAGE}\n`,
+        stderr: ""
+      });
+      fakeAdb.setCommandResponse("settings get secure", {
+        stdout: `${AndroidCtrlProxyManager.PACKAGE}/${AndroidCtrlProxyManager.PACKAGE}.CtrlProxy`,
+        stderr: ""
+      });
+
+      const result = await checkCtrlProxy(fakeFactory);
+
+      expect(result.status).toBe("pass");
+      expect(result.message).toContain("versionStatus=skipped");
+      expect(result.message).not.toContain("acceptedPreinstalled=true");
+      expect(result.recommendation).toBeUndefined();
+    } finally {
+      if (originalSkipDownload === undefined) {
+        delete process.env.AUTOMOBILE_SKIP_ACCESSIBILITY_DOWNLOAD_IF_INSTALLED;
+      } else {
+        process.env.AUTOMOBILE_SKIP_ACCESSIBILITY_DOWNLOAD_IF_INSTALLED = originalSkipDownload;
+      }
+    }
+  });
 });

--- a/test/utils/CtrlProxyManager.test.ts
+++ b/test/utils/CtrlProxyManager.test.ts
@@ -624,6 +624,7 @@ describe("CtrlProxyManager", function() {
 
       const result = await manager.ensureCompatibleVersion();
       expect(result.status).toBe("skipped");
+      expect(result.acceptedPreinstalled).toBeUndefined();
     });
 
     test("should reinstall when installed SHA cannot be determined", async function() {


### PR DESCRIPTION
## Summary
- keep `acceptedPreinstalled` reserved for verified CtrlProxy APK SHA mismatches
- prevent `auto-mobile doctor` from warning about stale CtrlProxy when `AUTOMOBILE_SKIP_ACCESSIBILITY_DOWNLOAD_IF_INSTALLED` explicitly skips download/version checks
- add manager and doctor regressions for the skip-env path

## Testing
- `bun test test/doctor/automobile.test.ts --bail`
- `bun test test/utils/CtrlProxyManager.test.ts --bail`
- `bun test test/daemon/socketServerIdeStatus.test.ts && bun run build && bun run lint && bun test`
