### PR TITLE
fix(daemon): type transport failures so sibling MCP sessions recover after daemon restart (#2737)

### DIFF
--- a/src/daemon/client.ts
+++ b/src/daemon/client.ts
@@ -28,6 +28,28 @@ export class DaemonUnavailableError extends Error {
   }
 }
 
+/**
+ * Normalize a socket-level transport failure into a `DaemonUnavailableError`.
+ *
+ * When a daemon restart/crash tears down the connection, an in-flight request's
+ * socket emits a raw transport error (`ECONNRESET` / `EPIPE` / "socket hang up")
+ * with no daemon-level meaning. Surfacing that raw error verbatim wedges every
+ * other connected session (#2599): the proxy only treats `DaemonUnavailableError`
+ * and the daemon's own `Session not found` as recoverable, so a raw `ECONNRESET`
+ * is not retried (#2737). Typing it here — at the layer that knows it is a socket
+ * failure — keeps the recoverability signal in one place: the proxy reconnects via
+ * its existing `instanceof DaemonUnavailableError` branch, and a *daemon-returned*
+ * application error that merely mentions a transport code (e.g. a tool reporting a
+ * downstream `connect ECONNREFUSED`) stays an `ActionableError` and is correctly
+ * not retried. Already-typed `DaemonUnavailableError`s pass through unchanged.
+ */
+export function toDaemonTransportError(error: Error): DaemonUnavailableError {
+  if (error instanceof DaemonUnavailableError) {
+    return error;
+  }
+  return new DaemonUnavailableError(`Daemon socket connection lost: ${error.message}`);
+}
+
 export interface DaemonClientRecoveryOptions extends StaleDaemonFileCleanupOptions {
   /**
    * When true, `isAvailable()` performs an observation-only probe and never
@@ -181,10 +203,14 @@ export class DaemonClient {
           this.socket.destroy();
           this.socket = null;
         }
-        rejectPendingRequests(error);
+        // Type the transport failure so the proxy can recover sibling sessions
+        // wedged by a daemon restart (#2599/#2737) instead of surfacing a raw
+        // ECONNRESET/EPIPE/"socket hang up" that its recovery does not match.
+        const failure = toDaemonTransportError(error);
+        rejectPendingRequests(failure);
         if (!settled) {
           settled = true;
-          reject(error);
+          reject(failure);
         }
       };
 
@@ -217,7 +243,20 @@ export class DaemonClient {
 
       this.socket.on("close", () => {
         this.connected = false;
+        this.socket = null;
         logger.info("Daemon socket connection closed");
+        // A daemon restart/crash closes the socket. Over a Unix domain socket
+        // (no TCP RST) a dying daemon delivers EOF -> "close" with no "error"
+        // event, so any in-flight request would otherwise hang until its request
+        // timeout. Reject pending requests with a recoverable transport error so
+        // the proxy reconnects to the restarted daemon and retries (#2599/#2737).
+        // After fail() the pending map is already cleared, so this is a no-op on
+        // the error path.
+        if (this.pendingRequests.size > 0) {
+          rejectPendingRequests(
+            new DaemonUnavailableError("Daemon socket connection lost: connection closed")
+          );
+        }
       });
     });
   }

--- a/test/daemon/daemonMcpProxy.test.ts
+++ b/test/daemon/daemonMcpProxy.test.ts
@@ -6,6 +6,7 @@ import {
   DaemonToolUnavailableError,
 } from "../../src/daemon/daemonMcpProxy";
 import { DaemonClient, DaemonUnavailableError, type DaemonClientLike } from "../../src/daemon/client";
+import { ActionableError } from "../../src/models";
 import { DAEMON_VERSION, DAEMON_VERSION_RESTART_COOLDOWN_MS } from "../../src/daemon/constants";
 import { logger } from "../../src/utils/logger";
 import { FakeDaemonManager } from "../fakes/FakeDaemonManager";
@@ -763,6 +764,128 @@ describe("DaemonMcpProxy", () => {
         expect(staleClient.readResourceCalls).toEqual(["automobile:devices/booted"]);
         expect(freshClient.connectCallCount).toBe(1);
         expect(freshClient.readResourceCalls).toEqual(["automobile:devices/booted"]);
+      } finally {
+        isAvailableSpy.mockRestore();
+        await proxy.close();
+      }
+    });
+  });
+
+  describe("sibling-session recovery after daemon restart (#2737)", () => {
+    // A daemon restart (build-mismatch #2733, version-mismatch, env change, or
+    // crash recovery) tears down every other connected session's live socket.
+    // DaemonClient now types that transport failure as DaemonUnavailableError
+    // (see daemonTransportError.test.ts), so the sibling's next forwarded call
+    // is recoverable here and reconnects+retries once instead of wedging (#2599).
+    // Critically, a *daemon-returned application error* that merely mentions a
+    // transport code (e.g. a tool reporting a downstream `connect ECONNREFUSED`)
+    // stays an ActionableError and must NOT be retried.
+
+    test("callTool recovers when a sibling's socket dropped (DaemonUnavailableError)", async () => {
+      const recoveredResult = { content: [{ type: "text", text: "sibling recovered" }] };
+      const staleClient = new ScriptedDaemonClient({
+        toolError: new DaemonUnavailableError("Daemon socket connection lost: connection closed"),
+      });
+      const freshClient = new ScriptedDaemonClient({ toolResult: recoveredResult });
+      const clients = [staleClient, freshClient];
+      const isAvailableSpy = spyOn(DaemonClient, "isAvailable").mockResolvedValue(true);
+
+      const proxy = new DaemonMcpProxy({
+        clientFactory: () => clients.shift()!,
+        autoStartDaemon: false,
+      });
+
+      try {
+        const result = await proxy.callTool("observe", { deviceId: "device-1" });
+
+        expect(result).toEqual(recoveredResult);
+        expect(staleClient.closeCallCount).toBe(1);
+        expect(staleClient.callToolCalls).toHaveLength(1);
+        expect(freshClient.connectCallCount).toBe(1);
+        expect(freshClient.callToolCalls).toEqual([
+          { toolName: "observe", params: { deviceId: "device-1" } },
+        ]);
+      } finally {
+        isAvailableSpy.mockRestore();
+        await proxy.close();
+      }
+    });
+
+    test("readResource recovers when a sibling's socket dropped", async () => {
+      const recoveredResult = { contents: [{ uri: "automobile:devices/booted", text: "[]" }] };
+      const staleClient = new ScriptedDaemonClient({
+        resourceError: new DaemonUnavailableError("Daemon socket connection lost: connection closed"),
+      });
+      const freshClient = new ScriptedDaemonClient({ resourceResult: recoveredResult });
+      const clients = [staleClient, freshClient];
+      const isAvailableSpy = spyOn(DaemonClient, "isAvailable").mockResolvedValue(true);
+
+      const proxy = new DaemonMcpProxy({
+        clientFactory: () => clients.shift()!,
+        autoStartDaemon: false,
+      });
+
+      try {
+        const result = await proxy.readResource("automobile:devices/booted");
+
+        expect(result).toEqual(recoveredResult);
+        expect(staleClient.closeCallCount).toBe(1);
+        expect(freshClient.readResourceCalls).toEqual(["automobile:devices/booted"]);
+      } finally {
+        isAvailableSpy.mockRestore();
+        await proxy.close();
+      }
+    });
+
+    test("caps sibling recovery at one retry", async () => {
+      const firstClient = new ScriptedDaemonClient({
+        toolError: new DaemonUnavailableError("Daemon socket connection lost: connection closed"),
+      });
+      const secondClient = new ScriptedDaemonClient({
+        toolError: new DaemonUnavailableError("Daemon socket connection lost: connection closed"),
+      });
+      const clients = [firstClient, secondClient];
+      const isAvailableSpy = spyOn(DaemonClient, "isAvailable").mockResolvedValue(true);
+
+      const proxy = new DaemonMcpProxy({
+        clientFactory: () => clients.shift()!,
+        autoStartDaemon: false,
+      });
+
+      try {
+        await expect(proxy.callTool("observe", {})).rejects.toBeInstanceOf(DaemonUnavailableError);
+        expect(firstClient.closeCallCount).toBe(1);
+        expect(firstClient.callToolCalls).toHaveLength(1);
+        expect(secondClient.callToolCalls).toHaveLength(1);
+        expect(clients).toHaveLength(0);
+      } finally {
+        isAvailableSpy.mockRestore();
+        await proxy.close();
+      }
+    });
+
+    test("does NOT retry a daemon-returned tool error that mentions a transport code", async () => {
+      // Regression guard: a tool whose *downstream* connection fails surfaces the
+      // raw errno in its message (e.g. EmulatorConsoleClient: sendSms over the
+      // emulator console). That ActionableError reaches the proxy as a normal tool
+      // failure — retrying it would re-run a non-idempotent action and mask the
+      // real cause. It must be surfaced, not classified as a recoverable session.
+      const client = new ScriptedDaemonClient({
+        toolError: new ActionableError(
+          "Emulator console connection to 127.0.0.1:5554 failed: connect ECONNREFUSED 127.0.0.1:5554"
+        ),
+      });
+      const isAvailableSpy = spyOn(DaemonClient, "isAvailable").mockResolvedValue(true);
+
+      const proxy = new DaemonMcpProxy({
+        clientFactory: () => client,
+        autoStartDaemon: false,
+      });
+
+      try {
+        await expect(proxy.callTool("sendSms", {})).rejects.toThrow("ECONNREFUSED");
+        expect(client.callToolCalls).toHaveLength(1);
+        expect(client.closeCallCount).toBe(0);
       } finally {
         isAvailableSpy.mockRestore();
         await proxy.close();

--- a/test/daemon/daemonTransportError.test.ts
+++ b/test/daemon/daemonTransportError.test.ts
@@ -1,0 +1,87 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { createServer, type Server, type Socket } from "node:net";
+import { mkdtempSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir, platform } from "node:os";
+import {
+  DaemonClient,
+  DaemonUnavailableError,
+  toDaemonTransportError,
+} from "../../src/daemon/client";
+
+const isWindows = platform() === "win32";
+
+describe("toDaemonTransportError", () => {
+  test("wraps a raw transport error as a recoverable DaemonUnavailableError", () => {
+    const raw = new Error("read ECONNRESET");
+    (raw as NodeJS.ErrnoException).code = "ECONNRESET";
+
+    const wrapped = toDaemonTransportError(raw);
+
+    expect(wrapped).toBeInstanceOf(DaemonUnavailableError);
+    // The original transport detail is preserved for diagnostics.
+    expect(wrapped.message).toContain("ECONNRESET");
+  });
+
+  test("wraps EPIPE and 'socket hang up' the same way", () => {
+    for (const message of ["write EPIPE", "socket hang up"]) {
+      const wrapped = toDaemonTransportError(new Error(message));
+      expect(wrapped).toBeInstanceOf(DaemonUnavailableError);
+      expect(wrapped.message).toContain(message);
+    }
+  });
+
+  test("passes an already-typed DaemonUnavailableError through unchanged", () => {
+    const original = new DaemonUnavailableError("Socket connection lost");
+    expect(toDaemonTransportError(original)).toBe(original);
+  });
+});
+
+describe("DaemonClient in-flight request on connection reset (#2737)", () => {
+  const tempDirs: string[] = [];
+  let server: Server | null = null;
+
+  afterEach(async () => {
+    if (server) {
+      await new Promise<void>(resolve => server!.close(() => resolve()));
+      server = null;
+    }
+    for (const dir of tempDirs) {
+      rmSync(dir, { recursive: true, force: true });
+    }
+    tempDirs.length = 0;
+  });
+
+  // A daemon restart resets every sibling session's live socket. The sibling's
+  // in-flight request must reject with a recoverable DaemonUnavailableError (so
+  // the proxy reconnects and retries), not a raw ECONNRESET that wedges it.
+  (isWindows ? test.skip : test)(
+    "rejects the pending request with DaemonUnavailableError when the daemon drops the connection",
+    async () => {
+      const dir = mkdtempSync(join(tmpdir(), "daemon-transport-test-"));
+      tempDirs.push(dir);
+      const socketPath = join(dir, "daemon.sock");
+
+      // Server accepts the connection, then drops it the moment the client sends
+      // its request — exactly what a dying/restarting daemon does to a sibling's
+      // live socket. Over a Unix domain socket this delivers EOF -> "close".
+      server = createServer((connection: Socket) => {
+        connection.once("data", () => {
+          connection.destroy();
+        });
+      });
+      await new Promise<void>(resolve => server!.listen(socketPath, resolve));
+
+      const client = new DaemonClient(socketPath, 2000);
+      await client.connect();
+
+      // Must reject promptly with a recoverable DaemonUnavailableError — not hang
+      // until the request timeout, and not a raw transport error.
+      await expect(client.callDaemonMethod("tools/list", {})).rejects.toBeInstanceOf(
+        DaemonUnavailableError
+      );
+
+      await client.close();
+    }
+  );
+});


### PR DESCRIPTION
## Summary
Verifies issue #2737 and closes the sibling-session gap it identified. A daemon restart — the build-mismatch restart from #2733, the version-mismatch restart, an env-change restart, or crash recovery — recovers the *connecting* session, but a **sibling** MCP session still attached to the old daemon wedged on its next call with no auto-recovery (the #2599 wedge).

The fix is **restart-cause-agnostic** and lives at the **transport layer**, so it covers every restart path (including #2733's build-mismatch restart) identically.

> Rebased onto post-#2733 `main` — #2733 merged (`42060e44`) and edits the same `isRecoverableDaemonSessionError` method. This branch reconciles cleanly: it deliberately makes **no** change to that predicate.

## Root cause
When a sibling's daemon is killed/restarted, its forwarded call fails differently depending on timing, and only the typed cases were recoverable:
1. `Session not found` — the frontend reconnects and the new daemon rejects the unknown session → already recoverable.
2. `DaemonUnavailableError("Socket connection lost")` — the *next* call finds `!this.socket` (`client.ts`) → already recoverable.
3. **The in-flight request at the moment of death** → not recoverable. Over a **Unix domain socket** (the daemon's transport — no TCP RST) a dying daemon delivers **EOF → `close`**, not an `error` event, so the in-flight request was never rejected and **hung until its request timeout** (then surfaced a non-recoverable `McpTimeoutError`). A raw `error` event (`EPIPE` on a later write) was surfaced verbatim and also not matched.

## Fix
Type the failure at the layer that owns it — `DaemonClient` — instead of pattern-matching error strings up in the proxy:
- **`toDaemonTransportError()`** wraps the raw socket `error` into a `DaemonUnavailableError` (preserving the transport detail), used by the `fail()` path.
- The **`close` handler** now nulls the socket and rejects any in-flight requests with a recoverable `DaemonUnavailableError`, so the EOF/`close` path (the common Unix-socket daemon-death case) recovers **promptly** instead of hanging until timeout. Graceful `client.close()` clears pending first, so this is a no-op there.
- The proxy's existing **`instanceof DaemonUnavailableError`** branch reconnects and retries **once**. **No predicate broadening.**

### Why this layer (addressing review)
Putting the recoverability signal in the transport keeps **one source of truth** and — critically — avoids a false positive: a *daemon-returned application error* that merely mentions a transport code stays an `ActionableError` and is **not** retried. Concretely, `EmulatorConsoleClient` surfaces a downstream `connect ECONNREFUSED 127.0.0.1:5554` for `sendSms`; a substring-matching predicate would have wrongly reconnected the daemon and **re-run the non-idempotent send**. A regression test locks this out.

### Scope / honest caveats
- **Retry-once can re-execute a non-idempotent in-flight call** if the daemon happened to process it before dying. This is the genuinely new surface vs. the pre-existing `Session not found` (a daemon *response*, side effect never ran) and `Socket connection lost` (thrown *before* the write) paths — not an "identical" policy. On a restart the in-flight request almost always did not complete, the retry is capped at one, and daemon-side request dedup is out of scope (broader #2599 work).
- **Reactive recovery only.** Proactive daemon-identity-change detection (#2599's alternative; #2733's `ensureBuildMatches` already has the primitive) and cache-hit staleness are intentionally **not** in scope here.

## Test plan
TDD. New `test/daemon/daemonTransportError.test.ts`:
- `toDaemonTransportError`: wraps raw `ECONNRESET`/`EPIPE`/`socket hang up` as `DaemonUnavailableError` (detail preserved); passes a typed error through unchanged.
- **Real-socket** in-flight test: server drops the connection mid-request → the pending call rejects **promptly** with `DaemonUnavailableError` (deterministic, ~34ms; no fakes).

New `sibling-session recovery` block in `test/daemon/daemonMcpProxy.test.ts`:
- End-to-end sibling recovery for `callTool` and `readResource` (reconnect + retry once → success).
- Recovery **capped at one retry**.
- **Regression guard**: a daemon-returned tool error containing `connect ECONNREFUSED` is **not** retried (single call, no reconnect).

- `bun test` → **5253 pass**, 0 fail; `bun test test/daemon/` → 480 pass (~0.6s), each unit test <100ms.
- `turbo run lint build` → green. `scripts/all_fast_validate_checks.sh` → 10/10.

Refs #2599, #2732, #2733
Closes #2737
