### PR TITLE
feat(daemon): stamp git SHA into pre-release version for dev builds (#2738)

### DIFF
--- a/src/daemon/daemonMcpProxy.ts
+++ b/src/daemon/daemonMcpProxy.ts
@@ -18,6 +18,18 @@ export type VersionMismatchReason =
   | "nonNumeric"
   | "restartMismatch";
 
+/**
+ * Strip semver build metadata (everything after the first `+`) from a version.
+ *
+ * Dev/non-release builds stamp a git short SHA as build metadata (e.g.
+ * `0.0.39+g1a2b3c4.dirty`, see `getMcpServerVersion`). The numeric version gate
+ * compares only the release portion; reconciling two builds that share a release
+ * version but differ by commit is the build-identity gate's job, not the version
+ * gate's. The metadata is also not an installable npm tag, so the restart hint
+ * uses the stripped version too.
+ */
+export const baseVersion = (version: string): string => version.split("+")[0];
+
 export type BuildMismatchReason =
   | "autoStartDisabled"
   | "cooldown"
@@ -40,8 +52,11 @@ export class DaemonVersionMismatchError extends DaemonUnavailableError {
     detail: string;
     retryAfterMs?: number;
   }) {
-    const restartCommand = params.clientVersion.length > 0 && params.clientVersion !== "unknown"
-      ? `bunx @kaeawc/auto-mobile@${params.clientVersion} --daemon restart`
+    // The git-SHA build metadata on dev builds is not an installable npm tag,
+    // so the bunx hint must point at the plain published version.
+    const installableVersion = baseVersion(params.clientVersion);
+    const restartCommand = installableVersion.length > 0 && installableVersion !== "unknown"
+      ? `bunx @kaeawc/auto-mobile@${installableVersion} --daemon restart`
       : "the same installed auto-mobile package";
     const retryGuidance = params.retryAfterMs !== undefined
       ? ` Retry after ${params.retryAfterMs}ms or restart the daemon with: ${restartCommand}`
@@ -151,6 +166,8 @@ export interface DaemonMcpProxyConfig {
   timer?: Pick<Timer, "now">;
   /** This client's build identity (for testing; defaults to the current process build) */
   buildIdentity?: BuildIdentity;
+  /** This client's version for the daemon version gate (defaults to DAEMON_VERSION; injectable for testing) */
+  clientVersion?: string;
 }
 
 /**
@@ -199,6 +216,7 @@ export class DaemonMcpProxy {
   private clientFactory: DaemonClientFactory;
   private readonly timer: Pick<Timer, "now">;
   private readonly buildIdentity: BuildIdentity;
+  private readonly clientVersion: string;
   private connecting: Promise<void> | null = null;
   private connected: boolean = false;
 
@@ -221,6 +239,7 @@ export class DaemonMcpProxy {
     ));
     this.timer = config.timer ?? defaultTimer;
     this.buildIdentity = config.buildIdentity ?? getCurrentBuildIdentity();
+    this.clientVersion = config.clientVersion ?? DAEMON_VERSION;
   }
 
   /**
@@ -285,19 +304,30 @@ export class DaemonMcpProxy {
     }
 
     const runningVersion = status.version?.trim() ?? "";
-    if (runningVersion === DAEMON_VERSION) {
+    if (runningVersion === this.clientVersion) {
       return;
     }
 
-    const cmp = runningVersion.length > 0
-      ? compareVersions(DAEMON_VERSION, runningVersion)
+    // Compare only the release portion. Two dev builds that share a release
+    // version but differ by git commit (`0.0.39+gAAA` vs `0.0.39+gBBB`) are
+    // reconciled by the build-identity gate (ensureBuildMatches, which restarts
+    // to the correct build on a content-hash mismatch). The version gate must
+    // defer here rather than hard-throw, or it would defeat that self-heal.
+    const runningBase = baseVersion(runningVersion);
+    const clientBase = baseVersion(this.clientVersion);
+    if (runningBase === clientBase) {
+      return;
+    }
+
+    const cmp = runningBase.length > 0
+      ? compareVersions(clientBase, runningBase)
       : Number.POSITIVE_INFINITY;
 
     if (!this.config.autoStartDaemon) {
       throw this.versionMismatchError(runningVersion, "autoStartDisabled", "auto-start is disabled");
     }
 
-    if (runningVersion.length > 0 && !Number.isFinite(cmp)) {
+    if (runningBase.length > 0 && !Number.isFinite(cmp)) {
       throw this.versionMismatchError(
         runningVersion,
         "nonNumeric",
@@ -317,7 +347,7 @@ export class DaemonMcpProxy {
       const daemonAgeMs = this.timer.now() - status.startedAt;
       if (daemonAgeMs < DAEMON_VERSION_RESTART_COOLDOWN_MS) {
         logger.warn(
-          `[DaemonMcpProxy] Skipping version-mismatch restart due to cooldown: daemon ${runningVersion || "unknown"} is ${daemonAgeMs}ms old, client version is ${DAEMON_VERSION}`
+          `[DaemonMcpProxy] Skipping version-mismatch restart due to cooldown: daemon ${runningVersion || "unknown"} is ${daemonAgeMs}ms old, client version is ${this.clientVersion}`
         );
         throw this.versionMismatchError(
           runningVersion,
@@ -329,7 +359,7 @@ export class DaemonMcpProxy {
     }
 
     logger.info(
-      `[DaemonMcpProxy] Daemon version ${runningVersion || "unknown"} differs from MCP server ${DAEMON_VERSION}, restarting daemon`
+      `[DaemonMcpProxy] Daemon version ${runningVersion || "unknown"} differs from MCP server ${this.clientVersion}, restarting daemon`
     );
     await this.daemonManager.restart(this.config.daemonOptions ?? {});
     // The replacement daemon may expose a different tool set; drop the cache so we
@@ -344,7 +374,7 @@ export class DaemonMcpProxy {
 
     const restartedStatus = await this.daemonManager.status();
     const restartedVersion = restartedStatus.version?.trim() ?? "";
-    if (!restartedStatus.running || restartedVersion !== DAEMON_VERSION) {
+    if (!restartedStatus.running || restartedVersion !== this.clientVersion) {
       throw this.versionMismatchError(
         restartedVersion,
         "restartMismatch",
@@ -360,7 +390,7 @@ export class DaemonMcpProxy {
     retryAfterMs?: number,
   ): DaemonVersionMismatchError {
     const daemonVersion = runningVersion.length > 0 ? runningVersion : "unknown";
-    const clientVersion = DAEMON_VERSION.trim();
+    const clientVersion = this.clientVersion.trim();
     return new DaemonVersionMismatchError({
       clientVersion,
       daemonVersion,

--- a/src/daemon/daemonMcpProxy.ts
+++ b/src/daemon/daemonMcpProxy.ts
@@ -297,40 +297,46 @@ export class DaemonMcpProxy {
       return;
     }
 
-    // Compare only the release portion. Two dev builds that share a release
-    // version but differ by git commit (`0.0.39+gAAA` vs `0.0.39+gBBB`) are
-    // reconciled by the build-identity gate (ensureBuildMatches, which restarts
-    // to the correct build on a content-hash mismatch). The version gate must
-    // defer here rather than hard-throw, or it would defeat that self-heal.
+    // The release portions (before the `+g<sha>` dev stamp) drive the
+    // newer/older decision. Equal release + differing full strings means two
+    // source checkouts at the same release but different commits (dev-skew).
     const runningBase = releaseVersion(runningVersion);
     const clientBase = releaseVersion(this.clientVersion);
-    if (runningBase === clientBase) {
-      return;
-    }
-
-    const cmp = runningBase.length > 0
-      ? compareVersions(clientBase, runningBase)
-      : Number.POSITIVE_INFINITY;
+    const sameRelease = runningBase === clientBase;
 
     if (!this.config.autoStartDaemon) {
       throw this.versionMismatchError(runningVersion, "autoStartDisabled", "auto-start is disabled");
     }
 
-    if (runningBase.length > 0 && !Number.isFinite(cmp)) {
-      throw this.versionMismatchError(
-        runningVersion,
-        "nonNumeric",
-        "version comparison is not numeric"
-      );
+    if (!sameRelease) {
+      const cmp = runningBase.length > 0
+        ? compareVersions(clientBase, runningBase)
+        : Number.POSITIVE_INFINITY;
+
+      if (runningBase.length > 0 && !Number.isFinite(cmp)) {
+        throw this.versionMismatchError(
+          runningVersion,
+          "nonNumeric",
+          "version comparison is not numeric"
+        );
+      }
+
+      if (cmp <= 0) {
+        throw this.versionMismatchError(
+          runningVersion,
+          "daemonNewer",
+          "the running daemon is newer than this client"
+        );
+      }
     }
 
-    if (cmp <= 0) {
-      throw this.versionMismatchError(
-        runningVersion,
-        "daemonNewer",
-        "the running daemon is newer than this client"
-      );
-    }
+    // Reach here when the client is strictly newer OR the daemon is a same-release
+    // dev-skew (different git stamp). Both reconcile by restarting the daemon from
+    // this client's build. Same-release dev-skew must be handled HERE rather than
+    // deferred to ensureBuildMatches: the build-identity hash covers only the entry
+    // script (process.argv[1]), so in unbundled source-mode runs (`bun src/index.ts`)
+    // it is blind to commits that change non-entry files — the git stamp is the only
+    // signal. The restart is cooldown-bounded below so two checkouts cannot thrash.
 
     if (status.startedAt) {
       const daemonAgeMs = this.timer.now() - status.startedAt;

--- a/src/daemon/daemonMcpProxy.ts
+++ b/src/daemon/daemonMcpProxy.ts
@@ -4,6 +4,7 @@ import { logger } from "../utils/logger";
 import { SOCKET_PATH, DAEMON_STARTUP_TIMEOUT_MS, CONNECTION_TIMEOUT_MS, DAEMON_VERSION, DAEMON_VERSION_RESTART_COOLDOWN_MS } from "./constants";
 import type { DaemonOptions } from "./types";
 import { compareVersions } from "../server/deviceMatcher";
+import { releaseVersion } from "../utils/mcpVersion";
 import { defaultTimer, type Timer } from "../utils/SystemTimer";
 import {
   type BuildIdentity,
@@ -17,18 +18,6 @@ export type VersionMismatchReason =
   | "daemonNewer"
   | "nonNumeric"
   | "restartMismatch";
-
-/**
- * Strip semver build metadata (everything after the first `+`) from a version.
- *
- * Dev/non-release builds stamp a git short SHA as build metadata (e.g.
- * `0.0.39+g1a2b3c4.dirty`, see `getMcpServerVersion`). The numeric version gate
- * compares only the release portion; reconciling two builds that share a release
- * version but differ by commit is the build-identity gate's job, not the version
- * gate's. The metadata is also not an installable npm tag, so the restart hint
- * uses the stripped version too.
- */
-export const baseVersion = (version: string): string => version.split("+")[0];
 
 export type BuildMismatchReason =
   | "autoStartDisabled"
@@ -54,7 +43,7 @@ export class DaemonVersionMismatchError extends DaemonUnavailableError {
   }) {
     // The git-SHA build metadata on dev builds is not an installable npm tag,
     // so the bunx hint must point at the plain published version.
-    const installableVersion = baseVersion(params.clientVersion);
+    const installableVersion = releaseVersion(params.clientVersion);
     const restartCommand = installableVersion.length > 0 && installableVersion !== "unknown"
       ? `bunx @kaeawc/auto-mobile@${installableVersion} --daemon restart`
       : "the same installed auto-mobile package";
@@ -313,8 +302,8 @@ export class DaemonMcpProxy {
     // reconciled by the build-identity gate (ensureBuildMatches, which restarts
     // to the correct build on a content-hash mismatch). The version gate must
     // defer here rather than hard-throw, or it would defeat that self-heal.
-    const runningBase = baseVersion(runningVersion);
-    const clientBase = baseVersion(this.clientVersion);
+    const runningBase = releaseVersion(runningVersion);
+    const clientBase = releaseVersion(this.clientVersion);
     if (runningBase === clientBase) {
       return;
     }

--- a/src/daemon/manager.ts
+++ b/src/daemon/manager.ts
@@ -3,6 +3,7 @@ import { open, readFile, unlink } from "node:fs/promises";
 import { existsSync, openSync, closeSync, mkdirSync, readFileSync, unlinkSync, writeFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { logger } from "../utils/logger";
+import { releaseVersion } from "../utils/mcpVersion";
 import { ensureSecureTempDirSync, TEMP_SUBDIRS } from "../utils/tempDir";
 import { ActionableError } from "../models";
 import {
@@ -148,7 +149,11 @@ function hasProcessLivenessChecker(value: unknown): value is DaemonProcessLivene
 const MAX_DAEMON_STARTUP_LOG_BYTES = 4000;
 
 function resolvePackageSpecifier(version: string): string {
-  const trimmedVersion = version.trim();
+  // Strip any dev build metadata (`0.0.39+g<sha>.dirty`): a stamped version is
+  // not an installable npm tag, so bunx must pin the published release. This
+  // mirrors the DaemonVersionMismatchError restart hint, which also installs the
+  // release portion (a dev SHA cannot be fetched from npm regardless).
+  const trimmedVersion = releaseVersion(version.trim());
   if (trimmedVersion.length === 0 || trimmedVersion === "unknown") {
     throw new ActionableError(
       "Cannot spawn AutoMobile daemon via bunx because the current package version is unknown. Run from an installed auto-mobile binary or set MCP_SERVER_VERSION."

--- a/src/server/mcpRecordingManager.ts
+++ b/src/server/mcpRecordingManager.ts
@@ -1,7 +1,7 @@
 import * as yaml from "js-yaml";
 import { Plan } from "../models";
 import { logger } from "../utils/logger";
-import { getMcpServerVersion } from "../utils/mcpVersion";
+import { getMcpServerVersion, releaseVersion } from "../utils/mcpVersion";
 import { PlanValidator } from "../utils/plan/PlanValidator";
 import { McpCallRecorder } from "../features/record/McpCallRecorder";
 import { defaultTimer, type Timer } from "../utils/SystemTimer";
@@ -115,7 +115,9 @@ export function stopMcpRecording(
     const plan: Plan = {
       name: resolvedName,
       steps,
-      mcpVersion: getMcpServerVersion(),
+      // Release portion only — recorded plans are schema-validated (`^\d+\.\d+\.\d+$`)
+      // before migration, so a dev build's `+g<sha>` stamp would make them unusable.
+      mcpVersion: releaseVersion(getMcpServerVersion()),
       metadata: {
         createdAt: new Date(stoppedAt).toISOString(),
         version: "1.0.0",

--- a/src/server/testRecordingManager.ts
+++ b/src/server/testRecordingManager.ts
@@ -2,7 +2,7 @@ import { randomUUID } from "node:crypto";
 import * as yaml from "js-yaml";
 import { BootedDevice, Plan, PlanStep } from "../models";
 import { logger } from "../utils/logger";
-import { getMcpServerVersion } from "../utils/mcpVersion";
+import { getMcpServerVersion, releaseVersion } from "../utils/mcpVersion";
 import { PlanValidator } from "../utils/plan/PlanValidator";
 import { defaultTimer, type Timer } from "../utils/SystemTimer";
 import { DualTrackRecorder } from "../features/record/android";
@@ -79,7 +79,9 @@ const buildPlanFromSteps = (
     name: planName,
     description: `Recorded plan with ${steps.length} interaction(s).`,
     steps,
-    mcpVersion: getMcpServerVersion(),
+    // Release portion only — recorded plans are schema-validated (`^\d+\.\d+\.\d+$`)
+    // before migration, so a dev build's `+g<sha>` stamp would make them unusable.
+    mcpVersion: releaseVersion(getMcpServerVersion()),
     metadata: {
       createdAt: new Date(stoppedAt).toISOString(),
       version: "1.0.0",

--- a/src/utils/mcpVersion.ts
+++ b/src/utils/mcpVersion.ts
@@ -42,6 +42,19 @@ const findPackageJson = (startDir: string): string | null => {
 
 const moduleDir = (): string => path.dirname(fileURLToPath(import.meta.url));
 
+/** The npm package name; used to confirm a git checkout is AutoMobile's own source repo. */
+const PACKAGE_NAME = "@kaeawc/auto-mobile";
+
+const readPackageName = (dir: string): string | null => {
+  try {
+    const raw = fs.readFileSync(path.join(dir, "package.json"), "utf-8");
+    return (JSON.parse(raw) as { name?: string }).name ?? null;
+  } catch {
+    // No/unreadable package.json at the repo root — treat as not-ours.
+    return null;
+  }
+};
+
 const readPackageVersionFromDisk = (): string | null => {
   const packagePath = findPackageJson(moduleDir()) ?? findPackageJson(process.cwd());
   if (!packagePath) {
@@ -57,7 +70,10 @@ const readPackageVersionFromDisk = (): string | null => {
   }
 };
 
-const runGit = (cwd: string, args: string[]): string | null => {
+/** Runs a git subcommand in `cwd` and returns trimmed stdout, or null on any failure. */
+export type GitRunner = (cwd: string, args: string[]) => string | null;
+
+const runGit: GitRunner = (cwd, args) => {
   try {
     const result = spawnSync("git", args, { cwd, encoding: "utf-8", timeout: 2000 });
     if (result.status !== 0 || result.error) {
@@ -72,25 +88,37 @@ const runGit = (cwd: string, args: string[]): string | null => {
 
 /**
  * Read the current git commit identity from the package's checkout. Returns
- * null when git is unavailable or the package is not inside a working tree
+ * null when git is unavailable or this is not AutoMobile's own source checkout
  * (i.e. a published/release install), which keeps release versions unstamped.
  *
- * A published package lives under `node_modules`; `git rev-parse` searches
- * upward and would otherwise report the *host project's* commit, wrongly
- * stamping a release build. Treat any node_modules location as a release
- * install and skip git entirely.
+ * `git rev-parse` searches *upward* from the package directory, so a release
+ * install vendored inside an unrelated git repo (or a `bunx`/global-cache layout
+ * with no `node_modules` segment) would otherwise be stamped with the *host*
+ * repo's commit. Two guards prevent that:
+ *  1. Any `node_modules` location is a dependency install → skip.
+ *  2. The enclosing repo's top-level `package.json` must be this package — i.e.
+ *     the checkout is AutoMobile's source repo, not a host project that merely
+ *     contains a copy.
  */
-export const readGitVersion = (cwd: string = moduleDir()): GitVersionInfo | null => {
+export const readGitVersion = (
+  cwd: string = moduleDir(),
+  run: GitRunner = runGit,
+  readName: (dir: string) => string | null = readPackageName,
+): GitVersionInfo | null => {
   if (cwd.split(path.sep).includes("node_modules")) {
     return null;
   }
-  const shortSha = runGit(cwd, ["rev-parse", "--short=12", "HEAD"]);
+  const toplevel = run(cwd, ["rev-parse", "--show-toplevel"]);
+  if (!toplevel || readName(toplevel) !== PACKAGE_NAME) {
+    return null;
+  }
+  const shortSha = run(cwd, ["rev-parse", "--short=12", "HEAD"]);
   if (!shortSha) {
     return null;
   }
   // --untracked-files=no: only tracked changes alter the built code; untracked
   // scratch files should not flip a checkout to "dirty".
-  const status = runGit(cwd, ["status", "--porcelain", "--untracked-files=no"]);
+  const status = run(cwd, ["status", "--porcelain", "--untracked-files=no"]);
   return { shortSha, dirty: status !== null && status.length > 0 };
 };
 

--- a/src/utils/mcpVersion.ts
+++ b/src/utils/mcpVersion.ts
@@ -105,7 +105,9 @@ export const readGitVersion = (
   run: GitRunner = runGit,
   readName: (dir: string) => string | null = readPackageName,
 ): GitVersionInfo | null => {
-  if (cwd.split(path.sep).includes("node_modules")) {
+  // Split on both separators — Windows paths use `\`, but git/bun can emit `/`
+  // even there, so a single `path.sep` split would miss the node_modules segment.
+  if (cwd.split(/[\\/]/).includes("node_modules")) {
     return null;
   }
   const toplevel = run(cwd, ["rev-parse", "--show-toplevel"]);

--- a/src/utils/mcpVersion.ts
+++ b/src/utils/mcpVersion.ts
@@ -1,6 +1,26 @@
 import fs from "fs";
 import path from "path";
+import { spawnSync } from "child_process";
 import { fileURLToPath } from "url";
+
+/**
+ * Identity of the git commit a dev/source checkout is built from.
+ * `shortSha` is the abbreviated commit hash; `dirty` flags uncommitted tracked changes.
+ */
+export interface GitVersionInfo {
+  shortSha: string;
+  dirty: boolean;
+}
+
+/**
+ * Injectable inputs for {@link resolveMcpServerVersion}. Keeps the resolution
+ * logic pure and unit-testable without touching the filesystem, env, or git.
+ */
+export interface McpVersionDeps {
+  env: { MCP_SERVER_VERSION?: string; npm_package_version?: string };
+  readPackageVersion: () => string | null;
+  readGitVersion: () => GitVersionInfo | null;
+}
 
 let cachedVersion: string | null = null;
 
@@ -20,32 +40,112 @@ const findPackageJson = (startDir: string): string | null => {
   return null;
 };
 
+const moduleDir = (): string => path.dirname(fileURLToPath(import.meta.url));
+
+const readPackageVersionFromDisk = (): string | null => {
+  const packagePath = findPackageJson(moduleDir()) ?? findPackageJson(process.cwd());
+  if (!packagePath) {
+    return null;
+  }
+  try {
+    const raw = fs.readFileSync(packagePath, "utf-8");
+    const parsed = JSON.parse(raw) as { version?: string };
+    return parsed.version ?? null;
+  } catch {
+    // Unreadable/malformed package.json — fall through to unknown.
+    return null;
+  }
+};
+
+const runGit = (cwd: string, args: string[]): string | null => {
+  try {
+    const result = spawnSync("git", args, { cwd, encoding: "utf-8", timeout: 2000 });
+    if (result.status !== 0 || result.error) {
+      return null;
+    }
+    return result.stdout.trim();
+  } catch {
+    // git missing or not a checkout (release install) — no dev stamp.
+    return null;
+  }
+};
+
+/**
+ * Read the current git commit identity from the package's checkout. Returns
+ * null when git is unavailable or the package is not inside a working tree
+ * (i.e. a published/release install), which keeps release versions unstamped.
+ *
+ * A published package lives under `node_modules`; `git rev-parse` searches
+ * upward and would otherwise report the *host project's* commit, wrongly
+ * stamping a release build. Treat any node_modules location as a release
+ * install and skip git entirely.
+ */
+export const readGitVersion = (cwd: string = moduleDir()): GitVersionInfo | null => {
+  if (cwd.split(path.sep).includes("node_modules")) {
+    return null;
+  }
+  const shortSha = runGit(cwd, ["rev-parse", "--short=12", "HEAD"]);
+  if (!shortSha) {
+    return null;
+  }
+  // --untracked-files=no: only tracked changes alter the built code; untracked
+  // scratch files should not flip a checkout to "dirty".
+  const status = runGit(cwd, ["status", "--porcelain", "--untracked-files=no"]);
+  return { shortSha, dirty: status !== null && status.length > 0 };
+};
+
+/**
+ * Stamp a git short SHA (and dirty marker) onto a base version as semver build
+ * metadata. Release builds (no git info) are returned unchanged.
+ *
+ * The `+` build-metadata separator is deliberate: the daemon version gate's
+ * numeric `compareVersions` yields a non-finite result for two different
+ * stamped versions, which the gate already treats as a mismatch — so two dev
+ * checkouts at different commits stop sharing a daemon silently.
+ */
+export const formatMcpServerVersion = (baseVersion: string, git: GitVersionInfo | null): string => {
+  if (!git || git.shortSha.length === 0) {
+    return baseVersion;
+  }
+  const dirty = git.dirty ? ".dirty" : "";
+  return `${baseVersion}+g${git.shortSha}${dirty}`;
+};
+
+/**
+ * Resolve the effective MCP server version from injected inputs.
+ *
+ * - An explicit `MCP_SERVER_VERSION` is an exact override (CI/test pin) and is
+ *   never stamped.
+ * - Otherwise the base version comes from `npm_package_version` or package.json,
+ *   and is stamped with the git commit when the build is a source checkout.
+ * - With no resolvable base version, returns "unknown" (unstamped).
+ */
+export const resolveMcpServerVersion = (deps: McpVersionDeps): string => {
+  const override = deps.env.MCP_SERVER_VERSION;
+  if (override) {
+    return override;
+  }
+
+  const base = deps.env.npm_package_version || deps.readPackageVersion() || "unknown";
+  if (base === "unknown") {
+    return base;
+  }
+
+  return formatMcpServerVersion(base, deps.readGitVersion());
+};
+
 export const getMcpServerVersion = (): string => {
   if (cachedVersion) {
     return cachedVersion;
   }
 
-  const envVersion = process.env.MCP_SERVER_VERSION || process.env.npm_package_version;
-  if (envVersion) {
-    cachedVersion = envVersion;
-    return envVersion;
-  }
-
-  const moduleDir = path.dirname(fileURLToPath(import.meta.url));
-  const packagePath = findPackageJson(moduleDir) ?? findPackageJson(process.cwd());
-  if (packagePath) {
-    try {
-      const raw = fs.readFileSync(packagePath, "utf-8");
-      const parsed = JSON.parse(raw) as { version?: string };
-      if (parsed.version) {
-        cachedVersion = parsed.version;
-        return parsed.version;
-      }
-    } catch {
-      // Fall through to unknown
-    }
-  }
-
-  cachedVersion = "unknown";
+  cachedVersion = resolveMcpServerVersion({
+    env: {
+      MCP_SERVER_VERSION: process.env.MCP_SERVER_VERSION,
+      npm_package_version: process.env.npm_package_version,
+    },
+    readPackageVersion: readPackageVersionFromDisk,
+    readGitVersion: () => readGitVersion(),
+  });
   return cachedVersion;
 };

--- a/src/utils/mcpVersion.ts
+++ b/src/utils/mcpVersion.ts
@@ -95,13 +95,22 @@ export const readGitVersion = (cwd: string = moduleDir()): GitVersionInfo | null
 };
 
 /**
+ * The release portion of a version string — everything before the first `+`
+ * (semver build metadata). Dev/non-release builds carry a `+g<sha>[.dirty]`
+ * stamp; consumers that compare or parse versions numerically (the daemon
+ * version gate, plan migration) must strip it first. This is the one canonical
+ * place that knows the stamp format.
+ */
+export const releaseVersion = (version: string): string => version.split("+")[0];
+
+/**
  * Stamp a git short SHA (and dirty marker) onto a base version as semver build
  * metadata. Release builds (no git info) are returned unchanged.
  *
- * The `+` build-metadata separator is deliberate: the daemon version gate's
- * numeric `compareVersions` yields a non-finite result for two different
- * stamped versions, which the gate already treats as a mismatch — so two dev
- * checkouts at different commits stop sharing a daemon silently.
+ * The `+` separator keeps the release portion (before `+`) intact so numeric
+ * comparisons still work once {@link releaseVersion} strips the metadata, while
+ * the full string still varies per commit for diagnostics (doctor, logs,
+ * `DaemonVersionMismatchError`).
  */
 export const formatMcpServerVersion = (baseVersion: string, git: GitVersionInfo | null): string => {
   if (!git || git.shortSha.length === 0) {

--- a/src/utils/mcpVersion.ts
+++ b/src/utils/mcpVersion.ts
@@ -1,15 +1,20 @@
 import fs from "fs";
 import path from "path";
+import { createHash } from "crypto";
 import { spawnSync } from "child_process";
 import { fileURLToPath } from "url";
 
 /**
  * Identity of the git commit a dev/source checkout is built from.
- * `shortSha` is the abbreviated commit hash; `dirty` flags uncommitted tracked changes.
+ * `shortSha` is the abbreviated commit hash; `dirty` flags uncommitted tracked
+ * changes; `dirtyHash` is a short content hash of those changes (null when clean)
+ * so two checkouts at the same commit with *different* uncommitted edits report
+ * different versions rather than colliding on a bare `.dirty` marker.
  */
 export interface GitVersionInfo {
   shortSha: string;
   dirty: boolean;
+  dirtyHash?: string | null;
 }
 
 /**
@@ -121,7 +126,18 @@ export const readGitVersion = (
   // --untracked-files=no: only tracked changes alter the built code; untracked
   // scratch files should not flip a checkout to "dirty".
   const status = run(cwd, ["status", "--porcelain", "--untracked-files=no"]);
-  return { shortSha, dirty: status !== null && status.length > 0 };
+  const dirty = status !== null && status.length > 0;
+  // When dirty, hash the actual tracked diff so two checkouts at the same commit
+  // with different uncommitted edits get distinct stamps (a bare boolean would
+  // collide). Falls back to the plain `.dirty` marker if the diff is unavailable.
+  let dirtyHash: string | null = null;
+  if (dirty) {
+    const diff = run(cwd, ["diff", "HEAD"]);
+    if (diff) {
+      dirtyHash = createHash("sha256").update(diff).digest("hex").slice(0, 12);
+    }
+  }
+  return { shortSha, dirty, dirtyHash };
 };
 
 /**
@@ -146,7 +162,9 @@ export const formatMcpServerVersion = (baseVersion: string, git: GitVersionInfo 
   if (!git || git.shortSha.length === 0) {
     return baseVersion;
   }
-  const dirty = git.dirty ? ".dirty" : "";
+  // Dirty suffix: `.dirty` for the human marker, plus the tracked-diff hash when
+  // available so distinct working trees at the same commit don't collide.
+  const dirty = git.dirty ? (git.dirtyHash ? `.dirty.${git.dirtyHash}` : ".dirty") : "";
   return `${baseVersion}+g${git.shortSha}${dirty}`;
 };
 

--- a/src/utils/plan/PlanMigrator.ts
+++ b/src/utils/plan/PlanMigrator.ts
@@ -1,4 +1,4 @@
-import { getMcpServerVersion } from "../mcpVersion";
+import { getMcpServerVersion, releaseVersion } from "../mcpVersion";
 
 type MigrationWarning = {
   message: string;
@@ -18,7 +18,11 @@ const parseVersion = (version: string | undefined): number[] | null => {
   if (!version || version === "unknown" || version === "latest") {
     return null;
   }
-  const numericParts = version.split(".").map(part => parseInt(part.replace(/\D/g, ""), 10));
+  // Dev builds stamp a git SHA as semver build metadata (`0.0.39+g<sha>[.dirty]`).
+  // Strip it before parsing — otherwise the SHA's hex digits corrupt the patch
+  // number and a `.dirty` suffix parses to NaN (→ always-outdated). Migration
+  // only cares about the release portion.
+  const numericParts = releaseVersion(version).split(".").map(part => parseInt(part.replace(/\D/g, ""), 10));
   if (numericParts.some(part => Number.isNaN(part))) {
     return null;
   }

--- a/src/utils/plan/PlanSerializer.ts
+++ b/src/utils/plan/PlanSerializer.ts
@@ -5,7 +5,7 @@ import { Plan, PlanStep } from "../../models/Plan";
 import { logger } from "../logger";
 import { PlanNormalizer } from "./PlanNormalizer";
 import { migratePlan } from "./PlanMigrator";
-import { getMcpServerVersion } from "../mcpVersion";
+import { getMcpServerVersion, releaseVersion } from "../mcpVersion";
 import { PlanValidator } from "./PlanValidator";
 import { PLAN_YAML_LOAD_OPTIONS } from "./planYaml";
 
@@ -163,8 +163,11 @@ export class YamlPlanSerializer implements PlanSerializer {
         }
       }
 
-      // Create the plan
-      const mcpVersion = getMcpServerVersion();
+      // Create the plan. Persist the release portion only: the test-plan schema
+      // requires `^\d+\.\d+\.\d+$`, and plan files are schema-validated before
+      // migration runs, so a dev build's `+g<sha>` stamp would be rejected. The
+      // stamp's purpose (daemon skew detection, diagnostics) is unrelated to plans.
+      const mcpVersion = releaseVersion(getMcpServerVersion());
       const plan: Plan = {
         name: planName,
         description: `Exported plan with ${planSteps.length} steps`,

--- a/test/daemon/daemonMcpProxy.test.ts
+++ b/test/daemon/daemonMcpProxy.test.ts
@@ -21,6 +21,18 @@ const NEWER_VERSION = "9999.0.0";
 const CLIENT_VERSION = "0.0.39";
 const ANCIENT_TIMESTAMP = 1;
 
+// A FakeDaemonManager reporting a running daemon whose version matches this
+// client (the ambient stamped DAEMON_VERSION). Forwarding/recovery tests use a
+// real DaemonClient stub but must NOT consult the real local DaemonManager —
+// otherwise a release daemon running on the dev machine (version "0.0.39") would
+// mismatch the stamped client and trip the version gate. No buildId is set, so
+// the build-identity gate treats it as a match (missing identity = compatible).
+const matchingDaemonManager = (): FakeDaemonManager => {
+  const manager = new FakeDaemonManager();
+  manager.statusResult = { ...manager.statusResult, version: DAEMON_VERSION };
+  return manager;
+};
+
 class ScriptedDaemonClient implements DaemonClientLike {
   readonly callToolCalls: Array<{ toolName: string; params: Record<string, any> }> = [];
   readonly readResourceCalls: string[] = [];
@@ -549,6 +561,7 @@ describe("DaemonMcpProxy", () => {
 
       const proxy = new DaemonMcpProxy({
         clientFactory: () => fakeClient,
+        daemonManager: matchingDaemonManager(),
         autoStartDaemon: false
       });
 
@@ -576,6 +589,7 @@ describe("DaemonMcpProxy", () => {
 
       const proxy = new DaemonMcpProxy({
         clientFactory: () => fakeClient,
+        daemonManager: matchingDaemonManager(),
         autoStartDaemon: false
       });
 
@@ -599,6 +613,7 @@ describe("DaemonMcpProxy", () => {
 
       const proxy = new DaemonMcpProxy({
         clientFactory: () => fakeClient,
+        daemonManager: matchingDaemonManager(),
         autoStartDaemon: false
       });
 
@@ -629,6 +644,7 @@ describe("DaemonMcpProxy", () => {
 
       const proxy = new DaemonMcpProxy({
         clientFactory: () => clients.shift()!,
+        daemonManager: matchingDaemonManager(),
         autoStartDaemon: false
       });
 
@@ -663,6 +679,7 @@ describe("DaemonMcpProxy", () => {
 
       const proxy = new DaemonMcpProxy({
         clientFactory: () => clients.shift()!,
+        daemonManager: matchingDaemonManager(),
         autoStartDaemon: false
       });
 
@@ -686,6 +703,7 @@ describe("DaemonMcpProxy", () => {
 
       const proxy = new DaemonMcpProxy({
         clientFactory: () => client,
+        daemonManager: matchingDaemonManager(),
         autoStartDaemon: false
       });
 
@@ -716,6 +734,7 @@ describe("DaemonMcpProxy", () => {
 
       const proxy = new DaemonMcpProxy({
         clientFactory: () => clients.shift()!,
+        daemonManager: matchingDaemonManager(),
         autoStartDaemon: false
       });
 
@@ -751,6 +770,7 @@ describe("DaemonMcpProxy", () => {
 
       const proxy = new DaemonMcpProxy({
         clientFactory: () => fakeClient,
+        daemonManager: matchingDaemonManager(),
         autoStartDaemon: false
       });
 
@@ -771,6 +791,7 @@ describe("DaemonMcpProxy", () => {
 
       const proxy = new DaemonMcpProxy({
         clientFactory: () => fakeClient,
+        daemonManager: matchingDaemonManager(),
         autoStartDaemon: false
       });
 
@@ -798,6 +819,7 @@ describe("DaemonMcpProxy", () => {
 
       const proxy = new DaemonMcpProxy({
         clientFactory: () => clients.shift()!,
+        daemonManager: matchingDaemonManager(),
         autoStartDaemon: false
       });
 
@@ -829,6 +851,7 @@ describe("DaemonMcpProxy", () => {
 
       const proxy = new DaemonMcpProxy({
         clientFactory: () => fakeClient,
+        daemonManager: matchingDaemonManager(),
         autoStartDaemon: false
       });
 
@@ -1044,6 +1067,7 @@ describe("DaemonMcpProxy", () => {
 
       const proxy = new DaemonMcpProxy({
         clientFactory: () => clients.shift()!,
+        daemonManager: matchingDaemonManager(),
         autoStartDaemon: false,
       });
 
@@ -1082,6 +1106,7 @@ describe("DaemonMcpProxy", () => {
 
       const proxy = new DaemonMcpProxy({
         clientFactory: () => clients.shift()!,
+        daemonManager: matchingDaemonManager(),
         autoStartDaemon: false,
         buildIdentity: { entryScript: "/client/dist/index.js", buildId: "clientbuild" },
       });
@@ -1116,6 +1141,7 @@ describe("DaemonMcpProxy", () => {
 
       const proxy = new DaemonMcpProxy({
         clientFactory: () => client,
+        daemonManager: matchingDaemonManager(),
         autoStartDaemon: false,
       });
 

--- a/test/daemon/daemonMcpProxy.test.ts
+++ b/test/daemon/daemonMcpProxy.test.ts
@@ -14,6 +14,11 @@ import { FakeTimer } from "../fakes/FakeTimer";
 
 const OLDER_VERSION = "0.0.1";
 const NEWER_VERSION = "9999.0.0";
+// Pinned plain client version for the version-gate suite. The ambient
+// DAEMON_VERSION is git-SHA-stamped in a source checkout (e.g. "0.0.39+g...")
+// which is intentionally non-numeric; these tests exercise release-version
+// (numeric) comparison semantics, so the client version is injected explicitly.
+const CLIENT_VERSION = "0.0.39";
 const ANCIENT_TIMESTAMP = 1;
 
 class ScriptedDaemonClient implements DaemonClientLike {
@@ -145,6 +150,7 @@ describe("DaemonMcpProxy", () => {
         waitForReadyResult?: boolean;
         daemonOptions?: { debug?: boolean; port?: number };
         statusAfterRestartVersion?: string;
+        clientVersion?: string;
       } = {}) {
         const timer = new FakeTimer();
         timer.advanceTime(100_000);
@@ -165,7 +171,7 @@ describe("DaemonMcpProxy", () => {
           initialStatus,
           {
             ...initialStatus,
-            version: opts.statusAfterRestartVersion ?? DAEMON_VERSION,
+            version: opts.statusAfterRestartVersion ?? CLIENT_VERSION,
             startedAt: timer.now(),
           },
         ];
@@ -179,6 +185,7 @@ describe("DaemonMcpProxy", () => {
           autoStartDaemon: opts.autoStartDaemon ?? true,
           daemonOptions: opts.daemonOptions,
           timer,
+          clientVersion: opts.clientVersion ?? CLIENT_VERSION,
         });
         return { fakeClient, fakeManager, isAvailableSpy, proxy };
       }
@@ -216,7 +223,7 @@ describe("DaemonMcpProxy", () => {
           const error = await expectVersionMismatch(proxy.listTools());
           expect(error.reason).toBe("daemonNewer");
           expect(error.daemonVersion).toBe(NEWER_VERSION);
-          expect(error.clientVersion).toBe(DAEMON_VERSION);
+          expect(error.clientVersion).toBe(CLIENT_VERSION);
           expect(fakeManager.restartCalled).toBe(false);
           expect(fakeClient.isConnected()).toBe(false);
         } finally {
@@ -227,7 +234,26 @@ describe("DaemonMcpProxy", () => {
 
       test("does not restart when versions match", async () => {
         const { fakeManager, isAvailableSpy, proxy } = makeProxy({
-          runningVersion: DAEMON_VERSION,
+          runningVersion: CLIENT_VERSION,
+          startedAt: ANCIENT_TIMESTAMP,
+        });
+        try {
+          await proxy.listTools();
+          expect(fakeManager.restartCalled).toBe(false);
+        } finally {
+          isAvailableSpy.mockRestore();
+          await proxy.close();
+        }
+      });
+
+      test("defers dev-build skew (same release version, different git stamp) to the build-identity gate", async () => {
+        // Two checkouts at different commits both report release 0.0.39 but carry
+        // different git build metadata. The version gate must NOT hard-throw on the
+        // non-numeric difference — that would defeat the build-identity gate's
+        // self-heal. With matching (absent) build identity it connects cleanly.
+        const { fakeManager, isAvailableSpy, proxy } = makeProxy({
+          clientVersion: "0.0.39+gaaaaaaaaaaaa",
+          runningVersion: "0.0.39+gbbbbbbbbbbbb",
           startedAt: ANCIENT_TIMESTAMP,
         });
         try {
@@ -1080,6 +1106,33 @@ describe("DaemonMcpProxy", () => {
         isAvailableSpy.mockRestore();
         await proxy.close();
       }
+    });
+  });
+
+  describe("DaemonVersionMismatchError restart hint", () => {
+    test("strips git build metadata from the bunx restart hint for dev builds", () => {
+      const error = new DaemonVersionMismatchError({
+        clientVersion: "0.0.39+g1a2b3c4d5e6f.dirty",
+        daemonVersion: "0.0.39+gffffffffffff",
+        reason: "nonNumeric",
+        detail: "version comparison is not numeric",
+      });
+      // The hint must be npm-installable: build metadata (+...) is not a valid npm tag.
+      expect(error.message).toContain("bunx @kaeawc/auto-mobile@0.0.39 --daemon restart");
+      expect(error.message).not.toContain("bunx @kaeawc/auto-mobile@0.0.39+g");
+      // The displayed client/daemon versions stay fully qualified for diagnostics.
+      expect(error.message).toContain("client=0.0.39+g1a2b3c4d5e6f.dirty");
+      expect(error.message).toContain("daemon=0.0.39+gffffffffffff");
+    });
+
+    test("leaves a plain release version untouched in the restart hint", () => {
+      const error = new DaemonVersionMismatchError({
+        clientVersion: "0.0.40",
+        daemonVersion: "0.0.39",
+        reason: "daemonNewer",
+        detail: "daemon is newer",
+      });
+      expect(error.message).toContain("bunx @kaeawc/auto-mobile@0.0.40 --daemon restart");
     });
   });
 });

--- a/test/daemon/daemonMcpProxy.test.ts
+++ b/test/daemon/daemonMcpProxy.test.ts
@@ -246,20 +246,41 @@ describe("DaemonMcpProxy", () => {
         }
       });
 
-      test("defers dev-build skew (same release version, different git stamp) to the build-identity gate", async () => {
-        // Two checkouts at different commits both report release 0.0.39 but carry
-        // different git build metadata. The version gate must NOT hard-throw on the
-        // non-numeric difference — that would defeat the build-identity gate's
-        // self-heal. With matching (absent) build identity it connects cleanly.
+      test("self-heals same-release dev-build skew by restarting to this client's build", async () => {
+        // Two checkouts at the same release (0.0.39) but different commits carry
+        // different git stamps. The version gate must NOT hard-throw on the
+        // non-numeric difference, and must NOT silently attach (the build-identity
+        // hash is blind to non-entry-file changes in source mode) — it reconciles
+        // by restarting the daemon to this client's build.
         const { fakeManager, isAvailableSpy, proxy } = makeProxy({
           clientVersion: "0.0.39+gaaaaaaaaaaaa",
           runningVersion: "0.0.39+gbbbbbbbbbbbb",
+          statusAfterRestartVersion: "0.0.39+gaaaaaaaaaaaa",
           startedAt: ANCIENT_TIMESTAMP,
         });
         try {
           await proxy.listTools();
-          expect(fakeManager.restartCalled).toBe(false);
+          expect(fakeManager.restartCalled).toBe(true);
         } finally {
+          isAvailableSpy.mockRestore();
+          await proxy.close();
+        }
+      });
+
+      test("throws cooldown (no restart) for same-release dev-skew within the cooldown window", async () => {
+        const warnSpy = spyOn(logger, "warn").mockImplementation(() => {});
+        const { fakeClient, fakeManager, isAvailableSpy, proxy } = makeProxy({
+          clientVersion: "0.0.39+gaaaaaaaaaaaa",
+          runningVersion: "0.0.39+gbbbbbbbbbbbb",
+          startedAt: 100_000 - Math.floor(DAEMON_VERSION_RESTART_COOLDOWN_MS / 2),
+        });
+        try {
+          const error = await expectVersionMismatch(proxy.listTools());
+          expect(error.reason).toBe("cooldown");
+          expect(fakeManager.restartCalled).toBe(false);
+          expect(fakeClient.isConnected()).toBe(false);
+        } finally {
+          warnSpy.mockRestore();
           isAvailableSpy.mockRestore();
           await proxy.close();
         }
@@ -847,11 +868,6 @@ describe("DaemonMcpProxy", () => {
       startedAt?: number;
       autoStartDaemon?: boolean;
       waitForReadyResult?: boolean;
-      // Version strings — default to a matched DAEMON_VERSION on both sides so
-      // only the build differs. Override to exercise the same-release/different-
-      // stamp dev-skew path that defers from the version gate to the build gate.
-      clientVersion?: string;
-      daemonVersion?: string;
     } = {}) {
       const timer = new FakeTimer();
       timer.advanceTime(100_000);
@@ -865,21 +881,20 @@ describe("DaemonMcpProxy", () => {
         pid: 1234,
         port: 3000,
         socketPath: "/tmp/test.sock",
-        version: opts.daemonVersion ?? DAEMON_VERSION,
+        version: DAEMON_VERSION, // versions match so only the build differs
         startedAt: opts.startedAt ?? ANCIENT_TIMESTAMP,
         ...(opts.daemonBuildId === null ? {} : { buildId: opts.daemonBuildId ?? DAEMON_BUILD.buildId }),
         ...(opts.daemonEntryScript === null ? {} : { entryScript: opts.daemonEntryScript ?? DAEMON_BUILD.entryScript }),
       };
       const restartedStatus = {
         ...mismatchStatus,
-        version: opts.clientVersion ?? mismatchStatus.version,
         buildId: opts.restartedBuildId ?? CLIENT_BUILD.buildId,
         entryScript: opts.restartedEntryScript ?? CLIENT_BUILD.entryScript,
         startedAt: timer.now(),
       };
 
-      // ensureVersionMatches consumes one status() (versions match/defer → returns),
-      // then ensureBuildMatches consumes one to detect the mismatch. Both return the
+      // ensureVersionMatches consumes one status() (versions match → returns), then
+      // ensureBuildMatches consumes one to detect the mismatch. Both return the
       // mismatch status; the fallback statusResult is the post-restart identity.
       fakeManager.statusResult = restartedStatus;
       fakeManager.statusResults = [mismatchStatus, mismatchStatus];
@@ -894,7 +909,6 @@ describe("DaemonMcpProxy", () => {
         autoStartDaemon: opts.autoStartDaemon ?? true,
         timer,
         buildIdentity: { ...CLIENT_BUILD },
-        ...(opts.clientVersion !== undefined ? { clientVersion: opts.clientVersion } : {}),
       });
       return { fakeClient, fakeManager, isAvailableSpy, proxy };
     }
@@ -911,30 +925,6 @@ describe("DaemonMcpProxy", () => {
 
     test("restarts daemon and invalidates cache when build differs", async () => {
       const { fakeManager, isAvailableSpy, proxy } = makeBuildProxy();
-      const invalidateSpy = spyOn(proxy, "invalidateCache");
-      try {
-        await proxy.listTools();
-        expect(fakeManager.restartCalled).toBe(true);
-        expect(invalidateSpy).toHaveBeenCalled();
-      } finally {
-        invalidateSpy.mockRestore();
-        isAvailableSpy.mockRestore();
-        await proxy.close();
-      }
-    });
-
-    test("self-heals two dev checkouts: same release version, different git stamp AND different build", async () => {
-      // The end-to-end #2738 scenario: two checkouts both at release 0.0.39 with
-      // different git stamps and different builds share one socket. The version
-      // gate sees differing stamped strings, defers (same release portion), and
-      // the build-identity gate restarts to this client's build — self-heal, not
-      // a hard version-mismatch throw.
-      const { fakeManager, isAvailableSpy, proxy } = makeBuildProxy({
-        clientVersion: "0.0.39+gaaaaaaaaaaaa",
-        daemonVersion: "0.0.39+gbbbbbbbbbbbb",
-        daemonBuildId: DAEMON_BUILD.buildId,
-        daemonEntryScript: DAEMON_BUILD.entryScript,
-      });
       const invalidateSpy = spyOn(proxy, "invalidateCache");
       try {
         await proxy.listTools();

--- a/test/daemon/daemonMcpProxy.test.ts
+++ b/test/daemon/daemonMcpProxy.test.ts
@@ -847,6 +847,11 @@ describe("DaemonMcpProxy", () => {
       startedAt?: number;
       autoStartDaemon?: boolean;
       waitForReadyResult?: boolean;
+      // Version strings — default to a matched DAEMON_VERSION on both sides so
+      // only the build differs. Override to exercise the same-release/different-
+      // stamp dev-skew path that defers from the version gate to the build gate.
+      clientVersion?: string;
+      daemonVersion?: string;
     } = {}) {
       const timer = new FakeTimer();
       timer.advanceTime(100_000);
@@ -860,20 +865,21 @@ describe("DaemonMcpProxy", () => {
         pid: 1234,
         port: 3000,
         socketPath: "/tmp/test.sock",
-        version: DAEMON_VERSION, // versions match so only the build differs
+        version: opts.daemonVersion ?? DAEMON_VERSION,
         startedAt: opts.startedAt ?? ANCIENT_TIMESTAMP,
         ...(opts.daemonBuildId === null ? {} : { buildId: opts.daemonBuildId ?? DAEMON_BUILD.buildId }),
         ...(opts.daemonEntryScript === null ? {} : { entryScript: opts.daemonEntryScript ?? DAEMON_BUILD.entryScript }),
       };
       const restartedStatus = {
         ...mismatchStatus,
+        version: opts.clientVersion ?? mismatchStatus.version,
         buildId: opts.restartedBuildId ?? CLIENT_BUILD.buildId,
         entryScript: opts.restartedEntryScript ?? CLIENT_BUILD.entryScript,
         startedAt: timer.now(),
       };
 
-      // ensureVersionMatches consumes one status() (versions match → returns), then
-      // ensureBuildMatches consumes one to detect the mismatch. Both return the
+      // ensureVersionMatches consumes one status() (versions match/defer → returns),
+      // then ensureBuildMatches consumes one to detect the mismatch. Both return the
       // mismatch status; the fallback statusResult is the post-restart identity.
       fakeManager.statusResult = restartedStatus;
       fakeManager.statusResults = [mismatchStatus, mismatchStatus];
@@ -888,6 +894,7 @@ describe("DaemonMcpProxy", () => {
         autoStartDaemon: opts.autoStartDaemon ?? true,
         timer,
         buildIdentity: { ...CLIENT_BUILD },
+        ...(opts.clientVersion !== undefined ? { clientVersion: opts.clientVersion } : {}),
       });
       return { fakeClient, fakeManager, isAvailableSpy, proxy };
     }
@@ -904,6 +911,30 @@ describe("DaemonMcpProxy", () => {
 
     test("restarts daemon and invalidates cache when build differs", async () => {
       const { fakeManager, isAvailableSpy, proxy } = makeBuildProxy();
+      const invalidateSpy = spyOn(proxy, "invalidateCache");
+      try {
+        await proxy.listTools();
+        expect(fakeManager.restartCalled).toBe(true);
+        expect(invalidateSpy).toHaveBeenCalled();
+      } finally {
+        invalidateSpy.mockRestore();
+        isAvailableSpy.mockRestore();
+        await proxy.close();
+      }
+    });
+
+    test("self-heals two dev checkouts: same release version, different git stamp AND different build", async () => {
+      // The end-to-end #2738 scenario: two checkouts both at release 0.0.39 with
+      // different git stamps and different builds share one socket. The version
+      // gate sees differing stamped strings, defers (same release portion), and
+      // the build-identity gate restarts to this client's build — self-heal, not
+      // a hard version-mismatch throw.
+      const { fakeManager, isAvailableSpy, proxy } = makeBuildProxy({
+        clientVersion: "0.0.39+gaaaaaaaaaaaa",
+        daemonVersion: "0.0.39+gbbbbbbbbbbbb",
+        daemonBuildId: DAEMON_BUILD.buildId,
+        daemonEntryScript: DAEMON_BUILD.entryScript,
+      });
       const invalidateSpy = spyOn(proxy, "invalidateCache");
       try {
         await proxy.listTools();

--- a/test/daemon/integration/versionMismatchRestart.test.ts
+++ b/test/daemon/integration/versionMismatchRestart.test.ts
@@ -18,6 +18,11 @@ import { FakeTimer } from "../../fakes/FakeTimer";
  * PID is guaranteed to be alive for the duration of the test. The test stubs
  * the spawn/restart side via a wrapper so no real daemon child is forked.
  */
+// Pinned plain client version: DAEMON_VERSION is git-SHA-stamped (non-numeric)
+// in a source checkout, but this suite exercises the numeric release-version
+// comparison path, so the proxy's client version is injected explicitly.
+const CLIENT_VERSION = "0.0.39";
+
 describe("DaemonMcpProxy + real DaemonManager (version-mismatch integration)", () => {
   let tempDir: string;
   let pidFilePath: string;
@@ -74,7 +79,7 @@ describe("DaemonMcpProxy + real DaemonManager (version-mismatch integration)", (
       async restart(options?: DaemonOptions) {
         restartCalled = true;
         restartOptions = options;
-        writePidFile({ version: DAEMON_VERSION, startedAt: fakeTimer.now() });
+        writePidFile({ version: CLIENT_VERSION, startedAt: fakeTimer.now() });
       },
       async waitForReady() {
         return tracker.waitForReadyResult;
@@ -91,6 +96,7 @@ describe("DaemonMcpProxy + real DaemonManager (version-mismatch integration)", (
       daemonManager: tracked,
       autoStartDaemon: true,
       timer: fakeTimer,
+      clientVersion: CLIENT_VERSION,
     });
     try {
       await proxy.listTools();
@@ -109,6 +115,7 @@ describe("DaemonMcpProxy + real DaemonManager (version-mismatch integration)", (
       daemonManager: tracked,
       autoStartDaemon: true,
       timer: fakeTimer,
+      clientVersion: CLIENT_VERSION,
     });
     try {
       await expect(proxy.listTools()).rejects.toThrow(DaemonVersionMismatchError);
@@ -120,13 +127,14 @@ describe("DaemonMcpProxy + real DaemonManager (version-mismatch integration)", (
   });
 
   test("real PID file with matching version does not trigger restart", async () => {
-    writePidFile({ version: DAEMON_VERSION, startedAt: 1 });
+    writePidFile({ version: CLIENT_VERSION, startedAt: 1 });
     const tracked = makeTracked();
     const proxy = new DaemonMcpProxy({
       clientFactory: () => new FakeDaemonClient(),
       daemonManager: tracked,
       autoStartDaemon: true,
       timer: fakeTimer,
+      clientVersion: CLIENT_VERSION,
     });
     try {
       await proxy.listTools();
@@ -148,6 +156,7 @@ describe("DaemonMcpProxy + real DaemonManager (version-mismatch integration)", (
       daemonManager: tracked,
       autoStartDaemon: true,
       timer: fakeTimer,
+      clientVersion: CLIENT_VERSION,
     });
     try {
       await expect(proxy.listTools()).rejects.toThrow(DaemonVersionMismatchError);
@@ -172,6 +181,7 @@ describe("DaemonMcpProxy + real DaemonManager (version-mismatch integration)", (
       daemonManager: tracked,
       autoStartDaemon: true,
       timer: fakeTimer,
+      clientVersion: CLIENT_VERSION,
     });
     try {
       await proxy.listTools();
@@ -227,6 +237,7 @@ describe("DaemonMcpProxy + real DaemonManager (version-mismatch integration)", (
       daemonManager: tracked,
       autoStartDaemon: true,
       timer: fakeTimer,
+      clientVersion: CLIENT_VERSION,
     });
     try {
       await proxy.listTools();

--- a/test/daemon/manager.test.ts
+++ b/test/daemon/manager.test.ts
@@ -90,6 +90,17 @@ describe("resolveDaemonLaunchCommand", () => {
       "current package version is unknown"
     );
   });
+
+  test("strips a dev git-SHA stamp so the bunx specifier is an installable release", () => {
+    // A dev build reports e.g. "0.0.39+g1a2b3c4.dirty"; that is not an installable
+    // npm tag, so the bunx fallback must pin the published release portion.
+    const launch = resolveDaemonLaunchCommand("", "bunx", "0.0.39+g1a2b3c4d5e6f.dirty.abc123def456");
+
+    expect(launch).toEqual({
+      command: "bunx",
+      args: ["-y", "@kaeawc/auto-mobile@0.0.39", "--daemon-mode"],
+    });
+  });
 });
 
 describe("Daemon manager process detection", () => {

--- a/test/server/mcpRecordingManager.test.ts
+++ b/test/server/mcpRecordingManager.test.ts
@@ -134,6 +134,23 @@ describe("mcpRecordingManager", () => {
       expect(result.planContent).toContain("generatedFromToolCalls: true");
     });
 
+    test("records a schema-valid mcpVersion (release portion only, even on a dev build)", () => {
+      // Recorded plans are schema-validated (`^\d+\.\d+\.\d+$`) before migration,
+      // so a dev build's git-SHA stamp must be stripped or replay is unusable.
+      const timer = new FakeTimer();
+      timer.setCurrentTime(1000);
+      startMcpRecording(timer);
+      getMcpRecorder()!.record("tapOn", { text: "Login" });
+
+      const stopTimer = new FakeTimer();
+      stopTimer.setCurrentTime(5000);
+      const result = stopMcpRecording("schema-test", stopTimer);
+
+      const mcpVersion = result.planContent.match(/mcpVersion:\s*(\S+)/)?.[1];
+      expect(mcpVersion).toMatch(/^\d+\.\d+\.\d+$/);
+      expect(result.planContent).not.toContain("+g");
+    });
+
     test("strips internal params from plan content", () => {
       const timer = new FakeTimer();
       timer.setCurrentTime(1000);

--- a/test/utils/mcpVersion.test.ts
+++ b/test/utils/mcpVersion.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 import {
   formatMcpServerVersion,
   readGitVersion,
+  releaseVersion,
   resolveMcpServerVersion,
   type GitVersionInfo,
   type McpVersionDeps,
@@ -9,6 +10,20 @@ import {
 import { compareVersions } from "../../src/server/deviceMatcher";
 
 const git = (shortSha: string, dirty = false): GitVersionInfo => ({ shortSha, dirty });
+
+describe("releaseVersion", () => {
+  test("returns the version unchanged when there is no build metadata", () => {
+    expect(releaseVersion("0.0.39")).toBe("0.0.39");
+  });
+
+  test("strips the git-SHA build metadata", () => {
+    expect(releaseVersion("0.0.39+g1a2b3c4d5e6f")).toBe("0.0.39");
+  });
+
+  test("strips the dirty marker too", () => {
+    expect(releaseVersion("0.0.39+g1a2b3c4d5e6f.dirty")).toBe("0.0.39");
+  });
+});
 
 describe("formatMcpServerVersion", () => {
   test("returns the base version unchanged when there is no git info (release build)", () => {

--- a/test/utils/mcpVersion.test.ts
+++ b/test/utils/mcpVersion.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, test } from "bun:test";
+import {
+  formatMcpServerVersion,
+  readGitVersion,
+  resolveMcpServerVersion,
+  type GitVersionInfo,
+  type McpVersionDeps,
+} from "../../src/utils/mcpVersion";
+import { compareVersions } from "../../src/server/deviceMatcher";
+
+const git = (shortSha: string, dirty = false): GitVersionInfo => ({ shortSha, dirty });
+
+describe("formatMcpServerVersion", () => {
+  test("returns the base version unchanged when there is no git info (release build)", () => {
+    expect(formatMcpServerVersion("0.0.39", null)).toBe("0.0.39");
+  });
+
+  test("returns the base version unchanged when the short SHA is empty", () => {
+    expect(formatMcpServerVersion("0.0.39", git(""))).toBe("0.0.39");
+  });
+
+  test("stamps the git short SHA as semver build metadata", () => {
+    expect(formatMcpServerVersion("0.0.39", git("1a2b3c4d5e6f"))).toBe("0.0.39+g1a2b3c4d5e6f");
+  });
+
+  test("appends a dirty marker when the working tree is dirty", () => {
+    expect(formatMcpServerVersion("0.0.39", git("1a2b3c4d5e6f", true))).toBe("0.0.39+g1a2b3c4d5e6f.dirty");
+  });
+
+  test("two different commits yield two different version strings", () => {
+    const a = formatMcpServerVersion("0.0.39", git("aaaaaaaaaaaa"));
+    const b = formatMcpServerVersion("0.0.39", git("bbbbbbbbbbbb"));
+    expect(a).not.toBe(b);
+  });
+
+  test("a clean vs dirty checkout at the same commit are distinguished", () => {
+    const clean = formatMcpServerVersion("0.0.39", git("1a2b3c4d5e6f", false));
+    const dirty = formatMcpServerVersion("0.0.39", git("1a2b3c4d5e6f", true));
+    expect(clean).not.toBe(dirty);
+  });
+});
+
+describe("formatMcpServerVersion + the daemon version gate", () => {
+  // The stamp is semver build metadata: it makes the *string* vary with the
+  // commit (for doctor/logs/DaemonVersionMismatchError diagnostics) while the
+  // release portion before `+` stays stable. The version gate compares the
+  // release portion and defers same-release dev-skew to the build-identity gate.
+  test("stamped dev builds share the same release portion (gate treats them as same-release)", () => {
+    const a = formatMcpServerVersion("0.0.39", git("aaaaaaaaaaaa"));
+    const b = formatMcpServerVersion("0.0.39", git("bbbbbbbbbbbb"));
+    expect(a.split("+")[0]).toBe(b.split("+")[0]);
+    expect(compareVersions(a.split("+")[0], b.split("+")[0])).toBe(0);
+  });
+
+  test("the full stamped string still varies with the commit (diagnostics distinguish them)", () => {
+    const a = formatMcpServerVersion("0.0.39", git("aaaaaaaaaaaa"));
+    const b = formatMcpServerVersion("0.0.39", git("bbbbbbbbbbbb"));
+    expect(a).not.toBe(b);
+  });
+
+  test("a genuine release-version bump still compares numerically across stamps", () => {
+    const older = formatMcpServerVersion("0.0.39", git("aaaaaaaaaaaa"));
+    const newer = formatMcpServerVersion("0.0.40", git("bbbbbbbbbbbb"));
+    expect(compareVersions(newer.split("+")[0], older.split("+")[0])).toBeGreaterThan(0);
+  });
+});
+
+describe("readGitVersion (release-install detection)", () => {
+  test("returns null for a node_modules location without consulting git (release install)", () => {
+    // A published package nested under a host project's git repo must not be
+    // stamped with the host's commit.
+    expect(readGitVersion("/some/host/project/node_modules/@kaeawc/auto-mobile/dist")).toBeNull();
+  });
+
+  test("returns null when the cwd is not a git checkout", () => {
+    expect(readGitVersion("/")).toBeNull();
+  });
+});
+
+describe("resolveMcpServerVersion", () => {
+  const deps = (overrides: Partial<McpVersionDeps>): McpVersionDeps => ({
+    env: {},
+    readPackageVersion: () => "0.0.39",
+    readGitVersion: () => git("1a2b3c4d5e6f"),
+    ...overrides,
+  });
+
+  test("MCP_SERVER_VERSION override is returned verbatim, even inside a git checkout", () => {
+    expect(
+      resolveMcpServerVersion(deps({ env: { MCP_SERVER_VERSION: "9.9.9" } }))
+    ).toBe("9.9.9");
+  });
+
+  test("npm_package_version is used as the base and stamped when git is present", () => {
+    expect(
+      resolveMcpServerVersion(
+        deps({ env: { npm_package_version: "1.2.3" }, readGitVersion: () => git("abcdef123456") })
+      )
+    ).toBe("1.2.3+gabcdef123456");
+  });
+
+  test("package.json version is used as the base and stamped when git is present", () => {
+    expect(resolveMcpServerVersion(deps({}))).toBe("0.0.39+g1a2b3c4d5e6f");
+  });
+
+  test("returns 'unknown' with no stamp when no base version can be resolved", () => {
+    expect(
+      resolveMcpServerVersion(deps({ readPackageVersion: () => null }))
+    ).toBe("unknown");
+  });
+
+  test("release build (no git) reports the base version unchanged", () => {
+    expect(
+      resolveMcpServerVersion(deps({ readGitVersion: () => null }))
+    ).toBe("0.0.39");
+  });
+});

--- a/test/utils/mcpVersion.test.ts
+++ b/test/utils/mcpVersion.test.ts
@@ -80,15 +80,51 @@ describe("formatMcpServerVersion + the daemon version gate", () => {
   });
 });
 
-describe("readGitVersion (release-install detection)", () => {
-  test("returns null for a node_modules location without consulting git (release install)", () => {
-    // A published package nested under a host project's git repo must not be
-    // stamped with the host's commit.
-    expect(readGitVersion("/some/host/project/node_modules/@kaeawc/auto-mobile/dist")).toBeNull();
+describe("readGitVersion", () => {
+  // Fake git runner: maps each git invocation (keyed by first arg) to canned
+  // stdout. Keeps these tests pure — no spawn, no real repo. `readName` is
+  // injected too so the ownership check needs no filesystem.
+  const OWN = "@kaeawc/auto-mobile";
+  const fakeRun = (responses: Record<string, string | null>) =>
+    (_cwd: string, args: string[]): string | null => {
+      if (args[0] === "rev-parse" && args[1] === "--show-toplevel") {return responses.toplevel ?? null;}
+      if (args[0] === "rev-parse" && args[1] === "--short=12") {return responses.sha ?? null;}
+      if (args[0] === "status") {return responses.status ?? null;}
+      return null;
+    };
+  const ownsRepo = () => OWN;
+
+  test("returns null for a node_modules location without consulting git (dependency install)", () => {
+    let called = false;
+    const run = (_c: string, _a: string[]) => { called = true; return null; };
+    expect(readGitVersion("/host/node_modules/@kaeawc/auto-mobile/dist", run, ownsRepo)).toBeNull();
+    expect(called).toBe(false);
   });
 
-  test("returns null when the cwd is not a git checkout", () => {
-    expect(readGitVersion("/")).toBeNull();
+  test("returns null when not inside a git work tree (release install)", () => {
+    expect(readGitVersion("/opt/app", fakeRun({ toplevel: null }), ownsRepo)).toBeNull();
+  });
+
+  test("returns null when the enclosing repo is a different project (vendored release install)", () => {
+    // git rev-parse walks upward; a copy nested in a host repo must not be
+    // stamped with the host's commit.
+    const run = fakeRun({ toplevel: "/host/repo", sha: "deadbeefcafe" });
+    expect(readGitVersion("/host/repo/vendor/auto-mobile", run, () => "some-host-app")).toBeNull();
+  });
+
+  test("returns null when HEAD has no resolvable short SHA", () => {
+    const run = fakeRun({ toplevel: "/src/auto-mobile", sha: null });
+    expect(readGitVersion("/src/auto-mobile", run, ownsRepo)).toBeNull();
+  });
+
+  test("stamps a clean checkout of AutoMobile's own repo", () => {
+    const run = fakeRun({ toplevel: "/src/auto-mobile", sha: "1a2b3c4d5e6f", status: "" });
+    expect(readGitVersion("/src/auto-mobile", run, ownsRepo)).toEqual({ shortSha: "1a2b3c4d5e6f", dirty: false });
+  });
+
+  test("marks the checkout dirty when there are tracked changes", () => {
+    const run = fakeRun({ toplevel: "/src/auto-mobile", sha: "1a2b3c4d5e6f", status: " M src/index.ts" });
+    expect(readGitVersion("/src/auto-mobile", run, ownsRepo)).toEqual({ shortSha: "1a2b3c4d5e6f", dirty: true });
   });
 });
 

--- a/test/utils/mcpVersion.test.ts
+++ b/test/utils/mcpVersion.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import {
   formatMcpServerVersion,
+  getMcpServerVersion,
   readGitVersion,
   releaseVersion,
   resolveMcpServerVersion,
@@ -9,7 +10,8 @@ import {
 } from "../../src/utils/mcpVersion";
 import { compareVersions } from "../../src/server/deviceMatcher";
 
-const git = (shortSha: string, dirty = false): GitVersionInfo => ({ shortSha, dirty });
+const git = (shortSha: string, dirty = false, dirtyHash: string | null = null): GitVersionInfo =>
+  ({ shortSha, dirty, dirtyHash });
 
 describe("releaseVersion", () => {
   test("returns the version unchanged when there is no build metadata", () => {
@@ -22,6 +24,15 @@ describe("releaseVersion", () => {
 
   test("strips the dirty marker too", () => {
     expect(releaseVersion("0.0.39+g1a2b3c4d5e6f.dirty")).toBe("0.0.39");
+  });
+
+  test("the value persisted into plan files matches the test-plan schema's mcpVersion pattern", () => {
+    // PlanSerializer writes releaseVersion(getMcpServerVersion()) so a dev build's
+    // `+g<sha>` stamp never reaches the schema gate (^\d+\.\d+\.\d+$), which runs
+    // before plan migration could strip it.
+    const schemaPattern = /^\d+\.\d+\.\d+$/;
+    expect(releaseVersion(getMcpServerVersion())).toMatch(schemaPattern);
+    expect(releaseVersion("0.0.39+g1a2b3c4d5e6f.dirty.abc123def456")).toMatch(schemaPattern);
   });
 });
 
@@ -38,8 +49,13 @@ describe("formatMcpServerVersion", () => {
     expect(formatMcpServerVersion("0.0.39", git("1a2b3c4d5e6f"))).toBe("0.0.39+g1a2b3c4d5e6f");
   });
 
-  test("appends a dirty marker when the working tree is dirty", () => {
+  test("appends a bare dirty marker when no diff hash is available", () => {
     expect(formatMcpServerVersion("0.0.39", git("1a2b3c4d5e6f", true))).toBe("0.0.39+g1a2b3c4d5e6f.dirty");
+  });
+
+  test("includes the tracked-diff hash in the dirty marker when available", () => {
+    expect(formatMcpServerVersion("0.0.39", git("1a2b3c4d5e6f", true, "abc123def456")))
+      .toBe("0.0.39+g1a2b3c4d5e6f.dirty.abc123def456");
   });
 
   test("two different commits yield two different version strings", () => {
@@ -53,13 +69,20 @@ describe("formatMcpServerVersion", () => {
     const dirty = formatMcpServerVersion("0.0.39", git("1a2b3c4d5e6f", true));
     expect(clean).not.toBe(dirty);
   });
+
+  test("two dirty checkouts at the same commit with different edits are distinguished", () => {
+    const a = formatMcpServerVersion("0.0.39", git("1a2b3c4d5e6f", true, "aaaaaaaaaaaa"));
+    const b = formatMcpServerVersion("0.0.39", git("1a2b3c4d5e6f", true, "bbbbbbbbbbbb"));
+    expect(a).not.toBe(b);
+  });
 });
 
 describe("formatMcpServerVersion + the daemon version gate", () => {
   // The stamp is semver build metadata: it makes the *string* vary with the
   // commit (for doctor/logs/DaemonVersionMismatchError diagnostics) while the
   // release portion before `+` stays stable. The version gate compares the
-  // release portion and defers same-release dev-skew to the build-identity gate.
+  // release portion for newer/older decisions and treats a same-release/
+  // different-stamp difference as a reconcilable dev-skew (restart, not throw).
   test("stamped dev builds share the same release portion (gate treats them as same-release)", () => {
     const a = formatMcpServerVersion("0.0.39", git("aaaaaaaaaaaa"));
     const b = formatMcpServerVersion("0.0.39", git("bbbbbbbbbbbb"));
@@ -90,6 +113,7 @@ describe("readGitVersion", () => {
       if (args[0] === "rev-parse" && args[1] === "--show-toplevel") {return responses.toplevel ?? null;}
       if (args[0] === "rev-parse" && args[1] === "--short=12") {return responses.sha ?? null;}
       if (args[0] === "status") {return responses.status ?? null;}
+      if (args[0] === "diff") {return responses.diff ?? null;}
       return null;
     };
   const ownsRepo = () => OWN;
@@ -119,12 +143,40 @@ describe("readGitVersion", () => {
 
   test("stamps a clean checkout of AutoMobile's own repo", () => {
     const run = fakeRun({ toplevel: "/src/auto-mobile", sha: "1a2b3c4d5e6f", status: "" });
-    expect(readGitVersion("/src/auto-mobile", run, ownsRepo)).toEqual({ shortSha: "1a2b3c4d5e6f", dirty: false });
+    expect(readGitVersion("/src/auto-mobile", run, ownsRepo)).toEqual({
+      shortSha: "1a2b3c4d5e6f",
+      dirty: false,
+      dirtyHash: null,
+    });
   });
 
-  test("marks the checkout dirty when there are tracked changes", () => {
-    const run = fakeRun({ toplevel: "/src/auto-mobile", sha: "1a2b3c4d5e6f", status: " M src/index.ts" });
-    expect(readGitVersion("/src/auto-mobile", run, ownsRepo)).toEqual({ shortSha: "1a2b3c4d5e6f", dirty: true });
+  test("marks the checkout dirty and hashes the tracked diff", () => {
+    const run = fakeRun({
+      toplevel: "/src/auto-mobile",
+      sha: "1a2b3c4d5e6f",
+      status: " M src/index.ts",
+      diff: "diff --git a/src/index.ts b/src/index.ts\n+console.log('a')",
+    });
+    const result = readGitVersion("/src/auto-mobile", run, ownsRepo);
+    expect(result?.shortSha).toBe("1a2b3c4d5e6f");
+    expect(result?.dirty).toBe(true);
+    expect(result?.dirtyHash).toMatch(/^[0-9a-f]{12}$/);
+  });
+
+  test("two different dirty diffs produce different dirty hashes", () => {
+    const base = { toplevel: "/src/auto-mobile", sha: "1a2b3c4d5e6f", status: " M src/index.ts" };
+    const a = readGitVersion("/src/auto-mobile", fakeRun({ ...base, diff: "edit A" }), ownsRepo);
+    const b = readGitVersion("/src/auto-mobile", fakeRun({ ...base, diff: "edit B" }), ownsRepo);
+    expect(a?.dirtyHash).not.toBe(b?.dirtyHash);
+  });
+
+  test("falls back to a bare dirty marker when the diff is unavailable", () => {
+    const run = fakeRun({ toplevel: "/src/auto-mobile", sha: "1a2b3c4d5e6f", status: " M x", diff: null });
+    expect(readGitVersion("/src/auto-mobile", run, ownsRepo)).toEqual({
+      shortSha: "1a2b3c4d5e6f",
+      dirty: true,
+      dirtyHash: null,
+    });
   });
 });
 

--- a/test/utils/plan/PlanMigrator.test.ts
+++ b/test/utils/plan/PlanMigrator.test.ts
@@ -1,7 +1,41 @@
 import { describe, expect, test } from "bun:test";
 import { migratePlan } from "../../../src/utils/plan/PlanMigrator";
+import { getMcpServerVersion, releaseVersion } from "../../../src/utils/mcpVersion";
 
 describe("PlanMigrator", () => {
+  describe("version metadata (dev-build SHA stamp)", () => {
+    // Regression: dev builds report a git-SHA-stamped version (`0.0.39+g<sha>[.dirty]`).
+    // The runtime target version is stamped, and PlanSerializer persists the same
+    // stamped string into a plan's mcpVersion. parseVersion must strip the metadata
+    // or the SHA's hex digits corrupt the patch number and `.dirty` → NaN → the plan
+    // is falsely reported outdated.
+    test("a plan at the current release is not falsely reported outdated under a dev-stamped runtime", () => {
+      const currentRelease = releaseVersion(getMcpServerVersion());
+      const { report } = migratePlan({
+        mcpVersion: currentRelease,
+        steps: [{ tool: "observe", params: {} }],
+      });
+      expect(report.outdated).toBe(false);
+    });
+
+    test("a plan written by a dev build (stamped mcpVersion) at the current release is not outdated", () => {
+      const currentRelease = releaseVersion(getMcpServerVersion());
+      const { report } = migratePlan({
+        mcpVersion: `${currentRelease}+g1a2b3c4d5e6f.dirty`,
+        steps: [{ tool: "observe", params: {} }],
+      });
+      expect(report.outdated).toBe(false);
+    });
+
+    test("a genuinely older release version is still reported outdated", () => {
+      const { report } = migratePlan({
+        mcpVersion: "0.0.1",
+        steps: [{ tool: "observe", params: {} }],
+      });
+      expect(report.outdated).toBe(true);
+    });
+  });
+
   describe("migratePlan", () => {
     test("throws for non-object input", () => {
       expect(() => migratePlan("not an object")).toThrow("Plan is not a valid object");


### PR DESCRIPTION
## Summary
Pre-release builds all report the same `package.json` version (`0.0.39`), so the daemon version gate (`DaemonMcpProxy.ensureVersionMatches()`) and every version-based diagnostic (`doctor`, logs, `DaemonVersionMismatchError`) are blind to dev-build skew between two checkouts (#2732). This stamps a git short SHA (+ dirty marker) into the version string for **source checkouts** so the reported version varies with the commit, while **release installs are unchanged**.

Belt-and-suspenders to the content-hash build identity from #2733: that gate already detects + self-heals wrong-build daemons; this makes the *version string itself* meaningful for dev builds.

## Changes
- **`src/utils/mcpVersion.ts`** — `getMcpServerVersion()` resolves a base version (explicit `MCP_SERVER_VERSION` override > `npm_package_version` > `package.json`) and, for a source checkout, appends `+g<shortSha>[.dirty]`. Refactored into pure, injectable pieces:
  - `formatMcpServerVersion(base, git)` — pure formatter (no git → unchanged).
  - `resolveMcpServerVersion(deps)` — pure resolution with injected env/package/git readers.
  - `readGitVersion(cwd)` — one-time `git rev-parse --short=12 HEAD` + tracked-only dirty check; returns `null` (→ unstamped) when git is absent. **Skips any `node_modules` location** so a published package nested inside a host git repo is never stamped with the host's commit.
- **`src/daemon/daemonMcpProxy.ts`**
  - `ensureVersionMatches()` compares only the **release portion** (`baseVersion()` strips `+…` metadata) and **defers** same-release dev-skew (`0.0.39+gAAA` vs `0.0.39+gBBB`) to the build-identity gate (`ensureBuildMatches`, #2733) instead of hard-throwing `nonNumeric` — preserving #2733's restart/self-heal.
  - `DaemonVersionMismatchError` restart hint strips build metadata (a `+`-stamped version is not an installable npm tag): `bunx @kaeawc/auto-mobile@0.0.39 --daemon restart`.
  - Added injectable `clientVersion` to `DaemonMcpProxyConfig` (decouples the gate tests from the ambient stamped `DAEMON_VERSION`).

## Acceptance check
- Dev build (this checkout): `getMcpServerVersion()` → `0.0.39+gec6f9cee8444.dirty` ✓ (varies with commit)
- Release build (no git / `node_modules`): `0.0.39` unchanged ✓
- `MCP_SERVER_VERSION` override returned verbatim ✓

## Test plan
- New `test/utils/mcpVersion.test.ts` — pure unit tests for formatter, resolver, release detection (no git/network).
- `test/daemon/daemonMcpProxy.test.ts` — restart-hint metadata stripping; dev-skew **defers** to the build gate (does not restart/throw); existing version-gate suite pinned to a plain injected `clientVersion`.
- `test/daemon/integration/versionMismatchRestart.test.ts` — pinned client version for the numeric-comparison path.
- `bun test` → 5264 pass, 0 fail. `turbo run lint build` → green.

Refs #2732, #2733
Closes #2738
