### PR TITLE
ci: remove flaky lychee link check from Fast Validation

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -541,7 +541,6 @@ jobs:
             git clone --depth 1 https://github.com/bats-core/bats-core.git /tmp/bats-core
             sudo /tmp/bats-core/install.sh /usr/local
           fi
-          scripts/lychee/install_lychee.sh
 
       - name: "Run fast validation checks"
         shell: bash
@@ -550,7 +549,7 @@ jobs:
           KTFMT_ONLY_TOUCHED_FILES: "false"
         run: |
           scripts/all_fast_validate_checks.sh \
-            --only yaml,xml,shellcheck,mkdocs-nav,ktfmt,claude-plugin,lychee \
+            --only yaml,xml,shellcheck,mkdocs-nav,ktfmt,claude-plugin \
             --max-parallel 4
 
       - name: "Run BATS Tests (Ubuntu)"


### PR DESCRIPTION
## Problem

The `lychee` link checker in the **Fast Validation** job (`.github/workflows/pull_request.yml`) intermittently fails on transient network errors and rate-limited external links, producing spurious red CI that blocks PRs.

## Change

Remove lychee from the Fast Validation job only:

- Drop the `scripts/lychee/install_lychee.sh` install step.
- Remove `lychee` from the `all_fast_validate_checks.sh --only` list.

All other fast validation (yaml, xml, shellcheck, mkdocs-nav, ktfmt, claude-plugin, BATS, hadolint) is untouched.

## Link checking still happens

Lychee link validation continues to run post-merge in `merge.yml` (`Validate Links` job), which is **not** PR-blocking. The shared `scripts/lychee/*` scripts and `.lycherc.toml` config remain referenced there, so nothing is orphaned.

## Validation

- `python3` YAML parse: OK
- `actionlint`: no new errors (pre-existing local-composite-action metadata warnings are unrelated)
- Confirmed no remaining lychee link-check invocation in the Fast Validation path