### PR TITLE
[codex] fix plan yaml schema bundling

### DIFF
--- a/src/utils/plan/planYaml.ts
+++ b/src/utils/plan/planYaml.ts
@@ -1,5 +1,5 @@
 import * as yaml from "js-yaml";
 
 export const PLAN_YAML_LOAD_OPTIONS: yaml.LoadOptions = {
-  schema: yaml.CORE_SCHEMA.withTags(yaml.mergeTag),
+  schema: new yaml.Schema([...yaml.CORE_SCHEMA.tags, yaml.mergeTag]),
 };


### PR DESCRIPTION
## Summary

- Build plan YAML load options with `new yaml.Schema(...)` instead of `CORE_SCHEMA.withTags(...)`.
- Keep YAML merge-key support by including `yaml.mergeTag` alongside the core schema tags.

## Root Cause

Bun's minified bundle can lose the `withTags` prototype method on the `js-yaml` schema object, causing `auto-mobile --daemon restart` to crash at import time before the daemon command runs.

## Observed Failure

This was seen on `main` after rebuilding and installing the package locally:

```bash
bun run build
bun link
npm install -g
auto-mobile --daemon restart
```

The installed CLI crashed during startup while importing `src/utils/plan/planYaml.ts`:

```text
TypeError: hY0.withTags is not a function. (In 'hY0.withTags(void 0)', 'hY0.withTags' is undefined)
      at <anonymous> (.../src/utils/plan/planYaml.ts:4:28)
      at <anonymous> (.../dist/src/index.js:3:1039)
```

The failure happens before daemon restart logic runs because `planYaml.ts` is imported through the bundled server/plan-tool module graph.

## Validation

- `bun test test/utils/plan/PlanSerializer.test.ts test/plan/PlanSchemaValidator.test.ts test/plan/PlanValidator.test.ts`
- `bun run build`
- `bun run lint`
- `bun dist/src/index.js --daemon status`
