### PR TITLE
Accept appId aliases in tool schemas

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -15,6 +15,13 @@ import { registerDoctorTools } from "../server/doctorTools";
 import { registerVideoRecordingTools } from "../server/videoRecordingTools";
 import { registerNotificationTools } from "../server/notificationTools";
 
+type CliHelpSchemaShape = Record<string, any> | undefined;
+interface CliHelpParameterInfo {
+  isOptional: boolean;
+  typeName: string;
+  description?: string;
+}
+
 // Initialize tool registry for CLI mode
 function initializeCliTools(): void {
 
@@ -448,18 +455,16 @@ function showToolHelp(toolName: string): void {
   // Show schema information
   console.log("\nParameters:");
   try {
-    const schema = tool.schema._def;
-    if (schema && schema.shape) {
-      Object.entries(schema.shape).forEach(([key, value]: [string, any]) => {
-        const isOptional = value._def.typeName === "ZodOptional";
-        const actualType = isOptional ? value._def.innerType : value;
-        const typeName = actualType._def.typeName || "unknown";
+    const shape = getCliHelpSchemaShape(tool.schema);
+    if (shape) {
+      Object.entries(shape).forEach(([key, value]: [string, any]) => {
+        const parameter = getCliHelpParameterInfo(value);
 
-        console.log(`  --${key} ${isOptional ? "(optional)" : "(required)"}`);
-        console.log(`    Type: ${typeName.replace("Zod", "").toLowerCase()}`);
+        console.log(`  --${key} ${parameter.isOptional ? "(optional)" : "(required)"}`);
+        console.log(`    Type: ${parameter.typeName}`);
 
-        if (actualType._def.description) {
-          console.log(`    Description: ${actualType._def.description}`);
+        if (parameter.description) {
+          console.log(`    Description: ${parameter.description}`);
         }
       });
     } else {
@@ -471,4 +476,38 @@ function showToolHelp(toolName: string): void {
 
   console.log(`\nExample usage:`);
   console.log(`  bunx @kaeawc/auto-mobile@latest --cli ${toolName} [parameters...]`);
+}
+
+export function getCliHelpSchemaShape(schema: any): CliHelpSchemaShape {
+  const definition = schema?._def;
+  if (!definition) {
+    return undefined;
+  }
+
+  if (definition.shape) {
+    return definition.shape;
+  }
+
+  if (definition.type === "pipe" && definition.out?._def?.shape) {
+    return definition.out._def.shape;
+  }
+
+  return undefined;
+}
+
+export function getCliHelpParameterInfo(schema: any): CliHelpParameterInfo {
+  const isOptional = typeof schema?.isOptional === "function"
+    ? schema.isOptional()
+    : schema?._def?.typeName === "ZodOptional";
+  const actualType = isOptional
+    ? schema?._def?.innerType ?? schema
+    : schema;
+  const rawTypeName = actualType?._def?.typeName ?? actualType?._def?.type ?? "unknown";
+  const typeName = String(rawTypeName).replace(/^Zod/, "").toLowerCase();
+
+  return {
+    isOptional,
+    typeName,
+    description: schema?.description ?? actualType?.description ?? actualType?._def?.description,
+  };
 }

--- a/src/server/appFileContract.ts
+++ b/src/server/appFileContract.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import { addDeviceTargetingToSchema } from "./toolSchemaHelpers";
+import { addDeviceTargetingToSchema, withAppIdAliases } from "./toolSchemaHelpers";
 import type { Platform } from "../models";
 
 export const APP_FILE_CONTAINERS = [
@@ -104,7 +104,7 @@ export function normalizeAppFileRelativePath(path: string): string {
   return normalized;
 }
 
-export const putAppFileSchema = addDeviceTargetingToSchema(z.object({
+export const putAppFileSchema = withAppIdAliases(addDeviceTargetingToSchema(z.object({
   appId: z.string().min(1),
   container: appFileContainerSchema.describe("App container"),
   sourcePath: z.string().min(1).optional().describe("Host file path"),
@@ -144,7 +144,7 @@ export const putAppFileSchema = addDeviceTargetingToSchema(z.object({
       });
     }
   }
-}));
+})));
 
 function encodePathSegments(path: string): string {
   return normalizeAppFileRelativePath(path)

--- a/src/server/appTools.ts
+++ b/src/server/appTools.ts
@@ -7,7 +7,7 @@ import { InstallApp } from "../features/action/InstallApp";
 import { UninstallApp } from "../features/action/UninstallApp";
 import { AppPermissions } from "../features/action/AppPermissions";
 import { createJSONToolResponse, DefaultToolResponseFormatter, ToolResponseFormatter } from "../utils/toolUtils";
-import { addDeviceTargetingToSchema } from "./toolSchemaHelpers";
+import { addDeviceTargetingToSchema, withAppIdAliases } from "./toolSchemaHelpers";
 import {
   APPS_RESOURCE_URIS,
   APP_RESOURCE_TEMPLATES,
@@ -43,28 +43,28 @@ export function resetListAppsToolDependencies(): void {
 }
 
 // Schema definitions
-export const packageNameSchema = addDeviceTargetingToSchema(z.object({
+export const packageNameSchema = withAppIdAliases(addDeviceTargetingToSchema(z.object({
   appId: z.string(),
-}));
+})));
 
-export const launchAppSchema = addDeviceTargetingToSchema(z.object({
+export const launchAppSchema = withAppIdAliases(addDeviceTargetingToSchema(z.object({
   appId: z.string(),
   clearAppData: z.boolean().optional().describe("Clear app data before launch (default false)"),
   coldBoot: z.boolean().optional().describe("Cold boot app (default false)"),
-}));
+})));
 
 export const installAppSchema = addDeviceTargetingToSchema(z.object({
   artifactPath: z.string().describe("App artifact path (.apk, .app, or .ipa)"),
 }));
 
-export const uninstallAppSchema = addDeviceTargetingToSchema(z.object({
+export const uninstallAppSchema = withAppIdAliases(addDeviceTargetingToSchema(z.object({
   appId: z.string(),
   keepData: z.boolean().optional().describe("Keep app data after uninstall (Android only, default false)"),
-}));
+})));
 
 const appPermissionActionSchema = z.enum(["grant", "revoke", "reset"]);
 
-export const setAppPermissionsSchema = addDeviceTargetingToSchema(
+export const setAppPermissionsSchema = withAppIdAliases(addDeviceTargetingToSchema(
   z.object({
     appId: z.string(),
     action: appPermissionActionSchema
@@ -89,7 +89,7 @@ export const setAppPermissionsSchema = addDeviceTargetingToSchema(
       .optional()
       .describe("Android: set SCHEDULE_EXACT_ALARM appop"),
   })
-).refine(
+)).refine(
   args =>
     (args.permissions !== undefined && args.permissions.length > 0) ||
     args.notificationPolicyAccess !== undefined ||
@@ -97,7 +97,7 @@ export const setAppPermissionsSchema = addDeviceTargetingToSchema(
   "Provide at least one permission or platform-specific permission option"
 );
 
-export const getAppPermissionsSchema = addDeviceTargetingToSchema(
+export const getAppPermissionsSchema = withAppIdAliases(addDeviceTargetingToSchema(
   z.object({
     appId: z.string(),
     permissions: z
@@ -105,7 +105,7 @@ export const getAppPermissionsSchema = addDeviceTargetingToSchema(
       .optional()
       .describe("Optional permissions or simulator privacy services to query"),
   })
-);
+));
 
 export const listAppsSchema = z.object({}).passthrough();
 

--- a/src/server/databaseTools.ts
+++ b/src/server/databaseTools.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 import { ToolRegistry } from "./toolRegistry";
 import { ActionableError, BootedDevice } from "../models";
-import { addDeviceTargetingToSchema } from "./toolSchemaHelpers";
+import { addDeviceTargetingToSchema, withAppIdAliases } from "./toolSchemaHelpers";
 import { createJSONToolResponse } from "../utils/toolUtils";
 import { DatabaseInspector } from "../features/database/DatabaseInspector";
 import { defaultAdbClientFactory } from "../utils/android-cmdline-tools/AdbClientFactory";
@@ -10,13 +10,13 @@ import { IOSCtrlProxyClient } from "../features/observe/ios";
 import type { SQLResult } from "../features/database/DatabaseInspector";
 
 // Schema for sqlQuery tool
-const sqlQuerySchema = addDeviceTargetingToSchema(
+const sqlQuerySchema = withAppIdAliases(addDeviceTargetingToSchema(
   z.object({
     appId: z.string(),
     databasePath: z.string().describe("Database path"),
     query: z.string().describe("SQL query")
   })
-);
+));
 
 // Type interface for tool arguments
 interface SqlQueryArgs {

--- a/src/server/debugTools.ts
+++ b/src/server/debugTools.ts
@@ -5,7 +5,7 @@ import { DebugSearch } from "../features/debug/DebugSearch";
 import { BugReport } from "../features/debug/BugReport";
 import { createJSONToolResponse } from "../utils/toolUtils";
 import { BootedDevice, Platform } from "../models";
-import { addDeviceTargetingToSchema, platformSchema } from "./toolSchemaHelpers";
+import { addDeviceTargetingToSchema, platformSchema, withAppIdAliases } from "./toolSchemaHelpers";
 import { isDebugModeEnabled } from "../utils/debug";
 import {
   elementContainerSchema,
@@ -61,12 +61,12 @@ export const debugSearchSchema = addDeviceTargetingToSchema(debugSearchBaseSchem
   validateElementIdTextSelector(value, ctx);
 });
 
-export const bugReportSchema = addDeviceTargetingToSchema(z.object({
+export const bugReportSchema = withAppIdAliases(addDeviceTargetingToSchema(z.object({
   platform: platformSchema,
   appId: z.string().optional().describe("App package ID to filter logcat for specific app"),
   logcatLines: z.number().optional().describe("Number of recent logcat lines to include (default: 1000)"),
   saveDir: z.string().optional().describe("Directory to save report to")
-}));
+})));
 
 // Register debug tools
 export function registerDebugTools() {

--- a/src/server/deepLinkTools.ts
+++ b/src/server/deepLinkTools.ts
@@ -4,12 +4,12 @@ import { GetDeepLinks } from "../features/utility/GetDeepLinks";
 import { ActionableError, BootedDevice } from "../models";
 import { createJSONToolResponse } from "../utils/toolUtils";
 import { logger } from "../utils/logger";
-import { addDeviceTargetingToSchema } from "./toolSchemaHelpers";
+import { addDeviceTargetingToSchema, withAppIdAliases } from "./toolSchemaHelpers";
 
 // Schema definitions for tool arguments
-export const getDeepLinksSchema = addDeviceTargetingToSchema(z.object({
+export const getDeepLinksSchema = withAppIdAliases(addDeviceTargetingToSchema(z.object({
   appId: z.string(),
-}));
+})));
 
 // Type definitions for better TypeScript support
 export interface GetDeepLinksArgs {

--- a/src/server/interactionTools.ts
+++ b/src/server/interactionTools.ts
@@ -26,7 +26,7 @@ import { ListInstalledApps } from "../features/observe/ListInstalledApps";
 import { createJSONToolResponse, createStructuredToolResponse } from "../utils/toolUtils";
 import { resolveSwipeDirection } from "../utils/swipeOnUtils";
 import { RecompositionTracker } from "../features/performance/RecompositionTracker";
-import { addDeviceTargetingToSchema, platformSchema } from "./toolSchemaHelpers";
+import { addDeviceTargetingToSchema, platformSchema, withAppIdAliases } from "./toolSchemaHelpers";
 import { serverConfig } from "../utils/ServerConfig";
 import {
   createElementIdTextSelectorSchema,
@@ -268,7 +268,7 @@ const systemTraySchemaBase = z.object({
   platform: platformSchema
 });
 
-export const systemTraySchema = addDeviceTargetingToSchema(systemTraySchemaBase).superRefine((value, ctx) => {
+export const systemTraySchema = withAppIdAliases(addDeviceTargetingToSchema(systemTraySchemaBase).superRefine((value, ctx) => {
   const notification = value.notification ?? {};
 
   if (value.action === "open" || value.action === "close") {
@@ -296,18 +296,18 @@ export const systemTraySchema = addDeviceTargetingToSchema(systemTraySchemaBase)
       message: "notification.tapActionLabel is only valid for tap action"
     });
   }
-});
-
-export const stopAppSchema = addDeviceTargetingToSchema(z.object({
-  appId: z.string(),
-  platform: platformSchema
 }));
 
-export const clearStateSchema = addDeviceTargetingToSchema(z.object({
+export const stopAppSchema = withAppIdAliases(addDeviceTargetingToSchema(z.object({
+  appId: z.string(),
+  platform: platformSchema
+})));
+
+export const clearStateSchema = withAppIdAliases(addDeviceTargetingToSchema(z.object({
   appId: z.string(),
   clearKeychain: z.boolean().optional().describe("Clear iOS keychain"),
   platform: platformSchema
-}));
+})));
 
 export const inputTextSchema = addDeviceTargetingToSchema(z.object({
   text: z.string().min(1),

--- a/src/server/notificationTools.ts
+++ b/src/server/notificationTools.ts
@@ -2,7 +2,7 @@ import { z } from "zod";
 import { ToolRegistry } from "./toolRegistry";
 import { ActionableError, BootedDevice, Platform } from "../models";
 import { createJSONToolResponse } from "../utils/toolUtils";
-import { addDeviceTargetingToSchema } from "./toolSchemaHelpers";
+import { addDeviceTargetingToSchema, withAppIdAliases } from "./toolSchemaHelpers";
 import { PostNotification, PostNotificationOptions } from "../features/utility/PostNotification";
 import { NotificationPolicy } from "../features/utility/NotificationPolicy";
 
@@ -26,7 +26,7 @@ const postNotificationCommonShape = {
   channelId: z.string().optional().describe("Android channel ID / iOS APNs category"),
 };
 
-export const postNotificationSchema = z.discriminatedUnion("platform", [
+export const postNotificationSchema = withAppIdAliases(z.discriminatedUnion("platform", [
   addDeviceTargetingToSchema(z.object({
     ...postNotificationCommonShape,
     appId: z.string({ error: iosAppIdRequiredMessage })
@@ -39,16 +39,16 @@ export const postNotificationSchema = z.discriminatedUnion("platform", [
     appId: z.string().min(1).optional().describe("iOS target bundle ID"),
     platform: z.literal("android")
   }))
-]);
+]));
 
-export const getNotificationPolicySchema = addDeviceTargetingToSchema(z.object({
+export const getNotificationPolicySchema = withAppIdAliases(addDeviceTargetingToSchema(z.object({
   appId: z.string().min(1),
-}));
+})));
 
-export const setNotificationPolicySchema = addDeviceTargetingToSchema(z.object({
+export const setNotificationPolicySchema = withAppIdAliases(addDeviceTargetingToSchema(z.object({
   appId: z.string().min(1),
   policyAccess: z.boolean().describe("Android: allow DND policy access"),
-}));
+})));
 
 export type GetNotificationPolicyArgs = z.infer<typeof getNotificationPolicySchema>;
 

--- a/src/server/storageTools.ts
+++ b/src/server/storageTools.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 import { ToolRegistry } from "./toolRegistry";
 import { ActionableError, BootedDevice } from "../models";
-import { addDeviceTargetingToSchema } from "./toolSchemaHelpers";
+import { addDeviceTargetingToSchema, withAppIdAliases } from "./toolSchemaHelpers";
 import { createJSONToolResponse } from "../utils/toolUtils";
 import { AndroidCtrlProxyClient } from "../features/observe/android";
 import { IOSCtrlProxyClient } from "../features/observe/ios";
@@ -45,7 +45,7 @@ function resolveStorageName(args: { name?: string; fileName?: string }): string 
 }
 
 // Schema for setKeyValue tool
-const setKeyValueSchema = z.union([
+const setKeyValueSchema = withAppIdAliases(z.union([
   addDeviceTargetingToSchema(z.object({
     appId: z.string(),
     name: z.string().describe(STORAGE_NAME_DESCRIPTION),
@@ -66,10 +66,10 @@ const setKeyValueSchema = z.union([
       "Value type"
     ),
   })),
-]);
+]));
 
 // Schema for removeKeyValue tool
-const removeKeyValueSchema = z.union([
+const removeKeyValueSchema = withAppIdAliases(z.union([
   addDeviceTargetingToSchema(z.object({
     appId: z.string(),
     name: z.string().describe(STORAGE_NAME_DESCRIPTION),
@@ -82,10 +82,10 @@ const removeKeyValueSchema = z.union([
     fileName: z.string().describe(legacyFileNameDescription),
     key: z.string().describe("Key"),
   })),
-]);
+]));
 
 // Schema for clearKeyValueFile tool
-const clearKeyValueFileSchema = z.union([
+const clearKeyValueFileSchema = withAppIdAliases(z.union([
   addDeviceTargetingToSchema(z.object({
     appId: z.string(),
     name: z.string().describe(STORAGE_NAME_DESCRIPTION),
@@ -96,7 +96,7 @@ const clearKeyValueFileSchema = z.union([
     name: z.string().optional().describe(STORAGE_NAME_DESCRIPTION),
     fileName: z.string().describe(legacyFileNameDescription),
   })),
-]);
+]));
 
 interface SetKeyValueArgs {
   appId: string;

--- a/src/server/toolSchemaHelpers.ts
+++ b/src/server/toolSchemaHelpers.ts
@@ -6,6 +6,75 @@ export const platformSchema = z.enum(["android", "ios"]);
 export const DEVICE_LABEL_DESCRIPTION =
   "Device label";
 
+export const appIdFieldAliases = [
+  "packageId",
+  "package",
+  "packageName",
+  "appPackage",
+  "appPackageId",
+  "bundle",
+  "bundleId",
+  "bundleID",
+  "bundleIdentifier",
+  "application",
+  "applicationId",
+  "applicationIdentifier",
+  "app",
+  "appIdentifier",
+  "package_id",
+  "package_name",
+  "bundle_id",
+  "application_id",
+] as const;
+
+export type FieldAliasMap = Record<string, readonly string[]>;
+
+export function withFieldAliases<T extends z.ZodTypeAny>(schema: T, aliases: FieldAliasMap): T {
+  return z.preprocess(input => normalizeFieldAliases(input, aliases), schema) as unknown as T;
+}
+
+export function withAppIdAliases<T extends z.ZodTypeAny>(schema: T): T {
+  return withFieldAliases(schema, { appId: appIdFieldAliases });
+}
+
+function normalizeFieldAliases(input: unknown, aliases: FieldAliasMap): unknown {
+  if (Array.isArray(input)) {
+    return input.map(item => normalizeFieldAliases(item, aliases));
+  }
+
+  if (!isPlainObject(input)) {
+    return input;
+  }
+
+  const normalized: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(input)) {
+    normalized[key] = normalizeFieldAliases(value, aliases);
+  }
+
+  for (const [canonicalField, fieldAliases] of Object.entries(aliases)) {
+    if (normalized[canonicalField] === undefined) {
+      const matchingAlias = fieldAliases.find(alias => normalized[alias] !== undefined);
+      if (matchingAlias) {
+        normalized[canonicalField] = normalized[matchingAlias];
+      }
+    }
+
+    for (const alias of fieldAliases) {
+      delete normalized[alias];
+    }
+  }
+
+  return normalized;
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    return false;
+  }
+  const prototype = Object.getPrototypeOf(value);
+  return prototype === Object.prototype || prototype === null;
+}
+
 /**
  * Helper to add sessionUuid field to tool schemas
  *

--- a/test/cli/helpSchema.test.ts
+++ b/test/cli/helpSchema.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, test } from "bun:test";
+import { getCliHelpParameterInfo, getCliHelpSchemaShape } from "../../src/cli";
+import { launchAppSchema } from "../../src/server/appTools";
+
+describe("getCliHelpSchemaShape", () => {
+  test("unwraps aliased preprocess schemas for CLI parameter help", () => {
+    const shape = getCliHelpSchemaShape(launchAppSchema);
+
+    expect(shape).toBeDefined();
+    expect(shape?.appId).toBeDefined();
+    expect(shape?.clearAppData).toBeDefined();
+    expect(shape?.coldBoot).toBeDefined();
+
+    expect(getCliHelpParameterInfo(shape?.appId)).toMatchObject({
+      isOptional: false,
+      typeName: "string",
+    });
+    expect(getCliHelpParameterInfo(shape?.clearAppData)).toMatchObject({
+      isOptional: true,
+      typeName: "boolean",
+      description: "Clear app data before launch (default false)",
+    });
+  });
+});

--- a/test/server/toolSchemaHelpers.test.ts
+++ b/test/server/toolSchemaHelpers.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, test } from "bun:test";
 import { z } from "zod";
-import { addDeviceTargetingToSchema, platformSchema } from "../../src/server/toolSchemaHelpers";
+import {
+  addDeviceTargetingToSchema,
+  appIdFieldAliases,
+  platformSchema,
+  withFieldAliases
+} from "../../src/server/toolSchemaHelpers";
 import { accessibilitySchema } from "../../src/server/accessibilityTools";
 import { packageNameSchema, launchAppSchema, installAppSchema, uninstallAppSchema, getAppPermissionsSchema } from "../../src/server/appTools";
 import { biometricAuthSchema } from "../../src/server/biometricTools";
@@ -109,6 +114,138 @@ describe("addDeviceTargetingToSchema", () => {
     expect(withExplicit.success).toBe(true);
     if (withExplicit.success) {
       expect(withExplicit.data.platform).toBe("ios");
+    }
+  });
+});
+
+describe("withFieldAliases", () => {
+  const schema = withFieldAliases(
+    z.object({
+      appId: z.string(),
+      nested: z.object({
+        appId: z.string().optional(),
+      }).optional(),
+    }).strict(),
+    {
+      appId: appIdFieldAliases,
+    }
+  );
+
+  test("maps common app identifier aliases to appId", () => {
+    for (const alias of appIdFieldAliases) {
+      const result = schema.safeParse({ [alias]: "com.example.app" });
+
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.appId).toBe("com.example.app");
+        expect(alias in result.data).toBe(false);
+      }
+    }
+  });
+
+  test("preserves appId when an alias is also present", () => {
+    const result = schema.safeParse({
+      appId: "com.example.primary",
+      packageId: "com.example.alias",
+    });
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.appId).toBe("com.example.primary");
+      expect("packageId" in result.data).toBe(false);
+    }
+  });
+
+  test("normalizes nested objects with appId aliases", () => {
+    const result = schema.safeParse({
+      appId: "com.example.outer",
+      nested: {
+        bundleId: "com.example.inner",
+      },
+    });
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.nested?.appId).toBe("com.example.inner");
+    }
+  });
+
+  test("does not recurse into non-plain objects", () => {
+    const date = new Date("2026-01-01T00:00:00.000Z");
+    const dateSchema = withFieldAliases(z.object({
+      appId: z.string(),
+      value: z.instanceof(Date),
+    }), {
+      appId: appIdFieldAliases,
+    });
+
+    const result = dateSchema.safeParse({
+      packageId: "com.example.app",
+      value: date,
+    });
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.value).toBe(date);
+    }
+  });
+});
+
+describe("appId aliases on tool schemas", () => {
+  test("launchAppSchema accepts packageId as an appId alias", () => {
+    const result = launchAppSchema.safeParse({
+      packageId: "com.example.app",
+      platform: "android",
+    });
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.appId).toBe("com.example.app");
+      expect("packageId" in result.data).toBe(false);
+    }
+  });
+
+  test("launchAppSchema accepts natural app identifier aliases", () => {
+    for (const alias of ["package", "packageName", "bundle", "bundleId", "application", "applicationId"]) {
+      const result = launchAppSchema.safeParse({
+        [alias]: "com.example.app",
+        platform: "ios",
+      });
+
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.appId).toBe("com.example.app");
+      }
+    }
+  });
+
+  test("postNotificationSchema accepts bundleId for the iOS appId field", () => {
+    const result = postNotificationSchema.safeParse({
+      platform: "ios",
+      title: "Hello",
+      body: "World",
+      bundleId: "com.example.app",
+    });
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.appId).toBe("com.example.app");
+    }
+  });
+
+  test("systemTraySchema accepts appId aliases in notification criteria", () => {
+    const result = systemTraySchema.safeParse({
+      platform: "android",
+      action: "clearAll",
+      notification: {
+        packageName: "com.example.app",
+      },
+    });
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.notification?.appId).toBe("com.example.app");
+      expect("packageName" in (result.data.notification ?? {})).toBe(false);
     }
   });
 });


### PR DESCRIPTION
## Summary
- Add a reusable `withFieldAliases` Zod preprocessor for canonical field aliases.
- Accept common app identifier aliases (`packageId`, `package`, `packageName`, `bundle`, `bundleId`, `application`, `applicationId`, and related variants) for tool-call `appId` fields.
- Apply the helper to app lifecycle, app files, permissions, deep links, notifications, storage, database, debug, and interaction schemas, including nested `systemTray.notification.appId`.

Closes #2217

## Testing
- `bun test test/server/toolSchemaHelpers.test.ts --bail`
- `bun run build`
- `bun run lint`
- `bun test`

## Self-review
- Verified `appId` remains authoritative when aliases are also present.
- Verified aliases are consumed before strict schema validation.
- Verified nested alias normalization for notification criteria.
- Verified non-plain objects are not recursively rewritten.
- Verified generated MCP JSON schema remains alias-free, so tool schema token usage does not increase.
