### PR TITLE
fix: replace `any` in navigation hierarchy logic with typed ViewHierarchyResult / AccessibilityNode model

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -206,6 +206,28 @@ export default [
 		rules: baseRules,
 	},
 	{
+		// Navigation hierarchy logic is correctness-sensitive: screen
+		// fingerprinting drives navigation-graph dedup and element extraction
+		// drives Explore, so a wrong field name silently produces a wrong
+		// fingerprint/hash. Ban the `any` escape hatch in these files so the
+		// typed ViewHierarchyResult / AccessibilityNode model is always used and
+		// the #1122-style carry-over regression cannot recur. Genuine boundaries
+		// must opt out with an inline
+		// `// eslint-disable-next-line @typescript-eslint/no-explicit-any -- <reason>`.
+		// (Other navigation files still carry pre-existing `any`; broadening the
+		// scope to the full directory is a follow-up once those are migrated.)
+		files: [
+			"src/features/navigation/ScreenFingerprint.ts",
+			"src/features/navigation/ExploreElementExtraction.ts",
+		],
+		plugins,
+		languageOptions,
+		rules: {
+			...baseRules,
+			"@typescript-eslint/no-explicit-any": "error",
+		},
+	},
+	{
         files: ["test/**/*.ts", "**/scratch/**/*.ts"],
 		plugins,
 		languageOptions,

--- a/src/features/navigation/ExploreElementExtraction.ts
+++ b/src/features/navigation/ExploreElementExtraction.ts
@@ -1,4 +1,4 @@
-import type { Element } from "../../models";
+import type { Element, ViewHierarchyResult } from "../../models";
 import { isTruthy, isFalsy } from "../../models";
 import type { ElementParser } from "../../utils/interfaces/ElementParser";
 import type { TrackedElement } from "./ExploreTypes";
@@ -7,7 +7,7 @@ import type { TrackedElement } from "./ExploreTypes";
  * Extract elements likely to be navigation controls
  */
 export function extractNavigationElements(
-  viewHierarchy: any,
+  viewHierarchy: ViewHierarchyResult,
   elementParser: ElementParser
 ): Element[] {
   const flatElements = elementParser.flattenViewHierarchy(viewHierarchy);
@@ -71,7 +71,7 @@ export function enrichElementWithChildProperties(element: Element): Element {
  * Extract scrollable containers for swiping
  */
 export function extractScrollableContainers(
-  viewHierarchy: any,
+  viewHierarchy: ViewHierarchyResult,
   elementParser: ElementParser
 ): Element[] {
   const flatElements = elementParser.flattenViewHierarchy(viewHierarchy);
@@ -152,7 +152,7 @@ export function isNavigationCandidate(element: Element): boolean {
  * Extract all elements from hierarchy (including non-clickable)
  */
 export function extractAllElements(
-  viewHierarchy: any,
+  viewHierarchy: ViewHierarchyResult,
   elementParser: ElementParser
 ): Element[] {
   const flatElements = elementParser.flattenViewHierarchy(viewHierarchy);

--- a/src/features/navigation/ScreenFingerprint.ts
+++ b/src/features/navigation/ScreenFingerprint.ts
@@ -27,6 +27,17 @@ export interface AccessibilityHierarchy {
 }
 
 /**
+ * Reduced node produced by {@link ScreenFingerprint.filterHierarchyEnhanced}.
+ * It carries a dynamic subset of accessibility fields plus synthetic markers
+ * (`_scrollable`, `_selected`) used only for hashing, so the value bag is typed
+ * as `unknown` while the recursive `node` shape stays explicit.
+ */
+export interface FilteredNode {
+  node?: FilteredNode[];
+  [key: string]: unknown;
+}
+
+/**
  * Fingerprint confidence levels based on method used
  */
 export enum FingerprintConfidence {
@@ -197,7 +208,7 @@ export class ScreenFingerprint {
   /**
    * Extract navigation resource-id from hierarchy (navigation.* pattern).
    */
-  private static extractNavigationId(node: any): string | null {
+  private static extractNavigationId(node: AccessibilityNode): string | null {
     if (!node || typeof node !== "object") {return null;}
 
     if (node["resource-id"]?.startsWith("navigation.")) {
@@ -221,7 +232,7 @@ export class ScreenFingerprint {
    * Indicators: content-desc with "Delete", "Enter", "keyboard", "emoji"
    */
   private static detectKeyboard(hierarchy: AccessibilityHierarchy): boolean {
-    function hasKeyboardElements(node: any): boolean {
+    function hasKeyboardElements(node: AccessibilityNode): boolean {
       if (!node || typeof node !== "object") {return false;}
 
       // Check resource-id patterns
@@ -326,7 +337,7 @@ export class ScreenFingerprint {
    * - Keep static text for differentiation
    * - Preserve selected state
    */
-  private static filterHierarchyEnhanced(node: any): any {
+  private static filterHierarchyEnhanced(node: AccessibilityNode): FilteredNode | null {
     if (!node || typeof node !== "object") {return null;}
 
     // Skip keyboard elements (match detectKeyboard indicators)
@@ -342,7 +353,7 @@ export class ScreenFingerprint {
       return null;
     }
 
-    const filtered: any = {};
+    const filtered: FilteredNode = {};
 
     // Handle scrollable containers with enhanced strategy
     if (node.scrollable === "true") {
@@ -364,8 +375,8 @@ export class ScreenFingerprint {
       if (node.node) {
         const children = Array.isArray(node.node) ? node.node : [node.node];
         const selectedItems = children
-          .filter((child: any) => child.selected === "true")
-          .map((child: any) => this.extractSelectedInfo(child))
+          .filter((child: AccessibilityNode) => child.selected === "true")
+          .map((child: AccessibilityNode) => this.extractSelectedInfo(child))
           .filter(Boolean);
 
         if (selectedItems.length > 0) {
@@ -430,8 +441,8 @@ export class ScreenFingerprint {
     if (node.node) {
       const children = Array.isArray(node.node) ? node.node : [node.node];
       const filteredChildren = children
-        .map((child: any) => this.filterHierarchyEnhanced(child))
-        .filter(Boolean);
+        .map((child: AccessibilityNode) => this.filterHierarchyEnhanced(child))
+        .filter(Boolean) as FilteredNode[];
 
       if (filteredChildren.length > 0) {
         filtered.node = filteredChildren;
@@ -444,10 +455,10 @@ export class ScreenFingerprint {
   /**
    * Extract selected item information (text, content-desc, or resource-id).
    */
-  private static extractSelectedInfo(node: any): any {
+  private static extractSelectedInfo(node: AccessibilityNode): FilteredNode | null {
     if (!node || typeof node !== "object") {return null;}
 
-    const info: any = { selected: "true" };
+    const info: FilteredNode = { selected: "true" };
 
     // Get text from node or its children
     if (node.text) {
@@ -473,8 +484,14 @@ export class ScreenFingerprint {
   /**
    * Find text in node children.
    */
-  private static findTextInChildren(node: any): string | null {
+  private static findTextInChildren(
+    node: AccessibilityNode | AccessibilityNode[]
+  ): string | null {
     if (!node || typeof node !== "object") {return null;}
+
+    // An array argument has no text/node fields of its own; preserve the
+    // original behavior of treating it as "no text found" (it is never iterated).
+    if (Array.isArray(node)) {return null;}
 
     if (node.text) {return node.text;}
 
@@ -492,7 +509,7 @@ export class ScreenFingerprint {
   /**
    * Count elements in filtered hierarchy.
    */
-  private static countElements(node: any): number {
+  private static countElements(node: FilteredNode | null): number {
     if (!node || typeof node !== "object") {return 0;}
 
     let count = 1; // Count this node
@@ -517,7 +534,7 @@ export class ScreenFingerprint {
   /**
    * Generate SHA-256 hash from object.
    */
-  private static hashObject(obj: any): string {
+  private static hashObject(obj: FilteredNode | null): string {
     const data = JSON.stringify(obj);
     return crypto.createHash("sha256").update(data).digest("hex");
   }

--- a/test/features/navigation/ScreenFingerprint.test.ts
+++ b/test/features/navigation/ScreenFingerprint.test.ts
@@ -900,6 +900,53 @@ describe("ScreenFingerprint - Enhanced Implementation", () => {
       expect(hash2).toBe(hash4);
     });
   });
+
+  // Golden-hash stability guard: pins the exact hash output for fixed inputs so
+  // that the `any` -> typed annotation refactor is proven to make zero runtime
+  // change. If any of these values shift, the type migration altered behavior.
+  describe("Golden hash stability (refactor guard)", () => {
+    test("navigation-id fingerprint hash is stable", () => {
+      const hierarchy = createHierarchy({
+        node: {
+          "resource-id": "navigation.HomeDestination",
+          "node": { "text": "Home Screen", "resource-id": "home_screen_content" },
+        },
+      });
+
+      const result = ScreenFingerprint.compute(hierarchy);
+
+      expect(result.method).toBe(FingerprintMethod.NAVIGATION_ID);
+      expect(result.hash).toBe("5c6a39c949cfeec058c563e7a0c1bd8f9f9226e1626ca48e3998df4c6b50f64d");
+    });
+
+    test("shallow-scrollable filtered fingerprint hash is stable", () => {
+      const hierarchy = createHierarchy({
+        node: {
+          className: "Root",
+          node: [
+            {
+              "scrollable": "true",
+              "resource-id": "app:id/list",
+              "className": "RecyclerView",
+              "node": [
+                { "selected": "true", "text": "Tab One", "resource-id": "app:id/tab1" },
+                { "selected": "false", "text": "Tab Two", "resource-id": "app:id/tab2" },
+              ],
+            },
+            { "text": "Static Label", "resource-id": "app:id/label" },
+            { "content-desc": "Battery 50 percent" },
+            { "text": "12:34" },
+          ],
+        },
+      });
+
+      const result = ScreenFingerprint.compute(hierarchy);
+
+      expect(result.method).toBe(FingerprintMethod.SHALLOW_SCROLLABLE);
+      expect(result.hash).toBe("ff3379f2bb03233f1101775d913077b39802854a9e62ab1236ab7c512744a1f3");
+      expect(result.elementCount).toBe(4);
+    });
+  });
 });
 
 // Helper function to create AccessibilityHierarchy


### PR DESCRIPTION
## What

Replaces `any` annotations in the navigation hierarchy logic with the existing typed model, the highest-value follow-up to #1717's type-safety pass. Closes #2655.

- **`src/features/navigation/ScreenFingerprint.ts`** — typed all 12 `any` sites (incl. the inner `detectKeyboard` helper). The traversal helpers operate on the **flat** accessibility-node shape, so they're typed against the in-file `AccessibilityNode` interface (not `ViewHierarchyNode`, which wraps attributes under `$` — see Why). A new exported `FilteredNode` (`{ node?: FilteredNode[]; [key: string]: unknown }`) types the hash/filter accumulator instead of `any`.
- **`src/features/navigation/ExploreElementExtraction.ts`** — typed `viewHierarchy: ViewHierarchyResult` in `extractNavigationElements`, `extractScrollableContainers`, and `extractAllElements` (matching what `ElementParser.flattenViewHierarchy` already requires).
- **`eslint.config.mjs`** — added `@typescript-eslint/no-explicit-any: error` scoped to these two files to prevent the #1122-style carry-over regression. Verified the rule fires on a probe `any` and passes on the cleaned files.

## Why

Screen fingerprinting drives navigation-graph dedup and element extraction drives `Explore`; a wrong field name in `any`-typed traversal silently produces a wrong fingerprint/hash. The typed building blocks already existed — this finishes #1717's job on the annotation side.

**Type-choice note:** the issue suggested `ViewHierarchyNode` for `ScreenFingerprint`, but that type exposes attributes under `node.$["resource-id"]`, while these helpers read flat fields (`node["resource-id"]`, `node.text`, `node.scrollable`) — the `AccessibilityNode` shape already defined in-file and confirmed by the test fixtures. Using `AccessibilityNode` is the behavior-correct choice.

**eslint scope note:** the rule is scoped to the two cleaned files rather than the full `src/features/navigation/**`, because 6 other files in that directory still carry pre-existing `any` that would break `eslint .`. Broadening the scope once those are migrated is a documented follow-up.

Zero runtime change — only type annotations modified (one behavior-preserving array guard added to `findTextInChildren`). A new **golden-hash stability** guard test pins the exact `navigation-id` and `shallow-scrollable` fingerprint output across the refactor.

## Validation

- `scripts/all_fast_validate_checks.sh` → 9/9 pass
- `bun run build.ts` → green
- `eslint .` → exit 0 (and rule verified to fire on a probe `any`)
- `bun test test/features/navigation/` → 274 pass / 0 fail (incl. new golden-hash guard)
- `tsc --noEmit` → no new errors (only a pre-existing `moduleResolution` deprecation warning)
