### PR TITLE
fix(ios): give simctl time to flush moov atom on video recording stop

### DIFF
--- a/src/features/video/FfmpegVideoProcessingBackend.ts
+++ b/src/features/video/FfmpegVideoProcessingBackend.ts
@@ -4,7 +4,7 @@ import path from "node:path";
 import { promises as fsPromises } from "node:fs";
 import { pathExists } from "../../utils/filesystem/DefaultFileSystem";
 import { ActionableError, type BootedDevice } from "../../models";
-import { defaultTimer } from "../../utils/SystemTimer";
+import { defaultTimer, type Timer } from "../../utils/SystemTimer";
 import { defaultAdbClientFactory } from "../../utils/android-cmdline-tools/AdbClientFactory";
 import type { AdbClientFactory } from "../../utils/android-cmdline-tools/AdbClientFactory";
 import { SimCtlClient } from "../../utils/ios-cmdline-tools/SimCtlClient";
@@ -16,7 +16,14 @@ import type {
   VideoCaptureConfig,
 } from "./VideoRecorderService";
 
-const PROCESS_EXIT_TIMEOUT_MS = 5000;
+export const PROCESS_EXIT_TIMEOUT_MS = 5000;
+// `xcrun simctl io ... recordVideo` only writes the MP4/MOV moov atom after it
+// receives SIGINT. If we SIGKILL it before the flush finishes the on-disk file is
+// truncated (often 0 bytes), and the downstream ffmpeg `-c copy` remux fails with
+// "moov atom not found". On a loaded CI macOS runner the flush can take well over
+// the generic 5s window, so the iOS stop path waits much longer before escalating
+// to SIGKILL. In the normal case simctl exits within ~1s and we return immediately.
+export const IOS_RECORDING_STOP_TIMEOUT_MS = 30000;
 const FFMPEG_POST_PROCESS_TIMEOUT_MS = 60000;
 const IOS_RECORDING_START_TIMEOUT_MS = 30000;
 const IOS_RECORDING_START_MESSAGES = [
@@ -111,9 +118,28 @@ function trackProcess(process: ChildProcessWithoutNullStreams): ProcessTracker {
   return { process, exitState, exitPromise, stderr };
 }
 
-async function waitForExit(
-  process: ChildProcessWithoutNullStreams,
-  exitPromise: Promise<void>
+/**
+ * Minimal child-process surface needed to gracefully stop a recording. Narrowed
+ * from `ChildProcessWithoutNullStreams` so the SIGINT→SIGKILL escalation can be
+ * unit-tested with a fake process instead of a real spawn.
+ */
+export interface StoppableProcess {
+  exitCode: number | null;
+  killed: boolean;
+  kill(signal?: NodeJS.Signals | number): boolean;
+}
+
+/**
+ * Stop a capture process by sending SIGINT first (which lets `simctl`/`screenrecord`
+ * flush and finalize the file), then escalating to SIGKILL only if the process has
+ * not exited within `timeoutMs`. Callers that record formats requiring a trailing
+ * moov-atom flush (iOS simctl) should pass a generous `timeoutMs`.
+ */
+export async function waitForExit(
+  process: StoppableProcess,
+  exitPromise: Promise<void>,
+  timeoutMs: number = PROCESS_EXIT_TIMEOUT_MS,
+  timer: Timer = defaultTimer
 ): Promise<void> {
   if (process.exitCode !== null) {
     await exitPromise;
@@ -129,18 +155,18 @@ async function waitForExit(
 
   let timeoutId: NodeJS.Timeout | undefined;
   const timeoutPromise = new Promise<void>(resolve => {
-    timeoutId = defaultTimer.setTimeout(() => {
+    timeoutId = timer.setTimeout(() => {
       if (process.exitCode === null) {
         process.kill("SIGKILL");
       }
       resolve();
-    }, PROCESS_EXIT_TIMEOUT_MS);
+    }, timeoutMs);
   });
 
   await Promise.race([exitPromise, timeoutPromise]);
 
   if (timeoutId) {
-    clearTimeout(timeoutId);
+    timer.clearTimeout(timeoutId);
   }
 
   await exitPromise;
@@ -289,9 +315,13 @@ export class FfmpegVideoProcessingBackend implements VideoCaptureBackend {
         );
       }
     } else {
+      // iOS: simctl writes the moov atom only after SIGINT, so give it a generous
+      // window to finalize the file before escalating to SIGKILL. A premature
+      // SIGKILL truncates the raw .mov and breaks the ffmpeg `-c copy` remux.
       await waitForExit(
         backendHandle.captureTracker.process,
-        backendHandle.captureTracker.exitPromise
+        backendHandle.captureTracker.exitPromise,
+        IOS_RECORDING_STOP_TIMEOUT_MS
       );
       await this.postProcessRecording(backendHandle);
     }

--- a/test/features/video/FfmpegVideoProcessingBackend.test.ts
+++ b/test/features/video/FfmpegVideoProcessingBackend.test.ts
@@ -7,11 +7,16 @@ import path from "node:path";
 import {
   containsIosRecordingStartMessage,
   FfmpegVideoProcessingBackend,
+  IOS_RECORDING_STOP_TIMEOUT_MS,
+  PROCESS_EXIT_TIMEOUT_MS,
+  waitForExit,
   waitForStderrMessage,
   type ProcessTracker,
+  type StoppableProcess,
 } from "../../../src/features/video/FfmpegVideoProcessingBackend";
 import type { VideoCaptureConfig } from "../../../src/features/video/VideoRecorderService";
 import type { BootedDevice } from "../../../src/models";
+import { FakeTimer } from "../../fakes/FakeTimer";
 
 function commandVersionAvailable(command: string): boolean {
   const result = spawnSync(command, ["-version"], { stdio: "ignore" });
@@ -475,5 +480,128 @@ describe("FfmpegVideoProcessingBackend - Unit Tests", function() {
       expect(encoders.length).toBeGreaterThan(0);
       expect(listEncodersCalls).toBe(1);
     });
+  });
+});
+
+interface FakeProcessControl {
+  process: StoppableProcess;
+  exitPromise: Promise<void>;
+  killSignals: Array<NodeJS.Signals | number>;
+  exit: (code?: number) => void;
+}
+
+/**
+ * A fake capture process that records which signals it received. It only exits
+ * when the test explicitly calls `exit()` or when it is sent SIGKILL — mirroring
+ * a real `simctl recordVideo` process that ignores everything but SIGINT (which
+ * triggers a flush) and SIGKILL (which terminates immediately).
+ */
+function createFakeProcess(): FakeProcessControl {
+  const killSignals: Array<NodeJS.Signals | number> = [];
+  let resolveExit: () => void = () => {};
+  const exitPromise = new Promise<void>(resolve => {
+    resolveExit = resolve;
+  });
+
+  const exit = (code = 0): void => {
+    if (process.exitCode !== null) {
+      return;
+    }
+    process.exitCode = code;
+    resolveExit();
+  };
+
+  const process: StoppableProcess = {
+    exitCode: null,
+    killed: false,
+    kill(signal?: NodeJS.Signals | number): boolean {
+      killSignals.push(signal ?? "SIGTERM");
+      process.killed = true;
+      if (signal === "SIGKILL") {
+        exit(137);
+      }
+      return true;
+    },
+  };
+
+  return { process, exitPromise, killSignals, exit };
+}
+
+describe("waitForExit - graceful capture stop", function() {
+  test("sends SIGINT and returns without SIGKILL when the process flushes in time", async function() {
+    const timer = new FakeTimer();
+    const { process, exitPromise, killSignals, exit } = createFakeProcess();
+
+    const pending = waitForExit(process, exitPromise, IOS_RECORDING_STOP_TIMEOUT_MS, timer);
+
+    // SIGINT is delivered synchronously so simctl can begin flushing the moov atom.
+    expect(killSignals).toEqual(["SIGINT"]);
+
+    // simctl takes 8s to write the file under load — well within the iOS window.
+    timer.advanceTime(8000);
+    await Promise.resolve();
+    expect(killSignals).toEqual(["SIGINT"]);
+
+    exit(0);
+    await pending;
+
+    // No SIGKILL: the file was allowed to finalize cleanly.
+    expect(killSignals).toEqual(["SIGINT"]);
+  });
+
+  test("escalates to SIGKILL once the timeout elapses", async function() {
+    const timer = new FakeTimer();
+    const { process, exitPromise, killSignals } = createFakeProcess();
+
+    const pending = waitForExit(process, exitPromise, PROCESS_EXIT_TIMEOUT_MS, timer);
+
+    expect(killSignals).toEqual(["SIGINT"]);
+
+    // Just before the deadline the process is still given a chance to exit cleanly.
+    timer.advanceTime(PROCESS_EXIT_TIMEOUT_MS - 1);
+    await Promise.resolve();
+    expect(killSignals).toEqual(["SIGINT"]);
+
+    // After the deadline it is force-killed so the caller never hangs.
+    timer.advanceTime(1);
+    await pending;
+    expect(killSignals).toEqual(["SIGINT", "SIGKILL"]);
+  });
+
+  test("the legacy 5s window would SIGKILL a slow simctl flush that the iOS window survives", async function() {
+    const slowFlushMs = 8000;
+
+    // Legacy generic timeout: the same slow flush is force-killed mid-write.
+    const legacyTimer = new FakeTimer();
+    const legacy = createFakeProcess();
+    const legacyPending = waitForExit(
+      legacy.process,
+      legacy.exitPromise,
+      PROCESS_EXIT_TIMEOUT_MS,
+      legacyTimer
+    );
+    legacyTimer.advanceTime(slowFlushMs);
+    await legacyPending;
+    expect(legacy.killSignals).toEqual(["SIGINT", "SIGKILL"]);
+
+    // iOS window: the slow flush completes and the process exits via SIGINT only.
+    const iosTimer = new FakeTimer();
+    const ios = createFakeProcess();
+    const iosPending = waitForExit(
+      ios.process,
+      ios.exitPromise,
+      IOS_RECORDING_STOP_TIMEOUT_MS,
+      iosTimer
+    );
+    iosTimer.advanceTime(slowFlushMs);
+    await Promise.resolve();
+    ios.exit(0);
+    await iosPending;
+    expect(ios.killSignals).toEqual(["SIGINT"]);
+  });
+
+  test("iOS stop window is generous enough for a moov-atom flush under load", function() {
+    expect(IOS_RECORDING_STOP_TIMEOUT_MS).toBeGreaterThan(PROCESS_EXIT_TIMEOUT_MS);
+    expect(IOS_RECORDING_STOP_TIMEOUT_MS).toBeGreaterThanOrEqual(30000);
   });
 });


