### PR TITLE
fix: avoid stale launch observations

### DIFF
--- a/src/features/action/LaunchApp.ts
+++ b/src/features/action/LaunchApp.ts
@@ -1,6 +1,6 @@
 import { AdbClient } from "../../utils/android-cmdline-tools/AdbClient";
 import { BaseVisualChange } from "./BaseVisualChange";
-import { BootedDevice, LaunchAppResult } from "../../models";
+import { BootedDevice, LaunchAppResult, ObserveResult } from "../../models";
 import { ActionableError } from "../../models";
 import { TerminateApp } from "./TerminateApp";
 import { ClearAppData } from "./ClearAppData";
@@ -16,6 +16,9 @@ import { Timer, defaultTimer } from "../../utils/SystemTimer";
 import { IOSCtrlProxyClient } from "../observe/ios";
 import { IOSCtrlProxyManager } from "../../utils/IOSCtrlProxyManager";
 import { AndroidCtrlProxyClient } from "../observe/android";
+
+const LAUNCH_OBSERVATION_TIMEOUT_MS = 5000;
+const LAUNCH_OBSERVATION_POLL_INTERVAL_MS = 200;
 
 export interface TargetUserDetector {
   detectTargetUserId(packageName: string, userId?: number): Promise<number>;
@@ -245,7 +248,7 @@ export class LaunchApp extends BaseVisualChange {
 
     const isSystemBundleId = bundleId.startsWith("com.apple.");
 
-    return this.observedInteraction(
+    const result = await this.observedInteraction(
       async () => {
         // Set bundle ID before starting CtrlProxy so it targets the app, not SpringBoard
         if (!isSystemBundleId) {
@@ -377,6 +380,8 @@ export class LaunchApp extends BaseVisualChange {
         overrideMinTimestamp: 0
       }
     );
+
+    return this.ensureLaunchObservationMatchesPackage(result, bundleId);
   }
 
   private async waitForIosHierarchyReady(
@@ -635,13 +640,16 @@ export class LaunchApp extends BaseVisualChange {
           );
         }
         const launchOutcome = await this.performLaunch(packageName, activityName, targetUserId, perf);
-        await this.waitForAppForeground(
+        const foregroundReady = await this.waitForAppForeground(
           packageName,
           targetUserId,
           foregroundWaitTimeoutMs,
           foregroundPollIntervalMs,
           perf
         );
+        if (!foregroundReady) {
+          logger.warn(`[LaunchApp] ${packageName} did not become the foreground app before observation; continuing to validate launch observation`);
+        }
         observationTimestampMs = await this.adb.getDeviceTimestampMs();
         return launchOutcome;
       },
@@ -655,8 +663,10 @@ export class LaunchApp extends BaseVisualChange {
       }
     );
 
-    logger.info(`[LaunchApp] TTI capture check: collector=${!!displayedMetricsCollector}, startMs=${displayedMetricsStartMs}, hasObservation=${!!launchResult?.observation}`);
-    if (displayedMetricsCollector && displayedMetricsStartMs !== null && launchResult?.observation) {
+    const settledLaunchResult = await this.ensureLaunchObservationMatchesPackage(launchResult, packageName);
+
+    logger.info(`[LaunchApp] TTI capture check: collector=${!!displayedMetricsCollector}, startMs=${displayedMetricsStartMs}, hasObservation=${!!settledLaunchResult?.observation}`);
+    if (displayedMetricsCollector && displayedMetricsStartMs !== null && settledLaunchResult?.observation) {
       const displayedMetricsEndMs = await perf.track(
         "displayedLogcatEndTime",
         () => this.adb.getDeviceTimestampMs()
@@ -671,7 +681,7 @@ export class LaunchApp extends BaseVisualChange {
         perf
       );
       logger.info(`[LaunchApp] Captured ${displayedTimeMetrics.length} displayed metrics`);
-      launchResult.observation.displayedTimeMetrics = displayedTimeMetrics;
+      settledLaunchResult.observation.displayedTimeMetrics = displayedTimeMetrics;
 
       // Store TTI for the performance monitor to report
       // Use the first displayed metric as the TTI (time to first frame / interactive)
@@ -686,7 +696,98 @@ export class LaunchApp extends BaseVisualChange {
       logger.info(`[LaunchApp] Skipping TTI capture - conditions not met`);
     }
 
-    return launchResult;
+    return settledLaunchResult;
+  }
+
+  private async ensureLaunchObservationMatchesPackage(
+    result: LaunchAppResult,
+    expectedPackageName: string,
+    timeoutMs: number = LAUNCH_OBSERVATION_TIMEOUT_MS,
+    pollIntervalMs: number = LAUNCH_OBSERVATION_POLL_INTERVAL_MS
+  ): Promise<LaunchAppResult> {
+    if (!result.observation || this.launchObservationMatchesPackage(result.observation, expectedPackageName)) {
+      return result;
+    }
+
+    if (!result.success) {
+      return this.withoutStaleLaunchObservation(result, expectedPackageName, result.observation);
+    }
+
+    const startTime = this.timer.now();
+    let latestObservation = result.observation;
+
+    while (this.timer.now() - startTime < timeoutMs) {
+      logger.info(`[LaunchApp] Launch observation still reports previous app; re-observing for ${expectedPackageName}`);
+      await this.timer.sleep(pollIntervalMs);
+      latestObservation = await this.observeScreen.execute({ skipWaitForFresh: false });
+      if (this.launchObservationMatchesPackage(latestObservation, expectedPackageName)) {
+        result.observation = this.preserveLaunchObservationMetadata(latestObservation, result.observation);
+        return result;
+      }
+    }
+
+    return this.withoutStaleLaunchObservation(
+      {
+        ...result,
+        success: false,
+        error: `Timed out waiting for launch observation to show ${expectedPackageName}; last observation reported ${this.describeLaunchObservationPackages(latestObservation)}`
+      },
+      expectedPackageName,
+      latestObservation
+    );
+  }
+
+  private withoutStaleLaunchObservation(
+    result: LaunchAppResult,
+    expectedPackageName: string,
+    staleObservation: ObserveResult
+  ): LaunchAppResult {
+    logger.warn(
+      `[LaunchApp] Omitting stale launch observation for ${expectedPackageName}; ` +
+      `last observation reported ${this.describeLaunchObservationPackages(staleObservation)}`
+    );
+    const resultWithoutObservation = { ...result };
+    delete resultWithoutObservation.observation;
+    return resultWithoutObservation;
+  }
+
+  private preserveLaunchObservationMetadata(
+    observation: ObserveResult,
+    previousObservation: ObserveResult
+  ): ObserveResult {
+    return {
+      ...observation,
+      gfxMetrics: observation.gfxMetrics ?? previousObservation.gfxMetrics,
+      perfTiming: observation.perfTiming ?? previousObservation.perfTiming
+    };
+  }
+
+  private launchObservationMatchesPackage(observation: ObserveResult, expectedPackageName: string): boolean {
+    if (this.isLaunchPermissionDialogObservation(observation)) {
+      return true;
+    }
+
+    const packageNames = this.getLaunchObservationPackageNames(observation);
+    return packageNames.length === 0 || packageNames.every(packageName => packageName === expectedPackageName);
+  }
+
+  private isLaunchPermissionDialogObservation(observation: ObserveResult): boolean {
+    return observation.notificationPermissionDetected === true &&
+      observation.activeWindow?.type === "notification_permission_dialog";
+  }
+
+  private describeLaunchObservationPackages(observation: ObserveResult): string {
+    const packageNames = this.getLaunchObservationPackageNames(observation);
+    return packageNames.length > 0 ? packageNames.join(", ") : "unknown app";
+  }
+
+  private getLaunchObservationPackageNames(observation: ObserveResult): string[] {
+    const packageNames = [
+      observation.activeWindow?.appId,
+      observation.viewHierarchy?.packageName
+    ].filter((packageName): packageName is string => !!packageName);
+
+    return [...new Set(packageNames)];
   }
 
   /**

--- a/test/features/action/LaunchApp.test.ts
+++ b/test/features/action/LaunchApp.test.ts
@@ -27,11 +27,12 @@ describe("LaunchApp", () => {
 
   const packageName = "com.example.app";
 
-  const createObserveResult = (): ObserveResult => ({
+  const createObserveResult = (appId?: string): ObserveResult => ({
     updatedAt: Date.now(),
     screenSize: { width: 1080, height: 1920 },
     systemInsets: { top: 0, bottom: 0, left: 0, right: 0 },
-    viewHierarchy: { node: {} }
+    viewHierarchy: appId ? { node: {}, packageName: appId } as any : { node: {} },
+    activeWindow: appId ? { appId, activityName: "MainActivity", layoutSeqSum: 1 } : undefined
   });
 
   const configureInstalledApp = () => {
@@ -95,6 +96,67 @@ describe("LaunchApp", () => {
     expect(result.success).toBe(true);
     expect(result.observation).toBeDefined();
     expect(fakeTimer.getSleepCallCount()).toBeGreaterThan(0);
+  });
+
+  test("re-observes until the launch observation reports the launched Android app", async () => {
+    fakeTimer.enableAutoAdvance();
+    const previousPackageName = "com.example.previous";
+    const observations = [
+      createObserveResult(previousPackageName),
+      createObserveResult(packageName)
+    ];
+
+    fakeAdb.setForegroundApp({ packageName, userId: 0 });
+    fakeAdb.setCommandResponse(`shell ps | grep ${packageName}`, { stdout: "0\n", stderr: "" });
+    fakeObserveScreen.setObserveResult(() => observations.shift() ?? createObserveResult(packageName));
+
+    const result = await launchApp.execute(packageName, false, false);
+
+    expect(result.success).toBe(true);
+    expect(result.observation?.activeWindow?.appId).toBe(packageName);
+    expect(result.observation?.viewHierarchy?.packageName).toBe(packageName);
+    expect(fakeObserveScreen.getExecuteCallCount()).toBeGreaterThan(1);
+  });
+
+  test("treats Android notification permission dialogs as valid launch observations", async () => {
+    fakeTimer.enableAutoAdvance();
+    const permissionControllerPackageName = "com.google.android.permissioncontroller";
+
+    fakeAdb.setForegroundApp({ packageName: permissionControllerPackageName, userId: 0 });
+    fakeAdb.setCommandResponse(`shell ps | grep ${packageName}`, { stdout: "0\n", stderr: "" });
+    fakeObserveScreen.setObserveResult({
+      ...createObserveResult(permissionControllerPackageName),
+      activeWindow: {
+        appId: permissionControllerPackageName,
+        activityName: "GrantPermissionsActivity",
+        layoutSeqSum: 1,
+        type: "notification_permission_dialog"
+      },
+      notificationPermissionDetected: true
+    });
+
+    const result = await launchApp.execute(packageName, false, false);
+
+    expect(result.success).toBe(true);
+    expect(result.observation?.notificationPermissionDetected).toBe(true);
+    expect(result.observation?.activeWindow?.type).toBe("notification_permission_dialog");
+    expect(result.observation?.activeWindow?.appId).toBe(permissionControllerPackageName);
+    expect(fakeObserveScreen.getExecuteCallCount()).toBe(1);
+  });
+
+  test("fails without embedding a stale Android observation when the launched app never appears", async () => {
+    fakeTimer.enableAutoAdvance();
+    const previousPackageName = "com.example.previous";
+
+    fakeAdb.setForegroundApp({ packageName, userId: 0 });
+    fakeAdb.setCommandResponse(`shell ps | grep ${packageName}`, { stdout: "0\n", stderr: "" });
+    fakeObserveScreen.setObserveResult(() => createObserveResult(previousPackageName));
+
+    const result = await launchApp.execute(packageName, false, false);
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain(`Timed out waiting for launch observation to show ${packageName}`);
+    expect(result.observation).toBeUndefined();
   });
 
   test("runs target user detection and install check in parallel", async () => {
@@ -352,6 +414,63 @@ describe("LaunchApp", () => {
         // bundle ID via SIMCTL_CHILD_CTRL_PROXY_IOS_BUNDLE_ID when it starts.
         expect(callOrder.indexOf(`setTargetBundleId:${userBundleId}`))
           .toBeLessThan(callOrder.indexOf(`simctlLaunch:${userBundleId}`));
+      } finally {
+        ctrlProxySpy.mockRestore();
+        managerSpy.mockRestore();
+      }
+    });
+
+    test("re-observes until the iOS launch observation hierarchy reports the launched bundle", async () => {
+      fakeTimer.enableAutoAdvance();
+      const iosDevice: BootedDevice = { name: "test-ios", platform: "ios", deviceId: "ios-observation" };
+      const previousBundleId = "com.apple.Maps";
+      const observations = [
+        {
+          updatedAt: Date.now(),
+          screenSize: { width: 1080, height: 1920 },
+          systemInsets: { top: 0, bottom: 0, left: 0, right: 0 },
+          viewHierarchy: { hierarchy: { node: {} }, packageName: previousBundleId } as any,
+        },
+        {
+          updatedAt: Date.now(),
+          screenSize: { width: 1080, height: 1920 },
+          systemInsets: { top: 0, bottom: 0, left: 0, right: 0 },
+          viewHierarchy: { hierarchy: { node: {} }, packageName: userBundleId } as any,
+        },
+      ];
+
+      const ctrlProxySpy = spyOn(IOSCtrlProxyClient, "getInstance").mockReturnValue(
+        new FakeIOSCtrlProxy() as unknown as IOSCtrlProxyClient
+      );
+      const managerSpy = spyOn(IOSCtrlProxyManager, "getInstance").mockReturnValue({
+        setTargetBundleId: () => {},
+      } as unknown as IOSCtrlProxyManager);
+      const fakeSimctl = {
+        launchApp: async () => ({ success: true, pid: 123 }),
+        terminateApp: async () => {},
+      };
+      const iosObserveScreen = new FakeObserveScreen();
+      iosObserveScreen.setObserveResult(() => observations.shift() ?? {
+        updatedAt: Date.now(),
+        screenSize: { width: 1080, height: 1920 },
+        systemInsets: { top: 0, bottom: 0, left: 0, right: 0 },
+        viewHierarchy: { hierarchy: { node: {} }, packageName: userBundleId } as any,
+      });
+      const iosWindow = new FakeWindow();
+      iosWindow.configureCachedActiveWindow({ appId: userBundleId, activityName: "Main", layoutSeqSum: 1 });
+      const installedApps = new FakeInstalledAppsProvider(fakeTimer, { installedApps: [userBundleId] });
+
+      const iosLaunchApp = new LaunchApp(iosDevice, fakeAdb as unknown as any, fakeSimctl as any, fakeTimer, { installedAppsProvider: installedApps });
+      (iosLaunchApp as any).awaitIdle = new FakeAwaitIdle();
+      (iosLaunchApp as any).observeScreen = iosObserveScreen;
+      (iosLaunchApp as any).window = iosWindow;
+      (iosLaunchApp as any).waitForIosHierarchyReady = async () => {};
+
+      try {
+        const result = await iosLaunchApp.execute(userBundleId, false, false);
+        expect(result.success).toBe(true);
+        expect(result.observation?.viewHierarchy?.packageName).toBe(userBundleId);
+        expect(iosObserveScreen.getExecuteCallCount()).toBeGreaterThan(1);
       } finally {
         ctrlProxySpy.mockRestore();
         managerSpy.mockRestore();


### PR DESCRIPTION
## Summary
- Closes #2641.
- Make `launchApp` verify its embedded observation after launch so known package fields (`activeWindow.appId` and hierarchy `packageName`) do not report the previous foreground app.
- Re-observe briefly when launch/foreground detection succeeds but the embedded observation still names another app; if the target app never appears in the observation, fail explicitly and omit the stale observation.
- Preserve launch observation metadata such as `gfxMetrics` and `perfTiming` when replacing a stale observation with a matching one.

## Evaluation Criteria
- Android `launchApp` does not return success with an embedded observation from the previous foreground app.
- iOS `launchApp` does not return success with a hierarchy package from the previous foreground app.
- If the launched app never appears in the embedded observation before timeout, the result is an explicit failure and does not include the stale observation.
- Existing launch behavior for already-foreground apps, target bundle setup, clear-data flows, and displayed metrics remains intact.

## Testing
- `bun test test/features/action/LaunchApp.test.ts`
- `bun run lint`
- `bun run build`
- `bun test`
- `bash scripts/all_fast_validate_checks.sh`

## Notes
- I did not find a checked-in `.github/PULL_REQUEST_TEMPLATE.md` or equivalent PR template in this repo, so this uses the repo's existing multiline `## Summary` / `## Evaluation Criteria` / `## Testing` PR body convention.
