### PR TITLE
Fix iOS pinchOn routing

### DIFF
--- a/ios/control-proxy/Sources/CtrlProxy/CommandHandler.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/CommandHandler.swift
@@ -468,14 +468,13 @@ public class CommandHandler: CommandHandling {
             throw CommandError.missingParameter("centerX, centerY, distanceStart, distanceEnd")
         }
 
-        let duration = request.duration ?? 300
-        let scale = Double(distanceEnd) / Double(distanceStart)
-
         try gesturePerformer.pinch(
             centerX: Double(centerX),
             centerY: Double(centerY),
-            scale: scale,
-            duration: TimeInterval(duration) / 1000.0
+            distanceStart: Double(distanceStart),
+            distanceEnd: Double(distanceEnd),
+            rotationDegrees: Double(request.rotationDegrees ?? 0),
+            duration: TimeInterval(request.duration ?? 300) / 1000.0
         )
 
         return WebSocketResponse.success(
@@ -976,7 +975,8 @@ public class CommandHandler: CommandHandling {
         let highlightId = request.id ?? request.requestId ?? UUID().uuidString
         if sdkHierarchyClient != nil,
            sdkServerMatchesTrackedForegroundApp(),
-           sdkHierarchyClient?.addHighlight(id: highlightId, shape: shape) == true {
+           sdkHierarchyClient?.addHighlight(id: highlightId, shape: shape) == true
+        {
             return WebSocketResponse.success(
                 type: ResponseType.highlightResponse.rawValue,
                 requestId: request.requestId,

--- a/ios/control-proxy/Sources/CtrlProxy/Fakes.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/Fakes.swift
@@ -175,7 +175,9 @@ public class FakeGesturePerformer: GesturePerforming {
     public struct PinchCall {
         public let centerX: Double
         public let centerY: Double
-        public let scale: Double
+        public let distanceStart: Double
+        public let distanceEnd: Double
+        public let rotationDegrees: Double
         public let duration: TimeInterval
     }
 
@@ -391,7 +393,9 @@ public class FakeGesturePerformer: GesturePerforming {
         fingerCount: Int,
         fingerSpacing: Double,
         duration: TimeInterval
-    ) throws {
+    )
+        throws
+    {
         try checkFailure("multiFingerSwipe")
         multiFingerSwipeHistory.append(MultiFingerSwipeCall(
             startX: startX,
@@ -427,9 +431,25 @@ public class FakeGesturePerformer: GesturePerforming {
         ))
     }
 
-    public func pinch(centerX: Double, centerY: Double, scale: Double, duration: TimeInterval) throws {
+    public func pinch(
+        centerX: Double,
+        centerY: Double,
+        distanceStart: Double,
+        distanceEnd: Double,
+        rotationDegrees: Double,
+        duration: TimeInterval
+    )
+        throws
+    {
         try checkFailure("pinch")
-        pinchHistory.append(PinchCall(centerX: centerX, centerY: centerY, scale: scale, duration: duration))
+        pinchHistory.append(PinchCall(
+            centerX: centerX,
+            centerY: centerY,
+            distanceStart: distanceStart,
+            distanceEnd: distanceEnd,
+            rotationDegrees: rotationDegrees,
+            duration: duration
+        ))
     }
 
     public func typeText(text: String) throws {

--- a/ios/control-proxy/Sources/CtrlProxy/GesturePerformer.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/GesturePerformer.swift
@@ -1,7 +1,7 @@
 import Foundation
 import ObjCExceptionCatcher
 #if canImport(os)
-import os
+    import os
 #endif
 #if canImport(XCTest) && os(iOS)
     import XCTest
@@ -80,7 +80,9 @@ public class GesturePerformer: GesturePerforming {
         private static func snapshotHasTextInputWithFocus(
             _ snapshot: XCUIElementSnapshot,
             depth: Int = 0
-        ) -> Bool {
+        )
+            -> Bool
+        {
             if depth > 64 { return false }
 
             let type = snapshot.elementType
@@ -140,7 +142,8 @@ public class GesturePerformer: GesturePerforming {
                 // the app we want is never SpringBoard in a text-input flow.
                 if app.identifier != "com.apple.springboard" {
                     if let snapshot = try? app.snapshot(),
-                       GesturePerformer.snapshotHasTextInputWithFocus(snapshot) {
+                       GesturePerformer.snapshotHasTextInputWithFocus(snapshot)
+                    {
                         return (true, "snapshot.hasFocus")
                     }
                 }
@@ -166,7 +169,10 @@ public class GesturePerformer: GesturePerforming {
             let (hasFocus, strategy) = try detectKeyboardFocus(app: app)
             let elapsedMs = Int(Date().timeIntervalSince(queryStart) * 1000)
             let appLabel = runOnMainThreadNonThrowing({ app.label }, fallback: "unknown")
-            gestureLog.debug("requireKeyboardFocus hasFocus=\(hasFocus, privacy: .public) strategy=\(strategy, privacy: .public) context=\"\(context, privacy: .public)\" elapsedMs=\(elapsedMs, privacy: .public) appLabel=\(appLabel, privacy: .public)")
+            gestureLog
+                .debug(
+                    "requireKeyboardFocus hasFocus=\(hasFocus, privacy: .public) strategy=\(strategy, privacy: .public) context=\"\(context, privacy: .public)\" elapsedMs=\(elapsedMs, privacy: .public) appLabel=\(appLabel, privacy: .public)"
+                )
 
             guard hasFocus else {
                 let diag = buildFocusDiagnostic(app: app, reason: "requireKeyboardFocus: \(context)")
@@ -188,9 +194,14 @@ public class GesturePerformer: GesturePerforming {
             app: XCUIApplication,
             element: XCUIElement,
             resourceId: String
-        ) throws {
+        )
+            throws
+        {
             let tapStart = Date()
-            gestureLog.debug("tapAndAwaitKeyboardFocus begin resourceId=\(resourceId, privacy: .public) exists=\(element.exists, privacy: .public) isHittable=\(element.isHittable, privacy: .public) type=\(element.elementType.rawValue, privacy: .public)")
+            gestureLog
+                .debug(
+                    "tapAndAwaitKeyboardFocus begin resourceId=\(resourceId, privacy: .public) exists=\(element.exists, privacy: .public) isHittable=\(element.isHittable, privacy: .public) type=\(element.elementType.rawValue, privacy: .public)"
+                )
             element.tap()
 
             let deadline = Date().addingTimeInterval(0.5)
@@ -207,7 +218,10 @@ public class GesturePerformer: GesturePerforming {
                 }
             }
             let elapsedMs = Int(Date().timeIntervalSince(tapStart) * 1000)
-            gestureLog.debug("tapAndAwaitKeyboardFocus done resourceId=\(resourceId, privacy: .public) hasFocus=\(hasFocus, privacy: .public) strategy=\(strategy, privacy: .public) iterations=\(iterations, privacy: .public) elapsedMs=\(elapsedMs, privacy: .public)")
+            gestureLog
+                .debug(
+                    "tapAndAwaitKeyboardFocus done resourceId=\(resourceId, privacy: .public) hasFocus=\(hasFocus, privacy: .public) strategy=\(strategy, privacy: .public) iterations=\(iterations, privacy: .public) elapsedMs=\(elapsedMs, privacy: .public)"
+                )
 
             guard hasFocus else {
                 let diag = buildFocusDiagnostic(app: app, reason: "tapAndAwaitKeyboardFocus: \(resourceId)")
@@ -243,7 +257,7 @@ public class GesturePerformer: GesturePerforming {
                     // Only introspect a small number to avoid heavy XPC.
                     let cap = min(count, 5)
                     if cap > 0 {
-                        for i in 0..<cap {
+                        for i in 0 ..< cap {
                             let el = query.element(boundBy: i)
                             let hasFocus = (el.value(forKey: "hasKeyboardFocus") as? Bool) ?? false
                             let identifier = el.identifier
@@ -251,7 +265,10 @@ public class GesturePerformer: GesturePerforming {
                             let isSelected = el.isSelected
                             let isHittable = el.isHittable
                             let frame = el.frame
-                            parts.append("\(name)[\(i)]={id=\"\(identifier)\",hasKeyboardFocus=\(hasFocus),isSelected=\(isSelected),isHittable=\(isHittable),value.len=\(value.count),frame=\(Int(frame.origin.x)),\(Int(frame.origin.y)),\(Int(frame.size.width)),\(Int(frame.size.height))}")
+                            parts
+                                .append(
+                                    "\(name)[\(i)]={id=\"\(identifier)\",hasKeyboardFocus=\(hasFocus),isSelected=\(isSelected),isHittable=\(isHittable),value.len=\(value.count),frame=\(Int(frame.origin.x)),\(Int(frame.origin.y)),\(Int(frame.size.width)),\(Int(frame.size.height))}"
+                                )
                         }
                     }
                 }
@@ -340,7 +357,9 @@ public class GesturePerformer: GesturePerforming {
             fingerCount: Int,
             fingerSpacing: Double,
             duration: TimeInterval
-        ) throws {
+        )
+            throws
+        {
             guard application != nil else {
                 throw GestureError.noApplication
             }
@@ -432,10 +451,38 @@ public class GesturePerformer: GesturePerforming {
 
         // MARK: - Pinch Gestures
 
-        public func pinch(centerX _: Double, centerY _: Double, scale _: Double, duration _: TimeInterval) throws {
-            // Pinch gesture using XCUITest is limited
-            // We can simulate by using the app's pinch method if an element is available
-            throw GestureError.notSupported("Coordinate-based pinch not yet implemented")
+        public func pinch(
+            centerX: Double,
+            centerY: Double,
+            distanceStart: Double,
+            distanceEnd: Double,
+            rotationDegrees: Double,
+            duration: TimeInterval
+        )
+            throws
+        {
+            guard application != nil else {
+                throw GestureError.noApplication
+            }
+
+            try runOnMainThread {
+                let orientation = GesturePerformer.currentInterfaceOrientation()
+                var errorMessage: NSString?
+                let succeeded = ObjCExceptionCatcher_synthesizePinch(
+                    CGFloat(centerX),
+                    CGFloat(centerY),
+                    CGFloat(distanceStart),
+                    CGFloat(distanceEnd),
+                    CGFloat(rotationDegrees),
+                    duration,
+                    orientation.rawValue,
+                    &errorMessage
+                )
+
+                if !succeeded {
+                    throw GestureError.gestureFailed(errorMessage as String? ?? "pinch synthesis failed")
+                }
+            }
         }
 
         // MARK: - Text Input
@@ -544,7 +591,7 @@ public class GesturePerformer: GesturePerforming {
                 for query in queries {
                     let count = query.count
                     guard count > 0 else { continue }
-                    for i in 0..<count {
+                    for i in 0 ..< count {
                         let candidate = query.element(boundBy: i)
                         guard let snap = try? candidate.snapshot() else { continue }
                         if snap.hasFocus { return candidate }
@@ -553,10 +600,10 @@ public class GesturePerformer: GesturePerforming {
 
                 let otherQuery = app.otherElements
                 let otherCount = otherQuery.count
-                for i in 0..<otherCount {
+                for i in 0 ..< otherCount {
                     let candidate = otherQuery.element(boundBy: i)
                     guard let snap = try? candidate.snapshot() else { continue }
-                    if snap.hasFocus && GesturePerformer.snapshotLooksLikeTextInput(snap) {
+                    if snap.hasFocus, GesturePerformer.snapshotLooksLikeTextInput(snap) {
                         return candidate
                     }
                 }
@@ -595,7 +642,7 @@ public class GesturePerformer: GesturePerforming {
         /// so the loop runs the full count. Extra deletes on an empty field
         /// are harmless no-ops.
         private static func clearViaDeletes(element: XCUIElement) {
-            for _ in 0..<clearViaDeletesMaxIterations {
+            for _ in 0 ..< clearViaDeletesMaxIterations {
                 let current = (element.value as? String) ?? ""
                 if current.isEmpty { break }
                 element.coordinate(withNormalizedOffset: CGVector(dx: 0.95, dy: 0.5)).tap()
@@ -672,7 +719,9 @@ public class GesturePerformer: GesturePerforming {
             expected: Bool,
             timeout: TimeInterval = 1.0,
             interval: TimeInterval = 0.05
-        ) -> Bool {
+        )
+            -> Bool
+        {
             let deadline = Date().addingTimeInterval(timeout)
             var visible = isKeyboardVisible(app: app)
             while visible != expected && Date() < deadline {
@@ -1196,7 +1245,16 @@ public class GesturePerformer: GesturePerforming {
             throw GestureError.notSupported("XCUITest only available on iOS")
         }
 
-        public func pinch(centerX _: Double, centerY _: Double, scale _: Double, duration _: TimeInterval) throws {
+        public func pinch(
+            centerX _: Double,
+            centerY _: Double,
+            distanceStart _: Double,
+            distanceEnd _: Double,
+            rotationDegrees _: Double,
+            duration _: TimeInterval
+        )
+            throws
+        {
             throw GestureError.notSupported("XCUITest only available on iOS")
         }
 

--- a/ios/control-proxy/Sources/CtrlProxy/Protocols.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/Protocols.swift
@@ -104,8 +104,16 @@ public protocol GesturePerforming {
 
     // MARK: - Pinch Gestures
 
-    /// Pinch at center with scale
-    func pinch(centerX: Double, centerY: Double, scale: Double, duration: TimeInterval) throws
+    /// Pinch at center with explicit starting and ending finger distances.
+    func pinch(
+        centerX: Double,
+        centerY: Double,
+        distanceStart: Double,
+        distanceEnd: Double,
+        rotationDegrees: Double,
+        duration: TimeInterval
+    )
+        throws
 
     // MARK: - Text Input
 

--- a/ios/control-proxy/Sources/ObjCExceptionCatcher/ObjCExceptionCatcher.m
+++ b/ios/control-proxy/Sources/ObjCExceptionCatcher/ObjCExceptionCatcher.m
@@ -1,4 +1,5 @@
 #import "ObjCExceptionCatcher.h"
+#import <math.h>
 
 NSException * _Nullable ObjCExceptionCatcher_tryBlock(void (NS_NOESCAPE ^block)(void)) {
     @try {
@@ -86,6 +87,98 @@ BOOL ObjCExceptionCatcher_synthesizeMultiFingerSwipe(
 #else
     if (errorMessage != NULL) {
         *errorMessage = @"XCTest private multi-touch event synthesis is only available on iOS";
+    }
+    return NO;
+#endif
+}
+
+BOOL ObjCExceptionCatcher_synthesizePinch(
+    CGFloat centerX,
+    CGFloat centerY,
+    CGFloat distanceStart,
+    CGFloat distanceEnd,
+    CGFloat rotationDegrees,
+    NSTimeInterval duration,
+    NSInteger interfaceOrientation,
+    NSString *_Nullable *_Nullable errorMessage
+) {
+#if TARGET_OS_IOS
+    __block BOOL success = NO;
+    __block NSString *failure = nil;
+
+    NSException *exception = ObjCExceptionCatcher_tryBlock(^{
+        Class pathClass = NSClassFromString(@"XCPointerEventPath");
+        Class recordClass = NSClassFromString(@"XCSynthesizedEventRecord");
+
+        if (pathClass == Nil || recordClass == Nil) {
+            failure = @"XCTest private pinch event synthesis classes are unavailable";
+            return;
+        }
+        if (![pathClass instancesRespondToSelector:@selector(initForTouchAtPoint:offset:)] ||
+            ![pathClass instancesRespondToSelector:@selector(moveToPoint:atOffset:)] ||
+            ![pathClass instancesRespondToSelector:@selector(liftUpAtOffset:)]) {
+            failure = @"XCPointerEventPath does not support the expected pinch selectors";
+            return;
+        }
+        if (![recordClass instancesRespondToSelector:@selector(initWithName:interfaceOrientation:)] ||
+            ![recordClass instancesRespondToSelector:@selector(addPointerEventPath:)] ||
+            ![recordClass instancesRespondToSelector:@selector(synthesizeWithError:)]) {
+            failure = @"XCSynthesizedEventRecord does not support the expected pinch synthesis selectors";
+            return;
+        }
+
+        CGFloat startRadius = MAX(distanceStart, 1) / 2.0;
+        CGFloat endRadius = MAX(distanceEnd, 1) / 2.0;
+        CGFloat endRadians = rotationDegrees * (CGFloat)M_PI / 180.0;
+        CGFloat dxStart = startRadius;
+        CGFloat dyStart = 0;
+        CGFloat dxEnd = cos(endRadians) * endRadius;
+        CGFloat dyEnd = sin(endRadians) * endRadius;
+
+        XCSynthesizedEventRecord *record = [[recordClass alloc]
+            initWithName:@"AutoMobile pinch"
+            interfaceOrientation:(UIInterfaceOrientation)interfaceOrientation
+        ];
+        NSTimeInterval liftOffset = duration > 0.05 ? duration : 0.05;
+
+        XCPointerEventPath *firstPath = [[pathClass alloc]
+            initForTouchAtPoint:CGPointMake(centerX - dxStart, centerY - dyStart)
+            offset:0
+        ];
+        [firstPath moveToPoint:CGPointMake(centerX - dxEnd, centerY - dyEnd) atOffset:duration];
+        [firstPath liftUpAtOffset:liftOffset];
+        [record addPointerEventPath:firstPath];
+
+        XCPointerEventPath *secondPath = [[pathClass alloc]
+            initForTouchAtPoint:CGPointMake(centerX + dxStart, centerY + dyStart)
+            offset:0
+        ];
+        [secondPath moveToPoint:CGPointMake(centerX + dxEnd, centerY + dyEnd) atOffset:duration];
+        [secondPath liftUpAtOffset:liftOffset];
+        [record addPointerEventPath:secondPath];
+
+        NSError *synthesisError = nil;
+        success = [record synthesizeWithError:&synthesisError];
+        if (!success) {
+            NSString *description = synthesisError.localizedDescription != nil ? synthesisError.localizedDescription : @"unknown error";
+            failure = [NSString stringWithFormat:@"pinch synthesis failed: %@",
+                       description];
+        }
+    });
+
+    if (exception != nil) {
+        NSString *reason = exception.reason != nil ? exception.reason : @"no reason";
+        failure = [NSString stringWithFormat:@"Objective-C exception during pinch synthesis: %@ - %@",
+                   exception.name, reason];
+    }
+    if (!success && errorMessage != NULL) {
+        *errorMessage = failure != nil ? failure : @"pinch synthesis failed";
+    }
+
+    return success;
+#else
+    if (errorMessage != NULL) {
+        *errorMessage = @"XCTest private pinch event synthesis is only available on iOS";
     }
     return NO;
 #endif

--- a/ios/control-proxy/Sources/ObjCExceptionCatcher/include/ObjCExceptionCatcher.h
+++ b/ios/control-proxy/Sources/ObjCExceptionCatcher/include/ObjCExceptionCatcher.h
@@ -43,4 +43,18 @@ FOUNDATION_EXPORT BOOL ObjCExceptionCatcher_synthesizeMultiFingerSwipe(
     NSString *_Nullable *_Nullable errorMessage
 );
 
+/// Synthesizes a two-finger pinch through XCTest private event APIs.
+/// Returns NO with a descriptive error message when the private symbols are unavailable
+/// or synthesis fails. Objective-C exceptions are caught and reported through errorMessage.
+FOUNDATION_EXPORT BOOL ObjCExceptionCatcher_synthesizePinch(
+    CGFloat centerX,
+    CGFloat centerY,
+    CGFloat distanceStart,
+    CGFloat distanceEnd,
+    CGFloat rotationDegrees,
+    NSTimeInterval duration,
+    NSInteger interfaceOrientation,
+    NSString *_Nullable *_Nullable errorMessage
+);
+
 NS_ASSUME_NONNULL_END

--- a/ios/control-proxy/Tests/CtrlProxyTests/CommandHandlerTests.swift
+++ b/ios/control-proxy/Tests/CtrlProxyTests/CommandHandlerTests.swift
@@ -575,7 +575,57 @@ final class CommandHandlerTests: XCTestCase {
 
         XCTAssertFalse(response.success ?? true)
         XCTAssertEqual(response.type, "multi_finger_swipe_result")
-        XCTAssertTrue(response.error?.contains("XCTest private multi-touch event synthesis classes are unavailable") ?? false)
+        XCTAssertTrue(response.error?
+            .contains("XCTest private multi-touch event synthesis classes are unavailable") ?? false)
+    }
+
+    func testPinchSuccessForwardsRequestPayload() {
+        let request = WebSocketRequest(
+            type: "request_pinch",
+            requestId: "test-pinch",
+            duration: 700,
+            centerX: 100,
+            centerY: 200,
+            distanceStart: 40,
+            distanceEnd: 120,
+            rotationDegrees: 15
+        )
+
+        guard let response = handleRequest(request, as: WebSocketResponse.self) else { return }
+
+        XCTAssertTrue(response.success ?? false)
+        XCTAssertEqual(response.type, "pinch_result")
+        XCTAssertEqual(response.requestId, "test-pinch")
+
+        let history = fakeGesturePerformer.getPinchHistory()
+        XCTAssertEqual(history.count, 1)
+        XCTAssertEqual(history.first?.centerX, 100)
+        XCTAssertEqual(history.first?.centerY, 200)
+        XCTAssertEqual(history.first?.distanceStart, 40)
+        XCTAssertEqual(history.first?.distanceEnd, 120)
+        XCTAssertEqual(history.first?.rotationDegrees, 15)
+        XCTAssertEqual(history.first?.duration ?? -1, 0.7, accuracy: 0.0001)
+    }
+
+    func testPinchFailureReturnsTypedError() {
+        fakeGesturePerformer.setFailure(
+            for: "pinch",
+            error: GesturePerformer.GestureError.gestureFailed("pinch synthesis failed")
+        )
+        let request = WebSocketRequest(
+            type: "request_pinch",
+            requestId: "test-pinch-failure",
+            centerX: 100,
+            centerY: 200,
+            distanceStart: 40,
+            distanceEnd: 120
+        )
+
+        guard let response = handleRequest(request, as: WebSocketResponse.self) else { return }
+
+        XCTAssertFalse(response.success ?? true)
+        XCTAssertEqual(response.type, "pinch_result")
+        XCTAssertTrue(response.error?.contains("pinch synthesis failed") ?? false)
     }
 
     // MARK: - Text Input Tests

--- a/src/features/action/PinchOn.ts
+++ b/src/features/action/PinchOn.ts
@@ -14,6 +14,7 @@ import type { ElementParser } from "../../utils/interfaces/ElementParser";
 import { DefaultElementFinder } from "../utility/ElementFinder";
 import { DefaultElementParser } from "../utility/ElementParser";
 import { AndroidCtrlProxyClient } from "../observe/android";
+import { IOSCtrlProxyClient } from "../observe/ios";
 import { AndroidCtrlProxyManager } from "../../utils/CtrlProxyManager";
 import { createGlobalPerformanceTracker } from "../../utils/PerformanceTracker";
 import { boundsArea, clamp } from "../../utils/bounds";
@@ -83,24 +84,9 @@ export class PinchOn extends BaseVisualChange {
       return this.createErrorResult("Pinch direction is required ('in' or 'out')", options);
     }
 
-    if (this.device.platform === "ios") {
-      perf.end();
-      return this.createErrorResult("pinchOn is not supported on iOS yet.", options);
-    }
-
-    if (this.device.platform !== "android") {
+    if (this.device.platform !== "android" && this.device.platform !== "ios") {
       perf.end();
       return this.createErrorResult(`Unsupported platform: ${this.device.platform}`, options);
-    }
-
-    const a11yManager = AndroidCtrlProxyManager.getInstance(this.device, this.adb);
-    const available = await perf.track("a11yAvailable", () => a11yManager.isAvailable());
-    if (!available) {
-      perf.end();
-      return this.createErrorResult(
-        "pinchOn requires the AutoMobile accessibility service to be installed and enabled.",
-        options
-      );
     }
 
     if (options.scale !== undefined && options.scale <= 0) {
@@ -129,18 +115,46 @@ export class PinchOn extends BaseVisualChange {
       }
     }
 
+    if (this.device.platform === "android") {
+      const a11yManager = AndroidCtrlProxyManager.getInstance(this.device, this.adb);
+      const available = await perf.track("a11yAvailable", () => a11yManager.isAvailable());
+      if (!available) {
+        perf.end();
+        return this.createErrorResult(
+          "pinchOn requires the AutoMobile accessibility service to be installed and enabled.",
+          options
+        );
+      }
+    }
+
     try {
       const target = await perf.track("resolveTarget", () => this.resolveTarget(options));
       const { centerX, centerY } = this.getCenter(target.bounds);
-      const { distanceStart, distanceEnd, scale } = this.resolveDistances(options, target.bounds);
+      let { distanceStart, distanceEnd, scale } = this.resolveDistances(options, target.bounds);
+      if (this.device.platform === "ios") {
+        distanceStart = Math.round(distanceStart);
+        distanceEnd = Math.round(distanceEnd);
+        scale = distanceStart > 0 ? distanceEnd / distanceStart : scale;
+      }
       const duration = options.duration ?? 300;
       const rotationDegrees = options.rotationDegrees ?? 0;
 
-      const a11yClient = AndroidCtrlProxyClient.getInstance(this.device, this.adbFactory);
-
       const pinchResult = await this.observedInteraction(
         async () => {
-          return await a11yClient.requestPinch(
+          if (this.device.platform === "ios") {
+            return await IOSCtrlProxyClient.getInstance(this.device).requestPinch(
+              centerX,
+              centerY,
+              distanceStart,
+              distanceEnd,
+              rotationDegrees,
+              duration,
+              5000,
+              perf
+            );
+          }
+
+          return await AndroidCtrlProxyClient.getInstance(this.device, this.adbFactory).requestPinch(
             centerX,
             centerY,
             distanceStart,

--- a/test/features/action/PinchOn.test.ts
+++ b/test/features/action/PinchOn.test.ts
@@ -2,8 +2,10 @@ import { afterEach, beforeEach, describe, expect, spyOn, test } from "bun:test";
 import type { BootedDevice, ObserveResult, ViewHierarchyResult } from "../../../src/models";
 import { PinchOn } from "../../../src/features/action/PinchOn";
 import { AndroidCtrlProxyClient } from "../../../src/features/observe/android";
+import { IOSCtrlProxyClient } from "../../../src/features/observe/ios";
 import { AndroidCtrlProxyManager } from "../../../src/utils/CtrlProxyManager";
 import { FakeCtrlProxy } from "../../fakes/FakeCtrlProxy";
+import { FakeIOSCtrlProxy } from "../../fakes/FakeIOSCtrlProxy";
 import { FakeAdbExecutor } from "../../fakes/FakeAdbExecutor";
 import { FakeAwaitIdle } from "../../fakes/FakeAwaitIdle";
 import { FakeObserveScreen } from "../../fakes/FakeObserveScreen";
@@ -23,8 +25,10 @@ describe("PinchOn", () => {
   let fakeWindow: FakeWindow;
   let fakeTimer: FakeTimer;
   let fakeA11yService: FakeCtrlProxy;
+  let fakeIosService: FakeIOSCtrlProxy;
   let fakeAdb: FakeAdbExecutor;
   let getInstanceSpy: ReturnType<typeof spyOn> | null = null;
+  let iosGetInstanceSpy: ReturnType<typeof spyOn> | null = null;
   let managerSpy: ReturnType<typeof spyOn> | null = null;
 
   const createHierarchy = (): ViewHierarchyResult => ({
@@ -58,6 +62,7 @@ describe("PinchOn", () => {
     fakeTimer = new FakeTimer();
     fakeTimer.enableAutoAdvance();
     fakeA11yService = new FakeCtrlProxy();
+    fakeIosService = new FakeIOSCtrlProxy();
     fakeAdb = new FakeAdbExecutor();
 
     fakeObserveScreen.setObserveResult(() => createObserveResult());
@@ -68,6 +73,7 @@ describe("PinchOn", () => {
       isAvailable: async () => true
     } as any);
     getInstanceSpy = spyOn(AndroidCtrlProxyClient, "getInstance").mockReturnValue(fakeA11yService as any);
+    iosGetInstanceSpy = spyOn(IOSCtrlProxyClient, "getInstance").mockReturnValue(fakeIosService as any);
 
     pinchOn = new PinchOn(device);
     (pinchOn as any).observeScreen = fakeObserveScreen;
@@ -79,6 +85,7 @@ describe("PinchOn", () => {
 
   afterEach(() => {
     getInstanceSpy?.mockRestore();
+    iosGetInstanceSpy?.mockRestore();
     managerSpy?.mockRestore();
   });
 
@@ -117,5 +124,107 @@ describe("PinchOn", () => {
     expect(pinchCall).toBeDefined();
     expect(pinchCall.centerX).toBe(100);
     expect(pinchCall.centerY).toBe(100);
+  });
+
+  test("routes iOS pinch through the iOS CtrlProxy request_pinch command", async () => {
+    const iosDevice: BootedDevice = {
+      deviceId: "11111111-2222-3333-4444-555555555555",
+      platform: "ios",
+      name: "iPhone 16 Pro"
+    };
+    managerSpy?.mockReturnValue({
+      isAvailable: async () => false
+    } as any);
+    fakeIosService.setPinchResult({ success: true, totalTimeMs: 710, gestureTimeMs: 700 });
+    pinchOn = new PinchOn(iosDevice);
+    (pinchOn as any).observeScreen = fakeObserveScreen;
+    (pinchOn as any).awaitIdle = fakeAwaitIdle;
+    (pinchOn as any).window = fakeWindow;
+    (pinchOn as any).adb = fakeAdb;
+    (pinchOn as any).timer = fakeTimer;
+
+    const result = await pinchOn.execute({
+      direction: "out",
+      container: { elementId: "container-id" },
+      duration: 700,
+      rotationDegrees: 15
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.targetType).toBe("container");
+    expect(result.a11yTotalTimeMs).toBe(710);
+    expect(fakeA11yService.getPinchHistory()).toHaveLength(0);
+    expect(managerSpy).not.toHaveBeenCalled();
+
+    const [pinchCall] = fakeIosService.getPinchHistory();
+    expect(pinchCall).toEqual({
+      centerX: 100,
+      centerY: 100,
+      distanceStart: 40,
+      distanceEnd: 120,
+      rotationDegrees: 15,
+      duration: 700,
+      timeoutMs: 5000
+    });
+  });
+
+  test("rounds fractional default iOS pinch distances before sending request_pinch", async () => {
+    const iosDevice: BootedDevice = {
+      deviceId: "11111111-2222-3333-4444-555555555555",
+      platform: "ios",
+      name: "iPhone 16 Pro"
+    };
+    fakeObserveScreen.setObserveResult(() => ({
+      updatedAt: Date.now(),
+      screenSize: { width: 393, height: 852 },
+      systemInsets: { top: 0, right: 0, bottom: 0, left: 0 },
+      viewHierarchy: createHierarchy()
+    }));
+    fakeIosService.setPinchResult({ success: true, totalTimeMs: 300, gestureTimeMs: 300 });
+    pinchOn = new PinchOn(iosDevice);
+    (pinchOn as any).observeScreen = fakeObserveScreen;
+    (pinchOn as any).awaitIdle = fakeAwaitIdle;
+    (pinchOn as any).window = fakeWindow;
+    (pinchOn as any).adb = fakeAdb;
+    (pinchOn as any).timer = fakeTimer;
+
+    const result = await pinchOn.execute({
+      direction: "out",
+      autoTarget: false
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.distanceStart).toBe(79);
+    expect(result.distanceEnd).toBe(236);
+    expect(result.scale).toBe(236 / 79);
+
+    const [pinchCall] = fakeIosService.getPinchHistory();
+    expect(pinchCall.distanceStart).toBe(79);
+    expect(pinchCall.distanceEnd).toBe(236);
+  });
+
+  test("surfaces iOS CtrlProxy pinch failures", async () => {
+    const iosDevice: BootedDevice = {
+      deviceId: "11111111-2222-3333-4444-555555555555",
+      platform: "ios",
+      name: "iPhone 16 Pro"
+    };
+    fakeIosService.setPinchResult({ success: false, error: "Pinch failed on runner" });
+    pinchOn = new PinchOn(iosDevice);
+    (pinchOn as any).observeScreen = fakeObserveScreen;
+    (pinchOn as any).awaitIdle = fakeAwaitIdle;
+    (pinchOn as any).window = fakeWindow;
+    (pinchOn as any).adb = fakeAdb;
+    (pinchOn as any).timer = fakeTimer;
+
+    const result = await pinchOn.execute({
+      direction: "in",
+      autoTarget: false
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBe("Pinch failed on runner");
+    expect(fakeIosService.getPinchHistory()).toHaveLength(1);
+    expect(fakeA11yService.getPinchHistory()).toHaveLength(0);
   });
 });


### PR DESCRIPTION
## Summary
- Fixes #2639 by routing TypeScript `pinchOn` calls on iOS through `IOSCtrlProxyClient.requestPinch`
- Implements the iOS CtrlProxy `request_pinch` runner path with two-finger synthesized touch paths using the requested center, distances, rotation, and duration
- Adds focused TypeScript and Swift command-handler tests for iOS pinch success and failure propagation

## Testing
- `bun test test/features/action/PinchOn.test.ts`
- `bash scripts/ios/swift-test.sh`
- `bun test`
- `bun run lint`
- `bun run build`
- `ONLY_TOUCHED_FILES=true bash scripts/swiftformat/validate_swiftformat.sh`
- `ONLY_TOUCHED_FILES=true bash scripts/swiftlint/validate_swiftlint.sh`
- `(cd ios/control-proxy && swift test)`
- `git diff --check`

## Notes
- No `.github/pull_request_template.md` or `.github/PULL_REQUEST_TEMPLATE/` file exists locally, and GitHub did not return a standard repository PR template path. This body follows the repo's Summary/Testing convention.
