### PR TITLE
Fix iOS CtrlProxy reconnect cooldown signal

### DIFF
--- a/src/features/observe/DeviceServiceClient.ts
+++ b/src/features/observe/DeviceServiceClient.ts
@@ -22,6 +22,7 @@ import type { Timer } from "../../utils/SystemTimer";
 import { defaultTimer } from "../../utils/SystemTimer";
 import { RequestManager } from "../../utils/RequestManager";
 import { RetryExecutor, defaultRetryExecutor } from "../../utils/retry/RetryExecutor";
+import type { CtrlProxyReconnectStatus } from "../../models/CtrlProxyReconnectStatus";
 
 /**
  * Factory function type for creating WebSocket instances.
@@ -161,6 +162,28 @@ export abstract class DeviceServiceClient {
     perf: PerformanceTracker = new NoOpPerformanceTracker()
   ): Promise<boolean> {
     return this.connectWebSocket(perf);
+  }
+
+  public getReconnectStatus(): CtrlProxyReconnectStatus | null {
+    if (this.isConnected() || this.connectionAttempts < this.config.maxConnectionAttempts) {
+      return null;
+    }
+
+    const retryAfterMs = Math.max(
+      0,
+      this.config.connectionResetMs - (this.timer.now() - this.lastConnectionAttempt)
+    );
+    if (retryAfterMs <= 0) {
+      return null;
+    }
+
+    return {
+      state: "cooldown",
+      retryAfterMs,
+      retryAfterSeconds: Math.ceil(retryAfterMs / 1000),
+      connectionAttempts: this.connectionAttempts,
+      maxConnectionAttempts: this.config.maxConnectionAttempts,
+    };
   }
 
   /**

--- a/src/features/observe/DeviceServiceClient.ts
+++ b/src/features/observe/DeviceServiceClient.ts
@@ -375,6 +375,7 @@ export abstract class DeviceServiceClient {
       }));
     } catch (error) {
       this.isConnecting = false;
+      this.lastConnectionAttempt = this.timer.now();
       logger.warn(`[${this.logTag}] Failed to connect to WebSocket: ${error}`);
       return false;
     }

--- a/src/features/observe/ViewHierarchy.ts
+++ b/src/features/observe/ViewHierarchy.ts
@@ -132,6 +132,16 @@ export class ViewHierarchy implements ViewHierarchyInterface {
       );
 
       if (!result || !result.hierarchy) {
+        if (result?.reconnectStatus) {
+          return {
+            hierarchy: {
+              error: result.reconnectMessage ?? `CtrlProxy reconnecting, retry in ${result.reconnectStatus.retryAfterSeconds}s`
+            },
+            ctrlProxyReconnect: result.reconnectStatus,
+            updatedAt: this.timer.now()
+          } as ViewHierarchyResult;
+        }
+
         return {
           hierarchy: {
             error: "Failed to retrieve iOS view hierarchy from CtrlProxy iOS"

--- a/src/features/observe/ViewHierarchy.ts
+++ b/src/features/observe/ViewHierarchy.ts
@@ -150,7 +150,7 @@ export class ViewHierarchy implements ViewHierarchyInterface {
       }
 
       // Convert XCTestHierarchy to ViewHierarchyResult format
-      return this.convertXCTestHierarchy(result.hierarchy, result.updatedAt);
+      return this.convertXCTestHierarchy(result.hierarchy, result.updatedAt, result.reconnectStatus);
     });
 
     perf.end();
@@ -163,11 +163,15 @@ export class ViewHierarchy implements ViewHierarchyInterface {
   /**
    * Convert XCTestHierarchy to ViewHierarchyResult format
    */
