### PR TITLE
Implement iOS simulator app file management

### DIFF
--- a/docs/design-docs/mcp/resources.md
+++ b/docs/design-docs/mcp/resources.md
@@ -73,7 +73,7 @@ Lists files in a logical app container without requiring callers to know Android
 - `tmp`
 - `externalFiles` where the platform supports it
 
-List responses include each entry's relative `path`, `name`, `resourceUri`, `isDirectory` marker, byte size for files when available, and `lastModified` timestamp when the platform can report one.
+List responses include each entry's relative `path`, `name`, `resourceUri`, `isDirectory` marker, byte size for files when available, and `lastModified` timestamp when the platform can report one. Host absolute app-container paths are intentionally omitted.
 
 Example list request:
 
@@ -90,6 +90,12 @@ Example list request:
 
 Reads a single file from an app container. Nested paths and filenames containing spaces are encoded as URI path segments. Binary content is returned as an MCP `blob` so it can be round-tripped losslessly.
 UTF-8 text files are returned as text with `text/plain; charset=utf-8` so clients do not need Android or iOS specific decoding logic.
+
+iOS simulator examples:
+
+- `automobile:devices/AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE/apps/com.example.app/files/documents/fixtures/welcome.png`
+- `automobile:devices/AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE/apps/com.example.app/files/cache/responses/home.json`
+- `automobile:devices/AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE/apps/com.example.app/files/tmp/session/output.bin`
 
 Example read request:
 

--- a/docs/design-docs/mcp/tools.md
+++ b/docs/design-docs/mcp/tools.md
@@ -72,6 +72,30 @@ Android app files support `externalFiles` through `/sdcard/Android/data/{appId}/
 
 Android private containers (`documents`, `cache`, and `tmp`) use `run-as {appId}` and require a debuggable app build. Non-debuggable apps fail with an actionable error instead of reporting a successful write. `library` is not an Android container; use `documents`, `cache`, `tmp`, or `externalFiles`.
 
+iOS app files are supported for simulators through `xcrun simctl get_app_container {deviceId} {bundleId} data`. Logical containers map to the app data container as follows:
+
+| Container | iOS path |
+|-----------|----------|
+| `documents` | `Documents` |
+| `library` | `Library` |
+| `cache` | `Library/Caches` |
+| `tmp` | `tmp` |
+
+Use `documents` for user-visible fixtures, `cache` for cache-like test data, and `tmp` for temporary files:
+
+```json
+{
+  "tool": "putAppFile",
+  "params": {
+    "appId": "com.example.app",
+    "container": "cache",
+    "contentBase64": "AAEC/w==",
+    "destinationPath": "fixtures/image.bin",
+    "platform": "ios"
+  }
+}
+```
+
 Manual emulator validation for Android:
 
 ```sh
@@ -79,6 +103,16 @@ printf '{"enabled":true}\n' > /tmp/automobile-settings.json
 # Call putAppFile with appId=com.example.app, container=externalFiles,
 # sourcePath=/tmp/automobile-settings.json, destinationPath=config/settings.json.
 adb shell cat /sdcard/Android/data/com.example.app/files/config/settings.json
