### PR TITLE
fix(release): wire iOS runner checksum + add version-equality release gate

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -57,10 +57,13 @@ jobs:
         run: |
           APK_CURRENT=$(grep 'apkSha256' src/constants/release.ts | head -1 | sed 's/.*"\([a-f0-9]\{64\}\)".*/\1/')
           IPA_CURRENT=$(grep 'ipaSha256' src/constants/release.ts | head -1 | sed 's/.*"\([a-f0-9]\{64\}\)".*/\1/')
+          RUNNER_CURRENT=$(grep '^export const IOS_CTRL_PROXY_RUNNER_SHA256' src/constants/release.ts | sed 's/.*= "\([a-f0-9]*\)".*/\1/')
           echo "apk_sha256=$APK_CURRENT" >> $GITHUB_OUTPUT
           echo "ipa_sha256=$IPA_CURRENT" >> $GITHUB_OUTPUT
+          echo "runner_sha256=$RUNNER_CURRENT" >> $GITHUB_OUTPUT
           echo "Current APK SHA256: ${APK_CURRENT:-(empty)}"
           echo "Current IPA SHA256: ${IPA_CURRENT:-(empty)}"
+          echo "Current runner SHA256: ${RUNNER_CURRENT:-(empty)}"
 
       - name: "Check if updates needed"
         id: check
@@ -69,9 +72,12 @@ jobs:
           OLD_APK="${{ steps.current.outputs.apk_sha256 }}"
           NEW_IPA="${{ needs.build-ctrl-proxy-ios-ipa.outputs.sha256 }}"
           OLD_IPA="${{ steps.current.outputs.ipa_sha256 }}"
+          NEW_RUNNER="${{ needs.build-ctrl-proxy-ios-ipa.outputs.runner_sha256 }}"
+          OLD_RUNNER="${{ steps.current.outputs.runner_sha256 }}"
 
           APK_CHANGED="false"
           IPA_CHANGED="false"
+          RUNNER_CHANGED="false"
 
           if [ "$NEW_APK" != "$OLD_APK" ]; then
             APK_CHANGED="true"
@@ -91,10 +97,24 @@ jobs:
             echo "IPA SHA256 unchanged"
           fi
 
+          # The runner binary lives inside the IPA, so a runner change usually
+          # also changes the IPA sha — but detect it independently so an empty
+          # or stale runner sha (e.g. a registry entry cut before the runner-sha
+          # wiring) is backfilled even when the IPA is byte-identical.
+          if [ "$NEW_RUNNER" != "$OLD_RUNNER" ]; then
+            RUNNER_CHANGED="true"
+            echo "Runner SHA256 changed"
+            echo "  Previous: ${OLD_RUNNER:-(empty)}"
+            echo "  New:      $NEW_RUNNER"
+          else
+            echo "Runner SHA256 unchanged"
+          fi
+
           echo "apk_changed=$APK_CHANGED" >> $GITHUB_OUTPUT
           echo "ipa_changed=$IPA_CHANGED" >> $GITHUB_OUTPUT
+          echo "runner_changed=$RUNNER_CHANGED" >> $GITHUB_OUTPUT
 
-          if [ "$APK_CHANGED" = "true" ] || [ "$IPA_CHANGED" = "true" ]; then
+          if [ "$APK_CHANGED" = "true" ] || [ "$IPA_CHANGED" = "true" ] || [ "$RUNNER_CHANGED" = "true" ]; then
             echo "needed=true" >> $GITHUB_OUTPUT
           else
             echo "needed=false" >> $GITHUB_OUTPUT

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -105,6 +105,7 @@ jobs:
         env:
           APK_SHA256_CHECKSUM: ${{ needs.build-control-proxy-apk.outputs.sha256 }}
           IOS_CTRL_PROXY_SHA256_CHECKSUM: ${{ needs.build-ctrl-proxy-ios-ipa.outputs.sha256 }}
+          IOS_CTRL_PROXY_RUNNER_SHA256: ${{ needs.build-ctrl-proxy-ios-ipa.outputs.runner_sha256 }}
         run: bash scripts/generate-release-constants.sh
 
       - name: "Build PR title"

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -94,6 +94,7 @@ jobs:
         run: >
           bash scripts/ci/verify-release-integrity.sh
           "${{ inputs.version }}"
+          /tmp/control-proxy.ipa
 
       - name: Create pull request
         id: create_pr

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -86,7 +86,14 @@ jobs:
           APK_SHA256_CHECKSUM: ${{ steps.checksum.outputs.apk_sha256 }}
           IOS_CTRL_PROXY_SHA256_CHECKSUM:
             ${{ steps.checksum.outputs.ipa_sha256 }}
+          IOS_CTRL_PROXY_RUNNER_SHA256:
+            ${{ needs.build-ctrl-proxy-ios-ipa.outputs.runner_sha256 }}
         run: bash scripts/generate-release-constants.sh
+
+      - name: Verify release integrity
+        run: >
+          bash scripts/ci/verify-release-integrity.sh
+          "${{ inputs.version }}"
 
       - name: Create pull request
         id: create_pr

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -101,6 +101,7 @@ jobs:
         run: >
           bash scripts/ci/verify-release-integrity.sh
           "${{ steps.version.outputs.version }}"
+          /tmp/control-proxy.ipa
 
       - name: Run tests
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -93,7 +93,14 @@ jobs:
           APK_SHA256_CHECKSUM: ${{ steps.verify_checksum.outputs.checksum }}
           IOS_CTRL_PROXY_SHA256_CHECKSUM:
             ${{ steps.verify_ipa_checksum.outputs.checksum }}
+          IOS_CTRL_PROXY_RUNNER_SHA256:
+            ${{ needs.build-ctrl-proxy-ios-ipa.outputs.runner_sha256 }}
         run: bash scripts/generate-release-constants.sh
+
+      - name: Verify release integrity
+        run: >
+          bash scripts/ci/verify-release-integrity.sh
+          "${{ steps.version.outputs.version }}"
 
       - name: Run tests
         env:

