### PR TITLE
fix(android): default to headless emulator on displayless Linux hosts

### DIFF
--- a/docs/design-docs/plat/android/emulator-startup.md
+++ b/docs/design-docs/plat/android/emulator-startup.md
@@ -1,0 +1,55 @@
+# Emulator Startup & Headless Hosts
+
+<kbd>✅ Implemented</kbd> <kbd>🧪 Tested</kbd>
+
+> See the [Status Glossary](../../status-glossary.md) for chip definitions.
+
+When AutoMobile cold-starts an Android emulator (`startDevice` → `startEmulator`
+in `src/utils/android-cmdline-tools/AndroidEmulatorClient.ts`), it picks the
+display mode based on the host and a small set of environment variables.
+
+## Display mode auto-detection
+
+By default the emulator launches **windowed**. On a headless Linux host (a CI
+runner with no X server, a container, an SSH session with no `DISPLAY`) a
+windowed launch cannot connect to the display, fails to load the Qt `xcb`
+platform plugin, and is killed by signal in a few hundred milliseconds. Node
+reports the signal death as `code: null`, which previously collapsed into an
+opaque `Emulator process exited with code: null`.
+
+To avoid this, AutoMobile resolves the display mode as follows:
+
+| Condition | Mode |
+|-----------|------|
+| `AUTOMOBILE_EMULATOR_HEADLESS=true` | **headless** (any platform) |
+| `AUTOMOBILE_EMULATOR_HEADLESS=false` | **windowed** (forced, even on a Linux host with no display) |
+| Linux with no `DISPLAY` and no `WAYLAND_DISPLAY` | **headless** (auto) |
+| Linux with `DISPLAY`/`WAYLAND_DISPLAY`, macOS, Windows | **windowed** |
+
+In headless mode AutoMobile appends `-no-window -no-audio` to the `emulator`
+invocation. The chosen mode and the reason are logged at `INFO`.
+
+If a windowed launch still fails with a display / Qt-plugin error (for example
+because `AUTOMOBILE_EMULATOR_HEADLESS=false` was set on a headless host),
+AutoMobile detects the underlying error in the emulator output and surfaces an
+actionable message instead of `code: null`, pointing you at
+`AUTOMOBILE_EMULATOR_HEADLESS=true`.
+
+## Environment variables
+
+| Variable | Values | Effect |
+|----------|--------|--------|
+| `AUTOMOBILE_EMULATOR_HEADLESS` | `true` / `false` / unset | Force headless (`-no-window -no-audio`), force windowed, or auto-detect (default). |
+| `AUTOMOBILE_EMULATOR_ARGS` | space-separated args | Extra arguments appended to the `emulator` command (e.g. `-gpu swiftshader_indirect`). |
+| `AUTOMOBILE_EMULATOR_EXTERNAL` | `true` / unset | Skip launching a local emulator; attach to an externally managed device (e.g. a cloud ADB session) and read AVD metadata from config files. |
+
+### Running emulators in CI
+
+On a headless CI runner you can rely on auto-detection (no `DISPLAY`), or set it
+explicitly for clarity:
+
+```bash
+export AUTOMOBILE_EMULATOR_HEADLESS=true
+# optionally, for software rendering on hosts without a GPU:
+export AUTOMOBILE_EMULATOR_ARGS="-gpu swiftshader_indirect -no-snapshot"
+```

--- a/docs/design-docs/plat/android/index.md
+++ b/docs/design-docs/plat/android/index.md
@@ -39,6 +39,13 @@ AutoMobile daemon via HTTP, stdio, or socket transport.
 
 See [Desktop App](desktop-app.md) for full details.
 
+## Emulator Startup
+
+AutoMobile cold-starts Android emulators on demand and auto-detects whether the host
+has a usable display, defaulting to headless (`-no-window`) on headless Linux hosts
+such as CI runners. See [Emulator Startup & Headless Hosts](emulator-startup.md) for
+the display-mode rules and the `AUTOMOBILE_EMULATOR_*` environment variables.
+
 ## Batteries Included
 
 AutoMobile includes tooling to minimize setup for required platform dependencies.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -136,6 +136,7 @@ nav:
             - 'Overview': design-docs/plat/android/index.md
             - 'Observe': design-docs/plat/android/observe.md
             - 'Screen Streaming': design-docs/plat/android/screen-streaming.md
