### PR TITLE
fix(daemon): detect wrong-build daemon via build identity + self-heal unknown-tool (#2732)

### DIFF
--- a/src/daemon/buildIdentity.ts
+++ b/src/daemon/buildIdentity.ts
@@ -1,0 +1,90 @@
+import { createHash } from "node:crypto";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+/**
+ * Identity of a particular AutoMobile build.
+ *
+ * The daemon and the MCP frontend share one per-uid socket, so two checkouts on
+ * the same machine (e.g. a worktree RC build + a main-repo build) can end up with
+ * a daemon from one checkout serving a frontend from another. Both builds may
+ * report the same package version (pre-release, package.json not bumped), so the
+ * version string alone cannot detect the skew. A content hash of the entry script
+ * can — that is what {@link BuildIdentity.buildId} carries.
+ */
+export interface BuildIdentity {
+  /** Absolute path to the entry script (process.argv[1]) — "" when unknown. */
+  entryScript: string;
+  /** Short content hash of the entry script, or "unknown" when it cannot be read. */
+  buildId: string;
+}
+
+/** Sentinel used when a build id cannot be computed. */
+const UNKNOWN_BUILD_ID = "unknown";
+
+function hashEntryScript(absolutePath: string): string {
+  const content = readFileSync(absolutePath);
+  return createHash("sha256").update(content).digest("hex").slice(0, 16);
+}
+
+/**
+ * Compute the {@link BuildIdentity} for an entry script.
+ *
+ * @param entryScript path to the entry script (typically process.argv[1])
+ * @param hashFile injectable hasher (defaults to a sha256 of the file contents);
+ *                 overridden in tests to avoid touching the filesystem
+ */
+export function computeBuildIdentity(
+  entryScript: string | undefined,
+  hashFile: (absolutePath: string) => string = hashEntryScript
+): BuildIdentity {
+  if (!entryScript) {
+    return { entryScript: "", buildId: UNKNOWN_BUILD_ID };
+  }
+  const absolute = resolve(entryScript);
+  try {
+    return { entryScript: absolute, buildId: hashFile(absolute) };
+  } catch {
+    // The entry script should always be readable; if it is not, fall back to an
+    // unknown id rather than crashing the connection path. The entryScript path
+    // is still recorded so callers can fall back to path identity.
+    return { entryScript: absolute, buildId: UNKNOWN_BUILD_ID };
+  }
+}
+
+let cachedIdentity: BuildIdentity | null = null;
+
+/**
+ * Identity of the currently running process's build. Cached after first use —
+ * the entry script does not change while the process is alive.
+ */
+export function getCurrentBuildIdentity(): BuildIdentity {
+  if (!cachedIdentity) {
+    cachedIdentity = computeBuildIdentity(process.argv[1]);
+  }
+  return cachedIdentity;
+}
+
+function isKnownBuildId(buildId: string): boolean {
+  return buildId.length > 0 && buildId !== UNKNOWN_BUILD_ID;
+}
+
+/**
+ * Decide whether two builds are the same.
+ *
+ * - When both sides expose a known content hash, compare the hashes.
+ * - When a hash is missing on one side, fall back to comparing the resolved entry
+ *   script path.
+ * - When neither side carries usable identity (e.g. a legacy daemon whose PID file
+ *   predates build identity), treat it as a match so the frontend does not enter
+ *   an endless restart loop against a daemon it cannot identify.
+ */
+export function buildIdentitiesMatch(a: BuildIdentity, b: BuildIdentity): boolean {
+  if (isKnownBuildId(a.buildId) && isKnownBuildId(b.buildId)) {
+    return a.buildId === b.buildId;
+  }
+  if (a.entryScript.length > 0 && b.entryScript.length > 0) {
+    return a.entryScript === b.entryScript;
+  }
+  return true;
+}

--- a/src/daemon/daemon.ts
+++ b/src/daemon/daemon.ts
@@ -19,6 +19,7 @@ import { DaemonOptions, PidFileData } from "./types";
 import { mkdir, writeFile } from "node:fs/promises";
 import { dirname } from "node:path";
 import { PID_FILE_PATH, DAEMON_VERSION } from "./constants";
+import { getCurrentBuildIdentity } from "./buildIdentity";
 import { cleanupDaemonFiles, cleanupDaemonFilesSync, readPidFileDataSync } from "./daemonFiles";
 import { executionTracker } from "../server/executionTracker";
 import { closeDatabase, getDatabase } from "../db";
@@ -603,6 +604,7 @@ export class Daemon {
    * Write PID file with daemon metadata
    */
   private async writePidFile(): Promise<void> {
+    const buildIdentity = getCurrentBuildIdentity();
     const pidData: PidFileData = {
       pid: process.pid,
       socketPath: SOCKET_PATH,
@@ -610,6 +612,8 @@ export class Daemon {
       port: this.port,
       startedAt: this.timer.now(),
       version: DAEMON_VERSION,
+      entryScript: buildIdentity.entryScript,
+      buildId: buildIdentity.buildId,
       options: this.options,
     };
 

--- a/src/daemon/daemonMcpProxy.ts
+++ b/src/daemon/daemonMcpProxy.ts
@@ -5,12 +5,22 @@ import { SOCKET_PATH, DAEMON_STARTUP_TIMEOUT_MS, CONNECTION_TIMEOUT_MS, DAEMON_V
 import type { DaemonOptions } from "./types";
 import { compareVersions } from "../server/deviceMatcher";
 import { defaultTimer, type Timer } from "../utils/SystemTimer";
+import {
+  type BuildIdentity,
+  buildIdentitiesMatch,
+  getCurrentBuildIdentity,
+} from "./buildIdentity";
 
 export type VersionMismatchReason =
   | "autoStartDisabled"
   | "cooldown"
   | "daemonNewer"
   | "nonNumeric"
+  | "restartMismatch";
+
+export type BuildMismatchReason =
+  | "autoStartDisabled"
+  | "cooldown"
   | "restartMismatch";
 
 /**
@@ -49,6 +59,79 @@ export class DaemonVersionMismatchError extends DaemonUnavailableError {
 }
 
 /**
+ * Raised when the running daemon is a *different build* than this client even
+ * though the version strings may be identical (e.g. two checkouts that both
+ * report a pre-release version sharing one per-uid socket). Detected via the
+ * build-identity content hash rather than the version string.
+ */
+export class DaemonBuildMismatchError extends DaemonUnavailableError {
+  readonly clientBuildId: string;
+  readonly daemonBuildId: string;
+  readonly clientEntryScript: string;
+  readonly daemonEntryScript: string;
+  readonly reason: BuildMismatchReason;
+  readonly retryAfterMs?: number;
+
+  constructor(params: {
+    client: BuildIdentity;
+    daemon: BuildIdentity;
+    reason: BuildMismatchReason;
+    detail: string;
+    retryAfterMs?: number;
+  }) {
+    const daemonScript = params.daemon.entryScript || "unknown";
+    const clientScript = params.client.entryScript || "unknown";
+    const retryGuidance = params.retryAfterMs !== undefined
+      ? ` Retry after ${params.retryAfterMs}ms.`
+      : "";
+    super(
+      `AutoMobile daemon build mismatch: the running daemon is a different build than this client ` +
+      `(${params.detail}). daemon build=${params.daemon.buildId} (${daemonScript}), ` +
+      `client build=${params.client.buildId} (${clientScript}).${retryGuidance}`
+    );
+    this.name = "DaemonBuildMismatchError";
+    this.clientBuildId = params.client.buildId;
+    this.daemonBuildId = params.daemon.buildId;
+    this.clientEntryScript = params.client.entryScript;
+    this.daemonEntryScript = params.daemon.entryScript;
+    this.reason = params.reason;
+    this.retryAfterMs = params.retryAfterMs;
+  }
+}
+
+/**
+ * Raised when a tool the frontend advertises is rejected by the daemon as
+ * "Unknown tool" even after the proxy reconciled build identity and retried.
+ * Replaces the opaque `-32603` with an actionable message naming both builds.
+ */
+export class DaemonToolUnavailableError extends Error {
+  readonly toolName: string;
+  readonly clientBuildId: string;
+  readonly daemonBuildId: string;
+
+  constructor(params: {
+    toolName: string;
+    client: BuildIdentity;
+    daemon: BuildIdentity;
+  }) {
+    const daemonScript = params.daemon.entryScript || "unknown";
+    const clientScript = params.client.entryScript || "unknown";
+    super(
+      `Tool "${params.toolName}" is advertised by this AutoMobile client but the connected daemon ` +
+      `does not provide it, even after restarting and refreshing the tool list. This usually means a ` +
+      `wrong-build daemon is serving this frontend. ` +
+      `client build=${params.client.buildId} (${clientScript}), ` +
+      `daemon build=${params.daemon.buildId} (${daemonScript}). ` +
+      `Restart the daemon from this checkout to resolve the skew.`
+    );
+    this.name = "DaemonToolUnavailableError";
+    this.toolName = params.toolName;
+    this.clientBuildId = params.client.buildId;
+    this.daemonBuildId = params.daemon.buildId;
+  }
+}
+
+/**
  * Configuration for the DaemonMcpProxy
  */
 export interface DaemonMcpProxyConfig {
@@ -66,6 +149,8 @@ export interface DaemonMcpProxyConfig {
   daemonOptions?: DaemonOptions;
   /** Timer for version restart cooldown checks */
   timer?: Pick<Timer, "now">;
+  /** This client's build identity (for testing; defaults to the current process build) */
+  buildIdentity?: BuildIdentity;
 }
 
 /**
@@ -113,6 +198,7 @@ export class DaemonMcpProxy {
   private daemonManager: DaemonManagerLike;
   private clientFactory: DaemonClientFactory;
   private readonly timer: Pick<Timer, "now">;
+  private readonly buildIdentity: BuildIdentity;
   private connecting: Promise<void> | null = null;
   private connected: boolean = false;
 
@@ -134,6 +220,7 @@ export class DaemonMcpProxy {
       this.config.connectionTimeoutMs
     ));
     this.timer = config.timer ?? defaultTimer;
+    this.buildIdentity = config.buildIdentity ?? getCurrentBuildIdentity();
   }
 
   /**
@@ -172,9 +259,11 @@ export class DaemonMcpProxy {
       logger.info("[DaemonMcpProxy] Daemon not available, starting daemon...");
       await this.startDaemon();
       await this.ensureVersionMatches();
+      await this.ensureBuildMatches();
       await this.ensureStartupOptionsMatch();
     } else {
       await this.ensureVersionMatches();
+      await this.ensureBuildMatches();
       await this.ensureStartupOptionsMatch();
     }
 
@@ -243,6 +332,9 @@ export class DaemonMcpProxy {
       `[DaemonMcpProxy] Daemon version ${runningVersion || "unknown"} differs from MCP server ${DAEMON_VERSION}, restarting daemon`
     );
     await this.daemonManager.restart(this.config.daemonOptions ?? {});
+    // The replacement daemon may expose a different tool set; drop the cache so we
+    // never advertise the old daemon's tools against the new build.
+    this.invalidateCache();
     const ready = await this.daemonManager.waitForReady(DAEMON_STARTUP_TIMEOUT_MS);
     if (!ready) {
       throw new DaemonUnavailableError(
@@ -272,6 +364,90 @@ export class DaemonMcpProxy {
     return new DaemonVersionMismatchError({
       clientVersion,
       daemonVersion,
+      reason,
+      detail,
+      retryAfterMs,
+    });
+  }
+
+  /**
+   * Ensure the client never attaches to a daemon built from a *different* checkout.
+   * The version string alone cannot detect this (two checkouts can both report the
+   * same pre-release version), so we compare a content hash of the entry script.
+   * On mismatch, restart the daemon from this client's own entrypoint so the live
+   * frontend and backend run the same code. Independent of, and complementary to,
+   * {@link ensureVersionMatches}.
+   */
+  private async ensureBuildMatches(): Promise<void> {
+    const status = await this.daemonManager.status();
+    if (!status.running) {
+      return;
+    }
+
+    const daemonIdentity: BuildIdentity = {
+      entryScript: status.entryScript ?? "",
+      buildId: status.buildId ?? "unknown",
+    };
+    if (buildIdentitiesMatch(this.buildIdentity, daemonIdentity)) {
+      return;
+    }
+
+    if (!this.config.autoStartDaemon) {
+      throw this.buildMismatchError(daemonIdentity, "autoStartDisabled", "auto-start is disabled");
+    }
+
+    if (status.startedAt) {
+      const daemonAgeMs = this.timer.now() - status.startedAt;
+      if (daemonAgeMs < DAEMON_VERSION_RESTART_COOLDOWN_MS) {
+        logger.warn(
+          `[DaemonMcpProxy] Skipping build-mismatch restart due to cooldown: daemon build ${daemonIdentity.buildId} is ${daemonAgeMs}ms old, client build is ${this.buildIdentity.buildId}`
+        );
+        throw this.buildMismatchError(
+          daemonIdentity,
+          "cooldown",
+          "restart is in cooldown",
+          DAEMON_VERSION_RESTART_COOLDOWN_MS - daemonAgeMs
+        );
+      }
+    }
+
+    logger.info(
+      `[DaemonMcpProxy] Daemon build ${daemonIdentity.buildId} (${daemonIdentity.entryScript || "unknown"}) differs from client build ${this.buildIdentity.buildId} (${this.buildIdentity.entryScript || "unknown"}), restarting daemon`
+    );
+    await this.daemonManager.restart(this.config.daemonOptions ?? {});
+    // The replacement daemon may expose a different tool set; drop the cache so we
+    // never advertise the old daemon's tools against the new build.
+    this.invalidateCache();
+    const ready = await this.daemonManager.waitForReady(DAEMON_STARTUP_TIMEOUT_MS);
+    if (!ready) {
+      throw new DaemonUnavailableError(
+        `Daemon failed to restart within ${DAEMON_STARTUP_TIMEOUT_MS}ms`
+      );
+    }
+
+    const restartedStatus = await this.daemonManager.status();
+    const restartedIdentity: BuildIdentity = {
+      entryScript: restartedStatus.entryScript ?? "",
+      buildId: restartedStatus.buildId ?? "unknown",
+    };
+    if (!restartedStatus.running || !buildIdentitiesMatch(this.buildIdentity, restartedIdentity)) {
+      throw this.buildMismatchError(
+        restartedIdentity,
+        "restartMismatch",
+        "daemon restart completed but build still differs"
+      );
+    }
+  }
+
+  private buildMismatchError(
+    daemon: BuildIdentity,
+    reason: BuildMismatchReason,
+    detail: string,
+    retryAfterMs?: number,
+  ): DaemonBuildMismatchError {
+    return new DaemonBuildMismatchError({
+      client: this.buildIdentity,
+      daemon,
       reason,
       detail,
       retryAfterMs,
@@ -365,7 +541,16 @@ export class DaemonMcpProxy {
     }
 
     const message = error instanceof Error ? error.message : String(error);
-    return message.includes("Session not found");
+    // "Unknown tool" means the frontend advertised a tool the daemon rejects —
+    // typically a wrong-build daemon serving this frontend. Reconnecting drops the
+    // stale tool cache and re-runs the build-identity handshake (which restarts the
+    // daemon to the correct build on skew), so retry once before giving up.
+    return message.includes("Session not found") || this.isUnknownToolError(error);
+  }
+
+  private isUnknownToolError(error: unknown): boolean {
+    const message = error instanceof Error ? error.message : String(error);
+    return message.includes("Unknown tool:");
   }
 
   private async resetConnection(): Promise<void> {
@@ -414,7 +599,36 @@ export class DaemonMcpProxy {
     name: string,
     args: Record<string, unknown>
   ): Promise<any> {
-    return await this.withRecoverableReconnect(() => this.client!.callTool(name, args));
+    try {
+      return await this.withRecoverableReconnect(() => this.client!.callTool(name, args));
+    } catch (error) {
+      // withRecoverableReconnect already reconciled build identity and retried once.
+      // A still-"Unknown tool" failure means the daemon genuinely cannot provide a
+      // tool this frontend advertises — surface an actionable error naming both
+      // builds instead of the opaque -32603.
+      if (this.isUnknownToolError(error)) {
+        throw await this.toolUnavailableError(name);
+      }
+      throw error;
+    }
+  }
+
+  private async toolUnavailableError(name: string): Promise<DaemonToolUnavailableError> {
+    let daemonIdentity: BuildIdentity = { entryScript: "", buildId: "unknown" };
+    try {
+      const status = await this.daemonManager.status();
+      daemonIdentity = {
+        entryScript: status.entryScript ?? "",
+        buildId: status.buildId ?? "unknown",
+      };
+    } catch (error) {
+      logger.warn(`[DaemonMcpProxy] Failed to read daemon status for tool-unavailable error: ${error}`);
+    }
+    return new DaemonToolUnavailableError({
+      toolName: name,
+      client: this.buildIdentity,
+      daemon: daemonIdentity,
+    });
   }
 
   /**

--- a/src/daemon/manager.ts
+++ b/src/daemon/manager.ts
@@ -795,6 +795,8 @@ export class DaemonManager implements DaemonManagerLike {
         sockets: pidData.sockets,
         startedAt: pidData.startedAt,
         version: pidData.version,
+        entryScript: pidData.entryScript,
+        buildId: pidData.buildId,
         options: pidData.options,
       };
     } catch (error) {

--- a/src/daemon/types.ts
+++ b/src/daemon/types.ts
@@ -66,6 +66,10 @@ export interface DaemonStatus {
   startedAt?: number;
   /** Daemon version */
   version?: string;
+  /** Absolute path to the daemon's entry script (build identity) */
+  entryScript?: string;
+  /** Content hash of the daemon's entry script (build identity) */
+  buildId?: string;
   /** Options used to start the daemon */
   options?: DaemonOptions;
 }
@@ -86,6 +90,10 @@ export interface PidFileData {
   startedAt: number;
   /** Daemon version */
   version: string;
+  /** Absolute path to the daemon's entry script (build identity) */
+  entryScript?: string;
+  /** Content hash of the daemon's entry script (build identity) */
+  buildId?: string;
   /** Options used to start the daemon */
   options?: DaemonOptions;
 }

--- a/test/daemon/buildIdentity.test.ts
+++ b/test/daemon/buildIdentity.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test";
+import { resolve } from "node:path";
 import {
   computeBuildIdentity,
   buildIdentitiesMatch,
@@ -17,7 +18,9 @@ describe("buildIdentity", () => {
 
     test("resolves the entry script to an absolute path", () => {
       const identity = computeBuildIdentity("/repo/dist/src/index.js", () => "abc123");
-      expect(identity.entryScript).toBe("/repo/dist/src/index.js");
+      // resolve() is platform-dependent (Windows prefixes a drive letter), so
+      // compare against resolve() of the same input rather than a POSIX literal.
+      expect(identity.entryScript).toBe(resolve("/repo/dist/src/index.js"));
     });
 
     test("returns different buildIds for different file contents", () => {
@@ -35,7 +38,7 @@ describe("buildIdentity", () => {
       const identity = computeBuildIdentity("/does/not/exist.js", () => {
         throw new Error("ENOENT");
       });
-      expect(identity.entryScript).toBe("/does/not/exist.js");
+      expect(identity.entryScript).toBe(resolve("/does/not/exist.js"));
       expect(identity.buildId).toBe("unknown");
     });
   });

--- a/test/daemon/buildIdentity.test.ts
+++ b/test/daemon/buildIdentity.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, test } from "bun:test";
+import {
+  computeBuildIdentity,
+  buildIdentitiesMatch,
+  type BuildIdentity,
+} from "../../src/daemon/buildIdentity";
+
+describe("buildIdentity", () => {
+  describe("computeBuildIdentity", () => {
+    test("returns a stable hash for identical contents", () => {
+      const hashFile = () => "deadbeefcafef00d";
+      const a = computeBuildIdentity("/a/dist/index.js", hashFile);
+      const b = computeBuildIdentity("/a/dist/index.js", hashFile);
+      expect(a.buildId).toBe(b.buildId);
+      expect(a.buildId).toBe("deadbeefcafef00d");
+    });
+
+    test("resolves the entry script to an absolute path", () => {
+      const identity = computeBuildIdentity("/repo/dist/src/index.js", () => "abc123");
+      expect(identity.entryScript).toBe("/repo/dist/src/index.js");
+    });
+
+    test("returns different buildIds for different file contents", () => {
+      const worktree = computeBuildIdentity("/wt/dist/index.js", () => "1111111111111111");
+      const main = computeBuildIdentity("/main/dist/index.js", () => "2222222222222222");
+      expect(worktree.buildId).not.toBe(main.buildId);
+    });
+
+    test("missing entry script yields an unknown identity without throwing", () => {
+      const identity = computeBuildIdentity(undefined);
+      expect(identity).toEqual({ entryScript: "", buildId: "unknown" });
+    });
+
+    test("unreadable entry script yields buildId 'unknown'", () => {
+      const identity = computeBuildIdentity("/does/not/exist.js", () => {
+        throw new Error("ENOENT");
+      });
+      expect(identity.entryScript).toBe("/does/not/exist.js");
+      expect(identity.buildId).toBe("unknown");
+    });
+  });
+
+  describe("buildIdentitiesMatch", () => {
+    const wt: BuildIdentity = { entryScript: "/wt/dist/index.js", buildId: "aaaa" };
+    const wt2: BuildIdentity = { entryScript: "/wt/dist/index.js", buildId: "aaaa" };
+    const main: BuildIdentity = { entryScript: "/main/dist/index.js", buildId: "bbbb" };
+
+    test("same known buildId matches", () => {
+      expect(buildIdentitiesMatch(wt, wt2)).toBe(true);
+    });
+
+    test("different known buildId does not match", () => {
+      expect(buildIdentitiesMatch(wt, main)).toBe(false);
+    });
+
+    test("falls back to entryScript when one buildId is unknown", () => {
+      const sameScriptUnknown: BuildIdentity = { entryScript: "/wt/dist/index.js", buildId: "unknown" };
+      expect(buildIdentitiesMatch(wt, sameScriptUnknown)).toBe(true);
+
+      const otherScriptUnknown: BuildIdentity = { entryScript: "/main/dist/index.js", buildId: "unknown" };
+      expect(buildIdentitiesMatch(wt, otherScriptUnknown)).toBe(false);
+    });
+
+    test("missing identity on either side is treated as a match (backward compatible)", () => {
+      const legacy: BuildIdentity = { entryScript: "", buildId: "unknown" };
+      expect(buildIdentitiesMatch(wt, legacy)).toBe(true);
+      expect(buildIdentitiesMatch(legacy, main)).toBe(true);
+    });
+  });
+});

--- a/test/daemon/daemonMcpProxy.test.ts
+++ b/test/daemon/daemonMcpProxy.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, test, spyOn } from "bun:test";
-import { DaemonMcpProxy, DaemonVersionMismatchError } from "../../src/daemon/daemonMcpProxy";
+import {
+  DaemonMcpProxy,
+  DaemonVersionMismatchError,
+  DaemonBuildMismatchError,
+  DaemonToolUnavailableError,
+} from "../../src/daemon/daemonMcpProxy";
 import { DaemonClient, DaemonUnavailableError, type DaemonClientLike } from "../../src/daemon/client";
 import { DAEMON_VERSION, DAEMON_VERSION_RESTART_COOLDOWN_MS } from "../../src/daemon/constants";
 import { logger } from "../../src/utils/logger";
@@ -383,9 +388,10 @@ describe("DaemonMcpProxy", () => {
         });
         const fakeManager = new FakeDaemonManager();
         fakeManager.statusResults = [
-          runningStatus({ embeddedSdk: false }),
-          runningStatus({ embeddedSdk: false }),
-          runningStatus({ embeddedSdk: true }),
+          runningStatus({ embeddedSdk: false }), // ensureVersionMatches
+          runningStatus({ embeddedSdk: false }), // ensureBuildMatches
+          runningStatus({ embeddedSdk: false }), // ensureStartupOptionsMatch (mismatch)
+          runningStatus({ embeddedSdk: true }), // post-restart verify
         ];
         const isAvailableSpy = spyOn(DaemonClient, "isAvailable").mockResolvedValue(true);
         const proxy = new DaemonMcpProxy({
@@ -410,8 +416,9 @@ describe("DaemonMcpProxy", () => {
         });
         const fakeManager = new FakeDaemonManager();
         fakeManager.statusResults = [
-          runningStatus({ embeddedSdk: true }),
-          runningStatus({ embeddedSdk: true }),
+          runningStatus({ embeddedSdk: true }), // ensureVersionMatches
+          runningStatus({ embeddedSdk: true }), // ensureBuildMatches
+          runningStatus({ embeddedSdk: true }), // ensureStartupOptionsMatch
         ];
         const isAvailableSpy = spyOn(DaemonClient, "isAvailable").mockResolvedValue(true);
         const proxy = new DaemonMcpProxy({
@@ -435,8 +442,9 @@ describe("DaemonMcpProxy", () => {
         });
         const fakeManager = new FakeDaemonManager();
         fakeManager.statusResults = [
-          runningStatus({ embeddedSdk: false }),
-          runningStatus({ embeddedSdk: false }),
+          runningStatus({ embeddedSdk: false }), // ensureVersionMatches
+          runningStatus({ embeddedSdk: false }), // ensureBuildMatches
+          runningStatus({ embeddedSdk: false }), // ensureStartupOptionsMatch
         ];
         const isAvailableSpy = spyOn(DaemonClient, "isAvailable").mockResolvedValue(true);
         const proxy = new DaemonMcpProxy({
@@ -792,6 +800,282 @@ describe("DaemonMcpProxy", () => {
         await proxy.listResources();
 
         expect(fakeClient.callDaemonMethodCalls.length).toBe(4);
+      } finally {
+        isAvailableSpy.mockRestore();
+        await proxy.close();
+      }
+    });
+  });
+
+  describe("build-identity handshake", () => {
+    const CLIENT_BUILD = { entryScript: "/client/dist/index.js", buildId: "clientbuild" };
+    const DAEMON_BUILD = { entryScript: "/daemon/dist/index.js", buildId: "daemonbuild" };
+
+    function makeBuildProxy(opts: {
+      // Identity reported by the running daemon before any restart.
+      daemonBuildId?: string | null;
+      daemonEntryScript?: string | null;
+      // Identity reported after a restart (defaults to the client's identity = match).
+      restartedBuildId?: string;
+      restartedEntryScript?: string;
+      startedAt?: number;
+      autoStartDaemon?: boolean;
+      waitForReadyResult?: boolean;
+    } = {}) {
+      const timer = new FakeTimer();
+      timer.advanceTime(100_000);
+      const fakeClient = new FakeDaemonClient({
+        daemonMethodResults: new Map([["tools/list", { tools: [] }]]),
+      });
+      const fakeManager = new FakeDaemonManager();
+
+      const mismatchStatus = {
+        running: true,
+        pid: 1234,
+        port: 3000,
+        socketPath: "/tmp/test.sock",
+        version: DAEMON_VERSION, // versions match so only the build differs
+        startedAt: opts.startedAt ?? ANCIENT_TIMESTAMP,
+        ...(opts.daemonBuildId === null ? {} : { buildId: opts.daemonBuildId ?? DAEMON_BUILD.buildId }),
+        ...(opts.daemonEntryScript === null ? {} : { entryScript: opts.daemonEntryScript ?? DAEMON_BUILD.entryScript }),
+      };
+      const restartedStatus = {
+        ...mismatchStatus,
+        buildId: opts.restartedBuildId ?? CLIENT_BUILD.buildId,
+        entryScript: opts.restartedEntryScript ?? CLIENT_BUILD.entryScript,
+        startedAt: timer.now(),
+      };
+
+      // ensureVersionMatches consumes one status() (versions match → returns), then
+      // ensureBuildMatches consumes one to detect the mismatch. Both return the
+      // mismatch status; the fallback statusResult is the post-restart identity.
+      fakeManager.statusResult = restartedStatus;
+      fakeManager.statusResults = [mismatchStatus, mismatchStatus];
+      if (opts.waitForReadyResult !== undefined) {
+        fakeManager.waitForReadyResult = opts.waitForReadyResult;
+      }
+
+      const isAvailableSpy = spyOn(DaemonClient, "isAvailable").mockResolvedValue(true);
+      const proxy = new DaemonMcpProxy({
+        clientFactory: () => fakeClient,
+        daemonManager: fakeManager,
+        autoStartDaemon: opts.autoStartDaemon ?? true,
+        timer,
+        buildIdentity: { ...CLIENT_BUILD },
+      });
+      return { fakeClient, fakeManager, isAvailableSpy, proxy };
+    }
+
+    async function expectBuildMismatch(promise: Promise<unknown>): Promise<DaemonBuildMismatchError> {
+      try {
+        await promise;
+      } catch (error) {
+        expect(error).toBeInstanceOf(DaemonBuildMismatchError);
+        return error as DaemonBuildMismatchError;
+      }
+      throw new Error("Expected DaemonBuildMismatchError");
+    }
+
+    test("restarts daemon and invalidates cache when build differs", async () => {
+      const { fakeManager, isAvailableSpy, proxy } = makeBuildProxy();
+      const invalidateSpy = spyOn(proxy, "invalidateCache");
+      try {
+        await proxy.listTools();
+        expect(fakeManager.restartCalled).toBe(true);
+        expect(invalidateSpy).toHaveBeenCalled();
+      } finally {
+        invalidateSpy.mockRestore();
+        isAvailableSpy.mockRestore();
+        await proxy.close();
+      }
+    });
+
+    test("does not restart when build identity matches", async () => {
+      const { fakeManager, isAvailableSpy, proxy } = makeBuildProxy({
+        daemonBuildId: CLIENT_BUILD.buildId,
+        daemonEntryScript: CLIENT_BUILD.entryScript,
+      });
+      try {
+        await proxy.listTools();
+        expect(fakeManager.restartCalled).toBe(false);
+      } finally {
+        isAvailableSpy.mockRestore();
+        await proxy.close();
+      }
+    });
+
+    test("treats a daemon with no build identity as a match (backward compatible)", async () => {
+      const { fakeManager, isAvailableSpy, proxy } = makeBuildProxy({
+        daemonBuildId: null,
+        daemonEntryScript: null,
+      });
+      try {
+        await proxy.listTools();
+        expect(fakeManager.restartCalled).toBe(false);
+      } finally {
+        isAvailableSpy.mockRestore();
+        await proxy.close();
+      }
+    });
+
+    test("throws DaemonBuildMismatchError without restarting when auto-start is disabled", async () => {
+      const { fakeClient, fakeManager, isAvailableSpy, proxy } = makeBuildProxy({
+        autoStartDaemon: false,
+      });
+      try {
+        const error = await expectBuildMismatch(proxy.listTools());
+        expect(error.reason).toBe("autoStartDisabled");
+        expect(error.daemonBuildId).toBe(DAEMON_BUILD.buildId);
+        expect(error.clientBuildId).toBe(CLIENT_BUILD.buildId);
+        expect(fakeManager.restartCalled).toBe(false);
+        expect(fakeClient.isConnected()).toBe(false);
+      } finally {
+        isAvailableSpy.mockRestore();
+        await proxy.close();
+      }
+    });
+
+    test("throws with cooldown reason when the daemon is too young to replace", async () => {
+      const warnSpy = spyOn(logger, "warn").mockImplementation(() => {});
+      const { fakeManager, isAvailableSpy, proxy } = makeBuildProxy({
+        startedAt: 100_000 - Math.floor(DAEMON_VERSION_RESTART_COOLDOWN_MS / 2),
+      });
+      try {
+        const error = await expectBuildMismatch(proxy.listTools());
+        expect(error.reason).toBe("cooldown");
+        expect(error.retryAfterMs).toBe(Math.floor(DAEMON_VERSION_RESTART_COOLDOWN_MS / 2));
+        expect(fakeManager.restartCalled).toBe(false);
+      } finally {
+        warnSpy.mockRestore();
+        isAvailableSpy.mockRestore();
+        await proxy.close();
+      }
+    });
+
+    test("throws restartMismatch when restarted daemon build still differs", async () => {
+      const { fakeManager, isAvailableSpy, proxy } = makeBuildProxy({
+        restartedBuildId: DAEMON_BUILD.buildId,
+        restartedEntryScript: DAEMON_BUILD.entryScript,
+      });
+      try {
+        const error = await expectBuildMismatch(proxy.listTools());
+        expect(error.reason).toBe("restartMismatch");
+        expect(fakeManager.restartCalled).toBe(true);
+      } finally {
+        isAvailableSpy.mockRestore();
+        await proxy.close();
+      }
+    });
+
+    test("throws when restarted daemon fails to become ready", async () => {
+      const { fakeManager, isAvailableSpy, proxy } = makeBuildProxy({
+        waitForReadyResult: false,
+      });
+      try {
+        await expect(proxy.listTools()).rejects.toThrow(DaemonUnavailableError);
+        expect(fakeManager.restartCalled).toBe(true);
+      } finally {
+        isAvailableSpy.mockRestore();
+        await proxy.close();
+      }
+    });
+  });
+
+  describe("unknown-tool self-heal", () => {
+    test("reconnects and retries once when daemon reports an advertised tool as unknown", async () => {
+      const recoveredResult = { content: [{ type: "text", text: "set after reconnect" }] };
+      const staleClient = new ScriptedDaemonClient({
+        daemonMethodResults: new Map([["tools/list", { tools: [{ name: "setPreference", inputSchema: {} }] }]]),
+        toolError: new Error("MCP error -32603: Unknown tool: setPreference"),
+      });
+      const freshClient = new ScriptedDaemonClient({
+        daemonMethodResults: new Map([["tools/list", { tools: [{ name: "setPreference", inputSchema: {} }] }]]),
+        toolResult: recoveredResult,
+      });
+      const clients = [staleClient, freshClient];
+      const isAvailableSpy = spyOn(DaemonClient, "isAvailable").mockResolvedValue(true);
+
+      const proxy = new DaemonMcpProxy({
+        clientFactory: () => clients.shift()!,
+        autoStartDaemon: false,
+      });
+
+      try {
+        // Prime the cache so we can prove it gets invalidated on recovery.
+        await proxy.listTools();
+        const result = await proxy.callTool("setPreference", { key: "k", value: "v" });
+
+        expect(result).toEqual(recoveredResult);
+        expect(staleClient.closeCallCount).toBe(1);
+        expect(staleClient.callToolCalls).toHaveLength(1);
+        expect(freshClient.callToolCalls).toEqual([
+          { toolName: "setPreference", params: { key: "k", value: "v" } },
+        ]);
+        // Recovery invalidated the cache, so a subsequent listTools re-queries the
+        // fresh (post-recovery) client instead of returning the stale tool list.
+        await proxy.listTools();
+        expect(freshClient.callDaemonMethodCalls).toEqual([{ method: "tools/list", params: {} }]);
+      } finally {
+        isAvailableSpy.mockRestore();
+        await proxy.close();
+      }
+    });
+
+    test("throws an actionable DaemonToolUnavailableError naming both builds when the tool stays unknown", async () => {
+      const firstClient = new ScriptedDaemonClient({
+        daemonMethodResults: new Map([["tools/list", { tools: [] }]]),
+        toolError: new Error("MCP error -32603: Unknown tool: setPreference"),
+      });
+      const secondClient = new ScriptedDaemonClient({
+        daemonMethodResults: new Map([["tools/list", { tools: [] }]]),
+        toolError: new Error("MCP error -32603: Unknown tool: setPreference"),
+      });
+      const clients = [firstClient, secondClient];
+      const isAvailableSpy = spyOn(DaemonClient, "isAvailable").mockResolvedValue(true);
+
+      const proxy = new DaemonMcpProxy({
+        clientFactory: () => clients.shift()!,
+        autoStartDaemon: false,
+        buildIdentity: { entryScript: "/client/dist/index.js", buildId: "clientbuild" },
+      });
+
+      try {
+        let caught: unknown;
+        try {
+          await proxy.callTool("setPreference", { key: "k" });
+        } catch (error) {
+          caught = error;
+        }
+        expect(caught).toBeInstanceOf(DaemonToolUnavailableError);
+        const err = caught as DaemonToolUnavailableError;
+        expect(err.toolName).toBe("setPreference");
+        expect(err.message).toContain("setPreference");
+        expect(err.message).toContain("clientbuild");
+        // Capped at one retry: exactly two clients consumed.
+        expect(clients).toHaveLength(0);
+        expect(firstClient.callToolCalls).toHaveLength(1);
+        expect(secondClient.callToolCalls).toHaveLength(1);
+      } finally {
+        isAvailableSpy.mockRestore();
+        await proxy.close();
+      }
+    });
+
+    test("does not retry on a non-recoverable daemon error", async () => {
+      const client = new ScriptedDaemonClient({
+        toolError: new Error("Permission denied"),
+      });
+      const isAvailableSpy = spyOn(DaemonClient, "isAvailable").mockResolvedValue(true);
+
+      const proxy = new DaemonMcpProxy({
+        clientFactory: () => client,
+        autoStartDaemon: false,
+      });
+
+      try {
+        await expect(proxy.callTool("observe", {})).rejects.toThrow("Permission denied");
+        expect(client.callToolCalls).toHaveLength(1);
+        expect(client.closeCallCount).toBe(0);
       } finally {
         isAvailableSpy.mockRestore();
         await proxy.close();


### PR DESCRIPTION
## Summary

On a machine with **two checkouts** of AutoMobile (e.g. a worktree RC build + the main-repo build) they share **one per-uid daemon socket** (`/tmp/auto-mobile-daemon-${uid}.sock`). The first daemon to bind serves every frontend from every checkout, so after a daemon restart the backend can silently swap to a **different build** than the frontend. Both builds report the same pre-release version (`0.0.39`), so the existing version gate is a no-op for this skew, and the frontend keeps advertising a cached tool list captured against the *other* build — a tool the frontend advertises then fails at the daemon with the opaque `MCP error -32603: Unknown tool: <name>`, and tool calls execute against the wrong build's code with no warning.

Ships the issue's recommended fixes **(1)** build-identity handshake and **(2)** self-heal on unknown-tool. Fix (3) (per-workspace socket discriminator) is intentionally **out of scope** — larger blast radius (IDE plugin / doctor / CLI / device-pool all assume one socket); the issue says to decide one-daemon-per-machine vs per-workspace separately.

## Root cause

- **Version gate is a no-op for same-version skew.** `ensureVersionMatches()` early-returns when `runningVersion === DAEMON_VERSION`; both builds are `0.0.39`, so the proxy attaches to a daemon running entirely different code. No build identity existed anywhere (the PID file carried none).
- **Tool-list cache not invalidated on daemon replacement.** A tool list captured against the worktree daemon kept advertising e.g. `setPreference`; the swapped main-build daemon's registry returns undefined → `Unknown tool` → `-32603`.

## Fix

**(1) Build-identity handshake + refuse/replace on mismatch.** A daemon's identity is now `{ entryScript, buildId }`, where `buildId` is a content hash of the entry script — independent of the version string, so it catches skew even when both builds report `0.0.39`.
- New pure module `src/daemon/buildIdentity.ts` (`computeBuildIdentity` / `getCurrentBuildIdentity` / `buildIdentitiesMatch`). Matching compares the content hash when both sides expose one; falls back to the resolved entry-script path; treats missing identity on **either** side as a match so a legacy daemon (PID file predating this change) never triggers a restart loop.
- `PidFileData` / `DaemonStatus` gain optional `entryScript` / `buildId`; `daemon.ts` `writePidFile()` records the daemon's own identity; `manager.status()` surfaces it.
- `DaemonMcpProxy.ensureBuildMatches()` runs in `doConnect()` (after `ensureVersionMatches`). On mismatch it restarts the daemon from this client's own entrypoint (the existing `manager.restart()` already spawns from the spawner's build), **invalidates the tool cache**, waits for ready, and verifies the restarted identity. Gated by the same `autoStartDaemon` / cooldown rules as the version gate so two checkouts can't ping-pong faster than `DAEMON_VERSION_RESTART_COOLDOWN_MS`. New `DaemonBuildMismatchError` carries both builds + a `reason`.
- `ensureVersionMatches()` restart path now also calls `invalidateCache()` (was missing).

**(2) Self-heal on advertised-but-unknown tool.** `isRecoverableDaemonSessionError()` now treats `Unknown tool:` as recoverable, so `withRecoverableReconnect` drops the stale cache, reconnects (re-running the build handshake — which restarts to the correct build on skew), and retries the call **once**. If the tool is still unknown after that single retry, `callTool()` throws a new actionable `DaemonToolUnavailableError` that names the tool and both builds instead of bubbling the opaque `-32603`.

## Test plan

TDD — tests written before implementation:
- New `test/daemon/buildIdentity.test.ts` (pure module): stable hash for identical contents, distinct hash for different contents, unreadable/missing entry script → `unknown` without throwing, and the three `buildIdentitiesMatch` cases (known-vs-known, entry-script fallback, missing-identity → match).
- New describe blocks in `test/daemon/daemonMcpProxy.test.ts`:
  - build-identity handshake: restart + cache-invalidate on mismatch; no restart on match; legacy daemon (no identity) → match; `autoStartDisabled` / `cooldown` / `restartMismatch` errors; restart-not-ready throws.
  - unknown-tool self-heal: reconnect+retry once and succeed (cache invalidated); still-unknown → actionable `DaemonToolUnavailableError` naming both builds, capped at one retry; non-recoverable errors (`Permission denied`) are not retried.
- `bun test test/daemon/` → **472 pass** (~0.7s), each unit test <100ms.
- `turbo run lint build` → green.
- `scripts/all_fast_validate_checks.sh` → 10/10 pass.

Refs #2732
