### PR TITLE
[codex] Split daemon and stdio log files

### DIFF
--- a/docs/design-docs/mcp/daemon/multi-agent-filesystem-contract.md
+++ b/docs/design-docs/mcp/daemon/multi-agent-filesystem-contract.md
@@ -55,7 +55,8 @@ single writer in its own tree.
 | `${TMPDIR}/auto-mobile/cache/screen-size` | N | `md5(deviceId).json` — per-device, content is stable; concurrent writes are idempotent. (No longer CWD-relative.) |
 | daemon control socket / PID / lock | 1 (daemon) | discovered by clients via env — see §2. |
 | auxiliary sockets (video, snapshot, …) | 1 (daemon) | path depends on `AUTOMOBILE_EMULATOR_EXTERNAL`. |
-| `${TMPDIR}/auto-mobile/logs/server-<pid>.log` | 1 each | per-process file; pruning only trims this pid's files + sweeps stale others by mtime. |
+| `${TMPDIR}/auto-mobile/logs/daemon.log` | 1 daemon | stable daemon log; rotated files are `daemon-<timestamp>.log`. |
+| `${TMPDIR}/auto-mobile/logs/stdio-<pid>.log` | 1 each | per-stdio-client file; pruning only trims this pid's files + sweeps stale others by mtime. |
 | `${TMPDIR}/auto-mobile/tool_logs` (`LOG_DIR`) | N | routed through `tempDir` (honors `TMPDIR`). |
 | `mkdtemp(...)` APK / prefetch / per-start daemon log dirs | per-call unique | **already safe** (random suffix). |
 
@@ -168,9 +169,10 @@ those are explicitly pinned, single-writer, and not derived from `TMPDIR`.
 If you instead run all agents under a **shared `TMPDIR`**, the code still avoids
 cross-agent data loss as defense-in-depth:
 
-- **Logs** are per-pid (`server-<pid>.log`); pruning only trims this pid's files
-  plus others already **stale by mtime** — never another live process's current
-  file (`logPruner.ts`).
+- **Logs** are role-scoped (`daemon.log` for the daemon, `stdio-<pid>.log` for
+  client processes); pruning only trims this process's files plus stdio logs
+  whose owner PID has exited and whose mtime is stale — never another live
+  process's current file (`logPruner.ts`).
 - **Screenshots** are evicted oldest-first only when over the size cap, and the
   eviction is **age-gated** (`screenshotCacheEviction.ts`) so a peer's recent /
   in-flight frame is never deleted.

