### PR TITLE
fix(daemon): write logs and caches to a stable non-ephemeral data dir (#2724)

### DIFF
--- a/docs/design-docs/mcp/daemon/multi-agent-filesystem-contract.md
+++ b/docs/design-docs/mcp/daemon/multi-agent-filesystem-contract.md
@@ -2,7 +2,18 @@
 
 <kbd>✅ Implemented</kbd> <kbd>🧪 Tested</kbd>
 
-> **Current state:** The filesystem isolation described here is implemented and covered by tests — per-pid logs with multi-process-safe pruning, age-gated screenshot eviction, and temp-tree cache paths. The operational guidance (per-agent `TMPDIR` + shared-daemon discovery) is a deployment recommendation. See the [Status Glossary](../../status-glossary.md) for chip definitions and [Daemon Overview](index.md) for architecture context.
+> **Current state:** The filesystem isolation described here is implemented and covered by tests — per-pid logs with multi-process-safe pruning, age-gated screenshot eviction, and data-dir cache paths. The operational guidance (per-agent `AUTOMOBILE_DATA_DIR` + shared-daemon discovery) is a deployment recommendation. See the [Status Glossary](../../status-glossary.md) for chip definitions and [Daemon Overview](index.md) for architecture context.
+
+> **Stable base dir (issue #2724):** All auto-mobile on-disk state resolves under a
+> **stable, non-ephemeral base directory**, not `os.tmpdir()`. The base is
+> resolved by `resolveAutoMobileBaseDir()` (`src/utils/tempDir.ts`):
+> `AUTOMOBILE_DATA_DIR` / `AUTO_MOBILE_DATA_DIR` if set → else `~/.auto-mobile` →
+> else `os.tmpdir()/auto-mobile` only when no home dir is resolvable. The base is
+> deliberately **not** derived from `TMPDIR`/`TMP`/`TEMP`, because `bunx` can point
+> those at an extraction tree it later reaps while the daemon still holds open
+> fds — the cause of the 0-byte logs and `ENOENT` cache writes in #2724.
+> Paths written `${TMPDIR}/auto-mobile/...` below are historical; read them as
+> `${AUTOMOBILE_DATA_DIR:-~/.auto-mobile}/...`.
 
 ## Overview
 
@@ -31,22 +42,24 @@ The rule that follows from the production shape:
 > **shared-directory cleanup**: a size/age sweep run by one process iterating the
 > whole directory can delete another process's files.
 
-**The recommended production isolation is a per-agent `TMPDIR`** (see §4): give
-each agent process its own temp tree so device caches never share a directory at
-all, while the shared daemon is still found via the explicit
-`AUTOMOBILE_DAEMON_*` paths (which are independent of `TMPDIR`). The code also
-applies defense-in-depth so cleanup can't delete a peer's in-flight file even
-when `TMPDIR` is shared (see §1 notes).
+**The recommended production isolation is a per-agent `AUTOMOBILE_DATA_DIR`**
+(see §4): give each agent process its own auto-mobile base dir so device caches
+never share a directory at all, while the shared daemon is still found via the
+explicit `AUTOMOBILE_DAEMON_*` paths (which are independent of the data dir). The
+code also applies defense-in-depth so cleanup can't delete a peer's in-flight
+file even when the data dir is shared (see §1 notes).
 
 ---
 
 ## 1. Ownership model
 
-Writer counts below are for **production (direct mode)** with a **shared
-`TMPDIR`**. With a per-agent `TMPDIR` (§4) every per-client row collapses to a
-single writer in its own tree.
+Writer counts below are for **production (direct mode)** with a **shared base
+dir**. With a per-agent `AUTOMOBILE_DATA_DIR` (§4) every per-client row collapses
+to a single writer in its own tree. Paths are written `${TMPDIR}/auto-mobile/...`
+for historical continuity; resolve them as
+`${AUTOMOBILE_DATA_DIR:-~/.auto-mobile}/...` (see the stable-base-dir note above).
 
-| Path / resource | Writers (shared TMPDIR) | Collision risk & mitigation |
+| Path / resource | Writers (shared base dir) | Collision risk & mitigation |
 |---|---|---|
 | `${TMPDIR}/auto-mobile/screenshots` | N (every client) | filenames are timestamp-only (not device/pid keyed). Size eviction is **age-gated** (`screenshotCacheEviction.ts`, `SCREENSHOT_MIN_EVICT_AGE_MS`) so it never deletes a peer's recent/in-flight frame. |
 | `${TMPDIR}/auto-mobile/observe_results` | N | `observe_<deviceId>_*.json`. Per-device cleanup (`clear(deviceId)`) only touches that agent's own device. `clear()` with **no** deviceId is host-wide — avoid on a shared host, or isolate TMPDIR. |
@@ -57,8 +70,9 @@ single writer in its own tree.
 | auxiliary sockets (video, snapshot, …) | 1 (daemon) | path depends on `AUTOMOBILE_EMULATOR_EXTERNAL`. |
 | `${TMPDIR}/auto-mobile/logs/daemon.log` | 1 daemon | stable daemon log; rotated files are `daemon-<timestamp>.log`. |
 | `${TMPDIR}/auto-mobile/logs/stdio-<pid>.log` | 1 each | per-stdio-client file; pruning only trims this pid's files + sweeps stale others by mtime. |
-| `${TMPDIR}/auto-mobile/tool_logs` (`LOG_DIR`) | N | routed through `tempDir` (honors `TMPDIR`). |
-| `mkdtemp(...)` APK / prefetch / per-start daemon log dirs | per-call unique | **already safe** (random suffix). |
+| `${TMPDIR}/auto-mobile/tool_logs` (`LOG_DIR`) | N | routed through `tempDir` (honors `AUTOMOBILE_DATA_DIR`, not `TMPDIR`). |
+| `…/auto-mobile/logs/daemon-launch-<pid>.log` | 1 per manager | daemon stdout/stderr launch capture, in the **stable** logs dir (was an ephemeral `mkdtemp(tmpdir())` — issue #2724); truncated per launch. |
+| `mkdtemp(...)` APK / prefetch dirs | per-call unique | **already safe** (random suffix). |
 
 The daemon enforces exactly one daemon per host per user (single-daemon policy in
 `manager.ts` `startUnlocked`, plus per-UID socket/PID/lock paths), so daemon-owned
@@ -75,10 +89,10 @@ single biggest source of "client can't find the daemon" failures.
 ### Required to be identical across all processes
 
 ```bash
-# TMPDIR should be PER-AGENT (see §4), NOT shared — it scopes each agent's
-# device caches. Daemon discovery does NOT depend on TMPDIR, so isolating it is
-# free.
-#   export TMPDIR=/run/auto-mobile/agent-$AGENT_ID
+# AUTOMOBILE_DATA_DIR should be PER-AGENT (see §4), NOT shared — it scopes each
+# agent's logs and device caches to a stable, non-ephemeral tree. Daemon
+# discovery does NOT depend on it, so isolating it is free.
+#   export AUTOMOBILE_DATA_DIR=/run/auto-mobile/agent-$AGENT_ID
 
 # Daemon discovery — MUST match between clients and the daemon, or clients
 # resolve a different socket/PID/lock than the daemon created.
@@ -97,11 +111,14 @@ export AUTOMOBILE_LOG_LEVEL=warn           # quieter shared log in prod
 
 ### Why each matters
 
-- **`TMPDIR`** — `tempDir.ts` builds `os.tmpdir()/auto-mobile`. In production
-  every client writes the device caches, so a **per-agent `TMPDIR`** (§4) is the
-  recommended isolation. If you keep a shared `TMPDIR` instead, the code's
-  defense-in-depth (age-gated screenshot eviction, per-pid logs, per-device cache
-  cleanup) keeps agents from deleting each other's files.
+- **`AUTOMOBILE_DATA_DIR`** — `tempDir.ts` (`resolveAutoMobileBaseDir`) anchors
+  the base on `AUTOMOBILE_DATA_DIR` → else `~/.auto-mobile` → else
+  `os.tmpdir()/auto-mobile`, and never on `TMPDIR` (which `bunx` may make
+  ephemeral — issue #2724). In production every client writes the device caches,
+  so a **per-agent `AUTOMOBILE_DATA_DIR`** (§4) is the recommended isolation. If
+  you keep a shared base instead, the code's defense-in-depth (age-gated
+  screenshot eviction, per-pid logs, per-device cache cleanup) keeps agents from
+  deleting each other's files.
 - **`AUTOMOBILE_DAEMON_*` paths** — `daemon/constants.ts` resolves these at
   module load. Default is `/tmp/auto-mobile-daemon-<uid>.{sock,pid,lock}`. If
   you override them, override them for **both** sides. The daemon already
@@ -149,14 +166,16 @@ run **one daemon per user** (each gets its own `<uid>` paths automatically).
 ## 4. Per-agent isolation (the primary production recommendation)
 
 Because every agent executes tools in its own process, the robust setup is to
-give **each agent its own `TMPDIR`** and point them all at the **same daemon**:
+give **each agent its own `AUTOMOBILE_DATA_DIR`** and point them all at the
+**same daemon**:
 
 ```bash
-# Per agent: isolated scratch (device caches, logs never share a directory).
-export TMPDIR=/run/auto-mobile/agent-$AGENT_ID
+# Per agent: isolated, STABLE base dir (device caches, logs never share a
+# directory, and survive bunx temp-dir cleanup — issue #2724).
+export AUTOMOBILE_DATA_DIR=/run/auto-mobile/agent-$AGENT_ID
 
 # Same on every agent: the shared daemon is discovered via explicit paths that
-# are INDEPENDENT of TMPDIR, so isolating TMPDIR does not fragment the daemon.
+# are INDEPENDENT of the data dir, so isolating it does not fragment the daemon.
 export AUTOMOBILE_DAEMON_SOCKET_PATH=/run/auto-mobile/daemon.sock
 export AUTOMOBILE_DAEMON_PID_FILE_PATH=/run/auto-mobile/daemon.pid
 export AUTOMOBILE_DAEMON_LOCK_FILE_PATH=/run/auto-mobile/daemon.lock
@@ -164,9 +183,9 @@ export AUTOMOBILE_EMULATOR_EXTERNAL=...   # identical everywhere (see §2)
 ```
 
 With this, the only shared filesystem state is the daemon's socket/PID/lock — and
-those are explicitly pinned, single-writer, and not derived from `TMPDIR`.
+those are explicitly pinned, single-writer, and not derived from the data dir.
 
-If you instead run all agents under a **shared `TMPDIR`**, the code still avoids
+If you instead run all agents under a **shared base dir**, the code still avoids
 cross-agent data loss as defense-in-depth:
 
 - **Logs** are role-scoped (`daemon.log` for the daemon, `stdio-<pid>.log` for
@@ -179,15 +198,15 @@ cross-agent data loss as defense-in-depth:
 - **observe_results / window / dumpsys / screen-size** are keyed by `deviceId`,
   and the pool hands each session a distinct device, so routine per-device
   cleanup only touches that agent's own files. (Avoid the host-wide `clear()`
-  with no deviceId on a shared `TMPDIR`.)
+  with no deviceId on a shared base dir.)
 
 ---
 
 ## 5. Quick checklist
 
 - [ ] All clients + daemon run as the **same OS user**.
-- [ ] **Per-agent `TMPDIR`** (preferred), with explicit `AUTOMOBILE_DAEMON_*`
-      paths pointing every agent at the one shared daemon.
+- [ ] **Per-agent `AUTOMOBILE_DATA_DIR`** (preferred), with explicit
+      `AUTOMOBILE_DAEMON_*` paths pointing every agent at the one shared daemon.
 - [ ] `AUTOMOBILE_EMULATOR_EXTERNAL` is the **same** value everywhere.
 - [ ] If overriding `AUTOMOBILE_DAEMON_{SOCKET,PID,LOCK}_FILE_PATH`, set them
       everywhere.

--- a/src/daemon/daemon.ts
+++ b/src/daemon/daemon.ts
@@ -190,8 +190,9 @@ export class Daemon {
    */
   async start(): Promise<void> {
     // Mirror structured daemon logs to stdout/stderr capture as well. The
-    // primary stable log is `${TMPDIR}/auto-mobile/logs/daemon.log`; the
-    // daemon manager also redirects stdout/stderr to a per-start capture file.
+    // primary stable log is `<auto-mobile data dir>/logs/daemon.log` (defaults to
+    // `~/.auto-mobile/logs/daemon.log`); the daemon manager also redirects
+    // stdout/stderr to a per-start capture file in that same stable logs dir.
     logger.enableStdoutLogging();
     const stableWorkingDirectory = resolveStableDaemonWorkingDirectory();
     process.env[DAEMON_LAUNCH_CWD_ENV] ??= safeProcessCwd(stableWorkingDirectory);

--- a/src/daemon/manager.ts
+++ b/src/daemon/manager.ts
@@ -1,9 +1,9 @@
 import { spawn as nodeSpawn, execSync, type ChildProcess, type SpawnOptions } from "node:child_process";
 import { open, readFile, unlink } from "node:fs/promises";
-import { existsSync, openSync, closeSync, mkdtempSync, mkdirSync, readFileSync, unlinkSync, writeFileSync } from "node:fs";
-import { tmpdir } from "node:os";
+import { existsSync, openSync, closeSync, mkdirSync, readFileSync, unlinkSync, writeFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { logger } from "../utils/logger";
+import { ensureSecureTempDirSync, TEMP_SUBDIRS } from "../utils/tempDir";
 import { ActionableError } from "../models";
 import {
   PID_FILE_PATH,
@@ -555,10 +555,18 @@ export class DaemonManager implements DaemonManagerLike {
       args.push("--mcp-recording");
     }
 
-    // Create secure temp directory with random suffix to prevent symlink attacks
-    const tempDir = mkdtempSync(join(tmpdir(), "auto-mobile-daemon-"));
-    const logPath = join(tempDir, "daemon.log");
-    // Open with restricted permissions (0o600 = owner read/write only)
+    // Redirect the detached daemon's stdout/stderr into the STABLE logs dir
+    // (`~/.auto-mobile/logs` by default) rather than an ephemeral
+    // `mkdtemp(tmpdir())` directory. Under bunx the temp tree is reaped while the
+    // daemon keeps this fd open, which previously left the on-disk log unlinked
+    // and post-hoc debugging impossible (issue #2724). The logs dir is created
+    // owner-only (0o700) by ensureSecureTempDirSync, so a fixed, predictable
+    // filename inside it is not exposed to other users.
+    const logsDir = ensureSecureTempDirSync(TEMP_SUBDIRS.LOGS);
+    const logPath = join(logsDir, `daemon-launch-${process.pid}.log`);
+    // Open with restricted permissions (0o600 = owner read/write only).
+    // Truncate per launch so a single manager's bootstrap captures don't grow
+    // unbounded across restarts.
     const logFd = openSync(logPath, "w", 0o600);
 
     // Propagate any non-default file paths to the child so its constants module

--- a/src/utils/logPruner.ts
+++ b/src/utils/logPruner.ts
@@ -35,9 +35,15 @@ function isOwnedBy(file: string, ownPrefix: string): boolean {
   return file === `${ownPrefix}.log` || file.startsWith(`${ownPrefix}-`);
 }
 
-/** Parse the owning PID from `stdio-<pid>.log` / `stdio-<pid>-<ts>.log`. */
+/**
+ * Parse the owning PID from a process-scoped log filename:
+ * `stdio-<pid>.log` / `stdio-<pid>-<ts>.log`, or the daemon launch-capture log
+ * `daemon-launch-<pid>.log` (PID is the spawning manager process). Letting the
+ * sweep recognize the launch log keeps it from leaking in the now-stable logs
+ * dir once its owner has exited (issue #2724).
+ */
 function ownerPid(file: string): number | undefined {
-  const match = /^(?:stdio|server)-(\d+)(?:-.*)?\.log$/.exec(file);
+  const match = /^(?:stdio|server|daemon-launch)-(\d+)(?:-.*)?\.log$/.exec(file);
   return match ? Number(match[1]) : undefined;
 }
 

--- a/src/utils/tempDir.ts
+++ b/src/utils/tempDir.ts
@@ -1,8 +1,14 @@
 /**
- * Secure temporary directory utilities.
+ * Auto-mobile working directory utilities.
  *
- * Provides consistent, secure temp directory creation with restrictive permissions.
- * Uses os.tmpdir() as the base for portability across platforms.
+ * Provides consistent, secure working directory creation with restrictive
+ * permissions. The base resolves to a STABLE, non-ephemeral location so that
+ * long-lived state (daemon logs, persistent caches) survives package-runner
+ * temp-dir cleanup. When AutoMobile is launched via `bunx`, `os.tmpdir()` can
+ * point into an extraction tree that bunx later reaps while the daemon still
+ * holds open file descriptors — leaving on-disk logs at 0 bytes and cache
+ * writes failing with ENOENT (issue #2724). Anchoring on the user's home dir
+ * (`~/.auto-mobile`) avoids that lifecycle entirely.
  */
 
 import fs from "node:fs";
@@ -10,26 +16,59 @@ import os from "os";
 import path from "path";
 
 /**
- * Base directory for all auto-mobile temp files.
- * Uses os.tmpdir() for portability (works on macOS, Linux, Windows).
- */
-const AUTO_MOBILE_TEMP_BASE = path.join(os.tmpdir(), "auto-mobile");
-
-/**
  * Restrictive directory permissions (owner read/write/execute only).
- * Prevents other users from accessing temp files.
+ * Prevents other users from accessing auto-mobile files.
  */
 const SECURE_DIR_MODE = 0o700;
 
 /**
- * Get a secure temp directory path for a given subdirectory.
- * Does NOT create the directory - use ensureSecureTempDir for that.
+ * Resolve the stable base directory for all auto-mobile on-disk state.
  *
- * @param subdirectory - Subdirectory name under auto-mobile temp base
- * @returns Full path to the temp directory
+ * Resolution order:
+ * 1. `AUTOMOBILE_DATA_DIR` / `AUTO_MOBILE_DATA_DIR` — explicit, configurable
+ *    override (also the per-agent isolation knob on shared hosts). Resolved to
+ *    an absolute path.
+ * 2. `~/.auto-mobile` — stable, per-user default. Matches the existing
+ *    `.auto-mobile` convention used for daemon sockets, and is never reaped by
+ *    a package runner's temp-dir cleanup.
+ * 3. `os.tmpdir()/auto-mobile` — last-resort fallback for locked-down
+ *    environments where no home directory is resolvable.
+ *
+ * Deliberately does NOT derive the base from `TMPDIR`/`TMP`/`TEMP`: bunx may set
+ * those to an ephemeral extraction dir, which is the root cause of issue #2724.
+ *
+ * @param env - Environment to read overrides from (injectable for tests)
+ * @param homeDir - Home directory to anchor the default on (injectable for tests)
+ * @returns Absolute path to the auto-mobile base directory
+ */
+export function resolveAutoMobileBaseDir(
+  env: NodeJS.ProcessEnv = process.env,
+  homeDir: string = os.homedir()
+): string {
+  const override = (env.AUTOMOBILE_DATA_DIR ?? env.AUTO_MOBILE_DATA_DIR)?.trim();
+  if (override && override.length > 0) {
+    return path.resolve(override);
+  }
+
+  if (homeDir && homeDir.length > 0) {
+    return path.join(homeDir, ".auto-mobile");
+  }
+
+  return path.join(os.tmpdir(), "auto-mobile");
+}
+
+/**
+ * Get a secure auto-mobile directory path for a given subdirectory.
+ * Does NOT create the directory - use ensureSecureTempDirSync for that.
+ *
+ * Resolved lazily on each call so an `AUTOMOBILE_DATA_DIR` override set after
+ * module load (and tests) is honored.
+ *
+ * @param subdirectory - Subdirectory name under the auto-mobile base
+ * @returns Full path to the directory
  */
 export function getTempDir(subdirectory: string): string {
-  return path.join(AUTO_MOBILE_TEMP_BASE, subdirectory);
+  return path.join(resolveAutoMobileBaseDir(), subdirectory);
 }
 
 /**

--- a/test/daemon/daemonManagerLaunch.test.ts
+++ b/test/daemon/daemonManagerLaunch.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, test } from "bun:test";
-import { existsSync, mkdtempSync, realpathSync, rmSync } from "node:fs";
+import { existsSync, mkdtempSync, readdirSync, realpathSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import type { ChildProcess, SpawnOptions } from "node:child_process";
@@ -20,16 +20,68 @@ describe("DaemonManager launch", () => {
   afterEach(() => {
     process.chdir(originalCwd);
     delete process.env[DAEMON_LAUNCH_CWD_ENV];
+    delete process.env.AUTOMOBILE_DATA_DIR;
     for (const dir of tempDirs) {
       rmSync(dir, { recursive: true, force: true });
     }
     tempDirs.length = 0;
   });
 
+  test("writes the daemon launch log under the stable data dir, not an ephemeral mkdtemp", async () => {
+    const stateDir = createTempDir("daemon-launch-state-");
+    const dataDir = createTempDir("daemon-data-dir-");
+    process.env.AUTOMOBILE_DATA_DIR = dataDir;
+
+    const processSpawner: DaemonProcessSpawner = {
+      spawn: (_command: string, _args: string[], _options: SpawnOptions) => {
+        return {
+          unref() {},
+          once() { return this; },
+          off() { return this; },
+        } as ChildProcess;
+      }
+    };
+
+    let statusCallCount = 0;
+    class TestDaemonManager extends DaemonManager {
+      override findAllDaemonProcesses(): number[] { return []; }
+      override async status(): Promise<any> {
+        statusCallCount++;
+        return statusCallCount === 1
+          ? { running: false }
+          : { running: true, pid: 1234, port: 31847, socketPath: join(stateDir, "daemon.sock") };
+      }
+      override async waitForReady(_timeout: number): Promise<boolean> {
+        return true;
+      }
+    }
+
+    const manager = new TestDaemonManager(
+      undefined,
+      undefined,
+      new FakeTimer(),
+      join(stateDir, "daemon.lock"),
+      join(stateDir, "daemon.pid"),
+      join(stateDir, "daemon.sock"),
+      undefined,
+      processSpawner
+    );
+
+    await manager.start();
+
+    const logsDir = join(dataDir, "logs");
+    expect(existsSync(logsDir)).toBe(true);
+    const launchLogs = readdirSync(logsDir).filter(name => name.startsWith("daemon-launch"));
+    expect(launchLogs.length).toBeGreaterThan(0);
+  });
+
   test("spawns detached daemon from a stable cwd instead of inheriting the spawner cwd", async () => {
     const spawnerCwd = createTempDir("daemon-spawner-cwd-");
     const stateDir = createTempDir("daemon-launch-state-");
     process.chdir(spawnerCwd);
+    // Keep the daemon launch log inside this test's temp tree, not the real
+    // `~/.auto-mobile/logs` default (see tempDir.resolveAutoMobileBaseDir).
+    process.env.AUTOMOBILE_DATA_DIR = spawnerCwd;
 
     let capturedOptions: SpawnOptions | undefined;
     const processSpawner: DaemonProcessSpawner = {
@@ -79,6 +131,9 @@ describe("DaemonManager launch", () => {
     const spawnerCwd = createTempDir("daemon-spawner-cwd-");
     const stateDir = createTempDir("daemon-launch-state-");
     process.chdir(spawnerCwd);
+    // Keep the daemon launch log inside this test's temp tree, not the real
+    // `~/.auto-mobile/logs` default (see tempDir.resolveAutoMobileBaseDir).
+    process.env.AUTOMOBILE_DATA_DIR = spawnerCwd;
 
     let capturedEnv: NodeJS.ProcessEnv | undefined;
     const processSpawner: DaemonProcessSpawner = {
@@ -125,6 +180,9 @@ describe("DaemonManager launch", () => {
   test("resolves relative daemon state paths before changing daemon cwd", async () => {
     const spawnerCwd = createTempDir("daemon-spawner-cwd-");
     process.chdir(spawnerCwd);
+    // Keep the daemon launch log inside this test's temp tree, not the real
+    // `~/.auto-mobile/logs` default (see tempDir.resolveAutoMobileBaseDir).
+    process.env.AUTOMOBILE_DATA_DIR = spawnerCwd;
     const canonicalSpawnerCwd = realpathSync(spawnerCwd);
     const expectedLockPath = resolve(canonicalSpawnerCwd, ".auto-mobile", "daemon.lock");
     const expectedPidPath = resolve(canonicalSpawnerCwd, ".auto-mobile", "daemon.pid");

--- a/test/daemon/daemonManagerLock.test.ts
+++ b/test/daemon/daemonManagerLock.test.ts
@@ -11,6 +11,9 @@ describe("DaemonManager file lock", () => {
   function createTempLockPath(): string {
     const dir = mkdtempSync(join(tmpdir(), "daemon-lock-test-"));
     tempDirs.push(dir);
+    // Keep any daemon launch log inside this test's temp tree, not the real
+    // `~/.auto-mobile/logs` default (see tempDir.resolveAutoMobileBaseDir).
+    process.env.AUTOMOBILE_DATA_DIR = dir;
     return join(dir, "daemon.lock");
   }
 
@@ -22,6 +25,7 @@ describe("DaemonManager file lock", () => {
       } catch { /* ignore */ }
     }
     tempDirs.length = 0;
+    delete process.env.AUTOMOBILE_DATA_DIR;
   });
 
   describe("acquireLock", () => {

--- a/test/daemon/daemonManagerReadiness.test.ts
+++ b/test/daemon/daemonManagerReadiness.test.ts
@@ -75,6 +75,9 @@ describe("DaemonManager readiness", () => {
   function createPaths(): { dir: string; lockPath: string; pidPath: string; socketPath: string } {
     const dir = mkdtempSync(join(tmpdir(), "daemon-readiness-test-"));
     tempDirs.push(dir);
+    // Keep the daemon launch log inside this test's temp dir instead of the real
+    // `~/.auto-mobile/logs` default (see tempDir.resolveAutoMobileBaseDir).
+    process.env.AUTOMOBILE_DATA_DIR = dir;
     return {
       dir,
       lockPath: join(dir, "daemon.lock"),
@@ -104,6 +107,7 @@ describe("DaemonManager readiness", () => {
       rmSync(dir, { recursive: true, force: true });
     }
     tempDirs.length = 0;
+    delete process.env.AUTOMOBILE_DATA_DIR;
   });
 
   test("reports ready only after the daemon socket accepts a connection", async () => {
@@ -299,7 +303,7 @@ describe("DaemonManager readiness", () => {
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
       expect(message).toMatch(
-        /Daemon failed to start within \d+ms[\s\S]*Logs: .*daemon\.log[\s\S]*SQLiteError: database is locked/
+        /Daemon failed to start within \d+ms[\s\S]*Logs: .*daemon-launch-\d+\.log[\s\S]*SQLiteError: database is locked/
       );
       expect(message).not.toContain("OLD_LOG_START");
     } finally {

--- a/test/daemon/loggerPrune.test.ts
+++ b/test/daemon/loggerPrune.test.ts
@@ -159,6 +159,39 @@ describe("pruneLogFiles", () => {
     expect(remaining).toContain("daemon.log");
   });
 
+  test("sweeps an exited manager's stale daemon-launch-<pid>.log (issue #2724)", async () => {
+    const logsDir = createTempLogsDir();
+    // Launch-capture log owned by a now-exited spawning manager (pid 222).
+    writeFileSync(join(logsDir, "daemon-launch-222.log"), "old bootstrap output");
+
+    await pruneLogFiles({
+      dir: logsDir,
+      ownPrefix: "stdio-111",
+      maxOwnFiles: 10,
+      abandonedMaxAgeMs: 1_000,
+      now: Date.now() + 1e9, // far future → mtime looks ancient
+      isProcessAlive: dead,
+    });
+
+    expect(readdirSync(logsDir)).not.toContain("daemon-launch-222.log");
+  });
+
+  test("never sweeps a LIVE manager's daemon-launch-<pid>.log even when stale", async () => {
+    const logsDir = createTempLogsDir();
+    writeFileSync(join(logsDir, "daemon-launch-222.log"), "in-flight bootstrap output");
+
+    await pruneLogFiles({
+      dir: logsDir,
+      ownPrefix: "stdio-111",
+      maxOwnFiles: 10,
+      abandonedMaxAgeMs: 1_000,
+      now: Date.now() + 1e9,
+      isProcessAlive: pid => pid === 222, // spawning manager still running
+    });
+
+    expect(readdirSync(logsDir)).toContain("daemon-launch-222.log");
+  });
+
   test("no-op when own count is at or below the cap", async () => {
     const logsDir = createTempLogsDir();
     for (let i = 0; i < 10; i++) {

--- a/test/daemon/manager.test.ts
+++ b/test/daemon/manager.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, spyOn, test } from "bun:test";
+import { afterEach, describe, expect, spyOn, test } from "bun:test";
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
@@ -93,6 +93,13 @@ describe("resolveDaemonLaunchCommand", () => {
 });
 
 describe("Daemon manager process detection", () => {
+  // Tests that reach manager.start() open a daemon launch log; keep it inside the
+  // per-test temp dir (set via AUTOMOBILE_DATA_DIR) rather than the real
+  // `~/.auto-mobile/logs` default (see tempDir.resolveAutoMobileBaseDir).
+  afterEach(() => {
+    delete process.env.AUTOMOBILE_DATA_DIR;
+  });
+
   test("parses daemon processes from ps pid ppid command output", () => {
     const records = parseDaemonProcessTable(`
       10     1 /usr/bin/unrelated --daemon-mode
@@ -312,6 +319,7 @@ describe("Daemon manager process detection", () => {
 
   test("start takeover escalates to SIGKILL when another live daemon is not the PID-file owner", async () => {
     const dir = mkdtempSync(join(tmpdir(), "daemon-manager-takeover-test-"));
+    process.env.AUTOMOBILE_DATA_DIR = dir;
     const pidFilePath = join(dir, "daemon.pid");
     writeDaemonPidFile(pidFilePath, 201);
     const fakeTimer = new FakeTimer();
@@ -374,6 +382,7 @@ describe("Daemon manager process detection", () => {
 
   test("start takeover does not SIGKILL when daemon identity is no longer confirmed", async () => {
     const dir = mkdtempSync(join(tmpdir(), "daemon-manager-takeover-revalidate-test-"));
+    process.env.AUTOMOBILE_DATA_DIR = dir;
     const pidFilePath = join(dir, "daemon.pid");
     writeDaemonPidFile(pidFilePath, 301);
     const fakeTimer = new FakeTimer();
@@ -445,6 +454,7 @@ describe("Daemon manager process detection", () => {
 
   test("start takeover does not signal transient daemon-mode candidates that are gone by liveness re-check", async () => {
     const dir = mkdtempSync(join(tmpdir(), "daemon-manager-transient-takeover-test-"));
+    process.env.AUTOMOBILE_DATA_DIR = dir;
     const pidFilePath = join(dir, "daemon.pid");
     writeDaemonPidFile(pidFilePath, 201);
     const fakeTimer = new FakeTimer();

--- a/test/utils/dataDir.test.ts
+++ b/test/utils/dataDir.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, test } from "bun:test";
+import os from "node:os";
+import path from "node:path";
+import { resolveAutoMobileBaseDir, getTempDir, TEMP_SUBDIRS } from "../../src/utils/tempDir";
+
+describe("resolveAutoMobileBaseDir", () => {
+  const home = "/home/tester";
+
+  test("prefers AUTOMOBILE_DATA_DIR override, resolved to absolute", () => {
+    expect(resolveAutoMobileBaseDir({ AUTOMOBILE_DATA_DIR: "/srv/automobile" }, home))
+      .toBe("/srv/automobile");
+  });
+
+  test("honors AUTO_MOBILE_DATA_DIR alias", () => {
+    expect(resolveAutoMobileBaseDir({ AUTO_MOBILE_DATA_DIR: "/srv/alias" }, home))
+      .toBe("/srv/alias");
+  });
+
+  test("AUTOMOBILE_DATA_DIR wins over the alias", () => {
+    expect(
+      resolveAutoMobileBaseDir(
+        { AUTOMOBILE_DATA_DIR: "/primary", AUTO_MOBILE_DATA_DIR: "/alias" },
+        home
+      )
+    ).toBe("/primary");
+  });
+
+  test("resolves a relative override against cwd", () => {
+    const resolved = resolveAutoMobileBaseDir({ AUTOMOBILE_DATA_DIR: "rel/data" }, home);
+    expect(path.isAbsolute(resolved)).toBe(true);
+    expect(resolved.endsWith(path.join("rel", "data"))).toBe(true);
+  });
+
+  test("ignores a blank override and uses the stable home default", () => {
+    expect(resolveAutoMobileBaseDir({ AUTOMOBILE_DATA_DIR: "   " }, home))
+      .toBe(path.join(home, ".auto-mobile"));
+  });
+
+  test("defaults to ~/.auto-mobile, never under os.tmpdir()", () => {
+    const base = resolveAutoMobileBaseDir({}, home);
+    expect(base).toBe(path.join(home, ".auto-mobile"));
+    expect(base.startsWith(os.tmpdir())).toBe(false);
+  });
+
+  test("falls back to os.tmpdir()/auto-mobile only when no home dir is available", () => {
+    expect(resolveAutoMobileBaseDir({}, ""))
+      .toBe(path.join(os.tmpdir(), "auto-mobile"));
+  });
+
+  test("does not derive the base from TMPDIR/TMP/TEMP env vars", () => {
+    const base = resolveAutoMobileBaseDir(
+      { TMPDIR: "/ephemeral/bunx-123", TMP: "/ephemeral/bunx-123", TEMP: "/ephemeral/bunx-123" },
+      home
+    );
+    expect(base).toBe(path.join(home, ".auto-mobile"));
+  });
+});
+
+describe("getTempDir", () => {
+  test("derives every subdirectory from the resolved stable base", () => {
+    const logs = getTempDir(TEMP_SUBDIRS.LOGS);
+    const base = resolveAutoMobileBaseDir();
+    expect(logs).toBe(path.join(base, TEMP_SUBDIRS.LOGS));
+  });
+});

--- a/test/utils/dataDir.test.ts
+++ b/test/utils/dataDir.test.ts
@@ -8,12 +8,12 @@ describe("resolveAutoMobileBaseDir", () => {
 
   test("prefers AUTOMOBILE_DATA_DIR override, resolved to absolute", () => {
     expect(resolveAutoMobileBaseDir({ AUTOMOBILE_DATA_DIR: "/srv/automobile" }, home))
-      .toBe("/srv/automobile");
+      .toBe(path.resolve("/srv/automobile"));
   });
 
   test("honors AUTO_MOBILE_DATA_DIR alias", () => {
     expect(resolveAutoMobileBaseDir({ AUTO_MOBILE_DATA_DIR: "/srv/alias" }, home))
-      .toBe("/srv/alias");
+      .toBe(path.resolve("/srv/alias"));
   });
 
   test("AUTOMOBILE_DATA_DIR wins over the alias", () => {
@@ -22,7 +22,7 @@ describe("resolveAutoMobileBaseDir", () => {
         { AUTOMOBILE_DATA_DIR: "/primary", AUTO_MOBILE_DATA_DIR: "/alias" },
         home
       )
-    ).toBe("/primary");
+    ).toBe(path.resolve("/primary"));
   });
 
   test("resolves a relative override against cwd", () => {


### PR DESCRIPTION
## Summary
- Resolve the auto-mobile base directory to a **stable, non-ephemeral** location instead of always `os.tmpdir()`. New `resolveAutoMobileBaseDir()` (`src/utils/tempDir.ts`) prefers `AUTOMOBILE_DATA_DIR`/`AUTO_MOBILE_DATA_DIR`, then `~/.auto-mobile`, falling back to `os.tmpdir()/auto-mobile` only when no home dir is resolvable. It deliberately does **not** derive the base from `TMPDIR`/`TMP`/`TEMP`.
- Relocate the daemon's stdout/stderr launch log from an ephemeral `mkdtemp(os.tmpdir(), "auto-mobile-daemon-")/daemon.log` into the stable logs dir (`…/logs/daemon-launch-<pid>.log`).
- Teach `logPruner` about `daemon-launch-<pid>.log` so the relocated launch log is swept once its spawning manager exits (it no longer lives in an OS-reaped temp dir).
- Update the multi-agent filesystem contract doc: the per-agent isolation knob is now `AUTOMOBILE_DATA_DIR` (not `TMPDIR`).

### Why
Under `bunx`, `os.tmpdir()` can resolve into an extraction tree that `bunx` later reaps while the daemon keeps file descriptors open. The on-disk `…/auto-mobile/logs/*.log` files end up **0 bytes** (live content only reachable via `/proc/<pid>/fd/1`), and persistent cache writes fail with `ENOENT` (e.g. `[OBSERVE_CACHE] Failed to save observe result to disk: ENOENT … /observe_results/…`). Anchoring on the user's home dir avoids that lifecycle entirely.

## Evaluation Criteria
- `resolveAutoMobileBaseDir` returns `AUTOMOBILE_DATA_DIR`/`AUTO_MOBILE_DATA_DIR` when set (resolved absolute), with the primary winning over the alias and blank values ignored.
- The default base is `~/.auto-mobile` and is **never** under `os.tmpdir()`; it falls back to `os.tmpdir()/auto-mobile` only when no home dir exists.
- The base is not derived from `TMPDIR`/`TMP`/`TEMP`.
- The daemon launch log, daemon `daemon.log`, observe cache (`OBSERVE_RESULTS`), and other `getTempDir` consumers all resolve under the stable base.
- The relocated `daemon-launch-<pid>.log` is swept by `logPruner` once its owner has exited and the file is stale, and is never swept while that manager is alive.
- Both issue symptoms are addressed: 0-byte daemon logs and observe-cache `ENOENT` writes.

## Testing
- `bun test` (full suite: 5168 tests, 0 fail)
- `bun test test/utils/dataDir.test.ts test/daemon/`
- `bun run lint`
- `bun run build`

New/updated tests: `test/utils/dataDir.test.ts` (resolver precedence/default/fallback/no-TMPDIR), `test/daemon/daemonManagerLaunch.test.ts` (launch log lands in the stable dir), `test/daemon/loggerPrune.test.ts` (daemon-launch sweep + live-owner preservation), plus data-dir isolation added to daemon manager/readiness/lock tests so they don't write into the real `~/.auto-mobile/logs`.

## Notes
- No PR template file exists in this checkout, so this follows the repo's standard Summary/Evaluation Criteria/Testing/Notes structure.
- Reviewed via `/auto-mobile-code-review`; the one substantive finding (relocated launch log leaking because `logPruner` didn't recognize its prefix) is fixed in this PR.
- Multi-agent deployments that previously isolated via per-agent `TMPDIR` should switch to per-agent `AUTOMOBILE_DATA_DIR` (no production code set `TMPDIR` programmatically; doc updated accordingly).

Closes #2724
