### PR TITLE
Fix doctor daemon and CtrlProxy status

### DIFF
--- a/src/daemon/debugTools.ts
+++ b/src/daemon/debugTools.ts
@@ -26,10 +26,20 @@ export interface DaemonHealthReport {
   recommendations: string[];
 }
 
+export interface DaemonHealthReportOptions {
+  socketPath?: string;
+  pidFilePath?: string;
+}
+
 /**
  * Get comprehensive daemon health report
  */
-export async function getDaemonHealthReport(timer: Timer = defaultTimer): Promise<DaemonHealthReport> {
+export async function getDaemonHealthReport(
+  timer: Timer = defaultTimer,
+  options: DaemonHealthReportOptions = {}
+): Promise<DaemonHealthReport> {
+  const socketPath = options.socketPath ?? SOCKET_PATH;
+  const pidFilePath = options.pidFilePath ?? PID_FILE_PATH;
   const report: DaemonHealthReport = {
     timestamp: new Date().toISOString(),
     daemonRunning: false,
@@ -42,7 +52,7 @@ export async function getDaemonHealthReport(timer: Timer = defaultTimer): Promis
   };
 
   // Check socket file
-  report.socketExists = existsSync(SOCKET_PATH);
+  report.socketExists = existsSync(socketPath);
   if (!report.socketExists) {
     report.recommendations.push("Socket file not found. Daemon may not be running.");
   } else {
@@ -50,14 +60,14 @@ export async function getDaemonHealthReport(timer: Timer = defaultTimer): Promis
   }
 
   // Check PID file
-  report.pidFileExists = existsSync(PID_FILE_PATH);
+  report.pidFileExists = existsSync(pidFilePath);
   if (!report.pidFileExists) {
     if (report.socketExists) {
       report.recommendations.push("Socket exists but PID file missing. Daemon may be in bad state.");
     }
   } else {
     try {
-      const pidContent = await readFile(PID_FILE_PATH, "utf-8");
+      const pidContent = await readFile(pidFilePath, "utf-8");
       const pidData: PidFileData = JSON.parse(pidContent);
       report.pidFileValid = true;
       report.daemonPid = pidData.pid;
@@ -83,15 +93,21 @@ export async function getDaemonHealthReport(timer: Timer = defaultTimer): Promis
     }
   }
 
-  // Try to connect to socket to verify daemon responsiveness
-  if (report.socketExists && report.daemonRunning) {
+  // Try to connect to socket to verify daemon responsiveness. A daemon can be
+  // serving via socket even when PID bookkeeping is stale or missing.
+  if (report.socketExists) {
     try {
-      const available = await DaemonClient.isAvailable(SOCKET_PATH);
+      const available = await DaemonClient.isAvailable(socketPath);
       report.socketConnectable = available;
       if (!available) {
         report.recommendations.push(
-          "Socket file exists and process is running, but socket is not responding. " +
+          "Socket file exists, but socket is not responding. " +
           "Daemon may be stuck or unresponsive."
+        );
+      } else if (!report.daemonRunning) {
+        report.daemonRunning = true;
+        report.recommendations.push(
+          "Daemon socket is responsive, but PID bookkeeping is stale or missing."
         );
       }
     } catch (error) {

--- a/src/doctor/checks/automobile.ts
+++ b/src/doctor/checks/automobile.ts
@@ -4,8 +4,11 @@
  */
 
 import { CheckResult } from "../types";
+import type { DoctorOptions } from "../types";
 import { DaemonManager } from "../../daemon/manager";
 import { getDaemonHealthReport } from "../../daemon/debugTools";
+import type { DaemonHealthReport } from "../../daemon/debugTools";
+import type { DaemonStatus } from "../../daemon/types";
 import { LATEST_RELEASE_VERSION, RELEASE_VERSION, resolveAssetVersion } from "../../constants/release";
 import { getMcpServerVersion } from "../../utils/mcpVersion";
 import { defaultAdbClientFactory } from "../../utils/android-cmdline-tools/AdbClientFactory";
@@ -14,6 +17,20 @@ import { AndroidCtrlProxyManager } from "../../utils/CtrlProxyManager";
 import { logger } from "../../utils/logger";
 
 const RELEASES_URL = "https://github.com/kaeawc/auto-mobile/releases";
+
+interface DaemonStatusManager {
+  status(): Promise<DaemonStatus>;
+}
+
+export interface DaemonStatusDependencies {
+  daemonManager?: DaemonStatusManager;
+  getDaemonHealthReport?: () => Promise<DaemonHealthReport>;
+}
+
+export interface AutoMobileCheckDependencies {
+  checkDaemonStatus?: () => Promise<CheckResult>;
+  checkDaemonConnectivity?: () => Promise<CheckResult>;
+}
 
 /**
  * Report the daemon JS package version, sourced from package.json.
@@ -46,9 +63,21 @@ export function checkCtrlProxyVersion(): CheckResult {
 /**
  * Check daemon status
  */
-async function checkDaemonStatus(): Promise<CheckResult> {
+export async function checkDaemonStatus(
+  dependencies: DaemonStatusDependencies = {}
+): Promise<CheckResult> {
   try {
-    const manager = new DaemonManager();
+    const report = await (dependencies.getDaemonHealthReport ?? getDaemonHealthReport)();
+    if (report.socketConnectable) {
+      return {
+        name: "Daemon Status",
+        status: "pass",
+        message: "Running (serving via socket)",
+        ...(report.daemonPid !== undefined ? { value: report.daemonPid } : {}),
+      };
+    }
+
+    const manager = dependencies.daemonManager ?? new DaemonManager();
     const status = await manager.status();
 
     if (status.running) {
@@ -79,9 +108,11 @@ async function checkDaemonStatus(): Promise<CheckResult> {
 /**
  * Check daemon connectivity
  */
-async function checkDaemonConnectivity(): Promise<CheckResult> {
+export async function checkDaemonConnectivity(
+  getHealthReport: () => Promise<DaemonHealthReport> = getDaemonHealthReport
+): Promise<CheckResult> {
   try {
-    const report = await getDaemonHealthReport();
+    const report = await getHealthReport();
 
     if (report.socketConnectable) {
       return {
@@ -144,6 +175,7 @@ export async function checkCtrlProxy(
     const isEnabled = await serviceManager.isEnabled();
 
     const diagnostics: string[] = [
+      `platform=${device.platform}`,
       `device=${device.deviceId}`,
       `installed=${isInstalled}`,
       `enabled=${isEnabled}`
@@ -331,15 +363,32 @@ export async function checkWorkProfileAccessibility(
 /**
  * Run all AutoMobile checks
  */
-export async function runAutoMobileChecks(): Promise<CheckResult[]> {
+export async function runAutoMobileChecks(
+  options: DoctorOptions = {},
+  dependencies: AutoMobileCheckDependencies = {}
+): Promise<CheckResult[]> {
   const results: CheckResult[] = [];
 
   results.push(checkDaemonVersion());
   results.push(checkCtrlProxyVersion());
-  results.push(await checkDaemonStatus());
-  results.push(await checkDaemonConnectivity());
-  results.push(await checkCtrlProxy());
-  results.push(await checkWorkProfileAccessibility());
+  results.push(await (dependencies.checkDaemonStatus ?? (() => checkDaemonStatus()))());
+  results.push(await (dependencies.checkDaemonConnectivity ?? (() => checkDaemonConnectivity()))());
+
+  if (options.ios === true && options.android !== true) {
+    results.push({
+      name: "CtrlProxy",
+      status: "skip",
+      message: "Skipped for iOS-only doctor run",
+    });
+    results.push({
+      name: "Work Profile Accessibility",
+      status: "skip",
+      message: "Skipped for iOS-only doctor run",
+    });
+  } else {
+    results.push(await checkCtrlProxy());
+    results.push(await checkWorkProfileAccessibility());
+  }
 
   return results;
 }

--- a/src/doctor/index.ts
+++ b/src/doctor/index.ts
@@ -88,7 +88,7 @@ export async function runDoctor(
   }
 
   // Always run AutoMobile checks
-  const autoMobileChecks = await runAutoMobileChecks();
+  const autoMobileChecks = await runAutoMobileChecks(options);
   allChecks.push(...autoMobileChecks);
 
   // Calculate summary and recommendations

--- a/test/daemon/debugTools.test.ts
+++ b/test/daemon/debugTools.test.ts
@@ -1,0 +1,46 @@
+import { afterEach, describe, expect, spyOn, test } from "bun:test";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { DaemonClient } from "../../src/daemon/client";
+import { getDaemonHealthReport } from "../../src/daemon/debugTools";
+
+describe("getDaemonHealthReport", () => {
+  const tempDirs: string[] = [];
+
+  afterEach(() => {
+    for (const dir of tempDirs) {
+      rmSync(dir, { recursive: true, force: true });
+    }
+    tempDirs.length = 0;
+  });
+
+  test("treats a responsive socket as running when PID bookkeeping is missing", async () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "automobile-daemon-health-"));
+    tempDirs.push(tempDir);
+    const socketPath = join(tempDir, "daemon.sock");
+    const pidPath = join(tempDir, "daemon.pid");
+    mkdirSync(dirname(socketPath), { recursive: true });
+    writeFileSync(socketPath, "");
+
+    const isAvailable = spyOn(DaemonClient, "isAvailable").mockResolvedValue(true);
+
+    try {
+      const report = await getDaemonHealthReport(undefined, {
+        socketPath,
+        pidFilePath: pidPath,
+      });
+
+      expect(isAvailable).toHaveBeenCalledWith(socketPath);
+      expect(report.socketExists).toBe(true);
+      expect(report.pidFileExists).toBe(false);
+      expect(report.socketConnectable).toBe(true);
+      expect(report.daemonRunning).toBe(true);
+      expect(report.recommendations).toContain(
+        "Daemon socket is responsive, but PID bookkeeping is stale or missing."
+      );
+    } finally {
+      isAvailable.mockRestore();
+    }
+  });
+});

--- a/test/doctor/automobile.test.ts
+++ b/test/doctor/automobile.test.ts
@@ -2,7 +2,9 @@ import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import {
   checkCtrlProxy,
   checkCtrlProxyVersion,
+  checkDaemonStatus,
   checkDaemonVersion,
+  runAutoMobileChecks,
 } from "../../src/doctor/checks/automobile";
 import {
   LATEST_RELEASE_VERSION,
@@ -42,6 +44,57 @@ describe("checkCtrlProxyVersion", () => {
     if (RELEASE_VERSION === LATEST_RELEASE_VERSION) {
       expect(result.message).toMatch(/\(latest\)$/);
     }
+  });
+});
+
+describe("checkDaemonStatus", () => {
+  test("probes daemon socket before invoking status cleanup", async () => {
+    const result = await checkDaemonStatus({
+      daemonManager: {
+        status: async () => {
+          throw new Error("status should not run before socket probe succeeds");
+        },
+      },
+      getDaemonHealthReport: async () => ({
+        timestamp: "2026-06-29T00:00:00.000Z",
+        daemonRunning: true,
+        socketExists: true,
+        socketAccessible: true,
+        pidFileExists: true,
+        pidFileValid: true,
+        daemonPid: 12345,
+        socketConnectable: true,
+        recommendations: [],
+      }),
+    });
+
+    expect(result.name).toBe("Daemon Status");
+    expect(result.status).toBe("pass");
+    expect(result.message).toBe("Running (serving via socket)");
+    expect(result.value).toBe(12345);
+  });
+
+  test("reports responsive serving daemon when pid status is stale", async () => {
+    const result = await checkDaemonStatus({
+      daemonManager: {
+        status: async () => ({ running: false }),
+      },
+      getDaemonHealthReport: async () => ({
+        timestamp: "2026-06-29T00:00:00.000Z",
+        daemonRunning: false,
+        socketExists: true,
+        socketAccessible: true,
+        pidFileExists: false,
+        pidFileValid: false,
+        socketConnectable: true,
+        recommendations: [],
+      }),
+    });
+
+    expect(result.name).toBe("Daemon Status");
+    expect(result.status).toBe("pass");
+    expect(result.message).toBe("Running (serving via socket)");
+    expect(result.recommendation).toBeUndefined();
   });
 });
 
@@ -141,6 +194,8 @@ describe("checkCtrlProxy", () => {
       const result = await checkCtrlProxy(fakeFactory);
 
       expect(result.status).toBe("pass");
+      expect(result.message).toContain("platform=android");
+      expect(result.message).toContain("device=emulator-5554");
       expect(result.message).toContain("versionStatus=skipped");
       expect(result.message).not.toContain("acceptedPreinstalled=true");
       expect(result.recommendation).toBeUndefined();
@@ -151,5 +206,31 @@ describe("checkCtrlProxy", () => {
         process.env.AUTOMOBILE_SKIP_ACCESSIBILITY_DOWNLOAD_IF_INSTALLED = originalSkipDownload;
       }
     }
+  });
+});
+
+describe("runAutoMobileChecks", () => {
+  test("skips Android CtrlProxy diagnostics during iOS-only doctor runs", async () => {
+    const results = await runAutoMobileChecks(
+      { ios: true },
+      {
+        checkDaemonStatus: async () => ({
+          name: "Daemon Status",
+          status: "pass",
+          message: "Running (serving via socket)",
+        }),
+        checkDaemonConnectivity: async () => ({
+          name: "Daemon Connectivity",
+          status: "pass",
+          message: "Daemon is responsive",
+        }),
+      }
+    );
+
+    const ctrlProxy = results.find(result => result.name === "CtrlProxy");
+
+    expect(ctrlProxy?.status).toBe("skip");
+    expect(ctrlProxy?.message).toBe("Skipped for iOS-only doctor run");
+    expect(ctrlProxy?.message).not.toContain("emulator-5554");
   });
 });


### PR DESCRIPTION
## Summary
- Fix daemon doctor status to trust a responsive daemon socket when PID bookkeeping is stale or missing
- Skip Android-only CtrlProxy and work-profile checks during iOS-only doctor runs
- Include the resolved platform in CtrlProxy diagnostics next to the actual device id

Fixes #2643

## Testing
- `bun test test/daemon/debugTools.test.ts test/doctor/automobile.test.ts test/doctor/index.test.ts`
- `bun run lint`
- `bun run build`
- `bun test`
