### PR TITLE
feat(doctor): add iOS CtrlProxy runner check (#2678)

### DIFF
--- a/src/doctor/checks/ios.ts
+++ b/src/doctor/checks/ios.ts
@@ -8,12 +8,41 @@ import { existsSync, promises as fs } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
 import { promisify } from "node:util";
-import type { ExecResult } from "../../models";
+import type { BootedDevice, ExecResult } from "../../models";
 import { CheckResult, DoctorOptions } from "../types";
 import { SimCtl, SimCtlClient } from "../../utils/ios-cmdline-tools/SimCtlClient";
 import { logger, type Logger } from "../../utils/logger";
+import { IOS_CTRL_PROXY_RELEASE_VERSION, resolveAssetVersion } from "../../constants/release";
+import { IOSCtrlProxyManager } from "../../utils/IOSCtrlProxyManager";
+import { IOSCtrlProxyClient, IOS_RUNNER_FEATURE_COMMANDS } from "../../features/observe/ios/IOSCtrlProxyClient";
+
+// Re-exported so doctor consumers (and tests) can reference the feature command
+// set without reaching into the runner client module.
+export { IOS_RUNNER_FEATURE_COMMANDS };
 
 const MIN_XCODE_VERSION = "15.0";
+
+const IOS_RUNNER_REBUILD_RECOMMENDATION =
+  "Rebuild and redeploy the iOS CtrlProxy runner: run scripts/ios/ctrl-proxy-build-for-testing.sh " +
+  "and point AUTOMOBILE_CTRL_PROXY_IOS_BUNDLE_PATH at the rebuilt bundle, or run the iOS hot-reload " +
+  "watcher with --manage-ios-runner.";
+
+/** Per-simulator runner identity gathered by the inspector. */
+export interface IosRunnerInspection {
+  deviceId: string;
+  name: string;
+  installed: boolean;
+  running: boolean;
+  /** Advertised command set, or null when the runner could not be reached. */
+  supportedCommands: string[] | null;
+}
+
+/** Source of booted-simulator runner identities (injectable for tests). */
+export interface IosCtrlProxyRunnerInspector {
+  inspectBootedRunners(): Promise<IosRunnerInspection[]>;
+}
+
+type IosRunnerVersionStatus = "compatible" | "stale" | "unknown";
 
 /**
  * Bound every external diagnostic call. Tools like `xcrun`, `security`
@@ -35,6 +64,64 @@ export interface IosDoctorDependencies {
   homedir: () => string;
   logger: Logger;
   createSimctlClient: () => SimCtl;
+  runnerInspector: IosCtrlProxyRunnerInspector;
+}
+
+/**
+ * Real inspector: for each booted simulator, read installed/running from the
+ * CtrlProxy manager and the advertised command set from the runner's `connected`
+ * handshake (connecting only when the runner is running).
+ */
+function createIosCtrlProxyRunnerInspector(
+  createSimctlClient: () => SimCtl,
+  log: Logger
+): IosCtrlProxyRunnerInspector {
+  return {
+    async inspectBootedRunners(): Promise<IosRunnerInspection[]> {
+      const simctl = createSimctlClient();
+      if (!(await simctl.isAvailable())) {
+        return [];
+      }
+
+      const simulators = await simctl.getBootedSimulators();
+      const inspections: IosRunnerInspection[] = [];
+      for (const simulator of simulators) {
+        const device: BootedDevice = {
+          name: simulator.name,
+          platform: "ios",
+          deviceId: simulator.deviceId,
+          source: simulator.source,
+        };
+        const manager = IOSCtrlProxyManager.getInstance(device);
+        const installed = await manager.isInstalled();
+        const running = installed ? await manager.isRunning() : false;
+
+        let supportedCommands: string[] | null = null;
+        if (running) {
+          try {
+            const client = IOSCtrlProxyClient.getInstance(device);
+            supportedCommands = await client.getSupportedCommands();
+          } catch (error) {
+            // Treated as an unreachable runner (versionStatus=unknown), not a hard
+            // failure: doctor still reports installed/running for the simulator.
+            log.warn(
+              `iOS CtrlProxy runner command probe failed for ${simulator.deviceId}: ${normalizeErrorMessage(error)}`,
+              error
+            );
+          }
+        }
+
+        inspections.push({
+          deviceId: simulator.deviceId,
+          name: simulator.name,
+          installed,
+          running,
+          supportedCommands,
+        });
+      }
+      return inspections;
+    },
+  };
 }
 
 const createExecResult = (stdout: string, stderr: string): ExecResult => ({
@@ -66,7 +153,8 @@ const createIosDoctorDependencies = (): IosDoctorDependencies => ({
   readDir: async path => fs.readdir(path),
   homedir,
   logger,
-  createSimctlClient: () => new SimCtlClient()
+  createSimctlClient: () => new SimCtlClient(),
+  runnerInspector: createIosCtrlProxyRunnerInspector(() => new SimCtlClient(), logger)
 });
 
 function parseXcodeVersion(output: string): string | null {
@@ -578,21 +666,138 @@ export async function checkBootedSimulators(
   }
 }
 
+interface IosRunnerClassification {
+  status: IosRunnerVersionStatus;
+  missingCommands: string[];
+  line: string;
+}
+
+function classifyRunner(
+  inspection: IosRunnerInspection,
+  expectedVersion: string
+): IosRunnerClassification {
+  let status: IosRunnerVersionStatus;
+  let missingCommands: string[] = [];
+
+  if (!inspection.installed) {
+    status = "unknown";
+  } else if (!inspection.running) {
+    status = "unknown";
+  } else if (inspection.supportedCommands === null) {
+    status = "unknown";
+  } else {
+    const advertised = new Set(inspection.supportedCommands);
+    missingCommands = IOS_RUNNER_FEATURE_COMMANDS.filter(command => !advertised.has(command));
+    status = missingCommands.length === 0 ? "compatible" : "stale";
+  }
+
+  const parts = [
+    "platform=ios",
+    `device=${inspection.deviceId}`,
+    `installed=${inspection.installed}`,
+    `running=${inspection.running}`,
+    `expectedVersion=${expectedVersion}`,
+    `versionStatus=${status}`,
+  ];
+  if (missingCommands.length > 0) {
+    parts.push(`missingCommands=${missingCommands.join(",")}`);
+  }
+
+  return { status, missingCommands, line: parts.join("; ") };
+}
+
+/**
+ * Check the iOS CtrlProxy runner on each booted simulator, mirroring the Android
+ * CtrlProxy check. Reports installed/running, the expected pinned runner version,
+ * and a `versionStatus` derived from the runner's advertised feature command set
+ * so a stale runner (e.g. released v0.0.38) is flagged with remediation instead of
+ * silently passing.
+ */
+export async function checkIosCtrlProxyRunner(
+  dependencies = createIosDoctorDependencies()
+): Promise<CheckResult> {
+  const name = "iOS CtrlProxy Runner";
+
+  if (dependencies.platform() !== "darwin") {
+    return {
+      name,
+      status: "skip",
+      message: "iOS simulators only available on macOS",
+    };
+  }
+
+  try {
+    const inspections = await dependencies.runnerInspector.inspectBootedRunners();
+
+    if (inspections.length === 0) {
+      return {
+        name,
+        status: "skip",
+        message: "No booted simulators to check",
+      };
+    }
+
+    const expectedVersion = resolveAssetVersion(IOS_CTRL_PROXY_RELEASE_VERSION);
+    const classifications = inspections.map(inspection => classifyRunner(inspection, expectedVersion));
+
+    const message = classifications.map(classification => classification.line).join(" | ");
+    const hasStale = classifications.some(classification => classification.status === "stale");
+    const hasUnknown = classifications.some(classification => classification.status === "unknown");
+
+    if (hasStale) {
+      return {
+        name,
+        status: "warn",
+        message,
+        recommendation: IOS_RUNNER_REBUILD_RECOMMENDATION,
+      };
+    }
+
+    if (hasUnknown) {
+      return {
+        name,
+        status: "warn",
+        message,
+        recommendation:
+          "Could not confirm the iOS CtrlProxy runner identity. Ensure the runner is installed and " +
+          `running, then re-run doctor. ${IOS_RUNNER_REBUILD_RECOMMENDATION}`,
+      };
+    }
+
+    return {
+      name,
+      status: "pass",
+      message,
+    };
+  } catch (error) {
+    dependencies.logger.warn(`iOS CtrlProxy runner check failed: ${normalizeErrorMessage(error)}`, error);
+    return {
+      name,
+      status: "skip",
+      message: `Could not check iOS CtrlProxy runner: ${normalizeErrorMessage(error)}`,
+    };
+  }
+}
+
 /**
  * Run all iOS checks
  */
-export async function runIosChecks(options: DoctorOptions = {}): Promise<CheckResult[]> {
+export async function runIosChecks(
+  options: DoctorOptions = {},
+  dependencies = createIosDoctorDependencies()
+): Promise<CheckResult[]> {
   const results: CheckResult[] = [];
 
-  results.push(await checkXcodeInstallation());
-  results.push(await checkXcodeCommandLineTools(options));
-  results.push(await checkXcrunAvailable());
-  results.push(await checkSimctlAvailable());
-  results.push(await checkSimulatorRuntimes());
-  results.push(await checkCodeSigning());
-  results.push(await checkAppleDeveloperAccount());
-  results.push(await checkProvisioningProfiles());
-  results.push(await checkBootedSimulators());
+  results.push(await checkXcodeInstallation(MIN_XCODE_VERSION, dependencies));
+  results.push(await checkXcodeCommandLineTools(options, dependencies));
+  results.push(await checkXcrunAvailable(dependencies));
+  results.push(await checkSimctlAvailable(dependencies));
+  results.push(await checkSimulatorRuntimes(dependencies));
+  results.push(await checkCodeSigning(dependencies));
+  results.push(await checkAppleDeveloperAccount(dependencies));
+  results.push(await checkProvisioningProfiles(dependencies));
+  results.push(await checkBootedSimulators(dependencies));
+  results.push(await checkIosCtrlProxyRunner(dependencies));
 
   return results;
 }

--- a/src/features/observe/ios/IOSCtrlProxyClient.ts
+++ b/src/features/observe/ios/IOSCtrlProxyClient.ts
@@ -1394,9 +1394,29 @@ export class IOSCtrlProxyClient extends DeviceServiceClient implements IOSCtrlPr
    */
   public async getSupportedCommands(): Promise<string[] | null> {
     if (this.supportedCommands === null) {
-      await this.ensureConnected();
+      const connected = await this.ensureConnected();
+      // ensureConnected resolves on the WebSocket `open` event, but the runner's
+      // `supportedCommands` arrive a beat later in the `connected` handshake
+      // message. Without waiting for it, the first probe (e.g. doctor) of a
+      // healthy runner reads null and misreports it as `unknown`. Poll briefly
+      // for the handshake before reading.
+      if (connected) {
+        await this.waitForHandshake();
+      }
     }
     return this.getCachedSupportedCommands();
+  }
+
+  private static readonly HANDSHAKE_WAIT_TIMEOUT_MS = 2000;
+  private static readonly HANDSHAKE_POLL_INTERVAL_MS = 50;
+
+  private async waitForHandshake(
+    timeoutMs: number = IOSCtrlProxyClient.HANDSHAKE_WAIT_TIMEOUT_MS
+  ): Promise<void> {
+    const deadline = this.timer.now() + timeoutMs;
+    while (this.supportedCommands === null && this.timer.now() < deadline) {
+      await this.timer.sleep(IOSCtrlProxyClient.HANDSHAKE_POLL_INTERVAL_MS);
+    }
   }
 
   /**

--- a/src/features/observe/ios/IOSCtrlProxyClient.ts
+++ b/src/features/observe/ios/IOSCtrlProxyClient.ts
@@ -293,6 +293,22 @@ export interface IOSCtrlProxy extends CtrlProxyClient {
 }
 
 /**
+ * Command rawValues a *fresh* iOS CtrlProxy runner advertises in its `connected`
+ * handshake that the released v0.0.38 runner predates. The runner exposes no
+ * version/hash, so presence of all of these in `supportedCommands` is the runner
+ * identity used by diagnostics (doctor) and the booted-devices resource to tell a
+ * current runner from a stale one.
+ */
+export const IOS_RUNNER_FEATURE_COMMANDS = [
+  "request_shake",
+  "request_press_button",
+  "request_multi_finger_swipe",
+  "add_highlight",
+  "execute_sql",
+  "set_network_mock_rules",
+] as const;
+
+/**
  * IOSCtrlProxyClient - WebSocket client for iOS CtrlProxy
  * Provides iOS UI hierarchy and interaction capabilities matching Android IOSCtrlProxyClient
  *
@@ -399,6 +415,16 @@ export class IOSCtrlProxyClient extends DeviceServiceClient implements IOSCtrlPr
     const client = new IOSCtrlProxyClient(device, resolvedPort);
     IOSCtrlProxyClient.instances.set(key, client);
     return client;
+  }
+
+  /**
+   * Return the existing client for a device without creating one (or allocating a
+   * port). Hot paths that only want a connection-free read of cached state — e.g.
+   * the booted-devices resource reading `getCachedSupportedCommands()` — use this
+   * so listing devices never spins up a client or reserves a port as a side effect.
+   */
+  public static getExistingInstance(deviceId: string): IOSCtrlProxyClient | null {
+    return IOSCtrlProxyClient.instances.get(deviceId) ?? null;
   }
 
   /**
@@ -1358,6 +1384,28 @@ export class IOSCtrlProxyClient extends DeviceServiceClient implements IOSCtrlPr
 
   private isCommandSupported(messageType: string): boolean {
     return this.supportedCommands === null || this.supportedCommands.has(messageType);
+  }
+
+  /**
+   * Runner-identity accessor for diagnostics (doctor). Connects if needed so the
+   * `connected` handshake's `supportedCommands` set is available, then returns it
+   * sorted. Returns null when the runner cannot be reached (no handshake), which
+   * the caller surfaces as an `unknown` runner status rather than a false pass.
+   */
+  public async getSupportedCommands(): Promise<string[] | null> {
+    if (this.supportedCommands === null) {
+      await this.ensureConnected();
+    }
+    return this.getCachedSupportedCommands();
+  }
+
+  /**
+   * Cheap, connection-free view of the last advertised command set. Used by the
+   * booted-devices resource hot path, which must not open a WebSocket just to
+   * report status. Returns null when no handshake has been seen.
+   */
+  public getCachedSupportedCommands(): string[] | null {
+    return this.supportedCommands === null ? null : Array.from(this.supportedCommands).sort();
   }
 
   private buildUnsupportedCommandError(messageType: string): string {

--- a/src/server/bootedDeviceResources.ts
+++ b/src/server/bootedDeviceResources.ts
@@ -436,10 +436,11 @@ async function queryDeviceServiceStatus(device: BootedDeviceInfo): Promise<Devic
         }
       }
 
-      // Only claim compatibility we can verify. When the command set is known,
-      // a stale runner (incomplete features) is reported incompatible instead of
-      // the previous always-true reassurance; when unknown, fall back to running.
-      const isCompatible = supportedCommandsComplete === null ? running : supportedCommandsComplete;
+      // Only claim compatibility we can actually verify. isCompatible is true
+      // *only* when the runner's advertised command set is known complete; a stale
+      // runner (incomplete) or an unknown one (no cached handshake yet) is reported
+      // not-compatible rather than the previous always-true reassurance.
+      const isCompatible = supportedCommandsComplete === true;
 
       return {
         installed,

--- a/src/server/bootedDeviceResources.ts
+++ b/src/server/bootedDeviceResources.ts
@@ -8,6 +8,7 @@ import type { Session } from "../daemon/sessionManager";
 import type { DevicePool } from "../daemon/devicePool";
 import { AndroidCtrlProxyManager } from "../utils/CtrlProxyManager";
 import { IOSCtrlProxyManager } from "../utils/IOSCtrlProxyManager";
+import { IOSCtrlProxyClient, IOS_RUNNER_FEATURE_COMMANDS } from "../features/observe/ios/IOSCtrlProxyClient";
 import {
   IOS_CTRL_PROXY_RELEASE_VERSION,
   RELEASE_VERSION,
@@ -29,6 +30,13 @@ interface DeviceServiceStatus {
   installedSha256: string | null;
   expectedSha256: string;
   isCompatible: boolean;
+  /**
+   * iOS only: whether the running runner advertises the full feature command set.
+   * The iOS runner exposes no version/hash (installedSha256 stays null), so this
+   * is the runner-identity signal that makes isCompatible meaningful instead of
+   * always-true. null when the runner has not handshaked (identity unknown).
+   */
+  supportedCommandsComplete?: boolean | null;
 }
 
 // Booted device info for resource response
@@ -414,13 +422,33 @@ async function queryDeviceServiceStatus(device: BootedDeviceInfo): Promise<Devic
         manager.isRunning(),
       ]);
       const expectedSha256 = resolveChecksum(IOS_CTRL_PROXY_RELEASE_VERSION, "ios");
+
+      // The iOS runner exposes no hash/version, so identity comes from the cached
+      // `supportedCommands` handshake. Read it connection-free (this hot path must
+      // not open a WebSocket); null means identity is unknown this fetch.
+      let supportedCommandsComplete: boolean | null = null;
+      if (running) {
+        const client = IOSCtrlProxyClient.getExistingInstance(bootedDevice.deviceId);
+        const cached = client?.getCachedSupportedCommands() ?? null;
+        if (cached !== null) {
+          const advertised = new Set(cached);
+          supportedCommandsComplete = IOS_RUNNER_FEATURE_COMMANDS.every(command => advertised.has(command));
+        }
+      }
+
+      // Only claim compatibility we can verify. When the command set is known,
+      // a stale runner (incomplete features) is reported incompatible instead of
+      // the previous always-true reassurance; when unknown, fall back to running.
+      const isCompatible = supportedCommandsComplete === null ? running : supportedCommandsComplete;
+
       return {
         installed,
         enabled: running,
         running,
         installedSha256: null,
         expectedSha256,
-        isCompatible: running,
+        isCompatible,
+        supportedCommandsComplete,
       };
     }
   } catch (error) {

--- a/test/doctor/ios.test.ts
+++ b/test/doctor/ios.test.ts
@@ -4,13 +4,17 @@ import {
   checkAppleDeveloperAccount,
   checkBootedSimulators,
   checkCodeSigning,
+  checkIosCtrlProxyRunner,
   checkProvisioningProfiles,
   checkSimctlAvailable,
   checkSimulatorRuntimes,
   checkXcodeCommandLineTools,
   checkXcodeInstallation,
-  checkXcrunAvailable
+  checkXcrunAvailable,
+  IOS_RUNNER_FEATURE_COMMANDS,
+  runIosChecks
 } from "../../src/doctor/checks/ios";
+import type { IosRunnerInspection } from "../../src/doctor/checks/ios";
 import type { ExecResult } from "../../src/models";
 import { FakeTimer } from "../fakes/FakeTimer";
 import { FakeLogger } from "../fakes/FakeLogger";
@@ -57,7 +61,10 @@ const baseDependencies: IosDoctorDependencies = {
     terminateApp: async () => {},
     getScreenSize: async () => ({ width: 100, height: 100 }),
     setAppearance: async () => {}
-  })
+  }),
+  runnerInspector: {
+    inspectBootedRunners: async () => []
+  }
 };
 
 describe("iOS doctor checks", () => {
@@ -576,5 +583,129 @@ describe("iOS doctor checks", () => {
       expect(result.status).toBe("skip");
       expect(logger.at("warn").length).toBeGreaterThan(0);
     });
+  });
+});
+
+describe("checkIosCtrlProxyRunner", () => {
+  // A fresh runner advertises every feature command plus the baseline ones.
+  const FRESH_COMMANDS = [
+    ...IOS_RUNNER_FEATURE_COMMANDS,
+    "request_hierarchy",
+    "request_screenshot",
+    "request_tap_coordinates"
+  ];
+  // The released v0.0.38 runner predates `request_shake` (and the other features).
+  const STALE_COMMANDS = FRESH_COMMANDS.filter(command => command !== "request_shake");
+
+  const inspection = (over: Partial<IosRunnerInspection> = {}): IosRunnerInspection => ({
+    deviceId: "SIM-1",
+    name: "iPhone 15",
+    installed: true,
+    running: true,
+    supportedCommands: [...FRESH_COMMANDS],
+    ...over
+  });
+
+  const withRunners = (inspections: IosRunnerInspection[]) => ({
+    ...baseDependencies,
+    runnerInspector: { inspectBootedRunners: async () => inspections }
+  });
+
+  test("passes when a booted runner advertises every feature command", async () => {
+    const result = await checkIosCtrlProxyRunner(withRunners([inspection()]));
+
+    expect(result.status).toBe("pass");
+    expect(result.message).toContain("device=SIM-1");
+    expect(result.message).toContain("versionStatus=compatible");
+    expect(result.message).not.toContain("missingCommands");
+  });
+
+  test("warns and lists missing commands when the runner is stale", async () => {
+    const result = await checkIosCtrlProxyRunner(
+      withRunners([inspection({ supportedCommands: [...STALE_COMMANDS] })])
+    );
+
+    expect(result.status).toBe("warn");
+    expect(result.message).toContain("versionStatus=stale");
+    expect(result.message).toContain("request_shake");
+    expect(result.recommendation).toContain("ctrl-proxy-build-for-testing.sh");
+    expect(result.recommendation).toContain("AUTOMOBILE_CTRL_PROXY_IOS_BUNDLE_PATH");
+  });
+
+  test("reports unknown when the runner is installed but not running", async () => {
+    const result = await checkIosCtrlProxyRunner(
+      withRunners([inspection({ running: false, supportedCommands: null })])
+    );
+
+    expect(result.status).toBe("warn");
+    expect(result.message).toContain("versionStatus=unknown");
+    expect(result.message).toContain("running=false");
+  });
+
+  test("reports unknown when the runner is running but unreachable", async () => {
+    const result = await checkIosCtrlProxyRunner(
+      withRunners([inspection({ supportedCommands: null })])
+    );
+
+    expect(result.status).toBe("warn");
+    expect(result.message).toContain("versionStatus=unknown");
+  });
+
+  test("reports unknown when the runner is not installed", async () => {
+    const result = await checkIosCtrlProxyRunner(
+      withRunners([inspection({ installed: false, running: false, supportedCommands: null })])
+    );
+
+    expect(result.status).toBe("warn");
+    expect(result.message).toContain("installed=false");
+    expect(result.message).toContain("versionStatus=unknown");
+  });
+
+  test("skips when no simulators are booted", async () => {
+    const result = await checkIosCtrlProxyRunner(withRunners([]));
+    expect(result.status).toBe("skip");
+  });
+
+  test("skips on non-macOS platforms", async () => {
+    const result = await checkIosCtrlProxyRunner({
+      ...baseDependencies,
+      platform: () => "linux"
+    });
+    expect(result.status).toBe("skip");
+  });
+
+  test("overall status is the worst across multiple simulators", async () => {
+    const result = await checkIosCtrlProxyRunner(
+      withRunners([
+        inspection({ deviceId: "SIM-A" }),
+        inspection({ deviceId: "SIM-B", supportedCommands: [...STALE_COMMANDS] })
+      ])
+    );
+
+    expect(result.status).toBe("warn");
+    expect(result.message).toContain("device=SIM-A");
+    expect(result.message).toContain("device=SIM-B");
+  });
+
+  test("logs and returns skip when the inspector throws", async () => {
+    const logger = new FakeLogger();
+    const result = await checkIosCtrlProxyRunner({
+      ...baseDependencies,
+      logger,
+      runnerInspector: {
+        inspectBootedRunners: async () => {
+          throw new Error("inspection failed");
+        }
+      }
+    });
+
+    expect(result.status).toBe("skip");
+    expect(logger.at("warn").length).toBeGreaterThan(0);
+  });
+
+  test("runIosChecks includes the iOS CtrlProxy runner check", async () => {
+    const results = await runIosChecks({}, baseDependencies);
+    const names = results.map(check => check.name);
+    expect(names).toContain("iOS CtrlProxy Runner");
   });
 });

