### PR TITLE
fix(doctor): close throwaway iOS runner probe client after diagnostics

### DIFF
--- a/src/doctor/checks/ios.ts
+++ b/src/doctor/checks/ios.ts
@@ -68,13 +68,47 @@ export interface IosDoctorDependencies {
 }
 
 /**
+ * Minimal runner-manager surface the inspector needs (install/run probes).
+ */
+interface IosRunnerManager {
+  isInstalled(): Promise<boolean>;
+  isRunning(): Promise<boolean>;
+}
+
+/**
+ * Minimal runner-client surface the inspector needs: read the advertised command
+ * set and (for throwaway probe clients) close the connection afterwards.
+ */
+interface IosRunnerProbeClient {
+  getSupportedCommands(): Promise<string[] | null>;
+  close(): Promise<void>;
+}
+
+/**
+ * Injection seam for the inspector's device-side singletons, so the
+ * close-only-when-created lifecycle is unit-testable without a real device.
+ */
+export interface IosRunnerInspectorHooks {
+  getManager(device: BootedDevice): IosRunnerManager;
+  getExistingClient(deviceId: string): IosRunnerProbeClient | null;
+  createClient(device: BootedDevice): IosRunnerProbeClient;
+}
+
+const defaultIosRunnerInspectorHooks: IosRunnerInspectorHooks = {
+  getManager: device => IOSCtrlProxyManager.getInstance(device),
+  getExistingClient: deviceId => IOSCtrlProxyClient.getExistingInstance(deviceId),
+  createClient: device => IOSCtrlProxyClient.getInstance(device),
+};
+
+/**
  * Real inspector: for each booted simulator, read installed/running from the
  * CtrlProxy manager and the advertised command set from the runner's `connected`
  * handshake (connecting only when the runner is running).
  */