+```
+
+Manual simulator validation for iOS:
+
+```sh
+printf 'hello simulator\n' > /tmp/automobile-ios-fixture.txt
+# Call putAppFile with appId=com.example.app, container=documents,
+# sourcePath=/tmp/automobile-ios-fixture.txt, destinationPath=fixtures/hello.txt.
+APP_CONTAINER=$(xcrun simctl get_app_container booted com.example.app data)
+cat "$APP_CONTAINER/Documents/fixtures/hello.txt"
 ```
 
 #### Input Methods

--- a/src/server/appFileService.ts
+++ b/src/server/appFileService.ts
@@ -1,6 +1,5 @@
 import { randomUUID } from "node:crypto";
 import { promises as nodeFs } from "node:fs";
-import type { Stats } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join, posix, relative } from "node:path";
 import { TextDecoder } from "node:util";
@@ -20,6 +19,7 @@ import { ActionableError, BootedDevice, Platform, type ExecResult } from "../mod
 import { defaultAdbClientFactory, type AdbClientFactory } from "../utils/android-cmdline-tools/AdbClientFactory";
 import type { AdbExecutor } from "../utils/android-cmdline-tools/interfaces/AdbExecutor";
 import { SimCtlClient } from "../utils/ios-cmdline-tools/SimCtlClient";
+import { isIosSimulatorUdid } from "../utils/ios-cmdline-tools/iosDeviceType";
 import { PlatformDeviceManagerFactory } from "../utils/factories/PlatformDeviceManagerFactory";
 
 export interface PutAppFileRequest extends PutAppFileArgs {
@@ -65,16 +65,61 @@ interface FileSource {
   cleanup?: () => Promise<void>;
 }
 
+export interface AppFileStats {
+  size: number;
+  mtime: Date;
+  isFile(): boolean;
+  isDirectory(): boolean;
+}
+
+export interface AppFileDirEntry {
+  name: string;
+}
+
+export interface AppFileFileSystem {
+  stat(path: string): Promise<AppFileStats>;
+  lstat(path: string): Promise<AppFileStats>;
+  readdir(path: string): Promise<AppFileDirEntry[]>;
+  mkdir(path: string): Promise<void>;
+  copyFile(sourcePath: string, destinationPath: string): Promise<void>;
+  readFileBuffer(path: string): Promise<Buffer>;
+  writeFileBuffer(path: string, data: Buffer): Promise<void>;
+  mkdtemp(prefix: string): Promise<string>;
+  rm(path: string): Promise<void>;
+}
+
 export interface AppFileServiceDependencies {
   adbFactory?: AdbClientFactory;
   simctlFactory?: (device: BootedDevice) => SimCtlClient;
+  fileSystem?: AppFileFileSystem;
   providers?: AppFileProvider[];
   deviceResolver?: (deviceId: string) => Promise<BootedDevice>;
 }
 
-const defaultDependencies: Required<Pick<AppFileServiceDependencies, "adbFactory" | "simctlFactory" | "deviceResolver">> = {
+const nodeAppFileFileSystem: AppFileFileSystem = {
+  stat: async path => nodeFs.stat(path),
+  lstat: async path => nodeFs.lstat(path),
+  readdir: async path => nodeFs.readdir(path, { withFileTypes: true }),
+  mkdir: async path => {
+    await nodeFs.mkdir(path, { recursive: true });
+  },
+  copyFile: async (sourcePath, destinationPath) => {
+    await nodeFs.copyFile(sourcePath, destinationPath);
+  },
+  readFileBuffer: async path => nodeFs.readFile(path),
+  writeFileBuffer: async (path, data) => {
+    await nodeFs.writeFile(path, data);
+  },
+  mkdtemp: async prefix => nodeFs.mkdtemp(prefix),
+  rm: async path => {
+    await nodeFs.rm(path, { recursive: true, force: true });
+  },
+};
+
+const defaultDependencies: Required<Pick<AppFileServiceDependencies, "adbFactory" | "simctlFactory" | "fileSystem" | "deviceResolver">> = {
   adbFactory: defaultAdbClientFactory,
   simctlFactory: device => new SimCtlClient(device),
+  fileSystem: nodeAppFileFileSystem,
   deviceResolver: findBootedDevice,
 };
 
@@ -84,7 +129,11 @@ let appFileService: AppFileService | null = null;
 
 export function getAppFileService(): AppFileService {
   if (!appFileService) {
-    appFileService = new DefaultAppFileService(createDefaultProviders(defaultDependencies), defaultDependencies.deviceResolver);
+    appFileService = new DefaultAppFileService(
+      createDefaultProviders(defaultDependencies),
+      defaultDependencies.deviceResolver,
+      defaultDependencies.fileSystem
+    );
   }
   return appFileService;
 }
@@ -101,20 +150,22 @@ export function createAppFileServiceForTesting(deps: AppFileServiceDependencies 
   const resolvedDeps = {
     adbFactory: deps.adbFactory ?? defaultDependencies.adbFactory,
     simctlFactory: deps.simctlFactory ?? defaultDependencies.simctlFactory,
+    fileSystem: deps.fileSystem ?? defaultDependencies.fileSystem,
     deviceResolver: deps.deviceResolver ?? defaultDependencies.deviceResolver,
   };
   return new DefaultAppFileService(
     deps.providers ?? createDefaultProviders(resolvedDeps),
-    resolvedDeps.deviceResolver
+    resolvedDeps.deviceResolver,
+    resolvedDeps.fileSystem
   );
 }
 
 function createDefaultProviders(
-  deps: Required<Pick<AppFileServiceDependencies, "adbFactory" | "simctlFactory">>
+  deps: Required<Pick<AppFileServiceDependencies, "adbFactory" | "simctlFactory" | "fileSystem">>
 ): AppFileProvider[] {
   return [
     new AndroidAppFileProvider(deps.adbFactory),
-    new IosSimulatorAppFileProvider(deps.simctlFactory),
+    new IosSimulatorAppFileProvider(deps.simctlFactory, deps.fileSystem),
   ];
 }
 
@@ -123,7 +174,8 @@ class DefaultAppFileService implements AppFileService {
 
   constructor(
     providers: AppFileProvider[],
-    private readonly deviceResolver: (deviceId: string) => Promise<BootedDevice>
+    private readonly deviceResolver: (deviceId: string) => Promise<BootedDevice>,
+    private readonly fileSystem: AppFileFileSystem
   ) {
     for (const provider of providers) {
       this.providersByPlatform.set(provider.platform, provider);
@@ -202,7 +254,7 @@ class DefaultAppFileService implements AppFileService {
 
   private async prepareSource(args: PutAppFileArgs): Promise<FileSource> {
     if (args.sourcePath !== undefined) {
-      const stat = await nodeFs.stat(args.sourcePath);
+      const stat = await this.fileSystem.stat(args.sourcePath);
       if (!stat.isFile()) {
         throw new ActionableError(`sourcePath is not a file: ${args.sourcePath}`);
       }
@@ -212,14 +264,14 @@ class DefaultAppFileService implements AppFileService {
     const buffer = args.contentBase64 !== undefined
       ? Buffer.from(args.contentBase64, "base64")
       : Buffer.from(args.contentText ?? "", "utf8");
-    const dir = await nodeFs.mkdtemp(join(tmpdir(), "automobile-app-file-"));
+    const dir = await this.fileSystem.mkdtemp(join(tmpdir(), "automobile-app-file-"));
     const tempPath = join(dir, "content");
-    await nodeFs.writeFile(tempPath, buffer);
+    await this.fileSystem.writeFileBuffer(tempPath, buffer);
     return {
       path: tempPath,
       byteCount: buffer.byteLength,
       cleanup: async () => {
-        await nodeFs.rm(dir, { recursive: true, force: true });
+        await this.fileSystem.rm(dir);
       },
     };
   }
@@ -369,17 +421,20 @@ class AndroidAppFileProvider implements AppFileProvider {
 class IosSimulatorAppFileProvider implements AppFileProvider {
   readonly platform = "ios" as const;
 
-  constructor(private readonly simctlFactory: (device: BootedDevice) => SimCtlClient) {}
+  constructor(
+    private readonly simctlFactory: (device: BootedDevice) => SimCtlClient,
+    private readonly fileSystem: AppFileFileSystem
+  ) {}
 
   async putFile(request: PutAppFileProviderRequest): Promise<void> {
     const target = await this.resolvePath(request.device, request.appId, request.container, request.destinationPath, "putFile");
-    await nodeFs.mkdir(dirname(target), { recursive: true });
-    await nodeFs.copyFile(request.sourcePath, target);
+    await this.fileSystem.mkdir(dirname(target));
+    await this.fileSystem.copyFile(request.sourcePath, target);
   }
 
   async listFiles(request: AppFileProviderListRequest): Promise<AppFileListResult> {
     const root = await this.resolvePath(request.device, request.appId, request.container, undefined, "listFiles");
-    const files = await listLocalFiles(root);
+    const files = await listLocalFiles(root, this.fileSystem);
     return {
       deviceId: request.device.deviceId,
       platform: request.device.platform,
@@ -399,7 +454,7 @@ class IosSimulatorAppFileProvider implements AppFileProvider {
 
   async readFile(request: AppFileProviderReadRequest): Promise<AppFileReadResult> {
     const target = await this.resolvePath(request.device, request.appId, request.container, request.path, "readFile");
-    const buffer = await nodeFs.readFile(target);
+    const buffer = await this.fileSystem.readFileBuffer(target);
     const text = decodeUtf8Text(buffer);
     return {
       deviceId: request.device.deviceId,
@@ -425,11 +480,25 @@ class IosSimulatorAppFileProvider implements AppFileProvider {
       throw unsupportedAppFileOperation(operation, device.platform, appId, container, "externalFiles is not available for iOS app containers");
     }
 
+    if (!isIosSimulatorUdid(device.deviceId)) {
+      throw new ActionableError(
+        `iOS app file ${operation} is only supported on iOS simulators. ` +
+        `Device ${device.deviceId} looks like a physical iOS device; app data containers require xcrun simctl.`
+      );
+    }
+
     const simctl = this.simctlFactory(device);
-    const result = await simctl.executeCommand(`get_app_container ${shellQuote(device.deviceId)} ${shellQuote(appId)} data`);
+    const result = await executeIosAppContainerCommand(
+      simctl,
+      `get_app_container ${shellQuote(device.deviceId)} ${shellQuote(appId)} data`,
+      { device, appId, container, operation }
+    );
     const dataRoot = result.stdout.trim();
     if (!dataRoot) {
-      throw new ActionableError(`Unable to resolve iOS app data container for ${appId} on ${device.deviceId}.`);
+      throw new ActionableError(
+        `Unable to resolve iOS simulator app data container for ${appId} on ${device.deviceId}. ` +
+        "Confirm the simulator is booted and the app is installed."
+      );
     }
 
     const containerRoot = join(dataRoot, iosContainerRelativePath(container, operation, appId, device.platform));
@@ -523,19 +592,18 @@ function iosContainerRelativePath(
 
 type LocalFileListEntry = Omit<AppFileListEntry, "resourceUri">;
 
-async function listLocalFiles(root: string): Promise<LocalFileListEntry[]> {
+async function listLocalFiles(root: string, fileSystem: AppFileFileSystem): Promise<LocalFileListEntry[]> {
   const entries: LocalFileListEntry[] = [];
 
   async function visit(dir: string): Promise<void> {
-    const children = await nodeFs.readdir(dir, { withFileTypes: true });
+    const children = await fileSystem.readdir(dir);
     for (const child of children) {
       const childPath = join(dir, child.name);
-      if (child.isDirectory()) {
-        const stat = await nodeFs.stat(childPath);
+      const stat = await fileSystem.lstat(childPath);
+      if (stat.isDirectory()) {
         entries.push(buildLocalListEntry(root, childPath, stat, true));
         await visit(childPath);
-      } else if (child.isFile()) {
-        const stat = await nodeFs.stat(childPath);
+      } else if (stat.isFile()) {
         entries.push(buildLocalListEntry(root, childPath, stat, false));
       }
     }
@@ -552,7 +620,7 @@ async function listLocalFiles(root: string): Promise<LocalFileListEntry[]> {
   return entries;
 }
 
-function buildLocalListEntry(root: string, childPath: string, stat: Stats, isDirectory: boolean): LocalFileListEntry {
+function buildLocalListEntry(root: string, childPath: string, stat: AppFileStats, isDirectory: boolean): LocalFileListEntry {
   const filePath = relative(root, childPath).replace(/\\/g, "/");
   return {
     path: filePath,
@@ -561,6 +629,54 @@ function buildLocalListEntry(root: string, childPath: string, stat: Stats, isDir
     isDirectory,
     lastModified: stat.mtime.toISOString(),
   };
+}
+
+interface IosAppContainerCommandContext {
+  device: BootedDevice;
+  appId: string;
+  container: AppFileContainer;
+  operation: string;
+}
+
+async function executeIosAppContainerCommand(
+  simctl: SimCtlClient,
+  command: string,
+  context: IosAppContainerCommandContext
+): Promise<ExecResult> {
+  try {
+    return await simctl.executeCommand(command);
+  } catch (error) {
+    throw mapIosAppContainerError(error, context);
+  }
+}
+
+function mapIosAppContainerError(error: unknown, context: IosAppContainerCommandContext): ActionableError {
+  const message = error instanceof Error ? error.message : String(error);
+  if (/not installed|application.*not.*installed|no such app|bundle.*not found|missing bundle/i.test(message)) {
+    return new ActionableError(
+      `iOS app ${context.appId} is not installed on simulator ${context.device.deviceId}; ` +
+      `cannot ${context.operation} ${context.container} app files. Original error: ${message}`
+    );
+  }
+
+  if (/no such device|invalid device|unavailable|shutdown|not booted/i.test(message)) {
+    return new ActionableError(
+      `iOS simulator ${context.device.deviceId} is unavailable or not booted; ` +
+      `cannot ${context.operation} ${context.container} app files for ${context.appId}. Original error: ${message}`
+    );
+  }
+
+  if (/host-control|docker|Driving the iOS simulator from inside Docker/i.test(message)) {
+    return new ActionableError(
+      `iOS simulator app file ${context.operation} requires local macOS simctl access; ` +
+      `host-control or Docker simulator access is unsupported. Original error: ${message}`
+    );
+  }
+
+  return new ActionableError(
+    `Failed to ${context.operation} iOS simulator ${context.container} app files for ` +
+    `${context.appId} on ${context.device.deviceId}: ${message}`
+  );
 }
 
 function parseAndroidStatListing(

--- a/test/server/appFileService.test.ts
+++ b/test/server/appFileService.test.ts
@@ -1,8 +1,8 @@
-import { mkdir, mkdtemp, readFile, rm, symlink, writeFile } from "node:fs/promises";
-import { tmpdir } from "node:os";
-import { join } from "node:path";
-import { afterEach, describe, expect, test } from "bun:test";
+import { dirname, join } from "node:path";
+import { describe, expect, test } from "bun:test";
 import {
+  type AppFileFileSystem,
+  type AppFileStats,
   createAppFileServiceForTesting,
   type AppFileProvider,
   type PutAppFileProviderRequest,
@@ -30,12 +30,11 @@ function adbFactoryFor(executor: FakeAdbExecutor): AdbClientFactory {
 }
 
 describe("AppFileService", () => {
-  const tempDirs: string[] = [];
-
-  afterEach(async () => {
-    await Promise.all(tempDirs.map(dir => rm(dir, { recursive: true, force: true })));
-    tempDirs.length = 0;
-  });
+  const iosSimulatorDevice: BootedDevice = {
+    deviceId: "AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE",
+    name: "iPhone",
+    platform: "ios",
+  };
 
   test("selects the matching provider and passes normalized put requests", async () => {
     const androidDevice: BootedDevice = {
@@ -219,21 +218,20 @@ describe("AppFileService", () => {
   });
 
   test("writes iOS files through the provider resolved app data container", async () => {
-    const dataRoot = await mkdtemp(join(tmpdir(), "automobile-ios-app-file-"));
-    tempDirs.push(dataRoot);
+    const fileSystem = new TestAppFileFileSystem();
+    const dataRoot = "/simulators/SIM-1/data";
     const simctl = new FakeSimCtlClient();
-    simctl.setCommandResult("get_app_container 'SIM-1' 'com.example.app' data", dataRoot);
+    simctl.setCommandResult(
+      `get_app_container '${iosSimulatorDevice.deviceId}' 'com.example.app' data`,
+      dataRoot
+    );
     const service = createAppFileServiceForTesting({
       simctlFactory: () => simctl as any,
+      fileSystem,
     });
-    const device: BootedDevice = {
-      deviceId: "SIM-1",
-      name: "iPhone",
-      platform: "ios",
-    };
 
     const result = await service.putFile({
-      device,
+      device: iosSimulatorDevice,
       appId: "com.example.app",
       container: "library",
       contentText: "hello ios",
@@ -242,24 +240,241 @@ describe("AppFileService", () => {
 
     expect(result).toMatchObject({
       success: true,
-      deviceId: "SIM-1",
+      deviceId: iosSimulatorDevice.deviceId,
       platform: "ios",
       appId: "com.example.app",
       container: "library",
       destinationPath: "Support/config.txt",
       byteCount: 9,
     });
-    await expect(readFile(join(dataRoot, "Library", "Support", "config.txt"), "utf8")).resolves.toBe("hello ios");
+    await expect(fileSystem.readText(join(dataRoot, "Library", "Support", "config.txt"))).resolves.toBe("hello ios");
+  });
+
+  test("maps iOS logical containers to simulator data container folders", async () => {
+    const fileSystem = new TestAppFileFileSystem();
+    const dataRoot = "/simulators/SIM-1/data";
+    const simctl = new FakeSimCtlClient();
+    simctl.setCommandResult(
+      `get_app_container '${iosSimulatorDevice.deviceId}' 'com.example.app' data`,
+      dataRoot
+    );
+    const service = createAppFileServiceForTesting({
+      simctlFactory: () => simctl as any,
+      fileSystem,
+    });
+
+    await service.putFile({
+      device: iosSimulatorDevice,
+      appId: "com.example.app",
+      container: "documents",
+      contentText: "documents",
+      destinationPath: "fixtures/value.txt",
+    });
+    await service.putFile({
+      device: iosSimulatorDevice,
+      appId: "com.example.app",
+      container: "cache",
+      contentText: "cache",
+      destinationPath: "fixtures/value.txt",
+    });
+    await service.putFile({
+      device: iosSimulatorDevice,
+      appId: "com.example.app",
+      container: "tmp",
+      contentText: "tmp",
+      destinationPath: "fixtures/value.txt",
+    });
+
+    await expect(fileSystem.readText(join(dataRoot, "Documents", "fixtures", "value.txt"))).resolves.toBe("documents");
+    await expect(fileSystem.readText(join(dataRoot, "Library", "Caches", "fixtures", "value.txt"))).resolves.toBe("cache");
+    await expect(fileSystem.readText(join(dataRoot, "tmp", "fixtures", "value.txt"))).resolves.toBe("tmp");
+  });
+
+  test("preserves iOS binary app files exactly when writing and reading", async () => {
+    const fileSystem = new TestAppFileFileSystem();
+    const dataRoot = "/simulators/SIM-1/data";
+    const simctl = new FakeSimCtlClient();
+    simctl.setCommandResult(
+      `get_app_container '${iosSimulatorDevice.deviceId}' 'com.example.app' data`,
+      dataRoot
+    );
+    const service = createAppFileServiceForTesting({
+      simctlFactory: () => simctl as any,
+      fileSystem,
+      deviceResolver: async () => iosSimulatorDevice,
+    });
+    const sourceBytes = Buffer.from([0, 1, 2, 239, 187, 191, 255]);
+    const sourcePath = "/host/fixtures/source.bin";
+    await fileSystem.writeFileBuffer(sourcePath, sourceBytes);
+
+    const putResult = await service.putFile({
+      device: iosSimulatorDevice,
+      appId: "com.example.app",
+      container: "documents",
+      sourcePath,
+      destinationPath: "fixtures/welcome.bin",
+    });
+    const readResult = await service.readFile({
+      deviceId: iosSimulatorDevice.deviceId,
+      appId: "com.example.app",
+      container: "documents",
+      path: "fixtures/welcome.bin",
+    });
+
+    expect(putResult.byteCount).toBe(sourceBytes.byteLength);
+    expect(readResult).toMatchObject({
+      deviceId: iosSimulatorDevice.deviceId,
+      platform: "ios",
+      appId: "com.example.app",
+      container: "documents",
+      path: "fixtures/welcome.bin",
+      byteCount: sourceBytes.byteLength,
+      mimeType: "application/octet-stream",
+      blob: sourceBytes.toString("base64"),
+    });
+    expect(readResult.text).toBeUndefined();
+  });
+
+  test("lists iOS app files and directories with relative metadata only", async () => {
+    const fileSystem = new TestAppFileFileSystem();
+    const dataRoot = "/simulators/SIM-1/data";
+    await fileSystem.mkdir(join(dataRoot, "Documents", "fixtures"));
+    await fileSystem.writeFileBuffer(join(dataRoot, "Documents", "root.txt"), Buffer.from("root"));
+    await fileSystem.writeFileBuffer(join(dataRoot, "Documents", "fixtures", "welcome.png"), Buffer.from([0, 1, 2]));
+    fileSystem.setSymlink(join(dataRoot, "Documents", "broken-link"));
+    const simctl = new FakeSimCtlClient();
+    simctl.setCommandResult(
+      `get_app_container '${iosSimulatorDevice.deviceId}' 'com.example.app' data`,
+      dataRoot
+    );
+    const service = createAppFileServiceForTesting({
+      simctlFactory: () => simctl as any,
+      fileSystem,
+      deviceResolver: async () => iosSimulatorDevice,
+    });
+
+    const result = await service.listFiles({
+      deviceId: iosSimulatorDevice.deviceId,
+      appId: "com.example.app",
+      container: "documents",
+    });
+
+    expect(result.files.map(file => file.path).sort()).toEqual([
+      "fixtures",
+      "fixtures/welcome.png",
+      "root.txt",
+    ]);
+    expect(result.files.every(file => !file.path.startsWith(dataRoot))).toBe(true);
+    expect(result.files.find(file => file.path === "fixtures")).toMatchObject({
+      name: "fixtures",
+      isDirectory: true,
+      resourceUri: `automobile:devices/${iosSimulatorDevice.deviceId}/apps/com.example.app/files/documents/fixtures`,
+    });
+    const fileEntry = result.files.find(file => file.path === "fixtures/welcome.png");
+    expect(fileEntry).toMatchObject({
+      name: "welcome.png",
+      byteCount: 3,
+      isDirectory: false,
+      resourceUri: `automobile:devices/${iosSimulatorDevice.deviceId}/apps/com.example.app/files/documents/fixtures/welcome.png`,
+    });
+    expect(fileEntry?.lastModified).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+  });
+
+  test("returns clear iOS simulator-only errors without invoking simctl for physical devices", async () => {
+    const simctl = new FakeSimCtlClient();
+    const service = createAppFileServiceForTesting({
+      simctlFactory: () => simctl as any,
+      fileSystem: new TestAppFileFileSystem(),
+      deviceResolver: async deviceId => ({ deviceId, name: "iPhone", platform: "ios" }),
+    });
+    const physicalDevice: BootedDevice = {
+      deviceId: "00008030-001A2B3C0E11002E",
+      name: "iPhone",
+      platform: "ios",
+    };
+
+    await expect(service.putFile({
+      device: physicalDevice,
+      appId: "com.example.app",
+      container: "documents",
+      contentText: "hello",
+      destinationPath: "config.txt",
+    })).rejects.toThrow("iOS app file putFile is only supported on iOS simulators");
+
+    await expect(service.listFiles({
+      deviceId: physicalDevice.deviceId,
+      appId: "com.example.app",
+      container: "documents",
+    })).rejects.toThrow("iOS app file listFiles is only supported on iOS simulators");
+    expect(simctl.getMethodCalls("executeCommand")).toHaveLength(0);
+  });
+
+  test("maps missing iOS app containers to actionable simulator errors", async () => {
+    const simctl = new FakeSimCtlClient();
+    simctl.setCommandError(
+      `get_app_container '${iosSimulatorDevice.deviceId}' 'com.missing.app' data`,
+      new Error("An error was encountered processing the command (domain=NSPOSIXErrorDomain, code=2): The application is not installed.")
+    );
+    const service = createAppFileServiceForTesting({
+      simctlFactory: () => simctl as any,
+      fileSystem: new TestAppFileFileSystem(),
+      deviceResolver: async () => iosSimulatorDevice,
+    });
+
+    await expect(service.readFile({
+      deviceId: iosSimulatorDevice.deviceId,
+      appId: "com.missing.app",
+      container: "documents",
+      path: "config.json",
+    })).rejects.toThrow("iOS app com.missing.app is not installed on simulator");
+  });
+
+  test("maps unavailable iOS simulators to actionable errors", async () => {
+    const simctl = new FakeSimCtlClient();
+    simctl.setCommandError(
+      `get_app_container '${iosSimulatorDevice.deviceId}' 'com.example.app' data`,
+      new Error("No such device or device is shutdown")
+    );
+    const service = createAppFileServiceForTesting({
+      simctlFactory: () => simctl as any,
+      fileSystem: new TestAppFileFileSystem(),
+      deviceResolver: async () => iosSimulatorDevice,
+    });
+
+    await expect(service.listFiles({
+      deviceId: iosSimulatorDevice.deviceId,
+      appId: "com.example.app",
+      container: "documents",
+    })).rejects.toThrow("iOS simulator AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE is unavailable or not booted");
+  });
+
+  test("does not let iOS app file paths escape the resolved app container", async () => {
+    const simctl = new FakeSimCtlClient();
+    const service = createAppFileServiceForTesting({
+      simctlFactory: () => simctl as any,
+      fileSystem: new TestAppFileFileSystem(),
+      deviceResolver: async () => iosSimulatorDevice,
+    });
+
+    await expect(service.readFile({
+      deviceId: iosSimulatorDevice.deviceId,
+      appId: "com.example.app",
+      container: "documents",
+      path: "../Library/Preferences/config.plist",
+    })).rejects.toThrow("destinationPath must be a non-empty relative path without '.' or '..' segments");
+
+    expect(simctl.getMethodCalls("executeCommand")).toHaveLength(0);
   });
 
   test("maps iOS externalFiles to explicit unsupported capability errors", async () => {
     const simctl = new FakeSimCtlClient();
     const service = createAppFileServiceForTesting({
       simctlFactory: () => simctl as any,
+      fileSystem: new TestAppFileFileSystem(),
       deviceResolver: async deviceId => ({ deviceId, name: "iPhone", platform: "ios" }),
     });
     const device: BootedDevice = {
-      deviceId: "SIM-1",
+      deviceId: iosSimulatorDevice.deviceId,
       name: "iPhone",
       platform: "ios",
     };
@@ -273,7 +488,7 @@ describe("AppFileService", () => {
     })).rejects.toThrow("putFile is not supported for appId com.example.app in externalFiles on ios");
 
     await expect(service.listFiles({
-      deviceId: "SIM-1",
+      deviceId: iosSimulatorDevice.deviceId,
       appId: "com.example.app",
       container: "externalFiles",
     })).rejects.toThrow("listFiles is not supported for appId com.example.app in externalFiles on ios");
@@ -491,29 +706,6 @@ describe("AppFileService", () => {
     );
   });
 
-  test("skips broken symlinks when listing iOS app container files", async () => {
-    const root = await mkdtemp(join(tmpdir(), "automobile-app-files-"));
-    tempDirs.push(root);
-    const dataRoot = join(root, "data");
-    const documentsRoot = join(dataRoot, "Documents");
-    await mkdir(documentsRoot, { recursive: true });
-    await writeFile(join(documentsRoot, "welcome.txt"), "hello");
-    await symlink(join(documentsRoot, "missing.txt"), join(documentsRoot, "broken-link"));
-    const simctl = new FakeSimCtlClient();
-    simctl.setCommandResult("get_app_container 'ios-sim-1' 'com.example.app' data", dataRoot);
-    const service = createAppFileServiceForTesting({
-      simctlFactory: () => simctl as any,
-      deviceResolver: async () => ({ deviceId: "ios-sim-1", name: "iPhone", platform: "ios" }),
-    });
-
-    const result = await service.listFiles({
-      deviceId: "ios-sim-1",
-      appId: "com.example.app",
-      container: "documents",
-    });
-
-    expect(result.files.map(file => file.path)).toEqual(["welcome.txt"]);
-  });
 });
 
 class RecordingAppFileProvider implements AppFileProvider {
@@ -531,5 +723,150 @@ class RecordingAppFileProvider implements AppFileProvider {
 
   async readFile(): Promise<never> {
     throw new Error(`${this.platform} readFile not supported in fake`);
+  }
+}
+
+class TestAppFileFileSystem implements AppFileFileSystem {
+  private readonly files = new Map<string, Buffer>();
+  private readonly directories = new Set<string>(["/"]);
+  private readonly symlinks = new Set<string>();
+  private tempIndex = 0;
+
+  async stat(path: string): Promise<AppFileStats> {
+    const normalized = this.normalize(path);
+    if (this.files.has(normalized)) {
+      return this.stats(this.files.get(normalized)?.byteLength ?? 0, "file");
+    }
+    if (this.directories.has(normalized)) {
+      return this.stats(0, "directory");
+    }
+    throw this.notFound(path);
+  }
+
+  async lstat(path: string): Promise<AppFileStats> {
+    const normalized = this.normalize(path);
+    if (this.symlinks.has(normalized)) {
+      return this.stats(0, "symlink");
+    }
+    return this.stat(path);
+  }
+
+  async readdir(path: string): Promise<Array<{ name: string }>> {
+    const normalized = this.normalize(path);
+    if (!this.directories.has(normalized)) {
+      throw this.notFound(path);
+    }
+    const prefix = normalized === "/" ? "/" : `${normalized}/`;
+    const names = new Set<string>();
+
+    for (const directory of this.directories) {
+      if (directory !== normalized && directory.startsWith(prefix)) {
+        names.add(directory.slice(prefix.length).split("/")[0] ?? "");
+      }
+    }
+    for (const file of this.files.keys()) {
+      if (file.startsWith(prefix)) {
+        names.add(file.slice(prefix.length).split("/")[0] ?? "");
+      }
+    }
+    for (const symlink of this.symlinks) {
+      if (symlink.startsWith(prefix)) {
+        names.add(symlink.slice(prefix.length).split("/")[0] ?? "");
+      }
+    }
+
+    return [...names].filter(Boolean).sort().map(name => ({ name }));
+  }
+
+  async mkdir(path: string): Promise<void> {
+    this.ensureDirectory(path);
+  }
+
+  async copyFile(sourcePath: string, destinationPath: string): Promise<void> {
+    const source = await this.readFileBuffer(sourcePath);
+    await this.writeFileBuffer(destinationPath, source);
+  }
+
+  async readFileBuffer(path: string): Promise<Buffer> {
+    const normalized = this.normalize(path);
+    const data = this.files.get(normalized);
+    if (data === undefined) {
+      throw this.notFound(path);
+    }
+    return Buffer.from(data);
+  }
+
+  async readText(path: string): Promise<string> {
+    return (await this.readFileBuffer(path)).toString("utf8");
+  }
+
+  async writeFileBuffer(path: string, data: Buffer): Promise<void> {
+    const normalized = this.normalize(path);
+    this.ensureDirectory(dirname(normalized));
+    this.files.set(normalized, Buffer.from(data));
+  }
+
+  async mkdtemp(prefix: string): Promise<string> {
+    const path = this.normalize(`${prefix}${++this.tempIndex}`);
+    this.ensureDirectory(path);
+    return path;
+  }
+
+  async rm(path: string): Promise<void> {
+    const normalized = this.normalize(path);
+    const prefix = normalized === "/" ? "/" : `${normalized}/`;
+
+    for (const file of [...this.files.keys()]) {
+      if (file === normalized || file.startsWith(prefix)) {
+        this.files.delete(file);
+      }
+    }
+    for (const symlink of [...this.symlinks]) {
+      if (symlink === normalized || symlink.startsWith(prefix)) {
+        this.symlinks.delete(symlink);
+      }
+    }
+    for (const directory of [...this.directories]) {
+      if (directory !== "/" && (directory === normalized || directory.startsWith(prefix))) {
+        this.directories.delete(directory);
+      }
+    }
+  }
+
+  setSymlink(path: string): void {
+    const normalized = this.normalize(path);
+    this.ensureDirectory(dirname(normalized));
+    this.symlinks.add(normalized);
+  }
+
+  private ensureDirectory(path: string): void {
+    const normalized = this.normalize(path);
+    const segments = normalized.split("/").filter(Boolean);
+    let current = normalized.startsWith("/") ? "/" : "";
+
+    for (const segment of segments) {
+      current = current === "/" || current === "" ? `${current}${segment}` : `${current}/${segment}`;
+      this.directories.add(current);
+    }
+  }
+
+  private normalize(path: string): string {
+    const normalized = path.replace(/\\/g, "/").replace(/\/+/g, "/");
+    return normalized.length > 1 && normalized.endsWith("/") ? normalized.slice(0, -1) : normalized;
+  }
+
+  private stats(size: number, kind: "file" | "directory" | "symlink"): AppFileStats {
+    return {
+      size,
+      mtime: new Date("2026-06-29T00:00:00.000Z"),
+      isFile: () => kind === "file",
+      isDirectory: () => kind === "directory",
+    };
+  }
+
+  private notFound(path: string): NodeJS.ErrnoException {
+    const error = new Error(`ENOENT: no such file or directory, ${path}`) as NodeJS.ErrnoException;
+    error.code = "ENOENT";
+    return error;
   }
 }


### PR DESCRIPTION
## Summary
- Implement iOS Simulator app-container file management for `putAppFile`, app-file listing resources, and app-file read resources.
- Resolve simulator app data containers with `simctl get_app_container ... data` and map logical containers to `Documents`, `Library`, `Library/Caches`, and `tmp`.
- Return relative list metadata without host container paths, preserve binary reads as MCP blobs, and surface actionable errors for physical iOS devices, missing apps, and unavailable simulators.
- Add an app-file filesystem dependency with fake filesystem tests for iOS provider behavior, including path traversal rejection and broken-symlink listing safety.
- Document iOS examples for `documents`, `cache`, and `tmp`, plus a manual simulator validation flow.

Closes #2571

## Testing
- `bun test test/server/appFileContract.test.ts test/server/appFileResources.test.ts test/server/appFileTools.test.ts test/server/appFileService.test.ts`
- `bun run lint`
- `bun run build`
- `bun test --bail`
- `bash scripts/all_fast_validate_checks.sh`