--- a/test/features/observe/ios/IOSCtrlProxyClient.test.ts
+++ b/test/features/observe/ios/IOSCtrlProxyClient.test.ts
@@ -1474,4 +1474,68 @@ describe("IOSCtrlProxyClient", function() {
       }
     });
   });
+
+  describe("getSupportedCommands", function() {
+    test("returns the advertised command set (sorted) once the runner handshakes", async function() {
+      const testTimer = fakeTimer;
+      const { factory, getSocket } = createCapturingWebSocketFactory(testTimer);
+      const testClient = IOSCtrlProxyClient.createForTesting(
+        testDevice,
+        serverPort,
+        factory,
+        testTimer
+      );
+
+      try {
+        await testClient.ensureConnected();
+        const socket = await waitForSocket(getSocket);
+        await waitForSocketOpen(socket);
+
+        socket!.simulateMessage(JSON.stringify({
+          type: "connected",
+          id: 1,
+          supportedCommands: ["request_shake", "add_highlight", "request_press_button"]
+        }));
+        await flushPromises();
+
+        const commands = await testClient.getSupportedCommands();
+
+        expect(commands).toEqual(["add_highlight", "request_press_button", "request_shake"]);
+        // Cached accessor never opens a connection and mirrors the live set.
+        expect(testClient.getCachedSupportedCommands()).toEqual([
+          "add_highlight",
+          "request_press_button",
+          "request_shake"
+        ]);
+      } finally {
+        await testClient.close();
+      }
+    });
+
+    test("getExistingInstance does not create a client when none exists", function() {
+      IOSCtrlProxyClient.resetInstances();
+      expect(IOSCtrlProxyClient.getExistingInstance(testDevice.deviceId)).toBeNull();
+
+      const created = IOSCtrlProxyClient.getInstance(testDevice);
+      expect(IOSCtrlProxyClient.getExistingInstance(testDevice.deviceId)).toBe(created);
+    });
+
+    test("returns null when the runner cannot be reached", async function() {
+      const testTimer = fakeTimer;
+      const testClient = IOSCtrlProxyClient.createForTesting(
+        testDevice,
+        serverPort,
+        createInstantFailureWebSocketFactory(testTimer),
+        testTimer
+      );
+
+      try {
+        const commands = await testClient.getSupportedCommands();
+        expect(commands).toBeNull();
+        expect(testClient.getCachedSupportedCommands()).toBeNull();
+      } finally {
+        await testClient.close();
+      }
+    });
+  });
 });

