### PR TITLE
fix(install): detect missing Android SDK platform for compileSdk (#2680)

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -115,13 +115,16 @@ read_required_compile_sdk() {
 }
 
 # Verify the Gradle-required SDK platform (the android.jar) is actually
-# installed under ${android_home}/platforms/android-<compileSdk>.
+# installed under ${android_home}/platforms/android-<compileSdk>. Mirrors the
+# build's fallback (android/video-server/build.gradle.kts), which accepts both
+# the `android-<sdk>` and `android-<sdk>.0` directory layouts.
 # Returns 0 when present, non-zero otherwise.
 android_platform_installed() {
     local android_home="$1"
     local compile_sdk="$2"
     [[ -n "${android_home}" && -n "${compile_sdk}" ]] || return 1
-    [[ -f "${android_home}/platforms/android-${compile_sdk}/android.jar" ]]
+    [[ -f "${android_home}/platforms/android-${compile_sdk}/android.jar" \
+        || -f "${android_home}/platforms/android-${compile_sdk}.0/android.jar" ]]
 }
 
 # Locate the sdkmanager binary so we can surface an exact install command.

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -89,6 +89,96 @@ command_exists() {
     command -v "$1" >/dev/null 2>&1
 }
 
+# ============================================================================
+# Android SDK platform helpers (issue #2680)
+#
+# These are intentionally pure (no gum / network / global state) so they can
+# be sourced and unit-tested in isolation (see
+# test/bats/install-android-sdk-platform.bats).
+# ============================================================================
+
+# Read the required Android compileSdk version from libs.versions.toml so the
+# installer never hardcodes the platform number — bumping
+# `build-android-compileSdk` is the single source of truth.
+# Echoes the version (e.g. "37") on success; non-zero exit if missing/unreadable.
+read_required_compile_sdk() {
+    local toml_file="$1"
+    [[ -f "${toml_file}" ]] || return 1
+
+    local version
+    version=$(grep -E '^[[:space:]]*build-android-compileSdk[[:space:]]*=' "${toml_file}" 2>/dev/null \
+        | head -1 \
+        | sed -E 's/.*=[[:space:]]*"([^"]+)".*/\1/')
+
+    [[ -n "${version}" ]] || return 1
+    printf '%s\n' "${version}"
+}
+
+# Verify the Gradle-required SDK platform (the android.jar) is actually
+# installed under ${android_home}/platforms/android-<compileSdk>.
+# Returns 0 when present, non-zero otherwise.
+android_platform_installed() {
+    local android_home="$1"
+    local compile_sdk="$2"
+    [[ -n "${android_home}" && -n "${compile_sdk}" ]] || return 1
+    [[ -f "${android_home}/platforms/android-${compile_sdk}/android.jar" ]]
+}
+
+# Locate the sdkmanager binary so we can surface an exact install command.
+# Prefers the modern cmdline-tools layout, then any versioned cmdline-tools
+# dir, then the legacy tools/bin location. Echoes the path on success.
+find_sdkmanager() {
+    local android_home="$1"
+    [[ -n "${android_home}" ]] || return 1
+
+    local candidate
+    if [[ -x "${android_home}/cmdline-tools/latest/bin/sdkmanager" ]]; then
+        printf '%s\n' "${android_home}/cmdline-tools/latest/bin/sdkmanager"
+        return 0
+    fi
+
+    for candidate in "${android_home}"/cmdline-tools/*/bin/sdkmanager; do
+        if [[ -x "${candidate}" ]]; then
+            printf '%s\n' "${candidate}"
+            return 0
+        fi
+    done
+
+    if [[ -x "${android_home}/tools/bin/sdkmanager" ]]; then
+        printf '%s\n' "${android_home}/tools/bin/sdkmanager"
+        return 0
+    fi
+
+    return 1
+}
+
+# Compose the helpers into the installer's decision. Given an SDK home and the
+# libs.versions.toml, determine whether the Gradle-required platform is present
+# and, when not, print the exact sdkmanager install command on stdout.
+# Exit codes (mirrored into the installer's status + messaging):
+#   0 = platform installed (ok)
+#   1 = unable to determine required compileSdk (no toml / key) — skip silently
+#   2 = platform missing (stdout = actionable `sdkmanager "platforms;..."` cmd)
+android_platform_install_advice() {
+    local android_home="$1"
+    local libs_toml="$2"
+
+    local compile_sdk
+    compile_sdk=$(read_required_compile_sdk "${libs_toml}") || return 1
+
+    if android_platform_installed "${android_home}" "${compile_sdk}"; then
+        return 0
+    fi
+
+    local sdkmanager_path
+    if sdkmanager_path=$(find_sdkmanager "${android_home}"); then
+        printf '"%s" "platforms;android-%s"\n' "${sdkmanager_path}" "${compile_sdk}"
+    else
+        printf 'sdkmanager "platforms;android-%s"\n' "${compile_sdk}"
+    fi
+    return 2
+}
+
 # Compare semver versions: returns 0 if $1 >= $2
 version_gte() {
     local v1="$1"
@@ -3876,6 +3966,32 @@ main() {
                 log_warn "Checking Android emulator: missing — install via Android Studio SDK Manager or: sdkmanager 'emulator'"
             fi
 
+            # Verify the SDK platform Gradle requires (platforms/android-<compileSdk>)
+            # is installed. Without it, `adb` is present but the build fails with
+            # "Unable to find android.jar for compileSdk N" (issue #2680). Derive
+            # the version from libs.versions.toml so bumping compileSdk needs no
+            # installer edit.
+            local libs_toml="${PROJECT_ROOT}/android/gradle/libs.versions.toml"
+            local compile_sdk install_advice platform_status
+            compile_sdk=$(read_required_compile_sdk "${libs_toml}" 2>/dev/null || true)
+            # Capture status via `if` so `set -e` doesn't abort on the non-zero
+            # (missing/unknown) return codes, which are expected signals here.
+            if install_advice=$(android_platform_install_advice "${detected_android_home}" "${libs_toml}"); then
+                platform_status=0
+            else
+                platform_status=$?
+            fi
+            if [[ "${platform_status}" -eq 0 ]]; then
+                log_info "Checking Android SDK platform (android-${compile_sdk}): ok"
+            elif [[ "${platform_status}" -eq 2 ]]; then
+                # Surface an actionable message BEFORE the Gradle build runs, and
+                # drop the green Android status so this isn't silently skipped.
+                ANDROID_SETUP_OK=false
+                log_warn "Checking Android SDK platform (android-${compile_sdk}): missing — required for compileSdk ${compile_sdk}. Install with: ${install_advice}"
+            fi
+            # platform_status == 1: required compileSdk unknown (running outside
+            # the repo / toml absent) — nothing actionable, skip the check.
+
             # List available AVDs with API levels
             if [[ -x "${emulator_path}" ]]; then
                 local avd_list
@@ -4206,4 +4322,10 @@ main() {
     fi
 }
 
-main "$@"
+# Run main unless the script is being sourced for testing (e.g. by BATS).
+# Tests set INSTALL_SH_SOURCE_ONLY=true to load helper functions without
+# executing the installer. The default (unset) path still runs main for both
+# `bash install.sh` and piped `curl | bash` invocations.
+if [[ "${INSTALL_SH_SOURCE_ONLY:-}" != "true" ]]; then
+    main "$@"
+fi

--- a/test/bats/install-android-sdk-platform.bats
+++ b/test/bats/install-android-sdk-platform.bats
@@ -94,6 +94,18 @@ TOML
   [ "$status" -ne 0 ]
 }
 
+@test "android_platform_installed honors the android-<sdk>.0 directory layout" {
+  # Some SDK installs lay the platform out as android-37.0; the Gradle build
+  # accepts that jar (android/video-server/build.gradle.kts), so the installer
+  # must too — otherwise it warns about a platform the build can use.
+  mkdir -p "${ANDROID_HOME_DIR}/platforms/android-37.0"
+  touch "${ANDROID_HOME_DIR}/platforms/android-37.0/android.jar"
+
+  run_helper "android_platform_installed '${ANDROID_HOME_DIR}' 37"
+
+  [ "$status" -eq 0 ]
+}
+
 @test "android_platform_installed fails when the platform is entirely absent" {
   mkdir -p "${ANDROID_HOME_DIR}/platforms/android-35"
   touch "${ANDROID_HOME_DIR}/platforms/android-35/android.jar"
@@ -197,6 +209,18 @@ TOML
   [ "$status" -eq 2 ]
   [[ "$output" == *"platforms;android-37"* ]]
   [[ "$output" == *"${bin}/sdkmanager"* ]]
+}
+
+@test "advice returns ok (0) for the android-<sdk>.0 layout" {
+  write_toml <<'TOML'
+build-android-compileSdk = "37"
+TOML
+  mkdir -p "${ANDROID_HOME_DIR}/platforms/android-37.0"
+  touch "${ANDROID_HOME_DIR}/platforms/android-37.0/android.jar"
+
+  run_helper "android_platform_install_advice '${ANDROID_HOME_DIR}' '${TOML}'"
+
+  [ "$status" -eq 0 ]
 }
 
 @test "advice tracks the compileSdk version from the toml (no hardcoded 37)" {

--- a/test/bats/install-android-sdk-platform.bats
+++ b/test/bats/install-android-sdk-platform.bats
@@ -1,0 +1,225 @@
+#!/usr/bin/env bats
+#
+# Tests for the Android SDK platform helpers in scripts/install.sh
+# (issue #2680 — install.sh should detect a missing platforms/android-<compileSdk>).
+#
+# Helpers are pure (no gum / network) and are loaded by sourcing install.sh
+# with INSTALL_SH_SOURCE_ONLY=true, which suppresses the main() invocation.
+
+SCRIPT="scripts/install.sh"
+
+setup() {
+  TEST_ROOT="$(mktemp -d)"
+  ANDROID_HOME_DIR="${TEST_ROOT}/sdk"
+  TOML="${TEST_ROOT}/libs.versions.toml"
+}
+
+teardown() {
+  rm -rf "$TEST_ROOT"
+}
+
+# Run a helper from install.sh in an isolated subshell so the script's
+# `set -euo pipefail` cannot affect the BATS process.
+run_helper() {
+  run bash -c "INSTALL_SH_SOURCE_ONLY=true source '${BATS_TEST_DIRNAME}/../../${SCRIPT}' && $*"
+}
+
+write_toml() {
+  cat > "$TOML"
+}
+
+# ---------------------------------------------------------------------------
+# read_required_compile_sdk
+# ---------------------------------------------------------------------------
+
+@test "read_required_compile_sdk extracts version from libs.versions.toml" {
+  write_toml <<'TOML'
+[versions]
+build-android-buildTools = "36.0.0"
+build-android-compileSdk = "37"
+TOML
+
+  run_helper "read_required_compile_sdk '${TOML}'"
+
+  [ "$status" -eq 0 ]
+  [ "$output" = "37" ]
+}
+
+@test "read_required_compile_sdk tolerates extra whitespace and trailing comment" {
+  write_toml <<'TOML'
+build-android-compileSdk   =   "41"    # Used in playground Android modules
+TOML
+
+  run_helper "read_required_compile_sdk '${TOML}'"
+
+  [ "$status" -eq 0 ]
+  [ "$output" = "41" ]
+}
+
+@test "read_required_compile_sdk fails when the key is absent" {
+  write_toml <<'TOML'
+[versions]
+build-android-buildTools = "36.0.0"
+TOML
+
+  run_helper "read_required_compile_sdk '${TOML}'"
+
+  [ "$status" -ne 0 ]
+}
+
+@test "read_required_compile_sdk fails when the file does not exist" {
+  run_helper "read_required_compile_sdk '${TEST_ROOT}/nope.toml'"
+
+  [ "$status" -ne 0 ]
+}
+
+# ---------------------------------------------------------------------------
+# android_platform_installed
+# ---------------------------------------------------------------------------
+
+@test "android_platform_installed succeeds when android.jar is present" {
+  mkdir -p "${ANDROID_HOME_DIR}/platforms/android-37"
+  touch "${ANDROID_HOME_DIR}/platforms/android-37/android.jar"
+
+  run_helper "android_platform_installed '${ANDROID_HOME_DIR}' 37"
+
+  [ "$status" -eq 0 ]
+}
+
+@test "android_platform_installed fails when the platform dir exists but android.jar is missing" {
+  mkdir -p "${ANDROID_HOME_DIR}/platforms/android-37"
+
+  run_helper "android_platform_installed '${ANDROID_HOME_DIR}' 37"
+
+  [ "$status" -ne 0 ]
+}
+
+@test "android_platform_installed fails when the platform is entirely absent" {
+  mkdir -p "${ANDROID_HOME_DIR}/platforms/android-35"
+  touch "${ANDROID_HOME_DIR}/platforms/android-35/android.jar"
+
+  run_helper "android_platform_installed '${ANDROID_HOME_DIR}' 37"
+
+  [ "$status" -ne 0 ]
+}
+
+# ---------------------------------------------------------------------------
+# find_sdkmanager
+# ---------------------------------------------------------------------------
+
+@test "find_sdkmanager locates cmdline-tools/latest/bin/sdkmanager" {
+  local bin="${ANDROID_HOME_DIR}/cmdline-tools/latest/bin"
+  mkdir -p "$bin"
+  touch "${bin}/sdkmanager"
+  chmod +x "${bin}/sdkmanager"
+
+  run_helper "find_sdkmanager '${ANDROID_HOME_DIR}'"
+
+  [ "$status" -eq 0 ]
+  [ "$output" = "${bin}/sdkmanager" ]
+}
+
+@test "find_sdkmanager falls back to a versioned cmdline-tools dir" {
+  local bin="${ANDROID_HOME_DIR}/cmdline-tools/13.0/bin"
+  mkdir -p "$bin"
+  touch "${bin}/sdkmanager"
+  chmod +x "${bin}/sdkmanager"
+
+  run_helper "find_sdkmanager '${ANDROID_HOME_DIR}'"
+
+  [ "$status" -eq 0 ]
+  [ "$output" = "${bin}/sdkmanager" ]
+}
+
+@test "find_sdkmanager falls back to legacy tools/bin/sdkmanager" {
+  local bin="${ANDROID_HOME_DIR}/tools/bin"
+  mkdir -p "$bin"
+  touch "${bin}/sdkmanager"
+  chmod +x "${bin}/sdkmanager"
+
+  run_helper "find_sdkmanager '${ANDROID_HOME_DIR}'"
+
+  [ "$status" -eq 0 ]
+  [ "$output" = "${bin}/sdkmanager" ]
+}
+
+@test "find_sdkmanager prefers cmdline-tools/latest over legacy tools/bin" {
+  local latest="${ANDROID_HOME_DIR}/cmdline-tools/latest/bin"
+  local legacy="${ANDROID_HOME_DIR}/tools/bin"
+  mkdir -p "$latest" "$legacy"
+  touch "${latest}/sdkmanager" "${legacy}/sdkmanager"
+  chmod +x "${latest}/sdkmanager" "${legacy}/sdkmanager"
+
+  run_helper "find_sdkmanager '${ANDROID_HOME_DIR}'"
+
+  [ "$status" -eq 0 ]
+  [ "$output" = "${latest}/sdkmanager" ]
+}
+
+@test "find_sdkmanager fails when no sdkmanager exists" {
+  mkdir -p "${ANDROID_HOME_DIR}/platform-tools"
+
+  run_helper "find_sdkmanager '${ANDROID_HOME_DIR}'"
+
+  [ "$status" -ne 0 ]
+}
+
+# ---------------------------------------------------------------------------
+# android_platform_install_advice (the composed installer decision — this is
+# the behavior the issue is about: adb present but platform missing).
+# ---------------------------------------------------------------------------
+
+@test "advice returns ok (0) when the required platform is installed" {
+  write_toml <<'TOML'
+build-android-compileSdk = "37"
+TOML
+  mkdir -p "${ANDROID_HOME_DIR}/platforms/android-37"
+  touch "${ANDROID_HOME_DIR}/platforms/android-37/android.jar"
+
+  run_helper "android_platform_install_advice '${ANDROID_HOME_DIR}' '${TOML}'"
+
+  [ "$status" -eq 0 ]
+}
+
+@test "advice flags missing platform (2) with an actionable sdkmanager command" {
+  write_toml <<'TOML'
+build-android-compileSdk = "37"
+TOML
+  # adb is present but the android-37 platform is not — the issue's scenario.
+  mkdir -p "${ANDROID_HOME_DIR}/platform-tools"
+  local bin="${ANDROID_HOME_DIR}/cmdline-tools/latest/bin"
+  mkdir -p "$bin"
+  touch "${bin}/sdkmanager"
+  chmod +x "${bin}/sdkmanager"
+
+  run_helper "android_platform_install_advice '${ANDROID_HOME_DIR}' '${TOML}'"
+
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"platforms;android-37"* ]]
+  [[ "$output" == *"${bin}/sdkmanager"* ]]
+}
+
+@test "advice tracks the compileSdk version from the toml (no hardcoded 37)" {
+  write_toml <<'TOML'
+build-android-compileSdk = "41"
+TOML
+  mkdir -p "${ANDROID_HOME_DIR}/platform-tools"
+
+  run_helper "android_platform_install_advice '${ANDROID_HOME_DIR}' '${TOML}'"
+
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"platforms;android-41"* ]]
+  # Falls back to a bare `sdkmanager` command when none is installed yet.
+  [[ "$output" == *'sdkmanager "platforms;android-41"'* ]]
+}
+
+@test "advice returns 1 (skip) when compileSdk cannot be determined" {
+  write_toml <<'TOML'
+[versions]
+build-android-buildTools = "36.0.0"
+TOML
+
+  run_helper "android_platform_install_advice '${ANDROID_HOME_DIR}' '${TOML}'"
+
+  [ "$status" -eq 1 ]
+}


### PR DESCRIPTION
## Summary

`scripts/install.sh` previously verified the Android SDK by checking only for `adb` (plus `ANDROID_HOME`/emulator/AVDs). It never checked whether the specific **SDK platform** the Gradle build requires (`platforms/android-<compileSdk>`) was installed — so the installer reported a fully green Android setup, then the very next Gradle build failed with:

```
Unable to find android.jar for compileSdk 37 in .../Android/sdk/platforms
```

Closes #2680.

## What

Adds the missing platform check to the Android SDK section of `install.sh`, built from small pure helpers so the logic is unit-testable:

- `read_required_compile_sdk <toml>` — derives the required version from `android/gradle/libs.versions.toml` (`build-android-compileSdk`). **Single source of truth** — bumping `compileSdk` needs no installer edit.
- `android_platform_installed <android_home> <sdk>` — checks `${android_home}/platforms/android-<sdk>/android.jar` exists.
- `find_sdkmanager <android_home>` — locates `sdkmanager` under `cmdline-tools/latest/bin`, any versioned `cmdline-tools/*/bin`, or legacy `tools/bin`.
- `android_platform_install_advice <android_home> <toml>` — composes the above into the installer's decision (0 = ok, 1 = unknown/skip, 2 = missing + prints the exact `sdkmanager "platforms;android-<sdk>"` command).

When the platform is missing, the installer now emits an actionable `log_warn` **before** any Gradle build runs and drops the green Android status, instead of a silent green check followed by a build failure.

`main "$@"` is now guarded by an `INSTALL_SH_SOURCE_ONLY` sentinel so BATS can source the script to test the helpers in isolation, while preserving both `bash install.sh` and piped `curl | bash` behavior.

## Why

The install + hot-reload flow (`hot-reload.sh` → `install.sh --preset local-dev`) reported a ready Android environment and then silently skipped Android hot-reload when the build failed on the missing platform. Surfacing the missing platform — with the exact remediation command — at install time turns a confusing post-hoc Gradle failure into a one-line fix.

The non-interactive/preset path (the hot-reload scenario) is unaffected beyond the new warning: every consumer of `ANDROID_SETUP_OK` that triggers setup work is gated behind interactive mode, so flipping it to `false` here only removes the false "ready" signal and prints the warning.

## Acceptance criteria

- [x] A machine with `adb` but no `android-37` platform gets a clear, actionable message from `install.sh` **before** the Gradle build runs.
- [x] Required SDK version is derived from `libs.versions.toml` (bumping `compileSdk` doesn't require editing the installer).
- [x] `sdkmanager` is detected under known locations and the exact install command is printed.

## Validation

- `bats test/bats/install-android-sdk-platform.bats` → **16 pass** (new file: helpers + the composed install-advice decision covering the issue's "adb present, platform missing" scenario, version-tracking, and skip-when-unknown).
- `shellcheck scripts/install.sh` → clean.
- End-to-end smoke test against the real `libs.versions.toml`: parses `37`, flags the missing platform with `"…/sdkmanager" "platforms;android-37"`, returns green once `android.jar` is present.
- Pre-existing unrelated `verify-runtime-deps.bats` "passes when all dependencies are present" failure reproduces on clean `main` (environment-dependent) and is untouched by this change.