--- a/android/junit-runner/build.gradle.kts
+++ b/android/junit-runner/build.gradle.kts
@@ -16,7 +16,11 @@ java {
   withSourcesJar()
 }
 
-// Version comes from root project's gradle.properties (VERSION_NAME)
+// The jar's Implementation-Version tracks the npm package version (package.json),
+// the canonical release version. The Maven publish coordinate, by contrast, uses
+// the Gradle `version` (VERSION_NAME in gradle.properties, normalized to the tag
+// via -PVERSION_NAME=<version> at release). scripts/ci/verify-release-integrity.sh
+// asserts these stay in lockstep so source/local builds can't diverge.
 val npmPackageVersion =
     providers.fileContents(rootProject.layout.projectDirectory.file("../package.json")).asText.map { packageJson ->
       val parsed = JsonSlurper().parseText(packageJson) as Map<*, *>

--- a/android/junit-runner/build.gradle.kts
+++ b/android/junit-runner/build.gradle.kts
@@ -18,9 +18,12 @@ java {
 
 // The jar's Implementation-Version tracks the npm package version (package.json),
 // the canonical release version. The Maven publish coordinate, by contrast, uses
-// the Gradle `version` (VERSION_NAME in gradle.properties, normalized to the tag
-// via -PVERSION_NAME=<version> at release). scripts/ci/verify-release-integrity.sh
-// asserts these stay in lockstep so source/local builds can't diverge.
+// the Gradle `version` (VERSION_NAME in gradle.properties), which carries a
+// -SNAPSHOT suffix locally and is normalized to the tag via -PVERSION_NAME at
+// release. So a plain local `:junit-runner:jar` still yields Implementation-Version
+// 0.0.40 with a 0.0.40-SNAPSHOT coordinate — that suffix is intentional. At
+// release, scripts/ci/verify-release-integrity.sh asserts the SNAPSHOT-stripped
+// base version here matches package.json and the git tag.
 val npmPackageVersion =
     providers.fileContents(rootProject.layout.projectDirectory.file("../package.json")).asText.map { packageJson ->
       val parsed = JsonSlurper().parseText(packageJson) as Map<*, *>

--- a/scripts/ci/verify-release-integrity.sh
+++ b/scripts/ci/verify-release-integrity.sh
@@ -47,28 +47,45 @@ check() {
   fi
 }
 
+# Extract a JSON field, failing the whole gate loudly (clean message, no python
+# traceback) if the file is malformed or the field is missing — a swallowed
+# extraction would otherwise surface only as a confusing "expected X, got ''".
 json_field() {
   # $1 = file, $2 = python expression evaluated against `d` (parsed JSON)
-  python3 -c 'import json,sys; d=json.load(open(sys.argv[1])); print(eval(sys.argv[2]))' "$1" "$2"
+  python3 -c 'import json,sys
+try:
+    d = json.load(open(sys.argv[1]))
+    print(eval(sys.argv[2]))
+except Exception as exc:
+    sys.stderr.write(f"failed to read {sys.argv[2]} from {sys.argv[1]}: {exc}\n")
+    sys.exit(1)' "$1" "$2"
 }
 
-check "package.json version" "$(json_field "$PACKAGE_JSON" 'd["version"]')"
-check ".claude-plugin/plugin.json version" "$(json_field "$PLUGIN_JSON" 'd["version"]')"
-check ".claude-plugin/marketplace.json plugins[0].version" \
-  "$(json_field "$MARKETPLACE_JSON" 'd["plugins"][0]["version"]')"
-check "server.json version" "$(json_field "$SERVER_JSON" 'd["version"]')"
+pkg_version="$(json_field "$PACKAGE_JSON" 'd["version"]')" || exit 1
+check "package.json version" "$pkg_version"
+plugin_version="$(json_field "$PLUGIN_JSON" 'd["version"]')" || exit 1
+check ".claude-plugin/plugin.json version" "$plugin_version"
+marketplace_version="$(json_field "$MARKETPLACE_JSON" 'd["plugins"][0]["version"]')" || exit 1
+check ".claude-plugin/marketplace.json plugins[0].version" "$marketplace_version"
+server_version="$(json_field "$SERVER_JSON" 'd["version"]')" || exit 1
+check "server.json version" "$server_version"
 
-while IFS= read -r pkg_version; do
-  check "server.json packages[].version" "$pkg_version"
-done < <(python3 -c 'import json,sys
-d=json.load(open(sys.argv[1]))
-for p in d.get("packages", []):
-    print(p["version"])' "$SERVER_JSON")
+server_packages="$(python3 -c 'import json,sys
+try:
+    d = json.load(open(sys.argv[1]))
+    for p in d.get("packages", []):
+        print(p["version"])
+except Exception as exc:
+    sys.stderr.write(f"failed to read packages from {sys.argv[1]}: {exc}\n")
+    sys.exit(1)' "$SERVER_JSON")" || exit 1
+while IFS= read -r pkg_ver; do
+  [ -n "$pkg_ver" ] && check "server.json packages[].version" "$pkg_ver"
+done <<< "$server_packages"
 
 # gradle.properties keeps a -SNAPSHOT suffix for dev/Maven coordinates; the
 # release coordinate is overridden with -PVERSION_NAME at publish. Only the base
-# version participates in equality.
-gradle_version="$(grep -E '^VERSION_NAME=' "$GRADLE_PROPS" | head -1 | cut -d= -f2)"
+# version participates in equality. (tr strips a stray CR from CRLF checkouts.)
+gradle_version="$(grep -E '^VERSION_NAME=' "$GRADLE_PROPS" | head -1 | cut -d= -f2 | tr -d '\r')"
 check "android/gradle.properties VERSION_NAME (base)" "${gradle_version%-SNAPSHOT}"
 
 registry_version="$(grep -m1 -E '^[[:space:]]+version: "' "$RELEASE_TS" \

--- a/scripts/ci/verify-release-integrity.sh
+++ b/scripts/ci/verify-release-integrity.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+# Verify release integrity before publishing.
+#
+# Two independent gaps this gate closes (see issue #2745):
+#   1. Version equality — the npm version, every release manifest, the checksum
+#      registry, and the git tag must all name the SAME version. Nothing else
+#      enforces this; bump-versions.sh merely writes them together.
+#   2. iOS runner-binary checksum — IOS_CTRL_PROXY_RUNNER_SHA256 must be a real
+#      sha256, not the "" default. Empty silently disables runner integrity
+#      verification for the simulator path.
+#
+# package.json is the canonical version source; every other value is checked
+# against the <version> argument (the git tag), which prepare-release keeps
+# equal to package.json.
+#
+# Usage: verify-release-integrity.sh <version>
+#   <version> is the release version / git tag. A leading "v" is stripped.
+set -euo pipefail
+
+RAW_VERSION="${1:?Usage: verify-release-integrity.sh <version>}"
+EXPECTED="${RAW_VERSION#v}"
+
+PACKAGE_JSON="package.json"
+PLUGIN_JSON=".claude-plugin/plugin.json"
+MARKETPLACE_JSON=".claude-plugin/marketplace.json"
+SERVER_JSON="server.json"
+GRADLE_PROPS="android/gradle.properties"
+RELEASE_TS="src/constants/release.ts"
+
+for f in "$PACKAGE_JSON" "$PLUGIN_JSON" "$MARKETPLACE_JSON" "$SERVER_JSON" \
+  "$GRADLE_PROPS" "$RELEASE_TS"; do
+  if [ ! -f "$f" ]; then
+    echo "ERROR: required file not found: $f"
+    exit 1
+  fi
+done
+
+errors=()
+
+# check <label> <actual-version>
+check() {
+  local label="$1" actual="$2"
+  if [ "$actual" != "$EXPECTED" ]; then
+    errors+=("${label}: expected '${EXPECTED}', got '${actual}'")
+  else
+    echo "  OK  ${label} = ${actual}"
+  fi
+}
+
+json_field() {
+  # $1 = file, $2 = python expression evaluated against `d` (parsed JSON)
+  python3 -c 'import json,sys; d=json.load(open(sys.argv[1])); print(eval(sys.argv[2]))' "$1" "$2"
+}
+
+check "package.json version" "$(json_field "$PACKAGE_JSON" 'd["version"]')"
+check ".claude-plugin/plugin.json version" "$(json_field "$PLUGIN_JSON" 'd["version"]')"
+check ".claude-plugin/marketplace.json plugins[0].version" \
+  "$(json_field "$MARKETPLACE_JSON" 'd["plugins"][0]["version"]')"
+check "server.json version" "$(json_field "$SERVER_JSON" 'd["version"]')"
+
+while IFS= read -r pkg_version; do
+  check "server.json packages[].version" "$pkg_version"
+done < <(python3 -c 'import json,sys
+d=json.load(open(sys.argv[1]))
+for p in d.get("packages", []):
+    print(p["version"])' "$SERVER_JSON")
+
+# gradle.properties keeps a -SNAPSHOT suffix for dev/Maven coordinates; the
+# release coordinate is overridden with -PVERSION_NAME at publish. Only the base
+# version participates in equality.
+gradle_version="$(grep -E '^VERSION_NAME=' "$GRADLE_PROPS" | head -1 | cut -d= -f2)"
+check "android/gradle.properties VERSION_NAME (base)" "${gradle_version%-SNAPSHOT}"
+
+registry_version="$(grep -m1 -E '^[[:space:]]+version: "' "$RELEASE_TS" \
+  | sed 's/.*version: "\([^"]*\)".*/\1/')"
+check "src/constants/release.ts registry[0].version" "$registry_version"
+
+# Runner-binary checksum must be populated. Empty ("" default) means integrity
+# verification is silently skipped — exactly the gap this gate exists to catch.
+runner_sha="$(grep -E '^export const IOS_CTRL_PROXY_RUNNER_SHA256' "$RELEASE_TS" \
+  | sed 's/.*= "\([^"]*\)".*/\1/')"
+if [[ "$runner_sha" =~ ^[a-f0-9]{64}$ ]]; then
+  echo "  OK  IOS_CTRL_PROXY_RUNNER_SHA256 populated"
+else
+  errors+=("IOS_CTRL_PROXY_RUNNER_SHA256 must be a 64-char hex sha256, got '${runner_sha}' (empty disables runner integrity verification)")
+fi
+
+if [ "${#errors[@]}" -gt 0 ]; then
+  echo ""
+  echo "ERROR: release integrity check failed for version '${EXPECTED}':"
+  for e in "${errors[@]}"; do
+    echo "  - ${e}"
+  done
+  echo ""
+  echo "All manifests + the checksum registry + the git tag must name the same"
+  echo "version, and the iOS runner checksum must be populated, before releasing."
+  exit 1
+fi
+
+echo ""
+echo "Release integrity verified for version ${EXPECTED}."

--- a/scripts/ci/verify-release-integrity.sh
+++ b/scripts/ci/verify-release-integrity.sh
@@ -13,12 +13,18 @@
 # against the <version> argument (the git tag), which prepare-release keeps
 # equal to package.json.
 #
-# Usage: verify-release-integrity.sh <version>
-#   <version> is the release version / git tag. A leading "v" is stripped.
+# Usage: verify-release-integrity.sh <version> [ipa-path]
+#   <version>  release version / git tag. A leading "v" is stripped.
+#   [ipa-path] optional built control-proxy.ipa. When given, the runner binary is
+#              hashed straight out of the IPA and required to match the recorded
+#              IOS_CTRL_PROXY_RUNNER_SHA256 — this *binds* the constant to the
+#              artifact that ships. Without it, only the syntactic (64-hex,
+#              non-empty) floor is checked.
 set -euo pipefail
 
-RAW_VERSION="${1:?Usage: verify-release-integrity.sh <version>}"
+RAW_VERSION="${1:?Usage: verify-release-integrity.sh <version> [ipa-path]}"
 EXPECTED="${RAW_VERSION#v}"
+IPA_PATH="${2:-}"
 
 PACKAGE_JSON="package.json"
 PLUGIN_JSON=".claude-plugin/plugin.json"
@@ -96,8 +102,37 @@ check "src/constants/release.ts registry[0].version" "$registry_version"
 # verification is silently skipped — exactly the gap this gate exists to catch.
 runner_sha="$(grep -E '^export const IOS_CTRL_PROXY_RUNNER_SHA256' "$RELEASE_TS" \
   | sed 's/.*= "\([^"]*\)".*/\1/')"
-if [[ "$runner_sha" =~ ^[a-f0-9]{64}$ ]]; then
-  echo "  OK  IOS_CTRL_PROXY_RUNNER_SHA256 populated"
+
+sha256_stdin() {
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum | cut -d' ' -f1
+  else
+    shasum -a 256 | cut -d' ' -f1
+  fi
+}
+
+if [ -n "$IPA_PATH" ]; then
+  # Bind the recorded sha to the runner binary inside the shipped IPA (a zip of
+  # Build/Products), so this proves the constant matches what actually ships —
+  # not merely that some 64-hex string was written.
+  if [ ! -f "$IPA_PATH" ]; then
+    errors+=("runner-sha binding: IPA not found at ${IPA_PATH}")
+  else
+    runner_entry="$(unzip -Z1 "$IPA_PATH" 2>/dev/null \
+      | grep -E 'CtrlProxyUITests-Runner\.app/CtrlProxyUITests-Runner$' | head -1 || true)"
+    if [ -z "$runner_entry" ]; then
+      errors+=("runner-sha binding: CtrlProxyUITests-Runner not found inside ${IPA_PATH}")
+    else
+      actual_runner_sha="$(unzip -p "$IPA_PATH" "$runner_entry" | sha256_stdin)"
+      if [ "$runner_sha" = "$actual_runner_sha" ]; then
+        echo "  OK  IOS_CTRL_PROXY_RUNNER_SHA256 matches the runner inside the IPA"
+      else
+        errors+=("IOS_CTRL_PROXY_RUNNER_SHA256 ('${runner_sha:-empty}') does not match the runner binary shipped in ${IPA_PATH} ('${actual_runner_sha}')")
+      fi
+    fi
+  fi
+elif [[ "$runner_sha" =~ ^[a-f0-9]{64}$ ]]; then
+  echo "  OK  IOS_CTRL_PROXY_RUNNER_SHA256 populated (syntactic; pass the IPA path to bind it)"
 else
   errors+=("IOS_CTRL_PROXY_RUNNER_SHA256 must be a 64-char hex sha256, got '${runner_sha}' (empty disables runner integrity verification)")
 fi

--- a/scripts/generate-release-constants.sh
+++ b/scripts/generate-release-constants.sh
@@ -104,35 +104,39 @@ if [ -n "$release_version" ]; then
   fi
 
   if grep -q "version: \"${release_version}\"" "$constants_path"; then
-    echo "INFO: Version ${release_version} already exists in registry — skipping"
-    exit 0
-  fi
-
-  new_entry="  {
+    # Version already registered — do NOT duplicate the entry, but fall through
+    # to the scalar-constant updates below (app hash / runner sha). The release
+    # job re-runs this after prepare-release already added the entry; skipping
+    # entirely would leave IOS_CTRL_PROXY_RUNNER_SHA256 empty (verification
+    # disabled) whenever prepare-release predates the runner-sha wiring.
+    echo "INFO: Version ${release_version} already in registry — refreshing scalar constants only"
+  else
+    new_entry="  {
     version: \"${release_version}\",
     apkSha256: \"${apk_checksum}\",
     ipaSha256: \"${ios_checksum}\",
   },"
 
-  # Prepend new entry after the opening bracket of RELEASE_CHECKSUM_REGISTRY
-  prepend_registry_entry "$tmp_file" "$new_entry"
+    # Prepend new entry after the opening bracket of RELEASE_CHECKSUM_REGISTRY
+    prepend_registry_entry "$tmp_file" "$new_entry"
 
-  # Cap registry at max_registry_entries
-  entry_count=$(grep -c 'version: "' "$tmp_file" || true)
-  if [ "$entry_count" -gt "$max_registry_entries" ]; then
-    excess=$((entry_count - max_registry_entries))
-    for ((i = 0; i < excess; i++)); do
-      last_version_line=$(grep -n 'version: "' "$tmp_file" | tail -1 | cut -d: -f1)
-      start_line=$((last_version_line - 1))
-      end_line=$((last_version_line + 3))
-      sed_inplace "${start_line},${end_line}d" "$tmp_file"
-    done
+    # Cap registry at max_registry_entries
+    entry_count=$(grep -c 'version: "' "$tmp_file" || true)
+    if [ "$entry_count" -gt "$max_registry_entries" ]; then
+      excess=$((entry_count - max_registry_entries))
+      for ((i = 0; i < excess; i++)); do
+        last_version_line=$(grep -n 'version: "' "$tmp_file" | tail -1 | cut -d: -f1)
+        start_line=$((last_version_line - 1))
+        end_line=$((last_version_line + 3))
+        sed_inplace "${start_line},${end_line}d" "$tmp_file"
+      done
+    fi
+
+    echo "Updated release constants:"
+    echo "   Added registry entry for version: ${release_version}"
+    echo "   APK checksum: ${apk_checksum}"
+    echo "   iOS checksum: ${ios_checksum}"
   fi
-
-  echo "Updated release constants:"
-  echo "   Added registry entry for version: ${release_version}"
-  echo "   APK checksum: ${apk_checksum}"
-  echo "   iOS checksum: ${ios_checksum}"
 else
   # Mode: update registry[0] checksums in place (nightly/checksum-only)
   if [ -n "$apk_checksum" ]; then

--- a/src/constants/release.ts
+++ b/src/constants/release.ts
@@ -190,4 +190,11 @@ export const IOS_CTRL_PROXY_RELEASE_VERSION: string = RELEASE_VERSION;
 export const IOS_CTRL_PROXY_IPA_URL: string = buildReleaseAssetUrl("control-proxy.ipa", IOS_CTRL_PROXY_RELEASE_VERSION);
 export const IOS_CTRL_PROXY_SHA256_CHECKSUM: string = resolveChecksum(IOS_CTRL_PROXY_RELEASE_VERSION, "ios");
 export const IOS_CTRL_PROXY_APP_HASH: string = ""; // Hash of CtrlProxyApp.app (device build), empty = skip verification
-export const IOS_CTRL_PROXY_RUNNER_SHA256: string = ""; // SHA256 of runner binary (CtrlProxyUITests-Runner), empty = skip verification
+// SHA256 of the simulator runner binary (CtrlProxyUITests-Runner), empty = skip
+// verification. This is a single global scalar, valid only for the runner inside
+// the *latest* IPA (registry[0]) — the runner lives inside that IPA, so its
+// integrity is transitively covered by registry[0].ipaSha256. If pinned-older
+// iOS downloads are ever wired (resolveChecksum(<pinned>, "ios")), move this to a
+// per-entry ReleaseChecksumEntry.runnerSha256 or the check would compare the
+// newest runner sha against an older IPA and reject a valid bundle.
+export const IOS_CTRL_PROXY_RUNNER_SHA256: string = "";

--- a/test/bats/generate-release-constants.bats
+++ b/test/bats/generate-release-constants.bats
@@ -59,6 +59,31 @@ teardown() {
     "${TEST_ROOT}/src/constants/release.ts"
 }
 
+@test "refreshes runner sha for an already-registered version (no duplicate entry)" {
+  # First release adds the entry but with an empty runner sha (pre-wiring state).
+  run env \
+    RELEASE_VERSION="99.99.99" \
+    APK_SHA256_CHECKSUM="$APK_SHA" \
+    IOS_CTRL_PROXY_SHA256_CHECKSUM="$IPA_SHA" \
+    bash "${TEST_ROOT}/scripts/generate-release-constants.sh"
+  [ "$status" -eq 0 ]
+
+  # Re-running for the SAME version must not duplicate the entry, but must still
+  # populate the runner sha scalar (self-heal at release time).
+  run env \
+    RELEASE_VERSION="99.99.99" \
+    APK_SHA256_CHECKSUM="$APK_SHA" \
+    IOS_CTRL_PROXY_SHA256_CHECKSUM="$IPA_SHA" \
+    IOS_CTRL_PROXY_RUNNER_SHA256="$RUNNER_SHA" \
+    bash "${TEST_ROOT}/scripts/generate-release-constants.sh"
+  [ "$status" -eq 0 ]
+
+  entry_count="$(grep -c 'version: "99.99.99"' "${TEST_ROOT}/src/constants/release.ts")"
+  [ "$entry_count" -eq 1 ]
+  grep -q "export const IOS_CTRL_PROXY_RUNNER_SHA256: string = \"${RUNNER_SHA}\";" \
+    "${TEST_ROOT}/src/constants/release.ts"
+}
+
 @test "rejects a malformed IOS_CTRL_PROXY_RUNNER_SHA256" {
   run env \
     IOS_CTRL_PROXY_SHA256_CHECKSUM="$IPA_SHA" \

--- a/test/bats/generate-release-constants.bats
+++ b/test/bats/generate-release-constants.bats
@@ -5,6 +5,7 @@
 SCRIPT="scripts/generate-release-constants.sh"
 APK_SHA="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
 IPA_SHA="bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+RUNNER_SHA="cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
 
 setup() {
   TEST_ROOT="$(mktemp -d)"
@@ -32,4 +33,38 @@ teardown() {
   [[ "$first_version" == *'version: "99.99.99"'* ]]
   grep -q "apkSha256: \"${APK_SHA}\"" "${TEST_ROOT}/src/constants/release.ts"
   grep -q "ipaSha256: \"${IPA_SHA}\"" "${TEST_ROOT}/src/constants/release.ts"
+}
+
+@test "writes IOS_CTRL_PROXY_RUNNER_SHA256 in release mode" {
+  run env \
+    RELEASE_VERSION="99.99.99" \
+    APK_SHA256_CHECKSUM="$APK_SHA" \
+    IOS_CTRL_PROXY_SHA256_CHECKSUM="$IPA_SHA" \
+    IOS_CTRL_PROXY_RUNNER_SHA256="$RUNNER_SHA" \
+    bash "${TEST_ROOT}/scripts/generate-release-constants.sh"
+
+  [ "$status" -eq 0 ]
+  grep -q "export const IOS_CTRL_PROXY_RUNNER_SHA256: string = \"${RUNNER_SHA}\";" \
+    "${TEST_ROOT}/src/constants/release.ts"
+}
+
+@test "writes IOS_CTRL_PROXY_RUNNER_SHA256 in checksum-only mode" {
+  run env \
+    IOS_CTRL_PROXY_SHA256_CHECKSUM="$IPA_SHA" \
+    IOS_CTRL_PROXY_RUNNER_SHA256="$RUNNER_SHA" \
+    bash "${TEST_ROOT}/scripts/generate-release-constants.sh"
+
+  [ "$status" -eq 0 ]
+  grep -q "export const IOS_CTRL_PROXY_RUNNER_SHA256: string = \"${RUNNER_SHA}\";" \
+    "${TEST_ROOT}/src/constants/release.ts"
+}
+
+@test "rejects a malformed IOS_CTRL_PROXY_RUNNER_SHA256" {
+  run env \
+    IOS_CTRL_PROXY_SHA256_CHECKSUM="$IPA_SHA" \
+    IOS_CTRL_PROXY_RUNNER_SHA256="not-a-sha" \
+    bash "${TEST_ROOT}/scripts/generate-release-constants.sh"
+
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"IOS_CTRL_PROXY_RUNNER_SHA256 must be a valid SHA256"* ]]
 }

--- a/test/bats/release-workflow-wiring.bats
+++ b/test/bats/release-workflow-wiring.bats
@@ -1,0 +1,28 @@
+#!/usr/bin/env bats
+#
+# Guards the wiring the issue #2745 regression was about: every workflow that
+# generates release constants must pass the computed iOS runner SHA256 into the
+# script, and the release paths must run the integrity gate before publishing.
+
+@test "release.yml passes runner sha256 into generate-release-constants" {
+  grep -q "IOS_CTRL_PROXY_RUNNER_SHA256:" ".github/workflows/release.yml"
+  grep -q "runner_sha256" ".github/workflows/release.yml"
+}
+
+@test "prepare-release.yml passes runner sha256 into generate-release-constants" {
+  grep -q "IOS_CTRL_PROXY_RUNNER_SHA256:" ".github/workflows/prepare-release.yml"
+  grep -q "runner_sha256" ".github/workflows/prepare-release.yml"
+}
+
+@test "nightly.yml passes runner sha256 into generate-release-constants" {
+  grep -q "IOS_CTRL_PROXY_RUNNER_SHA256:" ".github/workflows/nightly.yml"
+  grep -q "runner_sha256" ".github/workflows/nightly.yml"
+}
+
+@test "release.yml runs the release-integrity gate" {
+  grep -q "verify-release-integrity.sh" ".github/workflows/release.yml"
+}
+
+@test "prepare-release.yml runs the release-integrity gate" {
+  grep -q "verify-release-integrity.sh" ".github/workflows/prepare-release.yml"
+}

--- a/test/bats/verify-release-integrity.bats
+++ b/test/bats/verify-release-integrity.bats
@@ -1,0 +1,162 @@
+#!/usr/bin/env bats
+#
+# Tests for scripts/ci/verify-release-integrity.sh
+#
+# The gate asserts (1) version equality across every release manifest, the
+# checksum registry, and the git tag, and (2) that the iOS runner-binary SHA256
+# is populated. Fixtures are built aligned to VERSION, then individually
+# perturbed to prove each divergence is caught.
+
+SCRIPT_SRC="scripts/ci/verify-release-integrity.sh"
+VERSION="0.0.40"
+RUNNER_SHA="abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789"
+
+setup() {
+  TEST_ROOT="$(mktemp -d)"
+  SCRIPT_ABS="$(cd "$(dirname "$SCRIPT_SRC")" && pwd)/$(basename "$SCRIPT_SRC")"
+  mkdir -p "${TEST_ROOT}/.claude-plugin" \
+    "${TEST_ROOT}/android" \
+    "${TEST_ROOT}/src/constants"
+  write_fixtures "$VERSION" "$VERSION-SNAPSHOT" "$VERSION" "$RUNNER_SHA"
+}
+
+teardown() {
+  rm -rf "$TEST_ROOT"
+}
+
+# write_fixtures <manifest_version> <gradle_version_name> <registry_version> <runner_sha>
+write_fixtures() {
+  local ver="$1" gradle="$2" registry="$3" runner="$4"
+
+  cat > "${TEST_ROOT}/package.json" <<EOF
+{ "name": "@kaeawc/auto-mobile", "version": "${ver}" }
+EOF
+
+  cat > "${TEST_ROOT}/.claude-plugin/plugin.json" <<EOF
+{ "name": "auto-mobile", "version": "${ver}" }
+EOF
+
+  cat > "${TEST_ROOT}/.claude-plugin/marketplace.json" <<EOF
+{ "version": "1.0.0", "plugins": [ { "name": "auto-mobile", "version": "${ver}" } ] }
+EOF
+
+  cat > "${TEST_ROOT}/server.json" <<EOF
+{ "version": "${ver}", "packages": [ { "identifier": "@kaeawc/auto-mobile", "version": "${ver}" } ] }
+EOF
+
+  cat > "${TEST_ROOT}/android/gradle.properties" <<EOF
+GROUP=dev.jasonpearson.auto-mobile
+VERSION_NAME=${gradle}
+EOF
+
+  cat > "${TEST_ROOT}/src/constants/release.ts" <<EOF
+export const RELEASE_CHECKSUM_REGISTRY: ReleaseChecksumEntry[] = [
+  {
+    version: "${registry}",
+    apkSha256: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    ipaSha256: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  },
+];
+export const IOS_CTRL_PROXY_APP_HASH: string = "";
+export const IOS_CTRL_PROXY_RUNNER_SHA256: string = "${runner}";
+EOF
+}
+
+run_gate() {
+  run bash -c "cd '${TEST_ROOT}' && bash '${SCRIPT_ABS}' '$1'"
+}
+
+@test "passes when all versions align and runner sha is populated" {
+  run_gate "$VERSION"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Release integrity verified"* ]]
+}
+
+@test "accepts a git tag with a leading v" {
+  run_gate "v${VERSION}"
+  [ "$status" -eq 0 ]
+}
+
+@test "accepts VERSION_NAME with a -SNAPSHOT suffix (base compared)" {
+  write_fixtures "$VERSION" "${VERSION}-SNAPSHOT" "$VERSION" "$RUNNER_SHA"
+  run_gate "$VERSION"
+  [ "$status" -eq 0 ]
+}
+
+@test "fails when the git tag diverges from the manifests" {
+  run_gate "0.0.41"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"expected '0.0.41'"* ]]
+}
+
+@test "fails when package.json version diverges" {
+  python3 - "${TEST_ROOT}/package.json" <<'PY'
+import json,sys
+p=sys.argv[1]; d=json.load(open(p)); d["version"]="0.0.99"
+json.dump(d,open(p,"w"))
+PY
+  run_gate "$VERSION"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"package.json"* ]]
+}
+
+@test "fails when plugin.json version diverges" {
+  python3 - "${TEST_ROOT}/.claude-plugin/plugin.json" <<'PY'
+import json,sys
+p=sys.argv[1]; d=json.load(open(p)); d["version"]="0.0.99"
+json.dump(d,open(p,"w"))
+PY
+  run_gate "$VERSION"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"plugin.json"* ]]
+}
+
+@test "fails when marketplace plugins[0].version diverges" {
+  python3 - "${TEST_ROOT}/.claude-plugin/marketplace.json" <<'PY'
+import json,sys
+p=sys.argv[1]; d=json.load(open(p)); d["plugins"][0]["version"]="0.0.99"
+json.dump(d,open(p,"w"))
+PY
+  run_gate "$VERSION"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"marketplace.json"* ]]
+}
+
+@test "fails when server.json package version diverges" {
+  python3 - "${TEST_ROOT}/server.json" <<'PY'
+import json,sys
+p=sys.argv[1]; d=json.load(open(p)); d["packages"][0]["version"]="0.0.99"
+json.dump(d,open(p,"w"))
+PY
+  run_gate "$VERSION"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"server.json packages"* ]]
+}
+
+@test "fails when gradle VERSION_NAME base diverges" {
+  write_fixtures "$VERSION" "0.0.99-SNAPSHOT" "$VERSION" "$RUNNER_SHA"
+  run_gate "$VERSION"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"gradle.properties"* ]]
+}
+
+@test "fails when registry[0].version diverges" {
+  write_fixtures "$VERSION" "${VERSION}-SNAPSHOT" "0.0.99" "$RUNNER_SHA"
+  run_gate "$VERSION"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"registry"* ]]
+}
+
+@test "fails when runner sha256 is empty (verification disabled)" {
+  write_fixtures "$VERSION" "${VERSION}-SNAPSHOT" "$VERSION" ""
+  run_gate "$VERSION"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"IOS_CTRL_PROXY_RUNNER_SHA256"* ]]
+}
+
+@test "fails when runner sha256 is malformed" {
+  write_fixtures "$VERSION" "${VERSION}-SNAPSHOT" "$VERSION" "not-a-valid-sha"
+  run_gate "$VERSION"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"IOS_CTRL_PROXY_RUNNER_SHA256"* ]]
+}

