### PR TITLE
chore: bump versions to v0.0.40

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -14,7 +14,7 @@
       "name": "auto-mobile",
       "source": "./.claude-plugin",
       "description": "Mobile device automation for Android and iOS - control devices with natural language",
-      "version": "0.0.39",
+      "version": "0.0.40",
       "author": {
         "name": "AutoMobile Contributors",
         "email": "jason.d.pearson@gmail.com"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "auto-mobile",
   "description": "Mobile device automation for Android and iOS - control devices with natural language",
-  "version": "0.0.39",
+  "version": "0.0.40",
   "author": {
     "name": "AutoMobile Contributors",
     "email": "jason.d.pearson@gmail.com"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,31 @@
 # Changelog
 
+## [v0.0.40] - 2026-06-30
+### Added
+- Cross-platform tool to read/write app preferences (adb prop / SharedPreferences / iOS UserDefaults) ([#2714](https://github.com/kaeawc/auto-mobile/issues/2714))
+- install.sh should detect and help install the required Android SDK platform (compileSdk) ([#2680](https://github.com/kaeawc/auto-mobile/issues/2680))
+### Fixed
+- doctor reports all-green while iOS observe is broken (no client↔runner round-trip check) ([#2693](https://github.com/kaeawc/auto-mobile/issues/2693))
+- iOS CtrlProxy forced-restart recovery should use PortManager to clear processes bound to the target port ([#2692](https://github.com/kaeawc/auto-mobile/issues/2692))
+- iOS CtrlProxy port management collides with adb; client and runner ports diverge ([#2691](https://github.com/kaeawc/auto-mobile/issues/2691))
+### Other
+- Stamp git SHA into pre-release daemon version so the version gate distinguishes dev builds ([#2738](https://github.com/kaeawc/auto-mobile/issues/2738))
+- Verify build-mismatch daemon restart doesn't worsen the #2599 session-wedge for sibling MCP sessions ([#2737](https://github.com/kaeawc/auto-mobile/issues/2737))
+- doctor: surface daemon build identity (entryScript / buildId) to spot wrong-build skew ([#2736](https://github.com/kaeawc/auto-mobile/issues/2736))
+- doctor: iOS round-trip check can't detect runner/client port mismatch ([#2735](https://github.com/kaeawc/auto-mobile/issues/2735))
+- fix(ios): simulator runner ignores allocated port (binds 8765) when Android is connected → client/runner port mismatch, all iOS ops fail ([#2731](https://github.com/kaeawc/auto-mobile/issues/2731))
+- Daemon log file is unlinked by bunx temp-dir cleanup; on-disk logs end up empty ([#2724](https://github.com/kaeawc/auto-mobile/issues/2724))
+- openLink times out at 30s on slow deeplinks, then logs success=true after the timeout ([#2723](https://github.com/kaeawc/auto-mobile/issues/2723))
+- Emulator launches windowed by default; aborts with opaque "code: null" on headless hosts ([#2722](https://github.com/kaeawc/auto-mobile/issues/2722))
+- Headless daemon start fails 10s budget: open -a Simulator → OSLaunchdErrorDomain Code=125 in no-GUI launchd session ([#2721](https://github.com/kaeawc/auto-mobile/issues/2721))
+- Remove heapdump native addon dependency for Node 26 compatibility ([#2719](https://github.com/kaeawc/auto-mobile/issues/2719))
+- iOS CtrlProxy reconnect cooldown is very long (~137s) and observe gives no 'reconnecting' signal ([#2695](https://github.com/kaeawc/auto-mobile/issues/2695))
+- Demote/clarify WARN: 'Failed to read simulator app bundle for ...XCTestServiceApp' during iOS setup ([#2694](https://github.com/kaeawc/auto-mobile/issues/2694))
+- iOS CtrlProxy runner reports 320x480 screen (missing launch screen) instead of real device size ([#2683](https://github.com/kaeawc/auto-mobile/issues/2683))
+- iOS highlight (SDK path): verify/fix coordinate scaling so highlights land on the correct element ([#2682](https://github.com/kaeawc/auto-mobile/issues/2682))
+- iOS highlight: remove non-SDK runner-overlay fallback and report honestly that it requires the AutoMobile SDK ([#2681](https://github.com/kaeawc/auto-mobile/issues/2681))
+- doctor: add iOS CtrlProxy runner check so iOS gives the same certain feedback as Android ([#2678](https://github.com/kaeawc/auto-mobile/issues/2678))
+
 ## [Unreleased]
 ### Fixed
 - iOS `highlight`: remove the non-functional runner-overlay fallback and report honestly that highlighting requires the in-app AutoMobile SDK ([#2681](https://github.com/kaeawc/auto-mobile/issues/2681)) (ios)

--- a/android/control-proxy/build.gradle.kts
+++ b/android/control-proxy/build.gradle.kts
@@ -36,7 +36,7 @@ android {
     minSdk = libs.versions.build.android.minSdk.get().toInt()
     targetSdk = libs.versions.build.android.targetSdk.get().toInt()
     versionCode = 1
-    versionName = "0.0.39-SNAPSHOT"
+    versionName = "0.0.40-SNAPSHOT"
 
     testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
   }

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -140,7 +140,7 @@ org.jetbrains.dokka.experimental.gradle.pluginMode=V2Enabled
 # Maven Central Publishing
 
 # Library versions (single source of truth)
-VERSION_NAME=0.0.39-SNAPSHOT
+VERSION_NAME=0.0.40-SNAPSHOT
 GROUP=dev.jasonpearson.auto-mobile
 
 # POM metadata

--- a/android/playground/app/build.gradle.kts
+++ b/android/playground/app/build.gradle.kts
@@ -36,7 +36,7 @@ android {
     minSdk = libs.versions.build.android.minSdk.get().toInt()
     targetSdk = libs.versions.build.android.targetSdk.get().toInt()
     versionCode = 1
-    versionName = "0.0.39-SNAPSHOT"
+    versionName = "0.0.40-SNAPSHOT"
 
     testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kaeawc/auto-mobile",
-  "version": "0.0.39",
+  "version": "0.0.40",
   "description": "Mobile device interaction automation via MCP",
   "scripts": {
     "test": "bun test",

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "dev.jasonpearson/auto-mobile",
   "title": "AutoMobile",
   "description": "Mobile device interaction automation via MCP",
-  "version": "0.0.39",
+  "version": "0.0.40",
   "websiteUrl": "https://kaeawc.github.io/auto-mobile/",
   "repository": {
     "url": "https://github.com/kaeawc/auto-mobile",
@@ -13,7 +13,7 @@
     {
       "registryType": "npm",
       "identifier": "@kaeawc/auto-mobile",
-      "version": "0.0.39",
+      "version": "0.0.40",
       "runtimeHint": "bunx",
       "transport": {
         "type": "stdio"

--- a/src/constants/release.ts
+++ b/src/constants/release.ts
@@ -26,6 +26,11 @@ export interface ReleaseChecksumEntry {
  */
 export const RELEASE_CHECKSUM_REGISTRY: ReleaseChecksumEntry[] = [
   {
+    version: "0.0.40",
+    apkSha256: "8e89fbab6462ac1ead1f3f0a334aff4f5f299e7ae72e192045cf75e893ca87aa",
+    ipaSha256: "38adaed641ac6a8590773682e127a80a86c54e5804d47394e1b0cd437009b9ff",
+  },
+  {
     version: "0.0.39",
     apkSha256: "eaad59dd85e17c4633098b772b9f761f2124ffb73a5ca7ede703a9b435046942",
     ipaSha256: "87a720544c83718e5b70c987aecf30d2e43bdb0f23163ac75ac225bb4aec0ae4",


### PR DESCRIPTION
## Summary
- Bump versions to v0.0.40
- Update CHANGELOG.md from closed issues since the last tag
- Refresh CtrlProxy APK SHA256 checksum
- Refresh CtrlProxy iOS IPA SHA256 checksum

## Automation
- Generated by `prepare-release` workflow