### PR TITLE
feat(doctor): surface daemon build identity (entryScript/buildId) + skew (#2736)

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -193,7 +193,7 @@ async function runDoctorCommand(params: Record<string, any>): Promise<void> {
   try {
     logger.debug("Attempting to run doctor via daemon");
     const daemonResult = await runToolViaDaemon("doctor", daemonParams);
-    handleDoctorResult(daemonResult, jsonOutput);
+    await handleDoctorResult(daemonResult, jsonOutput);
     return;
   } catch (error) {
     logger.debug(`Daemon not available for doctor, falling back to direct execution: ${error}`);
@@ -223,7 +223,7 @@ async function runDoctorCommand(params: Record<string, any>): Promise<void> {
 /**
  * Handle doctor command result from daemon
  */
-function handleDoctorResult(result: any, jsonOutput: boolean): void {
+async function handleDoctorResult(result: any, jsonOutput: boolean): Promise<void> {
   // Extract the report from MCP response format
   let report = result;
   if (result && typeof result === "object" && "content" in result && Array.isArray(result.content)) {
@@ -236,13 +236,23 @@ function handleDoctorResult(result: any, jsonOutput: boolean): void {
     }
   }
 
+  // The daemon runs doctor in its own process, so its build-identity check
+  // compared the daemon to itself. Recompute it here, client-side, so the
+  // comparison uses THIS checkout's identity vs the daemon's PID-file identity
+  // and a wrong-build skew is actually surfaced (issue #2736).
+  try {
+    const { applyClientBuildIdentity } = await import("../doctor");
+    report = await applyClientBuildIdentity(report);
+  } catch (error) {
+    logger.debug(`Could not reconcile daemon build identity client-side: ${error}`);
+  }
+
   if (jsonOutput) {
     console.log(JSON.stringify(report, null, 2));
   } else {
     // Use the formatter for console output
-    import("../doctor").then(({ formatConsoleOutput }) => {
-      console.log(formatConsoleOutput(report, process.stdout.isTTY ?? true));
-    });
+    const { formatConsoleOutput } = await import("../doctor");
+    console.log(formatConsoleOutput(report, process.stdout.isTTY ?? true));
   }
 
   // Exit with error code if any failures

--- a/src/daemon/buildIdentity.ts
+++ b/src/daemon/buildIdentity.ts
@@ -88,3 +88,14 @@ export function buildIdentitiesMatch(a: BuildIdentity, b: BuildIdentity): boolea
   }
   return true;
 }
+
+/**
+ * Render a {@link BuildIdentity} as a single human-readable token:
+ * `"<buildId> (<entryScript>)"`. Falls back to `unknown` for an empty entry
+ * script so the rendering stays stable for legacy daemons that predate build
+ * identity. Shared by `doctor` and the `--daemon status` CLI so both surface the
+ * daemon's build in the same format.
+ */
+export function describeBuildIdentity(identity: BuildIdentity): string {
+  return `${identity.buildId} (${identity.entryScript || "unknown"})`;
+}

--- a/src/daemon/buildIdentity.ts
+++ b/src/daemon/buildIdentity.ts
@@ -99,3 +99,24 @@ export function buildIdentitiesMatch(a: BuildIdentity, b: BuildIdentity): boolea
 export function describeBuildIdentity(identity: BuildIdentity): string {
   return `${identity.buildId} (${identity.entryScript || "unknown"})`;
 }
+
+/**
+ * Project the build fields carried on a daemon status / PID-file record into a
+ * {@link BuildIdentity}, normalizing the optional wire fields (a missing
+ * `entryScript` becomes `""`, a missing `buildId` becomes the unknown sentinel).
+ *
+ * Centralizes the `DaemonStatus`/`PidFileData` → `BuildIdentity` mapping that
+ * `doctor`, the `--daemon status` CLI, and the MCP proxy all need, so they agree
+ * on how an unidentified (legacy) daemon is represented. Accepts a structural
+ * shape rather than importing `DaemonStatus` to avoid a module cycle and to keep
+ * the surface narrow.
+ */
+export function buildIdentityFromStatus(record: {
+  entryScript?: string;
+  buildId?: string;
+}): BuildIdentity {
+  return {
+    entryScript: record.entryScript ?? "",
+    buildId: record.buildId ?? UNKNOWN_BUILD_ID,
+  };
+}

--- a/src/daemon/daemonMcpProxy.ts
+++ b/src/daemon/daemonMcpProxy.ts
@@ -8,6 +8,8 @@ import { defaultTimer, type Timer } from "../utils/SystemTimer";
 import {
   type BuildIdentity,
   buildIdentitiesMatch,
+  buildIdentityFromStatus,
+  describeBuildIdentity,
   getCurrentBuildIdentity,
 } from "./buildIdentity";
 
@@ -79,15 +81,13 @@ export class DaemonBuildMismatchError extends DaemonUnavailableError {
     detail: string;
     retryAfterMs?: number;
   }) {
-    const daemonScript = params.daemon.entryScript || "unknown";
-    const clientScript = params.client.entryScript || "unknown";
     const retryGuidance = params.retryAfterMs !== undefined
       ? ` Retry after ${params.retryAfterMs}ms.`
       : "";
     super(
       `AutoMobile daemon build mismatch: the running daemon is a different build than this client ` +
-      `(${params.detail}). daemon build=${params.daemon.buildId} (${daemonScript}), ` +
-      `client build=${params.client.buildId} (${clientScript}).${retryGuidance}`
+      `(${params.detail}). daemon build=${describeBuildIdentity(params.daemon)}, ` +
+      `client build=${describeBuildIdentity(params.client)}.${retryGuidance}`
     );
     this.name = "DaemonBuildMismatchError";
     this.clientBuildId = params.client.buildId;
@@ -114,14 +114,12 @@ export class DaemonToolUnavailableError extends Error {
     client: BuildIdentity;
     daemon: BuildIdentity;
   }) {
-    const daemonScript = params.daemon.entryScript || "unknown";
-    const clientScript = params.client.entryScript || "unknown";
     super(
       `Tool "${params.toolName}" is advertised by this AutoMobile client but the connected daemon ` +
       `does not provide it, even after restarting and refreshing the tool list. This usually means a ` +
       `wrong-build daemon is serving this frontend. ` +
-      `client build=${params.client.buildId} (${clientScript}), ` +
-      `daemon build=${params.daemon.buildId} (${daemonScript}). ` +
+      `client build=${describeBuildIdentity(params.client)}, ` +
+      `daemon build=${describeBuildIdentity(params.daemon)}. ` +
       `Restart the daemon from this checkout to resolve the skew.`
     );
     this.name = "DaemonToolUnavailableError";
@@ -384,10 +382,7 @@ export class DaemonMcpProxy {
       return;
     }
 
-    const daemonIdentity: BuildIdentity = {
-      entryScript: status.entryScript ?? "",
-      buildId: status.buildId ?? "unknown",
-    };
+    const daemonIdentity = buildIdentityFromStatus(status);
     if (buildIdentitiesMatch(this.buildIdentity, daemonIdentity)) {
       return;
     }
@@ -426,10 +421,7 @@ export class DaemonMcpProxy {
     }
 
     const restartedStatus = await this.daemonManager.status();
-    const restartedIdentity: BuildIdentity = {
-      entryScript: restartedStatus.entryScript ?? "",
-      buildId: restartedStatus.buildId ?? "unknown",
-    };
+    const restartedIdentity = buildIdentityFromStatus(restartedStatus);
     if (!restartedStatus.running || !buildIdentitiesMatch(this.buildIdentity, restartedIdentity)) {
       throw this.buildMismatchError(
         restartedIdentity,
@@ -617,10 +609,7 @@ export class DaemonMcpProxy {
     let daemonIdentity: BuildIdentity = { entryScript: "", buildId: "unknown" };
     try {
       const status = await this.daemonManager.status();
-      daemonIdentity = {
-        entryScript: status.entryScript ?? "",
-        buildId: status.buildId ?? "unknown",
-      };
+      daemonIdentity = buildIdentityFromStatus(status);
     } catch (error) {
       logger.warn(`[DaemonMcpProxy] Failed to read daemon status for tool-unavailable error: ${error}`);
     }

--- a/src/daemon/manager.ts
+++ b/src/daemon/manager.ts
@@ -25,6 +25,7 @@ import {
 import { DaemonClient, type DaemonClientFactory, type DaemonClientLike } from "./client";
 import {
   buildIdentitiesMatch,
+  buildIdentityFromStatus,
   describeBuildIdentity,
   getCurrentBuildIdentity,
   type BuildIdentity,
@@ -1075,10 +1076,7 @@ export function daemonBuildIdentityStatusLines(
   status: DaemonStatus,
   client: BuildIdentity
 ): string[] {
-  const daemon: BuildIdentity = {
-    entryScript: status.entryScript ?? "",
-    buildId: status.buildId ?? "unknown",
-  };
+  const daemon = buildIdentityFromStatus(status);
   const lines = [
     `  Build ID: ${daemon.buildId || "unknown"}`,
     `  Entry Script: ${daemon.entryScript || "unknown"}`,

--- a/src/daemon/manager.ts
+++ b/src/daemon/manager.ts
@@ -1087,7 +1087,7 @@ export function daemonBuildIdentityStatusLines(
       "\n⚠️  WARNING: the running daemon is a different build than this checkout:",
       `  daemon build=${describeBuildIdentity(daemon)}`,
       `  client build=${describeBuildIdentity(client)}`,
-      "\nRun 'bunx @kaeawc/auto-mobile@latest --daemon restart' to align them."
+      "\nRestart the daemon from this checkout (run `--daemon restart` with this same CLI) to align them."
     );
   }
 

--- a/src/daemon/manager.ts
+++ b/src/daemon/manager.ts
@@ -23,6 +23,12 @@ import {
   formatSocketDiagnostics,
 } from "./debugTools";
 import { DaemonClient, type DaemonClientFactory, type DaemonClientLike } from "./client";
+import {
+  buildIdentitiesMatch,
+  describeBuildIdentity,
+  getCurrentBuildIdentity,
+  type BuildIdentity,
+} from "./buildIdentity";
 import { DaemonState, type DaemonStateLike } from "./daemonState";
 import { Timer, defaultTimer } from "../utils/SystemTimer";
 import {
@@ -1057,6 +1063,39 @@ export interface RunDaemonCommandOptions {
   stateProvider?: () => DaemonStateLike;
 }
 
+/**
+ * Build the `--daemon status` lines that surface the running daemon's build
+ * identity (`buildId` + `entryScript`) and flag wrong-build skew against this
+ * client. Pure so it is unit-testable without a live daemon. See #2736.
+ *
+ * @param status the running daemon's status (must be `running`)
+ * @param client this client's build identity
+ */
+export function daemonBuildIdentityStatusLines(
+  status: DaemonStatus,
+  client: BuildIdentity
+): string[] {
+  const daemon: BuildIdentity = {
+    entryScript: status.entryScript ?? "",
+    buildId: status.buildId ?? "unknown",
+  };
+  const lines = [
+    `  Build ID: ${daemon.buildId || "unknown"}`,
+    `  Entry Script: ${daemon.entryScript || "unknown"}`,
+  ];
+
+  if (!buildIdentitiesMatch(client, daemon)) {
+    lines.push(
+      "\n⚠️  WARNING: the running daemon is a different build than this checkout:",
+      `  daemon build=${describeBuildIdentity(daemon)}`,
+      `  client build=${describeBuildIdentity(client)}`,
+      "\nRun 'bunx @kaeawc/auto-mobile@latest --daemon restart' to align them."
+    );
+  }
+
+  return lines;
+}
+
 export async function runDaemonCommand(
   command: string,
   args: string[],
@@ -1086,6 +1125,9 @@ export async function runDaemonCommand(
           console.log(
             `  Started: ${status.startedAt ? new Date(status.startedAt).toISOString() : "unknown"}`
           );
+          for (const line of daemonBuildIdentityStatusLines(status, getCurrentBuildIdentity())) {
+            console.log(line);
+          }
 
           // Check for other daemon processes (exclude current daemon)
           const otherDaemons = manager.findOtherDaemonProcesses(status.pid);

--- a/src/doctor/checks/automobile.ts
+++ b/src/doctor/checks/automobile.ts
@@ -188,11 +188,13 @@ export async function checkDaemonBuildIdentity(
     const client = (dependencies.getClientBuildIdentity ?? getCurrentBuildIdentity)();
 
     if (buildIdentitiesMatch(client, daemon)) {
+      // No `value`: the console formatter renders `value` *instead of* `message`,
+      // and we want both the buildId and the entryScript visible — so carry them
+      // in the message.
       return {
         name: "Daemon Build Identity",
         status: "pass",
         message: `Build ${describeBuildIdentity(daemon)}`,
-        value: daemon.buildId,
       };
     }
 

--- a/src/doctor/checks/automobile.ts
+++ b/src/doctor/checks/automobile.ts
@@ -201,8 +201,10 @@ export async function checkDaemonBuildIdentity(
       status: "warn",
       message: `Build skew: daemon ${describeBuildIdentity(daemon)}, client ${describeBuildIdentity(client)}`,
       recommendation:
-        "The running daemon is a different build than this checkout. Restart it from here: " +
-        "bunx @kaeawc/auto-mobile@latest --daemon restart",
+        "The running daemon is a different build than this checkout. Restart the daemon " +
+        "from THIS checkout so it matches — run `--daemon restart` with the same auto-mobile " +
+        "CLI you invoked here. Avoid `@latest`, which starts the published build and may not " +
+        "match this checkout.",
     };
   } catch (error) {
     // Diagnostic path: log the underlying error before returning a typed failure

--- a/src/doctor/checks/automobile.ts
+++ b/src/doctor/checks/automobile.ts
@@ -9,6 +9,12 @@ import { DaemonManager } from "../../daemon/manager";
 import { getDaemonHealthReport } from "../../daemon/debugTools";
 import type { DaemonHealthReport } from "../../daemon/debugTools";
 import type { DaemonStatus } from "../../daemon/types";
+import {
+  buildIdentitiesMatch,
+  describeBuildIdentity,
+  getCurrentBuildIdentity,
+} from "../../daemon/buildIdentity";
+import type { BuildIdentity } from "../../daemon/buildIdentity";
 import { LATEST_RELEASE_VERSION, RELEASE_VERSION, resolveAssetVersion } from "../../constants/release";
 import { getMcpServerVersion } from "../../utils/mcpVersion";
 import { defaultAdbClientFactory } from "../../utils/android-cmdline-tools/AdbClientFactory";
@@ -27,9 +33,15 @@ export interface DaemonStatusDependencies {
   getDaemonHealthReport?: () => Promise<DaemonHealthReport>;
 }
 
+export interface DaemonBuildIdentityDependencies {
+  daemonManager?: DaemonStatusManager;
+  getClientBuildIdentity?: () => BuildIdentity;
+}
+
 export interface AutoMobileCheckDependencies {
   checkDaemonStatus?: () => Promise<CheckResult>;
   checkDaemonConnectivity?: () => Promise<CheckResult>;
+  checkDaemonBuildIdentity?: () => Promise<CheckResult>;
 }
 
 /**
@@ -141,6 +153,62 @@ export async function checkDaemonConnectivity(
       name: "Daemon Connectivity",
       status: "warn",
       message: `Connectivity check failed: ${error instanceof Error ? error.message : String(error)}`,
+    };
+  }
+}
+
+/**
+ * Surface the running daemon's build identity (`buildId` + `entryScript`) and
+ * flag wrong-build skew.
+ *
+ * Two checkouts on one machine share a single per-uid daemon socket, so the
+ * daemon serving this frontend can be from a *different* build (see #2732). The
+ * build-identity content hash recorded in the PID file (#2733) lets `doctor`
+ * make that visible *before* a tool call fails — rather than after.
+ */
+export async function checkDaemonBuildIdentity(
+  dependencies: DaemonBuildIdentityDependencies = {}
+): Promise<CheckResult> {
+  try {
+    const manager = dependencies.daemonManager ?? new DaemonManager();
+    const status = await manager.status();
+
+    if (!status.running) {
+      return {
+        name: "Daemon Build Identity",
+        status: "skip",
+        message: "Daemon is not running",
+      };
+    }
+
+    const daemon: BuildIdentity = {
+      entryScript: status.entryScript ?? "",
+      buildId: status.buildId ?? "unknown",
+    };
+    const client = (dependencies.getClientBuildIdentity ?? getCurrentBuildIdentity)();
+
+    if (buildIdentitiesMatch(client, daemon)) {
+      return {
+        name: "Daemon Build Identity",
+        status: "pass",
+        message: `Build ${describeBuildIdentity(daemon)}`,
+        value: daemon.buildId,
+      };
+    }
+
+    return {
+      name: "Daemon Build Identity",
+      status: "warn",
+      message: `Build skew: daemon ${describeBuildIdentity(daemon)}, client ${describeBuildIdentity(client)}`,
+      recommendation:
+        "The running daemon is a different build than this checkout. Restart it from here: " +
+        "bunx @kaeawc/auto-mobile@latest --daemon restart",
+    };
+  } catch (error) {
+    return {
+      name: "Daemon Build Identity",
+      status: "warn",
+      message: `Could not check daemon build identity: ${error instanceof Error ? error.message : String(error)}`,
     };
   }
 }
@@ -373,6 +441,7 @@ export async function runAutoMobileChecks(
   results.push(checkCtrlProxyVersion());
   results.push(await (dependencies.checkDaemonStatus ?? (() => checkDaemonStatus()))());
   results.push(await (dependencies.checkDaemonConnectivity ?? (() => checkDaemonConnectivity()))());
+  results.push(await (dependencies.checkDaemonBuildIdentity ?? (() => checkDaemonBuildIdentity()))());
 
   if (options.ios === true && options.android !== true) {
     results.push({

--- a/src/doctor/checks/automobile.ts
+++ b/src/doctor/checks/automobile.ts
@@ -11,6 +11,7 @@ import type { DaemonHealthReport } from "../../daemon/debugTools";
 import type { DaemonStatus } from "../../daemon/types";
 import {
   buildIdentitiesMatch,
+  buildIdentityFromStatus,
   describeBuildIdentity,
   getCurrentBuildIdentity,
 } from "../../daemon/buildIdentity";
@@ -181,10 +182,7 @@ export async function checkDaemonBuildIdentity(
       };
     }
 
-    const daemon: BuildIdentity = {
-      entryScript: status.entryScript ?? "",
-      buildId: status.buildId ?? "unknown",
-    };
+    const daemon = buildIdentityFromStatus(status);
     const client = (dependencies.getClientBuildIdentity ?? getCurrentBuildIdentity)();
 
     if (buildIdentitiesMatch(client, daemon)) {
@@ -207,6 +205,13 @@ export async function checkDaemonBuildIdentity(
         "bunx @kaeawc/auto-mobile@latest --daemon restart",
     };
   } catch (error) {
+    // Diagnostic path: log the underlying error before returning a typed failure
+    // so there is a trace even though the user only sees the summarized message
+    // (CLAUDE.md error-handling convention #2).
+    logger.warn(
+      `Daemon build identity check failed: ${error instanceof Error ? error.message : String(error)}`,
+      error
+    );
     return {
       name: "Daemon Build Identity",
       status: "warn",

--- a/src/doctor/index.ts
+++ b/src/doctor/index.ts
@@ -7,7 +7,7 @@ import { DoctorReport, DoctorOptions, DoctorSummary, CheckResult } from "./types
 import { runSystemChecks } from "./checks/system";
 import { runAndroidChecks } from "./checks/android";
 import { runIosChecks } from "./checks/ios";
-import { runAutoMobileChecks } from "./checks/automobile";
+import { runAutoMobileChecks, checkDaemonBuildIdentity } from "./checks/automobile";
 import { RELEASE_VERSION } from "../constants/release";
 
 /**
@@ -114,6 +114,58 @@ export async function runDoctor(
     report.ios = { checks: iosChecks };
   }
 
+  return report;
+}
+
+/**
+ * Collect every check across all sections of a report (for recomputing totals).
+ */
+function collectAllChecks(report: DoctorReport): CheckResult[] {
+  return [
+    ...report.system.checks,
+    ...(report.android?.checks ?? []),
+    ...(report.ios?.checks ?? []),
+    ...report.autoMobile.checks,
+  ];
+}
+
+/**
+ * Recompute a daemon-served report's "Daemon Build Identity" check from the
+ * **client** side and splice the authoritative result back in.
+ *
+ * `auto-mobile --cli doctor` runs {@link runDoctor} inside the *daemon* process
+ * (the CLI tries the daemon first), so the build-identity check there compares
+ * the daemon to *itself* via `getCurrentBuildIdentity()` and can never see a
+ * wrong-build skew — defeating the check in its primary flow (#2736). The
+ * invoking process is the only one that knows the real client build, so the CLI
+ * re-runs the check here (its own `getCurrentBuildIdentity()` vs the daemon's
+ * PID-file identity) and replaces the daemon's self-comparison, recomputing the
+ * summary/recommendations so a newly-detected skew is actually counted.
+ *
+ * No-op when the report has no AutoMobile section (e.g. an MCP parse fallback).
+ *
+ * @param runCheck injectable client-side check (defaults to {@link checkDaemonBuildIdentity})
+ */
+export async function applyClientBuildIdentity(
+  report: DoctorReport,
+  runCheck: () => Promise<CheckResult> = () => checkDaemonBuildIdentity()
+): Promise<DoctorReport> {
+  if (!report?.autoMobile?.checks) {
+    return report;
+  }
+
+  const clientCheck = await runCheck();
+  const checks = report.autoMobile.checks;
+  const idx = checks.findIndex(check => check.name === clientCheck.name);
+  if (idx >= 0) {
+    checks[idx] = clientCheck;
+  } else {
+    checks.push(clientCheck);
+  }
+
+  const allChecks = collectAllChecks(report);
+  report.summary = calculateSummary(allChecks);
+  report.recommendations = collectRecommendations(allChecks);
   return report;
 }
 

--- a/test/daemon/buildIdentity.test.ts
+++ b/test/daemon/buildIdentity.test.ts
@@ -3,6 +3,7 @@ import { resolve } from "node:path";
 import {
   computeBuildIdentity,
   buildIdentitiesMatch,
+  buildIdentityFromStatus,
   describeBuildIdentity,
   type BuildIdentity,
 } from "../../src/daemon/buildIdentity";
@@ -81,6 +82,23 @@ describe("buildIdentity", () => {
     test("falls back to 'unknown' entry script when it is empty", () => {
       const id: BuildIdentity = { entryScript: "", buildId: "unknown" };
       expect(describeBuildIdentity(id)).toBe("unknown (unknown)");
+    });
+  });
+
+  describe("buildIdentityFromStatus", () => {
+    test("projects populated status fields verbatim", () => {
+      expect(
+        buildIdentityFromStatus({ entryScript: "/wt/dist/index.js", buildId: "aaaa" })
+      ).toEqual({ entryScript: "/wt/dist/index.js", buildId: "aaaa" });
+    });
+
+    test("normalizes missing fields to '' / 'unknown' (legacy daemon)", () => {
+      expect(buildIdentityFromStatus({})).toEqual({ entryScript: "", buildId: "unknown" });
+    });
+
+    test("a legacy projection matches any client (no false skew)", () => {
+      const client: BuildIdentity = { entryScript: "/wt/dist/index.js", buildId: "aaaa" };
+      expect(buildIdentitiesMatch(client, buildIdentityFromStatus({}))).toBe(true);
     });
   });
 });

--- a/test/daemon/buildIdentity.test.ts
+++ b/test/daemon/buildIdentity.test.ts
@@ -3,6 +3,7 @@ import { resolve } from "node:path";
 import {
   computeBuildIdentity,
   buildIdentitiesMatch,
+  describeBuildIdentity,
   type BuildIdentity,
 } from "../../src/daemon/buildIdentity";
 
@@ -68,6 +69,18 @@ describe("buildIdentity", () => {
       const legacy: BuildIdentity = { entryScript: "", buildId: "unknown" };
       expect(buildIdentitiesMatch(wt, legacy)).toBe(true);
       expect(buildIdentitiesMatch(legacy, main)).toBe(true);
+    });
+  });
+
+  describe("describeBuildIdentity", () => {
+    test("renders '<buildId> (<entryScript>)' for a known identity", () => {
+      const id: BuildIdentity = { entryScript: "/wt/dist/index.js", buildId: "aaaabbbbccccdddd" };
+      expect(describeBuildIdentity(id)).toBe("aaaabbbbccccdddd (/wt/dist/index.js)");
+    });
+
+    test("falls back to 'unknown' entry script when it is empty", () => {
+      const id: BuildIdentity = { entryScript: "", buildId: "unknown" };
+      expect(describeBuildIdentity(id)).toBe("unknown (unknown)");
     });
   });
 });

--- a/test/daemon/manager.test.ts
+++ b/test/daemon/manager.test.ts
@@ -5,12 +5,15 @@ import { tmpdir } from "node:os";
 import type { ChildProcess, SpawnOptions } from "node:child_process";
 import {
   DAEMON_PROCESS_TABLE_MAX_BUFFER_BYTES,
+  daemonBuildIdentityStatusLines,
   DaemonManager,
   parseDaemonProcessTable,
   PsDaemonProcessFinder,
   resolveDaemonLaunchCommand,
   runDaemonCommand
 } from "../../src/daemon/manager";
+import type { BuildIdentity } from "../../src/daemon/buildIdentity";
+import type { DaemonStatus } from "../../src/daemon/types";
 import type {
   DaemonProcessFinder,
   DaemonProcessLivenessChecker,
@@ -20,6 +23,56 @@ import type {
 import type { DaemonStateLike } from "../../src/daemon/daemonState";
 import type { DaemonClientLike } from "../../src/daemon/client";
 import { FakeTimer } from "../fakes/FakeTimer";
+
+describe("daemonBuildIdentityStatusLines", () => {
+  const client: BuildIdentity = {
+    entryScript: "/wt/dist/src/index.js",
+    buildId: "1111111111111111",
+  };
+
+  test("always reports the daemon's Build ID and Entry Script", () => {
+    const status: DaemonStatus = {
+      running: true,
+      pid: 99,
+      entryScript: "/wt/dist/src/index.js",
+      buildId: "1111111111111111",
+    };
+
+    const lines = daemonBuildIdentityStatusLines(status, client);
+
+    expect(lines).toContain("  Build ID: 1111111111111111");
+    expect(lines).toContain("  Entry Script: /wt/dist/src/index.js");
+  });
+
+  test("falls back to 'unknown' for a legacy daemon and does not warn", () => {
+    const status: DaemonStatus = { running: true, pid: 99 };
+
+    const lines = daemonBuildIdentityStatusLines(status, client);
+
+    expect(lines).toContain("  Build ID: unknown");
+    expect(lines).toContain("  Entry Script: unknown");
+    expect(lines.some(line => line.includes("WARNING"))).toBe(false);
+  });
+
+  test("warns and shows both builds when the daemon is a different build", () => {
+    const status: DaemonStatus = {
+      running: true,
+      pid: 99,
+      entryScript: "/main/dist/src/index.js",
+      buildId: "2222222222222222",
+    };
+
+    const lines = daemonBuildIdentityStatusLines(status, client);
+    const text = lines.join("\n");
+
+    expect(text).toContain("WARNING");
+    expect(text).toContain("2222222222222222");
+    expect(text).toContain("/main/dist/src/index.js");
+    expect(text).toContain("1111111111111111");
+    expect(text).toContain("/wt/dist/src/index.js");
+    expect(text).toContain("--daemon restart");
+  });
+});
 
 class FakeDaemonClient implements DaemonClientLike {
   readonly readResourceCalls: string[] = [];

--- a/test/doctor/automobile.test.ts
+++ b/test/doctor/automobile.test.ts
@@ -131,7 +131,9 @@ describe("checkDaemonBuildIdentity", () => {
     });
 
     expect(result.status).toBe("pass");
-    expect(result.value).toBe("1111111111111111");
+    // No `value`: the console formatter renders `value` instead of `message`, so
+    // both buildId and entryScript are carried in the message to stay visible.
+    expect(result.value).toBeUndefined();
     expect(result.message).toContain("1111111111111111");
     expect(result.message).toContain("/wt/dist/src/index.js");
     expect(result.recommendation).toBeUndefined();

--- a/test/doctor/automobile.test.ts
+++ b/test/doctor/automobile.test.ts
@@ -162,6 +162,20 @@ describe("checkDaemonBuildIdentity", () => {
     expect(result.recommendation).toContain("restart");
   });
 
+  test("warns (does not throw) when reading daemon status fails", async () => {
+    const result = await checkDaemonBuildIdentity({
+      daemonManager: {
+        status: async () => {
+          throw new Error("PID file unreadable");
+        },
+      },
+      getClientBuildIdentity: () => client,
+    });
+
+    expect(result.status).toBe("warn");
+    expect(result.message).toContain("PID file unreadable");
+  });
+
   test("does not report a false skew for a legacy daemon without build identity", async () => {
     const result = await checkDaemonBuildIdentity({
       daemonManager: {

--- a/test/doctor/automobile.test.ts
+++ b/test/doctor/automobile.test.ts
@@ -2,10 +2,12 @@ import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import {
   checkCtrlProxy,
   checkCtrlProxyVersion,
+  checkDaemonBuildIdentity,
   checkDaemonStatus,
   checkDaemonVersion,
   runAutoMobileChecks,
 } from "../../src/doctor/checks/automobile";
+import type { BuildIdentity } from "../../src/daemon/buildIdentity";
 import {
   LATEST_RELEASE_VERSION,
   RELEASE_VERSION,
@@ -95,6 +97,83 @@ describe("checkDaemonStatus", () => {
     expect(result.status).toBe("pass");
     expect(result.message).toBe("Running (serving via socket)");
     expect(result.recommendation).toBeUndefined();
+  });
+});
+
+describe("checkDaemonBuildIdentity", () => {
+  const client: BuildIdentity = {
+    entryScript: "/wt/dist/src/index.js",
+    buildId: "1111111111111111",
+  };
+
+  test("skips when the daemon is not running", async () => {
+    const result = await checkDaemonBuildIdentity({
+      daemonManager: { status: async () => ({ running: false }) },
+      getClientBuildIdentity: () => client,
+    });
+
+    expect(result.name).toBe("Daemon Build Identity");
+    expect(result.status).toBe("skip");
+    expect(result.message).toBe("Daemon is not running");
+  });
+
+  test("passes and surfaces buildId + entryScript when client and daemon builds match", async () => {
+    const result = await checkDaemonBuildIdentity({
+      daemonManager: {
+        status: async () => ({
+          running: true,
+          pid: 4242,
+          entryScript: "/wt/dist/src/index.js",
+          buildId: "1111111111111111",
+        }),
+      },
+      getClientBuildIdentity: () => client,
+    });
+
+    expect(result.status).toBe("pass");
+    expect(result.value).toBe("1111111111111111");
+    expect(result.message).toContain("1111111111111111");
+    expect(result.message).toContain("/wt/dist/src/index.js");
+    expect(result.recommendation).toBeUndefined();
+  });
+
+  test("warns and shows BOTH identities when the daemon is a different build", async () => {
+    const result = await checkDaemonBuildIdentity({
+      daemonManager: {
+        status: async () => ({
+          running: true,
+          pid: 4242,
+          entryScript: "/main/dist/src/index.js",
+          buildId: "2222222222222222",
+        }),
+      },
+      getClientBuildIdentity: () => client,
+    });
+
+    expect(result.status).toBe("warn");
+    // daemon identity
+    expect(result.message).toContain("2222222222222222");
+    expect(result.message).toContain("/main/dist/src/index.js");
+    // client identity
+    expect(result.message).toContain("1111111111111111");
+    expect(result.message).toContain("/wt/dist/src/index.js");
+    expect(result.recommendation).toContain("restart");
+  });
+
+  test("does not report a false skew for a legacy daemon without build identity", async () => {
+    const result = await checkDaemonBuildIdentity({
+      daemonManager: {
+        status: async () => ({
+          running: true,
+          pid: 4242,
+          // legacy daemon predating build identity: no entryScript/buildId
+        }),
+      },
+      getClientBuildIdentity: () => client,
+    });
+
+    expect(result.status).toBe("pass");
+    expect(result.message).toContain("unknown");
   });
 });
 
@@ -210,27 +289,40 @@ describe("checkCtrlProxy", () => {
 });
 
 describe("runAutoMobileChecks", () => {
+  const stubChecks = {
+    checkDaemonStatus: async () => ({
+      name: "Daemon Status",
+      status: "pass" as const,
+      message: "Running (serving via socket)",
+    }),
+    checkDaemonConnectivity: async () => ({
+      name: "Daemon Connectivity",
+      status: "pass" as const,
+      message: "Daemon is responsive",
+    }),
+    checkDaemonBuildIdentity: async () => ({
+      name: "Daemon Build Identity",
+      status: "pass" as const,
+      message: "Build 1111111111111111 (/wt/dist/src/index.js)",
+    }),
+  };
+
   test("skips Android CtrlProxy diagnostics during iOS-only doctor runs", async () => {
-    const results = await runAutoMobileChecks(
-      { ios: true },
-      {
-        checkDaemonStatus: async () => ({
-          name: "Daemon Status",
-          status: "pass",
-          message: "Running (serving via socket)",
-        }),
-        checkDaemonConnectivity: async () => ({
-          name: "Daemon Connectivity",
-          status: "pass",
-          message: "Daemon is responsive",
-        }),
-      }
-    );
+    const results = await runAutoMobileChecks({ ios: true }, stubChecks);
 
     const ctrlProxy = results.find(result => result.name === "CtrlProxy");
 
     expect(ctrlProxy?.status).toBe("skip");
     expect(ctrlProxy?.message).toBe("Skipped for iOS-only doctor run");
     expect(ctrlProxy?.message).not.toContain("emulator-5554");
+  });
+
+  test("includes the daemon build identity check", async () => {
+    const results = await runAutoMobileChecks({ ios: true }, stubChecks);
+
+    const buildIdentity = results.find(result => result.name === "Daemon Build Identity");
+
+    expect(buildIdentity).toBeDefined();
+    expect(buildIdentity?.status).toBe("pass");
   });
 });

--- a/test/doctor/index.test.ts
+++ b/test/doctor/index.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { runDoctor } from "../../src/doctor";
+import { applyClientBuildIdentity, runDoctor } from "../../src/doctor";
 import { formatConsoleOutput, formatJsonOutput } from "../../src/doctor/formatter";
 import type { DoctorReport, CheckResult, DoctorSummary } from "../../src/doctor/types";
 
@@ -413,5 +413,69 @@ describe("runDoctor", () => {
       expect(report.ios?.checks.length).toBeGreaterThan(0);
       expect(report.ios?.checks.every(check => check.status === "skip")).toBe(true);
     });
+  });
+});
+
+describe("applyClientBuildIdentity", () => {
+  test("replaces the daemon's self-comparison with the client-side skew verdict and recounts", async () => {
+    const report = makeReport({
+      system: { checks: [makeCheck({ name: "Node.js", status: "pass" })] },
+      autoMobile: {
+        checks: [
+          makeCheck({ name: "AutoMobile Daemon Version", status: "pass" }),
+          // What the daemon produced by comparing itself to itself:
+          makeCheck({ name: "Daemon Build Identity", status: "pass", message: "Build aaaa (/daemon)" }),
+        ],
+      },
+    });
+    expect(report.summary.passed).toBe(3);
+    expect(report.summary.warnings).toBe(0);
+
+    const clientVerdict: CheckResult = {
+      name: "Daemon Build Identity",
+      status: "warn",
+      message: "Build skew: daemon aaaa (/daemon), client bbbb (/wt)",
+      recommendation: "Restart the daemon from THIS checkout.",
+    };
+
+    const result = await applyClientBuildIdentity(report, async () => clientVerdict);
+
+    const entry = result.autoMobile.checks.find(c => c.name === "Daemon Build Identity");
+    expect(entry?.status).toBe("warn");
+    expect(entry?.message).toContain("Build skew");
+    // Recounted: one of the three passes became a warn.
+    expect(result.summary.warnings).toBe(1);
+    expect(result.summary.passed).toBe(2);
+    expect(result.recommendations.some(r => r.includes("Restart the daemon from THIS checkout"))).toBe(true);
+  });
+
+  test("appends the client verdict when the daemon report lacks the check (older daemon)", async () => {
+    const report = makeReport({
+      autoMobile: { checks: [makeCheck({ name: "AutoMobile Daemon Version", status: "pass" })] },
+    });
+
+    const clientVerdict: CheckResult = {
+      name: "Daemon Build Identity",
+      status: "warn",
+      message: "Build skew",
+    };
+
+    const result = await applyClientBuildIdentity(report, async () => clientVerdict);
+
+    expect(result.autoMobile.checks.filter(c => c.name === "Daemon Build Identity")).toHaveLength(1);
+    expect(result.summary.warnings).toBe(1);
+  });
+
+  test("is a no-op when the report has no AutoMobile section", async () => {
+    let ran = false;
+    const malformed = { summary: { failed: 0 } } as any;
+
+    const result = await applyClientBuildIdentity(malformed, async () => {
+      ran = true;
+      return { name: "Daemon Build Identity", status: "warn", message: "x" };
+    });
+
+    expect(ran).toBe(false);
+    expect(result).toBe(malformed);
   });
 });


### PR DESCRIPTION
## Summary
Closes #2736. Surfaces the running daemon's **build identity** (`buildId` + `entryScript`, recorded in the PID file by #2733) so a developer can see *which build* the daemon is and spot **wrong-build skew** before a tool call fails — instead of discovering it only when a tool returns `Unknown tool`.

Two checkouts on one machine share a single per-uid daemon socket, so the daemon serving a frontend can be from a *different* build (#2732). #2733 added build identity to `PidFileData` / `DaemonStatus` and made the proxy self-heal the skew, but nothing **displayed** it. This PR adds the missing display in the two user-facing surfaces of `DaemonStatus`.

## Changes
- **`describeBuildIdentity(identity)`** (`src/daemon/buildIdentity.ts`) — shared renderer producing `"<buildId> (<entryScript>)"`, falling back to `unknown` for legacy daemons, so both surfaces format identically.
- **`doctor` — new `Daemon Build Identity` check** (`src/doctor/checks/automobile.ts`, wired into `runAutoMobileChecks`):
  - `pass` showing the daemon's `buildId` + `entryScript` when the client and daemon builds match;
  - `warn` showing **both** identities + a restart recommendation when they differ (skew visible without a failing tool call);
  - `skip` when the daemon is not running;
  - reuses `buildIdentitiesMatch`, so a legacy daemon without build identity does **not** raise a false skew.
- **`--daemon status` CLI** (`runDaemonCommand` in `src/daemon/manager.ts`) — adds `Build ID` / `Entry Script` lines and a skew warning, built by the pure, unit-tested `daemonBuildIdentityStatusLines(status, client)`.

A review pass caught that the doctor console formatter renders `CheckResult.value` *instead of* `message`; setting `value=buildId` would have hidden the `entryScript`. Fixed by carrying both in `message` (no `value`).

## Acceptance (from #2736)
- ✅ `doctor` output includes the daemon's `buildId` **and** `entryScript`.
- ✅ Client/daemon build skew is visible in `doctor` (and `--daemon status`) output without triggering a failing tool call.

## Test plan
- TDD: tests written first (red), then implementation (green).
- New/updated fast unit tests (injected fakes, no real fs/daemon, <100ms each):
  - `test/daemon/buildIdentity.test.ts` — `describeBuildIdentity` rendering + `unknown` fallback.
  - `test/doctor/automobile.test.ts` — pass/warn/skip + no-false-skew-for-legacy-daemon + presence in `runAutoMobileChecks`.
  - `test/daemon/manager.test.ts` — `daemonBuildIdentityStatusLines` always reports Build ID/Entry Script, falls back to `unknown` without warning, and warns showing both builds on skew.
- `bun test test/doctor/ test/daemon/` → 609 pass.
- `bun run lint` + `bun run build` → green.

Refs #2732, #2733
