### PR TITLE
Fail iOS doctor on broken observe round trip

### DIFF
--- a/src/doctor/checks/ios.ts
+++ b/src/doctor/checks/ios.ts
@@ -15,6 +15,9 @@ import { logger, type Logger } from "../../utils/logger";
 import { IOS_CTRL_PROXY_RELEASE_VERSION, resolveAssetVersion } from "../../constants/release";
 import { IOSCtrlProxyManager } from "../../utils/IOSCtrlProxyManager";
 import { IOSCtrlProxyClient, IOS_RUNNER_FEATURE_COMMANDS } from "../../features/observe/ios/IOSCtrlProxyClient";
+import { ObserveElementsBuilder } from "../../features/observe/ObserveElementsBuilder";
+import type { CtrlProxyHierarchy } from "../../features/observe/ios/types";
+import type { ViewHierarchyResult } from "../../models/ViewHierarchyResult";
 
 // Re-exported so doctor consumers (and tests) can reference the feature command
 // set without reaching into the runner client module.
@@ -42,6 +45,23 @@ export interface IosCtrlProxyRunnerInspector {
   inspectBootedRunners(): Promise<IosRunnerInspection[]>;
 }
 
+/** Per-simulator result of a real iOS runner observe round trip. */
+export interface IosObserveRoundTripInspection {
+  deviceId: string;
+  name: string;
+  runnerPort: number;
+  clientPort: number;
+  connected: boolean;
+  screenSize: { width: number; height: number };
+  hierarchyError: string | null;
+  elementCount: number;
+}
+
+/** Source of booted-simulator iOS observe round trips (injectable for tests). */
+export interface IosObserveRoundTripInspector {
+  inspectBootedObserveRoundTrips(): Promise<IosObserveRoundTripInspection[]>;
+}
+
 type IosRunnerVersionStatus = "compatible" | "stale" | "unknown";
 
 /**
@@ -65,6 +85,7 @@ export interface IosDoctorDependencies {
   logger: Logger;
   createSimctlClient: () => SimCtl;
   runnerInspector: IosCtrlProxyRunnerInspector;
+  observeRoundTripInspector: IosObserveRoundTripInspector;
 }
 
 /**
@@ -73,6 +94,7 @@ export interface IosDoctorDependencies {
 interface IosRunnerManager {
   isInstalled(): Promise<boolean>;
   isRunning(): Promise<boolean>;
+  getServicePort(): number;
 }
 
 /**
@@ -81,6 +103,19 @@ interface IosRunnerManager {
  */
 interface IosRunnerProbeClient {
   getSupportedCommands(): Promise<string[] | null>;
+  close(): Promise<void>;
+}
+
+/** Minimal iOS runner client surface for the doctor observe round-trip check. */
+interface IosObserveRoundTripClient {
+  getConnectionPortForDiagnostics(): number;
+  requestHierarchySync(
+    perf?: unknown,
+    disableAllFiltering?: boolean,
+    signal?: AbortSignal,
+    timeoutMs?: number
+  ): Promise<{ hierarchy: CtrlProxyHierarchy } | null>;
+  convertToViewHierarchyResult(hierarchy: CtrlProxyHierarchy): ViewHierarchyResult;
   close(): Promise<void>;
 }
 
@@ -94,12 +129,27 @@ export interface IosRunnerInspectorHooks {
   createClient(device: BootedDevice): IosRunnerProbeClient;
 }
 
