### PR TITLE
fix(doctor): make daemon health socket probes non-destructive

### DIFF
--- a/src/daemon/client.ts
+++ b/src/daemon/client.ts
@@ -28,7 +28,15 @@ export class DaemonUnavailableError extends Error {
   }
 }
 
-export interface DaemonClientRecoveryOptions extends StaleDaemonFileCleanupOptions {}
+export interface DaemonClientRecoveryOptions extends StaleDaemonFileCleanupOptions {
+  /**
+   * When true, `isAvailable()` performs an observation-only probe and never
+   * unlinks socket/PID files, even if the recorded PID is dead. Used by
+   * doctor/debug diagnostics so a momentary refusal or timeout from a loaded
+   * daemon cannot delete its live socket (issue #2658).
+   */
+  skipStaleCleanup?: boolean;
+}
 
 /**
  * CLI Client for communicating with the daemon via Unix socket
@@ -77,11 +85,14 @@ export class DaemonClient {
     // On Unix, verify the path exists and is a socket (not a stale regular file).
     // On Windows, named pipes don't have filesystem entries — skip the stat check
     // and let createConnection determine reachability.
+    const skipCleanup = recoveryOptions.skipStaleCleanup === true;
     if (platform() !== "win32") {
       try {
         const stats = statSync(socketPath);
         if (!stats.isSocket()) {
-          DaemonClient.cleanupStaleSocketIfDaemonDead(socketPath, recoveryOptions);
+          if (!skipCleanup) {
+            DaemonClient.cleanupStaleSocketIfDaemonDead(socketPath, recoveryOptions);
+          }
           return false;
         }
       } catch {
@@ -106,12 +117,16 @@ export class DaemonClient {
       socket.on("error", () => {
         defaultTimer.clearTimeout(timeout);
         socket.destroy();
-        DaemonClient.cleanupStaleSocketIfDaemonDead(socketPath, recoveryOptions);
+        if (!skipCleanup) {
+          DaemonClient.cleanupStaleSocketIfDaemonDead(socketPath, recoveryOptions);
+        }
         settle(false);
       });
       const timeout = defaultTimer.setTimeout(() => {
         socket.destroy();
-        DaemonClient.cleanupStaleSocketIfDaemonDead(socketPath, recoveryOptions);
+        if (!skipCleanup) {
+          DaemonClient.cleanupStaleSocketIfDaemonDead(socketPath, recoveryOptions);
+        }
         settle(false);
       }, 1000);
     });

--- a/src/daemon/debugTools.ts
+++ b/src/daemon/debugTools.ts
@@ -97,7 +97,9 @@ export async function getDaemonHealthReport(
   // serving via socket even when PID bookkeeping is stale or missing.
   if (report.socketExists) {
     try {
-      const available = await DaemonClient.isAvailable(socketPath);
+      // Observation-only probe: never unlink a live daemon's socket if PID
+      // bookkeeping is momentarily stale (issue #2658).
+      const available = await DaemonClient.isAvailable(socketPath, { skipStaleCleanup: true });
       report.socketConnectable = available;
       if (!available) {
         report.recommendations.push(
@@ -199,9 +201,13 @@ export interface SocketDiagnostics {
 /**
  * Run socket diagnostics
  */