+            - 'Emulator Startup': design-docs/plat/android/emulator-startup.md
             - 'CtrlProxy': design-docs/plat/android/control-proxy.md
             - 'AutoMobile SDK': design-docs/plat/android/auto-mobile-sdk.md
             - 'JUnitRunner':

--- a/src/utils/android-cmdline-tools/AndroidEmulatorClient.ts
+++ b/src/utils/android-cmdline-tools/AndroidEmulatorClient.ts
@@ -92,6 +92,47 @@ export function inferAndroidFormFactor(deviceName?: string): FormFactor | undefi
   return undefined;
 }
 
+/**
+ * Decide whether the emulator should launch headless (`-no-window`).
+ *
+ * Resolution order:
+ * 1. `AUTOMOBILE_EMULATOR_HEADLESS=true`  → always headless.
+ * 2. `AUTOMOBILE_EMULATOR_HEADLESS=false` → always windowed (honor the explicit
+ *    opt-out even on a Linux host with no display).
+ * 3. Linux with no usable display server (`DISPLAY`/`WAYLAND_DISPLAY` unset or
+ *    blank) → headless, because a windowed launch aborts on the Qt `xcb`
+ *    platform plugin (see issue #2722).
+ * 4. Otherwise → windowed (macOS/Windows have a native display; Linux has one).
+ *
+ * @param platform - `process.platform` value
+ * @param env - environment variables to read
+ * @returns the resolved mode plus a human-readable reason for logging
+ */
+export function resolveHeadlessMode(
+  platform: NodeJS.Platform,
+  env: NodeJS.ProcessEnv
+): { headless: boolean; reason: string } {
+  const explicit = env.AUTOMOBILE_EMULATOR_HEADLESS;
+  if (explicit === "true") {
+    return { headless: true, reason: "AUTOMOBILE_EMULATOR_HEADLESS=true" };
+  }
+  if (explicit === "false") {
+    return { headless: false, reason: "AUTOMOBILE_EMULATOR_HEADLESS=false (windowed forced)" };
+  }
+
+  if (platform === "linux") {
+    const hasDisplay = Boolean((env.DISPLAY && env.DISPLAY.trim()) || (env.WAYLAND_DISPLAY && env.WAYLAND_DISPLAY.trim()));
+    if (!hasDisplay) {
+      return {
+        headless: true,
+        reason: "no DISPLAY/WAYLAND_DISPLAY detected on Linux; defaulting to -no-window",
+      };
+    }
+  }
+
+  return { headless: false, reason: "usable display detected" };
+}
+
 const execAsync = async (command: string): Promise<ExecResult> => {
   const result = await promisify(exec)(command);
 
@@ -487,6 +528,35 @@ export class AndroidEmulatorClient implements AndroidEmulator {
   }
 
   /**
+   * Detect display / Qt platform-plugin errors in emulator output.
+   *
+   * On a headless host a windowed emulator cannot connect to the X display,
+   * fails to load the Qt `xcb` platform plugin, and is killed by signal — which
+   * Node reports as `code: null`. This surfaces that root cause instead of the
+   * opaque "exited with code: null" (see issue #2722).
+   */
+  detectDisplayError(output: string): {
+    isDisplayError: boolean;
+    message?: string;
+    suggestion?: string;
+  } {
+    const noDisplay = /could not connect to display/i.test(output);
+    const qtPlugin = /could not load the Qt platform plugin/i.test(output);
+
+    if (noDisplay || qtPlugin) {
+      return {
+        isDisplayError: true,
+        message: "Emulator could not connect to a display (Qt 'xcb' platform plugin failed to load)",
+        suggestion:
+          "Run the emulator headless by setting AUTOMOBILE_EMULATOR_HEADLESS=true " +
+          "(adds -no-window -no-audio), or start an X server / export DISPLAY before launching.",
+      };
+    }
+
+    return { isDisplayError: false };
+  }
+
+  /**
    * Execute an emulator command
    * @param command - The command to execute
    * @param timeoutMs - Optional timeout in milliseconds
@@ -825,8 +895,9 @@ export class AndroidEmulatorClient implements AndroidEmulator {
     }
 
     const args = ["-avd", avdName];
-    const headless = process.env.AUTOMOBILE_EMULATOR_HEADLESS === "true";
-    if (headless) {
+    const headlessMode = resolveHeadlessMode(process.platform, process.env);
+    logger.info(`Emulator display mode: ${headlessMode.headless ? "headless" : "windowed"} (${headlessMode.reason})`);
+    if (headlessMode.headless) {
       args.push("-no-window", "-no-audio");
     }
     const extraArgsRaw = process.env.AUTOMOBILE_EMULATOR_ARGS;
@@ -900,6 +971,28 @@ export class AndroidEmulatorClient implements AndroidEmulator {
           let errorMessage = `Emulator failed to start: ${corruptResult.message}`;
           if (corruptResult.suggestion) {
             errorMessage += `\n\nSuggestion: ${corruptResult.suggestion}`;
+          }
+
+          if (!child.killed) {
+            child.kill();
+          }
+
+          if (!startupValidationComplete) {
+            startupValidationComplete = true;
+            perf.endOperation("panicDetection");
+            reject(new ActionableError(errorMessage));
+          }
+          return;
+        }
+
+        // Check for display / Qt platform-plugin failure (windowed launch on a headless host)
+        const displayResult = this.detectDisplayError(initialOutput);
+        if (displayResult.isDisplayError) {
+          logger.error(`Emulator display error detected: ${displayResult.message}`);
+
+          let errorMessage = `Emulator failed to start: ${displayResult.message}`;
+          if (displayResult.suggestion) {
+            errorMessage += `\n\nSuggestion: ${displayResult.suggestion}`;
           }
 
           if (!child.killed) {
@@ -990,6 +1083,23 @@ export class AndroidEmulatorClient implements AndroidEmulator {
               }
               reject(new ActionableError(errorMessage));
             }
+            return;
+          }
+
+          // Check if exit was due to a display / Qt platform-plugin failure.
+          // Signal death (e.g. SIGABRT from the failed xcb plugin) arrives as code === null.
+          const displayResult = this.detectDisplayError(initialOutput);
+          if (displayResult.isDisplayError) {
+            logger.error(`Exit was due to display error: ${displayResult.message}`);
+            if (!startupValidationComplete) {
+              startupValidationComplete = true;
+              perf.endOperation("panicDetection");
+              let errorMessage = `Emulator failed to start: ${displayResult.message}`;
+              if (displayResult.suggestion) {
+                errorMessage += `\n\nSuggestion: ${displayResult.suggestion}`;
+              }
+              reject(new ActionableError(errorMessage));
+            }
           } else if (!startupValidationComplete) {
             startupValidationComplete = true;
             perf.endOperation("panicDetection");
@@ -1061,16 +1171,25 @@ export class AndroidEmulatorClient implements AndroidEmulator {
       childProcess.stdout?.on("data", captureOutput);
       childProcess.stderr?.on("data", captureOutput);
       childProcess.on("exit", code => {
-        if (code !== null && code !== 0) {
+        // A null code means the process was killed by signal (e.g. SIGABRT from a
+        // failed Qt xcb plugin on a headless host) — treat that as a failure too.
+        if (code !== 0) {
           processExited = true;
           const combinedOutput = processOutput.join("");
 
           // Check for known error patterns
           const corruptResult = this.detectCorruptImage(combinedOutput);
+          const displayResult = this.detectDisplayError(combinedOutput);
           if (corruptResult.isCorrupt) {
             let msg = `Emulator failed to start: ${corruptResult.message}`;
             if (corruptResult.suggestion) {
               msg += `\n\nSuggestion: ${corruptResult.suggestion}`;
+            }
+            processExitError = new ActionableError(msg);
+          } else if (displayResult.isDisplayError) {
+            let msg = `Emulator failed to start: ${displayResult.message}`;
+            if (displayResult.suggestion) {
+              msg += `\n\nSuggestion: ${displayResult.suggestion}`;
             }
             processExitError = new ActionableError(msg);
           } else {

--- a/test/utils/android-cmdline-tools/AndroidEmulatorClient-headless.test.ts
+++ b/test/utils/android-cmdline-tools/AndroidEmulatorClient-headless.test.ts
@@ -1,0 +1,246 @@
+import { beforeEach, describe, expect, test } from "bun:test";
+import {
+  AndroidEmulatorClient,
+  resolveHeadlessMode,
+} from "../../../src/utils/android-cmdline-tools/AndroidEmulatorClient";
+import { ExecResult, BootedDevice } from "../../../src/models";
+import { FakeTimer } from "../../fakes/FakeTimer";
+import { FakeAdbExecutor } from "../../fakes/FakeAdbExecutor";
+import { AdbClientFactory } from "../../../src/utils/android-cmdline-tools/AdbClientFactory";
+import { AdbExecutor } from "../../../src/utils/android-cmdline-tools/interfaces/AdbExecutor";
+import { ChildProcess } from "child_process";
+import { EventEmitter } from "events";
+import { Readable } from "stream";
+
+class TestAdbClientFactory implements AdbClientFactory {
+  constructor(private readonly fakeExecutor: FakeAdbExecutor) {}
+
+  create(_device?: BootedDevice | null): AdbExecutor {
+    return this.fakeExecutor;
+  }
+}
+
+const createExecResult = (stdout: string, stderr: string = ""): ExecResult => ({
+  stdout,
+  stderr,
+  toString: () => stdout,
+  trim: () => stdout.trim(),
+  includes: (s: string) => stdout.includes(s),
+});
+
+/** Prevent ensureEmulatorPath from running real filesystem/shell detection */
+function skipEmulatorPathDetection(client: AndroidEmulatorClient): void {
+  (client as any).ensureEmulatorPath = async () => "emulator";
+}
+
+describe("resolveHeadlessMode", () => {
+  test("AUTOMOBILE_EMULATOR_HEADLESS=true forces headless on any platform", () => {
+    expect(resolveHeadlessMode("darwin", { AUTOMOBILE_EMULATOR_HEADLESS: "true" }).headless).toBe(true);
+    expect(resolveHeadlessMode("linux", { AUTOMOBILE_EMULATOR_HEADLESS: "true" }).headless).toBe(true);
+    expect(resolveHeadlessMode("win32", { AUTOMOBILE_EMULATOR_HEADLESS: "true" }).headless).toBe(true);
+  });
+
+  test("AUTOMOBILE_EMULATOR_HEADLESS=false forces windowed even on a Linux host without a display", () => {
+    const result = resolveHeadlessMode("linux", { AUTOMOBILE_EMULATOR_HEADLESS: "false" });
+    expect(result.headless).toBe(false);
+  });
+
+  test("Linux without DISPLAY or WAYLAND_DISPLAY defaults to headless", () => {
+    const result = resolveHeadlessMode("linux", {});
+    expect(result.headless).toBe(true);
+    expect(result.reason.toLowerCase()).toContain("display");
+  });
+
+  test("Linux with DISPLAY set runs windowed", () => {
+    const result = resolveHeadlessMode("linux", { DISPLAY: ":0" });
+    expect(result.headless).toBe(false);
+  });
+
+  test("Linux with WAYLAND_DISPLAY set runs windowed", () => {
+    const result = resolveHeadlessMode("linux", { WAYLAND_DISPLAY: "wayland-0" });
+    expect(result.headless).toBe(false);
+  });
+
+  test("Linux with empty/whitespace DISPLAY is treated as no display", () => {
+    expect(resolveHeadlessMode("linux", { DISPLAY: "" }).headless).toBe(true);
+    expect(resolveHeadlessMode("linux", { DISPLAY: "   " }).headless).toBe(true);
+  });
+
+  test("macOS without DISPLAY runs windowed (native display always available)", () => {
+    expect(resolveHeadlessMode("darwin", {}).headless).toBe(false);
+  });
+
+  test("Windows without DISPLAY runs windowed", () => {
+    expect(resolveHeadlessMode("win32", {}).headless).toBe(false);
+  });
+});
+
+describe("AndroidEmulatorClient detectDisplayError", () => {
+  let client: AndroidEmulatorClient;
+
+  beforeEach(() => {
+    const fakeTimer = new FakeTimer();
+    const fakeAdb = new FakeAdbExecutor();
+    const fakeFactory = new TestAdbClientFactory(fakeAdb);
+    client = new AndroidEmulatorClient(async () => createExecResult("", ""), null, fakeTimer, fakeFactory);
+  });
+
+  test("detects 'could not connect to display'", () => {
+    const output = "Warning: could not connect to display  (:0, )";
+    const result = client.detectDisplayError(output);
+    expect(result.isDisplayError).toBe(true);
+    expect(result.suggestion).toContain("AUTOMOBILE_EMULATOR_HEADLESS");
+  });
+
+  test("detects Qt 'xcb' platform plugin failure", () => {
+    const output = 'Info: Could not load the Qt platform plugin "xcb" in "" even though it was found.';
+    const result = client.detectDisplayError(output);
+    expect(result.isDisplayError).toBe(true);
+    expect(result.message).toBeDefined();
+  });
+
+  test("returns false for normal startup output", () => {
+    const output = `INFO | emuDirName: Pixel_9_Pro
+Hax is enabled
+Detected GPU type: host`;
+    const result = client.detectDisplayError(output);
+    expect(result.isDisplayError).toBe(false);
+  });
+
+  test("returns false for empty output", () => {
+    expect(client.detectDisplayError("").isDisplayError).toBe(false);
+  });
+});
+
+describe("AndroidEmulatorClient startEmulator headless wiring", () => {
+  let fakeTimer: FakeTimer;
+  let fakeAdb: FakeAdbExecutor;
+  let fakeFactory: TestAdbClientFactory;
+  const savedHeadless = process.env.AUTOMOBILE_EMULATOR_HEADLESS;
+
+  beforeEach(() => {
+    fakeTimer = new FakeTimer();
+    fakeAdb = new FakeAdbExecutor();
+    fakeFactory = new TestAdbClientFactory(fakeAdb);
+  });
+
+  function restoreEnv() {
+    if (savedHeadless === undefined) {
+      delete process.env.AUTOMOBILE_EMULATOR_HEADLESS;
+    } else {
+      process.env.AUTOMOBILE_EMULATOR_HEADLESS = savedHeadless;
+    }
+  }
+
+  function createFakeChildProcess(): ChildProcess & EventEmitter {
+    const emitter = new EventEmitter() as ChildProcess & EventEmitter;
+    emitter.stdout = new Readable({ read() {} }) as any;
+    emitter.stderr = new Readable({ read() {} }) as any;
+    emitter.killed = false;
+    emitter.pid = 1234;
+    emitter.kill = () => { emitter.killed = true; return true; };
+    return emitter;
+  }
+
+  test("passes -no-window -no-audio when headless mode is enabled", async () => {
+    process.env.AUTOMOBILE_EMULATOR_HEADLESS = "true";
+    let capturedArgs: string[] = [];
+    const fakeChild = createFakeChildProcess();
+
+    const spawnFn = ((_cmd: string, args: string[]) => {
+      capturedArgs = args;
+      process.nextTick(() => {
+        fakeChild.stdout!.emit("data", Buffer.from("Detected GPU type: host\n"));
+      });
+      return fakeChild;
+    }) as any;
+
+    const execAsync = async (command: string): Promise<ExecResult> => {
+      if (command.includes("-list-avds")) {
+        return createExecResult("Pixel_9_Pro\n");
+      }
+      return createExecResult("");
+    };
+
+    fakeTimer.enableAutoAdvance();
+    const client = new AndroidEmulatorClient(execAsync, spawnFn, fakeTimer, fakeFactory);
+    skipEmulatorPathDetection(client);
+
+    try {
+      await client.startEmulator("Pixel_9_Pro");
+      expect(capturedArgs).toContain("-no-window");
+      expect(capturedArgs).toContain("-no-audio");
+    } finally {
+      restoreEnv();
+    }
+  });
+
+  test("does not pass -no-window when explicitly disabled", async () => {
+    process.env.AUTOMOBILE_EMULATOR_HEADLESS = "false";
+    let capturedArgs: string[] = [];
+    const fakeChild = createFakeChildProcess();
+
+    const spawnFn = ((_cmd: string, args: string[]) => {
+      capturedArgs = args;
+      process.nextTick(() => {
+        fakeChild.stdout!.emit("data", Buffer.from("Detected GPU type: host\n"));
+      });
+      return fakeChild;
+    }) as any;
+
+    const execAsync = async (command: string): Promise<ExecResult> => {
+      if (command.includes("-list-avds")) {
+        return createExecResult("Pixel_9_Pro\n");
+      }
+      return createExecResult("");
+    };
+
+    fakeTimer.enableAutoAdvance();
+    const client = new AndroidEmulatorClient(execAsync, spawnFn, fakeTimer, fakeFactory);
+    skipEmulatorPathDetection(client);
+
+    try {
+      await client.startEmulator("Pixel_9_Pro");
+      expect(capturedArgs).not.toContain("-no-window");
+    } finally {
+      restoreEnv();
+    }
+  });
+
+  test("rejects with actionable display error when emulator dies windowed on a headless host", async () => {
+    process.env.AUTOMOBILE_EMULATOR_HEADLESS = "false"; // force windowed to exercise the failure path
+    const fakeChild = createFakeChildProcess();
+
+    const spawnFn = ((_cmd: string, _args: string[]) => {
+      process.nextTick(() => {
+        fakeChild.stderr!.emit("data", Buffer.from("Warning: could not connect to display  (:0, )\n"));
+        fakeChild.stderr!.emit("data", Buffer.from('Info: Could not load the Qt platform plugin "xcb" in "" even though it was found.\n'));
+        // Signal death surfaces as a null exit code from Node.
+        fakeChild.emit("exit", null);
+      });
+      return fakeChild;
+    }) as any;
+
+    const execAsync = async (command: string): Promise<ExecResult> => {
+      if (command.includes("-list-avds")) {
+        return createExecResult("Pixel_9_Pro\n");
+      }
+      return createExecResult("");
+    };
+
+    fakeTimer.enableAutoAdvance();
+    const client = new AndroidEmulatorClient(execAsync, spawnFn, fakeTimer, fakeFactory);
+    skipEmulatorPathDetection(client);
+
+    try {
+      await client.startEmulator("Pixel_9_Pro");
+      expect(true).toBe(false); // should not reach here
+    } catch (error: any) {
+      expect(error.message).toContain("display");
+      expect(error.message).toContain("AUTOMOBILE_EMULATOR_HEADLESS");
+      expect(error.message).not.toBe("Emulator process exited with code: null");
+    } finally {
+      restoreEnv();
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #2722 — on a headless Linux host (no X display, e.g. a CI runner), `startDevice` launched the emulator **windowed**, which fails to connect to display `:0`, can't load the Qt `xcb` platform plugin, and is killed by signal (~400ms). Node reports the signal death as `code: null`, which collapsed into the opaque `MCP error -32603: Emulator process exited with code: null`.

This addresses all three asks in the issue.

## Changes

- **Auto-detect display mode** — new `resolveHeadlessMode(platform, env)` in `AndroidEmulatorClient.ts`:
  - `AUTOMOBILE_EMULATOR_HEADLESS=true` → headless (any platform)
  - `AUTOMOBILE_EMULATOR_HEADLESS=false` → windowed (explicit opt-out honored, even on a displayless host)
  - Linux with no `DISPLAY`/`WAYLAND_DISPLAY` → headless (`-no-window -no-audio`), avoiding the abort
  - Linux with a display, macOS, Windows → windowed
  - Chosen mode + reason logged at `INFO`.
- **Surface the root cause** — new `detectDisplayError(output)` matches the display / Qt-plugin failure and is wired into the streaming monitor, `startEmulator`'s exit handler, and `waitForEmulatorReady`'s exit handler. The user now gets an actionable message pointing at `AUTOMOBILE_EMULATOR_HEADLESS=true` instead of `code: null`. `waitForEmulatorReady` now also treats a `null` (signal) exit as a failure rather than waiting out the full timeout.
- **Documentation** — new `docs/design-docs/plat/android/emulator-startup.md` documenting `AUTOMOBILE_EMULATOR_HEADLESS` (and the related `_ARGS` / `_EXTERNAL` vars) and the headless-host behavior; linked from the Android overview and mkdocs nav.

## Testing

- New `test/utils/android-cmdline-tools/AndroidEmulatorClient-headless.test.ts` (15 tests, TDD) covering the `resolveHeadlessMode` matrix, `detectDisplayError`, `-no-window`/`-no-audio` arg injection, and the actionable-error-on-display-death path.
- `bun run lint` and `bun run build` clean.
- `bun test` across the affected areas (android-cmdline-tools, deviceUtils, devicePool): **222 pass, 0 fail**.
