### PR TITLE
Fix plan YAML merge schema for js-yaml v5

### DIFF
--- a/src/utils/plan/planYaml.ts
+++ b/src/utils/plan/planYaml.ts
@@ -1,5 +1,54 @@
 import * as yaml from "js-yaml";
 
+type SchemaWithTags = yaml.Schema & {
+  withTags?: (...tags: unknown[]) => yaml.Schema;
+};
+
+type SchemaWithExtend = yaml.Schema & {
+  extend?: (definition: { implicit?: unknown[]; explicit?: unknown[] }) => yaml.Schema;
+};
+
+type SchemaWithTagLists = {
+  implicit?: readonly unknown[];
+  explicit?: readonly unknown[];
+};
+
+function tagName(tag: unknown): unknown {
+  if (!tag || typeof tag !== "object") {
+    return undefined;
+  }
+
+  const record = tag as Record<string, unknown>;
+
+  return record.tagName ?? record.tag;
+}
+
+function findMergeTag(tags: readonly unknown[]): unknown {
+  return tags.find(tag => tagName(tag) === "tag:yaml.org,2002:merge");
+}
+
+function createPlanYamlSchema(): yaml.Schema {
+  const coreSchema = yaml.CORE_SCHEMA as SchemaWithTags & SchemaWithExtend;
+  const mergeTag = (yaml as typeof yaml & { mergeTag?: unknown }).mergeTag;
+
+  if (mergeTag && typeof coreSchema.withTags === "function") {
+    return coreSchema.withTags(mergeTag);
+  }
+
+  const defaultSchema = (yaml as typeof yaml & { DEFAULT_SCHEMA?: SchemaWithTagLists }).DEFAULT_SCHEMA;
+  const defaultTags = [
+    ...(defaultSchema?.implicit ?? []),
+    ...(defaultSchema?.explicit ?? []),
+  ];
+  const defaultMergeTag = findMergeTag(defaultTags);
+
+  if (defaultMergeTag && typeof coreSchema.extend === "function") {
+    return coreSchema.extend({ implicit: [defaultMergeTag] });
+  }
+
+  throw new Error("js-yaml merge tag support is not available");
+}
+
 export const PLAN_YAML_LOAD_OPTIONS: yaml.LoadOptions = {
-  schema: new yaml.Schema([...yaml.CORE_SCHEMA.tags, yaml.mergeTag]),
+  schema: createPlanYamlSchema(),
 };

--- a/test/utils/plan/planYaml.test.ts
+++ b/test/utils/plan/planYaml.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, test } from "bun:test";
+import * as yaml from "js-yaml";
+import { PLAN_YAML_LOAD_OPTIONS } from "../../../src/utils/plan/planYaml";
+
+describe("PLAN_YAML_LOAD_OPTIONS", () => {
+  test("loads YAML merge keys", () => {
+    const loaded = yaml.load(`
+defaults: &defaults
+  tool: tapOn
+  params:
+    selector:
+      text: Save
+step:
+  <<: *defaults
+  label: Tap save
+`, PLAN_YAML_LOAD_OPTIONS) as {
+      step: {
+        tool: string;
+        params: { selector: { text: string } };
+        label: string;
+      };
+    };
+
+    expect(loaded.step).toEqual({
+      tool: "tapOn",
+      params: { selector: { text: "Save" } },
+      label: "Tap save",
+    });
+  });
+
+  test("keeps timestamp-like plain scalars as strings", () => {
+    const loaded = yaml.load("when: 12:30:00\n", PLAN_YAML_LOAD_OPTIONS) as { when: unknown };
+
+    expect(loaded.when).toBe("12:30:00");
+  });
+});


### PR DESCRIPTION
## Summary
- Fix plan YAML load options so they no longer depend on spreading `CORE_SCHEMA.tags`
- Preserve CORE schema scalar behavior while enabling YAML merge keys
- Add focused tests for merge-key support and timestamp-like scalar typing

Closes #2635

## Testing
- `bun test test/utils/plan/planYaml.test.ts`
- `bun test test/utils/plan/PlanSerializer.test.ts test/utils/plan/planYaml.test.ts`
- `bash scripts/update-tool-definitions.sh`
- `bun run lint`
- `bun run build`
- `bash scripts/all_fast_validate_checks.sh`
- `bun test --bail`