--- a/test/bats/verify-release-integrity.bats
+++ b/test/bats/verify-release-integrity.bats
@@ -66,6 +66,33 @@ run_gate() {
   run bash -c "cd '${TEST_ROOT}' && bash '${SCRIPT_ABS}' '$1'"
 }
 
+run_gate_ipa() {
+  run bash -c "cd '${TEST_ROOT}' && bash '${SCRIPT_ABS}' '$1' '$2'"
+}
+
+sha256_of() {
+  if command -v sha256sum >/dev/null 2>&1; then
+    printf '%s' "$1" | sha256sum | cut -d' ' -f1
+  else
+    printf '%s' "$1" | shasum -a 256 | cut -d' ' -f1
+  fi
+}
+
+# make_ipa <runner-binary-content> <out.ipa> — build a zip mirroring the real
+# IPA layout (a zip of Build/Products) with the runner binary at the expected
+# path, and echo the sha256 of that binary's content.
+make_ipa() {
+  local content="$1" out="$2"
+  local stage runner_dir
+  stage="$(mktemp -d)"
+  runner_dir="${stage}/Build/Products/Debug-iphonesimulator/CtrlProxyUITests-Runner.app"
+  mkdir -p "$runner_dir"
+  printf '%s' "$content" > "${runner_dir}/CtrlProxyUITests-Runner"
+  ( cd "$stage" && zip -qr "$out" Build/Products/ )
+  rm -rf "$stage"
+  sha256_of "$content"
+}
+
 @test "passes when all versions align and runner sha is populated" {
   run_gate "$VERSION"
   [ "$status" -eq 0 ]
@@ -159,4 +186,43 @@ PY
   run_gate "$VERSION"
   [ "$status" -ne 0 ]
   [[ "$output" == *"IOS_CTRL_PROXY_RUNNER_SHA256"* ]]
+}
+
+@test "binds recorded runner sha to the runner inside the IPA (match passes)" {
+  local ipa="${TEST_ROOT}/control-proxy.ipa" sha
+  sha="$(make_ipa "fake-runner-binary-bytes" "$ipa")"
+  write_fixtures "$VERSION" "${VERSION}-SNAPSHOT" "$VERSION" "$sha"
+  run_gate_ipa "$VERSION" "$ipa"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"matches the runner inside the IPA"* ]]
+}
+
+@test "fails when recorded runner sha does not match the IPA runner (substitution)" {
+  local ipa="${TEST_ROOT}/control-proxy.ipa"
+  make_ipa "the-real-shipped-runner" "$ipa" >/dev/null
+  # Record a valid-looking but WRONG sha (as if a tampered/stale runner shipped).
+  write_fixtures "$VERSION" "${VERSION}-SNAPSHOT" "$VERSION" "$RUNNER_SHA"
+  run_gate_ipa "$VERSION" "$ipa"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"does not match the runner binary shipped"* ]]
+}
+
+@test "fails when the IPA path is given but the file is missing" {
+  write_fixtures "$VERSION" "${VERSION}-SNAPSHOT" "$VERSION" "$RUNNER_SHA"
+  run_gate_ipa "$VERSION" "${TEST_ROOT}/does-not-exist.ipa"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"IPA not found"* ]]
+}
+
+@test "fails when the IPA lacks the runner binary" {
+  local ipa="${TEST_ROOT}/empty.ipa" stage
+  stage="$(mktemp -d)"
+  mkdir -p "${stage}/Build/Products/Debug-iphonesimulator"
+  printf 'x' > "${stage}/Build/Products/Debug-iphonesimulator/unrelated.txt"
+  ( cd "$stage" && zip -qr "$ipa" Build/Products/ )
+  rm -rf "$stage"
+  write_fixtures "$VERSION" "${VERSION}-SNAPSHOT" "$VERSION" "$RUNNER_SHA"
+  run_gate_ipa "$VERSION" "$ipa"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"CtrlProxyUITests-Runner not found inside"* ]]
 }

