### PR TITLE
refactor: de-duplicate DevicePool assignment (LRU drift) + remove [*-DEBUG] logging

### DIFF
--- a/scripts/all_fast_validate_checks.sh
+++ b/scripts/all_fast_validate_checks.sh
@@ -39,6 +39,7 @@ add_check "claude-plugin" "\"$PROJECT_ROOT/scripts/claude/validate_plugin.sh\"" 
 add_check "codex-skills" "\"$PROJECT_ROOT/scripts/validate_codex_skills.sh\"" "config,docs" "Validate Codex skills and AGENTS inventory"
 add_check "lychee" "\"$PROJECT_ROOT/scripts/lychee/validate_lychee.sh\"" "docs,links" "Validate documentation links"
 add_check "dependabot" "\"$PROJECT_ROOT/scripts/validate_dependabot.sh\"" "config,yaml" "Validate Dependabot config"
+add_check "debug-tags" "\"$PROJECT_ROOT/scripts/validate-no-debug-log-tags.sh\"" "lint" "Reject stray [*-DEBUG] log tags in src/"
 
 print_usage() {
   cat <<'EOF'

--- a/scripts/validate-no-debug-log-tags.sh
+++ b/scripts/validate-no-debug-log-tags.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+#
+# Guard against stray "[*-DEBUG]" log tags merging into the TypeScript source.
+#
+# Temporary instrumentation often gets a bracketed tag like
+# "[DEVICE-POOL-DEBUG]" so it can be grepped out of logs during a debugging
+# session. Those statements are meant to be removed afterward; this check
+# fails CI if any survive in src/, complementing dead-code-detection.yml.
+#
+# See issue #2656 (left-in [DEVICE-POOL-DEBUG] logging).
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SRC_DIR="${ROOT_DIR}/src"
+
+# Match an uppercase tag ending in -DEBUG inside square brackets, e.g.
+# [DEVICE-POOL-DEBUG], [FOO-DEBUG]. Allow letters, digits, underscores, hyphens.
+PATTERN='\[[A-Z0-9_-]+-DEBUG\]'
+
+matches="$(grep -rEn --include='*.ts' "$PATTERN" "$SRC_DIR" || true)"
+
+if [[ -n "$matches" ]]; then
+  echo "error: stray [*-DEBUG] log tag(s) found in src/ — remove temporary instrumentation before merging:" >&2
+  echo "$matches" >&2
+  exit 1
+fi
+
+echo "No stray [*-DEBUG] log tags found in src/."

--- a/src/daemon/daemonState.ts
+++ b/src/daemon/daemonState.ts
@@ -1,6 +1,5 @@
 import { SessionManager } from "./sessionManager";
 import { DevicePool } from "./devicePool";
-import { logger } from "../utils/logger";
 
 export interface DaemonStateLike {
   isInitialized(): boolean;
@@ -55,12 +54,8 @@ export class DaemonState implements DaemonStateLike {
    */
   getDevicePool(): DevicePool {
     if (!this.devicePool) {
-      logger.error("[DAEMON-STATE-DEBUG] getDevicePool called but devicePool is null!");
       throw new Error("DaemonState not initialized");
     }
-    const stats = this.devicePool.getStats();
-    const poolInstanceId = this.devicePool.instanceId;
-    logger.debug(`[DAEMON-STATE-DEBUG] getDevicePool returning pool instance #${poolInstanceId} with ${stats.total} devices`);
     return this.devicePool;
   }
 

--- a/src/daemon/devicePool.ts
+++ b/src/daemon/devicePool.ts
@@ -67,8 +67,6 @@ export interface PooledDevice {
  * Works with SessionManager to maintain bidirectional mappings.
  */
 export class DevicePool {
-  private static instanceCounter = 0;
-  readonly instanceId: number;
   private devices: Map<string, PooledDevice> = new Map();
   private deviceSessionStarts: Map<string, number> = new Map();
   private sessionManager: SessionManager;
@@ -104,8 +102,6 @@ export class DevicePool {
     deviceSessionRepository: DeviceSessionRepository = new DeviceSessionRepository(),
     criteriaMatcher: DeviceCriteriaMatcher = new DeviceCriteriaMatcher()
   ) {
-    this.instanceId = ++DevicePool.instanceCounter;
-    logger.info(`[DEVICE-POOL-DEBUG] Creating DevicePool instance #${this.instanceId}`);
     this.sessionManager = sessionManager;
     this.daemonSessionId = daemonSessionId;
     this.timer = timer;
@@ -843,10 +839,6 @@ export class DevicePool {
    * This enables parallel test execution with limited devices.
    */
   async assignDeviceToSession(sessionId: string, platform?: Platform): Promise<string> {
-    logger.debug(`[DEVICE-POOL-DEBUG] Instance #${this.instanceId}: assignDeviceToSession called for session ${sessionId}`);
-    logger.debug(`[DEVICE-POOL-DEBUG] Instance #${this.instanceId}: Current devices.size: ${this.devices.size}`);
-    logger.debug(`[DEVICE-POOL-DEBUG] Instance #${this.instanceId}: Device IDs: ${Array.from(this.devices.keys()).join(", ")}`);
-
     const maxAttempts = Math.ceil(this.DEVICE_WAIT_TIMEOUT_MS / this.DEVICE_WAIT_INTERVAL_MS);
     let firstAttemptLogged = false;
 
@@ -937,11 +929,52 @@ export class DevicePool {
     shouldWait: boolean;
     totalDevices: number;
   }> {
-    return await this.assignmentMutex.runExclusive(async () => {
-      logger.info(`[DEVICE-POOL-DEBUG] tryAssignDevice: devices.size = ${this.devices.size}`);
-      logger.info(`[DEVICE-POOL-DEBUG] tryAssignDevice: device IDs = ${Array.from(this.devices.keys()).join(", ")}`);
+    return this.tryAssignFrom(
+      sessionId,
+      () => this.getDevicesByPlatform(platform),
+      "platform pool empty"
+    );
+  }
 
-      let candidates = this.getDevicesByPlatform(platform);
+  private async tryAssignDeviceWithCriteria(
+    sessionId: string,
+    criteria?: DeviceAllocationCriteria
+  ): Promise<{
+    success: boolean;
+    deviceId?: string;
+    shouldWait: boolean;
+    totalDevices: number;
+  }> {
+    return this.tryAssignFrom(
+      sessionId,
+      () => this.getDevicesMatchingCriteria(criteria),
+      "criteria pool empty"
+    );
+  }
+
+  /**
+   * Shared single-attempt assignment body for platform- and criteria-based
+   * allocation. Parameterized only by how candidate devices are selected and
+   * the label used when the candidate pool is empty.
+   *
+   * Selection order: prefer the most recently released device for reuse, then
+   * fall back to the least-recently-used idle device for load distribution.
+   *
+   * @param emptyCandidatePoolReason label logged when candidates exist in the
+   *   pool overall but none match this selector (the `totalDevices === 0` case)
+   */
+  private async tryAssignFrom(
+    sessionId: string,
+    selectCandidates: () => PooledDevice[],
+    emptyCandidatePoolReason: string
+  ): Promise<{
+    success: boolean;
+    deviceId?: string;
+    shouldWait: boolean;
+    totalDevices: number;
+  }> {
+    return await this.assignmentMutex.runExclusive(async () => {
+      let candidates = selectCandidates();
       let totalDevices = candidates.length;
 
       // Find idle devices and prefer most recently released for reuse
@@ -958,7 +991,6 @@ export class DevicePool {
           device = idleDevices[0];
         }
       }
-      logger.info(`[DEVICE-POOL-DEBUG] tryAssignDevice: found idle device = ${device?.id || "none"}`);
 
       // If no devices available and pool is empty, try to refresh
       // This handles race conditions during daemon startup
@@ -967,18 +999,14 @@ export class DevicePool {
         const refreshReason = this.devices.size === 0
           ? "empty pool"
           : totalDevices === 0
-            ? "platform pool empty"
+            ? emptyCandidatePoolReason
             : "no idle usable devices";
         logger.info(`[DevicePool] Auto-refreshing devices due to ${refreshReason}...`);
-        const addedCount = await this.refreshDevices();
-        logger.info(`[DEVICE-POOL-DEBUG] Auto-refresh added ${addedCount} devices`);
-        candidates = this.getDevicesByPlatform(platform);
+        await this.refreshDevices();
+        candidates = selectCandidates();
         totalDevices = candidates.length;
         device = candidates.find(d => d.status === "idle");
-        logger.info(`[DEVICE-POOL-DEBUG] After refresh, found idle device = ${device?.id || "none"}`);
       }
-
-      logger.info(`[DEVICE-POOL-DEBUG] tryAssignDevice: totalDevices = ${totalDevices}`);
 
       if (!device) {
         // No idle device - check if devices exist but are busy
@@ -1001,74 +1029,6 @@ export class DevicePool {
       device.errorCount = 0; // Reset errors on successful assignment
 
       // Create session in SessionManager
-      await this.sessionManager.createSession(sessionId, device.id, device.platform);
-
-      logger.info(`Assigned device ${device.id} to session ${sessionId}`);
-
-      return {
-        success: true,
-        deviceId: device.id,
-        shouldWait: false,
-        totalDevices,
-      };
-    });
-  }
-
-  private async tryAssignDeviceWithCriteria(
-    sessionId: string,
-    criteria?: DeviceAllocationCriteria
-  ): Promise<{
-    success: boolean;
-    deviceId?: string;
-    shouldWait: boolean;
-    totalDevices: number;
-  }> {
-    return await this.assignmentMutex.runExclusive(async () => {
-      let candidates = this.getDevicesMatchingCriteria(criteria);
-      let totalDevices = candidates.length;
-
-      const idleDevices = candidates.filter(d => d.status === "idle");
-      let device: PooledDevice | undefined;
-
-      if (idleDevices.length > 0) {
-        if (this.lastReleasedDeviceId) {
-          device = idleDevices.find(d => d.id === this.lastReleasedDeviceId);
-        }
-        if (!device) {
-          device = idleDevices[0];
-        }
-      }
-
-      const busyDevicesBeforeRefresh = candidates.filter(d => d.status === "busy").length;
-      if (!device && (this.devices.size === 0 || totalDevices === 0 || busyDevicesBeforeRefresh === 0)) {
-        const refreshReason = this.devices.size === 0
-          ? "empty pool"
-          : totalDevices === 0
-            ? "criteria pool empty"
-            : "no idle usable devices";
-        logger.info(`[DevicePool] Auto-refreshing devices due to ${refreshReason}...`);
-        const addedCount = await this.refreshDevices();
-        logger.info(`[DevicePool] Auto-refresh added ${addedCount} devices`);
-        candidates = this.getDevicesMatchingCriteria(criteria);
-        totalDevices = candidates.length;
-        device = candidates.find(d => d.status === "idle");
-      }
-
-      if (!device) {
-        const busyDevices = candidates.filter(d => d.status === "busy").length;
-        return {
-          success: false,
-          shouldWait: busyDevices > 0,
-          totalDevices,
-        };
-      }
-
-      device.sessionId = sessionId;
-      device.status = "busy";
-      device.lastUsedAt = this.nextLastUsedAt();
-      device.assignmentCount++;
-      device.errorCount = 0;
-
       await this.sessionManager.createSession(sessionId, device.id, device.platform);
 
       logger.info(`Assigned device ${device.id} to session ${sessionId}`);

--- a/test/bats/validate-no-debug-log-tags.bats
+++ b/test/bats/validate-no-debug-log-tags.bats
@@ -1,0 +1,20 @@
+#!/usr/bin/env bats
+#
+# Tests for scripts/validate-no-debug-log-tags.sh
+
+SCRIPT="scripts/validate-no-debug-log-tags.sh"
+
+@test "passes when no stray [*-DEBUG] log tags exist in src/" {
+  run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"No stray [*-DEBUG] log tags found in src/."* ]]
+}
+
+@test "fails when a [*-DEBUG] log tag is present in src/" {
+  local tmp="src/__debug_tag_guard_fixture__.ts"
+  printf 'export const x = "[DEVICE-POOL-DEBUG] leftover";\n' > "$tmp"
+  run bash "$SCRIPT"
+  rm -f "$tmp"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"stray [*-DEBUG] log tag"* ]]
+}

--- a/test/daemon/devicePool.test.ts
+++ b/test/daemon/devicePool.test.ts
@@ -723,6 +723,46 @@ describe("DevicePool", () => {
 
       expect(assignments.get("session-a")).toBe("sim-1");
     });
+
+    test("should prefer the least-recently-used idle device for criteria allocation", async () => {
+      // Regression test for LRU drift between tryAssignDevice and
+      // tryAssignDeviceWithCriteria (issue #2656). Criteria-based allocation
+      // must distribute load to the least-recently-used idle device, the same
+      // way platform-based allocation does.
+      await devicePool.initializeWithDevices([
+        createBootedDevice("dev-a", "android"),
+        createBootedDevice("dev-b", "android"),
+        createBootedDevice("dev-c", "android"),
+      ]);
+
+      // Touch devices in reverse insertion order so lastUsedAt ordering
+      // (c < b < a) differs from map insertion order (a, b, c).
+      await devicePool.bindOrReuseDeviceSession("seed-c", "dev-c", "android");
+      await devicePool.bindOrReuseDeviceSession("seed-b", "dev-b", "android");
+      await devicePool.bindOrReuseDeviceSession("seed-a", "dev-a", "android");
+
+      await devicePool.releaseDevice("dev-a");
+      await devicePool.releaseDevice("dev-b");
+      await devicePool.releaseDevice("dev-c");
+
+      // Re-bind dev-c so it is busy (and remains the lastReleasedDeviceId,
+      // which should be ignored because it is no longer idle). Idle pool is
+      // now {dev-a, dev-b}; insertion order would yield dev-a, but dev-b is
+      // less recently used and must win.
+      await devicePool.bindOrReuseDeviceSession("seed-c2", "dev-c", "android");
+
+      const assignments = await devicePool.assignMultipleDevicesByCriteria(
+        [
+          {
+            sessionId: "session-lru",
+            criteria: { platform: "android" },
+          },
+        ],
+        1000
+      );
+
+      expect(assignments.get("session-lru")).toBe("dev-b");
+    });
   });
 
   describe("releaseDevice", () => {


### PR DESCRIPTION
## Summary

De-duplicates `DevicePool`'s two near-identical assignment methods, fixes the LRU load-balancing drift between them, and removes left-in `[*-DEBUG]` instrumentation. Closes #2656.

- **Dedup + LRU fix:** `tryAssignDevice` and `tryAssignDeviceWithCriteria` shared ~80% of their body but had drifted — the criteria path silently dropped the least-recently-used sort, so criteria-based allocation (the multi-device plan path) didn't balance load. Extracted the shared single-attempt body into one private `tryAssignFrom(sessionId, selectCandidates, emptyCandidatePoolReason)` helper parameterized only by the candidate selector. Both public entry points now delegate to it, restoring LRU to the criteria path for free.
- **Removed debug logging:** deleted the 10 left-in `[DEVICE-POOL-DEBUG]` statements in `devicePool.ts` (several at `logger.info`, so they shipped in normal logs) and 2 `[DAEMON-STATE-DEBUG]` statements in `daemonState.ts`. Also removed the now-unused `instanceId`/`instanceCounter` fields that existed solely to label those logs (and the now-unused `logger` import in `daemonState.ts`).
- **Regression test:** added a test asserting criteria-based allocation prefers the least-recently-used idle device (this drift had no test catching it). It fails on the old code (`dev-a`) and passes on the fix (`dev-b`).
- **CI guard:** added `scripts/validate-no-debug-log-tags.sh` (wired into `all_fast_validate_checks.sh`, with BATS coverage) to reject stray `[*-DEBUG]` log tags in `src/` going forward — complements `dead-code-detection.yml`.

## Evaluation criteria

- [x] Criteria-based assignment prefers the least-recently-used idle device (new regression test).
- [x] No `[*-DEBUG]` log tags remain in `src/` (new guard returns clean).
- [x] Both entry points share one helper; behavior parity preserved (existing daemon tests green).
- [x] Full suite green: `bun test` → 4997 pass / 0 fail; `turbo run lint build` pass.

## Test plan

- `bun test test/daemon/devicePool.test.ts` — 43 pass (incl. new LRU test)
- `bun test` — 4997 pass, 2 skip, 0 fail
- `turbo run lint build` — pass
- `bash scripts/validate-no-debug-log-tags.sh` + `bats test/bats/validate-no-debug-log-tags.bats` — pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
