### PR TITLE
Fix daemon disconnect monitor churn

### DIFF
--- a/src/daemon/daemon.ts
+++ b/src/daemon/daemon.ts
@@ -878,11 +878,14 @@ export class Daemon {
         }
 
         for (const [deviceId, recordingIds] of missingByDevice.entries()) {
+          let deviceCleanupSucceeded = true;
+
           // Stop performance monitoring for this device
           getPerformanceMonitor().stopMonitoring(deviceId);
 
           for (const recordingId of recordingIds) {
             if (this.stoppingRecordings.has(recordingId)) {
+              deviceCleanupSucceeded = false;
               continue;
             }
             this.stoppingRecordings.add(recordingId);
@@ -901,6 +904,7 @@ export class Daemon {
                   `[Daemon] Marked recording ${recordingId} interrupted after device ${deviceId} disconnected`
                 );
               } catch (interruptError) {
+                deviceCleanupSucceeded = false;
                 logger.warn(
                   `[Daemon] Failed to mark recording ${recordingId} interrupted after device ${deviceId} disconnected: ${interruptError}`
                 );
@@ -921,7 +925,13 @@ export class Daemon {
           }
 
           await this.devicePool.removeDisconnectedDevice(deviceId);
-          this.deviceDisconnectMisses.delete(deviceId);
+          if (this.devicePool.getDevice(deviceId)) {
+            deviceCleanupSucceeded = false;
+          }
+          if (deviceCleanupSucceeded) {
+            this.confirmedDisconnectedDeviceIds.add(deviceId);
+            this.deviceDisconnectMisses.delete(deviceId);
+          }
         }
       } catch (error) {
         logger.warn(`[Daemon] Device disconnect monitor failed: ${error}`);

--- a/src/daemon/daemon.ts
+++ b/src/daemon/daemon.ts
@@ -50,8 +50,9 @@ import { DeviceSessionRepository } from "../db/deviceSessionRepository";
 import { DeviceSessionManager } from "../utils/DeviceSessionManager";
 import { startAppearanceSyncScheduler, stopAppearanceSyncScheduler } from "../utils/appearance/AppearanceSyncScheduler";
 import { startPerformanceMonitor, stopPerformanceMonitor, getPerformanceMonitor } from "../features/performance/PerformanceMonitor";
-import { listActiveVideoRecordings, stopVideoRecording } from "../server/videoRecordingManager";
+import { interruptVideoRecording, listActiveVideoRecordings, stopVideoRecording } from "../server/videoRecordingManager";
 import { Timer, defaultTimer } from "../utils/SystemTimer";
+import { evaluateDeviceDisconnects } from "./disconnectMonitor";
 import { describeUnknownError } from "../utils/describeUnknownError";
 import { FeatureFlagService } from "../features/featureFlags/FeatureFlagService";
 import { serverConfig } from "../utils/ServerConfig";
@@ -93,6 +94,7 @@ export class Daemon {
   private deviceDisconnectTimer: NodeJS.Timeout | null = null;
   private pidFileWritten = false;
   private deviceDisconnectMisses: Map<string, number> = new Map();
+  private confirmedDisconnectedDeviceIds: Set<string> = new Set();
   private stoppingRecordings: Set<string> = new Set();
   private sessionManager: SessionManager;
   private devicePool: DevicePool;
@@ -824,52 +826,48 @@ export class Daemon {
 
         const missingByDevice = new Map<string, string[]>();
         const candidateDeviceIds = new Set<string>();
+        const candidatePlatforms = new Map<string, "android" | "ios">();
+        const idleCandidateIds = new Set<string>();
         for (const recording of activeRecordings) {
           candidateDeviceIds.add(recording.deviceId);
+          candidatePlatforms.set(recording.deviceId, recording.platform);
         }
         for (const device of this.devicePool.getAllDevices()) {
-          // Skip idle devices on platforms whose discovery failed or was
-          // unavailable this poll — a partial discovery cannot confirm they
-          // disconnected, so counting misses would risk dropping a healthy
-          // idle device.
-          if (device.status === "idle" && !succeededPlatforms.has(device.platform)) {
-            logger.warn(
-              `[DisconnectMonitor] Skipping idle ${device.platform} device ${device.id}: ` +
-              `${device.platform} discovery did not succeed this poll`
-            );
-            this.deviceDisconnectMisses.delete(device.id);
-            continue;
-          }
           candidateDeviceIds.add(device.id);
+          candidatePlatforms.set(device.id, device.platform);
+          if (device.status === "idle") {
+            idleCandidateIds.add(device.id);
+          }
         }
         for (const deviceId of this.sessionManager.getAssignedDevices()) {
           candidateDeviceIds.add(deviceId);
         }
 
-        // When getBootedDevices returns empty but we have tracked devices, ADB
-        // itself likely failed (timeout, connection error). Counting misses in
-        // this state causes false disconnect detections on remote emulators
-        // where ADB can be intermittently slow.
-        if (bootedDeviceIds.size === 0 && candidateDeviceIds.size > 0) {
+        const disconnectResult = evaluateDeviceDisconnects({
+          deviceDisconnectMisses: this.deviceDisconnectMisses,
+          confirmedDisconnectedDeviceIds: this.confirmedDisconnectedDeviceIds,
+          bootedDeviceIds,
+          candidateDeviceIds,
+          succeededPlatforms,
+          candidatePlatforms,
+          idleCandidateIds,
+          missThreshold: DEVICE_DISCONNECT_MISS_THRESHOLD,
+        });
+
+        if (disconnectResult.skippedAdbUnreachable) {
           logger.warn(
             `[DisconnectMonitor] ADB returned 0 devices but ${candidateDeviceIds.size} tracked — skipping miss count (ADB likely unreachable)`
           );
           return;
         }
 
-        for (const deviceId of candidateDeviceIds) {
-          if (bootedDeviceIds.has(deviceId)) {
-            this.deviceDisconnectMisses.delete(deviceId);
-            continue;
-          }
-          const misses = (this.deviceDisconnectMisses.get(deviceId) ?? 0) + 1;
-          this.deviceDisconnectMisses.set(deviceId, misses);
+        for (const { deviceId, misses } of disconnectResult.missed) {
           logger.info(
             `[DisconnectMonitor] Device ${deviceId} not in booted list (miss ${misses}/${DEVICE_DISCONNECT_MISS_THRESHOLD}, booted=${bootedDeviceIds.size})`
           );
-          if (misses < DEVICE_DISCONNECT_MISS_THRESHOLD) {
-            continue;
-          }
+        }
+
+        for (const deviceId of disconnectResult.disconnected) {
           missingByDevice.set(deviceId, []);
         }
 
@@ -897,6 +895,16 @@ export class Daemon {
               logger.warn(
                 `[Daemon] Failed to stop recording ${recordingId} after device ${deviceId} disconnected: ${error}`
               );
+              try {
+                await interruptVideoRecording(recordingId);
+                logger.warn(
+                  `[Daemon] Marked recording ${recordingId} interrupted after device ${deviceId} disconnected`
+                );
+              } catch (interruptError) {
+                logger.warn(
+                  `[Daemon] Failed to mark recording ${recordingId} interrupted after device ${deviceId} disconnected: ${interruptError}`
+                );
+              }
             } finally {
               this.stoppingRecordings.delete(recordingId);
             }
@@ -912,7 +920,7 @@ export class Daemon {
             await this.cancelAndReleaseSession(sessionId);
           }
 
-          await this.devicePool.removeDevice(deviceId);
+          await this.devicePool.removeDisconnectedDevice(deviceId);
           this.deviceDisconnectMisses.delete(deviceId);
         }
       } catch (error) {

--- a/src/daemon/devicePool.ts
+++ b/src/daemon/devicePool.ts
@@ -78,6 +78,7 @@ export class DevicePool {
   private lastReleasedDeviceId: string | null = null;
   private readonly mcpSessionAutolockMap: Map<string, string> = new Map();
   private readonly refreshMissingDeviceMisses: Map<string, number> = new Map();
+  private readonly suppressedAutoStartDeviceImageKeys: Set<string> = new Set();
   private daemonSessionId: string;
   private installedAppsRepository: InstalledAppsStore;
   private deviceManager: PlatformDeviceManager;
@@ -132,6 +133,7 @@ export class DevicePool {
 
     perf.startOperation("populatePool");
     for (const device of devices) {
+      this.clearAutoStartSuppressionForBootedDevice(device);
       this.devices.set(device.deviceId, {
         id: device.deviceId,
         name: device.name,
@@ -195,6 +197,7 @@ export class DevicePool {
       );
 
       for (const device of bootedDevices) {
+        this.clearAutoStartSuppressionForBootedDevice(device);
         const pooledDevice = this.devices.get(device.deviceId);
         if (!pooledDevice) {
           this.devices.set(device.deviceId, {
@@ -249,6 +252,7 @@ export class DevicePool {
    * Add a new device to the pool
    */
   async addDevice(device: BootedDevice): Promise<void> {
+    this.clearAutoStartSuppressionForBootedDevice(device);
     const existing = this.devices.get(device.deviceId);
     if (existing) {
       // A successful (re)boot of an errored, idle device clears its failure state so
@@ -308,6 +312,14 @@ export class DevicePool {
     }
     await this.clearDeviceSessionCache(deviceId);
     logger.info(`Removed device ${deviceId} from pool and cleared cached data`);
+  }
+
+  async removeDisconnectedDevice(deviceId: string): Promise<void> {
+    const device = this.devices.get(deviceId);
+    if (device && !device.sessionId) {
+      this.suppressAutoStartForDevice(device);
+    }
+    await this.removeDevice(deviceId);
   }
 
   private async removeDevicesMissingFrom(
@@ -760,6 +772,9 @@ export class DevicePool {
       if (excludedImageIds.has(this.criteriaMatcher.getDeviceImageKey(image))) {
         continue;
       }
+      if (this.suppressedAutoStartDeviceImageKeys.has(this.criteriaMatcher.getDeviceImageKey(image))) {
+        continue;
+      }
       if (image.deviceId && bootedIds.has(image.deviceId)) {
         continue;
       }
@@ -800,6 +815,16 @@ export class DevicePool {
     }
     this.lastUsedAtMarker = now;
     return now;
+  }
+
+  private suppressAutoStartForDevice(device: PooledDevice): void {
+    this.suppressedAutoStartDeviceImageKeys.add(device.id);
+    this.suppressedAutoStartDeviceImageKeys.add(`${device.platform}:${device.name}`);
+  }
+
+  private clearAutoStartSuppressionForBootedDevice(device: BootedDevice): void {
+    this.suppressedAutoStartDeviceImageKeys.delete(device.deviceId);
+    this.suppressedAutoStartDeviceImageKeys.delete(`${device.platform}:${device.name}`);
   }
 
   /**

--- a/src/daemon/disconnectMonitor.ts
+++ b/src/daemon/disconnectMonitor.ts
@@ -1,0 +1,63 @@
+import type { Platform } from "../models";
+
+export interface DisconnectMonitorEvaluation {
+  disconnected: string[];
+  missed: Array<{ deviceId: string; misses: number }>;
+  skippedAdbUnreachable: boolean;
+}
+
+export interface DisconnectMonitorEvaluationInput {
+  deviceDisconnectMisses: Map<string, number>;
+  confirmedDisconnectedDeviceIds: Set<string>;
+  bootedDeviceIds: Set<string>;
+  candidateDeviceIds: Set<string>;
+  succeededPlatforms: Set<Platform>;
+  candidatePlatforms: Map<string, Platform>;
+  idleCandidateIds: Set<string>;
+  missThreshold: number;
+}
+
+export function evaluateDeviceDisconnects(
+  input: DisconnectMonitorEvaluationInput
+): DisconnectMonitorEvaluation {
+  const disconnected: string[] = [];
+  const missed: Array<{ deviceId: string; misses: number }> = [];
+
+  if (input.bootedDeviceIds.size === 0 && input.candidateDeviceIds.size > 0) {
+    return { disconnected, missed, skippedAdbUnreachable: true };
+  }
+
+  for (const deviceId of input.candidateDeviceIds) {
+    if (input.bootedDeviceIds.has(deviceId)) {
+      input.deviceDisconnectMisses.delete(deviceId);
+      input.confirmedDisconnectedDeviceIds.delete(deviceId);
+      continue;
+    }
+
+    if (input.confirmedDisconnectedDeviceIds.has(deviceId)) {
+      input.deviceDisconnectMisses.delete(deviceId);
+      continue;
+    }
+
+    const platform = input.candidatePlatforms.get(deviceId);
+    if (
+      platform &&
+      input.idleCandidateIds.has(deviceId) &&
+      !input.succeededPlatforms.has(platform)
+    ) {
+      input.deviceDisconnectMisses.delete(deviceId);
+      continue;
+    }
+
+    const misses = (input.deviceDisconnectMisses.get(deviceId) ?? 0) + 1;
+    input.deviceDisconnectMisses.set(deviceId, misses);
+    missed.push({ deviceId, misses });
+    if (misses >= input.missThreshold) {
+      disconnected.push(deviceId);
+      input.confirmedDisconnectedDeviceIds.add(deviceId);
+      input.deviceDisconnectMisses.delete(deviceId);
+    }
+  }
+
+  return { disconnected, missed, skippedAdbUnreachable: false };
+}

--- a/src/daemon/disconnectMonitor.ts
+++ b/src/daemon/disconnectMonitor.ts
@@ -49,13 +49,14 @@ export function evaluateDeviceDisconnects(
       continue;
     }
 
-    const misses = (input.deviceDisconnectMisses.get(deviceId) ?? 0) + 1;
+    const misses = Math.min(
+      (input.deviceDisconnectMisses.get(deviceId) ?? 0) + 1,
+      input.missThreshold
+    );
     input.deviceDisconnectMisses.set(deviceId, misses);
     missed.push({ deviceId, misses });
     if (misses >= input.missThreshold) {
       disconnected.push(deviceId);
-      input.confirmedDisconnectedDeviceIds.add(deviceId);
-      input.deviceDisconnectMisses.delete(deviceId);
     }
   }
 

--- a/src/server/videoRecordingManager.ts
+++ b/src/server/videoRecordingManager.ts
@@ -639,6 +639,34 @@ export async function stopVideoRecording(
   return { metadata, evictedRecordingIds: eviction.evictedRecordingIds };
 }
 
+export async function interruptVideoRecording(recordingId: string): Promise<void> {
+  const { recordingRepository, now } = await getVideoRecordingDependencies();
+  clearAutoStop(recordingId);
+
+  const record = await recordingRepository.getRecording(recordingId);
+  if (!record || record.status !== "recording") {
+    disposeHighlightSession(recordingId);
+    return;
+  }
+
+  const endedAt = now().toISOString();
+  const highlightSession = disposeHighlightSession(recordingId);
+  const highlights = highlightSession
+    ? finalizeHighlightSession(highlightSession, endedAt)
+    : record.highlights;
+
+  await recordingRepository.updateRecording(recordingId, {
+    status: "interrupted",
+    endedAt,
+    lastAccessedAt: endedAt,
+    sizeBytes: await getFileSize(record.filePath),
+    durationMs: calculateDurationMs(record.startedAt, endedAt),
+    highlights,
+  });
+
+  await notifyVideoRecordingResources([recordingId]);
+}
+
 export async function recordVideoRecordingHighlightAdded(
   device: BootedDevice,
   highlight: VideoRecordingHighlightInput

--- a/test/daemon/devicePool.autolock.test.ts
+++ b/test/daemon/devicePool.autolock.test.ts
@@ -88,6 +88,53 @@ describe("DevicePool autolock", () => {
     expect(session).toBeNull();
   });
 
+  it("does not auto-start a device image after that pool device disconnects", async () => {
+    const androidImage = {
+      name: "Medium_Phone_API_35",
+      platform: "android" as const,
+      deviceId: "emulator-5554",
+      isRunning: false,
+      source: "local" as const,
+    };
+
+    fakeDeviceUtils.setDeviceImages("android", [androidImage]);
+    fakeDeviceUtils.setBootedDevices("android", []);
+    await pool.initializeWithDevices([
+      { name: "Medium_Phone_API_35", platform: "android", deviceId: "emulator-5554" },
+    ]);
+
+    await pool.removeDisconnectedDevice("emulator-5554");
+
+    await expect(pool.assignMultipleDevices(["next-session"], 1000, "android")).rejects.toThrow(ActionableError);
+    expect(fakeDeviceUtils.getCallCount("startDevice")).toBe(0);
+  });
+
+  it("does not suppress auto-start when disconnected removal is blocked by assignment", async () => {
+    const androidImage = {
+      name: "Medium_Phone_API_35",
+      platform: "android" as const,
+      deviceId: "emulator-5554",
+      isRunning: false,
+      source: "local" as const,
+    };
+
+    fakeDeviceUtils.setDeviceImages("android", [androidImage]);
+    fakeDeviceUtils.setBootedDevices("android", []);
+    await pool.initializeWithDevices([
+      { name: "Medium_Phone_API_35", platform: "android", deviceId: "emulator-5554" },
+    ]);
+
+    await pool.assignDeviceToSession("active-session", "android");
+    await pool.removeDisconnectedDevice("emulator-5554");
+    await pool.releaseDevice("emulator-5554");
+    await pool.removeDevice("emulator-5554");
+
+    const assignments = await pool.assignMultipleDevices(["next-session"], 1000, "android");
+
+    expect(assignments.get("next-session")).toBe("emulator-5554");
+    expect(fakeDeviceUtils.getCallCount("startDevice")).toBe(1);
+  });
+
   it("createSession accepts custom timeout", async () => {
     const session = await sessionManager.createSession(
       "autolock-session",

--- a/test/daemon/sseKeepaliveAndDisconnect.test.ts
+++ b/test/daemon/sseKeepaliveAndDisconnect.test.ts
@@ -250,7 +250,7 @@ describe("disconnect monitor miss counting", () => {
     expect(misses.get("device-1")).toBe(1);
   });
 
-  test("settles a disconnected stale candidate after threshold", () => {
+  test("keeps returning a threshold-missed stale candidate until caller settles cleanup", () => {
     const misses = new Map<string, number>();
     const confirmedDisconnectedDeviceIds = new Set<string>();
     const input = {
@@ -267,8 +267,13 @@ describe("disconnect monitor miss counting", () => {
     expect(evaluateDeviceDisconnects(input).disconnected).toEqual([]);
     expect(evaluateDeviceDisconnects(input).disconnected).toEqual([]);
     expect(evaluateDeviceDisconnects(input).disconnected).toEqual(["device-1"]);
-    expect(confirmedDisconnectedDeviceIds.has("device-1")).toBe(true);
-    expect(misses.has("device-1")).toBe(false);
+    expect(confirmedDisconnectedDeviceIds.has("device-1")).toBe(false);
+    expect(misses.get("device-1")).toBe(DEVICE_DISCONNECT_MISS_THRESHOLD);
+
+    expect(evaluateDeviceDisconnects(input).disconnected).toEqual(["device-1"]);
+    expect(misses.get("device-1")).toBe(DEVICE_DISCONNECT_MISS_THRESHOLD);
+
+    confirmedDisconnectedDeviceIds.add("device-1");
 
     expect(evaluateDeviceDisconnects(input).disconnected).toEqual([]);
     expect(misses.has("device-1")).toBe(false);

--- a/test/daemon/sseKeepaliveAndDisconnect.test.ts
+++ b/test/daemon/sseKeepaliveAndDisconnect.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test";
+import { evaluateDeviceDisconnects } from "../../src/daemon/disconnectMonitor";
 import { FakeTimer } from "../fakes/FakeTimer";
 
 
@@ -136,36 +137,16 @@ describe("disconnect monitor miss counting", () => {
     candidatePlatforms: Map<string, string> = new Map(),
     idleCandidateIds: Set<string> = new Set(),
   ): { disconnected: string[]; skippedAdbUnreachable: boolean } => {
-    const disconnected: string[] = [];
-
-    if (bootedDeviceIds.size === 0 && candidateDeviceIds.size > 0) {
-      return { disconnected, skippedAdbUnreachable: true };
-    }
-
-    for (const deviceId of candidateDeviceIds) {
-      if (bootedDeviceIds.has(deviceId)) {
-        deviceDisconnectMisses.delete(deviceId);
-        continue;
-      }
-      const platform = candidatePlatforms.get(deviceId);
-      // Idle devices on platforms whose discovery did not succeed this poll are
-      // skipped — a partial/failed discovery cannot confirm they disconnected.
-      if (
-        platform &&
-        idleCandidateIds.has(deviceId) &&
-        !succeededPlatforms.has(platform)
-      ) {
-        deviceDisconnectMisses.delete(deviceId);
-        continue;
-      }
-      const misses = (deviceDisconnectMisses.get(deviceId) ?? 0) + 1;
-      deviceDisconnectMisses.set(deviceId, misses);
-      if (misses >= DEVICE_DISCONNECT_MISS_THRESHOLD) {
-        disconnected.push(deviceId);
-      }
-    }
-
-    return { disconnected, skippedAdbUnreachable: false };
+    return evaluateDeviceDisconnects({
+      deviceDisconnectMisses,
+      confirmedDisconnectedDeviceIds: new Set(),
+      bootedDeviceIds,
+      candidateDeviceIds,
+      succeededPlatforms: succeededPlatforms as Set<"android" | "ios">,
+      candidatePlatforms: candidatePlatforms as Map<string, "android" | "ios">,
+      idleCandidateIds,
+      missThreshold: DEVICE_DISCONNECT_MISS_THRESHOLD,
+    });
   };
 
   test("resets miss count when device appears in booted list", () => {
@@ -267,6 +248,48 @@ describe("disconnect monitor miss counting", () => {
 
     runDisconnectPoll(misses, new Set(["other"]), new Set(["device-1"]));
     expect(misses.get("device-1")).toBe(1);
+  });
+
+  test("settles a disconnected stale candidate after threshold", () => {
+    const misses = new Map<string, number>();
+    const confirmedDisconnectedDeviceIds = new Set<string>();
+    const input = {
+      deviceDisconnectMisses: misses,
+      confirmedDisconnectedDeviceIds,
+      bootedDeviceIds: new Set(["other"]),
+      candidateDeviceIds: new Set(["device-1"]),
+      succeededPlatforms: new Set(["android" as const, "ios" as const]),
+      candidatePlatforms: new Map([["device-1", "android" as const]]),
+      idleCandidateIds: new Set<string>(),
+      missThreshold: DEVICE_DISCONNECT_MISS_THRESHOLD,
+    };
+
+    expect(evaluateDeviceDisconnects(input).disconnected).toEqual([]);
+    expect(evaluateDeviceDisconnects(input).disconnected).toEqual([]);
+    expect(evaluateDeviceDisconnects(input).disconnected).toEqual(["device-1"]);
+    expect(confirmedDisconnectedDeviceIds.has("device-1")).toBe(true);
+    expect(misses.has("device-1")).toBe(false);
+
+    expect(evaluateDeviceDisconnects(input).disconnected).toEqual([]);
+    expect(misses.has("device-1")).toBe(false);
+  });
+
+  test("clears settled disconnect state when the device reappears", () => {
+    const confirmedDisconnectedDeviceIds = new Set(["device-1"]);
+    const misses = new Map<string, number>();
+
+    evaluateDeviceDisconnects({
+      deviceDisconnectMisses: misses,
+      confirmedDisconnectedDeviceIds,
+      bootedDeviceIds: new Set(["device-1"]),
+      candidateDeviceIds: new Set(["device-1"]),
+      succeededPlatforms: new Set(["android" as const]),
+      candidatePlatforms: new Map([["device-1", "android" as const]]),
+      idleCandidateIds: new Set<string>(),
+      missThreshold: DEVICE_DISCONNECT_MISS_THRESHOLD,
+    });
+
+    expect(confirmedDisconnectedDeviceIds.has("device-1")).toBe(false);
   });
 
   test("fires at poll interval using FakeTimer", () => {

--- a/test/server/videoRecordingManager.test.ts
+++ b/test/server/videoRecordingManager.test.ts
@@ -11,6 +11,7 @@ import { VideoRecorderService } from "../../src/features/video";
 import type { BootedDevice } from "../../src/models";
 import {
   listVideoRecordings,
+  interruptVideoRecording,
   recordVideoRecordingHighlightAdded,
   resetVideoRecordingManagerDependencies,
   setVideoRecordingManagerDependencies,
@@ -23,6 +24,7 @@ describe("videoRecordingManager", () => {
   let fakeTimer: FakeTimer;
   let fakeBackend: FakeVideoCaptureBackend;
   let fakeHighlightClient: FakeHighlightClient;
+  let fakeRepository: FakeVideoRecordingRepository;
   let archiveRoot: string;
   let testDevice: BootedDevice;
 
@@ -35,6 +37,7 @@ describe("videoRecordingManager", () => {
     fakeBackend = new FakeVideoCaptureBackend();
     fakeBackend.setNowProvider(() => new Date(fakeTimer.now()));
     fakeHighlightClient = new FakeHighlightClient();
+    fakeRepository = new FakeVideoRecordingRepository();
     await fsPromises.rm(archiveRoot, { recursive: true, force: true });
     await fsPromises.mkdir(archiveRoot, { recursive: true });
 
@@ -46,7 +49,7 @@ describe("videoRecordingManager", () => {
 
     await setVideoRecordingManagerDependencies({
       videoRecorderService: service,
-      recordingRepository: new FakeVideoRecordingRepository(),
+      recordingRepository: fakeRepository,
       configRepository: new FakeVideoRecordingConfigRepository(),
       highlightClient: fakeHighlightClient,
       timer: fakeTimer,
@@ -116,6 +119,26 @@ describe("videoRecordingManager", () => {
 
     fakeTimer.advanceTime(3000);
     expect(fakeBackend.stopCalls.length).toBe(1);
+  });
+
+  test("interrupt marks active recording inactive without calling capture stop", async () => {
+    const active = await startVideoRecording({
+      device: testDevice,
+      maxDurationSeconds: 3,
+    });
+
+    expect(fakeTimer.getPendingTimeoutCount()).toBe(1);
+
+    fakeTimer.advanceTime(1000);
+    await interruptVideoRecording(active.recordingId);
+
+    expect(fakeBackend.stopCalls.length).toBe(0);
+    expect(fakeTimer.getPendingTimeoutCount()).toBe(0);
+
+    const record = await fakeRepository.getRecording(active.recordingId);
+    expect(record?.status).toBe("interrupted");
+    expect(record?.endedAt).toBe(new Date(fakeTimer.now()).toISOString());
+    expect(record?.durationMs).toBe(1000);
   });
 
   test("records highlight timelines for scheduled highlights", async () => {


### PR DESCRIPTION
## Summary
- Settle daemon disconnect miss tracking after a device is confirmed gone so stale candidates do not churn every poll.
- Mark stale active video recording rows as interrupted when stop fails after device disconnect.
- Suppress automatic restart of a disconnected pool device image until that device is observed booted again.

Fixes #2638

## Testing
- `bun test test/daemon/sseKeepaliveAndDisconnect.test.ts test/server/videoRecordingManager.test.ts test/daemon/devicePool.autolock.test.ts`
- `bun run lint`
- `bun run build`
- `bun test`
- `bash scripts/all_fast_validate_checks.sh`