-function createIosCtrlProxyRunnerInspector(
+export function createIosCtrlProxyRunnerInspector(
   createSimctlClient: () => SimCtl,
-  log: Logger
+  log: Logger,
+  hooks: IosRunnerInspectorHooks = defaultIosRunnerInspectorHooks
 ): IosCtrlProxyRunnerInspector {
   return {
     async inspectBootedRunners(): Promise<IosRunnerInspection[]> {
@@ -92,15 +126,21 @@ function createIosCtrlProxyRunnerInspector(
           deviceId: simulator.deviceId,
           source: simulator.source,
         };
-        const manager = IOSCtrlProxyManager.getInstance(device);
+        const manager = hooks.getManager(device);
         const installed = await manager.isInstalled();
         const running = installed ? await manager.isRunning() : false;
 
         let supportedCommands: string[] | null = null;
         if (running) {
+          // Don't disturb a client someone else owns (e.g. the daemon's live
+          // session): if one already exists, read through it and leave its
+          // lifecycle alone. Otherwise open a throwaway probe client and close it
+          // afterwards so doctor leaves no persistent runner connection or SDK
+          // polling timer behind (especially for the one-shot CLI invocation).
+          const existing = hooks.getExistingClient(device.deviceId);
+          const probe = existing ?? hooks.createClient(device);
           try {
-            const client = IOSCtrlProxyClient.getInstance(device);
-            supportedCommands = await client.getSupportedCommands();
+            supportedCommands = await probe.getSupportedCommands();
           } catch (error) {
             // Treated as an unreachable runner (versionStatus=unknown), not a hard
             // failure: doctor still reports installed/running for the simulator.
@@ -108,6 +148,10 @@ function createIosCtrlProxyRunnerInspector(
               `iOS CtrlProxy runner command probe failed for ${simulator.deviceId}: ${normalizeErrorMessage(error)}`,
               error
             );
+          } finally {
+            if (existing === null) {
+              await probe.close();
+            }
           }
         }
 

--- a/test/doctor/ios.test.ts
+++ b/test/doctor/ios.test.ts
@@ -11,10 +11,11 @@ import {
   checkXcodeCommandLineTools,
   checkXcodeInstallation,
   checkXcrunAvailable,
+  createIosCtrlProxyRunnerInspector,
   IOS_RUNNER_FEATURE_COMMANDS,
   runIosChecks
 } from "../../src/doctor/checks/ios";
-import type { IosRunnerInspection } from "../../src/doctor/checks/ios";
+import type { IosRunnerInspection, IosRunnerInspectorHooks } from "../../src/doctor/checks/ios";
 import type { ExecResult } from "../../src/models";
 import { FakeTimer } from "../fakes/FakeTimer";
 import { FakeLogger } from "../fakes/FakeLogger";
@@ -707,5 +708,85 @@ describe("checkIosCtrlProxyRunner", () => {
     const results = await runIosChecks({}, baseDependencies);
     const names = results.map(check => check.name);
     expect(names).toContain("iOS CtrlProxy Runner");
+  });
+});
+
+describe("createIosCtrlProxyRunnerInspector lifecycle", () => {
+  const simctlReturning = (devices: { name: string; deviceId: string }[]) => ({
+    ...baseDependencies.createSimctlClient(),
+    isAvailable: async () => true,
+    getBootedSimulators: async () => devices.map(d => ({ name: d.name, platform: "ios" as const, deviceId: d.deviceId }))
+  });
+
+  const runningManager = { isInstalled: async () => true, isRunning: async () => true };
+
+  test("closes a probe client it created (no pre-existing client)", async () => {
+    let closes = 0;
+    const probe = {
+      getSupportedCommands: async () => [...IOS_RUNNER_FEATURE_COMMANDS],
+      close: async () => { closes += 1; }
+    };
+    const hooks: IosRunnerInspectorHooks = {
+      getManager: () => runningManager,
+      getExistingClient: () => null,
+      createClient: () => probe
+    };
+
+    const inspector = createIosCtrlProxyRunnerInspector(
+      () => simctlReturning([{ name: "iPhone 15", deviceId: "SIM-1" }]) as any,
+      new FakeLogger(),
+      hooks
+    );
+    const inspections = await inspector.inspectBootedRunners();
+
+    expect(inspections[0].supportedCommands).toEqual([...IOS_RUNNER_FEATURE_COMMANDS]);
+    expect(closes).toBe(1);
+  });
+
+  test("does not close a pre-existing client it did not create", async () => {
+    let closes = 0;
+    const existing = {
+      getSupportedCommands: async () => [...IOS_RUNNER_FEATURE_COMMANDS],
+      close: async () => { closes += 1; }
+    };
+    let created = false;
+    const hooks: IosRunnerInspectorHooks = {
+      getManager: () => runningManager,
+      getExistingClient: () => existing,
+      createClient: () => { created = true; return existing; }
+    };
+
+    const inspector = createIosCtrlProxyRunnerInspector(
+      () => simctlReturning([{ name: "iPhone 15", deviceId: "SIM-1" }]) as any,
+      new FakeLogger(),
+      hooks
+    );
+    await inspector.inspectBootedRunners();
+
+    expect(closes).toBe(0);
+    expect(created).toBe(false);
+  });
+
+  test("closes the created probe client even when the command read throws", async () => {
+    let closes = 0;
+    const probe = {
+      getSupportedCommands: async () => { throw new Error("unreachable"); },
+      close: async () => { closes += 1; }
+    };
+    const hooks: IosRunnerInspectorHooks = {
+      getManager: () => runningManager,
+      getExistingClient: () => null,
+      createClient: () => probe
+    };
+
+    const inspector = createIosCtrlProxyRunnerInspector(
+      () => simctlReturning([{ name: "iPhone 15", deviceId: "SIM-1" }]) as any,
+      new FakeLogger(),
+      hooks
+    );
+    const inspections = await inspector.inspectBootedRunners();
+
+    expect(inspections[0].supportedCommands).toBeNull();
+    expect(closes).toBe(1);
   });
 });


### PR DESCRIPTION
## What

Follow-up to #2687 (merged). Closes a connection leak in the new iOS CtrlProxy
runner doctor check: the inspector opened the singleton `IOSCtrlProxyClient` to
read the `connected` handshake and never closed it.

The inspector now closes a probe client **it created**, and leaves a pre-existing
client (e.g. the daemon's live session) untouched:

- `IOSCtrlProxyClient.getExistingInstance(deviceId)` is checked first; if present,
  read through it without altering its lifecycle.
- Otherwise a throwaway probe client is opened and `close()`d in a `finally`
  (covers the error path too).
- Added `IosRunnerInspectorHooks` DI so the close-only-when-created lifecycle is
  unit-tested with fakes.

## Why

Addresses a Codex P2 review comment on #2687 that landed just after the PR merged.
`ensureConnected()` starts the WebSocket health check and `onConnectionEstablished()`
starts SDK polling intervals. The CLI `doctor` only `process.exit`s on failure, so a
successful direct run could otherwise stay alive indefinitely; daemon-hosted runs
would accumulate an extra persistent runner connection. Closing only the probe we
created avoids tearing down a connection the daemon owns.

## Validation

- `bun test test/doctor/ios.test.ts` → 51 pass (3 new lifecycle tests:
  created→closed, pre-existing→untouched/not-created, error-path→still closed).
- `turbo run lint build` → clean.
