### PR TITLE
fix(daemon): raise openLink timeout default and reconcile post-timeout success

### DIFF
--- a/docs/design-docs/mcp/daemon/unix-socket-api.md
+++ b/docs/design-docs/mcp/daemon/unix-socket-api.md
@@ -34,7 +34,7 @@ All messages are newline-delimited JSON sent over the Unix socket. Each request 
 | `type` | `"mcp_request" \| "daemon_request"` | Yes | Request category |
 | `method` | `string` | Yes | Endpoint name (e.g. `ide/ping`, `daemon/availableDevices`) |
 | `params` | `object` | Yes | Method-specific parameters; pass `{}` when none are needed |
-| `timeoutMs` | `number` | No | Per-request timeout in milliseconds (default: 30 000). Long-running `tools/call` requests may be raised to a tool-specific minimum timeout by the daemon. `openLink` can be configured with `AUTOMOBILE_OPEN_LINK_MCP_TIMEOUT_MS` (legacy alias: `AUTO_MOBILE_OPEN_LINK_MCP_TIMEOUT_MS`), defaulting to 30 000 ms. |
+| `timeoutMs` | `number` | No | Per-request timeout in milliseconds (default: 30 000). Long-running `tools/call` requests may be raised to a tool-specific minimum timeout by the daemon (see [Tool-specific timeout floors](#tool-specific-timeout-floors)). |
 
 **Response**
 
@@ -281,6 +281,35 @@ Calls a registered MCP tool by name.
 | `arguments` | `object` | Yes | Tool-specific arguments |
 
 **Result:** standard MCP `CallToolResult`.
+
+#### Tool-specific timeout floors
+
+Some `tools/call` operations routinely run longer than the 30 000 ms default. For
+these, the daemon raises the effective timeout to a per-tool **floor** — the
+request still uses `max(timeoutMs, floor)`, so a caller-supplied `timeoutMs` above
+the floor is preserved, but a shorter one (or none) is lifted to the floor rather
+than aborting work that is still in progress.
+
+| Tool | Default floor | Override |
+|---|---|---|
+| `executePlan` | 600 000 ms | — |
+| `startDevice` | 180 000 ms | — |
+| `launchApp` | 90 000 ms | — |
+| `openLink` | 90 000 ms | `AUTOMOBILE_OPEN_LINK_MCP_TIMEOUT_MS` (legacy alias: `AUTO_MOBILE_OPEN_LINK_MCP_TIMEOUT_MS`) |
+
+`openLink`'s floor is configurable because a deeplink can launch the app and then
+block on a backend round-trip (sign-in / token exchange). Set
+`AUTOMOBILE_OPEN_LINK_MCP_TIMEOUT_MS` to a higher millisecond value on the daemon
+process for deployments with even slower deeplinks; values at or below the 90 000 ms
+default, or non-numeric values, are ignored.
+
+> **Post-timeout semantics.** A request that exceeds its (possibly raised) timeout
+> returns `MCP error -32001: Request timed out` to the caller. The underlying tool
+> may still finish afterward; when it does, the daemon logs the late result at
+> `WARN` noting it "completed after the caller's request already timed out" rather
+> than emitting a contradictory `success=true`. Treat the `-32001` timeout as the
+> authoritative outcome for that call and re-`observe` to confirm device state if
+> needed.
 
 ---
 

--- a/src/daemon/mcpRequestTimeout.ts
+++ b/src/daemon/mcpRequestTimeout.ts
@@ -29,11 +29,15 @@ export const MIN_LAUNCH_APP_MCP_TIMEOUT_MS = 90_000;
 
 /**
  * Floor for `openLink` — deep links can trigger sign-in, onboarding, data sync,
- * or other post-open navigation before the final observation settles. Keep the
- * default at the standard request timeout, while allowing deployments with slow
- * deeplinks to raise it without changing callers.
+ * or other post-open navigation before the final observation settles. A sign-in
+ * deeplink that launches the app and performs a backend token exchange was
+ * observed taking ~45s end to end (issue #2723), exceeding the 30s standard
+ * timeout and aborting a link-open that actually succeeded on screen. Default to
+ * the same 90s window as `launchApp` (openLink frequently launches the app too),
+ * while allowing deployments with even slower deeplinks to raise it via env var
+ * without changing callers.
  */
-export const DEFAULT_OPEN_LINK_MCP_TIMEOUT_MS = DEFAULT_MCP_REQUEST_TIMEOUT_MS;
+export const DEFAULT_OPEN_LINK_MCP_TIMEOUT_MS = 90_000;
 export const OPEN_LINK_MCP_TIMEOUT_ENV_VAR = "AUTOMOBILE_OPEN_LINK_MCP_TIMEOUT_MS";
 export const LEGACY_OPEN_LINK_MCP_TIMEOUT_ENV_VAR = "AUTO_MOBILE_OPEN_LINK_MCP_TIMEOUT_MS";
 

--- a/src/server/toolRegistry.ts
+++ b/src/server/toolRegistry.ts
@@ -22,6 +22,7 @@ import { isDevicePoolAutolockEnabled } from "../daemon/poolConfig";
 import { isDebugModeEnabled } from "../utils/debug";
 import { defaultTimer, type Timer } from "../utils/SystemTimer";
 import { getMcpRecorder } from "./mcpRecordingManager";
+import { formatToolResultLog } from "./toolResultLog";
 import { flattenTopLevelUnion } from "./TopLevelUnionFlattener";
 
 // Re-exported for backward compatibility; the implementation now lives in
@@ -383,7 +384,16 @@ class ToolRegistryClass {
             ? String(unwrapped.error || "")
             : null;
           if (unwrapped && typeof unwrapped === "object" && "success" in unwrapped) {
-            logger.info(`[ToolRegistry] ${name} result: success=${unwrapped.success}${unwrapped.success === false ? `, error=${unwrapped.error || "unknown"}` : ""}`);
+            // If the caller's request already timed out (signal aborted), the late
+            // result contradicts the timeout they received — surface it as a warning
+            // rather than a bare success=true. See issue #2723.
+            const resultLog = formatToolResultLog({
+              toolName: name,
+              success: unwrapped.success !== false,
+              error: unwrapped.error,
+              callerTimedOut: signal?.aborted ?? false,
+            });
+            logger[resultLog.level](resultLog.message);
           }
 
           // Emit tool call telemetry

--- a/src/server/toolResultLog.ts
+++ b/src/server/toolResultLog.ts
@@ -1,0 +1,43 @@
+/**
+ * Formats the `[ToolRegistry] <tool> result: ...` log line emitted after a tool
+ * handler resolves.
+ *
+ * Issue #2723: a slow `openLink` deeplink can exceed the caller's request timeout
+ * and surface `MCP error -32001: Request timed out` to the caller, yet the
+ * underlying handler keeps running and eventually resolves with `success=true`.
+ * Logging that late success verbatim contradicts the timeout the caller already
+ * received. When the caller has already timed out (the request's AbortSignal is
+ * aborted), reconcile the contradiction by emitting a single WARN that explains
+ * the result landed after the caller gave up — instead of a bare `success=true`.
+ */
+export interface ToolResultLogInput {
+  toolName: string;
+  /** The handler's reported `success` value. */
+  success: boolean;
+  /** The handler's reported `error`, if any. */
+  error?: unknown;
+  /** True when the caller's request already timed out / was cancelled. */
+  callerTimedOut: boolean;
+}
+
+export interface ToolResultLogLine {
+  level: "info" | "warn";
+  message: string;
+}
+
+export function formatToolResultLog(input: ToolResultLogInput): ToolResultLogLine {
+  const { toolName, success, error, callerTimedOut } = input;
+
+  let message = `[ToolRegistry] ${toolName} result: success=${success}`;
+  if (success === false) {
+    message += `, error=${error || "unknown"}`;
+  }
+
+  if (callerTimedOut) {
+    message +=
+      " (handler completed after the caller's request already timed out; the result was discarded)";
+    return { level: "warn", message };
+  }
+
+  return { level: "info", message };
+}

--- a/test/daemon/mcpRequestTimeout.test.ts
+++ b/test/daemon/mcpRequestTimeout.test.ts
@@ -150,6 +150,15 @@ describe("resolveMcpRequestTimeoutMs", () => {
     expect(resolveMcpRequestTimeoutMs(request)).toBe(300_000);
   });
 
+  test("default openLink floor is higher than the standard request timeout", () => {
+    // A deeplink that launches the app and performs a login/network round-trip can
+    // take ~45s end to end, exceeding the 30s standard timeout (issue #2723). The
+    // default floor must give those calls room to finish rather than aborting a
+    // link-open that actually succeeds on screen.
+    expect(DEFAULT_OPEN_LINK_MCP_TIMEOUT_MS).toBe(90_000);
+    expect(DEFAULT_OPEN_LINK_MCP_TIMEOUT_MS).toBeGreaterThan(DEFAULT_MCP_REQUEST_TIMEOUT_MS);
+  });
+
   test("applies default openLink floor when client omits timeoutMs", () => {
     const request: DaemonRequest = {
       id: "1",

--- a/test/server/toolRegistry.postTimeoutLog.test.ts
+++ b/test/server/toolRegistry.postTimeoutLog.test.ts
@@ -1,0 +1,91 @@
+import { afterEach, beforeEach, describe, expect, spyOn, test } from "bun:test";
+import { z } from "zod";
+import { ToolRegistry } from "../../src/server/toolRegistry";
+import { logger } from "../../src/utils/logger";
+
+/**
+ * Issue #2723: when a slow tool (e.g. openLink) resolves after the caller's
+ * request already timed out, the result must not be logged as a bare
+ * contradictory `success=true`. The registry inspects the request AbortSignal
+ * and routes the late result through logger.warn instead.
+ */
+describe("ToolRegistry post-timeout result logging", () => {
+  beforeEach(() => {
+    ToolRegistry.clearTools();
+  });
+
+  afterEach(() => {
+    ToolRegistry.clearTools();
+  });
+
+  function registerProbe(): void {
+    ToolRegistry.registerDeviceAware(
+      "postTimeoutProbe",
+      "Resolves with success regardless of caller state",
+      z.object({}),
+      async () => ({ success: true }),
+      false,
+      false,
+      {
+        shouldEnsureDevice: () => false,
+        nonDeviceHandler: async () => ({ success: true }),
+      }
+    );
+  }
+
+  test("warns (not infos) when the caller's request already timed out", async () => {
+    registerProbe();
+    const infoSpy = spyOn(logger, "info").mockImplementation(() => {});
+    const warnSpy = spyOn(logger, "warn").mockImplementation(() => {});
+
+    try {
+      const tool = ToolRegistry.getTool("postTimeoutProbe");
+      expect(tool).toBeDefined();
+
+      const response = await tool!.handler({}, undefined, AbortSignal.abort());
+
+      // The handler still returns its result (work already completed).
+      expect(response).toEqual({ success: true });
+
+      const resultWarn = warnSpy.mock.calls.find(
+        ([msg]) => typeof msg === "string" && msg.includes("postTimeoutProbe result")
+      );
+      expect(resultWarn).toBeDefined();
+      expect(String(resultWarn![0])).toMatch(/timed out/i);
+
+      const resultInfo = infoSpy.mock.calls.find(
+        ([msg]) => typeof msg === "string" && msg.includes("postTimeoutProbe result")
+      );
+      expect(resultInfo).toBeUndefined();
+    } finally {
+      infoSpy.mockRestore();
+      warnSpy.mockRestore();
+    }
+  });
+
+  test("infos as usual when the caller is still waiting", async () => {
+    registerProbe();
+    const infoSpy = spyOn(logger, "info").mockImplementation(() => {});
+    const warnSpy = spyOn(logger, "warn").mockImplementation(() => {});
+
+    try {
+      const tool = ToolRegistry.getTool("postTimeoutProbe");
+      const response = await tool!.handler({}, undefined, new AbortController().signal);
+
+      expect(response).toEqual({ success: true });
+
+      const resultInfo = infoSpy.mock.calls.find(
+        ([msg]) => typeof msg === "string" && msg.includes("postTimeoutProbe result: success=true")
+      );
+      expect(resultInfo).toBeDefined();
+
+      const resultWarn = warnSpy.mock.calls.find(
+        ([msg]) => typeof msg === "string" && msg.includes("postTimeoutProbe result")
+      );
+      expect(resultWarn).toBeUndefined();
+    } finally {
+      infoSpy.mockRestore();
+      warnSpy.mockRestore();
+    }
+  });
+});

--- a/test/server/toolResultLog.test.ts
+++ b/test/server/toolResultLog.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, test } from "bun:test";
+import { formatToolResultLog } from "../../src/server/toolResultLog";
+
+describe("formatToolResultLog", () => {
+  test("logs a completed success at info with no post-timeout note", () => {
+    const line = formatToolResultLog({
+      toolName: "openLink",
+      success: true,
+      error: null,
+      callerTimedOut: false,
+    });
+
+    expect(line.level).toBe("info");
+    expect(line.message).toContain("openLink result: success=true");
+    expect(line.message).not.toMatch(/timed out|cancel/i);
+  });
+
+  test("logs a failure at info and includes the error", () => {
+    const line = formatToolResultLog({
+      toolName: "openLink",
+      success: false,
+      error: "no activity found",
+      callerTimedOut: false,
+    });
+
+    expect(line.level).toBe("info");
+    expect(line.message).toContain("success=false");
+    expect(line.message).toContain("no activity found");
+  });
+
+  test("falls back to 'unknown' for a failure with no error", () => {
+    const line = formatToolResultLog({
+      toolName: "openLink",
+      success: false,
+      error: null,
+      callerTimedOut: false,
+    });
+
+    expect(line.message).toContain("error=unknown");
+  });
+
+  test("reconciles a post-timeout success: warns instead of a bare success=true", () => {
+    // Issue #2723: once the caller's request has already timed out (-32001), a
+    // late success=true is misleading. Surface it as a warning that explains the
+    // result arrived after the caller gave up, rather than a contradictory info log.
+    const line = formatToolResultLog({
+      toolName: "openLink",
+      success: true,
+      error: null,
+      callerTimedOut: true,
+    });
+
+    expect(line.level).toBe("warn");
+    expect(line.message).toContain("openLink");
+    expect(line.message).toMatch(/after the caller's request (already )?timed out/i);
+  });
+
+  test("post-timeout failure also warns and keeps the error", () => {
+    const line = formatToolResultLog({
+      toolName: "openLink",
+      success: false,
+      error: "boom",
+      callerTimedOut: true,
+    });
+
+    expect(line.level).toBe("warn");
+    expect(line.message).toContain("success=false");
+    expect(line.message).toContain("boom");
+    expect(line.message).toMatch(/timed out/i);
+  });
+});


### PR DESCRIPTION
## Summary
- Fixes [#2723](https://github.com/kaeawc/auto-mobile/issues/2723): a slow `openLink` deeplink (app launch + backend token exchange, ~45s observed) exceeded the 30s default, returned `MCP error -32001: Request timed out` to the caller, then the handler completed later and logged a contradictory `[ToolRegistry] openLink result: success=true`.
- Raise the `openLink` per-tool timeout floor default **30s → 90s** (matches the `launchApp` floor — `openLink` frequently launches the app too). The `AUTOMOBILE_OPEN_LINK_MCP_TIMEOUT_MS` env override (legacy alias `AUTO_MOBILE_OPEN_LINK_MCP_TIMEOUT_MS`) still raises it further; the floor only ever raises, never lowers.
- Reconcile the post-timeout race: when a tool resolves after the caller's request already timed out (the request `AbortSignal` is aborted), log the late result at `WARN` explaining it "completed after the caller's request already timed out" instead of a bare contradictory `success=true`. Extracted as a pure `formatToolResultLog()` helper.
- Document the per-tool timeout floors, the env override, and post-timeout semantics in `docs/design-docs/mcp/daemon/unix-socket-api.md`.

## Evaluation Criteria
- `resolveMcpRequestTimeoutMs` for `openLink` with no `timeoutMs` returns 90 000; short timeouts are raised to 90 000.
- A configured `AUTOMOBILE_OPEN_LINK_MCP_TIMEOUT_MS` above the default still wins; invalid/non-numeric values fall back to the default; the floor never lowers a larger caller-supplied `timeoutMs`.
- `formatToolResultLog`: a completed call logs `info` with no post-timeout note; a call that resolves while the caller already timed out logs `warn` noting the late completion (no bare `success=true`); failures keep the error (falling back to `unknown`).
- `ToolRegistry`: invoking a tool handler with an already-aborted signal still returns the handler's result and routes the result log through `logger.warn`, not `logger.info`; the non-aborted path is unchanged.
- Docs reflect the 90 000 ms default and the post-timeout `WARN` semantics.

## Testing
- `bun test test/daemon/mcpRequestTimeout.test.ts test/server/toolResultLog.test.ts test/server/toolRegistry.postTimeoutLog.test.ts`
- `bun test test/server/ test/daemon/` (1139 pass, 0 fail)
- `bun run build.ts`
- `bunx eslint` on touched files (clean)
- `./scripts/all_fast_validate_checks.sh --group docs` (mkdocs-nav, codex-skills, lychee link check — all pass)

## Notes
- No PR template file exists in the repo, so this follows the standard Summary / Evaluation Criteria / Testing structure used by recent merged PRs.
- This implements the issue's "don't emit a contradictory success" option (reconcile the log) rather than the alternative "cancel the underlying work" — the in-flight handler is left to complete; only the misleading log is corrected.
- New unit tests run in ~0.1ms–170ms; per CLAUDE.md the helper/registry unit tests are well under the 100ms target (the 170ms file total includes registry setup shared with existing duration tests).

Closes #2723