### PR DESCRIPTION
## Summary
Fixes the flaky/failing iOS video recording integration test (`test/integration/iosVideoRecordingStartStop.integration.test.ts`, added in #2632) by making the iOS recording **stop** reliably finalize a non-empty, ffprobe-playable MP4.

## Root cause
The iOS capture pipeline is `xcrun simctl io <udid> recordVideo <id>-raw.mov` → ffmpeg `-c copy` remux to `.mp4`. On stop, `FfmpegVideoProcessingBackend` called the generic `waitForExit`, which sends **SIGINT**, waits **5s** (`PROCESS_EXIT_TIMEOUT_MS`), then escalates to **SIGKILL**.

`simctl recordVideo` only writes the MP4/MOV **moov atom** *after* it receives SIGINT. Under load (e.g. a busy CI macOS runner with a slow disk) that flush can take longer than the 5s window, so the SIGKILL truncates the raw `.mov`. Reproduced locally:

- SIGINT → file is written, `ffprobe` reports a valid video stream ✅
- SIGKILL before flush → raw `.mov` is **0 bytes**; `ffmpeg -i raw.mov -c copy ...` fails immediately with **`moov atom not found`** → empty/unplayable output → the test's size/`ffprobe` assertions fail.

(The exact 123s CI wall-clock wasn't reproduced on my faster local machine — the test passes locally in ~5.5s — but the truncation failure mode above is the demonstrable cause behind the empty/unplayable MP4.)

## Fix
- Add `IOS_RECORDING_STOP_TIMEOUT_MS = 30000` and use it for the iOS stop path so `simctl` has a generous window to flush the moov atom before any SIGKILL. The happy path is unaffected — `simctl` normally exits within ~1s and `waitForExit` returns immediately.
- Make `waitForExit` accept an injectable `timeoutMs` + `Timer` (narrowed `StoppableProcess` surface) so the SIGINT→SIGKILL escalation is unit-testable with a fake process/`FakeTimer`. The Android and start-failure-cleanup callers keep the original 5s default.

No test was relaxed; the production behavior change is limited to the iOS stop window.

## Test plan
- New fast unit tests in `test/features/video/FfmpegVideoProcessingBackend.test.ts` (FakeTimer, no device, runs in ~ms):
  - SIGINT is sent and **no** SIGKILL follows when the process flushes within the window.
  - Escalates to SIGKILL once `timeoutMs` elapses (caller never hangs).
  - The legacy 5s window would SIGKILL a slow flush that the 30s iOS window survives (captures the regression).
  - `IOS_RECORDING_STOP_TIMEOUT_MS` is generous vs `PROCESS_EXIT_TIMEOUT_MS`.
- `bun test test/features/video/` → 69 pass (149ms).
- `AUTOMOBILE_IOS_VIDEO_RECORDING_INTEGRATION=1 bun test test/integration/iosVideoRecordingStartStop.integration.test.ts` against a booted simulator → passes.
- `turbo run lint build` → green.

Refs #2632