--- a/test/constants/release.test.ts
+++ b/test/constants/release.test.ts
@@ -1,8 +1,11 @@
 import { describe, expect, test } from "bun:test";
+import { readFileSync } from "fs";
+import { join } from "path";
 import {
   APK_SHA256_CHECKSUM,
   APK_URL,
   IOS_CTRL_PROXY_IPA_URL,
+  IOS_CTRL_PROXY_RUNNER_SHA256,
   IOS_CTRL_PROXY_SHA256_CHECKSUM,
   RELEASE_CHECKSUM_REGISTRY,
   resolveAssetVersion,
@@ -97,5 +100,29 @@ describe("module-level URL and checksum exports", function() {
   test("APK and IPA checksums match the newest registered entry", function() {
     expect(APK_SHA256_CHECKSUM).toBe(newest.apkSha256);
     expect(IOS_CTRL_PROXY_SHA256_CHECKSUM).toBe(newest.ipaSha256);
+  });
+});
+
+describe("package.json as canonical version source", function() {
+  // The npm version (package.json) is the canonical release version. The
+  // checksum registry's newest entry must name that same version, or "latest"
+  // resolves assets for a version that npm never published. The release gate
+  // (scripts/ci/verify-release-integrity.sh) enforces this across every
+  // manifest at release time; this test enforces it in the checked-in source.
+  const pkg = JSON.parse(
+    readFileSync(join(import.meta.dir, "../../package.json"), "utf8")
+  ) as { version: string };
+
+  test("resolveLatestVersion() equals package.json version", function() {
+    expect(resolveLatestVersion()).toBe(pkg.version);
+  });
+});
+
+describe("iOS runner-binary checksum", function() {
+  test("is empty or a well-formed 64-char sha256", function() {
+    // Empty is the local-dev default (verification skipped). When populated by
+    // the release pipeline it must be a lowercase 64-hex sha256 so the runner
+    // integrity check in IOSCtrlProxyBuilder can actually run.
+    expect(IOS_CTRL_PROXY_RUNNER_SHA256 === "" || /^[a-f0-9]{64}$/.test(IOS_CTRL_PROXY_RUNNER_SHA256)).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary

Closes #2745. Fixes two release-pipeline integrity gaps that let versions/artifacts drift undetected.

### Part A — iOS runner-binary checksum was never wired (verification disabled)
- `IOS_CTRL_PROXY_RUNNER_SHA256` shipped as `""` every release, so the runner integrity check in `IOSCtrlProxyBuilder` (simulator path, `src/utils/IOSCtrlProxyBuilder.ts:874-889`) was permanently skipped — a tampered/stale runner inside an otherwise-valid IPA was undetectable.
- The plumbing already existed (`build-ctrl-proxy-ios-ipa.yml` exposes `runner_sha256`; `generate-release-constants.sh` accepts the env var) but **no workflow passed the value through**.
- **Fix:** wire `IOS_CTRL_PROXY_RUNNER_SHA256: ${{ needs.build-ctrl-proxy-ios-ipa.outputs.runner_sha256 }}` into the generate-release-constants step of `prepare-release.yml` (the step that writes it when adding a new registry entry), `release.yml`, and `nightly.yml`.

### Part B — no version-equality gate at release
- Nothing asserted that the npm version, every release manifest, the checksum registry, and the git tag name the same version — they stayed equal only because `bump-versions.sh` writes them together.
- **Fix:** new `scripts/ci/verify-release-integrity.sh <version>`, run in `release.yml` (after generating constants) and `prepare-release.yml`. It asserts version equality across `package.json` (canonical), `.claude-plugin/plugin.json`, `.claude-plugin/marketplace.json` (`plugins[0]`), `server.json` (top-level + `packages[]`), `android/gradle.properties` `VERSION_NAME` (`-SNAPSHOT` base), and `release.ts` `registry[0].version` vs the git tag — and that `IOS_CTRL_PROXY_RUNNER_SHA256` is a populated 64-hex sha256.
- Corrected the stale version-source comment at `android/junit-runner/build.gradle.kts:19` (the jar's `Implementation-Version` tracks `package.json`; only the Maven coordinate uses `VERSION_NAME`).

### Design decisions
- **`RELEASE_VERSION="latest"` kept, not rewritten to import `package.json`.** `release.ts` is an auto-generated "do not edit" file, and deriving asset URLs straight from `package.json` would point at not-yet-published versions. `package.json` is instead made canonical by *enforcement*: the release gate + a unit test asserting `resolveLatestVersion() === package.json.version`.
- **`-SNAPSHOT` kept** for Gradle/Maven dev coordinates (intended; normalized via `-PVERSION_NAME` at publish); the gate compares the SNAPSHOT-stripped base so source/local builds can't diverge.
- **`IOS_CTRL_PROXY_APP_HASH` intentionally not required** — it is device-only (empty = skip on simulator) and no CI step produces it. Wiring a device app-hash output is left as a follow-up; the gate does not require it, so releases are not blocked.

## Testing (TDD)
- `test/bats/verify-release-integrity.bats` (new, 12 cases): full pass; a failing case per manifest; SNAPSHOT-base accepted; `v` tag prefix accepted; empty/malformed runner sha rejected.
- `test/bats/release-workflow-wiring.bats` (new, 5 cases): each workflow passes the runner sha; release/prepare-release run the gate.
- `test/bats/generate-release-constants.bats` (extended): runner sha written in release + checksum-only modes; malformed rejected.
- `test/constants/release.test.ts` (extended): `resolveLatestVersion() === package.json.version`; runner sha is `""` or 64-hex.

Verified: `bats test/bats/{verify-release-integrity,release-workflow-wiring,generate-release-constants}.bats` (21/21), `shellcheck` clean, `bun test test/constants/release.test.ts` (16/16), `eslint` clean, `bun run build` succeeds, `actionlint` clean on the new steps. Reproduced the gate catching the real repo's current empty-runner-sha state and passing a simulated post-prepare-release state.
