### PR TITLE
feat(release): hermetic single-version pinning knobs for external CI (#2746)

### DIFF
--- a/docs/using/hermetic-ci-pinning.md
+++ b/docs/using/hermetic-ci-pinning.md
@@ -102,13 +102,17 @@ mirror can only serve unverified assets if you deliberately opt out of verificat
    itself. Pin it by installing the exact `@kaeawc/auto-mobile@0.0.40` on the runner's
    PATH, or start the daemon yourself before the test job. (Baking the pin into the
    Swift runner is tracked as follow-up work for #2746.)
-2. **Vendor the IPA and skip the build** so nothing is fetched or compiled at test time:
+2. **Vendor the IPA** so nothing is fetched or compiled at test time:
    ```bash
    export AUTOMOBILE_CTRL_PROXY_IOS_IPA_PATH=/opt/automobile/control-proxy.ipa
-   export AUTOMOBILE_SKIP_CTRL_PROXY_IOS_BUILD=1
    ```
-   (or set `AUTOMOBILE_ASSET_BASE_URL` to your mirror for a checksummed download of a
-   registry-known version).
+   The daemon copies (and extracts) this local bundle directly — no network fetch, no
+   Xcode build. **Do not also set `AUTOMOBILE_SKIP_CTRL_PROXY_IOS_BUILD=1`**: that flag
+   short-circuits `needsRebuild()` and returns *before* the vendored IPA is consumed, so
+   on a fresh host CtrlProxy would never be installed. Use `AUTOMOBILE_SKIP_CTRL_PROXY_IOS_BUILD=1`
+   only when the extracted xctestrun artifacts are *already* present on the host.
+   Alternatively, set `AUTOMOBILE_ASSET_BASE_URL` to your mirror for a checksummed
+   download of a registry-known version (leave the IPA path unset).
 3. **Gate the job** on doctor:
    ```bash
    bunx @kaeawc/auto-mobile@0.0.40 --cli doctor --ios

--- a/docs/using/hermetic-ci-pinning.md
+++ b/docs/using/hermetic-ci-pinning.md
@@ -1,0 +1,126 @@
+# Hermetic CI Pinning
+
+AutoMobile is made of several components that must agree on one version:
+
+| Component | What it is |
+|-----------|------------|
+| **Daemon** | The `@kaeawc/auto-mobile` npm package (stdio/MCP + Unix-socket server) |
+| **Android CtrlProxy APK** | On-device accessibility service, downloaded by the daemon |
+| **iOS CtrlProxy IPA** | On-device XCUITest runner bundle, downloaded by the daemon |
+| **Android junit-runner** | Kotlin runner that spawns the daemon during tests |
+| **iOS XCTestRunner** | Swift runner that autostarts the daemon during tests |
+
+The repo's own CI is hermetic *by construction* — every component comes from a single
+checkout — so a version knob is not needed there. **External CI consumers** don't have
+that luxury: their inputs are independent, and without pinning they can silently drift
+(a `@latest` daemon pulling one APK while a runner expects another). This page documents
+how to pin everything to **one coherent version** and, optionally, mirror the release
+assets for offline builds.
+
+## The knobs
+
+### `AUTOMOBILE_VERSION` — the single-version knob
+
+Set `AUTOMOBILE_VERSION` to a released version (e.g. `0.0.40`) to pin the daemon package,
+the Android APK, the iOS IPA, and their expected SHA-256 checksums together. The daemon
+resolves all four from one value, so there is no way for them to disagree.
+
+```bash
+export AUTOMOBILE_VERSION=0.0.40
+```
+
+- Unset (or `latest`) resolves to the newest entry in the daemon's baked release registry
+  — a **concrete** version, never the floating `@latest` tag.
+- An unknown version resolves to an empty checksum (download proceeds unverified only if
+  you have also opted into a checksum-skip override — see below).
+- The Android Kotlin runner already reads `AUTOMOBILE_VERSION` as a fallback for the
+  daemon package version, so the same env var lines up the runner-spawned daemon too.
+
+### `AUTOMOBILE_ASSET_BASE_URL` — the mirror knob
+
+By default the daemon downloads the APK/IPA from GitHub Releases. For hermetic,
+offline-capable CI, mirror the assets and point the daemon at your mirror:
+
+```bash
+export AUTOMOBILE_ASSET_BASE_URL=https://artifacts.internal/automobile
+```
+
+The daemon fetches `${AUTOMOBILE_ASSET_BASE_URL}/${version}/control-proxy-debug.apk`
+(and `.../control-proxy.ipa`). Lay your mirror out with a directory per version:
+
+```
+https://artifacts.internal/automobile/
+  0.0.40/
+    control-proxy-debug.apk
+    control-proxy.ipa
+```
+
+Checksums are still verified against the daemon's baked registry, so a mirror cannot
+serve a tampered asset for a pinned version.
+
+## Android hermetic recipe
+
+1. **Pin the runner + daemon:**
+   ```bash
+   export AUTOMOBILE_VERSION=0.0.40
+   ```
+   In Gradle, pin the Maven coordinate of `junit-runner` to the matching release and set
+   `-Dautomobile.daemon.package.version=0.0.40` (or rely on `AUTOMOBILE_VERSION`).
+2. **Provision the APK out-of-band** so no network fetch happens at test time:
+   ```bash
+   export AUTOMOBILE_CTRL_PROXY_APK_PATH=/opt/automobile/control-proxy-debug.apk
+   ```
+   (or set `AUTOMOBILE_ASSET_BASE_URL` to your mirror for a checksummed download).
+3. **Force a clean daemon** so a stale reused daemon can't serve a different build:
+   ```bash
+   export AUTOMOBILE_DAEMON_PACKAGE_VERSION=0.0.40   # explicit runner-side pin
+   # -Dautomobile.daemon.force.restart=true
+   ```
+4. **Gate the job** on doctor so drift is a hard failure:
+   ```bash
+   bunx @kaeawc/auto-mobile@0.0.40 --cli doctor
+   ```
+
+## iOS hermetic recipe
+
+1. **Pin the runner + daemon:**
+   ```bash
+   export AUTOMOBILE_VERSION=0.0.40
+   ```
+   Pin the XCTestRunner SPM dependency to the matching git tag.
+2. **Vendor the IPA and skip the build** so nothing is fetched or compiled at test time:
+   ```bash
+   export AUTOMOBILE_CTRL_PROXY_IOS_IPA_PATH=/opt/automobile/control-proxy.ipa
+   export AUTOMOBILE_SKIP_CTRL_PROXY_IOS_BUILD=1
+   ```
+   (or set `AUTOMOBILE_ASSET_BASE_URL` to your mirror for a checksummed download).
+3. **Gate the job** on doctor:
+   ```bash
+   bunx @kaeawc/auto-mobile@0.0.40 --cli doctor --ios
+   ```
+
+## Verifying the pin
+
+Ask the running daemon what it will actually fetch — the `ide/status` handler reports the
+**concrete** resolved version plus the exact (mirror-aware) URLs and checksums:
+
+```jsonc
+{
+  "releaseVersion": "0.0.40",
+  "android": {
+    "ctrlProxy": {
+      "url": "https://artifacts.internal/automobile/0.0.40/control-proxy-debug.apk",
+      "expectedSha256": "…"
+    }
+  },
+  "ios": {
+    "xcTestService": {
+      "url": "https://artifacts.internal/automobile/0.0.40/control-proxy.ipa",
+      "expectedSha256": "…"
+    }
+  }
+}
+```
+
+If `releaseVersion` is anything other than the version you pinned, the environment is not
+hermetic — check that `AUTOMOBILE_VERSION` is exported into the daemon's process.

--- a/docs/using/hermetic-ci-pinning.md
+++ b/docs/using/hermetic-ci-pinning.md
@@ -29,12 +29,18 @@ resolves all four from one value, so there is no way for them to disagree.
 export AUTOMOBILE_VERSION=0.0.40
 ```
 
-- Unset (or `latest`) resolves to the newest entry in the daemon's baked release registry
-  — a **concrete** version, never the floating `@latest` tag.
-- An unknown version resolves to an empty checksum (download proceeds unverified only if
-  you have also opted into a checksum-skip override — see below).
-- The Android Kotlin runner already reads `AUTOMOBILE_VERSION` as a fallback for the
-  daemon package version, so the same env var lines up the runner-spawned daemon too.
+- Unset (or `latest`, case-insensitive) resolves to the newest entry in the daemon's
+  baked release registry — a **concrete** version, never the floating `@latest` tag.
+- A version **in** the daemon's baked registry is downloaded and its SHA-256 is verified.
+- A version **not** in the registry (a typo, or a real release newer than the daemon's
+  baked registry) has no checksum to verify against, so the download **fails closed** —
+  the daemon refuses to install an unverifiable asset. To use a not-yet-baked release,
+  either upgrade the daemon to one whose registry includes it, or take the explicit
+  escape hatch: `AUTOMOBILE_SKIP_ACCESSIBILITY_CHECKSUM=1` (Android) / vendor a trusted
+  bundle via `AUTOMOBILE_CTRL_PROXY_IOS_IPA_PATH` (iOS).
+- The Android Kotlin runner reads `AUTOMOBILE_VERSION` as a fallback for the daemon
+  package version, so a daemon **this runner spawns** lines up. A **pre-existing** shared
+  daemon does not re-read it — see [Shared daemon caveat](#shared-daemon-caveat).
 
 ### `AUTOMOBILE_ASSET_BASE_URL` — the mirror knob
 
@@ -55,8 +61,11 @@ https://artifacts.internal/automobile/
     control-proxy.ipa
 ```
 
-Checksums are still verified against the daemon's baked registry, so a mirror cannot
-serve a tampered asset for a pinned version.
+For any version in the daemon's baked registry, the downloaded asset's SHA-256 is
+verified against that registry, so a mirror **cannot** serve a tampered asset for a
+registry-known version. For a version **not** in the registry there is nothing to verify
+against, so the download fails closed (see the `AUTOMOBILE_VERSION` notes above) — a
+mirror can only serve unverified assets if you deliberately opt out of verification.
 
 ## Android hermetic recipe
 
@@ -87,17 +96,38 @@ serve a tampered asset for a pinned version.
    ```bash
    export AUTOMOBILE_VERSION=0.0.40
    ```
-   Pin the XCTestRunner SPM dependency to the matching git tag.
+   Pin the XCTestRunner SPM dependency to the matching git tag. Note: the iOS
+   XCTestRunner autostart currently spawns a bare-PATH `auto-mobile --daemon start`
+   (`AutoMobileEnvironment.swift`) — it does **not** yet pin the daemon package version
+   itself. Pin it by installing the exact `@kaeawc/auto-mobile@0.0.40` on the runner's
+   PATH, or start the daemon yourself before the test job. (Baking the pin into the
+   Swift runner is tracked as follow-up work for #2746.)
 2. **Vendor the IPA and skip the build** so nothing is fetched or compiled at test time:
    ```bash
    export AUTOMOBILE_CTRL_PROXY_IOS_IPA_PATH=/opt/automobile/control-proxy.ipa
    export AUTOMOBILE_SKIP_CTRL_PROXY_IOS_BUILD=1
    ```
-   (or set `AUTOMOBILE_ASSET_BASE_URL` to your mirror for a checksummed download).
+   (or set `AUTOMOBILE_ASSET_BASE_URL` to your mirror for a checksummed download of a
+   registry-known version).
 3. **Gate the job** on doctor:
    ```bash
    bunx @kaeawc/auto-mobile@0.0.40 --cli doctor --ios
    ```
+
+## Shared daemon caveat
+
+The pin is a property of **the daemon's launch environment**, resolved where the download
+happens. AutoMobile runs **one daemon per UID**, shared across worktrees via a single
+socket + PID file, and runners **reuse an already-running daemon** rather than restart it.
+So if a daemon is already up with a different `AUTOMOBILE_VERSION` (or none), a second job
+that exports a new pin will silently be served by the **existing** daemon — the pin is
+ignored until the daemon is restarted.
+
+For hermetic CI, force a clean daemon so the pin actually takes effect:
+
+- **Android:** `-Dautomobile.daemon.force.restart=true` (already in the recipe above).
+- **Any platform:** `bunx @kaeawc/auto-mobile@<version> --daemon restart` before the job,
+  then confirm via `ide/status` (below) that `releaseVersion` matches your pin.
 
 ## Verifying the pin
 
@@ -123,4 +153,6 @@ Ask the running daemon what it will actually fetch — the `ide/status` handler 
 ```
 
 If `releaseVersion` is anything other than the version you pinned, the environment is not
-hermetic — check that `AUTOMOBILE_VERSION` is exported into the daemon's process.
+hermetic — either `AUTOMOBILE_VERSION` was not exported into the daemon's process, or a
+pre-existing daemon with a different pin is still serving (see
+[Shared daemon caveat](#shared-daemon-caveat)). Restart the daemon and re-check.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -78,6 +78,7 @@ nav:
       - 'UX Exploration': using/ux-exploration.md
       - 'Reproducing Bugs': using/reproducing-bugs.md
       - 'UI Tests': using/ui-tests.md
+      - 'Hermetic CI Pinning': using/hermetic-ci-pinning.md
       - 'Performance Analysis':
           - 'Overview': using/perf-analysis/index.md
           - 'Startup': using/perf-analysis/startup.md

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -3,6 +3,7 @@ import { logger } from "../utils/logger";
 import { ActionableError } from "../models";
 import { DaemonClient, DaemonUnavailableError } from "../daemon/client";
 import { DaemonManager } from "../daemon/manager";
+import { resolveDaemonInstallSpecifier } from "../constants/release";
 
 // Import all tool registration functions
 import { registerObserveTools } from "../server/observeTools";
@@ -112,7 +113,7 @@ async function ensureDaemonRunning(timeout: number = 10000): Promise<void> {
     const message = error instanceof Error ? error.message : String(error);
     throw new ActionableError(
       `Failed to start daemon: ${message}. ` +
-      `Try running: bunx @kaeawc/auto-mobile@latest --daemon restart`
+      `Try running: bunx ${resolveDaemonInstallSpecifier()} --daemon restart`
     );
   }
 }
@@ -135,7 +136,7 @@ async function runToolViaDaemon(
     if (result === null) {
       throw new ActionableError(
         "Daemon returned null result. This may indicate a daemon connectivity issue. " +
-        "Try: bunx @kaeawc/auto-mobile@latest --daemon restart"
+        `Try: bunx ${resolveDaemonInstallSpecifier()} --daemon restart`
       );
     }
     return result;
@@ -357,21 +358,24 @@ export async function runCliCommand(args: string[]): Promise<void> {
 // Show general help
 function showHelp(): void {
   const tools = ToolRegistry.getAllTools();
+  // Concrete pinned specifier (honors AUTOMOBILE_VERSION), never the floating
+  // @latest tag — help output should be reproducible (#2746).
+  const installSpecifier = resolveDaemonInstallSpecifier();
 
   console.log(`
 AutoMobile CLI - Android Device Automation
 
 Usage:
-  bunx @kaeawc/auto-mobile@latest --cli [--session-uuid <uuid>] <tool-name> [--param value ...]
-  bunx @kaeawc/auto-mobile@latest --cli help [tool-name]
+  bunx ${installSpecifier} --cli [--session-uuid <uuid>] <tool-name> [--param value ...]
+  bunx ${installSpecifier} --cli help [tool-name]
 
 Examples:
-  bunx @kaeawc/auto-mobile@latest --cli listDeviceImages
-  bunx @kaeawc/auto-mobile@latest --cli observe
-  bunx @kaeawc/auto-mobile@latest --cli tapOn --text "Submit"
-  bunx @kaeawc/auto-mobile@latest --cli startDevice --avdName "pixel_7_api_34"
-  bunx @kaeawc/auto-mobile@latest --cli --session-uuid abc-123-uuid observe
-  bunx @kaeawc/auto-mobile@latest --cli --session-uuid $SESSION_UUID tapOn --text "Submit"
+  bunx ${installSpecifier} --cli listDeviceImages
+  bunx ${installSpecifier} --cli observe
+  bunx ${installSpecifier} --cli tapOn --text "Submit"
+  bunx ${installSpecifier} --cli startDevice --avdName "pixel_7_api_34"
+  bunx ${installSpecifier} --cli --session-uuid abc-123-uuid observe
+  bunx ${installSpecifier} --cli --session-uuid $SESSION_UUID tapOn --text "Submit"
 
 Options:
   help [tool-name]              Show help for a specific tool
@@ -442,15 +446,16 @@ Session-based Execution:
   });
 
   console.log(`\nTotal: ${tools.length} tools available`);
-  console.log("\nUse 'bunx @kaeawc/auto-mobile@latest --cli help <tool-name>' for detailed information about a specific tool.");
+  console.log(`\nUse 'bunx ${installSpecifier} --cli help <tool-name>' for detailed information about a specific tool.`);
 }
 
 // Show help for a specific tool
 function showToolHelp(toolName: string): void {
+  const installSpecifier = resolveDaemonInstallSpecifier();
   const tool = ToolRegistry.getTool(toolName);
   if (!tool) {
     console.error(`Unknown tool: ${toolName}`);
-    console.log("\nUse 'bunx @kaeawc/auto-mobile@latest --cli help' to see available tools.");
+    console.log(`\nUse 'bunx ${installSpecifier} --cli help' to see available tools.`);
     return;
   }
 
@@ -485,7 +490,7 @@ function showToolHelp(toolName: string): void {
   }
 
   console.log(`\nExample usage:`);
-  console.log(`  bunx @kaeawc/auto-mobile@latest --cli ${toolName} [parameters...]`);
+  console.log(`  bunx ${installSpecifier} --cli ${toolName} [parameters...]`);
 }
 
 export function getCliHelpSchemaShape(schema: any): CliHelpSchemaShape {

--- a/src/constants/release.ts
+++ b/src/constants/release.ts
@@ -150,11 +150,13 @@ export function resolveChecksum(
  * Version of the latest validated release in the registry.
  * Used to construct download URLs for pinned releases.
  */
-export function resolveLatestVersion(): string {
-  if (RELEASE_CHECKSUM_REGISTRY.length === 0) {
+export function resolveLatestVersion(
+  registry: ReleaseChecksumEntry[] = RELEASE_CHECKSUM_REGISTRY
+): string {
+  if (registry.length === 0) {
     return LATEST_RELEASE_VERSION;
   }
-  return RELEASE_CHECKSUM_REGISTRY[0].version;
+  return registry[0].version;
 }
 
 // --- Backward-compatible exports derived from RELEASE_VERSION ---
@@ -166,9 +168,12 @@ export const RELEASE_VERSION: string = LATEST_RELEASE_VERSION;
  * (URLs, on-disk metadata, doctor checks) want a concrete version like
  * "0.0.30", never the placeholder "latest".
  */
-export function resolveAssetVersion(version: string): string {
+export function resolveAssetVersion(
+  version: string,
+  registry: ReleaseChecksumEntry[] = RELEASE_CHECKSUM_REGISTRY
+): string {
   if (version === LATEST_RELEASE_VERSION) {
-    return resolveLatestVersion();
+    return resolveLatestVersion(registry);
   }
   return version;
 }
@@ -197,11 +202,44 @@ type EnvLike = Record<string, string | undefined>;
 /**
  * Resolve the pinned version from `AUTOMOBILE_VERSION`. Returns the trimmed value
  * when set, otherwise the `"latest"` placeholder (which downstream resolvers turn
- * into the concrete newest registry entry).
+ * into the concrete newest registry entry). The `latest` sentinel is normalized to
+ * lower-case so every sink agrees — `resolveChecksum` matches `latest`
+ * case-insensitively but `resolveAssetVersion`/URL building use a strict `===`
+ * compare, so an un-normalized `LATEST` would otherwise resolve to a valid checksum
+ * yet a 404 URL (an incoherent triple).
  */
 export function resolvePinnedVersion(env: EnvLike = process.env): string {
   const trimmed = env[AUTOMOBILE_VERSION_ENV]?.trim();
-  return trimmed && trimmed.length > 0 ? trimmed : LATEST_RELEASE_VERSION;
+  if (!trimmed || trimmed.length === 0) {
+    return LATEST_RELEASE_VERSION;
+  }
+  return trimmed.toLowerCase() === LATEST_RELEASE_VERSION ? LATEST_RELEASE_VERSION : trimmed;
+}
+
+/**
+ * True when `AUTOMOBILE_VERSION` names a concrete version (not unset, not the
+ * `latest` sentinel). Used to decide whether an unverifiable download should
+ * fail closed.
+ */
+export function isExplicitPin(env: EnvLike = process.env): boolean {
+  return resolvePinnedVersion(env) !== LATEST_RELEASE_VERSION;
+}
+
+/**
+ * True when the effective pin resolves to a checksum-bearing registry entry.
+ * A `latest` pin is known iff the registry is non-empty; a concrete pin is known
+ * iff the registry contains it. A pinned-but-unknown version cannot be
+ * integrity-verified — see the fail-closed guards in the CtrlProxy managers.
+ */
+export function isPinnedVersionKnown(
+  env: EnvLike = process.env,
+  registry: ReleaseChecksumEntry[] = RELEASE_CHECKSUM_REGISTRY
+): boolean {
+  const pinned = resolvePinnedVersion(env);
+  if (pinned === LATEST_RELEASE_VERSION) {
+    return registry.length > 0;
+  }
+  return registry.some(entry => entry.version === pinned);
 }
 
 /**
@@ -219,9 +257,10 @@ export function resolveAssetBaseUrl(env: EnvLike = process.env): string {
 function buildReleaseAssetUrl(
   filename: string,
   version: string,
-  baseUrl: string = DEFAULT_ASSET_BASE_URL
+  baseUrl: string = DEFAULT_ASSET_BASE_URL,
+  registry: ReleaseChecksumEntry[] = RELEASE_CHECKSUM_REGISTRY
 ): string {
-  const assetVersion = resolveAssetVersion(version);
+  const assetVersion = resolveAssetVersion(version, registry);
   if (assetVersion === LATEST_RELEASE_VERSION) {
     // Degenerate case: empty registry, no concrete version to key off.
     if (baseUrl === DEFAULT_ASSET_BASE_URL) {
@@ -235,13 +274,19 @@ function buildReleaseAssetUrl(
 }
 
 /** APK download URL honoring `AUTOMOBILE_VERSION` + `AUTOMOBILE_ASSET_BASE_URL`. */
-export function resolveApkUrl(env: EnvLike = process.env): string {
-  return buildReleaseAssetUrl("control-proxy-debug.apk", resolvePinnedVersion(env), resolveAssetBaseUrl(env));
+export function resolveApkUrl(
+  env: EnvLike = process.env,
+  registry: ReleaseChecksumEntry[] = RELEASE_CHECKSUM_REGISTRY
+): string {
+  return buildReleaseAssetUrl("control-proxy-debug.apk", resolvePinnedVersion(env), resolveAssetBaseUrl(env), registry);
 }
 
 /** iOS IPA download URL honoring `AUTOMOBILE_VERSION` + `AUTOMOBILE_ASSET_BASE_URL`. */
-export function resolveIpaUrl(env: EnvLike = process.env): string {
-  return buildReleaseAssetUrl("control-proxy.ipa", resolvePinnedVersion(env), resolveAssetBaseUrl(env));
+export function resolveIpaUrl(
+  env: EnvLike = process.env,
+  registry: ReleaseChecksumEntry[] = RELEASE_CHECKSUM_REGISTRY
+): string {
+  return buildReleaseAssetUrl("control-proxy.ipa", resolvePinnedVersion(env), resolveAssetBaseUrl(env), registry);
 }
 
 /** Expected APK SHA-256 for the pinned version (empty string if unknown). */

--- a/src/constants/release.ts
+++ b/src/constants/release.ts
@@ -173,21 +173,102 @@ export function resolveAssetVersion(version: string): string {
   return version;
 }
 
-function buildReleaseAssetUrl(filename: string, version: string): string {
-  const assetVersion = resolveAssetVersion(version);
-  if (assetVersion === LATEST_RELEASE_VERSION) {
-    // Degenerate case: empty registry. Fall back to GitHub's redirecting
-    // /latest/download/ endpoint.
-    return `https://github.com/kaeawc/auto-mobile/releases/latest/download/${filename}`;
-  }
-  return `https://github.com/kaeawc/auto-mobile/releases/download/${assetVersion}/${filename}`;
+// --- Hermetic single-version pinning knobs (issue #2746) ---
+//
+// External CI consumers need one coherent way to pin every AutoMobile component
+// to a single version and, optionally, to mirror the release assets off GitHub.
+// These pure, env-injectable resolvers are the daemon-side source of truth that
+// the Android/iOS clients delegate to (via `ide/status` + the CtrlProxy managers).
+
+/** npm package name of the daemon. */
+export const DAEMON_PACKAGE_NAME = "@kaeawc/auto-mobile";
+
+/** Environment variable that pins daemon + APK + IPA to one coherent version. */
+export const AUTOMOBILE_VERSION_ENV = "AUTOMOBILE_VERSION";
+
+/** Environment variable that mirrors the APK/IPA download host for offline CI. */
+export const AUTOMOBILE_ASSET_BASE_URL_ENV = "AUTOMOBILE_ASSET_BASE_URL";
+
+/** Default GitHub Releases base for versioned asset downloads. */
+export const DEFAULT_ASSET_BASE_URL = "https://github.com/kaeawc/auto-mobile/releases/download";
+
+type EnvLike = Record<string, string | undefined>;
+
+/**
+ * Resolve the pinned version from `AUTOMOBILE_VERSION`. Returns the trimmed value
+ * when set, otherwise the `"latest"` placeholder (which downstream resolvers turn
+ * into the concrete newest registry entry).
+ */
+export function resolvePinnedVersion(env: EnvLike = process.env): string {
+  const trimmed = env[AUTOMOBILE_VERSION_ENV]?.trim();
+  return trimmed && trimmed.length > 0 ? trimmed : LATEST_RELEASE_VERSION;
 }
 
-export const APK_URL: string = buildReleaseAssetUrl("control-proxy-debug.apk", RELEASE_VERSION);
-export const APK_SHA256_CHECKSUM: string = resolveChecksum(RELEASE_VERSION, "android");
+/**
+ * Resolve the asset download base URL. Returns `AUTOMOBILE_ASSET_BASE_URL`
+ * (trimmed, trailing slashes stripped) when set, otherwise the GitHub default.
+ */
+export function resolveAssetBaseUrl(env: EnvLike = process.env): string {
+  const trimmed = env[AUTOMOBILE_ASSET_BASE_URL_ENV]?.trim();
+  if (trimmed && trimmed.length > 0) {
+    return trimmed.replace(/\/+$/, "");
+  }
+  return DEFAULT_ASSET_BASE_URL;
+}
+
+function buildReleaseAssetUrl(
+  filename: string,
+  version: string,
+  baseUrl: string = DEFAULT_ASSET_BASE_URL
+): string {
+  const assetVersion = resolveAssetVersion(version);
+  if (assetVersion === LATEST_RELEASE_VERSION) {
+    // Degenerate case: empty registry, no concrete version to key off.
+    if (baseUrl === DEFAULT_ASSET_BASE_URL) {
+      // Fall back to GitHub's redirecting /latest/download/ endpoint.
+      return `https://github.com/kaeawc/auto-mobile/releases/latest/download/${filename}`;
+    }
+    // A mirror has no redirecting endpoint; use a conventional /latest/ path.
+    return `${baseUrl}/latest/${filename}`;
+  }
+  return `${baseUrl}/${assetVersion}/${filename}`;
+}
+
+/** APK download URL honoring `AUTOMOBILE_VERSION` + `AUTOMOBILE_ASSET_BASE_URL`. */
+export function resolveApkUrl(env: EnvLike = process.env): string {
+  return buildReleaseAssetUrl("control-proxy-debug.apk", resolvePinnedVersion(env), resolveAssetBaseUrl(env));
+}
+
+/** iOS IPA download URL honoring `AUTOMOBILE_VERSION` + `AUTOMOBILE_ASSET_BASE_URL`. */
+export function resolveIpaUrl(env: EnvLike = process.env): string {
+  return buildReleaseAssetUrl("control-proxy.ipa", resolvePinnedVersion(env), resolveAssetBaseUrl(env));
+}
+
+/** Expected APK SHA-256 for the pinned version (empty string if unknown). */
+export function resolveApkChecksum(env: EnvLike = process.env): string {
+  return resolveChecksum(resolvePinnedVersion(env), "android");
+}
+
+/** Expected iOS IPA SHA-256 for the pinned version (empty string if unknown). */
+export function resolveIpaChecksum(env: EnvLike = process.env): string {
+  return resolveChecksum(resolvePinnedVersion(env), "ios");
+}
+
+/**
+ * Concrete `@kaeawc/auto-mobile@<version>` install specifier for user-facing
+ * advice. Never yields the floating `@latest` tag (which causes silent version
+ * drift between a human-started daemon and a pinned runner, #2746) — it resolves
+ * `AUTOMOBILE_VERSION`, falling back to the concrete newest registry entry.
+ */
+export function resolveDaemonInstallSpecifier(env: EnvLike = process.env): string {
+  return `${DAEMON_PACKAGE_NAME}@${resolveAssetVersion(resolvePinnedVersion(env))}`;
+}
+
+export const APK_URL: string = resolveApkUrl();
+export const APK_SHA256_CHECKSUM: string = resolveApkChecksum();
 
 export const IOS_CTRL_PROXY_RELEASE_VERSION: string = RELEASE_VERSION;
-export const IOS_CTRL_PROXY_IPA_URL: string = buildReleaseAssetUrl("control-proxy.ipa", IOS_CTRL_PROXY_RELEASE_VERSION);
-export const IOS_CTRL_PROXY_SHA256_CHECKSUM: string = resolveChecksum(IOS_CTRL_PROXY_RELEASE_VERSION, "ios");
+export const IOS_CTRL_PROXY_IPA_URL: string = resolveIpaUrl();
+export const IOS_CTRL_PROXY_SHA256_CHECKSUM: string = resolveIpaChecksum();
 export const IOS_CTRL_PROXY_APP_HASH: string = ""; // Hash of CtrlProxyApp.app (device build), empty = skip verification
 export const IOS_CTRL_PROXY_RUNNER_SHA256: string = ""; // SHA256 of runner binary (CtrlProxyUITests-Runner), empty = skip verification

--- a/src/daemon/debugTools.ts
+++ b/src/daemon/debugTools.ts
@@ -4,6 +4,7 @@ import { DaemonClient } from "./client";
 import { readFile } from "node:fs/promises";
 import { PidFileData } from "./types";
 import { Timer, defaultTimer } from "../utils/SystemTimer";
+import { resolveDaemonInstallSpecifier } from "../constants/release";
 
 /**
  * Daemon Debug Tools
@@ -125,7 +126,7 @@ export async function getDaemonHealthReport(
     if (report.daemonRunning && report.socketConnectable) {
       report.recommendations.push("Daemon is healthy and responsive.");
     } else if (!report.daemonRunning && !report.socketExists && !report.pidFileExists) {
-      report.recommendations.push("Daemon is not running. Start it with: bunx @kaeawc/auto-mobile@latest --daemon start");
+      report.recommendations.push(`Daemon is not running. Start it with: bunx ${resolveDaemonInstallSpecifier()} --daemon start`);
     }
   }
 

--- a/src/daemon/manager.ts
+++ b/src/daemon/manager.ts
@@ -4,6 +4,7 @@ import { existsSync, openSync, closeSync, mkdirSync, readFileSync, unlinkSync, w
 import { dirname, join } from "node:path";
 import { logger } from "../utils/logger";
 import { releaseVersion } from "../utils/mcpVersion";
+import { resolveDaemonInstallSpecifier } from "../constants/release";
 import { ensureSecureTempDirSync, TEMP_SUBDIRS } from "../utils/tempDir";
 import { ActionableError } from "../models";
 import {
@@ -1142,7 +1143,7 @@ export async function runDaemonCommand(
               console.log(`  - PID ${pid}`);
             }
             console.log(
-              `\nThese can cause device pool conflicts. Run 'bunx @kaeawc/auto-mobile@latest --daemon restart' to stop them.`
+              `\nThese can cause device pool conflicts. Run 'bunx ${resolveDaemonInstallSpecifier()} --daemon restart' to stop them.`
             );
           }
         } else {

--- a/src/daemon/socketServer.ts
+++ b/src/daemon/socketServer.ts
@@ -23,12 +23,13 @@ import type { FeatureFlagService } from "../features/featureFlags/FeatureFlagSer
 import type { FeatureFlagKey } from "../features/featureFlags/FeatureFlagDefinitions";
 import { getMcpServerVersion } from "../utils/mcpVersion";
 import {
-  RELEASE_VERSION,
-  APK_URL,
-  IOS_CTRL_PROXY_RELEASE_VERSION,
-  IOS_CTRL_PROXY_IPA_URL,
   IOS_CTRL_PROXY_APP_HASH,
-  resolveChecksum,
+  resolveApkChecksum,
+  resolveApkUrl,
+  resolveAssetVersion,
+  resolveIpaChecksum,
+  resolveIpaUrl,
+  resolvePinnedVersion,
 } from "../constants/release";
 import { AndroidCtrlProxyManager } from "../utils/CtrlProxyManager";
 import { IOSCtrlProxyManager } from "../utils/IOSCtrlProxyManager";
@@ -558,19 +559,22 @@ export class UnixSocketServer {
       }
       case "ide/status": {
         return {
+          // Concrete pinned version (honors AUTOMOBILE_VERSION), never the
+          // floating "latest" tag — external consumers must see exactly what the
+          // daemon will fetch (#2746).
           version: getMcpServerVersion(),
-          releaseVersion: RELEASE_VERSION,
+          releaseVersion: resolveAssetVersion(resolvePinnedVersion()),
           android: {
             ctrlProxy: {
-              expectedSha256: resolveChecksum(RELEASE_VERSION, "android"),
-              url: APK_URL,
+              expectedSha256: resolveApkChecksum(),
+              url: resolveApkUrl(),
             },
           },
           ios: {
             xcTestService: {
-              expectedSha256: resolveChecksum(IOS_CTRL_PROXY_RELEASE_VERSION, "ios"),
+              expectedSha256: resolveIpaChecksum(),
               expectedAppHash: IOS_CTRL_PROXY_APP_HASH,
-              url: IOS_CTRL_PROXY_IPA_URL,
+              url: resolveIpaUrl(),
             },
           },
         };

--- a/src/doctor/checks/automobile.ts
+++ b/src/doctor/checks/automobile.ts
@@ -248,6 +248,19 @@ export async function checkCtrlProxy(
 
     // Check first connected device
     const device = devices[0];
+
+    // An unverifiable explicit pin is a hard configuration failure — surface it as
+    // `fail` (not the `skip` the thrown guard would otherwise become in the catch),
+    // so the documented `--cli doctor` CI gate actually blocks (#2746).
+    if (AndroidCtrlProxyManager.isPinnedVersionUnverifiable()) {
+      return {
+        name: "CtrlProxy",
+        status: "fail",
+        message: `platform=${device.platform}; device=${device.deviceId}; AUTOMOBILE_VERSION=${resolvePinnedVersion()} is not in the release checksum registry`,
+        recommendation: "The pinned CtrlProxy APK cannot be integrity-verified. Pin a released version, or set AUTOMOBILE_SKIP_ACCESSIBILITY_CHECKSUM=1 to override.",
+      };
+    }
+
     // Reset cached instances to ensure fresh ADB reads for doctor diagnostics
     // (getInstance memoizes isInstalled/isEnabled for 30 minutes which can report stale state)
     AndroidCtrlProxyManager.resetInstances();

--- a/src/doctor/checks/automobile.ts
+++ b/src/doctor/checks/automobile.ts
@@ -16,7 +16,12 @@ import {
   getCurrentBuildIdentity,
 } from "../../daemon/buildIdentity";
 import type { BuildIdentity } from "../../daemon/buildIdentity";
-import { LATEST_RELEASE_VERSION, RELEASE_VERSION, resolveAssetVersion } from "../../constants/release";
+import {
+  LATEST_RELEASE_VERSION,
+  resolveAssetVersion,
+  resolveDaemonInstallSpecifier,
+  resolvePinnedVersion,
+} from "../../constants/release";
 import { getMcpServerVersion } from "../../utils/mcpVersion";
 import { defaultAdbClientFactory } from "../../utils/android-cmdline-tools/AdbClientFactory";
 import type { AdbClientFactory } from "../../utils/android-cmdline-tools/AdbClientFactory";
@@ -64,11 +69,12 @@ export function checkDaemonVersion(): CheckResult {
  * comes from the release registry.
  */
 export function checkCtrlProxyVersion(): CheckResult {
-  const resolved = resolveAssetVersion(RELEASE_VERSION);
+  const pinned = resolvePinnedVersion();
+  const resolved = resolveAssetVersion(pinned);
   return {
     name: "CtrlProxy Release Version",
     status: "pass",
-    message: `Version ${resolved}${RELEASE_VERSION === LATEST_RELEASE_VERSION ? " (latest)" : ""}`,
+    message: `Version ${resolved}${pinned === LATEST_RELEASE_VERSION ? " (latest)" : ""}`,
     value: resolved,
   };
 }
@@ -106,14 +112,14 @@ export async function checkDaemonStatus(
       name: "Daemon Status",
       status: "warn",
       message: "Daemon is not running",
-      recommendation: "Start the daemon with: bunx @kaeawc/auto-mobile@latest --daemon start",
+      recommendation: `Start the daemon with: bunx ${resolveDaemonInstallSpecifier()} --daemon start`,
     };
   } catch (error) {
     return {
       name: "Daemon Status",
       status: "warn",
       message: `Could not check daemon: ${error instanceof Error ? error.message : String(error)}`,
-      recommendation: "Try: bunx @kaeawc/auto-mobile@latest --daemon start",
+      recommendation: `Try: bunx ${resolveDaemonInstallSpecifier()} --daemon start`,
     };
   }
 }
@@ -147,7 +153,7 @@ export async function checkDaemonConnectivity(
       name: "Daemon Connectivity",
       status: "warn",
       message: "Daemon running but not responding",
-      recommendation: report.recommendations.join("; ") || "Try: bunx @kaeawc/auto-mobile@latest --daemon restart",
+      recommendation: report.recommendations.join("; ") || `Try: bunx ${resolveDaemonInstallSpecifier()} --daemon restart`,
     };
   } catch (error) {
     return {
@@ -425,7 +431,7 @@ export async function checkWorkProfileAccessibility(
       name: "Work Profile Accessibility",
       status: "warn",
       message: `Accessibility service not enabled for work profile(s): ${profileList}`,
-      recommendation: "The accessibility service needs to be enabled in each work profile for full app install tracking. Run bunx @kaeawc/auto-mobile@latest --cli doctor or enable manually in Settings > Accessibility.",
+      recommendation: `The accessibility service needs to be enabled in each work profile for full app install tracking. Run bunx ${resolveDaemonInstallSpecifier()} --cli doctor or enable manually in Settings > Accessibility.`,
     };
   } catch (error) {
     logger.debug(`Work profile accessibility check failed: ${error}`);

--- a/src/doctor/checks/ios.ts
+++ b/src/doctor/checks/ios.ts
@@ -13,6 +13,7 @@ import { CheckResult, DoctorOptions } from "../types";
 import { SimCtl, SimCtlClient } from "../../utils/ios-cmdline-tools/SimCtlClient";
 import { logger, type Logger } from "../../utils/logger";
 import { resolveAssetVersion, resolvePinnedVersion } from "../../constants/release";
+import { IOSCtrlProxyBuilder } from "../../utils/IOSCtrlProxyBuilder";
 import { IOSCtrlProxyManager } from "../../utils/IOSCtrlProxyManager";
 import { IOSCtrlProxyClient, IOS_RUNNER_FEATURE_COMMANDS } from "../../features/observe/ios/IOSCtrlProxyClient";
 import { ObserveElementsBuilder } from "../../features/observe/ObserveElementsBuilder";
@@ -991,6 +992,18 @@ export async function checkIosCtrlProxyRunner(
         name,
         status: "skip",
         message: "No booted simulators to check",
+      };
+    }
+
+    // An unverifiable explicit pin is a hard configuration failure — classifyRunner
+    // only checks the advertised command set, so without this a running runner would
+    // still report `pass` and leave the `doctor --ios` hermetic gate green (#2746).
+    if (IOSCtrlProxyBuilder.isPinnedVersionUnverifiable()) {
+      return {
+        name,
+        status: "fail",
+        message: `AUTOMOBILE_VERSION=${resolvePinnedVersion()} is not in the release checksum registry`,
+        recommendation: "The pinned CtrlProxy bundle cannot be integrity-verified. Pin a released version, or vendor a trusted bundle via AUTOMOBILE_CTRL_PROXY_IOS_IPA_PATH.",
       };
     }
 

--- a/src/doctor/checks/ios.ts
+++ b/src/doctor/checks/ios.ts
@@ -12,7 +12,7 @@ import type { BootedDevice, ExecResult } from "../../models";
 import { CheckResult, DoctorOptions } from "../types";
 import { SimCtl, SimCtlClient } from "../../utils/ios-cmdline-tools/SimCtlClient";
 import { logger, type Logger } from "../../utils/logger";
-import { IOS_CTRL_PROXY_RELEASE_VERSION, resolveAssetVersion } from "../../constants/release";
+import { resolveAssetVersion, resolvePinnedVersion } from "../../constants/release";
 import { IOSCtrlProxyManager } from "../../utils/IOSCtrlProxyManager";
 import { IOSCtrlProxyClient, IOS_RUNNER_FEATURE_COMMANDS } from "../../features/observe/ios/IOSCtrlProxyClient";
 import { ObserveElementsBuilder } from "../../features/observe/ObserveElementsBuilder";
@@ -994,7 +994,9 @@ export async function checkIosCtrlProxyRunner(
       };
     }
 
-    const expectedVersion = resolveAssetVersion(IOS_CTRL_PROXY_RELEASE_VERSION);
+    // Honor AUTOMOBILE_VERSION so a pinned runner is not falsely flagged "stale"
+    // against the newest registry entry (#2746).
+    const expectedVersion = resolveAssetVersion(resolvePinnedVersion());
     const classifications = inspections.map(inspection => classifyRunner(inspection, expectedVersion));
 
     const message = classifications.map(classification => classification.line).join(" | ");

--- a/src/doctor/index.ts
+++ b/src/doctor/index.ts
@@ -8,7 +8,7 @@ import { runSystemChecks } from "./checks/system";
 import { runAndroidChecks } from "./checks/android";
 import { runIosChecks } from "./checks/ios";
 import { runAutoMobileChecks, checkDaemonBuildIdentity } from "./checks/automobile";
-import { RELEASE_VERSION } from "../constants/release";
+import { resolveAssetVersion, resolvePinnedVersion } from "../constants/release";
 
 /**
  * Calculate summary statistics from check results
@@ -97,7 +97,8 @@ export async function runDoctor(
 
   const report: DoctorReport = {
     timestamp: new Date().toISOString(),
-    version: RELEASE_VERSION,
+    // Concrete pinned version (honors AUTOMOBILE_VERSION), never the "latest" literal (#2746).
+    version: resolveAssetVersion(resolvePinnedVersion()),
     platform: process.platform,
     arch: process.arch,
     system: { checks: systemChecks },

--- a/src/server/bootedDeviceResources.ts
+++ b/src/server/bootedDeviceResources.ts
@@ -8,6 +8,7 @@ import type { Session } from "../daemon/sessionManager";
 import type { DevicePool } from "../daemon/devicePool";
 import { AndroidCtrlProxyManager } from "../utils/CtrlProxyManager";
 import { IOSCtrlProxyManager } from "../utils/IOSCtrlProxyManager";
+import { IOSCtrlProxyBuilder } from "../utils/IOSCtrlProxyBuilder";
 import { IOSCtrlProxyClient, IOS_RUNNER_FEATURE_COMMANDS } from "../features/observe/ios/IOSCtrlProxyClient";
 import {
   resolveApkChecksum,
@@ -442,8 +443,10 @@ async function queryDeviceServiceStatus(device: BootedDeviceInfo): Promise<Devic
       // Only claim compatibility we can actually verify. isCompatible is true
       // *only* when the runner's advertised command set is known complete; a stale
       // runner (incomplete) or an unknown one (no cached handshake yet) is reported
-      // not-compatible rather than the previous always-true reassurance.
-      const isCompatible = supportedCommandsComplete === true;
+      // not-compatible rather than the previous always-true reassurance. An
+      // unverifiable explicit pin is never compatible (#2746).
+      const isCompatible = supportedCommandsComplete === true &&
+        !IOSCtrlProxyBuilder.isPinnedVersionUnverifiable();
 
       return {
         installed,

--- a/src/server/bootedDeviceResources.ts
+++ b/src/server/bootedDeviceResources.ts
@@ -10,9 +10,8 @@ import { AndroidCtrlProxyManager } from "../utils/CtrlProxyManager";
 import { IOSCtrlProxyManager } from "../utils/IOSCtrlProxyManager";
 import { IOSCtrlProxyClient, IOS_RUNNER_FEATURE_COMMANDS } from "../features/observe/ios/IOSCtrlProxyClient";
 import {
-  IOS_CTRL_PROXY_RELEASE_VERSION,
-  RELEASE_VERSION,
-  resolveChecksum,
+  resolveApkChecksum,
+  resolveIpaChecksum,
 } from "../constants/release";
 import { defaultTimer } from "../utils/SystemTimer";
 
@@ -404,7 +403,7 @@ async function queryDeviceServiceStatus(device: BootedDeviceInfo): Promise<Devic
         manager.isEnabled(),
         manager.getInstalledApkSha256(),
       ]);
-      const expectedSha256 = resolveChecksum(RELEASE_VERSION, "android");
+      const expectedSha256 = resolveApkChecksum();
       const isCompatible = expectedSha256.length === 0 ||
         (installedSha256 !== null && installedSha256.toLowerCase() === expectedSha256.toLowerCase());
       return {
@@ -421,7 +420,7 @@ async function queryDeviceServiceStatus(device: BootedDeviceInfo): Promise<Devic
         manager.isInstalled(),
         manager.isRunning(),
       ]);
-      const expectedSha256 = resolveChecksum(IOS_CTRL_PROXY_RELEASE_VERSION, "ios");
+      const expectedSha256 = resolveIpaChecksum();
 
       // The iOS runner exposes no hash/version, so identity comes from the cached
       // `supportedCommands` handshake. Read it connection-free (this hot path must

--- a/src/server/bootedDeviceResources.ts
+++ b/src/server/bootedDeviceResources.ts
@@ -404,8 +404,12 @@ async function queryDeviceServiceStatus(device: BootedDeviceInfo): Promise<Devic
         manager.getInstalledApkSha256(),
       ]);
       const expectedSha256 = resolveApkChecksum();
-      const isCompatible = expectedSha256.length === 0 ||
-        (installedSha256 !== null && installedSha256.toLowerCase() === expectedSha256.toLowerCase());
+      // An explicit pin absent from the registry yields an empty expected checksum,
+      // which must NOT read as "compatible" — the installed APK is unverifiable (#2746).
+      const isCompatible = !AndroidCtrlProxyManager.isPinnedVersionUnverifiable() && (
+        expectedSha256.length === 0 ||
+        (installedSha256 !== null && installedSha256.toLowerCase() === expectedSha256.toLowerCase())
+      );
       return {
         installed,
         enabled,

--- a/src/utils/CtrlProxyManager.ts
+++ b/src/utils/CtrlProxyManager.ts
@@ -234,12 +234,7 @@ export class AndroidCtrlProxyManager implements CtrlProxyManager {
     // Fail closed before touching the network: don't background-download and cache
     // an unverifiable APK for an unknown explicit pin (#2746). Skipping (not
     // throwing) keeps daemon startup alive; the install path still fails closed.
-    if (
-      isExplicitPin() &&
-      !isPinnedVersionKnown() &&
-      AndroidCtrlProxyManager.expectedChecksumOverride === null &&
-      !AndroidCtrlProxyManager.isChecksumSkipConfigured()
-    ) {
+    if (AndroidCtrlProxyManager.isPinnedVersionUnverifiable()) {
       logger.warn(
         `[CTRL_PROXY] Prefetch skipped: AUTOMOBILE_VERSION=${resolvePinnedVersion()} is not in the ` +
         `release checksum registry, so the APK cannot be integrity-verified`
@@ -1530,7 +1525,7 @@ export class AndroidCtrlProxyManager implements CtrlProxyManager {
    * (or a local APK path override) is the explicit escape hatch.
    */
   private assertPinnedVersionVerifiable(): void {
-    if (isExplicitPin() && !isPinnedVersionKnown() && !this.shouldSkipChecksum()) {
+    if (AndroidCtrlProxyManager.isPinnedVersionUnverifiable()) {
       throw new ActionableError(
         `AUTOMOBILE_VERSION=${resolvePinnedVersion()} is not in the AutoMobile release ` +
         `checksum registry, so the CtrlProxy APK cannot be integrity-verified. ` +
@@ -1621,6 +1616,23 @@ export class AndroidCtrlProxyManager implements CtrlProxyManager {
     }
     const apkPathOverride = process.env.AUTOMOBILE_CTRL_PROXY_APK_PATH?.trim();
     return Boolean(apkPathOverride && apkPathOverride.length > 0);
+  }
+
+  /**
+   * Single source of truth for the fail-closed decision: `AUTOMOBILE_VERSION` names
+   * a concrete version absent from the checksum registry, with no escape hatch set,
+   * so the APK cannot be integrity-verified (#2746). Consumed by the download/readiness
+   * guards, the startup prefetch, `doctor`, and the booted-device compatibility check
+   * so they can't drift apart.
+   */
+  static isPinnedVersionUnverifiable(): boolean {
+    if (AndroidCtrlProxyManager.expectedChecksumOverride !== null) {
+      return false;
+    }
+    if (AndroidCtrlProxyManager.isChecksumSkipConfigured()) {
+      return false;
+    }
+    return isExplicitPin() && !isPinnedVersionKnown();
   }
 
   private shouldSkipDownloadIfInstalled(): boolean {

--- a/src/utils/CtrlProxyManager.ts
+++ b/src/utils/CtrlProxyManager.ts
@@ -231,6 +231,22 @@ export class AndroidCtrlProxyManager implements CtrlProxyManager {
    * Internal prefetch implementation
    */
   private static async doPrefetch(): Promise<string | null> {
+    // Fail closed before touching the network: don't background-download and cache
+    // an unverifiable APK for an unknown explicit pin (#2746). Skipping (not
+    // throwing) keeps daemon startup alive; the install path still fails closed.
+    if (
+      isExplicitPin() &&
+      !isPinnedVersionKnown() &&
+      AndroidCtrlProxyManager.expectedChecksumOverride === null &&
+      !AndroidCtrlProxyManager.isChecksumSkipConfigured()
+    ) {
+      logger.warn(
+        `[CTRL_PROXY] Prefetch skipped: AUTOMOBILE_VERSION=${resolvePinnedVersion()} is not in the ` +
+        `release checksum registry, so the APK cannot be integrity-verified`
+      );
+      return null;
+    }
+
     const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "auto-mobile-prefetch-"));
     const apkPath = path.join(tempDir, "control-proxy.apk");
 
@@ -1589,13 +1605,22 @@ export class AndroidCtrlProxyManager implements CtrlProxyManager {
   }
 
   private shouldSkipChecksum(): boolean {
+    return AndroidCtrlProxyManager.isChecksumSkipConfigured();
+  }
+
+  /**
+   * Env-only view of the checksum-skip escape hatches, usable from the static
+   * prefetch path (which has no instance). Mirrors {@link shouldSkipChecksum}.
+   */
+  private static isChecksumSkipConfigured(): boolean {
     // @deprecated AUTO_MOBILE_ACCESSIBILITY_SERVICE_SHA_SKIP_CHECK - use AUTOMOBILE_SKIP_ACCESSIBILITY_CHECKSUM instead
     const explicitSkip = process.env.AUTOMOBILE_SKIP_ACCESSIBILITY_CHECKSUM ??
       process.env.AUTO_MOBILE_ACCESSIBILITY_SERVICE_SHA_SKIP_CHECK;
     if (explicitSkip && (explicitSkip === "1" || explicitSkip.toLowerCase() === "true")) {
       return true;
     }
-    return this.getApkPathOverride() !== null;
+    const apkPathOverride = process.env.AUTOMOBILE_CTRL_PROXY_APK_PATH?.trim();
+    return Boolean(apkPathOverride && apkPathOverride.length > 0);
   }
 
   private shouldSkipDownloadIfInstalled(): boolean {

--- a/src/utils/CtrlProxyManager.ts
+++ b/src/utils/CtrlProxyManager.ts
@@ -6,10 +6,8 @@ import * as path from "path";
 import { BootedDevice } from "../models";
 import { requireBootedDevice } from "./requireBootedDevice";
 import {
-  APK_SHA256_CHECKSUM,
-  APK_URL,
-  RELEASE_VERSION,
-  resolveChecksum
+  resolveApkChecksum,
+  resolveApkUrl
 } from "../constants/release";
 import AdmZip from "adm-zip";
 import crypto from "crypto";
@@ -83,7 +81,6 @@ export class AndroidCtrlProxyManager implements CtrlProxyManager {
   public static readonly ACTIVITY = "dev.jasonpearson.automobile.ctrlproxy.MainActivity";
   /** Package name used before the rename to CtrlProxy — uninstalled opportunistically on device setup */
   private static readonly LEGACY_PACKAGE = "dev.jasonpearson.automobile.accessibilityservice";
-  private static readonly APK_URL = APK_URL;
 
   // Static cache for service availability
   private cachedAvailability: { isAvailable: boolean; timestamp: number } | null = null;
@@ -235,9 +232,10 @@ export class AndroidCtrlProxyManager implements CtrlProxyManager {
     const apkPath = path.join(tempDir, "control-proxy.apk");
 
     try {
-      // Download the APK
-      logger.info("[CTRL_PROXY] Prefetch: downloading APK", { url: APK_URL, destination: apkPath });
-      await AndroidCtrlProxyManager.defaultFileDownloader.download(APK_URL, apkPath);
+      // Download the APK (URL honors AUTOMOBILE_VERSION + AUTOMOBILE_ASSET_BASE_URL)
+      const apkUrl = resolveApkUrl();
+      logger.info("[CTRL_PROXY] Prefetch: downloading APK", { url: apkUrl, destination: apkPath });
+      await AndroidCtrlProxyManager.defaultFileDownloader.download(apkUrl, apkPath);
 
       // Verify the file exists and has reasonable size
       const stats = await fs.stat(apkPath);
@@ -249,7 +247,7 @@ export class AndroidCtrlProxyManager implements CtrlProxyManager {
       AndroidCtrlProxyManager.verifyApkIntegrityStatic(apkPath);
 
       // Verify checksum if provided
-      const expectedChecksum = AndroidCtrlProxyManager.expectedChecksumOverride ?? APK_SHA256_CHECKSUM;
+      const expectedChecksum = AndroidCtrlProxyManager.expectedChecksumOverride ?? resolveApkChecksum();
       if (expectedChecksum.length > 0) {
         const { checksum: actualChecksum } = await AndroidCtrlProxyManager.defaultChecksumCalculator.computeFileSha256(apkPath);
         if (actualChecksum.toLowerCase() !== expectedChecksum.toLowerCase()) {
@@ -822,8 +820,9 @@ export class AndroidCtrlProxyManager implements CtrlProxyManager {
         if (usedPrefetch) {
           logger.info("Using prefetched accessibility service APK", { path: apkPath });
         } else {
-          logger.info("Downloading APK", { url: AndroidCtrlProxyManager.APK_URL, destination: apkPath });
-          await this.fileDownloader.download(AndroidCtrlProxyManager.APK_URL, apkPath);
+          const apkUrl = resolveApkUrl();
+          logger.info("Downloading APK", { url: apkUrl, destination: apkPath });
+          await this.fileDownloader.download(apkUrl, apkPath);
         }
       }
       perf.endOperation("httpDownload");
@@ -856,7 +855,7 @@ export class AndroidCtrlProxyManager implements CtrlProxyManager {
         perf.endOperation("checksumVerify");
       } else {
         logger.warn("APK checksum verification SKIPPED - no checksum provided (development mode)", {
-          apkUrl: AndroidCtrlProxyManager.APK_URL
+          apkUrl: resolveApkUrl()
         });
       }
 
@@ -1494,7 +1493,7 @@ export class AndroidCtrlProxyManager implements CtrlProxyManager {
     if (this.shouldSkipChecksum()) {
       return "";
     }
-    return AndroidCtrlProxyManager.expectedChecksumOverride ?? resolveChecksum(RELEASE_VERSION, "android");
+    return AndroidCtrlProxyManager.expectedChecksumOverride ?? resolveApkChecksum();
   }
 
   private getCachedVersionCheckResult(): AccessibilityVersionCheckResult | null {

--- a/src/utils/CtrlProxyManager.ts
+++ b/src/utils/CtrlProxyManager.ts
@@ -574,6 +574,10 @@ export class AndroidCtrlProxyManager implements CtrlProxyManager {
   async ensureCompatibleVersion(options: AccessibilityVersionCheckOptions = {}): Promise<AccessibilityVersionCheckResult> {
     const perf = createGlobalPerformanceTracker();
 
+    // Fail closed before any readiness shortcut (skipped/acceptedPreinstalled) can
+    // accept an unverifiable APK for an unknown explicit pin (#2746).
+    this.assertPinnedVersionVerifiable();
+
     if (!options.bypassVersionCheckCache && !options.allowDownloadWhenInstalled) {
       const cachedResult = this.getCachedVersionCheckResult();
       if (cachedResult) {
@@ -803,6 +807,9 @@ export class AndroidCtrlProxyManager implements CtrlProxyManager {
    * Download APK
    */
   async downloadApk(): Promise<string> {
+    // Defense-in-depth for direct callers: fail closed on an unverifiable pin
+    // before touching the filesystem or network (#2746).
+    this.assertPinnedVersionVerifiable();
     const perf = createGlobalPerformanceTracker();
     const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "auto-mobile-"));
     const apkPath = path.join(tempDir, "control-proxy.apk");
@@ -856,16 +863,6 @@ export class AndroidCtrlProxyManager implements CtrlProxyManager {
 
         logger.info("APK checksum verified successfully", { checksum: normalizedActual, source });
         perf.endOperation("checksumVerify");
-      } else if (isExplicitPin() && !isPinnedVersionKnown() && !this.shouldSkipChecksum()) {
-        // Fail closed: an explicitly-pinned version with no registry checksum cannot
-        // be integrity-verified. Silently downloading it (esp. from a mirror) would
-        // defeat the point of pinning (#2746). The skip override remains the escape
-        // hatch for a real-but-not-yet-baked release.
-        throw new ActionableError(
-          `AUTOMOBILE_VERSION=${resolvePinnedVersion()} is not in the AutoMobile release ` +
-          `checksum registry, so the downloaded CtrlProxy APK cannot be integrity-verified. ` +
-          `Pin a released version, or set AUTOMOBILE_SKIP_ACCESSIBILITY_CHECKSUM=1 to override.`
-        );
       } else {
         logger.warn("APK checksum verification SKIPPED - no checksum provided (development mode)", {
           apkUrl: resolveApkUrl()
@@ -1507,6 +1504,23 @@ export class AndroidCtrlProxyManager implements CtrlProxyManager {
       return "";
     }
     return AndroidCtrlProxyManager.expectedChecksumOverride ?? resolveApkChecksum();
+  }
+
+  /**
+   * Fail closed when a concrete `AUTOMOBILE_VERSION` is pinned to a version absent
+   * from the baked checksum registry: the APK cannot be integrity-verified, so
+   * silently downloading it — or accepting an already-installed APK of unknown
+   * provenance — defeats the point of pinning (#2746). `AUTOMOBILE_SKIP_ACCESSIBILITY_CHECKSUM`
+   * (or a local APK path override) is the explicit escape hatch.
+   */
+  private assertPinnedVersionVerifiable(): void {
+    if (isExplicitPin() && !isPinnedVersionKnown() && !this.shouldSkipChecksum()) {
+      throw new ActionableError(
+        `AUTOMOBILE_VERSION=${resolvePinnedVersion()} is not in the AutoMobile release ` +
+        `checksum registry, so the CtrlProxy APK cannot be integrity-verified. ` +
+        `Pin a released version, or set AUTOMOBILE_SKIP_ACCESSIBILITY_CHECKSUM=1 to override.`
+      );
+    }
   }
 
   private getCachedVersionCheckResult(): AccessibilityVersionCheckResult | null {

--- a/src/utils/CtrlProxyManager.ts
+++ b/src/utils/CtrlProxyManager.ts
@@ -3,11 +3,14 @@ import type { AdbExecutor } from "./android-cmdline-tools/interfaces/AdbExecutor
 import { logger } from "./logger";
 import * as fs from "fs/promises";
 import * as path from "path";
-import { BootedDevice } from "../models";
+import { ActionableError, BootedDevice } from "../models";
 import { requireBootedDevice } from "./requireBootedDevice";
 import {
+  isExplicitPin,
+  isPinnedVersionKnown,
   resolveApkChecksum,
-  resolveApkUrl
+  resolveApkUrl,
+  resolvePinnedVersion
 } from "../constants/release";
 import AdmZip from "adm-zip";
 import crypto from "crypto";
@@ -853,6 +856,16 @@ export class AndroidCtrlProxyManager implements CtrlProxyManager {
 
         logger.info("APK checksum verified successfully", { checksum: normalizedActual, source });
         perf.endOperation("checksumVerify");
+      } else if (isExplicitPin() && !isPinnedVersionKnown() && !this.shouldSkipChecksum()) {
+        // Fail closed: an explicitly-pinned version with no registry checksum cannot
+        // be integrity-verified. Silently downloading it (esp. from a mirror) would
+        // defeat the point of pinning (#2746). The skip override remains the escape
+        // hatch for a real-but-not-yet-baked release.
+        throw new ActionableError(
+          `AUTOMOBILE_VERSION=${resolvePinnedVersion()} is not in the AutoMobile release ` +
+          `checksum registry, so the downloaded CtrlProxy APK cannot be integrity-verified. ` +
+          `Pin a released version, or set AUTOMOBILE_SKIP_ACCESSIBILITY_CHECKSUM=1 to override.`
+        );
       } else {
         logger.warn("APK checksum verification SKIPPED - no checksum provided (development mode)", {
           apkUrl: resolveApkUrl()

--- a/src/utils/IOSCtrlProxyBuilder.ts
+++ b/src/utils/IOSCtrlProxyBuilder.ts
@@ -371,6 +371,15 @@ export class IOSCtrlProxyBuilder {
     // wrong-version) runner without ever reaching verifyBundle's guard (#2746).
     this.assertPinnedVersionVerifiable();
 
+    // A vendored bundle override must always be (re)consumed: otherwise, on a
+    // reused host with an existing xctestrun + metadata, needsRebuild() would
+    // return false and silently keep the stale cached runner instead of the
+    // vendored IPA — the documented escape hatch would be a no-op (#2746).
+    if (this.getBundlePathOverride() !== null) {
+      logger.info("[IOSCtrlProxyBuilder] CtrlProxy bundle path override set, forcing extraction of the vendored bundle");
+      return true;
+    }
+
     const xctestrunPath = await this.getXctestrunPath(platform);
     if (!xctestrunPath) {
       logger.info("[IOSCtrlProxyBuilder] CtrlProxy artifacts missing, need download");

--- a/src/utils/IOSCtrlProxyBuilder.ts
+++ b/src/utils/IOSCtrlProxyBuilder.ts
@@ -366,6 +366,11 @@ export class IOSCtrlProxyBuilder {
       return false;
     }
 
+    // Fail closed here too: without this, an unknown explicit pin with a cached
+    // bundle + metadata would return false and silently reuse the cached (possibly
+    // wrong-version) runner without ever reaching verifyBundle's guard (#2746).
+    this.assertPinnedVersionVerifiable();
+
     const xctestrunPath = await this.getXctestrunPath(platform);
     if (!xctestrunPath) {
       logger.info("[IOSCtrlProxyBuilder] CtrlProxy artifacts missing, need download");
@@ -762,22 +767,31 @@ export class IOSCtrlProxyBuilder {
         throw new Error(`CtrlProxy checksum verification failed. Expected: ${expectedChecksum}, Got: ${checksum}`);
       }
       logger.info("[IOSCtrlProxyBuilder] Bundle checksum verified", { checksum, source });
-    } else if (
+    } else {
+      this.assertPinnedVersionVerifiable();
+      logger.warn("[IOSCtrlProxyBuilder] Bundle checksum verification skipped (no checksum provided)");
+    }
+  }
+
+  /**
+   * Fail closed when a concrete `AUTOMOBILE_VERSION` is pinned to a version absent
+   * from the baked checksum registry: the bundle cannot be integrity-verified, so
+   * silently downloading or reusing it defeats the point of pinning (#2746). A
+   * vendored bundle (`AUTOMOBILE_CTRL_PROXY_IOS_IPA_PATH`) or an explicit checksum
+   * override is the trusted escape hatch.
+   */
+  private assertPinnedVersionVerifiable(): void {
+    if (
       isExplicitPin() &&
       !isPinnedVersionKnown() &&
       IOSCtrlProxyBuilder.expectedChecksumOverride === null &&
       this.getBundlePathOverride() === null
     ) {
-      // Fail closed: an explicitly-pinned version with no registry checksum cannot
-      // be integrity-verified. A vendored bundle (AUTOMOBILE_CTRL_PROXY_IOS_IPA_PATH)
-      // or an explicit checksum override is the trusted escape hatch (#2746).
       throw new ActionableError(
         `AUTOMOBILE_VERSION=${resolvePinnedVersion()} is not in the AutoMobile release ` +
-        `checksum registry, so the downloaded CtrlProxy bundle cannot be integrity-verified. ` +
+        `checksum registry, so the CtrlProxy bundle cannot be integrity-verified. ` +
         `Pin a released version, or vendor a trusted bundle via AUTOMOBILE_CTRL_PROXY_IOS_IPA_PATH.`
       );
-    } else {
-      logger.warn("[IOSCtrlProxyBuilder] Bundle checksum verification skipped (no checksum provided)");
     }
   }
 

--- a/src/utils/IOSCtrlProxyBuilder.ts
+++ b/src/utils/IOSCtrlProxyBuilder.ts
@@ -790,18 +790,32 @@ export class IOSCtrlProxyBuilder {
    * override is the trusted escape hatch.
    */
   private assertPinnedVersionVerifiable(): void {
-    if (
-      isExplicitPin() &&
-      !isPinnedVersionKnown() &&
-      IOSCtrlProxyBuilder.expectedChecksumOverride === null &&
-      this.getBundlePathOverride() === null
-    ) {
+    if (IOSCtrlProxyBuilder.isPinnedVersionUnverifiable()) {
       throw new ActionableError(
         `AUTOMOBILE_VERSION=${resolvePinnedVersion()} is not in the AutoMobile release ` +
         `checksum registry, so the CtrlProxy bundle cannot be integrity-verified. ` +
         `Pin a released version, or vendor a trusted bundle via AUTOMOBILE_CTRL_PROXY_IOS_IPA_PATH.`
       );
     }
+  }
+
+  /**
+   * Single source of truth for the iOS fail-closed decision: `AUTOMOBILE_VERSION`
+   * names a concrete version absent from the checksum registry, with no escape hatch
+   * (vendored IPA/bundle path or explicit checksum override), so the CtrlProxy bundle
+   * cannot be integrity-verified (#2746). Reused by the build/reuse guards,
+   * `IOSCtrlProxyManager.setup()`, `doctor --ios`, and the booted-device compat check.
+   */
+  static isPinnedVersionUnverifiable(): boolean {
+    if (IOSCtrlProxyBuilder.expectedChecksumOverride !== null) {
+      return false;
+    }
+    const ipaPath = process.env.AUTOMOBILE_CTRL_PROXY_IOS_IPA_PATH?.trim();
+    const bundlePath = process.env.AUTOMOBILE_CTRL_PROXY_IOS_BUNDLE_PATH?.trim();
+    if ((ipaPath && ipaPath.length > 0) || (bundlePath && bundlePath.length > 0)) {
+      return false;
+    }
+    return isExplicitPin() && !isPinnedVersionKnown();
   }
 
   private async extractBundle(bundlePath: string): Promise<void> {

--- a/src/utils/IOSCtrlProxyBuilder.ts
+++ b/src/utils/IOSCtrlProxyBuilder.ts
@@ -6,12 +6,12 @@ import { defaultTimer, type Timer } from "./SystemTimer";
 import { NoOpPerformanceTracker, type PerformanceTracker } from "./PerformanceTracker";
 import {
   IOS_CTRL_PROXY_APP_HASH,
-  IOS_CTRL_PROXY_IPA_URL,
-  IOS_CTRL_PROXY_RELEASE_VERSION,
   IOS_CTRL_PROXY_RUNNER_SHA256,
-  IOS_CTRL_PROXY_SHA256_CHECKSUM,
   LATEST_RELEASE_VERSION,
-  resolveAssetVersion
+  resolveAssetVersion,
+  resolveIpaChecksum,
+  resolveIpaUrl,
+  resolvePinnedVersion
 } from "../constants/release";
 import {
   DefaultIOSCtrlProxyBundleDownloader,
@@ -645,7 +645,7 @@ export class IOSCtrlProxyBuilder {
     if (override) {
       return override;
     }
-    return IOS_CTRL_PROXY_IPA_URL;
+    return resolveIpaUrl();
   }
 
   private getBundlePathOverride(): string | null {
@@ -661,7 +661,7 @@ export class IOSCtrlProxyBuilder {
     if (override !== null) {
       return override;
     }
-    return IOS_CTRL_PROXY_SHA256_CHECKSUM;
+    return resolveIpaChecksum();
   }
 
   public getExpectedAppHash(platform: IOSCtrlProxyPlatform): string {
@@ -703,7 +703,9 @@ export class IOSCtrlProxyBuilder {
       const bundleReady = await this.isBundleValid(bundlePath, expectedChecksum);
 
       if (!bundleReady) {
-        const isLatest = IOS_CTRL_PROXY_RELEASE_VERSION.trim().toLowerCase() === LATEST_RELEASE_VERSION;
+        // When a version is pinned (AUTOMOBILE_VERSION), hermetic mode disables the
+        // silent cached-bundle fallback so a failed download fails hard (#2746).
+        const isLatest = resolvePinnedVersion().trim().toLowerCase() === LATEST_RELEASE_VERSION;
         const cachedBundleExists = await this.isBundleValid(bundlePath, "");
         try {
           logger.info("[IOSCtrlProxyBuilder] Downloading CtrlProxy bundle", {
@@ -770,7 +772,7 @@ export class IOSCtrlProxyBuilder {
     const appHashes = await this.computeAppHashes();
     const metadata: IOSCtrlProxyBundleMetadata = {
       checksum: this.getExpectedChecksum() || null,
-      version: resolveAssetVersion(IOS_CTRL_PROXY_RELEASE_VERSION),
+      version: resolveAssetVersion(resolvePinnedVersion()),
       extractedAt: new Date().toISOString(),
       appHashes
     };

--- a/src/utils/IOSCtrlProxyBuilder.ts
+++ b/src/utils/IOSCtrlProxyBuilder.ts
@@ -8,6 +8,8 @@ import {
   IOS_CTRL_PROXY_APP_HASH,
   IOS_CTRL_PROXY_RUNNER_SHA256,
   LATEST_RELEASE_VERSION,
+  isExplicitPin,
+  isPinnedVersionKnown,
   resolveAssetVersion,
   resolveIpaChecksum,
   resolveIpaUrl,
@@ -25,7 +27,7 @@ import {
   parsePlist,
   type PlistValue
 } from "./ios-cmdline-tools/XctestrunPlist";
-import { toActionableError } from "../models/ActionableError";
+import { ActionableError, toActionableError } from "../models/ActionableError";
 
 /**
  * Result of CtrlProxy download/install
@@ -705,7 +707,8 @@ export class IOSCtrlProxyBuilder {
       if (!bundleReady) {
         // When a version is pinned (AUTOMOBILE_VERSION), hermetic mode disables the
         // silent cached-bundle fallback so a failed download fails hard (#2746).
-        const isLatest = resolvePinnedVersion().trim().toLowerCase() === LATEST_RELEASE_VERSION;
+        // resolvePinnedVersion already normalizes the `latest` sentinel.
+        const isLatest = resolvePinnedVersion() === LATEST_RELEASE_VERSION;
         const cachedBundleExists = await this.isBundleValid(bundlePath, "");
         try {
           logger.info("[IOSCtrlProxyBuilder] Downloading CtrlProxy bundle", {
@@ -759,6 +762,20 @@ export class IOSCtrlProxyBuilder {
         throw new Error(`CtrlProxy checksum verification failed. Expected: ${expectedChecksum}, Got: ${checksum}`);
       }
       logger.info("[IOSCtrlProxyBuilder] Bundle checksum verified", { checksum, source });
+    } else if (
+      isExplicitPin() &&
+      !isPinnedVersionKnown() &&
+      IOSCtrlProxyBuilder.expectedChecksumOverride === null &&
+      this.getBundlePathOverride() === null
+    ) {
+      // Fail closed: an explicitly-pinned version with no registry checksum cannot
+      // be integrity-verified. A vendored bundle (AUTOMOBILE_CTRL_PROXY_IOS_IPA_PATH)
+      // or an explicit checksum override is the trusted escape hatch (#2746).
+      throw new ActionableError(
+        `AUTOMOBILE_VERSION=${resolvePinnedVersion()} is not in the AutoMobile release ` +
+        `checksum registry, so the downloaded CtrlProxy bundle cannot be integrity-verified. ` +
+        `Pin a released version, or vendor a trusted bundle via AUTOMOBILE_CTRL_PROXY_IOS_IPA_PATH.`
+      );
     } else {
       logger.warn("[IOSCtrlProxyBuilder] Bundle checksum verification skipped (no checksum provided)");
     }

--- a/src/utils/IOSCtrlProxyManager.ts
+++ b/src/utils/IOSCtrlProxyManager.ts
@@ -4,6 +4,7 @@ import { requireBootedDevice } from "./requireBootedDevice";
 import { NoOpPerformanceTracker, createGlobalPerformanceTracker, type PerformanceTracker } from "./PerformanceTracker";
 import { Timer, defaultTimer } from "./SystemTimer";
 import { IOSCtrlProxyBuilder, type CtrlProxyIosBuildResult } from "./IOSCtrlProxyBuilder";
+import { resolvePinnedVersion } from "../constants/release";
 import { type ChildProcess } from "child_process";
 import { IOS_CTRL_PROXY_RESERVED_PORTS, PortManager } from "./PortManager";
 import { DefaultProcessExecutor, type ProcessExecutor } from "./ProcessExecutor";
@@ -783,6 +784,20 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
     perf: PerformanceTracker = new NoOpPerformanceTracker()
   ): Promise<CtrlProxyIosSetupResult> {
     perf.serial("xcTestServiceSetup");
+
+    // Fail closed before any reuse/short-circuit (already-running, already-attempted)
+    // can serve an unverifiable pinned runner (#2746).
+    if (IOSCtrlProxyBuilder.isPinnedVersionUnverifiable()) {
+      perf.end();
+      return {
+        success: false,
+        message:
+          `AUTOMOBILE_VERSION=${resolvePinnedVersion()} is not in the AutoMobile release ` +
+          `checksum registry, so the CtrlProxy bundle cannot be integrity-verified. ` +
+          `Pin a released version, or vendor a trusted bundle via AUTOMOBILE_CTRL_PROXY_IOS_IPA_PATH.`,
+        perfTiming: perf.getTimings()
+      };
+    }
 
     await this.uninstallLegacyAppIfPresent();
 

--- a/test/constants/release.test.ts
+++ b/test/constants/release.test.ts
@@ -7,6 +7,8 @@ import {
   IOS_CTRL_PROXY_IPA_URL,
   IOS_CTRL_PROXY_SHA256_CHECKSUM,
   RELEASE_CHECKSUM_REGISTRY,
+  isExplicitPin,
+  isPinnedVersionKnown,
   resolveApkChecksum,
   resolveApkUrl,
   resolveAssetBaseUrl,
@@ -217,5 +219,82 @@ describe("resolveDaemonInstallSpecifier (EC5)", function() {
   test("honors AUTOMOBILE_VERSION", function() {
     expect(resolveDaemonInstallSpecifier({ AUTOMOBILE_VERSION: "0.0.18" }))
       .toBe(`${DAEMON_PACKAGE_NAME}@0.0.18`);
+  });
+});
+
+// --- Review feedback: mixed-case `latest` normalization (Priya) ---
+
+describe("resolvePinnedVersion normalizes the 'latest' sentinel", function() {
+  const newest = RELEASE_CHECKSUM_REGISTRY[0];
+
+  test("upper/mixed-case latest collapses to the canonical 'latest'", function() {
+    expect(resolvePinnedVersion({ AUTOMOBILE_VERSION: "LATEST" })).toBe("latest");
+    expect(resolvePinnedVersion({ AUTOMOBILE_VERSION: " Latest " })).toBe("latest");
+  });
+
+  test("mixed-case latest yields a coherent url + checksum + specifier (no /LATEST/ 404)", function() {
+    const env = { AUTOMOBILE_VERSION: "LATEST" };
+    expect(resolveApkUrl(env)).toBe(`${DEFAULT_ASSET_BASE_URL}/${newest.version}/control-proxy-debug.apk`);
+    expect(resolveIpaUrl(env)).toBe(`${DEFAULT_ASSET_BASE_URL}/${newest.version}/control-proxy.ipa`);
+    expect(resolveApkChecksum(env)).toBe(newest.apkSha256);
+    expect(resolveDaemonInstallSpecifier(env)).toBe(`${DAEMON_PACKAGE_NAME}@${newest.version}`);
+    // The bug: an un-normalized "LATEST" produced a real SHA but a .../LATEST/... URL.
+    expect(resolveApkUrl(env)).not.toContain("/LATEST/");
+  });
+
+  test("a concrete version keeps its exact casing (registry keys are exact)", function() {
+    expect(resolvePinnedVersion({ AUTOMOBILE_VERSION: "0.0.18" })).toBe("0.0.18");
+  });
+});
+
+// --- Review feedback: fail-closed predicates (Sofia) ---
+
+describe("isExplicitPin", function() {
+  test("false when unset or the latest sentinel (any case)", function() {
+    expect(isExplicitPin({})).toBe(false);
+    expect(isExplicitPin({ AUTOMOBILE_VERSION: "  " })).toBe(false);
+    expect(isExplicitPin({ AUTOMOBILE_VERSION: "latest" })).toBe(false);
+    expect(isExplicitPin({ AUTOMOBILE_VERSION: "LATEST" })).toBe(false);
+  });
+
+  test("true for a concrete pin, known or unknown", function() {
+    expect(isExplicitPin({ AUTOMOBILE_VERSION: "0.0.18" })).toBe(true);
+    expect(isExplicitPin({ AUTOMOBILE_VERSION: "99.99.99" })).toBe(true);
+  });
+});
+
+describe("isPinnedVersionKnown", function() {
+  test("latest/unset is known iff the registry is non-empty", function() {
+    expect(isPinnedVersionKnown({})).toBe(true);
+    expect(isPinnedVersionKnown({}, [])).toBe(false);
+  });
+
+  test("a concrete pin is known iff it is in the registry", function() {
+    expect(isPinnedVersionKnown({ AUTOMOBILE_VERSION: "0.0.18" })).toBe(true);
+    expect(isPinnedVersionKnown({ AUTOMOBILE_VERSION: "99.99.99" })).toBe(false);
+  });
+});
+
+// --- Review feedback: degenerate empty-registry URL branch is now testable (Priya) ---
+
+describe("resolveApkUrl / resolveIpaUrl with an injected registry", function() {
+  const registry: ReleaseChecksumEntry[] = [
+    { version: "0.0.20", apkSha256: "apk20", ipaSha256: "ipa20" },
+  ];
+
+  test("uses the injected registry's newest version", function() {
+    expect(resolveApkUrl({}, registry)).toBe(`${DEFAULT_ASSET_BASE_URL}/0.0.20/control-proxy-debug.apk`);
+  });
+
+  test("empty registry + default host falls back to GitHub's /latest/download redirect", function() {
+    expect(resolveApkUrl({}, [])).toBe(
+      "https://github.com/kaeawc/auto-mobile/releases/latest/download/control-proxy-debug.apk"
+    );
+  });
+
+  test("empty registry + mirror falls back to a conventional /latest/ path", function() {
+    expect(resolveIpaUrl({ AUTOMOBILE_ASSET_BASE_URL: "https://mirror.test/am" }, [])).toBe(
+      "https://mirror.test/am/latest/control-proxy.ipa"
+    );
   });
 });

--- a/test/constants/release.test.ts
+++ b/test/constants/release.test.ts
@@ -2,12 +2,21 @@ import { describe, expect, test } from "bun:test";
 import {
   APK_SHA256_CHECKSUM,
   APK_URL,
+  DAEMON_PACKAGE_NAME,
+  DEFAULT_ASSET_BASE_URL,
   IOS_CTRL_PROXY_IPA_URL,
   IOS_CTRL_PROXY_SHA256_CHECKSUM,
   RELEASE_CHECKSUM_REGISTRY,
+  resolveApkChecksum,
+  resolveApkUrl,
+  resolveAssetBaseUrl,
   resolveAssetVersion,
   resolveChecksum,
+  resolveDaemonInstallSpecifier,
+  resolveIpaChecksum,
+  resolveIpaUrl,
   resolveLatestVersion,
+  resolvePinnedVersion,
   type ReleaseChecksumEntry,
 } from "../../src/constants/release";
 
@@ -97,5 +106,116 @@ describe("module-level URL and checksum exports", function() {
   test("APK and IPA checksums match the newest registered entry", function() {
     expect(APK_SHA256_CHECKSUM).toBe(newest.apkSha256);
     expect(IOS_CTRL_PROXY_SHA256_CHECKSUM).toBe(newest.ipaSha256);
+  });
+});
+
+// --- Issue #2746: hermetic single-version pinning knobs ---
+
+describe("resolvePinnedVersion (AUTOMOBILE_VERSION single knob)", function() {
+  test("returns 'latest' when AUTOMOBILE_VERSION is unset", function() {
+    expect(resolvePinnedVersion({})).toBe("latest");
+  });
+
+  test("returns 'latest' when AUTOMOBILE_VERSION is blank", function() {
+    expect(resolvePinnedVersion({ AUTOMOBILE_VERSION: "   " })).toBe("latest");
+  });
+
+  test("returns the pinned version trimmed", function() {
+    expect(resolvePinnedVersion({ AUTOMOBILE_VERSION: " 0.0.18 " })).toBe("0.0.18");
+  });
+});
+
+describe("resolveAssetBaseUrl (AUTOMOBILE_ASSET_BASE_URL mirror knob)", function() {
+  test("defaults to the GitHub releases base when unset", function() {
+    expect(resolveAssetBaseUrl({})).toBe(DEFAULT_ASSET_BASE_URL);
+    expect(DEFAULT_ASSET_BASE_URL).toContain("github.com/kaeawc/auto-mobile/releases/download");
+  });
+
+  test("uses the mirror base when set, stripping trailing slashes", function() {
+    expect(resolveAssetBaseUrl({ AUTOMOBILE_ASSET_BASE_URL: "https://mirror.test/am/" }))
+      .toBe("https://mirror.test/am");
+    expect(resolveAssetBaseUrl({ AUTOMOBILE_ASSET_BASE_URL: "https://mirror.test/am///" }))
+      .toBe("https://mirror.test/am");
+  });
+
+  test("ignores a blank mirror base", function() {
+    expect(resolveAssetBaseUrl({ AUTOMOBILE_ASSET_BASE_URL: "  " })).toBe(DEFAULT_ASSET_BASE_URL);
+  });
+});
+
+describe("resolveApkUrl / resolveIpaUrl (EC1, EC2, EC3)", function() {
+  const newest = RELEASE_CHECKSUM_REGISTRY[0];
+
+  test("EC8: unset env resolves to the concrete latest version on the default host", function() {
+    expect(resolveApkUrl({})).toBe(
+      `${DEFAULT_ASSET_BASE_URL}/${newest.version}/control-proxy-debug.apk`
+    );
+    expect(resolveIpaUrl({})).toBe(
+      `${DEFAULT_ASSET_BASE_URL}/${newest.version}/control-proxy.ipa`
+    );
+  });
+
+  test("EC1: AUTOMOBILE_VERSION pins the URL version", function() {
+    expect(resolveApkUrl({ AUTOMOBILE_VERSION: "0.0.18" })).toBe(
+      `${DEFAULT_ASSET_BASE_URL}/0.0.18/control-proxy-debug.apk`
+    );
+    expect(resolveIpaUrl({ AUTOMOBILE_VERSION: "0.0.18" })).toBe(
+      `${DEFAULT_ASSET_BASE_URL}/0.0.18/control-proxy.ipa`
+    );
+  });
+
+  test("EC2: AUTOMOBILE_ASSET_BASE_URL mirrors the download host", function() {
+    expect(resolveApkUrl({ AUTOMOBILE_ASSET_BASE_URL: "https://mirror.test/am" })).toBe(
+      `https://mirror.test/am/${newest.version}/control-proxy-debug.apk`
+    );
+  });
+
+  test("EC3: both knobs compose", function() {
+    expect(resolveApkUrl({
+      AUTOMOBILE_VERSION: "0.0.18",
+      AUTOMOBILE_ASSET_BASE_URL: "https://mirror.test/am/",
+    })).toBe("https://mirror.test/am/0.0.18/control-proxy-debug.apk");
+    expect(resolveIpaUrl({
+      AUTOMOBILE_VERSION: "0.0.18",
+      AUTOMOBILE_ASSET_BASE_URL: "https://mirror.test/am/",
+    })).toBe("https://mirror.test/am/0.0.18/control-proxy.ipa");
+  });
+});
+
+describe("resolveApkChecksum / resolveIpaChecksum (EC1, EC4)", function() {
+  const newest = RELEASE_CHECKSUM_REGISTRY[0];
+
+  test("EC8: unset env resolves to the latest entry checksums", function() {
+    expect(resolveApkChecksum({})).toBe(newest.apkSha256);
+    expect(resolveIpaChecksum({})).toBe(newest.ipaSha256);
+  });
+
+  test("EC1: AUTOMOBILE_VERSION selects that version's checksums coherently", function() {
+    expect(resolveApkChecksum({ AUTOMOBILE_VERSION: "0.0.18" })).toBe(
+      "fd3c8d9f0b8542eaad56c78b18cf8e5666367b04ae8c4af74d8aa6dd1c8d1834"
+    );
+    expect(resolveIpaChecksum({ AUTOMOBILE_VERSION: "0.0.18" })).toBe(
+      "2a5eec63bce2f9dfc227c0732fcce67378305e945604d5eedd0e3df48e37fd39"
+    );
+  });
+
+  test("EC4: an unknown pinned version yields an empty checksum", function() {
+    expect(resolveApkChecksum({ AUTOMOBILE_VERSION: "99.99.99" })).toBe("");
+    expect(resolveIpaChecksum({ AUTOMOBILE_VERSION: "99.99.99" })).toBe("");
+  });
+});
+
+describe("resolveDaemonInstallSpecifier (EC5)", function() {
+  const newest = RELEASE_CHECKSUM_REGISTRY[0];
+
+  test("yields a concrete specifier, never @latest, when unset", function() {
+    const spec = resolveDaemonInstallSpecifier({});
+    expect(spec).toBe(`${DAEMON_PACKAGE_NAME}@${newest.version}`);
+    expect(spec).not.toContain("@latest");
+  });
+
+  test("honors AUTOMOBILE_VERSION", function() {
+    expect(resolveDaemonInstallSpecifier({ AUTOMOBILE_VERSION: "0.0.18" }))
+      .toBe(`${DAEMON_PACKAGE_NAME}@0.0.18`);
   });
 });

--- a/test/daemon/socketServerIdeStatus.test.ts
+++ b/test/daemon/socketServerIdeStatus.test.ts
@@ -11,6 +11,7 @@ import type { DaemonResponse } from "../../src/daemon/types";
 import { AndroidCtrlProxyManager } from "../../src/utils/CtrlProxyManager";
 import { PlatformDeviceManagerFactory } from "../../src/utils/factories/PlatformDeviceManagerFactory";
 import type { BootedDevice } from "../../src/models";
+import { RELEASE_CHECKSUM_REGISTRY } from "../../src/constants/release";
 
 function createFakeDaemonState() {
   return {
@@ -112,6 +113,54 @@ describe("UnixSocketServer ide/status and ide/updateService handlers", () => {
     expect(typeof result.ios.xcTestService.expectedSha256).toBe("string");
     expect(typeof result.ios.xcTestService.expectedAppHash).toBe("string");
     expect(typeof result.ios.xcTestService.url).toBe("string");
+  });
+
+  test("ide/status reports a concrete releaseVersion, never the 'latest' literal (EC7)", async () => {
+    const response = await sendRequest(socketPath, "ide/status");
+    const result = response.result as {
+      releaseVersion: string;
+      android: { ctrlProxy: { url: string } };
+    };
+    // Issue #2746: external consumers must see the concrete version the daemon
+    // will actually fetch, not the floating "latest" tag.
+    expect(result.releaseVersion).not.toBe("latest");
+    expect(result.releaseVersion).toBe(RELEASE_CHECKSUM_REGISTRY[0].version);
+    expect(result.android.ctrlProxy.url).toContain(`/${RELEASE_CHECKSUM_REGISTRY[0].version}/`);
+  });
+
+  test("ide/status honors AUTOMOBILE_VERSION + AUTOMOBILE_ASSET_BASE_URL (EC7)", async () => {
+    const prevVersion = process.env.AUTOMOBILE_VERSION;
+    const prevBase = process.env.AUTOMOBILE_ASSET_BASE_URL;
+    process.env.AUTOMOBILE_VERSION = "0.0.18";
+    process.env.AUTOMOBILE_ASSET_BASE_URL = "https://mirror.test/am";
+    try {
+      const response = await sendRequest(socketPath, "ide/status");
+      const result = response.result as {
+        releaseVersion: string;
+        android: { ctrlProxy: { expectedSha256: string; url: string } };
+        ios: { xcTestService: { expectedSha256: string; url: string } };
+      };
+      expect(result.releaseVersion).toBe("0.0.18");
+      expect(result.android.ctrlProxy.url).toBe("https://mirror.test/am/0.0.18/control-proxy-debug.apk");
+      expect(result.android.ctrlProxy.expectedSha256).toBe(
+        "fd3c8d9f0b8542eaad56c78b18cf8e5666367b04ae8c4af74d8aa6dd1c8d1834"
+      );
+      expect(result.ios.xcTestService.url).toBe("https://mirror.test/am/0.0.18/control-proxy.ipa");
+      expect(result.ios.xcTestService.expectedSha256).toBe(
+        "2a5eec63bce2f9dfc227c0732fcce67378305e945604d5eedd0e3df48e37fd39"
+      );
+    } finally {
+      if (prevVersion === undefined) {
+        delete process.env.AUTOMOBILE_VERSION;
+      } else {
+        process.env.AUTOMOBILE_VERSION = prevVersion;
+      }
+      if (prevBase === undefined) {
+        delete process.env.AUTOMOBILE_ASSET_BASE_URL;
+      } else {
+        process.env.AUTOMOBILE_ASSET_BASE_URL = prevBase;
+      }
+    }
   });
 
   test("ide/updateService returns error for missing params", async () => {

--- a/test/doctor/automobile.test.ts
+++ b/test/doctor/automobile.test.ts
@@ -262,6 +262,33 @@ describe("checkCtrlProxy", () => {
     expect(result.message).toBe("No Android devices connected");
   });
 
+  test("fails (not skips) when AUTOMOBILE_VERSION pins an unverifiable version (#2746)", async () => {
+    const prevVersion = process.env.AUTOMOBILE_VERSION;
+    process.env.AUTOMOBILE_VERSION = "99.99.99";
+    try {
+      fakeAdb.setDevices([{
+        deviceId: "emulator-5554",
+        platform: "android",
+        isEmulator: true,
+        name: "Pixel"
+      }]);
+
+      const result = await checkCtrlProxy(fakeFactory);
+
+      // Must be `fail` so the `--cli doctor` CI gate blocks — a thrown guard would
+      // otherwise be caught and downgraded to `skip`, which doesn't count as a failure.
+      expect(result.status).toBe("fail");
+      expect(result.message).toContain("99.99.99");
+      expect(result.recommendation).toContain("AUTOMOBILE_SKIP_ACCESSIBILITY_CHECKSUM");
+    } finally {
+      if (prevVersion === undefined) {
+        delete process.env.AUTOMOBILE_VERSION;
+      } else {
+        process.env.AUTOMOBILE_VERSION = prevVersion;
+      }
+    }
+  });
+
   test("warns when installed and enabled CtrlProxy is stale but accepted for readiness", async () => {
     AndroidCtrlProxyManager.setExpectedChecksumForTesting("expected-sha");
     const originalDefaultDownloader = (AndroidCtrlProxyManager as any).defaultFileDownloader;

--- a/test/doctor/automobile.test.ts
+++ b/test/doctor/automobile.test.ts
@@ -10,6 +10,7 @@ import {
 import type { BuildIdentity } from "../../src/daemon/buildIdentity";
 import {
   LATEST_RELEASE_VERSION,
+  RELEASE_CHECKSUM_REGISTRY,
   RELEASE_VERSION,
   resolveAssetVersion,
 } from "../../src/constants/release";
@@ -45,6 +46,22 @@ describe("checkCtrlProxyVersion", () => {
     expect(result.value).toBe(expected);
     if (RELEASE_VERSION === LATEST_RELEASE_VERSION) {
       expect(result.message).toMatch(/\(latest\)$/);
+    }
+  });
+
+  test("honors AUTOMOBILE_VERSION and drops the (latest) suffix when pinned (EC6)", () => {
+    const prev = process.env.AUTOMOBILE_VERSION;
+    process.env.AUTOMOBILE_VERSION = "0.0.18";
+    try {
+      const result = checkCtrlProxyVersion();
+      expect(result.value).toBe("0.0.18");
+      expect(result.message).toBe("Version 0.0.18");
+    } finally {
+      if (prev === undefined) {
+        delete process.env.AUTOMOBILE_VERSION;
+      } else {
+        process.env.AUTOMOBILE_VERSION = prev;
+      }
     }
   });
 });
@@ -97,6 +114,30 @@ describe("checkDaemonStatus", () => {
     expect(result.status).toBe("pass");
     expect(result.message).toBe("Running (serving via socket)");
     expect(result.recommendation).toBeUndefined();
+  });
+
+  test("recommends a concrete pinned install command, never @latest (EC6)", async () => {
+    const result = await checkDaemonStatus({
+      daemonManager: {
+        status: async () => ({ running: false }),
+      },
+      getDaemonHealthReport: async () => ({
+        timestamp: "2026-06-29T00:00:00.000Z",
+        daemonRunning: false,
+        socketExists: false,
+        socketAccessible: false,
+        pidFileExists: false,
+        pidFileValid: false,
+        socketConnectable: false,
+        recommendations: [],
+      }),
+    });
+
+    expect(result.status).toBe("warn");
+    expect(result.recommendation).toContain("@kaeawc/auto-mobile@");
+    // Issue #2746: floating @latest advice causes silent version drift.
+    expect(result.recommendation).not.toContain("@latest");
+    expect(result.recommendation).toContain(RELEASE_CHECKSUM_REGISTRY[0].version);
   });
 });
 

--- a/test/doctor/index.test.ts
+++ b/test/doctor/index.test.ts
@@ -414,6 +414,23 @@ describe("runDoctor", () => {
       expect(report.ios?.checks.every(check => check.status === "skip")).toBe(true);
     });
   });
+
+  test("report.version is a concrete pinned version, never the 'latest' literal (#2746)", async () => {
+    await withProcessPlatform("linux", async () => {
+      const prev = process.env.AUTOMOBILE_VERSION;
+      process.env.AUTOMOBILE_VERSION = "0.0.18";
+      try {
+        const report = await runDoctor({ ios: true });
+        expect(report.version).toBe("0.0.18");
+      } finally {
+        if (prev === undefined) {
+          delete process.env.AUTOMOBILE_VERSION;
+        } else {
+          process.env.AUTOMOBILE_VERSION = prev;
+        }
+      }
+    });
+  });
 });
 
 describe("applyClientBuildIdentity", () => {

--- a/test/doctor/ios.test.ts
+++ b/test/doctor/ios.test.ts
@@ -631,6 +631,21 @@ describe("checkIosCtrlProxyRunner", () => {
     expect(result.message).not.toContain("missingCommands");
   });
 
+  test("reports the pinned expectedVersion in the diagnostic line (#2746)", async () => {
+    const prev = process.env.AUTOMOBILE_VERSION;
+    process.env.AUTOMOBILE_VERSION = "0.0.18";
+    try {
+      const result = await checkIosCtrlProxyRunner(withRunners([inspection()]));
+      expect(result.message).toContain("expectedVersion=0.0.18");
+    } finally {
+      if (prev === undefined) {
+        delete process.env.AUTOMOBILE_VERSION;
+      } else {
+        process.env.AUTOMOBILE_VERSION = prev;
+      }
+    }
+  });
+
   test("warns and lists missing commands when the runner is stale", async () => {
     const result = await checkIosCtrlProxyRunner(
       withRunners([inspection({ supportedCommands: [...STALE_COMMANDS] })])

--- a/test/doctor/ios.test.ts
+++ b/test/doctor/ios.test.ts
@@ -631,6 +631,25 @@ describe("checkIosCtrlProxyRunner", () => {
     expect(result.message).not.toContain("missingCommands");
   });
 
+  test("fails (not passes) when AUTOMOBILE_VERSION pins an unverifiable version (#2746)", async () => {
+    const prev = process.env.AUTOMOBILE_VERSION;
+    process.env.AUTOMOBILE_VERSION = "99.99.99";
+    try {
+      // A running runner advertising the full command set would classify as
+      // `compatible` (pass); the unverifiable pin must override that to `fail`.
+      const result = await checkIosCtrlProxyRunner(withRunners([inspection()]));
+      expect(result.status).toBe("fail");
+      expect(result.message).toContain("99.99.99");
+      expect(result.recommendation).toContain("AUTOMOBILE_CTRL_PROXY_IOS_IPA_PATH");
+    } finally {
+      if (prev === undefined) {
+        delete process.env.AUTOMOBILE_VERSION;
+      } else {
+        process.env.AUTOMOBILE_VERSION = prev;
+      }
+    }
+  });
+
   test("reports the pinned expectedVersion in the diagnostic line (#2746)", async () => {
     const prev = process.env.AUTOMOBILE_VERSION;
     process.env.AUTOMOBILE_VERSION = "0.0.18";

--- a/test/utils/CtrlProxyManager.test.ts
+++ b/test/utils/CtrlProxyManager.test.ts
@@ -833,6 +833,67 @@ describe("CtrlProxyManager", function() {
       await accessibilityServiceClient.cleanupApk(apkPath);
     });
 
+    test("fails closed when AUTOMOBILE_VERSION is pinned to an unknown version (#2746)", async function() {
+      const prevVersion = process.env.AUTOMOBILE_VERSION;
+      process.env.AUTOMOBILE_VERSION = "99.99.99";
+      try {
+        const zip = new AdmZip();
+        zip.addFile("AndroidManifest.xml", Buffer.from('<?xml version="1.0" encoding="utf-8"?><manifest></manifest>', "utf8"));
+        zip.addFile("classes.dex", crypto.randomBytes(15000));
+        const payload = zip.toBuffer();
+
+        // No expected-checksum override and no APK-path/skip override: the pinned
+        // version has no registry checksum, so the download is unverifiable and
+        // must fail closed rather than install an unchecked APK (esp. from a mirror).
+        (accessibilityServiceClient as any).fileDownloader = {
+          download: async (_url: string, destination: string) => {
+            await fs.mkdir(path.dirname(destination), { recursive: true });
+            await fs.writeFile(destination, payload);
+          }
+        };
+
+        await expect(accessibilityServiceClient.downloadApk()).rejects.toThrow(
+          "not in the AutoMobile release"
+        );
+      } finally {
+        if (prevVersion === undefined) {
+          delete process.env.AUTOMOBILE_VERSION;
+        } else {
+          process.env.AUTOMOBILE_VERSION = prevVersion;
+        }
+      }
+    });
+
+    test("installs when the pinned version's checksum override is set (skip escape hatch, #2746)", async function() {
+      const prevVersion = process.env.AUTOMOBILE_VERSION;
+      process.env.AUTOMOBILE_VERSION = "99.99.99";
+      process.env.AUTOMOBILE_SKIP_ACCESSIBILITY_CHECKSUM = "true";
+      try {
+        const zip = new AdmZip();
+        zip.addFile("AndroidManifest.xml", Buffer.from('<?xml version="1.0" encoding="utf-8"?><manifest></manifest>', "utf8"));
+        zip.addFile("classes.dex", crypto.randomBytes(15000));
+        const payload = zip.toBuffer();
+
+        (accessibilityServiceClient as any).fileDownloader = {
+          download: async (_url: string, destination: string) => {
+            await fs.mkdir(path.dirname(destination), { recursive: true });
+            await fs.writeFile(destination, payload);
+          }
+        };
+
+        const apkPath = await accessibilityServiceClient.downloadApk();
+        const stats = await fs.stat(apkPath);
+        expect(stats.size).toBe(payload.length);
+        await accessibilityServiceClient.cleanupApk(apkPath);
+      } finally {
+        if (prevVersion === undefined) {
+          delete process.env.AUTOMOBILE_VERSION;
+        } else {
+          process.env.AUTOMOBILE_VERSION = prevVersion;
+        }
+      }
+    });
+
     test("should fail when checksum does not match", async function() {
       // Create a valid APK structure (ZIP with AndroidManifest.xml)
       const zip = new AdmZip();

--- a/test/utils/CtrlProxyManager.test.ts
+++ b/test/utils/CtrlProxyManager.test.ts
@@ -828,6 +828,43 @@ describe("CtrlProxyManager", function() {
     });
   });
 
+  describe("isPinnedVersionUnverifiable", () => {
+    const withVersion = (value: string | undefined, fn: () => void) => {
+      const prev = process.env.AUTOMOBILE_VERSION;
+      if (value === undefined) {
+        delete process.env.AUTOMOBILE_VERSION;
+      } else {
+        process.env.AUTOMOBILE_VERSION = value;
+      }
+      try {
+        fn();
+      } finally {
+        if (prev === undefined) {
+          delete process.env.AUTOMOBILE_VERSION;
+        } else {
+          process.env.AUTOMOBILE_VERSION = prev;
+        }
+      }
+    };
+
+    test("false when no explicit pin (latest)", () => {
+      withVersion(undefined, () => expect(AndroidCtrlProxyManager.isPinnedVersionUnverifiable()).toBe(false));
+    });
+
+    test("false for a known explicit pin", () => {
+      withVersion("0.0.18", () => expect(AndroidCtrlProxyManager.isPinnedVersionUnverifiable()).toBe(false));
+    });
+
+    test("true for an unknown explicit pin", () => {
+      withVersion("99.99.99", () => expect(AndroidCtrlProxyManager.isPinnedVersionUnverifiable()).toBe(true));
+    });
+
+    test("false for an unknown pin when checksum skip is configured", () => {
+      process.env.AUTOMOBILE_SKIP_ACCESSIBILITY_CHECKSUM = "true";
+      withVersion("99.99.99", () => expect(AndroidCtrlProxyManager.isPinnedVersionUnverifiable()).toBe(false));
+    });
+  });
+
   describe("downloadApk", () => {
     test("should copy from local APK override when provided", async function() {
       const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "auto-mobile-test-apk-"));

--- a/test/utils/CtrlProxyManager.test.ts
+++ b/test/utils/CtrlProxyManager.test.ts
@@ -527,6 +527,32 @@ describe("CtrlProxyManager", function() {
       expect(localFakeAdb.wasCommandExecuted(`shell pm uninstall ${AndroidCtrlProxyManager.PACKAGE}`)).toBe(true);
     });
 
+    test("prefetch is skipped (no network) for an unknown pin (#2746)", async function() {
+      const prevVersion = process.env.AUTOMOBILE_VERSION;
+      process.env.AUTOMOBILE_VERSION = "99.99.99";
+      const originalDefaultDownloader = (AndroidCtrlProxyManager as any).defaultFileDownloader;
+      let downloadCalls = 0;
+      try {
+        (AndroidCtrlProxyManager as any).defaultFileDownloader = {
+          download: async () => {
+            downloadCalls++;
+            throw new Error("download must not run for an unverifiable pin");
+          }
+        };
+
+        AndroidCtrlProxyManager.prefetchApk();
+        expect(await AndroidCtrlProxyManager.getPrefetchedApkPath()).toBeNull();
+        expect(downloadCalls).toBe(0);
+      } finally {
+        (AndroidCtrlProxyManager as any).defaultFileDownloader = originalDefaultDownloader;
+        if (prevVersion === undefined) {
+          delete process.env.AUTOMOBILE_VERSION;
+        } else {
+          process.env.AUTOMOBILE_VERSION = prevVersion;
+        }
+      }
+    });
+
     test("should allow background refresh to retry failed prefetches", async function() {
       AndroidCtrlProxyManager.setExpectedChecksumForTesting("");
       const zip = new AdmZip();

--- a/test/utils/CtrlProxyManager.test.ts
+++ b/test/utils/CtrlProxyManager.test.ts
@@ -261,6 +261,56 @@ describe("CtrlProxyManager", function() {
       includes: (searchString: string) => stdout.includes(searchString)
     });
 
+    test("fails closed on an unknown pin even when CtrlProxy is already installed (#2746)", async function() {
+      const prevVersion = process.env.AUTOMOBILE_VERSION;
+      process.env.AUTOMOBILE_VERSION = "99.99.99";
+      try {
+        // Device already has CtrlProxy installed + enabled: the readiness path
+        // would otherwise accept it (status "skipped") without ever downloading.
+        const localFakeAdb = new FakeAdbExecutor();
+        localFakeAdb.setCommandResponse(`shell pm list packages | grep ${AndroidCtrlProxyManager.PACKAGE}`, {
+          stdout: `package:${AndroidCtrlProxyManager.PACKAGE}\n`,
+          stderr: ""
+        });
+
+        AndroidCtrlProxyManager.resetInstances();
+        const manager = AndroidCtrlProxyManager.getInstance(testDevice, { create: () => localFakeAdb });
+
+        await expect(manager.ensureCompatibleVersion()).rejects.toThrow("not in the AutoMobile release");
+      } finally {
+        if (prevVersion === undefined) {
+          delete process.env.AUTOMOBILE_VERSION;
+        } else {
+          process.env.AUTOMOBILE_VERSION = prevVersion;
+        }
+      }
+    });
+
+    test("accepts a preinstalled CtrlProxy on an unknown pin when checksum skip is set (#2746)", async function() {
+      const prevVersion = process.env.AUTOMOBILE_VERSION;
+      process.env.AUTOMOBILE_VERSION = "99.99.99";
+      process.env.AUTOMOBILE_SKIP_ACCESSIBILITY_CHECKSUM = "true";
+      try {
+        const localFakeAdb = new FakeAdbExecutor();
+        localFakeAdb.setCommandResponse(`shell pm list packages | grep ${AndroidCtrlProxyManager.PACKAGE}`, {
+          stdout: `package:${AndroidCtrlProxyManager.PACKAGE}\n`,
+          stderr: ""
+        });
+
+        AndroidCtrlProxyManager.resetInstances();
+        const manager = AndroidCtrlProxyManager.getInstance(testDevice, { create: () => localFakeAdb });
+
+        const result = await manager.ensureCompatibleVersion();
+        expect(result.status).toBe("skipped");
+      } finally {
+        if (prevVersion === undefined) {
+          delete process.env.AUTOMOBILE_VERSION;
+        } else {
+          process.env.AUTOMOBILE_VERSION = prevVersion;
+        }
+      }
+    });
+
     test("should report compatible when installed SHA matches expected", async function() {
       AndroidCtrlProxyManager.setExpectedChecksumForTesting("expected-sha");
       const localFakeAdb = new FakeAdbExecutor();

--- a/test/utils/IOSCtrlProxyBuilder.test.ts
+++ b/test/utils/IOSCtrlProxyBuilder.test.ts
@@ -203,6 +203,60 @@ describe("IOSCtrlProxyBuilder", function() {
       const result = await builder.needsRebuild("simulator");
       expect(result).toBe(false);
     });
+
+    test("fails closed on an unknown pin instead of reusing a cached bundle (#2746)", async function() {
+      const prevVersion = process.env.AUTOMOBILE_VERSION;
+      process.env.AUTOMOBILE_VERSION = "99.99.99";
+      try {
+        // A cached bundle + metadata exist, so without the guard needsRebuild would
+        // return false and setup would silently reuse the cached (wrong-version) runner.
+        const derivedDataPath = path.join(tempDir, "DerivedData");
+        const productsDir = path.join(derivedDataPath, "Build", "Products");
+        await fs.mkdir(productsDir, { recursive: true });
+        await fs.writeFile(path.join(productsDir, "CtrlProxyApp_iphonesimulator.xctestrun"), "mock");
+        const cacheDir = path.join(tempDir, "cache");
+        await fs.mkdir(cacheDir, { recursive: true });
+        await fs.writeFile(
+          path.join(cacheDir, "ctrl-proxy-ios-bundle.json"),
+          JSON.stringify({ checksum: "stale", version: "latest", extractedAt: new Date().toISOString() })
+        );
+
+        IOSCtrlProxyBuilder.resetInstances();
+        const builder = IOSCtrlProxyBuilder.getInstance({ derivedDataPath, bundleCacheDir: cacheDir });
+
+        await expect(builder.needsRebuild("simulator")).rejects.toThrow("not in the AutoMobile release");
+      } finally {
+        if (prevVersion === undefined) {
+          delete process.env.AUTOMOBILE_VERSION;
+        } else {
+          process.env.AUTOMOBILE_VERSION = prevVersion;
+        }
+      }
+    });
+
+    test("a vendored IPA path exempts the unknown-pin guard (#2746)", async function() {
+      const prevVersion = process.env.AUTOMOBILE_VERSION;
+      process.env.AUTOMOBILE_VERSION = "99.99.99";
+      process.env.AUTOMOBILE_CTRL_PROXY_IOS_IPA_PATH = path.join(tempDir, "vendored.ipa");
+      try {
+        IOSCtrlProxyBuilder.resetInstances();
+        const builder = IOSCtrlProxyBuilder.getInstance({
+          derivedDataPath: path.join(tempDir, "nonexistent"),
+          projectRoot: tempDir,
+        });
+
+        // No throw: a vendored bundle is the trusted escape hatch. Build products
+        // are missing, so it simply reports a rebuild is needed.
+        const result = await builder.needsRebuild();
+        expect(result).toBe(true);
+      } finally {
+        if (prevVersion === undefined) {
+          delete process.env.AUTOMOBILE_VERSION;
+        } else {
+          process.env.AUTOMOBILE_VERSION = prevVersion;
+        }
+      }
+    });
   });
 
   describe("getBuildProductsPath", function() {

--- a/test/utils/IOSCtrlProxyBuilder.test.ts
+++ b/test/utils/IOSCtrlProxyBuilder.test.ts
@@ -234,20 +234,31 @@ describe("IOSCtrlProxyBuilder", function() {
       }
     });
 
-    test("a vendored IPA path exempts the unknown-pin guard (#2746)", async function() {
+    test("a vendored IPA path forces extraction even with a cached bundle on an unknown pin (#2746)", async function() {
       const prevVersion = process.env.AUTOMOBILE_VERSION;
       process.env.AUTOMOBILE_VERSION = "99.99.99";
       process.env.AUTOMOBILE_CTRL_PROXY_IOS_IPA_PATH = path.join(tempDir, "vendored.ipa");
       try {
-        IOSCtrlProxyBuilder.resetInstances();
-        const builder = IOSCtrlProxyBuilder.getInstance({
-          derivedDataPath: path.join(tempDir, "nonexistent"),
-          projectRoot: tempDir,
-        });
+        // A cached bundle + metadata already exist (reused CI host): without the
+        // override-forces-rebuild rule, needsRebuild() would return false and the
+        // vendored IPA would be silently ignored in favor of the stale runner.
+        const derivedDataPath = path.join(tempDir, "DerivedData");
+        const productsDir = path.join(derivedDataPath, "Build", "Products");
+        await fs.mkdir(productsDir, { recursive: true });
+        await fs.writeFile(path.join(productsDir, "CtrlProxyApp_iphonesimulator.xctestrun"), "mock");
+        const cacheDir = path.join(tempDir, "cache");
+        await fs.mkdir(cacheDir, { recursive: true });
+        await fs.writeFile(
+          path.join(cacheDir, "ctrl-proxy-ios-bundle.json"),
+          JSON.stringify({ checksum: "stale", version: "latest", extractedAt: new Date().toISOString() })
+        );
 
-        // No throw: a vendored bundle is the trusted escape hatch. Build products
-        // are missing, so it simply reports a rebuild is needed.
-        const result = await builder.needsRebuild();
+        IOSCtrlProxyBuilder.resetInstances();
+        const builder = IOSCtrlProxyBuilder.getInstance({ derivedDataPath, bundleCacheDir: cacheDir });
+
+        // No throw (vendored is the trusted escape hatch) AND forces a rebuild so
+        // the vendored IPA is actually consumed.
+        const result = await builder.needsRebuild("simulator");
         expect(result).toBe(true);
       } finally {
         if (prevVersion === undefined) {

--- a/test/utils/IOSCtrlProxyBuilder.test.ts
+++ b/test/utils/IOSCtrlProxyBuilder.test.ts
@@ -144,6 +144,43 @@ describe("IOSCtrlProxyBuilder", function() {
     });
   });
 
+  describe("isPinnedVersionUnverifiable", function() {
+    const withVersion = (value: string | undefined, fn: () => void) => {
+      const prev = process.env.AUTOMOBILE_VERSION;
+      if (value === undefined) {
+        delete process.env.AUTOMOBILE_VERSION;
+      } else {
+        process.env.AUTOMOBILE_VERSION = value;
+      }
+      try {
+        fn();
+      } finally {
+        if (prev === undefined) {
+          delete process.env.AUTOMOBILE_VERSION;
+        } else {
+          process.env.AUTOMOBILE_VERSION = prev;
+        }
+      }
+    };
+
+    test("false when no explicit pin (latest)", function() {
+      withVersion(undefined, () => expect(IOSCtrlProxyBuilder.isPinnedVersionUnverifiable()).toBe(false));
+    });
+
+    test("false for a known explicit pin", function() {
+      withVersion("0.0.18", () => expect(IOSCtrlProxyBuilder.isPinnedVersionUnverifiable()).toBe(false));
+    });
+
+    test("true for an unknown explicit pin", function() {
+      withVersion("99.99.99", () => expect(IOSCtrlProxyBuilder.isPinnedVersionUnverifiable()).toBe(true));
+    });
+
+    test("false for an unknown pin when a vendored IPA path is set", function() {
+      process.env.AUTOMOBILE_CTRL_PROXY_IOS_IPA_PATH = "/opt/automobile/control-proxy.ipa";
+      withVersion("99.99.99", () => expect(IOSCtrlProxyBuilder.isPinnedVersionUnverifiable()).toBe(false));
+    });
+  });
+
   describe("needsRebuild", function() {
     test("should return false when AUTOMOBILE_SKIP_CTRL_PROXY_IOS_BUILD is true", async function() {
       process.env.AUTOMOBILE_SKIP_CTRL_PROXY_IOS_BUILD = "true";

--- a/test/utils/IOSCtrlProxyBuilder.test.ts
+++ b/test/utils/IOSCtrlProxyBuilder.test.ts
@@ -516,6 +516,34 @@ describe("IOSCtrlProxyBuilder", function() {
       expect(buildProducts).toBe(path.join(derivedDataPath, "Build", "Products", "Debug-iphonesimulator"));
     });
 
+    test("fails closed when AUTOMOBILE_VERSION is pinned to an unknown version (#2746)", async function() {
+      const prev = process.env.AUTOMOBILE_VERSION;
+      process.env.AUTOMOBILE_VERSION = "99.99.99";
+      try {
+        const derivedDataPath = path.join(tempDir, "DerivedData");
+        const cacheDir = path.join(tempDir, "cache");
+        const downloader = new FakeIOSCtrlProxyBundleDownloader();
+        downloader.checksum = "actual-checksum-from-download";
+        // No expected-checksum override and no vendored IPA path: the pinned
+        // version has no registry checksum, so the download is unverifiable.
+        const builder = IOSCtrlProxyBuilder.getInstance(
+          { derivedDataPath, bundleCacheDir: cacheDir },
+          { downloader }
+        );
+
+        const result = await builder.build("simulator");
+
+        expect(result.success).toBe(false);
+        expect(result.error).toContain("not in the AutoMobile release");
+      } finally {
+        if (prev === undefined) {
+          delete process.env.AUTOMOBILE_VERSION;
+        } else {
+          process.env.AUTOMOBILE_VERSION = prev;
+        }
+      }
+    });
+
     test("should reject build when checksum does not match", async function() {
       const derivedDataPath = path.join(tempDir, "DerivedData");
       const cacheDir = path.join(tempDir, "cache");

--- a/test/utils/IOSCtrlProxyManager.test.ts
+++ b/test/utils/IOSCtrlProxyManager.test.ts
@@ -259,6 +259,25 @@ describe("IOSCtrlProxyManager", function() {
     PortManager.setPortAvailabilityCheckerForTesting(null);
   });
 
+  describe("setup fail-closed on unverifiable pin", function() {
+    test("returns failure for an unknown pin before any reuse short-circuit (#2746)", async function() {
+      const prev = process.env.AUTOMOBILE_VERSION;
+      process.env.AUTOMOBILE_VERSION = "99.99.99";
+      try {
+        const manager = IOSCtrlProxyManager.getInstance(testDevice);
+        const result = await manager.setup();
+        expect(result.success).toBe(false);
+        expect(result.message).toContain("not in the AutoMobile release");
+      } finally {
+        if (prev === undefined) {
+          delete process.env.AUTOMOBILE_VERSION;
+        } else {
+          process.env.AUTOMOBILE_VERSION = prev;
+        }
+      }
+    });
+  });
+
   describe("getInstance", function() {
     test("should return same instance for same device", function() {
       const instance1 = IOSCtrlProxyManager.getInstance(testDevice);


### PR DESCRIPTION
## Summary
External CI consumers had no single knob or hermetic recipe to pin every AutoMobile component — daemon, Android ctrlproxy APK, iOS ctrlproxy IPA, and their checksums — to one coherent version. The daemon is the source of truth the Android/iOS clients delegate to (it bakes the asset URLs + checksums and reports them via `ide/status`), yet on the TypeScript side those were module-load `const`s derived from the floating `"latest"` literal, with GitHub as the only host and no version knob. `AUTOMOBILE_VERSION` was read by the Kotlin runner but **ignored by TypeScript**, and ~20 user-facing `@latest` advice strings invited silent drift.

This adds the daemon-side pinning layer for issue #2746:
- **`AUTOMOBILE_VERSION`** — one knob selecting daemon + APK + IPA + both checksums.
- **`AUTOMOBILE_ASSET_BASE_URL`** — mirror the APK/IPA host for offline/hermetic CI.
- Concrete-version advice everywhere, never `@latest`.

Native follow-ups (bake a version into the XCTestRunner SPM package, gradle recipe wiring, Swift `startDaemon` pin) are intentionally out of scope — they can't be unit-tested in the TS harness and belong in a focused change.

## Changes
- **`src/constants/release.ts`** — new pure, env-injectable resolvers: `resolvePinnedVersion`, `resolveAssetBaseUrl`, `resolveApkUrl` / `resolveIpaUrl`, `resolveApkChecksum` / `resolveIpaChecksum`, and `resolveDaemonInstallSpecifier` (concrete `@kaeawc/auto-mobile@<version>` for advice). `buildReleaseAssetUrl` gains a base-URL parameter. Module-level `APK_URL` / `IPA_URL` / checksum exports are preserved (now derived via the resolvers) for backward compatibility.
- **Consumers resolve at call time** (so the daemon honors env set at launch): `CtrlProxyManager.ts` (APK download URL + expected checksum), `IOSCtrlProxyBuilder.ts` (`getBundleUrl`/`getExpectedChecksum` fallbacks, hermetic cached-fallback gate, metadata version), `daemon/socketServer.ts` `ide/status` (concrete `releaseVersion` + mirror/version-aware URLs + checksums), `server/bootedDeviceResources.ts` (compat checksums).
- **Concrete-version advice** replacing `@latest` in `doctor/checks/automobile.ts`, `cli/index.ts` (error paths + help/usage text), `daemon/manager.ts`, `daemon/debugTools.ts`. `doctor/index.ts` `report.version` and `doctor/checks/ios.ts` runner diagnostic line now report the pinned version.
- **Docs** — `docs/using/hermetic-ci-pinning.md` (per-platform Android + iOS recipes, mirror layout, `ide/status` verification) wired into `mkdocs.yml`.

## Acceptance check
- `AUTOMOBILE_VERSION=0.0.18` → APK url, IPA url, APK sha, IPA sha all resolve to `0.0.18` coherently; `ide/status` reports `releaseVersion: "0.0.18"`.
- `AUTOMOBILE_ASSET_BASE_URL=https://mirror.test/am` → `https://mirror.test/am/<version>/control-proxy-debug.apk`; both knobs compose.
- Unset env → unchanged default behavior (concrete latest registry version, GitHub host, existing checksums).
- No `@kaeawc/auto-mobile@latest` string remains in `src/`.

## Test plan
- **`test/constants/release.test.ts`** — pure resolver tests: pinning, mirror base (trailing-slash strip), composition, unknown-version → empty checksum, concrete specifier never `@latest`.
- **`test/daemon/socketServerIdeStatus.test.ts`** — `ide/status` reports concrete `releaseVersion` and honors both knobs (mirror + version).
- **`test/doctor/automobile.test.ts`**, **`test/doctor/ios.test.ts`**, **`test/doctor/index.test.ts`** — advice/report strings are concrete and honor `AUTOMOBILE_VERSION`.
- `bun test` → 5338 pass / 0 fail (+2 new). `bun run lint` + `bun run build` green; `tsc --noEmit` clean on touched files.

Refs #2731, #2732, #2742
Closes #2746