-  private convertXCTestHierarchy(hierarchy: any, updatedAt?: number): ViewHierarchyResult {
-    return {
+  private convertXCTestHierarchy(hierarchy: any, updatedAt?: number, ctrlProxyReconnect?: ViewHierarchyResult["ctrlProxyReconnect"]): ViewHierarchyResult {
+    const result = {
       ...hierarchy,
       updatedAt: updatedAt ?? hierarchy.updatedAt ?? this.timer.now()
     };
+    if (ctrlProxyReconnect) {
+      result.ctrlProxyReconnect = ctrlProxyReconnect;
+    }
+    return result;
   }
 
   /**

--- a/src/features/observe/ios/CtrlProxyHierarchy.ts
+++ b/src/features/observe/ios/CtrlProxyHierarchy.ts
@@ -125,16 +125,9 @@ export class CtrlProxyHierarchy {
         };
       }
 
-      const reconnectStatus = this.context.getReconnectStatus?.();
-      if (reconnectStatus) {
-        return {
-          hierarchy: null,
-          fresh: false,
-          reconnectStatus,
-          reconnectMessage: this.buildReconnectMessage(reconnectStatus.retryAfterSeconds)
-        };
-      }
     }
+
+    const reconnectStatus = this.context.getReconnectStatus?.();
 
     // Return cached (stale) data if available
     if (cachedHierarchy) {
@@ -149,11 +142,14 @@ export class CtrlProxyHierarchy {
         hierarchy: cachedHierarchy.hierarchy,
         fresh: false,
         updatedAt: cachedHierarchy.hierarchy.updatedAt,
-        perfTiming: cachedHierarchy.perfTiming
+        perfTiming: cachedHierarchy.perfTiming,
+        reconnectStatus,
+        reconnectMessage: reconnectStatus
+          ? this.buildReconnectMessage(reconnectStatus.retryAfterSeconds)
+          : undefined
       };
     }
 
-    const reconnectStatus = this.context.getReconnectStatus?.();
     if (reconnectStatus) {
       return {
         hierarchy: null,

--- a/src/features/observe/ios/CtrlProxyHierarchy.ts
+++ b/src/features/observe/ios/CtrlProxyHierarchy.ts
@@ -124,6 +124,16 @@ export class CtrlProxyHierarchy {
           perfTiming: result.perfTiming
         };
       }
+
+      const reconnectStatus = this.context.getReconnectStatus?.();
+      if (reconnectStatus) {
+        return {
+          hierarchy: null,
+          fresh: false,
+          reconnectStatus,
+          reconnectMessage: this.buildReconnectMessage(reconnectStatus.retryAfterSeconds)
+        };
+      }
     }
 
     // Return cached (stale) data if available
@@ -144,6 +154,10 @@ export class CtrlProxyHierarchy {
     }
 
     return { hierarchy: null, fresh: false };
+  }
+
+  private buildReconnectMessage(retryAfterSeconds: number): string {
+    return `CtrlProxy reconnecting, retry in ${retryAfterSeconds}s`;
   }
 
   /**

--- a/src/features/observe/ios/CtrlProxyHierarchy.ts
+++ b/src/features/observe/ios/CtrlProxyHierarchy.ts
@@ -153,6 +153,16 @@ export class CtrlProxyHierarchy {
       };
     }
 
+    const reconnectStatus = this.context.getReconnectStatus?.();
+    if (reconnectStatus) {
+      return {
+        hierarchy: null,
+        fresh: false,
+        reconnectStatus,
+        reconnectMessage: this.buildReconnectMessage(reconnectStatus.retryAfterSeconds)
+      };
+    }
+
     return { hierarchy: null, fresh: false };
   }
 

--- a/src/features/observe/ios/IOSCtrlProxyClient.ts
+++ b/src/features/observe/ios/IOSCtrlProxyClient.ts
@@ -368,6 +368,7 @@ export class IOSCtrlProxyClient extends DeviceServiceClient implements IOSCtrlPr
   private consecutiveConnectionFailures: number = 0;
   private isRequestingServiceRestart: boolean = false;
   private static readonly MAX_FAILURES_BEFORE_RESTART = 3;
+  private static readonly CONNECTION_RESET_MS = 2000;
 
   // Auto-setup on connection failure
   private readonly serviceManagerFactory: ServiceManagerFactory;
@@ -384,7 +385,7 @@ export class IOSCtrlProxyClient extends DeviceServiceClient implements IOSCtrlPr
     bootedDeviceLister: BootedDeviceLister = defaultBootedDeviceLister,
     deviceConnectionLostNotifier: DeviceConnectionLostNotifier = observationStreamDeviceConnectionLostNotifier
   ) {
-    super(timer, wsFactory);
+    super(timer, wsFactory, { connectionResetMs: IOSCtrlProxyClient.CONNECTION_RESET_MS });
     this.device = device;
     this.port = port;
     this.serviceManagerFactory = serviceManagerFactory;
@@ -519,6 +520,10 @@ export class IOSCtrlProxyClient extends DeviceServiceClient implements IOSCtrlPr
       return true;
     }
 
+    if (this.getReconnectStatus()) {
+      return false;
+    }
+
     // Prevent re-entry during auto-setup
     if (this.isAttemptingAutoSetup) {
       return false;
@@ -606,6 +611,7 @@ export class IOSCtrlProxyClient extends DeviceServiceClient implements IOSCtrlPr
       requestManager: this.requestManager,
       timer: this.timer,
       ensureConnected: perf => this.ensureConnected(perf),
+      getReconnectStatus: () => this.getReconnectStatus(),
       isCommandSupported: messageType => this.isCommandSupported(messageType),
       unsupportedCommandError: messageType => this.buildUnsupportedCommandError(messageType),
       cancelScreenshotBackoff: () => this.cancelScreenshotBackoff(),

--- a/src/features/observe/ios/types.ts
+++ b/src/features/observe/ios/types.ts
@@ -6,6 +6,7 @@
  */
 
 import type { ViewHierarchyWindowInfo } from "../../../models";
+import type { CtrlProxyReconnectStatus } from "../../../models/CtrlProxyReconnectStatus";
 import type { HighlightOperationResult } from "../../../models";
 import type {
   PerfTiming,
@@ -241,6 +242,8 @@ export interface CtrlProxyHierarchyResponse {
   fresh: boolean;
   updatedAt?: number;
   perfTiming?: CtrlProxyPerfTiming;
+  reconnectStatus?: CtrlProxyReconnectStatus;
+  reconnectMessage?: string;
 }
 
 /**

--- a/src/features/observe/shared/types.ts
+++ b/src/features/observe/shared/types.ts
@@ -10,6 +10,7 @@ import type WebSocket from "ws";
 import type { RequestManager } from "../../../utils/RequestManager";
 import type { Timer } from "../../../utils/SystemTimer";
 import type { PerformanceTracker } from "../../../utils/PerformanceTracker";
+import type { CtrlProxyReconnectStatus } from "../../../models/CtrlProxyReconnectStatus";
 
 // =============================================================================
 // Performance Timing
@@ -72,6 +73,8 @@ export interface DelegateContext {
   timer: Timer;
   /** Ensure the WebSocket connection is established */
   ensureConnected(perf?: PerformanceTracker): Promise<boolean>;
+  /** Return reconnect cooldown metadata when connection attempts are temporarily suppressed. */
+  getReconnectStatus?(): CtrlProxyReconnectStatus | null;
   /** Return false when a connected service advertises that it cannot handle this wire command. */
   isCommandSupported?(messageType: string): boolean;
   /** Build a user-facing error for an advertised unsupported wire command. */

--- a/src/models/CtrlProxyReconnectStatus.ts
+++ b/src/models/CtrlProxyReconnectStatus.ts
@@ -1,0 +1,7 @@
+export interface CtrlProxyReconnectStatus {
+  state: "cooldown";
+  retryAfterMs: number;
+  retryAfterSeconds: number;
+  connectionAttempts: number;
+  maxConnectionAttempts: number;
+}

--- a/src/models/ViewHierarchyResult.ts
+++ b/src/models/ViewHierarchyResult.ts
@@ -1,5 +1,6 @@
 import { ElementBounds } from "./ElementBounds";
 import { RecompositionMetrics, RecompositionNodeInfo } from "./Recomposition";
+import type { CtrlProxyReconnectStatus } from "./CtrlProxyReconnectStatus";
 
 /**
  * Hierarchy data sources that contributed to the result
@@ -57,6 +58,8 @@ export interface ViewHierarchyResult {
   deviceModel?: string;
   /** Whether running on an emulator (Android only, from accessibility service) */
   isEmulator?: boolean;
+  /** Present when CtrlProxy is reconnecting and the hierarchy is temporarily unavailable. */
+  ctrlProxyReconnect?: CtrlProxyReconnectStatus;
 }
 
 export interface ContentHiddenRegion {

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -89,6 +89,7 @@ export * from "./UninstallAppResult";
 export * from "./ViewHierarchyCache";
 export * from "./ViewHierarchyQueryOptions";
 export * from "./ViewHierarchyResult";
+export * from "./CtrlProxyReconnectStatus";
 export * from "./Plan";
 export * from "./ExportPlanResult";
 export * from "./ExecutePlanResult";

--- a/test/features/observe/DeviceServiceClientCooldown.test.ts
+++ b/test/features/observe/DeviceServiceClientCooldown.test.ts
@@ -69,7 +69,6 @@ describe("DeviceServiceClient connection cooldown", () => {
 
   test("enforces cooldown after max connection attempts", async () => {
     const timer = new FakeTimer();
-    timer.enableAutoAdvance();
     client = new TestDeviceServiceClient(
       timer,
       createInstantFailureWebSocketFactory(timer),
@@ -93,6 +92,41 @@ describe("DeviceServiceClient connection cooldown", () => {
     // Attempt 4 — should be rejected by cooldown (returns false without incrementing)
     const r4 = await client.ensureConnected(new NoOpPerformanceTracker());
     expect(r4).toBe(false);
+    expect(client.getConnectionAttempts()).toBe(3);
+    expect(client.getReconnectStatus()).toEqual({
+      state: "cooldown",
+      retryAfterMs: 10000,
+      retryAfterSeconds: 10,
+      connectionAttempts: 3,
+      maxConnectionAttempts: 3,
+    });
+  });
+
+  test("reports remaining cooldown without incrementing attempts", async () => {
+    const timer = new FakeTimer();
+    client = new TestDeviceServiceClient(
+      timer,
+      createInstantFailureWebSocketFactory(timer),
+      { maxConnectionAttempts: 3, connectionResetMs: 10000, reconnectDelayMs: 2000 }
+    );
+    client.disableAutoReconnect();
+
+    await client.ensureConnected(new NoOpPerformanceTracker());
+    await client.ensureConnected(new NoOpPerformanceTracker());
+    await client.ensureConnected(new NoOpPerformanceTracker());
+
+    timer.advanceTime(6500);
+
+    expect(client.getReconnectStatus()).toEqual({
+      state: "cooldown",
+      retryAfterMs: 3500,
+      retryAfterSeconds: 4,
+      connectionAttempts: 3,
+      maxConnectionAttempts: 3,
+    });
+
+    const blocked = await client.ensureConnected(new NoOpPerformanceTracker());
+    expect(blocked).toBe(false);
     expect(client.getConnectionAttempts()).toBe(3);
   });
 
@@ -240,7 +274,7 @@ describe("DeviceServiceClient connection cooldown", () => {
     expect(client.getConnectionAttempts()).toBe(3);
 
     // waitForConnection should also fail because cooldown is active
-    const connected = await client.waitForConnection(3, 100);
+    const connected = await client.waitForConnection(1, 1);
     expect(connected).toBe(false);
   });
 });

--- a/test/features/observe/ViewHierarchy.test.ts
+++ b/test/features/observe/ViewHierarchy.test.ts
@@ -254,6 +254,48 @@ describe("ViewHierarchy", function() {
         getInstanceSpy.mockRestore();
       }
     });
+
+    test("preserves iOS CtrlProxy reconnect metadata on stale cached hierarchy", async function() {
+      const iosDevice: BootedDevice = {
+        deviceId: "test-ios-device",
+        name: "Test iPhone",
+        platform: "ios"
+      };
+      const staleHierarchy = {
+        updatedAt: 1750934585218,
+        packageName: "com.example.cached",
+        hierarchy: { node: { $: { text: "Cached screen" } } },
+      };
+      const reconnectStatus = {
+        state: "cooldown",
+        retryAfterMs: 1800,
+        retryAfterSeconds: 2,
+        connectionAttempts: 3,
+        maxConnectionAttempts: 3,
+      };
+      const fakeIosClient = {
+        getLatestHierarchy: async () => ({
+          hierarchy: staleHierarchy,
+          fresh: false,
+          updatedAt: 1750934585218,
+          reconnectStatus,
+          reconnectMessage: "CtrlProxy reconnecting, retry in 2s",
+        }),
+      };
+      const getInstanceSpy = spyOn(IOSCtrlProxyClient, "getInstance").mockReturnValue(fakeIosClient as any);
+
+      try {
+        const viewHierarchyWithMocks = new ViewHierarchy(iosDevice, fakeAdb, mockCtrlProxyClient);
+
+        const result = await viewHierarchyWithMocks.getiOSViewHierarchy();
+
+        expect(result.hierarchy).toEqual(staleHierarchy.hierarchy);
+        expect(result.updatedAt).toBe(1750934585218);
+        expect(result.ctrlProxyReconnect).toEqual(reconnectStatus);
+      } finally {
+        getInstanceSpy.mockRestore();
+      }
+    });
   });
 
   describe("FilterViewHierarchy Tests", function() {

--- a/test/features/observe/ViewHierarchy.test.ts
+++ b/test/features/observe/ViewHierarchy.test.ts
@@ -1,9 +1,10 @@
-import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, spyOn, test } from "bun:test";
 import { ViewHierarchy } from "../../../src/features/observe/ViewHierarchy";
 import { FakeAdbClientFactory } from "../../fakes/FakeAdbClientFactory";
 import { FakeAdbExecutor } from "../../fakes/FakeAdbExecutor";
 import { BootedDevice } from "../../../src/models/DeviceInfo";
 import { AndroidCtrlProxyClient } from "../../../src/features/observe/android";
+import { IOSCtrlProxyClient } from "../../../src/features/observe/ios";
 
 // Note: the previous version of this file patched fs-extra's readFile to mock
 // screenshot reads. That dependency has been removed from production code, so
@@ -212,6 +213,46 @@ describe("ViewHierarchy", function() {
       expect(result).toBeDefined();
       expect(result.hierarchy).toBeDefined();
       expect(result.hierarchy).toHaveProperty("error");
+    });
+
+    test("surfaces iOS CtrlProxy reconnect cooldown as retry metadata", async function() {
+      const iosDevice: BootedDevice = {
+        deviceId: "test-ios-device",
+        name: "Test iPhone",
+        platform: "ios"
+      };
+      const fakeIosClient = {
+        getLatestHierarchy: async () => ({
+          hierarchy: null,
+          fresh: false,
+          reconnectStatus: {
+            state: "cooldown",
+            retryAfterMs: 1800,
+            retryAfterSeconds: 2,
+            connectionAttempts: 3,
+            maxConnectionAttempts: 3,
+          },
+          reconnectMessage: "CtrlProxy reconnecting, retry in 2s",
+        }),
+      };
+      const getInstanceSpy = spyOn(IOSCtrlProxyClient, "getInstance").mockReturnValue(fakeIosClient as any);
+
+      try {
+        const viewHierarchyWithMocks = new ViewHierarchy(iosDevice, fakeAdb, mockCtrlProxyClient);
+
+        const result = await viewHierarchyWithMocks.getiOSViewHierarchy();
+
+        expect(result.hierarchy.error).toBe("CtrlProxy reconnecting, retry in 2s");
+        expect(result.ctrlProxyReconnect).toEqual({
+          state: "cooldown",
+          retryAfterMs: 1800,
+          retryAfterSeconds: 2,
+          connectionAttempts: 3,
+          maxConnectionAttempts: 3,
+        });
+      } finally {
+        getInstanceSpy.mockRestore();
+      }
     });
   });
 

--- a/test/features/observe/ios/IOSCtrlProxyClient.test.ts
+++ b/test/features/observe/ios/IOSCtrlProxyClient.test.ts
@@ -77,6 +77,9 @@ describe("IOSCtrlProxyClient", function() {
     };
   };
 
+  const createConnectionTimeoutWebSocketFactory = (timer: FakeTimer): (url: string) => FakeWebSocket =>
+    url => new FakeWebSocket(url, "timeout", 60000, timer);
+
   const waitForSocketOpen = async (socket: FakeWebSocket | null): Promise<void> => {
     if (!socket) {
       return;
@@ -360,6 +363,41 @@ describe("IOSCtrlProxyClient", function() {
         await testClient.ensureConnected();
         await testClient.ensureConnected();
         await testClient.ensureConnected();
+
+        expect(testClient.getReconnectStatus()).toEqual({
+          state: "cooldown",
+          retryAfterMs: 2000,
+          retryAfterSeconds: 2,
+          connectionAttempts: 3,
+          maxConnectionAttempts: 3,
+        });
+      } finally {
+        await testClient.close();
+      }
+    });
+
+    test("keeps reconnect cooldown active after iOS WebSocket connection timeouts", async function() {
+      const testTimer = new FakeTimer();
+
+      const testClient = IOSCtrlProxyClient.createForTesting(
+        testDevice,
+        serverPort,
+        createConnectionTimeoutWebSocketFactory(testTimer),
+        testTimer
+      );
+      (testClient as any).autoReconnectEnabled = false;
+
+      const failAfterConnectionTimeout = async (): Promise<void> => {
+        const resultPromise = testClient.ensureConnected();
+        await flushPromises();
+        testTimer.advanceTime(5000);
+        expect(await resultPromise).toBe(false);
+      };
+
+      try {
+        await failAfterConnectionTimeout();
+        await failAfterConnectionTimeout();
+        await failAfterConnectionTimeout();
 
         expect(testClient.getReconnectStatus()).toEqual({
           state: "cooldown",

--- a/test/features/observe/ios/IOSCtrlProxyClient.test.ts
+++ b/test/features/observe/ios/IOSCtrlProxyClient.test.ts
@@ -405,6 +405,44 @@ describe("IOSCtrlProxyClient", function() {
         await testClient.close();
       }
     });
+
+    test("returns reconnecting metadata for default observe skip-wait hierarchy calls during cooldown", async function() {
+      const testTimer = new FakeTimer();
+
+      const testClient = IOSCtrlProxyClient.createForTesting(
+        testDevice,
+        serverPort,
+        createInstantFailureWebSocketFactory(testTimer),
+        testTimer
+      );
+      (testClient as any).autoReconnectEnabled = false;
+
+      try {
+        await testClient.ensureConnected();
+        await testClient.ensureConnected();
+        await testClient.ensureConnected();
+
+        const result = await testClient.getLatestHierarchy(
+          false,
+          100,
+          undefined,
+          true
+        );
+
+        expect(result.hierarchy).toBeNull();
+        expect(result.fresh).toBe(false);
+        expect(result.reconnectStatus).toEqual({
+          state: "cooldown",
+          retryAfterMs: 2000,
+          retryAfterSeconds: 2,
+          connectionAttempts: 3,
+          maxConnectionAttempts: 3,
+        });
+        expect(result.reconnectMessage).toBe("CtrlProxy reconnecting, retry in 2s");
+      } finally {
+        await testClient.close();
+      }
+    });
   });
 
   describe("requestSwipe", function() {

--- a/test/features/observe/ios/IOSCtrlProxyClient.test.ts
+++ b/test/features/observe/ios/IOSCtrlProxyClient.test.ts
@@ -344,6 +344,67 @@ describe("IOSCtrlProxyClient", function() {
         await testClient.close();
       }
     });
+
+    test("uses a short reconnect cooldown for failed iOS CtrlProxy connections", async function() {
+      const testTimer = new FakeTimer();
+
+      const testClient = IOSCtrlProxyClient.createForTesting(
+        testDevice,
+        serverPort,
+        createInstantFailureWebSocketFactory(testTimer),
+        testTimer
+      );
+      (testClient as any).autoReconnectEnabled = false;
+
+      try {
+        await testClient.ensureConnected();
+        await testClient.ensureConnected();
+        await testClient.ensureConnected();
+
+        expect(testClient.getReconnectStatus()).toEqual({
+          state: "cooldown",
+          retryAfterMs: 2000,
+          retryAfterSeconds: 2,
+          connectionAttempts: 3,
+          maxConnectionAttempts: 3,
+        });
+      } finally {
+        await testClient.close();
+      }
+    });
+
+    test("returns reconnecting metadata instead of an ambiguous empty hierarchy during cooldown", async function() {
+      const testTimer = new FakeTimer();
+
+      const testClient = IOSCtrlProxyClient.createForTesting(
+        testDevice,
+        serverPort,
+        createInstantFailureWebSocketFactory(testTimer),
+        testTimer
+      );
+      (testClient as any).autoReconnectEnabled = false;
+
+      try {
+        await testClient.ensureConnected();
+        await testClient.ensureConnected();
+        await testClient.ensureConnected();
+
+        const result = await testClient.getLatestHierarchy(false, 100);
+
+        expect(result.hierarchy).toBeNull();
+        expect(result.fresh).toBe(false);
+        expect(result.reconnectStatus).toEqual({
+          state: "cooldown",
+          retryAfterMs: 2000,
+          retryAfterSeconds: 2,
+          connectionAttempts: 3,
+          maxConnectionAttempts: 3,
+        });
+        expect(result.reconnectMessage).toBe("CtrlProxy reconnecting, retry in 2s");
+      } finally {
+        await testClient.close();
+      }
+    });
   });
 
   describe("requestSwipe", function() {

--- a/test/features/observe/ios/IOSCtrlProxyClient.test.ts
+++ b/test/features/observe/ios/IOSCtrlProxyClient.test.ts
@@ -443,6 +443,49 @@ describe("IOSCtrlProxyClient", function() {
         await testClient.close();
       }
     });
+
+    test("preserves stale hierarchy while reporting reconnecting metadata during cooldown", async function() {
+      const testTimer = new FakeTimer();
+      const cachedHierarchy: CtrlProxyHierarchy = {
+        updatedAt: 1750934585218,
+        packageName: "com.example.cached",
+        hierarchy: { text: "Cached screen" },
+      };
+
+      const testClient = IOSCtrlProxyClient.createForTesting(
+        testDevice,
+        serverPort,
+        createInstantFailureWebSocketFactory(testTimer),
+        testTimer
+      );
+      (testClient as any).autoReconnectEnabled = false;
+      (testClient as any).cachedHierarchy = {
+        hierarchy: cachedHierarchy,
+        receivedAt: 0,
+        fresh: false,
+      };
+      (testClient as any).connectionAttempts = 3;
+      (testClient as any).lastConnectionAttempt = 1000;
+      testTimer.advanceTime(1000);
+
+      try {
+        const result = await testClient.getLatestHierarchy(true, 100);
+
+        expect(result.hierarchy).toBe(cachedHierarchy);
+        expect(result.fresh).toBe(false);
+        expect(result.updatedAt).toBe(1750934585218);
+        expect(result.reconnectStatus).toEqual({
+          state: "cooldown",
+          retryAfterMs: 2000,
+          retryAfterSeconds: 2,
+          connectionAttempts: 3,
+          maxConnectionAttempts: 3,
+        });
+        expect(result.reconnectMessage).toBe("CtrlProxy reconnecting, retry in 2s");
+      } finally {
+        await testClient.close();
+      }
+    });
   });
 
   describe("requestSwipe", function() {


### PR DESCRIPTION
## Summary
- Caps iOS CtrlProxy reconnect cooldown at 2 seconds.
- Adds structured reconnect cooldown metadata so iOS observe can report `CtrlProxy reconnecting, retry in Ns` instead of an ambiguous empty hierarchy.
- Covers shared cooldown status, iOS cooldown behavior, and observe-level retry metadata with fake-timer unit tests.

Closes #2695

## Testing
- `bun test test/features/observe/DeviceServiceClientCooldown.test.ts`
- `bun test test/features/observe/DeviceServiceClientCooldown.test.ts test/features/observe/ios/IOSCtrlProxyClient.test.ts test/features/observe/ViewHierarchy.test.ts`
- `bun test test/features/observe/ios/CtrlProxyClientRestartThreshold.test.ts`
- `bun test test/features/observe/ios/CtrlProxyClientAutoSetup.test.ts`
- `bun run build`
- `bun run lint`
- `bun test --bail`

## Notes
- No pull request template file exists in this repo; this PR uses the repo's body-file workflow.
- `bash scripts/validate-bun-test-timings.sh` still reports unrelated pre-existing slow tests outside this change; the touched cooldown test now runs under 100ms.
