### PR TITLE
refactor(appFileService): replace positional-boolean params with options object

### DIFF
--- a/src/server/appFileService.ts
+++ b/src/server/appFileService.ts
@@ -296,19 +296,13 @@ class AndroidAppFileProvider implements AppFileProvider {
         adb,
         `shell mkdir -p ${shellQuote(posix.dirname(target.absolutePath))}`,
         { device: request.device, appId: request.appId, container: request.container, operation: "write", access: "externalFiles" },
-        undefined,
-        undefined,
-        true,
-        request.signal
+        { noRetry: true, signal: request.signal }
       );
       await executeAndroidAppFileCommand(
         adb,
         `push ${shellQuote(request.sourcePath)} ${shellQuote(target.absolutePath)}`,
         { device: request.device, appId: request.appId, container: request.container, operation: "write", access: "externalFiles" },
-        undefined,
-        undefined,
-        true,
-        request.signal
+        { noRetry: true, signal: request.signal }
       );
       return;
     }
@@ -318,10 +312,7 @@ class AndroidAppFileProvider implements AppFileProvider {
       adb,
       `push ${shellQuote(request.sourcePath)} ${shellQuote(tempDevicePath)}`,
       { device: request.device, appId: request.appId, container: request.container, operation: "write", access: "run-as" },
-      undefined,
-      undefined,
-      true,
-      request.signal
+      { noRetry: true, signal: request.signal }
     );
     try {
       const command = `mkdir -p ${shellQuote(posix.dirname(target.relativePath))} && ` +
@@ -331,10 +322,7 @@ class AndroidAppFileProvider implements AppFileProvider {
         adb,
         `shell run-as ${shellQuote(request.appId)} sh -c ${shellQuote(command)}`,
         { device: request.device, appId: request.appId, container: request.container, operation: "write", access: "run-as" },
-        undefined,
-        undefined,
-        true,
-        request.signal
+        { noRetry: true, signal: request.signal }
       );
     } finally {
       await adb.executeCommand(`shell rm -f ${shellQuote(tempDevicePath)}`, undefined, undefined, true, request.signal).catch(() => {});
@@ -355,17 +343,13 @@ class AndroidAppFileProvider implements AppFileProvider {
         adb,
         `shell ${script}`,
         { device: request.device, appId: request.appId, container: request.container, operation: "list", access: "externalFiles" },
-        undefined,
-        ANDROID_APP_FILE_MAX_BUFFER,
-        true
+        { maxBuffer: ANDROID_APP_FILE_MAX_BUFFER, noRetry: true }
       )).stdout
       : (await executeAndroidAppFileCommand(
         adb,
         `shell run-as ${shellQuote(request.appId)} sh -c ${shellQuote(script)}`,
         { device: request.device, appId: request.appId, container: request.container, operation: "list", access: "run-as" },
-        undefined,
-        ANDROID_APP_FILE_MAX_BUFFER,
-        true
+        { maxBuffer: ANDROID_APP_FILE_MAX_BUFFER, noRetry: true }
       )).stdout;
 
     const files = parseAndroidStatListing(stdout, root, request.device, request.appId, request.container);
@@ -391,17 +375,13 @@ class AndroidAppFileProvider implements AppFileProvider {
         adb,
         `shell base64 ${shellQuote(target.absolutePath)}`,
         { device: request.device, appId: request.appId, container: request.container, operation: "read", access: "externalFiles" },
-        undefined,
-        ANDROID_APP_FILE_MAX_BUFFER,
-        true
+        { maxBuffer: ANDROID_APP_FILE_MAX_BUFFER, noRetry: true }
       )).stdout
       : (await executeAndroidAppFileCommand(
         adb,
         `shell run-as ${shellQuote(request.appId)} base64 ${shellQuote(target.relativePath)}`,
         { device: request.device, appId: request.appId, container: request.container, operation: "read", access: "run-as" },
-        undefined,
-        ANDROID_APP_FILE_MAX_BUFFER,
-        true
+        { maxBuffer: ANDROID_APP_FILE_MAX_BUFFER, noRetry: true }
       )).stdout;
     const blob = stdout.replace(/\s+/g, "");
     const buffer = Buffer.from(blob, "base64");
@@ -740,17 +720,21 @@ interface AndroidAppFileCommandContext {
   access: "externalFiles" | "run-as";
 }
 
