### PR TITLE
fix iOS CtrlProxy port allocation collisions

### DIFF
--- a/src/features/observe/android/AndroidCtrlProxyClient.ts
+++ b/src/features/observe/android/AndroidCtrlProxyClient.ts
@@ -1845,6 +1845,26 @@ export class AndroidCtrlProxyClient extends DeviceServiceClient implements Andro
   // Private Methods
   // ===========================================================================
 
+  private ensureLocalPortAvailableForForwarding(): void {
+    const currentAllocation = PortManager.getPort(this.device.deviceId);
+    const currentPortIsAvailable = PortManager.isPortAvailable(this.localPort);
+    if (currentAllocation === this.localPort && currentPortIsAvailable) {
+      return;
+    }
+
+    const additionalReservedPorts = currentPortIsAvailable ? [] : [this.localPort];
+    PortManager.release(this.device.deviceId);
+    const nextPort = PortManager.allocate(this.device.deviceId, {
+      reservedPorts: additionalReservedPorts,
+    });
+    if (nextPort !== this.localPort) {
+      logger.info(
+        `[CTRL_PROXY] Reallocated local port from ${this.localPort} to ${nextPort} before adb forward`
+      );
+      this.localPort = nextPort;
+    }
+  }
+
   private async setupPortForwarding(perf: PerformanceTracker = new NoOpPerformanceTracker()): Promise<void> {
     // Verify port forwarding is still active even if we think it's set up
     // Port forwarding can be lost if ADB server restarts or emulator restarts
@@ -1859,11 +1879,19 @@ export class AndroidCtrlProxyClient extends DeviceServiceClient implements Andro
     }
 
     try {
-      logger.debug(`[CTRL_PROXY] Setting up port forwarding for WebSocket: localhost:${this.localPort} → device:${PortManager.DEVICE_PORT} (device: ${this.device.deviceId})`);
-
+      const previousLocalPort = this.localPort;
       await perf.track("clearPortForward", () =>
         this.adb.executeCommand(`forward --remove tcp:${this.localPort}`).catch(() => {})
       );
+
+      this.ensureLocalPortAvailableForForwarding();
+      logger.debug(`[CTRL_PROXY] Setting up port forwarding for WebSocket: localhost:${this.localPort} → device:${PortManager.DEVICE_PORT} (device: ${this.device.deviceId})`);
+
+      if (this.localPort !== previousLocalPort) {
+        await perf.track("clearReallocatedPortForward", () =>
+          this.adb.executeCommand(`forward --remove tcp:${this.localPort}`).catch(() => {})
+        );
+      }
 
       await perf.track("setupPortForward", () =>
         this.adb.executeCommand(`forward tcp:${this.localPort} tcp:${PortManager.DEVICE_PORT}`)

--- a/src/utils/IOSCtrlProxyManager.ts
+++ b/src/utils/IOSCtrlProxyManager.ts
@@ -849,6 +849,25 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
     });
   }
 
