### PR TITLE
fix(ios): skip open -a Simulator on headless hosts (#2721)

### DIFF
--- a/src/utils/ios-cmdline-tools/SimCtlClient.ts
+++ b/src/utils/ios-cmdline-tools/SimCtlClient.ts
@@ -358,6 +358,8 @@ export class SimCtlClient implements SimCtl {
   private timer: Timer;
   private platform: NodeJS.Platform;
   private readonly usesInjectedExecAsync: boolean;
+  // Cached result of the launchctl headless-session probe (null = not yet probed)
+  private headlessSessionCache: boolean | null = null;
 
   // Static cache for device list
   private static deviceListCache: { devices: DeviceInfo[], timestamp: number } | null = null;
@@ -597,20 +599,13 @@ export class SimCtlClient implements SimCtl {
     await this.executeCommand(`boot ${udid}`);
     perf.endOperation("simctlBoot");
 
-    // Open Simulator.app focused on this specific device
+    // Open Simulator.app focused on this specific device (no-op on headless hosts)
     try {
       perf.startOperation("openSimulatorApp");
       await this.openSimulatorApp(udid);
       perf.endOperation("openSimulatorApp");
     } catch {
       perf.endOperation("openSimulatorApp");
-      logger.debug("Could not open Simulator.app (non-fatal)");
-    }
-
-    // Open Simulator.app focused on this specific device
-    try {
-      await this.openSimulatorApp(udid);
-    } catch {
       logger.debug("Could not open Simulator.app (non-fatal)");
     }
 
@@ -1110,6 +1105,15 @@ export class SimCtlClient implements SimCtl {
   }
 
   async openSimulatorApp(udid?: string): Promise<void> {
+    // On a headless macOS host (no Aqua GUI session, e.g. a launchd daemon or
+    // SSH context) `open -a Simulator` fails with OSLaunchdErrorDomain Code=125
+    // after a slow retry, wasting wall-clock against the daemon-start budget.
+    // The booted simulator + CtrlProxy work without the GUI, so skip the launch.
+    if (await this.isHeadlessSession()) {
+      logger.debug("Skipping open -a Simulator: headless session (no Aqua GUI)");
+      return;
+    }
+
     // Ensure Simulator.app is open (creates windows for all booted devices)
     await this.execAsync("open", ["-a", "Simulator"]);
     // If a specific device is requested, focus it by switching to it
@@ -1119,6 +1123,50 @@ export class SimCtlClient implements SimCtl {
       try {
         await this.execAsync("osascript", ["-e", 'tell application "Simulator" to activate']);
       } catch { /* non-fatal */ }
+    }
+  }
+
+  /**
+   * Determine whether the current host can launch the Simulator GUI.
+   *
+   * Resolution order:
+   *  1. `AUTOMOBILE_IOS_HEADLESS` env override (`true`/`1` => headless,
+   *     `false`/`0` => force GUI launch).
+   *  2. Non-darwin platforms are always headless (Simulator.app is macOS-only).
+   *  3. Auto-detect via `launchctl managername`: an `Aqua` manager means a GUI
+   *     login session; anything else (`System`/`Background`) is a daemon/SSH
+   *     context with no GUI domain.
+   *
+   * If detection itself fails we assume a GUI session to preserve the prior
+   * behavior. The result is cached so launchctl is probed at most once.
+   */
+  private async isHeadlessSession(): Promise<boolean> {
+    const override = process.env.AUTOMOBILE_IOS_HEADLESS;
+    if (override !== undefined) {
+      return override === "true" || override === "1";
+    }
+
+    if (this.platform !== "darwin") {
+      return true;
+    }
+
+    if (this.headlessSessionCache === null) {
+      this.headlessSessionCache = await this.detectHeadlessSession();
+    }
+    return this.headlessSessionCache;
+  }
+
+  private async detectHeadlessSession(): Promise<boolean> {
+    try {
+      const result = await this.execAsync("launchctl", ["managername"]);
+      const managerName = (result.stdout || "").trim();
+      // "Aqua" is the GUI login session manager; "System"/"Background" are not.
+      return managerName !== "Aqua";
+    } catch (error) {
+      // Can't determine the session type; assume a GUI session so we preserve
+      // the historical behavior rather than silently suppressing the launch.
+      logger.debug(`launchctl managername probe failed, assuming GUI session: ${error}`);
+      return false;
     }
   }
 }

--- a/test/utils/ios-cmdline-tools/simctl.test.ts
+++ b/test/utils/ios-cmdline-tools/simctl.test.ts
@@ -457,4 +457,105 @@ describe("Simctl", function() {
       await expect(simctl.getDeviceTypes()).rejects.toThrow();
     });
   });
