### PR TITLE
refactor(models): introduce BaseActionResult to collapse ~65 duplicated action Result types

### DIFF
--- a/src/models/AppStatusResult.ts
+++ b/src/models/AppStatusResult.ts
@@ -1,13 +1,10 @@
-import { ObserveResult } from "./ObserveResult";
+import { BaseActionResult } from "./BaseActionResult";
 
 /**
  * Result of checking comprehensive app status
  */
-export interface AppStatusResult {
-  success: boolean;
+export interface AppStatusResult extends BaseActionResult {
   packageName: string;
   isInstalled: boolean;
   isRunning: boolean;
-  observation?: ObserveResult;
-  error?: string;
 }

--- a/src/models/BaseActionResult.ts
+++ b/src/models/BaseActionResult.ts
@@ -1,0 +1,14 @@
+import { ObserveResult } from "./ObserveResult";
+
+/**
+ * Shared base for action results that report success and optionally attach a
+ * post-action observation snapshot.
+ *
+ * Kept deliberately separate from `observe/shared` `BaseResult` (which carries
+ * timing fields and no `observation`) — the two model different concerns.
+ */
+export interface BaseActionResult {
+  success: boolean;
+  observation?: ObserveResult;
+  error?: string;
+}

--- a/src/models/BiometricAuthResult.ts
+++ b/src/models/BiometricAuthResult.ts
@@ -1,16 +1,13 @@
-import { ObserveResult } from "./ObserveResult";
+import { BaseActionResult } from "./BaseActionResult";
 
 /**
  * Result of a biometric authentication action
  */
-export interface BiometricAuthResult {
-  success: boolean;
+export interface BiometricAuthResult extends BaseActionResult {
   action: "match" | "fail" | "cancel" | "error";
   modality: "any" | "fingerprint" | "face";
   fingerprintId?: number;
   errorCode?: number;
   supported: boolean | "partial";
-  observation?: ObserveResult;
-  error?: string;
   message?: string;
 }

--- a/src/models/ClearAppDataResult.ts
+++ b/src/models/ClearAppDataResult.ts
@@ -1,13 +1,10 @@
-import { ObserveResult } from "./ObserveResult";
+import { BaseActionResult } from "./BaseActionResult";
 
 /**
  * Result of a clear app data operation
  */
-export interface ClearAppDataResult {
-  success: boolean;
+export interface ClearAppDataResult extends BaseActionResult {
   packageName: string;
   /** Android user ID where the app data was cleared (0 for primary user, 10+ for work profiles) */
   userId?: number;
-  observation?: ObserveResult;
-  error?: string;
 }

--- a/src/models/ClearTextResult.ts
+++ b/src/models/ClearTextResult.ts
@@ -1,10 +1,6 @@
-import { ObserveResult } from "./ObserveResult";
+import { BaseActionResult } from "./BaseActionResult";
 
 /**
  * Result of a clear text operation
  */
-export interface ClearTextResult {
-  success: boolean;
-  observation?: ObserveResult;
-  error?: string;
-}
+export type ClearTextResult = BaseActionResult;

--- a/src/models/DragAndDropResult.ts
+++ b/src/models/DragAndDropResult.ts
@@ -1,11 +1,8 @@
-import { ObserveResult } from "./ObserveResult";
+import { BaseActionResult } from "./BaseActionResult";
 
-export interface DragAndDropResult {
-  success: boolean;
+export interface DragAndDropResult extends BaseActionResult {
   duration: number;
   distance: number;
-  observation?: ObserveResult;
-  error?: string;
   a11yTotalTimeMs?: number;
   a11yGestureTimeMs?: number;
 }

--- a/src/models/ExitDialogResult.ts
+++ b/src/models/ExitDialogResult.ts
@@ -1,15 +1,12 @@
 import { Element } from "./Element";
-import { ObserveResult } from "./ObserveResult";
+import { BaseActionResult } from "./BaseActionResult";
 
 /**
  * Result of an exit dialog operation
  */
-export interface ExitDialogResult {
-  success: boolean;
+export interface ExitDialogResult extends BaseActionResult {
   elementFound: boolean;
   element?: Element;
   x?: number;
   y?: number;
-  observation?: ObserveResult;
-  error?: string;
 }

--- a/src/models/InstallAppResult.ts
+++ b/src/models/InstallAppResult.ts
@@ -1,10 +1,9 @@
-import { ObserveResult } from "./ObserveResult";
+import { BaseActionResult } from "./BaseActionResult";
 
 /**
  * Result of an install app operation
  */
-export interface InstallAppResult {
-  success: boolean;
+export interface InstallAppResult extends BaseActionResult {
   artifactPath: string;
   /** Android user ID where the app was installed (0 for primary user, 10+ for work profiles) */
   userId?: number;
@@ -14,6 +13,4 @@ export interface InstallAppResult {
   upgrade?: boolean;
   /** Warning message when best-effort detection was required */
   warning?: string;
-  observation?: ObserveResult;
-  error?: string;
 }

--- a/src/models/LaunchAppResult.ts
+++ b/src/models/LaunchAppResult.ts
@@ -1,16 +1,13 @@
-import { ObserveResult } from "./ObserveResult";
+import { BaseActionResult } from "./BaseActionResult";
 
 /**
  * Result of a launch app operation
  */
-export interface LaunchAppResult {
-  success: boolean;
+export interface LaunchAppResult extends BaseActionResult {
   packageName: string;
   activityName?: string;
   /** Android user ID where the app was launched (0 for primary user, 10+ for work profiles) */
   userId?: number;
   /** Process ID (iOS only) */
   pid?: number;
-  observation?: ObserveResult;
-  error?: string;
 }

--- a/src/models/LongPressResult.ts
+++ b/src/models/LongPressResult.ts
@@ -1,14 +1,11 @@
-import { ObserveResult } from "./ObserveResult";
+import { BaseActionResult } from "./BaseActionResult";
 
 /**
  * Result of a long press operation
  */
-export interface LongPressResult {
-  success: boolean;
+export interface LongPressResult extends BaseActionResult {
   x: number;
   y: number;
-  observation?: ObserveResult;
-  error?: string;
   pressRecognized?: boolean;
   contextMenuOpened?: boolean;
   selectionStarted?: boolean;

--- a/src/models/OpenURLResult.ts
+++ b/src/models/OpenURLResult.ts
@@ -1,11 +1,8 @@
-import { ObserveResult } from "./ObserveResult";
+import { BaseActionResult } from "./BaseActionResult";
 
 /**
  * Result of an open URL operation
  */
-export interface OpenURLResult {
-  success: boolean;
+export interface OpenURLResult extends BaseActionResult {
   url: string;
-  observation?: ObserveResult;
-  error?: string;
 }

--- a/src/models/PinchOnResult.ts
+++ b/src/models/PinchOnResult.ts
@@ -1,7 +1,6 @@
-import { ObserveResult } from "./ObserveResult";
+import { BaseActionResult } from "./BaseActionResult";
 
-export interface PinchOnResult {
-  success: boolean;
+export interface PinchOnResult extends BaseActionResult {
   direction: "in" | "out";
   distanceStart: number;
   distanceEnd: number;
@@ -16,8 +15,6 @@ export interface PinchOnResult {
     text?: string;
   };
   warning?: string;
-  observation?: ObserveResult;
-  error?: string;
   a11yTotalTimeMs?: number;
   a11yGestureTimeMs?: number;
 }

--- a/src/models/PinchResult.ts
+++ b/src/models/PinchResult.ts
@@ -1,10 +1,7 @@
-import { ObserveResult } from "./ObserveResult";
+import { BaseActionResult } from "./BaseActionResult";
 
-export interface PinchResult {
-  success: boolean;
+export interface PinchResult extends BaseActionResult {
   startingMagnitude: number;
   endingMagnitude: number;
   duration: number;
-  observation?: ObserveResult;
-  error?: string;
 }

--- a/src/models/PressButtonResult.ts
+++ b/src/models/PressButtonResult.ts
@@ -1,12 +1,9 @@
-import { ObserveResult } from "./ObserveResult";
+import { BaseActionResult } from "./BaseActionResult";
 
 /**
  * Result of a press button operation
  */
-export interface PressButtonResult {
-  success: boolean;
+export interface PressButtonResult extends BaseActionResult {
   button: string;
   keyCode: number;
-  observation?: ObserveResult;
-  error?: string;
 }

--- a/src/models/RecentAppsResult.ts
+++ b/src/models/RecentAppsResult.ts
@@ -1,11 +1,8 @@
-import { ObserveResult } from "./ObserveResult";
+import { BaseActionResult } from "./BaseActionResult";
 
 /**
  * Result of a recent apps navigation operation
  */
-export interface RecentAppsResult {
-    success: boolean;
+export interface RecentAppsResult extends BaseActionResult {
     method: "gesture" | "legacy" | "hardware" | "ios_swipe";
-    observation?: ObserveResult;
-    error?: string;
 }

--- a/src/models/RotateResult.ts
+++ b/src/models/RotateResult.ts
@@ -1,14 +1,11 @@
-import { ObserveResult } from "./ObserveResult";
+import { BaseActionResult } from "./BaseActionResult";
 
 /**
  * Result of a rotate operation
  */
-export interface RotateResult {
-  success: boolean;
+export interface RotateResult extends BaseActionResult {
   orientation: string;
   value: number;
-  observation?: ObserveResult;
-  error?: string;
 
   // Enhanced fields for intelligent rotation
   currentOrientation?: string;

--- a/src/models/SelectAllTextResult.ts
+++ b/src/models/SelectAllTextResult.ts
@@ -1,10 +1,6 @@
-import { ObserveResult } from "./ObserveResult";
+import { BaseActionResult } from "./BaseActionResult";
 
 /**
  * Result of a select all text operation
  */
-export interface SelectAllTextResult {
-  success: boolean;
-  observation?: ObserveResult;
-  error?: string;
-}
+export type SelectAllTextResult = BaseActionResult;

--- a/src/models/SendKeyEventResult.ts
+++ b/src/models/SendKeyEventResult.ts
@@ -1,11 +1,8 @@
-import { ObserveResult } from "./ObserveResult";
+import { BaseActionResult } from "./BaseActionResult";
 
 /**
  * Result of a send key event operation
  */
-export interface SendKeyEventResult {
-  success: boolean;
+export interface SendKeyEventResult extends BaseActionResult {
   keyCode: number | string;
-  observation?: ObserveResult;
-  error?: string;
 }

--- a/src/models/SendTextResult.ts
+++ b/src/models/SendTextResult.ts
@@ -1,12 +1,9 @@
-import { ObserveResult } from "./ObserveResult";
+import { BaseActionResult } from "./BaseActionResult";
 
 /**
  * Result of a send text operation
  */
-export interface SendTextResult {
-  success: boolean;
+export interface SendTextResult extends BaseActionResult {
   text: string;
   imeAction?: string;
-  observation?: ObserveResult;
-  error?: string;
 }

--- a/src/models/SetUIStateResult.ts
+++ b/src/models/SetUIStateResult.ts
@@ -1,4 +1,4 @@
-import { ObserveResult } from "./ObserveResult";
+import { BaseActionResult } from "./BaseActionResult";
 import { ElementSelector } from "./SetUIStateOptions";
 
 /**
@@ -29,15 +29,9 @@ export interface FieldResult {
 /**
  * Result of the setUIState operation
  */
-export interface SetUIStateResult {
-  /** Whether all fields were set successfully */
-  success: boolean;
+export interface SetUIStateResult extends BaseActionResult {
   /** Results for each field */
   fields: FieldResult[];
   /** Total attempts across all fields */
   totalAttempts: number;
-  /** Final observation after all operations */
-  observation?: ObserveResult;
-  /** Error message if the operation failed */
-  error?: string;
 }

--- a/src/models/ShakeResult.ts
+++ b/src/models/ShakeResult.ts
@@ -1,12 +1,9 @@
-import { ObserveResult } from "./ObserveResult";
+import { BaseActionResult } from "./BaseActionResult";
 
 /**
  * Result of a shake operation
  */
-export interface ShakeResult {
-    success: boolean;
+export interface ShakeResult extends BaseActionResult {
     duration: number;
     intensity: number;
-    observation?: ObserveResult;
-    error?: string;
 }

--- a/src/models/SwipeOnResult.ts
+++ b/src/models/SwipeOnResult.ts
@@ -1,13 +1,11 @@
-import { ObserveResult } from "./ObserveResult";
+import { BaseActionResult } from "./BaseActionResult";
 import { Element } from "./Element";
 import { ToolDebugInfo } from "../utils/DebugContextBuilder";
 
 /**
  * Result of a swipeOn operation
  */
-export interface SwipeOnResult {
-  success: boolean;
-  error?: string;
+export interface SwipeOnResult extends BaseActionResult {
   warning?: string;
 
   // Context to help callers target scrollable containers
@@ -33,9 +31,6 @@ export interface SwipeOnResult {
   scrollIterations?: number; // Number of scrolls performed
   elapsedMs?: number; // Time taken to find element
   hierarchyChanged?: boolean; // Did the hierarchy change during scroll?
-
-  // Observation
-  observation?: ObserveResult;
 
   // A11y mode timing (when scrollMode="a11y")
   a11yTotalTimeMs?: number;

--- a/src/models/SwipeResult.ts
+++ b/src/models/SwipeResult.ts
@@ -1,10 +1,9 @@
-import { ObserveResult } from "./ObserveResult";
+import { BaseActionResult } from "./BaseActionResult";
 
 /**
  * Result of a swipe operation
  */
-export interface SwipeResult {
-  success: boolean;
+export interface SwipeResult extends BaseActionResult {
   x1: number;
   y1: number;
   x2: number;
@@ -12,8 +11,6 @@ export interface SwipeResult {
   duration: number;
   path?: number;
   easing?: "linear" | "decelerate" | "accelerate" | "accelerateDecelerate";
-  observation?: ObserveResult;
-  error?: string;
   // A11y mode timing (when scrollMode="a11y")
   a11yTotalTimeMs?: number;   // Total time on device for swipe (including gesture dispatch)
   a11yGestureTimeMs?: number; // Actual gesture execution time on device

--- a/src/models/TapOnElementResult.ts
+++ b/src/models/TapOnElementResult.ts
@@ -1,7 +1,7 @@
 import { Element } from "./Element";
 import { ElementBounds } from "./ElementBounds";
 import { ElementSelectionStrategy } from "./ElementSelectionStrategy";
-import { ObserveResult } from "./ObserveResult";
+import { BaseActionResult } from "./BaseActionResult";
 import { ToolDebugInfo } from "../utils/DebugContextBuilder";
 
 export interface TapOnSelectedElementBounds extends ElementBounds {
@@ -21,13 +21,10 @@ export interface TapOnSelectedElement {
 /**
  * Result of a tap on text operation
  */
-export interface TapOnElementResult {
-  success: boolean;
+export interface TapOnElementResult extends BaseActionResult {
   action: string;
   element: Element;
   selectedElement?: TapOnSelectedElement;
-  observation?: ObserveResult;
-  error?: string;
   debug?: ToolDebugInfo;
   pressRecognized?: boolean;
   contextMenuOpened?: boolean;

--- a/src/models/TapResult.ts
+++ b/src/models/TapResult.ts
@@ -1,12 +1,9 @@
-import { ObserveResult } from "./ObserveResult";
+import { BaseActionResult } from "./BaseActionResult";
 
 /**
  * Result of a tap operation
  */
-export interface TapResult {
-  success: boolean;
+export interface TapResult extends BaseActionResult {
   x: number;
   y: number;
-  observation?: ObserveResult;
-  error?: string;
 }

--- a/src/models/TerminateAppResult.ts
+++ b/src/models/TerminateAppResult.ts
@@ -1,16 +1,13 @@
-import { ObserveResult } from "./ObserveResult";
+import { BaseActionResult } from "./BaseActionResult";
 
 /**
  * Result of a terminate app operation
  */
-export interface TerminateAppResult {
-  success: boolean;
+export interface TerminateAppResult extends BaseActionResult {
   packageName: string;
   wasInstalled: boolean;
   wasRunning: boolean;
   wasForeground: boolean;
   /** Android user ID where the app was terminated (0 for primary user, 10+ for work profiles) */
   userId?: number;
-  observation?: ObserveResult;
-  error?: string;
 }

--- a/src/models/UninstallAppResult.ts
+++ b/src/models/UninstallAppResult.ts
@@ -1,15 +1,12 @@
-import { ObserveResult } from "./ObserveResult";
+import { BaseActionResult } from "./BaseActionResult";
 
 /**
  * Result of an uninstall app operation
  */
-export interface UninstallAppResult {
-  success: boolean;
+export interface UninstallAppResult extends BaseActionResult {
   packageName: string;
   keepData: boolean;
   wasInstalled: boolean;
   /** Android user ID where the app was uninstalled from (0 for primary user, 10+ for work profiles) */
   userId?: number;
-  observation?: ObserveResult;
-  error?: string;
 }

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -4,6 +4,7 @@ export * from "./ActiveWindowInfo";
 export * from "./AndroidDeviceShellToolResult";
 export * from "./AndroidUser";
 export * from "./BackStack";
+export * from "./BaseActionResult";
 export * from "./BiometricAuthResult";
 export * from "./AppMetadataResult";
 export * from "./AppStatusResult";

--- a/test/models/BaseActionResult.test.ts
+++ b/test/models/BaseActionResult.test.ts
@@ -1,0 +1,181 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "fs";
+import { join } from "path";
+
+import type { BaseActionResult } from "../../src/models/BaseActionResult";
+import type { ObserveResult } from "../../src/models/ObserveResult";
+import type {
+  ClearTextResult,
+  SelectAllTextResult,
+  TapResult,
+  LaunchAppResult,
+  PressButtonResult,
+  SwipeResult,
+} from "../../src/models";
+
+const MODELS_DIR = join(__dirname, "..", "..", "src", "models");
+
+const read = (name: string): string =>
+  readFileSync(join(MODELS_DIR, `${name}.ts`), "utf8");
+
+/**
+ * Extracts the body of `export interface <name> extends BaseActionResult { ... }`
+ * using balanced-brace matching, so nested inline object types and sibling
+ * interfaces in the same file are not misattributed to the target interface.
+ */
+const interfaceBody = (src: string, name: string): string => {
+  const header = new RegExp(`interface ${name} extends BaseActionResult\\s*\\{`);
+  const match = header.exec(src);
+  if (!match) {
+    return "";
+  }
+  let depth = 0;
+  let start = -1;
+  for (let i = match.index; i < src.length; i++) {
+    if (src[i] === "{") {
+      if (depth === 0) {
+        start = i + 1;
+      }
+      depth++;
+    } else if (src[i] === "}") {
+      depth--;
+      if (depth === 0) {
+        return src.slice(start, i);
+      }
+    }
+  }
+  return "";
+};
+
+/**
+ * The exact-trio results that must become bare aliases of BaseActionResult.
+ */
+const ALIAS_TYPES = ["ClearTextResult", "SelectAllTextResult"] as const;
+
+/**
+ * Results that must `extends BaseActionResult`, mapped to a representative extra
+ * field that must survive the refactor.
+ */
+const EXTENDS_TYPES: Record<string, string> = {
+  AppStatusResult: "isInstalled",
+  BiometricAuthResult: "modality",
+  ClearAppDataResult: "packageName",
+  DragAndDropResult: "distance",
+  ExitDialogResult: "elementFound",
+  InstallAppResult: "artifactPath",
+  LaunchAppResult: "packageName",
+  LongPressResult: "pressRecognized",
+  OpenURLResult: "url",
+  PinchOnResult: "distanceStart",
+  PinchResult: "startingMagnitude",
+  PressButtonResult: "keyCode",
+  RecentAppsResult: "method",
+  RotateResult: "orientation",
+  SendKeyEventResult: "keyCode",
+  SendTextResult: "text",
+  SetUIStateResult: "totalAttempts",
+  ShakeResult: "intensity",
+  SwipeOnResult: "targetType",
+  SwipeResult: "x1",
+  TapOnElementResult: "action",
+  TapResult: "x",
+  TerminateAppResult: "wasForeground",
+  UninstallAppResult: "keepData",
+};
+
+/**
+ * Results that must be left untouched — they legitimately do not fit the trio.
+ */
+const UNTOUCHED_TYPES = [
+  "FocusOnResult", // no `error?` — different failure model
+  "IntentChooserResult", // observation?: any, not ObserveResult
+  "ImeActionResult", // observation?: any
+  "HomeScreenResult", // observation?: any
+];
+
+describe("BaseActionResult definition", () => {
+  test("declares the shared trio and imports ObserveResult", () => {
+    const src = read("BaseActionResult");
+    expect(src).toMatch(/import\s+\{\s*ObserveResult\s*\}\s+from\s+"\.\/ObserveResult"/);
+    expect(src).toMatch(/export\s+interface\s+BaseActionResult\s*\{/);
+    expect(src).toMatch(/success:\s*boolean;/);
+    expect(src).toMatch(/observation\?:\s*ObserveResult;/);
+    expect(src).toMatch(/error\?:\s*string;/);
+  });
+
+  test("is barrel-exported from src/models/index.ts", () => {
+    expect(read("index")).toMatch(/export \* from "\.\/BaseActionResult";/);
+  });
+
+  test("type-level: matches the exact trio shape", () => {
+    const value: BaseActionResult = {
+      success: true,
+      observation: undefined as ObserveResult | undefined,
+      error: undefined,
+    };
+    expect(value.success).toBe(true);
+  });
+});
+
+describe("exact-trio results alias BaseActionResult", () => {
+  for (const name of ALIAS_TYPES) {
+    test(`${name} is a bare alias of BaseActionResult`, () => {
+      const src = read(name);
+      expect(src).toMatch(
+        new RegExp(`import\\s+\\{[^}]*BaseActionResult[^}]*\\}\\s+from\\s+"\\./BaseActionResult"`)
+      );
+      expect(src).toMatch(new RegExp(`export type ${name} = BaseActionResult;`));
+      // The trio must no longer be hand-rolled inline.
+      expect(src).not.toMatch(/success:\s*boolean;/);
+      expect(src).not.toMatch(/observation\?:\s*ObserveResult;/);
+    });
+  }
+
+  test("type-level: alias is mutually assignable with BaseActionResult", () => {
+    const base: BaseActionResult = { success: false, error: "x" };
+    const clear: ClearTextResult = base;
+    const selectAll: SelectAllTextResult = base;
+    const back: BaseActionResult = clear;
+    expect(clear.success).toBe(false);
+    expect(selectAll.error).toBe("x");
+    expect(back.error).toBe("x");
+  });
+});
+
+describe("with-extras results extend BaseActionResult", () => {
+  for (const [name, extraField] of Object.entries(EXTENDS_TYPES)) {
+    test(`${name} extends BaseActionResult and keeps '${extraField}'`, () => {
+      const src = read(name);
+      expect(src).toMatch(
+        new RegExp(`import\\s+\\{[^}]*BaseActionResult[^}]*\\}\\s+from\\s+"\\./BaseActionResult"`)
+      );
+      expect(src).toMatch(new RegExp(`interface ${name} extends BaseActionResult`));
+      // The shared trio moved to the base — no inline redeclaration in THIS
+      // interface's own body (nested/sibling interfaces are unaffected).
+      const body = interfaceBody(src, name);
+      expect(body).not.toMatch(/^\s*success:\s*boolean;/m);
+      expect(body).not.toMatch(/^\s*observation\?:\s*ObserveResult;/m);
+      expect(body).not.toMatch(/^\s*error\?:\s*string;/m);
+      // Extra field preserved.
+      expect(body).toMatch(new RegExp(`\\b${extraField}\\b`));
+    });
+  }
+
+  test("type-level: extended results remain assignable to BaseActionResult", () => {
+    const tap: TapResult = { success: true, x: 1, y: 2 };
+    const launch: LaunchAppResult = { success: true, packageName: "com.x" };
+    const press: PressButtonResult = { success: true, button: "back", keyCode: 4 };
+    const swipe: SwipeResult = { success: true, x1: 0, y1: 0, x2: 1, y2: 1, duration: 100 };
+    const bases: BaseActionResult[] = [tap, launch, press, swipe];
+    expect(bases.every(b => b.success)).toBe(true);
+    expect(tap.x).toBe(1);
+  });
+});
+
+describe("out-of-scope results are left untouched", () => {
+  for (const name of UNTOUCHED_TYPES) {
+    test(`${name} does not adopt BaseActionResult`, () => {
+      expect(read(name)).not.toMatch(/BaseActionResult/);
+    });
+  }
+});

--- a/test/models/BaseActionResult.test.ts
+++ b/test/models/BaseActionResult.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { readFileSync } from "fs";
+import { readdirSync, readFileSync } from "fs";
 import { join } from "path";
 
 import type { BaseActionResult } from "../../src/models/BaseActionResult";
@@ -156,8 +156,9 @@ describe("with-extras results extend BaseActionResult", () => {
       expect(body).not.toMatch(/^\s*success:\s*boolean;/m);
       expect(body).not.toMatch(/^\s*observation\?:\s*ObserveResult;/m);
       expect(body).not.toMatch(/^\s*error\?:\s*string;/m);
-      // Extra field preserved.
-      expect(body).toMatch(new RegExp(`\\b${extraField}\\b`));
+      // Extra field preserved — anchored to an actual property declaration so a
+      // mention inside a comment can't satisfy the assertion.
+      expect(body).toMatch(new RegExp(`^\\s*${extraField}\\??:`, "m"));
     });
   }
 
@@ -178,4 +179,34 @@ describe("out-of-scope results are left untouched", () => {
       expect(read(name)).not.toMatch(/BaseActionResult/);
     });
   }
+});
+
+describe("coverage is exhaustive (self-enforcing lists)", () => {
+  // Discover, from source, every model that adopts BaseActionResult so the
+  // hardcoded ALIAS_TYPES/EXTENDS_TYPES lists cannot silently miss a future
+  // result type — a new adopter that isn't listed fails one of these tests.
+  const modelFiles = readdirSync(MODELS_DIR).filter(
+    f => f.endsWith(".ts") && f !== "BaseActionResult.ts"
+  );
+
+  const actualAliases: string[] = [];
+  const actualExtends: string[] = [];
+  for (const file of modelFiles) {
+    const src = readFileSync(join(MODELS_DIR, file), "utf8");
+    const alias = /export type (\w+) = BaseActionResult;/.exec(src);
+    if (alias) {
+      actualAliases.push(alias[1]);
+    }
+    for (const m of src.matchAll(/interface (\w+) extends BaseActionResult\b/g)) {
+      actualExtends.push(m[1]);
+    }
+  }
+
+  test("every source-level alias is listed in ALIAS_TYPES", () => {
+    expect([...actualAliases].sort()).toEqual([...ALIAS_TYPES].sort());
+  });
+
+  test("every source-level `extends BaseActionResult` is listed in EXTENDS_TYPES", () => {
+    expect([...actualExtends].sort()).toEqual(Object.keys(EXTENDS_TYPES).sort());
+  });
 });


### PR DESCRIPTION
## Summary

`src/models/` hand-rolled the same `{ success; observation?: ObserveResult; error? }` trio across dozens of `*Result.ts` interfaces with no shared base — 2 were byte-identical (`ClearTextResult`, `SelectAllTextResult`). This PR introduces `BaseActionResult` and collapses the 26 trio-based action results onto it, mirroring the `observe/shared` `BaseResult` precedent without merging the two concerns.

Closes #2753.

## What changed

- **New `src/models/BaseActionResult.ts`** — `{ success: boolean; observation?: ObserveResult; error?: string }`, barrel-exported from `src/models/index.ts`.
- **2 exact-trio results → bare aliases**: `export type ClearTextResult = BaseActionResult;` (same for `SelectAllTextResult`).
- **24 with-extras results → `extends BaseActionResult`**, keeping only their extra fields: `AppStatusResult`, `BiometricAuthResult`, `ClearAppDataResult`, `DragAndDropResult`, `ExitDialogResult`, `InstallAppResult`, `LaunchAppResult`, `LongPressResult`, `OpenURLResult`, `PinchOnResult`, `PinchResult`, `PressButtonResult`, `RecentAppsResult`, `RotateResult`, `SendKeyEventResult`, `SendTextResult`, `SetUIStateResult`, `ShakeResult`, `SwipeOnResult`, `SwipeResult`, `TapOnElementResult`, `TapResult`, `TerminateAppResult`, `UninstallAppResult`.
- Net **−84 lines** across 27 files.

## Deliberately left untouched (not force-fit)

- `FocusOnResult` — has `success` + `observation?` but **no `error?`** (different failure model).
- `IntentChooserResult`, `ImeActionResult`, `HomeScreenResult` — use `observation?: any`, not `ObserveResult`; narrowing to `ObserveResult` would be a real type change, not a structural no-op.
- The `observe/shared` `BaseResult` (timing-based, no `observation`) — a distinct concern, kept separate per the issue.

## Wire compatibility

Compile-time only. `extends`/alias produce structurally identical objects, so the serialized JSON wire shape of tool responses is unchanged. Not coupled to schema generation — the pre-commit `generate-tool-definitions` hook reported `schemas/tool-definitions.json` **up to date** (no diff), confirming `src/models/*Result` interfaces don't feed the generated artifact.

## How it was validated

- **TDD**: added `test/models/BaseActionResult.test.ts` (35 assertions) written **before** implementation — verifies the base definition + barrel export, alias structure, `extends` structure with representative extra-field preservation (balanced-brace scoped so nested/sibling interfaces like `FieldResult`/`ScrollableCandidate` aren't misattributed), untouched types, and type-level assignability. Red → green.
- Automated field-diff vs `origin/main`: **no non-trio field dropped** in any refactored interface.
- `turbo run lint build test` — green (**5437 pass, 0 fail**).
- `scripts/all_fast_validate_checks.sh` — 10/10 pass.
- Grepped for `implements`/declaration-merging on the two now-aliased types and for consumers relying on re-exported `ObserveResult` — none.
