### PR TITLE
fix(ios): recover CtrlProxy when startup port is occupied

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -384,6 +384,7 @@ async function main() {
   const { serverConfig } = await import("./utils/ServerConfig");
   const { AndroidCtrlProxyManager } = await import("./utils/CtrlProxyManager");
   const { IOSCtrlProxyBuilder } = await import("./utils/IOSCtrlProxyBuilder");
+  const { IOSCtrlProxyManager } = await import("./utils/IOSCtrlProxyManager");
 
   startupBenchmark.mark("processEntry");
 
@@ -460,6 +461,9 @@ async function main() {
     // Start iOS CtrlProxy iOS build prefetch (macOS only)
     // This runs asynchronously and will be ready when first iOS device connects
     if (process.platform === "darwin") {
+      IOSCtrlProxyManager.reapOrphanedRunnerProcessesOnStartup().catch(error => {
+        logger.debug(`[IOSCtrlProxy] Startup orphan sweep failed: ${error}`);
+      });
       IOSCtrlProxyBuilder.prefetchBuild();
     }
 

--- a/src/utils/IOSCtrlProxyManager.ts
+++ b/src/utils/IOSCtrlProxyManager.ts
@@ -1274,15 +1274,23 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
   }
 
   /**
-   * Check if an externally-managed xcodebuild process (e.g. from hot-reload)
-   * is already running CtrlProxy tests. Uses `pgrep -x xcodebuild` (exact
-   * binary name match to avoid self-matching shell wrappers) then verifies
-   * CtrlProxy appears in the process args.
+   * Check if an externally-managed CtrlProxy process (e.g. from hot-reload)
+   * is already running CtrlProxy tests. xcodebuild runners expose the simulator
+   * id in args; direct simctl-spawned runners are matched by listener port and
+   * launchd_sim ancestry.
    */
   private async findExternalCtrlProxyProcess(): Promise<ExternalCtrlProxyProcess | null> {
     if (this.useHostControl()) {
-      return null; // Host-control environments don't have external xcodebuild
+      return null; // Host-control environments don't have external local runners.
     }
+    const externalXcodebuildProcess = await this.findExternalXcodebuildCtrlProxyProcess();
+    if (externalXcodebuildProcess) {
+      return externalXcodebuildProcess;
+    }
+    return this.findExternalDirectCtrlProxyProcess();
+  }
+
+  private async findExternalXcodebuildCtrlProxyProcess(): Promise<ExternalCtrlProxyProcess | null> {
     try {
       // pgrep -x matches only processes whose binary name is exactly "xcodebuild"
       const { stdout: pgrepOut } = await this.processExecutor.exec(
@@ -1320,6 +1328,29 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
       // pgrep exits 1 when no process matches
       return null;
     }
+  }
+
+  private async findExternalDirectCtrlProxyProcess(): Promise<ExternalCtrlProxyProcess | null> {
+    const candidatePorts = new Set([
+      this.servicePort,
+      IOSCtrlProxyManager.DEFAULT_PORT,
+    ]);
+
+    for (const port of candidatePorts) {
+      const listeningProcesses = await this.findListeningProcessesOnPort(port);
+      for (const process of listeningProcesses) {
+        if (!IOSCtrlProxyManager.isDirectCtrlProxyRunnerCommand(process.command)) {
+          continue;
+        }
+        if (!await this.processAncestryContainsDeviceId(process)) {
+          continue;
+        }
+        logger.info(`[IOSCtrlProxy] Found external direct CtrlProxy runner: ${process.pid}`);
+        return { pid: process.pid, port };
+      }
+    }
+
+    return null;
   }
 
   private parseCtrlProxyPortFromProcessArgs(args: string): number | null {

--- a/src/utils/IOSCtrlProxyManager.ts
+++ b/src/utils/IOSCtrlProxyManager.ts
@@ -1344,9 +1344,12 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
         return;
       }
 
-      const ownedProcesses = listeningProcesses.filter(process =>
-        this.isOwnedCtrlProxyRunnerProcess(process.command)
-      );
+      const ownedProcesses: ListeningProcess[] = [];
+      for (const process of listeningProcesses) {
+        if (await this.isOwnedCtrlProxyRunnerProcess(process)) {
+          ownedProcesses.push(process);
+        }
+      }
       if (ownedProcesses.length > 0) {
         for (const process of ownedProcesses) {
           logger.warn(
@@ -1359,7 +1362,14 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
         if (remainingProcesses.length === 0) {
           return;
         }
-        if (remainingProcesses.some(process => this.isOwnedCtrlProxyRunnerProcess(process.command))) {
+        let ownedProcessStillHoldingPort = false;
+        for (const process of remainingProcesses) {
+          if (await this.isOwnedCtrlProxyRunnerProcess(process)) {
+            ownedProcessStillHoldingPort = true;
+            break;
+          }
+        }
+        if (ownedProcessStillHoldingPort) {
           throw new Error(
             `CtrlProxy recovery failed, port ${this.servicePort} still held by ` +
             this.formatListeningProcesses(remainingProcesses)
@@ -1400,11 +1410,36 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
     }
   }
 
-  private isOwnedCtrlProxyRunnerProcess(command: string): boolean {
-    if (!IOSCtrlProxyManager.isCtrlProxyRunnerCommand(command)) {
+  private async isOwnedCtrlProxyRunnerProcess(process: ListeningProcess): Promise<boolean> {
+    if (!IOSCtrlProxyManager.isCtrlProxyRunnerCommand(process.command)) {
       return false;
     }
-    return command.includes(this.device.deviceId);
+    if (process.command.includes(this.device.deviceId)) {
+      return true;
+    }
+    if (!IOSCtrlProxyManager.isDirectCtrlProxyRunnerCommand(process.command)) {
+      return false;
+    }
+    return this.processAncestryContainsDeviceId(process);
+  }
+
+  private async processAncestryContainsDeviceId(process: ListeningProcess): Promise<boolean> {
+    let parentPid = process.ppid;
+    const visitedPids = new Set<number>();
+
+    while (parentPid !== undefined && parentPid > 1 && !visitedPids.has(parentPid)) {
+      visitedPids.add(parentPid);
+      const processInfo = await IOSCtrlProxyManager.getProcessInfo(this.processExecutor, parentPid);
+      if (!processInfo) {
+        return false;
+      }
+      if (processInfo.command.includes(this.device.deviceId)) {
+        return true;
+      }
+      parentPid = processInfo.ppid;
+    }
+
+    return false;
   }
 
   private formatListeningProcesses(processes: ListeningProcess[]): string {
@@ -1480,6 +1515,10 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
         command.includes("CtrlProxyUITests-Runner") ||
         command.includes(".xctestrun")
       );
+  }
+
+  private static isDirectCtrlProxyRunnerCommand(command: string): boolean {
+    return command.includes("CtrlProxyUITests-Runner");
   }
 
   private static async terminateProcess(

--- a/src/utils/IOSCtrlProxyManager.ts
+++ b/src/utils/IOSCtrlProxyManager.ts
@@ -1377,7 +1377,7 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
 
       const ownedProcesses: ListeningProcess[] = [];
       for (const process of listeningProcesses) {
-        if (await this.isOwnedCtrlProxyRunnerProcess(process)) {
+        if (this.isOwnedCtrlProxyRunnerProcess(process)) {
           ownedProcesses.push(process);
         }
       }
@@ -1395,7 +1395,7 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
         }
         let ownedProcessStillHoldingPort = false;
         for (const process of remainingProcesses) {
-          if (await this.isOwnedCtrlProxyRunnerProcess(process)) {
+          if (this.isOwnedCtrlProxyRunnerProcess(process)) {
             ownedProcessStillHoldingPort = true;
             break;
           }
@@ -1441,17 +1441,11 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
     }
   }
 
-  private async isOwnedCtrlProxyRunnerProcess(process: ListeningProcess): Promise<boolean> {
+  private isOwnedCtrlProxyRunnerProcess(process: ListeningProcess): boolean {
     if (!IOSCtrlProxyManager.isCtrlProxyRunnerCommand(process.command)) {
       return false;
     }
-    if (process.command.includes(this.device.deviceId)) {
-      return true;
-    }
-    if (!IOSCtrlProxyManager.isDirectCtrlProxyRunnerCommand(process.command)) {
-      return false;
-    }
-    return this.processAncestryContainsDeviceId(process);
+    return process.command.includes(this.device.deviceId);
   }
 
   private async processAncestryContainsDeviceId(process: ListeningProcess): Promise<boolean> {

--- a/src/utils/IOSCtrlProxyManager.ts
+++ b/src/utils/IOSCtrlProxyManager.ts
@@ -97,6 +97,13 @@ interface ExternalCtrlProxyProcess {
   port: number;
 }
 
+interface ListeningProcess {
+  pid: number;
+  port: number;
+  command: string;
+  ppid?: number;
+}
+
 export interface HostPortAvailabilityChecker {
   isAvailable(host: string, port: number): Promise<boolean>;
 }
@@ -204,6 +211,8 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
   private static readonly MAX_RESTART_ATTEMPTS = 5;
   private static readonly RESTART_BASE_DELAY_MS = 2000;
   private static readonly RESTART_MAX_DELAY_MS = 30000;
+  private static readonly PORT_RELEASE_GRACE_MS = 250;
+  private static readonly PORT_RELEASE_ATTEMPTS = 4;
 
   // iproxy tunnel state (physical devices)
   private iproxyProcessId: number | null = null;
@@ -325,6 +334,36 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
     const instances = Array.from(IOSCtrlProxyManager.instances.values());
     await Promise.all(instances.map(instance => instance.stop()));
     IOSCtrlProxyManager.instances.clear();
+  }
+
+  /**
+   * Best-effort startup sweep for orphaned CtrlProxy iOS runner processes left
+   * behind by a previously crashed daemon.
+   */
+  public static async reapOrphanedRunnerProcessesOnStartup(
+    processExecutor: ProcessExecutor = new DefaultProcessExecutor(),
+    timer: Timer = defaultTimer
+  ): Promise<void> {
+    let pids: number[] = [];
+    try {
+      pids = await IOSCtrlProxyManager.findStartupCtrlProxyCandidatePids(processExecutor);
+    } catch (error) {
+      logger.debug(`[IOSCtrlProxy] Failed to enumerate CtrlProxy iOS processes during startup sweep: ${error}`);
+      return;
+    }
+
+    for (const pid of pids) {
+      try {
+        const processInfo = await IOSCtrlProxyManager.getProcessInfo(processExecutor, pid);
+        if (!processInfo || processInfo.ppid !== 1 || !IOSCtrlProxyManager.isCtrlProxyRunnerCommand(processInfo.command)) {
+          continue;
+        }
+        logger.info(`[IOSCtrlProxy] Reaping orphaned CtrlProxy iOS process ${pid}`);
+        await IOSCtrlProxyManager.terminateProcess(processExecutor, timer, pid);
+      } catch (error) {
+        logger.debug(`[IOSCtrlProxy] Failed to reap orphaned CtrlProxy iOS process ${pid}: ${error}`);
+      }
+    }
   }
 
   /**
@@ -579,6 +618,7 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
           }
           // Fall through to health polling below instead of spawning
         } else {
+          await this.ensureServicePortReadyForLaunch();
           perf.startOperation("spawnRunner");
           await this.startOnSimulator();
           perf.endOperation("spawnRunner");
@@ -620,6 +660,14 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
       await this.timer.sleep(delayMs);
     }
     perf.endOperation("healthPolling");
+
+    const heldProcesses = await this.findListeningProcessesOnPort(this.servicePort);
+    if (heldProcesses.length > 0) {
+      throw new Error(
+        `CtrlProxy failed to start within timeout (15s); port ${this.servicePort} ` +
+        `still held by ${this.formatListeningProcesses(heldProcesses)}`
+      );
+    }
 
     throw new Error("CtrlProxy failed to start within timeout (15s)");
   }
@@ -1282,6 +1330,203 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
 
     const port = Number.parseInt(match[1], 10);
     return Number.isNaN(port) || port <= 0 || port > 65535 ? null : port;
+  }
+
+  private async ensureServicePortReadyForLaunch(): Promise<void> {
+    if (this.useHostControl()) {
+      return;
+    }
+
+    const unavailablePorts = new Set<number>();
+    for (let attempt = 0; attempt < PortManager.getMaxDevices(); attempt++) {
+      const listeningProcesses = await this.findListeningProcessesOnPort(this.servicePort);
+      if (listeningProcesses.length === 0) {
+        return;
+      }
+
+      const ownedProcesses = listeningProcesses.filter(process =>
+        this.isOwnedCtrlProxyRunnerProcess(process.command)
+      );
+      if (ownedProcesses.length > 0) {
+        for (const process of ownedProcesses) {
+          logger.warn(
+            `[IOSCtrlProxy] Terminating stale CtrlProxy process ${process.pid} on port ${this.servicePort}`
+          );
+          await IOSCtrlProxyManager.terminateProcess(this.processExecutor, this.timer, process.pid);
+        }
+
+        const remainingProcesses = await this.findListeningProcessesOnPort(this.servicePort);
+        if (remainingProcesses.length === 0) {
+          return;
+        }
+        if (remainingProcesses.some(process => this.isOwnedCtrlProxyRunnerProcess(process.command))) {
+          throw new Error(
+            `CtrlProxy recovery failed, port ${this.servicePort} still held by ` +
+            this.formatListeningProcesses(remainingProcesses)
+          );
+        }
+      }
+
+      unavailablePorts.add(this.servicePort);
+      logger.warn(
+        `[IOSCtrlProxy] Port ${this.servicePort} is held by a foreign process; reallocating CtrlProxy port`
+      );
+      PortManager.release(this.device.deviceId);
+      this.servicePort = this.allocateServicePort(unavailablePorts);
+      this.clearCaches();
+    }
+
+    throw new Error(
+      `No iOS CtrlProxy ports are available for device ${this.device.deviceId}.`
+    );
+  }
+
+  private async findListeningProcessesOnPort(port: number): Promise<ListeningProcess[]> {
+    try {
+      const { stdout } = await this.processExecutor.exec(
+        `lsof -nP -iTCP:${port} -sTCP:LISTEN -Fp 2>/dev/null`
+      );
+      const pids = IOSCtrlProxyManager.parseLsofPids(stdout);
+      const processes: ListeningProcess[] = [];
+      for (const pid of pids) {
+        const processInfo = await IOSCtrlProxyManager.getProcessInfo(this.processExecutor, pid);
+        if (processInfo) {
+          processes.push({ pid, port, ...processInfo });
+        }
+      }
+      return processes;
+    } catch {
+      return [];
+    }
+  }
+
+  private isOwnedCtrlProxyRunnerProcess(command: string): boolean {
+    if (!IOSCtrlProxyManager.isCtrlProxyRunnerCommand(command)) {
+      return false;
+    }
+    return command.includes(this.device.deviceId);
+  }
+
+  private formatListeningProcesses(processes: ListeningProcess[]): string {
+    return processes
+      .map(process => `PID ${process.pid} (cmd: ${process.command})`)
+      .join(", ");
+  }
+
+  private static async findStartupCtrlProxyCandidatePids(processExecutor: ProcessExecutor): Promise<number[]> {
+    const pids = new Set<number>();
+    for (const command of [
+      "pgrep -x xcodebuild 2>/dev/null",
+      "pgrep -f 'CtrlProxyUITests-Runner' 2>/dev/null",
+    ]) {
+      try {
+        const { stdout } = await processExecutor.exec(command);
+        for (const line of stdout.trim().split("\n")) {
+          const pid = Number.parseInt(line, 10);
+          if (!Number.isNaN(pid)) {
+            pids.add(pid);
+          }
+        }
+      } catch {
+        // pgrep exits non-zero when no process matches.
+      }
+    }
+    return [...pids];
+  }
+
+  private static parseLsofPids(stdout: string): number[] {
+    const pids = new Set<number>();
+    for (const line of stdout.split("\n")) {
+      const match = line.match(/^p(\d+)$/);
+      if (!match) {
+        continue;
+      }
+      const pid = Number.parseInt(match[1], 10);
+      if (!Number.isNaN(pid)) {
+        pids.add(pid);
+      }
+    }
+    return [...pids];
+  }
+
+  private static async getProcessInfo(
+    processExecutor: ProcessExecutor,
+    pid: number
+  ): Promise<{ ppid?: number; command: string } | null> {
+    try {
+      const { stdout } = await processExecutor.exec(`ps -p ${pid} -o ppid= -o args= 2>/dev/null`);
+      const output = stdout.trim();
+      if (!output) {
+        return null;
+      }
+      const match = output.match(/^(\d+)\s+([\s\S]+)$/);
+      if (!match) {
+        return { command: output };
+      }
+      return {
+        ppid: Number.parseInt(match[1], 10),
+        command: match[2],
+      };
+    } catch {
+      return null;
+    }
+  }
+
+  private static isCtrlProxyRunnerCommand(command: string): boolean {
+    return command.includes("CtrlProxy") &&
+      (
+        command.includes("xcodebuild") ||
+        command.includes("CtrlProxyUITests") ||
+        command.includes("CtrlProxyUITests-Runner") ||
+        command.includes(".xctestrun")
+      );
+  }
+
+  private static async terminateProcess(
+    processExecutor: ProcessExecutor,
+    timer: Timer,
+    pid: number
+  ): Promise<void> {
+    try {
+      await processExecutor.exec(`kill -TERM ${pid} 2>/dev/null`);
+    } catch {
+      // Process may have already exited.
+    }
+
+    if (!await IOSCtrlProxyManager.waitForProcessExit(processExecutor, timer, pid)) {
+      try {
+        await processExecutor.exec(`kill -KILL ${pid} 2>/dev/null`);
+      } catch {
+        // Process may have exited between liveness check and kill.
+      }
+      await IOSCtrlProxyManager.waitForProcessExit(processExecutor, timer, pid);
+    }
+  }
+
+  private static async waitForProcessExit(
+    processExecutor: ProcessExecutor,
+    timer: Timer,
+    pid: number
+  ): Promise<boolean> {
+    for (let attempt = 0; attempt < IOSCtrlProxyManager.PORT_RELEASE_ATTEMPTS; attempt++) {
+      if (!await IOSCtrlProxyManager.isProcessRunningWithExecutor(processExecutor, pid)) {
+        return true;
+      }
+      await timer.sleep(IOSCtrlProxyManager.PORT_RELEASE_GRACE_MS);
+    }
+    return !await IOSCtrlProxyManager.isProcessRunningWithExecutor(processExecutor, pid);
+  }
+
+  private static async isProcessRunningWithExecutor(
+    processExecutor: ProcessExecutor,
+    pid: number
+  ): Promise<boolean> {
+    try {
+      await processExecutor.exec(`kill -0 ${pid} 2>/dev/null`);
+      return true;
+    } catch {
+      return false;
+    }
   }
 
   /**

--- a/test/fakes/FakeProcessExecutor.ts
+++ b/test/fakes/FakeProcessExecutor.ts
@@ -8,6 +8,7 @@ import { FakeChildProcess } from "./FakeChildProcess";
  */
 export class FakeProcessExecutor implements ProcessExecutor {
   private commandResponses: Map<string, ExecResult> = new Map();
+  private commandHandlers: Array<{ pattern: string; handler: (command: string) => ExecResult | Promise<ExecResult> }> = [];
   private defaultResponse: ExecResult = this.createExecResult("", "");
   private executedCommands: string[] = [];
   private spawnResponses: Array<{ command: string; args: string[]; options?: SpawnOptions; process: ChildProcess }> = [];
@@ -15,6 +16,10 @@ export class FakeProcessExecutor implements ProcessExecutor {
 
   setCommandResponse(commandPattern: string, response: ExecResult): void {
     this.commandResponses.set(commandPattern, this.ensureExecResultMethods(response));
+  }
+
+  setCommandHandler(commandPattern: string, handler: (command: string) => ExecResult | Promise<ExecResult>): void {
+    this.commandHandlers.push({ pattern: commandPattern, handler });
   }
 
   setDefaultResponse(response: ExecResult): void {
@@ -39,6 +44,11 @@ export class FakeProcessExecutor implements ProcessExecutor {
 
   async exec(command: string, _options?: ProcessExecOptions): Promise<ExecResult> {
     this.executedCommands.push(command);
+    for (const { pattern, handler } of this.commandHandlers) {
+      if (command.includes(pattern)) {
+        return this.ensureExecResultMethods(await handler(command));
+      }
+    }
     for (const [pattern, response] of this.commandResponses.entries()) {
       if (command.includes(pattern)) {
         return response;

--- a/test/utils/IOSCtrlProxyManager.test.ts
+++ b/test/utils/IOSCtrlProxyManager.test.ts
@@ -113,6 +113,72 @@ function createHostControlRunner(options: {
   };
 }
 
+interface FakeListeningProcess {
+  pid: number;
+  port: number;
+  command: string;
+  ppid?: number;
+  alive: boolean;
+  ignoreTerm?: boolean;
+  ignoreKill?: boolean;
+}
+
+function installListeningProcessFakes(
+  fakeExecutor: FakeProcessExecutor,
+  processes: FakeListeningProcess[]
+): void {
+  fakeExecutor.setCommandHandler("lsof -nP -iTCP:", command => {
+    const port = Number(command.match(/-iTCP:(\d+)/)?.[1]);
+    const stdout = processes
+      .filter(process => process.alive && process.port === port)
+      .map(process => `p${process.pid}`)
+      .join("\n");
+    return createExecResult(stdout, "");
+  });
+  fakeExecutor.setCommandHandler("ps -p", command => {
+    const pid = Number(command.match(/ps -p\s+(\d+)/)?.[1]);
+    const process = processes.find(candidate => candidate.pid === pid && candidate.alive);
+    return createExecResult(
+      process ? `${process.ppid ?? 1} ${process.command}` : "",
+      ""
+    );
+  });
+  fakeExecutor.setCommandHandler("kill -TERM", command => {
+    const pid = Number(command.match(/kill -TERM\s+(\d+)/)?.[1]);
+    const process = processes.find(candidate => candidate.pid === pid);
+    if (process && !process.ignoreTerm) {
+      process.alive = false;
+    }
+    return createExecResult("", "");
+  });
+  fakeExecutor.setCommandHandler("kill -KILL", command => {
+    const pid = Number(command.match(/kill -KILL\s+(\d+)/)?.[1]);
+    const process = processes.find(candidate => candidate.pid === pid);
+    if (process && !process.ignoreKill) {
+      process.alive = false;
+    }
+    return createExecResult("", "");
+  });
+  fakeExecutor.setCommandHandler("kill -0", command => {
+    const pid = Number(command.match(/kill -0\s+(\d+)/)?.[1]);
+    const process = processes.find(candidate => candidate.pid === pid && candidate.alive);
+    if (!process) {
+      throw new Error(`process ${pid} is not running`);
+    }
+    return createExecResult("", "");
+  });
+}
+
+function createFakeBuilder(xctestrunPath = "/tmp/CtrlProxy.xctestrun") {
+  return {
+    getXctestrunPath: async () => xctestrunPath,
+    getRunnerBinaryPath: async () => null,
+    needsRebuild: async () => false,
+    build: async () => ({ success: true, message: "built" }),
+    getExpectedAppHash: () => null,
+  } as unknown as import("../../src/utils/IOSCtrlProxyBuilder").IOSCtrlProxyBuilder;
+}
+
 describe("IOSCtrlProxyManager", function() {
   let testDevice: BootedDevice;
   let fakeTimer: FakeTimer;
@@ -926,6 +992,45 @@ describe("IOSCtrlProxyManager", function() {
       expect(fakeExecutor.getSpawnedProcesses()).toEqual([]);
     });
 
+    test("start() preserves an externally managed runner on the current port while it is still starting", async function() {
+      const externalProcess: FakeListeningProcess = {
+        pid: 2470,
+        port: 8765,
+        command: `xcodebuild test CtrlProxyUITests -destination id=${testDevice.deviceId} CTRL_PROXY_IOS_PORT=8765`,
+        alive: true,
+        ignoreTerm: true,
+        ignoreKill: true,
+      };
+      installListeningProcessFakes(fakeExecutor, [externalProcess]);
+      const fakeBuilder = {
+        getXctestrunPath: async () => {
+          throw new Error("should not build when an external CtrlProxy process is reused");
+        },
+        getRunnerBinaryPath: async () => null,
+      } as unknown as import("../../src/utils/IOSCtrlProxyBuilder").IOSCtrlProxyBuilder;
+      const manager = IOSCtrlProxyManager.createForTestingWithDeps(
+        testDevice,
+        fakeTimer,
+        fakeBuilder,
+        fakeExecutor
+      );
+
+      fakeExecutor.setCommandResponse("http://localhost:8765/health", createExecResult("", ""));
+      fakeExecutor.setCommandResponse("pgrep -x xcodebuild", createExecResult("2470\n", ""));
+      fakeExecutor.setCommandResponse(
+        "ps -p 2470",
+        createExecResult(externalProcess.command, "")
+      );
+      fakeTimer.enableAutoAdvance();
+
+      await expect(manager.start()).rejects.toThrow("CtrlProxy failed to start within timeout");
+
+      expect(externalProcess.alive).toBe(true);
+      expect(fakeExecutor.wasCommandExecuted("kill -TERM 2470")).toBe(false);
+      expect(fakeExecutor.wasCommandExecuted("kill -KILL 2470")).toBe(false);
+      expect(fakeExecutor.getSpawnedProcesses()).toEqual([]);
+    });
+
     test("start() ignores xcodebuild CtrlProxy processes for other simulators", async function() {
       const fakeBuilder = {
         getXctestrunPath: async () => "/tmp/test.xctestrun",
@@ -1042,6 +1147,167 @@ describe("IOSCtrlProxyManager", function() {
       expect(manager.getServicePort()).toBe(8767);
       expect(PortManager.getPort(testDevice.deviceId)).toBe(8767);
       expect((manager as unknown as { xcTestProcessId: number }).xcTestProcessId).toBe(2233);
+    });
+
+    test("start() terminates a stale owned runner on the intended port before spawning", async function() {
+      const staleProcess: FakeListeningProcess = {
+        pid: 2222,
+        port: 8765,
+        command: `xcodebuild test-without-building -xctestrun /tmp/CtrlProxy.xctestrun -destination platform=iOS Simulator,id=${testDevice.deviceId} -only-testing:CtrlProxyUITests/CtrlProxyUITests/testRunService`,
+        alive: true,
+        ignoreTerm: true,
+      };
+      installListeningProcessFakes(fakeExecutor, [staleProcess]);
+      fakeExecutor.setCommandResponse("pgrep -x xcodebuild", createExecResult("", ""));
+      fakeExecutor.setCommandHandler("curl -s", () =>
+        createExecResult(fakeExecutor.getSpawnedProcesses().length > 0 ? "ok" : "", "")
+      );
+      fakeTimer.enableAutoAdvance();
+      const manager = IOSCtrlProxyManager.createForTestingWithDeps(
+        testDevice,
+        fakeTimer,
+        createFakeBuilder(),
+        fakeExecutor
+      );
+
+      await manager.start();
+
+      expect(staleProcess.alive).toBe(false);
+      expect(fakeExecutor.wasCommandExecuted("kill -TERM 2222")).toBe(true);
+      expect(fakeExecutor.wasCommandExecuted("kill -KILL 2222")).toBe(true);
+      expect(fakeExecutor.getSpawnedProcesses()).toHaveLength(1);
+      expect(fakeExecutor.getSpawnedProcesses()[0].options?.env).toMatchObject({
+        CTRL_PROXY_IOS_PORT: "8765",
+        SIMCTL_CHILD_CTRL_PROXY_IOS_PORT: "8765",
+      });
+    });
+
+    test("start() reallocates when the intended port is held by a foreign process", async function() {
+      const foreignProcess: FakeListeningProcess = {
+        pid: 3333,
+        port: 8765,
+        command: "adb -L tcp:localhost:8765 fork-server server --reply-fd 4",
+        alive: true,
+      };
+      installListeningProcessFakes(fakeExecutor, [foreignProcess]);
+      fakeExecutor.setCommandResponse("pgrep -x xcodebuild", createExecResult("", ""));
+      fakeExecutor.setCommandHandler("curl -s", () =>
+        createExecResult(fakeExecutor.getSpawnedProcesses().length > 0 ? "ok" : "", "")
+      );
+      fakeTimer.enableAutoAdvance();
+      const manager = IOSCtrlProxyManager.createForTestingWithDeps(
+        testDevice,
+        fakeTimer,
+        createFakeBuilder(),
+        fakeExecutor
+      );
+
+      await manager.start();
+
+      expect(foreignProcess.alive).toBe(true);
+      expect(manager.getServicePort()).toBe(8767);
+      expect(PortManager.getPort(testDevice.deviceId)).toBe(8767);
+      expect(fakeExecutor.getSpawnedProcesses()[0].options?.env).toMatchObject({
+        CTRL_PROXY_IOS_PORT: "8767",
+        SIMCTL_CHILD_CTRL_PROXY_IOS_PORT: "8767",
+      });
+    });
+
+    test("start() reallocates instead of killing another simulator's CtrlProxy runner on the intended port", async function() {
+      const otherSimulatorProcess: FakeListeningProcess = {
+        pid: 3334,
+        port: 8765,
+        command: "xcodebuild test CtrlProxyUITests -destination id=OTHER-SIMULATOR CTRL_PROXY_IOS_PORT=8765",
+        alive: true,
+        ignoreTerm: true,
+        ignoreKill: true,
+      };
+      installListeningProcessFakes(fakeExecutor, [otherSimulatorProcess]);
+      fakeExecutor.setCommandResponse("pgrep -x xcodebuild", createExecResult("3334\n", ""));
+      fakeExecutor.setCommandHandler("curl -s", () =>
+        createExecResult(fakeExecutor.getSpawnedProcesses().length > 0 ? "ok" : "", "")
+      );
+      fakeTimer.enableAutoAdvance();
+      const manager = IOSCtrlProxyManager.createForTestingWithDeps(
+        testDevice,
+        fakeTimer,
+        createFakeBuilder(),
+        fakeExecutor
+      );
+
+      await manager.start();
+
+      expect(otherSimulatorProcess.alive).toBe(true);
+      expect(fakeExecutor.wasCommandExecuted("kill -TERM 3334")).toBe(false);
+      expect(manager.getServicePort()).toBe(8767);
+      expect(PortManager.getPort(testDevice.deviceId)).toBe(8767);
+      expect(fakeExecutor.getSpawnedProcesses()[0].options?.env).toMatchObject({
+        CTRL_PROXY_IOS_PORT: "8767",
+        SIMCTL_CHILD_CTRL_PROXY_IOS_PORT: "8767",
+      });
+    });
+
+    test("startup orphan reaping terminates orphaned CtrlProxy xcodebuild processes", async function() {
+      const orphanProcess: FakeListeningProcess = {
+        pid: 4444,
+        port: 8765,
+        ppid: 1,
+        command: `xcodebuild test-without-building -xctestrun /tmp/CtrlProxy.xctestrun -destination platform=iOS Simulator,id=${testDevice.deviceId} -only-testing:CtrlProxyUITests/CtrlProxyUITests/testRunService`,
+        alive: true,
+      };
+      installListeningProcessFakes(fakeExecutor, [orphanProcess]);
+      fakeExecutor.setCommandResponse("pgrep -x xcodebuild", createExecResult("4444\n", ""));
+      fakeTimer.enableAutoAdvance();
+
+      await IOSCtrlProxyManager.reapOrphanedRunnerProcessesOnStartup(fakeExecutor, fakeTimer);
+
+      expect(orphanProcess.alive).toBe(false);
+      expect(fakeExecutor.wasCommandExecuted("kill -TERM 4444")).toBe(true);
+    });
+
+    test("startup orphan reaping terminates orphaned CtrlProxy UITest runner processes", async function() {
+      const orphanProcess: FakeListeningProcess = {
+        pid: 4445,
+        port: 8765,
+        ppid: 1,
+        command: `/tmp/CtrlProxyUITests-Runner.app/PlugIns/CtrlProxyUITests.xctest/CtrlProxyUITests-Runner ${testDevice.deviceId}`,
+        alive: true,
+      };
+      installListeningProcessFakes(fakeExecutor, [orphanProcess]);
+      fakeExecutor.setCommandResponse("pgrep -x xcodebuild", createExecResult("", ""));
+      fakeExecutor.setCommandResponse("pgrep -f 'CtrlProxyUITests-Runner'", createExecResult("4445\n", ""));
+      fakeTimer.enableAutoAdvance();
+
+      await IOSCtrlProxyManager.reapOrphanedRunnerProcessesOnStartup(fakeExecutor, fakeTimer);
+
+      expect(orphanProcess.alive).toBe(false);
+      expect(fakeExecutor.wasCommandExecuted("kill -TERM 4445")).toBe(true);
+    });
+
+    test("start() reports the bound PID and command when owned port cleanup cannot free the port", async function() {
+      const stuckProcess: FakeListeningProcess = {
+        pid: 5555,
+        port: 8765,
+        command: `xcodebuild test-without-building -xctestrun /tmp/CtrlProxy.xctestrun -destination platform=iOS Simulator,id=${testDevice.deviceId} -only-testing:CtrlProxyUITests/CtrlProxyUITests/testRunService`,
+        alive: true,
+        ignoreTerm: true,
+        ignoreKill: true,
+      };
+      installListeningProcessFakes(fakeExecutor, [stuckProcess]);
+      fakeExecutor.setCommandResponse("pgrep -x xcodebuild", createExecResult("", ""));
+      fakeExecutor.setCommandResponse("curl -s", createExecResult("", ""));
+      fakeTimer.enableAutoAdvance();
+      const manager = IOSCtrlProxyManager.createForTestingWithDeps(
+        testDevice,
+        fakeTimer,
+        createFakeBuilder(),
+        fakeExecutor
+      );
+
+      await expect(manager.start()).rejects.toThrow(
+        /port 8765 still held by PID 5555 .*xcodebuild test-without-building/
+      );
+      expect(fakeExecutor.getSpawnedProcesses()).toHaveLength(0);
     });
   });
 });

--- a/test/utils/IOSCtrlProxyManager.test.ts
+++ b/test/utils/IOSCtrlProxyManager.test.ts
@@ -1182,6 +1182,45 @@ describe("IOSCtrlProxyManager", function() {
       });
     });
 
+    test("start() terminates a direct runner whose parent belongs to the current simulator", async function() {
+      const runnerProcess: FakeListeningProcess = {
+        pid: 2223,
+        port: 8765,
+        ppid: 2222,
+        command: "/tmp/CtrlProxyUITests-Runner.app/PlugIns/CtrlProxyUITests.xctest/CtrlProxyUITests-Runner",
+        alive: true,
+      };
+      const parentProcess: FakeListeningProcess = {
+        pid: 2222,
+        port: 0,
+        ppid: 1,
+        command: `launchd_sim ${testDevice.deviceId}`,
+        alive: true,
+      };
+      installListeningProcessFakes(fakeExecutor, [runnerProcess, parentProcess]);
+      fakeExecutor.setCommandResponse("pgrep -x xcodebuild", createExecResult("", ""));
+      fakeExecutor.setCommandHandler("curl -s", () =>
+        createExecResult(fakeExecutor.getSpawnedProcesses().length > 0 ? "ok" : "", "")
+      );
+      fakeTimer.enableAutoAdvance();
+      const manager = IOSCtrlProxyManager.createForTestingWithDeps(
+        testDevice,
+        fakeTimer,
+        createFakeBuilder(),
+        fakeExecutor
+      );
+
+      await manager.start();
+
+      expect(runnerProcess.alive).toBe(false);
+      expect(fakeExecutor.wasCommandExecuted("kill -TERM 2223")).toBe(true);
+      expect(manager.getServicePort()).toBe(8765);
+      expect(fakeExecutor.getSpawnedProcesses()[0].options?.env).toMatchObject({
+        CTRL_PROXY_IOS_PORT: "8765",
+        SIMCTL_CHILD_CTRL_PROXY_IOS_PORT: "8765",
+      });
+    });
+
     test("start() reallocates when the intended port is held by a foreign process", async function() {
       const foreignProcess: FakeListeningProcess = {
         pid: 3333,
@@ -1239,6 +1278,48 @@ describe("IOSCtrlProxyManager", function() {
 
       expect(otherSimulatorProcess.alive).toBe(true);
       expect(fakeExecutor.wasCommandExecuted("kill -TERM 3334")).toBe(false);
+      expect(manager.getServicePort()).toBe(8767);
+      expect(PortManager.getPort(testDevice.deviceId)).toBe(8767);
+      expect(fakeExecutor.getSpawnedProcesses()[0].options?.env).toMatchObject({
+        CTRL_PROXY_IOS_PORT: "8767",
+        SIMCTL_CHILD_CTRL_PROXY_IOS_PORT: "8767",
+      });
+    });
+
+    test("start() reallocates instead of killing another simulator's direct runner on the intended port", async function() {
+      const otherSimulatorProcess: FakeListeningProcess = {
+        pid: 3335,
+        port: 8765,
+        ppid: 3334,
+        command: "/tmp/CtrlProxyUITests-Runner.app/PlugIns/CtrlProxyUITests.xctest/CtrlProxyUITests-Runner",
+        alive: true,
+        ignoreTerm: true,
+        ignoreKill: true,
+      };
+      const otherSimulatorParent: FakeListeningProcess = {
+        pid: 3334,
+        port: 0,
+        ppid: 1,
+        command: "launchd_sim OTHER-SIMULATOR",
+        alive: true,
+      };
+      installListeningProcessFakes(fakeExecutor, [otherSimulatorProcess, otherSimulatorParent]);
+      fakeExecutor.setCommandResponse("pgrep -x xcodebuild", createExecResult("", ""));
+      fakeExecutor.setCommandHandler("curl -s", () =>
+        createExecResult(fakeExecutor.getSpawnedProcesses().length > 0 ? "ok" : "", "")
+      );
+      fakeTimer.enableAutoAdvance();
+      const manager = IOSCtrlProxyManager.createForTestingWithDeps(
+        testDevice,
+        fakeTimer,
+        createFakeBuilder(),
+        fakeExecutor
+      );
+
+      await manager.start();
+
+      expect(otherSimulatorProcess.alive).toBe(true);
+      expect(fakeExecutor.wasCommandExecuted("kill -TERM 3335")).toBe(false);
       expect(manager.getServicePort()).toBe(8767);
       expect(PortManager.getPort(testDevice.deviceId)).toBe(8767);
       expect(fakeExecutor.getSpawnedProcesses()[0].options?.env).toMatchObject({

--- a/test/utils/IOSCtrlProxyManager.test.ts
+++ b/test/utils/IOSCtrlProxyManager.test.ts
@@ -1182,7 +1182,7 @@ describe("IOSCtrlProxyManager", function() {
       });
     });
 
-    test("start() terminates a direct runner whose parent belongs to the current simulator", async function() {
+    test("start() adopts a direct runner for the current simulator while it is still starting", async function() {
       const runnerProcess: FakeListeningProcess = {
         pid: 2223,
         port: 8765,
@@ -1198,27 +1198,38 @@ describe("IOSCtrlProxyManager", function() {
         alive: true,
       };
       installListeningProcessFakes(fakeExecutor, [runnerProcess, parentProcess]);
-      fakeExecutor.setCommandResponse("pgrep -x xcodebuild", createExecResult("", ""));
-      fakeExecutor.setCommandHandler("curl -s", () =>
-        createExecResult(fakeExecutor.getSpawnedProcesses().length > 0 ? "ok" : "", "")
-      );
-      fakeTimer.enableAutoAdvance();
-      const manager = IOSCtrlProxyManager.createForTestingWithDeps(
-        testDevice,
-        fakeTimer,
-        createFakeBuilder(),
-        fakeExecutor
-      );
-
-      await manager.start();
-
-      expect(runnerProcess.alive).toBe(false);
-      expect(fakeExecutor.wasCommandExecuted("kill -TERM 2223")).toBe(true);
-      expect(manager.getServicePort()).toBe(8765);
-      expect(fakeExecutor.getSpawnedProcesses()[0].options?.env).toMatchObject({
-        CTRL_PROXY_IOS_PORT: "8765",
-        SIMCTL_CHILD_CTRL_PROXY_IOS_PORT: "8765",
+      PortManager.setPortAvailabilityCheckerForTesting({
+        isPortAvailable: port => port !== 8765,
       });
+      try {
+        fakeExecutor.setCommandResponse("http://localhost:8765/health", createExecResult("", ""));
+        fakeExecutor.setCommandResponse("http://localhost:8766/health", createExecResult("", ""));
+        fakeExecutor.setCommandResponse("pgrep -x xcodebuild", createExecResult("", ""));
+        fakeTimer.enableAutoAdvance();
+        const fakeBuilder = {
+          getXctestrunPath: async () => {
+            throw new Error("should not build when an external direct runner is reused");
+          },
+          getRunnerBinaryPath: async () => null,
+        } as unknown as import("../../src/utils/IOSCtrlProxyBuilder").IOSCtrlProxyBuilder;
+        const manager = IOSCtrlProxyManager.createForTestingWithDeps(
+          testDevice,
+          fakeTimer,
+          fakeBuilder,
+          fakeExecutor
+        );
+
+        await expect(manager.start()).rejects.toThrow("CtrlProxy failed to start within timeout");
+
+        expect(runnerProcess.alive).toBe(true);
+        expect(fakeExecutor.wasCommandExecuted("kill -TERM 2223")).toBe(false);
+        expect(fakeExecutor.wasCommandExecuted("kill -KILL 2223")).toBe(false);
+        expect(manager.getServicePort()).toBe(8765);
+        expect(PortManager.getPort(testDevice.deviceId)).toBe(8765);
+        expect(fakeExecutor.getSpawnedProcesses()).toEqual([]);
+      } finally {
+        PortManager.setPortAvailabilityCheckerForTesting(null);
+      }
     });
 
     test("start() reallocates when the intended port is held by a foreign process", async function() {


### PR DESCRIPTION
## Summary
- Clear stale iOS CtrlProxy runner processes that are still bound to the intended simulator service port before launching a new runner.
- Reallocate through `PortManager` when the intended port is held by a foreign process, and thread the confirmed port into the xcodebuild environment.
- Reap orphaned CtrlProxy iOS `xcodebuild` and `CtrlProxyUITests-Runner` processes at daemon startup.
- Surface the PID and command when recovery cannot free a held port.

Closes #2692

## Testing
- `bun test test/utils/IOSCtrlProxyManager.test.ts`
- `bun run lint`
- `bun run build`
- `bun test`

## Review
- Ran `/auto-mobile-code-review` against the current diff after fetching latest `origin/main`.
- Addressed the review finding by extending startup cleanup to direct `CtrlProxyUITests-Runner` processes and adding TDD coverage.
