### PR TITLE
refactor: consolidate device-vs-session scope resolution in SocketServer

### DIFF
--- a/src/daemon/socketServer.ts
+++ b/src/daemon/socketServer.ts
@@ -420,31 +420,33 @@ export class UnixSocketServer {
     const record = args as Record<string, unknown>;
     const hasSessionUuid = typeof record.sessionUuid === "string" && record.sessionUuid.length > 0;
     const hasDeviceLabel = typeof record.device === "string" && record.device.length > 0;
-    if (hasSessionUuid && hasDeviceLabel) {
-      const sessionUuid = this.resolveDeviceLabelSession(record.sessionUuid as string, record.device);
-      const assignedDevice = this.getAssignedDeviceForSession(sessionUuid);
-      if (assignedDevice) {
-        return `device:${assignedDevice}`;
-      }
-      return `session:${sessionUuid}`;
-    }
 
+    // Precedence (pinned by #2565 review): a device label resolves the mapped session before
+    // an explicit deviceId, which in turn beats a raw session, which beats implicit autolock.
+    if (hasSessionUuid && hasDeviceLabel) {
+      return this.sessionToScopeKey(this.resolveDeviceLabelSession(record.sessionUuid as string, record.device));
+    }
     // An explicit target device must serialize by physical device even when a session is present.
     if (typeof record.deviceId === "string" && record.deviceId.length > 0) {
       return `device:${record.deviceId}`;
     }
     if (hasSessionUuid) {
-      const sessionUuid = record.sessionUuid as string;
-      const assignedDevice = this.getAssignedDeviceForSession(sessionUuid);
-      if (assignedDevice) {
-        return `device:${assignedDevice}`;
-      }
-      return `session:${sessionUuid}`;
+      return this.sessionToScopeKey(record.sessionUuid as string);
     }
     if (typeof record.__mcpSessionId === "string" && record.__mcpSessionId.length > 0) {
       return this.getImplicitAutolockScopeKey(record.__mcpSessionId, args) ?? `mcp-session:${record.__mcpSessionId}`;
     }
     return undefined;
+  }
+
+  /**
+   * Resolve a session UUID to its forwarding scope key: the bound physical device when one is
+   * assigned (so independent devices serialize together), otherwise the raw session. This is the
+   * single resolver every session-keyed branch feeds, including implicit autolock resolution.
+   */
+  private sessionToScopeKey(sessionUuid: string): string {
+    const assignedDevice = this.getAssignedDeviceForSession(sessionUuid);
+    return assignedDevice ? `device:${assignedDevice}` : `session:${sessionUuid}`;
   }
 
   private getImplicitAutolockScopeKey(mcpSessionId: string, args: unknown): string | undefined {
@@ -459,8 +461,7 @@ export class UnixSocketServer {
       if (!autolockSession) {
         return undefined;
       }
-      const assignedDevice = this.getAssignedDeviceForSession(autolockSession);
-      return assignedDevice ? `device:${assignedDevice}` : `session:${autolockSession}`;
+      return this.sessionToScopeKey(autolockSession);
     } catch (error) {
       logger.debug(`Unable to resolve autolock session for MCP session ${mcpSessionId}: ${error}`);
       return undefined;

--- a/test/daemon/socketServerScopeKey.test.ts
+++ b/test/daemon/socketServerScopeKey.test.ts
@@ -1,0 +1,157 @@
+import { describe, expect, test } from "bun:test";
+import { randomUUID } from "node:crypto";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { UnixSocketServer } from "../../src/daemon/socketServer";
+import { FakeTimer } from "../fakes/FakeTimer";
+import type { Session } from "../../src/daemon/sessionManager";
+
+function createFakeSession(
+  sessionId: string,
+  assignedDevice: string,
+  customData: Record<string, unknown> = {}
+): Session {
+  return {
+    sessionId,
+    assignedDevice,
+    platform: "android",
+    createdAt: 0,
+    lastUsedAt: 0,
+    expiresAt: 60_000,
+    cacheData: { customData },
+    lastHeartbeat: 0,
+    sessionTimeoutMs: 60_000,
+    heartbeatTimeoutMs: 10_000,
+    heartbeatTimeoutSource: "default",
+    hasReceivedHeartbeat: false,
+  };
+}
+
+function createFakeDaemonState(
+  sessionDevices: Map<string, string>,
+  sessionCustomData: Map<string, Record<string, unknown>>,
+  mcpAutolockSessions: Map<string, string>
+) {
+  return {
+    isInitialized: () => true,
+    getSessionManager: () => ({
+      getSession: (sessionId: string) => {
+        const assignedDevice = sessionDevices.get(sessionId);
+        return assignedDevice
+          ? createFakeSession(sessionId, assignedDevice, sessionCustomData.get(sessionId) ?? {})
+          : null;
+      },
+      releaseSession: async () => null,
+    }),
+    getDevicePool: () => ({
+      refreshDevices: async () => 0,
+      getStats: () => ({ total: 0, idle: 0, assigned: 0, error: 0 }),
+      releaseDevice: async () => {},
+      resolveAutolockSessionForMcpSession: (mcpSessionId: string | undefined) => {
+        return mcpSessionId ? mcpAutolockSessions.get(mcpSessionId) : undefined;
+      },
+    }),
+  };
+}
+
+function createServer() {
+  const sessionDevices = new Map<string, string>();
+  const sessionCustomData = new Map<string, Record<string, unknown>>();
+  const mcpAutolockSessions = new Map<string, string>();
+
+  // session-a is bound to device-1
+  sessionDevices.set("session-a", "device-1");
+  // device label "B" on session-a maps to session-a:B, bound to device-2
+  sessionDevices.set("session-a:B", "device-2");
+  sessionCustomData.set("session-a", {
+    deviceLabelMap: { A: "session-a", B: "session-a:B" },
+  });
+  // mcp-bound has an autolock session resolving to session-a (device-1)
+  mcpAutolockSessions.set("mcp-bound", "session-a");
+
+  const server = new UnixSocketServer(
+    join(tmpdir(), `scope-${randomUUID()}.sock`),
+    "http://localhost:0/mcp",
+    createFakeDaemonState(sessionDevices, sessionCustomData, mcpAutolockSessions),
+    new FakeTimer(),
+  );
+  return server;
+}
+
+function scopeKey(server: UnixSocketServer, args: unknown): string | undefined {
+  return (server as unknown as { getRequestArgumentScopeKey: (a: unknown) => string | undefined })
+    .getRequestArgumentScopeKey(args);
+}
+
+describe("UnixSocketServer.getRequestArgumentScopeKey precedence", () => {
+  // Each row encodes one invariant the six P2 review comments on #2565 pinned down,
+  // in priority order: device label > explicit deviceId > resolved-device-for-session
+  // > raw session > implicit autolock/mcp-session.
+  const cases: Array<{ name: string; args: unknown; expected: string | undefined }> = [
+    { name: "non-object args resolve to undefined", args: "nope", expected: undefined },
+    { name: "null args resolve to undefined", args: null, expected: undefined },
+    { name: "array args resolve to undefined", args: [1, 2], expected: undefined },
+    { name: "empty object resolves to undefined", args: {}, expected: undefined },
+
+    {
+      name: "explicit deviceId keys by physical device",
+      args: { deviceId: "device-1" },
+      expected: "device:device-1",
+    },
+    {
+      name: "explicit deviceId beats a raw sessionUuid",
+      args: { deviceId: "device-9", sessionUuid: "session-a" },
+      expected: "device:device-9",
+    },
+
+    {
+      name: "device label resolves the mapped session to its bound device",
+      args: { sessionUuid: "session-a", device: "B" },
+      expected: "device:device-2",
+    },
+    {
+      name: "device label is honored over a stale deviceId",
+      args: { sessionUuid: "session-a", device: "B", deviceId: "device-1" },
+      expected: "device:device-2",
+    },
+    {
+      name: "unmapped device label falls back to the base session's device",
+      args: { sessionUuid: "session-a", device: "UNMAPPED" },
+      expected: "device:device-1",
+    },
+    {
+      name: "unmapped device label on an unbound session keys by session",
+      args: { sessionUuid: "session-unbound", device: "UNMAPPED" },
+      expected: "session:session-unbound",
+    },
+
+    {
+      name: "session bound to a device keys by the resolved device",
+      args: { sessionUuid: "session-a" },
+      expected: "device:device-1",
+    },
+    {
+      name: "unbound session keys by the raw session",
+      args: { sessionUuid: "session-unbound" },
+      expected: "session:session-unbound",
+    },
+
+    {
+      name: "mcp session with an autolock binding keys by the resolved device",
+      args: { __mcpSessionId: "mcp-bound" },
+      expected: "device:device-1",
+    },
+    {
+      name: "mcp session without an autolock binding keys by the mcp session",
+      args: { __mcpSessionId: "mcp-free" },
+      expected: "mcp-session:mcp-free",
+    },
+  ];
+
+  for (const { name, args, expected } of cases) {
+    test(name, () => {
+      const server = createServer();
+      expect(scopeKey(server, args)).toBe(expected);
+    });
+  }
+});


### PR DESCRIPTION
## Summary

Consolidates the three duplicated `assignedDevice ? "device:…" : "session:…"` resolutions in `SocketServer.getRequestArgumentScopeKey` / `getImplicitAutolockScopeKey` into a single `sessionToScopeKey()` helper. The logic accreted branch-by-branch across six P2 review comments on #2565, leaving three identical copies of the device-vs-session collapse. This is a pure extraction — correctness is already pinned by review + tests, so the refactor is low-risk.

Closes #2664.

## What changed

- Extracted `private sessionToScopeKey(sessionUuid)` — the one resolver every session-keyed branch feeds (label branch, raw-session branch, and implicit-autolock resolution).
- The two `hasSessionUuid` branches and `getImplicitAutolockScopeKey` are now one-liners that call it.
- **Branch ordering is unchanged**, exactly as the six review comments dictate: device label > explicit `deviceId` > resolved-device-for-session > raw session > implicit autolock / mcp-session > `undefined`.

## Tests

Added `test/daemon/socketServerScopeKey.test.ts` — a table-driven precedence test enumerating all the invariants the issue named (explicit device beats raw session, label honored over stale `deviceId`, unmapped-label fallbacks, autolock resolution, non-object → `undefined`). This pins the precedence as data so the next device-targeting field is a one-row addition with an obvious insertion point instead of another copy of the same shape.

Interface + Fake + FakeTimer, no real device/network, 14 tests in ~146ms.

## Validation

- `bun test test/daemon` — 440 pass, 0 fail
- `bun run lint` — clean
- `bun run build` — success
