### PR TITLE
fix(doctor): detect iOS runner/client port mismatch via runner-reported port (#2735)

### DIFF
--- a/ios/control-proxy/Sources/CtrlProxy/WebSocketServer.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/WebSocketServer.swift
@@ -115,6 +115,7 @@ public class WebSocketServer: WebSocketServing {
             id: connectionId,
             connection: nwConnection,
             queue: queue,
+            boundPort: port,
             sdkHierarchyCache: sdkHierarchyCache
         ) { [weak self] message in
             self?.handleMessage(message, connectionId: connectionId)
@@ -329,12 +330,16 @@ class WebSocketConnection {
     private let onMessage: (Data) -> Void
     private let onClose: () -> Void
     private let sdkHierarchyCache: (any SdkHierarchyCaching)?
+    /// The port the server is actually bound to; echoed in /health so the daemon
+    /// can detect a runner/client port mismatch (issue #2735).
+    private let boundPort: UInt16
     private var isWebSocketUpgraded = false
 
     init(
         id: Int,
         connection: NWConnection,
         queue: DispatchQueue,
+        boundPort: UInt16,
         sdkHierarchyCache: (any SdkHierarchyCaching)? = nil,
         onMessage: @escaping (Data) -> Void,
         onClose: @escaping () -> Void
@@ -342,6 +347,7 @@ class WebSocketConnection {
         self.id = id
         self.connection = connection
         self.queue = queue
+        self.boundPort = boundPort
         self.sdkHierarchyCache = sdkHierarchyCache
         self.onMessage = onMessage
         self.onClose = onClose
@@ -413,7 +419,7 @@ class WebSocketConnection {
     }
 
     private func handleHealthCheck() {
-        var payload: [String: String] = ["status": "ok"]
+        var payload: [String: Any] = ["status": "ok", "port": Int(boundPort)]
         if let deviceId = Self.currentDeviceId() {
             payload["deviceId"] = deviceId
         }

--- a/src/doctor/checks/ios.ts
+++ b/src/doctor/checks/ios.ts
@@ -95,6 +95,13 @@ interface IosRunnerManager {
   isInstalled(): Promise<boolean>;
   isRunning(): Promise<boolean>;
   getServicePort(): number;
+  /**
+   * The port the runner self-reports it is actually bound to (via /health), or
+   * null when no matching runner answers. Lets the round-trip check compare the
+   * runner's real port against the client port instead of comparing the service
+   * port to itself (issue #2735).
+   */
+  getReportedRunnerPort(): Promise<number | null>;
 }
 
 /**
@@ -250,8 +257,15 @@ export function createIosObserveRoundTripInspector(
           source: simulator.source,
         };
         const manager = hooks.getManager(device);
-        const runnerPort = manager.getServicePort();
-        let clientPort = runnerPort;
+        const servicePort = manager.getServicePort();
+        // The runner's *actual* bound port, read from its /health self-report, so
+        // a runner that bound the wrong port surfaces as a real mismatch instead
+        // of the service port being compared to itself (issue #2735). Falls back
+        // to the service port when no runner reports a port (older or unreachable
+        // runner) so a healthy runner is never falsely flagged.
+        const reportedRunnerPort = await manager.getReportedRunnerPort();
+        const runnerPort = reportedRunnerPort ?? servicePort;
+        let clientPort = servicePort;
         let connected = false;
         let screenSize = { width: 0, height: 0 };
         let hierarchyError: string | null = null;
@@ -261,7 +275,17 @@ export function createIosObserveRoundTripInspector(
           const installed = await manager.isInstalled();
           const running = installed ? await manager.isRunning() : false;
           if (!installed || !running) {
-            hierarchyError = installed ? "iOS CtrlProxy runner is not running" : "iOS CtrlProxy runner is not installed";
+            if (!installed) {
+              hierarchyError = "iOS CtrlProxy runner is not installed";
+            } else if (reportedRunnerPort !== null && reportedRunnerPort !== servicePort) {
+              // The runner is alive but bound to a different port than the client
+              // expects — the #2731 failure mode. Surface it explicitly rather
+              // than the misleading "not running".
+              hierarchyError =
+                `iOS CtrlProxy runner is bound to port ${reportedRunnerPort} but the client expects port ${servicePort}`;
+            } else {
+              hierarchyError = "iOS CtrlProxy runner is not running";
+            }
           } else {
             const existing = hooks.getExistingClient(device.deviceId);
             const client = existing ?? hooks.createClient(device, runnerPort);

--- a/src/features/observe/ios/IOSCtrlProxyClient.ts
+++ b/src/features/observe/ios/IOSCtrlProxyClient.ts
@@ -92,6 +92,7 @@ class NoOpIOSCtrlProxyManager implements CtrlProxyIosManager {
   async start(): Promise<void> {}
   async stop(): Promise<void> {}
   getServicePort(): number { return 0; }
+  async getReportedRunnerPort(): Promise<number | null> { return null; }
   setAutoRestart(): void {}
   isAutoRestartEnabled(): boolean { return false; }
   async forceRestart(): Promise<void> {}

--- a/src/utils/IOSCtrlProxyManager.ts
+++ b/src/utils/IOSCtrlProxyManager.ts
@@ -1380,6 +1380,11 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
     return null;
   }
 
+  /** Single source of truth for "is this a usable TCP port number". */
+  private static isValidPort(value: unknown): value is number {
+    return typeof value === "number" && Number.isInteger(value) && value > 0 && value <= 65535;
+  }
+
   private parseCtrlProxyPortFromProcessArgs(args: string): number | null {
     const match = args.match(/(?:^|\s)(?:SIMCTL_CHILD_)?CTRL_PROXY_IOS_PORT=(\d+)(?:\s|$)/);
     if (!match) {
@@ -1387,7 +1392,7 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
     }
 
     const port = Number.parseInt(match[1], 10);
-    return Number.isNaN(port) || port <= 0 || port > 65535 ? null : port;
+    return IOSCtrlProxyManager.isValidPort(port) ? port : null;
   }
 
   private async ensureServicePortReadyForLaunch(): Promise<void> {
@@ -1920,11 +1925,7 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
       if (health.deviceId !== this.device.deviceId) {
         return null;
       }
-      if (typeof health.port !== "number" || !Number.isInteger(health.port) ||
-          health.port <= 0 || health.port > 65535) {
-        return null;
-      }
-      return health.port;
+      return IOSCtrlProxyManager.isValidPort(health.port) ? health.port : null;
     } catch {
       return null;
     }

--- a/src/utils/IOSCtrlProxyManager.ts
+++ b/src/utils/IOSCtrlProxyManager.ts
@@ -47,6 +47,7 @@ export interface CtrlProxyIosManager extends ProxyManager {
   start(): Promise<void>;
   stop(): Promise<void>;
   getServicePort(): number;
+  getReportedRunnerPort(): Promise<number | null>;
   setAutoRestart(enabled: boolean): void;
   isAutoRestartEnabled(): boolean;
   forceRestart(): Promise<void>;
@@ -1867,6 +1868,50 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
   private async checkHealthEndpointOnPort(port: number): Promise<boolean> {
     const body = await this.readHealthEndpointBodyOnPort(port);
     return body !== null && (body.includes("ok") || body.includes("healthy"));
+  }
+
+  /**
+   * Ask the runner what port it is *actually* bound to, by reading the `port`
+   * field the runner self-reports in its `/health` payload. Probes the same
+   * candidate ports as runner discovery (the allocated service port plus the
+   * hardcoded default the runner falls back to), filtered to this device so a
+   * sibling runner sharing the default port is never mistaken for ours.
+   *
+   * Returns null when no matching runner answers or when the runner is too old
+   * to report a port. Used by `doctor` to compare the runner's real bound port
+   * against the client port — a comparison that is meaningless if both are
+   * derived from `getServicePort()` (issue #2735).
+   */
+  public async getReportedRunnerPort(): Promise<number | null> {
+    const candidatePorts = new Set([this.servicePort, IOSCtrlProxyManager.DEFAULT_PORT]);
+    for (const port of candidatePorts) {
+      const reportedPort = await this.readReportedPortFromHealth(port);
+      if (reportedPort !== null) {
+        return reportedPort;
+      }
+    }
+    return null;
+  }
+
+  private async readReportedPortFromHealth(port: number): Promise<number | null> {
+    const body = await this.readHealthEndpointBodyOnPort(port);
+    if (body === null) {
+      return null;
+    }
+    try {
+      const health = JSON.parse(body) as { status?: unknown; deviceId?: unknown; port?: unknown };
+      if (health.status !== "ok") {
+        return null;
+      }
+      // A runner that reports a deviceId must match ours; one that omits it
+      // (older runner) is accepted on the ports we already scope to this device.
+      if (health.deviceId !== undefined && health.deviceId !== this.device.deviceId) {
+        return null;
+      }
+      return typeof health.port === "number" ? health.port : null;
+    } catch {
+      return null;
+    }
   }
 
   private async checkHealthEndpointOnPortForDevice(port: number, deviceId: string): Promise<boolean> {

--- a/src/utils/IOSCtrlProxyManager.ts
+++ b/src/utils/IOSCtrlProxyManager.ts
@@ -1874,8 +1874,17 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
    * Ask the runner what port it is *actually* bound to, by reading the `port`
    * field the runner self-reports in its `/health` payload. Probes the same
    * candidate ports as runner discovery (the allocated service port plus the
-   * hardcoded default the runner falls back to), filtered to this device so a
-   * sibling runner sharing the default port is never mistaken for ours.
+   * hardcoded default the runner falls back to).
+   *
+   * A reported port is only accepted when the runner's `/health` identifies this
+   * exact device. This matters because the daemon may probe a port that is
+   * answered by a *different* runner — a sibling iOS simulator's runner that fell
+   * back to the shared default port (the same #2731 env-propagation failure can
+   * also drop the runner's device-id env var), or, on the default port, the
+   * Android CtrlProxy reached through its `adb forward`. The Android runner is
+   * additionally excluded structurally: its `/health` returns the plain text
+   * `OK`, so `JSON.parse` / the strict `status === "ok"` object check rejects it
+   * before the device-id guard is even consulted.
    *
    * Returns null when no matching runner answers or when the runner is too old
    * to report a port. Used by `doctor` to compare the runner's real bound port
@@ -1903,12 +1912,19 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
       if (health.status !== "ok") {
         return null;
       }
-      // A runner that reports a deviceId must match ours; one that omits it
-      // (older runner) is accepted on the ports we already scope to this device.
-      if (health.deviceId !== undefined && health.deviceId !== this.device.deviceId) {
+      // Require a positive device match: a runner answering this port that does
+      // not identify as our device is some other runner and must not be adopted.
+      // A new runner reporting a port always reports its device id; a runner that
+      // omits it is too old to report a port anyway (caught below), so this loses
+      // no genuine coverage while closing the cross-device false-adoption hole.
+      if (health.deviceId !== this.device.deviceId) {
         return null;
       }
-      return typeof health.port === "number" ? health.port : null;
+      if (typeof health.port !== "number" || !Number.isInteger(health.port) ||
+          health.port <= 0 || health.port > 65535) {
+        return null;
+      }
+      return health.port;
     } catch {
       return null;
     }

--- a/test/doctor/ios.test.ts
+++ b/test/doctor/ios.test.ts
@@ -847,7 +847,12 @@ describe("createIosCtrlProxyRunnerInspector lifecycle", () => {
     getBootedSimulators: async () => devices.map(d => ({ name: d.name, platform: "ios" as const, deviceId: d.deviceId }))
   });
 
-  const runningManager = { isInstalled: async () => true, isRunning: async () => true, getServicePort: () => 8765 };
+  const runningManager = {
+    isInstalled: async () => true,
+    isRunning: async () => true,
+    getServicePort: () => 8765,
+    getReportedRunnerPort: async () => 8765
+  };
 
   test("closes a probe client it created (no pre-existing client)", async () => {
     let closes = 0;
@@ -927,7 +932,12 @@ describe("createIosObserveRoundTripInspector lifecycle", () => {
     getBootedSimulators: async () => devices.map(d => ({ name: d.name, platform: "ios" as const, deviceId: d.deviceId }))
   });
 
-  const runningManager = { isInstalled: async () => true, isRunning: async () => true, getServicePort: () => 8790 };
+  const runningManager = {
+    isInstalled: async () => true,
+    isRunning: async () => true,
+    getServicePort: () => 8790,
+    getReportedRunnerPort: async () => 8790
+  };
   const viewHierarchy = {
     hierarchy: { node: { $: { text: "Home" } } },
     screenWidth: 390,
@@ -1047,7 +1057,8 @@ describe("createIosObserveRoundTripInspector lifecycle", () => {
       getManager: () => ({
         isInstalled: async () => true,
         isRunning: async () => false,
-        getServicePort: () => 8790
+        getServicePort: () => 8790,
+        getReportedRunnerPort: async () => null
       }),
       getExistingClient: () => null,
       createClient: () => {
@@ -1067,5 +1078,98 @@ describe("createIosObserveRoundTripInspector lifecycle", () => {
     expect(created).toBe(false);
     expect(inspections[0].connected).toBe(false);
     expect(inspections[0].hierarchyError).toBe("iOS CtrlProxy runner is not running");
+  });
+
+  test("reports the runner's actual bound port from the manager, not the client port (#2735)", async () => {
+    // #2731 failure mode: the runner binds 8765 while the client/daemon expects
+    // 8767. isRunning() probes the client port (8767) and finds nothing, but the
+    // runner reports its real bound port (8765) via /health.
+    const hooks: IosObserveRoundTripInspectorHooks = {
+      getManager: () => ({
+        isInstalled: async () => true,
+        isRunning: async () => false,
+        getServicePort: () => 8767,
+        getReportedRunnerPort: async () => 8765
+      }),
+      getExistingClient: () => null,
+      createClient: () => {
+        throw new Error("should not create client when runner unreachable on client port");
+      },
+      elementsBuilder
+    };
+
+    const inspector = createIosObserveRoundTripInspector(
+      () => simctlReturning([{ name: "iPhone 15", deviceId: "SIM-1" }]) as any,
+      new FakeLogger(),
+      hooks
+    );
+    const inspections = await inspector.inspectBootedObserveRoundTrips();
+
+    // runnerPort must reflect the runner's reported bound port, decoupled from
+    // the client port, so classifyObserveRoundTrip can detect the mismatch.
+    expect(inspections[0].runnerPort).toBe(8765);
+    expect(inspections[0].clientPort).toBe(8767);
+    expect(inspections[0].connected).toBe(false);
+  });
+
+  test("surfaces an actionable mismatch error when the runner is bound to a different port (#2735)", async () => {
+    const hooks: IosObserveRoundTripInspectorHooks = {
+      getManager: () => ({
+        isInstalled: async () => true,
+        isRunning: async () => false,
+        getServicePort: () => 8767,
+        getReportedRunnerPort: async () => 8765
+      }),
+      getExistingClient: () => null,
+      createClient: () => {
+        throw new Error("should not create client when runner unreachable on client port");
+      },
+      elementsBuilder
+    };
+
+    const inspector = createIosObserveRoundTripInspector(
+      () => simctlReturning([{ name: "iPhone 15", deviceId: "SIM-1" }]) as any,
+      new FakeLogger(),
+      hooks
+    );
+    const inspections = await inspector.inspectBootedObserveRoundTrips();
+
+    expect(inspections[0].hierarchyError).toContain("8765");
+    expect(inspections[0].hierarchyError).toContain("8767");
+    // The misleading "not running" must not be reported when the runner is alive
+    // on another port.
+    expect(inspections[0].hierarchyError).not.toBe("iOS CtrlProxy runner is not running");
+  });
+
+  test("falls back to the service port when the runner reports no bound port", async () => {
+    const hooks: IosObserveRoundTripInspectorHooks = {
+      getManager: () => ({
+        isInstalled: async () => true,
+        isRunning: async () => true,
+        getServicePort: () => 8790,
+        getReportedRunnerPort: async () => null
+      }),
+      getExistingClient: () => null,
+      createClient: (_device, port) => ({
+        getConnectionPortForDiagnostics: () => port,
+        requestHierarchySync: async () => ({ hierarchy: { updatedAt: 1, packageName: "SpringBoard", hierarchy: {} } as any }),
+        convertToViewHierarchyResult: () => viewHierarchy as any,
+        close: async () => {}
+      }),
+      elementsBuilder
+    };
+
+    const inspector = createIosObserveRoundTripInspector(
+      () => simctlReturning([{ name: "iPhone 15", deviceId: "SIM-1" }]) as any,
+      new FakeLogger(),
+      hooks
+    );
+    const inspections = await inspector.inspectBootedObserveRoundTrips();
+
+    // No reported port → runnerPort falls back to the service port so a healthy
+    // runner is not falsely flagged as a mismatch.
+    expect(inspections[0].runnerPort).toBe(8790);
+    expect(inspections[0].clientPort).toBe(8790);
+    expect(inspections[0].connected).toBe(true);
   });
 });

--- a/test/fakes/FakeIOSCtrlProxyManager.ts
+++ b/test/fakes/FakeIOSCtrlProxyManager.ts
@@ -11,6 +11,7 @@ export class FakeIOSCtrlProxyManager implements CtrlProxyIosManager {
   private availableState: boolean = false;
   private executedOperations: string[] = [];
   private servicePort: number = 8765;
+  private reportedRunnerPort: number | null = null;
   private shouldStartFail: boolean = false;
   private shouldStopFail: boolean = false;
   private shouldSetupFail: boolean = false;
@@ -43,6 +44,13 @@ export class FakeIOSCtrlProxyManager implements CtrlProxyIosManager {
    */
   setServicePort(port: number): void {
     this.servicePort = port;
+  }
+
+  /**
+   * Set the port the runner reports it is bound to (via /health)
+   */
+  setReportedRunnerPort(port: number | null): void {
+    this.reportedRunnerPort = port;
   }
 
   /**
@@ -116,6 +124,11 @@ export class FakeIOSCtrlProxyManager implements CtrlProxyIosManager {
   getServicePort(): number {
     this.executedOperations.push("getServicePort");
     return this.servicePort;
+  }
+
+  async getReportedRunnerPort(): Promise<number | null> {
+    this.executedOperations.push("getReportedRunnerPort");
+    return this.reportedRunnerPort;
   }
 
   async start(): Promise<void> {

--- a/test/utils/IOSCtrlProxyManager.test.ts
+++ b/test/utils/IOSCtrlProxyManager.test.ts
@@ -303,6 +303,39 @@ describe("IOSCtrlProxyManager", function() {
       expect(await manager.getReportedRunnerPort()).toBeNull();
     });
 
+    test("ignores a port reported without a matching device id (false-adoption guard)", async function() {
+      // The #2731 env-propagation failure that drops the port var can also drop
+      // the runner's device-id var, so a sibling simulator's runner on the shared
+      // default port could answer with a port but no device id. It must not be
+      // adopted as ours.
+      installHealthFakes({
+        8765: JSON.stringify({ status: "ok", port: 8765 })
+      });
+      const manager = IOSCtrlProxyManager.createForTestingWithDeps(
+        testDevice,
+        fakeTimer,
+        undefined,
+        fakeExecutor
+      );
+      (manager as unknown as { servicePort: number }).servicePort = 8767;
+
+      expect(await manager.getReportedRunnerPort()).toBeNull();
+    });
+
+    test("ignores an out-of-range reported port", async function() {
+      installHealthFakes({
+        8765: JSON.stringify({ status: "ok", deviceId: testDevice.deviceId, port: 70000 })
+      });
+      const manager = IOSCtrlProxyManager.createForTestingWithDeps(
+        testDevice,
+        fakeTimer,
+        undefined,
+        fakeExecutor
+      );
+
+      expect(await manager.getReportedRunnerPort()).toBeNull();
+    });
+
     test("returns null when the runner reports no port (older runner)", async function() {
       installHealthFakes({
         8765: JSON.stringify({ status: "ok", deviceId: testDevice.deviceId })

--- a/test/utils/IOSCtrlProxyManager.test.ts
+++ b/test/utils/IOSCtrlProxyManager.test.ts
@@ -243,6 +243,93 @@ describe("IOSCtrlProxyManager", function() {
     });
   });
 
+  describe("getReportedRunnerPort", function() {
+    let fakeExecutor: FakeProcessExecutor;
+
+    beforeEach(function() {
+      fakeExecutor = new FakeProcessExecutor();
+    });
+
+    // Map each candidate /health port to a body the runner would return.
+    const installHealthFakes = (bodyByPort: Record<number, string>): void => {
+      fakeExecutor.setCommandHandler("curl -s", command => {
+        const port = Number(command.match(/localhost:(\d+)\/health/)?.[1]);
+        return createExecResult(bodyByPort[port] ?? "", "");
+      });
+    };
+
+    test("returns the bound port the runner reports on the service port", async function() {
+      installHealthFakes({
+        8765: JSON.stringify({ status: "ok", deviceId: testDevice.deviceId, port: 8765 })
+      });
+      const manager = IOSCtrlProxyManager.createForTestingWithDeps(
+        testDevice,
+        fakeTimer,
+        undefined,
+        fakeExecutor
+      );
+
+      expect(await manager.getReportedRunnerPort()).toBe(8765);
+    });
+
+    test("discovers the runner on the default port when the service port is silent (#2731)", async function() {
+      installHealthFakes({
+        8765: JSON.stringify({ status: "ok", deviceId: testDevice.deviceId, port: 8765 })
+        // 8767 (service port) returns nothing — the runner bound the default instead.
+      });
+      const manager = IOSCtrlProxyManager.createForTestingWithDeps(
+        testDevice,
+        fakeTimer,
+        undefined,
+        fakeExecutor
+      );
+      (manager as unknown as { servicePort: number }).servicePort = 8767;
+
+      expect(await manager.getReportedRunnerPort()).toBe(8765);
+    });
+
+    test("ignores a health response from a different device on a shared port", async function() {
+      installHealthFakes({
+        8765: JSON.stringify({ status: "ok", deviceId: "SOME-OTHER-DEVICE", port: 8765 })
+      });
+      const manager = IOSCtrlProxyManager.createForTestingWithDeps(
+        testDevice,
+        fakeTimer,
+        undefined,
+        fakeExecutor
+      );
+      (manager as unknown as { servicePort: number }).servicePort = 8767;
+
+      expect(await manager.getReportedRunnerPort()).toBeNull();
+    });
+
+    test("returns null when the runner reports no port (older runner)", async function() {
+      installHealthFakes({
+        8765: JSON.stringify({ status: "ok", deviceId: testDevice.deviceId })
+      });
+      const manager = IOSCtrlProxyManager.createForTestingWithDeps(
+        testDevice,
+        fakeTimer,
+        undefined,
+        fakeExecutor
+      );
+
+      expect(await manager.getReportedRunnerPort()).toBeNull();
+    });
+
+    test("returns null when no runner answers the health endpoint", async function() {
+      installHealthFakes({});
+      const manager = IOSCtrlProxyManager.createForTestingWithDeps(
+        testDevice,
+        fakeTimer,
+        undefined,
+        fakeExecutor
+      );
+
+      expect(await manager.getReportedRunnerPort()).toBeNull();
+    });
+  });
+
   describe("getCapabilities", function() {
     test("should identify simulator device type for UUID format deviceId", async function() {
       const manager = IOSCtrlProxyManager.createForTesting(testDevice, fakeTimer);


### PR DESCRIPTION
## Summary
Fixes #2735. The iOS observe round-trip check derived **both** `runnerPort` and `clientPort` from `manager.getServicePort()` (`src/doctor/checks/ios.ts:253-254`), so `hasPortMismatch` (`:913`) always compared two identical numbers and was structurally incapable of catching a runner-binds-wrong-port mismatch — the #2731 failure mode (`doctor --ios` reported `runnerPort=8767; clientPort=8767; connected=false` while the runner was actually healthy on `8765`).

Follow-up to #2734, which fixed the underlying bug (the runner now receives the allocated port via the xctestrun `EnvironmentVariables`) but left the diagnostic blind.

## Root cause
`createIosObserveRoundTripInspector` set `runnerPort = manager.getServicePort()` and `clientPort = runnerPort`. The client's connection port is also derived from the daemon's allocated service port, so both sides of the mismatch comparison were the *daemon's* port — never the runner's **actual bound** port.

## Fix
The issue's stated direction: make the runner report its actual bound port back to the daemon via `/health`, then compare the *reported* runner port against the client port.

- **`ios/control-proxy/Sources/CtrlProxy/WebSocketServer.swift`**: thread the server's bound port into `WebSocketConnection` and echo it in the `/health` payload (`{"status":"ok","deviceId":...,"port":<boundPort>}`).
- **`src/utils/IOSCtrlProxyManager.ts`**: new `getReportedRunnerPort(): Promise<number | null>` — probes `/health` on the candidate ports (allocated service port + hardcoded default, mirroring `findExternalDirectCtrlProxyProcess`) and returns the reported `port`, **filtered by `deviceId`** so a sibling/Android runner on the shared default port is never mistaken for ours. Returns null when no matching runner answers or the runner is too old to report a port. Added to the `CtrlProxyIosManager` interface (+ `NoOpIOSCtrlProxyManager`, `FakeIOSCtrlProxyManager`).
- **`src/doctor/checks/ios.ts`**: `runnerPort` now comes from `getReportedRunnerPort()` (falling back to the service port when unavailable, so a healthy runner is never falsely flagged); `clientPort` stays the client connection port. When the runner is unreachable on the client port but reports a **different** bound port, the check surfaces an actionable `iOS CtrlProxy runner is bound to port X but the client expects port Y` instead of the misleading "not running". Added the method to the `IosRunnerManager` interface.

No false-negative introduced: when no runner answers, `runnerPort` falls back to the service port (no spurious mismatch) while `!connected` still flags a genuinely-down runner.

## Test plan
- `test/utils/IOSCtrlProxyManager.test.ts` — `getReportedRunnerPort`: reports the bound port on the service port; discovers the runner on the default port when the service port is silent (#2731); ignores a health response from a different device on a shared port; returns null for an older runner that omits `port`; returns null when no runner answers.
- `test/doctor/ios.test.ts` — round-trip inspector: reports the runner's reported bound port decoupled from the client port; surfaces the actionable mismatch error; falls back to the service port when the runner reports no port.
- `bun test` → 5220 pass / 0 fail (409 files); `eslint --fix` and `bun build.ts` → green; `swift build`/`swift test` for `ios/control-proxy` → green. No new `tsc` errors introduced.

### Verify on hardware
With one Android emulator + one iOS simulator connected (the #2731 setup), run `auto-mobile --doctor --ios`: a runner bound to the default port while the client expects the allocated port should now report a port mismatch with both ports and the actionable message — not "runner is not running".

### Follow-up required: re-cut the iOS runner release
This change adds the `port` field to the runner's `/health` protocol. Normal installs run the **downloaded pinned runner** (`IOS_CTRL_PROXY_IPA_URL` → `src/constants/release.ts`, currently v0.0.39), which does not yet report `port`. Until the runner release is re-cut and the checksum registry bumped (a coordinated `chore:` release PR — the `ipaSha256` must match a published artifact and cannot be hand-authored here), the deployed runner won't advertise its port.

This is intentionally **fail-safe**: when no `port` is reported, `getReportedRunnerPort()` returns null and the check falls back to the service port — no false mismatch, identical to today's behavior. The new diagnostic activates automatically once the updated runner ships. Locally it can be exercised now via `AUTOMOBILE_CTRL_PROXY_IOS_BUNDLE_PATH` pointing at a source build.

Refs #2731, #2734.
