### PR TITLE
Fix iOS recentApps App Switcher verification

### DIFF
--- a/ios/control-proxy/Sources/CtrlProxy/CommandHandler.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/CommandHandler.swift
@@ -753,8 +753,17 @@ public class CommandHandler: CommandHandling {
         perfProvider.serial("handleRecentApps")
         defer { perfProvider.end() }
 
-        try perfProvider.track("openRecentApps") {
+        let didOpen = try perfProvider.track("openRecentApps") {
             try gesturePerformer.openRecentApps()
+        }
+
+        guard didOpen else {
+            return WebSocketResponse.error(
+                type: ResponseType.recentAppsResult.rawValue,
+                requestId: request.requestId,
+                error: "iOS App Switcher did not appear after recent apps invocation",
+                totalTimeMs: totalTimeMs(from: startTime)
+            )
         }
 
         // Explicit state transition: app switcher is SpringBoard UI

--- a/ios/control-proxy/Sources/CtrlProxy/Fakes.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/Fakes.swift
@@ -206,6 +206,7 @@ public class FakeGesturePerformer: GesturePerforming {
     private var shakeCallCount = 0
     private var pressButtonHistory: [String] = []
     private var openRecentAppsCallCount = 0
+    private var openRecentAppsResult = true
     private var appLaunchHistory: [String] = []
     private var appTerminateHistory: [String] = []
     private var clipboardHistory: [(action: String, text: String?)] = []
@@ -281,6 +282,10 @@ public class FakeGesturePerformer: GesturePerforming {
         nextKeyboardResult = open
     }
 
+    public func setOpenRecentAppsResult(_ result: Bool) {
+        openRecentAppsResult = result
+    }
+
     public func getActionHistory() -> [(action: String, resourceId: String?, label: String?)] {
         actionHistory
     }
@@ -348,6 +353,7 @@ public class FakeGesturePerformer: GesturePerforming {
         shakeCallCount = 0
         pressButtonHistory.removeAll()
         openRecentAppsCallCount = 0
+        openRecentAppsResult = true
         appLaunchHistory.removeAll()
         appTerminateHistory.removeAll()
         clipboardHistory.removeAll()
@@ -535,9 +541,10 @@ public class FakeGesturePerformer: GesturePerforming {
         pressButtonHistory.append(button)
     }
 
-    public func openRecentApps() throws {
+    public func openRecentApps() throws -> Bool {
         try checkFailure("openRecentApps")
         openRecentAppsCallCount += 1
+        return openRecentAppsResult
     }
 
     public func launchApp(bundleId: String) throws {

--- a/ios/control-proxy/Sources/CtrlProxy/GesturePerformer.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/GesturePerformer.swift
@@ -963,7 +963,9 @@ public class GesturePerformer: GesturePerforming {
             case "home":
                 try pressHome()
             case "recent":
-                try openRecentApps()
+                guard try openRecentApps() else {
+                    throw GestureError.gestureFailed("iOS App Switcher did not appear after recent apps invocation")
+                }
             case "back":
                 try pressBack()
             case "volume_up", "volume_down":
@@ -1088,21 +1090,59 @@ public class GesturePerformer: GesturePerforming {
             }
         #endif
 
-        public func openRecentApps() throws {
+        public func openRecentApps() throws -> Bool {
+            guard let app = resolveNavigationApp() else {
+                throw GestureError.noApplication
+            }
+
             try runOnMainThread {
-                let springboard = XCUIApplication(bundleIdentifier: "com.apple.springboard")
-                let screenSize = springboard.frame.size
-                let startCoordinate = springboard.coordinate(withNormalizedOffset: .zero)
-                    .withOffset(CGVector(dx: screenSize.width / 2, dy: screenSize.height - 5))
-                let endCoordinate = springboard.coordinate(withNormalizedOffset: .zero)
-                    .withOffset(CGVector(dx: screenSize.width / 2, dy: screenSize.height * 0.4))
+                let frame = app.frame
+                guard frame.width > 0, frame.height > 0 else {
+                    throw GestureError.gestureFailed("Cannot determine application frame for recent apps gesture")
+                }
+
+                let startCoordinate = app.coordinate(withNormalizedOffset: .zero)
+                    .withOffset(CGVector(dx: frame.width / 2, dy: frame.height - 1))
+                let endCoordinate = app.coordinate(withNormalizedOffset: .zero)
+                    .withOffset(CGVector(dx: frame.width / 2, dy: frame.height * 0.58))
+                let distance = abs((frame.height - 1) - (frame.height * 0.58))
+                let velocity = XCUIGestureVelocity(distance / 0.6)
+
                 startCoordinate.press(
-                    forDuration: 0.05,
+                    forDuration: 0.35,
                     thenDragTo: endCoordinate,
-                    withVelocity: .default,
-                    thenHoldForDuration: 1.0
+                    withVelocity: velocity,
+                    thenHoldForDuration: 0.8
                 )
             }
+
+            return isAppSwitcherVisible()
+        }
+
+        private func isAppSwitcherVisible() -> Bool {
+            runOnMainThreadNonThrowing({
+                let candidates = [
+                    self.springboard.otherElements["AppSwitcher"],
+                    self.springboard.otherElements["App Switcher"],
+                    self.springboard.otherElements["AppSwitcherContentView"],
+                    self.springboard.collectionViews["AppSwitcher"],
+                    self.springboard.scrollViews["AppSwitcher"],
+                ]
+
+                for candidate in candidates where candidate.waitForExistence(timeout: 0.2) {
+                    return true
+                }
+
+                let appSwitcherPredicate = NSPredicate(
+                    format: "identifier CONTAINS[c] %@ OR label CONTAINS[c] %@",
+                    "AppSwitcher",
+                    "App Switcher"
+                )
+                return self.springboard.descendants(matching: .any)
+                    .matching(appSwitcherPredicate)
+                    .firstMatch
+                    .waitForExistence(timeout: 0.5)
+            }, fallback: false)
         }
 
         // MARK: - App Control
@@ -1260,7 +1300,7 @@ public class GesturePerformer: GesturePerforming {
             throw GestureError.notSupported("XCUITest only available on iOS")
         }
 
-        public func openRecentApps() throws {
+        public func openRecentApps() throws -> Bool {
             throw GestureError.notSupported("XCUITest only available on iOS")
         }
 

--- a/ios/control-proxy/Sources/CtrlProxy/Protocols.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/Protocols.swift
@@ -163,8 +163,8 @@ public protocol GesturePerforming {
     /// Press a named hardware or keyboard-backed button.
     func pressButton(_ button: String) throws
 
-    /// Open recent apps (app switcher) via swipe-up-and-hold gesture
-    func openRecentApps() throws
+    /// Open recent apps (app switcher) and return whether the switcher was verified.
+    func openRecentApps() throws -> Bool
 
     // MARK: - App Control
 

--- a/ios/control-proxy/Tests/CtrlProxyTests/CommandHandlerTests.swift
+++ b/ios/control-proxy/Tests/CtrlProxyTests/CommandHandlerTests.swift
@@ -1240,6 +1240,23 @@ final class CommandHandlerTests: XCTestCase {
         XCTAssertEqual(fakeGesturePerformer.getOpenRecentAppsCallCount(), 1)
     }
 
+    func testRecentAppsReturnsFailureWhenSwitcherIsNotVerified() {
+        fakeGesturePerformer.setOpenRecentAppsResult(false)
+        let request = WebSocketRequest(
+            type: "request_recent_apps",
+            requestId: "recents-not-visible"
+        )
+
+        guard let recentsResponse = handleRequest(request, as: WebSocketResponse.self) else { return }
+
+        XCTAssertEqual(recentsResponse.success, false)
+        XCTAssertEqual(recentsResponse.type, "recent_apps_result")
+        XCTAssertEqual(recentsResponse.error, "iOS App Switcher did not appear after recent apps invocation")
+        XCTAssertEqual(fakeGesturePerformer.getOpenRecentAppsCallCount(), 1)
+        XCTAssertTrue(fakeElementLocator.switchedBundleIds.isEmpty)
+        XCTAssertTrue(fakeGesturePerformer.updateApplicationHistory.isEmpty)
+    }
+
     func testRecentAppsSwitchesToSpringboard() {
         let request = WebSocketRequest(
             type: "request_recent_apps",

--- a/src/features/action/RecentApps.ts
+++ b/src/features/action/RecentApps.ts
@@ -46,8 +46,7 @@ export class RecentApps extends BaseVisualChange {
     if (this.device.platform === "ios") {
       return this.observedInteraction(
         async () => {
-          await perf.track("iOSRecentApps", () => this.executeIosRecentApps());
-          return { success: true, method: "ios_swipe" as const };
+          return perf.track("iOSRecentApps", () => this.executeIosRecentApps());
         },
         {
           changeExpected: true,
@@ -274,11 +273,13 @@ export class RecentApps extends BaseVisualChange {
     return { success: true, method: "hardware" };
   }
 
-  private async executeIosRecentApps(): Promise<void> {
+  private async executeIosRecentApps(): Promise<RecentAppsResult> {
     const client = IOSCtrlProxyClient.getInstance(this.device);
     const result = await client.requestRecentApps();
-    if (!result.success) {
-      throw new Error(result.error ?? "Failed to open iOS recent apps");
-    }
+    return {
+      success: result.success,
+      method: "ios_swipe",
+      error: result.success ? undefined : result.error ?? "Failed to open iOS recent apps"
+    };
   }
 }

--- a/src/server/interactionTools.ts
+++ b/src/server/interactionTools.ts
@@ -393,6 +393,13 @@ export function formatClipboardMessage(result: ClipboardResult): string {
   }
 }
 
+export function formatRecentAppsMessage(result: { success?: boolean; error?: string }): string {
+  if (result.success === false) {
+    return `Failed to open recent apps: ${result.error ?? "unknown error"}`;
+  }
+  return "Opened recent apps";
+}
+
 // ============================================================================
 // Tool Registration
 // ============================================================================
@@ -870,7 +877,7 @@ export function registerInteractionTools() {
       const result = await recentApps.execute(progress);
 
       return createJSONToolResponse({
-        message: "Opened recent apps",
+        message: formatRecentAppsMessage(result),
         observation: result.observation,
         ...result
       });

--- a/test/fakes/FakeIOSCtrlProxy.ts
+++ b/test/fakes/FakeIOSCtrlProxy.ts
@@ -114,6 +114,7 @@ export class FakeIOSCtrlProxy implements IOSCtrlProxy {
   private pinchResult: CtrlProxyPinchResult | null = null;
   private tapResult: CtrlProxyTapResult | null = null;
   private swipeResult: CtrlProxySwipeResult | null = null;
+  private recentAppsResult: CtrlProxyRecentAppsResult | null = null;
   private voiceOverState: boolean = false;
   private voiceOverActivateResult: CtrlProxyVoiceOverActionResult | null = null;
   private multiFingerSwipeResult: CtrlProxySwipeResult | null = null;
@@ -216,6 +217,10 @@ export class FakeIOSCtrlProxy implements IOSCtrlProxy {
    */
   setSwipeResult(result: CtrlProxySwipeResult | null): void {
     this.swipeResult = result;
+  }
+
+  setRecentAppsResult(result: CtrlProxyRecentAppsResult | null): void {
+    this.recentAppsResult = result;
   }
 
   /**
@@ -850,6 +855,13 @@ export class FakeIOSCtrlProxy implements IOSCtrlProxy {
     this.recentAppsRequestCount++;
     await this.applyDelay("recentApps");
     this.checkFailure("recentApps");
+
+    if (this.recentAppsResult) {
+      return {
+        ...this.recentAppsResult,
+        perfTiming: this.recentAppsResult.perfTiming ?? this.performanceTiming ?? undefined
+      };
+    }
 
     return {
       success: true,

--- a/test/features/action/RecentApps.test.ts
+++ b/test/features/action/RecentApps.test.ts
@@ -410,5 +410,20 @@ describe("RecentApps", () => {
         expect((error as Error).message).toContain("Connection lost");
       }
     });
+
+    test("should return explicit failure when CtrlProxy cannot verify App Switcher on iOS", async () => {
+      fakeIOSCtrlProxy.setRecentAppsResult({
+        success: false,
+        totalTimeMs: 100,
+        error: "iOS App Switcher did not appear after recent apps invocation"
+      });
+
+      const result = await iosRecentApps.execute();
+
+      expect(result.success).toBe(false);
+      expect(result.method).toBe("ios_swipe");
+      expect(result.error).toBe("iOS App Switcher did not appear after recent apps invocation");
+      expect(result.observation).toBeDefined();
+    });
   });
 });

--- a/test/server/interactionTools.clipboard.test.ts
+++ b/test/server/interactionTools.clipboard.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { clipboardSchema, formatClipboardMessage, registerInteractionTools } from "../../src/server/interactionTools";
+import { clipboardSchema, formatClipboardMessage, formatRecentAppsMessage, registerInteractionTools } from "../../src/server/interactionTools";
 import { ToolRegistry } from "../../src/server/toolRegistry";
 
 describe("clipboard tool schema", () => {
@@ -89,5 +89,15 @@ describe("clipboard tool schema", () => {
       action: "get",
       text: "",
     })).toBe("Retrieved empty clipboard");
+  });
+
+  test("formats failed recentApps without success wording", () => {
+    const message = formatRecentAppsMessage({
+      success: false,
+      error: "iOS App Switcher did not appear after recent apps invocation",
+    });
+
+    expect(message).toBe("Failed to open recent apps: iOS App Switcher did not appear after recent apps invocation");
+    expect(message).not.toContain("Opened recent apps");
   });
 });


### PR DESCRIPTION
## Summary
- Fix iOS `recentApps` so CtrlProxy no longer reports success unless the App Switcher is verified
- Preserve iOS recent-apps failures as structured `success: false` tool results with failure wording
- Add focused Swift and TypeScript coverage for the App Switcher verification failure path

Fixes #2642

## Testing
- `bun test test/features/action/RecentApps.test.ts test/server/interactionTools.clipboard.test.ts`
- `swift test --package-path ios/control-proxy --filter CommandHandlerTests/testRecentApps`
- `bun run build`
- `swift test --package-path ios/control-proxy`
- `bun run lint`
- `xcodebuild -project ios/control-proxy/CtrlProxy.xcodeproj -scheme CtrlProxyApp -destination 'generic/platform=iOS Simulator' -quiet build`
- `bun test --bail`

## Self-review
- Confirmed no stale `openRecentApps` call signatures remained
- Added iOS simulator build validation to cover the iOS-only XCTest implementation branch
- Confirmed failure responses do not use "Opened recent apps" wording
