### PR TITLE
Fix iOS video recording FFmpeg finalize

### DIFF
--- a/src/features/video/FfmpegVideoProcessingBackend.ts
+++ b/src/features/video/FfmpegVideoProcessingBackend.ts
@@ -41,6 +41,12 @@ type FfmpegInput =
   | { type: "pipe" }
   | { type: "file"; path: string };
 
+type FfmpegDiagnosticsTracker = Pick<ProcessTracker, "exitState" | "stderr">;
+
+function isFailedExitCode(exitCode: number | null | undefined): boolean {
+  return exitCode !== undefined && exitCode !== 0;
+}
+
 interface FfmpegBackendHandle {
   kind: "ffmpeg";
   platform: "android" | "ios";
@@ -363,16 +369,21 @@ export class FfmpegVideoProcessingBackend implements VideoCaptureBackend {
 
     await waitForExit(ffmpegProcess, ffmpegTracker.exitPromise);
 
-    if (ffmpegTracker.exitState.exitCode && ffmpegTracker.exitState.exitCode !== 0) {
+    if (isFailedExitCode(ffmpegTracker.exitState.exitCode)) {
       throw new ActionableError(
-        `FFmpeg post-processing failed with code ${ffmpegTracker.exitState.exitCode}: ${ffmpegTracker.stderr.join("")}`
+        this.buildFfmpegFailureMessage(
+          "FFmpeg post-processing failed",
+          ffmpegArgs,
+          ffmpegTracker
+        )
       );
     }
 
-    const outputExists = await pathExists(backendHandle.config.outputPath);
-    if (!outputExists) {
-      throw new ActionableError(`FFmpeg output file missing at ${backendHandle.config.outputPath}`);
-    }
+    await this.assertFfmpegOutputReady(
+      backendHandle.config.outputPath,
+      ffmpegArgs,
+      ffmpegTracker
+    );
 
     try {
       await fsPromises.rm(capturePath, { recursive: true, force: true });
@@ -392,6 +403,14 @@ export class FfmpegVideoProcessingBackend implements VideoCaptureBackend {
       args.push("-f", "mp4", "-i", "pipe:0");
     } else {
       args.push("-i", input.path);
+
+      if (!config.resolution) {
+        args.push("-c", "copy");
+        args.push("-movflags", "+faststart");
+        args.push("-y");
+        args.push(config.outputPath);
+        return args;
+      }
     }
 
     args.push("-r", String(config.fps));
@@ -618,8 +637,56 @@ export class FfmpegVideoProcessingBackend implements VideoCaptureBackend {
     }
   }
 
+  private async assertFfmpegOutputReady(
+    outputPath: string,
+    args: string[],
+    tracker: FfmpegDiagnosticsTracker
+  ): Promise<void> {
+    const outputExists = await pathExists(outputPath);
+    if (!outputExists) {
+      throw new ActionableError(
+        this.buildFfmpegFailureMessage(
+          "FFmpeg output file missing",
+          args,
+          tracker,
+          outputPath
+        )
+      );
+    }
+
+    const sizeBytes = await this.getFileSize(outputPath);
+    if (!sizeBytes || sizeBytes <= 0) {
+      throw new ActionableError(
+        this.buildFfmpegFailureMessage(
+          "FFmpeg output file is empty",
+          args,
+          tracker,
+          outputPath
+        )
+      );
+    }
+  }
+
+  private buildFfmpegFailureMessage(
+    summary: string,
+    args: string[],
+    tracker: FfmpegDiagnosticsTracker,
+    outputPath?: string
+  ): string {
+    const details = [
+      summary,
+      outputPath ? `output: ${outputPath}` : undefined,
+      `command: ${this.ffmpegPath} ${args.join(" ")}`,
+      `exitCode: ${tracker.exitState.exitCode ?? "null"}`,
+      `signal: ${tracker.exitState.signal ?? "null"}`,
+      `stderr:\n${tracker.stderr.join("").trim() || "(empty)"}`,
+    ].filter((line): line is string => Boolean(line));
+
+    return details.join("\n");
+  }
+
   private logProcessWarnings(label: string, tracker: ProcessTracker): void {
-    if (tracker.exitState.exitCode && tracker.exitState.exitCode !== 0) {
+    if (isFailedExitCode(tracker.exitState.exitCode)) {
       logger.warn(
         `[FfmpegVideo] ${label} exited with code ${tracker.exitState.exitCode}: ${tracker.stderr.join("")}`
       );

--- a/test/features/video/FfmpegVideoProcessingBackend.test.ts
+++ b/test/features/video/FfmpegVideoProcessingBackend.test.ts
@@ -1,5 +1,7 @@
 import { beforeEach, describe, expect, test } from "bun:test";
-import { platform } from "node:os";
+import { promises as fsPromises } from "node:fs";
+import os, { platform } from "node:os";
+import path from "node:path";
 import { FfmpegVideoProcessingBackend } from "../../../src/features/video/FfmpegVideoProcessingBackend";
 import type { VideoCaptureConfig } from "../../../src/features/video/VideoRecorderService";
 import type { BootedDevice } from "../../../src/models";
@@ -175,6 +177,123 @@ describe("FfmpegVideoProcessingBackend - Unit Tests", function() {
 
       expect(args).toContain("-t");
       expect(args).toContain("60");
+    });
+
+    test("should remux iOS simulator file input without re-encoding when no scaling is requested", async function() {
+      const hwAccel = {
+        encoder: "h264_videotoolbox",
+        available: true,
+        description: "VideoToolbox HW accel",
+      };
+
+      const args = await (backend as any).buildFfmpegArgs(
+        mockConfig,
+        hwAccel,
+        { type: "file", path: "/tmp/test/test-recording-raw.mov" }
+      );
+
+      expect(args).toEqual([
+        "-i",
+        "/tmp/test/test-recording-raw.mov",
+        "-c",
+        "copy",
+        "-movflags",
+        "+faststart",
+        "-y",
+        mockConfig.outputPath,
+      ]);
+    });
+
+    test("should transcode file input when scaling is requested", async function() {
+      const hwAccel = {
+        encoder: "h264_videotoolbox",
+        available: true,
+        description: "VideoToolbox HW accel",
+      };
+
+      const args = await (backend as any).buildFfmpegArgs(
+        {
+          ...mockConfig,
+          resolution: { width: 720, height: 1280 },
+        },
+        hwAccel,
+        { type: "file", path: "/tmp/test/test-recording-raw.mov" }
+      );
+
+      expect(args).toContain("-vf");
+      expect(args).toContain("scale=720:1280");
+      expect(args).toContain("-c:v");
+      expect(args).toContain("h264_videotoolbox");
+    });
+  });
+
+  describe("FFmpeg Diagnostics", function() {
+    test("should include command, stderr, and missing output path for opaque post-processing failures", function() {
+      const message = (backend as any).buildFfmpegFailureMessage(
+        "FFmpeg output file missing",
+        ["-i", "/tmp/raw.mov", "-c", "copy", "-y", "/tmp/out.mp4"],
+        {
+          exitState: { exitCode: null, signal: "SIGINT" },
+          stderr: ["moov atom not found\n"],
+        },
+        "/tmp/out.mp4"
+      );
+
+      expect(message).toContain("FFmpeg output file missing");
+      expect(message).toContain("output: /tmp/out.mp4");
+      expect(message).toContain("command: ffmpeg -i /tmp/raw.mov -c copy -y /tmp/out.mp4");
+      expect(message).toContain("exitCode: null");
+      expect(message).toContain("signal: SIGINT");
+      expect(message).toContain("stderr:\nmoov atom not found");
+    });
+
+    test("should include command and stderr for non-zero exits", function() {
+      const message = (backend as any).buildFfmpegFailureMessage(
+        "FFmpeg post-processing failed",
+        ["-i", "/tmp/raw.mov", "-y", "/tmp/out.mp4"],
+        {
+          exitState: { exitCode: 1, signal: null },
+          stderr: ["Invalid argument\n"],
+        }
+      );
+
+      expect(message).toContain("FFmpeg post-processing failed");
+      expect(message).toContain("command: ffmpeg -i /tmp/raw.mov -y /tmp/out.mp4");
+      expect(message).toContain("exitCode: 1");
+      expect(message).toContain("stderr:\nInvalid argument");
+    });
+
+    test("should reject missing post-processed output with FFmpeg context", async function() {
+      const outputPath = path.join(os.tmpdir(), "auto-mobile-missing-output.mp4");
+
+      await expect((backend as any).assertFfmpegOutputReady(
+        outputPath,
+        ["-i", "/tmp/raw.mov", "-c", "copy", "-y", outputPath],
+        {
+          exitState: { exitCode: 0, signal: null },
+          stderr: ["No output produced\n"],
+        }
+      )).rejects.toThrow(/FFmpeg output file missing/);
+    });
+
+    test("should reject empty post-processed output with FFmpeg context", async function() {
+      const tempDir = await fsPromises.mkdtemp(path.join(os.tmpdir(), "auto-mobile-video-"));
+      const outputPath = path.join(tempDir, "empty.mp4");
+
+      try {
+        await fsPromises.writeFile(outputPath, "");
+
+        await expect((backend as any).assertFfmpegOutputReady(
+          outputPath,
+          ["-i", "/tmp/raw.mov", "-c", "copy", "-y", outputPath],
+          {
+            exitState: { exitCode: 0, signal: null },
+            stderr: [],
+          }
+        )).rejects.toThrow(/FFmpeg output file is empty/);
+      } finally {
+        await fsPromises.rm(tempDir, { recursive: true, force: true });
+      }
     });
   });
 


### PR DESCRIPTION
## Summary
- Fixes #2606 by remuxing iOS simulator `.mov` captures to `.mp4` with FFmpeg stream copy when no scaling is requested, avoiding unnecessary H.264 re-encode constraints.
- Surfaces actionable FFmpeg post-processing diagnostics, including command, exit code, signal, stderr, and output path for non-zero, null-exit, missing-output, and empty-output failures.
- Adds focused TDD coverage for iOS file-input FFmpeg args and diagnostic failure paths.

## Plan and evaluation criteria
- iOS simulator `videoRecording` stop should produce a non-empty `.mp4` when FFmpeg succeeds.
- FFmpeg failures should include enough subprocess context to identify the underlying cause.
- Existing scaled-output behavior should still transcode with the configured encoder.

## Testing
- `bun test test/features/video/FfmpegVideoProcessingBackend.test.ts`
- `bun run lint`
- `bun run build`
- `bash scripts/all_fast_validate_checks.sh`
- `bun test`

## Notes
- This repo does not currently include a pull request template file under `.github/`; this body follows the repo's summary/testing convention.
- Initial dependency install with lifecycle scripts failed because `heapdump` does not compile under the local Node 26 headers; `bun install --ignore-scripts` completed and validation passed afterward.
