### PR TITLE
refactor: extract shared network mock-rule serializer (#2662)

### DIFF
--- a/src/features/observe/android/AndroidCtrlProxyClient.ts
+++ b/src/features/observe/android/AndroidCtrlProxyClient.ts
@@ -60,6 +60,8 @@ import { serverConfig } from "../../../utils/ServerConfig";
 import { TelemetryRecorder } from "../../telemetry/TelemetryRecorder";
 import { getPerformanceMonitor } from "../../performance/PerformanceMonitor";
 import type { StackTraceElement } from "../../../server/failuresResources";
+import { NetworkState } from "../../../server/NetworkState";
+import { buildNetworkMockRules } from "../../../server/networkMockRules";
 import type {
   PreferenceFile,
   KeyValueEntry,
@@ -1058,25 +1060,13 @@ export class AndroidCtrlProxyClient extends DeviceServiceClient implements Andro
 
   private syncNetworkStateToDevice(): void {
     try {
-      const { NetworkState } = require("../../../server/NetworkState");
       const state = NetworkState.getInstance();
 
-      // Always sync mock rules on reconnect — use limit (not remaining) so
-      // the device-side store reinitializes fresh counts. Sending an empty
-      // list clears stale rules that may linger from a previous connection.
-      const mocks = state.getMocks();
-      const rules = Array.from(mocks.values()).map((r: any) => ({
-        mockId: r.mockId,
-        host: r.host,
-        path: r.path,
-        method: r.method,
-        limit: r.limit,
-        remaining: r.limit,
-        statusCode: r.statusCode,
-        responseHeaders: r.responseHeaders,
-        responseBody: r.responseBody,
-        contentType: r.contentType,
-      }));
+      // Always sync mock rules on reconnect — buildNetworkMockRules uses limit
+      // (not remaining) so the device-side store reinitializes fresh counts.
+      // Sending an empty list clears stale rules that may linger from a
+      // previous connection.
+      const rules = buildNetworkMockRules(state);
       this.sendMessage(JSON.stringify({ type: "set_network_mock_rules", rules }));
 
       // Always re-sync error simulation state (including disabled) so the

--- a/src/features/observe/ios/IOSCtrlProxyClient.ts
+++ b/src/features/observe/ios/IOSCtrlProxyClient.ts
@@ -34,6 +34,8 @@ import { IOSCtrlProxyManager, CtrlProxyIosManager } from "../../../utils/IOSCtrl
 import { PlatformDeviceManagerFactory } from "../../../utils/factories/PlatformDeviceManagerFactory";
 import { NavigationGraphManager } from "../../navigation/NavigationGraphManager";
 import { serverConfig } from "../../../utils/ServerConfig";
+import { NetworkState } from "../../../server/NetworkState";
+import { buildNetworkMockRules } from "../../../server/networkMockRules";
 import { NavigationScreenshotManager } from "../../navigation/NavigationScreenshotManager";
 import {
   HierarchyNavigationDetector,
@@ -702,26 +704,12 @@ export class IOSCtrlProxyClient extends DeviceServiceClient implements IOSCtrlPr
     }
 
     try {
-      const { NetworkState } = require("../../../server/NetworkState");
-      const state = NetworkState.getInstance();
-
       // Always sync mock rules on reconnect. Sending an empty list clears
       // stale rules that may linger in the iOS SDK after a CtrlProxy restart.
-      const rules = Array.from(state.getMocks().values()).map((r: any) => ({
-        mockId: r.mockId,
-        host: r.host,
-        path: r.path,
-        method: r.method,
-        limit: r.limit,
-        remaining: r.limit,
-        statusCode: r.statusCode,
-        responseHeaders: r.responseHeaders,
-        responseBody: r.responseBody,
-        contentType: r.contentType,
-      }));
+      const rules = buildNetworkMockRules(NetworkState.getInstance());
       this.sendMessage(JSON.stringify({ type: "set_network_mock_rules", rules }));
     } catch (e) {
-      logger.debug(`[IOSCtrlProxyClient] Failed to sync network mock rules on reconnect: ${e}`);
+      logger.warn(`[IOSCtrlProxyClient] Failed to sync network mock rules on reconnect: ${e}`);
     }
   }
 

--- a/src/server/networkMockRules.ts
+++ b/src/server/networkMockRules.ts
@@ -1,0 +1,44 @@
+import { MockRule, NetworkState } from "./NetworkState";
+
+/**
+ * Wire shape for a single mock rule sent to a device's CtrlProxy over the
+ * `set_network_mock_rules` message. Mirrors {@link MockRule} but is the
+ * serialized contract — kept as its own type so the host-side serializer can
+ * evolve independently of the in-memory store.
+ */
+export interface NetworkMockRuleSync {
+  mockId: string;
+  host: string;
+  path: string;
+  method: string;
+  limit: number | null;
+  remaining: number | null;
+  statusCode: number;
+  responseHeaders: Record<string, string>;
+  responseBody: string;
+  contentType: string;
+}
+
+/**
+ * Build the device-bound mock-rule payload from the current {@link NetworkState}.
+ *
+ * Single source of truth for the host → device mock-rule mapping shared by the
+ * Android and iOS CtrlProxy clients (reconnect sync) and the `network` tool
+ * (live sync). `remaining` is reinitialized from `limit` rather than copied from
+ * the store: the server never tracks consumption, so the device-side
+ * NetworkMockRuleStore must start each connection with fresh counts.
+ */
+export function buildNetworkMockRules(state: NetworkState): NetworkMockRuleSync[] {
+  return Array.from(state.getMocks().values()).map((r: MockRule) => ({
+    mockId: r.mockId,
+    host: r.host,
+    path: r.path,
+    method: r.method,
+    limit: r.limit,
+    remaining: r.limit,
+    statusCode: r.statusCode,
+    responseHeaders: r.responseHeaders,
+    responseBody: r.responseBody,
+    contentType: r.contentType,
+  }));
+}

--- a/src/server/networkTools.ts
+++ b/src/server/networkTools.ts
@@ -3,6 +3,7 @@ import { ToolRegistry } from "./toolRegistry";
 import { createJSONToolResponse } from "../utils/toolUtils";
 import { addDeviceTargetingToSchema } from "./toolSchemaHelpers";
 import { NetworkState, type SimulatedErrorType } from "./NetworkState";
+import { buildNetworkMockRules } from "./networkMockRules";
 import { getNetworkEvents } from "../db/networkEventRepository";
 import { buildNetworkGraph } from "./networkGraph";
 import { serverConfig } from "../utils/ServerConfig";
@@ -124,18 +125,7 @@ function syncMockRulesToDevice(device: BootedDevice, state: NetworkState): void 
       : IOSCtrlProxyClient.getInstance(device);
     // Use limit (not remaining) since the server never tracks consumption —
     // the device-side NetworkMockRuleStore manages its own remaining count
-    const rules = Array.from(state.getMocks().values()).map(r => ({
-      mockId: r.mockId,
-      host: r.host,
-      path: r.path,
-      method: r.method,
-      limit: r.limit,
-      remaining: r.limit,
-      statusCode: r.statusCode,
-      responseHeaders: r.responseHeaders,
-      responseBody: r.responseBody,
-      contentType: r.contentType,
-    }));
+    const rules = buildNetworkMockRules(state);
     const msg = JSON.stringify({ type: "set_network_mock_rules", rules });
     const sent = client.sendMessage(msg);
     logger.info(`[networkTools] syncMockRules(${device.platform}): ${rules.length} rules, sent=${sent}`);

--- a/test/server/networkMockRules.test.ts
+++ b/test/server/networkMockRules.test.ts
@@ -1,0 +1,97 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { NetworkState } from "../../src/server/NetworkState";
+import { buildNetworkMockRules } from "../../src/server/networkMockRules";
+
+describe("buildNetworkMockRules", function() {
+  let state: NetworkState;
+
+  beforeEach(function() {
+    NetworkState.resetInstance();
+    state = NetworkState.getInstance();
+  });
+
+  afterEach(function() {
+    NetworkState.resetInstance();
+  });
+
+  test("returns an empty array when no mocks are registered", function() {
+    expect(buildNetworkMockRules(state)).toEqual([]);
+  });
+
+  test("maps every mock field onto the wire shape", function() {
+    const mock = state.addMock({
+      host: "api\\.example\\.com",
+      path: "/v1/items",
+      method: "GET",
+      limit: 3,
+      remaining: 3,
+      statusCode: 201,
+      responseHeaders: { "X-Test": "yes" },
+      responseBody: "{\"ok\":true}",
+      contentType: "application/json",
+    });
+
+    expect(buildNetworkMockRules(state)).toEqual([{
+      mockId: mock.mockId,
+      host: "api\\.example\\.com",
+      path: "/v1/items",
+      method: "GET",
+      limit: 3,
+      remaining: 3,
+      statusCode: 201,
+      responseHeaders: { "X-Test": "yes" },
+      responseBody: "{\"ok\":true}",
+      contentType: "application/json",
+    }]);
+  });
+
+  test("reinitializes remaining from limit so the device gets fresh counts", function() {
+    const mock = state.addMock({
+      host: "h",
+      path: "/p",
+      method: "POST",
+      limit: 5,
+      remaining: 1,
+      statusCode: 200,
+      responseHeaders: {},
+      responseBody: "",
+      contentType: "text/plain",
+    });
+
+    const [rule] = buildNetworkMockRules(state);
+    expect(rule.mockId).toBe(mock.mockId);
+    expect(rule.limit).toBe(5);
+    expect(rule.remaining).toBe(5);
+  });
+
+  test("preserves a null limit and emits a null remaining", function() {
+    state.addMock({
+      host: "h",
+      path: "/p",
+      method: "GET",
+      limit: null,
+      remaining: null,
+      statusCode: 200,
+      responseHeaders: {},
+      responseBody: "",
+      contentType: "text/plain",
+    });
+
+    const [rule] = buildNetworkMockRules(state);
+    expect(rule.limit).toBeNull();
+    expect(rule.remaining).toBeNull();
+  });
+
+  test("returns one rule per registered mock", function() {
+    state.addMock({
+      host: "a", path: "/1", method: "GET", limit: 1, remaining: 1,
+      statusCode: 200, responseHeaders: {}, responseBody: "", contentType: "text/plain",
+    });
+    state.addMock({
+      host: "b", path: "/2", method: "GET", limit: 1, remaining: 1,
+      statusCode: 200, responseHeaders: {}, responseBody: "", contentType: "text/plain",
+    });
+
+    expect(buildNetworkMockRules(state)).toHaveLength(2);
+  });
+});


### PR DESCRIPTION
## What

Extracts the host → device mock-rule serializer into a single typed helper,
`buildNetworkMockRules(state)` in [`src/server/networkMockRules.ts`](src/server/networkMockRules.ts),
and routes all three call sites through it:

- `IOSCtrlProxyClient.syncNetworkMockRulesToDevice`
- `AndroidCtrlProxyClient.syncNetworkStateToDevice` (keeps its extra error-simulation re-sync)
- `networkTools.syncMockRulesToDevice` (a third clone of the same 10-field map)

Each was an independent copy of the same 10-field object mapping. The helper is the lone owner now.

## Why

Resolves #2662. The iOS copy (added in #2580 to reach Android parity) carried three smells, two of them inherited from the Android original:

1. **CommonJS `require()` in an ESM module** — `const { NetworkState } = require("../../../server/NetworkState")`. Verified this was a copy-paste artifact, not a cycle-breaker: `NetworkState`'s import closure (`resourceRegistry`, `logger`, `SystemTimer`) never reaches the observe clients, so a top-level `import` is safe. Replaced in both clients.
2. **`(r: any)` type erasure** — dropped; the typed `MockRule` shape now flows through `buildNetworkMockRules`.
3. **Silent failure** — the iOS reconnect-sync catch logged at `debug`, hiding a broken feature path. Raised to `warn`.

## Validation

- `bun test test/server/networkMockRules.test.ts` — 5 new unit tests (TDD; empty state, full field map, `remaining` reinit from `limit`, null-limit passthrough, count). All pass.
- `bun test test/features/observe/ios/ test/features/observe/android/` — 84 pass.
- `bun test test/server/networkTools.test.ts` — passes.
- `bun run lint` — clean.
- `bun run build` — succeeds.
- Verified no `require(` remains in either CtrlProxy client.

Closes #2662
