### PR TITLE
Gate iOS network mocks to debug builds

### DIFF
--- a/ios/auto-mobile-sdk/Sources/AutoMobileSDK/Network/AutoMobileNetwork.swift
+++ b/ios/auto-mobile-sdk/Sources/AutoMobileSDK/Network/AutoMobileNetwork.swift
@@ -436,6 +436,7 @@ public class AutoMobileURLProtocol: URLProtocol {
         receivedData = Data()
         totalBytesReceived = 0
 
+        #if DEBUG
         if AutoMobileSDK.shared.isEnabled,
            let url = request.url,
            let match = NetworkMockRuleStore.shared.findMatchingRule(
@@ -478,6 +479,7 @@ public class AutoMobileURLProtocol: URLProtocol {
             ))
             return
         }
+        #endif
 
         guard let mutableRequest = (request as NSURLRequest).mutableCopy() as? NSMutableURLRequest else {
             client?.urlProtocol(self, didFailWithError: URLError(.badURL))

--- a/ios/auto-mobile-sdk/Sources/AutoMobileSDK/Network/NetworkMockRuleStore.swift
+++ b/ios/auto-mobile-sdk/Sources/AutoMobileSDK/Network/NetworkMockRuleStore.swift
@@ -1,3 +1,4 @@
+#if DEBUG
 import Foundation
 
 struct NetworkMockRuleDTO: Codable, Equatable {
@@ -101,3 +102,4 @@ final class NetworkMockRuleStore: @unchecked Sendable {
         return regex.firstMatch(in: value, range: range) != nil
     }
 }
+#endif

--- a/ios/auto-mobile-sdk/Tests/AutoMobileSDKTests/NetworkTests.swift
+++ b/ios/auto-mobile-sdk/Tests/AutoMobileSDKTests/NetworkTests.swift
@@ -11,7 +11,9 @@ private final class EventCollector: @unchecked Sendable {
 final class AutoMobileNetworkTests: XCTestCase {
     override func tearDown() {
         AutoMobileNetwork.shared.reset()
+        #if DEBUG
         NetworkMockRuleStore.shared.setRules([])
+        #endif
         super.tearDown()
     }
 
@@ -246,6 +248,7 @@ final class AutoMobileNetworkTests: XCTestCase {
 
     // MARK: - Network Mock Rules
 
+    #if DEBUG
     func testNetworkMockRuleStoreMatchesWildcardMethodAndRegex() {
         let store = NetworkMockRuleStore()
         store.setRules([
@@ -389,4 +392,5 @@ final class AutoMobileNetworkTests: XCTestCase {
         XCTAssertEqual(event?.contentType, "application/json")
         XCTAssertEqual(event?.error, "mocked:mock-1")
     }
+    #endif
 }

--- a/scripts/ios/validate-network-mock-debug-only.sh
+++ b/scripts/ios/validate-network-mock-debug-only.sh
@@ -14,11 +14,15 @@ fail() {
 line_number() {
   local pattern="$1"
   local file="$2"
-  rg -n -m 1 "$pattern" "$file" | cut -d: -f1 || true
+  awk -v pattern="$pattern" '$0 ~ pattern { print NR; exit }' "$file"
 }
 
-first_significant_line="$(rg -n '^[[:space:]]*[^[:space:]]' "$STORE_FILE" | head -1 | cut -d: -f2-)"
-last_significant_line="$(rg -n '^[[:space:]]*[^[:space:]]' "$STORE_FILE" | tail -1 | cut -d: -f2-)"
+first_significant_line="$(
+  awk '/^[[:space:]]*[^[:space:]]/ { sub(/^[[:space:]]*/, ""); print; exit }' "$STORE_FILE"
+)"
+last_significant_line="$(
+  awk '/^[[:space:]]*[^[:space:]]/ { line = $0 } END { sub(/^[[:space:]]*/, "", line); print line }' "$STORE_FILE"
+)"
 
 [[ "$first_significant_line" == "#if DEBUG" ]] ||
   fail "NetworkMockRuleStore.swift must compile only inside #if DEBUG"

--- a/scripts/ios/validate-network-mock-debug-only.sh
+++ b/scripts/ios/validate-network-mock-debug-only.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+NETWORK_FILE="${ROOT_DIR}/ios/auto-mobile-sdk/Sources/AutoMobileSDK/Network/AutoMobileNetwork.swift"
+STORE_FILE="${ROOT_DIR}/ios/auto-mobile-sdk/Sources/AutoMobileSDK/Network/NetworkMockRuleStore.swift"
+
+fail() {
+  echo "error: $*" >&2
+  exit 1
+}
+
+line_number() {
+  local pattern="$1"
+  local file="$2"
+  rg -n -m 1 "$pattern" "$file" | cut -d: -f1 || true
+}
+
+first_significant_line="$(rg -n '^[[:space:]]*[^[:space:]]' "$STORE_FILE" | head -1 | cut -d: -f2-)"
+last_significant_line="$(rg -n '^[[:space:]]*[^[:space:]]' "$STORE_FILE" | tail -1 | cut -d: -f2-)"
+
+[[ "$first_significant_line" == "#if DEBUG" ]] ||
+  fail "NetworkMockRuleStore.swift must compile only inside #if DEBUG"
+
+[[ "$last_significant_line" == "#endif" ]] ||
+  fail "NetworkMockRuleStore.swift must close its file-level #if DEBUG guard"
+
+start_loading_line="$(line_number 'public override func startLoading\(\)' "$NETWORK_FILE")"
+mock_lookup_line="$(line_number 'NetworkMockRuleStore\.shared\.findMatchingRule' "$NETWORK_FILE")"
+forwarding_line="$(line_number 'guard let mutableRequest' "$NETWORK_FILE")"
+
+[[ -n "$start_loading_line" && -n "$mock_lookup_line" && -n "$forwarding_line" ]] ||
+  fail "expected startLoading, mock lookup, and forwarding fallback in AutoMobileNetwork.swift"
+
+debug_guard_line="$(
+  awk -v start="$start_loading_line" -v lookup="$mock_lookup_line" \
+    'NR > start && NR < lookup && /^[[:space:]]*#if DEBUG[[:space:]]*$/ { line = NR } END { if (line) print line }' \
+    "$NETWORK_FILE"
+)"
+endif_line="$(
+  awk -v lookup="$mock_lookup_line" -v fallback="$forwarding_line" \
+    'NR > lookup && NR < fallback && /^[[:space:]]*#endif[[:space:]]*$/ { print NR; exit }' \
+    "$NETWORK_FILE"
+)"
+
+[[ -n "$debug_guard_line" ]] ||
+  fail "AutoMobileURLProtocol mock lookup must be guarded by #if DEBUG"
+
+[[ -n "$endif_line" ]] ||
+  fail "AutoMobileURLProtocol mock lookup must close #if DEBUG before forwarding"
+
+echo "iOS network mock enforcement is DEBUG-only."

--- a/test/bats/validate-network-mock-debug-only.bats
+++ b/test/bats/validate-network-mock-debug-only.bats
@@ -1,0 +1,11 @@
+#!/usr/bin/env bats
+#
+# Tests for scripts/ios/validate-network-mock-debug-only.sh
+
+SCRIPT="scripts/ios/validate-network-mock-debug-only.sh"
+
+@test "network mock enforcement is guarded to debug builds" {
+  run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"iOS network mock enforcement is DEBUG-only."* ]]
+}


### PR DESCRIPTION
## Summary
- Wrap iOS network mock rule storage and URLProtocol mock matching in `#if DEBUG`.
- Keep existing debug mock behavior covered while preventing release builds from compiling mock enforcement.
- Add a BATS-backed validator for the DEBUG-only guard.

Closes #2637

## Testing
- `bats test/bats/validate-network-mock-debug-only.bats`
- `shellcheck scripts/ios/validate-network-mock-debug-only.sh`
- `bash scripts/ios/validate-network-mock-debug-only.sh`
- `swift test --package-path ios/auto-mobile-sdk --filter AutoMobileNetworkTests -Xswiftc -warnings-as-errors`
- `swift test --package-path ios/auto-mobile-sdk -Xswiftc -warnings-as-errors`
- `swift build --package-path ios/auto-mobile-sdk -c release -Xswiftc -warnings-as-errors`

## Notes
- `swift test --package-path ios/auto-mobile-sdk -c release -Xswiftc -warnings-as-errors` still fails in existing storage route tests that reference other DEBUG-only SDK database route types; the SDK release build passes.
- Touched-file SwiftFormat/SwiftLint validators report pre-existing style violations in `AutoMobileNetwork.swift`; this PR keeps the behavior diff scoped to the network mock release-build issue.
