### PR TITLE
fix(doctor): use a detached iOS probe client so closed probes can't be rediscovered

### DIFF
--- a/src/doctor/checks/ios.ts
+++ b/src/doctor/checks/ios.ts
@@ -97,7 +97,9 @@ export interface IosRunnerInspectorHooks {
 const defaultIosRunnerInspectorHooks: IosRunnerInspectorHooks = {
   getManager: device => IOSCtrlProxyManager.getInstance(device),
   getExistingClient: deviceId => IOSCtrlProxyClient.getExistingInstance(deviceId),
-  createClient: device => IOSCtrlProxyClient.getInstance(device),
+  // Detached (not singleton-registered) so closing it leaves nothing for a later
+  // probe to rediscover and reconnect — see IOSCtrlProxyClient.createDetached.
+  createClient: device => IOSCtrlProxyClient.createDetached(device),
 };
 
 /**

--- a/src/features/observe/ios/IOSCtrlProxyClient.ts
+++ b/src/features/observe/ios/IOSCtrlProxyClient.ts
@@ -428,6 +428,23 @@ export class IOSCtrlProxyClient extends DeviceServiceClient implements IOSCtrlPr
   }
 
   /**
+   * Build a throwaway client that is NOT registered in the singleton map. Used by
+   * short-lived diagnostics (doctor) that must open a connection, read, and close
+   * without leaving anything behind: because it is never cached, a later
+   * `getExistingInstance` can't rediscover a closed probe and mistake it for a
+   * live session (which would reconnect and leak the socket/SDK polling timer).
+   * Identical to `getInstance` otherwise — same port allocation and production
+   * defaults — just unregistered.
+   */
+  public static createDetached(device: BootedDevice): IOSCtrlProxyClient {
+    requireBootedDevice(device, "IOSCtrlProxyClient.createDetached");
+    const port = device.platform === "ios"
+      ? PortManager.allocate(device.deviceId, { reservedPorts: IOS_CTRL_PROXY_RESERVED_PORTS })
+      : IOSCtrlProxyClient.DEFAULT_PORT;
+    return new IOSCtrlProxyClient(device, port);
+  }
+
+  /**
    * Bind this client to a session for multi-agent NavigationGraphManager isolation.
    */
   public bindSession(sessionId: string): void {

--- a/test/features/observe/ios/IOSCtrlProxyClient.test.ts
+++ b/test/features/observe/ios/IOSCtrlProxyClient.test.ts
@@ -1552,6 +1552,22 @@ describe("IOSCtrlProxyClient", function() {
       expect(IOSCtrlProxyClient.getExistingInstance(testDevice.deviceId)).toBe(created);
     });
 
+    test("createDetached returns an unregistered client (not rediscoverable after close)", async function() {
+      IOSCtrlProxyClient.resetInstances();
+
+      const detached = IOSCtrlProxyClient.createDetached(testDevice);
+      try {
+        // The throwaway probe must never enter the singleton map, so a later probe
+        // can't rediscover a closed client and reconnect it (regression guard).
+        expect(IOSCtrlProxyClient.getExistingInstance(testDevice.deviceId)).toBeNull();
+        expect(detached).toBeInstanceOf(IOSCtrlProxyClient);
+      } finally {
+        await detached.close();
+      }
+
+      expect(IOSCtrlProxyClient.getExistingInstance(testDevice.deviceId)).toBeNull();
+    });
+
     test("returns null when the runner cannot be reached", async function() {
       const testTimer = fakeTimer;
       const testClient = IOSCtrlProxyClient.createForTesting(


### PR DESCRIPTION
## What

Follow-up to #2689 (merged). Fixes a singleton-caching leak in the iOS CtrlProxy
runner doctor probe.

`#2689` closed the probe client it created, but the probe was built via
`IOSCtrlProxyClient.getInstance()`, which caches it in the `instances` map.
`close()` tears down the socket and timers but does **not** evict the map entry — so
a second `doctor` run finds the closed probe via `getExistingInstance`, treats it as
a daemon-owned client, reconnects in `getSupportedCommands()`, and skips the
`finally` close. The persistent socket / SDK-polling leak comes back on the next run.

Fix: add `IOSCtrlProxyClient.createDetached(device)` — identical to `getInstance`
(same port allocation and production defaults) but **never registered** in the
singleton map. The doctor inspector creates its throwaway probe via `createDetached`,
so closing it leaves nothing for a later probe to rediscover.

## Why

Addresses a Codex P2 review comment on #2689 that landed just after it merged. A
non-singleton probe is the cleaner of the two options the reviewer suggested
("non-singleton probe or evict/release the singleton") — it avoids mutating shared
singleton-map semantics for the daemon's own clients. `PortManager.allocate` is
idempotent per device, so an unregistered probe reuses the same port with no leak.

## Validation

- `bun test test/doctor/ios.test.ts test/features/observe/ios/IOSCtrlProxyClient.test.ts`
  → 91 pass (new regression test: a detached client never enters the singleton map,
  before or after `close()`).
- `turbo run lint build` → clean.
