### PR TITLE
Fix putAppFile relative source paths

### DIFF
--- a/src/server/appFileService.ts
+++ b/src/server/appFileService.ts
@@ -21,6 +21,7 @@ import type { AdbExecutor } from "../utils/android-cmdline-tools/interfaces/AdbE
 import { SimCtlClient } from "../utils/ios-cmdline-tools/SimCtlClient";
 import { isIosSimulatorUdid } from "../utils/ios-cmdline-tools/iosDeviceType";
 import { PlatformDeviceManagerFactory } from "../utils/factories/PlatformDeviceManagerFactory";
+import { resolvePathFromDaemonLaunchWorkingDirectory } from "../utils/workingDirectory";
 
 export interface PutAppFileRequest extends PutAppFileArgs {
   device: BootedDevice;
@@ -254,11 +255,12 @@ class DefaultAppFileService implements AppFileService {
 
   private async prepareSource(args: PutAppFileArgs): Promise<FileSource> {
     if (args.sourcePath !== undefined) {
-      const stat = await this.fileSystem.stat(args.sourcePath);
+      const sourcePath = resolvePathFromDaemonLaunchWorkingDirectory(args.sourcePath);
+      const stat = await this.fileSystem.stat(sourcePath);
       if (!stat.isFile()) {
-        throw new ActionableError(`sourcePath is not a file: ${args.sourcePath}`);
+        throw new ActionableError(`sourcePath is not a file: ${sourcePath}`);
       }
-      return { path: args.sourcePath, byteCount: stat.size };
+      return { path: sourcePath, byteCount: stat.size };
     }
 
     const buffer = args.contentBase64 !== undefined

--- a/test/server/appFileService.test.ts
+++ b/test/server/appFileService.test.ts
@@ -1,4 +1,4 @@
-import { dirname, join } from "node:path";
+import { dirname, join, resolve } from "node:path";
 import { describe, expect, test } from "bun:test";
 import {
   type AppFileFileSystem,
@@ -338,7 +338,8 @@ describe("AppFileService", () => {
 
   test("resolves relative sourcePath from the daemon launch working directory", async () => {
     const previousLaunchCwd = process.env[DAEMON_LAUNCH_CWD_ENV];
-    process.env[DAEMON_LAUNCH_CWD_ENV] = "/launch/cwd";
+    const launchCwd = resolve("/launch/cwd");
+    process.env[DAEMON_LAUNCH_CWD_ENV] = launchCwd;
     try {
       const fileSystem = new TestAppFileFileSystem();
       const dataRoot = "/simulators/SIM-1/data";
@@ -352,7 +353,7 @@ describe("AppFileService", () => {
         fileSystem,
       });
       const sourceBytes = Buffer.from("from launch cwd");
-      await fileSystem.writeFileBuffer("/launch/cwd/fixtures/source.bin", sourceBytes);
+      await fileSystem.writeFileBuffer(join(launchCwd, "fixtures", "source.bin"), sourceBytes);
 
       const result = await service.putFile({
         device: iosSimulatorDevice,

--- a/test/server/appFileService.test.ts
+++ b/test/server/appFileService.test.ts
@@ -9,6 +9,7 @@ import {
 } from "../../src/server/appFileService";
 import type { BootedDevice } from "../../src/models";
 import type { AdbClientFactory } from "../../src/utils/android-cmdline-tools/AdbClientFactory";
+import { DAEMON_LAUNCH_CWD_ENV } from "../../src/utils/workingDirectory";
 import { FakeAdbClientFactory } from "../fakes/FakeAdbClientFactory";
 import { FakeAdbExecutor } from "../fakes/FakeAdbExecutor";
 import { FakeSimCtlClient } from "../fakes/FakeSimCtlClient";
@@ -333,6 +334,44 @@ describe("AppFileService", () => {
       blob: sourceBytes.toString("base64"),
     });
     expect(readResult.text).toBeUndefined();
+  });
+
+  test("resolves relative sourcePath from the daemon launch working directory", async () => {
+    const previousLaunchCwd = process.env[DAEMON_LAUNCH_CWD_ENV];
+    process.env[DAEMON_LAUNCH_CWD_ENV] = "/launch/cwd";
+    try {
+      const fileSystem = new TestAppFileFileSystem();
+      const dataRoot = "/simulators/SIM-1/data";
+      const simctl = new FakeSimCtlClient();
+      simctl.setCommandResult(
+        `get_app_container '${iosSimulatorDevice.deviceId}' 'com.example.app' data`,
+        dataRoot
+      );
+      const service = createAppFileServiceForTesting({
+        simctlFactory: () => simctl as any,
+        fileSystem,
+      });
+      const sourceBytes = Buffer.from("from launch cwd");
+      await fileSystem.writeFileBuffer("/launch/cwd/fixtures/source.bin", sourceBytes);
+
+      const result = await service.putFile({
+        device: iosSimulatorDevice,
+        appId: "com.example.app",
+        container: "documents",
+        sourcePath: "./fixtures/source.bin",
+        destinationPath: "fixtures/copied.bin",
+      });
+
+      expect(result.byteCount).toBe(sourceBytes.byteLength);
+      await expect(fileSystem.readFileBuffer(join(dataRoot, "Documents", "fixtures", "copied.bin")))
+        .resolves.toEqual(sourceBytes);
+    } finally {
+      if (previousLaunchCwd === undefined) {
+        delete process.env[DAEMON_LAUNCH_CWD_ENV];
+      } else {
+        process.env[DAEMON_LAUNCH_CWD_ENV] = previousLaunchCwd;
+      }
+    }
   });
 
   test("lists iOS app files and directories with relative metadata only", async () => {


### PR DESCRIPTION
## Summary
- Fixes #2644.
- Resolve `putAppFile` relative `sourcePath` values from the daemon launch working directory before `stat` and provider handoff.
- Preserve absolute source paths and inline content behavior through the existing shared path helper.
- Add fake-backed iOS coverage proving a relative source file is copied from `AUTOMOBILE_DAEMON_LAUNCH_CWD`.

## Evaluation Criteria
- `putAppFile { sourcePath: "./file.bin" }` resolves against the user's daemon launch cwd, not the stable daemon cwd or homedir.
- `stat`, Android provider pushes, and iOS provider copies receive the resolved host path.
- Absolute `sourcePath` values continue to behave as before.
- Inline `contentText` and `contentBase64` sources are unaffected.

## Testing
- `bun test test/server/appFileService.test.ts` (failed before implementation with `ENOENT: no such file or directory, ./fixtures/source.bin`; passes after fix)
- `bun test`
- `bun run lint`
- `bun run build`
- `bash scripts/all_fast_validate_checks.sh`

## Notes
- I did not find a checked-in `.github/PULL_REQUEST_TEMPLATE.md` or equivalent PR template in this repo, so this uses the repo's existing multiline `## Summary` / `## Evaluation Criteria` / `## Testing` PR body convention.