+  private ensureLocalServicePortAllocatedAndAvailable(): void {
+    const currentAllocation = PortManager.getPort(this.device.deviceId);
+    const currentPortIsAvailable = PortManager.isPortAvailable(this.servicePort);
+    if (currentAllocation === this.servicePort && currentPortIsAvailable) {
+      return;
+    }
+
+    const additionalReservedPorts = currentPortIsAvailable ? [] : [this.servicePort];
+    PortManager.release(this.device.deviceId);
+    const nextPort = this.allocateServicePort(additionalReservedPorts);
+    if (nextPort !== this.servicePort) {
+      logger.info(
+        `[IOSCtrlProxy] Reallocated service port from ${this.servicePort} to ${nextPort} before runner launch`
+      );
+      this.servicePort = nextPort;
+      this.clearCaches();
+    }
+  }
+
   private adoptServicePort(port: number): void {
     if (PortManager.getPort(this.device.deviceId) !== port) {
       PortManager.reserve(this.device.deviceId, port);
@@ -951,6 +970,7 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
 
     const timeout = process.env.CTRL_PROXY_IOS_TIMEOUT || "86400";
     const bundleId = this.resolveTargetBundleId();
+    this.ensureLocalServicePortAllocatedAndAvailable();
 
     // Pass env vars via exec env option to avoid shell interpolation of user-controlled values.
     // SIMCTL_CHILD_* prefixed vars are forwarded by simctl (which xcodebuild uses internally
@@ -1360,6 +1380,7 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
       throw new Error("CtrlProxy xctestrun not found for device. Download the CtrlProxy bundle before starting.");
     }
 
+    this.ensureLocalServicePortAllocatedAndAvailable();
     await this.startIproxyTunnel();
     await this.verifyInstalledAppBundle();
 

--- a/src/utils/PortManager.ts
+++ b/src/utils/PortManager.ts
@@ -95,12 +95,18 @@ export class PortManager {
       return this.allocatedPorts.get(deviceId)!;
     }
 
+    if (this.allocatedPorts.size >= this.maxDevices) {
+      throw new Error(
+        `No available ports for device ${deviceId}. ` +
+        `The maximum of ${this.maxDevices} simultaneous device ports is already allocated.`
+      );
+    }
+
     // Find next available port
     const usedPorts = new Set(this.allocatedPorts.values());
     const reservedPorts = new Set(options.reservedPorts ?? []);
     const availabilityChecker = options.availabilityChecker ?? this.portAvailabilityChecker;
-    for (let i = 0; i < this.maxDevices; i++) {
-      const port = this.basePort + i;
+    for (let port = this.basePort; port <= 65535; port++) {
       if (usedPorts.has(port) || reservedPorts.has(port)) {
         continue;
       }
@@ -114,8 +120,15 @@ export class PortManager {
 
     throw new Error(
       `No available ports for device ${deviceId}. ` +
-      `All ${this.maxDevices} ports (${this.basePort}-${this.basePort + this.maxDevices - 1}) are in use or reserved.`
+      `No free host ports were found at or above ${this.basePort}.`
     );
+  }
+
+  /**
+   * Check whether a host port is currently free to bind.
+   */
+  public static isPortAvailable(port: number, checker: PortAvailabilityChecker = this.portAvailabilityChecker): boolean {
+    return checker.isPortAvailable(port);
   }
 
   /**

--- a/test/features/observe/CtrlProxyClient.test.ts
+++ b/test/features/observe/CtrlProxyClient.test.ts
@@ -14,6 +14,7 @@ import {
 import { FakeInstalledAppsRepository } from "../../fakes/FakeInstalledAppsRepository";
 import { FakeTimer } from "../../fakes/FakeTimer";
 import type { DeviceConnectionLostNotifier } from "../../../src/features/observe/DeviceConnectionLostNotifier";
+import { PortManager } from "../../../src/utils/PortManager";
 
 describe("AndroidCtrlProxyClient", function() {
   let accessibilityServiceClient: AndroidCtrlProxyClient;
@@ -132,6 +133,44 @@ describe("AndroidCtrlProxyClient", function() {
       await new Promise(resolve => setImmediate(resolve));
     }
   };
+
+  test("setupPortForwarding reallocates when the current local port becomes busy before adb forward", async function() {
+    await accessibilityServiceClient.close();
+    AndroidCtrlProxyClient.resetInstances();
+    PortManager.reset();
+
+    const unavailablePorts = new Set<number>();
+    const checkedPorts: number[] = [];
+    PortManager.setPortAvailabilityCheckerForTesting({
+      isPortAvailable: (port: number) => {
+        checkedPorts.push(port);
+        return !unavailablePorts.has(port);
+      },
+    });
+    try {
+      accessibilityServiceClient = AndroidCtrlProxyClient.createForTesting(
+        testDevice,
+        fakeAdb,
+        createSuccessWebSocketFactory(),
+        fakeTimer
+      );
+      unavailablePorts.add(8765);
+
+      await (accessibilityServiceClient as unknown as {
+        setupPortForwarding: () => Promise<void>;
+        getWebSocketUrl: () => string;
+      }).setupPortForwarding();
+
+      expect(checkedPorts).toEqual([8765, 8765, 8766]);
+      expect(fakeAdb.getExecutedCommands()).toContain("forward --remove tcp:8766");
+      expect(fakeAdb.getExecutedCommands()).toContain("forward tcp:8766 tcp:8765");
+      expect((accessibilityServiceClient as unknown as { getWebSocketUrl: () => string }).getWebSocketUrl()).toBe(
+        "ws://localhost:8766/ws"
+      );
+    } finally {
+      PortManager.setPortAvailabilityCheckerForTesting(null);
+    }
+  });
 
   describe("connection lifecycle", function() {
     test("notifies the observation stream when the WebSocket connection closes", function() {

--- a/test/utils/IOSCtrlProxyManager.test.ts
+++ b/test/utils/IOSCtrlProxyManager.test.ts
@@ -981,6 +981,45 @@ describe("IOSCtrlProxyManager", function() {
       }
     });
 
+    test("startOnSimulator() reallocates when the current simulator port becomes busy before launch", async function() {
+      const unavailablePorts = new Set<number>();
+      const checkedPorts: number[] = [];
+      PortManager.setPortAvailabilityCheckerForTesting({
+        isPortAvailable: (port: number) => {
+          checkedPorts.push(port);
+          return !unavailablePorts.has(port);
+        },
+      });
+      try {
+        const fakeBuilder = {
+          getXctestrunPath: async () => "/tmp/test.xctestrun",
+          getRunnerBinaryPath: async () => null,
+        } as unknown as import("../../src/utils/IOSCtrlProxyBuilder").IOSCtrlProxyBuilder;
+        const manager = IOSCtrlProxyManager.createForTestingWithDeps(
+          testDevice,
+          fakeTimer,
+          fakeBuilder,
+          fakeExecutor
+        );
+        expect(manager.getServicePort()).toBe(8765);
+
+        unavailablePorts.add(8765);
+
+        await (manager as unknown as { startOnSimulator: () => Promise<void> }).startOnSimulator();
+
+        const spawn = fakeExecutor.getSpawnedProcesses()[0];
+        expect(checkedPorts).toEqual([8765, 8765, 8767]);
+        expect(manager.getServicePort()).toBe(8767);
+        expect(PortManager.getPort(testDevice.deviceId)).toBe(8767);
+        expect(spawn.options?.env).toMatchObject({
+          CTRL_PROXY_IOS_PORT: "8767",
+          SIMCTL_CHILD_CTRL_PROXY_IOS_PORT: "8767",
+        });
+      } finally {
+        PortManager.setPortAvailabilityCheckerForTesting(null);
+      }
+    });
+
     test("host-control simulator start skips ports that are busy on the host", async function() {
       const fakeBuilder = {
         getXctestrunPath: async () => "/tmp/test.xctestrun",

--- a/test/utils/PortManager.test.ts
+++ b/test/utils/PortManager.test.ts
@@ -197,4 +197,35 @@ describe("PortManager", () => {
 
     expect(PortManager.getAllocatedCount()).toBe(50);
   });
+
+  test("should support 100 iOS devices while skipping reserved ports", () => {
+    const ports: number[] = [];
+
+    for (let i = 0; i < PortManager.getMaxDevices(); i++) {
+      ports.push(PortManager.allocate(`ios-device-${i}`, { reservedPorts: IOS_CTRL_PROXY_RESERVED_PORTS }));
+    }
+
+    expect(ports).toHaveLength(100);
+    expect(new Set(ports).size).toBe(100);
+    expect(ports).not.toContain(8766);
+    expect(ports[0]).toBe(8765);
+    expect(ports[99]).toBe(8865);
+  });
+
+  test("should support 100 mixed Android and iOS devices when the default port is already in use", () => {
+    const checker = new FakePortAvailabilityChecker(new Set([8765]));
+    PortManager.setPortAvailabilityCheckerForTesting(checker);
+    const ports: number[] = [];
+
+    for (let i = 0; i < PortManager.getMaxDevices(); i++) {
+      const reservedPorts = i % 2 === 0 ? IOS_CTRL_PROXY_RESERVED_PORTS : undefined;
+      ports.push(PortManager.allocate(`device-${i}`, { reservedPorts }));
+    }
+
+    expect(ports).toHaveLength(100);
+    expect(new Set(ports).size).toBe(100);
+    expect(ports).not.toContain(8765);
+    expect(ports[0]).toBe(8767);
+    expect(ports[99]).toBe(8865);
+  });
 });


### PR DESCRIPTION
## Summary

- Treat PortManager's default 100 as shared Android+iOS device capacity, even when reserved or externally busy host ports must be skipped.
- Revalidate iOS CtrlProxy local ports immediately before simulator runner launch and physical-device tunnel startup so the runner and client use the same free port.
- Revalidate Android local ports before `adb forward`, preserving stale-forward cleanup before reallocating.

Closes #2691

## Testing

- `bun test test/utils/PortManager.test.ts test/utils/IOSCtrlProxyManager.test.ts`
- `bun test test/features/observe/CtrlProxyClient.test.ts --test-name-pattern "setupPortForwarding reallocates"`
- `bun run lint`
- `bun run build`

## Notes

- No PR template file exists in this repo checkout or at `.github/PULL_REQUEST_TEMPLATE.md`, so this uses the repo's concise Summary/Testing format.
