### PR TITLE
Fix iOS highlight runner overlay default

### DIFF
--- a/docs/design-docs/mcp/observe/video-recording.md
+++ b/docs/design-docs/mcp/observe/video-recording.md
@@ -54,7 +54,7 @@ Example config payload:
     - `platform`: `android` or `ios`.
     - `deviceId`/`sessionUuid`/`device`: optional device targeting. If omitted, the action applies to all devices on the platform.
     - `recordingId`: optional (stop only).
-    - `highlights`: optional list of highlight entries to show during recording on Android and iOS apps with the AutoMobileSDK in-app bridge. Each entry includes optional `description`, `shape`, and optional `timing` (`startTimeMs`). iOS runner-process fallback overlays are disabled by default unless `AUTOMOBILE_IOS_LIVE_HIGHLIGHTS=true`.
+    - `highlights`: optional list of highlight entries to show during recording on Android and iOS. Each entry includes optional `description`, `shape`, and optional `timing` (`startTimeMs`). iOS prefers the AutoMobileSDK in-app bridge and falls back to runner-process overlays by default; set `AUTOMOBILE_IOS_LIVE_HIGHLIGHTS=false` to opt out.
     - Optional overrides for `targetBitrateKbps`, `fps`, `resolution`, `qualityPreset`, `format`,
       `maxDuration` (seconds, default 30, max 300), and `outputName`.
   - Returns: per-device recording metadata and any evictions.

--- a/docs/design-docs/mcp/observe/visual-highlighting.md
+++ b/docs/design-docs/mcp/observe/visual-highlighting.md
@@ -1,6 +1,6 @@
 # Visual Highlighting
 
-<kbd>✅ Implemented</kbd> <kbd>🧪 Tested</kbd> <kbd>🤖 Android</kbd> <kbd>🍎 iOS SDK</kbd>
+<kbd>✅ Implemented</kbd> <kbd>🧪 Tested</kbd> <kbd>🤖 Android</kbd> <kbd>🍎 iOS</kbd>
 
 Expose visual highlight overlays (box, circle, or path) as an MCP tool for debugging UI layout and state.
 
@@ -17,7 +17,7 @@ Expose visual highlight overlays (box, circle, or path) as an MCP tool for debug
     - Optional `timeoutMs` override
   - Returns: success flag and optional error message.
   - iOS app-under-test rendering: prefers the AutoMobileSDK in-app bridge and renders the overlay in the app process.
-  - iOS runner fallback: disabled by default because runner-process windows are not guaranteed to composite over the app under test or simulator video capture. Set `AUTOMOBILE_IOS_LIVE_HIGHLIGHTS=true` only for manual runner-overlay validation.
+  - iOS runner fallback: enabled by default for apps without the AutoMobileSDK in-app bridge. Set `AUTOMOBILE_IOS_LIVE_HIGHLIGHTS=false` to opt out when runner-process windows do not composite over the app under test or simulator video capture.
   - Screenshot-derived bounds with `sourceWidth`/`sourceHeight` are scaled to the target overlay size before drawing.
   - Highlights auto-remove after their animation completes.
 

