### PR TITLE
Loosen Compose interop hidden-region text reject to candidate node (#2634)

### DIFF
--- a/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/ViewHierarchyExtractor.kt
+++ b/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/ViewHierarchyExtractor.kt
@@ -536,7 +536,13 @@ class ViewHierarchyExtractor(private val recompositionStore: RecompositionStore?
       return false
     }
 
-    if (countTextBearingNodes(node) > 0) {
+    // Reject only when the candidate boundary itself is labeled: a node with its own text or
+    // content-desc is its own accessible content, not a hidden interop body. Descendant labels
+    // (e.g. a toolbar title above an otherwise inaccessible Fragment/RecyclerView) are allowed to
+    // coexist with a hidden-region report. The direct-child-coverage gate below is the guard
+    // against regions that are actually mostly visible. See #2634.
+    val nodeHasOwnLabel = !node.text.isNullOrBlank() || !node.contentDesc.isNullOrBlank()
+    if (nodeHasOwnLabel) {
       return false
     }
 
@@ -546,12 +552,6 @@ class ViewHierarchyExtractor(private val recompositionStore: RecompositionStore?
 
     val childCoverage = directChildCoverage(bounds, children)
     return childCoverage <= MAX_VISIBLE_CHILD_COVERAGE
-  }
-
-  private fun countTextBearingNodes(node: UIElementInfo): Int {
-    val hasText = !node.text.isNullOrBlank() || !node.contentDesc.isNullOrBlank()
-    return (if (hasText) 1 else 0) +
-        extractChildrenFromNode(node.node).sumOf { countTextBearingNodes(it) }
   }
 
   private fun isInteractive(node: UIElementInfo): Boolean {

--- a/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/ViewHierarchyExtractorTest.kt
+++ b/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/ViewHierarchyExtractorTest.kt
@@ -986,17 +986,94 @@ class ViewHierarchyExtractorTest {
   }
 
   @Test
-  fun `detectContentHiddenRegions ignores large Compose descendants with text content`() {
-    val textChild =
+  fun `detectContentHiddenRegions reports region when a sparse visible text child coexists`() {
+    // Compose interop body whose only accessibility-visible child is a small toolbar title
+    // ("general"). The recursive text reject treated this as a false negative; Option 1 lets the
+    // sparse title coexist with the hidden-region report, gated by direct child coverage.
+    val toolbarTitle =
         elementWithBounds(
-            bounds = bounds(32, 500, 400, 560),
+            resourceId = "com.slack:id/top_bar",
+            bounds = bounds(0, 290, 1440, 458),
             text = "general",
         )
     val contentRegion =
         elementWithBounds(
             bounds = bounds(0, 368, 1440, 2752),
             actions = listOf("accessibility_focus"),
-            children = listOf(textChild),
+            children = listOf(toolbarTitle),
+        )
+    val composeRoot =
+        elementWithBounds(
+            className = "androidx.compose.ui.platform.ComposeView",
+            bounds = bounds(0, 0, 1440, 3000),
+            children = listOf(contentRegion),
+        )
+
+    val regions = extractor.detectContentHiddenRegionsForTest(composeRoot, 1440, 3000)
+
+    assertEquals(1, regions.size)
+    assertEquals("compose-interop-no-hide-descendants", regions[0].reason)
+    assertEquals(bounds(0, 368, 1440, 2752), regions[0].bounds)
+    assertEquals(79, regions[0].areaPercent)
+  }
+
+  @Test
+  fun `detectContentHiddenRegions ignores boundary that itself carries text`() {
+    // When the candidate boundary node is itself labeled, it is its own accessible content, not a
+    // hidden interop body. Option 1 keeps rejecting on the candidate node's own text.
+    val contentRegion =
+        elementWithBounds(
+            bounds = bounds(0, 368, 1440, 2752),
+            text = "Accessible content",
+            actions = listOf("accessibility_focus"),
+        )
+    val composeRoot =
+        elementWithBounds(
+            className = "androidx.compose.ui.platform.ComposeView",
+            bounds = bounds(0, 0, 1440, 3000),
+            children = listOf(contentRegion),
+        )
+
+    val regions = extractor.detectContentHiddenRegionsForTest(composeRoot, 1440, 3000)
+
+    assertTrue(regions.isEmpty())
+  }
+
+  @Test
+  fun `detectContentHiddenRegions ignores boundary that itself carries a content description`() {
+    val contentRegion =
+        elementWithBounds(
+            bounds = bounds(0, 368, 1440, 2752),
+            contentDesc = "Map view",
+            actions = listOf("accessibility_focus"),
+        )
+    val composeRoot =
+        elementWithBounds(
+            className = "androidx.compose.ui.platform.ComposeView",
+            bounds = bounds(0, 0, 1440, 3000),
+            children = listOf(contentRegion),
+        )
+
+    val regions = extractor.detectContentHiddenRegionsForTest(composeRoot, 1440, 3000)
+
+    assertTrue(regions.isEmpty())
+  }
+
+  @Test
+  fun `detectContentHiddenRegions ignores region whose text descendants cover substantial bounds`() {
+    // Descendant text covering > MAX_VISIBLE_CHILD_COVERAGE means the region is mostly visible,
+    // not hidden. The direct-child-coverage gate (not descendant text counting) holds it back, so
+    // Option 1 does not regress this false-positive guard.
+    val denseTextChild =
+        elementWithBounds(
+            bounds = bounds(0, 400, 1440, 1500),
+            text = "Visible list content",
+        )
+    val contentRegion =
+        elementWithBounds(
+            bounds = bounds(0, 368, 1440, 2752),
+            actions = listOf("accessibility_focus"),
+            children = listOf(denseTextChild),
         )
     val composeRoot =
         elementWithBounds(
@@ -1074,6 +1151,7 @@ class ViewHierarchyExtractorTest {
       bounds: ElementBounds? = null,
       className: String? = null,
       text: String? = null,
+      contentDesc: String? = null,
       actions: List<String>? = null,
       children: List<UIElementInfo> = emptyList(),
   ): UIElementInfo {
@@ -1088,6 +1166,7 @@ class ViewHierarchyExtractorTest {
         bounds = bounds,
         className = className,
         text = text,
+        contentDesc = contentDesc,
         actions = actions,
         node = node,
     )

--- a/docs/design-docs/plat/android/compose-interop-hidden-regions.md
+++ b/docs/design-docs/plat/android/compose-interop-hidden-regions.md
@@ -1,0 +1,78 @@
+# Compose interop hidden-region text heuristic — evaluation
+
+Tracks the decision requested in [#2634](https://github.com/kaeawc/auto-mobile/issues/2634),
+following [#2619](https://github.com/kaeawc/auto-mobile/pull/2619) which introduced the
+`contentHiddenRegions` signal.
+
+## Background
+
+`ViewHierarchyExtractor` flags likely Compose `AndroidView` interop regions where the
+accessibility tree hides rendered descendants. A candidate boundary is reported when it is:
+
+- a descendant of a `ComposeView`,
+- large enough (`> MIN_HIDDEN_REGION_SCREEN_AREA`, 25% of the screen),
+- non-interactive, and
+- sparsely covered by its direct children (`<= MAX_VISIBLE_CHILD_COVERAGE`, 25%).
+
+The original gate also rejected the candidate when **any** descendant carried `text` or
+`contentDesc`:
+
+```kotlin
+if (countTextBearingNodes(node) > 0) {
+  return false
+}
+```
+
+This recursive reject is the subject of #2634.
+
+## The problem with the recursive reject
+
+Real Compose interop screens routinely expose a *small* accessibility-visible affordance —
+most commonly a toolbar / app-bar title — while the bulk of the interop content
+(a Fragment + `RecyclerView`, a `WebView`, a media surface) stays inaccessible. The
+recursive reject discards the entire region the moment that single title is present,
+producing a **false negative**: the screen that most needs the hidden-region signal is the
+one the heuristic stays silent on.
+
+## Examples evaluated
+
+The on-device app set available during evaluation does not include a Compose `AndroidView`
+interop screen (no Slack-like Fragment/RecyclerView host), so live capture of
+`contentHiddenRegions` was not possible here. The corpus below is built from the canonical
+case the issue describes, using realistic Slack-like geometry consistent with the existing
+`com.slack:id/top_bar` regression fixture (1440×3000 screen).
+
+| # | Screen | Region bounds | Area % | Visible child | Child coverage | Truth | Recursive reject | Option 1 |
+|---|--------|---------------|--------|---------------|----------------|-------|------------------|----------|
+| 1 | Slack-like channel, empty interop body | `0,368–1440,2752` | 79% | none | 0% | hidden (TP) | reports ✅ | reports ✅ |
+| 2 | Slack-like channel, **toolbar title visible** | `0,368–1440,2752` | 79% | `top_bar` "general" `0,290–1440,458` | ~3.8% | hidden (TP) | **silent (FN)** ❌ | reports ✅ |
+| 3 | Candidate boundary itself labeled | `0,368–1440,2752` | 79% | n/a (own `contentDesc`) | — | not a hidden body (it *is* the content) | silent ✅ | silent ✅ |
+| 4 | Mostly-accessible list, sparse hidden gaps | `0,368–1440,2752` | 79% | dense text rows covering ~60% | ~60% | visible (FP risk) | silent ✅ | silent ✅ (coverage gate) |
+| 5 | Interactive interop surface (clickable) | `0,368–1440,2752` | 79% | n/a (interactive) | — | interactive, not reported | silent ✅ | silent ✅ |
+
+Example 2 is the motivating false negative. Example 4 is the false-positive risk that Option 1
+must not regress — it is held back by the existing `directChildCoverage` gate, not by descendant
+text counting.
+
+## Decision
+
+**Adopt Option 1: reject only when the candidate boundary node itself carries `text` or
+`contentDesc`.** Descendant text is allowed to coexist with a hidden-region report; the
+`MAX_VISIBLE_CHILD_COVERAGE` direct-child-coverage gate remains the guard against regions
+that are actually mostly visible (Example 4).
+
+Rationale:
+
+- Fixes the documented false negative (Example 2) — the single most valuable interop case.
+- Smallest change; keeps the detector fast and the output additive (no node visibility or
+  bounds are mutated).
+- Does not introduce new tunables. Option 2 (coverage-weighting descendant text) adds a
+  second area computation, double-counting decisions for overlapping descendants, and more
+  test surface — premature without a corpus of real failures that the coverage gate cannot
+  already separate. Per the issue recommendation, Option 2 is deferred.
+
+## Follow-up
+
+If live capture later surfaces regions where descendant text is sparse in bounds yet
+semantically substantial (a long single-line caption over an otherwise hidden media surface),
+revisit Option 2 with that concrete corpus. Until then the coverage gate is the safety net.


### PR DESCRIPTION
## Summary

Resolves the evaluation requested in #2634 for the `contentHiddenRegions` Compose-interop heuristic added in #2619.

The previous gate rejected a candidate hidden boundary whenever **any** descendant carried `text` or `contentDesc` (recursive `countTextBearingNodes`). On the most common real interop screen — a small visible affordance (toolbar / channel title) above an otherwise inaccessible `Fragment` / `RecyclerView` body — that produced a **false negative**: the heuristic stayed silent on exactly the screen that needed the signal.

This adopts **Option 1** from the issue: reject only when the candidate boundary node **itself** is labeled. Sparse visible descendants are now allowed to coexist with a hidden-region report; the existing `directChildCoverage <= MAX_VISIBLE_CHILD_COVERAGE` (25%) gate remains the guard against regions that are actually mostly visible. No new tunables are introduced, and Option 2 (coverage-weighting descendant text) is deferred per the issue recommendation.

Output stays **additive** — no node visibility or bounds are mutated.

## Evaluation (acceptance criteria)

- **Examples gathered** — `docs/design-docs/plat/android/compose-interop-hidden-regions.md` captures the canonical Slack-like Fragment/RecyclerView interop cases (bounds, area %, visible-child coverage, TP/FP/FN classification). The on-device app set available had no Compose `AndroidView` interop screen, so the corpus uses realistic Slack-like geometry consistent with the existing `com.slack:id/top_bar` fixture; the doc is explicit about this.
- **Decision made** — Option 1, with rationale and a documented follow-up (revisit Option 2 only if a real corpus surfaces sparse-bounds-but-substantial text that the coverage gate cannot separate).
- **Regression tests added** — see Testing.
- **Additive output** — only the rejection predicate changed.

## Testing

- `JAVA_HOME=<jdk21> ANDROID_HOME=<sdk> android/gradlew -p android :control-proxy:testDebugUnitTest` — all 52 `ViewHierarchyExtractorTest` cases pass.
- TDD: the new false-negative test failed against the recursive reject (`ViewHierarchyExtractorTest.kt:1014`) and passes after the change; the own-label-reject and substantial-coverage-reject tests pass under both implementations, proving the FP guard is intact.

New/changed tests:
- `reports region when a sparse visible text child coexists` — toolbar title coexists with a reported hidden region (the fixed false negative; replaces the old `ignores large Compose descendants with text content`).
- `ignores boundary that itself carries text`
- `ignores boundary that itself carries a content description`
- `ignores region whose text descendants cover substantial bounds` — isolates the `directChildCoverage` gate as the false-positive guard.

## Notes

- Local `ktfmt` is 0.64 while the repo pins 0.55; added lines match the surrounding 0.55-formatted style and were flagged by neither version.
- `countTextBearingNodes` was only used by this gate and is removed.

Closes #2634