+/** Injection seam for the iOS observe round-trip inspector. */
+export interface IosObserveRoundTripInspectorHooks {
+  getManager(device: BootedDevice): IosRunnerManager;
+  getExistingClient(deviceId: string): IosObserveRoundTripClient | null;
+  createClient(device: BootedDevice, port: number): IosObserveRoundTripClient;
+  elementsBuilder: ObserveElementsBuilder;
+}
+
 const defaultIosRunnerInspectorHooks: IosRunnerInspectorHooks = {
   getManager: device => IOSCtrlProxyManager.getInstance(device),
   getExistingClient: deviceId => IOSCtrlProxyClient.getExistingInstance(deviceId),
   // Detached (not singleton-registered) so closing it leaves nothing for a later
   // probe to rediscover and reconnect — see IOSCtrlProxyClient.createDetached.
   createClient: device => IOSCtrlProxyClient.createDetached(device),
+};
+
+const defaultIosObserveRoundTripInspectorHooks: IosObserveRoundTripInspectorHooks = {
+  getManager: device => IOSCtrlProxyManager.getInstance(device),
+  getExistingClient: deviceId => IOSCtrlProxyClient.getExistingInstance(deviceId),
+  createClient: device => IOSCtrlProxyClient.createDetached(device),
+  elementsBuilder: new ObserveElementsBuilder(),
 };
 
 /**
@@ -170,6 +220,105 @@ export function createIosCtrlProxyRunnerInspector(
   };
 }
 
+/**
+ * Real iOS observe round-trip inspector: for every booted simulator, verify the
+ * runner is installed/running, connect through the same client-side port path
+ * `observe` uses, compare that client port to the runner service port, request a
+ * fresh hierarchy, and summarize the same non-degenerate signals users see in
+ * `observe`.
+ */
+export function createIosObserveRoundTripInspector(
+  createSimctlClient: () => SimCtl,
+  log: Logger,
+  hooks: IosObserveRoundTripInspectorHooks = defaultIosObserveRoundTripInspectorHooks
+): IosObserveRoundTripInspector {
+  return {
+    async inspectBootedObserveRoundTrips(): Promise<IosObserveRoundTripInspection[]> {
+      const simctl = createSimctlClient();
+      if (!(await simctl.isAvailable())) {
+        return [];
+      }
+
+      const simulators = await simctl.getBootedSimulators();
+      const inspections: IosObserveRoundTripInspection[] = [];
+
+      for (const simulator of simulators) {
+        const device: BootedDevice = {
+          name: simulator.name,
+          platform: "ios",
+          deviceId: simulator.deviceId,
+          source: simulator.source,
+        };
+        const manager = hooks.getManager(device);
+        const runnerPort = manager.getServicePort();
+        let clientPort = runnerPort;
+        let connected = false;
+        let screenSize = { width: 0, height: 0 };
+        let hierarchyError: string | null = null;
+        let elementCount = 0;
+
+        try {
+          const installed = await manager.isInstalled();
+          const running = installed ? await manager.isRunning() : false;
+          if (!installed || !running) {
+            hierarchyError = installed ? "iOS CtrlProxy runner is not running" : "iOS CtrlProxy runner is not installed";
+          } else {
+            const existing = hooks.getExistingClient(device.deviceId);
+            const client = existing ?? hooks.createClient(device, runnerPort);
+            try {
+              clientPort = client.getConnectionPortForDiagnostics();
+              const response = await client.requestHierarchySync(undefined, false, undefined, 5000);
+              clientPort = client.getConnectionPortForDiagnostics();
+              connected = response !== null;
+              if (!response?.hierarchy) {
+                hierarchyError = "No iOS hierarchy returned from CtrlProxy runner";
+              } else if (response.hierarchy.error) {
+                hierarchyError = response.hierarchy.error;
+              } else {
+                const viewHierarchy = client.convertToViewHierarchyResult(response.hierarchy);
+                hierarchyError = viewHierarchy.hierarchy.error ?? null;
+                screenSize = {
+                  width: viewHierarchy.screenWidth ?? response.hierarchy.screenWidth ?? 0,
+                  height: viewHierarchy.screenHeight ?? response.hierarchy.screenHeight ?? 0,
+                };
+                const elements = hooks.elementsBuilder.build(viewHierarchy, "ios");
+                elementCount =
+                  elements.clickable.length +
+                  elements.scrollable.length +
+                  elements.text.length +
+                  elements.media.length;
+              }
+            } finally {
+              if (existing === null) {
+                await client.close();
+              }
+            }
+          }
+        } catch (error) {
+          hierarchyError = normalizeErrorMessage(error);
+          log.warn(
+            `iOS observe round-trip failed for ${simulator.deviceId}: ${hierarchyError}`,
+            error
+          );
+        }
+
+        inspections.push({
+          deviceId: simulator.deviceId,
+          name: simulator.name,
+          runnerPort,
+          clientPort,
+          connected,
+          screenSize,
+          hierarchyError,
+          elementCount,
+        });
+      }
+
+      return inspections;
+    },
+  };
+}
+
 const createExecResult = (stdout: string, stderr: string): ExecResult => ({
   stdout,
   stderr,
@@ -200,7 +349,8 @@ const createIosDoctorDependencies = (): IosDoctorDependencies => ({
   homedir,
   logger,
   createSimctlClient: () => new SimCtlClient(),
-  runnerInspector: createIosCtrlProxyRunnerInspector(() => new SimCtlClient(), logger)
+  runnerInspector: createIosCtrlProxyRunnerInspector(() => new SimCtlClient(), logger),
+  observeRoundTripInspector: createIosObserveRoundTripInspector(() => new SimCtlClient(), logger)
 });
 
 function parseXcodeVersion(output: string): string | null {
@@ -752,6 +902,43 @@ function classifyRunner(
   return { status, missingCommands, line: parts.join("; ") };
 }
 
+interface IosObserveRoundTripClassification {
+  failed: boolean;
+  line: string;
+}
+
+function classifyObserveRoundTrip(
+  inspection: IosObserveRoundTripInspection
+): IosObserveRoundTripClassification {
+  const hasPortMismatch = inspection.runnerPort !== inspection.clientPort;
+  const hasDegenerateScreen =
+    inspection.screenSize.width <= 0 || inspection.screenSize.height <= 0;
+  const hasHierarchyError = inspection.hierarchyError !== null && inspection.hierarchyError.trim().length > 0;
+  const hasNoElements = inspection.elementCount < 1;
+  const failed =
+    !inspection.connected ||
+    hasPortMismatch ||
+    hasDegenerateScreen ||
+    hasHierarchyError ||
+    hasNoElements;
+
+  const parts = [
+    "platform=ios",
+    `device=${inspection.deviceId}`,
+    `runnerPort=${inspection.runnerPort}`,
+    `clientPort=${inspection.clientPort}`,
+    `connected=${inspection.connected}`,
+    `screenSize=${inspection.screenSize.width}x${inspection.screenSize.height}`,
+    `elementCount=${inspection.elementCount}`,
+    `hierarchyStatus=${hasHierarchyError ? "error" : "ok"}`,
+  ];
+  if (inspection.hierarchyError) {
+    parts.push(`hierarchyError=${inspection.hierarchyError}`);
+  }
+
+  return { failed, line: parts.join("; ") };
+}
+
 /**
  * Check the iOS CtrlProxy runner on each booted simulator, mirroring the Android
  * CtrlProxy check. Reports installed/running, the expected pinned runner version,
@@ -826,6 +1013,68 @@ export async function checkIosCtrlProxyRunner(
 }
 
 /**
+ * Exercise the daemon/client-to-runner path that `observe` depends on. This is a
+ * hard failure when a booted iOS simulator cannot return a non-degenerate
+ * hierarchy, because otherwise doctor reports green for the exact broken state
+ * users need it to diagnose.
+ */
+export async function checkIosObserveRoundTrip(
+  dependencies = createIosDoctorDependencies()
+): Promise<CheckResult> {
+  const name = "iOS Observe Round Trip";
+
+  if (dependencies.platform() !== "darwin") {
+    return {
+      name,
+      status: "skip",
+      message: "iOS simulators only available on macOS",
+    };
+  }
+
+  try {
+    const inspections = await dependencies.observeRoundTripInspector.inspectBootedObserveRoundTrips();
+
+    if (inspections.length === 0) {
+      return {
+        name,
+        status: "skip",
+        message: "No booted simulators to check",
+      };
+    }
+
+    const classifications = inspections.map(classifyObserveRoundTrip);
+    const message = classifications.map(classification => classification.line).join(" | ");
+    const hasFailure = classifications.some(classification => classification.failed);
+
+    if (hasFailure) {
+      return {
+        name,
+        status: "fail",
+        message,
+        recommendation:
+          "Restart the AutoMobile daemon and iOS CtrlProxy runner, then verify the runner WebSocket port " +
+          "matches the client port and re-run: auto-mobile --doctor --ios.",
+      };
+    }
+
+    return {
+      name,
+      status: "pass",
+      message,
+    };
+  } catch (error) {
+    dependencies.logger.warn(`iOS observe round-trip check failed: ${normalizeErrorMessage(error)}`, error);
+    return {
+      name,
+      status: "fail",
+      message: `Could not check iOS observe round trip: ${normalizeErrorMessage(error)}`,
+      recommendation:
+        "Restart the AutoMobile daemon and iOS CtrlProxy runner, then re-run: auto-mobile --doctor --ios.",
+    };
+  }
+}
+
+/**
  * Run all iOS checks
  */
 export async function runIosChecks(
@@ -844,6 +1093,7 @@ export async function runIosChecks(
   results.push(await checkProvisioningProfiles(dependencies));
   results.push(await checkBootedSimulators(dependencies));
   results.push(await checkIosCtrlProxyRunner(dependencies));
+  results.push(await checkIosObserveRoundTrip(dependencies));
 
   return results;
 }

--- a/src/features/observe/ios/IOSCtrlProxyClient.ts
+++ b/src/features/observe/ios/IOSCtrlProxyClient.ts
@@ -445,6 +445,14 @@ export class IOSCtrlProxyClient extends DeviceServiceClient implements IOSCtrlPr
   }
 
   /**
+   * Diagnostic accessor for doctor: reports the host port this client will use
+   * for the runner WebSocket without opening any additional connection.
+   */
+  public getConnectionPortForDiagnostics(): number {
+    return this.port;
+  }
+
+  /**
    * Bind this client to a session for multi-agent NavigationGraphManager isolation.
    */
   public bindSession(sessionId: string): void {

--- a/test/doctor/ios.test.ts
+++ b/test/doctor/ios.test.ts
@@ -5,17 +5,24 @@ import {
   checkBootedSimulators,
   checkCodeSigning,
   checkIosCtrlProxyRunner,
+  checkIosObserveRoundTrip,
   checkProvisioningProfiles,
   checkSimctlAvailable,
   checkSimulatorRuntimes,
   checkXcodeCommandLineTools,
   checkXcodeInstallation,
   checkXcrunAvailable,
+  createIosObserveRoundTripInspector,
   createIosCtrlProxyRunnerInspector,
   IOS_RUNNER_FEATURE_COMMANDS,
   runIosChecks
 } from "../../src/doctor/checks/ios";
-import type { IosRunnerInspection, IosRunnerInspectorHooks } from "../../src/doctor/checks/ios";
+import type {
+  IosObserveRoundTripInspection,
+  IosObserveRoundTripInspectorHooks,
+  IosRunnerInspection,
+  IosRunnerInspectorHooks
+} from "../../src/doctor/checks/ios";
 import type { ExecResult } from "../../src/models";
 import { FakeTimer } from "../fakes/FakeTimer";
 import { FakeLogger } from "../fakes/FakeLogger";
@@ -65,6 +72,9 @@ const baseDependencies: IosDoctorDependencies = {
   }),
   runnerInspector: {
     inspectBootedRunners: async () => []
+  },
+  observeRoundTripInspector: {
+    inspectBootedObserveRoundTrips: async () => []
   }
 };
 
@@ -711,6 +721,125 @@ describe("checkIosCtrlProxyRunner", () => {
   });
 });
 
