### PR TITLE
fix(ios): deliver allocated CtrlProxy port to the simulator/device runner via xctestrun (#2731)

### DIFF
--- a/src/utils/IOSCtrlProxyBuilder.ts
+++ b/src/utils/IOSCtrlProxyBuilder.ts
@@ -67,6 +67,12 @@ type IOSCtrlProxyBundleMetadata = {
  * Handles release bundle download and extraction for CtrlProxy
  */
 export class IOSCtrlProxyBuilder {
+  /**
+   * Filename prefix for the per-launch xctestrun copies written by
+   * {@link writeRunnerEnvironment}. Distinct from the build-products xctestrun so
+   * the copies are excluded from source discovery/cleanup globs.
+   */
+  private static readonly RUNNER_XCTESTRUN_PREFIX = "automobile-runner-";
   private static readonly DEFAULT_PROJECT_ROOT = process.cwd();
   private static readonly DEFAULT_DERIVED_DATA_PATH = "/tmp/automobile-ctrl-proxy";
   private static readonly DEFAULT_SCHEME = "CtrlProxyApp";
@@ -209,7 +215,10 @@ export class IOSCtrlProxyBuilder {
     const productsDir = path.join(this.config.derivedDataPath, "Build", "Products");
     try {
       const files = await fs.readdir(productsDir);
-      const xctestrunFiles = files.filter(file => file.endsWith(".xctestrun"));
+      const xctestrunFiles = files.filter(
+        file => file.endsWith(".xctestrun") &&
+          !file.startsWith(IOSCtrlProxyBuilder.RUNNER_XCTESTRUN_PREFIX)
+      );
       if (xctestrunFiles.length === 0) {
         return null;
       }
@@ -289,7 +298,7 @@ export class IOSCtrlProxyBuilder {
       const safeDeviceId = deviceId.replace(/[^A-Za-z0-9._-]/g, "_") || "device";
       const outputPath = path.join(
         path.dirname(xctestrunPath),
-        `automobile-runner-${safeDeviceId}.xctestrun`
+        `${IOSCtrlProxyBuilder.RUNNER_XCTESTRUN_PREFIX}${safeDeviceId}.xctestrun`
       );
       await fs.writeFile(outputPath, buildPlist(root), "utf-8");
       logger.info(
@@ -311,7 +320,10 @@ export class IOSCtrlProxyBuilder {
     const productsDir = path.join(this.config.derivedDataPath, "Build", "Products");
     try {
       const files = await fs.readdir(productsDir);
-      const xctestrunFiles = files.filter(file => file.endsWith(".xctestrun"));
+      const xctestrunFiles = files.filter(
+        file => file.endsWith(".xctestrun") &&
+          !file.startsWith(IOSCtrlProxyBuilder.RUNNER_XCTESTRUN_PREFIX)
+      );
       if (xctestrunFiles.length <= 1) {
         return;
       }

--- a/src/utils/IOSCtrlProxyBuilder.ts
+++ b/src/utils/IOSCtrlProxyBuilder.ts
@@ -19,6 +19,13 @@ import {
 } from "./IOSCtrlProxyBundleDownloader";
 import { hashAppBundle } from "./ios-cmdline-tools/AppBundleHasher";
 import { resolvePathFromDaemonLaunchWorkingDirectory } from "./workingDirectory";
+import {
+  buildPlist,
+  injectUITestEnvironment,
+  parsePlist,
+  type PlistValue
+} from "./ios-cmdline-tools/XctestrunPlist";
+import { toActionableError } from "../models/ActionableError";
 
 /**
  * Result of CtrlProxy download/install
@@ -237,6 +244,63 @@ export class IOSCtrlProxyBuilder {
       return fullPath;
     } catch {
       return null;
+    }
+  }
+
+  /**
+   * Inject runner environment variables into a copy of the xctestrun so they
+   * reach the in-simulator / on-device XCUITest runner process.
+   *
+   * `xcodebuild test-without-building` does NOT forward the host process
+   * environment (or `SIMCTL_CHILD_*`) into the runner — the only channel that
+   * reaches it is the xctestrun's per-target `EnvironmentVariables` dict, which
+   * xcodebuild injects into the test host (the runner app). Without this the
+   * runner never sees the allocated `CTRL_PROXY_IOS_PORT` and falls back to its
+   * hardcoded `defaultPort` (8765), breaking multi-device setups where the
+   * daemon allocated a non-default port (issue #2731).
+   *
+   * The injected variables are written to a per-launch copy in the SAME
+   * directory as the source xctestrun (so `__TESTROOT__` still resolves to the
+   * build products dir). The copy's name intentionally omits the platform token
+   * so it is ignored by {@link getXctestrunPath}/{@link cleanStaleXctestrunFiles}
+   * and so concurrent devices don't race on a shared file.
+   *
+   * @returns the path to the per-launch xctestrun copy to pass to `xcodebuild`.
+   */
+  public async writeRunnerEnvironment(
+    xctestrunPath: string,
+    env: Record<string, string>,
+    deviceId: string
+  ): Promise<string> {
+    try {
+      const xml = await fs.readFile(xctestrunPath, "utf-8");
+      const root = await parsePlist(xml);
+      if (!(root instanceof Map)) {
+        throw new Error("xctestrun root is not a plist dictionary");
+      }
+
+      const injected = injectUITestEnvironment(root as Map<string, PlistValue>, env);
+      if (injected === 0) {
+        throw new Error(
+          "xctestrun contains no UI-test bundle (IsUITestBundle) to receive the runner environment"
+        );
+      }
+
+      const safeDeviceId = deviceId.replace(/[^A-Za-z0-9._-]/g, "_") || "device";
+      const outputPath = path.join(
+        path.dirname(xctestrunPath),
+        `automobile-runner-${safeDeviceId}.xctestrun`
+      );
+      await fs.writeFile(outputPath, buildPlist(root), "utf-8");
+      logger.info(
+        `[IOSCtrlProxyBuilder] Wrote runner xctestrun with injected environment to ${outputPath}`
+      );
+      return outputPath;
+    } catch (error) {
+      throw toActionableError(
+        error,
+        `Failed to inject runner environment into xctestrun at ${xctestrunPath}`
+      );
     }
   }
 

--- a/src/utils/IOSCtrlProxyManager.ts
+++ b/src/utils/IOSCtrlProxyManager.ts
@@ -1021,27 +1021,31 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
     const bundleId = this.resolveTargetBundleId();
     this.ensureLocalServicePortAllocatedAndAvailable();
 
-    // Pass env vars via exec env option to avoid shell interpolation of user-controlled values.
-    // SIMCTL_CHILD_* prefixed vars are forwarded by simctl (which xcodebuild uses internally
-    // on simulators) to the XCUITest runner process after stripping the prefix.
-    // Keep unprefixed vars for potential physical device support.
-    const childEnv: Record<string, string> = {
+    // The runner reads CTRL_PROXY_IOS_PORT from its OWN ProcessInfo.environment.
+    // `xcodebuild test-without-building` does not forward the host process env
+    // (or SIMCTL_CHILD_*) into the in-simulator runner — the only channel that
+    // reaches it is the xctestrun's per-target EnvironmentVariables dict. Inject
+    // there so the runner binds the allocated port instead of its hardcoded
+    // default 8765 (issue #2731).
+    const runnerEnv: Record<string, string> = {
       CTRL_PROXY_IOS_PORT: String(this.servicePort),
       CTRL_PROXY_IOS_TIMEOUT: timeout,
       AUTOMOBILE_DEVICE_ID: this.device.deviceId,
-      SIMCTL_CHILD_CTRL_PROXY_IOS_PORT: String(this.servicePort),
-      SIMCTL_CHILD_CTRL_PROXY_IOS_TIMEOUT: timeout,
-      SIMCTL_CHILD_AUTOMOBILE_DEVICE_ID: this.device.deviceId,
     };
     if (bundleId) {
-      childEnv.CTRL_PROXY_IOS_BUNDLE_ID = bundleId;
-      childEnv.SIMCTL_CHILD_CTRL_PROXY_IOS_BUNDLE_ID = bundleId;
-      logger.info(`[IOSCtrlProxy] Passing CTRL_PROXY_IOS_BUNDLE_ID=${bundleId} to xcodebuild`);
+      runnerEnv.CTRL_PROXY_IOS_BUNDLE_ID = bundleId;
+      logger.info(`[IOSCtrlProxy] Passing CTRL_PROXY_IOS_BUNDLE_ID=${bundleId} to runner via xctestrun`);
     }
+    const runnerXctestrunPath = await this.builder.writeRunnerEnvironment(
+      xctestrunPath,
+      runnerEnv,
+      this.device.deviceId
+    );
+
     const command = [
       "xcodebuild",
       "test-without-building",
-      `-xctestrun "${xctestrunPath}"`,
+      `-xctestrun "${runnerXctestrunPath}"`,
       `-destination "platform=iOS Simulator,id=${this.device.deviceId}"`,
       "-only-testing:CtrlProxyUITests/CtrlProxyUITests/testRunService",
       "2>&1"
@@ -1049,12 +1053,15 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
 
     logger.info("[IOSCtrlProxy] Using xcodebuild test-without-building to start runner on simulator");
 
-    // Start in background with env vars passed via spawn options (not interpolated into the command).
     // Uses spawn with shell:true instead of exec() to avoid the default 1MB maxBuffer limit.
     // xcodebuild outputs verbose hierarchy dumps that easily exceed 1MB, causing
     // "stdout maxBuffer length exceeded" crashes when using exec().
+    // runnerEnv is ALSO set on the host xcodebuild process env — not for the runner
+    // (it can't see host env) but so the daemon can later discover, own, and recover
+    // this process by reading its env via `ps eww` (see findExternalXcodebuildCtrlProxyProcess
+    // / isDaemonManagedSimulatorXcodebuildProcess).
     // Routed through the injected processExecutor so tests can observe/control the process.
-    const child = this.processExecutor.spawn(command, [], { shell: true, env: { ...process.env, ...childEnv }, stdio: ["ignore", "pipe", "pipe"] });
+    const child = this.processExecutor.spawn(command, [], { shell: true, env: { ...process.env, ...runnerEnv }, stdio: ["ignore", "pipe", "pipe"] });
 
     child.on("error", error => {
       logger.warn(`[IOSCtrlProxy] xcodebuild test error: ${error.message}`);
@@ -1772,28 +1779,42 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
     }
 
     const bundleId = this.resolveTargetBundleId();
-    const envSettings = [
-      `CTRL_PROXY_IOS_PORT=${this.servicePort}`,
-    ];
+
+    // Deliver the allocated port to the on-device runner via the xctestrun's
+    // EnvironmentVariables. A bare `CTRL_PROXY_IOS_PORT=...` xcodebuild token is
+    // a BUILD SETTING, not a runner env var, so it never reaches the runner —
+    // which then falls back to its default 8765 (issue #2731).
+    const runnerEnv: Record<string, string> = {
+      CTRL_PROXY_IOS_PORT: String(this.servicePort),
+      CTRL_PROXY_IOS_TIMEOUT: process.env.CTRL_PROXY_IOS_TIMEOUT || "86400",
+      AUTOMOBILE_DEVICE_ID: this.device.deviceId,
+    };
     if (bundleId) {
-      envSettings.push(`CTRL_PROXY_IOS_BUNDLE_ID=${bundleId}`);
-      logger.info(`[IOSCtrlProxy] Passing CTRL_PROXY_IOS_BUNDLE_ID=${bundleId} to xcodebuild`);
+      runnerEnv.CTRL_PROXY_IOS_BUNDLE_ID = bundleId;
+      logger.info(`[IOSCtrlProxy] Passing CTRL_PROXY_IOS_BUNDLE_ID=${bundleId} to runner via xctestrun`);
     }
+    const runnerXctestrunPath = await this.builder.writeRunnerEnvironment(
+      xctestrunPath,
+      runnerEnv,
+      this.device.deviceId
+    );
+
     const command = [
       "xcodebuild",
       "test-without-building",
-      `-xctestrun "${xctestrunPath}"`,
+      `-xctestrun "${runnerXctestrunPath}"`,
       "-destination", `id=${this.device.deviceId}`,
       "-only-testing:CtrlProxyUITests/CtrlProxyUITests/testRunService",
-      ...envSettings,
       ...signingArgs,
       "2>&1"
     ].join(" ");
 
     // Start in background using spawn with shell:true to avoid the default 1MB maxBuffer limit.
     // xcodebuild outputs verbose hierarchy dumps that easily exceed 1MB.
+    // The runner env is ALSO set on the host xcodebuild process env so the daemon
+    // can later discover/own/recover this process by reading its env via `ps eww`.
     // Routed through the injected processExecutor so tests can observe/control the process.
-    const child = this.processExecutor.spawn(command, [], { shell: true, stdio: ["ignore", "pipe", "pipe"] });
+    const child = this.processExecutor.spawn(command, [], { shell: true, env: { ...process.env, ...runnerEnv }, stdio: ["ignore", "pipe", "pipe"] });
 
     child.on("error", error => {
       logger.warn(`[IOSCtrlProxy] xcodebuild test error: ${error.message}`);

--- a/src/utils/ios-cmdline-tools/XctestrunPlist.ts
+++ b/src/utils/ios-cmdline-tools/XctestrunPlist.ts
@@ -1,0 +1,187 @@
+import { Parser } from "xml2js";
+
+/**
+ * Minimal XML property-list (plist) reader/writer used to edit `.xctestrun`
+ * files in place.
+ *
+ * Dictionaries are represented as `Map<string, PlistValue>` so insertion order
+ * is preserved on round-trip (xctestrun ordering is cosmetic but worth keeping)
+ * and so callers can `get`/`set` keys ergonomically.
+ *
+ * Only the plist subset that appears in `.xctestrun` files is supported:
+ * dict, array, string, integer, real, true/false, date, data.
+ */
+export type PlistValue =
+  | string
+  | number
+  | boolean
+  | Date
+  | Buffer
+  | PlistValue[]
+  | Map<string, PlistValue>;
+
+interface PlistNode {
+  "#name": string;
+  "_"?: string;
+  "$$"?: PlistNode[];
+}
+
+const plistParser = new Parser({
+  explicitChildren: true,
+  preserveChildrenOrder: true,
+  explicitRoot: false
+});
+
+const nodeToValue = (node: PlistNode | undefined): PlistValue => {
+  if (!node) {
+    return "";
+  }
+
+  switch (node["#name"]) {
+    case "dict": {
+      const result = new Map<string, PlistValue>();
+      const children = node.$$ ?? [];
+      for (let i = 0; i < children.length; i += 2) {
+        const keyNode = children[i];
+        const valueNode = children[i + 1];
+        if (!keyNode || keyNode["#name"] !== "key") {
+          continue;
+        }
+        result.set(keyNode._ ?? "", nodeToValue(valueNode));
+      }
+      return result;
+    }
+    case "array":
+      return (node.$$ ?? []).map(child => nodeToValue(child));
+    case "string":
+    case "data":
+      return node._ ?? "";
+    case "date":
+      return node._ ? new Date(node._) : new Date(0);
+    case "integer":
+    case "real":
+      return node._ ? Number(node._) : 0;
+    case "true":
+      return true;
+    case "false":
+      return false;
+    default:
+      return node._ ?? "";
+  }
+};
+
+/**
+ * Parse an XML plist document into a {@link PlistValue}. Dictionaries become
+ * ordered `Map`s.
+ */
+export const parsePlist = async (xml: string): Promise<PlistValue> => {
+  const parsed = await plistParser.parseStringPromise(xml) as PlistNode;
+  const root = parsed["#name"] === "plist" ? parsed.$$?.[0] : parsed;
+  return nodeToValue(root);
+};
+
+const escapeXml = (value: string): string =>
+  value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;");
+
+const indent = (depth: number): string => "\t".repeat(depth);
+
+const valueToXml = (value: PlistValue, depth: number): string => {
+  const pad = indent(depth);
+
+  if (value instanceof Map) {
+    if (value.size === 0) {
+      return `${pad}<dict/>`;
+    }
+    const lines: string[] = [`${pad}<dict>`];
+    for (const [key, child] of value.entries()) {
+      lines.push(`${indent(depth + 1)}<key>${escapeXml(key)}</key>`);
+      lines.push(valueToXml(child, depth + 1));
+    }
+    lines.push(`${pad}</dict>`);
+    return lines.join("\n");
+  }
+
+  if (Array.isArray(value)) {
+    if (value.length === 0) {
+      return `${pad}<array/>`;
+    }
+    const lines: string[] = [`${pad}<array>`];
+    for (const child of value) {
+      lines.push(valueToXml(child, depth + 1));
+    }
+    lines.push(`${pad}</array>`);
+    return lines.join("\n");
+  }
+
+  if (typeof value === "boolean") {
+    return `${pad}${value ? "<true/>" : "<false/>"}`;
+  }
+
+  if (typeof value === "number") {
+    return Number.isInteger(value)
+      ? `${pad}<integer>${value}</integer>`
+      : `${pad}<real>${value}</real>`;
+  }
+
+  if (value instanceof Date) {
+    return `${pad}<date>${value.toISOString().replace(/\.\d{3}Z$/, "Z")}</date>`;
+  }
+
+  if (Buffer.isBuffer(value)) {
+    return `${pad}<data>${value.toString("base64")}</data>`;
+  }
+
+  return `${pad}<string>${escapeXml(value)}</string>`;
+};
+
+/**
+ * Serialize a {@link PlistValue} back to an XML plist document.
+ */
+export const buildPlist = (value: PlistValue): string => {
+  return [
+    "<?xml version=\"1.0\" encoding=\"UTF-8\"?>",
+    "<!DOCTYPE plist PUBLIC \"-//Apple//DTD PLIST 1.0//EN\" \"http://www.apple.com/DTDs/PropertyList-1.0.dtd\">",
+    "<plist version=\"1.0\">",
+    valueToXml(value, 0),
+    "</plist>",
+    ""
+  ].join("\n");
+};
+
+/**
+ * Merge `env` (string key/value pairs) into the `EnvironmentVariables` dict of
+ * every test target in `root` that is a UI-test bundle (`IsUITestBundle` true).
+ *
+ * Existing keys are overwritten, missing `EnvironmentVariables` dicts are
+ * created, and non-UI targets are left untouched.
+ *
+ * @returns the number of UI-test targets that received the environment.
+ */
+export const injectUITestEnvironment = (
+  root: Map<string, PlistValue>,
+  env: Record<string, string>
+): number => {
+  let injected = 0;
+
+  for (const value of root.values()) {
+    if (!(value instanceof Map) || value.get("IsUITestBundle") !== true) {
+      continue;
+    }
+
+    let envDict = value.get("EnvironmentVariables");
+    if (!(envDict instanceof Map)) {
+      envDict = new Map<string, PlistValue>();
+      value.set("EnvironmentVariables", envDict);
+    }
+
+    for (const [key, val] of Object.entries(env)) {
+      (envDict as Map<string, PlistValue>).set(key, val);
+    }
+    injected += 1;
+  }
+
+  return injected;
+};

--- a/test/utils/IOSCtrlProxyBuilder.test.ts
+++ b/test/utils/IOSCtrlProxyBuilder.test.ts
@@ -352,6 +352,23 @@ describe("IOSCtrlProxyBuilder", function() {
       expect(resolved).toBe(sourcePath);
     });
 
+    test("per-launch copy is excluded even from the platform-agnostic getXctestrunPath glob", async function() {
+      const productsDir = path.join(tempDir, "Build", "Products");
+      await fs.mkdir(productsDir, { recursive: true });
+      const sourcePath = path.join(productsDir, "CtrlProxyApp_iphonesimulator26.2-arm64-x86_64.xctestrun");
+      await fs.writeFile(sourcePath, SAMPLE_XCTESTRUN);
+      // Make the source older so a naive newest-mtime pick would prefer the copy.
+      await fs.utimes(sourcePath, new Date("2026-01-01"), new Date("2026-01-01"));
+
+      const builder = IOSCtrlProxyBuilder.getInstance({ derivedDataPath: tempDir });
+      const outputPath = await builder.writeRunnerEnvironment(sourcePath, { CTRL_PROXY_IOS_PORT: "8767" }, "SIM-UUID");
+      await fs.utimes(outputPath, new Date("2026-06-01"), new Date("2026-06-01"));
+
+      // No platform argument → no platform filter; the runner copy must still be skipped.
+      const resolved = await builder.getXctestrunPath();
+      expect(resolved).toBe(sourcePath);
+    });
+
     test("sanitizes the device id used in the copy filename", async function() {
       const productsDir = path.join(tempDir, "Build", "Products");
       await fs.mkdir(productsDir, { recursive: true });

--- a/test/utils/IOSCtrlProxyBuilder.test.ts
+++ b/test/utils/IOSCtrlProxyBuilder.test.ts
@@ -5,6 +5,7 @@ import * as fs from "fs/promises";
 import * as path from "path";
 import os from "os";
 import { DAEMON_LAUNCH_CWD_ENV } from "../../src/utils/workingDirectory";
+import { parsePlist } from "../../src/utils/ios-cmdline-tools/XctestrunPlist";
 
 describe("IOSCtrlProxyBuilder", function() {
   let originalProjectRoot: string | undefined;
@@ -277,6 +278,113 @@ describe("IOSCtrlProxyBuilder", function() {
       const result = await builder.getXctestrunPath("simulator");
 
       expect(result).toBe(newFile);
+    });
+  });
+
+  describe("writeRunnerEnvironment", function() {
+    const SAMPLE_XCTESTRUN = [
+      "<?xml version=\"1.0\" encoding=\"UTF-8\"?>",
+      "<!DOCTYPE plist PUBLIC \"-//Apple//DTD PLIST 1.0//EN\" \"http://www.apple.com/DTDs/PropertyList-1.0.dtd\">",
+      "<plist version=\"1.0\">",
+      "<dict>",
+      "\t<key>CtrlProxyUITests</key>",
+      "\t<dict>",
+      "\t\t<key>EnvironmentVariables</key>",
+      "\t\t<dict>",
+      "\t\t\t<key>TERM</key>",
+      "\t\t\t<string>dumb</string>",
+      "\t\t</dict>",
+      "\t\t<key>IsUITestBundle</key>",
+      "\t\t<true/>",
+      "\t</dict>",
+      "</dict>",
+      "</plist>"
+    ].join("\n");
+
+    async function readUiTestEnv(xctestrunPath: string): Promise<Map<string, unknown>> {
+      const xml = await fs.readFile(xctestrunPath, "utf-8");
+      const root = await parsePlist(xml) as Map<string, unknown>;
+      const uiTarget = root.get("CtrlProxyUITests") as Map<string, unknown>;
+      return uiTarget.get("EnvironmentVariables") as Map<string, unknown>;
+    }
+
+    test("writes a per-launch copy carrying the injected port without mutating the source (EC3)", async function() {
+      const productsDir = path.join(tempDir, "Build", "Products");
+      await fs.mkdir(productsDir, { recursive: true });
+      const sourcePath = path.join(productsDir, "CtrlProxyApp_iphonesimulator26.2-arm64-x86_64.xctestrun");
+      await fs.writeFile(sourcePath, SAMPLE_XCTESTRUN);
+
+      const builder = IOSCtrlProxyBuilder.getInstance({ derivedDataPath: tempDir });
+      const outputPath = await builder.writeRunnerEnvironment(
+        sourcePath,
+        { CTRL_PROXY_IOS_PORT: "8767", AUTOMOBILE_DEVICE_ID: "SIM-UUID" },
+        "SIM-UUID"
+      );
+
+      // New file, same directory, platform-token-free name.
+      expect(outputPath).not.toBe(sourcePath);
+      expect(path.dirname(outputPath)).toBe(productsDir);
+      const baseName = path.basename(outputPath);
+      expect(baseName).toBe("automobile-runner-SIM-UUID.xctestrun");
+      expect(baseName.includes("iphonesimulator")).toBe(false);
+
+      // Source untouched.
+      expect(await fs.readFile(sourcePath, "utf-8")).toBe(SAMPLE_XCTESTRUN);
+
+      // Per-launch copy carries the injected env plus the original entries.
+      const env = await readUiTestEnv(outputPath);
+      expect(env.get("CTRL_PROXY_IOS_PORT")).toBe("8767");
+      expect(env.get("AUTOMOBILE_DEVICE_ID")).toBe("SIM-UUID");
+      expect(env.get("TERM")).toBe("dumb");
+    });
+
+    test("per-launch copy is excluded from getXctestrunPath candidate globs", async function() {
+      const productsDir = path.join(tempDir, "Build", "Products");
+      await fs.mkdir(productsDir, { recursive: true });
+      const sourcePath = path.join(productsDir, "CtrlProxyApp_iphonesimulator26.2-arm64-x86_64.xctestrun");
+      await fs.writeFile(sourcePath, SAMPLE_XCTESTRUN);
+
+      const builder = IOSCtrlProxyBuilder.getInstance({ derivedDataPath: tempDir });
+      await builder.writeRunnerEnvironment(sourcePath, { CTRL_PROXY_IOS_PORT: "8767" }, "SIM-UUID");
+
+      // The runner copy must not be re-selected as the source xctestrun.
+      const resolved = await builder.getXctestrunPath("simulator");
+      expect(resolved).toBe(sourcePath);
+    });
+
+    test("sanitizes the device id used in the copy filename", async function() {
+      const productsDir = path.join(tempDir, "Build", "Products");
+      await fs.mkdir(productsDir, { recursive: true });
+      const sourcePath = path.join(productsDir, "CtrlProxyApp_iphoneos.xctestrun");
+      await fs.writeFile(sourcePath, SAMPLE_XCTESTRUN);
+
+      const builder = IOSCtrlProxyBuilder.getInstance({ derivedDataPath: tempDir });
+      const outputPath = await builder.writeRunnerEnvironment(
+        sourcePath,
+        { CTRL_PROXY_IOS_PORT: "8767" },
+        "00008030-001E/28C1 1E"
+      );
+      expect(path.basename(outputPath)).toBe("automobile-runner-00008030-001E_28C1_1E.xctestrun");
+    });
+
+    test("throws an actionable error when the xctestrun has no UI-test bundle (EC4)", async function() {
+      const productsDir = path.join(tempDir, "Build", "Products");
+      await fs.mkdir(productsDir, { recursive: true });
+      const sourcePath = path.join(productsDir, "CtrlProxyApp_iphonesimulator.xctestrun");
+      await fs.writeFile(sourcePath, [
+        "<?xml version=\"1.0\" encoding=\"UTF-8\"?>",
+        "<plist version=\"1.0\">",
+        "<dict>",
+        "\t<key>CtrlProxyTests</key>",
+        "\t<dict><key>IsUITestBundle</key><false/></dict>",
+        "</dict>",
+        "</plist>"
+      ].join("\n"));
+
+      const builder = IOSCtrlProxyBuilder.getInstance({ derivedDataPath: tempDir });
+      await expect(
+        builder.writeRunnerEnvironment(sourcePath, { CTRL_PROXY_IOS_PORT: "8767" }, "SIM")
+      ).rejects.toThrow("no UI-test bundle");
     });
   });
 

--- a/test/utils/IOSCtrlProxyManager.test.ts
+++ b/test/utils/IOSCtrlProxyManager.test.ts
@@ -7,6 +7,50 @@ import { FakeProcessExecutor } from "../fakes/FakeProcessExecutor";
 import { FakeChildProcess } from "../fakes/FakeChildProcess";
 import type { ExecResult } from "../../src/models";
 import { PortManager } from "../../src/utils/PortManager";
+import { IOSCtrlProxyBuilder } from "../../src/utils/IOSCtrlProxyBuilder";
+import { parsePlist } from "../../src/utils/ios-cmdline-tools/XctestrunPlist";
+import type { XcodeSigningManager } from "../../src/utils/ios-cmdline-tools/XcodeSigning";
+import * as fs from "fs/promises";
+import * as path from "path";
+import os from "os";
+
+/**
+ * A minimal format-version-1 xctestrun with a single UI-test bundle, used by the
+ * boundary test to model what the in-simulator runner actually reads.
+ */
+const BOUNDARY_XCTESTRUN = [
+  "<?xml version=\"1.0\" encoding=\"UTF-8\"?>",
+  "<!DOCTYPE plist PUBLIC \"-//Apple//DTD PLIST 1.0//EN\" \"http://www.apple.com/DTDs/PropertyList-1.0.dtd\">",
+  "<plist version=\"1.0\">",
+  "<dict>",
+  "\t<key>CtrlProxyUITests</key>",
+  "\t<dict>",
+  "\t\t<key>EnvironmentVariables</key>",
+  "\t\t<dict>",
+  "\t\t\t<key>TERM</key>",
+  "\t\t\t<string>dumb</string>",
+  "\t\t</dict>",
+  "\t\t<key>IsUITestBundle</key>",
+  "\t\t<true/>",
+  "\t</dict>",
+  "</dict>",
+  "</plist>"
+].join("\n");
+
+/**
+ * Default fake for IOSCtrlProxyBuilder.writeRunnerEnvironment: returns a
+ * deterministic per-launch xctestrun path (in the source's directory, without a
+ * platform token) so the manager's spawn path can run without touching disk.
+ */
+async function fakeWriteRunnerEnvironment(
+  xctestrunPath: string,
+  _env: Record<string, string>,
+  deviceId: string
+): Promise<string> {
+  const dir = xctestrunPath.includes("/") ? xctestrunPath.slice(0, xctestrunPath.lastIndexOf("/")) : ".";
+  const safeDeviceId = deviceId.replace(/[^A-Za-z0-9._-]/g, "_") || "device";
+  return `${dir}/automobile-runner-${safeDeviceId}.xctestrun`;
+}
 
 class FakeHostPortAvailabilityChecker implements HostPortAvailabilityChecker {
   public readonly calls: { host: string; port: number }[] = [];
@@ -182,6 +226,7 @@ function createFakeBuilder(xctestrunPath = "/tmp/CtrlProxy.xctestrun") {
   return {
     getXctestrunPath: async () => xctestrunPath,
     getRunnerBinaryPath: async () => null,
+    writeRunnerEnvironment: fakeWriteRunnerEnvironment,
     needsRebuild: async () => false,
     build: async () => ({ success: true, message: "built" }),
     getExpectedAppHash: () => null,
@@ -435,6 +480,7 @@ describe("IOSCtrlProxyManager", function() {
           throw new Error("should not build when an existing host-control process is reused");
         },
         getRunnerBinaryPath: async () => null,
+        writeRunnerEnvironment: fakeWriteRunnerEnvironment,
         getExpectedAppHash: () => null,
       } as unknown as import("../../src/utils/IOSCtrlProxyBuilder").IOSCtrlProxyBuilder;
       const { runner, starts, iproxyStarts } = createHostControlRunner({
@@ -472,6 +518,7 @@ describe("IOSCtrlProxyManager", function() {
           throw new Error("should not build when an existing host-control process is reused");
         },
         getRunnerBinaryPath: async () => null,
+        writeRunnerEnvironment: fakeWriteRunnerEnvironment,
         getExpectedAppHash: () => null,
       } as unknown as import("../../src/utils/IOSCtrlProxyBuilder").IOSCtrlProxyBuilder;
       const { runner, iproxyStarts } = createHostControlRunner({
@@ -521,6 +568,7 @@ describe("IOSCtrlProxyManager", function() {
       const fakeBuilder = {
         getXctestrunPath: async () => "/tmp/test.xctestrun",
         getRunnerBinaryPath: async () => null,
+        writeRunnerEnvironment: fakeWriteRunnerEnvironment,
         getExpectedAppHash: () => null,
       } as unknown as import("../../src/utils/IOSCtrlProxyBuilder").IOSCtrlProxyBuilder;
       const { runner, iproxyStarts, starts } = createHostControlRunner({
@@ -633,6 +681,7 @@ describe("IOSCtrlProxyManager", function() {
       const fakeBuilder = {
         getXctestrunPath: async () => "/tmp/test.xctestrun",
         getRunnerBinaryPath: async () => null,
+        writeRunnerEnvironment: fakeWriteRunnerEnvironment,
         getExpectedAppHash: () => null,
       } as unknown as import("../../src/utils/IOSCtrlProxyBuilder").IOSCtrlProxyBuilder;
       const { runner, starts, stops, iproxyStarts } = createHostControlRunner({
@@ -679,6 +728,7 @@ describe("IOSCtrlProxyManager", function() {
       const fakeBuilder = {
         getXctestrunPath: async () => "/tmp/test.xctestrun",
         getRunnerBinaryPath: async () => null,
+        writeRunnerEnvironment: fakeWriteRunnerEnvironment,
         getExpectedAppHash: () => null,
       } as unknown as import("../../src/utils/IOSCtrlProxyBuilder").IOSCtrlProxyBuilder;
       const { runner, starts, stops, iproxyStarts } = createHostControlRunner({
@@ -828,6 +878,7 @@ describe("IOSCtrlProxyManager", function() {
       const fakeBuilder = {
         getXctestrunPath: async () => null,
         getRunnerBinaryPath: async () => null,
+        writeRunnerEnvironment: fakeWriteRunnerEnvironment,
       } as unknown as import("../../src/utils/IOSCtrlProxyBuilder").IOSCtrlProxyBuilder;
 
       const manager = IOSCtrlProxyManager.createForTestingWithDeps(
@@ -850,6 +901,7 @@ describe("IOSCtrlProxyManager", function() {
       const fakeBuilder = {
         getXctestrunPath: async () => "/tmp/test.xctestrun",
         getRunnerBinaryPath: async () => null,
+        writeRunnerEnvironment: fakeWriteRunnerEnvironment,
       } as unknown as import("../../src/utils/IOSCtrlProxyBuilder").IOSCtrlProxyBuilder;
 
       const manager = IOSCtrlProxyManager.createForTestingWithDeps(
@@ -879,6 +931,7 @@ describe("IOSCtrlProxyManager", function() {
             throw new Error("should not build when an external CtrlProxy process is reused");
           },
           getRunnerBinaryPath: async () => null,
+          writeRunnerEnvironment: fakeWriteRunnerEnvironment,
         } as unknown as import("../../src/utils/IOSCtrlProxyBuilder").IOSCtrlProxyBuilder;
         const manager = IOSCtrlProxyManager.createForTestingWithDeps(
           testDevice,
@@ -914,6 +967,7 @@ describe("IOSCtrlProxyManager", function() {
         const fakeBuilder = {
           getXctestrunPath: async () => "/tmp/test.xctestrun",
           getRunnerBinaryPath: async () => null,
+          writeRunnerEnvironment: fakeWriteRunnerEnvironment,
         } as unknown as import("../../src/utils/IOSCtrlProxyBuilder").IOSCtrlProxyBuilder;
         const manager = IOSCtrlProxyManager.createForTestingWithDeps(
           testDevice,
@@ -949,6 +1003,7 @@ describe("IOSCtrlProxyManager", function() {
         const fakeBuilder = {
           getXctestrunPath: async () => "/tmp/test.xctestrun",
           getRunnerBinaryPath: async () => null,
+          writeRunnerEnvironment: fakeWriteRunnerEnvironment,
         } as unknown as import("../../src/utils/IOSCtrlProxyBuilder").IOSCtrlProxyBuilder;
         const manager = IOSCtrlProxyManager.createForTestingWithDeps(
           testDevice,
@@ -977,6 +1032,7 @@ describe("IOSCtrlProxyManager", function() {
           throw new Error("should not build when an external CtrlProxy process is reused");
         },
         getRunnerBinaryPath: async () => null,
+        writeRunnerEnvironment: fakeWriteRunnerEnvironment,
       } as unknown as import("../../src/utils/IOSCtrlProxyBuilder").IOSCtrlProxyBuilder;
       const manager = IOSCtrlProxyManager.createForTestingWithDeps(
         testDevice,
@@ -1016,6 +1072,7 @@ describe("IOSCtrlProxyManager", function() {
           throw new Error("should not build when an external CtrlProxy process is reused");
         },
         getRunnerBinaryPath: async () => null,
+        writeRunnerEnvironment: fakeWriteRunnerEnvironment,
       } as unknown as import("../../src/utils/IOSCtrlProxyBuilder").IOSCtrlProxyBuilder;
       const manager = IOSCtrlProxyManager.createForTestingWithDeps(
         testDevice,
@@ -1055,6 +1112,7 @@ describe("IOSCtrlProxyManager", function() {
           throw new Error("should not build when an external CtrlProxy process is reused");
         },
         getRunnerBinaryPath: async () => null,
+        writeRunnerEnvironment: fakeWriteRunnerEnvironment,
       } as unknown as import("../../src/utils/IOSCtrlProxyBuilder").IOSCtrlProxyBuilder;
       const manager = IOSCtrlProxyManager.createForTestingWithDeps(
         testDevice,
@@ -1096,6 +1154,7 @@ describe("IOSCtrlProxyManager", function() {
           throw new Error("should not build when an external CtrlProxy process is reused");
         },
         getRunnerBinaryPath: async () => null,
+        writeRunnerEnvironment: fakeWriteRunnerEnvironment,
       } as unknown as import("../../src/utils/IOSCtrlProxyBuilder").IOSCtrlProxyBuilder;
       const manager = IOSCtrlProxyManager.createForTestingWithDeps(
         testDevice,
@@ -1127,6 +1186,7 @@ describe("IOSCtrlProxyManager", function() {
       const fakeBuilder = {
         getXctestrunPath: async () => "/tmp/test.xctestrun",
         getRunnerBinaryPath: async () => null,
+        writeRunnerEnvironment: fakeWriteRunnerEnvironment,
       } as unknown as import("../../src/utils/IOSCtrlProxyBuilder").IOSCtrlProxyBuilder;
       const manager = IOSCtrlProxyManager.createForTestingWithDeps(
         testDevice,
@@ -1149,14 +1209,19 @@ describe("IOSCtrlProxyManager", function() {
       expect(fakeExecutor.getSpawnedProcesses()).toHaveLength(1);
     });
 
-    test("startOnSimulator() keeps the reallocated simulator port when spawning", async function() {
+    test("startOnSimulator() delivers the reallocated port to the runner via the xctestrun (EC5)", async function() {
       PortManager.setPortAvailabilityCheckerForTesting({
         isPortAvailable: (port: number) => port !== 8765,
       });
       try {
+        const writeCalls: { xctestrunPath: string; env: Record<string, string>; deviceId: string }[] = [];
         const fakeBuilder = {
           getXctestrunPath: async () => "/tmp/test.xctestrun",
           getRunnerBinaryPath: async () => null,
+          writeRunnerEnvironment: async (xctestrunPath: string, env: Record<string, string>, deviceId: string) => {
+            writeCalls.push({ xctestrunPath, env, deviceId });
+            return "/tmp/automobile-runner-SIM.xctestrun";
+          },
         } as unknown as import("../../src/utils/IOSCtrlProxyBuilder").IOSCtrlProxyBuilder;
         const manager = IOSCtrlProxyManager.createForTestingWithDeps(
           testDevice,
@@ -1169,10 +1234,25 @@ describe("IOSCtrlProxyManager", function() {
 
         const spawn = fakeExecutor.getSpawnedProcesses()[0];
         expect(manager.getServicePort()).toBe(8767);
+
+        // The allocated port is injected into the xctestrun (the only channel the
+        // in-simulator runner can read) — keyed off the cached source xctestrun.
+        expect(writeCalls).toHaveLength(1);
+        expect(writeCalls[0].xctestrunPath).toBe("/tmp/test.xctestrun");
+        expect(writeCalls[0].env.CTRL_PROXY_IOS_PORT).toBe("8767");
+        expect(writeCalls[0].deviceId).toBe(testDevice.deviceId);
+
+        // xcodebuild is pointed at the per-launch copy, not the cached source.
+        expect(spawn.command).toContain("-xctestrun \"/tmp/automobile-runner-SIM.xctestrun\"");
+        expect(spawn.command).not.toContain("-xctestrun \"/tmp/test.xctestrun\"");
+
+        // Host env still carries the identity vars used for daemon-side process
+        // discovery/ownership — but NOT the dead SIMCTL_CHILD_* prefixes.
         expect(spawn.options?.env).toMatchObject({
           CTRL_PROXY_IOS_PORT: "8767",
-          SIMCTL_CHILD_CTRL_PROXY_IOS_PORT: "8767",
+          AUTOMOBILE_DEVICE_ID: testDevice.deviceId,
         });
+        expect(Object.keys(spawn.options?.env ?? {}).some(key => key.startsWith("SIMCTL_CHILD_"))).toBe(false);
       } finally {
         PortManager.setPortAvailabilityCheckerForTesting(null);
       }
@@ -1191,6 +1271,7 @@ describe("IOSCtrlProxyManager", function() {
         const fakeBuilder = {
           getXctestrunPath: async () => "/tmp/test.xctestrun",
           getRunnerBinaryPath: async () => null,
+          writeRunnerEnvironment: fakeWriteRunnerEnvironment,
         } as unknown as import("../../src/utils/IOSCtrlProxyBuilder").IOSCtrlProxyBuilder;
         const manager = IOSCtrlProxyManager.createForTestingWithDeps(
           testDevice,
@@ -1210,7 +1291,120 @@ describe("IOSCtrlProxyManager", function() {
         expect(PortManager.getPort(testDevice.deviceId)).toBe(8767);
         expect(spawn.options?.env).toMatchObject({
           CTRL_PROXY_IOS_PORT: "8767",
-          SIMCTL_CHILD_CTRL_PROXY_IOS_PORT: "8767",
+        });
+      } finally {
+        PortManager.setPortAvailabilityCheckerForTesting(null);
+      }
+    });
+
+    test("the port the runner reads from the spawned xctestrun equals the client service port (EC6 boundary)", async function() {
+      // Boundary model of the simulator process boundary: the daemon (client) and
+      // the in-simulator runner agree on the port ONLY if the allocated port is
+      // carried in the xctestrun the runner reads. This is the assertion that
+      // would have caught #2731 (runner bound 8765 while the client used 8767).
+      const productsDir = await fs.mkdtemp(path.join(os.tmpdir(), "ctrlproxy-boundary-"));
+      const sourceXctestrun = path.join(
+        productsDir,
+        "CtrlProxyApp_iphonesimulator26.2-arm64-x86_64.xctestrun"
+      );
+      await fs.writeFile(sourceXctestrun, BOUNDARY_XCTESTRUN);
+
+      // Use the REAL writeRunnerEnvironment so a real per-launch xctestrun is produced.
+      const realBuilder = IOSCtrlProxyBuilder.getInstance({ derivedDataPath: productsDir });
+      PortManager.setPortAvailabilityCheckerForTesting({
+        isPortAvailable: (port: number) => port !== 8765,
+      });
+      try {
+        const fakeBuilder = {
+          getXctestrunPath: async () => sourceXctestrun,
+          getRunnerBinaryPath: async () => null,
+          writeRunnerEnvironment: (p: string, env: Record<string, string>, id: string) =>
+            realBuilder.writeRunnerEnvironment(p, env, id),
+        } as unknown as IOSCtrlProxyBuilder;
+        const manager = IOSCtrlProxyManager.createForTestingWithDeps(
+          testDevice,
+          fakeTimer,
+          fakeBuilder,
+          fakeExecutor
+        );
+
+        await (manager as unknown as { startOnSimulator: () => Promise<void> }).startOnSimulator();
+
+        // Read back the port the runner WILL read from its own ProcessInfo.environment.
+        const spawnCommand = fakeExecutor.getSpawnedProcesses()[0].command;
+        const match = spawnCommand.match(/-xctestrun "([^"]+)"/);
+        expect(match).not.toBeNull();
+        const runnerXctestrunPath = match![1];
+        const root = await parsePlist(await fs.readFile(runnerXctestrunPath, "utf-8")) as Map<string, unknown>;
+        const uiTarget = root.get("CtrlProxyUITests") as Map<string, unknown>;
+        const env = uiTarget.get("EnvironmentVariables") as Map<string, unknown>;
+        const runnerPort = Number(env.get("CTRL_PROXY_IOS_PORT"));
+
+        expect(runnerPort).toBe(8767);
+        expect(runnerPort).toBe(manager.getServicePort());
+      } finally {
+        PortManager.setPortAvailabilityCheckerForTesting(null);
+        await fs.rm(productsDir, { recursive: true, force: true });
+      }
+    });
+
+    test("startOnDevice() delivers the allocated port via the xctestrun, not a build setting (EC7)", async function() {
+      const physicalDevice: BootedDevice = {
+        deviceId: "00008030001E28C11E",
+        platform: "ios",
+        name: "iPhone"
+      };
+      PortManager.setPortAvailabilityCheckerForTesting({
+        isPortAvailable: (port: number) => port !== 8765,
+      });
+      try {
+        const writeCalls: { env: Record<string, string>; deviceId: string }[] = [];
+        const fakeBuilder = {
+          getXctestrunPath: async () => "/tmp/device.xctestrun",
+          getRunnerBinaryPath: async () => null,
+          writeRunnerEnvironment: async (_p: string, env: Record<string, string>, deviceId: string) => {
+            writeCalls.push({ env, deviceId });
+            return "/tmp/automobile-runner-DEV.xctestrun";
+          },
+        } as unknown as IOSCtrlProxyBuilder;
+        const fakeSigning = {
+          resolveSigningForDevice: async () => ({
+            buildSettings: [],
+            allowProvisioningUpdates: false,
+            warnings: []
+          }),
+        } as unknown as XcodeSigningManager;
+        const manager = IOSCtrlProxyManager.createForTestingWithDeps(
+          physicalDevice,
+          fakeTimer,
+          fakeBuilder,
+          fakeExecutor,
+          fakeSigning
+        );
+        const internal = manager as unknown as {
+          verifyInstalledAppBundle: () => Promise<void>;
+          startIproxyTunnel: () => Promise<void>;
+          startOnDevice: () => Promise<void>;
+        };
+        // Bypass tunnel/install verification — not under test here.
+        internal.verifyInstalledAppBundle = async () => {};
+        internal.startIproxyTunnel = async () => {};
+
+        await internal.startOnDevice();
+
+        const spawn = fakeExecutor.getSpawnedProcesses()[0];
+        expect(writeCalls).toHaveLength(1);
+        expect(writeCalls[0].env.CTRL_PROXY_IOS_PORT).toBe("8767");
+        expect(writeCalls[0].deviceId).toBe(physicalDevice.deviceId);
+
+        // xcodebuild points at the per-launch copy; the bare build-setting token is gone.
+        expect(spawn.command).toContain("-xctestrun \"/tmp/automobile-runner-DEV.xctestrun\"");
+        expect(spawn.command).not.toMatch(/(?:^|\s)CTRL_PROXY_IOS_PORT=/);
+
+        // Host env still carries identity vars for daemon-side process discovery.
+        expect(spawn.options?.env).toMatchObject({
+          CTRL_PROXY_IOS_PORT: "8767",
+          AUTOMOBILE_DEVICE_ID: physicalDevice.deviceId,
         });
       } finally {
         PortManager.setPortAvailabilityCheckerForTesting(null);
@@ -1221,6 +1415,7 @@ describe("IOSCtrlProxyManager", function() {
       const fakeBuilder = {
         getXctestrunPath: async () => "/tmp/test.xctestrun",
         getRunnerBinaryPath: async () => null,
+        writeRunnerEnvironment: fakeWriteRunnerEnvironment,
       } as unknown as import("../../src/utils/IOSCtrlProxyBuilder").IOSCtrlProxyBuilder;
       const { runner, starts } = createHostControlRunner();
       const checker = new FakeHostPortAvailabilityChecker(new Set([8765]));
@@ -1251,6 +1446,7 @@ describe("IOSCtrlProxyManager", function() {
           throw new Error("should not build when an existing host-control process is reused");
         },
         getRunnerBinaryPath: async () => null,
+        writeRunnerEnvironment: fakeWriteRunnerEnvironment,
       } as unknown as import("../../src/utils/IOSCtrlProxyBuilder").IOSCtrlProxyBuilder;
       const { runner, starts } = createHostControlRunner({
         runningCtrlProxyProcesses: [{
@@ -1309,7 +1505,6 @@ describe("IOSCtrlProxyManager", function() {
       expect(fakeExecutor.getSpawnedProcesses()).toHaveLength(1);
       expect(fakeExecutor.getSpawnedProcesses()[0].options?.env).toMatchObject({
         CTRL_PROXY_IOS_PORT: "8765",
-        SIMCTL_CHILD_CTRL_PROXY_IOS_PORT: "8765",
       });
     });
 
@@ -1342,6 +1537,7 @@ describe("IOSCtrlProxyManager", function() {
             throw new Error("should not build when an external direct runner is reused");
           },
           getRunnerBinaryPath: async () => null,
+          writeRunnerEnvironment: fakeWriteRunnerEnvironment,
         } as unknown as import("../../src/utils/IOSCtrlProxyBuilder").IOSCtrlProxyBuilder;
         const manager = IOSCtrlProxyManager.createForTestingWithDeps(
           testDevice,
@@ -1393,7 +1589,6 @@ describe("IOSCtrlProxyManager", function() {
       expect(fakeExecutor.getSpawnedProcesses()).toHaveLength(1);
       expect(fakeExecutor.getSpawnedProcesses()[0].options?.env).toMatchObject({
         CTRL_PROXY_IOS_PORT: "8765",
-        SIMCTL_CHILD_CTRL_PROXY_IOS_PORT: "8765",
       });
     });
 
@@ -1436,7 +1631,6 @@ describe("IOSCtrlProxyManager", function() {
       expect(fakeExecutor.getSpawnedProcesses()).toHaveLength(1);
       expect(fakeExecutor.getSpawnedProcesses()[0].options?.env).toMatchObject({
         CTRL_PROXY_IOS_PORT: "8765",
-        SIMCTL_CHILD_CTRL_PROXY_IOS_PORT: "8765",
       });
     });
 
@@ -1467,7 +1661,6 @@ describe("IOSCtrlProxyManager", function() {
       expect(PortManager.getPort(testDevice.deviceId)).toBe(8767);
       expect(fakeExecutor.getSpawnedProcesses()[0].options?.env).toMatchObject({
         CTRL_PROXY_IOS_PORT: "8767",
-        SIMCTL_CHILD_CTRL_PROXY_IOS_PORT: "8767",
       });
     });
 
@@ -1501,7 +1694,6 @@ describe("IOSCtrlProxyManager", function() {
       expect(PortManager.getPort(testDevice.deviceId)).toBe(8767);
       expect(fakeExecutor.getSpawnedProcesses()[0].options?.env).toMatchObject({
         CTRL_PROXY_IOS_PORT: "8767",
-        SIMCTL_CHILD_CTRL_PROXY_IOS_PORT: "8767",
       });
     });
 
@@ -1543,7 +1735,6 @@ describe("IOSCtrlProxyManager", function() {
       expect(PortManager.getPort(testDevice.deviceId)).toBe(8767);
       expect(fakeExecutor.getSpawnedProcesses()[0].options?.env).toMatchObject({
         CTRL_PROXY_IOS_PORT: "8767",
-        SIMCTL_CHILD_CTRL_PROXY_IOS_PORT: "8767",
       });
     });
 
@@ -1577,7 +1768,6 @@ describe("IOSCtrlProxyManager", function() {
       expect(manager.getServicePort()).toBe(8765);
       expect(fakeExecutor.getSpawnedProcesses()[0].options?.env).toMatchObject({
         CTRL_PROXY_IOS_PORT: "8765",
-        SIMCTL_CHILD_CTRL_PROXY_IOS_PORT: "8765",
       });
     });
 
@@ -1612,7 +1802,6 @@ describe("IOSCtrlProxyManager", function() {
       expect(PortManager.getPort(testDevice.deviceId)).toBe(8767);
       expect(fakeExecutor.getSpawnedProcesses()[0].options?.env).toMatchObject({
         CTRL_PROXY_IOS_PORT: "8767",
-        SIMCTL_CHILD_CTRL_PROXY_IOS_PORT: "8767",
       });
     });
 

--- a/test/utils/ios-cmdline-tools/XctestrunPlist.test.ts
+++ b/test/utils/ios-cmdline-tools/XctestrunPlist.test.ts
@@ -1,0 +1,165 @@
+import { describe, expect, test } from "bun:test";
+import {
+  parsePlist,
+  buildPlist,
+  injectUITestEnvironment
+} from "../../../src/utils/ios-cmdline-tools/XctestrunPlist";
+
+/**
+ * A minimal but representative format-version-1 xctestrun: two test targets
+ * (a unit-test bundle and a UI-test bundle), each with an EnvironmentVariables
+ * dict, plus the trailing __xctestrun_metadata__ entry.
+ */
+const SAMPLE_XCTESTRUN = `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+\t<key>CtrlProxyTests</key>
+\t<dict>
+\t\t<key>BlueprintName</key>
+\t\t<string>CtrlProxyTests</string>
+\t\t<key>EnvironmentVariables</key>
+\t\t<dict>
+\t\t\t<key>TERM</key>
+\t\t\t<string>dumb</string>
+\t\t</dict>
+\t\t<key>TestBundlePath</key>
+\t\t<string>__TESTROOT__/Debug-iphonesimulator/CtrlProxyTests.xctest</string>
+\t</dict>
+\t<key>CtrlProxyUITests</key>
+\t<dict>
+\t\t<key>BlueprintName</key>
+\t\t<string>CtrlProxyUITests</string>
+\t\t<key>EnvironmentVariables</key>
+\t\t<dict>
+\t\t\t<key>OS_ACTIVITY_DT_MODE</key>
+\t\t\t<string>YES</string>
+\t\t\t<key>TERM</key>
+\t\t\t<string>dumb</string>
+\t\t</dict>
+\t\t<key>IsUITestBundle</key>
+\t\t<true/>
+\t\t<key>CommandLineArguments</key>
+\t\t<array/>
+\t\t<key>DefaultTestExecutionTimeAllowance</key>
+\t\t<integer>600</integer>
+\t</dict>
+\t<key>__xctestrun_metadata__</key>
+\t<dict>
+\t\t<key>FormatVersion</key>
+\t\t<integer>1</integer>
+\t</dict>
+</dict>
+</plist>`;
+
+function expectDict(value: unknown): Map<string, unknown> {
+  expect(value).toBeInstanceOf(Map);
+  return value as Map<string, unknown>;
+}
+
+describe("XctestrunPlist", function() {
+  describe("parsePlist / buildPlist round-trip (EC2)", function() {
+    test("parses dicts as ordered Maps and preserves scalar types", async function() {
+      const root = expectDict(await parsePlist(SAMPLE_XCTESTRUN));
+
+      // Top-level key order preserved
+      expect([...root.keys()]).toEqual([
+        "CtrlProxyTests",
+        "CtrlProxyUITests",
+        "__xctestrun_metadata__"
+      ]);
+
+      const uiTarget = expectDict(root.get("CtrlProxyUITests"));
+      expect(uiTarget.get("IsUITestBundle")).toBe(true);
+      expect(uiTarget.get("DefaultTestExecutionTimeAllowance")).toBe(600);
+      expect(uiTarget.get("CommandLineArguments")).toEqual([]);
+
+      const metadata = expectDict(root.get("__xctestrun_metadata__"));
+      expect(metadata.get("FormatVersion")).toBe(1);
+    });
+
+    test("round-trips losslessly through buildPlist -> parsePlist", async function() {
+      const root = await parsePlist(SAMPLE_XCTESTRUN);
+      const rebuilt = buildPlist(root);
+
+      // Valid plist preamble
+      expect(rebuilt).toContain("<!DOCTYPE plist PUBLIC");
+      expect(rebuilt.trimStart().startsWith("<?xml")).toBe(true);
+
+      const reparsed = expectDict(await parsePlist(rebuilt));
+      const uiTarget = expectDict(reparsed.get("CtrlProxyUITests"));
+      const env = expectDict(uiTarget.get("EnvironmentVariables"));
+      expect([...env.entries()]).toEqual([
+        ["OS_ACTIVITY_DT_MODE", "YES"],
+        ["TERM", "dumb"]
+      ]);
+      expect(uiTarget.get("IsUITestBundle")).toBe(true);
+    });
+
+    test("escapes XML-special characters in string values", async function() {
+      const root = new Map<string, unknown>([
+        ["weird", "a & b < c > d \"q\""]
+      ]);
+      const xml = buildPlist(root);
+      expect(xml).toContain("a &amp; b &lt; c &gt; d");
+      const reparsed = expectDict(await parsePlist(xml));
+      expect(reparsed.get("weird")).toBe("a & b < c > d \"q\"");
+    });
+  });
+
+  describe("injectUITestEnvironment (EC1)", function() {
+    test("injects into UI-test target only, preserving existing entries", async function() {
+      const root = expectDict(await parsePlist(SAMPLE_XCTESTRUN));
+      const count = injectUITestEnvironment(root, {
+        CTRL_PROXY_IOS_PORT: "8767",
+        AUTOMOBILE_DEVICE_ID: "SIM-UUID"
+      });
+
+      expect(count).toBe(1);
+
+      const uiEnv = expectDict(
+        expectDict(root.get("CtrlProxyUITests")).get("EnvironmentVariables")
+      );
+      // Existing entries preserved
+      expect(uiEnv.get("OS_ACTIVITY_DT_MODE")).toBe("YES");
+      expect(uiEnv.get("TERM")).toBe("dumb");
+      // New entries injected
+      expect(uiEnv.get("CTRL_PROXY_IOS_PORT")).toBe("8767");
+      expect(uiEnv.get("AUTOMOBILE_DEVICE_ID")).toBe("SIM-UUID");
+
+      // The non-UI (unit) target is left untouched
+      const unitEnv = expectDict(
+        expectDict(root.get("CtrlProxyTests")).get("EnvironmentVariables")
+      );
+      expect(unitEnv.has("CTRL_PROXY_IOS_PORT")).toBe(false);
+    });
+
+    test("overwrites an existing key on the UI-test target", async function() {
+      const root = expectDict(await parsePlist(SAMPLE_XCTESTRUN));
+      injectUITestEnvironment(root, { TERM: "xterm" });
+      const uiEnv = expectDict(
+        expectDict(root.get("CtrlProxyUITests")).get("EnvironmentVariables")
+      );
+      expect(uiEnv.get("TERM")).toBe("xterm");
+    });
+
+    test("creates EnvironmentVariables when the UI-test target lacks one", async function() {
+      const root = new Map<string, unknown>([
+        ["UITarget", new Map<string, unknown>([["IsUITestBundle", true]])]
+      ]);
+      const count = injectUITestEnvironment(root, { CTRL_PROXY_IOS_PORT: "9000" });
+      expect(count).toBe(1);
+      const env = expectDict(
+        expectDict(root.get("UITarget")).get("EnvironmentVariables")
+      );
+      expect(env.get("CTRL_PROXY_IOS_PORT")).toBe("9000");
+    });
+
+    test("returns 0 when there is no UI-test bundle", async function() {
+      const root = new Map<string, unknown>([
+        ["UnitTarget", new Map<string, unknown>([["IsUITestBundle", false]])]
+      ]);
+      expect(injectUITestEnvironment(root, { X: "1" })).toBe(0);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
Fixes #2731: when an Android device and an iOS simulator are connected at the same time, all iOS CtrlProxy operations fail. The daemon allocates a collision-free non-default port (e.g. `8767`) but the in-simulator runner always binds its hardcoded `defaultPort = 8765`, so the client and runner disagree on the port and every iOS op fails closed (`doctor` shows `runnerPort=8767; clientPort=8767; connected=false`, while `lsof` shows the runner healthy on `8765`).

## Root cause
The simulator runner is launched via `xcodebuild test-without-building` and the allocated port was passed through the **host xcodebuild process env** (`CTRL_PROXY_IOS_PORT`) and `SIMCTL_CHILD_*` vars. Neither reaches the in-simulator runner:

- Host process env does **not** cross into the simulated test-runner process.
- `SIMCTL_CHILD_*` stripping/forwarding is a `simctl spawn`/`launch` feature — `xcodebuild test-without-building` does not route the runner through `simctl spawn`, so it is ignored.

The runner reads the **unprefixed** `CTRL_PROXY_IOS_PORT` from its own `ProcessInfo.environment` (`CtrlProxyUITests.swift:100`), finds nothing, and falls back to `CtrlProxy.defaultPort = 8765`. Pure-iOS setups stayed green only because with no Android device the iOS port allocates to `8765`, coincidentally matching the runner's default. The mixed-device port-allocation work (#2716/#2712/#2718) made the iOS port reliably ≠ 8765, activating the latent break.

The only channel that reaches the in-simulator runner is the xctestrun's per-target **`EnvironmentVariables`** dict, which `xcodebuild` injects into the test host (the runner app) — per `xcodebuild.xctestrun(5)`.

## Fix
Option A from the issue.

- New `src/utils/ios-cmdline-tools/XctestrunPlist.ts`: a minimal ordered XML-plist reader/writer (`parsePlist`/`buildPlist`) plus `injectUITestEnvironment`, which merges env vars into the `EnvironmentVariables` dict of every UI-test bundle (`IsUITestBundle`).
- New `IOSCtrlProxyBuilder.writeRunnerEnvironment(xctestrunPath, env, deviceId)`: injects the allocated port (+ timeout/bundleId/deviceId) and writes a **per-launch copy** named `automobile-runner-<deviceId>.xctestrun` in the **same** `Build/Products` dir (so `__TESTROOT__` still resolves). The copy is keyed by deviceId to avoid multi-device races and is excluded from the source-discovery/cleanup globs so it can never be re-selected as the source xctestrun.
- `IOSCtrlProxyManager` simulator + physical paths now point `xcodebuild` at the per-launch xctestrun. Dropped the dead `SIMCTL_CHILD_*` vars (simulator) and the ineffective bare `CTRL_PROXY_IOS_PORT=` build-setting token (physical), and rewrote the misleading comment.
- **Kept** the unprefixed `CTRL_PROXY_IOS_PORT` + `AUTOMOBILE_DEVICE_ID` on the host xcodebuild process env — they are *not* dead: the daemon reads them via `ps eww` for process discovery/ownership/recovery (`findExternalXcodebuildCtrlProxyProcess`, `isDaemonManagedSimulatorXcodebuildProcess`). The physical path now also sets them on the host env for the same reason.

No test was relaxed to pass; the previous `spawn.options.env` assertions that encoded the wrong "host env reaches the runner" assumption were replaced with assertions about the channel that actually reaches the runner (the xctestrun).

## Test plan
- New `test/utils/ios-cmdline-tools/XctestrunPlist.test.ts` — parse/build round-trip + `injectUITestEnvironment` (UI-target-only, preserves/overwrites entries, creates missing dict, ignores non-UI targets).
- New `IOSCtrlProxyBuilder.writeRunnerEnvironment` tests — writes a per-launch copy carrying the injected port without mutating the source; excluded from `getXctestrunPath` (incl. the platform-agnostic glob) and `cleanStaleXctestrunFiles`; device-id filename sanitized; throws an actionable error when the xctestrun has no UI-test bundle.
- `IOSCtrlProxyManager` tests:
  - simulator: spawn points at the per-launch xctestrun, `writeRunnerEnvironment` receives the allocated `8767`, host env keeps the identity vars, no `SIMCTL_CHILD_*`.
  - **boundary**: using the real `writeRunnerEnvironment`, the port the runner *would* read from the spawned `-xctestrun`'s UI-test `EnvironmentVariables` equals `manager.getServicePort()` — the assertion that would have caught this bug (runner `8765` vs client `8767`).
  - physical: spawn points at the per-launch xctestrun, no bare `CTRL_PROXY_IOS_PORT=` build-setting token, host env keeps the identity vars.
- `bun test` → 5226 pass / 0 fail (410 files); `eslint --fix` and `bun build.ts` → green.

### Not in scope / follow-up
- The `doctor` iOS round-trip check (`src/doctor/checks/ios.ts`) still derives both `runnerPort` and `clientPort` from `getServicePort()`, so it structurally cannot detect a runner/client port mismatch (issue's Option C). Making it meaningful requires the runner to report its actual bound port back; left as a follow-up.
- **Verify on hardware first:** with one Android emulator + one iOS simulator connected, `observe { platform: "ios" }` returns a hierarchy (not `screenSize: 0x0`), confirming `xcodebuild` forwards the xctestrun `EnvironmentVariables` into the runner so it binds the allocated port.

Refs #2731
