### PR TITLE
feat: establish & document error-handling convention; restore doctor diagnosability

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,6 +10,47 @@ Node TypeScript MCP server providing Android Debug Bridge (ADB) capabilities thr
 - Always use interfaces & fakes & FakeTimer to decouple implementations and keep tests extremely fast and non-flaky
 - Unit tests should pass in 100ms or less. Do not assume that a failing test can be allowed to fail.
 
+# Error Handling Convention
+
+Every `catch` block in `src/` must follow one of three strategies. Pick by the
+caller's contract, not by local precedent. The building blocks already exist:
+`ActionableError` (`src/models/ActionableError.ts`) and the shared `logger`
+(`src/utils/logger.ts`).
+
+1. **Throw a structured error** — for system/MCP boundaries and feature actions
+   whose failure should surface to the client. Throw `ActionableError` with
+   actionable context, or use `toActionableError(error, context)` to wrap an
+   unknown caught value in one call:
+   ```ts
+   } catch (error) {
+     throw toActionableError(error, "Failed to start Android screenrecord");
+   }
+   ```
+
+2. **Log, then return a typed failure** — for diagnostic/best-effort paths that
+   return a status object (e.g. `doctor` checks) instead of throwing. Always
+   `logger.debug`/`logger.warn` the underlying error *before* returning, so there
+   is a trace even when the user only sees a summarized message:
+   ```ts
+   } catch (error) {
+     logger.debug(`simctl check failed: ${normalizeErrorMessage(error)}`, error);
+     return { name: "simctl", status: "fail", message: "..." };
+   }
+   ```
+
+3. **Log-and-continue (swallow)** — only for genuinely-expected non-errors
+   (port probes, optional capability checks). Log at `debug` and add a one-line
+   comment stating *why* it is safe to swallow:
+   ```ts
+   } catch (error) {
+     // Connection refused is expected when no emulator is on this port.
+     logger.debug(`port ${port} probe failed: ${error}`);
+   }
+   ```
+
+Never leave a `catch` body empty or a bare `return`/`return null` with no log —
+lint allows it (`caughtErrors: "none"`), so this convention is the only backstop.
+
 # Project Structure
 
 This document summarizes the AutoMobile repo layout and where to find key components.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,12 +28,14 @@ caller's contract, not by local precedent. The building blocks already exist:
    ```
 
 2. **Log, then return a typed failure** — for diagnostic/best-effort paths that
-   return a status object (e.g. `doctor` checks) instead of throwing. Always
-   `logger.debug`/`logger.warn` the underlying error *before* returning, so there
-   is a trace even when the user only sees a summarized message:
+   return a status object (e.g. `doctor` checks) instead of throwing. Log the
+   underlying error *before* returning, so there is a trace even when the user
+   only sees a summarized message. Use `logger.warn` for unexpected failures —
+   the default level is `INFO`, so `logger.debug` is **dropped** unless the user
+   opted into debug logging, which defeats the trace:
    ```ts
    } catch (error) {
-     logger.debug(`simctl check failed: ${normalizeErrorMessage(error)}`, error);
+     logger.warn(`simctl check failed: ${normalizeErrorMessage(error)}`, error);
      return { name: "simctl", status: "fail", message: "..." };
    }
    ```

--- a/src/doctor/checks/ios.ts
+++ b/src/doctor/checks/ios.ts
@@ -11,6 +11,7 @@ import { promisify } from "node:util";
 import type { ExecResult } from "../../models";
 import { CheckResult, DoctorOptions } from "../types";
 import { SimCtl, SimCtlClient } from "../../utils/ios-cmdline-tools/SimCtlClient";
+import { logger, type Logger } from "../../utils/logger";
 
 const MIN_XCODE_VERSION = "15.0";
 
@@ -32,6 +33,7 @@ export interface IosDoctorDependencies {
   fileExists: (path: string) => boolean;
   readDir: (path: string) => Promise<string[]>;
   homedir: () => string;
+  logger: Logger;
   createSimctlClient: () => SimCtl;
 }
 
@@ -63,6 +65,7 @@ const createIosDoctorDependencies = (): IosDoctorDependencies => ({
   fileExists: existsSync,
   readDir: async path => fs.readdir(path),
   homedir,
+  logger,
   createSimctlClient: () => new SimCtlClient()
 });
 
@@ -152,6 +155,7 @@ export async function checkXcodeInstallation(
       value: version,
     };
   } catch (error) {
+    dependencies.logger.debug(`Xcode installation check failed: ${normalizeErrorMessage(error)}`, error);
     return {
       name: "Xcode",
       status: "fail",
@@ -197,6 +201,7 @@ export async function checkXcodeCommandLineTools(
         };
       }
 
+      dependencies.logger.debug(`Command Line Tools install failed: ${normalizeErrorMessage(error)}`, error);
       return {
         name,
         status: "fail",
@@ -239,6 +244,7 @@ export async function checkXcodeCommandLineTools(
       value: developerDir,
     };
   } catch (error) {
+    dependencies.logger.debug(`Command Line Tools check failed: ${normalizeErrorMessage(error)}`, error);
     return {
       name,
       status: "fail",
@@ -270,6 +276,7 @@ export async function checkXcrunAvailable(
       message: "xcrun functional",
     };
   } catch (error) {
+    dependencies.logger.debug(`xcrun check failed: ${normalizeErrorMessage(error)}`, error);
     return {
       name: "xcrun",
       status: "fail",
@@ -312,6 +319,7 @@ export async function checkSimctlAvailable(
       recommendation: "Install Xcode Command Line Tools: xcode-select --install",
     };
   } catch (error) {
+    dependencies.logger.debug(`simctl check failed: ${normalizeErrorMessage(error)}`, error);
     return {
       name: "simctl",
       status: "fail",
@@ -367,6 +375,7 @@ export async function checkSimulatorRuntimes(
       value: iosRuntimes.length,
     };
   } catch (error) {
+    dependencies.logger.debug(`Simulator runtimes check failed: ${normalizeErrorMessage(error)}`, error);
     return {
       name,
       status: "fail",
@@ -413,6 +422,7 @@ export async function checkCodeSigning(
       recommendation: "Sign in to Xcode and install a development certificate for device testing.",
     };
   } catch (error) {
+    dependencies.logger.debug(`Code signing check failed: ${normalizeErrorMessage(error)}`, error);
     return {
       name,
       status: "warn",
@@ -457,6 +467,7 @@ export async function checkAppleDeveloperAccount(
       recommendation: "Sign in to Xcode to enable device testing.",
     };
   } catch (error) {
+    dependencies.logger.debug(`Apple Developer account check failed: ${normalizeErrorMessage(error)}`, error);
     return {
       name,
       status: "warn",
@@ -503,6 +514,7 @@ export async function checkProvisioningProfiles(
       recommendation: "Create a provisioning profile in Xcode to enable device testing.",
     };
   } catch (error) {
+    dependencies.logger.debug(`Provisioning profiles check failed: ${normalizeErrorMessage(error)}`, error);
     return {
       name,
       status: "warn",
@@ -556,6 +568,7 @@ export async function checkBootedSimulators(
       value: simulators.length,
     };
   } catch (error) {
+    dependencies.logger.debug(`Booted simulators check failed: ${normalizeErrorMessage(error)}`, error);
     return {
       name: "Booted Simulators",
       status: "skip",

--- a/src/doctor/checks/ios.ts
+++ b/src/doctor/checks/ios.ts
@@ -155,7 +155,7 @@ export async function checkXcodeInstallation(
       value: version,
     };
   } catch (error) {
-    dependencies.logger.debug(`Xcode installation check failed: ${normalizeErrorMessage(error)}`, error);
+    dependencies.logger.warn(`Xcode installation check failed: ${normalizeErrorMessage(error)}`, error);
     return {
       name: "Xcode",
       status: "fail",
@@ -201,7 +201,7 @@ export async function checkXcodeCommandLineTools(
         };
       }
 
-      dependencies.logger.debug(`Command Line Tools install failed: ${normalizeErrorMessage(error)}`, error);
+      dependencies.logger.warn(`Command Line Tools install failed: ${normalizeErrorMessage(error)}`, error);
       return {
         name,
         status: "fail",
@@ -244,7 +244,7 @@ export async function checkXcodeCommandLineTools(
       value: developerDir,
     };
   } catch (error) {
-    dependencies.logger.debug(`Command Line Tools check failed: ${normalizeErrorMessage(error)}`, error);
+    dependencies.logger.warn(`Command Line Tools check failed: ${normalizeErrorMessage(error)}`, error);
     return {
       name,
       status: "fail",
@@ -276,7 +276,7 @@ export async function checkXcrunAvailable(
       message: "xcrun functional",
     };
   } catch (error) {
-    dependencies.logger.debug(`xcrun check failed: ${normalizeErrorMessage(error)}`, error);
+    dependencies.logger.warn(`xcrun check failed: ${normalizeErrorMessage(error)}`, error);
     return {
       name: "xcrun",
       status: "fail",
@@ -319,7 +319,7 @@ export async function checkSimctlAvailable(
       recommendation: "Install Xcode Command Line Tools: xcode-select --install",
     };
   } catch (error) {
-    dependencies.logger.debug(`simctl check failed: ${normalizeErrorMessage(error)}`, error);
+    dependencies.logger.warn(`simctl check failed: ${normalizeErrorMessage(error)}`, error);
     return {
       name: "simctl",
       status: "fail",
@@ -375,7 +375,7 @@ export async function checkSimulatorRuntimes(
       value: iosRuntimes.length,
     };
   } catch (error) {
-    dependencies.logger.debug(`Simulator runtimes check failed: ${normalizeErrorMessage(error)}`, error);
+    dependencies.logger.warn(`Simulator runtimes check failed: ${normalizeErrorMessage(error)}`, error);
     return {
       name,
       status: "fail",
@@ -422,7 +422,7 @@ export async function checkCodeSigning(
       recommendation: "Sign in to Xcode and install a development certificate for device testing.",
     };
   } catch (error) {
-    dependencies.logger.debug(`Code signing check failed: ${normalizeErrorMessage(error)}`, error);
+    dependencies.logger.warn(`Code signing check failed: ${normalizeErrorMessage(error)}`, error);
     return {
       name,
       status: "warn",
@@ -467,7 +467,7 @@ export async function checkAppleDeveloperAccount(
       recommendation: "Sign in to Xcode to enable device testing.",
     };
   } catch (error) {
-    dependencies.logger.debug(`Apple Developer account check failed: ${normalizeErrorMessage(error)}`, error);
+    dependencies.logger.warn(`Apple Developer account check failed: ${normalizeErrorMessage(error)}`, error);
     return {
       name,
       status: "warn",
@@ -514,7 +514,7 @@ export async function checkProvisioningProfiles(
       recommendation: "Create a provisioning profile in Xcode to enable device testing.",
     };
   } catch (error) {
-    dependencies.logger.debug(`Provisioning profiles check failed: ${normalizeErrorMessage(error)}`, error);
+    dependencies.logger.warn(`Provisioning profiles check failed: ${normalizeErrorMessage(error)}`, error);
     return {
       name,
       status: "warn",
@@ -568,7 +568,7 @@ export async function checkBootedSimulators(
       value: simulators.length,
     };
   } catch (error) {
-    dependencies.logger.debug(`Booted simulators check failed: ${normalizeErrorMessage(error)}`, error);
+    dependencies.logger.warn(`Booted simulators check failed: ${normalizeErrorMessage(error)}`, error);
     return {
       name: "Booted Simulators",
       status: "skip",

--- a/src/models/ActionableError.ts
+++ b/src/models/ActionableError.ts
@@ -6,3 +6,18 @@ export class ActionableError extends Error {
     super(message);
   }
 }
+
+/**
+ * Wrap an unknown caught error in an ActionableError with actionable context.
+ *
+ * Use at system/MCP boundaries and feature actions where the failure should
+ * surface to the client (see the error-handling convention in CLAUDE.md).
+ * Already-actionable errors are returned unchanged so context isn't doubled up.
+ */
+export function toActionableError(error: unknown, context: string): ActionableError {
+  if (error instanceof ActionableError) {
+    return error;
+  }
+  const message = error instanceof Error ? error.message : String(error);
+  return new ActionableError(`${context}: ${message}`);
+}

--- a/test/doctor/ios.test.ts
+++ b/test/doctor/ios.test.ts
@@ -462,7 +462,7 @@ describe("iOS doctor checks", () => {
       });
 
       expect(result.status).toBe("fail");
-      const debug = logger.at("debug");
+      const debug = logger.at("warn");
       expect(debug.length).toBeGreaterThan(0);
       expect(JSON.stringify(debug)).toContain("xcrun: command not found");
     });
@@ -476,7 +476,7 @@ describe("iOS doctor checks", () => {
       });
 
       expect(result.status).toBe("fail");
-      expect(logger.at("debug").length).toBeGreaterThan(0);
+      expect(logger.at("warn").length).toBeGreaterThan(0);
     });
 
     test("checkXcrunAvailable logs the underlying error before returning fail", async () => {
@@ -488,7 +488,7 @@ describe("iOS doctor checks", () => {
       });
 
       expect(result.status).toBe("fail");
-      expect(logger.at("debug").length).toBeGreaterThan(0);
+      expect(logger.at("warn").length).toBeGreaterThan(0);
     });
 
     test("checkSimctlAvailable logs the underlying error before returning fail", async () => {
@@ -502,7 +502,7 @@ describe("iOS doctor checks", () => {
       });
 
       expect(result.status).toBe("fail");
-      expect(logger.at("debug").length).toBeGreaterThan(0);
+      expect(logger.at("warn").length).toBeGreaterThan(0);
     });
 
     test("checkSimulatorRuntimes logs the underlying error before returning fail", async () => {
@@ -520,7 +520,7 @@ describe("iOS doctor checks", () => {
       });
 
       expect(result.status).toBe("fail");
-      expect(logger.at("debug").length).toBeGreaterThan(0);
+      expect(logger.at("warn").length).toBeGreaterThan(0);
     });
 
     test("checkCodeSigning logs the underlying error before returning warn", async () => {
@@ -532,7 +532,7 @@ describe("iOS doctor checks", () => {
       });
 
       expect(result.status).toBe("warn");
-      expect(logger.at("debug").length).toBeGreaterThan(0);
+      expect(logger.at("warn").length).toBeGreaterThan(0);
     });
 
     test("checkAppleDeveloperAccount logs the underlying error before returning warn", async () => {
@@ -546,7 +546,7 @@ describe("iOS doctor checks", () => {
       });
 
       expect(result.status).toBe("warn");
-      expect(logger.at("debug").length).toBeGreaterThan(0);
+      expect(logger.at("warn").length).toBeGreaterThan(0);
     });
 
     test("checkProvisioningProfiles logs the underlying error before returning warn", async () => {
@@ -560,7 +560,7 @@ describe("iOS doctor checks", () => {
       });
 
       expect(result.status).toBe("warn");
-      expect(logger.at("debug").length).toBeGreaterThan(0);
+      expect(logger.at("warn").length).toBeGreaterThan(0);
     });
 
     test("checkBootedSimulators logs the underlying error before returning skip", async () => {
@@ -574,7 +574,7 @@ describe("iOS doctor checks", () => {
       });
 
       expect(result.status).toBe("skip");
-      expect(logger.at("debug").length).toBeGreaterThan(0);
+      expect(logger.at("warn").length).toBeGreaterThan(0);
     });
   });
 });

--- a/test/doctor/ios.test.ts
+++ b/test/doctor/ios.test.ts
@@ -13,6 +13,7 @@ import {
 } from "../../src/doctor/checks/ios";
 import type { ExecResult } from "../../src/models";
 import { FakeTimer } from "../fakes/FakeTimer";
+import { FakeLogger } from "../fakes/FakeLogger";
 
 const createExecResult = (stdout: string, stderr: string = ""): ExecResult => ({
   stdout,
@@ -34,6 +35,7 @@ const baseDependencies: IosDoctorDependencies = {
   fileExists: () => true,
   readDir: async () => [],
   homedir: () => "/Users/test",
+  logger: new FakeLogger(),
   createSimctlClient: () => ({
     setDevice: () => {},
     executeCommand: async () => createExecResult(""),
@@ -443,6 +445,136 @@ describe("iOS doctor checks", () => {
       expect(result.status).toBe("skip");
       expect(result.message).toContain("only available on macOS");
       expect(createSimctlClientCalls).toBe(0);
+    });
+  });
+
+  describe("diagnostic tracing", () => {
+    const throwingExecFile = async () => {
+      throw new Error("xcrun: command not found");
+    };
+
+    test("checkXcodeInstallation logs the underlying error before returning fail", async () => {
+      const logger = new FakeLogger();
+      const result = await checkXcodeInstallation("15.0", {
+        ...baseDependencies,
+        logger,
+        execFile: throwingExecFile
+      });
+
+      expect(result.status).toBe("fail");
+      const debug = logger.at("debug");
+      expect(debug.length).toBeGreaterThan(0);
+      expect(JSON.stringify(debug)).toContain("xcrun: command not found");
+    });
+
+    test("checkXcodeCommandLineTools logs the underlying error before returning fail", async () => {
+      const logger = new FakeLogger();
+      const result = await checkXcodeCommandLineTools({}, {
+        ...baseDependencies,
+        logger,
+        execFile: throwingExecFile
+      });
+
+      expect(result.status).toBe("fail");
+      expect(logger.at("debug").length).toBeGreaterThan(0);
+    });
+
+    test("checkXcrunAvailable logs the underlying error before returning fail", async () => {
+      const logger = new FakeLogger();
+      const result = await checkXcrunAvailable({
+        ...baseDependencies,
+        logger,
+        execFile: throwingExecFile
+      });
+
+      expect(result.status).toBe("fail");
+      expect(logger.at("debug").length).toBeGreaterThan(0);
+    });
+
+    test("checkSimctlAvailable logs the underlying error before returning fail", async () => {
+      const logger = new FakeLogger();
+      const result = await checkSimctlAvailable({
+        ...baseDependencies,
+        logger,
+        createSimctlClient: () => {
+          throw new Error("simctl exploded");
+        }
+      });
+
+      expect(result.status).toBe("fail");
+      expect(logger.at("debug").length).toBeGreaterThan(0);
+    });
+
+    test("checkSimulatorRuntimes logs the underlying error before returning fail", async () => {
+      const logger = new FakeLogger();
+      const result = await checkSimulatorRuntimes({
+        ...baseDependencies,
+        logger,
+        createSimctlClient: () => ({
+          ...baseDependencies.createSimctlClient(),
+          isAvailable: async () => true,
+          getRuntimes: async () => {
+            throw new Error("runtimes exploded");
+          }
+        })
+      });
+
+      expect(result.status).toBe("fail");
+      expect(logger.at("debug").length).toBeGreaterThan(0);
+    });
+
+    test("checkCodeSigning logs the underlying error before returning warn", async () => {
+      const logger = new FakeLogger();
+      const result = await checkCodeSigning({
+        ...baseDependencies,
+        logger,
+        execFile: throwingExecFile
+      });
+
+      expect(result.status).toBe("warn");
+      expect(logger.at("debug").length).toBeGreaterThan(0);
+    });
+
+    test("checkAppleDeveloperAccount logs the underlying error before returning warn", async () => {
+      const logger = new FakeLogger();
+      const result = await checkAppleDeveloperAccount({
+        ...baseDependencies,
+        logger,
+        readDir: async () => {
+          throw new Error("home dir unreadable");
+        }
+      });
+
+      expect(result.status).toBe("warn");
+      expect(logger.at("debug").length).toBeGreaterThan(0);
+    });
+
+    test("checkProvisioningProfiles logs the underlying error before returning warn", async () => {
+      const logger = new FakeLogger();
+      const result = await checkProvisioningProfiles({
+        ...baseDependencies,
+        logger,
+        readDir: async () => {
+          throw new Error("profiles unreadable");
+        }
+      });
+
+      expect(result.status).toBe("warn");
+      expect(logger.at("debug").length).toBeGreaterThan(0);
+    });
+
+    test("checkBootedSimulators logs the underlying error before returning skip", async () => {
+      const logger = new FakeLogger();
+      const result = await checkBootedSimulators({
+        ...baseDependencies,
+        logger,
+        createSimctlClient: () => {
+          throw new Error("booted lookup failed");
+        }
+      });
+
+      expect(result.status).toBe("skip");
+      expect(logger.at("debug").length).toBeGreaterThan(0);
     });
   });
 });

--- a/test/fakes/FakeLogger.ts
+++ b/test/fakes/FakeLogger.ts
@@ -1,0 +1,49 @@
+import { LogLevel, type Logger } from "../../src/utils/logger";
+
+export interface LoggedMessage {
+  level: "debug" | "info" | "warn" | "error";
+  message: string;
+  args: any[];
+}
+
+/**
+ * In-memory Logger fake for asserting that code emits diagnostic traces
+ * without touching the filesystem. Keeps tests fast and non-flaky.
+ */
+export class FakeLogger implements Logger {
+  readonly messages: LoggedMessage[] = [];
+  private level: LogLevel = LogLevel.DEBUG;
+
+  debug(message: string, ...args: any[]): void {
+    this.messages.push({ level: "debug", message, args });
+  }
+
+  info(message: string, ...args: any[]): void {
+    this.messages.push({ level: "info", message, args });
+  }
+
+  warn(message: string, ...args: any[]): void {
+    this.messages.push({ level: "warn", message, args });
+  }
+
+  error(message: string, ...args: any[]): void {
+    this.messages.push({ level: "error", message, args });
+  }
+
+  setLogLevel(level: LogLevel): void {
+    this.level = level;
+  }
+
+  getLogLevel(): LogLevel {
+    return this.level;
+  }
+
+  enableStdoutLogging(): void {}
+  disableStdoutLogging(): void {}
+  close(): void {}
+
+  /** Messages emitted at the given level. */
+  at(level: LoggedMessage["level"]): LoggedMessage[] {
+    return this.messages.filter(m => m.level === level);
+  }
+}

--- a/test/models/ActionableError.test.ts
+++ b/test/models/ActionableError.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, test } from "bun:test";
+import { ActionableError, toActionableError } from "../../src/models/ActionableError";
+
+describe("toActionableError", () => {
+  test("prefixes context and extracts message from an Error", () => {
+    const result = toActionableError(new Error("boom"), "Failed to start recording");
+
+    expect(result).toBeInstanceOf(ActionableError);
+    expect(result.message).toBe("Failed to start recording: boom");
+  });
+
+  test("stringifies non-Error values", () => {
+    const result = toActionableError("plain string failure", "Context");
+
+    expect(result.message).toBe("Context: plain string failure");
+  });
+
+  test("handles null and undefined", () => {
+    expect(toActionableError(null, "Context").message).toBe("Context: null");
+    expect(toActionableError(undefined, "Context").message).toBe("Context: undefined");
+  });
+
+  test("returns the same ActionableError unchanged when already actionable", () => {
+    const original = new ActionableError("already actionable");
+    const result = toActionableError(original, "Context");
+
+    expect(result).toBe(original);
+  });
+});


### PR DESCRIPTION
## What

Establishes and documents a single error-handling convention for `src/`, and fixes the highest-value diagnosability gap it identified.

- **Documented convention** in `CLAUDE.md` — a new "Error Handling Convention" section spelling out the three strategies and when each applies:
  1. **Throw a structured error** at system/MCP boundaries and feature actions (`ActionableError` / `toActionableError`).
  2. **Log, then return a typed failure** for diagnostic/best-effort paths (`doctor` checks) — always trace before returning.
  3. **Log-and-continue (swallow)** only for genuinely-expected non-errors, with a comment stating *why*.
- **`toActionableError(error, context)` helper** (`src/models/ActionableError.ts`) — wraps an unknown caught value in an `ActionableError` with actionable context in one call; returns already-actionable errors unchanged so context isn't doubled.
- **Restored doctor diagnosability** — injected a `Logger` into `IosDoctorDependencies` and added `logger.debug(...)` before every `catch` in `src/doctor/checks/ios.ts` returns a fail/warn/skip status. Previously these failures only reached the user-facing message and left no trace in the daemon log.

Closes #2657.

## Why

`src/` has ~864 `catch` blocks using three divergent strategies with no written rule, so each contributor picks ad hoc and some failures leave no diagnostic trace. The building blocks (`ActionableError`, shared `logger`) already existed; what was missing was the documented rule and the doctor-check traces. The convention is the durable backstop — lint intentionally allows unused `catch (error)` (`caughtErrors: "none"`), so it can't enforce this.

## Scope note

The issue's optional ESLint `no-restricted-syntax` rule (flag empty / bare-`return` catch bodies) is **deliberately deferred**: enabling it would force a noisy mechanical pass over all ~864 catch blocks, out of proportion to this change. The written convention plus the doctor fix capture the highest ROI; the lint rule can follow as its own focused PR.

## Validation

- TDD: added `test/models/ActionableError.test.ts` and a "diagnostic tracing" suite in `test/doctor/ios.test.ts` (new `test/fakes/FakeLogger.ts`, Interface+Fake, no real device/network).
- `bun test` — **5009 pass / 0 fail** (full suite, ~13.6s).
- `turbo run lint build` — clean.