+describe("checkIosObserveRoundTrip", () => {
+  const inspection = (
+    over: Partial<IosObserveRoundTripInspection> = {}
+  ): IosObserveRoundTripInspection => ({
+    deviceId: "SIM-1",
+    name: "iPhone 15",
+    runnerPort: 8765,
+    clientPort: 8765,
+    connected: true,
+    screenSize: { width: 390, height: 844 },
+    hierarchyError: null,
+    elementCount: 7,
+    ...over
+  });
+
+  const withRoundTrips = (inspections: IosObserveRoundTripInspection[]) => ({
+    ...baseDependencies,
+    observeRoundTripInspector: {
+      inspectBootedObserveRoundTrips: async () => inspections
+    }
+  });
+
+  test("passes when the client port matches the runner port and observe returns a usable hierarchy", async () => {
+    const result = await checkIosObserveRoundTrip(withRoundTrips([inspection()]));
+
+    expect(result.status).toBe("pass");
+    expect(result.message).toContain("device=SIM-1");
+    expect(result.message).toContain("runnerPort=8765");
+    expect(result.message).toContain("clientPort=8765");
+    expect(result.message).toContain("screenSize=390x844");
+    expect(result.message).toContain("elementCount=7");
+  });
+
+  test("fails when the client port diverges from the runner serving port", async () => {
+    const result = await checkIosObserveRoundTrip(
+      withRoundTrips([inspection({ runnerPort: 8765, clientPort: 8766 })])
+    );
+
+    expect(result.status).toBe("fail");
+    expect(result.message).toContain("runnerPort=8765");
+    expect(result.message).toContain("clientPort=8766");
+    expect(result.recommendation).toContain("CtrlProxy");
+  });
+
+  test("fails when the runner WebSocket cannot return a hierarchy", async () => {
+    const result = await checkIosObserveRoundTrip(
+      withRoundTrips([
+        inspection({
+          connected: false,
+          screenSize: { width: 0, height: 0 },
+          hierarchyError: "Failed to retrieve iOS view hierarchy from CtrlProxy iOS",
+          elementCount: 0
+        })
+      ])
+    );
+
+    expect(result.status).toBe("fail");
+    expect(result.message).toContain("connected=false");
+    expect(result.message).toContain("hierarchyStatus=error");
+    expect(result.message).toContain("Failed to retrieve iOS view hierarchy");
+  });
+
+  test("fails for a degenerate observe result with zero screen size", async () => {
+    const result = await checkIosObserveRoundTrip(
+      withRoundTrips([inspection({ screenSize: { width: 0, height: 0 } })])
+    );
+
+    expect(result.status).toBe("fail");
+    expect(result.message).toContain("screenSize=0x0");
+  });
+
+  test("fails when observe returns no elements from the known simulator screen", async () => {
+    const result = await checkIosObserveRoundTrip(
+      withRoundTrips([inspection({ elementCount: 0 })])
+    );
+
+    expect(result.status).toBe("fail");
+    expect(result.message).toContain("elementCount=0");
+  });
+
+  test("skips when no simulators are booted", async () => {
+    const result = await checkIosObserveRoundTrip(withRoundTrips([]));
+
+    expect(result.status).toBe("skip");
+  });
+
+  test("skips on non-macOS platforms", async () => {
+    const result = await checkIosObserveRoundTrip({
+      ...baseDependencies,
+      platform: () => "linux"
+    });
+
+    expect(result.status).toBe("skip");
+  });
+
+  test("logs and fails when the round-trip inspector throws", async () => {
+    const logger = new FakeLogger();
+    const result = await checkIosObserveRoundTrip({
+      ...baseDependencies,
+      logger,
+      observeRoundTripInspector: {
+        inspectBootedObserveRoundTrips: async () => {
+          throw new Error("round trip failed");
+        }
+      }
+    });
+
+    expect(result.status).toBe("fail");
+    expect(result.message).toContain("round trip failed");
+    expect(logger.at("warn").length).toBeGreaterThan(0);
+  });
+
+  test("runIosChecks includes the iOS observe round-trip check", async () => {
+    const results = await runIosChecks({}, baseDependencies);
+    const names = results.map(check => check.name);
+    expect(names).toContain("iOS Observe Round Trip");
+  });
+});
+
 describe("createIosCtrlProxyRunnerInspector lifecycle", () => {
   const simctlReturning = (devices: { name: string; deviceId: string }[]) => ({
     ...baseDependencies.createSimctlClient(),
@@ -718,7 +847,7 @@ describe("createIosCtrlProxyRunnerInspector lifecycle", () => {
     getBootedSimulators: async () => devices.map(d => ({ name: d.name, platform: "ios" as const, deviceId: d.deviceId }))
   });
 
-  const runningManager = { isInstalled: async () => true, isRunning: async () => true };
+  const runningManager = { isInstalled: async () => true, isRunning: async () => true, getServicePort: () => 8765 };
 
   test("closes a probe client it created (no pre-existing client)", async () => {
     let closes = 0;
@@ -788,5 +917,155 @@ describe("createIosCtrlProxyRunnerInspector lifecycle", () => {
 
     expect(inspections[0].supportedCommands).toBeNull();
     expect(closes).toBe(1);
+  });
+});
+
+describe("createIosObserveRoundTripInspector lifecycle", () => {
+  const simctlReturning = (devices: { name: string; deviceId: string }[]) => ({
+    ...baseDependencies.createSimctlClient(),
+    isAvailable: async () => true,
+    getBootedSimulators: async () => devices.map(d => ({ name: d.name, platform: "ios" as const, deviceId: d.deviceId }))
+  });
+
+  const runningManager = { isInstalled: async () => true, isRunning: async () => true, getServicePort: () => 8790 };
+  const viewHierarchy = {
+    hierarchy: { node: { $: { text: "Home" } } },
+    screenWidth: 390,
+    screenHeight: 844
+  };
+  const elementsBuilder = {
+    build: () => ({
+      clickable: [{ index: 0 }],
+      scrollable: [],
+      text: [{ index: 1 }],
+      media: []
+    })
+  } as any;
+
+  test("passes the manager service port to the probe factory and closes the probe", async () => {
+    let closes = 0;
+    const requestedPorts: number[] = [];
+    const hooks: IosObserveRoundTripInspectorHooks = {
+      getManager: () => runningManager,
+      getExistingClient: () => null,
+      createClient: (_device, port) => {
+        requestedPorts.push(port);
+        return {
+          getConnectionPortForDiagnostics: () => port,
+          requestHierarchySync: async () => ({ hierarchy: { updatedAt: 1, packageName: "SpringBoard", hierarchy: {} } as any }),
+          convertToViewHierarchyResult: () => viewHierarchy as any,
+          close: async () => { closes += 1; }
+        };
+      },
+      elementsBuilder
+    };
+
+    const inspector = createIosObserveRoundTripInspector(
+      () => simctlReturning([{ name: "iPhone 15", deviceId: "SIM-1" }]) as any,
+      new FakeLogger(),
+      hooks
+    );
+    const inspections = await inspector.inspectBootedObserveRoundTrips();
+
+    expect(requestedPorts).toEqual([8790]);
+    expect(closes).toBe(1);
+    expect(inspections[0]).toEqual({
+      deviceId: "SIM-1",
+      name: "iPhone 15",
+      runnerPort: 8790,
+      clientPort: 8790,
+      connected: true,
+      screenSize: { width: 390, height: 844 },
+      hierarchyError: null,
+      elementCount: 2
+    });
+  });
+
+  test("does not close a pre-existing client and reports its actual client port", async () => {
+    let closes = 0;
+    let created = false;
+    const existing = {
+      getConnectionPortForDiagnostics: () => 8765,
+      requestHierarchySync: async () => ({ hierarchy: { updatedAt: 1, packageName: "SpringBoard", hierarchy: {} } as any }),
+      convertToViewHierarchyResult: () => viewHierarchy as any,
+      close: async () => { closes += 1; }
+    };
+    const hooks: IosObserveRoundTripInspectorHooks = {
+      getManager: () => runningManager,
+      getExistingClient: () => existing,
+      createClient: () => {
+        created = true;
+        return existing;
+      },
+      elementsBuilder
+    };
+
+    const inspector = createIosObserveRoundTripInspector(
+      () => simctlReturning([{ name: "iPhone 15", deviceId: "SIM-1" }]) as any,
+      new FakeLogger(),
+      hooks
+    );
+    const inspections = await inspector.inspectBootedObserveRoundTrips();
+
+    expect(created).toBe(false);
+    expect(closes).toBe(0);
+    expect(inspections[0].runnerPort).toBe(8790);
+    expect(inspections[0].clientPort).toBe(8765);
+  });
+
+  test("reports the client port after the hierarchy request can resync it", async () => {
+    let currentClientPort = 8765;
+    const existing = {
+      getConnectionPortForDiagnostics: () => currentClientPort,
+      requestHierarchySync: async () => {
+        currentClientPort = 8790;
+        return { hierarchy: { updatedAt: 1, packageName: "SpringBoard", hierarchy: {} } as any };
+      },
+      convertToViewHierarchyResult: () => viewHierarchy as any,
+      close: async () => {}
+    };
+    const hooks: IosObserveRoundTripInspectorHooks = {
+      getManager: () => runningManager,
+      getExistingClient: () => existing,
+      createClient: () => existing,
+      elementsBuilder
+    };
+
+    const inspector = createIosObserveRoundTripInspector(
+      () => simctlReturning([{ name: "iPhone 15", deviceId: "SIM-1" }]) as any,
+      new FakeLogger(),
+      hooks
+    );
+    const inspections = await inspector.inspectBootedObserveRoundTrips();
+
+    expect(inspections[0].clientPort).toBe(8790);
+  });
+
+  test("does not create a client when the runner is not running", async () => {
+    let created = false;
+    const hooks: IosObserveRoundTripInspectorHooks = {
+      getManager: () => ({
+        isInstalled: async () => true,
+        isRunning: async () => false,
+        getServicePort: () => 8790
+      }),
+      getExistingClient: () => null,
+      createClient: () => {
+        created = true;
+        throw new Error("should not create client for stopped runner");
+      },
+      elementsBuilder
+    };
+
+    const inspector = createIosObserveRoundTripInspector(
+      () => simctlReturning([{ name: "iPhone 15", deviceId: "SIM-1" }]) as any,
+      new FakeLogger(),
+      hooks
+    );
+    const inspections = await inspector.inspectBootedObserveRoundTrips();
+
+    expect(created).toBe(false);
+    expect(inspections[0].connected).toBe(false);
+    expect(inspections[0].hierarchyError).toBe("iOS CtrlProxy runner is not running");
   });
 });


### PR DESCRIPTION
## Summary

- Add an iOS doctor round-trip check that exercises the CtrlProxy WebSocket hierarchy path used by observe.
- Fail doctor when the client port differs from the runner service port, hierarchy retrieval fails, screen size is zero, or no elements are returned.
- Cover the new check and inspector lifecycle with fast injected-fake tests.

Closes #2693

## Testing

- `bun run lint`
- `bun run build`
- `bun test test/doctor/ios.test.ts`
- `bun test --bail`

## Review

- Ran `/auto-mobile-code-review` locally on the final diff.
- Addressed the review finding by reporting the client port after the hierarchy request can resync it, and by avoiding forced runner-port injection in the default client probe.