+
+  describe("openSimulatorApp headless detection", function() {
+    const HEADLESS_ENV = "AUTOMOBILE_IOS_HEADLESS";
+    let savedEnv: string | undefined;
+    let calls: Array<{ file: string; args: string[] }>;
+
+    function recordingExec(managerName: string | Error = "Aqua"): typeof mockExecAsync {
+      return async (file: string, args: string[]): Promise<ExecResult> => {
+        calls.push({ file, args });
+        if (file === "launchctl" && args[0] === "managername") {
+          if (managerName instanceof Error) {
+            throw managerName;
+          }
+          return createExecResult(`${managerName}\n`, "");
+        }
+        return createExecResult("", "");
+      };
+    }
+
+    function openCalls(): Array<{ file: string; args: string[] }> {
+      return calls.filter(c => c.file === "open" && c.args[0] === "-a" && c.args[1] === "Simulator");
+    }
+
+    function launchctlCalls(): Array<{ file: string; args: string[] }> {
+      return calls.filter(c => c.file === "launchctl" && c.args[0] === "managername");
+    }
+
+    beforeEach(function() {
+      savedEnv = process.env[HEADLESS_ENV];
+      delete process.env[HEADLESS_ENV];
+      calls = [];
+    });
+
+    function restoreEnv(): void {
+      if (savedEnv === undefined) {
+        delete process.env[HEADLESS_ENV];
+      } else {
+        process.env[HEADLESS_ENV] = savedEnv;
+      }
+    }
+
+    test("skips open -a Simulator when AUTOMOBILE_IOS_HEADLESS=true (no launchctl probe)", async function() {
+      process.env[HEADLESS_ENV] = "true";
+      try {
+        simctl = new Simctl(null, recordingExec("Aqua"), null, new FakeTimer(), "darwin");
+        await simctl.openSimulatorApp();
+        expect(openCalls()).toHaveLength(0);
+        expect(launchctlCalls()).toHaveLength(0);
+      } finally {
+        restoreEnv();
+      }
+    });
+
+    test("forces open -a Simulator when AUTOMOBILE_IOS_HEADLESS=false even if session is non-Aqua", async function() {
+      process.env[HEADLESS_ENV] = "false";
+      try {
+        simctl = new Simctl(null, recordingExec("System"), null, new FakeTimer(), "darwin");
+        await simctl.openSimulatorApp();
+        expect(openCalls()).toHaveLength(1);
+        expect(launchctlCalls()).toHaveLength(0);
+      } finally {
+        restoreEnv();
+      }
+    });
+
+    test("calls open -a Simulator when launchctl reports an Aqua GUI session", async function() {
+      simctl = new Simctl(null, recordingExec("Aqua"), null, new FakeTimer(), "darwin");
+      await simctl.openSimulatorApp();
+      expect(launchctlCalls()).toHaveLength(1);
+      expect(openCalls()).toHaveLength(1);
+    });
+
+    test("skips open -a Simulator when launchctl reports a non-Aqua (headless) session", async function() {
+      simctl = new Simctl(null, recordingExec("System"), null, new FakeTimer(), "darwin");
+      await simctl.openSimulatorApp();
+      expect(launchctlCalls()).toHaveLength(1);
+      expect(openCalls()).toHaveLength(0);
+    });
+
+    test("skips open -a Simulator on non-darwin platforms without any exec", async function() {
+      simctl = new Simctl(null, recordingExec("Aqua"), null, new FakeTimer(), "linux");
+      await simctl.openSimulatorApp();
+      expect(calls).toHaveLength(0);
+    });
+
+    test("attempts open -a Simulator when launchctl probe fails (safe fallback)", async function() {
+      simctl = new Simctl(null, recordingExec(new Error("launchctl unavailable")), null, new FakeTimer(), "darwin");
+      await simctl.openSimulatorApp();
+      expect(launchctlCalls()).toHaveLength(1);
+      expect(openCalls()).toHaveLength(1);
+    });
+
+    test("caches the headless detection so launchctl is probed at most once", async function() {
+      simctl = new Simctl(null, recordingExec("Aqua"), null, new FakeTimer(), "darwin");
+      await simctl.openSimulatorApp();
+      await simctl.openSimulatorApp();
+      await simctl.openSimulatorApp();
+      expect(launchctlCalls()).toHaveLength(1);
+      expect(openCalls()).toHaveLength(3);
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Fixes #2721. On a **headless macOS host** (no Aqua/GUI login session — a `launchd` system daemon or SSH context), the daemon's `openSimulatorApp()` unconditionally ran `open -a Simulator`, which fails with `OSLaunchdErrorDomain Code=125` ("Domain does not support specified action") after a slow RBS launch attempt. That wasted wall-clock pushed cold daemon startup past the 10s `doctor` budget, producing spurious `Daemon failed to start within 10000ms` failures even though the simulator was already booted and healthy.

This implements the issue's primary suggested fix: **detect a headless session and skip the GUI launch entirely**, operating against the already-booted simulator + CtrlProxy without bringing up Simulator.app.

## Changes

- `SimCtlClient.openSimulatorApp()` now early-returns (no-op) on a headless session, skipping both `open -a Simulator` and the `osascript ... activate` follow-up.
- New `isHeadlessSession()` resolution order:
  1. `AUTOMOBILE_IOS_HEADLESS` env override (`true`/`1` → headless, `false`/`0` → force GUI launch).
  2. Non-`darwin` platforms are always headless (Simulator.app is macOS-only).
  3. Auto-detect via `launchctl managername` — `Aqua` = GUI login session; `System`/`Background` = daemon/SSH context with no GUI domain.
  - If the probe itself fails, assume a GUI session (preserves prior behavior). Result is cached so launchctl is probed at most once per instance.
- Removed a redundant duplicate `openSimulatorApp(udid)` call in `startSimulator` that doubled the wasted latency in exactly this scenario.

## Tests

Added `openSimulatorApp headless detection` suite (Interface + Fake + `FakeTimer`, no real device/network, 21 tests in ~37ms):
- `AUTOMOBILE_IOS_HEADLESS=true` → no `open`, no launchctl probe.
- `AUTOMOBILE_IOS_HEADLESS=false` → `open` called even when launchctl reports non-Aqua.
- launchctl `Aqua` → `open` called; `System` → skipped.
- non-darwin → skipped with no exec at all.
- launchctl probe throws → `open` still attempted (safe fallback).
- detection cached → launchctl probed ≤1× across repeated calls.

Existing `DeviceSessionManager` openSimulatorApp tests still pass (25/25).

## Validation

- `bun test` for `simctl.test.ts` (21 pass) and `DeviceSessionManager.test.ts` (25 pass)
- `npx turbo run build` ✓, `eslint` on changed files ✓
- `scripts/all_fast_validate_checks.sh` → 10/10 pass

## Notes / scope

The issue's trace also shows a separate `Timeout after 5000ms` CtrlProxy WebSocket wait contributing to the cold-start overrun. That is a distinct concern and is intentionally out of scope here — this PR addresses the issue's named root trigger (`open -a Simulator → Code=125`) and primary requested fix (don't require a foreground Simulator GUI on a headless host).