--- a/src/daemon/daemon.ts
+++ b/src/daemon/daemon.ts
@@ -189,8 +189,9 @@ export class Daemon {
    * Start the daemon
    */
   async start(): Promise<void> {
-    // Enable stdout logging in daemon mode so logs appear in daemon.log file
-    // (daemon's stdout/stderr are redirected to /tmp/auto-mobile-daemon-XXXXXX/daemon.log)
+    // Mirror structured daemon logs to stdout/stderr capture as well. The
+    // primary stable log is `${TMPDIR}/auto-mobile/logs/daemon.log`; the
+    // daemon manager also redirects stdout/stderr to a per-start capture file.
     logger.enableStdoutLogging();
     const stableWorkingDirectory = resolveStableDaemonWorkingDirectory();
     process.env[DAEMON_LAUNCH_CWD_ENV] ??= safeProcessCwd(stableWorkingDirectory);

--- a/src/utils/logPruner.ts
+++ b/src/utils/logPruner.ts
@@ -4,7 +4,7 @@ import { readdirAsync, statAsync, unlinkAsync } from "./io";
 export interface LogPruneOptions {
   /** Directory containing the `.log` files. */
   dir: string;
-  /** Prefix identifying the current process's files, e.g. `server-12345` (no trailing `.`/`-`). */
+  /** Prefix identifying the current process's files, e.g. `stdio-12345` or `daemon` (no trailing `.`/`-`). */
   ownPrefix: string;
   /** Cap on the number of this process's own files to retain. */
   maxOwnFiles: number;
@@ -28,16 +28,16 @@ function defaultIsProcessAlive(pid: number): boolean {
 
 /**
  * Whether `file` belongs to `ownPrefix`, matched on an exact PID boundary so
- * `server-12` never claims `server-123`'s files. Filenames are `server-<pid>.log`
- * (active) and `server-<pid>-<ts>.log` (rotated).
+ * `stdio-12` never claims `stdio-123`'s files. Filenames are
+ * `<prefix>.log` (active) and `<prefix>-<ts>.log` (rotated).
  */
 function isOwnedBy(file: string, ownPrefix: string): boolean {
   return file === `${ownPrefix}.log` || file.startsWith(`${ownPrefix}-`);
 }
 
-/** Parse the owning PID from `server-<pid>.log` / `server-<pid>-<ts>.log`. */
+/** Parse the owning PID from `stdio-<pid>.log` / `stdio-<pid>-<ts>.log`. */
 function ownerPid(file: string): number | undefined {
-  const match = /^server-(\d+)(?:-.*)?\.log$/.exec(file);
+  const match = /^(?:stdio|server)-(\d+)(?:-.*)?\.log$/.exec(file);
   return match ? Number(match[1]) : undefined;
 }
 
@@ -51,7 +51,7 @@ function ownerPid(file: string): number | undefined {
  *      alive AND the file is stale by mtime.
  *
  * (b)'s liveness gate is essential: a still-running process can have a quiet
- * `server-<pid>.log` whose mtime is hours old, and the writer keeps appending to
+ * `stdio-<pid>.log` whose mtime is hours old, and the writer keeps appending to
  * the open fd. Deleting it by mtime alone would silently drop that live process's
  * diagnostics. So a peer's log is only removed once its process has exited.
  */
@@ -81,7 +81,10 @@ export async function pruneLogFiles(opts: LogPruneOptions): Promise<void> {
       continue;
     }
     const pid = ownerPid(file);
-    if (pid !== undefined && isAlive(pid)) {
+    if (pid === undefined) {
+      continue;
+    }
+    if (isAlive(pid)) {
       continue; // live peer — never touch its log, even if its mtime is old.
     }
     const full = path.join(opts.dir, file);

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -97,6 +97,10 @@ export function parseAutomobileLogLevel(value: string | undefined): LogLevel | n
   }
 }
 
+export function resolveProcessLogPrefix(argv: readonly string[], pid: number): string {
+  return argv.includes("--daemon-mode") ? "daemon" : `stdio-${pid}`;
+}
+
 // Default to INFO level in production, can be overridden
 let currentLogLevel: LogLevel = LogLevel.INFO;
 
@@ -114,12 +118,10 @@ ensureDirExists(logsDir).catch(err => {
   console.error("Failed to create logs directory:", err);
 });
 
-// Per-process log file. On a shared host many auto-mobile processes (one stdio
-// proxy per agent + the daemon) run in parallel and previously all appended to a
-// single `server.log`, interleaving and corrupting each other's output and
-// racing on rotation. Keying the filename by PID gives each process its own file
-// and clean per-process attribution.
-const ownLogPrefix = `server-${process.pid}`;
+// The daemon is single-owner, so keep its stable log name easy to document and
+// tail. Stdio/client processes remain PID-scoped because several can run in
+// parallel on the same host.
+const ownLogPrefix = resolveProcessLogPrefix(process.argv, process.pid);
 const logFilePath = path.join(logsDir, `${ownLogPrefix}.log`);
 let logStream = fs.createWriteStream(logFilePath, { flags: "a" });
 

--- a/test/daemon/loggerPrune.test.ts
+++ b/test/daemon/loggerPrune.test.ts
@@ -30,36 +30,36 @@ describe("pruneLogFiles", () => {
     tempDirs.length = 0;
   });
 
-  test("caps this process's own files and preserves the active server-<pid>.log", async () => {
+  test("caps this process's own files and preserves the active stdio-<pid>.log", async () => {
     const logsDir = createTempLogsDir();
     for (let i = 0; i < 15; i++) {
-      writeFileSync(join(logsDir, `server-111-2026-04-01T${String(i).padStart(2, "0")}.log`), "x");
+      writeFileSync(join(logsDir, `stdio-111-2026-04-01T${String(i).padStart(2, "0")}.log`), "x");
     }
-    writeFileSync(join(logsDir, "server-111.log"), "active");
+    writeFileSync(join(logsDir, "stdio-111.log"), "active");
 
-    await pruneLogFiles({ dir: logsDir, ownPrefix: "server-111", maxOwnFiles: 10, abandonedMaxAgeMs: 1e12, isProcessAlive: dead });
+    await pruneLogFiles({ dir: logsDir, ownPrefix: "stdio-111", maxOwnFiles: 10, abandonedMaxAgeMs: 1e12, isProcessAlive: dead });
 
     const remaining = readdirSync(logsDir).filter(f => f.endsWith(".log"));
     expect(remaining.length).toBe(10);
-    // "server-111.log" sorts after "server-111-..." so the active file survives.
-    expect(remaining).toContain("server-111.log");
+    // "stdio-111.log" sorts after "stdio-111-..." so the active file survives.
+    expect(remaining).toContain("stdio-111.log");
   });
 
-  test("matches own files on an exact PID boundary (server-12 does not claim server-123)", async () => {
+  test("matches own files on an exact PID boundary (stdio-12 does not claim stdio-123)", async () => {
     const logsDir = createTempLogsDir();
     // This process is pid 12; a peer is pid 123 (a prefix collision under startsWith).
     for (let i = 0; i < 15; i++) {
-      writeFileSync(join(logsDir, `server-12-${String(i).padStart(2, "0")}.log`), "x");
+      writeFileSync(join(logsDir, `stdio-12-${String(i).padStart(2, "0")}.log`), "x");
     }
-    writeFileSync(join(logsDir, "server-12.log"), "active");
+    writeFileSync(join(logsDir, "stdio-12.log"), "active");
     for (let i = 0; i < 5; i++) {
-      writeFileSync(join(logsDir, `server-123-${i}.log`), "peer");
+      writeFileSync(join(logsDir, `stdio-123-${i}.log`), "peer");
     }
 
     // Peer 123 is alive → must be untouched; own cap trims only pid-12 files.
     await pruneLogFiles({
       dir: logsDir,
-      ownPrefix: "server-12",
+      ownPrefix: "stdio-12",
       maxOwnFiles: 10,
       abandonedMaxAgeMs: 1_000,
       now: Date.now() + 1e9,
@@ -67,93 +67,126 @@ describe("pruneLogFiles", () => {
     });
 
     const remaining = readdirSync(logsDir);
-    const peerFiles = remaining.filter(f => f.startsWith("server-123"));
-    const ownFiles = remaining.filter(f => /^server-12(\.log|-)/.test(f));
+    const peerFiles = remaining.filter(f => f.startsWith("stdio-123"));
+    const ownFiles = remaining.filter(f => /^stdio-12(\.log|-)/.test(f));
     expect(peerFiles.length).toBe(5);   // peer's files never claimed/deleted
     expect(ownFiles.length).toBe(10);   // only own pid-12 files capped
   });
 
   test("never deletes a LIVE peer's log even when its mtime is stale", async () => {
     const logsDir = createTempLogsDir();
-    writeFileSync(join(logsDir, "server-222.log"), "quiet but alive");
+    writeFileSync(join(logsDir, "stdio-222.log"), "quiet but alive");
 
     await pruneLogFiles({
       dir: logsDir,
-      ownPrefix: "server-111",
+      ownPrefix: "stdio-111",
       maxOwnFiles: 10,
       abandonedMaxAgeMs: 1_000,
       now: Date.now() + 1e9, // far future → mtime looks ancient
       isProcessAlive: pid => pid === 222, // owner still running
     });
 
-    expect(readdirSync(logsDir)).toContain("server-222.log");
+    expect(readdirSync(logsDir)).toContain("stdio-222.log");
   });
 
   test("sweeps an EXITED process's stale log", async () => {
     const logsDir = createTempLogsDir();
     for (let i = 0; i < 5; i++) {
-      writeFileSync(join(logsDir, `server-222-${i}.log`), "x");
+      writeFileSync(join(logsDir, `stdio-222-${i}.log`), "x");
     }
 
     await pruneLogFiles({
       dir: logsDir,
-      ownPrefix: "server-111",
+      ownPrefix: "stdio-111",
       maxOwnFiles: 10,
       abandonedMaxAgeMs: 1_000,
       now: Date.now() + 60_000,
       isProcessAlive: dead,
     });
 
-    expect(readdirSync(logsDir).filter(f => f.startsWith("server-222")).length).toBe(0);
+    expect(readdirSync(logsDir).filter(f => f.startsWith("stdio-222")).length).toBe(0);
   });
 
   test("keeps an exited process's RECENT log (mtime grace before sweeping)", async () => {
     const logsDir = createTempLogsDir();
     for (let i = 0; i < 5; i++) {
-      writeFileSync(join(logsDir, `server-222-${i}.log`), "x");
+      writeFileSync(join(logsDir, `stdio-222-${i}.log`), "x");
     }
     const baseNow = Date.now();
 
     await pruneLogFiles({
       dir: logsDir,
-      ownPrefix: "server-111",
+      ownPrefix: "stdio-111",
       maxOwnFiles: 10,
       abandonedMaxAgeMs: 60_000,
       now: baseNow,
       isProcessAlive: dead,
     });
 
-    expect(readdirSync(logsDir).filter(f => f.startsWith("server-222")).length).toBe(5);
+    expect(readdirSync(logsDir).filter(f => f.startsWith("stdio-222")).length).toBe(5);
+  });
+
+  test("preserves daemon logs when pruning from a stdio process", async () => {
+    const logsDir = createTempLogsDir();
+    writeFileSync(join(logsDir, "daemon.log"), "active daemon");
+    writeFileSync(join(logsDir, "daemon-2026-04-01T00.log"), "rotated daemon");
+
+    await pruneLogFiles({
+      dir: logsDir,
+      ownPrefix: "stdio-111",
+      maxOwnFiles: 10,
+      abandonedMaxAgeMs: 1_000,
+      now: Date.now() + 1e9,
+      isProcessAlive: dead,
+    });
+
+    const remaining = readdirSync(logsDir);
+    expect(remaining).toContain("daemon.log");
+    expect(remaining).toContain("daemon-2026-04-01T00.log");
+  });
+
+  test("caps daemon logs and preserves the active daemon.log", async () => {
+    const logsDir = createTempLogsDir();
+    for (let i = 0; i < 15; i++) {
+      writeFileSync(join(logsDir, `daemon-2026-04-01T${String(i).padStart(2, "0")}.log`), "x");
+    }
+    writeFileSync(join(logsDir, "daemon.log"), "active");
+
+    await pruneLogFiles({ dir: logsDir, ownPrefix: "daemon", maxOwnFiles: 10, abandonedMaxAgeMs: 1e12, isProcessAlive: dead });
+
+    const remaining = readdirSync(logsDir).filter(f => f.endsWith(".log"));
+    expect(remaining.length).toBe(10);
+    expect(remaining).toContain("daemon.log");
   });
 
   test("no-op when own count is at or below the cap", async () => {
     const logsDir = createTempLogsDir();
     for (let i = 0; i < 10; i++) {
-      writeFileSync(join(logsDir, `server-111-${i}.log`), "x");
+      writeFileSync(join(logsDir, `stdio-111-${i}.log`), "x");
     }
 
-    await pruneLogFiles({ dir: logsDir, ownPrefix: "server-111", maxOwnFiles: 10, abandonedMaxAgeMs: 1e12, isProcessAlive: dead });
+    await pruneLogFiles({ dir: logsDir, ownPrefix: "stdio-111", maxOwnFiles: 10, abandonedMaxAgeMs: 1e12, isProcessAlive: dead });
 
     expect(readdirSync(logsDir).filter(f => f.endsWith(".log")).length).toBe(10);
   });
 
   test("no-op (no throw) when directory is empty or missing", async () => {
     const logsDir = createTempLogsDir();
-    await pruneLogFiles({ dir: logsDir, ownPrefix: "server-111", maxOwnFiles: 10, abandonedMaxAgeMs: 1000, isProcessAlive: dead });
+    await pruneLogFiles({ dir: logsDir, ownPrefix: "stdio-111", maxOwnFiles: 10, abandonedMaxAgeMs: 1000, isProcessAlive: dead });
     expect(readdirSync(logsDir).length).toBe(0);
 
-    await pruneLogFiles({ dir: join(logsDir, "does-not-exist"), ownPrefix: "server-111", maxOwnFiles: 10, abandonedMaxAgeMs: 1000, isProcessAlive: dead });
+    await pruneLogFiles({ dir: join(logsDir, "does-not-exist"), ownPrefix: "stdio-111", maxOwnFiles: 10, abandonedMaxAgeMs: 1000, isProcessAlive: dead });
   });
 
   test("ignores non-log files", async () => {
     const logsDir = createTempLogsDir();
     for (let i = 0; i < 15; i++) {
-      writeFileSync(join(logsDir, `server-111-${i}.log`), "x");
+      writeFileSync(join(logsDir, `stdio-111-${i}.log`), "x");
     }
     writeFileSync(join(logsDir, "config.json"), "not a log");
     writeFileSync(join(logsDir, "notes.txt"), "not a log");
 
-    await pruneLogFiles({ dir: logsDir, ownPrefix: "server-111", maxOwnFiles: 10, abandonedMaxAgeMs: 1e12, isProcessAlive: dead });
+    await pruneLogFiles({ dir: logsDir, ownPrefix: "stdio-111", maxOwnFiles: 10, abandonedMaxAgeMs: 1e12, isProcessAlive: dead });
 
     const allFiles = readdirSync(logsDir);
     expect(allFiles.filter(f => f.endsWith(".log")).length).toBe(10);

--- a/test/utils/logger-loglevel-env.test.ts
+++ b/test/utils/logger-loglevel-env.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { LogLevel, parseAutomobileLogLevel } from "../../src/utils/logger";
+import { LogLevel, parseAutomobileLogLevel, resolveProcessLogPrefix } from "../../src/utils/logger";
 
 describe("parseAutomobileLogLevel", () => {
   test("returns null for unset or blank", () => {
@@ -21,5 +21,15 @@ describe("parseAutomobileLogLevel", () => {
   test("returns null for garbage", () => {
     expect(parseAutomobileLogLevel("verbose")).toBeNull();
     expect(parseAutomobileLogLevel("infoo")).toBeNull();
+  });
+});
+
+describe("resolveProcessLogPrefix", () => {
+  test("uses stable daemon prefix in daemon mode", () => {
+    expect(resolveProcessLogPrefix(["auto-mobile", "--daemon-mode"], 123)).toBe("daemon");
+  });
+
+  test("uses pid-scoped stdio prefix outside daemon mode", () => {
+    expect(resolveProcessLogPrefix(["auto-mobile"], 123)).toBe("stdio-123");
   });
 });


### PR DESCRIPTION
## Summary

- rename structured daemon logs to the stable `${TMPDIR}/auto-mobile/logs/daemon.log`
- rename stdio/client process logs to `${TMPDIR}/auto-mobile/logs/stdio-<pid>.log`
- update log pruning and docs for the new role-scoped filenames

## Why

The previous `server-<pid>.log` naming made it hard to point contributors at the daemon log. The daemon is single-owner, so it can use a stable filename while stdio clients remain PID-scoped for concurrent safety.

## Validation

```bash
bun test test/daemon/loggerPrune.test.ts test/utils/logger-loglevel-env.test.ts
bun run build
```
