### PR TITLE
fix: verify Android time zone read-back in setTimeZone (#2661)

### DIFF
--- a/src/features/utility/system-configuration/AndroidSystemConfigurationAdapter.ts
+++ b/src/features/utility/system-configuration/AndroidSystemConfigurationAdapter.ts
@@ -84,11 +84,21 @@ export class AndroidSystemConfigurationAdapter implements SystemConfigurationAda
     const previousZoneId = await this.readSetting("shell getprop persist.sys.timezone");
 
     try {
-      await this.adb.executeCommand(`shell setprop persist.sys.timezone ${zoneId}`);
+      await this.adb.executeCommand(`shell setprop persist.sys.timezone ${quoteShellArg(zoneId)}`);
+      const effectiveZoneId = await this.readSetting("shell getprop persist.sys.timezone");
+      if (effectiveZoneId !== zoneId) {
+        return {
+          success: false,
+          zoneId,
+          previousZoneId,
+          error: `Read-back verification failed: expected "${zoneId}" but got "${effectiveZoneId ?? "null"}"`
+        };
+      }
       return {
         success: true,
         zoneId,
-        previousZoneId
+        previousZoneId,
+        method: "setprop persist.sys.timezone"
       };
     } catch (error) {
       const errorMessage = error instanceof Error ? error.message : String(error);

--- a/src/models/SetTimeZoneResult.ts
+++ b/src/models/SetTimeZoneResult.ts
@@ -2,5 +2,6 @@ export interface SetTimeZoneResult {
   success: boolean;
   zoneId: string;
   previousZoneId?: string | null;
+  method?: string;
   error?: string;
 }

--- a/test/features/utility/SystemConfigurationAdapter.test.ts
+++ b/test/features/utility/SystemConfigurationAdapter.test.ts
@@ -234,18 +234,80 @@ describe("SystemConfigurationAdapter", () => {
       expect(await adapter.broadcastLocaleChange()).toBe(false);
     });
 
-    it("sets the system time zone via setprop", async () => {
+    it("sets the system time zone via setprop and verifies the read-back", async () => {
       const adb = new FakeAdbClient();
+      adb.setCommandResult("shell getprop persist.sys.timezone", "Asia/Tokyo");
       const adapter = new AndroidSystemConfigurationAdapter(androidDevice, adb as any);
       const result = await adapter.setTimeZone("Asia/Tokyo");
       expect(result.success).toBe(true);
       expect(result.zoneId).toBe("Asia/Tokyo");
-      const recorded = (adb as any).commandCalls;
-      expect(
-        recorded.some((c: { command: string }) =>
-          c.command.includes("setprop persist.sys.timezone Asia/Tokyo")
-        )
-      ).toBe(true);
+      expect(result.method).toBe("setprop persist.sys.timezone");
+      expect(adb.wasCommandExecuted("setprop persist.sys.timezone 'Asia/Tokyo'")).toBe(true);
+    });
+
+    it("returns the previous time zone when read-back confirms the change", async () => {
+      const adb = new FakeAdbClient();
+      const responses = ["America/New_York", "Asia/Tokyo"];
+      const original = adb.executeCommand.bind(adb);
+      adb.executeCommand = (async (command: string, ...rest: any[]) => {
+        if (command === "shell getprop persist.sys.timezone") {
+          return {
+            stdout: responses.shift() ?? "Asia/Tokyo",
+            stderr: "",
+            toString: () => "",
+            trim: () => "",
+            includes: () => false,
+          };
+        }
+        return original(command, ...rest);
+      }) as any;
+      const adapter = new AndroidSystemConfigurationAdapter(androidDevice, adb as any);
+      const result = await adapter.setTimeZone("Asia/Tokyo");
+      expect(result.success).toBe(true);
+      expect(result.previousZoneId).toBe("America/New_York");
+    });
+
+    it("returns false when the time-zone read-back does not match (silent no-op)", async () => {
+      const adb = new FakeAdbClient();
+      // setprop is silently ignored (e.g. non-root adbd): getprop still returns the old value.
+      adb.setCommandResult("shell getprop persist.sys.timezone", "America/New_York");
+      const adapter = new AndroidSystemConfigurationAdapter(androidDevice, adb as any);
+      const result = await adapter.setTimeZone("Asia/Tokyo");
+
+      expect(result.success).toBe(false);
+      expect(result.zoneId).toBe("Asia/Tokyo");
+      expect(result.error).toBe('Read-back verification failed: expected "Asia/Tokyo" but got "America/New_York"');
+    });
+
+    it("returns false when the time-zone read-back is null", async () => {
+      const adb = new FakeAdbClient();
+      const adapter = new AndroidSystemConfigurationAdapter(androidDevice, adb as any);
+      const result = await adapter.setTimeZone("Asia/Tokyo");
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBe('Read-back verification failed: expected "Asia/Tokyo" but got "null"');
+    });
+
+    it("surfaces setprop failures for time-zone changes", async () => {
+      const adb = new FakeAdbClient();
+      adb.setCommandError(
+        "shell setprop persist.sys.timezone 'Asia/Tokyo'",
+        new Error("device offline")
+      );
+      const adapter = new AndroidSystemConfigurationAdapter(androidDevice, adb as any);
+      const result = await adapter.setTimeZone("Asia/Tokyo");
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBe("Failed to set time zone: device offline");
+    });
+
+    it("shell-quotes the time-zone id to avoid injection", async () => {
+      const adb = new FakeAdbClient();
+      adb.setCommandResult("shell getprop persist.sys.timezone", "Asia/Tokyo");
+      const adapter = new AndroidSystemConfigurationAdapter(androidDevice, adb as any);
+      await adapter.setTimeZone("Asia/Tokyo");
+      expect(adb.wasCommandExecuted("setprop persist.sys.timezone 'Asia/Tokyo'")).toBe(true);
+      expect(adb.wasCommandExecuted("setprop persist.sys.timezone Asia/Tokyo;")).toBe(false);
     });
   });
 

--- a/test/features/utility/SystemConfigurationManager.test.ts
+++ b/test/features/utility/SystemConfigurationManager.test.ts
@@ -512,16 +512,33 @@ describe("SystemConfigurationManager", () => {
 
   describe("Android setTimeZone still works", () => {
     test("uses adb commands for Android", async () => {
+      fakeAdbClient.setCommandResult("shell getprop persist.sys.timezone", "America/New_York");
       const mgr = new SystemConfigurationManager(ANDROID_DEVICE, fakeAdbFactory, fakeExec);
       const result = await mgr.setTimeZone("America/New_York");
 
       expect(result.success).toBe(true);
       expect(fakeExec.getExecutedCommands()).toHaveLength(0);
-      expect(fakeAdbClient.wasCommandExecuted("setprop persist.sys.timezone America/New_York")).toBe(true);
+      expect(fakeAdbClient.wasCommandExecuted("setprop persist.sys.timezone 'America/New_York'")).toBe(true);
     });
 
     test("reads previous timezone before setting", async () => {
-      fakeAdbClient.setCommandResult("shell getprop persist.sys.timezone", "America/Los_Angeles");
+      // First getprop (previous) returns the old zone; the read-back after
+      // setprop returns the new zone so verification passes.
+      const responses = ["America/Los_Angeles", "Asia/Tokyo"];
+      const original = fakeAdbClient.executeCommand.bind(fakeAdbClient);
+      fakeAdbClient.executeCommand = (async (command: string, ...rest: any[]) => {
+        if (command === "shell getprop persist.sys.timezone") {
+          const stdout = responses.shift() ?? "Asia/Tokyo";
+          return {
+            stdout,
+            stderr: "",
+            toString: () => stdout,
+            trim: () => stdout,
+            includes: (s: string) => stdout.includes(s),
+          };
+        }
+        return original(command, ...rest);
+      }) as any;
       const mgr = new SystemConfigurationManager(ANDROID_DEVICE, fakeAdbFactory, fakeExec);
       const result = await mgr.setTimeZone("Asia/Tokyo");
 
@@ -538,7 +555,7 @@ describe("SystemConfigurationManager", () => {
     });
 
     test("returns error when adb command fails", async () => {
-      fakeAdbClient.setCommandError("shell setprop persist.sys.timezone Bad/Zone", new Error("setprop failed"));
+      fakeAdbClient.setCommandError("shell setprop persist.sys.timezone 'Bad/Zone'", new Error("setprop failed"));
       const mgr = new SystemConfigurationManager(ANDROID_DEVICE, fakeAdbFactory, fakeExec);
       const result = await mgr.setTimeZone("Bad/Zone");
 


### PR DESCRIPTION
## Summary

`AndroidSystemConfigurationAdapter.setTimeZone` returned `success: true` **without reading the value back to confirm it stuck**, while every sibling setter in the same class (`setLocale`, `set24HourFormat`, `setCalendarSystem`) was given read-back verification. On a device where `setprop persist.sys.timezone` is silently ignored (non-root adbd, restricted prop), the tool reported success on a no-op.

Closes #2661.

## Changes

- **Read-back verification** — after `setprop`, read `persist.sys.timezone` back and compare, mirroring `setLocale`. On mismatch, return `success: false` with `Read-back verification failed: expected "X" but got "Y"`.
- **Shell quoting** — wrap the zone id in `quoteShellArg(...)`, matching `setLocale` and closing the latent interpolation seam (`setTimeZone` previously interpolated `${zoneId}` unguarded).
- **Model** — add optional `method` field to `SetTimeZoneResult` for parity with `SetLocaleResult`; success now reports `method: "setprop persist.sys.timezone"`.

## Test plan

Added cases to `test/features/utility/SystemConfigurationAdapter.test.ts` mirroring the existing `setLocale` read-back tests:

- success path with confirming read-back (asserts `method` + shell-quoted command)
- `previousZoneId` captured before the write
- read-back mismatch (silent no-op) → `success: false`
- null read-back → `success: false`
- `setprop` failure surfaces the error
- zone id is shell-quoted (injection guard)

```
bun test test/features/utility/SystemConfigurationAdapter.test.ts   # 41 pass, ~99ms
bun run lint
bun build.ts
```

All green.
