### PR TITLE
test(daemon): inject fake daemonManager into sibling-recovery tests

### DIFF
--- a/test/daemon/daemonMcpProxy.test.ts
+++ b/test/daemon/daemonMcpProxy.test.ts
@@ -861,6 +861,7 @@ describe("DaemonMcpProxy", () => {
 
       const proxy = new DaemonMcpProxy({
         clientFactory: () => clients.shift()!,
+        daemonManager: matchingDaemonManager(),
         autoStartDaemon: false,
       });
 
@@ -891,6 +892,7 @@ describe("DaemonMcpProxy", () => {
 
       const proxy = new DaemonMcpProxy({
         clientFactory: () => clients.shift()!,
+        daemonManager: matchingDaemonManager(),
         autoStartDaemon: false,
       });
 
@@ -918,6 +920,7 @@ describe("DaemonMcpProxy", () => {
 
       const proxy = new DaemonMcpProxy({
         clientFactory: () => clients.shift()!,
+        daemonManager: matchingDaemonManager(),
         autoStartDaemon: false,
       });
 
@@ -948,6 +951,7 @@ describe("DaemonMcpProxy", () => {
 
       const proxy = new DaemonMcpProxy({
         clientFactory: () => client,
+        daemonManager: matchingDaemonManager(),
         autoStartDaemon: false,
       });
 


### PR DESCRIPTION
## Summary

Fixes environment-dependent flakiness in the "sibling-session recovery after daemon restart (#2737)" suite in `test/daemon/daemonMcpProxy.test.ts`.

The four tests
- `callTool recovers when a sibling's socket dropped`
- `readResource recovers when a sibling's socket dropped`
- `caps sibling recovery at one retry`
- `does NOT retry a daemon-returned tool error that mentions a transport code`

constructed `DaemonMcpProxy` **without** injecting a fake `daemonManager`. Because `doConnect()` runs `ensureVersionMatches()` + `ensureBuildMatches()` + `ensureStartupOptionsMatch()`, those calls fell back to a real `new DaemonManager()` and read the machine's daemon PID file at `/tmp/auto-mobile-daemon-${uid}.pid`.

When a real daemon from a different build (different `entryScript`) runs at the same git commit, `ensureBuildMatches()` correctly throws `DaemonBuildMismatchError` and the tests fail — green in clean CI, red on a dev box with a stray daemon.

## Fix

Inject the existing `matchingDaemonManager()` helper (already used by every neighboring test in the file) so `doConnect` never touches the real system. `FakeDaemonManager.status()` returns an in-memory build/version matching the proxy's stamped identity.

## Notes

- Pre-existing on `main`; out of scope for #2732. It actually confirms the #2733 build-mismatch fix works.
- Minimal diff (one line per test), following the repo's interface+fake testing conventions.

## Test

```
bun test test/daemon/daemonMcpProxy.test.ts
# 48 pass, 0 fail, ~118ms
```