### PR TITLE
fix(ios): recover CtrlProxy startup port ownership

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -458,12 +458,10 @@ async function main() {
       AndroidCtrlProxyManager.prefetchApk();
     }
 
-    // Start iOS CtrlProxy iOS build prefetch (macOS only)
-    // This runs asynchronously and will be ready when first iOS device connects
+    // Reap orphaned iOS runners before the daemon accepts iOS work, then start
+    // the build prefetch asynchronously so it can be ready for first use.
     if (process.platform === "darwin") {
-      IOSCtrlProxyManager.reapOrphanedRunnerProcessesOnStartup().catch(error => {
-        logger.debug(`[IOSCtrlProxy] Startup orphan sweep failed: ${error}`);
-      });
+      await IOSCtrlProxyManager.reapOrphanedRunnerProcessesOnStartup();
       IOSCtrlProxyBuilder.prefetchBuild();
     }
 

--- a/src/utils/IOSCtrlProxyManager.ts
+++ b/src/utils/IOSCtrlProxyManager.ts
@@ -1329,17 +1329,19 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
           continue;
         }
         try {
-          const { stdout: argsOut } = await this.processExecutor.exec(
-            `ps -p ${pid} -o args= 2>/dev/null`
-          );
+          const processInfo = await IOSCtrlProxyManager.getProcessInfo(this.processExecutor, pid);
+          const argsOut = processInfo?.command ?? "";
           if (argsOut.includes("CtrlProxy")) {
-            if (IOSCtrlProxyManager.isDaemonManagedSimulatorXcodebuildCommand(argsOut)) {
+            if (IOSCtrlProxyManager.isDaemonManagedSimulatorXcodebuildCommand(argsOut, processInfo)) {
               continue;
             }
-            if (!argsOut.includes(`id=${this.device.deviceId}`)) {
+            const identityText = `${argsOut} ${processInfo?.environment ?? ""}`;
+            if (!IOSCtrlProxyManager.hasDeviceIdentity(identityText, this.device.deviceId)) {
               continue;
             }
-            const port = this.parseCtrlProxyPortFromProcessArgs(argsOut) ?? IOSCtrlProxyManager.DEFAULT_PORT;
+            const port = this.parseCtrlProxyPortFromProcessArgs(argsOut) ??
+              this.parseCtrlProxyPortFromProcessArgs(processInfo?.environment ?? "") ??
+              IOSCtrlProxyManager.DEFAULT_PORT;
             logger.info(`[IOSCtrlProxy] Found external xcodebuild CtrlProxy process: ${pid}`);
             return { pid, port };
           }
@@ -1571,14 +1573,25 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
       text.includes(`SIMCTL_CHILD_AUTOMOBILE_DEVICE_ID=${deviceId}`);
   }
 
-  private static isDaemonManagedSimulatorXcodebuildCommand(command: string): boolean {
+  private static isDaemonManagedSimulatorXcodebuildCommand(
+    command: string,
+    processInfo?: { ppid?: number; environment?: string } | null
+  ): boolean {
+    const environment = processInfo?.environment ?? "";
     return command.includes("xcodebuild") &&
       command.includes("test-without-building") &&
       command.includes("-xctestrun") &&
       command.includes("platform=iOS Simulator") &&
       command.includes("-only-testing:CtrlProxyUITests/CtrlProxyUITests/testRunService") &&
       !command.includes("CTRL_PROXY_IOS_PORT=") &&
-      !command.includes("AUTOMOBILE_DEVICE_ID=");
+      !command.includes("AUTOMOBILE_DEVICE_ID=") &&
+      (processInfo?.ppid === 1 || !IOSCtrlProxyManager.hasExternalXcodebuildIdentity(environment));
+  }
+
+  private static hasExternalXcodebuildIdentity(environment: string): boolean {
+    return environment.includes("CTRL_PROXY_IOS_PORT=") ||
+      environment.includes("AUTOMOBILE_DEVICE_ID=") ||
+      environment.includes("SIMCTL_CHILD_AUTOMOBILE_DEVICE_ID=");
   }
 
   private static isCtrlProxyRunnerCommand(command: string): boolean {

--- a/src/utils/IOSCtrlProxyManager.ts
+++ b/src/utils/IOSCtrlProxyManager.ts
@@ -1333,6 +1333,9 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
             `ps -p ${pid} -o args= 2>/dev/null`
           );
           if (argsOut.includes("CtrlProxy")) {
+            if (IOSCtrlProxyManager.isDaemonManagedSimulatorXcodebuildCommand(argsOut)) {
+              continue;
+            }
             if (!argsOut.includes(`id=${this.device.deviceId}`)) {
               continue;
             }
@@ -1563,6 +1566,16 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
     return text.includes(`id=${deviceId}`) ||
       text.includes(`AUTOMOBILE_DEVICE_ID=${deviceId}`) ||
       text.includes(`SIMCTL_CHILD_AUTOMOBILE_DEVICE_ID=${deviceId}`);
+  }
+
+  private static isDaemonManagedSimulatorXcodebuildCommand(command: string): boolean {
+    return command.includes("xcodebuild") &&
+      command.includes("test-without-building") &&
+      command.includes("-xctestrun") &&
+      command.includes("platform=iOS Simulator") &&
+      command.includes("-only-testing:CtrlProxyUITests/CtrlProxyUITests/testRunService") &&
+      !command.includes("CTRL_PROXY_IOS_PORT=") &&
+      !command.includes("AUTOMOBILE_DEVICE_ID=");
   }
 
   private static isCtrlProxyRunnerCommand(command: string): boolean {

--- a/src/utils/IOSCtrlProxyManager.ts
+++ b/src/utils/IOSCtrlProxyManager.ts
@@ -101,6 +101,7 @@ interface ListeningProcess {
   pid: number;
   port: number;
   command: string;
+  environment?: string;
   ppid?: number;
 }
 
@@ -1395,12 +1396,9 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
         return;
       }
 
-      const ownedProcesses: ListeningProcess[] = [];
-      for (const process of listeningProcesses) {
-        if (this.isOwnedCtrlProxyRunnerProcess(process)) {
-          ownedProcesses.push(process);
-        }
-      }
+      const ownedProcesses = listeningProcesses.filter(process =>
+        this.isOwnedCtrlProxyRunnerProcess(process)
+      );
       if (ownedProcesses.length > 0) {
         for (const process of ownedProcesses) {
           logger.warn(
@@ -1413,14 +1411,7 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
         if (remainingProcesses.length === 0) {
           return;
         }
-        let ownedProcessStillHoldingPort = false;
-        for (const process of remainingProcesses) {
-          if (this.isOwnedCtrlProxyRunnerProcess(process)) {
-            ownedProcessStillHoldingPort = true;
-            break;
-          }
-        }
-        if (ownedProcessStillHoldingPort) {
+        if (remainingProcesses.some(process => this.isOwnedCtrlProxyRunnerProcess(process))) {
           throw new Error(
             `CtrlProxy recovery failed, port ${this.servicePort} still held by ` +
             this.formatListeningProcesses(remainingProcesses)
@@ -1465,7 +1456,8 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
     if (!IOSCtrlProxyManager.isCtrlProxyRunnerCommand(process.command)) {
       return false;
     }
-    return process.command.includes(this.device.deviceId);
+    return IOSCtrlProxyManager.hasDeviceIdentity(process.command, this.device.deviceId) ||
+      IOSCtrlProxyManager.hasDeviceIdentity(process.environment ?? "", this.device.deviceId);
   }
 
   private async processAncestryContainsDeviceId(process: ListeningProcess): Promise<boolean> {
@@ -1478,7 +1470,7 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
       if (!processInfo) {
         return false;
       }
-      if (processInfo.command.includes(this.device.deviceId)) {
+      if (IOSCtrlProxyManager.hasDeviceIdentity(processInfo.command, this.device.deviceId)) {
         return true;
       }
       parentPid = processInfo.ppid;
@@ -1532,7 +1524,7 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
   private static async getProcessInfo(
     processExecutor: ProcessExecutor,
     pid: number
-  ): Promise<{ ppid?: number; command: string } | null> {
+  ): Promise<{ ppid?: number; command: string; environment?: string } | null> {
     try {
       const { stdout } = await processExecutor.exec(`ps -p ${pid} -o ppid= -o args= 2>/dev/null`);
       const output = stdout.trim();
@@ -1540,16 +1532,37 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
         return null;
       }
       const match = output.match(/^(\d+)\s+([\s\S]+)$/);
+      const environment = await IOSCtrlProxyManager.getProcessEnvironment(processExecutor, pid);
       if (!match) {
-        return { command: output };
+        return { command: output, environment };
       }
       return {
         ppid: Number.parseInt(match[1], 10),
         command: match[2],
+        environment,
       };
     } catch {
       return null;
     }
+  }
+
+  private static async getProcessEnvironment(
+    processExecutor: ProcessExecutor,
+    pid: number
+  ): Promise<string | undefined> {
+    try {
+      const { stdout } = await processExecutor.exec(`ps eww -p ${pid} -o command= 2>/dev/null`);
+      const output = stdout.trim();
+      return output.length > 0 ? output : undefined;
+    } catch {
+      return undefined;
+    }
+  }
+
+  private static hasDeviceIdentity(text: string, deviceId: string): boolean {
+    return text.includes(`id=${deviceId}`) ||
+      text.includes(`AUTOMOBILE_DEVICE_ID=${deviceId}`) ||
+      text.includes(`SIMCTL_CHILD_AUTOMOBILE_DEVICE_ID=${deviceId}`);
   }
 
   private static isCtrlProxyRunnerCommand(command: string): boolean {

--- a/src/utils/IOSCtrlProxyManager.ts
+++ b/src/utils/IOSCtrlProxyManager.ts
@@ -1332,7 +1332,7 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
           const processInfo = await IOSCtrlProxyManager.getProcessInfo(this.processExecutor, pid);
           const argsOut = processInfo?.command ?? "";
           if (argsOut.includes("CtrlProxy")) {
-            if (IOSCtrlProxyManager.isDaemonManagedSimulatorXcodebuildCommand(argsOut, processInfo)) {
+            if (await this.isDaemonManagedSimulatorXcodebuildProcess(argsOut, processInfo)) {
               continue;
             }
             const identityText = `${argsOut} ${processInfo?.environment ?? ""}`;
@@ -1573,19 +1573,47 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
       text.includes(`SIMCTL_CHILD_AUTOMOBILE_DEVICE_ID=${deviceId}`);
   }
 
-  private static isDaemonManagedSimulatorXcodebuildCommand(
+  private async isDaemonManagedSimulatorXcodebuildProcess(
     command: string,
     processInfo?: { ppid?: number; environment?: string } | null
-  ): boolean {
+  ): Promise<boolean> {
     const environment = processInfo?.environment ?? "";
+    if (!IOSCtrlProxyManager.isDaemonManagedSimulatorXcodebuildCommandShape(command)) {
+      return false;
+    }
+    if (processInfo?.ppid === 1) {
+      return true;
+    }
+    if (await this.hasOrphanedDaemonManagedShellParent(processInfo?.ppid)) {
+      return true;
+    }
+    return !IOSCtrlProxyManager.hasExternalXcodebuildIdentity(environment);
+  }
+
+  private async hasOrphanedDaemonManagedShellParent(parentPid: number | undefined): Promise<boolean> {
+    if (parentPid === undefined || parentPid <= 1) {
+      return false;
+    }
+    const parentInfo = await IOSCtrlProxyManager.getProcessInfo(this.processExecutor, parentPid);
+    if (!parentInfo || parentInfo.ppid !== 1) {
+      return false;
+    }
+    return IOSCtrlProxyManager.isShellCommand(parentInfo.command) &&
+      IOSCtrlProxyManager.isDaemonManagedSimulatorXcodebuildCommandShape(parentInfo.command);
+  }
+
+  private static isDaemonManagedSimulatorXcodebuildCommandShape(command: string): boolean {
     return command.includes("xcodebuild") &&
       command.includes("test-without-building") &&
       command.includes("-xctestrun") &&
       command.includes("platform=iOS Simulator") &&
       command.includes("-only-testing:CtrlProxyUITests/CtrlProxyUITests/testRunService") &&
       !command.includes("CTRL_PROXY_IOS_PORT=") &&
-      !command.includes("AUTOMOBILE_DEVICE_ID=") &&
-      (processInfo?.ppid === 1 || !IOSCtrlProxyManager.hasExternalXcodebuildIdentity(environment));
+      !command.includes("AUTOMOBILE_DEVICE_ID=");
+  }
+
+  private static isShellCommand(command: string): boolean {
+    return /(?:^|\/)(?:ba|z|c|t?c|k)?sh(?:\s|$)/.test(command);
   }
 
   private static hasExternalXcodebuildIdentity(environment: string): boolean {

--- a/src/utils/IOSCtrlProxyManager.ts
+++ b/src/utils/IOSCtrlProxyManager.ts
@@ -1473,7 +1473,10 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
       if (!processInfo) {
         return false;
       }
-      if (IOSCtrlProxyManager.hasDeviceIdentity(processInfo.command, this.device.deviceId)) {
+      if (
+        IOSCtrlProxyManager.hasDeviceIdentity(processInfo.command, this.device.deviceId) ||
+        processInfo.command.includes(this.device.deviceId)
+      ) {
         return true;
       }
       parentPid = processInfo.ppid;

--- a/test/utils/IOSCtrlProxyManager.test.ts
+++ b/test/utils/IOSCtrlProxyManager.test.ts
@@ -1040,6 +1040,45 @@ describe("IOSCtrlProxyManager", function() {
       expect(fakeExecutor.getSpawnedProcesses()).toEqual([]);
     });
 
+    test("start() preserves an externally managed test-without-building runner with inline identity", async function() {
+      const externalProcess: FakeListeningProcess = {
+        pid: 2471,
+        port: 8765,
+        command: `xcodebuild test-without-building -xctestrun /tmp/CtrlProxy.xctestrun -destination id=${testDevice.deviceId} -only-testing:CtrlProxyUITests/CtrlProxyUITests/testRunService CTRL_PROXY_IOS_PORT=8765 AUTOMOBILE_DEVICE_ID=${testDevice.deviceId}`,
+        alive: true,
+        ignoreTerm: true,
+        ignoreKill: true,
+      };
+      installListeningProcessFakes(fakeExecutor, [externalProcess]);
+      const fakeBuilder = {
+        getXctestrunPath: async () => {
+          throw new Error("should not build when an external CtrlProxy process is reused");
+        },
+        getRunnerBinaryPath: async () => null,
+      } as unknown as import("../../src/utils/IOSCtrlProxyBuilder").IOSCtrlProxyBuilder;
+      const manager = IOSCtrlProxyManager.createForTestingWithDeps(
+        testDevice,
+        fakeTimer,
+        fakeBuilder,
+        fakeExecutor
+      );
+
+      fakeExecutor.setCommandResponse("http://localhost:8765/health", createExecResult("", ""));
+      fakeExecutor.setCommandResponse("pgrep -x xcodebuild", createExecResult("2471\n", ""));
+      fakeExecutor.setCommandResponse(
+        "ps -p 2471",
+        createExecResult(externalProcess.command, "")
+      );
+      fakeTimer.enableAutoAdvance();
+
+      await expect(manager.start()).rejects.toThrow("CtrlProxy failed to start within timeout");
+
+      expect(externalProcess.alive).toBe(true);
+      expect(fakeExecutor.wasCommandExecuted("kill -TERM 2471")).toBe(false);
+      expect(fakeExecutor.wasCommandExecuted("kill -KILL 2471")).toBe(false);
+      expect(fakeExecutor.getSpawnedProcesses()).toEqual([]);
+    });
+
     test("start() ignores xcodebuild CtrlProxy processes for other simulators", async function() {
       const fakeBuilder = {
         getXctestrunPath: async () => "/tmp/test.xctestrun",
@@ -1278,6 +1317,39 @@ describe("IOSCtrlProxyManager", function() {
       } finally {
         PortManager.setPortAvailabilityCheckerForTesting(null);
       }
+    });
+
+    test("start() reclaims a stale daemon-owned xcodebuild even when pgrep finds it", async function() {
+      const staleProcess: FakeListeningProcess = {
+        pid: 2223,
+        port: 8765,
+        command: `xcodebuild test-without-building -xctestrun /tmp/CtrlProxy.xctestrun -destination platform=iOS Simulator,id=${testDevice.deviceId} -only-testing:CtrlProxyUITests/CtrlProxyUITests/testRunService`,
+        alive: true,
+        ignoreTerm: true,
+      };
+      installListeningProcessFakes(fakeExecutor, [staleProcess]);
+      fakeExecutor.setCommandResponse("pgrep -x xcodebuild", createExecResult("2223\n", ""));
+      fakeExecutor.setCommandHandler("curl -s", () =>
+        createExecResult(fakeExecutor.getSpawnedProcesses().length > 0 ? "ok" : "", "")
+      );
+      fakeTimer.enableAutoAdvance();
+      const manager = IOSCtrlProxyManager.createForTestingWithDeps(
+        testDevice,
+        fakeTimer,
+        createFakeBuilder(),
+        fakeExecutor
+      );
+
+      await manager.start();
+
+      expect(staleProcess.alive).toBe(false);
+      expect(fakeExecutor.wasCommandExecuted("kill -TERM 2223")).toBe(true);
+      expect(fakeExecutor.wasCommandExecuted("kill -KILL 2223")).toBe(true);
+      expect(fakeExecutor.getSpawnedProcesses()).toHaveLength(1);
+      expect(fakeExecutor.getSpawnedProcesses()[0].options?.env).toMatchObject({
+        CTRL_PROXY_IOS_PORT: "8765",
+        SIMCTL_CHILD_CTRL_PROXY_IOS_PORT: "8765",
+      });
     });
 
     test("start() reallocates when the intended port is held by a foreign process", async function() {

--- a/test/utils/IOSCtrlProxyManager.test.ts
+++ b/test/utils/IOSCtrlProxyManager.test.ts
@@ -1397,6 +1397,49 @@ describe("IOSCtrlProxyManager", function() {
       });
     });
 
+    test("start() reclaims a stale daemon-owned xcodebuild with an orphaned shell parent", async function() {
+      const staleProcess: FakeListeningProcess = {
+        pid: 2225,
+        port: 8765,
+        ppid: 2224,
+        command: `xcodebuild test-without-building -xctestrun /tmp/CtrlProxy.xctestrun -destination platform=iOS Simulator,id=${testDevice.deviceId} -only-testing:CtrlProxyUITests/CtrlProxyUITests/testRunService`,
+        environment: `CTRL_PROXY_IOS_PORT=8765 AUTOMOBILE_DEVICE_ID=${testDevice.deviceId}`,
+        alive: true,
+        ignoreTerm: true,
+      };
+      const orphanedShellProcess: FakeListeningProcess = {
+        pid: 2224,
+        port: 0,
+        ppid: 1,
+        command: `/bin/sh -c ${staleProcess.command} 2>&1`,
+        environment: staleProcess.environment,
+        alive: true,
+      };
+      installListeningProcessFakes(fakeExecutor, [staleProcess, orphanedShellProcess]);
+      fakeExecutor.setCommandResponse("pgrep -x xcodebuild", createExecResult("2225\n", ""));
+      fakeExecutor.setCommandHandler("curl -s", () =>
+        createExecResult(fakeExecutor.getSpawnedProcesses().length > 0 ? "ok" : "", "")
+      );
+      fakeTimer.enableAutoAdvance();
+      const manager = IOSCtrlProxyManager.createForTestingWithDeps(
+        testDevice,
+        fakeTimer,
+        createFakeBuilder(),
+        fakeExecutor
+      );
+
+      await manager.start();
+
+      expect(staleProcess.alive).toBe(false);
+      expect(fakeExecutor.wasCommandExecuted("kill -TERM 2225")).toBe(true);
+      expect(fakeExecutor.wasCommandExecuted("kill -KILL 2225")).toBe(true);
+      expect(fakeExecutor.getSpawnedProcesses()).toHaveLength(1);
+      expect(fakeExecutor.getSpawnedProcesses()[0].options?.env).toMatchObject({
+        CTRL_PROXY_IOS_PORT: "8765",
+        SIMCTL_CHILD_CTRL_PROXY_IOS_PORT: "8765",
+      });
+    });
+
     test("start() reallocates when the intended port is held by a foreign process", async function() {
       const foreignProcess: FakeListeningProcess = {
         pid: 3333,

--- a/test/utils/IOSCtrlProxyManager.test.ts
+++ b/test/utils/IOSCtrlProxyManager.test.ts
@@ -117,6 +117,7 @@ interface FakeListeningProcess {
   pid: number;
   port: number;
   command: string;
+  environment?: string;
   ppid?: number;
   alive: boolean;
   ignoreTerm?: boolean;
@@ -140,6 +141,14 @@ function installListeningProcessFakes(
     const process = processes.find(candidate => candidate.pid === pid && candidate.alive);
     return createExecResult(
       process ? `${process.ppid ?? 1} ${process.command}` : "",
+      ""
+    );
+  });
+  fakeExecutor.setCommandHandler("ps eww -p", command => {
+    const pid = Number(command.match(/ps eww -p\s+(\d+)/)?.[1]);
+    const process = processes.find(candidate => candidate.pid === pid && candidate.alive);
+    return createExecResult(
+      process ? `${process.command} ${process.environment ?? ""}`.trim() : "",
       ""
     );
   });
@@ -1370,6 +1379,75 @@ describe("IOSCtrlProxyManager", function() {
 
       expect(otherSimulatorProcess.alive).toBe(true);
       expect(fakeExecutor.wasCommandExecuted("kill -TERM 3335")).toBe(false);
+      expect(manager.getServicePort()).toBe(8767);
+      expect(PortManager.getPort(testDevice.deviceId)).toBe(8767);
+      expect(fakeExecutor.getSpawnedProcesses()[0].options?.env).toMatchObject({
+        CTRL_PROXY_IOS_PORT: "8767",
+        SIMCTL_CHILD_CTRL_PROXY_IOS_PORT: "8767",
+      });
+    });
+
+    test("start() terminates a stale direct runner identified by environment before spawning", async function() {
+      const staleProcess: FakeListeningProcess = {
+        pid: 3335,
+        port: 8765,
+        command: "/tmp/CtrlProxyUITests-Runner.app/PlugIns/CtrlProxyUITests.xctest/CtrlProxyUITests-Runner",
+        environment: `AUTOMOBILE_DEVICE_ID=${testDevice.deviceId}`,
+        alive: true,
+        ignoreTerm: true,
+      };
+      installListeningProcessFakes(fakeExecutor, [staleProcess]);
+      fakeExecutor.setCommandResponse("pgrep -x xcodebuild", createExecResult("", ""));
+      fakeExecutor.setCommandHandler("curl -s", () =>
+        createExecResult(fakeExecutor.getSpawnedProcesses().length > 0 ? "ok" : "", "")
+      );
+      fakeTimer.enableAutoAdvance();
+      const manager = IOSCtrlProxyManager.createForTestingWithDeps(
+        testDevice,
+        fakeTimer,
+        createFakeBuilder(),
+        fakeExecutor
+      );
+
+      await manager.start();
+
+      expect(staleProcess.alive).toBe(false);
+      expect(fakeExecutor.wasCommandExecuted("kill -TERM 3335")).toBe(true);
+      expect(fakeExecutor.wasCommandExecuted("kill -KILL 3335")).toBe(true);
+      expect(manager.getServicePort()).toBe(8765);
+      expect(fakeExecutor.getSpawnedProcesses()[0].options?.env).toMatchObject({
+        CTRL_PROXY_IOS_PORT: "8765",
+        SIMCTL_CHILD_CTRL_PROXY_IOS_PORT: "8765",
+      });
+    });
+
+    test("start() reallocates instead of killing another simulator's direct runner identified by environment", async function() {
+      const otherSimulatorProcess: FakeListeningProcess = {
+        pid: 3336,
+        port: 8765,
+        command: "/tmp/CtrlProxyUITests-Runner.app/PlugIns/CtrlProxyUITests.xctest/CtrlProxyUITests-Runner",
+        environment: "AUTOMOBILE_DEVICE_ID=OTHER-SIMULATOR",
+        alive: true,
+        ignoreTerm: true,
+        ignoreKill: true,
+      };
+      installListeningProcessFakes(fakeExecutor, [otherSimulatorProcess]);
+      fakeExecutor.setCommandResponse("pgrep -x xcodebuild", createExecResult("", ""));
+      fakeExecutor.setCommandHandler("curl -s", () =>
+        createExecResult(fakeExecutor.getSpawnedProcesses().length > 0 ? "ok" : "", "")
+      );
+      fakeTimer.enableAutoAdvance();
+      const manager = IOSCtrlProxyManager.createForTestingWithDeps(
+        testDevice,
+        fakeTimer,
+        createFakeBuilder(),
+        fakeExecutor
+      );
+
+      await manager.start();
+
+      expect(otherSimulatorProcess.alive).toBe(true);
+      expect(fakeExecutor.wasCommandExecuted("kill -TERM 3336")).toBe(false);
       expect(manager.getServicePort()).toBe(8767);
       expect(PortManager.getPort(testDevice.deviceId)).toBe(8767);
       expect(fakeExecutor.getSpawnedProcesses()[0].options?.env).toMatchObject({

--- a/test/utils/IOSCtrlProxyManager.test.ts
+++ b/test/utils/IOSCtrlProxyManager.test.ts
@@ -1079,6 +1079,50 @@ describe("IOSCtrlProxyManager", function() {
       expect(fakeExecutor.getSpawnedProcesses()).toEqual([]);
     });
 
+    test("start() preserves an externally managed test-without-building runner with environment identity", async function() {
+      const externalProcess: FakeListeningProcess = {
+        pid: 2472,
+        port: 8791,
+        ppid: 2468,
+        command: `xcodebuild test-without-building -xctestrun /tmp/CtrlProxy.xctestrun -destination platform=iOS Simulator,id=${testDevice.deviceId} -only-testing:CtrlProxyUITests/CtrlProxyUITests/testRunService`,
+        environment: `CTRL_PROXY_IOS_PORT=8791 AUTOMOBILE_DEVICE_ID=${testDevice.deviceId}`,
+        alive: true,
+        ignoreTerm: true,
+        ignoreKill: true,
+      };
+      installListeningProcessFakes(fakeExecutor, [externalProcess]);
+      const fakeBuilder = {
+        getXctestrunPath: async () => {
+          throw new Error("should not build when an external CtrlProxy process is reused");
+        },
+        getRunnerBinaryPath: async () => null,
+      } as unknown as import("../../src/utils/IOSCtrlProxyBuilder").IOSCtrlProxyBuilder;
+      const manager = IOSCtrlProxyManager.createForTestingWithDeps(
+        testDevice,
+        fakeTimer,
+        fakeBuilder,
+        fakeExecutor
+      );
+
+      fakeExecutor.setCommandResponse("http://localhost:8765/health", createExecResult("", ""));
+      fakeExecutor.setCommandResponse("http://localhost:8791/health", createExecResult("", ""));
+      fakeExecutor.setCommandResponse("pgrep -x xcodebuild", createExecResult("2472\n", ""));
+      fakeExecutor.setCommandResponse(
+        "ps -p 2472",
+        createExecResult(`${externalProcess.ppid} ${externalProcess.command}`, "")
+      );
+      fakeTimer.enableAutoAdvance();
+
+      await expect(manager.start()).rejects.toThrow("CtrlProxy failed to start within timeout");
+
+      expect(externalProcess.alive).toBe(true);
+      expect(fakeExecutor.wasCommandExecuted("kill -TERM 2472")).toBe(false);
+      expect(fakeExecutor.wasCommandExecuted("kill -KILL 2472")).toBe(false);
+      expect(manager.getServicePort()).toBe(8791);
+      expect(PortManager.getPort(testDevice.deviceId)).toBe(8791);
+      expect(fakeExecutor.getSpawnedProcesses()).toEqual([]);
+    });
+
     test("start() ignores xcodebuild CtrlProxy processes for other simulators", async function() {
       const fakeBuilder = {
         getXctestrunPath: async () => "/tmp/test.xctestrun",
@@ -1324,6 +1368,7 @@ describe("IOSCtrlProxyManager", function() {
         pid: 2223,
         port: 8765,
         command: `xcodebuild test-without-building -xctestrun /tmp/CtrlProxy.xctestrun -destination platform=iOS Simulator,id=${testDevice.deviceId} -only-testing:CtrlProxyUITests/CtrlProxyUITests/testRunService`,
+        environment: `CTRL_PROXY_IOS_PORT=8765 AUTOMOBILE_DEVICE_ID=${testDevice.deviceId}`,
         alive: true,
         ignoreTerm: true,
       };


### PR DESCRIPTION
## Summary

- Rebase the iOS CtrlProxy startup port recovery work onto `main` after #2716 merged.
- Preserve externally managed hot-reload runners by checking for them before stale-port cleanup.
- Reallocate around other simulators' runners instead of killing them, while terminating stale direct `CtrlProxyUITests-Runner` processes when their environment identifies the current simulator.
- Reap orphaned iOS CtrlProxy `xcodebuild` and direct runner processes at daemon startup and include PID/command details when recovery cannot free a port.

Supersedes #2712
Closes #2692

## Testing

- `bun test test/utils/IOSCtrlProxyManager.test.ts`
- `bun run lint`
- `bun run build`

## Review

- Addressed the unresolved Codex review feedback from #2712.
- Ran `/auto-mobile-code-review` against the current branch diff; no additional findings.