--- a/docs/design-docs/mcp/tools.md
+++ b/docs/design-docs/mcp/tools.md
@@ -90,7 +90,7 @@ After writing, use `automobile:devices/{deviceId}/apps/{appId}/files/{container}
 - 🐛 `bugReport` generates a comprehensive bug report including screen state, view hierarchy, logcat, screenshot, and optional highlight metadata.
 - 🔍 `debugSearch` debugs element search operations to understand why elements aren't found or wrong elements are selected.
 - 📸 `rawViewHierarchy` gets raw view hierarchy data (XML/JSON) without parsing for debugging.
-- 🖍️ `highlight` draws visual overlays to highlight areas of the screen during debugging. <kbd>🤖 Android</kbd> <kbd>🍎 iOS SDK</kbd>
+- 🖍️ `highlight` draws visual overlays to highlight areas of the screen during debugging. <kbd>🤖 Android</kbd> <kbd>🍎 iOS</kbd>
 - 🔗 `identifyInteractions` suggests likely interactions with ready-to-use tool calls (debug-only; enable the debug feature flag).
 
 #### Network & Connectivity

--- a/docs/design-docs/status-glossary.md
+++ b/docs/design-docs/status-glossary.md
@@ -65,7 +65,7 @@ The following items are documented as designs or proposals but have **no corresp
 - **Android live screen streaming (IDE mirroring)** — The Android `video-server` JAR (H.264, VirtualDisplay) is built; the full end-to-end IDE mirroring pipeline is in progress. The `videoRecording` MCP tool (record-to-file) is fully implemented. See [Android screen streaming](plat/android/screen-streaming.md).
 - **iOS XcodeCompanion** — Scaffolded macOS app with all views and navigation defined; feature completeness is ongoing. See [iOS IDE plugin](plat/ios/ide-plugin/overview.md).
 - **iOS XcodeExtension** — Scaffold with 5 registered commands; implementations are minimal stubs.
-- **`highlight` tool** — Fully implemented on Android and on iOS apps that include the AutoMobileSDK in-app bridge. iOS runner-process fallback overlays are gated behind `AUTOMOBILE_IOS_LIVE_HIGHLIGHTS=true` because they are not guaranteed to composite over the app under test.
+- **`highlight` tool** — Fully implemented on Android and iOS. iOS prefers the AutoMobileSDK in-app bridge and falls back to runner-process overlays by default for apps without the SDK. Set `AUTOMOBILE_IOS_LIVE_HIGHLIGHTS=false` to opt out when runner windows do not composite over the app under test.
 - **`rawViewHierarchy` (control-proxy source)** — Android only. iOS returns XCUITest JSON.
 - **Work profile `userId` override** — Auto-detection works; manual `userId` parameter is not supported in MCP tool schemas.
 - **AutoMobile SDK event pipeline** — Event tracking, crash handling, session management, and breadcrumbs are fully implemented on both Android and iOS. The SDK Event Pipeline MCP integration is complete. See [sdk-event-pipeline.md](mcp/sdk-event-pipeline.md).

--- a/ios/control-proxy/Sources/CtrlProxy/CommandHandler.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/CommandHandler.swift
@@ -987,7 +987,7 @@ public class CommandHandler: CommandHandling {
             return WebSocketResponse.error(
                 type: ResponseType.highlightResponse.rawValue,
                 requestId: request.requestId,
-                error: "Unable to render highlight on iOS: target app SDK highlight bridge unavailable and runner overlay fallback disabled.",
+                error: "Unable to render highlight on iOS: target app SDK highlight bridge unavailable and runner overlay fallback failed.",
                 totalTimeMs: totalTimeMs(from: startTime)
             )
         }

--- a/ios/control-proxy/Sources/CtrlProxy/HighlightOverlayManager.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/HighlightOverlayManager.swift
@@ -39,6 +39,8 @@ public struct HighlightOverlayRenderCommand {
     public let strokeColor: String
     public let strokeWidth: Float
     public let dashPattern: [Float]?
+    public let smoothing: String?
+    public let tension: Float?
     public let capStyle: String
     public let joinStyle: String
 }
@@ -96,6 +98,8 @@ public enum HighlightOverlayCommandScaler {
             strokeColor: command.strokeColor,
             strokeWidth: command.strokeWidth,
             dashPattern: command.dashPattern,
+            smoothing: command.smoothing,
+            tension: command.tension,
             capStyle: command.capStyle,
             joinStyle: command.joinStyle
         )
@@ -136,6 +140,9 @@ public struct HighlightOverlayColorComponents: Equatable {
 }
 
 public enum HighlightOverlayCommandBuilder {
+    private static let defaultStrokeWidth: Float = 8
+    private static let defaultPathTension: Float = 0.5
+
     public static func command(for shape: HighlightShape) throws -> HighlightOverlayRenderCommand {
         switch shape.type {
         case "box", "circle":
@@ -147,8 +154,10 @@ public enum HighlightOverlayCommandBuilder {
                 bounds: bounds,
                 points: [],
                 strokeColor: shape.style?.strokeColor ?? "#FF0000",
-                strokeWidth: shape.style?.strokeWidth ?? 3,
+                strokeWidth: shape.style?.strokeWidth ?? defaultStrokeWidth,
                 dashPattern: shape.style?.dashPattern,
+                smoothing: shape.style?.smoothing,
+                tension: shape.style?.tension ?? defaultPathTension,
                 capStyle: shape.style?.capStyle ?? "round",
                 joinStyle: shape.style?.joinStyle ?? "round"
             )
@@ -161,14 +170,318 @@ public enum HighlightOverlayCommandBuilder {
                 bounds: shape.bounds,
                 points: points,
                 strokeColor: shape.style?.strokeColor ?? "#FF0000",
-                strokeWidth: shape.style?.strokeWidth ?? 3,
+                strokeWidth: shape.style?.strokeWidth ?? defaultStrokeWidth,
                 dashPattern: shape.style?.dashPattern,
+                smoothing: shape.style?.smoothing,
+                tension: shape.style?.tension ?? defaultPathTension,
                 capStyle: shape.style?.capStyle ?? "round",
                 joinStyle: shape.style?.joinStyle ?? "round"
             )
         default:
             throw HighlightOverlayError.unsupportedShape(shape.type)
         }
+    }
+}
+
+public struct HighlightOverlayStrokeSegment: Equatable {
+    public let startX: Float
+    public let startY: Float
+    public let endX: Float
+    public let endY: Float
+    public let strokeWidth: Float
+}
+
+public enum HighlightOverlayHandDrawnSegments {
+    private static let ellipseSegmentCount = 160
+    private static let ellipseJitterRatio: Float = 0.035
+    private static let ellipseJitterFrequencyX = 2.3
+    private static let ellipseJitterFrequencyY = 3.7
+    private static let ellipseStartAngle: Float = -90
+    private static let ellipseStartAngleJitter: Float = 8
+    private static let ellipseMinWidthFactor: Float = 0.75
+    private static let ellipseMaxWidthFactor: Float = 2.0
+    private static let pathMinSampleDistance: Float = 3
+    private static let pathTaperFraction: Float = 0.12
+    private static let pathMinWidthFactor: Float = 0.35
+    private static let pathCurveTaperIntensity: Float = 0.35
+    private static let minimumPointDistanceSquared: Float = 0.25
+
+    public static func ellipseSegments(
+        bounds: HighlightBounds,
+        baseStrokeWidth: Float,
+        phaseX: Double? = nil,
+        phaseY: Double? = nil,
+        startAngleJitter: Float? = nil
+    ) -> [HighlightOverlayStrokeSegment] {
+        guard bounds.width > 0, bounds.height > 0, baseStrokeWidth > 0 else { return [] }
+        let centerX = Float(bounds.x) + Float(bounds.width) / 2
+        let centerY = Float(bounds.y) + Float(bounds.height) / 2
+        let radiusX = Float(bounds.width) / 2
+        let radiusY = Float(bounds.height) / 2
+        let sweep = 360 / Float(ellipseSegmentCount)
+        let resolvedPhaseX = phaseX ?? Double.random(in: 0..<(Double.pi * 2))
+        let resolvedPhaseY = phaseY ?? Double.random(in: 0..<(Double.pi * 2))
+        let resolvedStartAngleJitter = startAngleJitter
+            ?? Float.random(in: (-ellipseStartAngleJitter / 2)...(ellipseStartAngleJitter / 2))
+        let startOffset = ellipseStartAngle + resolvedStartAngleJitter
+
+        return (0..<ellipseSegmentCount).map { index in
+            let startAngle = startOffset + Float(index) * sweep
+            let endAngle = startAngle + sweep
+            let midAngle = startAngle + sweep / 2
+            let midRadians = Double(midAngle) * Double.pi / 180
+            let jitterX = 1 + ellipseJitterRatio * Float(sin(midRadians * ellipseJitterFrequencyX + resolvedPhaseX))
+            let jitterY = 1 + ellipseJitterRatio * Float(sin(midRadians * ellipseJitterFrequencyY + resolvedPhaseY))
+            let start = pointOnEllipse(
+                centerX: centerX,
+                centerY: centerY,
+                radiusX: radiusX * jitterX,
+                radiusY: radiusY * jitterY,
+                degrees: startAngle
+            )
+            let end = pointOnEllipse(
+                centerX: centerX,
+                centerY: centerY,
+                radiusX: radiusX * jitterX,
+                radiusY: radiusY * jitterY,
+                degrees: endAngle
+            )
+            let widthFactor = ellipseWidthFactor(angleRadians: midRadians)
+            return HighlightOverlayStrokeSegment(
+                startX: start.x,
+                startY: start.y,
+                endX: end.x,
+                endY: end.y,
+                strokeWidth: baseStrokeWidth * widthFactor
+            )
+        }
+    }
+
+    public static func pathSegments(
+        points: [HighlightPoint],
+        smoothing: String?,
+        tension: Float?,
+        baseStrokeWidth: Float
+    ) -> [HighlightOverlayStrokeSegment] {
+        guard points.count >= 2, baseStrokeWidth > 0 else { return [] }
+        let filtered = filterClosePoints(points)
+        guard filtered.count >= 2 else { return [] }
+        let smoothed = smoothedPoints(
+            filtered,
+            smoothing: smoothing ?? "catmull-rom",
+            tension: (tension ?? 0.5).clamped(to: 0...1)
+        )
+        guard smoothed.count >= 2 else { return [] }
+
+        let lengths = segmentLengths(smoothed)
+        let totalLength = lengths.reduce(0, +)
+        guard totalLength > 0 else { return [] }
+
+        var distance: Float = 0
+        var segments: [HighlightOverlayStrokeSegment] = []
+        for index in 0..<(smoothed.count - 1) {
+            let start = smoothed[index]
+            let end = smoothed[index + 1]
+            let length = lengths[index]
+            guard length > 0 else { continue }
+            let previous = index > 0 ? vector(from: smoothed[index - 1], to: start) : vector(from: start, to: end)
+            let current = vector(from: start, to: end)
+            let progress = ((distance + length / 2) / totalLength).clamped(to: 0...1)
+            let widthFactor = pathWidthFactor(progress: progress, previous: previous, current: current)
+            segments.append(
+                HighlightOverlayStrokeSegment(
+                    startX: start.x,
+                    startY: start.y,
+                    endX: end.x,
+                    endY: end.y,
+                    strokeWidth: baseStrokeWidth * widthFactor
+                )
+            )
+            distance += length
+        }
+        return segments
+    }
+
+    private static func pointOnEllipse(
+        centerX: Float,
+        centerY: Float,
+        radiusX: Float,
+        radiusY: Float,
+        degrees: Float
+    ) -> (x: Float, y: Float) {
+        let radians = Double(degrees) * Double.pi / 180
+        return (
+            x: centerX + radiusX * Float(cos(radians)),
+            y: centerY + radiusY * Float(sin(radians))
+        )
+    }
+
+    private static func ellipseWidthFactor(angleRadians: Double) -> Float {
+        let variation = abs(Float(sin(angleRadians)))
+        return ellipseMinWidthFactor + (ellipseMaxWidthFactor - ellipseMinWidthFactor) * variation
+    }
+
+    private static func smoothedPoints(
+        _ points: [HighlightPoint],
+        smoothing: String,
+        tension: Float
+    ) -> [HighlightPoint] {
+        switch smoothing {
+        case "none", "douglas-peucker":
+            return points
+        case "bezier":
+            return sampleBezier(points, tension: tension)
+        default:
+            return sampleCatmullRom(points, tension: tension)
+        }
+    }
+
+    private static func sampleCatmullRom(_ points: [HighlightPoint], tension: Float) -> [HighlightPoint] {
+        var sampled = [points[0]]
+        for index in 0..<(points.count - 1) {
+            let p0 = index > 0 ? points[index - 1] : points[index]
+            let p1 = points[index]
+            let p2 = points[index + 1]
+            let p3 = index + 2 < points.count ? points[index + 2] : p2
+            let cp1 = HighlightPoint(
+                x: p1.x + (p2.x - p0.x) * tension / 6,
+                y: p1.y + (p2.y - p0.y) * tension / 6
+            )
+            let cp2 = HighlightPoint(
+                x: p2.x - (p3.x - p1.x) * tension / 6,
+                y: p2.y - (p3.y - p1.y) * tension / 6
+            )
+            appendCubicSamples(to: &sampled, p0: p1, cp1: cp1, cp2: cp2, p1: p2)
+        }
+        return sampled
+    }
+
+    private static func sampleBezier(_ points: [HighlightPoint], tension: Float) -> [HighlightPoint] {
+        guard points.count > 2 else { return points }
+        var sampled = [points[0]]
+        for index in 1..<(points.count - 1) {
+            let current = points[index]
+            let next = points[index + 1]
+            let mid = HighlightPoint(x: (current.x + next.x) / 2, y: (current.y + next.y) / 2)
+            let end = HighlightPoint(
+                x: current.x + (mid.x - current.x) * tension,
+                y: current.y + (mid.y - current.y) * tension
+            )
+            appendQuadraticSamples(to: &sampled, p0: sampled.last ?? current, cp: current, p1: end)
+        }
+        sampled.append(points[points.count - 1])
+        return sampled
+    }
+
+    private static func appendCubicSamples(
+        to sampled: inout [HighlightPoint],
+        p0: HighlightPoint,
+        cp1: HighlightPoint,
+        cp2: HighlightPoint,
+        p1: HighlightPoint
+    ) {
+        let samples = max(2, Int(distance(from: p0, to: p1) / pathMinSampleDistance))
+        for step in 1...samples {
+            let t = Float(step) / Float(samples)
+            let inv = 1 - t
+            sampled.append(
+                HighlightPoint(
+                    x: inv * inv * inv * p0.x + 3 * inv * inv * t * cp1.x + 3 * inv * t * t * cp2.x + t * t * t * p1.x,
+                    y: inv * inv * inv * p0.y + 3 * inv * inv * t * cp1.y + 3 * inv * t * t * cp2.y + t * t * t * p1.y
+                )
+            )
+        }
+    }
+
+    private static func appendQuadraticSamples(
+        to sampled: inout [HighlightPoint],
+        p0: HighlightPoint,
+        cp: HighlightPoint,
+        p1: HighlightPoint
+    ) {
+        let samples = max(2, Int(distance(from: p0, to: p1) / pathMinSampleDistance))
+        for step in 1...samples {
+            let t = Float(step) / Float(samples)
+            let inv = 1 - t
+            sampled.append(
+                HighlightPoint(
+                    x: inv * inv * p0.x + 2 * inv * t * cp.x + t * t * p1.x,
+                    y: inv * inv * p0.y + 2 * inv * t * cp.y + t * t * p1.y
+                )
+            )
+        }
+    }
+
+    private static func filterClosePoints(_ points: [HighlightPoint]) -> [HighlightPoint] {
+        guard points.count > 2 else { return points }
+        var filtered = [points[0]]
+        var lastKept = points[0]
+        for point in points.dropFirst().dropLast() {
+            if distanceSquared(from: lastKept, to: point) >= minimumPointDistanceSquared {
+                filtered.append(point)
+                lastKept = point
+            }
+        }
+        let last = points[points.count - 1]
+        if distanceSquared(from: lastKept, to: last) >= minimumPointDistanceSquared || filtered.count == 1 {
+            filtered.append(last)
+        } else {
+            filtered[filtered.count - 1] = last
+        }
+        return filtered
+    }
+
+    private static func segmentLengths(_ points: [HighlightPoint]) -> [Float] {
+        (0..<(points.count - 1)).map { distance(from: points[$0], to: points[$0 + 1]) }
+    }
+
+    private static func pathWidthFactor(
+        progress: Float,
+        previous: (x: Float, y: Float),
+        current: (x: Float, y: Float)
+    ) -> Float {
+        max(pathMinWidthFactor, taperFactor(progress: progress) * curveFactor(previous: previous, current: current))
+    }
+
+    private static func taperFactor(progress: Float) -> Float {
+        guard pathTaperFraction > 0 else { return 1 }
+        let start = min(1, progress / pathTaperFraction)
+        let end = min(1, (1 - progress) / pathTaperFraction)
+        let taper = min(start, end)
+        return taper * taper * (3 - 2 * taper)
+    }
+
+    private static func curveFactor(previous: (x: Float, y: Float), current: (x: Float, y: Float)) -> Float {
+        let previousMagnitude = sqrt(previous.x * previous.x + previous.y * previous.y)
+        let currentMagnitude = sqrt(current.x * current.x + current.y * current.y)
+        guard previousMagnitude > 0, currentMagnitude > 0 else { return 1 }
+        let previousX = previous.x / previousMagnitude
+        let previousY = previous.y / previousMagnitude
+        let currentX = current.x / currentMagnitude
+        let currentY = current.y / currentMagnitude
+        let dot = (previousX * currentX + previousY * currentY).clamped(to: -1...1)
+        let curvature = (1 - dot) / 2
+        return 1 - min(1, curvature) * pathCurveTaperIntensity
+    }
+
+    private static func vector(from start: HighlightPoint, to end: HighlightPoint) -> (x: Float, y: Float) {
+        (x: end.x - start.x, y: end.y - start.y)
+    }
+
+    private static func distance(from start: HighlightPoint, to end: HighlightPoint) -> Float {
+        sqrt(distanceSquared(from: start, to: end))
+    }
+
+    private static func distanceSquared(from start: HighlightPoint, to end: HighlightPoint) -> Float {
+        let dx = end.x - start.x
+        let dy = end.y - start.y
+        return dx * dx + dy * dy
+    }
+}
+
+private extension Float {
+    func clamped(to range: ClosedRange<Float>) -> Float {
+        min(max(self, range.lowerBound), range.upperBound)
     }
 }
 
@@ -219,7 +532,7 @@ public final class DefaultHighlightOverlayRenderer: HighlightOverlayRendering {
 
     #if canImport(UIKit) && canImport(QuartzCore)
         private var window: UIWindow?
-        private var layers: [String: CAShapeLayer] = [:]
+        private var layers: [String: [CAShapeLayer]] = [:]
         private let liveOverlayEnabled: () -> Bool
 
         public init(liveOverlayEnabled: @escaping () -> Bool = DefaultHighlightOverlayRenderer.defaultLiveOverlayEnabled) {
@@ -239,18 +552,16 @@ public final class DefaultHighlightOverlayRenderer: HighlightOverlayRendering {
                 guard let scaledCommand = HighlightOverlayCommandScaler.scaled(command, targetSize: targetSize) else {
                     return
                 }
-                let layer = self.layers[id] ?? CAShapeLayer()
-                layer.fillColor = UIColor.clear.cgColor
-                layer.strokeColor = UIColor(autoMobileHex: scaledCommand.strokeColor).cgColor
-                layer.lineWidth = CGFloat(scaledCommand.strokeWidth)
-                layer.lineDashPattern = scaledCommand.dashPattern?.map { NSNumber(value: $0) }
-                layer.lineCap = scaledCommand.capStyle.caLineCap
-                layer.lineJoin = scaledCommand.joinStyle.caLineJoin
-                layer.path = Self.path(for: scaledCommand)
-                if layer.superlayer == nil {
-                    window.layer.addSublayer(layer)
+                self.layers.removeValue(forKey: id)?.forEach { $0.removeFromSuperlayer() }
+                let segmentLayers = Self.segmentLayers(for: scaledCommand)
+                guard !segmentLayers.isEmpty else {
+                    return
                 }
-                self.layers[id] = layer
+                segmentLayers.enumerated().forEach { index, layer in
+                    window.layer.addSublayer(layer)
+                    Self.animate(layer: layer, index: index, total: segmentLayers.count)
+                }
+                self.layers[id] = segmentLayers
                 rendered = true
             }
 
@@ -264,7 +575,7 @@ public final class DefaultHighlightOverlayRenderer: HighlightOverlayRendering {
 
         public func remove(id: String) {
             let removeLayer = {
-                self.layers.removeValue(forKey: id)?.removeFromSuperlayer()
+                self.layers.removeValue(forKey: id)?.forEach { $0.removeFromSuperlayer() }
                 if self.layers.isEmpty {
                     self.window?.isHidden = true
                     self.window = nil
@@ -296,40 +607,69 @@ public final class DefaultHighlightOverlayRenderer: HighlightOverlayRendering {
             return newWindow
         }
 
-        private static func path(for command: HighlightOverlayRenderCommand) -> CGPath? {
+        private static func segmentLayers(for command: HighlightOverlayRenderCommand) -> [CAShapeLayer] {
+            let segments: [HighlightOverlayStrokeSegment]
             switch command.shapeType {
-            case "box":
-                guard let bounds = command.bounds else { return nil }
-                return UIBezierPath(
-                    roundedRect: CGRect(
-                        x: CGFloat(bounds.x),
-                        y: CGFloat(bounds.y),
-                        width: CGFloat(bounds.width),
-                        height: CGFloat(bounds.height)
-                    ),
-                    cornerRadius: 4
-                ).cgPath
-            case "circle":
-                guard let bounds = command.bounds else { return nil }
-                return UIBezierPath(
-                    ovalIn: CGRect(
-                        x: CGFloat(bounds.x),
-                        y: CGFloat(bounds.y),
-                        width: CGFloat(bounds.width),
-                        height: CGFloat(bounds.height)
-                    )
-                ).cgPath
+            case "box", "circle":
+                guard let bounds = command.bounds else { return [] }
+                segments = HighlightOverlayHandDrawnSegments.ellipseSegments(
+                    bounds: bounds,
+                    baseStrokeWidth: command.strokeWidth
+                )
             case "path":
-                let path = UIBezierPath()
-                guard let first = command.points.first else { return nil }
-                path.move(to: CGPoint(x: CGFloat(first.x), y: CGFloat(first.y)))
-                for point in command.points.dropFirst() {
-                    path.addLine(to: CGPoint(x: CGFloat(point.x), y: CGFloat(point.y)))
-                }
-                return path.cgPath
+                segments = HighlightOverlayHandDrawnSegments.pathSegments(
+                    points: command.points,
+                    smoothing: command.smoothing,
+                    tension: command.tension,
+                    baseStrokeWidth: command.strokeWidth
+                )
             default:
-                return nil
+                return []
             }
+            return segments.map { segment in
+                let path = UIBezierPath()
+                path.move(to: CGPoint(x: CGFloat(segment.startX), y: CGFloat(segment.startY)))
+                path.addLine(to: CGPoint(x: CGFloat(segment.endX), y: CGFloat(segment.endY)))
+
+                let layer = CAShapeLayer()
+                layer.fillColor = UIColor.clear.cgColor
+                layer.strokeColor = UIColor(autoMobileHex: command.strokeColor).cgColor
+                layer.lineWidth = CGFloat(segment.strokeWidth)
+                layer.lineDashPattern = command.dashPattern?.map { NSNumber(value: $0) }
+                layer.lineCap = command.capStyle.caLineCap
+                layer.lineJoin = command.joinStyle.caLineJoin
+                layer.path = path.cgPath
+                layer.strokeEnd = 1
+                layer.opacity = 1
+                return layer
+            }
+        }
+
+        private static func animate(layer: CAShapeLayer, index: Int, total: Int) {
+            let drawDuration = 0.5
+            let displayDuration = 0.5
+            let fadeDuration = 0.2
+            let segmentDelay = total > 1 ? drawDuration * 0.95 * Double(index) / Double(total - 1) : 0
+
+            let drawAnimation = CABasicAnimation(keyPath: "strokeEnd")
+            drawAnimation.fromValue = 0
+            drawAnimation.toValue = 1
+            drawAnimation.duration = max(0.02, drawDuration - segmentDelay)
+            drawAnimation.beginTime = CACurrentMediaTime() + segmentDelay
+            drawAnimation.timingFunction = CAMediaTimingFunction(name: .easeInEaseOut)
+            drawAnimation.fillMode = .backwards
+            drawAnimation.isRemovedOnCompletion = true
+            layer.add(drawAnimation, forKey: "autoMobileDraw")
+
+            let fadeAnimation = CABasicAnimation(keyPath: "opacity")
+            fadeAnimation.fromValue = 1
+            fadeAnimation.toValue = 0
+            fadeAnimation.duration = fadeDuration
+            fadeAnimation.beginTime = CACurrentMediaTime() + drawDuration + displayDuration + segmentDelay * 0.2
+            fadeAnimation.timingFunction = CAMediaTimingFunction(name: .easeInEaseOut)
+            fadeAnimation.fillMode = .forwards
+            fadeAnimation.isRemovedOnCompletion = false
+            layer.add(fadeAnimation, forKey: "autoMobileFade")
         }
     #else
         public init() {}

--- a/ios/control-proxy/Sources/CtrlProxy/HighlightOverlayManager.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/HighlightOverlayManager.swift
@@ -200,6 +200,23 @@ public final class HighlightOverlayManager: HighlightOverlayManaging {
 }
 
 public final class DefaultHighlightOverlayRenderer: HighlightOverlayRendering {
+    public static func defaultLiveOverlayEnabled() -> Bool {
+        liveOverlayEnabled(environment: ProcessInfo.processInfo.environment)
+    }
+
+    public static func liveOverlayEnabled(environment: [String: String]) -> Bool {
+        let flag = environment["AUTOMOBILE_IOS_LIVE_HIGHLIGHTS"]?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased()
+        if flag == "0" || flag == "false" || flag == "no" {
+            return false
+        }
+        if flag == "1" || flag == "true" || flag == "yes" {
+            return true
+        }
+        return true
+    }
+
     #if canImport(UIKit) && canImport(QuartzCore)
         private var window: UIWindow?
         private var layers: [String: CAShapeLayer] = [:]
@@ -243,14 +260,6 @@ public final class DefaultHighlightOverlayRenderer: HighlightOverlayRendering {
                 DispatchQueue.main.sync(execute: draw)
             }
             return rendered
-        }
-
-        public static func defaultLiveOverlayEnabled() -> Bool {
-            let flag = ProcessInfo.processInfo.environment["AUTOMOBILE_IOS_LIVE_HIGHLIGHTS"]?.lowercased()
-            if flag == "1" || flag == "true" || flag == "yes" {
-                return true
-            }
-            return false
         }
 
         public func remove(id: String) {

--- a/ios/control-proxy/Sources/CtrlProxy/HighlightOverlayManager.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/HighlightOverlayManager.swift
@@ -200,6 +200,8 @@ public enum HighlightOverlayHandDrawnSegments {
     private static let ellipseStartAngleJitter: Float = 8
     private static let ellipseMinWidthFactor: Float = 0.75
     private static let ellipseMaxWidthFactor: Float = 2.0
+    private static let boxSegmentCount = 160
+    private static let boxJitterRatio: Float = 0.025
     private static let pathMinSampleDistance: Float = 3
     private static let pathTaperFraction: Float = 0.12
     private static let pathMinWidthFactor: Float = 0.35
@@ -257,6 +259,55 @@ public enum HighlightOverlayHandDrawnSegments {
         }
     }
 
+    public static func boxSegments(
+        bounds: HighlightBounds,
+        baseStrokeWidth: Float,
+        phase: Double? = nil
+    ) -> [HighlightOverlayStrokeSegment] {
+        guard bounds.width > 0, bounds.height > 0, baseStrokeWidth > 0 else { return [] }
+        let left = Float(bounds.x)
+        let top = Float(bounds.y)
+        let right = left + Float(bounds.width)
+        let bottom = top + Float(bounds.height)
+        let perimeter = 2 * (Float(bounds.width) + Float(bounds.height))
+        guard perimeter > 0 else { return [] }
+
+        let step = perimeter / Float(boxSegmentCount)
+        let jitterAmplitude = min(Float(bounds.width), Float(bounds.height)) * boxJitterRatio
+        let resolvedPhase = phase ?? Double.random(in: 0..<(Double.pi * 2))
+
+        return (0..<boxSegmentCount).map { index in
+            let startDistance = Float(index) * step
+            let endDistance = startDistance + step
+            let start = pointOnBox(
+                distance: startDistance,
+                left: left,
+                top: top,
+                right: right,
+                bottom: bottom,
+                jitterAmplitude: jitterAmplitude,
+                phase: resolvedPhase
+            )
+            let end = pointOnBox(
+                distance: endDistance,
+                left: left,
+                top: top,
+                right: right,
+                bottom: bottom,
+                jitterAmplitude: jitterAmplitude,
+                phase: resolvedPhase
+            )
+            let progress = ((startDistance + step / 2) / perimeter).clamped(to: 0...1)
+            return HighlightOverlayStrokeSegment(
+                startX: start.x,
+                startY: start.y,
+                endX: end.x,
+                endY: end.y,
+                strokeWidth: baseStrokeWidth * boxWidthFactor(progress: progress)
+            )
+        }
+    }
+
     public static func pathSegments(
         points: [HighlightPoint],
         smoothing: String?,
@@ -300,6 +351,37 @@ public enum HighlightOverlayHandDrawnSegments {
             distance += length
         }
         return segments
+    }
+
+    private static func pointOnBox(
+        distance: Float,
+        left: Float,
+        top: Float,
+        right: Float,
+        bottom: Float,
+        jitterAmplitude: Float,
+        phase: Double
+    ) -> (x: Float, y: Float) {
+        let width = right - left
+        let height = bottom - top
+        let perimeter = 2 * (width + height)
+        let wrappedDistance = distance.truncatingRemainder(dividingBy: perimeter)
+        let jitter = jitterAmplitude * Float(sin(Double(wrappedDistance) * 0.11 + phase))
+
+        if wrappedDistance <= width {
+            return (x: left + wrappedDistance, y: top + jitter)
+        }
+        if wrappedDistance <= width + height {
+            return (x: right + jitter, y: top + (wrappedDistance - width))
+        }
+        if wrappedDistance <= (2 * width) + height {
+            return (x: right - (wrappedDistance - width - height), y: bottom + jitter)
+        }
+        return (x: left + jitter, y: bottom - (wrappedDistance - (2 * width) - height))
+    }
+
+    private static func boxWidthFactor(progress: Float) -> Float {
+        ellipseMinWidthFactor + (ellipseMaxWidthFactor - ellipseMinWidthFactor) * Float(abs(sin(Double(progress) * Double.pi * 2)))
     }
 
     private static func pointOnEllipse(
@@ -610,7 +692,13 @@ public final class DefaultHighlightOverlayRenderer: HighlightOverlayRendering {
         private static func segmentLayers(for command: HighlightOverlayRenderCommand) -> [CAShapeLayer] {
             let segments: [HighlightOverlayStrokeSegment]
             switch command.shapeType {
-            case "box", "circle":
+            case "box":
+                guard let bounds = command.bounds else { return [] }
+                segments = HighlightOverlayHandDrawnSegments.boxSegments(
+                    bounds: bounds,
+                    baseStrokeWidth: command.strokeWidth
+                )
+            case "circle":
                 guard let bounds = command.bounds else { return [] }
                 segments = HighlightOverlayHandDrawnSegments.ellipseSegments(
                     bounds: bounds,

--- a/ios/control-proxy/Tests/CtrlProxyTests/CommandHandlerTests.swift
+++ b/ios/control-proxy/Tests/CtrlProxyTests/CommandHandlerTests.swift
@@ -1635,7 +1635,7 @@ final class CommandHandlerTests: XCTestCase {
         XCTAssertEqual(response.success, false)
         XCTAssertEqual(
             response.error,
-            "Unable to render highlight on iOS: target app SDK highlight bridge unavailable and runner overlay fallback disabled."
+            "Unable to render highlight on iOS: target app SDK highlight bridge unavailable and runner overlay fallback failed."
         )
     }
 

--- a/ios/control-proxy/Tests/CtrlProxyTests/HighlightOverlayManagerTests.swift
+++ b/ios/control-proxy/Tests/CtrlProxyTests/HighlightOverlayManagerTests.swift
@@ -33,7 +33,7 @@ final class HighlightOverlayManagerTests: XCTestCase {
         XCTAssertEqual(command.bounds?.x, 30)
         XCTAssertEqual(command.bounds?.width, 80)
         XCTAssertEqual(command.strokeColor, "#FF0000")
-        XCTAssertEqual(command.strokeWidth, 3)
+        XCTAssertEqual(command.strokeWidth, 8)
     }
 
     func testBuildsPathRenderCommand() throws {
@@ -45,7 +45,7 @@ final class HighlightOverlayManagerTests: XCTestCase {
         let shape = HighlightShape(
             type: "path",
             points: points,
-            style: HighlightStyle(strokeColor: "#FF3B30", strokeWidth: 2)
+            style: HighlightStyle(strokeColor: "#FF3B30", strokeWidth: 2, smoothing: "catmull-rom", tension: 0.6)
         )
 
         let command = try HighlightOverlayCommandBuilder.command(for: shape)
@@ -58,6 +58,48 @@ final class HighlightOverlayManagerTests: XCTestCase {
         XCTAssertEqual(command.points[2].y, 6)
         XCTAssertEqual(command.strokeColor, "#FF3B30")
         XCTAssertEqual(command.strokeWidth, 2)
+        XCTAssertEqual(command.smoothing, "catmull-rom")
+        XCTAssertEqual(command.tension, 0.6)
+    }
+
+    func testBuildsHandDrawnEllipseSegmentsWithJitterAndWidthVariation() {
+        let segments = HighlightOverlayHandDrawnSegments.ellipseSegments(
+            bounds: HighlightBounds(x: 10, y: 20, width: 100, height: 80),
+            baseStrokeWidth: 8,
+            phaseX: 0,
+            phaseY: 0,
+            startAngleJitter: 0
+        )
+
+        XCTAssertEqual(segments.count, 160)
+        XCTAssertLessThan(segments.map(\.strokeWidth).min() ?? 0, 7)
+        XCTAssertGreaterThan(segments.map(\.strokeWidth).max() ?? 0, 15)
+        XCTAssertNotEqual(segments[0].startX, segments[40].startX)
+        XCTAssertNotEqual(segments[0].strokeWidth, segments[40].strokeWidth)
+    }
+
+    func testBuildsHandDrawnPathSegmentsWithDefaultSmoothingAndTaper() {
+        let points = [
+            HighlightPoint(x: 10, y: 20),
+            HighlightPoint(x: 40, y: 35),
+            HighlightPoint(x: 80, y: 25),
+        ]
+
+        let segments = HighlightOverlayHandDrawnSegments.pathSegments(
+            points: points,
+            smoothing: nil,
+            tension: nil,
+            baseStrokeWidth: 8
+        )
+
+        XCTAssertGreaterThan(segments.count, points.count - 1)
+        XCTAssertEqual(segments.first?.startX, 10)
+        XCTAssertEqual(segments.first?.startY, 20)
+        XCTAssertEqual(segments.last?.endX, 80)
+        XCTAssertEqual(segments.last?.endY, 25)
+        XCTAssertLessThan(segments.first?.strokeWidth ?? 0, 8)
+        XCTAssertLessThan(segments.last?.strokeWidth ?? 0, 8)
+        XCTAssertGreaterThan(segments.map(\.strokeWidth).max() ?? 0, 7)
     }
 
     func testScalesScreenshotBoundsToOverlayTargetSize() throws {

--- a/ios/control-proxy/Tests/CtrlProxyTests/HighlightOverlayManagerTests.swift
+++ b/ios/control-proxy/Tests/CtrlProxyTests/HighlightOverlayManagerTests.swift
@@ -147,6 +147,37 @@ final class HighlightOverlayManagerTests: XCTestCase {
         XCTAssertTrue(renderer.rendered.isEmpty)
         XCTAssertTrue(scheduler.scheduled.isEmpty)
     }
+
+    func testLiveOverlayDefaultsEnabledWhenEnvironmentFlagIsUnset() {
+        XCTAssertTrue(DefaultHighlightOverlayRenderer.liveOverlayEnabled(environment: [:]))
+    }
+
+    func testLiveOverlayEnvironmentFlagCanDisableOverlay() {
+        XCTAssertFalse(DefaultHighlightOverlayRenderer.liveOverlayEnabled(environment: [
+            "AUTOMOBILE_IOS_LIVE_HIGHLIGHTS": "false",
+        ]))
+        XCTAssertFalse(DefaultHighlightOverlayRenderer.liveOverlayEnabled(environment: [
+            "AUTOMOBILE_IOS_LIVE_HIGHLIGHTS": "0",
+        ]))
+        XCTAssertFalse(DefaultHighlightOverlayRenderer.liveOverlayEnabled(environment: [
+            "AUTOMOBILE_IOS_LIVE_HIGHLIGHTS": "no",
+        ]))
+        XCTAssertFalse(DefaultHighlightOverlayRenderer.liveOverlayEnabled(environment: [
+            "AUTOMOBILE_IOS_LIVE_HIGHLIGHTS": " FALSE ",
+        ]))
+    }
+
+    func testLiveOverlayEnvironmentFlagCanExplicitlyEnableOverlay() {
+        XCTAssertTrue(DefaultHighlightOverlayRenderer.liveOverlayEnabled(environment: [
+            "AUTOMOBILE_IOS_LIVE_HIGHLIGHTS": "true",
+        ]))
+        XCTAssertTrue(DefaultHighlightOverlayRenderer.liveOverlayEnabled(environment: [
+            "AUTOMOBILE_IOS_LIVE_HIGHLIGHTS": "1",
+        ]))
+        XCTAssertTrue(DefaultHighlightOverlayRenderer.liveOverlayEnabled(environment: [
+            "AUTOMOBILE_IOS_LIVE_HIGHLIGHTS": "yes",
+        ]))
+    }
 }
 
 private final class FakeHighlightOverlayRenderer: HighlightOverlayRendering {

--- a/ios/control-proxy/Tests/CtrlProxyTests/HighlightOverlayManagerTests.swift
+++ b/ios/control-proxy/Tests/CtrlProxyTests/HighlightOverlayManagerTests.swift
@@ -78,6 +78,28 @@ final class HighlightOverlayManagerTests: XCTestCase {
         XCTAssertNotEqual(segments[0].strokeWidth, segments[40].strokeWidth)
     }
 
+    func testBuildsHandDrawnBoxSegmentsAroundRectangularPerimeter() {
+        let segments = HighlightOverlayHandDrawnSegments.boxSegments(
+            bounds: HighlightBounds(x: 10, y: 20, width: 100, height: 80),
+            baseStrokeWidth: 8,
+            phase: 0
+        )
+
+        XCTAssertEqual(segments.count, 160)
+        XCTAssertEqual(segments.first?.startX, 10)
+        XCTAssertEqual(segments.first?.startY ?? 0, 20, accuracy: 0.001)
+        XCTAssertEqual(segments[40].startY, 20, accuracy: 2)
+        XCTAssertGreaterThan(segments[40].startX, 90)
+        XCTAssertEqual(segments[45].startX, 110, accuracy: 2)
+        XCTAssertGreaterThan(segments[45].startY, 20)
+        XCTAssertEqual(segments[80].startY, 100, accuracy: 2)
+        XCTAssertGreaterThan(segments[80].startX, 108)
+        XCTAssertEqual(segments[125].startX, 10, accuracy: 2)
+        XCTAssertLessThan(segments[125].startY, 100)
+        XCTAssertLessThan(segments.map(\.strokeWidth).min() ?? 0, 7)
+        XCTAssertGreaterThan(segments.map(\.strokeWidth).max() ?? 0, 15)
+    }
+
     func testBuildsHandDrawnPathSegmentsWithDefaultSmoothingAndTaper() {
         let points = [
             HighlightPoint(x: 10, y: 20),

--- a/src/features/observe/ios/IOSCtrlProxyClient.ts
+++ b/src/features/observe/ios/IOSCtrlProxyClient.ts
@@ -1189,7 +1189,7 @@ export class IOSCtrlProxyClient extends DeviceServiceClient implements IOSCtrlPr
 
         case "highlight_response":
           result = {
-            success: message.success ?? true,
+            success: message.success ?? false,
             totalTimeMs: message.totalTimeMs ?? 0,
             error: message.error,
             requestId,

--- a/test/features/observe/ios/IOSCtrlProxyClient.test.ts
+++ b/test/features/observe/ios/IOSCtrlProxyClient.test.ts
@@ -552,6 +552,46 @@ describe("IOSCtrlProxyClient", function() {
         await testClient.close();
       }
     });
+
+    test("treats iOS highlight responses without success as failures", async function() {
+      const testTimer = fakeTimer;
+
+      const { factory, getSocket } = createCapturingWebSocketFactory(testTimer);
+      const testClient = IOSCtrlProxyClient.createForTesting(
+        testDevice,
+        serverPort,
+        factory,
+        testTimer
+      );
+      const shape: HighlightShape = {
+        type: "box",
+        bounds: {
+          x: 10,
+          y: 20,
+          width: 100,
+          height: 80,
+        },
+      };
+
+      try {
+        const requestPromise = testClient.requestAddHighlight("highlight-1", shape, 2000);
+        const socket = await waitForSocket(getSocket);
+        expect(socket).not.toBeNull();
+        await waitForSocketOpen(socket);
+        await waitForSentMessages(socket, 1);
+
+        const payload = JSON.parse(socket!.sentMessages[0]);
+        socket!.simulateMessage(JSON.stringify({
+          type: "highlight_response",
+          requestId: payload.requestId,
+        }));
+
+        const result = await requestPromise;
+        expect(result.success).toBe(false);
+      } finally {
+        await testClient.close();
+      }
+    });
   });
 
   describe("requestScreenshot", function() {


### PR DESCRIPTION
## Summary
- Enable the iOS CtrlProxy runner highlight overlay by default, with `AUTOMOBILE_IOS_LIVE_HIGHLIGHTS=false` as the opt-out.
- Render iOS runner fallback highlights with Android-style hand-drawn segments: jittered ellipses, variable stroke widths, smoothed/tapered paths, and draw/fade animation.
- Treat malformed iOS `highlight_response` messages without `success` as failures instead of successes.
- Update highlight docs to describe iOS SDK-first rendering with default runner fallback.

Fixes #2607

## Tests
- `bun test test/features/observe/ios/IOSCtrlProxyClient.test.ts`
- `(cd ios/control-proxy && swift test --filter HighlightOverlayManagerTests)`
- `(cd ios/control-proxy && swift test --filter CommandHandlerTests)`
- `bun run build`

## Validation Notes
- `bash scripts/ios/swift-test.sh ios/control-proxy` passes `control-proxy`, but the broader script fails in `XCTestRunner` on a live Reminders plan because `tapOn` could not find text `Done`.
- `bun install` fails in this environment while building the existing `heapdump` native dependency against Node 26.

## Self Review
- Reviewed the final diff for reuse, contracts, docs, and edge cases.
- Hardened the environment parser to trim whitespace before checking opt-out values.
- Added platform-neutral Swift tests for the hand-drawn segment builder so the Android-style visual behavior is covered without UIKit.