+interface AndroidAppFileExecOptions {
+  timeoutMs?: number;
+  maxBuffer?: number;
+  noRetry?: boolean;
+  signal?: AbortSignal;
+}
+
 async function executeAndroidAppFileCommand(
   adb: AdbExecutor,
   command: string,
   context: AndroidAppFileCommandContext,
-  timeoutMs?: number,
-  maxBuffer?: number,
-  noRetry?: boolean,
-  signal?: AbortSignal
+  options: AndroidAppFileExecOptions = {}
 ): Promise<ExecResult> {
   try {
-    return await adb.executeCommand(command, timeoutMs, maxBuffer, noRetry, signal);
+    return await adb.executeCommand(command, options.timeoutMs, options.maxBuffer, options.noRetry, options.signal);
   } catch (error) {
     throw mapAndroidAppFileError(error, context);
   }

--- a/test/server/appFileService.test.ts
+++ b/test/server/appFileService.test.ts
@@ -598,6 +598,64 @@ describe("AppFileService", () => {
     expect(calls[1]?.maxBuffer).toBe(calls[0]?.maxBuffer);
   });
 
+  test("suppresses ADB retries on every read and list app-file command", async () => {
+    const adbFactory = new FakeAdbClientFactory();
+    const service = createAppFileServiceForTesting({
+      adbFactory,
+      simctlFactory: () => {
+        throw new Error("simctl not used");
+      },
+      deviceResolver: async () => ({ deviceId: "emulator-5554", name: "Pixel", platform: "android" }),
+    });
+
+    await service.readFile({
+      deviceId: "emulator-5554",
+      appId: "com.example.app",
+      container: "documents",
+      path: "screenshots/home.png",
+    });
+    await service.listFiles({
+      deviceId: "emulator-5554",
+      appId: "com.example.app",
+      container: "externalFiles",
+    });
+
+    const calls = adbFactory.getFakeClient().getCommandCalls();
+    expect(calls).toHaveLength(2);
+    expect(calls.every(call => call.noRetry === true)).toBe(true);
+  });
+
+  test("propagates noRetry and the caller's AbortSignal through every Android putFile command", async () => {
+    const adbFactory = new FakeAdbClientFactory();
+    const service = createAppFileServiceForTesting({
+      adbFactory,
+      simctlFactory: () => {
+        throw new Error("simctl not used");
+      },
+    });
+    const device: BootedDevice = {
+      deviceId: "emulator-5554",
+      name: "Pixel",
+      platform: "android",
+    };
+    const controller = new AbortController();
+
+    await service.putFile({
+      device,
+      appId: "com.example.app",
+      container: "documents",
+      contentText: "hello",
+      destinationPath: "fixtures/welcome.txt",
+      signal: controller.signal,
+    });
+
+    const calls = adbFactory.getFakeClient().getCommandCalls();
+    // push to temp, run-as cp, and the rm cleanup all flow through the helper / adb.
+    expect(calls.length).toBeGreaterThanOrEqual(3);
+    expect(calls.every(call => call.noRetry === true)).toBe(true);
+    expect(calls.every(call => call.signal === controller.signal)).toBe(true);
+  });
+
   test("lists Android externalFiles with file names, directory markers, byte sizes, and last-modified metadata", async () => {
     const adb = new FakeAdbExecutor();
     adb.setCommandResponse("find '/sdcard/Android/data/com.example.app/files'", execResult([


### PR DESCRIPTION
## What

Replaces the five trailing positional params of `executeAndroidAppFileCommand` in `src/server/appFileService.ts` with a single typed options object:

```ts
interface AndroidAppFileExecOptions {
  timeoutMs?: number;
  maxBuffer?: number;
  noRetry?: boolean;
  signal?: AbortSignal;
}
```

All 8 call sites updated. The unreadable `undefined, undefined, true, request.signal` runs become self-documenting `{ noRetry: true, signal: request.signal }` and `{ maxBuffer: ANDROID_APP_FILE_MAX_BUFFER, noRetry: true }`.

## Why

Closes #2660. The positional shape was the classic positional-boolean smell: a transposed `maxBuffer`/`noRetry` (both optional, adjacent `number | undefined` / `boolean | undefined`) would silently change retry/buffer behavior and slip past the type checker. Named options make each slot visible at the call site and transposition-proof.

Purely mechanical — no behavioral change. The direct `adb.executeCommand` cleanup call (`rm -f` temp) is intentionally left as-is; reworking `AdbExecutor.executeCommand` itself is a separate, larger follow-up noted in the issue.

## Validation

- `bun test test/server/appFileService.test.ts` → 24 pass (added 2 contract tests asserting `noRetry`/`signal`/`maxBuffer` propagation across every read/list/put command, so a transposition regresses loudly).
- `bun run lint` → clean.
- `bun run build` → passes.