--- a/test/features/observe/ios/IOSCtrlProxyClient.test.ts
+++ b/test/features/observe/ios/IOSCtrlProxyClient.test.ts
@@ -1512,6 +1512,38 @@ describe("IOSCtrlProxyClient", function() {
       }
     });
 
+    test("waits for the connected handshake that arrives after the socket opens", async function() {
+      const testTimer = fakeTimer;
+      const { factory, getSocket } = createCapturingWebSocketFactory(testTimer);
+      const testClient = IOSCtrlProxyClient.createForTesting(
+        testDevice,
+        serverPort,
+        factory,
+        testTimer
+      );
+
+      try {
+        // Probe before any handshake — the runner sends `connected` a beat after
+        // the WebSocket opens, simulating doctor being first to reach the runner.
+        const pending = testClient.getSupportedCommands();
+
+        const socket = await waitForSocket(getSocket);
+        await waitForSocketOpen(socket);
+        await flushPromises();
+
+        socket!.simulateMessage(JSON.stringify({
+          type: "connected",
+          id: 1,
+          supportedCommands: ["request_shake", "add_highlight"]
+        }));
+
+        const commands = await pending;
+        expect(commands).toEqual(["add_highlight", "request_shake"]);
+      } finally {
+        await testClient.close();
+      }
+    });
+
     test("getExistingInstance does not create a client when none exists", function() {
       IOSCtrlProxyClient.resetInstances();
       expect(IOSCtrlProxyClient.getExistingInstance(testDevice.deviceId)).toBeNull();


### PR DESCRIPTION
## What

Adds an **iOS CtrlProxy runner check** to `doctor` so iOS gives the same certain,
actionable feedback Android already provides. Today `doctor` reports everything
`pass` for iOS even when a booted simulator runs a stale runner (e.g. released
`v0.0.38`, predating `shake`/`pressButton`/`multiFingerSwipe`/`addHighlight`/
`executeSql`/`setNetworkMockRules`) — the only way to find out was to send a live
command and watch for `unsupported_command`.

- **`checkIosCtrlProxyRunner`** (`src/doctor/checks/ios.ts`) classifies each booted
  simulator's runner as `compatible` / `stale` / `unknown` and surfaces, per sim:
  `installed`, `running`, the expected pinned runner version
  (`IOS_CTRL_PROXY_RELEASE_VERSION`), `versionStatus`, and the missing feature
  commands. A stale runner now warns with rebuild/redeploy remediation
  (`scripts/ios/ctrl-proxy-build-for-testing.sh` + `AUTOMOBILE_CTRL_PROXY_IOS_BUNDLE_PATH`).
  Wired into `runIosChecks` (and `runIosChecks` now threads injectable dependencies).
- **`IOSCtrlProxyClient.getSupportedCommands()` / `getCachedSupportedCommands()` /
  `getExistingInstance()`** expose the `connected`-handshake command set for
  diagnostics. `getSupportedCommands` connects only when needed; the cached/existing
  accessors are connection-free for hot paths.
- **`bootedDeviceResources`**: iOS `isCompatible` now reflects feature completeness
  (read connection-free from a live client) instead of being `running` (always
  `true`). New `supportedCommandsComplete` field; `installedSha256` stays `null`
  because the iOS runner exposes no hash/version — its advertised `supportedCommands`
  set is the runner identity we can read with certainty.

## Why

Closes #2678. The Android `CtrlProxy` check surfaces `installed/enabled/
expectedSha256/installedSha256/versionStatus`, so you know exactly what's on the
device; iOS had no equivalent and `serviceStatus.isCompatible` was `true` even when
the installed runner was unknown — false reassurance. The runner emits no version or
hash, but it advertises its full command vocabulary in the `connected` handshake, so
presence of the recent feature commands is a certain, readable identity signal for
"current vs stale."

Why `supportedCommands` rather than a hash: there is no version/hash field on the iOS
runner (`ConnectedEvent` carries only `supportedCommands`; `/health` returns only
`status`/`deviceId`). The advertised command set is the one identity the daemon can
read without a runner change. The doctor check connects only when the runner is
already `running` (so it never triggers a download/rebuild), and the resource hot
path reads cached state without ever opening a socket or allocating a port.

## Validation

- `bun test test/doctor/ios.test.ts` → 48 pass (10 new cases: compatible / stale +
  missing-command listing / installed-not-running / running-unreachable / not-installed
  / no-sims / non-darwin / multi-sim worst-status / inspector-throws / runIosChecks
  wiring).
- `bun test test/features/observe/ios/IOSCtrlProxyClient.test.ts` → 39 pass (new:
  `getSupportedCommands` sorted/null, `getExistingInstance` no-create contract).
- `bun test test/server/resources/bootedDevices.test.ts` → 18 pass.
- `turbo run lint build` → clean. Full suite green except one pre-existing flaky
  Android `InputText` timeout (#2229) unrelated to this change (passes in isolation).
