### PR TITLE
fix(ios): report real device screen size from CtrlProxy runner (#2683)

### DIFF
--- a/ios/control-proxy/Sources/CtrlProxy/ElementLocator.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/ElementLocator.swift
@@ -517,11 +517,20 @@ public class ElementLocator: ElementLocating {
             // Get screen scale and dimensions for coordinate conversion
             // iOS reports bounds in points, but screenshots are in pixels
             // screenScale converts: pixels = points * screenScale
-            let (screenScale, screenWidth, screenHeight): (Float, Int, Int) = try runOnMainThread {
+            //
+            // The runner's UIScreen.main.bounds can be a stale 320x480 compatibility
+            // value (issue #2683), so prefer the foreground app's root frame and only
+            // fall back to UIScreen.main.bounds.
+            let (screenScale, fallbackWidth, fallbackHeight): (Float, Int, Int) = try runOnMainThread {
                 let scale = Float(UIScreen.main.scale)
                 let bounds = UIScreen.main.bounds
                 return (scale, Int(bounds.width), Int(bounds.height))
             }
+            let (screenWidth, screenHeight) = ElementLocator.resolveScreenDimensions(
+                rootBounds: finalHierarchy.bounds,
+                fallbackWidth: fallbackWidth,
+                fallbackHeight: fallbackHeight
+            )
 
             return ViewHierarchy(
                 packageName: bundleId,
@@ -1173,6 +1182,24 @@ public class ElementLocator: ElementLocating {
             || element.resourceId != nil
             || element.contentDesc != nil
             || element.hintText != nil
+    }
+
+    /// Resolve the logical screen dimensions reported in the hierarchy.
+    ///
+    /// The XCUITest runner process can report a stale 320x480 `UIScreen.main.bounds`
+    /// when it runs in legacy compatibility mode (issue #2683). The foreground app's
+    /// root snapshot frame reflects the true device size, so prefer it and fall back
+    /// to the runner-reported bounds only when the root frame is unavailable or
+    /// degenerate.
+    static func resolveScreenDimensions(
+        rootBounds: ElementBounds?,
+        fallbackWidth: Int,
+        fallbackHeight: Int
+    ) -> (width: Int, height: Int) {
+        if let bounds = rootBounds, bounds.width > 0, bounds.height > 0 {
+            return (bounds.width, bounds.height)
+        }
+        return (fallbackWidth, fallbackHeight)
     }
 
     /// Collapse same-type text-input children into their parent.

--- a/ios/control-proxy/Tests/CtrlProxyTests/ElementLocatorTests.swift
+++ b/ios/control-proxy/Tests/CtrlProxyTests/ElementLocatorTests.swift
@@ -571,4 +571,51 @@ final class ElementLocatorTests: XCTestCase {
         XCTAssertEqual(locator.foregroundBundleId, "com.example.second")
         XCTAssertEqual(locator.switchedBundleIds, ["com.example.first", "com.example.second"])
     }
+
+    // MARK: - resolveScreenDimensions (issue #2683)
+
+    func testResolveScreenDimensions_prefersRootBoundsOverStaleFallback() {
+        // The runner can report a legacy 320x480 compatibility size; the
+        // foreground app's root frame carries the true device size and wins.
+        let root = ElementBounds(left: 0, top: 0, right: 402, bottom: 874)
+        let resolved = ElementLocator.resolveScreenDimensions(
+            rootBounds: root,
+            fallbackWidth: 320,
+            fallbackHeight: 480
+        )
+        XCTAssertEqual(resolved.width, 402)
+        XCTAssertEqual(resolved.height, 874)
+    }
+
+    func testResolveScreenDimensions_usesRootBoundsWithNonZeroOrigin() {
+        let root = ElementBounds(left: 10, top: 20, right: 410, bottom: 820)
+        let resolved = ElementLocator.resolveScreenDimensions(
+            rootBounds: root,
+            fallbackWidth: 320,
+            fallbackHeight: 480
+        )
+        XCTAssertEqual(resolved.width, 400)
+        XCTAssertEqual(resolved.height, 800)
+    }
+
+    func testResolveScreenDimensions_fallsBackWhenRootBoundsMissing() {
+        let resolved = ElementLocator.resolveScreenDimensions(
+            rootBounds: nil,
+            fallbackWidth: 402,
+            fallbackHeight: 874
+        )
+        XCTAssertEqual(resolved.width, 402)
+        XCTAssertEqual(resolved.height, 874)
+    }
+
+    func testResolveScreenDimensions_fallsBackWhenRootBoundsDegenerate() {
+        let zero = ElementBounds(left: 0, top: 0, right: 0, bottom: 0)
+        let resolved = ElementLocator.resolveScreenDimensions(
+            rootBounds: zero,
+            fallbackWidth: 402,
+            fallbackHeight: 874
+        )
+        XCTAssertEqual(resolved.width, 402)
+        XCTAssertEqual(resolved.height, 874)
+    }
 }

--- a/src/features/observe/ObserveScreen.ts
+++ b/src/features/observe/ObserveScreen.ts
@@ -510,6 +510,13 @@ export class RealObserveScreen implements ObserveScreen {
         // Filter offscreen nodes to keep payload small. Original hierarchy stays
         // attached for raw element search when enabled.
         if (result.viewHierarchy && result.screenSize?.width > 0 && result.screenSize?.height > 0) {
+          // Reconcile the duplicated viewHierarchy.screenWidth/screenHeight fields
+          // with the authoritative screenSize before filtering (which preserves
+          // them). The iOS runner can report a stale 320x480 (legacy compatibility
+          // mode) value; keep the hierarchy fields consistent for consumers that
+          // read them directly (issue #2683).
+          this.hierarchyCollector.reconcileScreenDimensions(result.viewHierarchy, result.screenSize);
+
           const rawHierarchy = result.viewHierarchy;
           result.viewHierarchy = this.viewHierarchy.filterOffscreenNodes(
             rawHierarchy,

--- a/src/features/observe/collectors/HierarchyCollector.ts
+++ b/src/features/observe/collectors/HierarchyCollector.ts
@@ -192,4 +192,32 @@ export class HierarchyCollector {
 
     return null;
   }
+
+  /**
+   * Reconcile the duplicated `screenWidth`/`screenHeight` fields on the view
+   * hierarchy with the authoritative screen size.
+   *
+   * The iOS CtrlProxy runner reports `UIScreen.main.bounds`, which can be the
+   * legacy 320x480 compatibility value when the runner app has no launch screen
+   * (see issue #2683). The top-level `screenSize` is derived from the root
+   * element bounds and is correct, so we copy it back onto the hierarchy to keep
+   * the two values consistent for any consumer that trusts the hierarchy fields.
+   *
+   * Mutates and returns the same `viewHierarchy` object. When `screenSize` is
+   * missing or non-positive the hierarchy is left untouched.
+   */
+  reconcileScreenDimensions(
+    viewHierarchy: ObserveResult["viewHierarchy"],
+    screenSize: { width: number; height: number } | null
+  ): ObserveResult["viewHierarchy"] {
+    if (!viewHierarchy || typeof viewHierarchy === "string") {
+      return viewHierarchy;
+    }
+    if (!screenSize || screenSize.width <= 0 || screenSize.height <= 0) {
+      return viewHierarchy;
+    }
+    viewHierarchy.screenWidth = screenSize.width;
+    viewHierarchy.screenHeight = screenSize.height;
+    return viewHierarchy;
+  }
 }

--- a/test/features/observe/collectors/HierarchyCollector.test.ts
+++ b/test/features/observe/collectors/HierarchyCollector.test.ts
@@ -176,4 +176,67 @@ describe("HierarchyCollector", () => {
       expect(size).toBeNull();
     });
   });
+
+  describe("reconcileScreenDimensions", () => {
+    test("overwrites stale screenWidth/screenHeight with authoritative screenSize", () => {
+      // Regression for #2683: the iOS runner reports 320x480 (legacy
+      // compatibility mode) while the authoritative size from root bounds is
+      // the real device size. screenWidth/screenHeight must follow screenSize.
+      const viewHierarchy = {
+        hierarchy: { bounds: { left: 0, top: 0, right: 402, bottom: 874 } },
+        screenWidth: 320,
+        screenHeight: 480,
+      } as any;
+
+      const result = collector.reconcileScreenDimensions(viewHierarchy, { width: 402, height: 874 });
+
+      expect(result.screenWidth).toBe(402);
+      expect(result.screenHeight).toBe(874);
+    });
+
+    test("mutates and returns the same view hierarchy object", () => {
+      const viewHierarchy = { hierarchy: {}, screenWidth: 320, screenHeight: 480 } as any;
+
+      const result = collector.reconcileScreenDimensions(viewHierarchy, { width: 402, height: 874 });
+
+      expect(result).toBe(viewHierarchy);
+      expect(viewHierarchy.screenWidth).toBe(402);
+      expect(viewHierarchy.screenHeight).toBe(874);
+    });
+
+    test("populates screenWidth/screenHeight when previously absent", () => {
+      const viewHierarchy = { hierarchy: {} } as any;
+
+      const result = collector.reconcileScreenDimensions(viewHierarchy, { width: 1170, height: 2532 });
+
+      expect(result.screenWidth).toBe(1170);
+      expect(result.screenHeight).toBe(2532);
+    });
+
+    test("leaves screenWidth/screenHeight untouched when screenSize is null", () => {
+      const viewHierarchy = { hierarchy: {}, screenWidth: 320, screenHeight: 480 } as any;
+
+      const result = collector.reconcileScreenDimensions(viewHierarchy, null);
+
+      expect(result.screenWidth).toBe(320);
+      expect(result.screenHeight).toBe(480);
+    });
+
+    test("leaves screenWidth/screenHeight untouched when screenSize has non-positive dimensions", () => {
+      const viewHierarchy = { hierarchy: {}, screenWidth: 320, screenHeight: 480 } as any;
+
+      const zeroWidth = collector.reconcileScreenDimensions(viewHierarchy, { width: 0, height: 874 });
+      expect(zeroWidth.screenWidth).toBe(320);
+      expect(zeroWidth.screenHeight).toBe(480);
+
+      const zeroHeight = collector.reconcileScreenDimensions(viewHierarchy, { width: 402, height: 0 });
+      expect(zeroHeight.screenWidth).toBe(320);
+      expect(zeroHeight.screenHeight).toBe(480);
+    });
+
+    test("returns the input unchanged when view hierarchy is null", () => {
+      expect(collector.reconcileScreenDimensions(null as any, { width: 402, height: 874 })).toBeNull();
+      expect(collector.reconcileScreenDimensions(undefined as any, { width: 402, height: 874 })).toBeUndefined();
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- Fix the iOS CtrlProxy runner reporting a stale **320×480** screen instead of the real device size (e.g. 402×874 on iPhone 16 Pro). The runner reads `UIScreen.main.bounds`, which falls into legacy 320×480 compatibility mode, so `viewHierarchy.screenWidth/screenHeight` disagreed with the authoritative top-level `screenSize`.
- **Source fix** (`ElementLocator.resolveScreenDimensions`): derive screen dimensions from the foreground app's root snapshot frame (the true device size), falling back to `UIScreen.main.bounds` only when the root frame is unavailable or degenerate.
- **TS reconciliation** (`HierarchyCollector.reconcileScreenDimensions`): on the iOS observe path, reconcile the duplicated `viewHierarchy.screenWidth/height` with the authoritative `screenSize` so any consumer reading the hierarchy fields directly agrees with `screenSize`.

Closes #2683

### Note on the proposed launch-screen fix
The issue proposed adding a `UILaunchScreen` to the `CtrlProxyUITests-Runner` Info.plist. Investigated and **ruled out**: the runner app's Info.plist is Apple's `XCTRunner.app` template and does **not** inherit the UI-test target's `INFOPLIST_KEY_*` build settings — verified empirically by adding `INFOPLIST_KEY_UILaunchScreen_Generation: YES` to the `CtrlProxyUITests` target, regenerating, rebuilding (Xcode 26.3), and confirming the rebuilt runner Info.plist still had no `UILaunchScreen`. Deriving the size from the host app's root frame fixes the reported dimensions at the source regardless of runner letterboxing or Xcode version.

## Testing
- `xcodebuild test -only-testing:CtrlProxyTests/ElementLocatorTests` → 47 pass (4 new `resolveScreenDimensions` cases: prefers root bounds over stale fallback, non-zero origin, falls back on nil/degenerate bounds).
- `bun test test/features/observe/ObserveScreen.test.ts test/features/observe/collectors/HierarchyCollector.test.ts` → 50 pass (6 new `reconcileScreenDimensions` cases).
- `bun test` → 5052 pass, 0 fail.
- `bun build.ts` → passes.
- `npx eslint` on changed TS files → clean.
- `ONLY_TOUCHED_FILES=true scripts/swiftlint/validate_swiftlint.sh` → passed (0 serious).

## Self-review
- Folded the reconciliation into the existing `filterOffscreenNodes` guard in `ObserveScreen.ts` (identical condition) — `filterOffscreenNodes` spreads the hierarchy, preserving the reconciled fields.
- Kept the Swift diff minimal (no whole-file reformat churn): the repo's pinned SwiftFormat (`0.54.6`) differs from the local Homebrew version, and running the local one rewrites many pre-existing lines, so added code matches the file's existing style instead.
- **Not verified on a physical device:** the live simulator E2E runner's `/hierarchy` requires a foregrounded app and timed out during probing. The logic is covered deterministically by unit tests at both layers. To verify on-device: launch a full-screen app, `observe`, and confirm `viewHierarchy.screenWidth/height == screenSize`.