### PR TITLE
[codex] fix IntelliJ live view device disconnect handling

### DIFF
--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/AutoMobileContent.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/AutoMobileContent.kt
@@ -159,6 +159,24 @@ internal fun isActiveDeviceStreamFrame(deviceId: String?, activeDeviceId: String
   return activeDeviceId != null && deviceId == activeDeviceId
 }
 
+internal interface AutoMobileDeviceStreamEventSink {
+  fun disconnectLayout()
+
+  fun clearPerformanceMetrics()
+}
+
+internal class AutoMobileDeviceStreamEventHandler(
+    private val activeDeviceId: () -> String?,
+    private val sink: AutoMobileDeviceStreamEventSink,
+) {
+  fun handle(event: DeviceStreamEvent): DeviceStreamEvent.DeviceConnectionLost? {
+    val lostEvent = activeDeviceConnectionLostEvent(event, activeDeviceId()) ?: return null
+    sink.disconnectLayout()
+    sink.clearPerformanceMetrics()
+    return lostEvent
+  }
+}
+
 // Notification handler is injected via parameter
 
 enum class Dashboard(val title: String, val icon: String) {
@@ -603,8 +621,12 @@ fun AutoMobileContent(
     val baseDelayMs = 5000L
     val maxDelayMs = 60000L
     while (true) {
-      val delayMs = if (consecutiveFailures <= 1) baseDelayMs
-          else (baseDelayMs * (1L shl (consecutiveFailures - 1).coerceAtMost(4))).coerceAtMost(maxDelayMs)
+      val delayMs =
+          if (consecutiveFailures <= 1) baseDelayMs
+          else
+              (baseDelayMs * (1L shl (consecutiveFailures - 1).coerceAtMost(4))).coerceAtMost(
+                  maxDelayMs
+              )
       kotlinx.coroutines.delay(delayMs)
       kotlinx.coroutines.withContext(Dispatchers.IO) {
         try {
@@ -903,12 +925,24 @@ fun AutoMobileContent(
   // stale last frame for the active device.
   LaunchedEffect(observationStreamClient, activeDeviceId) {
     val client = observationStreamClient ?: return@LaunchedEffect
+    val clearLivePerformanceMetrics = { clearPerformanceMetrics() }
+    val eventHandler =
+        AutoMobileDeviceStreamEventHandler(
+            activeDeviceId = { activeDeviceId },
+            sink =
+                object : AutoMobileDeviceStreamEventSink {
+                  override fun disconnectLayout() {
+                    layoutInspectorState.disconnect()
+                  }
+
+                  override fun clearPerformanceMetrics() {
+                    clearLivePerformanceMetrics()
+                  }
+                },
+        )
     client.deviceEvents.collect { event ->
-      activeDeviceConnectionLostEvent(event, activeDeviceId)?.let { lostEvent ->
-        LOG.warn("Device connection lost for ${lostEvent.deviceId}: ${lostEvent.error}")
-        layoutInspectorState.disconnect()
-        clearPerformanceMetrics()
-      }
+      val lostEvent = eventHandler.handle(event) ?: return@collect
+      LOG.warn("Device connection lost for ${lostEvent.deviceId}: ${lostEvent.error}")
     }
   }
 
@@ -1088,7 +1122,11 @@ fun AutoMobileContent(
 
   // Search provider wired to telemetry events, navigation screens, and installed apps
   val searchProvider: SearchResultProvider =
-      remember(telemetryEventCache.size, telemetryEventCache.lastOrNull()?.timestamp, installedApps.size) {
+      remember(
+          telemetryEventCache.size,
+          telemetryEventCache.lastOrNull()?.timestamp,
+          installedApps.size,
+      ) {
         object : SearchResultProvider {
           override fun search(query: String): List<SearchResult> {
             if (query.isBlank()) return emptyList()
@@ -1725,13 +1763,16 @@ fun AutoMobileContent(
                         }
                     // Version slider — only shown when 2+ distinct versions exist
                     var minIdx by remember { mutableStateOf(0f) }
-                    var maxIdxState by remember { mutableStateOf((allVersions.size - 1).coerceAtLeast(0).toFloat()) }
+                    var maxIdxState by remember {
+                      mutableStateOf((allVersions.size - 1).coerceAtLeast(0).toFloat())
+                    }
                     if (allVersions.size >= 2) {
                       val maxIdx = (allVersions.size - 1).toFloat()
                       // Clamp state in case allVersions changed
                       val clampedMaxIdx = maxIdxState.coerceIn(0f, maxIdx)
                       val clampedMinIdx = minIdx.coerceIn(0f, clampedMaxIdx)
-                      val minVer = allVersions.getOrElse(clampedMinIdx.toInt()) { allVersions.first() }
+                      val minVer =
+                          allVersions.getOrElse(clampedMinIdx.toInt()) { allVersions.first() }
                       val maxVer =
                           allVersions.getOrElse(
                               clampedMaxIdx.toInt().coerceAtMost(allVersions.size - 1)
@@ -1972,7 +2013,11 @@ fun AutoMobileContent(
         },
         bottomPaneContent = {
           val spans =
-              remember(telemetryEventCache.size, telemetryEventCache.lastOrNull()?.timestamp, filteredTimelineCategories) {
+              remember(
+                  telemetryEventCache.size,
+                  telemetryEventCache.lastOrNull()?.timestamp,
+                  filteredTimelineCategories,
+              ) {
                 buildTimelineSpans(telemetryEventCache.toList(), filteredTimelineCategories)
               }
           val lanes = remember(spans) { activeLanes(spans) }

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/AutoMobileContentDeviceEventTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/AutoMobileContentDeviceEventTest.kt
@@ -9,6 +9,51 @@ import kotlin.test.assertTrue
 
 class AutoMobileContentDeviceEventTest {
   @Test
+  fun `handler disconnects layout and clears performance metrics for active device connection loss`() {
+    val sink = FakeDeviceStreamEventSink()
+    val handler =
+        AutoMobileDeviceStreamEventHandler(
+            activeDeviceId = { "emulator-5554" },
+            sink = sink,
+        )
+
+    handler.handle(deviceConnectionLostEvent(deviceId = "emulator-5554"))
+
+    assertEquals(1, sink.disconnectLayoutCalls)
+    assertEquals(1, sink.clearPerformanceMetricsCalls)
+  }
+
+  @Test
+  fun `handler ignores inactive device connection loss`() {
+    val sink = FakeDeviceStreamEventSink()
+    val handler =
+        AutoMobileDeviceStreamEventHandler(
+            activeDeviceId = { "emulator-5556" },
+            sink = sink,
+        )
+
+    handler.handle(deviceConnectionLostEvent(deviceId = "emulator-5554"))
+
+    assertEquals(0, sink.disconnectLayoutCalls)
+    assertEquals(0, sink.clearPerformanceMetricsCalls)
+  }
+
+  @Test
+  fun `handler ignores connection loss when no device is active`() {
+    val sink = FakeDeviceStreamEventSink()
+    val handler =
+        AutoMobileDeviceStreamEventHandler(
+            activeDeviceId = { null },
+            sink = sink,
+        )
+
+    handler.handle(deviceConnectionLostEvent(deviceId = "emulator-5554"))
+
+    assertEquals(0, sink.disconnectLayoutCalls)
+    assertEquals(0, sink.clearPerformanceMetricsCalls)
+  }
+
+  @Test
   fun `device connection lost event matches active device`() {
     val event = deviceConnectionLostEvent(deviceId = "emulator-5554")
 
@@ -31,12 +76,16 @@ class AutoMobileContentDeviceEventTest {
 
   @Test
   fun `stream frame matches active device`() {
-    assertTrue(isActiveDeviceStreamFrame(deviceId = "emulator-5554", activeDeviceId = "emulator-5554"))
+    assertTrue(
+        isActiveDeviceStreamFrame(deviceId = "emulator-5554", activeDeviceId = "emulator-5554")
+    )
   }
 
   @Test
   fun `stream frame ignores inactive device`() {
-    assertFalse(isActiveDeviceStreamFrame(deviceId = "emulator-5554", activeDeviceId = "emulator-5556"))
+    assertFalse(
+        isActiveDeviceStreamFrame(deviceId = "emulator-5554", activeDeviceId = "emulator-5556")
+    )
   }
 
   @Test
@@ -50,4 +99,20 @@ class AutoMobileContentDeviceEventTest {
           timestamp = 1234,
           error = "device connection lost",
       )
+
+  private class FakeDeviceStreamEventSink : AutoMobileDeviceStreamEventSink {
+    var disconnectLayoutCalls = 0
+      private set
+
+    var clearPerformanceMetricsCalls = 0
+      private set
+
+    override fun disconnectLayout() {
+      disconnectLayoutCalls++
+    }
+
+    override fun clearPerformanceMetrics() {
+      clearPerformanceMetricsCalls++
+    }
+  }
 }


### PR DESCRIPTION
## Summary
- Closes #2531.
- Route shipped `AutoMobileContent` device-stream disconnect handling through a small tested handler so device-side CtrlProxy connection loss clears the live layout state and performance summary for the active device.
- Keep active-device filtering centralized so disconnects from inactive devices or no active device do not blank the live view.

## Evaluation Criteria
- Active-device `DeviceConnectionLost` events disconnect the layout inspector state so the stale last frame is no longer presented as live.
- Active-device disconnects also clear live performance metrics.
- Inactive-device and missing-active-device events are ignored.
- Existing observation stream frame filtering remains unchanged.

## Testing
- `./gradlew :desktop-core:test --tests 'dev.jasonpearson.automobile.desktop.core.AutoMobileContentDeviceEventTest'`
- `./gradlew :desktop-core:test`
- `./scripts/all_fast_validate_checks.sh`

## Notes
- I did not find a checked-in `.github/PULL_REQUEST_TEMPLATE.md` or equivalent PR template in this repo, so this uses the repo's existing multiline `## Summary` / `## Testing` PR body convention.
