### PR TITLE
fix(android): loading-aware pre-tap re-find via wall-clock deadline + poll floor (#1949)

### DIFF
--- a/docs/design-docs/mcp/index.md
+++ b/docs/design-docs/mcp/index.md
@@ -10,7 +10,7 @@ The MCP server exposes AutoMobile's capabilities as tool calls, resources, and r
 
 - 🤖 **Fast UX Inspection** Kotlin [Accessibility Service](../plat/android/control-proxy.md) and Swift [CtrlProxy iOS](../plat/ios/ctrl-proxy-ios.md) to enable fast, accurate observations. 10x faster than the next fastest observation toolkit.
 - 🦾 **Full Touch Injection** Tap, Swipe, Pinch, Drag & Drop, Shake with automatic element targeting.
-- ♻️ **Tool Feedback** [Observations](observe/index.md) drive the [interaction loop](interaction-loop.md) for all [tool calls](tools.md).
+- ♻️ **Tool Feedback** [Observations](observe/index.md) drive the [interaction loop](interaction-loop.md) for all [tool calls](tools.md), with [loading-state awareness](loading-awareness.md) extending patience through transient loading UI.
 - 🧪 **Test Execution** [Kotlin JUnitRunner](../plat/android/junit-runner/index.md) & [Swift XCTestRunner](../plat/ios/xctestrunner/index.md) execute tests natively handling device pooling, multi-device tests, and automatically optimizing test timing.
 
 ## Additional Features

--- a/docs/design-docs/mcp/loading-awareness.md
+++ b/docs/design-docs/mcp/loading-awareness.md
@@ -1,0 +1,196 @@
+# Loading-State Awareness
+
+<kbd>✅ Implemented</kbd> <kbd>🧪 Tested</kbd> <kbd>🤖 Android Only</kbd>
+
+> **Current state:** The pre-tap re-find loop on Android now bounds its patience by a
+> **wall-clock deadline** instead of a fixed attempt count, and **extends that deadline**
+> when the accessibility tree shows a blocking loading indicator (progress bar / shimmer).
+> This is the v1 that closes [issue #1949](https://github.com/kaeawc/auto-mobile/issues/1949).
+> A larger multi-signal loading model was designed and deliberately deferred — see
+> [§4 Aspirational future direction](#4-aspirational-future-direction). See the
+> [Status Glossary](../status-glossary.md) for chip definitions.
+
+---
+
+## 1. Problem
+
+From [issue #1949](https://github.com/kaeawc/auto-mobile/issues/1949):
+
+> When a search-result list shows a loading spinner between `observe` and `tapOn`, a
+> fixed retry budget for re-finding the element can expire before the list content
+> reappears.
+
+The literal defect was that the pre-tap stability loop in
+[`TapOnElement.ts`](../../../src/features/action/TapOnElement.ts) expressed its patience
+as **`N attempts × poll delay`**. That couples the real wall-clock window to the polling
+cadence and per-refresh fetch latency, so the budget could run out before a loading list
+repopulated — even though the target eventually reappeared.
+
+A prior narrow fix already existed: [`androidTransientLoading.ts`](../../../src/utils/androidTransientLoading.ts)
+regex-matches `ProgressBar` / `ShimmerFrameLayout` / `ContentLoadingProgressBar` and bumped
+the attempt ceiling from 8 → 32. v1 keeps that detector but changes what the extension buys:
+**wall-clock time, not attempts.**
+
+## 2. What we implemented (v1)
+
+Scope: the Android pre-tap re-find loop, `resolveAndroidStableTapTargetAfterRefreshes`.
+The change is deliberately small and preserves every existing safety property.
+
+### 2.1 Patience is bounded by BOTH a poll floor and a wall-clock deadline
+
+The loop keeps polling until **both** a minimum productive-poll count **and** a wall-clock
+deadline are exceeded (`refindAttempt >= minPolls && productiveElapsed >= budgetMs`). Two
+bounds, because neither alone is correct — this was the key finding from adversarial review:
+
+- The **wall-clock deadline** adds patience when fetches are fast. A fixed
+  "N attempts × poll delay" budget expires in ~1.2 s and can miss a list that repopulates a
+  few seconds later (#1949).
+- The **productive-poll floor** prevents a regression in the opposite regime. On a slow
+  device where each hierarchy fetch costs 300–800 ms, real fetch latency counts against a
+  pure wall-clock budget, so 2500 ms would buy only ~3–5 polls — *fewer* than the old fixed
+  8. The floor guarantees we never poll fewer times than the previous implementation, so the
+  change is **never less patient** than before, in any fetch-speed regime.
+
+| | base | when loading detected |
+|---|---|---|
+| `ANDROID_PRE_TAP_REFIND_BUDGET_MS` | 2500 ms | 10000 ms |
+| `ANDROID_PRE_TAP_REFIND_MIN_POLLS` | 8 | 32 |
+
+Success still returns immediately when the target's bounds are stable within ±3 px for the
+required consecutive re-finds — the common case is unchanged and fast.
+
+### 2.2 "No hierarchy" recovery time is fully excluded from the budget
+
+A temporarily-unresponsive ctrl-proxy WebSocket (refresh returns `null`) must **not** consume
+the element's patience — that streak is bounded separately by
+`ANDROID_PRE_TAP_NO_HIERARCHY_MAX_CONSECUTIVE = 12` with its own 500 ms backoff. v1 excludes
+from the deadline **both** the recovery sleep **and** the wall-clock the failed refresh itself
+burned (up to the 800 ms timeout) — the latter matters because on a real device a null result
+usually *is* a timeout, and counting only the sleep would let a slow proxy silently eat the
+budget:
+
+```ts
+const productiveElapsedMs = this.timer.now() - startTime - noHierarchyTimeMs;
+const budgetExhausted = refindAttempt >= minProductivePolls && productiveElapsedMs >= budgetMs;
+// ...on a null refresh:
+noHierarchyTimeMs += this.timer.now() - refreshStart; // exclude the failed fetch's wall-clock too
+```
+
+The floor also backstops this: because null polls never increment `refindAttempt`, they can
+never reduce the guaranteed productive-poll count regardless of timing.
+
+### 2.3 Loading detection extends both bounds (not the attempt count)
+
+The existing `androidViewHierarchyIndicatesLikelyBlockingLoading()` still runs each productive
+iteration; when it fires, it raises the deadline and the floor once (monotonic — later
+non-loading hierarchies never shrink them back):
+
+```ts
+if (androidViewHierarchyIndicatesLikelyBlockingLoading(freshHierarchy, this.elementParser) &&
+    budgetMs < ANDROID_PRE_TAP_REFIND_BUDGET_MS_WHEN_LOADING) {
+  budgetMs = ANDROID_PRE_TAP_REFIND_BUDGET_MS_WHEN_LOADING;
+  minProductivePolls = ANDROID_PRE_TAP_REFIND_MIN_POLLS_WHEN_LOADING;
+}
+```
+
+### 2.4 Deadline grace for in-progress stability runs
+
+The deadline break is skipped during a null-recovery streak. A subtlety surfaced in review:
+if a null streak resets stability progress right as the deadline passes, a sibling selector
+(which needs 2 consecutive stable matches) could be failed even though the target is present
+and stable. v1 grants a small grace — up to `stableMatchesRequired` extra polls past the
+deadline to finish confirming an already-stable candidate — bounded so a perpetually-shifting
+target cannot extend forever. A defensive `ANDROID_PRE_TAP_MAX_ITERATIONS` backstop guards
+against a future refactor that stops advancing the injected timer.
+
+### 2.5 Behavior
+
+```mermaid
+flowchart TD
+    Start["pre-tap re-find loop"] --> Check{"floor met AND<br/>productive elapsed ≥ budget?"}
+    Check -- "yes (no stable run in progress)" --> Fail["abort: could not re-find<br/>target with stable bounds"]
+    Check -- "no, or finishing a stable run<br/>(bounded grace)" --> Refresh["refresh view hierarchy"]
+    Refresh --> Null{"hierarchy null?"}
+    Null -- yes --> NoHier["consecutiveNoHierarchy++<br/>(sleep + failed-fetch time<br/>excluded from budget)"]
+    NoHier --> Cap{"≥ 12 consecutive?"}
+    Cap -- yes --> AbortWs["abort: accessibility<br/>service unreachable"]
+    Cap -- no --> Check
+    Null -- no --> Loading{"loading indicator<br/>present?"}
+    Loading -- yes --> Extend["budget → 10000ms,<br/>floor → 32 polls<br/>(hard ceilings, once)"]
+    Loading -- no --> Find
+    Extend --> Find["re-find target"]
+    Find --> Stable{"bounds stable ±3px<br/>for N consecutive?"}
+    Stable -- yes --> Tap["✅ return stable target → tap"]
+    Stable -- no --> Sleep["sleep 150ms"]
+    Sleep --> Check
+```
+
+### 2.6 What did NOT change
+
+- The consecutive-stable-bounds requirement (±3px, `androidPreTapConsecutiveStableMatchesRequired`)
+  — the anti-mis-tap guarantee is untouched.
+- The separate no-hierarchy budget, its 500 ms backoff, and its distinct error message.
+- The 150 ms normal poll delay, the 800 ms per-refresh timeout, abort-signal handling.
+- iOS: the iOS tap strategy does not run pre-tap stability, so this change is Android-only.
+
+### 2.7 Tests
+
+[`TapOnElement.preTapStability.test.ts`](../../../test/features/action/TapOnElement.preTapStability.test.ts)
+(FakeTimer, no device):
+
+- Existing behavior re-verified: immediate stability, epsilon convergence, target never
+  re-found, null-recovery, the 12-consecutive-null abort, null-counter reset, longer delay
+  after null, 2-consecutive-stable for churn-prone selectors, abort signal.
+- `fails when bounds never stabilize` reworked to shift bounds for the whole wall-clock
+  budget (it previously relied on the attempt cap).
+- **Pinning #1949 (with symbolic budget/elapsed assertions, so the specific values are what's
+  tested):** `extends budget when loading indicators present…` and its decisive negation
+  `without loading indicators, gives up right at the base budget` (asserts elapsed ≈ 2500 ms).
+- **Regression guards from review:** `guarantees the productive-poll floor even when every
+  fetch is slow` (simulates 800 ms fetches — a pure deadline would bail at ~3 polls; the floor
+  keeps ≥ 8); `detects a loading indicator that appears mid-stream and extends late`;
+  `loading budget is bounded — a target that never appears still fails at the ceiling`
+  (~10000 ms, not forever); `extended budget is not reset by a later non-loading hierarchy`.
+
+## 3. Deliberately out of scope for v1
+
+The three-reviewer critique flagged these as either unsupported by the current data model or
+YAGNI. They are **not** built:
+
+- **Positive `enabled=true` readiness gating.** The ctrl-proxy emitter drops the `enabled`
+  attribute when false, so absent-`enabled` cannot today be distinguished from "unknown";
+  gating on it would stall healthy taps. A prerequisite emitter change is required first.
+- **Determinate-progress escape (`RANGE_INFO`).** Not extracted into the node model today.
+- **Pixel-stability / network-activity signals.** New I/O subsystems; deferred.
+- **Confidence-score fusion, geometry/z-order gate, `SettlePolicy`, `observe` surfacing.**
+  Deferred until a second consumer and real evidence justify the machinery.
+
+## 4. Aspirational future direction
+
+If loaders that the regex cannot name (Compose skeletons, WebView/canvas spinners) show up in
+practice, the intended evolution — in rough priority — is:
+
+1. **Promote positive target readiness to the primary mechanism.** Poll a predicate on the
+   target (`exists ∧ interactable ∧ bounds-stable ∧ not-occluded`) to a deadline, treating
+   absent-`enabled` as "assume ready." This subsumes most tree-based loading detection.
+   Prerequisite: fix the ctrl-proxy `enabled` emitter to distinguish explicit-false.
+2. **Add at most one structural signal** (empty list container / skeleton cluster) behind the
+   existing helper, still returning a boolean + budget-ms — no fusion framework.
+3. **One region pixel-diff signal** for genuinely tree-blind surfaces (WebView/canvas/video),
+   where there is no target node to run a predicate against.
+4. **Instrumentation tier first for first-party targets.** For AutoMobile's own android/ios
+   test apps, an app-exported `busy`/`idle` marker is ground truth (Espresso IdlingResource
+   model) and beats every heuristic.
+5. **Cross-platform readiness**, not Android-shaped signals with iOS stapled on. The iOS
+   quiescence probe must stay timeout-bounded to avoid the known SpringBoard-vs-app 65 s hang.
+
+Rejected outright: globally raising the fixed budget, an ML screenshot classifier, fixed
+`sleep()` after navigation, and confidence-score fusion whose scalar is never actually
+branched on.
+
+## See Also
+
+- [Interaction Loop](interaction-loop.md)
+- [Observe](observe/index.md)
+- [Status Glossary](../status-glossary.md)
+- Issue [#1949](https://github.com/kaeawc/auto-mobile/issues/1949)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -106,6 +106,7 @@ nav:
              - 'Vision Fallback': design-docs/mcp/observe/vision-fallback.md
              - 'Visual Highlighting': design-docs/mcp/observe/visual-highlighting.md
           - 'Interaction Loop': design-docs/mcp/interaction-loop.md
+          - 'Loading-State Awareness': design-docs/mcp/loading-awareness.md
           - 'Daemon':
              - 'Overview': design-docs/mcp/daemon/index.md
              - 'Critical Section': design-docs/mcp/daemon/critical-section.md

--- a/src/features/action/TapOnElement.ts
+++ b/src/features/action/TapOnElement.ts
@@ -115,14 +115,45 @@ export class TapOnElement extends BaseVisualChange {
   private static readonly SEARCH_UNTIL_MIN_MS = 100;
   private static readonly SEARCH_UNTIL_MAX_MS = 12000;
 
-  /** Android: refresh + re-find attempts before tap (includes stability requirement). */
-  private static readonly ANDROID_PRE_TAP_REFIND_MAX_ATTEMPTS = 8;
+  /**
+   * Android: the pre-tap refresh + re-find + stability loop keeps polling until BOTH
+   * a minimum number of productive polls AND a wall-clock deadline are exceeded
+   * (`refindAttempt >= minPolls && productiveElapsed >= budgetMs`).
+   *
+   * Two bounds, because neither alone is sufficient:
+   * - The **wall-clock deadline** adds patience when fetches are fast: a fixed
+   *   "N attempts × poll delay" budget expires in ~1.2s and can miss a list that
+   *   repopulates a few seconds later (#1949).
+   * - The **minimum productive-poll floor** prevents a regression in the opposite
+   *   regime: on a slow device where each hierarchy fetch costs 300–800ms, a pure
+   *   wall-clock budget would allow only ~3–5 polls, fewer than the old fixed 8.
+   *   The floor guarantees we never poll *fewer* times than the previous
+   *   attempt-count implementation, so this change is never less patient.
+   *
+   * Only *productive* polls count toward the floor and only *productive* wall-clock
+   * counts toward the deadline: time spent recovering from "no hierarchy" responses
+   * is excluded (see {@link ANDROID_PRE_TAP_NO_HIERARCHY_MAX_CONSECUTIVE}).
+   */
+  private static readonly ANDROID_PRE_TAP_REFIND_BUDGET_MS = 2500;
+  private static readonly ANDROID_PRE_TAP_REFIND_MIN_POLLS = 8;
 
   /**
-   * When the tree shows a loading overlay (progress/shimmer), list rows may be absent for longer than
-   * {@link ANDROID_PRE_TAP_REFIND_MAX_ATTEMPTS} polling cycles; allow extra refreshes before aborting.
+   * Extended deadline + poll floor (hard ceilings) applied when the tree shows a
+   * blocking loading overlay (progress/shimmer). List rows can stay absent for
+   * several seconds while content loads; give the re-find loop more wall-clock time
+   * and more guaranteed polls before aborting.
    */
-  private static readonly ANDROID_PRE_TAP_REFIND_MAX_ATTEMPTS_WHEN_LOADING = 32;
+  private static readonly ANDROID_PRE_TAP_REFIND_BUDGET_MS_WHEN_LOADING = 10000;
+  private static readonly ANDROID_PRE_TAP_REFIND_MIN_POLLS_WHEN_LOADING = 32;
+
+  /**
+   * Defensive upper bound on total loop iterations (productive + no-hierarchy +
+   * deadline-grace). Real scenarios terminate far sooner via the deadline/floor,
+   * the {@link ANDROID_PRE_TAP_NO_HIERARCHY_MAX_CONSECUTIVE} cap, or finding the
+   * target; this only guards against a future refactor making the loop spin when
+   * the injected timer stops advancing.
+   */
+  private static readonly ANDROID_PRE_TAP_MAX_ITERATIONS = 1000;
 
   /**
    * Separate budget for consecutive "ctrl-proxy returned no hierarchy" results.
@@ -391,30 +422,75 @@ export class TapOnElement extends BaseVisualChange {
       usedParent: boolean;
     } | null = null;
 
-    let maxAttempts = TapOnElement.ANDROID_PRE_TAP_REFIND_MAX_ATTEMPTS;
+    const startTime = this.timer.now();
+    // Wall-clock time NOT attributable to productive polling — the "no hierarchy"
+    // recovery sleeps AND the wall-clock the failed refreshes themselves consumed.
+    // Excluded from the deadline so a temporarily-unresponsive ctrl-proxy WebSocket
+    // doesn't consume the element's patience (that streak is bounded separately by
+    // ANDROID_PRE_TAP_NO_HIERARCHY_MAX_CONSECUTIVE).
+    let noHierarchyTimeMs = 0;
+    let budgetMs = TapOnElement.ANDROID_PRE_TAP_REFIND_BUDGET_MS;
+    let minProductivePolls = TapOnElement.ANDROID_PRE_TAP_REFIND_MIN_POLLS;
     let consecutiveNoHierarchy = 0;
     let refindAttempt = 0;
+    let firstIteration = true;
+    let iterations = 0;
+    // Extra polls allowed past the deadline to finish confirming an already-stable
+    // candidate, so a sibling selector isn't failed at the boundary (e.g. a null
+    // streak resets stability progress right as the deadline passes). Bounded by
+    // stableMatchesRequired so a perpetually-shifting target can't extend forever.
+    let deadlineGracePolls = stableMatchesRequired;
 
-    while (refindAttempt < maxAttempts) {
+    while (true) {
       throwIfAborted(signal);
-      if (refindAttempt > 0 || consecutiveNoHierarchy > 0) {
-        const delayMs = consecutiveNoHierarchy > 0
+      if (++iterations > TapOnElement.ANDROID_PRE_TAP_MAX_ITERATIONS) {
+        break;
+      }
+
+      // Keep polling until BOTH the productive-poll floor and the wall-clock
+      // deadline are exceeded; the floor guarantees we never poll fewer times than
+      // the old fixed attempt count on a slow device.
+      const productiveElapsedMs = this.timer.now() - startTime - noHierarchyTimeMs;
+      const budgetExhausted =
+        refindAttempt >= minProductivePolls && productiveElapsedMs >= budgetMs;
+      const midStabilityRun =
+        best !== null && consecutiveStable > 0 && consecutiveStable < stableMatchesRequired;
+      if (!firstIteration && consecutiveNoHierarchy === 0 && budgetExhausted) {
+        if (midStabilityRun && deadlineGracePolls > 0) {
+          deadlineGracePolls--;
+        } else {
+          break;
+        }
+      }
+
+      if (!firstIteration) {
+        const inNoHierarchyRecovery = consecutiveNoHierarchy > 0;
+        const delayMs = inNoHierarchyRecovery
           ? TapOnElement.ANDROID_PRE_TAP_NO_HIERARCHY_DELAY_MS
           : TapOnElement.ANDROID_PRE_TAP_REFIND_DELAY_MS;
         await this.timer.sleep(delayMs);
+        if (inNoHierarchyRecovery) {
+          noHierarchyTimeMs += delayMs;
+        }
       }
+      firstIteration = false;
 
+      const refreshStart = this.timer.now();
       const freshHierarchy = await this.refreshViewHierarchy(
         TapOnElement.ANDROID_PRE_TAP_REFRESH_TIMEOUT_MS,
         observeResult.screenSize,
         signal
       );
       if (!freshHierarchy) {
+        // The failed refresh itself burned wall-clock (up to the timeout); exclude
+        // that from the deadline too, not just the recovery sleep, otherwise a slow
+        // unresponsive proxy still eats the element's patience.
+        noHierarchyTimeMs += this.timer.now() - refreshStart;
         consecutiveNoHierarchy++;
         logger.warn(
           `[TapOnElement] Android pre-tap refresh returned no hierarchy ` +
           `(consecutive: ${consecutiveNoHierarchy}/${TapOnElement.ANDROID_PRE_TAP_NO_HIERARCHY_MAX_CONSECUTIVE}, ` +
-          `refind attempt: ${refindAttempt}/${maxAttempts})`
+          `refind attempt: ${refindAttempt})`
         );
         if (consecutiveNoHierarchy >= TapOnElement.ANDROID_PRE_TAP_NO_HIERARCHY_MAX_CONSECUTIVE) {
           return {
@@ -434,18 +510,20 @@ export class TapOnElement extends BaseVisualChange {
 
       if (
         androidViewHierarchyIndicatesLikelyBlockingLoading(freshHierarchy, this.elementParser) &&
-        maxAttempts < TapOnElement.ANDROID_PRE_TAP_REFIND_MAX_ATTEMPTS_WHEN_LOADING
+        budgetMs < TapOnElement.ANDROID_PRE_TAP_REFIND_BUDGET_MS_WHEN_LOADING
       ) {
-        maxAttempts = TapOnElement.ANDROID_PRE_TAP_REFIND_MAX_ATTEMPTS_WHEN_LOADING;
+        budgetMs = TapOnElement.ANDROID_PRE_TAP_REFIND_BUDGET_MS_WHEN_LOADING;
+        minProductivePolls = TapOnElement.ANDROID_PRE_TAP_REFIND_MIN_POLLS_WHEN_LOADING;
         logger.info(
-          `[TapOnElement] Android pre-tap: loading/progress indicators present; extending refind attempts to ${maxAttempts}`
+          `[TapOnElement] Android pre-tap: loading/progress indicators present; ` +
+          `extending refind budget to ${budgetMs}ms / ${minProductivePolls} polls`
         );
       }
 
       const refind = this.findElementInHierarchy(options, freshHierarchy);
       if (!refind.selection.element) {
         logger.warn(
-          `[TapOnElement] Android pre-tap refresh attempt ${refindAttempt}/${maxAttempts} did not re-find tap target`
+          `[TapOnElement] Android pre-tap refresh attempt ${refindAttempt} did not re-find tap target`
         );
         consecutiveStable = 0;
         prevBounds = null;

--- a/test/features/action/TapOnElement.preTapStability.test.ts
+++ b/test/features/action/TapOnElement.preTapStability.test.ts
@@ -303,7 +303,7 @@ describe("resolveAndroidStableTapTargetAfterRefreshes", () => {
   test("extended budget is not reset by a later non-loading hierarchy", async () => {
     // Spinner on the first poll extends the budget; subsequent plain hierarchies must
     // not shrink it back (the target appears past the base budget's reach).
-    const { tap, timer } = createTapOnElement();
+    const { tap } = createTapOnElement();
     let call = 0;
     (tap as any).refreshViewHierarchy = async () => {
       call++;

--- a/test/features/action/TapOnElement.preTapStability.test.ts
+++ b/test/features/action/TapOnElement.preTapStability.test.ts
@@ -131,12 +131,17 @@ describe("resolveAndroidStableTapTargetAfterRefreshes", () => {
     const { tap } = createTapOnElement();
     const vh = makeHierarchy();
 
-    const sequence: StubSequenceEntry[] = Array.from({ length: 8 }, (_, i) => ({
-      hierarchy: vh,
-      element: makeElement({ left: i * 20, top: 0, right: i * 20 + 100, bottom: 50 }),
-    }));
-
-    stubStabilityDeps(tap, sequence);
+    // Bounds shift on every re-find and never converge. Generated per call so the
+    // element keeps moving for the entire wall-clock budget (the stability loop is
+    // deadline-bounded, not attempt-count-bounded).
+    let idx = 0;
+    (tap as any).refreshViewHierarchy = async () => vh;
+    (tap as any).findElementInHierarchy = () => {
+      const element = makeElement({ left: idx * 20, top: 0, right: idx * 20 + 100, bottom: 50 });
+      idx++;
+      return { selection: { element }, containerFound: false };
+    };
+    (tap as any).resolveTapTargetElement = (el: Element) => ({ element: el, usedParent: false });
 
     const result = await (tap as any).resolveAndroidStableTapTargetAfterRefreshes(
       { text: "Row", sibling: true, action: "tap" },
@@ -147,6 +152,177 @@ describe("resolveAndroidStableTapTargetAfterRefreshes", () => {
 
     expect(result.ok).toBe(false);
     expect(result.error).toContain("could not re-find the target");
+  });
+
+  // Regression for #1949: the target row is absent while a spinner is up and only
+  // reappears after the base (non-loading) budget would have expired. These tests pin
+  // that detecting a loading indicator extends BOTH the wall-clock budget and the
+  // productive-poll floor, and assert elapsed time symbolically so the specific budget
+  // values (not just "some big number") are what's under test.
+  const BASE_BUDGET_MS = (TapOnElement as any).ANDROID_PRE_TAP_REFIND_BUDGET_MS as number;
+  const LOADING_BUDGET_MS = (TapOnElement as any).ANDROID_PRE_TAP_REFIND_BUDGET_MS_WHEN_LOADING as number;
+  const MIN_POLLS = (TapOnElement as any).ANDROID_PRE_TAP_REFIND_MIN_POLLS as number;
+
+  const LOADING_HIERARCHY: ViewHierarchyResult = {
+    hierarchy: {
+      node: { "class": "android.widget.ProgressBar", "bounds": { left: 0, top: 0, right: 10, bottom: 10 } }
+    }
+  } as unknown as ViewHierarchyResult;
+
+  // Stub that reveals the target only from `appearsOnCall` onward. Optional per-poll
+  // `refreshDelayMs` simulates real device fetch latency (FakeTimer refresh is otherwise
+  // instant), and `loadingFromCall` switches the returned hierarchy to a loading one at a
+  // given poll so mid-stream detection can be exercised. Returns a live poll counter.
+  function stubLateAppearingTarget(
+    tap: TapOnElement,
+    timer: FakeTimer,
+    opts: {
+      appearsOnCall: number;
+      hierarchy?: ViewHierarchyResult;
+      loadingFromCall?: number;
+      refreshDelayMs?: number;
+    }
+  ): { calls: () => number } {
+    let call = 0;
+    (tap as any).refreshViewHierarchy = async () => {
+      if (opts.refreshDelayMs) {
+        await timer.sleep(opts.refreshDelayMs);
+      }
+      const loading = opts.loadingFromCall !== undefined && call + 1 >= opts.loadingFromCall;
+      return loading ? LOADING_HIERARCHY : (opts.hierarchy ?? makeHierarchy());
+    };
+    (tap as any).findElementInHierarchy = () => {
+      call++;
+      const element = call >= opts.appearsOnCall ? makeElement(STABLE_BOUNDS) : null;
+      return { selection: { element }, containerFound: false };
+    };
+    (tap as any).resolveTapTargetElement = (el: Element) => ({ element: el, usedParent: false });
+    return { calls: () => call };
+  }
+
+  test("extends budget when loading indicators present so a late list repopulation still taps", async () => {
+    const { tap, timer } = createTapOnElement();
+    // Target appears well past what the base budget can reach (~18 polls @150ms), so
+    // only the loading extension can find it.
+    stubLateAppearingTarget(tap, timer, { appearsOnCall: 25, hierarchy: LOADING_HIERARCHY });
+
+    const t0 = timer.now();
+    const result = await (tap as any).resolveAndroidStableTapTargetAfterRefreshes(
+      { text: "Row", action: "tap" },
+      { screenSize: { width: 1080, height: 1920 } },
+      "tap",
+      false
+    );
+
+    expect(result.ok).toBe(true);
+    expect(result.tapElement.bounds).toEqual(STABLE_BOUNDS);
+    // Proves the extension was load-bearing: it kept polling past the base budget.
+    expect(timer.now() - t0).toBeGreaterThan(BASE_BUDGET_MS);
+    expect(timer.now() - t0).toBeLessThan(LOADING_BUDGET_MS);
+  });
+
+  test("without loading indicators, gives up right at the base budget", async () => {
+    const { tap, timer } = createTapOnElement();
+    // Same target appearance, but a plain hierarchy — nothing justifies extending.
+    stubLateAppearingTarget(tap, timer, { appearsOnCall: 25 });
+
+    const t0 = timer.now();
+    const result = await (tap as any).resolveAndroidStableTapTargetAfterRefreshes(
+      { text: "Row", action: "tap" },
+      { screenSize: { width: 1080, height: 1920 } },
+      "tap",
+      false
+    );
+
+    expect(result.ok).toBe(false);
+    expect(result.error).toContain("could not re-find the target");
+    // Decisive: it gave up AT the base budget, not merely "before the element" — the
+    // elapsed time pins the 2500ms value, so raising the base budget fails this loudly.
+    const elapsed = timer.now() - t0;
+    expect(elapsed).toBeGreaterThanOrEqual(BASE_BUDGET_MS);
+    expect(elapsed).toBeLessThan(BASE_BUDGET_MS + 600);
+  });
+
+  test("guarantees the productive-poll floor even when every fetch is slow", async () => {
+    // Regression guard: on a slow device each hierarchy fetch costs ~800ms, so a pure
+    // wall-clock deadline (2500ms) would allow only ~3 polls — fewer than the old fixed
+    // 8. The floor must keep polling until MIN_POLLS regardless of elapsed wall-clock.
+    const { tap, timer } = createTapOnElement();
+    const stub = stubLateAppearingTarget(tap, timer, { appearsOnCall: MIN_POLLS, refreshDelayMs: 800 });
+
+    const result = await (tap as any).resolveAndroidStableTapTargetAfterRefreshes(
+      { text: "Row", action: "tap" },
+      { screenSize: { width: 1080, height: 1920 } },
+      "tap",
+      false
+    );
+
+    // The target sits exactly at the floor; a pure-deadline loop would have bailed at
+    // ~3 polls and failed. Reaching it proves at least MIN_POLLS productive polls ran.
+    expect(result.ok).toBe(true);
+    expect(stub.calls()).toBeGreaterThanOrEqual(MIN_POLLS);
+  });
+
+  test("detects a loading indicator that appears mid-stream and extends late", async () => {
+    // The #1949 shape: several plain polls tick the base-budget clock, THEN a spinner
+    // mounts. Detection must extend even though the first polls were non-loading.
+    const { tap, timer } = createTapOnElement();
+    stubLateAppearingTarget(tap, timer, { appearsOnCall: 25, loadingFromCall: 11 });
+
+    const t0 = timer.now();
+    const result = await (tap as any).resolveAndroidStableTapTargetAfterRefreshes(
+      { text: "Row", action: "tap" },
+      { screenSize: { width: 1080, height: 1920 } },
+      "tap",
+      false
+    );
+
+    expect(result.ok).toBe(true);
+    expect(timer.now() - t0).toBeGreaterThan(BASE_BUDGET_MS);
+  });
+
+  test("loading budget is bounded — a target that never appears still fails at the ceiling", async () => {
+    const { tap, timer } = createTapOnElement();
+    // Loading indicator present throughout, target never appears: must NOT wait forever.
+    stubLateAppearingTarget(tap, timer, { appearsOnCall: Number.MAX_SAFE_INTEGER, hierarchy: LOADING_HIERARCHY });
+
+    const t0 = timer.now();
+    const result = await (tap as any).resolveAndroidStableTapTargetAfterRefreshes(
+      { text: "Row", action: "tap" },
+      { screenSize: { width: 1080, height: 1920 } },
+      "tap",
+      false
+    );
+
+    expect(result.ok).toBe(false);
+    const elapsed = timer.now() - t0;
+    expect(elapsed).toBeGreaterThanOrEqual(LOADING_BUDGET_MS);
+    expect(elapsed).toBeLessThan(LOADING_BUDGET_MS + 1000);
+  });
+
+  test("extended budget is not reset by a later non-loading hierarchy", async () => {
+    // Spinner on the first poll extends the budget; subsequent plain hierarchies must
+    // not shrink it back (the target appears past the base budget's reach).
+    const { tap, timer } = createTapOnElement();
+    let call = 0;
+    (tap as any).refreshViewHierarchy = async () => {
+      call++;
+      return call === 1 ? LOADING_HIERARCHY : makeHierarchy();
+    };
+    (tap as any).findElementInHierarchy = () => ({
+      selection: { element: call >= 40 ? makeElement(STABLE_BOUNDS) : null },
+      containerFound: false
+    });
+    (tap as any).resolveTapTargetElement = (el: Element) => ({ element: el, usedParent: false });
+
+    const result = await (tap as any).resolveAndroidStableTapTargetAfterRefreshes(
+      { text: "Row", action: "tap" },
+      { screenSize: { width: 1080, height: 1920 } },
+      "tap",
+      false
+    );
+
+    expect(result.ok).toBe(true);
   });
 
   test("recovers after hierarchy returns null then stabilizes", async () => {


### PR DESCRIPTION
## Summary

Fixes #1949 — the Android pre-tap stability loop could exhaust its retry budget before a loading list repopulated, so a `tapOn` on a search result would fail even though the target row reappeared moments later.

The loop (`resolveAndroidStableTapTargetAfterRefreshes`) previously expressed patience as a fixed **attempt count** (8, bumped to 32 when a `ProgressBar`/`ShimmerFrameLayout`/`ContentLoadingProgressBar` was detected). Coupling patience to poll cadence is what let it expire early.

## What changed

Patience is now bounded by **two values, applied together** — `refindAttempt >= minPolls && productiveElapsed >= budgetMs`:

| | base | when loading detected |
|---|---|---|
| wall-clock deadline | 2500 ms | 10000 ms |
| productive-poll floor | 8 | 32 |

- **Wall-clock deadline** adds patience when fetches are fast (the #1949 case).
- **Poll floor** prevents the opposite regression: real hierarchy-fetch latency (300–800 ms on-device) counts against a pure wall-clock budget, so 2500 ms alone would buy only ~3–5 polls — *fewer* than the old fixed 8. The floor guarantees the loop is **never less patient** than before, in any fetch-speed regime.

Also hardened from adversarial review:
- Exclude the failed refresh's own wall-clock (up to the 800 ms timeout) from the budget, not just the 500 ms recovery sleep, so a slow unresponsive ctrl-proxy can't silently eat the element's patience.
- Bounded **deadline grace** (≤ `stableMatchesRequired` extra polls) so a sibling selector isn't failed at the boundary when a null streak resets its stability progress right as the deadline passes.
- Defensive max-iteration backstop now that the attempt counter is gone.

## Preserved (no regression)

The ±3 px consecutive-stable-bounds anti-mis-tap guarantee, the separate 12-consecutive no-hierarchy abort + 500 ms backoff, the 150 ms poll delay, the 800 ms refresh timeout, and abort-signal handling are all unchanged. iOS does not run pre-tap stability, so this is Android-only.

## Tests

`test/features/action/TapOnElement.preTapStability.test.ts` (FakeTimer, no device, 17 tests):
- All prior behaviors re-verified.
- `#1949` pinned with **symbolic budget + elapsed-time assertions** (so the specific 2500/10000 values are what's tested, not just "some big number").
- New regression guards: poll floor under slow fetches, mid-stream loading detection, bounded loading ceiling (fails at ~10 s, not forever), and extended-budget-not-reset-by-plain-hierarchy.

Full `test/features/action/` suite: 690 pass / 0 fail. Lint + build green.

## Design doc

`docs/design-docs/mcp/loading-awareness.md` documents the shipped v1 and defers the larger multi-signal loading model (readiness predicates, pixel/network signals, instrumentation tier) as aspirational — see §3–4.

## Not yet covered

No real-device/emulator E2E exercises this path — neither playground app currently has a "spinner up → target row absent → reappears" screen. A follow-up could add one plus a plan YAML; happy to do that separately.