### PR TITLE
fix(ios): drop MAX() macro that breaks CtrlProxy build on Xcode 26.3

### DIFF
--- a/ios/control-proxy/Sources/ObjCExceptionCatcher/ObjCExceptionCatcher.m
+++ b/ios/control-proxy/Sources/ObjCExceptionCatcher/ObjCExceptionCatcher.m
@@ -127,8 +127,11 @@ BOOL ObjCExceptionCatcher_synthesizePinch(
             return;
         }
 
-        CGFloat startRadius = MAX(distanceStart, 1) / 2.0;
-        CGFloat endRadius = MAX(distanceEnd, 1) / 2.0;
+        // Avoid the MAX() macro: it expands to a GNU statement expression, which
+        // Xcode 26.3's clang flags under -Wgnu-statement-expression-from-macro-expansion
+        // and the target builds with -pedantic -Werror.
+        CGFloat startRadius = (distanceStart > 1 ? distanceStart : 1) / 2.0;
+        CGFloat endRadius = (distanceEnd > 1 ? distanceEnd : 1) / 2.0;
         CGFloat endRadians = rotationDegrees * (CGFloat)M_PI / 180.0;
         CGFloat dxStart = startRadius;
         CGFloat dyStart = 0;


### PR DESCRIPTION
## Problem

The **XCTestRunner Simulator Tests** CI job (`scripts/ios/ctrl-proxy-build-for-testing.sh`) was failing for **every open PR**, blocking all merges. It's a branch-independent break: PRs touching no iOS files (e.g. #2673, #2672) all failed at the identical `CompileC ObjCExceptionCatcher.m` step, with the real diagnostic suppressed by xcbeautify in the CI log.

## Root cause

Reproduced locally on the same toolchain as CI (Xcode 26.3 / iOS 26.2 SDK), running `build-for-testing` without xcbeautify:

```
ObjCExceptionCatcher.m:130:31: error: use of GNU statement expression extension from macro expansion [-Werror,-Wgnu-statement-expression-from-macro-expansion]
ObjCExceptionCatcher.m:131:29: error: ...
2 errors generated.
** TEST BUILD FAILED **
```

Lines 130–131 used the `MAX()` macro (`MAX(distanceStart, 1)` / `MAX(distanceEnd, 1)`). Foundation defines `MAX` as a **GNU statement-expression** (`({ ... })`). Xcode 26.3's clang split out a new warning — `-Wgnu-statement-expression-from-macro-expansion` — and this target builds with `-pedantic -Werror`, so it's promoted to a hard error.

It's the intersection of two things:
- The `MAX()` usage was introduced by the pinch synthesis in #2653 (`git blame` → `080d3564`) and is the **only** macro use in the file (the multi-finger-swipe function has none, which is why only the pinch lines fail).
- It only triggers under **Xcode 26.3's** new diagnostic, so it merged green and then started failing every PR once CI moved to that SDK.

## Fix

Replace the two `MAX()` calls with explicit ternaries. `MAX(x, 1)` and `(x > 1 ? x : 1)` are behaviorally identical for all inputs (they agree at the `x == 1` boundary too), and the ternary doesn't use the statement-expression extension.

## Verification

On Xcode 26.3 / iOS 26.2 SDK:

```
** TEST BUILD SUCCEEDED **
xctestrun: .../CtrlProxyApp_iphonesimulator26.2-arm64-x86_64.xctestrun
```

The `.xctestrun` artifact the CI job checks for is produced. Confirmed `MAX`/`MIN` macros appear nowhere else in the iOS runner ObjC sources, and the full `build-for-testing` compiles every sibling `.m`/`.swift` clean — so no other file hits this under the new SDK.