-export async function runSocketDiagnostics(timer: Timer = defaultTimer): Promise<SocketDiagnostics> {
+export async function runSocketDiagnostics(
+  timer: Timer = defaultTimer,
+  options: DaemonHealthReportOptions = {}
+): Promise<SocketDiagnostics> {
+  const socketPath = options.socketPath ?? SOCKET_PATH;
   const diagnostics: SocketDiagnostics = {
-    socketExists: existsSync(SOCKET_PATH),
+    socketExists: existsSync(socketPath),
     socketReadable: false,
     socketWritable: false,
     socketConnectable: false,
@@ -216,7 +222,7 @@ export async function runSocketDiagnostics(timer: Timer = defaultTimer): Promise
 
   // Try to get file stats to check read/write permissions
   try {
-    await (await import("node:fs/promises")).stat(SOCKET_PATH);
+    await (await import("node:fs/promises")).stat(socketPath);
     diagnostics.socketReadable = true;
     diagnostics.socketWritable = true;
   } catch (error) {
@@ -224,10 +230,11 @@ export async function runSocketDiagnostics(timer: Timer = defaultTimer): Promise
     return diagnostics;
   }
 
-  // Try to connect
+  // Try to connect. Observation-only probe: never unlink a live daemon's
+  // socket if PID bookkeeping is momentarily stale (issue #2658).
   try {
     const startTime = timer.now();
-    const available = await DaemonClient.isAvailable(SOCKET_PATH);
+    const available = await DaemonClient.isAvailable(socketPath, { skipStaleCleanup: true });
     const latency = timer.now() - startTime;
 
     if (available) {

--- a/test/daemon/debugTools.test.ts
+++ b/test/daemon/debugTools.test.ts
@@ -31,7 +31,10 @@ describe("getDaemonHealthReport", () => {
         pidFilePath: pidPath,
       });
 
-      expect(isAvailable).toHaveBeenCalledWith(socketPath);
+      expect(isAvailable).toHaveBeenCalledWith(
+        socketPath,
+        expect.objectContaining({ skipStaleCleanup: true })
+      );
       expect(report.socketExists).toBe(true);
       expect(report.pidFileExists).toBe(false);
       expect(report.socketConnectable).toBe(true);

--- a/test/daemon/debugToolsNonDestructive.test.ts
+++ b/test/daemon/debugToolsNonDestructive.test.ts
@@ -1,0 +1,131 @@
+import { afterEach, describe, expect, spyOn, test } from "bun:test";
+import { existsSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir, platform } from "node:os";
+import { join } from "node:path";
+import { DaemonClient } from "../../src/daemon/client";
+import { getDaemonHealthReport, runSocketDiagnostics } from "../../src/daemon/debugTools";
+import type { PidFileData } from "../../src/daemon/types";
+
+const isWindows = platform() === "win32";
+
+/**
+ * Regression coverage for issue #2658: doctor/debug health probes must be
+ * observation-only. A loaded daemon whose PID bookkeeping is stale must not
+ * have its live socket unlinked just because the probe errors or times out.
+ */
+describe("daemon health probes are non-destructive", () => {
+  const tempDirs: string[] = [];
+
+  function createTempPaths(): { socketPath: string; pidFilePath: string } {
+    const dir = mkdtempSync(join(tmpdir(), "daemon-nondestructive-test-"));
+    tempDirs.push(dir);
+    return {
+      socketPath: join(dir, "daemon.sock"),
+      pidFilePath: join(dir, "daemon.pid"),
+    };
+  }
+
+  function writeDeadPidFile(pidFilePath: string, socketPath: string): void {
+    const pidData: PidFileData = {
+      pid: 12345,
+      socketPath,
+      port: 3000,
+      startedAt: 0,
+      version: "test",
+    };
+    writeFileSync(pidFilePath, JSON.stringify(pidData));
+  }
+
+  afterEach(() => {
+    for (const dir of tempDirs) {
+      rmSync(dir, { recursive: true, force: true });
+    }
+    tempDirs.length = 0;
+  });
+
+  test("isAvailable skips stale-socket cleanup when skipStaleCleanup is set", async () => {
+    if (isWindows) {
+      return;
+    }
+    const { socketPath, pidFilePath } = createTempPaths();
+    // A non-socket regular file represents a stale/errored socket probe target.
+    writeFileSync(socketPath, "stale socket placeholder");
+    writeDeadPidFile(pidFilePath, socketPath);
+
+    const available = await DaemonClient.isAvailable(socketPath, {
+      pidFilePath,
+      socketPaths: [socketPath],
+      isProcessRunning: () => false,
+      skipStaleCleanup: true,
+    });
+
+    expect(available).toBe(false);
+    // Files must survive: cleanup was explicitly disabled.
+    expect(existsSync(socketPath)).toBe(true);
+    expect(existsSync(pidFilePath)).toBe(true);
+  });
+
+  test("getDaemonHealthReport invokes isAvailable with stale-cleanup disabled", async () => {
+    const { socketPath, pidFilePath } = createTempPaths();
+    writeFileSync(socketPath, "");
+
+    const isAvailable = spyOn(DaemonClient, "isAvailable").mockResolvedValue(true);
+    try {
+      await getDaemonHealthReport(undefined, { socketPath, pidFilePath });
+      expect(isAvailable).toHaveBeenCalledWith(
+        socketPath,
+        expect.objectContaining({ skipStaleCleanup: true })
+      );
+    } finally {
+      isAvailable.mockRestore();
+    }
+  });
+
+  test("getDaemonHealthReport does not unlink files when the probe errors under a dead PID", async () => {
+    if (isWindows) {
+      return;
+    }
+    const { socketPath, pidFilePath } = createTempPaths();
+    // Non-socket file makes isAvailable's stat check fail (its error branch).
+    writeFileSync(socketPath, "stale socket placeholder");
+    writeDeadPidFile(pidFilePath, socketPath);
+
+    const report = await getDaemonHealthReport(undefined, { socketPath, pidFilePath });
+
+    expect(report.socketConnectable).toBe(false);
+    // The live socket and PID files must remain untouched by the diagnostic.
+    expect(existsSync(socketPath)).toBe(true);
+    expect(existsSync(pidFilePath)).toBe(true);
+  });
+
+  test("runSocketDiagnostics invokes isAvailable with stale-cleanup disabled", async () => {
+    const { socketPath } = createTempPaths();
+    writeFileSync(socketPath, "");
+
+    const isAvailable = spyOn(DaemonClient, "isAvailable").mockResolvedValue(true);
+    try {
+      await runSocketDiagnostics(undefined, { socketPath });
+      expect(isAvailable).toHaveBeenCalledWith(
+        socketPath,
+        expect.objectContaining({ skipStaleCleanup: true })
+      );
+    } finally {
+      isAvailable.mockRestore();
+    }
+  });
+
+  test("runSocketDiagnostics does not unlink files when the probe errors under a dead PID", async () => {
+    if (isWindows) {
+      return;
+    }
+    const { socketPath, pidFilePath } = createTempPaths();
+    writeFileSync(socketPath, "stale socket placeholder");
+    writeDeadPidFile(pidFilePath, socketPath);
+
+    const diag = await runSocketDiagnostics(undefined, { socketPath, pidFilePath });
+
+    expect(diag.socketConnectable).toBe(false);
+    expect(existsSync(socketPath)).toBe(true);
+    expect(existsSync(pidFilePath)).toBe(true);
+  });
+});


### PR DESCRIPTION
## What

Makes the doctor/debug daemon **health probes observation-only** so they can no longer unlink a live daemon's socket.

- `DaemonClient.isAvailable()` gains a `skipStaleCleanup` recovery option that gates all three stale-socket cleanup sites (the non-socket stat branch, the connect-error handler, and the 1s timeout handler).
- `getDaemonHealthReport()` and `runSocketDiagnostics()` now pass `skipStaleCleanup: true`.
- `runSocketDiagnostics()` accepts an optional `socketPath` (mirroring `getDaemonHealthReport`) so the probe target is injectable for tests.
- Startup/proxy/`connect()` recovery paths (`ensureDaemonRunning`, `DaemonMcpProxy.doConnect`) are unchanged and still clean stale files.

Closes #2658.

## Why

Follow-up to #2643 / PR #2649. PR #2649 fixed the *ordering* (probe health before `DaemonManager.status()`), but the probe itself was not read-only: `DaemonClient.isAvailable()` calls `cleanupStaleSocketIfDaemonDead()` on socket error/timeout and unlinks the socket whenever the PID file points at a dead PID (`src/daemon/client.ts`). A loaded daemon that briefly refuses or times out during doctor could have its live socket deleted before the status/connectivity checks recovered.

## How

`isAvailable()` reads `recoveryOptions.skipStaleCleanup` once and guards each cleanup call. Diagnostics opt in; recovery paths keep the default destructive behavior, so a genuinely stale socket is still cleared before a fresh `manager.start()`.

## Acceptance criteria

- [x] `getDaemonHealthReport()` does not unlink socket files when its probe errors or times out.
- [x] `runSocketDiagnostics()` evaluated and made non-destructive.
- [x] Existing recovery behavior for daemon startup/proxy/connect paths remains intact.
- [x] Tests cover stale-PID + socket error and prove the diagnostics do not call stale-socket cleanup.

## Validation

- `bun test test/daemon/debugToolsNonDestructive.test.ts test/daemon/debugTools.test.ts test/daemon/daemonClientStaleSocketRecovery.test.ts test/daemon/daemonClientAvailability.test.ts` → 12 pass
- `bun test test/doctor/automobile.test.ts` → 10 pass
- `turbo run lint build` → pass

New test file `test/daemon/debugToolsNonDestructive.test.ts` adds regression coverage; `debugTools.test.ts` updated to assert the `skipStaleCleanup` option is forwarded.
