### PR TITLE
refactor(observe): standardize AdbClientFactory injection, remove factory-vs-executor sniff across 11 observe classes

### DIFF
--- a/src/features/action/UninstallApp.ts
+++ b/src/features/action/UninstallApp.ts
@@ -15,6 +15,7 @@ export interface DeviceAppUninstaller {
 
 export class UninstallApp {
   private device: BootedDevice;
+  private adbFactory: AdbClientFactory;
   private adb: AdbExecutor;
   private simctl: SimCtlClient;
   private deviceAppUninstaller: DeviceAppUninstaller;
@@ -26,6 +27,7 @@ export class UninstallApp {
     deviceAppUninstaller: DeviceAppUninstaller | null = null
   ) {
     this.device = device;
+    this.adbFactory = adbFactory;
     this.adb = adbFactory.create(device);
     this.simctl = simctl || new SimCtlClient(device);
     this.deviceAppUninstaller = deviceAppUninstaller || new DeviceAppInspector();
@@ -80,8 +82,10 @@ export class UninstallApp {
     try {
       const simulator = this.isSimulator();
 
-      // Check if app is installed
-      const listApps = new ListInstalledApps(this.device, null, this.simctl);
+      // Check if app is installed. Keep the cache disabled so the pre-uninstall
+      // check always reflects live device state (the previous executor-arg path
+      // left caching off; passing the default factory would silently enable it).
+      const listApps = new ListInstalledApps(this.device, this.adbFactory, this.simctl, { cacheEnabled: false });
       const installed = (await listApps.execute()).find(app => app === bundleId) !== undefined;
 
       if (!installed) {
@@ -165,8 +169,10 @@ export class UninstallApp {
         }
       }
 
-      // Check if app is installed
-      const listApps = new ListInstalledApps(this.device, this.adb);
+      // Check if app is installed. Keep the cache disabled so the pre-uninstall
+      // check always reflects live device state (the previous executor-arg path
+      // left caching off; passing the default factory would silently enable it).
+      const listApps = new ListInstalledApps(this.device, this.adbFactory, null, { cacheEnabled: false });
 
       const installed = (await listApps.execute()).find(app => app === packageName) !== undefined;
 

--- a/src/features/navigation/DefaultUIStateSetup.ts
+++ b/src/features/navigation/DefaultUIStateSetup.ts
@@ -1,4 +1,5 @@
 import { BootedDevice } from "../../models";
+import { ObserveResult } from "../../models/ObserveResult";
 import { AdbClient } from "../../utils/android-cmdline-tools/AdbClient";
 import { logger } from "../../utils/logger";
 import { AndroidCtrlProxyClient } from "../observe/android";
@@ -14,13 +15,31 @@ import { defaultTimer } from "../../utils/SystemTimer";
  * Default implementation of UIStateSetup that handles UI state alignment
  * before navigation steps.
  */
+/**
+ * Minimal observe seam so UI-state setup can be unit-tested without driving a
+ * real ObserveScreen (WebSocket / device I/O).
+ */
+export interface ObserveScreenLike {
+  execute(): Promise<ObserveResult>;
+}
+
 export class DefaultUIStateSetup implements UIStateSetup {
   private device: BootedDevice;
   private adb: AdbClient;
+  private observeScreenProvider: () => ObserveScreenLike;
 
-  constructor(device: BootedDevice, adb: AdbClient) {
+  constructor(
+    device: BootedDevice,
+    adb: AdbClient,
+    observeScreenProvider?: () => ObserveScreenLike
+  ) {
     this.device = device;
     this.adb = adb;
+    // The setup holds a resolved AdbClient (not a factory), so wrap it in a
+    // trivial factory to satisfy ObserveScreen's factory-only contract (matches
+    // the AndroidCtrlProxyClient.getInstance call below).
+    this.observeScreenProvider = observeScreenProvider
+      ?? (() => new RealObserveScreen(this.device, { create: () => this.adb }));
   }
 
   /**
@@ -164,7 +183,7 @@ export class DefaultUIStateSetup implements UIStateSetup {
    */
   private async getCurrentUIState(_platform: string): Promise<UIState | undefined> {
     try {
-      const observeScreen = new RealObserveScreen(this.device, this.adb);
+      const observeScreen = this.observeScreenProvider();
       const result = await observeScreen.execute();
 
       if (!result.viewHierarchy) {

--- a/src/features/navigation/NavigationScreenshotManager.ts
+++ b/src/features/navigation/NavigationScreenshotManager.ts
@@ -233,8 +233,9 @@ export class NavigationScreenshotManager {
       // Ensure directory exists
       await this.fs.ensureDir(this.screenshotDir);
 
-      // 1. Capture screenshot
-      const capture = screenshotCapture ?? new TakeScreenshot(device, adb);
+      // 1. Capture screenshot. This manager holds a resolved AdbClient (not a factory),
+      // so wrap it in a trivial factory to satisfy TakeScreenshot's factory-only contract.
+      const capture = screenshotCapture ?? new TakeScreenshot(device, { create: () => adb });
       const result = await capture.execute();
 
       if (!result.success || !result.path) {

--- a/src/features/observe/AwaitIdle.ts
+++ b/src/features/observe/AwaitIdle.ts
@@ -19,23 +19,12 @@ export class AwaitIdle implements AwaitIdleInterface {
 
   /**
    * Create a AwaitIdle instance
-   * @param device - Optional device
-   * @param adbFactoryOrExecutor - Factory for creating AdbClient instances, or an AdbExecutor for testing
+   * @param device - Device to run ADB commands against
+   * @param adbFactory - Factory for creating AdbClient instances
    */
-  constructor(device: BootedDevice, adbFactoryOrExecutor: AdbClientFactory | AdbExecutor | null = defaultAdbClientFactory, timer: Timer = defaultTimer) {
-    // Detect if the argument is a factory (has create method) or an executor
-    if (adbFactoryOrExecutor && typeof (adbFactoryOrExecutor as AdbClientFactory).create === "function") {
-      this.adbFactory = adbFactoryOrExecutor as AdbClientFactory;
-      this.adb = this.adbFactory.create(device);
-    } else if (adbFactoryOrExecutor) {
-      // Legacy path: wrap the executor in a factory for downstream dependencies
-      const executor = adbFactoryOrExecutor as AdbExecutor;
-      this.adb = executor;
-      this.adbFactory = { create: () => executor };
-    } else {
-      this.adbFactory = defaultAdbClientFactory;
-      this.adb = this.adbFactory.create(device);
-    }
+  constructor(device: BootedDevice, adbFactory: AdbClientFactory = defaultAdbClientFactory, timer: Timer = defaultTimer) {
+    this.adbFactory = adbFactory;
+    this.adb = adbFactory.create(device);
     this.idle = new Idle(device, this.adbFactory);
     this.timer = timer;
   }

--- a/src/features/observe/GetBackStack.ts
+++ b/src/features/observe/GetBackStack.ts
@@ -13,15 +13,8 @@ export class GetBackStack implements BackStack {
   private adb: AdbExecutor;
   private timer: Timer;
 
-  constructor(adbFactoryOrExecutor: AdbClientFactory | AdbExecutor | null = defaultAdbClientFactory, device?: BootedDevice, timer: Timer = defaultTimer) {
-    // Detect if the argument is a factory (has create method) or an executor
-    if (adbFactoryOrExecutor && typeof (adbFactoryOrExecutor as AdbClientFactory).create === "function") {
-      this.adb = (adbFactoryOrExecutor as AdbClientFactory).create(device);
-    } else if (adbFactoryOrExecutor) {
-      this.adb = adbFactoryOrExecutor as AdbExecutor;
-    } else {
-      this.adb = defaultAdbClientFactory.create(device);
-    }
+  constructor(device: BootedDevice, adbFactory: AdbClientFactory = defaultAdbClientFactory, timer: Timer = defaultTimer) {
+    this.adb = adbFactory.create(device);
     this.timer = timer;
   }
 

--- a/src/features/observe/GetDumpsysWindow.ts
+++ b/src/features/observe/GetDumpsysWindow.ts
@@ -20,19 +20,12 @@ export class GetDumpsysWindow implements DumpsysWindow {
 
   /**
    * Create a GetDumpsysWindow instance
-   * @param device - Optional device
-   * @param adbFactoryOrExecutor - Factory for creating AdbClient instances, or an AdbExecutor for testing
+   * @param device - Device to run ADB commands against
+   * @param adbFactory - Factory for creating AdbClient instances
    */
-  constructor(device: BootedDevice, adbFactoryOrExecutor: AdbClientFactory | AdbExecutor | null = defaultAdbClientFactory, timer: Timer = defaultTimer) {
+  constructor(device: BootedDevice, adbFactory: AdbClientFactory = defaultAdbClientFactory, timer: Timer = defaultTimer) {
     this.device = device;
-    // Detect if the argument is a factory (has create method) or an executor
-    if (adbFactoryOrExecutor && typeof (adbFactoryOrExecutor as AdbClientFactory).create === "function") {
-      this.adb = (adbFactoryOrExecutor as AdbClientFactory).create(device);
-    } else if (adbFactoryOrExecutor) {
-      this.adb = adbFactoryOrExecutor as AdbExecutor;
-    } else {
-      this.adb = defaultAdbClientFactory.create(device);
-    }
+    this.adb = adbFactory.create(device);
     this.cacheDir = getTempDir(TEMP_SUBDIRS.CACHE);
     this.cacheFilePath = path.join(this.cacheDir, `dumpsys-window-${device.deviceId}.json`);
     this.timer = timer;

--- a/src/features/observe/GetScreenSize.ts
+++ b/src/features/observe/GetScreenSize.ts
@@ -24,18 +24,11 @@ export class GetScreenSize implements ScreenSize {
   /**
    * Create a GetScreenSize instance
    * @param device - Device to get screen size for
-   * @param adbFactoryOrExecutor - Factory for creating AdbClient instances, or an AdbExecutor for testing
+   * @param adbFactory - Factory for creating AdbClient instances
    */
-  constructor(device: BootedDevice, adbFactoryOrExecutor: AdbClientFactory | AdbExecutor | null = defaultAdbClientFactory) {
+  constructor(device: BootedDevice, adbFactory: AdbClientFactory = defaultAdbClientFactory) {
     this.device = device;
-    // Detect if the argument is a factory (has create method) or an executor
-    if (adbFactoryOrExecutor && typeof (adbFactoryOrExecutor as AdbClientFactory).create === "function") {
-      this.adb = (adbFactoryOrExecutor as AdbClientFactory).create(device);
-    } else if (adbFactoryOrExecutor) {
-      this.adb = adbFactoryOrExecutor as AdbExecutor;
-    } else {
-      this.adb = defaultAdbClientFactory.create(device);
-    }
+    this.adb = adbFactory.create(device);
   }
 
   /**

--- a/src/features/observe/GetSystemInsets.ts
+++ b/src/features/observe/GetSystemInsets.ts
@@ -11,20 +11,13 @@ export class GetSystemInsets implements SystemInsets {
   /**
    * Create a GetSystemInsets instance
    * @param device - Device to get system insets for
-   * @param adbFactoryOrExecutor - Factory for creating AdbClient instances, or an AdbExecutor for testing
+   * @param adbFactory - Factory for creating AdbClient instances
    */
   constructor(
     device: BootedDevice,
-    adbFactoryOrExecutor: AdbClientFactory | AdbExecutor | null = defaultAdbClientFactory
+    adbFactory: AdbClientFactory = defaultAdbClientFactory
   ) {
-    // Detect if the argument is a factory (has create method) or an executor
-    if (adbFactoryOrExecutor && typeof (adbFactoryOrExecutor as AdbClientFactory).create === "function") {
-      this.adb = (adbFactoryOrExecutor as AdbClientFactory).create(device);
-    } else if (adbFactoryOrExecutor) {
-      this.adb = adbFactoryOrExecutor as AdbExecutor;
-    } else {
-      this.adb = defaultAdbClientFactory.create(device);
-    }
+    this.adb = adbFactory.create(device);
   }
 
   /**

--- a/src/features/observe/Idle.ts
+++ b/src/features/observe/Idle.ts
@@ -11,18 +11,11 @@ export class Idle {
 
   /**
    * Create an Idle instance
-   * @param device - Optional device ID
-   * @param adbFactoryOrExecutor - Factory for creating AdbClient instances, or an AdbExecutor for testing
+   * @param device - Device to run ADB commands against
+   * @param adbFactory - Factory for creating AdbClient instances
    */
-  constructor(device: BootedDevice, adbFactoryOrExecutor: AdbClientFactory | AdbExecutor | null = defaultAdbClientFactory, timer: Timer = defaultTimer) {
-    // Detect if the argument is a factory (has create method) or an executor
-    if (adbFactoryOrExecutor && typeof (adbFactoryOrExecutor as AdbClientFactory).create === "function") {
-      this.adb = (adbFactoryOrExecutor as AdbClientFactory).create(device);
-    } else if (adbFactoryOrExecutor) {
-      this.adb = adbFactoryOrExecutor as AdbExecutor;
-    } else {
-      this.adb = defaultAdbClientFactory.create(device);
-    }
+  constructor(device: BootedDevice, adbFactory: AdbClientFactory = defaultAdbClientFactory, timer: Timer = defaultTimer) {
+    this.adb = adbFactory.create(device);
     this.timer = timer;
   }
 

--- a/src/features/observe/ListInstalledApps.ts
+++ b/src/features/observe/ListInstalledApps.ts
@@ -25,30 +25,23 @@ export class ListInstalledApps {
   private timer: Timer;
   /**
    * Create an ListInstalledApps instance
-   * @param device - Optional device
-   * @param adbFactoryOrExecutor - Factory for creating AdbClient instances, or an AdbExecutor for testing
+   * @param device - Device to run ADB commands against
+   * @param adbFactory - Factory for creating AdbClient instances
    * @param simctl - Optional SimCtlClient instance for testing
    * @param options - Optional cache configuration
    */
   constructor(
     device: BootedDevice,
-    adbFactoryOrExecutor: AdbClientFactory | AdbExecutor | null = defaultAdbClientFactory,
+    adbFactory: AdbClientFactory = defaultAdbClientFactory,
     simctl: SimCtlClient | null = null,
     options: ListInstalledAppsOptions = {}
   ) {
-    // Detect if the argument is a factory (has create method) or an executor
-    if (adbFactoryOrExecutor && typeof (adbFactoryOrExecutor as AdbClientFactory).create === "function") {
-      this.adb = (adbFactoryOrExecutor as AdbClientFactory).create(device);
-    } else if (adbFactoryOrExecutor) {
-      this.adb = adbFactoryOrExecutor as AdbExecutor;
-    } else {
-      this.adb = defaultAdbClientFactory.create(device);
-    }
+    this.adb = adbFactory.create(device);
     this.simctl = simctl || new SimCtlClient(device);
     this.device = device;
     this.installedAppsRepository = options.installedAppsRepository ?? new InstalledAppsRepository();
     // Enable caching by default when using the production factory
-    const defaultCacheEnabled = adbFactoryOrExecutor === defaultAdbClientFactory;
+    const defaultCacheEnabled = adbFactory === defaultAdbClientFactory;
     this.cacheEnabled = options.cacheEnabled ?? defaultCacheEnabled;
     this.timer = options.timer ?? defaultTimer;
   }

--- a/src/features/observe/ObserveScreen.ts
+++ b/src/features/observe/ObserveScreen.ts
@@ -123,22 +123,13 @@ export class RealObserveScreen implements ObserveScreen {
 
   constructor(
     device: BootedDevice,
-    adbFactoryOrExecutor: AdbClientFactory | AdbExecutor | null = defaultAdbClientFactory,
+    adbFactory: AdbClientFactory = defaultAdbClientFactory,
     dependencies?: ObserveScreenDependencies,
     timer: Timer = defaultTimer
   ) {
     this.device = device;
-    if (adbFactoryOrExecutor && typeof (adbFactoryOrExecutor as AdbClientFactory).create === "function") {
-      this.adbFactory = adbFactoryOrExecutor as AdbClientFactory;
-      this.adb = this.adbFactory.create(device);
-    } else if (adbFactoryOrExecutor) {
-      const executor = adbFactoryOrExecutor as AdbExecutor;
-      this.adb = executor;
-      this.adbFactory = { create: () => executor };
-    } else {
-      this.adbFactory = defaultAdbClientFactory;
-      this.adb = this.adbFactory.create(device);
-    }
+    this.adbFactory = adbFactory;
+    this.adb = adbFactory.create(device);
     this.timer = timer;
 
     // Data sources (either injected or default)
@@ -148,7 +139,7 @@ export class RealObserveScreen implements ObserveScreen {
     const window = dependencies?.window ?? new Window(device, this.adbFactory);
     const screenshotUtil = dependencies?.screenshot ?? new TakeScreenshot(device, this.adbFactory);
     this.dumpsysWindow = dependencies?.dumpsysWindow ?? new GetDumpsysWindow(device, this.adbFactory);
-    const backStack = dependencies?.backStack ?? new GetBackStack(this.adbFactory, device);
+    const backStack = dependencies?.backStack ?? new GetBackStack(device, this.adbFactory);
     this.predictiveUIState = dependencies?.predictiveUIState ?? new PredictiveUIState();
 
     // Caches: install injected stores into the registry so instance methods AND

--- a/src/features/observe/TakeScreenshot.ts
+++ b/src/features/observe/TakeScreenshot.ts
@@ -62,28 +62,17 @@ export class TakeScreenshot implements ScreenshotService {
 
   /**
    * Create a TakeScreenshot instance
-   * @param device - Optional device
-   * @param adbFactoryOrExecutor - Factory for creating AdbClient instances, or an AdbExecutor for testing
+   * @param device - Device to run ADB commands against
+   * @param adbFactory - Factory for creating AdbClient instances
    */
   constructor(
     device: BootedDevice,
-    adbFactoryOrExecutor: AdbClientFactory | AdbExecutor | null = defaultAdbClientFactory,
+    adbFactory: AdbClientFactory = defaultAdbClientFactory,
     timer: Timer = defaultTimer,
   ) {
     this.device = device;
-    // Detect if the argument is a factory (has create method) or an executor
-    if (adbFactoryOrExecutor && typeof (adbFactoryOrExecutor as AdbClientFactory).create === "function") {
-      this.adbFactory = adbFactoryOrExecutor as AdbClientFactory;
-      this.adb = this.adbFactory.create(device);
-    } else if (adbFactoryOrExecutor) {
-      // Legacy path: wrap the executor in a factory for downstream dependencies
-      const executor = adbFactoryOrExecutor as AdbExecutor;
-      this.adb = executor;
-      this.adbFactory = { create: () => executor };
-    } else {
-      this.adbFactory = defaultAdbClientFactory;
-      this.adb = this.adbFactory.create(device);
-    }
+    this.adbFactory = adbFactory;
+    this.adb = adbFactory.create(device);
     this.window = new Window(device, this.adbFactory);
     this.timer = timer;
 

--- a/src/features/observe/ViewHierarchy.ts
+++ b/src/features/observe/ViewHierarchy.ts
@@ -1,5 +1,4 @@
 import { AdbClientFactory, defaultAdbClientFactory } from "../../utils/android-cmdline-tools/AdbClientFactory";
-import type { AdbExecutor } from "../../utils/android-cmdline-tools/interfaces/AdbExecutor";
 import { logger } from "../../utils/logger";
 import { BootedDevice } from "../../models";
 import { Element } from "../../models";
@@ -38,30 +37,18 @@ export class ViewHierarchy implements ViewHierarchyInterface {
   /**
    * Create a ViewHierarchy instance
    * @param device - Device to get view hierarchy from
-   * @param adbFactoryOrExecutor - Factory for creating AdbClient instances, or an AdbExecutor for testing
+   * @param adbFactory - Factory for creating AdbClient instances
    * @param accessibilityServiceClient - Optional AndroidCtrlProxyClient instance for testing
    */
   constructor(
     device: BootedDevice,
-    adbFactoryOrExecutor: AdbClientFactory | AdbExecutor | null = defaultAdbClientFactory,
+    adbFactory: AdbClientFactory = defaultAdbClientFactory,
     accessibilityServiceClient: AndroidCtrlProxyClient | null = null,
     timer: Timer = defaultTimer,
   ) {
     this.device = device;
     this.parser = new DefaultElementParser();
     this.geometry = new DefaultElementGeometry();
-
-    // Detect if the argument is a factory (has create method) or an executor
-    let adbFactory: AdbClientFactory;
-    if (adbFactoryOrExecutor && typeof (adbFactoryOrExecutor as AdbClientFactory).create === "function") {
-      adbFactory = adbFactoryOrExecutor as AdbClientFactory;
-    } else if (adbFactoryOrExecutor) {
-      // Legacy path: wrap the executor in a factory for downstream dependencies
-      const executor = adbFactoryOrExecutor as AdbExecutor;
-      adbFactory = { create: () => executor };
-    } else {
-      adbFactory = defaultAdbClientFactory;
-    }
 
     this.accessibilityServiceClient = accessibilityServiceClient || AndroidCtrlProxyClient.getInstance(device, adbFactory);
     this.timer = timer;

--- a/src/features/observe/Window.ts
+++ b/src/features/observe/Window.ts
@@ -21,18 +21,11 @@ export class Window implements WindowInterface {
 
   /**
    * Create a Window instance
-   * @param device - Optional device
-   * @param adbFactoryOrExecutor - Factory for creating AdbClient instances, or an AdbExecutor for testing
+   * @param device - Device to run ADB commands against
+   * @param adbFactory - Factory for creating AdbClient instances
    */
-  constructor(device: BootedDevice, adbFactoryOrExecutor: AdbClientFactory | AdbExecutor | null = defaultAdbClientFactory) {
-    // Detect if the argument is a factory (has create method) or an executor
-    if (adbFactoryOrExecutor && typeof (adbFactoryOrExecutor as AdbClientFactory).create === "function") {
-      this.adb = (adbFactoryOrExecutor as AdbClientFactory).create(device);
-    } else if (adbFactoryOrExecutor) {
-      this.adb = adbFactoryOrExecutor as ExtendedAdbExecutor;
-    } else {
-      this.adb = defaultAdbClientFactory.create(device);
-    }
+  constructor(device: BootedDevice, adbFactory: AdbClientFactory = defaultAdbClientFactory) {
+    this.adb = adbFactory.create(device);
     this.device = device;
   }
 

--- a/test/fakes/FakeAdbClientFactory.test.ts
+++ b/test/fakes/FakeAdbClientFactory.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach } from "bun:test";
 import { FakeAdbClientFactory } from "./FakeAdbClientFactory";
 import { FakeAdbClient } from "./FakeAdbClient";
+import { FakeAdbExecutor } from "./FakeAdbExecutor";
 import type { BootedDevice } from "../../src/models";
 
 describe("FakeAdbClientFactory", () => {
@@ -80,6 +81,21 @@ describe("FakeAdbClientFactory", () => {
 
       const client = factory.create(testDevice);
       expect(client).toBe(customFake);
+    });
+  });
+
+  describe("wrapping a configured AdbExecutor", () => {
+    it("returns the exact executor it was constructed with", async () => {
+      const executor = new FakeAdbExecutor();
+      const wrapping = new FakeAdbClientFactory(executor);
+
+      const client = wrapping.create(testDevice);
+
+      // create() must return the SAME object so command config / assertions land on it.
+      expect(client).toBe(executor);
+      await client.executeCommand("shell echo hi");
+      expect(executor.wasCommandExecuted("shell echo hi")).toBe(true);
+      expect(wrapping.getCallCount()).toBe(1);
     });
   });
 

--- a/test/fakes/FakeAdbClientFactory.ts
+++ b/test/fakes/FakeAdbClientFactory.ts
@@ -17,11 +17,16 @@ interface RecordedFactoryCall {
  */
 export class FakeAdbClientFactory implements AdbClientFactory {
   private calls: RecordedFactoryCall[] = [];
-  private fakeClient: FakeAdbClient;
-  private clientsByDevice: Map<string, FakeAdbClient> = new Map();
+  private fakeClient: AdbExecutor;
+  private clientsByDevice: Map<string, AdbExecutor> = new Map();
   private useSharedClient = true;
 
-  constructor(fakeClient?: FakeAdbClient) {
+  /**
+   * @param fakeClient - Optional executor to return from create(). Accepts either a
+   *   FakeAdbClient or any AdbExecutor (e.g. a pre-configured FakeAdbExecutor), so a test
+   *   can wrap an executor it already configured and have create() return that same object.
+   */
+  constructor(fakeClient?: FakeAdbClient | AdbExecutor) {
     this.fakeClient = fakeClient ?? new FakeAdbClient();
   }
 
@@ -52,14 +57,14 @@ export class FakeAdbClientFactory implements AdbClientFactory {
    * Get the shared fake client.
    */
   getFakeClient(): FakeAdbClient {
-    return this.fakeClient;
+    return this.fakeClient as FakeAdbClient;
   }
 
   /**
    * Get a fake client for a specific device.
    */
   getClientForDevice(deviceId: string): FakeAdbClient | undefined {
-    return this.clientsByDevice.get(deviceId);
+    return this.clientsByDevice.get(deviceId) as FakeAdbClient | undefined;
   }
 
   /**

--- a/test/features/navigation/DefaultUIStateSetup.test.ts
+++ b/test/features/navigation/DefaultUIStateSetup.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, test } from "bun:test";
+import { DefaultUIStateSetup, type ObserveScreenLike } from "../../../src/features/navigation/DefaultUIStateSetup";
+import { FakeAdbClient } from "../../fakes/FakeAdbClient";
+import type { AdbClient } from "../../../src/utils/android-cmdline-tools/AdbClient";
+import type { BootedDevice } from "../../../src/models";
+import type { ObserveResult } from "../../../src/models/ObserveResult";
+import type { NavigationEdge } from "../../../src/features/navigation/NavigationGraphManager";
+
+const device: BootedDevice = {
+  deviceId: "test-device",
+  name: "Test Device",
+  platform: "android",
+};
+
+function makeSetup(
+  observeScreenProvider?: () => ObserveScreenLike
+): DefaultUIStateSetup {
+  const fakeAdb = new FakeAdbClient() as unknown as AdbClient;
+  return new DefaultUIStateSetup(device, fakeAdb, observeScreenProvider);
+}
+
+describe("DefaultUIStateSetup", () => {
+  // Regression for the AdbClientFactory injection refactor (#2754): the default
+  // observe path used to be `new RealObserveScreen(this.device, this.adb)` with a
+  // resolved AdbClient. After ObserveScreen became factory-only, that call would
+  // throw `adbFactory.create is not a function` inside the constructor, get
+  // swallowed by getCurrentUIState's catch, and silently skip required UI setup.
+  test("default observe provider constructs from a resolved AdbClient without throwing", () => {
+    const setup = makeSetup();
+    const provider = (setup as unknown as { observeScreenProvider: () => ObserveScreenLike }).observeScreenProvider;
+
+    let observeScreen: ObserveScreenLike | undefined;
+    expect(() => { observeScreen = provider(); }).not.toThrow();
+    expect(typeof observeScreen!.execute).toBe("function");
+  });
+
+  test("setupUIState consults the observe provider when the edge requires UI state", async () => {
+    let calls = 0;
+    const provider = (): ObserveScreenLike => {
+      calls++;
+      // No viewHierarchy => getCurrentUIState returns undefined and setup proceeds
+      // without taps. The point is that the provider was reached, i.e. observation
+      // was not silently skipped by a construction failure.
+      return { execute: async () => ({ viewHierarchy: null } as unknown as ObserveResult) };
+    };
+
+    const setup = makeSetup(provider);
+    const edge = {
+      uiState: { modalStack: [{ type: "dialog" }] },
+    } as unknown as NavigationEdge;
+
+    const actions = await setup.setupUIState(edge, "android");
+
+    expect(calls).toBeGreaterThanOrEqual(1);
+    expect(Array.isArray(actions)).toBe(true);
+  });
+
+  test("setupUIState short-circuits with no observation when the edge has no UI-state requirements", async () => {
+    let calls = 0;
+    const setup = makeSetup(() => {
+      calls++;
+      return { execute: async () => ({ viewHierarchy: null } as unknown as ObserveResult) };
+    });
+
+    const edge = { uiState: {} } as unknown as NavigationEdge;
+    const actions = await setup.setupUIState(edge, "android");
+
+    expect(actions).toEqual([]);
+    expect(calls).toBe(0);
+  });
+});

--- a/test/features/observe/GetBackStack.test.ts
+++ b/test/features/observe/GetBackStack.test.ts
@@ -1,12 +1,12 @@
 import { beforeEach, describe, expect, test } from "bun:test";
 import { GetBackStack } from "../../../src/features/observe/GetBackStack";
 import { FakeAdbExecutor } from "../../fakes/FakeAdbExecutor";
+import { FakeAdbClientFactory } from "../../fakes/FakeAdbClientFactory";
 import { ExecResult, BootedDevice } from "../../../src/models";
-import type { AdbClientFactory } from "../../../src/utils/android-cmdline-tools/AdbClientFactory";
 
 describe("GetBackStack", function() {
   let fakeAdb: FakeAdbExecutor;
-  let fakeAdbFactory: AdbClientFactory;
+  let fakeAdbFactory: FakeAdbClientFactory;
   let getBackStack: GetBackStack;
   let mockDevice: BootedDevice;
 
@@ -21,10 +21,10 @@ describe("GetBackStack", function() {
     fakeAdb = new FakeAdbExecutor();
     fakeAdb.setCommandResponse("dumpsys activity activities", mockDumpsysOutput());
 
-    // Create a factory that returns our fake
-    fakeAdbFactory = { create: () => fakeAdb };
+    // Wrap the configured fake in a factory
+    fakeAdbFactory = new FakeAdbClientFactory(fakeAdb);
 
-    getBackStack = new GetBackStack(fakeAdbFactory, mockDevice);
+    getBackStack = new GetBackStack(mockDevice, fakeAdbFactory);
   });
 
   test("should parse activities from dumpsys output", async function() {
@@ -73,8 +73,8 @@ ACTIVITY MANAGER ACTIVITIES (dumpsys activity activities)
 
     const testFakeAdb = new FakeAdbExecutor();
     testFakeAdb.setCommandResponse("dumpsys activity activities", { stdout, stderr: "" });
-    const testFactory: AdbClientFactory = { create: () => testFakeAdb };
-    getBackStack = new GetBackStack(testFactory, mockDevice);
+    const testFactory = new FakeAdbClientFactory(testFakeAdb);
+    getBackStack = new GetBackStack(mockDevice, testFactory);
 
     const result = await getBackStack.execute();
 
@@ -93,8 +93,8 @@ ACTIVITY MANAGER ACTIVITIES (dumpsys activity activities)
     // Mock empty output
     const emptyFakeAdb = new FakeAdbExecutor();
     emptyFakeAdb.setCommandResponse("dumpsys activity activities", { stdout: "", stderr: "" });
-    const emptyFactory: AdbClientFactory = { create: () => emptyFakeAdb };
-    getBackStack = new GetBackStack(emptyFactory, mockDevice);
+    const emptyFactory = new FakeAdbClientFactory(emptyFakeAdb);
+    getBackStack = new GetBackStack(mockDevice, emptyFactory);
 
     const result = await getBackStack.execute();
 
@@ -106,8 +106,8 @@ ACTIVITY MANAGER ACTIVITIES (dumpsys activity activities)
     // Mock error by setting default response and letting the error handling work
     const errorFakeAdb = new FakeAdbExecutor();
     // Don't set any response - the error will come from the parsing logic
-    const errorFactory: AdbClientFactory = { create: () => errorFakeAdb };
-    getBackStack = new GetBackStack(errorFactory, mockDevice);
+    const errorFactory = new FakeAdbClientFactory(errorFakeAdb);
+    getBackStack = new GetBackStack(mockDevice, errorFactory);
 
     const result = await getBackStack.execute();
 

--- a/test/features/observe/GetScreenSize.test.ts
+++ b/test/features/observe/GetScreenSize.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, test } from "bun:test";
 import { GetScreenSize } from "../../../src/features/observe/GetScreenSize";
 import { BootedDevice } from "../../../src/models";
 import { FakeAdbExecutor } from "../../fakes/FakeAdbExecutor";
+import { FakeAdbClientFactory } from "../../fakes/FakeAdbClientFactory";
 
 describe("GetScreenSize", function() {
   describe("Unit Tests for Extracted Methods", function() {
@@ -16,7 +17,7 @@ describe("GetScreenSize", function() {
         platform: "android",
         deviceId: "test-device"
       } as BootedDevice;
-      getScreenSize = new GetScreenSize(mockDevice, fakeAdb);
+      getScreenSize = new GetScreenSize(mockDevice, new FakeAdbClientFactory(fakeAdb));
     });
 
     test("should parse physical dimensions correctly", function() {

--- a/test/features/observe/GetSystemInsets.test.ts
+++ b/test/features/observe/GetSystemInsets.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, test } from "bun:test";
 import { GetSystemInsets } from "../../../src/features/observe/GetSystemInsets";
 import { BootedDevice } from "../../../src/models";
 import { FakeAdbExecutor } from "../../fakes/FakeAdbExecutor";
+import { FakeAdbClientFactory } from "../../fakes/FakeAdbClientFactory";
 
 describe("GetSystemInsets", function() {
   describe("Unit Tests for Extracted Methods", function() {
@@ -18,7 +19,7 @@ describe("GetSystemInsets", function() {
 
       fakeAdb = new FakeAdbExecutor();
 
-      getSystemInsets = new GetSystemInsets(testDevice, fakeAdb);
+      getSystemInsets = new GetSystemInsets(testDevice, new FakeAdbClientFactory(fakeAdb));
     });
 
     test("should parse status bar height correctly", function() {
@@ -149,7 +150,7 @@ describe("GetSystemInsets", function() {
       });
 
       // Create GetSystemInsets with mocked dependencies
-      getSystemInsets = new GetSystemInsets(testDevice, fakeAdb);
+      getSystemInsets = new GetSystemInsets(testDevice, new FakeAdbClientFactory(fakeAdb));
 
       // Check for available devices (mocked to return empty list)
       try {

--- a/test/features/observe/Idle.test.ts
+++ b/test/features/observe/Idle.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, test } from "bun:test";
 import { Idle } from "../../../src/features/observe/Idle";
 import { FakeAdbExecutor } from "../../fakes/FakeAdbExecutor";
+import { FakeAdbClientFactory } from "../../fakes/FakeAdbClientFactory";
 import { BootedDevice } from "../../../src/models";
 
 describe("Idle - Unit Tests", function() {
@@ -14,7 +15,7 @@ describe("Idle - Unit Tests", function() {
       platform: "android"
     };
     const fakeAdb = new FakeAdbExecutor();
-    idle = new Idle(mockDevice, fakeAdb as any);
+    idle = new Idle(mockDevice, new FakeAdbClientFactory(fakeAdb));
   });
 
   describe("getTouchStatus", function() {

--- a/test/features/observe/ListInstalledApps.test.ts
+++ b/test/features/observe/ListInstalledApps.test.ts
@@ -1,6 +1,7 @@
 import { expect, describe, test, beforeEach } from "bun:test";
 import { ListInstalledApps } from "../../../src/features/observe/ListInstalledApps";
 import { FakeAdbExecutor } from "../../fakes/FakeAdbExecutor";
+import { FakeAdbClientFactory } from "../../fakes/FakeAdbClientFactory";
 import { BootedDevice, AndroidUser } from "../../../src/models";
 import type { NewInstalledApp } from "../../../src/db/types";
 import { FakeInstalledAppsRepository } from "../../fakes/FakeInstalledAppsRepository";
@@ -20,7 +21,7 @@ describe("ListInstalledApps", function() {
     fakeAdb = new FakeAdbExecutor();
     // Note: Don't set default command responses here - tests will configure as needed
 
-    listInstalledApps = new ListInstalledApps(mockDevice, fakeAdb);
+    listInstalledApps = new ListInstalledApps(mockDevice, new FakeAdbClientFactory(fakeAdb));
   });
 
   describe("execute", function() {
@@ -270,7 +271,7 @@ describe("ListInstalledApps", function() {
         platform: "ios"
       } as BootedDevice;
 
-      const iosListApps = new ListInstalledApps(iosDevice, fakeAdb);
+      const iosListApps = new ListInstalledApps(iosDevice, new FakeAdbClientFactory(fakeAdb));
       const result = await iosListApps.executeDetailed();
 
       expect(result).toEqual({ profiles: {}, system: [] });
@@ -307,7 +308,7 @@ describe("ListInstalledApps", function() {
 
       const cachedList = new ListInstalledApps(
         mockDevice,
-        fakeAdb as unknown as any,
+        new FakeAdbClientFactory(fakeAdb),
         null,
         { cacheEnabled: true, installedAppsRepository: repo, timer }
       );
@@ -347,7 +348,7 @@ describe("ListInstalledApps", function() {
 
       const cachedList = new ListInstalledApps(
         mockDevice,
-        fakeAdb as unknown as any,
+        new FakeAdbClientFactory(fakeAdb),
         null,
         { cacheEnabled: true, installedAppsRepository: repo, timer }
       );

--- a/test/features/observe/ObserveScreen.test.ts
+++ b/test/features/observe/ObserveScreen.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeAll, beforeEach, describe, expect, test } from "bun:test";
 import { RealObserveScreen } from "../../../src/features/observe/ObserveScreen";
 import { FakeAdbExecutor } from "../../fakes/FakeAdbExecutor";
+import { FakeAdbClientFactory } from "../../fakes/FakeAdbClientFactory";
 import { FakeTimer } from "../../fakes/FakeTimer";
 import { ObserveResult } from "../../../src/models/ObserveResult";
 import { BootedDevice } from "../../../src/models/DeviceInfo";
@@ -23,7 +24,7 @@ describe("ObserveScreen", function() {
         platform: "android"
       };
       fakeAdb = new FakeAdbExecutor();
-      observeScreen = new RealObserveScreen(mockDevice, fakeAdb);
+      observeScreen = new RealObserveScreen(mockDevice, new FakeAdbClientFactory(fakeAdb));
     });
 
     test("should create base result with correct structure", function() {
@@ -137,7 +138,7 @@ describe("ObserveScreen", function() {
       } as any);
 
       try {
-        const screen = new RealObserveScreen(mockDevice, fakeAdb, {
+        const screen = new RealObserveScreen(mockDevice, new FakeAdbClientFactory(fakeAdb), {
           viewHierarchy,
           cacheStore: new FakeObserveCacheStore(new FakeTimer()),
           performanceAuditor: { run: async () => undefined } as any,
@@ -168,7 +169,7 @@ describe("ObserveScreen", function() {
         platform: "android"
       };
       const fakeAdb = new FakeAdbExecutor();
-      const observeScreen = new RealObserveScreen(mockDevice, fakeAdb);
+      const observeScreen = new RealObserveScreen(mockDevice, new FakeAdbClientFactory(fakeAdb));
       viewHierarchy = (observeScreen as any).viewHierarchy;
     });
 
@@ -470,7 +471,7 @@ describe("ObserveScreen", function() {
         platform: "android"
       };
       // Pass fakeAdb to avoid creating real AdbClient
-      const invalidObserveScreen = new RealObserveScreen(invalidDevice, fakeAdb as any);
+      const invalidObserveScreen = new RealObserveScreen(invalidDevice, new FakeAdbClientFactory(fakeAdb));
 
       // Should still return a result object with error info
       const result = await invalidObserveScreen.execute();
@@ -506,7 +507,7 @@ describe("ObserveScreen", function() {
       RealObserveScreen.clearCache();
       observeScreen = new RealObserveScreen(
         { deviceId: "test", name: "Test", platform: "android" },
-        new FakeAdbExecutor()
+        new FakeAdbClientFactory(new FakeAdbExecutor())
       );
     });
 
@@ -564,8 +565,8 @@ describe("ObserveScreen", function() {
     });
 
     test("getRecentCachedResultForDevice returns only that device's entries", async function() {
-      const screenA = new RealObserveScreen(deviceA, new FakeAdbExecutor());
-      const screenB = new RealObserveScreen(deviceB, new FakeAdbExecutor());
+      const screenA = new RealObserveScreen(deviceA, new FakeAdbClientFactory(new FakeAdbExecutor()));
+      const screenB = new RealObserveScreen(deviceB, new FakeAdbClientFactory(new FakeAdbExecutor()));
 
       const resultA: ObserveResult = {
         ...screenA.createBaseResult(),
@@ -592,8 +593,8 @@ describe("ObserveScreen", function() {
       timerA.setCurrentTime(now - 1000);
       const timerB = new FakeTimer();
       timerB.setCurrentTime(now);
-      const screenA = new RealObserveScreen(deviceA, new FakeAdbExecutor(), undefined, timerA);
-      const screenB = new RealObserveScreen(deviceB, new FakeAdbExecutor(), undefined, timerB);
+      const screenA = new RealObserveScreen(deviceA, new FakeAdbClientFactory(new FakeAdbExecutor()), undefined, timerA);
+      const screenB = new RealObserveScreen(deviceB, new FakeAdbClientFactory(new FakeAdbExecutor()), undefined, timerB);
 
       await screenA.cacheObserveResult({ ...screenA.createBaseResult(), viewHierarchy: "A" });
       await screenB.cacheObserveResult({ ...screenB.createBaseResult(), viewHierarchy: "B" });
@@ -604,8 +605,8 @@ describe("ObserveScreen", function() {
     });
 
     test("clearCache with deviceId only clears that device", async function() {
-      const screenA = new RealObserveScreen(deviceA, new FakeAdbExecutor());
-      const screenB = new RealObserveScreen(deviceB, new FakeAdbExecutor());
+      const screenA = new RealObserveScreen(deviceA, new FakeAdbClientFactory(new FakeAdbExecutor()));
+      const screenB = new RealObserveScreen(deviceB, new FakeAdbClientFactory(new FakeAdbExecutor()));
 
       await screenA.cacheObserveResult(screenA.createBaseResult());
       await screenB.cacheObserveResult(screenB.createBaseResult());
@@ -617,8 +618,8 @@ describe("ObserveScreen", function() {
     });
 
     test("clearCache without deviceId clears all devices", async function() {
-      const screenA = new RealObserveScreen(deviceA, new FakeAdbExecutor());
-      const screenB = new RealObserveScreen(deviceB, new FakeAdbExecutor());
+      const screenA = new RealObserveScreen(deviceA, new FakeAdbClientFactory(new FakeAdbExecutor()));
+      const screenB = new RealObserveScreen(deviceB, new FakeAdbClientFactory(new FakeAdbExecutor()));
 
       await screenA.cacheObserveResult(screenA.createBaseResult());
       await screenB.cacheObserveResult(screenB.createBaseResult());
@@ -630,8 +631,8 @@ describe("ObserveScreen", function() {
     });
 
     test("getMostRecentCachedObserveResult returns only own device results", async function() {
-      const screenA = new RealObserveScreen(deviceA, new FakeAdbExecutor());
-      const screenB = new RealObserveScreen(deviceB, new FakeAdbExecutor());
+      const screenA = new RealObserveScreen(deviceA, new FakeAdbClientFactory(new FakeAdbExecutor()));
+      const screenB = new RealObserveScreen(deviceB, new FakeAdbClientFactory(new FakeAdbExecutor()));
 
       const resultA: ObserveResult = { ...screenA.createBaseResult(), viewHierarchy: "A-hierarchy" };
       await screenA.cacheObserveResult(resultA);

--- a/test/features/observe/ObserveScreenPlatformValidation.test.ts
+++ b/test/features/observe/ObserveScreenPlatformValidation.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, test } from "bun:test";
 import { RealObserveScreen } from "../../../src/features/observe/ObserveScreen";
 import { FakeAdbExecutor } from "../../fakes/FakeAdbExecutor";
+import { FakeAdbClientFactory } from "../../fakes/FakeAdbClientFactory";
 import { FakeTimer } from "../../fakes/FakeTimer";
 import { FakeObserveCacheStore } from "../../fakes/FakeObserveCacheStore";
 import { resetObserveCacheStore } from "../../../src/features/observe/cache/ObserveCacheRegistry";
@@ -48,7 +49,7 @@ describe("ObserveScreen.execute cross-platform hierarchy rejection", () => {
   });
 
   const buildScreen = (cacheStore: FakeObserveCacheStore) =>
-    new RealObserveScreen(androidDevice, new FakeAdbExecutor(), {
+    new RealObserveScreen(androidDevice, new FakeAdbClientFactory(new FakeAdbExecutor()), {
       hierarchyCollector: iosHierarchyCollector() as never,
       cacheStore,
       performanceAuditor: { run: async () => undefined } as never,
@@ -89,7 +90,7 @@ describe("ObserveScreen.execute cross-platform hierarchy rejection", () => {
 
   test("raw-mode append is skipped when the primary hierarchy was rejected", async () => {
     let collectRawCalled = false;
-    const screen = new RealObserveScreen(androidDevice, new FakeAdbExecutor(), {
+    const screen = new RealObserveScreen(androidDevice, new FakeAdbClientFactory(new FakeAdbExecutor()), {
       hierarchyCollector: {
         ...iosHierarchyCollector(),
         collectRaw: async (result: ObserveResult) => {

--- a/test/features/observe/ObserveScreenSkipOptions.test.ts
+++ b/test/features/observe/ObserveScreenSkipOptions.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { RealObserveScreen } from "../../../src/features/observe/ObserveScreen";
 import { FakeAdbExecutor } from "../../fakes/FakeAdbExecutor";
+import { FakeAdbClientFactory } from "../../fakes/FakeAdbClientFactory";
 import { FakeTimer } from "../../fakes/FakeTimer";
 import { FakeObserveCacheStore } from "../../fakes/FakeObserveCacheStore";
 import { FakeScreenshotStateStore } from "../../fakes/FakeScreenshotStateStore";
@@ -82,7 +83,7 @@ function createObserveScreen() {
   const fakeScreenshotRecorder = new FakeScreenshotRecorder();
   const fakeDeviceStateCollector = new FakeDeviceStateCollector();
 
-  const observeScreen = new RealObserveScreen(device, new FakeAdbExecutor(), {
+  const observeScreen = new RealObserveScreen(device, new FakeAdbClientFactory(new FakeAdbExecutor()), {
     cacheStore: new FakeObserveCacheStore(fakeTimer),
     screenshotStateStore: new FakeScreenshotStateStore(),
     screenshotRecorder: fakeScreenshotRecorder,

--- a/test/features/observe/TakeScreenshot.test.ts
+++ b/test/features/observe/TakeScreenshot.test.ts
@@ -4,7 +4,7 @@ import { BootedDevice } from "../../../src/models/DeviceInfo";
 import { FakeAdbExecutor } from "../../fakes/FakeAdbExecutor";
 import { FakeFileSystem } from "../../fakes/FakeFileSystem";
 import { FakeTimer } from "../../fakes/FakeTimer";
-import type { AdbClientFactory } from "../../../src/utils/android-cmdline-tools/AdbClientFactory";
+import { FakeAdbClientFactory } from "../../fakes/FakeAdbClientFactory";
 
 describe("TakeScreenshot", function() {
   describe("Unit Tests for Extracted Methods", function() {
@@ -22,7 +22,7 @@ describe("TakeScreenshot", function() {
 
       // Create a simple fake ADB for unit testing
       fakeAdb = new FakeAdbExecutor();
-      const fakeFactory: AdbClientFactory = { create: () => fakeAdb };
+      const fakeFactory = new FakeAdbClientFactory(fakeAdb);
       takeScreenshot = new TakeScreenshot(mockDevice, fakeFactory);
     });
 
@@ -72,7 +72,7 @@ describe("TakeScreenshot", function() {
       fakeFileSystem.setExists("/tmp/auto-mobile/screenshots", true);
 
       // Create factory that returns testFakeAdb
-      const testFactory: AdbClientFactory = { create: () => testFakeAdb };
+      const testFactory = new FakeAdbClientFactory(testFakeAdb);
       const takeScreenshot = new TakeScreenshot(mockDevice, testFactory);
 
       // Mock the window dependency to avoid additional ADB calls

--- a/test/features/observe/ViewHierarchy.filter.test.ts
+++ b/test/features/observe/ViewHierarchy.filter.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { ViewHierarchy } from "../../../src/features/observe/ViewHierarchy";
+import { FakeAdbClientFactory } from "../../fakes/FakeAdbClientFactory";
 
 const device = {
   name: "test-device",
@@ -9,7 +10,7 @@ const device = {
 
 describe("ViewHierarchy filtering", () => {
   test("preserves action-only interactive nodes", () => {
-    const viewHierarchy = new ViewHierarchy(device, null);
+    const viewHierarchy = new ViewHierarchy(device, new FakeAdbClientFactory());
     const result = viewHierarchy.filterViewHierarchy({
       hierarchy: {
         node: {

--- a/test/features/observe/ViewHierarchy.test.ts
+++ b/test/features/observe/ViewHierarchy.test.ts
@@ -183,7 +183,7 @@ describe("ViewHierarchy", function() {
         getAccessibilityHierarchy: async () => null
       } as unknown as AndroidCtrlProxyClient;
 
-      viewHierarchy = new ViewHierarchy(mockDevice, fakeAdb, mockCtrlProxyClient);
+      viewHierarchy = new ViewHierarchy(mockDevice, new FakeAdbClientFactory(fakeAdb), mockCtrlProxyClient);
       setupReadFileMock();
     });
 
@@ -206,7 +206,7 @@ describe("ViewHierarchy", function() {
         getAccessibilityHierarchy: async () => { throw new Error("Accessibility service error"); }
       } as unknown as AndroidCtrlProxyClient;
 
-      const viewHierarchyWithMocks = new ViewHierarchy(mockDevice, fakeAdb, mockCtrlProxyClientError);
+      const viewHierarchyWithMocks = new ViewHierarchy(mockDevice, new FakeAdbClientFactory(fakeAdb), mockCtrlProxyClientError);
 
       const result = await viewHierarchyWithMocks.getAndroidViewHierarchy();
 
@@ -238,7 +238,7 @@ describe("ViewHierarchy", function() {
       const getInstanceSpy = spyOn(IOSCtrlProxyClient, "getInstance").mockReturnValue(fakeIosClient as any);
 
       try {
-        const viewHierarchyWithMocks = new ViewHierarchy(iosDevice, fakeAdb, mockCtrlProxyClient);
+        const viewHierarchyWithMocks = new ViewHierarchy(iosDevice, new FakeAdbClientFactory(fakeAdb), mockCtrlProxyClient);
 
         const result = await viewHierarchyWithMocks.getiOSViewHierarchy();
 
@@ -285,7 +285,7 @@ describe("ViewHierarchy", function() {
       const getInstanceSpy = spyOn(IOSCtrlProxyClient, "getInstance").mockReturnValue(fakeIosClient as any);
 
       try {
-        const viewHierarchyWithMocks = new ViewHierarchy(iosDevice, fakeAdb, mockCtrlProxyClient);
+        const viewHierarchyWithMocks = new ViewHierarchy(iosDevice, new FakeAdbClientFactory(fakeAdb), mockCtrlProxyClient);
 
         const result = await viewHierarchyWithMocks.getiOSViewHierarchy();
 
@@ -319,7 +319,7 @@ describe("ViewHierarchy", function() {
         getAccessibilityHierarchy: async () => null
       } as unknown as AndroidCtrlProxyClient;
 
-      viewHierarchy = new ViewHierarchy(mockDevice, fakeAdb, mockCtrlProxyClient);
+      viewHierarchy = new ViewHierarchy(mockDevice, new FakeAdbClientFactory(fakeAdb), mockCtrlProxyClient);
     });
 
     test("should handle empty hierarchy", function() {
@@ -380,7 +380,7 @@ describe("ViewHierarchy", function() {
         getAccessibilityHierarchy: async () => null
       } as unknown as AndroidCtrlProxyClient;
 
-      viewHierarchy = new ViewHierarchy(mockDevice, fakeAdb, mockCtrlProxyClient);
+      viewHierarchy = new ViewHierarchy(mockDevice, new FakeAdbClientFactory(fakeAdb), mockCtrlProxyClient);
     });
 
     test("should handle node with empty children array", function() {
@@ -560,7 +560,7 @@ describe("findFocusedElement", function() {
       platform: "android"
     };
 
-    viewHierarchy = new ViewHierarchy(mockDevice, new FakeAdbExecutor() as any, null);
+    viewHierarchy = new ViewHierarchy(mockDevice, new FakeAdbClientFactory(new FakeAdbExecutor()), null);
   });
 
   test("should find focused element in simple hierarchy", function() {
@@ -771,7 +771,7 @@ describe("Offscreen Node Filtering", function() {
       platform: "android"
     };
     fakeAdb = new FakeAdbExecutor();
-    viewHierarchy = new ViewHierarchy(mockDevice, fakeAdb);
+    viewHierarchy = new ViewHierarchy(mockDevice, new FakeAdbClientFactory(fakeAdb));
   });
 
   test("should filter out nodes completely below the screen", function() {

--- a/test/features/observe/Window.test.ts
+++ b/test/features/observe/Window.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, test } from "bun:test";
 import { Window, parseActiveWindowModern, parseActiveWindowLegacy, parseDumpsysWindowFocus } from "../../../src/features/observe/Window";
 import { FakeAdbExecutor } from "../../fakes/FakeAdbExecutor";
+import { FakeAdbClientFactory } from "../../fakes/FakeAdbClientFactory";
 import { ExecResult } from "../../../src/models/ExecResult";
 import { BootedDevice } from "../../../src/models/DeviceInfo";
 import fs from "fs";
@@ -18,7 +19,7 @@ describe("Window", () => {
       platform: "android"
     };
     fakeAdb = new FakeAdbExecutor();
-    window = new Window(mockDevice, fakeAdb as any);
+    window = new Window(mockDevice, new FakeAdbClientFactory(fakeAdb));
     // Clear cache before each test to prevent stale results
     window.clearCache();
   });
@@ -31,7 +32,7 @@ describe("Window", () => {
         platform: "android"
       };
       const customAdb = new FakeAdbExecutor();
-      const windowInstance = new Window(mockDevice, customAdb as any);
+      const windowInstance = new Window(mockDevice, new FakeAdbClientFactory(customAdb));
       expect(windowInstance).toBeInstanceOf(Window);
     });
 
@@ -43,7 +44,7 @@ describe("Window", () => {
       };
       // Pass FakeAdbExecutor to avoid creating real AdbClient
       const defaultFakeAdb = new FakeAdbExecutor();
-      const windowInstance = new Window(mockDevice, defaultFakeAdb as any);
+      const windowInstance = new Window(mockDevice, new FakeAdbClientFactory(defaultFakeAdb));
       expect(windowInstance).toBeInstanceOf(Window);
     });
   });
@@ -187,7 +188,7 @@ describe("Window", () => {
           throw new Error("ADB command failed");
         }
       })();
-      const windowWithError = new Window(mockDevice, errorFakeAdb as any);
+      const windowWithError = new Window(mockDevice, new FakeAdbClientFactory(errorFakeAdb));
 
       const result = await windowWithError.getActive(true);
 

--- a/test/server/resources/read.test.ts
+++ b/test/server/resources/read.test.ts
@@ -8,6 +8,7 @@ import { z } from "zod";
 import { ScreenshotJobTracker } from "../../../src/utils/ScreenshotJobTracker";
 import { setScreenshotFileSystem, resetScreenshotFileSystem } from "../../../src/server/observationResources";
 import { FakeAdbExecutor } from "../../fakes/FakeAdbExecutor";
+import { FakeAdbClientFactory } from "../../fakes/FakeAdbClientFactory";
 import { BootedDevice } from "../../../src/models/DeviceInfo";
 import { FakeTimer } from "../../fakes/FakeTimer";
 import { OPERATION_CANCELLED_MESSAGE } from "../../../src/utils/constants";
@@ -183,7 +184,7 @@ describe("MCP Resources Read", () => {
       name: "Test Device",
       platform: "android"
     };
-    const observeScreen = new RealObserveScreen(mockDevice, new FakeAdbExecutor());
+    const observeScreen = new RealObserveScreen(mockDevice, new FakeAdbClientFactory(new FakeAdbExecutor()));
     await observeScreen.cacheObserveResult(observeScreen.createBaseResult());
 
     // Clear any pre-existing screenshot state


### PR DESCRIPTION
## Summary

Eleven observe classes each re-implemented the same runtime "is this an `AdbClientFactory` or an `AdbExecutor`?" type-sniff in their constructor, distinguished by duck-typing `.create`. This standardizes all of them on the pattern `GetAppMetadata` already uses — inject `AdbClientFactory`, call `.create(device)` — and removes the union, the sniff, and the `as AdbClientFactory` / `as AdbExecutor` casts.

Closes #2754.

## What changed

**11 observe constructors** (`Idle`, `AwaitIdle`, `GetBackStack`, `GetSystemInsets`, `Window`, `GetScreenSize`, `GetDumpsysWindow`, `ListInstalledApps`, `TakeScreenshot`, `ObserveScreen`, `ViewHierarchy`)
- Signature normalized to `(device, adbFactory: AdbClientFactory = defaultAdbClientFactory, ...)` — device first, factory second, consistently.
- `GetBackStack`'s arg order was `(factory, device)`; flipped to device-first to match its siblings (call site in `ObserveScreen` updated).
- Dropped the `AdbClientFactory | AdbExecutor` union, the `.create === "function"` branch, and the legacy executor-wrapping paths. `ViewHierarchy` no longer needs its `AdbExecutor` import.

**Call sites that passed an executor directly** (the only two in `src/`)
- `UninstallApp` now retains its `adbFactory` and threads it into `ListInstalledApps`. It passes an explicit `{ cacheEnabled: false }` to preserve the pre-refactor behavior: the previous executor/`null` argument left `ListInstalledApps` caching **off** for the pre-uninstall install-check, but simply forwarding the default factory would have silently flipped it **on** and let a stale cached app list drive the check. Keeping the cache off means the check still reflects live device state.
- `NavigationScreenshotManager` holds a resolved `AdbClient` (not a factory), so it wraps it in a trivial `{ create: () => adb }` factory at the `TakeScreenshot` boundary rather than plumbing a factory through the whole call chain.

**Test fake**
- `FakeAdbClientFactory`'s constructor is widened to accept a `FakeAdbClient | AdbExecutor`, so a test can wrap a pre-configured `FakeAdbExecutor` and have `create()` return that same object (command config / assertions still land). Added a fake test for the wrap contract.

**Tests**
- Every observe test for the 11 classes now injects `FakeAdbClientFactory` instead of `fakeAdb as any`, and uses the normalized `(device, factory)` arg order. `ViewHierarchy.filter.test.ts` swaps its `null` factory for a `FakeAdbClientFactory`.

## Scope / out of scope

Only the 11 observe classes named in the issue. The other sniff sites the issue flagged as out of scope (in `action/`, `debug/`, `performance/`, `utility/`, `utils/`) are untouched.

## Testing

- `bun run build.ts` — green.
- `bunx eslint .` — clean.
- `bun test` — **5403 pass, 0 fail** (full suite). No behavior change intended; `.create(device)` is what the factory path already did.

Note: `test/features/observe/CtrlProxyClient.test.ts` has one pre-existing failure ("preserve SDK screen names...") that reproduces on a clean `main` checkout in isolation and is unrelated to this change; it passes in the full-suite run.
